### PR TITLE
Fix pinned HTTPS SNI for app installs

### DIFF
--- a/backend/app/install.py
+++ b/backend/app/install.py
@@ -832,7 +832,10 @@ async def _http_get(
     async with client.stream(
       "GET", pinned_url,
       headers={"Host": host_header},
-      extensions={"sni_hostname": sni_host.encode("ascii")},
+      # httpcore/anyio expect a hostname string here. Passing bytes worked with
+      # older httpx but now reaches idna2008_resolve(), which calls `.encode()`
+      # and crashes every real HTTPS install/update before the request is sent.
+      extensions={"sni_hostname": sni_host},
     ) as r:
       # Handle redirects + error statuses with the stream closed
       # quickly so we don't hold a connection while recursing.

--- a/backend/tests/test_apps_install.py
+++ b/backend/tests/test_apps_install.py
@@ -1616,6 +1616,26 @@ def test_install_rejects_decompression_bomb_icon(client, auth, bypass_url_valida
 # --- Stream byte counter aborts mid-download (fix 3) ----------------
 
 
+@pytest.mark.asyncio
+async def test_http_get_passes_sni_hostname_as_text(monkeypatch):
+  """The live httpcore/anyio stack requires str, not pre-encoded bytes."""
+  from app import install
+
+  monkeypatch.setattr(
+    install, "_validate_url_safe",
+    lambda _url: ("https://203.0.113.8/file", "example.test", "example.test"),
+  )
+
+  class _Client:
+    def stream(self, method, url, **kwargs):
+      assert method == "GET"
+      assert kwargs["extensions"]["sni_hostname"] == "example.test"
+      assert isinstance(kwargs["extensions"]["sni_hostname"], str)
+      return _StreamCtx(200, b"ok")
+
+  assert await install._http_get(_Client(), "https://example.test/file", 10) == b"ok"
+
+
 def test_install_aborts_when_stream_exceeds_cap(client, auth, bypass_url_validation):
   """Fix 3: `_http_get` now reads via `client.stream()` and tracks
   bytes per chunk, aborting once the running total crosses the cap.


### PR DESCRIPTION
Production app updates currently crash before sending HTTPS because sni_hostname is passed as bytes to the current httpcore/anyio stack. Pass the validated hostname as text and cover the real extension type. This was exposed while store-updating Memory after the system-prompt mechanism deploy.