### PR TITLE
Stabilize shell theme switching

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -197,11 +197,27 @@
         // reload when the page was ALREADY controlled and a NEW worker takes over
         // (a genuine deploy/update).
         const hadControllerAtLoad = !!navigator.serviceWorker.controller
+        const rememberShellStateForAutoReload = () => {
+          try {
+            const activeView = localStorage.getItem('moebius_active_view') || 'chat'
+            const rawAppId = localStorage.getItem('moebius_active_app')
+            const activeAppId = rawAppId ? Number(rawAppId) : null
+            sessionStorage.setItem('shell-reload', JSON.stringify({
+              activeView,
+              activeAppId: Number.isFinite(activeAppId) ? activeAppId : null,
+              drawerOpen: false,
+              activeChatId: localStorage.getItem('moebius_active_chat') || null,
+            }))
+          } catch (_) {
+            // Best-effort: a failed storage read should not block an update.
+          }
+        }
         const reloadAfterControllerChange = () => {
           if (hadControllerAtLoad
               && navigator.serviceWorker.controller
               && !sessionStorage.getItem('sw-auto-reloaded')) {
             sessionStorage.setItem('sw-auto-reloaded', '1')
+            rememberShellStateForAutoReload()
             window.location.reload()
           }
         }

--- a/frontend/src/components/SettingsView/SettingsView.jsx
+++ b/frontend/src/components/SettingsView/SettingsView.jsx
@@ -790,7 +790,10 @@ export default function SettingsView({ onThemeChange, onOpenChat }) {
         </section>
 
         <section className="settings__section settings__section--compact">
-          <div className="settings__row">
+          <div
+            className="settings__row"
+            onPointerDownCapture={themeService.setThemeTransitionOriginFromEvent}
+          >
             <span className="settings__label">Dark mode</span>
             <Switch
               checked={!lightMode}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -160,9 +160,10 @@ body,
   color-scheme: light;
 }
 
-/* Theme flips should recolor the shell, not animate every descendant. A
-   document-wide transition repaints shadow/blur-heavy chat surfaces and makes
-   light/dark switching feel sticky on mobile. Keep this narrow and cheap. */
+/* Theme flips should feel like one surface changing, not every descendant
+   repainting separately. Modern Chromium/Safari get a View Transition bloom
+   from the user's tap point; older browsers fall back to this narrow color
+   transition so shadow/blur-heavy chat surfaces stay cheap on mobile. */
 :root.theme-transitioning,
 :root.theme-transitioning body,
 :root.theme-transitioning #root,
@@ -173,8 +174,48 @@ body,
 :root.theme-transitioning .chat__pill,
 :root.theme-transitioning .chat__plus {
   transition-property: background-color, border-color, color, fill, stroke;
-  transition-duration: 90ms;
-  transition-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+  transition-duration: 150ms;
+  transition-timing-function: cubic-bezier(0.2, 0, 0, 1);
+}
+
+html.theme-view-transitioning::view-transition-group(root) {
+  animation-duration: 260ms;
+  animation-timing-function: cubic-bezier(0.2, 0, 0, 1);
+}
+
+html.theme-view-transitioning::view-transition-old(root),
+html.theme-view-transitioning::view-transition-new(root) {
+  animation-duration: 260ms;
+  animation-fill-mode: both;
+  animation-timing-function: cubic-bezier(0.2, 0, 0, 1);
+  mix-blend-mode: normal;
+}
+
+html.theme-view-transitioning::view-transition-old(root) {
+  animation-name: mobius-theme-old;
+}
+
+html.theme-view-transitioning::view-transition-new(root) {
+  animation-name: mobius-theme-new;
+}
+
+@keyframes mobius-theme-old {
+  0%, 62% { opacity: 1; }
+  100% { opacity: 0; }
+}
+
+@keyframes mobius-theme-new {
+  0% {
+    opacity: 0.01;
+    clip-path: circle(0 at var(--theme-transition-x, 50%) var(--theme-transition-y, 50%));
+  }
+  18% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 1;
+    clip-path: circle(150vmax at var(--theme-transition-x, 50%) var(--theme-transition-y, 50%));
+  }
 }
 
 html, body, #root {

