### PR TITLE
Make legacy platform-app migration one-shot and wipe-safe

### DIFF
--- a/backend/app/bootstrap.py
+++ b/backend/app/bootstrap.py
@@ -42,11 +42,22 @@ _SKIP_ENV = "MOEBIUS_SKIP_BOOTSTRAP"
 
 
 def _is_legacy_platform_row(app: models.App) -> bool:
-  """True for active old rows whose source matches retired baked-app shapes."""
+  """True for active old rows whose source matches retired baked-app shapes.
+
+  The historical /data/apps/<slug> shape additionally requires an empty
+  manifest_url: once a migration stamps the canonical identity the row is on the
+  catalog model and must NOT be re-migrated on the next boot. Re-migrating
+  re-fetched the catalog from GitHub every restart and, when upstream had
+  advanced with no local edits, silently fast-forwarded the app past owner
+  review. The platform-core shape (`is_legacy_source_dir`) needs no such gate —
+  a migrated row moves out of /data/platform/core-apps, so it stops matching on
+  the source path alone.
+  """
+  data_dir = get_settings().data_dir
   return legacy_platform_apps.is_legacy_source_dir(
-    app.source_dir, get_settings().data_dir, app.slug,
+    app.source_dir, data_dir, app.slug,
   ) or _is_historical_platform_app_source_dir(
-    app.source_dir, get_settings().data_dir, app.slug,
+    app.source_dir, app.manifest_url, data_dir, app.slug,
   )
 
 

