### PR TITLE
Add a guarded local-service proxy boundary

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -195,6 +195,7 @@ Each module exposes a `router`; registration is in `routes/__init__.py`.
 | `uploads.py` | Per-chat file upload management |
 | `media.py` | Owner-authenticated per-chat image serving from the canonical `/media/` path |
 | `proxy.py` | Server-side CORS-bypass proxy for mini-apps |
+| `local_services.py` | Guarded same-origin mount for real local backend web apps at `/services/<slug>/`; reads the private `/data/local-services.json` map per request, requires an explicit `upstream_auth` declaration, accepts literal loopback HTTP origins only, strips Möbius authority headers, scopes cookies and loopback redirects back to the public mount, and fails closed without affecting shell startup |
 | `standalone.py` | Top-level routes that make a mini-app installable as its own PWA (own importmap) |
 | `published.py` | Serves published site snapshots at `/sites/<token>/` — token-validated, traversal-confined static files from `/data/published/<token>/` (created by `POST /api/apps/{id}/publish` in `apps.py`; token stable per project) |
 | `platform.py` | Owner-gated platform self-update: `GET /api/platform/status`, `POST /apply`, `POST /restart` (drives Settings → Updates; thin caller of `platform_update.py`) |

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -48,7 +48,7 @@ from app import models
 from app.routes import (
   admin_router, apps_router, auth_router,
   chat_logs_router, chat_router, chats_router, chats_stream_router,
-  debug_router, fs_router, github_router, media_router,
+  debug_router, fs_router, github_router, local_services_router, media_router,
   notifications_router, notify_router, proxy_router, push_router,
   secrets_router, self_reminders_router, settings_router,
   client_error_router, client_signal_router, standalone_router, storage_router,
@@ -710,6 +710,7 @@ except Exception as _exc:  # pragma: no cover - defensive boot guard
   )
 app.include_router(notify_router)
 app.include_router(proxy_router)
+app.include_router(local_services_router)
 app.include_router(client_error_router)
 app.include_router(client_signal_router)
 app.include_router(settings_router)

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -58,6 +58,7 @@ chats_router = _load("chats")
 chats_stream_router = _load("chats_stream")
 chat_logs_router = _load("chat_logs")
 proxy_router = _load("proxy")
+local_services_router = _load("local_services")
 notify_router = _load("notify")
 settings_router = _load("settings")
 storage_router = _load("storage")
