### PR TITLE
Harden public repository privacy gates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,8 +3,12 @@
 README.md
 SECURITY.md
 CONTRIBUTING.md
+AGENTS.md
 CLAUDE.md
-docs/
+docs
+demo-logs
+.claude
+.pm
 assets/
 apps/
 node_modules/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,18 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  privacy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Reject private workspace paths
+        run: scripts/check-private-paths.sh
+      - name: Test local privacy gates
+        run: scripts/test-git-privacy-gates.sh
+
   backend:
     runs-on: ubuntu-latest
     # The full backend suite is now large enough that cold hosted runners can

--- a/.gitignore
+++ b/.gitignore
@@ -58,14 +58,14 @@ playwright-report/
 core-apps/*/tests/.build*/
 
 # Internal planning docs — not for public release
-docs/
+/docs
 
 # Internal dev artifacts — not for public release
-demo-logs/
-.claude/
-.pm/
-AGENTS.md
-CLAUDE.md
+/demo-logs
+/.claude
+/.pm
+/AGENTS.md
+/CLAUDE.md
 
 # Baked Vite build output (created by the image build / test conftest stub)
 backend/static/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,17 @@ CI is `.github/workflows/test.yml`; the commands below mirror it.
 
 ## Landing a session branch
 
+Install the repository's shared privacy and quality gates once after cloning,
+and re-run the installer after pulling hook changes:
+
+```bash
+scripts/install-hooks.sh
+```
+
+The roots `docs`, `demo-logs`, `.claude`, `.pm`, `AGENTS.md`, and `CLAUDE.md`
+are private workspace state. Keep them outside the public clone (local symlinks
+are ignored), never force-add them, and never bypass a privacy hook failure.
+
 Parallel work should land through `scripts/land.sh` from the session worktree.
 It refuses dirty or detached checkouts, backs up the branch tip under
 `origin/preserve/session-*`, rebases onto the latest `origin/main`, then pushes

--- a/scripts/check-private-paths.sh
+++ b/scripts/check-private-paths.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Fail if a git tree contains private workspace roots.
+set -euo pipefail
+
+ref="${1:-HEAD}"
+private_paths=(docs demo-logs .claude .pm AGENTS.md CLAUDE.md)
+
+if ! git cat-file -e "${ref}^{tree}" 2>/dev/null; then
+  echo "check-private-paths: cannot resolve tree for ${ref}" >&2
+  exit 2
+fi
+
+commits="$(git rev-list "$ref" -- "${private_paths[@]}")"
+if [ -n "$commits" ]; then
+  echo "check-private-paths: private workspace paths occur in history reachable from ${ref}:" >&2
+  git log -n 8 --format='    %h %s' "$ref" -- "${private_paths[@]}" >&2
+  echo "check-private-paths: deleting a path later does not remove it from history" >&2
+  exit 1
+fi
+
+echo "check-private-paths: OK (${ref})"

--- a/scripts/git-doctor.sh
+++ b/scripts/git-doctor.sh
@@ -61,6 +61,42 @@ if [ -n "$BASE" ]; then
   fi
 fi
 
+# 5. Private workspace roots anywhere in reachable history. A clean tip is not
+#    sufficient because an earlier add remains fetchable after a later delete.
+PRIVATE_COMMITS="$(git rev-list HEAD -- \
+  docs demo-logs .claude .pm AGENTS.md CLAUDE.md 2>/dev/null || true)"
+if [ -n "$PRIVATE_COMMITS" ]; then
+  err "private workspace paths occur in history reachable from HEAD:"
+  git log -n 8 --format='    %h %s' HEAD -- \
+    docs demo-logs .claude .pm AGENTS.md CLAUDE.md >&2
+  warn "purge the paths from reachable history; do not push or bypass privacy hooks"
+  FAILS=$((FAILS + 1))
+fi
+
+# 6. Hooks must be installed and current. A copied hook deliberately survives
+#    worktree removal, but that also means a pull cannot update it in place.
+HOOKS_DIR="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)/hooks"
+ACTIVE_HOOKS_DIR="$(git rev-parse --path-format=absolute --git-path hooks 2>/dev/null)"
+STALE_HOOKS=0
+for pair in \
+  "scripts/pre-commit.sh:$HOOKS_DIR/pre-commit" \
+  "scripts/githooks/pre-push:$HOOKS_DIR/pre-push"; do
+  source_path="${pair%%:*}"
+  installed_path="${pair#*:}"
+  if [ ! -x "$installed_path" ] || ! cmp -s "$source_path" "$installed_path"; then
+    STALE_HOOKS=$((STALE_HOOKS + 1))
+  fi
+done
+if [ "$ACTIVE_HOOKS_DIR" != "$HOOKS_DIR" ]; then
+  err "active core.hooksPath is $ACTIVE_HOOKS_DIR, expected $HOOKS_DIR"
+  STALE_HOOKS=$((STALE_HOOKS + 1))
+fi
+if [ "$STALE_HOOKS" -gt 0 ]; then
+  err "$STALE_HOOKS required git hook(s) are missing or stale"
+  warn "install with: scripts/install-hooks.sh"
+  FAILS=$((FAILS + 1))
+fi
+
 if [ "$FAILS" -eq 0 ]; then
   echo "[git-doctor] OK"
   exit 0

