### PR TITLE
fix(embed): handshake lazy receiver readiness

### DIFF
--- a/frontend/public/mobius-runtime.js
+++ b/frontend/public/mobius-runtime.js
@@ -2232,6 +2232,7 @@ const EMBED_MESSAGE_SENT = EMBED_NS + 'message-sent'
 const EMBED_TURN_DONE = EMBED_NS + 'turn-done'
 const EMBED_ERROR = EMBED_NS + 'error'
 const EMBED_AUTH_EXPIRING = EMBED_NS + 'auth-expiring'
+const EMBED_BOOTSTRAP_READY = EMBED_NS + 'bootstrap-ready'
 // Context protocol — mirrored from src/lib/chatEmbed.js; keep in sync.
 const EMBED_CONTEXT_REQUEST = EMBED_NS + 'context-request'
 const EMBED_CONTEXT_RESPONSE = EMBED_NS + 'context-response'
@@ -2886,20 +2887,14 @@ function makeChat({ appId, getToken, storage }) {
       })
     }
 
-    function sendInit() {
-      authorizationHandoff?.start()
-    }
-
     function replaceEmbedFrame() {
       const previous = iframe
-      previous.removeEventListener('load', sendInit)
       authorizationHandoff?.destroy()
       frameReveal?.destroy()
       iframe = createEmbedFrame()
       frameReveal = makeFrameRevealController(iframe)
       hasAuthorizedOnce = false
       authorizationHandoff = createAuthorizationHandoff()
-      iframe.addEventListener('load', sendInit)
       if (previous.parentNode) previous.parentNode.replaceChild(iframe, previous)
     }
 
