### PR TITLE
Fix drawer and pane transition lifecycle

### DIFF
--- a/frontend/src/components/Drawer/Drawer.css
+++ b/frontend/src/components/Drawer/Drawer.css
@@ -113,12 +113,6 @@
   min-height: 0;
 }
 
-/* The shell header becomes inert while the mobile drawer is modal, so its
-   menu toggle cannot double as a dependable close affordance. Keep an
-   explicit escape target inside the modal boundary. The 44px square is a
-   comfortable minimum touch target without making the compact toolbar feel
-   oversized. Desktop has its own persistent-sidebar toggle and does not
-   render this row. */
 /* Wrapper around New chat + Chats + Apps. Holds the layout for
    the per-section scroll model: New chat stays at the top, Chats
    and Apps share the remaining space proportionally to their
@@ -372,15 +366,6 @@
 .drawer__row .drawer__item {
   flex: 1;
   min-width: 0;
-}
-
-
-
-
-@media (hover: hover) and (pointer: fine) {
-}
-
-@media (hover: none) {
 }
 
 /* The ⋮ button matches the row height so its hit area aligns

--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { memo, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { Plus, Chats, Grid, DotsVerticalMoreMenu, SettingsCog, Pin, PinFilled } from '@openai/apps-sdk-ui/components/Icon'
 import { Menu } from '@openai/apps-sdk-ui/components/Menu'
@@ -74,7 +74,7 @@ export default function Drawer({
   // returns this order already (see routes/chats.py list_chats), but we
   // mirror it defensively so the drawer stays correct if the cache holds
   // an older response.
-  const allChats = (chats || [])
+  const allChats = useMemo(() => (chats || [])
     .filter(c => c.has_messages)
     .sort((a, b) => {
       const ap = a.pinned_at, bp = b.pinned_at
@@ -83,18 +83,18 @@ export default function Drawer({
       if (ap && bp) return bp.localeCompare(ap)
       return ((b.activity_at || b.updated_at) || '')
         .localeCompare((a.activity_at || a.updated_at) || '')
-    })
+    }), [chats])
   // Mirror the same sort for apps. Server delivers it, but the cache
   // may carry a stale list. Unpinned apps stay in creation order so
   // the existing "stable apps list" UX (oldest-first within unpinned)
   // is preserved.
-  const sortedApps = (apps || []).slice().sort((a, b) => {
+  const sortedApps = useMemo(() => (apps || []).slice().sort((a, b) => {
     const ap = a.pinned_at, bp = b.pinned_at
     if (ap && !bp) return -1
     if (!ap && bp) return 1
     if (ap && bp) return bp.localeCompare(ap)
     return (a.created_at || '').localeCompare(b.created_at || '')
-  })
+  }), [apps])
 
   // One row at a time can be in rename or open-menu mode. Tracking the
   // active id (rather than per-row state) lets a click on another row's
@@ -145,6 +145,59 @@ export default function Drawer({
     renamingRef.current = next
     setRenamingState(next)
   }
+
+  // Rows receive one stable action surface instead of a new closure for every
+  // action on every item. The ref supplies the latest props and local helpers,
+  // while memoized rows can bail out when an unrelated row or drawer state changes.
+  const rowActionInputsRef = useRef(null)
+  const rowActions = useMemo(() => ({
+    select(kind, id) {
+      const current = rowActionInputsRef.current
+      if (kind === 'chat') current.onChat(id)
+      else current.onApp(id)
+    },
+    toggleMenu(kind, id, next) {
+      rowActionInputsRef.current.setOpenMenu(next ? { kind, id } : null)
+    },
+    startRename(kind, id) {
+      rowActionInputsRef.current.setRenaming({ kind, id })
+    },
+    cancelRename() {
+      rowActionInputsRef.current.setRenaming(null)
+    },
+    submitRename(kind, id, previous, next) {
+      const current = rowActionInputsRef.current
+      current.setRenaming(null)
+      if (current.overlayCancelRef.current) {
+        current.overlayCancelRef.current = false
+        return
+      }
+      if (!next || next === previous) return
+      if (kind === 'chat') current.renameChat(id, next)
+      else current.renameApp(id, next)
+    },
+    pin(kind, id, next) {
+      const current = rowActionInputsRef.current
+      if (kind === 'chat') current.pinChat(id, next)
+      else current.pinApp(id, next)
+    },
+    remove(kind, id) {
+      const current = rowActionInputsRef.current
+      if (kind === 'chat') current.onDeleteChat(id)
+      else current.onDeleteApp?.(id)
+    },
+    removeData(id) {
+      rowActionInputsRef.current.onDeleteAppData?.(id)
+    },
+    install(app) {
+      rowActionInputsRef.current.setInstallingApp({
+        id: app.id,
+        name: app.name,
+        slug: app.slug,
+        updatedAt: app.updated_at,
+      })
+    },
+  }), [])
 
   function handleOverlayPointerDown(e) {
     // Pointerdown is the canonical dismiss event. Waiting for `click` is
@@ -481,6 +534,22 @@ export default function Drawer({
     // It must never leave a click guard behind for a later destination tap.
   }
 
+  rowActionInputsRef.current = {
+    onChat,
+    onApp,
+    onDeleteChat,
+    onDeleteApp,
+    onDeleteAppData,
+    setOpenMenu,
+    setRenaming,
+    setInstallingApp,
+    overlayCancelRef,
+    renameChat,
+    renameApp,
+    pinChat,
+    pinApp,
+  }
+
   return (
     <>
       {!persistent && (
@@ -541,28 +610,13 @@ export default function Drawer({
                 <DrawerRow
                   key={chat.id}
                   kind="chat"
-                  id={chat.id}
-                  label={chat.title}
-                  pinned={!!chat.pinned_at}
+                  item={chat}
                   streaming={streamingSet.has(chat.id)}
                   attention={attentionSet.has(chat.id)}
                   active={activeView === 'chat' && activeChatId === chat.id}
-                  onSelect={() => onChat(chat.id)}
                   menuOpen={!!(openMenu && openMenu.kind === 'chat' && openMenu.id === chat.id)}
-                  onMenuToggle={(next) => setOpenMenu(next ? { kind: 'chat', id: chat.id } : null)}
-                  renaming={renaming && renaming.kind === 'chat' && renaming.id === chat.id}
-                  onRenameStart={() => setRenaming({ kind: 'chat', id: chat.id })}
-                  onRenameCancel={() => setRenaming(null)}
-                  onRenameSubmit={(next) => {
-                    setRenaming(null)
-                    if (overlayCancelRef.current) {
-                      overlayCancelRef.current = false
-                      return  // overlay-tap cancel — discard the value
-                    }
-                    if (next && next !== chat.title) renameChat(chat.id, next)
-                  }}
-                  onPin={(next) => pinChat(chat.id, next)}
-                  onDelete={() => onDeleteChat(chat.id)}
+                  renaming={!!(renaming && renaming.kind === 'chat' && renaming.id === chat.id)}
+                  actions={rowActions}
                 />
               )) : (
                 <EmptyMessage className="drawer__empty" fill="static">
@@ -585,31 +639,13 @@ export default function Drawer({
                   <DrawerRow
                     key={app.id}
                     kind="app"
-                    id={app.id}
-                    label={app.name}
-                    slug={app.slug}
-                    pinned={!!app.pinned_at}
+                    item={app}
                     building={!!(app.chat_id && streamingSet.has(app.chat_id))}
                     attention={newAppSet.has(Number(app.id))}
                     active={activeView === 'canvas' && Number(activeAppId) === Number(app.id)}
-                    onSelect={() => onApp(app.id)}
                     menuOpen={!!(openMenu && openMenu.kind === 'app' && openMenu.id === app.id)}
-                    onMenuToggle={(next) => setOpenMenu(next ? { kind: 'app', id: app.id } : null)}
-                    renaming={renaming && renaming.kind === 'app' && renaming.id === app.id}
-                    onRenameStart={() => setRenaming({ kind: 'app', id: app.id })}
-                    onRenameCancel={() => setRenaming(null)}
-                    onRenameSubmit={(next) => {
-                      setRenaming(null)
-                      if (overlayCancelRef.current) {
-                        overlayCancelRef.current = false
-                        return  // overlay-tap cancel — discard the value
-                      }
-                      if (next && next !== app.name) renameApp(app.id, next)
-                    }}
-                    onPin={(next) => pinApp(app.id, next)}
-                    onDelete={() => onDeleteApp?.(app.id)}
-                    onDeleteData={() => onDeleteAppData?.(app.id)}
-                    onInstall={() => setInstallingApp({ id: app.id, name: app.name, slug: app.slug, updatedAt: app.updated_at })}
+                    renaming={!!(renaming && renaming.kind === 'app' && renaming.id === app.id)}
+                    actions={rowActions}
                   />
                 ))}
               </div>
@@ -660,13 +696,10 @@ export default function Drawer({
 /** One row in the chat or app list — handles select, inline rename,
  * three-dots menu, and confirm-delete in a single self-contained unit
  * so the parent only orchestrates which row is currently expanded. */
