### PR TITLE
Prevent stale app interaction state from trapping navigation

### DIFF
--- a/frontend/src/components/AppCanvas/AppCanvas.jsx
+++ b/frontend/src/components/AppCanvas/AppCanvas.jsx
@@ -12,6 +12,7 @@ import {
   readCachedAppToken, removeAppFrameStorage, setAppFrameStorage,
   isSharedVirtualStorageKey,
 } from '../../lib/appFrameStorage.js'
+import { immersiveLifecycleValue } from '../../lib/immersive.js'
 import { getEffectiveTheme } from '../../lib/themeService.js'
 import { readSafeAreaInsets, zeroInsets } from '../../lib/safeAreaInsets.js'
 import { createCapabilityHost } from '../../lib/capabilityHost.js'
@@ -956,28 +957,27 @@ export default function AppCanvas({
     return () => { onNavReset?.(appId) }
   }, [appId, swap.liveVersion, onNavReset])
 
-  // Drive the shell chrome from the VISIBLE frame's recorded immersive intent,
-  // but ONLY while this canvas is the active one. Replays fire on promotion
-  // (swap.liveVersion changes — the promoted frame's real-time post was
-  // withheld while it was hidden, so an immersive game stays immersive across
-  // a rebuild) and on this canvas becoming active (`active` flips true — a
-  // hidden frame's post was withheld too, so returning to the game re-enters
-  // immersive). A hidden canvas never calls with value:true: Shell's holder is
-  // global last-writer-wins and a hidden promotion must not steal chrome from
-  // the app on screen. The cleanup release covers deactivation, swap, and
-  // unmount alike (a torn-down iframe can't run its own cleanup-post; the
-  // recorded intent survives in frameImmersiveRef, so reactivation restores
-  // it). Releasing an app that doesn't hold the slot is a no-op
-  // (lib/immersive.js). Keyed on swap.liveVersion, not the version prop, for
-  // the same reason as the nav reset above (a bump alone must not touch the
-  // live frame).
+  // Real-time immersive messages are forwarded in onMessage above. Lifecycle
+  // replay is intentionally narrower: leaving releases; returning to the same
+  // cached frame does NOT resurrect its old request; only a newly promoted
+  // frame may replay the intent it posted while hidden. This makes the shell's
+  // Exit choice survive app switches while preserving seamless in-place app
+  // updates. The pure helper keeps that policy regression-testable.
+  const immersiveLifecycleRef = useRef(null)
   useEffect(() => {
     if (!appId) return
-    if (active) {
-      onImmersive?.(appId, frameImmersiveRef.current.get(swap.liveVersion) === true)
-    }
-    return () => { onImmersive?.(appId, false) }
+    const current = { appId, liveVersion: swap.liveVersion, active }
+    const value = immersiveLifecycleValue(
+      immersiveLifecycleRef.current,
+      current,
+      frameImmersiveRef.current.get(swap.liveVersion),
+    )
+    immersiveLifecycleRef.current = current
+    if (value !== null) onImmersive?.(appId, value)
   }, [appId, swap.liveVersion, active, onImmersive])
+
+  // Unmount/eviction is a hard release even when no active-state render landed.
+  useEffect(() => () => { onImmersive?.(appId, false) }, [appId, onImmersive])
 
   // Broadcast theme updates to every loaded frame (live + any incoming) so each
   // refreshes its theme without remounting (and losing app state).

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -94,15 +94,17 @@ test('the drag chip is a pointer-transparent fixed layer with a [hidden] guard',
   assert.match(css, /\.workspace__drag-chip\[hidden\]\s*\{\s*display:\s*none/)
 })
 
