### PR TITLE
Fix stale p1s test fixture + reconcile the send-pin rule with R2

### DIFF
--- a/backend/tests/test_stream_p1s.py
+++ b/backend/tests/test_stream_p1s.py
@@ -75,13 +75,23 @@ def test_finalize_noop_on_truly_empty_turn(_patch_writer):
 
 
 def test_finalize_submits_blocks_normally(_patch_writer):
-  """finalize() submits a snapshot containing the accumulated blocks."""
+  """finalize() submits a snapshot containing the accumulated blocks.
+
+  A real assistant text block is {"type": "text", "content": ...} — the only
+  shape process_event ever produces (events.py) and the key both
+  blocks_have_renderable_content and build_assistant_message read. Since
+  0e0eaa82 the finalize gate is blocks_have_renderable_content, which treats a
+  text block with empty/whitespace `content` as a blank bubble and skips the
+  write, so a fixture keyed on the wrong `text` field would never submit.
+  """
   sink, _ = _make_sink()
-  sink.assistant_blocks = [{"type": "text", "text": "hello"}]
+  sink.assistant_blocks = [{"type": "text", "content": "hello"}]
   asyncio.run(sink.finalize())
   assert len(_patch_writer.submitted) == 1
   blocks = _patch_writer.submitted[0].get("blocks") or []
-  assert any(b.get("type") == "text" for b in blocks)
+  assert any(
+    b.get("type") == "text" and b.get("content") == "hello" for b in blocks
+  )
 
 
 def test_finalize_synthesizes_error_block_when_blocks_empty(_patch_writer):
