### PR TITLE
Clarify opaque app authority and lock module loading to the broker

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -49,6 +49,15 @@ Möbius is meant to be self-hosted on a user-provisioned host — a managed plat
 
 Two invariants follow. (1) **Möbius never patches the kernel from inside the container** — it only *surfaces* "host reboot pending / kernel CVE outstanding" to the owner; the platform/OS applies it. (2) **The in-container agent cannot recreate its own container** (the swap would kill its own process), so the shape is *propose-in* (agent scans → bumps → tests → commits) / *dispose-out* (a host-driven `deploy-prod.sh`, or blue-green, does the rebuild+recreate). Detection is the agent's leverage on every tier: `pip-audit` + `npm audit` + an image scanner (Trivy / `docker scout`) over the built image → triage → bump → test → deploy (tier 1) or surface a reboot window (tiers 2/3).
 
+**The in-product platform updater does not update host deployment files.**
+Settings advances the served `/data/platform` clone inside the app volume; the
+bundled self-hosted Caddy service instead reads `./Caddyfile` from the host
+checkout, and image/dependency changes likewise need a host rebuild/recreate.
+An incoming change to `Caddyfile`, `docker-compose.yml`, `Dockerfile`, or a
+dependency manifest therefore carries a separate host action (and may require a
+particular ordering) even when the live clone rebases cleanly. Never describe
+Apply + server restart alone as activating those files.
+
 **lodash is pinned to 4.18.1 via `overrides`.** `@openai/apps-sdk-ui` pulls lodash transitively — only through its `Slider` component, which the shell does not import. The 4.17.x line sat unfixed against several advisories for a long stretch; 4.18.x restored maintenance and patched them, so `frontend/package.json` `overrides` forces the transitive lodash to 4.18.1 (`npm audit` is clean). As defense-in-depth, `frontend/src/lib/__tests__/appsSdkLodash.test.js` also fails if the shell ever imports `Slider`, which keeps lodash tree-shaken out of the shipped bundle regardless of the pin.
 
 ## Self-update model — `upstream` / `main`, replay on update

--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -37,6 +37,28 @@ model, lifecycle rules, and escape hatches.
 it collapses the boundary it is meant to protect. A deliberately trusted app
 must receive its own origin or become an explicit platform extension.
 
+## Credentials and authority
+
+Opacity removes the shell's ambient **owner** authority; it does not make an
+ordinary app powerless. In the current transport, the runtime receives a
+refreshable app-scoped bearer and app code in that realm must be treated as able
+to possess it. The bearer is narrower than the owner JWT: its app id,
+installation nonce, owner epoch and installed permissions are rechecked by the
+server.
+
+Credential placement and granted authority are separate decisions. A future
+host-mediated request transport could keep the raw app bearer in the exact
+parent while still letting the live frame invoke every server operation its
+installed permissions allow. That would reduce theft and replay outside the
+frame; it would not reduce the app's approved authority while the frame is
+running. A generic request transport also need not become one bespoke wrapper
+per API route — server permissions remain the authorization contract.
+
+This does not replace lifecycle-aware browser capabilities or the trust tiers
+above. Origin-bound facilities such as cookies, service workers and durable
+origin storage still require a host provider or a separate service origin; a
+raw general shell-origin bridge would recreate the authority opacity removed.
+
 ## Manifest contract
 
 Runtime capabilities live in the root `capabilities` object:
@@ -224,11 +246,12 @@ Add primitives only after a real app needs them. Likely families are:
 - `device.midi`, `device.serial`, `device.bluetooth`
 - `display.fullscreen`, `display.wake_lock`
 
-External HTTP remains an app-token authenticated server surface rather than a
-host session. Its reviewable permission should describe destinations and
+Today external HTTP remains an app-token-authenticated server surface rather
+than a host session. Its reviewable permission should describe destinations and
 methods; wildcard access can remain possible through explicit owner approval.
-Likewise, app storage and cross-app access are durable server capabilities, not
-browser-session providers.
+Moving credential possession into a generic host request transport would not
+change that authorization model. Likewise, app storage and cross-app access are
+durable server capabilities, not browser-session providers.
 
 ## Adding a capability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,8 +28,11 @@ being external attackers reaching the public HTTPS endpoint.
 - **Mini-app isolation and tokens:** shell-mounted app frames omit
   `allow-same-origin`, giving them an opaque origin. They cannot read shell
   localStorage or the owner JWT. Each receives a refreshable app JWT bound to
-  the live app id, installation nonce and owner token epoch; server routes
-  enforce the app's exact permissions.
+  the live app id, installation nonce and owner token epoch; app code must be
+  treated as able to possess that narrower bearer, and server routes enforce
+  the app's exact installed permissions. Opacity protects ambient **owner**
+  authority — it is not a promise that ordinary app code never sees its own
+  scoped credential.
 - **Rate limiting:** 120 req/min global, 3-5/min on auth endpoints.
   Uses TCP peer address (not X-Forwarded-For).
 
