### PR TITLE
Backfill historical chat session links on startup

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -162,6 +162,22 @@ async def lifespan(app):
     # report cleanup failure without making the whole service unbootable.
     _log.error("legacy global auto-resume cleanup failed: %s", exc, exc_info=True)
   _init_db()
+  # Upgrade hygiene for lifecycle observability. The append-only link table is
+  # new, but older chats can already carry a current provider session pointer.
+  # Seed those once after create_all has made the table; future sightings are
+  # recorded by the runners. Ambiguous historical claims remain unlinked.
+  try:
+    from app.session_links import backfill_current_session_links
+    with SessionLocal() as _session_link_db:
+      _backfilled_links = backfill_current_session_links(_session_link_db)
+    if _backfilled_links:
+      _log.info(
+        "backfilled %s historical chat session link(s)", _backfilled_links,
+      )
+  except Exception as exc:
+    # Observability must never block the recovery surface. A failed link is
+    # retried on the next boot and the runner still records future sightings.
+    _log.error("session-link backfill failed: %s", exc, exc_info=True)
   # First-boot claim gate (card 261). Publish/reconcile the one-time setup
   # claim now — after _init_db() so the owner state is readable, and before
   # `yield` so no request can reach POST /api/auth/setup before the gate

--- a/backend/app/session_links.py
+++ b/backend/app/session_links.py
@@ -29,6 +29,82 @@ from app.timeutil import now_naive_utc
 log = logging.getLogger(__name__)
 
 
+def backfill_current_session_links(db) -> int:
+  """Seeds links from each chat's current provider/session pointer.
+
+  Upgrade-only hygiene: releases predating ``ChatSessionLink`` can already
+  have a durable ``Chat.session_id``. The live runners record every future
+  sighting, but without this startup pass those historical current sessions
+  remain invisible until the chat runs again.
+
+  The pass is idempotent and append-only. Existing links always win. If two
+  chats claim the same provider/session pair and no link has established the
+  owner yet, the mapping is ambiguous, so neither claim is inserted. Commits
+  the supplied session only when at least one row is added.
+  """
+  if db is None:
+    return 0
+  candidates = (
+    db.query(
+      models.Chat.id,
+      models.Chat.provider,
+      models.Chat.session_id,
+    )
+    .filter(
+      models.Chat.provider.isnot(None),
+      models.Chat.provider != "",
+      models.Chat.session_id.isnot(None),
+      models.Chat.session_id != "",
+    )
+    .order_by(models.Chat.id.asc())
+    .all()
+  )
+  existing = {
+    (provider, session_id): chat_id
+    for provider, session_id, chat_id in db.query(
+      models.ChatSessionLink.provider,
+      models.ChatSessionLink.session_id,
+      models.ChatSessionLink.chat_id,
+    ).all()
+  }
+  claims: dict[tuple[str, str], set[str]] = {}
+  for chat_id, provider, session_id in candidates:
+    key = (provider, session_id)
+    claims.setdefault(key, set()).add(chat_id)
+
+  now = now_naive_utc()
+  added = 0
+  for (provider, session_id), chat_ids in claims.items():
+    bound_chat = existing.get((provider, session_id))
+    if bound_chat is not None:
+      if bound_chat not in chat_ids:
+        log.warning(
+          "session-link backfill conflict: (%s, %s) already maps to chat %s, "
+          "not current claimant(s) %s — keeping the first binding",
+          provider, session_id, bound_chat, sorted(chat_ids),
+        )
+      continue
+    if len(chat_ids) != 1:
+      log.warning(
+        "session-link backfill ambiguous: (%s, %s) is claimed by chats %s — "
+        "skipping until authoritative runner evidence arrives",
+        provider, session_id, sorted(chat_ids),
+      )
+      continue
+    chat_id = next(iter(chat_ids))
+    db.add(models.ChatSessionLink(
+      provider=provider,
+      session_id=session_id,
+      chat_id=chat_id,
+      first_seen_at=now,
+      last_seen_at=now,
+    ))
+    added += 1
+  if added:
+    db.commit()
+  return added
+
+
 async def record_session_link_async(
   provider: str, session_id: str, chat_id: str
 ) -> None:

--- a/backend/tests/test_session_links.py
+++ b/backend/tests/test_session_links.py
@@ -9,7 +9,7 @@ owner-only `GET /api/chats/session-links` endpoint contract.
 from __future__ import annotations
 
 from app import models
-from app.session_links import record_session_link
+from app.session_links import backfill_current_session_links, record_session_link
 
 
 def _chat(db, chat_id: str, *, provider: str = "claude", session_id=None):
@@ -95,6 +95,45 @@ def test_record_session_link_noops_on_missing_args(db):
   record_session_link(None, "claude", "sess-A", "chat-1")
 
   assert db.query(models.ChatSessionLink).count() == 0
+
+
+def test_backfill_current_session_links_is_idempotent(db):
+  _chat(db, "chat-1", provider="claude", session_id="sess-A")
+  _chat(db, "chat-2", provider="codex", session_id="sess-B")
+  _chat(db, "chat-empty", provider="claude", session_id="")
+
+  assert backfill_current_session_links(db) == 2
+  assert backfill_current_session_links(db) == 0
+
+  links = {
+    (link.provider, link.session_id): link.chat_id
+    for link in db.query(models.ChatSessionLink).all()
+  }
+  assert links == {
+    ("claude", "sess-A"): "chat-1",
+    ("codex", "sess-B"): "chat-2",
+  }
+
+
+def test_backfill_preserves_existing_and_skips_ambiguous_claims(db):
+  _chat(db, "chat-existing", provider="claude", session_id="sess-existing")
+  _chat(db, "chat-claim", provider="claude", session_id="sess-existing")
+  _chat(db, "chat-a", provider="codex", session_id="sess-ambiguous")
+  _chat(db, "chat-b", provider="codex", session_id="sess-ambiguous")
+  db.add(models.ChatSessionLink(
+    provider="claude",
+    session_id="sess-existing",
+    chat_id="chat-existing",
+  ))
+  db.commit()
+
+  assert backfill_current_session_links(db) == 0
+  assert db.get(
+    models.ChatSessionLink, ("claude", "sess-existing")
+  ).chat_id == "chat-existing"
+  assert db.get(
+    models.ChatSessionLink, ("codex", "sess-ambiguous")
+  ) is None
 
 
 def test_provider_switch_nulls_session_id_but_leaves_links(


### PR DESCRIPTION
## Summary
- seed the append-only session-link map from historical current chat session pointers after database initialization
- preserve established mappings and skip ambiguous duplicate claims instead of guessing
- project only identity columns so startup cost is independent of transcript size
- keep failures non-fatal and retryable on the next boot

## Validation
- 10 session-link tests passed
- 4 adjacent lifecycle hard-purge tests passed
- Python syntax and pre-push repository gates passed