### PR TITLE
Apply reviewed labels when opening contributions

### DIFF
--- a/backend/app/routes/github.py
+++ b/backend/app/routes/github.py
@@ -1032,6 +1032,115 @@ def _parse_pr_number(url: str) -> int | None:
   return int(m.group(1)) if m else None
 
 
+def _reviewed_pr_labels(plan: dict) -> list[str]:
+  """Return only the two labels the owner could see in Contribute review."""
+  raw = plan.get("labels")
+  if not isinstance(raw, list):
+    return []
+  labels = []
+  seen = set()
+  for value in raw:
+    if not isinstance(value, str):
+      continue
+    label = value.strip()
+    folded = label.casefold()
+    if not label or len(label) > 50 or "\n" in label or folded in seen:
+      continue
+    seen.add(folded)
+    labels.append(label)
+    if len(labels) == 2:
+      break
+  return labels
+
+
+def _apply_reviewed_pr_labels(
+  repo: Path,
+  upstream_repo: str,
+  number: int | None,
+  labels: list[str],
+) -> dict:
+  """Best-effort add reviewed labels that already exist in the target repo.
+
+  Labeling is deliberately secondary to PR creation: a missing repository
+  label, permission restriction, or transient API failure must not turn an
+  already-open pull request into an apparent failed submission. The outcome is
+  persisted so the review never claims an unavailable label was applied.
+  """
+  if not labels:
+    return {}
+  patch = {
+    "last_submit_labels_requested": labels,
+    "last_submit_labels_applied": [],
+  }
+  if number is None:
+    return {
+      **patch,
+      "last_submit_labels_note": "GitHub did not return a PR number for labeling.",
+    }
+
+  try:
+    available = _gh(
+      repo,
+      "api", "--paginate",
+      f"repos/{upstream_repo}/labels?per_page=100",
+      "--jq", ".[].name",
+      check=False,
+    )
+  except (OSError, subprocess.SubprocessError):
+    return {
+      **patch,
+      "last_submit_labels_note": "Could not verify the repository labels.",
+    }
+  if available.returncode != 0:
+    return {
+      **patch,
+      "last_submit_labels_note": "Could not verify the repository labels.",
+    }
+  by_name = {}
+  for raw_name in (available.stdout or "").splitlines():
+    name = raw_name.strip()
+    if name:
+      by_name[name.casefold()] = name
+  applicable = [by_name[label.casefold()] for label in labels
+                if label.casefold() in by_name]
+  missing = [label for label in labels if label.casefold() not in by_name]
+  if not applicable:
+    return {
+      **patch,
+      "last_submit_labels_missing": missing,
+      "last_submit_labels_note": "The reviewed labels do not exist in this repository.",
+    }
+
+  try:
+    applied = _gh(
+      repo,
+      "api", "--method", "POST",
+      f"repos/{upstream_repo}/issues/{number}/labels",
+      *(part for label in applicable for part in ("-f", f"labels[]={label}")),
+      check=False,
+    )
+  except (OSError, subprocess.SubprocessError):
+    return {
+      **patch,
+      "last_submit_labels_missing": missing,
+      "last_submit_labels_note": "GitHub did not allow these labels to be applied.",
+    }
+  if applied.returncode != 0:
+    return {
+      **patch,
+      "last_submit_labels_missing": missing,
+      "last_submit_labels_note": "GitHub did not allow these labels to be applied.",
+    }
+  result = {
+    **patch,
+    "last_submit_labels_applied": applicable,
+  }
+  if missing:
+    result["last_submit_labels_missing"] = missing
+    result["last_submit_labels_note"] = "Some reviewed labels no longer exist."
+  return result
+
+
 def _find_existing_pr(
   repo: Path,
   upstream_repo: str,
@@ -1702,7 +1811,18 @@ def _submit_prepared_pr(
             same_repo=bool(direct_base),
           )
           if existing:
-            return existing, _parse_pr_number(existing), pushed_patch
+            existing_number = _parse_pr_number(existing)
+            label_patch = _apply_reviewed_pr_labels(
+              repo,
+              upstream_repo,
+              existing_number,
+              _reviewed_pr_labels(plan),
+            )
+            return (
+              existing,
+              existing_number,
+              _record_patch_with(pushed_patch, label_patch),
+            )
           detail = (pr.stderr or pr.stdout or "GitHub command failed.").strip()
           raise ContributionSubmitError(detail[:600] or "GitHub command failed.")
       except ContributionSubmitError as exc:
@@ -1723,7 +1843,14 @@ def _submit_prepared_pr(
         f"to {pushed_branch_url}.",
         record_patch=pushed_patch,
       )
-    return url, _parse_pr_number(url), pushed_patch
+    number = _parse_pr_number(url)
+    label_patch = _apply_reviewed_pr_labels(
+      repo,
+      upstream_repo,
+      number,
+      _reviewed_pr_labels(plan),
+    )
+    return url, number, _record_patch_with(pushed_patch, label_patch)
   finally:
     if checkout_back:
       _git(repo, "checkout", "-q", checkout_back, check=False)

--- a/backend/tests/test_github_routes.py
+++ b/backend/tests/test_github_routes.py
@@ -748,6 +748,91 @@ def test_graphql_mutation_as_string_literal_allowed(client, auth, monkeypatch):
 # --- contribution submit (approval button path) -----------------------
 
 
+def test_reviewed_pr_labels_are_bounded_to_the_visible_two():
+  assert github_routes._reviewed_pr_labels({
+    "labels": [" bug ", "area: ui", "hidden-third"],
+  }) == ["bug", "area: ui"]
+  assert github_routes._reviewed_pr_labels({
+    "labels": ["bug", "BUG", "area: ui"],
+  }) == ["bug", "area: ui"]
+  assert github_routes._reviewed_pr_labels({
+    "labels": [None, "bug", "area: ui"],
+  }) == ["bug", "area: ui"]
+  assert github_routes._reviewed_pr_labels({"labels": "bug"}) == []
+
+
+def test_pr_labels_apply_only_existing_names_and_preserve_missing(
+  monkeypatch, tmp_path,
+):
+  calls = []
+
+  def fake_gh(repo, *args, check=True):
+    calls.append(args)
+    if "--paginate" in args:
+      return _cp("bug\narea: ui\n")
+    return _cp("[]")
+
+  monkeypatch.setattr(github_routes, "_gh", fake_gh)
+  patch = github_routes._apply_reviewed_pr_labels(
+    tmp_path,
+    "mobius-os/mobius",
+    123,
+    ["Bug", "area: backend"],
+  )
+
+  assert patch["last_submit_labels_requested"] == ["Bug", "area: backend"]
+  assert patch["last_submit_labels_applied"] == ["bug"]
+  assert patch["last_submit_labels_missing"] == ["area: backend"]
+  assert "Some reviewed labels" in patch["last_submit_labels_note"]
+  apply_call = calls[-1]
+  assert apply_call[:3] == ("api", "--method", "POST")
+  assert "labels[]=bug" in apply_call
+  assert "labels[]=area: backend" not in apply_call
+
+
+def test_pr_label_permission_failure_does_not_fail_an_open_pr(
+  monkeypatch, tmp_path,
+):
+  def fake_gh(repo, *args, check=True):
+    if "--paginate" in args:
+      return _cp("bug\n")
+    return _cp("forbidden", returncode=1)
+
+  monkeypatch.setattr(github_routes, "_gh", fake_gh)
+  patch = github_routes._apply_reviewed_pr_labels(
+    tmp_path,
+    "someone/example",
+    7,
+    ["bug"],
+  )
+
+  assert patch["last_submit_labels_applied"] == []
+  assert "did not allow" in patch["last_submit_labels_note"]
+
+
+def test_pr_label_transport_exception_does_not_fail_an_open_pr(
+  monkeypatch, tmp_path,
+):
+  monkeypatch.setattr(
+    github_routes,
+    "_gh",
+    lambda *_args, **_kwargs: (_ for _ in ()).throw(
+      subprocess.TimeoutExpired("gh", 30),
+    ),
+  )
+
+  patch = github_routes._apply_reviewed_pr_labels(
+    tmp_path,
+    "someone/example",
+    7,
+    ["bug"],
+  )
+
+  assert patch["last_submit_labels_requested"] == ["bug"]
+  assert patch["last_submit_labels_applied"] == []
+  assert "Could not verify" in patch["last_submit_labels_note"]
+
+
 def _write_contribution(app_id, record_id, record, diff_text=""):
   base = Path(get_settings().data_dir) / "apps" / str(app_id) / "contributions"
   base.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

- accept at most two owner-reviewed PR labels from a prepared contribution
- resolve labels against the target repository's current taxonomy before applying them
- preserve the PR as successfully open when labels are missing, permissions are insufficient, or GitHub label lookup times out
- record requested, applied, and missing labels so Contribute reports the real outcome

## Companion

mobius-os/app-contribute#13 shows the proposed labels and related-work evidence in the review UI.

## Verification

- all 88 GitHub route tests
- transport-exception, permission, missing-label, duplicate, and visible-two regressions
- `git diff --check`