### PR TITLE
Harden delayed wheel scroll ownership and CI reproduction

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -572,9 +572,12 @@ and attaches their rule ids to new diagnostic chats. The Playwright lock-in spec
   rendering load the browser may deliver that scroll later. Ownership begins only for
   inputs whose default action can scroll the transcript; ordinary typing, Enter, and
   control activation are not reader scroll intent. Pointer/touch release handles taps,
-  while wheel/scrolling-key input that produces no scroll releases on the next frame;
-  only after a real scroll lands does the short momentum window begin. A bounded
-  dead-man remains the final escape hatch for an interrupted gesture.
+  while scrolling-key input that produces no scroll releases on the next frame. Wheel
+  input gets that early release only when its direction is exactly clamped at the
+  matching scroll edge. An elapsed frame is not evidence that an in-range wheel was a
+  no-op: renderer/compositor load can update geometry before the main-thread `scroll`
+  handler runs. Only after a real scroll lands does the short momentum window begin. A
+  bounded dead-man remains the final escape hatch for any interrupted gesture.
 - **R5a — Attention nudges reveal the usable tail.** Tapping an offscreen question
   or paused-turn nudge is an explicit one-shot reading action: it lands at the
   physical tail, including the list's composer-clearance padding, so the card's

--- a/backend/tests/test_verify_test_runtime.py
+++ b/backend/tests/test_verify_test_runtime.py
@@ -218,7 +218,9 @@ def test_local_browser_e2e_is_explicit_and_disposable():
   assert 'git clone --quiet --no-local "$ROOT" "$snapshot_dir"' in runner
   assert '--project-directory "$snapshot_dir"' in runner
   assert 'cd "$snapshot_dir"' in runner
-  assert '"$snapshot_dir/node_modules/.bin/playwright" test "$@" --workers=1' in runner
+  assert 'MOBIUS_LOCAL_E2E_WORKERS:-1' in runner
+  assert 'MOBIUS_LOCAL_E2E_WORKERS must be a positive integer' in runner
+  assert '"$snapshot_dir/node_modules/.bin/playwright" test "$@" --workers="$e2e_workers"' in runner
   assert "Local E2E artifacts retained at:" in runner
   assert 'compose logs --no-color app caddy recoveryd fake-tandoor' in runner
   assert 'MOBIUS_LOCAL_E2E_KEEP_CACHE' in runner

--- a/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
+++ b/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
@@ -236,6 +236,16 @@ test('only provably clamped wheel input gets a next-frame no-scroll release', ()
   }), true, 'an upward wheel already at the top is a no-op')
   assert.equal(readerInputNeedsFrameRelease('wheel', {
     ...middle,
+    scrollTop: 1199,
+    deltaY: 300,
+  }), false, 'a wheel one pixel from the bottom can still move')
+  assert.equal(readerInputNeedsFrameRelease('wheel', {
+    ...middle,
+    scrollTop: 1,
+    deltaY: -300,
+  }), false, 'a wheel one pixel from the top can still move')
+  assert.equal(readerInputNeedsFrameRelease('wheel', {
+    ...middle,
     deltaY: 0,
   }), true, 'a horizontal-only wheel cannot move this vertical controller')
   assert.equal(readerInputNeedsFrameRelease('keydown'), true)

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -31,8 +31,10 @@
  * User-gesture detection: pointerdown/wheel/touchstart/touchmove/keydown hold
  * reader ownership until the first scroll event actually arrives, then keep a
  * 250ms momentum window in which scroll events are user-driven and can
- * transition the mode. Outside that handoff/window, scrolls come from our
- * applyMode or browser clamps and are ignored.
+ * transition the mode. Wheel input is released early only when its direction
+ * is exactly clamped at the matching edge; elapsed frames cannot prove that an
+ * in-range gesture was a no-op under renderer load. Outside that handoff/window,
+ * scrolls come from our applyMode or browser clamps and are ignored.
  *
  * See ARCHITECTURE.md "Chat scroll + steer contract" for the full design.
  */
