### PR TITLE
fix(runtime): migrate bundles for feature markers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -338,7 +338,7 @@ The chat is large and self-contained; its hooks live beside it, not in `src/hook
 | `frontend/src/sw-cache-policy.js` | Authoritative cache-route policy (see *Service worker + offline* below) |
 | `frontend/src/lib/` | Cross-cutting helpers: `appToken.js`, `chatEmbed.js`, `themeService.js`, `onlineStatus.js`, `navHistory.js`, `errorLog.js`, etc. |
 
-**Mini-app modules are self-contained.** `app_compile_contract.py` points esbuild at the pinned production dependencies in `frontend/package.json`, injects React plus `mobius-runtime`, and bundles every used static import into one ESM artifact. The opaque frame asks its exact controlled parent to fetch and transfer that artifact, so a cold offline load performs no dependency subrequests. A compiler ABI banner lets the boot reconciler atomically rebuild older installed bundles after any runtime-contract change. Public `/vendor/` files remain only for true browser assets that code refers to by URL (currently the pdf.js worker, KaTeX CSS/fonts, and the D3/Pixi classic scripts); they are not a package resolver.
+**Mini-app modules are self-contained.** `app_compile_contract.py` points esbuild at the pinned production dependencies in `frontend/package.json`, injects React plus `mobius-runtime`, and bundles every used static import into one ESM artifact. The opaque frame asks its exact controlled parent to fetch and transfer that artifact, so a cold offline load performs no dependency subrequests. A compiler banner carries both a host ABI and an artifact revision: bump the revision to rebuild installed bundles for additive runtime changes, and bump the ABI only when old and new hosts are incompatible. Public `/vendor/` files remain only for true browser assets that code refers to by URL (currently the pdf.js worker, KaTeX CSS/fonts, and the D3/Pixi classic scripts); they are not a package resolver.
 
 ## Where do I make a change?
 
@@ -354,7 +354,7 @@ The chat is large and self-contained; its hooks live beside it, not in `src/hook
 | Change chat scroll/spacer/keyboard | `ChatView/ChatView.jsx` + `ChatView.css`; run the spacer/send-pin tests in repo-root `tests/` |
 | Change drawer / back-stack nav | `frontend/src/hooks/useNavigation.js` + `Shell/Shell.jsx` (read *Navigation back-stack + drawer model* below first) |
 | Change the mini-app iframe / cache | `AppCanvas/AppCanvas.jsx` + `Shell/Shell.jsx` (`appCache`); ETag logic in `routes/apps.py` |
-| Add an app-runtime capability | `frontend/public/mobius-runtime.js` + `app_runtime_inject.js`; bump the compiler ABI when the compiled bridge contract changes |
+| Add an app-runtime capability | `frontend/public/mobius-runtime.js` + `app_runtime_inject.js`; bump the compiler artifact revision for additive compiled-bridge changes, or the ABI only for host-incompatible changes |
 | Add a supported app package | Pin it in `frontend/package.json`, add it to `BUNDLED_RUNTIME_LIBS`, and run the compiler/offline-frame contracts |
 | Change offline / SW behavior | `frontend/src/sw.js` + `frontend/src/sw-cache-policy.js` (read *Service worker + offline* below first) |
 | Change the in-product agent's instructions | `skill/core.md` (constitution) or `backend/scripts/seed-skills/*.md` (per-task skills) — see below |

--- a/backend/app/app_compile_contract.py
+++ b/backend/app/app_compile_contract.py
@@ -35,9 +35,15 @@ BUNDLED_RUNTIME_LIBS: tuple[str, ...] = (
 )
 
 COMPILED_RUNTIME_ABI = 1
+# Bump this when every installed bundle must be rebuilt for an additive
+# compiled-runtime change that remains host-compatible. Keep ABI for actual
+# host/runtime incompatibilities: a revision-only rollout is safe while the
+# live checkout and backend process briefly run different generations.
+COMPILED_RUNTIME_ARTIFACT_REVISION = 2
 COMPILED_RUNTIME_GLOBAL = "__mobiusCompiledRuntime"
 COMPILED_RUNTIME_BANNER = (
-  f"/* mobius-compiled-runtime-abi:{COMPILED_RUNTIME_ABI} */"
+  f"/* mobius-compiled-runtime-abi:{COMPILED_RUNTIME_ABI};"
+  f"artifact-revision:{COMPILED_RUNTIME_ARTIFACT_REVISION} */"
 )
 
 

