### PR TITLE
Bootstrap Memory and Reflection on fresh installs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -169,7 +169,7 @@ Agent-editable general-purpose modules — several sit on live chat paths, so de
 
 | File | Role |
 |------|------|
-| `bootstrap.py` | First-boot bootstrap (`ensure_store_installed`) that auto-installs the curated app-store mini-app; called idempotently from the FastAPI lifespan |
+| `bootstrap.py` | First-boot bootstrap (`ensure_bootstrap_apps_installed`) that auto-installs the App Store, Memory, and Reflection; called idempotently from the FastAPI lifespan |
 | `chat_log_redaction.py` | Server-side structural redaction for the gated chat-log read API |
 | `chat_media.py` | One-way startup migration that moves old chat images and stored URLs onto the canonical `/media/` path |
 | `http_caching.py` | Range/206 hardening for revalidating `FileResponse`s |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ guide gets a fresh clone to a running dev/test loop.
 | `frontend/src/` | React 19 + Vite shell (chat UI, drawer, mini-app iframe canvas). |
 | `skill/core.md` | The agent's system prompt (the "constitution"); read from the live checkout after restart, with an image-baked degraded-boot fallback. |
 | `backend/scripts/seed-skills/` | Per-topic agent skills (building-apps, theming, cron, …), seeded into `/data/shared/skills/` create-if-absent on first boot. |
-| `core-apps/` | Built-in mini-apps (`memory`, `reflection`) shipped with the platform. |
+| `core-apps/` | Legacy snapshots only. Memory and Reflection ship from `mobius-os/app-memory` and `mobius-os/app-reflection`: they are auto-installed on first boot, then remain editable and updatable like any catalog app. |
 | `tests/` | Playwright end-to-end suite (repo root). |
 | `backend/tests/` | pytest backend suite. |
 

--- a/backend/app/bootstrap.py
+++ b/backend/app/bootstrap.py
@@ -1,4 +1,4 @@
-"""First-boot bootstrap that auto-installs the curated app-store mini-app.
+"""First-boot bootstrap for the App Store, Memory, and Reflection apps.
 
 Called from the FastAPI lifespan handler once the server is up and the
 DB is migrated. Calls `install_from_manifest()` directly (in-process)
@@ -7,16 +7,16 @@ ready to accept connections from itself at lifespan-startup time, and
 an in-process call skips the auth + rate-limit layers that exist for
 external callers we don't need to traverse here.
 
-Failure is non-fatal: a network blip fetching the store manifest must
-not crash uvicorn (otherwise the whole platform is unreachable on the
-first boot after a deploy that lands during a GitHub outage). We log
-the failure and return; the owner can install the store manually.
+Failure is non-fatal and isolated per app: a network blip fetching one
+manifest must not crash uvicorn or prevent the remaining bootstrap apps
+from installing. We log each failure and continue.
 """
 
 from __future__ import annotations
 
 import logging
 import os
+from dataclasses import dataclass
 
 from sqlalchemy.orm import Session
 
@@ -34,6 +34,22 @@ BOOTSTRAP_STORE_MANIFEST_URL = (
 )
 
 LEGACY_PLATFORM_APP_MANIFEST_URLS = legacy_platform_apps.MANIFEST_URLS
+
+
+@dataclass(frozen=True)
+class _BootstrapApp:
+  name: str
+  manifest_url: str
+  reinstall_after_uninstall: bool
+
+
+_BOOTSTRAP_APPS = (
+  _BootstrapApp("store", BOOTSTRAP_STORE_MANIFEST_URL, True),
+  _BootstrapApp("memory", LEGACY_PLATFORM_APP_MANIFEST_URLS["memory"], False),
+  _BootstrapApp(
+    "reflection", LEGACY_PLATFORM_APP_MANIFEST_URLS["reflection"], False,
+  ),
+)
 
 # Tests set MOEBIUS_SKIP_BOOTSTRAP=1 so the pytest suite doesn't hit
 # the live GitHub URL. Set in docker-compose.test.yml's `pytest`
@@ -64,9 +80,8 @@ def _is_legacy_platform_row(app: models.App) -> bool:
 async def _migrate_legacy_platform_apps(db: Session) -> None:
   """Move old built-in rows forward by installing their trusted catalog entry.
 
