### PR TITLE
Prevent passive shell rebuilds from interrupting readers

### DIFF
--- a/backend/scripts/agent-screenshot.sh
+++ b/backend/scripts/agent-screenshot.sh
@@ -111,6 +111,21 @@ agent-browser wait --fn \
   "!document.querySelector('input[type=password]')" >/dev/null 2>&1 || \
   agent-browser wait 1500 >/dev/null
 
+# The readiness wait above is deliberately bounded, but its old fallback then
+# continued unconditionally. If the token was rejected or expired, the helper
+# silently captured the login wall and reported success — indistinguishable
+# from a real product screenshot until the agent inspected the PNG. Verify the
+# post-navigation auth state explicitly and fail before writing any image.
+# Never print the token itself; only test that it survived the shell's 401
+# interceptor and that the login form is absent.
+AUTH_OK="$(agent-browser eval \
+  "!!localStorage.getItem('token') && !document.querySelector('input[type=password]')" \
+  2>/dev/null || true)"
+if [ "$AUTH_OK" != "true" ]; then
+  echo "agent-screenshot.sh: authentication failed; the token was rejected or the login page remained visible" >&2
+  exit 1
+fi
+
 # Dismiss the PWA install banner if it surfaces — it covers the bottom
 # of the view and would distract from the actual page.
 agent-browser find text "Not now" click >/dev/null 2>&1 || true

--- a/backend/tests/test_agent_screenshot_auth.py
+++ b/backend/tests/test_agent_screenshot_auth.py
@@ -1,0 +1,70 @@
+"""Regression coverage for authenticated screenshot readiness checks."""
+
+from pathlib import Path
+import os
+import subprocess
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "agent-screenshot.sh"
+
+
+def _fake_browser(tmp_path: Path) -> tuple[Path, Path]:
+  marker = tmp_path / "screenshot-called"
+  browser = tmp_path / "agent-browser"
+  browser.write_text(
+    "#!/bin/sh\n"
+    "case \"$1\" in\n"
+    "  eval)\n"
+    "    if [ \"$2\" = \"--stdin\" ]; then cat >/dev/null; exit 0; fi\n"
+    "    printf '%s\\n' \"${FAKE_AUTH_OK:-false}\"\n"
+    "    ;;\n"
+    "  screenshot)\n"
+    "    : > \"$2\"\n"
+    "    : > \"$FAKE_SCREENSHOT_MARKER\"\n"
+    "    ;;\n"
+    "  *) exit 0 ;;\n"
+    "esac\n",
+    encoding="utf-8",
+  )
+  browser.chmod(0o755)
+  return browser, marker
+
+
+def _run_helper(tmp_path: Path, *, auth_ok: bool) -> tuple[subprocess.CompletedProcess, Path, Path]:
+  _, marker = _fake_browser(tmp_path)
+  output = tmp_path / "shot.png"
+  env = {
+    **os.environ,
+    "PATH": f"{tmp_path}:{os.environ['PATH']}",
+    "AGENT_TOKEN": "test-token",
+    "API_BASE_URL": "http://mobius.test",
+    "VIEWPORT_WIDTH": "412",
+    "VIEWPORT_HEIGHT": "915",
+    "FAKE_AUTH_OK": "true" if auth_ok else "false",
+    "FAKE_SCREENSHOT_MARKER": str(marker),
+  }
+  result = subprocess.run(
+    ["bash", str(SCRIPT), "/chat/example", str(output)],
+    env=env,
+    text=True,
+    capture_output=True,
+    check=False,
+  )
+  return result, output, marker
+
+
+def test_helper_refuses_to_capture_login_wall(tmp_path: Path):
+  result, output, marker = _run_helper(tmp_path, auth_ok=False)
+
+  assert result.returncode != 0
+  assert "authentication failed" in result.stderr
+  assert not output.exists()
+  assert not marker.exists()
+
+
+def test_helper_captures_after_authentication_is_confirmed(tmp_path: Path):
+  result, output, marker = _run_helper(tmp_path, auth_ok=True)
+
+  assert result.returncode == 0, result.stderr
+  assert output.exists()
+  assert marker.exists()

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -34,6 +34,7 @@
 
 import { useState, useRef, useLayoutEffect, useCallback } from 'react'
 import { cidOf } from './chatRuntimeState.js'
+import { BEFORE_SHELL_RELOAD_EVENT } from '../../lib/shellReloadEvents.js'
 
 
 // Hide-then-reveal safety cap. Code-block-heavy chats with KaTeX and