@@ -47,8 +50,11 @@ These are intentional design decisions appropriate for a single-owner app:
   outer PWA shell which hosts the existing opaque app-frame protocol. Until
   then, standalone launch must not be presented as isolated from owner storage.
 - **`null` CORS origin:** Required for sandboxed mini-app iframes to call
-  the API. Mitigated by scoped tokens — even if a mini-app reads the
-  iframe's token, it can only access storage/proxy/AI endpoints.
+  the API. Mitigated by scoped tokens — even if a mini-app reads or copies its
+  bearer, it can reach only routes authorized by that app's installed
+  permissions, live installation nonce and owner token epoch. Keep this stated
+  in terms of the principal rather than an endpoint list: app-authorized routes
+  evolve, and there is no synchronous `/api/ai` surface.
 - **`unsafe-inline` in style-src CSP:** Required for server-injected theme
   CSS. The owner controls the theme content.
 - **90-day service token:** Used by cron scripts. Stored at

--- a/backend/app/routes/client_error.py
+++ b/backend/app/routes/client_error.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
 from app import activity
+from app.chat_log_redaction import scrub_secrets
 from app.deps import Principal, get_principal, reject_cross_site
 
 router = APIRouter(prefix="/api/client-error", tags=["client-error"])
@@ -44,16 +45,19 @@ def report_client_error(
   that differ only past the cap still collapse — so a render loop can't flood
   the log.
   """
-  message = body.message[:_MSG_MAX]
+  # Treat the server as the final retention boundary. A stale or hostile
+  # client can bypass the frame scrubber, so scrub every retained text field
+  # before debounce, truncation, and the activity.jsonl write.
+  message = scrub_secrets(body.message)[:_MSG_MAX]
   if not activity.should_emit_app_error(principal.app_id, message):
     return  # debounced — already recorded within the window; still 204
   fields: dict[str, object] = {"message": message}
   if principal.app_id is not None:
     fields["app_id"] = principal.app_id
   if body.where:
-    fields["where"] = body.where[:_WHERE_MAX]
+    fields["where"] = scrub_secrets(body.where)[:_WHERE_MAX]
   if body.stack:
-    fields["stack"] = body.stack[:_STACK_MAX]
+    fields["stack"] = scrub_secrets(body.stack)[:_STACK_MAX]
   if body.url:
-    fields["url"] = body.url[:_URL_MAX]
+    fields["url"] = scrub_secrets(body.url)[:_URL_MAX]
   activity.log_event("app_error", **fields)

--- a/backend/tests/test_client_error.py
+++ b/backend/tests/test_client_error.py
@@ -88,6 +88,36 @@ def test_oversized_message_and_stack_are_truncated(client, owner_token):
     assert len(errs[0].get("stack", "")) <= 8000
 
 
+def test_client_error_scrubs_every_field_before_activity_retention(client, owner_token):
+    app_id = _make_app(client, owner_token)
+    token = _app_token(client, owner_token, app_id)
+    secrets = {
+        "message": "MESSAGE-SECRET",
+        "where": "WHERE-SECRET",
+        "stack": "STACK-SECRET",
+        "url": "URL-SECRET",
+    }
+    r = client.post(
+        "/api/client-error",
+        json={
+            "message": f"boom?token={secrets['message']}",
+            "where": f"app:window.onerror?token={secrets['where']}",
+            "stack": f"at render (https://app.test/?token={secrets['stack']})",
+            "url": f"https://mobius.test/shell/?token={secrets['url']}",
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 204, r.text
+
+    errs = [e for e in _activity_lines() if e.get("ev") == "app_error"]
+    assert len(errs) == 1
+    retained = json.dumps(errs[0])
+    for secret in secrets.values():
+        assert secret not in retained
+    for field in ("message", "where", "stack", "url"):
+        assert "[redacted]" in errs[0][field]
+
+
 def test_owner_shell_error_records_no_app_id(client, owner_token):
     # An error reported with the owner JWT (the shell, not an app iframe)
     # must NOT carry an app_id, or it would pollute a real app's last_5_errors.

--- a/backend/tests/test_frame_error_reporting.py
+++ b/backend/tests/test_frame_error_reporting.py
@@ -19,5 +19,14 @@ def test_frame_error_report_redacts_module_token():
     r"[\s\S]{0,120}?if \(window\.__frameMounted\)",
     frame,
   ), "runtime error details must be redacted before any console branch"
+  report_block = frame.split("function reportAppError", 1)[1].split(
+    "window.addEventListener('error'", 1
+  )[0]
+  assert "const safeMessage = redactErrorCredentials(message)" in report_block
+  assert "const safeStack = stack ? redactErrorCredentials(stack)" in report_block
+  assert "const safeUrl = redactErrorCredentials(location.href)" in report_block
+  assert "message: safeMessage.slice" in report_block
+  assert "stack: safeStack ? safeStack.slice" in report_block
+  assert frame.count("e.preventDefault()") >= 2
   assert "user-select: text" in frame
   assert "Report to agent" in frame

--- a/backend/tests/test_frame_error_reporting.py
+++ b/backend/tests/test_frame_error_reporting.py
@@ -1,5 +1,6 @@
 """Mini-app frame failures expose a safe, actionable recovery report."""
 
+import re
 from pathlib import Path
 
 
@@ -12,5 +13,11 @@ def test_frame_error_report_redacts_module_token():
   assert "function redactErrorCredentials" in frame
   assert "detail = redactErrorCredentials(detail)" in frame
   assert "'$1[redacted]'" in frame
+  assert re.search(
+    r"function handleFrameError\(title, detail, source\)\s*\{\s*"
+    r"[\s\S]{0,260}?detail = redactErrorCredentials\(detail\)"
+    r"[\s\S]{0,120}?if \(window\.__frameMounted\)",
+    frame,
+  ), "runtime error details must be redacted before any console branch"
   assert "user-select: text" in frame
   assert "Report to agent" in frame

--- a/frontend/public/app-frame.html
+++ b/frontend/public/app-frame.html
@@ -513,9 +513,13 @@
     }
     window.addEventListener('error', function(e) {
       handleFrameError('Runtime error', e.error ? e.error.stack || e.message : e.message, e.filename)
+      // The browser's native console path would otherwise print the original
+      // token-bearing Error after our redacted replacement/panel.
+      e.preventDefault()
     })
     window.addEventListener('unhandledrejection', function(e) {
       handleFrameError('Unhandled error', e.reason ? (e.reason.stack || String(e.reason)) : String(e))
+      e.preventDefault()
     })
   </script>
 
@@ -988,17 +992,21 @@
     let _reportToken = null;
     const _reportSeen = new Map();
     function reportAppError(where, message, stack) {
-      if (!_reportToken || !message) return;
-      const key = String(message).slice(0, 200);
+      const safeMessage = redactErrorCredentials(message);
+      const safeStack = stack ? redactErrorCredentials(stack) : undefined;
+      const safeWhere = where ? redactErrorCredentials(where) : undefined;
+      const safeUrl = redactErrorCredentials(location.href);
+      if (!_reportToken || !safeMessage) return;
+      const key = safeMessage.slice(0, 200);
       const now = Date.now();
       const last = _reportSeen.get(key);
       if (last && now - last < 60000) return;
       _reportSeen.set(key, now);
       const body = JSON.stringify({
-        message: String(message).slice(0, 2000),
-        where: where,
-        stack: stack ? String(stack).slice(0, 8000) : undefined,
-        url: location.href,
+        message: safeMessage.slice(0, 2000),
+        where: safeWhere,
+        stack: safeStack ? safeStack.slice(0, 8000) : undefined,
+        url: safeUrl,
       });
       runtimeToken().then(function (token) {
         return fetch('/api/client-error', {

--- a/frontend/public/app-frame.html
+++ b/frontend/public/app-frame.html
@@ -494,6 +494,10 @@
       return EXTENSION_ORIGIN_RE.test(String(source || '')) || EXTENSION_ORIGIN_RE.test(String(stack || ''))
     }
     function handleFrameError(title, detail, source) {
+      // Redact before ANY branch can log, display or retain the detail. showErr
+      // repeats this at its direct call boundary for load failures that do not
+      // pass through the global error listeners.
+      detail = redactErrorCredentials(detail)
       if (window.__frameMounted) {
         // The browser also logs the uncaught error natively; this line
         // records why no error panel replaced the working UI.

--- a/frontend/src/lib/__tests__/appModuleBroker.test.js
+++ b/frontend/src/lib/__tests__/appModuleBroker.test.js
@@ -90,7 +90,15 @@ test('opaque frames request module bytes only after exact parent attribution', (
   assert.match(frame, /type: 'moebius:module-request'/)
   assert.match(frame, /new Blob\(\[bytes\], \{ type: 'text\/javascript' \}\)/)
   assert.match(frame, /URL\.revokeObjectURL\(blobUrl\)/)
-  assert.doesNotMatch(frame, /await import\(moduleUrl\([01]\)\)/)
+  // The opaque frame has one module-execution route: the bytes fetched by the
+  // exact parent broker are evaluated from its bounded blob. Pin the complete
+  // dynamic-import target list rather than one old helper spelling — a renamed
+  // direct URL fallback must not silently bypass attribution/version/offline
+  // behavior or put the app bearer in a module URL.
+  const dynamicImportTargets = [...frame.matchAll(/\bimport\s*\(\s*([^)\r\n]+)\s*\)/g)]
+    .map(match => match[1].trim())
+  assert.deepEqual(dynamicImportTargets, ['blobUrl'])
+  assert.doesNotMatch(frame, /\bimportDirectModule\b/)
   assert.doesNotMatch(frame, /type="importmap"/)
   assert.doesNotMatch(frame, /await import\(['"]react['"]\)/)
   assert.doesNotMatch(frame, /await import\(['"]\/mobius-runtime\.js['"]\)/)

--- a/frontend/src/lib/__tests__/appModuleBroker.test.js
+++ b/frontend/src/lib/__tests__/appModuleBroker.test.js
@@ -1,6 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
+import { parse } from 'acorn'
 
 import {
   APP_MODULE_MAX_BYTES,
@@ -22,6 +23,29 @@ const caddy = readFileSync(
   new URL('../../../../Caddyfile', import.meta.url),
   'utf8',
 )
+
+function dynamicImportTargetsFromHtml(html) {
+  const targets = []
+  for (const match of html.matchAll(/<script([^>]*)>([\s\S]*?)<\/script>/gi)) {
+    const [, attributes, source] = match
+    const sourceType = /\btype=["']module["']/i.test(attributes)
+      ? 'module'
+      : 'script'
+    const ast = parse(source, { ecmaVersion: 'latest', sourceType })
+    const visit = node => {
+      if (!node || typeof node !== 'object') return
+      if (node.type === 'ImportExpression') {
+        targets.push(source.slice(node.source.start, node.source.end).replace(/\s+/g, ' '))
+      }
+      for (const value of Object.values(node)) {
+        if (Array.isArray(value)) value.forEach(visit)
+        else if (value && typeof value === 'object') visit(value)
+      }
+    }
+    visit(ast)
+  }
+  return targets
+}
 
 test('module request keys keep the app version but discard the frame revision', () => {
   const url = new URL(appModuleRequestUrl(
@@ -95,8 +119,7 @@ test('opaque frames request module bytes only after exact parent attribution', (
   // dynamic-import target list rather than one old helper spelling — a renamed
   // direct URL fallback must not silently bypass attribution/version/offline
   // behavior or put the app bearer in a module URL.
-  const dynamicImportTargets = [...frame.matchAll(/\bimport\s*\(\s*([^)\r\n]+)\s*\)/g)]
-    .map(match => match[1].trim())
+  const dynamicImportTargets = dynamicImportTargetsFromHtml(frame)
   assert.deepEqual(dynamicImportTargets, ['blobUrl'])
   assert.doesNotMatch(frame, /\bimportDirectModule\b/)
   assert.doesNotMatch(frame, /type="importmap"/)
@@ -104,6 +127,11 @@ test('opaque frames request module bytes only after exact parent attribution', (
   assert.doesNotMatch(frame, /await import\(['"]\/mobius-runtime\.js['"]\)/)
   assert.match(frame, /globalThis\.__mobiusRuntimeConfig/)
   assert.match(frame, /compiledRuntime\.abi !== COMPILED_RUNTIME_ABI/)
+})
+
+test('dynamic import inventory includes multiline targets', () => {
+  const fixture = `<script type="module">await import(\n  moduleUrl(0)\n)</script>`
+  assert.deepEqual(dynamicImportTargetsFromHtml(fixture), ['moduleUrl(0)'])
 })
 
 test('the frame separates parent liveness from module transfer time', () => {


### PR DESCRIPTION
## Summary

- clarify that opaque app frames remove ambient owner authority while ordinary apps still operate with an app-scoped principal
- replace an outdated endpoint list with the installed-permission contract and document the host/deployment boundary of in-product updates
- lock the app frame to its exact-parent brokered blob import so renamed direct URL fallbacks cannot bypass attribution, versioning, size, or offline behavior
- redact token-bearing details before every Möbius-owned runtime error branch logs, displays, or retains them

## Context

PR #109 reproduced a real all-app outage when a newer blob-based loader met an older edge CSP. Its proposed direct module import also exposed a gap in the existing static assertion: CI rejected only one historical helper spelling, not the unsafe execution route itself.

This change does not resolve the edge migration tracked in #114. It records the architectural distinction uncovered there and prevents the direct-import workaround from returning unnoticed while that migration is designed.

## Verification

- 8 focused frontend module-broker tests
- 22 focused backend frame/security tests
- production frontend build
- inline app-frame script syntax checks