--- a/backend/app/compiler.py
+++ b/backend/app/compiler.py
@@ -575,16 +575,37 @@ def _bundle_is_content_addressed(app_id: int, bundle: Path) -> bool:
     return False
 
 
+def app_bundle_uses_current_compile_contract(app) -> bool:
+  """Return whether ``app`` points at a current immutable bundle.
+
+  The banner includes both the host ABI and the additive artifact revision, so
+  this predicate can require a runtime refresh without making old and new host
+  processes reject one another during a live deployment.
+  """
+  bundle = _bundle_path_for_app(app)
+  try:
+    present = bundle.exists() and bundle.stat().st_size > 0
+  except OSError:
+    present = False
+  return bool(
+    present
+    and _bundle_uses_current_runtime(bundle)
+    and _bundle_is_content_addressed(app.id, bundle)
+  )
+
+
 async def reconcile_outdated_bundles(db) -> list[int]:
-  """Rebuild legacy, corrupt, or older-ABI bundles into immutable artifacts.
+  """Rebuild legacy, corrupt, or older-contract bundles into immutable artifacts.
 
   Opaque app frames execute one self-contained module: React, the Mobius
   runtime bridge, and every supported app dependency are part of that artifact.
   A compiler-runtime change therefore needs a durable migration for already
-  installed apps, not a frame-side compatibility path. ``esbuild_command``
-  stamps its ABI banner at byte zero, while publication names the output by its
-  SHA-256. This boot sweep recompiles any present, non-empty bundle without the
-  current banner or a valid content address. The latter condition migrates
+  installed apps. ``esbuild_command`` stamps the ABI + artifact revision at byte
+  zero, while publication names the output by its SHA-256. Keeping additive
+  refreshes in the revision lets a live checkout and the pre-restart backend
+  remain host-compatible throughout deployment. This boot sweep recompiles any
+  present, non-empty bundle without the current banner or a valid content
+  address. The latter condition migrates
   every legacy fixed-name bundle once and repairs the pre-migration same-ABI
   crash gap by rebuilding from the committed row source.
 
@@ -614,10 +635,7 @@ async def reconcile_outdated_bundles(db) -> list[int]:
       present = bundle.exists() and bundle.stat().st_size > 0
     except OSError:
       present = False
-    if not present or (
-      _bundle_uses_current_runtime(bundle)
-      and _bundle_is_content_addressed(app.id, bundle)
-    ):
+    if not present or app_bundle_uses_current_compile_contract(app):
       continue
     if not app.jsx_source or not app.jsx_source.strip():
       continue

--- a/backend/app/fs_locks.py
+++ b/backend/app/fs_locks.py
@@ -42,6 +42,8 @@ No shared-skills holder ever acquires a lifecycle, app, or source lock.
 Multi-lock holders, all acquiring left-to-right:
 
   - ``delete_app`` holds all three.
+  - ``recover_app`` holds lifecycle -> app while it refreshes a stale bundle,
+    then may take source and shared-skills locks further inside that span.
   - ``update_app`` (PATCH) and the app watcher's auto-recompile hold
     lifecycle -> app -> source (PATCH takes the source lock only when the
     source_dir actually changes). Both recompile a bundle, so they take the

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -276,8 +276,8 @@ async def lifespan(app):
     _bn_db = _BundleSession()
     try:
       healed_bundle_ids = await reconcile_missing_bundles(_bn_db)
-      # Compiler ABI migrations fix forward: every app frame receives one
-      # dependency-complete module, so legacy external-import bundles must be
+      # Compiler contract migrations fix forward: every app frame receives one
+      # dependency-complete module, so legacy or older-revision bundles must be
       # rebuilt before requests can expose them. The sweep is atomic per app
       # and resumable across interrupted boots.
       migrated_bundle_ids = await reconcile_outdated_bundles(_bn_db)

--- a/backend/app/routes/apps.py
+++ b/backend/app/routes/apps.py
@@ -65,7 +65,11 @@ from app.storage_io import (
 )
 from app.app_capabilities import diff_contracts
 from app.broadcast import get_system_broadcast
