### PR TITLE
Prevent tool-heavy chat turns from hiding the transcript

### DIFF
--- a/frontend/src/components/ChatView/__tests__/chatContract.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatContract.test.js
@@ -306,6 +306,18 @@ test('mirrored constants stay in sync with useScrollMode.js (sync obligation)', 
   )
 })
 
+test('the transcript reveal safety deadline cannot be reset by message churn', () => {
+  const src = readFileSync(new URL('../useScrollMode.js', import.meta.url), 'utf8')
+  const deadline = src.indexOf('Absolute reveal deadline for this mounted chat')
+  const messagesEffect = src.indexOf('Single layout effect: spacer sizing')
+  assert.ok(deadline >= 0 && deadline < messagesEffect,
+    'the safety deadline is owned outside the messages-dependent layout effect')
+  assert.match(src.slice(deadline, messagesEffect), /\}, \[chatId\]\)/,
+    'the safety deadline resets only when the mounted chat changes')
+  assert.doesNotMatch(src.slice(messagesEffect), /clearTimeout\(safetyReveal\)/,
+    'message/layout cleanup cannot cancel and restart the absolute deadline')
+})
+
 test('every predicate id is registered in CHAT_CONTRACT (registry is the map)', () => {
   const registered = new Set(CHAT_CONTRACT.map(c => c.id))
   for (const c of CHAT_CONTRACT) {

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -448,6 +448,21 @@ export default function useScrollMode({
   // already changed, so we need the last known pre-change tail snapshot.
   const nearScrollBottomRef = useRef(false)
 
+  // Absolute reveal deadline for this mounted chat. This deliberately lives
+  // outside the messages-dependent layout effect below: tool-rich turns can
+  // re-run that effect continuously, and clearing/restarting its local safety
+  // timer kept the ENTIRE transcript visibility:hidden indefinitely.
+  useLayoutEffect(() => {
+    revealedRef.current = false
+    setRevealed(false)
+    const deadline = setTimeout(() => {
+      if (revealedRef.current) return
+      revealedRef.current = true
+      setRevealed(true)
+    }, REVEAL_CAP_MS)
+    return () => clearTimeout(deadline)
+  }, [chatId])
+
   const persistMode = ({ freezeToCurrentPosition = false } = {}) => {
     try {
       const mode = freezeToCurrentPosition
@@ -661,11 +676,10 @@ export default function useScrollMode({
     // streaming) doesn't strand the chat hidden.
     let revealTimer = 0
     const requestRevealOnQuiet = () => {
-      if (revealed || revealedOnce) return
+      if (revealedRef.current) return
       clearTimeout(revealTimer)
       revealTimer = setTimeout(() => {
         if (scrollRef.current === scrollEl) syncLayout()
-        revealedOnce = true
         revealedRef.current = true
         setRevealed(true)
       }, 50)
@@ -685,11 +699,6 @@ export default function useScrollMode({
     //                   jitter so we stop.
     //   PIN_USER_MSG  — never re-applied; same jitter risk.
     //
-    // `revealedOnce` mirrors `revealed` at effect-start so re-runs of
-    // this effect on an already-revealed chat (messages change, etc.)
-    // don't re-enter the during-reveal branch and cause mid-stream
-    // jitter.
-    let revealedOnce = revealed
     const ro = new ResizeObserver(() => {
       if (scrollEl.clientHeight > fullViewHRef.current) {
         fullViewHRef.current = scrollEl.clientHeight
@@ -697,7 +706,7 @@ export default function useScrollMode({
       sizeSpacer()
       const k = modeRef.current.kind
       if (k === 'FOLLOW_BOTTOM'
-          || (k === 'ANCHOR_AT' && !revealedOnce)) {
+          || (k === 'ANCHOR_AT' && !revealedRef.current)) {
         applyMode(scrollEl, modeRef.current)
         nearScrollBottomRef.current = isNearScrollBottom(scrollEl)
       } else if (k === 'PIN_USER_MSG') {
@@ -806,21 +815,14 @@ export default function useScrollMode({
     // Hide-then-reveal: kick off the quiet-debounce path immediately
     // (reveals ~50ms after the last RO firing, smoothing out
     // late-settling renderers like markdown/KaTeX/question cards).
-    // Capped at REVEAL_CAP_MS so a perpetually-mutating layout
-    // (live streaming) can't strand the chat hidden indefinitely.
-    let safetyReveal = 0
+    // The absolute reveal deadline is owned by the chatId-only effect above,
+    // so message and tool churn cannot reset it.
     if (!revealed) {
       requestRevealOnQuiet()
-      safetyReveal = setTimeout(() => {
-        revealedOnce = true
-        revealedRef.current = true
-        setRevealed(true)
-      }, REVEAL_CAP_MS)
     }
 
     return () => {
       clearTimeout(ioBounceTimer)
-      clearTimeout(safetyReveal)
       clearTimeout(revealTimer)
       io?.disconnect()
       ro.disconnect()


### PR DESCRIPTION
## Summary
- give each mounted chat one absolute transcript-reveal deadline
- keep the quiet-layout reveal path without allowing message or tool churn to reset the safety cap
- add a regression check that keeps the deadline outside the messages-dependent layout effect

## Why
The chat view initially hides the transcript while markdown, code highlighting, questions, and tool blocks settle. The quiet-layout timer is intentionally debounced, but the safety timer lived in the same effect that reruns whenever messages change. Tool-heavy turns repeatedly cleaned up and restarted that timer, so the entire transcript could remain hidden indefinitely even though every row was mounted.

The deadline is now owned by a chat-only layout effect. Tool and message updates can still delay the quiet-path reveal, but cannot extend the hard cap.

This is a focused fix discovered while validating the broader chat contract in #50 and can merge independently.

## Testing
- `node --test frontend/src/components/ChatView/__tests__/chatContract.test.js frontend/src/components/ChatView/__tests__/useScrollMode.test.js` — 61 tests pass
- `npm --prefix frontend run build` — passes
- authenticated browser reproduction with an active tool-heavy turn — 40 rows mounted and the transcript became visible within the deadline