### PR TITLE
Harden browser test protocol and ignore build backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ dist/
 .vite-tmp-rebuild/
 .dist-next/
 .dist-old/
+# Legacy/ad-hoc frontend publish backups are generated artifacts too.
+dist.old/
 .dist-staging/
 .dist-rebuild/
 .assets-attic/

--- a/scripts/test-git-privacy-gates.sh
+++ b/scripts/test-git-privacy-gates.sh
@@ -40,6 +40,11 @@ ln -s "$TMP/private-docs" "$repo/docs"
 git -C "$repo" check-ignore -q docs || fail ".gitignore missed docs symlink"
 rm "$repo/docs"
 
+# A legacy frontend publish-backup spelling once entered production as a
+# 100-file local reconciliation commit. It is generated output, not source.
+git -C "$repo" check-ignore -q frontend/dist.old/assets/app.js \
+  || fail ".gitignore missed frontend/dist.old build backup"
+
 git -C "$repo" add .gitignore scripts
 git -C "$repo" commit -qm baseline
 

--- a/tests/_mockAcceptedMessages.mjs
+++ b/tests/_mockAcceptedMessages.mjs
@@ -1,0 +1,61 @@
+/**
+ * Mock POST /messages without starting an agent while preserving the real
+ * durability contract: a successful send remains on subsequent chat-detail
+ * GETs. A bare 202 makes the optimistic row disappear on terminal refresh and
+ * turns unrelated rerenders into deterministic false failures.
+ */
+export async function mockAcceptedMessages(page) {
+  const acceptedByChat = new Map()
+
+  await page.route(/\/api\/chats\/[0-9a-f-]+(?:\?.*)?$/, async route => {
+    const request = route.request()
+    if (request.method() !== 'GET') return route.fallback()
+
+    const chatId = new URL(request.url()).pathname.split('/').pop()
+    const accepted = acceptedByChat.get(chatId)
+    if (!accepted?.length) return route.fallback()
+
+    const response = await route.fetch()
+    if (!response.ok()) return route.fulfill({ response })
+
+    const detail = await response.json()
+    const persisted = Array.isArray(detail.messages) ? detail.messages : []
+    const persistedCids = new Set(persisted.map(message => message?.cid).filter(Boolean))
+    const missing = accepted.filter(message => !persistedCids.has(message.cid))
+    const messages = [...persisted, ...missing]
+
+    return route.fulfill({
+      response,
+      json: {
+        ...detail,
+        messages,
+        total: Math.max(Number(detail.total) || 0, messages.length),
+      },
+    })
+  })
+
+  await page.route(/\/api\/chats\/[0-9a-f-]+\/messages$/, async route => {
+    const request = route.request()
+    if (request.method() !== 'POST') return route.fallback()
+
+    const chatId = new URL(request.url()).pathname.split('/').at(-2)
+    const body = request.postDataJSON() || {}
+    const message = {
+      role: 'user',
+      content: body.content || '',
+      ts: Date.now(),
+      cid: body.cid || `e2e-${crypto.randomUUID()}`,
+      ...(body.hidden ? { hidden: true } : {}),
+      ...(body.attachments ? { attachments: body.attachments } : {}),
+      ...(body.timezone ? { timezone: body.timezone } : {}),
+      ...(body.viewport ? { viewport: body.viewport } : {}),
+    }
+    acceptedByChat.set(chatId, [...(acceptedByChat.get(chatId) || []), message])
+
+    return route.fulfill({
+      status: 202,
+      contentType: 'application/json',
+      json: { status: 'started', message },
+    })
+  })
+}

--- a/tests/spacer.spec.mjs
+++ b/tests/spacer.spec.mjs
@@ -10,6 +10,7 @@
  */
 import { test, expect } from '@playwright/test'
 import { createTaggedChat, attachCleanup } from './_chatTracker.mjs'
+import { mockAcceptedMessages } from './_mockAcceptedMessages.mjs'
 
 const BASE = process.env.MOBIUS_URL || 'http://localhost:8001'
 
