### PR TITLE
Isolate browser tests from owner conversations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,12 +2,9 @@ name: Tests
 
 on:
   push:
-    # All long-lived branches get CI on push, not just main. Today's
-    # session shipped three commits to integration/ux-recovery-mod
-    # that would have broken three frontend tests if main-only CI
-    # had been the gate — instead the breakage was found ~10 hours
-    # later during a manual mobius-test rebuild. CI minutes are
-    # cheap; finding regressions early is not.
+    # Cheap checks run on development branches too. The e2e job below narrows
+    # its own execution to PRs and long-lived branches, avoiding a duplicate
+    # full browser run for both a feature push and its PR event.
     branches: [main, 'integration/**', 'feat/**', 'fix/**']
   pull_request:
     # True PR stacks target the upstream branch directly beneath them. Run the
@@ -108,6 +105,8 @@ jobs:
           node-version: 20
       - name: Run static app packager tests
         run: npm run test:packager
+      - name: Run browser harness unit tests
+        run: npm run test:e2e-harness
 
   core-apps-unit:
     runs-on: ubuntu-latest
@@ -135,6 +134,14 @@ jobs:
         run: scripts/check-core-apps-sync.sh
 
   e2e:
+    # Full browser E2E is the comprehensive integration gate, not a per-push
+    # development loop. Run it for reviewable PRs and long-lived branches;
+    # feature/fix branch pushes still get the cheap jobs above without paying
+    # twice before their PR check.
+    if: >-
+      github.event_name == 'pull_request' ||
+      github.ref == 'refs/heads/main' ||
+      startsWith(github.ref, 'refs/heads/integration/')
     runs-on: ubuntu-latest
     # Building the Docker image can take several minutes on cold hosted
     # runners. Keep the job cap comfortably above the inner Playwright timeout

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,15 +80,20 @@ returning always preserves the exact visible anchor and never restores
 auto-scroll to a newer tail. New send and lifecycle paths must use the shared
 state machine rather than deriving intent from geometry alone.
 
-**End-to-end (Playwright).** From the repo root, against a running `mobius-test`
-container on port 8001 (the suite defaults to `http://localhost:8001`, owner
-`admin/admin`):
+**End-to-end (Playwright).** Comprehensive browser checks run in GitHub after a
+PR is opened. Do not point raw Playwright, an auth setup, or a preview proxy at
+a live Möbius backend. For a rare local reproduction, first commit the exact
+revision, then run the host-only disposable wrapper from a Docker-capable host:
 
 ```bash
 npm ci && npx playwright install --with-deps chrome
-npx playwright test                       # full suite
-npx playwright test tests/navigation.spec.mjs   # one file
+scripts/playwright-local.sh --allow-local-e2e tests/navigation.spec.mjs
 ```
+
+The wrapper clones that committed revision into temporary storage, builds a
+separate backend/database/credential set on random ports, uses one browser
+worker, and tears the stack down. It intentionally refuses uncommitted source
+changes so the browser tests and served runtime cannot drift apart.
 
 ## Dev loop: live app rebuild
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,13 @@
 # Builds the frontend, installs the backend + CLI tools, and serves
 # everything from one FastAPI process.  Works on VPS, Railway, PikaPods.
 
+# Keep the Node runtime source independent of the frontend build. Copying Node
+# from the completed frontend stage made every UI edit invalidate the backend's
+# expensive apt/agent-CLI/browser layers during local E2E builds.
+FROM node:22-slim AS node-runtime
+
 # -- Stage 1: build the frontend --------------------------------------
-FROM node:22-slim AS frontend
+FROM node-runtime AS frontend
 
 WORKDIR /build
 COPY frontend/package.json frontend/package-lock.json* ./
@@ -18,8 +23,8 @@ FROM python:3.12-slim
 # Copy Node.js binary from the frontend stage instead of installing via
 # apt.  The debian nodejs/npm packages pull in ~200MB of system node
 # packages we don't need — only the claude CLI and npm globals need Node.
-COPY --from=frontend /usr/local/bin/node /usr/local/bin/node
-COPY --from=frontend /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/npm
+COPY --from=node-runtime /usr/local/bin/node /usr/local/bin/node
+COPY --from=node-runtime /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/npm
 RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
     && ln -s ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
