### PR TITLE
Unify active-answer rendering across DB and live sources (contract v2 item 2, lever 1)

### DIFF
--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -25,7 +25,7 @@ import { formatResetTime } from './resetTime.js'
 import { questionKey } from './questionKey.js'
 import { resolveStopResend } from './resolveStopResend.js'
 import { focusComposerElement, shouldApplyComposerFocusRequest } from './composerFocusPolicy.js'
-import { chooseActiveAssistantSurface, findTrailingAssistantPartialIndex, promoteAssistantStream, streamItemsHaveRenderableContent } from './streamPromotion.js'
+import { chooseActiveAssistantDataKey, chooseActiveAssistantMirrorIndex, chooseActiveAssistantSurface, findTrailingAssistantPartialIndex, promoteAssistantStream, streamItemsHaveRenderableContent, streamItemsToAssistantPayload } from './streamPromotion.js'
 import {
   builtAppPulseDecision,
   canFastForwardQueue,
@@ -558,6 +558,7 @@ export default function ChatView({
   const chatIdStaleRef = useRef(false)
   const hadMessagesRef = useRef((cached?.messages?.length ?? 0) > 0)
   const promotedRef = useRef(false)
+  const activeAssistantDataKeyRef = useRef(null)
   // Bridge-partial gating decides whether the next promote REPLACES
   // the kept DB partial (in-flight turn whose snapshot we mounted
   // on top of) or APPENDS a fresh assistant message. The captured
@@ -1143,6 +1144,9 @@ export default function ChatView({
           ? messagesRef.current[trailingIdx]?.ts
           : null)
     bridgeHook.markBridged()
+    // Promotion ends this active row. A queued/steered continuation must seed
+    // its own anchor instead of inheriting a bridged DB key.
+    activeAssistantDataKeyRef.current = null
     commitMessages(
       prev => promoteAssistantStream(prev, { items, bridgeTs }),
       undefined,
@@ -1337,14 +1341,12 @@ export default function ChatView({
           return
         }
 
-        // Keep the DB partial when the agent is still running. The
-        // user sees the most recent persisted state immediately; SSE
-        // catch-up populates streamItems and the streaming <li> takes
-        // over visually (see messages.map render — last assistant is
-        // suppressed when sending && streamItems.length > 0). On done,
-        // promoteStreamToMessages replaces this partial with the
-        // final version. Previously we stripped this and waited for
-        // SSE — caused the "message disappears on choppy return" bug.
+        // Keep the DB partial when the agent is still running. The user sees
+        // the most recent persisted state immediately; SSE catch-up makes the
+        // same active MsgContent swap to the live payload. On done,
+        // promoteStreamToMessages replaces this partial with the final version.
+        // Previously we stripped this and waited for SSE — caused the "message
+        // disappears on choppy return" bug.
 
         // Normalize stale "running" tool blocks from interrupted sessions.
         for (const msg of msgs) {
@@ -2649,28 +2651,49 @@ export default function ChatView({
     : null
   const showLoadError = loadError && messages.length === 0 && !loading && !turnActive
   const lastUserIdx = messages.reduce((acc, m, i) => (m.role === 'user' && !m.hidden) ? i : acc, -1)
-  const bridgeMsgIdx = (turnActive && streamItems.length > 0)
+  // The captured bridge partial enters the active row before catch-up emits a
+  // single item. That is the load-bearing part of Lever 1: when SSE becomes the
+  // selected source, React updates MsgContent props instead of replacing the
+  // DB row with a different renderer subtree.
+  const bridgeMsgIdx = turnActive
     ? bridgeHook.findBridgeIndex(messages)
     : -1
-  const trailingAssistantPartialIdx = (turnActive && streamItems.length > 0)
+  const trailingAssistantPartialIdx = turnActive
     ? findTrailingAssistantPartialIndex(messages)
     : -1
   const activePartialMsgIdx = bridgeMsgIdx >= 0 ? bridgeMsgIdx : trailingAssistantPartialIdx
   const activePartialMsg = activePartialMsgIdx >= 0 ? messages[activePartialMsgIdx] : null
-  // Single-surface invariant for active assistant partials:
-  // - if the live stream is at least as fresh as the saved DB partial, hide the
-  //   DB row and render StreamingMessage; final promotion replaces that row.
-  // - if the DB partial is richer than a stale cached stream snapshot (e.g.
-  //   stray "I" after returning to chat), keep the DB row and suppress the
-  //   stale stream until catch-up catches up.
-  // - if both surfaces clearly belong to the same active answer but tool /
-  //   thinking metadata is only partially replayed, still choose ONE surface.
-  //   Rendering both was the transient "duplicated agent output" bug: reopening
-  //   the chat fixed it because the durable transcript had only one copy.
+  // Select DATA, never a component tree. A captured bridge is authoritative;
+  // without one, the trailing assistant is folded into the active row only
+  // when chooseActiveAssistantSurface establishes that it mirrors this stream.
+  // Unrelated prior assistant history therefore remains untouched.
   const activeAssistantSurface = chooseActiveAssistantSurface(activePartialMsg, streamItems)
-  const liveMirrorMsgIdx = activeAssistantSurface.hideMessage ? activePartialMsgIdx : -1
-  const suppressStreamingSurface = !!(activePartialMsg && activeAssistantSurface.suppressStream)
-  const showStreamingSurface = turnActive && streamItems.length > 0 && !suppressStreamingSurface
+  const hasLiveAssistantPayload = turnActive && streamItems.length > 0
+  const activeMirrorMsgIdx = chooseActiveAssistantMirrorIndex({
+    bridgeMsgIdx,
+    trailingAssistantPartialIdx,
+    hasLivePayload: hasLiveAssistantPayload,
+    surface: activeAssistantSurface,
+  })
+  const activeMirrorMsg = activeMirrorMsgIdx >= 0 ? messages[activeMirrorMsgIdx] : null
+  const useDbActivePayload = !!(
+    activeMirrorMsg
+    && (!hasLiveAssistantPayload || activeAssistantSurface.suppressStream)
+  )
+  const activeAssistantMsg = useDbActivePayload
+    ? activeMirrorMsg
+    : (hasLiveAssistantPayload
+        ? {
+            ...(activeMirrorMsg || {}),
+            role: 'assistant',
+            // Live rendering keeps running tool state and thinking clock
+            // anchors; final promotion uses the converter's default finalize
+            // mode and still seals running tools as done.
+            ...streamItemsToAssistantPayload(streamItems, { finalize: false }),
+          }
+        : null)
+  const showActiveAssistantSurface = !!activeAssistantMsg
+  const activeAssistantIsStreaming = !!(activeAssistantMsg && !useDbActivePayload)
 
   // ── Sticky "needs your answer" affordance ──────────────────────────
   // A pending AskUserQuestion freezes the turn until the user answers,
@@ -2681,7 +2704,7 @@ export default function ChatView({
   // tail-question invariant on the last visible assistant message (the
   // same rule MsgContent's blockAnswerable enforces; recovery preserves
   // that tail question even when the original process was interrupted).
-  const pendingQuestionInStream = showStreamingSurface
+  const pendingQuestionInStream = activeAssistantIsStreaming
     && streamItems.some(it => it.type === 'question' && !it.answers)
   const pendingQuestionInMessages = (() => {
     for (let i = messages.length - 1; i >= 0; i--) {
@@ -2729,7 +2752,7 @@ export default function ChatView({
     [...(scrollRef.current?.querySelectorAll('.qcard:not(.qcard--answered)') ?? [])].pop()
   const pendingCardOffscreen = useOffscreenNudge(
     scrollRef, hasPendingQuestion, findPendingQuestionCard,
-    [showStreamingSurface, messages],
+    [showActiveAssistantSurface, messages],
   )
 
   // The resume card: only the tail resumable note renders `.chat__resume`
@@ -2739,16 +2762,14 @@ export default function ChatView({
     [...(scrollRef.current?.querySelectorAll('.chat__resume') ?? [])].pop()
   const resumeCardOffscreen = useOffscreenNudge(
     scrollRef, hasPendingResume, findResumeCard,
-    [showStreamingSurface, messages],
+    [showActiveAssistantSurface, messages],
   )
 
-  // The streaming <li> carries a stable data-key so the scroll state machine
-  // can anchor inside an in-flight answer. Without this, returning to a
-  // streaming chat while scrolled into the live bubble had no anchorable row,
-  // so reconnect/catch-up could fall back to bottom-follow behavior. In the
-  // BRIDGE case (we kept a DB partial on mount and the streaming <li> is the
-  // visual replacement for that suppressed message), use the partial's key so
-  // an existing ANCHOR_AT still resolves through the catch-up window.
+  // The ONE active <li> carries this data-key for both DB and live payloads.
+  // ANCHOR_AT resolves `[data-key]`, so source selection must never change it.
+  // The first committed source owns the key: a DB-first bridge seeds the
+  // partial's durable key, while a live-first answer keeps its synthetic key
+  // even if a related DB partial arrives later.
   //
   // Fast-forward can insert a user row AFTER the mounted partial while the
   // stream remains live. Therefore bridge identity is ts-based across the
@@ -2756,13 +2777,29 @@ export default function ChatView({
   // bridge), the previous assistant is rendered alongside the streaming
   // <li> (different turns), so the streaming <li> gets its own synthetic key
   // rather than reusing a previous assistant row's key.
-  const streamingDataKey = (() => {
-    const bridged = liveMirrorMsgIdx >= 0 ? messages[liveMirrorMsgIdx] : null
-    if (!bridged || bridged.role !== 'assistant' || bridged.hidden) {
-      return `streaming-${chatId}`
+  const streamingDataKey = chooseActiveAssistantDataKey({
+    latched: activeAssistantDataKeyRef.current,
+    mirroredMsg: activeMirrorMsg,
+    mirrorIndex: activeMirrorMsgIdx,
+    hasLivePayload: hasLiveAssistantPayload,
+    chatId,
+  })
+  useLayoutEffect(() => {
+    if (!turnActive) {
+      activeAssistantDataKeyRef.current = null
+      return
     }
-    return bridged.id || `${bridged.role}-${bridged.ts ?? bridgeMsgIdx}`
-  })()
+    if (showActiveAssistantSurface
+        && activeAssistantDataKeyRef.current?.key !== streamingDataKey) {
+      activeAssistantDataKeyRef.current = {
+        key: streamingDataKey,
+        mirrorKey: activeMirrorMsg
+          ? (activeMirrorMsg.id
+              || `${activeMirrorMsg.role}-${activeMirrorMsg.ts ?? activeMirrorMsgIdx}`)
+          : null,
+      }
+    }
+  }, [turnActive, showActiveAssistantSurface, streamingDataKey, activeMirrorMsg, activeMirrorMsgIdx])
 
   // Polite aria-live status: announced once per state transition, not per
   // token. Visually hidden via the sr-only utility in ChatView.css.
@@ -2918,17 +2955,12 @@ export default function ChatView({
             if (msg.hidden) return null
             const isLastMsg = i === messages.length - 1
               || messages.slice(i + 1).every(m => m.hidden)
-            // Suppress the last assistant message ONLY when this is
-            // the BRIDGE case (we kept a DB partial on mount and the
-            // streaming <li> is about to render the same in-flight
-            // turn). For normal multi-turn flow, the existing
-            // assistant message and the streaming <li> represent
-            // DIFFERENT turns and must BOTH render — otherwise a
-            // user's answered-question card would hide whenever the
-            // next turn streams.
-            if (i === liveMirrorMsgIdx
+            // The mirrored DB row is rendered below by the SAME active
+            // MsgContent instance that consumes live payloads. Suppress only
+            // that row; unrelated assistant history remains in this map.
+            if (i === activeMirrorMsgIdx
                 && msg.role === 'assistant'
-                && showStreamingSurface) {
+                && showActiveAssistantSurface) {
               return null
             }
             // A question is answerable while the runner is parked on it,
@@ -3000,15 +3032,20 @@ export default function ChatView({
             </li>
           )})}
 
-          {showStreamingSurface && (
+          {showActiveAssistantSurface && (
             <StreamingMessage
-              streamItems={streamItems}
+              key={streamingDataKey}
+              msg={activeAssistantMsg}
               dataKey={streamingDataKey}
+              chatId={chatId}
               onAnswer={doSendSilent}
+              onResume={activeAssistantIsStreaming ? undefined : doSend}
+              liveQuestionId={liveQuestionId}
+              isStreaming={activeAssistantIsStreaming}
             />
           )}
 
-          {turnActive && streamItems.length === 0 && !loading && (
+          {turnActive && streamItems.length === 0 && !loading && !showActiveAssistantSurface && (
             <li className="chat__msg chat__msg--assistant">
               <div className="chat__thinking"><span /><span /><span /></div>
             </li>

--- a/frontend/src/components/ChatView/ErrorCard.jsx
+++ b/frontend/src/components/ChatView/ErrorCard.jsx
@@ -1,13 +1,11 @@
 import { StandardMarkdown } from './markdown/BlockRenderer.jsx'
 import { formatResetTime } from './resetTime.js'
 
-// The single renderer for the error/pause/park card family, shared by BOTH
-// surfaces that draw an error block: MsgContent (persisted transcript) and
-// StreamingMessage (live stream + SSE catch-up). One renderer is the
-// invariant — when the classification lived only in MsgContent, the live
-// surface hardcoded the danger-red "Error" card and a benign pause flashed
-// red until promotion. Any future field that changes how the card reads must
-// land here, not in one surface.
+// The single renderer for the error/pause/park card family. MsgContent consumes
+// both persisted blocks and the converted live stream, so source selection
+// cannot change this card's classification. When the live path had a separate
+// renderer, a benign pause flashed danger-red until promotion. Any future field
+// that changes how the card reads must land here.
 //
 // Classification, all from the single `pause` descriptor: a provider-limit
 // park carries `pause.resets_at` and reads "Rate limit" — the honest, specific

--- a/frontend/src/components/ChatView/MsgContent.jsx
+++ b/frontend/src/components/ChatView/MsgContent.jsx
@@ -1,5 +1,5 @@
-import { memo } from 'react'
-import { StandardMarkdown } from './markdown/BlockRenderer.jsx'
+import { memo, useEffect, useState } from 'react'
+import { ProgressiveMarkdown, StandardMarkdown } from './markdown/BlockRenderer.jsx'
 import ToolBlock from './ToolBlock.jsx'
 import ToolActivityGroup from './ToolActivityGroup.jsx'
 import { groupToolRuns, coalesceThinkingEntries } from './groupBlocks.js'
@@ -7,9 +7,10 @@ import QuestionCard from './QuestionCard.jsx'
 import Attachments from './Attachments.jsx'
 import CompactionCard from './CompactionCard.jsx'
 import { questionKey } from './questionKey.js'
-import { suppressedQuestionToolIndices } from './streamReducers.js'
+import { suppressedQuestionToolIndices, thinkingElapsedMs } from './streamReducers.js'
 import { stripAugmentation } from './msgText.js'
 import ErrorCard from './ErrorCard.jsx'
+import { assistantBlockKey } from './streamPromotion.js'
 
 
 function thoughtSeconds(durationMs) {
@@ -22,6 +23,55 @@ function thoughtLine(durationMs) {
   const seconds = thoughtSeconds(durationMs)
   if (!seconds) return '> Thought'
   return `> Thought for ${seconds} ${seconds === 1 ? 'second' : 'seconds'}`
+}
+
+
+function formatSeconds(seconds) {
+  if (!Number.isFinite(seconds)) return null
+  return `${seconds} ${seconds === 1 ? 'second' : 'seconds'}`
+}
+
+
+function ActiveThinkingDisclosure({ block, isStreaming }) {
+  const [now, setNow] = useState(() => Date.now())
+
+  useEffect(() => {
+    if (!isStreaming) return undefined
+    const id = window.setInterval(() => setNow(Date.now()), 1000)
+    return () => window.clearInterval(id)
+  }, [isStreaming])
+
+  // Live items carry the runner-clock anchors used by thinkingElapsedMs.
+  // Persisted partials may only have duration_ms, so the shared renderer
+  // freezes at that durable value until live data becomes the selected source.
+  const elapsedMs = isStreaming ? thinkingElapsedMs(block, now) : block.duration_ms
+  const seconds = thoughtSeconds(elapsedMs)
+  const secondsText = formatSeconds(seconds)
+  const label = isStreaming
+    ? `> Thinking for ${secondsText || 'a moment'}`
+    : secondsText
+      ? `> Thought for ${secondsText}`
+      : '> Thought'
+
+  return (
+    <details className="chat__reasoning">
+      <summary className="chat__reasoning-summary">
+        <span className="chat__reasoning-line">
+          {label}
+          {isStreaming && (
+            <span className="chat__reasoning-ellipsis" aria-hidden="true">
+              <span />
+              <span />
+              <span />
+            </span>
+          )}
+        </span>
+      </summary>
+      <div className="chat__reasoning-body">
+        <StandardMarkdown text={block.content || ''} />
+      </div>
+    </details>
+  )
 }
 
 
@@ -55,6 +105,11 @@ function MsgContentInner({
   // fresh function reference every render and defeat it.
   isLastMsg,
   liveQuestionId,
+  // Active answers always use this renderer for both their DB partial and
+  // live SSE payload. isStreaming only enables the cursor, aria-live, and the
+  // active thinking timer; it never selects a different component tree.
+  isActiveAnswer = false,
+  isStreaming = false,
   // Set of questionKey strings currently live in streamItems. When
   // non-null, any question block whose key appears here is already
   // rendered by the streaming <li> and should be suppressed to prevent
@@ -94,9 +149,14 @@ function MsgContentInner({
           ? stripAugmentation(block.content) : block.content
         if (!text) return null
         return (
-          <div key={i} className={`chat__text chat__text--${msg.role}`}>
+          <div key={assistantBlockKey(block, i)} className={`chat__text chat__text--${msg.role}`}>
             {msg.role === 'assistant'
-              ? <StandardMarkdown text={text} />
+              ? (isActiveAnswer
+                  ? <ProgressiveMarkdown
+                      text={text}
+                      isStreaming={isStreaming && i === msg.blocks.length - 1}
+                    />
+                  : <StandardMarkdown text={text} />)
               : text}
           </div>
         )
@@ -111,7 +171,7 @@ function MsgContentInner({
         // delete+insert. `i` is the block's index = the group's first index, and
         // the group wrapper prefers the same tool's id, so the keys coincide.
         return (
-          <div key={block.tool_use_id ?? `t-${i}`} className="chat__tools">
+          <div key={assistantBlockKey(block, i)} className="chat__tools">
             {/* chatId + the block's tool_use_id let ToolBlock lazily fetch a
                 truncated large output on expand (GET
                 /tool-output/{tool_use_id}). */}
@@ -120,8 +180,17 @@ function MsgContentInner({
         )
       }
       if (block.type === 'thinking') {
+        if (isActiveAnswer) {
+          return (
+            <ActiveThinkingDisclosure
+              key={assistantBlockKey(block, i)}
+              block={block}
+              isStreaming={isStreaming && i === msg.blocks.length - 1}
+            />
+          )
+        }
         return (
-          <details key={i} className="chat__reasoning">
+          <details key={assistantBlockKey(block, i)} className="chat__reasoning">
             <summary className="chat__reasoning-summary">
               <span className="chat__reasoning-line">
                 {thoughtLine(block.duration_ms)}
@@ -151,7 +220,7 @@ function MsgContentInner({
           onQuestionAnswer && isTailBlock && isQuestionAnswerable?.(block)
         )
         return (
-          <div key={i}>
+          <div key={assistantBlockKey(block, i)}>
             <QuestionCard
               questions={block.questions || []}
               questionId={block.question_id}
@@ -172,8 +241,8 @@ function MsgContentInner({
         // vanished on chat return; that was the bug.
         //
         // The card body (label, park/pause classification, reset line) is
-        // ErrorCard — the SAME renderer StreamingMessage uses for the live
-        // stream, so the two surfaces cannot diverge. Only the Resume button
+        // ErrorCard — this SAME block renderer consumes the live payload too,
+        // so the two sources cannot diverge. Only the Resume button
         // lives here: a turn paused by a drain-gated restart (or interrupted
         // by a crash) persists a `resumable` note (backend reconcile marks
         // it), and only the TAIL note on the last message is resumable —
@@ -184,7 +253,7 @@ function MsgContentInner({
         const resumable = !!(block.resumable && isLastMsg && onResume)
         const parked = !!block.pause?.resets_at
         return (
-          <ErrorCard key={i} block={block}>
+          <ErrorCard key={assistantBlockKey(block, i)} block={block}>
             {resumable && (
               <button
                 type="button"
@@ -201,9 +270,8 @@ function MsgContentInner({
     }
 
     // Skip the AskUserQuestion tool twin, then fold runs of adjacent tool
-    // blocks into one Activity card. groupToolRuns runs on the SAME entries on
-    // the live path (StreamingMessage), so the transcript doesn't reshuffle
-    // when a streaming turn is promoted.
+    // blocks into one Activity card. Live items arrive here after conversion
+    // to the same block shape, so the transcript doesn't reshuffle on promote.
     const entries = msg.blocks
       .map((block, i) => ({ item: block, idx: i }))
       .filter(({ idx }) => !skipToolIdx.has(idx))
@@ -228,13 +296,13 @@ function MsgContentInner({
             // reconciles each block by identity within the group.
             return (
               <div
-                key={node.group[0].item.tool_use_id ?? `t-${node.group[0].idx}`}
+                key={assistantBlockKey(node.group[0].item, node.group[0].idx)}
                 className="chat__tools"
               >
                 <ToolActivityGroup tools={tools}>
                   {node.group.map(e => (
                     <ToolBlock
-                      key={e.item.tool_use_id ?? e.idx}
+                      key={assistantBlockKey(e.item, e.idx)}
                       t={e.item}
                       chatId={chatId}
                     />
@@ -256,9 +324,14 @@ function MsgContentInner({
     <>
       {msg.role === 'user' && <Attachments attachments={msg.attachments} chatId={chatId} />}
       {text ? (
-        <div className={`chat__text chat__text--${msg.role}`}>
+        <div
+          key={isActiveAnswer ? 0 : undefined}
+          className={`chat__text chat__text--${msg.role}`}
+        >
           {msg.role === 'assistant'
-            ? <StandardMarkdown text={text} />
+            ? (isActiveAnswer
+                ? <ProgressiveMarkdown text={text} isStreaming={isStreaming} />
+                : <StandardMarkdown text={text} />)
             : text}
         </div>
       ) : null}
@@ -282,6 +355,8 @@ export default memo(MsgContentInner, (prev, next) => {
     && prev.onResume === next.onResume
     && prev.isLastMsg === next.isLastMsg
     && prev.liveQuestionId === next.liveQuestionId
+    && prev.isActiveAnswer === next.isActiveAnswer
+    && prev.isStreaming === next.isStreaming
     // suppressedQuestionKeys is a Set (new reference each render) or null.
     // Compare by size + content when both are Sets; treat null vs Set as unequal.
     // This is intentionally conservative — a false inequality triggers a

--- a/frontend/src/components/ChatView/StreamingMessage.jsx
+++ b/frontend/src/components/ChatView/StreamingMessage.jsx
@@ -1,213 +1,38 @@
-import { useEffect, useState } from 'react'
-import { ProgressiveMarkdown, StandardMarkdown } from './markdown/BlockRenderer.jsx'
-import ToolBlock from './ToolBlock.jsx'
-import ToolActivityGroup from './ToolActivityGroup.jsx'
-import { groupToolRuns } from './groupBlocks.js'
-import { thinkingElapsedMs } from './streamReducers.js'
-import QuestionCard from './QuestionCard.jsx'
-import ErrorCard from './ErrorCard.jsx'
-
-
-function durationSeconds(durationMs) {
-  if (!Number.isFinite(durationMs)) return null
-  return Math.max(1, Math.round(durationMs / 1000))
-}
-
-
-function formatSeconds(seconds) {
-  if (!Number.isFinite(seconds)) return null
-  return `${seconds} ${seconds === 1 ? 'second' : 'seconds'}`
-}
-
-
-function ThinkingDisclosure({ item, isActive }) {
-  const [now, setNow] = useState(() => Date.now())
-
-  useEffect(() => {
-    if (!isActive) return undefined
-    const id = window.setInterval(() => setNow(Date.now()), 1000)
-    return () => window.clearInterval(id)
-  }, [isActive])
-
-  // Anchored to the runner's clock (duration_ms + tail since the last delta),
-  // NOT the client mount time — so navigating back to a still-thinking block
-  // shows its true elapsed instead of restarting at 1s. See thinkingElapsedMs.
-  const activeSeconds = durationSeconds(thinkingElapsedMs(item, now))
-  const frozenSeconds = durationSeconds(item.duration_ms)
-  const seconds = isActive ? (activeSeconds || 1) : frozenSeconds
-  const secondsText = formatSeconds(seconds)
-  const label = isActive
-    ? `> Thinking for ${secondsText || 'a moment'}`
-    : secondsText
-      ? `> Thought for ${secondsText}`
-      : '> Thought'
-
-  return (
-    <details className="chat__reasoning">
-      <summary className="chat__reasoning-summary">
-        <span className="chat__reasoning-line">
-          {label}
-          {isActive && (
-            <span className="chat__reasoning-ellipsis" aria-hidden="true">
-              <span />
-              <span />
-              <span />
-            </span>
-          )}
-        </span>
-      </summary>
-      <div className="chat__reasoning-body">
-        <StandardMarkdown text={item.content} />
-      </div>
-    </details>
-  )
-}
+import MsgContent from './MsgContent.jsx'
 
 
 /**
- * The single live `<li>` that renders the in-flight turn's
- * `streamItems` (text deltas, tool blocks, question cards, provider
- * errors) while the agent is streaming — i.e. the
- * `sending && streamItems.length > 0` branch of the message list.
+ * Stable row shell for the one active assistant answer.
  *
- * Relocated verbatim from ChatView's render. This is a pure leaf:
- * no refs, no effects, no scroll/spacer/queue logic. It exists only
- * to keep that vocabulary (the four block renderers) out of ChatView,
- * which no longer imports any of them.
- *
- * The `<li>` MUST keep `className="chat__msg chat__msg--assistant"`
-   * and `data-key={dataKey}`: the scroll state machine
-   * (useScrollMode's applyMode) resolves ANCHOR_AT via
-   * `querySelector('.chat__msg[data-key]')`. `dataKey` is
-   * `streamingDataKey` from ChatView — the kept DB partial's key in the
-   * BRIDGE case, otherwise a synthetic `streaming-<chatId>` key. The
-   * synthetic key lets foreground reconnect preserve the reader's position
-   * inside a live streaming answer while catch-up fills content below.
- *
- * @param {object} props
- * @param {Array<object>} props.streamItems  the live stream items
- *   (latestItemsRef's render mirror): text/tool/question/error.
-   * @param {string|undefined} props.dataKey  ChatView's stable
-   *   `streamingDataKey`.
- * @param {(text: string, resolvedAnswers: object, questionId?: string) => void} props.onAnswer
- *   doSendSilent — submits an AskUserQuestion answer as a hidden
- *   user message. The card is clickable even mid-stream because the
- *   runner is paused on the AskUserQuestion future.
+ * The DB partial and the live SSE payload both flow through MsgContent. This
+ * wrapper never selects a renderer; it only owns the invariant DOM anchor the
+ * scroll state machine resolves through `[data-key]`.
  */
-export default function StreamingMessage({ streamItems, dataKey, onAnswer }) {
-  // Render a single stream item by type. `i` is the ORIGINAL index in
-  // streamItems, so the isLast/isActive checks below (which key off
-  // `streamItems.length - 1`) stay correct even after adjacent tool items are
-  // folded into a group — grouping never touches a trailing text/thinking item.
-  const renderItem = (item, i) => {
-    if (item.type === 'tool') {
-      // Key a lone tool by its real `tool_use_id` (lever 2a) so the block —
-      // the heaviest remount cost — survives a catch-up commit and the answer's
-      // source switch by identity. Fall back to `s-t-<firstIdx>` for a
-      // legacy/tokenless block: the SAME scheme the group wrapper below uses, so
-      // when a second adjacent tool arrives and this slot becomes a group the
-      // wrapper key is unchanged and React updates it in place instead of
-      // delete+insert. `i` is the item's original index = the group's first
-      // index, and the group wrapper prefers the same tool's id, so the keys
-      // coincide across the 1→2 transition either way.
-      return (
-        <div key={item.tool_use_id ?? `s-t-${i}`} className="chat__tools">
-          <ToolBlock t={item} />
-        </div>
-      )
-    }
-    if (item.type === 'question') {
-      // QuestionCard tracks its own `submitted` state and
-      // disables itself after the user answers. The agent
-      // is paused on the AskUserQuestion future, so the
-      // user MUST be able to click these chips even while
-      // the turn is otherwise "streaming". No external
-      // disabled gate.
-      //
-      // Pass item.answers as answeredMap so patchQuestionAnswers's
-      // optimistic update is visible immediately when the question
-      // is still in streamItems — without this, the card stays
-      // in the interactive state even after the user submitted.
-      return (
-        <div key={`s-${i}`}>
-          <QuestionCard
-            questions={item.questions}
-            questionId={item.question_id}
-            answeredMap={item.answers}
-            onAnswer={item.answers ? undefined : onAnswer}
-          />
-        </div>
-      )
-    }
-    if (item.type === 'thinking') {
-      // The agent's live reasoning, shown as a COLLAPSED, secondary
-      // disclosure so a long "thinking" stretch reads as a quiet
-      // timer (filling the silence) rather than a
-      // wall of raw chain-of-thought. The partner can expand it to
-      // peek; by default the answer stays the focus. While this is
-      // the last item the agent is still mid-thought, so the summary
-      // animates with dots; an earlier thinking block the agent has
-      // already moved past reads as a frozen "Thought for Ns" toggle.
-      const isActive = i === streamItems.length - 1
-      return (
-        <ThinkingDisclosure key={`s-${i}`} item={item} isActive={isActive} />
-      )
-    }
-    if (item.type === 'text') {
-      const isLast = i === streamItems.length - 1
-      return (
-        <div key={`s-${i}`} className="chat__text chat__text--assistant">
-          <ProgressiveMarkdown text={item.content} />
-          {isLast && <span className="chat__cursor" />}
-        </div>
-      )
-    }
-    if (item.type === 'error') {
-      // The SAME ErrorCard renderer MsgContent uses for persisted blocks, so
-      // a benign pause/park renders calm on the live stream and SSE catch-up
-      // too — a hardcoded red card here made a pause flash "Error" until
-      // promotion. No Resume button on the live surface: the button's
-      // tail-only gate is a persisted-transcript concept, and a terminal
-      // error promotes within the same breath.
-      return <ErrorCard key={`s-${i}`} block={item} />
-    }
-    return null
-  }
-
-  // Fold adjacent tool items into one Activity card — the SAME grouping
-  // MsgContent applies to the persisted blocks, so the live view and the
-  // promoted message look identical.
-  const nodes = groupToolRuns(streamItems.map((item, i) => ({ item, idx: i })))
-
+export default function StreamingMessage({
+  msg,
+  dataKey,
+  chatId,
+  onAnswer,
+  onResume,
+  liveQuestionId,
+  isStreaming,
+}) {
   return (
     <li
       className="chat__msg chat__msg--assistant"
       data-key={dataKey}
     >
-      {nodes.map(node => {
-        if (node.group) {
-          const tools = node.group.map(e => e.item)
-          // Prefer the first tool's `tool_use_id` (lever 2a); fall back to
-          // `s-t-<firstIdx>` — the SAME key a lone tool at that index uses (see
-          // renderItem), so the 1→2-tool transition updates this slot in place
-          // rather than swapping keys and forcing a delete+insert. Each grouped
-          // ToolBlock is keyed by its own id so a catch-up commit reconciles
-          // each block by identity within the group.
-          return (
-            <div
-              key={node.group[0].item.tool_use_id ?? `s-t-${node.group[0].idx}`}
-              className="chat__tools"
-            >
-              <ToolActivityGroup tools={tools}>
-                {node.group.map(e => (
-                  <ToolBlock key={e.item.tool_use_id ?? `s-${e.idx}`} t={e.item} />
-                ))}
-              </ToolActivityGroup>
-            </div>
-          )
-        }
-        return renderItem(node.single.item, node.single.idx)
-      })}
+      <MsgContent
+        msg={msg}
+        chatId={chatId}
+        onQuestionAnswer={onAnswer}
+        onResume={onResume}
+        isLastMsg
+        liveQuestionId={liveQuestionId}
+        isActiveAnswer
+        isStreaming={isStreaming}
+        suppressedQuestionKeys={null}
+      />
     </li>
   )
 }

--- a/frontend/src/components/ChatView/__tests__/parkedCard.test.js
+++ b/frontend/src/components/ChatView/__tests__/parkedCard.test.js
@@ -6,9 +6,8 @@ import assert from 'node:assert/strict'
 // block carrying a single `pause` descriptor ({kind, resets_at?}), which
 // renders as a live "Rate limit — resets at … · Resume now" card. That one
 // field must survive all three client seams: the live stream reducer,
-// promote-to-block, and the shared ErrorCard renderer (consumed by BOTH
-// MsgContent and StreamingMessage, so the persisted and live surfaces cannot
-// diverge).
+// promote-to-block, and the shared ErrorCard renderer. MsgContent owns the
+// block tree for BOTH persisted and live data, so those sources cannot diverge.
 const msgContent = readFileSync(new URL('../MsgContent.jsx', import.meta.url), 'utf8')
 const streamingMessage = readFileSync(new URL('../StreamingMessage.jsx', import.meta.url), 'utf8')
 const errorCard = readFileSync(new URL('../ErrorCard.jsx', import.meta.url), 'utf8')
@@ -28,13 +27,16 @@ test('ErrorCard renders a parked card for a block whose pause has a reset time',
     'the tail resume button reads "Resume now" on a parked card')
 })
 
-test('both surfaces consume the shared ErrorCard — no private error render', () => {
+test('the one block renderer owns ErrorCard for both active sources', () => {
   // The live/catch-up surface once hardcoded a red "Error" card, so a benign
-  // pause flashed red until promotion. One renderer is the invariant.
+  // pause flashed red until promotion. StreamingMessage is now only the stable
+  // <li> shell and delegates all blocks to MsgContent.
   assert.match(msgContent, /import ErrorCard from '\.\/ErrorCard\.jsx'/,
     'MsgContent must consume the shared ErrorCard')
-  assert.match(streamingMessage, /import ErrorCard from '\.\/ErrorCard\.jsx'/,
-    'StreamingMessage must consume the shared ErrorCard')
+  assert.match(streamingMessage, /import MsgContent from '\.\/MsgContent\.jsx'/,
+    'the active row shell must delegate both DB and live payloads to MsgContent')
+  assert.doesNotMatch(streamingMessage, /import (ErrorCard|ToolBlock|QuestionCard)/,
+    'the active row shell must not grow a second block renderer')
   assert.doesNotMatch(streamingMessage, /chat__error-label/,
     'the live surface must not hand-roll its own error card body')
   assert.doesNotMatch(msgContent, /chat__error-label/,

--- a/frontend/src/components/ChatView/__tests__/streamPromotion.test.js
+++ b/frontend/src/components/ChatView/__tests__/streamPromotion.test.js
@@ -14,6 +14,9 @@ import {
   findTrailingAssistantPartialIndex,
   streamItemsHaveRenderableContent,
   streamItemToBlock,
+  assistantBlockKey,
+  chooseActiveAssistantMirrorIndex,
+  chooseActiveAssistantDataKey,
 } from '../streamPromotion.js'
 
 // Lever 2a: the live tool item carries tool_use_id, and streamItemToBlock
@@ -48,6 +51,41 @@ test('streamItemsToAssistantPayload preserves text boundaries in legacy content'
   assert.equal(payload.content, 'first\n\nsecond')
   assert.deepEqual(payload.blocks.map(b => b.type), ['text', 'tool', 'text'])
   assert.equal(payload.blocks[1].status, 'done')
+})
+
+test('source switch preserves the active answer block key namespace', () => {
+  const dbBlocks = [
+    { type: 'text', content: 'Inspecting' },
+    { type: 'tool', tool: 'Bash', status: 'running', tool_use_id: 'toolu_same' },
+    { type: 'text', content: 'Done' },
+    { type: 'tool', tool: 'Read', status: 'running' },
+  ]
+  const liveBlocks = streamItemsToAssistantPayload(dbBlocks, { finalize: false }).blocks
+
+  assert.deepEqual(
+    liveBlocks.map(assistantBlockKey),
+    dbBlocks.map(assistantBlockKey),
+    'DB partial → live SSE must retain tool ids and ordinal text/tool fallbacks so React reuses every block slot',
+  )
+  assert.deepEqual(
+    liveBlocks.map(assistantBlockKey),
+    [0, 'toolu_same', 2, 't-3'],
+    'tools use tool_use_id ?? ordinal while text stays ordinal',
+  )
+})
+
+test('live payload conversion preserves running tools and thinking clock anchors', () => {
+  const payload = streamItemsToAssistantPayload([
+    { type: 'tool', tool: 'Bash', status: 'running', tool_use_id: 'toolu_live' },
+    {
+      type: 'thinking', content: 'checking', duration_ms: 1200,
+      startedAt: 100, lastAt: 200,
+    },
+  ], { finalize: false })
+
+  assert.equal(payload.blocks[0].status, 'running', 'the unified live renderer keeps its spinner')
+  assert.equal(payload.blocks[1].startedAt, 100)
+  assert.equal(payload.blocks[1].lastAt, 200, 'the unified live renderer keeps its timer anchor')
 })
 
 test('promoteAssistantStream appends when there is no bridge partial', () => {
@@ -219,6 +257,76 @@ test('chooseActiveAssistantSurface does not collapse unrelated assistant and str
     hideMessage: false,
     suppressStream: false,
   })
+})
+
+test('active trailing DB row stays mirrored across an empty to related-live source switch', () => {
+  const emptyStreamIdx = chooseActiveAssistantMirrorIndex({
+    bridgeMsgIdx: -1,
+    trailingAssistantPartialIdx: 4,
+    hasLivePayload: false,
+    surface: { hideMessage: false, suppressStream: false },
+  })
+  const liveStreamIdx = chooseActiveAssistantMirrorIndex({
+    bridgeMsgIdx: -1,
+    trailingAssistantPartialIdx: 4,
+    hasLivePayload: true,
+    surface: { hideMessage: true, suppressStream: false },
+  })
+
+  assert.equal(emptyStreamIdx, 4)
+  assert.equal(liveStreamIdx, 4,
+    'the same row index keeps the active shell mounted when reconnect/question catch-up resumes')
+  assert.equal(chooseActiveAssistantMirrorIndex({
+    bridgeMsgIdx: -1,
+    trailingAssistantPartialIdx: 4,
+    hasLivePayload: true,
+    surface: { hideMessage: false, suppressStream: false },
+  }), -1, 'an unrelated prior assistant remains ordinary history')
+})
+
+test('active row data-key is latched for both live-first and DB-first source switches', () => {
+  const synthetic = chooseActiveAssistantDataKey({
+    latched: null,
+    mirroredMsg: null,
+    mirrorIndex: -1,
+    hasLivePayload: true,
+    chatId: 'chat-1',
+  })
+  assert.equal(synthetic, 'streaming-chat-1')
+  assert.equal(chooseActiveAssistantDataKey({
+    latched: { key: synthetic, mirrorKey: null },
+    mirroredMsg: { role: 'assistant', ts: 9 },
+    mirrorIndex: 2,
+    hasLivePayload: true,
+    chatId: 'chat-1',
+  }), synthetic, 'live-first DB adoption must keep the mounted synthetic anchor')
+
+  const dbFirst = chooseActiveAssistantDataKey({
+    latched: null,
+    mirroredMsg: { role: 'assistant', ts: 9 },
+    mirrorIndex: 2,
+    hasLivePayload: false,
+    chatId: 'chat-1',
+  })
+  assert.equal(dbFirst, 'assistant-9')
+  assert.equal(chooseActiveAssistantDataKey({
+    latched: { key: dbFirst, mirrorKey: dbFirst },
+    mirroredMsg: { role: 'assistant', ts: 9 },
+    mirrorIndex: 2,
+    hasLivePayload: true,
+    chatId: 'chat-1',
+  }), dbFirst, 'DB-first bridge must keep its durable anchor when live data wins')
+
+  const released = chooseActiveAssistantDataKey({
+    latched: { key: dbFirst, mirrorKey: dbFirst },
+    mirroredMsg: null,
+    mirrorIndex: -1,
+    hasLivePayload: true,
+    chatId: 'chat-1',
+  })
+  assert.equal(released, synthetic)
+  assert.notEqual(released, dbFirst,
+    'an unrelated live answer must not duplicate the restored history row data-key')
 })
 
 test('text prefix does not hide a persisted tool block when stream lacks it', () => {

--- a/frontend/src/components/ChatView/__tests__/streamingRobustness.test.js
+++ b/frontend/src/components/ChatView/__tests__/streamingRobustness.test.js
@@ -10,6 +10,31 @@
  */
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const chatViewSource = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8')
+const msgContentSource = readFileSync(new URL('../MsgContent.jsx', import.meta.url), 'utf8')
+const streamingMessageSource = readFileSync(new URL('../StreamingMessage.jsx', import.meta.url), 'utf8')
+const blockRendererSource = readFileSync(new URL('../markdown/BlockRenderer.jsx', import.meta.url), 'utf8')
+
+test('active DB and live sources share one row shell and one block renderer', () => {
+  assert.match(streamingMessageSource, /<MsgContent[\s\S]*msg=\{msg\}/,
+    'the stable active <li> must always delegate its selected payload to MsgContent')
+  assert.doesNotMatch(streamingMessageSource, /ToolBlock|QuestionCard|ErrorCard|ProgressiveMarkdown/,
+    'StreamingMessage must not mount a competing assistant block tree')
+  assert.match(chatViewSource, /streamItemsToAssistantPayload\(streamItems, \{ finalize: false \}\)/,
+    'the live source must feed the same DB-shaped payload consumed by MsgContent')
+  assert.match(chatViewSource, /key=\{streamingDataKey\}[\s\S]*dataKey=\{streamingDataKey\}/,
+    'the active row key and scroll-anchor data-key must remain stable across source selection')
+})
+
+test('streaming deltas are flags on the shared active markdown tree', () => {
+  assert.match(msgContentSource, /<ProgressiveMarkdown[\s\S]*isStreaming=\{isStreaming/,
+    'active DB and live text must keep ProgressiveMarkdown mounted')
+  assert.match(blockRendererSource, /data-is-streaming=\{isStreaming \? 'true' : undefined\}/)
+  assert.match(blockRendererSource, /\{isStreaming && <span className="chat__cursor" \/>\}/,
+    'cursor insertion must toggle behind isStreaming instead of selecting another renderer')
+})
 
 // ---------------------------------------------------------------------------
 // Fix 1: lastGoodItemsRef preservation across reconnect resets

--- a/frontend/src/components/ChatView/groupBlocks.js
+++ b/frontend/src/components/ChatView/groupBlocks.js
@@ -4,10 +4,9 @@ import { toolActivityLabel } from './toolActivityLabel.js'
 // Fold runs of adjacent tool entries into one activity node, including a lone
 // tool. This gives single-tool and multi-tool runs the same collapsed header and
 // lets a live single tool become a multi-tool run without swapping visual
-// primitives. This runs on BOTH render paths — MsgContent (persisted msg.blocks)
-// and StreamingMessage (live streamItems) — so the transcript looks the same
-// before and after a streaming turn is promoted. Keep them calling the same
-// function.
+// primitives. MsgContent applies this to both DB-shaped history blocks and the
+// converted live payload, so source selection cannot reshuffle the active
+// answer.
 //
 // Rules:
 //   - any run of entries whose item.type === 'tool' becomes a group

--- a/frontend/src/components/ChatView/markdown/BlockRenderer.jsx
+++ b/frontend/src/components/ChatView/markdown/BlockRenderer.jsx
@@ -22,28 +22,33 @@ function tokenize(text) {
 
 
 /**
- * ProgressiveMarkdown — streaming mode.
- * Re-lexes on every update; only the last block re-renders
- * thanks to React.memo comparison on token.raw.
+ * ProgressiveMarkdown — active-answer mode.
+ * Re-lexes on every update; only changed blocks re-render thanks to
+ * React.memo comparison on token.raw. The same component stays mounted when
+ * the active answer switches from its DB partial to live SSE data; streaming
+ * affordances are props, not a second markdown subtree.
  */
-export function ProgressiveMarkdown({ text }) {
+export function ProgressiveMarkdown({ text, isStreaming = false }) {
   const tokens = useMemo(() => tokenize(text), [text])
 
   return (
-    <div
-      className="progressive-markdown md-blocks"
-      data-is-streaming="true"
-      aria-live="polite"
-      aria-atomic="false"
-    >
-      {tokens.map((token, i) => {
-        if (token.type === 'blockKatex') {
-          return <MathBlock key={i} tex={token.text} />
-        }
-        if (token.type === 'space') return null
-        return <MemoBlock key={i} token={token} />
-      })}
-    </div>
+    <>
+      <div
+        className="progressive-markdown md-blocks"
+        data-is-streaming={isStreaming ? 'true' : undefined}
+        aria-live={isStreaming ? 'polite' : undefined}
+        aria-atomic={isStreaming ? 'false' : undefined}
+      >
+        {tokens.map((token, i) => {
+          if (token.type === 'blockKatex') {
+            return <MathBlock key={i} tex={token.text} />
+          }
+          if (token.type === 'space') return null
+          return <MemoBlock key={i} token={token} />
+        })}
+      </div>
+      {isStreaming && <span className="chat__cursor" />}
+    </>
   )
 }
 

--- a/frontend/src/components/ChatView/streamPromotion.js
+++ b/frontend/src/components/ChatView/streamPromotion.js
@@ -6,9 +6,13 @@
 
 import { questionKey } from './questionKey.js'
 
-export function streamItemToBlock(item) {
+export function streamItemToBlock(item, { finalize = true } = {}) {
   if (item.type === 'text') return { type: 'text', content: item.content }
   if (item.type === 'thinking') {
+    // The active renderer needs the runner-clock anchors for its live timer.
+    // Promotion deliberately strips those client-only fields and keeps only
+    // the durable duration.
+    if (!finalize) return { ...item }
     return {
       type: 'thinking',
       content: item.content,
@@ -37,8 +41,19 @@ export function streamItemToBlock(item) {
       ...(item.pause ? { pause: item.pause } : {}),
     }
   }
-  const status = item.status === 'running' ? 'done' : item.status
+  const status = finalize && item.status === 'running' ? 'done' : item.status
   return { type: 'tool', ...item, status }
+}
+
+
+// One key namespace for the active answer, regardless of whether its blocks
+// came from the DB partial or streamItemsToAssistantPayload. Tools use their
+// protocol identity when available; every legacy/tokenless block falls back to
+// its ordinal. Keeping this helper source-agnostic is what lets React preserve
+// ToolBlock state and markdown/image DOM across the source switch.
+export function assistantBlockKey(block, index) {
+  if (block?.type === 'tool') return block.tool_use_id ?? `t-${index}`
+  return index
 }
 
 
@@ -237,6 +252,56 @@ export function chooseActiveAssistantSurface(msg, items) {
   return { hideMessage: false, suppressStream: true }
 }
 
+
+// Decide whether an existing DB assistant row belongs in the stable active
+// shell. A captured bridge always does. After that gate retires, a trailing
+// assistant stays in the shell while the active turn has no live items, then
+// remains there only if surface selection relates it to the returning stream.
+// This closes the empty→nonempty reconnect/question gap without swallowing an
+// unrelated completed assistant from the previous turn.
+export function chooseActiveAssistantMirrorIndex({
+  bridgeMsgIdx,
+  trailingAssistantPartialIdx,
+  hasLivePayload,
+  surface,
+}) {
+  if (bridgeMsgIdx >= 0) return bridgeMsgIdx
+  if (trailingAssistantPartialIdx < 0) return -1
+  if (!hasLivePayload) return trailingAssistantPartialIdx
+  return surface?.hideMessage || surface?.suppressStream
+    ? trailingAssistantPartialIdx
+    : -1
+}
+
+
+// The first mounted active row owns the scroll-anchor key for its lifetime.
+// DB-first bridge answers seed from the durable row; live-first answers seed a
+// synthetic turn key and must not adopt a later DB partial's key, because both
+// React reconciliation and ANCHOR_AT resolve through this identity.
+export function chooseActiveAssistantDataKey({
+  latched,
+  mirroredMsg,
+  mirrorIndex,
+  hasLivePayload,
+  chatId,
+}) {
+  const mirroredKey = mirroredMsg?.role === 'assistant' && !mirroredMsg.hidden
+    ? (mirroredMsg.id || `${mirroredMsg.role}-${mirroredMsg.ts ?? mirrorIndex}`)
+    : null
+  if (latched?.key) {
+    // A DB-seeded key is valid only while that row still mirrors the active
+    // answer. If surface selection releases it as unrelated, the restored
+    // history row owns the durable key and the live answer needs a distinct
+    // synthetic anchor. A live-first latch is intentionally retained when it
+    // later adopts a related DB mirror.
+    if (latched.mirrorKey && latched.mirrorKey !== mirroredKey) {
+      return mirroredKey || (hasLivePayload ? `streaming-${chatId}` : latched.key)
+    }
+    return latched.key
+  }
+  return mirroredKey || `streaming-${chatId}`
+}
+
 export function findTrailingAssistantPartialIndex(messages) {
   if (!Array.isArray(messages)) return -1
   for (let i = messages.length - 1; i >= 0; i--) {
@@ -248,8 +313,8 @@ export function findTrailingAssistantPartialIndex(messages) {
 }
 
 
-export function streamItemsToAssistantPayload(items) {
-  const blocks = items.map(streamItemToBlock)
+export function streamItemsToAssistantPayload(items, options) {
+  const blocks = items.map(item => streamItemToBlock(item, options))
   const content = items
     .filter(i => i.type === 'text')
     .map(i => i.content)


### PR DESCRIPTION
The final lever of return-without-redraw. The active assistant answer was rendered by two different component subtrees — MsgContent for the DB partial, StreamingMessage for the live SSE stream — with disjoint key namespaces, so the catch-up commit tore down and rebuilt the entire answer (every ToolBlock, image, KaTeX node) when returning mid-stream. This unifies both sources onto one MsgContent tree (StreamingMessage shrinks to a thin row shell); isStreaming only toggles the cursor/aria-live/active-thinking-timer, never the tree. A latching data-key ref makes the first committed source own the scroll anchor so ANCHOR_AT resolution never breaks across a switch; bridge promotion stays replace-by-ts; tool/text key namespaces stay identical (matching lever 2a); exactly one active surface mounts (constraint 9); history rows untouched. With 2a (id-keyed blocks) + 2c (reconcile-in-place) already landed, a mid-stream return is now an in-place prop update — no remounts, expanded tool state and decoded images survive.

Implemented by Codex, reviewed + verified by the main session. Frontend-only, +450/−311 across 10 ChatView files. Units 791+44/0; build clean. Real-container e2e (fresh volume, byte-verified bundle): 61/0 across stream-reconnect (the direct no-redraw proof), steer-queued, spacer, second-send-pin, pin-clamp-settle, chat-redesign.

Completes contract-v2 item 2. Only 2b (synthetic text/thinking ids) remains as optional future polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)