### PR TITLE
Enforce sandbox CSP on every opaque embed response

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -654,13 +654,23 @@ _SECURITY_HEADERS = [
 ]
 _SECURITY_HEADER_NAMES = frozenset(name for name, _ in _SECURITY_HEADERS)
 _X_FRAME_OPTIONS = b"x-frame-options"
+_CONTENT_SECURITY_POLICY = b"content-security-policy"
 _OPAQUE_STATIC_EMBED_PREFIX = "/app-embeds/by-id/"
+
+# This isolation boundary must always be enforced, never Report-Only: browsers
+# ignore the CSP sandbox directive in a Report-Only policy.
+_STATIC_EMBED_CSP = (
+  "sandbox allow-scripts allow-forms allow-pointer-lock; default-src 'self'; "
+  "script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; "
+  "font-src 'self' data:; connect-src 'self'; img-src 'self' data: blob:; "
+  "media-src 'self' blob:; worker-src 'self' blob:"
+)
 
 
 def _frame_policy_exception(scope) -> bool:
   """Exact routes whose own isolation permits a non-SAMEORIGIN ancestor."""
   path = scope.get("path") or ""
-  if path == "/shell/embed/chat" or path.startswith(_OPAQUE_STATIC_EMBED_PREFIX):
+  if path == "/shell/embed/chat":
     return True
   if path.startswith("/services/"):
     try:
@@ -675,9 +685,10 @@ class _SecurityHeadersMiddleware:
   """Authoritatively sets the platform security headers on every response. Pure
   ASGI so it never buffers a streaming body. It strips any same-named header a
   route may have set first and replaces it with the platform value, so no route
-  can weaken the HSTS/MIME/etc. wall. Frame-policy exceptions are delegated to
-  exact routes whose own response sandbox or dedicated-origin adapter provides
-  the replacement boundary; ordinary routes retain SAMEORIGIN protection."""
+  can weaken the HSTS/MIME/etc. wall. Opaque static embeds get their enforced
+  response sandbox here alongside their frame-policy exception. Other frame
+  exceptions are exact routes whose inert response or dedicated-origin adapter
+  provides the replacement boundary; ordinary routes retain SAMEORIGIN."""
 
   def __init__(self, app):
     self.app = app
@@ -686,24 +697,55 @@ class _SecurityHeadersMiddleware:
     if scope["type"] != "http":
       return await self.app(scope, receive, send)
 
+    # Frameability and sandboxing are one policy for this exact namespace; keep
+    # both decisions adjacent so no response can receive only the exception.
+    opaque_static_embed = (scope.get("path") or "").startswith(
+      _OPAQUE_STATIC_EMBED_PREFIX
+    )
     response_headers = _SECURITY_HEADERS
-    if _frame_policy_exception(scope):
+    replaced_header_names = _SECURITY_HEADER_NAMES
+    if opaque_static_embed or _frame_policy_exception(scope):
       response_headers = [
         (name, value) for name, value in _SECURITY_HEADERS
         if name != _X_FRAME_OPTIONS
       ]
+    if opaque_static_embed:
+      response_headers.append((
+        _CONTENT_SECURITY_POLICY,
+        _STATIC_EMBED_CSP.encode("ascii"),
+      ))
+      replaced_header_names = replaced_header_names | {
+        _CONTENT_SECURITY_POLICY
+      }
+
+    response_started = False
 
     async def _send(message):
+      nonlocal response_started
       if message["type"] == "http.response.start":
+        response_started = True
         headers = [
           (k, v) for k, v in message.get("headers", [])
-          if k.lower() not in _SECURITY_HEADER_NAMES
+          if k.lower() not in replaced_header_names
         ]
         headers.extend(response_headers)
         message["headers"] = headers
       await send(message)
 
-    return await self.app(scope, receive, _send)
+    try:
+      return await self.app(scope, receive, _send)
+    except Exception:
+      # Starlette's unhandled-error response is outside user middleware. Send
+      # this namespace's generic 500 through our wrapper before re-raising so
+      # the outer layer still logs it without bypassing the sandbox boundary.
+      if opaque_static_embed and not response_started:
+        response = Response(
+          "Internal Server Error",
+          status_code=500,
+          media_type="text/plain",
+        )
+        await response(scope, receive, _send)
+      raise
 
 
 class _DatabaseRequestContextMiddleware:
@@ -1329,14 +1371,6 @@ async def app_owned_asset_by_id(app_id: int, asset_path: str, request: Request):
   )
 
 
-_STATIC_EMBED_CSP = (
-  "sandbox allow-scripts allow-forms allow-pointer-lock; default-src 'self'; "
-  "script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; "
-  "font-src 'self' data:; connect-src 'self'; img-src 'self' data: blob:; "
-  "media-src 'self' blob:; worker-src 'self' blob:"
-)
-
-
 @app.api_route(
   "/app-embeds/by-id/{app_id}/{asset_path:path}",
   methods=["GET", "HEAD"],
@@ -1352,13 +1386,11 @@ async def app_owned_opaque_embed_by_id(
   assets stay below the same alias. Ordinary /app-assets remains protected by
   SAMEORIGIN and is never the document-navigation surface.
   """
