### PR TITLE
Preserve attachments in unfinished chat drafts

### DIFF
--- a/frontend/src/components/ChatView/ChatInputBar.jsx
+++ b/frontend/src/components/ChatView/ChatInputBar.jsx
@@ -215,22 +215,34 @@ function stripExt(name) {
  *  The remove `×` is a 20×20 button floating at the card's top-
  *  right corner (half-overlapping outside). */
 function FileChips({ files, onRemove, chatId }) {
-  const [tokenParam, setTokenParam] = useState('')
+  const [tokenState, setTokenState] = useState({
+    chatId: null,
+    param: '',
+    failed: false,
+  })
   const hasRestoredImage = files?.some(file => (
     file.mime_type?.startsWith('image/') && !file.objectUrl
   ))
 
   useEffect(() => {
     if (!hasRestoredImage || !chatId) {
-      setTokenParam('')
+      setTokenState({ chatId: null, param: '', failed: false })
       return undefined
     }
     let cancelled = false
+    setTokenState({ chatId, param: '', failed: false })
     mediaTokenParam(chatId).then(param => {
-      if (!cancelled) setTokenParam(param)
+      if (!cancelled) setTokenState({ chatId, param, failed: !param })
+    }).catch(() => {
+      if (!cancelled) setTokenState({ chatId, param: '', failed: true })
     })
     return () => { cancelled = true }
   }, [chatId, hasRestoredImage])
+
+  // Never reuse a previous chat's token during the effect boundary.
+  const currentTokenState = tokenState.chatId === chatId
+    ? tokenState
+    : { param: '', failed: false }
 
   if (!files?.length) return null
   return (
@@ -238,9 +250,12 @@ function FileChips({ files, onRemove, chatId }) {
       {files.map(chip => {
         const isImage = !!chip.objectUrl || chip.mime_type?.startsWith('image/')
         const previewSrc = chip.objectUrl || (
-          isImage && tokenParam
-            ? `${BASE}/api/chats/${chatId}/uploads/${encodeURIComponent(chip.name)}${tokenParam}`
+          isImage && currentTokenState.param
+            ? `${BASE}/api/chats/${chatId}/uploads/${encodeURIComponent(chip.name)}${currentTokenState.param}`
             : ''
+        )
+        const previewFailed = !!(
+          isImage && !chip.objectUrl && currentTokenState.failed
         )
         const cls = classifyFile(chip.name || '')
         const errorMark = chip.status === 'error' ? ' chat__attach-card--error' : ''
@@ -252,10 +267,16 @@ function FileChips({ files, onRemove, chatId }) {
               + (isImage ? ' chat__attach-card--image' : ' chat__attach-card--file')
               + errorMark
             }
-            title={chip.status === 'error' ? chip.error : chip.name}
+            title={previewFailed
+              ? `${chip.name} — preview unavailable; attachment is still ready to send`
+              : (chip.status === 'error' ? chip.error : chip.name)}
           >
             {isImage && previewSrc ? (
               <img className="chat__attach-card-thumb" src={previewSrc} alt="" />
+            ) : previewFailed ? (
+              <span className="chat__attach-card-preview-error" role="status">
+                Preview unavailable
+              </span>
             ) : isImage ? (
               <span className="chat__attach-card-spin" aria-hidden="true" />
             ) : (

--- a/frontend/src/components/ChatView/ChatInputBar.jsx
+++ b/frontend/src/components/ChatView/ChatInputBar.jsx
@@ -69,8 +69,10 @@
  * ╚══════════════════════════════════════════════════════════════════╝
  */
 
-import { useRef, useLayoutEffect } from 'react'
+import { useRef, useState, useEffect, useLayoutEffect } from 'react'
 import { ArrowUp, Mic, DoubleChevronRight } from '@openai/apps-sdk-ui/components/Icon'
+import { BASE } from '../../api/client.js'
+import { mediaTokenParam } from '../../api/mediaToken.js'
 import { resolveComposerEnterAction } from './composerShortcuts.js'
 import { filePasteNeedsDefaultPrevented, pastedFiles } from './pasteUpload.js'
 
@@ -212,12 +214,34 @@ function stripExt(name) {
  *     type badge and the filename below.
  *  The remove `×` is a 20×20 button floating at the card's top-
  *  right corner (half-overlapping outside). */
-function FileChips({ files, onRemove }) {
+function FileChips({ files, onRemove, chatId }) {
+  const [tokenParam, setTokenParam] = useState('')
+  const hasRestoredImage = files?.some(file => (
+    file.mime_type?.startsWith('image/') && !file.objectUrl
+  ))
+
+  useEffect(() => {
+    if (!hasRestoredImage || !chatId) {
+      setTokenParam('')
+      return undefined
+    }
+    let cancelled = false
+    mediaTokenParam(chatId).then(param => {
+      if (!cancelled) setTokenParam(param)
+    })
+    return () => { cancelled = true }
+  }, [chatId, hasRestoredImage])
+
   if (!files?.length) return null
   return (
     <div className="chat__attach-tray">
       {files.map(chip => {
-        const isImage = !!chip.objectUrl
+        const isImage = !!chip.objectUrl || chip.mime_type?.startsWith('image/')
+        const previewSrc = chip.objectUrl || (
+          isImage && tokenParam
+            ? `${BASE}/api/chats/${chatId}/uploads/${encodeURIComponent(chip.name)}${tokenParam}`
+            : ''
+        )
         const cls = classifyFile(chip.name || '')
         const errorMark = chip.status === 'error' ? ' chat__attach-card--error' : ''
         return (
@@ -230,8 +254,10 @@ function FileChips({ files, onRemove }) {
             }
             title={chip.status === 'error' ? chip.error : chip.name}
           >
-            {isImage ? (
-              <img className="chat__attach-card-thumb" src={chip.objectUrl} alt="" />
+            {isImage && previewSrc ? (
+              <img className="chat__attach-card-thumb" src={previewSrc} alt="" />
+            ) : isImage ? (
+              <span className="chat__attach-card-spin" aria-hidden="true" />
             ) : (
               <>
                 <span className={`chat__attach-card-icon chat__attach-card-icon--${cls.kind}`}>
@@ -315,6 +341,7 @@ function FileChips({ files, onRemove }) {
  * The bar's only job: composition + the Send/Stop/Mic resolution.
  */
 export default function ChatInputBar({
+  chatId,
   input,
   onInputChange,
   onSubmit,
@@ -456,7 +483,11 @@ export default function ChatInputBar({
         {leftButtons}
         <div className={`chat__pill${hasFiles ? ' chat__pill--with-attach' : ''}`}>
           {hasFiles && (
-            <FileChips files={pendingFiles} onRemove={onRemoveFile} />
+            <FileChips
+              files={pendingFiles}
+              onRemove={onRemoveFile}
+              chatId={chatId}
+            />
           )}
           <div className="chat__input-line">
             <textarea

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -2214,6 +2214,19 @@
   border-color: rgba(248, 113, 113, 0.55);
 }
 
+.chat__attach-card-preview-error {
+  width: 100%;
+  height: 100%;
+  display: grid;
+  place-items: center;
+  padding: 18px 8px 8px;
+  color: color-mix(in srgb, var(--danger) 78%, var(--text));
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.2;
+  text-align: center;
+}
+
 .chat__attach-card-thumb {
   width: 100%;
   height: 100%;

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -81,7 +81,7 @@ import {
   saveFailedSendAttempt,
   sendAttemptIsDurable,
 } from './sendAttemptRecovery.js'
-import { persistComposerDraft } from './composerDraft.js'
+import { persistComposerDraft, readComposerDraft } from './composerDraft.js'
 import {
   EMPTY_BUILD_PHASE_RAIL,
   accumulateBuildPhase,
@@ -192,8 +192,8 @@ function readInitialComposer(chatId) {
     const failedAttempt = loadFailedSendAttempt(chatId)
     const pending = sessionStorage.getItem(PENDING_DRAFT_KEY)
     if (pending && failedAttempt) clearFailedSendAttempt(chatId)
-    const saved = sessionStorage.getItem(`draft:${chatId}`) || ''
-    const input = pending || failedAttempt?.text || saved
+    const saved = readComposerDraft(chatId)
+    const input = pending || failedAttempt?.text || saved.input
     const autoSendDraft =
       sessionStorage.getItem(PENDING_DRAFT_AUTOSEND_KEY) ||
       sessionStorage.getItem(`${DRAFT_AUTOSEND_PREFIX}${chatId}`)
@@ -201,7 +201,9 @@ function readInitialComposer(chatId) {
       input,
       autoSend: !!input && autoSendDraft === input,
       failedAttempt: pending ? null : failedAttempt,
-      attachments: pending ? [] : (failedAttempt?.attachments || []),
+      attachments: pending
+        ? []
+        : (failedAttempt?.attachments || saved.attachments),
     }
   } catch {
     return { input: '', autoSend: false, failedAttempt: null, attachments: [] }
@@ -354,12 +356,16 @@ export default function ChatView({
   if (!initialComposerRef.current) {
     initialComposerRef.current = readInitialComposer(chatId)
   }
+  const draftAttachmentsRef = useRef(initialComposerRef.current.attachments)
   const [input, setInputState] = useState(() => initialComposerRef.current.input)
+  const inputValueRef = useRef(input)
+  inputValueRef.current = input
   function setComposerInput(nextInput) {
     // Navigation can unmount this component before React flushes passive
     // effects. Keep every composer transition durable at the state boundary,
     // whether it came from typing, voice, restoration, or send cleanup.
-    persistComposerDraft(chatId, nextInput)
+    inputValueRef.current = nextInput
+    persistComposerDraft(chatId, nextInput, draftAttachmentsRef.current)
     setInputState(nextInput)
   }
   const [sendFailure, setSendFailure] = useState(() => (
@@ -1404,6 +1410,10 @@ export default function ChatView({
   } = useFileUpload({
     chatId,
     initialFiles: initialComposerRef.current.attachments,
+    onFilesChange: nextFiles => {
+      draftAttachmentsRef.current = nextFiles
+      persistComposerDraft(chatId, inputValueRef.current, nextFiles)
+    },
   })
 
   function clearFailedAttempt() {
@@ -1589,7 +1599,7 @@ export default function ChatView({
   // voice transcription, send cleanup). Direct owner edits are saved
   // synchronously in handleComposerInputChange above.
   useEffect(() => {
-    persistComposerDraft(chatId, input)
+    persistComposerDraft(chatId, input, draftAttachmentsRef.current)
   }, [input, chatId])
 
   // Auto-size textarea when a draft is restored. Cap matches the
@@ -3959,6 +3969,7 @@ export default function ChatView({
           </>
         )}
         <ChatInputBar
+          chatId={chatId}
           input={input}
           onInputChange={handleComposerInputChange}
           onSubmit={handleSubmit}

--- a/frontend/src/components/ChatView/__tests__/accessibilityHardening.test.js
+++ b/frontend/src/components/ChatView/__tests__/accessibilityHardening.test.js
@@ -48,6 +48,15 @@ test('chat image preview actions use labeled buttons', () => {
   assert.match(markdown, /<button[\s\S]*className="md-image-frame"[\s\S]*aria-label=\{`Open \$\{alt \|\| 'image'\} preview`\}/)
 })
 
+test('a restored image with no media token stops spinning and exposes its failure', () => {
+  const composer = read('../ChatInputBar.jsx')
+  assert.match(composer, /setTokenState\(\{ chatId, param, failed: !param \}\)/)
+  assert.match(composer, /className="chat__attach-card-preview-error" role="status"/)
+  assert.match(composer, /Preview unavailable/)
+  assert.match(composer, /aria-label=\{`Remove \$\{chip\.name\}`\}/,
+    'the failed preview must retain an explicit removal affordance')
+})
+
 test('QuestionCard gives the conditional Other field a durable accessible name', () => {
   const source = read('../QuestionCard.jsx')
   assert.match(source, /aria-label=\{`Other answer for: \$\{q\.question\}`\}/)

--- a/frontend/src/components/ChatView/__tests__/composerDraft.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerDraft.test.js
@@ -45,9 +45,27 @@ test('persists uploaded attachments with text and restores a sendable draft', ()
       name: 'map.png',
       size: 1096340,
       mime_type: 'image/png',
+      status: 'done',
     }],
   })
   assert.equal(storage.getItem('draft:chat-map').includes('blob:temporary'), false)
+})
+
+test('a restored attachment survives the mount persistence pass', () => {
+  const storage = storageStub()
+  persistComposerDraft('chat-remount', 'Keep this', [{
+    name: 'draft-note.txt', size: 16, mime_type: 'text/plain', status: 'done',
+  }], storage)
+
+  const firstMount = readComposerDraft('chat-remount', storage)
+  assert.deepEqual(firstMount.attachments.map(a => a.status), ['done'])
+  persistComposerDraft(
+    'chat-remount', firstMount.input, firstMount.attachments, storage,
+  )
+
+  assert.deepEqual(readComposerDraft('chat-remount', storage).attachments, [{
+    name: 'draft-note.txt', size: 16, mime_type: 'text/plain', status: 'done',
+  }])
 })
 
 test('keeps legacy plain-text drafts readable', () => {
@@ -64,10 +82,29 @@ test('does not restore attachments that never finished uploading', () => {
     { name: 'ready.png', status: 'done', mime_type: 'image/png', size: 1 },
     { name: 'still-uploading.png', status: 'uploading', mime_type: 'image/png', size: 2 },
     { name: 'failed.png', status: 'error', mime_type: 'image/png', size: 3 },
+    { name: 'future-state.png', status: 'processing', mime_type: 'image/png', size: 4 },
   ], storage)
   assert.deepEqual(
     readComposerDraft('chat-a', storage).attachments.map(a => a.name),
     ['ready.png'],
+  )
+})
+
+test('rejects status-bearing attachments injected into a stored envelope', () => {
+  const storage = storageStub({
+    'draft:chat-a': JSON.stringify({
+      type: 'mobius-composer-draft',
+      version: 1,
+      input: 'draft',
+      attachments: [
+        { name: 'safe.txt', size: 1, mime_type: 'text/plain' },
+        { name: 'unknown.txt', status: 'processing', size: 2, mime_type: 'text/plain' },
+      ],
+    }),
+  })
+  assert.deepEqual(
+    readComposerDraft('chat-a', storage).attachments.map(a => a.name),
+    ['safe.txt'],
   )
 })
 

--- a/frontend/src/components/ChatView/__tests__/composerDraft.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerDraft.test.js
@@ -2,7 +2,7 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 
-import { persistComposerDraft } from '../composerDraft.js'
+import { persistComposerDraft, readComposerDraft } from '../composerDraft.js'
 
 function storageStub(initial = {}) {
   const values = new Map(Object.entries(initial))
@@ -24,6 +24,53 @@ test('persists and clears a chat draft synchronously', () => {
   assert.equal(storage.getItem('draft:chat-a'), null)
 })
 
+test('persists uploaded attachments with text and restores a sendable draft', () => {
+  const storage = storageStub()
+  const attachments = [{
+    id: 'local-only',
+    name: 'map.png',
+    size: 1096340,
+    mime_type: 'image/png',
+    objectUrl: 'blob:temporary-and-non-restorable',
+    status: 'done',
+  }]
+
+  assert.equal(
+    persistComposerDraft('chat-map', 'What is this?', attachments, storage),
+    true,
+  )
+  assert.deepEqual(readComposerDraft('chat-map', storage), {
+    input: 'What is this?',
+    attachments: [{
+      name: 'map.png',
+      size: 1096340,
+      mime_type: 'image/png',
+    }],
+  })
+  assert.equal(storage.getItem('draft:chat-map').includes('blob:temporary'), false)
+})
+
+test('keeps legacy plain-text drafts readable', () => {
+  const storage = storageStub({ 'draft:legacy': 'unfinished thought' })
+  assert.deepEqual(readComposerDraft('legacy', storage), {
+    input: 'unfinished thought',
+    attachments: [],
+  })
+})
+
+test('does not restore attachments that never finished uploading', () => {
+  const storage = storageStub()
+  persistComposerDraft('chat-a', 'draft', [
+    { name: 'ready.png', status: 'done', mime_type: 'image/png', size: 1 },
+    { name: 'still-uploading.png', status: 'uploading', mime_type: 'image/png', size: 2 },
+    { name: 'failed.png', status: 'error', mime_type: 'image/png', size: 3 },
+  ], storage)
+  assert.deepEqual(
+    readComposerDraft('chat-a', storage).attachments.map(a => a.name),
+    ['ready.png'],
+  )
+})
+
 test('evicts one draft and retries when session storage is full', () => {
   const storage = storageStub({ 'draft:chat-a': 'older' })
   const normalSet = storage.setItem.bind(storage)
@@ -38,7 +85,7 @@ test('evicts one draft and retries when session storage is full', () => {
     normalSet(key, value)
   }
 
-  assert.equal(persistComposerDraft('chat-b', 'latest', storage), true)
+  assert.equal(persistComposerDraft('chat-b', 'latest', [], storage), true)
   assert.equal(storage.getItem('draft:chat-a'), null)
   assert.equal(storage.getItem('draft:chat-b'), 'latest')
 })
@@ -49,7 +96,7 @@ test('the composer state boundary saves before scheduling React state', () => {
   const end = source.indexOf('\n  }', start)
   const body = source.slice(start, end)
 
-  const save = body.indexOf('persistComposerDraft(chatId, nextInput)')
+  const save = body.indexOf('persistComposerDraft(chatId, nextInput, draftAttachmentsRef.current)')
   const render = body.indexOf('setInputState(nextInput)')
   assert.ok(save >= 0, 'all composer changes must be persisted directly')
   assert.ok(render > save, 'draft persistence must happen before navigation can unmount React')

--- a/frontend/src/components/ChatView/composerDraft.js
+++ b/frontend/src/components/ChatView/composerDraft.js
@@ -3,6 +3,53 @@ function availableStorage(storage) {
   try { return globalThis.sessionStorage ?? null } catch { return null }
 }
 
+const DRAFT_ENVELOPE = 'mobius-composer-draft'
+
+function restorableAttachments(attachments) {
+  if (!Array.isArray(attachments)) return []
+  return attachments
+    .filter(attachment => (
+      attachment
+      && attachment.status !== 'uploading'
+      && attachment.status !== 'error'
+      && typeof attachment.name === 'string'
+      && attachment.name.length > 0
+    ))
+    .map(attachment => ({
+      name: attachment.name,
+      size: Number.isFinite(attachment.size) ? attachment.size : 0,
+      mime_type: typeof attachment.mime_type === 'string'
+        ? attachment.mime_type
+        : 'application/octet-stream',
+    }))
+}
+
+/**
+ * Reads either the current structured draft or a legacy plain-text draft.
+ * Object URLs are deliberately not stored: they stop working when the chat
+ * unmounts. Restored image cards point at the already-uploaded chat file.
+ */
+export function readComposerDraft(chatId, storage) {
+  const target = availableStorage(storage)
+  if (!target || chatId == null) return { input: '', attachments: [] }
+  try {
+    const raw = target.getItem(`draft:${chatId}`)
+    if (!raw) return { input: '', attachments: [] }
+    try {
+      const parsed = JSON.parse(raw)
+      if (parsed?.type === DRAFT_ENVELOPE && parsed.version === 1) {
+        return {
+          input: typeof parsed.input === 'string' ? parsed.input : '',
+          attachments: restorableAttachments(parsed.attachments),
+        }
+      }
+    } catch { /* legacy plain text */ }
+    return { input: raw, attachments: [] }
+  } catch {
+    return { input: '', attachments: [] }
+  }
+}
+
 function evictOneDraft(storage) {
   try {
     const draftKeys = []
@@ -27,20 +74,35 @@ function evictOneDraft(storage) {
  * settling. Synchronous storage here makes the text durable before React gets
  * a chance to remove the composer.
  */
-export function persistComposerDraft(chatId, input, storage) {
-  const target = availableStorage(storage)
+export function persistComposerDraft(chatId, input, attachments = [], storage) {
+  // Backward compatibility for callers of the former
+  // persistComposerDraft(chatId, input, storage) signature.
+  const legacyStorage = !Array.isArray(attachments) && storage === undefined
+    ? attachments
+    : undefined
+  const draftAttachments = Array.isArray(attachments) ? attachments : []
+  const target = availableStorage(storage ?? legacyStorage)
   if (!target || chatId == null) return false
   const key = `draft:${chatId}`
+  const safeAttachments = restorableAttachments(draftAttachments)
+  const value = safeAttachments.length > 0
+    ? JSON.stringify({
+        type: DRAFT_ENVELOPE,
+        version: 1,
+        input: typeof input === 'string' ? input : '',
+        attachments: safeAttachments,
+      })
+    : (typeof input === 'string' ? input : '')
 
   try {
-    if (input) target.setItem(key, input)
+    if (value) target.setItem(key, value)
     else target.removeItem(key)
     return true
   } catch (error) {
     if (error?.name !== 'QuotaExceededError' && error?.code !== 22) return false
     evictOneDraft(target)
     try {
-      if (input) target.setItem(key, input)
+      if (value) target.setItem(key, value)
       else target.removeItem(key)
       return true
     } catch {

--- a/frontend/src/components/ChatView/composerDraft.js
+++ b/frontend/src/components/ChatView/composerDraft.js
@@ -5,23 +5,45 @@ function availableStorage(storage) {
 
 const DRAFT_ENVELOPE = 'mobius-composer-draft'
 
-function restorableAttachments(attachments) {
+function attachmentMetadata(attachment) {
+  return {
+    name: attachment.name,
+    size: Number.isFinite(attachment.size) ? attachment.size : 0,
+    mime_type: typeof attachment.mime_type === 'string'
+      ? attachment.mime_type
+      : 'application/octet-stream',
+  }
+}
+
+function isNamedAttachment(attachment) {
+  return !!(
+    attachment
+    && typeof attachment.name === 'string'
+    && attachment.name.length > 0
+  )
+}
+
+// Live upload state is an explicit trust boundary: only a completed upload is
+// safe to persist as a sendable draft. Unknown/future states fail closed.
+function completedAttachments(attachments) {
   if (!Array.isArray(attachments)) return []
   return attachments
-    .filter(attachment => (
-      attachment
-      && attachment.status !== 'uploading'
-      && attachment.status !== 'error'
-      && typeof attachment.name === 'string'
-      && attachment.name.length > 0
-    ))
-    .map(attachment => ({
-      name: attachment.name,
-      size: Number.isFinite(attachment.size) ? attachment.size : 0,
-      mime_type: typeof attachment.mime_type === 'string'
-        ? attachment.mime_type
-        : 'application/octet-stream',
-    }))
+    .filter(attachment => isNamedAttachment(attachment) && attachment.status === 'done')
+    .map(attachmentMetadata)
+}
+
+// Stored envelopes are intentionally status-less because persistence already
+// crossed the completed-only boundary above. Reject status-bearing/malformed
+// rows instead of accidentally blessing a future pending state on reload.
+function storedAttachments(attachments) {
+  if (!Array.isArray(attachments)) return []
+  return attachments
+    .filter(attachment => isNamedAttachment(attachment) && attachment.status === undefined)
+    // The envelope stays status-less on disk, but the live composer boundary
+    // is explicit: a successfully validated stored row is a completed upload.
+    // Returning `done` prevents the mount persistence effect (and React strict
+    // remount) from immediately filtering the restored attachment back out.
+    .map(attachment => ({ ...attachmentMetadata(attachment), status: 'done' }))
 }
 
 /**
@@ -40,7 +62,7 @@ export function readComposerDraft(chatId, storage) {
       if (parsed?.type === DRAFT_ENVELOPE && parsed.version === 1) {
         return {
           input: typeof parsed.input === 'string' ? parsed.input : '',
-          attachments: restorableAttachments(parsed.attachments),
+          attachments: storedAttachments(parsed.attachments),
         }
       }
     } catch { /* legacy plain text */ }
@@ -84,7 +106,7 @@ export function persistComposerDraft(chatId, input, attachments = [], storage) {
   const target = availableStorage(storage ?? legacyStorage)
   if (!target || chatId == null) return false
   const key = `draft:${chatId}`
-  const safeAttachments = restorableAttachments(draftAttachments)
+  const safeAttachments = completedAttachments(draftAttachments)
   const value = safeAttachments.length > 0
     ? JSON.stringify({
         type: DRAFT_ENVELOPE,

--- a/frontend/src/components/ChatView/useFileUpload.js
+++ b/frontend/src/components/ChatView/useFileUpload.js
@@ -14,12 +14,33 @@ import { getAuthHeaders, BASE } from '../../api/client.js'
  *   releaseFiles: (files: Array) => void,
  * }}
  */
-export default function useFileUpload({ chatId, initialFiles = [] }) {
-  const [files, setFiles] = useState(() => initialFiles)
+export default function useFileUpload({ chatId, initialFiles = [], onFilesChange }) {
+  const normalizedInitialFiles = initialFiles.map((file, index) => ({
+    id: file.id || `restored-${index}-${file.name || 'file'}`,
+    name: file.name,
+    size: file.size,
+    mime_type: file.mime_type,
+    objectUrl: file.objectUrl || null,
+    status: file.status || 'done',
+    error: file.error || null,
+  }))
+  const [files, setFiles] = useState(() => normalizedInitialFiles)
   // Keep a ref in sync so the unmount cleanup can revoke object URLs
   // without closing over a stale `files` state value.
   const filesRef = useRef(files)
   filesRef.current = files
+  const onFilesChangeRef = useRef(onFilesChange)
+  onFilesChangeRef.current = onFilesChange
+
+  function commitFiles(nextOrUpdater) {
+    const next = typeof nextOrUpdater === 'function'
+      ? nextOrUpdater(filesRef.current)
+      : nextOrUpdater
+    filesRef.current = next
+    setFiles(next)
+    onFilesChangeRef.current?.(next)
+    return next
+  }
 
   // Revoke any surviving object URLs when the component unmounts —
   // e.g. the user navigated away while files were still staged.
@@ -41,7 +62,7 @@ export default function useFileUpload({ chatId, initialFiles = [] }) {
       status: 'uploading',
       error: null,
     }))
-    setFiles(prev => [...prev, ...newChips])
+    commitFiles(prev => [...prev, ...newChips])
 
     for (let i = 0; i < newChips.length; i++) {
       const chip = newChips[i]
@@ -57,21 +78,21 @@ export default function useFileUpload({ chatId, initialFiles = [] }) {
         })
         if (!res.ok) {
           const msg = await res.text().catch(() => 'Upload failed')
-          setFiles(prev => prev.map(c =>
+          commitFiles(prev => prev.map(c =>
             c.id === chip.id ? { ...c, status: 'error', error: msg } : c
           ))
         } else {
           // Update name from server response (sanitized filename).
           const data = await res.json().catch(() => [])
           const serverName = data?.[0]?.name
-          setFiles(prev => prev.map(c =>
+          commitFiles(prev => prev.map(c =>
             c.id === chip.id
               ? { ...c, status: 'done', ...(serverName ? { name: serverName } : {}) }
               : c
           ))
         }
       } catch (err) {
-        setFiles(prev => prev.map(c =>
+        commitFiles(prev => prev.map(c =>
           c.id === chip.id ? { ...c, status: 'error', error: err.message } : c
         ))
       }
@@ -85,7 +106,7 @@ export default function useFileUpload({ chatId, initialFiles = [] }) {
     // file. Compute the next state first, then apply side effects once.
     const removing = filesRef.current.find(c => c.id === id)
     if (removing?.objectUrl) URL.revokeObjectURL(removing.objectUrl)
-    setFiles(prev => prev.filter(c => c.id !== id))
+    commitFiles(prev => prev.filter(c => c.id !== id))
     if (removing?.status === 'done' && removing.name) {
       fetch(`${BASE}/api/chats/${chatId}/uploads/${encodeURIComponent(removing.name)}`, {
         method: 'DELETE',
@@ -103,14 +124,12 @@ export default function useFileUpload({ chatId, initialFiles = [] }) {
   function clearFiles({ revoke = true } = {}) {
     const current = filesRef.current
     if (revoke) releaseFiles(current)
-    filesRef.current = []
-    setFiles([])
+    commitFiles([])
   }
 
   function restoreFiles(fileList) {
     const restored = Array.isArray(fileList) ? fileList : []
-    filesRef.current = restored
-    setFiles(restored)
+    commitFiles(restored)
   }
 
   return { files, addFiles, removeFile, clearFiles, restoreFiles, releaseFiles }

--- a/tests/composer-draft-attachments.spec.mjs
+++ b/tests/composer-draft-attachments.spec.mjs
@@ -60,7 +60,7 @@ test('an uploaded attachment survives a chat switch and remains sendable', async
       body: JSON.stringify({ status: 'started' }),
     })
   })
-  await page.keyboard.press('Enter')
+  await composer.press('Enter')
   await expect.poll(() => sentBody?.attachments?.map(file => file.name) || [])
     .toEqual(['draft-note.txt'])
 })

--- a/tests/composer-draft-attachments.spec.mjs
+++ b/tests/composer-draft-attachments.spec.mjs
@@ -1,0 +1,66 @@
+import { test, expect } from '@playwright/test'
+import { attachCleanup, createTaggedChat } from './_chatTracker.mjs'
+
+const BASE = process.env.MOBIUS_URL || 'http://localhost:8001'
+
+test.use({ serviceWorkers: 'block' })
+attachCleanup()
+
+test('an uploaded attachment survives a chat switch and remains sendable', async ({ page }) => {
+  await page.setViewportSize({ width: 412, height: 915 })
+  await page.route(/\/api\/chats\/[0-9a-f-]+\/stream$/, route =>
+    route.fulfill({ status: 204, body: '' }))
+
+  await page.goto(BASE, { waitUntil: 'domcontentloaded' })
+  const draftChat = await createTaggedChat(page, 'attachment-draft')
+  const otherChat = await createTaggedChat(page, 'attachment-draft-other')
+
+  await page.goto(`${BASE}/shell/?chat=${encodeURIComponent(draftChat.id)}`, {
+    waitUntil: 'domcontentloaded',
+  })
+  const composer = page.getByRole('textbox', { name: 'Message Möbius…' })
+  await expect(composer).toBeVisible({ timeout: 8000 })
+  await composer.fill('Keep this file with my unfinished message')
+  await page.locator('input[type="file"]').setInputFiles({
+    name: 'draft-note.txt',
+    mimeType: 'text/plain',
+    buffer: Buffer.from('draft attachment'),
+  })
+  await expect(page.getByRole('button', { name: 'Remove draft-note.txt' }))
+    .toBeVisible({ timeout: 8000 })
+  await expect.poll(() => page.evaluate((chatId) => {
+    const raw = sessionStorage.getItem(`draft:${chatId}`)
+    if (!raw) return null
+    try {
+      const value = JSON.parse(raw)
+      return value.attachments?.map(file => file.name) || []
+    } catch {
+      return []
+    }
+  }, draftChat.id)).toEqual(['draft-note.txt'])
+
+  await page.goto(`${BASE}/shell/?chat=${encodeURIComponent(otherChat.id)}`, {
+    waitUntil: 'domcontentloaded',
+  })
+  await expect(page.getByRole('textbox', { name: 'Message Möbius…' }))
+    .toBeVisible({ timeout: 8000 })
+  await page.goto(`${BASE}/shell/?chat=${encodeURIComponent(draftChat.id)}`, {
+    waitUntil: 'domcontentloaded',
+  })
+
+  await expect(composer).toHaveValue('Keep this file with my unfinished message')
+  await expect(page.getByRole('button', { name: 'Remove draft-note.txt' })).toBeVisible()
+
+  let sentBody = null
+  await page.route(/\/api\/chats\/[0-9a-f-]+\/messages$/, async route => {
+    sentBody = JSON.parse(route.request().postData() || '{}')
+    await route.fulfill({
+      status: 202,
+      contentType: 'application/json',
+      body: JSON.stringify({ status: 'started' }),
+    })
+  })
+  await page.keyboard.press('Enter')
+  await expect.poll(() => sentBody?.attachments?.map(file => file.name) || [])
+    .toEqual(['draft-note.txt'])
+})


### PR DESCRIPTION
## Summary
- store only completed attachment metadata with each per-chat draft
- restore uploaded files after leaving and returning to a chat without persisting invalid blob URLs
- fetch a scoped media token for restored image previews
- keep file state and synchronous draft persistence aligned through upload, remove, send, failure restore, and clear paths

## Provenance
Reviewed from production-local commit a603eb12 and replayed cleanly onto current main 41a3809b. A browser-level remount regression was added during review.

## Validation
- focused draft serialization tests: 6 passed
- full reviewed UI stack: 1,765 frontend library tests and 47 hook tests passed
- production frontend build passed
- adds a disposable-stack Playwright test covering upload, chat switch, restoration, and send payload

Local disposable E2E was not forced past the repository disk-safety guard; hosted PR checks remain authoritative.