### PR TITLE
Land reviewed spacer and voice production fixes

### DIFF
--- a/frontend/src/components/ChatView/ChatInputBar.jsx
+++ b/frontend/src/components/ChatView/ChatInputBar.jsx
@@ -278,7 +278,8 @@ function FileChips({ files, onRemove }) {
  *   inputRef           — for caller to focus/blur (e.g. dismiss keyboard)
  *   sending            — agent is currently streaming
  *   listening          — voice input active
- *   listeningRef       — synchronous mirror (for guarding textarea onChange)
+ *   listeningRef       — synchronous mirror of voice input state
+ *   onManualVoiceEdit  — rebases live dictation onto an owner-edited value
  *   onToggleVoice      — mic button handler
  *   onStop             — stop button handler
  *   onSteer            — fast-forward handler (steer queued msgs into the
@@ -321,6 +322,7 @@ export default function ChatInputBar({
   sending,
   listening,
   listeningRef,
+  onManualVoiceEdit,
   onToggleVoice,
   onStop,
   onSteer,
@@ -387,7 +389,7 @@ export default function ChatInputBar({
   }
 
   function handleTextareaChange(e) {
-    if (listeningRef?.current) return  // voice in progress
+    if (listeningRef?.current) onManualVoiceEdit?.(e.target.value)
     onInputChange(e.target.value)
     e.target.style.height = 'auto'
     const h = Math.min(e.target.scrollHeight, 280)

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -1432,7 +1432,13 @@ export default function ChatView({
     })
   }
 
-  const { listening, listeningRef, stopVoice, toggleVoice } = useVoiceInput({
+  const {
+    listening,
+    listeningRef,
+    stopVoice,
+    toggleVoice,
+    acceptManualEdit,
+  } = useVoiceInput({
     onTranscript: handleComposerInputChange,
     inputRef,
   })
@@ -3700,6 +3706,7 @@ export default function ChatView({
           sending={composerBusy}
           listening={listening}
           listeningRef={listeningRef}
+          onManualVoiceEdit={acceptManualEdit}
           onToggleVoice={toggleVoice}
           onStop={handleStop}
           onSteer={handleSteer}

--- a/frontend/src/components/ChatView/__tests__/composerVoiceEditing.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerVoiceEditing.test.js
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+const inputBarSrc = readFileSync(new URL('../ChatInputBar.jsx', import.meta.url), 'utf8')
+const chatViewSrc = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8')
+const changeHandler = inputBarSrc.match(
+  /function handleTextareaChange\(e\) \{[\s\S]*?\n  \}/,
+)?.[0] || ''
+
+test('manual textarea changes remain enabled while voice input is active', () => {
+  assert.doesNotMatch(changeHandler, /listeningRef\?\.current\) return/,
+    'listening must not discard owner edits')
+  assert.match(changeHandler,
+    /if \(listeningRef\?\.current\) onManualVoiceEdit\?\.\(e\.target\.value\)/,
+    'a live edit must rebase the recognition session before updating the draft')
+  assert.match(changeHandler, /onInputChange\(e\.target\.value\)/,
+    'the controlled composer must still receive the owner edit')
+})
+
+test('ChatView connects manual voice edits to the voice-input session', () => {
+  assert.match(chatViewSrc, /onManualVoiceEdit=\{acceptManualEdit\}/)
+})

--- a/frontend/src/components/ChatView/__tests__/preserveTogglePosition.test.js
+++ b/frontend/src/components/ChatView/__tests__/preserveTogglePosition.test.js
@@ -141,3 +141,90 @@ test('opening a disclosure leaves normal spacer sizing alone', () => {
     globalThis.requestAnimationFrame = originalRaf
   }
 })
+
+test('a fast close-open-close cycle unwinds provisional space instead of accumulating it', () => {
+  const originalMutationObserver = globalThis.MutationObserver
+  const originalRaf = globalThis.requestAnimationFrame
+  const originalGetComputedStyle = globalThis.getComputedStyle
+  globalThis.MutationObserver = undefined
+  globalThis.requestAnimationFrame = () => 1
+  globalThis.getComputedStyle = () => ({ marginTop: '4px', marginBottom: '2px' })
+
+  try {
+    const spacer = {
+      style: { height: '100px' },
+      get offsetHeight() { return Number.parseFloat(this.style.height) },
+    }
+    const scroller = {
+      scrollTop: 50,
+      querySelector: () => spacer,
+    }
+    const body = { getBoundingClientRect: () => ({ height: 60 }) }
+    let expanded = 'true'
+    const anchor = {
+      parentElement: {},
+      nextElementSibling: body,
+      closest: () => scroller,
+      getAttribute: () => expanded,
+      getBoundingClientRect: () => ({ top: 120 }),
+    }
+
+    preserveTogglePosition(anchor)
+    assert.equal(spacer.style.height, '166px')
+
+    // Re-open before ResizeObserver has replaced the provisional value.
+    expanded = 'false'
+    preserveTogglePosition(anchor)
+    assert.equal(spacer.style.height, '100px')
+
+    // A second fast close reserves one body height, not two.
+    expanded = 'true'
+    preserveTogglePosition(anchor)
+    assert.equal(spacer.style.height, '166px')
+  }
+  finally {
+    globalThis.MutationObserver = originalMutationObserver
+    globalThis.requestAnimationFrame = originalRaf
+    globalThis.getComputedStyle = originalGetComputedStyle
+  }
+})
+
+test('provisional cleanup never overwrites a newer authoritative spacer value', () => {
+  const originalMutationObserver = globalThis.MutationObserver
+  const originalRaf = globalThis.requestAnimationFrame
+  const originalGetComputedStyle = globalThis.getComputedStyle
+  globalThis.MutationObserver = undefined
+  globalThis.requestAnimationFrame = () => 1
+  globalThis.getComputedStyle = () => ({ marginTop: '0px', marginBottom: '0px' })
+
+  try {
+    const spacer = {
+      style: { height: '100px' },
+      get offsetHeight() { return Number.parseFloat(this.style.height) },
+    }
+    const scroller = { scrollTop: 0, querySelector: () => spacer }
+    const body = { getBoundingClientRect: () => ({ height: 60 }) }
+    let expanded = 'true'
+    const anchor = {
+      parentElement: {},
+      nextElementSibling: body,
+      closest: () => scroller,
+      getAttribute: () => expanded,
+      getBoundingClientRect: () => ({ top: 80 }),
+    }
+
+    preserveTogglePosition(anchor)
+    assert.equal(spacer.style.height, '160px')
+
+    // Simulate ResizeObserver publishing new settled geometry.
+    spacer.style.height = '112px'
+    expanded = 'false'
+    preserveTogglePosition(anchor)
+    assert.equal(spacer.style.height, '112px')
+  }
+  finally {
+    globalThis.MutationObserver = originalMutationObserver
+    globalThis.requestAnimationFrame = originalRaf
+    globalThis.getComputedStyle = originalGetComputedStyle
+  }
+})

--- a/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
+++ b/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
@@ -177,22 +177,6 @@ test('only scrolling keys claim reader ownership', () => {
   assert.equal(readerInputMayScroll('touchmove'), true)
 })
 
-test('a disclosure tap does not mistake its collapse clamp for a reader swipe', () => {
-  const disclosureTarget = {
-    closest(selector) {
-      assert.match(selector, /chat__activity-header/)
-      return { className: 'chat__activity-header' }
-    },
-  }
-  const ordinaryTarget = { closest: () => null }
-
-  assert.equal(readerInputMayScroll('pointerdown', '', disclosureTarget), false)
-  assert.equal(readerInputMayScroll('touchstart', '', disclosureTarget), false)
-  assert.equal(readerInputMayScroll('touchmove', '', disclosureTarget), true,
-    'a real drag starting on the disclosure still claims reader ownership')
-  assert.equal(readerInputMayScroll('pointerdown', '', ordinaryTarget), true)
-})
-
 test('inputs without an end event get a next-frame no-scroll release', () => {
   assert.equal(readerInputNeedsFrameRelease('wheel'), true)
   assert.equal(readerInputNeedsFrameRelease('keydown'), true)

--- a/frontend/src/components/ChatView/hooks/__tests__/useVoiceInput.test.js
+++ b/frontend/src/components/ChatView/hooks/__tests__/useVoiceInput.test.js
@@ -1,0 +1,100 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { renderHook } from './react-hook-shim.mjs'
+import useVoiceInput from '../../useVoiceInput.js'
+
+function speechResult(transcript, { final = false, confidence = 1 } = {}) {
+  const result = {
+    0: { transcript, confidence },
+    isFinal: final,
+  }
+  return { resultIndex: 0, results: [result] }
+}
+
+function installSpeechRecognition() {
+  const instances = []
+  class Recognition {
+    constructor() {
+      this.aborted = false
+      instances.push(this)
+    }
+    start() { this.started = true }
+    abort() { this.aborted = true }
+  }
+  globalThis.window = { SpeechRecognition: Recognition }
+  return instances
+}
+
+test('live dictation grows to the composer cap and bottom-anchors its mic', () => {
+  const instances = installSpeechRecognition()
+  const toggles = []
+  const input = {
+    value: '',
+    scrollHeight: 120,
+    style: {},
+    closest: () => ({
+      classList: { toggle: (...args) => toggles.push(args) },
+    }),
+  }
+  const transcripts = []
+  const prevRaf = globalThis.requestAnimationFrame
+  globalThis.requestAnimationFrame = fn => { fn(); return 1 }
+  try {
+    const { result } = renderHook(() => useVoiceInput({
+      onTranscript: text => transcripts.push(text),
+      inputRef: { current: input },
+    }))
+    result.current.startVoice()
+    instances[0].onresult(speechResult('a sufficiently long dictated message'))
+
+    assert.equal(transcripts.at(-1), 'a sufficiently long dictated message')
+    assert.equal(input.style.height, '120px')
+    assert.deepEqual(toggles.at(-1), ['chat__pill--tall', true])
+  } finally {
+    globalThis.requestAnimationFrame = prevRaf
+    delete globalThis.window
+  }
+})
+
+test('a manual edit while listening survives late speech results and rebases dictation', () => {
+  const instances = installSpeechRecognition()
+  const transcripts = []
+  const timers = new Map()
+  let timerId = 0
+  const prevTimeout = globalThis.setTimeout
+  const prevClearTimeout = globalThis.clearTimeout
+  const prevRaf = globalThis.requestAnimationFrame
+  globalThis.setTimeout = fn => {
+    const id = ++timerId
+    timers.set(id, fn)
+    return id
+  }
+  globalThis.clearTimeout = id => timers.delete(id)
+  globalThis.requestAnimationFrame = fn => { fn(); return 1 }
+  try {
+    const input = { value: 'draft', style: {}, scrollHeight: 30, closest: () => null }
+    const { result } = renderHook(() => useVoiceInput({
+      onTranscript: text => transcripts.push(text),
+      inputRef: { current: input },
+    }))
+    result.current.startVoice()
+    const retired = instances[0]
+
+    result.current.acceptManualEdit('draft corrected')
+    assert.equal(retired.aborted, true)
+
+    retired.onresult(speechResult(' stale interim'))
+    assert.deepEqual(transcripts, [], 'an abort-race result cannot overwrite the edit')
+
+    assert.equal(timers.size, 1)
+    timers.values().next().value()
+    const resumed = instances[1]
+    resumed.onresult(speechResult('and more', { final: true }))
+    assert.equal(transcripts.at(-1), 'draft corrected and more')
+  } finally {
+    globalThis.setTimeout = prevTimeout
+    globalThis.clearTimeout = prevClearTimeout
+    globalThis.requestAnimationFrame = prevRaf
+    delete globalThis.window
+  }
+})

--- a/frontend/src/components/ChatView/preserveTogglePosition.js
+++ b/frontend/src/components/ChatView/preserveTogglePosition.js
@@ -1,3 +1,20 @@
+// A fast close→open can happen before ResizeObserver replaces the provisional
+// collapse reservation. Remember the exact baseline so the next toggle can
+// unwind only OUR still-present write instead of stacking another body height
+// on top. WeakMap keeps the bookkeeping DOM-lifetime scoped.
+const provisionalSpacer = new WeakMap()
+
+function unwindProvisionalSpacer(spacer) {
+  const pending = provisionalSpacer.get(spacer)
+  if (!pending) return
+  // If normal layout already wrote a different value, it owns the spacer now;
+  // never roll that authoritative calculation back to our stale baseline.
+  if (Math.abs((spacer.offsetHeight || 0) - pending.primedHeight) <= 1) {
+    spacer.style.height = `${pending.baselineHeight}px`
+  }
+  provisionalSpacer.delete(spacer)
+}
+
 export function preserveTogglePosition(anchorEl) {
   if (!anchorEl || typeof requestAnimationFrame !== 'function') return
   const scroller = anchorEl.closest?.('.chat__scroll')
@@ -10,8 +27,10 @@ export function preserveTogglePosition(anchorEl) {
   // outer height synchronously so total scroll height stays constant across the
   // React commit; the observer replaces this provisional value with its normal
   // spacer calculation on the next layout pass.
+  const spacer = scroller.querySelector?.('.spacer-dynamic')
+  if (spacer) unwindProvisionalSpacer(spacer)
+
   if (anchorEl.getAttribute?.('aria-expanded') === 'true') {
-    const spacer = scroller.querySelector?.('.spacer-dynamic')
     const body = anchorEl.nextElementSibling
     if (spacer && body) {
       const rectHeight = body.getBoundingClientRect?.().height || 0
@@ -22,7 +41,10 @@ export function preserveTogglePosition(anchorEl) {
       const marginBottom = Number.parseFloat(styles?.marginBottom) || 0
       const removedHeight = rectHeight + marginTop + marginBottom
       if (removedHeight > 0) {
-        spacer.style.height = `${(spacer.offsetHeight || 0) + removedHeight}px`
+        const baselineHeight = spacer.offsetHeight || 0
+        const primedHeight = baselineHeight + removedHeight
+        spacer.style.height = `${primedHeight}px`
+        provisionalSpacer.set(spacer, { baselineHeight, primedHeight })
       }
     }
   }

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -534,21 +534,10 @@ export function gestureLayoutRetryDelay(gestureWindowUntil, now) {
 }
 
 
-/** Only input whose default action can move the chat begins reader ownership.
+/** Only keys whose default action can move the chat begin reader ownership.
  * Text entry and activating controls inside a message must not freeze layout
- * until the no-scroll dead-man expires. A disclosure tap is especially
- * important here: collapsing its body can clamp scrollTop and emit a synthetic
- * scroll event. Treating that clamp as the start of a swipe holds the smaller
- * spacer for the 250ms momentum window, so the viewport moves once on collapse
- * and again when layout ownership returns. A real drag that starts on a
- * disclosure still produces touchmove, which claims reader ownership below. */
-export function readerInputMayScroll(type, key = '', target = null) {
-  if ((type === 'pointerdown' || type === 'touchstart')
-      && target?.closest?.(
-        '.chat__activity-header, .chat__tool-header, .chat__marker-header',
-      )) {
-    return false
-  }
+ * until the no-scroll dead-man expires. */
+export function readerInputMayScroll(type, key = '') {
   if (type !== 'keydown') return true
   return [
     'ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End', 'Tab', ' ',
@@ -1441,7 +1430,7 @@ export default function useScrollMode({
       })
     }
     const onUserInput = (event) => {
-      if (!readerInputMayScroll(event?.type, event?.key, event?.target)) return
+      if (!readerInputMayScroll(event?.type, event?.key)) return
       // Input and its first scroll event are ordered, but not guaranteed to be
       // less than 250ms apart under a busy renderer. Keep layout ownership
       // suspended until that first event actually lands; after it, the normal

--- a/frontend/src/components/ChatView/useVoiceInput.js
+++ b/frontend/src/components/ChatView/useVoiceInput.js
@@ -14,8 +14,10 @@ import { useState, useRef, useEffect } from 'react'
  * interim is shown live.
  *
  * Sessions restart on onend (mobile Chrome ends sessions after a few seconds
- * of silence). listeningRef stays true across restart gaps so the onChange
- * guard blocks Chrome's textarea direct-fill throughout.
+ * of silence). Manual textarea edits deliberately retire the current speech
+ * session and restart after a short idle window. That makes the owner's edit
+ * the new authoritative base instead of letting a later interim result
+ * overwrite it.
  *
  * @param {object} options
  * @param {(text: string) => void} options.onTranscript
@@ -31,10 +33,9 @@ import { useState, useRef, useEffect } from 'react'
  *   startVoice: () => void,
  *   stopVoice: () => void,
  *   toggleVoice: () => void,
+ *   acceptManualEdit: (text: string) => void,
  * }}
- *   `listeningRef` is the synchronous mirror of `listening`; gate any
- *   `onChange` handlers on it to block Chrome's OS dictation layer
- *   from racing with `onresult` mid-session.
+ *   `listeningRef` is the synchronous mirror of `listening`.
  */
 export default function useVoiceInput({ onTranscript, inputRef }) {
   const [listening, setListening] = useState(false)
@@ -65,6 +66,9 @@ export default function useVoiceInput({ onTranscript, inputRef }) {
     recognitionRef.current = rec
 
     rec.onresult = (e) => {
+      // A manual edit retires its in-flight recognition object before aborting
+      // it. Ignore any result Chrome delivers during that abort race.
+      if (recognitionRef.current !== rec) return
       let interim = ''
       for (let i = e.resultIndex; i < e.results.length; i++) {
         // Android Chrome bug: duplicate final events fire with confidence=0 — skip them.
@@ -80,12 +84,16 @@ export default function useVoiceInput({ onTranscript, inputRef }) {
       requestAnimationFrame(() => {
         if (inputRef.current) {
           inputRef.current.style.height = 'auto'
-          inputRef.current.style.height = Math.min(inputRef.current.scrollHeight, 160) + 'px'
+          const h = Math.min(inputRef.current.scrollHeight, 280)
+          inputRef.current.style.height = h + 'px'
+          inputRef.current.closest('.chat__pill')
+            ?.classList.toggle('chat__pill--tall', h > 45)
         }
       })
     }
 
     rec.onerror = (e) => {
+      if (recognitionRef.current !== rec) return
       if (e.error === 'not-allowed') {
         listeningRef.current = false
         setListening(false)
@@ -101,6 +109,7 @@ export default function useVoiceInput({ onTranscript, inputRef }) {
     }
 
     rec.onend = () => {
+      if (recognitionRef.current !== rec) return
       recognitionRef.current = null
       if (!listeningRef.current) return  // user stopped — don't restart
       if (voiceFinalRef.current && !voiceFinalRef.current.endsWith(' ')) {
@@ -145,5 +154,36 @@ export default function useVoiceInput({ onTranscript, inputRef }) {
     }
   }
 
-  return { listening, listeningRef, startVoice, stopVoice, toggleVoice }
+  function acceptManualEdit(text) {
+    if (!listeningRef.current) return
+
+    // Preserve the exact owner-edited value as the new dictation base. Add a
+    // separator only inside the speech buffer, so the next spoken word does
+    // not run into the manually typed text.
+    voiceFinalRef.current = text && !text.endsWith(' ') ? text + ' ' : text
+
+    // The current result set may still contain an interim derived from the
+    // pre-edit value. Retire it synchronously before aborting so a late result
+    // cannot clobber the edit, then debounce the replacement session while the
+    // owner is still typing.
+    const rec = recognitionRef.current
+    recognitionRef.current = null
+    rec?.abort()
+    if (restartTimerRef.current !== null) {
+      clearTimeout(restartTimerRef.current)
+    }
+    restartTimerRef.current = setTimeout(() => {
+      restartTimerRef.current = null
+      if (listeningRef.current) startVoiceSession()
+    }, 250)
+  }
+
+  return {
+    listening,
+    listeningRef,
+    startVoice,
+    stopVoice,
+    toggleVoice,
+    acceptManualEdit,
+  }
 }


### PR DESCRIPTION
## Summary
- unwind provisional disclosure spacer writes across rapid close/open cycles without overwriting newer layout geometry
- keep live voice dictation editable by rebasing onto owner changes and rejecting abort-race speech results
- grow dictated composer content to the normal cap and keep the microphone anchored with multiline input

## Review notes
These were complete commits found in the final production audit after PR #82 merged. They were transplanted onto current `main` in a clean worktree; the separate dirty microphone/runtime sibling WIP remains untouched and is not included.

## Verification
- frontend unit/lib: 1,100 passed
- frontend hooks: 46 passed
- production Vite/PWA build passed
- exact committed Docker runtime: `tests/chat-redesign.spec.mjs`, 13 passed
- `git diff --check` passed
