### PR TITLE
Allow explicit app focus over builder workspaces

### DIFF
--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -378,14 +378,14 @@ export default function Shell() {
   const handleImmersive = useCallback((appId, value) => {
     dispatchImmersive({ type: 'request', appId, value })
   }, [])
-  // Immersive-solo is a full-screen takeover, so per the ABSOLUTE builder
-  // invariant ("no exceptions, no special casing") it applies ONLY in single-screen
-  // mode. In builder mode an immersive request never seizes the workspace — the app
-  // stays a normal pane (this also keeps the bar + exit button, which key off this
-  // flag, out of builder). The request (immersiveAppId) is retained, so switching
-  // to single mode with the holder focused solos it exactly as landed.
-  const immersiveActive = effectiveViewMode === 'single'
-    && isImmersiveActive(immersiveAppId, activeView, activeAppId)
+  // Immersive is a temporary overlay lease, independent of the durable builder /
+  // single worlds. A verified request from the focused app may therefore solo
+  // that app over EITHER world; clearing the lease reveals the exact world below
+  // without changing its workspace mode, pane tree, tabs, or single-screen slot.
+  // Settings keeps its builder invariant because isImmersiveActive additionally
+  // requires the active shell view to be the requesting canvas, and AppCanvas
+  // forwards live requests only from its focused active frame.
+  const immersiveActive = isImmersiveActive(immersiveAppId, activeView, activeAppId)
   useLayoutEffect(() => {
     if (!immersiveActive) return
     const drawer = document.getElementById('navigation-drawer')
@@ -985,13 +985,15 @@ export default function Shell() {
   // single leaf, where this single-pane .shell__tabstrip stands in for the
   // tiled WorkspaceChrome strips, giving phone users the drag source), riding
   // an exit beat or a single-mode drag preview with the rest of the tiled
-  // presentation, and NEVER rendered in single mode (owner: tabs exist in one
-  // world and don't exist in the other). The legacy tabStripEngaged latch is
+  // presentation, and NEVER rendered in single mode OR over an immersive lease
+  // (the shell exit replaces every builder navigation surface). The legacy
+  // tabStripEngaged latch is
   // the KILL-SWITCH world's rule only (engaged after 2+ tabs) — letting it
   // leak into the flag-ON formula painted the parked builder tree's strip
   // over single mode whenever the latch was set. An empty workspace (no tabs)
   // shows nothing either way — the >= 1 gate stays.
-  const tabStripVisible = (SPLITS ? effectiveViewMode === 'panes' : tabStripEngaged)
+  const tabStripVisible = !immersiveActive
+    && (SPLITS ? effectiveViewMode === 'panes' : tabStripEngaged)
     && openTabs.length >= 1
 
   // tabKey -> { paneId, CONTENT rect } (pane rect minus its strip) of the active
@@ -1472,9 +1474,9 @@ export default function Shell() {
     tabCount: openTabs.length,
     dismissed: wsCoachmarkDismissed,
     // M6: only where the tab strip actually exists — the EFFECTIVE builder world —
-    // and never over an immersive-solo (z-120). Immersive is single-mode only, so
-    // the panes gate already excludes it; the explicit check is the last line of
-    // defense if that coupling ever changes.
+    // and never over an immersive lease (z-120). Immersive may temporarily cover
+    // either durable world, so the explicit check keeps the hint with the chrome it
+    // teaches instead of painting it over the focused app.
     builderWorld: effectiveViewMode === 'panes' && !immersiveActive,
   })
   // Auto-dismiss after 12s — deliberately NOT on an unrelated pointerdown (§7.2).
@@ -3527,9 +3529,8 @@ export default function Shell() {
       {/* SHELL-provided immersive exit. With the top bar gone the drawer
           toggle is unreachable, so this floating button is the guaranteed
           way back — an app can never trap the user in immersive mode.
-          Exit only clears the shell-side request; the app re-enters by
-          posting again (which a mounted app won't do until it remounts),
-          so the user's choice sticks for the rest of the visit. */}
+          Exit only clears the shell-side request; re-entry requires another
+          explicit app post, so the user remains in control. */}
       {immersiveActive && (
         <button
           ref={immersiveExitRef}

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -53,8 +53,9 @@ test('an implicit home tab does not engage the single-pane tab strip', () => {
   assert.match(shell, /if \(openTabs\.length >= 2\) setTabStripEngaged\(true\)/)
   assert.match(shell, /else if \(openTabs\.length === 0\) setTabStripEngaged\(false\)/)
   // With splits ON the strip follows the EFFECTIVE builder world only (never
-  // single mode); the engaged latch is the kill-switch world's legacy rule.
-  assert.match(shell, /const tabStripVisible = \(SPLITS \? effectiveViewMode === 'panes' : tabStripEngaged\)\s*\n?\s*&& openTabs\.length >= 1/)
+  // single mode or an immersive takeover); the engaged latch is the kill-switch
+  // world's legacy rule.
+  assert.match(shell, /const tabStripVisible = !immersiveActive\s*\n?\s*&& \(SPLITS \? effectiveViewMode === 'panes' : tabStripEngaged\)\s*\n?\s*&& openTabs\.length >= 1/)
   assert.match(shell, /tabStripEngaged[\s\S]*?paneModel\.flattenRollbackPriority\(workspace\)[\s\S]*?: \[\]/)
   // v2 DELETED the legacy sole-tab "unpin" shortcut (deletion list): the sole-tab
   // close is always a real CLOSE_TAB now, so an emptied builder auto-returns to
@@ -548,8 +549,9 @@ test('entry assembles on keyed beat classes, compositor-only, instant under redu
 
 test('builder single-leaf: the strip deals with its pane, entry through the ONE controller (item 3)', () => {
   // The strip is the builder surface: visible in the effective builder world even
-  // at one leaf, and never in single mode.
-  assert.match(shell, /const tabStripVisible = \(SPLITS \? effectiveViewMode === 'panes' : tabStripEngaged\)\s*\n?\s*&& openTabs\.length >= 1/)
+  // at one leaf, and never in single mode or while immersive is covering the
+  // preserved builder world.
+  assert.match(shell, /const tabStripVisible = !immersiveActive\s*\n?\s*&& \(SPLITS \? effectiveViewMode === 'panes' : tabStripEngaged\)\s*\n?\s*&& openTabs\.length >= 1/)
   const handler = shell.match(/const handleToggleViewMode = useCallback\(\(cause\) => \{[\s\S]*?\}, \[[^\]]*\]\)/)?.[0] || ''
   // v2: the handler builds the latched plan (deriveEnter/ExitPlan from the
   // projection) and dispatches the controller beat + the durable flip in the SAME

--- a/frontend/src/components/Shell/__tests__/workspaceView.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceView.test.js
@@ -61,7 +61,7 @@ test('multi-pane immersive solos the holder over the whole workspace', () => {
   const v = deriveContentVisibility({
     workspace: ws, projection: project(ws),
     settingsOverlayOpen: false, immersiveActive: true, immersiveAppId: 42,
-    viewMode: 'single', // immersive-solo is a takeover — single-screen mode only
+    viewMode: 'single',
   })
   // Chrome hidden: no strips or dividers paint over the solo.
   assert.equal(v.chromeActive, false)
@@ -102,25 +102,51 @@ test('Settings overlay (single mode) hides every pane and frame', () => {
   assert.equal(v.chatPanesVisible, false)
 })
 
-// The ABSOLUTE builder invariant, made structural: in builder mode ('panes') NO
-// takeover can seize the workspace — not even if BOTH the overlay flag and an
-// immersive request arrive. deriveContentVisibility is the last line of defense,
-// so it forces them inert in builder and keeps the single tiled path.
-test('builder mode has ZERO takeover branches (overlay + immersive both inert)', () => {
+// Settings remains structurally inert in builder, while a focused app's explicit
+// immersive lease is a temporary overlay over the untouched pane world.
+test('builder immersive temporarily solos its holder while Settings stays inert', () => {
   const ws = twoPaneChatAndApp() // 2 panes, focused pane holds app 42
   const v = deriveContentVisibility({
     workspace: ws, projection: project(ws),
     settingsOverlayOpen: true, immersiveActive: true, immersiveAppId: 42,
     viewMode: 'panes', // builder
   })
-  // Tiled render stands: chrome up, sibling panes painting, no solo, no full-bleed.
+  // The temporary lease solos the holder without turning builder into single mode.
   assert.equal(v.multiPane, true)
   assert.equal(v.single, false)
-  assert.equal(v.chromeActive, true, 'no takeover hides the panes in builder')
-  assert.equal(v.chatPanesVisible, true)
-  assert.equal(v.fullBleedKey, null, 'tiled — nothing paints over the whole box')
-  // The immersive request does NOT solo: both app panes stay visible.
+  assert.equal(v.settingsOverlay, false, 'Settings never becomes a builder takeover')
+  assert.equal(v.chromeActive, false, 'immersive hides pane chrome temporarily')
+  assert.equal(v.chatPanesVisible, false)
+  assert.equal(v.fullBleedKey, 'app:42')
   assert.deepEqual([...v.visibleAppIds].sort(), ['42'])
+})
+
+test('releasing builder immersive restores the exact tiled derivation', () => {
+  const ws = twoPaneChatAndApp()
+  const projection = project(ws)
+  const before = deriveContentVisibility({
+    workspace: ws, projection,
+    settingsOverlayOpen: false, immersiveActive: false, immersiveAppId: null,
+    viewMode: 'panes',
+  })
+  const during = deriveContentVisibility({
+    workspace: ws, projection,
+    settingsOverlayOpen: false, immersiveActive: true, immersiveAppId: 42,
+    viewMode: 'panes',
+  })
+  const after = deriveContentVisibility({
+    workspace: ws, projection,
+    settingsOverlayOpen: false, immersiveActive: false, immersiveAppId: null,
+    viewMode: 'panes',
+  })
+
+  assert.equal(during.fullBleedKey, 'app:42')
+  assert.equal(during.chromeActive, false)
+  assert.equal(after.fullBleedKey, before.fullBleedKey)
+  assert.equal(after.chromeActive, before.chromeActive)
+  assert.equal(after.focusedActiveKey, before.focusedActiveKey)
+  assert.deepEqual([...after.visibleAppIds], [...before.visibleAppIds])
+  assert.equal(after.chatPanesVisible, before.chatPanesVisible)
 })
 
 // The named risk, made structural: a builder Settings TAB (overlay closed) must

--- a/frontend/src/components/Shell/workspaceView.js
+++ b/frontend/src/components/Shell/workspaceView.js
@@ -349,24 +349,23 @@ export function deriveEnterPlan(input) {
 // `viewMode` is 'panes' (tiled, the default = BUILDER mode) or 'single' (collapse
 // a preserved multi-pane tree to the focused pane's active tab, full-bleed).
 //
-// ABSOLUTE BUILDER INVARIANT (owner: "no exceptions, no special casing"): in
-// builder mode NOTHING renders full-screen — not the Settings overlay, not an
-// immersive-solo. Builder mode has exactly ONE rendering path: the tiled/paned
-// render. Full-screen takeovers (Settings overlay, immersive-solo, single-mode
-// collapse) exist ONLY in single-screen mode. So both the overlay flag and the
-// immersive-solo are GATED off in builder here — the invariant is structural,
-// not an upstream promise (the nav adapter also keeps settingsOverlayOpen false
-// in builder, and Shell keeps immersiveActive false in builder — this is the
-// last line of defense so a stray input still can't seize the builder workspace).
+// Builder's durable world has exactly one structural rendering path: its pane
+// tree is never collapsed or rewritten by Settings. Immersive is deliberately
+// different: it is a temporary verified app lease layered OVER either world.
+// While held it solos the focused app; clearing it re-derives the untouched pane
+// tree immediately. Settings remains mode-gated and cannot become a builder
+// takeover, preserving that invariant without making a game's explicit Focus
+// control silently inert whenever the owner happens to be in Builder mode.
 export function deriveContentVisibility({
   workspace, projection, settingsOverlayOpen, immersiveActive, immersiveAppId,
   viewMode = 'panes', exitUnderlayKey = null,
 }) {
   const multiPane = projection.visibleLeaves.length >= 2
   const builder = viewMode !== 'single'
-  // The two full-screen takeovers, forced INERT in builder mode.
+  // Settings is structurally inert in builder. Immersive is a temporary overlay
+  // lease and may cover either world without mutating it.
   const settingsOverlay = !!settingsOverlayOpen && !builder
-  const immersive = !builder && !!immersiveActive && immersiveAppId != null
+  const immersive = !!immersiveActive && immersiveAppId != null
   // Single view-mode collapse is active only when no takeover already owns the box.
   const single = !builder && !settingsOverlay && !immersive
   // TWO-WORLDS (codex-modecontext-design.md): in SINGLE mode the active content is
@@ -395,10 +394,10 @@ export function deriveContentVisibility({
   // the New Chat landing is a chat/app tab (the landing is not a tab).
   const focusedActiveKey = settingsOverlay
     ? null
-    : (single ? slotKey : focusedPaneKey)
+    : (immersive ? `app:${immersiveAppId}` : (single ? slotKey : focusedPaneKey))
   // Pane chrome (strips + dividers) whenever the box is TILED: ≥2 visible leaves
-  // and no takeover. In builder this is simply `multiPane` (no takeover can trip
-  // here); single-mode / a takeover paints one surface over the whole box.
+  // and no takeover. An ordinary builder render follows `multiPane`; single mode
+  // or an immersive lease paints one surface over the whole box.
   const chromeActive = multiPane && !settingsOverlay && !immersive && !single
   // The single wrapper painted full-bleed. Null ONLY in the tiled multi-pane render;
   // the New Chat landing key for an empty single slot; the focused/holder key
@@ -409,8 +408,8 @@ export function deriveContentVisibility({
     : ((multiPane && !immersive && !single) ? null : focusedActiveKey)
   // The app ids that PAINT and stay interactive/frame-visible. A single-mode
   // immersive solos the holder; single-mode solos the focused pane's active app;
-  // the Settings overlay hides all; the tiled (incl. all of builder) render keeps
-  // every visible pane's active app. A builder Settings tab is NOT an app, so it
+  // the Settings overlay hides all; an ordinary tiled builder render keeps every
+  // visible pane's active app. A builder Settings tab is NOT an app, so it
   // contributes no id here — sibling app panes keep painting.
   let visibleAppIds
   if (settingsOverlay) visibleAppIds = new Set()
@@ -437,7 +436,7 @@ export function deriveContentVisibility({
     visibleAppIds.add(exitUnderlayKey.slice('app:'.length))
   }
   // Chat panes stay MOUNTED (no remount on overlay/view toggle) but hidden while a
-  // takeover owns the box. In builder (never a takeover) and single-mode they
+  // takeover owns the box. In an ordinary builder world and single-mode they
   // paint; the renderer additionally gates each NON-focused single-mode chat pane
   // off via the `single` flag, the chat analogue of visibleAppIds.
   const chatPanesVisible = !settingsOverlay && !immersive


### PR DESCRIPTION
## Summary

- treat an active app's verified immersive request as a temporary overlay lease over either Builder or Single
- preserve the Builder pane tree, tabs, focus, and single-screen slot beneath the lease
- keep Settings mode-gated while hiding pane/tab chrome under the shell-provided exit affordance
- cover Builder entry, release/restoration, Settings coexistence, and tab-strip behavior

This packages production commit `36588ddaad6398b02612f7d2faf60fbb718ab0e0` cleanly on current public `main`. It is the platform half of app-cuberun PR #8.

## Validation

- `npm test --prefix frontend` — 1,757 library tests + 47 hook tests
- `npm run build --prefix frontend`
- focused workspace/immersive suite — 126/126
- `git diff --check`