### PR TITLE
feat(chat): resume automatically after planned restarts

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -740,6 +740,34 @@ real turn as a `<compacted_chat>` block, so the new agent continues rather than
 starting cold. Same-provider model swaps skip the handoff because their session
 context is preserved.
 
+### Automatic continuation
+
+The per-chat continuation switch covers both provider-limit resets and
+**planned, drain-gated server restarts** (the persisted API/column name remains
+`auto_resume_on_limit` for rolling-client compatibility). Both paths converge
+on the existing `ChatRun.status="resume_pending"` gate and are claimed through
+the same transition lock, queue lock, global-idle check, actor append/promote,
+and identity-keyed rollback. The synthetic provider-facing user text remains
+`continue`; its persisted row carries `kind="auto_continuation"` plus a reason,
+so the UI renders a quiet marker rather than attributing text to the owner.
+
+| Durable state at recovery | Policy/ownership | Transition |
+|---|---|---|
+| Due provider park | Enabled owner chat | `parked → resume_pending →` one serial continuation |
+| Exact drain-for-update pause | Enabled owner chat, no open question/app queue | `running → resume_pending →` one serial continuation |
+| Planned restart, policy disabled | Any | `running → interrupted`; manual Resume |
+| Crash/OOM without the exact drain note | Any | `running → interrupted`; manual Resume (prevents reboot loops) |
+| Open question or app-attributed work | Any | `running → interrupted`; question/app ownership is preserved |
+| Manual send/provider switch/delete/newer run | Any pending auto state | Existing identity gate supersedes or retires it |
+
+The lifespan creates no short-interval polling loop. Its indexed due-run sweep
+executes once immediately after startup yields to serving, then at most once per
+minute. A sweep that finds another due continuation specifically blocked by the
+global live-turn gate returns a wait hint; only then does the loop wake early on
+the process-local `chat_run_finished` event. Ordinary completed turns do not
+trigger another database query. Automatic continuations therefore stay strictly
+serial and drain promptly without paying a per-turn polling cost.
+
 ### Staying aligned (enforcement)
 
 This section is the **owner-authoritative source of truth** for chat UX; the

--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -1177,15 +1177,23 @@ def reconcile_interrupted_chats(db: Session) -> list[str]:
       in ``messages`` (it was committed at turn start); ``pending_messages``
       holds only the SUBSEQUENT sends the user queued while that turn ran,
       so preserving them does NOT re-run the interrupted turn — it just
-      keeps the unsent queue. We deliberately do NOT auto-drain it here:
+      keeps the unsent queue. We deliberately do NOT auto-drain it inside
+      pre-serving reconciliation:
       clearing only the run marker (below) leaves the chat in the SAME
       markerless state (``run_status=None`` + non-empty queue) the bottom
       of this function already documents, which self-heals on the NEXT user
       POST via the stale-pending drain in ``chats_stream.send_message``
-      (it claims ``mark_starting`` and promotes the head). Auto-promoting
-      at boot is what the crash-loop concern below forbids; a drain gated
-      on an explicit user interaction does not re-spawn turns during boot;
-    - clear the durable run marker.
+      (it claims ``mark_starting`` and promotes the head). A planned update may
+      instead create a retryable signal below, consumed by the ordinary serial
+      sweep only after startup yields. Generic crashes never create that signal,
+      which preserves the crash-loop safety boundary;
+    - clear the durable run marker. When the turn carries the exact
+      drain-for-update note and the chat's automatic-continuation policy is
+      enabled, its latest owner-run record moves to the existing retryable
+      ``resume_pending`` state instead of becoming terminal. The normal reset
+      sweep then starts one continuation after serving begins. Generic crashes,
+      app-attributed work, and unanswered questions remain manual recovery so
+      a bad turn cannot create a reboot loop.
 
   No queue lock is taken: this runs single-threaded at startup before
   any POST /messages can land, so the serialization invariant that the
@@ -1219,10 +1227,12 @@ def reconcile_interrupted_chats(db: Session) -> list[str]:
   recovered live: the marker stays set and reconciliation only sees it on the
   next boot. Under the single-owner restart-recovery contract this is
   acceptable: the turn is durable, the marker is the recovery handle, and a
-  restart resolves it. `_schedule_continuation`'s scheduling-failure path is the
-  same shape (marker left, recovered on restart). A future live-recovery would
-  gate the marker on an in-process watcher that reschedules a late promote
-  without a restart; deliberately deferred.
+  restart resolves it. A planned, drain-gated restart may then continue it
+  automatically under the explicit per-chat policy below; an unplanned crash
+  remains a manual Resume. `_schedule_continuation`'s scheduling-failure path
+  is the same shape (marker left, recovered on restart). A future live-recovery
+  would gate the marker on an in-process watcher that reschedules a late
+  promote without a restart; deliberately deferred.
 
   Intentional direct-write exception to the C2 single-writer rule: this
   mutates `chat.messages` / `chat.pending_messages` / the run marker
@@ -1261,8 +1271,15 @@ def reconcile_interrupted_chats(db: Session) -> list[str]:
       continue
     try:
       queued = len(chat.pending_messages or [])
+      app_work_queued = any(
+        isinstance(msg, dict)
+        and msg.get("_initiated_by_app_id") is not None
+        for msg in (chat.pending_messages or [])
+      )
       from app.chat_transcript import materialized_messages
       msgs = materialized_messages(chat)
+      planned_restart = False
+      waiting_for_answer = False
       note = "This turn was paused when Möbius restarted."
       if queued:
         # The queue is PRESERVED across the restart (it is NOT cleared
@@ -1292,32 +1309,55 @@ def reconcile_interrupted_chats(db: Session) -> list[str]:
         # A drain-gated restart (design §2.2) already wrote its own terminal
         # "paused for a platform update" note through the sink before the
         # process went down. Don't stack a second interrupted note on top of