--- a/frontend/src/lib/__tests__/themeService.test.js
+++ b/frontend/src/lib/__tests__/themeService.test.js
@@ -27,6 +27,7 @@ function makeDomStub() {
   // (and the stub captures the assignment for the assertions below).
   const statusBar = { content: 'black', getAttribute: (k) => statusBar[k], setAttribute: (k, v) => { statusBar[k] = v } }
   const body = { style: {} }
+  const classes = new Set()
   // documentElement was added when light/dark mode support landed (set
   // data-theme attribute drives the CSS variable cascade). The stub
   // captures the assignment so tests can assert mode inference.
@@ -37,6 +38,11 @@ function makeDomStub() {
     _attrs: {},
     getAttribute: (k) => documentElement._attrs[k],
     setAttribute: (k, v) => { documentElement._attrs[k] = v },
+    classList: {
+      add: (c) => { classes.add(c) },
+      remove: (c) => { classes.delete(c) },
+      contains: (c) => classes.has(c),
+    },
     // colorScheme captured so the delegation tests can assert applyThemeToDom
     // now sets documentElement.style.colorScheme via the shared library.
     style: { _props: {}, colorScheme: '', setProperty(name, value) { this._props[name] = value }, getPropertyValue(name) { return this._props[name] } },
@@ -97,6 +103,7 @@ function makeDomStub() {
     meta,
     statusBar,
     documentElement,
+    classes,
     fontLinks,
     headChildren,
     styleNodes,
@@ -212,6 +219,49 @@ test('applyThemeToDom is idempotent — repeated calls produce identical DOM', (
   themeService.applyThemeToDom(css, '#aabbcc')
   assert.equal(dom.fontLinks.length, 1, 'no duplicate font links')
   assert.equal(dom.styleNodes.size, 1, 'one style node')
+})
+
+test('applyThemeToDom uses View Transitions for post-boot theme changes', async () => {
+  themeService.applyThemeToDom(':root { --bg: #111111; }', '#111111')
+  let callbackSawTransitionClass = false
+  dom.document.startViewTransition = (callback) => {
+    callbackSawTransitionClass = dom.documentElement.classList.contains('theme-view-transitioning')
+    callback()
+    return { finished: Promise.resolve() }
+  }
+
+  themeService.setThemeTransitionOriginFromEvent({ clientX: 23, clientY: 45 })
+  themeService.applyThemeToDom(':root { --bg: #f0eeeb; }', '#f0eeeb')
+
+  assert.equal(callbackSawTransitionClass, true,
+    'the view-transition CSS class should be present while the DOM mutates')
+  assert.equal(dom.documentElement.style.getPropertyValue('--theme-transition-x'), '23px')
+  assert.equal(dom.documentElement.style.getPropertyValue('--theme-transition-y'), '45px')
+  assert.equal(dom.document.body.style.background, '#f0eeeb')
+
+  await Promise.resolve()
+  await Promise.resolve()
+  assert.equal(dom.documentElement.classList.contains('theme-view-transitioning'), false,
+    'the view-transition class should be removed after the transition finishes')
+})
+
+test('applyThemeToDom can opt out of View Transitions for back-stack-sensitive toggles', () => {
+  themeService.applyThemeToDom(':root { --bg: #111111; }', '#111111')
+  let called = false
+  dom.document.startViewTransition = () => {
+    called = true
+    throw new Error('should not use View Transitions when opted out')
+  }
+
+  themeService.applyThemeToDom(
+    ':root { --bg: #f0eeeb; }',
+    '#f0eeeb',
+    'light',
+    { preferViewTransition: false },
+  )
+
+  assert.equal(called, false)
+  assert.equal(dom.document.body.style.background, '#f0eeeb')
 })
 
 test('persistTheme writes CSS + mode + sends notify in parallel', async () => {

--- a/frontend/src/lib/__tests__/themeService.toggleTheme.test.js
+++ b/frontend/src/lib/__tests__/themeService.toggleTheme.test.js
@@ -561,6 +561,23 @@ test('REVERT RACE — toggleTheme seeds the theme query cache with the NEW theme
     'seeded css must equal the freshly-built/applied css')
 })
 
+test('NAV REGRESSION — Settings toggleTheme avoids View Transition snapshot navigation', async () => {
+  const qc = makeQueryClient()
+  const api = makeApi(DARK_CSS)
+  let viewTransitionCalled = false
+  dom.document.startViewTransition = () => {
+    viewTransitionCalled = true
+    throw new Error('Settings theme toggle must use the CSS transition path')
+  }
+
+  const result = await themeService.toggleTheme(qc, 'dark', api)
+
+  assert.equal(viewTransitionCalled, false,
+    'theme toggles from Settings should not invoke document.startViewTransition')
+  assert.equal(result.newMode, 'light')
+  assert.equal(dom.document.body.style.background, '#f0eeeb')
+})
+
 test('REVERT RACE — query cache is seeded BEFORE stale marking', async () => {
   // setQueryData must land before invalidateQueries: invalidation marks the
   // query stale for later refresh, but the cache must already hold the new

--- a/frontend/src/lib/themeService.js
+++ b/frontend/src/lib/themeService.js
@@ -37,6 +37,9 @@ import { applyTheme, inferMode, HEX_RE } from './applyTheme.js'
 const STYLE_ID = 'mobius-theme'
 let themeAppliedOnce = false
 let themeTransitionTimer = null
+let themeViewTransitionTimer = null
+let themeTransitionToken = 0
+let nextThemeTransitionOrigin = null
 let lastThemeSignature = null
 
 function signatureForTheme(css, bg, mode) {
@@ -51,7 +54,6 @@ function signatureForTheme(css, bg, mode) {
 
 function beginThemeTransition() {
   if (typeof document === 'undefined') return
-  if (!themeAppliedOnce) return
   if (typeof window !== 'undefined'
       && window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches) {
     return
@@ -65,6 +67,120 @@ function beginThemeTransition() {
     root.classList.remove('theme-transitioning')
     themeTransitionTimer = null
   }, 180)
+}
+
+function shouldAnimateThemeChange() {
+  if (typeof document === 'undefined') return false
+  if (!themeAppliedOnce) return false
+  if (typeof window !== 'undefined'
+      && window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches) {
+    return false
+  }
+  if (document.visibilityState === 'hidden') return false
+  return true
+}
+
+function defaultThemeTransitionOrigin() {
+  if (typeof window === 'undefined') return null
+  const width = window.innerWidth || document.documentElement?.clientWidth || 0
+  const height = window.innerHeight || document.documentElement?.clientHeight || 0
+  if (!width || !height) return null
+  return { x: width / 2, y: height / 2 }
+}
+
+function applyThemeTransitionOrigin(root, origin) {
+  const next = origin || defaultThemeTransitionOrigin()
+  root.style.setProperty('--theme-transition-x', next ? `${Math.round(next.x)}px` : '50%')
+  root.style.setProperty('--theme-transition-y', next ? `${Math.round(next.y)}px` : '50%')
+}
+
+function consumeThemeTransitionOrigin() {
+  const origin = nextThemeTransitionOrigin
+  nextThemeTransitionOrigin = null
+  return origin
+}
+
+/**
+ * Remember where the user started the theme toggle so the view-transition
+ * reveal can bloom from the tap/click instead of cross-fading from nowhere.
+ * Keyboard/programmatic toggles fall back to the viewport center.
+ */
+export function setThemeTransitionOriginFromEvent(event) {
+  const native = event?.nativeEvent || event
+  const point = native?.touches?.[0]
+    || native?.changedTouches?.[0]
+    || native
+  const x = Number(point?.clientX)
+  const y = Number(point?.clientY)
+  if (Number.isFinite(x) && Number.isFinite(y)) {
+    nextThemeTransitionOrigin = { x, y }
+    return
+  }
+
+  const target = event?.currentTarget || event?.target
+  const rect = target?.getBoundingClientRect?.()
+  if (rect) {
+    nextThemeTransitionOrigin = {
+      x: rect.left + rect.width / 2,
+      y: rect.top + rect.height / 2,
+    }
+  }
+}
+
+function runThemeTransition(mutateDom, options = {}) {
+  const preferViewTransition = options.preferViewTransition !== false
+  if (!shouldAnimateThemeChange()) {
+    nextThemeTransitionOrigin = null
+    mutateDom()
+    return
+  }
+
+  const root = document.documentElement
+  const timerHost = typeof window !== 'undefined' ? window : globalThis
+
+  if (preferViewTransition
+      && typeof document.startViewTransition === 'function'
+      && root?.classList?.add
+      && root.classList.remove
+      && root.style?.setProperty) {
+    const token = ++themeTransitionToken
+    let didMutate = false
+    const cleanup = () => {
+      if (token !== themeTransitionToken) return
+      root.classList.remove('theme-view-transitioning')
+      if (themeViewTransitionTimer) timerHost.clearTimeout(themeViewTransitionTimer)
+      themeViewTransitionTimer = null
+    }
+    applyThemeTransitionOrigin(root, consumeThemeTransitionOrigin())
+    root.classList.add('theme-view-transitioning')
+    if (themeViewTransitionTimer) timerHost.clearTimeout(themeViewTransitionTimer)
+    themeViewTransitionTimer = timerHost.setTimeout(cleanup, 520)
+    try {
+      const transition = document.startViewTransition(() => {
+        didMutate = true
+        mutateDom()
+      })
+      const finished = transition?.finished || transition?.ready
+      if (finished?.then) {
+        finished.catch(() => {}).then(cleanup)
+      }
+      return
+    } catch (err) {
+      root.classList.remove('theme-view-transitioning')
+      if (themeViewTransitionTimer) {
+        timerHost.clearTimeout(themeViewTransitionTimer)
+        themeViewTransitionTimer = null
+      }
+      if (didMutate) throw err
+      beginThemeTransition()
+      mutateDom()
+      return
+    }
+  }
+
+  nextThemeTransitionOrigin = null
+  beginThemeTransition()
+  mutateDom()
 }
 
 /**
@@ -81,12 +197,15 @@ function beginThemeTransition() {
  * Kept as a named export so existing callers (useTheme's apply effect,
  * toggleTheme below, tests) don't have to change their call shape.
  */
-export function applyThemeToDom(css, bg, mode) {
+export function applyThemeToDom(css, bg, mode, options = {}) {
   const signature = signatureForTheme(css, bg, mode)
-  if (signature !== lastThemeSignature) beginThemeTransition()
-  applyTheme({ css, bg, mode })
-  lastThemeSignature = signature
-  themeAppliedOnce = true
+  const mutateDom = () => {
+    applyTheme({ css, bg, mode })
+    lastThemeSignature = signature
+    themeAppliedOnce = true
+  }
+  if (signature !== lastThemeSignature) runThemeTransition(mutateDom, options)
+  else mutateDom()
 }
 
 /**
@@ -293,7 +412,12 @@ export async function toggleTheme(queryClient, currentMode, api) {
   // the same tick as the visual change.
   await _cancelThemeQueries(queryClient)
   _seedThemeQueries(queryClient, newCss, newBg, newMode)
-  applyThemeToDom(newCss, newBg, newMode)
+  // The Settings toggle sits on the shell's back-stack sentinel. On mobile
+  // Chromium/PWA builds, combining a user tap, the View Transitions snapshot
+  // layer, and the Navigation API can occasionally consume that sentinel and
+  // restore the previous chat. Use the explicit CSS color transition for this
+  // user-tap path; it is still smooth, but avoids browser navigation machinery.
+  applyThemeToDom(newCss, newBg, newMode, { preferViewTransition: false })
 
   try {
     // Refresh SWR's local /api/theme body before notify.send can provoke a
@@ -311,7 +435,7 @@ export async function toggleTheme(queryClient, currentMode, api) {
   } catch (err) {
     _seedThemeQueries(queryClient, currentCss, oldBg, currentMode)
     await _refreshThemeSwCache(currentCss, oldBg, currentMode)
-    applyThemeToDom(currentCss, oldBg, currentMode)
+    applyThemeToDom(currentCss, oldBg, currentMode, { preferViewTransition: false })
     throw err
   }
 


### PR DESCRIPTION
## Summary
- make shell theme changes feel smoother with a tap-origin transition when safe
- keep the Settings dark-mode switch on the simpler color-transition path so it cannot consume shell navigation/back-stack state
- preserve the active shell view/chat before service-worker auto-reloads so updates do not bounce users to a different chat

## Testing
- `node --loader=./src/lib/__tests__/vite-env-loader.mjs --test src/lib/__tests__/themeService.test.js src/lib/__tests__/themeService.toggleTheme.test.js`
- `npm run build`

Prepared by a Möbius agent with owner review.