### PR TITLE
Fail closed on invalid edge deploy topology

### DIFF
--- a/backend/tests/test_deploy_edge_topology.py
+++ b/backend/tests/test_deploy_edge_topology.py
@@ -1,0 +1,59 @@
+"""Fail-closed contracts for the shared-edge production deploy path."""
+
+from pathlib import Path
+import re
+import subprocess
+
+import pytest
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "deploy-prod.sh"
+
+
+def _gateway_validator() -> str:
+  text = SCRIPT.read_text(encoding="utf-8")
+  match = re.search(r"valid_gateway_origin\(\) \{.*?^\}", text, re.MULTILINE | re.DOTALL)
+  assert match, "deploy script must keep gateway validation in one testable helper"
+  return match.group(0)
+
+
+@pytest.mark.parametrize("origin", [
+  "https://services.example.test",
+  "https://services.example.test:8443",
+  "https://127.0.0.1:443",
+])
+def test_gateway_renderer_accepts_bare_https_origins(origin):
+  result = subprocess.run(
+    ["bash", "-c", f'{_gateway_validator()}\nvalid_gateway_origin "$1"', "_", origin],
+    check=False,
+  )
+  assert result.returncode == 0
+
+
+@pytest.mark.parametrize("origin", [
+  "http://services.example.test",
+  "https://services.example.test/path",
+  "https://user@services.example.test",
+  "https://services.example.test|d",
+  "https://services.example.test:0",
+  "https://services.example.test:65536",
+])
+def test_gateway_renderer_rejects_non_origins_and_render_metacharacters(origin):
+  result = subprocess.run(
+    ["bash", "-c", f'{_gateway_validator()}\nvalid_gateway_origin "$1"', "_", origin],
+    check=False,
+  )
+  assert result.returncode != 0
+
+
+def test_stopped_shared_edge_never_falls_back_to_bundled_caddy():
+  text = SCRIPT.read_text(encoding="utf-8")
+  assert "EDGE_CONTAINER_STATE" in text
+  assert "{{.State.Status}}" in text
+  assert "refusing to fall back to bundled Caddy" in text
+  assert "Restore the shared edge proxy" in text
+
+
+def test_unknown_csp_mode_fails_instead_of_silently_enforcing():
+  text = SCRIPT.read_text(encoding="utf-8")
+  assert "EDGE_CSP_MODE must be 'enforce' or 'report-only'." in text

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -288,15 +288,31 @@ ensure_prod_env
 # the answers and, e.g., start the bundled caddy against edge-owned ports.
 EDGE_TOPOLOGY="self-hosted"
 if [ "$TARGET" = "prod" ]; then