-  response = _serve_app_static_asset(
+  return _serve_app_static_asset(
     await asyncio.to_thread(_app_source_dir_for_static_asset, app_id=app_id),
     asset_path,
     request,
   )
-  response.headers["Content-Security-Policy"] = _STATIC_EMBED_CSP
-  return response
 
 
 @app.api_route(

--- a/backend/tests/test_app_assets_cache.py
+++ b/backend/tests/test_app_assets_cache.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 from app import models
 from app.database import SessionLocal
+from app.main import _STATIC_EMBED_CSP
 
 
 def _create_app(client, owner_token, name="CubeRun"):
@@ -43,6 +44,12 @@ def _write_static(app_id, relpath, content):
     return target
   finally:
     db.close()
+
+
+def _assert_opaque_embed_policy(response, status_code):
+  assert response.status_code == status_code
+  assert response.headers["content-security-policy"] == _STATIC_EMBED_CSP
+  assert "x-frame-options" not in response.headers
 
 
 def test_asset_get_carries_validators_and_revalidate_semantics(
@@ -220,19 +227,50 @@ def test_opaque_embed_alias_preserves_relative_tree_and_sandboxes_document(
   ordinary = client.get(f"/app-assets/by-id/{app['id']}/index.html")
   svg = client.get(f"/app-embeds/by-id/{app['id']}/active.svg")
 
-  assert entry.status_code == 200
-  assert child.status_code == 200
-  assert "x-frame-options" not in entry.headers
-  csp = entry.headers["content-security-policy"]
-  assert "sandbox allow-scripts" in csp
-  assert "allow-same-origin" not in csp
-  assert "frame-ancestors" not in csp
+  _assert_opaque_embed_policy(entry, 200)
+  _assert_opaque_embed_policy(child, 200)
+  _assert_opaque_embed_policy(svg, 200)
   assert entry.headers["access-control-allow-origin"] == "null"
-  assert "sandbox allow-scripts" in child.headers["content-security-policy"]
-  assert "allow-same-origin" not in child.headers["content-security-policy"]
-  assert "sandbox allow-scripts" in svg.headers["content-security-policy"]
-  assert "allow-same-origin" not in svg.headers["content-security-policy"]
   assert ordinary.headers["x-frame-options"] == "SAMEORIGIN"
+
+
+def test_opaque_embed_head_and_revalidation_keep_sandbox_policy(
+  client, owner_token,
+):
+  app = _create_app(client, owner_token)
+  _write_static(app["id"], "index.html", "<title>CubeRun</title>")
+  path = f"/app-embeds/by-id/{app['id']}/index.html"
+
+  head = client.head(path)
+  _assert_opaque_embed_policy(head, 200)
+  assert head.content == b""
+
+  first = client.get(path)
+  revalidated = client.get(
+    path,
+    headers={"If-None-Match": first.headers["etag"]},
+  )
+  _assert_opaque_embed_policy(revalidated, 304)
+  assert revalidated.content == b""
+
+
+def test_opaque_embed_error_responses_keep_sandbox_policy(
+  client, owner_token,
+):
+  app = _create_app(client, owner_token)
+
+  missing_app = client.get("/app-embeds/by-id/999999/index.html")
+  _assert_opaque_embed_policy(missing_app, 404)
+
+  missing_file = client.get(
+    f"/app-embeds/by-id/{app['id']}/does-not-exist.js"
+  )
+  _assert_opaque_embed_policy(missing_file, 404)
+
+  invalid_app_id = client.get(
+    "/app-embeds/by-id/not-an-integer/index.html"
+  )
+  _assert_opaque_embed_policy(invalid_app_id, 422)
 
 
 def test_security_guards_run_before_caching(client, owner_token):

--- a/backend/tests/test_security_headers.py
+++ b/backend/tests/test_security_headers.py
@@ -7,9 +7,11 @@ documents supply their own policies while the bundled proxy owns shell CSP.
 
 from pathlib import Path
 
+from fastapi import Response
 from fastapi.testclient import TestClient
 
-from app.main import app
+from app import main
+from app.main import _STATIC_EMBED_CSP, app
 
 
 def _headers(path="/api/health"):
@@ -44,6 +46,42 @@ def test_embedded_chat_allows_opaque_origin_app_ancestor():
 
 def test_frame_exception_is_exactly_scoped_to_embed_document():
   assert _headers("/shell/embed/chat/other").get("x-frame-options") == "SAMEORIGIN"
+
+
+def test_static_embed_policy_authoritatively_replaces_route_headers(monkeypatch):
+  monkeypatch.setattr(
+    main,
+    "_serve_app_static_asset",
+    lambda *_args, **_kwargs: Response(
+      status_code=418,
+      headers={
+        "Content-Security-Policy": "default-src 'none'",
+        "X-Frame-Options": "DENY",
+      },
+    ),
+  )
+
+  response = TestClient(app).get("/app-embeds/by-id/999/index.html")
+
+  assert response.status_code == 418
+  assert response.headers["content-security-policy"] == _STATIC_EMBED_CSP
+  assert "x-frame-options" not in response.headers
+
+
+def test_static_embed_policy_survives_unhandled_route_exception(monkeypatch):
+  def _raise(*_args, **_kwargs):
+    raise RuntimeError("static asset failure")
+
+  monkeypatch.setattr(main, "_serve_app_static_asset", _raise)
+
+  response = TestClient(
+    app,
+    raise_server_exceptions=False,
+  ).get("/app-embeds/by-id/999/index.html")
+
+  assert response.status_code == 500
+  assert response.headers["content-security-policy"] == _STATIC_EMBED_CSP
+  assert "x-frame-options" not in response.headers
 
 
 def test_bundled_caddy_mirrors_exact_embed_frame_exception():


### PR DESCRIPTION
## Summary

- `/app-embeds/by-id/*` responses now carry the sandbox Content-Security-Policy on every status and method — set authoritatively by `_SecurityHeadersMiddleware`, adjacent to the frame-policy exception for the same prefix, so no response can receive the exception without the sandbox.
- Covers unhandled 500s: the middleware emits the namespace's generic 500 through its own wrapped sender before re-raising, so Starlette's outer handler cannot bypass the boundary.
- Single-sources the policy constant (route-level writer removed) and documents the invariant that this policy must never be Report-Only (browsers ignore the `sandbox` directive in Report-Only policies).
- Restores the SECURITY.md claim that every response in the namespace carries the sandbox policy — previously only success responses did, while X-Frame-Options was stripped prefix-wide.

## Testing

- Exact header assertions for GET 200, HEAD, 304, missing-app 404, missing-file 404, validation 422, and patched unhandled-exception 500; conflicting route-set headers are replaced.
- Full backend suite on this branch: 2274 passed, 4 env-only failures reproduced on base and green with frontend validator deps installed (22/22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)