@@ -2909,6 +2904,13 @@ function makeChat({ appId, getToken, storage }) {
       const msg = e.data
       if (!msg || typeof msg !== 'object') return
       if (typeof msg.type !== 'string' || !msg.type.startsWith(EMBED_NS)) return
+      // A lazy route can finish document loading before its React effect has
+      // installed the INIT listener. Mint the one-use grant only after the
+      // exact child WindowProxy says that receiver is ready.
+      if (msg.type === EMBED_BOOTSTRAP_READY) {
+        authorizationHandoff?.start()
+        return
+      }
       if (msg.instanceId !== instanceId) return
       if (msg.type === EMBED_READY) {
         if (!authorizationHandoff?.ready(msg.authorizationId)) return
@@ -2963,15 +2965,10 @@ function makeChat({ appId, getToken, storage }) {
       }
     }
 
-    // Register the message listener BEFORE appending the iframe, so it's
-    // live before the embed can post its mount-time READY. INIT is sent
-    // on the iframe's load event, which (per the HTML spec) fires after
-    // the embed document's scripts have run and its own message listener
-    // is registered — so the single INIT reaches it without a race, the
-    // same handshake AppCanvas ↔ app-frame.html rely on.
+    // Register before append so the child's bootstrap-ready message cannot be
+    // lost. The child sends it only after installing its INIT listener.
     authorizationHandoff = createAuthorizationHandoff()
     window.addEventListener('message', onMessage)
-    iframe.addEventListener('load', sendInit)
     frameMount.appendChild(iframe)
     if (controlsShell) {
       mount.appendChild(controlsShell)
@@ -2990,7 +2987,6 @@ function makeChat({ appId, getToken, storage }) {
       },
       destroy() {
         window.removeEventListener('message', onMessage)
-        iframe.removeEventListener('load', sendInit)
         authorizationHandoff?.destroy()
         frameReveal?.destroy()
         revokeEmbed(chatId, instanceId)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import * as setupSession from './lib/setupSession.js'
 import { setupQueries } from './hooks/queries.js'
 import { queryClient, persistOptions } from './queryClient.js'
 import { shellReload } from './lib/shellReloadState.js'
+import { beginEmbedBootstrap } from './lib/chatEmbedBootstrap.js'
 
 // These flows are mutually exclusive. Keep setup, login, the full shell, and
 // the opaque embed out of one another's startup path; first boot should not
@@ -34,7 +35,10 @@ function isEmbedRoute() {
 }
 
 const EMBED_ROUTE = isEmbedRoute()
-if (EMBED_ROUTE) beginEphemeralAuth()
+if (EMBED_ROUTE) {
+  beginEphemeralAuth()
+  beginEmbedBootstrap()
+}
 
 // Validate a ?return= target: same-origin in-app path only. Rejects
 // backslashes (browsers normalize '/\\evil' to '//evil' -> open redirect),

--- a/frontend/src/components/ChatEmbed/ChatEmbed.jsx
+++ b/frontend/src/components/ChatEmbed/ChatEmbed.jsx
@@ -7,8 +7,10 @@ import {
   setEphemeralAuthSession,
 } from '../../api/client.js'
 import { applyThemeToDom } from '../../lib/themeService.js'
+import { handoffEmbedBootstrap } from '../../lib/chatEmbedBootstrap.js'
 import {
   INIT, READY, MESSAGE_SENT, TURN_DONE, ERROR, AUTH_EXPIRING,
+  BOOTSTRAP_READY,
   CONTEXT_REQUEST, CONTEXT_RESPONSE, CONTEXT_RESPONSE_TIMEOUT_MS,
   isEmbedMessage, retainEmbedSessionAfterExchangeFailure,
 } from '../../lib/chatEmbed.js'
@@ -218,6 +220,14 @@ export default function ChatEmbed() {
 
     window.addEventListener('message', onMessage)
     window.addEventListener('mobius:chat-embed-auth-expired', onAuthExpired)
+    handoffEmbedBootstrap(onMessage)
+    // This route is lazy-loaded, so the iframe's document load may finish
+    // before this effect installs its INIT listener. Tell the exact parent
+    // WindowProxy when the receiver is live; no grant or identifier is sent
+    // until then.
+    if (parentRef.current && parentRef.current !== window) {
+      parentRef.current.postMessage({ type: BOOTSTRAP_READY }, '*')
+    }
     return () => {
       window.removeEventListener('message', onMessage)
       window.removeEventListener('mobius:chat-embed-auth-expired', onAuthExpired)

--- a/frontend/src/lib/__tests__/chatEmbed.test.js
+++ b/frontend/src/lib/__tests__/chatEmbed.test.js
@@ -19,6 +19,7 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import {
   NS, INIT, READY, MESSAGE_SENT, TURN_DONE, ERROR, HEIGHT, AUTH_EXPIRING,
+  BOOTSTRAP_READY,
   CONTEXT_RESPONSE_TIMEOUT_MS,
   isEmbedMessage, embedUrl, makeEmitter, retainEmbedSessionAfterExchangeFailure,
 } from '../chatEmbed.js'
@@ -31,7 +32,10 @@ function evt({ origin = ORIGIN, source = SRC, type, instanceId, chatId } = {}) {
 }
 
 test('all message types share the moebius:chat-embed: namespace', () => {
-  for (const t of [INIT, READY, MESSAGE_SENT, TURN_DONE, ERROR, HEIGHT, AUTH_EXPIRING]) {
+  for (const t of [
+    INIT, READY, MESSAGE_SENT, TURN_DONE, ERROR, HEIGHT, AUTH_EXPIRING,
+    BOOTSTRAP_READY,
+  ]) {
     assert.ok(t.startsWith(NS), `${t} must start with ${NS}`)
   }
   // Distinct from the app-frame protocol so a stray frame message can

--- a/frontend/src/lib/__tests__/chatEmbedOpaqueSandbox.test.js
+++ b/frontend/src/lib/__tests__/chatEmbedOpaqueSandbox.test.js
@@ -11,6 +11,10 @@ const runtimeSource = readFileSync(
   new URL('../../../public/mobius-runtime.js', import.meta.url),
   'utf8',
 )
+const bootstrapSource = readFileSync(
+  new URL('../chatEmbedBootstrap.js', import.meta.url),
+  'utf8',
+)
 const indexSource = readFileSync(
   new URL('../../../index.html', import.meta.url),
   'utf8',
@@ -36,6 +40,15 @@ test('runtime INIT carries a one-use bootstrap rather than an owner or app token
   assert.match(runtimeSource, /e\.source !== iframe\.contentWindow/)
   assert.match(runtimeSource, /e\.origin !== 'null'/)
   assert.doesNotMatch(runtimeSource, /msg\.token\s*=/)
+})
+
+test('lazy embed route announces receiver readiness before the runtime mints a grant', () => {
+  assert.match(appSource, /beginEmbedBootstrap\(\)/)
+  assert.match(bootstrapSource, /event\.source !== window\.parent/)
+  assert.match(embedSource, /handoffEmbedBootstrap\(onMessage\)/)
+  assert.match(embedSource, /postMessage\(\{ type: BOOTSTRAP_READY \}, '\*'\)/)
+  assert.match(runtimeSource, /msg\.type === EMBED_BOOTSTRAP_READY/)
+  assert.doesNotMatch(runtimeSource, /addEventListener\('load', sendInit\)/)
 })
 
 test('nested renderer stays inert until the server verifies the bootstrap', () => {

--- a/frontend/src/lib/__tests__/chatEmbedTheme.test.js
+++ b/frontend/src/lib/__tests__/chatEmbedTheme.test.js
@@ -12,7 +12,7 @@ const APP_SOURCE = readFileSync(new URL('../../App.jsx', import.meta.url), 'utf8
 test('ChatEmbed does not load owner theme/storage before authorization', () => {
   assert.doesNotMatch(SOURCE, /\buseTheme\s*\(/)
   assert.doesNotMatch(SOURCE, /localStorage\s*\./)
-  assert.match(APP_SOURCE, /if \(EMBED_ROUTE\) beginEphemeralAuth\(\)/)
+  assert.match(APP_SOURCE, /if \(EMBED_ROUTE\) \{[\s\S]*beginEphemeralAuth\(\)/)
 })
 
 test('ChatEmbed applies theme returned by the verified session exchange', () => {

--- a/frontend/src/lib/chatEmbed.js
+++ b/frontend/src/lib/chatEmbed.js
@@ -31,6 +31,7 @@ export const TURN_DONE = NS + 'turn-done' // the agent turn finished streaming
 export const ERROR = NS + 'error' // the embed hit a load/stream error
 export const HEIGHT = NS + 'height' // optional content height (see note below)
 export const AUTH_EXPIRING = NS + 'auth-expiring' // parent should mint a new grant
+export const BOOTSTRAP_READY = NS + 'bootstrap-ready' // child listener is installed
 
 // Parent (app frame) → child (embed frame).
 export const INIT = NS + 'init' // hand the embed its config + correlation id

--- a/frontend/src/lib/chatEmbedBootstrap.js
+++ b/frontend/src/lib/chatEmbedBootstrap.js
@@ -1,0 +1,30 @@
+const INIT = 'moebius:chat-embed:init'
+
+let queuedInit = null
+let listening = false
+
+function captureInit(event) {
+  if (event.origin !== 'null' && event.origin !== window.location.origin) return
+  if (event.source !== window.parent) return
+  if (event.data?.type !== INIT) return
+  queuedInit = event
+}
+
+// Install the tiny receiver from the shared entry bundle, before React asks
+// for the lazy ChatEmbed chunk. This preserves compatibility with older app
+// runtimes that send INIT on document load.
+export function beginEmbedBootstrap() {
+  if (listening || typeof window === 'undefined' || window.parent === window) return
+  window.addEventListener('message', captureInit)
+  listening = true
+}
+
+// ChatEmbed installs its full receiver first, then atomically takes over and
+// drains the one pre-mount INIT (if an older runtime already sent it).
+export function handoffEmbedBootstrap(receiver) {
+  if (listening) window.removeEventListener('message', captureInit)
+  listening = false
+  const event = queuedInit
+  queuedInit = null
+  if (event && typeof receiver === 'function') receiver(event)
+}

--- a/tests/app-canvas.spec.mjs
+++ b/tests/app-canvas.spec.mjs
@@ -644,6 +644,11 @@ test.describe('AppCanvas: iframe-mount contract', () => {
     await page.goto(`${BASE}/shell/?chat=open-app-chat`, { waitUntil: 'domcontentloaded' })
     await page.waitForFunction(() => window.location.pathname === '/shell/')
 
+    // A real app frame cannot post before the lazy Shell has mounted it and
+    // installed its receiver. Mirror that topology before adding our synthetic
+    // opaque sender.
+    await expect(page.getByRole('button', { name: 'Toggle navigation' })).toBeVisible()
+
     await postFromOpaqueCanvasFrame(page, {
       type: 'moebius:open-app', appId,
     })

--- a/tests/embedded-chat-hostile.unauth.spec.mjs
+++ b/tests/embedded-chat-hostile.unauth.spec.mjs
@@ -44,6 +44,9 @@ test('external hostile framer gets only an inert document without a grant', asyn
     const attacker = page.frames().find(frame => frame.url().startsWith('data:text/html,'))
     expect(attacker).toBeTruthy()
     const victim = page.frameLocator('#attacker').frameLocator('#victim')
+    // The embed route is a lazy chunk. Wait for its inert receiver to mount so
+    // this test exercises server rejection, not a pre-listener message race.
+    await expect(victim.locator('.chat-embed')).toHaveCount(1)
     await expect(victim.locator('#root')).toHaveText('')
 
     const exchanges = []


### PR DESCRIPTION
## Summary
- wait for a lazy embedded-chat receiver before minting a one-use capability
- buffer one legacy load-time INIT in the small entry bundle so already-compiled local apps remain compatible
- align the synthetic open-app E2E sender with the real Shell receiver lifecycle

## Verification
- `cd frontend && npm test` (1,691 lib + 47 hook tests)
- `cd frontend && npm run build`
- isolated two-worker Playwright rerun of the three failed flows (4/4 including auth setup)