### PR TITLE
Guard frontend publishing against runtime globals

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,15 +51,24 @@ jobs:
           python-version: '3.12'
           cache: 'pip'
           cache-dependency-path: backend/requirements.txt
-      - uses: actions/setup-node@v5
+      - name: Set up Node with npm cache
+        uses: actions/setup-node@v5
         with:
           node-version: 20
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
       - name: Install esbuild
         # compile_jsx shells out to esbuild; /api/apps/ tests need it.
         # Keep aligned with the Dockerfile pin (the source of truth) — drift
         # here means a 0.25-only compile regression passes green CI but
         # breaks the prod image build.
         run: npm install -g esbuild@0.25.12
+      - name: Install frontend runtime deps
+        # frontend_watcher's publish validation executes the locked Acorn /
+        # eslint-scope checker. The production image installs this same
+        # lockfile, so backend integration tests need the matching runtime.
+        working-directory: frontend
+        run: npm ci --ignore-scripts
       - name: Install backend deps
         working-directory: backend
         run: pip install -r requirements.txt

--- a/backend/app/frontend_watcher.py
+++ b/backend/app/frontend_watcher.py
@@ -41,7 +41,8 @@ _REBUILD_DIST_DIR = _FRONTEND_DIR / ".dist-rebuild"
 _NEXT_DIST_DIR = _FRONTEND_DIR / ".dist-next"
 _OLD_DIST_DIR = _FRONTEND_DIR / ".dist-old"
 _ATTIC_DIR = _FRONTEND_DIR / ".assets-attic"
-_ATTIC_KEEP = 3
+_ATTIC_KEEP = 64
+_BUILT_GLOBAL_CHECK = _FRONTEND_DIR / "scripts" / "check-built-globals.mjs"
 _CACHE_DIR = _FRONTEND_DIR / ".vite-cache"
 _TMP_DIR = _FRONTEND_DIR / ".vite-tmp"
 # The explicit full-rebuild path gets its own cache/temp dirs: rebuild_shell.sh
@@ -65,6 +66,10 @@ class _StagingChangedDuringPublish(RuntimeError):
 
 class _IncompleteBuild(RuntimeError):
   """Raised when the watched staging tree is not a full Vite generation yet."""
+
+
+class _BuiltGlobalValidationError(RuntimeError):
+  """Raised when a built shell still references an undeclared identifier."""
 
 
 def _acquire_watch_lock():
@@ -117,6 +122,32 @@ def _complete_build(d: Path) -> bool:
     and (d / "sw.js").is_file()
     and (d / "manifest.webmanifest").is_file()
   )
+
+
+def _validate_built_globals(d: Path) -> None:
+  """Reject a complete-looking bundle with undeclared runtime identifiers."""
+  if not _BUILT_GLOBAL_CHECK.is_file():
+    raise _BuiltGlobalValidationError(
+      f"frontend global checker is missing: {_BUILT_GLOBAL_CHECK}"
+    )
+  try:
+    result = subprocess.run(
+      ["node", str(_BUILT_GLOBAL_CHECK), str(d)],
+      cwd=str(_FRONTEND_DIR),
+      stdout=subprocess.PIPE,
+      stderr=subprocess.STDOUT,
+      text=True,
+      timeout=45,
+    )
+  except (OSError, subprocess.TimeoutExpired) as exc:
+    raise _BuiltGlobalValidationError(
+      f"frontend global checker could not run: {exc}"
+    ) from exc
+  if result.returncode != 0:
+    detail = _tail(result.stdout) or (
+      f"frontend global checker exited {result.returncode}"
+    )
+    raise _BuiltGlobalValidationError(detail)
 
 
 def _tail(text: str, limit: int = 4000) -> str:
@@ -374,6 +405,13 @@ def _publish_built_dir(source_dir: Path, reason: str) -> bool:
             "served dist", reason,
           )
           return False
+        try:
+          _validate_built_globals(_NEXT_DIST_DIR)
+        except Exception:
+          # A rejected candidate must not linger as a complete-looking next
+          # generation that a later publisher could mistake for its output.
+          shutil.rmtree(_NEXT_DIST_DIR, ignore_errors=True)
+          raise
         _replace_dist()
         return True
       finally:

--- a/backend/tests/test_frontend_watcher_publish.py
+++ b/backend/tests/test_frontend_watcher_publish.py
@@ -3,6 +3,7 @@
 import asyncio
 import fcntl
 import shutil
+from pathlib import Path
 
 import pytest
 
