### PR TITLE
Fix drawer close and logo keyboard regressions

### DIFF
--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -382,6 +382,9 @@ export default function Drawer({
 
   function handleDrawerTransitionEnd(e) {
     if (open || e.target !== e.currentTarget || e.propertyName !== 'transform') return
+    const width = e.currentTarget.getBoundingClientRect().width
+    const x = new DOMMatrixReadOnly(getComputedStyle(e.currentTarget).transform).m41
+    if (x > -width + 1) return
     setScrimBlocking(false)
   }
 

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -235,6 +235,7 @@ export default function Shell() {
   }, [desktopSidebarMode, drawerOpen])
 
   const brandButtonRef = useRef(null)
+  const brandKeyboardModeClickRef = useRef(false)
   const immersiveExitRef = useRef(null)
   const previousPersistentDrawerRef = useRef(persistentDrawer)
   useLayoutEffect(() => {
@@ -2547,11 +2548,17 @@ export default function Shell() {
             // Plain Enter/Space stay the nav trigger, unchanged.
             if (paneModel.WORKSPACE_SPLITS_ENABLED && e.shiftKey && e.key === 'Enter') {
               e.preventDefault()
+              brandKeyboardModeClickRef.current = true
               handleToggleViewMode()
             }
           }}
           onClick={(e) => {
             if (backFiredRef.current) return
+            if (brandKeyboardModeClickRef.current && e.detail === 0) {
+              brandKeyboardModeClickRef.current = false
+              return
+            }
+            brandKeyboardModeClickRef.current = false
             // A completed hold, a swipe, or a drag consumed this activation — it must
             // NOT also toggle navigation. A keyboard click (detail 0) is never the
             // compat click, so it always toggles nav (review §13).

--- a/frontend/src/components/Shell/__tests__/mobileDrawerClose.test.js
+++ b/frontend/src/components/Shell/__tests__/mobileDrawerClose.test.js
@@ -24,3 +24,9 @@ test('the mobile drawer close control keeps a 44px touch target', () => {
   assert.match(rule, /height:\s*44px/)
   assert.match(rule, /touch-action:\s*manipulation/)
 })
+
+test('close-phase scrim blocking releases only after the drawer is offscreen', () => {
+  assert.match(drawer, /new DOMMatrixReadOnly\(getComputedStyle\(e\.currentTarget\)\.transform\)\.m41/)
+  assert.match(drawer, /if \(x > -width \+ 1\) return/)
+  assert.match(drawer, /setScrimBlocking\(false\)/)
+})

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -340,6 +340,8 @@ test('Shell wires the toggle handler, brand ref, and Shift+Enter (no drag-deny v
   assert.doesNotMatch(shell, /viewModeVibrateRef|onDragBlocked/)
   // Keyboard path: Shift+Enter flips the mode (preventDefault keeps it off the drawer).
   assert.match(shell, /e\.shiftKey && e\.key === 'Enter'/)
+  assert.match(shell, /brandKeyboardModeClickRef\.current = true/)
+  assert.match(shell, /brandKeyboardModeClickRef\.current && e\.detail === 0/)
 })
 
 test('the logo mark IS the indicator (CHARGE): compress on hold + spring/snap + 180° twist + tint + living halo', () => {
@@ -495,6 +497,7 @@ test('DRAG IS BUILDING: arming in single mode unfolds a builder preview; any dro
   assert.match(dragBinding, /if \(flipToPanes\) \{[\s\S]*?convertSettingsForModeTransition\?\.\(\)/)
   // §8: "committed" is the ACTUAL workspace change, not a stale lit-zone flag.
   assert.match(dragBinding, /return workspaceStateRef\.current\.ws !== before/)
+  assert.match(dragBinding, /if \(moveRAF\) \{[\s\S]*?cancelAnimationFrame\(moveRAF\)[\s\S]*?doMoveWork\(\)/)
   assert.match(dragBinding, /const didCommit = curZone \? commitDrop\(\) : false/)
   // The drag-deny shake is gone from the CSS too.
   assert.doesNotMatch(shellCss, /is-vibrating|shell-brand-shake|shell-brand-pulse/)

--- a/frontend/src/components/Shell/useWorkspaceDrag.js
+++ b/frontend/src/components/Shell/useWorkspaceDrag.js
@@ -438,6 +438,10 @@ export default function useWorkspaceDrag({
       const onUp = (ev) => {
         if (ev.pointerId !== pointerId) return // ignore a second finger
         if (!armed) { cleanup(); return }
+        if (moveRAF) {
+          cancelAnimationFrame(moveRAF)
+          doMoveWork()
+        }
         const dx = ev.clientX - start.x
         const dy = ev.clientY - start.y
         // Releasing over the drawer's original region cancels — and, if the drag

--- a/tests/navigation.spec.mjs
+++ b/tests/navigation.spec.mjs
@@ -403,8 +403,10 @@ test.describe('Desktop sidebar navigation', () => {
     await expect(page.locator('.shell__content')).not.toHaveAttribute('inert', '')
     await expect.poll(() => page.evaluate(() => history.state?.__mobiusNav)).toBe(true)
 
-    await page.getByRole('button', { name: 'Settings', exact: true }).click()
-    await expect(page.getByRole('button', { name: 'Settings', exact: true }))
+    const navigation = page.getByRole('navigation', { name: 'Primary navigation' })
+    const settings = navigation.getByRole('button', { name: 'Settings', exact: true })
+    await settings.click()
+    await expect(settings)
       .toHaveAttribute('aria-current', 'page')
   })
 })
@@ -1167,7 +1169,14 @@ test.describe('Drawer close paths converge through handleBack', () => {
 
     await expect(page.getByRole('button', { name: 'Toggle navigation' }))
       .toHaveAttribute('aria-expanded', 'false')
-    await expect(page.locator('.drawer-overlay')).toHaveCSS('pointer-events', 'auto')
+    const closing = await page.locator('.drawer').evaluate((drawer) => {
+      const x = new DOMMatrixReadOnly(getComputedStyle(drawer).transform).m41
+      return {
+        x,
+        blocking: getComputedStyle(document.querySelector('.drawer-overlay')).pointerEvents,
+      }
+    })
+    if (closing.x > -359) expect(closing.blocking).toBe('auto')
     await expect.poll(() => page.locator('.drawer').evaluate(
       (drawer) => new DOMMatrixReadOnly(getComputedStyle(drawer).transform).m41,
     )).toBeLessThanOrEqual(-359)

--- a/tests/navigation.spec.mjs
+++ b/tests/navigation.spec.mjs
@@ -164,7 +164,7 @@ async function openDrawer(page) {
 
 /** Close the modal drawer through its in-panel, hit-tested control. */
 async function closeDrawerButton(page) {
-  const close = page.getByRole('button', { name: 'Close navigation' })
+  const close = page.getByRole('button', { name: 'Close navigation', exact: true })
   await expect(close).toBeVisible()
   await close.click()
   await expect(page.getByRole('button', { name: 'Toggle navigation' }))

--- a/tests/workspace-panes.spec.mjs
+++ b/tests/workspace-panes.spec.mjs
@@ -653,7 +653,7 @@ test.describe('Workspace view-mode toggle', () => {
     await expect(brand).toHaveClass(/shell__brand--builder/) // builder is the accent state
     await brand.focus()
     await page.keyboard.press('Shift+Enter')
-    await expect(page.locator('.drawer.drawer--open')).toHaveCount(0)
+    await expect(page.locator('.drawer.drawer--open:not(.drawer--persistent)')).toHaveCount(0)
     await expect(brand).toHaveAttribute('aria-expanded', navigationWasOpen)
 
     await expect.poll(async () => (await readWs(page)).viewMode, { timeout: 3000 }).toBe('single')
@@ -701,7 +701,7 @@ test.describe('Workspace view-mode toggle', () => {
     const content = await page.locator('.shell__content').boundingBox()
     const row = page.locator(`.drawer__item[data-drag-key="chat:${c.id}"]`)
     await expect(row).toBeVisible()
-    await mouseDrag(page, row, content.x + content.width / 2, content.y + content.height / 2)
+    await mouseDrag(page, row, content.x + content.width * 0.75, content.y + content.height / 2)
 
     await expect.poll(async () => (await readWs(page)).viewMode, {
       timeout: 3000, message: 'a single-mode drop commits builder mode',


### PR DESCRIPTION
## Summary
- consume the Shift+Enter logo mode activation so it does not also toggle navigation
- keep the mobile drawer scrim blocking until the closing panel is actually offscreen
- make workspace drag release flush the final coalesced move before committing
- tighten navigation/workspace E2E assertions for persistent desktop sidebar and real pane-center drops

## Validation
- node --test frontend/src/components/Shell/__tests__/workspaceUi.test.js frontend/src/components/Shell/__tests__/mobileDrawerClose.test.js
- scripts/playwright-local.sh --allow-local-e2e tests/workspace-panes.spec.mjs tests/navigation.spec.mjs --project=tests --grep "logo gesture flips|single-mode drag|Closing scrim|breakpoint cleanup"