### PR TITLE
Fix interrupted drawer touch state

### DIFF
--- a/frontend/src/components/Drawer/Drawer.css
+++ b/frontend/src/components/Drawer/Drawer.css
@@ -22,6 +22,13 @@
 
 .drawer-overlay--visible {
   opacity: 1;
+}
+
+/* `open` becomes false when the close transition STARTS, not when the panel
+   has left the viewport. Keep the fading scrim as the touch/pointer owner until
+   Drawer.jsx observes the panel's transform transitionend (or its fallback),
+   so the app behind never becomes interactive beneath visible drawer pixels. */
+.drawer-overlay--blocking {
   pointer-events: auto;
 }
 

--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -1,10 +1,14 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { Plus, Chats, Grid, DotsVerticalMoreMenu, SettingsCog, Pin, PinFilled } from '@openai/apps-sdk-ui/components/Icon'
 import { Menu } from '@openai/apps-sdk-ui/components/Menu'
 import { EmptyMessage } from '@openai/apps-sdk-ui/components/EmptyMessage'
 import { apiFetch } from '../../api/client.js'
 import { appQueries, chatQueries } from '../../hooks/queries.js'
+import {
+  DRAWER_CLOSE_FALLBACK_MS,
+  clearDrawerGestureStyles,
+} from '../../lib/drawerLifecycle.js'
 import InstallSheet from './InstallSheet.jsx'
 import './Drawer.css'
 
