### PR TITLE
Own timed Docker probe cleanup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,7 +81,7 @@ jobs:
         # validation values non-empty and production-shaped so both site
         # blocks and the cross-origin CSP are actually parsed.
         run: >-
-          docker run --rm
+          scripts/docker-probe.sh --timeout 30 --
           -e DOMAIN=mobius.example.test
           -e FRONTEND_ORIGIN=https://mobius.example.test
           -e MOBIUS_SERVICE_GATEWAY_ORIGIN=https://services.example.test
@@ -205,6 +205,9 @@ jobs:
           # built and loaded image into a red build. The image itself remains
           # authoritative; cache export is only a performance optimization.
           cache-to: type=gha,mode=max,ignore-error=true
+
+      - name: Verify timed Docker probe cleanup
+        run: scripts/test-docker-probe.sh
 
       - name: Start test container
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,12 @@ docker compose -p mobius-test -f docker-compose.test.yml run --rm pytest
 CI runs the equivalent natively: from `backend/`, `pip install -r requirements.txt`,
 `npm install -g esbuild@0.25.12` (compile path shells out to it), then `pytest -q`.
 
+For one-off `docker run` probes, use `scripts/docker-probe.sh --timeout
+SECONDS -- ...`. It gives the container an exact identity and removes it at
+the daemon after a timeout, so killing the Docker client cannot leave a hidden
+CPU- or disk-consuming probe behind. `scripts/docker-probe.sh --list` shows
+the age, CPU, and memory of any active probes.
+
 **Frontend unit (node:test).** From `frontend/`, after `npm ci`:
 
 ```bash

--- a/backend/tests/test_docker_probe.py
+++ b/backend/tests/test_docker_probe.py
@@ -37,4 +37,6 @@ def test_helper_owns_exact_container_identity_and_cleanup():
   assert "trap cleanup EXIT" in helper
   assert "trap 'exit 143' TERM" in helper
   assert "io.mobius.probe.started_at" in helper
+  assert "io.mobius.probe.owner_token" in helper
+  assert '[ "$token" = "$OWNER_TOKEN" ]' in helper
   assert "docker stats --no-stream" in helper

--- a/backend/tests/test_docker_probe.py
+++ b/backend/tests/test_docker_probe.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+import subprocess
+
+
+ROOT = Path(__file__).resolve().parents[2]
+HELPER = ROOT / "scripts" / "docker-probe.sh"
+
+
+def test_docker_probe_scripts_parse():
+  for script in (HELPER, ROOT / "scripts" / "test-docker-probe.sh"):
+    result = subprocess.run(
+      ["bash", "-n", str(script)], capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_direct_docker_runs_use_the_lifecycle_helper():
+  test_wrapper = (ROOT / "scripts" / "test.sh").read_text(encoding="utf-8")
+  preship = (ROOT / "scripts" / "preship-gate.sh").read_text(encoding="utf-8")
+  workflow = (
+    ROOT / ".github" / "workflows" / "test.yml"
+  ).read_text(encoding="utf-8")
+
+  assert "docker-probe.sh" in test_wrapper
+  assert "docker-probe.sh" in preship
+  assert "scripts/docker-probe.sh" in workflow
+  assert "scripts/test-docker-probe.sh" in workflow
+
+
+def test_helper_owns_exact_container_identity_and_cleanup():
+  helper = HELPER.read_text(encoding="utf-8")
+
+  assert '--cidfile "$CID_FILE"' in helper
+  assert '--name "$PROBE_NAME"' in helper
+  assert 'docker rm -f "$ref"' in helper
+  assert 'docker inspect "$ref"' in helper
+  assert "trap cleanup EXIT" in helper
+  assert "trap 'exit 143' TERM" in helper
+  assert "io.mobius.probe.started_at" in helper
+  assert "docker stats --no-stream" in helper

--- a/scripts/docker-probe.sh
+++ b/scripts/docker-probe.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# Run one disposable Docker probe with a deadline that owns daemon-side cleanup.
+
+set -u
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/docker-probe.sh [--timeout SECONDS] [--name NAME] -- [docker run args...]
+  scripts/docker-probe.sh --list
+
+The helper supplies --rm, --name, --cidfile, and probe labels. It returns 124
+when the deadline expires and verifies that the exact container disappeared.
+EOF
+}
+
+list_probes() {
+  local ids
+  ids="$(docker ps -q --filter label=io.mobius.probe=true)"
+  if [ -z "$ids" ]; then
+    echo "No active Möbius Docker probes."
+    return 0
+  fi
+  docker ps \
+    --filter label=io.mobius.probe=true \
+    --format 'table {{.ID}}\t{{.Names}}\t{{.RunningFor}}\t{{.Status}}'
+  docker stats --no-stream \
+    --format 'table {{.ID}}\t{{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}' \
+    $ids
+}
+
+TIMEOUT_SECONDS="${MOBIUS_DOCKER_PROBE_TIMEOUT:-30}"
+PROBE_NAME=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --timeout)
+      [ "$#" -ge 2 ] || { usage >&2; exit 2; }
+      TIMEOUT_SECONDS="$2"
+      shift 2
+      ;;
+    --timeout=*)
+      TIMEOUT_SECONDS="${1#*=}"
+      shift
+      ;;
+    --name)
+      [ "$#" -ge 2 ] || { usage >&2; exit 2; }
+      PROBE_NAME="$2"
+      shift 2
+      ;;
+    --name=*)
+      PROBE_NAME="${1#*=}"
+      shift
+      ;;
+    --list)
+      [ "$#" -eq 1 ] || { usage >&2; exit 2; }
+      list_probes
+      exit
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -h|--help)
+      usage
+      exit
+      ;;
+    *)
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "$TIMEOUT_SECONDS" in
+  ''|*[!0-9]*|0)
+    echo "docker-probe: timeout must be a positive integer, got '$TIMEOUT_SECONDS'" >&2
+    exit 2
+    ;;
+esac
+[ "$#" -gt 0 ] || { usage >&2; exit 2; }
+
+if [ -z "$PROBE_NAME" ]; then
+  PROBE_NAME="mobius-probe-${BASHPID}-${RANDOM}"
+fi
+if [[ ! "$PROBE_NAME" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]*$ ]]; then
+  echo "docker-probe: invalid container name '$PROBE_NAME'" >&2
+  exit 2
+fi
+
+STATE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/mobius-docker-probe.XXXXXX")" || exit 1
+CID_FILE="$STATE_DIR/cid"
+TIMED_OUT="$STATE_DIR/timed-out"
+CLIENT_PID=""
+WATCHDOG_PID=""
+
+container_ref() {
+  if [ -s "$CID_FILE" ]; then
+    head -n 1 "$CID_FILE"
+  else
+    printf '%s\n' "$PROBE_NAME"
+  fi
+}
+
+remove_container() {
+  local ref attempt
+  ref="$(container_ref)"
+  docker rm -f "$ref" >/dev/null 2>&1 || true
+  for attempt in 1 2 3; do
+    if ! docker inspect "$ref" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+    docker rm -f "$ref" >/dev/null 2>&1 || true
+  done
+  echo "docker-probe: container '$PROBE_NAME' survived cleanup" >&2
+  return 1
+}
+
+cleanup() {
+  local rc="$?"
+  trap - EXIT HUP INT TERM
+  if [ -n "$WATCHDOG_PID" ]; then
+    kill "$WATCHDOG_PID" >/dev/null 2>&1 || true
+    wait "$WATCHDOG_PID" 2>/dev/null || true
+  fi
+  if ! remove_container && [ "$rc" -eq 0 ]; then
+    rc=1
+  fi
+  if [ -n "$CLIENT_PID" ] && kill -0 "$CLIENT_PID" >/dev/null 2>&1; then
+    kill -TERM "$CLIENT_PID" >/dev/null 2>&1 || true
+  fi
+  if [ -n "$CLIENT_PID" ]; then
+    wait "$CLIENT_PID" 2>/dev/null || true
+  fi
+  rm -f "$CID_FILE" "$TIMED_OUT"
+  rmdir "$STATE_DIR" 2>/dev/null || true
+  exit "$rc"
+}
+
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+docker run --rm \
+  --name "$PROBE_NAME" \
+  --cidfile "$CID_FILE" \
+  --label io.mobius.probe=true \
+  --label "io.mobius.probe.started_at=$started_at" \
+  --label "io.mobius.probe.owner_pid=$$" \
+  "$@" <&0 &
+CLIENT_PID="$!"
+
+# Keep the deadline in a child so it survives an unexpected death of the
+# wrapper itself. SIGKILL cannot be trapped; the watchdog still removes this
+# exact named container when its deadline arrives.
+(
+  sleep "$TIMEOUT_SECONDS"
+  : >"$TIMED_OUT"
+  remove_container
+  kill -TERM "$CLIENT_PID" >/dev/null 2>&1 || true
+  sleep 2
+  kill -KILL "$CLIENT_PID" >/dev/null 2>&1 || true
+) &
+WATCHDOG_PID="$!"
+
+set +e
+wait "$CLIENT_PID"
+rc="$?"
+set -e
+
+if [ -f "$TIMED_OUT" ]; then
+  echo "docker-probe: timed out after ${TIMEOUT_SECONDS}s (${PROBE_NAME})" >&2
+  exit 124
+fi
+exit "$rc"

--- a/scripts/docker-probe.sh
+++ b/scripts/docker-probe.sh
@@ -91,20 +91,36 @@ fi
 STATE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/mobius-docker-probe.XXXXXX")" || exit 1
 CID_FILE="$STATE_DIR/cid"
 TIMED_OUT="$STATE_DIR/timed-out"
+OWNER_TOKEN="${BASHPID}-${RANDOM}-${RANDOM}"
 CLIENT_PID=""
 WATCHDOG_PID=""
 
 container_ref() {
+  local identity ref token
   if [ -s "$CID_FILE" ]; then
     head -n 1 "$CID_FILE"
-  else
-    printf '%s\n' "$PROBE_NAME"
+    return
   fi
+
+  # docker run can fail before writing the cidfile because PROBE_NAME already
+  # belongs to someone else. Resolve the name to an immutable container ID only
+  # when its private label proves this invocation created it.
+  identity=$(
+    docker inspect \
+      --format '{{.Id}} {{index .Config.Labels "io.mobius.probe.owner_token"}}' \
+      "$PROBE_NAME" 2>/dev/null
+  ) || return 1
+  ref="${identity%% *}"
+  token="${identity#* }"
+  [ -n "$ref" ] && [ "$token" = "$OWNER_TOKEN" ] || return 1
+  printf '%s\n' "$ref"
 }
 
 remove_container() {
   local ref attempt
-  ref="$(container_ref)"
+  if ! ref="$(container_ref)"; then
+    return 0
+  fi
   docker rm -f "$ref" >/dev/null 2>&1 || true
   for attempt in 1 2 3; do
     if ! docker inspect "$ref" >/dev/null 2>&1; then
@@ -150,6 +166,7 @@ docker run --rm \
   --label io.mobius.probe=true \
   --label "io.mobius.probe.started_at=$started_at" \
   --label "io.mobius.probe.owner_pid=$$" \
+  --label "io.mobius.probe.owner_token=$OWNER_TOKEN" \
   "$@" <&0 &
 CLIENT_PID="$!"
 

--- a/scripts/preship-gate.sh
+++ b/scripts/preship-gate.sh
@@ -87,7 +87,8 @@ fi
 echo "  ok — $(grep -oE '[0-9]+ passed' /tmp/preship-pytest.log | tail -1)"
 
 echo "[5/5] frontend build (Node 24) + offline-build check"
-docker run --rm -v "$PWD/frontend":/app -w /app node:24-slim sh -c \
+"$PWD/scripts/docker-probe.sh" --timeout 900 -- \
+  -v "$PWD/frontend":/app -w /app node:24-slim sh -c \
   "npm install --no-audit --no-fund >/tmp/preship-npm.log 2>&1 && \
    npm run build >/tmp/preship-build.log 2>&1 && \
    node scripts/check-offline-build.mjs" >/tmp/preship-fe.log 2>&1 \

--- a/scripts/test-docker-probe.sh
+++ b/scripts/test-docker-probe.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Real-Docker regression for the timeout path. Requires mobius-test:ci.
+
+set -euo pipefail
+
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)"
+name="mobius-probe-regression-$$"
+
+cleanup() {
+  docker rm -f "$name" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+set +e
+"$ROOT/scripts/docker-probe.sh" --timeout 2 --name "$name" -- \
+  -i --entrypoint python mobius-test:ci -u - <<'PY'
+import time
+
+print("probe-started", flush=True)
+time.sleep(60)
+PY
+rc="$?"
+set -e
+
+if [ "$rc" -ne 124 ]; then
+  echo "expected timeout exit 124, got $rc" >&2
+  exit 1
+fi
+if docker inspect "$name" >/dev/null 2>&1; then
+  echo "timed probe left container $name behind" >&2
+  exit 1
+fi
+if python3 - "$name" <<'PY'
+import os
+import sys
+
+needle = sys.argv[1].encode()
+for entry in os.scandir("/proc"):
+  if not entry.name.isdigit():
+    continue
+  try:
+    cmdline = open(f"/proc/{entry.name}/cmdline", "rb").read()
+  except OSError:
+    continue
+  if cmdline.startswith(b"docker\0run\0") and needle in cmdline:
+    raise SystemExit(0)
+raise SystemExit(1)
+PY
+then
+  echo "timed probe left its Docker client behind" >&2
+  exit 1
+fi
+
+echo "docker probe cleanup regression: PASS"

--- a/scripts/test-docker-probe.sh
+++ b/scripts/test-docker-probe.sh
@@ -5,9 +5,14 @@ set -euo pipefail
 
 ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)"
 name="mobius-probe-regression-$$"
+collision_name="${name}-collision"
+collision_id=""
 
 cleanup() {
   docker rm -f "$name" >/dev/null 2>&1 || true
+  if [ -n "$collision_id" ]; then
+    docker rm -f "$collision_id" >/dev/null 2>&1 || true
+  fi
 }
 trap cleanup EXIT
 
@@ -50,5 +55,26 @@ then
   echo "timed probe left its Docker client behind" >&2
   exit 1
 fi
+
+collision_id=$(
+  docker create --name "$collision_name" \
+    --entrypoint python mobius-test:ci \
+    -c 'import time; time.sleep(60)'
+)
+set +e
+"$ROOT/scripts/docker-probe.sh" --timeout 2 --name "$collision_name" -- \
+  --entrypoint true mobius-test:ci >/dev/null 2>&1
+collision_rc="$?"
+set -e
+if [ "$collision_rc" -ne 125 ]; then
+  echo "expected Docker name-conflict exit 125, got $collision_rc" >&2
+  exit 1
+fi
+if ! docker inspect "$collision_id" >/dev/null 2>&1; then
+  echo "probe removed a pre-existing container after a name conflict" >&2
+  exit 1
+fi
+docker rm -f "$collision_id" >/dev/null
+collision_id=""
 
 echo "docker probe cleanup regression: PASS"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -74,7 +74,8 @@ check_backend_prereqs() {
 
   local expected actual
   expected="$("${PROJECT_DIR}/scripts/test-image-fingerprint.sh")"
-  actual="$(docker run --rm --entrypoint sh "${TEST_IMAGE}" -c \
+  actual="$("${PROJECT_DIR}/scripts/docker-probe.sh" --timeout 15 -- \
+    --entrypoint sh "${TEST_IMAGE}" -c \
     'test -r /app/test-image-fingerprint && cat /app/test-image-fingerprint' \
     2>/dev/null || true)"
   if [ "${actual}" != "${expected}" ]; then


### PR DESCRIPTION
## Summary

- add one small `docker-probe.sh` lifecycle wrapper that assigns an exact name/cidfile, enforces a deadline, verifies per-invocation ownership before name fallback, removes only that daemon-side container, and verifies disappearance
- keep a deadline watchdog alive if the wrapper itself is killed; label active probes and expose a lightweight `--list` view with age, CPU, and memory
- route the repository’s direct CI/test/preship `docker run` probes through the helper
- add a real regression that hangs stdin-driven Python and proves both the container and Docker client are gone

This does not scan or prune unrelated Docker workloads and has no standing runtime cost.

## Validation

- `scripts/test-docker-probe.sh`
- `docker compose -p mobius-test-issue-150 -f docker-compose.test.yml run --rm --no-deps --entrypoint python pytest -m pytest -q tests/test_docker_probe.py tests/test_verify_test_runtime.py` (24 passed)
- manual TERM, wrapper-SIGKILL, and pre-existing-name collision lifecycle probes
- `bash -n` for all changed shell scripts

Closes #150