### PR TITLE
Keep Recovery model snapshot aligned

### DIFF
--- a/backend/recovery/recovery_chat_runner.py
+++ b/backend/recovery/recovery_chat_runner.py
@@ -85,10 +85,10 @@ SUPPORTED_PROVIDERS: tuple[str, ...] = ("claude", "codex")
 # NOT import app.providers or the SDK stack (the production chat path
 # may be exactly what's broken). So the model lists the recovery picker
 # offers are FROZEN LITERALS here, deliberately duplicated from
-# providers.KNOWN_MODELS rather than imported. They drift only when
-# someone hand-edits both — acceptable, because the recovery surface is
-# small, rarely changed, and its whole value is surviving a broken
-# import chain.
+# providers.KNOWN_MODELS rather than imported. A platform-side test requires
+# this frozen snapshot to match the fallback registry for every provider
+# Recovery supports. That preserves the broken-import-chain boundary at
+# runtime without letting the two user-facing pickers silently drift.
 #
 # Recovery always runs the single recovery system prompt built by
 # `_system_prompt(chat_id)` (it needs the per-chat log path
@@ -105,12 +105,22 @@ SUPPORTED_PROVIDERS: tuple[str, ...] = ("claude", "codex")
 RECOVERY_MODELS: dict[str, tuple[str, ...]] = {
   "claude": (
     "claude-opus-4-8",
+    "claude-opus-4-7",
+    "claude-opus-4-6",
+    "claude-opus-4-5-20251001",
     "claude-sonnet-4-6",
+    "claude-sonnet-4-7-20251215",
+    "claude-sonnet-4-5-20251001",
     "claude-haiku-4-5-20251001",
   ),
   "codex": (
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
     "gpt-5.5",
     "gpt-5.4",
+    "gpt-5.4-mini",
+    "gpt-5.3-codex-spark",
   ),
 }
 

--- a/backend/tests/test_model_registry.py
+++ b/backend/tests/test_model_registry.py
@@ -15,9 +15,11 @@ Two gaps this guards:
   fetch still offers today's models, not a stale snapshot.
 """
 
+import importlib.util
 import json
 import stat
 import time
+from pathlib import Path
 
 import httpx
 import pytest
@@ -69,6 +71,33 @@ def test_known_models_fallback_lists_current_claude_and_codex():
   ):
     assert model_id in codex, f"{model_id} missing from KNOWN_MODELS[codex]"
   assert codex[0] == "gpt-5.6-sol", "gpt-5.6-sol must be the Codex default"
+
+
+def test_recovery_models_match_platform_fallback_registry():
+  """The isolated Recovery literals must not silently lag Settings.
+
+  Recovery cannot import app.providers at runtime because that dependency
+  boundary is the feature. This platform-side test can compare both registries
+  and force a fallback-model change to update the frozen snapshot in the same
+  reviewed commit.
+  """
+  recovery_path = (
+    Path(__file__).resolve().parents[1]
+    / "recovery"
+    / "recovery_chat_runner.py"
+  )
+  spec = importlib.util.spec_from_file_location(
+    "recovery_model_snapshot_for_test",
+    recovery_path,
+  )
+  assert spec is not None and spec.loader is not None
+  chat_runner = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(chat_runner)
+  expected = {
+    provider: tuple(providers.KNOWN_MODELS[provider])
+    for provider in chat_runner.SUPPORTED_PROVIDERS
+  }
+  assert chat_runner.RECOVERY_MODELS == expected
 
 
 def test_fallback_models_shape_matches_registry_entries():


### PR DESCRIPTION
## Summary

- update the intentionally frozen Recovery picker snapshot to every current model in providers.KNOWN_MODELS for supported providers
- add a platform-side invariant so future fallback-registry changes cannot silently leave Recovery behind
- keep the Recovery runtime import-isolated; only the test compares the two registries

## Why

Recovery had drifted far behind Settings: three of eight Claude fallback IDs and two of seven Codex IDs were selectable. Its comments claimed it copied KNOWN_MODELS, but nothing enforced that contract.

## Verification

- backend/tests/test_recoveryd.py + backend/tests/test_model_registry.py: 27 passed
- git diff --check: clean

Core PR: review only; do not merge without the required independent reviews.