### PR TITLE
Show durable app activity dots

### DIFF
--- a/backend/app/app_activity.py
+++ b/backend/app/app_activity.py
@@ -1,0 +1,100 @@
+"""Durable per-app unread activity derived from app-attributed notifications."""
+
+from sqlalchemy import update
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app import models
+from app.timeutil import now_naive_utc
+
+
+def mark_from_notification(
+  db: Session, *, source_type: str, source_id: str | None,
+) -> int | None:
+  """Mark a live app unread inside the caller's notification transaction.
+
+  Returns the app id when a durable marker was written. The update-first,
+  savepoint-backed insert is race-safe when an existing app receives its first
+  two notifications concurrently, without committing the caller's transaction.
+  """
+  if source_type != "app" or source_id is None:
+    return None
+  try:
+    app_id = int(source_id)
+  except (TypeError, ValueError):
+    return None
+  app = db.get(models.App, app_id)
+  if app is None or app.deleted_at is not None:
+    return None
+
+  now = now_naive_utc()
+  result = db.execute(
+    update(models.AppActivityState)
+    .where(models.AppActivityState.app_id == app_id)
+    .values(
+      activity_at=now,
+      activity_version=models.AppActivityState.activity_version + 1,
+      unseen=True,
+    )
+  )
+  if result.rowcount:
+    return app_id
+
+  try:
+    with db.begin_nested():
+      db.add(models.AppActivityState(
+        app_id=app_id, activity_at=now, unseen=True,
+      ))
+      db.flush()
+  except IntegrityError:
+    # Another first notification inserted the singleton row after our UPDATE.
+    # The savepoint kept the outer Notification insert intact; make this event
+    # the winning latest marker.
+    db.execute(
+      update(models.AppActivityState)
+      .where(models.AppActivityState.app_id == app_id)
+      .values(
+        activity_at=now,
+        activity_version=models.AppActivityState.activity_version + 1,
+        unseen=True,
+      )
+    )
+  return app_id
+
+
+def mark_seen(db: Session, app_id: int, seen_through_version: int) -> None:
+  """Acknowledge only activity the opening shell actually observed.
+
+  A newer notification can race the acknowledgement request. Bounding the
+  update by its observed monotonic version keeps that newer event unread instead of
+  letting a late acknowledgement erase it.
+  """
+  db.execute(
+    update(models.AppActivityState)
+    .where(
+      models.AppActivityState.app_id == app_id,
+      models.AppActivityState.activity_version <= seen_through_version,
+    )
+    .values(unseen=False)
+  )
+
+
+def annotate_apps(db: Session, apps: list[models.App]) -> list[models.App]:
+  """Attach the response-only ``has_unseen_activity`` flag to app rows."""
+  ids = [app.id for app in apps]
+  unseen_by_id = {}
+  if ids:
+    unseen_by_id = {
+      row.app_id: row.activity_version
+      for row in db.query(
+        models.AppActivityState.app_id,
+        models.AppActivityState.activity_version,
+      ).filter(
+        models.AppActivityState.app_id.in_(ids),
+        models.AppActivityState.unseen.is_(True),
+      ).all()
+    }
+  for app in apps:
+    app.has_unseen_activity = app.id in unseen_by_id
+    app.unseen_activity_version = unseen_by_id.get(app.id)
+  return apps

--- a/backend/app/app_activity.py
+++ b/backend/app/app_activity.py
@@ -23,6 +23,11 @@ def mark_from_notification(
     app_id = int(source_id)
   except (TypeError, ValueError):
     return None
+  # SQLite INTEGER keys are signed 64-bit values.  Reject values outside that
+  # bindable range before ``Session.get`` so malformed attribution cannot turn
+  # an otherwise valid notification into a persistence failure.
+  if app_id <= 0 or app_id > (2**63 - 1):
+    return None
   app = db.get(models.App, app_id)
   if app is None or app.deleted_at is not None:
     return None

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -521,6 +521,23 @@ class App(Base):
   )
 
 
