### PR TITLE
Lazy tool output: bounded excerpts on the wire, full text fetched on expand (contract v2 item 3)

### DIFF
--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -51,6 +51,7 @@ from app.chat_writer import (
   PersistTranscript,
   QuestionCommit,
   ResolvePark,
+  StashToolOutput,
   alloc_run_token,
   await_ack as _await_ack,
   get_writer,
@@ -59,10 +60,12 @@ from app.chat_writer import (
 )
 from app.config import get_settings
 from app.events import (
+  TOOL_OUTPUT_INLINE_THRESHOLD,
   blocks_have_renderable_content,
   build_assistant_message,
   capture_question_scrub,
   commit_question_scrub,
+  excerpt_tool_output,
   finalize_blocks,
   process_event,
   undo_question_scrub,
@@ -281,6 +284,52 @@ class _ChatEventSink:
 
     ack.add_done_callback(_log_if_failed)
 
+  def _reduce_tool_output(self, event: ChatEvent) -> None:
+    """Move a large tool_output's full text OFF the wire (contract rule 6).
+
+    This is the single funnel where the live SSE push, the catch-up event_log,
+    and the persisted Chat.messages blob all branch from one event object, so
+    rewriting the event here bounds all three at once and keeps the live and
+    replayed excerpts byte-identical by construction.
+
+    Rewrites the event to a bounded head+tail excerpt and stamps
+    `output_truncated` / `output_full_len` / `output_exit_code` / `tool_use_id`,
+    then stashes the FULL text via the writer actor keyed by tool_use_id.
+
+    Two pass-throughs leave the event unchanged:
+      - a small output (<= threshold) — a fetch round-trip costs more than the
+        bytes;
+      - an output with NO tool_use_id — there is nothing to key a stash by, so
+        it keeps the full text inline and rides the LEGACY `?ts=&i=` fetch path
+        against Chat.messages (dual-read migration; near-universal tagging means
+        this is rare).
+
+    The stash is submitted UNCONDITIONALLY — never gated on `_steering` (unlike
+    the transcript save in `publish`) — so a tool that completes during a steer
+    split does not strand a truncated block with no fetchable full text."""
+    content = event.get("content")
+    if (not isinstance(content, str)
+        or len(content) <= TOOL_OUTPUT_INLINE_THRESHOLD):
+      return
+    tool_use_id = event.get("tool_use_id")
+    # No id or no chat = nothing to key a stash by. Do NOT reduce in that case:
+    # rewriting the wire event to an excerpt without a matching stash would
+    # strand the full text (the block would 404 the fetch). Leaving it inline
+    # keeps the legacy `?ts=&i=` path working (dual-read migration).
+    if not tool_use_id or not self.chat_id:
+      return
+    full = content
+    excerpt, full_len, exit_code = excerpt_tool_output(full)
+    event["content"] = excerpt
+    event["output_truncated"] = True
+    event["output_full_len"] = full_len
+    event["output_exit_code"] = exit_code
+    self._submit_fire_and_forget(
+      StashToolOutput(
+        chat_id=self.chat_id, tool_use_id=tool_use_id, output=full,
+      )
+    )
+
   def publish(self, event: ChatEvent) -> bool:
     """Publishes an ordinary event and routes any due save to the actor.
 
@@ -299,6 +348,13 @@ class _ChatEventSink:
     assert event_type != "question", (
       "question events must go through publish_question(), not publish()"
     )
+
+    # Contract rule 6: reduce a large tool_output to a bounded excerpt and stash
+    # its full text BEFORE process_event (which copies content onto the block)
+    # and before the broadcast below, so the rewritten event is the single
+    # source feeding the persisted block, the live wire, and the catch-up log.
+    if event_type == "tool_output":
+      self._reduce_tool_output(event)
 
     # Accumulate the event into assistant_blocks and decide whether a
     # save is due (immediate for save-triggering types, throttled

--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -203,6 +203,27 @@ class PersistSessionId(_Command):
   session_id: str = ""
 
 
+@dataclass
+class StashToolOutput(_Command):
+  """Fire-and-forget stash of a large tool output's FULL text (contract rule 6).
+
+  Writes the `tool_outputs` side table keyed by `(chat_id, tool_use_id)` as an
+  insert/upsert on the composite PK — NOT a read-modify-write of the shared
+  `Chat.messages` JSON blob — so it is IMMUNE to the lost-update race the actor
+  guardrail exists to close (two readers of the same snapshot clobbering each
+  other). It is routed through the actor anyway to keep a single DB writer, but
+  it is deliberately NOT a `_FENCE_COMMANDS` member and NOT coalescible: it
+  touches neither `messages` nor `pending_messages`, so it needs no snapshot
+  fence and takes the plain-enqueue path in `submit`.
+
+  Fire-and-forget like `PersistTranscript`: a dropped stash just 404s on expand
+  and the UI keeps showing the inline excerpt — no correctness loss."""
+
+  chat_id: str = ""
+  tool_use_id: str = ""
+  output: str = ""
+
+
 # -- queue + turn commands (the JSON-blob RMW the actor owns) ------------
 # These own the read-modify-write of the chat's `messages` /
 # `pending_messages` blobs: initial-send (`StartTurn`, from
@@ -1174,6 +1195,8 @@ class ChatWriterActor:
       return self._answer_question(db, cmd)
     if isinstance(cmd, PersistSessionId):
       return self._persist_session_id(db, cmd)
+    if isinstance(cmd, StashToolOutput):
+      return self._stash_tool_output(db, cmd)
     if isinstance(cmd, StartTurn):
       return self._start_turn(db, cmd)
     if isinstance(cmd, AppendPending):
@@ -1303,6 +1326,35 @@ class ChatWriterActor:
     chat.session_id = cmd.session_id
     if not _commit_or_rollback(db):
       raise _PersistFailed("PersistSessionId did not persist")
+    return True
+
+  def _stash_tool_output(self, db, cmd: "StashToolOutput") -> bool:
+    """Insert/upsert a large tool output's full text into `tool_outputs`.
+
+    Keyed by the composite PK `(chat_id, tool_use_id)`, so a repeated stash for
+    the same tool (e.g. a streamed intermediate then the final aggregate)
+    overwrites in place — last write wins, which is correct (the final output is
+    authoritative). Does not touch `Chat.messages`, so it is outside the
+    lost-update guardrail. Fire-and-forget: raising on a dropped commit only
+    logs via the caller's done-callback; the UI keeps the inline excerpt."""
+    if not cmd.chat_id or not cmd.tool_use_id:
+      return False
+    from app.models import ToolOutput
+
+    row = db.query(ToolOutput).filter(
+      ToolOutput.chat_id == cmd.chat_id,
+      ToolOutput.tool_use_id == cmd.tool_use_id,
+    ).first()
+    if row is None:
+      db.add(ToolOutput(
+        chat_id=cmd.chat_id,
+        tool_use_id=cmd.tool_use_id,
+        output=cmd.output or "",
+      ))
+    else:
+      row.output = cmd.output or ""
+    if not _commit_or_rollback(db):
+      raise _PersistFailed("StashToolOutput did not persist")
     return True
 
   def _start_turn(self, db, cmd: StartTurn) -> dict:

--- a/backend/app/claude_sdk_runner.py
+++ b/backend/app/claude_sdk_runner.py
@@ -770,10 +770,14 @@ def dispatch_sdk_message(
     server_tools: dict[str, str] = {}
     for block in sdk_msg.content:
       if isinstance(block, ToolUseBlock):
+        # block.id is the canonical tool_use_id; the matching ToolResultBlock
+        # carries it as .tool_use_id. Thread it through so a large tool output
+        # can be reduced on the wire and fetched lazily by id (contract rule 6).
         bc.publish({
           "type": "tool_start",
           "tool": block.name,
           "input": "",
+          "tool_use_id": block.id,
         })
         summary = summarize_tool_input(block.name, block.input)
         if summary:
@@ -857,15 +861,18 @@ def dispatch_sdk_message(
     for block in content:
       if isinstance(block, ToolResultBlock):
         output = _format_tool_output(block.content)
+        # Carry the tool_use_id (matches the ToolUseBlock's .id) so the sink can
+        # key a stash of the full output and the block can fetch it by id.
         bc.publish({
           "type": "tool_output",
           "content": output,
+          "tool_use_id": block.tool_use_id,
         })
         if output.startswith("Web search results for query"):
           sources = sources_from_websearch_text(output)
           if sources:
             bc.publish({"type": "tool_sources", "sources": sources})
-        bc.publish({"type": "tool_end"})
+        bc.publish({"type": "tool_end", "tool_use_id": block.tool_use_id})
         continue
       _emit_unknown(bc, f"user_block:{type(block).__name__}", block)
     return current_session_id, None

--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -321,6 +321,33 @@ def _web_search_sources(item: Any) -> list[dict[str, str]]:
   return collected
 
 
+def _stamp_tool_use_id(event: dict[str, Any], item: Any) -> None:
+  """Stamp the ThreadItem's stable id onto a tool event as `tool_use_id`
+  (contract rule 6), so a large tool output can be reduced on the wire and
+  fetched lazily by id.
+
+  Verified stable: every Codex ThreadItem carries an `id`, the SAME id rides
+  the `ItemStarted` (tool_start) and `ItemCompleted` (tool_output/tool_end)
+  notifications for one tool call, and the streaming output-delta / file-change
+  notifications reference it as `itemId` — so it is stable emit->read and unique
+  within the chat, which is all the stash key needs. A test fake without an
+  `id` (or a null id) is left unstamped, so the event shape is unchanged."""
+  tid = getattr(item, "id", None)
+  if tid:
+    event["tool_use_id"] = tid
+
+
+def _stamp_notification_item_id(event: dict[str, Any], payload: Any) -> None:
+  """Stamp `tool_use_id` from a notification's `item_id` (the streaming
+  output-delta / file-change-patch notifications reference their ThreadItem by
+  `itemId`, the same id the completed item carries). getattr-guarded so SDK
+  shape drift or a test fake without the field degrades to an untagged event
+  (which the sink leaves inline) rather than raising."""
+  item_id = getattr(payload, "item_id", None) or getattr(payload, "itemId", None)
+  if item_id:
+    event["tool_use_id"] = item_id
+
+
 def _tool_start_event(item: Any, sdk: dict[str, Any]) -> dict[str, Any] | None:
   """Builds one Möbius `tool_start` event from a typed item."""
   if isinstance(item, sdk["CommandExecutionThreadItem"]):
@@ -1068,7 +1095,9 @@ async def run_codex_sdk_turn(
           sdk["CommandExecutionOutputDeltaNotification"],
         ):
           if payload.delta:
-            bc.publish({"type": "tool_output", "content": payload.delta})
+            event = {"type": "tool_output", "content": payload.delta}
+            _stamp_notification_item_id(event, payload)
+            bc.publish(event)
           continue
 
         if isinstance(payload, sdk["ItemStartedNotification"]):
@@ -1078,6 +1107,7 @@ async def run_codex_sdk_turn(
             continue
           event = _tool_start_event(item, sdk)
           if event is not None:
+            _stamp_tool_use_id(event, item)
             bc.publish(event)
           _observe_skill_reads(item, sdk, bc=bc, chat_id=chat_id)
           continue
@@ -1085,12 +1115,15 @@ async def run_codex_sdk_turn(
         if isinstance(payload, sdk["FileChangePatchUpdatedNotification"]):
           summary = _file_change_patch_summary(payload.changes)
           if summary:
-            bc.publish({"type": "tool_output", "content": summary})
+            event = {"type": "tool_output", "content": summary}
+            _stamp_notification_item_id(event, payload)
+            bc.publish(event)
           continue
 
         if isinstance(payload, sdk["ItemCompletedNotification"]):
           item = payload.item.root if hasattr(payload.item, "root") else payload.item
           for event in _tool_completed_events(item, sdk):
+            _stamp_tool_use_id(event, item)
             bc.publish(event)
           continue
 

--- a/backend/app/events.py
+++ b/backend/app/events.py
@@ -10,6 +10,8 @@ tools interleaved between them.
 """
 
 import copy
+import json
+import re
 from dataclasses import dataclass, field
 from typing import Literal
 
@@ -136,6 +138,106 @@ _THINKING_INTERRUPTING_TYPES: frozenset[str] = frozenset({
 })
 
 
+# -- tool-output reduction (contract rule 6) ------------------------------
+# A tool_output larger than this is reduced to a bounded head+tail excerpt on
+# the ONE event funnel (chat.py _ChatEventSink.publish), so the live SSE wire,
+# the catch-up replay, and the persisted Chat.messages blob all carry only the
+# excerpt; the full text is stashed server-side keyed by tool_use_id and
+# fetched lazily on expand. A round-trip costs more than a few KB, so small
+# outputs stay whole.
+TOOL_OUTPUT_INLINE_THRESHOLD = 4096
+# Bytes kept from the start (preserves the start-anchored "Exit code N\n"
+# failure head for a Claude bash result) and the end (the diagnostic tail the
+# reader actually wants) of a carved plain-text output.
+TOOL_OUTPUT_HEAD = 2048
+TOOL_OUTPUT_TAIL = 1024
+# Hard ceiling on the whole excerpt. Per-string carving handles the common shell
+# envelope (one big stdout), but a JSON value with MANY small strings re-
+# serializes near full size, which would defeat "bounded on the wire". When the
+# re-serialized excerpt still exceeds this budget, fall back to a plain head+tail
+# carve of the serialized string. That last carve can break JSON validity, but
+# the exit code is already captured as a separate field (output_exit_code), so
+# the failure chip is unaffected — only the inline preview's pretty rendering is,
+# and the full valid text is one expand away. Generous enough that a realistic
+# terminal envelope (stdout+stderr+exit_code) stays valid JSON.
+TOOL_OUTPUT_EXCERPT_MAX = 16384
+# Claude bash reports a failure as a start-anchored "Exit code N\n<stderr>"
+# (a success is plain stdout with no prefix). Mirror toolResultFormat.js:27.
+_TOOL_OUTPUT_EXIT_RE = re.compile(r"^Exit code (\d+)\r?\n")
+
+
+def _shorten_text(s: str) -> str:
+  """head + a byte-count marker + tail, for a plain-text output over budget."""
+  if len(s) <= TOOL_OUTPUT_HEAD + TOOL_OUTPUT_TAIL:
+    return s
+  head = s[:TOOL_OUTPUT_HEAD]
+  tail = s[-TOOL_OUTPUT_TAIL:]
+  shown = len(head) + len(tail)
+  return f"{head}\n…[{len(s)} B total — {shown} shown, expand for full]…\n{tail}"
+
+
+def _truncate_json_strings(value, depth: int = 0):
+  """Return a copy of a parsed-JSON value with every long string field carved
+  to a head+tail excerpt, so a re-serialization stays VALID JSON. This is how
+  a shell envelope ({stdout, stderr, exit_code}) is truncated: the raw string
+  is never cut mid-way (that breaks the JSON and loses the exit code); the
+  inner stdout/stderr are shortened and small keys (exit_code) pass through."""
+  if isinstance(value, str):
+    return _shorten_text(value)
+  if depth >= 6:
+    return value
+  if isinstance(value, dict):
+    return {k: _truncate_json_strings(v, depth + 1) for k, v in value.items()}
+  if isinstance(value, list):
+    return [_truncate_json_strings(v, depth + 1) for v in value]
+  return value
+
+
+def _tool_output_exit_code(content: str, parsed):
+  """Best-effort integer exit code, or None. A shell envelope carries it as a
+  top-level exit_code/exitCode int; a Claude bash failure as the start-anchored
+  'Exit code N\\n' head. Booleans are rejected (True == 1 in Python)."""
+  if isinstance(parsed, dict):
+    raw = parsed.get("exit_code")
+    if raw is None:
+      raw = parsed.get("exitCode")
+    if isinstance(raw, bool):
+      return None
+    return raw if isinstance(raw, int) else None
+  m = _TOOL_OUTPUT_EXIT_RE.match(content)
+  return int(m.group(1)) if m else None
+
+
+def excerpt_tool_output(content: str):
+  """Reduce a large tool_output string to (excerpt, full_len, exit_code).
+
+  Envelope-aware: a JSON container is parsed, its inner strings carved, and
+  re-serialized so it stays valid JSON with the exit code intact (the frontend
+  failure chip and terminal rendering both depend on parseable JSON). A plain
+  string keeps its head (the 'Exit code N' failure signal survives) and tail.
+  Called only when len(content) > TOOL_OUTPUT_INLINE_THRESHOLD."""
+  full_len = len(content)
+  parsed = None
+  stripped = content.lstrip()
+  if stripped[:1] in ("{", "["):
+    try:
+      parsed = json.loads(content)
+    except (ValueError, TypeError):
+      parsed = None
+  exit_code = _tool_output_exit_code(content, parsed)
+  if parsed is not None:
+    excerpt = json.dumps(_truncate_json_strings(parsed), ensure_ascii=True)
+    # Boundedness ceiling: a JSON value whose size is in its STRUCTURE (many
+    # small strings) survives per-string carving near full size. Cap it with a
+    # plain carve — the exit code is already in `exit_code`, so this costs only
+    # JSON validity of the inline preview (the full text is fetched on expand).
+    if len(excerpt) > TOOL_OUTPUT_EXCERPT_MAX:
+      excerpt = _shorten_text(excerpt)
+  else:
+    excerpt = _shorten_text(content)
+  return excerpt, full_len, exit_code
+
+
 def process_event(event: dict, assistant_blocks: list) -> bool:
   """Accumulates a parsed event into the assistant blocks list.
 
@@ -241,13 +343,21 @@ def process_event(event: dict, assistant_blocks: list) -> bool:
     return False
 
   if event_type == "tool_start":
-    assistant_blocks.append({
+    block = {
       "type": "tool",
       "tool": event.get("tool", ""),
       "input": event.get("input", ""),
       "output": "",
       "status": "running",
-    })
+    }
+    # Carry the tool's stable identity onto the block (contract rule 6) so a
+    # reduced output can be fetched lazily by tool_use_id. Only stamp it when
+    # the runner supplied one — a tokenless legacy/test event keeps the block
+    # shape unchanged.
+    tool_use_id = event.get("tool_use_id")
+    if tool_use_id:
+      block["tool_use_id"] = tool_use_id
+    assistant_blocks.append(block)
     return True
 
   if event_type == "tool_input":
@@ -266,6 +376,21 @@ def process_event(event: dict, assistant_blocks: list) -> bool:
       if (blk.get("type") == "tool"
           and blk.get("status") != "done"):
         blk["output"] = event.get("content", "")
+        # A tool_output the sink reduced (contract rule 6) carries a bounded
+        # excerpt as `content` plus the metadata below; carry it onto the block
+        # so the persisted transcript + wire agree and the frontend can fetch
+        # the full text and read a failure exit code from a field, not a parse
+        # of the possibly-carved excerpt. Absent fields leave the block shape
+        # unchanged (a small, un-reduced output).
+        tool_use_id = event.get("tool_use_id")
+        if tool_use_id and not blk.get("tool_use_id"):
+          blk["tool_use_id"] = tool_use_id
+        if event.get("output_truncated"):
+          blk["output_truncated"] = True
+          blk["output_full_len"] = event.get("output_full_len")
+          exit_code = event.get("output_exit_code")
+          if exit_code is not None:
+            blk["output_exit_code"] = exit_code
         break
     return True
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -418,3 +418,33 @@ class Notification(Base):
   actions = Column(JSON, nullable=True)
   sent_at = Column(DateTime, default=lambda: datetime.now(UTC))
   clicked_at = Column(DateTime, nullable=True)
+
+
+class ToolOutput(Base):
+  """Full text of a large tool result, stored out-of-band (contract rule 6).
+
+  The chat transcript blob (`Chat.messages`) and the live / catch-up event
+  stream carry only a bounded head+tail excerpt of a big tool output; the full
+  text lives here, keyed by the tool's stable identity, and `ToolBlock` fetches
+  it lazily on expand via GET /api/chats/{chat_id}/tool-output/{tool_use_id}.
+
+  Why a table, not a file: `db/` (ultimate.db) is gitignored, so these blobs
+  are correctly EXCLUDED from the nightly `/data` git safety-net (we do not want
+  megabytes of tool output versioned every night), and the rows ride the chat
+  lifecycle for free — soft-delete keeps them (a recovered chat re-shows its
+  outputs), the hard-purge sweep drops them with their chat. Written via the
+  single-writer actor's `StashToolOutput` command as an insert/upsert on the
+  composite PK (race-immune; see chat_writer.py). `create_all` builds this table
+  on the next boot — a new table needs no ALTER migration (see run_migrations,
+  which only ALTERs existing tables)."""
+
+  __tablename__ = "tool_outputs"
+
+  chat_id = Column(
+    String(64), ForeignKey("chats.id"), primary_key=True, index=True
+  )
+  # The tool_use_id (Claude) / ThreadItem id (Codex) — stable emit→read and
+  # unique within the chat, which is all the composite PK needs.
+  tool_use_id = Column(String(128), primary_key=True)
+  output = Column(Text, nullable=False, default="")
+  created_at = Column(DateTime, default=lambda: datetime.now(UTC))

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -15,6 +15,10 @@ from sqlalchemy.orm import Session
 
 from app import activity, auth, models, providers, questions
 from app.config import get_settings
+from app.events import (
+  TOOL_OUTPUT_INLINE_THRESHOLD as _TOOL_OUTPUT_INLINE_THRESHOLD,
+  excerpt_tool_output,
+)
 from app.chat import (
   _clear_run_status,
   bump_run_generation,
@@ -185,6 +189,13 @@ def list_chats(
     # unbounded over the instance's life.
     db.query(models.ChatRun).filter(
       models.ChatRun.chat_id == c.id
+    ).delete(synchronize_session=False)
+    # Drop the chat's stashed large tool outputs (contract rule 6) with it —
+    # same lifecycle, same no-FK-cascade reasoning as chat_runs above. The
+    # rows rode the soft-delete window (a recovered chat re-showed its
+    # outputs); at hard-purge time the chat is gone for good, so are they.
+    db.query(models.ToolOutput).filter(
+      models.ToolOutput.chat_id == c.id
     ).delete(synchronize_session=False)
     db.delete(c)
   # Hard-delete abandoned empties — chats that were created, never had
@@ -560,18 +571,21 @@ async def patch_chat(
     }
 
 
-_TOOL_OUTPUT_INLINE_THRESHOLD = 4096
-
-
 def _truncate_large_tool_outputs(messages: list) -> list:
-  """Returns a copy of ``messages`` with large tool outputs dropped to an
-  ``output_truncated`` marker, so loading a chat does not ship the full output
-  (a Read of a 2000-line file, a long bash run) for every tool block — including
-  the ones the user never expands. The collapsed block already shows its
-  top-line summary (the tool + its ``input``, e.g. the bash command), so a
-  preview of the output adds nothing on load; the client fetches the full output
-  on expand via ``GET /api/chats/{id}/tool-output?ts=&i=``. Outputs at or below
-  the threshold stay inline, since a round-trip would cost more than the bytes."""
+  """LEGACY-ROW reducer (contract rule 6). New turns are reduced at the event
+  funnel (``chat.py`` ``_ChatEventSink._reduce_tool_output`` -> ``excerpt_tool_output``),
+  so their persisted blocks already carry a bounded head+tail excerpt plus
+  ``output_truncated`` / ``output_full_len`` / ``tool_use_id`` and the full text
+  is stashed in ``tool_outputs``. This only trims the FEW pre-migration
+  transcripts whose tool blocks still hold the full output inline, so loading
+  such a chat does not ship a 2000-line Read for blocks the user never expands.
+
+  A block already marked ``output_truncated`` (a new-funnel excerpt) is left
+  UNTOUCHED. Legacy blocks (no ``tool_use_id``, full output still in
+  ``Chat.messages``) are reduced to the same head+tail excerpt and the client
+  fetches the full text via the legacy ``?ts=&i=`` endpoint; new blocks carry a
+  ``tool_use_id`` and use the ``/tool-output/{tool_use_id}`` endpoint instead
+  (dual-read). Returns a copy — never mutates the stored message dicts."""
   out = []
   for m in messages:
     blocks = m.get("blocks") if isinstance(m, dict) else None
@@ -586,18 +600,33 @@ def _truncate_large_tool_outputs(messages: list) -> list:
     for i, blk in enumerate(blocks):
       if not isinstance(blk, dict) or blk.get("type") != "tool":
         continue
+      # Already reduced at the funnel — leave the excerpt inline; the client
+      # fetches the full text by tool_use_id.
+      if blk.get("output_truncated"):
+        continue
       output = blk.get("output")
       if (not isinstance(output, str)
           or len(output) <= _TOOL_OUTPUT_INLINE_THRESHOLD):
         continue
+      excerpt, full_len, exit_code = excerpt_tool_output(output)
       if new_blocks is None:
         new_blocks = list(blocks)
-      new_blocks[i] = {
+      reduced = {
         **blk,
-        "output": "",
+        "output": excerpt,
         "output_truncated": True,
-        "output_full_len": len(output),
+        "output_full_len": full_len,
       }
+      if exit_code is not None:
+        reduced["output_exit_code"] = exit_code
+      # This block's full text lives INLINE in Chat.messages, not the
+      # `tool_outputs` side table (the sink already reduced + stashed every
+      # tagged block, so anything reaching here is un-stashed). Drop any stray
+      # tool_use_id so the frontend fetches the full via the legacy ?ts=&i=
+      # endpoint (this reducer's contract) instead of the by-id endpoint, which
+      # would 404 with no stash row.
+      reduced.pop("tool_use_id", None)
+      new_blocks[i] = reduced
     out.append({**m, "blocks": new_blocks} if new_blocks is not None else m)
   return out
 
@@ -664,6 +693,33 @@ def get_chat(
   }
 
 
+@router.get("/{chat_id}/tool-output/{tool_use_id}", response_class=PlainTextResponse)
+def get_tool_output_by_id(
+  chat_id: str,
+  tool_use_id: str,
+  _: models.Owner = Depends(get_current_owner),
+  db: Session = Depends(get_db),
+) -> PlainTextResponse:
+  """Returns the FULL text of a large tool block, fetched lazily on expand
+  (contract rule 6). New blocks ship only a bounded excerpt in the chat-load
+  payload and the live stream; the full output is stashed in ``tool_outputs``
+  keyed by the tool's stable id. A 404 (a dropped/absent stash) tells the client
+  to keep showing the inline excerpt.
+
+  This is the NEW path for blocks that carry a ``tool_use_id``. Legacy blocks
+  (no id, full output still inline in ``Chat.messages``) use the ``?ts=&i=``
+  sibling endpoint below instead — the frontend branches on ``tool_use_id``
+  (dual-read migration, no backfill)."""
+  get_active_chat_or_404(db, chat_id)
+  row = db.query(models.ToolOutput).filter(
+    models.ToolOutput.chat_id == chat_id,
+    models.ToolOutput.tool_use_id == tool_use_id,
+  ).first()
+  if row is None:
+    raise HTTPException(status_code=404, detail="tool output not found")
+  return PlainTextResponse(row.output or "")
+
+
 @router.get("/{chat_id}/tool-output", response_class=PlainTextResponse)
 def get_tool_output(
   chat_id: str,
@@ -672,10 +728,11 @@ def get_tool_output(
   _: models.Owner = Depends(get_current_owner),
   db: Session = Depends(get_db),
 ) -> PlainTextResponse:
-  """Returns the FULL output of a single tool block, fetched lazily when the
-  user expands it — the chat-load payload ships only a preview (see
-  ``_truncate_large_tool_outputs``). The block is located by its message ``ts``
-  plus its index ``i`` within that message's blocks."""
+  """LEGACY lazy fetch for a tool block whose full output still lives inline in
+  ``Chat.messages`` (pre-contract-rule-6 rows, or any block with no
+  ``tool_use_id``). The block is located by its message ``ts`` plus its index
+  ``i`` within that message's blocks. Kept as the dual-read fallback; new blocks
+  carry a ``tool_use_id`` and use ``/tool-output/{tool_use_id}`` instead."""
   chat = get_active_chat_or_404(db, chat_id)
   for m in (chat.messages or []):
     if m.get("role") != "assistant" or m.get("ts") != ts:

--- a/backend/tests/test_chats_tool_output.py
+++ b/backend/tests/test_chats_tool_output.py
@@ -1,29 +1,62 @@
-"""Lazy tool-output truncation (card 163): large tool outputs are dropped to an
-output_truncated marker on chat load (the collapsed block already shows its
-top-line summary), fetched in full on expand. Tests the pure truncation helper,
-including the no-mutation invariant (it must NOT corrupt the stored message
-dicts)."""
+"""Legacy-row tool-output reducer (contract rule 6). New turns are reduced at
+the event funnel (chat.py _ChatEventSink) so their persisted blocks already
+carry a bounded excerpt; `_truncate_large_tool_outputs` now only trims the FEW
+pre-migration transcripts whose tool blocks still hold the full output inline,
+carving them to the SAME head+tail excerpt (non-empty) the funnel produces. A
+block already marked output_truncated is left untouched. Tests the pure reducer
+plus its no-mutation invariant."""
+from app.events import TOOL_OUTPUT_HEAD
 from app.routes.chats import (
     _truncate_large_tool_outputs,
     _TOOL_OUTPUT_INLINE_THRESHOLD,
 )
 
 
-def _tool_msg(output, ts=1):
-    return {
-        "role": "assistant", "ts": ts,
-        "blocks": [{"type": "tool", "tool": "Read", "input": "f", "output": output}],
-    }
+def _tool_msg(output, ts=1, extra=None):
+    blk = {"type": "tool", "tool": "Read", "input": "f", "output": output}
+    if extra:
+        blk.update(extra)
+    return {"role": "assistant", "ts": ts, "blocks": [blk]}
 
 
-def test_large_tool_output_is_dropped_to_marker():
+def test_large_tool_output_is_reduced_to_a_nonempty_excerpt():
     big = "x" * (_TOOL_OUTPUT_INLINE_THRESHOLD + 5000)
     blk = _truncate_large_tool_outputs([_tool_msg(big)])[0]["blocks"][0]
     assert blk["output_truncated"] is True
     assert blk["output_full_len"] == len(big)
-    # No preview is shipped — the collapsed block's top-line summary is enough;
-    # the full output is fetched on expand via /tool-output.
-    assert blk["output"] == ""
+    # The excerpt is NON-EMPTY (the head+tail is shown inline; the full output is
+    # fetched on expand), and the HEAD is preserved verbatim so a start-anchored
+    # failure signal / the first lines survive the carve.
+    assert blk["output"] != ""
+    assert blk["output"].startswith("x" * TOOL_OUTPUT_HEAD)
+
+
+def test_bash_failure_head_survives_the_legacy_carve():
+    # A legacy Claude-bash failure ("Exit code N\n<stderr>") stays detectable:
+    # the start-anchored head is preserved and the exit code is stamped as a
+    # field so the frontend chip reads a field, not a re-parse of the excerpt.
+    stderr = "boom\n" * 2000
+    big = f"Exit code 1\n{stderr}"
+    assert len(big) > _TOOL_OUTPUT_INLINE_THRESHOLD
+    blk = _truncate_large_tool_outputs([_tool_msg(big)])[0]["blocks"][0]
+    assert blk["output"].startswith("Exit code 1\n")
+    assert blk["output_exit_code"] == 1
+
+
+def test_already_truncated_block_is_left_untouched():
+    # A block reduced at the funnel already carries output_truncated + a bounded
+    # excerpt; the legacy reducer must not re-carve it (or blank it).
+    excerpt = "head…[999999 B total]…tail"
+    blk = _truncate_large_tool_outputs([
+        _tool_msg(excerpt, extra={
+            "output_truncated": True,
+            "output_full_len": 999999,
+            "tool_use_id": "tu_1",
+        })
+    ])[0]["blocks"][0]
+    assert blk["output"] == excerpt
+    assert blk["output_full_len"] == 999999
+    assert blk["tool_use_id"] == "tu_1"
 
 
 def test_small_tool_output_stays_inline():
@@ -54,3 +87,16 @@ def test_does_not_mutate_input():
     _truncate_large_tool_outputs([msg])
     assert msg["blocks"][0]["output"] == big
     assert "output_truncated" not in msg["blocks"][0]
+
+
+def test_legacy_reduction_strips_tool_use_id():
+    # A legacy fat block with full output inline (no side-table stash) must NOT
+    # keep a stray tool_use_id, or the frontend would call the by-id endpoint
+    # (404, no stash) instead of the legacy ?ts=&i= endpoint. The reduced block
+    # carries the excerpt + output_truncated but no id.
+    big = "x" * (_TOOL_OUTPUT_INLINE_THRESHOLD + 5000)
+    blk = _truncate_large_tool_outputs([
+        _tool_msg(big, extra={"tool_use_id": "stray_id"})
+    ])[0]["blocks"][0]
+    assert blk["output_truncated"] is True
+    assert "tool_use_id" not in blk

--- a/backend/tests/test_claude_sdk_runner.py
+++ b/backend/tests/test_claude_sdk_runner.py
@@ -895,6 +895,23 @@ def test_dispatch_user_tool_result():
   assert "tool_end" in types
 
 
+def test_dispatch_user_tool_result_threads_tool_use_id():
+  # The ToolResultBlock's tool_use_id (contract rule 6) rides both the
+  # tool_output and tool_end events so the sink can key a stash of a large
+  # output and the block can fetch it by id.
+  bus = _Bus()
+  dispatch_sdk_message(
+    UserMessage(
+      content=[ToolResultBlock(tool_use_id="tu_abc", content="output text")],
+    ),
+    bus,
+    None,
+  )
+  by_type = {e["type"]: e for e in bus.events}
+  assert by_type["tool_output"]["tool_use_id"] == "tu_abc"
+  assert by_type["tool_end"]["tool_use_id"] == "tu_abc"
+
+
 def test_dispatch_server_web_search_result_emits_sources():
   bus = _Bus()
   msg = AssistantMessage(
@@ -961,9 +978,9 @@ def test_dispatch_client_web_search_tool_result_emits_sources():
   )
 
   assert bus.events == [
-    {"type": "tool_start", "tool": "WebSearch", "input": ""},
+    {"type": "tool_start", "tool": "WebSearch", "input": "", "tool_use_id": "t1"},
     {"type": "tool_input", "tool": "WebSearch", "input": "mobius docs"},
-    {"type": "tool_output", "content": result_text},
+    {"type": "tool_output", "content": result_text, "tool_use_id": "t1"},
     {"type": "tool_sources", "sources": [
       {
         "title": "Mobius",
@@ -972,7 +989,7 @@ def test_dispatch_client_web_search_tool_result_emits_sources():
       },
       {"title": "Docs", "url": "https://example.com/docs"},
     ]},
-    {"type": "tool_end"},
+    {"type": "tool_end", "tool_use_id": "t1"},
   ]
 
 

--- a/backend/tests/test_codex_sdk_runner.py
+++ b/backend/tests/test_codex_sdk_runner.py
@@ -160,6 +160,26 @@ def _fake_sdk(async_codex_cls):
   }
 
 
+def test_stamp_tool_use_id_uses_stable_item_id():
+  # Every Codex ThreadItem carries a stable `id` (same id on ItemStarted /
+  # ItemCompleted for one tool call); _stamp_tool_use_id threads it onto the
+  # tool event so a large output can be reduced + fetched by id (contract rule
+  # 6). A fake without an id is left unstamped, so event shape is unchanged.
+  from types import SimpleNamespace
+
+  event = {"type": "tool_output", "content": "x"}
+  codex_sdk_runner._stamp_tool_use_id(event, SimpleNamespace(id="item_42"))
+  assert event["tool_use_id"] == "item_42"
+
+  untagged = {"type": "tool_output", "content": "x"}
+  codex_sdk_runner._stamp_tool_use_id(untagged, SimpleNamespace())
+  assert "tool_use_id" not in untagged
+
+  null_id = {"type": "tool_output", "content": "x"}
+  codex_sdk_runner._stamp_tool_use_id(null_id, SimpleNamespace(id=None))
+  assert "tool_use_id" not in null_id
+
+
 def test_tool_completed_events_emit_output_before_end():
   class CommandExecutionThreadItem:
     def __init__(self, output: str):

--- a/backend/tests/test_tool_output_excerpt.py
+++ b/backend/tests/test_tool_output_excerpt.py
@@ -1,0 +1,107 @@
+"""The tool-output carve (contract rule 6): excerpt_tool_output reduces a large
+tool result to a bounded excerpt while preserving the failure signal — a
+head+tail for plain text (start-anchored 'Exit code N' survives), and a
+re-serialized envelope for JSON (stays valid, exit code intact)."""
+import json
+
+from app.events import (
+    TOOL_OUTPUT_EXCERPT_MAX,
+    TOOL_OUTPUT_HEAD,
+    TOOL_OUTPUT_INLINE_THRESHOLD,
+    excerpt_tool_output,
+)
+
+
+def test_excerpt_is_nonempty_and_preserves_head_and_tail():
+    body = "".join(f"line-{i}\n" for i in range(20000))
+    assert len(body) > TOOL_OUTPUT_INLINE_THRESHOLD
+    excerpt, full_len, exit_code = excerpt_tool_output(body)
+    assert full_len == len(body)
+    assert exit_code is None
+    assert excerpt  # non-empty
+    assert len(excerpt) < len(body)
+    assert excerpt.startswith(body[:TOOL_OUTPUT_HEAD])
+    assert excerpt.endswith(body[-1024:])
+    # The marker announces the true size so the reader knows it is a preview.
+    assert str(full_len) in excerpt
+
+
+def test_bash_failure_head_and_exit_code_survive_truncation():
+    stderr = "traceback line\n" * 3000
+    content = f"Exit code 137\n{stderr}"
+    assert len(content) > TOOL_OUTPUT_INLINE_THRESHOLD
+    excerpt, full_len, exit_code = excerpt_tool_output(content)
+    # The start-anchored failure head survives, so a frontend re-parse still
+    # detects the failure; the exit code is also returned as an explicit field.
+    assert excerpt.startswith("Exit code 137\n")
+    assert exit_code == 137
+    assert full_len == len(content)
+
+
+def test_json_envelope_stays_valid_json_with_exit_code_intact():
+    envelope = {
+        "stdout": "S" * 200000,
+        "stderr": "E" * 50000,
+        "exit_code": 2,
+    }
+    content = json.dumps(envelope)
+    assert len(content) > TOOL_OUTPUT_INLINE_THRESHOLD
+    excerpt, full_len, exit_code = excerpt_tool_output(content)
+    # The carve NEVER breaks the JSON — a naive mid-string cut would.
+    parsed = json.loads(excerpt)
+    assert parsed["exit_code"] == 2
+    assert exit_code == 2
+    # The inner streams are truncated (bounded), not dropped.
+    assert len(parsed["stdout"]) < 200000
+    assert len(excerpt) < len(content)
+    assert full_len == len(content)
+
+
+def test_json_envelope_exitcode_camelcase_is_read():
+    content = json.dumps({"stdout": "x" * 100000, "exitCode": 1})
+    _, _, exit_code = excerpt_tool_output(content)
+    assert exit_code == 1
+
+
+def test_json_boolean_field_is_not_mistaken_for_exit_code():
+    # A boolean exit_code is nonsense; True == 1 in Python must not leak through.
+    content = json.dumps({"stdout": "x" * 100000, "exit_code": True})
+    excerpt, _, exit_code = excerpt_tool_output(content)
+    assert exit_code is None
+    assert json.loads(excerpt)  # still valid JSON
+
+
+def test_json_under_budget_stays_valid_json():
+    # A large-but-not-pathological JSON value (its size is one big string, or a
+    # handful of fields) stays valid JSON after per-string carving.
+    content = json.dumps([{"line": "y" * 500} for _ in range(20)])
+    assert len(content) > TOOL_OUTPUT_INLINE_THRESHOLD
+    excerpt, _, exit_code = excerpt_tool_output(content)
+    assert len(excerpt) <= TOOL_OUTPUT_EXCERPT_MAX
+    json.loads(excerpt)  # must not raise
+    assert exit_code is None
+
+
+def test_pathological_json_is_bounded():
+    # A JSON value whose bulk is STRUCTURE (many small strings) re-serializes
+    # near full size after per-string carving; the ceiling still bounds it (at
+    # the cost of the inline preview's JSON validity — the full is one expand
+    # away and the exit code is a separate field).
+    content = json.dumps([{"line": "y" * 500} for _ in range(2000)])
+    assert len(content) > TOOL_OUTPUT_EXCERPT_MAX * 4
+    excerpt, full_len, _ = excerpt_tool_output(content)
+    assert len(excerpt) <= TOOL_OUTPUT_EXCERPT_MAX
+    assert full_len == len(content)
+
+
+def test_shell_envelope_stays_valid_under_the_ceiling():
+    # The common case must NOT trip the ceiling: a stdout+stderr+exit_code
+    # envelope stays valid JSON so the terminal rendering + exit code survive.
+    content = json.dumps({
+        "stdout": "S" * 500000, "stderr": "E" * 500000, "exit_code": 3,
+    })
+    excerpt, _, exit_code = excerpt_tool_output(content)
+    assert len(excerpt) <= TOOL_OUTPUT_EXCERPT_MAX
+    parsed = json.loads(excerpt)  # still valid
+    assert parsed["exit_code"] == 3
+    assert exit_code == 3

--- a/backend/tests/test_tool_output_stash.py
+++ b/backend/tests/test_tool_output_stash.py
@@ -1,0 +1,192 @@
+"""Server-side stash of large tool outputs (contract rule 6): the StashToolOutput
+actor command writes the `tool_outputs` side table keyed by (chat_id,
+tool_use_id); the sink reduces the wire event and submits the stash; the
+GET /tool-output/{tool_use_id} endpoint serves the full text on expand and 404s
+when absent (so the frontend keeps the inline excerpt). Also covers the reducer
+carrying tool identity + truncation metadata onto the persisted block."""
+import uuid
+
+from app import models
+from app.chat_writer import Barrier, StashToolOutput, get_writer
+from app.events import (
+    TOOL_OUTPUT_INLINE_THRESHOLD,
+    process_event,
+)
+
+
+def _flush_writer():
+    """Barrier proves the fire-and-forget stash already processed."""
+    get_writer().submit(Barrier()).result(timeout=5)
+
+
+# -- actor round-trip -----------------------------------------------------
+def test_stash_round_trip_insert_and_read_back(db):
+    big = "z" * (TOOL_OUTPUT_INLINE_THRESHOLD + 100)
+    get_writer().submit(
+        StashToolOutput(chat_id="c1", tool_use_id="tu_1", output=big)
+    ).result(timeout=5)
+    row = db.query(models.ToolOutput).filter(
+        models.ToolOutput.chat_id == "c1",
+        models.ToolOutput.tool_use_id == "tu_1",
+    ).first()
+    assert row is not None
+    assert row.output == big
+
+
+def test_stash_upsert_last_write_wins(db):
+    get_writer().submit(
+        StashToolOutput(chat_id="c1", tool_use_id="tu_1", output="first")
+    ).result(timeout=5)
+    get_writer().submit(
+        StashToolOutput(chat_id="c1", tool_use_id="tu_1", output="second")
+    ).result(timeout=5)
+    rows = db.query(models.ToolOutput).filter(
+        models.ToolOutput.chat_id == "c1",
+        models.ToolOutput.tool_use_id == "tu_1",
+    ).all()
+    assert len(rows) == 1
+    assert rows[0].output == "second"
+
+
+def test_stash_ignores_empty_key(db):
+    fut = get_writer().submit(
+        StashToolOutput(chat_id="", tool_use_id="tu_1", output="x")
+    )
+    assert fut.result(timeout=5) is False
+
+
+# -- endpoint -------------------------------------------------------------
+def test_tool_output_by_id_endpoint_serves_full_text(client, auth, db):
+    chat_id = str(uuid.uuid4())
+    db.add(models.Chat(id=chat_id, title="t", messages=[]))
+    db.commit()
+    big = "hello world\n" * 5000
+    get_writer().submit(
+        StashToolOutput(chat_id=chat_id, tool_use_id="tu_x", output=big)
+    ).result(timeout=5)
+    r = client.get(f"/api/chats/{chat_id}/tool-output/tu_x", headers=auth)
+    assert r.status_code == 200
+    assert r.text == big
+
+
+def test_tool_output_by_id_endpoint_404_when_absent(client, auth, db):
+    chat_id = str(uuid.uuid4())
+    db.add(models.Chat(id=chat_id, title="t", messages=[]))
+    db.commit()
+    r = client.get(f"/api/chats/{chat_id}/tool-output/missing", headers=auth)
+    assert r.status_code == 404
+
+
+def test_tool_output_by_id_endpoint_requires_owner(client, db):
+    chat_id = str(uuid.uuid4())
+    db.add(models.Chat(id=chat_id, title="t", messages=[]))
+    db.commit()
+    r = client.get(f"/api/chats/{chat_id}/tool-output/tu_x")
+    assert r.status_code == 401
+
+
+# -- sink reduction + stash ----------------------------------------------
+class _FakeBC:
+    def __init__(self):
+        self.events = []
+
+    def publish(self, event):
+        self.events.append(event)
+
+
+def _sink(chat_id="c-sink"):
+    from app.chat import _ChatEventSink
+    return _ChatEventSink(_FakeBC(), chat_id, run_token="rt")
+
+
+def test_sink_reduces_large_tagged_output_and_stashes_full(db):
+    sink = _sink()
+    big = "Exit code 1\n" + ("err\n" * 4000)
+    assert len(big) > TOOL_OUTPUT_INLINE_THRESHOLD
+    event = {"type": "tool_output", "content": big, "tool_use_id": "tu_big"}
+    sink._reduce_tool_output(event)
+    # Event rewritten to a bounded excerpt with metadata; tool_use_id intact.
+    assert event["content"] != big
+    assert len(event["content"]) < len(big)
+    assert event["output_truncated"] is True
+    assert event["output_full_len"] == len(big)
+    assert event["output_exit_code"] == 1
+    assert event["tool_use_id"] == "tu_big"
+    # Full text stashed under the tool_use_id.
+    _flush_writer()
+    row = db.query(models.ToolOutput).filter(
+        models.ToolOutput.chat_id == "c-sink",
+        models.ToolOutput.tool_use_id == "tu_big",
+    ).first()
+    assert row is not None and row.output == big
+
+
+def test_sink_passes_through_small_output(db):
+    sink = _sink()
+    small = "ok"
+    event = {"type": "tool_output", "content": small, "tool_use_id": "tu_s"}
+    sink._reduce_tool_output(event)
+    assert event["content"] == small
+    assert "output_truncated" not in event
+    _flush_writer()
+    assert db.query(models.ToolOutput).filter(
+        models.ToolOutput.tool_use_id == "tu_s"
+    ).first() is None
+
+
+def test_sink_passes_through_untagged_large_output(db):
+    # No tool_use_id -> nothing to key a stash by; leave the full output inline
+    # so it rides the legacy ?ts=&i= path against Chat.messages.
+    sink = _sink()
+    big = "y" * (TOOL_OUTPUT_INLINE_THRESHOLD + 100)
+    event = {"type": "tool_output", "content": big}
+    sink._reduce_tool_output(event)
+    assert event["content"] == big
+    assert "output_truncated" not in event
+    _flush_writer()
+    assert db.query(models.ToolOutput).count() == 0
+
+
+# -- reducer carries identity + metadata onto the block -------------------
+def test_reducer_carries_tool_use_id_from_tool_start():
+    blocks = []
+    process_event(
+        {"type": "tool_start", "tool": "Bash", "input": "ls", "tool_use_id": "tu_9"},
+        blocks,
+    )
+    assert blocks[0]["tool_use_id"] == "tu_9"
+
+
+def test_reducer_carries_truncation_metadata_from_tool_output():
+    blocks = []
+    process_event(
+        {"type": "tool_start", "tool": "Bash", "input": "ls", "tool_use_id": "tu_9"},
+        blocks,
+    )
+    process_event(
+        {
+            "type": "tool_output",
+            "content": "excerpt…",
+            "tool_use_id": "tu_9",
+            "output_truncated": True,
+            "output_full_len": 123456,
+            "output_exit_code": 2,
+        },
+        blocks,
+    )
+    blk = blocks[0]
+    assert blk["output"] == "excerpt…"
+    assert blk["tool_use_id"] == "tu_9"
+    assert blk["output_truncated"] is True
+    assert blk["output_full_len"] == 123456
+    assert blk["output_exit_code"] == 2
+
+
+def test_reducer_leaves_block_shape_unchanged_without_id_or_metadata():
+    blocks = []
+    process_event({"type": "tool_start", "tool": "Bash", "input": "ls"}, blocks)
+    process_event({"type": "tool_output", "content": "small"}, blocks)
+    assert blocks[0] == {
+        "type": "tool", "tool": "Bash", "input": "ls",
+        "output": "small", "status": "running",
+    }

--- a/frontend/src/components/ChatView/ToolBlock.jsx
+++ b/frontend/src/components/ChatView/ToolBlock.jsx
@@ -86,6 +86,11 @@ export default function ToolBlock({ t, chatId, msgTs, blockIdx }) {
   // re-collapsing doesn't refetch.
   const [fullOutput, setFullOutput] = useState(null)
   const [loadingFull, setLoadingFull] = useState(false)
+  // A fetch that failed (offline, or a 404 when no stash row exists) is
+  // TERMINAL: without this, loadingFull flips false and the effect re-fires on
+  // the same deps, retrying the fetch forever. A 404 is a designed outcome
+  // (contract rule 6: keep the inline excerpt), so try once and stop.
+  const [loadFailed, setLoadFailed] = useState(false)
   const toolName = t.tool || 'Tool'
   const label = toolName + (t.input ? `: ${t.input}` : '')
   const sources = Array.isArray(t.sources)
@@ -96,17 +101,29 @@ export default function ToolBlock({ t, chatId, msgTs, blockIdx }) {
   )
 
   useEffect(() => {
-    if (!open || !t.output_truncated || fullOutput !== null || loadingFull) return
-    if (!chatId || msgTs == null || blockIdx == null) return
+    if (!open || !t.output_truncated || fullOutput !== null || loadingFull || loadFailed) return
+    if (!chatId) return
+    // Contract rule 6 dual-read: a block reduced at the funnel carries a stable
+    // tool_use_id and fetches its full text from the side-table endpoint; a
+    // legacy block (no id, full output still in Chat.messages) falls back to the
+    // ?ts=&i= endpoint keyed by message ts + block index.
+    let url
+    if (t.tool_use_id) {
+      url = `/chats/${chatId}/tool-output/${encodeURIComponent(t.tool_use_id)}`
+    } else if (msgTs != null && blockIdx != null) {
+      url = `/chats/${chatId}/tool-output?ts=${msgTs}&i=${blockIdx}`
+    } else {
+      return
+    }
     let cancelled = false
     setLoadingFull(true)
-    apiFetch(`/chats/${chatId}/tool-output?ts=${msgTs}&i=${blockIdx}`)
+    apiFetch(url)
       .then(res => (res.ok ? res.text() : Promise.reject(new Error(`HTTP ${res.status}`))))
       .then(text => { if (!cancelled) setFullOutput(text) })
-      .catch(() => {})
+      .catch(() => { if (!cancelled) setLoadFailed(true) })
       .finally(() => { if (!cancelled) setLoadingFull(false) })
     return () => { cancelled = true }
-  }, [open, t.output_truncated, fullOutput, loadingFull, chatId, msgTs, blockIdx])
+  }, [open, t.output_truncated, t.tool_use_id, fullOutput, loadingFull, loadFailed, chatId, msgTs, blockIdx])
 
   // Show the fetched full output once it lands; until then the inline preview.
   const shownOutput = t.output_truncated && fullOutput !== null ? fullOutput : t.output
@@ -121,9 +138,15 @@ export default function ToolBlock({ t, chatId, msgTs, blockIdx }) {
     () => (shownOutput ? formatToolResult(shownOutput) : null),
     [shownOutput],
   )
-  const failed = !!(
-    r && r.kind === 'terminal' && r.exitCode != null && r.exitCode !== 0
-  )
+  // Failure exit code, field-or-parse (contract rule 6): a block reduced at the
+  // funnel carries an explicit output_exit_code, so read that rather than
+  // re-parsing a possibly-carved excerpt; else fall back to the parsed terminal
+  // envelope. This surfaces a failed step on the collapsed header without a
+  // fetch, even when the inline text is only an excerpt.
+  const exitCode = t.output_exit_code != null
+    ? t.output_exit_code
+    : (r && r.kind === 'terminal' ? r.exitCode : null)
+  const failed = exitCode != null && exitCode !== 0
 
   return (
     <div className={
@@ -150,7 +173,7 @@ export default function ToolBlock({ t, chatId, msgTs, blockIdx }) {
           {t.status === 'running' ? `${toolActivityLabel(toolName)}…` : label}
         </span>
         {failed && (
-          <span className="chat__tool-exit chat__tool-exit--head">exit {r.exitCode}</span>
+          <span className="chat__tool-exit chat__tool-exit--head">exit {exitCode}</span>
         )}
         {hasDetail && <span className="chat__tool-toggle">{open ? '▾' : '▸'}</span>}
       </div>

--- a/frontend/src/components/ChatView/__tests__/groupBlocks.test.js
+++ b/frontend/src/components/ChatView/__tests__/groupBlocks.test.js
@@ -220,3 +220,15 @@ test('coalesceThinkingEntries: groupToolRuns after coalesce yields one thinking 
   assert.equal(nodes[0].single.item.content, 'ab')
   assert.equal(nodes[1].group.map(x => x.idx).join(','), '2,3')
 })
+
+test('toolGroupState: reads output_exit_code field on a reduced block', () => {
+  // Contract rule 6: a failed tool whose output is only a carved excerpt (that
+  // may not re-parse) still resolves the group to 'error' via the explicit
+  // output_exit_code field.
+  const carved = { type: 'tool', status: 'done', output: 'head…[9 B]…tail', output_exit_code: 1 }
+  const ok = { type: 'tool', status: 'done', output: 'fine', output_exit_code: 0 }
+  assert.equal(toolGroupState([ok, carved]), 'error')
+  assert.equal(toolGroupState([ok, ok]), 'done')
+  // A still-running tool keeps the group 'running' even with a failed sibling.
+  assert.equal(toolGroupState([carved, { type: 'tool', status: 'running' }]), 'running')
+})

--- a/frontend/src/components/ChatView/__tests__/toolResultFormat.test.js
+++ b/frontend/src/components/ChatView/__tests__/toolResultFormat.test.js
@@ -1,6 +1,11 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { formatToolResult, toolResultFailed } from '../toolResultFormat.js'
+import {
+  formatToolResult,
+  toolResultFailed,
+  toolBlockFailed,
+  toolBlockExitCode,
+} from '../toolResultFormat.js'
 
 test('plain text passes through unchanged', () => {
   const r = formatToolResult('hello world\nsecond line')
@@ -157,4 +162,29 @@ test('toolResultFailed: true only for a nonzero terminal exit', () => {
   assert.equal(toolResultFailed('plain text, not a terminal'), false)
   assert.equal(toolResultFailed(JSON.stringify({ path: '/x', bytes: 1 })), false)
   assert.equal(toolResultFailed(null), false)
+})
+
+test('toolBlockExitCode: explicit output_exit_code field wins over a parse', () => {
+  // A reduced block (contract rule 6) carries output_exit_code; the inline text
+  // is only a carved excerpt, so the field is authoritative.
+  assert.equal(toolBlockExitCode({ output_exit_code: 1, output: 'carved…excerpt' }), 1)
+  assert.equal(toolBlockExitCode({ output_exit_code: 0, output: 'anything' }), 0)
+})
+
+test('toolBlockExitCode: falls back to parsing the output when no field', () => {
+  assert.equal(
+    toolBlockExitCode({ output: JSON.stringify({ stderr: 'x', exit_code: 137 }) }),
+    137,
+  )
+  assert.equal(toolBlockExitCode({ output: 'plain text' }), null)
+  assert.equal(toolBlockExitCode({}), null)
+})
+
+test('toolBlockFailed: field-or-parse failure detection survives truncation', () => {
+  // Field path: a carved excerpt that no longer parses still reads failed.
+  assert.equal(toolBlockFailed({ output_exit_code: 2, output: 'head…[X B]…tail' }), true)
+  assert.equal(toolBlockFailed({ output_exit_code: 0, output: 'head…tail' }), false)
+  // Parse path: a preserved "Exit code N" head still detects the failure.
+  assert.equal(toolBlockFailed({ output: 'Exit code 1\nboom' }), true)
+  assert.equal(toolBlockFailed({ output: 'all good' }), false)
 })

--- a/frontend/src/components/ChatView/groupBlocks.js
+++ b/frontend/src/components/ChatView/groupBlocks.js
@@ -1,4 +1,4 @@
-import { toolResultFailed } from './toolResultFormat.js'
+import { toolBlockFailed } from './toolResultFormat.js'
 import { toolActivityLabel } from './toolActivityLabel.js'
 
 // Fold runs of adjacent tool entries into one activity node, including a lone
@@ -88,8 +88,10 @@ export function coalesceThinkingEntries(entries) {
 //
 // "Failed" comes from the result's exit code, NOT a tool status — the stream
 // contract only sets 'running' → 'done' (streamReducers.js), so a failed bash
-// still ends 'done'. toolResultFailed reads the nonzero exit out of the parsed
-// terminal envelope, the same signal ToolBlock shows on the block header. A
+// still ends 'done'. toolBlockFailed reads the explicit output_exit_code field
+// when a reduced block carries one (contract rule 6), else the nonzero exit out
+// of the parsed terminal envelope — the same signal ToolBlock shows on the
+// block header. A
 // still-running tool has no final output yet, so it can't be "failed" here.
 //
 // `running` wins over `error`: while ANY child is still live the header reads
@@ -99,7 +101,7 @@ export function coalesceThinkingEntries(entries) {
 // every streaming frame while the run is in flight.
 export function toolGroupState(tools) {
   if (tools.some(t => t?.status === 'running')) return 'running'
-  if (tools.some(t => toolResultFailed(t?.output))) return 'error'
+  if (tools.some(t => toolBlockFailed(t))) return 'error'
   return 'done'
 }
 

--- a/frontend/src/components/ChatView/toolResultFormat.js
+++ b/frontend/src/components/ChatView/toolResultFormat.js
@@ -176,3 +176,21 @@ export function toolResultFailed(output) {
   const r = formatToolResult(output)
   return r.kind === 'terminal' && r.exitCode != null && r.exitCode !== 0
 }
+
+// Did this tool BLOCK report a failure? Field-or-parse (contract rule 6): a
+// block reduced at the funnel carries an explicit `output_exit_code`, so read
+// that when present rather than re-parsing a possibly-carved excerpt (a JSON
+// envelope truncated inside its stdout, or a bash head+tail). Absent the field
+// (a small un-reduced output, or a live streaming item) fall back to parsing
+// the output — the excerpt preserves the failure head, so the parse still
+// works. Shared by ToolBlock's header chip and groupBlocks' Failed state.
+export function toolBlockExitCode(t) {
+  if (t && t.output_exit_code != null) return t.output_exit_code
+  const r = formatToolResult(t?.output)
+  return r.kind === 'terminal' ? r.exitCode : null
+}
+
+export function toolBlockFailed(t) {
+  const code = toolBlockExitCode(t)
+  return code != null && code !== 0
+}


### PR DESCRIPTION
Implements contract-v2 rule 6 per the design addendum in docs/design/chat-behavior-contract-v2.md. Truncation moves up to the single event funnel (_ChatEventSink), so the live SSE push, the catch-up replay, and the persisted Chat.messages blob all carry a bounded head+tail excerpt from one rewritten event — byte-identical live and replayed. Full text stashes once into a new tool_outputs table keyed (chat_id, tool_use_id) via a fire-and-forget, non-fenced actor command (insert/upsert — outside the lost-update guardrail by construction), served by GET /api/chats/{chat_id}/tool-output/{tool_use_id} on expand. Failure detection survives the carve: envelope outputs are parsed and inner-truncated so JSON + exit code stay intact, plain text keeps the start-anchored "Exit code N" head, and an explicit output_exit_code field backs the chip. Dual-read migration: blocks without tool_use_id keep full text inline and ride the legacy ?ts=&i= path; the legacy GET-boundary reducer now emits a real excerpt instead of an empty string.

tool_use_id threaded through both runners (Claude ToolUseBlock/ToolResultBlock ids; Codex ThreadItem ids — verified stable in the SDK, getattr-guarded). Frontend touch kept minimal/additive (ToolBlock endpoint switch, terminal 404, field-or-parse chip; groupBlocks field-aware) since the sibling session owns the streaming surface — live-stream lazy-fetch deliberately deferred to that rework.

A Codex adversarial review ran during implementation; four findings fixed (JSON boundedness ceiling, item_id AttributeError guard, legacy rows stripped of tool_use_id to prevent wrong-endpoint fetches, 404 made terminal instead of a refetch loop). Backend 1904 passed / 1 skipped post-rebase, frontend units 756+44 / 0 fail, plus new excerpt/stash/endpoint test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)