### PR TITLE
Preserve chat disclosure state and viewport position

### DIFF
--- a/frontend/src/components/ChatView/ActivityStretch.jsx
+++ b/frontend/src/components/ChatView/ActivityStretch.jsx
@@ -1,4 +1,4 @@
-import { useId, useMemo, useRef, useState } from 'react'
+import { useId, useMemo, useRef } from 'react'
 import { StandardMarkdown } from './markdown/BlockRenderer.jsx'
 import ToolBlock from './ToolBlock.jsx'
 import {
@@ -16,6 +16,7 @@ import { preserveTogglePosition } from './preserveTogglePosition.js'
 import ActivityLineHeader, { ActivityTypeIcon } from './ActivityLineHeader.jsx'
 import SubagentChips from './SubagentChips.jsx'
 import { useThinkingTrace } from './useThinkingTrace.js'
+import { useDisclosureState } from './disclosureState.js'
 
 // One collapsible activity line standing in for a MULTI-STEP contiguous stretch
 // of thinking and tool blocks, so a build turn's pre-prose burst reads as one
@@ -32,8 +33,9 @@ import { useThinkingTrace } from './useThinkingTrace.js'
 // the transcript. A thought keeps this same child component as tools arrive,
 // avoiding an automatic height/state change in the middle of a live run.
 //
-// COLLAPSED BY DEFAULT, ALWAYS — the line never auto-opens; the user's tap is
-// the only thing that opens or closes it, mid-run included. An earlier version
+// COLLAPSED ON FIRST ENCOUNTER, then restored from this chat's session screen
+// state — the line never auto-opens; the user's tap is the only thing that
+// changes its saved open/closed value, mid-run included. An earlier version
 // of the tool-group card this replaces force-opened while any child was running
 // (`open = running || userOpen`), on the theory that the live tool should stay
 // visible mid-stream. That was wrong on two counts:
@@ -48,9 +50,10 @@ import { useThinkingTrace } from './useThinkingTrace.js'
 // shimmer plus the running-first activity summary already say what is
 // executing. So the sole open/close signal is `userOpen`, and no effect or
 // prop derives it.
-function TimelineThought({ label, thought, chatId }) {
-  const [open, setOpen] = useState(false)
+function TimelineThought({ label, thought, chatId, disclosureKey }) {
+  const [open, setOpen] = useDisclosureState(chatId, disclosureKey)
   const headerRef = useRef(null)
+  const bodyRef = useRef(null)
   const bodyId = useId()
   const trace = useThinkingTrace({ open, thought, chatId })
   const content = thinkingContentForDisplay(trace.content)
@@ -85,7 +88,7 @@ function TimelineThought({ label, thought, chatId }) {
         type="button"
         className="chat__activity-think-toggle"
         onClick={() => {
-          preserveTogglePosition(headerRef.current)
+          preserveTogglePosition(headerRef.current, bodyRef.current)
           setOpen(o => !o)
         }}
         aria-expanded={open}
@@ -96,7 +99,7 @@ function TimelineThought({ label, thought, chatId }) {
         </span>
         <span className="chat__activity-think-label">{label}</span>
       </button>
-      <div id={bodyId} className="chat__reasoning-body" hidden={!open}>
+      <div ref={bodyRef} id={bodyId} className="chat__reasoning-body" hidden={!open}>
         {open && body}
         {open && loadState === 'ready' && !trace.previewComplete && (
           <div className="chat__lazy-status chat__reasoning-preview-status">
@@ -121,8 +124,9 @@ function TimelineThought({ label, thought, chatId }) {
   )
 }
 
-function SingleActivity({ entry, chatId, live }) {
+function SingleActivity({ entry, chatId, live, surfaceKey }) {
   const { item, idx } = entry
+  const blockKey = assistantBlockKey(item, idx)
   if (item.type === 'thinking') {
     return (
       <TimelineThought
@@ -130,6 +134,7 @@ function SingleActivity({ entry, chatId, live }) {
         label={live ? 'Thinking' : thoughtDurationLabel(item.duration_ms)}
         thought={item}
         chatId={chatId}
+        disclosureKey={`${surfaceKey}:thought:${blockKey}`}
       />
     )
   }
@@ -138,15 +143,25 @@ function SingleActivity({ entry, chatId, live }) {
     && Object.keys(item.subagent).length > 0
   return (
     <>
-      <ToolBlock key={assistantBlockKey(item, idx)} t={item} chatId={chatId} />
+      <ToolBlock
+        key={assistantBlockKey(item, idx)}
+        t={item}
+        chatId={chatId}
+        disclosureKey={`${surfaceKey}:tool:${blockKey}`}
+      />
       {hasHelpers && <SubagentChips subagent={item.subagent} />}
     </>
   )
 }
 
-function GroupedActivityStretch({ entries, chatId, live = false }) {
-  const [userOpen, setUserOpen] = useState(false)
+function GroupedActivityStretch({ entries, chatId, live = false, surfaceKey }) {
+  const stretchKey = assistantBlockKey(entries[0]?.item, entries[0]?.idx)
+  const [userOpen, setUserOpen] = useDisclosureState(
+    chatId,
+    `${surfaceKey}:activity:${stretchKey}`,
+  )
   const headerRef = useRef(null)
+  const timelineRef = useRef(null)
   const timelineId = useId()
 
   const lastItem = entries[entries.length - 1]?.item
@@ -262,7 +277,7 @@ function GroupedActivityStretch({ entries, chatId, live = false }) {
         // no forced-open state for a tap to fight, so the user can peek into a
         // live run and close it again.
         onToggle={() => {
-          preserveTogglePosition(headerRef.current)
+          preserveTogglePosition(headerRef.current, timelineRef.current)
           setUserOpen(o => !o)
         }}
         // A delegating turn's helper rollup ("2 running · 1 done"); the header
@@ -279,7 +294,7 @@ function GroupedActivityStretch({ entries, chatId, live = false }) {
           subagent={tool.subagent}
         />
       ))}
-      <div id={timelineId} className="chat__activity-timeline" hidden={!open}>
+      <div ref={timelineRef} id={timelineId} className="chat__activity-timeline" hidden={!open}>
         {open && entries.map(({ item, idx }) => {
           if (item.type === 'thinking') {
             const key = assistantBlockKey(item, idx)
@@ -289,13 +304,19 @@ function GroupedActivityStretch({ entries, chatId, live = false }) {
                 label={thoughtDurationLabel(item.duration_ms)}
                 thought={item}
                 chatId={chatId}
+                disclosureKey={`${surfaceKey}:thought:${key}`}
               />
             )
           }
           // chatId + the block's tool_use_id let ToolBlock lazily fetch a
           // truncated large output on expand (GET /tool-output/{tool_use_id}).
           return (
-            <ToolBlock key={assistantBlockKey(item, idx)} t={item} chatId={chatId} />
+            <ToolBlock
+              key={assistantBlockKey(item, idx)}
+              t={item}
+              chatId={chatId}
+              disclosureKey={`${surfaceKey}:tool:${assistantBlockKey(item, idx)}`}
+            />
           )
         })}
       </div>
@@ -303,9 +324,23 @@ function GroupedActivityStretch({ entries, chatId, live = false }) {
   )
 }
 
-export default function ActivityStretch({ entries, chatId, live = false }) {
+export default function ActivityStretch({ entries, chatId, live = false, surfaceKey }) {
   if (entries.length === 1) {
-    return <SingleActivity entry={entries[0]} chatId={chatId} live={live} />
+    return (
+      <SingleActivity
+        entry={entries[0]}
+        chatId={chatId}
+        live={live}
+        surfaceKey={surfaceKey}
+      />
+    )
   }
-  return <GroupedActivityStretch entries={entries} chatId={chatId} live={live} />
+  return (
+    <GroupedActivityStretch
+      entries={entries}
+      chatId={chatId}
+      live={live}
+      surfaceKey={surfaceKey}
+    />
+  )
 }

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -3768,6 +3768,7 @@ export default function ChatView({
               <MsgContent
                 msg={msg}
                 chatId={chatId}
+                messageKey={dataKey}
                 onQuestionAnswer={doSendSilent}
                 onResume={doSend}
                 onInternalNav={internalNav}

--- a/frontend/src/components/ChatView/MsgContent.jsx
+++ b/frontend/src/components/ChatView/MsgContent.jsx
@@ -33,6 +33,7 @@ function blockAnswerable(block, { msg, isLastMsg, liveQuestionId, onQuestionAnsw
 function MsgContentInner({
   msg,
   chatId,
+  messageKey,
   onQuestionAnswer,
   // Resume a turn paused by a drain-gated restart (or interrupted by a crash):
   // a stable send callback that re-sends a short "continue". Only the tail
@@ -278,7 +279,12 @@ function MsgContentInner({
                 key={assistantBlockKey(node.group[0].item, node.group[0].idx)}
                 className="chat__tools"
               >
-                <ActivityStretch entries={node.group} chatId={chatId} live={live} />
+                <ActivityStretch
+                  entries={node.group}
+                  chatId={chatId}
+                  live={live}
+                  surfaceKey={messageKey}
+                />
               </div>
             )
           }
@@ -333,6 +339,7 @@ export default memo(MsgContentInner, (prev, next) => {
   return (
     prev.msg === next.msg
     && prev.chatId === next.chatId
+    && prev.messageKey === next.messageKey
     && prev.onQuestionAnswer === next.onQuestionAnswer
     && prev.onResume === next.onResume
     && prev.onInternalNav === next.onInternalNav

--- a/frontend/src/components/ChatView/StreamingMessage.jsx
+++ b/frontend/src/components/ChatView/StreamingMessage.jsx
@@ -33,6 +33,7 @@ export default function StreamingMessage({
       <MsgContent
         msg={msg}
         chatId={chatId}
+        messageKey={dataKey}
         onQuestionAnswer={onAnswer}
         onResume={onResume}
         onInternalNav={onInternalNav}

--- a/frontend/src/components/ChatView/ToolBlock.jsx
+++ b/frontend/src/components/ChatView/ToolBlock.jsx
@@ -11,6 +11,7 @@ import {
 } from './toolActivityLabel.js'
 import { preserveTogglePosition } from './preserveTogglePosition.js'
 import { ActivityTypeIcon } from './ActivityLineHeader.jsx'
+import { useDisclosureState } from './disclosureState.js'
 
 // Render an already-formatted tool result (see toolResultFormat.js) so shell
 // output reads as a terminal (stdout / stderr / exit code) and a structured
@@ -72,13 +73,14 @@ function ToolResult({ r }) {
   )
 }
 
-export default function ToolBlock({ t, chatId }) {
+export default function ToolBlock({ t, chatId, disclosureKey }) {
   // Collapsed until tapped — nothing produces a pre-opened tool block anymore
   // (the last producer, the legacy compaction path, renders as CompactionCard;
   // a legacy persisted `defaultOpen` field is ignored and renders collapsed
   // like everything else).
-  const [open, setOpen] = useState(false)
+  const [open, setOpen] = useDisclosureState(chatId, disclosureKey)
   const headerRef = useRef(null)
+  const detailRef = useRef(null)
   const headerId = useId()
   const detailId = useId()
   // Expansion fetches only the renderer-sized preview. The exact full output
@@ -337,7 +339,7 @@ export default function ToolBlock({ t, chatId }) {
           type="button"
           className="chat__tool-header"
           onClick={() => {
-            preserveTogglePosition(headerRef.current)
+            preserveTogglePosition(headerRef.current, detailRef.current)
             setOpen(o => !o)
           }}
           aria-expanded={open}
@@ -354,6 +356,7 @@ export default function ToolBlock({ t, chatId }) {
       )}
       {hasDetail && (
         <div
+          ref={detailRef}
           id={detailId}
           className="chat__tool-detail"
           role="region"

--- a/frontend/src/components/ChatView/__tests__/activityLineStructure.test.js
+++ b/frontend/src/components/ChatView/__tests__/activityLineStructure.test.js
@@ -57,8 +57,8 @@ test('every thinking entry remains the same collapsed nested disclosure', () => 
     'thinking is an activity type, not an empty icon column')
   assert.match(activityStretch, /function TimelineThought/,
     'a mixed thought owns its disclosure state')
-  assert.match(activityStretch, /const \[open, setOpen\] = useState\(false\)/,
-    'nested thinking starts collapsed')
+  assert.match(activityStretch, /const \[open, setOpen\] = useDisclosureState\(chatId, disclosureKey\)/,
+    'nested thinking restores its per-chat disclosure state')
   assert.match(activityStretch, /className="chat__activity-think-toggle"/)
   assert.doesNotMatch(activityStretch, /chat__activity-think-chevron/,
     'nested reasoning uses its icon and row affordance without a chevron')
@@ -72,7 +72,7 @@ test('every thinking entry remains the same collapsed nested disclosure', () => 
     'deferred thought state changes should be announced')
   assert.match(activityStretch, /className="chat__lazy-retry" onClick=\{trace\.retry\}/,
     'a failed thought should retry without a close/reopen ritual')
-  assert.match(activityStretch, /preserveTogglePosition\(headerRef\.current\)\s*setOpen\(o => !o\)/,
+  assert.match(activityStretch, /preserveTogglePosition\(headerRef\.current, bodyRef\.current\)\s*setOpen\(o => !o\)/,
     'opening a long trace preserves the reader anchor')
   assert.doesNotMatch(activityStretch, /if \(thinkingOnly\) \{/,
     'a thinking-only entry must not swap component type when the first tool arrives')
@@ -82,10 +82,10 @@ test('every thinking entry remains the same collapsed nested disclosure', () => 
 
 test('a single activity discloses directly without a redundant parent row', () => {
   assert.match(activityStretch, /if \(entries\.length === 1\)/)
-  assert.match(activityStretch, /return <SingleActivity entry=\{entries\[0\]\}/)
+  assert.match(activityStretch, /<SingleActivity[\s\S]*entry=\{entries\[0\]\}/)
   assert.match(activityStretch,
     /item\.type === 'thinking'[\s\S]*<TimelineThought[\s\S]*key=\{assistantBlockKey\(item, idx\)\}/)
-  assert.match(activityStretch, /<ToolBlock key=\{assistantBlockKey\(item, idx\)\}/)
+  assert.match(activityStretch, /<ToolBlock[\s\S]*key=\{assistantBlockKey\(item, idx\)\}/)
 })
 
 test('lazy tool details and touch targets keep their accessibility contract', () => {

--- a/frontend/src/components/ChatView/__tests__/activityNoAutoOpen.test.js
+++ b/frontend/src/components/ChatView/__tests__/activityNoAutoOpen.test.js
@@ -17,9 +17,9 @@ const src = readFileSync(new URL('../ActivityStretch.jsx', import.meta.url), 'ut
 // removed, and that history must not trip the code-level guard below.
 const body = src.slice(src.indexOf('function GroupedActivityStretch'))
 
-test('the stretch starts collapsed and open is exactly userOpen', () => {
-  assert.match(body, /const \[userOpen, setUserOpen\] = useState\(false\)/,
-    'userOpen initializes to false (collapsed by default)')
+test('the stretch restores saved user state and open is exactly userOpen', () => {
+  assert.match(body, /const \[userOpen, setUserOpen\] = useDisclosureState\(/,
+    'userOpen restores only the user-authored per-chat state')
   assert.match(body, /\n\s*const open = userOpen\n/,
     'open derives from userOpen alone — no force-open expression')
   // No `open = running || userOpen` / `userOpen || live` style force-open.
@@ -34,7 +34,7 @@ test('the only open-state write is the user toggle, guarded by preserveTogglePos
     'setUserOpen is called from exactly one place')
   // preserveTogglePosition runs BEFORE the state mutation on every toggle path —
   // the scroll anchor is captured before the height changes.
-  assert.match(src, /preserveTogglePosition\(headerRef\.current\)\s*setUserOpen\(o => !o\)/,
+  assert.match(src, /preserveTogglePosition\(headerRef\.current, timelineRef\.current\)\s*setUserOpen\(o => !o\)/,
     'the toggle preserves the anchor before flipping open state')
 })
 

--- a/frontend/src/components/ChatView/__tests__/disclosureState.test.js
+++ b/frontend/src/components/ChatView/__tests__/disclosureState.test.js
@@ -1,0 +1,40 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  _resetDisclosureStateForTests,
+  disclosureIsOpen,
+  persistDisclosureOpen,
+} from '../disclosureState.js'
+
+function memorySessionStorage() {
+  const values = new Map()
+  return {
+    getItem: key => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, String(value)),
+  }
+}
+
+test('disclosure screen state restores per chat and stable surface key', () => {
+  const original = globalThis.sessionStorage
+  globalThis.sessionStorage = memorySessionStorage()
+  _resetDisclosureStateForTests()
+  try {
+    persistDisclosureOpen('chat-a', 'message-1:activity:think-1', true)
+    assert.equal(disclosureIsOpen('chat-a', 'message-1:activity:think-1'), true)
+    assert.equal(disclosureIsOpen('chat-a', 'message-2:activity:think-1'), false)
+    assert.equal(disclosureIsOpen('chat-b', 'message-1:activity:think-1'), false)
+
+    // Simulate a ChatView remount by dropping the module's memory cache. The
+    // browser-session copy remains the restoration authority.
+    _resetDisclosureStateForTests()
+    assert.equal(disclosureIsOpen('chat-a', 'message-1:activity:think-1'), true)
+
+    persistDisclosureOpen('chat-a', 'message-1:activity:think-1', false)
+    _resetDisclosureStateForTests()
+    assert.equal(disclosureIsOpen('chat-a', 'message-1:activity:think-1'), false)
+  } finally {
+    _resetDisclosureStateForTests()
+    globalThis.sessionStorage = original
+  }
+})

--- a/frontend/src/components/ChatView/__tests__/preserveTogglePosition.test.js
+++ b/frontend/src/components/ChatView/__tests__/preserveTogglePosition.test.js
@@ -26,19 +26,22 @@ test('toggle position is corrected from the DOM mutation before rAF', () => {
   }
 
   try {
-    const parentElement = {}
+    const body = {}
     const scroller = { scrollTop: 40 }
     let top = 120
     const anchor = {
-      parentElement,
+      parentElement: {},
+      nextElementSibling: body,
       closest: () => scroller,
       getBoundingClientRect: () => ({ top }),
     }
 
     preserveTogglePosition(anchor)
-    assert.equal(observedNode, parentElement)
-    assert.deepEqual(observedOptions, { childList: true },
-      'live descendant churn must not win the disclosure mutation race')
+    assert.equal(observedNode, body)
+    assert.deepEqual(observedOptions, {
+      attributes: true,
+      attributeFilter: ['hidden'],
+    }, 'the body visibility commit must be the exact correction boundary')
 
     top = 155
     mutationCallback()
@@ -81,6 +84,44 @@ test('rAF remains a fallback when MutationObserver is unavailable', () => {
     assert.equal(scroller.scrollTop, 8)
   }
   finally {
+    globalThis.MutationObserver = originalMutationObserver
+    globalThis.requestAnimationFrame = originalRaf
+  }
+})
+
+test('toggle preservation never exempts a disclosure because follow was active', () => {
+  const originalMutationObserver = globalThis.MutationObserver
+  const originalRaf = globalThis.requestAnimationFrame
+  let observed = false
+  let scheduled = false
+  globalThis.MutationObserver = class {
+    constructor() {}
+    observe() { observed = true }
+    disconnect() {}
+  }
+  globalThis.requestAnimationFrame = () => {
+    scheduled = true
+    return 1
+  }
+
+  try {
+    const scroller = {
+      // Regression guard: an earlier implementation published this marker and
+      // used it to bypass preservation, replaying follow after the toggle.
+      dataset: { scrollMode: 'FOLLOW_BOTTOM' },
+      scrollTop: 30,
+      querySelector: () => null,
+    }
+    const body = {}
+    const anchor = {
+      closest: () => scroller,
+      getAttribute: () => 'false',
+      getBoundingClientRect: () => ({ top: 80 }),
+    }
+    preserveTogglePosition(anchor, body)
+    assert.equal(observed, true)
+    assert.equal(scheduled, true)
+  } finally {
     globalThis.MutationObserver = originalMutationObserver
     globalThis.requestAnimationFrame = originalRaf
   }

--- a/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
+++ b/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
@@ -15,6 +15,7 @@ import {
   layoutMayOwnScroll,
   mountMediaSettled,
   modeForChatExit,
+  modeForDisclosureToggle,
   modeForForegroundReturn,
   modeForQueuedSubmission,
   modeForViewportChange,
@@ -208,6 +209,29 @@ test('disclosure activation is recognized as an anchor-latching reading action',
   assert.equal(readerInputActivatesDisclosure(
     'pointerdown', '', staticStatusTarget), false,
   'a non-interactive status row must not stop live follow')
+})
+
+test('disclosure toggles always hold the reader anchor, including from FOLLOW_BOTTOM', () => {
+  const row = {
+    dataset: { key: 'assistant-1' },
+    offsetTop: 420,
+    offsetHeight: 300,
+  }
+  const scrollEl = {
+    scrollTop: 500,
+    querySelectorAll: () => [row],
+  }
+  const follow = { kind: 'FOLLOW_BOTTOM' }
+  assert.deepEqual(
+    modeForDisclosureToggle(scrollEl, follow),
+    { kind: 'ANCHOR_AT', key: 'assistant-1', offset: -80 },
+    'a disclosure tap retires autoscroll before its body changes height',
+  )
+  assert.deepEqual(
+    modeForDisclosureToggle(scrollEl, { kind: 'PIN_USER_MSG', cid: 'c1' }),
+    { kind: 'ANCHOR_AT', key: 'assistant-1', offset: -80 },
+    'outside autoscroll the visible reading position is frozen before resize',
+  )
 })
 
 test('only provably clamped wheel input gets a next-frame no-scroll release', () => {

--- a/frontend/src/components/ChatView/disclosureState.js
+++ b/frontend/src/components/ChatView/disclosureState.js
@@ -1,0 +1,68 @@
+import { useRef, useState } from 'react'
+
+
+// Disclosure state is screen state, not transcript data. Keep it for the
+// browser session so leaving a chat and returning restores the exact activity,
+// thought, and tool rows the reader opened without writing presentation state
+// into the durable conversation.
+const STORAGE_PREFIX = 'chat-disclosures:'
+const MAX_OPEN_DISCLOSURES = 200
+const cache = new Map()
+
+function storageKey(chatId) {
+  return `${STORAGE_PREFIX}${chatId}`
+}
+
+function readOpenKeys(chatId) {
+  const id = String(chatId || '')
+  if (!id) return new Set()
+  if (cache.has(id)) return cache.get(id)
+  let keys = []
+  try {
+    const parsed = JSON.parse(sessionStorage.getItem(storageKey(id)) || '[]')
+    if (Array.isArray(parsed)) keys = parsed.filter(key => typeof key === 'string')
+  } catch {}
+  const openKeys = new Set(keys.slice(-MAX_OPEN_DISCLOSURES))
+  cache.set(id, openKeys)
+  return openKeys
+}
+
+export function persistDisclosureOpen(chatId, disclosureKey, open) {
+  const id = String(chatId || '')
+  const key = String(disclosureKey || '')
+  if (!id || !key) return
+  const openKeys = readOpenKeys(id)
+  // Refresh insertion order when opening so the bounded set retains the most
+  // recently used disclosures in an unusually long tool-heavy chat.
+  openKeys.delete(key)
+  if (open) openKeys.add(key)
+  while (openKeys.size > MAX_OPEN_DISCLOSURES) {
+    openKeys.delete(openKeys.values().next().value)
+  }
+  try {
+    sessionStorage.setItem(storageKey(id), JSON.stringify([...openKeys]))
+  } catch {}
+}
+
+export function disclosureIsOpen(chatId, disclosureKey) {
+  return readOpenKeys(chatId).has(String(disclosureKey || ''))
+}
+
+export function useDisclosureState(chatId, disclosureKey) {
+  const [open, setOpenState] = useState(
+    () => disclosureIsOpen(chatId, disclosureKey),
+  )
+  const openRef = useRef(open)
+  openRef.current = open
+  const setOpen = (next) => {
+    const value = typeof next === 'function' ? !!next(openRef.current) : !!next
+    openRef.current = value
+    persistDisclosureOpen(chatId, disclosureKey, value)
+    setOpenState(value)
+  }
+  return [open, setOpen]
+}
+
+export function _resetDisclosureStateForTests() {
+  cache.clear()
+}

--- a/frontend/src/components/ChatView/preserveTogglePosition.js
+++ b/frontend/src/components/ChatView/preserveTogglePosition.js
@@ -15,7 +15,7 @@ function unwindProvisionalSpacer(spacer) {
   provisionalSpacer.delete(spacer)
 }
 
-export function preserveTogglePosition(anchorEl) {
+export function preserveTogglePosition(anchorEl, bodyEl = anchorEl?.nextElementSibling) {
   if (!anchorEl || typeof requestAnimationFrame !== 'function') return
   const scroller = anchorEl.closest?.('.chat__scroll')
   if (!scroller) return
@@ -31,11 +31,10 @@ export function preserveTogglePosition(anchorEl) {
   if (spacer) unwindProvisionalSpacer(spacer)
 
   if (anchorEl.getAttribute?.('aria-expanded') === 'true') {
-    const body = anchorEl.nextElementSibling
-    if (spacer && body) {
-      const rectHeight = body.getBoundingClientRect?.().height || 0
+    if (spacer && bodyEl) {
+      const rectHeight = bodyEl.getBoundingClientRect?.().height || 0
       const styles = typeof getComputedStyle === 'function'
-        ? getComputedStyle(body)
+        ? getComputedStyle(bodyEl)
         : null
       const marginTop = Number.parseFloat(styles?.marginTop) || 0
       const marginBottom = Number.parseFloat(styles?.marginBottom) || 0
@@ -67,16 +66,17 @@ export function preserveTogglePosition(anchorEl) {
     if (Math.abs(delta) > 0.5) scroller.scrollTop += delta
   }
 
-  if (typeof MutationObserver === 'function' && anchorEl.parentElement) {
+  if (typeof MutationObserver === 'function' && bodyEl) {
     observer = new MutationObserver(settle)
-    // The disclosure body is always a DIRECT sibling of the header. Observe
-    // only that wrapper's child list: an open live activity stretch keeps
-    // changing text, tool status, and timeline children below this level. A
-    // subtree observer can therefore settle on unrelated stream churn before
-    // React inserts/removes the disclosure body, making the same tap hold on
-    // one attempt and drift on the next. Direct-child observation names the
-    // actual transition and leaves live descendants out of the race.
-    observer.observe(anchorEl.parentElement, { childList: true })
+    // Every disclosure keeps its body node mounted and flips `hidden` while
+    // inserting/removing its rendered children. Watching the header's parent
+    // child list never saw that transition, leaving the rAF fallback to race a
+    // ResizeObserver. The body's own hidden attribute is the exact commit
+    // boundary, independent of live descendant churn.
+    observer.observe(bodyEl, {
+      attributes: true,
+      attributeFilter: ['hidden'],
+    })
   }
 
   // Safety fallback for an unusual disclosure that changes layout without a

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -560,7 +560,7 @@ export function readerInputActivatesDisclosure(
   pointerButton = 0,
 ) {
   const disclosure = target?.closest?.(
-    'button.chat__activity-header, button.chat__tool-header, button.chat__marker-header',
+    'button.chat__activity-header, button.chat__activity-think-toggle, button.chat__tool-header, button.chat__marker-header',
   )
   if (!disclosure) return false
   return (type === 'pointerdown' && pointerButton === 0)
@@ -614,6 +614,15 @@ export function modeForForegroundReturn(scrollEl) {
 export function modeForChatExit(scrollEl) {
   if (!scrollEl) return null
   return anchorModeFromScroll(scrollEl)
+}
+
+
+/** A disclosure toggle is a reading action, so it freezes the exact visible
+ * message anchor before the disclosure changes height. This deliberately
+ * retires FOLLOW_BOTTOM: replaying follow after the toggle makes an identical
+ * tap move only when live content happens to resize in the same frame. */
+export function modeForDisclosureToggle(scrollEl, currentMode) {
+  return anchorModeFromScroll(scrollEl) || currentMode
 }
 
 
@@ -1493,15 +1502,14 @@ export default function useScrollMode({
         scrollEl,
       })
       if (activatesDisclosure) {
-        // A disclosure tap says "hold what I am reading", not "keep following
-        // the conversation tail". Latch that intent BEFORE React changes the
-        // body height. The normal gesture gate below then defers ResizeObserver
-        // writes until pointerup, at which point it replays this anchor rather
-        // than the stale FOLLOW_BOTTOM that caused the non-repeatable jump.
-        const anchor = anchorModeFromScroll(scrollEl)
-        if (anchor) {
+        // A disclosure tap says "hold what I am reading," including when the
+        // previous mode was FOLLOW_BOTTOM. Latch the visible anchor BEFORE React
+        // changes body height. The gesture gate below defers ResizeObserver
+        // writes until pointerup, then replays that same held position.
+        const nextMode = modeForDisclosureToggle(scrollEl, modeRef.current)
+        if (nextMode && nextMode !== modeRef.current) {
           readerLocationExplicitRef.current = true
-          transitionMode(anchor, 'reader:disclosure-toggle')
+          transitionMode(nextMode, 'reader:disclosure-toggle')
           persistMode()
         }
       }


### PR DESCRIPTION
## Summary
- restore opened thinking, activity, and tool details when returning to a chat during the same browser session
- anchor every disclosure toggle to the visible message before its height changes
- observe the disclosure body's actual visibility change so repeated toggles cannot race layout updates

## Testing
- npm test
- npm run build
- toggled the same activity block ten times in a phone-sized viewport; its row and scroll position stayed unchanged