### PR TITLE
Refresh copied git hooks after platform updates

### DIFF
--- a/backend/app/platform_update.py
+++ b/backend/app/platform_update.py
@@ -44,8 +44,10 @@ import contextlib
 import fcntl
 import logging
 import os
+import stat
 import subprocess
 import sys
+import tempfile
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -112,6 +114,11 @@ _PROBE_TIMEOUT = 60
 # Hook installation only copies a handful of local files and updates one
 # repo-local config value. A long run is a wedged filesystem/process, not work.
 _HOOK_INSTALL_TIMEOUT = 15
+_HOOK_MAX_BYTES = 1_000_000
+_HOOK_SOURCES = (
+  ("scripts/pre-commit.sh", "pre-commit"),
+  ("scripts/githooks/pre-push", "pre-push"),
+)
 
 # Update-preview payload bounds. A whole-platform deploy can carry a huge diff;
 # the review sheet renders the file summary (always small) by default and the raw
@@ -737,37 +744,156 @@ def _touched_frontend(repo: Path, before: str | None, after: str | None) -> bool
   )
 
 
-def _refresh_git_hooks(repo: Path) -> str | None:
-  """Refresh copied repository hooks from the newly served platform tree.
+def _hook_git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+  """Run one bounded, non-interactive Git plumbing command for hook refresh."""
+  return subprocess.run(
+    ["git", "-C", str(repo), *args],
+    cwd=str(repo),
+    env=_scrubbed_git_env(repo),
+    capture_output=True,
+    timeout=_HOOK_INSTALL_TIMEOUT,
+    check=False,
+  )
 
-  ``install-hooks.sh`` deliberately installs copies, not symlinks, so linked
-  worktrees keep working if their source worktree disappears. The consequence
-  is that a platform update can advance ``scripts/pre-commit.sh`` while the
-  active ``.git/hooks/pre-commit`` stays stale. Run the existing deterministic
-  installer after a successful Apply and on every healthy boot. ``None`` means
-  there is no installer in this checkout, ``""`` means success, and a non-empty
-  string is a bounded diagnostic. Hook refresh is important development hygiene
-  but must never roll back an otherwise healthy platform update.
-  """
-  installer = repo / "scripts" / "install-hooks.sh"
-  if not installer.is_file():
-    return None
+
+def _hook_command_error(proc: subprocess.CompletedProcess) -> str:
+  raw = proc.stderr or proc.stdout or f"exit {proc.returncode}".encode()
+  return os.fsdecode(raw).strip()[-500:]
+
+
+def _stage_hook_file(hooks_dir: Path, data: bytes) -> Path:
+  fd, raw_path = tempfile.mkstemp(prefix=".mobius-hook-", dir=str(hooks_dir))
+  path = Path(raw_path)
   try:
