### PR TITLE
Prevent thinking row movement on first reasoning event

### DIFF
--- a/frontend/src/components/ChatView/ActivityLineHeader.jsx
+++ b/frontend/src/components/ChatView/ActivityLineHeader.jsx
@@ -88,6 +88,7 @@ const ActivityLineHeader = forwardRef(function ActivityLineHeader({
   controlsId,
   onToggle,
   count = null,
+  reserveInteractiveGeometry = false,
 }, ref) {
   const Header = interactive ? 'button' : 'div'
 
@@ -97,6 +98,9 @@ const ActivityLineHeader = forwardRef(function ActivityLineHeader({
       type={interactive ? 'button' : undefined}
       className={
         `chat__activity-header${interactive ? '' : ' chat__activity-header--static'}`
+        + (reserveInteractiveGeometry
+            ? ' chat__activity-header--reserve-interactive'
+            : '')
       }
       onClick={interactive ? onToggle : undefined}
       aria-expanded={interactive ? open : undefined}

--- a/frontend/src/components/ChatView/ActivityStretch.jsx
+++ b/frontend/src/components/ChatView/ActivityStretch.jsx
@@ -50,7 +50,7 @@ import { useDisclosureState } from './disclosureState.js'
 // shimmer plus the running-first activity summary already say what is
 // executing. So the sole open/close signal is `userOpen`, and no effect or
 // prop derives it.
-function TimelineThought({ label, thought, chatId, disclosureKey }) {
+function TimelineThought({ label, thought, chatId, disclosureKey, direct = false, live = false }) {
   const [open, setOpen] = useDisclosureState(chatId, disclosureKey)
   const headerRef = useRef(null)
   const bodyRef = useRef(null)
@@ -78,27 +78,45 @@ function TimelineThought({ label, thought, chatId, disclosureKey }) {
     )
   }
 
+  const toggle = () => {
+    preserveTogglePosition(headerRef.current, bodyRef.current)
+    setOpen(o => !o)
+  }
+
   return (
-    <div className={
-      `chat__activity-think chat__activity-think--collapsible`
-      + (open ? ' chat__activity-think--open' : '')
+    <div className={direct
+      ? `chat__activity chat__activity--direct-thought chat__activity--${live ? 'running' : 'done'}`
+        + (open ? ' chat__activity--open' : '')
+      : `chat__activity-think chat__activity-think--collapsible`
+        + (open ? ' chat__activity-think--open' : '')
     }>
-      <button
-        ref={headerRef}
-        type="button"
-        className="chat__activity-think-toggle"
-        onClick={() => {
-          preserveTogglePosition(headerRef.current, bodyRef.current)
-          setOpen(o => !o)
-        }}
-        aria-expanded={open}
-        aria-controls={bodyId}
-      >
-        <span className="chat__activity-think-icon" aria-hidden="true">
-          <ActivityTypeIcon kind="reasoning" />
-        </span>
-        <span className="chat__activity-think-label">{label}</span>
-      </button>
+      {direct ? (
+        <ActivityLineHeader
+          ref={headerRef}
+          text={label}
+          displayState={live ? 'running' : 'done'}
+          iconKind="reasoning"
+          interactive
+          open={open}
+          ariaLabel={`${label}${live ? ', in progress' : ''}`}
+          controlsId={bodyId}
+          onToggle={toggle}
+        />
+      ) : (
+        <button
+          ref={headerRef}
+          type="button"
+          className="chat__activity-think-toggle"
+          onClick={toggle}
+          aria-expanded={open}
+          aria-controls={bodyId}
+        >
+          <span className="chat__activity-think-icon" aria-hidden="true">
+            <ActivityTypeIcon kind="reasoning" />
+          </span>
+          <span className="chat__activity-think-label">{label}</span>
+        </button>
+      )}
       <div ref={bodyRef} id={bodyId} className="chat__reasoning-body" hidden={!open}>
         {open && body}
         {open && loadState === 'ready' && !trace.previewComplete && (
@@ -135,6 +153,8 @@ function SingleActivity({ entry, chatId, live, surfaceKey }) {
         thought={item}
         chatId={chatId}
         disclosureKey={`${surfaceKey}:thought:${blockKey}`}
+        direct
+        live={live}
       />
     )
   }

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -1412,6 +1412,15 @@
   padding-block: 2px var(--activity-row-gap, 4px);
 }
 
+/* A lone thought discloses directly through the same activity header used by
+   the pre-first-event placeholder. Only its body needs the reasoning indent;
+   the closed row therefore keeps identical geometry while it changes from a
+   static placeholder into a real button. */
+.chat__activity--direct-thought .chat__reasoning-body {
+  margin-inline-start: 20px;
+  padding-block: 2px var(--activity-row-gap, 4px);
+}
+
 .chat__reasoning-load {
   display: inline-block;
   padding: 3px 0;
@@ -1490,6 +1499,7 @@
   .chat__empty-action,
   .chat__quick-action-chip,
   .chat__activity-header:not(.chat__activity-header--static),
+  .chat__activity-header--reserve-interactive,
   .chat__activity-think-toggle,
   .chat__tool-header:not(.chat__tool-header--static),
   .chat__activity-timeline .chat__tool-header:not(.chat__tool-header--static),

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -3862,6 +3862,7 @@ export default function ChatView({
                     displayState="running"
                     iconKind="reasoning"
                     ariaLabel="Thinking, in progress"
+                    reserveInteractiveGeometry
                   />
                 </div>
               </div>

--- a/frontend/src/components/ChatView/__tests__/activityLineStructure.test.js
+++ b/frontend/src/components/ChatView/__tests__/activityLineStructure.test.js
@@ -30,7 +30,7 @@ test('reasoning markdown has a scoped quiet typography lane', () => {
     'bold lead-ins should not dominate the activity timeline')
 })
 
-test('placeholder and real stretches render through the shared activity header', () => {
+test('placeholder and the first real thought render through the shared activity header', () => {
   const placeholderStart = chatView.indexOf('className="chat__tools chat__thinking"')
   const placeholderEnd = chatView.indexOf('</li>', placeholderStart)
   const placeholder = chatView.slice(placeholderStart, placeholderEnd)
@@ -42,8 +42,13 @@ test('placeholder and real stretches render through the shared activity header',
   assert.ok(placeholderStart >= 0, 'placeholder should use the standard activity wrapper')
   assert.match(placeholder, /className="chat__activity chat__activity--running"/)
   assert.match(placeholder, /<ActivityLineHeader/)
+  assert.match(placeholder, /reserveInteractiveGeometry/,
+    'the static placeholder must reserve the eventual touch-target geometry')
   assert.doesNotMatch(placeholder, /chat__activity-icon|chat__activity-label/,
     'placeholder must not duplicate shared header internals')
+  assert.match(activityStretch,
+    /direct \? \([\s\S]*<ActivityLineHeader[\s\S]*interactive/,
+    'the direct first-thought branch must use the same header, not only grouped stretches')
   assert.doesNotMatch(chatCss, /\.chat__thinking\s*\{/,
     'the e2e presence hook must not carry layout compensation')
 })
@@ -84,7 +89,7 @@ test('a single activity discloses directly without a redundant parent row', () =
   assert.match(activityStretch, /if \(entries\.length === 1\)/)
   assert.match(activityStretch, /<SingleActivity[\s\S]*entry=\{entries\[0\]\}/)
   assert.match(activityStretch,
-    /item\.type === 'thinking'[\s\S]*<TimelineThought[\s\S]*key=\{assistantBlockKey\(item, idx\)\}/)
+    /item\.type === 'thinking'[\s\S]*<TimelineThought[\s\S]*direct[\s\S]*live=\{live\}/)
   assert.match(activityStretch, /<ToolBlock[\s\S]*key=\{assistantBlockKey\(item, idx\)\}/)
 })
 

--- a/tests/activity-lazy.spec.mjs
+++ b/tests/activity-lazy.spec.mjs
@@ -13,6 +13,82 @@ const BASE = process.env.MOBIUS_URL || 'http://localhost:8001'
 test.use({ serviceWorkers: 'block', hasTouch: true })
 attachCleanup()
 
+test('the first thinking event becomes interactive without moving the row', async ({ page }) => {
+  await page.setViewportSize({ width: 412, height: 915 })
+  await page.route(/\/api\/chats\/[0-9a-f-]+\/messages$/, route => {
+    if (route.request().method() !== 'POST') return route.fallback()
+    return route.fulfill({ status: 202, contentType: 'application/json', body: '{"status":"started"}' })
+  })
+  await page.route('**/api/chat/stop', route =>
+    route.fulfill({ status: 200, body: '{}' }))
+  await page.route(/\/api\/chats\/[0-9a-f-]+\/stream$/, route =>
+    route.fulfill({ status: 204, body: '' }))
+
+  await page.goto(BASE, { waitUntil: 'domcontentloaded' })
+  await page.waitForFunction(
+    () => !!(document.querySelector('.chat__empty-wrap')
+      || document.querySelector('.chat__scroll')
+      || document.querySelector('.chat__form')),
+    { timeout: 10000 },
+  )
+  const chat = await createTaggedChat(page, 'thinking-handoff')
+  await page.goto(`${BASE}/shell/?chat=${encodeURIComponent(chat.id)}`, {
+    waitUntil: 'domcontentloaded',
+  })
+  await expect(page.locator('.chat__empty-wrap')).toBeVisible({ timeout: 8000 })
+
+  // The empty chat opens one terminal stream before a turn starts. Install
+  // the gated handler only after that mount so the delayed response belongs to
+  // the message below, leaving the real placeholder observable first.
+  let releaseThinking
+  const thinkingGate = new Promise(resolve => { releaseThinking = resolve })
+  let streamCount = 0
+  await page.route(/\/api\/chats\/[0-9a-f-]+\/stream$/, async route => {
+    streamCount += 1
+    if (streamCount > 1) return route.fulfill({ status: 204, body: '' })
+    await thinkingGate
+    return route.fulfill({
+      status: 200,
+      headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
+      body: [
+        `data: ${JSON.stringify({
+          type: 'thinking',
+          content: 'Checking the handoff.',
+          ts: 1700000001000,
+        })}\n\n`,
+        'data: {"type":"done"}\n\n',
+      ].join(''),
+    })
+  })
+
+  await page.getByRole('textbox', { name: 'Message Möbius…' }).fill('Think about this')
+  await page.getByRole('button', { name: 'Send', exact: true }).click()
+  await expect(page.locator('.chat__msg--user')).toBeVisible()
+
+  const placeholder = page.locator('.chat__thinking .chat__activity-header')
+  await expect(placeholder).toBeVisible()
+  await expect(placeholder).not.toHaveAttribute('aria-expanded', /.+/)
+  const before = await placeholder.boundingBox()
+  expect(before).not.toBeNull()
+
+  releaseThinking()
+  const thought = page.locator(
+    '.chat__activity--direct-thought > .chat__activity-header[aria-expanded]',
+  )
+  await expect(thought).toBeVisible()
+  await expect(thought).toHaveAttribute('aria-expanded', 'false')
+  await expect(page.locator('.chat__thinking')).toHaveCount(0)
+  await page.evaluate(() => new Promise(resolve =>
+    requestAnimationFrame(() => requestAnimationFrame(resolve))))
+  const after = await thought.boundingBox()
+  expect(after).not.toBeNull()
+
+  expect(Math.abs(after.x - before.x)).toBeLessThanOrEqual(0.5)
+  expect(Math.abs(after.y - before.y)).toBeLessThanOrEqual(0.5)
+  expect(Math.abs(after.width - before.width)).toBeLessThanOrEqual(0.5)
+  expect(Math.abs(after.height - before.height)).toBeLessThanOrEqual(0.5)
+})
+
 test('a lone activity is direct and sources render as local compact pills', async ({ page }) => {
   await page.setViewportSize({ width: 412, height: 915 })
   const requestedSourceHosts = []


### PR DESCRIPTION
## Summary

- Keep the initial static Thinking placeholder and the first interactive thought on the same shared row geometry.
- Reserve the eventual touch-target height before reasoning content arrives.
- Add source and browser regressions for the placeholder-to-thought handoff.

## Why

A new turn briefly renders a static Thinking placeholder before the first reasoning event. The placeholder used the shared activity header, while a lone thought switched to a padded disclosure row. That changed the row height by 4px on desktop and 20px on touch layouts, causing a visible nudge. The existing structure check only proved that the shared header appeared somewhere in the activity component, not that the direct-thought branch used it.

## Testing

- `npm test` (1,802 tests)
- `npm run build`
- `tests/activity-lazy.spec.mjs` (3 tests)