### PR TITLE
Expose safe aggregate source status

### DIFF
--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -412,13 +412,16 @@ def get_owner_or_app_with_github_access(
 ) -> models.Owner:
   """Owner JWT, OR an app-scoped JWT whose App row has github_access=true.
 
-  Gates the WHOLE GitHub surface in routes/github.py: the connect flow
+  Gates the WHOLE GitHub/Contribute surface in routes/github.py: the connect flow
   (device-code start/poll, PAT submit) AND disconnect AND the read-only
   REST/GraphQL passthrough. So this is NOT a read-only grant — read it
   as "let this app manage and read the owner's GitHub connection". A
   github_access app can drive the connect UI (a normal connect still
   needs the owner to authorize on github.com or paste their own PAT),
-  can disconnect, and can read PR/issue state under the stored token.
+  can disconnect, and can read PR/issue state under the stored token. It also
+  gates Contribute's fetch-free local source-status metadata (sanitized refs,
+  counts, and relative path names; never source contents or absolute paths),
+  avoiding a much broader filesystem grant.
   What it CANNOT do is exfiltrate the token (it never leaves the server,
   INV1) or write arbitrary GitHub mutations over HTTP with an app-scoped
   token. The read surface is GET-only / mutation-rejecting; the PR submit

--- a/backend/app/routes/github.py
+++ b/backend/app/routes/github.py
@@ -7,7 +7,7 @@ connection-management grant, not a read scope: an app with it can
 start/complete the connect flow, submit a PAT, and disconnect. A
 normal connect still needs the owner to authorize on github.com or
 paste their own token, but the grant itself is powerful — see the
-get_owner_or_app_with_github_access docstring. The read surface
+get_owner_or_app_with_github_access docstring. The remote read surface
 (/api/{path}, /graphql) is read-only by construction (INV2): the REST
 passthrough registers GET only, and the GraphQL endpoint rejects any
 document containing a mutation or subscription operation. GitHub writes
@@ -16,6 +16,12 @@ prepared ledger record after the owner presses Send: it claims that
 record, rechecks the reviewed branch/diff, pushes to the owner's fork,
 and creates the pull request. An app-scoped github_access token may submit
 only its own prepared record; it cannot act as a general GitHub write proxy.
+
+The fetch-free /source-status read is the local companion for Contribute's
+Sources view. It exposes only sanitized repository identity, refs, diff
+magnitudes, and capped relative path names — never source contents, absolute
+paths, raw remotes, or credentials — so Contribute does not need the broader
+filesystem capability merely to explain where local work sits.
 
 The token itself never appears in any response or log line (INV1).
 """
@@ -42,7 +48,7 @@ from slowapi import Limiter
 from slowapi.util import get_remote_address
 from sqlalchemy.orm import Session
 
