### PR TITLE
Review platform updates before applying

### DIFF
--- a/backend/app/platform_update.py
+++ b/backend/app/platform_update.py
@@ -102,6 +102,14 @@ _FETCH_TIMEOUT = 120
 # as probe-fail -> roll back.
 _PROBE_TIMEOUT = 60
 
+# Update-preview payload bounds. A whole-platform deploy can carry a huge diff;
+# the review sheet renders the file summary (always small) by default and the raw
+# diff only on demand, so cap the diff bytes on the wire and flag truncation. The
+# commit list is capped too — a normal deploy is a handful, and the sheet lists
+# them, not paginates.
+MAX_PREVIEW_DIFF_CHARS = 200_000
+_PREVIEW_COMMIT_LIMIT = 100
+
 # Serialise Apply in-process (uvicorn is single-worker; belt-and-braces against a
 # double-click racing two reconciles). The cross-process guard is RECONCILE_LOCK.
 _APPLY_LOCK = asyncio.Lock()
@@ -162,6 +170,42 @@ class PlatformConflictResolverChatOut(TypedDict):
   chat_id: str
   created: bool
   started: bool
+
+
+class PlatformCommitSummary(TypedDict):
+  """One incoming commit in an update preview: short sha + subject line."""
+
+  sha: str
+  subject: str
+
+
+class PlatformFileChange(TypedDict):
+  """One file the incoming update touches. ``insertions``/``deletions`` are None
+  for a binary file (git reports ``-`` in numstat)."""
+
+  path: str
+  status: str
+  insertions: int | None
+  deletions: int | None
+
+
+class PlatformUpdatePreview(TypedDict):
+  """Response shape for ``GET /api/platform/update-preview``.
+
+  The upstream-side changes ``origin/main`` brings relative to the served clone,
+  so the owner can review what a clean Apply would pull BEFORE applying. ``diff``
+  is capped at :data:`MAX_PREVIEW_DIFF_CHARS`; ``files``/``commits`` stay small
+  and are the compact default the review sheet renders."""
+
+  state: str
+  available: bool
+  current_sha: str | None
+  target_sha: str | None
+  commits: list[PlatformCommitSummary]
+  files: list[PlatformFileChange]
+  diff: str | None
+  diff_truncated: bool
+  conflict_paths: list[str]
 
 
 @dataclass(frozen=True)
@@ -787,6 +831,137 @@ def check_for_updates(repo: Path = PLATFORM_REPO) -> PlatformStatus:
         if target and _is_ancestor(repo, target, local):
           _set_upstream(repo, target)
   return platform_status(repo)
