### PR TITLE
Fix reflection Codex cron import + memory-search silent-failure fallback

### DIFF
--- a/backend/scripts/memory_search.py
+++ b/backend/scripts/memory_search.py
@@ -181,17 +181,29 @@ class SearchRunResult(NamedTuple):
   stderr: str
   returncode: int
   read_ids: list[str]
+  # The result event's own error flag. The Claude CLI mislabels a 401
+  # ResultMessage as subtype="success" while setting is_error=True and can exit
+  # 0, so the exit code alone reads that failed run as a success — is_error is
+  # the reliable structured signal (recovery_chat_runner reads the same field).
+  # Codex has no equivalent in its output file, so it stays False and relies on
+  # the exit code, which is trustworthy for that CLI.
+  is_error: bool = False
 
 
-def _is_provider_failure(text: str, returncode: int = 1) -> bool:
-  """True when a failed CLI result looks like auth/usage/provider trouble.
+def _is_provider_failure(
+  text: str, returncode: int = 1, is_error: bool = False
+) -> bool:
+  """True when a CLI result looks like auth/usage/provider trouble.
 
   The memory-search helper is best-effort, but provider exhaustion is exactly
-  when trying the configured fallback is valuable. Keep this conservative:
-  ordinary "No relevant memories" is a successful search, while nonzero CLI
-  exits or familiar auth/usage strings can move to the fallback.
+  when trying the configured fallback is valuable. A run failed if the process
+  exited nonzero OR the result event carried is_error (the exit-0-with-error
+  case the Claude CLI produces on a 401). A clean run (exit 0, not is_error) is
+  scanned only for familiar auth/usage strings in its stderr — never its
+  synthesis text, so a legitimate memory that mentions "rate limit" can't be
+  misread as a failure.
   """
-  if returncode != 0:
+  if returncode != 0 or is_error:
     return True
   low = (text or "").lower()
   return any(marker in low for marker in (*_AUTH_FAILURE_MARKERS, *_USAGE_LIMIT_MARKERS))
@@ -294,9 +306,12 @@ def _resolve_search_agents() -> list[dict]:
   return choices or [{"provider": "claude", "model": DEFAULT_CLAUDE_MODEL, "effort": None}]
 
 
-def _extract_read_ids_from_claude_stdout(stdout: str) -> tuple[str, list[str]]:
+def _extract_read_ids_from_claude_stdout(
+  stdout: str,
+) -> tuple[str, list[str], bool]:
   read_ids: list[str] = []
   final_text = ""
+  is_error = False
   for line in stdout.splitlines():
     line = line.strip()
     if not line:
@@ -320,11 +335,13 @@ def _extract_read_ids_from_claude_stdout(stdout: str) -> tuple[str, list[str]]:
               read_ids.append(nid)
     elif typ == "result":
       final_text = obj.get("result") or final_text
+      # is_error is the one honest signal on a 401 the CLI exits 0 for.
+      is_error = bool(obj.get("is_error"))
 
   for nid in _sources_to_node_ids(final_text):
     if nid not in read_ids:
       read_ids.append(nid)
-  return final_text, read_ids
+  return final_text, read_ids, is_error
 
 
 def _run_claude_search(choice: dict, prompt: str) -> SearchRunResult:
@@ -368,9 +385,12 @@ def _run_claude_search(choice: dict, prompt: str) -> SearchRunResult:
     text=True,
     timeout=TIMEOUT_SECS,
   )
-  final_text, read_ids = _extract_read_ids_from_claude_stdout(proc.stdout)
+  final_text, read_ids, is_error = _extract_read_ids_from_claude_stdout(
+    proc.stdout
+  )
   return SearchRunResult(
     "claude", final_text, proc.stdout, proc.stderr, proc.returncode, read_ids,
+    is_error,
   )
 
 
@@ -589,7 +609,9 @@ def run() -> int:
         result.stdout,
         result.stderr,
       ])
-      if _is_provider_failure(failure_output, result.returncode):
+      if _is_provider_failure(
+        failure_output, result.returncode, result.is_error
+      ):
         failures.append(f"{provider}: {_failure_snippet(result)}")
         if index + 1 < len(choices):
           sys.stderr.write(

--- a/backend/scripts/reflection_runner.py
+++ b/backend/scripts/reflection_runner.py
@@ -87,6 +87,17 @@ import subprocess
 import sys
 from pathlib import Path
 
+# The Codex background path does `from app.codex_sdk_runner import ...`; the
+# Claude path uses the pip-installed SDK directly, so only Codex needs the
+# `app` package importable. Reflection runs from cron with a near-empty
+# environment and no PYTHONPATH, so sys.path[0] is this scripts/ dir — which
+# holds no `app` package — and that import would raise ModuleNotFoundError,
+# killing the whole Codex primary/fallback night with no brief. Put the package
+# root (the backend dir holding `app`) on sys.path so the import resolves
+# regardless of cwd, exactly as memory_search.py does for its own app.memory
+# imports.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
 # --- Fixed locations (the container's data layout) -------------------
 # These are intentionally hard-coded rather than env-derived: Reflection
 # runs from cron with a near-empty environment, and the wrapper exports

--- a/backend/tests/test_memory_search.py
+++ b/backend/tests/test_memory_search.py
@@ -10,6 +10,7 @@ hint parsing (a flag with no value used to silently become the query text).
 """
 
 import importlib.util
