### PR TITLE
Align sent attachment previews

### DIFF
--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -2325,7 +2325,7 @@
   width: fit-content;
   padding: 0;
   border: 0;
-  border-radius: 8px;
+  border-radius: 14px;
   background: transparent;
   color: inherit;
   cursor: pointer;
@@ -2337,10 +2337,12 @@
 }
 
 .chat__attach-thumb {
-  height: 80px;
-  max-width: 160px;
+  /* Match the composer's attachment card after send. The thumbnail is a
+     consistent square crop; tapping it still opens the full source image. */
+  width: 96px;
+  height: 96px;
   object-fit: cover;
-  border-radius: 8px;
+  border-radius: 14px;
   border: 1px solid var(--border-light); /* CONTRACT: subtle 1px hairline on opaque fill */
   cursor: inherit;
   transition: opacity 0.15s;

--- a/frontend/src/components/ChatView/__tests__/attachmentSizing.test.js
+++ b/frontend/src/components/ChatView/__tests__/attachmentSizing.test.js
@@ -1,0 +1,37 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const css = readFileSync(new URL('../ChatView.css', import.meta.url), 'utf8')
+const msgContent = readFileSync(new URL('../MsgContent.jsx', import.meta.url), 'utf8')
+
+function ruleBody(selector) {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const match = css.match(new RegExp(`${escaped}\\s*\\{([^}]*)\\}`))
+  assert.ok(match, `${selector} rule must exist`)
+  return match[1]
+}
+
+test('sent image attachments match the composer card height and corners', () => {
+  const composer = ruleBody('.chat__attach-card--image')
+  const sentButton = ruleBody('.chat__attach-thumb-button')
+  const sent = ruleBody('.chat__attach-thumb')
+
+  assert.match(composer, /height:\s*96px/)
+  assert.match(sent, /width:\s*96px/)
+  assert.match(sent, /height:\s*96px/)
+  assert.match(composer, /border-radius:\s*14px/)
+  assert.match(sentButton, /border-radius:\s*14px/)
+  assert.match(sent, /border-radius:\s*14px/)
+})
+
+test('sent attachments render above message text in both message paths', () => {
+  const attachmentNeedle = "msg.role === 'user' && <Attachments"
+  const firstAttachments = msgContent.indexOf(attachmentNeedle)
+  const blockContent = msgContent.indexOf('{nodes.map(', firstAttachments)
+  const secondAttachments = msgContent.indexOf(attachmentNeedle, firstAttachments + 1)
+  const plainText = msgContent.indexOf('{text ? (', secondAttachments)
+
+  assert.ok(firstAttachments >= 0 && firstAttachments < blockContent)
+  assert.ok(secondAttachments >= 0 && secondAttachments < plainText)
+})


### PR DESCRIPTION
## Summary
- render sent images as the same 96 by 96 square crop used by the composer
- keep the full source available through the existing lightbox
- align the focus boundary and image corners at the shared 14px radius
- guard attachment-before-text ordering in both message render paths

## Provenance
Squashes the production-local checkpoint 67ce0a58 and follow-ups e8a10051 plus 12343b57 into one final patch on current main 41a3809b. The interim 96 by 192 variant is intentionally absent.

## Validation
- focused sizing and message-order tests: 2 passed
- full reviewed UI stack: 1,765 frontend library tests and 47 hook tests passed
- production frontend build passed