+
+
+def empty_platform_update_preview(
+  *, current_sha: str | None = None, target_sha: str | None = None,
+) -> PlatformUpdatePreview:
+  """A preview carrying no incoming changes — the up-to-date / unreadable case.
+  The review sheet reads ``available``/``files`` and shows "nothing to review"
+  rather than an empty diff panel."""
+  return PlatformUpdatePreview(
+    state=PlatformUpdateState.UP_TO_DATE.value, available=False,
+    current_sha=current_sha, target_sha=target_sha,
+    commits=[], files=[], diff=None, diff_truncated=False, conflict_paths=[],
+  )
+
+
+def _preview_commits(
+  repo: Path, base: str, target: str,
+) -> list[PlatformCommitSummary]:
+  """The commits ``target`` adds beyond ``base`` (newest first), capped."""
+  proc = _git(
+    "log", f"--max-count={_PREVIEW_COMMIT_LIMIT}", "--format=%h%x1f%s",
+    f"{base}..{target}", repo=repo, check=False,
+  )
+  if proc.returncode != 0:
+    return []
+  commits: list[PlatformCommitSummary] = []
+  for line in proc.stdout.splitlines():
+    if "\x1f" not in line:
+      continue
+    sha, subject = line.split("\x1f", 1)
+    commits.append(PlatformCommitSummary(sha=sha.strip(), subject=subject.strip()))
+  return commits
+
+
+def _preview_files(repo: Path, base: str, target: str) -> list[PlatformFileChange]:
+  """Per-file change summary for ``base..target``.
+
+  ``--name-status`` is authoritative for the path list + status letter (A/M/D/R);
+  ``--numstat`` counts are merged in best-effort, keyed on the same path. A rename
+  spells its numstat path differently, so its counts stay None — a display nicety,
+  not load-bearing (the status letter still reads ``R``)."""
+  by_path: dict[str, PlatformFileChange] = {}
+  order: list[str] = []
+  name_status = _git(
+    "diff", "--name-status", f"{base}..{target}", repo=repo, check=False,
+  )
+  if name_status.returncode == 0:
+    for line in name_status.stdout.splitlines():
+      parts = line.split("\t")
+      if len(parts) < 2:
+        continue
+      status = (parts[0].strip() or "M")[:1]
+      path = parts[-1].strip()  # rename: last field is the new path
+      if not path or path in by_path:
+        continue
+      by_path[path] = PlatformFileChange(
+        path=path, status=status, insertions=None, deletions=None,
+      )
+      order.append(path)
+  numstat = _git(
+    "diff", "--numstat", f"{base}..{target}", repo=repo, check=False,
+  )
+  if numstat.returncode == 0:
+    for line in numstat.stdout.splitlines():
+      parts = line.split("\t")
+      if len(parts) < 3:
+        continue
+      record = by_path.get(parts[-1].strip())
+      if record is None:
+        continue
+      ins, dele = parts[0], parts[1]
+      record["insertions"] = None if ins == "-" else (int(ins) if ins.isdigit() else None)
+      record["deletions"] = None if dele == "-" else (int(dele) if dele.isdigit() else None)
+  return [by_path[path] for path in order]
+
+
+def _preview_diff(repo: Path, base: str, target: str) -> tuple[str | None, bool]:
+  """The unified diff for ``base..target``, capped at :data:`MAX_PREVIEW_DIFF_CHARS`.
+  Returns ``(diff, truncated)``; ``(None, False)`` when git could not produce it."""
+  proc = _git(
+    "diff", "--no-ext-diff", f"{base}..{target}", repo=repo, check=False,
+  )
+  if proc.returncode != 0:
+    return None, False
+  text = proc.stdout
+  if len(text) > MAX_PREVIEW_DIFF_CHARS:
+    return text[:MAX_PREVIEW_DIFF_CHARS], True
+  return (text or None), False
+
+
+def platform_update_preview(repo: Path = PLATFORM_REPO) -> PlatformUpdatePreview:
+  """Read-only preview of the incoming platform update, for the Settings review
+  step before Apply (fetch-free, never mutates the tree).
+
+  Shows the upstream-side changes ``origin/main`` brings since the shared merge
+  base — local edits are excluded, so the owner reviews exactly what a clean Apply
+  would pull. Availability is the same ancestry check :func:`platform_status`
+  uses; an up-to-date instance returns an empty preview. Degrades to an empty
+  preview (never raises) when the clone or ancestry can't be read, so it can never
+  break Settings."""
+  if not (repo / ".git").exists() or not _has_origin(repo):
+    return empty_platform_update_preview()
+  local = _local_branch(repo)
+  local_sha = _rev(repo, local) or None
+  target = _rev(repo, DEFAULT_TARGET_REF) or None
+  available = bool(target) and not _is_ancestor(repo, target, local)
+  if not target or not available:
+    return empty_platform_update_preview(
+      current_sha=local_sha, target_sha=target,
+    )
+  base = _git(
+    "merge-base", local, target, repo=repo, check=False,
+  ).stdout.strip() or local_sha
+  if not base:
+    # No shared base and no local tip to diff against — surface availability
+    # without a diff rather than raising.
+    return PlatformUpdatePreview(
+      state=PlatformUpdateState.AVAILABLE.value, available=True,
+      current_sha=local_sha, target_sha=target, commits=[], files=[],
+      diff=None, diff_truncated=False, conflict_paths=[],
+    )
+  diff, truncated = _preview_diff(repo, base, target)
+  conflict = _read_conflict_flag() or {}
+  return PlatformUpdatePreview(
+    state=PlatformUpdateState.AVAILABLE.value, available=True,
+    current_sha=local_sha, target_sha=target,
+    commits=_preview_commits(repo, base, target),
+    files=_preview_files(repo, base, target),
+    diff=diff, diff_truncated=truncated,
+    conflict_paths=conflict.get("paths") or [],
+  )
 
 
 async def apply_platform_update(

--- a/backend/app/routes/platform.py
+++ b/backend/app/routes/platform.py
@@ -27,7 +27,7 @@ from app.database import get_db
 from app.deps import get_current_owner, reject_cross_site
 from app.platform_update import (
   PlatformApplyResult, PlatformConflictResolverChatOut, PlatformStatus,
-  PlatformUpdateError,
+  PlatformUpdateError, PlatformUpdatePreview,
 )
 from app.restart_util import restart_this_worker
 
@@ -77,6 +77,21 @@ async def check_platform_updates(
       recorded_upstream_sha=None, seed_required=False, conflict_paths=[],
       conflict_chat_id=None,
     )
+
+
+@router.get("/update-preview")
+async def get_platform_update_preview(
+  _: models.Owner = Depends(get_current_owner),
+) -> PlatformUpdatePreview:
+  """Read-only preview of the incoming platform update, for the Settings review
+  step the owner sees before Apply. Fetch-free and non-mutating like ``/status``.
+  Never raises — a git hiccup degrades to an empty preview so the review sheet
+  shows "nothing to review" rather than breaking the page."""
+  try:
+    return await asyncio.to_thread(platform_update.platform_update_preview)
+  except Exception as exc:
+    log.warning("platform update-preview failed: %r", exc)
+    return platform_update.empty_platform_update_preview()
 
 
 @router.post("/apply", dependencies=[Depends(reject_cross_site)])

--- a/backend/tests/test_platform_routes.py
+++ b/backend/tests/test_platform_routes.py
@@ -1,0 +1,29 @@
+"""Route-level wiring for the platform updater endpoints.
+
+The reconcile plumbing is covered exhaustively in ``test_platform_update.py``
+against throwaway clones; these assert the HTTP surface: owner-gating and the
+degrade-to-empty contract the Settings review step relies on. There is no real
+``/data/platform`` clone in the test env, so ``GET /update-preview`` returns the
+empty preview — which is exactly the "nothing to review" shape the sheet reads.
+"""
+
+
+def test_update_preview_requires_owner(client):
+  assert client.get("/api/platform/update-preview").status_code == 401
+
+
+def test_update_preview_returns_empty_shape_without_a_clone(client, auth):
+  res = client.get("/api/platform/update-preview", headers=auth)
+  assert res.status_code == 200
+  body = res.json()
+  # The keys the review sheet + its summarizer read must always be present.
+  for key in (
+    "available", "state", "commits", "files", "diff", "diff_truncated",
+    "conflict_paths",
+  ):
+    assert key in body
+  assert body["available"] is False
+  assert body["commits"] == []
+  assert body["files"] == []
+  assert body["diff"] is None
+  assert body["diff_truncated"] is False

--- a/backend/tests/test_platform_update.py
+++ b/backend/tests/test_platform_update.py
@@ -573,3 +573,95 @@ def test_rolled_back_flag_roundtrips(clone_env):
   got = pu._read_rolled_back_flag()
   assert got["target"] == "tgt-sha"
   assert "ModuleNotFoundError" in got["error"]
+
+
+# --- update preview: the read-only "review before Apply" surface ------------
+# platform_update_preview is fetch-free (it reads the origin/main left by the
+# last fetch), so each test fetches first to mirror the real order: Check
+# fetches, then Update opens the preview.
+
+
+def test_update_preview_up_to_date_is_empty(clone_env):
+  origin, platform = clone_env
+  pu._fetch(platform)
+
+  preview = pu.platform_update_preview(platform)
+
+  assert preview["available"] is False
+  assert preview["commits"] == []
+  assert preview["files"] == []
+  assert preview["diff"] is None
+  assert preview["diff_truncated"] is False
+
+
+def test_update_preview_clean_fast_forward(clone_env):
+  origin, platform = clone_env
+  new = _advance_origin(origin, edits={"backend/app/main.py":
+    _MAIN_PY.replace("LINE_C = 3", "LINE_C = 300")}, msg="bump line c")
+  pu._fetch(platform)
+
+  preview = pu.platform_update_preview(platform)
+
+  assert preview["available"] is True
+  assert preview["target_sha"] == new
+  assert [c["subject"] for c in preview["commits"]] == ["bump line c"]
+  changed = {f["path"] for f in preview["files"]}
+  assert "backend/app/main.py" in changed
+  assert "LINE_C = 300" in preview["diff"]
+  assert preview["diff_truncated"] is False
+
+
+def test_update_preview_excludes_local_edits(clone_env):
+  # A committed local edit must NOT appear in the preview — the owner reviews
+  # only the upstream-side changes a clean Apply pulls in.
+  origin, platform = clone_env
+  _local_commit(platform, edits={"backend/app/main.py":
+    _MAIN_PY.replace("LINE_A = 1", "LINE_A = 111")})
+  _advance_origin(origin, edits={"backend/app/main.py":
+    _MAIN_PY.replace("LINE_C = 3", "LINE_C = 333")})
+  pu._fetch(platform)
+
+  preview = pu.platform_update_preview(platform)
+
+  assert preview["available"] is True
+  assert "LINE_C = 333" in preview["diff"]  # upstream change is shown
+  assert "LINE_A = 111" not in preview["diff"]  # local edit is excluded
+
+
+def test_update_preview_reports_file_status(clone_env):
+  origin, platform = clone_env
+  _advance_origin(
+    origin,
+    edits={"backend/app/added.py": "NEW = 1\n"},
+    deletes=["backend/app/foo.py"],
+    msg="add + delete",
+  )
+  pu._fetch(platform)
+
+  preview = pu.platform_update_preview(platform)
+
+  status_by_path = {f["path"]: f["status"] for f in preview["files"]}
+  assert status_by_path.get("backend/app/added.py") == "A"
+  assert status_by_path.get("backend/app/foo.py") == "D"
+
+
+def test_update_preview_caps_large_diff(clone_env):
+  origin, platform = clone_env
+  huge = "x" * (pu.MAX_PREVIEW_DIFF_CHARS + 50_000) + "\n"
+  _advance_origin(origin, edits={"backend/app/big.py": huge}, msg="big file")
+  pu._fetch(platform)
+
+  preview = pu.platform_update_preview(platform)
+
+  assert preview["diff_truncated"] is True
+  assert len(preview["diff"]) == pu.MAX_PREVIEW_DIFF_CHARS
+
+
+def test_update_preview_degrades_when_not_a_clone(tmp_path):
+  # A non-git directory must degrade to an empty preview, never raise, so the
+  # route + Settings can't break on a missing/odd platform tree.
+  preview = pu.platform_update_preview(tmp_path)
+
+  assert preview["available"] is False
+  assert preview["diff"] is None
+  assert preview["commits"] == []

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -293,6 +293,8 @@ export const api = {
   platform: {
     status: () => apiFetch('/platform/status'),
     check: () => apiFetch('/platform/check', { method: 'POST' }),
+    // Read-only preview of the incoming update, shown for review before Apply.
+    updatePreview: () => apiFetch('/platform/update-preview'),
     apply: () => apiFetch('/platform/apply', { method: 'POST' }),
     conflictResolverChat: () => apiFetch('/platform/conflict-resolver-chat', {
       method: 'POST',

--- a/frontend/src/components/SettingsView/SettingsView.jsx
+++ b/frontend/src/components/SettingsView/SettingsView.jsx
@@ -13,6 +13,7 @@ import CodexAuth from '../ProviderAuth/CodexAuth.jsx'
 import ProviderRow from '../ProviderAuth/ProviderRow.jsx'
 import StatusDot from '../ui/StatusDot.jsx'
 import ManageModelsModal from '../ChatView/ManageModelsModal.jsx'
+import UpdateReviewModal from './UpdateReviewModal.jsx'
 import { PROVIDER_INFO, PROVIDER_ORDER } from '../ChatView/ChatSettingsPanel.jsx'
 import '../ui/StatusDot.css'
 import './SettingsView.css'
@@ -325,6 +326,10 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
   const [platform, setPlatform] = useState(null)
   const [platformPhase, setPlatformPhase] = useState('idle')
   const [platformError, setPlatformError] = useState('')
+  // Whether the update-review sheet is open. The "Update" button routes through
+  // it so the owner reviews the incoming changes before applying, rather than
+  // Apply firing on the first click.
+  const [reviewOpen, setReviewOpen] = useState(false)
   // 'idle' | 'checking' | 'checked' — the "Check for updates" button asks the
   // service worker to re-check cached frontend assets and re-reads
   // /api/version. 'checked' is a short-lived success label when no update is
@@ -869,11 +874,13 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  // Press Update -> merge the baked platform release into the live backend.
-  // Clean -> the row flips to "restart needed"; conflict -> show a resolver
-  // action, but wait for the owner's click before opening an agent chat.
+  // Apply the reviewed update: merge the fetched platform release into the live
+  // backend. Clean -> the row flips to "restart needed"; conflict -> show a
+  // resolver action, but wait for the owner's click before opening an agent
+  // chat. Returns whether the apply landed cleanly so the review sheet can close
+  // on success and keep itself open (showing the error) on failure.
   async function applyPlatformUpdate() {
-    if (platformPhase !== 'idle') return
+    if (platformPhase !== 'idle') return false
     setPlatformError('')
     setPlatformPhase('applying')
     try {
@@ -882,11 +889,13 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
         let detail = ''
         try { detail = (await res.json())?.detail || '' } catch {}
         setPlatformError(detail ? `Update failed: ${detail}` : 'Update failed — the instance is unchanged.')
-        return
+        return false
       }
       await refreshPlatform()
+      return true
     } catch {
       setPlatformError('Update failed — the instance is unchanged.')
+      return false
     } finally {
       setPlatformPhase('idle')
     }
@@ -921,13 +930,13 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
     }
   }
 
-  // One "Update" button for the platform updater. A clean merge marks
-  // restart-needed, so the row advances to "Restart to finish"; that restart
-  // reloads onto the fresh service worker too.
-  async function applyMobiusUpdate() {
-    if (platform?.available) {
-      await applyPlatformUpdate()
-    }
+  // The "Update" button opens the review sheet instead of applying immediately,
+  // so the owner sees the incoming changes first. Apply happens from inside the
+  // sheet (which then advances the row to "Restart to finish").
+  function openUpdateReview() {
+    if (platformPhase !== 'idle' || !platform?.available) return
+    setPlatformError('')
+    setReviewOpen(true)
   }
 
   // Poll until the restart is actually safe to navigate. A plain successful
@@ -1386,10 +1395,10 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
               <button
                 className="settings__btn settings__btn--sm settings__btn--nowrap"
                 type="button"
-                onClick={applyMobiusUpdate}
+                onClick={openUpdateReview}
                 disabled={mobiusUpdating}
               >
-                {mobiusUpdating ? 'Updating…' : 'Update'}
+                {mobiusUpdating ? 'Updating…' : 'Review update'}
               </button>
             ) : (
               // Nothing to apply — offer an explicit refresh. Subtle outline (a
@@ -1416,6 +1425,15 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
             <Alert color="danger" variant="soft" description={platformError} />
           )}
         </section>
+
+        {reviewOpen && (
+          <UpdateReviewModal
+            onClose={() => setReviewOpen(false)}
+            onApply={applyPlatformUpdate}
+            applying={platformPhase === 'applying'}
+            applyError={platformError}
+          />
+        )}
 
         <section className="settings__section settings__section--compact settings__section--server">
           <h2 className="settings__section-title">Server</h2>

--- a/frontend/src/components/SettingsView/UpdateReviewModal.css
+++ b/frontend/src/components/SettingsView/UpdateReviewModal.css
@@ -1,0 +1,351 @@
+/* Update-review sheet. Overlay + card conventions mirror ManageModelsModal
+   (paints over shell content, starts below the persistent shell bar, tap-outside
+   closes); typography + tokens follow SettingsView so it reads as one system. */
+
+.urm__overlay {
+  position: fixed;
+  top: calc(58px + env(safe-area-inset-top, 0px));
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background: rgba(0, 0, 0, 0.50);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding:
+    max(18px, env(safe-area-inset-top, 0px))
+    max(18px, env(safe-area-inset-right, 0px))
+    max(18px, env(safe-area-inset-bottom, 0px))
+    max(18px, env(safe-area-inset-left, 0px));
+  box-sizing: border-box;
+  overflow: hidden;
+  overscroll-behavior: contain;
+}
+
+[data-theme="light"] .urm__overlay {
+  background: rgba(15, 18, 25, 0.32);
+}
+
+.urm {
+  background:
+    linear-gradient(
+      145deg,
+      color-mix(in srgb, var(--surface2) 24%, transparent),
+      transparent 38%
+    ),
+    var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  width: min(560px, 100%);
+  height: min(720px, calc(100dvh - 36px));
+  max-height: 100%;
+  overflow: hidden;
+  padding: 18px;
+  box-sizing: border-box;
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr) auto auto;
+  gap: 12px;
+  color: var(--text);
+  min-height: 0;
+}
+
+.urm__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.urm__title {
+  font-size: 17px;
+  font-weight: 600;
+  letter-spacing: 0;
+  margin: 0;
+}
+
+.urm__close {
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  font-size: 22px;
+  line-height: 1;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.urm__close:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .urm__close:hover:not(:disabled) {
+    background: var(--surface2);
+    color: var(--text);
+  }
+}
+
+.urm__subtext {
+  font-size: 13px;
+  color: var(--muted);
+  line-height: 1.5;
+  margin: 0;
+}
+
+.urm__body {
+  overflow-y: auto;
+  overflow-x: hidden;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding-right: 2px;
+  scrollbar-width: thin;
+}
+
+.urm__notice {
+  padding: 12px 14px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: var(--surface2);
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.urm__section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.urm__section-title {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--muted);
+  letter-spacing: 0;
+  margin: 0;
+}
+
+.urm__commits,
+.urm__files {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.urm__commit {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding: 5px 8px;
+  border-radius: 8px;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.urm__commit:nth-child(odd) {
+  background: color-mix(in srgb, var(--surface2) 45%, transparent);
+}
+
+.urm__commit-subject {
+  color: var(--text);
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.urm__sha {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  color: var(--muted);
+  flex-shrink: 0;
+}
+
+.urm__file {
+  display: grid;
+  grid-template-columns: 20px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  padding: 5px 8px;
+  border-radius: 8px;
+  font-size: 13px;
+}
+
+.urm__file:nth-child(odd) {
+  background: color-mix(in srgb, var(--surface2) 45%, transparent);
+}
+
+.urm__file-badge {
+  width: 20px;
+  height: 20px;
+  border-radius: 6px;
+  display: grid;
+  place-items: center;
+  font-size: 11px;
+  font-weight: 600;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  background: color-mix(in srgb, var(--muted) 20%, transparent);
+  color: var(--muted);
+  flex-shrink: 0;
+}
+
+/* Semantic tints for the common statuses; unknown letters keep the neutral
+   default above. Kept subtle — this is a review surface, not an alert. */
+.urm__file-badge--a {
+  background: color-mix(in srgb, var(--green, #16a34a) 18%, transparent);
+  color: var(--green, #16a34a);
+}
+
+.urm__file-badge--d {
+  background: color-mix(in srgb, var(--danger, #ef4444) 18%, transparent);
+  color: var(--danger, #ef4444);
+}
+
+.urm__file-path {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12.5px;
+}
+
+.urm__file-stat {
+  display: inline-flex;
+  gap: 8px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  flex-shrink: 0;
+}
+
+.urm__stat-add { color: var(--green, #16a34a); }
+.urm__stat-del { color: var(--danger, #ef4444); }
+
+.urm__diff-toggle {
+  align-self: flex-start;
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text);
+  border-radius: 8px;
+  padding: 6px 12px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .urm__diff-toggle:hover {
+    background: var(--surface2);
+  }
+}
+
+.urm__diff {
+  margin: 0;
+  padding: 12px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  max-height: 320px;
+  overflow: auto;
+  white-space: pre;
+  overscroll-behavior: contain;
+}
+
+.urm__diff-note {
+  margin: 6px 0 0;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.urm__skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.urm__skeleton-row {
+  height: 34px;
+  border-radius: 8px;
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--surface2) 60%, transparent) 25%,
+    color-mix(in srgb, var(--surface2) 30%, transparent) 50%,
+    color-mix(in srgb, var(--surface2) 60%, transparent) 75%
+  );
+  background-size: 200% 100%;
+  animation: urm-shimmer 1.4s ease-in-out infinite;
+}
+
+@keyframes urm-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .urm__skeleton-row { animation: none; }
+}
+
+.urm__foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.urm__foot-actions {
+  display: inline-flex;
+  gap: 10px;
+}
+
+.urm__btn {
+  background: var(--accent);
+  color: var(--accent-fg);
+  border: none;
+  border-radius: 8px;
+  padding: 9px 18px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .urm__btn:hover:not(:disabled) {
+    background: var(--accent-hover);
+  }
+}
+
+.urm__btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.urm__btn--ghost {
+  background: transparent;
+  color: var(--text);
+  border: 1px solid var(--border);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .urm__btn--ghost:hover:not(:disabled) {
+    background: var(--surface2);
+  }
+}
+
+.urm__btn:focus-visible,
+.urm__diff-toggle:focus-visible,
+.urm__close:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}

--- a/frontend/src/components/SettingsView/UpdateReviewModal.jsx
+++ b/frontend/src/components/SettingsView/UpdateReviewModal.jsx
@@ -1,0 +1,269 @@
+/**
+ * UpdateReviewModal — the "review the changes before you pull them" sheet for a
+ * platform update. Opened from the Settings "Möbius" update row when an update
+ * is available, in place of applying immediately.
+ *
+ * It fetches GET /api/platform/update-preview (read-only, fetch-free on the
+ * server) and shows the incoming changes: the target commit, a per-commit list,
+ * a per-file summary (status + insertions/deletions), and the raw diff on
+ * demand. Two explicit actions: Apply (delegates to the caller's existing
+ * platform-apply flow) and Not now (closes, nothing changed).
+ *
+ * No dead-ends by contract:
+ *   - a trivial update (no file changes) shows a one-line confirm, no empty diff
+ *     panel;
+ *   - a failed preview load shows a readable message with Try again + an
+ *     "Update anyway" fallback (the owner could already apply without a preview,
+ *     so we never take that capability away);
+ *   - Not now / tap-outside / Escape leave the instance untouched.
+ *
+ * Design language mirrors SettingsView + ManageModelsModal: card-on-surface,
+ * 1px borders, sentence-case titles, the shared .settings tokens.
+ */
+
+import { useCallback, useEffect, useState } from 'react'
+import { Alert } from '@openai/apps-sdk-ui/components/Alert'
+import { api } from '../../api/client.js'
+import {
+  fileStatusLabel,
+  shortSha,
+  summarizePreview,
+  isTrivialUpdate,
+} from '../../lib/platformUpdatePreview.js'
+import './UpdateReviewModal.css'
+
+function fileCountLabel(count) {
+  return `${count} ${count === 1 ? 'file' : 'files'}`
+}
+
+function commitCountLabel(count) {
+  return `${count} ${count === 1 ? 'commit' : 'commits'}`
+}
+
+export default function UpdateReviewModal({ onClose, onApply, applying, applyError }) {
+  const [preview, setPreview] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState(false)
+  const [diffOpen, setDiffOpen] = useState(false)
+
+  const loadPreview = useCallback(async () => {
+    setLoading(true)
+    setLoadError(false)
+    try {
+      const res = await api.platform.updatePreview()
+      if (!res.ok) throw new Error(`status ${res.status}`)
+      setPreview(await res.json())
+    } catch {
+      setLoadError(true)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { loadPreview() }, [loadPreview])
+
+  // Escape closes, but never mid-apply — an apply leads to a restart, so we
+  // don't want a stray keypress to abandon the sheet while it's in flight.
+  useEffect(() => {
+    const onKey = (event) => {
+      if (event.key === 'Escape' && !applying) onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [applying, onClose])
+
+  const requestClose = useCallback(() => {
+    if (!applying) onClose()
+  }, [applying, onClose])
+
+  const handleApply = useCallback(async () => {
+    const ok = await onApply()
+    // On success the caller advances the row to "Restart to finish"; close so
+    // the owner sees that next step. On failure applyError renders in the sheet.
+    if (ok) onClose()
+  }, [onApply, onClose])
+
+  const summary = summarizePreview(preview)
+  const trivial = preview && isTrivialUpdate(preview)
+  const target = shortSha(preview?.target_sha)
+  const commits = Array.isArray(preview?.commits) ? preview.commits : []
+  const files = Array.isArray(preview?.files) ? preview.files : []
+  // A preview that resolved to "not available" (e.g. the update landed from
+  // another surface between status and open) has nothing to apply.
+  const notAvailable = preview && preview.available === false && !loadError
+
+  const summaryBits = []
+  if (summary.commitCount) summaryBits.push(commitCountLabel(summary.commitCount))
+  if (summary.fileCount) summaryBits.push(fileCountLabel(summary.fileCount))
+
+  return (
+    <div
+      className="urm__overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="urm-title"
+      onClick={requestClose}
+    >
+      <div className="urm" onClick={(event) => event.stopPropagation()}>
+        <div className="urm__head">
+          <h2 id="urm-title" className="urm__title">Review update</h2>
+          <button
+            type="button"
+            className="urm__close"
+            onClick={requestClose}
+            aria-label="Close"
+            disabled={applying}
+          >×</button>
+        </div>
+
+        {!loadError && target && (
+          <p className="urm__subtext">
+            Updating Möbius to <code className="urm__sha">{target}</code>.
+            {summaryBits.length ? ` ${summaryBits.join(' · ')}.` : ''}
+          </p>
+        )}
+
+        <div className="urm__body">
+          {loading && (
+            <div className="urm__skeleton" aria-hidden="true">
+              <div className="urm__skeleton-row" />
+              <div className="urm__skeleton-row" />
+              <div className="urm__skeleton-row" />
+            </div>
+          )}
+
+          {!loading && loadError && (
+            <div className="urm__notice" role="status">
+              Couldn’t load the change preview. You can try again, or apply the
+              update without reviewing it.
+            </div>
+          )}
+
+          {!loading && !loadError && notAvailable && (
+            <div className="urm__notice" role="status">
+              This instance is already up to date — there’s nothing to apply.
+            </div>
+          )}
+
+          {!loading && !loadError && !notAvailable && trivial && (
+            <div className="urm__notice" role="status">
+              No file changes to review — this update just advances the version.
+            </div>
+          )}
+
+          {!loading && !loadError && !notAvailable && !trivial && (
+            <>
+              {commits.length > 0 && (
+                <section className="urm__section">
+                  <h3 className="urm__section-title">
+                    {commitCountLabel(commits.length)}
+                  </h3>
+                  <ul className="urm__commits">
+                    {commits.map((commit) => (
+                      <li key={commit.sha} className="urm__commit">
+                        <code className="urm__sha">{shortSha(commit.sha)}</code>
+                        <span className="urm__commit-subject">{commit.subject}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              )}
+
+              <section className="urm__section">
+                <h3 className="urm__section-title">{fileCountLabel(files.length)}</h3>
+                <ul className="urm__files">
+                  {files.map((file) => (
+                    <li key={file.path} className="urm__file">
+                      <span
+                        className={`urm__file-badge urm__file-badge--${(file.status || 'M').charAt(0).toLowerCase()}`}
+                        title={fileStatusLabel(file.status)}
+                      >
+                        {(file.status || 'M').charAt(0).toUpperCase()}
+                      </span>
+                      <span className="urm__file-path">{file.path}</span>
+                      <span className="urm__file-stat">
+                        {typeof file.insertions === 'number' && file.insertions > 0 && (
+                          <span className="urm__stat-add">+{file.insertions}</span>
+                        )}
+                        {typeof file.deletions === 'number' && file.deletions > 0 && (
+                          <span className="urm__stat-del">−{file.deletions}</span>
+                        )}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+
+              {summary.hasDiff && (
+                <section className="urm__section">
+                  <button
+                    type="button"
+                    className="urm__diff-toggle"
+                    onClick={() => setDiffOpen((open) => !open)}
+                    aria-expanded={diffOpen}
+                  >
+                    {diffOpen ? 'Hide changes' : 'Show changes'}
+                  </button>
+                  {diffOpen && (
+                    <>
+                      <pre className="urm__diff"><code>{preview.diff}</code></pre>
+                      {summary.diffTruncated && (
+                        <p className="urm__diff-note">
+                          Diff truncated — the full changes apply when you update.
+                        </p>
+                      )}
+                    </>
+                  )}
+                </section>
+              )}
+            </>
+          )}
+        </div>
+
+        {applyError && (
+          <Alert color="danger" variant="soft" description={applyError} />
+        )}
+
+        <div className="urm__foot">
+          <button
+            type="button"
+            className="urm__btn urm__btn--ghost"
+            onClick={requestClose}
+            disabled={applying}
+          >
+            Not now
+          </button>
+          {loadError ? (
+            <div className="urm__foot-actions">
+              <button
+                type="button"
+                className="urm__btn urm__btn--ghost"
+                onClick={loadPreview}
+                disabled={applying}
+              >
+                Try again
+              </button>
+              <button
+                type="button"
+                className="urm__btn"
+                onClick={handleApply}
+                disabled={applying}
+              >
+                {applying ? 'Applying…' : 'Update anyway'}
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              className="urm__btn"
+              onClick={handleApply}
+              disabled={applying || loading || notAvailable}
+            >
+              {applying ? 'Applying…' : 'Apply update'}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/lib/__tests__/platformUpdatePreview.test.js
+++ b/frontend/src/lib/__tests__/platformUpdatePreview.test.js
@@ -1,0 +1,74 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  fileStatusLabel,
+  shortSha,
+  summarizePreview,
+  isTrivialUpdate,
+  hasReviewableChanges,
+} from '../platformUpdatePreview.js'
+
+test('fileStatusLabel maps git status letters, falls back gracefully', () => {
+  assert.equal(fileStatusLabel('A'), 'Added')
+  assert.equal(fileStatusLabel('M'), 'Modified')
+  assert.equal(fileStatusLabel('D'), 'Removed')
+  assert.equal(fileStatusLabel('R100'), 'Renamed')
+  assert.equal(fileStatusLabel('x'), 'Changed')
+  assert.equal(fileStatusLabel(''), 'Changed')
+  assert.equal(fileStatusLabel(undefined), 'Changed')
+})
+
+test('shortSha truncates and tolerates junk', () => {
+  assert.equal(shortSha('0123456789abcdef'), '01234567')
+  assert.equal(shortSha('abc'), 'abc')
+  assert.equal(shortSha(''), '')
+  assert.equal(shortSha(null), '')
+})
+
+test('summarizePreview totals files/commits and skips binary counts', () => {
+  const preview = {
+    commits: [{ sha: 'a', subject: 'one' }, { sha: 'b', subject: 'two' }],
+    files: [
+      { path: 'a.py', status: 'M', insertions: 3, deletions: 1 },
+      { path: 'img.png', status: 'A', insertions: null, deletions: null },
+      { path: 'b.py', status: 'D', insertions: 0, deletions: 12 },
+    ],
+    diff: 'diff --git ...',
+    diff_truncated: true,
+  }
+  const s = summarizePreview(preview)
+  assert.equal(s.commitCount, 2)
+  assert.equal(s.fileCount, 3)
+  assert.equal(s.insertions, 3)
+  assert.equal(s.deletions, 13)
+  assert.equal(s.hasDiff, true)
+  assert.equal(s.diffTruncated, true)
+})
+
+test('summarizePreview is safe on empty/absent fields', () => {
+  const s = summarizePreview({})
+  assert.deepEqual(s, {
+    commitCount: 0,
+    fileCount: 0,
+    insertions: 0,
+    deletions: 0,
+    hasDiff: false,
+    diffTruncated: false,
+  })
+  // Fully undefined input must not throw.
+  assert.equal(summarizePreview(undefined).fileCount, 0)
+})
+
+test('isTrivialUpdate is true only when no files changed', () => {
+  assert.equal(isTrivialUpdate({ files: [] }), true)
+  assert.equal(isTrivialUpdate({}), true)
+  assert.equal(isTrivialUpdate({ files: [{ path: 'a', status: 'M' }] }), false)
+})
+
+test('hasReviewableChanges: files OR commits make it reviewable', () => {
+  assert.equal(hasReviewableChanges({ files: [], commits: [] }), false)
+  assert.equal(hasReviewableChanges({ files: [{ path: 'a' }], commits: [] }), true)
+  // A version bump with commits but no tree delta is still worth listing.
+  assert.equal(hasReviewableChanges({ files: [], commits: [{ sha: 'a' }] }), true)
+})

--- a/frontend/src/lib/platformUpdatePreview.js
+++ b/frontend/src/lib/platformUpdatePreview.js
@@ -1,0 +1,62 @@
+// Pure helpers for the platform update-review sheet. Kept side-effect-free (no
+// React, no fetch) so the "what does this preview contain" decisions — trivial
+// vs reviewable, the compact totals, the short sha — are unit-testable in
+// isolation, mirroring restartReadiness.js / streamPromotion.js.
+
+// A single-letter git status → a short human label for the file badge.
+const STATUS_LABELS = {
+  A: 'Added',
+  M: 'Modified',
+  D: 'Removed',
+  R: 'Renamed',
+  C: 'Copied',
+  T: 'Type changed',
+}
+
+export function fileStatusLabel(status) {
+  return STATUS_LABELS[(status || '').charAt(0).toUpperCase()] || 'Changed'
+}
+
+// Abbreviate a commit sha for display. The backend already sends short shas, so
+// this only guards against a full sha slipping through.
+export function shortSha(sha) {
+  const s = typeof sha === 'string' ? sha.trim() : ''
+  return s ? s.slice(0, 8) : ''
+}
+
+// The compact totals the sheet header shows. Insertions/deletions skip binary
+// files (backend sends null counts for those) so the numbers stay meaningful.
+export function summarizePreview(preview) {
+  const files = Array.isArray(preview?.files) ? preview.files : []
+  const commits = Array.isArray(preview?.commits) ? preview.commits : []
+  let insertions = 0
+  let deletions = 0
+  for (const file of files) {
+    if (typeof file?.insertions === 'number') insertions += file.insertions
+    if (typeof file?.deletions === 'number') deletions += file.deletions
+  }
+  const diff = typeof preview?.diff === 'string' ? preview.diff : ''
+  return {
+    commitCount: commits.length,
+    fileCount: files.length,
+    insertions,
+    deletions,
+    hasDiff: diff.length > 0,
+    diffTruncated: !!preview?.diff_truncated,
+  }
+}
+
+// A trivial update carries no file changes (e.g. a version/commit bump with no
+// tree delta): the sheet then shows a one-line confirm, never an empty diff
+// panel. An update with no preview data at all (files + commits both empty) is
+// also trivial — there's nothing to render but the Apply confirmation.
+export function isTrivialUpdate(preview) {
+  const files = Array.isArray(preview?.files) ? preview.files : []
+  return files.length === 0
+}
+
+// Whether the sheet has anything worth showing beyond the Apply confirmation.
+export function hasReviewableChanges(preview) {
+  const commits = Array.isArray(preview?.commits) ? preview.commits : []
+  return !isTrivialUpdate(preview) || commits.length > 0
+}


### PR DESCRIPTION
Implements the review-before-apply step for clean platform updates — the owner-vision gap a multi-agent review ranked highest in the app-store dimension: the backend could already produce update diffs, but only the CONFLICT branch ever showed the owner anything; a clean update applied unseen on first click.

## What changed
- **New read-only endpoint** `GET /api/platform/update-preview` (`platform_update.platform_update_preview()`): fetch-free and non-mutating like `/status`; returns target/current sha, per-commit summaries, per-file status + insertion/deletion counts, and the unified diff of exactly what a clean Apply would pull (upstream side since the merge base — local edits excluded). Diff capped at 200KB with a truncation flag. Never raises: a git hiccup degrades to an empty preview.
- **Settings "Update" → "Review update"**: the button now opens a review sheet (`UpdateReviewModal`, design language mirroring ManageModelsModal) showing commits, files, and the diff on demand, with explicit **Apply** / **Not now**.
- **No dead ends by contract:** trivial update (no file changes) → one-line confirm, no empty diff panel; preview load failure → readable message with Try again + an "Update anyway" fallback (never removes the pre-existing apply capability); Not now / tap-outside / Escape leave everything untouched; Escape is ignored mid-apply; already-applied-elsewhere race → notice + disabled Apply.
- Pure presentation logic extracted to `lib/platformUpdatePreview.js` (mirrors `restartReadiness.js`) with unit tests.

## Not in scope (follow-up spec included below)
App-catalog updates run through the external App Store app; the backend `GET /api/apps/{id}/update-preview` already exists. The store app should adopt the same review-then-apply interaction: preview before `POST /api/apps/install` when updating an installed app, review sheet on `status:"clean"`, keep the existing conflict-resolver affordance on `status:"conflict"`, lightweight confirm for version-only bumps, fresh installs unchanged.

## Tests
Post-rebase onto af8db701 (conflicts with the shell-update-status work resolved — review flow now rides its `mobiusUpdating` busy flag):
- backend: `wt-pytest tests/test_platform_update.py tests/test_platform_routes.py -q` → **32 passed** (6 new preview + 2 new route tests)
- frontend: `npm test` → **584 + 51 pass, 0 fail** (6 new `platformUpdatePreview` cases); `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)