### PR TITLE
Resume Codex threads containing sub-agent activity

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     fonts-liberation fonts-noto-color-emoji \
     && npm install -g esbuild@0.28.1 \
     && npm install -g @anthropic-ai/claude-code@2.1.207 \
-    && npm install -g @openai/codex@0.144.3 \
+    && npm install -g @openai/codex@0.144.4 \
     && npm install -g agent-browser@0.31.1 \
     && agent-browser install \
     && mv /root/.agent-browser /opt/agent-browser \
@@ -110,14 +110,14 @@ RUN pip install --no-cache-dir -r requirements.txt
 # upstream pyproject pins openai-codex-cli-bin==0.137.0a4. Install
 # --no-deps so Docker keeps the exact runtime pin below explicit.
 # Pinned to commit SHA (not tag) for full reproducibility — tags are
-# mutable on GitHub. SHA corresponds to refs/tags/rust-v0.144.3 as of
-# 2026-07-13. The SDK exposes the request bridge as a public
+# mutable on GitHub. SHA corresponds to refs/tags/rust-v0.144.4 as of
+# 2026-07-14. The SDK exposes the request bridge as a public
 # `approval_handler` constructor argument on
 # `openai_codex.client.CodexClient`; `AsyncCodex` still does not forward
 # it, so codex_sdk_runner.py installs the handler on the wrapped sync
 # client's `_approval_handler`.
 RUN pip install --no-cache-dir --no-deps \
-      'openai-codex @ git+https://github.com/openai/codex.git@78ad6e6bfd1d3b6a209acd3ef82172a96b25179c#subdirectory=sdk/python' \
+      'openai-codex @ git+https://github.com/openai/codex.git@8c68d4c87dc54d38861f5114e920c3de2efa5876#subdirectory=sdk/python' \
     && pip install --no-cache-dir 'openai-codex-cli-bin==0.137.0a4'
 
 # Capture each installed agent CLI's npm publish date into a small JSON the

--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -195,7 +195,7 @@ def _sdk_imports() -> dict[str, Any]:
   freely. TG-NEW should add a contract test that imports these symbols
   at test time so breakage is caught immediately.
   """
-  from openai_codex import ApprovalMode, AsyncCodex, Sandbox
+  from openai_codex import ApprovalMode, AsyncCodex, AsyncThread, Sandbox
   from openai_codex.client import CodexConfig
   from openai_codex.errors import CodexRpcError, InvalidParamsError
   from openai_codex.types import ReasoningEffort, ReasoningSummary
@@ -226,6 +226,7 @@ def _sdk_imports() -> dict[str, Any]:
     "AgentMessageThreadItem": AgentMessageThreadItem,
     "ApprovalMode": ApprovalMode,
     "AsyncCodex": AsyncCodex,
+    "AsyncThread": AsyncThread,
     "CodexConfig": CodexConfig,
     "CodexRpcError": CodexRpcError,
     "CommandExecutionOutputDeltaNotification": (
@@ -260,6 +261,94 @@ def _sdk_imports() -> dict[str, Any]:
     "TurnCompletedNotification": TurnCompletedNotification,
     "WebSearchThreadItem": WebSearchThreadItem,
   }
+
+
+def _is_subagent_activity_resume_validation_error(exc: Exception) -> bool:
+  """Whether a typed resume failed only on valid sub-agent history items.
+
+  Codex 0.143+ persists `subAgentActivity` ThreadItems, but the beta Python
+  SDK's generated ThreadItem union is still based on its 0.137 runtime and
+  does not include that variant. `thread/resume` has already succeeded in the
+  app-server before response-model validation raises, so the caller can safely
+  construct the public AsyncThread handle for the requested thread.
+
+  Keep this deliberately narrow. Any other validation drift must continue to
+  fail loudly rather than being mistaken for a successful resume.
+  """
+  errors_method = getattr(exc, "errors", None)
+  if not callable(errors_method):
+    return False
+  try:
+    errors = errors_method(include_url=False)
+  except TypeError:
+    errors = errors_method()
+  if not errors:
+    return False
+
+  required_fields = {
+    "type",
+    "id",
+    "kind",
+    "agentThreadId",
+    "agentPath",
+  }
+  item_locations: set[tuple[Any, ...]] = set()
+  validated_item_locations: set[tuple[Any, ...]] = set()
+  for error in errors:
+    if not isinstance(error, dict):
+      return False
+    location = tuple(error.get("loc", ()))
+    item = error.get("input")
+    if (
+      len(location) < 5
+      or location[0:2] != ("thread", "turns")
+      or location[3] != "items"
+    ):
+      return False
+    item_location = location[:5]
+    item_locations.add(item_location)
+    if isinstance(item, dict):
+      if (
+        item.get("type") != "subAgentActivity"
+        or not required_fields.issubset(item)
+      ):
+        return False
+      validated_item_locations.add(item_location)
+    elif item != "subAgentActivity":
+      # Pydantic reports literal discriminator failures against the string
+      # value itself, while missing-field failures carry the whole item.
+      return False
+  return item_locations == validated_item_locations
+
+
+async def _resume_codex_thread(
+  codex: Any,
+  session_id: str,
+  *,
+  sdk: dict[str, Any],
+  approval_mode: Any,
+  sandbox: Any,
+  cwd: str,
+  model: str | None,
+) -> Any:
+  """Resume a thread, tolerating the SDK's one known history-model gap."""
+  try:
+    return await codex.thread_resume(
+      session_id,
+      approval_mode=approval_mode,
+      sandbox=sandbox,
+      cwd=cwd,
+      model=model,
+    )
+  except Exception as exc:
+    if not _is_subagent_activity_resume_validation_error(exc):
+      raise
+    log.warning(
+      "Codex Python SDK rejected subAgentActivity history while resuming "
+      "thread %s; using the already-resumed public AsyncThread handle",
+      session_id,
+    )
+    return sdk["AsyncThread"](codex, session_id)
 
 
 def _model_dump(value: Any) -> Any:
@@ -1003,8 +1092,10 @@ async def run_codex_sdk_turn(
           model=model,
         )
       else:
-        thread = await codex.thread_resume(
+        thread = await _resume_codex_thread(
+          codex,
           session_id,
+          sdk=sdk,
           approval_mode=sdk["ApprovalMode"].auto_review,
           sandbox=_sandbox,
           cwd=cwd,

--- a/backend/tests/test_codex_sdk_contract.py
+++ b/backend/tests/test_codex_sdk_contract.py
@@ -35,6 +35,8 @@ See CLAUDE.md "Codex `_approval_handler` patch — known fragility" for
 the broader context.
 """
 
+import json
+
 import pytest
 
 
@@ -123,3 +125,26 @@ def test_request_user_input_bridge_has_no_user_answer_timeout():
   assert "fut.result()" in source
   assert "fut.result(timeout=" not in source
   assert "_BRIDGE_USER_ANSWER_TIMEOUT" not in source
+
+
+def test_subagent_activity_resume_compatibility_is_still_required():
+  """Trip when the SDK grows native `subAgentActivity` support.
+
+  Möbius currently resumes 0.143+ histories through a narrow compatibility
+  path because the beta Python SDK's generated ThreadItem union still targets
+  its 0.137 runtime. Once upstream adds the item, a dependency bump must fail
+  here until we remove that path and explicitly decide how live and replayed
+  sub-agent activity should appear in Möbius. This prevents native support
+  from being silently masked by a stale workaround.
+  """
+  pytest.importorskip("openai_codex")
+  from openai_codex.generated import v2_all
+
+  schema = json.dumps(v2_all.ThreadItem.model_json_schema())
+  native_model = getattr(v2_all, "SubAgentActivityThreadItem", None)
+  assert native_model is None and "subAgentActivity" not in schema, (
+    "The Codex Python SDK now exposes native subAgentActivity ThreadItems. "
+    "Remove _resume_codex_thread's compatibility fallback, import the native "
+    "item in _sdk_imports, and explicitly handle its live/replayed behavior "
+    "before accepting this SDK bump."
+  )

--- a/backend/tests/test_codex_sdk_runner.py
+++ b/backend/tests/test_codex_sdk_runner.py
@@ -471,6 +471,124 @@ def test_run_codex_sdk_turn_resume_skips_skill_lookup(monkeypatch):
   assert registry.get_handle("chat-1", RunnerKind.CODEX_SDK) is None
 
 
+def test_run_codex_sdk_turn_resumes_subagent_activity_history(monkeypatch, caplog):
+  completed_turn = SimpleNamespace(id="turn-1", usage=None, error=None)
+  turn_handle = _FakeTurnHandle([
+    SimpleNamespace(
+      method="turn/completed",
+      payload=_FakeTurnCompletedNotification(completed_turn),
+    )
+  ])
+
+  activities = [
+    ("started", "/root/scout"),
+    ("started", "/root/builder"),
+    ("started", "/root/reviewer"),
+    ("interacted", "/root/reviewer"),
+    ("interrupted", "/root/reviewer"),
+    ("interacted", "/root/reviewer"),
+  ]
+
+  class ResumeValidationError(Exception):
+    def errors(self, include_url=False):
+      del include_url
+      errors = []
+      for item_index, (kind, agent_path) in enumerate(activities):
+        item = {
+          "type": "subAgentActivity",
+          "id": f"activity-{item_index}",
+          "kind": kind,
+          "agentThreadId": f"thread-{item_index}",
+          "agentPath": agent_path,
+        }
+        for variant_index in range(44):
+          errors.append({
+            "loc": (
+              "thread",
+              "turns",
+              1,
+              "items",
+              item_index,
+              f"KnownThreadItem{variant_index}",
+              "type",
+            ),
+            "input": item if variant_index % 2 == 0 else "subAgentActivity",
+          })
+      return errors
+
+  class FakeAsyncCodex:
+    def __init__(self, config=None):
+      self.config = config
+
+    async def __aenter__(self):
+      return self
+
+    async def __aexit__(self, _exc_type, _exc, _tb):
+      return None
+
+    async def thread_resume(self, *_args, **_kwargs):
+      raise ResumeValidationError("264 validation errors for ThreadResumeResponse")
+
+  sdk = _fake_sdk(FakeAsyncCodex)
+  sdk["AsyncThread"] = lambda _codex, thread_id: _FakeThread(
+    thread_id,
+    turn_handle,
+  )
+  monkeypatch.setattr(codex_sdk_runner, "_sdk_imports", lambda: sdk)
+
+  bc = _FakeBroadcast()
+  with caplog.at_level("WARNING", logger="moebius.chat"):
+    result = asyncio.run(
+      codex_sdk_runner.run_codex_sdk_turn(
+        user_message="continue",
+        session_id="requested-thread",
+        base_env={},
+        cwd="/tmp",
+        chat_id="chat-1",
+        bc=bc,
+        pending_questions={},
+        db=None,
+      )
+    )
+
+  assert result == {
+    "session_id": "requested-thread",
+    "cost_usd": None,
+    "error": None,
+  }
+  assert bc.events == [{
+    "type": "session_init",
+    "session_id": "requested-thread",
+  }]
+  assert "rejected subAgentActivity history" in caplog.text
+
+
+def test_subagent_activity_resume_compat_rejects_mixed_schema_drift():
+  class MixedValidationError(Exception):
+    def errors(self, include_url=False):
+      del include_url
+      return [
+        {
+          "loc": ("thread", "turns", 1, "items", 3, "KnownItem", "type"),
+          "input": {
+            "type": "subAgentActivity",
+            "id": "activity-1",
+            "kind": "started",
+            "agentThreadId": "thread-1",
+            "agentPath": "/root/scout",
+          },
+        },
+        {
+          "loc": ("thread", "model"),
+          "input": {"unexpected": "response drift"},
+        },
+      ]
+
+  assert codex_sdk_runner._is_subagent_activity_resume_validation_error(
+    MixedValidationError(),
+  ) is False
+
+
 def test_run_codex_sdk_turn_aborts_after_turn_before_stream_registration(monkeypatch):
   completed_turn = SimpleNamespace(id="turn-1", usage=None, error=None)
   turn_handle = _FakeTurnHandle([


### PR DESCRIPTION
## Summary

- update the Codex CLI and Python SDK source pins to the stable 0.144.4 release
- resume threads when the Python SDK rejects only well-formed `subAgentActivity` history items after app-server has already resumed the thread
- keep unrelated response-schema drift fail-closed
- add a contract tripwire that forces removal of the compatibility path when native SDK support lands

## Context

Codex 0.143+ persists completion-only `subAgentActivity` thread items, while the beta Python SDK's generated `ThreadItem` union still targets its 0.137 runtime and cannot deserialize them. A resumed multi-agent thread therefore fails with a large Pydantic union error even though app-server has already completed `thread/resume`.

This change recognizes only that exact validation shape and constructs the public `AsyncThread` handle for the already-resumed thread. It does not delete, rewrite, or fabricate thread history. Any mixed or unrelated validation failure still propagates.

The contract test intentionally fails once the SDK exposes native `subAgentActivity` support so the compatibility path cannot silently mask the real feature after a future dependency bump.

## Testing

- `pytest -q tests/test_codex_sdk_runner.py tests/test_codex_sdk_contract.py tests/test_codex_provider.py tests/test_settings.py` (89 passed)
- `bash scripts/check-core-apps-sync.sh`
- verified against a real resumed thread containing six sub-agent activity items
- full backend run: six unrelated environment-dependent failures in build-stamp, platform-clone, and serving-source tests; no failures in the Codex path