### PR TITLE
Fix false-positive Claude connection status

### DIFF
--- a/backend/app/providers.py
+++ b/backend/app/providers.py
@@ -551,7 +551,43 @@ class ClaudeProvider(BaseProvider):
         "Not signed in. Open Settings and connect "
         "under AI provider."
       )
-    return None
+    try:
+      raw = json.loads(creds.read_text())
+    except (json.JSONDecodeError, OSError, UnicodeError):
+      raw = None
+    oauth = raw.get("claudeAiOauth") if isinstance(raw, dict) else None
+    if isinstance(oauth, dict):
+      access_token = oauth.get("accessToken")
+      refresh_token = oauth.get("refreshToken")
+      expires_at = oauth.get("expiresAt")
+      refresh_expires_at = oauth.get("refreshTokenExpiresAt")
+      now_ms = time.time() * 1000
+      access_is_current = (
+        isinstance(access_token, str)
+        and bool(access_token.strip())
+        and isinstance(expires_at, (int, float))
+        and not isinstance(expires_at, bool)
+        and expires_at - now_ms >= _CLAUDE_TOKEN_REFRESH_MARGIN_MS
+      )
+      refresh_expiry_is_current = (
+        "refreshTokenExpiresAt" not in oauth
+        or (
+          isinstance(refresh_expires_at, (int, float))
+          and not isinstance(refresh_expires_at, bool)
+          and refresh_expires_at > now_ms
+        )
+      )
+      can_refresh = (
+        isinstance(refresh_token, str)
+        and bool(refresh_token.strip())
+        and refresh_expiry_is_current
+      )
+      if access_is_current or can_refresh:
+        return None
+    return (
+      "Claude sign-in is incomplete or expired. Open Settings and "
+      "reconnect under AI provider."
+    )
 
   async def ensure_auth(self, data_dir: str) -> None:
     """Refresh the Claude OAuth token before a chat turn, if expired.

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,6 +1,7 @@
 """Tests for authentication flow."""
 
 import json
+import time
 
 import bcrypt
 
@@ -198,6 +199,137 @@ def test_provider_status_exposes_configured_with_legacy_alias(client, auth):
   assert r.status_code == 200, r.text
   body = r.json()
   assert body["configured"] is body["authenticated"]
+
+
+def test_providers_status_rejects_empty_claude_oauth_record(
+  client, auth, tmp_path, monkeypatch,
+):
+  """A leftover credential shell is not a connected Claude session.
+
+  Recovery can preserve the scopes/email metadata while clearing unusable
+  tokens. File-presence checks used to report that state as connected even
+  though the next turn deterministically failed authentication.
+  """
+  from app.config import get_settings
+
+  data_dir = tmp_path / "data"
+  creds = data_dir / "cli-auth" / "claude" / ".credentials.json"
+  creds.parent.mkdir(parents=True)
+  creds.write_text(json.dumps({
+    "claudeAiOauth": {
+      "expiresAt": 0,
+      "scopes": ["user:inference"],
+    },
+  }))
+  monkeypatch.setattr(get_settings(), "data_dir", str(data_dir))
+
+  r = client.get("/api/auth/providers/status", headers=auth)
+
+  assert r.status_code == 200, r.text
+  status = r.json()["claude"]
+  assert status["configured"] is False
+  assert status["authenticated"] is False
+  assert "reconnect" in status["error"].lower()
+
+
+def test_claude_auth_accepts_current_access_or_refreshable_session(tmp_path):
+  from app.providers import ClaudeProvider
+
+  creds = tmp_path / "cli-auth" / "claude" / ".credentials.json"
+  creds.parent.mkdir(parents=True)
+
+  creds.write_text(json.dumps({
+    "claudeAiOauth": {
+      "accessToken": "current-token",
+      "expiresAt": int(time.time() * 1000) + 120_000,
+    },
+  }))
+  assert ClaudeProvider().check_auth(str(tmp_path)) is None
+
+  # Older Claude credential documents omit refreshTokenExpiresAt.
+  creds.write_text(json.dumps({
+    "claudeAiOauth": {
+      "accessToken": "expired-token",
+      "refreshToken": "refresh-token",
+      "expiresAt": 0,
+    },
+  }))
+  assert ClaudeProvider().check_auth(str(tmp_path)) is None
+
+  creds.write_text(json.dumps({
+    "claudeAiOauth": {
+      "accessToken": "expired-token",
+      "refreshToken": "refresh-token",
+      "expiresAt": 0,
+      "refreshTokenExpiresAt": int(time.time() * 1000) + 120_000,
+    },
+  }))
+  assert ClaudeProvider().check_auth(str(tmp_path)) is None
+
+
+def test_claude_auth_rejects_expired_unrefreshable_session(tmp_path):
+  from app.providers import ClaudeProvider
+
+  creds = tmp_path / "cli-auth" / "claude" / ".credentials.json"
+  creds.parent.mkdir(parents=True)
+  creds.write_text(json.dumps({
+    "claudeAiOauth": {
+      "accessToken": "expired-token",
+      "expiresAt": 0,
+    },
+  }))
+
+  error = ClaudeProvider().check_auth(str(tmp_path))
+
+  assert error is not None
+  assert "reconnect" in error.lower()
+
+  creds.write_text(json.dumps({
+    "claudeAiOauth": {
+      "accessToken": "expired-token",
+      "refreshToken": "expired-refresh-token",
+      "expiresAt": 0,
+      "refreshTokenExpiresAt": 0,
+    },
+  }))
+
+  error = ClaudeProvider().check_auth(str(tmp_path))
+
+  assert error is not None
+  assert "reconnect" in error.lower()
+
+
+def test_claude_auth_rejects_malformed_credentials(tmp_path):
+  from app.providers import ClaudeProvider
+
+  creds = tmp_path / "cli-auth" / "claude" / ".credentials.json"
+  creds.parent.mkdir(parents=True)
+  creds.write_text("{not-json")
+
+  error = ClaudeProvider().check_auth(str(tmp_path))
+
+  assert error is not None
+  assert "reconnect" in error.lower()
+
+
+def test_providers_status_rejects_non_utf8_claude_credentials(
+  client, auth, tmp_path, monkeypatch,
+):
+  from app.config import get_settings
+
+  data_dir = tmp_path / "data"
+  creds = data_dir / "cli-auth" / "claude" / ".credentials.json"
+  creds.parent.mkdir(parents=True)
+  creds.write_bytes(b"\xff\xfe")
+  monkeypatch.setattr(get_settings(), "data_dir", str(data_dir))
+
+  r = client.get("/api/auth/providers/status", headers=auth)
+
+  assert r.status_code == 200, r.text
+  status = r.json()["claude"]
+  assert status["configured"] is False
+  assert status["authenticated"] is False
+  assert "reconnect" in status["error"].lower()
 
 
 def test_providers_models_returns_known_models_on_missing_creds(

--- a/backend/tests/test_chat_writer_activation.py
+++ b/backend/tests/test_chat_writer_activation.py
@@ -12,6 +12,7 @@ to the test DB, so these exercise the actual `get_writer()` path.
 """
 
 import asyncio