@@ -143,26 +148,6 @@ try{const t=JSON.parse(cp.execSync('npm view '+name+'@'+v+' time --json',{stdio:
 fs.writeFileSync('/app/cli-release-dates.json',JSON.stringify(out));\
 console.log('cli-release-dates.json:',JSON.stringify(out));" \
     || echo '{}' > /app/cli-release-dates.json
-
-COPY backend/app ./app/
-COPY backend/scripts ./scripts/
-COPY skill/ ./skill/
-COPY core-apps/ ./core-apps/
-COPY protected-files.txt ./protected-files.txt
-
-# Frozen recovery floor (recoveryd) — the Tier-1 recovery system that runs
-# in its OWN container (same image, command `python3 -P /app/recovery/
-# recoveryd.py`). It imports ZERO app.* code and survives a fully-broken
-# platform. Baked root-owned + chmod a-w so even root can't modify it in
-# place and the agent (mobius) cannot touch it; recoveryd self-checks this
-# at startup and refuses to run if any file is writable. This is the floor
-# of the recovery story, distinct from the platform-baked backend floor.
-COPY backend/recovery ./recovery/
-RUN chmod -R a-w /app/recovery
-
-# Frontend static files + app-frame served by FastAPI.
-COPY --from=frontend /build/dist ./static/
-COPY frontend/public/app-frame.html ./app-frame.html
 
 # Self-hosted vendor libs for mini-app import maps. Pinned via npm
 # install at image build time, served same-origin under /vendor/ with
@@ -347,6 +332,13 @@ RUN mkdir -p /tmp/dompurify-install && cd /tmp/dompurify-install \
          /app/static/vendor/dompurify@3.4.11 "$(command -v esbuild)" \
     && cd / && rm -rf /tmp/dompurify-install /tmp/build-dompurify-vendor.mjs
 
+# Copy revision-varying source only after the expensive pinned vendor layers.
+# COPY merges the frontend build into the existing /app/static tree, retaining
+# the self-hosted vendor directory created above. This keeps ordinary backend,
+# script, and UI edits from rebuilding every vendored browser dependency.
+COPY --from=frontend /build/dist ./static/
+COPY frontend/public/app-frame.html ./app-frame.html
+
 # Full frontend source with installed node_modules. /app/shell-src is kept so
 # /data/platform/frontend/node_modules can symlink to it at runtime.
 COPY frontend/ ./shell-src/
@@ -439,7 +431,18 @@ RUN printf 'mobius ALL=(root) NOPASSWD: /usr/bin/apt-get, /usr/bin/apt, /usr/bin
     && chmod 440 /etc/sudoers.d/mobius-apt \
     && visudo -cf /etc/sudoers.d/mobius-apt
 
-COPY backend/scripts/entrypoint.sh ./scripts/entrypoint.sh
+# Runtime source belongs at the tail of the image so normal code changes reuse
+# the browser, CLI, Python, vendor, and platform-seed layers above.
+COPY backend/app ./app/
+COPY backend/scripts ./scripts/
+COPY skill/ ./skill/
+COPY core-apps/ ./core-apps/
+COPY protected-files.txt ./protected-files.txt
+
+# Frozen recovery floor (recoveryd) — the Tier-1 recovery system that runs in
+# its own container. It imports no app.* code and remains root-owned/read-only.
+COPY backend/recovery ./recovery/
+RUN chmod -R a-w /app/recovery
 RUN chmod +x ./scripts/entrypoint.sh
 
 # Build identity — passed at `docker compose build` time (deploy-prod.sh

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -878,6 +878,10 @@ def version():
   settings = get_settings()
   return {"sha": settings.build_sha,
           "build_date": settings.build_date,
+          # Browser setup verifies this dedicated test-container marker before
+          # any write. Localhost is not sufficient evidence because a preview
+          # proxy can still forward to the live app.
+          "test_runtime": os.environ.get("MOBIUS_TEST_RUNTIME") == "1",
           **_served_platform_identity(settings.data_dir),
           **_served_frontend_identity()}
 

--- a/backend/scripts/verify_test_runtime.py
+++ b/backend/scripts/verify_test_runtime.py
@@ -21,6 +21,8 @@ PLATFORM_ROOT = Path("/data/platform")
 def validate_runtime(version: dict[str, object], head: str, expected: str) -> list[str]:
   """Return identity errors; an empty list means the runtime is coherent."""
   errors: list[str] = []
+  if version.get("test_runtime") is not True:
+    errors.append(f"test_runtime={version.get('test_runtime')!r}")
   if version.get("serving_source") != "platform":
     errors.append(f"serving_source={version.get('serving_source')!r}")
   if version.get("frontend_source") != "platform":
@@ -44,7 +46,15 @@ def main() -> int:
     with urlopen(VERSION_URL, timeout=3) as response:
       version = json.load(response)
     head = subprocess.run(
-      ["git", "-C", str(PLATFORM_ROOT), "rev-parse", "HEAD"],
+      [
+        "git",
+        "-c",
+        f"safe.directory={PLATFORM_ROOT}",
+        "-C",
+        str(PLATFORM_ROOT),
+        "rev-parse",
+        "HEAD",
+      ],
       check=True,
       capture_output=True,
       text=True,

--- a/backend/tests/test_verify_test_runtime.py
+++ b/backend/tests/test_verify_test_runtime.py
@@ -1,4 +1,7 @@
+import os
 from pathlib import Path
+import shutil
+import subprocess
 
 from scripts.verify_test_runtime import validate_runtime
 
@@ -9,6 +12,7 @@ ROOT = Path(__file__).resolve().parents[2]
 
 def _version(**overrides):
   value = {
+    "test_runtime": True,
     "sha": SHA,
     "serving_source": "platform",
     "served_sha": SHA,
@@ -46,6 +50,11 @@ def test_rejects_baked_or_mismatched_runtime():
   assert any("sha=" in error for error in errors)
 
 
+def test_rejects_runtime_without_explicit_test_identity():
+  errors = validate_runtime(_version(test_runtime=False), SHA, SHA)
+  assert any("test_runtime" in error for error in errors)
+
+
 def test_rejects_checkout_that_differs_from_ci_sha():
   other = "b" * 40
   errors = validate_runtime(_version(), SHA, other)
@@ -78,6 +87,13 @@ def test_pre_push_syntax_check_keeps_bytecode_out_of_checkout():
   assert 'PYTHONPYCACHEPREFIX="$PP_TMP/pycache"' in hook
 
 
+def test_identity_verifier_allows_the_mobius_owned_platform_repo():
+  verifier = (ROOT / "backend/scripts/verify_test_runtime.py").read_text(
+    encoding="utf-8"
+  )
+  assert 'f"safe.directory={PLATFORM_ROOT}"' in verifier
+
+
 def test_test_runtime_seed_precedes_selection_and_skips_reconcile():
   entrypoint = (
     ROOT / "backend" / "scripts" / "entrypoint.sh"
@@ -89,3 +105,135 @@ def test_test_runtime_seed_precedes_selection_and_skips_reconcile():
     'if [ "$_use_platform" -eq 1 ] && '
     '[ "${MOBIUS_TEST_RUNTIME:-0}" != "1" ]; then'
   ) in entrypoint
+
+
+def test_browser_setup_fails_closed_before_auth_and_never_wipes_chats():
+  setup = (ROOT / "tests" / "auth.setup.mjs").read_text(encoding="utf-8")
+  marker_probe = 'request.get(`${BASE}/api/version`'
+  auth_write = 'request.post(`${BASE}/api/auth/setup`'
+  assert marker_probe in setup
+  assert "version?.test_runtime !== true" in setup
+  assert setup.index(marker_probe) < setup.index(auth_write)
+  assert 'request.get(`${BASE}/api/chats`' not in setup
+  assert 'request.delete(`${BASE}/api/chats/' not in setup
+
+
+def test_chat_cleanup_uses_registered_ids_without_account_listing():
+  tracker = (ROOT / "tests" / "_chatTracker.mjs").read_text(encoding="utf-8")
+  assert "registerCreatedChats" in tracker
+  assert "drainCreatedChats" in tracker
+  assert "Promise.all(ids.map" in tracker
+  assert 'request.get(`${BASE}/api/chats`' not in tracker
+
+
+def test_local_browser_e2e_is_explicit_and_disposable():
+  config = (ROOT / "playwright.config.mjs").read_text(encoding="utf-8")
+  runner = (ROOT / "scripts" / "playwright-local.sh").read_text(encoding="utf-8")
+  assert "MOBIUS_LOCAL_E2E" in config
+  assert "MOBIUS_AUTH_FILE" in config
+  assert "--allow-local-e2e" in runner
+  assert "down -v --remove-orphans" in runner
+  assert 'value.get("test_runtime") is not True' in runner
+  assert 'MOBIUS_AUTH_FILE="$auth_file"' in runner
+  assert 'git clone --quiet --no-local "$ROOT" "$snapshot_dir"' in runner
+  assert '--project-directory "$snapshot_dir"' in runner
+  assert 'cd "$snapshot_dir"' in runner
+  assert '"$snapshot_dir/node_modules/.bin/playwright" test "$@" --workers=1' in runner
+  assert 'error: timed out waiting for the isolated test backend' in runner
+
+
+def _git(repo: Path, *args: str):
+  return subprocess.run(
+    ["git", "-C", str(repo), *args], check=True, capture_output=True, text=True
+  )
+
+
+def _init_repo(repo: Path):
+  repo.mkdir(parents=True)
+  _git(repo, "init", "-q")
+  _git(repo, "config", "user.name", "Test")
+  _git(repo, "config", "user.email", "test@example.com")
+
+
+def test_local_runner_refuses_uncommitted_edits_before_docker(tmp_path):
+  repo = tmp_path / "repo"
+  _init_repo(repo)
+  (repo / "scripts").mkdir()
+  shutil.copy2(ROOT / "scripts" / "playwright-local.sh", repo / "scripts")
+  playwright = repo / "node_modules" / ".bin" / "playwright"
+  playwright.parent.mkdir(parents=True)
+  playwright.write_text("#!/bin/sh\nexit 99\n", encoding="utf-8")
+  playwright.chmod(0o755)
+  tracked = repo / "tracked.txt"
+  tracked.write_text("clean\n", encoding="utf-8")
+  _git(repo, "add", ".")
+  _git(repo, "commit", "-qm", "fixture")
+  tracked.write_text("dirty\n", encoding="utf-8")
+
+  fake_bin = tmp_path / "bin"
+  fake_bin.mkdir()
+  docker = fake_bin / "docker"
+  docker.write_text("#!/bin/sh\nexit 99\n", encoding="utf-8")
+  docker.chmod(0o755)
+  result = subprocess.run(
+    [str(repo / "scripts" / "playwright-local.sh"), "--allow-local-e2e"],
+    cwd=repo,
+    capture_output=True,
+    text=True,
+    env={**os.environ, "PATH": f"{fake_bin}:{os.environ['PATH']}"},
+  )
+  assert result.returncode == 2
+  assert "requires a committed revision" in result.stderr
+
+  _git(repo, "restore", "tracked.txt")
+  (repo / "new-source.py").write_text("untracked\n", encoding="utf-8")
+  result = subprocess.run(
+    [str(repo / "scripts" / "playwright-local.sh"), "--allow-local-e2e"],
+    cwd=repo,
+    capture_output=True,
+    text=True,
+    env={**os.environ, "PATH": f"{fake_bin}:{os.environ['PATH']}"},
+  )
+  assert result.returncode == 2
+  assert "requires a committed revision" in result.stderr
+
+
+def test_no_local_clone_from_linked_worktree_has_standalone_git_dir(tmp_path):
+  repo = tmp_path / "repo"
+  _init_repo(repo)
+  (repo / "tracked.txt").write_text("one\n", encoding="utf-8")
+  _git(repo, "add", ".")
+  _git(repo, "commit", "-qm", "fixture")
+  linked = tmp_path / "linked"
+  snapshot = tmp_path / "snapshot"
+  _git(repo, "worktree", "add", "-q", "--detach", str(linked), "HEAD")
+
+  subprocess.run(
+    ["git", "clone", "--quiet", "--no-local", str(linked), str(snapshot)],
+    check=True,
+  )
+  assert (linked / ".git").is_file()
+  assert (snapshot / ".git").is_dir()
+  assert _git(snapshot, "rev-parse", "HEAD").stdout == _git(
+    linked, "rev-parse", "HEAD"
+  ).stdout
+
+
+def test_documented_browser_commands_use_disposable_runner():
+  contributing = (ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
+  spec_text = "\n".join(
+    path.read_text(encoding="utf-8") for path in (ROOT / "tests").glob("*.mjs")
+  )
+  assert "npx playwright test" not in contributing
+  assert "npx playwright test" not in spec_text
+  assert "playwright-local.sh --allow-local-e2e" in contributing
+
+
+def test_hosted_e2e_runs_for_prs_and_long_lived_branches_only():
+  workflow = (ROOT / ".github" / "workflows" / "test.yml").read_text(
+    encoding="utf-8"
+  )
+  e2e = workflow.split("\n  e2e:\n", 1)[1]
+  assert "github.event_name == 'pull_request'" in e2e
+  assert "github.ref == 'refs/heads/main'" in e2e
+  assert "refs/heads/integration/" in e2e

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "scripts": {
     "test:core-apps": "node scripts/test-core-apps.mjs",
+    "test:e2e-harness": "node --test tests/chat-fixture-registry.test.mjs",
     "test:packager": "node --test scripts/package-static-app.test.mjs"
   },
   "devDependencies": {

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -3,7 +3,7 @@ import { existsSync, readdirSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 
-const AUTH_FILE = 'tests/.auth/state.json'
+const AUTH_FILE = process.env.MOBIUS_AUTH_FILE || 'tests/.auth/state.json'
 const isCI = !!process.env.CI
 
 /** Resolve the Chrome-for-Testing binary already installed for agent-browser.
@@ -42,6 +42,14 @@ function localChromeExecutable() {
 
 const localChrome = isCI ? null : localChromeExecutable()
 
+if (!isCI && process.env.MOBIUS_LOCAL_E2E !== '1') {
+  throw new Error(
+    'Local Playwright E2E is opt-in because it builds a disposable Möbius ' +
+    'backend and database. Prefer the GitHub PR checks. For a focused local ' +
+    'run, use scripts/playwright-local.sh --allow-local-e2e <spec or --grep>.'
+  )
+}
+
 export default defineConfig({
   testDir: './tests',
   timeout: 60000,
@@ -55,9 +63,9 @@ export default defineConfig({
   retries: 1,
   // Per-file parallelism. Within a file, tests stay sequential
   // because many spec files share state via send-then-read patterns
-  // (the streaming and queue tests in particular). Across files
-  // is safe: auth.setup.mjs wipes chats before the suite starts,
-  // and each spec file's tests operate on chats they create.
+  // (the streaming and queue tests in particular). Across files is safe
+  // because the run uses a disposable database and specs operate on explicit
+  // fixtures they create or mock.
   fullyParallel: false,
   // Match CI's worker count locally too. The previous local=4 setting
   // saturated mobius-test (single SQLite, single uvicorn) and produced

--- a/scripts/playwright-local.sh
+++ b/scripts/playwright-local.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Explicit, host-only Playwright runner over one committed, disposable revision.
+
+set -euo pipefail
+
+if [[ "${1:-}" != "--allow-local-e2e" ]]; then
+  cat >&2 <<'EOF'
+Local browser E2E is intentionally opt-in: it builds a full disposable
+Möbius stack and can take several minutes. Prefer the GitHub PR checks.
+
+Run this on a Docker-capable host, not inside the Möbius app container:
+  scripts/playwright-local.sh --allow-local-e2e <spec or --grep arguments>
+EOF
+  exit 2
+fi
+shift
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+for command_name in git docker curl flock python3 sha256sum; do
+  command -v "$command_name" >/dev/null || {
+    echo "error: $command_name is required for isolated local E2E" >&2
+    exit 2
+  }
+done
+
+if [[ ! -x "$ROOT/node_modules/.bin/playwright" ]]; then
+  echo "error: Playwright is not installed; run 'npm ci' from $ROOT" >&2
+  exit 2
+fi
+
+# The disposable runtime intentionally serves a committed tree. Refuse tracked
+# edits rather than running working-tree tests against an older backend/frontend
+# from HEAD and reporting a false result. Ignored build artifacts do not affect
+# the snapshot; non-ignored untracked source does.
+if ! git diff --quiet \
+    || ! git diff --cached --quiet \
+    || [[ -n "$(git ls-files --others --exclude-standard)" ]]; then
+  cat >&2 <<'EOF'
+error: local E2E requires a committed revision.
+Commit or stash source changes first so the tests and runtime use identical code.
+EOF
+  exit 2
+fi
+
+head_sha="$(git rev-parse --verify HEAD)"
+root_id="$(printf '%s' "$ROOT" | sha256sum | cut -c1-12)"
+lock_path="${TMPDIR:-/tmp}/mobius-local-e2e-${root_id}.lock"
+exec 9>"$lock_path"
+if ! flock -n 9; then
+  echo "error: another isolated local E2E run is active for $ROOT" >&2
+  exit 2
+fi
+run_id="$(date +%s)-$$"
+project="mobius-local-e2e-${run_id}"
+image_name="mobius-local-e2e-${root_id}:test"
+app_container="${project}-app"
+recovery_container="${project}-recoveryd"
+test_publish_port="${TEST_PORT:-0}"
+recovery_publish_port="${RECOVERY_TEST_PORT:-0}"
+run_dir="$(mktemp -d "${TMPDIR:-/tmp}/mobius-local-e2e.XXXXXX")"
+snapshot_dir="$run_dir/source"
+auth_file="$run_dir/auth-state.json"
+compose_used=0
+
+compose() {
+  # The baked fallback clones GitHub and cannot fetch an unpublished local
+  # commit. Leave that fallback unstamped; the mounted /workspace checkout and
+  # runtime BUILD_SHA below still use the exact committed local revision.
+  MOBIUS_CONTAINER="$app_container" \
+  MOBIUS_RECOVERYD_CONTAINER="$recovery_container" \
+  MOBIUS_IMAGE="$image_name" \
+  TEST_PORT="$test_publish_port" \
+  RECOVERY_TEST_PORT="$recovery_publish_port" \
+  BUILD_SHA=unknown \
+  GITHUB_SHA="$head_sha" \
+    docker compose -p "$project" -f "$snapshot_dir/docker-compose.test.yml" \
+      --project-directory "$snapshot_dir" "$@"
+}
+
+cleanup() {
+  if [[ "$compose_used" == "1" ]]; then
+    compose down -v --remove-orphans >/dev/null 2>&1 || true
+  fi
+  rm -rf "$run_dir"
+}
+trap cleanup EXIT
+trap 'exit 130' INT TERM
+
+# A real standalone clone gives linked worktrees a self-contained .git
+# directory inside /workspace. --no-local copies objects instead of writing an
+# alternates path that would point outside the container mount.
+git clone --quiet --no-local "$ROOT" "$snapshot_dir"
+git -C "$snapshot_dir" checkout --quiet --detach "$head_sha"
+snapshot_sha="$(git -C "$snapshot_dir" rev-parse --verify HEAD)"
+if [[ "$snapshot_sha" != "$head_sha" ]]; then
+  echo "error: revision snapshot mismatch ($snapshot_sha != $head_sha)" >&2
+  exit 1
+fi
+
+# Playwright runs from the same committed snapshot as the disposable server.
+# node_modules is host-only and excluded from the Docker build context.
+node_modules_root="$(cd "$ROOT/node_modules" && pwd -P)"
+ln -s "$node_modules_root" "$snapshot_dir/node_modules"
+
+echo "Building disposable test stack for ${head_sha:0:12} (project: $project)..."
+compose_used=1
+compose build
+compose up -d
+test_port="$(docker port "$app_container" 8000/tcp | tail -1 | awk -F: '{print $NF}')"
+if [[ -z "$test_port" ]]; then
+  echo "error: Docker did not publish the isolated backend port" >&2
+  exit 1
+fi
+
+echo "Waiting for isolated backend identity check..."
+healthy=0
+for _ in $(seq 1 60); do
+  health="$(docker inspect --format='{{.State.Health.Status}}' "$app_container" 2>/dev/null || true)"
+  if [[ "$health" == "healthy" ]]; then
+    healthy=1
+    break
+  fi
+  if [[ "$health" == "unhealthy" ]]; then
+    docker inspect --format='{{range .State.Health.Log}}{{println .Output}}{{end}}' \
+      "$app_container" >&2 || true
+    compose logs --tail 200 app
+    echo "error: isolated test backend is unhealthy" >&2
+    exit 1
+  fi
+  sleep 2
+done
+if [[ "$healthy" != "1" ]]; then
+  compose logs --tail 200 app
+  echo "error: timed out waiting for the isolated test backend" >&2
+  exit 1
+fi
+
+version="$(curl -fsS "http://127.0.0.1:${test_port}/api/version")"
+python3 -c '
+import json, sys
+value = json.loads(sys.argv[1])
+expected = sys.argv[2]
+errors = []
+if value.get("test_runtime") is not True:
+    errors.append("test_runtime is not true")
+serving_source = value.get("serving_source")
+if serving_source != "platform":
+    errors.append(f"serving_source={serving_source!r}")
+frontend_source = value.get("frontend_source")
+if frontend_source != "platform":
+    errors.append(f"frontend_source={frontend_source!r}")
+for field in ("sha", "served_sha", "platform_sha"):
+    if value.get(field) != expected:
+        errors.append(f"{field}={value.get(field)!r}, want {expected}")
+if errors:
+    raise SystemExit("refusing browser run: " + "; ".join(errors))
+' "$version" "$head_sha"
+
+echo "Running focused Playwright checks with one worker..."
+cd "$snapshot_dir"
+CI= \
+MOBIUS_LOCAL_E2E=1 \
+MOBIUS_AUTH_FILE="$auth_file" \
+MOBIUS_URL="http://127.0.0.1:${test_port}" \
+MOBIUS_USER=admin \
+MOBIUS_PASS=admin \
+  "$snapshot_dir/node_modules/.bin/playwright" test "$@" --workers=1

--- a/tests/_chatFixtureRegistry.mjs
+++ b/tests/_chatFixtureRegistry.mjs
@@ -1,0 +1,21 @@
+/** Process-local registry of exact chat fixture IDs created by each worker. */
+const createdChatIdsByWorker = new Map()
+
+export function registerCreatedChats(workerIndex, chatsOrIds) {
+  const values = Array.isArray(chatsOrIds) ? chatsOrIds : [chatsOrIds]
+  let ids = createdChatIdsByWorker.get(workerIndex)
+  if (!ids) {
+    ids = new Set()
+    createdChatIdsByWorker.set(workerIndex, ids)
+  }
+  for (const value of values) {
+    const id = typeof value === 'string' ? value : value?.id
+    if (id) ids.add(id)
+  }
+}
+
+export function drainCreatedChats(workerIndex) {
+  const ids = [...(createdChatIdsByWorker.get(workerIndex) || [])]
+  createdChatIdsByWorker.delete(workerIndex)
+  return ids
+}

--- a/tests/_chatTracker.mjs
+++ b/tests/_chatTracker.mjs
@@ -3,22 +3,9 @@
  *
  * Why this exists
  * ---------------
- * `auth.setup.mjs` wipes chats once before the whole suite. With
- * `workers: 4`, every worker creates chats in the same SQLite file
- * and they accumulate until the next run. Any test that lists chats
- * sees the union of in-flight work from all workers.
- *
- * Per-worker DATABASE_URL isolation would require N containers — the
- * backend builds its engine at import time, not per-request. That's a
- * lot of moving parts to add to docker-compose + CI for a contention
- * surface that, in practice, only really matters for the chat list
- * endpoint (the drawer filters `has_messages`, and Playwright mocks
- * `/messages`, so created chats stay drawer-invisible).
- *
- * Cheaper isolation: tag each test-created chat with a worker-scoped
- * title prefix, and bulk-delete that prefix at the end of each spec
- * file. SQLite stays single-DB; each worker effectively owns its own
- * title namespace. No backend changes, no container changes.
+ * Each run already has its own backend and database. Within that run, this
+ * helper records the exact IDs created by each worker and deletes only those
+ * IDs. It never lists the account and never infers ownership from titles.
  *
  * Usage
  * -----
@@ -36,21 +23,24 @@
  * ---------------
  * `/api/auth/token` is throttled at 5/min. Cleanup across 4 workers
  * would blow through that, so we read the bearer token straight from
- * Playwright's saved `tests/.auth/state.json` (auth.setup.mjs writes
- * it into localStorage) and only fall back to the login endpoint if
- * the file is missing.
+ * Playwright's configured auth-state file (auth.setup.mjs writes the token
+ * into localStorage) and only fall back to the login endpoint if it is missing.
  */
 
 import { test } from '@playwright/test'
+import {
+  drainCreatedChats,
+  registerCreatedChats,
+} from './_chatFixtureRegistry.mjs'
+
+export { registerCreatedChats } from './_chatFixtureRegistry.mjs'
 
 const BASE = process.env.MOBIUS_URL || 'http://localhost:8001'
 const USER = process.env.MOBIUS_USER || 'admin'
 const PASS = process.env.MOBIUS_PASS || 'admin'
 
-// Title prefix scheme: `__pw_w<workerIndex>_` so every spec file in
-// the same worker shares the same namespace (worker reused across
-// files in a Playwright run). The leading `__pw_` is the global tag
-// — used by the cleanup pass to filter via startsWith.
+// Human-readable title tags remain useful in diagnostics, but cleanup never
+// relies on them.
 const GLOBAL_PREFIX = '__pw_'
 export function workerPrefix(workerIndex) {
   return `${GLOBAL_PREFIX}w${workerIndex}_`
@@ -76,7 +66,8 @@ async function getToken(request) {
   //    into localStorage at the BASE origin. Read it from disk.
   try {
     const fs = await import('fs/promises')
-    const raw = await fs.readFile('tests/.auth/state.json', 'utf8')
+    const authFile = process.env.MOBIUS_AUTH_FILE || 'tests/.auth/state.json'
+    const raw = await fs.readFile(authFile, 'utf8')
     const state = JSON.parse(raw)
     for (const origin of state.origins || []) {
       for (const item of origin.localStorage || []) {
@@ -127,26 +118,22 @@ export async function createTaggedChat(page, label = '') {
     if (!res.ok) return null
     return res.json()
   }, title)
+  if (info && result?.id) registerCreatedChats(info.workerIndex, result.id)
   return result
 }
 
 /**
- * Delete every chat whose title starts with this worker's prefix.
- * Runs as `test.afterAll` per spec file (one cleanup pass per
- * worker-file pair). Best-effort: 4xx responses are swallowed so a
- * stale chat ID can't fail the suite.
+ * Delete only chats registered by this worker. Best-effort: 4xx responses
+ * are swallowed so a stale fixture ID cannot fail the suite.
  */
 export async function cleanupWorkerChats(workerIndex, request) {
+  const ids = drainCreatedChats(workerIndex)
+  if (ids.length === 0) return
   const token = await getToken(request)
   if (!token) return
   const headers = { Authorization: `Bearer ${token}` }
-  const listRes = await request.get(`${BASE}/api/chats`, { headers })
-  if (!listRes.ok()) return
-  const chats = await listRes.json()
-  const prefix = workerPrefix(workerIndex)
-  const mine = chats.filter(c => (c.title || '').startsWith(prefix))
-  await Promise.all(mine.map(c =>
-    request.delete(`${BASE}/api/chats/${c.id}`, {
+  await Promise.all(ids.map(id =>
+    request.delete(`${BASE}/api/chats/${id}`, {
       headers, failOnStatusCode: false,
     })
   ))

--- a/tests/app-canvas.spec.mjs
+++ b/tests/app-canvas.spec.mjs
@@ -21,7 +21,7 @@
  * postMessage behavior end-to-end and assert the parent overlay
  * reacts correctly.
  *
- * Run: npx playwright test tests/app-canvas.spec.mjs
+ * Run: scripts/playwright-local.sh --allow-local-e2e tests/app-canvas.spec.mjs
  */
 import { test, expect } from '@playwright/test'
 

--- a/tests/auth.setup.mjs
+++ b/tests/auth.setup.mjs
@@ -4,44 +4,49 @@
  * On a fresh container (CI), the setup endpoint creates the owner account.
  * On an existing container, it 409s harmlessly.
  *
- * Also wipes chats from prior runs. The Playwright suite shares the
- * mobius-test DB across runs and tests; without this, chats pile up
- * (we've seen 400+) and every drawer-list fetch slows down until
- * tests start timing out.
+ * This setup must never enumerate or delete an owner's chats. Every
+ * browser run is required to identify itself as an isolated test runtime,
+ * and individual specs clean up only the fixture IDs they created.
  */
-import { test as setup, expect } from '@playwright/test'
+import { test as setup } from '@playwright/test'
 
 const BASE = process.env.MOBIUS_URL || 'http://localhost:8001'
 const USER = process.env.MOBIUS_USER || 'admin'
 const PASS = process.env.MOBIUS_PASS || 'admin'
-const AUTH_FILE = 'tests/.auth/state.json'
+const AUTH_FILE = process.env.MOBIUS_AUTH_FILE || 'tests/.auth/state.json'
 
-// Safety: refuse to run against anything that isn't a local mobius-test
-// container. Setup wipes ALL chats for the owner and write-once stamps
-// walkthrough_completed_at (irreversible via the API). A stray MOBIUS_URL
-// pointing at prod + matching admin/admin creds would destroy data and
-// permanently mark prod walkthrough done. Match scripts/live-test.sh's
-// own guard: localhost only, port 8000 is explicitly off-limits.
+// First guard: only local-family hosts on a non-production port.
 const allowedHosts = ['localhost', '127.0.0.1', '0.0.0.0', '172.17.0.1']
 const baseUrl = new URL(BASE)
 if (!allowedHosts.includes(baseUrl.hostname) || baseUrl.port === '8000') {
   throw new Error(
     `auth.setup refuses to run against ${BASE} — only local mobius-test ` +
     `(non-prod port, localhost-family host) is allowed. ` +
-    `Setup destructively wipes chats and write-once stamps the walkthrough; ` +
-    `running against prod would corrupt owner state irreversibly.`
+    `Setup writes test-owner state and must only target an isolated runtime.`
   )
 }
 
 setup('authenticate', async ({ page, request }) => {
+  // Authoritative guard: a localhost URL can still be a proxy to the live
+  // backend. Verify the backend itself opted into test mode before making
+  // any authenticated or write request.
+  const versionRes = await request.get(`${BASE}/api/version`, {
+    failOnStatusCode: false,
+  })
+  const version = versionRes.ok() ? await versionRes.json() : null
+  if (version?.test_runtime !== true) {
+    throw new Error(
+      `auth.setup refuses ${BASE}: /api/version did not report ` +
+      `test_runtime=true. Use the isolated local E2E runner or hosted CI.`
+    )
+  }
+
   // Ensure the owner account exists (idempotent — 409 if already set up).
   await request.post(`${BASE}/api/auth/setup`, {
     data: { username: USER, password: PASS },
   })
 
-  // Wipe prior-run chats. Best-effort: get a token, list, delete each.
-  // If the token fetch fails (fresh container, no owner yet) we just
-  // skip — there's nothing to wipe anyway.
+  // Fetch the test-owner token so the walkthrough cannot intercept clicks.
   const tokRes = await request.post(`${BASE}/api/auth/token`, {
     form: { username: USER, password: PASS },
     failOnStatusCode: false,
@@ -49,15 +54,6 @@ setup('authenticate', async ({ page, request }) => {
   if (tokRes.ok()) {
     const { access_token } = await tokRes.json()
     const headers = { Authorization: `Bearer ${access_token}` }
-    const listRes = await request.get(`${BASE}/api/chats`, { headers })
-    if (listRes.ok()) {
-      const chats = await listRes.json()
-      await Promise.all(chats.map(c =>
-        request.delete(`${BASE}/api/chats/${c.id}`, {
-          headers, failOnStatusCode: false,
-        })
-      ))
-    }
     // Mark walkthrough complete server-side so the WalkthroughOverlay
     // doesn't render during tests. The overlay's centered-modal +
     // backdrop intercepts every pointer event in the shell; without

--- a/tests/bootstrap.spec.mjs
+++ b/tests/bootstrap.spec.mjs
@@ -37,7 +37,7 @@
  *      asserting only `mobius-*` would miss a regression that dropped
  *      the workbox-precache purge. We seed both and assert both go.
  *
- * Run: npx playwright test tests/bootstrap.spec.mjs
+ * Run: scripts/playwright-local.sh --allow-local-e2e tests/bootstrap.spec.mjs
  */
 import { test, expect } from '@playwright/test'
 

--- a/tests/cache.spec.mjs
+++ b/tests/cache.spec.mjs
@@ -9,10 +9,14 @@
  * The point of these tests is to lock in the no-flash chat-back-nav
  * behavior so future changes don't silently regress it.
  *
- * Run:  npx playwright test tests/cache.spec.mjs
+ * Run:  scripts/playwright-local.sh --allow-local-e2e tests/cache.spec.mjs
  */
 import { test, expect } from '@playwright/test'
-import { workerChatTitle, workerPrefix, attachCleanup } from './_chatTracker.mjs'
+import {
+  workerChatTitle,
+  registerCreatedChats,
+  attachCleanup,
+} from './_chatTracker.mjs'
 
 const BASE = process.env.MOBIUS_URL || 'http://localhost:8001'
 
@@ -50,7 +54,7 @@ async function ensureChats(page, count = 2) {
     { length: count },
     () => workerChatTitle(workerIndex, testTitle)
   )
-  return page.evaluate(async ({ titles: ts }) => {
+  const ids = await page.evaluate(async ({ titles: ts }) => {
     const tok = localStorage.getItem('token')
     if (!tok) return []
     const ids = []
@@ -67,40 +71,8 @@ async function ensureChats(page, count = 2) {
     }
     return ids
   }, { titles })
-}
-
-async function openDrawer(page) {
-  await page.evaluate(() => {
-    const btn = document.querySelector('[aria-expanded]')
-    if (btn && btn.getAttribute('aria-expanded') !== 'true') btn.click()
-  })
-  await page.evaluate(() => new Promise(r => setTimeout(r, 400)))
-}
-
-async function clickChatInDrawer(page, index) {
-  // The drawer renders chats in a `.drawer__group` with title "Chats"
-  // (or unlabeled), then apps in another group. Filter strictly to
-  // chat items by excluding `--new`, `--active` styling is irrelevant.
-  await page.evaluate((idx) => {
-    // Find the group whose label is "Chats" or whose first non-"new"
-    // item is a chat. Simpler: walk all groups, take the first that
-    // contains chat-shaped items (text but no app icon, not Settings).
-    const allGroups = document.querySelectorAll('.drawer__group')
-    let chatItems = []
-    for (const g of allGroups) {
-      const items = g.querySelectorAll('.drawer__item')
-      for (const el of items) {
-        if (el.classList.contains('drawer__item--new')) continue
-        const text = el.querySelector('.drawer__item-text')?.textContent?.trim()
-        // Exclude obvious non-chat items.
-        if (!text || text === 'Settings' || text === 'Hello World') continue
-        chatItems.push(el)
-      }
-      if (chatItems.length > 0) break
-    }
-    if (chatItems[idx]) chatItems[idx].click()
-  }, index)
-  await page.evaluate(() => new Promise(r => setTimeout(r, 300)))
+  registerCreatedChats(workerIndex, ids)
+  return ids
 }
 
 async function getActiveChatId(page) {
@@ -130,7 +102,7 @@ test.describe('Chat messages cache (TanStack Query)', () => {
     // BLOCKED. If the cache is doing its job, the chat view still
     // renders and shows the persisted messages.
     await setup(page)
-    await ensureChats(page, 2)
+    const ids = await ensureChats(page, 2)
     await page.reload({ waitUntil: 'domcontentloaded' })
     await page.waitForFunction(
       () => !!(document.querySelector('.chat__empty-wrap')
@@ -139,23 +111,9 @@ test.describe('Chat messages cache (TanStack Query)', () => {
       { timeout: 10000 }
     )
 
-    // Use the chat IDs returned by ensureChats directly. Driving via
-    // localStorage + reload is reliable across drawer rendering quirks.
-    // Filter to this worker's chats so concurrent workers' fixtures
-    // don't bleed into the list and shift ids[0]/ids[1].
-    const myPrefix = workerPrefix(test.info().workerIndex)
-    const ids = await page.evaluate(async (prefix) => {
-      const tok = localStorage.getItem('token')
-      const res = await fetch('/api/chats', {
-        headers: { 'Authorization': 'Bearer ' + tok },
-      })
-      const list = await res.json()
-      if (!Array.isArray(list)) return []
-      return list
-        .filter(c => (c.title || '').startsWith(prefix))
-        .map(c => c.id)
-    }, myPrefix)
-    expect(ids.length).toBeGreaterThanOrEqual(2)
+    // Use only the exact fixture IDs returned by ensureChats. The test never
+    // enumerates the owner account or borrows rows created elsewhere.
+    expect(ids).toHaveLength(2)
     const chatA = ids[0]
     const chatB = ids[1]
     expect(chatA).not.toBe(chatB)
@@ -263,7 +221,9 @@ test.describe('Chat messages cache (TanStack Query)', () => {
     // Verifies the persister is actually writing to IndexedDB. The
     // persister key is `mobius-query-cache` (set in queryClient.js).
     await setup(page)
-    await ensureChats(page, 1)
+    const [chatId] = await ensureChats(page, 1)
+    expect(chatId).toBeTruthy()
+    await page.evaluate((id) => localStorage.setItem('moebius_active_chat', id), chatId)
     await page.reload({ waitUntil: 'domcontentloaded' })
     await page.waitForFunction(
       () => !!(document.querySelector('.chat__empty-wrap')
@@ -271,9 +231,6 @@ test.describe('Chat messages cache (TanStack Query)', () => {
             || document.querySelector('.chat__form')),
       { timeout: 10000 }
     )
-    await openDrawer(page)
-    await clickChatInDrawer(page, 0)
-
     // The persister throttles writes (1000ms). Wait long enough.
     await page.evaluate(() => new Promise(r => setTimeout(r, 1500)))
 

--- a/tests/chat-fixture-registry.test.mjs
+++ b/tests/chat-fixture-registry.test.mjs
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  drainCreatedChats,
+  registerCreatedChats,
+} from './_chatFixtureRegistry.mjs'
+
+test('registry drains only exact IDs registered by one worker', () => {
+  registerCreatedChats(3, ['chat-a', { id: 'chat-b' }, 'chat-a', null])
+  registerCreatedChats(4, 'other-worker-chat')
+
+  assert.deepEqual(drainCreatedChats(3), ['chat-a', 'chat-b'])
+  assert.deepEqual(drainCreatedChats(3), [])
+  assert.deepEqual(drainCreatedChats(4), ['other-worker-chat'])
+})

--- a/tests/chat-redesign.spec.mjs
+++ b/tests/chat-redesign.spec.mjs
@@ -10,7 +10,7 @@
  *   4. Auto-follow engages when user scrolls to bottom.
  *
  * Tests use mocked SSE / mocked /messages — no agent tokens spent.
- * Run: npx playwright test tests/chat-redesign.spec.mjs
+ * Run: scripts/playwright-local.sh --allow-local-e2e tests/chat-redesign.spec.mjs
  */
 import { test, expect } from '@playwright/test'
 import { createTaggedChat, attachCleanup } from './_chatTracker.mjs'

--- a/tests/frontend.spec.mjs
+++ b/tests/frontend.spec.mjs
@@ -4,7 +4,7 @@
  * Tests message rendering, input behavior, theme switching, and app canvas.
  * All tests use API interception — no agent tokens consumed.
  *
- * Run: npx playwright test tests/frontend.spec.mjs
+ * Run: scripts/playwright-local.sh --allow-local-e2e tests/frontend.spec.mjs
  */
 import { test, expect } from '@playwright/test'
 import { createTaggedChat, attachCleanup } from './_chatTracker.mjs'

--- a/tests/handleStop-sync-ordering.spec.mjs
+++ b/tests/handleStop-sync-ordering.spec.mjs
@@ -21,7 +21,7 @@
  * handleStop + the bundler output, catching wiring regressions that
  * the node-side unit suite cannot see.
  *
- * Run: npx playwright test tests/handleStop-sync-ordering.spec.mjs
+ * Run: scripts/playwright-local.sh --allow-local-e2e tests/handleStop-sync-ordering.spec.mjs
  */
 import { test, expect } from '@playwright/test'
 

--- a/tests/navigation.spec.mjs
+++ b/tests/navigation.spec.mjs
@@ -4,11 +4,40 @@
  * Tests the useNavigation hook: back button between chats, back from app
  * canvas to chat, drawer open/close via back, and pushState/popstate handling.
  *
- * Run:  npx playwright test tests/navigation.spec.mjs
+ * Run:  scripts/playwright-local.sh --allow-local-e2e tests/navigation.spec.mjs
  */
 import { test, expect } from '@playwright/test'
 
 const BASE = process.env.MOBIUS_URL || 'http://localhost:8001'
+const NAV_CHATS = [
+  ['10000000-0000-4000-8000-000000000001', 'Navigation Alpha'],
+  ['10000000-0000-4000-8000-000000000002', 'Navigation Beta'],
+  ['10000000-0000-4000-8000-000000000003', 'Navigation Gamma'],
+].map(([id, title], index) => ({
+  id,
+  title,
+  created_at: `2026-01-01T00:00:0${index}Z`,
+  updated_at: `2026-01-01T00:00:0${index}Z`,
+  activity_at: `2026-01-01T00:00:0${index}Z`,
+  pinned_at: null,
+  created_by_app_id: null,
+  has_messages: true,
+  running: false,
+  run_status: null,
+}))
+
+function navChatDetail(id) {
+  return {
+    messages: [
+      { role: 'user', content: `Open ${id}`, ts: 1700000000000, blocks: [] },
+      { role: 'assistant', content: 'Fixture response', ts: 1700000000001, blocks: [] },
+    ],
+    total: 2,
+    offset: 0,
+    running: false,
+    pending_messages: [],
+  }
+}
 
 /** Click the Settings entry in the drawer; assumes drawer is open. */
 async function navigateToSettings(page) {
@@ -27,6 +56,30 @@ async function navigateToSettings(page) {
 
 async function setup(page, viewport = { width: 412, height: 915 }) {
   await page.setViewportSize(viewport)
+
+  // Navigation is a client-side contract. Seed an explicit active chat and
+  // mock the complete chat surface so the suite neither reads nor borrows
+  // rows from any backend database.
+  await page.addInitScript(chatId => {
+    localStorage.setItem('moebius_active_chat', chatId)
+  }, NAV_CHATS[0].id)
+  await page.route(/\/api\/chats(?:\?.*)?$/, route => {
+    if (route.request().method() !== 'GET') return route.fallback()
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(NAV_CHATS),
+    })
+  })
+  await page.route(/\/api\/chats\/([0-9a-f-]+)(?:\?.*)?$/, route => {
+    if (route.request().method() !== 'GET') return route.fallback()
+    const id = new URL(route.request().url()).pathname.split('/').pop()
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(navChatDetail(id)),
+    })
+  })
 
   // Intercept agent routes.
   await page.route(/\/api\/chats\/[0-9a-f-]+\/messages$/, route =>

--- a/tests/recovery-chat.spec.mjs
+++ b/tests/recovery-chat.spec.mjs
@@ -12,7 +12,7 @@
  * exercise the create-a-chat-then-use-it flow rather than the old
  * single-chat shortcut.
  *
- * Run: npx playwright test tests/recovery-chat.spec.mjs
+ * Run: scripts/playwright-local.sh --allow-local-e2e tests/recovery-chat.spec.mjs
  */
 import { test, expect } from '@playwright/test'
 

--- a/tests/send-rule.spec.mjs
+++ b/tests/send-rule.spec.mjs
@@ -10,7 +10,7 @@
  *
  * Mirrors the route-mock SSE flow of second-send-pin.spec.mjs.
  *
- * Run: npx playwright test tests/send-rule.spec.mjs
+ * Run: scripts/playwright-local.sh --allow-local-e2e tests/send-rule.spec.mjs
  */
 import { test, expect } from '@playwright/test'
 

--- a/tests/shell-update-idle.spec.mjs
+++ b/tests/shell-update-idle.spec.mjs
@@ -37,7 +37,7 @@
  * Reloads are observed via a sessionStorage load counter bumped in an init
  * script that runs on every navigation (including reload).
  *
- * Run: npx playwright test tests/shell-update-idle.spec.mjs
+ * Run: scripts/playwright-local.sh --allow-local-e2e tests/shell-update-idle.spec.mjs
  */
 import { test, expect } from '@playwright/test'
 import { createTaggedChat, attachCleanup } from './_chatTracker.mjs'

--- a/tests/spacer.spec.mjs
+++ b/tests/spacer.spec.mjs
@@ -5,8 +5,8 @@
  * tokens consumed.  Tests the spacer formula, ResizeObserver, scroll
  * restoration, and chat-switching edge cases.
  *
- * Run:  npx playwright test tests/spacer.spec.mjs
- * Debug: npx playwright test tests/spacer.spec.mjs --headed --debug
+ * Run:  scripts/playwright-local.sh --allow-local-e2e tests/spacer.spec.mjs
+ * Debug: scripts/playwright-local.sh --allow-local-e2e tests/spacer.spec.mjs --headed --debug
  */
 import { test, expect } from '@playwright/test'
 import { createTaggedChat, attachCleanup } from './_chatTracker.mjs'

--- a/tests/standalone-routing.spec.mjs
+++ b/tests/standalone-routing.spec.mjs
@@ -1,7 +1,7 @@
 /**
  * Standalone app routing regressions.
  *
- * Run: npx playwright test tests/standalone-routing.spec.mjs
+ * Run: scripts/playwright-local.sh --allow-local-e2e tests/standalone-routing.spec.mjs
  */
 import { test, expect } from '@playwright/test'
 

--- a/tests/steer-queued.spec.mjs
+++ b/tests/steer-queued.spec.mjs
@@ -19,7 +19,7 @@
  *       consume_pending_cids + the exact "\n\n"-joined content,
  *   (c) the queued tray clears on a {status:"steered"} response.
  *
- * Run: npx playwright test tests/steer-queued.spec.mjs
+ * Run: scripts/playwright-local.sh --allow-local-e2e tests/steer-queued.spec.mjs
  */
 import { test, expect } from '@playwright/test'
 

--- a/tests/storage-typed.spec.mjs
+++ b/tests/storage-typed.spec.mjs
@@ -5,7 +5,7 @@
 // read-your-writes, the fatal-write deadlock regression) without owner auth.
 //
 // Run against a container serving the NEW mobius-runtime.js:
-//   MOBIUS_URL=http://localhost:8030 npx playwright test tests/storage-typed.spec.mjs
+//   scripts/playwright-local.sh --allow-local-e2e tests/storage-typed.spec.mjs
 import { test, expect } from '@playwright/test'
 
 const BASE = process.env.MOBIUS_URL || 'http://localhost:8030'

--- a/tests/stream-reconnect.spec.mjs
+++ b/tests/stream-reconnect.spec.mjs
@@ -8,7 +8,7 @@
  * refreshes from the DB, Stop clears streaming, and short post-send 204s
  * still retry.
  *
- * Run: npx playwright test tests/stream-reconnect.spec.mjs
+ * Run: scripts/playwright-local.sh --allow-local-e2e tests/stream-reconnect.spec.mjs
  */
 import { test, expect } from '@playwright/test'
 

--- a/tests/sw-cache-policy.spec.mjs
+++ b/tests/sw-cache-policy.spec.mjs
@@ -7,7 +7,7 @@
  * These are pure functions (frontend/src/sw-cache-policy.js), so no
  * browser/SW context is needed.
  *
- * Run: npx playwright test tests/sw-cache-policy.spec.mjs
+ * Run: scripts/playwright-local.sh --allow-local-e2e tests/sw-cache-policy.spec.mjs
  */
 import { test, expect } from '@playwright/test'
 import {

--- a/tests/sw-pwa.spec.mjs
+++ b/tests/sw-pwa.spec.mjs
@@ -13,7 +13,7 @@
  * accidentally drops precache injection or runtime caching, or
  * any plugin upgrade that changes the SW URL or cache shape.
  *
- * Run: npx playwright test tests/sw-pwa.spec.mjs
+ * Run: scripts/playwright-local.sh --allow-local-e2e tests/sw-pwa.spec.mjs
  */
 import { test, expect } from '@playwright/test'
 

--- a/tests/tabs.spec.mjs
+++ b/tests/tabs.spec.mjs
@@ -10,7 +10,7 @@
  * Runs against the deployed app with agent + apps routes intercepted — no
  * agent tokens consumed.
  *
- * Run: MOBIUS_URL=http://localhost:8079 npx playwright test tests/tabs.spec.mjs --project=tests
+ * Run: scripts/playwright-local.sh --allow-local-e2e tests/tabs.spec.mjs --project=tests
  */
 import { test, expect } from '@playwright/test'
 import { createTaggedChat, attachCleanup } from './_chatTracker.mjs'


### PR DESCRIPTION
## Summary
- run local Playwright checks in an isolated disposable runtime with an exact identity gate
- create and clean only fixture-registered chats, never owner conversations
- stabilize the cached image and root lock so warm checks avoid rebuild work
- keep the hosted CI path authoritative and document the Docker-capable local fallback

## Testing
- `pytest -q backend/tests/test_verify_test_runtime.py` — 17 passed
- fixture registry unit test — passed
- isolated Playwright runs — passed twice, including warm-cache verification