### PR TITLE
Harden split-pane workspace lifecycle and compact UX

### DIFF
--- a/frontend/public/app-frame.html
+++ b/frontend/public/app-frame.html
@@ -474,6 +474,8 @@
     //   6. parent posts {type:'moebius:frame-interactivity', interactive}
     //      whenever a shell modal (currently the navigation drawer) suspends or
     //      restores direct input without unpainting/reloading the app.
+    //   7. pointer input posts {type:'moebius:frame-focus'} so the shell can focus
+    //      this app's pane; iframe events do not bubble into the parent wrapper.
     //
     // Origin check: the opaque iframe still sees the parent shell's concrete
     // origin on incoming postMessage events and rejects every other sender.
@@ -507,6 +509,10 @@
           gestureScrollers.add(node);
         }
       }
+    }
+
+    function notifyParentFocus() {
+      window.parent.postMessage({ type: 'moebius:frame-focus' }, window.location.origin);
     }
 
     function cancelScrollerMomentum(element) {
@@ -563,6 +569,7 @@
 
     document.addEventListener('touchstart', rememberGestureScrollers, { capture: true, passive: true });
     document.addEventListener('pointerdown', rememberGestureScrollers, { capture: true, passive: true });
+    document.addEventListener('pointerdown', notifyParentFocus, { capture: true, passive: true });
     document.addEventListener('wheel', rememberGestureScrollers, { capture: true, passive: true });
 
     function renderMountedComponent() {

--- a/frontend/src/components/AppCanvas/AppCanvas.jsx
+++ b/frontend/src/components/AppCanvas/AppCanvas.jsx
@@ -102,9 +102,14 @@ import './AppCanvas.css'
 //      without inventing app-specific deep links.
 //
 //   7. moebius:microphone-*                                bidirectional
-//      Opaque frames cannot call getUserMedia themselves. The visible, active
+//      Opaque frames cannot call getUserMedia themselves. A visible
 //      frame requests a bounded capture; the trusted shell records mono PCM and
 //      transfers only those samples back to that exact contentWindow.
+//
+//   8. {type: 'moebius:frame-focus'}                       frame → parent
+//      Pointer input inside an opaque iframe cannot bubble into its positioned
+//      shell wrapper. The live frame signals the parent so its pane becomes the
+//      focused owner of keyboard and immersive state.
 //
 // Shell-level messages (handled by Shell.jsx, NOT this file):
 //   - {type: 'moebius:app-error', appId, error, chatId?}    frame → shell
@@ -237,11 +242,6 @@ export default function AppCanvas({
   //     freshly-promoted rebuild) steals chrome/insets from the app on screen.
   // Defaults true so any caller that omits it keeps apps un-paused (back-compat).
   active = true,
-  // Whether the live frame may receive direct interaction. This differs from
-  // `active` while the shell drawer is open: the app remains the visible canvas
-  // behind the scrim, but Android compositor momentum inside a long iframe must
-  // be cancelled so the background cannot keep coasting under the drawer.
-  interactive = active,
   // Whether this app is the active tab of ANY visible pane (design §5). Drives
   // the frame-visibility signal and the nav-push gate — an app visible in a
   // background split still runs and can install nested-view sentinels. `active`
@@ -249,8 +249,13 @@ export default function AppCanvas({
   // safe-area insets + the immersive holder (global last-writer-wins). Defaults
   // to `active` so a single-pane caller (where visible === focused) is unchanged.
   visible = active,
+  // Whether the live frame may receive direct interaction. This differs from
+  // `visible` while the shell drawer is open: each pane remains painted behind
+  // the scrim, but compositor momentum inside its iframe must be cancelled so
+  // background content cannot keep coasting beneath the drawer.
+  interactive = visible,
   pendingIntent = null,
-  onNavPush, onNavPop, onNavReset, onImmersive, onIntentDelivered, onAppError,
+  onNavPush, onNavPop, onNavReset, onAppFocus, onImmersive, onIntentDelivered, onAppError,
 }) {
   const queryClient = useQueryClient()
   const [serviceSurface, setServiceSurface] = useState(null)
@@ -364,6 +369,10 @@ export default function AppCanvas({
           if (v === liveVersionRef.current && capture?.sourceVersion === v) {
             cancelMicrophoneCapture(microphoneCaptureRef)
           }
+          // A service-surface takeover can remove the live iframe without
+          // unmounting AppCanvas or advancing the buffered version. Retire its
+          // host sentinels at this exhaustive document-removal boundary too.
+          if (v === liveVersionRef.current) onNavReset?.(appId)
           framesRef.current.delete(v)
           loadedDocsRef.current.delete(v)
           frameImmersiveRef.current.delete(v)
@@ -592,6 +601,11 @@ export default function AppCanvas({
       // directly — it is the verified sender window.
       if (srcVersion !== liveVersionRef.current) return
 
+      if (msg.type === 'moebius:frame-focus') {
+        onAppFocus?.(appId)
+        return
+      }
+
       if (msg.type === 'moebius:microphone-start') {
         // Reject, rather than truncate, an invalid correlation id. Truncation
         // makes every response impossible for the requesting runtime to match.
@@ -599,7 +613,7 @@ export default function AppCanvas({
           ? msg.requestId
           : ''
         const sourceWindow = e.source
-        if (!activeRef.current || !requestId) return
+        if (!visibleRef.current || !requestId) return
         if (microphoneCaptureRef.current) {
           sourceWindow.postMessage({
             type: 'moebius:microphone-error', requestId,
@@ -620,7 +634,7 @@ export default function AppCanvas({
               onLevel(level) {
                 if (microphoneCaptureRef.current !== pending
                     || pending.cancelled
-                    || !activeRef.current
+                    || !visibleRef.current
                     || pending.sourceVersion !== liveVersionRef.current) return
                 sourceWindow.postMessage({
                   type: 'moebius:microphone-level', requestId, level,
@@ -630,7 +644,7 @@ export default function AppCanvas({
             pending.control = control
             if (microphoneCaptureRef.current !== pending
                 || pending.cancelled
-                || !activeRef.current
+                || !visibleRef.current
                 || pending.sourceVersion !== liveVersionRef.current) {
               control.done.catch(() => {})
               control.cancel()
@@ -645,7 +659,7 @@ export default function AppCanvas({
             const result = await control.done
             const mayDeliver = microphoneCaptureRef.current === pending
               && !pending.cancelled
-              && activeRef.current
+              && visibleRef.current
               && pending.sourceVersion === liveVersionRef.current
             if (microphoneCaptureRef.current === pending) microphoneCaptureRef.current = null
             if (!mayDeliver) return
@@ -664,7 +678,7 @@ export default function AppCanvas({
           } catch (error) {
             const mayDeliver = microphoneCaptureRef.current === pending
               && !pending.cancelled
-              && activeRef.current
+              && visibleRef.current
               && pending.sourceVersion === liveVersionRef.current
             if (microphoneCaptureRef.current === pending) microphoneCaptureRef.current = null
             if (!mayDeliver || error?.name === 'AbortError') return
@@ -765,19 +779,19 @@ export default function AppCanvas({
     }
     window.addEventListener('message', onMessage)
     return () => window.removeEventListener('message', onMessage)
-  }, [appId, appSlug, onNavPush, onNavPop, onImmersive, onAppError, queryClient])
+  }, [appId, appSlug, onNavPush, onNavPop, onAppFocus, onImmersive, onAppError, queryClient])
 
   // Captures belong to the exact visible document that requested them. Cancel
-  // before paint when the canvas becomes hidden or a buffered build is
+  // before paint when the canvas leaves every visible pane or a buffered build is
   // promoted. A still-mounted hidden frame receives only the correlated
   // AbortError needed to settle its runtime session; samples and unrelated
   // permission errors remain gated out.
   useLayoutEffect(() => {
     const capture = microphoneCaptureRef.current
     if (!capture) return
-    if (active && capture.sourceVersion === swap.liveVersion) return
-    cancelMicrophoneCapture(microphoneCaptureRef, { notifyFrame: !active })
-  }, [active, swap.liveVersion])
+    if (visible && capture.sourceVersion === swap.liveVersion) return
+    cancelMicrophoneCapture(microphoneCaptureRef, { notifyFrame: !visible })
+  }, [visible, swap.liveVersion])
 
   useLayoutEffect(() => () => {
     cancelMicrophoneCapture(microphoneCaptureRef)
@@ -851,7 +865,7 @@ export default function AppCanvas({
   // shell count is 0, _anyAppHasSentinels returns false so popstate skips
   // interception and back-gestures through orphan history entries fall through
   // to native handling.
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!appId) return
     return () => { onNavReset?.(appId) }
   }, [appId, swap.liveVersion, onNavReset])
@@ -984,7 +998,7 @@ export default function AppCanvas({
     postToFrame(v, { type: 'moebius:frame-visibility', visible })
   }
 
-  function sendInteractivity(v, enabled, visible = activeRef.current) {
+  function sendInteractivity(v, enabled, visible = visibleRef.current) {
     postToFrame(v, {
       type: 'moebius:frame-interactivity',
       interactive: enabled,
@@ -1006,13 +1020,10 @@ export default function AppCanvas({
   // coast visibly beneath the newly-open drawer.
   useLayoutEffect(() => {
     if (loadedDocsRef.current.has(swap.liveVersion)) {
-      // "painted" tracks `visible` post active->visible split (the frame is
-      // painted iff it is the active tab of a visible pane); `interactive` stays
-      // the focused-pane, drawer-aware gate for momentum cancellation.
       sendInteractivity(swap.liveVersion, interactive, visible)
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [visible, interactive, swap.liveVersion])
+  }, [interactive, visible, swap.liveVersion])
 
   useEffect(() => {
     for (const v of framesRef.current.keys()) {

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -91,6 +91,12 @@ export default function Shell() {
     )),
   )
   const workspace = workspaceState.ws
+  // A lone workspace tab with no legacy pinned projection is the shell's
+  // implicit home surface. An explicit cold deep link should replace it rather
+  // than turning ordinary navigation into a two-item pinned strip.
+  const replaceImplicitBootTab = legacyOpenTabs.length === 0
+    && Object.keys(workspace.panes).length === 1
+    && paneModel.flatten(workspace).length <= 1
   // Whether a VALID persisted workspace blob booted this session (not a flat-tab
   // fallback). The nav adapter uses it to make the blob authoritative over the
   // legacy shell-reload triple, seeding from that triple only when absent/invalid
@@ -174,6 +180,7 @@ export default function Shell() {
     dispatchWorkspace,
     visiblePaneIds,
     blobValid,
+    replaceImplicitBootTab,
   })
 
   // Settings is a full-workspace overlay (§9) — while it is up we suppress the

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -78,12 +78,16 @@ export default function Shell() {
   // adapter derives its legacy triple from it. Init: forgiving read of the
   // versioned blob (readWorkspaceRaw guards the throwing sessionStorage.getItem
   // before parseWorkspace's own try/catch), else the legacy flat seed.
+  // Capture the legacy projection once. Besides seeding a missing workspace, an
+  // empty value distinguishes the implicit home tab from a strip the user had
+  // actually engaged. The workspace still owns rendering either way.
+  const [legacyOpenTabs] = useState(() => tabModel.readOpenTabs())
   const [workspaceState, dispatchWorkspaceRaw] = useReducer(
     paneModel.workspaceReducer,
     undefined,
     () => paneModel.initialWorkspaceState(paneModel.parseWorkspace(
       paneModel.readWorkspaceRaw(sessionStorage),
-      { fallbackTabs: tabModel.readOpenTabs() },
+      { fallbackTabs: legacyOpenTabs },
     )),
   )
   const workspace = workspaceState.ws
@@ -536,6 +540,14 @@ export default function Shell() {
   // declared above useNavigation). openTabs is the in-order flat walk that
   // today's single top strip renders.
   const openTabs = useMemo(() => paneModel.flatten(workspace), [workspace])
+  // Becoming a two-tab workspace engages the strip; returning to zero resets it.
+  // A single implicit home tab on a fresh session stays visually identical to
+  // the pre-workspace shell. Keep this as a ref so closing from two → one leaves
+  // the remaining explicitly-pinned tab visible, matching the existing contract.
+  const tabStripEngagedRef = useRef(legacyOpenTabs.length > 0)
+  const [, setTabStripVersion] = useState(0)
+  if (openTabs.length >= 2) tabStripEngagedRef.current = true
+  else if (openTabs.length === 0) tabStripEngagedRef.current = false
   // Dual-write on every workspace commit: the versioned blob is authoritative on
   // boot, and the legacy flat key is mirrored for one release so a rolled-back
   // client still finds its tabs. readOpenTabs keeps the LAST MAX_TABS, so the
@@ -544,7 +556,11 @@ export default function Shell() {
     try {
       sessionStorage.setItem(paneModel.STORAGE_KEY, paneModel.serializeWorkspace(workspace))
     } catch { /* private mode / quota — workspace stays in memory only */ }
-    tabModel.writeOpenTabs(paneModel.flattenRollbackPriority(workspace))
+    tabModel.writeOpenTabs(
+      tabStripEngagedRef.current
+        ? paneModel.flattenRollbackPriority(workspace)
+        : [],
+    )
   }, [workspace])
   // navTo now owns the OPEN_TAB dispatch (design §1), so openInTab is only a
   // routed navTo — drawer selections, tab activation, CTA, and protocol opens
@@ -567,8 +583,18 @@ export default function Shell() {
   // Close only the tab; the derived triple follows the workspace, so dropping the
   // focused pane's active tab activates its neighbour (paneModel.closeTab).
   const closeTab = useCallback((kind, id) => {
+    // In the single-pane parity path, closing the sole strip item means
+    // "unpin this surface", not "remove the content currently on screen". The
+    // workspace keeps its implicit authority tab while the legacy projection is
+    // cleared, exactly matching the pre-workspace shell.
+    if (openTabs.length === 1) {
+      tabStripEngagedRef.current = false
+      tabModel.writeOpenTabs([])
+      setTabStripVersion(version => version + 1)
+      return
+    }
     dispatchWorkspace({ type: 'CLOSE_TAB', tabKey: tabModel.tabKey(tabModel.makeTab(kind, id)) })
-  }, [])
+  }, [openTabs.length])
   const placeInWorkspace = useCallback((requestOrRequests) => {
     const requests = Array.isArray(requestOrRequests)
       ? requestOrRequests
@@ -592,7 +618,7 @@ export default function Shell() {
       ),
     })
   }, [activeAppIdRef, activeChatIdRef, activeViewRef])
-  const tabStripVisible = openTabs.length >= 1
+  const tabStripVisible = tabStripEngagedRef.current && openTabs.length >= 1
 
   // tabKey -> { paneId, CONTENT rect } (pane rect minus its strip) of the active
   // tab of each visible pane. A content wrapper matching a key is positioned +
@@ -733,14 +759,21 @@ export default function Shell() {
   // is always offered. The top strip attaches this handler only when the flag is
   // on, so single-pane right-click keeps today's native menu (parity).
   const [tabMenu, setTabMenu] = useState(null)
+  const tabMenuRef = useRef(null)
+  const tabMenuReturnFocusRef = useRef(null)
   const openTabMenu = useCallback((e, tab, paneId) => {
     e.preventDefault()
     const owner = paneId || paneModel.paneOf(workspace, tabModel.tabKey(tab))?.id
     if (!owner) return
+    tabMenuReturnFocusRef.current = e.currentTarget
     setTabMenu({ x: e.clientX, y: e.clientY, tab, tabKey: tabModel.tabKey(tab), paneId: owner })
   }, [workspace])
-  const closeTabMenu = useCallback(() => setTabMenu(null), [])
-  const tabMenuRef = useRef(null)
+  const closeTabMenu = useCallback((restoreFocus = true) => {
+    setTabMenu(null)
+    if (!restoreFocus) return
+    const returnTarget = tabMenuReturnFocusRef.current
+    queueMicrotask(() => returnTarget?.focus?.({ preventScroll: true }))
+  }, [])
   // A context menu must be keyboard-ready when it appears, and pointer
   // coordinates near a viewport edge must not place actions off-screen.
   useLayoutEffect(() => {
@@ -767,15 +800,15 @@ export default function Shell() {
   }, [])
   useEffect(() => {
     if (!tabMenu) return
-    const onDown = (e) => { if (!e.target.closest?.('.workspace__menu')) setTabMenu(null) }
-    const onKey = (e) => { if (e.key === 'Escape') setTabMenu(null) }
+    const onDown = (e) => { if (!e.target.closest?.('.workspace__menu')) closeTabMenu(false) }
+    const onKey = (e) => { if (e.key === 'Escape') closeTabMenu() }
     document.addEventListener('pointerdown', onDown, true)
     document.addEventListener('keydown', onKey, true)
     return () => {
       document.removeEventListener('pointerdown', onDown, true)
       document.removeEventListener('keydown', onKey, true)
     }
-  }, [tabMenu])
+  }, [closeTabMenu, tabMenu])
   // Ids of apps that appeared in the fetched list AFTER this session's
   // baseline — the drawer renders a subtle accent dot until each is opened.
   const [newAppIds, setNewAppIds] = useState(() => new Set())

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -542,12 +542,13 @@ export default function Shell() {
   const openTabs = useMemo(() => paneModel.flatten(workspace), [workspace])
   // Becoming a two-tab workspace engages the strip; returning to zero resets it.
   // A single implicit home tab on a fresh session stays visually identical to
-  // the pre-workspace shell. Keep this as a ref so closing from two → one leaves
-  // the remaining explicitly-pinned tab visible, matching the existing contract.
-  const tabStripEngagedRef = useRef(legacyOpenTabs.length > 0)
-  const [, setTabStripVersion] = useState(0)
-  if (openTabs.length >= 2) tabStripEngagedRef.current = true
-  else if (openTabs.length === 0) tabStripEngagedRef.current = false
+  // the pre-workspace shell. State (rather than a render-time ref mutation) keeps
+  // this safe under replayed or abandoned concurrent renders.
+  const [tabStripEngaged, setTabStripEngaged] = useState(legacyOpenTabs.length > 0)
+  useEffect(() => {
+    if (openTabs.length >= 2) setTabStripEngaged(true)
+    else if (openTabs.length === 0) setTabStripEngaged(false)
+  }, [openTabs.length])
   // Dual-write on every workspace commit: the versioned blob is authoritative on
   // boot, and the legacy flat key is mirrored for one release so a rolled-back
   // client still finds its tabs. readOpenTabs keeps the LAST MAX_TABS, so the
@@ -557,11 +558,11 @@ export default function Shell() {
       sessionStorage.setItem(paneModel.STORAGE_KEY, paneModel.serializeWorkspace(workspace))
     } catch { /* private mode / quota — workspace stays in memory only */ }
     tabModel.writeOpenTabs(
-      tabStripEngagedRef.current
+      tabStripEngaged
         ? paneModel.flattenRollbackPriority(workspace)
         : [],
     )
-  }, [workspace])
+  }, [tabStripEngaged, workspace])
   // navTo now owns the OPEN_TAB dispatch (design §1), so openInTab is only a
   // routed navTo — drawer selections, tab activation, CTA, and protocol opens
   // all go through navTo and therefore cannot bypass workspace ownership.
@@ -588,9 +589,8 @@ export default function Shell() {
     // workspace keeps its implicit authority tab while the legacy projection is
     // cleared, exactly matching the pre-workspace shell.
     if (openTabs.length === 1) {
-      tabStripEngagedRef.current = false
+      setTabStripEngaged(false)
       tabModel.writeOpenTabs([])
-      setTabStripVersion(version => version + 1)
       return
     }
     dispatchWorkspace({ type: 'CLOSE_TAB', tabKey: tabModel.tabKey(tabModel.makeTab(kind, id)) })
@@ -618,7 +618,7 @@ export default function Shell() {
       ),
     })
   }, [activeAppIdRef, activeChatIdRef, activeViewRef])
-  const tabStripVisible = tabStripEngagedRef.current && openTabs.length >= 1
+  const tabStripVisible = tabStripEngaged && openTabs.length >= 1
 
   // tabKey -> { paneId, CONTENT rect } (pane rect minus its strip) of the active
   // tab of each visible pane. A content wrapper matching a key is positioned +

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useState, useEffect, useCallback, useMemo, useReducer, useRef } from 'react'
+import { lazy, Suspense, useState, useEffect, useLayoutEffect, useCallback, useMemo, useReducer, useRef } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { Minimize2, X, MessageSquare, AppWindow } from 'lucide-react'
 import Drawer from '../Drawer/Drawer.jsx'
@@ -740,6 +740,31 @@ export default function Shell() {
     setTabMenu({ x: e.clientX, y: e.clientY, tab, tabKey: tabModel.tabKey(tab), paneId: owner })
   }, [workspace])
   const closeTabMenu = useCallback(() => setTabMenu(null), [])
+  const tabMenuRef = useRef(null)
+  // A context menu must be keyboard-ready when it appears, and pointer
+  // coordinates near a viewport edge must not place actions off-screen.
+  useLayoutEffect(() => {
+    if (!tabMenu || !tabMenuRef.current) return
+    const menu = tabMenuRef.current
+    const rect = menu.getBoundingClientRect()
+    const gutter = 8
+    menu.style.left = `${Math.max(gutter, Math.min(tabMenu.x, window.innerWidth - rect.width - gutter))}px`
+    menu.style.top = `${Math.max(gutter, Math.min(tabMenu.y, window.innerHeight - rect.height - gutter))}px`
+    menu.querySelector('[role="menuitem"]')?.focus()
+  }, [tabMenu])
+  const handleTabMenuKeyDown = useCallback((e) => {
+    const items = [...(tabMenuRef.current?.querySelectorAll('[role="menuitem"]') || [])]
+    if (items.length === 0) return
+    const current = Math.max(0, items.indexOf(document.activeElement))
+    let next = null
+    if (e.key === 'ArrowDown') next = (current + 1) % items.length
+    else if (e.key === 'ArrowUp') next = (current - 1 + items.length) % items.length
+    else if (e.key === 'Home') next = 0
+    else if (e.key === 'End') next = items.length - 1
+    if (next == null) return
+    e.preventDefault()
+    items[next].focus()
+  }, [])
   useEffect(() => {
     if (!tabMenu) return
     const onDown = (e) => { if (!e.target.closest?.('.workspace__menu')) setTabMenu(null) }
@@ -2343,7 +2368,14 @@ export default function Shell() {
         const canOfferSplit = paneModel.WORKSPACE_SPLITS_ENABLED
           && menuPane && menuPane.tabs.length >= 2
         return (
-          <div className="workspace__menu" role="menu" style={{ left: tabMenu.x, top: tabMenu.y }}>
+          <div
+            ref={tabMenuRef}
+            className="workspace__menu"
+            role="menu"
+            aria-label="Tab actions"
+            style={{ left: tabMenu.x, top: tabMenu.y }}
+            onKeyDown={handleTabMenuKeyDown}
+          >
             {canOfferSplit && [
               ['right', 'Split right'], ['left', 'Split left'],
               ['top', 'Split up'], ['bottom', 'Split down'],

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -553,6 +553,17 @@ export default function Shell() {
     const { view, opts } = tabModel.tabNavTarget(tabModel.makeTab(kind, id))
     navTo(view, paneId ? { ...opts, paneId } : opts)
   }, [navTo])
+  // Pointer events inside an iframe do not bubble to its positioned shell
+  // wrapper. The verified live frame sends a tiny focus signal so app panes have
+  // the same click-to-focus semantics as native chat panes.
+  const focusAppPane = useCallback((appId) => {
+    const ws = workspaceStateRef.current.ws
+    const pane = paneModel.paneOf(
+      ws,
+      tabModel.tabKey(tabModel.makeTab('app', appId)),
+    )
+    if (pane) dispatchWorkspace({ type: 'FOCUS', paneId: pane.id })
+  }, [dispatchWorkspace])
   // Close only the tab; the derived triple follows the workspace, so dropping the
   // focused pane's active tab activates its neighbour (paneModel.closeTab).
   const closeTab = useCallback((kind, id) => {
@@ -648,23 +659,16 @@ export default function Shell() {
     return out.sort((a, b) => String(a.chatId).localeCompare(String(b.chatId)))
   }, [projection, workspace])
 
-  // The rendered set as of the last derivation — the baseline the next derivation
-  // diffs against to identify eviction victims.
-  const prevRenderedRef = useRef(new Set())
-
   // ── Synchronous pinned iframe-cache derivation (design §2/§4) ─────────────
   // renderedAppIds = sortById(visibleAppIds ∪ boundedWarmLRU). Visible ids come
   // from the projection REGARDLESS of LRU membership and are never evicted, so a
   // MOVE_TAB that makes a never-visited app visible materializes its wrapper in
   // the SAME commit — no post-commit effect, no blank pane (finding B). The set is
   // bounded by APP_CACHE_MAX so it never renders five frames to preserve history
-  // (§4.1.4). Eviction victims are RETIRED here, synchronously in the derivation,
-  // BEFORE this render commits and unmounts their iframes (contract §4.1.2): any
-  // app that was rendered, is not in the new set, and is not still visible is
-  // losing its frame this commit, so its physical entries are marked consumed
-  // before the unmount — the orphan-Back hazard is closed without waiting for the
-  // AppCanvas cleanup backstop. retireAppHistory is idempotent, so the StrictMode
-  // double-render and the onNavReset unmount backstop are both no-ops.
+  // (§4.1.4). AppCanvas retires physical history in a layout-effect cleanup as a
+  // live frame is swapped or unmounted. Keeping retirement out of this derivation
+  // is load-bearing: React may replay or abandon a render, and render-time registry
+  // mutation would retire a frame that remains committed.
   const renderedAppIds = useMemo(() => {
     const result = new Set()
     for (const id of visibleAppIds) result.add(String(id))
@@ -672,21 +676,15 @@ export default function Shell() {
       if (result.size >= APP_CACHE_MAX) break
       result.add(String(id))
     }
-    for (const id of prevRenderedRef.current) {
-      if (!result.has(id) && !visibleAppIds.has(id)) retireAppHistory(id, 'evict')
-    }
-    prevRenderedRef.current = result
     return [...result].sort((a, b) => Number(a) - Number(b))
-    // warmVersion re-derives the set when the warm LRU changes; retireAppHistory
-    // is stable.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [visibleAppIds, warmVersion])
 
   // Maintain the warm LRU as the visible set changes: currently-visible apps are
   // the most-recent entries, and a just-hidden app slides into the warm remainder
   // (capped). Retirement is NOT done here — it happens synchronously in the
   // derivation above, before the unmount (§4.1.2). This effect only rotates the
-  // bounded warm list and bumps the version so the memo re-derives.
+  // bounded warm list and bumps the version so the memo re-derives. AppCanvas's
+  // layout cleanup owns retirement when a resulting eviction actually commits.
   useEffect(() => {
     const visible = [...visibleAppIds].map(String)
     const prevWarm = warmLruRef.current
@@ -2209,16 +2207,15 @@ export default function Shell() {
               // Focused-pane-only: gates safe-area insets + the immersive holder
               // (global last-writer-wins). Single-pane: active === visible.
               active={tabKey === focusedActiveKey}
-              // Painted beneath the drawer scrim but NON-interactive while the
-              // drawer is open, so Android kinetic momentum already in flight is
-              // cancelled (not just new pointer hits, which inert/pointer-events
-              // already block) — sibling 79952de27, re-expressed in workspace
-              // terms: the focused canvas, minus drawer-open.
-              interactive={tabKey === focusedActiveKey && !drawerOpen}
               // Visible in ANY pane: gates frame-visibility + nav-push (§5). A
               // background split's app keeps running and can install sentinels;
               // Settings/immersive-solo/hidden panes exclude it (visibleAppIds).
               visible={visibleAppIds.has(String(id))}
+              // Every visible pane remains painted beneath the modal scrim, but
+              // suspend its iframe interaction while the drawer is open. This
+              // cancels kinetic scrolling already in flight, in addition to the
+              // shell blocking new pointer input.
+              interactive={visibleAppIds.has(String(id)) && !drawerOpen}
               version={versionForApp(id)}
               appName={app?.name}
               appSlug={app?.slug}
@@ -2228,6 +2225,7 @@ export default function Shell() {
               onNavPush={appNavPush}
               onNavPop={appNavPop}
               onNavReset={appNavReset}
+              onAppFocus={focusAppPane}
               onImmersive={handleImmersive}
               onIntentDelivered={handleAppIntentDelivered}
               onAppError={handleAppError}

--- a/frontend/src/components/Shell/WorkspaceChrome.jsx
+++ b/frontend/src/components/Shell/WorkspaceChrome.jsx
@@ -315,8 +315,9 @@ export default function WorkspaceChrome({
           type="button"
           className="workspace__pane-chip"
           style={{ left: chipHostRect.x + chipHostRect.w - 60, top: chipHostRect.y + 5 }}
-          aria-haspopup="dialog"
-          aria-expanded={sheetOpen}
+        aria-haspopup="dialog"
+        aria-expanded={sheetOpen}
+        aria-label={`Show panes, ${projection.visibleLeaves.length} of ${allLeaves.length} visible`}
           onClick={() => setSheetOpen(true)}
         >
           <Layers size={13} aria-hidden="true" />

--- a/frontend/src/components/Shell/WorkspaceChrome.jsx
+++ b/frontend/src/components/Shell/WorkspaceChrome.jsx
@@ -1,10 +1,11 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { MessageSquare, AppWindow, X, Layers } from 'lucide-react'
 import * as tabModel from './tabModel.js'
 import {
   projectLayout, STRIP_H, WORKSPACE_SPLITS_ENABLED,
 } from './paneModel.js'
 import { ARROW_STEP_RATIO } from '../../lib/splitHelper.js'
+import useDialogFocus from '../../hooks/useDialogFocus.js'
 
 // The chrome layer for a tiled (≥2 visible leaves) workspace (design §2). It is
 // a sibling AFTER the flat content wrappers, absolute inset:0, pointer-events
@@ -137,6 +138,15 @@ export default function WorkspaceChrome({
   onTabContextMenu,
 }) {
   const [sheetOpen, setSheetOpen] = useState(false)
+  const sheetRef = useRef(null)
+  const sheetCloseRef = useRef(null)
+  const closeSheet = useCallback(() => setSheetOpen(false), [])
+  useDialogFocus({
+    open: sheetOpen,
+    containerRef: sheetRef,
+    initialFocusRef: sheetCloseRef,
+    onClose: closeSheet,
+  })
 
   const focusPane = useCallback((paneId) => {
     dispatchWorkspace({ type: 'FOCUS', paneId })
@@ -256,7 +266,7 @@ export default function WorkspaceChrome({
     && hasOverflow
 
   const pickPane = useCallback((paneId) => {
-    setSheetOpen(false)
+    closeSheet()
     const pane = workspace.panes[paneId]
     const active = pane?.tabs.find(t => tabModel.tabKey(t) === pane.activeTabKey)
     if (active) {
@@ -265,7 +275,7 @@ export default function WorkspaceChrome({
     } else {
       dispatchWorkspace({ type: 'FOCUS', paneId })
     }
-  }, [dispatchWorkspace, navTo, workspace.panes])
+  }, [closeSheet, dispatchWorkspace, navTo, workspace.panes])
 
   const focusRect = projection.rects[workspace.focusedPaneId]
   const chipHostRect = focusRect || projection.rects[projection.visibleLeaves[0]]
@@ -315,9 +325,9 @@ export default function WorkspaceChrome({
           type="button"
           className="workspace__pane-chip"
           style={{ left: chipHostRect.x + chipHostRect.w - 60, top: chipHostRect.y + 5 }}
-        aria-haspopup="dialog"
-        aria-expanded={sheetOpen}
-        aria-label={`Show panes, ${projection.visibleLeaves.length} of ${allLeaves.length} visible`}
+          aria-haspopup="dialog"
+          aria-expanded={sheetOpen}
+          aria-label={`Show panes, ${projection.visibleLeaves.length} of ${allLeaves.length} visible`}
           onClick={() => setSheetOpen(true)}
         >
           <Layers size={13} aria-hidden="true" />
@@ -326,14 +336,27 @@ export default function WorkspaceChrome({
       )}
 
       {showChip && sheetOpen && (
-        <div className="workspace__sheet-scrim" onPointerDown={() => setSheetOpen(false)}>
+        <div className="workspace__sheet-scrim" onPointerDown={closeSheet}>
           <div
+            ref={sheetRef}
             className="workspace__sheet"
             role="dialog"
+            aria-modal="true"
             aria-label="Switch pane"
             onPointerDown={(e) => e.stopPropagation()}
           >
-            <div className="workspace__sheet-title">Panes</div>
+            <div className="workspace__sheet-head">
+              <div className="workspace__sheet-title">Panes</div>
+              <button
+                ref={sheetCloseRef}
+                type="button"
+                className="workspace__sheet-close"
+                aria-label="Close pane switcher"
+                onClick={closeSheet}
+              >
+                <X size={16} aria-hidden="true" />
+              </button>
+            </div>
             {allLeaves.map(paneId => {
               const pane = workspace.panes[paneId]
               const active = pane?.tabs.find(t => tabModel.tabKey(t) === pane.activeTabKey)

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -35,12 +35,12 @@ test('the compact pane switcher describes its visible pane count', () => {
 })
 
 test('an implicit home tab does not engage the single-pane tab strip', () => {
-  assert.match(shell, /const tabStripEngagedRef = useRef\(legacyOpenTabs\.length > 0\)/)
-  assert.match(shell, /if \(openTabs\.length >= 2\) tabStripEngagedRef\.current = true/)
-  assert.match(shell, /else if \(openTabs\.length === 0\) tabStripEngagedRef\.current = false/)
-  assert.match(shell, /const tabStripVisible = tabStripEngagedRef\.current && openTabs\.length >= 1/)
-  assert.match(shell, /tabStripEngagedRef\.current[\s\S]*?paneModel\.flattenRollbackPriority\(workspace\)[\s\S]*?: \[\]/)
-  assert.match(shell, /if \(openTabs\.length === 1\) \{[\s\S]*?tabStripEngagedRef\.current = false[\s\S]*?tabModel\.writeOpenTabs\(\[\]\)/)
+  assert.match(shell, /const \[tabStripEngaged, setTabStripEngaged\] = useState\(legacyOpenTabs\.length > 0\)/)
+  assert.match(shell, /if \(openTabs\.length >= 2\) setTabStripEngaged\(true\)/)
+  assert.match(shell, /else if \(openTabs\.length === 0\) setTabStripEngaged\(false\)/)
+  assert.match(shell, /const tabStripVisible = tabStripEngaged && openTabs\.length >= 1/)
+  assert.match(shell, /tabStripEngaged[\s\S]*?paneModel\.flattenRollbackPriority\(workspace\)[\s\S]*?: \[\]/)
+  assert.match(shell, /if \(openTabs\.length === 1\) \{[\s\S]*?setTabStripEngaged\(false\)[\s\S]*?tabModel\.writeOpenTabs\(\[\]\)/)
 })
 
 test('the pane switcher uses the shared modal focus and dismissal contract', () => {

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -31,3 +31,10 @@ test('the workspace menu is labeled, edge-clamped, and arrow-key navigable', () 
 test('the compact pane switcher describes its visible pane count', () => {
   assert.match(chrome, /aria-label=\{`Show panes, \$\{projection\.visibleLeaves\.length\} of \$\{allLeaves\.length\} visible`\}/)
 })
+
+test('the pane switcher uses the shared modal focus and dismissal contract', () => {
+  assert.match(chrome, /useDialogFocus\(\{[\s\S]*?open: sheetOpen/)
+  assert.match(chrome, /initialFocusRef: sheetCloseRef/)
+  assert.match(chrome, /aria-modal="true"/)
+  assert.match(chrome, /aria-label="Close pane switcher"/)
+})

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -26,10 +26,21 @@ test('the workspace menu is labeled, edge-clamped, and arrow-key navigable', () 
   assert.match(shell, /window\.innerWidth - rect\.width - gutter/)
   assert.match(shell, /e\.key === 'ArrowDown'/)
   assert.match(shell, /querySelector\('\[role="menuitem"\]'\)\?\.focus\(\)/)
+  assert.match(shell, /tabMenuReturnFocusRef\.current = e\.currentTarget/)
+  assert.match(shell, /returnTarget\?\.focus\?\.\(\{ preventScroll: true \}\)/)
 })
 
 test('the compact pane switcher describes its visible pane count', () => {
   assert.match(chrome, /aria-label=\{`Show panes, \$\{projection\.visibleLeaves\.length\} of \$\{allLeaves\.length\} visible`\}/)
+})
+
+test('an implicit home tab does not engage the single-pane tab strip', () => {
+  assert.match(shell, /const tabStripEngagedRef = useRef\(legacyOpenTabs\.length > 0\)/)
+  assert.match(shell, /if \(openTabs\.length >= 2\) tabStripEngagedRef\.current = true/)
+  assert.match(shell, /else if \(openTabs\.length === 0\) tabStripEngagedRef\.current = false/)
+  assert.match(shell, /const tabStripVisible = tabStripEngagedRef\.current && openTabs\.length >= 1/)
+  assert.match(shell, /tabStripEngagedRef\.current[\s\S]*?paneModel\.flattenRollbackPriority\(workspace\)[\s\S]*?: \[\]/)
+  assert.match(shell, /if \(openTabs\.length === 1\) \{[\s\S]*?tabStripEngagedRef\.current = false[\s\S]*?tabModel\.writeOpenTabs\(\[\]\)/)
 })
 
 test('the pane switcher uses the shared modal focus and dismissal contract', () => {

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -6,6 +6,8 @@ const css = readFileSync(
   new URL('../workspace.css', import.meta.url),
   'utf8',
 )
+const shell = readFileSync(new URL('../Shell.jsx', import.meta.url), 'utf8')
+const chrome = readFileSync(new URL('../WorkspaceChrome.jsx', import.meta.url), 'utf8')
 
 test('the phone pane switcher keeps a 44px touch target', () => {
   const rule = css.match(/\.workspace__pane-chip\s*\{[\s\S]*?\}/)?.[0] || ''
@@ -17,4 +19,15 @@ test('the workspace menu avoids an oversized border-and-shadow card', () => {
   assert.match(rule, /border:\s*1px/)
   assert.match(rule, /box-shadow:\s*0 4px 8px/)
   assert.doesNotMatch(rule, /box-shadow:[^;]*(?:1[6-9]|[2-9]\d)px/)
+})
+
+test('the workspace menu is labeled, edge-clamped, and arrow-key navigable', () => {
+  assert.match(shell, /aria-label="Tab actions"/)
+  assert.match(shell, /window\.innerWidth - rect\.width - gutter/)
+  assert.match(shell, /e\.key === 'ArrowDown'/)
+  assert.match(shell, /querySelector\('\[role="menuitem"\]'\)\?\.focus\(\)/)
+})
+
+test('the compact pane switcher describes its visible pane count', () => {
+  assert.match(chrome, /aria-label=\{`Show panes, \$\{projection\.visibleLeaves\.length\} of \$\{allLeaves\.length\} visible`\}/)
 })

--- a/frontend/src/components/Shell/workspace.css
+++ b/frontend/src/components/Shell/workspace.css
@@ -136,11 +136,36 @@
   to { transform: translateY(0); }
 }
 
+.workspace__sheet-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 44px;
+}
 .workspace__sheet-title {
   font-size: 12px;
   font-weight: 600;
   color: var(--muted);
-  padding: 4px 8px 8px;
+  padding: 4px 8px;
+}
+.workspace__sheet-close {
+  display: grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+}
+.workspace__sheet-close:hover {
+  background: color-mix(in srgb, var(--text) 8%, transparent);
+  color: var(--text);
+}
+.workspace__sheet-close:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
 }
 .workspace__sheet-row {
   display: flex;

--- a/frontend/src/hooks/useNavigation.js
+++ b/frontend/src/hooks/useNavigation.js
@@ -306,6 +306,13 @@ export default function useNavigation({
   const consumeAppEntry = useCallback((entryId, ownerKey) => {
     if (!entryId) return
     const rec = appEntryOwnersRef.current.get(entryId)
+    // Consumption is idempotent. A Forward→Back traversal or a synthetic/user
+    // race can revisit an already-consumed physical entry; it must not decrement
+    // a different still-live level owned by the same pane/app.
+    if (!rec || rec.status !== 'live') {
+      consumedAppEntryIdsRef.current.add(entryId)
+      return
+    }
     const key = ownerKey || (rec ? ownerKeyOf(rec.paneId, rec.appId) : null)
     if (key) {
       const m = appSentinelCountsRef.current
@@ -371,6 +378,9 @@ export default function useNavigation({
   }, [])
 
   function openDrawer() {
+    // Synchronous guard for a rapid double activation before React has rendered
+    // `drawerOpen=true`. One drawer owns exactly one physical sentinel.
+    if (drawerOpenRef.current) return
     // Do not let a just-issued app history traversal consume a drawer entry
     // pushed after it began. Preserve the user's intent and open once the
     // serialized local-pop pump is idle.
@@ -823,21 +833,39 @@ export default function useNavigation({
         setTimeout(resumeLocalAppPops, 0)
         return
       }
-      // (4) Ordinary app sentinel, routed by the popped source's own tag: forward
-      // moebius:nav-back to that app's unique iframe and decrement its owner
-      // count. Focus follows the app to its CURRENT pane (paneOf), but accounting
-      // keeps the physical entry's ORIGINAL owner key even if the tab moved.
+      // (4) Ordinary app sentinel, routed by the popped source's own tag: restore
+      // its cached app into a visible pane when necessary, forward nav-back to
+      // that app's unique iframe, and decrement its owner count. This restoration
+      // is load-bearing for a direct tab close/focus change, which does not create
+      // a shell nav entry above the still-live app sentinel. Accounting keeps the
+      // physical entry's ORIGINAL owner key even if the tab moved.
       if (source?.kind === 'app' && sourceOwner && sourceOwner.appId != null) {
         const ws = workspaceStateRef.current.ws
         const n = appSentinelCountsRef.current.get(sourceOwnerKey) || 0
-        if (isVisibleApp(ws, sourceOwner.appId) && n > 0) {
-          consumeAppEntry(sourceEntryId, sourceOwnerKey)
-          const pane = paneModel.paneOf(ws, tabModel.tabKey(tabModel.makeTab('app', sourceOwner.appId)))
-          if (pane && pane.id !== ws.focusedPaneId) dispatchWorkspace({ type: 'FOCUS', paneId: pane.id })
-          const iframe = document.querySelector(`iframe[data-app-id="${sourceOwner.appId}"]`)
-          if (iframe?.contentWindow) {
-            iframe.contentWindow.postMessage({ type: 'moebius:nav-back' }, '*')
+        const iframe = document.querySelector(`iframe[data-app-id="${sourceOwner.appId}"]`)
+        if (iframe?.contentWindow && n > 0) {
+          let pane = paneModel.paneOf(
+            ws,
+            tabModel.tabKey(tabModel.makeTab('app', sourceOwner.appId)),
+          )
+          if (!isVisibleApp(ws, sourceOwner.appId)) {
+            const paneId = ws.panes[sourceOwner.paneId]
+              ? sourceOwner.paneId
+              : ws.focusedPaneId
+            dispatchWorkspace({
+              type: 'OPEN_TAB', paneId,
+              tab: tabModel.makeTab('app', sourceOwner.appId), activate: true,
+            })
+            pane = paneModel.paneOf(
+              workspaceStateRef.current.ws,
+              tabModel.tabKey(tabModel.makeTab('app', sourceOwner.appId)),
+            )
           }
+          consumeAppEntry(sourceEntryId, sourceOwnerKey)
+          if (pane && pane.id !== workspaceStateRef.current.ws.focusedPaneId) {
+            dispatchWorkspace({ type: 'FOCUS', paneId: pane.id })
+          }
+          iframe.contentWindow.postMessage({ type: 'moebius:nav-back' }, '*')
           // Defensive re-pump (L1): a queued request behind this one can now run.
           setTimeout(resumeLocalAppPops, 0)
           return

--- a/frontend/src/hooks/useNavigation.js
+++ b/frontend/src/hooks/useNavigation.js
@@ -159,6 +159,9 @@ export const coldRestoredCanvasAppId =
  *                       dispatch — so two events in one React batch observe each
  *                       other.
  *   visiblePaneIds      the renderer's committed set of visible pane ids.
+ *   replaceImplicitBootTab
+ *                       true when the only boot tab is the unpinned home
+ *                       surface, which an explicit deep link replaces.
  *
  * Three load-bearing pieces remain: `openDrawer` pushes a sentinel history
  * entry; `navTo` updates internal state + `navStackRef` and does NOT call
@@ -171,6 +174,7 @@ export default function useNavigation({
   dispatchWorkspace,
   visiblePaneIds,
   blobValid,
+  replaceImplicitBootTab,
 }) {
   // Resolve the initial view AND whether HOME must be seeded beneath it as the
   // back-stack root, in ONE place (resolveInitialNav) — enforces "HOME is always
@@ -649,7 +653,7 @@ export default function useNavigation({
   }, [dispatchWorkspace, workspaceStateRef])
 
   useEffect(() => {
-    const bootPaneId = workspaceStateRef.current.ws.focusedPaneId
+    let bootPaneId = workspaceStateRef.current.ws.focusedPaneId
     if (!historyInitializedRef.current) {
       historyInitializedRef.current = true
       // An EXPLICIT deep link (notification tap, PWA launch-at-app) opens its
@@ -661,16 +665,16 @@ export default function useNavigation({
       // a non-empty pane with no blob — so gate on `blobValid` directly. A seeded
       // chat is validated against the live list by Shell's chat-restore effect.
       const bootPaneEmpty = !workspaceStateRef.current.ws.panes[bootPaneId]?.activeTabKey
+      const openBootTab = (tab) => {
+        dispatchWorkspace(replaceImplicitBootTab
+          ? { type: 'RESET_FLAT', tabs: [tab] }
+          : { type: 'OPEN_TAB', paneId: bootPaneId, tab, activate: true })
+        bootPaneId = workspaceStateRef.current.ws.focusedPaneId
+      }
       if (deepLink?.view === 'canvas' && deepLink.appId != null) {
-        dispatchWorkspace({
-          type: 'OPEN_TAB', paneId: bootPaneId,
-          tab: tabModel.makeTab('app', deepLink.appId), activate: true,
-        })
+        openBootTab(tabModel.makeTab('app', deepLink.appId))
       } else if (deepLink?.view === 'chat' && deepLink.chatId) {
-        dispatchWorkspace({
-          type: 'OPEN_TAB', paneId: bootPaneId,
-          tab: tabModel.makeTab('chat', deepLink.chatId), activate: true,
-        })
+        openBootTab(tabModel.makeTab('chat', deepLink.chatId))
       } else if (!blobValid && bootPaneEmpty && initialNav.view === 'canvas' && initialNav.appId != null) {
         dispatchWorkspace({
           type: 'OPEN_TAB', paneId: bootPaneId,

--- a/frontend/src/lib/__tests__/frameInteractivityContract.test.js
+++ b/frontend/src/lib/__tests__/frameInteractivityContract.test.js
@@ -11,17 +11,23 @@ const canvas = readFileSync(resolve(src, 'components/AppCanvas/AppCanvas.jsx'), 
 const shell = readFileSync(resolve(src, 'components/Shell/Shell.jsx'), 'utf8')
 
 test('drawer suspension reaches the live app frame before paint', () => {
-  // The interactive gate is the FOCUSED canvas minus drawer-open. Post the
-  // workspace-reducer refactor (PR2) that is expressed in workspace terms
-  // (tabKey === focusedActiveKey) rather than the legacy activeView/activeAppId
-  // scalars; the behavior (cancel momentum when the drawer opens) is unchanged.
-  assert.match(shell, /interactive=\{tabKey === focusedActiveKey && !drawerOpen\}/)
-  // The layout effect's "painted" argument tracks `visible` after the
-  // active->visible split (a frame is painted iff it is the active tab of a
-  // visible pane); `interactive` stays the focused-pane, drawer-aware gate.
+  assert.match(shell, /interactive=\{visibleAppIds\.has\(String\(id\)\) && !drawerOpen\}/)
   assert.match(canvas, /useLayoutEffect\(\(\) => \{[\s\S]*sendInteractivity\(swap\.liveVersion, interactive, visible\)/)
   assert.match(canvas, /suspendScrolling:\s*visible\s*&&\s*!enabled/)
   assert.match(canvas, /moebius:frame-interactivity/)
+})
+
+test('iframe history retirement runs at the committed layout boundary, never during render', () => {
+  assert.match(
+    canvas,
+    /useLayoutEffect\(\(\) => \{\s*if \(!appId\) return\s*return \(\) => \{ onNavReset\?\.\(appId\) \}/,
+  )
+  const cacheDerivation = shell.slice(
+    shell.indexOf('const renderedAppIds = useMemo'),
+    shell.indexOf('// Maintain the warm LRU'),
+  )
+  assert.ok(cacheDerivation.length > 0)
+  assert.doesNotMatch(cacheDerivation, /retireAppHistory/)
 })
 
 test('frame suspension cancels compositor momentum without changing the resting offset', () => {

--- a/frontend/src/lib/__tests__/microphoneBrokerContract.test.js
+++ b/frontend/src/lib/__tests__/microphoneBrokerContract.test.js
@@ -15,7 +15,7 @@ test('microphone sessions are bound to one live app document', () => {
   assert.match(canvas, /pending\.sourceVersion !== liveVersionRef\.current/)
   assert.match(
     canvas,
-    /useLayoutEffect\(\(\) => \{[\s\S]*?if \(active && capture\.sourceVersion === swap\.liveVersion\) return[\s\S]*?cancelMicrophoneCapture\(microphoneCaptureRef, \{ notifyFrame: !active \}\)[\s\S]*?\}, \[active, swap\.liveVersion\]\)/,
+    /useLayoutEffect\(\(\) => \{[\s\S]*?if \(visible && capture\.sourceVersion === swap\.liveVersion\) return[\s\S]*?cancelMicrophoneCapture\(microphoneCaptureRef, \{ notifyFrame: !visible \}\)[\s\S]*?\}, \[visible, swap\.liveVersion\]\)/,
   )
   assert.match(
     canvas,
@@ -25,6 +25,12 @@ test('microphone sessions are bound to one live app document', () => {
     canvas,
     /if \(v === liveVersionRef\.current && capture\?\.sourceVersion === v\) \{[\s\S]*?cancelMicrophoneCapture\(microphoneCaptureRef\)/,
   )
+})
+
+test('a visible background pane keeps its microphone session', () => {
+  assert.match(canvas, /if \(!visibleRef\.current \|\| !requestId\) return/)
+  assert.doesNotMatch(canvas, /if \(!activeRef\.current \|\| !requestId\) return/)
+  assert.match(canvas, /const mayDeliver = microphoneCaptureRef\.current === pending[\s\S]*?&& visibleRef\.current/)
 })
 
 test('deactivation settles the cached frame without releasing samples to it', () => {

--- a/frontend/src/lib/__tests__/navigationWorkspaceContract.test.js
+++ b/frontend/src/lib/__tests__/navigationWorkspaceContract.test.js
@@ -1,0 +1,52 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const src = resolve(here, '../..')
+const navigation = readFileSync(resolve(src, 'hooks/useNavigation.js'), 'utf8')
+const canvas = readFileSync(resolve(src, 'components/AppCanvas/AppCanvas.jsx'), 'utf8')
+const shell = readFileSync(resolve(src, 'components/Shell/Shell.jsx'), 'utf8')
+const frame = readFileSync(resolve(src, '../public/app-frame.html'), 'utf8')
+
+test('one open drawer owns at most one physical sentinel', () => {
+  assert.match(
+    navigation,
+    /function openDrawer\(\) \{\s*\/\/[\s\S]*?if \(drawerOpenRef\.current\) return[\s\S]*?pushShellEntry\('drawer'/,
+  )
+})
+
+test('ordinary Back restores a hidden sentinel owner before messaging it', () => {
+  const ordinaryBack = navigation.slice(
+    navigation.indexOf('// (4) Ordinary app sentinel'),
+    navigation.indexOf('// (5) Plain route'),
+  )
+  assert.ok(ordinaryBack.length > 0)
+  assert.match(ordinaryBack, /if \(!isVisibleApp\(ws, sourceOwner\.appId\)\)/)
+  assert.match(ordinaryBack, /type: 'OPEN_TAB'/)
+  assert.match(ordinaryBack, /moebius:nav-back/)
+})
+
+test('app-entry consumption cannot decrement the same owner twice', () => {
+  assert.match(
+    navigation,
+    /if \(!rec \|\| rec\.status !== 'live'\) \{\s*consumedAppEntryIdsRef\.current\.add\(entryId\)\s*return/,
+  )
+})
+
+test('removing the live iframe retires its host navigation even without an AppCanvas unmount', () => {
+  assert.match(
+    canvas,
+    /if \(v === liveVersionRef\.current\) onNavReset\?\.\(appId\)[\s\S]*framesRef\.current\.delete\(v\)/,
+  )
+})
+
+test('pointer input inside an opaque app frame focuses its owning pane', () => {
+  assert.match(frame, /pointerdown', notifyParentFocus/)
+  assert.match(frame, /type: 'moebius:frame-focus'/)
+  assert.match(canvas, /msg\.type === 'moebius:frame-focus'[\s\S]*onAppFocus\?\.\(appId\)/)
+  assert.match(shell, /const focusAppPane = useCallback[\s\S]*type: 'FOCUS', paneId: pane\.id/)
+  assert.match(shell, /onAppFocus=\{focusAppPane\}/)
+})

--- a/frontend/src/lib/__tests__/navigationWorkspaceContract.test.js
+++ b/frontend/src/lib/__tests__/navigationWorkspaceContract.test.js
@@ -50,3 +50,14 @@ test('pointer input inside an opaque app frame focuses its owning pane', () => {
   assert.match(shell, /const focusAppPane = useCallback[\s\S]*type: 'FOCUS', paneId: pane\.id/)
   assert.match(shell, /onAppFocus=\{focusAppPane\}/)
 })
+
+test('an explicit deep link replaces an unpinned implicit home tab', () => {
+  assert.match(
+    shell,
+    /const replaceImplicitBootTab = legacyOpenTabs\.length === 0[\s\S]*paneModel\.flatten\(workspace\)\.length <= 1/,
+  )
+  assert.match(
+    navigation,
+    /dispatchWorkspace\(replaceImplicitBootTab[\s\S]*type: 'RESET_FLAT', tabs: \[tab\][\s\S]*type: 'OPEN_TAB'/,
+  )
+})

--- a/tests/tabs.spec.mjs
+++ b/tests/tabs.spec.mjs
@@ -237,11 +237,10 @@ test.describe('Tabs', () => {
     await expect(page.locator('.workspace__strip--focused')).toContainText(chat.title)
 
     // Opaque iframe input uses the explicit frame-focus bridge.
-    await page.locator(`iframe[data-app-id="${APP_ID}"]`).evaluate(frame => {
-      frame.contentDocument.querySelector('#probe').dispatchEvent(
-        new PointerEvent('pointerdown', { bubbles: true }),
-      )
-    })
+    await page
+      .frameLocator(`iframe[data-app-id="${APP_ID}"]`)
+      .locator('#probe')
+      .dispatchEvent('pointerdown')
     await expect(page.locator('.workspace__strip--focused')).toContainText('Demo App')
 
     // The global drawer suspends kinetic interaction in every visible app pane.

--- a/tests/tabs.spec.mjs
+++ b/tests/tabs.spec.mjs
@@ -245,9 +245,10 @@ test.describe('Tabs', () => {
 
     // The global drawer suspends kinetic interaction in every visible app pane.
     await page.locator('.shell__brand').click()
-    await expect.poll(() => page.locator(`iframe[data-app-id="${APP_ID}"]`).evaluate(
-      frame => frame.contentDocument.body.dataset.interactive,
-    )).toBe('false')
+    await expect(page
+      .frameLocator(`iframe[data-app-id="${APP_ID}"]`)
+      .locator('body'))
+      .toHaveAttribute('data-interactive', 'false')
     await page.evaluate(() => history.back())
     await expect(page.locator('.drawer')).not.toHaveClass(/drawer--open/)
 

--- a/tests/tabs.spec.mjs
+++ b/tests/tabs.spec.mjs
@@ -76,6 +76,14 @@ async function mockOwnedApp(page, chatId) {
       })
     </script></body></html>`,
   }))
+  // AppCanvas deliberately waits for a scoped app token while online. Without
+  // this protocol mock the shell renders its loading surface, so an iframe
+  // lifecycle assertion would be testing an impossible half-mocked app.
+  await page.route(/\/api\/auth\/app-token$/, route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ token: 'mock-app-token' }),
+  }))
   return state
 }
 

--- a/tests/tabs.spec.mjs
+++ b/tests/tabs.spec.mjs
@@ -65,7 +65,16 @@ async function mockOwnedApp(page, chatId) {
   })
   await page.route(new RegExp(`/api/apps/${APP_ID}/frame`), route => route.fulfill({
     status: 200, contentType: 'text/html',
-    body: '<!doctype html><html><body style="margin:0"><div id="probe">app</div></body></html>',
+    body: `<!doctype html><html><body style="margin:0"><div id="probe">app</div><script>
+      document.addEventListener('pointerdown', function () {
+        window.parent.postMessage({ type: 'moebius:frame-focus' }, window.location.origin)
+      })
+      window.addEventListener('message', function (event) {
+        if (event.data && event.data.type === 'moebius:frame-interactivity') {
+          document.body.dataset.interactive = String(event.data.interactive)
+        }
+      })
+    </script></body></html>`,
   }))
   return state
 }
@@ -191,5 +200,54 @@ test.describe('Tabs', () => {
     // Exactly one iframe wrapper for the single app — no string/number duplicate.
     await expect(page.locator('.shell__view')).toHaveCount(1)
     expect(keyErrors, keyErrors.join('\n')).toHaveLength(0)
+  })
+
+  test('split mode tiles, focuses both content types, suspends apps, and collapses cleanly', async ({ page }) => {
+    const chat = await bootAndCreateChat(page, 'split', { width: 1200, height: 800 })
+    const appsMock = await mockOwnedApp(page, chat.id)
+    await seedTabs(page, [{ kind: 'chat', id: chat.id }, { kind: 'app', id: APP_ID }])
+    await page.addInitScript(() => localStorage.setItem('mobius:workspace-splits', '1'))
+
+    await page.goto(`${BASE}/shell/?chat=${chat.id}`, { waitUntil: 'domcontentloaded' })
+    await expect.poll(() => appsMock.requests, { timeout: 5000 }).toBeGreaterThan(0)
+
+    const appTab = page.locator('.shell__tab', { hasText: 'Demo App' }).locator('.shell__tab-open')
+    await appTab.click({ button: 'right' })
+    await page.getByRole('menuitem', { name: 'Split right' }).click()
+
+    await expect(page.locator('.workspace__strip')).toHaveCount(2)
+    await expect(page.locator('.shell__view--paned')).toHaveCount(2)
+    const rects = await page.locator('.shell__view--paned').evaluateAll(nodes => nodes.map(node => {
+      const r = node.getBoundingClientRect()
+      return { x: r.x, y: r.y, w: r.width, h: r.height }
+    }))
+    expect(rects.every(r => r.w >= 280 && r.h >= 200)).toBe(true)
+    expect(Math.abs(rects[0].x - rects[1].x)).toBeGreaterThan(100)
+
+    // Native chat content focuses its pane through wrapper capture.
+    await page.locator('.chat').dispatchEvent('pointerdown')
+    await expect(page.locator('.workspace__strip--focused')).toContainText(chat.title)
+
+    // Opaque iframe input uses the explicit frame-focus bridge.
+    await page.locator(`iframe[data-app-id="${APP_ID}"]`).evaluate(frame => {
+      frame.contentDocument.querySelector('#probe').dispatchEvent(
+        new PointerEvent('pointerdown', { bubbles: true }),
+      )
+    })
+    await expect(page.locator('.workspace__strip--focused')).toContainText('Demo App')
+
+    // The global drawer suspends kinetic interaction in every visible app pane.
+    await page.locator('.shell__brand').click()
+    await expect.poll(() => page.locator(`iframe[data-app-id="${APP_ID}"]`).evaluate(
+      frame => frame.contentDocument.body.dataset.interactive,
+    )).toBe('false')
+    await page.evaluate(() => history.back())
+    await expect(page.locator('.drawer')).not.toHaveClass(/drawer--open/)
+
+    // Closing the app's sole pane collapses back to the unchanged single-pane UI.
+    await page.locator('.workspace__strip', { hasText: 'Demo App' }).locator('.shell__tab-close').click()
+    await expect(page.locator('.workspace__strip')).toHaveCount(0)
+    await expect(page.locator('.shell__tabstrip')).toHaveCount(1)
+    await expect(page.locator('.chat')).toBeVisible()
   })
 })


### PR DESCRIPTION
## Summary

- keep chat and app surfaces mounted consistently across single-pane and tiled layouts
- make pane visibility, focus, microphone ownership, drawer suspension, and iframe navigation lifecycle pane-aware
- preserve implicit single-pane parity while replacing the unpinned home tab on explicit cold deep links
- add keyboard-ready tab actions and a real modal focus contract for the compact pane switcher
- exercise split lifecycle through the real opaque iframe boundary

The split affordance remains opt-in behind `mobius:workspace-splits`; the reducer/navigation and single-pane parity paths apply by default.

## Review findings fixed

- the compact pane switcher looked like a dialog but did not trap focus, close on Escape, inert background controls, or restore focus
- the tab context menu did not return focus to its invoking tab
- ordinary cold deep links could append to the implicit home surface and expose an unintended pinned strip
- the new browser test omitted the scoped app-token protocol and then reached through an intentionally opaque iframe, so it could not actually validate the lifecycle

## Verification

- frontend unit: 1,137 library + 46 hook tests passed
- PWA production build passed, including service-worker generation
- exact local browser gate: 5/5 auth/tab/split tests passed against commit `23b4cec28` before the final conflict-free rebase onto current main; branch-only code is patch-equivalent after rebase
- `git diff --check` and pre-push source gates passed