+import json
 import threading
 import time
 
@@ -345,7 +346,12 @@ def test_finalize_failure_via_run_chat_leaves_marker_for_reconciliation(
     / "cli-auth" / "claude" / ".credentials.json"
   )
   creds.parent.mkdir(parents=True, exist_ok=True)
-  creds.write_text("{}", encoding="utf-8")
+  creds.write_text(json.dumps({
+    "claudeAiOauth": {
+      "accessToken": "test-token",
+      "expiresAt": int(time.time() * 1000) + 3_600_000,
+    },
+  }), encoding="utf-8")
 
   # Fake the Claude SDK runner: stream one text block through the sink (so
   # finalize() has accumulated blocks and actually submits a Finalize), then

--- a/backend/tests/test_terminal_completion.py
+++ b/backend/tests/test_terminal_completion.py
@@ -14,9 +14,11 @@ the test DB, so `get_writer()` is the real path throughout.
 """
 
 import asyncio
+import json
 import os
 import pathlib
 import threading
+import time
 
 import pytest
 
@@ -53,7 +55,12 @@ def _seed_owner_and_creds():
     / ".credentials.json"
   )
   creds.parent.mkdir(parents=True, exist_ok=True)
-  creds.write_text("{}", encoding="utf-8")
+  creds.write_text(json.dumps({
+    "claudeAiOauth": {
+      "accessToken": "test-token",
+      "expiresAt": int(time.time() * 1000) + 3_600_000,
+    },
+  }), encoding="utf-8")
 
 
 def _seed_chat(chat_id, messages=None, pending=None, run_status=None,
@@ -928,22 +935,28 @@ def test_no_owner_cleanup_clears_marker_before_registry_release(monkeypatch):
 
 
 # -- 12. auth-error setup cleanup: marker cleared, pending dropped ----------
-def test_auth_error_cleanup_clears_marker_before_registry_release(monkeypatch):
+@pytest.mark.parametrize("malformed_credentials", [False, True])
+def test_auth_error_cleanup_clears_marker_before_registry_release(
+  monkeypatch, malformed_credentials,
+):
   """The auth-error setup early return routes through the same bounded
   terminal cleanup: pending cleared, marker cleared, registry released, no
   continuation."""
-  # Seed an owner but NO creds file → Claude check_auth returns an error.
+  # Seed an owner with either NO creds file or a non-UTF-8 creds file →
+  # Claude check_auth returns an error without escaping into a route/runner 500.
   # The DATA_DIR tmpdir is shared across tests and conftest does not sweep
   # the creds file, so a prior _seed_owner_and_creds may have written one —
-  # remove it explicitly to guarantee the auth-error precondition.
+  # remove or replace it explicitly to guarantee the auth-error precondition.
   from app import auth as auth_mod
 
   creds = (
     pathlib.Path(os.environ["DATA_DIR"]) / "cli-auth" / "claude"
     / ".credentials.json"
   )
-  if creds.exists():
-    creds.unlink()
+  creds.unlink(missing_ok=True)
+  if malformed_credentials:
+    creds.parent.mkdir(parents=True, exist_ok=True)
+    creds.write_bytes(b"\xff\xfe")
   dbx = SessionLocal()
   try:
     dbx.add(models.Owner(


### PR DESCRIPTION
## Summary

- validate the local Claude OAuth record instead of treating credential-file presence as connected
- accept a current access token with at least the existing 60-second refresh margin, or a nonempty refresh token whose optional refreshTokenExpiresAt is still in the future
- preserve compatibility with legacy Claude credential documents that omit refreshTokenExpiresAt
- report missing, malformed JSON, non-UTF-8, expired-access/unrefreshable, and explicitly expired-refresh records as disconnected with reconnect guidance
- update test fixtures that previously used an impossible empty credential document

## Production symptom

A production Claude credential file retained OAuth metadata/scopes but had no access token, no refresh token, and an expiry of zero. The provider-status endpoint nevertheless returned configured/authenticated=true because the preflight checked only for file existence. A subsequent Claude turn failed authentication; switching that chat to Codex recovered it. No chat message content is included here.

This change is a local predicate only. It does not probe Anthropic or change token-refresh behavior.

## Validation

82 focused backend tests passed after rebasing on current main, covering the auth predicate and status route, non-UTF-8 chat-preflight terminal cleanup, terminal completion, chat-writer activation, model registry, and chat agent settings. Cases include empty, malformed JSON, malformed encoding, current-access, legacy refreshable, future-expiring refreshable, expired-access/unrefreshable, and explicitly expired refresh-token credentials.

## Residual risk

A revoked but unexpired (or legacy expiry-less) refresh token continues to count as configured until a refresh is attempted. Detecting revocation here would require a remote token probe, which is intentionally outside this passive status path.