@@ -43,6 +44,12 @@ def fw_dirs(tmp_path, monkeypatch):
   monkeypatch.setattr(fw, "_ATTIC_DIR", dirs["attic"])
   monkeypatch.setattr(fw, "_CACHE_DIR", dirs["cache"])
   monkeypatch.setattr(fw, "_TMP_DIR", dirs["tmp"])
+  monkeypatch.setattr(
+    fw,
+    "_BUILT_GLOBAL_CHECK",
+    Path(__file__).resolve().parents[2]
+    / "frontend" / "scripts" / "check-built-globals.mjs",
+  )
   # Keep build comparisons hermetic when the test happens to run in an image
   # that has the production vendor tree mounted at /app/static/vendor.
   monkeypatch.setattr(fw, "_copy_vendor", lambda _dest: None)
@@ -70,6 +77,62 @@ def test_publish_rejects_broken_staging_without_touching_dist(fw_dirs):
   assert not (dist / "assets" / "index-broken.js").exists()
   assert not nxt.exists()
   assert not old.exists()
+
+
+def test_publish_rejects_undeclared_built_identifier_without_touching_dist(
+  fw_dirs,
+):
+  dist, staging, nxt, old = (
+    fw_dirs["dist"], fw_dirs["staging"], fw_dirs["next"], fw_dirs["old"]
+  )
+  _write_build(dist, "old")
+  _write_build(staging, "broken-global")
+  (staging / "assets" / "index-broken-global.js").write_text(
+    "export function cleanup() { clearTimeout(ioBounceTimer) }",
+    encoding="utf-8",
+  )
+
+  with pytest.raises(
+    fw._BuiltGlobalValidationError,
+    match=r"ioBounceTimer.*index-broken-global\.js",
+  ):
+    fw._publish_built_dir(staging, "undeclared global")
+
+  assert (dist / "assets" / "index-old.js").is_file()
+  assert not (dist / "assets" / "index-broken-global.js").exists()
+  assert not nxt.exists()
+  assert not old.exists()
+
+
+def test_publish_rejects_undeclared_identifier_in_root_runtime(fw_dirs):
+  staging = fw_dirs["staging"]
+  _write_build(staging, "broken-root-global")
+  (staging / "mobius-runtime.js").write_text(
+    "export function cleanup() { clearTimeout(rootBounceTimer) }",
+    encoding="utf-8",
+  )
+
+  with pytest.raises(
+    fw._BuiltGlobalValidationError,
+    match=r"rootBounceTimer.*mobius-runtime\.js",
+  ):
+    fw._publish_built_dir(staging, "undeclared root global")
+
+  assert not fw_dirs["next"].exists()
+  assert not fw_dirs["dist"].exists()
+
+
+def test_publish_accepts_declared_and_browser_globals(fw_dirs):
+  staging = fw_dirs["staging"]
+  _write_build(staging, "valid-globals")
+  (staging / "assets" / "index-valid-globals.js").write_text(
+    "const timer = setTimeout(() => window.fetch(new URL('/ok', location)), 1);"
+    " export function cleanup() { clearTimeout(timer) }",
+    encoding="utf-8",
+  )
+
+  assert fw._publish_built_dir(staging, "valid globals") is True
+  assert (fw_dirs["dist"] / "assets" / "index-valid-globals.js").is_file()
 
 
 @pytest.mark.asyncio