@@ -21,68 +22,6 @@ attachCleanup()
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/**
- * Mock the send contract without losing the durable message on the terminal
- * detail refetch. A bare 202 is not protocol-faithful: ChatView refetches the
- * chat after a stream ends, and the real endpoint has committed the accepted
- * user row by then.
- */
-async function mockAcceptedMessages(page) {
-  const acceptedByChat = new Map()
-
-  await page.route(/\/api\/chats\/[0-9a-f-]+(?:\?.*)?$/, async route => {
-    const request = route.request()
-    if (request.method() !== 'GET') return route.fallback()
-
-    const chatId = new URL(request.url()).pathname.split('/').pop()
-    const accepted = acceptedByChat.get(chatId)
-    if (!accepted?.length) return route.fallback()
-
-    const response = await route.fetch()
-    if (!response.ok()) return route.fulfill({ response })
-
-    const detail = await response.json()
-    const persisted = Array.isArray(detail.messages) ? detail.messages : []
-    const persistedCids = new Set(persisted.map(message => message?.cid).filter(Boolean))
-    const missing = accepted.filter(message => !persistedCids.has(message.cid))
-    const messages = [...persisted, ...missing]
-
-    return route.fulfill({
-      response,
-      json: {
-        ...detail,
-        messages,
-        total: Math.max(Number(detail.total) || 0, messages.length),
-      },
-    })
-  })
-
-  await page.route(/\/api\/chats\/[0-9a-f-]+\/messages$/, async route => {
-    const request = route.request()
-    if (request.method() !== 'POST') return route.fallback()
-
-    const chatId = new URL(request.url()).pathname.split('/').at(-2)
-    const body = request.postDataJSON() || {}
-    const message = {
-      role: 'user',
-      content: body.content || '',
-      ts: Date.now(),
-      cid: body.cid || `spacer-${crypto.randomUUID()}`,
-      ...(body.hidden ? { hidden: true } : {}),
-      ...(body.attachments ? { attachments: body.attachments } : {}),
-      ...(body.timezone ? { timezone: body.timezone } : {}),
-      ...(body.viewport ? { viewport: body.viewport } : {}),
-    }
-    acceptedByChat.set(chatId, [...(acceptedByChat.get(chatId) || []), message])
-
-    return route.fulfill({
-      status: 202,
-      contentType: 'application/json',
-      json: { status: 'started', message },
-    })
-  })
-}
 
 /** Log in and return an authenticated page with API interception. */
 async function setup(page, viewport = { width: 412, height: 915 }) {

--- a/tests/tabs.spec.mjs
+++ b/tests/tabs.spec.mjs
@@ -14,6 +14,7 @@
  */
 import { test, expect } from '@playwright/test'
 import { createTaggedChat, attachCleanup } from './_chatTracker.mjs'
+import { mockAcceptedMessages } from './_mockAcceptedMessages.mjs'
 import * as paneModel from '../frontend/src/components/Shell/paneModel.js'
 
 const BASE = process.env.MOBIUS_URL || 'http://localhost:8001'
@@ -26,7 +27,7 @@ attachCleanup()
  *  the app origin), and create a worker-tagged chat. Returns the chat. */
 async function bootAndCreateChat(page, label, viewport = { width: 412, height: 915 }) {
   await page.setViewportSize(viewport)
-  await page.route(/\/api\/chats\/[0-9a-f-]+\/messages$/, r => r.fulfill({ status: 202, body: '{}' }))
+  await mockAcceptedMessages(page)
   await page.route(/\/api\/chats\/[0-9a-f-]+\/stream$/, r => r.fulfill({ status: 204, body: '' }))
   await page.route('**/api/chat/stop', r => r.fulfill({ status: 200, body: '{}' }))
   const initialAppsResponse = page.waitForResponse(response =>


### PR DESCRIPTION
## Summary

- Extract the protocol-faithful accepted-message mock already used by the spacer suite and reuse it in the tab suite.
- Keep a mocked successful send visible on subsequent chat-detail reads, matching the production durability contract instead of returning a bare `202` followed by an empty real snapshot.
- Ignore the legacy `frontend/dist.old/` build-backup spelling so production reconciliation cannot auto-commit it as source.

The red tab E2E was not a shell state regression: its final trace retained the same chat but lost the optimistic-only message when the terminal detail refresh reached the real empty backend row. The speculative shell callback change was removed; this PR contains no shell runtime change.

The production-only platform commit still contains exactly 100 files under `frontend/dist.old/` and no source changes.

## Verification

- isolated disposable stack at exact commit: targeted `tests/tabs.spec.mjs` regression passed
- shared helper is the existing spacer protocol mock, moved without behavioral change
- `scripts/check-private-paths.sh`
- `scripts/test-git-privacy-gates.sh`
- `git check-ignore frontend/dist.old/assets/app.js`
- full PR CI matrix