### PR TITLE
test(steer-queued): block the service worker so route mocks stay authoritative

### DIFF
--- a/tests/steer-queued.spec.mjs
+++ b/tests/steer-queued.spec.mjs
@@ -65,6 +65,13 @@ async function sendMessage(page, text) {
   await page.keyboard.press('Enter')
 }
 
+// The real service worker claims the page ~1s after load; from then on its
+// fetch() handler bypasses page.route, so the mocked /messages + /stream
+// contracts silently fall through to the real backend and the mock's steer
+// events never arrive (the app-canvas spec hit the identical class). These
+// tests mock the network and do not exercise SW behavior, so block it.
+test.use({ serviceWorkers: 'block' })
+
 test.describe('Steer queued messages (fast-forward into the live turn)', () => {
   test('fast-forward button appears, POSTs force_steer with the right payload, and clears the tray', async ({ page }) => {
     // The server-assigned ts the queueOnly POST hands back. The steer's


### PR DESCRIPTION
Main's e2e failed steer-queued's no-wipe test twice (both attempts each run) while identical trees passed PR runs. Mechanism: the real SW claims the page mid-test; its fetch handler bypasses page.route, the mocked steer stream events never arrive, and the post-steer wait times out — the exact isolation class the app-canvas spec fixed. This spec mocks the network end to end and tests no SW behavior, so it blocks the worker. Suite-wide audit of the other 15 mock-driven specs without the block is noted in card 221 (selective — sw-pwa/shell-update-idle/bootstrap need the worker).

Validation note: PR runs were green even when main was red on this spec, so the PR check alone does not prove the fix — the fix's own post-merge main run is the real verdict and will be watched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)