### PR TITLE
Preserve disclosure scroll contract with rapid toggles

### DIFF
--- a/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
+++ b/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
@@ -177,6 +177,22 @@ test('only scrolling keys claim reader ownership', () => {
   assert.equal(readerInputMayScroll('touchmove'), true)
 })
 
+test('a disclosure tap does not mistake its collapse clamp for a reader swipe', () => {
+  const disclosureTarget = {
+    closest(selector) {
+      assert.match(selector, /chat__activity-header/)
+      return { className: 'chat__activity-header' }
+    },
+  }
+  const ordinaryTarget = { closest: () => null }
+
+  assert.equal(readerInputMayScroll('pointerdown', '', disclosureTarget), false)
+  assert.equal(readerInputMayScroll('touchstart', '', disclosureTarget), false)
+  assert.equal(readerInputMayScroll('touchmove', '', disclosureTarget), true,
+    'a real drag starting on the disclosure still claims reader ownership')
+  assert.equal(readerInputMayScroll('pointerdown', '', ordinaryTarget), true)
+})
+
 test('inputs without an end event get a next-frame no-scroll release', () => {
   assert.equal(readerInputNeedsFrameRelease('wheel'), true)
   assert.equal(readerInputNeedsFrameRelease('keydown'), true)

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -534,10 +534,21 @@ export function gestureLayoutRetryDelay(gestureWindowUntil, now) {
 }
 
 
-/** Only keys whose default action can move the chat begin reader ownership.
+/** Only input whose default action can move the chat begins reader ownership.
  * Text entry and activating controls inside a message must not freeze layout
- * until the no-scroll dead-man expires. */
-export function readerInputMayScroll(type, key = '') {
+ * until the no-scroll dead-man expires. A disclosure tap is especially
+ * important here: collapsing its body can clamp scrollTop and emit a synthetic
+ * scroll event. Treating that clamp as the start of a swipe holds the smaller
+ * spacer for the 250ms momentum window, so the viewport moves once on collapse
+ * and again when layout ownership returns. A real drag that starts on a
+ * disclosure still produces touchmove, which claims reader ownership below. */
+export function readerInputMayScroll(type, key = '', target = null) {
+  if ((type === 'pointerdown' || type === 'touchstart')
+      && target?.closest?.(
+        '.chat__activity-header, .chat__tool-header, .chat__marker-header',
+      )) {
+    return false
+  }
   if (type !== 'keydown') return true
   return [
     'ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End', 'Tab', ' ',
@@ -1430,7 +1441,7 @@ export default function useScrollMode({
       })
     }
     const onUserInput = (event) => {
-      if (!readerInputMayScroll(event?.type, event?.key)) return
+      if (!readerInputMayScroll(event?.type, event?.key, event?.target)) return
       // Input and its first scroll event are ordered, but not guaranteed to be
       // less than 250ms apart under a busy renderer. Keep layout ownership
       // suspended until that first event actually lands; after it, the normal


### PR DESCRIPTION
## Summary
- retain the disclosure-target reader-gesture guard added in #82
- keep #84’s rapid-toggle spacer bookkeeping and voice-dictation improvements intact
- restore the regression test that proves a disclosure tap is not treated as a reader swipe, while a real touchmove still is

## Why
The #84 production transplant was applied directly to `main` and accidentally reverted the newer #82 guard. The WeakMap and the guard cover different races: the WeakMap unwinds a provisional spacer on a rapid later toggle; the guard prevents the initiating tap/clamp from deferring the authoritative layout pass and causing a second viewport movement.

## Verification
- frontend library: 1,101 passed
- frontend hooks: 46 passed
- total frontend: 1,147 passed
- production Vite/PWA build passed
- `git diff --check` passed
- exact combined `chat-redesign` disposable-stack run in progress; full exact-head CI required before merge
