### PR TITLE
Keep New chat from borrowing a stale conversation

### DIFF
--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -41,6 +41,10 @@ import {
 } from './newAppAttention.js'
 import { shouldDeferShellReload } from './shellReloadPolicy.js'
 import {
+  currentReusableEmptyChat,
+  detailIsUntouchedEmptyChat,
+} from './newChatPolicy.js'
+import {
   reloadWhenWorkerTakesOver,
   shouldRearmShellApply,
 } from './swHandoff.js'
@@ -1365,14 +1369,10 @@ export default function Shell() {
   }, [apps, navTo, refreshApps, refreshChats])
 
   async function newChat({ draft, forceNew, exclude, autoSend, focusComposer } = {}) {
-    // Reuse the most-recently-updated empty chat if one exists; only
-    // POST a fresh row when no empty is available. Safe to reuse now
-    // that create_chat leaves agent_settings_json NULL — an untouched
-    // empty reads the live global default from agent-settings.json on
-    // render, so the user always sees their most recent model/effort
-    // pick. (Before, create_chat snapshotted defaults at creation time
-    // and reuse surfaced that stale snapshot, which is what made the
-    // empty-chat reuse path buggy in the first place.)
+    // Keep the active chat when it is still an untouched blank; only POST a
+    // fresh row when this explicit New-chat action needs one. Never borrow an
+    // off-screen blank: another browser may have started it while this tab's
+    // chat-list cache still says has_messages=false.
     //
     // `forceNew` bypasses reuse for callers that NEED a fresh row —
     // moebius:new-chat events (the ChatView wouldn't remount on the
@@ -1385,42 +1385,34 @@ export default function Shell() {
     // Resolve chatId BEFORE switching views — setting activeView='chat'
     // with the old chatId causes a visible flash of the previous chat.
     let chatId
-    // Reuse the most-recently-updated empty chat if one exists — INCLUDING
-    // the one we're already on. An earlier fix excluded the active chat (to
-    // avoid a no-op setActiveChatId), but that backfired: a tap on a blank
-    // chat then spawned a SECOND blank, or hopped to an identical-looking
-    // spare, and repeated taps ping-ponged between indistinguishable empties
-    // — which is the "+ New chat does nothing" report. Reusing
-    // deterministically (active included) means blanks never accumulate and a
-    // tap on a blank simply keeps you on it (the drawer closing is the
-    // acknowledgement). One exception: a `draft` must land on a chat that
-    // REMOUNTS ChatView to deliver the pending draft, and setActiveChatId to
-    // the current id won't remount — so draft calls still skip the active
-    // chat. forceNew bypasses reuse entirely.
-    //
-    // Also exclude any chat that's mid-stream: the cached `has_messages`
-    // flag lags the send, so for a beat after the user sends, the chat
-    // they just sent to still reads has_messages=false — reusing it would
-    // drop them onto a running turn instead of a blank chat (another flavor
-    // of "+ New chat did nothing"). streamingChatIds is marked synchronously
-    // on message start, so it closes that stale-cache window.
-    const empty = !forceNew && [...chats]
-      .filter(c => !c.has_messages
-        // `exclude` skips a chat the caller knows is invalid — e.g. the
-        // just-deleted active chat, still present in `chats` until the
-        // post-delete refreshChats lands (else reuse would re-open it).
-        && (exclude == null || String(c.id) !== String(exclude))
-        && !streamingChatIds.has(c.id)
-        && (!draft || String(c.id) !== String(activeChatIdRef.current))
-        // Exclude recently-recovered chats: an Undo may restore a chat
-        // whose has_messages=true hasn't propagated yet (optimistic delete
-        // left the cache with the tombstoned state). Reusing such a chat
-        // would silently navigate back into the just-recovered item instead
-        // of a genuine empty. The id is cleared once ChatView reports the
-        // first message (has_messages is then reliably true).
-        && !recoveredChatIdsRef.current.has(c.id))
-      .sort((a, b) => (b.updated_at || '').localeCompare(a.updated_at || ''))
-      [0]
+    let empty = currentReusableEmptyChat(chatsRef.current, {
+      activeChatId: activeChatIdRef.current,
+      draft: !!draft,
+      exclude,
+      forceNew: !!forceNew,
+      recoveredChatIds: recoveredChatIdsRef.current,
+      streamingChatIds: streamingChatIdsRef.current,
+    })
+
+    // The list is intentionally only a candidate source. Cross-client sends
+    // can make has_messages stale, so online reuse needs one fresh, bounded
+    // detail read. Any error or unfamiliar response fails closed to creating
+    // a new row rather than opening somebody else's newly-running chat.
+    if (empty && online) {
+      try {
+        const res = await apiFetch(
+          `/chats/${encodeURIComponent(empty.id)}?limit=1`,
+          { timeoutMs: 5000 },
+        )
+        const detail = res.ok ? await res.json() : null
+        if (!detailIsUntouchedEmptyChat(detail)) {
+          empty = null
+          void refreshChats()
+        }
+      } catch {
+        empty = null
+      }
+    }
     if (empty) {
       chatId = empty.id
     } else {

--- a/frontend/src/components/Shell/__tests__/newChatPolicy.test.js
+++ b/frontend/src/components/Shell/__tests__/newChatPolicy.test.js
@@ -1,0 +1,88 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  currentReusableEmptyChat,
+  detailIsUntouchedEmptyChat,
+} from '../newChatPolicy.js'
+
+const empty = (id, extra = {}) => ({
+  id,
+  has_messages: false,
+  running: false,
+  run_status: null,
+  ...extra,
+})
+
+test('only the active empty chat is eligible for client-side reuse', () => {
+  const offscreen = empty('offscreen')
+  const active = empty('active')
+
+  assert.equal(currentReusableEmptyChat([offscreen, active], {
+    activeChatId: 'active',
+  }), active)
+  assert.equal(currentReusableEmptyChat([offscreen], {
+    activeChatId: 'active',
+  }), null)
+})
+
+test('drafts and force-new callers always require a fresh chat', () => {
+  const active = empty('active')
+  assert.equal(currentReusableEmptyChat([active], {
+    activeChatId: 'active', draft: true,
+  }), null)
+  assert.equal(currentReusableEmptyChat([active], {
+    activeChatId: 'active', forceNew: true,
+  }), null)
+})
+
+test('running, excluded, recovered, and populated active chats are rejected', () => {
+  const options = { activeChatId: 'active' }
+  assert.equal(currentReusableEmptyChat([empty('active', { running: true })], options), null)
+  assert.equal(currentReusableEmptyChat([empty('active', { run_status: 'running' })], options), null)
+  assert.equal(currentReusableEmptyChat([empty('active', { has_messages: true })], options), null)
+  assert.equal(currentReusableEmptyChat([empty('active')], {
+    ...options, exclude: 'active',
+  }), null)
+  assert.equal(currentReusableEmptyChat([empty('active')], {
+    ...options, recoveredChatIds: new Set(['active']),
+  }), null)
+  assert.equal(currentReusableEmptyChat([empty('active')], {
+    ...options, streamingChatIds: new Set(['active']),
+  }), null)
+})
+
+test('id comparison is stable across numeric and string representations', () => {
+  const active = empty(7)
+  assert.equal(currentReusableEmptyChat([active], {
+    activeChatId: '7',
+  }), active)
+})
+
+function untouchedDetail(extra = {}) {
+  return {
+    total: 0,
+    messages: [],
+    pending_messages: [],
+    running: false,
+    pending_question_id: null,
+    session_id: null,
+    ...extra,
+  }
+}
+
+test('fresh detail accepts only a fully untouched empty chat', () => {
+  assert.equal(detailIsUntouchedEmptyChat(untouchedDetail()), true)
+  assert.equal(detailIsUntouchedEmptyChat(untouchedDetail({ total: 1 })), false)
+  assert.equal(detailIsUntouchedEmptyChat(untouchedDetail({ messages: [{}] })), false)
+  assert.equal(detailIsUntouchedEmptyChat(untouchedDetail({ pending_messages: [{}] })), false)
+  assert.equal(detailIsUntouchedEmptyChat(untouchedDetail({ running: true })), false)
+  assert.equal(detailIsUntouchedEmptyChat(untouchedDetail({ pending_question_id: 'q' })), false)
+  assert.equal(detailIsUntouchedEmptyChat(untouchedDetail({ session_id: 'session' })), false)
+})
+
+test('fresh detail fails closed on partial or malformed responses', () => {
+  assert.equal(detailIsUntouchedEmptyChat(null), false)
+  assert.equal(detailIsUntouchedEmptyChat({ messages: [], pending_messages: [] }), false)
+  assert.equal(detailIsUntouchedEmptyChat(untouchedDetail({ total: '0' })), false)
+})

--- a/frontend/src/components/Shell/newChatPolicy.js
+++ b/frontend/src/components/Shell/newChatPolicy.js
@@ -1,0 +1,53 @@
+function normalizedId(value) {
+  return value == null ? null : String(value)
+}
+
+/**
+ * Return the only client-side chat that is safe to consider for reuse.
+ *
+ * An off-screen empty row may belong to another browser that has just sent a
+ * message while this tab's list cache is stale. Reusing it makes an explicit
+ * "New chat" tap open that running conversation. The current chat is
+ * different: keeping an already-open blank open is the intended no-op that
+ * prevents repeated taps from manufacturing duplicate blanks. The caller
+ * still verifies this candidate against the detail endpoint while online.
+ */
+export function currentReusableEmptyChat(chats, {
+  activeChatId,
+  draft = false,
+  exclude = null,
+  forceNew = false,
+  recoveredChatIds = new Set(),
+  streamingChatIds = new Set(),
+} = {}) {
+  if (forceNew || draft || activeChatId == null) return null
+
+  const activeId = normalizedId(activeChatId)
+  const excludedId = normalizedId(exclude)
+  const recoveredIds = new Set([...recoveredChatIds].map(normalizedId))
+  const streamingIds = new Set([...streamingChatIds].map(normalizedId))
+
+  const chat = (chats || []).find(row => normalizedId(row?.id) === activeId)
+  if (!chat || chat.has_messages) return null
+  if (excludedId != null && activeId === excludedId) return null
+  if (recoveredIds.has(activeId) || streamingIds.has(activeId)) return null
+  if (chat.running || chat.run_status === 'running') return null
+  return chat
+}
+
+/**
+ * Validate the fresh detail response before keeping an active blank open.
+ * Fail closed when the response is partial or unfamiliar: creating a fresh
+ * row is preferable to navigating into a conversation that has started in
+ * another browser.
+ */
+export function detailIsUntouchedEmptyChat(detail) {
+  if (!detail || typeof detail !== 'object') return false
+  if (!Number.isInteger(detail.total) || detail.total !== 0) return false
+  if (!Array.isArray(detail.messages) || detail.messages.length !== 0) return false
+  if (!Array.isArray(detail.pending_messages) || detail.pending_messages.length !== 0) return false
+  if (detail.running) return false
+  if (detail.pending_question_id != null) return false
+  if (detail.session_id != null) return false
+  return true
+}


### PR DESCRIPTION
## Summary
- verify blank-chat ownership against fresh server detail before reuse
- fail closed when an off-screen blank may have been started elsewhere
- retain offline reuse only for the currently active blank conversation
- keep New chat responsive without silently opening stale work

## Testing
- full frontend tests and production build — passed