### PR TITLE
Preserve unfinished draft attachments across navigation

### DIFF
--- a/frontend/src/components/ChatView/ChatInputBar.jsx
+++ b/frontend/src/components/ChatView/ChatInputBar.jsx
@@ -69,8 +69,10 @@
  * ╚══════════════════════════════════════════════════════════════════╝
  */
 
-import { useRef, useLayoutEffect } from 'react'
+import { useRef, useState, useEffect, useLayoutEffect } from 'react'
 import { ArrowUp, Mic, DoubleChevronRight } from '@openai/apps-sdk-ui/components/Icon'
+import { BASE } from '../../api/client.js'
+import { mediaTokenParam } from '../../api/mediaToken.js'
 import { resolveComposerEnterAction } from './composerShortcuts.js'
 import { filePasteNeedsDefaultPrevented, pastedFiles } from './pasteUpload.js'
 
@@ -212,12 +214,34 @@ function stripExt(name) {
  *     type badge and the filename below.
  *  The remove `×` is a 20×20 button floating at the card's top-
  *  right corner (half-overlapping outside). */
-function FileChips({ files, onRemove }) {
+function FileChips({ files, onRemove, chatId }) {
+  const [tokenParam, setTokenParam] = useState('')
+  const hasRestoredImage = files?.some(file => (
+    file.mime_type?.startsWith('image/') && !file.objectUrl
+  ))
+
+  useEffect(() => {
+    if (!hasRestoredImage || !chatId) {
+      setTokenParam('')
+      return undefined
+    }
+    let cancelled = false
+    mediaTokenParam(chatId).then(param => {
+      if (!cancelled) setTokenParam(param)
+    })
+    return () => { cancelled = true }
+  }, [chatId, hasRestoredImage])
+
   if (!files?.length) return null
   return (
     <div className="chat__attach-tray">
       {files.map(chip => {
-        const isImage = !!chip.objectUrl
+        const isImage = !!chip.objectUrl || chip.mime_type?.startsWith('image/')
+        const previewSrc = chip.objectUrl || (
+          isImage && tokenParam
+            ? `${BASE}/api/chats/${chatId}/uploads/${encodeURIComponent(chip.name)}${tokenParam}`
+            : ''
+        )
         const cls = classifyFile(chip.name || '')
         const errorMark = chip.status === 'error' ? ' chat__attach-card--error' : ''
         return (
@@ -230,8 +254,10 @@ function FileChips({ files, onRemove }) {
             }
             title={chip.status === 'error' ? chip.error : chip.name}
           >
-            {isImage ? (
-              <img className="chat__attach-card-thumb" src={chip.objectUrl} alt="" />
+            {isImage && previewSrc ? (
+              <img className="chat__attach-card-thumb" src={previewSrc} alt="" />
+            ) : isImage ? (
+              <span className="chat__attach-card-spin" aria-hidden="true" />
             ) : (
               <>
                 <span className={`chat__attach-card-icon chat__attach-card-icon--${cls.kind}`}>
@@ -315,6 +341,7 @@ function FileChips({ files, onRemove }) {
  * The bar's only job: composition + the Send/Stop/Mic resolution.
  */
 export default function ChatInputBar({
+  chatId,
   input,
   onInputChange,
   onSubmit,
@@ -456,7 +483,11 @@ export default function ChatInputBar({
         {leftButtons}
         <div className={`chat__pill${hasFiles ? ' chat__pill--with-attach' : ''}`}>
           {hasFiles && (
-            <FileChips files={pendingFiles} onRemove={onRemoveFile} />
+            <FileChips
+              files={pendingFiles}
+              onRemove={onRemoveFile}
+              chatId={chatId}
+            />
           )}
           <div className="chat__input-line">
             <textarea

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -81,7 +81,7 @@ import {
   saveFailedSendAttempt,
   sendAttemptIsDurable,
 } from './sendAttemptRecovery.js'
-import { persistComposerDraft } from './composerDraft.js'
+import { persistComposerDraft, readComposerDraft } from './composerDraft.js'
 import {
   EMPTY_BUILD_PHASE_RAIL,
   accumulateBuildPhase,
@@ -192,8 +192,8 @@ function readInitialComposer(chatId) {
     const failedAttempt = loadFailedSendAttempt(chatId)
     const pending = sessionStorage.getItem(PENDING_DRAFT_KEY)
     if (pending && failedAttempt) clearFailedSendAttempt(chatId)
-    const saved = sessionStorage.getItem(`draft:${chatId}`) || ''
-    const input = pending || failedAttempt?.text || saved
+    const saved = readComposerDraft(chatId)
+    const input = pending || failedAttempt?.text || saved.input
     const autoSendDraft =
       sessionStorage.getItem(PENDING_DRAFT_AUTOSEND_KEY) ||
       sessionStorage.getItem(`${DRAFT_AUTOSEND_PREFIX}${chatId}`)
@@ -201,7 +201,9 @@ function readInitialComposer(chatId) {
       input,
       autoSend: !!input && autoSendDraft === input,
       failedAttempt: pending ? null : failedAttempt,
-      attachments: pending ? [] : (failedAttempt?.attachments || []),
+      attachments: pending
+        ? []
+        : (failedAttempt?.attachments || saved.attachments),
     }
   } catch {
     return { input: '', autoSend: false, failedAttempt: null, attachments: [] }
@@ -354,12 +356,16 @@ export default function ChatView({
   if (!initialComposerRef.current) {
     initialComposerRef.current = readInitialComposer(chatId)
   }
+  const draftAttachmentsRef = useRef(initialComposerRef.current.attachments)
   const [input, setInputState] = useState(() => initialComposerRef.current.input)
+  const inputValueRef = useRef(input)
+  inputValueRef.current = input
   function setComposerInput(nextInput) {
     // Navigation can unmount this component before React flushes passive
     // effects. Keep every composer transition durable at the state boundary,
     // whether it came from typing, voice, restoration, or send cleanup.
-    persistComposerDraft(chatId, nextInput)
+    inputValueRef.current = nextInput
+    persistComposerDraft(chatId, nextInput, draftAttachmentsRef.current)
     setInputState(nextInput)
   }
   const [sendFailure, setSendFailure] = useState(() => (
@@ -1404,6 +1410,10 @@ export default function ChatView({
   } = useFileUpload({
     chatId,
     initialFiles: initialComposerRef.current.attachments,
+    onFilesChange: nextFiles => {
+      draftAttachmentsRef.current = nextFiles
+      persistComposerDraft(chatId, inputValueRef.current, nextFiles)
+    },
   })
 
   function clearFailedAttempt() {
@@ -1589,7 +1599,7 @@ export default function ChatView({
   // voice transcription, send cleanup). Direct owner edits are saved
   // synchronously in handleComposerInputChange above.
   useEffect(() => {
-    persistComposerDraft(chatId, input)
+    persistComposerDraft(chatId, input, draftAttachmentsRef.current)
   }, [input, chatId])
 
   // Auto-size textarea when a draft is restored. Cap matches the
@@ -3959,6 +3969,7 @@ export default function ChatView({
           </>
         )}
         <ChatInputBar
+          chatId={chatId}
           input={input}
           onInputChange={handleComposerInputChange}
           onSubmit={handleSubmit}

--- a/frontend/src/components/ChatView/__tests__/composerDraft.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerDraft.test.js
@@ -2,7 +2,7 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 
-import { persistComposerDraft } from '../composerDraft.js'
+import { persistComposerDraft, readComposerDraft } from '../composerDraft.js'
 
 function storageStub(initial = {}) {
   const values = new Map(Object.entries(initial))
@@ -24,6 +24,53 @@ test('persists and clears a chat draft synchronously', () => {
   assert.equal(storage.getItem('draft:chat-a'), null)
 })
 
+test('persists uploaded attachments with text and restores a sendable draft', () => {
+  const storage = storageStub()
+  const attachments = [{
+    id: 'local-only',
+    name: 'map.png',
+    size: 1096340,
+    mime_type: 'image/png',
+    objectUrl: 'blob:temporary-and-non-restorable',
+    status: 'done',
+  }]
+
+  assert.equal(
+    persistComposerDraft('chat-map', 'What is this?', attachments, storage),
+    true,
+  )
+  assert.deepEqual(readComposerDraft('chat-map', storage), {
+    input: 'What is this?',
+    attachments: [{
+      name: 'map.png',
+      size: 1096340,
+      mime_type: 'image/png',
+    }],
+  })
+  assert.equal(storage.getItem('draft:chat-map').includes('blob:temporary'), false)
+})
+
+test('keeps legacy plain-text drafts readable', () => {
+  const storage = storageStub({ 'draft:legacy': 'unfinished thought' })
+  assert.deepEqual(readComposerDraft('legacy', storage), {
+    input: 'unfinished thought',
+    attachments: [],
+  })
+})
+
+test('does not restore attachments that never finished uploading', () => {
+  const storage = storageStub()
+  persistComposerDraft('chat-a', 'draft', [
+    { name: 'ready.png', status: 'done', mime_type: 'image/png', size: 1 },
+    { name: 'still-uploading.png', status: 'uploading', mime_type: 'image/png', size: 2 },
+    { name: 'failed.png', status: 'error', mime_type: 'image/png', size: 3 },
+  ], storage)
+  assert.deepEqual(
+    readComposerDraft('chat-a', storage).attachments.map(a => a.name),
+    ['ready.png'],
+  )
+})
+
 test('evicts one draft and retries when session storage is full', () => {
   const storage = storageStub({ 'draft:chat-a': 'older' })
   const normalSet = storage.setItem.bind(storage)
@@ -38,7 +85,7 @@ test('evicts one draft and retries when session storage is full', () => {
     normalSet(key, value)
   }
 
-  assert.equal(persistComposerDraft('chat-b', 'latest', storage), true)
+  assert.equal(persistComposerDraft('chat-b', 'latest', [], storage), true)
   assert.equal(storage.getItem('draft:chat-a'), null)
   assert.equal(storage.getItem('draft:chat-b'), 'latest')
 })
@@ -49,7 +96,7 @@ test('the composer state boundary saves before scheduling React state', () => {
   const end = source.indexOf('\n  }', start)
   const body = source.slice(start, end)
 
-  const save = body.indexOf('persistComposerDraft(chatId, nextInput)')
+  const save = body.indexOf('persistComposerDraft(chatId, nextInput, draftAttachmentsRef.current)')
   const render = body.indexOf('setInputState(nextInput)')
   assert.ok(save >= 0, 'all composer changes must be persisted directly')
   assert.ok(render > save, 'draft persistence must happen before navigation can unmount React')

--- a/frontend/src/components/ChatView/composerDraft.js
+++ b/frontend/src/components/ChatView/composerDraft.js
@@ -3,6 +3,53 @@ function availableStorage(storage) {
   try { return globalThis.sessionStorage ?? null } catch { return null }
 }
 
+const DRAFT_ENVELOPE = 'mobius-composer-draft'
+
+function restorableAttachments(attachments) {
+  if (!Array.isArray(attachments)) return []
+  return attachments
+    .filter(attachment => (
+      attachment
+      && attachment.status !== 'uploading'
+      && attachment.status !== 'error'
+      && typeof attachment.name === 'string'
+      && attachment.name.length > 0
+    ))
+    .map(attachment => ({
+      name: attachment.name,
+      size: Number.isFinite(attachment.size) ? attachment.size : 0,
+      mime_type: typeof attachment.mime_type === 'string'
+        ? attachment.mime_type
+        : 'application/octet-stream',
+    }))
+}
+
+/**
+ * Reads either the current structured draft or a legacy plain-text draft.
+ * Object URLs are deliberately not stored: they stop working when the chat
+ * unmounts. Restored image cards point at the already-uploaded chat file.
+ */
+export function readComposerDraft(chatId, storage) {
+  const target = availableStorage(storage)
+  if (!target || chatId == null) return { input: '', attachments: [] }
+  try {
+    const raw = target.getItem(`draft:${chatId}`)
+    if (!raw) return { input: '', attachments: [] }
+    try {
+      const parsed = JSON.parse(raw)
+      if (parsed?.type === DRAFT_ENVELOPE && parsed.version === 1) {
+        return {
+          input: typeof parsed.input === 'string' ? parsed.input : '',
+          attachments: restorableAttachments(parsed.attachments),
+        }
+      }
+    } catch { /* legacy plain text */ }
+    return { input: raw, attachments: [] }
+  } catch {
+    return { input: '', attachments: [] }
+  }
+}
+
 function evictOneDraft(storage) {
   try {
     const draftKeys = []
@@ -27,20 +74,35 @@ function evictOneDraft(storage) {
  * settling. Synchronous storage here makes the text durable before React gets
  * a chance to remove the composer.
  */
-export function persistComposerDraft(chatId, input, storage) {
-  const target = availableStorage(storage)
+export function persistComposerDraft(chatId, input, attachments = [], storage) {
+  // Backward compatibility for callers of the former
+  // persistComposerDraft(chatId, input, storage) signature.
+  const legacyStorage = !Array.isArray(attachments) && storage === undefined
+    ? attachments
+    : undefined
+  const draftAttachments = Array.isArray(attachments) ? attachments : []
+  const target = availableStorage(storage ?? legacyStorage)
   if (!target || chatId == null) return false
   const key = `draft:${chatId}`
+  const safeAttachments = restorableAttachments(draftAttachments)
+  const value = safeAttachments.length > 0
+    ? JSON.stringify({
+        type: DRAFT_ENVELOPE,
+        version: 1,
+        input: typeof input === 'string' ? input : '',
+        attachments: safeAttachments,
+      })
+    : (typeof input === 'string' ? input : '')
 
   try {
-    if (input) target.setItem(key, input)
+    if (value) target.setItem(key, value)
     else target.removeItem(key)
     return true
   } catch (error) {
     if (error?.name !== 'QuotaExceededError' && error?.code !== 22) return false
     evictOneDraft(target)
     try {
-      if (input) target.setItem(key, input)
+      if (value) target.setItem(key, value)
       else target.removeItem(key)
       return true
     } catch {

--- a/frontend/src/components/ChatView/useFileUpload.js
+++ b/frontend/src/components/ChatView/useFileUpload.js
@@ -14,12 +14,33 @@ import { getAuthHeaders, BASE } from '../../api/client.js'
  *   releaseFiles: (files: Array) => void,
  * }}
  */
-export default function useFileUpload({ chatId, initialFiles = [] }) {
-  const [files, setFiles] = useState(() => initialFiles)
+export default function useFileUpload({ chatId, initialFiles = [], onFilesChange }) {
+  const normalizedInitialFiles = initialFiles.map((file, index) => ({
+    id: file.id || `restored-${index}-${file.name || 'file'}`,
+    name: file.name,
+    size: file.size,
+    mime_type: file.mime_type,
+    objectUrl: file.objectUrl || null,
+    status: file.status || 'done',
+    error: file.error || null,
+  }))
+  const [files, setFiles] = useState(() => normalizedInitialFiles)
   // Keep a ref in sync so the unmount cleanup can revoke object URLs
   // without closing over a stale `files` state value.
   const filesRef = useRef(files)
   filesRef.current = files
+  const onFilesChangeRef = useRef(onFilesChange)
+  onFilesChangeRef.current = onFilesChange
+
+  function commitFiles(nextOrUpdater) {
+    const next = typeof nextOrUpdater === 'function'
+      ? nextOrUpdater(filesRef.current)
+      : nextOrUpdater
+    filesRef.current = next
+    setFiles(next)
+    onFilesChangeRef.current?.(next)
+    return next
+  }
 
   // Revoke any surviving object URLs when the component unmounts —
   // e.g. the user navigated away while files were still staged.
@@ -41,7 +62,7 @@ export default function useFileUpload({ chatId, initialFiles = [] }) {
       status: 'uploading',
       error: null,
     }))
-    setFiles(prev => [...prev, ...newChips])
+    commitFiles(prev => [...prev, ...newChips])
 
     for (let i = 0; i < newChips.length; i++) {
       const chip = newChips[i]
@@ -57,21 +78,21 @@ export default function useFileUpload({ chatId, initialFiles = [] }) {
         })
         if (!res.ok) {
           const msg = await res.text().catch(() => 'Upload failed')
-          setFiles(prev => prev.map(c =>
+          commitFiles(prev => prev.map(c =>
             c.id === chip.id ? { ...c, status: 'error', error: msg } : c
           ))
         } else {
           // Update name from server response (sanitized filename).
           const data = await res.json().catch(() => [])
           const serverName = data?.[0]?.name
-          setFiles(prev => prev.map(c =>
+          commitFiles(prev => prev.map(c =>
             c.id === chip.id
               ? { ...c, status: 'done', ...(serverName ? { name: serverName } : {}) }
               : c
           ))
         }
       } catch (err) {
-        setFiles(prev => prev.map(c =>
+        commitFiles(prev => prev.map(c =>
           c.id === chip.id ? { ...c, status: 'error', error: err.message } : c
         ))
       }
@@ -85,7 +106,7 @@ export default function useFileUpload({ chatId, initialFiles = [] }) {
     // file. Compute the next state first, then apply side effects once.
     const removing = filesRef.current.find(c => c.id === id)
     if (removing?.objectUrl) URL.revokeObjectURL(removing.objectUrl)
-    setFiles(prev => prev.filter(c => c.id !== id))
+    commitFiles(prev => prev.filter(c => c.id !== id))
     if (removing?.status === 'done' && removing.name) {
       fetch(`${BASE}/api/chats/${chatId}/uploads/${encodeURIComponent(removing.name)}`, {
         method: 'DELETE',
@@ -103,14 +124,12 @@ export default function useFileUpload({ chatId, initialFiles = [] }) {
   function clearFiles({ revoke = true } = {}) {
     const current = filesRef.current
     if (revoke) releaseFiles(current)
-    filesRef.current = []
-    setFiles([])
+    commitFiles([])
   }
 
   function restoreFiles(fileList) {
     const restored = Array.isArray(fileList) ? fileList : []
-    filesRef.current = restored
-    setFiles(restored)
+    commitFiles(restored)
   }
 
   return { files, addFiles, removeFile, clearFiles, restoreFiles, releaseFiles }


### PR DESCRIPTION
## Summary

- store completed attachment metadata alongside unfinished composer text
- restore staged files and screenshots when returning to a chat
- keep legacy plain-text drafts readable
- never persist temporary object URLs or incomplete and failed uploads
- reuse the already-uploaded chat file for restored image previews
- keep attachment changes durable at the same synchronous boundary as text changes

## Why

Chat navigation already preserved unfinished text, but it discarded staged attachment metadata. The uploaded file survived, yet returning to the chat showed only the text and a later send could lose the attachment card entirely.

## Testing

- focused draft tests (6 passed)
- `npm run build`
- exact leave-and-reopen flow verified with an uploaded screenshot