### PR TITLE
Reveal chat attention and build progress above the composer

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -538,6 +538,12 @@ and attaches their rule ids to new diagnostic chats. The Playwright lock-in spec
   text block in event order, without hiding, duplicating, or reordering them. Only a
   recovered answer whose POST returns `started` creates a new hidden continuation.
   Switching sources preserves the active row's anchor identity and writes no scroll.
+- **R4a — Attention nudges reveal the usable tail.** Tapping an offscreen question or
+  paused-turn nudge lands at the physical tail, including composer-clearance padding,
+  so the real Submit or Resume action is visible above the overlaid composer. This is
+  a settled `ANCHOR_AT` hold, not `FOLLOW_BOTTOM`; one-shot navigation must not create
+  live-follow intent for later content. It routes through the scroll owner rather than
+  `scrollIntoView`, whose viewport intersection cannot detect composer coverage.
 
 The transition table is intentionally exhaustive; adding a new send or lifecycle
 path means routing it through the same entries rather than inventing another rule:
@@ -560,6 +566,7 @@ path means routing it through the same entries rather than inventing another rul
 | Chat exits/backgrounds/returns | any | `ANCHOR_AT` | Restore exact saved anchor |
 | In-process question is answered | any | same mode and active assistant row | None |
 | Live assistant row settles to the durable transcript | any | same mode and row identity | None (except R3's exact spacer handoff) |
+| Offscreen question/paused-turn nudge tapped | any hold | `ANCHOR_AT` at physical tail | User-requested one-shot move; clears the overlaid composer |
 
 Controller structure is part of the contract, not an implementation detail:
 

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -1990,13 +1990,15 @@
 }
 
 /* ── Build-milestone rail ──────────────────────────── */
