### PR TITLE
app-frame: fall back to same-origin module import when CSP blocks blob:

### DIFF
--- a/frontend/public/app-frame.html
+++ b/frontend/public/app-frame.html
@@ -617,12 +617,40 @@
       });
     }
 
+    // Fallback loader for environments whose CSP forbids executing a blob:
+    // module. The blob path (below) needs `script-src ... blob:`; a deployment
+    // whose edge proxy serves an older policy WITHOUT blob: (an app-code vs.
+    // edge-CSP version skew) blocks EVERY app with an opaque
+    // "Failed to fetch dynamically imported module: blob:null/..." error. This
+    // imports the compiled module directly from its same-origin /module URL,
+    // which `script-src 'self'` always permits (the mechanism the frame used
+    // before brokered-blob loading). The token rides as a query param because
+    // dynamic import() can't set headers; a cache-buster avoids Chromium
+    // resolving a previously-cached import failure. Self-contained bundle, so no
+    // relative/bare sub-imports depend on the URL. This keeps a stale-edge
+    // deployment fully working instead of dark, and self-heals once the edge
+    // policy is corrected (the blob path simply stops throwing).
+    async function importDirectModule() {
+      const url = '/api/apps/' + encodeURIComponent(_FRAME_APP_ID)
+        + '/module?token=' + encodeURIComponent(currentToken)
+        + '&_=' + Date.now();
+      return await import(url);
+    }
+
     async function importBrokeredModule(retry) {
       const bytes = await requestModuleBytes(retry);
       const blob = new Blob([bytes], { type: 'text/javascript' });
       const blobUrl = URL.createObjectURL(blob);
       try {
         return await import(blobUrl);
+      } catch (blobImportErr) {
+        // The blob module itself failed to execute. The dominant cause in
+        // practice is a CSP that forbids blob: scripts (surfaced as a TypeError
+        // "Failed to fetch dynamically imported module: blob:null/..."); a
+        // genuine syntax/eval error in the bundle would fail identically on the
+        // direct path and fall through to the error surface, so the fallback is
+        // safe either way.
+        return await importDirectModule();
       } finally {
         URL.revokeObjectURL(blobUrl);
       }


### PR DESCRIPTION
## Problem

Since the app frame switched to brokered blob module loading, it executes each app's compiled module via `URL.createObjectURL` + `import(blobUrl)`. That requires the page CSP `script-src` to include `blob:`. On a deployment whose edge proxy serves a Content-Security-Policy WITHOUT `blob:` in `script-src` — e.g. a shared edge whose policy lags the app-code update (the bundled Caddyfile grants `blob:`, but a separately-deployed edge may not) — the browser blocks every app module with an opaque error:

```
TypeError: Failed to fetch dynamically imported module: blob:null/<uuid>
```

That is a total, cryptic app outage for the whole instance, caused by a version skew between the app code (needs `blob:`) and the edge security policy (doesn't grant it).

## Fix

Make module loading self-healing. `importBrokeredModule` still tries the secure brokered blob path first; if the blob `import()` throws, it falls back to importing the compiled module directly from its same-origin `/api/apps/{id}/module?token=...` URL, which `script-src 'self'` always permits (the mechanism the frame used before brokered-blob loading). The compiled bundle is self-contained, so no relative/bare sub-imports depend on the blob URL, and a genuine syntax/eval error in the bundle fails identically on the direct path and still reaches the error UI — so the fallback is safe either way.

Result: an app-code vs. edge-CSP skew degrades gracefully (apps still load) instead of taking the instance dark, and self-heals once the edge policy is corrected (the blob path simply stops throwing).

## Verification

Reproduced against a live deployment whose edge CSP lacked `blob:` in `script-src`: before, every app failed with the `blob:null` error; after, all apps load via the fallback. Verified two different apps load end-to-end through the real edge proxy.

Trade-off: the fallback passes the app token as a query param (dynamic `import()` cannot set headers) — the same compromise the pre-brokered loader made, and only on the degraded path.