### PR TITLE
Fix apply-on-idle stall: empty focused composer must count as idle

### DIFF
--- a/frontend/src/components/Shell/__tests__/shellReloadPolicy.test.js
+++ b/frontend/src/components/Shell/__tests__/shellReloadPolicy.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 
 import {
   hasActiveChatTurn,
+  hasProtectedEditingContent,
   isTextEditingElement,
   shouldDeferShellReload,
 } from '../shellReloadPolicy.js'
@@ -61,4 +62,53 @@ test('hidden pages can reload without disrupting focus', () => {
     lastUserInteractionAt: 10000,
     now: 10001,
   }), false)
+})
+
+test('only editors holding content block an apply-on-idle reload', () => {
+  // The regression case: an EMPTY composer that kept focus after send is idle,
+  // not "composing" — a reload would destroy nothing.
+  assert.equal(hasProtectedEditingContent(el('textarea', { value: '' })), false)
+  assert.equal(hasProtectedEditingContent(el('input', { type: 'text', value: '' })), false)
+  assert.equal(hasProtectedEditingContent(el('div', { isContentEditable: true, textContent: '' })), false)
+  // A draft in progress IS protected — a reload mid-typing would lose it.
+  assert.equal(hasProtectedEditingContent(el('textarea', { value: 'half typed' })), true)
+  assert.equal(hasProtectedEditingContent(el('input', { type: 'text', value: 'x' })), true)
+  assert.equal(hasProtectedEditingContent(el('div', { isContentEditable: true, textContent: 'note' })), true)
+  // Opaque / non-text focus targets stay protected regardless.
+  assert.equal(hasProtectedEditingContent(el('iframe')), true)
+  assert.equal(hasProtectedEditingContent(el('select')), true)
+  // Not an editing surface at all — nothing to protect.
+  assert.equal(hasProtectedEditingContent(el('body')), false)
+  assert.equal(hasProtectedEditingContent(el('input', { type: 'checkbox' })), false)
+})
+
+test('a focused but empty composer is idle enough to apply at turn-end', () => {
+  // Exactly the shell-update-idle case 2: turn is done (streaming set empty),
+  // the composer keeps focus on desktop but is empty → do NOT defer.
+  assert.equal(shouldDeferShellReload({
+    activeElement: el('textarea', { value: '' }),
+    activeView: 'chat',
+    activeChatId: 'c1',
+    streamingChatIds: new Set(),
+    lastUserInteractionAt: 0,
+    now: 10000,
+  }), false)
+  // A non-empty composer still defers (protect the draft).
+  assert.equal(shouldDeferShellReload({
+    activeElement: el('textarea', { value: 'draft' }),
+    activeView: 'chat',
+    activeChatId: 'c1',
+    streamingChatIds: new Set(),
+    lastUserInteractionAt: 0,
+    now: 10000,
+  }), true)
+  // A live turn still defers even with an empty composer (never during stream).
+  assert.equal(shouldDeferShellReload({
+    activeElement: el('textarea', { value: '' }),
+    activeView: 'chat',
+    activeChatId: 'c1',
+    streamingChatIds: new Set(['c1']),
+    lastUserInteractionAt: 0,
+    now: 10000,
+  }), true)
 })

--- a/frontend/src/components/Shell/shellReloadPolicy.js
+++ b/frontend/src/components/Shell/shellReloadPolicy.js
@@ -20,6 +20,36 @@ export function isTextEditingElement(el) {
   return false
 }
 
+// A focused editing surface only blocks an apply-on-idle reload when it holds
+// content the reload would DESTROY. The resting state right after the owner
+// sends a message is an EMPTY composer that keeps focus on desktop (see
+// ChatInputBar: the textarea stays focused after send on non-touch devices) —
+// there is nothing to protect. Treating that bare, blinking cursor as "still
+// composing" is what stalled the held reload forever and broke the design's
+// promise that apply-on-idle "feels live while the owner is watching a build
+// session" (§1.3): the shell update the owner just triggered never landed
+// while their cursor sat idle in the empty composer. So an EMPTY text editor
+// counts as idle.
+//
+// A focused cross-origin mini-app iframe is opaque — we cannot tell whether the
+// user is mid-interaction — so it stays protected (a reload would yank a live
+// app). Selects and role-based custom editors whose text we cannot read stay
+// protected too, conservatively: only a field we can positively read as empty
+// is cleared to apply.
+export function hasProtectedEditingContent(el) {
+  if (!isTextEditingElement(el)) return false
+  const tagName = String(el.tagName || '').toLowerCase()
+  if (tagName === 'input' || tagName === 'textarea') {
+    return String(el.value ?? '').length > 0
+  }
+  if (el.isContentEditable) {
+    return String(el.textContent ?? '').length > 0
+  }
+  // iframe / select / role=textbox|searchbox|combobox custom widgets: opaque or
+  // non-text. Keep the reload deferred while they hold focus.
+  return true
+}
+
 export function hasActiveChatTurn({ activeView, activeChatId, streamingChatIds }) {
   if (activeView !== 'chat' || !activeChatId || !streamingChatIds) return false
   if (typeof streamingChatIds.has === 'function') return streamingChatIds.has(activeChatId)
@@ -37,7 +67,7 @@ export function shouldDeferShellReload({
   visibilityState = 'visible',
 } = {}) {
   if (visibilityState === 'hidden') return false
-  if (isTextEditingElement(activeElement)) return true
+  if (hasProtectedEditingContent(activeElement)) return true
   if (hasActiveChatTurn({ activeView, activeChatId, streamingChatIds })) return true
   if (lastUserInteractionAt && now - lastUserInteractionAt < RECENT_SHELL_INTERACTION_MS) return true
   return false


### PR DESCRIPTION
Main's e2e job has been red since aadffc16 on tests/shell-update-idle.spec.mjs case 2 ("applies exactly once at the turn-end idle boundary"). Root cause is a product bug, not a CI-environment delta: shouldDeferShellReload deferred the held reload for ANY focused text-editing element, and the desktop composer deliberately keeps focus after send (ChatInputBar only blurs on touch-primary devices). An empty-but-focused composer therefore deferred the apply-on-idle reload forever — the 6s recheck rescheduled indefinitely and the spec's wait for load_count===1 burned to the test cap. Reproduced deterministically under both bundled chromium (CI=1) and system Chrome against clean origin/main.

Fix: new hasProtectedEditingContent(el) — defer only when the focused editor holds content a reload would destroy (non-empty input/textarea/contenteditable). Opaque focus targets (mini-app iframe, select, role-based custom editors) stay protected. An empty composer counts as idle, restoring the design's own §1.3 promise that apply-on-idle feels live while the owner watches a build session. The "never during streaming" invariant is untouched (hasActiveChatTurn still defers) and the recent-interaction window still buffers active typing.

Evidence: previously-failing case 5/5 green under bundled chromium + CI=1; full shell-update-idle spec 3/3; frontend units 637/637 (2 new tests covering empty-vs-non-empty editors); backend 1764 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)