-function DrawerRow({
+const DrawerRow = memo(function DrawerRow({
   kind,
-  id,
-  label,
-  pinned,
+  item,
   active,
-  slug,
   streaming,
   // App rows only: the app's owning chat is streaming, i.e. the agent is
   // actively building/editing this app right now. Reuses the streaming
@@ -674,18 +707,14 @@ function DrawerRow({
   // pulses the same way an active chat does.
   building,
   attention,
-  onSelect,
   menuOpen,
-  onMenuToggle,
   renaming,
-  onRenameStart,
-  onRenameCancel,
-  onRenameSubmit,
-  onPin,
-  onDelete,
-  onDeleteData,
-  onInstall,
+  actions,
 }) {
+  const id = item.id
+  const label = kind === 'chat' ? item.title : item.name
+  const pinned = !!item.pinned_at
+  const slug = item.slug
   const wrapRef = useRef(null)
   const inputRef = useRef(null)
   const [confirmingDelete, setConfirmingDelete] = useState(false)
@@ -726,7 +755,7 @@ function DrawerRow({
       const inputEl = inputRef.current
       if (!inputEl || inputEl.contains(e.target)) return
       cancelingRef.current = true
-      onRenameCancel()
+      actions.cancelRename()
       if (e.target?.closest?.('.drawer-overlay')) return
       e.preventDefault()
       e.stopPropagation()
@@ -744,7 +773,7 @@ function DrawerRow({
       document.removeEventListener('pointerdown', onOutsidePointer, true)
       document.removeEventListener('click', onOutsideClick, true)
     }
-  }, [renaming, onRenameCancel])
+  }, [renaming, actions])
 
   // Autofocus + select-all on rename open so the user can either retype
   // from scratch or tap into the existing name to edit it.
@@ -761,12 +790,12 @@ function DrawerRow({
       return  // outside-tap canceled — discard the value
     }
     const value = inputRef.current?.value || ''
-    onRenameSubmit(value.trim())
+    actions.submitRename(kind, id, label, value.trim())
   }
 
   function onInputKeyDown(e) {
     if (e.key === 'Enter') { e.preventDefault(); commitRename() }
-    else if (e.key === 'Escape') { e.preventDefault(); onRenameCancel() }
+    else if (e.key === 'Escape') { e.preventDefault(); actions.cancelRename() }
   }
 
   if (renaming) {
@@ -795,7 +824,7 @@ function DrawerRow({
         // pane. Only present when the splits flag is on; a plain tap still opens
         // in the focused pane (the controller never arms without slop/hold).
         data-drag-key={WORKSPACE_SPLITS_ENABLED ? `${kind}:${id}` : undefined}
-        onClick={onSelect}
+        onClick={() => actions.select(kind, id)}
       >
         {/* Status dot. Sits before the text so the user's eye
             picks it up alongside the label rather than at the row's
@@ -828,8 +857,8 @@ function DrawerRow({
       </button>
       <Menu
         forceOpen={menuOpen}
-        onOpen={() => onMenuToggle(true)}
-        onClose={() => onMenuToggle(false)}
+        onOpen={() => actions.toggleMenu(kind, id, true)}
+        onClose={() => actions.toggleMenu(kind, id, false)}
       >
         <Menu.Trigger>
           {/* No Tooltip wrap here. Both Menu.Trigger and Tooltip
@@ -852,7 +881,7 @@ function DrawerRow({
           {!confirmingDelete && !confirmingDeleteData ? (
             <>
               <Menu.Item
-                onSelect={() => onPin?.(!pinned)}
+                onSelect={() => actions.pin(kind, id, !pinned)}
                 className="drawer__menu-item--icon"
               >
                 {pinned
@@ -860,7 +889,7 @@ function DrawerRow({
                   : <PinFilled width={14} height={14} aria-hidden="true" />}
                 <span>{pinned ? 'Unpin' : 'Pin to top'}</span>
               </Menu.Item>
-              <Menu.Item onSelect={() => onRenameStart()}>Rename</Menu.Item>
+              <Menu.Item onSelect={() => actions.startRename(kind, id)}>Rename</Menu.Item>
               {kind === 'app' && slug && (
                 // Opens the in-PWA InstallSheet to set the home-screen
                 // name + icon first; the sheet saves, then navigates
@@ -869,7 +898,7 @@ function DrawerRow({
                 // jarring browser-tab pop-out — and lets engagement
                 // from the parent shell count toward the per-origin
                 // Site Engagement score that gates beforeinstallprompt.
-                <Menu.Item onSelect={() => onInstall?.()}>
+                <Menu.Item onSelect={() => actions.install(item)}>
                   Install to home screen
                 </Menu.Item>
               )}
@@ -883,7 +912,10 @@ function DrawerRow({
                 // id, leaving a Radix trigger looking "pressed" on
                 // whichever row slides up into the slot.
                 <Menu.Item
-                  onSelect={() => { onMenuToggle(false); onDelete() }}
+                  onSelect={() => {
+                    actions.toggleMenu(kind, id, false)
+                    actions.remove(kind, id)
+                  }}
                   className="drawer__menu-item--danger"
                 >
                   Delete
@@ -936,8 +968,8 @@ function DrawerRow({
                     // open-trigger bookkeeping in sync. The app STAYS in the
                     // list here (only its data is wiped), so no row unmounts.
                     setConfirmingDeleteData(false)
-                    onMenuToggle(false)
-                    onDeleteData?.()
+                    actions.toggleMenu(kind, id, false)
+                    actions.removeData(id)
                   }}
                 >
                   Delete data
@@ -967,8 +999,8 @@ function DrawerRow({
                     // into the deleted slot looks stuck pressed
                     // because openMenu still references the dead id.
                     setConfirmingDelete(false)
-                    onMenuToggle(false)
-                    onDelete()
+                    actions.toggleMenu(kind, id, false)
+                    actions.remove(kind, id)
                   }}
                 >
                   Delete
@@ -988,4 +1020,4 @@ function DrawerRow({
       </Menu>
     </div>
   )
-}
+})

--- a/frontend/src/components/Shell/Shell.css
+++ b/frontend/src/components/Shell/Shell.css
@@ -423,8 +423,8 @@
   to { scale: 1; }
 }
 /* The LIVING HALO — the logo's "lit soul" in builder mode. A soft radial glow
-   behind the mark; useLivingHalo drives --halo-scale / --halo-x / --halo-y /
-   --halo-opacity on the brand via a two-sine rAF (or a static value under reduced
+   behind the mark; useLivingHalo writes translate, scale, and --halo-opacity
+   directly on this leaf via a two-sine rAF (or static values under reduced
    motion). Per-theme base alpha via --halo-alpha. Only lit in builder mode. */
 .shell__logo-halo {
   position: absolute;
@@ -435,8 +435,8 @@
   background: radial-gradient(closest-side,
     color-mix(in srgb, var(--accent) calc(var(--halo-alpha, 0.5) * 100%), transparent),
     transparent 72%);
-  translate: var(--halo-x, 0px) var(--halo-y, 0px);
-  scale: var(--halo-scale, 1);
+  translate: 0 0;
+  scale: 1;
   transition: opacity 220ms ease;
 }
 .shell__brand--builder .shell__logo-halo {

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -60,9 +60,8 @@ import './Shell.css'
 import './workspace.css'
 import WorkspaceChrome from './WorkspaceChrome.jsx'
 import useWorkspaceDrag from './useWorkspaceDrag.js'
-import { useLogoModeGesture, prefersReducedMotion } from './useLogoModeGesture.js'
+import { prefersReducedMotion } from './useLogoModeGesture.js'
 import { useModeTransitionBeats } from './useModeTransitionBeats.js'
-import useLivingHalo from './useLivingHalo.js'
 import {
   HINT_KEY, coachmarkArmed, coachmarkDismissed, undoKeyPressed, isEditableTarget,
 } from './workspaceOnboarding.js'
@@ -72,6 +71,7 @@ import { deriveContentVisibility } from './workspaceView.js'
 import { PaneTab, stripKeyDown } from './PaneStrip.jsx'
 import useAppIntentNavigation from './useAppIntentNavigation.js'
 import useDesktopSidebar from './useDesktopSidebar.js'
+import ShellBrand from './ShellBrand.jsx'
 
 const SHELL_RELOAD_RECHECK_MS = 6000
 // How long the transient builder mode-ENTER treatment holds its root class
@@ -176,9 +176,9 @@ export default function Shell() {
       // layout-bloom transition while it is in flight and restore it 200ms after
       // the last resize, so a subsequent discrete commit (drop/split) still
       // blooms but a continuous resize stays crisp.
-      el.classList.add('workspace--resizing')
+      el.classList.add('workspace--container-resizing')
       clearTimeout(resizeClassTimer)
-      resizeClassTimer = setTimeout(() => el.classList.remove('workspace--resizing'), 200)
+      resizeClassTimer = setTimeout(() => el.classList.remove('workspace--container-resizing'), 200)
       setContentRect(prev => {
         if (prev.w === w && prev.h === h) return prev
         // Flag-off single-pane never tiles, so a content-size change would
@@ -190,7 +190,11 @@ export default function Shell() {
       })
     })
     ro.observe(el)
-    return () => { ro.disconnect(); clearTimeout(resizeClassTimer) }
+    return () => {
+      ro.disconnect()
+      clearTimeout(resizeClassTimer)
+      el.classList.remove('workspace--container-resizing')
+    }
   }, [])
   const workspaceMode = useMemo(() => paneModel.modeForRect(contentRect), [contentRect])
   const projection = useMemo(
@@ -237,7 +241,6 @@ export default function Shell() {
   }, [desktopSidebarMode, drawerOpen])
 
   const brandButtonRef = useRef(null)
-  const brandKeyboardModeClickRef = useRef(false)
   const immersiveExitRef = useRef(null)
   const previousPersistentDrawerRef = useRef(persistentDrawer)
   useLayoutEffect(() => {
@@ -1151,26 +1154,13 @@ export default function Shell() {
     convertSettingsForModeTransition()
     dispatchWorkspace({ type: 'SET_VIEW_MODE', mode: 'toggle' })
   }, [armBeat, convertSettingsForModeTransition, dispatchWorkspace])
-  // The logo gesture layer: a HOLD (~450ms) or a touch swipe-right toggles the
-  // mode; the single tap keeps opening the drawer INSTANTLY (composed in the brand
-  // button below). Flag-gated so a splits-off build attaches no gesture handlers.
-  // It shares the brand button's ref (brandButtonRef, declared with the desktop
-  // sidebar focus-management above) to write the --hold-progress ring var and take
-  // pointer capture during a hold — ONE ref, both jobs.
-  const logoGesture = useLogoModeGesture({
-    onToggleMode: handleToggleViewMode,
-    brandRef: brandButtonRef,
-    enabled: paneModel.WORKSPACE_SPLITS_ENABLED,
-    // Cancel a live hold if navigation opens by ANY other path — the mobile modal
-    // drawer OR the persistent desktop sidebar toggling open (review §6 + sidebar
-    // reconciliation): navigationOpen unifies both.
-    drawerOpen: navigationOpen,
-    // Direction of a completed hold (enter → spring+12, exit → snap+8).
-    builderModeActive,
-  })
-  // The logo's living halo (its "lit soul") — a drifting glow behind the mark while
-  // builder mode is active; killed instantly on snap back to single.
-  useLivingHalo({ brandRef: brandButtonRef, active: builderModeActive })
+  const handleToggleNavigation = useCallback(() => {
+    if (persistentDrawer) {
+      setDesktopSidebarOpen(!desktopSidebarOpen)
+      return
+    }
+    drawerOpen ? closeDrawer() : openDrawer()
+  }, [persistentDrawer, desktopSidebarOpen, setDesktopSidebarOpen, drawerOpen, closeDrawer, openDrawer])
   useWorkspaceDrag({
     enabled: paneModel.WORKSPACE_SPLITS_ENABLED,
     contentElRef,
@@ -2585,118 +2575,20 @@ export default function Shell() {
       + `${builderEntering ? ' shell--builder-entering' : ''}`
       + `${builderExiting ? ' shell--builder-exiting' : ''}`
       + `${builderModeActive && paneModel.BUILDER_POWER_CHROME ? ' shell--builder-power' : ''}`}>
-      {/* inert on the header while the modal drawer is open so keyboard / AT
-          focus cannot reach shell-chrome behind the open drawer. The
-          drawer itself gains focus on open (Drawer.jsx focus-management
-          effect) and restores it here on close. React 19 reflects the
-          boolean `inert` prop to the boolean attribute (present when true,
-          absent when false); the old `drawerOpen ? '' : undefined` form was
-          a no-op because React 19 normalizes the known boolean attribute and
-          an empty string serializes as falsy, so it never applied. */}
-      <header className="shell__bar" inert={modalDrawerOpen}>
-        {/* The brand area (logo + wordmark) is the navigation trigger AND — when
-            splits are on — the builder-mode control (owner placement: no standalone
-            toggle button, the logo IS the mode control). SINGLE tap keeps its
-            per-platform meaning EXACTLY as before — instant, never suppressed:
-            toggles the persistent desktop sidebar, or opens/closes the mobile modal
-            drawer. A HOLD (~450ms) or a touch swipe-right toggles the view mode;
-            Shift+Enter is the keyboard path. The mark rotates 180deg (+ the wordmark
-            tints) to indicate the mode; an aria-live region announces the change to
-            assistive tech (the button keeps its nav aria-expanded semantics — one
-            control, two verbs — so mode state rides a live region, not a conflicting
-            aria-pressed). */}
-        <button
-          ref={brandButtonRef}
-          type="button"
-          className={`shell__brand${logoGesture.holding ? ' is-holding' : ''}`
-            + `${logoGesture.flourish ? ` is-${logoGesture.flourish}` : ''}`
-            + `${builderModeActive ? ' shell__brand--builder' : ''}`}
-          // The accessible NAME stays "Toggle navigation" — the button's primary
-          // job is the drawer, and both assistive tech and the e2e specs key off
-          // that stable name. The mode gesture rides aria-description (a supplement,
-          // not the name) so it is surfaced without renaming the control.
-          aria-label="Toggle navigation"
-          aria-description={paneModel.WORKSPACE_SPLITS_ENABLED
-            ? 'Hold or press Shift+Enter for builder mode'
-            : undefined}
-          aria-controls="navigation-drawer"
-          aria-expanded={navigationOpen}
-          /* Android may synthesize a bare click over the logo after an OS Back
-             gesture. backFiredRef still filters that compatibility click, but
-             a deliberate new interaction starts with pointerdown/keydown and
-             must immediately clear the guard — never make the owner wait out a
-             blanket 400ms dead zone before the drawer responds. */
-          onPointerDown={(e) => {
-            backFiredRef.current = false
-            if (paneModel.WORKSPACE_SPLITS_ENABLED) logoGesture.onPointerDown(e)
-          }}
-          onPointerMove={paneModel.WORKSPACE_SPLITS_ENABLED ? logoGesture.onPointerMove : undefined}
-          onPointerUp={paneModel.WORKSPACE_SPLITS_ENABLED ? logoGesture.onPointerUp : undefined}
-          onPointerCancel={paneModel.WORKSPACE_SPLITS_ENABLED ? logoGesture.onPointerCancel : undefined}
-          onContextMenu={paneModel.WORKSPACE_SPLITS_ENABLED ? logoGesture.onContextMenu : undefined}
-          onKeyDown={(e) => {
-            backFiredRef.current = false
-            // Keyboard path for the mode toggle (hold is pointer-only): Shift+Enter
-            // flips builder mode, preventDefault keeps it from also toggling nav.
-            // Plain Enter/Space stay the nav trigger, unchanged.
-            if (paneModel.WORKSPACE_SPLITS_ENABLED && e.shiftKey && e.key === 'Enter') {
-              e.preventDefault()
-              brandKeyboardModeClickRef.current = true
-              handleToggleViewMode()
-            }
-          }}
-          onClick={(e) => {
-            if (backFiredRef.current) return
-            if (brandKeyboardModeClickRef.current && e.detail === 0) {
-              brandKeyboardModeClickRef.current = false
-              return
-            }
-            brandKeyboardModeClickRef.current = false
-            // A completed hold, a swipe, or a drag consumed this activation — it must
-            // NOT also toggle navigation. A keyboard click (detail 0) is never the
-            // compat click, so it always toggles nav (review §13).
-            if (logoGesture.consumeSuppressedClick(e.detail)) return
-            // Single tap — per-platform nav toggle, EXACTLY as before (instant, no
-            // timer): toggle the persistent desktop sidebar, else the modal drawer.
-            if (persistentDrawer) { setDesktopSidebarOpen(!desktopSidebarOpen); return }
-            drawerOpen ? closeDrawer() : openDrawer()
-          }}
-          onAnimationEnd={logoGesture.onAnimationEnd}
-        >
-          {/* The mark IS the indicator (CHARGE model). The raster logo (a human hand
-              and a robot hand drawing each other in a circular loop) COMPRESSES as a
-              hold charges (--hold-progress), then springs (enter) / snaps (exit) back
-              and rotates 180deg — swapping which hand is "drawing". In builder mode a
-              living halo drifts behind it (its "lit soul"; useLivingHalo drives the
-              --halo-* vars). CSS-composed; reduced-motion makes the twist instant,
-              skips the spring, and stills the halo. */}
-          <span className="shell__logo-wrap">
-            {paneModel.WORKSPACE_SPLITS_ENABLED && (
-              <span className="shell__logo-halo" aria-hidden="true" />
-            )}
-            {/* Decorative (alt="") — the BUTTON owns every pointer event. The img
-                is pointer-inert (CSS pointer-events:none + draggable=false) so the
-                browser never sees a long-pressable image and can't raise its native
-                image callout/preview sheet on a builder-mode hold (owner phone
-                report: "sometimes holding the logo opens up the image"). The hold
-                gesture targets the button, so making the child inert only IMPROVES
-                pointerdown reliability. */}
-            <img
-              className="shell__logo"
-              src={`${BASE}/moebius.png`}
-              alt=""
-              width="30"
-              height="30"
-              draggable={false}
-            />
-          </span>
-          <span className="shell__wordmark">Möbius</span>
-        </button>
-        {paneModel.WORKSPACE_SPLITS_ENABLED && (
-          <span className="shell__sr-only" role="status" aria-live="polite">
-            {builderModeActive ? 'Builder mode' : 'Single screen'}
-          </span>
-        )}
+      {/* The existing brand toggle remains the visible close affordance while the
+          mobile drawer is modal. Keep the workspace inert below, but do not inert
+          the header: doing so lets the scrim intercept the toggle and strands the
+          drawer without the close path its label and aria-expanded state promise. */}
+      <header className="shell__bar">
+        <ShellBrand
+          brandRef={brandButtonRef}
+          splitsEnabled={paneModel.WORKSPACE_SPLITS_ENABLED}
+          navigationOpen={navigationOpen}
+          builderModeActive={builderModeActive}
+          backFiredRef={backFiredRef}
+          onToggleMode={handleToggleViewMode}
+          onToggleNavigation={handleToggleNavigation}
+        />
         {!online && (
           <span className="shell__offline" role="status" aria-live="polite">
             Offline
@@ -2744,9 +2636,8 @@ export default function Shell() {
       {/* inert on the main content while the modal drawer is open — mirrors
           the drawer's own inert-when-closed contract, but inverted.
           Prevents pointer / keyboard events from reaching the chat or
-          app canvas while the drawer is overlaid in front of it. Boolean
-          prop form — see the header's inert note for why the old
-          `? '' : undefined` form was a React 19 no-op. */}
+          app canvas while the drawer is overlaid in front of it. React 19's
+          boolean prop form emits the attribute only while this is true. */}
       {/* Tab strip: pinned chats/apps to swap between with one tap.
           Switching a tab is ordinary navTo, so back works through the
           existing navStack. The strip shrinks .shell__content by one row;

--- a/frontend/src/components/Shell/ShellBrand.jsx
+++ b/frontend/src/components/Shell/ShellBrand.jsx
@@ -1,0 +1,106 @@
+import { memo, useRef } from 'react'
+import { BASE } from '../../api/client.js'
+import { useLogoModeGesture } from './useLogoModeGesture.js'
+import useLivingHalo from './useLivingHalo.js'
+
+/**
+ * The brand owns its transient press/hold animation state. Keeping that state in
+ * this memoized leaf prevents a pointerdown/up on the navigation toggle from
+ * rerendering Shell and every row in a large drawer.
+ */
+const ShellBrand = memo(function ShellBrand({
+  brandRef,
+  splitsEnabled,
+  navigationOpen,
+  builderModeActive,
+  backFiredRef,
+  onToggleMode,
+  onToggleNavigation,
+}) {
+  const keyboardModeClickRef = useRef(false)
+  const haloRef = useRef(null)
+  const logoGesture = useLogoModeGesture({
+    onToggleMode,
+    brandRef,
+    enabled: splitsEnabled,
+    // Cancel a live hold if navigation opens by any other path.
+    drawerOpen: navigationOpen,
+    builderModeActive,
+  })
+  useLivingHalo({ haloRef, active: splitsEnabled && builderModeActive })
+
+  return (
+    <>
+      <button
+        ref={brandRef}
+        type="button"
+        className={`shell__brand${logoGesture.holding ? ' is-holding' : ''}`
+          + `${logoGesture.flourish ? ` is-${logoGesture.flourish}` : ''}`
+          + `${builderModeActive ? ' shell__brand--builder' : ''}`}
+        // Navigation remains the primary, stable accessible name. The builder
+        // gesture is supplementary and its state is announced below.
+        aria-label="Toggle navigation"
+        aria-description={splitsEnabled
+          ? 'Hold or press Shift+Enter for builder mode'
+          : undefined}
+        aria-controls="navigation-drawer"
+        aria-expanded={navigationOpen}
+        onPointerDown={(e) => {
+          // A deliberate interaction immediately clears Android's compatibility-
+          // click guard left by an OS Back gesture.
+          backFiredRef.current = false
+          if (splitsEnabled) logoGesture.onPointerDown(e)
+        }}
+        onPointerMove={splitsEnabled ? logoGesture.onPointerMove : undefined}
+        onPointerUp={splitsEnabled ? logoGesture.onPointerUp : undefined}
+        onPointerCancel={splitsEnabled ? logoGesture.onPointerCancel : undefined}
+        onContextMenu={splitsEnabled ? logoGesture.onContextMenu : undefined}
+        onKeyDown={(e) => {
+          backFiredRef.current = false
+          if (splitsEnabled && e.shiftKey && e.key === 'Enter') {
+            e.preventDefault()
+            keyboardModeClickRef.current = true
+            onToggleMode()
+          }
+        }}
+        onClick={(e) => {
+          if (backFiredRef.current) return
+          if (keyboardModeClickRef.current && e.detail === 0) {
+            keyboardModeClickRef.current = false
+            return
+          }
+          keyboardModeClickRef.current = false
+          // A hold/swipe/drag consumes only its trailing pointer click. Keyboard
+          // activation (detail 0) always retains the navigation action.
+          if (logoGesture.consumeSuppressedClick(e.detail)) return
+          onToggleNavigation()
+        }}
+        onAnimationEnd={logoGesture.onAnimationEnd}
+      >
+        <span className="shell__logo-wrap">
+          {splitsEnabled && (
+            <span ref={haloRef} className="shell__logo-halo" aria-hidden="true" />
+          )}
+          {/* Decorative and pointer-inert: the button owns long presses, so mobile
+              browsers cannot raise a native image preview over the gesture. */}
+          <img
+            className="shell__logo"
+            src={`${BASE}/moebius.png`}
+            alt=""
+            width="30"
+            height="30"
+            draggable={false}
+          />
+        </span>
+        <span className="shell__wordmark">Möbius</span>
+      </button>
+      {splitsEnabled && (
+        <span className="shell__sr-only" role="status" aria-live="polite">
+          {builderModeActive ? 'Builder mode' : 'Single screen'}
+        </span>
+      )}
+    </>
+  )
+})
+
+export default ShellBrand

--- a/frontend/src/components/Shell/WorkspaceChrome.jsx
+++ b/frontend/src/components/Shell/WorkspaceChrome.jsx
@@ -157,7 +157,7 @@ export default function WorkspaceChrome({
     document.body.style.userSelect = 'none'
     // Suppress the layout-bloom transition while the divider is dragged: rects are
     // written imperatively per frame and a transition would lag them.
-    contentEl.classList.add('workspace--resizing')
+    contentEl.classList.add('workspace--divider-dragging')
     const box = contentEl.getBoundingClientRect()
     const { dir, splitId } = divider
 
@@ -233,7 +233,7 @@ export default function WorkspaceChrome({
       window.removeEventListener('blur', end)
       try { handle.releasePointerCapture(e.pointerId) } catch { /* released */ }
       document.body.style.userSelect = prevUserSelect
-      contentEl.classList.remove('workspace--resizing')
+      contentEl.classList.remove('workspace--divider-dragging')
       dispatchWorkspace({ type: 'SET_RATIO', splitId, ratio: committed })
     }
     window.addEventListener('pointermove', onMove)

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -7,6 +7,8 @@ const css = readFileSync(
   'utf8',
 )
 const shell = readFileSync(new URL('../Shell.jsx', import.meta.url), 'utf8')
+const shellBrand = readFileSync(new URL('../ShellBrand.jsx', import.meta.url), 'utf8')
+const drawer = readFileSync(new URL('../../Drawer/Drawer.jsx', import.meta.url), 'utf8')
 const paneModelSrc = readFileSync(new URL('../paneModel.js', import.meta.url), 'utf8')
 const chrome = readFileSync(new URL('../WorkspaceChrome.jsx', import.meta.url), 'utf8')
 const dragBinding = readFileSync(new URL('../useWorkspaceDrag.js', import.meta.url), 'utf8')
@@ -172,9 +174,15 @@ test('the divider and drag paths coalesce their per-move work into a rAF', () =>
 test('a layout commit blooms the paned wrappers, suppressed while resizing', () => {
   const rule = css.match(/\.shell__view--paned\s*\{[\s\S]*?\}/)?.[0] || ''
   assert.match(rule, /transition:\s*top 180ms ease-out/)
-  assert.match(css, /\.workspace--resizing \.shell__view--paned[\s\S]*?transition: none/)
-  assert.match(shell, /el\.classList\.add\('workspace--resizing'\)/)
-  assert.match(chrome, /contentEl\.classList\.add\('workspace--resizing'\)/)
+  assert.match(css, /\.workspace--container-resizing \.shell__view--paned[\s\S]*?transition: none/)
+  assert.match(css, /\.workspace--divider-dragging \.shell__view--paned[\s\S]*?transition: none/)
+  assert.match(shell, /el\.classList\.add\('workspace--container-resizing'\)/)
+  assert.match(shell, /el\.classList\.remove\('workspace--container-resizing'\)/)
+  assert.match(chrome, /contentEl\.classList\.add\('workspace--divider-dragging'\)/)
+  assert.doesNotMatch(shell, /workspace--divider-dragging/,
+    'the ResizeObserver must not own the divider guard')
+  assert.doesNotMatch(chrome, /workspace--container-resizing/,
+    'the divider drag must not own the ResizeObserver guard')
 })
 
 test('strips sit above dividers so the 44px grab never occludes a tab', () => {
@@ -273,11 +281,11 @@ test('there is NO standalone view-mode toggle button — the logo is the control
 test('the SINGLE tap keeps its drawer job — instant, NO setTimeout on the tap path', () => {
   // The brand button is the drawer trigger; onClick toggles it synchronously after
   // a suppressed-gesture check, with zero timers.
-  assert.match(shell, /className=\{`shell__brand/)
-  assert.match(shell, /aria-expanded=\{navigationOpen\}/)
-  const onClick = shell.match(/onClick=\{\(e\) => \{[\s\S]*?\n {10}\}\}/)?.[0] || ''
+  assert.match(shellBrand, /className=\{`shell__brand/)
+  assert.match(shellBrand, /aria-expanded=\{navigationOpen\}/)
+  const onClick = shellBrand.match(/onClick=\{\(e\) => \{[\s\S]*?\n {8}\}\}/)?.[0] || ''
   assert.match(onClick, /if \(logoGesture\.consumeSuppressedClick\(e\.detail\)\) return/)
-  assert.match(onClick, /drawerOpen \? closeDrawer\(\) : openDrawer\(\)/)
+  assert.match(onClick, /onToggleNavigation\(\)/)
   assert.doesNotMatch(onClick, /setTimeout\(/, 'the tap path must carry no timer')
 })
 
@@ -341,7 +349,7 @@ test('completion feedback (SINGLE PULSE): one completion haptic, NO mid-hold ram
   assert.match(logoGestureSrc, /useEffect\(\(\) => \(\) => \{ stopRaf\(\) \}, \[stopRaf\]\)/)
 })
 
-test('Shell wires the toggle handler, brand ref, and Shift+Enter (no drag-deny vibrate)', () => {
+test('ShellBrand isolates gesture state and wires the brand ref + Shift+Enter', () => {
   const handler = shell.match(/const handleToggleViewMode = useCallback\(\(\) => \{[\s\S]*?\}, \[[^\]]*\]\)/)?.[0] || ''
   assert.match(handler, /convertSettingsForModeTransition\(\)/)
   assert.match(handler, /dispatchWorkspace\(\{ type: 'SET_VIEW_MODE', mode: 'toggle' \}\)/)
@@ -349,14 +357,16 @@ test('Shell wires the toggle handler, brand ref, and Shift+Enter (no drag-deny v
   // The gesture hook receives the toggle + the brand ref (for the ring var). The
   // ref is UNIFIED with the desktop-sidebar focus ref (one ref, both jobs) after
   // the sidebar rebase.
-  assert.match(shell, /useLogoModeGesture\(\{[\s\S]*?onToggleMode: handleToggleViewMode/)
-  assert.match(shell, /brandRef: brandButtonRef,/)
+  assert.doesNotMatch(shell, /useLogoModeGesture\(/)
+  assert.match(shellBrand, /const ShellBrand = memo\(function ShellBrand/)
+  assert.match(shellBrand, /useLogoModeGesture\(\{[\s\S]*?onToggleMode,/)
+  assert.match(shell, /<ShellBrand[\s\S]*?brandRef=\{brandButtonRef\}/)
   // The drag-deny vibrate is DEAD (point 15: dragging is building, never denied).
   assert.doesNotMatch(shell, /viewModeVibrateRef|onDragBlocked/)
   // Keyboard path: Shift+Enter flips the mode (preventDefault keeps it off the drawer).
-  assert.match(shell, /e\.shiftKey && e\.key === 'Enter'/)
-  assert.match(shell, /brandKeyboardModeClickRef\.current = true/)
-  assert.match(shell, /brandKeyboardModeClickRef\.current && e\.detail === 0/)
+  assert.match(shellBrand, /e\.shiftKey && e\.key === 'Enter'/)
+  assert.match(shellBrand, /keyboardModeClickRef\.current = true/)
+  assert.match(shellBrand, /keyboardModeClickRef\.current && e\.detail === 0/)
 })
 
 test('the logo mark IS the indicator (CHARGE): compress on hold + spring/snap + 180° twist + tint + living halo', () => {
@@ -385,8 +395,8 @@ test('the logo mark IS the indicator (CHARGE): compress on hold + spring/snap + 
   const halo = shellCss.match(/\.shell__logo-halo\s*\{[\s\S]*?\}/)?.[0] || ''
   assert.match(halo, /radial-gradient/)
   assert.match(halo, /var\(--halo-alpha, 0\.5\)/)
-  assert.match(halo, /translate:\s*var\(--halo-x, 0px\) var\(--halo-y, 0px\)/)
-  assert.match(halo, /scale:\s*var\(--halo-scale, 1\)/)
+  assert.match(halo, /translate:\s*0 0/)
+  assert.match(halo, /scale:\s*1/)
   assert.match(shellCss, /\.shell__brand--builder \.shell__logo-halo\s*\{[\s\S]*?opacity:\s*var\(--halo-opacity, 0\.85\)/)
   // Per-theme alpha token: quieter in dark.
   assert.match(shellCss, /\.shell \{ --halo-alpha: 0\.5; \}/)
@@ -408,7 +418,7 @@ test('the brand logo img is pointer-inert so a hold never raises the native imag
   assert.match(logoRule, /user-select:\s*none/)
   assert.match(logoRule, /-webkit-user-select:\s*none/)
   // The element itself is not draggable (kills the drag-image path).
-  assert.match(shell, /<img\s+className="shell__logo"[\s\S]*?draggable=\{false\}[\s\S]*?\/>/)
+  assert.match(shellBrand, /<img\s+className="shell__logo"[\s\S]*?draggable=\{false\}[\s\S]*?\/>/)
   // The button suppresses the native contextmenu for touch/pen UNCONDITIONALLY —
   // not only while a press is live — which closes the timing race that leaked the
   // menu: the browser's long-press contextmenu can fire just AFTER the ~450ms hold
@@ -422,9 +432,9 @@ test('the living halo lifecycle: lit only in builder mode, one allocation-free r
   // Gated on `active` (builder mode) — nothing runs when inactive, and the effect
   // re-runs on active flip so it turns ON at ignite and OFF (cleanup) at snap.
   assert.match(livingHaloSrc, /if \(!el \|\| !active\) return undefined/)
-  assert.match(livingHaloSrc, /\}, \[brandRef, active\]\)/)
+  assert.match(livingHaloSrc, /\}, \[haloRef, active\]\)/)
   // Reduced motion: settle static CSS vars, NO rAF at all.
-  assert.match(livingHaloSrc, /if \(prefersReducedMotion\(\)\) \{[\s\S]*?setProperty\('--halo-scale', '1'\)[\s\S]*?return undefined/)
+  assert.match(livingHaloSrc, /if \(prefersReducedMotion\(\)\) \{[\s\S]*?el\.style\.scale = '1'[\s\S]*?clearHaloStyles\(el\)/)
   // One reused frame object → zero per-frame allocation; the drift comes from the
   // pure haloFrame (tested in logoHoldMachine.test.js).
   assert.match(livingHaloSrc, /const frame = \{\} \/\/ reused every tick/)
@@ -434,19 +444,21 @@ test('the living halo lifecycle: lit only in builder mode, one allocation-free r
   assert.match(livingHaloSrc, /cancelAnimationFrame\(raf\)/)
   // Cleanup kills the loop instantly (the snap) + drops the visibility listener.
   assert.match(livingHaloSrc, /return \(\) => \{[\s\S]*?cancelAnimationFrame\(raf\)[\s\S]*?removeEventListener\('visibilitychange'/)
-  // Shell lights the halo only in builder mode, keyed to the SAME brand ref.
-  assert.match(shell, /useLivingHalo\(\{ brandRef: brandButtonRef, active: builderModeActive \}\)/)
-  assert.match(shell, /<span className="shell__logo-halo" aria-hidden/)
+  // The isolated brand lights a leaf ref only in builder mode and cleans inline styles.
+  assert.match(shellBrand, /useLivingHalo\(\{ haloRef, active: splitsEnabled && builderModeActive \}\)/)
+  assert.match(shellBrand, /<span ref=\{haloRef\} className="shell__logo-halo" aria-hidden/)
+  assert.match(livingHaloSrc, /clearHaloStyles\(el\)/)
 })
 
-test('the room flourish (CHARGE): panes DEAL in on class-apply, suppressed while resizing, instant under reduced motion', () => {
+test('the room flourish (CHARGE): panes DEAL once on class-apply and resize guards never restart it', () => {
   // The divider-DRAW is gone; the entry flourish is the card-DEAL on the pane wrapper.
   assert.doesNotMatch(css, /workspace-divider-draw/)
   const paned = css.match(/\.shell__view--paned\s*\{[\s\S]*?\}/)?.[0] || ''
   assert.match(paned, /animation:\s*shell-pane-deal 400ms cubic-bezier\(0\.22, 1, 0\.36, 1\)/)
   assert.match(css, /@keyframes shell-pane-deal\s*\{[\s\S]*?translateX\(18px\)[\s\S]*?translateX\(0\)/)
-  // A live resize must not re-deal every frame.
-  assert.match(css, /\.workspace--resizing \.shell__view--paned\s*\{\s*\n\s*animation: none;/)
+  // Live geometry suppresses only the layout transition. Overriding animation
+  // here and restoring it afterward restarts shell-pane-deal on a permanent pane.
+  assert.doesNotMatch(css, /workspace--(?:container-resizing|divider-dragging)[^{]*\{[^}]*animation:/)
   // Reduced motion drops the deal (and the layout-commit transition).
   const reduced = css.match(/@media \(prefers-reduced-motion: reduce\)\s*\{[\s\S]*?\n\}/)?.[0] || ''
   assert.match(reduced, /\.shell__view--paned \{ transition: none; animation: none; \}/)
@@ -526,10 +538,28 @@ test('the logo keeps the stable "Toggle navigation" name; gesture rides aria-des
   // The accessible NAME stays stable (drawer semantics + e2e selectors depend on
   // it); the hold/keyboard path is a supplementary aria-description, and mode state
   // rides a polite live region (not a conflicting aria-pressed).
-  assert.match(shell, /aria-label="Toggle navigation"/)
-  assert.match(shell, /aria-description=\{paneModel\.WORKSPACE_SPLITS_ENABLED\s*\n?\s*\? 'Hold or press Shift\+Enter for builder mode'/)
-  assert.match(shell, /role="status" aria-live="polite"/)
-  assert.match(shell, /builderModeActive \? 'Builder mode' : 'Single screen'/)
+  assert.match(shellBrand, /aria-label="Toggle navigation"/)
+  assert.match(shellBrand, /aria-description=\{splitsEnabled\s*\n?\s*\? 'Hold or press Shift\+Enter for builder mode'/)
+  assert.match(shellBrand, /role="status" aria-live="polite"/)
+  assert.match(shellBrand, /builderModeActive \? 'Builder mode' : 'Single screen'/)
+})
+
+test('the mobile modal keeps its existing brand close path while the workspace is inert', () => {
+  const header = shell.match(/<header className="shell__bar"[^>]*>/)?.[0] || ''
+  assert.doesNotMatch(header, /inert=/)
+  assert.match(shell, /<main className="shell__content" inert=\{modalDrawerOpen\}/)
+  assert.match(shellBrand, /aria-expanded=\{navigationOpen\}/)
+  assert.match(shell, /drawerOpen \? closeDrawer\(\) : openDrawer\(\)/)
+})
+
+test('large drawer lists memoize ordering and row actions without changing row ownership', () => {
+  assert.match(drawer, /const allChats = useMemo\(/)
+  assert.match(drawer, /const sortedApps = useMemo\(/)
+  assert.match(drawer, /const rowActions = useMemo\(/)
+  assert.match(drawer, /const DrawerRow = memo\(function DrawerRow/)
+  assert.match(drawer, /item=\{chat\}[\s\S]*?actions=\{rowActions\}/)
+  assert.match(drawer, /item=\{app\}[\s\S]*?actions=\{rowActions\}/)
+  assert.doesNotMatch(drawer, /onSelect=\{\(\) => on(?:Chat|App)/)
 })
 
 test('the Settings surface responds to PANE width via a query container', () => {

--- a/frontend/src/components/Shell/useLivingHalo.js
+++ b/frontend/src/components/Shell/useLivingHalo.js
@@ -7,27 +7,32 @@ import { prefersReducedMotion } from './useLogoModeGesture.js'
 // irrational frequencies (never a visible loop). One single rAF, ONE reused frame
 // object → zero per-frame allocation. Pauses on a hidden tab and is killed
 // instantly when builder mode deactivates (the effect cleanup). Under reduced
-// motion it settles to a static low halo with NO rAF at all. Writes the drift as
-// CSS vars on the brand element; the CSS (Shell.css) composes them. Per-theme base
+// motion it settles to a static low halo with NO rAF at all. The animated values
+// are written directly to the halo element so each frame invalidates only that
+// leaf, rather than a brand ancestor and all of its descendants. Per-theme base
 // alpha rides the --halo-alpha token.
-export default function useLivingHalo({ brandRef, active }) {
+function clearHaloStyles(el) {
+  el.style.removeProperty('translate')
+  el.style.removeProperty('scale')
+  el.style.removeProperty('--halo-opacity')
+}
+
+export default function useLivingHalo({ haloRef, active }) {
   useEffect(() => {
-    const el = brandRef?.current
+    const el = haloRef?.current
     if (!el || !active) return undefined
     if (prefersReducedMotion()) {
-      el.style.setProperty('--halo-scale', '1')
-      el.style.setProperty('--halo-x', '0px')
-      el.style.setProperty('--halo-y', '0px')
+      el.style.translate = '0px 0px'
+      el.style.scale = '1'
       el.style.setProperty('--halo-opacity', '0.8')
-      return undefined
+      return () => clearHaloStyles(el)
     }
     let raf = 0
     const frame = {} // reused every tick — no allocation in the loop
     const loop = () => {
       haloFrame(performance.now(), frame)
-      el.style.setProperty('--halo-scale', String(frame.scale))
-      el.style.setProperty('--halo-x', `${frame.x}px`)
-      el.style.setProperty('--halo-y', `${frame.y}px`)
+      el.style.translate = `${frame.x}px ${frame.y}px`
+      el.style.scale = String(frame.scale)
       el.style.setProperty('--halo-opacity', String(frame.opacity))
       raf = requestAnimationFrame(loop)
     }
@@ -43,6 +48,7 @@ export default function useLivingHalo({ brandRef, active }) {
     return () => {
       if (raf) cancelAnimationFrame(raf)
       document.removeEventListener('visibilitychange', onVisibility)
+      clearHaloStyles(el)
     }
-  }, [brandRef, active])
+  }, [haloRef, active])
 }

--- a/frontend/src/components/Shell/workspace.css
+++ b/frontend/src/components/Shell/workspace.css
@@ -16,15 +16,19 @@
   /* 180ms geometry bloom on a layout commit (drop / auto-split / pane close),
      design §3.4 / §6.2. Suppressed during a CONTINUOUS operation — a live
      divider drag or a window resize write rects every frame and must stay crisp
-     — via the `.workspace--resizing` root class Shell/WorkspaceChrome toggle. */
+     — via the operation-specific root classes owned by Shell and
+     WorkspaceChrome. Separate ownership matters: a debounced container resize
+     must never clear the divider drag's transition guard (or vice versa). */
   transition: top 180ms ease-out, left 180ms ease-out,
     width 180ms ease-out, height 180ms ease-out;
   /* Entry CARD-DEAL flourish (replaces the divider-draw): whenever a wrapper
      becomes a tiled pane — a builder-mode enter, a drop that unfolds the parked
      layout, or a split — it deals in from the right with a brief lift (shadow +
      radius) and settles flush. The rects settle on the 180ms transition above, so
-     the deal + settle read as one gesture. Plays only on class-apply (a resize
-     keeps --paned, so it never replays). Reduced-motion drops it (below). */
+     the deal + settle read as one gesture. Plays only on class-apply: live geometry
+     operations never override `animation`, because restoring an overridden
+     animation restarts the deal on an already-mounted pane. Reduced-motion drops
+     it (below). */
   animation: shell-pane-deal 400ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 @keyframes shell-pane-deal {
@@ -42,12 +46,12 @@
     border-radius: 0;
   }
 }
-.workspace--resizing .shell__view--paned {
-  animation: none; /* a live resize must not re-deal each frame */
-}
-.workspace--resizing .shell__view--paned,
-.workspace--resizing .workspace__strip,
-.workspace--resizing .workspace__divider {
+.workspace--container-resizing .shell__view--paned,
+.workspace--container-resizing .workspace__strip,
+.workspace--container-resizing .workspace__divider,
+.workspace--divider-dragging .shell__view--paned,
+.workspace--divider-dragging .workspace__strip,
+.workspace--divider-dragging .workspace__divider {
   transition: none;
 }
 
@@ -140,7 +144,7 @@
   border-radius: 8px 8px 0 0;
   /* Match the paned wrappers' 180ms geometry bloom on a layout commit, so a
      strip glides with its pane. Suppressed during a continuous resize via
-     `.workspace--resizing` above. */
+     the live-geometry guards above. */
   transition: top 180ms ease-out, left 180ms ease-out,
     width 180ms ease-out, height 180ms ease-out;
   /* Strips sit ABOVE dividers (z:4): a horizontal divider's 44px hit target

--- a/tests/navigation.spec.mjs
+++ b/tests/navigation.spec.mjs
@@ -470,7 +470,7 @@ test.describe('Back button edge cases', () => {
     // Regression guard for the bug where closeDrawer's history.back()
     // was popping the navStack and yanking the user out of the current
     // view. Sequence: navigate to settings, open drawer, close it via
-    // the X button — must stay on settings, not pop back to chat.
+    // the brand toggle — must stay on settings, not pop back to chat.
     await setup(page)
 
     // Move to a non-default view (settings) so navStack is non-empty.
@@ -481,7 +481,7 @@ test.describe('Back button edge cases', () => {
     )
     expect(onSettings).toBe(true)
 
-    // Open drawer (sentinel + drawer open) and close via the in-panel button.
+    // Open drawer (sentinel + drawer open) and close via the brand toggle.
     await openDrawer(page)
     expect((await getNavState(page)).drawerOpen).toBe(true)
 
@@ -684,7 +684,7 @@ test.describe('Drawer state machine — extended invariants', () => {
   })
 
   test('19. closeDrawer via toggle leaves history unchanged; back from open navigates', async ({ page }) => {
-    // Post-rewrite: the X-button close and the OS back-gesture from
+    // Post-rewrite: the brand-toggle close and the OS back-gesture from
     // drawer-open are no longer equivalent. Toggle is pure state;
     // back is a real navigation. Document the difference.
     await setup(page)
@@ -1186,8 +1186,8 @@ test.describe('Drawer close paths converge through handleBack', () => {
     await expect(page.locator('.drawer-overlay')).toHaveCSS('pointer-events', 'none')
   })
 
-  test('23. In-panel close button does not navigate, even from a deep view', async ({ page }) => {
-    // Same regression as test 22 but via the explicit mobile close control.
+  test('23. Brand toggle close does not navigate, even from a deep view', async ({ page }) => {
+    // Same regression as test 22 but via the existing mobile brand toggle.
     // Test 9 covers the basic case from a non-default view; this test keeps
     // the close-without-navigation contract explicit.
     await setup(page)

--- a/tests/tabs.spec.mjs
+++ b/tests/tabs.spec.mjs
@@ -133,6 +133,53 @@ async function paneChromeDeltas(page) {
   }))
 }
 
+/** Sample pane/strip alignment on every animation frame while the navigation
+ *  toggle changes the desktop content width. A settled-only assertion misses
+ *  transient animation restarts, which is exactly when the pane can drift away
+ *  from its strip. */
+async function toggleAndSamplePaneChrome(page) {
+  return page.evaluate(async () => {
+    const maximum = { left: 0, width: 0, seam: 0 }
+    let frames = 0
+    let comparisons = 0
+    const sample = () => {
+      for (const strip of document.querySelectorAll('.workspace__strip')) {
+        const active = strip.querySelector('.shell__tab--active .shell__tab-open')
+        const key = active?.dataset.dragKey
+        const pane = key
+          ? document.querySelector(`.shell__view--paned[data-tab-key="${CSS.escape(key)}"]`)
+          : null
+        if (!pane) continue
+        const stripRect = strip.getBoundingClientRect()
+        const paneRect = pane.getBoundingClientRect()
+        maximum.left = Math.max(maximum.left, Math.abs(stripRect.left - paneRect.left))
+        maximum.width = Math.max(maximum.width, Math.abs(stripRect.width - paneRect.width))
+        maximum.seam = Math.max(maximum.seam, Math.abs(stripRect.bottom - paneRect.top))
+        comparisons += 1
+      }
+      frames += 1
+    }
+
+    const toggle = document.querySelector('button[aria-label="Toggle navigation"]')
+    if (!toggle) throw new Error('navigation toggle not found')
+    await new Promise(resolve => {
+      let startedAt = null
+      const tick = (now) => {
+        if (startedAt === null) {
+          startedAt = now
+          sample()
+          toggle.click()
+        }
+        sample()
+        if (now - startedAt >= 650) resolve()
+        else requestAnimationFrame(tick)
+      }
+      requestAnimationFrame(tick)
+    })
+    return { maximum, frames, comparisons, expanded: toggle.getAttribute('aria-expanded') }
+  })
+}
+
 async function seedTabs(page, tabs, { viewMode } = {}) {
   // Builder mode ('panes', the default) now ALWAYS shows the strip, so the
   // single-pane strip's pinning/unpinning contract (pin engages, unpin to zero
@@ -301,11 +348,17 @@ test.describe('Tabs', () => {
     const navigationToggle = page.getByRole('button', { name: 'Toggle navigation' })
     await expect(navigationToggle).toHaveAttribute('aria-expanded', 'true')
     await expect.poll(() => paneChromeDeltas(page)).toEqual(aligned)
-    await navigationToggle.click()
-    await expect(navigationToggle).toHaveAttribute('aria-expanded', 'false')
+    const closingMotion = await toggleAndSamplePaneChrome(page)
+    expect(closingMotion.expanded).toBe('false')
+    expect(closingMotion.frames).toBeGreaterThan(5)
+    expect(closingMotion.comparisons).toBeGreaterThan(10)
+    expect(Math.max(...Object.values(closingMotion.maximum))).toBeLessThanOrEqual(1)
     await expect.poll(() => paneChromeDeltas(page)).toEqual(aligned)
-    await navigationToggle.click()
-    await expect(navigationToggle).toHaveAttribute('aria-expanded', 'true')
+    const openingMotion = await toggleAndSamplePaneChrome(page)
+    expect(openingMotion.expanded).toBe('true')
+    expect(openingMotion.frames).toBeGreaterThan(5)
+    expect(openingMotion.comparisons).toBeGreaterThan(10)
+    expect(Math.max(...Object.values(openingMotion.maximum))).toBeLessThanOrEqual(1)
     await expect.poll(() => paneChromeDeltas(page)).toEqual(aligned)
 
     // Native chat content focuses its pane through wrapper capture.


### PR DESCRIPTION
## Summary
- keep the desktop drawer docked as layout while preserving the mobile brand toggle as the modal close affordance
- separate container-resize and divider-drag transition ownership so pane content and tab strips remain aligned throughout drawer motion
- isolate brand gesture state and living-halo writes to leaf nodes, and memoize drawer rows to avoid rerendering the full navigation tree
- add transient frame-by-frame pane/strip alignment coverage plus updated drawer accessibility and lifecycle contracts

## Validation
- frontend unit and hook suites: 1,539 passed
- frontend production build
- exact committed-image Playwright navigation and tabs suites: 48 passed
- manual desktop and 426px mobile checks against the isolated production bundle
- final diff, conflict-marker, and whitespace audits