### PR TITLE
Preserve truthful chat and update outcomes

### DIFF
--- a/backend/app/app_git.py
+++ b/backend/app/app_git.py
@@ -349,6 +349,32 @@ def head_sha(source_dir: str | Path, branch: str) -> str:
   return _run(Path(source_dir), "rev-parse", branch).stdout.strip()
 
 
+def ref_is_ancestor(
+  source_dir: str | Path, ancestor: str, descendant: str,
+) -> bool | None:
+  """Whether ``ancestor`` is reachable from ``descendant``.
+
+  Returns ``True`` for Git's proven-ancestor exit 0, ``False`` for its normal
+  not-an-ancestor exit 1, and ``None`` when Git cannot answer (missing/corrupt
+  refs, timeout, or another execution error). Callers must not turn an unknown
+  repository state into a positive conflict/resolution claim.
+  """
+  if not is_repo(source_dir):
+    return None
+  try:
+    proc = _run(
+      Path(source_dir), "merge-base", "--is-ancestor",
+      ancestor, descendant, check=False,
+    )
+  except (OSError, subprocess.SubprocessError):
+    return None
+  if proc.returncode == 0:
+    return True
+  if proc.returncode == 1:
+    return False
+  return None
+
+
 def ref_exists(source_dir: str | Path, ref: str) -> bool:
   """Whether `ref` resolves in this repo. Read-only; never raises.
 

--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -740,6 +740,10 @@ _SKILL_TEXT_CACHE: str | None = None
 # sink save. Hand durable-marker clearing back to that run's wrapper so
 # the marker survives until persistence is complete.
 _clear_after_terminal_generation: dict[str, int] = {}
+# Outcome paired with the generation handoff above. Explicit Stop and the
+# liveness watchdog share the same safe "bump, let the runner finalize, then
+# clear" mechanism, but they are different durable outcomes.
+_clear_after_terminal_status: dict[str, str] = {}
 
 # Liveness watchdog. Derived-only in v1: no persisted run-state enum.
 PROGRESS_TIMEOUT = 600.0
@@ -1081,7 +1085,11 @@ def recover_chat_generation(chat_id: str) -> int:
 # reconciliation instead of reporting a clean completion.
 
 
-async def _clear_run_status(chat_id: str, run_token: str = "") -> None:
+async def _clear_run_status(
+  chat_id: str,
+  run_token: str = "",
+  terminal_status: str = "completed",
+) -> None:
   """Clears the chat's durable run marker once the turn has ended.
 
   Routes through the actor's `ClearRunStatus` (the sole runtime mutator
@@ -1098,7 +1106,11 @@ async def _clear_run_status(chat_id: str, run_token: str = "") -> None:
     return
   try:
     ack = get_writer().submit(
-      ClearRunStatus(chat_id=chat_id, run_token=run_token)
+      ClearRunStatus(
+        chat_id=chat_id,
+        run_token=run_token,
+        terminal_status=terminal_status,
+      )
     )
     await _await_ack(ack)
   except Exception:
@@ -1108,7 +1120,11 @@ async def _clear_run_status(chat_id: str, run_token: str = "") -> None:
     )
 
 
-async def _clear_run_status_strict(chat_id: str, run_token: str = "") -> None:
+async def _clear_run_status_strict(
+  chat_id: str,
+  run_token: str = "",
+  terminal_status: str = "completed",
+) -> None:
   """Strict terminal variant of `_clear_run_status`: surfaces a failed ack.
 
   The best-effort `_clear_run_status` above swallows a failed ack because a
@@ -1131,7 +1147,11 @@ async def _clear_run_status_strict(chat_id: str, run_token: str = "") -> None:
   if not chat_id:
     return
   ack = get_writer().submit(
-    ClearRunStatus(chat_id=chat_id, run_token=run_token)
+    ClearRunStatus(
+      chat_id=chat_id,
+      run_token=run_token,
+      terminal_status=terminal_status,
+    )
   )
   await _await_ack(ack)
 
@@ -1576,7 +1596,9 @@ async def sweep_wedged_run_markers(db: Session) -> list[str]:
           # owns a different token, so the actor no-ops instead of wiping it.
           # Strict variant so a failed ack RAISES — a marker we couldn't clear
           # must not be reported as swept (reconciliation repairs it on boot).
-          await _clear_run_status_strict(chat.id, run.id)
+          await _clear_run_status_strict(
+            chat.id, run.id, terminal_status="interrupted",
+          )
       _finalize_broadcast_if_running(chat.id)
       swept.append(chat.id)
     except (Exception, asyncio.TimeoutError):
@@ -1761,6 +1783,7 @@ async def sweep_stalled_live_runs(db: Session) -> list[str]:
       continue
     bump_run_generation(chat_id)
     _clear_after_terminal_generation[chat_id] = stopped_gen
+    _clear_after_terminal_status[chat_id] = "interrupted"
 
     all_interrupted = True
     for handle in handles:
@@ -1859,6 +1882,7 @@ async def drain_all_for_restart(timeout: float = DRAIN_TIMEOUT) -> list[str]:
     _restart_draining_chats.add(chat_id)
     bump_run_generation(chat_id)
     _clear_after_terminal_generation[chat_id] = stopped_gen
+    _clear_after_terminal_status[chat_id] = "interrupted"
     all_interrupted = True
     for handle in handles:
       try:
@@ -2408,6 +2432,7 @@ async def stop_chat_for(
   handles = registry.get_handles(chat_id)
   if handles:
     _clear_after_terminal_generation[chat_id] = stopped_gen
+    _clear_after_terminal_status[chat_id] = "stopped"
   # The queue-lock window guards the clear's COMPOUND decision against a
   # racing append/cancel/promote (the actor's ClearPending serializes the
   # DB write itself). Generation bump happens BEFORE the lock so the dying
@@ -2483,7 +2508,7 @@ async def stop_chat_for(
   # dies first, the retained marker lets crash recovery reconcile the
   # interrupted turn.
   if not handles:
-    await _clear_run_status(chat_id)
+    await _clear_run_status(chat_id, terminal_status="stopped")
   _finalize_broadcast_if_running(chat_id)
   registry.discard_starting(chat_id)
   return all_stopped, cleared_pending_cids
@@ -2606,6 +2631,7 @@ async def _drain_and_release(
   run_gen: int | None,
   run_token: str,
   ending_run_token: str = "",
+  ending_status: str = "completed",
 ) -> tuple[dict | None, list, str | None, chat_queue.TerminalDisposition]:
   """Local helper around chat_queue.drain_and_release that binds the
   chat.py-owned discard_starting + forget_chat + strict-clear callbacks.
@@ -2635,6 +2661,7 @@ async def _drain_and_release(
     clear_run_status_strict=_clear_run_status_strict,
     current_generation=current_run_generation,
     ending_run_token=ending_run_token,
+    ending_status=ending_status,
   )
 
 