-/* A slim, non-interactive progress rail in the foot, above the open-app CTA:
-   one dot+label per milestone the building agent emitted this turn. Frosted so
-   it reads as a card over the chat scrolling behind the transparent foot, muted
-   so it stays quiet next to the composer. The most recent phase is emphasized;
-   earlier ones dim to compact history. Entrance is transform/opacity ONLY — the
-   foot's ResizeObserver publishes --composer-h off its height, so a height
-   animation would fight the composer clearance. */
+/* A slim, non-interactive progress rail in the foot, directly above the composer:
+   one dot+label per milestone the building agent emitted this turn. Attention,
+   connection, queue, and open-app notices deliberately stack ABOVE this rail so
+   nothing interrupts its relationship to the chat controls. Frosted so it reads
+   as a card over the chat scrolling behind the transparent foot, muted so it
+   stays quiet next to the composer. The most recent phase is emphasized; earlier
+   ones dim to compact history. Entrance is transform/opacity ONLY — the foot's
+   ResizeObserver publishes --composer-h off its height, so a height animation
+   would fight the composer clearance. */
 .chat__build-rail {
   max-width: 720px;
   margin: 0 auto 8px;

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -3586,21 +3586,6 @@ export default function ChatView({
       )}
 
       <div ref={footRef} className="chat__foot">
-        {buildPhaseRail.length > 0 && (
-          <div className="chat__build-rail" role="group" aria-label="Build progress">
-            {buildPhaseRail.map(phase => (
-              <span
-                key={phase.ts}
-                className={`chat__build-phase${
-                  phase.current ? ' chat__build-phase--current' : ''
-                }`}
-              >
-                <span className="chat__build-phase-dot" aria-hidden="true" />
-                <span className="chat__build-phase-label">{phase.label}</span>
-              </span>
-            ))}
-          </div>
-        )}
         {openAppCtas.length > 0 && (
           <div className="chat__open-app">
             {openAppCtas.map(({ app, vm }) => {
@@ -3644,6 +3629,21 @@ export default function ChatView({
           onRetry={retry}
         />
         <QueuedMessages items={pendingQueue.pendingMessages} onCancel={handleCancelPending} />
+        {buildPhaseRail.length > 0 && (
+          <div className="chat__build-rail" role="group" aria-label="Build progress">
+            {buildPhaseRail.map(phase => (
+              <span
+                key={phase.ts}
+                className={`chat__build-phase${
+                  phase.current ? ' chat__build-phase--current' : ''
+                }`}
+              >
+                <span className="chat__build-phase-dot" aria-hidden="true" />
+                <span className="chat__build-phase-label">{phase.label}</span>
+              </span>
+            ))}
+          </div>
+        )}
         <ChatInputBar
           input={input}
           onInputChange={handleComposerInputChange}

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -797,6 +797,7 @@ export default function ChatView({
     closePreSendGestureWindow,
     freezeForegroundReturn,
     freezeQueuedSubmission,
+    revealConversationTail,
     reapplyActiveMode,
     settleNonPin,
     settleStreamingPin,
@@ -3621,12 +3622,7 @@ export default function ChatView({
           <button
             type="button"
             className="chat__question-nudge"
-            onClick={() => {
-              // USER-initiated scroll — the no-auto-scroll contract only
-              // forbids the app moving the viewport on its own; a tap on
-              // this chip is the user asking to be taken to the card.
-              findPendingQuestionCard()?.scrollIntoView({ block: 'nearest' })
-            }}
+            onClick={revealConversationTail}
           >
             Möbius asked you something — tap to answer
           </button>
@@ -3635,12 +3631,7 @@ export default function ChatView({
           <button
             type="button"
             className="chat__resume-nudge"
-            onClick={() => {
-              // USER-initiated scroll — same contract as the question nudge: a
-              // tap is the user asking to be taken to the card, not the app
-              // moving the viewport on its own.
-              findResumeCard()?.scrollIntoView({ block: 'nearest' })
-            }}
+            onClick={revealConversationTail}
           >
             {pendingResumeBlock?.pause?.resets_at
               ? 'Rate limit reached — tap to resume'

--- a/frontend/src/components/ChatView/__tests__/buildPhaseRail.test.js
+++ b/frontend/src/components/ChatView/__tests__/buildPhaseRail.test.js
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs'
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 
@@ -9,6 +10,8 @@ import {
   latestBuildPhaseAnnouncement,
   railAtRunStart,
 } from '../buildPhaseRail.js'
+
+const chatView = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8')
 
 test('buildPhaseFromEvent extracts label + ts and trims the label', () => {
   assert.deepEqual(
@@ -69,6 +72,28 @@ test('latestBuildPhaseAnnouncement announces the newest phase, empty when none',
 
 test('railAtRunStart resets to the shared empty rail', () => {
   assert.equal(railAtRunStart(), EMPTY_BUILD_PHASE_RAIL)
+})
+
+test('build rail is the final footer status strip directly above the composer', () => {
+  const footStart = chatView.indexOf('<div ref={footRef} className="chat__foot">')
+  const composer = chatView.indexOf('<ChatInputBar', footStart)
+  const foot = chatView.slice(footStart, composer)
+  const rail = foot.indexOf('className="chat__build-rail"')
+
+  assert.ok(footStart >= 0 && composer > footStart && rail >= 0,
+    'the footer, build rail, and composer must all be present')
+  for (const notice of [
+    'className="chat__open-app"',
+    'className="chat__question-nudge"',
+    'className="chat__resume-nudge"',
+    '<ConnectionStatus',
+    '<QueuedMessages',
+  ]) {
+    const noticeIndex = foot.indexOf(notice)
+    assert.ok(noticeIndex >= 0, `${notice} must be present in the footer`)
+    assert.ok(noticeIndex < rail,
+      `${notice} must stack above the build rail, never between it and the composer`)
+  }
 })
 
 test('a send that merely enqueues preserves the in-flight build rail', () => {

--- a/frontend/src/components/ChatView/__tests__/resumeAffordance.test.js
+++ b/frontend/src/components/ChatView/__tests__/resumeAffordance.test.js
@@ -53,7 +53,12 @@ test('Resume button clears the 44px touch floor with press feedback', () => {
     'the Resume button has :active press feedback')
 })
 
-test('ChatView mirrors the offscreen nudge for a scrolled-away resume card', () => {
+test('ChatView routes both offscreen attention nudges through the scroll owner', () => {
+  assert.match(
+    chatView,
+    /className="chat__question-nudge"\s+onClick=\{revealConversationTail\}/,
+    'the question nudge reveals the true usable tail through the scroll owner',
+  )
   assert.match(chatView, /hasPendingResume/,
     'ChatView detects a tail resumable pause/park block')
   assert.match(chatView, /const pendingResumeBlock = tailResumableBlock\(messages\)/,
@@ -64,8 +69,13 @@ test('ChatView mirrors the offscreen nudge for a scrolled-away resume card', () 
     'the non-park nudge copy names the pause')
   assert.match(chatView, /Rate limit reached — tap to resume/,
     'the park variant names the rate limit')
-  assert.match(chatView, /findResumeCard\(\)\?\.scrollIntoView/,
-    'tapping the nudge scrolls the resume card into view')
+  assert.match(
+    chatView,
+    /className="chat__resume-nudge"\s+onClick=\{revealConversationTail\}/,
+    'the resume nudge reveals the true usable tail through the scroll owner',
+  )
+  assert.doesNotMatch(chatView, /scrollIntoView\(\{ block: 'nearest' \}\)/,
+    'viewport intersection alone must not decide whether the action clears the composer')
   assert.match(css, /\.chat__resume-nudge/,
     'the resume nudge reuses the question-nudge visual style')
 })

--- a/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
+++ b/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
@@ -23,6 +23,7 @@ import {
   readerInputMayScroll,
   readerInputNeedsFrameRelease,
   settledPinMode,
+  physicalBottomAnchorModeFromScroll,
   shouldPinSend,
 } from '../useScrollMode.js'
 import {
@@ -547,6 +548,37 @@ test('an unresolvable saved location falls back to a settled bottom anchor', () 
   assert.equal(mode.defaultTail, true,
     'automatic fallback must not masquerade as a reader-chosen location')
   assert.notEqual(mode.kind, 'FOLLOW_BOTTOM')
+})
+
+test('attention nudge anchors the physical tail without enabling follow', () => {
+  const last = {
+    offsetTop: 1500,
+    offsetHeight: 220,
+    dataset: { key: 'assistant-attention-tail' },
+  }
+  const scrollEl = {
+    scrollHeight: 2100,
+    scrollTop: 700,
+    clientHeight: 700,
+    querySelector(selector) {
+      return selector === '[data-key="assistant-attention-tail"]' ? last : null
+    },
+    querySelectorAll(selector) {
+      return selector === '.chat__msg[data-key]' ? [last] : []
+    },
+  }
+
+  const mode = physicalBottomAnchorModeFromScroll(scrollEl)
+  assert.deepEqual(mode, {
+    kind: 'ANCHOR_AT',
+    key: 'assistant-attention-tail',
+    offset: 100,
+  })
+  applyMode(scrollEl, mode)
+  assert.equal(scrollEl.scrollTop, 1400,
+    'the move includes all composer clearance after the attention card')
+  assert.notEqual(mode.kind, 'FOLLOW_BOTTOM',
+    'revealing an action must not create live-follow intent')
 })
 
 test('chat exit freezes the visible anchor even at the physical tail', () => {

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -186,6 +186,31 @@ export function bottomAnchorModeFromScroll(scrollEl) {
 }
 
 
+/** Create a settled hold anchor at the true physical scroll tail.
+ *
+ * Sticky question and paused-turn nudges are explicit one-shot navigation.
+ * Their actions sit behind the overlaid composer, so merely bringing the card
+ * into the viewport can still leave Submit or Resume covered. Include all tail
+ * clearance, then hold as ANCHOR_AT instead of following future content.
+ */
+export function physicalBottomAnchorModeFromScroll(scrollEl) {
+  if (!scrollEl) return null
+  const items = scrollEl.querySelectorAll('.chat__msg[data-key]')
+  const last = items[items.length - 1]
+  const key = last?.dataset?.key
+  if (!last || !key) return null
+  const targetScrollTop = Math.max(
+    0,
+    scrollEl.scrollHeight - scrollEl.clientHeight,
+  )
+  return {
+    kind: 'ANCHOR_AT',
+    key,
+    offset: last.offsetTop - targetScrollTop,
+  }
+}
+
+
 /** Resolve the DOM row a PIN_USER_MSG targets: the user row whose
  *  `data-cid` equals the mode's cid.
  *
@@ -650,6 +675,7 @@ export function mountMediaSettled(scrollEl) {
  *   freezeQueuedSubmission: () => void,
  *   settleNonPin: (event?: object) => void,
  *   settleStreamingPin: () => void,
+ *   revealConversationTail: () => void,
  * }}
  */
 export default function useScrollMode({
@@ -1502,6 +1528,20 @@ export default function useScrollMode({
     writeMode,
   ])
 
+  // A sticky attention nudge is a reader-requested move, but not a gesture
+  // inside `.chat__scroll`. Route it through the mode owner so the absolutely
+  // positioned composer cannot cover the real action and the resulting hold
+  // position survives later layout work without creating live-follow intent.
+  const revealConversationTail = useCallback(() => {
+    const scrollEl = scrollRef.current
+    const nextMode = physicalBottomAnchorModeFromScroll(scrollEl)
+    if (!scrollEl || !nextMode) return
+    gestureWindowUntilRef.current = 0
+    transitionMode(nextMode, 'attention:reveal-physical-tail')
+    writeMode(scrollEl, nextMode, 'attention:reveal-physical-tail')
+    persistMode()
+  }, [persistMode, scrollRef, transitionMode, writeMode])
+
   return {
     modeRef,
     gestureWindowUntilRef,
@@ -1512,6 +1552,7 @@ export default function useScrollMode({
     closePreSendGestureWindow,
     freezeForegroundReturn,
     freezeQueuedSubmission,
+    revealConversationTail,
     reapplyActiveMode,
     settleNonPin,
     settleStreamingPin,

--- a/tests/app-canvas.spec.mjs
+++ b/tests/app-canvas.spec.mjs
@@ -488,14 +488,19 @@ test.describe('AppCanvas: iframe-mount contract', () => {
     await drawerToggle.click()
     await expect(drawerToggle).toHaveAttribute('aria-expanded', 'true')
 
-    await Promise.all([
-      frame.evaluate(() => {
-        window.parent.postMessage({ type: 'moebius:nav-pop' }, window.location.origin)
-      }),
-      page.evaluate(() => {
-        document.querySelector('[aria-label="Toggle navigation"]')?.click()
-      }),
-    ])
+    // Dispatch both requests in one parent-page task. Racing two independent
+    // CDP evaluations lets the drawer render detach the iframe before the
+    // frame-side evaluate is delivered, which tests Playwright scheduling
+    // rather than the shell's traversal arbitration.
+    await page.evaluate(id => {
+      const appFrame = document.querySelector(`iframe[data-app-id="${id}"]`)
+      window.dispatchEvent(new MessageEvent('message', {
+        data: { type: 'moebius:nav-pop' },
+        origin: window.location.origin,
+        source: appFrame?.contentWindow,
+      }))
+      document.querySelector('[aria-label="Toggle navigation"]')?.click()
+    }, appId)
     await expect(drawerToggle).toHaveAttribute('aria-expanded', 'false')
     await page.waitForTimeout(300)
     await expect(page.locator(`iframe[data-app-id="${appId}"]`)).toBeVisible()

--- a/tests/attention-nudges.spec.mjs
+++ b/tests/attention-nudges.spec.mjs
@@ -1,0 +1,166 @@
+/**
+ * Browser contract for sticky question / paused-turn attention nudges.
+ *
+ * The chat scroller extends behind an absolutely-positioned composer. The old
+ * `scrollIntoView({ block: 'nearest' })` actions stopped once their card
+ * intersected the scroll viewport, even though the composer still covered the
+ * card's Submit or Resume action.
+ *
+ * Run: npx playwright test tests/attention-nudges.spec.mjs
+ */
+import { test, expect } from '@playwright/test'
+import { createTaggedChat, attachCleanup } from './_chatTracker.mjs'
+
+const BASE = process.env.MOBIUS_URL || 'http://localhost:8001'
+
+attachCleanup()
+test.use({ serviceWorkers: 'block' })
+
+const SCENARIOS = [
+  {
+    name: 'paused-turn',
+    label: 'resume-nudge-tail',
+    cardSelector: '.chat__resume',
+    nudgeSelector: '.chat__resume-nudge',
+    actionSelector: '.chat__resume',
+    tailBlock: {
+      type: 'error',
+      message: 'Paused for a platform update.',
+      resumable: true,
+      pause: { kind: 'restart' },
+    },
+  },
+  {
+    name: 'question',
+    label: 'question-nudge-tail',
+    cardSelector: '.qcard',
+    nudgeSelector: '.chat__question-nudge',
+    actionSelector: '.qcard__submit',
+    tailBlock: {
+      type: 'question',
+      question_id: 'attention-nudge-question',
+      questions: [{
+        id: 'attention_nudge_answer',
+        question: 'Which option should we use?',
+        header: 'Choice',
+        multiSelect: false,
+        options: [
+          { label: 'First', description: 'Choose the first option.' },
+          { label: 'Second', description: 'Choose the second option.' },
+        ],
+      }],
+    },
+  },
+]
+
+for (const scenario of SCENARIOS) {
+  test(`${scenario.name} nudge clears the composer and lands at the physical tail`, async ({ page }) => {
+    await page.setViewportSize({ width: 1512, height: 861 })
+    await page.goto(BASE, { waitUntil: 'domcontentloaded' })
+    await page.waitForFunction(
+      () => !!(document.querySelector('.chat__empty-wrap')
+        || document.querySelector('.chat__scroll')
+        || document.querySelector('.chat__form')),
+      { timeout: 10000 },
+    )
+
+    const chat = await createTaggedChat(page, scenario.label)
+    expect(chat?.id).toBeTruthy()
+
+    const paragraphs = Array.from({ length: 42 }, (_, i) => ({
+      type: 'text',
+      content: `Attention history ${i + 1}. ${'Enough content to overflow the viewport. '.repeat(8)}`,
+    }))
+    const messages = [
+      {
+        role: 'user',
+        content: 'Please continue after the long review.',
+        ts: 1700000200000,
+        cid: `${scenario.label}-user`,
+        blocks: [{
+          type: 'text',
+          content: 'Please continue after the long review.',
+        }],
+      },
+      {
+        role: 'assistant',
+        content: '',
+        ts: 1700000200001,
+        blocks: [...paragraphs, scenario.tailBlock],
+      },
+    ]
+
+    await page.route(new RegExp(`/api/chats/${chat.id}\\?limit=`), route => {
+      if (route.request().method() !== 'GET') return route.continue()
+      return route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          messages,
+          total: messages.length,
+          offset: 0,
+          running: false,
+          pending_messages: [],
+        }),
+      })
+    })
+    await page.route(new RegExp(`/api/chats/${chat.id}/stream$`), route =>
+      route.fulfill({ status: 204, body: '' }))
+
+    await page.evaluate(chatId => {
+      localStorage.setItem('moebius_active_chat', chatId)
+    }, chat.id)
+    await page.goto(`${BASE}/shell/?chat=${chat.id}`, { waitUntil: 'domcontentloaded' })
+
+    await expect(page.locator('.chat__scroll')).toBeVisible({ timeout: 15000 })
+    await expect(page.locator(scenario.cardSelector)).toBeVisible({ timeout: 5000 })
+    await page.waitForFunction(() => {
+      const scroll = document.querySelector('.chat__scroll')
+      return !!scroll && scroll.scrollHeight > scroll.clientHeight + 1000
+    }, { timeout: 5000 })
+
+    await page.evaluate(() => {
+      const scroll = document.querySelector('.chat__scroll')
+      if (!scroll) return
+      scroll.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
+      scroll.scrollTop = Math.max(
+        0,
+        scroll.scrollHeight - scroll.clientHeight - 1200,
+      )
+    })
+    const nudge = page.locator(scenario.nudgeSelector)
+    await expect(nudge).toBeVisible({ timeout: 5000 })
+
+    await nudge.click()
+
+    await page.waitForFunction(nudgeSelector => {
+      const scroll = document.querySelector('.chat__scroll')
+      if (!scroll || document.querySelector(nudgeSelector)) return false
+      return Math.abs(scroll.scrollHeight - scroll.clientHeight - scroll.scrollTop) <= 1
+    }, scenario.nudgeSelector, { timeout: 5000 })
+
+    const geometry = await page.evaluate(({ chatId, actionSelector }) => {
+      const scroll = document.querySelector('.chat__scroll')
+      const action = document.querySelector(actionSelector)
+      const composer = document.querySelector('.chat__pill')
+      let mode = null
+      try {
+        mode = JSON.parse(sessionStorage.getItem('chat-mode') || '{}')[chatId]
+      } catch { /* assertion below reports null */ }
+      const actionRect = action?.getBoundingClientRect()
+      const composerRect = composer?.getBoundingClientRect()
+      return {
+        remaining: scroll
+          ? scroll.scrollHeight - scroll.clientHeight - scroll.scrollTop
+          : null,
+        actionBottom: actionRect?.bottom ?? null,
+        composerTop: composerRect?.top ?? null,
+        modeKind: mode?.kind ?? null,
+      }
+    }, { chatId: chat.id, actionSelector: scenario.actionSelector })
+
+    expect(Math.abs(geometry.remaining)).toBeLessThanOrEqual(1)
+    expect(geometry.actionBottom).toBeLessThan(geometry.composerTop)
+    expect(geometry.modeKind).toBe('ANCHOR_AT')
+  })
+}

--- a/tests/attention-nudges.spec.mjs
+++ b/tests/attention-nudges.spec.mjs
@@ -6,7 +6,7 @@
  * intersected the scroll viewport, even though the composer still covered the
  * card's Submit or Resume action.
  *
- * Run: npx playwright test tests/attention-nudges.spec.mjs
+ * Run: scripts/playwright-local.sh --allow-local-e2e tests/attention-nudges.spec.mjs
  */
 import { test, expect } from '@playwright/test'
 import { createTaggedChat, attachCleanup } from './_chatTracker.mjs'

--- a/tests/attention-nudges.spec.mjs
+++ b/tests/attention-nudges.spec.mjs
@@ -99,13 +99,30 @@ for (const scenario of SCENARIOS) {
           messages,
           total: messages.length,
           offset: 0,
-          running: false,
+          // Build phases only arrive while a chat stream is active. Mirror the
+          // real build state so this exercises event delivery, not just markup.
+          running: true,
           pending_messages: [],
         }),
       })
     })
+    const streamBody = [
+      `data: ${JSON.stringify({
+        type: 'build_phase',
+        label: 'Guarded service boundary ready — Tandoor migrated safely',
+        ts: 1700000200002,
+      })}\n\n`,
+      'data: {"type":"catch_up_done"}\n\n',
+    ].join('')
     await page.route(new RegExp(`/api/chats/${chat.id}/stream$`), route =>
-      route.fulfill({ status: 204, body: '' }))
+      route.fulfill({
+        status: 200,
+        headers: {
+          'Content-Type': 'text/event-stream',
+          'Cache-Control': 'no-cache',
+        },
+        body: streamBody,
+      }))
 
     await page.evaluate(chatId => {
       localStorage.setItem('moebius_active_chat', chatId)
@@ -130,6 +147,17 @@ for (const scenario of SCENARIOS) {
     })
     const nudge = page.locator(scenario.nudgeSelector)
     await expect(nudge).toBeVisible({ timeout: 5000 })
+    const rail = page.locator('.chat__build-rail')
+    const composer = page.locator('.chat__pill')
+    await expect(rail).toBeVisible({ timeout: 5000 })
+
+    const [nudgeBox, railBox, composerBox] = await Promise.all([
+      nudge.boundingBox(),
+      rail.boundingBox(),
+      composer.boundingBox(),
+    ])
+    expect((nudgeBox?.y ?? 0) + (nudgeBox?.height ?? 0)).toBeLessThan(railBox?.y)
+    expect((railBox?.y ?? 0) + (railBox?.height ?? 0)).toBeLessThan(composerBox?.y)
 
     await nudge.click()
 


### PR DESCRIPTION
## Summary
- reveal off-screen question and paused-turn actions directly above the composer
- route both attention nudges through the current scroll owner so reader intent remains authoritative
- keep the build milestone rail as the final footer status strip, immediately beside the controls it describes
- preserve run-start reset, replay deduplication, queue behavior, and accessible phase announcements
- fix the app-canvas regression fixture so its mocked runtime matches the real event protocol

## Testing
- full frontend unit and hook suites
- production frontend and service-worker build
- focused isolated Playwright attention checks — passed
- focused isolated Playwright build-progress checks — 3 passed
- pre-push privacy and frontend gates — passed
