### PR TITLE
fix(frontend): defer conflicted source builds

### DIFF
--- a/backend/app/frontend_watcher.py
+++ b/backend/app/frontend_watcher.py
@@ -42,6 +42,11 @@ _ROOT_SOURCE_FILES = {
   "index.html", "package-lock.json", "package.json", "vite.config.js",
 }
 _SOURCE_DIRS = {"public", "src"}
+_CONFLICT_SCAN_SUFFIXES = {
+  ".cjs", ".css", ".html", ".js", ".json", ".jsx", ".md", ".mjs",
+  ".svg", ".ts", ".tsx", ".txt", ".webmanifest", ".xml", ".yaml", ".yml",
+}
+_CONFLICT_MARKER_PREFIXES = (b"<<<<<<<", b">>>>>>>")
 _FRONTEND_DIR = Path(os.environ.get(
   "MOBIUS_FRONTEND_DIR", "/data/platform/frontend",
 ))
@@ -116,8 +121,8 @@ def _is_frontend_source_path(path: str | Path) -> bool:
   return bool(rel.parts and rel.parts[0] in _SOURCE_DIRS)
 
 
-def _source_snapshot() -> tuple[str, int]:
-  """Return a cheap source identity and newest input mtime."""
+def _source_paths() -> list[Path]:
+  """Return the files that can affect a frontend build."""
   paths = [
     _FRONTEND_DIR / name for name in sorted(_ROOT_SOURCE_FILES)
     if (_FRONTEND_DIR / name).is_file()
@@ -132,9 +137,14 @@ def _source_snapshot() -> tuple[str, int]:
       and not any(part.startswith(".") or part == "node_modules"
                   for part in path.relative_to(root).parts)
     )
+  return sorted(paths)
+
+
+def _source_snapshot() -> tuple[str, int]:
+  """Return a cheap source identity and newest input mtime."""
   digest = hashlib.sha256()
   newest_ns = 0
-  for path in sorted(paths):
+  for path in _source_paths():
     try:
       stat = path.stat()
       rel = path.relative_to(_FRONTEND_DIR).as_posix()
@@ -143,6 +153,46 @@ def _source_snapshot() -> tuple[str, int]:
     newest_ns = max(newest_ns, stat.st_mtime_ns)
     digest.update(f"{rel}\0{stat.st_size}\0{stat.st_mtime_ns}\n".encode())
   return digest.hexdigest(), newest_ns
+
+
+def _source_conflict_markers() -> tuple[str, ...]:
+  """Return build inputs containing a Git conflict boundary at line start.
+
+  Restrict the scan to text-like inputs so a transient merge conflict is much
+  cheaper to reject than a Vite process, without reading large binary assets
+  under ``public``. Git writes conflict boundaries at column zero; requiring
+  an opener or closer there avoids matching marker text inside source strings.
+  """
+  conflicts: list[str] = []
+  for path in _source_paths():
+    if path.suffix.lower() not in _CONFLICT_SCAN_SUFFIXES:
+      continue
+    try:
+      with path.open("rb") as source:
+        if any(
+          line.startswith(_CONFLICT_MARKER_PREFIXES) for line in source
+        ):
+          conflicts.append(path.relative_to(_FRONTEND_DIR).as_posix())
+    except (OSError, ValueError):
+      # The before/after snapshots below turn ordinary edit races into a cheap
+      # retry. A genuinely unreadable stable input is still reported by Vite.
+      continue
+  return tuple(conflicts)
+
+
+def _stable_source_preflight() -> tuple[str, tuple[str, ...]] | None:
+  """Return a stable source signature and its conflict-marker inputs.
+
+  Files can change while the marker scan is reading them. Do not launch Vite
+  for that indeterminate snapshot; the demand-build loop will debounce and
+  retry it just like any other racing edit.
+  """
+  before, _ = _source_snapshot()
+  conflicts = _source_conflict_markers()
+  after, _ = _source_snapshot()
+  if before != after:
+    return None
+  return after, conflicts
 
 
 def _source_stamp_path() -> Path:
@@ -632,6 +682,7 @@ class _FrontendHandler(FileSystemEventHandler):
     self._build_requested = threading.Event()
     self._last_source_change = 0.0
     self._last_build_reason = "startup"
+    self._blocked_conflict_signature: str | None = None
     self._staging_dirty = False
     self._incomplete_since: float | None = None
     self._incomplete_notified = False
@@ -746,6 +797,10 @@ class _FrontendHandler(FileSystemEventHandler):
   def _request_build(self, reason: str) -> None:
     if reason != "startup" and not _is_frontend_source_path(reason):
       return
+    self._queue_build(reason)
+
+  def _queue_build(self, reason: str) -> None:
+    """Queue a debounced build without applying the filesystem-path filter."""
     if self._closed.is_set():
       return
     with self._state_lock:
@@ -828,7 +883,40 @@ class _FrontendHandler(FileSystemEventHandler):
 
   def _run_demand_build(self, reason: str) -> None:
     """Run one isolated build and publish it before releasing its heap."""
-    source_signature, _ = _source_snapshot()
+    with self._state_lock:
+      blocked_signature = self._blocked_conflict_signature
+    if blocked_signature is not None:
+      current_signature, _ = _source_snapshot()
+      if current_signature == blocked_signature:
+        # The same conflicted snapshot is still present. Stat it cheaply, but
+        # do not reread every text input on each backstop retry.
+        self._queue_build("conflict-marker preflight retry")
+        return
+    preflight = _stable_source_preflight()
+    if preflight is None:
+      self._queue_build("source changed during conflict-marker preflight")
+      return
+    source_signature, conflicts = preflight
+    if conflicts:
+      with self._state_lock:
+        newly_blocked = self._blocked_conflict_signature != source_signature
+        self._blocked_conflict_signature = source_signature
+      if newly_blocked:
+        log.warning(
+          "frontend demand build deferred; conflict markers remain in %s",
+          ", ".join(conflicts),
+        )
+      # Poll the cheap preflight after the normal debounce as a backstop for a
+      # missed/coalesced observer event. Do not make a transient editing state
+      # sticky, and do not emit shell_rebuild_failed while the last good dist
+      # remains served.
+      self._queue_build("conflict-marker preflight retry")
+      return
+    with self._state_lock:
+      conflict_cleared = self._blocked_conflict_signature is not None
+      self._blocked_conflict_signature = None
+    if conflict_cleared:
+      log.info("frontend conflict-marker preflight cleared; resuming build")
     _ensure_node_modules()
     if _STAGING_DIST_DIR.exists():
       shutil.rmtree(_STAGING_DIST_DIR)
@@ -872,6 +960,14 @@ class _FrontendHandler(FileSystemEventHandler):
       raise RuntimeError(detail)
     if output.strip():
       log.info("frontend demand build complete: %s", _tail(output, 1000))
+    current_source_signature, _ = _source_snapshot()
+    if current_source_signature != source_signature:
+      shutil.rmtree(_STAGING_DIST_DIR, ignore_errors=True)
+      log.info(
+        "frontend source changed during demand build; discarding staging",
+      )
+      self._queue_build("source changed during demand build")
+      return
     if not self._refresh_staging_signature():
       raise RuntimeError("vite build completed without a staging generation")
     self._publish_dirty_sync(f"build:{reason}")

--- a/backend/tests/test_frontend_watcher_publish.py
+++ b/backend/tests/test_frontend_watcher_publish.py
@@ -23,6 +23,20 @@ def _write_build(root, marker):
   )
 
 
+class _FakeViteProcess:
+  def __init__(self, complete):
+    self.pid = 12345
+    self.returncode = 0
+    self._complete = complete
+
+  def communicate(self, timeout=None):
+    self._complete()
+    return "vite build complete", None
+
+  def poll(self):
+    return self.returncode
+
+
 @pytest.fixture
 def fw_dirs(tmp_path, monkeypatch):
   frontend = tmp_path / "frontend"
