### PR TITLE
Continue turns after planned server restarts

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -687,6 +687,37 @@ pins. Reservation lifetime and pin decisions are independent.
 - **Regression guards (owner-observed prod bugs):** an at-bottom send must not land
   mid-viewport; a steered row must not render after the agent's reply.
 
+### Automatic continuation after limits and planned restarts
+
+Automatic continuation reuses one durable transition. Provider-limit exits mark
+their exact `ChatRun` as `parked` until the parsed reset time; a planned restart
+that successfully stops a live handle marks that exact run `parked` with
+`park_reason="restart"` and a due time of now, before SIGTERM. The next process
+runs the same due-park sweep immediately. There is no restart ledger and startup
+never infers intent from transcript text.
+
+| Event | Durable result | Boot/sweep result |
+|-------|----------------|-------------------|
+| Provider usage/rate limit | exact run `parked` until reset | notify; continue if the chat policy is on |
+| Planned restart, handle stopped and exact transition committed | exact run `parked`, reason `restart`, due now | continue immediately if eligible |
+| Crash, stuck handle, missing exact token, or failed park commit | generic `running` evidence remains | reconcile to a manual resumable interruption |
+| Policy off, unanswered question, app-owned run, or app-queued work | due park resolves without an automatic send | notify/manual owner action |
+| Owner sends, switches provider, deletes the chat, or a newer run wins | old park is superseded by the existing latest-run fence | no stale continuation |
+
+Eligibility is rechecked under the per-chat transition lock immediately before
+promotion, and the global idle gate permits only one automatic turn at a time.
+The provider still receives a synthetic user `continue`, but the durable row is
+tagged `kind="auto_continuation"` with reason `restart` or `usage_limit`; the UI,
+copy behavior, title selection, time context, compaction, provider-switch
+handoff, chat-note summarization, and redacted chat logs treat it as a product
+marker rather than owner speech.
+
+The sweep is cheap: one indexed due-row query immediately at boot, on
+`chat_run_finished`, and on a 60-second fallback. It does not create per-chat
+workers or poll at a short interval. The shared chat-local policy retains its
+legacy wire name `auto_resume_on_limit` for compatibility, while product copy
+states that it covers both limits and restarts.
+
 ### Tool output rendering
 
 Tool runs are **grouped** so the reader sees at a glance what is running vs finished

--- a/SIMPLIFICATION_AUDIT.md
+++ b/SIMPLIFICATION_AUDIT.md
@@ -1,0 +1,207 @@
+# Simplification audit — 2026-07-23
+
+This audit started from planned-restart continuation and expanded outward. Its
+test is not “can this code be shorter?” It is:
+
+1. What fact is the real authority?
+2. Is the code recording that fact at the moment it is known, or reconstructing
+   it later from a proxy?
+3. Does an existing durable transition already express the outcome?
+4. Which compatibility paths can be moved out of steady-state runtime logic and
+   into an idempotent migration?
+
+The restart change is the reference example. The drain already knows the exact
+run it stopped. Recording that run as due in the existing park/resume state is
+enough; a second restart ledger and boot-time transcript classification are not.
+
+## Ranked opportunities
+
+### 1. Make `ChatRun.id` the only turn-ownership authority
+
+**Confidence: high. Impact: high. Risk: medium; do it as a dedicated
+state-machine migration.**
+
+The source already calls `Chat.run_status` a transitional dual-write and names
+its removal as the Step-3b follow-up (`backend/app/models.py`, `ChatRun`). Today
+one logical fact—“which turn owns this chat?”—is spread across:
+
+- `Chat.run_status` / `Chat.run_started_at`;
+- the latest `ChatRun` row;
+- the writer actor’s `_run_token_owner` map;
+- the in-memory generation counter and its stop/restart handoff maps in
+  `backend/app/chat.py`.
+
+That split explains much of the recovery union, wedged-marker sweep, compare
+logic, and special handling around Stop, stall, delete, provider limits, and
+restart. The repository currently has more than one hundred backend references
+to `run_status` / `run_started_at`, despite `ChatRun.id` already being the exact
+identity carried by the sink and actor commands.
+
+**Simpler shape:** use the latest nonterminal `ChatRun` as durable ownership and
+the run token itself as in-memory ownership. First migrate any legacy
+`Chat.run_status="running"` row without a matching `ChatRun` into a legacy
+recovery row. Then stop writing/reading the chat-level marker. In a later,
+separately reviewed step, replace generation-plus-handoff maps with token
+compare-and-swap transitions.
+
+**Intuition:** a generation number answers “is this still the same run?” only
+because the exact run identity was not used at that boundary. Once every path
+already carries a token, compare the token. Do not remove the latest-run fence
+or serial transition lock; those are the correctness mechanism, not accidental
+complexity.
+
+### 2. Move legacy app identity adoption out of the install hot path
+
+**Confidence: high. Impact: high. Risk: medium-high because self-hosted systems
+can skip releases.**
+
+`backend/app/install.py` interleaves ordinary install/update decisions with
+many historical identity shapes: raw and canonical manifest URLs, sourceless
+rows, baked platform apps, old platform source directories, catalog renames,
+and several `adopt_kind` branches. The comments are careful and the guards are
+important, but every new install executes and must preserve this history.
+
+**Simpler shape:** add one explicit, idempotent app-identity migration that
+normalizes old live rows to a versioned canonical identity before the installer
+runs. Keep ancient-upgrade support in that migration (self-hosted installs
+cannot rely on having visited an intermediate release). The steady-state
+installer can then match canonical identity, handle an explicit
+`previous_id`, and perform install vs update without knowing every historical
+storage shape.
+
+**Intuition:** compatibility is data normalization, not a permanent dimension
+of the product state machine. Normalize once at the boundary, then let all
+ordinary operations use one representation. The migration must remain
+upgrade-from-any-supported-version safe; simply deleting the legacy branches
+after a date would be wrong.
+
+### 3. Close standalone app isolation by reusing the existing frame protocol
+
+**Confidence: high. Impact: high (security and code ownership). Risk: medium.**
+
+`ARCHITECTURE.md` documents that in-shell mini-apps already run through the
+opaque `app-frame.html` protocol, while `/apps/<slug>/` executes the component
+in a trusted top-level Möbius document. Building a second standalone permission
+or sanitization system would duplicate the harder boundary.
+
+**Simpler shape:** make the standalone route a small trusted installable shell
+that owns auth, manifest, service worker, and error chrome, then mounts the same
+opaque frame/runtime bridge used in-shell.
+
+**Intuition:** isolation belongs at one process/origin boundary. Reusing the
+already-tested boundary is both simpler and stronger than recreating its rules
+as a list of forbidden capabilities.
+
+### 4. Retire the flat navigation compatibility mirrors after an explicit
+workspace migration
+
+**Confidence: medium. Impact: medium. Risk: medium.**
+
+The workspace blob is documented as authoritative, yet
+`frontend/src/hooks/useNavigation.js` still reads and continuously writes
+`moebius_active_chat`, `moebius_active_view`, and `moebius_active_app`, and has
+boot branches for `!blobValid`. These mirrors were useful during the workspace
+rollout, but they keep a second representation of the focused destination and
+expand cold-boot combinations.
+
+**Simpler shape:** when no valid workspace blob exists, run one small migration
+from the three legacy keys into a valid single-pane workspace blob, record that
+the migration succeeded, and thereafter boot from/depend on the workspace
+shape. Keep a deliberately simple corrupt-blob fallback (for example Home), not
+a permanently dual-written navigation model.
+
+**Intuition:** a compatibility read can be a one-time importer; it does not need
+to remain a live mirror forever. Validate this against PWA rollback and old
+service-worker behavior before removal.
+
+### 5. Retire the legacy provider-switch bridge behind a served-client floor
+
+**Confidence: medium. Impact: medium. Risk: medium.**
+
+The current provider switch has an authoritative, versioned atomic protocol
+(`provider-switch-v1`) plus the older bodyless `/compact` route and
+`legacy_switch_ready` compatibility state in `backend/app/routes/chats.py`.
+Keeping both means ordinary patch/switch logic must continue recognizing a
+historical two-step handoff.
+
+**Simpler shape:** first make served frontend/backend version mismatch explicit
+and force a safe client refresh when an old cached shell cannot speak the
+current protocol. Once that floor is proven, move any stored legacy handoff to
+an idempotent migration and delete the bodyless bridge.
+
+**Intuition:** rolling compatibility should end at a measured client-version
+boundary. Without that boundary, “temporary” protocol branches become permanent
+state. Do not remove the bridge merely because the current source no longer
+calls it; installed PWAs can retain old bundles.
+
+### 6. Give transcript rows shared semantic predicates
+
+**Confidence: high. Impact: medium. Risk: low.**
+
+Automatic continuation exposed a hidden assumption: `role="user"` means the
+provider should treat a row as user input, but it does not necessarily mean the
+owner authored it. Title selection, elapsed-time context, compaction,
+provider-switch reseeding, scrolling, copying, timestamps, and styling can all
+accidentally ask the wrong question.
+
+This change introduces shared frontend predicates for automatic-continuation
+and owner-user rows, but backend consumers still encode some semantic checks
+locally.
+
+**Simpler shape:** put small pure predicates such as
+`is_owner_user_message`, `is_product_marker`, and a single transcript label
+function in `backend/app/chat_transcript.py`, with the matching frontend helper
+as the UI boundary. Consumers ask the semantic question instead of repeating
+field combinations.
+
+**Intuition:** do not force one storage field to carry two meanings. A tiny
+classification function is simpler than adding more role values or teaching
+every consumer about every product-owned row kind.
+
+### 7. Extract a small supervised-loop helper, but keep maintenance jobs
+independent
+
+**Confidence: medium. Impact: low-medium. Risk: low.**
+
+The lifespan in `backend/app/main.py` repeats cancellation/error logging/session
+open-close scaffolding across wedged-marker, stalled-live, continuation, writer,
+and browser-profile jobs. A small helper could own the repeated supervision and
+make immediate-vs-delayed first-run behavior explicit.
+
+**Simpler shape:** a `run_supervised(name, tick, wait)` helper, while each job
+retains its own task, cadence, database session, and failure isolation.
+
+**Intuition:** share lifecycle boilerplate, not operational fate. Combining all
+maintenance work into one scheduler or transaction would look smaller but would
+couple unrelated failures and make slow quota work delay chat recovery.
+
+## Things that look simpler but are not recommended
+
+- **Do not add a restart ledger.** The exact `ChatRun` transition is already the
+  durable intent boundary.
+- **Do not infer restart intent from the pause-card text.** Presentation can be
+  missing, duplicated, historical, or written before the authoritative state
+  commit.
+- **Do not rename `auto_resume_on_limit` in storage/API during this change.** The
+  product label can broaden while the legacy wire name remains a harmless
+  compatibility detail; a rename would add migration and rolling-client work
+  without improving behavior.
+- **Do not merge the maintenance loops into one failure domain.** A shared
+  wrapper is useful; one giant loop is not.
+- **Do not split large files merely to reduce line counts.** `chat.py`,
+  `ChatView.jsx`, and `Shell.jsx` are large, but extraction is valuable only
+  when it creates a clearer authority boundary (for example transcript
+  semantics or run ownership), not when it scatters the same state machine
+  across more files.
+
+## Suggested order
+
+1. Ship and observe planned-restart continuation.
+2. Do the `ChatRun` single-authority transition as its own expanding-scope
+   review, starting with a transition table for every writer of run state.
+3. Normalize app identity in a boot migration, then simplify the installer.
+4. Reuse the opaque app frame for standalone.
+5. Use telemetry/version floors before retiring navigation and provider-switch
+   compatibility.
+6. Take the transcript predicates and supervised-loop helper opportunistically
+   when touching their consumers.