@@ -170,6 +233,18 @@ def test_identical_publish_is_skipped_without_event_or_attic(
   assert not fw_dirs["next"].exists()
   assert not (attic.exists() and list(attic.glob("gen-*")))
   assert events == []
+
+
+def test_identical_publish_skips_the_expensive_global_scan(fw_dirs, monkeypatch):
+  _write_build(fw_dirs["dist"], "same")
+  _write_build(fw_dirs["staging"], "same")
+  monkeypatch.setattr(
+    fw,
+    "_validate_built_globals",
+    lambda _built: pytest.fail("identical output should not be reparsed"),
+  )
+
+  assert fw._publish_built_dir(fw_dirs["staging"], "no-op rebuild") is False
 
 
 def test_publish_failure_restores_dirty_flag(monkeypatch):

--- a/backend/tests/test_generation_serving.py
+++ b/backend/tests/test_generation_serving.py
@@ -218,6 +218,9 @@ def fw_dirs(tmp_path, monkeypatch):
   monkeypatch.setattr(fw, "_NEXT_DIST_DIR", dirs["next"])
   monkeypatch.setattr(fw, "_OLD_DIST_DIR", dirs["old"])
   monkeypatch.setattr(fw, "_ATTIC_DIR", dirs["attic"])
+  # Global validation has focused publisher coverage; these fixtures exercise
+  # only generation rotation and contain deliberately tiny placeholder JS.
+  monkeypatch.setattr(fw, "_validate_built_globals", lambda _built: None)
   return dirs
 
 
@@ -250,18 +253,22 @@ def test_first_build_has_no_outgoing_generation(fw_dirs):
   assert not attic.exists() or list(attic.glob("gen-*")) == []
 
 
-def test_attic_prunes_to_keep_three_generations(fw_dirs):
+def test_attic_prunes_to_bounded_rapid_edit_window(fw_dirs):
   dist, nxt, attic = fw_dirs["dist"], fw_dirs["next"], fw_dirs["attic"]
   _fw_build(dist, "g1")
-  for i in range(2, 7):  # publish g2..g6 -> 5 swaps -> 5 outgoing generations
+  for i in range(2, fw._ATTIC_KEEP + 4):
     _fw_build(nxt, f"g{i}")
     fw._replace_dist()
 
   gens = sorted(attic.glob("gen-*"), key=fw._attic_gen_num)
-  # only the three newest outgoing generations survive (g3, g4, g5).
-  assert [p.name for p in gens] == ["gen-3", "gen-4", "gen-5"]
+  assert len(gens) == fw._ATTIC_KEEP
+  assert gens[0].name == "gen-3"
+  assert gens[-1].name == f"gen-{fw._ATTIC_KEEP + 2}"
   assert (attic / "gen-3" / "assets" / "index-g3.js").is_file()
-  assert (attic / "gen-5" / "assets" / "index-g5.js").is_file()
+  assert (
+    attic / f"gen-{fw._ATTIC_KEEP + 2}"
+    / "assets" / f"index-g{fw._ATTIC_KEEP + 2}.js"
+  ).is_file()
   assert not (attic / "gen-1").exists()
   assert not (attic / "gen-2").exists()
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,6 +24,8 @@
       "devDependencies": {
         "@tailwindcss/vite": "^4.3.2",
         "@vitejs/plugin-react": "^4.7.0",
+        "acorn": "^8.17.0",
+        "eslint-scope": "^9.1.2",
         "fake-indexeddb": "^6.2.5",
         "tailwindcss": "^4.3.2",
         "vite": "^7.3.6",
@@ -4365,6 +4367,13 @@
         "@types/ms": "*"
       }
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -4461,10 +4470,11 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5302,6 +5312,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/estree-util-is-identifier-name": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,8 @@
   "devDependencies": {
     "@tailwindcss/vite": "^4.3.2",
     "@vitejs/plugin-react": "^4.7.0",
+    "acorn": "^8.17.0",
+    "eslint-scope": "^9.1.2",
     "fake-indexeddb": "^6.2.5",
     "tailwindcss": "^4.3.2",
     "vite": "^7.3.6",

--- a/frontend/scripts/check-built-globals.mjs
+++ b/frontend/scripts/check-built-globals.mjs
@@ -1,0 +1,128 @@
+// Reject built shell modules that reference undeclared runtime identifiers.
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { parse } from 'acorn'
+import { analyze } from 'eslint-scope'
+
+const ALLOWED_GLOBALS = new Set([
+  // ECMAScript globals.
+  'AggregateError', 'Array', 'ArrayBuffer', 'Atomics', 'BigInt',
+  'BigInt64Array', 'BigUint64Array', 'Boolean', 'DataView', 'Date',
+  'decodeURI', 'decodeURIComponent', 'encodeURI', 'encodeURIComponent',
+  'Error', 'escape', 'eval', 'EvalError', 'FinalizationRegistry', 'Float32Array',
+  'Float64Array', 'Function', 'globalThis', 'Infinity', 'Int8Array',
+  'Int16Array', 'Int32Array', 'Intl', 'isFinite', 'isNaN', 'JSON', 'Map',
+  'Math', 'NaN', 'Number', 'Object', 'parseFloat', 'parseInt', 'Promise',
+  'Proxy', 'RangeError', 'ReferenceError', 'Reflect', 'RegExp', 'Set',
+  'SharedArrayBuffer', 'String', 'Symbol', 'SyntaxError', 'TypeError',
+  'Uint8Array', 'Uint8ClampedArray', 'Uint16Array', 'Uint32Array',
+  'undefined', 'unescape', 'URIError', 'WeakMap', 'WeakRef', 'WeakSet',
+  'WebAssembly',
+
+  // Window, DOM, and worker globals used by the shell and its dependencies.
+  'AbortController', 'AbortSignal', 'atob', 'Blob', 'BroadcastChannel', 'btoa',
+  'caches', 'cancelAnimationFrame', 'clearInterval', 'clearTimeout', 'console',
+  'createImageBitmap', 'crypto', 'CSS', 'CustomEvent', 'document', 'DOMParser',
+  'Element', 'Event', 'EventSource', 'fetch', 'File', 'FileReader', 'FormData',
+  'getComputedStyle', 'Headers', 'history', 'HTMLElement', 'HTMLInputElement',
+  'indexedDB', 'IntersectionObserver', 'localStorage', 'location', 'matchMedia',
+  'MessageChannel', 'MessageEvent', 'MutationObserver', 'navigation',
+  'navigator', 'Node', 'NodeFilter', 'Notification', 'performance',
+  'queueMicrotask', 'ReadableStream', 'reportError', 'Request',
+  'requestAnimationFrame', 'requestIdleCallback', 'ResizeObserver', 'Response',
+  'screen', 'sessionStorage', 'setImmediate', 'setInterval', 'setTimeout',
+  'ShadowRoot', 'TextDecoder', 'TextEncoder', 'URL', 'URLSearchParams',
+  'WebSocket', 'window', 'Worker', 'XMLHttpRequest',
+
+  // Service-worker globals and names emitted by Workbox's generated wrapper.
+  'clients', 'ExtendableEvent', 'FetchEvent', 'registration', 'self', '_',
+
+  // Optional globals probed defensively by bundled dependencies.
+  '__REACT_DEVTOOLS_GLOBAL_HOOK__', '__webpack_nonce__', 'arguments', 'Buffer',
+  'global', 'process',
+])
+
+function jsFiles(buildDir) {
+  const files = []
+  const assetsDir = path.join(buildDir, 'assets')
+  const isJavaScript = name => name.endsWith('.js') || name.endsWith('.mjs')
+
+  function walk(dir) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const file = path.join(dir, entry.name)
+      if (entry.isDirectory()) walk(file)
+      else if (entry.isFile() && isJavaScript(entry.name)) files.push(file)
+    }
+  }
+
+  if (fs.existsSync(assetsDir)) walk(assetsDir)
+  // Vendor assets are managed separately. Inspect Vite assets and root
+  // modules such as sw.js and mobius-runtime.js.
+  for (const entry of fs.readdirSync(buildDir, { withFileTypes: true })) {
+    if (entry.isFile() && isJavaScript(entry.name)) {
+      files.push(path.join(buildDir, entry.name))
+    }
+  }
+  return files.sort()
+}
+
+function findUnbound(buildDir) {
+  const failures = new Map()
+  for (const file of jsFiles(buildDir)) {
+    let ast
+    try {
+      ast = parse(fs.readFileSync(file, 'utf8'), {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+        locations: true,
+        ranges: true,
+      })
+    } catch (error) {
+      throw new Error(`could not parse ${path.relative(buildDir, file)}: ${error.message}`)
+    }
+
+    const scopeManager = analyze(ast, {
+      ecmaVersion: 2024,
+      sourceType: 'module',
+      optimistic: true,
+      ignoreEval: true,
+    })
+    for (const reference of scopeManager.globalScope.through) {
+      const { name, loc } = reference.identifier
+      if (ALLOWED_GLOBALS.has(name)) continue
+      const spots = failures.get(name) || []
+      if (spots.length < 6) {
+        spots.push(
+          `${path.relative(buildDir, file)}:${loc?.start.line ?? '?'}:${loc?.start.column ?? '?'}`,
+        )
+      }
+      failures.set(name, spots)
+    }
+  }
+  return failures
+}
+
+const buildDir = path.resolve(process.argv[2] || '')
+if (!process.argv[2] || !fs.existsSync(buildDir)) {
+  console.error('Usage: node check-built-globals.mjs <built-frontend-dir>')
+  process.exit(2)
+}
+
+try {
+  const failures = findUnbound(buildDir)
+  if (failures.size) {
+    console.error('Built shell contains undeclared runtime identifiers:')
+    for (const [name, spots] of [...failures].sort(([a], [b]) => a.localeCompare(b))) {
+      console.error(`  ${name}: ${spots.join(', ')}`)
+    }
+    console.error(
+      'Declare/import each application identifier, or add an intentional '
+      + 'browser/worker global to ALLOWED_GLOBALS.',
+    )
+    process.exit(1)
+  }
+} catch (error) {
+  console.error(`Built-global validation failed: ${error.message}`)
+  process.exit(2)
+}

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -50,7 +50,7 @@ import { focusComposerElement, shouldApplyComposerFocusRequest } from './compose
 import { sameMessageList } from './chatMessageList.js'
 import { copyableMessageText, copyPlainText } from './messageCopy.js'
 import { sendFailureMessage } from './sendFailure.js'