@@ -482,10 +483,12 @@ export default function useScrollMode({
     }
     window.addEventListener('pagehide', onPageLeaving)
     window.addEventListener('beforeunload', onPageLeaving)
+    window.addEventListener(BEFORE_SHELL_RELOAD_EVENT, onPageLeaving)
     document.addEventListener('visibilitychange', onVisibilityChange)
     return () => {
       window.removeEventListener('pagehide', onPageLeaving)
       window.removeEventListener('beforeunload', onPageLeaving)
+      window.removeEventListener(BEFORE_SHELL_RELOAD_EVENT, onPageLeaving)
       document.removeEventListener('visibilitychange', onVisibilityChange)
     }
   }, [chatId])

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -32,6 +32,7 @@ import {
 } from './workspacePlacement.js'
 import { appBuildFailureMessage } from '../../lib/appBuildFailure.js'
 import { shellRebuildFailureMessage } from '../../lib/shellRebuildFailure.js'
+import { BEFORE_SHELL_RELOAD_EVENT } from '../../lib/shellReloadEvents.js'
 import {
   freshChatBuiltApps,
   freshAppIds,
@@ -136,6 +137,9 @@ export default function Shell() {
     })
   }, [])
   const pendingShellReloadRef = useRef(false)
+  // False wins when several requests coalesce: an explicit shell_apply_now
+  // promotes an already-pending passive watcher rebuild to deliberate apply.
+  const pendingShellReloadPassiveRef = useRef(false)
   const shellReloadTimerRef = useRef(null)
   const lastShellInteractionAtRef = useRef(0)
   // Guards the once-per-mount deferred shell-update pickup effect below.
@@ -167,21 +171,26 @@ export default function Shell() {
     }
   }
 