-        # it — just mark THAT note resumable so the Resume affordance renders,
-        # and persist the finalized tool-block state. Only the drain's exact
-        # note text qualifies, so a live provider error never gets a spurious
-        # Resume button here.
-        paused_idx = next(
-          (len(blocks) - 1 - i
-           for i, b in enumerate(reversed(blocks))
-           if b.get("type") == "error"
-           and b.get("message") == PAUSED_FOR_RESTART_MESSAGE),
-          None,
+        # it — reuse THAT note and persist the finalized tool-block state. It
+        # becomes resumable unless it sits after a durable unanswered question,
+        # in which case the question remains the sole recovery affordance. Only
+        # the drain's exact note text qualifies, so a live provider error never
+        # gets a spurious Resume button here.
+        terminal_block = blocks[-1] if blocks else None
+        paused_idx = (
+          len(blocks) - 1
+          if (
+            terminal_block is not None
+            and terminal_block.get("type") == "error"
+            and terminal_block.get("message") == PAUSED_FOR_RESTART_MESSAGE
+          )
+          else None
         )
         if paused_idx is not None:
-          # The drain wrote the terminal note; just make it resumable — and
-          # carry `pause` so a note persisted before the descriptor existed
-          # (or one whose live event never landed) still renders in the calm
-          # "Paused" family — then fall through to the shared write-back below
-          # (no second note appended). Replace with a FRESH dict rather than
-          # mutating the ORM-loaded block in place: `Chat.messages` is a plain
-          # JSON column with no mutation tracking, so an in-place edit to a
-          # loaded block is not flushed — only a genuinely new value in the
-          # reassigned list persists (every other reconcile branch appends a
-          # fresh block for the same reason).
-          blocks[paused_idx] = {
-            **blocks[paused_idx], "resumable": True,
+          # A question can be persisted immediately before the drain's exact
+          # restart note (text -> question -> restart error). Remove the note
+          # temporarily before applying the tail-question invariant: otherwise
+          # the error hides the durable handoff and reconciliation mistakes the
+          # run for safe automatic work. When a question is exposed, put the
+          # calm pause note BEFORE it and keep it inert so the question remains
+          # the one answerable tail affordance.
+          remaining = blocks[:paused_idx] + blocks[paused_idx + 1:]
+          trailing_open_start = len(remaining)
+          while trailing_open_start > 0:
+            block = remaining[trailing_open_start - 1]
+            if block.get("type") != "question" or block.get("answers"):
+              break
+            trailing_open_start -= 1
+          waiting_for_answer = trailing_open_start < len(remaining)
+
+          # Replace with a FRESH dict rather than mutating the ORM-loaded block
+          # in place: `Chat.messages` is a plain JSON column with no mutation
+          # tracking, so only a genuinely new value in the reassigned list is
+          # flushed.
+          pause_block = {
+            **blocks[paused_idx], "resumable": not waiting_for_answer,
             "pause": {"kind": "restart"},
           }
+          if waiting_for_answer:
+            blocks = (
+              remaining[:trailing_open_start]
+              + [pause_block]
+              + remaining[trailing_open_start:]
+            )
+          else:
+            blocks[paused_idx] = pause_block
+          planned_restart = True
         else:
           # Preserve a tail unanswered question. It is a durable human handoff,
           # not a disposable in-memory callback: the route can record the later
@@ -1333,6 +1373,7 @@ def reconcile_interrupted_chats(db: Session) -> list[str]:
               break
             trailing_open_start -= 1
           if trailing_open_start < len(blocks):
+            waiting_for_answer = True
             # The tail affordance here is the QUESTION card — answering it is
             # how this turn resumes. A Resume button on the note would compete
             # with the card and send a visible "continue" instead of the
@@ -1384,14 +1425,47 @@ def reconcile_interrupted_chats(db: Session) -> list[str]:
       # so the run record matches reality. (Flipping the destructive read onto
       # chat_runs + retiring run_status is the Step-3b follow-up, once the
       # record is proven in prod.)
-      for run in (
+      running_runs = (
         db.query(models.ChatRun)
         .filter(models.ChatRun.chat_id == chat.id)
         .filter(models.ChatRun.status == "running")
         .all()
-      ):
-        run.status = "interrupted"
-        run.ended_at = datetime.now(UTC)
+      )
+      latest_run = (
+        db.query(models.ChatRun)
+        .filter(models.ChatRun.chat_id == chat.id)
+        .order_by(
+          models.ChatRun.started_at.desc(), models.ChatRun.id.desc(),
+        )
+        .first()
+      )
+      restart_resume_id = (
+        latest_run.id
+        if (
+          latest_run is not None
+          and any(run.id == latest_run.id for run in running_runs)
+          and planned_restart
+          and not waiting_for_answer
+          and bool(chat.auto_resume_on_limit)
+          and latest_run.initiated_by_app_id is None
+          and not app_work_queued
+        )
+        else None
+      )
+      ended_at = datetime.now(UTC)
+      for run in running_runs:
+        if run.id == restart_resume_id:
+          # Reuse the provider-limit retry state instead of creating another
+          # durable automaton. Every existing manual-send/provider-switch/
+          # delete gate already supersedes resume_pending safely. A due time
+          # of "now" makes the shared sweep pick it up on its immediate boot
+          # pass, after the server has begun accepting requests.
+          run.status = "resume_pending"
+          run.parked_until = ended_at.replace(tzinfo=None)
+          run.park_reason = "restart"
+        else:
+          run.status = "interrupted"
+        run.ended_at = ended_at
       db.commit()
       reconciled.append(chat.id)
     except Exception:
@@ -1475,7 +1549,7 @@ def reconcile_interrupted_chats(db: Session) -> list[str]:
 
 
 def notify_after_reconcile(db: Session, reconciled: list[str]) -> str | None:
-  """Push-notify once that paused turn(s) can be resumed (design §2.2 step 4).
+  """Push-notify once that paused turn(s) recovered (design §2.2 step 4).
 
   Called from the lifespan right after `reconcile_interrupted_chats`, so a
   drain-gated restart (or any crash that left turns mid-flight) surfaces a
@@ -1495,11 +1569,48 @@ def notify_after_reconcile(db: Session, reconciled: list[str]) -> str | None:
   from app import push
 
   single = reconciled[0] if len(reconciled) == 1 else None
+  # One startup-only indexed query, not one query per interrupted chat.
+  latest_by_chat: dict[str, models.ChatRun] = {}
+  for run in (
+    db.query(models.ChatRun)
+    .filter(models.ChatRun.chat_id.in_(reconciled))
+    .order_by(
+      models.ChatRun.chat_id.asc(),
+      models.ChatRun.started_at.desc(),
+      models.ChatRun.id.desc(),
+    )
+    .all()
+  ):
+    latest_by_chat.setdefault(run.chat_id, run)
+  automatic = 0
+  for chat_id in reconciled:
+    latest = latest_by_chat.get(chat_id)
+    if (
+      latest is not None
+      and latest.status == "resume_pending"
+      and latest.park_reason == "restart"
+    ):
+      automatic += 1
+  if automatic == len(reconciled):
+    title = "Continuing after restart"
+    body = (
+      "Möbius restarted and your turn will continue automatically."
+      if single
+      else "Möbius restarted and your turns will continue automatically."
+    )
+  elif automatic:
+    title = "Turns recovered after restart"
+    body = (
+      f"{automatic} will continue automatically; the rest are ready to resume."
+    )
+  else:
+    title = "Turn paused for an update"
+    body = "Your turn was paused for an update — tap to resume."
   return push.notify_owner(
     db,
     owner.id,
-    title="Turn paused for an update",
-    body="Your turn was paused for an update — tap to resume.",
+    title=title,
+    body=body,
     source_type="system",
     source_id=single,
     target=(f"/shell/?chat={single}" if single else None),
@@ -1923,7 +2034,7 @@ LIMIT_RESET_NOTIFY_BODY = "Your limit has reset."
 async def _auto_resume_chat(
   chat_id: str, provider_id: str | None, park_token: str | None = None,
 ) -> bool:
-  """Start ONE continue turn for a limit-parked chat whose reset arrived.
+  """Start ONE automatic continue turn for a due durable resume signal.
 
   The opt-in half of design §2.4 — mirrors the stale-pending drain in
   chats_stream.send_message (the same claim → append → promote → schedule
@@ -1951,7 +2062,9 @@ async def _auto_resume_chat(
   interrupted/resumable for manual recovery; automatic retry across that
   window requires a durable predecessor/payload link and is not claimed here.
 
-  Re-park-on-re-hit is automatic: the resumed turn is an ordinary turn, so
+  Planned restarts reuse the same signal with ``park_reason='restart'``;
+  unplanned crashes never enter it. Re-park-on-re-hit is automatic: the
+  resumed turn is an ordinary turn, so
   if it dies on the limit again it parks again with a fresh reset time.
   Returns True when a turn was scheduled.
   """
@@ -2002,6 +2115,7 @@ async def _auto_resume_chat(
               or not chat.auto_resume_on_limit
               or park is None
               or park.status != "resume_pending"
+              or park.initiated_by_app_id is not None
               or latest_id != park.id
               or any(
                 isinstance(msg, dict)
@@ -2011,6 +2125,7 @@ async def _auto_resume_chat(
             ):
               return False
             current_provider = chat.provider or "claude"
+            resume_reason = park.park_reason or "usage_limit"
           if not mark_starting(chat_id):
             return False
           claimed = True
@@ -2022,9 +2137,19 @@ async def _auto_resume_chat(
                 "role": "user",
                 "content": "continue",
                 "ts": int(time.time() * 1000),
+                # Persist the automatic action as a product marker. It remains
+                # a provider-facing user "continue", but the transcript can
+                # render the reason honestly instead of impersonating a user
+                # message.
+                "kind": "auto_continuation",
+                "continuation_reason": resume_reason,
                 # A retry after AppendPending succeeded but a later step failed
                 # must not enqueue a second synthetic continuation.
-                "cid": f"limit-resume-{park_token or chat_id}",
+                "cid": (
+                  f"restart-resume-{park_token or chat_id}"
+                  if resume_reason == "restart"
+                  else f"limit-resume-{park_token or chat_id}"
+                ),
               },
             )
           )
@@ -2079,16 +2204,21 @@ async def _auto_resume_chat(
     return False
 
 
-async def sweep_reset_parks(db: Session) -> list[str]:
-  """Notify (and optionally auto-resume) limit-parked chats at reset time.
+async def sweep_reset_parks(
+  db: Session, *, include_wait_hint: bool = False,
+) -> list[str] | tuple[list[str], bool]:
+  """Notify and start due automatic continuations.
 
   The third lifespan sweep (same 60s loop shape as the wedged-marker and
   stalled-live sweeps). A due park is a `chat_runs` row still
   ``status`` is ``parked`` or ``resume_pending`` and whose
-  `parked_until` has passed. For each, oldest reset first:
+  `parked_until` has passed. This includes provider-limit resets and the
+  planned-restart signals written by startup reconciliation. For each, oldest
+  due time first:
 
     - Notify-only parks resolve first, then send one best-effort notification.
-    - Auto-resume parks first become ``resume_pending``. That durable
+    - Auto-resume parks first become ``resume_pending``. Planned restarts are
+      created in that state already. The durable
       state suppresses duplicate notifications but remains sweepable until a
       continuation is actually scheduled; a race or reported task-creation
       failure cannot silently consume the promised continuation. The narrow
@@ -2101,12 +2231,24 @@ async def sweep_reset_parks(db: Session) -> list[str]:
       and queues never auto-resume.
 
   Stands down while draining — a restart is in progress, and the boot
-  reconcile + this sweep's next tick pick everything up. Never raises.
+  reconcile + this sweep's next tick pick everything up. When
+  ``include_wait_hint`` is true, returns ``(resolved, wait_for_turn_finish)``;
+  the second value is true only when another due automatic continuation is
+  specifically waiting on the global live-turn gate. This lets the lifespan
+  loop wake on useful completion events without querying after every ordinary
+  turn. Never raises.
   """
   log = _get_logger()
   resolved: list[str] = []
-  if draining:
+  wait_for_turn_finish = False
+
+  def result() -> list[str] | tuple[list[str], bool]:
+    if include_wait_hint:
+      return resolved, wait_for_turn_finish
     return resolved
+
+  if draining:
+    return result()
   now = datetime.now(UTC).replace(tzinfo=None)
   try:
     due = (
@@ -2119,9 +2261,9 @@ async def sweep_reset_parks(db: Session) -> list[str]:
     )
   except Exception:
     log.exception("sweep_reset_parks: query failed")
-    return resolved
+    return result()
   if not due:
-    return resolved
+    return result()
 
   def notify_reset(chat_id: str) -> None:
     try:
@@ -2169,6 +2311,7 @@ async def sweep_reset_parks(db: Session) -> list[str]:
       # owner's own send) must settle before this opted-in park is processed.
       # Leave this park untouched, but keep walking so a later notify-only
       # chat is not held hostage by another chat's auto-resume preference.
+      wait_for_turn_finish = True
       continue
     if auto_resume:
       try:
@@ -2225,12 +2368,17 @@ async def sweep_reset_parks(db: Session) -> list[str]:
         # The notification or refresh window admitted another turn. Keep the
         # durable pending state so the next sweep retries instead of silently
         # dropping the promised continuation.
+        wait_for_turn_finish = True
         continue
       auto_resume_started = await _auto_resume_chat(
         chat_id, chat.provider, park_token=run.id,
       )
       if auto_resume_started:
         resolved.append(chat_id)
+      elif _any_chat_turn_active():
+        # A turn can win the final locked claim inside `_auto_resume_chat`.
+        # Its completion is the useful event that should trigger our retry.
+        wait_for_turn_finish = True
       continue
 
     # Notify-only/app/deleted path: resolve before the best-effort push so a
@@ -2254,10 +2402,10 @@ async def sweep_reset_parks(db: Session) -> list[str]:
       notify_reset(chat_id)
   if resolved:
     log.info(
-      "limit-reset sweep resolved %d park(s): %s",
+      "automatic-continuation sweep resolved %d park(s): %s",
       len(resolved), ", ".join(resolved),
     )
-  return resolved
+  return result()
 
 
 async def _clear_pending(chat_id: str) -> list[str]:
@@ -3425,11 +3573,12 @@ def _last_user_message_elapsed(db, chat_id: str) -> str | None:
 
   Reads the persisted transcript (read-only) and scans back from the
   current turn's user message (messages[-1]) for the most recent message
-  carrying a usable wall-clock `ts`. User messages carry a millisecond ts
-  from the client; assistant messages historically persisted ts=None, so
-  we skip to the last message with a sane ts. This gives the agent a sense
-  of how long since the user last engaged ("you last spoke 3 days ago"),
-  which the bare clock can't convey. Best-effort: any failure → None.
+  carrying a usable wall-clock `ts`. Owner messages carry a millisecond ts
+  from the client; assistant messages historically persisted ts=None, and
+  product-authored automatic continuation markers deliberately do not count as
+  the owner speaking, so both are skipped. This gives the agent a sense of how
+  long since the owner last engaged ("you last spoke 3 days ago"), which the
+  bare clock can't convey. Best-effort: any failure → None.
   """
   try:
     import time as _time
@@ -3440,9 +3589,14 @@ def _last_user_message_elapsed(db, chat_id: str) -> str | None:
     msgs = (chat.messages if chat else None) or []
     now_ms = _time.time() * 1000.0
     for m in reversed(msgs[:-1]):  # skip the current (just-committed) message
-      # Only USER messages count — the label is "user's last message", and
-      # assistant rows would otherwise report the gap since the agent spoke.
-      if not isinstance(m, dict) or m.get("role") != "user":
+      # Only owner-authored USER messages count — the label is "user's last
+      # message". Assistant rows and automatic product markers would otherwise
+      # report the gap since Möbius, rather than the owner, spoke.
+      if (
+        not isinstance(m, dict)
+        or m.get("role") != "user"
+        or m.get("kind") == "auto_continuation"
+      ):
         continue
       ts = m.get("ts")
       if not isinstance(ts, (int, float)) or ts <= 0:
@@ -3758,7 +3912,9 @@ def _build_resumed_context(chat_row) -> str | None:
   whole turn would hard-fail. Möbius owns the durable transcript in the
   DB (`Chat.messages`), so instead of resuming we start a fresh session
   and hand the agent its own prior conversation as context — continuity
-  is preserved without the CLI session file.
+  is preserved without the CLI session file. Product-authored automatic
+  continuation rows retain their action but receive an explicit label rather
+  than being attributed to the owner.
 
   Truncation: we keep only the most recent messages that fit in a
   ~12 KB character budget (oldest-first dropped), so a long history
@@ -3784,7 +3940,11 @@ def _build_resumed_context(chat_row) -> str | None:
     content = msg.get("content")
     if not isinstance(content, str) or not content.strip():
       continue
-    speaker = "User" if role == "user" else "Assistant"
+    if msg.get("kind") == "auto_continuation":
+      reason = msg.get("continuation_reason") or "automatic recovery"
+      speaker = f"Automatic continuation ({reason})"
+    else:
+      speaker = "User" if role == "user" else "Assistant"
     line = f"{speaker}: {content.strip()}"
     if used + len(line) > _RESUME_CONTEXT_CHAR_BUDGET and lines:
       break

--- a/backend/app/compaction.py
+++ b/backend/app/compaction.py
@@ -111,11 +111,13 @@ def build_transcript_text(
 ) -> str:
   """Render the chat's messages into the plain text the summarizer reads.
 
-  Each message becomes a `ROLE: content` line. Tool blocks and other
-  non-text structure are dropped — the summary cares about the dialogue
-  and the assistant's prose, not the raw tool I/O. By default the result is
-  tail-capped to `_MAX_TRANSCRIPT_CHARS`; provider handoffs pass
-  ``max_chars=None`` and progressively synthesize the complete transcript.
+  Each message becomes a `ROLE: content` line. Product-authored automatic
+  continuations keep a distinct role label rather than impersonating the
+  owner. Tool blocks and other non-text structure are dropped — the summary
+  cares about the dialogue and the assistant's prose, not the raw tool I/O.
+  By default the result is tail-capped to `_MAX_TRANSCRIPT_CHARS`; provider
+  handoffs pass ``max_chars=None`` and progressively synthesize the complete
+  transcript.
   """
   lines: list[str] = []
   for m in messages or []:
@@ -123,7 +125,11 @@ def build_transcript_text(
     # it back into a later synthesis recursively inflates the next handoff.
     if m.get("kind") == "compaction":
       continue
-    role = (m.get("role") or "user").upper()
+    if m.get("kind") == "auto_continuation":
+      reason = str(m.get("continuation_reason") or "automatic recovery")
+      role = f"AUTOMATIC CONTINUATION ({reason.upper()})"
+    else:
+      role = (m.get("role") or "user").upper()
     content = m.get("content") or ""
     if not content.strip():
       continue

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -533,22 +533,53 @@ async def lifespan(app):
 
     _stalled_live_task = _asyncio.create_task(_stalled_live_loop())
 
-    # Provider-limit reset sweep (design §2.4): notifies once when a parked
-    # turn's reset time arrives, and — when the owner opted in — starts the
-    # strictly-serial auto-resume. Same shape as the two loops above.
+    # Durable automatic-continuation sweep (design §2.4): notifies once when
+    # a provider-limit reset arrives and starts either that continuation or a
+    # planned-restart continuation when the owner opted in. It runs once as
+    # soon as lifespan yields (so startup is fully complete and requests can
+    # be served), then wakes on a turn-finished event only when the preceding
+    # sweep found another due continuation blocked by a live turn, or at the
+    # 60s safety cadence. That hint drains recovered chats serially without
+    # querying after every unrelated ordinary turn.
     async def _reset_park_loop():
-      while True:
-        await _asyncio.sleep(60)
-        try:
-          _rp_db = _SweepSession()
+      from app.broadcast import get_system_broadcast as _system_broadcast
+      _resume_events = _system_broadcast().subscribe()
+      try:
+        while True:
+          _wait_for_turn_finish = False
           try:
-            await sweep_reset_parks(_rp_db)
-          finally:
-            _rp_db.close()
-        except _asyncio.CancelledError:
-          raise
-        except Exception as _exc:
-          _log.error("reset-park sweep failed: %s", _exc, exc_info=True)
+            _rp_db = _SweepSession()
+            try:
+              _, _wait_for_turn_finish = await sweep_reset_parks(
+                _rp_db, include_wait_hint=True,
+              )
+            finally:
+              _rp_db.close()
+          except _asyncio.CancelledError:
+            raise
+          except Exception as _exc:
+            _log.error("reset-park sweep failed: %s", _exc, exc_info=True)
+
+          _loop = _asyncio.get_running_loop()
+          _deadline = _loop.time() + 60
+          while True:
+            _remaining = _deadline - _loop.time()
+            if _remaining <= 0:
+              break
+            try:
+              _event = await _asyncio.wait_for(
+                _resume_events.get(), timeout=_remaining,
+              )
+            except _asyncio.TimeoutError:
+              break
+            if (
+              _wait_for_turn_finish
+              and _event
+              and _event.get("type") == "chat_run_finished"
+            ):
+              break
+      finally:
+        _system_broadcast().unsubscribe(_resume_events)
 
     _reset_park_task = _asyncio.create_task(_reset_park_loop())
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -35,7 +35,7 @@ class Owner(Base):
   hashed_password = Column(String(255), nullable=False)
   # Must stay in sync with providers.PROVIDER_NAMES.
   provider = Column(String(32), nullable=False, default="claude")
-  # Default provider-limit recovery policy for newly-created chats. Each chat
+  # Default automatic-continuation policy for newly-created chats. Each chat
   # stores its own copy; changing a chat's switch updates this seed for the
   # next chat without rewriting any existing conversation.
   auto_resume_on_limit_default = Column(
@@ -124,7 +124,9 @@ class Chat(Base):
   # start afterwards. Nullable is the migration/empty-chat state: the first
   # turn snapshots it atomically before invoking a provider.
   system_prompt_snapshot_id = Column(String(64), nullable=True, default=None)
-  # Per-chat policy for provider-limit recovery. Kept out of
+  # Per-chat policy for automatic recovery after provider limits and planned
+  # server restarts. The legacy column/API name is retained for compatibility.
+  # Kept out of
   # agent_settings_json because that blob is snapshotted/mirrored as SDK
   # runtime configuration; mixing this policy into it can skip first-send
   # model snapshots or overwrite the owner's global model defaults.
@@ -221,7 +223,8 @@ class ChatRun(Base):
   # "running" while in flight; terminal outcomes are "completed" for a clean
   # turn, "failed" for a provider/setup error, "stopped" for an explicit user
   # Stop, and "interrupted" for crash/supersession/watchdog recovery. Provider
-  # limits additionally use the parked/resume_pending/parked_notified states.
+  # limits additionally use the parked/resume_pending/parked_notified states;
+  # a planned restart briefly reuses resume_pending with park_reason=restart.
   status = Column(String(16), nullable=False, default="running", index=True)
   provider = Column(String(32), nullable=True, default=None)
   # App that initiated this turn under the app-attributed-chat contract

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -393,9 +393,10 @@ class ChatPatch(BaseModel):
   title: str | None = Field(default=None, max_length=500)
   # Drawer pin toggle. True sets pinned_at = now, False clears it.
   pinned: bool | None = None
-  # Per-chat opt-in to continuing a provider-limited turn at reset. This is
-  # intentionally absent from SettingsUpdate: background agents and other
-  # chats must never inherit it.
+  # Per-chat opt-in to continuing after a provider-limit reset or a planned
+  # server restart. The legacy wire name remains compatible with installed
+  # clients. This is intentionally absent from SettingsUpdate: background
+  # agents and unrelated existing chats must never inherit a runtime change.
   auto_resume_on_limit: bool | None = None
   # Naming precedence. by_agent marks an AGENT title-sync — it fills the name
   # only when the owner hasn't locked it via a manual rename. clear_title resets

--- a/backend/tests/test_chat_compact.py
+++ b/backend/tests/test_chat_compact.py
@@ -586,6 +586,18 @@ def test_build_transcript_text_skips_handoffs_and_tail_caps():
   assert len(capped) == compaction._MAX_TRANSCRIPT_CHARS
 
 
+def test_build_transcript_text_labels_automatic_continuation_as_product_event():
+  text = compaction.build_transcript_text([{
+    "role": "user",
+    "kind": "auto_continuation",
+    "continuation_reason": "usage_limit",
+    "content": "continue",
+  }])
+
+  assert text == "AUTOMATIC CONTINUATION (USAGE_LIMIT): continue"
+  assert "USER: continue" not in text
+
+
 def test_cumulative_chat_summary_is_unbounded_compaction_source(tmp_path):
   note = tmp_path / "shared" / "memory" / "chats" / "c1" / "index.md"
   note.parent.mkdir(parents=True)

--- a/backend/tests/test_claude_sdk_session_id.py
+++ b/backend/tests/test_claude_sdk_session_id.py
@@ -231,6 +231,21 @@ def test_resumed_context_skips_non_conversation_rows():
   assert "ignored" not in block
 
 
+def test_resumed_context_does_not_attribute_automatic_continue_to_owner():
+  from app.chat import _build_resumed_context
+
+  row = _FakeChatRow([{
+    "role": "user",
+    "kind": "auto_continuation",
+    "continuation_reason": "restart",
+    "content": "continue",
+  }])
+  block = _build_resumed_context(row)
+
+  assert "Automatic continuation (restart): continue" in block
+  assert "User: continue" not in block
+
+
 def test_resumed_context_none_when_empty():
   """A chat with no usable transcript yields no reseed block."""
   from app.chat import _build_resumed_context

--- a/backend/tests/test_drain_for_restart.py
+++ b/backend/tests/test_drain_for_restart.py
@@ -6,8 +6,8 @@ Locks in the four contracts that distinguish a restart-drain from a Stop:
       stop_chat_for CLEARS the queue (contrast).
   (b) The drain persists the "paused for a platform update" note WITHOUT losing
       the accumulated partial blocks.
-  (c) Boot reconcile marks the paused note resumable (no double note) and the
-      boot notify fires exactly once.
+  (c) Boot reconcile marks the paused note resumable (no double note), prepares
+      opted-in planned restarts for serial continuation, and notifies once.
   (d) A send arriving while draining QUEUES instead of starting a turn.
 """
 
@@ -43,7 +43,10 @@ def _drain_writer():
   get_writer().submit(Barrier()).result(timeout=5)
 
 
-def _seed(chat_id: str, *, pending=None, messages=None, run_status="running"):
+def _seed(
+  chat_id: str, *, pending=None, messages=None, run_status="running",
+  auto_resume=True, initiated_by_app_id=None,
+):
   db = SessionLocal()
   try:
     started = datetime.now(UTC).replace(tzinfo=None) - timedelta(seconds=30)
@@ -54,6 +57,7 @@ def _seed(chat_id: str, *, pending=None, messages=None, run_status="running"):
       pending_messages=pending or [],
       session_id="sess",
       provider="claude",
+      auto_resume_on_limit=auto_resume,
       run_status=run_status,
       run_started_at=started if run_status else None,
     ))
@@ -63,6 +67,7 @@ def _seed(chat_id: str, *, pending=None, messages=None, run_status="running"):
         chat_id=chat_id,
         status="running",
         provider="claude",
+        initiated_by_app_id=initiated_by_app_id,
         started_at=started,
       ))
     db.commit()
@@ -78,6 +83,19 @@ def _chat(chat_id: str):
       "messages": materialized_messages(row),
       "pending": list(row.pending_messages or []),
       "run_status": row.run_status,
+    }
+  finally:
+    db.close()
+
+
+def _run(run_id: str):
+  db = SessionLocal()
+  try:
+    row = db.query(models.ChatRun).filter(models.ChatRun.id == run_id).first()
+    return {
+      "status": row.status,
+      "parked_until": row.parked_until,
+      "park_reason": row.park_reason,
     }
   finally:
     db.close()
