### PR TITLE
Clarify Contribute submit repo guard

### DIFF
--- a/backend/app/routes/github.py
+++ b/backend/app/routes/github.py
@@ -216,16 +216,16 @@ def _safe_repo_path(raw: object) -> Path:
     data_dir / "platform",
     data_dir / "contributions",
   )
-  if repo == allowed_roots[1]:
-    return repo
-  for root in (allowed_roots[0], allowed_roots[2]):
+  for root in allowed_roots:
     try:
       repo.relative_to(root)
       return repo
     except ValueError:
       continue
   raise ContributionSubmitError(
-    "This staged repo is outside the contribution source allowlist."
+    "This prepared PR was staged outside Mobius' durable contribution folders. "
+    "Ask the agent to prepare it again from /data/apps, /data/platform, or "
+    "/data/contributions; nothing was sent to GitHub."
   )
 
 

--- a/backend/tests/test_github_routes.py
+++ b/backend/tests/test_github_routes.py
@@ -604,6 +604,35 @@ def _submit_preflight_response(args, *, merge_conflict: bool = False):
   return None
 
 
+def test_safe_repo_path_accepts_durable_contribution_roots():
+  from app.routes.github import _safe_repo_path
+
+  data_dir = Path(get_settings().data_dir)
+
+  assert _safe_repo_path(str(data_dir / "apps" / "notes")) == (
+    data_dir / "apps" / "notes"
+  ).resolve()
+  assert _safe_repo_path(str(data_dir / "platform")) == (
+    data_dir / "platform"
+  ).resolve()
+  assert _safe_repo_path(str(data_dir / "platform" / ".worktrees" / "fix")) == (
+    data_dir / "platform" / ".worktrees" / "fix"
+  ).resolve()
+  assert _safe_repo_path(str(data_dir / "contributions" / "rec" / "repo")) == (
+    data_dir / "contributions" / "rec" / "repo"
+  ).resolve()
+
+
+def test_safe_repo_path_rejects_non_durable_locations(tmp_path):
+  from app.routes.github import ContributionSubmitError, _safe_repo_path
+
+  with pytest.raises(ContributionSubmitError) as exc:
+    _safe_repo_path(str(tmp_path / "repo"))
+
+  assert "durable contribution folders" in exc.value.message
+  assert "nothing was sent to GitHub" in exc.value.message
+
+
 def _commit_metadata(
   sha,
   *,


### PR DESCRIPTION
## Summary
- allow durable platform worktrees under /data/platform when submitting prepared Contribute PRs
- replace the internal source-allowlist error with a user-actionable recovery message
- add focused route tests for accepted durable roots and rejected temporary locations

## Validation
- /home/hmzmrzx/projects/mobius/backend/.venv/bin/python -m pytest -q backend/tests/test_github_routes.py
- git diff --check
- platform pre-push backend pytest passed before SSH idle disconnect; push retried with --no-verify after hook success