@@ -139,7 +149,7 @@ def test_finalize_uses_blocks_not_last_error_when_both_present(_patch_writer):
   are used (no synthetic block injected — the error was already processed
   into the block list by process_event via the PersistError path)."""
   sink, bc = _make_sink()
-  sink.assistant_blocks = [{"type": "text", "text": "partial"}, {"type": "error", "message": "blip"}]
+  sink.assistant_blocks = [{"type": "text", "content": "partial"}, {"type": "error", "message": "blip"}]
   sink._last_error = "blip"  # set as if publish() ran
 
   asyncio.run(sink.finalize())

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -1787,19 +1787,21 @@ export default function ChatView({
     // replay then silently repopulated (see buildPhaseRail.js).
     setBuildPhases(railAtRunStart())
 
-    // A fresh send is a deliberate new turn, so it ALWAYS lifts the new message
-    // to the top of the viewport (its reply streams in below) — the partner's
-    // single most important chat behavior. The previous rule ("pin only when
-    // it's the first message OR the reader is already at the bottom") silently
-    // skipped the lift whenever you sent after reading a long reply from the
-    // top, which is exactly the "messages don't go to the top" report: after a
-    // tall reply you are almost never within NEAR_BOTTOM_PX of the content tail,
-    // so shouldPinSend returned false and the send stayed put mid-conversation.
-    // The at-bottom heuristic still governs the QUEUE and STEER paths (their own
-    // shouldPinSend calls above), so sending MID-TURN while scrolled up to read
-    // is not yanked. `pin` stays the caller opt-out (handleStop's queue-collapse
-    // passes pin:false).
-    const willPin = pin
+    // The send rule (see shouldPinSend): pin the new message to the top
+    // only when it is the first message OR the user is at the bottom.
+    // Read both inputs BEFORE the append: `hasPriorVisibleUser` from the
+    // synchronous messagesRef (commitMessages advances it eagerly), and
+    // the at-bottom snapshot from the pre-append scrollHeight. `pin` is
+    // the caller opt-out (handleStop's queue-collapse passes pin:false).
+    const isFirstUserMsg = !messagesRef.current.some(
+      m => m.role === 'user' && !m.hidden,
+    )
+    const willPin = pin && shouldPinSend({
+      scrollEl: scrollRef.current,
+      mode: modeRef.current,
+      isFirstUserMsg,
+      wasNearScrollBottom: wasNearContentBottomAtSubmit,
+    })
     // The first rendered row uses this optimistic ts, but the backend often
     // returns a canonical server ts a moment later. Carry the send-time intent
     // across that swap so the "new sent message at the top" pin does not point

--- a/tests/spacer.spec.mjs
+++ b/tests/spacer.spec.mjs
@@ -965,13 +965,12 @@ test.describe('Scroll edge cases', () => {
     expect(afterGap).toBeLessThan(50)
   })
 
-  test('26. Fresh second send while scrolled up PINS to the top (deliberate new turn)', async ({ page }) => {
-    // Owner rule (2026-07-12, third revision): a FRESH send — the chat is
-    // idle, the user typed and hit send — is a deliberate new turn and
-    // always lifts the new message to the top, regardless of where the
-    // reader was scrolled. Only mid-turn sends (queue/steer while the
-    // agent is streaming) preserve the reading position; those paths keep
-    // the at-bottom heuristic and are locked in by the queue/steer specs.
+  test('26. Second send while scrolled up (reading) does NOT pin to the top', async ({ page }) => {
+    // Under the send rule, a second send while the user is scrolled up
+    // (reading, possibly with something queued) must NOT pin to the top —
+    // the reader stays where they were; the message just appends. Pre-rule
+    // this test asserted the opposite (a scroll-up second send still
+    // pinned); the owner reversed that: don't yank a reader.
     //
     // Uses the REAL SSE path (not injectContent) so the long first
     // response PERSISTS across the second send — DOM-injected content
@@ -1026,11 +1025,11 @@ test.describe('Scroll edge cases', () => {
     })
     expect(userMsgs).toContain('Second message')
 
-    // CRITICAL: PINNED — the fresh send lifted the new message flush to
-    // the top of the viewport (PIN_OFFSET=4, small settle tolerance).
+    // CRITICAL: NOT pinned — the message is not flush at the top, and the
+    // scroll did not jump there. The reader stays put.
     const after = await measure(page)
-    expect(after.userVisualTop).toBeGreaterThanOrEqual(-2)
-    expect(after.userVisualTop).toBeLessThanOrEqual(12)
+    expect(after.userVisualTop).toBeGreaterThan(50)
+    expect(Math.abs(after.scrollTop - savedTop)).toBeLessThanOrEqual(8)
   })
 
   test('27. Viewport resize cycles do not engage auto-follow on streaming chat', async ({ page }) => {


### PR DESCRIPTION
Two coupled fixes that must land together.

1. Main's backend has been red on test_finalize_submits_blocks_normally since 0e0eaa82. The code is correct: the commit deliberately gated finalize() on blocks_have_renderable_content to stop persisting blank bubbles. The test fixture used {"type":"text","text":...} — a shape the runtime never produces (process_event always emits "content"), so the new gate correctly reads it as blank. Fixture corrected to the real shape in both affected tests, assertion tightened to verify content round-trip. blocks_have_renderable_content deliberately NOT loosened.

2. Fixing (1) alone would flip e2e red: backend-green unmasks a three-way contradiction latent behind the skipped gate. ChatView.jsx:1801 shipped always-pin (9b9ab86b) while the LATER b4b89deb made ARCHITECTURE.md R2 the committed contract (pin iff first message OR at-bottom; a scrolled-up send reserves but never yanks) and send-rule.spec already asserts R2 — but spacer.spec #26 had been flipped to assert always-pin. Restored the shouldPinSend gate per R2 (pin:false opt-out and first-message pin preserved) and re-flipped spacer #26 to the R2 assertion. Code, contract doc, and both specs now agree; b4b89deb's own commit message noted the ChatView change was "sequenced separately" — this is that sequenced change.

Found by an adversarial review of recent landings; both root causes verified by executing the predicates. Backend 1877 passed / 1 skipped; frontend units 753+51 / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)