@@ -209,6 +227,13 @@ def test_reconcile_marks_paused_note_resumable_without_double_note():
   # persisted before it existed (or whose live event never landed) renders
   # in the calm "Paused" family, not danger-red.
   assert errors[0]["pause"] == {"kind": "restart"}
+  # The exact drain note distinguishes a planned restart from a crash. With
+  # the chat policy enabled, its latest owner run reuses the existing durable
+  # auto-resume state and is due immediately after serving begins.
+  run = _run(f"rt-{cid}")
+  assert run["status"] == "resume_pending"
+  assert run["parked_until"] is not None
+  assert run["park_reason"] == "restart"
 
 
 def test_reconcile_crash_note_is_resumable():
@@ -226,6 +251,9 @@ def test_reconcile_crash_note_is_resumable():
   blocks = _chat(cid)["messages"][-1]["blocks"]
   note = next(b for b in blocks if b.get("type") == "error")
   assert note["resumable"] is True
+  # Unplanned crashes remain manual even when the chat policy is enabled: an
+  # agent-triggered crash must not become a reboot loop.
+  assert _run(f"rt-{cid}")["status"] == "interrupted"
 
 
 def test_reconcile_question_tail_note_is_not_resumable():
@@ -255,6 +283,147 @@ def test_reconcile_question_tail_note_is_not_resumable():
   note = next(b for b in blocks if b.get("type") == "error")
   assert "answer is still needed" in note["message"]
   assert not note.get("resumable")
