### PR TITLE
Preserve question choices through settlement

### DIFF
--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -1415,6 +1415,12 @@ class ChatWriterActor:
     )
     if not applied:
       raise _PersistFailed("AnswerQuestion: no matching question block")
+    # Answering an interactive question is an owner action just like a visible
+    # send. Keep drawer recency separate from generic transcript writes, but do
+    # advance it here so a parked chat returns to the top as soon as the answer
+    # commits (including the same-turn answer-delivery path).
+    from datetime import UTC, datetime
+    chat.activity_at = datetime.now(UTC)
     if not _commit_or_rollback(db):
       raise _PersistFailed("AnswerQuestion did not persist")
     return True

--- a/backend/app/questions.py
+++ b/backend/app/questions.py
@@ -12,8 +12,9 @@ pending question's future is resolved or cancelled by one of:
   (a) the user-answer POST → resolves with the answers dict, or
   (b) `stop_chat` / `stop_chat_for` → cancels the future.
 
-If neither user answer nor stop fires, the future may remain pending
-forever. This is intentional: the question card blocks the user's chat UI,
+If neither user answer, stop, nor an accepted steering message fires, the
+future may remain pending forever. This is intentional: the question card
+blocks the user's chat UI,
 so a silent timeout would silently drop their turn. Resolving with no
 answer would be worse than blocking — the agent would interpret the empty
 payload as a real choice and proceed with garbage state. If the process
@@ -127,7 +128,8 @@ def was_cancelled(chat_id: str, question_id: str | None = None) -> bool:
 def cancel(chat_id: str) -> None:
   """Cancels and drops any live AskUserQuestion for the chat.
 
-  Idempotent on a missing entry. Pop-first ordering is functionally
+  Used by both explicit Stop and an accepted steer that supersedes the open
+  question. Idempotent on a missing entry. Pop-first ordering is functionally
   equivalent to today's get + cancel + pop (single-thread asyncio
   means no concurrent caller can slip between operations) but reads
   cleaner and removes the temptation to re-fetch by chat_id.

--- a/backend/app/routes/chats_stream.py
+++ b/backend/app/routes/chats_stream.py
@@ -521,6 +521,15 @@ async def send_message(
   # practice; after that, the durable-transcript fallback below decides
   # whether this is recoverable or genuinely stale.
   if body.answers:
+    # Snapshot the Stop tombstone BEFORE waiting on the queue lock. A Stop
+    # that lands after this request began must still win the race (410); a
+    # Stop that had already completed is different: pressing Submit afterward
+    # is a fresh, explicit request to continue from the durable tail question.
+    # The old unconditional tombstone check made that later Submit impossible
+    # until the whole server restarted and forgot the in-memory tombstone.
+    cancelled_when_submitted = questions.was_cancelled(
+      chat_id, body.question_id,
+    )
     async with chat_queue.get_lock(chat_id):
       _GRACE_ATTEMPTS = 10
       _GRACE_INTERVAL = 0.05  # seconds — total ~500ms
@@ -610,7 +619,10 @@ async def send_message(
           status_code=410,
           detail="The question is no longer accepting answers.",
         )
-      if questions.was_cancelled(chat_id, body.question_id):
+      if (
+        questions.was_cancelled(chat_id, body.question_id)
+        and not cancelled_when_submitted
+      ):
         raise HTTPException(
           status_code=410,
           detail="The question is no longer accepting answers.",
@@ -822,6 +834,13 @@ async def _send_message_locked(
         # runner already does and queue the message instead.
         steered = False
       if steered:
+        # A question tool is a synchronous human pause. Once the owner
+        # explicitly fast-forwards (or a steer-enabled chat auto-steers), the
+        # new message supersedes that pause; leaving its future registered
+        # would strand Codex waiting on a card that the transcript has already
+        # moved past. Retire it only AFTER the provider accepts the steer so a
+        # failed steer still leaves the original question answerable.
+        questions.cancel(chat_id)
         # Persist the steer so a reload renders Q1, A1, Q2, A2: seal the
         # pre-interrupt assistant text (A1) as its own message, append this
         # steered user row at the END, and reset the live sink so the

--- a/backend/tests/test_chats_stream_answer_race.py
+++ b/backend/tests/test_chats_stream_answer_race.py
@@ -9,7 +9,7 @@ between "event published" and "registry populated" used to hit a
 410. The route now polls with a short grace period before deciding
 the question is stale.
 
-These tests pin four behaviours of that grace period:
+These tests pin five behaviours of that grace period:
 
   1. Happy path — pending registered before POST → 202 immediately.
   2. Race path — pending registered AFTER POST starts but inside
@@ -18,10 +18,13 @@ These tests pin four behaviours of that grace period:
      after restart → answer is recorded and a hidden continuation starts.
   4. Stale path — no pending, none arrives, and no durable open question
      exists → 410 after the grace window elapses.
+  5. Stopped path — once Stop has completed, a later deliberate Submit
+     restarts from the durable question while a Stop racing Submit still wins.
 """
 
 import asyncio
 import time
+from datetime import UTC, datetime
 from uuid import uuid4
 
 import pytest
@@ -132,6 +135,25 @@ def _set_pending_messages(chat_id: str, pending: list[dict]) -> None:
     db.close()
 
 
