### PR TITLE
Ease Settings surfaces on theme toggle; drop dead setup-ready flag

### DIFF
--- a/frontend/src/components/SettingsView/SettingsView.jsx
+++ b/frontend/src/components/SettingsView/SettingsView.jsx
@@ -19,7 +19,6 @@ import './SettingsView.css'
 
 const UPDATE_CHECKED_RESET_MS = 2200
 const RETURN_VIEW_KEY = 'mobius:return-view'
-const SYSTEM_SETUP_READY_KEY = 'mobius:system-setup-ready:v1'
 const RESTART_POLL_INTERVAL_MS = 1500
 const RESTART_POLL_MAX = 40
 const RESTART_SHELL_READY_PATH = '/shell/'
@@ -30,16 +29,6 @@ const PROVIDER_CHOICES = [
 const FALLBACK_MODEL_ROWS = {
   claude: CLAUDE_MODELS.map((m) => ({ id: m.value, label: m.label, available: true })),
   codex: CODEX_MODELS.map((m) => ({ id: m.value, label: m.label, available: true })),
-}
-
-function markSystemSetupReady() {
-  if (typeof window === 'undefined' || !window.localStorage) return
-  try {
-    window.localStorage.setItem(
-      SYSTEM_SETUP_READY_KEY,
-      JSON.stringify({ completedAt: new Date().toISOString() }),
-    )
-  } catch {}
 }
 
 function defaultEffort(provider) {
@@ -474,7 +463,6 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
         try { detail = (await res.json()).detail || '' } catch {}
         throw new Error(detail || 'Could not save background agents.')
       }
-      markSystemSetupReady()
       settingsQueries.owner.invalidate(queryClient)
     } catch (err) {
       if (reqId === backgroundSaveReqRef.current) {

--- a/frontend/src/components/SetupWizard/SetupWizard.jsx
+++ b/frontend/src/components/SetupWizard/SetupWizard.jsx
@@ -15,7 +15,6 @@ const SETUP_STEPS = [
   { id: 'provider', label: 'AI' },
   { id: 'gemini', label: 'Images' },
 ]
-const SYSTEM_SETUP_READY_KEY = 'mobius:system-setup-ready:v1'
 const PROVIDERS = [
   { id: 'codex', label: 'OpenAI Codex' },
   { id: 'claude', label: 'Claude Code' },
@@ -28,16 +27,6 @@ const FALLBACK_MODELS = {
 function defaultEffort(provider) {
   const efforts = PROVIDER_INFO[provider]?.efforts || []
   return efforts.find(e => e.value === 'medium')?.value || efforts[0]?.value || ''
-}
-
-function markSystemSetupReady() {
-  if (typeof window === 'undefined' || !window.localStorage) return
-  try {
-    window.localStorage.setItem(
-      SYSTEM_SETUP_READY_KEY,
-      JSON.stringify({ completedAt: new Date().toISOString() }),
-    )
-  } catch {}
 }
 
 export default function SetupWizard({ onDone, initialStep = 'account' }) {
@@ -372,7 +361,6 @@ function ProviderStep({ onSkip, onContinue, claudeAuthenticated }) {
         try { detail = (await res.json()).detail || '' } catch {}
         throw new Error(detail || 'Could not save agent defaults.')
       }
-      markSystemSetupReady()
       settingsQueries.owner.invalidate(queryClient)
       setAgentSaved(true)
       setTimeout(() => setAgentSaved(false), 1600)

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -162,17 +162,35 @@ body,
 
 /* Theme flips should feel like one surface changing, not every descendant
    repainting separately. Modern Chromium/Safari get a View Transition bloom
-   from the user's tap point; older browsers fall back to this narrow color
-   transition so shadow/blur-heavy chat surfaces stay cheap on mobile. */
+   from the user's tap point; older browsers — and the Settings toggle, which
+   opts out of the View Transition to protect the back-stack sentinel
+   (themeService.toggleTheme passes preferViewTransition:false) — fall back to
+   this color transition.
+
+   The property list stays narrow (colors only, never box-shadow/filter) so
+   shadow/blur-heavy surfaces stay cheap on mobile; that property narrowness,
+   not a short element list, is what keeps the fallback lightweight. The
+   selector is therefore scoped per PANEL, not per leaf: a bounded control
+   panel gets BOTH its own class AND a `<panel> *` descendant wildcard, so
+   every current and future surface inside it (section cards, rows, inputs,
+   status dots) eases together and no newly-added leaf can silently snap while
+   the chrome around it animates. The wildcard is deliberately NOT
+   document-wide (`.theme-transitioning *`) — that would drag the whole chat
+   message/token tree into the transition, the exact cost this fallback exists
+   to avoid and chatUiPolish.test.js forbids. Bounded control panels only; the
+   chat keeps only its chrome (pill/plus) so its message list still snaps. */
 :root.theme-transitioning,
 :root.theme-transitioning body,
 :root.theme-transitioning #root,
 :root.theme-transitioning .shell,
 :root.theme-transitioning .shell__bar,
-:root.theme-transitioning .drawer,
 :root.theme-transitioning .chat,
 :root.theme-transitioning .chat__pill,
-:root.theme-transitioning .chat__plus {
+:root.theme-transitioning .chat__plus,
+:root.theme-transitioning .drawer,
+:root.theme-transitioning .drawer *,
+:root.theme-transitioning .settings,
+:root.theme-transitioning .settings * {
   transition-property: background-color, border-color, color, fill, stroke;
   transition-duration: 150ms;
   transition-timing-function: cubic-bezier(0.2, 0, 0, 1);


### PR DESCRIPTION
Two small confirmed findings from a multi-agent UI review of the prod-refresh work.

## Theme-transition desync on Settings
The Settings dark-mode toggle opts out of the View Transition (`preferViewTransition: false`, the PR #3 back-stack fix) and falls back to the `.theme-transitioning` color-transition allowlist — which covered only shell chrome. Every `.settings*` surface (cards, rows, inputs, status dots) snapped instantly while the top bar eased over 150ms, a visible desync on the exact panel hosting the toggle.

**Fix:** scope the allowlist per *panel*, not per leaf — `.settings`, `.settings *`, `.drawer`, `.drawer *` join the list, so every current and future surface inside a bounded control panel eases together and a newly added leaf can't silently snap. Deliberately NOT document-wide (`.theme-transitioning *` would drag the chat message/token tree into the transition — the exact cost the narrow fallback exists to avoid, and `chatUiPolish.test.js` forbids it). Property list unchanged: colors only, 150ms, same curve.

## Dead write-only localStorage key
`mobius:system-setup-ready:v1` was written by `markSystemSetupReady()` in SettingsView and SetupWizard but read nowhere (whole-repo grep, frontend + backend) — implying a setup-complete gate that doesn't exist. Removed the constant, helper, and both call sites.

## Tests
Post-rebase: `npm test` → test:lib **578 pass / 0 fail**, test:hooks **51 pass / 0 fail** (incl. `chatUiPolish.test.js`, which guards the no-document-wide-transition and no-box-shadow invariants this change respects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)