+  assert _run(f"rt-{cid}")["status"] == "interrupted"
+
+
+def test_reconcile_planned_restart_keeps_question_manual_and_answerable():
+  """The drain appends its exact note after an already-persisted question.
+
+  Reconciliation must look through that note, preserve the question as the
+  tail affordance, and reject automatic ``continue`` while a human answer is
+  still required.
+  """
+  cid = "reco-drained-question"
+  _seed(cid, messages=[
+    {"role": "user", "content": "hi", "ts": 1},
+    {"role": "assistant", "ts": 2, "content": "", "blocks": [
+      {"type": "text", "content": "thinking"},
+      {"type": "question", "id": "q1", "text": "Which one?"},
+      {"type": "error", "message": chat_mod.PAUSED_FOR_RESTART_MESSAGE},
+    ]},
+  ])
+
+  db = SessionLocal()
+  try:
+    assert chat_mod.reconcile_interrupted_chats(db) == [cid]
+  finally:
+    db.close()
+
+  blocks = _chat(cid)["messages"][-1]["blocks"]
+  assert blocks[-1].get("type") == "question"
+  note = next(b for b in blocks if b.get("type") == "error")
+  assert note["message"] == chat_mod.PAUSED_FOR_RESTART_MESSAGE
+  assert note["pause"] == {"kind": "restart"}
+  assert not note.get("resumable")
+  assert _run(f"rt-{cid}")["status"] == "interrupted"
+
+
+def test_reconcile_old_nonterminal_restart_note_does_not_mask_new_crash():
+  """Only the drain's terminal note proves this specific run was planned.
+
+  A prior restart note can remain in an assistant row after a recovered
+  question continues. If a later turn crashes without a fresh terminal note,
+  that historical block must not manufacture an automatic reboot loop.
+  """
+  cid = "reco-old-restart-note"
+  _seed(cid, messages=[
+    {"role": "user", "content": "hi", "ts": 1},
+    {"role": "assistant", "ts": 2, "content": "", "blocks": [
+      {"type": "error", "message": chat_mod.PAUSED_FOR_RESTART_MESSAGE},
+      {"type": "text", "content": "new work after recovery"},
+    ]},
+  ])
+
+  db = SessionLocal()
+  try:
+    assert chat_mod.reconcile_interrupted_chats(db) == [cid]
+  finally:
+    db.close()
+
+  assert _run(f"rt-{cid}")["status"] == "interrupted"
+
+
+def test_reconcile_planned_restart_respects_disabled_policy():
+  cid = "reco-drained-disabled"
+  _seed(cid, auto_resume=False, messages=[
+    {"role": "user", "content": "hi", "ts": 1},
+    {"role": "assistant", "ts": 2, "blocks": [{
+      "type": "error", "message": chat_mod.PAUSED_FOR_RESTART_MESSAGE,
+    }]},
+  ])
+
+  db = SessionLocal()
+  try:
+    assert chat_mod.reconcile_interrupted_chats(db) == [cid]
+  finally:
+    db.close()
+
+  assert _run(f"rt-{cid}")["status"] == "interrupted"
+
+
+def test_reconcile_planned_restart_never_auto_continues_app_run():
+  cid = "reco-drained-app"
+  _seed(cid, initiated_by_app_id=17, messages=[
+    {"role": "user", "content": "background work", "ts": 1},
+    {"role": "assistant", "ts": 2, "blocks": [{
+      "type": "error", "message": chat_mod.PAUSED_FOR_RESTART_MESSAGE,
+    }]},
+  ])
+
+  db = SessionLocal()
+  try:
+    assert chat_mod.reconcile_interrupted_chats(db) == [cid]
+  finally:
+    db.close()
+
+  assert _run(f"rt-{cid}")["status"] == "interrupted"
+
+
+def test_planned_restart_sweep_starts_one_marked_continuation(monkeypatch):
+  cid = "reco-drained-auto"
+  queued = {
+    "role": "user", "content": "queued ask", "ts": 3, "cid": "queued-1",
+  }
+  _seed(cid, pending=[queued], messages=[
+    {"role": "user", "content": "hi", "ts": 1, "cid": "owner-1"},
+    {"role": "assistant", "ts": 2, "blocks": [{
+      "type": "error", "message": chat_mod.PAUSED_FOR_RESTART_MESSAGE,
+    }]},
+  ])
+  db = SessionLocal()
+  try:
+    assert chat_mod.reconcile_interrupted_chats(db) == [cid]
+  finally:
+    db.close()
+
+  scheduled = []
+  monkeypatch.setattr(
+    chat_mod, "_schedule_continuation",
+    lambda **kwargs: scheduled.append(kwargs),
+  )
+  db = SessionLocal()
+  try:
+    resolved = asyncio.run(chat_mod.sweep_reset_parks(db))
+  finally:
+    db.close()
+
+  try:
+    assert resolved == [cid]
+    assert len(scheduled) == 1
+    assert "queued ask" in scheduled[0]["next_user"]["content"]
+    assert "continue" in scheduled[0]["next_user"]["content"]
+    markers = [
+      msg for msg in _chat(cid)["messages"]
+      if msg.get("kind") == "auto_continuation"
+    ]
+    assert len(markers) == 1
+    assert markers[0]["role"] == "user"
+    assert markers[0]["content"] == "continue"
+    assert markers[0]["continuation_reason"] == "restart"
+    assert markers[0]["cid"] == f"restart-resume-rt-{cid}"
+  finally:
+    # The scheduler is stubbed, so release the claim the real spawned task owns.
+    chat_mod.discard_starting(cid)
 
 
 def test_notify_after_reconcile_fires_once(owner_token, monkeypatch):