--- a/backend/app/install.py
+++ b/backend/app/install.py
@@ -688,17 +688,26 @@ def _is_legacy_platform_source_dir(
 
 def _is_historical_platform_app_source_dir(
   source_dir: str | None,
+  manifest_url: str | None,
   data_dir: str | Path,
   slug: str | None,
 ) -> bool:
-  """True for retired core-app rows sourced directly from /data/apps/<slug>.
+  """True for a retired core-app row at /data/apps/<slug> not yet migrated.
 
   One prod-era installer shape registered Memory/Reflection/Beat Machine as
   editable app rows under /data/apps/<slug> with no manifest_url. They are not
   platform-owned source dirs, but they are still the predecessor rows the
-  trusted mobius-os catalog entry must update in place. Keep this narrow:
-  only historical platform slugs from legacy_platform_apps may match.
+  trusted mobius-os catalog entry must update in place. A catalog install lands
+  at exactly that same /data/apps/<slug> path but stamps a canonical
+  manifest_url, so path + slug alone cannot tell the un-migrated row from the
+  migrated steady state — matching on those alone re-fired the migration (an
+  extra GitHub fetch, and a no-owner-review fast-forward) on every boot. Gate on
+  the empty manifest_url the migration fills in, so this stays a ONE-SHOT
+  predicate that mirrors the install-side platform_row query's NULL/'' filter.
+  Keep it narrow: only historical platform slugs from legacy_platform_apps match.
   """
+  if manifest_url:
+    return False
   if not source_dir or not slug or slug not in HISTORICAL_PLATFORM_APP_SLUGS:
     return False
   try:
@@ -1835,7 +1844,8 @@ async def install_from_manifest(
         existing = platform_row
         adopt_kind = "legacy-platform"
       elif _is_historical_platform_app_source_dir(
-        platform_row.source_dir, settings_data_dir, manifest_id,
+        platform_row.source_dir, platform_row.manifest_url,
+        settings_data_dir, manifest_id,
       ):
         existing = platform_row
         adopt_kind = "legacy-catalog"
@@ -1972,6 +1982,19 @@ async def install_from_manifest(
             await asyncio.to_thread(_unregister_cron, Path(old_source_dir))
         app.slug = target_slug
         app.source_dir = target_source_dir
+        app.manifest_url = canonical_manifest_url
+        db.flush()
+      elif adopt_kind == "legacy-catalog":
+        # A pre-git-model catalog app: editable source already sits at
+        # /data/apps/<slug> (manifest_id == app.slug on this path, so no
+        # slug/source_dir move), only the canonical identity is missing. Stamp it
+        # NOW, before the git merge below can short-circuit on a conflict. The
+        # post-merge re-stamp is skipped on conflict, so deferring to it would
+        # leave a conflicting migration with a NULL manifest_url — the boot
+        # migration would then keep re-firing (and re-fetching) every restart
+        # instead of running once. The identity move is orthogonal to the source:
+        # the owner still resolves the surfaced conflict through the click-gated
+        # resolver, and the served source/bundle stay theirs until they do.
         app.manifest_url = canonical_manifest_url
         db.flush()
 
@@ -2131,8 +2154,23 @@ async def install_from_manifest(
       if git_source_dir:
         version = str(manifest.get("version", "unknown"))
         had_repo = app_git.is_repo(git_source_dir)
-        merge_existing_source = (
-          existing and had_repo and not legacy_platform_migration
+        # A pre-git-model app being adopted from the catalog — or any existing app
+        # that somehow lost its repo — has editable owner source on disk and in DB
+        # jsx_source but no per-app git history and no recorded upstream. Init the
+        # repo now so the merge path below captures those on-disk edits onto `main`
+        # BEFORE the catalog upstream is recorded. Without this the fresh-install
+        # branch's align_local_to_upstream would reset --hard the tree to catalog
+        # bytes and the owner's edits would land in ZERO git blobs — unrecoverable.
+        # Excludes legacy-platform rows: their real source lived under
+        # /data/platform/core-apps and the /data/apps/<slug> dir is only the
+        # retired cron sidecar, not owner source to preserve.
+        adopt_repoless_source = bool(
+          existing and not had_repo and not legacy_platform_migration
+        )
+        if adopt_repoless_source:
+          await asyncio.to_thread(app_git.ensure_repo, git_source_dir)
+        merge_existing_source = existing and not legacy_platform_migration and (
+          had_repo or adopt_repoless_source
         )
         if merge_existing_source:
           prev_upstream_commit = app.upstream_commit
@@ -2167,9 +2205,17 @@ async def install_from_manifest(
           # stranding the merge base at the install point and resolving the
           # NEXT update to stale local content. commit_replay still runs
           # (merge_applied gate) so the single-parent replay advances the base.
-          diverged = bool(prev_upstream_commit) and await asyncio.to_thread(
-            app_git.local_diverged_from,
-            git_source_dir, prev_upstream_commit,
+          # An adopted repo-less row has no recorded upstream to diverge from, so
+          # `prev_upstream_commit` is empty and the check below would read "no
+          # divergence" and take the catalog bytes verbatim — silently replacing
+          # the owner source we just committed to `main`. Force the three-way
+          # merge instead, so those edits are folded in cleanly or surfaced as an
+          # owner-gated conflict (identical on-disk == catalog resolves clean).
+          diverged = adopt_repoless_source or (
+            bool(prev_upstream_commit) and await asyncio.to_thread(
+              app_git.local_diverged_from,
+              git_source_dir, prev_upstream_commit,
+            )
           )
           if repo_ref is not None and await asyncio.to_thread(
             app_git.has_origin, git_source_dir,

--- a/backend/tests/test_apps_install.py
+++ b/backend/tests/test_apps_install.py
@@ -3274,6 +3274,90 @@ def test_trusted_catalog_install_adopts_historical_data_apps_row(
   assert (data_dir / "apps" / "beat-machine" / "index.jsx").read_text() == JSX
 
 
+def test_historical_data_apps_adoption_preserves_owner_edits(
+  client, auth, db, bypass_url_validation,
+):
+  """Adopting a pre-git-model app must NOT silently reset the owner's edits.
+
+  The historical shape is editable source on disk + a DB jsx_source with NO
+  per-app git repo and NO recorded upstream. Before the fix, adoption reached
+  align_local_to_upstream (reset --hard) and the owner's on-disk edits ended up in
+  ZERO git blobs — unrecoverable. Now the adoption captures the on-disk tree onto
+  `main` first, then three-way merges: because the owner's index.jsx diverges from
+  the catalog entry the merge verdicts a conflict, so the served source stays
+  theirs until they resolve it AND the owner bytes live in a recoverable git blob.
+  The identity still migrates once (canonical manifest_url stamped even on
+  conflict) so the boot migration never re-fires.
+  """
+  from app import bootstrap, models
+  data_dir = Path(get_settings().data_dir)
+  slug = "beat-machine"
+  src_dir = data_dir / "apps" / slug
+  src_dir.mkdir(parents=True, exist_ok=True)
+  owner_jsx = (
+    "export default function App() { /* OWNER EDIT */ return <div>mine</div> }"
+  )
+  (src_dir / "index.jsx").write_text(owner_jsx)
+  assert not app_git.is_repo(src_dir)
+
+  app = models.App(
+    name="Beat Machine",
+    description="",
+    jsx_source=owner_jsx,
+    source_dir=str(src_dir),
+    slug=slug,
+    manifest_url=None,
+    cross_app_access="none",
+    share_with_apps="none",
+    offline_capable=False,
+  )
+  db.add(app)
+  db.commit()
+  app_id = app.id
+  canonical = "https://raw.githubusercontent.com/mobius-os/app-beat-machine/main"
+  base = canonical + "/"
+
+  # The catalog entry (JSX) differs from the owner's edit — a real divergence.
+  r = _install_simple(
+    client, auth, base, _simple_manifest("beat-machine", version="1.0.5"),
+  )
+  assert r.status_code == 201, r.text
+  payload = r.json()
+  assert payload["mode"] == "conflict", payload
+  assert "index.jsx" in payload["conflict_paths"]
+  assert payload["id"] == app_id
+
+  # The served source on disk is STILL the owner's, never the catalog bytes.
+  assert (src_dir / "index.jsx").read_text() == owner_jsx
+  assert (src_dir / "index.jsx").read_text() != JSX
+
+  # The owner bytes survive in a git blob (recoverable): captured on `main`
+  # before the catalog upstream was recorded.
+  assert app_git.is_repo(src_dir)
+  main_tree = app_git.read_ref_tree(src_dir, app_git.LOCAL_BRANCH)
+  assert main_tree.get("index.jsx") == owner_jsx.encode()
+
+  # Identity migrated (one-shot): the row now carries the canonical manifest_url,
+  # so the boot predicate no longer treats it as an un-migrated historical row.
+  db.refresh(app)
+  assert app.manifest_url == canonical + "#manifest-id=beat-machine"
+  assert bootstrap._is_legacy_platform_row(app) is False
+
+  # A second catalog install (the next boot's Store update) resolves the row by
+  # its now-canonical manifest_url — a normal update, NOT a re-triggered
+  # migration — and still guards the unresolved owner edits behind a conflict,
+  # forking no duplicate.
+  r2 = _install_simple(
+    client, auth, base, _simple_manifest("beat-machine", version="1.0.6"),
+  )
+  assert r2.status_code == 201, r2.text
+  assert r2.json()["mode"] == "conflict"
+  assert r2.json()["id"] == app_id
+  assert (src_dir / "index.jsx").read_text() == owner_jsx
+  rows = db.query(models.App).filter(models.App.slug.like("beat-machine%")).all()
+  assert len(rows) == 1, [row.slug for row in rows]
+
+
 @pytest.mark.parametrize("stored_manifest_url_shape", ["raw_mobius_json", "canonical"])
 def test_trusted_catalog_update_migrates_legacy_platform_row_found_by_url(
   stored_manifest_url_shape, client, auth, db, bypass_url_validation,

--- a/backend/tests/test_bootstrap.py
+++ b/backend/tests/test_bootstrap.py
@@ -90,7 +90,19 @@ async def test_bootstrap_skips_when_store_already_installed(db, monkeypatch):
 async def test_bootstrap_migrates_active_legacy_platform_rows(
   source_shape, manifest_url_shape, db, monkeypatch,
 ):
-  """Old baked app rows are moved forward through the trusted catalog entry."""
+  """The migration is ONE-SHOT: it moves un-migrated baked rows forward through
+  the trusted catalog entry, but never re-fires on a row that already carries a
+  manifest_url.
+
+  Two un-migrated shapes exist. A `platform_core` row still points at
+  /data/platform/core-apps and is migrated regardless of its manifest_url (the
+  catalog install moves it out of that tree, so it stops matching next boot). A
+  `data_apps` row already sits at the steady-state /data/apps/<slug> path, so it
+  only counts as un-migrated while its manifest_url is empty — once the identity
+  is stamped (raw or canonical), re-migrating would re-fetch GitHub every restart
+  and could fast-forward the app past owner review. Matching data_apps + a set
+  manifest_url as legacy was the bug this pins closed.
+  """
   monkeypatch.delenv("MOEBIUS_SKIP_BOOTSTRAP", raising=False)
   from app.config import get_settings
   from app.install import _canonical_identity_key
@@ -125,17 +137,24 @@ async def test_bootstrap_migrates_active_legacy_platform_rows(
   ])
   db.commit()
 
+  # A platform-core row is always un-migrated (source still in that tree); a
+  # data_apps row is un-migrated only while its manifest_url is empty.
+  should_migrate = source_shape == "platform_core" or manifest_url_shape == "empty"
+
   mock_app = models.App(id=3, name="Memory", slug="memory")
   install_mock = AsyncMock(return_value=(mock_app, "update", [], {}, [], "none"))
   with patch("app.bootstrap.install_from_manifest", install_mock):
     await ensure_store_installed(db)
 
-  assert install_mock.await_count == 1
-  assert (
-    install_mock.await_args.kwargs["manifest_url"]
-    == LEGACY_PLATFORM_APP_MANIFEST_URLS["memory"]
-  )
-  assert install_mock.await_args.kwargs["source"] == "bootstrap"
+  if should_migrate:
+    assert install_mock.await_count == 1
+    assert (
+      install_mock.await_args.kwargs["manifest_url"]
+      == LEGACY_PLATFORM_APP_MANIFEST_URLS["memory"]
+    )
+    assert install_mock.await_args.kwargs["source"] == "bootstrap"
+  else:
+    assert install_mock.await_count == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes two HIGH findings from a multi-agent review of the prod-refresh restructuring (each confirmed 3/3 by independent adversarial verifiers; the wipe reproduced end-to-end through the real install endpoint).

## Bug 1 — legacy migration re-fired on every boot
`_is_historical_platform_app_source_dir` matched any `/data/apps/<slug>` row for memory/reflection/beat-machine on path + slug alone, so the fully-migrated steady state (canonical `manifest_url` at that same path) kept matching. `bootstrap._migrate_legacy_platform_apps` therefore re-ran `install_from_manifest` for all three apps on **every container restart** — three GitHub fetches added to each boot, and a silent fast-forward past owner review whenever upstream had advanced.

**Fix:** the predicate now requires an empty `manifest_url` (matching its own docstring and mirroring the install-side `platform_row` NULL/'' filter), threaded through both callers. The migration is one-shot. `test_bootstrap.py` previously codified the re-fire; updated to assert a canonical-manifest_url row is NOT re-installed while genuinely un-migrated shapes still are.

## Bug 2 — silent wipe of owner edits on repo-less historical rows
The pre-git-model shape (editable row at `/data/apps/<slug>`, NULL `manifest_url`, no per-app git repo — `create_app` never inits one) reached `align_local_to_upstream` on catalog adoption, which reset the tree to catalog bytes. Owner edits landed in zero git blobs — unrecoverable.

**Fix:** a repo-less existing row now gets `ensure_repo` + the merge path, committing the on-disk owner tree to `main` before the catalog upstream is recorded, with `diverged` forced so the three-way merge runs: edits fold in cleanly or surface as the standard owner-gated conflict — never silently discarded. A conflicting migration also stamps the canonical `manifest_url` early so Bug 1's one-shot property holds on the conflict path too.

## Tests
- post-rebase onto 6369a4b6: `scripts/wt-pytest.sh tests/test_bootstrap.py tests/test_apps_install.py tests/test_app_git.py -q` → **177 passed** (pre-push hook ran the full backend suite green as well)
- pre-rebase broader sweep (app_git / repair / uninstall-reversible / watcher / platform_update / migrate-rename) → 98 passed
- new combination test: no-repo historical row with owner-edited `index.jsx` → one safe migration (conflict surfaced, owner bytes on `main`, served source untouched, identity stamped), second install resolves by identity, no duplicate, no re-fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)