### PR TITLE
Harden deferred shell reloads and screenshot authentication

### DIFF
--- a/backend/scripts/agent-screenshot.sh
+++ b/backend/scripts/agent-screenshot.sh
@@ -101,35 +101,30 @@ AGENT_TOKEN="$AGENT_TOKEN" python3 -c 'import json,os; print("localStorage.setIt
 # Now navigate to the actual target route, authenticated.
 agent-browser open "${API_BASE_URL}${ROUTE}" >/dev/null
 
-# Wait on a SIGNAL, not a fixed sleep: the page is authenticated once
-# the login form's password field is gone. This holds for both the
-# shell (LoginForm unmounts after token resolves) and the standalone
-# app page (it redirects to login only when the token is missing — with
-# a token it renders the app, never the password field). Bounded so a
-# genuinely-stuck page fails loudly instead of hanging.
+# Give the target a bounded render window. The missing password field is only a
+# settling signal — token presence mounts Shell before the server has accepted
+# it — so the protected request below remains the authoritative auth check.
 agent-browser wait --fn \
   "!document.querySelector('input[type=password]')" >/dev/null 2>&1 || \
   agent-browser wait 1500 >/dev/null
-
-# The readiness wait above is deliberately bounded, but its old fallback then
-# continued unconditionally. If the token was rejected or expired, the helper
-# silently captured the login wall and reported success — indistinguishable
-# from a real product screenshot until the agent inspected the PNG. Verify the
-# post-navigation auth state explicitly and fail before writing any image.
-# Never print the token itself; only test that it survived the shell's 401
-# interceptor and that the login form is absent.
-AUTH_OK="$(agent-browser eval \
-  "!!localStorage.getItem('token') && !document.querySelector('input[type=password]')" \
-  2>/dev/null || true)"
-if [ "$AUTH_OK" != "true" ]; then
-  echo "agent-screenshot.sh: authentication failed; the token was rejected or the login page remained visible" >&2
-  exit 1
-fi
 
 # Dismiss the PWA install banner if it surfaces — it covers the bottom
 # of the view and would distract from the actual page.
 agent-browser find text "Not now" click >/dev/null 2>&1 || true
 agent-browser wait 300 >/dev/null
+
+# Token presence alone is not proof of authentication: App mounts Shell from
+# localStorage immediately, then a later protected request can reject the token,
+# clear it, and reload onto LoginForm. Verify the token with a protected request
+# at the FINAL capture boundary, after the settle/banner work above. The token is
+# read inside the page and never appears in argv or output.
+AUTH_OK="$(agent-browser eval \
+  "(async () => { const token = localStorage.getItem('token'); if (!token || document.querySelector('input[type=password]')) return false; try { const res = await fetch('/api/chats?agent-screenshot-auth=' + Date.now(), { cache: 'no-store', headers: { Authorization: 'Bearer ' + token } }); return res.status === 200 && !!localStorage.getItem('token') && !document.querySelector('input[type=password]'); } catch { return false; } })()" \
+  2>/dev/null || true)"
+if [ "$AUTH_OK" != "true" ]; then
+  echo "agent-screenshot.sh: authentication failed; the token was rejected or the login page remained visible" >&2
+  exit 1
+fi
 
 agent-browser screenshot "${OUT}" >/dev/null
 echo "${OUT}"