-test('the drag shield owns the grabbing cursor over the whole viewport', () => {
+test('the drag layer covers the viewport visually but can never block navigation', () => {
   const rule = css.match(/\.workspace__drag-shield\s*\{[\s\S]*?\}/)?.[0] || ''
   assert.match(rule, /position:\s*fixed/)
   assert.match(rule, /inset:\s*0/)
+  assert.match(rule, /pointer-events:\s*none/)
   assert.match(rule, /cursor:\s*grabbing/)
-  // The shield must out-layer the drawer (Drawer.css z-index 90/95) so a
-  // left-edge drag hits the drop zone, never the drawer beneath it.
+  // The visual layer may out-layer the drawer, but pointer capture — not this
+  // transparent DOM node — owns a live drag. An orphaned layer therefore cannot
+  // leave a visible drawer untappable.
   const z = Number(rule.match(/z-index:\s*(\d+)/)?.[1] || 0)
-  assert.ok(z >= 100, `drag shield z-index ${z} must sit above the drawer (95)`)
+  assert.ok(z >= 100, `drag layer z-index ${z} must paint above the drawer (95)`)
 })
 
 test('reduced motion makes the drop preview instant', () => {
@@ -795,10 +797,13 @@ test('the builder preview cannot outlive its drag session past one visibility bo
   assert.match(dragBinding, /document\.removeEventListener\('visibilitychange', onForegroundVisible\)/)
   // (3) NEXT-INTERACTION — a visible->visible steal (partial occlusion / split-screen)
   //     fires NEITHER edge; the next pointerdown reconciles a standing session whose
-  //     pointer is dead (different pointerId + no live capture), then proceeds. A live
-  //     drag keeps its capture, so this never cancels one.
+  //     pointer is dead (no live capture), then proceeds. Pointer identity is NOT a
+  //     liveness signal because mobile reuses ids across sequential gestures. This
+  //     newer boundary needs no old-gesture click guard; adding one would eat the
+  //     fresh tap on the same drawer row. A live drag keeps its capture, so it stays.
   assert.match(dragBinding, /function standingSessionPointerIsLive\(\) \{[\s\S]*?hasPointerCapture\?\.\(activePointerId\)/)
-  assert.match(dragBinding, /if \(e\.pointerId !== activePointerId && !standingSessionPointerIsLive\(\)\) \{[\s\S]*?activeCleanup\(\{ suppressClick: true \}\)/)
+  assert.match(dragBinding, /if \(!standingSessionPointerIsLive\(\)\) \{\s*activeCleanup\(\)/)
+  assert.match(dragBinding, /clearPendingSourceClick\?\.\(\)[\s\S]*?if \(activeCleanup\)/)
   // The invariant now spans one boundary OR one subsequent interaction.
   assert.match(dragBinding, /may outlive its session by at most ONE visibility\/foreground boundary,\s*\n?\s*\/\/ or at most one subsequent user interaction/)
 })

--- a/frontend/src/components/Shell/useWorkspaceDrag.js
+++ b/frontend/src/components/Shell/useWorkspaceDrag.js
@@ -62,6 +62,7 @@ function suppressNextSourceClick(sourceEl) {
   }
   window.addEventListener('click', onClick, true)
   const timer = setTimeout(clear, 400)
+  return clear
 }
 
 export default function useWorkspaceDrag({
@@ -100,6 +101,12 @@ export default function useWorkspaceDrag({
     let activeCleanup = null
     let activePointerId = null
     let activeSrcEl = null
+    // A drag-owned compatibility-click guard belongs to exactly one completed
+    // pointer gesture. A fresh pointerdown is proof that a later owner gesture
+    // has begun, so it must retire any old guard before that gesture's click.
+    // Without this boundary, an interrupted drag followed quickly by a tap on
+    // the same drawer row made the row look dead for up to 400ms.
+    let clearPendingSourceClick = null
 
     function contentBox() {
       return contentElRef.current?.getBoundingClientRect() || { left: 0, top: 0 }
@@ -576,7 +583,10 @@ export default function useWorkspaceDrag({
         removeOverlays()
         // The compat click fires after the shield is already gone; swallow it so
         // a committed drop is exactly one action, not a drop + a tab/row click.
-        if (suppressClick) suppressNextSourceClick(srcEl)
+        if (suppressClick) {
+          clearPendingSourceClick?.()
+          clearPendingSourceClick = suppressNextSourceClick(srcEl)
+        }
         // V6 (vizreview): a CANCELLED drag (Escape / blur / lost-capture) must not
         // leave the drag-origin row wearing its focus ring — blur it so the ring
         // clears with the drag. A committed drop keeps focus (the tab moved).
@@ -617,13 +627,20 @@ export default function useWorkspaceDrag({
 
     // ── Source detection (capture-phase, never preventDefault here) ───────────
     function onPointerDown(e) {
+      // A compatibility click from the previous gesture cannot legitimately
+      // begin with a new pointerdown. Clear its one-shot guard before doing any
+      // stale-session reconciliation so this fresh interaction stays live.
+      clearPendingSourceClick?.()
+      clearPendingSourceClick = null
       if (activeCleanup) {
-        // A session already stands. If THIS is a different pointer and the standing
-        // session's pointer is dead (capture lost — a visible->visible steal), the
-        // session is stale: force-clean it, then fall through to start the new one.
-        // A genuinely live drag keeps its capture, so this never cancels one.
-        if (e.pointerId !== activePointerId && !standingSessionPointerIsLive()) {
-          activeCleanup({ suppressClick: true })
+        // Pointer ids are routinely REUSED across sequential touch gestures
+        // (notably id=1 on mobile). Liveness comes from capture, never identity:
+        // if the standing source no longer owns capture, force-clean it and let
+        // this SAME pointerdown continue into the row it actually targeted.
+        // This boundary is already newer than the abandoned gesture, so arming
+        // a click suppressor here would eat this interaction's own click.
+        if (!standingSessionPointerIsLive()) {
+          activeCleanup()
         } else {
           return // one session at a time
         }
@@ -682,6 +699,7 @@ export default function useWorkspaceDrag({
       window.removeEventListener('pageshow', reconcileStaleSession)
       document.removeEventListener('visibilitychange', onForegroundVisible)
       activeCleanup?.() // tear down an in-flight drag
+      clearPendingSourceClick?.()
       removeOverlays()
     }
     // enabled is a module-load constant and every volatile input arrives through

--- a/frontend/src/components/Shell/workspace.css
+++ b/frontend/src/components/Shell/workspace.css
@@ -520,14 +520,18 @@
 }
 .workspace__drop-preglow.is-on { opacity: 1; }
 
-/* The full-viewport shield: owns the grabbing cursor and blocks iframe hover
-   artifacts while a drag is live. Transparent, so the preview shows through;
-   pointer-events:auto so an app iframe never sees the drag pointer. */
+/* The full-viewport drag layer is VISUAL only. Pointer capture on the source
+   element owns the live stream and keeps iframe hover/touch out of it. Keeping
+   this transparent layer hit-testable created a much worse failure mode: if a
+   mobile browser stole the terminal pointer event, the orphaned layer covered
+   the drawer and the owner's next tap only removed the stale drag instead of
+   opening a destination. A visual layer can never make navigation inert. */
 .workspace__drag-shield {
   position: fixed;
   inset: 0;
   z-index: 250;
   background: transparent;
+  pointer-events: none;
   cursor: grabbing;
 }
 

--- a/frontend/src/lib/__tests__/immersive.test.js
+++ b/frontend/src/lib/__tests__/immersive.test.js
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
 
-import { immersiveReducer, isImmersiveActive } from '../immersive.js'
+import {
+  immersiveLifecycleValue,
+  immersiveReducer,
+  isImmersiveActive,
+} from '../immersive.js'
 
 test('request value:true grants the immersive slot to the app', () => {
   assert.equal(immersiveReducer(null, { type: 'request', appId: 7, value: true }), 7)
@@ -50,4 +54,35 @@ test('immersive application tolerates numeric/string id mismatch', () => {
 
 test('no holder means no immersive regardless of view', () => {
   assert.equal(isImmersiveActive(null, 'canvas', 7), false)
+})
+
+test('leaving an app releases immersive intent', () => {
+  assert.equal(immersiveLifecycleValue(
+    { appId: 7, liveVersion: 'a', active: true },
+    { appId: 7, liveVersion: 'a', active: false },
+    true,
+  ), false)
+})
+
+test('returning to a cached app never resurrects its old immersive request', () => {
+  assert.equal(immersiveLifecycleValue(
+    { appId: 7, liveVersion: 'a', active: false },
+    { appId: 7, liveVersion: 'a', active: true },
+    true,
+  ), null)
+})
+
+test('a live frame promotion replays only the promoted frame intent', () => {
+  const previous = { appId: 7, liveVersion: 'a', active: true }
+  const current = { appId: 7, liveVersion: 'b', active: true }
+  assert.equal(immersiveLifecycleValue(previous, current, true), true)
+  assert.equal(immersiveLifecycleValue(previous, current, false), false)
+})
+
+test('initial mount is driven by the frame message, not a stale replay', () => {
+  assert.equal(immersiveLifecycleValue(
+    null,
+    { appId: 7, liveVersion: 'a', active: true },
+    true,
+  ), null)
 })

--- a/frontend/src/lib/immersive.js
+++ b/frontend/src/lib/immersive.js
@@ -12,10 +12,15 @@
 // The state is the id of the app that currently HOLDS an immersive request,
 // or null. Holding a request is not the same as immersive being APPLIED:
 // application additionally requires that app to be the active canvas (see
-// isImmersiveActive). Keeping request-state per-app means a cached, hidden
-// iframe's request survives an app switch — returning to the game re-enters
-// immersive without the app having to re-post (its iframe never remounted,
-// so it never would).
+// isImmersiveActive).
+//
+// Immersive intent is deliberately SESSIONAL, not sticky navigation state.
+// Leaving an app releases its request, and returning does not resurrect a
+// previously recorded `true`: the app must make a fresh request while it is
+// visible. This makes the owner's shell-level Exit action durable across an
+// app switch and prevents an eager game from repeatedly taking the workspace
+// over merely because its cached iframe stayed mounted. A live frame promotion
+// is the one replay boundary; AppCanvas owns that distinction below.
 
 export function immersiveReducer(immersiveAppId, action) {
   switch (action.type) {
@@ -47,6 +52,32 @@ export function isImmersiveActive(immersiveAppId, activeView, activeAppId) {
   return immersiveAppId != null
     && activeView === 'canvas'
     && sameApp(immersiveAppId, activeAppId)
+}
+
+/**
+ * Decide whether AppCanvas should drive Shell from a lifecycle transition.
+ *
+ * Real-time frame messages are forwarded directly and do not pass through
+ * this helper. Lifecycle replay is narrower:
+ *   - becoming inactive releases the holder;
+ *   - returning to the same cached frame does nothing (no sticky re-entry);
+ *   - promoting a newly loaded frame while continuously active replays that
+ *     new frame's recorded intent, so an in-place app update stays seamless.
+ *
+ * `null` means no callback. A boolean is the value to send to Shell.
+ */
+export function immersiveLifecycleValue(previous, current, recordedIntent) {
+  if (!current?.appId) return null
+  if (!current.active) return false
+
+  const sameCanvas = previous?.appId != null
+    && String(previous.appId) === String(current.appId)
+  const promotedWhileActive = sameCanvas
+    && previous.active === true
+    && previous.liveVersion !== current.liveVersion
+
+  if (!promotedWhileActive) return null
+  return recordedIntent === true
 }
 
 // App ids are numeric from /api/apps but arrive as strings on some paths

--- a/tests/navigation.spec.mjs
+++ b/tests/navigation.spec.mjs
@@ -422,6 +422,100 @@ test.describe('Desktop sidebar navigation', () => {
   })
 })
 
+test.describe('Drawer touch lifecycle', () => {
+  test.use({ hasTouch: true })
+
+  test('an interrupted drawer drag cannot consume the next real row tap', async ({ page }) => {
+    // Enable drawer-row workspace gestures before the shell module evaluates.
+    // This is the production path that creates the full-viewport drag layer.
+    await page.addInitScript(() => {
+      localStorage.setItem('mobius:workspace-splits', '1')
+    })
+    await setup(page, { width: 412, height: 915 })
+    await openDrawer(page)
+
+    const navigation = page.getByRole('navigation', { name: 'Primary navigation' })
+    const beta = navigation.getByRole('button', { name: NAV_CHATS[1].title, exact: true })
+    await expect(beta).toBeVisible()
+
+    // Reproduce the mobile interruption precisely: the row's drag controller
+    // arms and installs its transparent viewport layer, then the browser steals
+    // the terminal pointer event (notification shade/app switch), so no up or
+    // cancel reaches the shell. This used to leave the layer above the drawer.
+    await beta.evaluate((row) => {
+      const box = row.getBoundingClientRect()
+      const start = {
+        bubbles: true,
+        cancelable: true,
+        pointerId: 1,
+        pointerType: 'touch',
+        isPrimary: true,
+        button: 0,
+        clientX: box.left + 40,
+        clientY: box.top + box.height / 2,
+      }
+      row.dispatchEvent(new PointerEvent('pointerdown', start))
+      window.dispatchEvent(new PointerEvent('pointermove', {
+        ...start,
+        clientX: start.clientX + 30,
+      }))
+    })
+    await expect(page.locator('.workspace__drag-shield')).toHaveCount(1)
+    await expect(page.locator('.workspace__drag-shield')).toHaveCSS('pointer-events', 'none')
+
+    // A real touchscreen gesture (not HTMLElement.click) must both reconcile the
+    // abandoned session and activate its row in this SAME interaction. Mobile
+    // browsers commonly reuse pointerId=1, which is why identity cannot stand in
+    // for the old pointer's liveness.
+    const box = await beta.boundingBox()
+    await page.touchscreen.tap(box.x + box.width / 2, box.y + box.height / 2)
+
+    await expect(page.getByRole('button', { name: 'Toggle navigation' }))
+      .toHaveAttribute('aria-expanded', 'false')
+    await expect.poll(() => page.evaluate(() => localStorage.getItem('moebius_active_chat')))
+      .toBe(NAV_CHATS[1].id)
+    await expect(page.locator('.workspace__drag-shield')).toHaveCount(0)
+  })
+
+  test('touch rows recover through both responsive drawer modes', async ({ page }) => {
+    await setup(page, { width: 412, height: 915 })
+    await openDrawer(page)
+
+    // Widening consumes the mobile history sentinel before converting the modal
+    // into a persistent sidebar. `drawer--locked` is deliberately allowed only
+    // during that traversal; it must not survive into the interactive sidebar.
+    await page.setViewportSize({ width: 1280, height: 800 })
+    const drawer = page.locator('#navigation-drawer')
+    await expect(drawer).toHaveClass(/drawer--persistent/)
+    await expect(drawer).not.toHaveClass(/drawer--locked/)
+    await expect(drawer).not.toHaveAttribute('inert', '')
+
+    const navigation = page.getByRole('navigation', { name: 'Primary navigation' })
+    const beta = navigation.getByRole('button', { name: NAV_CHATS[1].title, exact: true })
+    let box = await beta.boundingBox()
+    await page.touchscreen.tap(box.x + box.width / 2, box.y + box.height / 2)
+    await expect.poll(() => page.evaluate(() => localStorage.getItem('moebius_active_chat')))
+      .toBe(NAV_CHATS[1].id)
+
+    // Narrowing returns to a closed modal; one real touch opens it and one real
+    // touch selects a different destination. No desktop interaction lock or
+    // stale sentinel may leak across the reverse transition.
+    await page.setViewportSize({ width: 412, height: 915 })
+    await expect(drawer).not.toHaveClass(/drawer--persistent/)
+    const toggle = page.getByRole('button', { name: 'Toggle navigation' })
+    box = await toggle.boundingBox()
+    await page.touchscreen.tap(box.x + box.width / 2, box.y + box.height / 2)
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true')
+
+    const gamma = navigation.getByRole('button', { name: NAV_CHATS[2].title, exact: true })
+    box = await gamma.boundingBox()
+    await page.touchscreen.tap(box.x + box.width / 2, box.y + box.height / 2)
+    await expect.poll(() => page.evaluate(() => localStorage.getItem('moebius_active_chat')))
+      .toBe(NAV_CHATS[2].id)
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false')
+  })
+})
+
 test.describe('Back button edge cases', () => {
   test('5. Multiple navigations — back pops in LIFO order', async ({ page }) => {
     await setup(page)


### PR DESCRIPTION
## Summary

- make the workspace drag overlay permanently pointer-transparent so an interrupted mobile gesture cannot cover the drawer
- retire stale compatibility-click guards at the next real pointer interaction
- determine drag liveness from pointer capture rather than reusable touch IDs
- release app immersive intent when leaving and never resurrect a cached frame's old request on return
- preserve immersive handoff only when a newly loaded frame is promoted during an active app update
- add touch and navigation regressions for the exact interrupted-drag and stale-immersive cases

## Why

Transient interaction state could outlive the gesture or app view that created it. An interrupted drawer drag could leave an invisible full-screen layer above navigation, and a cached app could silently reapply an old immersive request after the owner had exited it. Both paths now fail safe: stale state cannot block the next destination or retake shell chrome.

## Testing

- focused workspace and immersive tests (80 passed)
- `npm run build`
- the full platform frontend suite and production build passed on the live change