### PR TITLE
Deficit-only spacer: drop the flat pin cushion that broke fits-viewport chats

### DIFF
--- a/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
+++ b/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
@@ -294,9 +294,12 @@ test('spacer reservation is independent from pin mode', () => {
   const listEl = { offsetHeight: 900 }
   const lastUserMsgEl = { offsetTop: 700 }
 
+  // Deficit-only: 600 + (700 − 4) − 900. No flat cushion — see the
+  // _computeSpacerH docblock for why any additive bottom room breaks
+  // the send-rule / spacer lock-in specs.
   assert.equal(
     _computeSpacerH(scrollEl, listEl, lastUserMsgEl, 600),
-    576,
+    396,
   )
 })
 
@@ -320,20 +323,66 @@ test('queued tray does not shorten spacer reservation', () => {
 
   assert.equal(
     _computeSpacerH(scrollEl, listEl, lastUserMsgEl, 600),
-    576,
+    396,
+  )
+})
+
+test('fits-viewport chat: no phantom room — the pin sits at the true content bottom', () => {
+  // The geometry the overflow tests above never cover: a short chat whose
+  // whole conversation (listH 191) fits the viewport (viewH 857) — a first
+  // short send on a phone. A flat PIN_BOTTOM_ROOM cushion here reserved
+  // 180px of phantom scroll room below the pinned row, so the true-bottom
+  // gap read ≈ ROOM, isNearContentBottom classified the reader as away
+  // from the tail, and the NEXT send refused to pin (the send-rule
+  // "second send still pins" regression). Deficit-only sizing makes
+  // maxScrollTop land exactly on the pin target: reachable, no void below.
+  const scrollEl = makeSpacerScrollEl({ clientHeight: 857 })
+  const listEl = { offsetHeight: 191 }
+  const lastUserMsgEl = { offsetTop: 8 }
+
+  const spacerH = _computeSpacerH(scrollEl, listEl, lastUserMsgEl, 857)
+  assert.equal(spacerH, 670) // 857 + (8 − 4) − 191
+  const maxScrollTop = (191 + spacerH) - 857
+  const pinTarget = 8 - 4
+  assert.equal(maxScrollTop, pinTarget,
+    'pin target is exactly reachable with zero phantom room below')
+  assert.ok(spacerH <= 857,
+    'reserved spacer stays within one viewport on a fits chat')
+})
+
+test('spacer decays continuously to zero as content outgrows the viewport', () => {
+  // Continuity guard across the overflow boundary: as content streams in,
+  // the spacer shrinks 1:1 with listH growth and reaches EXACTLY 0 once
+  // the content below the pin fills the viewport (spacer.spec case 5's
+  // lock-in) — no residual and no scrollHeight step mid-stream.
+  const scrollEl = makeSpacerScrollEl({ clientHeight: 600 })
+  const lastUserMsgEl = { offsetTop: 100 }
+
+  // listH == viewH: only the pin deficit remains.
+  assert.equal(
+    _computeSpacerH(scrollEl, { offsetHeight: 600 }, lastUserMsgEl, 600),
+    96,
+  )
+  // 90px more content → 90px less spacer.
+  assert.equal(
+    _computeSpacerH(scrollEl, { offsetHeight: 690 }, lastUserMsgEl, 600),
+    6,
+  )
+  // Content below the pin fills the viewport → spacer is exactly 0.
+  assert.equal(
+    _computeSpacerH(scrollEl, { offsetHeight: 900 }, lastUserMsgEl, 600),
+    0,
   )
 })
 
 // R5 regression contract: a send while at the bottom must pin the new user
 // message to the TOP, which requires the dynamic spacer to reserve enough
 // bottom room that the pin target is actually REACHABLE (maxScrollTop >=
