### PR TITLE
Keep streamed reasoning as one grouped thinking block

### DIFF
--- a/backend/app/events.py
+++ b/backend/app/events.py
@@ -98,6 +98,33 @@ def _persisted_block(block: dict) -> dict:
   return persisted
 
 
+# Event types that begin (or belong to) a DIFFERENT visible content block and
+# therefore legitimately END a trailing thinking run. This is EXACTLY the set of
+# branches below that APPEND a new sibling block: text, text_final, text_boundary,
+# tool_start, error, question.
+#
+# Every OTHER event type must be TRANSPARENT to thinking coalescing:
+#  - Provider bookkeeping/heartbeats forwarded as "unknown_sdk_event" (a periodic
+#    `ping`, `signature_delta`, `content_block_stop`, `input_json_delta`), plus
+#    usage / session_init / done / catch_up_done / queued_turn_starting. These
+#    interleave BETWEEN successive thinking_delta events; closing the run on them
+#    fragmented one continuous reasoning pass into dozens of ~1s "Thought for 1
+#    second" blocks (even splitting mid-word). They change no block, so they must
+#    not touch thinking structure.
+#  - tool_input / tool_output / tool_sources / tool_end / skill_loaded only MUTATE
+#    an existing tool block. tool_start (which IS in this set) has already closed
+#    thinking and made a tool the trailing block before any of these arrive, so a
+#    later thinking auto-separates regardless.
+_THINKING_INTERRUPTING_TYPES: frozenset[str] = frozenset({
+  "text",
+  "text_final",
+  "text_boundary",
+  "tool_start",
+  "question",
+  "error",
+})
+
+
 def process_event(event: dict, assistant_blocks: list) -> bool:
   """Accumulates a parsed event into the assistant blocks list.
 
@@ -107,7 +134,10 @@ def process_event(event: dict, assistant_blocks: list) -> bool:
   """
   event_type = event.get("type")
 
-  if event_type != "thinking":
+  # Only a NEW visible content block ends a thinking run. Closing on transparent
+  # bookkeeping events (unknown_sdk_event/ping/signature_delta, usage, done, …)
+  # is what fragmented one reasoning pass into dozens of tiny blocks.
+  if event_type in _THINKING_INTERRUPTING_TYPES:
     _close_trailing_thinking(assistant_blocks)
 
   if event_type == "text":

--- a/backend/tests/test_events.py
+++ b/backend/tests/test_events.py
@@ -251,6 +251,57 @@ def test_thinking_event_after_tool_starts_fresh_block():
   assert [b["duration_ms"] for b in thinking_blocks] == [0, 0]
 
 
+def test_thinking_survives_interleaved_unknown_event():
+  # A provider `ping` heartbeat is forwarded as an "unknown_sdk_event" and lands
+  # BETWEEN two thinking_delta chunks (it can even split mid-word). It must NOT
+  # close the thinking run, else one reasoning pass fragments into many tiny
+  # "Thought for 1 second" blocks. Regression guard for that exact bug.
+  blocks = []
+  process_event({"type": "thinking", "content": "The sl", "ts": 1000}, blocks)
+  process_event(
+    {"type": "unknown_sdk_event", "kind": "stream:ping", "raw": {}}, blocks
+  )
+  process_event({"type": "thinking", "content": "iders move", "ts": 2200}, blocks)
+
+  assert len(blocks) == 1
+  assert blocks[0]["type"] == "thinking"
+  assert blocks[0]["content"] == "The sliders move"
+  assert blocks[0]["duration_ms"] == 1200
+
+
+def test_thinking_survives_interleaved_usage_and_signature():
+  # The full bookkeeping set is transparent to thinking coalescing: a `usage`
+  # event and a signature-style unknown_sdk_event between thinking chunks still
+  # yield one block. Only a real new content block (text/tool_start/…) splits it.
+  blocks = []
+  process_event({"type": "thinking", "content": "a", "ts": 1000}, blocks)
+  process_event({"type": "usage", "input_tokens": 5, "output_tokens": 7}, blocks)
+  process_event(
+    {"type": "unknown_sdk_event",
+     "kind": "stream:content_block_delta:signature_delta", "raw": {}},
+    blocks,
+  )
+  process_event({"type": "thinking", "content": "b", "ts": 1600}, blocks)
+
+  thinking_blocks = [b for b in blocks if b.get("type") == "thinking"]
+  assert len(thinking_blocks) == 1
+  assert thinking_blocks[0]["content"] == "ab"
+  assert thinking_blocks[0]["duration_ms"] == 600
+
+
+def test_thinking_split_by_text_boundary_then_text():
+  # The interrupting set is COMPLETE, not over-broad: a real text item between
+  # two thinking passes still splits them (thinking, text, thinking).
+  blocks = []
+  process_event({"type": "thinking", "content": "before", "ts": 1000}, blocks)
+  process_event({"type": "text_boundary"}, blocks)
+  process_event({"type": "text", "content": "answer"}, blocks)
+  process_event({"type": "thinking", "content": "after", "ts": 2000}, blocks)
+
+  assert [b["type"] for b in blocks] == ["thinking", "text", "thinking"]
+  assert [b["content"] for b in blocks] == ["before", "answer", "after"]
+
+
 def test_finalize_blocks_keeps_thinking_and_strips_transients():
   blocks = []
   process_event({"type": "thinking", "content": "a", "ts": 1000}, blocks)