+class AppActivityState(Base):
+  """Durable unread-activity marker for one installed app.
+
+  This deliberately lives outside ``apps``: acknowledging a report must not
+  advance ``App.updated_at``, which is the shell's executable-bundle cache key.
+  Notifications remain the detailed history; the drawer only needs one compact
+  unread/read row per app.
+  """
+
+  __tablename__ = "app_activity_state"
+
+  app_id = Column(Integer, ForeignKey("apps.id"), primary_key=True)
+  activity_at = Column(DateTime, nullable=False, default=lambda: now_naive_utc())
+  activity_version = Column(Integer, nullable=False, default=1, server_default="1")
+  unseen = Column(Boolean, nullable=False, default=True, server_default=true())
+
+
 class PushSubscription(Base):
   """Browser push subscription for Web Push delivery."""
 

--- a/backend/app/push.py
+++ b/backend/app/push.py
@@ -161,6 +161,13 @@ def notify_owner(
     sent_at=datetime.now(UTC),
   )
   db.add(notif)
+  # App background jobs already attribute their success/failure notification
+  # to the app. Make that canonical completion edge own the drawer dot too,
+  # rather than requiring every cron script to remember a parallel signal.
+  from app.app_activity import mark_from_notification
+  activity_app_id = mark_from_notification(
+    db, source_type=source_type, source_id=source_id,
+  )
   try:
     db.commit()
   except Exception:
