### PR TITLE
Improve shell update status and chat steering

### DIFF
--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -2244,6 +2244,16 @@ export default function ChatView({ chatId, onStreamEnd, onFirstMessage, onSystem
         // rows this request is steering; restore the snapshot below if the
         // backend says the turn was not steered.
         pendingQueue.promoteManyByTs(consumePendingTs)
+        const queueAfterOptimisticPromote = pendingQueue.pendingMessagesRef.current
+        const restoreOptimisticSteerQueue = () => {
+          // If another path touched the queue while the POST was in flight
+          // (notably the natural turn-end drain), every pendingQueue mutation
+          // assigns a fresh array. In that case the other path won the race,
+          // so restoring our stale snapshot would resurrect duplicate chips.
+          if (pendingQueue.pendingMessagesRef.current === queueAfterOptimisticPromote) {
+            pendingQueue.hydrate(confirmedSnapshot, { preserveMissing: true })
+          }
+        }
         const result = await streamSend(content, attachments, {
           forceSteer: true,
           consumePendingTs,
@@ -2267,7 +2277,7 @@ export default function ChatView({ chatId, onStreamEnd, onFirstMessage, onSystem
         }
         if (result?.status !== 'steered') {
           steerPinIntentRef.current = null
-          pendingQueue.hydrate(confirmedSnapshot, { preserveMissing: true })
+          restoreOptimisticSteerQueue()
         }
         // not_steered (the turn closed between the gate and the POST) or any
         // other status: restore the queue and let it drain at turn-end. The
@@ -2275,7 +2285,7 @@ export default function ChatView({ chatId, onStreamEnd, onFirstMessage, onSystem
         // it never gets lost.
       } catch {
         steerPinIntentRef.current = null
-        pendingQueue.hydrate(confirmedSnapshot, { preserveMissing: true })
+        restoreOptimisticSteerQueue()
         // Network/POST error — restore the queue for the turn-end drain.
       }
     } finally {

--- a/frontend/src/components/ChatView/__tests__/optimisticSteerQueue.test.js
+++ b/frontend/src/components/ChatView/__tests__/optimisticSteerQueue.test.js
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+const source = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8')
+
+test('optimistic steer restore only hydrates when no queue mutation won the race', () => {
+  assert.match(
+    source,
+    /const queueAfterOptimisticPromote = pendingQueue\.pendingMessagesRef\.current/,
+    'handleSteer should snapshot the queue array immediately after optimistic promote',
+  )
+  assert.match(
+    source,
+    /function restoreOptimisticSteerQueue|const restoreOptimisticSteerQueue = \(\) =>/,
+    'handleSteer should route failed optimistic restores through a helper',
+  )
+  assert.match(
+    source,
+    /pendingQueue\.pendingMessagesRef\.current === queueAfterOptimisticPromote[\s\S]*?pendingQueue\.hydrate\(confirmedSnapshot, \{ preserveMissing: true \}\)/,
+    'the restore helper must hydrate the stale snapshot only if the queue array identity is unchanged',
+  )
+})

--- a/frontend/src/components/Shell/Shell.css
+++ b/frontend/src/components/Shell/Shell.css
@@ -88,6 +88,114 @@
 }
 
 
+/* Shell update lifecycle. This is intentionally top-bar chrome, not a toast:
+   it shows owner-requested shell work while it is building, keeps "ready"
+   visible without stealing focus, and still offers an explicit refresh. */
+.shell__update {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  flex-shrink: 0;
+  max-width: min(42vw, 320px);
+  margin-left: 8px;
+  padding: 4px 7px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+  color: var(--text);
+  background: color-mix(in srgb, var(--surface2, #212121) 78%, transparent);
+  border: 1px solid var(--border-light);
+  box-shadow: 0 6px 18px color-mix(in srgb, #000 14%, transparent);
+  -webkit-backdrop-filter: blur(10px);
+  backdrop-filter: blur(10px);
+}
+
+.shell__update-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 16%, transparent);
+  flex-shrink: 0;
+}
+
+.shell__update--building .shell__update-dot,
+.shell__update--refreshing .shell__update-dot {
+  animation: shell-update-pulse 1.2s ease-in-out infinite;
+}
+
+.shell__update--ready {
+  color: var(--text);
+  border-color: color-mix(in srgb, var(--accent) 38%, var(--border-light));
+  background: color-mix(in srgb, var(--accent) 13%, var(--surface2, #212121));
+}
+
+.shell__update--failed {
+  color: var(--danger, #f87171);
+  border-color: color-mix(in srgb, var(--danger, #f87171) 38%, transparent);
+  background: color-mix(in srgb, var(--danger, #f87171) 12%, var(--surface2, #212121));
+}
+
+.shell__update--failed .shell__update-dot {
+  background: var(--danger, #f87171);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--danger, #f87171) 16%, transparent);
+}
+
+.shell__update-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.shell__update-action {
+  margin: -3px -4px -3px 2px;
+  padding: 4px 8px;
+  border: 0;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 20%, transparent);
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.shell__update-action:focus { outline: none; }
+.shell__update-action:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+
+@media (hover: hover) {
+  .shell__update-action:hover {
+    background: color-mix(in srgb, var(--accent) 30%, transparent);
+  }
+}
+
+@keyframes shell-update-pulse {
+  0%, 100% { opacity: 0.55; transform: scale(0.86); }
+  50% { opacity: 1; transform: scale(1); }
+}
+
+@media (max-width: 560px) {
+  .shell__update {
+    max-width: 42vw;
+    gap: 6px;
+    padding-inline: 7px;
+  }
+
+  .shell__update-label {
+    max-width: 18ch;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .shell__update--building .shell__update-dot,
+  .shell__update--refreshing .shell__update-dot {
+    animation: none;
+  }
+}
+
 /* ── Immersive mode (moebius:immersive, .pm/128) ───── */
 
 /* The active app asked for the full viewport (games). The bar leaves

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -45,6 +45,9 @@ function _warmTargetSw() {
     .catch(() => null)
 }
 
+const SHELL_BUILDING_NOTICE_DELAY_MS = 1200
+const SHELL_FAILURE_NOTICE_DELAY_MS = 1200
+const SHELL_FAILURE_AUTO_DISMISS_MS = 6000
 const SHELL_RELOAD_RECHECK_MS = 6000
 
 export default function Shell() {
@@ -119,9 +122,19 @@ export default function Shell() {
       return next
     })
   }, [])
+  // Shell update lifecycle shown in the top bar. This is deliberately separate
+  // from transient toasts: owner-initiated shell work should be visible while it
+  // is happening, and a ready update should not steal focus just to prove it
+  // landed.
+  const [shellUpdate, setShellUpdate] = useState({ state: 'idle' })
+  const shellUpdateRef = useRef(shellUpdate)
+  useEffect(() => { shellUpdateRef.current = shellUpdate }, [shellUpdate])
 
   const pendingShellReloadRef = useRef(false)
   const shellReloadTimerRef = useRef(null)
+  const shellBuildingNoticeTimerRef = useRef(null)
+  const shellFailureNoticeTimerRef = useRef(null)
+  const shellFailureDismissTimerRef = useRef(null)
   const lastShellInteractionAtRef = useRef(0)
   const [composerFocusRequest, setComposerFocusRequest] = useState(null)
   const composerFocusTokenRef = useRef(0)
@@ -150,12 +163,33 @@ export default function Shell() {
     }
   }
 
+  function setShellUpdateState(next) {
+    setShellUpdate(prev => (prev.state === next.state ? prev : next))
+  }
+
+  function clearShellUpdateTimers() {
+    if (shellBuildingNoticeTimerRef.current) {
+      clearTimeout(shellBuildingNoticeTimerRef.current)
+      shellBuildingNoticeTimerRef.current = null
+    }
+    if (shellFailureNoticeTimerRef.current) {
+      clearTimeout(shellFailureNoticeTimerRef.current)
+      shellFailureNoticeTimerRef.current = null
+    }
+    if (shellFailureDismissTimerRef.current) {
+      clearTimeout(shellFailureDismissTimerRef.current)
+      shellFailureDismissTimerRef.current = null
+    }
+  }
+
   function performShellReload() {
     pendingShellReloadRef.current = false
     if (shellReloadTimerRef.current) {
       clearTimeout(shellReloadTimerRef.current)
       shellReloadTimerRef.current = null
     }
+    clearShellUpdateTimers()
+    setShellUpdateState({ state: 'refreshing' })
     sessionStorage.setItem('shell-reload', JSON.stringify(shellReloadState()))
     // Match the manifest scope so the post-reload page lands inside
     // the installed PWA's declared scope — writing `/` here would
@@ -191,6 +225,11 @@ export default function Shell() {
 
   function deferShellReload() {
     pendingShellReloadRef.current = true
+    clearShellUpdateTimers()
+    // Keep an existing ready badge steady instead of re-announcing every
+    // watcher rebuild. A sibling agent may save several shell files in one
+    // task; the owner only needs one persistent "refresh when ready" affordance.
+    setShellUpdateState({ state: 'ready' })
     scheduleShellReloadCheck()
   }
 
@@ -200,6 +239,39 @@ export default function Shell() {
     } else {
       performShellReload()
     }
+  }
+
+  function noteShellRebuilding() {
+    // If a refresh is already pending, do not flip the badge back to
+    // "Updating…" on every subsequent source save. The ready affordance is the
+    // useful state now: it tells the owner a refresh will pick up the latest
+    // completed build when they are ready.
+    if (pendingShellReloadRef.current || shellUpdateRef.current.state === 'ready') return
+    clearShellUpdateTimers()
+    shellBuildingNoticeTimerRef.current = setTimeout(() => {
+      shellBuildingNoticeTimerRef.current = null
+      if (pendingShellReloadRef.current || shellUpdateRef.current.state === 'ready') return
+      setShellUpdateState({ state: 'building' })
+    }, SHELL_BUILDING_NOTICE_DELAY_MS)
+  }
+
+  function noteShellRebuildFailed() {
+    if (pendingShellReloadRef.current || shellUpdateRef.current.state === 'ready') return
+    clearShellUpdateTimers()
+    // The watcher can observe an in-progress file write and publish a failure
+    // that is immediately followed by a successful rebuild. Give success a
+    // chance to arrive before showing an error, and auto-clear the error if it
+    // really does remain visible.
+    shellFailureNoticeTimerRef.current = setTimeout(() => {
+      shellFailureNoticeTimerRef.current = null
+      setShellUpdateState({ state: 'failed' })
+      shellFailureDismissTimerRef.current = setTimeout(() => {
+        shellFailureDismissTimerRef.current = null
+        if (shellUpdateRef.current.state === 'failed') {
+          setShellUpdateState({ state: 'idle' })
+        }
+      }, SHELL_FAILURE_AUTO_DISMISS_MS)
+    }, SHELL_FAILURE_NOTICE_DELAY_MS)
   }
 
   useEffect(() => {
@@ -217,9 +289,9 @@ export default function Shell() {
       window.removeEventListener('input', record, opts)
       window.removeEventListener('focusin', record, opts)
       if (shellReloadTimerRef.current) clearTimeout(shellReloadTimerRef.current)
+      clearShellUpdateTimers()
     }
   }, [])
-
   // Global connectivity indicator. The composer already disables send when
   // offline (ChatView); this surfaces the state shell-wide so the user is
   // never tapping in the dark about whether they're connected.
@@ -797,7 +869,10 @@ export default function Shell() {
         }
       }
       refreshChats()
+    } else if (ev.type === 'shell_rebuilding') {
+      noteShellRebuilding()
     } else if (ev.type === 'shell_rebuilt') {
+      clearShellUpdateTimers()
       // Deduplicate against the SSE catch-up burst to avoid reload loops.
       const now = Date.now()
       const lastRebuilt = Number(sessionStorage.getItem('shell-rebuilt-at') || 0)
@@ -810,9 +885,12 @@ export default function Shell() {
       // closure values may be one render behind concurrent state updates.
       // Sibling branches (chat_run_started, chat_run_finished) already
       // use refs for exactly this reason. If the owner is typing, steering,
-      // or reading the currently-running chat, hold the refresh quietly until
-      // the page is idle instead of stealing focus.
+      // or reading the currently-running chat, hold the refresh behind a
+      // steady top-bar badge instead of fading the whole shell black and
+      // stealing focus.
       requestShellReload()
+    } else if (ev.type === 'shell_rebuild_failed') {
+      noteShellRebuildFailed()
     }
   }, [
     // Scalar state removed: shell_rebuilt now reads from refs (activeViewRef,
@@ -1353,6 +1431,42 @@ export default function Shell() {
           <img className="shell__logo" src={`${BASE}/moebius.png`} alt="" width="30" height="30" />
           <span className="shell__wordmark">Möbius</span>
         </div>
+        {shellUpdate.state !== 'idle' && (
+          <div
+            className={`shell__update shell__update--${shellUpdate.state}`}
+            role="status"
+            aria-live="polite"
+          >
+            <span className="shell__update-dot" aria-hidden="true" />
+            <span className="shell__update-label">
+              {shellUpdate.state === 'building' && 'Updating shell…'}
+              {shellUpdate.state === 'ready' && 'Update ready'}
+              {shellUpdate.state === 'refreshing' && 'Refreshing…'}
+              {shellUpdate.state === 'failed' && 'Update failed'}
+            </span>
+            {shellUpdate.state === 'ready' && (
+              <button
+                type="button"
+                className="shell__update-action"
+                onClick={performShellReload}
+              >
+                Refresh
+              </button>
+            )}
+            {shellUpdate.state === 'failed' && (
+              <button
+                type="button"
+                className="shell__update-action"
+                onClick={() => {
+                  clearShellUpdateTimers()
+                  setShellUpdateState({ state: 'idle' })
+                }}
+              >
+                Dismiss
+              </button>
+            )}
+          </div>
+        )}
         {!online && (
           <span className="shell__offline" role="status" aria-live="polite">
             Offline


### PR DESCRIPTION
## Summary
- defer shell refreshes while the owner is actively typing, using an app iframe, or reading the currently-running chat
- replace focus-stealing rebuild reloads with a compact top-bar update lifecycle badge
- smooth fast-forward/steer layout by moving confirmed queued rows into the transcript before the steer request settles

## Testing
- `npm test`
- `npm run build`

Prepared by a Möbius agent with owner review.
