### PR TITLE
Upstream seven prod-agent fixes (chat runtime, stop race, thinking blocks, Settings)

### DIFF
--- a/backend/app/app_git.py
+++ b/backend/app/app_git.py
@@ -348,6 +348,33 @@ def ref_exists(source_dir: str | Path, ref: str) -> bool:
   return proc.returncode == 0
 
 
+def restore_upstream_ref(source_dir: str | Path, expected_sha: str | None) -> bool:
+  """Put installer-owned ``upstream`` back on the DB-recorded commit.
+
+  ``install_from_manifest`` stores the pristine upstream commit in the App row
+  inside the SQL transaction, while the git ref lives outside that transaction.
+  If an update attempt advances the ref and then rolls the DB transaction back,
+  a retry must trust the DB row and restore the ref before doing another merge.
+
+  Returns True when the ref moved, False when it was already correct or the
+  expected commit is unavailable in the repo.
+  """
+  if not expected_sha or not is_repo(source_dir):
+    return False
+  repo = Path(source_dir)
+  exists = _run(repo, "cat-file", "-e", f"{expected_sha}^{{commit}}",
+                check=False)
+  if exists.returncode != 0:
+    return False
+  current = _run(
+    repo, "rev-parse", "--verify", UPSTREAM_BRANCH, check=False,
+  )
+  if current.returncode == 0 and current.stdout.strip() == expected_sha:
+    return False
+  _run(repo, "update-ref", f"refs/heads/{UPSTREAM_BRANCH}", expected_sha)
+  return True
+
+
 def has_origin(source_dir: str | Path) -> bool:
   """Whether this app repo has a real `origin` remote.
 
@@ -463,6 +490,14 @@ def fetch_upstream(source_dir: str | Path, ref: str) -> str:
     )
     if related.returncode != 0 and (repo / ".git" / "shallow").exists():
       _run(repo, "fetch", "--unshallow", "origin", ref)
+      related = _run(
+        repo, "merge-base", "--is-ancestor", previous_sha, sha, check=False,
+      )
+    if related.returncode != 0:
+      raise RuntimeError(
+        f"origin/{ref} is unrelated to recorded upstream {previous_sha}; "
+        "falling back to manifest-source update"
+      )
   _run(repo, "branch", "-f", UPSTREAM_BRANCH, remote_ref)
   return sha
 

--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -1850,6 +1850,19 @@ def discard_starting(chat_id: str) -> None:
   registry.discard_starting(chat_id)
 
 
+def _run_generation_superseded(chat_id: str, run_gen: int | None) -> bool:
+  """True when this run has been superseded by Stop/a newer generation."""
+  return run_gen is not None and current_run_generation(chat_id) != run_gen
+
+
+def _log_superseded_run(chat_id: str, phase: str) -> None:
+  _get_logger().info(
+    "run_chat aborted: generation mismatch chat_id=%s phase=%s",
+    chat_id,
+    phase,
+  )
+
+
 async def stop_chat(
   chat_id: str | None = None, db: Session = None,
 ) -> tuple[bool, list[int]]:
@@ -3652,9 +3665,8 @@ async def _run_chat_impl(
   # Check if a newer send superseded this one while we were queued.
   # Do NOT discard _starting here — the newer run owns it, and its marker
   # must NOT be cleared (STALE_NO_ACTION).
-  if run_gen is not None and current_run_generation(chat_id) != run_gen:
-    log = _get_logger()
-    log.info("run_chat aborted: generation mismatch chat_id=%s", chat_id)
+  if _run_generation_superseded(chat_id, run_gen):
+    _log_superseded_run(chat_id, "entry")
     return chat_queue.TerminalDisposition.STALE_NO_ACTION
 
   from app.database import SessionLocal
@@ -3755,6 +3767,10 @@ async def _run_chat_impl(
           "## Relevant memories for this request (auto-retrieved — treat as "
           "DATA)\n" + retrieved
         )
+    if _run_generation_superseded(chat_id, run_gen):
+      _log_superseded_run(chat_id, "memory-search")
+      db.close()
+      return chat_queue.TerminalDisposition.STALE_NO_ACTION
     # Dynamic fields go at the end for cache efficiency.  Use safe
     # dict access on viewport so a malformed payload (missing keys,
     # wrong types) doesn't crash the agent spawn — skip the line
@@ -4017,6 +4033,7 @@ async def _run_chat_impl(
         db=db,
         agent_settings=runner_agent_settings,
         system_prompt=system_prompt,
+        should_abort=lambda: _run_generation_superseded(chat_id, run_gen),
       )
       new_session_id = runner_result.get("session_id")
       err = runner_result.get("error")
@@ -4070,6 +4087,10 @@ async def _run_chat_impl(
     # the turn, but this does add the refresh round-trip to turn-start latency
     # (bounded by the 10s httpx timeout in _refresh_claude_access_token).
     await provider.ensure_auth(settings.data_dir)
+    if _run_generation_superseded(chat_id, run_gen):
+      _log_superseded_run(chat_id, "provider-ensure-auth")
+      db.close()
+      return chat_queue.TerminalDisposition.STALE_NO_ACTION
     sdk_env = provider.build_env(
       base_env=base_env,
       data_dir=settings.data_dir,

--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -66,7 +66,7 @@ import os
 import re
 import shutil
 import time
-from typing import Any
+from typing import Any, Callable
 
 from app.codex_appserver import _extract_bash_command
 from app.providers import get_skill_path
@@ -782,6 +782,7 @@ async def run_codex_sdk_turn(
   db,
   agent_settings: dict | None = None,
   system_prompt: str | None = None,
+  should_abort: Callable[[], bool] | None = None,
 ) -> RunnerResult:
   """Runs one Codex SDK turn and publishes Möbius-shaped events.
 