-  New instances do not auto-install these apps. This only runs when an active
-  row from an older image is already present and still points at the retired
-  platform-core source tree.
+  This only runs when an active row from an older image is already present and
+  still points at the retired platform-core source tree.
   """
   rows = (
     db.query(models.App)
@@ -99,72 +114,70 @@ async def _migrate_legacy_platform_apps(db: Session) -> None:
       )
 
 
-async def ensure_store_installed(db: Session) -> None:
-  """Idempotent: if no App installed from BOOTSTRAP_STORE_MANIFEST_URL
-  exists, install it.
+async def ensure_bootstrap_apps_installed(db: Session) -> None:
+  """Idempotently install the configured bootstrap apps when absent.
 
-  Identity is keyed on `manifest_url`, not slug. Two reasons:
+  Identity is keyed on `manifest_url`, not slug. This means:
     1. The bootstrapped store doesn't always end up with slug='store'
        — if the user already built an app called "store", first-boot
        slug-assignment hands it a fallback like 'app-store'. A slug
        check would then mis-treat the bootstrapped store as absent
        and try to install it again every boot.
-    2. If the user uninstalls the bootstrapped store (DELETE
-       /api/apps/<id>), the next container restart should reinstall
-       it. Keying on manifest_url makes the re-install fire correctly
-       regardless of what slug the deleted row had.
+    2. Every bootstrap app retains its canonical identity even if its
+       assigned slug differs from the catalog slug.
 
   Caller is the FastAPI lifespan/startup handler. Owns no transaction
   state — `install_from_manifest` commits its own work on success and
   rolls back on failure. We just decide whether to call it.
   """
   if os.environ.get(_SKIP_ENV) == "1":
-    log.info("bootstrap: %s=1, skipping store install", _SKIP_ENV)
+    log.info("bootstrap: %s=1, skipping bootstrap app installs", _SKIP_ENV)
     return
 
   await _migrate_legacy_platform_apps(db)
 
-  # Installs store the CANONICAL identity key (`<base>#manifest-id=<id>`, with a
-  # trailing `/mobius.json` stripped from the base), NOT the bare URL — so match
-  # on that canonical prefix, else this lookup misses every restart and
-  # needlessly re-fetches + updates the store (Codex review round-10 #8,
-  # round-11 #1).
+  # Manifest installs store the canonical identity key
+  # (`<base>#manifest-id=<id>`, with a trailing `/mobius.json` stripped from the
+  # base), not the bare URL.
   from app.install import _canonical_base