--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -801,8 +801,9 @@ STALLED_TURN_MESSAGE = (
 # interrupt (the stalled-live watchdog exempts it via `_stall_exemption`; the
 # wedged-marker sweep returns early). `_restart_draining_chats` records the chats
 # whose live turn the drain interrupted, so each turn's terminal transition
-# (run_chat's finally) LEAVES its run marker set (DRAINED_FOR_RESTART) instead of
-# clearing it — preserving it for boot reconcile + one-tap Resume.
+# (run_chat's finally) leaves its exact run intact long enough for the drain to
+# move it to the existing durable continuation state. If that transaction fails,
+# the still-set generic marker is deliberately left for manual boot recovery.
 draining = False
 _restart_draining_chats: set[str] = set()
 
@@ -1340,28 +1341,46 @@ def reconcile_interrupted_chats(db: Session) -> list[str]:
         # and persist the finalized tool-block state. Only the drain's exact
         # note text qualifies, so a live provider error never gets a spurious
         # Resume button here.
-        paused_idx = next(
-          (len(blocks) - 1 - i
-           for i, b in enumerate(reversed(blocks))
-           if b.get("type") == "error"
-           and b.get("message") == PAUSED_FOR_RESTART_MESSAGE),
-          None,
-        )
+        trailing_open_start = len(blocks)
+        while trailing_open_start > 0:
+          block = blocks[trailing_open_start - 1]
+          if block.get("type") != "question" or block.get("answers"):
+            break
+          trailing_open_start -= 1
+        # Display text is never enough to prove planned-restart intent. It is
+        # used here only to avoid duplicating the terminal note for a generic
+        # marker fallback, so accept it solely at the actual tail or directly
+        # before trailing unanswered questions. A historical restart note with
+        # later output must not mask a newer crash.
+        candidate_indices = [len(blocks) - 1]
+        if trailing_open_start < len(blocks):
+          candidate_indices.append(trailing_open_start - 1)
+        paused_idx = next((
+          idx for idx in candidate_indices
+          if idx >= 0
+          and blocks[idx].get("type") == "error"
+          and blocks[idx].get("message") == PAUSED_FOR_RESTART_MESSAGE
+        ), None)
         if paused_idx is not None:
-          # The drain wrote the terminal note; just make it resumable — and
-          # carry `pause` so a note persisted before the descriptor existed
-          # (or one whose live event never landed) still renders in the calm
-          # "Paused" family — then fall through to the shared write-back below
-          # (no second note appended). Replace with a FRESH dict rather than
-          # mutating the ORM-loaded block in place: `Chat.messages` is a plain
-          # JSON column with no mutation tracking, so an in-place edit to a
-          # loaded block is not flushed — only a genuinely new value in the
-          # reassigned list persists (every other reconcile branch appends a
-          # fresh block for the same reason).
-          blocks[paused_idx] = {
-            **blocks[paused_idx], "resumable": True,
-            "pause": {"kind": "restart"},
-          }
+          # Normalize both historical orderings around an open question. The
+          # drain marker belongs immediately BEFORE a trailing unanswered
+          # question so the card remains the tail affordance; in that shape it
+          # must not also offer Resume. With no question, the marker itself is
+          # the recovery affordance and remains resumable.
+          paused = dict(blocks.pop(paused_idx))
+          trailing_open_start = len(blocks)
+          while trailing_open_start > 0:
+            block = blocks[trailing_open_start - 1]
+            if block.get("type") != "question" or block.get("answers"):
+              break
+            trailing_open_start -= 1
+          paused["pause"] = {"kind": "restart"}
+          if trailing_open_start < len(blocks):
+            paused.pop("resumable", None)
+            blocks.insert(trailing_open_start, paused)
+          else:
+            paused["resumable"] = True
+            blocks.insert(min(paused_idx, len(blocks)), paused)
         else:
           # Preserve a tail unanswered question. It is a durable human handoff,
           # not a disposable in-memory callback: the route can record the later
@@ -1863,7 +1882,8 @@ async def drain_all_for_restart(timeout: float = DRAIN_TIMEOUT) -> list[str]:
   This is the DrainForRestart path from design §2.2 — distinct from
   `stop_chat_for`, which intentionally COLLAPSES the pending queue. A restart
   must NEVER touch `pending_messages`: every queued send is preserved and
-  self-heals on the owner's next action after the reboot.
+  joins the same continuation when an exact planned-restart park commits, or
+  remains available for the owner's next action on the manual fallback path.
 
   Sets the `draining` gate first (idempotent) so a send arriving mid-drain
   queues rather than starting, and both liveness sweeps stand down. Then, for
@@ -1878,13 +1898,17 @@ async def drain_all_for_restart(timeout: float = DRAIN_TIMEOUT) -> list[str]:
     - mirrors the stalled-live watchdog's clean-interrupt handoff — bump the
       generation so the turn-end drain sees a stale generation and does NOT
       promote the queue — BUT records the chat in `_restart_draining_chats` so
-      the turn's finally LEAVES the durable run marker set (DRAINED_FOR_RESTART)
-      instead of clearing it. The preserved marker is what boot reconcile
-      finalizes and what the one-tap Resume affordance keys on.
+      the turn's finally does not clear the exact run before this drain can
+      transition it. After every handle stops, the same writer transaction used
+      by provider-limit recovery moves that exact run to ``parked`` with
+      ``park_reason='restart'`` and a due time of now. Startup therefore sees an
+      authoritative continuation signal instead of guessing from transcript
+      text. If that transition cannot commit, the generic run marker remains for
+      manual crash reconciliation.
 
   Best-effort and bounded: a handle that won't interrupt in time keeps today's
   contract — the restart utility's SIGKILL backstop kills the worker and boot
-  reconcile finalizes the marker (still with the resume affordance). Handle
+  reconcile finalizes the marker for manual Resume. Handle
   stops run serially at up to 2s each, so with many concurrent live turns the
   tail may not drain before the backstop — accepted for the single-owner
   reality (a handful of turns at most); parallelize the stops before this
@@ -1894,9 +1918,9 @@ async def drain_all_for_restart(timeout: float = DRAIN_TIMEOUT) -> list[str]:
   log = _get_logger()
   drained: list[str] = []
   # `resumable` rides the event LIVE (events.process_event carries the
-  # whitelisted extras onto the persisted block), so a drained turn's Resume
-  # button renders immediately; boot reconcile's text-keyed marking stays as
-  # the crash-path fallback for a note that never made it through the sink.
+  # whitelisted extras onto the persisted block), so a drained turn's manual
+  # Resume fallback renders immediately. The exact ChatRun transition below,
+  # not this display block, is the authority for automatic continuation.
   # A drain-gated restart is a benign maintenance pause; `pause.kind='restart'`
   # lets the card render in the calm "Paused" family instead of the danger-red
   # error styling reserved for genuine failures.
@@ -1943,6 +1967,38 @@ async def drain_all_for_restart(timeout: float = DRAIN_TIMEOUT) -> list[str]:
         all_interrupted = False
     if all_interrupted:
       drained.append(chat_id)
+      run_token = sink.run_token if sink is not None else None
+      if run_token:
+        try:
+          parked = await _park_run_strict(
+            chat_id,
+            run_token,
+            datetime.now(UTC).replace(tzinfo=None),
+            "restart",
+          )
+          if not parked:
+            log.warning(
+              "drain-for-restart could not park exact run; leaving manual "
+              "recovery chat_id=%s run_token=%s",
+              chat_id,
+              run_token,
+            )
+        except Exception:
+          # Restart must still proceed. ParkRun is transactional; on failure
+          # the generic running marker remains for safe manual reconciliation.
+          log.warning(
+            "drain-for-restart park failed; leaving manual recovery "
+            "chat_id=%s run_token=%s",
+            chat_id,
+            run_token,
+            exc_info=True,
+          )
+      else:
+        log.warning(
+          "drain-for-restart has no exact run token; leaving manual recovery "
+          "chat_id=%s",
+          chat_id,
+        )
   # Flush the writer so every paused note (the sink's fire-and-forget
   # PersistError above) is durably committed before the worker restarts.
   try:
@@ -1962,6 +2018,39 @@ async def drain_all_for_restart(timeout: float = DRAIN_TIMEOUT) -> list[str]:
 # (design §2.4 step "at parked_until, push-notify").
 LIMIT_RESET_NOTIFY_TITLE = "Your limit has reset"
 LIMIT_RESET_NOTIFY_BODY = "Your limit has reset."
+
+
+def _has_unanswered_question(chat: models.Chat | None) -> bool:
+  """Whether the durable tail is waiting for an owner answer.
+
+  A restart pause is appended after the question while draining, so ignore that
+  one product-owned tail block before applying the same tail-question invariant
+  as the transcript UI. This is read-only and bounded to the latest assistant
+  row; it never scans tool output or historical questions.
+  """
+  if chat is None:
+    return False
+  try:
+    from app.chat_transcript import materialized_messages
+    messages = materialized_messages(chat)
+  except Exception:
+    messages = list(chat.messages or [])
+  if not messages or messages[-1].get("role") != "assistant":
+    return False
+  blocks = list(messages[-1].get("blocks") or [])
+  while blocks:
+    tail = blocks[-1]
+    if not (
+      tail.get("type") == "error"
+      and (tail.get("pause") or {}).get("kind") == "restart"
+    ):
+      break
+    blocks.pop()
+  return bool(
+    blocks
+    and blocks[-1].get("type") == "question"
+    and not blocks[-1].get("answers")
+  )
 
 
 async def _auto_resume_chat(
@@ -2044,8 +2133,10 @@ async def _auto_resume_chat(
               chat is None
               or chat.deleted_at is not None
               or not chat.auto_resume_on_limit
+              or _has_unanswered_question(chat)
               or park is None
               or park.status != "resume_pending"
+              or park.initiated_by_app_id is not None
               or latest_id != park.id
               or any(
                 isinstance(msg, dict)
@@ -2055,6 +2146,9 @@ async def _auto_resume_chat(
             ):
               return False
             current_provider = chat.provider or "claude"
+            resume_reason = (
+              "restart" if park.park_reason == "restart" else "usage_limit"
+            )
           if not mark_starting(chat_id):
             return False
           claimed = True
@@ -2066,9 +2160,15 @@ async def _auto_resume_chat(
                 "role": "user",
                 "content": "continue",
                 "ts": int(time.time() * 1000),
+                "kind": "auto_continuation",
+                "continuation_reason": resume_reason,
                 # A retry after AppendPending succeeded but a later step failed
                 # must not enqueue a second synthetic continuation.
-                "cid": f"limit-resume-{park_token or chat_id}",
+                "cid": (
+                  f"restart-resume-{park_token or chat_id}"
+                  if resume_reason == "restart"
+                  else f"limit-resume-{park_token or chat_id}"
+                ),
               },
             )
           )
@@ -2124,12 +2224,14 @@ async def _auto_resume_chat(
 
 
 async def sweep_reset_parks(db: Session) -> list[str]:
-  """Notify (and optionally auto-resume) limit-parked chats at reset time.
+  """Notify and optionally continue due durable recovery rows.
 
   The third lifespan sweep (same 60s loop shape as the wedged-marker and
   stalled-live sweeps). A due park is a `chat_runs` row still
   ``status`` is ``parked`` or ``resume_pending`` and whose
-  `parked_until` has passed. For each, oldest reset first:
+  `parked_until` has passed. Provider limits use their reset time; a planned
+  restart is parked by the drain itself with a due time of now. For each,
+  oldest due row first:
 
     - Notify-only parks resolve first, then send one best-effort notification.
     - Auto-resume parks first become ``resume_pending``. That durable
@@ -2144,8 +2246,8 @@ async def sweep_reset_parks(db: Session) -> list[str]:
       chats in the same due batch still resolve normally. App-attributed runs
       and queues never auto-resume.
 
-  Stands down while draining — a restart is in progress, and the boot
-  reconcile + this sweep's next tick pick everything up. Never raises.
+  Stands down while draining — a restart is in progress, and the fresh
+  process's immediate sweep picks everything up. Never raises.
   """
   log = _get_logger()
   resolved: list[str] = []
@@ -2167,23 +2269,28 @@ async def sweep_reset_parks(db: Session) -> list[str]:
   if not due:
     return resolved
 
-  def notify_reset(chat_id: str) -> None:
+  def notify_due(chat_id: str, run: models.ChatRun) -> None:
     try:
       owner = db.query(models.Owner).first()
       if owner is not None:
         from app import push
+        restarted = run.park_reason == "restart"
         push.notify_owner(
           db,
           owner.id,
-          title=LIMIT_RESET_NOTIFY_TITLE,
-          body=LIMIT_RESET_NOTIFY_BODY,
+          title=("Möbius restarted" if restarted else LIMIT_RESET_NOTIFY_TITLE),
+          body=(
+            "Your paused turn is ready."
+            if restarted
+            else LIMIT_RESET_NOTIFY_BODY
+          ),
           source_type="system",
           source_id=chat_id,
           target=f"/shell/?chat={chat_id}",
         )
     except Exception:
       log.warning(
-        "limit-reset notify failed chat_id=%s", chat_id, exc_info=True,
+        "continuation notify failed chat_id=%s", chat_id, exc_info=True,
       )
 
   def wants_auto_resume(chat, run) -> bool:
@@ -2197,6 +2304,7 @@ async def sweep_reset_parks(db: Session) -> list[str]:
       and chat.deleted_at is None
       and run.initiated_by_app_id is None
       and not app_work_queued
+      and not _has_unanswered_question(chat)
       and chat.auto_resume_on_limit
     )
 
@@ -2260,11 +2368,11 @@ async def sweep_reset_parks(db: Session) -> list[str]:
           continue
         resolved.append(chat_id)
         if prepared.get("notify") and not chat_gone:
-          notify_reset(chat_id)
+          notify_due(chat_id, run)
         continue
 
       if prepared.get("notify"):
-        notify_reset(chat_id)
+        notify_due(chat_id, run)
       if _any_chat_turn_active():
         # The notification or refresh window admitted another turn. Keep the
         # durable pending state so the next sweep retries instead of silently
@@ -2295,10 +2403,10 @@ async def sweep_reset_parks(db: Session) -> list[str]:
       continue
     resolved.append(chat_id)
     if should_notify and not chat_gone:
-      notify_reset(chat_id)
+      notify_due(chat_id, run)
   if resolved:
     log.info(
-      "limit-reset sweep resolved %d park(s): %s",
+      "continuation sweep resolved %d park(s): %s",
       len(resolved), ", ".join(resolved),
     )
   return resolved
@@ -3148,10 +3256,10 @@ async def _park_run_strict(
   run_token: str,
   parked_until: datetime,
   park_reason: str,
-) -> None:
+) -> bool:
   """Park the run via the actor (commit-before-return); raises on failure.
 
-  The limit-exit sibling of `_clear_run_status_strict`: same await-the-ack
+  The continuation sibling of `_clear_run_status_strict`: same await-the-ack
   discipline, same identity-keyed ownership inside the actor. A tokenless
   caller (legacy/test paths with no per-run row) degrades to the plain
   marker clear — there is no row to park on, so the chat keeps today's
@@ -3159,10 +3267,10 @@ async def _park_run_strict(
   notify-at-reset upgrade.
   """
   if not chat_id:
-    return
+    return False
   if not run_token:
     await _clear_run_status_strict(chat_id, "")
-    return
+    return False
   ack = get_writer().submit(
     ParkRun(
       chat_id=chat_id,
@@ -3171,7 +3279,7 @@ async def _park_run_strict(
       park_reason=park_reason,
     )
   )
-  await _await_ack(ack)
+  return bool(await _await_ack(ack))
 
 
 def _limit_exit(
@@ -3423,10 +3531,12 @@ async def _complete_turn(
       # lock can't burn it.
       async with asyncio.timeout(chat_queue.TERMINAL_LOCK_TIMEOUT_SECS):
         async with chat_queue.get_lock(chat_id):
-          await _park_run_strict(
+          parked = await _park_run_strict(
             chat_id, sink.run_token or "",
             parked_until, park_reason or "rate_limit",
           )
+          if not parked:
+            raise RuntimeError("exact limit run was not parked")
           # Release the send's `_starting` claim NOW, under the same lock —
           # not in run_chat's finally. The limit path skips drain_and_release
           # (which releases the claim for every other terminal), so without
@@ -3603,9 +3713,14 @@ def _last_user_message_elapsed(db, chat_id: str) -> str | None:
     msgs = (chat.messages if chat else None) or []
     now_ms = _time.time() * 1000.0
     for m in reversed(msgs[:-1]):  # skip the current (just-committed) message
-      # Only USER messages count — the label is "user's last message", and
-      # assistant rows would otherwise report the gap since the agent spoke.
-      if not isinstance(m, dict) or m.get("role") != "user":
+      # Only owner-authored USER messages count. Product-owned automatic
+      # continuation rows retain role=user for provider history but must not
+      # reset the owner's recency clock.
+      if (
+        not isinstance(m, dict)
+        or m.get("role") != "user"
+        or m.get("kind") == "auto_continuation"
+      ):
         continue
       ts = m.get("ts")
       if not isinstance(ts, (int, float)) or ts <= 0:
@@ -3947,7 +4062,11 @@ def _build_resumed_context(chat_row) -> str | None:
     content = msg.get("content")
     if not isinstance(content, str) or not content.strip():
       continue
-    speaker = "User" if role == "user" else "Assistant"
+    if msg.get("kind") == "auto_continuation":
+      reason = msg.get("continuation_reason") or "automatic recovery"
+      speaker = f"Automatic continuation ({reason})"
+    else:
+      speaker = "User" if role == "user" else "Assistant"
     line = f"{speaker}: {content.strip()}"
     if used + len(line) > _RESUME_CONTEXT_CHAR_BUDGET and lines:
       break
@@ -4079,14 +4198,13 @@ async def run_chat(
     if chat_id and clear_stopped_run and run_gen is not None:
       if chat_id in _restart_draining_chats:
         # Drain-for-restart handoff: this turn was interrupted for a graceful
-        # restart. LEAVE the durable run marker set (and the pending queue
-        # intact) so boot reconcile finalizes it and the one-tap Resume works —
-        # the deliberate difference from a Stop handoff, which CLEARS the marker
-        # in the else-branch below. `_complete_turn` already finalized the
-        # partials + the paused note above (stop-handoff-successor path); no
-        # queue was promoted (the bumped generation made the turn-end drain read
-        # STALE_NO_ACTION). Discard the per-chat flag so a hypothetical surviving
-        # process can't mis-tag a later turn.
+        # restart. Leave the exact running row and pending queue intact so
+        # drain_all_for_restart can move that row to the durable due-restart
+        # state after every handle reports stopped. The deliberate difference
+        # from Stop is that the else-branch below clears the exact row instead.
+        # `_complete_turn` already finalized the partials + paused note; the
+        # bumped generation prevented queue promotion. Discard the in-memory
+        # handoff flag once this dying wrapper has observed it.
         _restart_draining_chats.discard(chat_id)
         disposition = chat_queue.TerminalDisposition.DRAINED_FOR_RESTART
       else:

--- a/backend/app/chat_log_redaction.py
+++ b/backend/app/chat_log_redaction.py
@@ -163,6 +163,12 @@ def redact_message(msg: dict) -> dict | None:
     return None
   if msg.get("hidden"):
     return None
+  if msg.get("kind") == "auto_continuation":
+    reason = str(msg.get("continuation_reason") or "automatic recovery")
+    return {
+      "role": "system",
+      "text": f"Automatic continuation ({reason}).",
+    }
   role = msg.get("role")
   if role == "assistant":
     text = _assistant_text(msg.get("blocks") or [], msg.get("content", ""))

--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -518,15 +518,16 @@ class ClearRunStatus(_Command):
 
 @dataclass
 class ParkRun(_Command):
-  """Park a turn that died on a provider rate/usage limit (design §2.4).
+  """Park a turn for a due continuation (design §2.4).
 
   The identity-keyed sibling of `ClearRunStatus` for the limit exit: the
   turn is over, so the per-chat marker (`Chat.run_status`) is cleared the
   same way — but instead of closing the run's `chat_runs` row "completed",
-  the row moves to ``status="parked"`` carrying `parked_until` (the parsed
-  reset time, naive UTC) and `park_reason`. That parked row IS the
-  provider-parked signal the liveness exemptions and the reset sweep read;
-  no separate state enum exists. Same ownership discipline as
+  the row moves to ``status="parked"`` carrying `parked_until` (the due time,
+  naive UTC) and `park_reason`. Provider limits use their parsed reset time;
+  a successfully drained planned restart uses ``park_reason="restart"`` and
+  a due time of now. That parked row IS the durable continuation signal; no
+  separate state enum exists. Same ownership discipline as
   ClearRunStatus: a dying run whose marker was taken by a fresh turn still
   closes its OWN row (as "completed", NOT parked — the owner already moved
   on, so a stale park must not resurrect a notify) but leaves the fresh
@@ -541,12 +542,13 @@ class ParkRun(_Command):
 
 @dataclass
 class ResolvePark(_Command):
-  """Move a parked/pending run to ``parked_notified``.
+  """Resolve a parked/pending run without starting a continuation.
 
   Submitted by the reset sweep AFTER `parked_until` elapses. Notify-only
   parks resolve before their at-most-once push attempt; auto-resume parks first
   pass through PrepareAutoResume so retries remain selectable without
-  re-notifying.
+  re-notifying. Provider parks become ``parked_notified``; restart parks become
+  ordinary ``interrupted`` history.
   Not identity-keyed against `_run_token_owner`: the parked turn ended long
   ago and ParkRun already dropped its ownership entry. Idempotent — a row
   no longer parked is a no-op.
@@ -2464,7 +2466,7 @@ class ChatWriterActor:
     return None
 
   def _park_run(self, db, cmd: ParkRun):
-    """Park the run's row on a provider limit + clear the per-chat marker.
+    """Park the run's row for continuation + clear the per-chat marker.
 
     Mirrors `_clear_run_status`'s ownership discipline exactly — the same
     identity-keyed compare against `_run_token_owner` — with one difference:
@@ -2487,23 +2489,34 @@ class ChatWriterActor:
       cmd.run_token and owner is not None and owner != cmd.run_token
     )
     changed = False
+    parked = False
     if cmd.run_token:
       run = (
         db.query(ChatRun).filter(ChatRun.id == cmd.run_token).first()
       )
-      if run is not None and run.status == "running":
-        if marker_is_ours:
-          run.status = "parked"
-          run.parked_until = cmd.parked_until
-          run.park_reason = (cmd.park_reason or None)
-        else:
-          run.status = "completed"
-        run.ended_at = datetime.now(UTC)
-        changed = True
+      # A tokened transition is useful only when the exact running row exists.
+      # Do not clear the generic chat marker on a missing/terminal row: leaving
+      # it set lets startup reconciliation recover manually instead of losing
+      # the only durable evidence that work was interrupted.
+      if run is None or run.status != "running":
+        return bool(
+          run is not None
+          and run.status in ("parked", "resume_pending")
+          and run.park_reason == (cmd.park_reason or None)
+        )
+      if marker_is_ours:
+        run.status = "parked"
+        run.parked_until = cmd.parked_until
+        run.park_reason = (cmd.park_reason or None)
+        parked = True
+      else:
+        run.status = "completed"
+      run.ended_at = datetime.now(UTC)
+      changed = True
     if not marker_is_ours:
       if changed and not _commit_or_rollback(db):
         raise _PersistFailed("ParkRun did not persist")
-      return None
+      return False
     chat = db.query(Chat).filter(Chat.id == cmd.chat_id).first()
     if chat is not None and (
       chat.run_status is not None or chat.run_started_at is not None
@@ -2514,10 +2527,10 @@ class ChatWriterActor:
     if changed and not _commit_or_rollback(db):
       raise _PersistFailed("ParkRun did not persist")
     self._run_token_owner.pop(cmd.chat_id, None)
-    return None
+    return parked
 
   def _resolve_park(self, db, cmd: ResolvePark):
-    """Move a parked/pending row to ``parked_notified``; idempotent."""
+    """Resolve a parked/pending row without continuing; idempotent."""
     from datetime import UTC, datetime
 
     from app.models import ChatRun
@@ -2534,7 +2547,12 @@ class ChatWriterActor:
       if not _commit_or_rollback(db):
         raise _PersistFailed("ResolvePark stale-run retire did not persist")
       return False
-    run.status = "parked_notified"
+    # A planned restart with automatic continuation disabled (or cancelled by
+    # a later policy/ownership check) is an ordinary manual interruption, not a
+    # provider park that was notified. Keep the historical run outcome honest.
+    run.status = (
+      "interrupted" if run.park_reason == "restart" else "parked_notified"
+    )
     if run.ended_at is None:
       run.ended_at = datetime.now(UTC)
     if not _commit_or_rollback(db):

--- a/backend/app/compaction.py
+++ b/backend/app/compaction.py
@@ -123,7 +123,11 @@ def build_transcript_text(
     # it back into a later synthesis recursively inflates the next handoff.
     if m.get("kind") == "compaction":
       continue
-    role = (m.get("role") or "user").upper()
+    if m.get("kind") == "auto_continuation":
+      reason = str(m.get("continuation_reason") or "automatic recovery")
+      role = f"AUTOMATIC CONTINUATION ({reason.upper()})"
+    else:
+      role = (m.get("role") or "user").upper()
     content = m.get("content") or ""
     if not content.strip():
       continue

--- a/backend/app/events.py
+++ b/backend/app/events.py
@@ -750,6 +750,38 @@ def process_event(event: dict, assistant_blocks: list) -> bool:
     extras = {
       key: event[key] for key in ERROR_PASSTHROUGH_FIELDS if key in event
     }
+    # A planned restart can interrupt a runner that is blocked on a durable
+    # AskUserQuestion. Keep that question as the transcript tail so it remains
+    # answerable after reload, and do not offer a competing Resume button: the
+    # answer is the continuation. Repeated restart events update the one marker
+    # immediately before the trailing question run.
+    restart_pause = (extras.get("pause") or {}).get("kind") == "restart"
+    trailing_open_start = len(assistant_blocks)
+    if restart_pause:
+      while trailing_open_start > 0:
+        block = assistant_blocks[trailing_open_start - 1]
+        if block.get("type") != "question" or block.get("answers"):
+          break
+        trailing_open_start -= 1
+    if restart_pause and trailing_open_start < len(assistant_blocks):
+      extras.pop("resumable", None)
+      marker = {
+        "type": "error",
+        "message": message,
+        **extras,
+      }
+      previous_idx = trailing_open_start - 1
+      if (
+        previous_idx >= 0
+        and assistant_blocks[previous_idx].get("type") == "error"
+        and (
+          assistant_blocks[previous_idx].get("pause") or {}
+        ).get("kind") == "restart"
+      ):
+        assistant_blocks[previous_idx] = marker
+      else:
+        assistant_blocks.insert(trailing_open_start, marker)
+      return True
     if (assistant_blocks
         and assistant_blocks[-1].get("type") == "error"):
       block = assistant_blocks[-1]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -236,9 +236,10 @@ async def lifespan(app):
   # other lifespan steps: a failure here must not brick the recovery
   # surface. Runs single-threaded pre-serving, so no queue-lock
   # contention — see reconcile_interrupted_chats for the argument.
-  # Chats reconciled at boot (incl. any turn paused by a drain-gated restart),
-  # carried to the post-`init_vapid` notify below — VAPID must be initialized
-  # before a push can be delivered.
+  # Chats reconciled at boot (crashes plus a planned drain whose exact park did
+  # not commit) are carried to the post-`init_vapid` manual-recovery notify
+  # below. Exact planned-restart parks bypass this destructive reconciliation
+  # and are handled by the continuation sweep after the writer starts.
   _reconciled_chats: list[str] = []
   try:
     from app.chat import reconcile_interrupted_chats
@@ -317,9 +318,10 @@ async def lifespan(app):
     init_vapid()
   except Exception as exc:
     _log.error("init_vapid failed: %s", exc, exc_info=True)
-  # Boot resume notify (design §2.2 step 4). Runs AFTER init_vapid so the push
-  # can actually deliver: one "tap to resume" notification for any turn left
-  # paused by a drain-gated restart (or crash) that boot reconcile finalized.
+  # Boot manual-resume notify (design §2.2 step 4). Runs AFTER init_vapid so the
+  # push can actually deliver: one "tap to resume" notification for a crash or
+  # planned-drain fallback that boot reconciliation finalized. Exact restart
+  # parks notify through sweep_reset_parks instead.
   # Best-effort — the resumable note is already durable in the transcript, so a
   # notify failure never blocks boot.
   try:
@@ -533,22 +535,39 @@ async def lifespan(app):
 
     _stalled_live_task = _asyncio.create_task(_stalled_live_loop())
 
-    # Provider-limit reset sweep (design §2.4): notifies once when a parked
-    # turn's reset time arrives, and — when the owner opted in — starts the
-    # strictly-serial auto-resume. Same shape as the two loops above.
+    # Durable-continuation sweep (design §2.4): handles provider-limit resets
+    # and exact runs parked by a planned restart. It runs immediately on boot,
+    # then after a turn finishes or at the 60s fallback cadence. This is
+    # event-driven in the common path (one indexed query per completed turn),
+    # with no per-chat worker or short polling loop.
     async def _reset_park_loop():
-      while True:
-        await _asyncio.sleep(60)
-        try:
-          _rp_db = _SweepSession()
+      from app.broadcast import get_system_broadcast as _system_broadcast
+      _events = _system_broadcast().subscribe()
+      try:
+        while True:
           try:
-            await sweep_reset_parks(_rp_db)
-          finally:
-            _rp_db.close()
-        except _asyncio.CancelledError:
-          raise
-        except Exception as _exc:
-          _log.error("reset-park sweep failed: %s", _exc, exc_info=True)
+            _rp_db = _SweepSession()
+            try:
+              await sweep_reset_parks(_rp_db)
+            finally:
+              _rp_db.close()
+          except _asyncio.CancelledError:
+            raise
+          except Exception as _exc:
+            _log.error("reset-park sweep failed: %s", _exc, exc_info=True)
+
+          try:
+            # One absolute fallback window. Unrelated system events must not
+            # keep resetting a per-get timer and starve a future limit reset.
+            async with _asyncio.timeout(60):
+              while True:
+                _event = await _events.get()
+                if _event and _event.get("type") == "chat_run_finished":
+                  break
+          except _asyncio.TimeoutError:
+            pass
+      finally:
+        _system_broadcast().unsubscribe(_events)
 
     _reset_park_task = _asyncio.create_task(_reset_park_loop())
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -124,7 +124,8 @@ class Chat(Base):
   # start afterwards. Nullable is the migration/empty-chat state: the first
   # turn snapshots it atomically before invoking a provider.
   system_prompt_snapshot_id = Column(String(64), nullable=True, default=None)
-  # Per-chat policy for provider-limit recovery. Kept out of
+  # Per-chat policy for automatic recovery after provider limits and planned
+  # server restarts. The legacy column/API name stays compatible. Kept out of
   # agent_settings_json because that blob is snapshotted/mirrored as SDK
   # runtime configuration; mixing this policy into it can skip first-send
   # model snapshots or overwrite the owner's global model defaults.
@@ -222,6 +223,8 @@ class ChatRun(Base):
   # turn, "failed" for a provider/setup error, "stopped" for an explicit user
   # Stop, and "interrupted" for crash/supersession/watchdog recovery. Provider
   # limits additionally use the parked/resume_pending/parked_notified states.
+  # A successfully drained planned restart reuses that retry path with
+  # park_reason="restart"; an unplanned crash remains "interrupted".
   status = Column(String(16), nullable=False, default="running", index=True)
   provider = Column(String(32), nullable=True, default=None)
   # App that initiated this turn under the app-attributed-chat contract
@@ -239,8 +242,9 @@ class ChatRun(Base):
   # provider limit, the run is PARKED instead of just cleared: `status` moves
   # to "parked", `parked_until` holds the reset time (naive UTC, matching every
   # other DateTime here), and `park_reason` a short label ("rate_limit" /
-  # "usage_limit" / …). This run row IS the provider-parked signal — no
-  # separate state enum. The liveness checks read it via
+  # "usage_limit" / …). Planned restarts also use this row with
+  # park_reason="restart" and a due time of now. No separate state enum is
+  # needed. The liveness checks read it via
   # `chat._parked_until_for_chat`; the periodic reset sweep notifies once at
   # `parked_until`; auto-resume may pass through the retryable
   # "resume_pending" state before the row becomes terminal. Null on every

--- a/backend/app/restart_util.py
+++ b/backend/app/restart_util.py
@@ -10,8 +10,9 @@ never simply killed. The worker first sets the ``draining`` gate (new sends
 queue), interrupts each live turn so it finalizes its partials + a "paused for a
 platform update" note WITHOUT touching the pending queue, then restarts — SIGTERM
 for a graceful exit, with a SIGKILL backstop so a hung shutdown still cycles the
-container. Boot reconcile finalizes any marker left set and offers a one-tap
-Resume.
+container. A successfully stopped exact run is marked due for continuation before
+SIGTERM; boot reconcile handles only the fallback markers that could not make that
+transition.
 """
 
 from __future__ import annotations
@@ -44,10 +45,11 @@ async def restart_this_worker() -> None:
        worker dies no matter what, so a wedged drain or a hung graceful shutdown
        can never leave the container "Up" with a dead worker.
     3. Drain every live turn (interrupt → finalize partials + a "paused for a
-       platform update" note → LEAVE the run marker + pending queue intact for
-       boot reconcile + one-tap Resume). Bounded by ``DRAIN_TIMEOUT``;
-       best-effort — a turn that won't drain in time keeps today's contract (the
-       backstop kills the worker, boot reconcile finalizes the marker).
+       platform update" note → mark that exact run due now using the existing
+       continuation row; preserve the pending queue). Bounded by
+       ``DRAIN_TIMEOUT``; best-effort — a turn that won't drain, or whose exact
+       transition cannot commit, leaves its generic marker for manual boot
+       reconciliation.
     4. SIGTERM uvicorn for a graceful exit. If it drains and exits within the
        remaining window the backstop never fires (SIGKILL never runs); if it
        hangs on the open SSE stream, the backstop force-exits and the container
@@ -80,8 +82,8 @@ async def restart_this_worker() -> None:
     )
   except Exception:
     # Never let a drain failure block the restart — the backstop timer and the
-    # SIGTERM below still reboot the worker, and boot reconcile finalizes any
-    # turn whose marker was left set.
+    # SIGTERM below still reboots the worker. Exact runs already transitioned
+    # remain due; any marker left set falls back to manual boot reconciliation.
     log.warning("drain-for-restart failed; restarting anyway", exc_info=True)
 
   os.kill(pid, signal.SIGTERM)

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -744,7 +744,11 @@ def _first_message_title(chat) -> str:
   """The 'first message' fallback name: the first user message's text trimmed
   to a sane length (mirrors the StartTurn initial-title behavior)."""
   for m in (chat.messages or []):
-    if not isinstance(m, dict) or m.get("role") != "user":
+    if (
+      not isinstance(m, dict)
+      or m.get("role") != "user"
+      or m.get("kind") == "auto_continuation"
+    ):
       continue
     c = m.get("content")
     if isinstance(c, list):

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -397,9 +397,10 @@ class ChatPatch(BaseModel):
   title: str | None = Field(default=None, max_length=500)
   # Drawer pin toggle. True sets pinned_at = now, False clears it.
   pinned: bool | None = None
-  # Per-chat opt-in to continuing a provider-limited turn at reset. This is
-  # intentionally absent from SettingsUpdate: background agents and other
-  # chats must never inherit it.
+  # Per-chat opt-in to continuing after a provider-limit reset or planned
+  # server restart. The legacy wire name remains compatible. This is absent
+  # from SettingsUpdate: background agents and unrelated chats do not inherit
+  # a runtime change.
   auto_resume_on_limit: bool | None = None
   # Naming precedence. by_agent marks an AGENT title-sync — it fills the name
   # only when the owner hasn't locked it via a manual rename. clear_title resets

--- a/backend/scripts/chat_note.py
+++ b/backend/scripts/chat_note.py
@@ -116,7 +116,11 @@ def _render_transcript(raw: str) -> str:
     # recursively duplicate the same context on every later re-switch.
     if isinstance(m, dict) and m.get("kind") == "compaction":
       continue
-    role = m.get("role", "?") if isinstance(m, dict) else "?"
+    if isinstance(m, dict) and m.get("kind") == "auto_continuation":
+      reason = str(m.get("continuation_reason") or "automatic recovery")
+      role = f"automatic continuation ({reason})"
+    else:
+      role = m.get("role", "?") if isinstance(m, dict) else "?"
     content = m.get("content") if isinstance(m, dict) else None
     if isinstance(content, list):
       text = " ".join(

--- a/backend/tests/test_chat_compact.py
+++ b/backend/tests/test_chat_compact.py
@@ -586,6 +586,18 @@ def test_build_transcript_text_skips_handoffs_and_tail_caps():
   assert len(capped) == compaction._MAX_TRANSCRIPT_CHARS
 
 
+def test_build_transcript_text_labels_automatic_continuation_as_product_event():
+  text = compaction.build_transcript_text([{
+    "role": "user",
+    "kind": "auto_continuation",
+    "continuation_reason": "usage_limit",
+    "content": "continue",
+  }])
+
+  assert text == "AUTOMATIC CONTINUATION (USAGE_LIMIT): continue"
+  assert "USER: continue" not in text
+
+
 def test_cumulative_chat_summary_is_unbounded_compaction_source(tmp_path):
   note = tmp_path / "shared" / "memory" / "chats" / "c1" / "index.md"
   note.parent.mkdir(parents=True)

--- a/backend/tests/test_chat_log_redaction.py
+++ b/backend/tests/test_chat_log_redaction.py
@@ -45,6 +45,18 @@ def test_hidden_user_message_is_dropped_entirely():
   ) is None
 
 
+def test_automatic_continuation_is_redacted_as_a_product_event():
+  assert r.redact_message({
+    "role": "user",
+    "content": "continue",
+    "kind": "auto_continuation",
+    "continuation_reason": "restart",
+  }) == {
+    "role": "system",
+    "text": "Automatic continuation (restart).",
+  }
+
+
 def test_pure_tool_turn_with_no_text_is_dropped():
   msg = {
     "role": "assistant",

--- a/backend/tests/test_chat_note.py
+++ b/backend/tests/test_chat_note.py
@@ -212,6 +212,21 @@ def test_render_transcript_keeps_visible_blocks_and_excludes_tool_secrets():
   assert "SECRET" not in rendered
 
 
+def test_render_transcript_labels_automatic_continuation_as_product_event():
+  cn = _load_chat_note()
+  raw = json.dumps([{
+    "role": "user",
+    "kind": "auto_continuation",
+    "continuation_reason": "restart",
+    "content": "continue",
+  }])
+
+  rendered = cn._render_transcript(raw)
+
+  assert rendered == "automatic continuation (restart): continue"
+  assert "user: continue" not in rendered
+
+
 def test_claude_summary_prompt_receives_complete_transcript(monkeypatch):
   cn = _load_chat_note()
   monkeypatch.setattr(cn, "_configured_provider", lambda: "claude")

--- a/backend/tests/test_claude_sdk_session_id.py
+++ b/backend/tests/test_claude_sdk_session_id.py
@@ -231,6 +231,21 @@ def test_resumed_context_skips_non_conversation_rows():
   assert "ignored" not in block
 
 
+def test_resumed_context_labels_automatic_continuation_as_product_event():
+  from app.chat import _build_resumed_context
+
+  row = _FakeChatRow([{
+    "role": "user",
+    "kind": "auto_continuation",
+    "continuation_reason": "restart",
+    "content": "continue",
+  }])
+  block = _build_resumed_context(row)
+
+  assert "Automatic continuation (restart): continue" in block
+  assert "User: continue" not in block
+
+
 def test_resumed_context_none_when_empty():
   """A chat with no usable transcript yields no reseed block."""
   from app.chat import _build_resumed_context

--- a/backend/tests/test_drain_for_restart.py
+++ b/backend/tests/test_drain_for_restart.py
@@ -2,12 +2,12 @@
 
 Locks in the four contracts that distinguish a restart-drain from a Stop:
 
-  (a) DrainForRestart PRESERVES pending_messages + the run marker, while
-      stop_chat_for CLEARS the queue (contrast).
+  (a) DrainForRestart PRESERVES pending_messages and moves the exact run to a
+      due restart park, while stop_chat_for CLEARS the queue (contrast).
   (b) The drain persists the "paused for a platform update" note WITHOUT losing
       the accumulated partial blocks.
-  (c) Boot reconcile marks the paused note resumable (no double note) and the
-      boot notify fires exactly once.
+  (c) Generic boot reconciliation stays manual; display text alone never
+      manufactures planned-restart intent.
   (d) A send arriving while draining QUEUES instead of starting a turn.
 """
 
@@ -83,6 +83,23 @@ def _chat(chat_id: str):
     db.close()
 
 
+def _run(chat_id: str):
+  db = SessionLocal()
+  try:
+    row = db.query(models.ChatRun).filter(
+      models.ChatRun.chat_id == chat_id,
+    ).order_by(models.ChatRun.started_at.desc()).first()
+    if row is None:
+      return None
+    return {
+      "status": row.status,
+      "parked_until": row.parked_until,
+      "park_reason": row.park_reason,
+    }
+  finally:
+    db.close()
+
+
 def _live_turn(chat_id: str, *, pending=None, partial="partial answer"):
   """A live turn with a registered handle + sink, mid-stream (a real partial
   accumulated INTO the sink so the drain's finalize can preserve it)."""
@@ -124,6 +141,10 @@ def test_drain_persists_paused_note_and_preserves_partials():
     and b.get("message") == chat_mod.PAUSED_FOR_RESTART_MESSAGE
     for b in blocks
   )
+  # The exact run, not the display text, is the durable restart intent.
+  assert _run("drain-note-1")["status"] == "parked"
+  assert _run("drain-note-1")["park_reason"] == "restart"
+  assert _run("drain-note-1")["parked_until"] is not None
 
 
 # -- (a) DrainForRestart preserves the queue; stop_chat_for clears it ---------
@@ -133,12 +154,14 @@ def test_drain_preserves_pending_while_stop_clears_it():
   _live_turn("drain-keep", pending=list(queued))
   _live_turn("stop-clear", pending=list(queued))
 
-  # Drain-for-restart: queue + run marker intact.
+  # Drain-for-restart: queue intact; exact run moved to a due restart park.
   _run_drain()
   _drain_writer()
   drained_state = _chat("drain-keep")
   assert drained_state["pending"] == queued
-  assert drained_state["run_status"] == "running"  # marker LEFT for reconcile
+  assert drained_state["run_status"] is None
+  assert _run("drain-keep")["status"] == "parked"
+  assert _run("drain-keep")["park_reason"] == "restart"
 
   # Stop: queue collapsed (frontend resends; backend clears). The drain above
   # left the process-wide gate set (in production only the restart ends it), so
@@ -176,6 +199,40 @@ def test_drain_does_not_promote_the_queue():
   assert "drain-nopromote" in chat_mod._restart_draining_chats
 
 
+def test_drain_park_failure_leaves_generic_marker_for_manual_recovery(
+  monkeypatch,
+):
+  cid = "drain-park-failure"
+  _live_turn(cid)
+
+  async def _fail_park(*args, **kwargs):
+    del args, kwargs
+    raise RuntimeError("writer unavailable")
+
+  monkeypatch.setattr(chat_mod, "_park_run_strict", _fail_park)
+  assert _run_drain() == [cid]
+  _drain_writer()
+
+  assert _chat(cid)["run_status"] == "running"
+  assert _run(cid)["status"] == "running"
+
+
+def test_drain_without_exact_run_token_stays_manual():
+  cid = "drain-no-token"
+  _seed(cid)
+  bc = create_broadcast(cid)
+  sink = chat_mod._ChatEventSink(bc, cid, run_token=None)
+  chat_mod.register_active_sink(cid, sink)
+  handle = _Handle(cid)
+  registry.register(handle)
+
+  assert _run_drain() == [cid]
+  _drain_writer()
+
+  assert _chat(cid)["run_status"] == "running"
+  assert _run(cid)["status"] == "running"
+
+
 # -- (c) boot reconcile marks the note resumable (no double note) + notify once
 
 
@@ -198,6 +255,7 @@ def test_reconcile_marks_paused_note_resumable_without_double_note():
   assert cid in reconciled
   state = _chat(cid)
   assert state["run_status"] is None
+  assert _run(cid)["status"] == "interrupted"
   blocks = state["messages"][-1]["blocks"]
   errors = [b for b in blocks if b.get("type") == "error"]
   # Exactly ONE error note (no second interrupted note stacked on the drain's),
@@ -223,6 +281,7 @@ def test_reconcile_crash_note_is_resumable():
     db.close()
 
   assert cid in reconciled
+  assert _run(cid)["status"] == "interrupted"
   blocks = _chat(cid)["messages"][-1]["blocks"]
   note = next(b for b in blocks if b.get("type") == "error")
   assert note["resumable"] is True
@@ -255,6 +314,60 @@ def test_reconcile_question_tail_note_is_not_resumable():
   note = next(b for b in blocks if b.get("type") == "error")
   assert "answer is still needed" in note["message"]
   assert not note.get("resumable")
+
+
+def test_reconcile_restart_note_normalizes_before_open_question():
+  """A fallback marker may contain either historical block ordering."""
+  cid = "reco-restart-question-order"
+  _seed(cid, messages=[
+    {"role": "user", "content": "hi", "ts": 1},
+    {"role": "assistant", "ts": 2, "content": "", "blocks": [
+      {"type": "text", "content": "thinking"},
+      {"type": "question", "questions": [{"question": "Which one?"}]},
+      {
+        "type": "error",
+        "message": chat_mod.PAUSED_FOR_RESTART_MESSAGE,
+        "resumable": True,
+        "pause": {"kind": "restart"},
+      },
+    ]},
+  ])
+
+  db = SessionLocal()
+  try:
+    assert chat_mod.reconcile_interrupted_chats(db) == [cid]
+  finally:
+    db.close()
+
+  blocks = _chat(cid)["messages"][-1]["blocks"]
+  assert [block["type"] for block in blocks] == [
+    "text", "error", "question",
+  ]
+  assert not blocks[1].get("resumable")
+  assert blocks[1]["pause"] == {"kind": "restart"}
+
+
+def test_historical_restart_note_does_not_mask_a_newer_crash():
+  cid = "reco-historical-restart-note"
+  _seed(cid, messages=[
+    {"role": "user", "content": "hi", "ts": 1},
+    {"role": "assistant", "ts": 2, "content": "new work", "blocks": [
+      {"type": "error", "message": chat_mod.PAUSED_FOR_RESTART_MESSAGE},
+      {"type": "text", "content": "new work after recovery"},
+    ]},
+  ])
+
+  db = SessionLocal()
+  try:
+    assert chat_mod.reconcile_interrupted_chats(db) == [cid]
+  finally:
+    db.close()
+
+  blocks = _chat(cid)["messages"][-1]["blocks"]
+  errors = [block for block in blocks if block.get("type") == "error"]
+  assert len(errors) == 2
+  assert errors[-1]["message"] != chat_mod.PAUSED_FOR_RESTART_MESSAGE
+  assert errors[-1]["resumable"] is True
 
 
 def test_notify_after_reconcile_fires_once(owner_token, monkeypatch):

--- a/backend/tests/test_events.py
+++ b/backend/tests/test_events.py
@@ -981,6 +981,32 @@ def test_process_error_event_carries_whitelisted_extras_on_append():
   }
 
 
+def test_restart_error_stays_before_unanswered_question_without_resume():
+  blocks = [
+    {"type": "text", "content": "I need one detail."},
+    {
+      "type": "question",
+      "questions": [{"question": "Which color?"}],
+    },
+  ]
+  event = {
+    "type": "error",
+    "message": "Paused for a platform update.",
+    "resumable": True,
+    "pause": {"kind": "restart"},
+  }
+
+  process_event(event, blocks)
+  process_event(event, blocks)
+
+  assert [block["type"] for block in blocks] == [
+    "text", "error", "question",
+  ]
+  marker = blocks[1]
+  assert marker["pause"] == {"kind": "restart"}
+  assert not marker.get("resumable")
+
+
 def test_process_error_event_extras_are_whitelist_only():
   """An unexpected event key must NOT leak into the durable transcript."""
   blocks = []

--- a/backend/tests/test_limit_park.py
+++ b/backend/tests/test_limit_park.py
@@ -1,4 +1,4 @@
-"""Provider-limit parking (design §2.4): parse → park → sweep → resume.
+"""Durable continuation (design §2.4): parse/drain → park → sweep → resume.
 
 Locks in the six contracts of the limit-park feature:
 
@@ -18,6 +18,8 @@ Locks in the six contracts of the limit-park feature:
       park per tick, none while any turn is live; the resumed turn combines
       the preserved queue + a "continue" into one continuation.
   (f) The parks are observable: /api/debug/status lists parked runs.
+  (g) A planned restart reuses the same exact-run state with a due-now time;
+      crashes, unanswered questions, and app-owned work stay manual.
 """
 
 import asyncio
@@ -70,14 +72,18 @@ def _drain_writer():
 
 def _seed_chat(
   chat_id: str, *, pending=None, run_status=None, deleted=False,
-  auto_resume=False,
+  auto_resume=False, messages=None,
 ):
   db = SessionLocal()
   try:
     db.add(models.Chat(
       id=chat_id,
       title="t",
-      messages=[{"role": "user", "content": "do work", "ts": 1}],
+      messages=(
+        messages
+        if messages is not None
+        else [{"role": "user", "content": "do work", "ts": 1}]
+      ),
       pending_messages=pending or [],
       session_id="sess",
       provider="claude",
@@ -286,6 +292,20 @@ def test_park_run_parks_row_and_clears_marker():
   assert _chat_row(cid)["run_status"] is None
 
 
+def test_park_run_missing_exact_row_keeps_generic_marker():
+  """Losing the exact identity must fail safe into manual crash recovery."""
+  cid = "park-missing-exact-row"
+  _seed_chat(cid, run_status="running")
+
+  parked = get_writer().submit(ParkRun(
+    chat_id=cid, run_token="rt-does-not-exist",
+    parked_until=datetime(2026, 7, 11, 1, 40), park_reason="restart",
+  )).result(timeout=5)
+
+  assert parked is False
+  assert _chat_row(cid)["run_status"] == "running"
+
+
 def test_park_run_superseded_owner_completes_without_parking():
   """A dying run whose marker a fresh turn took must NOT park (a stale park
   would fire a spurious notify) — its own row closes 'completed' and the
@@ -485,13 +505,15 @@ def test_park_run_strict_tokenless_falls_back_to_marker_clear():
 
 def _due_park(
   cid: str, token: str, *, pending=None, deleted=False, auto_resume=False,
+  park_reason=None, messages=None,
 ):
   _seed_chat(
     cid, pending=pending, deleted=deleted, auto_resume=auto_resume,
+    messages=messages,
   )
   _seed_run(cid, token, status="parked",
             parked_until=datetime.now(UTC).replace(tzinfo=None)
-            - timedelta(minutes=1))
+            - timedelta(minutes=1), park_reason=park_reason)
 
 
 def _run_sweep():
@@ -628,6 +650,8 @@ def test_sweep_auto_resume_on_starts_one_serial_continue(
     promoted = scheduled[0]["next_user"]
     assert "queued ask" in promoted["content"]
     assert "continue" in promoted["content"]
+    assert promoted["_messages"][-1]["kind"] == "auto_continuation"
+    assert promoted["_messages"][-1]["continuation_reason"] == "usage_limit"
     state = _chat_row("sweep-auto")
     assert state["pending"] == []
     assert state["run_status"] == "running"  # PromotePending set the marker
@@ -635,6 +659,105 @@ def test_sweep_auto_resume_on_starts_one_serial_continue(
     # _schedule_continuation was stubbed, so release the claim it would have
     # handed to the spawned turn.
     chat_mod.discard_starting("sweep-auto")
+
+
+def test_restart_park_auto_continues_with_product_marker(
+  owner_token, monkeypatch,
+):
+  del owner_token
+  notifications = []
+  monkeypatch.setattr(
+    "app.push.notify_owner",
+    lambda *args, **kwargs: notifications.append(kwargs) or "notif-id",
+  )
+  scheduled = []
+  monkeypatch.setattr(
+    chat_mod, "_schedule_continuation",
+    lambda **kwargs: scheduled.append(kwargs),
+  )
+  cid = "restart-auto"
+  token = f"rt-{cid}"
+  _due_park(cid, token, auto_resume=True, park_reason="restart")
+
+  try:
+    assert _run_sweep() == [cid]
+    assert len(scheduled) == 1
+    marker = scheduled[0]["next_user"]["_messages"][-1]
+    assert marker["role"] == "user"
+    assert marker["content"] == "continue"
+    assert marker["kind"] == "auto_continuation"
+    assert marker["continuation_reason"] == "restart"
+    assert marker["cid"] == f"restart-resume-{token}"
+    assert notifications[0]["title"] == "Möbius restarted"
+    assert "limit" not in notifications[0]["body"].lower()
+  finally:
+    chat_mod.discard_starting(cid)
+
+
+def test_restart_park_waiting_on_question_stays_manual(
+  owner_token, monkeypatch,
+):
+  del owner_token
+  notifications = []
+  monkeypatch.setattr(
+    "app.push.notify_owner",
+    lambda *args, **kwargs: notifications.append(kwargs) or "notif-id",
+  )
+  resumes = []
+
+  async def _fake_resume(*args, **kwargs):
+    resumes.append((args, kwargs))
+    return True
+
+  monkeypatch.setattr(chat_mod, "_auto_resume_chat", _fake_resume)
+  cid = "restart-question"
+  _due_park(
+    cid,
+    f"rt-{cid}",
+    auto_resume=True,
+    park_reason="restart",
+    messages=[
+      {"role": "user", "content": "help me choose", "ts": 1},
+      {
+        "role": "assistant",
+        "ts": 2,
+        "blocks": [
+          {
+            "type": "error",
+            "message": chat_mod.PAUSED_FOR_RESTART_MESSAGE,
+            "pause": {"kind": "restart"},
+          },
+          {
+            "type": "question",
+            "questions": [{"question": "Which one?"}],
+          },
+        ],
+      },
+    ],
+  )
+
+  assert _run_sweep() == [cid]
+  assert resumes == []
+  assert _run_row(f"rt-{cid}")["status"] == "interrupted"
+  assert notifications[0]["title"] == "Möbius restarted"
+
+
+def test_restart_park_policy_off_resolves_to_manual_interruption(
+  owner_token, monkeypatch,
+):
+  del owner_token
+  notifications = []
+  monkeypatch.setattr(
+    "app.push.notify_owner",
+    lambda *args, **kwargs: notifications.append(kwargs) or "notif-id",
+  )
+  cid = "restart-policy-off"
+  _due_park(cid, f"rt-{cid}", auto_resume=False, park_reason="restart")
+
+  assert _run_sweep() == [cid]
+  assert _run_row(f"rt-{cid}")["status"] == "interrupted"
+  assert notifications[0]["title"] == "Möbius restarted"
+  assert "limit" not in notifications[0]["body"].lower()
 
 
 def test_sweep_auto_resume_defers_while_any_turn_is_live(
@@ -993,6 +1116,27 @@ def test_auto_resume_rechecks_app_work_inside_queue_handoff():
   assert not chat_mod.is_chat_running(cid)
 
 
+def test_auto_resume_rechecks_app_run_at_locked_handoff():
+  """A direct or stale sweep caller cannot bypass durable attribution."""
+  cid = "auto-final-app-run-check"
+  park_token = f"rt-{cid}"
+  _seed_chat(cid, auto_resume=True)
+  _seed_run(
+    cid,
+    park_token,
+    status="resume_pending",
+    started_offset=-30,
+    initiated_by_app_id=11,
+  )
+
+  assert asyncio.run(
+    chat_mod._auto_resume_chat(cid, "claude", park_token=park_token)
+  ) is False
+  assert _chat_row(cid)["pending"] == []
+  assert _run_row(park_token)["status"] == "resume_pending"
+  assert not chat_mod.is_chat_running(cid)
+
+
 # -- (f) observability ----------------------------------------------------------
 
 def test_debug_status_lists_parked_runs(client, auth):
@@ -1098,7 +1242,7 @@ def test_parked_probe_tiebreak_is_deterministic():
 
 
 def _limit_complete_turn(cid, *, parked_until, monkeypatch=None,
-                         park_raises=False):
+                         park_raises=False, park_returns_false=False):
   """Drive _complete_turn's limit branch with a real bc + sink + seeded run."""
   from app.broadcast import create_broadcast
 
@@ -1114,6 +1258,10 @@ def _limit_complete_turn(cid, *, parked_until, monkeypatch=None,
     async def _boom(*a, **kw):
       raise RuntimeError("park exploded")
     monkeypatch.setattr(chat_mod, "_park_run_strict", _boom)
+  elif park_returns_false:
+    async def _not_parked(*a, **kw):
+      return False
+    monkeypatch.setattr(chat_mod, "_park_run_strict", _not_parked)
 
   db = SessionLocal()
   disposition = asyncio.run(chat_mod._complete_turn(
@@ -1148,6 +1296,24 @@ def test_park_failure_degrades_card_and_keeps_resume(monkeypatch):
   # The degraded follow-up carries no pause descriptor, so the coalesced block
   # stops rendering the "resets at …" card.
   assert "pause" not in tail
+
+
+def test_park_false_result_uses_same_manual_recovery_fallback(monkeypatch):
+  cid = "park-false-result"
+  until = datetime.now(UTC).replace(tzinfo=None) + timedelta(hours=1)
+
+  disposition = _limit_complete_turn(
+    cid,
+    parked_until=until,
+    monkeypatch=monkeypatch,
+    park_returns_false=True,
+  )
+
+  assert disposition.value == "failed_leave_marker"
+  assert _chat_row(cid)["run_status"] == "running"
+  tail = _chat_row(cid)["messages"][-1]["blocks"][-1]
+  assert "could not be scheduled" in tail["message"]
+  assert not tail.get("pause")
 
 
 def test_limit_park_releases_starting_claim_before_returning():

--- a/backend/tests/test_time_context.py
+++ b/backend/tests/test_time_context.py
@@ -4,7 +4,17 @@ Locks in the contract that the agent gets a clock every turn (issue: the
 agent only ever saw an IANA timezone NAME, and only on turn 1).
 """
 
-from app.chat import _build_time_context, _human_elapsed, _is_cli_slash_command
+import time
+import uuid
+
+from app import models
+from app.chat import (
+  _build_time_context,
+  _human_elapsed,
+  _is_cli_slash_command,
+  _last_user_message_elapsed,
+)
+from app.database import SessionLocal
 
 
 def test_includes_timezone_label_and_clock():
@@ -47,6 +57,37 @@ def test_elapsed_clause_only_when_present():
   assert "user's last message was" not in _build_time_context("UTC", None)
   out = _build_time_context("UTC", "3 days ago")
   assert "user's last message was 3 days ago" in out
+
+
+def test_elapsed_ignores_automatic_continuation_marker(monkeypatch):
+  now = 1_800_000_000.0
+  monkeypatch.setattr(time, "time", lambda: now)
+  cid = f"time-context-{uuid.uuid4()}"
+  db = SessionLocal()
+  try:
+    db.add(models.Chat(
+      id=cid,
+      title="time context",
+      messages=[
+        {
+          "role": "user", "content": "owner message",
+          "ts": (now - 3 * 86400) * 1000,
+        },
+        {"role": "assistant", "content": "reply"},
+        {
+          "role": "user", "content": "continue",
+          "kind": "auto_continuation",
+          "ts": (now - 5 * 60) * 1000,
+        },
+        {"role": "assistant", "content": "automatic reply"},
+        {"role": "user", "content": "current owner message", "ts": now * 1000},
+      ],
+    ))
+    db.commit()
+
+    assert _last_user_message_elapsed(db, cid) == "3 days ago"
+  finally:
+    db.close()
 
 
 def test_goal_slash_command_is_detected_without_matching_paths():

--- a/frontend/src/components/ChatView/AutoContinuationCard.jsx
+++ b/frontend/src/components/ChatView/AutoContinuationCard.jsx
@@ -1,0 +1,30 @@
+import MarkerCard from './MarkerCard.jsx'
+
+export default function AutoContinuationCard({ msg }) {
+  const restarted = msg?.continuation_reason === 'restart'
+  const title = restarted
+    ? 'Server restarted — continuing automatically'
+    : 'Usage available again — continuing automatically'
+
+  return (
+    <MarkerCard
+      title={title}
+      icon={
+        <svg
+          aria-hidden="true"
+          viewBox="0 0 16 16"
+          width="14"
+          height="14"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.4"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M13 7a5 5 0 1 0-1.5 4" />
+          <path d="M10.5 8H13V5.5" />
+        </svg>
+      }
+    />
+  )
+}

--- a/frontend/src/components/ChatView/ChatSettingsPanel.jsx
+++ b/frontend/src/components/ChatView/ChatSettingsPanel.jsx
@@ -834,7 +834,7 @@ export default function ChatSettingsPanel({
             onPointerDown={preserveFocusUnlessTouch}
           >
             <label className="csp__automation-copy" htmlFor={autoResumeSwitchId}>
-              <span className="csp__automation-title">Continue after rate limits</span>
+              <span className="csp__automation-title">Continue after limits and restarts</span>
             </label>
             <Switch
               className="chat-policy-switch"

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -341,6 +341,7 @@
 }
 
 .chat__msg--user { align-items: flex-end; }
+.chat__msg--marker { align-items: stretch; }
 .chat__msg--assistant {
   --activity-block-gap: 8px;
   --activity-row-gap: 4px;

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -61,6 +61,8 @@ import {
   canFastForwardQueue,
   cidOf,
   continuationRowsFromPromotedMessage,
+  isAutoContinuationMessage,
+  isOwnerUserMessage,
   mergeRecentMessagesIntoLoadedWindow,
   openAppCtaViewModel,
   shouldRetryStopAfterConfirm,
@@ -918,9 +920,7 @@ export default function ChatView({
   // messagesRef catches up, so state alone is not authoritative. A row is
   // first only when both the state mirror and rendered transcript are empty.
   function isFirstVisibleUserMessage() {
-    const stateHasUser = messagesRef.current.some(
-      m => m.role === 'user' && !m.hidden,
-    )
+    const stateHasUser = messagesRef.current.some(isOwnerUserMessage)
     const domHasUser = !!scrollRef.current?.querySelector('.chat__msg--user')
     return !stateHasUser && !domHasUser
   }
@@ -3311,7 +3311,9 @@ export default function ChatView({
   useLayoutEffect(() => {
     if (displayReady) onDisplayReady?.(chatId)
   }, [chatId, displayReady, onDisplayReady])
-  const lastUserIdx = messages.reduce((acc, m, i) => (m.role === 'user' && !m.hidden) ? i : acc, -1)
+  const lastUserIdx = messages.reduce((acc, m, i) => (
+    isOwnerUserMessage(m) ? i : acc
+  ), -1)
   // The captured bridge partial enters the active row before catch-up emits a
   // single item. That is the load-bearing part of Lever 1: when SSE becomes the
   // selected source, React updates MsgContent props instead of replacing the
@@ -3326,7 +3328,7 @@ export default function ChatView({
   const bridgeMsg = bridgeMsgIdx >= 0 ? messages[bridgeMsgIdx] : null
   const bridgeFollowedByVisibleUser = bridgeMsgIdx >= 0 && messages
     .slice(bridgeMsgIdx + 1)
-    .some(msg => msg?.role === 'user' && !msg.hidden)
+    .some(isOwnerUserMessage)
   const trailingAssistantPartialMsg = trailingAssistantPartialIdx >= 0
     ? messages[trailingAssistantPartialIdx]
     : null
@@ -3726,6 +3728,7 @@ export default function ChatView({
 
           {messages.map((msg, i) => {
             if (msg.hidden) return null
+            const continuationMarker = isAutoContinuationMessage(msg)
             const isLastMsg = i === lastVisibleMessageIndex
             // The mirrored DB row is rendered below by the SAME active
             // MsgContent instance that consumes live payloads. Suppress only
@@ -3771,20 +3774,23 @@ export default function ChatView({
             // User rows key + pin on the stable cid so the optimistic→confirm
             // display-ts update never remounts the row (which would drop the
             // pin target mid-swap). data-ts stays for the timestamp tooltip only.
-            const userCid = msg.role === 'user' ? cidOf(msg) : null
+            const ownerUserMessage = isOwnerUserMessage(msg)
+            const userCid = ownerUserMessage ? cidOf(msg) : null
             return (
             <li
               key={userCid || msg.id || msg.ts || `${msg.role}-${i}`}
-              className={`chat__msg chat__msg--${msg.role}`}
+              className={`chat__msg chat__msg--${continuationMarker ? 'marker' : msg.role}`}
               ref={i === lastUserIdx ? setLastUserMsgRef : null}
               data-key={dataKey}
               data-cid={userCid || undefined}
-              data-ts={msg.role === 'user' && msg.ts ? String(msg.ts) : undefined}
-              onPointerDown={(event) => handleMessagePointerDown(event, msg, dataKey)}
-              onPointerMove={handleMessagePointerMove}
-              onPointerUp={cancelMessageHold}
-              onPointerCancel={cancelMessageHold}
-              onContextMenu={_isTouchPrimary
+              data-ts={ownerUserMessage && msg.ts ? String(msg.ts) : undefined}
+              onPointerDown={continuationMarker
+                ? undefined
+                : (event) => handleMessagePointerDown(event, msg, dataKey)}
+              onPointerMove={continuationMarker ? undefined : handleMessagePointerMove}
+              onPointerUp={continuationMarker ? undefined : cancelMessageHold}
+              onPointerCancel={continuationMarker ? undefined : cancelMessageHold}
+              onContextMenu={_isTouchPrimary && !continuationMarker
                 ? (event) => {
                     if (event.target?.closest?.('button, a, input, textarea, summary, pre, code')) return
                     event.preventDefault()
@@ -3792,7 +3798,7 @@ export default function ChatView({
                     void copyMessage(msg, dataKey)
                   }
                 : undefined}
-              onClick={msg.ts && msg.role === 'user'
+              onClick={msg.ts && ownerUserMessage
                 ? (event) => showTimestamp(event, dataKey)
                 : undefined}
             >
@@ -3823,7 +3829,7 @@ export default function ChatView({
                 liveQuestionId={liveQuestionId}
                 suppressedQuestionKeys={streamItemQuestionKeys}
               />
-              {msg.ts && msg.role === 'user' && (
+              {msg.ts && ownerUserMessage && (
                 <time className={`chat__ts${visibleTimestampKey === dataKey ? ' chat__ts--visible' : ''}`}>
                   {new Date(msg.ts).toLocaleString([], {
                     month: 'short', day: 'numeric',

--- a/frontend/src/components/ChatView/MarkerCard.jsx
+++ b/frontend/src/components/ChatView/MarkerCard.jsx
@@ -2,10 +2,9 @@ import { useRef, useState } from 'react'
 import { preserveTogglePosition } from './preserveTogglePosition.js'
 
 // Shared shell for "marker" messages — system/product moments that are neither
-// agent prose nor a tool call. A compaction summary is the only marker today;
-// interrupted-turn and other system notes can adopt this shell later so every
-// marker reads as one family (one card shape, one disclosure motion) instead of
-// each inventing its own look or masquerading as a chat bubble.
+// agent prose nor a tool call. Compaction summaries and automatic continuation
+// actions share this family (one card shape and disclosure motion) instead of
+// inventing separate chrome or masquerading as chat bubbles.
 //
 // Extracted from CompactionCard with no visual change — the default look IS the
 // accent-tinted summary divider that card established (`.chat__marker*` CSS,

--- a/frontend/src/components/ChatView/MsgContent.jsx
+++ b/frontend/src/components/ChatView/MsgContent.jsx
@@ -7,6 +7,7 @@ import QuestionCard from './QuestionCard.jsx'
 import MessageSources from './MessageSources.jsx'
 import Attachments from './Attachments.jsx'
 import CompactionCard from './CompactionCard.jsx'
+import AutoContinuationCard from './AutoContinuationCard.jsx'
 import { questionKey } from './questionKey.js'
 import {
   repairInterleavedQuestionText,
@@ -82,6 +83,10 @@ function MsgContentInner({
         <CompactionCard msg={msg} />
       </div>
     )
+  }
+
+  if (msg.kind === 'auto_continuation') {
+    return <AutoContinuationCard msg={msg} />
   }
 
   if (msg.blocks && msg.blocks.length > 0) {
@@ -221,7 +226,7 @@ function MsgContentInner({
                     className="chat__limit-option-label"
                     htmlFor={autoResumeSwitchId}
                   >
-                    Always continue after limits in this chat
+                    Always continue after limits and restarts in this chat
                   </label>
                 </div>
                 <Switch

--- a/frontend/src/components/ChatView/__tests__/chatRuntimeState.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatRuntimeState.test.js
@@ -8,6 +8,8 @@ import {
   canFastForwardQueue,
   cidOf,
   continuationRowsFromPromotedMessage,
+  isAutoContinuationMessage,
+  isOwnerUserMessage,
   mergeRecentMessagesIntoLoadedWindow,
   openAppCtaViewModel,
   previewReadyAnnouncement,
@@ -21,6 +23,19 @@ import {
   stripInternalUserMessageFields,
   systemEventForChat,
 } from '../chatRuntimeState.js'
+
+test('automatic continuations are product markers, not owner messages', () => {
+  const marker = {
+    role: 'user',
+    content: 'continue',
+    kind: 'auto_continuation',
+    continuation_reason: 'restart',
+  }
+  assert.equal(isAutoContinuationMessage(marker), true)
+  assert.equal(isOwnerUserMessage(marker), false)
+  assert.equal(isOwnerUserMessage({ role: 'user', content: 'hello' }), true)
+  assert.equal(isOwnerUserMessage({ role: 'user', hidden: true }), false)
+})
 
 test('an in-process question answer keeps ownership of the active assistant turn', () => {
   assert.equal(answerTurnDisposition({

--- a/frontend/src/components/ChatView/__tests__/contextMenuOrder.test.js
+++ b/frontend/src/components/ChatView/__tests__/contextMenuOrder.test.js
@@ -25,7 +25,7 @@ test('chat context actions follow model selection and continuation policy', () =
   assert.ok(picker !== -1 && summary !== -1 && inspector !== -1)
   assert.ok(picker < summary)
   assert.ok(summary < inspector)
-  assert.match(settingsSource, /Continue after rate limits/)
+  assert.match(settingsSource, /Continue after limits and restarts/)
   assert.doesNotMatch(settingsSource, /Chat summar(?:y|ies)/)
 })
 

--- a/frontend/src/components/ChatView/__tests__/messageCopy.test.js
+++ b/frontend/src/components/ChatView/__tests__/messageCopy.test.js
@@ -24,3 +24,12 @@ test('copyableMessageText removes hidden user augmentation', () => {
 test('copyableMessageText ignores hidden transcript rows', () => {
   assert.equal(copyableMessageText({ hidden: true, content: 'do not copy' }), '')
 })
+
+test('copyableMessageText ignores product-owned continuation markers', () => {
+  assert.equal(copyableMessageText({
+    role: 'user',
+    content: 'continue',
+    kind: 'auto_continuation',
+    continuation_reason: 'restart',
+  }), '')
+})

--- a/frontend/src/components/ChatView/__tests__/parkedCard.test.js
+++ b/frontend/src/components/ChatView/__tests__/parkedCard.test.js
@@ -20,6 +20,9 @@ const shell = readFileSync(new URL('../../Shell/Shell.jsx', import.meta.url), 'u
 const paneChatView = readFileSync(new URL('../../Shell/PaneChatView.jsx', import.meta.url), 'utf8')
 const chatEmbed = readFileSync(new URL('../../ChatEmbed/ChatEmbed.jsx', import.meta.url), 'utf8')
 const chatSettingsPanel = readFileSync(new URL('../ChatSettingsPanel.jsx', import.meta.url), 'utf8')
+const autoContinuationCard = readFileSync(
+  new URL('../AutoContinuationCard.jsx', import.meta.url), 'utf8',
+)
 const settingsView = readFileSync(
   new URL('../../SettingsView/SettingsView.jsx', import.meta.url), 'utf8',
 )
@@ -103,7 +106,7 @@ test('the parked card has styling distinct from a plain error', () => {
 test('auto-resume is a chat-local switch shown only on the active rate-limit card', () => {
   assert.match(msgContent, /resumable && parked && autoResumeAvailable && onAutoResumeChange/,
     'the switch must require the tail resumable rate-limit state')
-  assert.match(msgContent, /Always continue after limits in this chat/,
+  assert.match(msgContent, /Always continue after limits and restarts in this chat/,
     'the switch label makes the persistent, chat-local scope explicit')
   assert.match(msgContent, /htmlFor=\{autoResumeSwitchId\}/,
     'the visible switch label must also be its accessible name')
@@ -115,7 +118,7 @@ test('auto-resume is a chat-local switch shown only on the active rate-limit car
     'the in-card control has a dedicated layout')
   assert.doesNotMatch(settingsView, /auto_resume_on_limit|Auto.?resume/i,
     'the removed global automatic option must not reappear in Settings')
-  assert.match(chatSettingsPanel, /Continue after rate limits/,
+  assert.match(chatSettingsPanel, /Continue after limits and restarts/,
     'the durable policy remains manageable in the per-chat settings surface')
   assert.doesNotMatch(chatSettingsPanel, /On for this chat|Off for this chat/,
     'the switch color communicates state without redundant state copy')
@@ -123,6 +126,17 @@ test('auto-resume is a chat-local switch shown only on the active rate-limit car
     'the settings surface uses the same full-size black/purple switch treatment')
   assert.match(css, /\.chat-policy-switch button\[role="switch"\]\[data-state="checked"\]/,
     'the chat switch restores the SDK checked track after the button reset')
+})
+
+test('automatic continuation renders as a product marker, not a user bubble', () => {
+  assert.match(msgContent, /msg\.kind === 'auto_continuation'/,
+    'the stored provider-facing user row must take the product-marker branch')
+  assert.match(msgContent, /<AutoContinuationCard msg=\{msg\}/,
+    'both restart and limit continuations share the marker renderer')
+  assert.match(autoContinuationCard, /Server restarted — continuing automatically/)
+  assert.match(autoContinuationCard, /Usage available again — continuing automatically/)
+  assert.match(chatView, /chat__msg--\$\{continuationMarker \? 'marker' : msg\.role\}/,
+    'the row shell must not inherit owner-user alignment')
 })
 
 test('an enabled policy stays cancellable after the viewer clock reaches reset', () => {

--- a/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
+++ b/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
@@ -833,6 +833,37 @@ test('an unresolvable saved location falls back to a settled bottom anchor', () 
   assert.notEqual(mode.kind, 'FOLLOW_BOTTOM')
 })
 
+test('a product continuation marker cannot take ownership of a saved user pin', () => {
+  const messages = [
+    { role: 'user', cid: 'owner-cid', content: 'do work' },
+    {
+      role: 'user',
+      cid: 'restart-resume-token',
+      content: 'continue',
+      kind: 'auto_continuation',
+    },
+  ]
+
+  assert.deepEqual(
+    _validateSavedMode(
+      { kind: 'PIN_USER_MSG', cid: 'owner-cid', followWhenFilled: true },
+      messages,
+      null,
+    ),
+    { kind: 'PIN_USER_MSG', cid: 'owner-cid' },
+    'the preceding owner row remains the latest real user message',
+  )
+  assert.deepEqual(
+    _validateSavedMode(
+      { kind: 'PIN_USER_MSG', cid: 'restart-resume-token' },
+      messages,
+      null,
+    ),
+    { kind: 'INITIAL' },
+    'the provider-facing marker is never restored as an owner-authored pin',
+  )
+})
+
 test('a saved anchor wholly inside reserved blank space self-heals to real content', () => {
   const last = {
     offsetTop: 500,

--- a/frontend/src/components/ChatView/chatRuntimeState.js
+++ b/frontend/src/components/ChatView/chatRuntimeState.js
@@ -16,6 +16,19 @@ export function cidOf(msg) {
   return msg.cid || null
 }
 
+export function isAutoContinuationMessage(message) {
+  return message?.kind === 'auto_continuation'
+}
+
+/** A visible transcript row authored by the owner, excluding product events
+ * that retain role=user only because the provider receives `continue`. */
+export function isOwnerUserMessage(message) {
+  return !!message
+    && message.role === 'user'
+    && !message.hidden
+    && !isAutoContinuationMessage(message)
+}
+
 export function stripInternalUserMessageFields(raw) {
   if (!raw) return null
   // KEEP `cid` — it is now the durable row identity and must survive the

--- a/frontend/src/components/ChatView/messageCopy.js
+++ b/frontend/src/components/ChatView/messageCopy.js
@@ -1,6 +1,7 @@
 // Message-to-plain-text helpers for the mobile hold-to-copy action.
 
 import { stripAugmentation } from './msgText.js'
+import { isAutoContinuationMessage } from './chatRuntimeState.js'
 
 function questionText(block) {
   return (block.questions || []).map(question => {
@@ -14,7 +15,7 @@ function questionText(block) {
 /** Resolve the owner-visible prose in one transcript row. Tool chrome and
  * hidden prompt augmentation stay out of copied text. */
 export function copyableMessageText(message) {
-  if (!message || message.hidden) return ''
+  if (!message || message.hidden || isAutoContinuationMessage(message)) return ''
   const parts = []
   if (Array.isArray(message.blocks) && message.blocks.length > 0) {
     for (const block of message.blocks) {

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -40,7 +40,7 @@
  */
 
 import { useState, useRef, useLayoutEffect, useCallback } from 'react'
-import { cidOf } from './chatRuntimeState.js'
+import { cidOf, isOwnerUserMessage } from './chatRuntimeState.js'
 import { BEFORE_SHELL_RELOAD_EVENT } from '../../lib/shellReloadEvents.js'
 
 
@@ -386,7 +386,7 @@ export function _validateSavedMode(saved, messages, scrollEl) {
     // resolve a pin target — use the explicit no-location fallback.
     if (saved.cid == null) return holdBottom()
     const lastUserMsg = [...messages].reverse()
-      .find(m => m.role === 'user' && !m.hidden)
+      .find(isOwnerUserMessage)
     // Automatic pin→follow is live-turn state, never restoration state. Strip
     // the armed flag even if a pagehide captured it mid-stream; mount/return
     // must not manufacture tail-follow from saved geometry.


### PR DESCRIPTION
## Outcome

Chats whose live turn is successfully drained for a planned server restart now continue automatically after the new process boots, using the same chat-local policy and durable park/resume transition as usage-limit recovery.

This deliberately keeps the model small:

- the drain already has the exact `ChatRun` identity;
- after every handle reports stopped, it commits `status=parked`, `park_reason=restart`, and `parked_until=now` before SIGTERM;
- startup runs the existing due-park sweep immediately;
- there is no restart ledger, boot nonce, schema change, transcript-text inference, per-chat worker, or short polling loop.

## Safety boundaries

| Situation | Result |
|---|---|
| Exact planned drain commits | Eligible chat continues after boot |
| Handle stuck, token missing, or park commit fails | Generic running evidence remains; boot recovery is manual |
| Crash/OOM without the exact planned transition | Manual interruption; never auto-retried |
| Policy off | Restart park resolves to a manual interruption |
| Unanswered question | Question remains the tail affordance; no synthetic `continue` |
| App-owned run or app-queued work | Never auto-continues |
| Manual send, provider switch, delete, or newer run | Existing latest-run fence supersedes the park |
| Multiple due chats | Existing global-idle gate runs them strictly serially |

The final locked handoff rechecks policy, exact latest run, question state, app attribution, queued app work, provider, and global idleness. Failed task creation retains the existing rollback/retry behavior.

## Product/UI behavior

The existing per-chat setting is intentionally relabeled to **Continue after limits and restarts**. This is the product decision that one automatic-continuation preference covers both recoverable waits.

The provider-facing synthetic `continue` is persisted as `kind=auto_continuation` with reason `restart` or `usage_limit`. The transcript renders it as a product marker (for example, **Server restarted — continuing automatically**) rather than a user bubble. Copying, title derivation, owner-message recency, scroll pins, compaction/provider handoff, chat-note summaries, and redacted chat logs all preserve that distinction.

The continuation sweep does one indexed due-row query immediately at boot, on `chat_run_finished`, or at an absolute 60-second fallback. Unrelated system events cannot postpone that fallback.

## Review findings fixed during expanding-scope audit

- A historical restart note with later output can no longer mask a newer crash.
- Restart notes remain before trailing unanswered questions, with no competing Resume action.
- A stale/direct resume caller cannot bypass app-run attribution at the locked handoff.
- A missing exact `ParkRun` row no longer clears the generic crash evidence.
- A false (not only exceptional) park result takes the honest manual-recovery path.

`SIMPLIFICATION_AUDIT.md` records seven ranked follow-up opportunities. The strongest is the already-documented Step-3b cleanup: make `ChatRun.id` the single turn-ownership authority and retire the `Chat.run_status`/generation split in a dedicated state-machine change.

## Validation

- Backend full suite: `2771 passed, 6 skipped`
- Frontend full suite: `1801 + 47 passed`
- Final post-rebase affected backend suite: `253 passed`
- Final targeted frontend suite: `116 passed`
- Production Vite/PWA build: passed
- Python compile checks and `git diff --check`: passed

This supersedes the ledger design proposed in #145: the exact successfully drained run transition is the durable planned-restart intent boundary, and the broadened shared policy is intentional.

Closes #145.
