### PR TITLE
Add chat composer send and steer shortcuts

### DIFF
--- a/frontend/src/components/ChatView/ChatInputBar.jsx
+++ b/frontend/src/components/ChatView/ChatInputBar.jsx
@@ -58,16 +58,20 @@
  * ║      on iOS Safari without waiting for the 300ms click           ║
  * ║      synthesis. Don't remove either handler.                     ║
  * ║                                                                  ║
- * ║   7. `_isTouchPrimary` is detected once via                      ║
+ * ║   7. ENTER / SHORTCUT SEND                                       ║
+ * ║      `_isTouchPrimary` is detected once via                      ║
  * ║      `matchMedia('(hover: none) and (pointer: coarse)')` and     ║
- * ║      gates Enter-to-send. Touch devices: Enter inserts a         ║
- * ║      newline. Desktop: Enter sends.                              ║
+ * ║      gates plain Enter. Touch devices: Enter inserts a           ║
+ * ║      newline. Desktop: Enter sends or steers. Cmd/Ctrl+Enter     ║
+ * ║      is an explicit hardware-keyboard shortcut for the same      ║
+ * ║      send/steer action. Shift+Enter always inserts a newline.    ║
  * ║                                                                  ║
  * ╚══════════════════════════════════════════════════════════════════╝
  */
 
 import { useRef, useLayoutEffect } from 'react'
 import { ArrowUp, Mic, DoubleChevronRight } from '@openai/apps-sdk-ui/components/Icon'
+import { resolveComposerEnterAction } from './composerShortcuts.js'
 
 
 // Detect touch-primary once (same heuristic ChatView uses).