@@ -274,6 +443,34 @@ def test_notify_after_reconcile_fires_once(owner_token, monkeypatch):
   assert result == "notif-id"
   assert len(calls) == 1
   assert "resume" in calls[0]["body"].lower()
+
+
+def test_notify_after_reconcile_names_automatic_restart(owner_token, monkeypatch):
+  del owner_token
+  cid = "reco-auto-notify"
+  _seed(cid, messages=[
+    {"role": "user", "content": "hi", "ts": 1},
+    {"role": "assistant", "ts": 2, "blocks": [{
+      "type": "error", "message": chat_mod.PAUSED_FOR_RESTART_MESSAGE,
+    }]},
+  ])
+  calls = []
+  monkeypatch.setattr(
+    "app.push.notify_owner",
+    lambda db, owner_id, **kw: calls.append(kw) or "notif-id",
+  )
+
+  db = SessionLocal()
+  try:
+    reconciled = chat_mod.reconcile_interrupted_chats(db)
+    result = chat_mod.notify_after_reconcile(db, reconciled)
+  finally:
+    db.close()
+
+  assert result == "notif-id"
+  assert len(calls) == 1
+  assert "continu" in calls[0]["title"].lower()
+  assert "automatically" in calls[0]["body"].lower()
 
 
 def test_notify_after_reconcile_noop_when_nothing_reconciled(owner_token, monkeypatch):

--- a/backend/tests/test_limit_park.py
+++ b/backend/tests/test_limit_park.py
@@ -494,10 +494,12 @@ def _due_park(
             - timedelta(minutes=1))
 
 
-def _run_sweep():
+def _run_sweep(*, include_wait_hint=False):
   db = SessionLocal()
   try:
-    return asyncio.run(chat_mod.sweep_reset_parks(db))
+    return asyncio.run(chat_mod.sweep_reset_parks(
+      db, include_wait_hint=include_wait_hint,
+    ))
   finally:
     db.close()
 
@@ -617,9 +619,10 @@ def test_sweep_auto_resume_on_starts_one_serial_continue(
   )
 
   try:
-    resolved = _run_sweep()
+    resolved, wait_for_turn_finish = _run_sweep(include_wait_hint=True)
 
     assert resolved == ["sweep-auto"]
+    assert wait_for_turn_finish is False
     assert _run_row("rt-sweep-auto")["status"] == "completed"
     assert len(scheduled) == 1
     assert scheduled[0]["chat_id"] == "sweep-auto"