@@ -88,6 +89,7 @@ __all__ = [
   "chats_stream_router",
   "chat_logs_router",
   "proxy_router",
+  "local_services_router",
   "notify_router",
   "settings_router",
   "uploads_router",

--- a/backend/app/routes/local_services.py
+++ b/backend/app/routes/local_services.py
@@ -1,0 +1,342 @@
+"""Guarded same-origin reverse proxy for owner-configured local web services.
+
+Mini-apps are sandboxed frontend frames, so a real backend web application
+(Tandoor, Paperless, Grafana, etc.) cannot run *inside* one.  This route gives
+those applications one deliberately narrow integration boundary:
+
+  /services/<slug>/...  ->  a statically configured loopback HTTP origin
+
+The browser never supplies an upstream URL.  Configuration lives outside the
+platform checkout at ``<DATA_DIR>/local-services.json`` and stock Möbius ships
+with no configured services.  Only literal loopback targets are accepted in
+v1; this prevents the route from becoming an SSRF/open-proxy primitive while
+covering the local-process use case it was introduced for.
+
+Configuration schema::
+
+  {
+    "version": 1,
+    "services": {
+      "tandoor": {
+        "upstream": "http://127.0.0.1:8123",
+        "access": "upstream_auth"
+      }
+    }
+  }
+
+The public ``/services/<slug>`` prefix is preserved on the upstream request.
+Backend applications must therefore be configured to serve from that same
+base path.  This keeps redirects, cookie paths, forms, static assets, and API
+URLs coherent without unsafe response-body rewriting. The upstream application
+owns user authentication: configuration must acknowledge that explicitly, and
+the proxy never forwards a Möbius bearer token to it.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlsplit
+
+import httpx
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import RedirectResponse, Response, StreamingResponse
+
+from app.config import get_settings
+
+log = logging.getLogger(__name__)
+
+router = APIRouter(tags=["local-services"])
+
+_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"]
+_SLUG = re.compile(r"^[a-z0-9][a-z0-9-]{0,62}$")
+_CONFIG_NAME = "local-services.json"
+_MAX_CONFIG_BYTES = 64 * 1024
+
+# RFC 9110 hop-by-hop fields plus Content-Length: StreamingResponse owns the
+# downstream framing and httpx calculates the upstream request length.
+_HOP_BY_HOP = {
+  b"connection",
+  b"keep-alive",
+  b"proxy-authenticate",
+  b"proxy-authorization",
+  b"te",
+  b"trailer",
+  b"trailers",
+  b"transfer-encoding",
+  b"upgrade",
+  b"content-length",
+}
+_PRIVATE_REQUEST_HEADERS = {
+  "authorization",
+  "host",
+  "proxy-authorization",
+  "x-forwarded-for",
+  "x-forwarded-host",
+  "x-forwarded-prefix",
+  "x-forwarded-proto",
+  "x-script-name",
+}
+
+
+class ServiceConfigError(ValueError):
+  """The private local-service configuration failed closed."""
+
+
+@dataclass(frozen=True)
+class LocalService:
+  slug: str
+  upstream: str
+
+  @property
+  def mount_path(self) -> str:
+    return f"/services/{self.slug}"
+
+
+def _config_path() -> Path:
+  return Path(get_settings().data_dir) / _CONFIG_NAME
+
+
+def _read_config() -> dict | None:
+  path = _config_path()
+  try:
+    size = path.stat().st_size
+  except FileNotFoundError:
+    return None
+  except OSError as exc:
+    raise ServiceConfigError("configuration cannot be read") from exc
+  if size > _MAX_CONFIG_BYTES:
+    raise ServiceConfigError("configuration is too large")
+  try:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+  except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+    raise ServiceConfigError("configuration is not valid UTF-8 JSON") from exc
+  if not isinstance(payload, dict) or payload.get("version") != 1:
+    raise ServiceConfigError("configuration must declare version 1")
+  services = payload.get("services")
+  if not isinstance(services, dict):
+    raise ServiceConfigError("configuration must contain a services object")
+  return services
+
+
+def _validated_upstream(value: object) -> str:
+  if not isinstance(value, str):
+    raise ServiceConfigError("upstream must be a URL string")
+  parsed = urlsplit(value)
+  if (
+    parsed.scheme != "http"
+    or not parsed.hostname
+    or parsed.username is not None
+    or parsed.password is not None
+    or parsed.query
+    or parsed.fragment
+    or parsed.path not in ("", "/")
+  ):
+    raise ServiceConfigError(
+      "upstream must be an HTTP loopback origin without credentials or a path"
+    )
+  try:
+    address = ipaddress.ip_address(parsed.hostname)
+  except ValueError as exc:
+    raise ServiceConfigError("upstream host must be a literal loopback address") from exc
+  if not address.is_loopback:
+    raise ServiceConfigError("upstream host must be loopback")
+  try:
+    port = parsed.port
+  except ValueError as exc:
+    raise ServiceConfigError("upstream port is invalid") from exc
+  if port is None:
+    port = 80
+  host = f"[{address.compressed}]" if address.version == 6 else address.compressed
+  return f"http://{host}:{port}"
+
+
+def _service_for(slug: str) -> LocalService | None:
+  if not _SLUG.fullmatch(slug):
+    return None
+  try:
+    services = _read_config()
+    if services is None or slug not in services:
+      return None
+    entry = services[slug]
+    if not isinstance(entry, dict) or set(entry) != {"upstream", "access"}:
+      raise ServiceConfigError(
+        f"service {slug!r} must contain exactly upstream and access fields"
+      )
+    # Browser navigations cannot attach the owner's localStorage bearer token.
+    # Requiring this explicit declaration prevents an agent from accidentally
+    # publishing an unauthenticated dev server through the public Möbius host.
+    if entry["access"] != "upstream_auth":
+      raise ServiceConfigError(
+        f"service {slug!r} must explicitly declare access=upstream_auth"
+      )
+    return LocalService(slug=slug, upstream=_validated_upstream(entry["upstream"]))
+  except ServiceConfigError as exc:
+    log.warning("Local service %s is unavailable: %s", slug, exc)
+    raise HTTPException(
+      status_code=503,
+      detail=f"Local service '{slug}' is unavailable because its configuration is invalid.",
+    ) from exc
+
+
+def _forwarded_request_headers(request: Request, service: LocalService) -> dict[str, str]:
+  headers = {
+    key: value
+    for key, value in request.headers.items()
+    if (
+      key.lower().encode("latin-1") not in _HOP_BY_HOP
+      and key.lower() not in _PRIVATE_REQUEST_HEADERS
+    )
+  }
+  public = urlsplit(get_settings().frontend_origin)
+  public_host = public.netloc
+  if public_host:
+    headers["host"] = public_host
+    headers["x-forwarded-host"] = public_host
+  public_scheme = public.scheme
+  headers["x-forwarded-proto"] = (
+    public_scheme if public_scheme in {"http", "https"} else request.url.scheme
+  )
+  headers["x-forwarded-for"] = (
+    request.client.host if request.client else "127.0.0.1"
+  )
+  headers["x-script-name"] = service.mount_path
+  headers["x-forwarded-prefix"] = service.mount_path
+  return headers
+
+
+def _rewrite_location(value: str, service: LocalService) -> str:
+  """Keep absolute loopback redirects on the public Möbius origin."""
+  parsed = urlsplit(value)
+  upstream = urlsplit(service.upstream)
+  try:
+    same_upstream = (
+      parsed.scheme == upstream.scheme
+      and parsed.hostname == upstream.hostname
+      and (parsed.port or 80) == (upstream.port or 80)
+    )
+  except ValueError:
+    same_upstream = False
+  if not same_upstream:
+    return value
+  public = urlsplit(get_settings().frontend_origin)
+  return parsed._replace(scheme=public.scheme, netloc=public.netloc).geturl()
+
+
+def _rewrite_set_cookie(value: str, service: LocalService) -> str:
+  """Confine upstream cookies to their service and the public host."""
+  parts = [part.strip() for part in value.split(";")]
+  if not parts:
+    return value
+  attrs: list[str] = []
+  saw_path = False
+  mount = service.mount_path
+  for attr in parts[1:]:
+    name, separator, raw_value = attr.partition("=")
+    lowered = name.strip().lower()
+    if lowered == "domain":
+      continue
+    if lowered == "path":
+      saw_path = True
+      path = raw_value.strip() if separator else ""
+      if path != mount and not path.startswith(f"{mount}/"):
+        path = f"{mount}/"
+      attrs.append(f"Path={path}")
+      continue
+    if attr:
+      attrs.append(attr)
+  if not saw_path:
+    attrs.append(f"Path={mount}/")
+  return "; ".join([parts[0], *attrs])
+
+
+def _upstream_url(service: LocalService, request: Request) -> str:
+  # `request.url.path` is already normalized by the ASGI server.  Preserve the
+  # reserved public prefix exactly; the service owns all routing below it.
+  url = f"{service.upstream}{request.url.path}"
+  if request.url.query:
+    url = f"{url}?{request.url.query}"
+  return url
+
+
+async def _proxy(service: LocalService, request: Request) -> Response:
+  client = httpx.AsyncClient(
+    follow_redirects=False,
+    timeout=httpx.Timeout(90.0, connect=5.0),
+  )
+  upstream = None
+  try:
+    body = await request.body()
+    upstream_request = client.build_request(
+      request.method,
+      _upstream_url(service, request),
+      headers=_forwarded_request_headers(request, service),
+      content=body,
+    )
+    upstream = await client.send(upstream_request, stream=True)
+  except Exception as exc:
+    if upstream is not None:
+      await upstream.aclose()
+    await client.aclose()
+    log.warning("Local service %s is unreachable: %s", service.slug, exc)
+    return Response(
+      content=f"The local service '{service.slug}' is not available right now.",
+      status_code=502,
+      media_type="text/plain",
+    )
+
+  async def body_stream():
+    try:
+      async for chunk in upstream.aiter_raw():
+        yield chunk
+    finally:
+      await upstream.aclose()
+      await client.aclose()
+
+  response = StreamingResponse(body_stream(), status_code=upstream.status_code)
+  # Preserve every end-to-end response field as raw pairs.  In particular,
+  # multiple Set-Cookie headers MUST remain separate; joining them corrupts
+  # cookies whose Expires attributes contain commas.
+  response.raw_headers = [
+    (
+      name,
+      (
+        _rewrite_location(value.decode("latin-1"), service).encode("latin-1")
+        if name.lower() == b"location"
+        else _rewrite_set_cookie(value.decode("latin-1"), service).encode("latin-1")
+        if name.lower() == b"set-cookie"
+        else value
+      ),
+    )
+    for name, value in upstream.headers.raw
+    if name.lower() not in _HOP_BY_HOP
+  ]
+  return response
+
+
+@router.api_route("/services", methods=_METHODS)
+@router.api_route("/services/", methods=_METHODS)
+async def local_services_root():
+  # Reserve the namespace even when no services exist; never let it fall
+  # through to the SPA catch-all and masquerade as a shell route.
+  raise HTTPException(status_code=404, detail="Local service not found.")
+
+
+@router.api_route("/services/{slug}", methods=_METHODS)
+async def local_service_bare(slug: str):
+  service = _service_for(slug)
+  if service is None:
+    raise HTTPException(status_code=404, detail="Local service not found.")
+  return RedirectResponse(url=f"{service.mount_path}/", status_code=307)
+
+
+@router.api_route("/services/{slug}/{path:path}", methods=_METHODS)
+async def local_service_proxy(slug: str, path: str, request: Request):
+  service = _service_for(slug)
+  if service is None:
+    raise HTTPException(status_code=404, detail="Local service not found.")
+  return await _proxy(service, request)

--- a/backend/tests/test_local_services.py
+++ b/backend/tests/test_local_services.py
@@ -1,0 +1,214 @@
+"""Security and proxy-contract tests for owner-configured local services."""
+
+import json
+import os
+from pathlib import Path
+from urllib.parse import urlsplit
+
+import httpx
+import pytest
+
+from app.config import get_settings
+from app.routes import local_services as local_services_module
+
+
+@pytest.fixture(autouse=True)
+def clean_local_services_config():
+  path = Path(os.environ["DATA_DIR"]) / "local-services.json"
+  path.unlink(missing_ok=True)
+  yield path
+  path.unlink(missing_ok=True)
+
+
+def write_config(path: Path, services: dict):
+  declared = {
+    slug: {**entry, "access": "upstream_auth"}
+    for slug, entry in services.items()
+  }
+  path.write_text(json.dumps({"version": 1, "services": declared}))
+
+
+def test_stock_instance_exposes_no_local_service(client):
+  root = client.get("/services", follow_redirects=False)
+  response = client.get("/services/tandoor/", follow_redirects=False)
+
+  assert root.status_code == 404
+  assert response.status_code == 404
+  assert response.json()["detail"] == "Local service not found."
+
+
+def test_bare_configured_service_normalizes_to_trailing_slash(
+  client, clean_local_services_config,
+):
+  write_config(clean_local_services_config, {
+    "recipes": {"upstream": "http://127.0.0.1:8123"},
+  })
+
+  response = client.get("/services/recipes", follow_redirects=False)
+
+  assert response.status_code == 307
+  assert response.headers["location"] == "/services/recipes/"
+
+
+@pytest.mark.parametrize("upstream", [
+  "https://127.0.0.1:8123",
+  "http://localhost:8123",
+  "http://10.0.0.8:8123",
+  "http://127.0.0.1:8123/admin",
+  "http://user:pass@127.0.0.1:8123",
+])
+def test_non_loopback_or_ambiguous_targets_fail_closed(
+  client, clean_local_services_config, monkeypatch, upstream,
+):
+  write_config(clean_local_services_config, {
+    "recipes": {"upstream": upstream},
+  })
+
+  class MustNotConnect:
+    def __init__(self, *args, **kwargs):
+      raise AssertionError("invalid configuration attempted an outbound connection")
+
+  monkeypatch.setattr(local_services_module.httpx, "AsyncClient", MustNotConnect)
+  response = client.get("/services/recipes/")
+
+  assert response.status_code == 503
+  assert response.json()["detail"].startswith(
+    "Local service 'recipes' is unavailable"
+  )
+
+
+def test_malformed_configuration_does_not_affect_platform_health(
+  client, clean_local_services_config,
+):
+  clean_local_services_config.write_text("{ definitely not JSON")
+
+  service = client.get("/services/recipes/")
+  health = client.get("/api/health")
+
+  assert service.status_code == 503
+  assert health.status_code == 200
+
+
+def test_service_must_explicitly_delegate_access_to_upstream_auth(
+  client, clean_local_services_config,
+):
+  clean_local_services_config.write_text(json.dumps({
+    "version": 1,
+    "services": {
+      "recipes": {"upstream": "http://127.0.0.1:8123"},
+    },
+  }))
+
+  response = client.get("/services/recipes/")
+
+  assert response.status_code == 503
+  assert "configuration is invalid" in response.json()["detail"]
+
+
+def test_proxy_preserves_path_query_headers_body_and_repeated_cookies(
+  client, clean_local_services_config, monkeypatch,
+):
+  write_config(clean_local_services_config, {
+    "recipes": {"upstream": "http://127.0.0.1:8123"},
+  })
+  seen = {}
+
+  class FakeAsyncClient:
+    def __init__(self, *args, **kwargs):
+      seen["client_options"] = kwargs
+
+    def build_request(self, method, url, *, headers, content):
+      request = httpx.Request(method, url, headers=headers, content=content)
+      seen["request"] = request
+      return request
+
+    async def send(self, request, *, stream):
+      assert stream is True
+      return httpx.Response(
+        201,
+        headers=[
+          ("content-type", "text/plain"),
+          ("location", "http://127.0.0.1:8123/services/recipes/welcome/"),
+          ("set-cookie", "sessionid=abc; Path=/; Domain=127.0.0.1; HttpOnly"),
+          ("set-cookie", "csrftoken=xyz"),
+          ("connection", "close"),
+          ("content-length", "999"),
+        ],
+        stream=httpx.ByteStream(b"proxied"),
+        request=request,
+      )
+
+    async def aclose(self):
+      seen["closed"] = True
+
+  monkeypatch.setattr(
+    local_services_module.httpx, "AsyncClient", FakeAsyncClient,
+  )
+  response = client.post(
+    "/services/recipes/accounts/login/?next=%2Fservices%2Frecipes%2F",
+    content=b"username=owner",
+    headers={
+      "host": "attacker.invalid",
+      "authorization": "Bearer must-not-reach-upstream",
+      "x-forwarded-host": "attacker.invalid",
+      "content-type": "application/x-www-form-urlencoded",
+    },
+  )
+
+  request = seen["request"]
+  assert str(request.url) == (
+    "http://127.0.0.1:8123/services/recipes/accounts/login/"
+    "?next=%2Fservices%2Frecipes%2F"
+  )
+  assert request.content == b"username=owner"
+  public = urlsplit(get_settings().frontend_origin)
+  assert request.headers["host"] == public.netloc
+  assert request.headers["x-forwarded-host"] == public.netloc
+  assert request.headers["x-forwarded-proto"] == urlsplit(
+    get_settings().frontend_origin
+  ).scheme
+  assert request.headers["x-script-name"] == "/services/recipes"
+  assert request.headers["x-forwarded-prefix"] == "/services/recipes"
+  assert "authorization" not in request.headers
+  assert response.status_code == 201
+  assert response.content == b"proxied"
+  assert response.headers["location"] == (
+    f"{public.scheme}://{public.netloc}/services/recipes/welcome/"
+  )
+  assert response.headers.get_list("set-cookie") == [
+    "sessionid=abc; Path=/services/recipes/; HttpOnly",
+    "csrftoken=xyz; Path=/services/recipes/",
+  ]
+  assert "connection" not in response.headers
+  assert "content-length" not in response.headers
+  assert seen["closed"] is True
+
+
+def test_unreachable_service_degrades_to_scoped_502(
+  client, clean_local_services_config, monkeypatch,
+):
+  write_config(clean_local_services_config, {
+    "recipes": {"upstream": "http://127.0.0.1:8123"},
+  })
+
+  class FailingAsyncClient:
+    def __init__(self, *args, **kwargs):
+      pass
+
+    def build_request(self, method, url, *, headers, content):
+      return httpx.Request(method, url, headers=headers, content=content)
+
+    async def send(self, request, *, stream):
+      raise httpx.ConnectError("offline", request=request)
+
+    async def aclose(self):
+      pass
+
+  monkeypatch.setattr(
+    local_services_module.httpx, "AsyncClient", FailingAsyncClient,
+  )
+  response = client.get("/services/recipes/")
+
+  assert response.status_code == 502
+  assert response.text == "The local service 'recipes' is not available right now."
+  assert "127.0.0.1" not in response.text

--- a/frontend/src/lib/__tests__/swNavigationDenylist.test.js
+++ b/frontend/src/lib/__tests__/swNavigationDenylist.test.js
@@ -7,22 +7,21 @@ const SOURCE = readFileSync(
   'utf8',
 )
 
-// The denylist literal spreads `PROXIED_APP_SUBTREES` (the reverse-proxied-app
-// extension point), so the eval needs that binding in scope. `proxied` lets a
-// test drive the extension point without editing the shipped shell.
+// The denylist spreads the legacy instance-local extension point. Keep that
+// binding available while also testing the stock reserved /services subtree.
 function shellNavigationDenylist(proxied = null) {
   const match = SOURCE.match(/denylist:\s*\[([\s\S]*?)\n\s*\]/)
   assert.ok(match, 'shell NavigationRoute denylist exists')
-  let decl
+  let declaration
   if (proxied === null) {
     const constMatch = SOURCE.match(/^const PROXIED_APP_SUBTREES = (\[[\s\S]*?\])/m)
     assert.ok(constMatch, 'PROXIED_APP_SUBTREES extension point exists')
-    decl = constMatch[1]
+    declaration = constMatch[1]
   } else {
-    decl = `[${proxied}]`
+    declaration = `[${proxied}]`
   }
   return Function(
-    `"use strict"; const PROXIED_APP_SUBTREES = ${decl}; return [${match[1]}]`,
+    `"use strict"; const PROXIED_APP_SUBTREES = ${declaration}; return [${match[1]}]`,
   )()
 }
 
@@ -58,33 +57,34 @@ test('shell embed navigation reaches the server, not the non-injected precache',
   assert.equal(denied('/shell/chat/abc'), false)
 })
 
-test('reverse-proxied app subtrees ship empty — no instance app baked in', () => {
-  // The shipped shell must not deny any concrete instance's proxy prefix; the
-  // extension point is empty by default.
-  const constMatch = SOURCE.match(/^const PROXIED_APP_SUBTREES = (\[[\s\S]*?\])/m)
-  assert.ok(constMatch, 'PROXIED_APP_SUBTREES extension point exists')
-  assert.equal(constMatch[1].replace(/\s/g, ''), '[]', 'ships empty')
-
-  // With the empty default, a deep path under an arbitrary would-be proxy
-  // prefix still falls through to the SPA (nothing extra is denied).
+test('guarded local services bypass the shell at every depth', () => {
   const denied = path => shellNavigationDenylist().some(re => re.test(path))
+
+  assert.equal(denied('/services'), true)
+  assert.equal(denied('/services/'), true)
+  assert.equal(denied('/services/recipes'), true)
+  assert.equal(denied('/services/recipes/setup/'), true)
+  assert.equal(denied('/services/recipes/accounts/login/'), true)
+  assert.equal(denied('/services/recipes/api/recipe/42/'), true)
+  // No concrete instance service is compiled into the shell. An old ad-hoc
+  // prefix is still an ordinary SPA path unless it moves under /services/.
   assert.equal(denied('/recipes/setup/step/2'), false)
+  assert.equal(denied('/shell/chat/abc'), false)
 })
 
-test('a configured proxied subtree denies the WHOLE subtree, deep paths too', () => {
-  // Mechanism/regression guard for the deep-path bounce: when an instance adds
-  // its proxied app root, EVERY deep navigation under it must be denied (sent to
-  // the network), not just the single-segment root the catch-all already covers.
+test('legacy reverse-proxy extension still ships empty', () => {
+  const constMatch = SOURCE.match(/^const PROXIED_APP_SUBTREES = (\[[\s\S]*?\])/m)
+  assert.ok(constMatch, 'PROXIED_APP_SUBTREES extension point exists')
+  assert.equal(constMatch[1].replace(/\s/g, ''), '[]')
+})
+
+test('a configured legacy proxy subtree still bypasses the shell deeply', () => {
   const denylist = shellNavigationDenylist(String.raw`/^\/recipes(\/|$)/`)
   const denied = path => denylist.some(re => re.test(path))
 
   assert.equal(denied('/recipes'), true)
-  assert.equal(denied('/recipes/'), true)
-  assert.equal(denied('/recipes/setup/'), true)
-  assert.equal(denied('/recipes/accounts/login/'), true)
-  assert.equal(denied('/recipes/api/recipe/42/'), true)
-  // A sibling top-level route is unaffected — still SPA-served.
-  assert.equal(denied('/shell/chat/abc'), false)
+  assert.equal(denied('/recipes/setup/step/2'), true)
+  assert.equal(denied('/other/deep/path'), false)
 })
 
 test('offline app cache key ignores install intent query', () => {

--- a/frontend/src/sw.js
+++ b/frontend/src/sw.js
@@ -689,6 +689,12 @@ registerRoute(
 // Empty here on purpose: no single instance's app is baked into the shipped shell.
 const PROXIED_APP_SUBTREES = []
 
+// Owner-configured backend web services live under one reserved namespace.
+// They are server-served, multi-page applications rather than SPA routes, so
+// every depth below /services/ must reach the guarded backend proxy.  The
+// concrete service map is private data (`/data/local-services.json`), never
+// compiled into the stock shell or edited into this service worker.
+
 registerRoute(new NavigationRoute(
   createHandlerBoundToURL('/index.html'),
   {
@@ -702,7 +708,8 @@ registerRoute(new NavigationRoute(
       // cached index.html for a published URL, so opening it showed the Möbius
       // app instead of the built website.
       /^\/sites(\/|$)/,
-      // Instance-configured reverse-proxied app subtrees (empty in stock Möbius).
+      /^\/services(\/|$)/,
+      // Legacy instance-local mounts remain supported as an extension point.
       ...PROXIED_APP_SUBTREES,
       /^\/(?!(?:shell|apps|recover)(?:\/|$))[A-Za-z0-9_-]+(?:\/(?:index\.html)?)?$/,
     ],


### PR DESCRIPTION
## Summary
- add explicit `/services/<slug>/` proxy configuration for loopback HTTP services
- require an upstream-auth access declaration before a service can be exposed
- strip owner authorization and inbound forwarding headers at the trust boundary
- rewrite loopback redirects and scope upstream cookies to the service prefix
- preserve the legacy extension point while reserving the service namespace in the shell worker

## Testing
- `pytest -q backend/tests/test_local_services.py` — 11 passed
- focused service-worker checks, full frontend tests, and production build — passed