### PR TITLE
fix(compiler): pin supported app runtime packages

### DIFF
--- a/backend/app/app_compile_contract.py
+++ b/backend/app/app_compile_contract.py
@@ -39,7 +39,7 @@ COMPILED_RUNTIME_ABI = 1
 # compiled-runtime change that remains host-compatible. Keep ABI for actual
 # host/runtime incompatibilities: a revision-only rollout is safe while the
 # live checkout and backend process briefly run different generations.
-COMPILED_RUNTIME_ARTIFACT_REVISION = 2
+COMPILED_RUNTIME_ARTIFACT_REVISION = 3
 COMPILED_RUNTIME_GLOBAL = "__mobiusCompiledRuntime"
 COMPILED_RUNTIME_BANNER = (
   f"/* mobius-compiled-runtime-abi:{COMPILED_RUNTIME_ABI};"
@@ -75,12 +75,37 @@ def esbuild_environment() -> dict[str, str]:
 
   Esbuild's CLI consumes Node's ``NODE_PATH`` environment variable (its JS API
   calls the equivalent option ``nodePaths``); there is no ``--node-path`` CLI
-  flag. Replace rather than append any inherited value so app builds resolve
-  bare imports only from the platform's pinned frontend runtime installation.
+  flag. Replace rather than append any inherited value. ``NODE_PATH`` is only a
+  fallback after an entry's nearby ``node_modules``, so the compile command also
+  aliases every supported package root to the platform runtime installation.
   """
   environment = dict(os.environ)
   environment["NODE_PATH"] = str(runtime_node_path())
   return environment
+
+
+def _package_root(specifier: str) -> str:
+  """Return the package root for a supported bare import or subpath."""
+  clean = specifier.removesuffix("/*")
+  if clean.startswith("@"):
+    return "/".join(clean.split("/")[:2])
+  return clean.split("/", 1)[0]
+
+
+def runtime_library_aliases() -> tuple[tuple[str, Path], ...]:
+  """Pin supported bare imports to one physical runtime package copy.
+
+  Esbuild normally resolves an app entry's imports relative to that app before
+  consulting ``NODE_PATH``. A gitignored development ``node_modules/react``
+  beside an app could therefore be bundled alongside the platform React used by
+  ``app_runtime_inject.js``. React then sees two dispatchers and every hook
+  fails at first render. Package-root aliases apply to the root and its subpaths
+  (for example ``react/jsx-runtime``), keeping each supported library singular.
+  """
+  node_path = runtime_node_path()
+  roots = sorted({_package_root(specifier) for specifier in BUNDLED_RUNTIME_LIBS})
+  return tuple((root, node_path / root) for root in roots)
+
 
 NO_DEFAULT_EXPORT_ERROR = (
   "JSX source has no default export — mini-apps must export a default React "
@@ -111,6 +136,10 @@ def esbuild_command(
     f"--banner:js={COMPILED_RUNTIME_BANNER}",
     f"--inject:{runtime_inject_path()}",
     f"--alias:mobius-runtime={mobius_runtime_path()}",
+    *(
+      f"--alias:{specifier}={path}"
+      for specifier, path in runtime_library_aliases()
+    ),
     f"--outfile={output}",
   ]
   if metafile is not None:

--- a/backend/tests/test_runtime_libs.py
+++ b/backend/tests/test_runtime_libs.py
@@ -19,6 +19,7 @@ from app.app_compile_contract import (
   esbuild_command,
   esbuild_environment,
   mobius_runtime_path,
+  runtime_library_aliases,
   runtime_inject_path,
 )
 
@@ -71,8 +72,53 @@ def test_compile_command_bundles_the_complete_runtime_graph():
   assert not any(arg.startswith("--node-path") for arg in command)
   assert esbuild_environment()["NODE_PATH"]
   assert f"--alias:mobius-runtime={mobius_runtime_path()}" in command
+  for specifier, path in runtime_library_aliases():
+    assert f"--alias:{specifier}={path}" in command
   assert runtime_inject_path().is_file()
   assert mobius_runtime_path().is_file()
+
+
+def test_app_local_or_transitive_react_cannot_shadow_platform_runtime(tmp_path):
+  """App-local dependencies must not create a second React dispatcher."""
+  local_react = tmp_path / "node_modules" / "react"
+  local_react.mkdir(parents=True)
+  (local_react / "package.json").write_text(
+    json.dumps({"name": "react", "version": "0.0.0-shadow", "main": "index.js"})
+  )
+  (local_react / "index.js").write_text(
+    'export function useState() { throw new Error("shadow-react-copy") }\n'
+  )
+  local_widget = tmp_path / "node_modules" / "shadow-widget"
+  local_widget.mkdir()
+  (local_widget / "package.json").write_text(
+    json.dumps({"name": "shadow-widget", "version": "1.0.0", "main": "index.js"})
+  )
+  (local_widget / "index.js").write_text(
+    "import { useState } from 'react'\n"
+    "export function useWidget() { return useState('platform-react') }\n"
+  )
+  entry = tmp_path / "entry.jsx"
+  output = tmp_path / "app.js"
+  entry.write_text(
+    """import { useWidget } from 'shadow-widget'
+
+export default function Fixture() {
+  const [value] = useWidget()
+  return <div>{value}</div>
+}
+"""
+  )
+
+  completed = subprocess.run(
+    esbuild_command(entry, output),
+    capture_output=True,
+    check=False,
+    env=esbuild_environment(),
+    text=True,
+    timeout=ESBUILD_TIMEOUT_SECS,
+  )
+  assert completed.returncode == 0, completed.stderr
+  assert "shadow-react-copy" not in output.read_text()
 
 
 def test_app_hosts_have_no_runtime_import_map_or_static_module_imports():


### PR DESCRIPTION
## Summary
- Pin every supported app runtime package to Möbius's frontend installation during compilation.
- Prevent app-local and transitive dependencies from introducing a second React dispatcher.
- Advance the compiled artifact revision so existing installed bundles migrate on restart.

## Root cause
`NODE_PATH` is a fallback, not an override. When an app had a development `node_modules/react` beside its entrypoint, esbuild resolved the app's hooks to that copy while the injected mounting bridge used Möbius's React copy. The first render then failed with an invalid-hook-call error.

## Testing
- `backend/tests/test_runtime_libs.py`, compiler-contract tests, and startup bundle-reconciliation tests: 15 passed.
- App API and installation regression suites: 161 passed.
- Recompiled the affected core app with one React module and verified both source and preview views in a real browser with no console or page errors.