### PR TITLE
Run topic branch backend CI once

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    # Cheap checks run on development branches too. The e2e job below narrows
-    # its own execution to PRs and long-lived branches, avoiding a duplicate
-    # full browser run for both a feature push and its PR event.
+    # Cheap checks run on development branches too. The expensive backend and
+    # e2e jobs below narrow themselves to PRs and long-lived branches, avoiding
+    # duplicate full suites for both a topic push and its PR event.
     branches: [main, 'integration/**', 'feat/**', 'fix/**']
   pull_request:
     # True PR stacks target the upstream branch directly beneath them. Run the
@@ -36,6 +36,13 @@ jobs:
         run: scripts/test-git-privacy-gates.sh
 
   backend:
+    # A topic push is immediately followed by its PR event in the submission
+    # flow. Keep the branch's fast feedback, but run this seven-minute suite
+    # once on the reviewable PR instead of twice for the same commit.
+    if: >-
+      github.event_name == 'pull_request' ||
+      github.ref == 'refs/heads/main' ||
+      startsWith(github.ref, 'refs/heads/integration/')
     runs-on: ubuntu-latest
     # The full backend suite now reaches roughly 10 minutes on a cold hosted
     # runner, plus dependency/setup time. Keep the cap bounded, but leave enough

--- a/backend/tests/test_verify_test_runtime.py
+++ b/backend/tests/test_verify_test_runtime.py
@@ -342,13 +342,17 @@ def test_documented_browser_commands_use_disposable_runner():
   assert '/home/' not in test_script
 
 
-def test_hosted_e2e_runs_for_prs_and_long_lived_branches_only():
+def test_hosted_expensive_suites_run_for_prs_and_long_lived_branches_only():
   workflow = (ROOT / ".github" / "workflows" / "test.yml").read_text(
     encoding="utf-8"
   )
+  backend = workflow.split("\n  backend:\n", 1)[1].split(
+    "\n  frontend-unit:\n", 1,
+  )[0]
   e2e = workflow.split("\n  e2e:\n", 1)[1]
-  assert "github.event_name == 'pull_request'" in e2e
-  assert "github.ref == 'refs/heads/main'" in e2e
-  assert "refs/heads/integration/" in e2e
+  for job in (backend, e2e):
+    assert "github.event_name == 'pull_request'" in job
+    assert "github.ref == 'refs/heads/main'" in job
+    assert "refs/heads/integration/" in job
   assert "needs: privacy" in e2e
   assert "needs: backend" not in e2e


### PR DESCRIPTION
A normal contribution push is immediately followed by its pull-request event. The live #77 submission showed that both events started the full backend suite for the same SHA (7m21s and 7m46s), even though browser E2E already avoids that duplicate.

Keep privacy, frontend, packager, and core-app fast feedback on topic pushes. Run the expensive backend suite on pull requests, main, and long-lived integration branches, matching the existing E2E policy.

Verification: the workflow contract now asserts the event/ref gate for both expensive jobs; 20 focused runtime/workflow tests pass. This topic push itself should show backend skipped, while this PR event runs it once.