### PR TITLE
Copy chat messages on mobile hold

### DIFF
--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -377,6 +377,36 @@
 }
 .chat__ts--visible { opacity: 1; }
 
+/* Holding a mobile message copies immediately. The only visible UI is this
+   brief confirmation, kept above the composer so it never shifts content. */
+.chat__copy-toast {
+  position: absolute;
+  left: 50%;
+  bottom: calc(var(--composer-h, 72px) + 18px);
+  z-index: 230;
+  transform: translateX(-50%);
+  max-width: calc(100% - 32px);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--surface) 92%, transparent);
+  backdrop-filter: blur(16px) saturate(140%);
+  color: var(--text);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.22);
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+  animation: chat-copy-toast-in 0.18s var(--ease-out-soft, ease-out);
+}
+.chat__copy-toast--success svg { color: var(--accent); }
+
+@keyframes chat-copy-toast-in {
+  from { opacity: 0; transform: translate(-50%, 6px); }
+}
+
 /* ── Bubble content ────────────────────────────────── */
 
 .chat__text {
@@ -2037,7 +2067,8 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .chat__build-rail { animation: none; }
+  .chat__build-rail,
+  .chat__copy-toast { animation: none; }
 }
 
 /* ── Queued messages tray ──────────────────────────── */

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -7,6 +7,7 @@ import {
   useSyncExternalStore,
 } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
+import { Check } from 'lucide-react'
 import { apiFetch, getToken, BASE } from '../../api/client.js'
 import { chatMessagesQueryKey } from '../../hooks/queries.js'
 import useStreamConnection from './useStreamConnection.js'