@@ -100,9 +102,10 @@ function _appendScrollTrace(bucket, entry) {
   const existing = window.__mobiusChatScrollTrace
   const trace = existing?.version === 1
     ? existing
-    : { version: 1, transitions: [], writes: [] }
-  const rows = trace[bucket]
-  if (!Array.isArray(rows)) return
+    : { version: 1, transitions: [], writes: [], events: [] }
+  const rows = Array.isArray(trace[bucket])
+    ? trace[bucket]
+    : (trace[bucket] = [])
   rows.push(entry)
   if (rows.length > SCROLL_TRACE_LIMIT) {
     rows.splice(0, rows.length - SCROLL_TRACE_LIMIT)
@@ -568,11 +571,11 @@ export function readerInputActivatesDisclosure(
 
 /** Wheel and keyboard input have no pointer/touch release event. Keyboard
  * input keeps the next-frame no-scroll release. A wheel gets that fast release
- * only when its requested direction is already clamped at the corresponding
- * edge (or has no vertical delta). For a wheel that can move, the compositor's
- * actual scroll event owns the release; under load it can arrive after rAF.
- * Releasing every wheel after one frame lost that event and left the viewport
- * physically at the bottom while its durable mode still said ANCHOR_AT. */
+ * only when its requested direction is exactly clamped at the corresponding
+ * edge (or has no vertical delta). A proximity epsilon is not sufficient: a
+ * wheel can still move through that final gap, and its compositor scroll can
+ * arrive after rAF. For a wheel that can move, the actual scroll event owns the
+ * release. */
 export function readerInputNeedsFrameRelease(
   type,
   {
@@ -587,8 +590,8 @@ export function readerInputNeedsFrameRelease(
   if (!Number.isFinite(deltaY) || deltaY === 0) return true
 
   const maxScrollTop = Math.max(0, scrollHeight - clientHeight)
-  if (deltaY < 0) return scrollTop <= PHYSICAL_BOTTOM_EPSILON_PX
-  return scrollTop >= maxScrollTop - PHYSICAL_BOTTOM_EPSILON_PX
+  if (deltaY < 0) return scrollTop <= 0
+  return scrollTop >= maxScrollTop
 }
 
 
@@ -1462,13 +1465,14 @@ export default function useScrollMode({
       gestureWindowUntilRef.current = 0
       clearTimeout(pendingGestureTimerRef.current)
       pendingGestureTimerRef.current = 0
+      recordTrace('events', 'reader:no-scroll-release', { scrollEl })
       resumeLayoutAfterGestureRef.current?.()
     }
     const scheduleNoScrollRelease = () => {
       if (gestureWindowUntilRef.current !== Number.POSITIVE_INFINITY) return
-      // Scroll events are delivered in the rendering step before rAF. Yield
-      // one frame so a scroll already caused by this gesture can claim the
-      // viewport before an input that changed nothing releases it.
+      // Geometry has already proved this input is clamped at its matching edge
+      // (or it is an unknown focus-navigation key). Yield one frame so any
+      // synchronous scroll can still claim the viewport before release.
       const sequence = gestureSequenceRef.current
       cancelAnimationFrame(pendingGestureReleaseRafRef.current)
       pendingGestureReleaseRafRef.current = requestAnimationFrame(() => {
@@ -1485,6 +1489,9 @@ export default function useScrollMode({
       )
       if (!activatesDisclosure
           && !readerInputMayScroll(event?.type, event?.key)) return
+      recordTrace('events', `reader:input-${event?.type || 'unknown'}`, {
+        scrollEl,
+      })
       if (activatesDisclosure) {
         // A disclosure tap says "hold what I am reading", not "keep following
         // the conversation tail". Latch that intent BEFORE React changes the
@@ -1539,7 +1546,11 @@ export default function useScrollMode({
     const onScroll = () => {
       nearScrollBottomRef.current = isNearScrollBottom(scrollEl)
       const userDriven = performance.now() < gestureWindowUntilRef.current
-      if (!userDriven) return
+      if (!userDriven) {
+        recordTrace('events', 'scroll:unowned', { scrollEl })
+        return
+      }
+      recordTrace('events', 'scroll:owned', { scrollEl })
       if (gestureWindowUntilRef.current === Number.POSITIVE_INFINITY) {
         clearTimeout(pendingGestureTimerRef.current)
         pendingGestureTimerRef.current = 0

--- a/scripts/playwright-local.sh
+++ b/scripts/playwright-local.sh
@@ -11,6 +11,9 @@ Möbius stack and can take several minutes. Prefer the GitHub PR checks.
 Run this on a Docker-capable host, not inside the Möbius app container:
   scripts/playwright-local.sh --allow-local-e2e <spec or --grep arguments>
 
+Focused checks use one browser worker by default. Set
+MOBIUS_LOCAL_E2E_WORKERS=2 to reproduce hosted-CI concurrency.
+
 The runner deletes its test image by default. Set
 MOBIUS_LOCAL_E2E_KEEP_CACHE=1 only for an intentionally retained per-checkout
 image; BuildKit already owns the ordinary build cache.
@@ -67,6 +70,11 @@ cache_image="${MOBIUS_LOCAL_E2E_CACHE_IMAGE:-mobius-local-e2e-cache-${checkout_i
 keep_cache="${MOBIUS_LOCAL_E2E_KEEP_CACHE:-0}"
 if [[ "$keep_cache" != "0" && "$keep_cache" != "1" ]]; then
   echo "error: MOBIUS_LOCAL_E2E_KEEP_CACHE must be 0 or 1" >&2
+  exit 2
+fi
+e2e_workers="${MOBIUS_LOCAL_E2E_WORKERS:-1}"
+if [[ ! "$e2e_workers" =~ ^[1-9][0-9]*$ ]]; then
+  echo "error: MOBIUS_LOCAL_E2E_WORKERS must be a positive integer" >&2
   exit 2
 fi
 min_free_gb="${MOBIUS_LOCAL_E2E_MIN_FREE_GB:-20}"
@@ -235,7 +243,7 @@ if errors:
     raise SystemExit("refusing browser run: " + "; ".join(errors))
 ' "$version" "$head_sha"
 
-echo "Running focused Playwright checks with one worker..."
+echo "Running focused Playwright checks with ${e2e_workers} worker(s)..."
 cd "$snapshot_dir"
 if CI= \
    MOBIUS_LOCAL_E2E=1 \
@@ -245,7 +253,7 @@ if CI= \
    MOBIUS_TEST_INTERNAL_API="http://127.0.0.1:${internal_test_port}" \
    MOBIUS_USER=admin \
    MOBIUS_PASS=admin \
-     "$snapshot_dir/node_modules/.bin/playwright" test "$@" --workers=1; then
+     "$snapshot_dir/node_modules/.bin/playwright" test "$@" --workers="$e2e_workers"; then
   exit 0
 else
   test_rc=$?

--- a/tests/frontend.spec.mjs
+++ b/tests/frontend.spec.mjs
@@ -73,6 +73,29 @@ async function sendMessage(page, text) {
   ))
 }
 
+async function waitForChatMode(page, chatId, kind, timeout = 3000) {
+  await expect.poll(
+    () => page.evaluate(id => {
+      let mode = null
+      try {
+        mode = JSON.parse(sessionStorage.getItem('chat-mode') || '{}')[id] || null
+      } catch {}
+      return {
+        kind: mode?.kind || null,
+        // The controller trace contains only event names, coarse geometry, and
+        // redacted mode shapes. Returning it here makes a future ownership race
+        // diagnosable from the assertion artifact without exposing chat text or
+        // stable message identities.
+        diagnostics: window.__mobiusChatScrollTrace || null,
+      }
+    }, chatId),
+    {
+      timeout,
+      message: `chat ${chatId} should persist scroll mode ${kind}`,
+    },
+  ).toMatchObject({ kind })
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -653,18 +676,7 @@ test.describe('Scroll position', () => {
     await expect(page.locator('.drawer.drawer--open')).toBeVisible({ timeout: 3000 })
     await page.getByRole('button', { name: 'Settings', exact: true }).click()
     await expect(page.locator('.settings')).toBeVisible({ timeout: 5000 })
-    await page.waitForFunction(
-      id => {
-        try {
-          const modes = JSON.parse(sessionStorage.getItem('chat-mode') || '{}')
-          return modes[id]?.kind === 'ANCHOR_AT'
-        } catch {
-          return false
-        }
-      },
-      chatId,
-      { timeout: 3000 }
-    )
+    await waitForChatMode(page, chatId, 'ANCHOR_AT')
 
     // Return through the app navigation stack so ChatView remounts and consumes
     // the saved mode for the same chat.
@@ -696,7 +708,12 @@ test.describe('Scroll position', () => {
     expect(chatId).toBeTruthy()
 
     let messages = [
-      { role: 'user', content: 'Follow restore prompt', ts: 1700000100000 },
+      {
+        cid: 'follow-restore-cid',
+        role: 'user',
+        content: 'Follow restore prompt',
+        ts: 1700000100000,
+      },
       {
         role: 'assistant',
         ts: 1700000100001,
@@ -755,18 +772,7 @@ test.describe('Scroll position', () => {
       const el = document.querySelector('.chat__scroll')
       return !!el && el.scrollHeight - el.scrollTop - el.clientHeight < 50
     }, { timeout: 3000 })
-    await page.waitForFunction(
-      id => {
-        try {
-          return JSON.parse(sessionStorage.getItem('chat-mode') || '{}')[id]?.kind
-            === 'FOLLOW_BOTTOM'
-        } catch {
-          return false
-        }
-      },
-      chatId,
-      { timeout: 3000 },
-    )
+    await waitForChatMode(page, chatId, 'FOLLOW_BOTTOM')
     const scrollBefore = await page.evaluate(
       () => document.querySelector('.chat__scroll')?.scrollTop ?? null,
     )
@@ -776,18 +782,7 @@ test.describe('Scroll position', () => {
     await expect(page.locator('.drawer.drawer--open')).toBeVisible({ timeout: 3000 })
     await page.getByRole('button', { name: 'Settings', exact: true }).click()
     await expect(page.locator('.settings')).toBeVisible({ timeout: 5000 })
-    await page.waitForFunction(
-      id => {
-        try {
-          return JSON.parse(sessionStorage.getItem('chat-mode') || '{}')[id]?.kind
-            === 'ANCHOR_AT'
-        } catch {
-          return false
-        }
-      },
-      chatId,
-      { timeout: 3000 },
-    )
+    await waitForChatMode(page, chatId, 'ANCHOR_AT')
 
     // Grow the same assistant row while the chat is inactive. A restored
     // FOLLOW_BOTTOM would jump to this new tail; the saved anchor must not.


### PR DESCRIPTION
## Summary
- tighten the wheel handoff already fixed by main at 93bcd9360: only an exact edge, not the 4px near-bottom tolerance, proves that wheel input cannot still scroll
- add bounded content-free input and owned/unowned scroll events to the existing diagnostic trace, and surface it when mode assertions fail
- let the local disposable runner reproduce hosted CI worker concurrency
- align the return-scroll fixture with the explicit user-row cid contract

## Context
Main independently landed the primary fix while this PR was in progress: in-range wheel input now waits for its actual scroll event instead of releasing after one animation frame. This PR is rebased on that change and intentionally keeps only incremental hardening and reproducibility.

The remaining edge case was a viewport 1 to 4 pixels from the boundary. That position is near enough for bottom detection, but it is not clamped: a wheel can still move it. Releasing ownership after one frame there can reproduce the same delayed-scroll classification failure under load. Exact geometry now controls only the no-op release; the existing 4px tolerance remains unchanged for semantic bottom detection.

The added trace stays bounded and content-free. It records event names, coarse geometry, and redacted mode shapes so a future race is visible in CI artifacts without message content or message identifiers.

## Verification
- focused scroll-controller unit: 58/58
- frontend: 1,623 library/component + 47 hook tests
- production frontend build and built-global audit
- focused backend runner-contract test: 1/1
- privacy gates, static-app packager, browser harness, and core-app checks
- exact application head in a disposable stack with two workers: 21/21 across 10 affected-scroll repeats, 10 opaque embedded-chat companion repeats, and auth
- pre-push privacy, syntax, and frontend gates passed

The earlier CI backend failure on 20b0d7f3 was the now-updated runner contract still requiring a literal one worker; all 2,618 other backend tests passed and the E2E job was green.