### PR TITLE
Fix chat live rendering, scroll intent, and stale refresh

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -197,11 +197,27 @@
         // reload when the page was ALREADY controlled and a NEW worker takes over
         // (a genuine deploy/update).
         const hadControllerAtLoad = !!navigator.serviceWorker.controller
+        const rememberShellStateForAutoReload = () => {
+          try {
+            const activeView = localStorage.getItem('moebius_active_view') || 'chat'
+            const rawAppId = localStorage.getItem('moebius_active_app')
+            const activeAppId = rawAppId ? Number(rawAppId) : null
+            sessionStorage.setItem('shell-reload', JSON.stringify({
+              activeView,
+              activeAppId: Number.isFinite(activeAppId) ? activeAppId : null,
+              drawerOpen: false,
+              activeChatId: localStorage.getItem('moebius_active_chat') || null,
+            }))
+          } catch (_) {
+            // Best-effort: a failed storage read should not block an update.
+          }
+        }
         const reloadAfterControllerChange = () => {
           if (hadControllerAtLoad
               && navigator.serviceWorker.controller
               && !sessionStorage.getItem('sw-auto-reloaded')) {
             sessionStorage.setItem('sw-auto-reloaded', '1')
+            rememberShellStateForAutoReload()
             window.location.reload()
           }
         }
@@ -227,6 +243,63 @@
             watchWorker(reg.installing)
           })
         }
+        // Stale-precache escape hatch.
+        //
+        // The normal path is: /sw.js updates → controllerchange → reload onto
+        // the new Workbox precache. We have seen Chromium keep serving the old
+        // precached index after a shell rebuild even though network /sw.js
+        // already advertises a newer Vite bundle. In that state a normal
+        // reload is a no-op: the old service worker keeps handing out the old
+        // /index.html, and the chat UI can look like saved rows are missing.
+        //
+        // Detect that exact mismatch at boot. /sw.js is not runtime-cached by
+        // the service worker and is registered with updateViaCache:'none', so
+        // fetch('/sw.js', {cache:'reload'}) is the reliable network identity.
+        // If the current document loaded bundle A but network /sw.js precaches
+        // bundle B, delete only Workbox's precache and reload once. The old
+        // worker then falls through to network for /index.html and the new
+        // hashed asset, while app/runtime caches remain untouched.
+        const stalePrecacheRecoveryKey = 'sw-stale-precache-recovering'
+        const wasRecoveringStalePrecache =
+          sessionStorage.getItem(stalePrecacheRecoveryKey) === '1'
+        if (wasRecoveringStalePrecache) {
+          sessionStorage.removeItem(stalePrecacheRecoveryKey)
+        }
+        let stalePrecacheCheckStarted = false
+        const currentShellBundle = () => {
+          const scripts = Array.from(document.scripts || [])
+            .map(s => s.src || '')
+          return scripts.find(src => /\/assets\/index-[A-Za-z0-9_-]+\.js(?:[?#].*)?$/.test(src)) || ''
+        }
+        const expectedShellBundleFromSw = (swText) => {
+          const matches = String(swText || '').match(/assets\/index-[A-Za-z0-9_-]+\.js/g)
+          return matches && matches.length ? matches[matches.length - 1] : ''
+        }
+        const recoverStalePrecacheIfNeeded = async (reg) => {
+          if (stalePrecacheCheckStarted || wasRecoveringStalePrecache) return
+          stalePrecacheCheckStarted = true
+          try {
+            if (!hadControllerAtLoad || !navigator.serviceWorker.controller || !window.caches) return
+            const current = currentShellBundle()
+            if (!current) return
+            const res = await fetch('/sw.js', { cache: 'reload' })
+            if (!res.ok) return
+            const expected = expectedShellBundleFromSw(await res.text())
+            if (!expected || current.includes(expected)) return
+            try { await reg?.update?.() } catch (_) {}
+            const keys = await caches.keys()
+            await Promise.all(
+              keys
+                .filter(k => k.startsWith('workbox-precache-'))
+                .map(k => caches.delete(k))
+            )
+            sessionStorage.setItem(stalePrecacheRecoveryKey, '1')
+            rememberShellStateForAutoReload()
+            window.location.reload()
+          } catch (_) {
+            // Best-effort self-heal only; never block shell boot.
+          }
+        }
         // Watchdog: if the registration we just installed sees a NEW
         // SW available, refresh once it activates. Attach to the registration
         // returned by register() immediately; waiting for
@@ -234,6 +307,7 @@
         navigator.serviceWorker.register('/sw.js', { updateViaCache: 'none' })
         .then(reg => {
           watchRegistration(reg)
+          recoverStalePrecacheIfNeeded(reg)
           // Poll for a new SW whenever the PWA returns to the foreground.
           // The explicit `shell_rebuilt` SSE event (Shell.jsx) handles a
           // PWA with a LIVE connection, but a backgrounded/reopened install
@@ -249,7 +323,10 @@
             }
           })
         }).catch(() => {})
-        navigator.serviceWorker.ready.then(watchRegistration).catch(() => {})
+        navigator.serviceWorker.ready.then(reg => {
+          watchRegistration(reg)
+          recoverStalePrecacheIfNeeded(reg)
+        }).catch(() => {})
       }
       // Request persistent storage so cached app modules and offline
       // state aren't evicted under storage pressure. Best-effort —

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -6,7 +6,7 @@ import useStreamConnection from './useStreamConnection.js'
 import useScrollMode, {
   shouldPinSend,
   anchorModeFromScroll,
-  isNearScrollBottom,
+  isNearContentBottom,
   modeForForegroundReturn,
 } from './useScrollMode.js'
 import useVoiceInput from './useVoiceInput.js'
@@ -23,7 +23,7 @@ import QueuedMessages from './QueuedMessages.jsx'
 import MsgContent from './MsgContent.jsx'
 import { questionKey } from './questionKey.js'
 import { resolveStopResend } from './resolveStopResend.js'
