### PR TITLE
Skip chat session persistence for out-of-band Codex turns

### DIFF
--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -190,9 +190,11 @@ async def _persist_session_id(db, chat_id: str, session_id: str | None) -> None:
   invoking it, so the codex thread id is recorded (and re-sighted idempotently
   on resume) with no second call site. The link record is what survives the
   provider switch / session reset that later NULLs ``Chat.session_id``. Mirrors
-  ``claude_sdk_runner._persist_session_id``.
+  ``claude_sdk_runner._persist_session_id``. Out-of-band callers such as the
+  nightly Reflection runner pass ``db=None`` because their synthetic chat id
+  has no durable Chat row; they must not enter these chat-only write paths.
   """
-  if not chat_id or not session_id:
+  if db is None or not chat_id or not session_id:
     return
   try:
     from app.chat_writer import PersistSessionId, await_ack, get_writer
@@ -1159,7 +1161,8 @@ async def run_codex_sdk_turn(
     pending_questions: Shared AskUserQuestion registry owned by
       chat.py — keyed by chat_id. Used by the request_user_input
       bridge to park on a future while the user answers.
-    db: SQLAlchemy session for runner-side persistence paths.
+    db: SQLAlchemy session for durable-chat persistence paths, or None for an
+      out-of-band turn with no Chat row (for example nightly Reflection).
 
   Returns:
     Dict with `session_id`, `cost_usd`, and `error`.

--- a/backend/tests/test_codex_sdk_runner.py
+++ b/backend/tests/test_codex_sdk_runner.py
@@ -1383,6 +1383,30 @@ def test_persist_session_id_records_codex_link(db):
   assert link.first_seen_at == link.last_seen_at
 
 
+def test_persist_session_id_skips_synthetic_turn_without_db(monkeypatch, caplog):
+  # Reflection invokes the shared Codex runner with a synthetic chat id and no
+  # database session. It has no Chat row to update and must not initialize the
+  # chat writer/session-link stack (which also requires the web app's secrets).
+  from app import chat_writer, session_links
+
+  def fail_writer_lookup():
+    raise AssertionError("synthetic turn must not initialize the chat writer")
+
+  async def fail_link_write(*_args, **_kwargs):
+    raise AssertionError("synthetic turn must not record a chat session link")
+
+  monkeypatch.setattr(chat_writer, "get_writer", fail_writer_lookup)
+  monkeypatch.setattr(session_links, "record_session_link_async", fail_link_write)
+
+  asyncio.run(
+    codex_sdk_runner._persist_session_id(
+      None, "reflection-nightly", "thread-synthetic",
+    )
+  )
+
+  assert "Codex session id persistence failed" not in caplog.text
+
+
 def test_codex_config_overrides_default_pins_agents_namespace(monkeypatch):
   """Multi-agent is on by default AND pins the 'agents' tool namespace so the
   reserved 'collaboration' default (Codex #31864) can never brick a turn."""


### PR DESCRIPTION
## Summary

- treat `db=None` as the existing out-of-band runner boundary
- skip chat-writer and session-link persistence for synthetic Reflection turns
- preserve early session persistence for ordinary durable chats

## Why

The nightly Reflection runner intentionally calls `run_codex_sdk_turn` with `chat_id="reflection-nightly"` and `db=None`. That synthetic id has no `Chat` row, but the shared runner still initialized the chat persistence stack and logged `Codex session id persistence failed` under the cron environment. The model turn still completed, so this was noisy false-failure telemetry rather than a Reflection run failure.

## Tests

- `PYTHONPATH=backend pytest -q backend/tests/test_codex_sdk_runner.py` (43 passed)
- `PYTHONPATH=backend pytest -q backend/tests/test_reflection_runner.py` (51 passed)
- `scripts/check-private-paths.sh HEAD`