### PR TITLE
Seed new chats from the last rate-limit choice

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -571,6 +571,13 @@ def run_migrations(eng) -> None:
         "ALTER TABLE owner ADD COLUMN provider VARCHAR(32) "
         "NOT NULL DEFAULT 'claude'"
       )
+    if "auto_resume_on_limit_default" not in owner_cols:
+      # Start conservatively off. Later chat-level selections update this
+      # owner seed so new chats inherit the most recently chosen value.
+      _add_owner.append(
+        "ALTER TABLE owner ADD COLUMN auto_resume_on_limit_default BOOLEAN "
+        "NOT NULL DEFAULT FALSE"
+      )
     if "model_prefs_json" not in owner_cols:
       # Nullable JSON blob holding the owner's model-picker
       # preferences (e.g. hidden model IDs). Null = "show

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -34,6 +34,12 @@ class Owner(Base):
   hashed_password = Column(String(255), nullable=False)
   # Must stay in sync with providers.PROVIDER_NAMES.
   provider = Column(String(32), nullable=False, default="claude")
+  # Default provider-limit recovery policy for newly-created chats. Each chat
+  # stores its own copy; changing a chat's switch updates this seed for the
+  # next chat without rewriting any existing conversation.
+  auto_resume_on_limit_default = Column(
+    Boolean, nullable=False, default=False, server_default=false()
+  )
   # Per-owner model-picker preferences. Shape:
   #   {"hidden_ids": ["claude-haiku-4-5-20251001", ...]}
   # The picker filters out any registry entry whose ID appears in

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -352,6 +352,9 @@ def create_chat(
     messages=body.messages or [],
     provider=provider,
     agent_settings_json=None,
+    auto_resume_on_limit=(
+      bool(owner.auto_resume_on_limit_default) if owner else False
+    ),
   )
   db.add(chat)
   db.commit()
@@ -428,7 +431,7 @@ def _first_message_title(chat) -> str:
 async def patch_chat(
   body: ChatPatch,
   chat_id: str,
-  _: models.Owner = Depends(get_current_owner),
+  owner: models.Owner = Depends(get_current_owner),
   db: Session = Depends(get_db),
 ):
   """Partial-update endpoint used by the `/` slash picker.
@@ -500,6 +503,10 @@ async def patch_chat(
 
     if body.auto_resume_on_limit is not None:
       chat.auto_resume_on_limit = body.auto_resume_on_limit
+      # Existing chats keep their own stored policy. This only seeds the next
+      # chat, matching other "last picked" defaults without making the setting
+      # global at runtime.
+      owner.auto_resume_on_limit_default = body.auto_resume_on_limit
 
     # Determine the effective target provider. The body may set it
     # explicitly, OR it may be implied by a model-only PATCH whose

--- a/backend/tests/test_chat_agent_settings.py
+++ b/backend/tests/test_chat_agent_settings.py
@@ -206,6 +206,41 @@ def test_auto_resume_is_per_chat_and_survives_runtime_clear(
   assert disabled["agent_settings_json"] is None
 
 
+def test_new_chat_inherits_last_auto_resume_selection(client, auth, chat):
+  """The last explicit choice seeds new chats without rewriting old ones."""
+  initial = client.post(
+    "/api/chats", headers=auth, json={"title": "initial"},
+  ).json()
+  assert client.get(
+    f"/api/chats/{initial['id']}", headers=auth,
+  ).json()["auto_resume_on_limit"] is False
+
+  client.patch(
+    f"/api/chats/{chat.id}", headers=auth,
+    json={"auto_resume_on_limit": True},
+  )
+  inherited_on = client.post(
+    "/api/chats", headers=auth, json={"title": "inherits on"},
+  ).json()
+  assert client.get(
+    f"/api/chats/{inherited_on['id']}", headers=auth,
+  ).json()["auto_resume_on_limit"] is True
+
+  client.patch(
+    f"/api/chats/{chat.id}", headers=auth,
+    json={"auto_resume_on_limit": False},
+  )
+  inherited_off = client.post(
+    "/api/chats", headers=auth, json={"title": "inherits off"},
+  ).json()
+  assert client.get(
+    f"/api/chats/{inherited_off['id']}", headers=auth,
+  ).json()["auto_resume_on_limit"] is False
+  assert client.get(
+    f"/api/chats/{inherited_on['id']}", headers=auth,
+  ).json()["auto_resume_on_limit"] is True
+
+
 def test_stale_global_auto_resume_setting_is_not_a_chat_default(
   client, auth, chat,
 ):

--- a/backend/tests/test_db_migrations.py
+++ b/backend/tests/test_db_migrations.py
@@ -152,3 +152,42 @@ def test_fresh_chat_schema_has_database_auto_resume_default():
   assert column.default is not None
   assert column.server_default is not None
   assert str(column.server_default.arg).lower() == "false"
+
+
+def test_run_migrations_adds_owner_auto_resume_default(tmp_path):
+  db_path = tmp_path / "legacy-owner.db"
+  eng = create_engine(f"sqlite:///{db_path}")
+  with eng.connect() as conn:
+    conn.execute(text(
+      "CREATE TABLE apps (id INTEGER PRIMARY KEY, name VARCHAR(255))"
+    ))
+    conn.execute(text(
+      "CREATE TABLE owner (id INTEGER PRIMARY KEY, username VARCHAR(64), "
+      "hashed_password VARCHAR(255))"
+    ))
+    conn.execute(text(
+      "INSERT INTO owner (id, username, hashed_password) "
+      "VALUES (1, 'owner', 'hash')"
+    ))
+    conn.commit()
+
+  run_migrations(eng)
+  run_migrations(eng)
+
+  cols = {c["name"]: c for c in inspect(eng).get_columns("owner")}
+  assert "auto_resume_on_limit_default" in cols
+  assert cols["auto_resume_on_limit_default"]["nullable"] is False
+  with eng.connect() as conn:
+    value = conn.execute(text(
+      "SELECT auto_resume_on_limit_default FROM owner WHERE id = 1"
+    )).scalar_one()
+  assert value in (False, 0)
+
+
+def test_fresh_owner_schema_has_auto_resume_default():
+  column = models.Owner.__table__.c.auto_resume_on_limit_default
+
+  assert column.nullable is False
+  assert column.default is not None
+  assert column.server_default is not None
+  assert str(column.server_default.arg).lower() == "false"


### PR DESCRIPTION
## Summary
- remember the most recently chosen rate-limit policy across new chats
- keep the initial default off until the owner explicitly chooses otherwise
- preserve each existing chat's own setting and migration behavior

## Testing
- focused agent-settings and migration suites — 33 passed