-import { chooseActiveAssistantDataKey, chooseActiveAssistantMirrorIndex, chooseActiveAssistantSurface, findTrailingAssistantPartialIndex, promoteAssistantStream, streamItemsHaveRenderableContent, streamItemsToAssistantPayload } from './streamPromotion.js'
+import { assistantStreamCoversMessage, chooseActiveAssistantDataKey, chooseActiveAssistantMirrorIndex, chooseActiveAssistantSurface, findTrailingAssistantPartialIndex, promoteAssistantStream, streamItemsHaveRenderableContent, streamItemsToAssistantPayload } from './streamPromotion.js'
 import {
   answerKeepsCurrentTurn,
   builtAppPulseDecision,
@@ -64,6 +64,7 @@ import {
   stopRequestSucceeded,
   serverSnapshotBehindLocal,
   startedMessagesFromResponse,
+  stripInternalUserMessageFields,
   systemEventForChat,
 } from './chatRuntimeState.js'
 import {
@@ -2800,6 +2801,18 @@ export default function ChatView({
       }
       if (!content) return
 
+      let queueAfterOptimisticPromote = null
+      function restoreOptimisticSteerQueue() {
+        // Every pendingQueue mutation assigns a fresh array. Restore only if
+        // no other path won the race while the steer request was in flight.
+        if (
+          queueAfterOptimisticPromote !== null
+          && pendingQueue.pendingMessagesRef.current === queueAfterOptimisticPromote
+        ) {
+          pendingQueue.hydrate(confirmedSnapshot, { preserveMissing: true })
+        }
+      }
+
       try {
         const steerIsFirstUser = isFirstVisibleUserMessage()
         // Fast-forward is a deliberate visibility action, unlike automatic
@@ -2819,16 +2832,7 @@ export default function ChatView({
         // rows this request is steering; restore the snapshot below if the
         // backend says the turn was not steered.
         pendingQueue.promoteManyByCid(consumePendingCids)
-        const queueAfterOptimisticPromote = pendingQueue.pendingMessagesRef.current
-        const restoreOptimisticSteerQueue = () => {
-          // If another path touched the queue while the POST was in flight
-          // (notably the natural turn-end drain), every pendingQueue mutation
-          // assigns a fresh array. In that case the other path won the race,
-          // so restoring our stale snapshot would resurrect duplicate chips.
-          if (pendingQueue.pendingMessagesRef.current === queueAfterOptimisticPromote) {
-            pendingQueue.hydrate(confirmedSnapshot, { preserveMissing: true })
-          }
-        }
+        queueAfterOptimisticPromote = pendingQueue.pendingMessagesRef.current
         const result = await streamSend(content, attachments, {
           forceSteer: true,
           consumePendingCids,

--- a/frontend/src/components/ChatView/__tests__/optimisticSteerQueue.test.js
+++ b/frontend/src/components/ChatView/__tests__/optimisticSteerQueue.test.js
@@ -7,13 +7,19 @@ const source = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8')
 test('optimistic steer restore only hydrates when no queue mutation won the race', () => {
   assert.match(
     source,
-    /const queueAfterOptimisticPromote = pendingQueue\.pendingMessagesRef\.current/,
+    /queueAfterOptimisticPromote = pendingQueue\.pendingMessagesRef\.current/,
     'handleSteer should snapshot the queue array immediately after optimistic promote',
   )
   assert.match(
     source,
     /function restoreOptimisticSteerQueue|const restoreOptimisticSteerQueue = \(\) =>/,
     'handleSteer should route failed optimistic restores through a helper',
+  )
+  const restoreHelper = source.indexOf('function restoreOptimisticSteerQueue')
+  const guardedRequest = source.indexOf('\n      try {', restoreHelper)
+  assert.ok(
+    restoreHelper >= 0 && guardedRequest > restoreHelper,
+    'the restore helper must be declared outside the request try block so catch can call it',
   )
   assert.match(
     source,


### PR DESCRIPTION
## Summary
- parse generated JavaScript with Acorn before publishing a new frontend generation
- reject undeclared runtime globals while avoiding lint-only false positives
- skip identical builds and retain prior lazy chunks during edit-heavy rebuilds
- keep the guard fast enough for the live watcher path

## Testing
- focused backend publish/serving suites — 24 passed
- full frontend tests and production build — passed