### PR TITLE
Preserve edge gateway config in worktree deploys

### DIFF
--- a/backend/tests/test_deploy_edge_gateway_env.py
+++ b/backend/tests/test_deploy_edge_gateway_env.py
@@ -1,0 +1,118 @@
+"""The shared-edge deploy must preserve one gateway value end to end."""
+
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "deploy-prod.sh"
+BLOCK_START = "# ── prod environment resolution"
+BLOCK_END = "# ── end prod environment resolution"
+
+
+def _resolution_source() -> str:
+  text = SCRIPT.read_text()
+  start = text.index(BLOCK_START)
+  end = text.index(BLOCK_END, start)
+  return text[start:end]
+
+
+def _git(repo: Path, *args: str) -> str:
+  env = {
+    **os.environ,
+    "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+    "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+  }
+  return subprocess.run(
+    ["git", "-C", str(repo), *args],
+    check=True, capture_output=True, text=True, env=env,
+  ).stdout.strip()
+
+
+@pytest.fixture
+def linked_worktree(tmp_path):
+  canonical = tmp_path / "canonical"
+  linked = tmp_path / "linked"
+  canonical.mkdir()
+  _git(canonical, "init", "-q", "-b", "main")
+  (canonical / "tracked").write_text("base")
+  _git(canonical, "add", "tracked")
+  _git(canonical, "commit", "-q", "-m", "base")
+  _git(canonical, "worktree", "add", "-q", "-b", "linked", str(linked))
+  return canonical, linked
+
+
+def _run_resolution(
+  repo_root: Path, *, gateway: str | None = None,
+) -> subprocess.CompletedProcess:
+  gateway_setup = (
+    "unset MOBIUS_SERVICE_GATEWAY_ORIGIN"
+    if gateway is None
+    else f"MOBIUS_SERVICE_GATEWAY_ORIGIN={gateway!r}"
+  )
+  harness = textwrap.dedent(f"""\
+    set -euo pipefail
+    info() {{ printf 'INFO %s\\n' "$1" >&2; }}
+    fail() {{ printf 'FAIL %s\\n' "$1" >&2; }}
+    TARGET=prod
+    DOMAIN=mobius.example.com
+    REPO_ROOT={str(repo_root)!r}
+    {gateway_setup}
+    {_resolution_source()}
+    resolve_prod_service_gateway_origin
+    printf '%s' "$MOBIUS_SERVICE_GATEWAY_ORIGIN"
+  """)
+  return subprocess.run(["bash", "-c", harness], capture_output=True, text=True)
+
+
+def test_preexported_domain_still_loads_gateway_from_canonical_checkout(
+  linked_worktree,
+):
+  canonical, linked = linked_worktree
+  (canonical / ".env").write_text(
+    "MOBIUS_SERVICE_GATEWAY_ORIGIN=https://services.mobius.example.com/\n"
+  )
+
+  result = _run_resolution(linked)
+
+  assert result.returncode == 0, result.stderr
+  assert result.stdout == "https://services.mobius.example.com"
+  assert f"loaded service gateway origin from {canonical / '.env'}" in result.stderr
+
+
+def test_explicit_gateway_wins_over_canonical_checkout(linked_worktree):
+  canonical, linked = linked_worktree
+  (canonical / ".env").write_text(
+    "MOBIUS_SERVICE_GATEWAY_ORIGIN=https://canonical.example.com\n"
+  )
+
+  result = _run_resolution(linked, gateway="https://explicit.example.com:443/")
+
+  assert result.returncode == 0, result.stderr
+  assert result.stdout == "https://explicit.example.com"
+  assert "loaded service gateway origin from" not in result.stderr
+
+
+@pytest.mark.parametrize("gateway", [
+  "http://services.mobius.example.com",
+  "https://mobius.example.com",
+  "https://services.mobius.example.com/path",
+  "https://services.mobius.example.com|bad",
+])
+def test_invalid_or_shell_gateway_is_rejected(tmp_path, gateway):
+  result = _run_resolution(tmp_path, gateway=gateway)
+
+  assert result.returncode != 0
+  assert "must be a separate HTTPS origin" in result.stderr
+
+
+def test_render_and_public_verification_share_the_resolved_variable():
+  text = SCRIPT.read_text()
+  assert 'local gw="$MOBIUS_SERVICE_GATEWAY_ORIGIN"' in text
+  assert 'gw_origin="${MOBIUS_SERVICE_GATEWAY_ORIGIN:-}"' in text
+  assert text.index("resolve_prod_service_gateway_origin") < text.index(
+    "# ── proxy topology"
+  )

--- a/backend/tests/test_deploy_edge_gateway_env.py
+++ b/backend/tests/test_deploy_edge_gateway_env.py
@@ -101,6 +101,8 @@ def test_explicit_gateway_wins_over_canonical_checkout(linked_worktree):
   "https://mobius.example.com",
   "https://services.mobius.example.com/path",
   "https://services.mobius.example.com|bad",
+  "https://services.mobius.example.com:0",
+  "https://services.mobius.example.com:65536",
 ])
 def test_invalid_or_shell_gateway_is_rejected(tmp_path, gateway):
   result = _run_resolution(tmp_path, gateway=gateway)

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -340,6 +340,7 @@ if (
   or parsed.fragment
   or parsed.path not in ("", "/")
   or host == shell_host.rstrip(".").lower()
+  or port is not None and not 1 <= port <= 65535
 ):
   raise SystemExit(1)
 authority = host if port in (None, 443) else f"{host}:{port}"

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -241,6 +241,31 @@ source_env_file() {
   return 0
 }
 
