### PR TITLE
Return-without-redraw slice: id-keyed tool blocks, reconciling catch-up commits, dimension-stable media (contract v2 item 2: 2a+2c+L3)

### DIFF
--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback } from 'react'
+import { useState, useRef, useEffect, useLayoutEffect, useCallback } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { apiFetch, getToken, BASE } from '../../api/client.js'
 import { chatMessagesQueryKey } from '../../hooks/queries.js'
@@ -664,6 +664,7 @@ export default function ChatView({
     gestureWindowUntilRef,
     userScrollIntentVersionRef,
     revealed,
+    reapplyActiveMode,
   } = useScrollMode({
     chatId,
     scrollRef,
@@ -858,6 +859,7 @@ export default function ChatView({
     isStreamingRef,
     connectionError,
     reconnecting,
+    catchUpCommitSeq,
     sendMessage: streamSend,
     connectToStream,
     retry,
@@ -2520,6 +2522,21 @@ export default function ChatView({
       window.removeEventListener('online', freezeStreamingReturn)
     }
   }, [turnActive, modeRef])
+
+  // Cloak the first post-reconnect catch-up commit (contract v2 item 2, lever
+  // 3). freezeStreamingReturn above already anchors the mode at the moment the
+  // tab returns; the atomic catch-up commit lands async AFTER that, and even the
+  // in-place reconcile (lever 2c) can re-settle heights. Re-hold the anchor the
+  // instant the commit's DOM mutation lands — in a layout effect, before paint,
+  // so a real reconnect (Path B) or a Path-A commit after the reveal cap never
+  // blinks the reader's position. reapplyActiveMode no-ops before reveal, and a
+  // quick-wake kept socket never reconnects (no commit → seq stays put), so a
+  // glance at the notification shade cannot trigger it. The seq starts at 0 and
+  // only a commit bumps it, so this skips the initial mount.
+  useLayoutEffect(() => {
+    if (catchUpCommitSeq === 0) return
+    reapplyActiveMode()
+  }, [catchUpCommitSeq, reapplyActiveMode])
 
   // Composer action state: queued work is also non-idle from the user's point
   // of view. Even if we momentarily don't have a live stream attached yet, a

--- a/frontend/src/components/ChatView/MsgContent.jsx
+++ b/frontend/src/components/ChatView/MsgContent.jsx
@@ -102,13 +102,16 @@ function MsgContentInner({
         )
       }
       if (block.type === 'tool') {
-        // Key a lone tool by `t-<firstIdx>` — the SAME scheme the group wrapper
-        // below uses — so a message that renders one tool and then (on a later
-        // render carrying a second adjacent tool) folds it into a group updates
-        // the slot in place instead of delete+insert. `i` is the block's index
-        // = the group's first index, so the keys coincide.
+        // Key a lone tool by its persisted `tool_use_id` (lever 2a) so the block
+        // survives the live↔DB surface switch and a catch-up commit by identity.
+        // Fall back to `t-<firstIdx>` for a legacy/tokenless block — the SAME
+        // scheme the group wrapper below uses — so a message that renders one
+        // tool and then (on a later render carrying a second adjacent tool)
+        // folds it into a group updates the slot in place instead of
+        // delete+insert. `i` is the block's index = the group's first index, and
+        // the group wrapper prefers the same tool's id, so the keys coincide.
         return (
-          <div key={`t-${i}`} className="chat__tools">
+          <div key={block.tool_use_id ?? `t-${i}`} className="chat__tools">
             {/* chatId + msg.ts + block index let ToolBlock lazily fetch a
                 truncated large output on expand (see chats.py
                 _truncate_large_tool_outputs + GET /tool-output). */}
@@ -217,15 +220,21 @@ function MsgContentInner({
         {nodes.map(node => {
           if (node.group) {
             const tools = node.group.map(e => e.item)
+            // Prefer the first tool's `tool_use_id` (lever 2a); fall back to
             // `t-<firstIdx>` — the SAME key a lone tool at that index uses (see
             // renderBlock), so a single→group transition updates this slot in
-            // place rather than swapping keys and forcing a delete+insert.
+            // place rather than swapping keys and forcing a delete+insert. Each
+            // grouped ToolBlock is keyed by its own id so a catch-up commit
+            // reconciles each block by identity within the group.
             return (
-              <div key={`t-${node.group[0].idx}`} className="chat__tools">
+              <div
+                key={node.group[0].item.tool_use_id ?? `t-${node.group[0].idx}`}
+                className="chat__tools"
+              >
                 <ToolActivityGroup tools={tools}>
                   {node.group.map(e => (
                     <ToolBlock
-                      key={e.idx}
+                      key={e.item.tool_use_id ?? e.idx}
                       t={e.item}
                       chatId={chatId}
                       msgTs={msg.ts}

--- a/frontend/src/components/ChatView/StreamingMessage.jsx
+++ b/frontend/src/components/ChatView/StreamingMessage.jsx
@@ -101,14 +101,17 @@ export default function StreamingMessage({ streamItems, dataKey, onAnswer }) {
   // folded into a group — grouping never touches a trailing text/thinking item.
   const renderItem = (item, i) => {
     if (item.type === 'tool') {
-      // Key a lone tool by `s-t-<firstIdx>` — the SAME scheme the group wrapper
-      // below uses. When a second adjacent tool arrives and this slot becomes a
-      // group, the wrapper key is unchanged, so React updates the slot in place
-      // instead of delete+insert (which would churn height and displace the
-      // reader). `i` here is the item's original index = the group's first
-      // index, so the two keys coincide.
+      // Key a lone tool by its real `tool_use_id` (lever 2a) so the block —
+      // the heaviest remount cost — survives a catch-up commit and the answer's
+      // source switch by identity. Fall back to `s-t-<firstIdx>` for a
+      // legacy/tokenless block: the SAME scheme the group wrapper below uses, so
+      // when a second adjacent tool arrives and this slot becomes a group the
+      // wrapper key is unchanged and React updates it in place instead of
+      // delete+insert. `i` is the item's original index = the group's first
+      // index, and the group wrapper prefers the same tool's id, so the keys
+      // coincide across the 1→2 transition either way.
       return (
-        <div key={`s-t-${i}`} className="chat__tools">
+        <div key={item.tool_use_id ?? `s-t-${i}`} className="chat__tools">
           <ToolBlock t={item} />
         </div>
       )
@@ -184,14 +187,20 @@ export default function StreamingMessage({ streamItems, dataKey, onAnswer }) {
       {nodes.map(node => {
         if (node.group) {
           const tools = node.group.map(e => e.item)
-          // `s-t-<firstIdx>` — the SAME key a lone tool at that index uses
-          // (see renderItem), so the 1→2-tool transition updates this slot in
-          // place rather than swapping keys and forcing a delete+insert.
+          // Prefer the first tool's `tool_use_id` (lever 2a); fall back to
+          // `s-t-<firstIdx>` — the SAME key a lone tool at that index uses (see
+          // renderItem), so the 1→2-tool transition updates this slot in place
+          // rather than swapping keys and forcing a delete+insert. Each grouped
+          // ToolBlock is keyed by its own id so a catch-up commit reconciles
+          // each block by identity within the group.
           return (
-            <div key={`s-t-${node.group[0].idx}`} className="chat__tools">
+            <div
+              key={node.group[0].item.tool_use_id ?? `s-t-${node.group[0].idx}`}
+              className="chat__tools"
+            >
               <ToolActivityGroup tools={tools}>
                 {node.group.map(e => (
-                  <ToolBlock key={`s-${e.idx}`} t={e.item} />
+                  <ToolBlock key={e.item.tool_use_id ?? `s-${e.idx}`} t={e.item} />
                 ))}
               </ToolActivityGroup>
             </div>

--- a/frontend/src/components/ChatView/__tests__/imageReserveHeight.test.js
+++ b/frontend/src/components/ChatView/__tests__/imageReserveHeight.test.js
@@ -40,6 +40,7 @@ import { dirname, resolve } from 'node:path'
 const here = dirname(fileURLToPath(import.meta.url))
 const markdownCss = readFileSync(resolve(here, '../markdown.css'), 'utf8')
 const chatViewCss = readFileSync(resolve(here, '../ChatView.css'), 'utf8')
+const inlineContentJsx = readFileSync(resolve(here, '../markdown/InlineContent.jsx'), 'utf8')
 
 /** Extract the body `{ ... }` of the first rule whose selector list contains
  *  `selector`. Brace-counting so nested at-rules don't trip a naive regex. */
@@ -112,5 +113,33 @@ describe('chat messages must NOT use content-visibility (it clamps the pin-scrol
     assert.doesNotMatch(cssNoComments, /content-visibility/,
       'content-visibility on .chat__msg clamps the pin-scroll so 2nd+ sends are ' +
       'no longer pinned to top — do not re-add it (see useScrollMode PIN_USER_MSG)')
+  })
+})
+
+describe('ExpandableImage reserves the frame BEFORE the token resolves (lever 3)', () => {
+  // Strip comments so prose describing the old behavior does not match.
+  const src = inlineContentJsx.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '')
+
+  test('does not early-return null on a missing resolvedSrc (that inserted the frame late)', () => {
+    assert.doesNotMatch(src, /if\s*\(\s*!resolvedSrc\s*\)\s*return\s+null/,
+      'returning null until resolvedSrc let the whole .md-image-frame insert late and ' +
+      'shove the surrounding text — the box must be reserved during the async token hop')
+  })
+
+  test('guards only the render on an INVALID href (rawSrc), reserving the frame otherwise', () => {
+    assert.match(src, /if\s*\(\s*!rawSrc\s*\)\s*return\s+null/,
+      'a blocked/empty href renders nothing, but a valid-but-unresolved href still reserves its frame')
+  })
+
+  test('the <img> element is gated on resolvedSrc while the frame is not', () => {
+    // The frame span is unconditional; the img swaps in once resolvedSrc lands.
+    assert.match(src, /resolvedSrc\s*&&\s*\(?\s*<img/,
+      'the <img> must render only once resolvedSrc is ready, inside an always-present frame')
+  })
+
+  test('seeds first-paint aspect ratio from known dims (parseImageDims/imageVarsFromDims)', () => {
+    assert.match(src, /parseImageDims/,
+      'known dimensions carried in the markup must seed --md-image-ratio on the first paint')
+    assert.match(src, /imageVarsFromDims/)
   })
 })

--- a/frontend/src/components/ChatView/__tests__/mediaImageEmbed.test.js
+++ b/frontend/src/components/ChatView/__tests__/mediaImageEmbed.test.js
@@ -28,6 +28,7 @@
  */
 import { test, describe } from 'node:test'
 import assert from 'node:assert/strict'
+import { parseImageDims, imageVarsFromDims } from '../markdown/imageDims.js'
 
 // ---------------------------------------------------------------------------
 // Replicate the regex and helper from InlineContent.jsx
@@ -362,4 +363,84 @@ describe('regex and extraction consistency', () => {
       assert.equal(getMediaChatId(path), null)
     })
   }
+})
+
+// ---------------------------------------------------------------------------
+// 7. Known image dimensions carried in the markup (contract v2 item 2, lever 3)
+//
+// A screenshot whose size the agent already knew can carry it as `?w=&h=` so
+// the frame reserves the exact aspect ratio on the first paint and the on-load
+// ratio delta vanishes. parseImageDims reads the query; imageVarsFromDims turns
+// dims into the same custom-property object the onLoad handler computes.
+// ---------------------------------------------------------------------------
+
+describe('parseImageDims', () => {
+  test('extracts positive integer w/h from a media href query', () => {
+    const dims = parseImageDims('/api/chats/abc/media/shot.png?w=412&h=915')
+    assert.deepEqual(dims, { width: 412, height: 915 })
+  })
+
+  test('works on an absolute URL too', () => {
+    const dims = parseImageDims('https://host.example/api/chats/abc/media/shot.png?w=800&h=600')
+    assert.deepEqual(dims, { width: 800, height: 600 })
+  })
+
+  test('returns null when no dims are present (the common case)', () => {
+    assert.equal(parseImageDims('/api/chats/abc/media/shot.png'), null)
+  })
+
+  test('returns null for zero, negative, or non-numeric dims', () => {
+    assert.equal(parseImageDims('/x.png?w=0&h=100'), null)
+    assert.equal(parseImageDims('/x.png?w=-5&h=100'), null)
+    assert.equal(parseImageDims('/x.png?w=abc&h=100'), null)
+    assert.equal(parseImageDims('/x.png?w=100'), null, 'height missing')
+  })
+
+  test('returns null for empty/invalid input', () => {
+    assert.equal(parseImageDims(''), null)
+    assert.equal(parseImageDims(null), null)
+    assert.equal(parseImageDims(undefined), null)
+  })
+})
+
+describe('imageVarsFromDims — known dims kill the on-load delta', () => {
+  // Replicate ExpandableImage's onLoad math so we can prove the first-paint
+  // vars (from known dims) EQUAL the vars onLoad would set from the same natural
+  // size — i.e. there is no delta to shift on decode.
+  function onLoadVars(naturalW, naturalH, viewportH) {
+    const ratio = naturalW / naturalH
+    const cappedH = Math.min(viewportH * 0.60, 480)
+    const fitWidth = Math.min(520, Math.max(120, Math.round(cappedH * ratio)))
+    return {
+      '--md-image-ratio': `${naturalW} / ${naturalH}`,
+      '--md-image-fit-width': `${fitWidth}px`,
+    }
+  }
+
+  test('first-paint vars from known dims equal the onLoad vars for the same size', () => {
+    const w = 412, h = 915, vh = 900
+    assert.deepEqual(
+      imageVarsFromDims(w, h, vh),
+      onLoadVars(w, h, vh),
+      'known-dimension first paint must match the eventual onLoad measurement — zero delta',
+    )
+  })
+
+  test('sets an exact aspect-ratio custom property', () => {
+    const vars = imageVarsFromDims(800, 600, 900)
+    assert.equal(vars['--md-image-ratio'], '800 / 600')
+  })
+
+  test('portrait dims produce a fit-width narrower than the 520px cap (no gray letterbox)', () => {
+    // A tall phone screenshot: cappedH * ratio is small, so fit-width shrinks.
+    const vars = imageVarsFromDims(412, 915, 900)
+    const fit = Number.parseInt(vars['--md-image-fit-width'], 10)
+    assert.ok(fit < 520, 'portrait frame width shrinks below the max so the frame hugs the image')
+    assert.ok(fit >= 120, 'but never below the min width')
+  })
+
+  test('falls back to a default viewport when none is given', () => {
+    assert.ok(imageVarsFromDims(800, 600), 'produces vars even without a viewport height')
+    assert.equal(imageVarsFromDims(0, 100), null, 'invalid dims still yield null')
+  })
 })

--- a/frontend/src/components/ChatView/__tests__/streamPromotion.test.js
+++ b/frontend/src/components/ChatView/__tests__/streamPromotion.test.js
@@ -13,7 +13,30 @@ import {
   assistantMessageText,
   findTrailingAssistantPartialIndex,
   streamItemsHaveRenderableContent,
+  streamItemToBlock,
 } from '../streamPromotion.js'
+
+// Lever 2a: the live tool item carries tool_use_id, and streamItemToBlock
+// spreads ...item, so the identity flows onto the promoted DB-shaped block for
+// free — MsgContent then keys the persisted tool block by the same id the live
+// stream used, so a promote (or reopen) reuses the ToolBlock by identity.
+test('streamItemToBlock carries tool_use_id onto the promoted tool block', () => {
+  const block = streamItemToBlock({
+    type: 'tool', tool: 'Bash', input: 'ls', output: 'a', status: 'done',
+    tool_use_id: 'toolu_42',
+  })
+  assert.equal(block.type, 'tool')
+  assert.equal(block.tool_use_id, 'toolu_42',
+    'tool_use_id must flow through the promotion so live and persisted keys agree')
+})
+
+test('streamItemToBlock leaves tool_use_id absent for a legacy tokenless item', () => {
+  const block = streamItemToBlock({
+    type: 'tool', tool: 'Bash', input: 'ls', output: 'a', status: 'running',
+  })
+  assert.equal(block.tool_use_id, undefined, 'no id on the item → none on the block; ordinal key applies')
+  assert.equal(block.status, 'done', 'running promotes to done as before')
+})
 
 test('streamItemsToAssistantPayload preserves text boundaries in legacy content', () => {
   const payload = streamItemsToAssistantPayload([

--- a/frontend/src/components/ChatView/__tests__/streamReducers.test.js
+++ b/frontend/src/components/ChatView/__tests__/streamReducers.test.js
@@ -24,6 +24,7 @@ import {
   appendThinkingChunk,
   thinkingElapsedMs,
   attachToolSources,
+  reconcileStreamItems,
 } from '../streamReducers.js'
 import { questionKey } from '../questionKey.js'
 
@@ -476,4 +477,114 @@ test('appendThinkingChunk opens a fresh item after a non-thinking item', () => {
 test('appendThinkingChunk is a no-op on empty content', () => {
   const items = [{ type: 'thinking', content: 'x' }]
   assert.equal(appendThinkingChunk(items, ''), items, 'empty chunk returns the same array')
+})
+
+// ---------------------------------------------------------------------------
+// reconcileStreamItems — the catch-up commit "return without redraw" merge
+// (contract v2 item 2, lever 2c). The core assertion is OBJECT IDENTITY: an
+// unchanged item keeps its reference across the commit, so a mid-stream return
+// re-renders nothing. tool_use_id (lever 2a) is the identity key for tools.
+// ---------------------------------------------------------------------------
+
+test('reconcile preserves object identity for an unchanged tool item (the core assertion)', () => {
+  const tool = { type: 'tool', tool: 'Bash', input: 'ls', output: 'a\nb', status: 'done', tool_use_id: 'toolu_1' }
+  const prev = [{ type: 'text', content: 'hi' }, tool]
+  // The catch-up replay rebuilds fresh objects carrying the SAME tool_use_id.
+  const next = [{ type: 'text', content: 'hi' }, { ...tool }]
+
+  const result = reconcileStreamItems(prev, next)
+
+  assert.equal(result[1], tool, 'unchanged tool item keeps its exact object reference across the commit')
+  assert.equal(result[0], prev[0], 'unchanged text item keeps its reference too')
+  assert.equal(result, prev, 'a fully-unchanged replay returns the prev array itself (React bails out entirely)')
+})
+
+test('reconcile merges a tool that changed state, keeping its key so the DOM node survives', () => {
+  const running = { type: 'tool', tool: 'Bash', input: 'ls', output: '', status: 'running', tool_use_id: 'toolu_1' }
+  const prev = [running]
+  // Same tool, now completed with output — the reconnect replays the finished form.
+  const next = [{ type: 'tool', tool: 'Bash', input: 'ls', output: 'a\nb', status: 'done', tool_use_id: 'toolu_1' }]
+
+  const result = reconcileStreamItems(prev, next)
+
+  assert.notEqual(result[0], running, 'a changed tool becomes a new object (props must update)')
+  assert.equal(result[0].tool_use_id, 'toolu_1', 'but the identity key is preserved, so React reuses the ToolBlock instance/DOM')
+  assert.equal(result[0].status, 'done')
+  assert.equal(result[0].output, 'a\nb')
+})
+
+test('reconcile matches tools by tool_use_id, not position, and never merges two different tools', () => {
+  const t1 = { type: 'tool', tool: 'Bash', input: 'ls', output: 'x', status: 'done', tool_use_id: 'toolu_1' }
+  const prev = [t1]
+  // The replay's first item is a DIFFERENT tool (different id) — a positional
+  // collision must not silently inherit t1's identity.
+  const t2 = { type: 'tool', tool: 'Grep', input: 'foo', output: 'y', status: 'done', tool_use_id: 'toolu_2' }
+  const next = [t2]
+
+  const result = reconcileStreamItems(prev, next)
+  assert.notEqual(result[0], t1, 'different tool_use_id → the replayed object wins, not a merge onto t1')
+  assert.equal(result[0].tool_use_id, 'toolu_2')
+})
+
+test('reconcile appends genuinely new replayed items without disturbing existing identity', () => {
+  const tool = { type: 'tool', tool: 'Bash', input: 'ls', output: 'a', status: 'done', tool_use_id: 'toolu_1' }
+  const prev = [tool]
+  const next = [
+    { ...tool },
+    { type: 'tool', tool: 'Read', input: 'f', output: 'z', status: 'done', tool_use_id: 'toolu_2' },
+    { type: 'text', content: 'summary' },
+  ]
+
+  const result = reconcileStreamItems(prev, next)
+  assert.equal(result.length, 3)
+  assert.equal(result[0], tool, 'existing tool keeps its reference')
+  assert.equal(result[1].tool_use_id, 'toolu_2', 'new tool is appended')
+  assert.equal(result[2].type, 'text')
+})
+
+test('reconcile drops on-screen items absent from the replay — never resurrects a steer-dropped segment', () => {
+  const prev = [
+    { type: 'text', content: 'pre-steer answer' },
+    { type: 'tool', tool: 'Bash', input: 'ls', output: 'a', status: 'done', tool_use_id: 'toolu_1' },
+  ]
+  // Post-steer replay carries only the continuation — the pre-steer segment was
+  // promoted to its own message and must not reappear.
+  const next = [{ type: 'text', content: 'post-steer continuation' }]
+
+  const result = reconcileStreamItems(prev, next)
+  assert.equal(result.length, 1)
+  assert.equal(result[0].content, 'post-steer continuation')
+})
+
+test('reconcile keeps the legacy ordinal (tokenless) path working positionally', () => {
+  // Old chats / legacy wires carry no tool_use_id; both prev and next lack it,
+  // so identity falls back to position — an unchanged legacy tool is still reused.
+  const legacy = { type: 'tool', tool: 'Bash', input: 'ls', output: 'a', status: 'done' }
+  const prev = [legacy]
+  const result = reconcileStreamItems(prev, [{ ...legacy }])
+  assert.equal(result, prev, 'legacy tokenless tool reuses identity positionally when unchanged')
+})
+
+test('reconcile onto a snapshot-seeded stream reconciles in place (no duplicate append)', () => {
+  // Path A remount: streamSnapshotCache seeds the visible items (they carry
+  // tool_use_id, so they survive JSON round-trip). The first catch-up commit
+  // must reconcile onto them, not append a second copy.
+  const seeded = JSON.parse(JSON.stringify([
+    { type: 'text', content: 'partial' },
+    { type: 'tool', tool: 'Bash', input: 'ls', output: '', status: 'running', tool_use_id: 'toolu_1' },
+  ]))
+  const replay = [
+    { type: 'text', content: 'partial then more' },
+    { type: 'tool', tool: 'Bash', input: 'ls', output: 'done', status: 'done', tool_use_id: 'toolu_1' },
+  ]
+
+  const result = reconcileStreamItems(seeded, replay)
+  assert.equal(result.length, 2, 'no duplicate tool block appended — reconciled onto the seeded item by id')
+  assert.equal(result[1].tool_use_id, 'toolu_1')
+  assert.equal(result[1].status, 'done')
+})
+
+test('reconcile returns the fresh array when prev is empty', () => {
+  const next = [{ type: 'text', content: 'x' }]
+  assert.equal(reconcileStreamItems([], next), next)
 })

--- a/frontend/src/components/ChatView/markdown/InlineContent.jsx
+++ b/frontend/src/components/ChatView/markdown/InlineContent.jsx
@@ -4,6 +4,7 @@ import DOMPurify from 'dompurify'
 import { getToken, BASE } from '../../../api/client.js'
 import { mediaTokenParam } from '../../../api/mediaToken.js'
 import { renderInlineMath, renderBlockMath, renderMathToString } from './math.js'
+import { parseImageDims, imageVarsFromDims } from './imageDims.js'
 import ImageLightbox from './ImageLightbox.jsx'
 import '../lightbox.css'
 
@@ -128,11 +129,22 @@ function resolveStaticImageSrc(href) {
 
 function ExpandableImage({ href, alt }) {
   const [open, setOpen] = useState(false)
-  const [imageVars, setImageVars] = useState(null)
   const [resolvedSrc, setResolvedSrc] = useState(null)
 
   const rawSrc = safeUrl(href, SAFE_IMAGE_PROTOCOLS)
   const mediaChatId = rawSrc ? getMediaChatId(rawSrc) : null
+
+  // Reserve the exact aspect ratio on the FIRST paint when the markup carries
+  // known dimensions (?w=&h=, lever 3): a screenshot whose size the agent
+  // already knew never shifts on decode. Absent dims this stays null and the
+  // frame falls back to the CSS 4/3 default, corrected by onLoad below.
+  const [imageVars, setImageVars] = useState(() => {
+    const dims = parseImageDims(rawSrc)
+    if (!dims) return null
+    const viewportH = (typeof window !== 'undefined'
+      && (window.visualViewport?.height || window.innerHeight)) || 800
+    return imageVarsFromDims(dims.width, dims.height, viewportH)
+  })
 
   useEffect(() => {
     if (!rawSrc) { setResolvedSrc(null); return }
@@ -149,38 +161,38 @@ function ExpandableImage({ href, alt }) {
     return () => { cancelled = true }
   }, [rawSrc, mediaChatId])
 
-  if (!resolvedSrc) return null
+  // A blocked/empty href (javascript:, data:, "") renders nothing. But a valid
+  // href whose token has not resolved yet still reserves its frame (lever 3):
+  // returning null until resolvedSrc let the whole box insert late and shove the
+  // surrounding text. The <img> swaps in once resolvedSrc lands.
+  if (!rawSrc) return null
   return (
     <>
       <span
         className="md-image-frame"
         style={imageVars || undefined}
       >
-        <img
-          src={resolvedSrc}
-          alt={alt}
-          className="md-image"
-          onLoad={(e) => {
-            const img = e.currentTarget
-            if (img.naturalWidth && img.naturalHeight) {
-              const ratio = img.naturalWidth / img.naturalHeight
-              const viewportH =
-                window.visualViewport?.height || window.innerHeight || 800
-              const cappedH = Math.min(viewportH * 0.60, 480)
-              const fitWidth = Math.min(
-                520,
-                Math.max(120, Math.round(cappedH * ratio)),
-              )
-              setImageVars({
-                '--md-image-ratio': `${img.naturalWidth} / ${img.naturalHeight}`,
-                '--md-image-fit-width': `${fitWidth}px`,
-              })
-            }
-          }}
-          onClick={() => setOpen(true)}
-        />
+        {resolvedSrc && (
+          <img
+            src={resolvedSrc}
+            alt={alt}
+            className="md-image"
+            onLoad={(e) => {
+              const img = e.currentTarget
+              if (img.naturalWidth && img.naturalHeight) {
+                const ratio = img.naturalWidth / img.naturalHeight
+                const viewportH =
+                  window.visualViewport?.height || window.innerHeight || 800
+                setImageVars(imageVarsFromDims(
+                  img.naturalWidth, img.naturalHeight, viewportH,
+                ))
+              }
+            }}
+            onClick={() => setOpen(true)}
+          />
+        )}
       </span>
-      {open && createPortal(
+      {open && resolvedSrc && createPortal(
         <ImageLightbox src={resolvedSrc} alt={alt} onClose={() => setOpen(false)} />,
         document.body,
       )}

--- a/frontend/src/components/ChatView/markdown/imageDims.js
+++ b/frontend/src/components/ChatView/markdown/imageDims.js
@@ -1,0 +1,69 @@
+/*
+ * Known-dimension parsing for chat markdown images (contract v2 item 2, lever
+ * 3). When the agent embeds an image whose size it already knows — a screenshot
+ * taken at the viewport it was handed — it can carry that size in the image
+ * href as `?w=<int>&h=<int>`. The frame then reserves the exact aspect ratio on
+ * the FIRST paint, so the box does not resize when the image decodes and the
+ * on-load ratio delta disappears. Absent dims, the frame falls back to the CSS
+ * 4/3 default and `onLoad` measures the real ratio as before.
+ *
+ * Pure + DOM-free so it unit-tests without React (see mediaImageEmbed.test.js).
+ * The fit-width math mirrors ExpandableImage's onLoad handler exactly, so when
+ * the carried dims equal the natural dims the two agree and nothing shifts.
+ */
+
+const FRAME_MAX_WIDTH = 520
+const FRAME_MIN_WIDTH = 120
+const FRAME_CAP_H = 480
+const FRAME_VIEWPORT_FRACTION = 0.6
+const DEFAULT_VIEWPORT_H = 800
+
+/**
+ * Extracts known pixel dimensions from an image href's `?w=&h=` query.
+ *
+ * @param {string} href  raw href from the markdown image token
+ * @returns {{width:number, height:number}|null}  positive integer dims, or null
+ */
+export function parseImageDims(href) {
+  if (!href || typeof href !== 'string') return null
+  let params
+  try {
+    // Root the (possibly relative) href so URLSearchParams can read the query.
+    // The origin is discarded — only the query matters here.
+    params = new URL(href, 'https://mobius.local').searchParams
+  } catch {
+    return null
+  }
+  const width = Number.parseInt(params.get('w'), 10)
+  const height = Number.parseInt(params.get('h'), 10)
+  if (!Number.isFinite(width) || !Number.isFinite(height)) return null
+  if (width <= 0 || height <= 0) return null
+  return { width, height }
+}
+
+/**
+ * Builds the `--md-image-ratio` / `--md-image-fit-width` custom-property object
+ * the frame reads, from known dimensions. Identical formula to the onLoad
+ * measurement, so a correct carried size produces no on-load delta.
+ *
+ * @param {number} width
+ * @param {number} height
+ * @param {number} [viewportH]  visual-viewport height for the height cap
+ * @returns {object|null}  a React style object, or null for invalid dims
+ */
+export function imageVarsFromDims(width, height, viewportH) {
+  if (!(width > 0) || !(height > 0)) return null
+  const ratio = width / height
+  const vh = Number.isFinite(viewportH) && viewportH > 0
+    ? viewportH
+    : DEFAULT_VIEWPORT_H
+  const cappedH = Math.min(vh * FRAME_VIEWPORT_FRACTION, FRAME_CAP_H)
+  const fitWidth = Math.min(
+    FRAME_MAX_WIDTH,
+    Math.max(FRAME_MIN_WIDTH, Math.round(cappedH * ratio)),
+  )
+  return {
+    '--md-image-ratio': `${width} / ${height}`,
+    '--md-image-fit-width': `${fitWidth}px`,
+  }
+}

--- a/frontend/src/components/ChatView/streamReducers.js
+++ b/frontend/src/components/ChatView/streamReducers.js
@@ -274,3 +274,72 @@ export function closeAllToolLifecycles(prev) {
     return b
   })
 }
+
+/**
+ * True when two stream items carry identical own-enumerable fields by ===.
+ * Nested values (a tool's `sources` array, a question's `answers`/`questions`)
+ * compare by reference, so an item that gained or replaced one of those reads
+ * as changed and is merged rather than reused — 2a's key still preserves its
+ * DOM node, only the props update.
+ */
+function shallowEqualItem(a, b) {
+  if (a === b) return true
+  if (!a || !b) return false
+  const ka = Object.keys(a)
+  const kb = Object.keys(b)
+  if (ka.length !== kb.length) return false
+  for (const k of ka) {
+    if (a[k] !== b[k]) return false
+  }
+  return true
+}
+
+/**
+ * Reconcile a catch-up replay (`next`) onto the on-screen stream (`prev`),
+ * merging by key so unchanged items keep their object + DOM identity through
+ * the commit instead of remounting the whole answer (contract v2 item 2, lever
+ * 2c — "return without redraw").
+ *
+ * The replay is deterministic and in-order, so position k in `next` is the same
+ * logical item as position k in `prev`. Tool items additionally require a
+ * matching `tool_use_id` (lever 2a) before reusing identity, so a positional
+ * collision between two different tools can never silently merge; text/thinking
+ * match positionally (until lever 2b gives them a synthetic id). For each
+ * replayed item:
+ *   - identity matches an on-screen item AND all fields are equal → reuse the
+ *     on-screen object, so React skips even a memoized re-render;
+ *   - identity matches but fields differ → merge `{...prev, ...next}` (a new
+ *     object under the SAME key, so the DOM node survives and only props
+ *     update);
+ *   - no identity match → take the replayed object (a genuinely new item).
+ *
+ * Items on-screen but absent from `next` are dropped — catch-up is
+ * authoritative, so a steer-dropped or trimmed pre-reconnect segment is never
+ * resurrected. Returns `prev` unchanged (same array ref) when nothing changed,
+ * making a no-op reconnect commit a complete React bail-out.
+ */
+export function reconcileStreamItems(prev, next) {
+  if (!Array.isArray(next)) return prev
+  if (!Array.isArray(prev) || prev.length === 0) return next
+  let changed = next.length !== prev.length
+  const result = next.map((n, k) => {
+    const p = prev[k]
+    if (!p || p.type !== n.type) {
+      changed = true
+      return n
+    }
+    if (n.type === 'tool') {
+      const bothTagged = p.tool_use_id != null && n.tool_use_id != null
+      const bothLegacy = p.tool_use_id == null && n.tool_use_id == null
+      const idMatch = bothTagged ? p.tool_use_id === n.tool_use_id : bothLegacy
+      if (!idMatch) {
+        changed = true
+        return n
+      }
+    }
+    if (shallowEqualItem(p, n)) return p
+    changed = true
+    return { ...p, ...n }
+  })
+  return changed ? result : prev
+}

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -32,7 +32,7 @@
  * See ARCHITECTURE.md "Chat scroll + steer contract" for the full design.
  */
 
-import { useState, useRef, useLayoutEffect } from 'react'
+import { useState, useRef, useLayoutEffect, useCallback } from 'react'
 import { cidOf } from './chatRuntimeState.js'
 
 
@@ -444,6 +444,10 @@ export default function useScrollMode({
   spacerActive = false,
 }) {
   const [revealed, setRevealed] = useState(false)
+  // Synchronous mirror of `revealed` for reapplyActiveMode, which is called
+  // from a ChatView layout effect (a closure that may pre-date the reveal
+  // flip). Set inline at every setRevealed(true) so the read is never stale.
+  const revealedRef = useRef(false)
   const modeRef = useRef({ kind: 'INITIAL' })
   const modeChatIdRef = useRef(null)
   const bottomVisibleRef = useRef(false)
@@ -691,6 +695,7 @@ export default function useScrollMode({
       revealTimer = setTimeout(() => {
         if (scrollRef.current === scrollEl) syncLayout()
         revealedOnce = true
+        revealedRef.current = true
         setRevealed(true)
       }, 50)
     }
@@ -836,6 +841,7 @@ export default function useScrollMode({
       requestRevealOnQuiet()
       safetyReveal = setTimeout(() => {
         revealedOnce = true
+        revealedRef.current = true
         setRevealed(true)
       }, REVEAL_CAP_MS)
     }
@@ -861,10 +867,29 @@ export default function useScrollMode({
     // but the flip is an explicit trigger, not an inferred one).
   }, [messages, pendingMessagesLength, chatId, spacerActive])
 
+  // Re-hold the reading position after an atomic catch-up commit lands
+  // post-reveal (contract v2 item 2, lever 3 — cloak the commit). The in-place
+  // reconcile keeps DOM identity but can still re-settle heights, so a real
+  // reconnect (Path B) or a Path-A commit after the reveal cap must not shift
+  // what the reader was looking at. Before reveal, hide-then-reveal already owns
+  // the position, so this no-ops; a quick-wake kept socket produces no commit,
+  // so the caller never invokes it. Mirrors the RO's content-tracking re-apply
+  // (FOLLOW_BOTTOM/ANCHOR_AT only — PIN_USER_MSG settles via its own RO branch).
+  const reapplyActiveMode = useCallback(() => {
+    if (!revealedRef.current) return
+    const scrollEl = scrollRef.current
+    if (!scrollEl) return
+    const k = modeRef.current.kind
+    if (k === 'FOLLOW_BOTTOM' || k === 'ANCHOR_AT') {
+      applyMode(scrollEl, modeRef.current)
+    }
+  }, [scrollRef])
+
   return {
     modeRef,
     gestureWindowUntilRef,
     userScrollIntentVersionRef,
     revealed,
+    reapplyActiveMode,
   }
 }

--- a/frontend/src/components/ChatView/useStreamConnection.js
+++ b/frontend/src/components/ChatView/useStreamConnection.js
@@ -12,6 +12,7 @@ import {
   closeAllToolLifecycles,
   appendThinkingChunk,
   attachToolSources,
+  reconcileStreamItems,
 } from './streamReducers.js'
 import {
   readStoredStreamSnapshot,
@@ -155,6 +156,7 @@ const BROADCAST_REGISTRATION_WINDOW_MS = 1500
  *   isStreamingRef: React.MutableRefObject<boolean>,
  *   connectionError: string | null,
  *   reconnecting: boolean,
+ *   catchUpCommitSeq: number,
  *   sendMessage: (text: string, attachments?: Array<object>,
  *                 opts?: {hidden?: boolean, queueOnly?: boolean, cid?: string,
  *                         forceSteer?: boolean, consumePendingCids?: string[],
@@ -198,6 +200,13 @@ export default function useStreamConnection(chatId, {
   // catch-up commits; if replay stalls on a tool-only pause or drops before
   // catch_up_done, the user still sees the last real stream state.
   const catchUpStartedRef = useRef(false)
+  // Monotonic counter bumped on every atomic catch-up commit. useScrollMode
+  // reads it to cloak the first post-reconnect commit (lever 3): after a real
+  // reconnect the reconcile can still re-settle heights, so the scroll machine
+  // re-holds the reading position once the commit lands. A quick-wake kept
+  // socket never reconnects, so it produces no commit and no bump — the shade
+  // glance can't blink the chat.
+  const [catchUpCommitSeq, setCatchUpCommitSeq] = useState(0)
 
   // Wrapper that keeps latestItemsRef in sync synchronously.
   // This prevents promoteStreamToMessages from reading stale items
@@ -654,7 +663,17 @@ export default function useStreamConnection(chatId, {
       const commitCatchUp = () => {
         if (!isCatchUp) return
         if (catchUpItems.length > 0) {
-          setStreamItems(catchUpItems)
+          // Reconcile-into-existing (lever 2c): merge the replayed items onto
+          // the on-screen items by key so unchanged items keep their object +
+          // DOM identity through the commit, instead of replacing the whole
+          // array with fresh objects (which remounted every ToolBlock, <img>,
+          // KaTeX/highlight node in the answer). `prev` is the visible stream —
+          // catch-up rebuilt off-screen into catchUpItems, so the snapshot- or
+          // live-seeded on-screen items are what we reconcile onto (covers the
+          // streamSnapshotCache hand-off: no duplicate append). A steer drop
+          // leaves catchUpItems empty and falls to the authoritative branch
+          // below, so dropped pre-steer items are never resurrected here.
+          setStreamItems(prev => reconcileStreamItems(prev, catchUpItems))
         } else {
           // Empty replay is authoritative. Do not preserve a stale visible
           // snapshot here: after fast-forward, that snapshot may already be
@@ -667,6 +686,11 @@ export default function useStreamConnection(chatId, {
         catchUpItems = []
         isCatchUp = false
         catchUpStartedRef.current = false
+        // Signal the scroll machine to cloak this commit (lever 3). It only
+        // acts once the chat is already revealed (a real reconnect / a Path-A
+        // commit after the reveal cap); a pre-reveal mount commit is covered by
+        // hide-then-reveal and a kept socket produces no commit at all.
+        setCatchUpCommitSeq(s => s + 1)
       }
 
       const patchCatchUpQuestionAnswers = (questionId, answers) => {
@@ -768,6 +792,14 @@ export default function useStreamConnection(chatId, {
               input: event.input || '',
               output: '',
               status: 'running',
+              // Carry the real per-tool identity from the wire (lever 2a). It
+              // keys the tool block (StreamingMessage/MsgContent) and lets a
+              // catch-up commit reconcile onto it by identity instead of
+              // remounting the heaviest block (expanded state, <img>, lazy
+              // fullOutput). streamItemToBlock spreads ...item, so it flows to
+              // the promoted message too. Undefined on a legacy/tokenless wire,
+              // where the ordinal fallback key still applies.
+              tool_use_id: event.tool_use_id,
             }])
           } else if (event.type === 'tool_input') {
             // Backfill input summary from the assistant event.
@@ -1411,6 +1443,7 @@ export default function useStreamConnection(chatId, {
     isStreamingRef,
     connectionError,
     reconnecting,
+    catchUpCommitSeq,
     sendMessage,
     connectToStream,
     retry,


### PR DESCRIPTION
The claimed slice of contract-v2 item 2. Lever 2a: tool_use_id (already on the wire since #30) now rides the live stream item and keys every tool block rendering — lone, group wrapper, and grouped — with ordinal fallback for legacy blocks. Lever 2c: commitCatchUp reconciles the replay onto the on-screen items by identity instead of replacing the array — unchanged items keep their exact object reference (full React bail), changed tools keep their key so the DOM node survives with prop updates, replay stays authoritative (steer-dropped segments never resurrect), and the snapshot-seeded first commit reconciles in place. Lever L3: image frames render before the media token resolves, carried ?w=&h= dimensions seed the exact aspect ratio on first paint, and a post-reveal catch-up commit re-holds the active scroll mode so the landing never visibly shifts (covers the previously-uncloaked foreground-return path).

Net effect on a mid-stream return: tool blocks keep expanded state and decoded images, nothing remounts, the scroll anchor holds — an in-place prop update instead of a full answer redraw. The remaining redraw source (the DB↔live surface swap) is lever L1, deliberately untouched and offered to the sibling session; both key namespaces are now id-aware for it.

Frontend-only (+537/−50, 12 files; backend diff empty). Units 772+44/0; named container specs (stream-reconnect, spacer, second-send-pin, pin-clamp-settle) 47/0 on a fresh-volume byte-verified container; broader chat-surface run 48/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)