@@ -631,6 +634,14 @@ def test_sweep_auto_resume_on_starts_one_serial_continue(
     state = _chat_row("sweep-auto")
     assert state["pending"] == []
     assert state["run_status"] == "running"  # PromotePending set the marker
+    markers = [
+      msg for msg in state["messages"]
+      if msg.get("kind") == "auto_continuation"
+    ]
+    assert len(markers) == 1
+    assert markers[0]["content"] == "continue"
+    assert markers[0]["continuation_reason"] == "usage_limit"
+    assert markers[0]["cid"] == "limit-resume-rt-sweep-auto"
   finally:
     # _schedule_continuation was stubbed, so release the claim it would have
     # handed to the spawned turn.
@@ -652,7 +663,7 @@ def test_sweep_auto_resume_defers_while_any_turn_is_live(
   handle = _Handle(other)
   registry.register(handle)
   try:
-    assert _run_sweep() == []
+    assert _run_sweep(include_wait_hint=True) == ([], True)
   finally:
     registry.unregister(other, handle.kind)
   # Untouched: still parked, not notified — deferred to a later tick, never
@@ -739,8 +750,9 @@ def test_sweep_starts_only_one_of_two_opted_chats(owner_token, monkeypatch):
   _due_park("sweep-auto-b", "rt-sweep-auto-b", auto_resume=True)
 
   try:
-    resolved = _run_sweep()
+    resolved, wait_for_turn_finish = _run_sweep(include_wait_hint=True)
     assert len(resolved) == 1
+    assert wait_for_turn_finish is True
     assert len(scheduled) == 1
     untouched = ({"sweep-auto-a", "sweep-auto-b"} - set(resolved)).pop()
     assert _run_row(f"rt-{untouched}")["status"] == "parked"
@@ -990,6 +1002,24 @@ def test_auto_resume_rechecks_app_work_inside_queue_handoff():
   state = _chat_row(cid)
   assert state["pending"] == [app_msg]
   assert state["run_status"] is None
+  assert not chat_mod.is_chat_running(cid)
+
+
+def test_auto_resume_rechecks_app_run_at_locked_handoff():
+  """A direct/stale sweep caller cannot bypass durable run attribution."""
+  cid = "auto-final-app-run-check"
+  park_token = f"rt-{cid}"
+  _seed_chat(cid, auto_resume=True)
+  _seed_run(
+    cid, park_token, status="resume_pending", started_offset=-30,
+    initiated_by_app_id=11,
+  )
+
+  assert asyncio.run(
+    chat_mod._auto_resume_chat(cid, "claude", park_token=park_token)
+  ) is False
+  assert _chat_row(cid)["pending"] == []
+  assert _run_row(park_token)["status"] == "resume_pending"
   assert not chat_mod.is_chat_running(cid)
 
 

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -14,7 +14,7 @@ from app.schemas import SettingsUpdate
 
 
 def test_global_settings_do_not_expose_chat_auto_resume(client, auth):
-  """Rate-limit auto-resume is controlled per chat, not globally."""
+  """Automatic continuation is controlled per chat, not globally."""
   res = client.get("/api/settings", headers=auth)
   assert res.status_code == 200
   assert "auto_resume_on_limit" not in res.json()

--- a/backend/tests/test_time_context.py
+++ b/backend/tests/test_time_context.py
@@ -4,7 +4,17 @@ Locks in the contract that the agent gets a clock every turn (issue: the
 agent only ever saw an IANA timezone NAME, and only on turn 1).
 """
 
-from app.chat import _build_time_context, _human_elapsed, _is_cli_slash_command
+import time
+import uuid
+
+from app import models
+from app.chat import (
+  _build_time_context,
+  _human_elapsed,
+  _is_cli_slash_command,
+  _last_user_message_elapsed,
+)
+from app.database import SessionLocal
 
 
 def test_includes_timezone_label_and_clock():
@@ -47,6 +57,37 @@ def test_elapsed_clause_only_when_present():
   assert "user's last message was" not in _build_time_context("UTC", None)
   out = _build_time_context("UTC", "3 days ago")
   assert "user's last message was 3 days ago" in out
+
+
+def test_elapsed_ignores_automatic_continuation_marker(monkeypatch):
+  now = 1_800_000_000.0
+  monkeypatch.setattr(time, "time", lambda: now)
+  cid = f"time-context-{uuid.uuid4()}"
+  db = SessionLocal()
+  try:
+    db.add(models.Chat(
+      id=cid,
+      title="time context",
+      messages=[
+        {
+          "role": "user", "content": "owner message",
+          "ts": (now - 3 * 86400) * 1000,
+        },
+        {"role": "assistant", "content": "reply"},
+        {
+          "role": "user", "content": "continue",
+          "kind": "auto_continuation",
+          "ts": (now - 5 * 60) * 1000,
+        },
+        {"role": "assistant", "content": "automatic reply"},
+        {"role": "user", "content": "current owner message", "ts": now * 1000},
+      ],
+    ))
+    db.commit()
+
+    assert _last_user_message_elapsed(db, cid) == "3 days ago"
+  finally:
+    db.close()
 
 
 def test_goal_slash_command_is_detected_without_matching_paths():

--- a/frontend/src/components/ChatView/AutoContinuationCard.jsx
+++ b/frontend/src/components/ChatView/AutoContinuationCard.jsx
@@ -1,0 +1,31 @@
+import MarkerCard from './MarkerCard.jsx'
+
+// A synthetic provider-facing "continue" is stored as a user message so the
+// next turn and future provider history remain truthful. In the transcript it
+// is a product event, though, not text the owner typed. Render the durable
+// reason with the same quiet marker language as compaction.
+export default function AutoContinuationCard({ msg }) {
+  const restarted = msg?.continuation_reason === 'restart'
+  const title = restarted
+    ? 'Server restarted — continuing automatically'
+    : 'Usage available again — continuing automatically'
+
+  return (
+    <MarkerCard title={title} icon={
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 16 16"
+        width="14"
+        height="14"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M13 7a5 5 0 1 0-1.5 4" />
+        <path d="M10.5 8H13V5.5" />
+      </svg>
+    } />
+  )
+}

--- a/frontend/src/components/ChatView/ChatSettingsPanel.jsx
+++ b/frontend/src/components/ChatView/ChatSettingsPanel.jsx
@@ -834,7 +834,7 @@ export default function ChatSettingsPanel({
             onPointerDown={preserveFocusUnlessTouch}
           >
             <label className="csp__automation-copy" htmlFor={autoResumeSwitchId}>
-              <span className="csp__automation-title">Continue after rate limits</span>
+              <span className="csp__automation-title">Continue after limits and restarts</span>
             </label>
             <Switch
               className="chat-policy-switch"

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -353,6 +353,7 @@
 }
 
 .chat__msg--user { align-items: flex-end; }
+.chat__msg--marker { align-items: stretch; }
 .chat__msg--assistant {
   --activity-block-gap: 8px;
   --activity-row-gap: 4px;
@@ -1514,7 +1515,7 @@
   }
 }
 
-/* ── Marker card (compaction + future system markers) ── */
+/* ── Marker card (compaction + automatic recovery events) ── */
 
 /* A marker is a product/system moment ("the chat was summarized", "the turn
    was interrupted"), not a tool call — so it gets a labeled card instead of

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -61,6 +61,8 @@ import {
   canFastForwardQueue,
   cidOf,
   continuationRowsFromPromotedMessage,
+  isAutoContinuationMessage,
+  isOwnerUserMessage,
   mergeRecentMessagesIntoLoadedWindow,
   openAppCtaViewModel,
   shouldRetryStopAfterConfirm,
@@ -920,9 +922,7 @@ export default function ChatView({
   // messagesRef catches up, so state alone is not authoritative. A row is
   // first only when both the state mirror and rendered transcript are empty.
   function isFirstVisibleUserMessage() {
-    const stateHasUser = messagesRef.current.some(
-      m => m.role === 'user' && !m.hidden,
-    )
+    const stateHasUser = messagesRef.current.some(isOwnerUserMessage)
     const domHasUser = !!scrollRef.current?.querySelector('.chat__msg--user')
     return !stateHasUser && !domHasUser
   }
@@ -3295,7 +3295,9 @@ export default function ChatView({
   useLayoutEffect(() => {
     if (displayReady) onDisplayReady?.(chatId)
   }, [chatId, displayReady, onDisplayReady])
-  const lastUserIdx = messages.reduce((acc, m, i) => (m.role === 'user' && !m.hidden) ? i : acc, -1)
+  const lastUserIdx = messages.reduce((acc, m, i) => (
+    isOwnerUserMessage(m) ? i : acc
+  ), -1)
   // The captured bridge partial enters the active row before catch-up emits a
   // single item. That is the load-bearing part of Lever 1: when SSE becomes the
   // selected source, React updates MsgContent props instead of replacing the
@@ -3310,7 +3312,7 @@ export default function ChatView({
   const bridgeMsg = bridgeMsgIdx >= 0 ? messages[bridgeMsgIdx] : null
   const bridgeFollowedByVisibleUser = bridgeMsgIdx >= 0 && messages
     .slice(bridgeMsgIdx + 1)
-    .some(msg => msg?.role === 'user' && !msg.hidden)
+    .some(isOwnerUserMessage)
   const trailingAssistantPartialMsg = trailingAssistantPartialIdx >= 0
     ? messages[trailingAssistantPartialIdx]
     : null
@@ -3721,6 +3723,7 @@ export default function ChatView({
 
           {messages.map((msg, i) => {
             if (msg.hidden) return null
+            const continuationMarker = isAutoContinuationMessage(msg)
             const isLastMsg = i === lastVisibleMessageIndex
             // The mirrored DB row is rendered below by the SAME active
             // MsgContent instance that consumes live payloads. Suppress only
@@ -3766,20 +3769,25 @@ export default function ChatView({
             // User rows key + pin on the stable cid so the optimistic→confirm
             // display-ts update never remounts the row (which would drop the
             // pin target mid-swap). data-ts stays for the timestamp tooltip only.
-            const userCid = msg.role === 'user' ? cidOf(msg) : null
+            const ownerUserMessage = isOwnerUserMessage(msg)
+            const userCid = ownerUserMessage
+              ? cidOf(msg)
+              : null
             return (
             <li
               key={userCid || msg.id || msg.ts || `${msg.role}-${i}`}
-              className={`chat__msg chat__msg--${msg.role}`}
+              className={`chat__msg chat__msg--${continuationMarker ? 'marker' : msg.role}`}
               ref={i === lastUserIdx ? setLastUserMsgRef : null}
               data-key={dataKey}
               data-cid={userCid || undefined}
-              data-ts={msg.role === 'user' && msg.ts ? String(msg.ts) : undefined}
-              onPointerDown={(event) => handleMessagePointerDown(event, msg, dataKey)}
-              onPointerMove={handleMessagePointerMove}
-              onPointerUp={cancelMessageHold}
-              onPointerCancel={cancelMessageHold}
-              onContextMenu={_isTouchPrimary
+              data-ts={ownerUserMessage && msg.ts ? String(msg.ts) : undefined}
+              onPointerDown={continuationMarker
+                ? undefined
+                : (event) => handleMessagePointerDown(event, msg, dataKey)}
+              onPointerMove={continuationMarker ? undefined : handleMessagePointerMove}
+              onPointerUp={continuationMarker ? undefined : cancelMessageHold}
+              onPointerCancel={continuationMarker ? undefined : cancelMessageHold}
+              onContextMenu={_isTouchPrimary && !continuationMarker
                 ? (event) => {
                     if (event.target?.closest?.('button, a, input, textarea, summary, pre, code')) return
                     event.preventDefault()
@@ -3787,7 +3795,7 @@ export default function ChatView({
                     void copyMessage(msg, dataKey)
                   }
                 : undefined}
-              onClick={msg.ts && msg.role === 'user'
+              onClick={msg.ts && ownerUserMessage
                 ? (event) => showTimestamp(event, dataKey)
                 : undefined}
             >
@@ -3818,7 +3826,7 @@ export default function ChatView({
                 liveQuestionId={liveQuestionId}
                 suppressedQuestionKeys={streamItemQuestionKeys}
               />
-              {msg.ts && msg.role === 'user' && (
+              {msg.ts && ownerUserMessage && (
                 <time className={`chat__ts${visibleTimestampKey === dataKey ? ' chat__ts--visible' : ''}`}>
                   {new Date(msg.ts).toLocaleString([], {
                     month: 'short', day: 'numeric',

--- a/frontend/src/components/ChatView/MarkerCard.jsx
+++ b/frontend/src/components/ChatView/MarkerCard.jsx
@@ -2,10 +2,10 @@ import { useRef, useState } from 'react'
 import { preserveTogglePosition } from './preserveTogglePosition.js'
 
 // Shared shell for "marker" messages — system/product moments that are neither
-// agent prose nor a tool call. A compaction summary is the only marker today;
-// interrupted-turn and other system notes can adopt this shell later so every
-// marker reads as one family (one card shape, one disclosure motion) instead of
-// each inventing its own look or masquerading as a chat bubble.
+// agent prose nor a tool call. Compaction summaries and automatic continuation
+// events use this shell so every marker reads as one family (one card shape,
+// one disclosure motion) instead of each inventing its own look or masquerading
+// as a chat bubble.
 //
 // Extracted from CompactionCard with no visual change — the default look IS the
 // accent-tinted summary divider that card established (`.chat__marker*` CSS,

--- a/frontend/src/components/ChatView/MsgContent.jsx
+++ b/frontend/src/components/ChatView/MsgContent.jsx
@@ -7,6 +7,7 @@ import QuestionCard from './QuestionCard.jsx'
 import MessageSources from './MessageSources.jsx'
 import Attachments from './Attachments.jsx'
 import CompactionCard from './CompactionCard.jsx'
+import AutoContinuationCard from './AutoContinuationCard.jsx'
 import { questionKey } from './questionKey.js'
 import {
   repairInterleavedQuestionText,
@@ -82,6 +83,9 @@ function MsgContentInner({
         <CompactionCard msg={msg} />
       </div>
     )
+  }
+  if (msg.kind === 'auto_continuation') {
+    return <AutoContinuationCard msg={msg} />
   }
 
   if (msg.blocks && msg.blocks.length > 0) {
@@ -221,7 +225,7 @@ function MsgContentInner({
                     className="chat__limit-option-label"
                     htmlFor={autoResumeSwitchId}
                   >
-                    Always continue after limits in this chat
+                    Always continue after limits and restarts in this chat
                   </label>
                 </div>
                 <Switch

--- a/frontend/src/components/ChatView/__tests__/chatRuntimeState.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatRuntimeState.test.js
@@ -8,6 +8,8 @@ import {
   canFastForwardQueue,
   cidOf,
   continuationRowsFromPromotedMessage,
+  isAutoContinuationMessage,
+  isOwnerUserMessage,
   mergeRecentMessagesIntoLoadedWindow,
   openAppCtaViewModel,
   previewReadyAnnouncement,
@@ -148,6 +150,17 @@ test('cidOf returns the row cid, else null (no read-time derivation)', () => {
   assert.equal(cidOf({ ts: 5 }), null)
   assert.equal(cidOf({}), null)
   assert.equal(cidOf(null), null)
+})
+
+test('automatic continuation rows are product events, not owner messages', () => {
+  const marker = {
+    role: 'user', kind: 'auto_continuation', content: 'continue', cid: 'resume-1',
+  }
+  assert.equal(isAutoContinuationMessage(marker), true)
+  assert.equal(isOwnerUserMessage(marker), false)
+  assert.equal(isOwnerUserMessage({ role: 'user', content: 'hello' }), true)
+  assert.equal(isOwnerUserMessage({ role: 'user', hidden: true }), false)
+  assert.equal(isOwnerUserMessage({ role: 'assistant' }), false)
 })
 
 test('stripInternalUserMessageFields KEEPS cid and drops the envelope fields', () => {

--- a/frontend/src/components/ChatView/__tests__/contextMenuOrder.test.js
+++ b/frontend/src/components/ChatView/__tests__/contextMenuOrder.test.js
@@ -25,7 +25,7 @@ test('chat context actions follow model selection and continuation policy', () =
   assert.ok(picker !== -1 && summary !== -1 && inspector !== -1)
   assert.ok(picker < summary)
   assert.ok(summary < inspector)
-  assert.match(settingsSource, /Continue after rate limits/)
+  assert.match(settingsSource, /Continue after limits and restarts/)
   assert.doesNotMatch(settingsSource, /Chat summar(?:y|ies)/)
 })
 

--- a/frontend/src/components/ChatView/__tests__/messageCopy.test.js
+++ b/frontend/src/components/ChatView/__tests__/messageCopy.test.js
@@ -24,3 +24,11 @@ test('copyableMessageText removes hidden user augmentation', () => {
 test('copyableMessageText ignores hidden transcript rows', () => {
   assert.equal(copyableMessageText({ hidden: true, content: 'do not copy' }), '')
 })
+
+test('copyableMessageText ignores automatic continuation product markers', () => {
+  assert.equal(copyableMessageText({
+    role: 'user',
+    kind: 'auto_continuation',
+    content: 'continue',
+  }), '')
+})

--- a/frontend/src/components/ChatView/__tests__/parkedCard.test.js
+++ b/frontend/src/components/ChatView/__tests__/parkedCard.test.js
@@ -20,6 +20,9 @@ const shell = readFileSync(new URL('../../Shell/Shell.jsx', import.meta.url), 'u
 const paneChatView = readFileSync(new URL('../../Shell/PaneChatView.jsx', import.meta.url), 'utf8')
 const chatEmbed = readFileSync(new URL('../../ChatEmbed/ChatEmbed.jsx', import.meta.url), 'utf8')
 const chatSettingsPanel = readFileSync(new URL('../ChatSettingsPanel.jsx', import.meta.url), 'utf8')
+const autoContinuationCard = readFileSync(
+  new URL('../AutoContinuationCard.jsx', import.meta.url), 'utf8',
+)
 const settingsView = readFileSync(
   new URL('../../SettingsView/SettingsView.jsx', import.meta.url), 'utf8',
 )
@@ -100,10 +103,10 @@ test('the parked card has styling distinct from a plain error', () => {
     'the reset line has its own style')
 })
 
-test('auto-resume is a chat-local switch shown only on the active rate-limit card', () => {
+test('automatic continuation is chat-local and manageable at a rate-limit card', () => {
   assert.match(msgContent, /resumable && parked && autoResumeAvailable && onAutoResumeChange/,
     'the switch must require the tail resumable rate-limit state')
-  assert.match(msgContent, /Always continue after limits in this chat/,
+  assert.match(msgContent, /Always continue after limits and restarts in this chat/,
     'the switch label makes the persistent, chat-local scope explicit')
   assert.match(msgContent, /htmlFor=\{autoResumeSwitchId\}/,
     'the visible switch label must also be its accessible name')
@@ -115,7 +118,7 @@ test('auto-resume is a chat-local switch shown only on the active rate-limit car
     'the in-card control has a dedicated layout')
   assert.doesNotMatch(settingsView, /auto_resume_on_limit|Auto.?resume/i,
     'the removed global automatic option must not reappear in Settings')
-  assert.match(chatSettingsPanel, /Continue after rate limits/,
+  assert.match(chatSettingsPanel, /Continue after limits and restarts/,
     'the durable policy remains manageable in the per-chat settings surface')
   assert.doesNotMatch(chatSettingsPanel, /On for this chat|Off for this chat/,
     'the switch color communicates state without redundant state copy')
@@ -123,6 +126,25 @@ test('auto-resume is a chat-local switch shown only on the active rate-limit car
     'the settings surface uses the same full-size black/purple switch treatment')
   assert.match(css, /\.chat-policy-switch button\[role="switch"\]\[data-state="checked"\]/,
     'the chat switch restores the SDK checked track after the button reset')
+})
+
+test('automatic sends render as durable product markers, not user bubbles', () => {
+  assert.match(msgContent, /msg\.kind === 'auto_continuation'/,
+    'the shared message renderer recognizes the persisted automatic action')
+  assert.match(msgContent, /<AutoContinuationCard msg=\{msg\}/,
+    'the automatic action uses the marker component')
+  assert.match(autoContinuationCard, /import MarkerCard from '\.\/MarkerCard\.jsx'/,
+    'the new event belongs to the same visual family as compaction')
+  assert.match(autoContinuationCard, /Server restarted — continuing automatically/,
+    'planned restart recovery names why the agent resumed')
+  assert.match(autoContinuationCard, /Usage available again — continuing automatically/,
+    'limit recovery names why the agent resumed')
+  assert.match(chatView, /continuationMarker \? 'marker' : msg\.role/,
+    'the transcript row does not keep user-bubble alignment')
+  assert.match(chatView, /onPointerDown=\{continuationMarker[\s\S]*?\? undefined/,
+    'the marker does not gain hold-to-copy interaction behavior')
+  assert.match(chatView, /const ownerUserMessage = isOwnerUserMessage\(msg\)/,
+    'timestamps and pin identity use the shared owner-message predicate')
 })
 
 test('an enabled policy stays cancellable after the viewer clock reaches reset', () => {

--- a/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
+++ b/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
@@ -726,6 +726,27 @@ test('no saved chat location opens at the latest real content without enabling f
     'the real content tail is visible and reserved spacer room is excluded')
 })
 
+test('saved user pin ignores a newer automatic continuation marker', () => {
+  const scrollEl = {
+    scrollHeight: 1000,
+    scrollTop: 100,
+    clientHeight: 500,
+    querySelector: () => null,
+    querySelectorAll: () => [],
+  }
+  const saved = { kind: 'PIN_USER_MSG', cid: 'owner-cid', followWhenFilled: true }
+  const mode = _validateSavedMode(saved, [
+    { role: 'user', cid: 'owner-cid', content: 'owner message' },
+    { role: 'assistant', content: 'reply' },
+    {
+      role: 'user', cid: 'restart-marker', content: 'continue',
+      kind: 'auto_continuation',
+    },
+  ], scrollEl)
+
+  assert.deepEqual(mode, { kind: 'PIN_USER_MSG', cid: 'owner-cid' })
+})
+
 test('attention nudge anchors the physical tail without enabling follow', () => {
   const last = {
     offsetTop: 1500,

--- a/frontend/src/components/ChatView/chatRuntimeState.js
+++ b/frontend/src/components/ChatView/chatRuntimeState.js
@@ -16,6 +16,19 @@ export function cidOf(msg) {
   return msg.cid || null
 }
 
+export function isAutoContinuationMessage(message) {
+  return message?.kind === 'auto_continuation'
+}
+
+/** A visible transcript row authored by the owner, excluding product events
+ * that are persisted with role=user only to keep provider history truthful. */
+export function isOwnerUserMessage(message) {
+  return !!message
+    && message.role === 'user'
+    && !message.hidden
+    && !isAutoContinuationMessage(message)
+}
+
 export function stripInternalUserMessageFields(raw) {
   if (!raw) return null
   // KEEP `cid` — it is now the durable row identity and must survive the

--- a/frontend/src/components/ChatView/messageCopy.js
+++ b/frontend/src/components/ChatView/messageCopy.js
@@ -1,6 +1,7 @@
 // Message-to-plain-text helpers for the mobile hold-to-copy action.
 
 import { stripAugmentation } from './msgText.js'
+import { isAutoContinuationMessage } from './chatRuntimeState.js'
 
 function questionText(block) {
   return (block.questions || []).map(question => {
@@ -14,7 +15,7 @@ function questionText(block) {
 /** Resolve the owner-visible prose in one transcript row. Tool chrome and
  * hidden prompt augmentation stay out of copied text. */
 export function copyableMessageText(message) {
-  if (!message || message.hidden) return ''
+  if (!message || message.hidden || isAutoContinuationMessage(message)) return ''
   const parts = []
   if (Array.isArray(message.blocks) && message.blocks.length > 0) {
     for (const block of message.blocks) {

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -40,7 +40,7 @@
  */
 
 import { useState, useRef, useLayoutEffect, useCallback } from 'react'
-import { cidOf } from './chatRuntimeState.js'
+import { cidOf, isOwnerUserMessage } from './chatRuntimeState.js'
 import { BEFORE_SHELL_RELOAD_EVENT } from '../../lib/shellReloadEvents.js'
 
 
@@ -334,7 +334,7 @@ export function _validateSavedMode(saved, messages, scrollEl) {
     // resolve a pin target — use the explicit no-location fallback.
     if (saved.cid == null) return holdBottom()
     const lastUserMsg = [...messages].reverse()
-      .find(m => m.role === 'user' && !m.hidden)
+      .find(isOwnerUserMessage)
     // Automatic pin→follow is live-turn state, never restoration state. Strip
     // the armed flag even if a pagehide captured it mid-stream; mount/return
     // must not manufacture tail-follow from saved geometry.


### PR DESCRIPTION
## Summary

- Extend the existing per-chat `auto_resume_on_limit` policy to planned, drain-gated server restarts while retaining the persisted field name for rolling-client and database compatibility.
- Reconcile an eligible interrupted owner run to `resume_pending` during startup and let the existing serialized reset sweep start the continuation only when the system is globally idle.
- Render the synthetic continuation as a product-owned status card with an explicit reason (`restart` or `usage_limit`) instead of making it look like user-authored text.

## Restart eligibility and safety

Startup recovery only queues continuation when all of the following are true:

- the previous shutdown persisted a fresh, terminal, exact restart pause;
- the run is the latest owner run for the chat;
- automatic continuation is enabled for that chat;
- no unanswered question is waiting;
- no app-attributed run or queued app work owns the transition;
- the chat was not deleted, superseded, or manually transitioned.

Unplanned crashes remain `interrupted` and require manual recovery. This prevents reboot loops and prevents an older restart marker from reclassifying a later crash. Queue and transition locks, the global-idle check, actor append/promote ordering, and identity-keyed rollback keep the continuation single-owner and recover safely if task creation fails.

## Performance

- Run one reconciliation sweep at startup, then reuse the existing 60-second cadence.
- Wake early on `chat_run_finished` only when the previous sweep reported a due continuation blocked by a live turn.
- Do not query continuation state after ordinary completed turns.
- Start at most one continuation globally per sweep.

This keeps restart recovery event-assisted and bounded without introducing per-chat workers or a new busy polling loop.

## Transcript and UI behavior

- Persist the provider-facing synthetic prompt as `role=user`, `kind=auto_continuation`, with `continuation_reason` metadata so provider/session reconstruction remains compatible.
- Exclude automatic markers from user ownership semantics including copy and hold actions, latest-user timestamps, recency, and scroll-pin restoration.
- Label the marker as automatic during compaction and session reconstruction so it is never summarized as a real `USER` message.
- Update settings copy to **Continue after limits and restarts**.

## Expanded review fixes included

The expanding-scope review found and fixed these additional edge cases before the PR was opened:

- exact persisted `text -> question -> restart error` ordering could bypass an unanswered question;
- partial marker handling still leaked into several user-message behaviors;
- the initial wake-up path queried the database after every finished turn;
- a historical restart note could classify a later unplanned crash as restart recovery;
- compaction and provider session fallback could label an automatic marker as `USER`.

The architecture transition table and focused regressions cover these paths.

## Validation

- Protected pre-push gate on rebased head `57eaf012`: full backend pytest passed, frontend-unit passed, Python syntax passed, privacy scan passed, and conflict-marker scan passed.
- Final integration head `9f9c1c33` after the pane-handoff update: **1,773 frontend library tests + 47 hook tests passed**.
- Focused backend restart, limit, time-context, session, compaction, and settings suites: **162 passed**.
- Frontend production build passed.
- `git diff --check` passed.

## Compatibility and rollback

The wire and database key remains `auto_resume_on_limit`; no destructive migration or new background service is introduced. Disabling **Continue after limits and restarts** preserves manual restart recovery for an individual chat.