--- a/backend/tests/test_agent_screenshot_auth.py
+++ b/backend/tests/test_agent_screenshot_auth.py
@@ -13,6 +13,7 @@ def _fake_browser(tmp_path: Path) -> tuple[Path, Path]:
   browser = tmp_path / "agent-browser"
   browser.write_text(
     "#!/bin/sh\n"
+    "printf '%s\\n' \"$*\" >> \"$FAKE_BROWSER_LOG\"\n"
     "case \"$1\" in\n"
     "  eval)\n"
     "    if [ \"$2\" = \"--stdin\" ]; then cat >/dev/null; exit 0; fi\n"
@@ -30,9 +31,10 @@ def _fake_browser(tmp_path: Path) -> tuple[Path, Path]:
   return browser, marker
 
 
-def _run_helper(tmp_path: Path, *, auth_ok: bool) -> tuple[subprocess.CompletedProcess, Path, Path]:
+def _run_helper(tmp_path: Path, *, auth_ok: bool) -> tuple[subprocess.CompletedProcess, Path, Path, Path]:
   _, marker = _fake_browser(tmp_path)
   output = tmp_path / "shot.png"
+  browser_log = tmp_path / "browser.log"
   env = {
     **os.environ,
     "PATH": f"{tmp_path}:{os.environ['PATH']}",
@@ -41,6 +43,7 @@ def _run_helper(tmp_path: Path, *, auth_ok: bool) -> tuple[subprocess.CompletedP
     "VIEWPORT_WIDTH": "412",
     "VIEWPORT_HEIGHT": "915",
     "FAKE_AUTH_OK": "true" if auth_ok else "false",
+    "FAKE_BROWSER_LOG": str(browser_log),
     "FAKE_SCREENSHOT_MARKER": str(marker),
   }
   result = subprocess.run(
@@ -50,21 +53,29 @@ def _run_helper(tmp_path: Path, *, auth_ok: bool) -> tuple[subprocess.CompletedP
     capture_output=True,
     check=False,
   )
-  return result, output, marker
+  return result, output, marker, browser_log
 
 
-def test_helper_refuses_to_capture_login_wall(tmp_path: Path):
-  result, output, marker = _run_helper(tmp_path, auth_ok=False)
+def test_helper_refuses_to_capture_when_protected_request_rejects_token(tmp_path: Path):
+  result, output, marker, browser_log = _run_helper(tmp_path, auth_ok=False)
 
   assert result.returncode != 0
   assert "authentication failed" in result.stderr
+  assert "/api/chats" in browser_log.read_text(encoding="utf-8")
   assert not output.exists()
   assert not marker.exists()
 
 
 def test_helper_captures_after_authentication_is_confirmed(tmp_path: Path):
-  result, output, marker = _run_helper(tmp_path, auth_ok=True)
+  result, output, marker, browser_log = _run_helper(tmp_path, auth_ok=True)
 
   assert result.returncode == 0, result.stderr
   assert output.exists()
   assert marker.exists()
+
+  commands = browser_log.read_text(encoding="utf-8").splitlines()
+  settle_index = commands.index("wait 300")
+  auth_index = next(i for i, command in enumerate(commands) if "/api/chats" in command)
+  screenshot_index = next(i for i, command in enumerate(commands) if command.startswith("screenshot "))
+  assert settle_index < auth_index < screenshot_index
+  assert all("test-token" not in command for command in commands)

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -263,17 +263,31 @@ export default function Shell() {
     })
   }
 
+  function passiveChatReloadIsReadingHold(passive) {
+    return passive
+      && document.visibilityState !== 'hidden'
+      && activeViewRef.current === 'chat'
+      && activeChatIdRef.current != null
+  }
+
+  function checkPendingShellReload() {
+    if (!pendingShellReloadRef.current) return
+    const passive = pendingShellReloadPassiveRef.current
+    if (shellReloadWouldDisruptUser({ passive })) {
+      // A passive watcher generation has no deadline while somebody is reading
+      // a visible chat. Wait for the view/visibility effects below instead of
+      // waking the page every six seconds for the whole reading session.
+      if (!passiveChatReloadIsReadingHold(passive)) scheduleShellReloadCheck()
+    } else {
+      performShellReload({ passive })
+    }
+  }
+
   function scheduleShellReloadCheck() {
     if (shellReloadTimerRef.current) clearTimeout(shellReloadTimerRef.current)
     shellReloadTimerRef.current = setTimeout(() => {
       shellReloadTimerRef.current = null
-      if (!pendingShellReloadRef.current) return
-      const passive = pendingShellReloadPassiveRef.current
-      if (shellReloadWouldDisruptUser({ passive })) {
-        scheduleShellReloadCheck()
-      } else {
-        performShellReload({ passive })
-      }
+      checkPendingShellReload()
     }, SHELL_RELOAD_RECHECK_MS)
   }
 
@@ -282,7 +296,9 @@ export default function Shell() {
       ? (pendingShellReloadPassiveRef.current && passive)
       : passive
     pendingShellReloadRef.current = true
-    scheduleShellReloadCheck()
+    if (!passiveChatReloadIsReadingHold(pendingShellReloadPassiveRef.current)) {
+      scheduleShellReloadCheck()
+    }
   }
 
   function requestShellReload({ passive = false } = {}) {
@@ -295,21 +311,32 @@ export default function Shell() {
 
   useEffect(() => {
     const record = () => { lastShellInteractionAtRef.current = Date.now() }
+    const releaseWhenHidden = () => {
+      if (document.visibilityState === 'hidden') checkPendingShellReload()
+    }
     const opts = { capture: true, passive: true }
     window.addEventListener('pointerdown', record, opts)
     window.addEventListener('touchstart', record, opts)
     window.addEventListener('keydown', record, opts)
     window.addEventListener('input', record, opts)
     window.addEventListener('focusin', record, opts)
+    document.addEventListener('visibilitychange', releaseWhenHidden)
     return () => {
       window.removeEventListener('pointerdown', record, opts)
       window.removeEventListener('touchstart', record, opts)
       window.removeEventListener('keydown', record, opts)
       window.removeEventListener('input', record, opts)
       window.removeEventListener('focusin', record, opts)
+      document.removeEventListener('visibilitychange', releaseWhenHidden)
       if (shellReloadTimerRef.current) clearTimeout(shellReloadTimerRef.current)
     }
   }, [])
+
+  // A passive generation held for a visible chat should land as soon as the
+  // owner leaves the chat surface. Switching between chats remains protected.
+  useEffect(() => {
+    checkPendingShellReload()
+  }, [activeView, activeChatId])
   // Global connectivity indicator. The composer already disables send when
   // offline (ChatView); this surfaces the state shell-wide so the user is
   // never tapping in the dark about whether they're connected.
@@ -1014,7 +1041,10 @@ export default function Shell() {
       shellUpdatePickupRef.current = true
       // requestShellReload reads streaming/view state from refs at call time, so
       // the captured closure is fresh even though it isn't in this effect's deps.
-      requestShellReload({ passive: true })
+      // This is recovery, not watcher noise: the page has just mounted and a
+      // waiting/mismatched worker must not remain stranded behind a restored
+      // chat (especially when another tab keeps the outgoing worker alive).
+      requestShellReload()
     })()
     return () => { cancelled = true }
   }, [chatsQuery.isSuccess, chatsQuery.isFetchedAfterMount])