--- a/frontend/src/components/ChatView/MsgContent.jsx
+++ b/frontend/src/components/ChatView/MsgContent.jsx
@@ -2,7 +2,7 @@ import { memo } from 'react'
 import { StandardMarkdown } from './markdown/BlockRenderer.jsx'
 import ToolBlock from './ToolBlock.jsx'
 import ToolActivityGroup from './ToolActivityGroup.jsx'
-import { groupToolRuns } from './groupBlocks.js'
+import { groupToolRuns, coalesceThinkingEntries } from './groupBlocks.js'
 import QuestionCard from './QuestionCard.jsx'
 import Attachments from './Attachments.jsx'
 import CompactionCard from './CompactionCard.jsx'
@@ -236,7 +236,12 @@ function MsgContentInner({
     const entries = msg.blocks
       .map((block, i) => ({ item: block, idx: i }))
       .filter(({ idx }) => !skipToolIdx.has(idx))
-    const nodes = groupToolRuns(entries)
+    // Repair already-persisted transcripts where a continuous reasoning pass was
+    // fragmented into many thinking blocks: coalesce runs of adjacent thinking
+    // AFTER idx assignment (each survivor keeps its original persisted idx) so
+    // ToolBlock's blockIdx stays a correct absolute index into msg.blocks and the
+    // lazy tool-output fetch keeps working. See groupBlocks.coalesceThinkingEntries.
+    const nodes = groupToolRuns(coalesceThinkingEntries(entries))
 
     return (
       <>

--- a/frontend/src/components/ChatView/__tests__/groupBlocks.test.js
+++ b/frontend/src/components/ChatView/__tests__/groupBlocks.test.js
@@ -1,6 +1,11 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { groupToolRuns, toolGroupState, toolGroupSummary } from '../groupBlocks.js'
+import {
+  groupToolRuns,
+  coalesceThinkingEntries,
+  toolGroupState,
+  toolGroupSummary,
+} from '../groupBlocks.js'
 import { toolActivityLabel } from '../toolActivityLabel.js'
 
 const e = item => ({ item })
@@ -158,4 +163,60 @@ test('toolActivityLabel: maps known tools, falls back to the raw name', () => {
   assert.equal(toolActivityLabel(undefined), 'Tool')
   // Prototype-chain names must not resolve to Object internals.
   assert.equal(toolActivityLabel('constructor'), 'constructor')
+})
+
+
+const think = (content, duration_ms = 0) => ({ type: 'thinking', content, duration_ms })
+
+test('coalesceThinkingEntries: adjacent thinking merges into one, content + duration summed', () => {
+  const entries = [
+    { item: think('The sl', 700), idx: 0 },
+    { item: think('iders move', 500), idx: 1 },
+  ]
+  const out = coalesceThinkingEntries(entries)
+  assert.equal(out.length, 1)
+  assert.equal(out[0].item.content, 'The sliders move')
+  assert.equal(out[0].item.duration_ms, 1200)
+})
+
+test('coalesceThinkingEntries: preserves the FIRST survivor idx so tool blockIdx stays absolute', () => {
+  // Persisted shape [thinking, thinking, thinking, tool] — the fragmented case.
+  // The tool MUST keep idx 3 so ToolBlock's GET /tool-output?i=3 hits the real block.
+  const entries = [
+    { item: think('a', 100), idx: 0 },
+    { item: think('b', 100), idx: 1 },
+    { item: think('c', 100), idx: 2 },
+    { item: { type: 'tool', tool: 'Bash' }, idx: 3 },
+  ]
+  const out = coalesceThinkingEntries(entries)
+  assert.equal(out.length, 2)
+  assert.equal(out[0].idx, 0)
+  assert.equal(out[0].item.content, 'abc')
+  assert.equal(out[1].idx, 3)
+  assert.equal(out[1].item.type, 'tool')
+})
+
+test('coalesceThinkingEntries: thinking separated by a tool stays two distinct blocks', () => {
+  const entries = [
+    { item: think('first', 100), idx: 0 },
+    { item: { type: 'tool', tool: 'Bash' }, idx: 1 },
+    { item: think('second', 100), idx: 2 },
+  ]
+  const out = coalesceThinkingEntries(entries)
+  assert.deepEqual(out.map(x => x.item.type), ['thinking', 'tool', 'thinking'])
+  assert.deepEqual(out.map(x => x.idx), [0, 1, 2])
+})
+
+test('coalesceThinkingEntries: groupToolRuns after coalesce yields one thinking single + tool group', () => {
+  const entries = [
+    { item: think('a', 100), idx: 0 },
+    { item: think('b', 100), idx: 1 },
+    { item: { type: 'tool', tool: 'Read' }, idx: 2 },
+    { item: { type: 'tool', tool: 'Edit' }, idx: 3 },
+  ]
+  const nodes = groupToolRuns(coalesceThinkingEntries(entries))
+  assert.equal(nodes.length, 2)
+  assert.equal(nodes[0].single.item.type, 'thinking')
+  assert.equal(nodes[0].single.item.content, 'ab')
+  assert.equal(nodes[1].group.map(x => x.idx).join(','), '2,3')
 })

--- a/frontend/src/components/ChatView/groupBlocks.js
+++ b/frontend/src/components/ChatView/groupBlocks.js
@@ -43,6 +43,42 @@ export function groupToolRuns(entries) {
   return nodes
 }
 
+// Merge runs of ADJACENT thinking entries into one, so a persisted transcript
+// renders a continuous reasoning pass as a SINGLE "Thought for Ns" disclosure
+// instead of many tiny fragments. Fragments only exist in already-saved chats
+// from before the backend stopped closing the thinking run on transparent
+// bookkeeping events (see events.py _THINKING_INTERRUPTING_TYPES); the live path
+// already coalesces in streamReducers.appendThinkingChunk. This is a render-time
+// repair with no migration — same spirit as suppressedQuestionToolIndices.
+//
+// CRITICAL: this runs on the ENTRIES array (each `{ item, idx }`) AFTER idx has
+// been assigned from the persisted position, and it PRESERVES the first merged
+// entry's original `idx`. idx is an absolute reference into the persisted
+// msg.blocks (ToolBlock uses it for the lazy GET /tool-output fetch), so
+// re-deriving it from a shortened array would fetch the wrong block / 404. Only
+// truly-adjacent thinking entries merge; anything between them (a tool/text
+// block) breaks the run, so distinct reasoning segments around tool calls stay
+// separate. Pure — new entries, inputs untouched.
+export function coalesceThinkingEntries(entries) {
+  const out = []
+  for (const entry of entries) {
+    const prev = out[out.length - 1]
+    if (prev?.item?.type === 'thinking' && entry?.item?.type === 'thinking') {
+      out[out.length - 1] = {
+        ...prev,
+        item: {
+          ...prev.item,
+          content: (prev.item.content || '') + (entry.item.content || ''),
+          duration_ms: (prev.item.duration_ms || 0) + (entry.item.duration_ms || 0),
+        },
+      }
+    } else {
+      out.push(entry)
+    }
+  }
+  return out
+}
+
 // Derive the collapsed status of a tool group from its children: a failed tool
 // dominates (so a broken step is visible without expanding), then a running
 // tool, else done. Shared by ToolActivityGroup, which maps this to the header


### PR DESCRIPTION
## Problem

When an agent streams extended reasoning (Claude `thinking_delta`), reopening the chat rendered the reasoning as dozens of tiny "Thought for 1 second" disclosures instead of one grouped block — sometimes splitting mid-word. The *live* stream looked correct; only the persisted/reopened transcript was fragmented.

## Root cause

The runner sets `include_partial_messages=True`, so the CLI forwards raw Anthropic stream events as `StreamEvent`. Non-content events that arrive *between* two `thinking_delta` chunks — a periodic `ping` heartbeat, and the trailing `signature_delta` — fall through to `_emit_unknown` and are published as `{"type": "unknown_sdk_event"}` (emission defaults on). `_ChatEventSink.publish` runs `events.process_event` on every event, and `process_event` closed the trailing thinking run on *every* `event_type != "thinking"`. So each ping marked the thinking block closed and the next delta opened a fresh one, fragmenting one reasoning pass into many blocks. The live view was spared because unknown events create no stream item, so the frontend reducer kept coalescing.

## Fix

- **`events.py`** — only end a thinking run on events that begin a new visible block (`text`, `text_final`, `text_boundary`, `tool_start`, `question`, `error` — exactly the branches that append a sibling block). Bookkeeping events (`unknown_sdk_event`, `usage`, `done`, …) are now transparent to thinking coalescing, fixing fragmentation at the source for new turns.
- **`MsgContent.jsx` / `groupBlocks.js`** — coalesce adjacent persisted thinking blocks at render time, preserving each surviving block's original index so `ToolBlock`'s absolute `blockIdx` (used by the lazy `GET /tool-output` fetch) stays correct. This repairs already-saved fragmented transcripts with no migration.

## Tests

- Backend: interleaving `unknown_sdk_event` / `usage` / signature-style events between two thinking chunks yields one coalesced block; a real content block (e.g. `text_boundary` + `text`) still splits thinking.
- Frontend: `coalesceThinkingEntries` merges adjacent thinking, preserves indices (so a following tool keeps its `blockIdx`), and leaves thinking separated by a tool distinct.