+import json
 import os
 import subprocess
 import sys
@@ -265,6 +266,119 @@ def test_run_falls_back_to_codex_when_claude_is_usage_limited(
   assert cmd[cmd.index("-a") + 1] == "never"
   assert "model_reasoning_effort=\"high\"" in cmd
   assert captured["codex_env"]["CODEX_HOME"] == str(ms.CODEX_HOME)
+
+
+def test_run_falls_back_when_claude_exits_zero_with_an_error_result(
+  monkeypatch, capsys
+):
+  # The Claude CLI mislabels a 401 as subtype="success" and can exit 0 while
+  # setting is_error=True on the result event, with the auth-error string as
+  # the "result" text. Without honoring is_error, run() would accept that blob
+  # as the synthesis and inject the error text into the agent's context as
+  # "memories". The fallback must fire on this class and the error text must
+  # never reach stdout.
+  ms = _load()
+  monkeypatch.setattr(ms, "_path_to_node_id", _identity_path_to_id(ms))
+  monkeypatch.setattr(
+    ms,
+    "_resolve_search_agents",
+    lambda: [
+      {"provider": "claude", "model": "claude-sonnet-4-6", "effort": None},
+      {"provider": "codex", "model": "gpt-5.5", "effort": None},
+    ],
+  )
+  monkeypatch.setattr(ms.sys, "argv", ["memory_search.py", "the request"])
+  providers = []
+
+  error_blob = "Invalid authentication credentials. Please run /login (401)."
+
+  class _Proc:
+    def __init__(self, stdout="", stderr="", returncode=0):
+      self.stdout = stdout
+      self.stderr = stderr
+      self.returncode = returncode
+
+  def _fake_run(cmd, **kwargs):
+    if cmd[0] == ms.CLAUDE_CLI_PATH:
+      providers.append("claude")
+      # exit 0, but the result event flags the error and carries the 401 text.
+      return _Proc(
+        stdout=json.dumps(
+          {"type": "result", "is_error": True, "result": error_blob}
+        )
+        + "\n",
+        returncode=0,
+      )
+    if cmd[0] == ms.CODEX_CLI_PATH:
+      providers.append("codex")
+      Path(cmd[cmd.index("-o") + 1]).write_text(
+        "- Relevant thing (notes/foo).\nSOURCES: notes/foo\n",
+        encoding="utf-8",
+      )
+      return _Proc(stdout='{"type":"result"}\n', returncode=0)
+    raise AssertionError(f"unexpected command: {cmd}")
+
+  monkeypatch.setattr(ms.subprocess, "run", _fake_run)
+
+  assert ms.run() == 0
+  out = capsys.readouterr()
+  assert providers == ["claude", "codex"]
+  # the fallback synthesis is served; the 401 blob is never injected as memory.
+  assert "Relevant thing" in out.out
+  assert error_blob not in out.out
+  assert "provider=codex" in out.err
+
+
+def test_is_provider_failure_honors_is_error_and_markers():
+  ms = _load()
+  # exit 0 + is_error is a failure (the mislabeled-401 case).
+  assert ms._is_provider_failure("clean synthesis", 0, True) is True
+  # a clean run with no auth/usage marker in the scanned text is a success.
+  assert ms._is_provider_failure("clean synthesis", 0, False) is False
+  # an auth marker in the scanned text (stderr) still routes to the fallback.
+  assert ms._is_provider_failure("401 not logged in", 0, False) is True
+
+
+def test_run_accepts_clean_synthesis_that_mentions_a_limit(monkeypatch, capsys):
+  # The false-positive guard for the is_error fix: a clean run (exit 0,
+  # is_error False) whose SYNTHESIS happens to mention "rate limit" must be
+  # served as-is, not misread as a provider failure — run() scans only stderr
+  # on a clean zero exit, never the synthesis text.
+  ms = _load()
+  monkeypatch.setattr(ms, "_path_to_node_id", _identity_path_to_id(ms))
+  monkeypatch.setattr(
+    ms,
+    "_resolve_search_agents",
+    lambda: [
+      {"provider": "claude", "model": "claude-sonnet-4-6", "effort": None},
+      {"provider": "codex", "model": "gpt-5.5", "effort": None},
+    ],
+  )
+  monkeypatch.setattr(ms.sys, "argv", ["memory_search.py", "the request"])
+  providers = []
+  synthesis = "- We once hit a rate limit on provider X (notes/foo)."
+
+  class _Proc:
+    stderr = ""
+    returncode = 0
+
+    def __init__(self, stdout):
+      self.stdout = stdout
+
+  def _fake_run(cmd, **kwargs):
+    if cmd[0] == ms.CLAUDE_CLI_PATH:
+      providers.append("claude")
+      return _Proc(
+        json.dumps({"type": "result", "is_error": False, "result": synthesis})
+        + "\n"
+      )
+    raise AssertionError("fallback must not run for a clean synthesis")
+
+  monkeypatch.setattr(ms.subprocess, "run", _fake_run)
+  assert ms.run() == 0
+  out = capsys.readouterr()
+  assert providers == ["claude"]
+  assert "rate limit" in out.out
 
 
 # --- the constructed CLI command scopes Bash (the HIGH finding) ----------

--- a/backend/tests/test_reflection_runner.py
+++ b/backend/tests/test_reflection_runner.py
@@ -12,10 +12,16 @@ impossible.
 
 from datetime import date
 import json
+import os
+import subprocess
+import sys
+from pathlib import Path
 
 import pytest
 
 import scripts.reflection_runner as dr
+
+RUNNER = Path(dr.__file__).resolve()
 
 
 # ---------------------------------------------------------------------------
@@ -408,6 +414,42 @@ def test_resolve_agents_drops_cross_provider_model(tmp_path, monkeypatch):
     "model": None,
     "effort": None,
   }
