### PR TITLE
Steer composed messages with modified Enter

### DIFF
--- a/frontend/src/components/ChatView/ChatInputBar.jsx
+++ b/frontend/src/components/ChatView/ChatInputBar.jsx
@@ -62,9 +62,10 @@
  * ║      `_isTouchPrimary` is detected once via                      ║
  * ║      `matchMedia('(hover: none) and (pointer: coarse)')` and     ║
  * ║      gates plain Enter. Touch devices: Enter inserts a           ║
- * ║      newline. Desktop: Enter sends or steers. Cmd/Ctrl+Enter     ║
- * ║      is an explicit hardware-keyboard shortcut for the same      ║
- * ║      send/steer action. Shift+Enter always inserts a newline.    ║
+ * ║      newline. Desktop: Enter sends or steers queued text.        ║
+ * ║      Cmd/Ctrl+Enter fast-forwards composed text into a live      ║
+ * ║      turn when possible, otherwise it sends normally.            ║
+ * ║      Shift+Enter always inserts a newline.                        ║
  * ║                                                                  ║
  * ╚══════════════════════════════════════════════════════════════════╝
  */
@@ -275,6 +276,8 @@ function FileChips({ files, onRemove }) {
  *   input              — current textarea value
  *   onInputChange      — receives new string
  *   onSubmit           — called with FormEvent | MouseEvent | TouchEvent
+ *   onSubmitSteer      — submits composed text and immediately steers
+ *                        it when a live turn can accept steering
  *   inputRef           — for caller to focus/blur (e.g. dismiss keyboard)
  *   sending            — agent is currently streaming
  *   listening          — voice input active
@@ -292,6 +295,8 @@ function FileChips({ files, onRemove }) {
  *                        existing steer handler to reconcile/steer queued
  *                        messages, even before the visual fast-forward gate
  *                        is ready.
+ *   canSubmitSteer     — true when Cmd/Ctrl+Enter may submit the current
+ *                        draft through the live-turn steer path.
  *   pendingFiles       — file upload chips state
  *   onAddFiles         — receives FileList from file picker
  *   onRemoveFile       — receives chip id
@@ -318,6 +323,7 @@ export default function ChatInputBar({
   input,
   onInputChange,
   onSubmit,
+  onSubmitSteer,
   inputRef,
   sending,
   listening,
@@ -328,6 +334,7 @@ export default function ChatInputBar({
   onSteer,
   canSteer,
   canRequestSteer = canSteer,
+  canSubmitSteer = canRequestSteer,
   offline,
   sendFailure = null,
   submissionBlocked = false,
@@ -418,12 +425,17 @@ export default function ChatInputBar({
       hasInput,
       canSteer,
       canRequestSteer,
+      canSubmitSteer,
       isTouchPrimary: _isTouchPrimary,
     })
     if (!action) return
     e.preventDefault()
     if (action === 'steer') {
       onSteer()
+      return
+    }
+    if (action === 'submit-steer') {
+      if (!submissionBlocked) onSubmitSteer(e)
       return
     }
     if (action === 'submit') {

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -1945,6 +1945,15 @@ export default function ChatView({
   //     they just stopped) → original turn 1 user msg + partial get
   //     pushed above the viewport. Keep their current scroll mode
   //     instead — the new turn streams into view from where they were.
+  // Modified-Enter spans two requests (durable queue acknowledgement, then
+  // force-steer). Claim that whole operation synchronously so repeated
+  // keydowns cannot submit a second message before the steer busy state flips.
+  const submitSteerInFlightRef = useRef(false)
+  // doSend is intentionally stable and therefore must not capture the
+  // render-local steer implementation. Dereference the current function only
+  // after the queue POST settles, when a newer render may have replaced it.
+  const handleSteerOneRef = useRef(null)
+
   const doSend = useCallback(async (text, opts = {}) => {
     if (isProviderSwitchBlocking(chatId)) return
     const pin = opts.pin !== false  // default true
@@ -2159,7 +2168,7 @@ export default function ChatView({
             // as the visible per-row arrow. The queue acknowledgement gives
             // the new row a canonical ts before steering, so a failed or
             // racing steer naturally leaves the message safely queued.
-            await handleSteerOne(cid)
+            await handleSteerOneRef.current?.(cid)
           }
         }
         // Mid-turn steer: the backend delivered the send into the live
@@ -2614,7 +2623,10 @@ export default function ChatView({
   function handleSubmitSteer(e) {
     e.preventDefault()
     if (isProviderSwitchBlocking(chatId)) return
-    doSend(input.trim(), { steerAfterQueue: true })
+    if (submitSteerInFlightRef.current) return
+    submitSteerInFlightRef.current = true
+    void doSend(input.trim(), { steerAfterQueue: true })
+      .finally(() => { submitSteerInFlightRef.current = false })
   }
 
   // Cancel one queued message via DELETE. Keep reconciliation scoped to that
@@ -3115,6 +3127,7 @@ export default function ChatView({
       setSteerBusy(false)
     }
   }
+  handleSteerOneRef.current = handleSteerOne
 
   // Re-anchor the scroll mode when the tab returns to the foreground
   // (visibilitychange/pageshow/online) while a turn is active, so a

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -2154,6 +2154,12 @@ export default function ChatView({
               cidList: result.message?._consumed_cids,
             })
             bridgeHook.markBridged()
+          } else if (opts.steerAfterQueue) {
+            // Ctrl/Cmd+Enter uses the same durable queue -> force-steer path
+            // as the visible per-row arrow. The queue acknowledgement gives
+            // the new row a canonical ts before steering, so a failed or
+            // racing steer naturally leaves the message safely queued.
+            await handleSteerOne(cid)
           }
         }
         // Mid-turn steer: the backend delivered the send into the live
@@ -2603,6 +2609,12 @@ export default function ChatView({
     e.preventDefault()
     if (isProviderSwitchBlocking(chatId)) return
     doSend(input.trim())
+  }
+
+  function handleSubmitSteer(e) {
+    e.preventDefault()
+    if (isProviderSwitchBlocking(chatId)) return
+    doSend(input.trim(), { steerAfterQueue: true })
   }
 
   // Cancel one queued message via DELETE. Keep reconciliation scoped to that
@@ -3382,10 +3394,11 @@ export default function ChatView({
   const canSteer = !hasPendingQuestion
     && connectionError !== 'disconnected' && !steerBusy
     && canFastForwardQueue(pendingQueue.pendingMessages, turnActive)
-  const canRequestSteer = !hasPendingQuestion
+  const canSubmitSteer = !hasPendingQuestion
     && connectionError !== 'disconnected'
     && !steerBusy
     && turnActive
+  const canRequestSteer = canSubmitSteer
     && pendingQueue.pendingMessages.length > 0
 
   // ── Sticky "tap to resume" affordance ──────────────────────────────
@@ -3962,6 +3975,7 @@ export default function ChatView({
           input={input}
           onInputChange={handleComposerInputChange}
           onSubmit={handleSubmit}
+          onSubmitSteer={handleSubmitSteer}
           inputRef={inputRef}
           sending={composerBusy}
           listening={listening}
@@ -3972,6 +3986,7 @@ export default function ChatView({
           onSteer={handleSteer}
           canSteer={canSteer}
           canRequestSteer={canRequestSteer}
+          canSubmitSteer={canSubmitSteer}
           offline={!online}
           sendFailure={sendFailure}
           submissionBlocked={providerSwitching}

--- a/frontend/src/components/ChatView/__tests__/buildPhaseRail.test.js
+++ b/frontend/src/components/ChatView/__tests__/buildPhaseRail.test.js
@@ -109,8 +109,10 @@ test('connection failure hides queued actions and disables composer steering', (
     'the lost-connection state should own the footer stack until Retry succeeds')
   assert.match(chatView, /const canSteer = !hasPendingQuestion[\s\S]*?connectionError !== 'disconnected' && !steerBusy[\s\S]*?canFastForwardQueue/,
     'the visible composer steer action must be gated by pending QA and connection health')
-  assert.match(chatView, /const canRequestSteer = !hasPendingQuestion[\s\S]*?connectionError !== 'disconnected'[\s\S]*?!steerBusy[\s\S]*?turnActive/,
-    'the keyboard steer path must be gated by pending QA and connection health too')
+  assert.match(chatView, /const canSubmitSteer = !hasPendingQuestion[\s\S]*?connectionError !== 'disconnected'[\s\S]*?!steerBusy[\s\S]*?turnActive/,
+    'the composed-text keyboard steer path must be gated by pending QA and connection health too')
+  assert.match(chatView, /const canRequestSteer = canSubmitSteer[\s\S]*?pendingQueue\.pendingMessages\.length > 0/,
+    'the empty-composer keyboard path must share the same gate and require queued work')
 })
 
 test('a send that merely enqueues preserves the in-flight build rail', () => {

--- a/frontend/src/components/ChatView/__tests__/composerShortcuts.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerShortcuts.test.js
@@ -5,22 +5,35 @@ import { resolveComposerEnterAction } from '../composerShortcuts.js'
 
 const enter = (overrides = {}) => ({ key: 'Enter', ...overrides })
 
-test('Cmd+Enter submits composer text', () => {
+test('Cmd+Enter steers composer text when a live turn can accept it', () => {
   assert.equal(
     resolveComposerEnterAction(enter({ metaKey: true }), {
       hasInput: true,
       canSteer: true,
+      canSubmitSteer: true,
       isTouchPrimary: false,
     }),
-    'submit',
+    'submit-steer',
   )
 })
 
-test('Ctrl+Enter submits composer text', () => {
+test('Ctrl+Enter steers composer text when a live turn can accept it', () => {
   assert.equal(
     resolveComposerEnterAction(enter({ ctrlKey: true }), {
       hasInput: true,
       canSteer: false,
+      canSubmitSteer: true,
+      isTouchPrimary: false,
+    }),
+    'submit-steer',
+  )
+})
+
+test('Cmd/Ctrl+Enter submits normally when there is no steerable live turn', () => {
+  assert.equal(
+    resolveComposerEnterAction(enter({ metaKey: true }), {
+      hasInput: true,
+      canSubmitSteer: false,
       isTouchPrimary: false,
     }),
     'submit',

--- a/frontend/src/components/ChatView/__tests__/optimisticSteerQueue.test.js
+++ b/frontend/src/components/ChatView/__tests__/optimisticSteerQueue.test.js
@@ -74,3 +74,16 @@ test('a steer request disables sibling row actions until it settles', () => {
   assert.match(source, /steerBusy=\{steerBusy\}/,
     'the queued tray should receive the in-flight state for its row buttons')
 })
+
+test('the modified-Enter submit waits for durability, then reuses per-row steer', () => {
+  assert.match(
+    source,
+    /pendingQueue\.confirmQueued\(cid,[\s\S]*?else if \(opts\.steerAfterQueue\) \{[\s\S]*?await handleSteerOne\(cid\)/,
+    'the composed message must be server-confirmed before the existing row steer consumes it',
+  )
+  assert.match(
+    source,
+    /function handleSubmitSteer\(e\) \{[\s\S]*?doSend\(input\.trim\(\), \{ steerAfterQueue: true \}\)/,
+    'the keyboard handler should opt into the queue-to-steer path without changing ordinary sends',
+  )
+})

--- a/frontend/src/components/ChatView/__tests__/optimisticSteerQueue.test.js
+++ b/frontend/src/components/ChatView/__tests__/optimisticSteerQueue.test.js
@@ -76,14 +76,31 @@ test('a steer request disables sibling row actions until it settles', () => {
 })
 
 test('the modified-Enter submit waits for durability, then reuses per-row steer', () => {
-  assert.match(
-    source,
-    /pendingQueue\.confirmQueued\(cid,[\s\S]*?else if \(opts\.steerAfterQueue\) \{[\s\S]*?await handleSteerOne\(cid\)/,
-    'the composed message must be server-confirmed before the existing row steer consumes it',
+  const refDeclaration = source.indexOf('const handleSteerOneRef = useRef(null)')
+  const doSendDeclaration = source.indexOf('const doSend = useCallback')
+  assert.ok(
+    refDeclaration >= 0 && refDeclaration < doSendDeclaration,
+    'the stable doSend callback must reach the current steer implementation through a ref',
   )
   assert.match(
     source,
-    /function handleSubmitSteer\(e\) \{[\s\S]*?doSend\(input\.trim\(\), \{ steerAfterQueue: true \}\)/,
-    'the keyboard handler should opt into the queue-to-steer path without changing ordinary sends',
+    /pendingQueue\.confirmQueued\(cid,[\s\S]*?else if \(opts\.steerAfterQueue\) \{[\s\S]*?await handleSteerOneRef\.current\?\.\(cid\)/,
+    'the composed message must be server-confirmed before the existing row steer consumes it',
+  )
+  assert.doesNotMatch(
+    source,
+    /else if \(opts\.steerAfterQueue\) \{[\s\S]*?await handleSteerOne\(cid\)/,
+    'doSend must not capture a render-local steer function across the queue request',
+  )
+  const steerOneDeclaration = source.indexOf('async function handleSteerOne(cid)')
+  const currentAssignment = source.indexOf('handleSteerOneRef.current = handleSteerOne')
+  assert.ok(
+    steerOneDeclaration >= 0 && currentAssignment > steerOneDeclaration,
+    'each render must publish the current per-row steer implementation',
+  )
+  assert.match(
+    source,
+    /function handleSubmitSteer\(e\) \{[\s\S]*?if \(submitSteerInFlightRef\.current\) return[\s\S]*?submitSteerInFlightRef\.current = true[\s\S]*?doSend\(input\.trim\(\), \{ steerAfterQueue: true \}\)[\s\S]*?\.finally\(\(\) => \{ submitSteerInFlightRef\.current = false \}\)/,
+    'the keyboard handler must synchronously guard the full queue-to-steer operation',
   )
 })

--- a/frontend/src/components/ChatView/composerShortcuts.js
+++ b/frontend/src/components/ChatView/composerShortcuts.js
@@ -2,6 +2,7 @@ export function resolveComposerEnterAction(event, {
   hasInput = false,
   canSteer = false,
   canRequestSteer = canSteer,
+  canSubmitSteer = canRequestSteer,
   isTouchPrimary = false,
 } = {}) {
   if (!event || event.key !== 'Enter' || event.shiftKey) return null
@@ -9,7 +10,10 @@ export function resolveComposerEnterAction(event, {
   const modifiedEnter = !!(event.metaKey || event.ctrlKey)
   if (!modifiedEnter && isTouchPrimary) return null
 
-  if (hasInput) return 'submit'
+  if (hasInput) {
+    if (modifiedEnter && canSubmitSteer) return 'submit-steer'
+    return 'submit'
+  }
   if (canRequestSteer) return 'steer'
   return 'noop'
 }

--- a/tests/steer-queued.spec.mjs
+++ b/tests/steer-queued.spec.mjs
@@ -198,6 +198,8 @@ test.describe('Steer queued messages (fast-forward into the live turn)', () => {
   test('Ctrl+Enter queues durably, then automatically steers only the composed message', async ({ page }) => {
     const STEER_TEXT = 'change course immediately'
     const messagePosts = []
+    let releaseQueueAck
+    const queueAckGate = new Promise(resolve => { releaseQueueAck = resolve })
 
     await page.route(/\/api\/chats\/[0-9a-f-]+\/messages$/, async (route) => {
       let body = {}
@@ -227,6 +229,9 @@ test.describe('Steer queued messages (fast-forward into the live turn)', () => {
           }),
         })
       }
+      // Hold the durable queue acknowledgement open so a repeated shortcut
+      // exercises the synchronous submit guard, before steerBusy can flip.
+      await queueAckGate
       return route.fulfill({
         status: 202,
         contentType: 'application/json',
@@ -251,6 +256,15 @@ test.describe('Steer queued messages (fast-forward into the live turn)', () => {
     const input = page.getByRole('textbox', { name: 'Message Möbius…' })
     await input.fill(STEER_TEXT)
     await page.keyboard.press('Control+Enter')
+    await expect.poll(() => messagePosts.filter(body => (
+      !body.force_steer && body.content === STEER_TEXT
+    )).length).toBe(1)
+    await page.keyboard.press('Control+Enter')
+    await page.waitForTimeout(100)
+    expect(messagePosts.filter(body => (
+      !body.force_steer && body.content === STEER_TEXT
+    ))).toHaveLength(1)
+    releaseQueueAck()
 
     await expect.poll(
       () => messagePosts.filter(body => body.force_steer).length,

--- a/tests/steer-queued.spec.mjs
+++ b/tests/steer-queued.spec.mjs
@@ -195,6 +195,78 @@ test.describe('Steer queued messages (fast-forward into the live turn)', () => {
     expect(await page.locator('.queued__row').count()).toBe(0)
   })
 
+  test('Ctrl+Enter queues durably, then automatically steers only the composed message', async ({ page }) => {
+    const STEER_TEXT = 'change course immediately'
+    const messagePosts = []
+
+    await page.route(/\/api\/chats\/[0-9a-f-]+\/messages$/, async (route) => {
+      let body = {}
+      try { body = JSON.parse(route.request().postData() || '{}') } catch { /* empty */ }
+      messagePosts.push(body)
+
+      if (body.force_steer) {
+        return route.fulfill({
+          status: 202,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            status: 'steered',
+            chat_id: 'mock',
+            pending_messages: [],
+          }),
+        })
+      }
+      if (body.content === 'first message') {
+        return route.fulfill({
+          status: 202,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            status: 'started',
+            message: {
+              role: 'user', content: body.content, ts: Date.now(), cid: body.cid,
+            },
+          }),
+        })
+      }
+      return route.fulfill({
+        status: 202,
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'queued', ts: 778001, position: 1 }),
+      })
+    })
+
+    await page.route(/\/api\/chats\/[0-9a-f-]+\/stream$/, async (route) => {
+      await new Promise(resolve => setTimeout(resolve, 8000))
+      await route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
+        body: sseBody([{ type: 'catch_up_done' }, { type: 'text', content: 'streaming...' }]),
+      }).catch(() => {})
+    })
+
+    await setupChat(page)
+    await newChat(page)
+    await sendMessage(page, 'first message')
+    await expect(page.locator('.chat__stop')).toBeVisible({ timeout: 5000 })
+
+    const input = page.getByRole('textbox', { name: 'Message Möbius…' })
+    await input.fill(STEER_TEXT)
+    await page.keyboard.press('Control+Enter')
+
+    await expect.poll(
+      () => messagePosts.filter(body => body.force_steer).length,
+      { timeout: 5000 },
+    ).toBe(1)
+
+    const queuePost = messagePosts.find(body => (
+      !body.force_steer && body.content === STEER_TEXT
+    ))
+    const steerPost = messagePosts.find(body => body.force_steer)
+    expect(typeof queuePost.cid).toBe('string')
+    expect(steerPost.content).toBe(STEER_TEXT)
+    expect(steerPost.consume_pending_cids).toEqual([queuePost.cid])
+    await expect(page.locator('.queued__row')).toHaveCount(0, { timeout: 5000 })
+  })
+
   test('two queued messages steer with the exact "\\n\\n"-joined content', async ({ page }) => {
     // Verifies the frontend content join sent to the provider steer: the
     // non-empty trimmed contents joined


### PR DESCRIPTION
## Summary
- make Cmd/Ctrl+Enter queue the current draft durably and then steer exactly that confirmed row into a live turn
- fall back to ordinary submit when no steerable turn is active
- reuse the existing per-row steer state machine so racing turn completion leaves the message safely queued
- retain plain Enter and Shift+Enter behavior across desktop and touch-primary input

## Provenance
Reviewed from production-local commit d74b6a5c and replayed cleanly onto current main 41a3809b without depending on the attachment-draft patch.

## Validation
- focused shortcut, queue-race, and build-rail tests: 28 passed
- full reviewed UI stack: 1,765 frontend library tests and 47 hook tests passed
- production frontend build passed
- includes a Playwright regression for the durable queue-to-steer request sequence