-// pinTarget). It also leaves a real bottom-room cushion so the pinned row
-// does not feel cramped at the exact end of the scroll range. When
-// fullViewH is stale-SMALL (the keyboard-open height used after the keyboard
-// has already closed and grown clientHeight), the spacer is undersized, the
-// pin clamps short, and the message lands mid-viewport. The fix keeps
-// fullViewHRef >= clientHeight at every sizeSpacer() call (grow guard), so
-// this asserts the math the fix preserves.
+// pinTarget). When fullViewH is stale-SMALL (the keyboard-open height used
+// after the keyboard has already closed and grown clientHeight), the spacer
+// is undersized, the pin clamps short, and the message lands mid-viewport.
+// The fix keeps fullViewHRef >= clientHeight at every sizeSpacer() call
+// (grow guard), so this asserts the math the fix preserves.
 function pinReachable({ fullViewH, clientHeight, listH, lastUserTop }) {
   const scrollEl = makeScrollEl({
     scrollHeight: 0, scrollTop: 0, clientHeight,
@@ -352,8 +401,8 @@ test('R5: spacer keeps the pin reachable when fullViewH tracks the (grown) clien
   // fullViewH is >= clientHeight, so the pin target is reachable → top pin.
   const r = pinReachable({ fullViewH: 700, clientHeight: 700, listH: 1040, lastUserTop: 1000 })
   assert.equal(r.reachable, true, 'message can reach the top when fullViewH >= clientHeight')
-  assert.ok(r.maxScrollTop > r.pinTarget, 'spacer leaves breathing room below the pinned message')
-  assert.equal(r.maxScrollTop - r.pinTarget, 180, 'bottom breathing room stays intentional and bounded')
+  assert.equal(r.maxScrollTop, r.pinTarget,
+    'deficit-only spacer lands maxScrollTop exactly on the pin target — no phantom room')
 })
 
 test('R5: a stale-small fullViewH undersizes the spacer and strands the pin mid-viewport (the bug)', () => {

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -170,15 +170,33 @@ function _validateSavedMode(saved, messages, scrollEl) {
  *  The spacer's only job is reserving bottom room — it does NOT touch
  *  scrollTop and it does NOT decide whether a send pins.
  *
- *  Formula:
- *    max(0, viewH + (lastUserMsgTop − PIN_OFFSET) − listH
- *           + PIN_BOTTOM_ROOM).
+ *  Formula: max(0, viewH + (lastUserMsgTop − PIN_OFFSET) − listH).
  *
- *  The (− PIN_OFFSET) must match applyMode's PIN_USER_MSG target so
- *  the target is reachable. PIN_BOTTOM_ROOM deliberately leaves real
- *  scroll room under the pinned message instead of stranding the new
- *  send exactly at maxScrollTop; without it, the row can technically be at
- *  the top while still feeling cramped / end-stopped.
+ *  The (− PIN_OFFSET) must match applyMode's PIN_USER_MSG target so the
+ *  target is reachable: with the spacer active, maxScrollTop lands
+ *  exactly on the pin target.
+ *
+ *  The spacer reserves only the DEFICIT — the room the content below
+ *  the pinned message still needs to fill one keyboard-closed viewport.
+ *  It never adds artificial scroll room past the true content bottom.
+ *  A flat PIN_BOTTOM_ROOM cushion (added unconditionally to the
+ *  formula) was tried and reverted: on a chat that fits the viewport it
+ *  left the pinned row ~ROOM px above the true scroll bottom, so
+ *  isNearContentBottom read the reader as away from the tail and the
+ *  NEXT send refused to pin (the send-rule "second send still pins"
+ *  regression); the reserved spacer could exceed a full viewport; and
+ *  the spacer no longer reached 0 once streamed content outgrew the
+ *  viewport. Those three behaviors are the lock-in contract
+ *  (send-rule.spec.mjs, spacer.spec.mjs cases 1-3/5/8/10): any cushion
+ *  big enough to feel is big enough to break them. Real scroll room
+ *  below the pin appears the honest way — from content: once the reply
+ *  outgrows the viewport, maxScrollTop moves past the pin target by
+ *  exactly the overflow.
+ *
+ *  PIN_BOTTOM_ROOM stays declared (not applied) because
+ *  chatContract.js mirrors it and the constants-drift guard pins the
+ *  declaration text; the contract-side meaning of the cushion is
+ *  adjudicated there, not here.
  *
  *  Reservation is intentionally independent from pinning. The send rule
  *  decides whether to move scrollTop (first message / already at bottom).
@@ -193,7 +211,7 @@ export function _computeSpacerH(scrollEl, listEl, lastUserMsgEl, fullViewH) {
   if (!lastUserMsgEl) return 0
   const viewH = fullViewH || scrollEl.clientHeight
   const pinTarget = Math.max(0, lastUserMsgEl.offsetTop - PIN_OFFSET)
-  return Math.max(0, viewH + pinTarget - listEl.offsetHeight + PIN_BOTTOM_ROOM)
+  return Math.max(0, viewH + pinTarget - listEl.offsetHeight)
 }
 
 


### PR DESCRIPTION
Main has been red for three consecutive e2e runs (11 tests: send-rule.spec.mjs:262 + spacer.spec.mjs 1/2/3/5/8/10). Root cause is deterministic geometry, not flakiness: PIN_BOTTOM_ROOM was added as a flat, unconditional cushion in _computeSpacerH (96px in 8f1ced9f, raised to 180px in a1ee2db9). Because the spacer is a sibling of the list, a pinned fits-viewport chat gets phantom scroll room below the true content equal to the cushion — the true-bottom gap reads 181, isNearContentBottom classifies the reader as away from the tail, and the NEXT send refuses to pin (the owner's non-negotiable second-send invariant). Short exchanges also reserved a spacer taller than the viewport (899 > 857), and the spacer stopped decaying to exactly 0 once content outgrew the viewport.

Reproduced red deterministically on a fast host in bundled chromium AND system Chrome against a byte-verified served bundle — the earlier "passes locally" readings were artifacts (a stale /data/platform overlay bundle in one case, an exit-code-masking pipe in another). A cushion ramp was evaluated and is provably either a no-op or a spec violation (max(0, D + clamp(-D, 0, 180)) === max(0, D)), so the fix is deficit-only reservation: spacer = max(0, viewH + pinTarget - listH). Real scroll room below the pin comes from content overflow, the honest way. The a1ee2db9 drift-hold (_pinReapplyNeeded) is preserved untouched; PIN_BOTTOM_ROOM stays declared because chatContract.js mirrors the constant — whether a felt cushion is desirable is a spec-level owner decision documented in the docblock.

Tests: two new lock-ins (fits-viewport no-phantom-room; continuous decay to exact 0), R5 contract updated to exact-reachability, the two drift-hold tests kept as-is. Evidence: failing cluster red x2 on origin/main bundle, 8/8 green x2 on the fixed bundle, full e2e 163 passed / 0 failed / 1 known-class flaky (exit 0), frontend units 662+51 / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)