+
+
+# ---------------------------------------------------------------------------
+# Codex import seam — the runner is invoked from cron with a near-empty env
+# ---------------------------------------------------------------------------
+
+def test_codex_import_resolves_from_a_foreign_cwd(tmp_path):
+  # The Codex background path does `from app.codex_sdk_runner import ...`, but
+  # cron invokes this runner from cwd /data with no PYTHONPATH and no
+  # SECRET_KEY. Without the module's sys.path fix that import raises
+  # ModuleNotFoundError, _run_codex_session catches it as rc=1 (outside the
+  # 64/65/66 band), the provider fallback never fires, and the guaranteed-brief
+  # rescue re-runs the same dead path — a Codex night silently produces
+  # nothing. Exec the module body (which runs its sys.path.insert) from a cwd
+  # that lacks backend/ on the path, with PYTHONPATH and SECRET_KEY cleared,
+  # then do the real import. Mirrors memory_search's foreign-cwd smoke test.
+  prog = (
+    "import importlib.util\n"
+    f"spec = importlib.util.spec_from_file_location('rr', r'{RUNNER}')\n"
+    "m = importlib.util.module_from_spec(spec)\n"
+    "spec.loader.exec_module(m)\n"
+    "from app.codex_sdk_runner import run_codex_sdk_turn\n"
+    "print('IMPORT_OK')\n"
+  )
+  env = {
+    k: v for k, v in os.environ.items() if k not in ("PYTHONPATH", "SECRET_KEY")
+  }
+  r = subprocess.run(
+    [sys.executable, "-c", prog],
+    cwd=str(tmp_path),
+    env=env,
+    capture_output=True,
+    text=True,
+  )
+  assert "ModuleNotFoundError" not in r.stderr, r.stderr
+  assert "IMPORT_OK" in r.stdout, f"stdout={r.stdout!r} stderr={r.stderr!r}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Two verified bugs from the 2026-07-10 review wave (.pm card 205, "being fixed now" rows):

- **Reflection background Codex path was dead on arrival from cron**: `reflection_runner.py` does `from app.codex_sdk_runner import ...` but cron invokes it with a near-empty env and no PYTHONPATH, so `app` was unimportable → rc=1 (outside the 64/65/66 fallback band) → the guaranteed-brief rescue re-ran the same dead path → Codex-primary/fallback nights silently produced no brief. Fix mirrors `memory_search.py`'s package-root `sys.path.insert`, with a subprocess smoke test that executes the real import from a foreign cwd with `PYTHONPATH`/`SECRET_KEY` cleared. (The runtime `get_settings()` seam inside the Codex runner is already wrapped in `try/except` for skill-load bookkeeping only — verified non-fatal.)
- **memory_search treated exit-0-with-error-text as a successful synthesis**: the Claude CLI can exit 0 on a 401 while setting `is_error: true` on the result event — the error blob got injected into agent context as "memories" and the provider fallback never fired. Fix threads the structured `is_error` flag through `SearchRunResult` into `_is_provider_failure`; clean runs now scan only stderr for auth/usage markers so a legitimate memory mentioning "rate limit" can't be misread as a failure.

## Tests
- `scripts/wt-pytest.sh tests/test_reflection_runner.py tests/test_memory_search.py -q` → 59 passed
- Full backend suite passed in the land.sh pre-push gate on the pre-rebase head (landing raced the #11–#14 merge burst; switched to the PR rail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)