### PR TITLE
Contain Codex descendants and custom browser sessions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
 # it before execing the job. docker-compose.yml supplies the three required
 # capabilities absent from Docker's default bounding set.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    cron curl ca-certificates git sudo procps bubblewrap age \
+    cron curl ca-certificates git sudo procps util-linux bubblewrap age \
     libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libcups2 \
     libdrm2 libxkbcommon0 libatspi2.0-0 libxcomposite1 libxdamage1 \
     libxfixes3 libxrandr2 libgbm1 libpango-1.0-0 libcairo2 libasound2t64 \

--- a/backend/app/browser_profiles.py
+++ b/backend/app/browser_profiles.py
@@ -15,6 +15,7 @@ from app import models
 
 
 _CHAT_PROFILE = re.compile(r"^chat-([0-9a-fA-F-]{36})$")
+_BROWSER_SESSION = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 _CACHE_PATHS = (
   "Default/Cache",
   "Default/Code Cache",
@@ -132,6 +133,57 @@ def _active_profile_names(root: Path) -> set[str]:
       except (OSError, RuntimeError):
         pass
   return active
+
+
+def browser_sessions_for_chat(
+  chat_id: str,
+  *,
+  proc_root: Path = Path("/proc"),
+) -> set[str]:
+  """Return live agent-browser session names created by one chat.
+
+  ``AGENT_BROWSER_SESSION=chat-<id>`` gives ordinary invocations a safe
+  inherited name, but an agent can explicitly pass ``--session foo``.  The
+  agent-browser daemon detaches into its own session and preserves the
+  creator's ``CHAT_ID`` plus its resolved ``AGENT_BROWSER_SESSION`` in
+  ``/proc/<pid>/environ``.  Discovering that attribution lets terminal cleanup
+  reclaim custom sessions too instead of leaking their Chromium trees until a
+  container restart.
+
+  Only the agent-browser server binary is considered, and returned names are
+  restricted to the CLI's simple session-name alphabet.  Proc races and
+  permission errors are normal and read as an incomplete, best-effort set.
+  """
+  if not chat_id or not proc_root.is_dir():
+    return set()
+  try:
+    processes = list(proc_root.iterdir())
+  except OSError:
+    return set()
+
+  sessions: set[str] = set()
+  for process in processes:
+    if not process.name.isdigit():
+      continue
+    try:
+      argv = (process / "cmdline").read_bytes().split(b"\0")
+      executable = Path(argv[0].decode("utf-8", errors="replace")).name
+      if executable != "agent-browser-linux-x64":
+        continue
+      values = {}
+      for raw in (process / "environ").read_bytes().split(b"\0"):
+        key, separator, value = raw.partition(b"=")
+        if separator and key in (b"CHAT_ID", b"AGENT_BROWSER_SESSION"):
+          values[key] = value.decode("utf-8", errors="replace")
+    except OSError:
+      continue
+    session = values.get(b"AGENT_BROWSER_SESSION", "")
+    if (
+      values.get(b"CHAT_ID") == chat_id
+      and _BROWSER_SESSION.fullmatch(session) is not None
+    ):
+      sessions.add(session)
+  return sessions
 
 
 def chat_activity_snapshot(db: Session) -> dict[str, dict]:

--- a/backend/app/browser_profiles.py
+++ b/backend/app/browser_profiles.py
@@ -15,7 +15,6 @@ from app import models
 
 
 _CHAT_PROFILE = re.compile(r"^chat-([0-9a-fA-F-]{36})$")
-_BROWSER_SESSION = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 _CACHE_PATHS = (
   "Default/Cache",
   "Default/Code Cache",
@@ -41,6 +40,25 @@ _status = {
   "cache_dirs_pruned": 0,
   "profiles_pruned": 0,
 }
+
+
+def browser_session_is_safely_closable(session: str) -> bool:
+  """Whether a discovered name is safe to pass as one CLI argv value.
+
+  Treat the daemon's ``AGENT_BROWSER_SESSION`` as an opaque value: Unicode,
+  colons, spaces, and values longer than 128 characters are not dangerous here.
+  Cleanup uses
+  ``create_subprocess_exec`` with an argv list, never a shell or a constructed
+  path.  Reject only values that can be interpreted as an option/path by the
+  downstream CLI, plus control characters that do not form a useful session
+  name.  There is no arbitrary length cap: the value already exists in a live
+  process environment, so it necessarily fit the host's exec/env limit.
+  """
+  if not isinstance(session, str) or not session or session.startswith("-"):
+    return False
+  if session in (".", "..") or "/" in session or "\\" in session:
+    return False
+  return not any(ord(char) < 0x20 or ord(char) == 0x7F for char in session)
 
 
 def _env_int(name: str, default: int) -> int:
@@ -150,9 +168,8 @@ def browser_sessions_for_chat(
   reclaim custom sessions too instead of leaking their Chromium trees until a
   container restart.
 
-  Only the agent-browser server binary is considered, and returned names are
-  restricted to the CLI's simple session-name alphabet.  Proc races and
-  permission errors are normal and read as an incomplete, best-effort set.
+  Only the agent-browser server binary is considered. Proc races and permission
+  errors are normal and read as an incomplete, best-effort set.
   """
   if not chat_id or not proc_root.is_dir():
     return set()
@@ -180,7 +197,7 @@ def browser_sessions_for_chat(
     session = values.get(b"AGENT_BROWSER_SESSION", "")
     if (
       values.get(b"CHAT_ID") == chat_id
-      and _BROWSER_SESSION.fullmatch(session) is not None
+      and browser_session_is_safely_closable(session)
     ):
       sessions.add(session)
   return sessions

--- a/backend/app/browser_profiles.py
+++ b/backend/app/browser_profiles.py
@@ -6,6 +6,7 @@ import os
 import re
 import shutil
 import time
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -42,23 +43,13 @@ _status = {
 }
 
 
-def browser_session_is_safely_closable(session: str) -> bool:
-  """Whether a discovered name is safe to pass as one CLI argv value.
+@dataclass(frozen=True)
+class BrowserSessionTarget:
+  """Opaque routing identity retained by one agent-browser daemon."""
 
-  Treat the daemon's ``AGENT_BROWSER_SESSION`` as an opaque value: Unicode,
-  colons, spaces, and values longer than 128 characters are not dangerous here.
-  Cleanup uses
-  ``create_subprocess_exec`` with an argv list, never a shell or a constructed
-  path.  Reject only values that can be interpreted as an option/path by the
-  downstream CLI, plus control characters that do not form a useful session
-  name.  There is no arbitrary length cap: the value already exists in a live
-  process environment, so it necessarily fit the host's exec/env limit.
-  """
-  if not isinstance(session, str) or not session or session.startswith("-"):
-    return False
-  if session in (".", "..") or "/" in session or "\\" in session:
-    return False
-  return not any(ord(char) < 0x20 or ord(char) == 0x7F for char in session)
+  session: str
+  namespace: str | None = None
+  socket_dir: str | None = None
 
 
 def _env_int(name: str, default: int) -> int:
@@ -153,21 +144,24 @@ def _active_profile_names(root: Path) -> set[str]:
   return active
 
 
-def browser_sessions_for_chat(
+def browser_session_targets_for_chat(
   chat_id: str,
   *,
   proc_root: Path = Path("/proc"),
-) -> set[str]:
-  """Return live agent-browser session names created by one chat.
+) -> set[BrowserSessionTarget]:
+  """Return live agent-browser routing targets created by one chat.
 
   ``AGENT_BROWSER_SESSION=chat-<id>`` gives ordinary invocations a safe
   inherited name, but an agent can explicitly pass ``--session foo``.  The
   agent-browser daemon detaches into its own session and preserves the
-  creator's ``CHAT_ID`` plus its resolved ``AGENT_BROWSER_SESSION`` in
-  ``/proc/<pid>/environ``.  Discovering that attribution lets terminal cleanup
-  reclaim custom sessions too instead of leaking their Chromium trees until a
-  container restart.
+  creator's ``CHAT_ID`` plus its resolved session, namespace, and socket-dir
+  routing in ``/proc/<pid>/environ``. Discovering that complete identity lets
+  terminal cleanup reach custom sessions instead of leaking their Chromium
+  trees until a container restart.
 
+  Routing values are opaque. agent-browser accepts values that look like paths
+  or options; cleanup passes them only through a child environment (never a
+  shell, CLI option value, or path operation), matching the daemon exactly.
   Only the agent-browser server binary is considered. Proc races and permission
   errors are normal and read as an incomplete, best-effort set.
   """
@@ -178,7 +172,7 @@ def browser_sessions_for_chat(
   except OSError:
     return set()
 
-  sessions: set[str] = set()
+  targets: set[BrowserSessionTarget] = set()
   for process in processes:
     if not process.name.isdigit():
       continue
@@ -187,20 +181,26 @@ def browser_sessions_for_chat(
       executable = Path(argv[0].decode("utf-8", errors="replace")).name
       if executable != "agent-browser-linux-x64":
         continue
-      values = {}
+      values: dict[bytes, str] = {}
       for raw in (process / "environ").read_bytes().split(b"\0"):
         key, separator, value = raw.partition(b"=")
-        if separator and key in (b"CHAT_ID", b"AGENT_BROWSER_SESSION"):
-          values[key] = value.decode("utf-8", errors="replace")
+        if separator and key in (
+          b"CHAT_ID",
+          b"AGENT_BROWSER_SESSION",
+          b"AGENT_BROWSER_NAMESPACE",
+          b"AGENT_BROWSER_SOCKET_DIR",
+        ):
+          values[key] = value.decode("utf-8", errors="surrogateescape")
     except OSError:
       continue
-    session = values.get(b"AGENT_BROWSER_SESSION", "")
-    if (
-      values.get(b"CHAT_ID") == chat_id
-      and browser_session_is_safely_closable(session)
-    ):
-      sessions.add(session)
-  return sessions
+    session = values.get(b"AGENT_BROWSER_SESSION")
+    if values.get(b"CHAT_ID") == chat_id and session is not None:
+      targets.add(BrowserSessionTarget(
+        session=session,
+        namespace=values.get(b"AGENT_BROWSER_NAMESPACE"),
+        socket_dir=values.get(b"AGENT_BROWSER_SOCKET_DIR"),
+      ))
+  return targets
 
 
 def chat_activity_snapshot(db: Session) -> dict[str, dict]:

--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -2666,39 +2666,60 @@ async def _drain_and_release(
 
 
 async def _close_browser_session(chat_id: str) -> None:
-  """Close this chat's agent-browser session so Chrome doesn't linger.
+  """Close every agent-browser session created by this chat.
 
   Best-effort: logs and swallows any error so cleanup never blocks a
   chat from completing. agent-browser must be on PATH (installed by the
   Dockerfile); if it's not (e.g. local dev outside the container), the
-  call silently no-ops.
+  call silently no-ops. The inherited ``chat-<id>`` session is always tried;
+  proc attribution also finds explicit ``--session`` names whose detached
+  Chromium trees would otherwise escape terminal cleanup.
   """
   if not chat_id:
     return
   log = _get_logger()
+  sessions = {f"chat-{chat_id}"}
   try:
-    # Bound the subprocess CREATION too, not just the wait below.
-    # This runs on the terminal/cleanup path; an unbounded create_subprocess
-    # (e.g. a wedged event-loop child watcher or fork) would hang the whole
-    # turn's teardown. The wait() is already bounded at 5s; cap creation at
-    # the same budget. On either timeout we just stop waiting and let cleanup
-    # continue — a lingering Chrome is far cheaper than a hung turn.
-    proc = await asyncio.wait_for(
-      asyncio.create_subprocess_exec(
-        "agent-browser", "--session", f"chat-{chat_id}", "close",
-        stdout=asyncio.subprocess.DEVNULL,
-        stderr=asyncio.subprocess.DEVNULL,
-      ),
-      timeout=5.0,
-    )
-    await asyncio.wait_for(proc.wait(), timeout=5.0)
-    log.info("agent-browser session closed chat_id=%s", chat_id)
-  except FileNotFoundError:
-    pass  # agent-browser not installed (local dev)
-  except asyncio.TimeoutError:
-    log.warning("agent-browser close timed out for chat %s", chat_id)
+    from app.browser_profiles import browser_sessions_for_chat
+    sessions.update(await asyncio.to_thread(
+      browser_sessions_for_chat, chat_id,
+    ))
   except Exception as exc:
-    log.warning("agent-browser close failed for chat %s: %s", chat_id, exc)
+    log.warning(
+      "agent-browser session discovery failed for chat %s: %s",
+      chat_id,
+      exc,
+    )
+
+  async def close_one(session: str) -> bool:
+    try:
+      # Bound subprocess CREATION too, not just the wait. Custom sessions close
+      # concurrently, so one wedged CLI adds at most this single 10s budget to
+      # terminal teardown rather than one budget per leaked browser.
+      proc = await asyncio.wait_for(
+        asyncio.create_subprocess_exec(
+          "agent-browser", "--session", session, "close",
+          stdout=asyncio.subprocess.DEVNULL,
+          stderr=asyncio.subprocess.DEVNULL,
+        ),
+        timeout=5.0,
+      )
+      await asyncio.wait_for(proc.wait(), timeout=5.0)
+      return True
+    except FileNotFoundError:
+      return False  # agent-browser not installed (local dev)
+    except asyncio.TimeoutError:
+      log.warning("agent-browser close timed out for chat %s", chat_id)
+    except Exception as exc:
+      log.warning("agent-browser close failed for chat %s: %s", chat_id, exc)
+    return False
+
+  results = await asyncio.gather(*(close_one(name) for name in sorted(sessions)))
+  closed = sum(results)
+  if closed:
+    log.info(
+      "agent-browser sessions closed chat_id=%s count=%d", chat_id, closed,
+    )
 
 
 async def _terminal_setup_error_cleanup(

--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -2680,10 +2680,16 @@ async def _close_browser_session(chat_id: str) -> None:
   log = _get_logger()
   sessions = {f"chat-{chat_id}"}
   try:
-    from app.browser_profiles import browser_sessions_for_chat
-    sessions.update(await asyncio.to_thread(
-      browser_sessions_for_chat, chat_id,
-    ))
+    from app.browser_profiles import (
+      browser_session_is_safely_closable,
+      browser_sessions_for_chat,
+    )
+    discovered = await asyncio.to_thread(browser_sessions_for_chat, chat_id)
+    # Defense in depth: discovery already filters these, but keep the exact
+    # argv-safety predicate at the execution boundary too.
+    sessions.update(
+      name for name in discovered if browser_session_is_safely_closable(name)
+    )
   except Exception as exc:
     log.warning(
       "agent-browser session discovery failed for chat %s: %s",
@@ -2704,7 +2710,14 @@ async def _close_browser_session(chat_id: str) -> None:
         ),
         timeout=5.0,
       )
-      await asyncio.wait_for(proc.wait(), timeout=5.0)
+      return_code = await asyncio.wait_for(proc.wait(), timeout=5.0)
+      if return_code != 0:
+        log.warning(
+          "agent-browser close exited nonzero for chat %s: rc=%s",
+          chat_id,
+          return_code,
+        )
+        return False
       return True
     except FileNotFoundError:
       return False  # agent-browser not installed (local dev)

--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -2701,36 +2701,42 @@ async def _close_browser_session(chat_id: str) -> None:
 
   async def terminate_close_process(proc) -> None:
     """Bounded TERM/KILL cleanup for a wedged agent-browser close CLI."""
+    async def wait_for_reap(timeout: float, stage: str | None = None) -> bool:
+      try:
+        await asyncio.wait_for(proc.wait(), timeout=timeout)
+        return True
+      except asyncio.TimeoutError:
+        # A stale/wedged child watcher can fail to publish the return code even
+        # after the OS process is gone. No process state is worth turning this
+        # best-effort terminal cleanup into an unbounded chat teardown.
+        if stage is not None:
+          log.warning(
+            "agent-browser close process did not reap %s for chat %s",
+            stage,
+            chat_id,
+          )
+        return False
+
     if getattr(proc, "returncode", None) is not None:
-      await proc.wait()
+      await wait_for_reap(
+        _BROWSER_CLOSE_KILL_WAIT_TIMEOUT, "after observed exit",
+      )
       return
     try:
       proc.terminate()
     except ProcessLookupError:
-      await proc.wait()
-      return
-    try:
-      await asyncio.wait_for(
-        proc.wait(), timeout=_BROWSER_CLOSE_KILL_GRACE,
+      await wait_for_reap(
+        _BROWSER_CLOSE_KILL_WAIT_TIMEOUT,
+        "after disappearing before SIGTERM",
       )
       return
-    except asyncio.TimeoutError:
-      pass
+    if await wait_for_reap(_BROWSER_CLOSE_KILL_GRACE):
+      return
     try:
       proc.kill()
     except ProcessLookupError:
       pass
-    try:
-      await asyncio.wait_for(
-        proc.wait(), timeout=_BROWSER_CLOSE_KILL_WAIT_TIMEOUT,
-      )
-    except asyncio.TimeoutError:
-      # SIGKILL has already been issued. A wedged child watcher must not turn
-      # this best-effort terminal cleanup into an unbounded chat teardown.
-      log.warning(
-        "agent-browser close process did not reap after SIGKILL for chat %s",
-        chat_id,
-      )
+    await wait_for_reap(_BROWSER_CLOSE_KILL_WAIT_TIMEOUT, "after SIGKILL")
 
   async def close_one(target: BrowserSessionTarget) -> bool:
     proc = None

--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -2668,6 +2668,7 @@ async def _drain_and_release(
 _BROWSER_CLOSE_CREATE_TIMEOUT = 5.0
 _BROWSER_CLOSE_WAIT_TIMEOUT = 5.0
 _BROWSER_CLOSE_KILL_GRACE = 1.0
+_BROWSER_CLOSE_KILL_WAIT_TIMEOUT = 1.0
 
 
 async def _close_browser_session(chat_id: str) -> None:
@@ -2719,7 +2720,17 @@ async def _close_browser_session(chat_id: str) -> None:
       proc.kill()
     except ProcessLookupError:
       pass
-    await proc.wait()
+    try:
+      await asyncio.wait_for(
+        proc.wait(), timeout=_BROWSER_CLOSE_KILL_WAIT_TIMEOUT,
+      )
+    except asyncio.TimeoutError:
+      # SIGKILL has already been issued. A wedged child watcher must not turn
+      # this best-effort terminal cleanup into an unbounded chat teardown.
+      log.warning(
+        "agent-browser close process did not reap after SIGKILL for chat %s",
+        chat_id,
+      )
 
   async def close_one(target: BrowserSessionTarget) -> bool:
     proc = None

--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -2665,6 +2665,11 @@ async def _drain_and_release(
   )
 
 
+_BROWSER_CLOSE_CREATE_TIMEOUT = 5.0
+_BROWSER_CLOSE_WAIT_TIMEOUT = 5.0
+_BROWSER_CLOSE_KILL_GRACE = 1.0
+
+
 async def _close_browser_session(chat_id: str) -> None:
   """Close every agent-browser session created by this chat.
 
@@ -2678,17 +2683,13 @@ async def _close_browser_session(chat_id: str) -> None:
   if not chat_id:
     return
   log = _get_logger()
-  sessions = {f"chat-{chat_id}"}
+  from app.browser_profiles import BrowserSessionTarget
+
+  targets = {BrowserSessionTarget(session=f"chat-{chat_id}")}
   try:
-    from app.browser_profiles import (
-      browser_session_is_safely_closable,
-      browser_sessions_for_chat,
-    )
-    discovered = await asyncio.to_thread(browser_sessions_for_chat, chat_id)
-    # Defense in depth: discovery already filters these, but keep the exact
-    # argv-safety predicate at the execution boundary too.
-    sessions.update(
-      name for name in discovered if browser_session_is_safely_closable(name)
+    from app.browser_profiles import browser_session_targets_for_chat
+    targets.update(
+      await asyncio.to_thread(browser_session_targets_for_chat, chat_id)
     )
   except Exception as exc:
     log.warning(
@@ -2697,20 +2698,64 @@ async def _close_browser_session(chat_id: str) -> None:
       exc,
     )
 
-  async def close_one(session: str) -> bool:
+  async def terminate_close_process(proc) -> None:
+    """Bounded TERM/KILL cleanup for a wedged agent-browser close CLI."""
+    if getattr(proc, "returncode", None) is not None:
+      await proc.wait()
+      return
     try:
+      proc.terminate()
+    except ProcessLookupError:
+      await proc.wait()
+      return
+    try:
+      await asyncio.wait_for(
+        proc.wait(), timeout=_BROWSER_CLOSE_KILL_GRACE,
+      )
+      return
+    except asyncio.TimeoutError:
+      pass
+    try:
+      proc.kill()
+    except ProcessLookupError:
+      pass
+    await proc.wait()
+
+  async def close_one(target: BrowserSessionTarget) -> bool:
+    proc = None
+    try:
+      # Session/namespace/socket-dir are daemon-provided opaque routing values.
+      # Keep them out of argv entirely: a dedicated child environment avoids
+      # shell expansion, option parsing, and path construction in Möbius while
+      # still selecting the exact daemon agent-browser created.
+      child_env = dict(os.environ)
+      for key in (
+        "AGENT_BROWSER_SESSION",
+        "AGENT_BROWSER_NAMESPACE",
+        "AGENT_BROWSER_SOCKET_DIR",
+      ):
+        child_env.pop(key, None)
+      child_env["AGENT_BROWSER_SESSION"] = target.session
+      if target.namespace is not None:
+        child_env["AGENT_BROWSER_NAMESPACE"] = target.namespace
+      if target.socket_dir is not None:
+        child_env["AGENT_BROWSER_SOCKET_DIR"] = target.socket_dir
+
       # Bound subprocess CREATION too, not just the wait. Custom sessions close
       # concurrently, so one wedged CLI adds at most this single 10s budget to
       # terminal teardown rather than one budget per leaked browser.
       proc = await asyncio.wait_for(
         asyncio.create_subprocess_exec(
-          "agent-browser", "--session", session, "close",
+          "agent-browser", "close",
           stdout=asyncio.subprocess.DEVNULL,
           stderr=asyncio.subprocess.DEVNULL,
+          env=child_env,
         ),
-        timeout=5.0,
+        timeout=_BROWSER_CLOSE_CREATE_TIMEOUT,
       )
-      return_code = await asyncio.wait_for(proc.wait(), timeout=5.0)
+      return_code = await asyncio.wait_for(
+        proc.wait(), timeout=_BROWSER_CLOSE_WAIT_TIMEOUT,
+      )
       if return_code != 0:
         log.warning(
           "agent-browser close exited nonzero for chat %s: rc=%s",
@@ -2723,11 +2768,25 @@ async def _close_browser_session(chat_id: str) -> None:
       return False  # agent-browser not installed (local dev)
     except asyncio.TimeoutError:
       log.warning("agent-browser close timed out for chat %s", chat_id)
+      if proc is not None:
+        await asyncio.shield(terminate_close_process(proc))
+    except asyncio.CancelledError:
+      if proc is not None:
+        await asyncio.shield(terminate_close_process(proc))
+      raise
     except Exception as exc:
       log.warning("agent-browser close failed for chat %s: %s", chat_id, exc)
     return False
 
-  results = await asyncio.gather(*(close_one(name) for name in sorted(sessions)))
+  results = await asyncio.gather(*(
+    close_one(target)
+    for target in sorted(
+      targets,
+      key=lambda value: (
+        value.session, value.namespace or "", value.socket_dir or "",
+      ),
+    )
+  ))
   closed = sum(results)
   if closed:
     log.info(

--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -235,6 +235,12 @@ async def _enter_codex_context_owned(
       if enter_task.cancelled():
         break
       deferred_cancel = deferred_cancel or exc
+    except BaseException:
+      # The owned task has reached a terminal failure. Reconcile it below so
+      # a caller cancellation already deferred by this loop takes precedence
+      # over the later startup error instead of leaking that error as a normal
+      # RunnerResult.
+      break
   try:
     entered = enter_task.result()
   except asyncio.CancelledError:
@@ -249,7 +255,14 @@ async def _enter_codex_context_owned(
 
 
 class _EnteredCodexContext:
-  """Delegate exit for an AsyncCodex context whose enter is already owned."""
+  """Own exit for an AsyncCodex context whose enter is already owned.
+
+  The pinned SDK delegates close to ``asyncio.to_thread``. An ordinary await
+  lets a second caller cancellation cancel that awaiter while its worker is
+  still queued or running, allowing process-group reap and runner return to
+  overtake the SDK's direct-child ``wait()``. Keep the complete exit in a
+  runner-owned task and defer every repeated cancellation until it finishes.
+  """
 
   def __init__(self, context: Any, entered: Any) -> None:
     self._context = context
@@ -259,7 +272,41 @@ class _EnteredCodexContext:
     return self._entered
 
   async def __aexit__(self, exc_type, exc, traceback) -> Any:
-    return await self._context.__aexit__(exc_type, exc, traceback)
+    exit_task = asyncio.create_task(
+      self._context.__aexit__(exc_type, exc, traceback)
+    )
+    deferred_cancel: asyncio.CancelledError | None = None
+    while not exit_task.done():
+      try:
+        await asyncio.shield(exit_task)
+      except asyncio.CancelledError as cancel_exc:
+        if exit_task.cancelled():
+          break
+        deferred_cancel = deferred_cancel or cancel_exc
+      except BaseException:
+        # Reconcile the terminal exit failure below. In particular, a caller
+        # cancellation that was already unwinding the context must not be
+        # replaced by a later SDK-close error.
+        break
+    try:
+      result = exit_task.result()
+    except asyncio.CancelledError as exit_cancel:
+      caller_cancel = (
+        exc if isinstance(exc, asyncio.CancelledError) else deferred_cancel
+      )
+      if caller_cancel is not None:
+        raise caller_cancel from exit_cancel
+      raise
+    except BaseException as exit_exc:
+      caller_cancel = (
+        exc if isinstance(exc, asyncio.CancelledError) else deferred_cancel
+      )
+      if caller_cancel is not None:
+        raise caller_cancel from exit_exc
+      raise
+    if deferred_cancel is not None:
+      raise deferred_cancel
+    return result
 
 
 async def _capture_codex_process_group_during_start(

--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -212,6 +212,56 @@ def _codex_process_group_id(
   return pgid
 
 
+async def _enter_codex_context_owned(
+  codex_context: Any,
+) -> tuple[Any, asyncio.CancelledError | None]:
+  """Enter AsyncCodex without abandoning its threaded startup on cancel.
+
+  The pinned SDK implements ``AsyncCodexClient.start()`` with
+  ``asyncio.to_thread(CodexClient.start)``. Cancelling ``__aenter__`` therefore
+  cancels only the awaiter; the worker can continue through ``Popen`` and
+  publish ``_proc`` after the cancelled runner has already returned. Keep the
+  complete enter operation in a runner-owned task, shield it through every
+  caller cancellation, and hand the cancellation back to the caller only once
+  startup has either completed or failed. That keeps PGID capture alive for
+  the entire interval in which the worker can create a process.
+  """
+  enter_task = asyncio.create_task(codex_context.__aenter__())
+  deferred_cancel: asyncio.CancelledError | None = None
+  while not enter_task.done():
+    try:
+      await asyncio.shield(enter_task)
+    except asyncio.CancelledError as exc:
+      if enter_task.cancelled():
+        break
+      deferred_cancel = deferred_cancel or exc
+  try:
+    entered = enter_task.result()
+  except asyncio.CancelledError:
+    if deferred_cancel is not None:
+      raise deferred_cancel
+    raise
+  except BaseException as exc:
+    if deferred_cancel is not None:
+      raise deferred_cancel from exc
+    raise
+  return entered, deferred_cancel
+
+
+class _EnteredCodexContext:
+  """Delegate exit for an AsyncCodex context whose enter is already owned."""
+
+  def __init__(self, context: Any, entered: Any) -> None:
+    self._context = context
+    self._entered = entered
+
+  async def __aenter__(self) -> Any:
+    return self._entered
+
+  async def __aexit__(self, exc_type, exc, traceback) -> Any:
+    return await self._context.__aexit__(exc_type, exc, traceback)
+
+
 async def _capture_codex_process_group_during_start(
   codex: Any,
   stop: asyncio.Event,
@@ -1405,7 +1455,8 @@ async def run_codex_sdk_turn(
     }
 
   try:
-    async with codex_context as codex:
+    codex, entry_cancel = await _enter_codex_context_owned(codex_context)
+    async with _EnteredCodexContext(codex_context, codex) as codex:
       process_group_id = _codex_process_group_id(codex)
       if process_group_capture_stop is not None:
         process_group_capture_stop.set()
@@ -1413,6 +1464,8 @@ async def run_codex_sdk_turn(
       # __aenter__ would propagate through an ordinary await and cancel the
       # task that owns our initialization-failure PGID. The outer finally is
       # its sole joiner and shields that join before reaping the group.
+      if entry_cancel is not None:
+        raise entry_cancel
       # Install AskUserQuestion bridge on the sync CodexClient's
       # approval_handler attribute. `approval_handler` is a public
       # sync-client constructor argument as of openai-codex 0.142.5;

--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -64,6 +64,7 @@ import json
 import logging
 import os
 import re
+import signal
 import shutil
 import time
 from typing import Any, Callable
@@ -146,6 +147,106 @@ def _codex_config_overrides() -> list[str]:
       "suppress_unstable_features_warning=true",
     ]
   return overrides
+
+
+def _codex_app_server_launch_args(
+  codex_bin: str | None,
+  config_overrides: list[str],
+) -> list[str] | None:
+  """Build an app-server command isolated in its own Unix session.
+
+  The Python SDK starts Codex with a plain ``subprocess.Popen`` and, on
+  ``close()``, terminates only that one PID.  Tool commands are descendants of
+  the app-server; if a shell exits while one of its children is still running,
+  that child is re-parented to PID 1 and survives both the tool result and the
+  SDK close.  A memory-hungry survivor can therefore outlive its chat and push
+  the whole platform cgroup into OOM.
+
+  ``setsid`` makes the app-server the leader of a private process group/session
+  without requiring a change in the upstream SDK.  The terminal cleanup below
+  can then signal exactly that group, never uvicorn or another concurrent chat.
+  Return ``None`` outside the Linux/container runtime so local SDK resolution
+  keeps its existing fallback behavior.
+  """
+  setsid_bin = shutil.which("setsid")
+  if not codex_bin or not setsid_bin:
+    return None
+  args = [setsid_bin, codex_bin]
+  for override in config_overrides:
+    args.extend(["--config", override])
+  args.extend(["app-server", "--listen", "stdio://"])
+  return args
+
+
+def _codex_process_group_id(codex: Any) -> int | None:
+  """Return the isolated app-server PGID, or ``None`` if not provable.
+
+  The SDK does not expose its child PID publicly.  We already target its sync
+  client for the documented approval-handler slot, so keep this second private
+  access in one defensive helper.  Refuse a group that is not led by the SDK
+  process: on an old/non-``setsid`` launch that group can be uvicorn's own.
+  """
+  sync_client = getattr(getattr(codex, "_client", None), "_sync", None)
+  proc = getattr(sync_client, "_proc", None)
+  pid = getattr(proc, "pid", None)
+  if not isinstance(pid, int) or pid <= 1:
+    return None
+  try:
+    pgid = os.getpgid(pid)
+  except (OSError, ProcessLookupError):
+    return None
+  if pgid != pid or pgid == os.getpgrp():
+    log.error(
+      "Codex app-server process group is not isolated pid=%s pgid=%s; "
+      "descendant cleanup disabled",
+      pid,
+      pgid,
+    )
+    return None
+  return pgid
+
+
+def _terminate_codex_process_group(
+  pgid: int | None,
+  *,
+  grace_seconds: float = 0.25,
+) -> bool:
+  """Terminate every process left in one completed Codex turn's group.
+
+  Called only after the SDK context has closed its app-server PID.  SIGTERM
+  gives ordinary shell/browser helpers a brief exit window; SIGKILL is the
+  bounded backstop for the exact failure mode this guards (a CPU-heavy child
+  that ignores or never receives its parent's termination).  Returns whether
+  a live group was found.  All failures are best-effort because terminal chat
+  persistence must not fail merely because the OS already reaped the group.
+  """
+  if not isinstance(pgid, int) or pgid <= 1 or pgid == os.getpgrp():
+    return False
+  try:
+    os.killpg(pgid, signal.SIGTERM)
+  except ProcessLookupError:
+    return False
+  except OSError as exc:
+    log.warning("Codex descendant SIGTERM failed pgid=%s: %s", pgid, exc)
+    return False
+
+  deadline = time.monotonic() + max(0.0, grace_seconds)
+  while time.monotonic() < deadline:
+    try:
+      os.killpg(pgid, 0)
+    except ProcessLookupError:
+      return True
+    except OSError:
+      break
+    time.sleep(min(0.025, max(0.0, deadline - time.monotonic())))
+
+  try:
+    os.killpg(pgid, signal.SIGKILL)
+  except ProcessLookupError:
+    pass
+  except OSError as exc:
+    log.warning("Codex descendant SIGKILL failed pgid=%s: %s", pgid, exc)
+  return True
 
 
 class _BridgeError(Exception):
@@ -1229,17 +1330,29 @@ async def run_codex_sdk_turn(
   # config_overrides carries the request_user_input (AskUserQuestion parity) and
   # multi-agent enablement flags — assembled, with the #31864 tool_namespace pin
   # and the MOEBIUS_CODEX_MULTI_AGENT kill switch, in _codex_config_overrides().
-  config = sdk["CodexConfig"](
-    codex_bin=shutil.which("codex"),
+  codex_bin = shutil.which("codex")
+  config_overrides = _codex_config_overrides()
+  launch_args = _codex_app_server_launch_args(codex_bin, config_overrides)
+  config_kwargs: dict[str, Any] = dict(
+    codex_bin=codex_bin,
     cwd=cwd,
     env=env,
-    config_overrides=_codex_config_overrides(),
+    config_overrides=config_overrides,
   )
+  if launch_args is not None:
+    config_kwargs["launch_args_override"] = launch_args
+  else:
+    log.warning(
+      "Codex app-server process-group isolation unavailable; "
+      "descendant cleanup is best-effort only"
+    )
+  config = sdk["CodexConfig"](**config_kwargs)
 
   thread = None
   turn = None
   current_session_id = session_id
   completed_turn: Any | None = None
+  process_group_id: int | None = None
 
   def abort_requested() -> bool:
     return bool(should_abort and should_abort())
@@ -1253,6 +1366,7 @@ async def run_codex_sdk_turn(
 
   try:
     async with sdk["AsyncCodex"](config=config) as codex:
+      process_group_id = _codex_process_group_id(codex)
       # Install AskUserQuestion bridge on the sync CodexClient's
       # approval_handler attribute. `approval_handler` is a public
       # sync-client constructor argument as of openai-codex 0.142.5;
@@ -1541,6 +1655,17 @@ async def run_codex_sdk_turn(
     if isinstance(current, ActiveCodexTurn) and current.turn is turn:
       registry.unregister(chat_id, RunnerKind.CODEX_SDK)
       current.mark_finished()
+    # AsyncCodex.close() terminates only its direct Popen PID.  Reap the
+    # isolated group after that context exit so a tool child cannot be
+    # re-parented to container init and consume CPU/RAM after the turn.  A
+    # worker keeps the short grace period off the FastAPI event loop; shield
+    # ensures task cancellation cannot prevent the SIGKILL backstop from
+    # running in that worker once cleanup has started.
+    if process_group_id is not None:
+      await asyncio.shield(asyncio.to_thread(
+        _terminate_codex_process_group,
+        process_group_id,
+      ))
 
 
 async def steer_into_active_turn(

--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -1384,12 +1384,15 @@ async def run_codex_sdk_turn(
   completed_turn: Any | None = None
   process_group_id: int | None = None
   codex_context = sdk["AsyncCodex"](config=config)
-  process_group_capture_stop = asyncio.Event()
-  process_group_capture_task = asyncio.create_task(
-    _capture_codex_process_group_during_start(
-      codex_context, process_group_capture_stop,
+  process_group_capture_stop: asyncio.Event | None = None
+  process_group_capture_task: asyncio.Task[int | None] | None = None
+  if launch_args is not None:
+    process_group_capture_stop = asyncio.Event()
+    process_group_capture_task = asyncio.create_task(
+      _capture_codex_process_group_during_start(
+        codex_context, process_group_capture_stop,
+      )
     )
-  )
 
   def abort_requested() -> bool:
     return bool(should_abort and should_abort())
@@ -1404,10 +1407,12 @@ async def run_codex_sdk_turn(
   try:
     async with codex_context as codex:
       process_group_id = _codex_process_group_id(codex)
-      process_group_capture_stop.set()
-      captured_during_start = await process_group_capture_task
-      if process_group_id is None:
-        process_group_id = captured_during_start
+      if process_group_capture_stop is not None:
+        process_group_capture_stop.set()
+      # Do NOT await the capture task here. Cancellation immediately after
+      # __aenter__ would propagate through an ordinary await and cancel the
+      # task that owns our initialization-failure PGID. The outer finally is
+      # its sole joiner and shields that join before reaping the group.
       # Install AskUserQuestion bridge on the sync CodexClient's
       # approval_handler attribute. `approval_handler` is a public
       # sync-client constructor argument as of openai-codex 0.142.5;
@@ -1692,13 +1697,31 @@ async def run_codex_sdk_turn(
       "error": str(exc),
     }
   finally:
-    process_group_capture_stop.set()
-    try:
-      captured_during_start = await asyncio.shield(process_group_capture_task)
-      if process_group_id is None:
-        process_group_id = captured_during_start
-    except Exception as exc:
-      log.warning("Codex process-group capture failed: %s", exc)
+    deferred_cancel: asyncio.CancelledError | None = None
+    if process_group_capture_stop is not None:
+      process_group_capture_stop.set()
+    if process_group_capture_task is not None:
+      while not process_group_capture_task.done():
+        try:
+          await asyncio.shield(process_group_capture_task)
+        except asyncio.CancelledError as exc:
+          if process_group_capture_task.cancelled():
+            break
+          # A caller cancellation landed during the shielded join. Keep
+          # waiting for the runner-owned task so initialization-failure cleanup
+          # cannot lose the only observed PGID.
+          deferred_cancel = deferred_cancel or exc
+      try:
+        captured_during_start = process_group_capture_task.result()
+        if process_group_id is None:
+          process_group_id = captured_during_start
+      except asyncio.CancelledError:
+        # A task owned only by this runner should not be cancelled, but a
+        # proven PGID captured synchronously after __aenter__ still permits
+        # safe cleanup. Never let its CancelledError skip that cleanup.
+        log.warning("Codex process-group capture task was cancelled")
+      except Exception as exc:
+        log.warning("Codex process-group capture failed: %s", exc)
     current = registry.get_handle(chat_id, RunnerKind.CODEX_SDK)
     if isinstance(current, ActiveCodexTurn) and current.turn is turn:
       registry.unregister(chat_id, RunnerKind.CODEX_SDK)
@@ -1710,10 +1733,19 @@ async def run_codex_sdk_turn(
     # ensures task cancellation cannot prevent the SIGKILL backstop from
     # running in that worker once cleanup has started.
     if process_group_id is not None:
-      await asyncio.shield(asyncio.to_thread(
-        _terminate_codex_process_group,
-        process_group_id,
+      reap_task = asyncio.create_task(asyncio.to_thread(
+        _terminate_codex_process_group, process_group_id,
       ))
+      while not reap_task.done():
+        try:
+          await asyncio.shield(reap_task)
+        except asyncio.CancelledError as exc:
+          # shield keeps the worker alive. Defer every caller cancellation
+          # until its bounded TERM/KILL sequence has completed.
+          deferred_cancel = deferred_cancel or exc
+      reap_task.result()
+    if deferred_cancel is not None:
+      raise deferred_cancel
 
 
 async def steer_into_active_turn(

--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -178,7 +178,11 @@ def _codex_app_server_launch_args(
   return args
 
 
-def _codex_process_group_id(codex: Any) -> int | None:
+def _codex_process_group_id(
+  codex: Any,
+  *,
+  log_unisolated: bool = True,
+) -> int | None:
   """Return the isolated app-server PGID, or ``None`` if not provable.
 
   The SDK does not expose its child PID publicly.  We already target its sync
@@ -196,6 +200,8 @@ def _codex_process_group_id(codex: Any) -> int | None:
   except (OSError, ProcessLookupError):
     return None
   if pgid != pid or pgid == os.getpgrp():
+    if not log_unisolated:
+      return None
     log.error(
       "Codex app-server process group is not isolated pid=%s pgid=%s; "
       "descendant cleanup disabled",
@@ -204,6 +210,30 @@ def _codex_process_group_id(codex: Any) -> int | None:
     )
     return None
   return pgid
+
+
+async def _capture_codex_process_group_during_start(
+  codex: Any,
+  stop: asyncio.Event,
+) -> int | None:
+  """Capture the isolated PGID while ``AsyncCodex.__aenter__`` initializes.
+
+  ``__aenter__`` starts the subprocess and then performs a separate async SDK
+  initialize request. If that request fails, the SDK closes the direct Popen
+  and clears ``_proc`` before propagating the error. Polling concurrently from
+  before entry captures the group in that window, so the outer runner finally
+  can still reap a descendant the SDK direct-PID close left behind.
+
+  During the tiny pre-exec window the child still has uvicorn's group. The
+  identity helper therefore runs silently until ``setsid`` makes PID == PGID;
+  it never returns or signals the shared group.
+  """
+  while not stop.is_set():
+    pgid = _codex_process_group_id(codex, log_unisolated=False)
+    if pgid is not None:
+      return pgid
+    await asyncio.sleep(0)
+  return _codex_process_group_id(codex, log_unisolated=False)
 
 
 def _terminate_codex_process_group(
@@ -1353,6 +1383,13 @@ async def run_codex_sdk_turn(
   current_session_id = session_id
   completed_turn: Any | None = None
   process_group_id: int | None = None
+  codex_context = sdk["AsyncCodex"](config=config)
+  process_group_capture_stop = asyncio.Event()
+  process_group_capture_task = asyncio.create_task(
+    _capture_codex_process_group_during_start(
+      codex_context, process_group_capture_stop,
+    )
+  )
 
   def abort_requested() -> bool:
     return bool(should_abort and should_abort())
@@ -1365,8 +1402,12 @@ async def run_codex_sdk_turn(
     }
 
   try:
-    async with sdk["AsyncCodex"](config=config) as codex:
+    async with codex_context as codex:
       process_group_id = _codex_process_group_id(codex)
+      process_group_capture_stop.set()
+      captured_during_start = await process_group_capture_task
+      if process_group_id is None:
+        process_group_id = captured_during_start
       # Install AskUserQuestion bridge on the sync CodexClient's
       # approval_handler attribute. `approval_handler` is a public
       # sync-client constructor argument as of openai-codex 0.142.5;
@@ -1651,6 +1692,13 @@ async def run_codex_sdk_turn(
       "error": str(exc),
     }
   finally:
+    process_group_capture_stop.set()
+    try:
+      captured_during_start = await asyncio.shield(process_group_capture_task)
+      if process_group_id is None:
+        process_group_id = captured_during_start
+    except Exception as exc:
+      log.warning("Codex process-group capture failed: %s", exc)
     current = registry.get_handle(chat_id, RunnerKind.CODEX_SDK)
     if isinstance(current, ActiveCodexTurn) and current.turn is turn:
       registry.unregister(chat_id, RunnerKind.CODEX_SDK)

--- a/backend/tests/test_browser_profiles.py
+++ b/backend/tests/test_browser_profiles.py
@@ -219,6 +219,51 @@ def test_terminal_browser_cleanup_kills_timed_out_close_process(monkeypatch):
   assert proc.returncode == -9
 
 
+def test_terminal_browser_cleanup_bounds_wait_after_sigkill(monkeypatch, caplog):
+  monkeypatch.setattr(
+    browser_profiles, "browser_session_targets_for_chat", lambda _chat_id: set(),
+  )
+  monkeypatch.setattr(chat, "_BROWSER_CLOSE_WAIT_TIMEOUT", 0.01)
+  monkeypatch.setattr(chat, "_BROWSER_CLOSE_KILL_GRACE", 0.01)
+  monkeypatch.setattr(chat, "_BROWSER_CLOSE_KILL_WAIT_TIMEOUT", 0.01)
+
+  class NeverReapedProcess:
+    returncode = None
+
+    def __init__(self):
+      self.terminate_calls = 0
+      self.kill_calls = 0
+      self.wait_calls = 0
+
+    async def wait(self):
+      self.wait_calls += 1
+      await asyncio.Future()
+
+    def terminate(self):
+      self.terminate_calls += 1
+
+    def kill(self):
+      self.kill_calls += 1
+
+  proc = NeverReapedProcess()
+
+  async def fake_create_subprocess_exec(*_args, **_kwargs):
+    return proc
+
+  monkeypatch.setattr(
+    chat.asyncio, "create_subprocess_exec", fake_create_subprocess_exec,
+  )
+
+  asyncio.run(asyncio.wait_for(
+    chat._close_browser_session("chat-a"), timeout=0.5,
+  ))
+
+  assert proc.terminate_calls == 1
+  assert proc.kill_calls == 1
+  assert proc.wait_calls == 3
+  assert "did not reap after SIGKILL" in caplog.text
+
+
 def test_quota_prunes_regenerable_cache_before_profile(tmp_path):
   old = "11111111-1111-1111-1111-111111111111"
   profile = _profile(tmp_path, old, cache_bytes=80, durable_bytes=20)

--- a/backend/tests/test_browser_profiles.py
+++ b/backend/tests/test_browser_profiles.py
@@ -54,15 +54,25 @@ def test_profile_sweep_interval_is_hourly_and_bounded(monkeypatch):
   assert browser_profiles.browser_profile_sweep_seconds() == 7200
 
 
-def _fake_browser_process(proc, pid, *, chat_id, session):
+def _fake_browser_process(
+  proc, pid, *, chat_id, session, namespace=None, socket_dir=None,
+):
   process = proc / str(pid)
   process.mkdir(parents=True)
   (process / "cmdline").write_bytes(
     b"/usr/local/lib/agent-browser-linux-x64\0"
   )
-  (process / "environ").write_bytes(
-    f"CHAT_ID={chat_id}\0AGENT_BROWSER_SESSION={session}\0".encode()
-  )
+  values = {
+    "CHAT_ID": chat_id,
+    "AGENT_BROWSER_SESSION": session,
+  }
+  if namespace is not None:
+    values["AGENT_BROWSER_NAMESPACE"] = namespace
+  if socket_dir is not None:
+    values["AGENT_BROWSER_SOCKET_DIR"] = socket_dir
+  (process / "environ").write_bytes("".join(
+    f"{key}={value}\0" for key, value in values.items()
+  ).encode())
 
 
 def test_browser_sessions_for_chat_preserves_opaque_session_values(tmp_path):
@@ -75,6 +85,11 @@ def test_browser_sessions_for_chat_preserves_opaque_session_values(tmp_path):
     proc, 102, chat_id="chat-a", session="unicode-ø-世界",
   )
   _fake_browser_process(proc, 103, chat_id="chat-a", session=long_name)
+  _fake_browser_process(
+    proc, 106, chat_id="chat-a", session="../escape",
+    namespace="custom/ns", socket_dir="/tmp/ab-sockets",
+  )
+  _fake_browser_process(proc, 107, chat_id="chat-a", session="-x")
 
   foreign = proc / "104"
   foreign.mkdir()
@@ -90,35 +105,40 @@ def test_browser_sessions_for_chat_preserves_opaque_session_values(tmp_path):
     b"CHAT_ID=chat-a\0AGENT_BROWSER_SESSION=not-a-browser\0"
   )
 
-  assert browser_profiles.browser_sessions_for_chat(
+  assert browser_profiles.browser_session_targets_for_chat(
     "chat-a", proc_root=proc,
-  ) == {"custom:colon", "unicode-ø-世界", long_name}
-
-
-def test_browser_session_safety_rejects_path_option_and_control_names():
-  safe = browser_profiles.browser_session_is_safely_closable
-  assert safe("custom:colon")
-  assert safe("unicode-ø-世界")
-  assert safe("preview-" + ("x" * 256))
-  assert safe("name with spaces")
-
-  for unsafe in (
-    "", "-x", "--help", ".", "..", "../escape", "safe/../escape",
-    r"..\escape", "line\nbreak", "control\x7f",
-  ):
-    assert not safe(unsafe), unsafe
+  ) == {
+    browser_profiles.BrowserSessionTarget(session="custom:colon"),
+    browser_profiles.BrowserSessionTarget(session="unicode-ø-世界"),
+    browser_profiles.BrowserSessionTarget(session=long_name),
+    browser_profiles.BrowserSessionTarget(
+      session="../escape",
+      namespace="custom/ns",
+      socket_dir="/tmp/ab-sockets",
+    ),
+    browser_profiles.BrowserSessionTarget(session="-x"),
+  }
 
 
 def test_terminal_browser_cleanup_closes_inherited_and_custom_sessions(
   monkeypatch,
 ):
   long_name = "preview-" + ("x" * 256)
+  monkeypatch.setenv("AGENT_BROWSER_NAMESPACE", "stale-parent-namespace")
+  monkeypatch.setenv("AGENT_BROWSER_SOCKET_DIR", "/stale/parent/socket-dir")
   monkeypatch.setattr(
     browser_profiles,
-    "browser_sessions_for_chat",
+    "browser_session_targets_for_chat",
     lambda _chat_id: {
-      "custom:colon", "unicode-ø-世界", long_name,
-      "../escape", "--help",
+      browser_profiles.BrowserSessionTarget(session="custom:colon"),
+      browser_profiles.BrowserSessionTarget(session="unicode-ø-世界"),
+      browser_profiles.BrowserSessionTarget(session=long_name),
+      browser_profiles.BrowserSessionTarget(
+        session="../escape",
+        namespace="custom/ns",
+        socket_dir="/tmp/ab-sockets",
+      ),
+      browser_profiles.BrowserSessionTarget(session="-x"),
     },
   )
   calls = []
@@ -127,8 +147,8 @@ def test_terminal_browser_cleanup_closes_inherited_and_custom_sessions(
     async def wait(self):
       return 0
 
-  async def fake_create_subprocess_exec(*args, **_kwargs):
-    calls.append(args)
+  async def fake_create_subprocess_exec(*args, **kwargs):
+    calls.append((args, kwargs["env"]))
     return FakeProcess()
 
   monkeypatch.setattr(
@@ -139,12 +159,64 @@ def test_terminal_browser_cleanup_closes_inherited_and_custom_sessions(
 
   asyncio.run(chat._close_browser_session("chat-a"))
 
-  assert calls == [
-    ("agent-browser", "--session", "chat-chat-a", "close"),
-    ("agent-browser", "--session", "custom:colon", "close"),
-    ("agent-browser", "--session", long_name, "close"),
-    ("agent-browser", "--session", "unicode-ø-世界", "close"),
-  ]
+  assert all(args == ("agent-browser", "close") for args, _env in calls)
+  routes = {
+    env["AGENT_BROWSER_SESSION"]: env
+    for _args, env in calls
+  }
+  assert set(routes) == {
+    "chat-chat-a", "custom:colon", "unicode-ø-世界", long_name,
+    "../escape", "-x",
+  }
+  assert "AGENT_BROWSER_NAMESPACE" not in routes["chat-chat-a"]
+  assert "AGENT_BROWSER_SOCKET_DIR" not in routes["chat-chat-a"]
+  assert routes["../escape"]["AGENT_BROWSER_NAMESPACE"] == "custom/ns"
+  assert routes["../escape"]["AGENT_BROWSER_SOCKET_DIR"] == "/tmp/ab-sockets"
+
+
+def test_terminal_browser_cleanup_kills_timed_out_close_process(monkeypatch):
+  monkeypatch.setattr(
+    browser_profiles, "browser_session_targets_for_chat", lambda _chat_id: set(),
+  )
+  monkeypatch.setattr(chat, "_BROWSER_CLOSE_WAIT_TIMEOUT", 0.01)
+  monkeypatch.setattr(chat, "_BROWSER_CLOSE_KILL_GRACE", 0.01)
+
+  class WedgedProcess:
+    returncode = None
+
+    def __init__(self):
+      self.terminate_calls = 0
+      self.kill_calls = 0
+      self.wait_calls = 0
+
+    async def wait(self):
+      self.wait_calls += 1
+      if self.kill_calls:
+        self.returncode = -9
+        return self.returncode
+      await asyncio.Future()
+
+    def terminate(self):
+      self.terminate_calls += 1
+
+    def kill(self):
+      self.kill_calls += 1
+
+  proc = WedgedProcess()
+
+  async def fake_create_subprocess_exec(*_args, **_kwargs):
+    return proc
+
+  monkeypatch.setattr(
+    chat.asyncio, "create_subprocess_exec", fake_create_subprocess_exec,
+  )
+
+  asyncio.run(chat._close_browser_session("chat-a"))
+
+  assert proc.terminate_calls == 1
+  assert proc.kill_calls == 1
+  assert proc.wait_calls == 3
+  assert proc.returncode == -9
 
 
 def test_quota_prunes_regenerable_cache_before_profile(tmp_path):

--- a/backend/tests/test_browser_profiles.py
+++ b/backend/tests/test_browser_profiles.py
@@ -54,25 +54,36 @@ def test_profile_sweep_interval_is_hourly_and_bounded(monkeypatch):
   assert browser_profiles.browser_profile_sweep_seconds() == 7200
 
 
-def test_browser_sessions_for_chat_attributes_custom_detached_session(tmp_path):
-  proc = tmp_path / "proc"
-  matching = proc / "101"
-  matching.mkdir(parents=True)
-  (matching / "cmdline").write_bytes(
+def _fake_browser_process(proc, pid, *, chat_id, session):
+  process = proc / str(pid)
+  process.mkdir(parents=True)
+  (process / "cmdline").write_bytes(
     b"/usr/local/lib/agent-browser-linux-x64\0"
   )
-  (matching / "environ").write_bytes(
-    b"CHAT_ID=chat-a\0AGENT_BROWSER_SESSION=custom-preview-3\0"
+  (process / "environ").write_bytes(
+    f"CHAT_ID={chat_id}\0AGENT_BROWSER_SESSION={session}\0".encode()
   )
 
-  foreign = proc / "102"
+
+def test_browser_sessions_for_chat_preserves_opaque_session_values(tmp_path):
+  proc = tmp_path / "proc"
+  long_name = "preview-" + ("x" * 256)
+  _fake_browser_process(
+    proc, 101, chat_id="chat-a", session="custom:colon",
+  )
+  _fake_browser_process(
+    proc, 102, chat_id="chat-a", session="unicode-ø-世界",
+  )
+  _fake_browser_process(proc, 103, chat_id="chat-a", session=long_name)
+
+  foreign = proc / "104"
   foreign.mkdir()
   (foreign / "cmdline").write_bytes(b"/opt/agent-browser-linux-x64\0")
   (foreign / "environ").write_bytes(
     b"CHAT_ID=chat-b\0AGENT_BROWSER_SESSION=foreign-preview\0"
   )
 
-  unrelated = proc / "103"
+  unrelated = proc / "105"
   unrelated.mkdir()
   (unrelated / "cmdline").write_bytes(b"/usr/bin/python3\0")
   (unrelated / "environ").write_bytes(
@@ -81,16 +92,34 @@ def test_browser_sessions_for_chat_attributes_custom_detached_session(tmp_path):
 
   assert browser_profiles.browser_sessions_for_chat(
     "chat-a", proc_root=proc,
-  ) == {"custom-preview-3"}
+  ) == {"custom:colon", "unicode-ø-世界", long_name}
+
+
+def test_browser_session_safety_rejects_path_option_and_control_names():
+  safe = browser_profiles.browser_session_is_safely_closable
+  assert safe("custom:colon")
+  assert safe("unicode-ø-世界")
+  assert safe("preview-" + ("x" * 256))
+  assert safe("name with spaces")
+
+  for unsafe in (
+    "", "-x", "--help", ".", "..", "../escape", "safe/../escape",
+    r"..\escape", "line\nbreak", "control\x7f",
+  ):
+    assert not safe(unsafe), unsafe
 
 
 def test_terminal_browser_cleanup_closes_inherited_and_custom_sessions(
   monkeypatch,
 ):
+  long_name = "preview-" + ("x" * 256)
   monkeypatch.setattr(
     browser_profiles,
     "browser_sessions_for_chat",
-    lambda _chat_id: {"custom-preview-3"},
+    lambda _chat_id: {
+      "custom:colon", "unicode-ø-世界", long_name,
+      "../escape", "--help",
+    },
   )
   calls = []
 
@@ -112,7 +141,9 @@ def test_terminal_browser_cleanup_closes_inherited_and_custom_sessions(
 
   assert calls == [
     ("agent-browser", "--session", "chat-chat-a", "close"),
-    ("agent-browser", "--session", "custom-preview-3", "close"),
+    ("agent-browser", "--session", "custom:colon", "close"),
+    ("agent-browser", "--session", long_name, "close"),
+    ("agent-browser", "--session", "unicode-ø-世界", "close"),
   ]
 
 

--- a/backend/tests/test_browser_profiles.py
+++ b/backend/tests/test_browser_profiles.py
@@ -1,6 +1,7 @@
+import asyncio
 from datetime import UTC, datetime, timedelta
 
-from app import browser_profiles
+from app import browser_profiles, chat
 from app.browser_profiles import enforce_browser_profile_quota
 
 
@@ -51,6 +52,68 @@ def test_profile_sweep_interval_is_hourly_and_bounded(monkeypatch):
   assert browser_profiles.browser_profile_sweep_seconds() == 60
   monkeypatch.setenv("AGENT_BROWSER_PROFILE_SWEEP_SECONDS", "7200")
   assert browser_profiles.browser_profile_sweep_seconds() == 7200
+
+
+def test_browser_sessions_for_chat_attributes_custom_detached_session(tmp_path):
+  proc = tmp_path / "proc"
+  matching = proc / "101"
+  matching.mkdir(parents=True)
+  (matching / "cmdline").write_bytes(
+    b"/usr/local/lib/agent-browser-linux-x64\0"
+  )
+  (matching / "environ").write_bytes(
+    b"CHAT_ID=chat-a\0AGENT_BROWSER_SESSION=custom-preview-3\0"
+  )
+
+  foreign = proc / "102"
+  foreign.mkdir()
+  (foreign / "cmdline").write_bytes(b"/opt/agent-browser-linux-x64\0")
+  (foreign / "environ").write_bytes(
+    b"CHAT_ID=chat-b\0AGENT_BROWSER_SESSION=foreign-preview\0"
+  )
+
+  unrelated = proc / "103"
+  unrelated.mkdir()
+  (unrelated / "cmdline").write_bytes(b"/usr/bin/python3\0")
+  (unrelated / "environ").write_bytes(
+    b"CHAT_ID=chat-a\0AGENT_BROWSER_SESSION=not-a-browser\0"
+  )
+
+  assert browser_profiles.browser_sessions_for_chat(
+    "chat-a", proc_root=proc,
+  ) == {"custom-preview-3"}
+
+
+def test_terminal_browser_cleanup_closes_inherited_and_custom_sessions(
+  monkeypatch,
+):
+  monkeypatch.setattr(
+    browser_profiles,
+    "browser_sessions_for_chat",
+    lambda _chat_id: {"custom-preview-3"},
+  )
+  calls = []
+
+  class FakeProcess:
+    async def wait(self):
+      return 0
+
+  async def fake_create_subprocess_exec(*args, **_kwargs):
+    calls.append(args)
+    return FakeProcess()
+
+  monkeypatch.setattr(
+    chat.asyncio,
+    "create_subprocess_exec",
+    fake_create_subprocess_exec,
+  )
+
+  asyncio.run(chat._close_browser_session("chat-a"))
+
+  assert calls == [
+    ("agent-browser", "--session", "chat-chat-a", "close"),
+    ("agent-browser", "--session", "custom-preview-3", "close"),
+  ]
 
 
 def test_quota_prunes_regenerable_cache_before_profile(tmp_path):

--- a/backend/tests/test_browser_profiles.py
+++ b/backend/tests/test_browser_profiles.py
@@ -264,6 +264,53 @@ def test_terminal_browser_cleanup_bounds_wait_after_sigkill(monkeypatch, caplog)
   assert "did not reap after SIGKILL" in caplog.text
 
 
+def test_terminal_browser_cleanup_bounds_wait_when_process_disappears_before_term(
+  monkeypatch, caplog,
+):
+  monkeypatch.setattr(
+    browser_profiles, "browser_session_targets_for_chat", lambda _chat_id: set(),
+  )
+  monkeypatch.setattr(chat, "_BROWSER_CLOSE_WAIT_TIMEOUT", 0.01)
+  monkeypatch.setattr(chat, "_BROWSER_CLOSE_KILL_WAIT_TIMEOUT", 0.01)
+
+  class GoneWithWedgedWatcher:
+    returncode = None
+
+    def __init__(self):
+      self.terminate_calls = 0
+      self.kill_calls = 0
+      self.wait_calls = 0
+
+    async def wait(self):
+      self.wait_calls += 1
+      await asyncio.Future()
+
+    def terminate(self):
+      self.terminate_calls += 1
+      raise ProcessLookupError
+
+    def kill(self):
+      self.kill_calls += 1
+
+  proc = GoneWithWedgedWatcher()
+
+  async def fake_create_subprocess_exec(*_args, **_kwargs):
+    return proc
+
+  monkeypatch.setattr(
+    chat.asyncio, "create_subprocess_exec", fake_create_subprocess_exec,
+  )
+
+  asyncio.run(asyncio.wait_for(
+    chat._close_browser_session("chat-a"), timeout=0.5,
+  ))
+
+  assert proc.wait_calls == 2
+  assert proc.terminate_calls == 1
+  assert proc.kill_calls == 0
+  assert "did not reap after disappearing before SIGTERM" in caplog.text
+
+
 def test_quota_prunes_regenerable_cache_before_profile(tmp_path):
   old = "11111111-1111-1111-1111-111111111111"
   profile = _profile(tmp_path, old, cache_bytes=80, durable_bytes=20)

--- a/backend/tests/test_codex_sdk_runner.py
+++ b/backend/tests/test_codex_sdk_runner.py
@@ -1553,3 +1553,55 @@ def test_run_codex_sdk_turn_reaps_isolated_descendants(monkeypatch):
 
   assert result["error"] is None
   assert reaped == [4321]
+
+
+def test_run_codex_sdk_turn_reaps_group_when_initialization_fails(monkeypatch):
+  class FakeAsyncCodex:
+    def __init__(self, config=None):
+      self.config = config
+      self._client = SimpleNamespace(
+        _sync=SimpleNamespace(_proc=None, _approval_handler=None),
+      )
+
+    async def __aenter__(self):
+      # Model the pinned SDK's lifecycle: start() publishes _proc, initialize()
+      # yields/fails, and close() clears _proc before __aenter__ re-raises.
+      self._client._sync._proc = SimpleNamespace(pid=4321)
+      await asyncio.sleep(0)
+      self._client._sync._proc = None
+      raise RuntimeError("initialize failed")
+
+    async def __aexit__(self, _exc_type, _exc, _tb):
+      return None
+
+  monkeypatch.setattr(
+    codex_sdk_runner,
+    "_sdk_imports",
+    lambda: _fake_sdk(FakeAsyncCodex),
+  )
+  monkeypatch.setattr(codex_sdk_runner.shutil, "which", lambda name: {
+    "codex": "/usr/local/bin/codex",
+    "setsid": "/usr/bin/setsid",
+  }.get(name))
+  monkeypatch.setattr(codex_sdk_runner.os, "getpgid", lambda _pid: 4321)
+  monkeypatch.setattr(codex_sdk_runner.os, "getpgrp", lambda: 9999)
+  reaped = []
+  monkeypatch.setattr(
+    codex_sdk_runner,
+    "_terminate_codex_process_group",
+    lambda pgid: reaped.append(pgid) or True,
+  )
+
+  result = asyncio.run(codex_sdk_runner.run_codex_sdk_turn(
+    user_message="hello",
+    session_id=None,
+    base_env={},
+    cwd="/tmp",
+    chat_id="chat-init-failure",
+    bc=_FakeBroadcast(),
+    pending_questions={},
+    db=None,
+  ))
+
+  assert "initialize failed" in result["error"]
+  assert reaped == [4321]

--- a/backend/tests/test_codex_sdk_runner.py
+++ b/backend/tests/test_codex_sdk_runner.py
@@ -1605,3 +1605,127 @@ def test_run_codex_sdk_turn_reaps_group_when_initialization_fails(monkeypatch):
 
   assert "initialize failed" in result["error"]
   assert reaped == [4321]
+
+
+def test_run_codex_sdk_turn_cancel_after_entry_still_reaps_group(monkeypatch):
+  class FakeAsyncCodex:
+    def __init__(self, config=None):
+      self.config = config
+      self._client = SimpleNamespace(
+        _sync=SimpleNamespace(
+          _proc=SimpleNamespace(pid=4321),
+          _approval_handler=None,
+        ),
+      )
+
+    async def __aenter__(self):
+      # Deliver cancellation at the first await after entry. The runner must
+      # synchronously retain the PGID and must not cancel its capture-task
+      # ownership while unwinding.
+      asyncio.get_running_loop().call_soon(asyncio.current_task().cancel)
+      return self
+
+    async def __aexit__(self, _exc_type, _exc, _tb):
+      return None
+
+    async def thread_start(self, *_args, **_kwargs):
+      await asyncio.sleep(0)
+      raise AssertionError("cancellation should land before thread start")
+
+  monkeypatch.setattr(
+    codex_sdk_runner,
+    "_sdk_imports",
+    lambda: _fake_sdk(FakeAsyncCodex),
+  )
+  monkeypatch.setattr(codex_sdk_runner.shutil, "which", lambda name: {
+    "codex": "/usr/local/bin/codex",
+    "setsid": "/usr/bin/setsid",
+  }.get(name))
+  monkeypatch.setattr(codex_sdk_runner.os, "getpgid", lambda _pid: 4321)
+  monkeypatch.setattr(codex_sdk_runner.os, "getpgrp", lambda: 9999)
+  reaped = []
+  monkeypatch.setattr(
+    codex_sdk_runner,
+    "_terminate_codex_process_group",
+    lambda pgid: reaped.append(pgid) or True,
+  )
+
+  async def scenario():
+    with pytest.raises(asyncio.CancelledError):
+      await codex_sdk_runner.run_codex_sdk_turn(
+        user_message="hello",
+        session_id=None,
+        base_env={},
+        cwd="/tmp",
+        chat_id="chat-cancel-after-entry",
+        bc=_FakeBroadcast(),
+        pending_questions={},
+        db=None,
+      )
+
+  asyncio.run(scenario())
+
+  assert reaped == [4321]
+
+
+def test_run_codex_sdk_turn_fallback_does_not_start_capture_poller(
+  monkeypatch,
+):
+  completed_turn = SimpleNamespace(id="turn-1", usage=None, error=None)
+  notifications = [
+    SimpleNamespace(
+      method="turn/completed",
+      payload=_FakeTurnCompletedNotification(completed_turn),
+    )
+  ]
+  thread = _FakeThread("thread-1", _FakeTurnHandle(notifications))
+
+  class FakeAsyncCodex:
+    def __init__(self, config=None):
+      self.config = config
+
+    async def __aenter__(self):
+      return self
+
+    async def __aexit__(self, _exc_type, _exc, _tb):
+      return None
+
+    async def thread_start(self, *_args, **_kwargs):
+      return thread
+
+  monkeypatch.setattr(
+    codex_sdk_runner,
+    "_sdk_imports",
+    lambda: _fake_sdk(FakeAsyncCodex),
+  )
+  monkeypatch.setattr(codex_sdk_runner.shutil, "which", lambda name: {
+    "codex": "/usr/local/bin/codex",
+    "setsid": None,
+  }.get(name))
+
+  async def forbidden_poller(*_args, **_kwargs):
+    raise AssertionError("fallback launch must not start PGID polling")
+
+  monkeypatch.setattr(
+    codex_sdk_runner,
+    "_capture_codex_process_group_during_start",
+    forbidden_poller,
+  )
+  monkeypatch.setattr(
+    codex_sdk_runner,
+    "_persist_session_id",
+    lambda *_args, **_kwargs: asyncio.sleep(0),
+  )
+
+  result = asyncio.run(codex_sdk_runner.run_codex_sdk_turn(
+    user_message="hello",
+    session_id=None,
+    base_env={},
+    cwd="/tmp",
+    chat_id="chat-fallback-no-poll",
+    bc=_FakeBroadcast(),
+    pending_questions={},
+    db=None,
+  ))
+
+  assert result["error"] is None

--- a/backend/tests/test_codex_sdk_runner.py
+++ b/backend/tests/test_codex_sdk_runner.py
@@ -1,5 +1,6 @@
 import asyncio
 import signal
+import threading
 from types import SimpleNamespace
 
 import pytest
@@ -1608,6 +1609,8 @@ def test_run_codex_sdk_turn_reaps_group_when_initialization_fails(monkeypatch):
 
 
 def test_run_codex_sdk_turn_cancel_after_entry_still_reaps_group(monkeypatch):
+  owner_task = None
+
   class FakeAsyncCodex:
     def __init__(self, config=None):
       self.config = config
@@ -1622,7 +1625,7 @@ def test_run_codex_sdk_turn_cancel_after_entry_still_reaps_group(monkeypatch):
       # Deliver cancellation at the first await after entry. The runner must
       # synchronously retain the PGID and must not cancel its capture-task
       # ownership while unwinding.
-      asyncio.get_running_loop().call_soon(asyncio.current_task().cancel)
+      asyncio.get_running_loop().call_soon(owner_task.cancel)
       return self
 
     async def __aexit__(self, _exc_type, _exc, _tb):
@@ -1651,6 +1654,8 @@ def test_run_codex_sdk_turn_cancel_after_entry_still_reaps_group(monkeypatch):
   )
 
   async def scenario():
+    nonlocal owner_task
+    owner_task = asyncio.current_task()
     with pytest.raises(asyncio.CancelledError):
       await codex_sdk_runner.run_codex_sdk_turn(
         user_message="hello",
@@ -1662,6 +1667,80 @@ def test_run_codex_sdk_turn_cancel_after_entry_still_reaps_group(monkeypatch):
         pending_questions={},
         db=None,
       )
+
+  asyncio.run(scenario())
+
+  assert reaped == [4321]
+
+
+def test_run_codex_sdk_turn_cancel_during_threaded_start_waits_then_reaps(
+  monkeypatch,
+):
+  """Cancellation cannot outrun the pinned SDK's asyncio.to_thread(start)."""
+  worker_started = threading.Event()
+  release_worker = threading.Event()
+
+  class FakeAsyncCodex:
+    def __init__(self, config=None):
+      self.config = config
+      self._client = SimpleNamespace(
+        _sync=SimpleNamespace(_proc=None, _approval_handler=None),
+      )
+
+    async def __aenter__(self):
+      def threaded_start():
+        worker_started.set()
+        assert release_worker.wait(timeout=2)
+        self._client._sync._proc = SimpleNamespace(pid=4321)
+
+      # Match the pinned SDK: cancelling this await does not stop the worker.
+      await asyncio.to_thread(threaded_start)
+      return self
+
+    async def __aexit__(self, _exc_type, _exc, _tb):
+      self._client._sync._proc = None
+      return None
+
+    async def thread_start(self, *_args, **_kwargs):
+      raise AssertionError("deferred cancellation must land before thread start")
+
+  monkeypatch.setattr(
+    codex_sdk_runner,
+    "_sdk_imports",
+    lambda: _fake_sdk(FakeAsyncCodex),
+  )
+  monkeypatch.setattr(codex_sdk_runner.shutil, "which", lambda name: {
+    "codex": "/usr/local/bin/codex",
+    "setsid": "/usr/bin/setsid",
+  }.get(name))
+  monkeypatch.setattr(codex_sdk_runner.os, "getpgid", lambda _pid: 4321)
+  monkeypatch.setattr(codex_sdk_runner.os, "getpgrp", lambda: 9999)
+  reaped = []
+  monkeypatch.setattr(
+    codex_sdk_runner,
+    "_terminate_codex_process_group",
+    lambda pgid: reaped.append(pgid) or True,
+  )
+
+  async def scenario():
+    task = asyncio.create_task(codex_sdk_runner.run_codex_sdk_turn(
+      user_message="hello",
+      session_id=None,
+      base_env={},
+      cwd="/tmp",
+      chat_id="chat-cancel-during-start",
+      bc=_FakeBroadcast(),
+      pending_questions={},
+      db=None,
+    ))
+    while not worker_started.is_set():
+      await asyncio.sleep(0)
+    task.cancel()
+    await asyncio.sleep(0)
+    assert not task.done()
+    release_worker.set()
+    with pytest.raises(asyncio.CancelledError):
+      await task
 
   asyncio.run(scenario())
 

--- a/backend/tests/test_codex_sdk_runner.py
+++ b/backend/tests/test_codex_sdk_runner.py
@@ -1747,6 +1747,179 @@ def test_run_codex_sdk_turn_cancel_during_threaded_start_waits_then_reaps(
   assert reaped == [4321]
 
 
+@pytest.mark.parametrize("cancel_count", [1, 2, 5])
+def test_run_codex_sdk_turn_start_failure_preserves_deferred_cancellation(
+  monkeypatch, cancel_count,
+):
+  """Caller cancellation wins after owned startup later fails internally."""
+  startup_ready = None
+  release_startup = None
+
+  class FakeAsyncCodex:
+    def __init__(self, config=None):
+      self.config = config
+      self._client = SimpleNamespace(
+        _sync=SimpleNamespace(_proc=None, _approval_handler=None),
+      )
+
+    async def __aenter__(self):
+      self._client._sync._proc = SimpleNamespace(pid=4321)
+      startup_ready.set()
+      await release_startup.wait()
+      # Match an initialize failure after the SDK has closed/forgotten its
+      # direct process. The concurrent capture task is now the only PGID owner.
+      self._client._sync._proc = None
+      raise RuntimeError("initialize failed after caller cancellation")
+
+    async def __aexit__(self, _exc_type, _exc, _tb):
+      raise AssertionError("a failed enter must not invoke __aexit__")
+
+  monkeypatch.setattr(
+    codex_sdk_runner,
+    "_sdk_imports",
+    lambda: _fake_sdk(FakeAsyncCodex),
+  )
+  monkeypatch.setattr(codex_sdk_runner.shutil, "which", lambda name: {
+    "codex": "/usr/local/bin/codex",
+    "setsid": "/usr/bin/setsid",
+  }.get(name))
+  monkeypatch.setattr(codex_sdk_runner.os, "getpgid", lambda _pid: 4321)
+  monkeypatch.setattr(codex_sdk_runner.os, "getpgrp", lambda: 9999)
+  reaped = []
+  monkeypatch.setattr(
+    codex_sdk_runner,
+    "_terminate_codex_process_group",
+    lambda pgid: reaped.append(pgid) or True,
+  )
+
+  async def scenario():
+    nonlocal startup_ready, release_startup
+    startup_ready = asyncio.Event()
+    release_startup = asyncio.Event()
+    task = asyncio.create_task(codex_sdk_runner.run_codex_sdk_turn(
+      user_message="hello",
+      session_id=None,
+      base_env={},
+      cwd="/tmp",
+      chat_id=f"chat-cancel-failed-start-{cancel_count}",
+      bc=_FakeBroadcast(),
+      pending_questions={},
+      db=None,
+    ))
+    await startup_ready.wait()
+    # Let the concurrent PGID watcher observe the published process before the
+    # fake SDK forgets it on initialization failure.
+    await asyncio.sleep(0)
+    for _ in range(cancel_count):
+      task.cancel()
+      await asyncio.sleep(0)
+      assert not task.done()
+    release_startup.set()
+    with pytest.raises(asyncio.CancelledError):
+      await task
+
+  asyncio.run(scenario())
+
+  assert reaped == [4321]
+
+
+@pytest.mark.parametrize("cancel_count", [1, 2, 5])
+def test_run_codex_sdk_turn_waits_for_sdk_exit_before_reap_and_return(
+  monkeypatch, cancel_count,
+):
+  """Repeated cancellation cannot outrun the SDK's threaded close/wait."""
+  body_ready = None
+  close_started = threading.Event()
+  release_close = threading.Event()
+  close_finished = threading.Event()
+  order = []
+
+  class FakeAsyncCodex:
+    def __init__(self, config=None):
+      self.config = config
+      self._client = SimpleNamespace(
+        _sync=SimpleNamespace(
+          _proc=SimpleNamespace(pid=4321),
+          _approval_handler=None,
+        ),
+      )
+
+    async def __aenter__(self):
+      return self
+
+    async def __aexit__(self, _exc_type, _exc, _tb):
+      def close_worker():
+        close_started.set()
+        assert release_close.wait(timeout=5)
+        self._client._sync._proc = None
+        order.append("close")
+        close_finished.set()
+
+      # Match the pinned SDK close path. Cancelling this await must never
+      # abandon either a queued or already-running direct-child wait.
+      await asyncio.to_thread(close_worker)
+      return None
+
+    async def thread_start(self, *_args, **_kwargs):
+      body_ready.set()
+      await asyncio.Future()
+
+  monkeypatch.setattr(
+    codex_sdk_runner,
+    "_sdk_imports",
+    lambda: _fake_sdk(FakeAsyncCodex),
+  )
+  monkeypatch.setattr(codex_sdk_runner.shutil, "which", lambda name: {
+    "codex": "/usr/local/bin/codex",
+    "setsid": "/usr/bin/setsid",
+  }.get(name))
+  monkeypatch.setattr(codex_sdk_runner.os, "getpgid", lambda _pid: 4321)
+  monkeypatch.setattr(codex_sdk_runner.os, "getpgrp", lambda: 9999)
+
+  def reap(pgid):
+    assert pgid == 4321
+    assert close_finished.is_set()
+    order.append("reap")
+    return True
+
+  monkeypatch.setattr(
+    codex_sdk_runner,
+    "_terminate_codex_process_group",
+    reap,
+  )
+
+  async def scenario():
+    nonlocal body_ready
+    body_ready = asyncio.Event()
+    task = asyncio.create_task(codex_sdk_runner.run_codex_sdk_turn(
+      user_message="hello",
+      session_id=None,
+      base_env={},
+      cwd="/tmp",
+      chat_id=f"chat-cancel-sdk-exit-{cancel_count}",
+      bc=_FakeBroadcast(),
+      pending_questions={},
+      db=None,
+    ))
+    await body_ready.wait()
+    task.cancel()
+    assert await asyncio.to_thread(close_started.wait, 2)
+    for _ in range(cancel_count - 1):
+      task.cancel()
+      await asyncio.sleep(0)
+    assert not task.done()
+    assert not close_finished.is_set()
+    assert order == []
+    release_close.set()
+    with pytest.raises(asyncio.CancelledError):
+      await task
+
+  asyncio.run(scenario())
+
+  assert close_finished.is_set()
+  assert order == ["close", "reap"]
+
+
 def test_run_codex_sdk_turn_fallback_does_not_start_capture_poller(
   monkeypatch,
 ):

--- a/backend/tests/test_codex_sdk_runner.py
+++ b/backend/tests/test_codex_sdk_runner.py
@@ -1,4 +1,5 @@
 import asyncio
+import signal
 from types import SimpleNamespace
 
 import pytest
@@ -1425,3 +1426,130 @@ def test_codex_config_overrides_kill_switch(monkeypatch):
   ov = runner._codex_config_overrides()
   assert ov == ["features.default_mode_request_user_input=true"]
   assert not any("multi_agent_v2" in o for o in ov)
+
+
+def test_codex_app_server_launch_args_preserve_overrides_under_setsid(
+  monkeypatch,
+):
+  paths = {
+    "setsid": "/usr/bin/setsid",
+  }
+  monkeypatch.setattr(
+    codex_sdk_runner.shutil,
+    "which",
+    lambda name: paths.get(name),
+  )
+
+  args = codex_sdk_runner._codex_app_server_launch_args(
+    "/usr/local/bin/codex",
+    ["feature.one=true", "feature.two=false"],
+  )
+
+  assert args == [
+    "/usr/bin/setsid",
+    "/usr/local/bin/codex",
+    "--config",
+    "feature.one=true",
+    "--config",
+    "feature.two=false",
+    "app-server",
+    "--listen",
+    "stdio://",
+  ]
+
+
+def test_codex_process_group_id_refuses_shared_uvicorn_group(monkeypatch):
+  codex = SimpleNamespace(
+    _client=SimpleNamespace(
+      _sync=SimpleNamespace(_proc=SimpleNamespace(pid=4321)),
+    ),
+  )
+  monkeypatch.setattr(codex_sdk_runner.os, "getpgid", lambda _pid: 4000)
+  monkeypatch.setattr(codex_sdk_runner.os, "getpgrp", lambda: 4000)
+
+  assert codex_sdk_runner._codex_process_group_id(codex) is None
+
+
+def test_terminate_codex_process_group_has_sigkill_backstop(monkeypatch):
+  calls = []
+  monkeypatch.setattr(codex_sdk_runner.os, "getpgrp", lambda: 9999)
+  monkeypatch.setattr(
+    codex_sdk_runner.os,
+    "killpg",
+    lambda pgid, sig: calls.append((pgid, sig)),
+  )
+
+  assert codex_sdk_runner._terminate_codex_process_group(
+    4321, grace_seconds=0,
+  ) is True
+  assert calls == [
+    (4321, signal.SIGTERM),
+    (4321, signal.SIGKILL),
+  ]
+
+
+def test_run_codex_sdk_turn_reaps_isolated_descendants(monkeypatch):
+  completed_turn = SimpleNamespace(id="turn-1", usage=None, error=None)
+  notifications = [
+    SimpleNamespace(
+      method="turn/completed",
+      payload=_FakeTurnCompletedNotification(completed_turn),
+    )
+  ]
+  thread = _FakeThread("thread-1", _FakeTurnHandle(notifications))
+
+  class FakeAsyncCodex:
+    def __init__(self, config=None):
+      self.config = config
+      self._client = SimpleNamespace(
+        _sync=SimpleNamespace(
+          _proc=SimpleNamespace(pid=4321),
+          _approval_handler=None,
+        ),
+      )
+
+    async def __aenter__(self):
+      return self
+
+    async def __aexit__(self, _exc_type, _exc, _tb):
+      return None
+
+    async def thread_start(self, *_args, **_kwargs):
+      return thread
+
+  monkeypatch.setattr(
+    codex_sdk_runner,
+    "_sdk_imports",
+    lambda: _fake_sdk(FakeAsyncCodex),
+  )
+  monkeypatch.setattr(codex_sdk_runner.shutil, "which", lambda name: {
+    "codex": "/usr/local/bin/codex",
+    "setsid": "/usr/bin/setsid",
+  }.get(name))
+  monkeypatch.setattr(codex_sdk_runner.os, "getpgid", lambda _pid: 4321)
+  monkeypatch.setattr(codex_sdk_runner.os, "getpgrp", lambda: 9999)
+  reaped = []
+  monkeypatch.setattr(
+    codex_sdk_runner,
+    "_terminate_codex_process_group",
+    lambda pgid: reaped.append(pgid) or True,
+  )
+  monkeypatch.setattr(
+    codex_sdk_runner,
+    "_persist_session_id",
+    lambda *_args, **_kwargs: asyncio.sleep(0),
+  )
+
+  result = asyncio.run(codex_sdk_runner.run_codex_sdk_turn(
+    user_message="hello",
+    session_id=None,
+    base_env={},
+    cwd="/tmp",
+    chat_id="chat-process-group",
+    bc=_FakeBroadcast(),
+    pending_questions={},
+    db=None,
+  ))
+
+  assert result["error"] is None
+  assert reaped == [4321]


### PR DESCRIPTION
## Summary
- launch each Codex app-server in its own Unix session/process group and reap the group after SDK teardown
- preserve all existing Codex config overrides when using the isolated launch command
- discover detached agent-browser daemons by inherited `CHAT_ID` and close custom `--session` names alongside the default per-chat session
- explicitly install `util-linux` for the `setsid` runtime invariant

## Production finding
The SDK currently uses plain `Popen` and closes only its direct app-server PID. Its descendants share uvicorn's process group; a shell/tool child that survives its parent is reparented to container init and no later turn cleanup owns it. Separately, agent-browser daemons detach into their own sessions. The ordinary inherited session is closed at terminal turn, but explicit session names bypass that cleanup and retain a full Chromium tree.

On the affected container, cgroup evidence showed a 6 GiB limit, three OOM admissions, one OOM kill, and current pressure dominated by concurrent Chromium trees. No production state is changed by this PR.

## Verification
- `test_codex_sdk_runner.py`, `test_browser_profiles.py`, `test_terminal_completion.py`, `test_verify_test_runtime.py`: 115 passed
- real Linux probe: launched a TERM-resistant child under `setsid`, verified a distinct PGID, and verified the group helper reaped it with the SIGKILL backstop
- `git diff --check`
