### PR TITLE
Add read-only git-native app update-check endpoint

### DIFF
--- a/backend/app/app_git.py
+++ b/backend/app/app_git.py
@@ -332,6 +332,22 @@ def head_sha(source_dir: str | Path, branch: str) -> str:
   return _run(Path(source_dir), "rev-parse", branch).stdout.strip()
 
 
+def ref_exists(source_dir: str | Path, ref: str) -> bool:
+  """Whether `ref` resolves in this repo. Read-only; never raises.
+
+  Lets a caller tell "this app has a recorded upstream branch" apart from "the
+  branch was never recorded" before reading its tree — `read_ref_tree` would
+  raise on a missing ref, so the guard belongs here. `--verify --quiet` resolves
+  the ref without printing, exiting non-zero when it doesn't exist. A repo with
+  no `.git` is trivially false rather than a git error."""
+  if not is_repo(source_dir):
+    return False
+  proc = _run(
+    Path(source_dir), "rev-parse", "--verify", "--quiet", ref, check=False,
+  )
+  return proc.returncode == 0
+
+
 def has_origin(source_dir: str | Path) -> bool:
   """Whether this app repo has a real `origin` remote.
 

--- a/backend/app/install.py
+++ b/backend/app/install.py
@@ -34,6 +34,7 @@ import re
 import shutil
 import subprocess
 import warnings as _warnings_mod
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Callable
@@ -1529,6 +1530,85 @@ async def _sync_app_skills(
         sidecar_path,
         json.dumps(records, indent=2, sort_keys=True) + "\n",
       )
+
+
+@dataclass
+class FetchedUpstream:
+  """The manifest + source bytes install would record, fetched read-only.
+
+  `source_files` and `job_bytes` mirror what `install_from_manifest` records on
+  the per-app `upstream` branch — the entry, its declared sibling modules, and
+  the schedule job script. The entry name the manifest declares is carried
+  separately in `manifest["entry"]` so the caller can key the entry the way the
+  recorded tree does (synthetic installs record it as "index.jsx"; a cloned
+  repo keys it by its repo path)."""
+  manifest: dict
+  entry_bytes: bytes
+  source_files: dict[str, bytes]
+  job_name: str | None
+  job_bytes: bytes | None
+
+
+async def fetch_upstream_source(manifest_url: str) -> FetchedUpstream:
+  """Fetch a manifest and its source files read-only — no install, DB, or git.
+
+  The read-only twin of `install_from_manifest`'s fetch phase: GET the manifest
+  at `manifest_url`, then the entry JSX, every declared `source_files` sibling,
+  and the schedule job script — exactly the files install records on the
+  per-app `upstream` branch. Reuses the same `_http_get` (SSRF-validated,
+  size-capped, manual-redirect) and `_validate_manifest` that install uses, so
+  the fetched bytes match install's byte-for-byte and a later content compare
+  against the recorded upstream tree is apples-to-apples.
+
+  Storage seeds, static assets, and the icon are deliberately NOT fetched: none
+  of them are tracked source (seeds land in the id-keyed storage tree, static
+  assets under gitignored `static/`, the icon as a processed PNG), so they never
+  appear on the `upstream` branch an update-check compares against.
+
+  Raises HTTPException on any fetch or validation failure. The caller decides
+  whether that is a hard error or a degrade-to-unknown."""
+  # follow_redirects=False — _http_get walks the chain manually so every hop is
+  # re-validated against SSRF, matching install_from_manifest's client setup.
+  async with httpx.AsyncClient(
+    timeout=_HTTP_TIMEOUT, follow_redirects=False,
+  ) as cli:
+    raw = await _http_get(cli, manifest_url, _MANIFEST_MAX_BYTES)
+    try:
+      manifest = json.loads(raw)
+    except json.JSONDecodeError as exc:
+      raise HTTPException(400, f"Manifest is not valid JSON: {exc}")
+    _validate_manifest(manifest)
+    raw_base = _normalize_raw_base(_derive_raw_base(manifest_url))
+
+    entry_bytes = await _http_get(
+      cli, raw_base + manifest["entry"], _ENTRY_MAX_BYTES,
+    )
+
+    source_files: dict[str, bytes] = {}
+    source_files_total = 0
+    for rel in manifest.get("source_files") or []:
+      data = await _http_get(cli, raw_base + rel, _ENTRY_MAX_BYTES)
+      source_files_total += len(data)
+      if source_files_total > _SOURCE_FILES_TOTAL_MAX:
+        raise HTTPException(
+          400,
+          f"Manifest source_files exceed {_SOURCE_FILES_TOTAL_MAX} bytes total.",
+        )
+      source_files[rel] = data
+
+    sched = manifest.get("schedule")
+    job_name = sched.get("job") if isinstance(sched, dict) else None
+    job_bytes: bytes | None = None
+    if job_name:
+      job_bytes = await _http_get(cli, raw_base + job_name, _ENTRY_MAX_BYTES)
+
+  return FetchedUpstream(
+    manifest=manifest,
+    entry_bytes=entry_bytes,
+    source_files=source_files,
+    job_name=job_name,
+    job_bytes=job_bytes,
+  )
 
 
 async def install_from_manifest(

--- a/backend/app/routes/apps.py
+++ b/backend/app/routes/apps.py
@@ -863,6 +863,150 @@ def _materialize_conflict_files(
     shutil.rmtree(tmp_parent, ignore_errors=True)
 
 
+def _fetched_differs_from_upstream(
+  repo: Path,
+  fetched_tree: dict[str, bytes],
+  cloned: bool,
+  non_source: frozenset[str],
+) -> bool:
+  """Whether the freshly-fetched upstream source differs from what the app
+  recorded on its `upstream` branch — the git-native update signal.
+
+  Reads the pristine `upstream` tree via git cat-file (`read_ref_tree`), which
+  only reads objects — it never touches the index or working tree, so this is
+  safe to call on every store open. Any fetched file that is new (absent
+  upstream) or whose bytes changed means upstream moved, which catches a code
+  push that forgot to bump the version.
+
+  Removal is only inferable for a SYNTHETIC install: there the recorded upstream
+  tree is exactly the declared source set, so a source file present upstream but
+  gone from the fetch is a genuine removal. A CLONED (real-origin) repo's
+  upstream tree also holds repo-native non-source files (README, the manifest,
+  the repo's own .gitignore) that were never part of the fetched declared set,
+  so a raw set-diff there would false-flag every catalog app — only added and
+  changed content is compared for those.
+  """
+  upstream_tree = app_git.read_ref_tree(repo, app_git.UPSTREAM_BRANCH)
+  for rel, data in fetched_tree.items():
+    if upstream_tree.get(rel) != data:
+      return True
+  if not cloned:
+    upstream_source = {
+      rel for rel in upstream_tree if rel not in non_source
+    }
+    if upstream_source - set(fetched_tree):
+      return True
+  return False
+
+
+@router.get(
+  "/{app_id}/update-check",
+  response_model=schemas.UpdateCheckOut,
+)
+async def update_check(
+  app_id: int,
+  db: Session = Depends(get_db),
+  principal: Principal = Depends(get_principal),
+):
+  """Read-only, git-native update detection for an installed app.
+
+  Content-compares the app's CURRENT upstream source (fetched the same way
+  install does) against the pristine `upstream` branch the last install
+  recorded, so a push that changed code WITHOUT bumping the version string
+  still surfaces as an update. Strictly read-only — no working-tree mutation,
+  no `record_upstream`, no DB write — which is what makes it safe to call on
+  every store open.
+
+  `update_available` is null (unknown) whenever the compare can't run — no
+  `manifest_url`, no git repo, no recorded upstream branch, or the upstream
+  fetch failed — and the caller then falls back to version comparison. A store
+  open must degrade, not error, so a network failure is a 200 with null rather
+  than a 5xx; only a genuinely invalid request (unknown app id) keeps its normal
+  HTTP error.
+  """
+  # Mirror update-preview's trust boundary exactly: an app token may check its
+  # OWN app; an App-Store-style manager token (manage_apps) may check other
+  # apps; the owner (app_id is None) may check any.
+  if principal.app_id is not None and principal.app_id != app_id:
+    caller = (
+      db.query(models.App)
+      .filter(models.App.id == principal.app_id)
+      .first()
+    )
+    if caller is None:
+      raise HTTPException(status_code=401, detail="App not found.")
+    if not bool(caller.manage_apps):
+      raise HTTPException(
+        status_code=403,
+        detail=(
+          "This app needs permissions.manage_apps=true in its manifest "
+          "to check updates for other apps."
+        ),
+      )
+  from app import install
+
+  app = live_app_or_404(db, app_id)
+  checked_at = datetime.now(UTC)
+  local_version = app.version
+
+  def _unknown() -> schemas.UpdateCheckOut:
+    # Null is "we can't tell git-natively" — NOT an error. The caller falls back
+    # to version comparison. Shared by every precondition-miss + fetch failure.
+    return schemas.UpdateCheckOut(
+      update_available=None,
+      upstream_version=None,
+      local_version=local_version,
+      checked_at=checked_at,
+    )
+
+  if not app.manifest_url or not app.source_dir:
+    return _unknown()
+  repo = Path(app.source_dir)
+  if not app_git.is_repo(repo) or not app_git.ref_exists(
+    repo, app_git.UPSTREAM_BRANCH,
+  ):
+    return _unknown()
+
+  # Reconstruct the fetchable manifest URL from the stored canonical identity
+  # key (`<base>#manifest-id=<id>`): the raw manifest lives at <base>/mobius.json,
+  # exactly where a store-driven update re-fetches it.
+  base = install._canonical_base(app.manifest_url)
+  fetch_manifest_url = base + "/mobius.json"
+  try:
+    fetched = await install.fetch_upstream_source(fetch_manifest_url)
+  except HTTPException:
+    # Upstream unreachable / rate-limited / now-invalid — degrade to unknown so
+    # a store open never errors on a transient network failure.
+    return _unknown()
+
+  # Build the fetched source tree the way install records it on `upstream`. A
+  # synthetic install keys the entry as "index.jsx" regardless of the manifest's
+  # entry name; a cloned (real-origin) repo keys files by their repo paths, so
+  # the entry sits under manifest["entry"] there.
+  cloned = await asyncio.to_thread(app_git.has_origin, repo)
+  entry_key = fetched.manifest["entry"] if cloned else "index.jsx"
+  fetched_tree: dict[str, bytes] = {entry_key: fetched.entry_bytes}
+  fetched_tree.update(fetched.source_files)
+  if fetched.job_name and fetched.job_bytes is not None:
+    fetched_tree[fetched.job_name] = fetched.job_bytes
+
+  # Hold the source-dir lock only around the git read so a concurrent installer's
+  # record_upstream can't move the `upstream` ref mid-read. The read itself
+  # (read_ref_tree = ls-tree + cat-file) never touches the index or working tree.
+  async with fs_locks.source_dir_lock(str(repo)):
+    update_available = await asyncio.to_thread(
+      _fetched_differs_from_upstream,
+      repo, fetched_tree, cloned, install._MERGED_NON_SOURCE,
+    )
+
+  return schemas.UpdateCheckOut(
+    update_available=update_available,
+    upstream_version=fetched.manifest.get("version"),
+    local_version=local_version,
+    checked_at=checked_at,
+  )
+
+
 @router.get(
   "/{app_id}/update-preview",
   response_model=schemas.UpdatePreviewOut,

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -197,6 +197,21 @@ class UpdatePreviewOut(BaseModel):
   upstream_diff: str | None = None
 
 
+class UpdateCheckOut(BaseModel):
+  """Git-native update detection: fetched upstream source vs recorded upstream.
+
+  `update_available` is null (unknown) when a content compare can't run — no
+  manifest_url, no git repo, no recorded upstream branch, or the upstream fetch
+  failed — so the caller falls back to version comparison. It is a real
+  true/false only when a byte-level compare actually ran, so a push that changed
+  code WITHOUT bumping the version still reads as an update. The version strings
+  are display-only, never the detection signal."""
+  update_available: bool | None = None
+  upstream_version: str | None = None
+  local_version: str | None = None
+  checked_at: datetime
+
+
 class AppConflictResolverChatOut(BaseModel):
   chat_id: str
   created: bool

--- a/backend/tests/test_apps_install.py
+++ b/backend/tests/test_apps_install.py
@@ -4165,3 +4165,303 @@ def test_multifile_update_deletes_dropped_sibling(
   assert r3.json()["mode"] == "update"
   assert r3.json()["divergence"] != "conflict"
   assert r3.json()["conflict_paths"] == []
+
+
+# --------------------------------------------------------------------------
+# GET /{app_id}/update-check — read-only, git-native update detection.
+#
+# Content-compares the CURRENT upstream source (fetched the same way install
+# does) against the pristine `upstream` branch the last install recorded, so a
+# push that changed code WITHOUT bumping the version still reads as an update.
+# --------------------------------------------------------------------------
+
+
+def _install_with_sources(client, auth, base, manifest, jsx, sources):
+  """Install a manifest whose `source_files` need extra fetched bytes.
+
+  `_install_v1` only maps the entry/icon/seed/job set; a multi-file manifest
+  also has to serve each declared source_files sibling, which this adds."""
+  responses = {
+    base + "mobius.json": (200, json.dumps(manifest).encode()),
+    base + "index.jsx": (200, jsx.encode()),
+    base + "icon.png": (200, _png_bytes()),
+    base + "prompt.md": (200, PROMPT.encode()),
+    base + "fetch.sh": (200, b""),
+  }
+  for rel, data in sources.items():
+    responses[base + rel] = (200, data if isinstance(data, bytes) else data.encode())
+  with patch(
+    "app.install.httpx.AsyncClient",
+    side_effect=_fake_async_client(responses),
+  ):
+    return client.post("/api/apps/install", headers=auth, json={
+      "manifest_url": base + "mobius.json",
+    })
+
+
+def _check_responses(base, manifest, jsx, sources=None, job=b""):
+  """Response map for the upstream fetch a GET /update-check performs.
+
+  update-check fetches ONLY tracked source — the manifest, the entry, declared
+  source_files, and the job — never the icon or storage seeds, so only those
+  are mapped (a stray unmapped fetch would 404 → degrade to unknown)."""
+  responses = {
+    base + "mobius.json": (200, json.dumps(manifest).encode()),
+    base + "index.jsx": (200, jsx.encode()),
+  }
+  sched = manifest.get("schedule")
+  if isinstance(sched, dict) and sched.get("job"):
+    responses[base + sched["job"]] = (200, job)
+  for rel, data in (sources or {}).items():
+    responses[base + rel] = (200, data if isinstance(data, bytes) else data.encode())
+  return responses
+
+
+def _update_check(client, headers, base, app_id, manifest, jsx, sources=None, job=b""):
+  responses = _check_responses(base, manifest, jsx, sources=sources, job=job)
+  with patch(
+    "app.install.httpx.AsyncClient",
+    side_effect=_fake_async_client(responses),
+  ):
+    return client.get(f"/api/apps/{app_id}/update-check", headers=headers)
+
+
+def test_update_check_unchanged_upstream_is_false(
+  client, auth, bypass_url_validation,
+):
+  """Byte-identical upstream → update_available is a real False, not null."""
+  base = "https://uc-unchanged.test/repo/"
+  m = {**MANIFEST_NEWS, "id": "uc-unchanged"}
+  r1 = _install_v1(client, auth, base, m, JSX)
+  assert r1.status_code == 201, r1.text
+  app_id = r1.json()["id"]
+
+  res = _update_check(client, auth, base, app_id, m, JSX)
+  assert res.status_code == 200, res.text
+  payload = res.json()
+  assert payload["update_available"] is False
+  assert payload["upstream_version"] == "1.0.0"
+  assert payload["local_version"] == "1.0.0"
+  assert payload["checked_at"]
+
+
+def test_update_check_changed_file_is_true(
+  client, auth, bypass_url_validation,
+):
+  """A changed entry byte upstream → update_available True."""
+  base = "https://uc-changed.test/repo/"
+  m = {**MANIFEST_NEWS, "id": "uc-changed"}
+  r1 = _install_v1(client, auth, base, m, JSX)
+  assert r1.status_code == 201, r1.text
+  app_id = r1.json()["id"]
+
+  res = _update_check(
+    client, auth, base, app_id, m, JSX.replace("ok", "CHANGED"),
+  )
+  assert res.status_code == 200, res.text
+  assert res.json()["update_available"] is True
+
+
+def test_update_check_version_unchanged_content_changed_is_true(
+  client, auth, bypass_url_validation,
+):
+  """The whole point: version string identical, content changed → True."""
+  base = "https://uc-samever.test/repo/"
+  m = {**MANIFEST_NEWS, "id": "uc-samever"}
+  r1 = _install_v1(client, auth, base, m, JSX)
+  assert r1.status_code == 201, r1.text
+  app_id = r1.json()["id"]
+
+  # Same manifest (same version "1.0.0"), different entry bytes.
+  res = _update_check(
+    client, auth, base, app_id, m, JSX.replace("ok", "SILENT PUSH"),
+  )
+  assert res.status_code == 200, res.text
+  payload = res.json()
+  assert payload["update_available"] is True
+  assert payload["upstream_version"] == payload["local_version"] == "1.0.0"
+
+
+def test_update_check_added_file_is_true(
+  client, auth, bypass_url_validation,
+):
+  """A new source_files sibling upstream → update_available True."""
+  base = "https://uc-added.test/repo/"
+  m = {**MANIFEST_NEWS, "id": "uc-added"}
+  r1 = _install_v1(client, auth, base, m, JSX)
+  assert r1.status_code == 201, r1.text
+  app_id = r1.json()["id"]
+
+  m2 = {**m, "source_files": ["helper.js"]}
+  res = _update_check(
+    client, auth, base, app_id, m2, JSX,
+    sources={"helper.js": b"export const x = 1\n"},
+  )
+  assert res.status_code == 200, res.text
+  assert res.json()["update_available"] is True
+
+
+def test_update_check_removed_file_is_true(
+  client, auth, bypass_url_validation,
+):
+  """A source file dropped from the manifest upstream → update_available True."""
+  base = "https://uc-removed.test/repo/"
+  m1 = {**MANIFEST_NEWS, "id": "uc-removed", "source_files": ["helper.js"]}
+  r1 = _install_with_sources(
+    client, auth, base, m1, JSX, {"helper.js": b"export const x = 1\n"},
+  )
+  assert r1.status_code == 201, r1.text
+  app_id = r1.json()["id"]
+
+  # Upstream drops the sibling — same entry bytes, no more source_files.
+  m2 = {**MANIFEST_NEWS, "id": "uc-removed"}
+  res = _update_check(client, auth, base, app_id, m2, JSX)
+  assert res.status_code == 200, res.text
+  assert res.json()["update_available"] is True
+
+
+def test_update_check_no_manifest_url_is_null(client, auth, db, tmp_path):
+  """An app with no manifest_url can't be checked git-natively → null."""
+  from app import models
+  app = models.App(
+    name="uc-nomani", description="", jsx_source="export default () => null",
+    source_dir=str(tmp_path / "nomani"), slug="uc-nomani",
+    manifest_url=None, version="3.0.0",
+    cross_app_access="none", share_with_apps="none",
+    offline_capable=False, manage_apps=False,
+  )
+  db.add(app)
+  db.commit()
+
+  res = client.get(f"/api/apps/{app.id}/update-check", headers=auth)
+  assert res.status_code == 200, res.text
+  payload = res.json()
+  assert payload["update_available"] is None
+  # Version still flows through so the caller can fall back to comparing it.
+  assert payload["local_version"] == "3.0.0"
+  assert payload["upstream_version"] is None
+
+
+def test_update_check_no_git_repo_is_null(client, auth, db, tmp_path):
+  """A manifest_url'd app whose source_dir isn't a git repo → null."""
+  from app import models
+  plain = tmp_path / "norepo"
+  plain.mkdir()
+  app = models.App(
+    name="uc-norepo", description="", jsx_source="export default () => null",
+    source_dir=str(plain), slug="uc-norepo",
+    manifest_url="https://uc-norepo.test/repo#manifest-id=uc-norepo",
+    version="1.0.0",
+    cross_app_access="none", share_with_apps="none",
+    offline_capable=False, manage_apps=False,
+  )
+  db.add(app)
+  db.commit()
+
+  res = client.get(f"/api/apps/{app.id}/update-check", headers=auth)
+  assert res.status_code == 200, res.text
+  assert res.json()["update_available"] is None
+
+
+def test_update_check_no_upstream_branch_is_null(client, auth, db, tmp_path):
+  """A git repo with no recorded `upstream` branch → null (nothing to diff)."""
+  from app import models
+  repo = tmp_path / "bare-repo"
+  repo.mkdir()
+  subprocess.run(["git", "init", "-q", str(repo)], check=True)
+  app = models.App(
+    name="uc-noups", description="", jsx_source="export default () => null",
+    source_dir=str(repo), slug="uc-noups",
+    manifest_url="https://uc-noups.test/repo#manifest-id=uc-noups",
+    version="1.0.0",
+    cross_app_access="none", share_with_apps="none",
+    offline_capable=False, manage_apps=False,
+  )
+  db.add(app)
+  db.commit()
+
+  res = client.get(f"/api/apps/{app.id}/update-check", headers=auth)
+  assert res.status_code == 200, res.text
+  assert res.json()["update_available"] is None
+
+
+def test_update_check_network_failure_degrades_to_null(
+  client, auth, bypass_url_validation,
+):
+  """An unreachable upstream is a 200 + null (store open must degrade)."""
+  base = "https://uc-netfail.test/repo/"
+  m = {**MANIFEST_NEWS, "id": "uc-netfail"}
+  r1 = _install_v1(client, auth, base, m, JSX)
+  assert r1.status_code == 201, r1.text
+  app_id = r1.json()["id"]
+
+  # Empty response map → every fetch 404s → fetch_upstream_source raises →
+  # the route swallows it and returns unknown rather than erroring.
+  with patch(
+    "app.install.httpx.AsyncClient",
+    side_effect=_fake_async_client({}),
+  ):
+    res = client.get(f"/api/apps/{app_id}/update-check", headers=auth)
+  assert res.status_code == 200, res.text
+  assert res.json()["update_available"] is None
+
+
+def test_update_check_unknown_app_id_is_404(client, auth):
+  """A genuinely invalid request keeps its normal HTTP error — not a degrade."""
+  res = client.get("/api/apps/9999999/update-check", headers=auth)
+  assert res.status_code == 404, res.text
+
+
+def test_update_check_rejects_ordinary_app_token_for_other_app(
+  client, db, auth, bypass_url_validation,
+):
+  """App tokens without manage_apps cannot check another app — mirrors preview."""
+  from app.auth import create_access_token
+  base = "https://uc-denied.test/repo/"
+  m = {**MANIFEST_NEWS, "id": "uc-denied-target"}
+  r1 = _install_v1(client, auth, base, m, JSX)
+  assert r1.status_code == 201, r1.text
+  target_app_id = r1.json()["id"]
+
+  caller_app_id = _seed_app_with_perms(
+    db, perms_cross_write="none", manage_apps=False,
+  )
+  db.commit()
+  token = create_access_token({
+    "sub": "test", "scope": "app", "app_id": caller_app_id,
+  })
+
+  res = client.get(
+    f"/api/apps/{target_app_id}/update-check",
+    headers={"Authorization": f"Bearer {token}"},
+  )
+  assert res.status_code == 403, res.text
+  assert "manage_apps" in res.json()["detail"]
+
+
+def test_update_check_accepts_app_token_with_manage_apps_for_other_app(
+  client, db, auth, bypass_url_validation,
+):
+  """A manage_apps token (the App Store) may check apps it manages."""
+  from app.auth import create_access_token
+  base = "https://uc-manager.test/repo/"
+  m = {**MANIFEST_NEWS, "id": "uc-manager-target"}
+  r1 = _install_v1(client, auth, base, m, JSX)
+  assert r1.status_code == 201, r1.text
+  target_app_id = r1.json()["id"]
+
+  manager_app_id = _seed_app_with_perms(
+    db, perms_cross_write="none", manage_apps=True,
+  )
+  db.commit()
+  token = create_access_token({
+    "sub": "test", "scope": "app", "app_id": manager_app_id,
+  })
+
+  res = _update_check(
+    client, {"Authorization": f"Bearer {token}"}, base, target_app_id, m, JSX,
+  )
+  assert res.status_code == 200, res.text
+  payload = res.json()
+  assert payload["update_available"] is False
+  assert payload["upstream_version"] == "1.0.0"


