### PR TITLE
Make Reflection questions opt-in by default

### DIFF
--- a/backend/scripts/reflection-brief-template.html
+++ b/backend/scripts/reflection-brief-template.html
@@ -11,9 +11,10 @@
 
   The chat lives BELOW this brief: the Reflection app renders this static page, then
   mounts the morning-chat thread underneath it. Keep this page a clean READ. The
-  structured decisions ride in the brief as a declarative question carrier (the
-  data-report-questions section near the end) — the app lifts that out and renders
-  native tap cards whose answers are saved for the NEXT run. Do NOT call
+  A genuinely necessary structured decision can ride in the brief as an optional
+  declarative question carrier — the app lifts that out and renders native tap
+  cards whose answers are saved for the NEXT run. The default template asks
+  nothing. Do NOT call
   AskUserQuestion from the nightly run (it parks a future a reset orphans). The
   morning chat is the open-ended escape hatch for anything the cards can't capture.
 
@@ -581,50 +582,10 @@
     </div>
   </section>
 
-  <!-- ===================== §4 What needs your input ===================== -->
-  <section id="input" aria-labelledby="input-h">
-    <div class="sec-head"><span class="sec-num">4</span><h2 id="input-h">What needs your input</h2></div>
-    <p class="sec-sub">Decisions I didn’t make for you. Answer these as tappable cards at the end of this brief — one tap each. Your picks guide tomorrow night, not today.</p>
-    <div class="items">
-      <!-- repeatable collapsed decision; add .urgent for a security/data call.
-           badge: review | risk | hold | rank. The summary alone must say what
-           to decide; the triad inside carries the receipts. -->
-      <details class="item decision">
-        <summary><span class="badge review">Decide</span> {{INPUT_TITLE_1}}</summary>
-        <p class="lead">{{INPUT_DESC_1}}</p>
-        <dl class="meta">
-          <div><dt>Trigger</dt><span class="v">{{INPUT_TRIGGER_1}}</span></div>
-          <div><dt>Why</dt><span class="v">{{INPUT_WHY_1}}</span></div>
-          <div><dt>Options</dt><span class="v action">{{INPUT_OPTIONS_1}}</span></div>
-        </dl>
-        <p class="answer-hint"><span class="dot"></span>Tap your answer in the question card at the end of this brief — it’s saved for tomorrow night’s run.</p>
-      </details>
-      <!-- /repeatable -->
-    </div>
-
-    <!-- Declarative question carrier. The app extracts the JSON below, strips
-         this whole section before rendering the iframe, and shows native tap
-         cards. The script is INERT inside the sandboxed brief (it never
-         executes); it is a data carrier only. The partner's taps are saved for
-         your NEXT run. Fill questions[] with the real enumerable decisions, if any — ZERO is a valid night (omit this whole carrier when nothing genuinely needs input), several are fine when they're real; the same decisions;
-         each option has a label (required) and an optional description. Omit the
-         whole section if you have nothing real to ask. The JSON MUST be valid —
-         a malformed carrier is silently dropped. -->
-    <section class="report-questions" data-report-questions>
-      <h2>A few questions for tomorrow night</h2>
-      <p class="rq-note">Your answers guide my next run — they won't change this brief.</p>
-      <script type="application/mobius-questions+json">
-      {"version":1,"questions":[
-        {"question":"{{QUESTION_1}}","header":"{{Q1_LABEL}}","multiSelect":false,
-         "options":[{"label":"{{Q1_OPTION_A}}","description":"{{Q1_OPTION_A_DESC}}"},
-                    {"label":"{{Q1_OPTION_B}}"}]},
-        {"question":"{{QUESTION_2}}","header":"{{Q2_LABEL}}","multiSelect":false,
-         "options":[{"label":"{{Q2_OPTION_A}}"},{"label":"{{Q2_OPTION_B}}"}]}
-      ]}
-      </script>
-    </section>
-
-  </section>
+  <!-- §4 What needs your input is intentionally absent by default. Add that
+       section and ONE declarative question carrier only when a real decision
+       blocks a better next step and no safe reversible default is good enough.
+       The Reflection skill owns the exact carrier shape. -->
 
   <!-- ===================== §5 Details ===================== -->
   <section id="details" aria-labelledby="details-h">

--- a/backend/scripts/seed-skills/reflection.md
+++ b/backend/scripts/seed-skills/reflection.md
@@ -76,7 +76,23 @@ Read `inputs/meta-state.md` first. It is your compact current operating model of
 
 Read `inputs/resource-snapshot.json`, `inputs/resource-history.jsonl`, and `inputs/resource-decisions.jsonl` in the same pass. The snapshot already paid for tonight's observation: it always contains cheap disk/cgroup counters and contains a bounded deep `/data` inventory only when due, under pressure, or after unusual growth. The history supplies recent trends and the last deep inventory; the decisions ledger says what prior runs changed, the measured result, when to look again, and what trigger permits an earlier review. **Do not rerun broad `du`, recursive `find`, browser sweeps, or equivalent diagnostics when the snapshot is fresh and the relevant decision is neither due nor triggered.** Missing or failed telemetry is a reason to repair telemetry, not permission to launch an unbounded scan.
 
