### PR TITLE
fix(apps): make external-link sandbox escape cache-safe

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -64,7 +64,9 @@
     header @notFrameableEmbed >X-Frame-Options "SAMEORIGIN"
     header @notFrameableEmbed >Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://esm.sh; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com https://cdn.openai.com; connect-src 'self'; img-src 'self' data: blob:; frame-src 'self' {$MOBIUS_SERVICE_GATEWAY_ORIGIN}; frame-ancestors 'self'"
     header @appFrame >X-Frame-Options "SAMEORIGIN"
-    header @appFrame >Content-Security-Policy "sandbox allow-scripts allow-forms allow-popups allow-top-navigation-by-user-activation; default-src 'self'; script-src 'self' 'unsafe-inline' blob: https://esm.sh; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com https://cdn.openai.com; connect-src 'self'; img-src 'self' data: blob:; frame-src 'self' {$MOBIUS_SERVICE_GATEWAY_ORIGIN}; frame-ancestors 'self'"
+    # A user-opened external tab must not inherit the app frame's opaque
+    # origin. The app remains sandboxed; only its new popup/tab escapes.
+    header @appFrame >Content-Security-Policy "sandbox allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox allow-top-navigation-by-user-activation; default-src 'self'; script-src 'self' 'unsafe-inline' blob: https://esm.sh; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com https://cdn.openai.com; connect-src 'self'; img-src 'self' data: blob:; frame-src 'self' {$MOBIUS_SERVICE_GATEWAY_ORIGIN}; frame-ancestors 'self'"
     # The embedded chat mounts the full ChatView (upload previews, image
     # lightbox), so its img-src needs blob: for the same object URLs as the
     # shell policy above.

