### PR TITLE
Default agent viewport for shell-less turns (412x915)

### DIFF
--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -2867,6 +2867,32 @@ async def _sync_chat_title(data_dir: str, chat_id: str) -> None:
     log.debug("sync_chat_title failed", exc_info=True)
 
 
+# Fallback viewport for turns no shell initiated (cron, reflection,
+# background continuations spawned by apps.py / platform_update.py).
+# 412x915 is the owner's PWA size — the shape screenshots should default
+# to when no real client viewport exists for the turn.
+DEFAULT_VIEWPORT_WIDTH = 412
+DEFAULT_VIEWPORT_HEIGHT = 915
+
+
+def viewport_env(viewport: dict | None) -> dict[str, str]:
+  """Returns the VIEWPORT_* env vars for an agent turn.
+
+  The React shell sends `{width, height}` with every message POST and
+  agent-screenshot.sh hard-requires both vars (deliberately strict — it
+  is the guard that surfaced the missing-viewport bug). Shell-less turns
+  have no sender, so a missing or malformed viewport falls back to the
+  documented default instead of leaving the vars unset and failing every
+  screenshot in those contexts.
+  """
+  vp_w = (viewport or {}).get("width")
+  vp_h = (viewport or {}).get("height")
+  if not (vp_w and vp_h):
+    vp_w = DEFAULT_VIEWPORT_WIDTH
+    vp_h = DEFAULT_VIEWPORT_HEIGHT
+  return {"VIEWPORT_WIDTH": str(vp_w), "VIEWPORT_HEIGHT": str(vp_h)}
+
+
 async def _run_chat_impl(
   messages: list[schemas.ChatMessage],
   chat_id: str = "",
@@ -3134,12 +3160,9 @@ async def _run_chat_impl(
   # Partner viewport (sent by the React shell on each turn). The agent
   # uses these when taking screenshots so the framing matches what the
   # partner actually sees — preview_shell.sh reads them, mini-app
-  # screenshots in the seed/skill recipes use them.
-  vp_w = (viewport or {}).get("width")
-  vp_h = (viewport or {}).get("height")
-  if vp_w and vp_h:
-    base_env["VIEWPORT_WIDTH"] = str(vp_w)
-    base_env["VIEWPORT_HEIGHT"] = str(vp_h)
+  # screenshots in the seed/skill recipes use them. Always set: shell-less
+  # turns get the documented 412x915 default (see viewport_env).
+  base_env.update(viewport_env(viewport))
   # Per-chat persistent Chrome profile for agent-browser. Default
   # (no AGENT_BROWSER_PROFILE) spins up a fresh ephemeral profile per
   # invocation — no SW registered, no warm cache, no localStorage

--- a/backend/tests/test_provider_agent_browser_env.py
+++ b/backend/tests/test_provider_agent_browser_env.py
@@ -1,3 +1,8 @@
+from app.chat import (
+  DEFAULT_VIEWPORT_HEIGHT,
+  DEFAULT_VIEWPORT_WIDTH,
+  viewport_env,
+)
 from app.providers import ClaudeProvider, CodexProvider
 
 
@@ -38,3 +43,33 @@ def test_claude_and_codex_use_same_agent_browser_session_name(tmp_path):
 
   assert claude_env["AGENT_BROWSER_SESSION"] == "chat-same-chat"
   assert codex_env["AGENT_BROWSER_SESSION"] == "chat-same-chat"
+
+
+# VIEWPORT_WIDTH/HEIGHT belong to the same agent-browser env contract:
+# chat.py exports them per turn and agent-screenshot.sh hard-requires
+# both (deliberately strict — fix producers, never the consumer).
+
+
+def test_viewport_env_passes_through_the_shell_sent_viewport():
+  env = viewport_env({"width": 390, "height": 844})
+  assert env == {"VIEWPORT_WIDTH": "390", "VIEWPORT_HEIGHT": "844"}
+
+
+def test_viewport_env_defaults_when_no_shell_sent_a_viewport():
+  # Shell-less turns (cron, reflection, background continuations from
+  # apps.py / platform_update.py) never send a viewport; the documented
+  # default keeps screenshots working there instead of hard-failing.
+  env = viewport_env(None)
+  assert env == {
+    "VIEWPORT_WIDTH": str(DEFAULT_VIEWPORT_WIDTH),
+    "VIEWPORT_HEIGHT": str(DEFAULT_VIEWPORT_HEIGHT),
+  }
+
+
+def test_viewport_env_defaults_on_malformed_viewport():
+  # A half-set or zero payload must not export a broken pair — the
+  # helper requires BOTH values, so anything short of that defaults.
+  for bad in ({}, {"width": 390}, {"height": 844}, {"width": 0, "height": 915}):
+    env = viewport_env(bad)
+    assert env["VIEWPORT_WIDTH"] == str(DEFAULT_VIEWPORT_WIDTH)
+    assert env["VIEWPORT_HEIGHT"] == str(DEFAULT_VIEWPORT_HEIGHT)


### PR DESCRIPTION
Closes the real half of .pm card 206 (wrong-viewport agent screenshots on prod). The shell has sent viewport {width,height} on every message POST since 014649e8 (April) — the card's "shell never sends it" premise was a grep false-negative — and promote parity already works (chat_writer's _combine_pending_messages threads the latest pending viewport). The live bug was narrower: shell-less turns (cron, reflection, background continuations from apps.py and platform_update.py) exported no VIEWPORT_* env, so the deliberately-strict agent-screenshot.sh hard-failed and raw agent-browser fell back to Chromium's default window size.

Fix: DEFAULT_VIEWPORT_WIDTH/HEIGHT = 412x915 + pure viewport_env() helper in chat.py; the single env-export site now always sets both vars (shell value when a well-formed viewport arrived, documented default otherwise, including malformed payloads — never a broken half-pair). agent-screenshot.sh stays strict: producers fixed, consumer untouched.

Tests: 3 cases (passthrough / shell-less default / malformed fallback) appended to the existing agent-browser env-contract file. Full backend suite 1767 passed, 1 skipped.

Note: this PR's e2e check will inherit main's shell-update-idle red until #17 merges; rerun after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)