-import { assistantStreamCoversMessage, findTrailingAssistantPartialIndex, messageCoversAssistantStream, promoteAssistantStream, streamItemsHaveRenderableContent } from './streamPromotion.js'
+import { chooseActiveAssistantSurface, findTrailingAssistantPartialIndex, promoteAssistantStream, streamItemsHaveRenderableContent } from './streamPromotion.js'
 import {
   canFastForwardQueue,
   continuationRowsFromPromotedMessage,
@@ -145,12 +145,16 @@ function findOptimisticUserIndex(messages, ts) {
  *  user is reading above the tail. Convert that stale pin into the reader's
  *  current scroll position (ANCHOR_AT). The bottom spacer is now independent
  *  from pinning, so it can still reserve room below the newest user message
- *  without moving the reader. Any other current mode is left untouched:
- *  ANCHOR_AT is already the reader's position, and FOLLOW_BOTTOM (reachable
- *  only via pin:false, e.g. handleStop's queue-collapse) must keep following
- *  the stream. */
-function settleNonPinMode(modeRef, scrollEl) {
-  if (modeRef.current?.kind !== 'PIN_USER_MSG') return
+ *  without moving the reader. By default FOLLOW_BOTTOM is left alone because
+ *  pin:false synthetic sends (e.g. handleStop's queue-collapse) intentionally
+ *  keep following. Real user sends/steers that choose not to pin pass
+ *  retireFollow:true so a stale FOLLOW_BOTTOM cannot yank a scrolled-up reader
+ *  when the delayed message becomes visible. */
+function settleNonPinMode(modeRef, scrollEl, { retireFollow = false } = {}) {
+  const kind = modeRef.current?.kind
+  if (kind !== 'PIN_USER_MSG' && !(retireFollow && kind === 'FOLLOW_BOTTOM')) {
+    return
+  }
   const anchor = anchorModeFromScroll(scrollEl)
   if (anchor) modeRef.current = anchor
 }
@@ -317,7 +321,11 @@ export default function ChatView({ chatId, onStreamEnd, onFirstMessage, onSystem
   // cid preservation).
   const pendingQueue = usePendingQueue(cached?.pending_messages || [])
   const queuedContinuationLocalPromotedRef = useRef(null)
+  const queuedContinuationPinIntentRef = useRef(null)
+  const queuedPinIntentByCidRef = useRef(new Map())
+  const queuedPinIntentByTsRef = useRef(new Map())
   const steerPinIntentRef = useRef(null)
+  const inlineSteerPinIntentRef = useRef(null)
   const runtimeReconnectInFlightRef = useRef(false)
   const swReloadHoldTimerRef = useRef(null)
 
@@ -501,12 +509,21 @@ export default function ChatView({ chatId, onStreamEnd, onFirstMessage, onSystem
   //                             ANCHOR_AT{...} on pagination, etc.
   //   • gestureWindowUntilRef — read by handleScroll to gate pagination
   //                             on user-driven scrolls only.
+  //   • userScrollIntentVersionRef
+  //                           — bumped only by human scroll input; delayed
+  //                             queued/steered sends honor their pin intent
+  //                             only if this has not changed since submit.
   //   • revealed              — apply to .chat__scroll style for the
   //                             hide-then-reveal scroll restore.
   //
   // See useScrollMode.js + ARCHITECTURE.md "Chat scroll + steer
   // contract" for full design.
-  const { modeRef, gestureWindowUntilRef, revealed } = useScrollMode({
+  const {
+    modeRef,
+    gestureWindowUntilRef,
+    userScrollIntentVersionRef,
+    revealed,
+  } = useScrollMode({
     chatId,
     scrollRef,
     spacerRef,
@@ -516,6 +533,65 @@ export default function ChatView({ chatId, onStreamEnd, onFirstMessage, onSystem
     pendingMessagesLength: pendingQueue.pendingMessages.length,
     loadingOlderRef: loadingOlder,
   })
+
+  function makeSendPinIntent(willPin) {
+    return {
+      willPin: !!willPin,
+      userScrollIntentVersion: userScrollIntentVersionRef.current,
+    }
+  }
+
+  function pinIntentStillCurrent(intent) {
+    return !!intent
+      && intent.userScrollIntentVersion === userScrollIntentVersionRef.current
+  }
+
+  function rememberQueuedPinIntent(cid, intent) {
+    if (!cid || !intent) return
+    queuedPinIntentByCidRef.current.set(cid, intent)
+  }
+
+  function rememberQueuedPinIntentTs(cid, ts) {
+    if (ts == null) return
+    const intent = cid ? queuedPinIntentByCidRef.current.get(cid) : null
+    if (intent) queuedPinIntentByTsRef.current.set(ts, intent)
+  }
+
+  function forgetQueuedPinIntent({ cid = null, ts = null, tsList = null } = {}) {
+    if (cid) queuedPinIntentByCidRef.current.delete(cid)
+    if (ts != null) queuedPinIntentByTsRef.current.delete(ts)
+    if (Array.isArray(tsList)) {
+      for (const value of tsList) queuedPinIntentByTsRef.current.delete(value)
+    }
+  }
+
+  function takeQueuedPinIntent({ tsList = null, ts = null, localPromoted = null } = {}) {
+    const keys = []
+    if (Array.isArray(tsList)) keys.push(...tsList.filter(v => v != null))
+    if (ts != null) keys.push(ts)
+    let intent = null
+    for (const key of keys) {
+      if (!intent && queuedPinIntentByTsRef.current.has(key)) {
+        intent = queuedPinIntentByTsRef.current.get(key)
+      }
+      queuedPinIntentByTsRef.current.delete(key)
+    }
+    const cid = localPromoted?.cid
+    if (cid) {
+      if (!intent && queuedPinIntentByCidRef.current.has(cid)) {
+        intent = queuedPinIntentByCidRef.current.get(cid)
+      }
+      queuedPinIntentByCidRef.current.delete(cid)
+    }
+    return intent
+  }
+
+  function forgetAllQueuedPinIntents() {
+    queuedPinIntentByCidRef.current.clear()
+    queuedPinIntentByTsRef.current.clear()
+    queuedContinuationPinIntentRef.current = null
+    inlineSteerPinIntentRef.current = null
+  }
 
   // Re-fetch messages from the API. Called when the SSE stream reconnects
   // and gets a 204 (no active broadcast — the chat finished while the
@@ -657,6 +733,8 @@ export default function ChatView({ chatId, onStreamEnd, onFirstMessage, onSystem
         // that event cannot be accidentally folded into this turn here.
         const localPromoted = queuedContinuationLocalPromotedRef.current
         queuedContinuationLocalPromotedRef.current = null
+        const continuationPinIntent = queuedContinuationPinIntentRef.current
+        queuedContinuationPinIntentRef.current = null
         const promotedRows = continuationRowsFromPromotedMessage(
           promotedMessage,
           localPromoted,
@@ -672,20 +750,28 @@ export default function ChatView({ chatId, onStreamEnd, onFirstMessage, onSystem
             m => m.role === 'user' && !m.hidden,
           )
           const pinTargetTs = promotedRows[0]?.ts
-          const contWillPin = pinTargetTs != null && shouldPinSend({
+          const fallbackWillPin = () => shouldPinSend({
             scrollEl: scrollRef.current,
             mode: modeRef.current,
             isFirstUserMsg: contIsFirstUser,
             respectFollowMode: false,
           })
+          const intentStillCurrent = continuationPinIntent
+            ? pinIntentStillCurrent(continuationPinIntent)
+            : true
+          const contWillPin = pinTargetTs != null && intentStillCurrent && (
+            continuationPinIntent
+              ? continuationPinIntent.willPin
+              : fallbackWillPin()
+          )
           commitMessages(prev => appendMessageBatch(prev, promotedRows))
           promotedRef.current = false
           setSpacerActive(true)
           if (contWillPin) {
             if (spacerRef.current) spacerRef.current.style.height = '0px'
             modeRef.current = { kind: 'PIN_USER_MSG', ts: pinTargetTs }
-          } else {
-            settleNonPinMode(modeRef, scrollRef.current)
+          } else if (intentStillCurrent) {
+            settleNonPinMode(modeRef, scrollRef.current, { retireFollow: true })
           }
         } else {
           // Server's promoted ts isn't in our local queue (cancel raced
@@ -697,6 +783,7 @@ export default function ChatView({ chatId, onStreamEnd, onFirstMessage, onSystem
         setServerRunningState(true)
       } else {
         queuedContinuationLocalPromotedRef.current = null
+        queuedContinuationPinIntentRef.current = null
         setSending(false)
         sendingRef.current = false
         setServerRunningState(false)
@@ -721,6 +808,11 @@ export default function ChatView({ chatId, onStreamEnd, onFirstMessage, onSystem
         : pendingQueue.promoteAll(ts)
       queuedContinuationLocalPromotedRef.current =
         serverRows?.length ? serverRows : localPromoted
+      queuedContinuationPinIntentRef.current = takeQueuedPinIntent({
+        tsList: consumedTs,
+        ts,
+        localPromoted,
+      })
     },
     onLiveQuestion: setLiveQuestionId,
     onSteeredIntoTurn: ({ ts, content, messages: steeredBatch }) => {
@@ -740,7 +832,8 @@ export default function ChatView({ chatId, onStreamEnd, onFirstMessage, onSystem
       // could work while the message stayed low in the viewport with no
       // reserved room below it.
       //
-      const pinIntent = steerPinIntentRef.current
+      const pinIntent = steerPinIntentRef.current || inlineSteerPinIntentRef.current
+      inlineSteerPinIntentRef.current = null
       const steeredMessages = Array.isArray(steeredBatch) && steeredBatch.length > 0
         ? steeredBatch.map((m, i) => ({
             role: 'user',
@@ -751,21 +844,19 @@ export default function ChatView({ chatId, onStreamEnd, onFirstMessage, onSystem
         : [{ role: 'user', content, ts: ts ?? Date.now() }]
       const pinTargetTs = steeredMessages[0]?.ts
       promoteStreamToMessages({ keepTurnOpen: true })
-      // Pin decision is intentionally recomputed at the moment the steered
-      // row becomes visible. The reader may have scrolled after tapping the
-      // button or while the queued POST was in flight; using an old at-bottom
-      // snapshot would yank a scrolled-up reader back to the new message.
       const steeredIsFirstUser = !messagesRef.current.some(
         m => m.role === 'user' && !m.hidden,
       )
-      const pinStillValid = !!pinIntent
-      const shouldPinSteered = pinTargetTs != null && pinStillValid
-        && shouldPinSend({
-          scrollEl: scrollRef.current,
-          mode: modeRef.current,
-          isFirstUserMsg: steeredIsFirstUser,
-          respectFollowMode: false,
-        })
+      const fallbackWillPin = () => shouldPinSend({
+        scrollEl: scrollRef.current,
+        mode: modeRef.current,
+        isFirstUserMsg: steeredIsFirstUser,
+        respectFollowMode: false,
+      })
+      const pinStillValid = pinIntent ? pinIntentStillCurrent(pinIntent) : false
+      const shouldPinSteered = pinTargetTs != null && pinStillValid && (
+        pinIntent ? pinIntent.willPin : fallbackWillPin()
+      )
       // Dedup by ts so a reconnect's catch-up replay of the same event
       // can't double-insert the steered user message. Insert by transcript ts
       // instead of blindly appending: if a fetch/replay already committed the
@@ -776,7 +867,7 @@ export default function ChatView({ chatId, onStreamEnd, onFirstMessage, onSystem
         if (spacerRef.current) spacerRef.current.style.height = '0px'
         modeRef.current = { kind: 'PIN_USER_MSG', ts: pinTargetTs }
       } else if (pinStillValid) {
-        settleNonPinMode(modeRef, scrollRef.current)
+        settleNonPinMode(modeRef, scrollRef.current, { retireFollow: true })
       }
       steerPinIntentRef.current = null
     },
@@ -1230,8 +1321,8 @@ export default function ChatView({ chatId, onStreamEnd, onFirstMessage, onSystem
     // viewport before we compute the send rule; if we measure after
     // blur, a reader who was genuinely at the bottom can be misread as
     // scrolled up and the new user message won't pin to the top.
-    const wasNearScrollBottomAtSubmit = scrollRef.current
-      ? isNearScrollBottom(scrollRef.current)
+    const wasNearContentBottomAtSubmit = scrollRef.current
+      ? isNearContentBottom(scrollRef.current)
       : null
 
     // On touch devices, blur to dismiss the soft keyboard. Desktop keeps
@@ -1294,18 +1385,20 @@ export default function ChatView({ chatId, onStreamEnd, onFirstMessage, onSystem
       // rule as a fresh send. The at-bottom / following decision and the
       // first-user check must reflect the moment of sending — reading them
       // AFTER `await streamSend(...)` lets a scroll during the POST flip the
-      // decision. `modeAtSend` lets us detect such a scroll and yield to it
-      // (a user-driven mode change during the await is the newer intent).
+      // decision. The user-scroll intent version lets us detect such a scroll
+      // and yield to it (a user-driven scroll after send is the newer intent).
       const queuedIsFirstUser = !messagesRef.current.some(
         m => m.role === 'user' && !m.hidden,
       )
-      const queuedModeAtSend = modeRef.current
-      const queuedWillPin = shouldPinSend({
+      const queuedWillPin = pin && shouldPinSend({
         scrollEl: scrollRef.current,
         mode: modeRef.current,
         isFirstUserMsg: queuedIsFirstUser,
-        wasNearScrollBottom: wasNearScrollBottomAtSubmit,
+        wasNearScrollBottom: wasNearContentBottomAtSubmit,
       })
+      const queuedPinIntent = makeSendPinIntent(queuedWillPin)
+      rememberQueuedPinIntent(cid, queuedPinIntent)
+      inlineSteerPinIntentRef.current = queuedPinIntent
       setInput('')
       clearComposerFilesForSend()
       if (inputRef.current) {
@@ -1332,6 +1425,7 @@ export default function ChatView({ chatId, onStreamEnd, onFirstMessage, onSystem
           const canonicalPending = result.pending_message || null
           // Replace optimistic ts with server's (cid is stable).
           const ackTs = canonicalPending?.ts ?? result.ts
+          rememberQueuedPinIntentTs(queuedMsg.cid, ackTs)
           pendingQueue.swapOptimisticTs(
             queuedMsg.cid,
             ackTs ?? queuedMsg.ts,
@@ -1364,7 +1458,7 @@ export default function ChatView({ chatId, onStreamEnd, onFirstMessage, onSystem
             // (captured before the await) and yield to a user scroll that
             // changed the mode during the POST. Pin keys to the first SERVER
             // ts from the promoted batch, not the optimistic queuedMsg.ts.
-            const pinStillValid = modeRef.current === queuedModeAtSend
+            const pinStillValid = pinIntentStillCurrent(queuedPinIntent)
             const pinTargetTs = startedMessages?.[0]?.ts ?? queuedMsg.ts
             setSpacerActive(true)
             if (queuedWillPin && pinStillValid) {
@@ -1374,8 +1468,13 @@ export default function ChatView({ chatId, onStreamEnd, onFirstMessage, onSystem
                 ts: pinTargetTs,
               }
             } else if (pinStillValid) {
-              settleNonPinMode(modeRef, scrollRef.current)
+              settleNonPinMode(modeRef, scrollRef.current, { retireFollow: pin })
             }
+            forgetQueuedPinIntent({
+              cid: queuedMsg.cid,
+              ts: ackTs,
+              tsList: result.message?._consumed_ts,
+            })
             bridgeHook.markBridged()
           }
         }
@@ -1386,6 +1485,7 @@ export default function ChatView({ chatId, onStreamEnd, onFirstMessage, onSystem
         // optimistic queued-tray entry here — it never queued.
         if (result?.status === 'steered') {
           pendingQueue.cancelByCid(queuedMsg.cid)
+          forgetQueuedPinIntent({ cid: queuedMsg.cid })
         }
         // Race: server said "started" though we expected queued.
         if (result?.status === 'started') {
@@ -1415,7 +1515,7 @@ export default function ChatView({ chatId, onStreamEnd, onFirstMessage, onSystem
           // ANCHOR_AT (see settleNonPinMode) so the reader stays put with
           // reservation still available below. Pin keys to the first SERVER
           // ts when available; otherwise fall back to the optimistic ts.
-          const startedPinStillValid = modeRef.current === queuedModeAtSend
+          const startedPinStillValid = pinIntentStillCurrent(queuedPinIntent)
           const pinTargetTs = startedMessages?.[0]?.ts ?? queuedMsg.ts
           setSpacerActive(true)
           if (queuedWillPin && startedPinStillValid) {
@@ -1425,13 +1525,20 @@ export default function ChatView({ chatId, onStreamEnd, onFirstMessage, onSystem
               ts: pinTargetTs,
             }
           } else if (startedPinStillValid) {
-            settleNonPinMode(modeRef, scrollRef.current)
+            settleNonPinMode(modeRef, scrollRef.current, { retireFollow: pin })
           }
+          forgetQueuedPinIntent({
+            cid: queuedMsg.cid,
+            tsList: result.message?._consumed_ts,
+          })
           // This is a NEW turn (not the bridge turn from mount).
           // Retire the bridge gate so the upcoming promote appends a
           // fresh assistant instead of replacing whichever message
           // is currently last.
           bridgeHook.markBridged()
+        }
+        if (result?.status !== 'steered') {
+          inlineSteerPinIntentRef.current = null
         }
         // Invariant: every observable queue-path status must resolve
         // the optimistic entry's in-flight flag. queued/steered/started
@@ -1449,6 +1556,8 @@ export default function ChatView({ chatId, onStreamEnd, onFirstMessage, onSystem
       } catch (err) {
         // Roll back optimistic + restore input.
         pendingQueue.cancelByCid(queuedMsg.cid)
+        forgetQueuedPinIntent({ cid: queuedMsg.cid })
+        inlineSteerPinIntentRef.current = null
         restoreComposerAfterFailedSend()
         commitMessages(prev => [
           ...prev,
@@ -1480,7 +1589,7 @@ export default function ChatView({ chatId, onStreamEnd, onFirstMessage, onSystem
       scrollEl: scrollRef.current,
       mode: modeRef.current,
       isFirstUserMsg,
-      wasNearScrollBottom: wasNearScrollBottomAtSubmit,
+      wasNearScrollBottom: wasNearContentBottomAtSubmit,
     })
 
     const userMsg = { role: 'user', content: text, ts: Date.now(), optimistic: true }
@@ -1509,7 +1618,7 @@ export default function ChatView({ chatId, onStreamEnd, onFirstMessage, onSystem
       if (spacerRef.current) spacerRef.current.style.height = '0px'
       modeRef.current = { kind: 'PIN_USER_MSG', ts: userMsg.ts }
     } else {
-      settleNonPinMode(modeRef, scrollRef.current)
+      settleNonPinMode(modeRef, scrollRef.current, { retireFollow: pin })
     }
     // Fresh turn — not a bridge from a mounted DB partial.
     bridgeHook.markBridged()
@@ -1764,6 +1873,7 @@ export default function ChatView({ chatId, onStreamEnd, onFirstMessage, onSystem
   // by re-fetching authoritative state on success or on error.
   const handleCancelPending = useCallback(async (ts) => {
     pendingQueue.cancelByTs(ts)
+    forgetQueuedPinIntent({ ts })
     try {
       const res = await apiFetch(`/chats/${chatId}/pending/${ts}`, {
         method: 'DELETE',
@@ -1841,6 +1951,7 @@ export default function ChatView({ chatId, onStreamEnd, onFirstMessage, onSystem
       // pendingQueue.clear() updates pendingMessagesRef.current to
       // [] before this line returns (synchronous).
       fetchGenRef.current += 1
+      forgetAllQueuedPinIntents()
       pendingQueue.clear()
 
       let stoppedCleanly = true
@@ -2050,7 +2161,20 @@ export default function ChatView({ chatId, onStreamEnd, onFirstMessage, onSystem
       if (!content) return
 
       try {
-        steerPinIntentRef.current = { inFlight: true }
+        const wasNearContentBottomAtSteer = scrollRef.current
+          ? isNearContentBottom(scrollRef.current)
+          : null
+        const steerIsFirstUser = !messagesRef.current.some(
+          m => m.role === 'user' && !m.hidden,
+        )
+        const steerWillPin = shouldPinSend({
+          scrollEl: scrollRef.current,
+          mode: modeRef.current,
+          isFirstUserMsg: steerIsFirstUser,
+          respectFollowMode: false,
+          wasNearScrollBottom: wasNearContentBottomAtSteer,
+        })
+        steerPinIntentRef.current = makeSendPinIntent(steerWillPin)
         const result = await streamSend(content, attachments, {
           forceSteer: true,
           consumePendingTs,
@@ -2070,6 +2194,7 @@ export default function ChatView({ chatId, onStreamEnd, onFirstMessage, onSystem
           } else {
             for (const ts of consumePendingTs) pendingQueue.cancelByTs(ts)
           }
+          forgetQueuedPinIntent({ tsList: consumePendingTs })
         }
         if (result?.status !== 'steered') {
           steerPinIntentRef.current = null
@@ -2238,20 +2363,19 @@ export default function ChatView({ chatId, onStreamEnd, onFirstMessage, onSystem
     : -1
   const activePartialMsgIdx = bridgeMsgIdx >= 0 ? bridgeMsgIdx : trailingAssistantPartialIdx
   const activePartialMsg = activePartialMsgIdx >= 0 ? messages[activePartialMsgIdx] : null
-  const liveStreamCoversPartial = activePartialMsg
-    ? assistantStreamCoversMessage(activePartialMsg, streamItems)
-    : false
-  const partialCoversLiveStream = activePartialMsg
-    ? messageCoversAssistantStream(activePartialMsg, streamItems)
-    : false
   // Single-surface invariant for active assistant partials:
   // - if the live stream is at least as fresh as the saved DB partial, hide the
   //   DB row and render StreamingMessage; final promotion replaces that row.
   // - if the DB partial is richer than a stale cached stream snapshot (e.g.
   //   stray "I" after returning to chat), keep the DB row and suppress the
   //   stale stream until catch-up catches up.
-  const liveMirrorMsgIdx = liveStreamCoversPartial ? activePartialMsgIdx : -1
-  const suppressStreamingSurface = !!(activePartialMsg && partialCoversLiveStream && !liveStreamCoversPartial)
+  // - if both surfaces clearly belong to the same active answer but tool /
+  //   thinking metadata is only partially replayed, still choose ONE surface.
+  //   Rendering both was the transient "duplicated agent output" bug: reopening
+  //   the chat fixed it because the durable transcript had only one copy.
+  const activeAssistantSurface = chooseActiveAssistantSurface(activePartialMsg, streamItems)
+  const liveMirrorMsgIdx = activeAssistantSurface.hideMessage ? activePartialMsgIdx : -1
+  const suppressStreamingSurface = !!(activePartialMsg && activeAssistantSurface.suppressStream)
   const showStreamingSurface = turnActive && streamItems.length > 0 && !suppressStreamingSurface
 
   // ── Sticky "needs your answer" affordance ──────────────────────────

--- a/frontend/src/components/ChatView/__tests__/chatRuntimeState.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatRuntimeState.test.js
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict'
 import {
   canFastForwardQueue,
   continuationRowsFromPromotedMessage,
+  serverSnapshotBehindLocal,
   startedMessagesFromResponse,
 } from '../chatRuntimeState.js'
 
@@ -42,4 +43,31 @@ test('canFastForwardQueue requires active turn and server-confirmed queued rows'
   assert.equal(canFastForwardQueue([{ ts: 1, serverTs: false }], true), false)
   assert.equal(canFastForwardQueue([{ ts: '1', serverTs: true }], true), false)
   assert.equal(canFastForwardQueue([{ ts: 1, serverTs: true }, { ts: 2, serverTs: true }], true), true)
+})
+
+test('serverSnapshotBehindLocal only preserves explicit unsaved local rows', () => {
+  const server = [
+    { role: 'user', content: 'saved one', ts: 1 },
+    { role: 'assistant', content: 'saved two', ts: 2 },
+  ]
+
+  assert.equal(serverSnapshotBehindLocal(server, [
+    ...server,
+    { role: 'assistant', content: 'stale duplicate from old client', ts: 3 },
+  ]), false)
+
+  assert.equal(serverSnapshotBehindLocal(server, [
+    ...server,
+    { role: 'user', content: 'posting', ts: 4, optimistic: true },
+  ]), true)
+
+  assert.equal(serverSnapshotBehindLocal(server, [
+    ...server,
+    { role: 'user', content: 'queued', ts: 5, queued: true },
+  ]), true)
+
+  assert.equal(serverSnapshotBehindLocal(server, [
+    ...server,
+    { role: 'user', content: 'waiting for canonical ts', ts: 6, serverTs: false },
+  ]), true)
 })

--- a/frontend/src/components/ChatView/__tests__/streamPromotion.test.js
+++ b/frontend/src/components/ChatView/__tests__/streamPromotion.test.js
@@ -9,6 +9,7 @@ import {
   promoteAssistantStream,
   assistantStreamCoversMessage,
   messageCoversAssistantStream,
+  chooseActiveAssistantSurface,
   assistantMessageText,
   findTrailingAssistantPartialIndex,
   streamItemsHaveRenderableContent,
@@ -130,6 +131,71 @@ test('messageCoversAssistantStream prefers a richer DB partial over a stale one-
   const items = [{ type: 'text', content: 'I' }]
   assert.equal(assistantStreamCoversMessage(msg, items), false)
   assert.equal(messageCoversAssistantStream(msg, items), true)
+})
+
+test('chooseActiveAssistantSurface hides DB partial when live replay is same turn but block metadata drifted', () => {
+  const msg = {
+    role: 'assistant',
+    ts: 2,
+    content: 'I’ll inspect the component and patch the active flow.',
+    blocks: [
+      { type: 'text', content: 'I’ll inspect the component and patch the active flow.' },
+      { type: 'tool', tool: 'Bash', status: 'done', input: 'sed -n 1,200p app.jsx' },
+      { type: 'thinking', content: 'I' },
+    ],
+  }
+  const items = [
+    { type: 'text', content: 'I’ll inspect the component and patch the active flow.' },
+    // Same live turn, but catch-up/tool summaries can temporarily differ.
+    { type: 'tool', tool: 'Bash', status: 'running', input: 'grep -n lookup app.jsx' },
+    { type: 'thinking', content: 'I’m checking the active renderer path now.' },
+  ]
+
+  assert.equal(assistantStreamCoversMessage(msg, items), false)
+  assert.equal(messageCoversAssistantStream(msg, items), false)
+  assert.deepEqual(chooseActiveAssistantSurface(msg, items), {
+    hideMessage: true,
+    suppressStream: false,
+  })
+})
+
+test('chooseActiveAssistantSurface suppresses under-caught-up stream when DB partial is richer', () => {
+  const msg = {
+    role: 'assistant',
+    ts: 2,
+    content: 'I’ll inspect the component and patch the active flow.',
+    blocks: [
+      { type: 'text', content: 'I’ll inspect the component and patch the active flow.' },
+      { type: 'tool', tool: 'Bash', status: 'running', input: 'python3 very-long-inspection.py --all' },
+      { type: 'thinking', content: 'I’m already well into the inspection.' },
+    ],
+  }
+  const items = [
+    { type: 'text', content: 'I’ll inspect the component and patch the active flow.' },
+    { type: 'tool', tool: 'Bash', status: 'running', input: '' },
+  ]
+
+  assert.equal(assistantStreamCoversMessage(msg, items), false)
+  assert.equal(messageCoversAssistantStream(msg, items), false)
+  assert.deepEqual(chooseActiveAssistantSurface(msg, items), {
+    hideMessage: false,
+    suppressStream: true,
+  })
+})
+
+test('chooseActiveAssistantSurface does not collapse unrelated assistant and stream surfaces', () => {
+  const msg = {
+    role: 'assistant',
+    ts: 2,
+    content: 'Previous answer',
+    blocks: [{ type: 'text', content: 'Previous answer' }],
+  }
+  const items = [{ type: 'text', content: 'New active answer' }]
+
+  assert.deepEqual(chooseActiveAssistantSurface(msg, items), {
+    hideMessage: false,
+    suppressStream: false,
+  })
 })
 
 test('text prefix does not hide a persisted tool block when stream lacks it', () => {

--- a/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
+++ b/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 
 import {
   _computeSpacerH,
+  _pinReapplyNeeded,
   isNearContentBottom,
   isNearScrollBottom,
   modeForForegroundReturn,
@@ -67,10 +68,11 @@ test('shouldPinSend can ignore stale follow mode for delayed queued insertion', 
   }), false)
 })
 
-test('shouldPinSend ignores dynamic pin spacer when checking bottom gap', () => {
+test('shouldPinSend treats the bottom of real content as at-bottom, ignoring dynamic pin spacer', () => {
   // Raw gap is 440px, but 400px is phantom spacer left by a previous pin.
-  // Real content gap is 40px, but the reader is in the middle of the reserved
-  // spacer, not the true scroll bottom. Sending should NOT yank them.
+  // Real content gap is 40px: visually, the reader is at the conversation
+  // tail. The next send should pin to the top even though the physical scroll
+  // bottom includes empty reserved room below the messages.
   const scrollEl = makeScrollEl({
     scrollHeight: 2000,
     scrollTop: 1000,
@@ -81,7 +83,7 @@ test('shouldPinSend ignores dynamic pin spacer when checking bottom gap', () => 
     scrollEl,
     mode: { kind: 'PIN_USER_MSG', ts: 123 },
     isFirstUserMsg: false,
-  }), false)
+  }), true)
 })
 
 test('shouldPinSend still refuses to pin when real content gap is large', () => {
@@ -108,6 +110,44 @@ test('isNearContentBottom uses the same phantom-spacer bottom contract', () => {
   assert.equal(isNearContentBottom(scrollEl), true)
   assert.equal(isNearScrollBottom(scrollEl), false,
     'middle of reserved spacer is not true scroll bottom')
+})
+
+test('pin reapply is needed when the first pin was clamped but spacer now makes the target reachable', () => {
+  const scrollEl = {
+    scrollHeight: 2000,
+    scrollTop: 500,
+    clientHeight: 700,
+    querySelector(selector) {
+      if (selector === '.chat__msg--user[data-ts="123"]') {
+        return { offsetTop: 1000 }
+      }
+      return null
+    },
+  }
+
+  assert.equal(
+    _pinReapplyNeeded(scrollEl, { kind: 'PIN_USER_MSG', ts: 123 }, 1000),
+    true,
+  )
+})
+
+test('pin reapply waits until the target is reachable to avoid stepwise pin jitter', () => {
+  const scrollEl = {
+    scrollHeight: 1500,
+    scrollTop: 500,
+    clientHeight: 700,
+    querySelector(selector) {
+      if (selector === '.chat__msg--user[data-ts="123"]') {
+        return { offsetTop: 1000 }
+      }
+      return null
+    },
+  }
+
+  assert.equal(
+    _pinReapplyNeeded(scrollEl, { kind: 'PIN_USER_MSG', ts: 123 }, 1000),
+    false,
+  )
 })
 
 test('viewport resize at physical bottom retires stale pin mode', () => {

--- a/frontend/src/components/ChatView/chatRuntimeState.js
+++ b/frontend/src/components/ChatView/chatRuntimeState.js
@@ -36,7 +36,6 @@ export function continuationRowsFromPromotedMessage(promotedMessage, localPromot
 export function serverSnapshotBehindLocal(serverMsgs, localMsgs) {
   if (!Array.isArray(localMsgs) || localMsgs.length === 0) return false
   if (!Array.isArray(serverMsgs)) return false
-  if (serverMsgs.length < localMsgs.length) return true
   if (serverMsgs.length > localMsgs.length) return false
 
   const serverTs = new Set(serverMsgs.map(m => m?.ts).filter(v => v != null))

--- a/frontend/src/components/ChatView/streamPromotion.js
+++ b/frontend/src/components/ChatView/streamPromotion.js
@@ -87,6 +87,84 @@ function streamBlocksCoverMessageBlocks(msgBlocks, streamBlocks) {
   return true
 }
 
+function blockWeight(block) {
+  if (!block) return 0
+  if (block.type === 'text' || block.type === 'thinking') {
+    return normalizeMirrorText(block.content).length
+  }
+  if (block.type === 'tool') {
+    return 40
+      + normalizeMirrorText(block.tool).length
+      + normalizeMirrorText(block.input).length
+      + normalizeMirrorText(block.output).length
+  }
+  if (block.type === 'question') {
+    return 40
+      + (Array.isArray(block.questions)
+        ? block.questions.map(q => normalizeMirrorText(q?.question || q?.text)).join(' ').length
+        : 0)
+      + (block.answers ? 20 : 0)
+  }
+  if (block.type === 'error') return 40 + normalizeMirrorText(block.message).length
+  return 0
+}
+
+function surfaceWeight({ content, blocks }) {
+  const blockTotal = Array.isArray(blocks)
+    ? blocks.reduce((sum, block) => sum + blockWeight(block), 0)
+    : 0
+  return normalizeMirrorText(content).length + blockTotal
+}
+
+function firstMeaningfulBlock(blocks) {
+  if (!Array.isArray(blocks)) return null
+  return blocks.find(block => {
+    if (!block) return false
+    if (block.type === 'text' || block.type === 'thinking') {
+      return !!normalizeMirrorText(block.content)
+    }
+    return true
+  }) || null
+}
+
+function blocksLookLikeSameTurn(a, b) {
+  if (!a || !b || a.type !== b.type) return false
+  if (a.type === 'text' || a.type === 'thinking') {
+    const aText = normalizeMirrorText(a.content)
+    const bText = normalizeMirrorText(b.content)
+    return !!(aText && bText && (aText.startsWith(bText) || bText.startsWith(aText)))
+  }
+  if (a.type === 'tool') return !!(a.tool && a.tool === b.tool)
+  if (a.type === 'question') return questionKey(a) === questionKey(b)
+  if (a.type === 'error') return (a.message || '') === (b.message || '')
+  return false
+}
+
+function assistantSurfacesLookRelated(msg, streamPayload) {
+  const msgText = normalizeMirrorText(assistantMessageText(msg))
+  const streamText = normalizeMirrorText(streamPayload.content)
+  if (msgText && streamText) {
+    if (msgText.startsWith(streamText) || streamText.startsWith(msgText)) {
+      return true
+    }
+    // Allow a small amount of metadata drift around the same opening prose.
+    // This is deliberately a prefix-only heuristic: unrelated turns often
+    // share generic words later in the paragraph, but a long shared opener is
+    // a strong signal that the DB partial and replay stream are the same turn.
+    const n = Math.min(msgText.length, streamText.length, 48)
+    if (n >= 24 && msgText.slice(0, n) === streamText.slice(0, n)) {
+      return true
+    }
+  }
+
+  const msgBlocks = Array.isArray(msg?.blocks) ? msg.blocks.filter(Boolean) : []
+  const streamBlocks = Array.isArray(streamPayload?.blocks) ? streamPayload.blocks.filter(Boolean) : []
+  return blocksLookLikeSameTurn(
+    firstMeaningfulBlock(msgBlocks),
+    firstMeaningfulBlock(streamBlocks),
+  )
+}
+
 export function assistantStreamCoversMessage(msg, items) {
   if (!msg || msg.role !== 'assistant') return false
   if (!Array.isArray(items) || items.length === 0) return false
@@ -119,6 +197,33 @@ export function messageCoversAssistantStream(msg, items) {
     if (block.type === 'error') return (msgBlock.message || '') === (block.message || '')
     return false
   })
+}
+
+export function chooseActiveAssistantSurface(msg, items) {
+  if (!msg || msg.role !== 'assistant' || !Array.isArray(items) || items.length === 0) {
+    return { hideMessage: false, suppressStream: false }
+  }
+
+  if (assistantStreamCoversMessage(msg, items)) {
+    return { hideMessage: true, suppressStream: false }
+  }
+  if (messageCoversAssistantStream(msg, items)) {
+    return { hideMessage: false, suppressStream: true }
+  }
+
+  const streamPayload = streamItemsToAssistantPayload(items)
+  if (!assistantSurfacesLookRelated(msg, streamPayload)) {
+    return { hideMessage: false, suppressStream: false }
+  }
+
+  const msgPayload = {
+    content: assistantMessageText(msg),
+    blocks: Array.isArray(msg.blocks) ? msg.blocks.filter(Boolean) : [],
+  }
+  if (surfaceWeight(streamPayload) >= surfaceWeight(msgPayload)) {
+    return { hideMessage: true, suppressStream: false }
+  }
+  return { hideMessage: false, suppressStream: true }
 }
 
 export function findTrailingAssistantPartialIndex(messages) {

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -15,10 +15,12 @@
  *
  * Bottom detection: the load-bearing at-bottom decision for
  * send-pinning is scrollHeight math (`shouldPinSend` →
- * `isNearScrollBottom`, read from `scrollTop` before the append). The
- * IntersectionObserver on a sentinel at the end of `.chat__scroll` is
+ * `isNearContentBottom`, read from `scrollTop` before the append). The
+ * dynamic pin spacer is reserved room, not message content: if the reader is
+ * at the bottom of the real conversation, the next send should still pin.
+ * The IntersectionObserver on a sentinel at the end of `.chat__scroll` is
  * used only for the gesture-driven mode transition (engaging
- * FOLLOW_BOTTOM when the user scrolls to the bottom), not for the
+ * FOLLOW_BOTTOM when the user scrolls to the physical bottom), not for the
  * send-pin decision.
  *
  * User-gesture detection: pointerdown/wheel/touchstart/keydown open a
@@ -126,6 +128,19 @@ export function applyMode(scrollEl, mode) {
   }
 }
 
+export function _pinReapplyNeeded(scrollEl, mode, lastPinTop) {
+  if (!scrollEl || mode?.kind !== 'PIN_USER_MSG') return false
+  const el = scrollEl.querySelector(
+    `.chat__msg--user[data-ts="${mode.ts}"]`,
+  )
+  if (!el) return false
+  const target = Math.max(0, el.offsetTop - PIN_OFFSET)
+  const maxScrollTop = scrollEl.scrollHeight - scrollEl.clientHeight
+  const clampedShort = scrollEl.scrollTop < target - 1
+    && maxScrollTop >= target - 1
+  return el.offsetTop !== lastPinTop || clampedShort
+}
+
 
 /** Validates a saved ScrollMode against current state.
  *  Degrades to FOLLOW_BOTTOM if the anchor no longer exists. */
@@ -191,14 +206,14 @@ const NEAR_BOTTOM_PX = 50
  *  the first follow-write, so a sentinel read at send time would
  *  mis-classify an at-bottom reader):
  *
- *    1. The scroll position is within NEAR_BOTTOM_PX of the true scroll
- *       bottom right now, measured from scrollTop BEFORE the new message
- *       appends. This is a position computation, not a sentinel read, and
- *       it covers a chat short enough to fit the viewport and a reader
- *       sitting at the actual tail without having made the bottom gesture.
- *       Reserved pin-spacer room is part of the scroll range for this
- *       purpose: a reader in the middle of that empty reserved room is not
- *       at the bottom and must not be yanked to the next user message.
+ *    1. The scroll position is within NEAR_BOTTOM_PX of the bottom of the
+ *       real message content right now, measured from scrollTop BEFORE the
+ *       new message appends. This is a position computation, not a sentinel
+ *       read, and it covers a chat short enough to fit the viewport and a
+ *       reader sitting at the visible tail without having made the bottom
+ *       gesture. Reserved pin-spacer room is excluded for this purpose:
+ *       empty room below the last message should not make the next send land
+ *       mid-screen when the user is visually at the bottom of the chat.
  *
  *    2. FOLLOW_BOTTOM is only a fallback when the scroll element is not
  *       available. It is deliberately NOT authoritative when scrollEl
@@ -216,7 +231,7 @@ export function shouldPinSend({
 }) {
   if (isFirstUserMsg) return true
   if (typeof wasNearScrollBottom === 'boolean') return wasNearScrollBottom
-  if (scrollEl) return isNearScrollBottom(scrollEl)
+  if (scrollEl) return isNearContentBottom(scrollEl)
   if (respectFollowMode && mode && mode.kind === 'FOLLOW_BOTTOM') return true
   return false
 }
@@ -337,6 +352,7 @@ export function modeForForegroundReturn(scrollEl) {
  *     | {kind: 'ANCHOR_AT', key: string, offset: number}
  *   >,
  *   gestureWindowUntilRef: React.MutableRefObject<number>,
+ *   userScrollIntentVersionRef: React.MutableRefObject<number>,
  *   revealed: boolean,
  * }}
  */
@@ -355,6 +371,12 @@ export default function useScrollMode({
   const modeChatIdRef = useRef(null)
   const bottomVisibleRef = useRef(false)
   const gestureWindowUntilRef = useRef(0)
+  // Monotonic counter for actual user scroll intent. Send/steer code captures
+  // this at submit time and honors a delayed pin only if the user did not
+  // scroll after submitting. Programmatic applyMode scrolls must not increment
+  // it, so it is bumped from pointer/wheel/touch/key input on the scroll pane,
+  // not from every scroll event.
+  const userScrollIntentVersionRef = useRef(0)
   const fullViewHRef = useRef(0)
   // Lives outside the layout effect so it survives StrictMode's
   // double-invoke in dev (and any future effect re-run). If this were
@@ -498,6 +520,19 @@ export default function useScrollMode({
       }
     }
 
+    function settlePinnedMode() {
+      if (!_pinReapplyNeeded(scrollEl, modeRef.current, lastPinTopRef.current)) {
+        return
+      }
+      applyMode(scrollEl, modeRef.current)
+      const el = scrollEl.querySelector(
+        `.chat__msg--user[data-ts="${modeRef.current.ts}"]`,
+      )
+      lastPinTopRef.current = el ? el.offsetTop : null
+      lastAppliedModeRef.current = modeRef.current
+      nearScrollBottomRef.current = isNearScrollBottom(scrollEl)
+    }
+
     // Full sync — size spacer and apply-if-changed. Used at mount, RO, reveal,
     // and visualViewport keyboard changes. Each call sizes the spacer (always
     // needed — the spacer math depends on changing content). Most callers only
@@ -527,6 +562,12 @@ export default function useScrollMode({
       } else {
         maybeApplyMode()
       }
+      // A send can set PIN_USER_MSG while the dynamic spacer is still at its
+      // old height. `sizeSpacer()` above makes the target reachable; this
+      // immediate settle pass applies the same pin again if the browser had
+      // clamped the first write, instead of waiting for a later RO event that
+      // may never fire for the spacer-only height change.
+      settlePinnedMode()
       nearScrollBottomRef.current = isNearScrollBottom(scrollEl)
     }
     syncLayout()
@@ -614,28 +655,15 @@ export default function useScrollMode({
         // tall-enough scrollHeight already keeps the pin satisfied (no
         // clamp, no offsetTop shift) — so this stays a no-op there and does
         // NOT reintroduce the May-2026 re-pin-every-RO-firing jitter.
-        const el = scrollEl.querySelector(
-          `.chat__msg--user[data-ts="${modeRef.current.ts}"]`,
-        )
-        if (el) {
-          const target = Math.max(0, el.offsetTop - PIN_OFFSET)
-          const maxScrollTop = scrollEl.scrollHeight - scrollEl.clientHeight
-          // Reachability is measured against the TARGET, not "is there any
-          // more room than now". If we gated on `maxScrollTop >= scrollTop`,
-          // a layout still growing toward the target (scrollHeight climbing
-          // as content streams in below) would re-pin stepwise on every RO
-          // firing — clamp to the current max, fire again, clamp a little
-          // higher — reintroducing the May-2026 stutter. Gating on the
-          // target means we re-pin exactly once, when the settled layout
-          // can actually hold the message at the top.
-          const clampedShort = scrollEl.scrollTop < target - 1
-            && maxScrollTop >= target - 1
-          if (el.offsetTop !== lastPinTopRef.current || clampedShort) {
-            applyMode(scrollEl, modeRef.current)
-            lastPinTopRef.current = el.offsetTop
-            nearScrollBottomRef.current = isNearScrollBottom(scrollEl)
-          }
-        }
+        // Reachability is measured against the TARGET, not "is there any
+        // more room than now". If we gated on `maxScrollTop >= scrollTop`,
+        // a layout still growing toward the target (scrollHeight climbing
+        // as content streams in below) would re-pin stepwise on every RO
+        // firing — clamp to the current max, fire again, clamp a little
+        // higher — reintroducing the May-2026 stutter. Gating on the
+        // target means we re-pin exactly once, when the settled layout
+        // can actually hold the message at the top.
+        settlePinnedMode()
       }
       nearScrollBottomRef.current = isNearScrollBottom(scrollEl)
       requestRevealOnQuiet()  // each RO firing pushes the reveal back
@@ -648,6 +676,7 @@ export default function useScrollMode({
     // User-gesture detection.
     const onUserInput = () => {
       gestureWindowUntilRef.current = performance.now() + GESTURE_WINDOW_MS
+      userScrollIntentVersionRef.current += 1
     }
     scrollEl.addEventListener('pointerdown', onUserInput, { passive: true })
     scrollEl.addEventListener('touchstart', onUserInput, { passive: true })
@@ -738,6 +767,7 @@ export default function useScrollMode({
   return {
     modeRef,
     gestureWindowUntilRef,
+    userScrollIntentVersionRef,
     revealed,
   }
 }


### PR DESCRIPTION
Fixes several active-chat UI edge cases that made the chat look inconsistent even when the saved transcript was correct:

- Prevents an in-progress assistant answer from rendering twice during reconnect/catch-up when the saved DB partial and replayed live stream are the same answer but their tool/thinking metadata differs temporarily.
- Fixes send/steer scroll placement for queued user messages by carrying submit/tap-time scroll intent forward until the delayed user row becomes visible.
- Makes transcript refresh trust the server again unless the local list contains explicit unsaved rows, so stale duplicated/local cached rows cannot hide saved messages after reopening.
- Adds a shell boot self-heal for stale Workbox precaches: if the loaded Vite bundle differs from the bundle advertised by network /sw.js, the shell clears only the Workbox precache and reloads once.

What changed:
- Adds `chooseActiveAssistantSurface()` so ChatView chooses either the saved assistant partial or the live stream surface, instead of rendering both, while still preserving genuinely unrelated prior assistant messages.
- Treats the dynamic pin spacer as reserved room for send-time bottom detection, so sending from the visible conversation tail still pins the new user message to the top.
- Re-applies `PIN_USER_MSG` after spacer sizing when the browser initially clamps the scroll write and the pin target becomes reachable.
- Captures submit/steer scroll intent and invalidates it only if the reader manually scrolls afterward.
- Retires stale follow/pin modes on non-pinning real sends/steers so sending or steering while scrolled up preserves the reader's position.
- Narrows `serverSnapshotBehindLocal()` so a merely longer local list no longer blocks authoritative saved rows.
- Preserves shell view state across automatic service-worker reloads and adds the stale-precache recovery check in `index.html`.

Tested:
- `npm --prefix /data/platform/frontend test -- src/components/ChatView/__tests__/streamPromotion.test.js src/components/ChatView/__tests__/useScrollMode.test.js src/components/ChatView/__tests__/chatRuntimeState.test.js`
- `npm --prefix /data/platform/frontend run build`
- Manual live-shell verification: a fresh shell renders the saved rows; deleting the stale Workbox precache makes a diagnostic stale browser load the current bundle.

Prepared by a Möbius agent with owner review.