-  existing = (
-    db.query(models.App)
-    .filter(models.App.manifest_url.like(
-      _canonical_base(BOOTSTRAP_STORE_MANIFEST_URL) + "#manifest-id=%"
+
+  for bootstrap_app in _BOOTSTRAP_APPS:
+    query = db.query(models.App).filter(models.App.manifest_url.like(
+      _canonical_base(bootstrap_app.manifest_url) + "#manifest-id=%"
     ))
-    # A tombstoned (soft-deleted) store reads as ABSENT here so this boot
-    # reinstalls it — install_from_manifest reattaches the same row and clears
-    # deleted_at, reviving it with its data. Without this filter an uninstalled
-    # store would never return on restart, contradicting reason (2) above and
-    # leaving the owner with no UI surface to get it back (feature 110).
-    .filter(models.App.deleted_at.is_(None))
-    .first()
-  )
-  if existing is not None:
-    log.info("bootstrap: store already installed (app id=%s)", existing.id)
-    return
-  log.info("bootstrap: installing store from %s", BOOTSTRAP_STORE_MANIFEST_URL)
-  try:
-    app, mode, warnings, _manifest, _conflicts, _divergence = (
-      await install_from_manifest(
-        db,
-        manifest_url=BOOTSTRAP_STORE_MANIFEST_URL,
-        manifest=None,
-        raw_base=None,
-        source="bootstrap",
+    if bootstrap_app.reinstall_after_uninstall:
+      # The store is the recovery surface, so it must return after uninstall;
+      # owner uninstalls of the other bootstrap apps are respected.
+      query = query.filter(models.App.deleted_at.is_(None))
+    existing = query.first()
+    if existing is not None:
+      log.info(
+        "bootstrap: %s already installed (app id=%s)",
+        bootstrap_app.name, existing.id,
       )
+      continue
+    log.info(
+      "bootstrap: installing %s from %s",
+      bootstrap_app.name, bootstrap_app.manifest_url,
     )
-  except Exception as exc:
-    # Catch-all on purpose: HTTPException, network errors, JSON parse
-    # errors, anything else. The cost of letting the bootstrap crash
-    # lifespan is higher than the cost of an uninstalled store —
-    # without uvicorn there's no recovery surface to install it from.
-    log.exception("bootstrap: store install failed — %s", exc)
-    return
-  log.info(
-    "bootstrap: store install %s (app id=%s, warnings=%s)",
-    mode, app.id, warnings,
-  )
+    try:
+      app, mode, warnings, _manifest, _conflicts, _divergence = (
+        await install_from_manifest(
+          db,
+          manifest_url=bootstrap_app.manifest_url,
+          manifest=None,
+          raw_base=None,
+          source="bootstrap",
+        )
+      )
+    except Exception as exc:
+      # Catch-all on purpose: no manifest failure should crash lifespan or
+      # prevent the remaining bootstrap apps from installing.
+      log.exception(
+        "bootstrap: %s install failed — %s", bootstrap_app.name, exc,
+      )
+      continue
+    log.info(
+      "bootstrap: %s install %s (app id=%s, warnings=%s)",
+      bootstrap_app.name, mode, app.id, warnings,
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -248,21 +248,19 @@ async def lifespan(app):
         _nt_db.close()
   except Exception as exc:
     _log.error("paused-turn resume notify failed: %s", exc, exc_info=True)
-  # First-boot auto-install of the curated app-store mini-app so a
-  # fresh container shows the store in the drawer immediately. The
-  # bootstrap module is idempotent (no-op if slug='store' already
-  # exists) and swallows its own failures — a GitHub blip must not
-  # crash lifespan and brick the recovery surface.
+  # First-boot auto-install of the App Store, Memory, and Reflection. The
+  # bootstrap module is idempotent and isolates failures so a GitHub blip must
+  # not crash lifespan or prevent another bootstrap app from installing.
   try:
-    from app.bootstrap import ensure_store_installed
+    from app.bootstrap import ensure_bootstrap_apps_installed
     from app.database import SessionLocal as _BootstrapSession
     _bs_db = _BootstrapSession()
     try:
-      await ensure_store_installed(_bs_db)
+      await ensure_bootstrap_apps_installed(_bs_db)
     finally:
       _bs_db.close()
   except Exception as exc:
-    _log.error("bootstrap store install wiring failed: %s", exc, exc_info=True)
+    _log.error("bootstrap app install wiring failed: %s", exc, exc_info=True)
   # Reconcile the DB-independent recovery credential seed with the current
   # owner. Backfills instances that completed setup before the seed
   # existed and keeps it current; idempotent (no write when unchanged) and

--- a/backend/tests/test_activity.py
+++ b/backend/tests/test_activity.py
@@ -706,24 +706,24 @@ def test_install_endpoint_emits_app_install(client, auth, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_bootstrap_install_emits_with_source_bootstrap(db, monkeypatch):
-  """ensure_store_installed → install_from_manifest(source='bootstrap')
+  """ensure_bootstrap_apps_installed → install_from_manifest(source='bootstrap')
   → event records the right source."""
-  from unittest.mock import patch, AsyncMock
-  from app.bootstrap import BOOTSTRAP_STORE_MANIFEST_URL, ensure_store_installed
-  from app import models, install as install_mod
+  from unittest.mock import patch
+  from app.bootstrap import ensure_bootstrap_apps_installed
+  from app import models
 
   monkeypatch.delenv("MOEBIUS_SKIP_BOOTSTRAP", raising=False)
 
   # Have the bootstrap call into the REAL install code path but with
   # the network mocked. Simpler: capture the kwargs and emit the event
   # ourselves to mirror what install_from_manifest does.
-  captured = {}
+  captured = []
 
   async def _fake_install(db, manifest_url, manifest, raw_base, source="url"):
-    captured["source"] = source
+    captured.append(source)
     fake = models.App(
       id=42, name="Store", slug="store",
-      manifest_url=BOOTSTRAP_STORE_MANIFEST_URL,
+      manifest_url=manifest_url,
     )
     # Mimic install_from_manifest's log call so the assertion below
     # exercises the wiring contract (bootstrap → source='bootstrap').
@@ -733,12 +733,12 @@ async def test_bootstrap_install_emits_with_source_bootstrap(db, monkeypatch):
     return fake, "install", [], {}, [], "none"
 
   with patch("app.bootstrap.install_from_manifest", _fake_install):
-    await ensure_store_installed(db)
+    await ensure_bootstrap_apps_installed(db)
 
-  assert captured["source"] == "bootstrap"
+  assert captured == ["bootstrap", "bootstrap", "bootstrap"]
   installs = [l for l in _read_lines() if l["ev"] == "app_install"]
-  assert len(installs) == 1
-  assert installs[0]["source"] == "bootstrap"
+  assert len(installs) == 3
+  assert all(event["source"] == "bootstrap" for event in installs)
 
 
 # --- Wiring: storage_write via PUT + DELETE ----------------------------

--- a/backend/tests/test_bootstrap.py
+++ b/backend/tests/test_bootstrap.py
@@ -1,19 +1,12 @@
-"""First-boot bootstrap — ensure_store_installed contract.
+"""First-boot bootstrap — ensure_bootstrap_apps_installed contract.
 
-Validates the four behaviors that matter for boot-time correctness:
-  1. Calls install_from_manifest with the pinned store URL when no
-     App with slug='store' exists.
-  2. Skips the install call when one already does.
-  3. Swallows install failures so lifespan can't crash.
-  4. Respects MOEBIUS_SKIP_BOOTSTRAP=1 so tests + offline boots don't
-     hit GitHub.
-
-The FastAPI startup-hook wiring itself isn't exercised here — that's
-TestClient lifecycle territory and the in-process call is a one-liner
-that's easier to read than test.
+Validates the boot-time invariants: ordered installs, canonical manifest
+identity, per-app uninstall policy and failure isolation, legacy migration,
+and the offline-test escape hatch.
 """
 
-from unittest.mock import patch, AsyncMock
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi import HTTPException
@@ -22,65 +15,132 @@ from app import models
 from app.bootstrap import (
   BOOTSTRAP_STORE_MANIFEST_URL,
   LEGACY_PLATFORM_APP_MANIFEST_URLS,
-  ensure_store_installed,
+  _migrate_legacy_platform_apps,
+  ensure_bootstrap_apps_installed,
 )
 
 
-@pytest.mark.asyncio
-async def test_bootstrap_installs_store_when_absent(db, monkeypatch):
-  """No App with the bootstrap manifest_url → install_from_manifest
-  called with the pinned URL.
+def _install_result(name="App", slug="app", app_id=1, mode="install"):
+  app = models.App(id=app_id, name=name, slug=slug)
+  return app, mode, [], {}, [], "none"
 
-  Pre-assert that no row matches the manifest_url so the test's
-  starting state is unambiguous — a slug='store' row with a different
-  manifest_url would still satisfy "bootstrap absent" under the new
-  identity rule.
-  """
+
+def _bootstrap_urls():
+  return [
+    BOOTSTRAP_STORE_MANIFEST_URL,
+    LEGACY_PLATFORM_APP_MANIFEST_URLS["memory"],
+    LEGACY_PLATFORM_APP_MANIFEST_URLS["reflection"],
+  ]
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_installs_all_apps_in_order_when_absent(db, monkeypatch):
+  """A fresh database installs the store first, then Memory and Reflection."""
   monkeypatch.delenv("MOEBIUS_SKIP_BOOTSTRAP", raising=False)
-  assert (
-    db.query(models.App)
-    .filter(models.App.manifest_url == BOOTSTRAP_STORE_MANIFEST_URL)
-    .first()
-  ) is None
-  mock_app = models.App(id=1, name="Store", slug="store")
-  install_mock = AsyncMock(return_value=(mock_app, "install", [], {}, [], "none"))
+  install_mock = AsyncMock(return_value=_install_result())
+
   with patch("app.bootstrap.install_from_manifest", install_mock):
-    await ensure_store_installed(db)
-  assert install_mock.await_count == 1
-  call_kwargs = install_mock.await_args.kwargs
-  assert call_kwargs["manifest_url"] == BOOTSTRAP_STORE_MANIFEST_URL
-  assert call_kwargs["manifest"] is None
-  assert call_kwargs["raw_base"] is None
+    await ensure_bootstrap_apps_installed(db)
+
+  assert install_mock.await_count == 3
+  assert [
+    call.kwargs["manifest_url"] for call in install_mock.await_args_list
+  ] == _bootstrap_urls()
+  for call in install_mock.await_args_list:
+    assert call.kwargs["manifest"] is None
+    assert call.kwargs["raw_base"] is None
+    assert call.kwargs["source"] == "bootstrap"
 
 
 @pytest.mark.asyncio
-async def test_bootstrap_skips_when_store_already_installed(db, monkeypatch):
-  """Pre-existing row with the bootstrap manifest_url → install never
-  called.
-
-  Identity is keyed on manifest_url (not slug) so an app the user
-  built that happens to be called "store" doesn't accidentally
-  satisfy this check, and the bootstrapped store's actual slug
-  (which may be 'app-store' if 'store' was taken) doesn't have to
-  be guessed.
-  """
+async def test_bootstrap_applies_per_app_uninstall_policy(db, monkeypatch):
+  """Store returns after uninstall; Memory stays gone; live Reflection skips."""
   monkeypatch.delenv("MOEBIUS_SKIP_BOOTSTRAP", raising=False)
   from app.install import _canonical_identity_key
-  existing = models.App(
-    name="Store",
-    description="already here",
-    jsx_source="export default function App() {}",
-    slug="app-store",
-    # Install stores the CANONICAL key, not the bare URL — seed that so the
-    # bootstrap's canonical-prefix lookup matches (Codex review round-11 #1).
-    manifest_url=_canonical_identity_key(BOOTSTRAP_STORE_MANIFEST_URL, "store"),
+
+  deleted_at = datetime.now(timezone.utc)
+  db.add_all([
+    models.App(
+      name="Store",
+      description="owner uninstalled",
+      jsx_source="export default function App() {}",
+      slug="store",
+      manifest_url=_canonical_identity_key(
+        BOOTSTRAP_STORE_MANIFEST_URL, "store",
+      ),
+      deleted_at=deleted_at,
+    ),
+    models.App(
+      name="Memory",
+      description="owner uninstalled",
+      jsx_source="export default function App() {}",
+      slug="memory",
+      manifest_url=_canonical_identity_key(
+        LEGACY_PLATFORM_APP_MANIFEST_URLS["memory"], "memory",
+      ),
+      deleted_at=deleted_at,
+    ),
+    models.App(
+      name="Reflection",
+      description="already here",
+      jsx_source="export default function App() {}",
+      slug="reflection",
+      manifest_url=_canonical_identity_key(
+        LEGACY_PLATFORM_APP_MANIFEST_URLS["reflection"], "reflection",
+      ),
+    ),
+  ])
+  db.commit()
+
+  install_mock = AsyncMock(return_value=_install_result("Store", "store"))
+  with patch("app.bootstrap.install_from_manifest", install_mock):
+    await ensure_bootstrap_apps_installed(db)
+
+  install_mock.assert_awaited_once()
+  assert (
+    install_mock.await_args.kwargs["manifest_url"]
+    == BOOTSTRAP_STORE_MANIFEST_URL
   )
-  db.add(existing)
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_skips_live_apps_by_canonical_manifest(db, monkeypatch):
+  """Canonical manifest identity, rather than slug, makes installs idempotent."""
+  monkeypatch.delenv("MOEBIUS_SKIP_BOOTSTRAP", raising=False)
+  from app.install import _canonical_identity_key
+
+  db.add_all([
+    models.App(
+      name="Store",
+      description="already here",
+      jsx_source="export default function App() {}",
+      slug="app-store",
+      manifest_url=_canonical_identity_key(BOOTSTRAP_STORE_MANIFEST_URL, "store"),
+    ),
+    models.App(
+      name="Memory",
+      description="already here",
+      jsx_source="export default function App() {}",
+      slug="memory-custom",
+      manifest_url=_canonical_identity_key(
+        LEGACY_PLATFORM_APP_MANIFEST_URLS["memory"], "memory",
+      ),
+    ),
+    models.App(
+      name="Reflection",
+      description="already here",
+      jsx_source="export default function App() {}",
+      slug="reflection-custom",
+      manifest_url=_canonical_identity_key(
+        LEGACY_PLATFORM_APP_MANIFEST_URLS["reflection"], "reflection",
+      ),
+    ),
+  ])
   db.commit()
 
   install_mock = AsyncMock()
   with patch("app.bootstrap.install_from_manifest", install_mock):
-    await ensure_store_installed(db)
+    await ensure_bootstrap_apps_installed(db)
   install_mock.assert_not_awaited()
 
 
@@ -90,19 +150,7 @@ async def test_bootstrap_skips_when_store_already_installed(db, monkeypatch):
 async def test_bootstrap_migrates_active_legacy_platform_rows(
   source_shape, manifest_url_shape, db, monkeypatch,
 ):
-  """The migration is ONE-SHOT: it moves un-migrated baked rows forward through
-  the trusted catalog entry, but never re-fires on a row that already carries a
-  manifest_url.
-
-  Two un-migrated shapes exist. A `platform_core` row still points at
-  /data/platform/core-apps and is migrated regardless of its manifest_url (the
-  catalog install moves it out of that tree, so it stops matching next boot). A
-  `data_apps` row already sits at the steady-state /data/apps/<slug> path, so it
-  only counts as un-migrated while its manifest_url is empty — once the identity
-  is stamped (raw or canonical), re-migrating would re-fetch GitHub every restart
-  and could fast-forward the app past owner review. Matching data_apps + a set
-  manifest_url as legacy was the bug this pins closed.
-  """
+  """The legacy migration remains one-shot and limited to retired sources."""
   monkeypatch.delenv("MOEBIUS_SKIP_BOOTSTRAP", raising=False)
   from app.config import get_settings
   from app.install import _canonical_identity_key
@@ -118,106 +166,89 @@ async def test_bootstrap_migrates_active_legacy_platform_rows(
     "raw": raw_memory_manifest,
     "canonical": _canonical_identity_key(raw_memory_manifest, "memory"),
   }[manifest_url_shape]
-  db.add_all([
-    models.App(
-      name="Memory",
-      description="legacy platform app",
-      jsx_source="export default function App() {}",
-      slug="memory",
-      source_dir=legacy_source,
-      manifest_url=stored_manifest_url,
-    ),
-    models.App(
-      name="Store",
-      description="already here",
-      jsx_source="export default function App() {}",
-      slug="store",
-      manifest_url=_canonical_identity_key(BOOTSTRAP_STORE_MANIFEST_URL, "store"),
-    ),
-  ])
+  db.add(models.App(
+    name="Memory",
+    description="legacy platform app",
+    jsx_source="export default function App() {}",
+    slug="memory",
+    source_dir=legacy_source,
+    manifest_url=stored_manifest_url,
+  ))
   db.commit()
 
-  # A platform-core row is always un-migrated (source still in that tree); a
-  # data_apps row is un-migrated only while its manifest_url is empty.
   should_migrate = source_shape == "platform_core" or manifest_url_shape == "empty"
-
-  mock_app = models.App(id=3, name="Memory", slug="memory")
-  install_mock = AsyncMock(return_value=(mock_app, "update", [], {}, [], "none"))
+  install_mock = AsyncMock(
+    return_value=_install_result("Memory", "memory", app_id=3, mode="update"),
+  )
   with patch("app.bootstrap.install_from_manifest", install_mock):
-    await ensure_store_installed(db)
+    await _migrate_legacy_platform_apps(db)
 
   if should_migrate:
-    assert install_mock.await_count == 1
+    install_mock.assert_awaited_once()
     assert (
       install_mock.await_args.kwargs["manifest_url"]
       == LEGACY_PLATFORM_APP_MANIFEST_URLS["memory"]
     )
     assert install_mock.await_args.kwargs["source"] == "bootstrap"
   else:
-    assert install_mock.await_count == 0
+    install_mock.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_bootstrap_ignores_unrelated_store_slug(db, monkeypatch):
-  """A user-built app with slug='store' but no bootstrap manifest_url
-  does NOT prevent bootstrap. Under the prior slug-keyed check, this
-  case mis-treated the bootstrapped store as already-installed and
-  skipped the real install.
-  """
+  """A user-built app named store does not satisfy canonical app identity."""
   monkeypatch.delenv("MOEBIUS_SKIP_BOOTSTRAP", raising=False)
-  user_built = models.App(
+  db.add(models.App(
     name="Store",
     description="user's own app, unrelated to the bootstrap manifest",
     jsx_source="export default function App() {}",
     slug="store",
     manifest_url=None,
-  )
-  db.add(user_built)
+  ))
   db.commit()
 
-  mock_app = models.App(id=2, name="Store", slug="app-store")
-  install_mock = AsyncMock(return_value=(mock_app, "install", [], {}, [], "none"))
+  install_mock = AsyncMock(return_value=_install_result())
   with patch("app.bootstrap.install_from_manifest", install_mock):
-    await ensure_store_installed(db)
-  assert install_mock.await_count == 1
-  assert (
-    install_mock.await_args.kwargs["manifest_url"]
-    == BOOTSTRAP_STORE_MANIFEST_URL
-  )
+    await ensure_bootstrap_apps_installed(db)
+
+  assert [
+    call.kwargs["manifest_url"] for call in install_mock.await_args_list
+  ] == _bootstrap_urls()
 
 
 @pytest.mark.asyncio
-async def test_bootstrap_logs_but_doesnt_raise_on_network_failure(
+async def test_bootstrap_failure_doesnt_block_remaining_apps(
   db, monkeypatch, caplog,
 ):
-  """install_from_manifest raises HTTPException(502) → returns cleanly.
-
-  Bootstrap failure on first boot must not crash uvicorn — without
-  the server, there's no recovery surface to install the store from.
-  """
+  """A failed first install is logged and the remaining apps still install."""
   monkeypatch.delenv("MOEBIUS_SKIP_BOOTSTRAP", raising=False)
-  install_mock = AsyncMock(side_effect=HTTPException(502, "upstream down"))
+  install_mock = AsyncMock(side_effect=[
+    HTTPException(502, "upstream down"),
+    _install_result("Memory", "memory", app_id=2),
+    _install_result("Reflection", "reflection", app_id=3),
+  ])
   with patch("app.bootstrap.install_from_manifest", install_mock):
-    # Should NOT raise — explicit assert on no-exception behavior.
-    await ensure_store_installed(db)
-  assert install_mock.await_count == 1
-  # The failure is logged so an operator can find out why the store
-  # didn't auto-install. Don't pin the exact message — just that it
-  # surfaced as an exception-level record from the bootstrap logger.
+    await ensure_bootstrap_apps_installed(db)
+
+  assert install_mock.await_count == 3
+  assert [
+    call.kwargs["manifest_url"] for call in install_mock.await_args_list
+  ] == _bootstrap_urls()
   bootstrap_errors = [
-    r for r in caplog.records
-    if r.name == "mobius.bootstrap" and r.levelname == "ERROR"
+    record for record in caplog.records
+    if record.name == "mobius.bootstrap" and record.levelname == "ERROR"
   ]
   assert bootstrap_errors, "expected bootstrap failure to log at ERROR"
 
 
 @pytest.mark.asyncio
 async def test_bootstrap_respects_skip_env_var(db, monkeypatch):
-  """MOEBIUS_SKIP_BOOTSTRAP=1 → install_from_manifest never called even
-  when the DB is empty. This is the env var docker-compose.test.yml
-  sets so the test suite can't accidentally reach GitHub."""
+  """MOEBIUS_SKIP_BOOTSTRAP=1 skips migrations and every app install."""
   monkeypatch.setenv("MOEBIUS_SKIP_BOOTSTRAP", "1")
   install_mock = AsyncMock()
-  with patch("app.bootstrap.install_from_manifest", install_mock):
-    await ensure_store_installed(db)
+  migration_mock = AsyncMock()
+  with patch("app.bootstrap.install_from_manifest", install_mock), \
+       patch("app.bootstrap._migrate_legacy_platform_apps", migration_mock):
+    await ensure_bootstrap_apps_installed(db)
   install_mock.assert_not_awaited()
+  migration_mock.assert_not_awaited()

--- a/core-apps/SOURCES
+++ b/core-apps/SOURCES
@@ -1,8 +1,9 @@
 # No catalog app is pinned as a platform core app.
 #
-# The App Store is bootstrapped separately by backend/app/bootstrap.py. Memory,
-# Reflection, Beat Machine, and every other app install from their catalog repos
-# into /data/apps/<slug>, where users and agents can edit/update them normally.
+# The App Store, Memory, and Reflection are bootstrapped by
+# backend/app/bootstrap.py. Beat Machine and every other app install from their
+# catalog repos into /data/apps/<slug>, where users and agents can edit/update
+# them normally.
 #
 # Kept as an empty registry so older tooling can run without a missing-file
 # branch. Format, when intentionally reintroduced for a platform-owned app:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -190,9 +190,9 @@ services:
       # unrelated `git ls-remote` from failing while discovering the broken
       # outer worktree pointer first.
       - GIT_CEILING_DIRECTORIES=/workspace
-      # Bootstrap fetches the curated store manifest from GitHub on
-      # first boot. Tests must not depend on outbound network — set
-      # this so ensure_store_installed() returns immediately.
+      # Bootstrap fetches curated app manifests from GitHub on first boot.
+      # Tests must not depend on outbound network — set
+      # this so ensure_bootstrap_apps_installed() returns immediately.
       - MOEBIUS_SKIP_BOOTSTRAP=1
     working_dir: /workspace/backend
     entrypoint: ["python", "-m", "pytest", "tests/", "-v"]


### PR DESCRIPTION
## Summary

- Generalize the first-boot bootstrap into an ordered registry: App Store, Memory, Reflection — all auto-installed on fresh instances from their catalog repos.
- Per-app uninstall semantics: an uninstalled Store returns on restart (it is the recovery surface); owner uninstalls of Memory and Reflection are respected — a tombstoned row reads as present, and they remain reinstallable from the Store.
- Per-app failure isolation: one manifest failure (network blip, bad JSON) cannot crash lifespan or block the remaining installs.
- Rename `ensure_store_installed` → `ensure_bootstrap_apps_installed`; align SOURCES, CONTRIBUTING, ARCHITECTURE.

## Testing

- `tests/test_bootstrap.py`: install order + URLs, per-app tombstone policy, canonical-identity skip, failure isolation, `MOEBIUS_SKIP_BOOTSTRAP` skip — 12 passed.
- Full backend suite on this branch: 2271 passed, 4 env-only failures reproduced on base and green with frontend validator deps installed (22/22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)