@@ -2725,7 +2752,9 @@ async def _terminal_setup_error_cleanup(
         if run_gen is not None and current_run_generation(chat_id) != run_gen:
           return chat_queue.TerminalDisposition.STALE_NO_ACTION
         await _clear_pending_strict(chat_id)
-        await _clear_run_status_strict(chat_id, run_token)
+        await _clear_run_status_strict(
+          chat_id, run_token, terminal_status="failed",
+        )
         discard_starting(chat_id)
         forget_chat_if_current(chat_id, run_gen)
     return chat_queue.TerminalDisposition.EMPTY_TERMINAL_CLEARED
@@ -3160,12 +3189,19 @@ async def _complete_turn(
   # disowns the generation above), a park sets limit_reached, an errored/refused
   # turn sets _last_error, and any real text/thinking/tool_use makes the blocks
   # renderable. cost_usd is unusable (None for every run here) and not consulted.
-  sink._lost_reply_marker = (
+  lost_reply = (
     we_own_gen
     and not stop_handoff_successor
     and not limit_reached
     and not sink._last_error
     and not blocks_have_renderable_content(sink.assistant_blocks)
+  )
+  sink._lost_reply_marker = lost_reply
+  ending_status = (
+    _clear_after_terminal_status.get(chat_id, "stopped")
+    if stop_handoff_successor
+    else "failed" if sink._last_error or lost_reply
+    else "completed"
   )
 
   try:
@@ -3284,6 +3320,7 @@ async def _complete_turn(
       await _drain_and_release(
         db, chat_id, run_gen, next_run_token,
         ending_run_token=sink.run_token or "",
+        ending_status=ending_status,
       )
     )
   except (Exception, asyncio.TimeoutError) as exc:
@@ -3834,8 +3871,10 @@ async def run_chat(
   finally:
     stopped_gen = _clear_after_terminal_generation.get(chat_id)
     clear_stopped_run = run_gen is not None and stopped_gen == run_gen
+    terminal_status = _clear_after_terminal_status.get(chat_id, "stopped")
     if clear_stopped_run:
       _clear_after_terminal_generation.pop(chat_id, None)
+      _clear_after_terminal_status.pop(chat_id, None)
     # Only clear _starting if we still own this generation. A newer
     # stop_chat_for may have bumped the generation and taken ownership of
     # _starting. (The EMPTY_TERMINAL_CLEARED path already released _starting
@@ -3899,7 +3938,9 @@ async def run_chat(
                 # Identity-keyed on this dying run's token: if a fresh turn
                 # raced in and set a new marker (the is_alive window above),
                 # the actor no-ops this clear instead of wiping it.
-                await _clear_run_status_strict(chat_id, run_token or "")
+                await _clear_run_status_strict(
+                  chat_id, run_token or "", terminal_status=terminal_status,
+                )
                 disposition = (
                   chat_queue.TerminalDisposition.STOP_HANDOFF_CLEARED
                 )

--- a/backend/app/chat_queue.py
+++ b/backend/app/chat_queue.py
@@ -196,6 +196,7 @@ async def promote_pending_messages_locked(
   db: Session,
   chat_id: str,
   run_token: str,
+  ending_status: str = "completed",
 ) -> tuple[list[schemas.ChatMessage], dict | None, str | None]:
   """Inner promote logic. PRECONDITION: caller holds the per-chat
   queue lock.
@@ -228,7 +229,11 @@ async def promote_pending_messages_locked(
   from app.chat_writer import PromotePending, await_ack, get_writer
 
   ack = get_writer().submit(
-    PromotePending(chat_id=chat_id, run_token=run_token)
+    PromotePending(
+      chat_id=chat_id,
+      run_token=run_token,
+      ending_status=ending_status,
+    )
   )
   result = await await_ack(ack)
   promoted = result["promoted"]
@@ -286,6 +291,7 @@ async def drain_and_release(
   clear_run_status_strict,
   current_generation,
   ending_run_token: str = "",
+  ending_status: str = "completed",
 ) -> tuple[dict | None, list, str | None, "TerminalDisposition"]:
   """End-of-turn queue drain. Returns (next_user, next_messages,
   next_session_id, disposition) for the caller to publish + schedule.
@@ -349,7 +355,9 @@ async def drain_and_release(
       if not we_own_gen:
         return None, [], None, TerminalDisposition.STALE_NO_ACTION
       next_messages, first_pending, next_session_id = (
-        await promote_pending_messages_locked(db, chat_id, run_token)
+        await promote_pending_messages_locked(
+          db, chat_id, run_token, ending_status=ending_status,
+        )
       )
       if first_pending is None:
         # Clear-before-forget, all under this one lock: clear the durable
@@ -361,7 +369,9 @@ async def drain_and_release(
         # keyed on the finishing run's token, so even a StartTurn that lands
         # mid-drain (no generation bump → we_own_gen still true) keeps its
         # marker — the actor no-ops a clear that names the old owner.
-        await clear_run_status_strict(chat_id, ending_run_token)
+        await clear_run_status_strict(
+          chat_id, ending_run_token, ending_status,
+        )
         discard_starting(chat_id)
         forget_chat(chat_id)
         return (

--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -86,6 +86,13 @@ log = logging.getLogger("moebius.chat.writer")
 # error / 503) rather than hanging the turn forever.
 ACK_TIMEOUT_SECS = 30.0
 
+# Terminal outcomes accepted by the two actor commands that close a live
+# ChatRun.  Keep this separate from active/parking states: these values all
+# mean the turn is over and are safe for existing "active status" filters.
+_TERMINAL_RUN_STATUSES = frozenset({
+  "completed", "failed", "stopped", "interrupted",
+})
+
 
 async def await_ack(ack: Future, *, timeout: float | None = None):
   """Await a writer-actor ack on the loop, bounded by `timeout`.
@@ -398,6 +405,10 @@ class PromotePending(_Command):
 
   chat_id: str = ""
   run_token: str = ""
+  # Outcome of the turn handing off to this continuation.  Most callers are
+  # not turn-end handoffs and keep the clean default; drain_and_release passes
+  # "failed" when the provider returned an error before queued work continues.
+  ending_status: str = "completed"
 
 
 @dataclass
@@ -487,6 +498,10 @@ class ClearRunStatus(_Command):
 
   chat_id: str = ""
   run_token: str = ""
+  # Durable outcome for the run row.  Clearing Chat.run_status only means the
+  # chat is idle; it must not collapse a provider/setup failure into a
+  # successful "completed" run in the observability record.
+  terminal_status: str = "completed"
 
 
 @dataclass
@@ -2240,7 +2255,7 @@ class ChatWriterActor:
     # handoff — so this is where the prior run's record is closed.
     from app.models import ChatRun
     self._close_running_runs(
-      db, cmd.chat_id, "completed", except_token=cmd.run_token
+      db, cmd.chat_id, cmd.ending_status, except_token=cmd.run_token
     )
     db.add(ChatRun(
       id=cmd.run_token, chat_id=cmd.chat_id, status="running",
@@ -2342,6 +2357,9 @@ class ChatWriterActor:
 
     from app.models import ChatRun
 
+    if status not in _TERMINAL_RUN_STATUSES:
+      raise _PersistFailed(f"invalid terminal ChatRun status: {status!r}")
+
     # "parked" rows (a provider-limit park, design §2.4) are superseded here
     # too: a fresh StartTurn / PromotePending on a parked chat means the owner
     # resumed it themselves (one-tap Resume, or any new send), so the stale
@@ -2374,7 +2392,10 @@ class ChatWriterActor:
     know they own the marker (reconciliation, no-handoff cleanup).
 
     The per-run `chat_runs` record (077 Step 3) is closed in the SAME commit:
-    a tokened clear marks its own run's row "completed" IF it is still running.
+    a tokened clear marks its own run's row with `cmd.terminal_status` IF it is
+    still running. The default is the clean-success outcome "completed";
+    provider/setup errors, explicit Stop, and live interruption callers pass a
+    more specific terminal outcome.
     A run superseded by a fresh StartTurn is already terminal ("interrupted",
     set by that StartTurn's `_close_running_runs`), so its dying
     no-op-on-the-marker clear correctly leaves the row terminal rather than
@@ -2386,6 +2407,11 @@ class ChatWriterActor:
 
     from app.models import Chat, ChatRun
 
+    if cmd.terminal_status not in _TERMINAL_RUN_STATUSES:
+      raise _PersistFailed(
+        f"invalid terminal ChatRun status: {cmd.terminal_status!r}"
+      )
+
     owner = self._run_token_owner.get(cmd.chat_id)
     marker_is_ours = not (
       cmd.run_token and owner is not None and owner != cmd.run_token
@@ -2396,12 +2422,12 @@ class ChatWriterActor:
         db.query(ChatRun).filter(ChatRun.id == cmd.run_token).first()
       )
       if run is not None and run.status == "running":
-        run.status = "completed"
+        run.status = cmd.terminal_status
         run.ended_at = datetime.now(UTC)
         changed = True
     elif marker_is_ours:
       changed = self._close_running_runs(
-        db, cmd.chat_id, "completed"
+        db, cmd.chat_id, cmd.terminal_status
       ) or changed
     if not marker_is_ours:
       # A dying run's stale clear: its own run record is closed above, but the

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -218,8 +218,10 @@ class ChatRun(Base):
   chat_id = Column(
     String(64), ForeignKey("chats.id"), nullable=False, index=True
   )
-  # "running" while in flight, "completed" on a clean turn end, "interrupted"
-  # when boot reconciliation resolves a turn whose process died mid-flight.
+  # "running" while in flight; terminal outcomes are "completed" for a clean
+  # turn, "failed" for a provider/setup error, "stopped" for an explicit user
+  # Stop, and "interrupted" for crash/supersession/watchdog recovery. Provider
+  # limits additionally use the parked/resume_pending/parked_notified states.
   status = Column(String(16), nullable=False, default="running", index=True)
   provider = Column(String(32), nullable=True, default=None)
   # App that initiated this turn under the app-attributed-chat contract

--- a/backend/app/routes/apps.py
+++ b/backend/app/routes/apps.py
@@ -15,6 +15,7 @@ import time
 import uuid
 from datetime import datetime, UTC
 from pathlib import Path
+from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi.responses import FileResponse, HTMLResponse, StreamingResponse
@@ -1175,6 +1176,42 @@ def _fetched_differs_from_upstream(
   return False
 
 
+def _pending_update_state(repo: Path, upstream_commit: str) -> Literal[
+  "needs_resolution", "replay_pending", "unknown",
+]:
+  """Classify a validated pending receipt without changing repository state.
+
+  Before the owner resolves a click-gated conflict, the new ``upstream`` tip is
+  not an ancestor of local ``main``. Once marker-free source is committed, the
+  replay commit is parented on that upstream tip; the receipt deliberately
+  remains until the canonical installer promotes every artifact atomically.
+
+  During a materialized merge, text markers and unresolved binary paths still
+  need owner/agent work. Marker-free text may remain un-staged briefly, but the
+  watcher stages and commits it itself, so that is already replay-pending rather
+  than a reason to start another resolver. If Git cannot prove ancestry, report
+  unknown rather than inventing a resolution requirement.
+  """
+  try:
+    if app_git.merge_in_progress(repo):
+      if (
+        app_git.has_conflict_markers(repo)
+        or app_git.has_unresolved_binary_conflicts(repo)
+      ):
+        return "needs_resolution"
+      return "replay_pending"
+  except (OSError, subprocess.SubprocessError):
+    return "unknown"
+  ancestor = app_git.ref_is_ancestor(
+    repo, upstream_commit, app_git.LOCAL_BRANCH,
+  )
+  if ancestor is True:
+    return "replay_pending"
+  if ancestor is False:
+    return "needs_resolution"
+  return "unknown"
+
+
 @router.get(
   "/{app_id}/update-check",
   response_model=schemas.UpdateCheckOut,
@@ -1227,7 +1264,6 @@ async def update_check(
   target_app_id = app.id
   manifest_url = app.manifest_url
   source_dir = app.source_dir
-  upstream_commit = app.upstream_commit
 
   def _unknown() -> schemas.UpdateCheckOut:
     # Null is "we can't tell git-natively" — NOT an error. The caller falls back
@@ -1255,19 +1291,48 @@ async def update_check(
   ):
     return _unknown()
 
-  pending = install.read_pending_conflict_update_receipt(
-    repo, app_id=target_app_id, upstream_commit=upstream_commit,
-  )
-  if pending is not None:
-    # A resolver may have committed source while the final install replay was
-    # interrupted (network/restart). Keep Update visible so the owner can retry;
-    # the same receipt is also retried automatically by the watcher at startup.
+  def _current_pending_update() -> tuple[
+    dict | None,
+    Literal["needs_resolution", "replay_pending", "unknown"] | None,
+  ]:
+    """Read receipt identity and Git phase at one source-lock snapshot."""
+    current_upstream = app_git.head_sha(repo, app_git.UPSTREAM_BRANCH)
+    receipt = install.read_pending_conflict_update_receipt(
+      repo, app_id=target_app_id, upstream_commit=current_upstream,
+    )
+    state = (
+      _pending_update_state(repo, receipt["upstream_commit"])
+      if receipt is not None else None
+    )
+    return receipt, state
+
+  def _pending_result(
+    receipt: dict,
+    state: Literal["needs_resolution", "replay_pending", "unknown"],
+  ) -> schemas.UpdateCheckOut:
     return schemas.UpdateCheckOut(
       update_available=True,
-      upstream_version=str(pending["manifest"].get("version") or "") or None,
+      pending_update_state=state,
+      needs_resolution=state == "needs_resolution",
+      upstream_version=str(receipt["manifest"].get("version") or "") or None,
       local_version=local_version,
       checked_at=checked_at,
     )
+
+  async with fs_locks.source_dir_lock(str(repo)):
+    try:
+      pending, pending_state = await asyncio.to_thread(
+        _current_pending_update,
+      )
+    except (OSError, subprocess.SubprocessError):
+      return _unknown()
+  if pending is not None:
+    # A resolver may have committed source while the final install replay was
+    # interrupted (network/restart). Keep Update visible so the owner can retry,
+    # but do not send already-resolved source back through the resolver endpoint
+    # (which correctly 409s once upstream is an ancestor of main). The same
+    # receipt is also retried automatically by the watcher at startup.
+    return _pending_result(pending, pending_state)
 
   # Reconstruct the fetchable manifest URL from the stored canonical identity
   # key (`<base>#manifest-id=<id>`): the raw manifest lives at <base>/mobius.json,
@@ -1290,10 +1355,21 @@ async def update_check(
   if fetched.job_name and fetched.job_bytes is not None:
     fetched_tree[fetched.job_name] = fetched.job_bytes
 
-  # Hold the source-dir lock only around the git read so a concurrent installer's
-  # record_upstream can't move the `upstream` ref mid-read. The read itself
-  # (read_ref_tree = ls-tree + cat-file) never touches the index or working tree.
+  # This final lock is the response's linearization fence. A concurrent install
+  # can advance `upstream` and create a receipt while the network fetch is in
+  # flight; revalidate receipt identity against the CURRENT locked ref before
+  # comparing bytes, otherwise this request could overwrite a newly-observed
+  # needs-resolution state with stale false/none. With no receipt, the compare
+  # reads that same locked upstream snapshot (ls-tree + cat-file only).
   async with fs_locks.source_dir_lock(str(repo)):
+    try:
+      pending, pending_state = await asyncio.to_thread(
+        _current_pending_update,
+      )
+    except (OSError, subprocess.SubprocessError):
+      return _unknown()
+    if pending is not None:
+      return _pending_result(pending, pending_state)
     update_available = await asyncio.to_thread(
       _fetched_differs_from_upstream,
       repo, fetched_tree, cloned, install._MERGED_NON_SOURCE,

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -1214,7 +1214,7 @@ async def delete_chat(
   # run_status + drops the actor's _run_token_owner entry; it is best-effort
   # and safe on a soft-deleted row (clear commands don't resurrect), and
   # idempotent when the run state is already clean (the common idle delete).
-  await _clear_run_status(chat_id)
+  await _clear_run_status(chat_id, terminal_status="stopped")
 
 
 @router.post("/{chat_id}/recover", dependencies=[Depends(reject_cross_site)])

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -286,9 +286,22 @@ class UpdateCheckOut(BaseModel):
   manifest_url, no git repo, no recorded upstream branch, or the upstream fetch
   failed — so the caller falls back to version comparison. It is a real
   true/false only when a byte-level compare actually ran, so a push that changed
-  code WITHOUT bumping the version still reads as an update. The version strings
-  are display-only, never the detection signal."""
+  code WITHOUT bumping the version still reads as an update.
+
+  A durable conflict receipt has two materially different states. In
+  `needs_resolution`, upstream is not yet incorporated into local source (or a
+  materialized merge still has conflicts). In `replay_pending`, source was
+  resolved and committed but the canonical installer still has to promote the
+  bundle/metadata transaction. Only the former should open a resolver chat.
+  `needs_resolution` remains as a derived rolling-deploy compatibility field;
+  new consumers should use `pending_update_state`. `unknown` means a receipt
+  proves an update is pending but Git could not safely classify its resolution
+  phase. The version strings are display-only, never the detection signal."""
   update_available: bool | None = None
+  pending_update_state: Literal[
+    "none", "needs_resolution", "replay_pending", "unknown",
+  ] = "none"
+  needs_resolution: bool = False
   upstream_version: str | None = None
   local_version: str | None = None
   checked_at: datetime

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -127,6 +127,7 @@ def fresh_db():
   setattr(chat_mod, "_SKILL_TEXT_CACHE", None)
   chat_mod.draining = False
   chat_mod._clear_after_terminal_generation.clear()
+  chat_mod._clear_after_terminal_status.clear()
   chat_mod._restart_draining_chats.clear()
   bc_mod._broadcasts.clear() if hasattr(bc_mod, "_broadcasts") else None
   # Activity log: clear the per-process debounce cache and delete any

--- a/backend/tests/test_app_git.py
+++ b/backend/tests/test_app_git.py
@@ -67,6 +67,20 @@ def _commit_all(repo: Path, msg: str) -> str:
   ).stdout.strip()
 
 
+def test_ref_is_ancestor_distinguishes_false_from_git_errors(tmp_path):
+  repo = tmp_path / "app"
+  repo.mkdir()
+  app_git.ensure_repo(repo)
+  base = app_git.head_sha(repo, app_git.UPSTREAM_BRANCH)
+  _write(repo, "export default function App() { return <div>local</div> }\n")
+  local = app_git.commit_local(repo, "local edit")
+  assert local
+
+  assert app_git.ref_is_ancestor(repo, base, local) is True
+  assert app_git.ref_is_ancestor(repo, local, base) is False
+  assert app_git.ref_is_ancestor(repo, "missing-ref", local) is None
+
+
 def test_clone_upstream_uses_real_origin_and_app_gitignore(tmp_path):
   """clone_upstream checks out main at a real origin/<ref> commit."""
   fixture = tmp_path / "fixture"

--- a/backend/tests/test_apps_install.py
+++ b/backend/tests/test_apps_install.py
@@ -2631,7 +2631,17 @@ def test_flag_on_conflicting_update_leaves_source_unchanged_until_resolve(
   update = client.get(f"/api/apps/{payload['id']}/update-check", headers=auth)
   assert update.status_code == 200, update.text
   assert update.json()["update_available"] is True
+  assert update.json()["pending_update_state"] == "needs_resolution"
+  assert update.json()["needs_resolution"] is True
   assert update.json()["upstream_version"] == "2.0.0"
+  with patch("app.app_git.ref_is_ancestor", return_value=None):
+    unknown = client.get(
+      f"/api/apps/{payload['id']}/update-check", headers=auth,
+    )
+  assert unknown.status_code == 200, unknown.text
+  assert unknown.json()["update_available"] is True
+  assert unknown.json()["pending_update_state"] == "unknown"
+  assert unknown.json()["needs_resolution"] is False
 
   bypass = client.patch(
     f"/api/apps/{payload['id']}",
@@ -2649,6 +2659,27 @@ def test_flag_on_conflicting_update_leaves_source_unchanged_until_resolve(
   assert (app_dir / ".git" / "MERGE_HEAD").is_file()
   resolved = JSX_MULTI.replace("ORIGINAL TITLE", "RESOLVED TITLE")
   jsx_file.write_text(resolved)
+
+  # Resolution and promotion are separate crash-safe phases. Once the resolved
+  # source is committed, the receipt remains so the canonical installer can
+  # replay bundle/static/DB promotion. This state must stay updateable but must
+  # NOT offer another resolver: upstream is already an ancestor and that route
+  # correctly rejects it as no longer conflicted.
+  from app import app_git
+  resolved_commit = app_git.commit_local(app_dir, "resolve app update")
+  assert resolved_commit
+  assert not (app_dir / ".git" / "MERGE_HEAD").exists()
+  pending_update = client.get(
+    f"/api/apps/{payload['id']}/update-check", headers=auth,
+  )
+  assert pending_update.status_code == 200, pending_update.text
+  assert pending_update.json()["update_available"] is True
+  assert pending_update.json()["pending_update_state"] == "replay_pending"
+  assert pending_update.json()["needs_resolution"] is False
+  redundant_resolver = client.post(
+    f"/api/apps/{payload['id']}/conflict-resolver-chat", headers=auth,
+  )
+  assert redundant_resolver.status_code == 409, redundant_resolver.text
 
   replay_responses = {
     base + "index.jsx": (200, jsx_v2.encode()),
@@ -4816,9 +4847,72 @@ def test_update_check_unchanged_upstream_is_false(
   assert res.status_code == 200, res.text
   payload = res.json()
   assert payload["update_available"] is False
+  assert payload["pending_update_state"] == "none"
+  assert payload["needs_resolution"] is False
   assert payload["upstream_version"] == "1.0.0"
   assert payload["local_version"] == "1.0.0"
   assert payload["checked_at"]
+
+
+def test_update_check_final_fence_preserves_concurrent_pending_conflict(
+  client, auth, bypass_url_validation, monkeypatch,
+):
+  """A conflict receipt created during fetch wins over the stale comparison.
+
+  The DB snapshot intentionally remains on v1 while the simulated concurrent
+  installer advances the locked repo ref to v2 and journals its receipt. Without
+  the final identity fence, comparing the just-fetched v2 bytes to that v2 ref
+  returns False and overwrites the App Store's already-observed blocked state.
+  """
+  from app import install
+
+  base = "https://uc-race.test/repo/"
+  manifest_v1 = {**MANIFEST_NEWS, "id": "uc-race"}
+  installed = _install_v1(client, auth, base, manifest_v1, JSX_MULTI)
+  assert installed.status_code == 201, installed.text
+  app_id = installed.json()["id"]
+  repo = Path(get_settings().data_dir) / "apps" / "uc-race"
+
+  local = JSX_MULTI.replace("ORIGINAL TITLE", "LOCAL TITLE")
+  (repo / "index.jsx").write_text(local)
+  assert app_git.commit_local(repo, "local edit before raced update")
+  upstream_v2 = JSX_MULTI.replace("ORIGINAL TITLE", "UPSTREAM TITLE")
+  manifest_v2 = {**manifest_v1, "version": "2.0.0"}
+
+  async def advance_during_fetch(_manifest_url):
+    current_upstream = app_git.record_upstream(
+      repo,
+      {"index.jsx": upstream_v2.encode()},
+      base + "mobius.json",
+      "2.0.0",
+    )
+    install.stage_pending_conflict_update(
+      repo,
+      app_id=app_id,
+      upstream_commit=current_upstream,
+      manifest=manifest_v2,
+      raw_base=base,
+      capability_digest="test-capability-digest",
+      candidate_digest="0" * 64,
+    )
+    return install.FetchedUpstream(
+      manifest=manifest_v2,
+      entry_bytes=upstream_v2.encode(),
+      source_files={},
+      job_name=None,
+      job_bytes=None,
+    )
+
+  monkeypatch.setattr(
+    "app.install.fetch_upstream_source", advance_during_fetch,
+  )
+  res = client.get(f"/api/apps/{app_id}/update-check", headers=auth)
+  assert res.status_code == 200, res.text
+  payload = res.json()
+  assert payload["update_available"] is True
+  assert payload["pending_update_state"] == "needs_resolution"
+  assert payload["needs_resolution"] is True
+  assert payload["upstream_version"] == "2.0.0"
 
 
 def test_update_check_changed_file_is_true(

--- a/backend/tests/test_chat_queue_module.py
+++ b/backend/tests/test_chat_queue_module.py
@@ -28,13 +28,15 @@ def _record_clear(sink: list):
   empty-queue case (clear-before-forget) and never for a promoted
   continuation, so the recorded list pins which disposition fired.
   """
-  async def _clear(chat_id, run_token=""):
+  async def _clear(chat_id, run_token="", terminal_status="completed"):
     sink.append(chat_id)
 
   return _clear
 
 
-async def _noop_clear(_chat_id, _run_token=""):
+async def _noop_clear(
+  _chat_id, _run_token="", _terminal_status="completed",
+):
   """An async clear stub that records nothing (for paths that don't clear)."""
   return None
 

--- a/backend/tests/test_chat_runs.py
+++ b/backend/tests/test_chat_runs.py
@@ -112,6 +112,21 @@ def test_clear_run_status_completes_the_run_record():
   assert _run_status("r2") is None
 
 
+def test_clear_run_status_preserves_failed_outcome():
+  """An idle marker is not proof of success: a provider-error turn closes
+  durably as failed while clearing the same per-chat recovery marker."""
+  _seed_chat("r2-failed")
+  _start("r2-failed", "rt-2-failed")
+  get_writer().submit(ClearRunStatus(
+    chat_id="r2-failed",
+    run_token="rt-2-failed",
+    terminal_status="failed",
+  )).result(timeout=5)
+  _drain()
+  assert _runs("r2-failed")["rt-2-failed"] == ("failed", True)
+  assert _run_status("r2-failed") is None
+
+
 # -- continuation handoff -------------------------------------------------
 def test_promote_closes_prior_run_and_opens_the_continuation():
   _seed_chat("r3")
@@ -131,6 +146,27 @@ def test_promote_closes_prior_run_and_opens_the_continuation():
   assert runs["rt-3b"] == ("running", False)
   # The per-chat marker stays set across the handoff (the continuation runs).
   assert _run_status("r3") == "running"
+
+
+def test_error_handoff_marks_prior_run_failed_before_continuation():
+  """Queued work may continue after a provider error, but that continuation
+  must not rewrite the failed turn's observability row as successful."""
+  _seed_chat("r3-failed")
+  _start("r3-failed", "rt-3-failed-a")
+  get_writer().submit(AppendPending(
+    chat_id="r3-failed", run_token="rt-3-failed-a",
+    user_msg={"role": "user", "content": "next", "ts": 2},
+  )).result(timeout=5)
+  get_writer().submit(PromotePending(
+    chat_id="r3-failed",
+    run_token="rt-3-failed-b",
+    ending_status="failed",
+  )).result(timeout=5)
+  _drain()
+  runs = _runs("r3-failed")
+  assert runs["rt-3-failed-a"] == ("failed", True)
+  assert runs["rt-3-failed-b"] == ("running", False)
+  assert _run_status("r3-failed") == "running"
 
 
 # -- identity-keyed dying-run clear ---------------------------------------

--- a/backend/tests/test_chat_stop_delete_safety.py
+++ b/backend/tests/test_chat_stop_delete_safety.py
@@ -80,6 +80,13 @@ def test_stop_on_orphaned_run_after_restart_succeeds(client, auth, db):
     run_started_at=datetime.now(UTC),
   )
   db.add(c)
+  db.add(models.ChatRun(
+    id="rt-orphan-after-restart",
+    chat_id=chat_id,
+    status="running",
+    provider="claude",
+    started_at=datetime.now(UTC),
+  ))
   db.commit()
   # No registry handle — exactly the post-restart orphan shape.
   assert chat_mod.is_chat_running(chat_id) is False
@@ -92,4 +99,8 @@ def test_stop_on_orphaned_run_after_restart_succeeds(client, auth, db):
   row = db.query(models.Chat).filter(models.Chat.id == chat_id).first()
   assert row.run_status is None, "the orphaned 'running' marker must be cleared"
   assert row.run_started_at is None
+  run = db.query(models.ChatRun).filter(
+    models.ChatRun.id == "rt-orphan-after-restart",
+  ).one()
+  assert run.status == "stopped"
   assert chat_mod.is_chat_running(chat_id) is False

--- a/backend/tests/test_terminal_completion.py
+++ b/backend/tests/test_terminal_completion.py
@@ -98,6 +98,36 @@ def _load(chat_id):
     db.close()
 
 
+def _seed_run(run_id, chat_id, *, provider="claude"):
+  from datetime import UTC, datetime
+
+  db = SessionLocal()
+  try:
+    db.add(models.ChatRun(
+      id=run_id,
+      chat_id=chat_id,
+      status="running",
+      provider=provider,
+      started_at=datetime.now(UTC),
+    ))
+    db.commit()
+  finally:
+    db.close()
+
+
+def _run_outcomes(chat_id):
+  db = SessionLocal()
+  try:
+    return {
+      row.id: row.status
+      for row in db.query(models.ChatRun).filter(
+        models.ChatRun.chat_id == chat_id,
+      ).all()
+    }
+  finally:
+    db.close()
+
+
 def _run_real_chat(chat_id, *, run_token, run_gen, provider_id="claude",
                    published=None):
   """Drive the REAL run_chat for `chat_id` (Claude branch) on a fresh
@@ -153,6 +183,141 @@ def test_empty_queue_terminal_clears_marker(monkeypatch):
   # The chat was forgotten (generation dropped) after the clear.
   assert chat_mod.current_run_generation("t1") == 0
   assert not chat_mod.registry.is_alive("t1")
+
+
+def test_provider_error_clears_marker_but_records_failed_run(monkeypatch):
+  """The runner's terminal error is a settled turn, not a successful one.
+
+  This is the production OAuth/capacity-error shape: the error is persisted in
+  the transcript, the chat becomes idle, and the per-run observability row
+  records ``failed`` rather than overloading ``completed`` as "any terminal".
+  """
+  _seed_owner_and_creds()
+  _seed_chat(
+    "t1-failed", messages=[{"role": "user", "content": "hi", "ts": 1}],
+    pending=[], run_status="running",
+  )
+  _seed_run("rt-1-failed", "t1-failed")
+
+  async def error_runner(**_kwargs):
+    return {
+      "session_id": "sess",
+      "cost_usd": 0.0,
+      "error": "authentication failed",
+    }
+
+  import app.claude_sdk_runner as csr
+  monkeypatch.setattr(csr, "run_claude_sdk_turn", error_runner)
+
+  chat_mod.mark_starting("t1-failed")
+  gen = chat_mod.current_run_generation("t1-failed")
+  published = []
+  _run_real_chat(
+    "t1-failed",
+    run_token="rt-1-failed",
+    run_gen=gen,
+    published=published,
+  )
+  _drain_actor()
+
+  assert _load("t1-failed")["run_status"] is None
+  assert _run_outcomes("t1-failed") == {"rt-1-failed": "failed"}
+  assert "error" in published
+  assert "done" in published
+
+
+def test_provider_error_handoff_keeps_failed_predecessor(monkeypatch):
+  """A queued continuation gets a fresh running row without laundering the
+  provider-error predecessor into ``completed`` during PromotePending."""
+  _seed_owner_and_creds()
+  _seed_chat(
+    "t1-failed-queued",
+    messages=[{"role": "user", "content": "hi", "ts": 1}],
+    pending=[{"role": "user", "content": "next", "ts": 2}],
+    run_status="running",
+  )
+  _seed_run("rt-1-failed-queued", "t1-failed-queued")
+
+  async def error_runner(**_kwargs):
+    return {"session_id": "sess", "cost_usd": 0.0, "error": "capacity"}
+
+  import app.claude_sdk_runner as csr
+  monkeypatch.setattr(csr, "run_claude_sdk_turn", error_runner)
+  scheduled = []
+  monkeypatch.setattr(
+    chat_mod, "_schedule_continuation",
+    lambda **kwargs: scheduled.append(kwargs),
+  )
+
+  chat_mod.mark_starting("t1-failed-queued")
+  gen = chat_mod.current_run_generation("t1-failed-queued")
+  _run_real_chat(
+    "t1-failed-queued",
+    run_token="rt-1-failed-queued",
+    run_gen=gen,
+  )
+  _drain_actor()
+
+  assert len(scheduled) == 1
+  successor_token = scheduled[0]["run_token"]
+  assert _run_outcomes("t1-failed-queued") == {
+    "rt-1-failed-queued": "failed",
+    successor_token: "running",
+  }
+  assert _load("t1-failed-queued")["run_status"] == "running"
+
+
+@pytest.mark.parametrize("queued", [False, True], ids=["settled", "handoff"])
+def test_empty_provider_result_persists_retryable_failure(monkeypatch, queued):
+  """A clean-looking provider return with no renderable output is a failed
+  run, including when queued work immediately opens a successor turn."""
+  cid = f"t1-empty-{'queued' if queued else 'settled'}"
+  run_token = f"rt-{cid}"
+  pending = (
+    [{"role": "user", "content": "next", "ts": 2}] if queued else []
+  )
+  _seed_owner_and_creds()
+  _seed_chat(
+    cid,
+    messages=[{"role": "user", "content": "hi", "ts": 1}],
+    pending=pending,
+    run_status="running",
+  )
+  _seed_run(run_token, cid)
+  _patch_claude_runner(monkeypatch, text=None)
+  scheduled = []
+  monkeypatch.setattr(
+    chat_mod, "_schedule_continuation",
+    lambda **kwargs: scheduled.append(kwargs),
+  )
+
+  chat_mod.mark_starting(cid)
+  gen = chat_mod.current_run_generation(cid)
+  _run_real_chat(cid, run_token=run_token, run_gen=gen)
+  _drain_actor()
+
+  state = _load(cid)
+  retry_blocks = [
+    block
+    for message in state["messages"]
+    if message.get("role") == "assistant"
+    for block in message.get("blocks", [])
+    if block.get("type") == "error"
+  ]
+  assert retry_blocks == [{
+    "type": "error",
+    "message": "This turn ended without a response — tap to retry.",
+  }]
+  outcomes = _run_outcomes(cid)
+  assert outcomes[run_token] == "failed"
+  if queued:
+    assert len(scheduled) == 1
+    assert outcomes[scheduled[0]["run_token"]] == "running"
+    assert state["run_status"] == "running"
+  else:
+    assert scheduled == []
+    assert outcomes == {run_token: "failed"}
+    assert state["run_status"] is None
 
 
 # -- 2. terminal write failure LEAVES the marker (+ reconcile repairs) ---
@@ -498,6 +663,7 @@ def test_stop_handoff_clears_only_immediate_successor_marker(monkeypatch):
     "t6", messages=[{"role": "user", "content": "hi", "ts": 1}],
     pending=[], run_status="running",
   )
+  _seed_run("rt-6", "t6")
   _patch_claude_runner(monkeypatch)
 
   chat_mod.mark_starting("t6")
@@ -523,6 +689,7 @@ def test_stop_handoff_clears_only_immediate_successor_marker(monkeypatch):
   assert _load("t6")["run_status"] is None, (
     "Stop handoff must clear the marker after terminal persistence"
   )
+  assert _run_outcomes("t6") == {"rt-6": "stopped"}
 
   # A newer run's marker must NEVER be cleared by a stale Stop-bumped run.
   _seed_chat("t6b", run_status="running")
@@ -546,6 +713,50 @@ def test_stop_handoff_clears_only_immediate_successor_marker(monkeypatch):
   assert _load("t6b")["run_status"] == "running", (
     "a stale Stop-bumped run must NOT clear a newer run's marker"
   )
+
+
+def test_watchdog_handoff_records_interrupted_outcome(monkeypatch):
+  """The watchdog shares Stop's safe generation handoff, but its durable
+  outcome is an interruption rather than a user-requested stop."""
+  from app.runner_registry import RunnerKind
+
+  cid = "watchdog-outcome"
+  _seed_owner_and_creds()
+  _seed_chat(
+    cid, messages=[{"role": "user", "content": "hi", "ts": 1}],
+    pending=[], run_status="running",
+  )
+  _seed_run(f"rt-{cid}", cid)
+
+  class StoppableHandle:
+    chat_id = cid
+    kind = RunnerKind.CLAUDE_SDK
+
+    async def stop(self, timeout=2.0):
+      del timeout
+      chat_mod.registry.unregister(self.chat_id, self.kind)
+      return True
+
+  async def stalled_runner(*, bc, **_kwargs):
+    chat_mod.registry.register(StoppableHandle())
+    bc.bc.last_event_at = time.monotonic() - chat_mod.PROGRESS_TIMEOUT - 1
+    db = SessionLocal()
+    try:
+      assert await chat_mod.sweep_stalled_live_runs(db) == [cid]
+    finally:
+      db.close()
+    return {"session_id": "sess", "cost_usd": 0.0}
+
+  import app.claude_sdk_runner as csr
+  monkeypatch.setattr(csr, "run_claude_sdk_turn", stalled_runner)
+
+  chat_mod.mark_starting(cid)
+  gen = chat_mod.current_run_generation(cid)
+  _run_real_chat(cid, run_token=f"rt-{cid}", run_gen=gen)
+  _drain_actor()
+
+  assert _load(cid)["run_status"] is None
+  assert _run_outcomes(cid) == {f"rt-{cid}": "interrupted"}
 
 
 # -- 7. unsupported runtime cleanup: marker cleared, pending dropped -----
@@ -971,6 +1182,7 @@ def test_auth_error_cleanup_clears_marker_before_registry_release(
     pending=[{"role": "user", "content": "queued", "ts": 3}],
     run_status="running",
   )
+  _seed_run("rt-12", "t12")
 
   scheduled = []
   orig_sched = chat_mod._schedule_continuation
@@ -991,6 +1203,7 @@ def test_auth_error_cleanup_clears_marker_before_registry_release(
   state = _load("t12")
   assert state["run_status"] is None, "auth-error cleanup must clear the marker"
   assert state["pending_messages"] == [], "pending must be cleared durably"
+  assert _run_outcomes("t12") == {"rt-12": "failed"}
   assert not chat_mod.registry.is_alive("t12"), "registry released"
 
 

--- a/backend/tests/test_wedged_marker_sweep.py
+++ b/backend/tests/test_wedged_marker_sweep.py
@@ -60,6 +60,17 @@ def _state(chat_id):
     db.close()
 
 
+def _run_outcome(chat_id):
+  db = SessionLocal()
+  try:
+    row = db.query(models.ChatRun).filter(
+      models.ChatRun.chat_id == chat_id,
+    ).one()
+    return row.status
+  finally:
+    db.close()
+
+
 def _sweep():
   db = SessionLocal()
   try:
@@ -75,6 +86,7 @@ def test_sweep_clears_orphaned_marker_and_preserves_queue():
   assert "wedged-1" in swept
   status, pending = _state("wedged-1")
   assert status is None, "orphaned marker should be cleared"
+  assert _run_outcome("wedged-1") == "interrupted"
   # The queue is preserved for the next-send stale-pending self-heal.
   assert len(pending) == 1
 

--- a/frontend/src/components/SettingsView/SettingsView.jsx
+++ b/frontend/src/components/SettingsView/SettingsView.jsx
@@ -45,6 +45,9 @@ const RETURN_VIEW_KEY = 'mobius:return-view'
 const RESTART_POLL_INTERVAL_MS = 1500
 const RESTART_POLL_MAX = 40
 const RESTART_SHELL_READY_PATH = '/shell/'
+const PLATFORM_APPLY_STATES = new Set([
+  'restart_needed', 'up_to_date', 'conflict', 'rolled_back',
+])
 const PROVIDER_CHOICES = [
   { id: 'claude', label: 'Claude Code' },
   { id: 'codex', label: 'OpenAI Codex' },
@@ -52,6 +55,32 @@ const PROVIDER_CHOICES = [
 const FALLBACK_MODEL_ROWS = {
   claude: CLAUDE_MODELS.map((m) => ({ id: m.value, label: m.label, available: true })),
   codex: CODEX_MODELS.map((m) => ({ id: m.value, label: m.label, available: true })),
+}
+
+// POST /platform/apply is the authoritative outcome of the mutation it just
+// performed. Project that result into the status shape immediately so a failed
+// follow-up GET /status cannot leave Settings claiming the old state. A fresh
+// successful status response still replaces this fallback in refreshPlatform.
+function platformStatusFromApply(previous, result) {
+  const state = result.state
+  const upstream = result.upstream_commit || previous?.recorded_upstream_sha || null
+  const clean = state === 'restart_needed' || state === 'up_to_date'
+  return {
+    ...(previous || {}),
+    state,
+    available: state === 'rolled_back',
+    needs_restart: state === 'restart_needed' || !!result.needs_restart,
+    current_build_sha: previous?.current_build_sha || null,
+    recorded_upstream_sha: upstream,
+    contained_upstream_sha: clean
+      ? (result.upstream_commit || previous?.contained_upstream_sha || null)
+      : (previous?.contained_upstream_sha || null),
+    seed_required: false,
+    conflict_paths: Array.isArray(result.conflict_paths)
+      ? result.conflict_paths
+      : [],
+    conflict_chat_id: state === 'conflict' ? (result.chat_id || null) : null,
+  }
 }
 
 function defaultEffort(provider) {
@@ -328,6 +357,10 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
   // it so the owner reviews the incoming changes before applying, rather than
   // Apply firing on the first click.
   const [reviewOpen, setReviewOpen] = useState(false)
+  // Every update-row action occupies the same conditional slot. Keep one ref
+  // on that slot so closing the review can focus the live replacement button
+  // after refreshPlatform swaps Review for Restart/Resolve/Check.
+  const platformActionRef = useRef(null)
   // 'idle' | 'checking' | 'checked' | 'error' — the "Check for updates" button
   // asks the service worker to re-check cached frontend assets and re-reads
   // /api/version. 'checked' is a short-lived success label when no update is
@@ -914,25 +947,40 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
   // Apply the reviewed update: merge the fetched platform release into the live
   // backend. Clean -> the row flips to "restart needed"; conflict -> show a
   // resolver action, but wait for the owner's click before opening an agent
-  // chat. Returns whether the apply landed cleanly so the review sheet can close
-  // on success and keep itself open (showing the error) on failure.
+  // chat. Returns the domain outcome (not merely HTTP success) so the review
+  // sheet closes only for a clean apply and becomes an explicit result when
+  // the update was blocked.
   async function applyPlatformUpdate() {
-    if (platformPhase !== 'idle') return false
+    if (platformPhase !== 'idle') return { ok: false }
     setPlatformError('')
     setPlatformPhase('applying')
     try {
       const res = await api.platform.apply()
+      let body = null
+      try { body = await res.json() } catch {}
       if (!res.ok) {
-        let detail = ''
-        try { detail = (await res.json())?.detail || '' } catch {}
+        const detail = body?.detail || ''
         setPlatformError(detail ? `Update failed: ${detail}` : 'Update failed — the instance is unchanged.')
-        return false
+        return { ok: false }
+      }
+      const state = typeof body?.state === 'string' ? body.state : ''
+      if (PLATFORM_APPLY_STATES.has(state)) {
+        setPlatform(current => platformStatusFromApply(current, body))
       }
       await refreshPlatform()
-      return true
+      if (state === 'restart_needed' || state === 'up_to_date') {
+        return { ok: true, state }
+      }
+      if (state === 'conflict' || state === 'rolled_back') {
+        return { ok: false, state }
+      }
+      setPlatformError(
+        'The update returned an unexpected result. This review will stay open — check the current status before trying again.',
+      )
+      return { ok: false, state }
     } catch {
       setPlatformError('Update failed — the instance is unchanged.')
-      return false
+      return { ok: false }
     } finally {
       setPlatformPhase('idle')
     }
@@ -974,6 +1022,16 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
     if (platformPhase !== 'idle' || !platform?.available) return
     setPlatformError('')
     setReviewOpen(true)
+  }
+
+  function closeUpdateReview() {
+    setReviewOpen(false)
+    // useDialogFocus first restores the opener captured at mount. A successful
+    // apply can replace that node during refreshPlatform, so focus the live
+    // conditional action after React commits the close and replacement.
+    requestAnimationFrame(() => {
+      platformActionRef.current?.focus({ preventScroll: true })
+    })
   }
 
   // Poll until the restart is actually safe to navigate. A plain successful
@@ -1341,7 +1399,7 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
                 color={platformConflict || platformRolledBack || platformRestart || updateAvailable ? '--accent' : '--green'}
               >
                 {platformConflict
-                  ? 'Resolving a conflict'
+                  ? 'Update blocked'
                   : platformRolledBack
                     ? 'Update needs repair'
                     : platformRestart
@@ -1361,6 +1419,7 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
             {platformConflict ? (
               onOpenChat ? (
                 <button
+                  ref={platformActionRef}
                   className="settings__btn settings__btn--outline settings__btn--sm settings__btn--nowrap"
                   type="button"
                   onClick={resolvePlatformConflict}
@@ -1375,6 +1434,7 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
               ) : null
             ) : platformRestart ? (
               <button
+                ref={platformActionRef}
                 className="settings__btn settings__btn--sm settings__btn--nowrap"
                 type="button"
                 onClick={restartToFinish}
@@ -1388,6 +1448,7 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
               </button>
             ) : updateAvailable ? (
               <button
+                ref={platformActionRef}
                 className="settings__btn settings__btn--sm settings__btn--nowrap"
                 type="button"
                 onClick={openUpdateReview}
@@ -1402,6 +1463,7 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
               // If the check surfaces an update, this slot re-renders to the
               // Update button on the next paint.
               <button
+                ref={platformActionRef}
                 className="settings__btn settings__btn--outline settings__btn--sm settings__btn--nowrap"
                 type="button"
                 onClick={checkForUpdates}
@@ -1423,9 +1485,11 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
 
         {reviewOpen && (
           <UpdateReviewModal
-            onClose={() => setReviewOpen(false)}
+            onClose={closeUpdateReview}
             onApply={applyPlatformUpdate}
+            onResolve={resolvePlatformConflict}
             applying={platformPhase === 'applying'}
+            resolving={platformPhase === 'resolving'}
             applyError={platformError}
           />
         )}

--- a/frontend/src/components/SettingsView/UpdateReviewModal.css
+++ b/frontend/src/components/SettingsView/UpdateReviewModal.css
@@ -56,6 +56,12 @@
   min-height: 0;
 }
 
+.urm--result {
+  height: auto;
+  max-width: 520px;
+  grid-template-rows: auto auto auto;
+}
+
 .urm__head {
   display: flex;
   align-items: center;
@@ -121,6 +127,19 @@
   color: var(--muted);
   font-size: 13px;
   line-height: 1.5;
+}
+
+.urm__notice--result {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  border-color: color-mix(in srgb, var(--accent) 68%, var(--border));
+  background: color-mix(in srgb, var(--accent) 9%, var(--surface));
+}
+
+.urm__notice--result strong {
+  color: var(--text);
+  font-size: 16px;
 }
 
 .urm__section {

--- a/frontend/src/components/SettingsView/UpdateReviewModal.jsx
+++ b/frontend/src/components/SettingsView/UpdateReviewModal.jsx
@@ -42,12 +42,21 @@ function commitCountLabel(count) {
   return `${count} ${count === 1 ? 'commit' : 'commits'}`
 }
 
-export default function UpdateReviewModal({ onClose, onApply, applying, applyError }) {
+export default function UpdateReviewModal({
+  onClose,
+  onApply,
+  onResolve,
+  applying,
+  resolving,
+  applyError,
+}) {
   const [preview, setPreview] = useState(null)
   const [loading, setLoading] = useState(true)
   const [loadError, setLoadError] = useState(false)
+  const [resultState, setResultState] = useState('')
   const dialogRef = useRef(null)
   const closeRef = useRef(null)
+  const resultActionRef = useRef(null)
 
   const loadPreview = useCallback(async () => {
     setLoading(true)
@@ -66,23 +75,39 @@ export default function UpdateReviewModal({ onClose, onApply, applying, applyErr
   useEffect(() => { loadPreview() }, [loadPreview])
 
   const requestClose = useCallback(() => {
-    if (!applying) onClose()
-  }, [applying, onClose])
+    if (!applying && !resolving) onClose()
+  }, [applying, onClose, resolving])
 
-  // Escape and backdrop dismissal remain disabled while an update is applying.
+  // Escape and backdrop dismissal remain disabled while an update or resolver
+  // request is in flight.
   useDialogFocus({
     containerRef: dialogRef,
     initialFocusRef: closeRef,
     onClose: requestClose,
-    closeOnEscape: !applying,
+    closeOnEscape: !applying && !resolving,
   })
 
   const handleApply = useCallback(async () => {
-    const ok = await onApply()
-    // On success the caller advances the row to "Restart to finish"; close so
-    // the owner sees that next step. On failure applyError renders in the sheet.
-    if (ok) onClose()
+    const result = await onApply()
+    // A successful request can still mean the update was blocked. Keep the
+    // reviewed sheet open and show that honest outcome in place; only a clean
+    // apply closes automatically and advances Settings to its next step.
+    if (result?.state === 'conflict' || result?.state === 'rolled_back') {
+      setResultState(result.state)
+      return
+    }
+    if (
+      result?.ok
+      && (result.state === 'restart_needed' || result.state === 'up_to_date')
+    ) onClose()
   }, [onApply, onClose])
+
+  // Applying replaces the focused Apply button with a result surface. Focus a
+  // real action in that surface so both Tab directions remain inside the
+  // dialog; the result notice announces the outcome through role=status.
+  useEffect(() => {
+    if (resultState) resultActionRef.current?.focus({ preventScroll: true })
+  }, [resultState])
 
   const summary = summarizePreview(preview)
   const trivial = preview && isTrivialUpdate(preview)
@@ -96,6 +121,10 @@ export default function UpdateReviewModal({ onClose, onApply, applying, applyErr
   // A preview that resolved to "not available" (e.g. the update landed from
   // another surface between status and open) has nothing to apply.
   const notAvailable = preview && preview.available === false && !loadError
+  const hasResult = resultState === 'conflict' || resultState === 'rolled_back'
+  const resultTitle = resultState === 'rolled_back'
+    ? 'Update rolled back'
+    : 'Update not applied'
 
   const summaryBits = []
   if (summary.commitCount) summaryBits.push(commitCountLabel(summary.commitCount))
@@ -109,25 +138,28 @@ export default function UpdateReviewModal({ onClose, onApply, applying, applyErr
     >
       <div
         ref={dialogRef}
-        className="urm"
+        className={`urm${hasResult ? ' urm--result' : ''}`}
         role="dialog"
         aria-modal="true"
         aria-labelledby="urm-title"
+        tabIndex={-1}
         onClick={(event) => event.stopPropagation()}
       >
         <div className="urm__head">
-          <h2 id="urm-title" className="urm__title">Review update</h2>
+          <h2 id="urm-title" className="urm__title">
+            {hasResult ? resultTitle : 'Review update'}
+          </h2>
           <button
             ref={closeRef}
             type="button"
             className="urm__close"
             onClick={requestClose}
             aria-label="Close"
-            disabled={applying}
+            disabled={applying || resolving}
           >×</button>
         </div>
 
-        {!loadError && target && (
+        {!hasResult && !loadError && target && (
           <p className="urm__subtext">
             Updating Möbius to <code className="urm__sha">{target}</code>.
             {summaryBits.length ? ` ${summaryBits.join(' · ')}.` : ''}
@@ -135,7 +167,20 @@ export default function UpdateReviewModal({ onClose, onApply, applying, applyErr
         )}
 
         <div className="urm__body">
-          {loading && (
+          {hasResult ? (
+            <div className="urm__notice urm__notice--result" role="status">
+              <strong>
+                {resultState === 'rolled_back'
+                  ? 'Your previous working version was restored.'
+                  : 'Your current version is still running.'}
+              </strong>
+              <span>
+                {resultState === 'rolled_back'
+                  ? 'The updated version could not start cleanly, so Möbius rolled it back. The update needs repair before it can land.'
+                  : 'Local changes overlap the new version, so Möbius left the working installation untouched. Resolve the overlap in chat when you’re ready.'}
+              </span>
+            </div>
+          ) : loading && (
             <div className="urm__skeleton" aria-hidden="true">
               <div className="urm__skeleton-row" />
               <div className="urm__skeleton-row" />
@@ -143,26 +188,26 @@ export default function UpdateReviewModal({ onClose, onApply, applying, applyErr
             </div>
           )}
 
-          {!loading && loadError && (
+          {!hasResult && !loading && loadError && (
             <div className="urm__notice" role="status">
               Couldn’t load the change preview. You can try again, or apply the
               update without reviewing it.
             </div>
           )}
 
-          {!loading && !loadError && notAvailable && (
+          {!hasResult && !loading && !loadError && notAvailable && (
             <div className="urm__notice" role="status">
               This instance is already up to date — there’s nothing to apply.
             </div>
           )}
 
-          {!loading && !loadError && !notAvailable && trivial && (
+          {!hasResult && !loading && !loadError && !notAvailable && trivial && (
             <div className="urm__notice" role="status">
               No file changes to review — this update just advances the version.
             </div>
           )}
 
-          {!loading && !loadError && !notAvailable && !trivial && (
+          {!hasResult && !loading && !loadError && !notAvailable && !trivial && (
             <>
               {commits.length > 0 && (
                 <section className="urm__section">
@@ -193,19 +238,42 @@ export default function UpdateReviewModal({ onClose, onApply, applying, applyErr
         </div>
 
         {applyError && (
-          <Alert color="danger" variant="soft" description={applyError} />
+          <div className="urm__error">
+            <Alert color="danger" variant="soft" description={applyError} />
+          </div>
         )}
 
         <div className="urm__foot">
-          <button
-            type="button"
-            className="urm__btn urm__btn--ghost"
-            onClick={requestClose}
-            disabled={applying}
-          >
-            Not now
-          </button>
-          {loadError ? (
+          {resultState !== 'rolled_back' && (
+            <button
+              type="button"
+              className="urm__btn urm__btn--ghost"
+              onClick={requestClose}
+              disabled={applying || resolving}
+            >
+              Not now
+            </button>
+          )}
+          {resultState === 'conflict' ? (
+            <button
+              ref={resultActionRef}
+              type="button"
+              className="urm__btn"
+              onClick={onResolve}
+              disabled={applying || resolving}
+            >
+              {resolving ? 'Opening…' : 'Resolve in chat'}
+            </button>
+          ) : resultState === 'rolled_back' ? (
+            <button
+              ref={resultActionRef}
+              type="button"
+              className="urm__btn"
+              onClick={requestClose}
+            >
+              Done
+            </button>
+          ) : loadError ? (
             <div className="urm__foot-actions">
               <button
                 type="button"

--- a/frontend/src/lib/__tests__/updateReviewModal.test.js
+++ b/frontend/src/lib/__tests__/updateReviewModal.test.js
@@ -6,6 +6,7 @@ const read = relative => readFileSync(new URL(relative, import.meta.url), 'utf8'
 
 const modal = read('../../components/SettingsView/UpdateReviewModal.jsx')
 const modalCss = read('../../components/SettingsView/UpdateReviewModal.css')
+const settingsView = read('../../components/SettingsView/SettingsView.jsx')
 const diffView = read('../../components/DiffView/DiffView.jsx')
 const diffStyles = read('../../components/DiffView/styles.js')
 
@@ -24,6 +25,39 @@ test('the combined raw-diff toggle is gone and truncation is explained per file'
   assert.doesNotMatch(modal, /diffOpen|Show changes|Hide changes|<pre/)
   assert.doesNotMatch(modalCss, /\.urm__diff(?:\s|\{|--)/)
   assert.match(modal, /preview\?\.diff_truncated/)
+})
+
+test('apply outcomes close only for explicit clean states and preserve actionable results', () => {
+  assert.match(settingsView, /state === 'restart_needed' \|\| state === 'up_to_date'/)
+  assert.match(settingsView, /state === 'conflict' \|\| state === 'rolled_back'/)
+  assert.match(settingsView, /The update returned an unexpected result/)
+  assert.match(modal, /result\?\.state === 'conflict' \|\| result\?\.state === 'rolled_back'/)
+  assert.match(modal, /result\.state === 'restart_needed' \|\| result\.state === 'up_to_date'/)
+  assert.doesNotMatch(modal, /if \(result\?\.ok\) onClose\(\)/)
+})
+
+test('the apply response is a truthful fallback when status refresh fails', () => {
+  assert.match(settingsView, /function platformStatusFromApply\(previous, result\)/)
+  assert.match(settingsView, /available: state === 'rolled_back'/)
+  assert.match(settingsView, /conflict_paths: Array\.isArray\(result\.conflict_paths\)/)
+  assert.match(settingsView, /conflict_chat_id: state === 'conflict' \? \(result\.chat_id \|\| null\) : null/)
+  assert.match(
+    settingsView,
+    /setPlatform\(current => platformStatusFromApply\(current, body\)\)[\s\S]*await refreshPlatform\(\)/,
+  )
+})
+
+test('apply errors have exactly one live alert owner', () => {
+  assert.match(modal, /<div className="urm__error">[\s\S]*<Alert color="danger"/)
+  assert.doesNotMatch(modal, /className="urm__error" role="alert"/)
+})
+
+test('result and close focus always land on live tabbable controls', () => {
+  assert.match(modal, /ref=\{resultActionRef\}/)
+  assert.match(modal, /tabIndex=\{-1\}/)
+  assert.doesNotMatch(modal, /resultHeadingRef|tabIndex=\{blocked/)
+  assert.match(settingsView, /ref=\{platformActionRef\}/)
+  assert.match(settingsView, /requestAnimationFrame\(\(\) => \{[\s\S]*platformActionRef\.current\?\.focus/)
 })
 
 test('DiffView stays generic, semantic, and keyboard-scrollable', () => {

--- a/tests/platform-update-modal.spec.mjs
+++ b/tests/platform-update-modal.spec.mjs
@@ -1,0 +1,384 @@
+/**
+ * Behavior contracts for the platform update result dialog.
+ *
+ * Every platform endpoint is intercepted, so these tests exercise the real
+ * Settings UI without fetching, applying, resolving, or restarting anything.
+ *
+ * Run: scripts/playwright-local.sh --allow-local-e2e tests/platform-update-modal.spec.mjs
+ */
+import { test, expect } from '@playwright/test'
+
+const BASE = process.env.MOBIUS_URL || 'http://localhost:8001'
+
+test.use({ serviceWorkers: 'block' })
+
+function platformStatus(state = 'available') {
+  return {
+    state,
+    available: state === 'available' || state === 'rolled_back',
+    needs_restart: state === 'restart_needed',
+    current_build_sha: '1111111111111111111111111111111111111111',
+    recorded_upstream_sha: '1111111111111111111111111111111111111111',
+    contained_upstream_sha: '1111111111111111111111111111111111111111',
+    seed_required: false,
+    conflict_paths: state === 'conflict' ? ['frontend/src/example.js'] : [],
+    conflict_chat_id: null,
+  }
+}
+
+const preview = {
+  state: 'available',
+  available: true,
+  current_sha: '1111111111111111111111111111111111111111',
+  target_sha: '2222222222222222222222222222222222222222',
+  commits: [{ sha: '22222222', subject: 'Incoming platform change' }],
+  files: [],
+  diff: null,
+  diff_truncated: false,
+  conflict_paths: [],
+}
+
+function deferred() {
+  let resolve
+  const promise = new Promise(done => { resolve = done })
+  return { promise, resolve }
+}
+
+async function mockPlatform(page, stateRef) {
+  await page.route('**/api/platform/status', route => {
+    if (stateRef.failStatus) {
+      return route.fulfill({
+        status: 503,
+        contentType: 'application/json',
+        body: JSON.stringify({ detail: 'Status temporarily unavailable.' }),
+      })
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(platformStatus(stateRef.current)),
+    })
+  })
+  await page.route('**/api/platform/update-preview', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify(preview),
+  }))
+}
+
+async function openUpdateReview(page) {
+  await page.setViewportSize({ width: 900, height: 800 })
+  await page.goto(BASE, { waitUntil: 'domcontentloaded' })
+  await page.waitForFunction(
+    () => !!(document.querySelector('.chat__empty-wrap')
+      || document.querySelector('.chat__scroll')
+      || document.querySelector('.chat__form')),
+    { timeout: 10000 },
+  )
+
+  const navigationToggle = page.getByLabel('Toggle navigation')
+  if (await navigationToggle.getAttribute('aria-expanded') !== 'true') {
+    await navigationToggle.click()
+  }
+  await expect(page.locator('.drawer.drawer--open')).toBeVisible()
+  await page.getByRole('button', { name: 'Settings', exact: true }).click()
+  await expect(page.locator('.settings')).toBeVisible()
+  await expect(page.getByText('New update available', { exact: true })).toBeVisible()
+
+  await page.getByRole('button', { name: 'Review update', exact: true }).click()
+  const dialog = page.getByRole('dialog', { name: 'Review update' })
+  await expect(dialog).toBeVisible()
+  await expect(dialog.getByRole('button', { name: 'Apply update' })).toBeEnabled()
+  return dialog
+}
+
+test('a clean apply closes the review and exposes the restart step', async ({ page }) => {
+  const state = { current: 'available' }
+  await mockPlatform(page, state)
+  await page.route('**/api/platform/apply', route => {
+    state.current = 'restart_needed'
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        state: 'restart_needed',
+        needs_restart: true,
+        upstream_commit: preview.target_sha,
+        merge_commit: '3333333333333333333333333333333333333333',
+        conflict_paths: [],
+        chat_id: null,
+      }),
+    })
+  })
+
+  const dialog = await openUpdateReview(page)
+  await dialog.getByRole('button', { name: 'Apply update' }).click()
+
+  await expect(dialog).toHaveCount(0)
+  const restart = page.getByRole('button', { name: 'Restart to finish' })
+  await expect(restart).toBeVisible()
+  await expect(restart).toBeFocused()
+})
+
+test('a blocked apply stays open, focuses its result, and shows resolver failures', async ({ page }) => {
+  const state = { current: 'available' }
+  await mockPlatform(page, state)
+  await page.route('**/api/platform/apply', route => {
+    state.current = 'conflict'
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        state: 'conflict',
+        needs_restart: false,
+        upstream_commit: preview.target_sha,
+        merge_commit: null,
+        conflict_paths: ['frontend/src/example.js'],
+        chat_id: null,
+      }),
+    })
+  })
+
+  const resolver = deferred()
+  await page.route('**/api/platform/conflict-resolver-chat', async route => {
+    await resolver.promise
+    return route.fulfill({
+      status: 409,
+      contentType: 'application/json',
+      body: JSON.stringify({ detail: 'The recorded conflict is no longer resolvable.' }),
+    })
+  })
+
+  const review = await openUpdateReview(page)
+  await review.getByRole('button', { name: 'Apply update' }).click()
+
+  const blocked = page.getByRole('dialog', { name: 'Update not applied' })
+  await expect(blocked).toBeVisible()
+  await expect(blocked.getByText('Your current version is still running.')).toBeVisible()
+
+  const resolveButton = blocked.getByRole('button', { name: 'Resolve in chat' })
+  await expect(resolveButton).toBeFocused()
+  await page.keyboard.press('Shift+Tab')
+  await expect(blocked.getByRole('button', { name: 'Not now' })).toBeFocused()
+  await page.keyboard.press('Tab')
+  await expect(resolveButton).toBeFocused()
+
+  await resolveButton.click()
+  await expect(blocked.getByRole('button', { name: 'Opening…' })).toBeDisabled()
+  await page.keyboard.press('Shift+Tab')
+  await expect(blocked).toBeFocused()
+  await page.keyboard.press('Escape')
+  await expect(blocked).toBeVisible()
+
+  resolver.resolve()
+  const error = blocked.locator('.urm__error')
+  await expect(error.getByRole('alert')).toContainText(
+    'Could not open chat: The recorded conflict is no longer resolvable.',
+  )
+  await expect(blocked.getByRole('alert')).toHaveCount(1)
+  await expect(blocked.getByRole('button', { name: 'Resolve in chat' })).toBeEnabled()
+
+  await page.locator('.urm__overlay').click({ position: { x: 2, y: 2 } })
+  await expect(blocked).toHaveCount(0)
+  await expect(page.getByRole('button', { name: 'Resolve in chat' })).toBeFocused()
+})
+
+test('a rolled-back apply stays open with an explicit repair result', async ({ page }) => {
+  const state = { current: 'available' }
+  await mockPlatform(page, state)
+  await page.route('**/api/platform/apply', route => {
+    state.current = 'rolled_back'
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        state: 'rolled_back',
+        needs_restart: false,
+        upstream_commit: preview.target_sha,
+        merge_commit: null,
+        conflict_paths: [],
+        chat_id: null,
+      }),
+    })
+  })
+
+  const review = await openUpdateReview(page)
+  await review.getByRole('button', { name: 'Apply update' }).click()
+
+  const result = page.getByRole('dialog', { name: 'Update rolled back' })
+  await expect(result).toBeVisible()
+  await expect(result.getByText('Your previous working version was restored.')).toBeVisible()
+  const done = result.getByRole('button', { name: 'Done', exact: true })
+  await expect(done).toBeFocused()
+  await done.click()
+  await expect(result).toHaveCount(0)
+  await expect(page.getByText('Update needs repair', { exact: true })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Review update', exact: true })).toBeFocused()
+})
+
+test('a clean apply remains truthful when every follow-up status read fails', async ({ page }) => {
+  const state = { current: 'available', failStatus: false }
+  await mockPlatform(page, state)
+  await page.route('**/api/platform/apply', route => {
+    state.failStatus = true
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        state: 'restart_needed',
+        needs_restart: true,
+        upstream_commit: preview.target_sha,
+        merge_commit: '3333333333333333333333333333333333333333',
+        conflict_paths: [],
+        chat_id: null,
+      }),
+    })
+  })
+
+  const review = await openUpdateReview(page)
+  await review.getByRole('button', { name: 'Apply update' }).click()
+
+  await expect(review).toHaveCount(0)
+  await expect(
+    page.locator('.settings__update').getByText('Restart to finish', { exact: true }),
+  ).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Restart to finish' })).toBeFocused()
+})
+
+test('a conflict result closes to truthful repair state when status reads fail', async ({ page }) => {
+  const state = { current: 'available', failStatus: false }
+  await mockPlatform(page, state)
+  await page.route('**/api/platform/apply', route => {
+    state.failStatus = true
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        state: 'conflict',
+        needs_restart: false,
+        upstream_commit: preview.target_sha,
+        merge_commit: null,
+        conflict_paths: ['frontend/src/example.js'],
+        chat_id: null,
+      }),
+    })
+  })
+
+  const review = await openUpdateReview(page)
+  await review.getByRole('button', { name: 'Apply update' }).click()
+
+  const result = page.getByRole('dialog', { name: 'Update not applied' })
+  await expect(result).toBeVisible()
+  await result.getByRole('button', { name: 'Not now' }).click()
+  await expect(result).toHaveCount(0)
+  await expect(page.getByText('Update blocked', { exact: true })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Resolve in chat' })).toBeFocused()
+})
+
+test('a rollback result closes to truthful retry state when status reads fail', async ({ page }) => {
+  const state = { current: 'available', failStatus: false }
+  await mockPlatform(page, state)
+  await page.route('**/api/platform/apply', route => {
+    state.failStatus = true
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        state: 'rolled_back',
+        needs_restart: false,
+        upstream_commit: preview.target_sha,
+        merge_commit: null,
+        conflict_paths: [],
+        chat_id: null,
+      }),
+    })
+  })
+
+  const review = await openUpdateReview(page)
+  await review.getByRole('button', { name: 'Apply update' }).click()
+
+  const result = page.getByRole('dialog', { name: 'Update rolled back' })
+  await expect(result).toBeVisible()
+  await result.getByRole('button', { name: 'Done', exact: true }).click()
+  await expect(result).toHaveCount(0)
+  await expect(page.getByText('Update needs repair', { exact: true })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Review update', exact: true })).toBeFocused()
+})
+
+test('malformed, missing, and unknown successful states fail open and can retry', async ({ page }) => {
+  const state = { current: 'available' }
+  await mockPlatform(page, state)
+  let attempts = 0
+  await page.route('**/api/platform/apply', route => {
+    attempts += 1
+    if (attempts === 1) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: '{' })
+    }
+    if (attempts === 2) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    }
+    if (attempts === 3) {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ state: 'future_state' }),
+      })
+    }
+    state.current = 'restart_needed'
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ state: 'restart_needed', needs_restart: true }),
+    })
+  })
+
+  const review = await openUpdateReview(page)
+  const apply = review.getByRole('button', { name: 'Apply update' })
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    await apply.click()
+    await expect(review).toBeVisible()
+    await expect(review.locator('.urm__error').getByRole('alert')).toContainText(
+      'The update returned an unexpected result.',
+    )
+    await expect(review.getByRole('alert')).toHaveCount(1)
+    await expect(apply).toBeEnabled()
+  }
+
+  await apply.click()
+  await expect(review).toHaveCount(0)
+  await expect(page.getByRole('button', { name: 'Restart to finish' })).toBeFocused()
+})
+
+test('Escape and dismissal stay gated while Apply is pending', async ({ page }) => {
+  const state = { current: 'available' }
+  await mockPlatform(page, state)
+  const apply = deferred()
+  await page.route('**/api/platform/apply', async route => {
+    await apply.promise
+    state.current = 'restart_needed'
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        state: 'restart_needed',
+        needs_restart: true,
+        upstream_commit: preview.target_sha,
+        merge_commit: '3333333333333333333333333333333333333333',
+        conflict_paths: [],
+        chat_id: null,
+      }),
+    })
+  })
+
+  const dialog = await openUpdateReview(page)
+  await dialog.getByRole('button', { name: 'Apply update' }).click()
+  await expect(dialog.getByRole('button', { name: 'Applying…' })).toBeDisabled()
+  await expect(dialog.getByRole('button', { name: 'Not now' })).toBeDisabled()
+  await expect(dialog.getByRole('button', { name: 'Close' })).toBeDisabled()
+
+  await page.keyboard.press('Escape')
+  await expect(dialog).toBeVisible()
+
+  apply.resolve()
+  await expect(dialog).toHaveCount(0)
+})


### PR DESCRIPTION
## Summary

This final production-audit integration keeps three independently reviewed contracts truthful:

- records terminal `chat_runs` as `failed`, `stopped`, or `interrupted` when appropriate, reserving `completed` for clean turns; queued handoff preserves the ending run's outcome and a lost reply is a failure
- distinguishes unresolved app-update receipts from resolved replay-pending receipts, returns an explicit unknown phase on Git uncertainty, and re-fences receipt identity against the locked current upstream ref after fetch
- turns platform apply responses into honest modal results: only clean states close, conflict/rollback remain actionable, unexpected 2xx results fail open, failed follow-up status reads retain the authoritative apply outcome, and focus stays on the live next action

The three commits were prepared and adversarially reviewed independently. Their patch IDs are unchanged after composing them on current main (`1a710c064`, PR #112).

## Review-driven fixes

- run outcome: provider success with no renderable reply now records `failed` instead of false `completed`
- update state: closed a fetch/classification TOCTOU with a final locked ref fence and tri-state ancestry
- modal: added `rolled_back`/unknown result handling, live focus restoration and pending-state focus containment, then added apply-body fallback for failed post-apply status reads and removed a duplicate alert role

## Local validation

- chat outcome changed-file suite: 70 passed in the composed worktree; originating focused suite: 214 passed
- app Git/install suites: 208 passed in the composed worktree (originating evidence: 63 Git + 145 install)
- Settings/modal/accessibility contracts: 103 passed
- production frontend build: passed
- real Playwright platform-update suite: 9/9 passed
- `git diff --check`: passed

All seven hosted jobs are required before merge.