### PR DESCRIPTION
Owner-directed: app-update detection should be git-native — "compare the app repo's actual content against what's recorded locally; treat the version string as display-only" — so a release that forgot a `mobius.json` version bump still surfaces as an update.

## What
`GET /api/apps/{app_id}/update-check` → `{ update_available: bool|null, upstream_version, local_version, checked_at }`.

- Fetches the app's current upstream (manifest + entry + source_files + job) via a new read-only `install.fetch_upstream_source()` — the fetch-phase twin of `install_from_manifest`, reusing the same SSRF-validated, size-capped `_http_get` + `_validate_manifest`, so the compare is apples-to-apples with what install records.
- Byte-compares against the pristine `upstream` branch tree via git object reads only (`read_ref_tree` + new `app_git.ref_exists` guard) — no working tree, no index, no `record_upstream`, no DB write. Safe on every store open.
- `update_available=null` (HTTP 200) whenever the compare can't run — no manifest_url / no repo / no recorded upstream / fetch failure — so callers degrade to today's version comparison. Unknown app id keeps its 404. Auth mirrors update-preview's trust boundary exactly (owner / own app / `manage_apps`).
- Removal detection applies to synthetic-upstream installs only; cloned repos' upstream trees carry repo-native non-source files that would false-flag a raw set-diff (documented in the helper).

## Consumer
App Store v1.11.0 (mobius-os/app-store `e725a4d`) already keys its update badge on this tri-state — true/false authoritative, null → semver fallback — so older platforms without the endpoint keep exactly today's behavior. Pairs with the catalog.json discovery-index change (`70d0c82`, snapshots removed; e2e-verified against a live store on mobius-test).

## Tests
Post-rebase: `wt-pytest tests/test_apps_install.py tests/test_apps.py -q` → **146 passed** (12 new: unchanged/changed/added/removed, version-unchanged-content-changed→true, all null-degradation shapes, network-failure→200+null, 404, 403/manager auth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)