--- a/backend/app/routes/apps.py
+++ b/backend/app/routes/apps.py
@@ -2513,7 +2513,10 @@ def _etag_for_app(app: models.App) -> str | None:
 
 
 def _not_modified_if_match(
-  request: Request, etag: str, offline: bool = False
+  request: Request,
+  etag: str,
+  offline: bool = False,
+  response_headers: dict[str, str] | None = None,
 ) -> Response | None:
   """Returns a 304 Response if the request's If-None-Match matches
   `etag`, else None. The 304 keeps the ETag header so a browser
@@ -2521,14 +2524,24 @@ def _not_modified_if_match(
   mirrors the X-Mobius-Offline marker so the 304 carries the same
   cache metadata as the 200 it stands in for. The SW's
   appCodeStoreAction policy keys on that header for the gated
-  standalone-navigation cache."""
+  standalone-navigation cache. Callers whose representation metadata changes
+  independently of the body (notably the frame CSP) pass it through so a 304
+  freshens the cached policy instead of preserving obsolete headers."""
   match = request.headers.get("if-none-match")
   if match and etag in [v.strip() for v in match.split(",")]:
-    headers = {"ETag": etag}
+    headers = dict(response_headers or {})
+    headers["ETag"] = etag
     if offline:
       headers["X-Mobius-Offline"] = "1"
     return Response(status_code=304, headers=headers)
   return None
+
+
+_APP_FRAME_CSP = (
+  "sandbox allow-scripts allow-forms allow-popups "
+  "allow-popups-to-escape-sandbox "
+  "allow-top-navigation-by-user-activation"
+)
 
 
 def _frame_etag(
@@ -2646,8 +2659,17 @@ def get_frame(
   # validator on it plus app.updated_at.
   frame_rev = theme.frame_content_rev(get_settings().data_dir)
   etag = _frame_etag(app, frame_path, frame_rev=frame_rev)
+  frame_cache_headers = {
+    "Cache-Control": "no-cache",
+    "Content-Security-Policy": _APP_FRAME_CSP,
+  }
   if etag:
-    not_modified = _not_modified_if_match(request, etag, app.offline_capable)
+    not_modified = _not_modified_if_match(
+      request,
+      etag,
+      app.offline_capable,
+      response_headers=frame_cache_headers,
+    )
     if not_modified is not None:
       return not_modified
 
@@ -2675,14 +2697,12 @@ def get_frame(
   # worker can intercept and serve a cached frame offline. Apply the equivalent
   # sandbox on the RESPONSE: the loaded app still receives an opaque origin,
   # including when this backend is reached without the edge proxy. Caddy adds
-  # the full resource policy while preserving this sandbox contract.
-  headers = {
-    "Cache-Control": "no-cache",
-    "Content-Security-Policy": (
-      "sandbox allow-scripts allow-forms allow-popups "
-      "allow-top-navigation-by-user-activation"
-    ),
-  }
+  # the full resource policy while preserving this sandbox contract. Popups
+  # opened by an explicit app link must escape the opaque-origin sandbox:
+  # otherwise the destination inherits Origin: null and sites such as GitHub
+  # load their document but fail same-origin API/storage requests. This does
+  # not relax the app frame itself or let it navigate the owner shell.
+  headers = dict(frame_cache_headers)
   if etag:
     headers["ETag"] = etag
   # The X-Mobius-Offline header does not gate frame/module caching: the SW

--- a/backend/tests/test_frame.py
+++ b/backend/tests/test_frame.py
@@ -83,6 +83,10 @@ def test_frame_returns_etag_and_cache_control(client, owner_token):
   assert "no-cache" in r.headers.get("cache-control", "")
   sandbox = r.headers.get("content-security-policy", "")
   assert "sandbox allow-scripts" in sandbox
+  # A target=_blank link must open as a normal destination page rather than
+  # inheriting this frame's opaque origin (which breaks same-origin fetches and
+  # signed-in storage on sites such as GitHub).
+  assert "allow-popups-to-escape-sandbox" in sandbox
   assert "allow-same-origin" not in sandbox
 
 
@@ -107,6 +111,16 @@ def test_frame_304_on_matching_if_none_match(client, owner_token):
   assert r2.text == ""
   # ETag is preserved on 304 so the browser keeps its validator.
   assert r2.headers["etag"] == etag
+  # Response policy changes independently of the frame body. A conditional
+  # direct-origin load must freshen cached CSP metadata rather than keeping the
+  # old popup sandbox after deployment.
+  assert r2.headers["content-security-policy"] == (
+    r1.headers["content-security-policy"]
+  )
+  assert "allow-popups-to-escape-sandbox" in (
+    r2.headers["content-security-policy"]
+  )
+  assert "no-cache" in r2.headers["cache-control"]
 
 
 def test_frame_etag_changes_after_app_update(client, auth, db):

--- a/backend/tests/test_security_headers.py
+++ b/backend/tests/test_security_headers.py
@@ -201,6 +201,7 @@ def test_bundled_caddy_mirrors_exact_embed_frame_exception():
     if line.startswith("header @appFrame >Content-Security-Policy ")
   )
   assert "sandbox allow-scripts" in app_frame_csp
+  assert "allow-popups-to-escape-sandbox" in app_frame_csp
   assert "allow-same-origin" not in app_frame_csp
   assert "script-src 'self' 'unsafe-inline' blob: https://esm.sh" in app_frame_csp
   assert "blob:" not in ordinary_csp.split("style-src", 1)[0]

--- a/frontend/src/lib/__tests__/appModuleBroker.test.js
+++ b/frontend/src/lib/__tests__/appModuleBroker.test.js
@@ -154,6 +154,7 @@ test('only app-frame responses admit brokered blob modules at the edge', () => {
     line => line.includes('header @notFrameableEmbed >Content-Security-Policy'),
   ) || ''
   assert.match(frameCsp, /sandbox allow-scripts/)
+  assert.match(frameCsp, /allow-popups-to-escape-sandbox/)
   assert.doesNotMatch(frameCsp, /allow-same-origin/)
   assert.match(frameCsp, /script-src[^;]*\bblob:/)
   assert.doesNotMatch(ordinaryCsp, /script-src[^;]*\bblob:/)

--- a/frontend/src/lib/__tests__/storageBridgeFrame.test.js
+++ b/frontend/src/lib/__tests__/storageBridgeFrame.test.js
@@ -88,6 +88,7 @@ test('AppCanvas routes storage only after exact frame-source attribution', () =>
     line => line.includes('header @appFrame >Content-Security-Policy'),
   ) || ''
   assert.match(frameCsp, /sandbox allow-scripts/)
+  assert.match(frameCsp, /allow-popups-to-escape-sandbox/)
   assert.doesNotMatch(frameCsp, /\ballow-same-origin\b/)
 })
 

--- a/frontend/src/lib/__tests__/swCachePolicy.test.js
+++ b/frontend/src/lib/__tests__/swCachePolicy.test.js
@@ -42,6 +42,10 @@ test('runtime cache cleanup evicts old offline app caches', () => {
   // v2 superseded by the -v3 bump (frame-rev cache-key fix). Must be evicted on
   // activate so installed PWAs drop frames cached under the pre-fix un-revved key.
   assert.equal(isStaleRuntimeCache('mobius-offline-apps-v2'), true)
+  // v3 stored app-frame responses before popup escape was added to their CSP.
+  // It must not survive offline/cache-first into the revised policy.
+  assert.equal(isStaleRuntimeCache('mobius-offline-apps-v3'), true)
+  assert.equal(isStaleRuntimeCache(OFFLINE_APPS_CACHE), false)
   assert.equal(isStaleRuntimeCache('mobius-standalone'), true)
   assert.equal(isStaleRuntimeCache('mobius-standalone-v1'), true)
 })

--- a/frontend/src/sw-cache-policy.js
+++ b/frontend/src/sw-cache-policy.js
@@ -21,7 +21,11 @@ export const ESM_CACHE = 'mobius-esm-v2'
 // app-frame.html (un-gated light @media flipping --bg on a light OS). Renaming
 // the cache makes isStaleRuntimeCache delete the old `-v2` cache on the next
 // activate so the next open re-warms under the correct revved key.
-export const OFFLINE_APPS_CACHE = 'mobius-offline-apps-v3'
+// Bumped -v3 → -v4 (2026-07-22): frame response CSP now lets user-opened
+// destination tabs escape the frame's opaque sandbox. Cache-first would serve
+// the old response policy once (or indefinitely offline), so activation must
+// evict v3 and make the first post-upgrade frame load use the new CSP.
+export const OFFLINE_APPS_CACHE = 'mobius-offline-apps-v4'
 export const STANDALONE_APPS_CACHE = 'mobius-standalone-v2'
 // app-assets bumped to -v2 ONCE (2026-06-12) to evict entries poisoned by
 // ranged-request bodies: CubeRun's probe GET with `Range: bytes=0-0` came


### PR DESCRIPTION
## Summary

- allow app-opened external links to escape the inherited iframe sandbox
- bump the offline app-shell cache version so existing installations receive the policy change
- preserve the current CSP and Cache-Control headers on conditional 304 responses
- add frontend and backend regressions for the complete upgrade path

## Review note

The original sandbox flag was directionally correct but incomplete because cached shells could retain the old policy. This revision closes that deployment boundary.

## Validation

- 36 focused frontend tests passed
- 24 focused backend tests passed
- production build passed
- full frontend and backend suites passed through the privacy pre-push gate