-  async function performShellReload() {
+  async function performShellReload({ passive = false } = {}) {
     let stalePrecache = false
     try { stalePrecache = sessionStorage.getItem('sw-stale-precache-pending') === '1' } catch { /* ignore */ }
     if (stalePrecache && navigator.onLine === false) {
       // An offline reload is safe only while the existing precache remains
       // intact; purging Workbox offline can strand an installed PWA on the
       // fallback page, so stale recovery waits for an online idle boundary.
-      deferShellReload()
+      deferShellReload({ passive })
       return
     }
     pendingShellReloadRef.current = false
+    pendingShellReloadPassiveRef.current = false
     if (shellReloadTimerRef.current) {
       clearTimeout(shellReloadTimerRef.current)
       shellReloadTimerRef.current = null
     }
+    // Capture view-owned transient state synchronously, before the
+    // service-worker handoff can let layout/data change underneath it.
+    // ChatView uses this to persist the exact visible message anchor.
+    window.dispatchEvent(new Event(BEFORE_SHELL_RELOAD_EVENT))
     sessionStorage.setItem('shell-reload', JSON.stringify(shellReloadState()))
     // Match the manifest scope so the post-reload page lands inside
     // the installed PWA's declared scope — writing `/` here would
@@ -241,12 +250,13 @@ export default function Shell() {
     }
   }
 
-  function shellReloadWouldDisruptUser() {
+  function shellReloadWouldDisruptUser({ passive = false } = {}) {
     return shouldDeferShellReload({
       activeElement: document.activeElement,
       activeView: activeViewRef.current,
       activeChatId: activeChatIdRef.current,
       streamingChatIds: streamingChatIdsRef.current,
+      passiveRebuild: passive,
       voiceDictationActive: voiceDictationActiveRef.current,
       lastUserInteractionAt: lastShellInteractionAtRef.current,
       visibilityState: document.visibilityState,
@@ -258,24 +268,28 @@ export default function Shell() {
     shellReloadTimerRef.current = setTimeout(() => {
       shellReloadTimerRef.current = null
       if (!pendingShellReloadRef.current) return
-      if (shellReloadWouldDisruptUser()) {
+      const passive = pendingShellReloadPassiveRef.current
+      if (shellReloadWouldDisruptUser({ passive })) {
         scheduleShellReloadCheck()
       } else {
-        performShellReload()
+        performShellReload({ passive })
       }
     }, SHELL_RELOAD_RECHECK_MS)
   }
 
-  function deferShellReload() {
+  function deferShellReload({ passive = false } = {}) {
+    pendingShellReloadPassiveRef.current = pendingShellReloadRef.current
+      ? (pendingShellReloadPassiveRef.current && passive)
+      : passive
     pendingShellReloadRef.current = true
     scheduleShellReloadCheck()
   }
 
-  function requestShellReload() {
-    if (shellReloadWouldDisruptUser()) {
-      deferShellReload()
+  function requestShellReload({ passive = false } = {}) {
+    if (shellReloadWouldDisruptUser({ passive })) {
+      deferShellReload({ passive })
     } else {
-      performShellReload()
+      performShellReload({ passive })
     }
   }
 
@@ -1000,7 +1014,7 @@ export default function Shell() {
       shellUpdatePickupRef.current = true
       // requestShellReload reads streaming/view state from refs at call time, so
       // the captured closure is fresh even though it isn't in this effect's deps.
-      requestShellReload()
+      requestShellReload({ passive: true })
     })()
     return () => { cancelled = true }
   }, [chatsQuery.isSuccess, chatsQuery.isFetchedAfterMount])
@@ -1079,8 +1093,10 @@ export default function Shell() {
     } else if (ev.type === 'shell_rebuilt' || ev.type === 'shell_apply_now') {
       // A new shell generation is available. `shell_rebuilt` fires automatically
       // when the frontend rebuilds; `shell_apply_now` is the agent's EXPLICIT
-      // "look now" signal (design §1.5). Both carry identical client policy —
-      // apply if idle, else hold — so they share this branch.
+      // "look now" signal (design §1.5). A watcher rebuild is passive and
+      // coalesces while an idle chat is visible; apply-now is deliberate and
+      // uses the ordinary apply-on-idle policy. This prevents source-save
+      // bursts from repeatedly refreshing a transcript someone is reading.
       //
       // These are system-bus-only (frontend_watcher / notify skip the per-chat
       // fan-out) and SystemBroadcast has no replay, so each reaches the Shell
@@ -1095,7 +1111,7 @@ export default function Shell() {
       // leash rides the same moment: performShellReload posts SKIP_WAITING to
       // the waiting worker so the SW generation flips exactly when the page
       // reloads.
-      requestShellReload()
+      requestShellReload({ passive: ev.type === 'shell_rebuilt' })
     } else if (ev.type === 'shell_rebuild_failed') {
       // System-bus-only, delivered once — no dedup stamp.
       showToast(shellRebuildFailureMessage(ev), {

--- a/frontend/src/components/Shell/__tests__/shellReloadPolicy.test.js
+++ b/frontend/src/components/Shell/__tests__/shellReloadPolicy.test.js
@@ -60,6 +60,35 @@ test('recent interaction defers visible shell reloads', () => {
   }), false)
 })
 
+test('passive watcher rebuilds coalesce while an idle chat is visible', () => {
+  const base = {
+    activeElement: el('body'),
+    activeView: 'chat',
+    activeChatId: 'c1',
+    streamingChatIds: new Set(),
+    lastUserInteractionAt: 0,
+    now: 10000,
+  }
+  assert.equal(shouldDeferShellReload({
+    ...base,
+    passiveRebuild: true,
+  }), true)
+  assert.equal(shouldDeferShellReload({
+    ...base,
+    passiveRebuild: false,
+  }), false, 'a deliberate apply-now still uses normal idle policy')
+  assert.equal(shouldDeferShellReload({
+    ...base,
+    activeView: 'canvas',
+    passiveRebuild: true,
+  }), false, 'leaving the chat releases a queued watcher rebuild')
+  assert.equal(shouldDeferShellReload({
+    ...base,
+    passiveRebuild: true,
+    visibilityState: 'hidden',
+  }), false, 'a hidden page is a safe apply boundary')
+})
+
 test('hidden pages can reload without disrupting focus', () => {
   assert.equal(shouldDeferShellReload({
     activeElement: el('textarea'),

--- a/frontend/src/components/Shell/shellReloadPolicy.js
+++ b/frontend/src/components/Shell/shellReloadPolicy.js
@@ -62,12 +62,19 @@ export function shouldDeferShellReload({
   activeView,
   activeChatId,
   streamingChatIds,
+  passiveRebuild = false,
   voiceDictationActive = false,
   lastUserInteractionAt = 0,
   now = Date.now(),
   visibilityState = 'visible',
 } = {}) {
   if (visibilityState === 'hidden') return false
+  // Watcher rebuilds are noisy implementation detail: a burst of source saves
+  // can publish several generations while the owner is simply reading an idle
+  // chat. Keep those generations coalesced until the chat is no longer the
+  // visible surface. A deliberate shell_apply_now is not passive and continues
+  // through the ordinary apply-on-idle policy below.
+  if (passiveRebuild && activeView === 'chat' && activeChatId != null) return true
   if (hasProtectedEditingContent(activeElement)) return true
   if (hasActiveChatTurn({ activeView, activeChatId, streamingChatIds })) return true
   // A reload mid-dictation would drop the in-flight transcript, so hold it

--- a/frontend/src/lib/shellReloadEvents.js
+++ b/frontend/src/lib/shellReloadEvents.js
@@ -1,0 +1,3 @@
+/** Shared event names for the shell-to-view handoff before a hard reload. */
+
+export const BEFORE_SHELL_RELOAD_EVENT = 'mobius:before-shell-reload'

--- a/tests/shell-update-idle.spec.mjs
+++ b/tests/shell-update-idle.spec.mjs
@@ -8,28 +8,27 @@
  *   1. shell_rebuilt DURING a streaming turn does NOT reload; the reload is held
  *      QUIETLY (shellReloadPolicy.shouldDeferShellReload) until idle — no toast,
  *      no popup — and the live turn keeps rendering.
- *   2. a shell_rebuilt that lands mid-turn reloads exactly ONCE at the idle
- *      boundary (the hold-until-idle recheck fires after the turn reaches
- *      `done`), and does not loop.
- *   3. shell_rebuilt delivered on the GLOBAL system stream while idle applies
- *      immediately (reloads once; the dedup window prevents a loop).
+ *   2. passive shell_rebuilt generations stay coalesced while an idle chat is
+ *      visible, so source-save bursts cannot interrupt a reader.
+ *   3. deliberate shell_apply_now still reloads exactly ONCE at the idle
+ *      boundary and does not loop.
  *   4. after a REAL SW update (a genuinely new, WAITING worker), an idle apply
  *      lands the page on the NEW generation — controlled by the registration's
- *      ACTIVE worker with nothing left waiting. Cases 1-3 assert apply-ONCE but
- *      never WHICH generation the page ends on; feature 207 is precisely an
- *      apply that reloads back onto the OUTGOING generation and sticks, so this
- *      case pins generation identity (the gap that let 207 ship).
+ *      ACTIVE worker with nothing left waiting. Deliberate-apply cases assert
+ *      apply-ONCE but never WHICH generation the page ends on; feature 207 is
+ *      precisely an apply that reloads onto the OUTGOING generation and sticks,
+ *      so this case pins generation identity (the gap that let 207 ship).
  *
  * SYNTHESIS NOTES — why these differ from a naive mock:
  *   - shell_rebuilt is SYSTEM-BUS-ONLY: the backend never fans it out to
  *     per-chat broadcasts (a chat reconnect replaying a stale rebuilt would
  *     fire a spurious apply), so the mock delivers it over /api/events/system.
  *     The mocked system route mirrors the REAL SystemBroadcast contract — live
- *     delivery, NO replay on reconnect (oneShotRebuiltSystemRoute) — which is
+ *     delivery, NO replay on reconnect (oneShotSystemEventRoute) — which is
  *     exactly why the client needs no dedup stamps, and why a mock that
  *     redelivered on every reconnect would (rightly) reload-loop.
- *   - The reload is HELD via a recheck timer, not an event-driven boundary, so
- *     the idle apply in case 2 lands a few seconds after `done` — the waits
+ *   - A deliberate reload is HELD via a recheck timer, not an event-driven
+ *     boundary, so the idle apply lands a few seconds after `done` — the waits
  *     account for that.
  *   - The mechanism is QUIET (the sibling's "Quiet shell maintenance popups"):
  *     there is no toast to assert. The observable is the reload counter.
@@ -71,7 +70,7 @@ function fulfillStream(body) {
 // replay on reconnect is the load-bearing property: with the sessionStorage
 // dedup stamps gone, single delivery is what prevents a reload loop, so a
 // mock that redelivered would fail these cases for the right reason.
-function oneShotRebuiltSystemRoute(armed) {
+function oneShotSystemEventRoute(eventType, armed) {
   let delivered = false
   return async (route) => {
     try {
@@ -83,7 +82,7 @@ function oneShotRebuiltSystemRoute(armed) {
         if (!delivered) {
           await route.fulfill(fulfillStream(sse([
             { type: 'system_stream_open' },
-            { type: 'shell_rebuilt' },
+            { type: eventType },
           ])))
           delivered = true
           return
@@ -164,7 +163,7 @@ test.describe('shell update — apply on idle, SW on a leash', () => {
     ])
     await setup(page, {
       streamRoute: route => route.fulfill(fulfillStream(streamingBody)),
-      systemRoute: oneShotRebuiltSystemRoute(armed),
+      systemRoute: oneShotSystemEventRoute('shell_rebuilt', armed),
     })
     await gotoEmptyChat(page)
     await resetLoadCount(page)
@@ -182,8 +181,8 @@ test.describe('shell update — apply on idle, SW on a leash', () => {
     expect(await loadCount(page)).toBe(0)
   })
 
-  test('a mid-turn shell_rebuilt applies exactly once at the turn-end idle boundary', async ({ page }) => {
-    // shell_rebuilt arrives on the system stream while the turn streams →
+  test('a deliberate mid-turn shell_apply_now applies exactly once at the turn-end idle boundary', async ({ page }) => {
+    // shell_apply_now arrives on the system stream while the turn streams →
     // defer; the chat stream's `done` (held back so the rebuilt lands
     // genuinely mid-turn) then empties the streaming set → the hold-until-idle
     // recheck applies → exactly one reload. No loop: the post-reload system
@@ -216,10 +215,15 @@ test.describe('shell update — apply on idle, SW on a leash', () => {
           { type: 'done' },
         ])))
       },
-      systemRoute: oneShotRebuiltSystemRoute(armed),
+      systemRoute: oneShotSystemEventRoute('shell_apply_now', armed),
     })
     await gotoEmptyChat(page)
     await resetLoadCount(page)
+    await page.evaluate(() => {
+      window.addEventListener('mobius:before-shell-reload', () => {
+        sessionStorage.setItem('__before_shell_reload_seen', '1')
+      }, { once: true })
+    })
 
     await sendMessage(page, 'rebuild the shell')
     // The send marks the chat streaming synchronously (onMessageStart), so
@@ -232,14 +236,34 @@ test.describe('shell update — apply on idle, SW on a leash', () => {
       () => Number(sessionStorage.getItem('__load_count') || '0') === 1,
       { timeout: 20000 },
     )
+    expect(await page.evaluate(() => (
+      sessionStorage.getItem('__before_shell_reload_seen')
+    ))).toBe('1')
     // And does NOT loop: the reloaded page's system reconnect gets only the
     // hello (no replay), so nothing re-applies.
     await page.waitForTimeout(2000)
     expect(await loadCount(page)).toBe(1)
   })
 
-  test('shell_rebuilt on the global system stream while idle applies immediately', async ({ page }) => {
-    // No turn is streaming; the global system stream delivers shell_rebuilt at
+  test('passive shell_rebuilt stays queued while an idle chat is visible', async ({ page }) => {
+    let armRebuilt
+    const armed = new Promise(resolve => { armRebuilt = resolve })
+    await setup(page, {
+      streamRoute: route => route.fulfill(fulfillStream(sse([{ type: 'done' }]))),
+      systemRoute: oneShotSystemEventRoute('shell_rebuilt', armed),
+    })
+    await gotoEmptyChat(page)
+    await resetLoadCount(page)
+
+    armRebuilt()
+    // Wait past the six-second recheck: a passive generation must remain
+    // coalesced for as long as this idle chat is still the visible surface.
+    await page.waitForTimeout(7000)
+    expect(await loadCount(page)).toBe(0)
+  })
+
+  test('shell_apply_now on the global system stream while idle applies immediately', async ({ page }) => {
+    // No turn is streaming; the global system stream delivers shell_apply_now at
     // load. Idle → immediate apply → one reload. Loop prevention is single
     // delivery itself: the post-reload reconnect gets no replay, exactly like
     // the real SystemBroadcast (the old sessionStorage dedup is gone).
@@ -248,7 +272,7 @@ test.describe('shell update — apply on idle, SW on a leash', () => {
     // makes it #2. No pre-reset — the base is the initial load.
     await setup(page, {
       streamRoute: route => route.fulfill(fulfillStream(sse([{ type: 'done' }]))),
-      systemRoute: oneShotRebuiltSystemRoute(Promise.resolve()),
+      systemRoute: oneShotSystemEventRoute('shell_apply_now', Promise.resolve()),
     })
 
     await page.waitForFunction(


### PR DESCRIPTION
## Summary

- coalesce passive `shell_rebuilt` generations while an idle chat is visible, while preserving deliberate `shell_apply_now` behavior
- persist the exact visible chat anchor synchronously before an eventual hard reload
- make authenticated screenshots fail clearly when the token is rejected or the login page remains visible

## Why

A burst of frontend source saves could repeatedly hard-reload an idle transcript while someone was reading. If the exact anchor was unavailable during early hydration, the reader could also land on an older question card. Separately, the authenticated screenshot helper could time out and silently capture the login wall as if it were a valid product screenshot.

## Validation

- `npm test` — 887 frontend library tests and 44 hook tests passed
- focused shell/scroll tests — 39 passed
- authenticated screenshot helper tests — 2 passed
- production Vite/PWA build passed
- core app snapshots are in sync
- full backend run: 2,115 passed and 1 skipped; six unrelated baseline/container failures remained in frontend-watcher, platform-preview, and build-version sentinel tests
- Playwright coverage updated; full browser run deferred to CI