--- a/scripts/githooks/pre-push
+++ b/scripts/githooks/pre-push
@@ -10,7 +10,7 @@
 # CI is the backstop for anything skipped (e.g. from a deps-less worktree).
 #
 # Install: scripts/install-hooks.sh (copies this into the shared hooks
-# dir, so every worktree is covered). Bypass once: `git push --no-verify`.
+# dir, so every worktree is covered). Privacy failures must never be bypassed.
 #
 # Design note: this is a GATE, not a full CI replacement. It mirrors the
 # fast CI jobs (frontend-unit, syntax) so a red push is caught in seconds
@@ -48,6 +48,7 @@ PP_TMP="$(mktemp -d "${TMPDIR:-/tmp}/mobius-pp.XXXXXX")" || exit 1
 trap 'rm -rf "$PP_TMP"' EXIT
 
 FAIL=0
+PRIVACY_FAIL=0
 c_ok=$'\033[1;32m'; c_warn=$'\033[1;33m'; c_err=$'\033[1;31m'; c_off=$'\033[0m'
 ok()   { printf '%s[pre-push]%s %s\n' "$c_ok"  "$c_off" "$*"; }
 warn() { printf '%s[pre-push]%s %s\n' "$c_warn" "$c_off" "$*"; }
@@ -117,30 +118,38 @@ if [ "${POLLUTION:-0}" -gt 0 ]; then
   FAIL=1
 fi
 
-# 1c. Internal docs must never reach the PUBLIC repo. `docs/` is gitignored
-#     ("internal planning — not for public release"), but gitignore only
-#     blocks UNtracked files — a `git add -f` makes a doc track forever and
-#     bypasses the rule. So decision/design docs keep creeping into origin
-#     (untracked by hand more than once: bb97fd74, 5c176b21 — and they came
-#     back). This blocks any tracked docs/ path at the tip. Decision records
-#     stay LOCAL: they live on disk under the gitignored docs/, just not in
-#     git. A doc that genuinely belongs in the repo goes in ARCHITECTURE.md.
-#     To publish a specific doc, add its path regex to DOCS_ALLOWLIST.
-DOCS_ALLOWLIST=''   # newline-separated regex(es) of docs/ paths allowed public; empty = none
-TRACKED_DOCS="$(git ls-tree -r --name-only HEAD -- docs 2>/dev/null || true)"
-if [ -n "$DOCS_ALLOWLIST" ]; then
-  TRACKED_DOCS="$(printf '%s\n' "$TRACKED_DOCS" | grep -vE "$DOCS_ALLOWLIST" || true)"
+# 1c. Private workspace paths must never reach the PUBLIC repo. Gitignore only
+#     protects untracked files; `git add -f` bypasses it. Inspect every local
+#     object named on pre-push stdin, not only HEAD: `git push other:remote`
+#     otherwise bypasses a HEAD-only gate. Exact root names also catch symlinks.
+PRIVATE_PATHS=(docs demo-logs .claude .pm AGENTS.md CLAUDE.md)
+PRIVATE_TIPS="$PP_TMP/private-tips"
+: >"$PRIVATE_TIPS"
+while read -r _local_ref local_sha remote_ref _remote_sha; do
+  [ -n "${local_sha:-}" ] || continue
+  [ "$local_sha" = "$ZERO" ] && continue
+  printf '%s\t%s\n' "$local_sha" "$remote_ref" >>"$PRIVATE_TIPS"
+done <"$PUSH_REFS"
+
+# Direct/manual invocation has no pre-push stdin. Check HEAD so the hook stays
+# useful as a diagnostic command and in the repository's regression tests.
+if [ ! -s "$PRIVATE_TIPS" ]; then
+  printf '%s\t%s\n' "$(git rev-parse HEAD)" HEAD >>"$PRIVATE_TIPS"
 fi