--- a/tests/shell-update-idle.spec.mjs
+++ b/tests/shell-update-idle.spec.mjs
@@ -262,6 +262,36 @@ test.describe('shell update — apply on idle, SW on a leash', () => {
     expect(await loadCount(page)).toBe(0)
   })
 
+  test('a queued passive rebuild releases when the visible chat is backgrounded', async ({ page }) => {
+    let armRebuilt
+    const armed = new Promise(resolve => { armRebuilt = resolve })
+    await setup(page, {
+      streamRoute: route => route.fulfill(fulfillStream(sse([{ type: 'done' }]))),
+      systemRoute: oneShotSystemEventRoute('shell_rebuilt', armed),
+    })
+    await gotoEmptyChat(page)
+    await resetLoadCount(page)
+
+    armRebuilt()
+    await page.waitForTimeout(500)
+    expect(await loadCount(page)).toBe(0)
+
+    // Headless Chromium keeps the only page visible, so shadow the readonly
+    // getter for this document and dispatch the real lifecycle event. The
+    // override disappears with the reload.
+    await page.evaluate(() => {
+      Object.defineProperty(document, 'visibilityState', {
+        configurable: true,
+        value: 'hidden',
+      })
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+    await page.waitForFunction(
+      () => Number(sessionStorage.getItem('__load_count') || '0') === 1,
+      { timeout: 8000 },
+    )
+  })
+
   test('shell_apply_now on the global system stream while idle applies immediately', async ({ page }) => {
     // No turn is streaming; the global system stream delivers shell_apply_now at
     // load. Idle → immediate apply → one reload. Loop prevention is single
@@ -307,8 +337,16 @@ test.describe('shell update — apply on idle, SW on a leash', () => {
       streamRoute: route => route.fulfill(fulfillStream(sse([{ type: 'done' }]))),
       systemBody: sse([{ type: 'system_stream_open' }]),
     })
+    await gotoEmptyChat(page)
     // gen A controls the page (first install claims).
     await page.waitForFunction(() => !!navigator.serviceWorker?.controller, { timeout: 15000 })
+
+    // Keep a second gen-A client alive. Without it, navigation commonly leaves
+    // no outgoing client and Chromium activates gen B before the shell mounts,
+    // so the test never exercises the mount-time pickup path it claims to pin.
+    const keeper = await page.context().newPage()
+    await keeper.goto(BASE, { waitUntil: 'domcontentloaded' })
+    await keeper.waitForFunction(() => !!navigator.serviceWorker?.controller, { timeout: 15000 })
 
     // Publish gen B; wait until it is installed and WAITING (leashed — the SW
     // never skipWaiting()s on its own).
@@ -325,6 +363,14 @@ test.describe('shell update — apply on idle, SW on a leash', () => {
     // generation is installed but the page has not adopted it.
     await page.reload({ waitUntil: 'domcontentloaded' })
 
+    // The explicit reload above is load 1. Mount-time pickup must deliberately
+    // hand off the still-waiting worker and perform load 2 even though a restored
+    // idle chat is visible.
+    await page.waitForFunction(
+      () => Number(sessionStorage.getItem('__load_count') || '0') >= 2,
+      { timeout: 20000 },
+    )
+
     // Generation identity: the apply settles with the page controlled by the
     // registration's ACTIVE worker and NOTHING left waiting.
     await page.waitForFunction(async () => {
@@ -340,5 +386,6 @@ test.describe('shell update — apply on idle, SW on a leash', () => {
       return !reg.waiting && navigator.serviceWorker.controller === reg.active
     })
     expect(stable).toBe(true)
+    await keeper.close()
   })
 })


### PR DESCRIPTION
## Summary

- keep passive watcher rebuilds queued without polling, release them on chat exit or backgrounding, and keep mount-time service-worker recovery deliberate
- make the service-worker regression keep an outgoing client alive so it genuinely exercises waiting-worker recovery
- verify screenshot authentication with a cache-busted protected request at the final capture boundary without exposing the token in arguments or logs

## Context

Follow-up to #56. Review found that mount-time recovery had been classified as passive, so a restored chat could strand a waiting worker when another client kept the old generation alive. The screenshot helper also checked token presence before its final settle delay, leaving a race where a later rejection could still produce a login-wall screenshot.

## Validation

- `npm test` — 887 frontend library tests and 44 hook tests passed
- authenticated screenshot helper tests — 2 passed
- production Vite/PWA build passed
- core app snapshots are in sync
- Playwright discovery lists all six shell-update browser cases, including the new background-release and two-client recovery paths
- full browser execution deferred to CI because the local review checkout has no Playwright Chrome binary