### PR TITLE
Honest update-check when a probe fails (feature 20)

### DIFF
--- a/frontend/src/components/SettingsView/SettingsView.jsx
+++ b/frontend/src/components/SettingsView/SettingsView.jsx
@@ -894,11 +894,21 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
         if (reg) await reg.update()
       }
       await versionQueries.current.invalidate(queryClient)
-      await versionQuery.refetch()
+      // refetch resolves with an error result rather than rejecting, so a
+      // failed version probe must be re-thrown for allSettled to see it —
+      // same honesty rule as the platform arm below (feature 20).
+      const versionResult = await versionQuery.refetch()
+      if (versionResult.isError) {
+        throw versionResult.error ?? new Error('version check failed')
+      }
     })()
     const platformP = (async () => {
       const res = await api.platform.check()
-      if (res.ok) setPlatform(await res.json())
+      // An HTTP failure must REJECT, not resolve: allSettled treats a
+      // resolved probe as success, so a swallowed !ok let updateCheckOutcome
+      // report "No updates found" on a real 500 (feature 20).
+      if (!res.ok) throw new Error(`platform check failed: ${res.status}`)
+      setPlatform(await res.json())
     })()
     const results = await Promise.allSettled([frontendP, platformP])
     setUpdatePhase(updateCheckOutcome(results))

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/hmzmrzx/projects/mobius/node_modules


### PR DESCRIPTION
Settings 'Check for updates' fans out a platform git-fetch and a frontend version/SW probe via Promise.allSettled (which never rejects), then maps the settled results through updateCheckOutcome — 'error' only if an arm rejected. But both arms silently swallowed HTTP failures: the platform arm ignored !res.ok and the frontend arm let TanStack refetch() resolve with an error result. So a real 500 read as 'No updates found'. Both arms now re-throw on failure; the existing rejected→'error' path then shows 'Couldn't check for updates' (the button doubles as retry). Two-line-per-arm change, why-comments state the invariant. Frontend units 785+44/0.

Owner-requested this session (was permission-blocked earlier; now green-lit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)