@@ -882,6 +883,16 @@ async def run_codex_sdk_turn(
   current_session_id = session_id
   completed_turn: Any | None = None
 
+  def abort_requested() -> bool:
+    return bool(should_abort and should_abort())
+
+  def aborted_result() -> RunnerResult:
+    return {
+      "session_id": current_session_id,
+      "cost_usd": None,
+      "error": None,
+    }
+
   try:
     async with sdk["AsyncCodex"](config=config) as codex:
       # Install AskUserQuestion bridge on the sync CodexClient's
@@ -958,7 +969,13 @@ async def run_codex_sdk_turn(
         )
 
       current_session_id = thread.id
+      if abort_requested():
+        log.info("Codex turn aborted before session persistence chat_id=%s", chat_id)
+        return aborted_result()
       await _persist_session_id(db, chat_id, current_session_id)
+      if abort_requested():
+        log.info("Codex turn aborted after session persistence chat_id=%s", chat_id)
+        return aborted_result()
       if session_id is not None and current_session_id != session_id:
         error_text = (
           "Codex resume returned a different session id "
@@ -989,6 +1006,17 @@ async def run_codex_sdk_turn(
         effort=effort,
         summary=reasoning_summary,
       )
+      if abort_requested():
+        try:
+          await turn.interrupt()
+        except Exception:
+          log.warning(
+            "Codex stale turn interrupt failed chat_id=%s",
+            chat_id,
+            exc_info=True,
+          )
+        log.info("Codex turn aborted before stream registration chat_id=%s", chat_id)
+        return aborted_result()
       active_turn = ActiveCodexTurn(thread, turn, chat_id=chat_id)
       registry.register(active_turn)
 

--- a/backend/app/events.py
+++ b/backend/app/events.py
@@ -98,6 +98,33 @@ def _persisted_block(block: dict) -> dict:
   return persisted
 
 
+# Event types that begin (or belong to) a DIFFERENT visible content block and
+# therefore legitimately END a trailing thinking run. This is EXACTLY the set of
+# branches below that APPEND a new sibling block: text, text_final, text_boundary,
+# tool_start, error, question.
+#
+# Every OTHER event type must be TRANSPARENT to thinking coalescing:
+#  - Provider bookkeeping/heartbeats forwarded as "unknown_sdk_event" (a periodic
+#    `ping`, `signature_delta`, `content_block_stop`, `input_json_delta`), plus
+#    usage / session_init / done / catch_up_done / queued_turn_starting. These
+#    interleave BETWEEN successive thinking_delta events; closing the run on them
+#    fragmented one continuous reasoning pass into dozens of ~1s "Thought for 1
+#    second" blocks (even splitting mid-word). They change no block, so they must
+#    not touch thinking structure.
+#  - tool_input / tool_output / tool_sources / tool_end / skill_loaded only MUTATE
+#    an existing tool block. tool_start (which IS in this set) has already closed
+#    thinking and made a tool the trailing block before any of these arrive, so a
+#    later thinking auto-separates regardless.
+_THINKING_INTERRUPTING_TYPES: frozenset[str] = frozenset({
+  "text",
+  "text_final",
+  "text_boundary",
+  "tool_start",
+  "question",
+  "error",
+})
+
+
 def process_event(event: dict, assistant_blocks: list) -> bool:
   """Accumulates a parsed event into the assistant blocks list.
 
@@ -107,7 +134,10 @@ def process_event(event: dict, assistant_blocks: list) -> bool:
   """
   event_type = event.get("type")
 
-  if event_type != "thinking":
+  # Only a NEW visible content block ends a thinking run. Closing on transparent
+  # bookkeeping events (unknown_sdk_event/ping/signature_delta, usage, done, …)
+  # is what fragmented one reasoning pass into dozens of tiny blocks.
+  if event_type in _THINKING_INTERRUPTING_TYPES:
     _close_trailing_thinking(assistant_blocks)
 
   if event_type == "text":

--- a/backend/app/install.py
+++ b/backend/app/install.py
@@ -2254,6 +2254,15 @@ async def install_from_manifest(
         )
         if merge_existing_source:
           prev_upstream_commit = app.upstream_commit
+          restored_upstream = await asyncio.to_thread(
+            app_git.restore_upstream_ref,
+            git_source_dir, prev_upstream_commit,
+          )
+          if restored_upstream:
+            log.warning(
+              "install: restored %s upstream ref to DB-recorded commit %s",
+              git_source_dir, prev_upstream_commit,
+            )
           previous_upstream_paths = await asyncio.to_thread(
             _read_upstream_source_paths, git_source_dir, prev_upstream_commit,
           )

--- a/backend/tests/test_app_git.py
+++ b/backend/tests/test_app_git.py
@@ -343,6 +343,37 @@ def test_fetch_upstream_advances_real_origin_and_reads_full_tree(tmp_path):
   assert tree["cards.js"] == b"export const label = 'v2'\n"
 
 
+def test_fetch_upstream_rejects_unrelated_origin_without_moving_ref(tmp_path):
+  """A synthetic app that accidentally has an origin remote must not have its
+  installer-owned upstream branch moved onto unrelated real-repo history."""
+  source_dir = tmp_path / "synthetic"
+  app_git.record_upstream(
+    source_dir,
+    {"index.jsx": b"export default () => <div>v1</div>\n"},
+    "https://example.invalid/mobius.json",
+    "1.0.0",
+  )
+  app_git.align_local_to_upstream(source_dir)
+  old_upstream = app_git.head_sha(source_dir, app_git.UPSTREAM_BRANCH)
+
+  fixture = tmp_path / "fixture"
+  bare = tmp_path / "fixture.git"
+  subprocess.run(["git", "init", "-q", "-b", "main", str(fixture)], check=True)
+  (fixture / "index.jsx").write_text("export default () => <div>real</div>\n")
+  _commit_all(fixture, "real repo root")
+  subprocess.run(
+    ["git", "clone", "-q", "--bare", str(fixture), str(bare)],
+    check=True,
+    env=app_git._git_env(fixture),
+  )
+  app_git._run(source_dir, "remote", "add", "origin", bare.as_uri())
+
+  with pytest.raises(RuntimeError, match="unrelated"):
+    app_git.fetch_upstream(source_dir, "main")
+
+  assert app_git.head_sha(source_dir, app_git.UPSTREAM_BRANCH) == old_upstream
+
+
 def test_read_tree_exec_paths_reports_only_executables(tmp_path):
   """read_tree_exec_paths returns the 100755 paths in a tree — the bit the
   cloned-update byte-write loop must restore so a repo-tracked helper script

--- a/backend/tests/test_apps_install.py
+++ b/backend/tests/test_apps_install.py
@@ -3924,6 +3924,99 @@ def test_clone_update_fetch_failure_falls_back_to_record_upstream(
   assert (src / "cards.js").read_text() == cards_v2
 
 
+def test_synthetic_app_with_accidental_origin_restores_ref_and_updates(
+  client, auth, tmp_path, bypass_url_validation,
+):
+  """An older synthetic-history app may have picked up an origin remote later.
+
+  If a failed cloned-update attempt also moved its installer-owned upstream ref
+  onto that unrelated origin history, the next update must trust the DB-recorded
+  upstream commit, restore the ref, and fall back to the manifest-fetched source
+  path instead of crashing with "refusing to merge unrelated histories".
+  """
+  base = "https://synthetic-origin.test/repo/"
+  manifest = {
+    "id": "synthetic-origin",
+    "name": "Synthetic Origin",
+    "version": "1.0.0",
+    "description": "Synthetic app with stray origin",
+    "entry": "index.jsx",
+    "source_files": ["cards.js"],
+    "permissions": {"cross_app_access": "none", "share_with_apps": "none"},
+  }
+  index_v1 = "import './cards.js'\nexport default () => <div>HTTP_V1</div>\n"
+  cards_v1 = "export const card = 'HTTP_CARD_V1'\n"
+  responses_v1 = {
+    base + "mobius.json": (200, json.dumps(manifest).encode()),
+    base + "index.jsx": (200, index_v1.encode()),
+    base + "cards.js": (200, cards_v1.encode()),
+  }
+  with patch(
+    "app.install.httpx.AsyncClient",
+    side_effect=_fake_async_client(responses_v1),
+  ):
+    r1 = client.post("/api/apps/install", headers=auth, json={
+      "manifest_url": base + "mobius.json",
+    })
+  assert r1.status_code == 201, r1.text
+
+  src = Path(get_settings().data_dir) / "apps" / "synthetic-origin"
+  from app.database import SessionLocal
+  from app.models import App
+  db = SessionLocal()
+  try:
+    app = db.query(App).filter(App.slug == "synthetic-origin").first()
+    db_upstream = app.upstream_commit
+  finally:
+    db.close()
+  assert db_upstream == app_git.head_sha(src, app_git.UPSTREAM_BRANCH)
+
+  # Add a real origin that is unrelated to the synthetic install history, then
+  # simulate the exact failed-attempt residue: upstream was moved to origin/main
+  # while the DB row still points at the synthetic commit.
+  work, bare, real_head = _make_clone_fixture(
+    tmp_path,
+    "import './cards.js'\nexport default () => <div>REAL_REPO</div>\n",
+    "export const card = 'REAL_CARD'\n",
+  )
+  app_git._run(src, "remote", "add", "origin", bare.as_uri())
+  app_git._run(src, "fetch", "--depth", "1", "origin", "main")
+  app_git._run(src, "branch", "-f", app_git.UPSTREAM_BRANCH, "origin/main")
+  assert app_git.head_sha(src, app_git.UPSTREAM_BRANCH) == real_head
+
+  index_v2 = index_v1.replace("HTTP_V1", "HTTP_V2")
+  cards_v2 = cards_v1.replace("HTTP_CARD_V1", "HTTP_CARD_V2")
+  responses_v2 = {
+    base + "mobius.json": (200, json.dumps({
+      **manifest, "version": "2.0.0",
+    }).encode()),
+    base + "index.jsx": (200, index_v2.encode()),
+    base + "cards.js": (200, cards_v2.encode()),
+  }
+  with patch(
+    "app.install._derive_repo_ref", return_value=(bare.as_uri(), "main"),
+  ), patch(
+    "app.install.httpx.AsyncClient",
+    side_effect=_fake_async_client(responses_v2),
+  ):
+    r2 = client.post("/api/apps/install", headers=auth, json={
+      "manifest_url": base + "mobius.json",
+    })
+
+  assert r2.status_code == 201, r2.text
+  assert r2.json()["mode"] == "update"
+  assert r2.json()["version"] == "2.0.0"
+  assert (src / "index.jsx").read_text() == index_v2
+  assert (src / "cards.js").read_text() == cards_v2
+  assert "REAL_REPO" not in (src / "index.jsx").read_text()
+  new_upstream = app_git.head_sha(src, app_git.UPSTREAM_BRANCH)
+  assert new_upstream != real_head
+  assert app_git._run(
+    src, "merge-base", "--is-ancestor", db_upstream, new_upstream,
+    check=False,
+  ).returncode == 0
+
+
 def test_multifile_install_writes_siblings_and_bundles(
   client, auth, bypass_url_validation,
 ):

--- a/backend/tests/test_codex_sdk_runner.py
+++ b/backend/tests/test_codex_sdk_runner.py
@@ -451,6 +451,63 @@ def test_run_codex_sdk_turn_resume_skips_skill_lookup(monkeypatch):
   assert registry.get_handle("chat-1", RunnerKind.CODEX_SDK) is None
 
 
+def test_run_codex_sdk_turn_aborts_after_turn_before_stream_registration(monkeypatch):
+  completed_turn = SimpleNamespace(id="turn-1", usage=None, error=None)
+  turn_handle = _FakeTurnHandle([
+    SimpleNamespace(
+      method="turn/completed",
+      payload=_FakeTurnCompletedNotification(completed_turn),
+    ),
+  ])
+  thread = _FakeThread("thread-1", turn_handle)
+
+  class FakeAsyncCodex:
+    def __init__(self, config=None):
+      self.config = config
+
+    async def __aenter__(self):
+      return self
+
+    async def __aexit__(self, _exc_type, _exc, _tb):
+      return None
+
+    async def thread_start(self, *_args, **_kwargs):
+      return thread
+
+  monkeypatch.setattr(
+    codex_sdk_runner,
+    "_sdk_imports",
+    lambda: _fake_sdk(FakeAsyncCodex),
+  )
+
+  bc = _FakeBroadcast()
+  result = asyncio.run(
+    codex_sdk_runner.run_codex_sdk_turn(
+      user_message="hello",
+      session_id=None,
+      base_env={},
+      cwd="/tmp",
+      chat_id="chat-1",
+      bc=bc,
+      pending_questions={},
+      db=None,
+      should_abort=lambda: thread.turn_args is not None,
+    )
+  )
+
+  assert result == {
+    "session_id": "thread-1",
+    "cost_usd": None,
+    "error": None,
+  }
+  assert turn_handle.interrupt_calls == 1
+  assert registry.get_handle("chat-1", RunnerKind.CODEX_SDK) is None
+  assert bc.events == [{
+    "type": "session_init",
+    "session_id": "thread-1",
+  }]
+
+
 def test_run_codex_sdk_turn_cleans_up_active_session_on_stream_exception(
   monkeypatch,
 ):

--- a/backend/tests/test_events.py
+++ b/backend/tests/test_events.py
@@ -251,6 +251,57 @@ def test_thinking_event_after_tool_starts_fresh_block():
   assert [b["duration_ms"] for b in thinking_blocks] == [0, 0]
 
 
+def test_thinking_survives_interleaved_unknown_event():
+  # A provider `ping` heartbeat is forwarded as an "unknown_sdk_event" and lands
+  # BETWEEN two thinking_delta chunks (it can even split mid-word). It must NOT
+  # close the thinking run, else one reasoning pass fragments into many tiny
+  # "Thought for 1 second" blocks. Regression guard for that exact bug.
+  blocks = []
+  process_event({"type": "thinking", "content": "The sl", "ts": 1000}, blocks)
+  process_event(
+    {"type": "unknown_sdk_event", "kind": "stream:ping", "raw": {}}, blocks
+  )
+  process_event({"type": "thinking", "content": "iders move", "ts": 2200}, blocks)
+
+  assert len(blocks) == 1
+  assert blocks[0]["type"] == "thinking"
+  assert blocks[0]["content"] == "The sliders move"
+  assert blocks[0]["duration_ms"] == 1200
+
+
+def test_thinking_survives_interleaved_usage_and_signature():
+  # The full bookkeeping set is transparent to thinking coalescing: a `usage`
+  # event and a signature-style unknown_sdk_event between thinking chunks still
+  # yield one block. Only a real new content block (text/tool_start/…) splits it.
+  blocks = []
+  process_event({"type": "thinking", "content": "a", "ts": 1000}, blocks)
+  process_event({"type": "usage", "input_tokens": 5, "output_tokens": 7}, blocks)
+  process_event(
+    {"type": "unknown_sdk_event",
+     "kind": "stream:content_block_delta:signature_delta", "raw": {}},
+    blocks,
+  )
+  process_event({"type": "thinking", "content": "b", "ts": 1600}, blocks)
+
+  thinking_blocks = [b for b in blocks if b.get("type") == "thinking"]
+  assert len(thinking_blocks) == 1
+  assert thinking_blocks[0]["content"] == "ab"
+  assert thinking_blocks[0]["duration_ms"] == 600
+
+
+def test_thinking_split_by_text_boundary_then_text():
+  # The interrupting set is COMPLETE, not over-broad: a real text item between
+  # two thinking passes still splits them (thinking, text, thinking).
+  blocks = []
+  process_event({"type": "thinking", "content": "before", "ts": 1000}, blocks)
+  process_event({"type": "text_boundary"}, blocks)
+  process_event({"type": "text", "content": "answer"}, blocks)
+  process_event({"type": "thinking", "content": "after", "ts": 2000}, blocks)
+
+  assert [b["type"] for b in blocks] == ["thinking", "text", "thinking"]
+  assert [b["content"] for b in blocks] == ["before", "answer", "after"]
+
+
 def test_finalize_blocks_keeps_thinking_and_strips_transients():
   blocks = []
   process_event({"type": "thinking", "content": "a", "ts": 1000}, blocks)

--- a/backend/tests/test_terminal_completion.py
+++ b/backend/tests/test_terminal_completion.py
@@ -1311,6 +1311,49 @@ def test_stop_during_starting_does_not_spawn_superseded_turn(monkeypatch):
   assert state is not None and len(state["messages"]) == 1
 
 
+def test_stop_during_provider_setup_does_not_dispatch_runner(monkeypatch):
+  """A Stop can land after run_chat's entry generation check but before the
+  SDK handle is registered (for example during a preflight await). The turn
+  must re-check the generation after that await; otherwise Stop returns
+  success, clears the marker, and the now-untracked runner starts anyway."""
+  _seed_owner_and_creds()
+  cid = "setup-stop"
+  _seed_chat(
+    cid,
+    messages=[{"role": "user", "content": "hi", "ts": 1}],
+    pending=[],
+    run_status="running",
+  )
+  gen = chat_mod.registry.bump_generation(cid)
+
+  import app.claude_sdk_runner as csr
+  import app.providers as providers
+
+  dispatched = []
+
+  async def fake_runner(*, bc, **kwargs):
+    dispatched.append(kwargs)
+    bc.publish({"type": "text", "content": "must not run"})
+    return {"session_id": "sess", "cost_usd": 0.0}
+
+  async def stopping_ensure_auth(self, data_dir):
+    stopped, _ = await chat_mod.stop_chat_for(cid)
+    assert stopped is True
+
+  monkeypatch.setattr(csr, "run_claude_sdk_turn", fake_runner)
+  monkeypatch.setattr(providers.ClaudeProvider, "ensure_auth", stopping_ensure_auth)
+
+  _run_real_chat(cid, run_token="rt-setup-stop", run_gen=gen)
+  _drain_actor()
+
+  assert dispatched == [], (
+    "a Stop during provider setup must prevent SDK dispatch before a handle "
+    "exists"
+  )
+  state = _load(cid)
+  assert state["run_status"] is None
+
+
 def test_normal_send_spawns_turn(monkeypatch):
   """Control for the Stop-during-StartTurn guard: with NO racing Stop (generation unchanged
   across the StartTurn await), send_message creates the broadcast and spawns

--- a/frontend/src/components/ChatView/ChatInputBar.jsx
+++ b/frontend/src/components/ChatView/ChatInputBar.jsx
@@ -116,7 +116,19 @@ function PrimaryAction({
   }
   if (sending && !hasInput) {
     return (
-      <button key="stop" className="chat__action chat__stop" type="button" onClick={onStop} aria-label="Stop">
+      <button
+        key="stop"
+        className="chat__action chat__stop"
+        type="button"
+        // Match Send's touch handling: the composer keeps focus on
+        // pointerdown, then dispatches the action on touchend instead of
+        // waiting for a synthesized click. Without this, a focused mobile
+        // textarea can eat the first Stop tap while the keyboard settles.
+        onPointerDown={(e) => e.preventDefault()}
+        onTouchEnd={(e) => { e.preventDefault(); onStop() }}
+        onClick={onStop}
+        aria-label="Stop"
+      >
         <svg width="16" height="16" viewBox="0 0 12 12" fill="currentColor">
           <rect width="12" height="12" rx="2" />
         </svg>

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -32,6 +32,9 @@ import {
   previewReadyAnnouncement,
   resolveFreshPinRetarget,
   resolveSteeredPinDecision,
+  shouldRetryStopAfterConfirm,
+  stopConfirmedIdle,
+  stopRequestSucceeded,
   serverSnapshotBehindLocal,
   shouldShowOpenAppCta,
   startedMessagesFromResponse,
@@ -52,6 +55,12 @@ const EMPTY_PROMPTS = [
   { label: 'Plan a task', prompt: 'Help me break down a task I need to finish this week.' },
   { label: 'Analyze an idea', prompt: 'Help me think through an idea and find the sharpest next step.' },
 ]
+
+const STOP_RETRY_DELAYS_MS = [0, 250, 700, 1200]
+
+function delay(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
 
 /** Cheap structural equality for chat-message arrays. Returns true when
  *  the lists have the same length AND the last message has the same
@@ -2054,12 +2063,12 @@ export default function ChatView({ chatId, onStreamEnd, onFirstMessage, onSystem
       forgetAllQueuedPinIntents()
       pendingQueue.clear()
 
-      let stoppedCleanly = true
+      let stoppedCleanly = false
       // The backend reports which queued ts it actually removed. null = an
       // older backend without the field (→ fall back to resending all); an
       // array is the authoritative cleared set.
       let clearedPendingTs = null
-      try {
+      const requestStopOnce = async () => {
         const stopRes = await fetch(`${BASE}/api/chat/stop`, {
           method: 'POST',
           headers: {
@@ -2068,28 +2077,66 @@ export default function ChatView({ chatId, onStreamEnd, onFirstMessage, onSystem
           },
           body: JSON.stringify({ chat_id: chatId }),
         })
+        let data = null
         if (stopRes.ok) {
           // stop_chat returns {stopped: false} when the SDK interrupt
           // timed out — the runner is still alive. We must NOT tear
           // down local state or re-send the collapsed queue, because
           // that would mean two concurrent runs of the same chat.
-          // Leave the stream attached and surface the failure so the
-          // user can retry. Network errors are treated as success-ish
-          // (we have to assume the proc died on our end too).
+          // Leave the stream attached so the user can retry. Likewise,
+          // a non-OK / missing response is NOT success: keeping Stop visible
+          // is safer than pretending the turn halted while the backend runs on.
           try {
-            const data = await stopRes.json()
-            if (data && data.stopped === false) stoppedCleanly = false
-            // Resend only what Stop truly cleared: a queued message the
-            // turn-end drain already promoted into a continuation (right as
-            // Stop landed) is gone from the queue, so it's absent here and
-            // must NOT be re-sent — that was the natural-finish-races-Stop
-            // double-send (PM 115).
-            if (Array.isArray(data?.cleared_pending_ts)) {
-              clearedPendingTs = data.cleared_pending_ts
-            }
-          } catch { /* non-JSON body — assume legacy success */ }
+            data = await stopRes.json()
+          } catch { /* non-JSON body — legacy success if HTTP itself was OK */ }
+          // Resend only what Stop truly cleared: a queued message the
+          // turn-end drain already promoted into a continuation (right as
+          // Stop landed) is gone from the queue, so it's absent here and
+          // must NOT be re-sent — that was the natural-finish-races-Stop
+          // double-send (PM 115).
+          if (clearedPendingTs === null && Array.isArray(data?.cleared_pending_ts)) {
+            clearedPendingTs = data.cleared_pending_ts
+          }
         }
-      } catch { /* network error during stop is non-critical */ }
+        return stopRequestSucceeded({ responseOk: stopRes.ok, data })
+      }
+      const confirmStopIdle = async () => {
+        try {
+          const res = await apiFetch(`/chats/${chatId}?limit=1`, { timeoutMs: 5000 })
+          if (!res.ok) return { failed: true, running: null }
+          const data = await res.json()
+          return { failed: false, running: data?.running }
+        } catch {
+          return { failed: true, running: null }
+        }
+      }
+      for (const retryDelayMs of STOP_RETRY_DELAYS_MS) {
+        if (retryDelayMs > 0) await delay(retryDelayMs)
+        let requestSucceeded = false
+        try {
+          requestSucceeded = await requestStopOnce()
+        } catch {
+          requestSucceeded = stopRequestSucceeded({ fetchFailed: true })
+        }
+        if (!requestSucceeded) {
+          stoppedCleanly = false
+          break
+        }
+        const confirmation = await confirmStopIdle()
+        stoppedCleanly = stopConfirmedIdle({
+          stopSucceeded: requestSucceeded,
+          confirmRunning: confirmation.running,
+          confirmFailed: confirmation.failed,
+        })
+        if (stoppedCleanly) break
+        if (!shouldRetryStopAfterConfirm({
+          requestSucceeded,
+          confirmRunning: confirmation.running,
+          confirmFailed: confirmation.failed,
+        })) {
+          break
+        }
+      }
 
       // Resolve WHAT to resend from the queued snapshot + the set the
       // backend reports it actually cleared, via the SHARED, pure

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -30,6 +30,7 @@ import {
   continuationRowsFromPromotedMessage,
   openAppCtaViewModel,
   previewReadyAnnouncement,
+  resolveFreshPinRetarget,
   resolveSteeredPinDecision,
   serverSnapshotBehindLocal,
   shouldShowOpenAppCta,
@@ -1657,6 +1658,11 @@ export default function ChatView({ chatId, onStreamEnd, onFirstMessage, onSystem
       isFirstUserMsg,
       wasNearScrollBottom: wasNearContentBottomAtSubmit,
     })
+    // The first rendered row uses this optimistic ts, but the backend often
+    // returns a canonical server ts a moment later. Carry the send-time intent
+    // across that swap so the "new sent message at the top" pin does not point
+    // at a removed optimistic DOM node on fast second sends / start races.
+    const freshPinIntent = makeSendPinIntent(willPin)
 
     const userMsg = { role: 'user', content: text, ts: Date.now(), optimistic: true }
     if (attachments.length > 0) userMsg.attachments = attachments
@@ -1743,12 +1749,30 @@ export default function ChatView({ chatId, onStreamEnd, onFirstMessage, onSystem
             pendingQueue.promoteManyByTs(result.message._consumed_ts)
           }
           const startedMessages = startedMessagesFromResponse(result)
+          const freshPin = resolveFreshPinRetarget({
+            startedMessages,
+            fallbackTs: userMsg.ts,
+            willPin,
+            pinIntent: freshPinIntent,
+            pinIntentStillCurrent,
+          })
+          if (freshPin.shouldPin) {
+            setSpacerActive(true)
+            if (spacerRef.current) spacerRef.current.style.height = '0px'
+            modeRef.current = { kind: 'PIN_USER_MSG', ts: freshPin.pinTargetTs }
+          } else if (freshPin.intentStillCurrent) {
+            settleNonPinMode(modeRef, scrollRef.current, { retireFollow: pin })
+          }
           if (startedMessages) {
             commitMessages(prev => appendMessageBatch(prev, startedMessages))
           }
           return
         }
         if (!result.started) {
+          const queuedPinStillValid = pinIntentStillCurrent(freshPinIntent)
+          if (queuedPinStillValid) {
+            settleNonPinMode(modeRef, scrollRef.current, { retireFollow: pin })
+          }
           setSending(false)
           setServerRunningState(false)
         }
@@ -1756,6 +1780,20 @@ export default function ChatView({ chatId, onStreamEnd, onFirstMessage, onSystem
       }
       const startedMessages = startedMessagesFromResponse(result)
       if (startedMessages) {
+        const freshPin = resolveFreshPinRetarget({
+          startedMessages,
+          fallbackTs: userMsg.ts,
+          willPin,
+          pinIntent: freshPinIntent,
+          pinIntentStillCurrent,
+        })
+        if (freshPin.shouldPin) {
+          setSpacerActive(true)
+          if (spacerRef.current) spacerRef.current.style.height = '0px'
+          modeRef.current = { kind: 'PIN_USER_MSG', ts: freshPin.pinTargetTs }
+        } else if (freshPin.intentStillCurrent) {
+          settleNonPinMode(modeRef, scrollRef.current, { retireFollow: pin })
+        }
         commitMessages(prev => {
           return replaceOptimisticWithBatch(prev, userMsg.ts, startedMessages)
         })

--- a/frontend/src/components/ChatView/MsgContent.jsx
+++ b/frontend/src/components/ChatView/MsgContent.jsx
@@ -2,7 +2,7 @@ import { memo } from 'react'
 import { StandardMarkdown } from './markdown/BlockRenderer.jsx'
 import ToolBlock from './ToolBlock.jsx'
 import ToolActivityGroup from './ToolActivityGroup.jsx'
-import { groupToolRuns } from './groupBlocks.js'
+import { groupToolRuns, coalesceThinkingEntries } from './groupBlocks.js'
 import QuestionCard from './QuestionCard.jsx'
 import Attachments from './Attachments.jsx'
 import CompactionCard from './CompactionCard.jsx'
@@ -236,7 +236,12 @@ function MsgContentInner({
     const entries = msg.blocks
       .map((block, i) => ({ item: block, idx: i }))
       .filter(({ idx }) => !skipToolIdx.has(idx))
-    const nodes = groupToolRuns(entries)
+    // Repair already-persisted transcripts where a continuous reasoning pass was
+    // fragmented into many thinking blocks: coalesce runs of adjacent thinking
+    // AFTER idx assignment (each survivor keeps its original persisted idx) so
+    // ToolBlock's blockIdx stays a correct absolute index into msg.blocks and the
+    // lazy tool-output fetch keeps working. See groupBlocks.coalesceThinkingEntries.
+    const nodes = groupToolRuns(coalesceThinkingEntries(entries))
 
     return (
       <>

--- a/frontend/src/components/ChatView/__tests__/chatRuntimeState.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatRuntimeState.test.js
@@ -9,8 +9,11 @@ import {
   resolveFreshPinRetarget,
   resolveSteeredPinDecision,
   serverSnapshotBehindLocal,
+  shouldRetryStopAfterConfirm,
   shouldShowOpenAppCta,
   startedMessagesFromResponse,
+  stopConfirmedIdle,
+  stopRequestSucceeded,
   systemEventForChat,
 } from '../chatRuntimeState.js'
 
@@ -177,4 +180,58 @@ test('resolveFreshPinRetarget yields to a user scroll after submit', () => {
     intentStillCurrent: false,
     shouldPin: false,
   })
+})
+
+
+test('stopRequestSucceeded requires a confirmed backend stop', () => {
+  assert.equal(stopRequestSucceeded({ responseOk: true, data: { stopped: true } }), true)
+  assert.equal(stopRequestSucceeded({ responseOk: true, data: {} }), true,
+    'legacy 200/non-json stop responses are accepted')
+  assert.equal(stopRequestSucceeded({ responseOk: true, data: { stopped: false } }), false)
+  assert.equal(stopRequestSucceeded({ responseOk: false, data: null }), false)
+  assert.equal(stopRequestSucceeded({ fetchFailed: true }), false)
+})
+
+test('stopConfirmedIdle requires the chat runtime to report idle', () => {
+  assert.equal(stopConfirmedIdle({
+    stopSucceeded: true,
+    confirmRunning: false,
+  }), true)
+  assert.equal(stopConfirmedIdle({
+    stopSucceeded: true,
+    confirmRunning: true,
+  }), false)
+  assert.equal(stopConfirmedIdle({
+    stopSucceeded: true,
+    confirmRunning: undefined,
+  }), false)
+  assert.equal(stopConfirmedIdle({
+    stopSucceeded: false,
+    confirmRunning: false,
+  }), false)
+  assert.equal(stopConfirmedIdle({
+    stopSucceeded: true,
+    confirmRunning: false,
+    confirmFailed: true,
+  }), false)
+})
+
+test('shouldRetryStopAfterConfirm retries only the start-window running race', () => {
+  assert.equal(shouldRetryStopAfterConfirm({
+    requestSucceeded: true,
+    confirmRunning: true,
+  }), true)
+  assert.equal(shouldRetryStopAfterConfirm({
+    requestSucceeded: true,
+    confirmRunning: false,
+  }), false)
+  assert.equal(shouldRetryStopAfterConfirm({
+    requestSucceeded: false,
+    confirmRunning: true,
+  }), false)
+  assert.equal(shouldRetryStopAfterConfirm({
+    requestSucceeded: true,
+    confirmRunning: true,
+    confirmFailed: true,
+  }), false)
 })

--- a/frontend/src/components/ChatView/__tests__/chatRuntimeState.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatRuntimeState.test.js
@@ -6,6 +6,7 @@ import {
   continuationRowsFromPromotedMessage,
   openAppCtaViewModel,
   previewReadyAnnouncement,
+  resolveFreshPinRetarget,
   resolveSteeredPinDecision,
   serverSnapshotBehindLocal,
   shouldShowOpenAppCta,
@@ -145,6 +146,34 @@ test('resolveSteeredPinDecision honors stale local intent over fallback', () => 
     pinIntentStillCurrent: () => false,
     fallbackWillPin: () => true,
   }), {
+    intentStillCurrent: false,
+    shouldPin: false,
+  })
+})
+
+test('resolveFreshPinRetarget moves pin from optimistic ts to canonical server ts', () => {
+  assert.deepEqual(resolveFreshPinRetarget({
+    startedMessages: [{ role: 'user', content: 'hello', ts: 222 }],
+    fallbackTs: 111,
+    willPin: true,
+    pinIntent: { willPin: true, userScrollIntentVersion: 1 },
+    pinIntentStillCurrent: () => true,
+  }), {
+    pinTargetTs: 222,
+    intentStillCurrent: true,
+    shouldPin: true,
+  })
+})
+
+test('resolveFreshPinRetarget yields to a user scroll after submit', () => {
+  assert.deepEqual(resolveFreshPinRetarget({
+    startedMessages: [{ role: 'user', content: 'hello', ts: 222 }],
+    fallbackTs: 111,
+    willPin: true,
+    pinIntent: { willPin: true, userScrollIntentVersion: 1 },
+    pinIntentStillCurrent: () => false,
+  }), {
+    pinTargetTs: 222,
     intentStillCurrent: false,
     shouldPin: false,
   })

--- a/frontend/src/components/ChatView/__tests__/composerStopTouch.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerStopTouch.test.js
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+const src = readFileSync(new URL('../ChatInputBar.jsx', import.meta.url), 'utf8')
+const stopBlock = src.match(/key="stop"[\s\S]*?aria-label="Stop"/)?.[0] || ''
+
+test('Stop dispatches on touchend and preserves composer focus on pointerdown', () => {
+  assert.match(stopBlock, /onPointerDown=\{\(e\) => e\.preventDefault\(\)\}/,
+    'Stop must not let a touch pointerdown blur the textarea before the action')
+  assert.match(stopBlock, /onTouchEnd=\{\(e\) => \{ e\.preventDefault\(\); onStop\(\) \}\}/,
+    'Stop should fire on touchend instead of relying on a synthesized click')
+  assert.match(stopBlock, /onClick=\{onStop\}/,
+    'Desktop click must keep working')
+})

--- a/frontend/src/components/ChatView/__tests__/groupBlocks.test.js
+++ b/frontend/src/components/ChatView/__tests__/groupBlocks.test.js
@@ -1,6 +1,11 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { groupToolRuns, toolGroupState, toolGroupSummary } from '../groupBlocks.js'
+import {
+  groupToolRuns,
+  coalesceThinkingEntries,
+  toolGroupState,
+  toolGroupSummary,
+} from '../groupBlocks.js'
 import { toolActivityLabel } from '../toolActivityLabel.js'
 
 const e = item => ({ item })
@@ -158,4 +163,60 @@ test('toolActivityLabel: maps known tools, falls back to the raw name', () => {
   assert.equal(toolActivityLabel(undefined), 'Tool')
   // Prototype-chain names must not resolve to Object internals.
   assert.equal(toolActivityLabel('constructor'), 'constructor')
+})
+
+
+const think = (content, duration_ms = 0) => ({ type: 'thinking', content, duration_ms })
+
+test('coalesceThinkingEntries: adjacent thinking merges into one, content + duration summed', () => {
+  const entries = [
+    { item: think('The sl', 700), idx: 0 },
+    { item: think('iders move', 500), idx: 1 },
+  ]
+  const out = coalesceThinkingEntries(entries)
+  assert.equal(out.length, 1)
+  assert.equal(out[0].item.content, 'The sliders move')
+  assert.equal(out[0].item.duration_ms, 1200)
+})
+
+test('coalesceThinkingEntries: preserves the FIRST survivor idx so tool blockIdx stays absolute', () => {
+  // Persisted shape [thinking, thinking, thinking, tool] — the fragmented case.
+  // The tool MUST keep idx 3 so ToolBlock's GET /tool-output?i=3 hits the real block.
+  const entries = [
+    { item: think('a', 100), idx: 0 },
+    { item: think('b', 100), idx: 1 },
+    { item: think('c', 100), idx: 2 },
+    { item: { type: 'tool', tool: 'Bash' }, idx: 3 },
+  ]
+  const out = coalesceThinkingEntries(entries)
+  assert.equal(out.length, 2)
+  assert.equal(out[0].idx, 0)
+  assert.equal(out[0].item.content, 'abc')
+  assert.equal(out[1].idx, 3)
+  assert.equal(out[1].item.type, 'tool')
+})
+
+test('coalesceThinkingEntries: thinking separated by a tool stays two distinct blocks', () => {
+  const entries = [
+    { item: think('first', 100), idx: 0 },
+    { item: { type: 'tool', tool: 'Bash' }, idx: 1 },
+    { item: think('second', 100), idx: 2 },
+  ]
+  const out = coalesceThinkingEntries(entries)
+  assert.deepEqual(out.map(x => x.item.type), ['thinking', 'tool', 'thinking'])
+  assert.deepEqual(out.map(x => x.idx), [0, 1, 2])
+})
+
+test('coalesceThinkingEntries: groupToolRuns after coalesce yields one thinking single + tool group', () => {
+  const entries = [
+    { item: think('a', 100), idx: 0 },
+    { item: think('b', 100), idx: 1 },
+    { item: { type: 'tool', tool: 'Read' }, idx: 2 },
+    { item: { type: 'tool', tool: 'Edit' }, idx: 3 },
+  ]
+  const nodes = groupToolRuns(coalesceThinkingEntries(entries))
+  assert.equal(nodes.length, 2)
+  assert.equal(nodes[0].single.item.type, 'thinking')
+  assert.equal(nodes[0].single.item.content, 'ab')
+  assert.equal(nodes[1].group.map(x => x.idx).join(','), '2,3')
 })

--- a/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
+++ b/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
@@ -151,6 +151,46 @@ test('pin reapply waits until the target is reachable to avoid stepwise pin jitt
   )
 })
 
+test('pin reapply holds a pinned send when streaming drags the viewport toward bottom', () => {
+  const scrollEl = {
+    scrollHeight: 2000,
+    // Target is 996. This simulates browser/follow-bottom drift after content
+    // streams below the pinned user row.
+    scrollTop: 1200,
+    clientHeight: 700,
+    querySelector(selector) {
+      if (selector === '.chat__msg--user[data-ts="123"]') {
+        return { offsetTop: 1000 }
+      }
+      return null
+    },
+  }
+
+  assert.equal(
+    _pinReapplyNeeded(scrollEl, { kind: 'PIN_USER_MSG', ts: 123 }, 1000),
+    true,
+  )
+})
+
+test('pin reapply is idle when the pinned send is still at its target', () => {
+  const scrollEl = {
+    scrollHeight: 2000,
+    scrollTop: 996,
+    clientHeight: 700,
+    querySelector(selector) {
+      if (selector === '.chat__msg--user[data-ts="123"]') {
+        return { offsetTop: 1000 }
+      }
+      return null
+    },
+  }
+
+  assert.equal(
+    _pinReapplyNeeded(scrollEl, { kind: 'PIN_USER_MSG', ts: 123 }, 1000),
+    false,
+  )
+})
+
 test('viewport resize at physical bottom retires stale pin mode', () => {
   const stalePin = { kind: 'PIN_USER_MSG', ts: 123 }
   assert.deepEqual(
@@ -256,7 +296,7 @@ test('spacer reservation is independent from pin mode', () => {
 
   assert.equal(
     _computeSpacerH(scrollEl, listEl, lastUserMsgEl, 600),
-    492,
+    576,
   )
 })
 
@@ -280,14 +320,14 @@ test('queued tray does not shorten spacer reservation', () => {
 
   assert.equal(
     _computeSpacerH(scrollEl, listEl, lastUserMsgEl, 600),
-    492,
+    576,
   )
 })
 
 // R5 regression contract: a send while at the bottom must pin the new user
 // message to the TOP, which requires the dynamic spacer to reserve enough
 // bottom room that the pin target is actually REACHABLE (maxScrollTop >=
-// pinTarget). It also leaves a small bottom-room cushion so the pinned row
+// pinTarget). It also leaves a real bottom-room cushion so the pinned row
 // does not feel cramped at the exact end of the scroll range. When
 // fullViewH is stale-SMALL (the keyboard-open height used after the keyboard
 // has already closed and grown clientHeight), the spacer is undersized, the
@@ -313,7 +353,7 @@ test('R5: spacer keeps the pin reachable when fullViewH tracks the (grown) clien
   const r = pinReachable({ fullViewH: 700, clientHeight: 700, listH: 1040, lastUserTop: 1000 })
   assert.equal(r.reachable, true, 'message can reach the top when fullViewH >= clientHeight')
   assert.ok(r.maxScrollTop > r.pinTarget, 'spacer leaves breathing room below the pinned message')
-  assert.equal(r.maxScrollTop - r.pinTarget, 96, 'bottom breathing room stays intentional and bounded')
+  assert.equal(r.maxScrollTop - r.pinTarget, 180, 'bottom breathing room stays intentional and bounded')
 })
 
 test('R5: a stale-small fullViewH undersizes the spacer and strands the pin mid-viewport (the bug)', () => {
@@ -321,6 +361,6 @@ test('R5: a stale-small fullViewH undersizes the spacer and strands the pin mid-
   // height (400) after clientHeight had already grown to 700.
   const r = pinReachable({ fullViewH: 400, clientHeight: 700, listH: 1040, lastUserTop: 1000 })
   assert.equal(r.reachable, false, 'stale-small fullViewH leaves the pin target unreachable')
-  assert.ok(r.pinTarget - r.maxScrollTop > 150,
+  assert.ok(r.pinTarget - r.maxScrollTop > 80,
     'the message is still stranded far below the top — visually mid-viewport')
 })

--- a/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
+++ b/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
@@ -256,7 +256,7 @@ test('spacer reservation is independent from pin mode', () => {
 
   assert.equal(
     _computeSpacerH(scrollEl, listEl, lastUserMsgEl, 600),
-    396,
+    492,
   )
 })
 
@@ -280,14 +280,15 @@ test('queued tray does not shorten spacer reservation', () => {
 
   assert.equal(
     _computeSpacerH(scrollEl, listEl, lastUserMsgEl, 600),
-    396,
+    492,
   )
 })
 
 // R5 regression contract: a send while at the bottom must pin the new user
 // message to the TOP, which requires the dynamic spacer to reserve enough
 // bottom room that the pin target is actually REACHABLE (maxScrollTop >=
-// pinTarget). The reachability reduces to: fullViewH >= clientHeight. When
+// pinTarget). It also leaves a small bottom-room cushion so the pinned row
+// does not feel cramped at the exact end of the scroll range. When
 // fullViewH is stale-SMALL (the keyboard-open height used after the keyboard
 // has already closed and grown clientHeight), the spacer is undersized, the
 // pin clamps short, and the message lands mid-viewport. The fix keeps
@@ -311,7 +312,8 @@ test('R5: spacer keeps the pin reachable when fullViewH tracks the (grown) clien
   // fullViewH is >= clientHeight, so the pin target is reachable → top pin.
   const r = pinReachable({ fullViewH: 700, clientHeight: 700, listH: 1040, lastUserTop: 1000 })
   assert.equal(r.reachable, true, 'message can reach the top when fullViewH >= clientHeight')
-  assert.equal(r.maxScrollTop, r.pinTarget, 'spacer reserves exactly enough — no phantom overscroll')
+  assert.ok(r.maxScrollTop > r.pinTarget, 'spacer leaves breathing room below the pinned message')
+  assert.equal(r.maxScrollTop - r.pinTarget, 96, 'bottom breathing room stays intentional and bounded')
 })
 
 test('R5: a stale-small fullViewH undersizes the spacer and strands the pin mid-viewport (the bug)', () => {
@@ -319,6 +321,6 @@ test('R5: a stale-small fullViewH undersizes the spacer and strands the pin mid-
   // height (400) after clientHeight had already grown to 700.
   const r = pinReachable({ fullViewH: 400, clientHeight: 700, listH: 1040, lastUserTop: 1000 })
   assert.equal(r.reachable, false, 'stale-small fullViewH leaves the pin target unreachable')
-  assert.ok(r.pinTarget - r.maxScrollTop > 250,
-    'the message is stranded hundreds of px below the top — visually mid-viewport')
+  assert.ok(r.pinTarget - r.maxScrollTop > 150,
+    'the message is still stranded far below the top — visually mid-viewport')
 })

--- a/frontend/src/components/ChatView/chatRuntimeState.js
+++ b/frontend/src/components/ChatView/chatRuntimeState.js
@@ -99,3 +99,23 @@ export function resolveSteeredPinDecision({
       && (pinIntent ? !!pinIntent.willPin : !!fallbackWillPin?.()),
   }
 }
+
+export function resolveFreshPinRetarget({
+  startedMessages,
+  fallbackTs,
+  willPin,
+  pinIntent,
+  pinIntentStillCurrent,
+}) {
+  const pinTargetTs = Array.isArray(startedMessages) && startedMessages.length > 0
+    ? startedMessages[0]?.ts
+    : fallbackTs
+  const intentStillCurrent = pinIntent
+    ? !!pinIntentStillCurrent?.(pinIntent)
+    : true
+  return {
+    pinTargetTs,
+    intentStillCurrent,
+    shouldPin: pinTargetTs != null && intentStillCurrent && !!willPin,
+  }
+}

--- a/frontend/src/components/ChatView/chatRuntimeState.js
+++ b/frontend/src/components/ChatView/chatRuntimeState.js
@@ -119,3 +119,28 @@ export function resolveFreshPinRetarget({
     shouldPin: pinTargetTs != null && intentStillCurrent && !!willPin,
   }
 }
+
+export function stopRequestSucceeded({ responseOk, data = null, fetchFailed = false }) {
+  if (fetchFailed) return false
+  if (!responseOk) return false
+  if (data && data.stopped === false) return false
+  return true
+}
+
+export function stopConfirmedIdle({
+  stopSucceeded,
+  confirmRunning,
+  confirmFailed = false,
+}) {
+  if (!stopSucceeded) return false
+  if (confirmFailed) return false
+  return confirmRunning === false
+}
+
+export function shouldRetryStopAfterConfirm({
+  requestSucceeded,
+  confirmRunning,
+  confirmFailed = false,
+}) {
+  return !!requestSucceeded && !confirmFailed && confirmRunning === true
+}

--- a/frontend/src/components/ChatView/groupBlocks.js
+++ b/frontend/src/components/ChatView/groupBlocks.js
@@ -43,6 +43,42 @@ export function groupToolRuns(entries) {
   return nodes
 }
 
+// Merge runs of ADJACENT thinking entries into one, so a persisted transcript
+// renders a continuous reasoning pass as a SINGLE "Thought for Ns" disclosure
+// instead of many tiny fragments. Fragments only exist in already-saved chats
+// from before the backend stopped closing the thinking run on transparent
+// bookkeeping events (see events.py _THINKING_INTERRUPTING_TYPES); the live path
+// already coalesces in streamReducers.appendThinkingChunk. This is a render-time
+// repair with no migration — same spirit as suppressedQuestionToolIndices.
+//
+// CRITICAL: this runs on the ENTRIES array (each `{ item, idx }`) AFTER idx has
+// been assigned from the persisted position, and it PRESERVES the first merged
+// entry's original `idx`. idx is an absolute reference into the persisted
+// msg.blocks (ToolBlock uses it for the lazy GET /tool-output fetch), so
+// re-deriving it from a shortened array would fetch the wrong block / 404. Only
+// truly-adjacent thinking entries merge; anything between them (a tool/text
+// block) breaks the run, so distinct reasoning segments around tool calls stay
+// separate. Pure — new entries, inputs untouched.
+export function coalesceThinkingEntries(entries) {
+  const out = []
+  for (const entry of entries) {
+    const prev = out[out.length - 1]
+    if (prev?.item?.type === 'thinking' && entry?.item?.type === 'thinking') {
+      out[out.length - 1] = {
+        ...prev,
+        item: {
+          ...prev.item,
+          content: (prev.item.content || '') + (entry.item.content || ''),
+          duration_ms: (prev.item.duration_ms || 0) + (entry.item.duration_ms || 0),
+        },
+      }
+    } else {
+      out.push(entry)
+    }
+  }
+  return out
+}
+
 // Derive the collapsed status of a tool group from its children: a failed tool
 // dominates (so a broken step is visible without expanding), then a running
 // tool, else done. Shared by ToolActivityGroup, which maps this to the header

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -167,12 +167,15 @@ function _validateSavedMode(saved, messages, scrollEl) {
  *  The spacer's only job is reserving bottom room — it does NOT touch
  *  scrollTop and it does NOT decide whether a send pins.
  *
- *  Formula: max(0, viewH + (lastUserMsgTop − PIN_OFFSET) − listH).
+ *  Formula:
+ *    max(0, viewH + (lastUserMsgTop − PIN_OFFSET) − listH
+ *           + PIN_BOTTOM_ROOM).
  *
  *  The (− PIN_OFFSET) must match applyMode's PIN_USER_MSG target so
- *  scrollTop-max equals the PIN target — otherwise the message
- *  lands PIN_OFFSET pixels below the top (visual "extra space" at
- *  the top + phantom over-scroll room at the bottom).
+ *  the target is reachable. PIN_BOTTOM_ROOM deliberately leaves a little
+ *  real scroll room under the pinned message instead of stranding the new
+ *  send exactly at maxScrollTop; without it, the row can technically be at
+ *  the top while still feeling cramped / end-stopped.
  *
  *  Reservation is intentionally independent from pinning. The send rule
  *  decides whether to move scrollTop (first message / already at bottom).
@@ -181,12 +184,13 @@ function _validateSavedMode(saved, messages, scrollEl) {
  *  that message lose its reachable "top of screen" position.
  */
 const PIN_OFFSET = 4
+const PIN_BOTTOM_ROOM = 96
 export function _computeSpacerH(scrollEl, listEl, lastUserMsgEl, fullViewH) {
   if (!scrollEl || !listEl) return 0
   if (!lastUserMsgEl) return 0
   const viewH = fullViewH || scrollEl.clientHeight
   const pinTarget = Math.max(0, lastUserMsgEl.offsetTop - PIN_OFFSET)
-  return Math.max(0, viewH + pinTarget - listEl.offsetHeight)
+  return Math.max(0, viewH + pinTarget - listEl.offsetHeight + PIN_BOTTOM_ROOM)
 }
 
 

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -136,9 +136,12 @@ export function _pinReapplyNeeded(scrollEl, mode, lastPinTop) {
   if (!el) return false
   const target = Math.max(0, el.offsetTop - PIN_OFFSET)
   const maxScrollTop = scrollEl.scrollHeight - scrollEl.clientHeight
+  const targetReachable = maxScrollTop >= target - 1
   const clampedShort = scrollEl.scrollTop < target - 1
-    && maxScrollTop >= target - 1
-  return el.offsetTop !== lastPinTop || clampedShort
+    && targetReachable
+  const driftedPastTarget = scrollEl.scrollTop > target + 1
+    && targetReachable
+  return el.offsetTop !== lastPinTop || clampedShort || driftedPastTarget
 }
 
 
@@ -172,8 +175,8 @@ function _validateSavedMode(saved, messages, scrollEl) {
  *           + PIN_BOTTOM_ROOM).
  *
  *  The (− PIN_OFFSET) must match applyMode's PIN_USER_MSG target so
- *  the target is reachable. PIN_BOTTOM_ROOM deliberately leaves a little
- *  real scroll room under the pinned message instead of stranding the new
+ *  the target is reachable. PIN_BOTTOM_ROOM deliberately leaves real
+ *  scroll room under the pinned message instead of stranding the new
  *  send exactly at maxScrollTop; without it, the row can technically be at
  *  the top while still feeling cramped / end-stopped.
  *
@@ -184,7 +187,7 @@ function _validateSavedMode(saved, messages, scrollEl) {
  *  that message lose its reachable "top of screen" position.
  */
 const PIN_OFFSET = 4
-const PIN_BOTTOM_ROOM = 96
+const PIN_BOTTOM_ROOM = 180
 export function _computeSpacerH(scrollEl, listEl, lastUserMsgEl, fullViewH) {
   if (!scrollEl || !listEl) return 0
   if (!lastUserMsgEl) return 0

--- a/frontend/src/components/SettingsView/SettingsView.css
+++ b/frontend/src/components/SettingsView/SettingsView.css
@@ -338,14 +338,20 @@
 .settings-bg-row {
   position: relative;
   display: grid;
-  grid-template-columns: 32px minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr);
   align-items: center;
-  gap: 10px;
   min-height: 54px;
   padding: 8px;
   border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
   border-radius: 8px;
   background: color-mix(in srgb, var(--surface) 68%, var(--bg));
+  /* The whole row is the drag handle now — press and hold to reorder.
+     Keep default touch-action so a plain swipe still scrolls the page;
+     the JS only claims the gesture once a still hold has elapsed. */
+  cursor: grab;
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
   transition:
     transform 0.18s cubic-bezier(0.22, 1, 0.36, 1),
     background 0.15s ease,
@@ -364,6 +370,10 @@
   background: color-mix(in srgb, var(--accent) 7%, var(--surface));
   box-shadow: 0 4px 8px rgb(0 0 0 / 18%);
   opacity: 0.96;
+  cursor: grabbing;
+  /* Once a hold has become a drag, stop the page from scrolling under
+     the finger so the vertical drag reorders instead. */
+  touch-action: none;
 }
 
 .settings-bg-row--drop-target {
@@ -397,38 +407,9 @@
   opacity: 0.78;
 }
 
-.settings-bg-row__icon {
-  width: 32px;
-  height: 32px;
-  border-radius: 8px;
-  border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
-  background: color-mix(in srgb, var(--surface2) 72%, var(--surface));
-  color: var(--text);
-  display: grid;
-  place-items: center;
-  flex-shrink: 0;
-  font-size: 13px;
-  cursor: grab;
-  user-select: none;
-  touch-action: none;
-}
-
-.settings-bg-row__icon:active {
-  cursor: grabbing;
-}
-
-.settings-bg-row--dragging .settings-bg-row__icon {
-  cursor: grabbing;
-}
-
-.settings-bg-row__icon svg {
-  pointer-events: none;
-}
-
-/* Body stacks the model trigger over the effort stepper, both full
-   width. The grip stays in its own grid column so drag-to-reorder is
-   unchanged; only the model control modernized from a native <select>
-   to the shared bottom-sheet trigger. */
+/* The body holds the model trigger, full width. Effort moved into the
+   model sheet (under the selected model), and the grip column is gone —
+   the whole row is the drag handle now. */
 .settings-bg-row__body {
   min-width: 0;
   display: flex;
@@ -444,8 +425,7 @@
 
 @media (max-width: 620px) {
   .settings-bg-row {
-    grid-template-columns: 30px minmax(0, 1fr);
-    gap: 8px;
+    grid-template-columns: minmax(0, 1fr);
     padding-inline: 6px;
   }
 }

--- a/frontend/src/components/SettingsView/SettingsView.jsx
+++ b/frontend/src/components/SettingsView/SettingsView.jsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { GripVertical } from 'lucide-react'
 import { useQueryClient } from '@tanstack/react-query'
 import { Switch } from '@openai/apps-sdk-ui/components/Switch'
 import { Alert } from '@openai/apps-sdk-ui/components/Alert'
@@ -14,7 +13,6 @@ import ProviderAuth from '../ProviderAuth/ProviderAuth.jsx'
 import CodexAuth from '../ProviderAuth/CodexAuth.jsx'
 import ProviderRow from '../ProviderAuth/ProviderRow.jsx'
 import StatusDot from '../ui/StatusDot.jsx'
-import EffortStepper from '../ui/EffortStepper.jsx'
 import ModelSheet from '../ui/ModelSheet.jsx'
 import ManageModelsModal from '../ChatView/ManageModelsModal.jsx'
 import UpdateReviewModal from './UpdateReviewModal.jsx'
@@ -122,11 +120,83 @@ function BackgroundProviderRow({
   const enabled = row.enabled !== false
   const selectedModel = enabled ? (row.model || defaultModel(row.provider)) : ''
   const selectedRow = models.find((m) => m.id === selectedModel)
+  const efforts = info?.efforts || []
+  const effortLabel = enabled
+    ? (efforts.find((e) => e.value === row.effort)?.label || '')
+    : ''
   const [sheetOpen, setSheetOpen] = useState(false)
+
+  // Press-and-hold anywhere on the row to drag it — there's no separate
+  // grip handle. A quick tap still opens the model sheet; only a
+  // deliberate hold that doesn't turn into a scroll starts a reorder.
+  const holdTimerRef = useRef(null)
+  const pressRef = useRef(null)
+  const draggedRef = useRef(false)
+  const clearHold = () => {
+    if (holdTimerRef.current) {
+      clearTimeout(holdTimerRef.current)
+      holdTimerRef.current = null
+    }
+  }
+  useEffect(() => clearHold, [])
+  const handleRowPointerDown = (event) => {
+    if (event.button !== undefined && event.button !== 0) return
+    // The open sheet's full-screen backdrop is a DOM descendant of this
+    // row, so its presses bubble here — don't let them arm a drag.
+    if (sheetOpen) return
+    draggedRef.current = false
+    pressRef.current = {
+      x: event.clientX,
+      y: event.clientY,
+      pointerId: event.pointerId,
+      node: event.currentTarget,
+    }
+    clearHold()
+    holdTimerRef.current = window.setTimeout(() => {
+      holdTimerRef.current = null
+      const press = pressRef.current
+      if (!press) return
+      draggedRef.current = true
+      onReorderStart(index, {
+        clientY: press.y,
+        pointerId: press.pointerId,
+        node: press.node,
+      })
+    }, 240)
+  }
+  const handleRowPointerMove = (event) => {
+    if (draggedRef.current) return
+    const press = pressRef.current
+    if (!press) return
+    // Movement before the hold elapses means the finger is scrolling,
+    // not holding — cancel the pending drag and let the page scroll.
+    if (
+      Math.abs(event.clientY - press.y) > 10
+      || Math.abs(event.clientX - press.x) > 10
+    ) {
+      clearHold()
+      pressRef.current = null
+    }
+  }
+  const handleRowPointerUp = () => {
+    clearHold()
+    pressRef.current = null
+  }
+  const handleRowClickCapture = (event) => {
+    // Swallow the click that ends a hold-drag so releasing over the
+    // model trigger doesn't also pop the sheet open.
+    if (draggedRef.current) {
+      event.preventDefault()
+      event.stopPropagation()
+      draggedRef.current = false
+    }
+  }
+
   // This row is a fixed provider, so the sheet shows only that
   // provider's models plus a "None" row that disables the background
-  // agent (the old <select>'s empty option). The active model floats
-  // to the top of the list.
+  // agent. Effort lives inside the sheet, under the selected model:
+  // providers expose different effort scales, so it belongs with the
+  // model choice (mirrors the chat composer's picker).
   const groups = [{
     key: row.provider,
     label: info?.label || row.provider,
@@ -148,28 +218,24 @@ function BackgroundProviderRow({
       }
       style={dragStyle}
       aria-label={`${info?.label || row.provider} background priority ${index + 1}`}
+      onPointerDown={handleRowPointerDown}
+      onPointerMove={handleRowPointerMove}
+      onPointerUp={handleRowPointerUp}
+      onPointerCancel={handleRowPointerUp}
+      onClickCapture={handleRowClickCapture}
+      onKeyDown={(event) => {
+        // Alt+Arrow reorders from the keyboard. Focus lands on the model
+        // trigger; requiring Alt keeps plain arrows free for scrolling.
+        if (!event.altKey) return
+        if (event.key === 'ArrowUp') {
+          event.preventDefault()
+          onMove(-1)
+        } else if (event.key === 'ArrowDown') {
+          event.preventDefault()
+          onMove(1)
+        }
+      }}
     >
-      <span
-        className="settings-bg-row__icon"
-        title="Drag to change priority"
-        role="button"
-        tabIndex={0}
-        aria-label={`Drag ${info?.label || row.provider} to change priority`}
-        onPointerDown={(event) => onReorderStart(event, index)}
-        onKeyDown={(event) => {
-          if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') {
-            event.preventDefault()
-            onMove(-1)
-          } else if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
-            event.preventDefault()
-            onMove(1)
-          }
-        }}
-      >
-        {/* Drag-to-reorder grip. The provider's own logo lives in the
-            model trigger below; showing it here too doubled the logo. */}
-        <GripVertical size={16} aria-hidden="true" />
-      </span>
       <div className="settings-bg-row__body">
         <button
           type="button"
@@ -177,6 +243,7 @@ function BackgroundProviderRow({
           onClick={() => setSheetOpen(true)}
           aria-haspopup="dialog"
           aria-label={`${info?.label || row.provider} background model`}
+          title="Press and hold to reorder"
         >
           <span className="model-trigger__icon">
             {Logo ? <Logo /> : (row.provider[0] || '?').toUpperCase()}
@@ -187,15 +254,11 @@ function BackgroundProviderRow({
               <span className="model-trigger__id">{selectedModel}</span>
             )}
           </span>
+          {effortLabel && (
+            <span className="model-trigger__effort">{effortLabel}</span>
+          )}
           <span className="model-trigger__caret" aria-hidden="true">▾</span>
         </button>
-        <EffortStepper
-          efforts={info?.efforts || []}
-          value={row.effort}
-          disabled={!enabled}
-          ariaLabel={`${info?.label || row.provider} background effort`}
-          onChange={onEffortChange}
-        />
       </div>
       <ModelSheet
         open={sheetOpen}
@@ -204,6 +267,9 @@ function BackgroundProviderRow({
         groups={groups}
         provider={enabled ? row.provider : ''}
         model={selectedModel}
+        efforts={efforts}
+        effort={row.effort}
+        onEffortChange={onEffortChange}
         onPick={(pid, id) => onModelChange(id)}
         allowNone
         noneLabel="None (disable)"
@@ -527,9 +593,11 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
     return rows.length - 1
   }, [])
 
-  const startBackgroundReorder = useCallback((event, index) => {
-    if (event.button !== undefined && event.button !== 0) return
-    const node = backgroundRowRefs.current[index]
+  // Called by a row once its press-and-hold elapses. `pointer` carries
+  // the captured hold position/id (the original pointerdown event is
+  // long gone by the time the hold timer fires).
+  const startBackgroundReorder = useCallback((index, pointer) => {
+    const node = backgroundRowRefs.current[index] || pointer?.node
     if (!node) return
     const rowRect = node.getBoundingClientRect()
     const rows = backgroundRowRefs.current
@@ -542,13 +610,12 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
         center: rect.top + rect.height / 2,
       }
     }).filter(Boolean)
-    event.preventDefault()
-    event.stopPropagation()
-    event.currentTarget.setPointerCapture?.(event.pointerId)
+    try { node.setPointerCapture?.(pointer?.pointerId) } catch { /* best-effort */ }
+    const grabY = typeof pointer?.clientY === 'number' ? pointer.clientY : rowRect.top
     const next = {
       fromIndex: index,
       toIndex: index,
-      grabOffsetY: event.clientY - rowRect.top,
+      grabOffsetY: grabY - rowRect.top,
       rowHeight: rowRect.height,
       slots,
     }
@@ -1158,8 +1225,8 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
                   <div>
                     <h3 className="settings__agent-title">Background agents</h3>
                     <p className="settings__subtext settings__subtext--tight">
-                      Priority order. Drag the handle to reorder; if quota or auth fails,
-                      Möbius tries the next enabled agent.
+                      Priority order. Press and hold a row to reorder; if quota or auth
+                      fails, Möbius tries the next enabled agent.
                     </p>
                   </div>
                 </div>

--- a/frontend/src/components/SettingsView/SettingsView.jsx
+++ b/frontend/src/components/SettingsView/SettingsView.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
+import { GripVertical } from 'lucide-react'
 import { useQueryClient } from '@tanstack/react-query'
 import { Switch } from '@openai/apps-sdk-ui/components/Switch'
 import { Alert } from '@openai/apps-sdk-ui/components/Alert'
@@ -165,7 +166,9 @@ function BackgroundProviderRow({
           }
         }}
       >
-        {Logo ? <Logo /> : row.provider.slice(0, 1).toUpperCase()}
+        {/* Drag-to-reorder grip. The provider's own logo lives in the
+            model trigger below; showing it here too doubled the logo. */}
+        <GripVertical size={16} aria-hidden="true" />
       </span>
       <div className="settings-bg-row__body">
         <button
@@ -1155,7 +1158,7 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
                   <div>
                     <h3 className="settings__agent-title">Background agents</h3>
                     <p className="settings__subtext settings__subtext--tight">
-                      Priority order. Drag a logo to reorder; if quota or auth fails,
+                      Priority order. Drag the handle to reorder; if quota or auth fails,
                       Möbius tries the next enabled agent.
                     </p>
                   </div>

--- a/frontend/src/components/ui/ModelSheet.css
+++ b/frontend/src/components/ui/ModelSheet.css
@@ -71,10 +71,32 @@
   white-space: nowrap;
 }
 
+/* A compact read-only summary of the current reasoning effort on the
+   collapsed trigger — the actual control lives inside the sheet, but
+   this keeps the level glanceable without opening it. */
+.model-trigger__effort {
+  flex-shrink: 0;
+  font-size: 11px;
+  line-height: 1;
+  font-weight: 500;
+  padding: 3px 7px;
+  border-radius: 999px;
+  color: var(--muted);
+  background: color-mix(in srgb, var(--accent) 12%, var(--surface2));
+  border: 1px solid color-mix(in srgb, var(--accent) 24%, var(--border));
+  white-space: nowrap;
+}
+
 .model-trigger__caret {
   color: var(--muted);
   font-size: 11px;
   flex-shrink: 0;
+}
+
+/* Reasoning-effort stepper nested under the selected model row, indented
+   to align beneath the row title (row pad 10 + icon 30 + gap 12). */
+.model-sheet__effort {
+  margin: 2px 10px 8px 52px;
 }
 
 /* ── sheet ──────────────────────────────────────────────── */

--- a/frontend/src/components/ui/ModelSheet.jsx
+++ b/frontend/src/components/ui/ModelSheet.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react'
+import EffortStepper from './EffortStepper.jsx'
 import './ModelSheet.css'
 
 /**
@@ -17,6 +18,13 @@ import './ModelSheet.css'
  * the current selection — the owner must always be able to see and
  * switch away from what's active. `allowNone` adds a leading "none"
  * row for the optional fallback slot; picking it calls `onNone`.
+ *
+ * When `efforts` is passed, a reasoning-effort stepper renders inline
+ * under the selected model row (the effort scale is provider-specific,
+ * so it belongs with the model choice — this mirrors the chat
+ * composer's picker). Providing `efforts` also keeps the sheet OPEN on
+ * a model pick so the owner can set effort in the same interaction;
+ * without it, picking a model closes the sheet as before.
  */
 export default function ModelSheet({
   open,
@@ -30,7 +38,11 @@ export default function ModelSheet({
   allowNone = false,
   noneLabel = 'No fallback',
   onNone,
+  efforts,
+  effort,
+  onEffortChange,
 }) {
+  const hasEfforts = Array.isArray(efforts) && efforts.length > 0
   const closeRef = useRef(null)
 
   useEffect(() => {
@@ -97,20 +109,31 @@ export default function ModelSheet({
                   const on = provider === group.key && model === m.id
                   const disabled = !connected && !on
                   return (
-                    <button
-                      key={`${group.key}-${m.id}`}
-                      type="button"
-                      className={`model-sheet__row${on ? ' model-sheet__row--sel' : ''}`}
-                      disabled={disabled}
-                      onClick={() => { onPick(group.key, m.id); onClose() }}
-                    >
-                      <span className="model-sheet__row-icon">{Logo && <Logo />}</span>
-                      <span className="model-sheet__row-main">
-                        <span className="model-sheet__row-title">{m.name || m.label || m.id}</span>
-                        <span className="model-sheet__row-id">{m.id}</span>
-                      </span>
-                      {on && <span className="model-sheet__check" aria-hidden="true" />}
-                    </button>
+                    <div key={`${group.key}-${m.id}`}>
+                      <button
+                        type="button"
+                        className={`model-sheet__row${on ? ' model-sheet__row--sel' : ''}`}
+                        disabled={disabled}
+                        onClick={() => { onPick(group.key, m.id); if (!hasEfforts) onClose() }}
+                      >
+                        <span className="model-sheet__row-icon">{Logo && <Logo />}</span>
+                        <span className="model-sheet__row-main">
+                          <span className="model-sheet__row-title">{m.name || m.label || m.id}</span>
+                          <span className="model-sheet__row-id">{m.id}</span>
+                        </span>
+                        {on && <span className="model-sheet__check" aria-hidden="true" />}
+                      </button>
+                      {on && hasEfforts && (
+                        <div className="model-sheet__effort">
+                          <EffortStepper
+                            efforts={efforts}
+                            value={effort}
+                            onChange={onEffortChange}
+                            ariaLabel="Reasoning effort"
+                          />
+                        </div>
+                      )}
+                    </div>
                   )
                 })}
               </div>


### PR DESCRIPTION
The in-product prod agent accumulated seven local commits on its platform clone over the last day — real fixes with tests, developed against live usage. This PR upstreams them verbatim (authorship preserved, no host-side edits) so they stop living only on one instance and the prod clone converges back to origin/main on its next update.

The seven, in order: stray-origin-remote guard for synthetic app updates (+ two regression tests); fresh send-pin retention across the server ts swap; chat stop startup-race + send-spacing fix (backend + frontend, with terminal-completion and Codex-runner tests); pinned-live-send hold during streaming (useScrollMode, with lock-in tests); thinking-block fragmentation fix (provider ping heartbeats between thinking_deltas were closing the run on every bookkeeping event — one reasoning pass rendered as dozens of 1-second blocks); doubled provider logo fix; Settings background-agents rework (hold-to-drag reorder, effort control moved into the model sheet — owner-requested).

Reviewed host-side commit-by-commit: no instance-specific content (scanned for domains, tokens, data paths), all changes carry tests, the scroll/stop-contract surfaces are covered by the existing lock-in specs. Backend 1845 passed / 1 skipped; frontend suites fail 0. Prefer a rebase-merge to keep the seven commits distinct and bisectable — each is an independent logical change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)