@@ -283,6 +287,41 @@ export default function Drawer({
   // Movement (px) beyond which a gesture is a swipe, not a tap.
   const SWIPE_THRESHOLD = 10
 
+  // The panel's swipe position is an imperative, frame-by-frame DOM write.
+  // React's `open` prop remains authoritative: if navigation closes the drawer
+  // before the browser delivers touchend/touchcancel, clear that stale write in
+  // a layout effect (before paint). Otherwise the inline translateX can keep a
+  // now-inert drawer visibly stranded over the live app forever.
+  useLayoutEffect(() => {
+    if (open) return
+    clearDrawerGestureStyles(drawerRef.current)
+    dragStart.current = null
+    swipingRef.current = false
+  }, [open])
+
+  // Keep the scrim hit-testable while the panel is sliding away. `open` flips
+  // false at the START of the 250ms close transition; dropping pointer-events
+  // in that same render exposes the chat/app while drawer pixels are still on
+  // screen. transitionend is the normal release, with a timeout fallback for
+  // reduced-motion or an interrupted compositor transition.
+  const [scrimBlocking, setScrimBlocking] = useState(open)
+  useLayoutEffect(() => {
+    if (open) setScrimBlocking(true)
+  }, [open])
+  useEffect(() => {
+    if (open || !scrimBlocking) return undefined
+    const timer = setTimeout(
+      () => setScrimBlocking(false),
+      DRAWER_CLOSE_FALLBACK_MS,
+    )
+    return () => clearTimeout(timer)
+  }, [open, scrimBlocking])
+
+  function handleDrawerTransitionEnd(e) {
+    if (open || e.target !== e.currentTarget || e.propertyName !== 'transform') return
+    setScrimBlocking(false)
+  }
+
   function onTouchStart(e) {
     if (!open || e.touches.length !== 1) return
     swipingRef.current = false
@@ -397,7 +436,7 @@ export default function Drawer({
   return (
     <>
       <div
-        className={`drawer-overlay ${open ? 'drawer-overlay--visible' : ''}`}
+        className={`drawer-overlay${open ? ' drawer-overlay--visible' : ''}${scrimBlocking ? ' drawer-overlay--blocking' : ''}`}
         onPointerDown={handleOverlayPointerDown}
       />
       {/* React 19 reflects the boolean `inert` prop to the boolean
@@ -417,6 +456,7 @@ export default function Drawer({
         onTouchMove={onTouchMove}
         onTouchEnd={onTouchEnd}
         onTouchCancel={onTouchCancel}
+        onTransitionEnd={handleDrawerTransitionEnd}
       >
         <div className="drawer__body">
 

--- a/frontend/src/lib/__tests__/drawerLifecycle.test.js
+++ b/frontend/src/lib/__tests__/drawerLifecycle.test.js
@@ -1,0 +1,28 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  DRAWER_CLOSE_FALLBACK_MS,
+  clearDrawerGestureStyles,
+} from '../drawerLifecycle.js'
+
+test('closed drawer cleanup removes an interrupted swipe transform', () => {
+  const removed = []
+  const element = {
+    classList: { remove: (...names) => removed.push(...names) },
+    style: { transform: 'translateX(-25px)' },
+  }
+
+  clearDrawerGestureStyles(element)
+
+  assert.deepEqual(removed, ['drawer--dragging'])
+  assert.equal(element.style.transform, '')
+})
+
+test('drawer cleanup is safe before the panel ref mounts', () => {
+  assert.doesNotThrow(() => clearDrawerGestureStyles(null))
+})
+
+test('close fallback outlasts the 250ms panel transition', () => {
+  assert.ok(DRAWER_CLOSE_FALLBACK_MS > 250)
+})

--- a/frontend/src/lib/drawerLifecycle.js
+++ b/frontend/src/lib/drawerLifecycle.js
@@ -1,0 +1,21 @@
+// Drawer lifecycle helpers keep imperative swipe styling subordinate to the
+// shell's authoritative open/closed state.
+
+// Slightly longer than Drawer.css's 250ms transform transition. This is only
+// a fallback for reduced-motion / interrupted transitions where transitionend
+// does not fire; the normal path releases on the real transform event.
+export const DRAWER_CLOSE_FALLBACK_MS = 350
+
+/**
+ * Remove every DOM mutation made by Drawer.jsx's touch-drag handlers.
+ *
+ * A browser/app navigation can close the drawer before touchend/touchcancel is
+ * delivered. Without an authoritative close cleanup, the stale inline
+ * transform wins over `.drawer { transform: translateX(-100%) }`, leaving a
+ * visually-open panel whose React `open` prop is false (therefore inert).
+ */
+export function clearDrawerGestureStyles(element) {
+  if (!element) return
+  element.classList?.remove?.('drawer--dragging')
+  if (element.style) element.style.transform = ''
+}

--- a/tests/navigation.spec.mjs
+++ b/tests/navigation.spec.mjs
@@ -681,6 +681,67 @@ test.describe('Drawer close paths converge through handleBack', () => {
     expect(contract.overscrollBehavior).toBe('none')
   })
 
+  test('22c. Interrupted drawer swipe cannot strand an inert panel onscreen', async ({ page }) => {
+    await setup(page, { width: 426, height: 860 })
+    await openDrawer(page)
+
+    // Reproduce the mobile failure: a slight horizontal drawer drag writes an
+    // inline transform, then shell navigation closes the drawer before the
+    // browser delivers touchend/touchcancel. The close state must clear that
+    // imperative transform unconditionally rather than trusting a terminal
+    // touch event that may never arrive.
+    await page.locator('.drawer').evaluate((drawer) => {
+      const point = (x, y) => new Touch({
+        identifier: 41,
+        target: drawer,
+        clientX: x,
+        clientY: y,
+      })
+      drawer.dispatchEvent(new TouchEvent('touchstart', {
+        bubbles: true,
+        cancelable: true,
+        touches: [point(220, 420)],
+      }))
+      drawer.dispatchEvent(new TouchEvent('touchmove', {
+        bubbles: true,
+        cancelable: true,
+        touches: [point(195, 420)],
+      }))
+    })
+    expect(await page.locator('.drawer').evaluate((drawer) => drawer.style.transform))
+      .toBe('translateX(-25px)')
+
+    await page.evaluate(() => history.back())
+    await expect(page.getByRole('button', { name: 'Toggle navigation' }))
+      .toHaveAttribute('aria-expanded', 'false')
+    expect(await page.locator('.drawer').evaluate((drawer) => ({
+      inlineTransform: drawer.style.transform,
+      inert: drawer.inert,
+    }))).toEqual({ inlineTransform: '', inert: true })
+    await expect.poll(() => page.locator('.drawer').evaluate(
+      (drawer) => new DOMMatrixReadOnly(getComputedStyle(drawer).transform).m41,
+    )).toBeLessThanOrEqual(-359)
+  })
+
+  test('22d. Closing scrim blocks the app until the panel is offscreen', async ({ page }) => {
+    await setup(page, { width: 426, height: 860 })
+    await openDrawer(page)
+    await page.locator('.drawer-overlay').dispatchEvent('pointerdown', {
+      button: 0,
+      isPrimary: true,
+      pointerId: 7,
+      pointerType: 'touch',
+    })
+
+    await expect(page.getByRole('button', { name: 'Toggle navigation' }))
+      .toHaveAttribute('aria-expanded', 'false')
+    await expect(page.locator('.drawer-overlay')).toHaveCSS('pointer-events', 'auto')
+    await expect.poll(() => page.locator('.drawer').evaluate(
+      (drawer) => new DOMMatrixReadOnly(getComputedStyle(drawer).transform).m41,
+    )).toBeLessThanOrEqual(-359)
+    await expect(page.locator('.drawer-overlay')).toHaveCSS('pointer-events', 'none')
+  })
+
   test('23. X-button (toggle) closes drawer (does not navigate, even from deep view)', async ({ page }) => {
     // Same regression as test 22 but via the toggle button. test 9
     // covers the basic case from a non-default view; this test just


### PR DESCRIPTION
## Summary

- clear stale swipe positioning whenever shell state closes the drawer
- keep the closing scrim hit-testable until the panel is fully offscreen
- add lifecycle and mobile navigation regressions for interrupted touch sequences

## Testing

- `npm test`
- `npm run build`
- `bash scripts/check-core-apps-sync.sh`
- targeted Playwright drawer regressions (22c and 22d)