+# ── prod environment resolution ─────────────────────────────────────
+canonical_env_path() {
+  local git_common canonical_root
+  git_common=$(git -C "$REPO_ROOT" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
+  [ -n "$git_common" ] || return 1
+  canonical_root="$(dirname "$git_common")"
+  [ "$canonical_root" != "$REPO_ROOT" ] || return 1
+  [ -f "$canonical_root/.env" ] || return 1
+  printf '%s\n' "$canonical_root/.env"
+}
+
+env_value_from_file() {
+  local file="$1" key="$2"
+  [ -f "$file" ] || return 1
+  (
+    # .env is shell syntax in this repo. Read it in a subshell so resolving one
+    # missing setting cannot overwrite an explicitly exported deploy setting.
+    set +u
+    set -a
+    # shellcheck disable=SC1090
+    . "$file" >/dev/null
+    printf '%s' "${!key:-}"
+  )
+}
+
 ensure_prod_env() {
   if [ "$TARGET" != "prod" ]; then return 0; fi
   if [ -n "${DOMAIN:-}" ]; then return 0; fi
@@ -271,7 +296,68 @@ ensure_prod_env() {
   fi
 }
 
+resolve_prod_service_gateway_origin() {
+  [ "$TARGET" = "prod" ] || return 0
+  local value="${MOBIUS_SERVICE_GATEWAY_ORIGIN:-}" source="environment"
+  local file candidate canonical_env=""
+
+  # DOMAIN is commonly exported explicitly for a worktree deploy. In that
+  # case ensure_prod_env intentionally does not source .env, but the gateway
+  # still has to come from the canonical checkout rather than disappearing
+  # from the rendered edge fragment and its final verification.
+  if [ -z "$value" ]; then
+    canonical_env=$(canonical_env_path || true)
+    for file in "$REPO_ROOT/.env" "$canonical_env"; do
+      [ -n "$file" ] || continue
+      candidate=$(env_value_from_file "$file" MOBIUS_SERVICE_GATEWAY_ORIGIN || true)
+      if [ -n "$candidate" ]; then
+        value="$candidate"
+        source="$file"
+        break
+      fi
+    done
+  fi
+
+  if [ -n "$value" ]; then
+    if ! value=$(python3 - "$value" "$DOMAIN" <<'PY'
+import re
+import sys
+from urllib.parse import urlsplit
+
+raw, shell_host = sys.argv[1:]
+try:
+  parsed = urlsplit(raw.strip())
+  port = parsed.port
+except ValueError:
+  raise SystemExit(1)
+host = (parsed.hostname or "").rstrip(".").lower()
+if (
+  parsed.scheme != "https"
+  or not re.fullmatch(r"[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?", host)
+  or parsed.username is not None
+  or parsed.password is not None
+  or parsed.query
+  or parsed.fragment
+  or parsed.path not in ("", "/")
+  or host == shell_host.rstrip(".").lower()
+):
+  raise SystemExit(1)
+authority = host if port in (None, 443) else f"{host}:{port}"
+print(f"https://{authority}")
+PY
+    ); then
+      fail "MOBIUS_SERVICE_GATEWAY_ORIGIN must be a separate HTTPS origin without credentials, a path, query, or fragment."
+      exit 1
+    fi
+    [ "$source" = "environment" ] || info "loaded service gateway origin from $source"
+  fi
+  MOBIUS_SERVICE_GATEWAY_ORIGIN="$value"
+  export MOBIUS_SERVICE_GATEWAY_ORIGIN
+}
+# ── end prod environment resolution ──────────────────────────────
+
 ensure_prod_env
+resolve_prod_service_gateway_origin
 
 # ── proxy topology — sampled ONCE, then frozen ──────────────────────────
 # The shared edge proxy (its own compose stack; see the edge repo's README)
@@ -363,13 +449,9 @@ install_edge_fragment() {
     fail "Set MOBIUS_EDGE_DIR to the edge checkout, or restore it, then re-run."
     exit 1
   fi
-  # ensure_prod_env skips .env when DOMAIN is pre-exported, so the gateway
-  # origin can be unset here even though the canonical .env carries it. Fall
-  # back to that file before concluding the gateway is unconfigured.
-  local gw="${MOBIUS_SERVICE_GATEWAY_ORIGIN:-}"
-  if [ -z "$gw" ] && [ -f "$REPO_ROOT/.env" ]; then
-    gw=$(sed -n 's/^MOBIUS_SERVICE_GATEWAY_ORIGIN=//p' "$REPO_ROOT/.env" | tail -1)
-  fi
+  # Resolved once before topology selection so rendering and final verification
+  # use the same normalized value, including from a linked worktree.
+  local gw="$MOBIUS_SERVICE_GATEWAY_ORIGIN"
   case "$DOMAIN" in
     *[!A-Za-z0-9.-]*|"") fail "DOMAIN '$DOMAIN' is not a bare hostname; refusing to render the edge fragment"; exit 1 ;;
   esac


### PR DESCRIPTION
## What changed
- resolve the service-gateway origin once from the explicit environment, worktree `.env`, or canonical checkout `.env`
- normalize and strictly validate it before rendering the shared-edge fragment
- reuse the resolved value for the final public gateway check
- add behavioral linked-worktree and validation coverage

## Why
When `DOMAIN` was pre-exported, `ensure_prod_env` returned before sourcing `.env`. A deploy from a linked worktree (which normally has no `.env`) could then render the edge fragment without the configured gateway and skip the corresponding public verification, even though the canonical checkout carried the setting.

## Verification
- 57 focused deploy, local-service, Memory boot, and security-header tests passed
- `bash -n scripts/deploy-prod.sh`
- `git diff --check`
- checked the actual `vps-edge` manifest and transactional `edgectl install` contract