-from app import fs_locks, github_auth, models
+from app import fs_locks, github_auth, models, source_status
 from app.config import get_settings
 from app.database import get_db
 from app.deps import (
@@ -1352,6 +1358,76 @@ async def github_status(
     "token_source": state.get("token_source") if connected else None,
     "device_flow_available": bool(get_settings().github_oauth_client_id),
     "gh_version": github_auth.gh_version(),
+  }
+
+
+@router.get("/source-status")
+async def github_source_status(
+  _: models.Owner = Depends(get_owner_or_app_with_github_access),
+  db: Session = Depends(get_db),
+):
+  """Fetch-free local source map for the Contribute app.
+
+  Returns refs, diff magnitudes, and working-tree metadata for the platform and
+  every live app source repository.  It deliberately does not fetch remotes,
+  expose source contents/absolute paths, or grant Contribute the much broader
+  filesystem capability.  App reads take the same per-source lock as the
+  watcher and installer, so a commit/update cannot split one status snapshot.
+  """
+  rows = (
+    db.query(models.App)
+    .filter(
+      models.App.deleted_at.is_(None),
+      models.App.source_dir.isnot(None),
+    )
+    .order_by(models.App.name.asc())
+    .all()
+  )
+  apps = [{
+    "id": row.id,
+    "name": row.name,
+    "slug": row.slug,
+    "version": row.version,
+    "manifest_url": row.manifest_url,
+    "source_dir": row.source_dir,
+  } for row in rows]
+
+  # The repository scan may wait on the same source lock held by an app
+  # compile/update. Do not keep a database connection checked out across that
+  # wait: the compiler also needs the pool before it can release its lock, so
+  # overlapping map refreshes would otherwise create a lock-order deadlock.
+  # FastAPI's dependency finalizer will close again; SQLAlchemy close is safe
+  # and idempotent.
+  db.close()
+
+  platform = await asyncio.to_thread(source_status.build_platform_status)
+  semaphore = asyncio.Semaphore(4)
+
+  async def inspect(app: dict) -> dict | None:
+    async with semaphore:
+      async with fs_locks.source_dir_lock(app["source_dir"]):
+        try:
+          return await asyncio.to_thread(source_status.build_app_status, app)
+        except Exception:
+          # One damaged checkout must not blank the complete repository map.
+          # The omitted app can recover on the next refresh after its source is
+          # repaired, while every healthy source remains useful now.
+          log.warning(
+            "Could not inspect source status for app %s",
+            app.get("id"),
+            exc_info=True,
+          )
+          return None
+
+  inspected = await asyncio.gather(*(inspect(app) for app in apps))
+  projects = [item for item in inspected if item is not None]
+  projects.sort(key=lambda item: item["name"].casefold())
+  return {
+    "schema": 1,
+    "generated_at": _now_iso(),
+    "fetch_free": True,
+    "platform": platform,
+    "apps": projects,
   }
 
 

--- a/backend/app/source_status.py
+++ b/backend/app/source_status.py
@@ -1,0 +1,321 @@
+"""Fetch-free aggregate Git status for Contribute's Sources view.
+
+The Contribute app needs one narrow answer — how the live platform and each
+installed app relate to the update source already recorded on disk.  Granting
+it the general filesystem capability would be much broader than that question,
+so this module returns metadata only: refs, ancestry counts, source-diff
+magnitudes, and working-tree counts/path names.  It never fetches, writes, or
+returns source contents.
+
+Platform compares ``HEAD`` with ``origin/main``.  Apps compare ``HEAD`` with
+their installer-owned ``upstream`` branch.  The latter is the last installed
+source, not a promise that the remote catalog was checked just now; callers
+must keep that wording honest.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from app.config import get_settings
+
+_GIT_TIMEOUT = 8
+_PATH_PREVIEW = 12
+_GITHUB_HTTPS = re.compile(
+  r"^https://github\.com/([^/]+)/([^/#]+?)(?:\.git)?/?$", re.IGNORECASE,
+)
+_GITHUB_SSH = re.compile(
+  r"^(?:ssh://git@github\.com/|git@github\.com:)([^/]+)/([^/#]+?)(?:\.git)?$",
+  re.IGNORECASE,
+)
+_RAW_GITHUB = re.compile(
+  r"^https://raw\.githubusercontent\.com/([^/]+)/([^/]+)/", re.IGNORECASE,
+)
+
+
+def _git_env(repo: Path) -> dict[str, str]:
+  """Scrub inherited git pointers and stop discovery above this repository."""
+  env = dict(os.environ)
+  for name in (
+    "GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_OBJECT_DIRECTORY",
+    "GIT_COMMON_DIR", "GIT_NAMESPACE",
+  ):
+    env.pop(name, None)
+  env["GIT_CEILING_DIRECTORIES"] = str(repo.resolve().parent)
+  return env
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+  try:
+    return subprocess.run(
+      ["git", "-C", str(repo), *args], capture_output=True, text=True,
+      errors="replace", timeout=_GIT_TIMEOUT, check=False, env=_git_env(repo),
+    )
+  except (OSError, subprocess.TimeoutExpired) as exc:
+    return subprocess.CompletedProcess(
+      ["git", "-C", str(repo), *args], 1, "", str(exc),
+    )
+
+
+def _rev(repo: Path, ref: str) -> str | None:
+  proc = _git(repo, "rev-parse", "--verify", ref)
+  value = proc.stdout.strip()
+  return value if proc.returncode == 0 and value else None
+
+
+def _canonical_repo(url: str | None) -> str | None:
+  """Turn common GitHub remote/manifest URLs into ``owner/repo``."""
+  if not url:
+    return None
+  raw = url.strip()
+  for pattern in (_GITHUB_HTTPS, _GITHUB_SSH, _RAW_GITHUB):
+    match = pattern.match(raw)
+    if match:
+      return f"{match.group(1)}/{match.group(2).removesuffix('.git')}"
+  return None
+
+
+def _diff_summary(repo: Path, left: str, right: str) -> dict[str, Any]:
+  """Count endpoint tree differences without returning source content."""
+  proc = _git(repo, "diff", "--numstat", "--no-renames", left, right, "--")
+  if proc.returncode != 0:
+    return {
+      "available": False, "files": 0, "insertions": 0, "deletions": 0,
+      "binary_files": 0, "paths": [], "truncated": False,
+    }
+  files = insertions = deletions = binaries = 0
+  paths: list[dict[str, Any]] = []
+  for line in proc.stdout.splitlines():
+    parts = line.split("\t", 2)
+    if len(parts) != 3:
+      continue
+    add_raw, del_raw, path = parts
+    files += 1
+    binary = add_raw == "-" or del_raw == "-"
+    if binary:
+      binaries += 1
+      add = delete = None
+    else:
+      try:
+        add, delete = int(add_raw), int(del_raw)
+      except ValueError:
+        add = delete = 0
+      insertions += add
+      deletions += delete
+    if len(paths) < _PATH_PREVIEW:
+      paths.append({
+        "path": path, "insertions": add, "deletions": delete,
+        "binary": binary,
+      })
+  return {
+    "available": True,
+    "files": files,
+    "insertions": insertions,
+    "deletions": deletions,
+    "binary_files": binaries,
+    "paths": paths,
+    "truncated": files > len(paths),
+  }
+
+
+def _working_summary(repo: Path) -> dict[str, Any]:
+  """Parse porcelain status into staged/unstaged/untracked/conflict groups."""
+  proc = _git(repo, "status", "--porcelain=v1", "-z", "--untracked-files=all")
+  if proc.returncode != 0:
+    return {
+      "available": False, "files": 0, "staged": 0, "unstaged": 0,
+      "untracked": 0, "conflicts": 0, "paths": [], "truncated": False,
+    }
+  records = [item for item in proc.stdout.split("\0") if item]
+  files = staged = unstaged = untracked = conflicts = 0
+  paths: list[dict[str, str]] = []
+  conflict_codes = {"DD", "AU", "UD", "UA", "DU", "AA", "UU"}
+  i = 0
+  while i < len(records):
+    record = records[i]
+    if len(record) < 3:
+      i += 1
+      continue
+    code, path = record[:2], record[3:]
+    files += 1
+    if code == "??":
+      untracked += 1
+      group = "untracked"
+    elif code in conflict_codes:
+      conflicts += 1
+      group = "conflict"
+    else:
+      has_staged = code[0] not in " ?"
+      has_unstaged = code[1] not in " "
+      staged += int(has_staged)
+      unstaged += int(has_unstaged)
+      group = "staged" if has_staged and not has_unstaged else "unstaged"
+    if len(paths) < _PATH_PREVIEW:
+      paths.append({"path": path, "status": code, "group": group})
+    # In -z porcelain, rename/copy records carry the old path as the next item.
+    if code[0] in "RC" and i + 1 < len(records):
+      i += 1
+    i += 1
+  merge_active = _rev(repo, "MERGE_HEAD") is not None
+  return {
+    "available": True,
+    "files": files,
+    "staged": staged,
+    "unstaged": unstaged,
+    "untracked": untracked,
+    "conflicts": conflicts,
+    "merge_active": merge_active,
+    "paths": paths,
+    "truncated": files > len(paths),
+  }
+
+
+def _project_status(
+  *, repo: Path, kind: str, key: str, name: str, slug: str | None,
+  version: str | None, manifest_url: str | None,
+) -> dict[str, Any]:
+  response: dict[str, Any] = {
+    "key": key,
+    "kind": kind,
+    "name": name,
+    "slug": slug,
+    "version": version,
+    "available": False,
+    "canonical_repo": "mobius-os/mobius" if kind == "platform" else None,
+    "branch": None,
+    "head_sha": None,
+    "base_ref": "origin/main" if kind == "platform" else "upstream",
+    "base_sha": None,
+    "ahead": None,
+    "behind": None,
+    "tree": None,
+    "working": None,
+    "state": "unavailable",
+  }
+  if not repo.is_dir() or not (repo / ".git").exists():
+    return response
+
+  branch_proc = _git(repo, "branch", "--show-current")
+  branch = branch_proc.stdout.strip() or None
+  head = _rev(repo, "HEAD")
+  base_ref = response["base_ref"]
+  base = _rev(repo, base_ref)
+  origin_proc = _git(repo, "remote", "get-url", "origin")
+  origin_url = origin_proc.stdout.strip() if origin_proc.returncode == 0 else None
+  if kind != "platform":
+    response["canonical_repo"] = (
+      _canonical_repo(origin_url) or _canonical_repo(manifest_url)
+    )
+
+  response.update({
+    "available": bool(head),
+    "branch": branch,
+    "detached": bool(head and not branch),
+    "head_sha": head,
+    "base_sha": base,
+    "has_update_source": bool(base),
+  })
+  working = _working_summary(repo)
+  response["working"] = working
+  if not head:
+    return response
+  if not base:
+    response["state"] = "local_only"
+    return response
+
+  counts = _git(repo, "rev-list", "--left-right", "--count", f"{base_ref}...HEAD")
+  parts = counts.stdout.split()
+  if counts.returncode == 0 and len(parts) == 2:
+    try:
+      behind, ahead = int(parts[0]), int(parts[1])
+    except ValueError:
+      behind = ahead = None
+  else:
+    behind = ahead = None
+  tree = _diff_summary(repo, base_ref, "HEAD")
+  response.update({"behind": behind, "ahead": ahead, "tree": tree})
+
+  has_working = bool(working.get("files"))
+  has_conflict = bool(working.get("conflicts") or working.get("merge_active"))
+  has_local = bool(tree.get("files"))
+  if has_conflict:
+    state = "conflict"
+  elif has_working:
+    state = "working"
+  elif behind and (ahead or has_local):
+    state = "diverged"
+  elif behind:
+    state = "incoming"
+  elif has_local:
+    state = "customized"
+  else:
+    state = "aligned"
+  response["state"] = state
+  return response
+
+
+def build_platform_status() -> dict[str, Any]:
+  """Inspect the live platform clone against its last-fetched origin/main."""
+  settings = get_settings()
+  data_dir = Path(settings.data_dir).resolve()
+  return _project_status(
+    repo=data_dir / "platform",
+    kind="platform", key="platform", name="Möbius", slug=None,
+    version=None, manifest_url=None,
+  )
+
+
+def build_app_status(app: dict[str, Any]) -> dict[str, Any] | None:
+  """Inspect one validated live app source row; invalid paths are excluded."""
+  settings = get_settings()
+  app_root = Path(settings.data_dir).resolve() / "apps"
+  raw_source = app.get("source_dir")
+  if not isinstance(raw_source, str) or not raw_source:
+    return None
+  try:
+    raw_path = Path(raw_source)
+    if raw_path.is_symlink():
+      return None
+    source_dir = raw_path.resolve()
+    if source_dir.parent != app_root or source_dir.name.isdigit():
+      return None
+  except (OSError, RuntimeError, ValueError):
+    # A corrupt DB path must not turn this narrow metadata surface into an
+    # arbitrary filesystem probe.
+    return None
+  return _project_status(
+    repo=source_dir,
+    kind="app",
+    key=f"app:{app.get('id')}",
+    name=str(app.get("name") or app.get("slug") or "Unnamed app"),
+    slug=str(app.get("slug") or "") or None,
+    version=str(app.get("version") or "") or None,
+    manifest_url=(str(app.get("manifest_url")) if app.get("manifest_url") else None),
+  )
+
+
+def build_source_status(apps: list[dict[str, Any]]) -> dict[str, Any]:
+  """Return the platform plus every live app source repo in one snapshot.
+
+  Routes should hold ``source_dir_lock`` around each :func:`build_app_status`
+  call.  This aggregate remains useful to tests and non-serving callers where
+  no watcher can race the inspection.
+  """
+  platform = build_platform_status()
+  app_results: list[dict[str, Any]] = []
+  for app in apps:
+    status = build_app_status(app)
+    if status is not None:
+      app_results.append(status)
+  app_results.sort(key=lambda item: item["name"].casefold())
+  return {
+    "generated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+    "fetch_free": True,
+    "platform": platform,
+    "apps": app_results,
+  }

--- a/backend/tests/test_github_routes.py
+++ b/backend/tests/test_github_routes.py
@@ -12,6 +12,7 @@ the network. Two harness notes:
   identity test re-points GIT_CONFIG_GLOBAL at a tmp file and reads it back.
 """
 
+import asyncio
 import hashlib
 import json
 import os
@@ -22,13 +23,14 @@ from pathlib import Path
 import httpx
 import pytest
 
-from app import github_auth
+from app import github_auth, source_status
 from app.config import get_settings
 from app.storage_io import atomic_write
 
 # The github router's Limiter is a separate instance from app.state.limiter,
 # so conftest's disable doesn't reach it (see module docstring).
 from app.routes.github import _limiter as _github_limiter
+from app.routes import github as github_routes
 
 _github_limiter.enabled = False
 
@@ -406,6 +408,116 @@ def test_status_connected_never_echoes_token(client, auth):
   # INV1: the token never appears anywhere in the payload.
   assert "token" not in body
   assert secret not in json.dumps(body)
+
+
+def test_source_status_is_fetch_free_and_available_to_owner(client, auth):
+  r = client.get("/api/github/source-status", headers=auth)
+  assert r.status_code == 200, r.text
+  body = r.json()
+  assert body["schema"] == 1
+  assert body["fetch_free"] is True
+  assert body["platform"]["key"] == "platform"
+  assert body["apps"] == []
+  serialized = json.dumps(body)
+  assert "source_dir" not in serialized
+  assert "manifest_url" not in serialized
+
+
+def test_source_status_releases_db_before_waiting_on_repository_locks(
+  monkeypatch,
+):
+  class EmptyQuery:
+    def filter(self, *args):
+      return self
+
+    def order_by(self, *args):
+      return self
+
+    def all(self):
+      return []
+
+  class FakeSession:
+    closed = False
+
+    def query(self, *args):
+      return EmptyQuery()
+
+    def close(self):
+      self.closed = True
+
+  db = FakeSession()
+
+  async def checked_to_thread(function, *args):
+    assert db.closed, "repository inspection started with DB still checked out"
+    assert function is source_status.build_platform_status
+    return {"key": "platform", "available": True}
+
+  monkeypatch.setattr(github_routes.asyncio, "to_thread", checked_to_thread)
+  result = asyncio.run(github_routes.github_source_status(None, db))
+
+  assert result["platform"] == {"key": "platform", "available": True}
+  assert result["apps"] == []
+
+
+def test_source_status_requires_github_access_for_app_tokens(
+  client, owner_token,
+):
+  _, denied_token = _app_token(client, owner_token, github_access=False)
+  denied = client.get(
+    "/api/github/source-status",
+    headers={"Authorization": f"Bearer {denied_token}"},
+  )
+  assert denied.status_code == 403
+
+  _, allowed_token = _app_token(client, owner_token, github_access=True)
+  allowed = client.get(
+    "/api/github/source-status",
+    headers={"Authorization": f"Bearer {allowed_token}"},
+  )
+  assert allowed.status_code == 200, allowed.text
+
+
+def test_source_status_keeps_healthy_apps_when_one_checkout_fails(
+  client, owner_token, auth, monkeypatch,
+):
+  from app import models
+  from app.database import SessionLocal
+
+  good_id, _ = _app_token(client, owner_token)
+  bad_id, _ = _app_token(client, owner_token)
+  app_root = Path(get_settings().data_dir) / "apps"
+  good_dir = app_root / "good-source"
+  bad_dir = app_root / "bad-source"
+  good_dir.mkdir(parents=True, exist_ok=True)
+  bad_dir.mkdir(parents=True, exist_ok=True)
+  session = SessionLocal()
+  try:
+    session.query(models.App).filter(models.App.id == good_id).update({
+      "name": "Good source", "source_dir": str(good_dir),
+    })
+    session.query(models.App).filter(models.App.id == bad_id).update({
+      "name": "Bad source", "source_dir": str(bad_dir),
+    })
+    session.commit()
+  finally:
+    session.close()
+
+  monkeypatch.setattr(source_status, "build_platform_status", lambda: {
+    "key": "platform", "available": True,
+  })
+
+  def inspect(app):
+    if app["id"] == bad_id:
+      raise RuntimeError("damaged checkout")
+    return {"key": f'app:{app["id"]}', "name": app["name"]}
+
+  monkeypatch.setattr(source_status, "build_app_status", inspect)
+  response = client.get("/api/github/source-status", headers=auth)
+
+  assert response.status_code == 200, response.text
+  assert response.json()["apps"] == [{
+    "key": f"app:{good_id}", "name": "Good source",
+  }]
 
 
 # --- disconnect -------------------------------------------------------

--- a/backend/tests/test_source_status.py
+++ b/backend/tests/test_source_status.py
@@ -1,0 +1,152 @@
+"""Focused tests for Contribute's fetch-free aggregate source metadata."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from app import source_status
+from app.config import get_settings
+
+
+def _git(repo: Path, *args: str) -> str:
+  proc = subprocess.run(
+    ["git", "-C", str(repo), *args], capture_output=True, text=True,
+    check=True,
+  )
+  return proc.stdout.strip()
+
+
+def _commit(repo: Path, message: str, *, allow_empty: bool = False) -> str:
+  args = [
+    "-c", "user.name=Test", "-c", "user.email=test@example.com",
+    "commit", "-q", "-m", message,
+  ]
+  if allow_empty:
+    args.append("--allow-empty")
+  _git(repo, *args)
+  return _git(repo, "rev-parse", "HEAD")
+
+
+def _repo(name: str = "demo") -> Path:
+  root = Path(get_settings().data_dir) / "apps" / name
+  root.mkdir(parents=True, exist_ok=True)
+  _git(root, "init", "-q", "-b", "main")
+  (root / "index.jsx").write_text("export default 1\n", encoding="utf-8")
+  _git(root, "add", "index.jsx")
+  _commit(root, "install")
+  _git(root, "branch", "upstream")
+  return root
+
+
+def _app(repo: Path, *, app_id: int = 7) -> dict:
+  return {
+    "id": app_id,
+    "name": "Demo",
+    "slug": repo.name,
+    "version": "1.0.0",
+    "manifest_url": (
+      "https://raw.githubusercontent.com/mobius-os/app-demo/main/mobius.json"
+    ),
+    "source_dir": str(repo),
+  }
+
+
+def test_aligned_and_history_only_ahead_keep_tree_magnitude_zero():
+  repo = _repo()
+  aligned = source_status.build_app_status(_app(repo))
+  assert aligned is not None
+  assert aligned["state"] == "aligned"
+  assert aligned["ahead"] == 0
+  assert aligned["behind"] == 0
+  assert aligned["tree"]["files"] == 0
+
+  _commit(repo, "watcher bookkeeping", allow_empty=True)
+  ahead = source_status.build_app_status(_app(repo))
+  assert ahead is not None
+  assert ahead["ahead"] == 1
+  assert ahead["tree"]["files"] == 0
+  assert ahead["state"] == "aligned"
+
+
+def test_committed_and_working_deltas_are_reported_separately():
+  repo = _repo()
+  (repo / "index.jsx").write_text("export default 2\n", encoding="utf-8")
+  _git(repo, "add", "index.jsx")
+  _commit(repo, "local source edit")
+  (repo / "index.jsx").write_text("export default 3\n", encoding="utf-8")
+  (repo / "staged.js").write_text("export const x = 1\n", encoding="utf-8")
+  (repo / "untracked.js").write_text("export const y = 2\n", encoding="utf-8")
+  _git(repo, "add", "staged.js")
+
+  result = source_status.build_app_status(_app(repo))
+  assert result is not None
+  assert result["state"] == "working"
+  assert result["tree"]["files"] == 1
+  assert result["tree"]["insertions"] == 1
+  assert result["tree"]["deletions"] == 1
+  assert result["working"]["files"] == 3
+  assert result["working"]["staged"] == 1
+  assert result["working"]["unstaged"] == 1
+  assert result["working"]["untracked"] == 1
+
+
+def test_diverged_counts_and_sanitized_github_identity():
+  repo = _repo()
+  _git(repo, "checkout", "-q", "upstream")
+  (repo / "remote.js").write_text("remote\n", encoding="utf-8")
+  _git(repo, "add", "remote.js")
+  _commit(repo, "incoming")
+  _git(repo, "checkout", "-q", "main")
+  (repo / "local.js").write_text("local\n", encoding="utf-8")
+  _git(repo, "add", "local.js")
+  _commit(repo, "local")
+  _git(repo, "remote", "add", "origin", "git@github.com:example/private-demo.git")
+
+  result = source_status.build_app_status(_app(repo))
+  assert result is not None
+  assert result["state"] == "diverged"
+  assert result["behind"] == 1
+  assert result["ahead"] == 1
+  assert result["canonical_repo"] == "example/private-demo"
+  payload = repr(result)
+  assert str(repo) not in payload
+  assert "git@github.com" not in payload
+
+
+def test_local_only_and_invalid_source_paths_degrade_safely(tmp_path):
+  repo = _repo("local-only")
+  _git(repo, "branch", "-D", "upstream")
+  result = source_status.build_app_status(_app(repo))
+  assert result is not None
+  assert result["state"] == "local_only"
+  assert result["base_sha"] is None
+
+  outside = tmp_path / "outside"
+  outside.mkdir()
+  assert source_status.build_app_status(_app(outside)) is None
+
+  numeric = Path(get_settings().data_dir) / "apps" / "66"
+  numeric.mkdir(parents=True, exist_ok=True)
+  assert source_status.build_app_status(_app(numeric)) is None
+
+  target = Path(get_settings().data_dir) / "apps" / "target"
+  target.mkdir()
+  link = Path(get_settings().data_dir) / "apps" / "linked"
+  link.symlink_to(target, target_is_directory=True)
+  assert source_status.build_app_status(_app(link)) is None
+
+
+def test_git_output_with_non_utf8_path_is_safely_sanitized():
+  repo = _repo("odd-path")
+  raw_name = b"odd-\xff.js"
+  raw_path = bytes(repo) + b"/" + raw_name
+  with open(raw_path, "wb") as handle:
+    handle.write(b"export default 1\n")
+
+  result = source_status.build_app_status(_app(repo))
+
+  assert result is not None
+  assert result["working"]["files"] == 1
+  assert result["working"]["untracked"] == 1
+  assert result["working"]["paths"][0]["path"] == "odd-�.js"


### PR DESCRIPTION
## Summary
- add a least-privilege, fetch-free source-status service for the platform and installed apps
- report repository ancestry, authored/install-managed tree differences, and working paths without exposing source contents
- release database connections before waiting for repository locks, isolate damaged checkouts, and sanitize unusual filenames
- keep one problematic repository or overlapping refresh from blocking the shell or blanking the complete map

This is layer 1 of the Contribute platform stack.

## Testing
- `pytest -q backend/tests/test_source_status.py backend/tests/test_github_routes.py` (63 passed)