@@ -48,6 +49,7 @@ import {
 import { questionKey } from './questionKey.js'
 import { resolveStopResend } from './resolveStopResend.js'
 import { focusComposerElement, shouldApplyComposerFocusRequest } from './composerFocusPolicy.js'
+import { copyableMessageText, copyPlainText } from './messageCopy.js'
 import { chooseActiveAssistantDataKey, chooseActiveAssistantMirrorIndex, chooseActiveAssistantSurface, findTrailingAssistantPartialIndex, promoteAssistantStream, streamItemsHaveRenderableContent, streamItemsToAssistantPayload } from './streamPromotion.js'
 import {
   answerKeepsCurrentTurn,
@@ -465,6 +467,10 @@ export default function ChatView({
   // observer hook (useOffscreenNudge, below); their booleans are computed near
   // hasPendingQuestion / hasPendingResume where the card finders live.
   const [showInspector, setShowInspector] = useState(false)
+  const [copyStatus, setCopyStatus] = useState('')
+  const messageHoldRef = useRef(null)
+  const suppressMessageClickRef = useRef(null)
+  const copyStatusTimerRef = useRef(null)
   const [previewReadyStatus, setPreviewReadyStatus] = useState('')
   // The app id whose CTA is mid recompile-pulse (label swapped to "Preview
   // updated ✓" for ~2s), or null.
@@ -484,6 +490,60 @@ export default function ChatView({
   const [buildPhases, setBuildPhases] = useState(EMPTY_BUILD_PHASE_RAIL)
   const [buildPhaseStatus, setBuildPhaseStatus] = useState('')
   const lastAnnouncedPhaseRef = useRef(null)
+
+  useEffect(() => () => {
+    if (messageHoldRef.current?.timer) clearTimeout(messageHoldRef.current.timer)
+    if (copyStatusTimerRef.current) clearTimeout(copyStatusTimerRef.current)
+  }, [])
+
+  const cancelMessageHold = useCallback(() => {
+    if (messageHoldRef.current?.timer) {
+      clearTimeout(messageHoldRef.current.timer)
+    }
+    messageHoldRef.current = null
+  }, [])
+
+  const copyMessage = useCallback(async (message, key) => {
+    const text = copyableMessageText(message)
+    if (!text) return
+    suppressMessageClickRef.current = key
+    const copied = await copyPlainText(text)
+    if (copied) {
+      try { navigator.vibrate?.(8) } catch { /* haptics are optional */ }
+    }
+    setCopyStatus(copied ? 'Copied' : 'Couldn’t copy')
+    if (copyStatusTimerRef.current) clearTimeout(copyStatusTimerRef.current)
+    copyStatusTimerRef.current = setTimeout(() => {
+      copyStatusTimerRef.current = null
+      setCopyStatus('')
+    }, 1800)
+  }, [])
+
+  const handleMessagePointerDown = useCallback((event, message, key) => {
+    if (
+      !_isTouchPrimary
+      || event.pointerType !== 'touch'
+      || event.button !== 0
+      || event.target?.closest?.('button, a, input, textarea, summary, pre, code')
+    ) return
+    cancelMessageHold()
+    const startX = event.clientX
+    const startY = event.clientY
+    const timer = setTimeout(() => {
+      messageHoldRef.current = null
+      void copyMessage(message, key)
+    }, 520)
+    messageHoldRef.current = { timer, startX, startY, key }
+  }, [cancelMessageHold, copyMessage])
+
+  const handleMessagePointerMove = useCallback((event) => {
+    const hold = messageHoldRef.current
+    if (!hold) return
+    if (
+      Math.abs(event.clientX - hold.startX) > 10
+      || Math.abs(event.clientY - hold.startY) > 10
+    ) cancelMessageHold()
+  }, [cancelMessageHold])
 
   useEffect(() => {
     autoResumeRequestRef.current += 1
@@ -3172,6 +3232,16 @@ export default function ChatView({
           onClose={() => setShowInspector(false)}
         />
       )}
+      {copyStatus && (
+        <div
+          className={`chat__copy-toast${copyStatus === 'Copied' ? ' chat__copy-toast--success' : ''}`}
+          role="status"
+          aria-live="polite"
+        >
+          {copyStatus === 'Copied' && <Check size={15} strokeWidth={2.5} aria-hidden="true" />}
+          {copyStatus}
+        </div>
+      )}
       {showEmpty && (
         <div className="chat__empty-wrap">
           {embedded ? (
@@ -3315,8 +3385,26 @@ export default function ChatView({
               data-key={dataKey}
               data-cid={userCid || undefined}
               data-ts={msg.role === 'user' && msg.ts ? String(msg.ts) : undefined}
+              onPointerDown={(event) => handleMessagePointerDown(event, msg, dataKey)}
+              onPointerMove={handleMessagePointerMove}
+              onPointerUp={cancelMessageHold}
+              onPointerCancel={cancelMessageHold}
+              onContextMenu={_isTouchPrimary
+                ? (event) => {
+                    if (event.target?.closest?.('button, a, input, textarea, summary, pre, code')) return
+                    event.preventDefault()
+                    cancelMessageHold()
+                    void copyMessage(msg, dataKey)
+                  }
+                : undefined}
               onClick={msg.ts && msg.role === 'user'
-                ? (e) => { e.currentTarget.querySelector('.chat__ts')?.classList.toggle('chat__ts--visible') }
+                ? (event) => {
+                    if (suppressMessageClickRef.current === dataKey) {
+                      suppressMessageClickRef.current = null
+                      return
+                    }
+                    event.currentTarget.querySelector('.chat__ts')?.classList.toggle('chat__ts--visible')
+                  }
                 : undefined}
             >
               <MsgContent

--- a/frontend/src/components/ChatView/__tests__/chatUiPolish.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatUiPolish.test.js
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict'
 
 const indexCss = readFileSync(new URL('../../../index.css', import.meta.url), 'utf8')
 const chatCss = readFileSync(new URL('../ChatView.css', import.meta.url), 'utf8')
+const chatView = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8')
 
 function stripComments(css) {
   return css.replace(/\/\*[\s\S]*?\*\//g, '')
@@ -44,4 +45,17 @@ test('stop action has no visible circular shell', () => {
     'Stop must override the circular action-slot focus outline')
   assert.match(stopGlyphFocusRule, /outline:\s*2px solid var\(--accent\)/,
     'Stop keyboard focus should move to the square glyph')
+})
+
+test('mobile hold copies immediately without opening an action menu', () => {
+  const css = stripComments(chatCss)
+
+  assert.doesNotMatch(css, /\.chat__copy-menu|\.chat__copy-overlay/,
+    'instant copy should not render a menu or modal backdrop')
+  assert.match(chatView, /void copyMessage\(message, key\)/,
+    'the completed hold should copy the message directly')
+  assert.match(chatView, /navigator\.vibrate\?\.\(8\)/,
+    'successful copy should offer subtle haptic confirmation where supported')
+  assert.match(chatView, /event\.pointerType !== 'touch'/,
+    'desktop text interaction should stay unchanged')
 })

--- a/frontend/src/components/ChatView/__tests__/messageCopy.test.js
+++ b/frontend/src/components/ChatView/__tests__/messageCopy.test.js
@@ -1,0 +1,26 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { copyableMessageText } from '../messageCopy.js'
+
+test('copyableMessageText copies visible prose and excludes tool chrome', () => {
+  assert.equal(copyableMessageText({
+    role: 'assistant',
+    blocks: [
+      { type: 'text', content: 'First paragraph.' },
+      { type: 'tool', tool: 'Bash', input: 'secret command' },
+      { type: 'text', content: 'Second paragraph.' },
+    ],
+  }), 'First paragraph.\n\nSecond paragraph.')
+})
+
+test('copyableMessageText removes hidden user augmentation', () => {
+  assert.equal(copyableMessageText({
+    role: 'user',
+    content: 'Visible request\n\n<agent_experience>hidden context</agent_experience>',
+  }), 'Visible request')
+})
+
+test('copyableMessageText ignores hidden transcript rows', () => {
+  assert.equal(copyableMessageText({ hidden: true, content: 'do not copy' }), '')
+})

--- a/frontend/src/components/ChatView/messageCopy.js
+++ b/frontend/src/components/ChatView/messageCopy.js
@@ -1,0 +1,59 @@
+// Message-to-plain-text helpers for the mobile hold-to-copy action.
+
+import { stripAugmentation } from './msgText.js'
+
+function questionText(block) {
+  return (block.questions || []).map(question => {
+    const answer = block.answers?.[question.question]
+    return answer
+      ? `${question.question}\n${answer}`
+      : question.question
+  }).filter(Boolean).join('\n\n')
+}
+
+/** Resolve the owner-visible prose in one transcript row. Tool chrome and
+ * hidden prompt augmentation stay out of copied text. */
+export function copyableMessageText(message) {
+  if (!message || message.hidden) return ''
+  const parts = []
+  if (Array.isArray(message.blocks) && message.blocks.length > 0) {
+    for (const block of message.blocks) {
+      if (block?.type === 'text' && block.content) parts.push(block.content)
+      else if (block?.type === 'error' && block.message) parts.push(block.message)
+      else if (block?.type === 'question') {
+        const text = questionText(block)
+        if (text) parts.push(text)
+      }
+    }
+  }
+  if (parts.length === 0 && typeof message.content === 'string') {
+    parts.push(message.role === 'user'
+      ? stripAugmentation(message.content)
+      : message.content)
+  }
+  return parts.join('\n\n').trim()
+}
+
+/** Clipboard API first, textarea fallback for older/iOS PWA contexts. */
+export async function copyPlainText(text) {
+  if (!text) return false
+  try {
+    await navigator.clipboard.writeText(text)
+    return true
+  } catch {
+    try {
+      const textarea = document.createElement('textarea')
+      textarea.value = text
+      textarea.setAttribute('readonly', '')
+      textarea.style.position = 'fixed'
+      textarea.style.opacity = '0'
+      document.body.appendChild(textarea)
+      textarea.select()
+      const copied = document.execCommand('copy')
+      textarea.remove()
+      return copied
+    } catch {
+      return false
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- copy owner-visible message text immediately after a touch hold, without opening an action menu or moving the transcript
- exclude tool chrome, hidden prompt augmentation, and interactive controls from the copied content
- show a small accessible confirmation, optional haptic feedback, and retain a clipboard fallback for older mobile PWA contexts

## Testing

- `npm test` — 890 frontend library/component tests and 44 hook tests pass
- `npm run build`
- `bash scripts/check-core-apps-sync.sh`
- authenticated phone-sized browser verification — hold-to-copy showed the compact confirmation with no action menu or layout shift