### PR TITLE
Preserve disclosure scroll contract after activity UI update

### DIFF
--- a/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
+++ b/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
@@ -177,6 +177,22 @@ test('only scrolling keys claim reader ownership', () => {
   assert.equal(readerInputMayScroll('touchmove'), true)
 })
 
+test('a disclosure tap does not mistake its collapse clamp for a reader swipe', () => {
+  const disclosureTarget = {
+    closest(selector) {
+      assert.match(selector, /chat__activity-header/)
+      return { className: 'chat__activity-header' }
+    },
+  }
+  const ordinaryTarget = { closest: () => null }
+
+  assert.equal(readerInputMayScroll('pointerdown', '', disclosureTarget), false)
+  assert.equal(readerInputMayScroll('touchstart', '', disclosureTarget), false)
+  assert.equal(readerInputMayScroll('touchmove', '', disclosureTarget), true,
+    'a real drag starting on the disclosure still claims reader ownership')
+  assert.equal(readerInputMayScroll('pointerdown', '', ordinaryTarget), true)
+})
+
 test('inputs without an end event get a next-frame no-scroll release', () => {
   assert.equal(readerInputNeedsFrameRelease('wheel'), true)
   assert.equal(readerInputNeedsFrameRelease('keydown'), true)

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -534,10 +534,21 @@ export function gestureLayoutRetryDelay(gestureWindowUntil, now) {
 }
 
 
-/** Only keys whose default action can move the chat begin reader ownership.
+/** Only input whose default action can move the chat begins reader ownership.
  * Text entry and activating controls inside a message must not freeze layout
- * until the no-scroll dead-man expires. */
-export function readerInputMayScroll(type, key = '') {
+ * until the no-scroll dead-man expires. A disclosure tap is especially
+ * important here: collapsing its body can clamp scrollTop and emit a synthetic
+ * scroll event. Treating that clamp as the start of a swipe holds the smaller
+ * spacer for the 250ms momentum window, so the viewport moves once on collapse
+ * and again when layout ownership returns. A real drag that starts on a
+ * disclosure still produces touchmove, which claims reader ownership below. */
+export function readerInputMayScroll(type, key = '', target = null) {
+  if ((type === 'pointerdown' || type === 'touchstart')
+      && target?.closest?.(
+        '.chat__activity-header, .chat__tool-header, .chat__marker-header',
+      )) {
+    return false
+  }
   if (type !== 'keydown') return true
   return [
     'ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End', 'Tab', ' ',
@@ -1430,7 +1441,7 @@ export default function useScrollMode({
       })
     }
     const onUserInput = (event) => {
-      if (!readerInputMayScroll(event?.type, event?.key)) return
+      if (!readerInputMayScroll(event?.type, event?.key, event?.target)) return
       // Input and its first scroll event are ordered, but not guaranteed to be
       // less than 250ms apart under a busy renderer. Keep layout ownership
       // suspended until that first event actually lands; after it, the normal


### PR DESCRIPTION
## Summary
- restore the disclosure-target gesture guard after the production rapid-toggle spacer update
- retain the newer per-message WeakMap spacer bookkeeping unchanged
- add regression coverage proving a disclosure tap does not transfer reader-scroll ownership

## Why both mechanisms are required
The WeakMap unwinds provisional spacer state during a later rapid toggle. The gesture guard handles the earlier phase: the initiating disclosure tap must not be classified as reader scrolling, which would defer authoritative layout and allow a second movement. They cover separate races and are complementary.

## Reviewed sibling integration
This branch is based on `32ad6f441` (settled activity labels and type glyphs). That sibling UI change was reviewed for live/settled/failure precedence, ordering, accessibility, unknown-tool fallback, and casing; its focused tests pass on this combined tree.

## Verification
- 1,103 frontend lib tests passed
- 46 frontend hook tests passed
- 1,149 frontend tests total
- production Vite/PWA build passed
- pre-push repository gates passed

An exact combined-tree Playwright run and full GitHub CI are being completed before merge.