-from app.compiler import compile_jsx, recompile_app_bundle
+from app.compiler import (
+  app_bundle_uses_current_compile_contract,
+  compile_jsx,
+  recompile_app_bundle,
+)
 from app.config import get_settings
 from app.database import get_db
 from app.deps import (
@@ -2218,13 +2222,21 @@ async def recover_app(
   source-dir lock, then its cadence is converged through the common supervised
   runner. Reinstalling a store app also re-registers it. See feature 110.
 
+  Before the row becomes live, a stale compiled artifact is rebuilt from its
+  preserved source. This covers tombstones intentionally skipped by the boot
+  sweep and keeps recovery from reviving an app without the current additive
+  runtime features.
+
   Held under install_uninstall_lock — the same lock the TTL purge takes — so a
   recover near the TTL boundary can't race the purge into reviving a row the
   sweep is hard-deleting (or vice versa). Whoever wins the lock leaves a
   consistent state: a purged row → recover 404s; a recovered row → purge's
   under-lock stale re-query no longer matches it.
   """
-  async with fs_locks.install_uninstall_lock():
+  async with (
+    fs_locks.install_uninstall_lock(),
+    fs_locks.app_storage_lock(app_id),
+  ):
     app = (
       db.query(models.App)
       .filter(models.App.id == app_id, models.App.deleted_at.isnot(None))
@@ -2238,6 +2250,23 @@ async def recover_app(
       now_naive_utc() - app.deleted_at
     ) >= APP_SOFT_DELETE_TTL:
       raise HTTPException(status_code=410, detail="Recovery window has expired.")
+    if not app_bundle_uses_current_compile_contract(app):
+      if not app.jsx_source or not app.jsx_source.strip():
+        raise HTTPException(
+          status_code=409,
+          detail="App source is unavailable; reinstall it to recover.",
+        )
+      try:
+        # recompile_app_bundle commits internally, but the row remains
+        # tombstoned until the separate commit below. A crash or compile error
+        # therefore cannot expose a stale or partially rebuilt app.
+        await recompile_app_bundle(db, app, app.jsx_source)
+      except RuntimeError as exc:
+        db.rollback()
+        raise HTTPException(
+          status_code=422,
+          detail=f"Could not rebuild app for recovery: {exc}",
+        )
     app.deleted_at = None
     app_name = app.name
     app_source_dir = app.source_dir

--- a/backend/tests/test_app_uninstall_reversible.py
+++ b/backend/tests/test_app_uninstall_reversible.py
@@ -6,6 +6,7 @@ of minting a fresh empty app. Recovery is agent-driven and consistent with
 chats: POST /api/apps/{id}/recover, plus reinstall-reattach for store apps.
 """
 
+import hashlib
 import io
 import json
 from datetime import datetime, timedelta, UTC
@@ -187,6 +188,41 @@ def test_recover_endpoint_restores_app(client, auth, db, bypass_url_validation):
   assert row.deleted_at is None
   assert data_file.read_text() == "recover-me"
   assert app_id in [a["id"] for a in client.get("/api/apps/", headers=auth).json()]
+
+
+def test_recover_refreshes_tombstoned_old_runtime_bundle(
+  client, auth, db, bypass_url_validation,
+):
+  from app.app_compile_contract import COMPILED_RUNTIME_BANNER
+
+  app = _install(client, auth)
+  app_id = app["id"]
+  row = db.query(models.App).filter(models.App.id == app_id).one()
+  current = Path(row.compiled_path)
+  current_bytes = current.read_bytes()
+  current_banner = COMPILED_RUNTIME_BANNER.encode("ascii")
+  assert current_bytes.startswith(current_banner)
+
+  old_banner = b"/* mobius-compiled-runtime-abi:1 */"
+  old_bytes = old_banner + current_bytes[len(current_banner):]
+  old_digest = hashlib.sha256(old_bytes).hexdigest()
+  old_bundle = current.parent / f"app-{app_id}-{old_digest}.js"
+  old_bundle.write_bytes(old_bytes)
+  row.compiled_path = str(old_bundle)
+  db.commit()
+  current.unlink()
+
+  assert client.delete(f"/api/apps/{app_id}", headers=auth).status_code == 204
+  response = client.post(f"/api/apps/{app_id}/recover", headers=auth)
+
+  assert response.status_code == 200, response.text
+  db.expire_all()
+  recovered = db.query(models.App).filter(models.App.id == app_id).one()
+  recovered_bundle = Path(recovered.compiled_path)
+  assert recovered.deleted_at is None
+  assert recovered_bundle.read_bytes().startswith(current_banner)
+  assert recovered_bundle != old_bundle
+  assert not old_bundle.exists()
 
 
 def test_recover_never_reactivates_pre_uninstall_app_token(

--- a/backend/tests/test_runtime_libs.py
+++ b/backend/tests/test_runtime_libs.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from app.app_compile_contract import (
   BUNDLED_RUNTIME_LIBS,
   COMPILED_RUNTIME_ABI,
+  COMPILED_RUNTIME_ARTIFACT_REVISION,
   COMPILED_RUNTIME_BANNER,
   ESBUILD_TIMEOUT_SECS,
   esbuild_command,
@@ -110,6 +111,10 @@ def test_compiler_and_both_hosts_agree_on_runtime_abi():
   assert f"abi: {COMPILED_RUNTIME_ABI}" in inject
   assert f"COMPILED_RUNTIME_ABI = {COMPILED_RUNTIME_ABI}" in frame
   assert f"compiledRuntime.abi !== {COMPILED_RUNTIME_ABI}" in standalone
+  assert (
+    f"artifact-revision:{COMPILED_RUNTIME_ARTIFACT_REVISION}"
+    in COMPILED_RUNTIME_BANNER
+  )
 
 
 def test_codemirror_direct_imports_remain_supported():

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -1,5 +1,6 @@
 """Storage API: tests for both envelope and inner-object PUT forms."""
 
+import hashlib
 import json
 from pathlib import Path
 import subprocess
@@ -1169,6 +1170,43 @@ async def test_reconcile_outdated_bundles_recompiles_legacy_bundle(
   assert "ABI_MIGRATED" in rebuilt
   assert rebuilt_path != legacy
   assert not legacy.exists()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_outdated_bundles_recompiles_old_artifact_revision(
+  client, owner_token, db,
+):
+  import app.models as models
+  from app.app_compile_contract import COMPILED_RUNTIME_BANNER
+  from app.compiler import reconcile_outdated_bundles
+
+  app_id = _make_app(client, owner_token)
+  row = db.query(models.App).filter(models.App.id == app_id).first()
+  current = Path(row.compiled_path)
+  current_bytes = current.read_bytes()
+  current_banner = COMPILED_RUNTIME_BANNER.encode("ascii")
+  old_banner = b"/* mobius-compiled-runtime-abi:1 */"
+  assert current_bytes.startswith(current_banner)
+  old_bytes = old_banner + current_bytes[len(current_banner):]
+  old_digest = hashlib.sha256(old_bytes).hexdigest()
+  old_bundle = current.parent / f"app-{app_id}-{old_digest}.js"
+  current.unlink()
+  old_bundle.write_bytes(old_bytes)
+  row.compiled_path = str(old_bundle)
+  row.jsx_source = (
+    "export default function App(){ return <div>REVISION_MIGRATED</div> }"
+  )
+  db.commit()
+
+  migrated = await reconcile_outdated_bundles(db)
+
+  rebuilt_path = _bundle_path(db, app_id)
+  rebuilt = rebuilt_path.read_text(encoding="utf-8")
+  assert app_id in migrated
+  assert rebuilt.startswith(COMPILED_RUNTIME_BANNER)
+  assert "REVISION_MIGRATED" in rebuilt
+  assert rebuilt_path != old_bundle
+  assert not old_bundle.exists()
 
 
 @pytest.mark.asyncio

--- a/frontend/src/lib/__tests__/mobiusRuntimeStore.test.js
+++ b/frontend/src/lib/__tests__/mobiusRuntimeStore.test.js
@@ -565,6 +565,9 @@ test('init reuses one runtime per installation and updates its token broker', as
       appInstanceId: 'install-one',
       getToken: async () => firstToken,
     })
+    assert.equal(first.runtimeFeatures, runtime.runtimeFeatures)
+    assert.equal(first.runtimeFeatures.idleDocument, true)
+    assert.equal(Object.isFrozen(first.runtimeFeatures), true)
     const listenerCounts = () => ({
       window: [...windowListeners].map(([type, callbacks]) => [type, callbacks.size]),
       document: [...documentListeners].map(([type, callbacks]) => [type, callbacks.size]),


### PR DESCRIPTION
Follow-up to #96: adds an artifact revision so existing installed bundles receive runtimeFeatures without introducing a cross-generation host ABI break; rebuilds stale tombstoned bundles before recovery; strengthens init() and migration coverage. Local verification: 12 targeted backend tests, full frontend unit suite, production/offline build, focused 4-flow E2E, privacy and preship gates. Independent fresh-eyes review: merge ready.