@@ -261,6 +265,10 @@ function FileChips({ files, onRemove }) {
  *   canSteer           — true when there are queued messages that can be
  *                        steered right now (all server-confirmed). Drives
  *                        the FastForward-vs-Stop choice in PrimaryAction.
+ *   canRequestSteer    — true when the keyboard shortcut may ask the
+ *                        existing steer handler to reconcile/steer queued
+ *                        messages, even before the visual fast-forward gate
+ *                        is ready.
  *   pendingFiles       — file upload chips state
  *   onAddFiles         — receives FileList from file picker
  *   onRemoveFile       — receives chip id
@@ -292,6 +300,7 @@ export default function ChatInputBar({
   onStop,
   onSteer,
   canSteer,
+  canRequestSteer = canSteer,
   offline,
   pendingFiles,
   onAddFiles,
@@ -367,8 +376,19 @@ export default function ChatInputBar({
   }
 
   function handleKeyDown(e) {
-    if (e.key === 'Enter' && !e.shiftKey && !_isTouchPrimary) {
-      e.preventDefault()
+    const action = resolveComposerEnterAction(e, {
+      hasInput,
+      canSteer,
+      canRequestSteer,
+      isTouchPrimary: _isTouchPrimary,
+    })
+    if (!action) return
+    e.preventDefault()
+    if (action === 'steer') {
+      onSteer()
+      return
+    }
+    if (action === 'submit') {
       onSubmit(e)
     }
   }

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -2126,6 +2126,7 @@ export default function ChatView({ chatId, onStreamEnd, onFirstMessage, onSystem
   // visible in the tray but do not expose an inert fast-forward button.
   const composerBusy = turnActive || pendingQueue.pendingMessages.length > 0
   const canSteer = canFastForwardQueue(pendingQueue.pendingMessages, turnActive)
+  const canRequestSteer = turnActive && pendingQueue.pendingMessages.length > 0
 
   useEffect(() => {
     try {
@@ -2592,6 +2593,7 @@ export default function ChatView({ chatId, onStreamEnd, onFirstMessage, onSystem
           onStop={handleStop}
           onSteer={handleSteer}
           canSteer={canSteer}
+          canRequestSteer={canRequestSteer}
           offline={!online}
           pendingFiles={pendingFiles}
           onAddFiles={addFiles}

--- a/frontend/src/components/ChatView/__tests__/composerShortcuts.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerShortcuts.test.js
@@ -1,0 +1,124 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { resolveComposerEnterAction } from '../composerShortcuts.js'
+
+const enter = (overrides = {}) => ({ key: 'Enter', ...overrides })
+
+test('Cmd+Enter submits composer text', () => {
+  assert.equal(
+    resolveComposerEnterAction(enter({ metaKey: true }), {
+      hasInput: true,
+      canSteer: true,
+      isTouchPrimary: false,
+    }),
+    'submit',
+  )
+})
+
+test('Ctrl+Enter submits composer text', () => {
+  assert.equal(
+    resolveComposerEnterAction(enter({ ctrlKey: true }), {
+      hasInput: true,
+      canSteer: false,
+      isTouchPrimary: false,
+    }),
+    'submit',
+  )
+})
+
+test('Cmd/Ctrl+Enter steers when the composer is empty and steering is available', () => {
+  assert.equal(
+    resolveComposerEnterAction(enter({ metaKey: true }), {
+      hasInput: false,
+      canSteer: true,
+      isTouchPrimary: false,
+    }),
+    'steer',
+  )
+  assert.equal(
+    resolveComposerEnterAction(enter({ ctrlKey: true }), {
+      hasInput: false,
+      canSteer: true,
+      isTouchPrimary: true,
+    }),
+    'steer',
+  )
+})
+
+test('Cmd/Ctrl+Enter can request steer before the visible fast-forward gate is ready', () => {
+  assert.equal(
+    resolveComposerEnterAction(enter({ metaKey: true }), {
+      hasInput: false,
+      canSteer: false,
+      canRequestSteer: true,
+      isTouchPrimary: false,
+    }),
+    'steer',
+  )
+})
+
+test('Cmd/Ctrl+Enter with no text and no steer affordance consumes the shortcut without acting', () => {
+  assert.equal(
+    resolveComposerEnterAction(enter({ metaKey: true }), {
+      hasInput: false,
+      canSteer: false,
+      isTouchPrimary: false,
+    }),
+    'noop',
+  )
+})
+
+test('plain Enter submits composer text on desktop', () => {
+  assert.equal(
+    resolveComposerEnterAction(enter(), {
+      hasInput: true,
+      isTouchPrimary: false,
+    }),
+    'submit',
+  )
+})
+
+test('plain Enter steers queued text on desktop when the composer is empty', () => {
+  assert.equal(
+    resolveComposerEnterAction(enter(), {
+      hasInput: false,
+      canRequestSteer: true,
+      isTouchPrimary: false,
+    }),
+    'steer',
+  )
+})
+
+test('plain Enter remains a newline on touch-primary devices', () => {
+  assert.equal(
+    resolveComposerEnterAction(enter(), {
+      hasInput: true,
+      canRequestSteer: true,
+      isTouchPrimary: true,
+    }),
+    null,
+  )
+})
+
+test('Shift+Enter always stays a newline chord', () => {
+  assert.equal(
+    resolveComposerEnterAction(enter({ shiftKey: true, metaKey: true }), {
+      hasInput: true,
+      canSteer: true,
+      isTouchPrimary: false,
+    }),
+    null,
+  )
+})
+
+test('non-Enter keys do not trigger composer shortcuts', () => {
+  assert.equal(
+    resolveComposerEnterAction({ key: 'a', metaKey: true }, {
+      hasInput: true,
+      canSteer: true,
+      isTouchPrimary: false,
+    }),
+    null,
+  )
+})

--- a/frontend/src/components/ChatView/composerShortcuts.js
+++ b/frontend/src/components/ChatView/composerShortcuts.js
@@ -1,0 +1,15 @@
+export function resolveComposerEnterAction(event, {
+  hasInput = false,
+  canSteer = false,
+  canRequestSteer = canSteer,
+  isTouchPrimary = false,
+} = {}) {
+  if (!event || event.key !== 'Enter' || event.shiftKey) return null
+
+  const modifiedEnter = !!(event.metaKey || event.ctrlKey)
+  if (!modifiedEnter && isTouchPrimary) return null
+
+  if (hasInput) return 'submit'
+  if (canRequestSteer) return 'steer'
+  return 'noop'
+}


### PR DESCRIPTION
## Summary
- Add a shared chat composer shortcut resolver for Enter/Cmd/Ctrl+Enter behavior.
- Keep the common desktop chat behavior: Enter sends, Shift+Enter inserts a newline, and touch keyboards keep Enter as newline.
- Let Enter or Cmd/Ctrl+Enter steer queued messages into an active turn when the composer is empty.

## Testing
- `node --loader=./src/lib/__tests__/vite-env-loader.mjs --test src/components/ChatView/__tests__/composerShortcuts.test.js`
- `npm test`
- `npm run build`

Prepared by a Möbius agent with owner review.