-    proc = subprocess.run(
-      ["bash", str(installer)],
-      cwd=str(repo),
-      env=_scrubbed_git_env(repo),
-      capture_output=True,
-      text=True,
-      timeout=_HOOK_INSTALL_TIMEOUT,
-      check=False,
-    )
-  except (OSError, subprocess.TimeoutExpired) as exc:
-    return repr(exc)[:500]
-  if proc.returncode != 0:
-    detail = (proc.stderr or proc.stdout or f"exit {proc.returncode}").strip()
-    return detail[-500:]
+    with os.fdopen(fd, "wb") as handle:
+      handle.write(data)
+      handle.flush()
+      os.fchmod(handle.fileno(), 0o755)
+      os.fsync(handle.fileno())
+    return path
+  except Exception:
+    path.unlink(missing_ok=True)
+    raise
+
+
+def _read_hook_destination(path: Path) -> tuple[str, object] | None:
+  """Snapshot one destination without ever following a hook symlink."""
+  try:
+    info = path.lstat()
+  except FileNotFoundError:
+    return None
+  if stat.S_ISLNK(info.st_mode):
+    return ("symlink", os.readlink(path))
+  if not stat.S_ISREG(info.st_mode):
+    raise OSError(f"hook destination is not a regular file: {path.name}")
+  if info.st_size > _HOOK_MAX_BYTES:
+    raise OSError(f"existing hook is unexpectedly large: {path.name}")
+  return ("file", (path.read_bytes(), stat.S_IMODE(info.st_mode)))
+
+
+def _restore_hook_destination(path: Path, previous: tuple[str, object] | None) -> None:
+  if previous is None:
+    path.unlink(missing_ok=True)
+    return
+  kind, value = previous
+  if kind == "file":
+    data, mode = value
+    staged = _stage_hook_file(path.parent, data)
+    os.chmod(staged, mode)
+  else:
+    staged = path.parent / f".mobius-hook-link-{os.getpid()}-{path.name}"
+    staged.unlink(missing_ok=True)
+    os.symlink(value, staged)
+  os.replace(staged, path)
+
+
+def _refresh_git_hooks_impl(repo: Path) -> str | None:
+  """Install the fixed hook allowlist from committed blobs, without executing it."""
+  # Preserve the rollout contract of older trees: no committed installer means
+  # this checkout predates managed hooks and boot should simply skip refresh.
+  enabled = _hook_git(repo, "cat-file", "-e", "HEAD:scripts/install-hooks.sh")
+  if enabled.returncode != 0:
+    return None
+
+  sources: list[tuple[str, bytes]] = []
+  for source, destination in _HOOK_SOURCES:
+    size_proc = _hook_git(repo, "cat-file", "-s", f"HEAD:{source}")
+    if size_proc.returncode != 0:
+      raise OSError(_hook_command_error(size_proc))
+    try:
+      size = int(size_proc.stdout.strip())
+    except (TypeError, ValueError) as exc:
+      raise OSError(f"could not size committed hook {source}") from exc
+    if size <= 0 or size > _HOOK_MAX_BYTES:
+      raise OSError(f"committed hook has invalid size: {source}")
+    show = _hook_git(repo, "show", f"HEAD:{source}")
+    if show.returncode != 0:
+      raise OSError(_hook_command_error(show))
+    if len(show.stdout) != size or not show.stdout.startswith(b"#!"):
+      raise OSError(f"committed hook failed verification: {source}")
+    sources.append((destination, show.stdout))
+
+  common = _hook_git(repo, "rev-parse", "--path-format=absolute", "--git-common-dir")
+  if common.returncode != 0:
+    raise OSError(_hook_command_error(common))
+  common_dir = Path(os.fsdecode(common.stdout.strip())).resolve(strict=True)
+  hooks_dir = common_dir / "hooks"
+  if hooks_dir.is_symlink():
+    raise OSError("refusing symlinked git hooks directory")
+  hooks_dir.mkdir(mode=0o755, parents=True, exist_ok=True)
+  if not hooks_dir.is_dir():
+    raise OSError("git hooks path is not a directory")
+
+  lock_path = hooks_dir / ".mobius-refresh.lock"
+  with lock_path.open("a+b") as lock_handle:
+    try:
+      fcntl.flock(lock_handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+      return ""  # The concurrent refresher owns the same complete operation.
+
+    previous = {
+      name: _read_hook_destination(hooks_dir / name)
+      for name, _data in sources
+    }
+    staged: dict[str, Path] = {}
+    try:
+      for name, data in sources:
+        staged[name] = _stage_hook_file(hooks_dir, data)
+    except Exception:
+      for path in staged.values():
+        path.unlink(missing_ok=True)
+      raise
+    replaced: list[str] = []
+    try:
+      try:
+        for name, _data in sources:
+          os.replace(staged[name], hooks_dir / name)
+          replaced.append(name)
+      except Exception:
+        for name in reversed(replaced):
+          _restore_hook_destination(hooks_dir / name, previous[name])
+        raise
+      # A repository-local hooksPath takes effect only after the complete set
+      # exists. On refresh each destination changes by atomic inode swap, so a
+      # concurrent Git process sees either the previous hook or the new hook,
+      # never an absent path.
+      configured = _hook_git(
+        repo, "config", "--local", "core.hooksPath", str(hooks_dir),
+      )
+      if configured.returncode != 0:
+        raise OSError(_hook_command_error(configured))
+    finally:
+      for path in staged.values():
+        path.unlink(missing_ok=True)
   return ""
+
+
+def _refresh_git_hooks(repo: Path) -> str | None:
+  """Best-effort hook refresh that is total at boot and after committed Apply."""
+  try:
+    return _refresh_git_hooks_impl(repo)
+  except Exception as exc:
+    return repr(exc)[:500]
 
 
 async def _rebuild_frontend_after_update_if_needed(

--- a/backend/app/platform_update.py
+++ b/backend/app/platform_update.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import fcntl
+import logging
 import os
 import subprocess
 import sys
@@ -54,6 +55,8 @@ from sqlalchemy.orm import Session
 
 from app import app_git
 
+
+log = logging.getLogger(__name__)
 
 PLATFORM_REPO = Path("/data/platform")
 # The served backend — the import probe's cwd, so ``import app.main`` resolves
@@ -106,6 +109,9 @@ _FETCH_TIMEOUT = 120
 # in agent-edited code would otherwise wedge boot forever; a timeout-kill counts
 # as probe-fail -> roll back.
 _PROBE_TIMEOUT = 60
+# Hook installation only copies a handful of local files and updates one
+# repo-local config value. A long run is a wedged filesystem/process, not work.
+_HOOK_INSTALL_TIMEOUT = 15
 
 # Update-preview payload bounds. A whole-platform deploy can carry a huge diff;
 # the review sheet renders the file summary (always small) by default and the raw
@@ -731,6 +737,39 @@ def _touched_frontend(repo: Path, before: str | None, after: str | None) -> bool
   )
 
 
+def _refresh_git_hooks(repo: Path) -> str | None:
+  """Refresh copied repository hooks from the newly served platform tree.
+
+  ``install-hooks.sh`` deliberately installs copies, not symlinks, so linked
+  worktrees keep working if their source worktree disappears. The consequence
+  is that a platform update can advance ``scripts/pre-commit.sh`` while the
+  active ``.git/hooks/pre-commit`` stays stale. Run the existing deterministic
+  installer after a successful Apply and on every healthy boot. ``None`` means
+  there is no installer in this checkout, ``""`` means success, and a non-empty
+  string is a bounded diagnostic. Hook refresh is important development hygiene
+  but must never roll back an otherwise healthy platform update.
+  """
+  installer = repo / "scripts" / "install-hooks.sh"
+  if not installer.is_file():
+    return None
+  try:
+    proc = subprocess.run(
+      ["bash", str(installer)],
+      cwd=str(repo),
+      env=_scrubbed_git_env(repo),
+      capture_output=True,
+      text=True,
+      timeout=_HOOK_INSTALL_TIMEOUT,
+      check=False,
+    )
+  except (OSError, subprocess.TimeoutExpired) as exc:
+    return repr(exc)[:500]
+  if proc.returncode != 0:
+    detail = (proc.stderr or proc.stdout or f"exit {proc.returncode}").strip()
+    return detail[-500:]
+  return ""
+
+
 async def _rebuild_frontend_after_update_if_needed(
   repo: Path, res: ReconcileResult,
 ) -> None:
@@ -911,10 +950,18 @@ def reconcile_clone_sync() -> str:
   worst case leaves the pre-reconcile code serving and a flag set."""
   try:
     res = _reconcile_under_lock(PLATFORM_REPO, at_boot=True)
+    # Even an offline/conflict pass leaves a complete served tree on disk. Hook
+    # refresh is local-only, so do it on every boot rather than waiting for a
+    # successful fetch that may be unrelated to the stale installed copy.
+    hook_refresh = _refresh_git_hooks(PLATFORM_REPO)
     summary = (
       f"reconcile[{res.status}] pre={_short(res.pre_sha)} "
       f"new={_short(res.new_sha)} target={_short(res.target_sha)}"
     )
+    if hook_refresh == "":
+      summary += " hooks=refreshed"
+    elif hook_refresh:
+      summary += f" hooks=error:{hook_refresh}"
     if res.conflict_paths:
       summary += f" conflicts={len(res.conflict_paths)}"
     if res.error:
@@ -1159,6 +1206,9 @@ async def apply_platform_update(
     chat_id: str | None = None
 
     if res.status == "updated":
+      hook_refresh = await asyncio.to_thread(_refresh_git_hooks, repo)
+      if hook_refresh:
+        log.warning("git hook refresh failed after platform update: %s", hook_refresh)
       # Frontend changes rebuild into dist (served per-request, no restart);
       # only a served-backend or constitution change requires restarting
       # uvicorn. Path-aware so test/docs/frontend-only updates finish without a

--- a/backend/app/platform_update.py
+++ b/backend/app/platform_update.py
@@ -48,7 +48,7 @@ import stat
 import subprocess
 import sys
 import tempfile
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from enum import Enum
 from pathlib import Path
 from typing import Literal, TypedDict
@@ -252,6 +252,10 @@ class ReconcileResult:
   target_sha: str | None
   conflict_paths: list[str] = field(default_factory=list)
   error: str | None = None
+  # Exact reviewed release/upstream commit captured while RECONCILE_LOCK is
+  # still held. Hook refresh reads every allowlisted blob from this immutable
+  # generation rather than trusting replayed local HEAD or a moving ref.
+  hook_source_sha: str | None = None
 
 
 def _scrubbed_git_env(repo: Path) -> dict:
@@ -807,17 +811,20 @@ def _restore_hook_destination(path: Path, previous: tuple[str, object] | None) -
   os.replace(staged, path)
 
 
-def _refresh_git_hooks_impl(repo: Path) -> str | None:
-  """Install the fixed hook allowlist from committed blobs, without executing it."""
+def _refresh_git_hooks_impl(repo: Path, source_oid: str) -> str | None:
+  """Install allowlisted hooks from one pinned reviewed oid, without executing it."""
   # Preserve the rollout contract of older trees: no committed installer means
   # this checkout predates managed hooks and boot should simply skip refresh.
-  enabled = _hook_git(repo, "cat-file", "-e", "HEAD:scripts/install-hooks.sh")
+  enabled = _hook_git(
+    repo, "cat-file", "-e", f"{source_oid}:scripts/install-hooks.sh",
+  )
   if enabled.returncode != 0:
     return None
 
   sources: list[tuple[str, bytes]] = []
   for source, destination in _HOOK_SOURCES:
-    size_proc = _hook_git(repo, "cat-file", "-s", f"HEAD:{source}")
+    blob = f"{source_oid}:{source}"
+    size_proc = _hook_git(repo, "cat-file", "-s", blob)
     if size_proc.returncode != 0:
       raise OSError(_hook_command_error(size_proc))
     try:
@@ -826,7 +833,10 @@ def _refresh_git_hooks_impl(repo: Path) -> str | None:
       raise OSError(f"could not size committed hook {source}") from exc
     if size <= 0 or size > _HOOK_MAX_BYTES:
       raise OSError(f"committed hook has invalid size: {source}")
-    show = _hook_git(repo, "show", f"HEAD:{source}")
+    # `cat-file blob` returns the committed bytes without textconv/filter
+    # execution. `git show` is presentation porcelain and may consult local
+    # diff-driver configuration, which is not a trusted boot-time code path.
+    show = _hook_git(repo, "cat-file", "blob", blob)
     if show.returncode != 0:
       raise OSError(_hook_command_error(show))
     if len(show.stdout) != size or not show.stdout.startswith(b"#!"):
@@ -888,10 +898,12 @@ def _refresh_git_hooks_impl(repo: Path) -> str | None:
   return ""
 
 
-def _refresh_git_hooks(repo: Path) -> str | None:
+def _refresh_git_hooks(repo: Path, source_oid: str | None) -> str | None:
   """Best-effort hook refresh that is total at boot and after committed Apply."""
+  if not source_oid:
+    return None
   try:
-    return _refresh_git_hooks_impl(repo)
+    return _refresh_git_hooks_impl(repo, source_oid)
   except Exception as exc:
     return repr(exc)[:500]
 
@@ -1062,7 +1074,15 @@ def _reconcile_under_lock(repo: Path, at_boot: bool) -> ReconcileResult:
   """Hold :data:`RECONCILE_LOCK` around one reconcile so the boot subprocess and
   the running uvicorn's Apply can never run two reconciles on the same repo."""
   with _reconcile_flock():
-    return reconcile_clone(repo, at_boot=at_boot)
+    result = reconcile_clone(repo, at_boot=at_boot)
+    # `upstream` is moved only by a successful/contained reconcile to the
+    # fetched release target. Capture its immutable oid before releasing the
+    # cross-process lock; local replay commits on main are intentionally not a
+    # hook trust transition.
+    return replace(
+      result,
+      hook_source_sha=_rev(repo, UPSTREAM_BRANCH) or None,
+    )
 
 
 def _short(sha: str | None) -> str:
@@ -1079,7 +1099,7 @@ def reconcile_clone_sync() -> str:
     # Even an offline/conflict pass leaves a complete served tree on disk. Hook
     # refresh is local-only, so do it on every boot rather than waiting for a
     # successful fetch that may be unrelated to the stale installed copy.
-    hook_refresh = _refresh_git_hooks(PLATFORM_REPO)
+    hook_refresh = _refresh_git_hooks(PLATFORM_REPO, res.hook_source_sha)
     summary = (
       f"reconcile[{res.status}] pre={_short(res.pre_sha)} "
       f"new={_short(res.new_sha)} target={_short(res.target_sha)}"
@@ -1332,7 +1352,9 @@ async def apply_platform_update(
     chat_id: str | None = None
 
     if res.status == "updated":
-      hook_refresh = await asyncio.to_thread(_refresh_git_hooks, repo)
+      hook_refresh = await asyncio.to_thread(
+        _refresh_git_hooks, repo, res.hook_source_sha,
+      )
       if hook_refresh:
         log.warning("git hook refresh failed after platform update: %s", hook_refresh)
       # Frontend changes rebuild into dist (served per-request, no restart);

--- a/backend/tests/test_platform_update.py
+++ b/backend/tests/test_platform_update.py
@@ -19,7 +19,7 @@ aborted on the next pass.
 
 import subprocess
 import textwrap
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -479,11 +479,11 @@ async def test_apply_rebuilds_frontend_but_no_restart_when_update_is_frontend_on
     calls.append((repo, res.new_sha))
 
   monkeypatch.setattr(pu, "_reconcile_under_lock", lambda repo, at_boot: (
-    pu.ReconcileResult("updated", served, new, new)
+    pu.ReconcileResult("updated", served, new, new, hook_source_sha=new)
   ))
   monkeypatch.setattr(
     pu, "_refresh_git_hooks",
-    lambda repo: hook_calls.append(repo) or "",
+    lambda repo, source_oid: hook_calls.append((repo, source_oid)) or "",
   )
   monkeypatch.setattr(pu, "_rebuild_frontend_after_update_if_needed", fake_rebuild)
 
@@ -494,7 +494,7 @@ async def test_apply_rebuilds_frontend_but_no_restart_when_update_is_frontend_on
   assert res["state"] == pu.PlatformUpdateState.UP_TO_DATE.value
   assert res["needs_restart"] is False
   assert calls == [(platform, new)]
-  assert hook_calls == [platform]
+  assert hook_calls == [(platform, new)]
 
 
 def test_boot_reconcile_refreshes_copied_hooks(monkeypatch, tmp_path):
@@ -503,17 +503,53 @@ def test_boot_reconcile_refreshes_copied_hooks(monkeypatch, tmp_path):
   calls = []
   monkeypatch.setattr(pu, "PLATFORM_REPO", platform)
   monkeypatch.setattr(pu, "_reconcile_under_lock", lambda repo, at_boot: (
-    pu.ReconcileResult("up_to_date", "pre-sha", "pre-sha", "target-sha")
+    pu.ReconcileResult(
+      "up_to_date", "pre-sha", "pre-sha", "target-sha",
+      hook_source_sha="trusted-hook-sha",
+    )
   ))
   monkeypatch.setattr(
     pu, "_refresh_git_hooks",
-    lambda repo: calls.append(repo) or "",
+    lambda repo, source_oid: calls.append((repo, source_oid)) or "",
   )
 
   summary = pu.reconcile_clone_sync()
 
-  assert calls == [platform]
+  assert calls == [(platform, "trusted-hook-sha")]
   assert "hooks=refreshed" in summary
+
+
+def test_reconcile_pins_upstream_hook_source_before_unlock(monkeypatch, tmp_path):
+  repo = tmp_path / "platform"
+  repo.mkdir()
+  events = []
+
+  @contextmanager
+  def fake_lock():
+    events.append("locked")
+    yield
+    events.append("unlocked")
+
+  def fake_reconcile(repo_path, *, at_boot):
+    assert events == ["locked"]
+    assert repo_path == repo
+    assert at_boot is True
+    return pu.ReconcileResult("up_to_date", "pre", "pre", "target")
+
+  def fake_rev(repo_path, ref):
+    assert events == ["locked"]
+    assert repo_path == repo
+    assert ref == pu.UPSTREAM_BRANCH
+    return "trusted-upstream-oid"
+
+  monkeypatch.setattr(pu, "_reconcile_flock", fake_lock)
+  monkeypatch.setattr(pu, "reconcile_clone", fake_reconcile)
+  monkeypatch.setattr(pu, "_rev", fake_rev)
+
+  result = pu._reconcile_under_lock(repo, at_boot=True)
+
+  assert events == ["locked", "unlocked"]
+  assert result.hook_source_sha == "trusted-upstream-oid"
 
 
 def _make_hook_repo(tmp_path: Path, *, complete: bool = True) -> Path:
@@ -535,6 +571,7 @@ def _make_hook_repo(tmp_path: Path, *, complete: bool = True) -> Path:
 
 def test_hook_refresh_uses_only_committed_allowlisted_sources(tmp_path):
   repo = _make_hook_repo(tmp_path)
+  source_oid = _git(repo, "rev-parse", "HEAD").stdout.strip()
   # Neither a dirty managed hook nor a newly dropped executable may run merely
   # because a healthy boot refreshes the installed copies.
   (repo / "scripts" / "pre-commit.sh").write_text("#!/bin/sh\necho DIRTY\n")
@@ -542,7 +579,7 @@ def test_hook_refresh_uses_only_committed_allowlisted_sources(tmp_path):
     "#!/bin/sh\necho UNTRACKED\n"
   )
 
-  assert pu._refresh_git_hooks(repo) == ""
+  assert pu._refresh_git_hooks(repo, source_oid) == ""
 
   hooks = repo / ".git" / "hooks"
   assert (hooks / "pre-commit").read_text() == (
@@ -558,11 +595,58 @@ def test_hook_refresh_uses_only_committed_allowlisted_sources(tmp_path):
   assert Path(configured.stdout.strip()) == hooks.resolve()
 
 
+def test_hook_refresh_reads_one_pinned_generation_when_head_moves(
+  tmp_path, monkeypatch,
+):
+  repo = _make_hook_repo(tmp_path)
+  source_oid = _git(repo, "rev-parse", "HEAD").stdout.strip()
+  expected = {
+    "pre-commit": b"#!/bin/sh\necho committed-pre-commit\n",
+    "pre-push": b"#!/bin/sh\necho committed-pre-push\n",
+  }
+
+  (repo / "scripts" / "pre-commit.sh").write_text("#!/bin/sh\necho NEW-commit\n")
+  (repo / "scripts" / "githooks" / "pre-push").write_text(
+    "#!/bin/sh\necho NEW-push\n"
+  )
+  _git(repo, "add", "scripts")
+  _git(repo, "commit", "-q", "-m", "new hook generation")
+  next_oid = _git(repo, "rev-parse", "HEAD").stdout.strip()
+  _git(repo, "reset", "--hard", "-q", source_oid)
+
+  real_hook_git = pu._hook_git
+  moved = False
+
+  def move_head_between_blob_reads(repo_path, *args):
+    nonlocal moved
+    result = real_hook_git(repo_path, *args)
+    if (
+      not moved
+      and args == (
+        "cat-file", "blob", f"{source_oid}:scripts/pre-commit.sh",
+      )
+    ):
+      moved = True
+      _git(repo, "reset", "--hard", "-q", next_oid)
+    return result
+
+  monkeypatch.setattr(pu, "_hook_git", move_head_between_blob_reads)
+
+  assert pu._refresh_git_hooks(repo, source_oid) == ""
+  assert moved is True
+  hooks = repo / ".git" / "hooks"
+  assert {
+    name: (hooks / name).read_bytes()
+    for name in expected
+  } == expected
+
+
 def test_hook_refresh_rolls_back_without_absent_destinations(
   tmp_path, monkeypatch,
 ):
   repo = _make_hook_repo(tmp_path)
-  assert pu._refresh_git_hooks(repo) == ""
+  source_oid = _git(repo, "rev-parse", "HEAD").stdout.strip()
+  assert pu._refresh_git_hooks(repo, source_oid) == ""
   hooks = repo / ".git" / "hooks"
   old = {
     name: (hooks / name).read_bytes()
@@ -574,6 +658,7 @@ def test_hook_refresh_rolls_back_without_absent_destinations(
   )
   _git(repo, "add", "scripts")
   _git(repo, "commit", "-q", "-m", "update hooks")
+  source_oid = _git(repo, "rev-parse", "HEAD").stdout.strip()
 
   real_replace = pu.os.replace
   failed = False
@@ -592,7 +677,7 @@ def test_hook_refresh_rolls_back_without_absent_destinations(
 
   monkeypatch.setattr(pu.os, "replace", fail_second_hook_once)
 
-  result = pu._refresh_git_hooks(repo)
+  result = pu._refresh_git_hooks(repo, source_oid)
 
   assert "simulated second replacement failure" in result
   assert {(name, (hooks / name).read_bytes()) for name in old} == set(old.items())
@@ -606,26 +691,29 @@ def test_hook_refresh_missing_incomplete_and_timeout_are_nonfatal(
   (missing / "README").write_text("old checkout\n")
   _git(missing, "add", "README")
   _git(missing, "commit", "-q", "-m", "old checkout")
-  assert pu._refresh_git_hooks(missing) is None
+  missing_oid = _git(missing, "rev-parse", "HEAD").stdout.strip()
+  assert pu._refresh_git_hooks(missing, missing_oid) is None
 
   incomplete = _make_hook_repo(tmp_path / "incomplete", complete=False)
-  result = pu._refresh_git_hooks(incomplete)
+  incomplete_oid = _git(incomplete, "rev-parse", "HEAD").stdout.strip()
+  result = pu._refresh_git_hooks(incomplete, incomplete_oid)
   assert result
   assert "pre-push" in result
 
   monkeypatch.setattr(
     pu, "_refresh_git_hooks_impl",
-    lambda _repo: (_ for _ in ()).throw(
+    lambda _repo, _source_oid: (_ for _ in ()).throw(
       subprocess.TimeoutExpired(["git", "show"], timeout=15)
     ),
   )
-  assert "TimeoutExpired" in pu._refresh_git_hooks(missing)
+  assert "TimeoutExpired" in pu._refresh_git_hooks(missing, missing_oid)
 
 
 def test_hook_refresh_config_failure_keeps_complete_first_population(
   tmp_path, monkeypatch,
 ):
   repo = _make_hook_repo(tmp_path)
+  source_oid = _git(repo, "rev-parse", "HEAD").stdout.strip()
   real_hook_git = pu._hook_git
 
   def fail_config(repo_path, *args):
@@ -635,7 +723,7 @@ def test_hook_refresh_config_failure_keeps_complete_first_population(
 
   monkeypatch.setattr(pu, "_hook_git", fail_config)
 
-  result = pu._refresh_git_hooks(repo)
+  result = pu._refresh_git_hooks(repo, source_oid)
 
   assert "config locked" in result
   hooks = repo / ".git" / "hooks"

--- a/backend/tests/test_platform_update.py
+++ b/backend/tests/test_platform_update.py
@@ -516,6 +516,133 @@ def test_boot_reconcile_refreshes_copied_hooks(monkeypatch, tmp_path):
   assert "hooks=refreshed" in summary
 
 
+def _make_hook_repo(tmp_path: Path, *, complete: bool = True) -> Path:
+  tmp_path.mkdir(parents=True, exist_ok=True)
+  repo = tmp_path / "hook-repo"
+  _git(tmp_path, "init", "-b", "main", str(repo))
+  scripts = repo / "scripts"
+  (scripts / "githooks").mkdir(parents=True)
+  (scripts / "install-hooks.sh").write_text("#!/bin/sh\nexit 99\n")
+  (scripts / "pre-commit.sh").write_text("#!/bin/sh\necho committed-pre-commit\n")
+  if complete:
+    (scripts / "githooks" / "pre-push").write_text(
+      "#!/bin/sh\necho committed-pre-push\n"
+    )
+  _git(repo, "add", "scripts")
+  _git(repo, "commit", "-q", "-m", "add hooks")
+  return repo
+
+
+def test_hook_refresh_uses_only_committed_allowlisted_sources(tmp_path):
+  repo = _make_hook_repo(tmp_path)
+  # Neither a dirty managed hook nor a newly dropped executable may run merely
+  # because a healthy boot refreshes the installed copies.
+  (repo / "scripts" / "pre-commit.sh").write_text("#!/bin/sh\necho DIRTY\n")
+  (repo / "scripts" / "githooks" / "post-checkout").write_text(
+    "#!/bin/sh\necho UNTRACKED\n"
+  )
+
+  assert pu._refresh_git_hooks(repo) == ""
+
+  hooks = repo / ".git" / "hooks"
+  assert (hooks / "pre-commit").read_text() == (
+    "#!/bin/sh\necho committed-pre-commit\n"
+  )
+  assert (hooks / "pre-push").read_text() == (
+    "#!/bin/sh\necho committed-pre-push\n"
+  )
+  assert not (hooks / "post-checkout").exists()
+  assert (hooks / "pre-commit").stat().st_mode & 0o777 == 0o755
+  assert (hooks / "pre-push").stat().st_mode & 0o777 == 0o755
+  configured = _git(repo, "config", "--local", "--get", "core.hooksPath")
+  assert Path(configured.stdout.strip()) == hooks.resolve()
+
+
+def test_hook_refresh_rolls_back_without_absent_destinations(
+  tmp_path, monkeypatch,
+):
+  repo = _make_hook_repo(tmp_path)
+  assert pu._refresh_git_hooks(repo) == ""
+  hooks = repo / ".git" / "hooks"
+  old = {
+    name: (hooks / name).read_bytes()
+    for name in ("pre-commit", "pre-push")
+  }
+  (repo / "scripts" / "pre-commit.sh").write_text("#!/bin/sh\necho new-commit\n")
+  (repo / "scripts" / "githooks" / "pre-push").write_text(
+    "#!/bin/sh\necho new-push\n"
+  )
+  _git(repo, "add", "scripts")
+  _git(repo, "commit", "-q", "-m", "update hooks")
+
+  real_replace = pu.os.replace
+  failed = False
+
+  def fail_second_hook_once(source, destination):
+    nonlocal failed
+    target = Path(destination)
+    if target.name in old:
+      assert all((hooks / name).exists() for name in old)
+      if target.name == "pre-push" and not failed:
+        failed = True
+        raise OSError("simulated second replacement failure")
+    real_replace(source, destination)
+    if target.name in old:
+      assert all((hooks / name).exists() for name in old)
+
+  monkeypatch.setattr(pu.os, "replace", fail_second_hook_once)
+
+  result = pu._refresh_git_hooks(repo)
+
+  assert "simulated second replacement failure" in result
+  assert {(name, (hooks / name).read_bytes()) for name in old} == set(old.items())
+
+
+def test_hook_refresh_missing_incomplete_and_timeout_are_nonfatal(
+  tmp_path, monkeypatch,
+):
+  missing = tmp_path / "missing"
+  _git(tmp_path, "init", "-b", "main", str(missing))
+  (missing / "README").write_text("old checkout\n")
+  _git(missing, "add", "README")
+  _git(missing, "commit", "-q", "-m", "old checkout")
+  assert pu._refresh_git_hooks(missing) is None
+
+  incomplete = _make_hook_repo(tmp_path / "incomplete", complete=False)
+  result = pu._refresh_git_hooks(incomplete)
+  assert result
+  assert "pre-push" in result
+
+  monkeypatch.setattr(
+    pu, "_refresh_git_hooks_impl",
+    lambda _repo: (_ for _ in ()).throw(
+      subprocess.TimeoutExpired(["git", "show"], timeout=15)
+    ),
+  )
+  assert "TimeoutExpired" in pu._refresh_git_hooks(missing)
+
+
+def test_hook_refresh_config_failure_keeps_complete_first_population(
+  tmp_path, monkeypatch,
+):
+  repo = _make_hook_repo(tmp_path)
+  real_hook_git = pu._hook_git
+
+  def fail_config(repo_path, *args):
+    if args[:3] == ("config", "--local", "core.hooksPath"):
+      return subprocess.CompletedProcess(args, 1, b"", b"config locked")
+    return real_hook_git(repo_path, *args)
+
+  monkeypatch.setattr(pu, "_hook_git", fail_config)
+
+  result = pu._refresh_git_hooks(repo)
+
+  assert "config locked" in result
+  hooks = repo / ".git" / "hooks"
+  assert (hooks / "pre-commit").read_text().startswith("#!/bin/sh")
+  assert (hooks / "pre-push").read_text().startswith("#!/bin/sh")
+
+
 @pytest.mark.asyncio
 async def test_apply_restarts_and_rebuilds_when_update_touches_backend(
   monkeypatch, clone_env,

--- a/backend/tests/test_platform_update.py
+++ b/backend/tests/test_platform_update.py
@@ -473,6 +473,7 @@ async def test_apply_rebuilds_frontend_but_no_restart_when_update_is_frontend_on
   pu.SERVING_SHA_FILE.write_text(served + "\n")  # the running uvicorn's sha
   new = _local_commit(platform, edits={"frontend/src/App.jsx": "export default 2\n"})
   calls = []
+  hook_calls = []
 
   async def fake_rebuild(repo, res):
     calls.append((repo, res.new_sha))
@@ -480,6 +481,10 @@ async def test_apply_rebuilds_frontend_but_no_restart_when_update_is_frontend_on
   monkeypatch.setattr(pu, "_reconcile_under_lock", lambda repo, at_boot: (
     pu.ReconcileResult("updated", served, new, new)
   ))
+  monkeypatch.setattr(
+    pu, "_refresh_git_hooks",
+    lambda repo: hook_calls.append(repo) or "",
+  )
   monkeypatch.setattr(pu, "_rebuild_frontend_after_update_if_needed", fake_rebuild)
 
   res = await pu.apply_platform_update(SimpleNamespace(), platform)
@@ -489,6 +494,26 @@ async def test_apply_rebuilds_frontend_but_no_restart_when_update_is_frontend_on
   assert res["state"] == pu.PlatformUpdateState.UP_TO_DATE.value
   assert res["needs_restart"] is False
   assert calls == [(platform, new)]
+  assert hook_calls == [platform]
+
+
+def test_boot_reconcile_refreshes_copied_hooks(monkeypatch, tmp_path):
+  platform = tmp_path / "platform"
+  platform.mkdir()
+  calls = []
+  monkeypatch.setattr(pu, "PLATFORM_REPO", platform)
+  monkeypatch.setattr(pu, "_reconcile_under_lock", lambda repo, at_boot: (
+    pu.ReconcileResult("up_to_date", "pre-sha", "pre-sha", "target-sha")
+  ))
+  monkeypatch.setattr(
+    pu, "_refresh_git_hooks",
+    lambda repo: calls.append(repo) or "",
+  )
+
+  summary = pu.reconcile_clone_sync()
+
+  assert calls == [platform]
+  assert "hooks=refreshed" in summary
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Repository hooks are installed as durable copies so linked worktrees do not depend on a removable source worktree. A platform update can therefore advance `scripts/pre-commit.sh` while the active copy under the shared Git directory remains stale.

This happened with the existing zero-code-fence Markdown fix: the tracked hook and regression test were correct, but the live copied hook still ran the older arithmetic bug.

## Fix

Reuse the existing deterministic hook installer:

- after every successful owner-applied platform update; and
- on every boot, including an offline or conflict pass that still leaves a complete served tree.

Refresh is bounded to 15 seconds and best-effort. A failure is reported in the boot summary or backend log but never rolls back an otherwise healthy platform update.

## Verification

- all 46 platform-update tests
- privacy-gate integration suite
- the refreshed live hook accepts staged Markdown with zero code fences