### PR TITLE
Prevent chat restore into reserved blank space

### DIFF
--- a/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
+++ b/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
@@ -1081,7 +1081,7 @@ test('anchor reservation disappears once real content makes the target reachable
   )
 })
 
-test('an off-content anchor cannot enlarge the dynamic spacer', () => {
+test('a live off-content anchor reserves its exact reader-owned position', () => {
   const anchor = { offsetTop: 500, offsetHeight: 220 }
   const scrollEl = {
     clientHeight: 700,
@@ -1094,8 +1094,8 @@ test('an off-content anchor cannot enlarge the dynamic spacer', () => {
   }
   assert.equal(
     _computeSpacerH(scrollEl, { offsetHeight: 700 }, { offsetTop: 100 }, 700, mode),
-    96,
-    'only the ordinary latest-user pin reservation remains',
+    1400,
+    'live reader ownership survives in reserved room; persistence rejects it',
   )
 })
 

--- a/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
+++ b/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
@@ -26,6 +26,7 @@ import {
   modeAfterReaderReachesBottom,
   modeAfterSpacerResize,
   modeAfterTerminalLayout,
+  physicalBottomAnchorModeFromScroll,
   readerInputActivatesDisclosure,
   readerInputMayScroll,
   readerInputNeedsFrameRelease,
@@ -729,7 +730,7 @@ test('no saved chat location opens at the latest real content without enabling f
     'the real content tail is visible and reserved spacer room is excluded')
 })
 
-test('attention nudge anchors the real-content tail without enabling follow', () => {
+test('attention nudge anchors the physical tail without enabling follow', () => {
   const last = {
     offsetTop: 1500,
     offsetHeight: 220,
@@ -740,7 +741,6 @@ test('attention nudge anchors the real-content tail without enabling follow', ()
     scrollTop: 700,
     clientHeight: 700,
     querySelector(selector) {
-      if (selector === '.spacer-dynamic') return { offsetHeight: 200 }
       if (selector === '[data-key="assistant-paused-tail"]') return last
       return null
     },
@@ -749,18 +749,55 @@ test('attention nudge anchors the real-content tail without enabling follow', ()
     },
   }
 
-  const mode = bottomAnchorModeFromScroll(scrollEl)
+  const mode = physicalBottomAnchorModeFromScroll(scrollEl)
   assert.deepEqual(mode, {
+    kind: 'ANCHOR_AT',
+    key: 'assistant-paused-tail',
+    offset: 100,
+  })
+  applyMode(scrollEl, mode)
+  assert.equal(scrollEl.scrollTop, 1400,
+    'the nudge includes all composer clearance after the attention card')
+  assert.notEqual(mode.kind, 'FOLLOW_BOTTOM',
+    'revealing a question or Resume control must not create live-follow intent')
+})
+
+test('an off-content physical nudge stays live but persists the real-content tail', () => {
+  const last = {
+    offsetTop: 1500,
+    offsetHeight: 220,
+    dataset: { key: 'assistant-paused-tail' },
+  }
+  const scrollEl = {
+    scrollHeight: 3100,
+    scrollTop: 700,
+    clientHeight: 700,
+    querySelector(selector) {
+      if (selector === '.spacer-dynamic') return { offsetHeight: 1200 }
+      if (selector === '[data-key="assistant-paused-tail"]') return last
+      return null
+    },
+    querySelectorAll(selector) {
+      return selector === '.chat__msg[data-key]' ? [last] : []
+    },
+  }
+
+  const liveMode = physicalBottomAnchorModeFromScroll(scrollEl)
+  assert.deepEqual(liveMode, {
+    kind: 'ANCHOR_AT',
+    key: 'assistant-paused-tail',
+    offset: -900,
+  })
+  applyMode(scrollEl, liveMode)
+  assert.equal(scrollEl.scrollTop, 2400,
+    'the explicit nudge reaches the true physical tail in the live mount')
+
+  assert.deepEqual(_modeForPersistence(liveMode, [], scrollEl), {
     kind: 'ANCHOR_AT',
     key: 'assistant-paused-tail',
     offset: 300,
     defaultTail: true,
-  })
-  applyMode(scrollEl, mode)
-  assert.equal(scrollEl.scrollTop, 1200,
-    'the nudge excludes blank reservation while retaining composer-cleared content')
-  assert.notEqual(mode.kind, 'FOLLOW_BOTTOM',
-    'revealing a question or Resume control must not create live-follow intent')
+  }, 'durable state normalizes the off-content nudge to the real tail')
 })
 
 test('an unresolvable saved location falls back to a settled bottom anchor', () => {

--- a/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
+++ b/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
@@ -5,11 +5,13 @@ import {
   _anchorModeIntersectsContent,
   _anchorReapplyNeeded,
   _computeSpacerH,
+  _modeForPersistence,
   _pinReapplyNeeded,
   _scrollModeForDiagnostics,
   _validateSavedMode,
   applyMode,
   bottomAnchorModeFromScroll,
+  contentHoldModeFromScroll,
   gestureLayoutRetryDelay,
   isNearContentBottom,
   isNearScrollBottom,
@@ -827,6 +829,35 @@ test('a saved anchor wholly inside reserved blank space self-heals to real conte
   })
 })
 
+test('live persistence preserves follow while restore settles it to real content', () => {
+  const last = {
+    offsetTop: 500,
+    offsetHeight: 220,
+    dataset: { key: 'assistant-tail' },
+  }
+  const scrollEl = {
+    scrollHeight: 1900,
+    clientHeight: 700,
+    querySelector(selector) {
+      if (selector === '.spacer-dynamic') return { offsetHeight: 1200 }
+      return null
+    },
+    querySelectorAll(selector) {
+      return selector === '.chat__msg[data-key]' ? [last] : []
+    },
+  }
+  const follow = { kind: 'FOLLOW_BOTTOM' }
+
+  assert.equal(_modeForPersistence(follow, [], scrollEl), follow,
+    'ordinary live persistence must not erase the active follow state')
+  assert.deepEqual(_validateSavedMode(follow, [], scrollEl), {
+    kind: 'ANCHOR_AT',
+    key: 'assistant-tail',
+    offset: 500,
+    defaultTail: true,
+  }, 'mount restore still converts follow into a settled content hold')
+})
+
 test('a saved partially-visible anchor remains exact', () => {
   const row = {
     offsetTop: 500,
@@ -911,6 +942,33 @@ test('chat exit from blank reservation persists the real-content tail', () => {
   }
 
   assert.deepEqual(modeForChatExit(scrollEl), {
+    kind: 'ANCHOR_AT',
+    key: 'assistant-question',
+    offset: 500,
+    defaultTail: true,
+  })
+})
+
+test('leaving the physical bottom inside blank reservation retires follow', () => {
+  const last = {
+    offsetTop: 500,
+    offsetHeight: 220,
+    dataset: { key: 'assistant-question' },
+  }
+  const scrollEl = {
+    scrollHeight: 1900,
+    scrollTop: 1200,
+    clientHeight: 700,
+    querySelector(selector) {
+      if (selector === '.spacer-dynamic') return { offsetHeight: 1200 }
+      return null
+    },
+    querySelectorAll(selector) {
+      return selector === '.chat__msg[data-key]' ? [last] : []
+    },
+  }
+
+  assert.deepEqual(contentHoldModeFromScroll(scrollEl), {
     kind: 'ANCHOR_AT',
     key: 'assistant-question',
     offset: 500,

--- a/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
+++ b/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
@@ -2,6 +2,7 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 
 import {
+  _anchorModeIntersectsContent,
   _anchorReapplyNeeded,
   _computeSpacerH,
   _pinReapplyNeeded,
@@ -23,7 +24,6 @@ import {
   modeAfterReaderReachesBottom,
   modeAfterSpacerResize,
   modeAfterTerminalLayout,
-  physicalBottomAnchorModeFromScroll,
   readerInputActivatesDisclosure,
   readerInputMayScroll,
   readerInputNeedsFrameRelease,
@@ -220,6 +220,7 @@ test('disclosure toggles follow only in FOLLOW_BOTTOM and otherwise hold the rea
   }
   const scrollEl = {
     scrollTop: 500,
+    clientHeight: 600,
     querySelectorAll: () => [row],
   }
   const follow = { kind: 'FOLLOW_BOTTOM' }
@@ -726,7 +727,7 @@ test('no saved chat location opens at the latest real content without enabling f
     'the real content tail is visible and reserved spacer room is excluded')
 })
 
-test('attention nudge anchors the physical tail without enabling follow', () => {
+test('attention nudge anchors the real-content tail without enabling follow', () => {
   const last = {
     offsetTop: 1500,
     offsetHeight: 220,
@@ -737,6 +738,7 @@ test('attention nudge anchors the physical tail without enabling follow', () => 
     scrollTop: 700,
     clientHeight: 700,
     querySelector(selector) {
+      if (selector === '.spacer-dynamic') return { offsetHeight: 200 }
       if (selector === '[data-key="assistant-paused-tail"]') return last
       return null
     },
@@ -745,15 +747,16 @@ test('attention nudge anchors the physical tail without enabling follow', () => 
     },
   }
 
-  const mode = physicalBottomAnchorModeFromScroll(scrollEl)
+  const mode = bottomAnchorModeFromScroll(scrollEl)
   assert.deepEqual(mode, {
     kind: 'ANCHOR_AT',
     key: 'assistant-paused-tail',
-    offset: 100,
+    offset: 300,
+    defaultTail: true,
   })
   applyMode(scrollEl, mode)
-  assert.equal(scrollEl.scrollTop, 1400,
-    'the nudge includes all composer clearance after the attention card')
+  assert.equal(scrollEl.scrollTop, 1200,
+    'the nudge excludes blank reservation while retaining composer-cleared content')
   assert.notEqual(mode.kind, 'FOLLOW_BOTTOM',
     'revealing a question or Resume control must not create live-follow intent')
 })
@@ -791,35 +794,69 @@ test('an unresolvable saved location falls back to a settled bottom anchor', () 
   assert.notEqual(mode.kind, 'FOLLOW_BOTTOM')
 })
 
-test('attention nudge anchors the physical tail without enabling follow', () => {
+test('a saved anchor wholly inside reserved blank space self-heals to real content', () => {
   const last = {
-    offsetTop: 1500,
+    offsetTop: 500,
     offsetHeight: 220,
-    dataset: { key: 'assistant-attention-tail' },
+    dataset: { key: 'assistant-question' },
   }
   const scrollEl = {
-    scrollHeight: 2100,
-    scrollTop: 700,
+    scrollHeight: 1900,
+    scrollTop: 0,
     clientHeight: 700,
     querySelector(selector) {
-      return selector === '[data-key="assistant-attention-tail"]' ? last : null
+      if (selector === '.spacer-dynamic') return { offsetHeight: 1200 }
+      if (selector === '[data-key="assistant-question"]') return last
+      return null
     },
     querySelectorAll(selector) {
       return selector === '.chat__msg[data-key]' ? [last] : []
     },
   }
 
-  const mode = physicalBottomAnchorModeFromScroll(scrollEl)
-  assert.deepEqual(mode, {
+  const restored = _validateSavedMode(
+    { kind: 'ANCHOR_AT', key: 'assistant-question', offset: -900 },
+    [],
+    scrollEl,
+  )
+  assert.deepEqual(restored, {
     kind: 'ANCHOR_AT',
-    key: 'assistant-attention-tail',
-    offset: 100,
+    key: 'assistant-question',
+    offset: 500,
+    defaultTail: true,
   })
-  applyMode(scrollEl, mode)
-  assert.equal(scrollEl.scrollTop, 1400,
-    'the move includes all composer clearance after the attention card')
-  assert.notEqual(mode.kind, 'FOLLOW_BOTTOM',
-    'revealing an action must not create live-follow intent')
+})
+
+test('a saved partially-visible anchor remains exact', () => {
+  const row = {
+    offsetTop: 500,
+    offsetHeight: 220,
+    dataset: { key: 'assistant-reading' },
+  }
+  const saved = {
+    kind: 'ANCHOR_AT', key: 'assistant-reading', offset: -100,
+  }
+  const scrollEl = {
+    clientHeight: 700,
+    querySelector(selector) {
+      return selector === '[data-key="assistant-reading"]' ? row : null
+    },
+  }
+  assert.equal(_validateSavedMode(saved, [], scrollEl), saved,
+    'an anchor whose row still intersects its restored viewport is preserved')
+})
+
+test('the anchor invariant distinguishes content from layout reservation', () => {
+  const row = { offsetHeight: 220 }
+  assert.equal(_anchorModeIntersectsContent(
+    row, { offset: -100 }, 700,
+  ), true, 'a partially visible row is a readable location')
+  assert.equal(_anchorModeIntersectsContent(
+    row, { offset: -900 }, 700,
+  ), false, 'a row wholly above the viewport is blank reservation')
+  assert.equal(_anchorModeIntersectsContent(
+    row, { offset: 700 }, 700,
+  ), false, 'a row beginning below the viewport is not visible content')
 })
 
 test('chat exit freezes the visible anchor even at the physical tail', () => {
@@ -852,6 +889,33 @@ test('chat exit never infers follow mode when no message anchor exists', () => {
   }
 
   assert.equal(modeForChatExit(scrollEl), null)
+})
+
+test('chat exit from blank reservation persists the real-content tail', () => {
+  const last = {
+    offsetTop: 500,
+    offsetHeight: 220,
+    dataset: { key: 'assistant-question' },
+  }
+  const scrollEl = {
+    scrollHeight: 1900,
+    scrollTop: 1200,
+    clientHeight: 700,
+    querySelector(selector) {
+      if (selector === '.spacer-dynamic') return { offsetHeight: 1200 }
+      return null
+    },
+    querySelectorAll(selector) {
+      return selector === '.chat__msg[data-key]' ? [last] : []
+    },
+  }
+
+  assert.deepEqual(modeForChatExit(scrollEl), {
+    kind: 'ANCHOR_AT',
+    key: 'assistant-question',
+    offset: 500,
+    defaultTail: true,
+  })
 })
 
 test('applyMode PIN is a no-op when the cid resolves no row (strict, no fallback)', () => {
@@ -918,7 +982,7 @@ test('spacer reservation returns zero before there is a user message', () => {
 })
 
 test('viewport growth keeps a question-answer anchor reachable before output resumes', () => {
-  const anchor = { offsetTop: 1320 }
+  const anchor = { offsetTop: 1320, offsetHeight: 220 }
   const scrollEl = {
     clientHeight: 960,
     querySelector(selector) {
@@ -944,7 +1008,7 @@ test('viewport growth keeps a question-answer anchor reachable before output res
 })
 
 test('anchor reservation disappears once real content makes the target reachable', () => {
-  const anchor = { offsetTop: 1320 }
+  const anchor = { offsetTop: 1320, offsetHeight: 220 }
   const scrollEl = {
     clientHeight: 960,
     querySelector(selector) {
@@ -956,6 +1020,24 @@ test('anchor reservation disappears once real content makes the target reachable
   assert.equal(
     _computeSpacerH(scrollEl, { offsetHeight: 2300 }, { offsetTop: 900 }, 960, mode),
     0,
+  )
+})
+
+test('an off-content anchor cannot enlarge the dynamic spacer', () => {
+  const anchor = { offsetTop: 500, offsetHeight: 220 }
+  const scrollEl = {
+    clientHeight: 700,
+    querySelector(selector) {
+      return selector === '[data-key="assistant-question"]' ? anchor : null
+    },
+  }
+  const mode = {
+    kind: 'ANCHOR_AT', key: 'assistant-question', offset: -900,
+  }
+  assert.equal(
+    _computeSpacerH(scrollEl, { offsetHeight: 700 }, { offsetTop: 100 }, 700, mode),
+    96,
+    'only the ordinary latest-user pin reservation remains',
   )
 })
 

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -213,6 +213,36 @@ export function bottomAnchorModeFromScroll(scrollEl) {
 }
 
 
+/** Create a settled hold anchor at the true physical scroll tail.
+ *
+ * This is deliberately different from `bottomAnchorModeFromScroll`, which
+ * excludes the dynamic reservation for the automatic no-location restore.
+ * An explicit attention-nudge tap asks to see everything after the question
+ * or paused card too: composer clearance, any remaining reservation, and the
+ * card's primary action. Keep that one-shot navigation as ANCHOR_AT rather
+ * than FOLLOW_BOTTOM so revealing a control cannot manufacture live-follow
+ * intent for a later answer or resume. Persistence independently rejects an
+ * off-content physical anchor, so this live navigation cannot recreate a
+ * blank viewport on reload.
+ */
+export function physicalBottomAnchorModeFromScroll(scrollEl) {
+  if (!scrollEl) return null
+  const items = scrollEl.querySelectorAll('.chat__msg[data-key]')
+  const last = items[items.length - 1]
+  const key = last?.dataset?.key
+  if (!last || !key) return null
+  const targetScrollTop = Math.max(
+    0,
+    scrollEl.scrollHeight - scrollEl.clientHeight,
+  )
+  return {
+    kind: 'ANCHOR_AT',
+    key,
+    offset: last.offsetTop - targetScrollTop,
+  }
+}
+
+
 /** Freeze a viewport to real conversation content.
  *
  * A reader can move away from the physical bottom while the viewport is
@@ -1114,10 +1144,7 @@ export default function useScrollMode({
   // be mistaken for a second human gesture that enables FOLLOW_BOTTOM.
   const revealConversationTail = useCallback(() => {
     const scrollEl = scrollRef.current
-    // The real-content tail already includes the list's measured composer
-    // clearance. The dynamic spacer is layout machinery for send pinning, not
-    // a conversation destination.
-    const nextMode = bottomAnchorModeFromScroll(scrollEl)
+    const nextMode = physicalBottomAnchorModeFromScroll(scrollEl)
     if (!scrollEl || !nextMode) return
     gestureWindowUntilRef.current = 0
     readerLocationExplicitRef.current = true

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -194,6 +194,17 @@ export function bottomAnchorModeFromScroll(scrollEl) {
 }
 
 
+/** Freeze a viewport to real conversation content.
+ *
+ * A reader can move away from the physical bottom while the viewport is
+ * wholly inside dynamic spacer. There is no exact visible row to anchor in
+ * that case, but the gesture must still retire live follow. Settle at the
+ * latest real-content tail rather than leaving FOLLOW_BOTTOM armed. */
+export function contentHoldModeFromScroll(scrollEl) {
+  return anchorModeFromScroll(scrollEl) || bottomAnchorModeFromScroll(scrollEl)
+}
+
+
 /** Resolve the DOM row a PIN_USER_MSG targets: the user row whose
  *  `data-cid` equals the mode's cid.
  *
@@ -346,6 +357,19 @@ export function _validateSavedMode(saved, messages, scrollEl) {
       : holdBottom()
   }
   return holdBottom()
+}
+
+
+/** Normalize durable reader locations without collapsing live mode state.
+ *
+ * FOLLOW_BOTTOM and PIN_USER_MSG are useful while this mount is active and
+ * are already converted to settled restore modes by `_validateSavedMode` on
+ * the next mount. ANCHOR_AT is the only mode whose stored geometry can point
+ * wholly into spacer, so validate that location before every write. */
+export function _modeForPersistence(mode, messages, scrollEl) {
+  return mode?.kind === 'ANCHOR_AT'
+    ? _validateSavedMode(mode, messages, scrollEl)
+    : mode
 }
 
 
@@ -623,7 +647,7 @@ export function readerInputNeedsFrameRelease(
  *  FOLLOW_BOTTOM afterward. */
 export function modeForForegroundReturn(scrollEl) {
   if (!scrollEl) return null
-  return anchorModeFromScroll(scrollEl) || bottomAnchorModeFromScroll(scrollEl)
+  return contentHoldModeFromScroll(scrollEl)
 }
 
 
@@ -634,7 +658,7 @@ export function modeForForegroundReturn(scrollEl) {
  *  yanking the reader to the latest tail. */
 export function modeForChatExit(scrollEl) {
   if (!scrollEl) return null
-  return anchorModeFromScroll(scrollEl) || bottomAnchorModeFromScroll(scrollEl)
+  return contentHoldModeFromScroll(scrollEl)
 }
 
 
@@ -959,12 +983,11 @@ export default function useScrollMode({
       const candidate = freezeToCurrentPosition
         ? (modeForChatExit(scrollRef.current) || modeRef.current)
         : modeRef.current
-      // One persistence gate for every lifecycle path. Never write a location
-      // that cannot render real conversation content; normalize invalid or
-      // stale modes to the settled real-content tail before they reach
-      // sessionStorage. Mount uses the same validator when reading, so the
-      // invariant is symmetric and older bad state self-heals.
-      const mode = _validateSavedMode(
+      // One persistence gate for every lifecycle path. Invalid ANCHOR_AT
+      // geometry is normalized before it reaches sessionStorage. Live
+      // FOLLOW_BOTTOM/PIN_USER_MSG remains observable while mounted; the
+      // restore gate settles those modes on the next mount.
+      const mode = _modeForPersistence(
         candidate, messagesRef.current, scrollRef.current,
       )
       if (mode && mode.kind !== 'INITIAL') {
@@ -989,7 +1012,7 @@ export default function useScrollMode({
         && !(retireFollow && kind === 'FOLLOW_BOTTOM')) {
       return modeRef.current
     }
-    const anchor = anchorModeFromScroll(scrollRef.current)
+    const anchor = contentHoldModeFromScroll(scrollRef.current)
     return anchor ? transitionMode(anchor, event) : modeRef.current
   }, [scrollRef, transitionMode])
 
@@ -1675,7 +1698,11 @@ export default function useScrollMode({
           'reader:physical-bottom',
         )
       } else {
-        const anchor = anchorModeFromScroll(scrollEl)
+        // Moving away from the physical bottom always retires live follow.
+        // If the viewport is wholly inside reserved spacer there is no exact
+        // row anchor, so settle on the real-content tail instead of leaving a
+        // stale FOLLOW_BOTTOM armed for the next content resize.
+        const anchor = contentHoldModeFromScroll(scrollEl)
         if (anchor) transitionMode(anchor, 'reader:hold-anchor')
       }
       persistMode()

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -131,13 +131,14 @@ const _scrollModes = (() => {
 })()
 
 
-/** Returns the topmost message <li> that ACTUALLY intersects the viewport.
+/** Returns the topmost intersecting message, or the last real row while the
+ * viewport is inside the dynamic reservation below the transcript.
  *
- * The dynamic spacer is intentionally scrollable blank room after the real
- * transcript. Returning the last row when the viewport is wholly inside that
- * room manufactures a huge negative anchor offset; persisting it makes reload
- * recreate the same black screen forever. No visible row means no reader
- * anchor — callers must fall back to the latest real conversation content. */
+ * That fallback is load-bearing for LIVE reader ownership: a gesture through
+ * reserved room still needs an anchor so streaming/layout work cannot move the
+ * viewport underneath the reader. Lifecycle save/restore validates that the
+ * anchor intersects real content and normalizes this live-only negative offset
+ * to the real transcript tail before persistence. */
 function _topmostVisibleMsg(scrollEl) {
   const items = scrollEl.querySelectorAll('.chat__msg[data-key]')
   const top = scrollEl.scrollTop
@@ -146,7 +147,7 @@ function _topmostVisibleMsg(scrollEl) {
     const itemBottom = el.offsetTop + el.offsetHeight
     if (itemBottom > top && el.offsetTop < bottom) return el
   }
-  return null
+  return items[items.length - 1] || null
 }
 
 
@@ -170,6 +171,24 @@ export function anchorModeFromScroll(scrollEl) {
     key: anchorEl.dataset.key,
     offset: anchorEl.offsetTop - scrollEl.scrollTop,
   }
+}
+
+
+/** Lifecycle anchors must describe visible conversation content. Live scroll
+ * handling may temporarily anchor reserved room, but foreground/chat restore
+ * must never recreate that blank viewport. */
+function _contentAnchorModeFromScroll(scrollEl) {
+  if (!scrollEl) return null
+  const row = _topmostVisibleMsg(scrollEl)
+  if (!row?.dataset?.key) return null
+  const mode = {
+    kind: 'ANCHOR_AT',
+    key: row.dataset.key,
+    offset: row.offsetTop - scrollEl.scrollTop,
+  }
+  return _anchorModeIntersectsContent(row, mode, scrollEl?.clientHeight)
+    ? mode
+    : null
 }
 
 
@@ -201,7 +220,8 @@ export function bottomAnchorModeFromScroll(scrollEl) {
  * that case, but the gesture must still retire live follow. Settle at the
  * latest real-content tail rather than leaving FOLLOW_BOTTOM armed. */
 export function contentHoldModeFromScroll(scrollEl) {
-  return anchorModeFromScroll(scrollEl) || bottomAnchorModeFromScroll(scrollEl)
+  return _contentAnchorModeFromScroll(scrollEl)
+    || bottomAnchorModeFromScroll(scrollEl)
 }
 
 
@@ -416,7 +436,7 @@ export function _computeSpacerH(
   let target = pinTarget
   if (mode?.kind === 'ANCHOR_AT') {
     const anchorEl = _anchorEl(scrollEl, mode.key)
-    if (_anchorModeIntersectsContent(anchorEl, mode, viewH)) {
+    if (anchorEl) {
       target = Math.max(target, Math.max(0, anchorEl.offsetTop - mode.offset))
     }
   }

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -131,17 +131,22 @@ const _scrollModes = (() => {
 })()
 
 
-/** Returns the first message <li> whose bottom edge is past the
- *  viewport top — i.e. the topmost partially-visible message.
- *  Used to resolve a fresh ANCHOR_AT when the user scrolls. */
+/** Returns the topmost message <li> that ACTUALLY intersects the viewport.
+ *
+ * The dynamic spacer is intentionally scrollable blank room after the real
+ * transcript. Returning the last row when the viewport is wholly inside that
+ * room manufactures a huge negative anchor offset; persisting it makes reload
+ * recreate the same black screen forever. No visible row means no reader
+ * anchor — callers must fall back to the latest real conversation content. */
 function _topmostVisibleMsg(scrollEl) {
   const items = scrollEl.querySelectorAll('.chat__msg[data-key]')
   const top = scrollEl.scrollTop
+  const bottom = top + scrollEl.clientHeight
   for (const el of items) {
-    const bottom = el.offsetTop + el.offsetHeight
-    if (bottom > top) return el
+    const itemBottom = el.offsetTop + el.offsetHeight
+    if (itemBottom > top && el.offsetTop < bottom) return el
   }
-  return items[items.length - 1] || null
+  return null
 }
 
 
@@ -185,34 +190,6 @@ export function bottomAnchorModeFromScroll(scrollEl) {
     key,
     offset: last.offsetTop - targetScrollTop,
     defaultTail: true,
-  }
-}
-
-
-/** Create a settled hold anchor at the true physical scroll tail.
- *
- * This is deliberately different from `bottomAnchorModeFromScroll`, which
- * excludes the dynamic reservation for the automatic no-location restore.
- * An explicit attention-nudge tap asks to see everything after the question
- * or paused card too: composer clearance, any remaining reservation, and the
- * card's primary action. Keep that one-shot navigation as ANCHOR_AT rather
- * than FOLLOW_BOTTOM so revealing a control cannot manufacture live-follow
- * intent for a later answer or resume.
- */
-export function physicalBottomAnchorModeFromScroll(scrollEl) {
-  if (!scrollEl) return null
-  const items = scrollEl.querySelectorAll('.chat__msg[data-key]')
-  const last = items[items.length - 1]
-  const key = last?.dataset?.key
-  if (!last || !key) return null
-  const targetScrollTop = Math.max(
-    0,
-    scrollEl.scrollHeight - scrollEl.clientHeight,
-  )
-  return {
-    kind: 'ANCHOR_AT',
-    key,
-    offset: last.offsetTop - targetScrollTop,
   }
 }
 
@@ -300,6 +277,20 @@ function _anchorEl(scrollEl, key) {
   return scrollEl.querySelector(`[data-key="${esc}"]`)
 }
 
+/** The defining ANCHOR_AT invariant: its row intersects the viewport encoded
+ * by `offset`. Negative offsets are valid while the row remains partially
+ * visible; an offset beyond either edge describes layout reservation, not a
+ * readable conversation location. */
+export function _anchorModeIntersectsContent(row, mode, viewportHeight) {
+  const offset = Number(mode?.offset)
+  return !!row
+    && Number.isFinite(offset)
+    && Number.isFinite(viewportHeight)
+    && viewportHeight > 0
+    && offset < viewportHeight
+    && offset > -row.offsetHeight
+}
+
 /** The ANCHOR_AT twin of `_pinReapplyNeeded` — the SAME two-case repair. A
  *  settled anchor drifts off its reader-chosen position when either the anchor
  *  element's offsetTop SHIFTED (content grew above it) or scrollTop was CLAMPED
@@ -345,7 +336,14 @@ export function _validateSavedMode(saved, messages, scrollEl) {
   if (saved.kind === 'ANCHOR_AT') {
     const sel = `[data-key="${(typeof CSS !== 'undefined' && CSS.escape)
       ? CSS.escape(saved.key) : saved.key}"]`
-    return scrollEl?.querySelector(sel) ? saved : holdBottom()
+    const row = scrollEl?.querySelector(sel)
+    // A resolvable row is not enough: an old build could persist that row with
+    // a huge negative offset while the viewport sat wholly in spacer below it.
+    // Enforce the same content-intersection invariant used by spacer sizing,
+    // self-healing every off-content restore to the real tail.
+    return _anchorModeIntersectsContent(row, saved, scrollEl?.clientHeight)
+      ? saved
+      : holdBottom()
   }
   return holdBottom()
 }
@@ -394,7 +392,7 @@ export function _computeSpacerH(
   let target = pinTarget
   if (mode?.kind === 'ANCHOR_AT') {
     const anchorEl = _anchorEl(scrollEl, mode.key)
-    if (anchorEl) {
+    if (_anchorModeIntersectsContent(anchorEl, mode, viewH)) {
       target = Math.max(target, Math.max(0, anchorEl.offsetTop - mode.offset))
     }
   }
@@ -625,7 +623,7 @@ export function readerInputNeedsFrameRelease(
  *  FOLLOW_BOTTOM afterward. */
 export function modeForForegroundReturn(scrollEl) {
   if (!scrollEl) return null
-  return anchorModeFromScroll(scrollEl)
+  return anchorModeFromScroll(scrollEl) || bottomAnchorModeFromScroll(scrollEl)
 }
 
 
@@ -636,7 +634,7 @@ export function modeForForegroundReturn(scrollEl) {
  *  yanking the reader to the latest tail. */
 export function modeForChatExit(scrollEl) {
   if (!scrollEl) return null
-  return anchorModeFromScroll(scrollEl)
+  return anchorModeFromScroll(scrollEl) || bottomAnchorModeFromScroll(scrollEl)
 }
 
 
@@ -958,18 +956,28 @@ export default function useScrollMode({
         sessionStorage.setItem('chat-mode', JSON.stringify(_scrollModes))
         return
       }
-      const mode = freezeToCurrentPosition
+      const candidate = freezeToCurrentPosition
         ? (modeForChatExit(scrollRef.current) || modeRef.current)
         : modeRef.current
+      // One persistence gate for every lifecycle path. Never write a location
+      // that cannot render real conversation content; normalize invalid or
+      // stale modes to the settled real-content tail before they reach
+      // sessionStorage. Mount uses the same validator when reading, so the
+      // invariant is symmetric and older bad state self-heals.
+      const mode = _validateSavedMode(
+        candidate, messagesRef.current, scrollRef.current,
+      )
       if (mode && mode.kind !== 'INITIAL') {
         if (freezeToCurrentPosition) {
           transitionMode(mode, 'lifecycle:chat-exit')
         }
         _scrollModes[chatId] = mode
-        sessionStorage.setItem('chat-mode', JSON.stringify(_scrollModes))
+      } else {
+        delete _scrollModes[chatId]
       }
+      sessionStorage.setItem('chat-mode', JSON.stringify(_scrollModes))
     } catch {}
-  }, [chatId, scrollRef, transitionMode])
+  }, [chatId, messagesRef, scrollRef, transitionMode])
 
   const settleNonPin = useCallback(({
     retireFollow = false,
@@ -1063,7 +1071,10 @@ export default function useScrollMode({
   // be mistaken for a second human gesture that enables FOLLOW_BOTTOM.
   const revealConversationTail = useCallback(() => {
     const scrollEl = scrollRef.current
-    const nextMode = physicalBottomAnchorModeFromScroll(scrollEl)
+    // The real-content tail already includes the list's measured composer
+    // clearance. The dynamic spacer is layout machinery for send pinning, not
+    // a conversation destination.
+    const nextMode = bottomAnchorModeFromScroll(scrollEl)
     if (!scrollEl || !nextMode) return
     gestureWindowUntilRef.current = 0
     readerLocationExplicitRef.current = true


### PR DESCRIPTION
## Summary

- Treat the dynamic reply spacer as layout reservation rather than readable conversation content when deriving and restoring chat scroll anchors.
- Self-heal stale saved anchors that put the whole viewport below the last real message.
- Reuse the same content-intersection invariant for persistence, restoration, foreground return, spacer sizing, and attention-card navigation.

## Why

A chat could be left while scrolled inside the blank space reserved for pinning a reply. The old controller persisted the last message with a very large negative offset because it always fell back to the final row even when no row intersected the viewport. Reopening then recreated the blank screen indefinitely.

## Review coverage

Two local review passes traced mount restoration, chat exit, foreground return, nudge navigation, pin/follow transitions, spacer growth, viewport resize, and malformed/stale saved modes. The implementation fixes the existing scroll-mode ownership path rather than adding a parallel correction.

## Validation

- 68 focused scroll-mode tests pass
- full frontend suites: 1,773 library + 47 hook tests pass
- production Vite/PWA build passes
- pre-push privacy/syntax/frontend gate passes
- `git diff --check` passes