-if [ -n "$TRACKED_DOCS" ]; then
-  err "refusing to push tracked files under docs/ (internal, gitignored):"
-  printf '%s\n' "$TRACKED_DOCS" | sed 's/^/    /' >&2
-  err "docs/ is LOCAL-ONLY. Untrack (the file stays on disk):"
-  err "    git rm --cached <path>   # then commit + re-push"
-  err "A design decision that belongs in the repo goes in ARCHITECTURE.md, not docs/."
-  err "To publish one doc, add its path to DOCS_ALLOWLIST in scripts/githooks/pre-push."
-  FAIL=1
-else
-  ok "no tracked docs/ (internal docs stay local)"
+
+while IFS=$'\t' read -r tip destination; do
+  private_commits="$(git rev-list "$tip" -- "${PRIVATE_PATHS[@]}" 2>/dev/null || true)"
+  if [ -n "$private_commits" ]; then
+    err "refusing to push history containing private workspace paths to ${destination}:"
+    git log -n 8 --format='    %h %s' "$tip" -- "${PRIVATE_PATHS[@]}" >&2
+    err "removing a path in a later commit is insufficient; purge it from reachable history"
+    err "do not bypass this privacy gate"
+    FAIL=1
+    PRIVACY_FAIL=1
+  fi
+done <"$PRIVATE_TIPS"
+if [ "$PRIVACY_FAIL" -eq 0 ]; then
+  ok "no private workspace paths in pushed histories"
 fi
 
 # 2. Python syntax on changed .py files (instant; no deps beyond python3).
@@ -255,7 +264,11 @@ if changed_match '^backend/'; then
 fi
 
 if [ "$FAIL" -ne 0 ]; then
-  err "push blocked. Fix the above, or bypass with:  git push --no-verify"
+  if [ "$PRIVACY_FAIL" -ne 0 ]; then
+    err "push blocked by the privacy gate. Do not use --no-verify; remove the private paths."
+  else
+    err "push blocked. Fix the above, or bypass only if the non-privacy failure is understood."
+  fi
   exit 1
 fi
 ok "all gate checks passed — pushing"

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,19 +1,20 @@
 #!/usr/bin/env bash
 # Install Möbius git hooks for this clone.
 #
-# Copies scripts/githooks/* into the repo's SHARED hooks dir
-# (git-common-dir/hooks), so one install covers every linked worktree.
+# Copies scripts/githooks/* plus scripts/pre-commit.sh into the repo's SHARED
+# hooks dir (git-common-dir/hooks), so one install covers every linked worktree.
 # Idempotent — re-run after pulling updated hooks to refresh them.
 #
 #   ./scripts/install-hooks.sh
 #
 # A copy (not a symlink) is used so the installed hook is self-contained
-# and survives removal of whatever worktree it was installed from. Bypass
-# a hook once with `git <cmd> --no-verify`.
+# and survives removal of whatever worktree it was installed from. Privacy
+# failures must never be bypassed with `--no-verify`.
 set -euo pipefail
 
 ROOT="$(git rev-parse --show-toplevel)"
-HOOKS_DIR="$(git rev-parse --git-common-dir)/hooks"
+COMMON_DIR="$(git rev-parse --path-format=absolute --git-common-dir)"
+HOOKS_DIR="$COMMON_DIR/hooks"
 SRC="$ROOT/scripts/githooks"
 
 if [ ! -d "$SRC" ]; then
@@ -22,6 +23,12 @@ if [ ! -d "$SRC" ]; then
 fi
 
 mkdir -p "$HOOKS_DIR"