-  if docker inspect -f '{{.State.Running}}' edge-caddy 2>/dev/null | grep -q true; then
-    EDGE_TOPOLOGY="edge"
-    COMPOSE_ARGS+=(-f docker-compose.yml -f docker-compose.prod.yml)
-  elif docker inspect -f '{{.State.Running}}' deploy-caddy-1 2>/dev/null | grep -q true; then
-    fail "the retired legacy proxy (deploy-caddy-1) still owns ports 80/443."
-    fail "This script now deploys behind the shared edge proxy (edge-caddy);"
-    fail "run the edge cutover first, or stop deploy-caddy-1 to self-host."
-    exit 1
-  fi
+  EDGE_CONTAINER_STATE=$(
+    docker inspect -f '{{.State.Status}}' edge-caddy 2>/dev/null || true
+  )
+  case "$EDGE_CONTAINER_STATE" in
+    running)
+      EDGE_TOPOLOGY="edge"
+      COMPOSE_ARGS+=(-f docker-compose.yml -f docker-compose.prod.yml)
+      ;;
+    "")
+      if docker inspect -f '{{.State.Running}}' deploy-caddy-1 2>/dev/null | grep -q true; then
+        fail "the retired legacy proxy (deploy-caddy-1) still owns ports 80/443."
+        fail "This script now deploys behind the shared edge proxy (edge-caddy);"
+        fail "run the edge cutover first, or stop deploy-caddy-1 to self-host."
+        exit 1
+      fi
+      ;;
+    *)
+      # An existing edge stack defines this host's topology even while it is
+      # unhealthy. Starting the bundled Caddy in that window would silently
+      # seize the edge-owned ports and replace every other routed service.
+      fail "edge-caddy exists but is ${EDGE_CONTAINER_STATE}; refusing to fall back to bundled Caddy."
+      fail "Restore the shared edge proxy, then re-run the deploy."
+      exit 1
+      ;;
+  esac
 fi
 
 external_prod_caddy_running() {
@@ -310,6 +326,20 @@ ensure_edge_network() {
   docker network inspect edge-mobius >/dev/null 2>&1 && return 0
   intent "docker network create edge-mobius"
   docker network create edge-mobius >/dev/null
+}
+
+valid_gateway_origin() {
+  local origin="$1" authority port
+  # Keep the render substitution inert: one HTTPS DNS/IPv4 authority, with an
+  # optional numeric port, and no credentials, path, query, fragment, control
+  # characters, or sed delimiter. Caddy validates the hostname itself later.
+  [[ "$origin" =~ ^https://[A-Za-z0-9]([A-Za-z0-9.-]*[A-Za-z0-9])?(:[0-9]{1,5})?$ ]] \
+    || return 1
+  authority=${origin#https://}
+  if [[ "$authority" == *:* ]]; then
+    port=${authority##*:}
+    (( 10#$port >= 1 && 10#$port <= 65535 )) || return 1
+  fi
 }
 
 # The bundled Caddyfile is the single routing source of truth for BOTH
@@ -343,10 +373,10 @@ install_edge_fragment() {
   case "$DOMAIN" in
     *[!A-Za-z0-9.-]*|"") fail "DOMAIN '$DOMAIN' is not a bare hostname; refusing to render the edge fragment"; exit 1 ;;
   esac
-  case "$gw" in
-    ""|https://[A-Za-z0-9]*) : ;;
-    *) fail "MOBIUS_SERVICE_GATEWAY_ORIGIN '$gw' is not an https origin; refusing to render the edge fragment"; exit 1 ;;
-  esac
+  if [ -n "$gw" ] && ! valid_gateway_origin "$gw"; then
+    fail "MOBIUS_SERVICE_GATEWAY_ORIGIN '$gw' is not a bare https origin; refusing to render the edge fragment"
+    exit 1
+  fi
   local rendered
   rendered=$(mktemp)
   if [ -n "$gw" ]; then
@@ -380,10 +410,18 @@ install_edge_fragment() {
     rm -f "$rendered"
     exit 1
   fi
-  if [ "${EDGE_CSP_MODE:-enforce}" = "report-only" ]; then
-    sed -i 's|>Content-Security-Policy |>Content-Security-Policy-Report-Only |g' "$rendered"
-    info "edge fragment CSP rendered as Report-Only (EDGE_CSP_MODE=report-only)"
-  fi
+  case "${EDGE_CSP_MODE:-enforce}" in
+    enforce) ;;
+    report-only)
+      sed -i 's|>Content-Security-Policy |>Content-Security-Policy-Report-Only |g' "$rendered"
+      info "edge fragment CSP rendered as Report-Only (EDGE_CSP_MODE=report-only)"
+      ;;
+    *)
+      rm -f "$rendered"
+      fail "EDGE_CSP_MODE must be 'enforce' or 'report-only'."
+      exit 1
+      ;;
+  esac
   # edgectl is transactional: a bad render never replaces the installed
   # fragment, a failed reload restores it, and the previously SERVED fragment
   # stays available as `edgectl rollback mobius`.


### PR DESCRIPTION
Release follow-up from the sibling edge-routing review.

- Refuse a production deploy when the shared `edge-caddy` container exists but is stopped/unhealthy, instead of silently starting bundled Caddy on edge-owned ports.
- Validate the rendered service-gateway value as a bare HTTPS origin with a valid optional port before it reaches `sed`/Caddy.
- Reject misspelled `EDGE_CSP_MODE` values rather than silently enforcing the wrong rollout mode.
- Add executable validator coverage plus static topology guardrails (11 focused tests green; `bash -n` green).

The live edge cutover was also checked read-only: shell CSP report-only is present with `blob:`, recovery preserves `DENY` + `frame-ancestors none`, gateway root returns 404, and the served platform tree is clean/current.