### PR TITLE
test: block the service worker in ten SW-independent mock-driven specs

### DIFF
--- a/tests/cache.spec.mjs
+++ b/tests/cache.spec.mjs
@@ -109,6 +109,13 @@ async function getActiveChatId(page) {
 
 // ---------------------------------------------------------------------------
 
+// These tests mock the network via page.route and assert no service-worker
+// behavior. The real SW claims the page ~1s after load and its fetch handler
+// bypasses page.route, silently un-mocking the API/stream contracts mid-test
+// (the app-canvas and steer-queued specs both hit this class). Block it so
+// the mocks stay authoritative for the whole test.
+test.use({ serviceWorkers: 'block' })
+
 test.describe('Chat messages cache (TanStack Query)', () => {
   test('1. Second visit to a chat renders content from cache without hitting the network', async ({ page }) => {
     // Goal: the back-navigation flash is gone because the cache served

--- a/tests/chat-redesign.spec.mjs
+++ b/tests/chat-redesign.spec.mjs
@@ -100,6 +100,13 @@ async function sendMessage(page, text) {
 // BUG 1: AskUserQuestion answerable
 // ─────────────────────────────────────────────────────────────────
 
+// These tests mock the network via page.route and assert no service-worker
+// behavior. The real SW claims the page ~1s after load and its fetch handler
+// bypasses page.route, silently un-mocking the API/stream contracts mid-test
+// (the app-canvas and steer-queued specs both hit this class). Block it so
+// the mocks stay authoritative for the whole test.
+test.use({ serviceWorkers: 'block' })
+
 test.describe('Bug 1: AskUserQuestion', () => {
 
   test('QuestionCard buttons are NOT disabled after the question event', async ({ page }) => {

--- a/tests/frontend.spec.mjs
+++ b/tests/frontend.spec.mjs
@@ -73,6 +73,13 @@ async function sendMessage(page, text) {
 // Tests
 // ---------------------------------------------------------------------------
 
+// These tests mock the network via page.route and assert no service-worker
+// behavior. The real SW claims the page ~1s after load and its fetch handler
+// bypasses page.route, silently un-mocking the API/stream contracts mid-test
+// (the app-canvas and steer-queued specs both hit this class). Block it so
+// the mocks stay authoritative for the whole test.
+test.use({ serviceWorkers: 'block' })
+
 test.describe('Input behavior', () => {
   test('1. Input clears after send', async ({ page }) => {
     await setup(page)

--- a/tests/handleStop-sync-ordering.spec.mjs
+++ b/tests/handleStop-sync-ordering.spec.mjs
@@ -67,6 +67,13 @@ async function sendMessage(page, text) {
   await page.keyboard.press('Enter')
 }
 
+// These tests mock the network via page.route and assert no service-worker
+// behavior. The real SW claims the page ~1s after load and its fetch handler
+// bypasses page.route, silently un-mocking the API/stream contracts mid-test
+// (the app-canvas and steer-queued specs both hit this class). Block it so
+// the mocks stay authoritative for the whole test.
+test.use({ serviceWorkers: 'block' })
+
 test.describe('handleStop sync-ordering (Ticket 034 R1)', () => {
   test('Stop with a queued message clears the queue and never resurrects it during the stop POST', async ({ page }) => {
     // Route plan:

--- a/tests/navigation.spec.mjs
+++ b/tests/navigation.spec.mjs
@@ -131,6 +131,13 @@ async function goBack(page) {
 // Tests
 // ---------------------------------------------------------------------------
 
+// These tests mock the network via page.route and assert no service-worker
+// behavior. The real SW claims the page ~1s after load and its fetch handler
+// bypasses page.route, silently un-mocking the API/stream contracts mid-test
+// (the app-canvas and steer-queued specs both hit this class). Block it so
+// the mocks stay authoritative for the whole test.
+test.use({ serviceWorkers: 'block' })
+
 test.describe('Navigation basics', () => {
   test('1. Initial state — chat view, URL is /shell/', async ({ page }) => {
     await setup(page)

--- a/tests/pin-clamp-settle.spec.mjs
+++ b/tests/pin-clamp-settle.spec.mjs
@@ -122,6 +122,13 @@ async function measure(page) {
   })
 }
 
+// These tests mock the network via page.route and assert no service-worker
+// behavior. The real SW claims the page ~1s after load and its fetch handler
+// bypasses page.route, silently un-mocking the API/stream contracts mid-test
+// (the app-canvas and steer-queued specs both hit this class). Block it so
+// the mocks stay authoritative for the whole test.
+test.use({ serviceWorkers: 'block' })
+
 test('Deep second send pins flush to top after the post-send layout settle (no halfway clamp)', async ({ page }) => {
   await setup(page)
   await newChat(page)

--- a/tests/second-send-pin.spec.mjs
+++ b/tests/second-send-pin.spec.mjs
@@ -126,6 +126,13 @@ async function measure(page) {
   })
 }
 
+// These tests mock the network via page.route and assert no service-worker
+// behavior. The real SW claims the page ~1s after load and its fetch handler
+// bypasses page.route, silently un-mocking the API/stream contracts mid-test
+// (the app-canvas and steer-queued specs both hit this class). Block it so
+// the mocks stay authoritative for the whole test.
+test.use({ serviceWorkers: 'block' })
+
 test('Second send through full SSE flow: new user msg pins to viewport top', async ({ page }) => {
   // Mock a long streamed response so the chat has real content
   // through React's promoteStreamToMessages path (the user's actual

--- a/tests/send-rule.spec.mjs
+++ b/tests/send-rule.spec.mjs
@@ -142,6 +142,13 @@ async function measure(page) {
 // First message — always pins
 // ───────────────────────────────────────────────────────────────────
 
+// These tests mock the network via page.route and assert no service-worker
+// behavior. The real SW claims the page ~1s after load and its fetch handler
+// bypasses page.route, silently un-mocking the API/stream contracts mid-test
+// (the app-canvas and steer-queued specs both hit this class). Block it so
+// the mocks stay authoritative for the whole test.
+test.use({ serviceWorkers: 'block' })
+
 test('First message in a chat pins to the viewport top', async ({ page }) => {
   await setup(page)
   await newChat(page)

--- a/tests/spacer.spec.mjs
+++ b/tests/spacer.spec.mjs
@@ -240,6 +240,13 @@ function assertSpacerReasonable(m, label = '') {
 // Tests
 // ---------------------------------------------------------------------------
 
+// These tests mock the network via page.route and assert no service-worker
+// behavior. The real SW claims the page ~1s after load and its fetch handler
+// bypasses page.route, silently un-mocking the API/stream contracts mid-test
+// (the app-canvas and steer-queued specs both hit this class). Block it so
+// the mocks stay authoritative for the whole test.
+test.use({ serviceWorkers: 'block' })
+
 test.describe('Spacer mechanics', () => {
   test('1. First message — spacer reserves space, user msg at top', async ({ page }) => {
     await setup(page)

--- a/tests/stream-reconnect.spec.mjs
+++ b/tests/stream-reconnect.spec.mjs
@@ -109,6 +109,13 @@ async function pillOverlapDiagnostics(page) {
   })
 }
 
+// These tests mock the network via page.route and assert no service-worker
+// behavior. The real SW claims the page ~1s after load and its fetch handler
+// bypasses page.route, silently un-mocking the API/stream contracts mid-test
+// (the app-canvas and steer-queued specs both hit this class). Block it so
+// the mocks stay authoritative for the whole test.
+test.use({ serviceWorkers: 'block' })
+
 test.describe('Stream reconnection', () => {
   test('1. Completed stream stays idle after visibility change', async ({ page }) => {
     let streamRequestCount = 0


### PR DESCRIPTION
Follow-through on the SW-isolation flake class that produced repeated PR-green/main-red asymmetries (app-canvas and steer-queued both fixed the same way). The real service worker claims the page ~1s after load; its fetch handler then bypasses page.route, silently un-mocking the API/stream contracts mid-test — a race that resolves differently by runner warmth, so it passes on PR runs and fails on main (or vice versa). Adjudicated per-spec: these ten mock the network end to end and carry zero serviceWorker/offline references, so serviceWorkers: 'block' is safe and correct. Deliberately excluded: sw-pwa, shell-update-idle, bootstrap (they test SW behavior) and storage-typed, outbox, tabs (offline/multi-tab semantics where the worker may be load-bearing — left green). Should retire a recurring class of phantom main-reds.

Playwright --list parses all 24 files (169 tests); no assertion changes, only test.use isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)