@@ -184,6 +191,14 @@ def notify_owner(
     except Exception:
       pass
     return notification_id
+
+  if activity_app_id is not None:
+    # The row above is durable; this replay-free event only makes a live shell
+    # refetch immediately. A reconnect/boot refetch recovers a missed event.
+    from app.broadcast import get_system_broadcast
+    get_system_broadcast().publish({
+      "type": "app_activity", "appId": str(activity_app_id),
+    })
 
   # Skip push when a live SSE subscriber is already watching the
   # source chat — the in-tab UX surfaces the event there. presence

--- a/backend/app/routes/apps.py
+++ b/backend/app/routes/apps.py
@@ -19,7 +19,7 @@ from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi.responses import FileResponse, HTMLResponse, StreamingResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from app import (
@@ -1824,7 +1824,7 @@ def get_app(
 
 
 class AppActivitySeenRequest(BaseModel):
-  activity_version: int
+  activity_version: int = Field(ge=1, le=(2**63 - 1))
 
 
 @router.post(

--- a/backend/app/routes/apps.py
+++ b/backend/app/routes/apps.py
@@ -23,7 +23,8 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from app import (
-  activity, app_git, app_jobs, fs_locks, icon_cache, legacy_platform_apps,
+  activity, app_activity, app_git, app_jobs, fs_locks, icon_cache,
+  legacy_platform_apps,
   models, providers, schemas,
   source_dirs, theme,
 )
@@ -410,6 +411,11 @@ async def _hard_delete_app(db: Session, app: models.App) -> None:
   # cleanup of the slug-keyed source tree below leaves harmless orphans — those
   # are not addressable by a reused integer id, so a live row pointing at
   # missing files (a 404) is the acceptable failure, not data exposure.
+  # The activity marker is id-keyed too; remove it before the reusable app id
+  # is freed so a future unrelated app never inherits the old app's dot.
+  db.query(models.AppActivityState).filter(
+    models.AppActivityState.app_id == deleted_app_id,
+  ).delete(synchronize_session=False)
   db.delete(app)
   db.commit()
   get_system_broadcast().publish(
@@ -671,7 +677,7 @@ async def list_apps(
               "hard-delete purge failed for app %s; leaving tombstone", app.id
             )
             db.rollback()
-  return (
+  apps = (
     db.query(models.App)
     .filter(models.App.deleted_at.is_(None))
     .order_by(
@@ -681,6 +687,7 @@ async def list_apps(
     )
     .all()
   )
+  return app_activity.annotate_apps(db, apps)
 
 
 @router.get("/schedules", response_model=list[schemas.AppScheduleOut])
@@ -1813,7 +1820,29 @@ def get_app(
 ):
   """Returns a single mini-app by ID (404 for a tombstoned one)."""
   app = live_app_or_404(db, app_id)
-  return app
+  return app_activity.annotate_apps(db, [app])[0]
+
+
+class AppActivitySeenRequest(BaseModel):
+  activity_version: int
+
+
+@router.post(
+  "/{app_id}/activity/seen",
+  status_code=204,
+  dependencies=[Depends(reject_cross_site)],
+)
+def mark_app_activity_seen(
+  app_id: int,
+  body: AppActivitySeenRequest,
+  db: Session = Depends(get_db),
+  _: models.Owner = Depends(get_current_owner),
+):
+  """Clear an app's durable activity dot when the owner opens the app."""
+  live_app_or_404(db, app_id)
+  app_activity.mark_seen(db, app_id, body.activity_version)
+  db.commit()
+  return Response(status_code=204)
 
 
 @router.patch(

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -119,6 +119,10 @@ class AppOut(BaseModel):
   chat_id: str | None = None
   source_dir: str | None = None
   pinned_at: datetime | None = None
+  # A durable app-attributed notification landed since this app was last
+  # opened. The shell renders the same quiet activity dot used for chats.
+  has_unseen_activity: bool = False
+  unseen_activity_version: int | None = None
   cross_app_access: ShareLevel = "none"
   share_with_apps: ShareLevel = "none"
   offline_capable: bool = False

--- a/backend/tests/test_app_activity.py
+++ b/backend/tests/test_app_activity.py
@@ -97,7 +97,12 @@ def test_non_app_and_unknown_app_notifications_do_not_create_markers(
   client, auth, db,
 ):
   app = _app(db)
-  for source_type, source_id in (("system", None), ("app", "999")):
+  for source_type, source_id in (
+    ("system", None),
+    ("app", "999"),
+    ("app", "0"),
+    ("app", "999999999999999999999999999999999999"),
+  ):
     payload = {"title": "Background work finished", "source_type": source_type}
     if source_id is not None:
       payload["source_id"] = source_id
@@ -110,3 +115,4 @@ def test_non_app_and_unknown_app_notifications_do_not_create_markers(
   )
   assert row["has_unseen_activity"] is False
   assert db.query(models.AppActivityState).count() == 0
+  assert db.query(models.Notification).count() == 4

--- a/backend/tests/test_app_activity.py
+++ b/backend/tests/test_app_activity.py
@@ -1,0 +1,112 @@
+"""App-attributed notifications drive a durable drawer activity marker."""
+
+from app import models
+from app.broadcast import get_system_broadcast
+
+
+def _app(db):
+  app = models.App(
+    name="News", description="", jsx_source="export default function App(){}",
+    compiled_path="/tmp/app.js",
+  )
+  db.add(app)
+  db.commit()
+  db.refresh(app)
+  return app
+
+
+def test_app_notification_marks_list_unseen_and_open_acknowledges(
+  client, auth, db,
+):
+  app = _app(db)
+  system_bus = get_system_broadcast()
+  events = system_bus.subscribe()
+
+  try:
+    sent = client.post("/api/notifications/send", headers=auth, json={
+      "title": "News digest ready",
+      "source_type": "app",
+      "source_id": str(app.id),
+      "target": f"/shell/?app={app.id}",
+    })
+    assert sent.status_code == 200, sent.text
+    assert events.get_nowait() == {
+      "type": "app_activity", "appId": str(app.id),
+    }
+  finally:
+    system_bus.unsubscribe(events)
+
+  listed = client.get("/api/apps/", headers=auth)
+  assert listed.status_code == 200, listed.text
+  row = next(item for item in listed.json() if item["id"] == app.id)
+  assert row["has_unseen_activity"] is True
+  observed_version = row["unseen_activity_version"]
+
+  seen = client.post(
+    f"/api/apps/{app.id}/activity/seen",
+    headers=auth,
+    json={"activity_version": observed_version},
+  )
+  assert seen.status_code == 204, seen.text
+  row = next(
+    item for item in client.get("/api/apps/", headers=auth).json()
+    if item["id"] == app.id
+  )
+  assert row["has_unseen_activity"] is False
+
+
+def test_late_seen_request_does_not_erase_newer_app_activity(client, auth, db):
+  app = _app(db)
+  payload = {
+    "title": "Background work finished",
+    "source_type": "app",
+    "source_id": str(app.id),
+  }
+  assert client.post("/api/notifications/send", headers=auth, json=payload).status_code == 200
+  first = db.get(models.AppActivityState, app.id)
+  db.refresh(first)
+  observed_version = first.activity_version
+
+  # A second completion lands after the shell fetched the first marker but
+  # before its acknowledgement reaches the server.
+  assert client.post("/api/notifications/send", headers=auth, json=payload).status_code == 200
+  db.refresh(first)
+  newer_version = first.activity_version
+  assert newer_version == observed_version + 1
+
+  stale = client.post(
+    f"/api/apps/{app.id}/activity/seen",
+    headers=auth,
+    json={"activity_version": observed_version},
+  )
+  assert stale.status_code == 204
+  db.refresh(first)
+  assert first.unseen is True
+
+  current = client.post(
+    f"/api/apps/{app.id}/activity/seen",
+    headers=auth,
+    json={"activity_version": newer_version},
+  )
+  assert current.status_code == 204
+  db.refresh(first)
+  assert first.unseen is False
+
+
+def test_non_app_and_unknown_app_notifications_do_not_create_markers(
+  client, auth, db,
+):
+  app = _app(db)
+  for source_type, source_id in (("system", None), ("app", "999")):
+    payload = {"title": "Background work finished", "source_type": source_type}
+    if source_id is not None:
+      payload["source_id"] = source_id
+    sent = client.post("/api/notifications/send", headers=auth, json=payload)
+    assert sent.status_code == 200, sent.text
+
+  row = next(
+    item for item in client.get("/api/apps/", headers=auth).json()
+    if item["id"] == app.id
+  )
+  assert row["has_unseen_activity"] is False
+  assert db.query(models.AppActivityState).count() == 0

--- a/backend/tests/test_app_activity.py
+++ b/backend/tests/test_app_activity.py
@@ -93,6 +93,28 @@ def test_late_seen_request_does_not_erase_newer_app_activity(client, auth, db):
   assert first.unseen is False
 
 
+def test_seen_rejects_versions_outside_sqlite_integer_range(client, auth, db):
+  app = _app(db)
+  sent = client.post("/api/notifications/send", headers=auth, json={
+    "title": "Background work finished",
+    "source_type": "app",
+    "source_id": str(app.id),
+  })
+  assert sent.status_code == 200, sent.text
+
+  for invalid_version in (0, -1, 1 << 63, 10**80):
+    response = client.post(
+      f"/api/apps/{app.id}/activity/seen",
+      headers=auth,
+      json={"activity_version": invalid_version},
+    )
+    assert response.status_code == 422, response.text
+
+  state = db.get(models.AppActivityState, app.id)
+  db.refresh(state)
+  assert state.unseen is True
+
+
 def test_non_app_and_unknown_app_notifications_do_not_create_markers(
   client, auth, db,
 ):

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -358,6 +358,10 @@ export const api = {
   },
   apps: {
     list: () => apiFetch('/apps/'),
+    markActivitySeen: (appId, activityVersion) => apiFetch(`/apps/${appId}/activity/seen`, {
+      method: 'POST',
+      body: JSON.stringify({ activity_version: activityVersion }),
+    }),
     remove: (appId) => apiFetch(`/apps/${appId}`, { method: 'DELETE' }),
     recover: (appId) => apiFetch(`/apps/${appId}/recover`, { method: 'POST' }),
     // Wipes the app's runtime storage back to empty while KEEPING it

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -48,6 +48,7 @@ import {
 } from '../../lib/appRecovery.js'
 import { BEFORE_SHELL_RELOAD_EVENT } from '../../lib/shellReloadEvents.js'
 import {
+  acknowledgeAppActivity,
   appAttentionIds,
   freshChatBuiltApps,
   freshAppIds,
@@ -1734,19 +1735,18 @@ export default function Shell() {
       const app = apps.find(row => Number(row.id) === appId)
       if (!app?.has_unseen_activity || !app?.unseen_activity_version) continue
       const observedActivityVersion = app.unseen_activity_version
-      const ackKey = `${appId}:${observedActivityVersion}`
-      if (appActivityAckRef.current.has(ackKey)) continue
-      appActivityAckRef.current.add(ackKey)
-      queryClient.setQueryData(
-        appQueries.keys.all,
-        rows => withAppActivitySeen(rows, appId),
-      )
-      api.apps.markActivitySeen(appId, observedActivityVersion).then(res => {
-        if (!res.ok) throw new Error(`activity acknowledgement failed (${res.status})`)
-      }).catch(() => {
-        appQueries.list.invalidate(queryClient)
-      }).finally(() => {
-        appActivityAckRef.current.delete(ackKey)
+      acknowledgeAppActivity({
+        appId,
+        activityVersion: observedActivityVersion,
+        inFlight: appActivityAckRef.current,
+        request: api.apps.markActivitySeen,
+        clearCached: (seenAppId, seenThroughVersion) => {
+          queryClient.setQueryData(
+            appQueries.keys.all,
+            rows => withAppActivitySeen(rows, seenAppId, seenThroughVersion),
+          )
+        },
+        restoreServerTruth: () => appQueries.list.invalidate(queryClient),
       })
     }
   }, [visibleAppIds, apps, queryClient])

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -48,8 +48,10 @@ import {
 } from '../../lib/appRecovery.js'
 import { BEFORE_SHELL_RELOAD_EVENT } from '../../lib/shellReloadEvents.js'
 import {
+  appAttentionIds,
   freshChatBuiltApps,
   freshAppIds,
+  withAppActivitySeen,
   withAppsFlagged,
   withoutAppFlagged,
 } from './newAppAttention.js'
@@ -1595,6 +1597,10 @@ export default function Shell() {
   // Ids of apps that appeared in the fetched list AFTER this session's
   // baseline — the drawer renders a subtle accent dot until each is opened.
   const [newAppIds, setNewAppIds] = useState(() => new Set())
+  const appAttentionSet = useMemo(
+    () => appAttentionIds(apps, newAppIds, visibleAppIds),
+    [apps, newAppIds, visibleAppIds],
+  )
   // First-sign-in walkthrough. The query result is the source of
   // truth — backend persists completion via
   // POST /api/owner/walkthrough/complete. We render the overlay iff
@@ -1714,6 +1720,36 @@ export default function Shell() {
   useEffect(() => {
     for (const id of visibleAppIds) clearAppAttention(Number(id))
   }, [visibleAppIds, clearAppAttention])
+
+  // Opening an app acknowledges its durable background activity. Optimistic
+  // cache clearing removes the dot immediately; server truth is restored on a
+  // failed request. In-flight keys include the observed activity version:
+  // duplicate renders share one request, while genuinely newer activity can
+  // be acknowledged independently without waiting for an older request.
+  const appActivityAckRef = useRef(new Set())
+  useEffect(() => {
+    for (const rawId of visibleAppIds) {
+      const appId = Number(rawId)
+      if (Number.isNaN(appId)) continue
+      const app = apps.find(row => Number(row.id) === appId)
+      if (!app?.has_unseen_activity || !app?.unseen_activity_version) continue
+      const observedActivityVersion = app.unseen_activity_version
+      const ackKey = `${appId}:${observedActivityVersion}`
+      if (appActivityAckRef.current.has(ackKey)) continue
+      appActivityAckRef.current.add(ackKey)
+      queryClient.setQueryData(
+        appQueries.keys.all,
+        rows => withAppActivitySeen(rows, appId),
+      )
+      api.apps.markActivitySeen(appId, observedActivityVersion).then(res => {
+        if (!res.ok) throw new Error(`activity acknowledgement failed (${res.status})`)
+      }).catch(() => {
+        appQueries.list.invalidate(queryClient)
+      }).finally(() => {
+        appActivityAckRef.current.delete(ackKey)
+      })
+    }
+  }, [visibleAppIds, apps, queryClient])
 
   // Immersive games request OS fullscreen to also drop the Android status bar
   // and paint under the notch — but ENTER must come from the app, because the
@@ -2358,6 +2394,11 @@ export default function Shell() {
       // to bump appVersions / cycle iframe keys — that would tear
       // down running apps for a CSS swap and lose their state.
       loadTheme()
+    } else if (ev.type === 'app_activity') {
+      // The durable marker was committed with an app-attributed notification.
+      // A refetch surfaces the dot; if the app is already visible, the effect
+      // above immediately acknowledges it instead of leaving a stale nudge.
+      refreshApps()
     } else if (ev.type === 'app_updated' || ev.type === 'app_created') {
       const placementRequest = workspaceRequestFromSystemEvent(ev)
       // Refresh server truth before warming or placing. app_updated is
@@ -3233,7 +3274,7 @@ export default function Shell() {
         }}
         streamingChatIds={streamingChatIds}
         attentionChatIds={attentionChatIds}
-        newAppIds={newAppIds}
+        newAppIds={appAttentionSet}
         settingsWarning={providerAuth.needsAttention}
         dragActiveRef={dragActiveRef}
       />
@@ -3580,7 +3621,7 @@ export default function Shell() {
             stripMotion={wrapperMotion}
             streamingChatIds={streamingChatIds}
             attentionChatIds={attentionChatIds}
-            newAppIds={newAppIds}
+            newAppIds={appAttentionSet}
           />
         )}
       </main>

--- a/frontend/src/components/Shell/__tests__/newAppAttention.test.js
+++ b/frontend/src/components/Shell/__tests__/newAppAttention.test.js
@@ -2,11 +2,43 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 
 import {
+  appAttentionIds,
   freshChatBuiltApps,
   freshAppIds,
+  withAppActivitySeen,
   withAppsFlagged,
   withoutAppFlagged,
 } from '../newAppAttention.js'
+
+test('appAttentionIds combines session arrivals with durable app activity', () => {
+  const ids = appAttentionIds([
+    { id: 1, has_unseen_activity: false },
+    { id: '2', has_unseen_activity: true },
+    { id: 3, has_unseen_activity: true },
+  ], new Set([1, '2']))
+  assert.deepEqual([...ids], [1, 2, 3])
+})
+
+test('appAttentionIds never marks an app that is already visible', () => {
+  const ids = appAttentionIds([
+    { id: 1, has_unseen_activity: true },
+    { id: 2, has_unseen_activity: true },
+  ], new Set([1, 3]), new Set(['1', 3]))
+  assert.deepEqual([...ids], [2])
+})
+
+test('withAppActivitySeen clears only the matching durable flag', () => {
+  const rows = [
+    { id: 1, has_unseen_activity: true },
+    { id: 2, has_unseen_activity: true },
+  ]
+  const next = withAppActivitySeen(rows, '1')
+  assert.deepEqual(next, [
+    { id: 1, has_unseen_activity: false },
+    { id: 2, has_unseen_activity: true },
+  ])
+  assert.equal(withAppActivitySeen(next, 1), next)
+})
 
 test('freshAppIds returns only ids absent from the baseline', () => {
   const baseline = new Set([1, 2, 3])

--- a/frontend/src/components/Shell/__tests__/newAppAttention.test.js
+++ b/frontend/src/components/Shell/__tests__/newAppAttention.test.js
@@ -2,6 +2,7 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 
 import {
+  acknowledgeAppActivity,
   appAttentionIds,
   freshChatBuiltApps,
   freshAppIds,
@@ -29,15 +30,79 @@ test('appAttentionIds never marks an app that is already visible', () => {
 
 test('withAppActivitySeen clears only the matching durable flag', () => {
   const rows = [
-    { id: 1, has_unseen_activity: true },
+    { id: 1, has_unseen_activity: true, unseen_activity_version: 4 },
     { id: 2, has_unseen_activity: true },
   ]
-  const next = withAppActivitySeen(rows, '1')
+  const next = withAppActivitySeen(rows, '1', 4)
   assert.deepEqual(next, [
-    { id: 1, has_unseen_activity: false },
+    { id: 1, has_unseen_activity: false, unseen_activity_version: null },
     { id: 2, has_unseen_activity: true },
   ])
   assert.equal(withAppActivitySeen(next, 1), next)
+})
+
+test('withAppActivitySeen never lets an older acknowledgement hide newer work', () => {
+  const rows = [
+    { id: 1, has_unseen_activity: true, unseen_activity_version: 5 },
+  ]
+  assert.equal(withAppActivitySeen(rows, 1, 4), rows)
+})
+
+test('acknowledgement deduplicates one exact app version and confirms the cache', async () => {
+  const inFlight = new Set()
+  const clears = []
+  let releaseRequest
+  let requests = 0
+  const request = () => {
+    requests += 1
+    return new Promise(resolve => { releaseRequest = resolve })
+  }
+  const options = {
+    appId: 7,
+    activityVersion: 3,
+    inFlight,
+    request,
+    clearCached: (...args) => clears.push(args),
+    restoreServerTruth: () => assert.fail('success must not restore server truth'),
+  }
+
+  const first = acknowledgeAppActivity(options)
+  const duplicate = acknowledgeAppActivity(options)
+  assert.equal(await duplicate, false)
+  assert.equal(requests, 1)
+  assert.deepEqual(clears, [[7, 3]])
+  releaseRequest({ ok: true, status: 204 })
+  assert.equal(await first, true)
+  assert.deepEqual(clears, [[7, 3], [7, 3]])
+  assert.equal(inFlight.size, 0)
+})
+
+test('failed acknowledgement releases its key before server truth can retry', async () => {
+  const inFlight = new Set()
+  let attempts = 0
+  let restores = 0
+  const options = {
+    appId: 7,
+    activityVersion: 3,
+    inFlight,
+    request: async () => {
+      attempts += 1
+      return attempts === 1
+        ? { ok: false, status: 503 }
+        : { ok: true, status: 204 }
+    },
+    clearCached: () => {},
+    restoreServerTruth: async () => {
+      restores += 1
+      assert.equal(inFlight.has('7:3'), false)
+    },
+  }
+
+  assert.equal(await acknowledgeAppActivity(options), false)
+  assert.equal(await acknowledgeAppActivity(options), true)
+  assert.equal(attempts, 2)
+  assert.equal(restores, 1)
+  assert.equal(inFlight.size, 0)
 })
 
 test('freshAppIds returns only ids absent from the baseline', () => {

--- a/frontend/src/components/Shell/newAppAttention.js
+++ b/frontend/src/components/Shell/newAppAttention.js
@@ -59,3 +59,36 @@ export function withoutAppFlagged(prev, id) {
   next.delete(n)
   return next
 }
+
+// The shell has two honest reasons to mark an app: it arrived during this
+// browser session, or a durable app-attributed background notification landed.
+// Present them as one visual state to Drawer + WorkspaceChrome.
+export function appAttentionIds(apps, newAppIds, visibleAppIds = []) {
+  const next = new Set()
+  const visible = new Set(
+    [...visibleAppIds].map(Number).filter(id => !Number.isNaN(id)),
+  )
+  for (const raw of newAppIds || []) {
+    const id = Number(raw)
+    if (!Number.isNaN(id) && !visible.has(id)) next.add(id)
+  }
+  for (const app of apps || []) {
+    const id = Number(app?.id)
+    if (!Number.isNaN(id) && !visible.has(id) && app?.has_unseen_activity) next.add(id)
+  }
+  return next
+}
+
+// Optimistically clear the query-cache flag as soon as a visible app is
+// acknowledged. A failed POST invalidates the list and restores server truth.
+export function withAppActivitySeen(apps, appId) {
+  const id = Number(appId)
+  if (!Array.isArray(apps) || Number.isNaN(id)) return apps
+  let changed = false
+  const next = apps.map(app => {
+    if (Number(app?.id) !== id || !app?.has_unseen_activity) return app
+    changed = true
+    return { ...app, has_unseen_activity: false }
+  })
+  return changed ? next : apps
+}

--- a/frontend/src/components/Shell/newAppAttention.js
+++ b/frontend/src/components/Shell/newAppAttention.js
@@ -81,14 +81,62 @@ export function appAttentionIds(apps, newAppIds, visibleAppIds = []) {
 
 // Optimistically clear the query-cache flag as soon as a visible app is
 // acknowledged. A failed POST invalidates the list and restores server truth.
-export function withAppActivitySeen(apps, appId) {
+export function withAppActivitySeen(apps, appId, seenThroughVersion = Infinity) {
   const id = Number(appId)
+  const seenThrough = Number(seenThroughVersion)
   if (!Array.isArray(apps) || Number.isNaN(id)) return apps
   let changed = false
   const next = apps.map(app => {
     if (Number(app?.id) !== id || !app?.has_unseen_activity) return app
+    const rowVersion = Number(app.unseen_activity_version)
+    if (
+      Number.isFinite(seenThrough) &&
+      Number.isFinite(rowVersion) &&
+      rowVersion > seenThrough
+    ) return app
     changed = true
-    return { ...app, has_unseen_activity: false }
+    return {
+      ...app,
+      has_unseen_activity: false,
+      unseen_activity_version: null,
+    }
   })
   return changed ? next : apps
+}
+
+// Own one exact app/version acknowledgement. The key is released before a
+// failed request restores server truth, so the resulting refetch can retry
+// immediately while the app is still visible. A successful request clears the
+// cache again because an unrelated in-flight refetch may have restored the
+// just-acknowledged version after the initial optimistic update.
+export async function acknowledgeAppActivity({
+  appId,
+  activityVersion,
+  inFlight,
+  request,
+  clearCached,
+  restoreServerTruth,
+}) {
+  const key = `${appId}:${activityVersion}`
+  if (inFlight.has(key)) return false
+  inFlight.add(key)
+  clearCached(appId, activityVersion)
+  try {
+    const response = await request(appId, activityVersion)
+    if (!response?.ok) {
+      throw new Error(`activity acknowledgement failed (${response?.status ?? 'unknown'})`)
+    }
+    clearCached(appId, activityVersion)
+    return true
+  } catch {
+    inFlight.delete(key)
+    try {
+      await restoreServerTruth()
+    } catch {
+      // Reconnect/foreground refresh remains the durable recovery path.
+    }
+    return false
+  } finally {
+    inFlight.delete(key)
+  }
 }


### PR DESCRIPTION
## What changed
- derive a durable unread marker from app-attributed notifications
- show the existing quiet activity dot for apps with unseen background work
- acknowledge only the exact activity version the visible shell observed, so a late acknowledgement cannot erase newer work
- remove markers before hard-deleted app IDs can be reused

## Why
Background apps can finish while their UI is closed. Their notification was durable, but the shell had no durable, app-specific nudge after reconnect. This reuses that canonical completion edge rather than adding a second signaling path.

## Existing work checked
Searched Möbius PRs and issues for app activity, unread notifications, and drawer dots; no overlapping work was found.

## Verification
- 30 affected backend tests
- 76 focused shell tests
- production Vite/PWA build
- race regression for newer activity arriving before an older acknowledgement
- git diff --check

Co-authored-by: Möbius Agent <mobius-agent@users.noreply.github.com>