-Also read `inputs/prev-question-answers.json` here (present when the partner tapped a recent brief's question cards). Those answers were saved for THIS run — no live agent waited on them. Note each decision now and **act on it in phase 2**: build the feature they picked, apply the fix they approved, drop the declines. Absent on first runs or when no questions were asked → move on.
+Also read `inputs/prev-question-answers.json` here when present. Those answers
+were saved for THIS run — no live agent waited on them. Note each decision now
+and **act on it in phase 2**: build the feature they picked, apply the fix they
+approved, drop the declines. The staged file is the newest answer record, not
+necessarily an answer to `prev-report.html`; use its `report_date` when relating
+it to a particular brief.
+
+**Question-engagement evidence must be report-aligned.** Read
+`inputs/prev-report-name.txt` for the previous report's date and inspect
+`inputs/prev-report.html` for a valid, non-empty
+`application/mobius-questions+json` carrier. Infer that the previous brief's
+cards were unanswered only when that exact report really contained questions
+and no staged answer record has the same `report_date`. A missing carrier or an
+empty questions array means the run asked nothing, so it supplies no
+non-response evidence. A mismatched older answer record proves neither that the
+previous brief asked questions nor that its cards were ignored. One unanswered
+brief is a weak channel signal, never a durable partner preference.
 
 ### 1. INTROSPECTION — interview the agents worth interviewing (summary-first triage)
 
@@ -394,7 +410,16 @@ Copy this skeleton — the template (and the base style the app injects into eve
 
 Be ruthless below the lede: a section with nothing that clears the trigger/why/next-action bar gets deleted, not padded, and a one-item night is a fine brief. The exec-summary is never collapsed; everything else defaults shut.
 
-**Honor the brief-style setting.** Use the `verbosity` value supplied in tonight's goal from canonical numeric app storage (`/data/apps/<Reflection app id>/settings.json`): `terse` = TL;DR plus keypoints plus only the must-act items, everything else dropped entirely; `standard` = the default above; `chatty` = the partner has opted into more narrative, so the lead paragraphs *inside* the collapsed items may run longer (the TL;DR cap and collapsed-by-default details still hold). Do not read settings from the `/data/apps/reflection` source directory. Absent or unrecognized → treat as `standard`.
+**Adapt the brief instead of obeying a fixed style control.** Start concise: a
+TL;DR, keypoints, and only items that clear the trigger/why/next-action bar.
+Compare `prev-report.html` with what changed tonight; compress repeated context
+and spend detail only where it improves a decision or explains a concrete
+result. Use the report-aligned engagement evidence above to ask fewer, sharper
+questions when cards are low-yield, but do not treat one unanswered brief as a
+request for less writing. The collapsed details can carry necessary narrative;
+the TL;DR cap and collapsed-by-default contract remain fixed. There is no
+`verbosity`, `focus`, or `avoid` setting to honor — editorial judgment belongs
+to the Reflection agent each run.
 
 **Put the questions IN the brief as tappable cards — the in-report contract.** The partner answers your decisions by tapping cards rendered *in the brief itself*, and those answers are saved for your **NEXT run** — not collected by a live agent. This is the durable replacement for the old "post AskUserQuestion cards in a morning chat" flow: a background/morning agent that calls `AskUserQuestion` parks a synchronous in-memory future that a server reset orphans, freezing the night. Instead, **emit the questions declaratively inside the brief HTML** and let the app render the cards.
 

--- a/backend/tests/test_reflection_brief_template.py
+++ b/backend/tests/test_reflection_brief_template.py
@@ -1,0 +1,16 @@
+"""The baked Reflection scaffold asks only questions earned by a real run."""
+
+from pathlib import Path
+
+
+def test_default_reflection_brief_has_no_placeholder_question_carrier():
+  template = (
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "reflection-brief-template.html"
+  ).read_text(encoding="utf-8")
+
+  assert "intentionally absent by default" in template
+  assert "data-report-questions" not in template
+  assert "{{QUESTION_" not in template
+  assert "{{INPUT_" not in template

--- a/backend/tests/test_reflection_runner.py
+++ b/backend/tests/test_reflection_runner.py
@@ -1084,3 +1084,17 @@ def test_seed_skill_uses_chat_sent_without_false_activity_substitutes():
   assert "never infer activity from `Chat.created_at`" in seed
   assert "a shared timestamp alone is not evidence" in seed
   assert "this schema has no `chat_sent`" not in seed
+
+
+def test_seed_skill_aligns_question_engagement_and_owns_brief_style():
+  seed = (
+    Path(dr.__file__).resolve().parent / "seed-skills" / "reflection.md"
+  ).read_text(encoding="utf-8")
+  assert "Question-engagement evidence must be report-aligned" in seed
+  assert "valid, non-empty" in seed
+  assert "same `report_date`" in seed
+  assert "empty questions array means the run asked nothing" in seed
+  assert "weak channel signal, never a durable partner preference" in seed
+  assert "Adapt the brief instead of obeying a fixed style control" in seed
+  assert "There is no\n`verbosity`, `focus`, or `avoid` setting to honor" in seed
+  assert "Honor the brief-style setting" not in seed


### PR DESCRIPTION
## What changed
Remove placeholder decision cards from the baked Reflection morning-brief scaffold. A nightly run can still add the documented declarative question carrier, but only when a real choice is worth asking.

This is the platform half of the adaptive Reflection cleanup; the companion app PR removes fixed verbosity/nightly steering controls and reads actual prior-answer engagement.

## Existing work checked
Searched Möbius PRs and issues for Reflection brief steering, adaptive questions, and placeholder question cards; no overlapping work was found.

## Verification
- 52 Reflection/template checks
- explicit invariant: no default carrier or placeholder question/input tokens
- git diff --check

Co-authored-by: Möbius Agent <mobius-agent@users.noreply.github.com>