+# Pin the active hook path in repository-local config. This prevents a global
+# core.hooksPath setting from silently bypassing the hooks we install, without
+# affecting any other repository.
+git config --local core.hooksPath "$HOOKS_DIR"
+install -m 0755 "$ROOT/scripts/pre-commit.sh" "$HOOKS_DIR/pre-commit"
+echo "installed pre-commit -> $HOOKS_DIR/pre-commit"
 for hook in "$SRC"/*; do
   [ -e "$hook" ] || continue
   name="$(basename "$hook")"

--- a/scripts/land.sh
+++ b/scripts/land.sh
@@ -9,11 +9,30 @@ cd "$ROOT"
 err() { printf 'land: %s\n' "$*" >&2; }
 info() { printf 'land: %s\n' "$*"; }
 
+check_private_history() {
+  local ref="${1:-HEAD}"
+  local commits
+  commits="$(git rev-list "$ref" -- \
+    docs demo-logs .claude .pm AGENTS.md CLAUDE.md 2>/dev/null || true)"
+  if [ -n "$commits" ]; then
+    err "refusing to land history containing private workspace paths from ${ref}:"
+    git log -n 8 --format='    %h %s' "$ref" -- \
+      docs demo-logs .claude .pm AGENTS.md CLAUDE.md >&2
+    err "deleting a path later is insufficient; purge it from reachable history"
+    err "this privacy gate must not be bypassed"
+    return 1
+  fi
+}
+
 branch="$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
 if [ -z "$branch" ]; then
   err "detached HEAD; check out a session branch before landing"
   exit 2
 fi
+
+# This must run before the preservation push below. Otherwise the backup ref
+# intended to protect work could itself publish private workspace material.
+check_private_history HEAD
 
 dirty="$(git status --porcelain)"
 if [ -n "$dirty" ]; then
@@ -62,6 +81,10 @@ if [ -n "$dirty" ]; then
   git status --short >&2
   exit 1
 fi
+
+# Rebase can introduce paths from the updated base. Re-check the exact tree
+# that will be sent to main.
+check_private_history HEAD
 
 info "pushing HEAD to main with normal fast-forward semantics"
 if git push origin HEAD:main; then

--- a/scripts/mobius-session.sh
+++ b/scripts/mobius-session.sh
@@ -37,6 +37,10 @@ if [[ ! -f docker-compose.test.yml ]]; then
   exit 2
 fi
 
+# Refresh the shared hooks before creating a worktree. One install covers all
+# current and future worktrees attached to this clone.
+scripts/install-hooks.sh
+
 worktree=".claude/worktrees/${slug}"
 branch="session-${slug}"
 

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# pre-commit.sh — Lightweight syntax-only checks for staged files.
+# pre-commit.sh — Privacy and lightweight syntax checks for staged files.
 #
 # Runs in well under 1 second on a typical 5-file commit. NOT a substitute
 # for tests or linting — just catches "I committed a file with a typo /
@@ -16,18 +16,10 @@
 #                          esbuild runs in the build path; let it catch them.
 #   tests, linters, formatters — too slow for a pre-commit gate.
 #
-# Install (pick one — this script is NOT auto-installed):
-#
-#   # Option A — point core.hooksPath at the scripts/ dir (requires a
-#   # `pre-commit` filename, so symlink it once):
-#   ln -sf "$(pwd)/scripts/pre-commit.sh" scripts/pre-commit
-#   git config core.hooksPath scripts
-#
-#   # Option B — symlink directly into .git/hooks (per-clone, not tracked):
-#   ln -sf "$(pwd)/scripts/pre-commit.sh" .git/hooks/pre-commit
-#
-# Bypass (always available, by design):
-#   git commit --no-verify
+# Install with `scripts/install-hooks.sh`. The installer copies this hook into
+# the shared git-common-dir, covering every linked worktree in the clone.
+# Syntax checks can be bypassed in an emergency; privacy failures must never be
+# bypassed. Remove private paths from the index instead.
 #
 # Run manually against currently-staged files:
 #   bash scripts/pre-commit.sh
@@ -43,19 +35,25 @@ if [ "${#STAGED[@]}" -eq 0 ]; then
 fi
 
 FAILURES=0
+PRIVACY_FAILURES=0
 fail() {
   printf 'pre-commit: %s\n' "$*" >&2
   FAILURES=$((FAILURES + 1))
 }
+privacy_fail() {
+  fail "$@"
+  PRIVACY_FAILURES=$((PRIVACY_FAILURES + 1))
+}
 
-# docs/ is gitignored ("internal planning — not for public release"), but a
-# `git add -f` bypasses that and the file then tracks forever. Block staged
-# docs/ paths here so a leak fails at commit time; the pre-push hook is the
-# backstop. Decision records stay local — a repo-worthy design goes in
-# ARCHITECTURE.md. Bypass once with `git commit --no-verify`.
+# Gitignore only protects untracked files: `git add -f` can still stage a
+# private path. Block every private workspace root at commit time. The exact
+# root names matter because local private directories may be symlinked into a
+# clean public checkout.
 for f in "${STAGED[@]}"; do
   case "$f" in
-    docs/*) fail "refusing to commit $f — docs/ is internal & gitignored (git reset $f to unstage; decision records stay local, repo-worthy designs go in ARCHITECTURE.md)" ;;
+    docs|docs/*|demo-logs|demo-logs/*|.claude|.claude/*|.pm|.pm/*|AGENTS.md|CLAUDE.md)
+      privacy_fail "refusing to commit $f — private workspace path (git reset $f to unstage)"
+      ;;
   esac
 done
 
@@ -107,8 +105,13 @@ for f in "${MD_FILES[@]:-}"; do
 done
 
 if [ "$FAILURES" -gt 0 ]; then
-  printf '\npre-commit: %d check(s) failed. Fix the issues above, or bypass with `git commit --no-verify`.\n' \
-    "$FAILURES" >&2
+  if [ "$PRIVACY_FAILURES" -gt 0 ]; then
+    printf '\npre-commit: %d check(s) failed, including %d privacy failure(s). Do not bypass this gate; remove the private paths from the index.\n' \
+      "$FAILURES" "$PRIVACY_FAILURES" >&2
+  else
+    printf '\npre-commit: %d syntax check(s) failed. Fix the issues above, or bypass only if the failure is understood.\n' \
+      "$FAILURES" >&2
+  fi
   exit 1
 fi
 

--- a/scripts/test-git-privacy-gates.sh
+++ b/scripts/test-git-privacy-gates.sh
@@ -11,6 +11,13 @@ fail() {
   exit 1
 }
 
+# Private workspace roots must not be sent to the Docker daemon either. Exact
+# root patterns cover both directories and the local symlinks used here.
+for path in docs demo-logs .claude .pm AGENTS.md CLAUDE.md; do
+  grep -Fxq "$path" "$ROOT/.dockerignore" \
+    || fail ".dockerignore missed $path"
+done
+
 repo="$TMP/repo"
 git init -q "$repo"
 git -C "$repo" config user.name Privacy-Test

--- a/scripts/test-git-privacy-gates.sh
+++ b/scripts/test-git-privacy-gates.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Regression tests for the public-repository privacy gates.
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/mobius-privacy-test.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "privacy-gates-test: $*" >&2
+  exit 1
+}
+
+repo="$TMP/repo"
+git init -q "$repo"
+git -C "$repo" config user.name Privacy-Test
+git -C "$repo" config user.email privacy-test@invalid
+mkdir -p "$repo/scripts/githooks"
+cp "$ROOT/.gitignore" "$repo/.gitignore"
+cp "$ROOT/scripts/pre-commit.sh" "$repo/scripts/pre-commit.sh"
+cp "$ROOT/scripts/install-hooks.sh" "$repo/scripts/install-hooks.sh"
+cp "$ROOT/scripts/githooks/pre-push" "$repo/scripts/githooks/pre-push"
+cp "$ROOT/scripts/land.sh" "$repo/scripts/land.sh"
+cp "$ROOT/scripts/check-private-paths.sh" "$repo/scripts/check-private-paths.sh"
+chmod +x "$repo/scripts/"*.sh "$repo/scripts/githooks/pre-push"
+
+# Root-anchored ignores must cover directories, filenames, and the symlink form
+# used to expose out-of-repo private state in a clean local checkout.
+for path in docs demo-logs .claude .pm AGENTS.md CLAUDE.md; do
+  git -C "$repo" check-ignore -q "$path" || fail ".gitignore missed $path"
+done
+ln -s "$TMP/private-docs" "$repo/docs"
+git -C "$repo" check-ignore -q docs || fail ".gitignore missed docs symlink"
+rm "$repo/docs"
+
+git -C "$repo" add .gitignore scripts
+git -C "$repo" commit -qm baseline
+
+(cd "$repo" && scripts/install-hooks.sh >/dev/null)
+cmp -s "$repo/scripts/pre-commit.sh" "$repo/.git/hooks/pre-commit" \
+  || fail "installer did not install pre-commit"
+cmp -s "$repo/scripts/githooks/pre-push" "$repo/.git/hooks/pre-push" \
+  || fail "installer did not install pre-push"
+[ "$(git -C "$repo" rev-parse --path-format=absolute --git-path hooks)" = \
+  "$repo/.git/hooks" ] || fail "installer did not activate the repository hook directory"
+
+# Pre-commit must reject all private roots even when force-added.
+mkdir -p "$repo/docs" "$repo/demo-logs" "$repo/.claude" "$repo/.pm"
+for path in \
+  docs/private.md demo-logs/private.log .claude/private.json .pm/private.md \
+  AGENTS.md CLAUDE.md; do
+  printf 'private\n' >"$repo/$path"
+  git -C "$repo" add -f "$path"
+done
+if (cd "$repo" && scripts/pre-commit.sh >/dev/null 2>&1); then
+  fail "pre-commit accepted private paths"
+fi
+git -C "$repo" reset -q --hard HEAD
+
+printf 'public\n' >"$repo/public.txt"
+git -C "$repo" add public.txt
+(cd "$repo" && scripts/pre-commit.sh >/dev/null) || fail "pre-commit rejected a public path"
+git -C "$repo" commit -qm public
+
+# A committed private path must be rejected by the reusable CI check, the
+# pre-push hook, and land.sh before land.sh attempts any remote backup push.
+git -C "$repo" switch -qc private-fixture
+mkdir -p "$repo/.pm"
+printf 'private\n' >"$repo/.pm/private.md"
+git -C "$repo" add -f .pm/private.md
+git -C "$repo" commit -qm private-fixture --no-verify
+private_sha="$(git -C "$repo" rev-parse HEAD)"
+
+# Delete the path again so the tip tree looks clean while its object remains
+# reachable. Every history-level gate must still reject this branch.
+git -C "$repo" rm -q -f .pm/private.md
+git -C "$repo" commit -qm remove-private-fixture
+history_sha="$(git -C "$repo" rev-parse HEAD)"
+
+if git -C "$repo" show HEAD:.pm/private.md >/dev/null 2>&1; then :; else
+  git -C "$repo" show "$private_sha":.pm/private.md >/dev/null 2>&1 \
+    || fail "private fixture was not committed"
+fi
+if git -C "$repo" ls-tree -r --name-only HEAD -- .pm | grep -q .; then
+  fail "private fixture still exists in the tip tree"
+fi
+if (cd "$repo" && scripts/check-private-paths.sh >/dev/null 2>&1); then
+  fail "CI history check accepted an add-then-delete private path"
+fi
+if (cd "$repo" && scripts/githooks/pre-push </dev/null >/dev/null 2>&1); then
+  fail "pre-push accepted an add-then-delete private path"
+fi
+if (cd "$repo" && scripts/land.sh >/dev/null 2>&1); then
+  fail "land.sh accepted an add-then-delete private path"
+fi
+
+# The pushed object can differ from HEAD (`git push other:remote`). Verify the
+# hook checks the object supplied on pre-push stdin, not merely the checkout.
+git -C "$repo" switch -q master
+zero=0000000000000000000000000000000000000000
+if printf 'refs/heads/private-fixture %s refs/heads/leak %s\n' \
+     "$history_sha" "$zero" \
+     | (cd "$repo" && scripts/githooks/pre-push >/dev/null 2>&1); then
+  fail "pre-push accepted private history from a non-HEAD ref"
+fi
+
+echo "privacy-gates-test: OK"

--- a/tests/app-canvas.spec.mjs
+++ b/tests/app-canvas.spec.mjs
@@ -281,17 +281,32 @@ async function setupOpenAppRoutesWithStaleInitialList(page, appId, frameHTML) {
   return { getAppsFetches: () => appsFetches }
 }
 
+/** Wait for the browser frame behind an iframe element, not just the DOM node.
+ * React can commit the iframe before Chromium attaches its Frame; a one-shot
+ * contentFrame() call in that window returns null. Re-querying the element also
+ * survives a keyed iframe replacement while the app canvas settles. */
+async function waitForContentFrame(page, selector, timeout = 10000) {
+  let frame = null
+  await expect.poll(async () => {
+    const element = await page.$(selector)
+    frame = element ? await element.contentFrame() : null
+    return frame !== null
+  }, {
+    timeout,
+    message: `browser frame did not attach for ${selector}`,
+  }).toBe(true)
+  return frame
+}
+
 async function postFromOpaqueCanvasFrame(page, data) {
-  const handle = await page.evaluateHandle(() => {
+  await page.evaluate(() => {
     const frame = document.createElement('iframe')
     frame.className = 'canvas canvas--test-sender'
     frame.setAttribute('sandbox', 'allow-scripts')
     frame.srcdoc = '<!doctype html><script>window.__ready = true<\/script>'
     document.body.appendChild(frame)
-    return frame
   })
-  const element = handle.asElement()
-  const frame = await element.contentFrame()
+  const frame = await waitForContentFrame(page, 'iframe.canvas--test-sender')
   await frame.waitForFunction(() => window.__ready === true)
   await frame.evaluate((message) => {
     window.parent.postMessage(message, '*')
@@ -338,8 +353,7 @@ test.describe('AppCanvas: iframe-mount contract', () => {
     // execute inside the frame, so wait for its own load state and dispatch the
     // deterministic test signal there. postMounted then reaches the parent with
     // the real frame as event.source and the opaque `null` event.origin.
-    const frameElement = await page.waitForSelector('iframe.canvas')
-    const frame = await frameElement.contentFrame()
+    const frame = await waitForContentFrame(page, 'iframe.canvas')
     await frame.waitForLoadState('load')
     await frame.evaluate(() => {
       window.dispatchEvent(new MessageEvent('message', {
@@ -367,8 +381,7 @@ test.describe('AppCanvas: iframe-mount contract', () => {
     await page.goto(`${BASE}/`, { waitUntil: 'domcontentloaded' })
     await expect(page.locator('.canvas-loading')).toBeHidden({ timeout: 10000 })
 
-    const frameElement = await page.waitForSelector(`iframe[data-app-id="${appId}"]`, { timeout: 10000 })
-    const frame = await frameElement.contentFrame()
+    const frame = await waitForContentFrame(page, `iframe[data-app-id="${appId}"]`)
     await frame.evaluate(() => {
       window.__navBacks = 0
       window.__navAcks = []
@@ -414,8 +427,7 @@ test.describe('AppCanvas: iframe-mount contract', () => {
       localStorage.setItem('moebius_active_app', String(id))
     }, appId)
     await page.goto(`${BASE}/`, { waitUntil: 'domcontentloaded' })
-    const frameElement = await page.waitForSelector(`iframe[data-app-id="${appId}"]`, { timeout: 10000 })
-    const frame = await frameElement.contentFrame()
+    const frame = await waitForContentFrame(page, `iframe[data-app-id="${appId}"]`)
     await frame.evaluate(() => {
       window.__navBacks = 0
       window.__navAck = false
@@ -458,8 +470,7 @@ test.describe('AppCanvas: iframe-mount contract', () => {
       localStorage.setItem('moebius_active_app', String(id))
     }, appId)
     await page.goto(`${BASE}/`, { waitUntil: 'domcontentloaded' })
-    const frameElement = await page.waitForSelector(`iframe[data-app-id="${appId}"]`, { timeout: 10000 })
-    const frame = await frameElement.contentFrame()
+    const frame = await waitForContentFrame(page, `iframe[data-app-id="${appId}"]`)
     await frame.evaluate(() => {
       window.__navBacks = 0
       window.__navAck = false
@@ -503,8 +514,7 @@ test.describe('AppCanvas: iframe-mount contract', () => {
       localStorage.setItem('moebius_active_app', String(id))
     }, appId)
     await page.goto(`${BASE}/`, { waitUntil: 'domcontentloaded' })
-    const frameElement = await page.waitForSelector(`iframe[data-app-id="${appId}"]`, { timeout: 10000 })
-    const frame = await frameElement.contentFrame()
+    const frame = await waitForContentFrame(page, `iframe[data-app-id="${appId}"]`)
     await frame.evaluate(() => {
       window.__navBacks = 0
       window.__navAck = false
@@ -735,10 +745,10 @@ test.describe('AppCanvas: iframe-mount contract', () => {
     // open-app target refetches once before giving up) — the bumped updated_at
     // starts the swap and mounts the hidden incoming frame.
     swapArmed = true
-    const settledLiveEl = await page.waitForSelector(
+    const settledLiveFrame = await waitForContentFrame(
+      page,
       'iframe.canvas--live[data-frame-version="1000"]',
     )
-    const settledLiveFrame = await settledLiveEl.contentFrame()
     await settledLiveFrame.evaluate(() => {
       window.parent.postMessage(
         { type: 'moebius:open-app', appId: 'no-such-app' },
@@ -746,13 +756,13 @@ test.describe('AppCanvas: iframe-mount contract', () => {
       )
     })
     // state:'attached', not 'visible' — the incoming frame is visibility:hidden.
-    const incomingEl = await page.waitForSelector('iframe.canvas--incoming', {
+    await page.waitForSelector('iframe.canvas--incoming', {
       state: 'attached', timeout: 8000,
     })
 
     // Crash report from the HIDDEN incoming frame → swallowed: no chat
     // create, no navigation away from the canvas.
-    const incomingFrame = await incomingEl.contentFrame()
+    const incomingFrame = await waitForContentFrame(page, 'iframe.canvas--incoming')
     await incomingFrame.evaluate((id) => {
       window.parent.postMessage(
         { type: 'moebius:app-error', appId: String(id), error: 'hidden-frame crash' },
@@ -765,10 +775,10 @@ test.describe('AppCanvas: iframe-mount contract', () => {
 
     // Crash report from the LIVE frame → forwarded: Shell routes it to a new
     // chat with the report as a reviewable draft (not auto-sent).
-    const liveEl = await page.waitForSelector('iframe.canvas--live', {
+    await page.waitForSelector('iframe.canvas--live', {
       state: 'attached', timeout: 4000,
     })
-    const liveFrame = await liveEl.contentFrame()
+    const liveFrame = await waitForContentFrame(page, 'iframe.canvas--live')
     await liveFrame.evaluate((id) => {
       window.parent.postMessage(
         { type: 'moebius:app-error', appId: String(id), error: 'live-frame crash' },

--- a/tests/outbox.spec.mjs
+++ b/tests/outbox.spec.mjs
@@ -10,6 +10,14 @@ import { test, expect } from '@playwright/test'
 
 const BASE = process.env.MOBIUS_URL || 'http://localhost:8001'
 
+function stubAppToken(appId) {
+  const claims = Buffer.from(JSON.stringify({
+    scope: 'app',
+    app_id: String(appId),
+  })).toString('base64url')
+  return `stub.${claims}.stub`
+}
+
 test('storage.set queues on failure and flushes on recovery', async ({ page }) => {
   let net = 'down'
   let puts = 0
@@ -21,12 +29,14 @@ test('storage.set queues on failure and flushes on recovery', async ({ page }) =
 
   await page.goto(`${BASE}/shell/`)
   // Initialize the runtime against a throwaway app id with a stub token.
-  await page.evaluate(async () => {
+  const appId = 990001
+  const token = stubAppToken(appId)
+  await page.evaluate(async ({ appId, token }) => {
     const rt = await import('/mobius-runtime.js')
-    rt.init({ appId: 990001, getToken: async () => 'stub-token' })
+    rt.init({ appId, getToken: async () => token })
     // Start from an empty queue in case a previous run left entries.
     await new Promise((res) => { const r = indexedDB.deleteDatabase('mobius-outbox'); r.onsuccess = r.onerror = r.onblocked = () => res() })
-  })
+  }, { appId, token })
 
   // Network down → the write queues instead of failing.
   const queued = await page.evaluate(async () => {

--- a/tests/storage-typed.spec.mjs
+++ b/tests/storage-typed.spec.mjs
@@ -10,6 +10,14 @@ import { test, expect } from '@playwright/test'
 
 const BASE = process.env.MOBIUS_URL || 'http://localhost:8030'
 
+function stubAppToken(appId) {
+  const claims = Buffer.from(JSON.stringify({
+    scope: 'app',
+    app_id: String(appId),
+  })).toString('base64url')
+  return `stub.${claims}.stub`
+}
+
 // Install an in-memory /api/storage backend: PUT stores {body,ct} by path; GET
 // returns it (404 if absent); DELETE removes. `mode` lets a test force offline
 // (abort) or a fatal 422. Returns handles to flip mode + inspect.
@@ -69,11 +77,12 @@ async function installStore(page, opts = {}) {
 
 async function initRuntime(page, appId) {
   await page.goto(`${BASE}/shell/`)
-  await page.evaluate(async (id) => {
+  const token = stubAppToken(appId)
+  await page.evaluate(async ({ appId, token }) => {
     await new Promise((res) => { const r = indexedDB.deleteDatabase('mobius-outbox'); r.onsuccess = r.onerror = r.onblocked = () => res() })
     const rt = await import('/mobius-runtime.js')
-    rt.init({ appId: id, getToken: async () => 'stub-token' })
-  }, appId)
+    rt.init({ appId, getToken: async () => token })
+  }, { appId, token })
 }
 
 test('json round-trip + back-compat get/set', async ({ page }) => {


### PR DESCRIPTION
## Summary

- block every private workspace root at commit, push, landing, Docker-build, and CI time
- scan the full history reachable from every pushed ref, including non-HEAD refspecs and preservation branches
- install and verify shared hooks across worktrees, overriding global hook-path bypasses locally
- add end-to-end regression coverage for forced adds, ignored symlinks, add-then-delete history, and push/landing bypasses
- fix the pre-existing AppCanvas e2e race by waiting for Chromium to attach each iframe frame before evaluation
- align storage/outbox e2e mocks with the runtime's scoped app-token contract

## Verification

- `bash -n` and `node --check` on changed scripts/tests
- `scripts/check-private-paths.sh`
- `scripts/test-git-privacy-gates.sh`
- installed-hook pre-push simulation against the exact branch object
- isolated Docker image rebuilt from current `main`: all 20 affected AppCanvas, storage, and outbox cases passed
