### PR TITLE
Add installed system-app prompt composition

### DIFF
--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -721,6 +721,28 @@ def is_draining() -> bool:
   return draining
 
 
+_SYSTEM_APP_PROMPT_SUFFIX_CACHE: str | None = None
+
+
+def _with_system_app_prompts(base: str) -> str:
+  """Append the restart-bound live system-app fragments to any chat prompt."""
+  global _SYSTEM_APP_PROMPT_SUFFIX_CACHE
+  if _SYSTEM_APP_PROMPT_SUFFIX_CACHE is None:
+    try:
+      from app.database import SessionLocal
+      from app.system_prompts import compose_system_prompt
+      with SessionLocal() as db:
+        _SYSTEM_APP_PROMPT_SUFFIX_CACHE = compose_system_prompt("", db)
+    except Exception:
+      _get_logger().warning(
+        "could not compose installed-app system prompts", exc_info=True
+      )
+      _SYSTEM_APP_PROMPT_SUFFIX_CACHE = ""
+  if not _SYSTEM_APP_PROMPT_SUFFIX_CACHE:
+    return base
+  return base.rstrip() + _SYSTEM_APP_PROMPT_SUFFIX_CACHE
+
+
 def _read_skill_text() -> str:
   """Returns the agent skill (system-prompt) text, cached after first
   read. Used by SDK runners as the `system_prompt` option.
@@ -739,8 +761,10 @@ def _read_skill_text() -> str:
   if skill_path is not None:
     try:
       text = skill_path.read_text(encoding="utf-8")
-      _SKILL_TEXT_CACHE = text
-      return text
+      # The fragment cache is shared with custom-prompt chats below, so Memory
+      # remains available in every chat while activation stays restart-bound.
+      _SKILL_TEXT_CACHE = _with_system_app_prompts(text)
+      return _SKILL_TEXT_CACHE
     except (OSError, FileNotFoundError):
       pass
   # No skill file found — cache the empty fallback so subsequent calls
@@ -4120,12 +4144,15 @@ async def _run_chat_impl(
         )
         db.rollback()
 
-  # A turn runs the deployed skill plus the chat's picker-chosen
-  # provider/model/effort. A per-chat custom system prompt (from
-  # chat_overrides) still wins when present; otherwise the deployed
-  # skill text is the system prompt.
+  # A per-chat custom prompt replaces the base constitution, but installed
+  # system-app contributions still append to it: system apps apply to every
+  # chat, including embedded/custom-prompt app chats.
   runner_agent_settings = agent_settings
-  system_prompt = _custom_system_prompt(chat_overrides) or _read_skill_text()
+  custom_prompt = _custom_system_prompt(chat_overrides)
+  system_prompt = (
+    _with_system_app_prompts(custom_prompt) if custom_prompt
+    else _read_skill_text()
+  )
 
   # Pre-flight: check that provider credentials exist before invoking
   # the SDK runner. Without this, the SDK fails with a cryptic error.

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -347,6 +347,14 @@ def run_migrations(eng) -> None:
         "ALTER TABLE apps ADD COLUMN offline_contract JSON NULL"
       ))
       conn.commit()
+  if "system_prompt_file" not in apps_cols:
+    # Installed system-app prompt contribution. Existing apps remain inert
+    # until updated from a manifest that explicitly declares the file.
+    with eng.connect() as conn:
+      conn.execute(text(
+        "ALTER TABLE apps ADD COLUMN system_prompt_file VARCHAR(255) NULL"
+      ))
+      conn.commit()
   if "chats" in tables:
     chats_cols = {c["name"] for c in inspector.get_columns("chats")}
     _add = []

--- a/backend/app/install.py
+++ b/backend/app/install.py
@@ -171,6 +171,10 @@ _SOURCE_FILES_MANAGED_EXACT = frozenset((
 _SKILLS_COUNT_MAX = 5
 _SKILL_MAX_BYTES = 256 * 1024
 
+# A system-prompt fragment is more privileged than a skill because it is read
+# every turn. It uses the same root-level markdown and byte-size contract.
+_SYSTEM_PROMPT_MAX_BYTES = 256 * 1024
+
 # Installer-owned ownership/provenance sidecar inside the skills dir. A
 # dotfile that is not `*.md`, so the skill loaders (the app-skills catalog
 # app, the SDK skill-load observers) never list or read it.
@@ -415,6 +419,35 @@ def _validate_manifest(m: dict) -> None:
           "bytes from the installed source tree, so a skill that is not a "
           "source file has nothing to install.",
         )
+  # A manifest may contribute one mandatory prompt fragment while the app is
+  # installed. The file stays in the app source tree; live-row DB composition
+  # is the activation/teardown mechanism, so uninstall needs no file deletion.
+  system_prompt = m.get("system_prompt")
+  if system_prompt is not None:
+    if (
+      not isinstance(system_prompt, str)
+      or not system_prompt.endswith(".md")
+      or system_prompt == ".md"
+      or "/" in system_prompt
+      or "\\" in system_prompt
+      or ".." in system_prompt
+      or system_prompt.startswith(".")
+    ):
+      raise HTTPException(
+        400,
+        "Manifest `system_prompt` must be a bare `<name>.md` filename — "
+        "no directories, traversal, or dotfiles.",
+      )
+    root_sources = {
+      rel for rel in (source_files or [])
+      if isinstance(rel, str) and "/" not in rel
+    }
+    if system_prompt not in root_sources:
+      raise HTTPException(
+        400,
+        "Manifest `system_prompt` must also be listed in `source_files` as "
+        "a root-level file.",
+      )
   sched = m.get("schedule")
   if sched is not None:
     if not isinstance(sched, dict):
@@ -2045,6 +2078,12 @@ async def install_from_manifest(
     "index.jsx": entry_bytes,
     **source_files_fetched,
   }
+  prompt_rel = manifest.get("system_prompt")
+  if prompt_rel and len(source_tree.get(prompt_rel, b"")) > _SYSTEM_PROMPT_MAX_BYTES:
+    raise HTTPException(
+      400,
+      f"Manifest system_prompt exceeds {_SYSTEM_PROMPT_MAX_BYTES} bytes.",
+    )
   if job_name and bundled_job is not None:
     source_tree[job_name] = bundled_job
   repo_ref = (
@@ -2266,6 +2305,7 @@ async def install_from_manifest(
         embeds_agent=bool(manifest.get("embeds_agent", False)),
         # P1-D: persist the offline contract block (None when not declared).
         offline_contract=manifest.get("offline") or None,
+        system_prompt_file=manifest.get("system_prompt") or None,
       )
       db.add(app)
       db.flush()  # assign app.id without committing yet
@@ -2636,6 +2676,7 @@ async def install_from_manifest(
           # P1-D: persist the offline contract block (replaces on update to match
           # the new manifest; None if the key is absent in the new manifest).
           app.offline_contract = manifest.get("offline") or None
+          app.system_prompt_file = manifest.get("system_prompt") or None
 
         # The compiled bundle is written OUT OF PLACE to a staging file and
         # promoted into the live bundle only AFTER the DB commit (commit_actions

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -387,6 +387,10 @@ class App(Base):
   # for the agent and SW; no server-side enforcement. Example shape:
   #   {"reads": true, "writes": "queued", "execution": "full", "precache": []}
   offline_contract = Column(JSON, nullable=True, default=None)
+  # Optional root-level markdown file contributed to the agent system prompt.
+  # Only live installed rows are composed; soft-uninstall is therefore the
+  # activation gate even though the app's source tree remains recoverable.
+  system_prompt_file = Column(String(255), nullable=True, default=None)
   created_at = Column(DateTime, default=lambda: datetime.now(UTC))
   updated_at = Column(
     DateTime, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC)

--- a/backend/app/routes/apps.py
+++ b/backend/app/routes/apps.py
@@ -638,6 +638,7 @@ async def install_app(
     background_color=app.background_color,
     display=app.display,
     offline_contract=app.offline_contract,
+    system_prompt_file=app.system_prompt_file,
     created_at=app.created_at,
     updated_at=app.updated_at,
     mode=mode,

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -689,13 +689,14 @@ def get_chat_agent_context(
     _custom_system_prompt,
     _latest_compaction_brief,
     _read_skill_text,
+    _with_system_app_prompts,
   )
 
   chat = get_active_chat_or_404(db, chat_id)
   data_dir = get_settings().data_dir
   overrides = _chat_settings_dict(chat)
   custom = _custom_system_prompt(overrides)
-  system_prompt = custom or _read_skill_text()
+  system_prompt = _with_system_app_prompts(custom) if custom else _read_skill_text()
   app_context_block, _env = _build_app_context(db, chat_id, data_dir)
   app_report_block = _build_app_report_block(db, chat_id, data_dir)
   compaction_brief = _latest_compaction_brief(chat)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -114,6 +114,9 @@ class AppOut(BaseModel):
   # block was declared; otherwise the raw validated JSON object. Informational
   # for the agent + future store badge — no server-side enforcement.
   offline_contract: dict | None = None
+  # Root-level manifest file composed into the agent prompt while this app is
+  # live. Informational so install UIs can surface the privileged declaration.
+  system_prompt_file: str | None = None
   created_at: datetime
   updated_at: datetime
 

--- a/backend/app/system_prompts.py
+++ b/backend/app/system_prompts.py
@@ -1,0 +1,83 @@
+"""Compose the base agent prompt with live installed-app fragments.
+
+An app opts into this privileged surface by declaring a root-level
+``system_prompt`` markdown file in its manifest.  The installer stores only the
+validated basename; composition reads the bytes from the app's installed source
+tree and, critically, selects only live rows.  Soft-uninstall therefore removes
+the fragment by construction even though the app source and user data remain.
+
+Möbius is single-owner software: installing an app is the trust decision.  This
+module does not invent a second allowlist that can drift from the owner's app
+catalog.  Fragments are instructions, so manifests and the install UI should
+continue to make the declaration visible.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from sqlalchemy.orm import Session
+
+from app import models
+
+log = logging.getLogger("moebius.chat")
+_MAX_FRAGMENT_BYTES = 256 * 1024
+
+
+def _safe_fragment_path(source_dir: str | None, basename: str | None) -> Path | None:
+  """Return a confined root-level markdown path, tolerating legacy/corrupt rows."""
+  if not source_dir or not basename or not isinstance(basename, str):
+    return None
+  if (
+    not basename.endswith(".md")
+    or basename == ".md"
+    or Path(basename).name != basename
+    or basename.startswith(".")
+    or ".." in basename
+  ):
+    return None
+  return Path(source_dir) / basename
+
+
+def compose_system_prompt(base: str, db: Session) -> str:
+  """Append prompt fragments from live installed apps in stable id order.
+
+  Missing or unreadable fragments are skipped rather than taking chat down.
+  When no live app contributes a readable fragment, the return value is exactly
+  ``base`` so landing the mechanism is behavior-neutral.
+  """
+  rows = (
+    db.query(models.App)
+    .filter(
+      models.App.deleted_at.is_(None),
+      models.App.system_prompt_file.isnot(None),
+    )
+    .order_by(models.App.id.asc())
+    .all()
+  )
+  fragments: list[str] = []
+  for app in rows:
+    path = _safe_fragment_path(app.source_dir, app.system_prompt_file)
+    if path is None:
+      log.warning("invalid system-prompt fragment row for app id=%s", app.id)
+      continue
+    try:
+      raw = path.read_bytes()
+      if len(raw) > _MAX_FRAGMENT_BYTES:
+        log.warning("system-prompt fragment too large for app id=%s", app.id)
+        continue
+      fragment = raw.decode("utf-8").strip()
+    except (OSError, UnicodeError) as exc:
+      log.warning(
+        "could not read system-prompt fragment for app id=%s: %r", app.id, exc
+      )
+      continue
+    if not fragment:
+      continue
+    fragments.append(
+      f"<!-- installed system app: {app.slug or app.id} -->\n{fragment}"
+    )
+  if not fragments:
+    return base
+  return base.rstrip() + "\n\n" + "\n\n".join(fragments) + "\n"