+def _set_activity_at(chat_id: str, value: datetime) -> None:
+  db = SessionLocal()
+  try:
+    chat = db.query(models.Chat).filter(models.Chat.id == chat_id).first()
+    chat.activity_at = value
+    db.commit()
+  finally:
+    db.close()
+
+
+def _activity_at(chat_id: str) -> datetime:
+  db = SessionLocal()
+  try:
+    chat = db.query(models.Chat).filter(models.Chat.id == chat_id).first()
+    return chat.activity_at
+  finally:
+    db.close()
+
+
 def test_answer_delivers_immediately_when_pending_registered(
   client, auth, chat,
 ):
@@ -144,6 +166,8 @@ def test_answer_delivers_immediately_when_pending_registered(
     questions.register(chat.id, pending)
     # The actor's AnswerQuestion merges into a durable question block.
     _seed_question_block(chat.id, pending.question_id)
+    old_activity = datetime(2000, 1, 1, tzinfo=UTC)
+    _set_activity_at(chat.id, old_activity)
 
     started = time.monotonic()
     res = client.post(
@@ -166,6 +190,7 @@ def test_answer_delivers_immediately_when_pending_registered(
     assert fut.result() == {"Pick one": "a"}
     # Registry cleared atomically by claim().
     assert questions.get(chat.id) is None
+    assert _activity_at(chat.id).replace(tzinfo=UTC) > old_activity
     # No grace-period delay on the happy path. 500ms cap; 250ms
     # leaves comfortable headroom for slow CI without making the
     # test useless.
@@ -241,6 +266,75 @@ def test_answer_recovers_durable_question_without_live_pending(
         "queued-visible"
       ]
       assert row.run_status == "running"
+    finally:
+      db.close()
+
+  asyncio.run(go())
+
+
+def test_answer_after_completed_stop_recovers_durable_question(
+  client, auth, chat, monkeypatch,
+):
+  """Submit after Stop is a fresh continuation request, not a stale race.
+
+  Stop cancels the in-memory future and leaves its tombstone behind. If the
+  user subsequently answers the still-durable tail card, that later Submit
+  should record the answer and start a hidden continuation. A request that
+  began before Stop remains 410 (covered by the real lock-contention test).
+  """
+  scheduled: list[dict] = []
+
+  def fake_schedule_continuation(**kwargs):
+    scheduled.append(kwargs)
+    chat_mod.discard_starting(kwargs["chat_id"])
+
+  monkeypatch.setattr(
+    chats_stream, "_schedule_continuation", fake_schedule_continuation,
+  )
+
+  async def go():
+    qid = "q-stopped-then-submitted"
+    _seed_question_block(chat.id, qid)
+    loop = asyncio.get_event_loop()
+    pending = PendingQuestion(
+      question_id=qid,
+      questions=[{"id": "q1", "question": "Pick one"}],
+      future=loop.create_future(),
+    )
+    questions.register(chat.id, pending)
+    questions.cancel(chat.id)
+    assert questions.was_cancelled(chat.id, qid)
+    assert pending.future.cancelled()
+
+    res = await loop.run_in_executor(
+      None,
+      lambda: client.post(
+        f"/api/chats/{chat.id}/messages",
+        json={
+          "content": "- Pick one: a",
+          "hidden": True,
+          "answers": {"Pick one": "a"},
+          "question_id": qid,
+        },
+        headers=auth,
+      ),
+    )
+
+    assert res.status_code == 202, res.text
+    assert res.json()["status"] == "started"
+    assert res.json()["answer_turn"] == "new"
+    assert scheduled
+    assert scheduled[0]["next_user"]["hidden"] is True
+    db = SessionLocal()
+    try:
+      row = db.query(models.Chat).filter(models.Chat.id == chat.id).first()
+      question = next(
+        block
+        for msg in row.messages
+        for block in (msg.get("blocks") or [])
+        if block.get("question_id") == qid
+      )
+      assert question["answers"] == {"Pick one": "a"}
     finally:
       db.close()
 

--- a/backend/tests/test_chats_stream_steer.py
+++ b/backend/tests/test_chats_stream_steer.py
@@ -23,11 +23,13 @@ covered by `test_codex_sdk_runner.py`; here we only exercise the wiring.
 """
 
 import asyncio
+from concurrent.futures import Future
 
-from app import models
+from app import models, questions
 from app.broadcast import create_broadcast, get_broadcast
 from app.chat_writer import cid_of
 from app.database import SessionLocal
+from app.pending_questions import PendingQuestion
 from app.runner_registry import RunnerKind, registry
 
 
@@ -177,6 +179,65 @@ def test_steers_into_live_codex_turn_when_flag_on(
       "content": "actually use blue",
     }
   ]
+
+
+def test_accepted_steer_retires_open_question(client, auth, monkeypatch):
+  """Steering supersedes a synchronous question instead of leaving its hidden
+  future parked after the transcript has already moved on."""
+  chat_id = "questionsteer"
+  question_id = "q-open"
+  _make_codex_chat(chat_id, steer_enabled=False)
+  db = SessionLocal()
+  try:
+    chat = db.query(models.Chat).filter(models.Chat.id == chat_id).first()
+    chat.messages[-1]["blocks"] = [{
+      "type": "question",
+      "question_id": question_id,
+      "questions": [{"question": "Keep going?", "options": [{"label": "Yes"}]}],
+    }]
+    chat.pending_messages = [{
+      "role": "user",
+      "content": "Skip that and use the default",
+      "ts": 10,
+      "cid": "question-steer-cid",
+    }]
+    from sqlalchemy.orm.attributes import flag_modified
+    flag_modified(chat, "messages")
+    db.commit()
+  finally:
+    db.close()
+
+  waiting = Future()
+  questions.register(chat_id, PendingQuestion(
+    question_id=question_id,
+    questions=[],
+    future=waiting,
+  ))
+  registry.register(_make_active_codex_turn(chat_id))
+
+  async def _fake_steer(cid, message):
+    return True
+
+  monkeypatch.setattr(
+    "app.codex_sdk_runner.steer_into_active_turn", _fake_steer,
+  )
+
+  res = client.post(
+    f"/api/chats/{chat_id}/messages",
+    json={
+      "content": "Skip that and use the default",
+      "force_steer": True,
+      "consume_pending_cids": ["question-steer-cid"],
+    },
+    headers=auth,
+  )
+
+  assert res.status_code == 202, res.text
+  assert res.json()["status"] == "steered"
+  assert waiting.cancelled()
+  assert questions.get(chat_id) is None
+  assert questions.was_cancelled(chat_id, question_id)
+  assert _read_chat(chat_id).messages[-1]["content"] == "Skip that and use the default"
 
 
 def _register_sink_with_partial(chat_id: str, run_token: str, text: str):

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -45,6 +45,7 @@ import {
   subscribeProviderSwitch,
 } from './providerSwitch.js'
 import { questionKey } from './questionKey.js'
+import { clearChatQuestionDrafts } from './questionDraft.js'
 import { resolveStopResend } from './resolveStopResend.js'
 import { focusComposerElement, shouldApplyComposerFocusRequest } from './composerFocusPolicy.js'
 import { sameMessageList } from './chatMessageList.js'
@@ -163,6 +164,7 @@ function findUserIndexByCid(messages, cid) {
 export function deleteChatDraft(chatId) {
   try { sessionStorage.removeItem(`draft:${chatId}`) } catch { /* private browsing */ }
   clearFailedSendAttempt(chatId)
+  clearChatQuestionDrafts(chatId)
 }
 
 // Evict the oldest draft: key from sessionStorage so a new draft can land.
@@ -274,6 +276,7 @@ export default function ChatView({
   builtApps = NO_BUILT_APPS,
   onOpenApp,
   onMessageStart,
+  onQuestionAnswered,
   onVoiceListeningChange,
   showPicker = true,
   embedded = false,
@@ -737,6 +740,8 @@ export default function ChatView({
   // declared further down.
   const onMessageStartRef = useRef(onMessageStart)
   onMessageStartRef.current = onMessageStart
+  const onQuestionAnsweredRef = useRef(onQuestionAnswered)
+  onQuestionAnsweredRef.current = onQuestionAnswered
   const onFirstMessageRef = useRef(onFirstMessage)
   onFirstMessageRef.current = onFirstMessage
   const onStreamEndRef = useRef(onStreamEnd)
@@ -2365,11 +2370,11 @@ export default function ChatView({
     // deliberately allowed while sendingRef is true (the runner is
     // parked waiting for the answer), but we still need to prevent the
     // same answer from being submitted twice concurrently.
-    if (sendSilentInFlightRef.current) return
+    if (sendSilentInFlightRef.current) return false
     sendSilentInFlightRef.current = true
     if (!text.trim()) {
       sendSilentInFlightRef.current = false
-      return
+      return false
     }
     // Answer submissions (resolvedAnswers truthy) are allowed mid-turn:
     // the runner is paused on the AskUserQuestion future and is waiting
@@ -2381,36 +2386,11 @@ export default function ChatView({
     // own `submitted` state guards against double-clicks on the same card.
     if ((sendingRef.current || isStreamingRef.current) && !resolvedAnswers) {
       sendSilentInFlightRef.current = false
-      return
+      return false
     }
     sendingRef.current = true
     onMessageStartRef.current?.()
     promotedRef.current = false
-
-    // Local optimistic update of the question block so the UI shows
-    // the answered state immediately (before backend round-trip).
-    if (resolvedAnswers) {
-      commitMessages(prev => {
-        const updated = [...prev]
-        const lastIdx = updated.length - 1
-        if (lastIdx >= 0 && updated[lastIdx].role === 'assistant') {
-          const msg = { ...updated[lastIdx] }
-          msg.blocks = (msg.blocks || []).map(b => {
-            if (b.type !== 'question') return b
-            if (questionId && b.question_id !== questionId) return b
-            return { ...b, answers: resolvedAnswers }
-          })
-          updated[lastIdx] = msg
-        }
-        return updated
-      })
-      // When the question is still live in streamItems (not yet promoted
-      // to messages — the turn is mid-flight and messages[-1] is the user
-      // message, not the assistant), the commitMessages patch above has no
-      // target. Also update streamItems so the card visually transitions to
-      // answered regardless of which source is currently rendering it.
-      patchQuestionAnswers(questionId, resolvedAnswers)
-    }
 
     setSending(true)
     setServerRunningState(true)
@@ -2432,6 +2412,28 @@ export default function ChatView({
         answers: resolvedAnswers,
         question_id: questionId,
       })
+      // The 202 means the answer write committed. Settle the durable and live
+      // card sources only now; an optimistic pre-request answer made transient
+      // failures look final and erased the retryable per-tab question draft.
+      if (resolvedAnswers) {
+        commitMessages(prev => {
+          const updated = [...prev]
+          const lastIdx = updated.length - 1
+          if (lastIdx >= 0 && updated[lastIdx].role === 'assistant') {
+            const msg = { ...updated[lastIdx] }
+            msg.blocks = (msg.blocks || []).map(b => {
+              if (b.type !== 'question') return b
+              if (questionId && b.question_id !== questionId) return b
+              return { ...b, answers: resolvedAnswers }
+            })
+            updated[lastIdx] = msg
+          }
+          return updated
+        })
+        // A mid-turn question may still live in streamItems rather than the
+        // durable message list. Keep both render sources in agreement.
+        patchQuestionAnswers(questionId, resolvedAnswers)
+      }
       // `answer_delivered` resumes the SAME assistant turn. Keep its bridge
       // alive so terminal promotion replaces/extends the active row rather
       // than dropping the question and pre-answer output during the
@@ -2445,7 +2447,13 @@ export default function ChatView({
         bridgeHook.markBridged()
         activeAssistantDataKeyRef.current = null
       }
+      // The answer write has committed before the 202 response. Refreshing the
+      // owner's chat list now makes this deliberate interaction visible in
+      // drawer recency immediately, instead of waiting for the resumed turn to
+      // finish and emit its terminal refresh.
+      onQuestionAnsweredRef.current?.()
       if (questionId) setLiveQuestionId(prev => prev === questionId ? null : prev)
+      return true
     } catch (err) {
       setSending(false)
       setServerRunningState(false)
@@ -2456,13 +2464,13 @@ export default function ChatView({
         // than keeping the optimistic answer locally.
         setLiveQuestionId(null)
         fetchMessages({ force: true })
-        sendSilentInFlightRef.current = false
-        return
+        throw err
       }
       commitMessages(prev => [
         ...prev,
         { role: 'assistant', content: `Error: ${err.message}`, blocks: [] },
       ])
+      throw err
     } finally {
       sendSilentInFlightRef.current = false
     }

--- a/frontend/src/components/ChatView/MsgContent.jsx
+++ b/frontend/src/components/ChatView/MsgContent.jsx
@@ -234,6 +234,7 @@ function MsgContentInner({
         return (
           <div key={assistantBlockKey(block, i)}>
             <QuestionCard
+              chatId={chatId}
               questions={block.questions || []}
               questionId={block.question_id}
               answeredMap={answers}

--- a/frontend/src/components/ChatView/QuestionCard.css
+++ b/frontend/src/components/ChatView/QuestionCard.css
@@ -180,6 +180,13 @@
   border-color: var(--accent);
   box-shadow: 0 0 0 3px var(--accent-dim);
 }
+.qcard__input:disabled {
+  /* Keep the submitted custom answer readable but visibly settled. Safari
+     otherwise preserves the active text color through -webkit-text-fill-color. */
+  color: var(--muted);
+  -webkit-text-fill-color: var(--muted);
+  opacity: 1;
+}
 
 .qcard__submit {
   display: block;

--- a/frontend/src/components/ChatView/QuestionCard.jsx
+++ b/frontend/src/components/ChatView/QuestionCard.jsx
@@ -1,5 +1,11 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import './QuestionCard.css'
+import {
+  clearQuestionDraft,
+  questionDraftKey,
+  readQuestionDraft,
+  writeQuestionDraft,
+} from './questionDraft.js'
 
 
 function resolveAnswer(answer, otherText) {
@@ -12,13 +18,39 @@ function resolveAnswer(answer, otherText) {
 }
 
 
-export default function QuestionCard({ questions, questionId, answeredMap, onAnswer, disabled }) {
-  const [answers, setAnswers] = useState({})
-  const [otherTexts, setOtherTexts] = useState({})
+export default function QuestionCard({
+  chatId,
+  questions,
+  questionId,
+  answeredMap,
+  onAnswer,
+  disabled,
+}) {
+  const draftKey = questionDraftKey(chatId, questionId, questions)
+  const [answers, setAnswers] = useState(
+    () => readQuestionDraft(draftKey).answers,
+  )
+  const [otherTexts, setOtherTexts] = useState(
+    () => readQuestionDraft(draftKey).otherTexts,
+  )
+  const [submitting, setSubmitting] = useState(false)
   const [submitted, setSubmitted] = useState(false)
 
   const answered = submitted || !!answeredMap
   const displayAnswers = answeredMap || {}
+
+  // ChatView is keyed by chat, so switching away remounts this card. Keep an
+  // unsubmitted selection in the same per-tab cache as composer drafts; the
+  // owner can inspect another chat and return without rebuilding their answer.
+  // A completed or superseded card clears its draft instead of leaving stale
+  // choices attached to transcript history.
+  useEffect(() => {
+    if (answered || disabled) {
+      clearQuestionDraft(draftKey)
+      return
+    }
+    writeQuestionDraft(draftKey, answers, otherTexts)
+  }, [draftKey, answers, otherTexts, answered, disabled])
 
   const allAnswered = questions.every(q => {
     const a = answers[q.question]
@@ -69,16 +101,26 @@ export default function QuestionCard({ questions, questionId, answeredMap, onAns
     }
   }
 
-  function handleSubmit() {
-    if (!allAnswered || answered || disabled) return
+  async function handleSubmit() {
+    if (!allAnswered || answered || disabled || submitting) return
     const resolved = {}
     const lines = questions.map(q => {
       const val = resolveAnswer(answers[q.question], otherTexts[q.question])
       resolved[q.question] = val
       return `- ${q.question}: ${val}`
     })
-    setSubmitted(true)
-    onAnswer?.(lines.join('\n'), resolved, questionId)
+    setSubmitting(true)
+    try {
+      const accepted = await onAnswer?.(lines.join('\n'), resolved, questionId)
+      // Only settle (and therefore clear the durable per-tab draft) after the
+      // answer endpoint confirms that the transcript write committed.
+      if (accepted !== false) setSubmitted(true)
+    } catch {
+      // ChatView presents the transport/stale error. Keep the choices and
+      // custom text intact so a transient failure is immediately retryable.
+    } finally {
+      setSubmitting(false)
+    }
   }
 
   return (
@@ -95,10 +137,24 @@ export default function QuestionCard({ questions, questionId, answeredMap, onAns
         const isOtherSelected = isMulti
           ? selectedArr.includes('__other__')
           : selected === '__other__'
-        const inactive = answered || disabled
+        const inactive = answered || disabled || submitting
 
         const answeredValue = displayAnswers[q.question]
           || (submitted ? resolveAnswer(answers[q.question], otherTexts[q.question]) : '')
+        const answeredArr = answered && isMulti
+          ? (answeredValue ? answeredValue.split(', ').map(s => s.trim()) : [])
+          : []
+        const unmatchedAnswers = answered
+          ? (isMulti
+              ? answeredArr.filter(v => !q.options?.some(o => o.label === v))
+              : (answeredValue && !q.options?.some(o => o.label === answeredValue)
+                  ? [answeredValue]
+                  : []))
+          : []
+        const answeredWithOther = unmatchedAnswers.length > 0
+        const selectionCount = answered
+          ? (isMulti ? answeredArr.length : (answeredValue ? 1 : 0))
+          : selectedArr.length
 
         return (
           <div key={qi} className="qcard__q">
@@ -110,10 +166,10 @@ export default function QuestionCard({ questions, questionId, answeredMap, onAns
                 and watched whether a prior pick cleared. Surface it up front:
                 a caption (with a live count for multi) plus a per-option glyph
                 (□ checkbox for multi, ○ radio for single). */}
-            {!answered && !disabled && (
+            {(!disabled || answered) && (
               <div className="qcard__hint">
                 {isMulti
-                  ? `Select all that apply${selectedArr.length ? ` · ${selectedArr.length} selected` : ''}`
+                  ? `Select all that apply${selectionCount ? ` · ${selectionCount} selected` : ''}`
                   : 'Choose one'}
               </div>
             )}
@@ -125,19 +181,12 @@ export default function QuestionCard({ questions, questionId, answeredMap, onAns
               role={isMulti ? 'group' : 'radiogroup'}
               aria-label={q.question}
             >
-              {/* For multi-select answered state, parse the comma-joined
-                  value back into an array so each chosen option highlights
-                  correctly. Without this split, isChosen = (fullString ===
-                  opt.label) was always false and a fallback span rendered
-                  the whole joined string instead of individual chips. */}
+              {/* For multi-select answered state, the comma-joined value is
+                  parsed above so each chosen option highlights correctly. */}
               {(() => {
-                const answeredArr = answered && isMulti
-                  ? (answeredValue ? answeredValue.split(', ').map(s => s.trim()) : [])
-                  : null
-
                 return q.options?.map((opt, oi) => {
                   const isChosen = answered
-                    ? (isMulti ? (answeredArr?.includes(opt.label) ?? false) : answeredValue === opt.label)
+                    ? (isMulti ? answeredArr.includes(opt.label) : answeredValue === opt.label)
                     : false
                   const isActive = answered
                     ? isChosen
@@ -173,13 +222,12 @@ export default function QuestionCard({ questions, questionId, answeredMap, onAns
                   )
                 })
               })()}
-              {!answered && (
               <button
                 type="button"
                 role={isMulti ? 'checkbox' : 'radio'}
-                aria-checked={isOtherSelected}
-                className={`qcard__opt qcard__opt--other${isOtherSelected ? ' qcard__opt--on' : ''}`}
-                onClick={() => selectOther(q.question)}
+                aria-checked={answered ? answeredWithOther : isOtherSelected}
+                className={`qcard__opt qcard__opt--other${(answered ? answeredWithOther : isOtherSelected) ? ' qcard__opt--on' : ''}${answered && !answeredWithOther ? ' qcard__opt--dim' : ''}`}
+                onClick={answered ? undefined : () => selectOther(q.question)}
                 disabled={inactive}
               >
                 <span
@@ -188,28 +236,17 @@ export default function QuestionCard({ questions, questionId, answeredMap, onAns
                 />
                 Other
               </button>
-              )}
-              {/* Fallback span for "other" text answers that don't match
-                  any known option label. For multi-select, show the unmatched
-                  entries; for single-select, show the whole value. */}
-              {answered && isMulti && (() => {
-                const answeredArr = answeredValue ? answeredValue.split(', ').map(s => s.trim()) : []
-                const unmatched = answeredArr.filter(v => !q.options?.some(o => o.label === v))
-                if (unmatched.length === 0) return null
-                return <span className="qcard__opt qcard__opt--on">{unmatched.join(', ')}</span>
-              })()}
-              {answered && !isMulti && answeredValue && !q.options?.some(o => o.label === answeredValue) && (
-                <span className="qcard__opt qcard__opt--on">{answeredValue}</span>
-              )}
             </div>
-            {isOtherSelected && !answered && (
+            {(isOtherSelected || answeredWithOther) && (
               <input
                 className="qcard__input"
                 type="text"
                 aria-label={`Other answer for: ${q.question}`}
                 placeholder="Type your answer…"
                 autoComplete="off"
-                value={otherTexts[q.question] || ''}
+                value={answered
+                  ? unmatchedAnswers.join(', ')
+                  : (otherTexts[q.question] || '')}
                 onChange={e => setOtherText(q.question, e.target.value)}
                 disabled={inactive}
                 autoFocus
@@ -224,14 +261,14 @@ export default function QuestionCard({ questions, questionId, answeredMap, onAns
           </div>
         )
       })}
-      {!answered && !disabled && (
+      {(answered || !disabled) && (
         <button
           type="button"
           className="qcard__submit"
           onClick={handleSubmit}
-          disabled={!allAnswered || disabled}
+          disabled={!allAnswered || disabled || answered || submitting}
         >
-          Submit
+          {submitting ? 'Submitting…' : (answered ? 'Submitted' : 'Submit')}
         </button>
       )}
     </div>

--- a/frontend/src/components/ChatView/__tests__/questionCardState.test.js
+++ b/frontend/src/components/ChatView/__tests__/questionCardState.test.js
@@ -12,10 +12,24 @@ test('unanswered question cards do not have a stale gray state', () => {
     'unanswered cards should not receive a stale visual class')
   assert.doesNotMatch(component, /This question is no longer active/,
     'unanswered cards should not tell the user the question expired')
-  assert.match(component, /\{!answered && !disabled && \(\s*<button[\s\S]*className="qcard__submit"/,
-    'submit button should render only while the card can still be answered')
-  assert.match(component, /\{!answered && !disabled && \(\s*<div className="qcard__hint"/,
-    'selection hints should render only when the card is answerable')
+  assert.match(component, /\{\(answered \|\| !disabled\) && \(\s*<button[\s\S]*className="qcard__submit"/,
+    'submit button should remain in place after an answer is submitted')
+  assert.match(component, /submitting \? 'Submitting…' : \(answered \? 'Submitted' : 'Submit'\)/,
+    'the retained submit button should explain pending and answered states')
+  assert.match(component, /\{\(!disabled \|\| answered\) && \(\s*<div className="qcard__hint"/,
+    'selection hints should stay in place after the answer is submitted')
+  assert.doesNotMatch(component, /\{!answered && \(\s*<button[\s\S]*?qcard__opt--other/,
+    'the Other option should not disappear after submission')
+  assert.match(component, /\{\(isOtherSelected \|\| answeredWithOther\) && \(\s*<input/,
+    'a submitted custom answer should keep its input row in place')
+  assert.match(component, /writeQuestionDraft\(draftKey, answers, otherTexts\)/,
+    'unsubmitted selections and custom text should be cached')
+  assert.match(component, /if \(answered \|\| disabled\) \{\s*clearQuestionDraft\(draftKey\)/,
+    'submitted or superseded questions should clear their cached draft')
+  assert.match(component, /const accepted = await onAnswer[\s\S]*if \(accepted !== false\) setSubmitted\(true\)/,
+    'a card should settle only after the answer request is accepted')
+  assert.match(component, /catch \{[\s\S]*Keep the choices and[\s\S]*\} finally/,
+    'a failed answer should retain its retryable draft')
 })
 
 test('question card css has no stale styling hook', () => {
@@ -23,4 +37,6 @@ test('question card css has no stale styling hook', () => {
     'stale question styling should not come back')
   assert.doesNotMatch(css, /\.qcard__status\s*\{[\s\S]*?\}/,
     'expiration status styling should not come back')
+  assert.match(css, /\.qcard__input:disabled\s*\{[\s\S]*?color:\s*var\(--muted\);[\s\S]*?-webkit-text-fill-color:\s*var\(--muted\);[\s\S]*?\}/,
+    'a submitted custom answer should visibly gray out in every browser')
 })

--- a/frontend/src/components/ChatView/__tests__/questionDraft.test.js
+++ b/frontend/src/components/ChatView/__tests__/questionDraft.test.js
@@ -1,0 +1,75 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  clearChatQuestionDrafts,
+  clearQuestionDraft,
+  questionDraftKey,
+  readQuestionDraft,
+  writeQuestionDraft,
+} from '../questionDraft.js'
+
+
+class MemoryStorage {
+  constructor() { this.values = new Map() }
+  get length() { return this.values.size }
+  getItem(key) { return this.values.get(key) ?? null }
+  setItem(key, value) { this.values.set(key, String(value)) }
+  removeItem(key) { this.values.delete(key) }
+  key(index) { return [...this.values.keys()][index] ?? null }
+}
+
+
+const questions = [{
+  question: 'Which direction?',
+  multiSelect: true,
+  options: [{ label: 'Polish' }, { label: 'Simplify' }],
+}]
+
+
+test('question drafts restore selections and custom text by chat and question', () => {
+  const storage = new MemoryStorage()
+  const key = questionDraftKey('chat-1', 'question-7', questions)
+
+  writeQuestionDraft(
+    key,
+    { 'Which direction?': ['Polish', '__other__'] },
+    { 'Which direction?': 'Keep the current shape' },
+    storage,
+  )
+
+  assert.deepEqual(readQuestionDraft(key, storage), {
+    answers: { 'Which direction?': ['Polish', '__other__'] },
+    otherTexts: { 'Which direction?': 'Keep the current shape' },
+  })
+  assert.deepEqual(
+    readQuestionDraft(questionDraftKey('chat-2', 'question-7', questions), storage),
+    { answers: {}, otherTexts: {} },
+    'another chat must not inherit the selection',
+  )
+})
+
+
+test('legacy questions without an id get a stable content-derived draft key', () => {
+  const first = questionDraftKey('chat-1', null, questions)
+  const second = questionDraftKey('chat-1', null, structuredClone(questions))
+  assert.equal(first, second)
+  assert.notEqual(first, questionDraftKey('chat-1', null, [{ question: 'Different?' }]))
+})
+
+
+test('question drafts clear on submit and with the owning chat', () => {
+  const storage = new MemoryStorage()
+  const first = questionDraftKey('chat-1', 'q1', questions)
+  const second = questionDraftKey('chat-1', 'q2', questions)
+  const otherChat = questionDraftKey('chat-2', 'q1', questions)
+  for (const key of [first, second, otherChat]) {
+    writeQuestionDraft(key, { 'Which direction?': 'Polish' }, {}, storage)
+  }
+
+  clearQuestionDraft(first, storage)
+  assert.equal(storage.getItem(first), null)
+  clearChatQuestionDrafts('chat-1', storage)
+  assert.equal(storage.getItem(second), null)
+  assert.notEqual(storage.getItem(otherChat), null)
+})

--- a/frontend/src/components/ChatView/questionDraft.js
+++ b/frontend/src/components/ChatView/questionDraft.js
@@ -1,0 +1,90 @@
+const QUESTION_DRAFT_PREFIX = 'qa-draft:'
+
+
+function browserSessionStorage() {
+  try { return globalThis.sessionStorage } catch { return null }
+}
+
+
+function questionFingerprint(questions) {
+  const source = JSON.stringify((questions || []).map(q => ({
+    header: q?.header || '',
+    question: q?.question || '',
+    multiSelect: !!q?.multiSelect,
+    options: (q?.options || []).map(option => option?.label || ''),
+  })))
+  let hash = 2166136261
+  for (let i = 0; i < source.length; i++) {
+    hash ^= source.charCodeAt(i)
+    hash = Math.imul(hash, 16777619)
+  }
+  return `legacy-${(hash >>> 0).toString(36)}`
+}
+
+
+export function questionDraftKey(chatId, questionId, questions) {
+  if (chatId == null || chatId === '') return null
+  const identity = questionId || questionFingerprint(questions)
+  return `${QUESTION_DRAFT_PREFIX}${encodeURIComponent(String(chatId))}:${encodeURIComponent(String(identity))}`
+}
+
+
+export function readQuestionDraft(key, storage) {
+  const target = storage ?? browserSessionStorage()
+  if (!key || !target) return { answers: {}, otherTexts: {} }
+  try {
+    const parsed = JSON.parse(target.getItem(key) || 'null')
+    return {
+      answers: parsed?.answers && typeof parsed.answers === 'object'
+        ? parsed.answers
+        : {},
+      otherTexts: parsed?.otherTexts && typeof parsed.otherTexts === 'object'
+        ? parsed.otherTexts
+        : {},
+    }
+  } catch {
+    return { answers: {}, otherTexts: {} }
+  }
+}
+
+
+export function writeQuestionDraft(
+  key,
+  answers,
+  otherTexts,
+  storage,
+) {
+  const target = storage ?? browserSessionStorage()
+  if (!key || !target) return
+  try {
+    const hasAnswers = Object.keys(answers || {}).length > 0
+    const hasText = Object.values(otherTexts || {}).some(value => String(value || '').length > 0)
+    if (!hasAnswers && !hasText) {
+      target.removeItem(key)
+      return
+    }
+    target.setItem(key, JSON.stringify({ answers, otherTexts }))
+  } catch { /* private browsing, disabled storage, or quota exceeded */ }
+}
+
+
+export function clearQuestionDraft(key, storage) {
+  const target = storage ?? browserSessionStorage()
+  if (!key || !target) return
+  try { target.removeItem(key) } catch { /* private browsing */ }
+}
+
+
+export function clearChatQuestionDrafts(chatId, storage) {
+  const target = storage ?? browserSessionStorage()
+  if (chatId == null || chatId === '' || !target) return
+  const prefix = `${QUESTION_DRAFT_PREFIX}${encodeURIComponent(String(chatId))}:`
+  try {
+    const matches = []
+    for (let i = 0; i < target.length; i++) {
+      const key = target.key(i)
+      if (key?.startsWith(prefix)) matches.push(key)
+    }
+    for (const key of matches) target.removeItem(key)
+  } catch { /* private browsing */ }
+}

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -1883,6 +1883,7 @@ export default function Shell() {
               // round-trip wait for the first SSE event).
               markStreamingStart(activeChatId)
             }}
+            onQuestionAnswered={refreshChats}
             onVoiceListeningChange={markVoiceListening}
             composerFocusRequest={composerFocusRequest}
             onComposerFocusHandled={handleComposerFocusHandled}

--- a/tests/chat-redesign.spec.mjs
+++ b/tests/chat-redesign.spec.mjs
@@ -45,7 +45,7 @@ async function setupWithStreamMock(page, streamBody) {
           'Content-Type': 'text/event-stream',
           'Cache-Control': 'no-cache',
         },
-        body: streamBody,
+        body: typeof streamBody === 'function' ? streamBody() : streamBody,
       })
     )
   } else {
@@ -137,6 +137,88 @@ test.describe('Bug 1: AskUserQuestion', () => {
     // disabled={isStreaming} stayed grayed out).
     const optionButtons = page.locator('.qcard__opt')
     await expect(optionButtons.first()).toBeEnabled({ timeout: 5000 })
+  })
+
+
+  test('submitting a choice keeps every question-card row in place', async ({ page }) => {
+    const streamBody = [
+      `data: ${JSON.stringify({
+        type: 'question',
+        question_id: 'q-stable-card',
+        questions: [{
+          question: 'Which route?',
+          header: 'Route',
+          multiSelect: false,
+          options: [
+            { label: 'Direct', description: 'Use the shortest path' },
+            { label: 'Scenic', description: 'Keep more context visible' },
+          ],
+        }],
+      })}\n\n`,
+      'data: {"type":"done"}\n\n',
+    ].join('')
+    let streamCount = 0
+    await setupWithStreamMock(page, () => (
+      streamCount++ === 0 ? streamBody : 'data: {"type":"done"}\n\n'
+    ))
+    await newChat(page)
+    await sendMessage(page, 'Ask me which route')
+
+    const card = page.locator('.qcard')
+    await expect(card).toBeVisible({ timeout: 5000 })
+    await page.getByRole('radio', { name: 'Other' }).click()
+    const customAnswer = card.getByRole('textbox', { name: 'Other answer for: Which route?' })
+    await customAnswer.fill('Take the quiet streets')
+
+    const geometry = () => card.evaluate(el => ({
+      height: el.getBoundingClientRect().height,
+      hint: (() => {
+        const node = el.querySelector('.qcard__hint')
+        const rect = node?.getBoundingClientRect()
+        return node && rect
+          ? { text: node.textContent, top: rect.top, height: rect.height }
+          : null
+      })(),
+      options: [...el.querySelectorAll('.qcard__opt')].map(node => {
+        const rect = node.getBoundingClientRect()
+        return { text: node.textContent.trim(), top: rect.top, height: rect.height }
+      }),
+      input: (() => {
+        const node = el.querySelector('.qcard__input')
+        const rect = node?.getBoundingClientRect()
+        return node && rect
+          ? {
+              value: node.value,
+              top: rect.top,
+              width: rect.width,
+              height: rect.height,
+              color: getComputedStyle(node).color,
+              textFillColor: getComputedStyle(node).webkitTextFillColor,
+            }
+          : null
+      })(),
+      submitTop: el.querySelector('.qcard__submit')?.getBoundingClientRect().top,
+    }))
+
+    const before = await geometry()
+    await page.getByRole('button', { name: 'Submit' }).click()
+    await expect(page.getByRole('button', { name: 'Submitted' })).toBeDisabled()
+    await expect(card.locator('.qcard__hint')).toHaveText('Choose one')
+    await expect(card.locator('.qcard__opt')).toHaveCount(3)
+    await expect(customAnswer).toBeDisabled()
+    await expect(customAnswer).toHaveValue('Take the quiet streets')
+
+    const after = await geometry()
+    expect(after.height).toBeCloseTo(before.height, 5)
+    expect(after.hint).toEqual(before.hint)
+    expect(after.options).toEqual(before.options)
+    expect(after.input.value).toBe(before.input.value)
+    expect(after.input.top).toBeCloseTo(before.input.top, 5)
+    expect(after.input.width).toBeCloseTo(before.input.width, 5)
+    expect(after.input.height).toBeCloseTo(before.input.height, 5)
+    expect(after.input.color).not.toBe(before.input.color)
+    expect(after.input.textFillColor).toBe(after.input.color)
+    expect(after.submitTop).toBeCloseTo(before.submitTop, 5)
   })
 
 

--- a/tests/frontend.spec.mjs
+++ b/tests/frontend.spec.mjs
@@ -330,8 +330,10 @@ test.describe('Message rendering', () => {
     // contract is that submitting an answer starts the hidden continuation.
     await expect.poll(() => followupStreamServed).toBe(true)
 
-    // Verify the question card is in answered state (no submit button).
-    await expect(page.locator('.qcard__submit')).toHaveCount(0)
+    // Verify the question card is in its stable answered state. The retained
+    // disabled button keeps the card geometry fixed while making settlement
+    // explicit instead of collapsing the final row.
+    await expect(page.getByRole('button', { name: 'Submitted' })).toBeDisabled()
   })
 
   test('6c. Question card answer sends hidden message', async ({ page }) => {


### PR DESCRIPTION
## Summary
- preserve question drafts and row geometry while a choice is being submitted
- mark a choice submitted only after the backend accepts it
- keep failed answers retryable without erasing the draft or painting a false final state
- resume safely after Stop, restart, replay, and concurrent answer races
- mute completed custom answers without hiding their content

## Testing
- focused backend answer/steer suites — 25 passed
- full frontend tests and production build — passed
- isolated Playwright question-layout regression — 2 passed