### PR TITLE
Contribute: CI checks feedback loop (feature 196, items 1-3)

### DIFF
--- a/backend/app/routes/github.py
+++ b/backend/app/routes/github.py
@@ -51,6 +51,7 @@ from app.deps import (
   get_owner_or_app_with_github_access,
   reject_cross_site,
 )
+from app.push import notify_owner
 from app.storage_io import atomic_write
 
 router = APIRouter(prefix="/api/github", tags=["github"])
@@ -90,6 +91,15 @@ _COAUTHOR_TRAILER = (
 )
 _SUBMIT_TIMEOUT = 90
 _PUSH_RETRIES = 3
+
+# The classic-token creation URL with the required scope + description
+# pre-filled. Fine-grained tokens (github_pat_…) can't push to or open PRs
+# on public repos the owner doesn't own, so contributing upstream needs a
+# classic token with public_repo — this link creates exactly that.
+_CLASSIC_TOKEN_URL = (
+  "https://github.com/settings/tokens/new"
+  "?scopes=public_repo&description=Mobius%20Contribute"
+)
 
 
 class GithubTokenRequest(BaseModel):
@@ -1047,10 +1057,12 @@ async def connect_token(
     raise HTTPException(
       status_code=400,
       detail=(
-        "That is a fine-grained personal access token — GitHub does "
-        "not let those write to public repos you don't own, so it "
-        "can't open pull requests upstream. Use a classic token with "
-        "the public_repo scope (or the device flow)."
+        "That's a fine-grained personal access token (github_pat_…). "
+        "Fine-grained tokens can only reach repositories you own or are "
+        "explicitly granted, so they can't push to or open pull requests "
+        "on the upstream public repos Contribute targets. Create a classic "
+        "token with the public_repo scope instead — this link pre-fills it: "
+        f"{_CLASSIC_TOKEN_URL} (or use the device flow)."
       ),
     )
   if not token:
@@ -1190,6 +1202,472 @@ async def submit_contribution(
       record_patch=record_patch,
     )
   return {"record": submitted, "url": pr_url, "number": number}
+
+
+# --- contribution CI feedback (checks refresh + classification) -------
+#
+# THE `checks` CONTRACT (feature 196). Written onto a contribution record
+# under the top-level `checks` key, ORTHOGONAL to the lifecycle `status`
+# enum — a record can be `open` with failing `checks`, and refreshing
+# checks never advances the lifecycle. The Contribute app UI reads this
+# shape, so it is a stable contract; extend it additively.
+#
+#   "checks": {
+#     "state":       overall statusCheckRollup state — one of
+#                    "SUCCESS" | "FAILURE" | "PENDING" | "ERROR" |
+#                    "EXPECTED" | null (null = no checks reported yet),
+#     "head_sha":    the PR head commit these results were observed at,
+#     "pr_state":    "OPEN" | "MERGED" | "CLOSED" (PR lifecycle on GitHub,
+#                    NOT the ledger status),
+#     "base_ref":    upstream base branch the PR targets (e.g. "main"),
+#     "jobs": [ {
+#         "name":          check/context name (e.g. "e2e"),
+#         "conclusion":    "SUCCESS" | "FAILURE" | "TIMED_OUT" | ... | null
+#                          (null = still running),
+#         "status":        CheckRun status ("COMPLETED"/"IN_PROGRESS"/…) or
+#                          null for legacy StatusContexts,
+#         "url":           details URL for the run/context,
+#         "classification": present ONLY on failing jobs — "inherited"
+#                          (same-named check also red on upstream base),
+#                          "suspect-pr-caused" (green on base, red here), or
+#                          "unknown" (base data unavailable),
+#     } ],
+#     "observed_at": ISO-8601 timestamp of this refresh,
+#     "notified_sha": last head SHA a failure notification fired for; the
+#                     dedupe key so one red result notifies exactly once.
+#   }
+
+# A PR whose checks we still track. Merged/closed PRs and non-PR records
+# are skipped — a merged PR's red check is moot.
+_ACTIVE_PR_STATUSES = frozenset({"open", "draft"})
+
+# Check conclusions that count as red. GraphQL reports these uppercase; the
+# REST check-runs API reports them lowercase, so `_is_failing` uppercases
+# before comparing and both sources land here. CANCELLED is deliberately
+# excluded: a cancelled run is inconclusive, not a failure.
+_FAILING_CONCLUSIONS = frozenset({
+  "FAILURE", "ERROR", "TIMED_OUT", "STARTUP_FAILURE", "ACTION_REQUIRED",
+})
+
+_CLASSIFICATION_PHRASE = {
+  "inherited": "inherited (also red on upstream main)",
+  "suspect-pr-caused": "suspect (PR-caused)",
+  "unknown": "unclassified",
+}
+
+# One batched GraphQL round-trip fetches statusCheckRollup for every tracked
+# PR head. Aliases (pr0, pr1, …) and per-alias variables ($pr0o/$pr0n/$pr0p)
+# keep repo owner/name/number out of the query string (no injection) while
+# following github.py's existing variables-not-interpolation idiom.
+_PR_CHECKS_FRAGMENT = """
+fragment prChecks on PullRequest {
+  number
+  state
+  isDraft
+  baseRefName
+  url
+  commits(last: 1) {
+    nodes {
+      commit {
+        oid
+        statusCheckRollup {
+          state
+          contexts(first: 100) {
+            nodes {
+              __typename
+              ... on CheckRun { name conclusion status detailsUrl }
+              ... on StatusContext { context state targetUrl }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+""".strip()
+
+
+def _contributions_dir(app_id: int) -> Path:
+  return Path(get_settings().data_dir) / "apps" / str(app_id) / "contributions"
+
+
+def _read_record_tolerant(path: Path) -> dict | None:
+  """Reads a contribution record, returning None (not raising) on a missing
+  or corrupt file so one bad record can't abort a whole refresh sweep."""
+  try:
+    data = json.loads(path.read_text(encoding="utf-8"))
+  except (OSError, ValueError):
+    return None
+  return data if isinstance(data, dict) else None
+
+
+def _is_failing(conclusion: object) -> bool:
+  return str(conclusion or "").upper() in _FAILING_CONCLUSIONS
+
+
+def _pr_ref(record: dict) -> tuple[str, int] | None:
+  """Returns (upstream_repo, pr_number) for a trackable PR record, else None."""
+  repo = record.get("repo") or (record.get("plan") or {}).get("repo")
+  if not isinstance(repo, str) or not _GITHUB_REPO.match(repo):
+    return None
+  try:
+    number = int(record.get("number"))
+  except (TypeError, ValueError):
+    return None
+  if number <= 0:
+    return None
+  return repo, number
+
+
+def _active_pr_records(app_id: int) -> list[tuple[str, Path, str, int]]:
+  """Returns (record_id, path, upstream_repo, pr_number) for every open/draft
+  PR record with a durable PR number, sorted by record id for stable aliasing."""
+  out: list[tuple[str, Path, str, int]] = []
+  base = _contributions_dir(app_id)
+  if not base.is_dir():
+    return out
+  for path in sorted(base.glob("*.json")):
+    record = _read_record_tolerant(path)
+    if record is None:
+      continue
+    if record.get("status") not in _ACTIVE_PR_STATUSES:
+      continue
+    if record.get("type") != "pr":
+      continue
+    ref = _pr_ref(record)
+    if ref is None:
+      continue
+    out.append((path.stem, path, ref[0], ref[1]))
+  return out
+
+
+def _build_pr_checks_query(
+  refs: list[tuple[str, str, str, int]],
+) -> tuple[str, dict]:
+  """Builds the batched checks query from (alias, owner, name, number) refs.
+
+  Pure so it is unit-testable without the network. Each ref becomes an
+  aliased `repository(...) { pullRequest(...) { ...prChecks } }` selection
+  driven by its own String!/Int! variables.
+  """
+  var_decls: list[str] = []
+  selections: list[str] = []
+  variables: dict = {}
+  for alias, owner, name, number in refs:
+    var_decls.append(f"${alias}o: String!, ${alias}n: String!, ${alias}p: Int!")
+    variables[f"{alias}o"] = owner
+    variables[f"{alias}n"] = name
+    variables[f"{alias}p"] = number
+    selections.append(
+      f"  {alias}: repository(owner: ${alias}o, name: ${alias}n) "
+      f"{{ pullRequest(number: ${alias}p) {{ ...prChecks }} }}"
+    )
+  query = (
+    "query(" + ", ".join(var_decls) + ") {\n"
+    + "\n".join(selections)
+    + "\n}\n\n"
+    + _PR_CHECKS_FRAGMENT
+  )
+  return query, variables
+
+
+def _normalize_context(ctx: dict) -> dict | None:
+  """Flattens a statusCheckRollup context (CheckRun or legacy StatusContext)
+  into the uniform job shape the `checks` contract stores."""
+  kind = ctx.get("__typename")
+  if kind == "CheckRun":
+    return {
+      "name": ctx.get("name") or "",
+      "conclusion": ctx.get("conclusion"),
+      "status": ctx.get("status"),
+      "url": ctx.get("detailsUrl"),
+    }
+  if kind == "StatusContext":
+    # A commit status has no separate conclusion; its state IS the outcome.
+    return {
+      "name": ctx.get("context") or "",
+      "conclusion": ctx.get("state"),
+      "status": None,
+      "url": ctx.get("targetUrl"),
+    }
+  return None
+
+
+def _parse_rollup(pr_node: object) -> dict | None:
+  """Parses one `pullRequest` GraphQL node into the fields the `checks`
+  field is built from, or None when the PR could not be resolved."""
+  if not isinstance(pr_node, dict):
+    return None
+  nodes = ((pr_node.get("commits") or {}).get("nodes")) or []
+  commit = nodes[-1].get("commit") if nodes and isinstance(nodes[-1], dict) else None
+  commit = commit if isinstance(commit, dict) else {}
+  rollup = commit.get("statusCheckRollup")
+  rollup = rollup if isinstance(rollup, dict) else {}
+  contexts = ((rollup.get("contexts") or {}).get("nodes")) or []
+  jobs: list[dict] = []
+  for ctx in contexts:
+    norm = _normalize_context(ctx) if isinstance(ctx, dict) else None
+    if norm and norm["name"]:
+      jobs.append(norm)
+  return {
+    "pr_state": pr_node.get("state"),
+    "is_draft": bool(pr_node.get("isDraft")),
+    "base_ref": pr_node.get("baseRefName"),
+    "pr_url": pr_node.get("url"),
+    "head_sha": commit.get("oid"),
+    "rollup_state": rollup.get("state"),
+    "jobs": jobs,
+  }
+
+
+def _classify_jobs(jobs: list[dict], base_failing_names: set | None) -> None:
+  """Annotates each FAILING job in place with a `classification`.
+
+  `base_failing_names` is the set of check names red on the upstream base
+  branch, or None when that data could not be fetched. A failing check whose
+  name is also red on base is `inherited`; green on base is `suspect-pr-caused`;
+  no base data at all is `unknown`. Passing (or still-running) jobs carry no
+  classification.
+  """
+  for job in jobs:
+    if not _is_failing(job.get("conclusion")):
+      job.pop("classification", None)
+      continue
+    if base_failing_names is None:
+      job["classification"] = "unknown"
+    elif job.get("name") in base_failing_names:
+      job["classification"] = "inherited"
+    else:
+      job["classification"] = "suspect-pr-caused"
+
+
+def _build_checks_field(
+  parsed: dict,
+  base_failing_names: set | None,
+  observed_at: str,
+  prev_notified_sha: str | None,
+) -> dict:
+  """Assembles the persisted `checks` object from a parsed rollup. Carries a
+  prior `notified_sha` forward so an unchanged head keeps its dedupe key."""
+  jobs = [dict(j) for j in parsed["jobs"]]
+  _classify_jobs(jobs, base_failing_names)
+  checks: dict = {
+    "state": parsed.get("rollup_state"),
+    "head_sha": parsed.get("head_sha"),
+    "pr_state": parsed.get("pr_state"),
+    "base_ref": parsed.get("base_ref"),
+    "jobs": jobs,
+    "observed_at": observed_at,
+  }
+  if prev_notified_sha:
+    checks["notified_sha"] = prev_notified_sha
+  return checks
+
+
+def _should_notify_failure(
+  parsed: dict, checks: dict, prev_notified_sha: str | None,
+) -> bool:
+  """A failure notification fires only for an OPEN PR whose head is newly red
+  (a head SHA we have not already notified for)."""
+  head = parsed.get("head_sha")
+  return bool(
+    parsed.get("pr_state") == "OPEN"
+    and head
+    and head != prev_notified_sha
+    and any(_is_failing(j.get("conclusion")) for j in checks["jobs"])
+  )
+
+
+def _checks_failure_notification(record: dict, checks: dict) -> dict:
+  """Builds the owner/agent notification payload for a newly-red PR.
+
+  Self-contained by design: a memory-less follow-up session must be able to
+  act from repo + PR number + head SHA + each failing job's name, URL, and
+  inherited-vs-suspect verdict alone.
+  """
+  repo = record.get("repo") or (record.get("plan") or {}).get("repo") or ""
+  number = record.get("number")
+  head = checks.get("head_sha") or ""
+  url = record.get("url") or (
+    f"https://github.com/{repo}/pull/{number}" if repo and number else ""
+  )
+  failing = [j for j in checks["jobs"] if _is_failing(j.get("conclusion"))]
+  lines = [f"{repo}#{number} at {head[:7]} — {len(failing)} check(s) red."]
+  for job in failing:
+    phrase = _CLASSIFICATION_PHRASE.get(job.get("classification"), "unclassified")
+    detail = f"{job.get('name')} — {phrase}"
+    if job.get("url"):
+      detail += f": {job['url']}"
+    lines.append(detail)
+  return {
+    "title": f"PR checks failing: {repo}#{number}",
+    "body": "\n".join(lines),
+    "target": url or None,
+    "actions": [{"action": "open-pr", "title": "Open PR", "target": url}]
+    if url else None,
+  }
+
+
+async def _github_graphql_json(token: str, query: str, variables: dict) -> dict | None:
+  """Server-side GraphQL call for the refresh sweep. Returns the `data`
+  object, or None on any transport/HTTP/parse failure (a refresh degrades
+  gracefully rather than 500ing). The token stays in the Authorization
+  header and never reaches a response or log line (INV1)."""
+  async with httpx.AsyncClient(follow_redirects=False, timeout=20) as client:
+    try:
+      r = await client.post(
+        f"{_API_BASE}/graphql",
+        json={"query": query, "variables": variables},
+        headers={
+          "Authorization": f"Bearer {token}",
+          "Accept": "application/json",
+          "User-Agent": "mobius",
+        },
+      )
+    except httpx.HTTPError:
+      return None
+  if r.status_code != 200:
+    return None
+  try:
+    body = r.json()
+  except ValueError:
+    return None
+  data = body.get("data") if isinstance(body, dict) else None
+  return data if isinstance(data, dict) else None
+
+
+async def _fetch_base_failing_names(
+  token: str, repo: str, base_ref: str,
+) -> set | None:
+  """Returns the set of check names currently red on the upstream base
+  branch (one REST call), or None if the data is unavailable — the signal
+  `_classify_jobs` uses to mark a failing check inherited vs suspect."""
+  path = f"repos/{repo}/commits/{quote(base_ref, safe='')}/check-runs?per_page=100"
+  async with httpx.AsyncClient(follow_redirects=False, timeout=20) as client:
+    try:
+      r = await client.get(
+        f"{_API_BASE}/{path}",
+        headers={
+          "Authorization": f"Bearer {token}",
+          "Accept": "application/vnd.github+json",
+          "User-Agent": "mobius",
+        },
+      )
+    except httpx.HTTPError:
+      return None
+  if r.status_code != 200:
+    return None
+  try:
+    body = r.json()
+  except ValueError:
+    return None
+  runs = body.get("check_runs") if isinstance(body, dict) else None
+  if not isinstance(runs, list):
+    return None
+  return {
+    run.get("name")
+    for run in runs
+    if isinstance(run, dict) and run.get("name") and _is_failing(run.get("conclusion"))
+  }
+
+
+@router.post(
+  "/contributions/{app_id}/refresh",
+  dependencies=[Depends(reject_cross_site)],
+)
+@_limiter.limit("20/minute")
+async def refresh_contribution_checks(
+  request: Request,
+  app_id: int,
+  db: Session = Depends(get_db),
+  principal: Principal = Depends(get_principal),
+):
+  """Refresh CI check results for the app's tracked pull requests.
+
+  Both the Contribute app's live refresh and the hourly cron job hit this:
+  it batches one statusCheckRollup GraphQL query across every open/draft PR
+  record, classifies each failing job against the upstream base branch, writes
+  the `checks` object onto each record (orthogonal to the lifecycle status),
+  and fires ONE owner notification per newly-red PR head. The GitHub token is
+  read server-side and never returned to the caller.
+  """
+  _validate_submit_app(app_id, principal, db)
+  token = github_auth.get_token()
+  if not token:
+    raise HTTPException(status_code=401, detail="GitHub not connected.")
+
+  records = _active_pr_records(app_id)
+  if not records:
+    return {"refreshed": [], "notified": 0}
+
+  refs = [
+    (f"pr{i}", repo.split("/", 1)[0], repo.split("/", 1)[1], number)
+    for i, (_, _, repo, number) in enumerate(records)
+  ]
+  query, variables = _build_pr_checks_query(refs)
+  data = await _github_graphql_json(token, query, variables)
+
+  # Parse first, then fetch base check-runs only for repos that actually have
+  # a failing job — cached per (repo, base_ref) so N red PRs on one repo cost
+  # one REST call, not N. All network happens BEFORE the storage lock.
+  parsed_by_index: dict[int, dict | None] = {}
+  base_cache: dict[tuple[str, str], set | None] = {}
+  for i, (_, _, repo, _number) in enumerate(records):
+    node = (data or {}).get(f"pr{i}")
+    pr_node = node.get("pullRequest") if isinstance(node, dict) else None
+    parsed = _parse_rollup(pr_node)
+    parsed_by_index[i] = parsed
+    if parsed is None:
+      continue
+    base_ref = parsed.get("base_ref")
+    if base_ref and any(_is_failing(j.get("conclusion")) for j in parsed["jobs"]):
+      key = (repo, base_ref)
+      if key not in base_cache:
+        base_cache[key] = await _fetch_base_failing_names(token, repo, base_ref)
+
+  observed_at = _now_iso()
+  results: list[dict] = []
+  pending_notifications: list[dict] = []
+  async with fs_locks.app_storage_lock(app_id):
+    for i, (record_id, path, repo, _number) in enumerate(records):
+      parsed = parsed_by_index[i]
+      if parsed is None:
+        continue
+      # Re-read under the lock: submit (or a sibling refresh) may have rewritten
+      # the record since the pre-network read.
+      record = _read_record_tolerant(path)
+      if record is None:
+        continue
+      prev_checks = record.get("checks")
+      prev_notified = (
+        prev_checks.get("notified_sha") if isinstance(prev_checks, dict) else None
+      )
+      base_failing = base_cache.get((repo, parsed.get("base_ref")))
+      checks = _build_checks_field(parsed, base_failing, observed_at, prev_notified)
+      notify = _should_notify_failure(parsed, checks, prev_notified)
+      if notify:
+        checks["notified_sha"] = parsed["head_sha"]
+      record["checks"] = checks
+      _write_record(path, record)
+      results.append({"id": record_id, "checks": checks})
+      if notify:
+        pending_notifications.append(_checks_failure_notification(record, checks))
+
+  # Notifications fire after the storage lock releases — notify_owner owns its
+  # own DB commit and Web Push delivery, mirroring the merged-PR notify path.
+  for payload in pending_notifications:
+    notify_owner(
+      db,
+      principal.owner.id,
+      title=payload["title"],
+      body=payload["body"],
+      source_type="app",
+      source_id=str(app_id),
+      target=payload["target"],
+      actions=payload["actions"],
+    )
+
+  return {"refreshed": results, "notified": len(pending_notifications)}
 
 
 async def _forward_capped(

--- a/backend/tests/test_github_routes.py
+++ b/backend/tests/test_github_routes.py
@@ -325,7 +325,12 @@ def test_connect_token_rejects_fine_grained(client, auth):
   r = client.post("/api/github/connect/token",
                   json={"token": "github_pat_11ABCDEF_secret"}, headers=auth)
   assert r.status_code == 400
-  assert "fine-grained" in r.json()["detail"]
+  detail = r.json()["detail"]
+  assert "fine-grained" in detail
+  # The rejection is actionable: it links straight to the classic-token
+  # creation page with the required scope pre-filled, and says why.
+  assert "https://github.com/settings/tokens/new" in detail
+  assert "scopes=public_repo" in detail
 
 
 def test_connect_token_rejects_missing_scope(client, auth, monkeypatch):
@@ -1433,3 +1438,320 @@ def test_submit_contribution_rolls_back_unready_record(
   )
   assert stored["status"] == "prepared"
   assert "last_submit_error" in stored
+
+
+# --- contribution CI feedback loop (checks refresh + classification) ---
+
+
+_HEAD_SHA = "f" * 40
+
+
+def _pr_node(
+  *, number=4, state="OPEN", is_draft=False, base_ref="main",
+  head_sha=_HEAD_SHA, rollup_state="FAILURE", contexts=None,
+):
+  """A statusCheckRollup GraphQL `pullRequest` node for the mock transport."""
+  if contexts is None:
+    contexts = [
+      {"__typename": "CheckRun", "name": "e2e", "conclusion": "FAILURE",
+       "status": "COMPLETED",
+       "detailsUrl": "https://github.com/mobius-os/app-demo/runs/e2e"},
+      {"__typename": "CheckRun", "name": "core-apps-sync",
+       "conclusion": "FAILURE", "status": "COMPLETED",
+       "detailsUrl": "https://github.com/mobius-os/app-demo/runs/cas"},
+      {"__typename": "CheckRun", "name": "backend", "conclusion": "SUCCESS",
+       "status": "COMPLETED",
+       "detailsUrl": "https://github.com/mobius-os/app-demo/runs/be"},
+    ]
+  rollup = None
+  if rollup_state is not None or contexts:
+    rollup = {"state": rollup_state, "contexts": {"nodes": contexts}}
+  return {
+    "number": number,
+    "state": state,
+    "isDraft": is_draft,
+    "baseRefName": base_ref,
+    "url": f"https://github.com/mobius-os/app-demo/pull/{number}",
+    "commits": {"nodes": [{"commit": {
+      "oid": head_sha,
+      "statusCheckRollup": rollup,
+    }}]},
+  }
+
+
+def test_parse_rollup_extracts_jobs_head_and_state():
+  from app.routes.github import _parse_rollup
+
+  parsed = _parse_rollup(_pr_node(contexts=[
+    {"__typename": "CheckRun", "name": "e2e", "conclusion": "FAILURE",
+     "status": "COMPLETED", "detailsUrl": "https://x/runs/e2e"},
+    {"__typename": "StatusContext", "context": "legacy-ci", "state": "SUCCESS",
+     "targetUrl": "https://x/status/legacy"},
+    {"__typename": "CheckRun", "name": "", "conclusion": "SUCCESS"},
+  ]))
+  assert parsed["pr_state"] == "OPEN"
+  assert parsed["head_sha"] == _HEAD_SHA
+  assert parsed["base_ref"] == "main"
+  assert parsed["rollup_state"] == "FAILURE"
+  by_name = {j["name"]: j for j in parsed["jobs"]}
+  # Nameless contexts are dropped; both CheckRun and StatusContext normalize.
+  assert set(by_name) == {"e2e", "legacy-ci"}
+  assert by_name["e2e"]["conclusion"] == "FAILURE"
+  assert by_name["e2e"]["url"] == "https://x/runs/e2e"
+  assert by_name["legacy-ci"]["conclusion"] == "SUCCESS"
+  assert by_name["legacy-ci"]["url"] == "https://x/status/legacy"
+
+
+def test_parse_rollup_handles_missing_pr_and_empty_rollup():
+  from app.routes.github import _parse_rollup
+
+  assert _parse_rollup(None) is None
+  assert _parse_rollup("nope") is None
+  # PR with no checks reported yet: resolvable, but zero jobs, null state.
+  empty = _parse_rollup(_pr_node(rollup_state=None, contexts=[]))
+  assert empty["jobs"] == []
+  assert empty["rollup_state"] is None
+  assert empty["head_sha"] == _HEAD_SHA
+
+
+def test_classify_jobs_inherited_suspect_unknown():
+  from app.routes.github import _classify_jobs
+
+  jobs = [
+    {"name": "e2e", "conclusion": "FAILURE"},
+    {"name": "core-apps-sync", "conclusion": "FAILURE"},
+    {"name": "backend", "conclusion": "SUCCESS"},
+  ]
+  # core-apps-sync is also red on base → inherited; e2e is green on base →
+  # suspect; passing jobs get no classification.
+  _classify_jobs(jobs, {"core-apps-sync"})
+  assert jobs[0]["classification"] == "suspect-pr-caused"
+  assert jobs[1]["classification"] == "inherited"
+  assert "classification" not in jobs[2]
+
+  # No base data at all → every failing job is unknown.
+  unknown = [{"name": "e2e", "conclusion": "FAILURE"}]
+  _classify_jobs(unknown, None)
+  assert unknown[0]["classification"] == "unknown"
+
+  # Empty base set (base is green) → the failure is suspect, not inherited.
+  suspect = [{"name": "e2e", "conclusion": "FAILURE"}]
+  _classify_jobs(suspect, set())
+  assert suspect[0]["classification"] == "suspect-pr-caused"
+
+
+def test_build_pr_checks_query_aliases_and_variables():
+  from app.routes.github import _build_pr_checks_query
+
+  query, variables = _build_pr_checks_query([
+    ("pr0", "mobius-os", "app-demo", 4),
+    ("pr1", "mobius-os", "app-notes", 7),
+  ])
+  assert variables == {
+    "pr0o": "mobius-os", "pr0n": "app-demo", "pr0p": 4,
+    "pr1o": "mobius-os", "pr1n": "app-notes", "pr1p": 7,
+  }
+  assert "pr0: repository(owner: $pr0o, name: $pr0n)" in query
+  assert "pullRequest(number: $pr0p)" in query
+  assert "pr1: repository(owner: $pr1o, name: $pr1n)" in query
+  assert "fragment prChecks on PullRequest" in query
+  # No repo slug is interpolated into the query text (injection guard).
+  assert "app-demo" not in query
+
+
+def test_checks_failure_notification_payload_is_self_contained():
+  from app.routes.github import _checks_failure_notification
+
+  record = {
+    "repo": "mobius-os/app-demo", "number": 4,
+    "url": "https://github.com/mobius-os/app-demo/pull/4",
+  }
+  checks = {
+    "head_sha": _HEAD_SHA,
+    "jobs": [
+      {"name": "e2e", "conclusion": "FAILURE",
+       "classification": "suspect-pr-caused",
+       "url": "https://github.com/mobius-os/app-demo/runs/e2e"},
+      {"name": "core-apps-sync", "conclusion": "FAILURE",
+       "classification": "inherited",
+       "url": "https://github.com/mobius-os/app-demo/runs/cas"},
+      {"name": "backend", "conclusion": "SUCCESS"},
+    ],
+  }
+  n = _checks_failure_notification(record, checks)
+  assert n["title"] == "PR checks failing: mobius-os/app-demo#4"
+  # repo, PR number, head SHA, per-job name + URL + classification all present.
+  assert "mobius-os/app-demo#4" in n["body"]
+  assert "fffffff" in n["body"]
+  assert "e2e — suspect (PR-caused)" in n["body"]
+  assert "core-apps-sync — inherited (also red on upstream main)" in n["body"]
+  assert "https://github.com/mobius-os/app-demo/runs/e2e" in n["body"]
+  # Passing jobs are not surfaced as failures.
+  assert "backend" not in n["body"]
+  assert n["target"] == record["url"]
+  assert n["actions"][0]["target"] == record["url"]
+
+
+def _write_open_pr_record(app_id, record_id="rec-open-pr", number=4):
+  record = {
+    "id": record_id,
+    "type": "pr",
+    "repo": "mobius-os/app-demo",
+    "status": "open",
+    "number": number,
+    "url": f"https://github.com/mobius-os/app-demo/pull/{number}",
+    "branch": "fix/demo",
+    "plan": {"action": "pr", "repo": "mobius-os/app-demo"},
+  }
+  _write_contribution(app_id, record_id, record)
+  return record_id
+
+
+def _checks_refresh_handler(seen, *, pr_node=None):
+  if pr_node is None:
+    pr_node = _pr_node()
+
+  def handler(request):
+    url = str(request.url)
+    if url == "https://api.github.com/graphql" and request.method == "POST":
+      seen["graphql"] = json.loads(request.content)
+      assert request.headers.get("authorization") == "Bearer gh-checks-tok"
+      return httpx.Response(200, json={"data": {"pr0": {"pullRequest": pr_node}}})
+    if (
+      request.method == "GET"
+      and url.startswith(
+        "https://api.github.com/repos/mobius-os/app-demo/commits/main/check-runs"
+      )
+    ):
+      seen["base_calls"] = seen.get("base_calls", 0) + 1
+      # core-apps-sync is red on main (inherited); e2e is green (suspect).
+      return httpx.Response(200, json={"check_runs": [
+        {"name": "core-apps-sync", "conclusion": "failure"},
+        {"name": "e2e", "conclusion": "success"},
+        {"name": "backend", "conclusion": "success"},
+      ]})
+    return _fail(request)
+
+  return handler
+
+
+def _stored_checks(app_id, record_id):
+  return json.loads(
+    (Path(get_settings().data_dir) / "apps" / str(app_id) /
+     "contributions" / f"{record_id}.json").read_text()
+  )["checks"]
+
+
+def _all_notifications():
+  from app import models
+  from app.database import SessionLocal
+  s = SessionLocal()
+  try:
+    return s.query(models.Notification).all()
+  finally:
+    s.close()
+
+
+def test_refresh_requires_github_connection(client, owner_token):
+  app_id, _ = _app_token(client, owner_token, github_access=True)
+  r = client.post(f"/api/github/contributions/{app_id}/refresh",
+                  headers={"Authorization": f"Bearer {owner_token}"})
+  assert r.status_code == 401
+  assert "not connected" in r.json()["detail"].lower()
+
+
+def test_refresh_no_records_is_noop(client, owner_token, monkeypatch):
+  _write_token(token="gh-checks-tok")
+  app_id, _ = _app_token(client, owner_token, github_access=True)
+  # No upstream call should happen when there are no tracked PRs.
+  _install_mock_transport(monkeypatch, _fail)
+  r = client.post(f"/api/github/contributions/{app_id}/refresh",
+                  headers={"Authorization": f"Bearer {owner_token}"})
+  assert r.status_code == 200
+  assert r.json() == {"refreshed": [], "notified": 0}
+
+
+def test_refresh_persists_checks_classifies_and_notifies(
+  client, owner_token, monkeypatch,
+):
+  _write_token(token="gh-checks-tok")
+  app_id, _ = _app_token(client, owner_token, github_access=True)
+  record_id = _write_open_pr_record(app_id)
+  seen = {}
+  _install_mock_transport(monkeypatch, _checks_refresh_handler(seen))
+
+  r = client.post(f"/api/github/contributions/{app_id}/refresh",
+                  headers={"Authorization": f"Bearer {owner_token}"})
+  assert r.status_code == 200, r.text
+  body = r.json()
+  assert body["notified"] == 1
+  assert len(body["refreshed"]) == 1
+
+  # The batched query carried the PR ref as a variable, not interpolated.
+  assert seen["graphql"]["variables"]["pr0p"] == 4
+
+  checks = _stored_checks(app_id, record_id)
+  assert checks["state"] == "FAILURE"
+  assert checks["head_sha"] == _HEAD_SHA
+  assert checks["pr_state"] == "OPEN"
+  assert checks["base_ref"] == "main"
+  assert checks["notified_sha"] == _HEAD_SHA
+  by_name = {j["name"]: j for j in checks["jobs"]}
+  assert by_name["e2e"]["classification"] == "suspect-pr-caused"
+  assert by_name["core-apps-sync"]["classification"] == "inherited"
+  # Passing jobs carry no classification.
+  assert "classification" not in by_name["backend"]
+
+  notes = _all_notifications()
+  assert len(notes) == 1
+  assert notes[0].source_type == "app"
+  assert notes[0].source_id == str(app_id)
+  assert "core-apps-sync — inherited" in notes[0].body
+  assert "e2e — suspect" in notes[0].body
+  assert notes[0].target == "https://github.com/mobius-os/app-demo/pull/4"
+
+
+def test_refresh_dedupes_notification_on_unchanged_head(
+  client, owner_token, monkeypatch,
+):
+  _write_token(token="gh-checks-tok")
+  app_id, _ = _app_token(client, owner_token, github_access=True)
+  _write_open_pr_record(app_id)
+  seen = {}
+  _install_mock_transport(monkeypatch, _checks_refresh_handler(seen))
+
+  first = client.post(f"/api/github/contributions/{app_id}/refresh",
+                      headers={"Authorization": f"Bearer {owner_token}"})
+  assert first.json()["notified"] == 1
+  # Second refresh, same red head SHA — must NOT re-notify (dedupe on
+  # checks.notified_sha), and base check-runs are cached per repo per call.
+  second = client.post(f"/api/github/contributions/{app_id}/refresh",
+                       headers={"Authorization": f"Bearer {owner_token}"})
+  assert second.status_code == 200
+  assert second.json()["notified"] == 0
+  assert len(_all_notifications()) == 1
+
+
+def test_refresh_skips_non_open_and_success_without_notifying(
+  client, owner_token, monkeypatch,
+):
+  _write_token(token="gh-checks-tok")
+  app_id, _ = _app_token(client, owner_token, github_access=True)
+  record_id = _write_open_pr_record(app_id)
+  # All green: checks persist, base branch is never queried, nothing notifies.
+  green = _pr_node(rollup_state="SUCCESS", contexts=[
+    {"__typename": "CheckRun", "name": "e2e", "conclusion": "SUCCESS",
+     "status": "COMPLETED", "detailsUrl": "https://x/runs/e2e"},
+  ])
+  seen = {}
+  _install_mock_transport(monkeypatch, _checks_refresh_handler(seen, pr_node=green))
+
+  r = client.post(f"/api/github/contributions/{app_id}/refresh",
+                  headers={"Authorization": f"Bearer {owner_token}"})
+  assert r.status_code == 200
+  assert r.json()["notified"] == 0
+  assert seen.get("base_calls", 0) == 0
+  checks = _stored_checks(app_id, record_id)
+  assert checks["state"] == "SUCCESS"
+  assert "notified_sha" not in checks
+  assert _all_notifications() == []


### PR DESCRIPTION
Closes the contribution CI-blindness gap (feature 196 items 1-3): agent-opened PRs #4/#5 sat red on core-apps-sync/e2e with no surface ever saying so — the refresh fetched only PR state, the ledger had no notion of checks, and the submitting agent's turn ended at "PR opened".

## What changed
- **Checks fetch** — new `POST /api/github/contributions/{app_id}/refresh` (serves both the Contribute app's live refresh and the hourly cron): ONE batched GraphQL query per sweep (aliased `pr0/pr1/…`, repo/number passed as GraphQL variables, never interpolated) fetching `statusCheckRollup` per PR head. `_parse_rollup` normalizes both CheckRun and legacy StatusContext contexts.
- **`checks` persisted on the ledger record** — orthogonal to the lifecycle `status` enum, documented as a stable contract in the comment block above `_ACTIVE_PR_STATUSES`: `state`, `head_sha`, `pr_state`, `base_ref`, `jobs[].{name,conclusion,status,url,classification}`, `observed_at`, `notified_sha`.
- **Classification + notification** — one cached REST call per (repo, base_ref) fetches check runs on the upstream base: same job red on base → `inherited`, green on base → `suspect-pr-caused`, no data → `unknown`. Failure notifications ride the existing `notify_owner` push path, fire once per newly-red head SHA (dedupe on `notified_sha`), and carry repo, PR#, head SHA, failing jobs + URLs + classification — self-contained for a memoryless follow-up session.
- **Papercut:** `connect_token` still rejects fine-grained `github_pat_` tokens but now says why and links the classic-token creation URL with `public_repo` scope pre-filled.

## Invariants respected
Token never appears in responses/logs; no host-side rebasing of fork PR branches; network I/O completes before the storage lock and records are re-read under `fs_locks.app_storage_lock` (no lost updates against a concurrent submit); CANCELLED conclusions treated as inconclusive, not red.

## Tests
`wt-pytest tests/test_github_routes.py -q` → **48 passed** post-rebase onto current main (incl. PR #10's fork-handling tests). 10 new tests: rollup parsing, classification, batched-query build (no-interpolation guard), notification payload self-containment, endpoint auth/edge cases, end-to-end persistence + classify + notify, head-SHA dedupe, green-checks skip.

## Remaining 196 scope (deferred as specced)
Fix-loop safety flow, pre-PR validation matrix + `local-pr-check.sh`, submit-flow paper cuts (diff_format_version, submitting lease, head_repository), upstream repo hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)