--- a/backend/tests/test_app_system_prompt.py
+++ b/backend/tests/test_app_system_prompt.py
@@ -1,0 +1,132 @@
+"""Installed-app system-prompt composition and uninstall boundary."""
+
+from datetime import datetime, UTC
+import json
+from unittest.mock import patch
+
+from fastapi import HTTPException
+import pytest
+
+from app import models
+from app import chat
+from app.install import _validate_manifest
+from app.system_prompts import compose_system_prompt
+from tests.test_apps_install import (  # noqa: F401
+  JSX,
+  _bypass_cron_scaffold,
+  _fake_async_client,
+  _stub_resolver_run_chat,
+  bypass_url_validation,
+)
+
+
+def _manifest(**over):
+  value = {
+    "id": "memory",
+    "name": "Memory",
+    "version": "2.0.0",
+    "description": "System memory",
+    "entry": "index.jsx",
+    "source_files": ["memory-core.md"],
+    "system_prompt": "memory-core.md",
+  }
+  value.update(over)
+  return value
+
+
+@pytest.mark.parametrize("value", ["../x.md", "dir/x.md", ".hidden.md", "x.txt", 7])
+def test_system_prompt_manifest_requires_bare_markdown(value):
+  with pytest.raises(HTTPException, match="system_prompt"):
+    _validate_manifest(_manifest(system_prompt=value))
+
+
+def test_system_prompt_must_be_a_declared_source_file():
+  with pytest.raises(HTTPException, match="source_files"):
+    _validate_manifest(_manifest(source_files=[]))
+
+
+def test_no_fragments_returns_base_bytes_verbatim(db):
+  base = "base prompt\n"
+  assert compose_system_prompt(base, db) == base
+
+
+def test_only_live_app_fragments_are_composed_in_stable_order(db, tmp_path):
+  first = tmp_path / "one"
+  second = tmp_path / "two"
+  gone = tmp_path / "gone"
+  for path, text in ((first, "FIRST"), (second, "SECOND"), (gone, "GONE")):
+    path.mkdir()
+    (path / "fragment.md").write_text(text, encoding="utf-8")
+  db.add_all([
+    models.App(
+      id=20, name="two", slug="two", source_dir=str(second),
+      system_prompt_file="fragment.md",
+    ),
+    models.App(
+      id=10, name="one", slug="one", source_dir=str(first),
+      system_prompt_file="fragment.md",
+    ),
+    models.App(
+      id=5, name="gone", slug="gone", source_dir=str(gone),
+      system_prompt_file="fragment.md", deleted_at=datetime.now(UTC),
+    ),
+  ])
+  db.commit()
+
+  prompt = compose_system_prompt("BASE\n", db)
+  assert prompt.startswith("BASE\n")
+  assert prompt.index("FIRST") < prompt.index("SECOND")
+  assert "GONE" not in prompt
+
+
+def test_lingering_fragment_is_inert_after_soft_uninstall(db, tmp_path):
+  source = tmp_path / "memory"
+  source.mkdir()
+  (source / "memory-core.md").write_text("GRAPH INSTRUCTIONS", encoding="utf-8")
+  app = models.App(
+    name="Memory", slug="memory", source_dir=str(source),
+    system_prompt_file="memory-core.md",
+  )
+  db.add(app)
+  db.commit()
+  assert "GRAPH INSTRUCTIONS" in compose_system_prompt("BASE", db)
+
+  app.deleted_at = datetime.now(UTC)
+  db.commit()
+  assert compose_system_prompt("BASE", db) == "BASE"
+  assert (source / "memory-core.md").is_file()
+
+
+def test_install_persists_system_prompt_capability(
+  client, auth, db, bypass_url_validation,
+):
+  base = "https://system-prompt.test/memory/"
+  manifest = _manifest()
+  responses = {
+    base + "mobius.json": (200, json.dumps(manifest).encode()),
+    base + "index.jsx": (200, JSX.encode()),
+    base + "memory-core.md": (200, b"RETRIEVE ON DEMAND"),
+  }
+  with patch(
+    "app.install.httpx.AsyncClient",
+    side_effect=_fake_async_client(responses),
+  ):
+    response = client.post("/api/apps/install", headers=auth, json={
+      "manifest_url": base + "mobius.json",
+    })
+
+  assert response.status_code == 201, response.text
+  app = db.query(models.App).filter(models.App.slug == "memory").one()
+  assert app.system_prompt_file == "memory-core.md"
+  assert response.json()["system_prompt_file"] == "memory-core.md"
+  assert "RETRIEVE ON DEMAND" in compose_system_prompt("BASE", db)
+
+
+def test_system_app_suffix_also_applies_to_custom_chat_prompts(monkeypatch):
+  monkeypatch.setattr(
+    chat, "_SYSTEM_APP_PROMPT_SUFFIX_CACHE",
+    "\n\n<!-- installed system app: memory -->\nRECALL\n",
+  )
+  assert chat._with_system_app_prompts("CUSTOM") == (
+    "CUSTOM\n\n<!-- installed system app: memory -->\nRECALL\n"
+  )

--- a/backend/tests/test_db_migrations.py
+++ b/backend/tests/test_db_migrations.py
@@ -27,6 +27,7 @@ def test_run_migrations_adds_manifest_url_to_existing_apps_table(tmp_path):
   # Reversible-uninstall tombstone column is added on an existing apps table
   # (feature 110) — the path that runs on a real prod boot, not create_all.
   assert "deleted_at" in cols
+  assert "system_prompt_file" in cols
 
 
 def test_run_migrations_adds_park_columns_to_existing_chat_runs(tmp_path):


### PR DESCRIPTION
Introduces the DB-driven, restart-bound system_prompt manifest capability. Live app rows compose stable prompt fragments into both normal and custom app chats; tombstoned apps are excluded. This is the safe mechanism-first phase and does not remove existing graph instructions or startup behavior.