### PR TITLE
Collapse stale composer height on tab return

### DIFF
--- a/frontend/src/components/ChatView/ChatInputBar.jsx
+++ b/frontend/src/components/ChatView/ChatInputBar.jsx
@@ -391,17 +391,6 @@ export default function ChatInputBar({
   function handleTextareaChange(e) {
     if (listeningRef?.current) onManualVoiceEdit?.(e.target.value)
     onInputChange(e.target.value)
-    e.target.style.height = 'auto'
-    const h = Math.min(e.target.scrollHeight, 280)
-    e.target.style.height = h + 'px'
-    // Toggle the `--tall` class only when the textarea ACTUALLY
-    // spans multiple lines. A single line of 16px text at line-
-    // height 1.45 with 8px padding measures ~31px scrollHeight,
-    // so a threshold of 30 was triggering --tall on every keystroke
-    // and dropping the cursor + mic to the bottom. 45px sits
-    // safely between single-line (~31) and two-line (~55).
-    const pill = e.target.closest('.chat__pill')
-    if (pill) pill.classList.toggle('chat__pill--tall', h > 45)
   }
 
   function handlePaste(e) {

--- a/frontend/src/components/ChatView/ChatInputBar.jsx
+++ b/frontend/src/components/ChatView/ChatInputBar.jsx
@@ -22,7 +22,7 @@
  * ║   CONTRACTS — small but load-bearing                             ║
  * ║                                                                  ║
  * ║   1. AUTOSIZE THRESHOLD                                          ║
- * ║      `handleTextareaChange` toggles `chat__pill--tall` when      ║
+ * ║      Shared textarea sizing toggles `chat__pill--tall` when     ║
  * ║      height > 45px. NOT 30 (single-line is ~31, fires every      ║
  * ║      keystroke), NOT 50 (lags two-line typing). 45 sits          ║
  * ║      safely between single-line and two-line. See ChatView.css   ║

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -1461,7 +1461,7 @@ export default function ChatView({
     requestAnimationFrame(() => {
       const el = inputRef.current
       if (!el) return
-      resizeComposerTextarea(el)
+      resizeComposerTextarea(el, text)
       if (focus) {
         try { el.focus({ preventScroll: true }) }
         catch { el.focus() }
@@ -1610,7 +1610,7 @@ export default function ChatView({
   // scrollHeight; they reconcile when `hidden` flips back to false.
   useLayoutEffect(() => {
     const el = inputRef.current
-    if (el && !hidden) resizeComposerTextarea(el)
+    if (el && !hidden) resizeComposerTextarea(el, input)
   }, [chatId, hidden, input])
 
   // Publish `.chat__foot`'s rendered height as `--composer-h` on
@@ -1638,7 +1638,7 @@ export default function ChatView({
       // returns from background or the back-forward cache. Reconcile the
       // textarea first; measuring only the outer foot would preserve a stale
       // multi-line height on an empty composer.
-      resizeComposerTextarea(inputRef.current)
+      resizeComposerTextarea(inputRef.current, inputValueRef.current)
       applySoon()
     }
     const onVisible = () => {

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -2082,10 +2082,9 @@ export default function ChatView({
         // flex-end alignment after a send-from-tall and the freshly
         // empty textarea renders pinned to the bottom — text appears
         // off-center (lower than its resting position) until the
-        // user types again. `handleTextareaChange` re-evaluates this
-        // class on every keystroke, but send doesn't go through that
-        // path. Tap-to-focus doesn't trigger a change event either,
-        // so the visual stayed broken until the next keystroke.
+        // user types again. Shared textarea sizing re-evaluates this
+        // on each committed value, but the synchronous reset keeps the
+        // send transition correct before React commits the empty value.
       }
       try {
         const result = await streamSend(

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -83,6 +83,10 @@ import {
 } from './sendAttemptRecovery.js'
 import { persistComposerDraft } from './composerDraft.js'
 import {
+  resetComposerTextarea,
+  resizeComposerTextarea,
+} from './composerTextareaSizing.js'
+import {
   EMPTY_BUILD_PHASE_RAIL,
   accumulateBuildPhase,
   buildPhaseRailViewModel,
@@ -1447,10 +1451,7 @@ export default function ChatView({
     requestAnimationFrame(() => {
       const el = inputRef.current
       if (!el) return
-      el.style.height = 'auto'
-      const h = Math.min(el.scrollHeight, 280)
-      el.style.height = `${h}px`
-      el.closest('.chat__pill')?.classList.toggle('chat__pill--tall', h > 45)
+      resizeComposerTextarea(el)
       if (focus) {
         try { el.focus({ preventScroll: true }) }
         catch { el.focus() }
@@ -1592,24 +1593,15 @@ export default function ChatView({
     persistComposerDraft(chatId, input)
   }, [input, chatId])
 
-  // Auto-size textarea when a draft is restored. Cap matches the
-  // 280px max-height enforced by `handleTextareaChange` in
-  // ChatInputBar; without keeping these in sync a tall draft would
-  // restore visually truncated until the user types one more
-  // character to trigger the live-grow path. Also mirror the
-  // .chat__pill--tall class toggle so a restored multi-line draft
-  // anchors the send/mic buttons to the bottom of the pill — the
-  // toggle otherwise only fires on input keystrokes.
-  useEffect(() => {
+  // Text changes through input, restores, voice, send cleanup, and
+  // authoritative foreground reconciliation. Reconcile after every committed
+  // value — including the empty value — so no programmatic clear can retain a
+  // previous multi-line inline height. Hidden retained panes have no useful
+  // scrollHeight; they reconcile when `hidden` flips back to false.
+  useLayoutEffect(() => {
     const el = inputRef.current
-    if (el && input) {
-      el.style.height = 'auto'
-      const h = Math.min(el.scrollHeight, 280)
-      el.style.height = h + 'px'
-      const pill = el.closest('.chat__pill')
-      if (pill) pill.classList.toggle('chat__pill--tall', h > 45)
-    }
-  }, [chatId])
+    if (el && !hidden) resizeComposerTextarea(el)
+  }, [chatId, hidden, input])
 
   // Publish `.chat__foot`'s rendered height as `--composer-h` on
   // `.chat`. `.chat__list` reads this var for its bottom padding so
@@ -1631,8 +1623,16 @@ export default function ChatView({
         raf2 = requestAnimationFrame(measureComposerHeight)
       })
     }
+    const reconcileForegroundGeometry = () => {
+      // Chromium can restore form/layout state independently when a document
+      // returns from background or the back-forward cache. Reconcile the
+      // textarea first; measuring only the outer foot would preserve a stale
+      // multi-line height on an empty composer.
+      resizeComposerTextarea(inputRef.current)
+      applySoon()
+    }
     const onVisible = () => {
-      if (document.visibilityState === 'visible') applySoon()
+      if (document.visibilityState === 'visible') reconcileForegroundGeometry()
     }
 
     applySoon()
@@ -1641,7 +1641,7 @@ export default function ChatView({
       : null
     ro?.observe(footEl)
     window.addEventListener('resize', applySoon)
-    window.addEventListener('pageshow', applySoon)
+    window.addEventListener('pageshow', reconcileForegroundGeometry)
     window.visualViewport?.addEventListener('resize', applySoon)
     window.visualViewport?.addEventListener('scroll', applySoon)
     document.addEventListener('visibilitychange', onVisible)
@@ -1651,7 +1651,7 @@ export default function ChatView({
       if (raf2) cancelAnimationFrame(raf2)
       ro?.disconnect()
       window.removeEventListener('resize', applySoon)
-      window.removeEventListener('pageshow', applySoon)
+      window.removeEventListener('pageshow', reconcileForegroundGeometry)
       window.visualViewport?.removeEventListener('resize', applySoon)
       window.visualViewport?.removeEventListener('scroll', applySoon)
       document.removeEventListener('visibilitychange', onVisible)
@@ -2066,7 +2066,7 @@ export default function ChatView({
       setComposerInput('')
       clearComposerFilesForSend()
       if (inputRef.current) {
-        inputRef.current.style.height = 'auto'
+        resetComposerTextarea(inputRef.current)
         // Drop the multi-line `.chat__pill--tall` class so send/mic
         // re-center vertically. Without this, the pill stays in
         // flex-end alignment after a send-from-tall and the freshly
@@ -2076,7 +2076,6 @@ export default function ChatView({
         // class on every keystroke, but send doesn't go through that
         // path. Tap-to-focus doesn't trigger a change event either,
         // so the visual stayed broken until the next keystroke.
-        inputRef.current.closest('.chat__pill')?.classList.remove('chat__pill--tall')
       }
       try {
         const result = await streamSend(
@@ -2266,10 +2265,9 @@ export default function ChatView({
     setComposerInput('')
     clearComposerFilesForSend()
     if (inputRef.current) {
-      inputRef.current.style.height = 'auto'
+      resetComposerTextarea(inputRef.current)
       // Drop the multi-line `.chat__pill--tall` class — see queue-path
       // comment above for the full rationale.
-      inputRef.current.closest('.chat__pill')?.classList.remove('chat__pill--tall')
     }
     setSending(true)
     setServerRunningState(true)

--- a/frontend/src/components/ChatView/__tests__/composerTextareaSizing.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerTextareaSizing.test.js
@@ -31,10 +31,13 @@ function textareaStub({ value = '', scrollHeight = 31, tall = false } = {}) {
 }
 
 test('foreground reconciliation collapses an empty textarea with stale tall geometry', () => {
-  const { textarea, pill } = textareaStub({ value: '', scrollHeight: 31, tall: true })
+  // Chromium can expose the old/capped client height as scrollHeight while a
+  // focused empty textarea is returning inside a multi-pane layout. Empty must
+  // not trust that measurement at all.
+  const { textarea, pill } = textareaStub({ value: '', scrollHeight: 280, tall: true })
 
-  assert.equal(resizeComposerTextarea(textarea), 31)
-  assert.equal(textarea.style.height, '31px')
+  assert.equal(resizeComposerTextarea(textarea), 0)
+  assert.equal(textarea.style.height, 'auto')
   assert.equal(pill.classList.contains('chat__pill--tall'), false)
 })
 
@@ -43,6 +46,14 @@ test('textarea sizing caps multi-line content and retains the tall alignment', (
 
   assert.equal(resizeComposerTextarea(textarea), 280)
   assert.equal(textarea.style.height, '280px')
+  assert.equal(pill.classList.contains('chat__pill--tall'), true)
+})
+
+test('authoritative text can size before React commits it into the DOM value', () => {
+  const { textarea, pill } = textareaStub({ value: '', scrollHeight: 120 })
+
+  assert.equal(resizeComposerTextarea(textarea, 'voice transcript'), 120)
+  assert.equal(textarea.style.height, '120px')
   assert.equal(pill.classList.contains('chat__pill--tall'), true)
 })
 
@@ -66,8 +77,8 @@ test('ChatView reconciles textarea geometry on value commits and foreground retu
   const source = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8')
   const inputBarSource = readFileSync(new URL('../ChatInputBar.jsx', import.meta.url), 'utf8')
   const voiceSource = readFileSync(new URL('../useVoiceInput.js', import.meta.url), 'utf8')
-  assert.match(source, /useLayoutEffect\(\(\) => \{[\s\S]*resizeComposerTextarea\(el\)[\s\S]*\}, \[chatId, hidden, input\]\)/)
-  assert.match(source, /const reconcileForegroundGeometry = \(\) => \{[\s\S]*resizeComposerTextarea\(inputRef\.current\)[\s\S]*applySoon\(\)/)
+  assert.match(source, /useLayoutEffect\(\(\) => \{[\s\S]*resizeComposerTextarea\(el, input\)[\s\S]*\}, \[chatId, hidden, input\]\)/)
+  assert.match(source, /const reconcileForegroundGeometry = \(\) => \{[\s\S]*resizeComposerTextarea\(inputRef\.current, inputValueRef\.current\)[\s\S]*applySoon\(\)/)
   assert.match(source, /window\.addEventListener\('pageshow', reconcileForegroundGeometry\)/)
   assert.doesNotMatch(inputBarSource, /resizeComposerTextarea/)
   assert.doesNotMatch(voiceSource, /resizeComposerTextarea/)

--- a/frontend/src/components/ChatView/__tests__/composerTextareaSizing.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerTextareaSizing.test.js
@@ -1,0 +1,76 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+import {
+  resetComposerTextarea,
+  resizeComposerTextarea,
+} from '../composerTextareaSizing.js'
+
+function textareaStub({ value = '', scrollHeight = 31, tall = false } = {}) {
+  const classes = new Set(tall ? ['chat__pill--tall'] : [])
+  const pill = {
+    classList: {
+      toggle(name, enabled) {
+        if (enabled) classes.add(name)
+        else classes.delete(name)
+      },
+      remove(name) { classes.delete(name) },
+      contains(name) { return classes.has(name) },
+    },
+  }
+  return {
+    textarea: {
+      value,
+      scrollHeight,
+      style: { height: tall ? '280px' : '' },
+      closest: selector => selector === '.chat__pill' ? pill : null,
+    },
+    pill,
+  }
+}
+
+test('foreground reconciliation collapses an empty textarea with stale tall geometry', () => {
+  const { textarea, pill } = textareaStub({ value: '', scrollHeight: 31, tall: true })
+
+  assert.equal(resizeComposerTextarea(textarea), 31)
+  assert.equal(textarea.style.height, '31px')
+  assert.equal(pill.classList.contains('chat__pill--tall'), false)
+})
+
+test('textarea sizing caps multi-line content and retains the tall alignment', () => {
+  const { textarea, pill } = textareaStub({ value: 'many lines', scrollHeight: 420 })
+
+  assert.equal(resizeComposerTextarea(textarea), 280)
+  assert.equal(textarea.style.height, '280px')
+  assert.equal(pill.classList.contains('chat__pill--tall'), true)
+})
+
+test('hidden retained panes keep intrinsic height instead of receiving zero pixels', () => {
+  const { textarea, pill } = textareaStub({ value: '', scrollHeight: 0, tall: true })
+
+  assert.equal(resizeComposerTextarea(textarea), 0)
+  assert.equal(textarea.style.height, 'auto')
+  assert.equal(pill.classList.contains('chat__pill--tall'), false)
+})
+
+test('reset collapses immediately before React commits the empty value', () => {
+  const { textarea, pill } = textareaStub({ value: 'old multi-line value', scrollHeight: 280, tall: true })
+
+  resetComposerTextarea(textarea)
+  assert.equal(textarea.style.height, 'auto')
+  assert.equal(pill.classList.contains('chat__pill--tall'), false)
+})
+
+test('ChatView reconciles textarea geometry on value commits and foreground return', () => {
+  const source = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8')
+  const inputBarSource = readFileSync(new URL('../ChatInputBar.jsx', import.meta.url), 'utf8')
+  const voiceSource = readFileSync(new URL('../useVoiceInput.js', import.meta.url), 'utf8')
+  assert.match(source, /useLayoutEffect\(\(\) => \{[\s\S]*resizeComposerTextarea\(el\)[\s\S]*\}, \[chatId, hidden, input\]\)/)
+  assert.match(source, /const reconcileForegroundGeometry = \(\) => \{[\s\S]*resizeComposerTextarea\(inputRef\.current\)[\s\S]*applySoon\(\)/)
+  assert.match(source, /window\.addEventListener\('pageshow', reconcileForegroundGeometry\)/)
+  assert.doesNotMatch(inputBarSource, /resizeComposerTextarea/)
+  assert.doesNotMatch(voiceSource, /resizeComposerTextarea/)
+  const resets = source.match(/resetComposerTextarea\(inputRef\.current\)/g) || []
+  assert.equal(resets.length, 2, 'both queued and immediate sends collapse stale textarea geometry')
+})

--- a/frontend/src/components/ChatView/composerTextareaSizing.js
+++ b/frontend/src/components/ChatView/composerTextareaSizing.js
@@ -13,8 +13,18 @@ function composerPill(textarea) {
  * foregrounding can all update or restore it. Keeping this operation shared
  * prevents an empty textarea from retaining a previous multi-line height.
  */
-export function resizeComposerTextarea(textarea) {
+export function resizeComposerTextarea(textarea, value = textarea?.value) {
   if (!textarea?.style) return 0
+
+  // Empty is a semantic one-line state, not a geometry question. During a
+  // multi-pane mount / foreground transition Chromium can briefly report an
+  // empty textarea's scrollHeight as its old or available flex height (often
+  // the 280px cap). Measuring that transient value makes the blank composer
+  // fill the pane until the next keystroke. Reset deterministically instead.
+  if (value === '') {
+    resetComposerTextarea(textarea)
+    return 0
+  }
 
   textarea.style.height = 'auto'
   const measured = Number(textarea.scrollHeight) || 0
@@ -22,10 +32,7 @@ export function resizeComposerTextarea(textarea) {
   // Retained workspace panes can be display:none while React commits a state
   // update. Their scrollHeight is 0, which is not useful geometry; leave the
   // intrinsic one-row height in place and reconcile when the pane is visible.
-  if (measured <= 0) {
-    if (!textarea.value) composerPill(textarea)?.classList?.remove('chat__pill--tall')
-    return 0
-  }
+  if (measured <= 0) return 0
 
   const height = Math.min(measured, COMPOSER_TEXTAREA_MAX_HEIGHT)
   textarea.style.height = `${height}px`
@@ -40,5 +47,5 @@ export function resizeComposerTextarea(textarea) {
 export function resetComposerTextarea(textarea) {
   if (!textarea?.style) return
   textarea.style.height = 'auto'
-  composerPill(textarea)?.classList?.remove('chat__pill--tall')
+  composerPill(textarea)?.classList?.remove?.('chat__pill--tall')
 }

--- a/frontend/src/components/ChatView/composerTextareaSizing.js
+++ b/frontend/src/components/ChatView/composerTextareaSizing.js
@@ -1,0 +1,44 @@
+export const COMPOSER_TEXTAREA_MAX_HEIGHT = 280
+export const COMPOSER_TEXTAREA_TALL_THRESHOLD = 45
+
+function composerPill(textarea) {
+  return textarea?.closest?.('.chat__pill') || null
+}
+
+/**
+ * Reconcile the textarea's inline height with its current DOM value.
+ *
+ * Composer text changes through more than the input event: send cleanup,
+ * failed-send reconciliation, voice input, restored drafts, and browser
+ * foregrounding can all update or restore it. Keeping this operation shared
+ * prevents an empty textarea from retaining a previous multi-line height.
+ */
+export function resizeComposerTextarea(textarea) {
+  if (!textarea?.style) return 0
+
+  textarea.style.height = 'auto'
+  const measured = Number(textarea.scrollHeight) || 0
+
+  // Retained workspace panes can be display:none while React commits a state
+  // update. Their scrollHeight is 0, which is not useful geometry; leave the
+  // intrinsic one-row height in place and reconcile when the pane is visible.
+  if (measured <= 0) {
+    if (!textarea.value) composerPill(textarea)?.classList?.remove('chat__pill--tall')
+    return 0
+  }
+
+  const height = Math.min(measured, COMPOSER_TEXTAREA_MAX_HEIGHT)
+  textarea.style.height = `${height}px`
+  composerPill(textarea)?.classList?.toggle(
+    'chat__pill--tall',
+    height > COMPOSER_TEXTAREA_TALL_THRESHOLD,
+  )
+  return height
+}
+
+/** Collapse immediately while React is still committing an empty value. */
+export function resetComposerTextarea(textarea) {
+  if (!textarea?.style) return
+  textarea.style.height = 'auto'
+  composerPill(textarea)?.classList?.remove('chat__pill--tall')
+}

--- a/frontend/src/components/ChatView/hooks/__tests__/useVoiceInput.test.js
+++ b/frontend/src/components/ChatView/hooks/__tests__/useVoiceInput.test.js
@@ -25,20 +25,16 @@ function installSpeechRecognition() {
   return instances
 }
 
-test('live dictation grows to the composer cap and bottom-anchors its mic', () => {
+test('live dictation delegates geometry to the controlled composer value owner', () => {
   const instances = installSpeechRecognition()
-  const toggles = []
+  let closestCalls = 0
   const input = {
     value: '',
     scrollHeight: 120,
     style: {},
-    closest: () => ({
-      classList: { toggle: (...args) => toggles.push(args) },
-    }),
+    closest: () => { closestCalls += 1 },
   }
   const transcripts = []
-  const prevRaf = globalThis.requestAnimationFrame
-  globalThis.requestAnimationFrame = fn => { fn(); return 1 }
   try {
     const { result } = renderHook(() => useVoiceInput({
       onTranscript: text => transcripts.push(text),
@@ -48,10 +44,9 @@ test('live dictation grows to the composer cap and bottom-anchors its mic', () =
     instances[0].onresult(speechResult('a sufficiently long dictated message'))
 
     assert.equal(transcripts.at(-1), 'a sufficiently long dictated message')
-    assert.equal(input.style.height, '120px')
-    assert.deepEqual(toggles.at(-1), ['chat__pill--tall', true])
+    assert.equal(input.style.height, undefined)
+    assert.equal(closestCalls, 0, 'the hook must not force a second layout')
   } finally {
-    globalThis.requestAnimationFrame = prevRaf
     delete globalThis.window
   }
 })
@@ -63,14 +58,12 @@ test('a manual edit while listening survives late speech results and rebases dic
   let timerId = 0
   const prevTimeout = globalThis.setTimeout
   const prevClearTimeout = globalThis.clearTimeout
-  const prevRaf = globalThis.requestAnimationFrame
   globalThis.setTimeout = fn => {
     const id = ++timerId
     timers.set(id, fn)
     return id
   }
   globalThis.clearTimeout = id => timers.delete(id)
-  globalThis.requestAnimationFrame = fn => { fn(); return 1 }
   try {
     const input = { value: 'draft', style: {}, scrollHeight: 30, closest: () => null }
     const { result } = renderHook(() => useVoiceInput({
@@ -94,7 +87,6 @@ test('a manual edit while listening survives late speech results and rebases dic
   } finally {
     globalThis.setTimeout = prevTimeout
     globalThis.clearTimeout = prevClearTimeout
-    globalThis.requestAnimationFrame = prevRaf
     delete globalThis.window
   }
 })

--- a/frontend/src/components/ChatView/useVoiceInput.js
+++ b/frontend/src/components/ChatView/useVoiceInput.js
@@ -23,10 +23,11 @@ import useScreenWakeLock from '../../hooks/useScreenWakeLock.js'
  * @param {object} options
  * @param {(text: string) => void} options.onTranscript
  *   Called with the concatenated final+interim transcript on every
- *   onresult event. Caller writes this into the composer textarea.
+ *   onresult event. Caller commits this into the controlled composer; the
+ *   composer layout effect owns its post-commit textarea sizing.
  * @param {React.RefObject<HTMLTextAreaElement>} options.inputRef
- *   The composer textarea — used for auto-height resize on transcript
- *   growth and to seed voiceFinalRef with the current value on start.
+ *   The composer textarea — used to seed voiceFinalRef with the current value
+ *   on start and to preserve the current value in permission-error copy.
  *
  * @returns {{
  *   listening: boolean,
@@ -87,15 +88,6 @@ export default function useVoiceInput({ onTranscript, inputRef }) {
       }
       const text = voiceFinalRef.current + interim
       onTranscript(text)
-      requestAnimationFrame(() => {
-        if (inputRef.current) {
-          inputRef.current.style.height = 'auto'
-          const h = Math.min(inputRef.current.scrollHeight, 280)
-          inputRef.current.style.height = h + 'px'
-          inputRef.current.closest('.chat__pill')
-            ?.classList.toggle('chat__pill--tall', h > 45)
-        }
-      })
     }
 
     rec.onerror = (e) => {

--- a/tests/frontend.spec.mjs
+++ b/tests/frontend.spec.mjs
@@ -108,6 +108,32 @@ async function waitForChatMode(page, chatId, kind, timeout = 3000) {
 test.use({ serviceWorkers: 'block' })
 
 test.describe('Input behavior', () => {
+  test('returning to the tab collapses stale empty-composer geometry', async ({ page }) => {
+    await setup(page)
+    await newChat(page)
+
+    const input = page.getByRole('textbox', { name: 'Message Möbius…' })
+    await input.evaluate(el => {
+      el.value = ''
+      el.style.height = '280px'
+      el.closest('.chat__pill')?.classList.add('chat__pill--tall')
+    })
+    await expect(input).toHaveCSS('height', '280px')
+
+    const background = await page.context().newPage()
+    await background.goto('about:blank')
+    await expect.poll(() => page.evaluate(() => document.visibilityState)).toBe('hidden')
+
+    await page.bringToFront()
+    await expect.poll(() => page.evaluate(() => document.visibilityState)).toBe('visible')
+    await expect.poll(() => input.evaluate(el => ({
+      collapsed: el.getBoundingClientRect().height < 60,
+      tall: el.closest('.chat__pill')?.classList.contains('chat__pill--tall') || false,
+    }))).toEqual({ collapsed: true, tall: false })
+
+    await background.close()
+  })
+
   test('Voice input holds a screen wake lock until recording stops', async ({ page }) => {
     await page.addInitScript(() => {
       window.__wakeLockRequests = []

--- a/tests/frontend.spec.mjs
+++ b/tests/frontend.spec.mjs
@@ -120,18 +120,42 @@ test.describe('Input behavior', () => {
     })
     await expect(input).toHaveCSS('height', '280px')
 
-    const background = await page.context().newPage()
-    await background.goto('about:blank')
-    await expect.poll(() => page.evaluate(() => document.visibilityState)).toBe('hidden')
+    await page.evaluate(() => {
+      Object.defineProperty(document, 'visibilityState', {
+        configurable: true,
+        get: () => 'hidden',
+      })
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+    await expect(input).toHaveCSS('height', '280px')
+    await expect.poll(() => input.evaluate(
+      el => el.closest('.chat__pill')?.classList.contains('chat__pill--tall') || false,
+    )).toBe(true)
 
-    await page.bringToFront()
-    await expect.poll(() => page.evaluate(() => document.visibilityState)).toBe('visible')
+    await page.evaluate(() => {
+      Object.defineProperty(document, 'visibilityState', {
+        configurable: true,
+        get: () => 'visible',
+      })
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
     await expect.poll(() => input.evaluate(el => ({
       collapsed: el.getBoundingClientRect().height < 60,
       tall: el.closest('.chat__pill')?.classList.contains('chat__pill--tall') || false,
     }))).toEqual({ collapsed: true, tall: false })
 
-    await background.close()
+    // The bfcache/pageshow trigger owns the same reconciliation contract.
+    await input.evaluate(el => {
+      el.style.height = '280px'
+      el.closest('.chat__pill')?.classList.add('chat__pill--tall')
+    })
+    await page.evaluate(() => {
+      window.dispatchEvent(new PageTransitionEvent('pageshow', { persisted: true }))
+    })
+    await expect.poll(() => input.evaluate(el => ({
+      collapsed: el.getBoundingClientRect().height < 60,
+      tall: el.closest('.chat__pill')?.classList.contains('chat__pill--tall') || false,
+    }))).toEqual({ collapsed: true, tall: false })
   })
 
   test('Voice input holds a screen wake lock until recording stops', async ({ page }) => {


### PR DESCRIPTION
## Summary

- centralize composer textarea sizing across typed input, voice input, restores, and send cleanup
- reconcile programmatic empty-value commits so a previously multiline composer cannot retain stale inline height
- reconcile textarea geometry before measuring the composer on `visibilitychange` and `pageshow`

## Production evidence

The originating production chat reproduced an empty composer forced to about 290px after returning to the tab; the foreground reconciliation collapsed it to the expected one-row geometry (about 50px including the composer shell). No production deployment is performed by this PR.

## Verification

- `npm test` — 1,808 tests passed (1,761 lib + 47 hooks)
- `npm run build`
- `git diff --check`
