### PR TITLE
Fix lifecycle schema width and prompt privacy

### DIFF
--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -815,7 +815,11 @@ def _subagent_lifecycle_event(
     "parent_kind": "unknown",
     "event_type": event_type,
     "state": state,
-    "summary": getattr(item, "agent_path", None),
+    # agent_path is identity/role metadata, not an outcome summary. Keeping
+    # non-terminal Codex summaries empty gives the durable table a structural
+    # guarantee that delegated prompt/preview prose cannot enter through a
+    # start fact.
+    "agent_type": getattr(item, "agent_path", None),
     "occurred_at": occurred_at,
     "source": "runner",
     "source_event_id": getattr(item, "id", None),
@@ -850,8 +854,9 @@ def _thread_started_lifecycle_event(
     "parent_kind": "main" if parent_id == root_thread_id else "agent",
     "event_type": "agent_spawned",
     "state": "running",
+    # ``thread.preview`` derives from the delegated prompt. Role/nickname is
+    # sufficient lifecycle metadata; never copy the preview into persistence.
     "agent_type": role or nickname,
-    "summary": getattr(thread, "preview", None),
     "occurred_at": getattr(thread, "created_at", None),
     "source": "runner",
     "source_event_id": f"thread-started:{thread_id}",
@@ -914,7 +919,10 @@ def _collab_reactivation_events(
       "parent_provider_activation_id": active.get(str(sender)) if sender else None,
       "parent_kind": parent_kind,
       "event_type": "agent_started", "state": "running",
-      "summary": getattr(item, "prompt", None), "occurred_at": occurred_at,
+      # ``item.prompt`` is the delegated prompt body, not a lifecycle summary.
+      # It must not enter the durable observability table; the terminal agent
+      # state may later contribute a provider-authored result summary.
+      "occurred_at": occurred_at,
       "source": "runner", "source_event_id": f"{call_id}:{child_id}:started",
     })
   return events

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -194,6 +194,27 @@ class Base(DeclarativeBase):
   pass
 
 
+def _agent_lifecycle_width_migrations(
+  dialect_name: str, columns: list[dict],
+) -> list[str]:
+  """Return lossless ALTERs for the original undersized activation ids."""
+  if dialect_name != "postgresql":
+    # SQLite does not enforce VARCHAR lengths and cannot ALTER a column type in
+    # place. Its existing 75-character values are already stored losslessly.
+    return []
+  by_name = {column["name"]: column for column in columns}
+  statements = []
+  for column_name in ("activation_id", "parent_activation_id"):
+    column = by_name.get(column_name)
+    length = getattr(column.get("type"), "length", None) if column else None
+    if length is not None and length < 75:
+      statements.append(
+        "ALTER TABLE agent_lifecycle_events "
+        f"ALTER COLUMN {column_name} TYPE VARCHAR(75)"
+      )
+  return statements
+
+
 def run_migrations(eng) -> None:
   """Run schema migrations on startup.
 
@@ -664,6 +685,40 @@ def run_migrations(eng) -> None:
     if _add_runs:
       with eng.connect() as conn:
         for stmt in _add_runs:
+          conn.execute(text(stmt))
+        conn.commit()
+
+  # d6fae591 briefly copied Codex delegated prompts/thread previews into
+  # non-terminal lifecycle ``summary``. Remove all such already-persisted
+  # values on upgrade. The corrected emitter keeps identity/role on agent_type
+  # and reserves Codex summary for terminal provider-authored results, so this
+  # structural cleanup needs no brittle inference from clipped source ids.
+  if "agent_lifecycle_events" in tables:
+    with eng.connect() as conn:
+      conn.execute(text(
+        "UPDATE agent_lifecycle_events SET summary = NULL "
+        "WHERE provider = 'codex' AND summary IS NOT NULL "
+        "AND event_type IN ('agent_spawned', 'agent_started')"
+      ))
+      conn.commit()
+
+  # The same commit introduced activation ids as ``activation-`` + SHA-256 (75
+  # characters) but declared both columns VARCHAR(70). SQLite ignores the
+  # declared VARCHAR length, so its already-deployed rows are intact and need no
+  # table rebuild. PostgreSQL enforces it and therefore needs an explicit widen:
+  # create_all never alters an existing table. Widening is lossless and each
+  # column is independently gated so a restart after one ALTER converges.
+  if (
+    eng.dialect.name == "postgresql"
+    and "agent_lifecycle_events" in tables
+  ):
+    _widen_lifecycle = _agent_lifecycle_width_migrations(
+      eng.dialect.name,
+      inspector.get_columns("agent_lifecycle_events"),
+    )
+    if _widen_lifecycle:
+      with eng.connect() as conn:
+        for stmt in _widen_lifecycle:
           conn.execute(text(stmt))
         conn.commit()
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -319,9 +319,12 @@ class AgentLifecycleEvent(Base):
   provider_session_id = Column(String(160), nullable=True)
   provider_agent_id = Column(String(160), nullable=False)
   agent_id = Column(String(70), nullable=False, index=True)
-  activation_id = Column(String(70), nullable=False, index=True)
+  # ``stable_activation_id`` is ``activation-`` (11 chars) plus a 64-char
+  # SHA-256 digest. Keep the declared width exact: SQLite does not enforce a
+  # VARCHAR length, but PostgreSQL does.
+  activation_id = Column(String(75), nullable=False, index=True)
   parent_agent_id = Column(String(70), nullable=True, index=True)
-  parent_activation_id = Column(String(70), nullable=True, index=True)
+  parent_activation_id = Column(String(75), nullable=True, index=True)
   parent_kind = Column(String(16), nullable=False, default="unknown")
   parent_source_id = Column(String(160), nullable=True)
   event_type = Column(String(32), nullable=False)

--- a/backend/tests/test_agent_lifecycle.py
+++ b/backend/tests/test_agent_lifecycle.py
@@ -127,6 +127,18 @@ def test_same_logical_agent_in_new_chat_run_has_distinct_activation():
   assert one["event_key"] != two["event_key"]
 
 
+def test_hashed_identifiers_fit_the_declared_cross_database_schema():
+  values = _start()
+
+  assert len(values["agent_id"]) <= models.AgentLifecycleEvent.agent_id.type.length
+  assert (
+    len(values["activation_id"])
+    <= models.AgentLifecycleEvent.activation_id.type.length
+  )
+  assert models.AgentLifecycleEvent.activation_id.type.length == 75
+  assert models.AgentLifecycleEvent.parent_activation_id.type.length == 75
+
+
 def test_explicit_main_and_agent_parent_kinds_are_not_conflated():
   main_child = normalize_chat_event(
     chat_id="chat-life", chat_run_id="run-life", event={

--- a/backend/tests/test_codex_sdk_runner.py
+++ b/backend/tests/test_codex_sdk_runner.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 import pytest
 
 from app import codex_sdk_runner, models
+from app.agent_lifecycle import normalize_chat_event
 from app.database import SessionLocal
 from app.runner_registry import RunnerKind, registry
 
@@ -694,7 +695,8 @@ def test_subagent_activity_item_dispatch_stays_out_of_tool_stream():
   assert started["provider_agent_id"] == "thread-1"
   assert started["event_type"] == "agent_started"
   assert started["state"] == "running"
-  assert started["summary"] == "/root/scout"
+  assert started["agent_type"] == "/root/scout"
+  assert "summary" not in started
   assert started["occurred_at"] == 123_000
   assert started["provider_activation_id"] == "activation-1"
 
@@ -719,7 +721,7 @@ def test_codex_lifecycle_reactivation_and_terminal_state_mapping():
   item.tool = "resumeAgent"
   item.sender_thread_id = "root-thread"
   item.receiver_thread_ids = ["child-thread"]
-  item.prompt = "Continue the review"
+  item.prompt = "Read the confidential acquisition plan"
   item.agents_states = {}
   active = {}
   known = set()
@@ -735,6 +737,12 @@ def test_codex_lifecycle_reactivation_and_terminal_state_mapping():
   assert starts[0]["provider_activation_id"] == "call-resume:child-thread"
   assert starts[0]["parent_kind"] == "main"
   assert starts[0]["occurred_at"] == 123_000
+  assert "summary" not in starts[0]
+  normalized = normalize_chat_event(
+    chat_id="chat", chat_run_id="run", event=starts[0],
+  )
+  assert normalized["summary"] is None
+  assert "confidential acquisition" not in repr(normalized)
   assert active == {"child-thread": "call-resume:child-thread"}
 
   item.agents_states = {
@@ -865,7 +873,7 @@ def test_codex_input_to_running_child_is_progress_and_nested_spawn_uses_current_
 
   payload = SimpleNamespace(thread=SimpleNamespace(
     id="grandchild", parent_thread_id="child", agent_role="reviewer",
-    agent_nickname=None, preview="Review", created_at=301,
+    agent_nickname=None, preview="Confidential customer list", created_at=301,
   ))
   nested = codex_sdk_runner._thread_started_lifecycle_event(
     payload, root_thread_id="root",
@@ -873,6 +881,12 @@ def test_codex_input_to_running_child_is_progress_and_nested_spawn_uses_current_
   )
   assert nested["parent_kind"] == "agent"
   assert nested["parent_provider_activation_id"] == "resume-b:child"
+  assert "summary" not in nested
+  normalized = normalize_chat_event(
+    chat_id="chat", chat_run_id="run", event=nested,
+  )
+  assert normalized["summary"] is None
+  assert "Confidential customer list" not in repr(normalized)
 
 
 def test_run_codex_sdk_turn_dispatches_lifecycle_sequence_with_late_exact_fact(

--- a/backend/tests/test_db_migrations.py
+++ b/backend/tests/test_db_migrations.py
@@ -1,9 +1,9 @@
 import pytest
-from sqlalchemy import create_engine, inspect, text
+from sqlalchemy import String, create_engine, inspect, text
 from sqlalchemy.exc import IntegrityError
 
 from app import models
-from app.database import run_migrations
+from app.database import _agent_lifecycle_width_migrations, run_migrations
 
 
 def test_run_migrations_drops_removed_image_generation_columns(tmp_path):
@@ -83,6 +83,87 @@ def test_run_migrations_adds_park_columns_to_existing_chat_runs(tmp_path):
   cols = {c["name"] for c in inspector.get_columns("chat_runs")}
   assert "parked_until" in cols
   assert "park_reason" in cols
+
+
+def test_agent_lifecycle_width_migration_is_postgres_only_and_idempotent():
+  legacy = [
+    {"name": "activation_id", "type": String(70)},
+    {"name": "parent_activation_id", "type": String(70)},
+  ]
+  expected = [
+    "ALTER TABLE agent_lifecycle_events "
+    "ALTER COLUMN activation_id TYPE VARCHAR(75)",
+    "ALTER TABLE agent_lifecycle_events "
+    "ALTER COLUMN parent_activation_id TYPE VARCHAR(75)",
+  ]
+
+  assert _agent_lifecycle_width_migrations("postgresql", legacy) == expected
+  assert _agent_lifecycle_width_migrations("sqlite", legacy) == []
+  assert _agent_lifecycle_width_migrations("postgresql", [
+    {"name": "activation_id", "type": String(75)},
+    {"name": "parent_activation_id", "type": String(75)},
+  ]) == []
+
+
+def test_run_migrations_removes_only_persisted_codex_prompt_summaries(tmp_path):
+  eng = create_engine(f"sqlite:///{tmp_path / 'lifecycle-privacy.db'}")
+  models.Base.metadata.create_all(eng)
+  common = (
+    "INSERT INTO agent_lifecycle_events ("
+    "event_key, chat_id, provider, provider_agent_id, agent_id, activation_id, "
+    "parent_kind, event_type, state, observed_at, time_quality, source, "
+    "source_event_id, summary) VALUES ("
+    ":event_key, 'chat', :provider, :provider_agent_id, :agent_id, "
+    ":activation_id, 'unknown', :event_type, :state, CURRENT_TIMESTAMP, "
+    "'observed', 'runner', :source_event_id, :summary)"
+  )
+  rows = [
+    ("spawn", "codex", "agent_spawned", "running", "thread-started:child",
+     "private thread preview"),
+    ("resume", "codex", "agent_started", "running", "call:child:started",
+     "private delegated prompt"),
+    ("native", "codex", "agent_started", "running", "native-item-id",
+     "/root/scout"),
+    ("terminal", "codex", "agent_terminal", "done", "call:child:completed",
+     "provider result summary"),
+    ("claude", "claude", "agent_started", "running", "message-uuid",
+     "task description"),
+  ]
+  with eng.connect() as conn:
+    conn.execute(text(
+      "INSERT INTO chats (id, title, title_locked, messages, pending_messages, "
+      "uploads, provider) VALUES ('chat', 'Chat', 0, '[]', '[]', '[]', 'claude')"
+    ))
+    for index, (key, provider, event_type, state, source_id, summary) in enumerate(
+      rows,
+    ):
+      conn.execute(text(common), {
+        "event_key": key,
+        "provider": provider,
+        "provider_agent_id": f"provider-{index}",
+        "agent_id": f"agent-{index}",
+        "activation_id": f"activation-{index}",
+        "event_type": event_type,
+        "state": state,
+        "source_event_id": source_id,
+        "summary": summary,
+      })
+    conn.commit()
+
+  run_migrations(eng)
+  run_migrations(eng)
+
+  with eng.connect() as conn:
+    summaries = dict(conn.execute(text(
+      "SELECT event_key, summary FROM agent_lifecycle_events ORDER BY event_key"
+    )).all())
+  assert summaries == {
+    "claude": "task description",
+    "native": None,
+    "resume": None,
+    "spawn": None,
+    "terminal": "provider result summary",
+  }
 
 
 def test_run_migrations_adds_chat_auto_resume_policy(tmp_path):


### PR DESCRIPTION
## Summary

Follow-up to the directly landed lifecycle observability commit `d6fae591` after two independent exact-head review rounds.

- widen lifecycle activation IDs from 70 to their actual exact 75-character form
- migrate existing PostgreSQL columns idempotently; SQLite already stores the values losslessly
- stop persisting Codex delegated prompts and thread previews as lifecycle summaries
- keep agent-path identity in `agent_type`
- scrub historical nonterminal Codex prompt/preview summaries on upgrade while preserving terminal Codex results and Claude descriptions

## Why

The parent generated `activation-` plus a 64-character SHA-256 digest (75 characters) but declared `VARCHAR(70)`. SQLite ignores that length; PostgreSQL rejects the insert. It also mapped `item.prompt` and `thread.preview` into durable lifecycle summaries despite the explicit no-prompt persistence contract.

## Verification

- original focused matrix: 320 passed
- independent privacy/lifecycle/restart review: 237 passed
- real PostgreSQL 17 migration probe: both columns widened; rows/indexes survived; 75-character insert passed
- SQLite legacy/repeated-migration probe: passed
- rebased exact-head targeted suite: 90 passed
- stable patch-id unchanged across the new `b036eb2c` base; no overlapping paths
- compile and `git diff --check`: clean

No immediate production revert is needed: current production uses SQLite and the endpoint remains owner-only. This PR fixes the cross-database and privacy contracts before the next deploy.