@@ -411,6 +425,171 @@ def test_edit_during_demand_build_requests_one_rerun(fw_dirs, monkeypatch):
     str(fw_dirs["frontend"] / "src" / "first.js"),
     str(fw_dirs["frontend"] / "src" / "second.js"),
   ]
+
+
+def test_conflict_markers_defer_vite_without_touching_generations(
+  fw_dirs, monkeypatch, caplog,
+):
+  src = fw_dirs["frontend"] / "src"
+  src.mkdir()
+  conflicted = src / "SettingsView.jsx"
+  conflicted.write_text(
+    "<<<<<<< HEAD\nexport default 'ours'\n=======\n"
+    "export default 'theirs'\n>>>>>>> incoming\n",
+    encoding="utf-8",
+  )
+  _write_build(fw_dirs["dist"], "served")
+  _write_build(fw_dirs["staging"], "unpublished")
+  events = []
+  marker_scans = 0
+  scan_conflicts = fw._source_conflict_markers
+
+  def counted_marker_scan():
+    nonlocal marker_scans
+    marker_scans += 1
+    return scan_conflicts()
+
+  monkeypatch.setattr(fw, "_publish_system_event", events.append)
+  monkeypatch.setattr(fw, "_source_conflict_markers", counted_marker_scan)
+  monkeypatch.setattr(
+    fw, "_ensure_node_modules",
+    lambda: pytest.fail("marker snapshot must be rejected before setup"),
+  )
+  monkeypatch.setattr(
+    fw.subprocess, "Popen",
+    lambda *args, **kwargs: pytest.fail("marker snapshot must not run Vite"),
+  )
+  monkeypatch.setattr(
+    fw, "_publish_built_dir",
+    lambda *args, **kwargs: pytest.fail("marker snapshot must not publish"),
+  )
+  loop = asyncio.new_event_loop()
+  handler = fw._FrontendHandler(loop, start_threads=False)
+  try:
+    handler._run_demand_build(str(conflicted))
+    handler._run_demand_build("conflict-marker preflight retry")
+
+    assert handler._build_requested.is_set()
+    assert handler._blocked_conflict_signature is not None
+  finally:
+    handler.close()
+    loop.close()
+
+  assert (fw_dirs["dist"] / "assets" / "index-served.js").is_file()
+  assert (
+    fw_dirs["staging"] / "assets" / "index-unpublished.js"
+  ).is_file()
+  assert events == []
+  assert marker_scans == 1
+  assert caplog.text.count("conflict markers remain in src/SettingsView.jsx") == 1
+
+
+def test_conflict_marker_retry_builds_after_resolution_without_observer_event(
+  fw_dirs, monkeypatch,
+):
+  src = fw_dirs["frontend"] / "src"
+  src.mkdir()
+  conflicted = src / "SetupWizard.jsx"
+  conflicted.write_text(
+    "<<<<<<< HEAD\nexport default 1\n=======\n"
+    "export default 2\n>>>>>>> incoming\n",
+    encoding="utf-8",
+  )
+  monkeypatch.setattr(fw, "_DEBOUNCE_SECS", 0.01)
+  monkeypatch.setattr(fw, "_ensure_node_modules", lambda: None)
+  vite_calls = []
+  publish_calls = []
+  events = []
+
+  def popen(*args, **kwargs):
+    vite_calls.append(args)
+    return _FakeViteProcess(
+      lambda: _write_build(fw_dirs["staging"], "resolved"),
+    )
+
+  monkeypatch.setattr(fw.subprocess, "Popen", popen)
+  monkeypatch.setattr(
+    fw, "_publish_built_dir",
+    lambda source, reason: publish_calls.append((source, reason)) or True,
+  )
+  monkeypatch.setattr(fw, "_publish_system_event", events.append)
+  loop = asyncio.new_event_loop()
+  handler = fw._FrontendHandler(loop, start_threads=False)
+  thread = threading.Thread(target=handler._build_loop)
+  try:
+    thread.start()
+    handler._request_build(str(conflicted))
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline:
+      with handler._state_lock:
+        if handler._blocked_conflict_signature is not None:
+          break
+      time.sleep(0.005)
+    else:
+      pytest.fail("conflict snapshot was not deferred")
+
+    # No observer callback follows this edit. The deferred preflight itself
+    # must retain a retry so conflict resolution cannot become sticky.
+    conflicted.write_text("export default 2\n", encoding="utf-8")
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline and not publish_calls:
+      time.sleep(0.005)
+  finally:
+    handler.close()
+    thread.join(timeout=2)
+    loop.close()
+
+  assert len(vite_calls) == 1
+  assert len(publish_calls) == 1
+  assert publish_calls[0][0] == fw_dirs["staging"]
+  assert events == [{"type": "shell_rebuilt"}]
+
+
+def test_source_edit_during_vite_discards_staging_and_requests_rerun(
+  fw_dirs, monkeypatch,
+):
+  src = fw_dirs["frontend"] / "src"
+  src.mkdir()
+  source_file = src / "useStreamConnection.js"
+  source_file.write_text("export default 1\n", encoding="utf-8")
+  monkeypatch.setattr(fw, "_ensure_node_modules", lambda: None)
+  vite_calls = 0
+  publish_calls = []
+
+  def popen(*args, **kwargs):
+    nonlocal vite_calls
+    vite_calls += 1
+
+    def complete():
+      _write_build(fw_dirs["staging"], f"build-{vite_calls}")
+      if vite_calls == 1:
+        source_file.write_text("export default 2222\n", encoding="utf-8")
+
+    return _FakeViteProcess(complete)
+
+  monkeypatch.setattr(fw.subprocess, "Popen", popen)
+  monkeypatch.setattr(
+    fw, "_publish_built_dir",
+    lambda source, reason: publish_calls.append((source, reason)) or True,
+  )
+  monkeypatch.setattr(fw, "_publish_system_event", lambda event: None)
+  loop = asyncio.new_event_loop()
+  handler = fw._FrontendHandler(loop, start_threads=False)
+  try:
+    handler._run_demand_build(str(source_file))
+
+    assert publish_calls == []
+    assert not fw_dirs["staging"].exists()
+    assert handler._build_requested.is_set()
+
+    handler._run_demand_build("source changed during demand build")
+  finally:
+    handler.close()
+    loop.close()
+
+  assert vite_calls == 2
+  assert len(publish_calls) == 1
+  assert publish_calls[0][0] == fw_dirs["staging"]
 
 
 def test_idle_observer_requests_build_for_source_edit(fw_dirs, monkeypatch):


### PR DESCRIPTION
## Summary

- scan text-like frontend build inputs for column-zero Git conflict boundaries before launching the live demand-build Vite process
- debounce and retry blocked snapshots internally, preserving the served and staged generations and resuming even if the resolution event is missed
- discard successful Vite staging when the source signature changed during the build, then queue one coherent rerun
- suppress transient shell failure events while conflict markers remain, while logging the affected relative paths once per blocked signature

## Verification

- `PYTHONPATH=backend backend/.venv/bin/pytest -q backend/tests/test_frontend_watcher_publish.py backend/tests/test_debug_status.py backend/tests/test_generation_serving.py backend/tests/test_routes_init_resilience.py` — 37 passed
- `bash scripts/githooks/pre-push </dev/null` — privacy and syntax gates passed

## Review notes

The guard intentionally applies only to the live demand-build watcher. Explicit/manual one-shot rebuilds retain their existing fail-fast behavior. The scanner is limited to known text-like build input suffixes so repeated blocked-state checks do not read binary public assets.