### PR TITLE
Continue eligible chats after authenticated planned restarts

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -687,6 +687,37 @@ pins. Reservation lifetime and pin decisions are independent.
 - **Regression guards (owner-observed prod bugs):** an at-bottom send must not land
   mid-viewport; a steered row must not render after the agent's reply.
 
+### Automatic continuation after limits and planned restarts
+
+Automatic continuation reuses one durable transition. Provider-limit exits mark
+their exact `ChatRun` as `parked` until the parsed reset time; a planned restart
+that successfully stops a live handle marks that exact run `parked` with
+`park_reason="restart"` and a due time of now, before SIGTERM. The next process
+runs the same due-park sweep immediately. There is no restart ledger and startup
+never infers intent from transcript text.
+
+| Event | Durable result | Boot/sweep result |
+|-------|----------------|-------------------|
+| Provider usage/rate limit | exact run `parked` until reset | notify; continue if the chat policy is on |
+| Planned restart, handle stopped and exact transition committed | exact run `parked`, reason `restart`, due now | continue immediately if eligible |
+| Crash, stuck handle, missing exact token, or failed park commit | generic `running` evidence remains | reconcile to a manual resumable interruption |
+| Policy off, unanswered question, app-owned run, or app-queued work | due park resolves without an automatic send | notify/manual owner action |
+| Owner sends, switches provider, deletes the chat, or a newer run wins | old park is superseded by the existing latest-run fence | no stale continuation |
+
+Eligibility is rechecked under the per-chat transition lock immediately before
+promotion, and the global idle gate permits only one automatic turn at a time.
+The provider still receives a synthetic user `continue`, but the durable row is
+tagged `kind="auto_continuation"` with reason `restart` or `usage_limit`; the UI,
+copy behavior, title selection, time context, compaction, provider-switch
+handoff, chat-note summarization, and redacted chat logs treat it as a product
+marker rather than owner speech.
+
+The sweep is cheap: one indexed due-row query immediately at boot, on
+`chat_run_finished`, and on a 60-second fallback. It does not create per-chat
+workers or poll at a short interval. The shared chat-local policy retains its
+legacy wire name `auto_resume_on_limit` for compatibility, while product copy
+states that it covers both limits and restarts.
+
 ### Tool output rendering
 
 Tool runs are **grouped** so the reader sees at a glance what is running vs finished

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -689,20 +689,32 @@ pins. Reservation lifetime and pin decisions are independent.
 
 ### Automatic continuation after limits and planned restarts
 
-Automatic continuation reuses one durable transition. Provider-limit exits mark
-their exact `ChatRun` as `parked` until the parsed reset time; a planned restart
-that successfully stops a live handle marks that exact run `parked` with
-`park_reason="restart"` and a due time of now, before SIGTERM. The next process
-runs the same due-park sweep immediately. There is no restart ledger and startup
-never infers intent from transcript text.
+Automatic continuation reuses one durable run transition but has two separate
+consent and cause boundaries. Provider-limit exits mark their exact `ChatRun` as
+`parked` until the parsed reset time. A planned restart creates a fresh nonce,
+stops and finalizes each exact live run, and parks it due-now with that nonce.
+The platform process then publishes an intent and restart request; it does not
+terminate itself on the normal path.
+
+The frozen root-owned entrypoint poller validates and consumes the request,
+records the exact `(chat_id, run_id, nonce)` set in `/data/.restart-ledger`, and
+only then terminates pid 1. At the very start of the next entrypoint invocation,
+the ledger binds that accepted intent to the new `MOBIUS_BOOT_ID`. The app only
+continues a restart park when this root-owned acknowledgement, the exact DB run
+and nonce, and the separately stored restart policy all match. An intent that
+was merely written before a crash/OOM, an acknowledgement skipped by a failed
+handshake, or an acknowledgement left across another boot authorizes nothing.
+Transcript text is presentation, never restart-cause evidence.
 
 | Event | Durable result | Boot/sweep result |
 |-------|----------------|-------------------|
 | Provider usage/rate limit | exact run `parked` until reset | notify; continue if the chat policy is on |
-| Planned restart, handle stopped and exact transition committed | exact run `parked`, reason `restart`, due now | continue immediately if eligible |
-| Crash, stuck handle, missing exact token, or failed park commit | generic `running` evidence remains | reconcile to a manual resumable interruption |
+| Accepted planned restart, exact park + ledger tuple match | exact run `parked`, reason `restart`, nonce, due now | continue immediately if separate restart consent is on |
+| Crash/OOM before supervisor acknowledgement | unacknowledged park or generic `running` evidence | resolve/reconcile to manual resumable interruption |
+| Repeated/unrelated boot before claim | acknowledgement is retired by boot-id mismatch | manual resumable interruption |
 | Policy off, unanswered question, app-owned run, or app-queued work | due park resolves without an automatic send | notify/manual owner action |
 | Owner sends, switches provider, deletes the chat, or a newer run wins | old park is superseded by the existing latest-run fence | no stale continuation |
+| Restart task creation fails after promotion | exact promoted rows roll back; restart park becomes `interrupted` | manual recovery; one-shot cause is not retried |
 
 Eligibility is rechecked under the per-chat transition lock immediately before
 promotion, and the global idle gate permits only one automatic turn at a time.
@@ -713,10 +725,12 @@ handoff, chat-note summarization, and redacted chat logs treat it as a product
 marker rather than owner speech.
 
 The sweep is cheap: one indexed due-row query immediately at boot, on
-`chat_run_finished`, and on a 60-second fallback. It does not create per-chat
-workers or poll at a short interval. The shared chat-local policy retains its
-legacy wire name `auto_resume_on_limit` for compatibility, while product copy
-states that it covers both limits and restarts.
+`chat_run_finished`, and on a 60-second fallback, plus one bounded local ledger
+read when due rows exist. It does not create per-chat workers or poll at a short
+interval. `auto_resume_on_limit` keeps its legacy initial default of on.
+`auto_resume_on_restart` is a separate chat-local preference and migrates
+existing chats and owners to off; enabling it is explicit consent and only
+seeds future chats without rewriting existing conversations.
 
 ### Tool output rendering
 

--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -1003,6 +1003,34 @@ def _parked_until_for_chat(
   return None
 
 
+def _restart_manual_hold_for_chat(db: Session, chat_id: str) -> bool:
+  """Whether the latest run retired to manual restart recovery.
+
+  ResolvePark and a one-shot task-creation rollback deliberately leave restart
+  history as ``interrupted``. Pending owner rows must remain intact, but the
+  generic stale-pending sweeper must not turn that manual outcome back into an
+  unauthenticated automatic continuation. A new owner send/Resume inserts a
+  newer run and naturally releases this latest-run hold.
+  """
+  try:
+    run = (
+      db.query(models.ChatRun.status, models.ChatRun.park_reason)
+      .filter(models.ChatRun.chat_id == chat_id)
+      .order_by(
+        models.ChatRun.started_at.desc(),
+        models.ChatRun.id.desc(),
+      )
+      .first()
+    )
+  except Exception:
+    return True  # Fail closed: a DB probe failure cannot authorize replay.
+  return bool(
+    run is not None
+    and run[0] == "interrupted"
+    and run[1] == "restart"
+  )
+
+
 def _is_future_park(
   parked_until: datetime | None,
   now: datetime | None = None,
@@ -1722,6 +1750,8 @@ async def sweep_idle_pending_chats(db: Session) -> list[str]:
     # distinguish "crashed drain" from "parked on purpose".
     if _parked_until_for_chat(db, chat.id) is not None:
       continue
+    if _restart_manual_hold_for_chat(db, chat.id):
+      continue
     claimed = False
     try:
       async with asyncio.timeout(chat_queue.TERMINAL_LOCK_TIMEOUT_SECS):
@@ -1733,6 +1763,7 @@ async def sweep_idle_pending_chats(db: Session) -> list[str]:
               chat.run_status is not None
               or not _pending_head_is_stale(pending, now_ms)
               or _parked_until_for_chat(db, chat.id) is not None
+              or _restart_manual_hold_for_chat(db, chat.id)
               or not mark_starting(chat.id)
             ):
               continue
@@ -1876,7 +1907,11 @@ async def sweep_stalled_live_runs(db: Session) -> list[str]:
   return interrupted
 
 
-async def drain_all_for_restart(timeout: float = DRAIN_TIMEOUT) -> list[str]:
+async def drain_all_for_restart(
+  timeout: float = DRAIN_TIMEOUT,
+  *,
+  restart_nonce: str = "",
+) -> list[dict[str, str]]:
   """Interrupt every live turn for a graceful restart, preserving queues.
 
   This is the DrainForRestart path from design §2.2 — distinct from
@@ -1912,11 +1947,12 @@ async def drain_all_for_restart(timeout: float = DRAIN_TIMEOUT) -> list[str]:
   stops run serially at up to 2s each, so with many concurrent live turns the
   tail may not drain before the backstop — accepted for the single-owner
   reality (a handful of turns at most); parallelize the stops before this
-  assumption breaks. Returns the chat ids it interrupted cleanly.
+  assumption breaks. Returns only the exact chat/run pairs that finalized and
+  parked successfully; the restart supervisor binds precisely that set.
   """
   begin_drain()
   log = _get_logger()
-  drained: list[str] = []
+  parked_runs: list[dict[str, str]] = []
   # `resumable` rides the event LIVE (events.process_event carries the
   # whitelisted extras onto the persisted block), so a drained turn's manual
   # Resume fallback renders immediately. The exact ChatRun transition below,
@@ -1966,17 +2002,36 @@ async def drain_all_for_restart(timeout: float = DRAIN_TIMEOUT) -> list[str]:
       if not stopped:
         all_interrupted = False
     if all_interrupted:
-      drained.append(chat_id)
       run_token = sink.run_token if sink is not None else None
-      if run_token:
+      # Own the terminal snapshot fence here instead of assuming the runner's
+      # teardown won the scheduling race. This force-completes running tool
+      # blocks/thinking sidecars before ParkRun clears the generic boot-reconcile
+      # marker. A failed Finalize leaves that marker intact for manual recovery.
+      if sink is not None:
+        try:
+          await sink.finalize()
+        except Exception:
+          log.warning(
+            "drain-for-restart terminal snapshot failed; leaving manual "
+            "recovery chat_id=%s run_token=%s",
+            chat_id, run_token, exc_info=True,
+          )
+          continue
+      if run_token and restart_nonce:
         try:
           parked = await _park_run_strict(
             chat_id,
             run_token,
             datetime.now(UTC).replace(tzinfo=None),
             "restart",
+            restart_nonce=restart_nonce,
           )
-          if not parked:
+          if parked:
+            parked_runs.append({
+              "chat_id": chat_id,
+              "run_token": run_token,
+            })
+          else:
             log.warning(
               "drain-for-restart could not park exact run; leaving manual "
               "recovery chat_id=%s run_token=%s",
@@ -1995,9 +2050,9 @@ async def drain_all_for_restart(timeout: float = DRAIN_TIMEOUT) -> list[str]:
           )
       else:
         log.warning(
-          "drain-for-restart has no exact run token; leaving manual recovery "
-          "chat_id=%s",
-          chat_id,
+          "drain-for-restart has no exact run token/nonce; leaving manual "
+          "recovery chat_id=%s run_token=%s",
+          chat_id, run_token,
         )
   # Flush the writer so every paused note (the sink's fire-and-forget
   # PersistError above) is durably committed before the worker restarts.
@@ -2006,12 +2061,13 @@ async def drain_all_for_restart(timeout: float = DRAIN_TIMEOUT) -> list[str]:
     await _await_ack(ack, timeout=min(timeout, 10.0))
   except Exception:
     log.warning("drain-for-restart writer flush failed", exc_info=True)
-  if drained:
+  if parked_runs:
     log.info(
-      "drain-for-restart interrupted %d turn(s): %s",
-      len(drained), ", ".join(drained),
+      "drain-for-restart parked %d exact turn(s): %s",
+      len(parked_runs),
+      ", ".join(item["chat_id"] for item in parked_runs),
     )
-  return drained
+  return parked_runs
 
 
 # One-shot notify copy for a limit park whose reset time has arrived
@@ -2129,10 +2185,26 @@ async def _auto_resume_chat(
               .first()
             )
             latest_id = latest[0] if latest is not None else None
+            restart_authorized = True
+            if park is not None and park.park_reason == "restart":
+              from app.restart_ledger import authorized_runs
+              restart_authorized = (
+                authorized_runs().get(park.id)
+                == (chat_id, park.restart_nonce)
+              )
+            policy_enabled = bool(
+              chat is not None
+              and (
+                chat.auto_resume_on_restart
+                if park is not None and park.park_reason == "restart"
+                else chat.auto_resume_on_limit
+              )
+            )
             if (
               chat is None
               or chat.deleted_at is not None
-              or not chat.auto_resume_on_limit
+              or not policy_enabled
+              or not restart_authorized
               or _has_unanswered_question(chat)
               or park is None
               or park.status != "resume_pending"
@@ -2207,6 +2279,7 @@ async def _auto_resume_chat(
                 promoted_pending=list(
                   next_user.get("_promoted_pending") or []
                 ),
+                retry_park=resume_reason != "restart",
               )
             ))
             if rolled_back:
@@ -2268,6 +2341,16 @@ async def sweep_reset_parks(db: Session) -> list[str]:
     return resolved
   if not due:
     return resolved
+  try:
+    from app.restart_ledger import authorized_runs
+    restart_authorizations = authorized_runs()
+  except Exception:
+    log.warning(
+      "sweep_reset_parks: restart ledger read failed; restart parks will "
+      "fall back to manual recovery",
+      exc_info=True,
+    )
+    restart_authorizations = {}
 
   def notify_due(chat_id: str, run: models.ChatRun) -> None:
     try:
@@ -2299,13 +2382,27 @@ async def sweep_reset_parks(db: Session) -> list[str]:
       isinstance(msg, dict) and msg.get("_initiated_by_app_id") is not None
       for msg in pending
     )
+    restart_park = run.park_reason == "restart"
+    policy_enabled = bool(
+      chat is not None
+      and (
+        chat.auto_resume_on_restart
+        if restart_park else chat.auto_resume_on_limit
+      )
+    )
+    restart_authorized = (
+      not restart_park
+      or restart_authorizations.get(run.id)
+      == (run.chat_id, run.restart_nonce)
+    )
     return bool(
       chat is not None
       and chat.deleted_at is None
       and run.initiated_by_app_id is None
       and not app_work_queued
       and not _has_unanswered_question(chat)
-      and chat.auto_resume_on_limit
+      and policy_enabled
+      and restart_authorized
     )
 
   auto_resume_started = False
@@ -3256,6 +3353,8 @@ async def _park_run_strict(
   run_token: str,
   parked_until: datetime,
   park_reason: str,
+  *,
+  restart_nonce: str = "",
 ) -> bool:
   """Park the run via the actor (commit-before-return); raises on failure.
 
@@ -3277,6 +3376,7 @@ async def _park_run_strict(
       run_token=run_token,
       parked_until=parked_until,
       park_reason=park_reason,
+      restart_nonce=restart_nonce,
     )
   )
   return bool(await _await_ack(ack))

--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -1483,6 +1483,7 @@ def reconcile_interrupted_chats(db: Session) -> list[str]:
       ):
         run.status = "interrupted"
         run.ended_at = datetime.now(UTC)
+        run.restart_nonce = None
       db.commit()
       reconciled.append(chat.id)
     except Exception:
@@ -1536,6 +1537,7 @@ def reconcile_interrupted_chats(db: Session) -> list[str]:
         continue
       run.status = "interrupted"
       run.ended_at = datetime.now(UTC)
+      run.restart_nonce = None
       closed += 1
     if closed:
       db.commit()
@@ -2112,7 +2114,7 @@ def _has_unanswered_question(chat: models.Chat | None) -> bool:
 async def _auto_resume_chat(
   chat_id: str, provider_id: str | None, park_token: str | None = None,
 ) -> bool:
-  """Start ONE continue turn for a limit-parked chat whose reset arrived.
+  """Start one continuation for an eligible due park.
 
   The opt-in half of design §2.4 — mirrors the stale-pending drain in
   chats_stream.send_message (the same claim → append → promote → schedule
@@ -2269,8 +2271,9 @@ async def _auto_resume_chat(
           )
           if scheduled is False:
             # PromotePending committed before task creation. Reverse only this
-            # exact speculative handoff while the queue lock is still held, so
-            # the original park and preserved queue remain retryable.
+            # exact speculative handoff while the queue lock is still held.
+            # Provider-limit parks remain retryable; one-shot restart parks
+            # retire to manual recovery while preserving the queue.
             rolled_back = await _await_ack(get_writer().submit(
               RollbackAutoResume(
                 chat_id=chat_id,

--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -801,8 +801,9 @@ STALLED_TURN_MESSAGE = (
 # interrupt (the stalled-live watchdog exempts it via `_stall_exemption`; the
 # wedged-marker sweep returns early). `_restart_draining_chats` records the chats
 # whose live turn the drain interrupted, so each turn's terminal transition
-# (run_chat's finally) LEAVES its run marker set (DRAINED_FOR_RESTART) instead of
-# clearing it — preserving it for boot reconcile + one-tap Resume.
+# (run_chat's finally) leaves its exact run intact long enough for the drain to
+# move it to the existing durable continuation state. If that transaction fails,
+# the still-set generic marker is deliberately left for manual boot recovery.
 draining = False
 _restart_draining_chats: set[str] = set()
 
@@ -1340,28 +1341,46 @@ def reconcile_interrupted_chats(db: Session) -> list[str]:
         # and persist the finalized tool-block state. Only the drain's exact
         # note text qualifies, so a live provider error never gets a spurious
         # Resume button here.
-        paused_idx = next(
-          (len(blocks) - 1 - i
-           for i, b in enumerate(reversed(blocks))
-           if b.get("type") == "error"
-           and b.get("message") == PAUSED_FOR_RESTART_MESSAGE),
-          None,
-        )
+        trailing_open_start = len(blocks)
+        while trailing_open_start > 0:
+          block = blocks[trailing_open_start - 1]
+          if block.get("type") != "question" or block.get("answers"):
+            break
+          trailing_open_start -= 1
+        # Display text is never enough to prove planned-restart intent. It is
+        # used here only to avoid duplicating the terminal note for a generic
+        # marker fallback, so accept it solely at the actual tail or directly
+        # before trailing unanswered questions. A historical restart note with
+        # later output must not mask a newer crash.
+        candidate_indices = [len(blocks) - 1]
+        if trailing_open_start < len(blocks):
+          candidate_indices.append(trailing_open_start - 1)
+        paused_idx = next((
+          idx for idx in candidate_indices
+          if idx >= 0
+          and blocks[idx].get("type") == "error"
+          and blocks[idx].get("message") == PAUSED_FOR_RESTART_MESSAGE
+        ), None)
         if paused_idx is not None:
-          # The drain wrote the terminal note; just make it resumable — and
-          # carry `pause` so a note persisted before the descriptor existed
-          # (or one whose live event never landed) still renders in the calm
-          # "Paused" family — then fall through to the shared write-back below
-          # (no second note appended). Replace with a FRESH dict rather than
-          # mutating the ORM-loaded block in place: `Chat.messages` is a plain
-          # JSON column with no mutation tracking, so an in-place edit to a
-          # loaded block is not flushed — only a genuinely new value in the
-          # reassigned list persists (every other reconcile branch appends a
-          # fresh block for the same reason).
-          blocks[paused_idx] = {
-            **blocks[paused_idx], "resumable": True,
-            "pause": {"kind": "restart"},
-          }
+          # Normalize both historical orderings around an open question. The
+          # drain marker belongs immediately BEFORE a trailing unanswered
+          # question so the card remains the tail affordance; in that shape it
+          # must not also offer Resume. With no question, the marker itself is
+          # the recovery affordance and remains resumable.
+          paused = dict(blocks.pop(paused_idx))
+          trailing_open_start = len(blocks)
+          while trailing_open_start > 0:
+            block = blocks[trailing_open_start - 1]
+            if block.get("type") != "question" or block.get("answers"):
+              break
+            trailing_open_start -= 1
+          paused["pause"] = {"kind": "restart"}
+          if trailing_open_start < len(blocks):
+            paused.pop("resumable", None)
+            blocks.insert(trailing_open_start, paused)
+          else:
+            paused["resumable"] = True
+            blocks.insert(min(paused_idx, len(blocks)), paused)
         else:
           # Preserve a tail unanswered question. It is a durable human handoff,
           # not a disposable in-memory callback: the route can record the later
@@ -1863,7 +1882,8 @@ async def drain_all_for_restart(timeout: float = DRAIN_TIMEOUT) -> list[str]:
   This is the DrainForRestart path from design §2.2 — distinct from
   `stop_chat_for`, which intentionally COLLAPSES the pending queue. A restart
   must NEVER touch `pending_messages`: every queued send is preserved and
-  self-heals on the owner's next action after the reboot.
+  joins the same continuation when an exact planned-restart park commits, or
+  remains available for the owner's next action on the manual fallback path.
 
   Sets the `draining` gate first (idempotent) so a send arriving mid-drain
   queues rather than starting, and both liveness sweeps stand down. Then, for
@@ -1878,13 +1898,17 @@ async def drain_all_for_restart(timeout: float = DRAIN_TIMEOUT) -> list[str]:
     - mirrors the stalled-live watchdog's clean-interrupt handoff — bump the
       generation so the turn-end drain sees a stale generation and does NOT
       promote the queue — BUT records the chat in `_restart_draining_chats` so
-      the turn's finally LEAVES the durable run marker set (DRAINED_FOR_RESTART)
-      instead of clearing it. The preserved marker is what boot reconcile
-      finalizes and what the one-tap Resume affordance keys on.
+      the turn's finally does not clear the exact run before this drain can
+      transition it. After every handle stops, the same writer transaction used
+      by provider-limit recovery moves that exact run to ``parked`` with
+      ``park_reason='restart'`` and a due time of now. Startup therefore sees an
+      authoritative continuation signal instead of guessing from transcript
+      text. If that transition cannot commit, the generic run marker remains for
+      manual crash reconciliation.
 
   Best-effort and bounded: a handle that won't interrupt in time keeps today's
   contract — the restart utility's SIGKILL backstop kills the worker and boot
-  reconcile finalizes the marker (still with the resume affordance). Handle
+  reconcile finalizes the marker for manual Resume. Handle
   stops run serially at up to 2s each, so with many concurrent live turns the
   tail may not drain before the backstop — accepted for the single-owner
   reality (a handful of turns at most); parallelize the stops before this
@@ -1894,9 +1918,9 @@ async def drain_all_for_restart(timeout: float = DRAIN_TIMEOUT) -> list[str]:
   log = _get_logger()
   drained: list[str] = []
   # `resumable` rides the event LIVE (events.process_event carries the
-  # whitelisted extras onto the persisted block), so a drained turn's Resume
-  # button renders immediately; boot reconcile's text-keyed marking stays as
-  # the crash-path fallback for a note that never made it through the sink.
+  # whitelisted extras onto the persisted block), so a drained turn's manual
+  # Resume fallback renders immediately. The exact ChatRun transition below,
+  # not this display block, is the authority for automatic continuation.
   # A drain-gated restart is a benign maintenance pause; `pause.kind='restart'`
   # lets the card render in the calm "Paused" family instead of the danger-red
   # error styling reserved for genuine failures.
@@ -1943,6 +1967,38 @@ async def drain_all_for_restart(timeout: float = DRAIN_TIMEOUT) -> list[str]:
         all_interrupted = False
     if all_interrupted:
       drained.append(chat_id)
+      run_token = sink.run_token if sink is not None else None
+      if run_token:
+        try:
+          parked = await _park_run_strict(
+            chat_id,
+            run_token,
+            datetime.now(UTC).replace(tzinfo=None),
+            "restart",
+          )
+          if not parked:
+            log.warning(
+              "drain-for-restart could not park exact run; leaving manual "
+              "recovery chat_id=%s run_token=%s",
+              chat_id,
+              run_token,
+            )
+        except Exception:
+          # Restart must still proceed. ParkRun is transactional; on failure
+          # the generic running marker remains for safe manual reconciliation.
+          log.warning(
+            "drain-for-restart park failed; leaving manual recovery "
+            "chat_id=%s run_token=%s",
+            chat_id,
+            run_token,
+            exc_info=True,
+          )
+      else:
+        log.warning(
+          "drain-for-restart has no exact run token; leaving manual recovery "
+          "chat_id=%s",
+          chat_id,
+        )
   # Flush the writer so every paused note (the sink's fire-and-forget
   # PersistError above) is durably committed before the worker restarts.
   try:
@@ -1962,6 +2018,39 @@ async def drain_all_for_restart(timeout: float = DRAIN_TIMEOUT) -> list[str]:
 # (design §2.4 step "at parked_until, push-notify").
 LIMIT_RESET_NOTIFY_TITLE = "Your limit has reset"
 LIMIT_RESET_NOTIFY_BODY = "Your limit has reset."
+
+
+def _has_unanswered_question(chat: models.Chat | None) -> bool:
+  """Whether the durable tail is waiting for an owner answer.
+
+  A restart pause is appended after the question while draining, so ignore that
+  one product-owned tail block before applying the same tail-question invariant
+  as the transcript UI. This is read-only and bounded to the latest assistant
+  row; it never scans tool output or historical questions.
+  """
+  if chat is None:
+    return False
+  try:
+    from app.chat_transcript import materialized_messages
+    messages = materialized_messages(chat)
+  except Exception:
+    messages = list(chat.messages or [])
+  if not messages or messages[-1].get("role") != "assistant":
+    return False
+  blocks = list(messages[-1].get("blocks") or [])
+  while blocks:
+    tail = blocks[-1]
+    if not (
+      tail.get("type") == "error"
+      and (tail.get("pause") or {}).get("kind") == "restart"
+    ):
+      break
+    blocks.pop()
+  return bool(
+    blocks
+    and blocks[-1].get("type") == "question"
+    and not blocks[-1].get("answers")
+  )
 
 
 async def _auto_resume_chat(
@@ -2044,8 +2133,10 @@ async def _auto_resume_chat(
               chat is None
               or chat.deleted_at is not None
               or not chat.auto_resume_on_limit
+              or _has_unanswered_question(chat)
               or park is None
               or park.status != "resume_pending"
+              or park.initiated_by_app_id is not None
               or latest_id != park.id
               or any(
                 isinstance(msg, dict)
@@ -2055,6 +2146,9 @@ async def _auto_resume_chat(
             ):
               return False
             current_provider = chat.provider or "claude"
+            resume_reason = (
+              "restart" if park.park_reason == "restart" else "usage_limit"
+            )
           if not mark_starting(chat_id):
             return False
           claimed = True
@@ -2066,9 +2160,15 @@ async def _auto_resume_chat(
                 "role": "user",
                 "content": "continue",
                 "ts": int(time.time() * 1000),
+                "kind": "auto_continuation",
+                "continuation_reason": resume_reason,
                 # A retry after AppendPending succeeded but a later step failed
                 # must not enqueue a second synthetic continuation.
-                "cid": f"limit-resume-{park_token or chat_id}",
+                "cid": (
+                  f"restart-resume-{park_token or chat_id}"
+                  if resume_reason == "restart"
+                  else f"limit-resume-{park_token or chat_id}"
+                ),
               },
             )
           )
@@ -2124,12 +2224,14 @@ async def _auto_resume_chat(
 
 
 async def sweep_reset_parks(db: Session) -> list[str]:
-  """Notify (and optionally auto-resume) limit-parked chats at reset time.
+  """Notify and optionally continue due durable recovery rows.
 
   The third lifespan sweep (same 60s loop shape as the wedged-marker and
   stalled-live sweeps). A due park is a `chat_runs` row still
   ``status`` is ``parked`` or ``resume_pending`` and whose
-  `parked_until` has passed. For each, oldest reset first:
+  `parked_until` has passed. Provider limits use their reset time; a planned
+  restart is parked by the drain itself with a due time of now. For each,
+  oldest due row first:
 
     - Notify-only parks resolve first, then send one best-effort notification.
     - Auto-resume parks first become ``resume_pending``. That durable
@@ -2144,8 +2246,8 @@ async def sweep_reset_parks(db: Session) -> list[str]:
       chats in the same due batch still resolve normally. App-attributed runs
       and queues never auto-resume.
 
-  Stands down while draining — a restart is in progress, and the boot
-  reconcile + this sweep's next tick pick everything up. Never raises.
+  Stands down while draining — a restart is in progress, and the fresh
+  process's immediate sweep picks everything up. Never raises.
   """
   log = _get_logger()
   resolved: list[str] = []
@@ -2167,23 +2269,28 @@ async def sweep_reset_parks(db: Session) -> list[str]:
   if not due:
     return resolved
 
-  def notify_reset(chat_id: str) -> None:
+  def notify_due(chat_id: str, run: models.ChatRun) -> None:
     try:
       owner = db.query(models.Owner).first()
       if owner is not None:
         from app import push
+        restarted = run.park_reason == "restart"
         push.notify_owner(
           db,
           owner.id,
-          title=LIMIT_RESET_NOTIFY_TITLE,
-          body=LIMIT_RESET_NOTIFY_BODY,
+          title=("Möbius restarted" if restarted else LIMIT_RESET_NOTIFY_TITLE),
+          body=(
+            "Your paused turn is ready."
+            if restarted
+            else LIMIT_RESET_NOTIFY_BODY
+          ),
           source_type="system",
           source_id=chat_id,
           target=f"/shell/?chat={chat_id}",
         )
     except Exception:
       log.warning(
-        "limit-reset notify failed chat_id=%s", chat_id, exc_info=True,
+        "continuation notify failed chat_id=%s", chat_id, exc_info=True,
       )
 
   def wants_auto_resume(chat, run) -> bool:
@@ -2197,6 +2304,7 @@ async def sweep_reset_parks(db: Session) -> list[str]:
       and chat.deleted_at is None
       and run.initiated_by_app_id is None
       and not app_work_queued
+      and not _has_unanswered_question(chat)
       and chat.auto_resume_on_limit
     )
 
@@ -2260,11 +2368,11 @@ async def sweep_reset_parks(db: Session) -> list[str]:
           continue
         resolved.append(chat_id)
         if prepared.get("notify") and not chat_gone:
-          notify_reset(chat_id)
+          notify_due(chat_id, run)
         continue
 
       if prepared.get("notify"):
-        notify_reset(chat_id)
+        notify_due(chat_id, run)
       if _any_chat_turn_active():
         # The notification or refresh window admitted another turn. Keep the
         # durable pending state so the next sweep retries instead of silently
@@ -2295,10 +2403,10 @@ async def sweep_reset_parks(db: Session) -> list[str]:
       continue
     resolved.append(chat_id)
     if should_notify and not chat_gone:
-      notify_reset(chat_id)
+      notify_due(chat_id, run)
   if resolved:
     log.info(
-      "limit-reset sweep resolved %d park(s): %s",
+      "continuation sweep resolved %d park(s): %s",
       len(resolved), ", ".join(resolved),
     )
   return resolved
@@ -3148,10 +3256,10 @@ async def _park_run_strict(
   run_token: str,
   parked_until: datetime,
   park_reason: str,
-) -> None:
+) -> bool:
   """Park the run via the actor (commit-before-return); raises on failure.
 
-  The limit-exit sibling of `_clear_run_status_strict`: same await-the-ack
+  The continuation sibling of `_clear_run_status_strict`: same await-the-ack
   discipline, same identity-keyed ownership inside the actor. A tokenless
   caller (legacy/test paths with no per-run row) degrades to the plain
   marker clear — there is no row to park on, so the chat keeps today's
@@ -3159,10 +3267,10 @@ async def _park_run_strict(
   notify-at-reset upgrade.
   """
   if not chat_id:
-    return
+    return False
   if not run_token:
     await _clear_run_status_strict(chat_id, "")
-    return
+    return False
   ack = get_writer().submit(
     ParkRun(
       chat_id=chat_id,
@@ -3171,7 +3279,7 @@ async def _park_run_strict(
       park_reason=park_reason,
     )
   )
-  await _await_ack(ack)
+  return bool(await _await_ack(ack))
 
 
 def _limit_exit(
@@ -3423,10 +3531,12 @@ async def _complete_turn(
       # lock can't burn it.
       async with asyncio.timeout(chat_queue.TERMINAL_LOCK_TIMEOUT_SECS):
         async with chat_queue.get_lock(chat_id):
-          await _park_run_strict(
+          parked = await _park_run_strict(
             chat_id, sink.run_token or "",
             parked_until, park_reason or "rate_limit",
           )
+          if not parked:
+            raise RuntimeError("exact limit run was not parked")
           # Release the send's `_starting` claim NOW, under the same lock —
           # not in run_chat's finally. The limit path skips drain_and_release
           # (which releases the claim for every other terminal), so without
@@ -3603,9 +3713,14 @@ def _last_user_message_elapsed(db, chat_id: str) -> str | None:
     msgs = (chat.messages if chat else None) or []
     now_ms = _time.time() * 1000.0
     for m in reversed(msgs[:-1]):  # skip the current (just-committed) message
-      # Only USER messages count — the label is "user's last message", and
-      # assistant rows would otherwise report the gap since the agent spoke.
-      if not isinstance(m, dict) or m.get("role") != "user":
+      # Only owner-authored USER messages count. Product-owned automatic
+      # continuation rows retain role=user for provider history but must not
+      # reset the owner's recency clock.
+      if (
+        not isinstance(m, dict)
+        or m.get("role") != "user"
+        or m.get("kind") == "auto_continuation"
+      ):
         continue
       ts = m.get("ts")
       if not isinstance(ts, (int, float)) or ts <= 0:
@@ -3947,7 +4062,11 @@ def _build_resumed_context(chat_row) -> str | None:
     content = msg.get("content")
     if not isinstance(content, str) or not content.strip():
       continue
-    speaker = "User" if role == "user" else "Assistant"
+    if msg.get("kind") == "auto_continuation":
+      reason = msg.get("continuation_reason") or "automatic recovery"
+      speaker = f"Automatic continuation ({reason})"
+    else:
+      speaker = "User" if role == "user" else "Assistant"
     line = f"{speaker}: {content.strip()}"
     if used + len(line) > _RESUME_CONTEXT_CHAR_BUDGET and lines:
       break
@@ -4079,14 +4198,13 @@ async def run_chat(
     if chat_id and clear_stopped_run and run_gen is not None:
       if chat_id in _restart_draining_chats:
         # Drain-for-restart handoff: this turn was interrupted for a graceful
-        # restart. LEAVE the durable run marker set (and the pending queue
-        # intact) so boot reconcile finalizes it and the one-tap Resume works —
-        # the deliberate difference from a Stop handoff, which CLEARS the marker
-        # in the else-branch below. `_complete_turn` already finalized the
-        # partials + the paused note above (stop-handoff-successor path); no
-        # queue was promoted (the bumped generation made the turn-end drain read
-        # STALE_NO_ACTION). Discard the per-chat flag so a hypothetical surviving
-        # process can't mis-tag a later turn.
+        # restart. Leave the exact running row and pending queue intact so
+        # drain_all_for_restart can move that row to the durable due-restart
+        # state after every handle reports stopped. The deliberate difference
+        # from Stop is that the else-branch below clears the exact row instead.
+        # `_complete_turn` already finalized the partials + paused note; the
+        # bumped generation prevented queue promotion. Discard the in-memory
+        # handoff flag once this dying wrapper has observed it.
         _restart_draining_chats.discard(chat_id)
         disposition = chat_queue.TerminalDisposition.DRAINED_FOR_RESTART
       else:

--- a/backend/app/chat_log_redaction.py
+++ b/backend/app/chat_log_redaction.py
@@ -163,6 +163,12 @@ def redact_message(msg: dict) -> dict | None:
     return None
   if msg.get("hidden"):
     return None
+  if msg.get("kind") == "auto_continuation":
+    reason = str(msg.get("continuation_reason") or "automatic recovery")
+    return {
+      "role": "system",
+      "text": f"Automatic continuation ({reason}).",
+    }
   role = msg.get("role")
   if role == "assistant":
     text = _assistant_text(msg.get("blocks") or [], msg.get("content", ""))

--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -518,15 +518,16 @@ class ClearRunStatus(_Command):
 
 @dataclass
 class ParkRun(_Command):
-  """Park a turn that died on a provider rate/usage limit (design §2.4).
+  """Park a turn for a due continuation (design §2.4).
 
   The identity-keyed sibling of `ClearRunStatus` for the limit exit: the
   turn is over, so the per-chat marker (`Chat.run_status`) is cleared the
   same way — but instead of closing the run's `chat_runs` row "completed",
-  the row moves to ``status="parked"`` carrying `parked_until` (the parsed
-  reset time, naive UTC) and `park_reason`. That parked row IS the
-  provider-parked signal the liveness exemptions and the reset sweep read;
-  no separate state enum exists. Same ownership discipline as
+  the row moves to ``status="parked"`` carrying `parked_until` (the due time,
+  naive UTC) and `park_reason`. Provider limits use their parsed reset time;
+  a successfully drained planned restart uses ``park_reason="restart"`` and
+  a due time of now. That parked row IS the durable continuation signal; no
+  separate state enum exists. Same ownership discipline as
   ClearRunStatus: a dying run whose marker was taken by a fresh turn still
   closes its OWN row (as "completed", NOT parked — the owner already moved
   on, so a stale park must not resurrect a notify) but leaves the fresh
@@ -541,12 +542,13 @@ class ParkRun(_Command):
 
 @dataclass
 class ResolvePark(_Command):
-  """Move a parked/pending run to ``parked_notified``.
+  """Resolve a parked/pending run without starting a continuation.
 
   Submitted by the reset sweep AFTER `parked_until` elapses. Notify-only
   parks resolve before their at-most-once push attempt; auto-resume parks first
   pass through PrepareAutoResume so retries remain selectable without
-  re-notifying.
+  re-notifying. Provider parks become ``parked_notified``; restart parks become
+  ordinary ``interrupted`` history.
   Not identity-keyed against `_run_token_owner`: the parked turn ended long
   ago and ParkRun already dropped its ownership entry. Idempotent — a row
   no longer parked is a no-op.
@@ -2464,7 +2466,7 @@ class ChatWriterActor:
     return None
 
   def _park_run(self, db, cmd: ParkRun):
-    """Park the run's row on a provider limit + clear the per-chat marker.
+    """Park the run's row for continuation + clear the per-chat marker.
 
     Mirrors `_clear_run_status`'s ownership discipline exactly — the same
     identity-keyed compare against `_run_token_owner` — with one difference:
@@ -2487,23 +2489,34 @@ class ChatWriterActor:
       cmd.run_token and owner is not None and owner != cmd.run_token
     )
     changed = False
+    parked = False
     if cmd.run_token:
       run = (
         db.query(ChatRun).filter(ChatRun.id == cmd.run_token).first()
       )
-      if run is not None and run.status == "running":
-        if marker_is_ours:
-          run.status = "parked"
-          run.parked_until = cmd.parked_until
-          run.park_reason = (cmd.park_reason or None)
-        else:
-          run.status = "completed"
-        run.ended_at = datetime.now(UTC)
-        changed = True
+      # A tokened transition is useful only when the exact running row exists.
+      # Do not clear the generic chat marker on a missing/terminal row: leaving
+      # it set lets startup reconciliation recover manually instead of losing
+      # the only durable evidence that work was interrupted.
+      if run is None or run.status != "running":
+        return bool(
+          run is not None
+          and run.status in ("parked", "resume_pending")
+          and run.park_reason == (cmd.park_reason or None)
+        )
+      if marker_is_ours:
+        run.status = "parked"
+        run.parked_until = cmd.parked_until
+        run.park_reason = (cmd.park_reason or None)
+        parked = True
+      else:
+        run.status = "completed"
+      run.ended_at = datetime.now(UTC)
+      changed = True
     if not marker_is_ours:
       if changed and not _commit_or_rollback(db):
         raise _PersistFailed("ParkRun did not persist")
-      return None
+      return False
     chat = db.query(Chat).filter(Chat.id == cmd.chat_id).first()
     if chat is not None and (
       chat.run_status is not None or chat.run_started_at is not None
@@ -2514,10 +2527,10 @@ class ChatWriterActor:
     if changed and not _commit_or_rollback(db):
       raise _PersistFailed("ParkRun did not persist")
     self._run_token_owner.pop(cmd.chat_id, None)
-    return None
+    return parked
 
   def _resolve_park(self, db, cmd: ResolvePark):
-    """Move a parked/pending row to ``parked_notified``; idempotent."""
+    """Resolve a parked/pending row without continuing; idempotent."""
     from datetime import UTC, datetime
 
     from app.models import ChatRun
@@ -2534,7 +2547,12 @@ class ChatWriterActor:
       if not _commit_or_rollback(db):
         raise _PersistFailed("ResolvePark stale-run retire did not persist")
       return False
-    run.status = "parked_notified"
+    # A planned restart with automatic continuation disabled (or cancelled by
+    # a later policy/ownership check) is an ordinary manual interruption, not a
+    # provider park that was notified. Keep the historical run outcome honest.
+    run.status = (
+      "interrupted" if run.park_reason == "restart" else "parked_notified"
+    )
     if run.ended_at is None:
       run.ended_at = datetime.now(UTC)
     if not _commit_or_rollback(db):

--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -2447,6 +2447,7 @@ class ChatWriterActor:
       if run is not None and run.status == "running":
         run.status = cmd.terminal_status
         run.ended_at = datetime.now(UTC)
+        run.restart_nonce = None
         changed = True
     elif marker_is_ours:
       changed = self._close_running_runs(
@@ -2509,6 +2510,10 @@ class ChatWriterActor:
           run is not None
           and run.status in ("parked", "resume_pending")
           and run.park_reason == (cmd.park_reason or None)
+          and (
+            run.park_reason != "restart"
+            or run.restart_nonce == (cmd.restart_nonce or None)
+          )
         )
       if marker_is_ours:
         run.status = "parked"
@@ -2520,6 +2525,7 @@ class ChatWriterActor:
         parked = True
       else:
         run.status = "completed"
+        run.restart_nonce = None
       run.ended_at = datetime.now(UTC)
       changed = True
     if not marker_is_ours:

--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -538,6 +538,7 @@ class ParkRun(_Command):
   run_token: str = ""
   parked_until: object = None
   park_reason: str = ""
+  restart_nonce: str = ""
 
 
 @dataclass
@@ -587,6 +588,9 @@ class RollbackAutoResume(_Command):
   run_token: str = ""
   promoted_run_token: str = ""
   promoted_pending: list[dict] = field(default_factory=list)
+  # Provider-limit retries remain eligible after a task-creation failure.
+  # A restart authorization is one-shot, so that path resolves to manual.
+  retry_park: bool = True
 
 
 @dataclass
@@ -2129,6 +2133,7 @@ class ChatWriterActor:
     ).all():
       run.status = "interrupted"
       run.ended_at = datetime.now(UTC)
+      run.restart_nonce = None
     if not _commit_or_rollback(db):
       raise _PersistFailed("SwitchProviderWithCompaction did not persist")
     return {
@@ -2394,6 +2399,7 @@ class ChatWriterActor:
     for run in q.all():
       run.status = status
       run.ended_at = datetime.now(UTC)
+      run.restart_nonce = None
       changed = True
     return changed
 
@@ -2508,6 +2514,9 @@ class ChatWriterActor:
         run.status = "parked"
         run.parked_until = cmd.parked_until
         run.park_reason = (cmd.park_reason or None)
+        run.restart_nonce = (
+          cmd.restart_nonce if cmd.park_reason == "restart" else None
+        )
         parked = True
       else:
         run.status = "completed"
@@ -2542,6 +2551,7 @@ class ChatWriterActor:
       # A newer run already superseded this park. Retire the stale signal but
       # report False so the sweep neither notifies nor claims it resolved.
       run.status = "completed"
+      run.restart_nonce = None
       if run.ended_at is None:
         run.ended_at = datetime.now(UTC)
       if not _commit_or_rollback(db):
@@ -2553,6 +2563,8 @@ class ChatWriterActor:
     run.status = (
       "interrupted" if run.park_reason == "restart" else "parked_notified"
     )
+    if run.park_reason == "restart":
+      run.restart_nonce = None
     if run.ended_at is None:
       run.ended_at = datetime.now(UTC)
     if not _commit_or_rollback(db):
@@ -2570,6 +2582,7 @@ class ChatWriterActor:
       return {"active": False, "notify": False}
     if not self._run_is_latest(db, run):
       run.status = "completed"
+      run.restart_nonce = None
       if run.ended_at is None:
         run.ended_at = datetime.now(UTC)
       if not _commit_or_rollback(db):
@@ -2639,7 +2652,11 @@ class ChatWriterActor:
     chat.run_status = None
     chat.run_started_at = None
     db.delete(promoted_run)
-    park.status = "resume_pending"
+    if cmd.retry_park:
+      park.status = "resume_pending"
+    else:
+      park.status = "interrupted"
+      park.restart_nonce = None
     if not _commit_or_rollback(db):
       raise _PersistFailed("RollbackAutoResume did not persist")
     self._run_token_owner.pop(cmd.chat_id, None)

--- a/backend/app/compaction.py
+++ b/backend/app/compaction.py
@@ -123,7 +123,11 @@ def build_transcript_text(
     # it back into a later synthesis recursively inflates the next handoff.
     if m.get("kind") == "compaction":
       continue
-    role = (m.get("role") or "user").upper()
+    if m.get("kind") == "auto_continuation":
+      reason = str(m.get("continuation_reason") or "automatic recovery")
+      role = f"AUTOMATIC CONTINUATION ({reason.upper()})"
+    else:
+      role = (m.get("role") or "user").upper()
     content = m.get("content") or ""
     if not content.strip():
       continue

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -579,6 +579,13 @@ def run_migrations(eng) -> None:
         "ALTER TABLE chats ADD COLUMN auto_resume_on_limit BOOLEAN "
         "NOT NULL DEFAULT TRUE"
       )
+    if "auto_resume_on_restart" not in chats_cols:
+      # Separate consent boundary. Every existing chat is explicitly off even
+      # when its legacy provider-limit preference is on.
+      _add.append(
+        "ALTER TABLE chats ADD COLUMN auto_resume_on_restart BOOLEAN "
+        "NOT NULL DEFAULT FALSE"
+      )
     if "pinned_at" not in chats_cols:
       # NOT NULL = pinned. Drawer sort key (see routes/chats.py).
       _add.append("ALTER TABLE chats ADD COLUMN pinned_at DATETIME NULL")
@@ -634,6 +641,11 @@ def run_migrations(eng) -> None:
         "ALTER TABLE owner ADD COLUMN auto_resume_on_limit_default BOOLEAN "
         "NOT NULL DEFAULT TRUE"
       )
+    if "auto_resume_on_restart_default" not in owner_cols:
+      _add_owner.append(
+        "ALTER TABLE owner ADD COLUMN auto_resume_on_restart_default BOOLEAN "
+        "NOT NULL DEFAULT FALSE"
+      )
     if "model_prefs_json" not in owner_cols:
       # Nullable JSON blob holding the owner's model-picker
       # preferences (e.g. hidden model IDs). Null = "show
@@ -681,6 +693,10 @@ def run_migrations(eng) -> None:
     if "park_reason" not in chat_runs_cols:
       _add_runs.append(
         "ALTER TABLE chat_runs ADD COLUMN park_reason VARCHAR(32) NULL"
+      )
+    if "restart_nonce" not in chat_runs_cols:
+      _add_runs.append(
+        "ALTER TABLE chat_runs ADD COLUMN restart_nonce VARCHAR(128) NULL"
       )
     if _add_runs:
       with eng.connect() as conn:

--- a/backend/app/events.py
+++ b/backend/app/events.py
@@ -750,6 +750,38 @@ def process_event(event: dict, assistant_blocks: list) -> bool:
     extras = {
       key: event[key] for key in ERROR_PASSTHROUGH_FIELDS if key in event
     }
+    # A planned restart can interrupt a runner that is blocked on a durable
+    # AskUserQuestion. Keep that question as the transcript tail so it remains
+    # answerable after reload, and do not offer a competing Resume button: the
+    # answer is the continuation. Repeated restart events update the one marker
+    # immediately before the trailing question run.
+    restart_pause = (extras.get("pause") or {}).get("kind") == "restart"
+    trailing_open_start = len(assistant_blocks)
+    if restart_pause:
+      while trailing_open_start > 0:
+        block = assistant_blocks[trailing_open_start - 1]
+        if block.get("type") != "question" or block.get("answers"):
+          break
+        trailing_open_start -= 1
+    if restart_pause and trailing_open_start < len(assistant_blocks):
+      extras.pop("resumable", None)
+      marker = {
+        "type": "error",
+        "message": message,
+        **extras,
+      }
+      previous_idx = trailing_open_start - 1
+      if (
+        previous_idx >= 0
+        and assistant_blocks[previous_idx].get("type") == "error"
+        and (
+          assistant_blocks[previous_idx].get("pause") or {}
+        ).get("kind") == "restart"
+      ):
+        assistant_blocks[previous_idx] = marker
+      else:
+        assistant_blocks.insert(trailing_open_start, marker)
+      return True
     if (assistant_blocks
         and assistant_blocks[-1].get("type") == "error"):
       block = assistant_blocks[-1]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -252,9 +252,10 @@ async def lifespan(app):
   # other lifespan steps: a failure here must not brick the recovery
   # surface. Runs single-threaded pre-serving, so no queue-lock
   # contention — see reconcile_interrupted_chats for the argument.
-  # Chats reconciled at boot (incl. any turn paused by a drain-gated restart),
-  # carried to the post-`init_vapid` notify below — VAPID must be initialized
-  # before a push can be delivered.
+  # Chats reconciled at boot (crashes plus a planned drain whose exact park did
+  # not commit) are carried to the post-`init_vapid` manual-recovery notify
+  # below. Exact planned-restart parks bypass this destructive reconciliation
+  # and are handled by the continuation sweep after the writer starts.
   _reconciled_chats: list[str] = []
   try:
     from app.chat import reconcile_interrupted_chats
@@ -333,9 +334,10 @@ async def lifespan(app):
     init_vapid()
   except Exception as exc:
     _log.error("init_vapid failed: %s", exc, exc_info=True)
-  # Boot resume notify (design §2.2 step 4). Runs AFTER init_vapid so the push
-  # can actually deliver: one "tap to resume" notification for any turn left
-  # paused by a drain-gated restart (or crash) that boot reconcile finalized.
+  # Boot manual-resume notify (design §2.2 step 4). Runs AFTER init_vapid so the
+  # push can actually deliver: one "tap to resume" notification for a crash or
+  # planned-drain fallback that boot reconciliation finalized. Exact restart
+  # parks notify through sweep_reset_parks instead.
   # Best-effort — the resumable note is already durable in the transcript, so a
   # notify failure never blocks boot.
   try:
@@ -549,22 +551,39 @@ async def lifespan(app):
 
     _stalled_live_task = _asyncio.create_task(_stalled_live_loop())
 
-    # Provider-limit reset sweep (design §2.4): notifies once when a parked
-    # turn's reset time arrives, and — when the owner opted in — starts the
-    # strictly-serial auto-resume. Same shape as the two loops above.
+    # Durable-continuation sweep (design §2.4): handles provider-limit resets
+    # and exact runs parked by a planned restart. It runs immediately on boot,
+    # then after a turn finishes or at the 60s fallback cadence. This is
+    # event-driven in the common path (one indexed query per completed turn),
+    # with no per-chat worker or short polling loop.
     async def _reset_park_loop():
-      while True:
-        await _asyncio.sleep(60)
-        try:
-          _rp_db = _SweepSession()
+      from app.broadcast import get_system_broadcast as _system_broadcast
+      _events = _system_broadcast().subscribe()
+      try:
+        while True:
           try:
-            await sweep_reset_parks(_rp_db)
-          finally:
-            _rp_db.close()
-        except _asyncio.CancelledError:
-          raise
-        except Exception as _exc:
-          _log.error("reset-park sweep failed: %s", _exc, exc_info=True)
+            _rp_db = _SweepSession()
+            try:
+              await sweep_reset_parks(_rp_db)
+            finally:
+              _rp_db.close()
+          except _asyncio.CancelledError:
+            raise
+          except Exception as _exc:
+            _log.error("reset-park sweep failed: %s", _exc, exc_info=True)
+
+          try:
+            # One absolute fallback window. Unrelated system events must not
+            # keep resetting a per-get timer and starve a future limit reset.
+            async with _asyncio.timeout(60):
+              while True:
+                _event = await _events.get()
+                if _event and _event.get("type") == "chat_run_finished":
+                  break
+          except _asyncio.TimeoutError:
+            pass
+      finally:
+        _system_broadcast().unsubscribe(_events)
 
     _reset_park_task = _asyncio.create_task(_reset_park_loop())
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -56,7 +56,7 @@ from app.routes import (
   published_router,
 )
 
-_BOOT_ID = f"{os.getpid()}-{time.time_ns()}"
+_BOOT_ID = os.environ.get("MOBIUS_BOOT_ID") or f"{os.getpid()}-{time.time_ns()}"
 
 
 def _init_db():

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -124,7 +124,8 @@ class Chat(Base):
   # start afterwards. Nullable is the migration/empty-chat state: the first
   # turn snapshots it atomically before invoking a provider.
   system_prompt_snapshot_id = Column(String(64), nullable=True, default=None)
-  # Per-chat policy for provider-limit recovery. Kept out of
+  # Per-chat policy for automatic recovery after provider limits and planned
+  # server restarts. The legacy column/API name stays compatible. Kept out of
   # agent_settings_json because that blob is snapshotted/mirrored as SDK
   # runtime configuration; mixing this policy into it can skip first-send
   # model snapshots or overwrite the owner's global model defaults.
@@ -222,6 +223,8 @@ class ChatRun(Base):
   # turn, "failed" for a provider/setup error, "stopped" for an explicit user
   # Stop, and "interrupted" for crash/supersession/watchdog recovery. Provider
   # limits additionally use the parked/resume_pending/parked_notified states.
+  # A successfully drained planned restart reuses that retry path with
+  # park_reason="restart"; an unplanned crash remains "interrupted".
   status = Column(String(16), nullable=False, default="running", index=True)
   provider = Column(String(32), nullable=True, default=None)
   # App that initiated this turn under the app-attributed-chat contract
@@ -239,8 +242,9 @@ class ChatRun(Base):
   # provider limit, the run is PARKED instead of just cleared: `status` moves
   # to "parked", `parked_until` holds the reset time (naive UTC, matching every
   # other DateTime here), and `park_reason` a short label ("rate_limit" /
-  # "usage_limit" / …). This run row IS the provider-parked signal — no
-  # separate state enum. The liveness checks read it via
+  # "usage_limit" / …). Planned restarts also use this row with
+  # park_reason="restart" and a due time of now. No separate state enum is
+  # needed. The liveness checks read it via
   # `chat._parked_until_for_chat`; the periodic reset sweep notifies once at
   # `parked_until`; auto-resume may pass through the retryable
   # "resume_pending" state before the row becomes terminal. Null on every

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -18,7 +18,7 @@ from datetime import UTC, datetime
 
 from sqlalchemy import (
   Boolean, Column, DateTime, Float, ForeignKey, Integer, JSON, LargeBinary,
-  String, Text, event, true,
+  String, Text, event, false, true,
 )
 
 from app.database import Base
@@ -40,6 +40,12 @@ class Owner(Base):
   # next chat without rewriting any existing conversation.
   auto_resume_on_limit_default = Column(
     Boolean, nullable=False, default=True, server_default=true()
+  )
+  # Separately consented planned-restart policy for newly created chats.
+  # Existing owners migrate to false: consenting to provider-limit recovery
+  # never silently opts them into replay after a process restart.
+  auto_resume_on_restart_default = Column(
+    Boolean, nullable=False, default=False, server_default=false()
   )
   # Per-owner model-picker preferences. Shape:
   #   {"hidden_ids": ["claude-haiku-4-5-20251001", ...]}
@@ -124,13 +130,15 @@ class Chat(Base):
   # start afterwards. Nullable is the migration/empty-chat state: the first
   # turn snapshots it atomically before invoking a provider.
   system_prompt_snapshot_id = Column(String(64), nullable=True, default=None)
-  # Per-chat policy for automatic recovery after provider limits and planned
-  # server restarts. The legacy column/API name stays compatible. Kept out of
-  # agent_settings_json because that blob is snapshotted/mirrored as SDK
-  # runtime configuration; mixing this policy into it can skip first-send
-  # model snapshots or overwrite the owner's global model defaults.
+  # Per-chat policy for automatic recovery after provider limits.
   auto_resume_on_limit = Column(
     Boolean, nullable=False, default=True, server_default=true()
+  )
+  # Planned restart continuation is materially broader than provider-limit
+  # recovery and therefore has separate, explicit consent. Existing and fresh
+  # chats start off until the owner enables it in that chat.
+  auto_resume_on_restart = Column(
+    Boolean, nullable=False, default=False, server_default=false()
   )
   # Vestigial: the named-agent feature was removed; column retained
   # nullable to avoid a prod migration. Nothing reads or writes it.
@@ -251,6 +259,10 @@ class ChatRun(Base):
   # non-parked run and on rows created before this column existed.
   parked_until = Column(DateTime, nullable=True, default=None)
   park_reason = Column(String(32), nullable=True, default=None)
+  # One-shot platform-authored intent identity for a planned restart. It only
+  # authorizes replay when the frozen supervisor's root-owned boot ledger binds
+  # the same nonce + exact run id to the current boot.
+  restart_nonce = Column(String(128), nullable=True, default=None)
 
 
 class ChatSessionLink(Base):

--- a/backend/app/restart_ledger.py
+++ b/backend/app/restart_ledger.py
@@ -1,0 +1,139 @@
+"""Platform-facing half of the planned-restart authorization protocol."""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import stat
+import time
+from pathlib import Path
+from typing import Any
+
+from app.config import get_settings
+
+
+PROTOCOL_VERSION = 1
+MAX_ACK_BYTES = 64 * 1024
+
+
+def current_boot_id() -> str:
+  return os.environ.get("MOBIUS_BOOT_ID", "")
+
+
+def new_nonce() -> str:
+  return secrets.token_urlsafe(32)
+
+
+def _paths() -> tuple[Path, Path, Path]:
+  root = Path(get_settings().data_dir)
+  return (
+    root / ".restart-continuation-intent.json",
+    root / ".platform-restart-requested",
+    root / ".restart-ledger",
+  )
+
+
+def _atomic_json(path: Path, value: dict[str, Any]) -> None:
+  payload = json.dumps(
+    value, sort_keys=True, separators=(",", ":"),
+  ).encode("utf-8")
+  tmp = path.with_name(f".{path.name}.{secrets.token_hex(8)}.tmp")
+  flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+  flags |= getattr(os, "O_NOFOLLOW", 0)
+  fd = os.open(tmp, flags, 0o600)
+  try:
+    offset = 0
+    while offset < len(payload):
+      offset += os.write(fd, payload[offset:])
+    os.fsync(fd)
+  finally:
+    os.close(fd)
+  os.replace(tmp, path)
+
+
+def request_restart(
+  *,
+  boot_id: str,
+  nonce: str,
+  runs: list[dict[str, str]],
+  now: float | None = None,
+) -> None:
+  """Publish intent first, then the sentinel the frozen poller consumes."""
+  intent_path, request_path, _ = _paths()
+  created_at = time.time() if now is None else now
+  normalized = [
+    {"chat_id": str(item["chat_id"]), "run_token": str(item["run_token"])}
+    for item in runs
+  ]
+  _atomic_json(intent_path, {
+    "version": PROTOCOL_VERSION,
+    "nonce": nonce,
+    "source_boot_id": boot_id,
+    "created_at": created_at,
+    "runs": normalized,
+  })
+  _atomic_json(request_path, {
+    "nonce": nonce,
+    "source_boot_id": boot_id,
+  })
+
+
+def authorized_runs(
+  boot_id: str | None = None,
+  *,
+  trusted_uid: int = 0,
+  trusted_gid: int = 0,
+) -> dict[str, tuple[str, str]]:
+  """Return ``run_token -> (chat_id, nonce)`` for this authenticated boot."""
+  expected_boot = boot_id if boot_id is not None else current_boot_id()
+  if not expected_boot:
+    return {}
+  _, _, ledger_dir = _paths()
+  ack_path = ledger_dir / "ack.json"
+  try:
+    dir_st = ledger_dir.lstat()
+    ack_st = ack_path.lstat()
+    if (
+      not stat.S_ISDIR(dir_st.st_mode)
+      or stat.S_ISLNK(dir_st.st_mode)
+      or dir_st.st_uid != trusted_uid
+      or dir_st.st_gid != trusted_gid
+      or dir_st.st_mode & (stat.S_IWGRP | stat.S_IWOTH)
+      or not stat.S_ISREG(ack_st.st_mode)
+      or ack_st.st_uid != trusted_uid
+      or ack_st.st_gid != trusted_gid
+      or ack_st.st_mode & (stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH)
+      or ack_st.st_size > MAX_ACK_BYTES
+    ):
+      return {}
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    fd = os.open(ack_path, flags)
+    try:
+      raw = os.read(fd, MAX_ACK_BYTES + 1)
+    finally:
+      os.close(fd)
+    value = json.loads(raw.decode("utf-8"))
+  except (OSError, UnicodeError, json.JSONDecodeError):
+    return {}
+  if (
+    not isinstance(value, dict)
+    or value.get("version") != PROTOCOL_VERSION
+    or value.get("target_boot_id") != expected_boot
+    or not isinstance(value.get("nonce"), str)
+    or not isinstance(value.get("runs"), list)
+  ):
+    return {}
+  nonce = value["nonce"]
+  result: dict[str, tuple[str, str]] = {}
+  for item in value["runs"]:
+    if not isinstance(item, dict):
+      return {}
+    chat_id = item.get("chat_id")
+    run_token = item.get("run_token")
+    if not isinstance(chat_id, str) or not isinstance(run_token, str):
+      return {}
+    if run_token in result:
+      return {}
+    result[run_token] = (chat_id, nonce)
+  return result

--- a/backend/app/restart_util.py
+++ b/backend/app/restart_util.py
@@ -10,8 +10,9 @@ never simply killed. The worker first sets the ``draining`` gate (new sends
 queue), interrupts each live turn so it finalizes its partials + a "paused for a
 platform update" note WITHOUT touching the pending queue, then restarts — SIGTERM
 for a graceful exit, with a SIGKILL backstop so a hung shutdown still cycles the
-container. Boot reconcile finalizes any marker left set and offers a one-tap
-Resume.
+container. A successfully stopped exact run is marked due for continuation before
+SIGTERM; boot reconcile handles only the fallback markers that could not make that
+transition.
 """
 
 from __future__ import annotations
@@ -44,10 +45,11 @@ async def restart_this_worker() -> None:
        worker dies no matter what, so a wedged drain or a hung graceful shutdown
        can never leave the container "Up" with a dead worker.
     3. Drain every live turn (interrupt → finalize partials + a "paused for a
-       platform update" note → LEAVE the run marker + pending queue intact for
-       boot reconcile + one-tap Resume). Bounded by ``DRAIN_TIMEOUT``;
-       best-effort — a turn that won't drain in time keeps today's contract (the
-       backstop kills the worker, boot reconcile finalizes the marker).
+       platform update" note → mark that exact run due now using the existing
+       continuation row; preserve the pending queue). Bounded by
+       ``DRAIN_TIMEOUT``; best-effort — a turn that won't drain, or whose exact
+       transition cannot commit, leaves its generic marker for manual boot
+       reconciliation.
     4. SIGTERM uvicorn for a graceful exit. If it drains and exits within the
        remaining window the backstop never fires (SIGKILL never runs); if it
        hangs on the open SSE stream, the backstop force-exits and the container
@@ -80,8 +82,8 @@ async def restart_this_worker() -> None:
     )
   except Exception:
     # Never let a drain failure block the restart — the backstop timer and the
-    # SIGTERM below still reboot the worker, and boot reconcile finalizes any
-    # turn whose marker was left set.
+    # SIGTERM below still reboots the worker. Exact runs already transitioned
+    # remain due; any marker left set falls back to manual boot reconciliation.
     log.warning("drain-for-restart failed; restarting anyway", exc_info=True)
 
   os.kill(pid, signal.SIGTERM)

--- a/backend/app/restart_util.py
+++ b/backend/app/restart_util.py
@@ -8,11 +8,11 @@ the other is exactly the bug this consolidates away.
 Every restart routes through one DRAIN-GATED path (design §2.2): live turns are
 never simply killed. The worker first sets the ``draining`` gate (new sends
 queue), interrupts each live turn so it finalizes its partials + a "paused for a
-platform update" note WITHOUT touching the pending queue, then restarts — SIGTERM
-for a graceful exit, with a SIGKILL backstop so a hung shutdown still cycles the
-container. A successfully stopped exact run is marked due for continuation before
-SIGTERM; boot reconcile handles only the fallback markers that could not make that
-transition.
+platform update" note WITHOUT touching the pending queue, then asks the frozen
+entrypoint supervisor to acknowledge the exact restart intent and cycle pid 1.
+A SIGKILL backstop still guarantees recovery if the handshake or shutdown
+wedges. Boot reconcile handles fallback markers and unacknowledged parks
+manually.
 """
 
 from __future__ import annotations
@@ -50,10 +50,10 @@ async def restart_this_worker() -> None:
        ``DRAIN_TIMEOUT``; best-effort — a turn that won't drain, or whose exact
        transition cannot commit, leaves its generic marker for manual boot
        reconciliation.
-    4. SIGTERM uvicorn for a graceful exit. If it drains and exits within the
-       remaining window the backstop never fires (SIGKILL never runs); if it
-       hangs on the open SSE stream, the backstop force-exits and the container
-       cycles, and a fresh worker boots.
+    4. Publish the exact intent + restart sentinel. The frozen root-owned
+       poller acknowledges it in the boot ledger, then SIGTERMs pid 1. If that
+       path wedges, the backstop force-exits the worker without an
+       acknowledgement, so the next boot recovers manually.
 
   Data is safe: the chat writer commits before any response returns, and the
   drain flushes each paused note before SIGTERM, so a hard kill loses nothing a
@@ -75,9 +75,17 @@ async def restart_this_worker() -> None:
   timer.daemon = True
   timer.start()
 
+  from app import restart_ledger
+
+  boot_id = restart_ledger.current_boot_id()
+  restart_nonce = restart_ledger.new_nonce()
+  parked_runs: list[dict[str, str]] = []
   try:
-    await asyncio.wait_for(
-      chat.drain_all_for_restart(timeout=chat.DRAIN_TIMEOUT),
+    parked_runs = await asyncio.wait_for(
+      chat.drain_all_for_restart(
+        timeout=chat.DRAIN_TIMEOUT,
+        restart_nonce=restart_nonce,
+      ),
       timeout=chat.DRAIN_TIMEOUT,
     )
   except Exception:
@@ -86,4 +94,25 @@ async def restart_this_worker() -> None:
     # remain due; any marker left set falls back to manual boot reconciliation.
     log.warning("drain-for-restart failed; restarting anyway", exc_info=True)
 
-  os.kill(pid, signal.SIGTERM)
+  try:
+    if not boot_id:
+      raise RuntimeError("entrypoint boot id is unavailable")
+    # Publishing the sentinel is the only normal shutdown request. The frozen
+    # root-owned entrypoint poller validates the matching intent, records its
+    # exact runs in the one-shot boot ledger, and then terminates pid 1.
+    restart_ledger.request_restart(
+      boot_id=boot_id,
+      nonce=restart_nonce,
+      runs=parked_runs,
+    )
+  except Exception:
+    # Restart reliability and continuation authorization are independent.
+    # If the external handshake cannot be published, restart directly; the
+    # next boot has no root-owned acknowledgement and resolves every parked run
+    # to manual recovery.
+    log.warning(
+      "planned-restart handshake failed; restarting without automatic "
+      "continuation",
+      exc_info=True,
+    )
+    os.kill(pid, signal.SIGTERM)

--- a/backend/app/restart_util.py
+++ b/backend/app/restart_util.py
@@ -90,7 +90,7 @@ async def restart_this_worker() -> None:
     )
   except Exception:
     # Never let a drain failure block the restart — the backstop timer and the
-    # SIGTERM below still reboots the worker. Exact runs already transitioned
+    # fallback path still reboots the worker. Exact runs already transitioned
     # remain due; any marker left set falls back to manual boot reconciliation.
     log.warning("drain-for-restart failed; restarting anyway", exc_info=True)
 

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -744,7 +744,11 @@ def _first_message_title(chat) -> str:
   """The 'first message' fallback name: the first user message's text trimmed
   to a sane length (mirrors the StartTurn initial-title behavior)."""
   for m in (chat.messages or []):
-    if not isinstance(m, dict) or m.get("role") != "user":
+    if (
+      not isinstance(m, dict)
+      or m.get("role") != "user"
+      or m.get("kind") == "auto_continuation"
+    ):
       continue
     c = m.get("content")
     if isinstance(c, list):

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -324,6 +324,7 @@ def _chat_detail_response(
     "provider": provider,
     "created_by_app_id": chat.created_by_app_id,
     "auto_resume_on_limit": bool(chat.auto_resume_on_limit),
+    "auto_resume_on_restart": bool(chat.auto_resume_on_restart),
     "agent_settings_json": settings_obj,
     "effective_agent_settings": effective_agent_settings(
       get_settings().data_dir,
@@ -676,6 +677,9 @@ def create_chat(
     auto_resume_on_limit=(
       bool(owner.auto_resume_on_limit_default) if owner else True
     ),
+    auto_resume_on_restart=(
+      bool(owner.auto_resume_on_restart_default) if owner else False
+    ),
   )
   db.add(chat)
   db.commit()
@@ -794,6 +798,7 @@ async def patch_chat(
     body.title is not None
     or body.pinned is not None
     or body.auto_resume_on_limit is not None
+    or body.auto_resume_on_restart is not None
     or body.by_agent
     or body.clear_title
   ):
@@ -854,6 +859,12 @@ async def patch_chat(
       # chat, matching other "last picked" defaults without making the setting
       # global at runtime.
       principal.owner.auto_resume_on_limit_default = body.auto_resume_on_limit
+
+    if body.auto_resume_on_restart is not None:
+      chat.auto_resume_on_restart = body.auto_resume_on_restart
+      principal.owner.auto_resume_on_restart_default = (
+        body.auto_resume_on_restart
+      )
 
     # Determine the effective target provider. The body may set it
     # explicitly, OR it may be implied by a model-only PATCH whose
@@ -1012,6 +1023,7 @@ async def patch_chat(
       "agent_settings_json": _coerce_agent_settings(chat.agent_settings_json) or None,
       "provider": chat.provider or "claude",
       "auto_resume_on_limit": bool(chat.auto_resume_on_limit),
+      "auto_resume_on_restart": bool(chat.auto_resume_on_restart),
       "effective": effective_agent_settings(
         data_dir,
         _coerce_agent_settings(chat.agent_settings_json) or None,

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -397,9 +397,10 @@ class ChatPatch(BaseModel):
   title: str | None = Field(default=None, max_length=500)
   # Drawer pin toggle. True sets pinned_at = now, False clears it.
   pinned: bool | None = None
-  # Per-chat opt-in to continuing a provider-limited turn at reset. This is
-  # intentionally absent from SettingsUpdate: background agents and other
-  # chats must never inherit it.
+  # Per-chat opt-in to continuing after a provider-limit reset or planned
+  # server restart. The legacy wire name remains compatible. This is absent
+  # from SettingsUpdate: background agents and unrelated chats do not inherit
+  # a runtime change.
   auto_resume_on_limit: bool | None = None
   # Naming precedence. by_agent marks an AGENT title-sync — it fills the name
   # only when the owner hasn't locked it via a manual rename. clear_title resets

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -397,11 +397,11 @@ class ChatPatch(BaseModel):
   title: str | None = Field(default=None, max_length=500)
   # Drawer pin toggle. True sets pinned_at = now, False clears it.
   pinned: bool | None = None
-  # Per-chat opt-in to continuing after a provider-limit reset or planned
-  # server restart. The legacy wire name remains compatible. This is absent
-  # from SettingsUpdate: background agents and unrelated chats do not inherit
-  # a runtime change.
+  # Per-chat opt-in to continuing after a provider-limit reset.
   auto_resume_on_limit: bool | None = None
+  # Separate explicit consent for a supervisor-authenticated planned restart.
+  # Existing chats migrate off; provider-limit consent never broadens into it.
+  auto_resume_on_restart: bool | None = None
   # Naming precedence. by_agent marks an AGENT title-sync — it fills the name
   # only when the owner hasn't locked it via a manual rename. clear_title resets
   # the name (unlock + drop to the first-message default; re-derived next turn).

--- a/backend/recovery/restart_ledger.py
+++ b/backend/recovery/restart_ledger.py
@@ -54,7 +54,7 @@ def _valid_token(value: Any) -> bool:
   return isinstance(value, str) and bool(_TOKEN_RE.fullmatch(value))
 
 
-def _remove(path: Path) -> None:
+def _remove(path: Path) -> bool:
   try:
     if path.is_dir() and not path.is_symlink():
       shutil.rmtree(path)
@@ -62,6 +62,13 @@ def _remove(path: Path) -> None:
       path.unlink(missing_ok=True)
   except OSError:
     pass
+  try:
+    path.lstat()
+  except FileNotFoundError:
+    return True
+  except OSError:
+    return False
+  return False
 
 
 def _fsync_dir(path: Path) -> None:
@@ -213,8 +220,9 @@ def begin_boot(boot_id: str, *, now: float | None = None) -> bool:
   current = time.time() if now is None else now
   _prepare_ledger_dir()
   accepted = _read_bounded_json(ACCEPTED_PATH)
-  _remove(ACK_PATH)
-  authorized = False
+  if not _remove(ACK_PATH):
+    raise OSError("could not retire the prior boot acknowledgement")
+  authorized_payload: dict[str, Any] | None = None
   if accepted:
     try:
       accepted_at = float(accepted.get("accepted_at"))
@@ -230,13 +238,19 @@ def begin_boot(boot_id: str, *, now: float | None = None) -> bool:
       and accepted_at <= current + 5
       and current - accepted_at <= MAX_ACCEPTED_AGE_SECONDS
     ):
-      _write_json(ACK_PATH, {
+      authorized_payload = {
         **accepted,
         "runs": runs,
         "target_boot_id": boot_id,
-      }, 0o444)
-      authorized = True
-  _remove(ACCEPTED_PATH)
+      }
+  # Consume before acknowledging. If the volume refuses this deletion, the
+  # accepted record must not be reusable by another boot; fail closed without
+  # creating an acknowledgement for this one.
+  if not _remove(ACCEPTED_PATH):
+    raise OSError("could not consume the accepted restart intent")
+  authorized = authorized_payload is not None
+  if authorized_payload is not None:
+    _write_json(ACK_PATH, authorized_payload, 0o444)
   _atomic_write(BOOT_PATH, f"{boot_id}\n".encode("utf-8"), 0o444)
 
   # Any platform-authored request not already accepted by the supervisor

--- a/backend/recovery/restart_ledger.py
+++ b/backend/recovery/restart_ledger.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""Frozen supervisor half of planned-restart continuation.
+
+The platform process may *request* a restart, but it cannot authenticate the
+cause of the next boot by writing a transcript row or database flag itself. This
+helper runs from the baked, root-owned recovery bundle and maintains a
+root-owned ledger under ``/data/.restart-ledger``:
+
+* ``accept`` validates and consumes one untrusted platform request, records the
+  exact run identities, and is called immediately before the entrypoint poller
+  terminates pid 1.
+* ``begin-boot`` binds that accepted request to exactly the next boot id.
+* ``harden`` restores root ownership after the entrypoint's broad compatibility
+  chown. If that cannot be proven, authorization is deleted and continuation
+  fails closed to manual recovery.
+
+No ``app.*`` imports are used. The platform can suppress a continuation by
+deleting its own request, but it cannot forge the root-owned acknowledgement.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import secrets
+import shutil
+import stat
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+DATA_DIR = Path(os.environ.get("DATA_DIR", "/data"))
+INTENT_PATH = DATA_DIR / ".restart-continuation-intent.json"
+REQUEST_PATH = DATA_DIR / ".platform-restart-requested"
+LEDGER_DIR = DATA_DIR / ".restart-ledger"
+ACCEPTED_PATH = LEDGER_DIR / "accepted.json"
+ACK_PATH = LEDGER_DIR / "ack.json"
+BOOT_PATH = LEDGER_DIR / "boot-id"
+
+PROTOCOL_VERSION = 1
+MAX_REQUEST_BYTES = 64 * 1024
+MAX_RUNS = 64
+MAX_REQUEST_AGE_SECONDS = 120
+MAX_ACCEPTED_AGE_SECONDS = 10 * 60
+_TOKEN_RE = re.compile(r"^[A-Za-z0-9._:-]{8,160}$")
+SUPERVISOR_UID = 0
+SUPERVISOR_GID = 0
+
+
+def _valid_token(value: Any) -> bool:
+  return isinstance(value, str) and bool(_TOKEN_RE.fullmatch(value))
+
+
+def _remove(path: Path) -> None:
+  try:
+    if path.is_dir() and not path.is_symlink():
+      shutil.rmtree(path)
+    else:
+      path.unlink(missing_ok=True)
+  except OSError:
+    pass
+
+
+def _fsync_dir(path: Path) -> None:
+  try:
+    fd = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+  except OSError:
+    return
+  try:
+    os.fsync(fd)
+  finally:
+    os.close(fd)
+
+
+def _atomic_write(path: Path, payload: bytes, mode: int) -> None:
+  tmp = path.parent / f".{path.name}.{secrets.token_hex(8)}.tmp"
+  flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+  flags |= getattr(os, "O_NOFOLLOW", 0)
+  fd = os.open(tmp, flags, mode)
+  try:
+    offset = 0
+    while offset < len(payload):
+      offset += os.write(fd, payload[offset:])
+    os.fsync(fd)
+    os.fchmod(fd, mode)
+    if hasattr(os, "fchown"):
+      os.fchown(fd, SUPERVISOR_UID, SUPERVISOR_GID)
+  finally:
+    os.close(fd)
+  os.replace(tmp, path)
+  _fsync_dir(path.parent)
+
+
+def _write_json(path: Path, value: dict[str, Any], mode: int) -> None:
+  payload = json.dumps(
+    value, sort_keys=True, separators=(",", ":"),
+  ).encode("utf-8")
+  _atomic_write(path, payload, mode)
+
+
+def _read_bounded_json(path: Path) -> dict[str, Any] | None:
+  try:
+    st = path.lstat()
+    if not stat.S_ISREG(st.st_mode) or st.st_size > MAX_REQUEST_BYTES:
+      return None
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    fd = os.open(path, flags)
+    try:
+      raw = os.read(fd, MAX_REQUEST_BYTES + 1)
+    finally:
+      os.close(fd)
+    if len(raw) > MAX_REQUEST_BYTES:
+      return None
+    value = json.loads(raw.decode("utf-8"))
+    return value if isinstance(value, dict) else None
+  except (OSError, UnicodeError, json.JSONDecodeError):
+    return None
+
+
+def _trusted_ledger_dir() -> bool:
+  try:
+    st = LEDGER_DIR.lstat()
+  except OSError:
+    return False
+  return bool(
+    stat.S_ISDIR(st.st_mode)
+    and not stat.S_ISLNK(st.st_mode)
+    and st.st_uid == SUPERVISOR_UID
+    and st.st_gid == SUPERVISOR_GID
+    and not (st.st_mode & (stat.S_IWGRP | stat.S_IWOTH))
+  )
+
+
+def _recreate_ledger_dir() -> None:
+  if LEDGER_DIR.exists() or LEDGER_DIR.is_symlink():
+    _remove(LEDGER_DIR)
+  LEDGER_DIR.mkdir(mode=0o755, parents=False, exist_ok=False)
+  os.chown(LEDGER_DIR, SUPERVISOR_UID, SUPERVISOR_GID)
+  os.chmod(LEDGER_DIR, 0o755)
+  _fsync_dir(DATA_DIR)
+
+
+def _prepare_ledger_dir() -> None:
+  if not _trusted_ledger_dir():
+    _recreate_ledger_dir()
+
+
+def _valid_runs(value: Any) -> list[dict[str, str]] | None:
+  if not isinstance(value, list) or len(value) > MAX_RUNS:
+    return None
+  seen: set[tuple[str, str]] = set()
+  runs: list[dict[str, str]] = []
+  for item in value:
+    if not isinstance(item, dict):
+      return None
+    chat_id = item.get("chat_id")
+    run_token = item.get("run_token")
+    if not _valid_token(chat_id) or not _valid_token(run_token):
+      return None
+    key = (chat_id, run_token)
+    if key in seen:
+      return None
+    seen.add(key)
+    runs.append({"chat_id": chat_id, "run_token": run_token})
+  return runs
+
+
+def _valid_intent(
+  intent: dict[str, Any] | None,
+  request: dict[str, Any] | None,
+  boot_id: str,
+  now: float,
+) -> dict[str, Any] | None:
+  if not intent or not request:
+    return None
+  if intent.get("version") != PROTOCOL_VERSION:
+    return None
+  nonce = intent.get("nonce")
+  source_boot_id = intent.get("source_boot_id")
+  if (
+    not _valid_token(nonce)
+    or source_boot_id != boot_id
+    or request.get("nonce") != nonce
+    or request.get("source_boot_id") != boot_id
+  ):
+    return None
+  try:
+    created_at = float(intent.get("created_at"))
+  except (TypeError, ValueError):
+    return None
+  if created_at > now + 5 or now - created_at > MAX_REQUEST_AGE_SECONDS:
+    return None
+  runs = _valid_runs(intent.get("runs"))
+  if runs is None:
+    return None
+  return {
+    "version": PROTOCOL_VERSION,
+    "nonce": nonce,
+    "source_boot_id": source_boot_id,
+    "created_at": created_at,
+    "accepted_at": now,
+    "runs": runs,
+  }
+
+
+def begin_boot(boot_id: str, *, now: float | None = None) -> bool:
+  """Bind a previously accepted restart to this one boot, or retire it."""
+  if not _valid_token(boot_id):
+    raise ValueError("invalid boot id")
+  current = time.time() if now is None else now
+  _prepare_ledger_dir()
+  accepted = _read_bounded_json(ACCEPTED_PATH)
+  _remove(ACK_PATH)
+  authorized = False
+  if accepted:
+    try:
+      accepted_at = float(accepted.get("accepted_at"))
+    except (TypeError, ValueError):
+      accepted_at = 0
+    runs = _valid_runs(accepted.get("runs"))
+    if (
+      accepted.get("version") == PROTOCOL_VERSION
+      and _valid_token(accepted.get("nonce"))
+      and _valid_token(accepted.get("source_boot_id"))
+      and accepted.get("source_boot_id") != boot_id
+      and runs is not None
+      and accepted_at <= current + 5
+      and current - accepted_at <= MAX_ACCEPTED_AGE_SECONDS
+    ):
+      _write_json(ACK_PATH, {
+        **accepted,
+        "runs": runs,
+        "target_boot_id": boot_id,
+      }, 0o444)
+      authorized = True
+  _remove(ACCEPTED_PATH)
+  _atomic_write(BOOT_PATH, f"{boot_id}\n".encode("utf-8"), 0o444)
+
+  # Any platform-authored request not already accepted by the supervisor
+  # belongs to an unrelated prior boot and must never authorize this one.
+  _remove(INTENT_PATH)
+  _remove(REQUEST_PATH)
+  return authorized
+
+
+def harden(boot_id: str) -> bool:
+  """Restore ledger ownership after the entrypoint's compatibility chown."""
+  if not _valid_token(boot_id):
+    return False
+  try:
+    if LEDGER_DIR.is_symlink() or not LEDGER_DIR.is_dir():
+      return False
+    if BOOT_PATH.read_text(encoding="utf-8").strip() != boot_id:
+      _remove(ACK_PATH)
+      return False
+    for path in (BOOT_PATH, ACK_PATH, ACCEPTED_PATH):
+      if not path.exists():
+        continue
+      st = path.lstat()
+      if not stat.S_ISREG(st.st_mode):
+        _remove(path)
+        continue
+      os.chown(path, SUPERVISOR_UID, SUPERVISOR_GID)
+      os.chmod(path, 0o444 if path != ACCEPTED_PATH else 0o600)
+    os.chown(LEDGER_DIR, SUPERVISOR_UID, SUPERVISOR_GID)
+    os.chmod(LEDGER_DIR, 0o755)
+    return _trusted_ledger_dir()
+  except OSError:
+    _remove(ACK_PATH)
+    return False
+
+
+def accept(boot_id: str, *, now: float | None = None) -> bool:
+  """Consume one restart request and record exact externally accepted runs."""
+  current = time.time() if now is None else now
+  _prepare_ledger_dir()
+  try:
+    ledger_boot = BOOT_PATH.read_text(encoding="utf-8").strip()
+  except OSError:
+    ledger_boot = ""
+  intent = _read_bounded_json(INTENT_PATH)
+  request = _read_bounded_json(REQUEST_PATH)
+  accepted = (
+    _valid_intent(intent, request, boot_id, current)
+    if ledger_boot == boot_id else None
+  )
+  _remove(ACCEPTED_PATH)
+  if accepted is not None:
+    _write_json(ACCEPTED_PATH, accepted, 0o600)
+  _remove(INTENT_PATH)
+  _remove(REQUEST_PATH)
+  return accepted is not None
+
+
+def _main(argv: list[str]) -> int:
+  if len(argv) != 3:
+    print("usage: restart_ledger.py begin-boot|harden|accept BOOT_ID", file=sys.stderr)
+    return 2
+  command, boot_id = argv[1:]
+  try:
+    if command == "begin-boot":
+      result = begin_boot(boot_id)
+    elif command == "harden":
+      result = harden(boot_id)
+    elif command == "accept":
+      result = accept(boot_id)
+    else:
+      return 2
+  except Exception as exc:
+    print(f"restart ledger {command} failed: {exc}", file=sys.stderr)
+    return 1
+  print(f"{command}={'accepted' if result else 'none'}")
+  # `accept=none` still represents a valid restart request (for example a
+  # Recovery restore); it simply grants no automatic chat continuation.
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(_main(sys.argv))

--- a/backend/scripts/chat_note.py
+++ b/backend/scripts/chat_note.py
@@ -116,7 +116,11 @@ def _render_transcript(raw: str) -> str:
     # recursively duplicate the same context on every later re-switch.
     if isinstance(m, dict) and m.get("kind") == "compaction":
       continue
-    role = m.get("role", "?") if isinstance(m, dict) else "?"
+    if isinstance(m, dict) and m.get("kind") == "auto_continuation":
+      reason = str(m.get("continuation_reason") or "automatic recovery")
+      role = f"automatic continuation ({reason})"
+    else:
+      role = m.get("role", "?") if isinstance(m, dict) else "?"
     content = m.get("content") if isinstance(m, dict) else None
     if isinstance(content, list):
       text = " ".join(

--- a/backend/scripts/entrypoint.sh
+++ b/backend/scripts/entrypoint.sh
@@ -15,6 +15,17 @@ mkdir -p /data/db /data/apps /data/app-secrets /data/compiled /data/shared /data
 # discovered managed schedule has been converged through the common runner.
 rm -f /data/run/app-cron-supervision-ready
 
+# Root-owned planned-restart ledger. Bind an externally accepted intent to this
+# exact boot BEFORE any fallible platform/bootstrap work, so a boot that dies
+# early cannot pass the authorization on to a later unrelated boot. The helper
+# is frozen under /app/recovery and imports no platform code.
+MOBIUS_BOOT_ID="${MOBIUS_BOOT_ID:-$(python3 -c 'import secrets; print(secrets.token_urlsafe(24))')}"
+export MOBIUS_BOOT_ID
+if ! DATA_DIR=/data python3 -P /app/recovery/restart_ledger.py \
+  begin-boot "$MOBIUS_BOOT_ID"; then
+  echo "WARNING: planned-restart ledger could not begin this boot; automatic restart continuation is disabled." >&2
+fi
+
 # /data/agent-browser-profiles holds PER-CHAT Chrome user-data dirs
 # (chat-<chat_id>/...) for agent-browser. The path is set per-chat by
 # `app.chat._build_subprocess_env` so the agent's repeated screenshots
@@ -120,6 +131,14 @@ if ! chown -R mobius:mobius /data 2>/dev/null; then
   echo "WARNING: it needs to be able to create files in /data, not just traverse." >&2
   chmod 1777 /data 2>/dev/null || true
   chmod -R 777 /data/db /data/apps /data/compiled /data/shared /data/logs /data/cron-logs /data/cli-auth /data/run 2>/dev/null || true
+fi
+
+# The compatibility chown above necessarily traverses the root-owned restart
+# ledger. Re-harden it before any mobius process starts. Failure is fail-closed:
+# the app rejects a non-root-owned acknowledgement and offers manual Resume.
+if ! DATA_DIR=/data python3 -P /app/recovery/restart_ledger.py \
+  harden "$MOBIUS_BOOT_ID"; then
+  echo "WARNING: planned-restart ledger could not be re-hardened; automatic restart continuation is disabled." >&2
 fi
 
 # App credentials live outside ordinary app storage and the outer /data git
@@ -238,7 +257,16 @@ _start_platform_restart_poller() {
   (
     while true; do
       if [ -f /data/.platform-restart-requested ]; then
-        rm -f /data/.platform-restart-requested 2>/dev/null || true
+        # The frozen helper authenticates a matching one-shot chat intent when
+        # present, or consumes the legacy Recovery restore sentinel without
+        # granting chat continuation. Either way, only this external poller
+        # acknowledges the cause before terminating pid 1.
+        if ! DATA_DIR=/data python3 -P /app/recovery/restart_ledger.py \
+          accept "$MOBIUS_BOOT_ID"; then
+          rm -f /data/.platform-restart-requested \
+            /data/.restart-continuation-intent.json 2>/dev/null || true
+          echo "O1: restart ledger acceptance failed — restarting without automatic continuation." >&2
+        fi
         echo "O1: platform-restart sentinel seen — sending SIGTERM to pid 1 (container restart)." >&2
         kill -TERM 1 2>/dev/null || true
         # pid1 is now draining + exiting; give it a moment, then stop polling.

--- a/backend/tests/test_chat_agent_settings.py
+++ b/backend/tests/test_chat_agent_settings.py
@@ -246,6 +246,42 @@ def test_new_chat_inherits_last_auto_resume_selection(client, auth, chat):
   ).json()["auto_resume_on_limit"] is True
 
 
+def test_restart_resume_requires_separate_explicit_consent(
+  client, auth, chat,
+):
+  """Legacy limit consent stays on while every existing restart policy is off."""
+  initial = client.get(f"/api/chats/{chat.id}", headers=auth).json()
+  assert initial["auto_resume_on_limit"] is True
+  assert initial["auto_resume_on_restart"] is False
+
+  existing = client.post(
+    "/api/chats", headers=auth, json={"title": "existing off"},
+  ).json()
+  assert client.get(
+    f"/api/chats/{existing['id']}", headers=auth,
+  ).json()["auto_resume_on_restart"] is False
+
+  enabled = client.patch(
+    f"/api/chats/{chat.id}",
+    headers=auth,
+    json={"auto_resume_on_restart": True},
+  )
+  assert enabled.status_code == 200
+  assert enabled.json()["auto_resume_on_restart"] is True
+  assert enabled.json()["auto_resume_on_limit"] is True
+
+  inherited = client.post(
+    "/api/chats", headers=auth, json={"title": "explicitly inherited on"},
+  ).json()
+  assert client.get(
+    f"/api/chats/{inherited['id']}", headers=auth,
+  ).json()["auto_resume_on_restart"] is True
+  # Explicit consent seeds future chats only; it never rewrites older rows.
+  assert client.get(
+    f"/api/chats/{existing['id']}", headers=auth,
+  ).json()["auto_resume_on_restart"] is False
+
+
 def test_stale_global_auto_resume_setting_is_not_a_chat_default(
   client, auth, chat,
 ):

--- a/backend/tests/test_chat_compact.py
+++ b/backend/tests/test_chat_compact.py
@@ -586,6 +586,18 @@ def test_build_transcript_text_skips_handoffs_and_tail_caps():
   assert len(capped) == compaction._MAX_TRANSCRIPT_CHARS
 
 
+def test_build_transcript_text_labels_automatic_continuation_as_product_event():
+  text = compaction.build_transcript_text([{
+    "role": "user",
+    "kind": "auto_continuation",
+    "continuation_reason": "usage_limit",
+    "content": "continue",
+  }])
+
+  assert text == "AUTOMATIC CONTINUATION (USAGE_LIMIT): continue"
+  assert "USER: continue" not in text
+
+
 def test_cumulative_chat_summary_is_unbounded_compaction_source(tmp_path):
   note = tmp_path / "shared" / "memory" / "chats" / "c1" / "index.md"
   note.parent.mkdir(parents=True)

--- a/backend/tests/test_chat_log_redaction.py
+++ b/backend/tests/test_chat_log_redaction.py
@@ -45,6 +45,18 @@ def test_hidden_user_message_is_dropped_entirely():
   ) is None
 
 
+def test_automatic_continuation_is_redacted_as_a_product_event():
+  assert r.redact_message({
+    "role": "user",
+    "content": "continue",
+    "kind": "auto_continuation",
+    "continuation_reason": "restart",
+  }) == {
+    "role": "system",
+    "text": "Automatic continuation (restart).",
+  }
+
+
 def test_pure_tool_turn_with_no_text_is_dropped():
   msg = {
     "role": "assistant",

--- a/backend/tests/test_chat_note.py
+++ b/backend/tests/test_chat_note.py
@@ -212,6 +212,21 @@ def test_render_transcript_keeps_visible_blocks_and_excludes_tool_secrets():
   assert "SECRET" not in rendered
 
 
+def test_render_transcript_labels_automatic_continuation_as_product_event():
+  cn = _load_chat_note()
+  raw = json.dumps([{
+    "role": "user",
+    "kind": "auto_continuation",
+    "continuation_reason": "restart",
+    "content": "continue",
+  }])
+
+  rendered = cn._render_transcript(raw)
+
+  assert rendered == "automatic continuation (restart): continue"
+  assert "user: continue" not in rendered
+
+
 def test_claude_summary_prompt_receives_complete_transcript(monkeypatch):
   cn = _load_chat_note()
   monkeypatch.setattr(cn, "_configured_provider", lambda: "claude")

--- a/backend/tests/test_claude_sdk_session_id.py
+++ b/backend/tests/test_claude_sdk_session_id.py
@@ -231,6 +231,21 @@ def test_resumed_context_skips_non_conversation_rows():
   assert "ignored" not in block
 
 
+def test_resumed_context_labels_automatic_continuation_as_product_event():
+  from app.chat import _build_resumed_context
+
+  row = _FakeChatRow([{
+    "role": "user",
+    "kind": "auto_continuation",
+    "continuation_reason": "restart",
+    "content": "continue",
+  }])
+  block = _build_resumed_context(row)
+
+  assert "Automatic continuation (restart): continue" in block
+  assert "User: continue" not in block
+
+
 def test_resumed_context_none_when_empty():
   """A chat with no usable transcript yields no reseed block."""
   from app.chat import _build_resumed_context

--- a/backend/tests/test_db_migrations.py
+++ b/backend/tests/test_db_migrations.py
@@ -83,6 +83,7 @@ def test_run_migrations_adds_park_columns_to_existing_chat_runs(tmp_path):
   cols = {c["name"] for c in inspector.get_columns("chat_runs")}
   assert "parked_until" in cols
   assert "park_reason" in cols
+  assert "restart_nonce" in cols
 
 
 def test_agent_lifecycle_width_migration_is_postgres_only_and_idempotent():
@@ -192,6 +193,9 @@ def test_run_migrations_adds_chat_auto_resume_policy(tmp_path):
   assert "auto_resume_on_limit" in cols
   assert cols["auto_resume_on_limit"]["nullable"] is False
   assert cols["auto_resume_on_limit"]["default"] is not None
+  assert "auto_resume_on_restart" in cols
+  assert cols["auto_resume_on_restart"]["nullable"] is False
+  assert cols["auto_resume_on_restart"]["default"] is not None
   assert "system_prompt_snapshot_id" in cols
   with eng.connect() as conn:
     value = conn.execute(text(
@@ -204,8 +208,12 @@ def test_run_migrations_adds_chat_auto_resume_policy(tmp_path):
       "SELECT auto_resume_on_limit FROM chats "
       "WHERE id = 'new-after-upgrade'"
     )).scalar_one()
+    restart_values = conn.execute(text(
+      "SELECT id, auto_resume_on_restart FROM chats ORDER BY id"
+    )).all()
   assert value in (True, 1)
   assert future_value in (True, 1)
+  assert all(restart in (False, 0) for _, restart in restart_values)
 
 
 def test_run_migrations_adds_bounded_live_assistant_snapshot(tmp_path):
@@ -236,6 +244,11 @@ def test_fresh_chat_schema_has_database_auto_resume_default():
   assert column.default is not None
   assert column.server_default is not None
   assert str(column.server_default.arg).lower() == "true"
+  restart = models.Chat.__table__.c.auto_resume_on_restart
+  assert restart.nullable is False
+  assert restart.default is not None
+  assert restart.server_default is not None
+  assert str(restart.server_default.arg).lower() == "false"
 
 
 def test_run_migrations_adds_owner_auto_resume_default(tmp_path):
@@ -261,11 +274,17 @@ def test_run_migrations_adds_owner_auto_resume_default(tmp_path):
   cols = {c["name"]: c for c in inspect(eng).get_columns("owner")}
   assert "auto_resume_on_limit_default" in cols
   assert cols["auto_resume_on_limit_default"]["nullable"] is False
+  assert "auto_resume_on_restart_default" in cols
+  assert cols["auto_resume_on_restart_default"]["nullable"] is False
   with eng.connect() as conn:
     value = conn.execute(text(
       "SELECT auto_resume_on_limit_default FROM owner WHERE id = 1"
     )).scalar_one()
+    restart_value = conn.execute(text(
+      "SELECT auto_resume_on_restart_default FROM owner WHERE id = 1"
+    )).scalar_one()
   assert value in (True, 1)
+  assert restart_value in (False, 0)
 
 
 def test_fresh_owner_schema_has_auto_resume_default():
@@ -275,3 +294,8 @@ def test_fresh_owner_schema_has_auto_resume_default():
   assert column.default is not None
   assert column.server_default is not None
   assert str(column.server_default.arg).lower() == "true"
+  restart = models.Owner.__table__.c.auto_resume_on_restart_default
+  assert restart.nullable is False
+  assert restart.default is not None
+  assert restart.server_default is not None
+  assert str(restart.server_default.arg).lower() == "false"

--- a/backend/tests/test_drain_for_restart.py
+++ b/backend/tests/test_drain_for_restart.py
@@ -95,6 +95,7 @@ def _run(chat_id: str):
       "status": row.status,
       "parked_until": row.parked_until,
       "park_reason": row.park_reason,
+      "restart_nonce": row.restart_nonce,
     }
   finally:
     db.close()
@@ -115,7 +116,9 @@ def _live_turn(chat_id: str, *, pending=None, partial="partial answer"):
 
 
 def _run_drain():
-  return asyncio.run(chat_mod.drain_all_for_restart())
+  return asyncio.run(chat_mod.drain_all_for_restart(
+    restart_nonce="restart-nonce-drain",
+  ))
 
 
 # -- (b) the drain persists the paused note + preserves partials --------------
@@ -126,7 +129,10 @@ def test_drain_persists_paused_note_and_preserves_partials():
   drained = _run_drain()
   _drain_writer()
 
-  assert drained == ["drain-note-1"]
+  assert drained == [{
+    "chat_id": "drain-note-1",
+    "run_token": "rt-drain-note-1",
+  }]
   assert handle.stop_calls == 1
   state = _chat("drain-note-1")
   blocks = state["messages"][-1]["blocks"]
@@ -145,6 +151,32 @@ def test_drain_persists_paused_note_and_preserves_partials():
   assert _run("drain-note-1")["status"] == "parked"
   assert _run("drain-note-1")["park_reason"] == "restart"
   assert _run("drain-note-1")["parked_until"] is not None
+  assert _run("drain-note-1")["restart_nonce"] == "restart-nonce-drain"
+
+
+def test_drain_finalizes_running_tool_before_clearing_reconcile_marker():
+  cid = "drain-running-tool"
+  _, sink, _ = _live_turn(cid, partial="")
+  sink.publish({
+    "type": "tool_start",
+    "tool": "Bash",
+    "input": "long command",
+    "tool_use_id": "tool-drain-1",
+  })
+
+  assert _run_drain() == [{
+    "chat_id": cid,
+    "run_token": f"rt-{cid}",
+  }]
+  _drain_writer()
+
+  state = _chat(cid)
+  tool = next(
+    block for block in state["messages"][-1]["blocks"]
+    if block.get("type") == "tool"
+  )
+  assert tool["status"] == "done"
+  assert state["run_status"] is None
 
 
 # -- (a) DrainForRestart preserves the queue; stop_chat_for clears it ---------
@@ -210,7 +242,7 @@ def test_drain_park_failure_leaves_generic_marker_for_manual_recovery(
     raise RuntimeError("writer unavailable")
 
   monkeypatch.setattr(chat_mod, "_park_run_strict", _fail_park)
-  assert _run_drain() == [cid]
+  assert _run_drain() == []
   _drain_writer()
 
   assert _chat(cid)["run_status"] == "running"
@@ -226,7 +258,7 @@ def test_drain_without_exact_run_token_stays_manual():
   handle = _Handle(cid)
   registry.register(handle)
 
-  assert _run_drain() == [cid]
+  assert _run_drain() == []
   _drain_writer()
 
   assert _chat(cid)["run_status"] == "running"

--- a/backend/tests/test_drain_for_restart.py
+++ b/backend/tests/test_drain_for_restart.py
@@ -2,12 +2,12 @@
 
 Locks in the four contracts that distinguish a restart-drain from a Stop:
 
-  (a) DrainForRestart PRESERVES pending_messages + the run marker, while
-      stop_chat_for CLEARS the queue (contrast).
+  (a) DrainForRestart PRESERVES pending_messages and moves the exact run to a
+      due restart park, while stop_chat_for CLEARS the queue (contrast).
   (b) The drain persists the "paused for a platform update" note WITHOUT losing
       the accumulated partial blocks.
-  (c) Boot reconcile marks the paused note resumable (no double note) and the
-      boot notify fires exactly once.
+  (c) Generic boot reconciliation stays manual; display text alone never
+      manufactures planned-restart intent.
   (d) A send arriving while draining QUEUES instead of starting a turn.
 """
 
@@ -83,6 +83,23 @@ def _chat(chat_id: str):
     db.close()
 
 
+def _run(chat_id: str):
+  db = SessionLocal()
+  try:
+    row = db.query(models.ChatRun).filter(
+      models.ChatRun.chat_id == chat_id,
+    ).order_by(models.ChatRun.started_at.desc()).first()
+    if row is None:
+      return None
+    return {
+      "status": row.status,
+      "parked_until": row.parked_until,
+      "park_reason": row.park_reason,
+    }
+  finally:
+    db.close()
+
+
 def _live_turn(chat_id: str, *, pending=None, partial="partial answer"):
   """A live turn with a registered handle + sink, mid-stream (a real partial
   accumulated INTO the sink so the drain's finalize can preserve it)."""
@@ -124,6 +141,10 @@ def test_drain_persists_paused_note_and_preserves_partials():
     and b.get("message") == chat_mod.PAUSED_FOR_RESTART_MESSAGE
     for b in blocks
   )
+  # The exact run, not the display text, is the durable restart intent.
+  assert _run("drain-note-1")["status"] == "parked"
+  assert _run("drain-note-1")["park_reason"] == "restart"
+  assert _run("drain-note-1")["parked_until"] is not None
 
 
 # -- (a) DrainForRestart preserves the queue; stop_chat_for clears it ---------
@@ -133,12 +154,14 @@ def test_drain_preserves_pending_while_stop_clears_it():
   _live_turn("drain-keep", pending=list(queued))
   _live_turn("stop-clear", pending=list(queued))
 
-  # Drain-for-restart: queue + run marker intact.
+  # Drain-for-restart: queue intact; exact run moved to a due restart park.
   _run_drain()
   _drain_writer()
   drained_state = _chat("drain-keep")
   assert drained_state["pending"] == queued
-  assert drained_state["run_status"] == "running"  # marker LEFT for reconcile
+  assert drained_state["run_status"] is None
+  assert _run("drain-keep")["status"] == "parked"
+  assert _run("drain-keep")["park_reason"] == "restart"
 
   # Stop: queue collapsed (frontend resends; backend clears). The drain above
   # left the process-wide gate set (in production only the restart ends it), so
@@ -176,6 +199,40 @@ def test_drain_does_not_promote_the_queue():
   assert "drain-nopromote" in chat_mod._restart_draining_chats
 
 
+def test_drain_park_failure_leaves_generic_marker_for_manual_recovery(
+  monkeypatch,
+):
+  cid = "drain-park-failure"
+  _live_turn(cid)
+
+  async def _fail_park(*args, **kwargs):
+    del args, kwargs
+    raise RuntimeError("writer unavailable")
+
+  monkeypatch.setattr(chat_mod, "_park_run_strict", _fail_park)
+  assert _run_drain() == [cid]
+  _drain_writer()
+
+  assert _chat(cid)["run_status"] == "running"
+  assert _run(cid)["status"] == "running"
+
+
+def test_drain_without_exact_run_token_stays_manual():
+  cid = "drain-no-token"
+  _seed(cid)
+  bc = create_broadcast(cid)
+  sink = chat_mod._ChatEventSink(bc, cid, run_token=None)
+  chat_mod.register_active_sink(cid, sink)
+  handle = _Handle(cid)
+  registry.register(handle)
+
+  assert _run_drain() == [cid]
+  _drain_writer()
+
+  assert _chat(cid)["run_status"] == "running"
+  assert _run(cid)["status"] == "running"
+
+
 # -- (c) boot reconcile marks the note resumable (no double note) + notify once
 
 
@@ -198,6 +255,7 @@ def test_reconcile_marks_paused_note_resumable_without_double_note():
   assert cid in reconciled
   state = _chat(cid)
   assert state["run_status"] is None
+  assert _run(cid)["status"] == "interrupted"
   blocks = state["messages"][-1]["blocks"]
   errors = [b for b in blocks if b.get("type") == "error"]
   # Exactly ONE error note (no second interrupted note stacked on the drain's),
@@ -223,6 +281,7 @@ def test_reconcile_crash_note_is_resumable():
     db.close()
 
   assert cid in reconciled
+  assert _run(cid)["status"] == "interrupted"
   blocks = _chat(cid)["messages"][-1]["blocks"]
   note = next(b for b in blocks if b.get("type") == "error")
   assert note["resumable"] is True
@@ -255,6 +314,60 @@ def test_reconcile_question_tail_note_is_not_resumable():
   note = next(b for b in blocks if b.get("type") == "error")
   assert "answer is still needed" in note["message"]
   assert not note.get("resumable")
+
+
+def test_reconcile_restart_note_normalizes_before_open_question():
+  """A fallback marker may contain either historical block ordering."""
+  cid = "reco-restart-question-order"
+  _seed(cid, messages=[
+    {"role": "user", "content": "hi", "ts": 1},
+    {"role": "assistant", "ts": 2, "content": "", "blocks": [
+      {"type": "text", "content": "thinking"},
+      {"type": "question", "questions": [{"question": "Which one?"}]},
+      {
+        "type": "error",
+        "message": chat_mod.PAUSED_FOR_RESTART_MESSAGE,
+        "resumable": True,
+        "pause": {"kind": "restart"},
+      },
+    ]},
+  ])
+
+  db = SessionLocal()
+  try:
+    assert chat_mod.reconcile_interrupted_chats(db) == [cid]
+  finally:
+    db.close()
+
+  blocks = _chat(cid)["messages"][-1]["blocks"]
+  assert [block["type"] for block in blocks] == [
+    "text", "error", "question",
+  ]
+  assert not blocks[1].get("resumable")
+  assert blocks[1]["pause"] == {"kind": "restart"}
+
+
+def test_historical_restart_note_does_not_mask_a_newer_crash():
+  cid = "reco-historical-restart-note"
+  _seed(cid, messages=[
+    {"role": "user", "content": "hi", "ts": 1},
+    {"role": "assistant", "ts": 2, "content": "new work", "blocks": [
+      {"type": "error", "message": chat_mod.PAUSED_FOR_RESTART_MESSAGE},
+      {"type": "text", "content": "new work after recovery"},
+    ]},
+  ])
+
+  db = SessionLocal()
+  try:
+    assert chat_mod.reconcile_interrupted_chats(db) == [cid]
+  finally:
+    db.close()
+
+  blocks = _chat(cid)["messages"][-1]["blocks"]
+  errors = [block for block in blocks if block.get("type") == "error"]
+  assert len(errors) == 2
+  assert errors[-1]["message"] != chat_mod.PAUSED_FOR_RESTART_MESSAGE
+  assert errors[-1]["resumable"] is True
 
 
 def test_notify_after_reconcile_fires_once(owner_token, monkeypatch):

--- a/backend/tests/test_events.py
+++ b/backend/tests/test_events.py
@@ -981,6 +981,32 @@ def test_process_error_event_carries_whitelisted_extras_on_append():
   }
 
 
+def test_restart_error_stays_before_unanswered_question_without_resume():
+  blocks = [
+    {"type": "text", "content": "I need one detail."},
+    {
+      "type": "question",
+      "questions": [{"question": "Which color?"}],
+    },
+  ]
+  event = {
+    "type": "error",
+    "message": "Paused for a platform update.",
+    "resumable": True,
+    "pause": {"kind": "restart"},
+  }
+
+  process_event(event, blocks)
+  process_event(event, blocks)
+
+  assert [block["type"] for block in blocks] == [
+    "text", "error", "question",
+  ]
+  marker = blocks[1]
+  assert marker["pause"] == {"kind": "restart"}
+  assert not marker.get("resumable")
+
+
 def test_process_error_event_extras_are_whitelist_only():
   """An unexpected event key must NOT leak into the durable transcript."""
   blocks = []

--- a/backend/tests/test_limit_park.py
+++ b/backend/tests/test_limit_park.py
@@ -1,4 +1,4 @@
-"""Provider-limit parking (design §2.4): parse → park → sweep → resume.
+"""Durable continuation (design §2.4): parse/drain → park → sweep → resume.
 
 Locks in the six contracts of the limit-park feature:
 
@@ -18,6 +18,8 @@ Locks in the six contracts of the limit-park feature:
       park per tick, none while any turn is live; the resumed turn combines
       the preserved queue + a "continue" into one continuation.
   (f) The parks are observable: /api/debug/status lists parked runs.
+  (g) A planned restart reuses the same exact-run state with a due-now time;
+      crashes, unanswered questions, and app-owned work stay manual.
 """
 
 import asyncio
@@ -70,14 +72,18 @@ def _drain_writer():
 
 def _seed_chat(
   chat_id: str, *, pending=None, run_status=None, deleted=False,
-  auto_resume=False,
+  auto_resume=False, messages=None,
 ):
   db = SessionLocal()
   try:
     db.add(models.Chat(
       id=chat_id,
       title="t",
-      messages=[{"role": "user", "content": "do work", "ts": 1}],
+      messages=(
+        messages
+        if messages is not None
+        else [{"role": "user", "content": "do work", "ts": 1}]
+      ),
       pending_messages=pending or [],
       session_id="sess",
       provider="claude",
@@ -286,6 +292,20 @@ def test_park_run_parks_row_and_clears_marker():
   assert _chat_row(cid)["run_status"] is None
 
 
+def test_park_run_missing_exact_row_keeps_generic_marker():
+  """Losing the exact identity must fail safe into manual crash recovery."""
+  cid = "park-missing-exact-row"
+  _seed_chat(cid, run_status="running")
+
+  parked = get_writer().submit(ParkRun(
+    chat_id=cid, run_token="rt-does-not-exist",
+    parked_until=datetime(2026, 7, 11, 1, 40), park_reason="restart",
+  )).result(timeout=5)
+
+  assert parked is False
+  assert _chat_row(cid)["run_status"] == "running"
+
+
 def test_park_run_superseded_owner_completes_without_parking():
   """A dying run whose marker a fresh turn took must NOT park (a stale park
   would fire a spurious notify) — its own row closes 'completed' and the
@@ -485,13 +505,15 @@ def test_park_run_strict_tokenless_falls_back_to_marker_clear():
 
 def _due_park(
   cid: str, token: str, *, pending=None, deleted=False, auto_resume=False,
+  park_reason=None, messages=None,
 ):
   _seed_chat(
     cid, pending=pending, deleted=deleted, auto_resume=auto_resume,
+    messages=messages,
   )
   _seed_run(cid, token, status="parked",
             parked_until=datetime.now(UTC).replace(tzinfo=None)
-            - timedelta(minutes=1))
+            - timedelta(minutes=1), park_reason=park_reason)
 
 
 def _run_sweep():
@@ -628,6 +650,8 @@ def test_sweep_auto_resume_on_starts_one_serial_continue(
     promoted = scheduled[0]["next_user"]
     assert "queued ask" in promoted["content"]
     assert "continue" in promoted["content"]
+    assert promoted["_messages"][-1]["kind"] == "auto_continuation"
+    assert promoted["_messages"][-1]["continuation_reason"] == "usage_limit"
     state = _chat_row("sweep-auto")
     assert state["pending"] == []
     assert state["run_status"] == "running"  # PromotePending set the marker
@@ -635,6 +659,105 @@ def test_sweep_auto_resume_on_starts_one_serial_continue(
     # _schedule_continuation was stubbed, so release the claim it would have
     # handed to the spawned turn.
     chat_mod.discard_starting("sweep-auto")
+
+
+def test_restart_park_auto_continues_with_product_marker(
+  owner_token, monkeypatch,
+):
+  del owner_token
+  notifications = []
+  monkeypatch.setattr(
+    "app.push.notify_owner",
+    lambda *args, **kwargs: notifications.append(kwargs) or "notif-id",
+  )
+  scheduled = []
+  monkeypatch.setattr(
+    chat_mod, "_schedule_continuation",
+    lambda **kwargs: scheduled.append(kwargs),
+  )
+  cid = "restart-auto"
+  token = f"rt-{cid}"
+  _due_park(cid, token, auto_resume=True, park_reason="restart")
+
+  try:
+    assert _run_sweep() == [cid]
+    assert len(scheduled) == 1
+    marker = scheduled[0]["next_user"]["_messages"][-1]
+    assert marker["role"] == "user"
+    assert marker["content"] == "continue"
+    assert marker["kind"] == "auto_continuation"
+    assert marker["continuation_reason"] == "restart"
+    assert marker["cid"] == f"restart-resume-{token}"
+    assert notifications[0]["title"] == "Möbius restarted"
+    assert "limit" not in notifications[0]["body"].lower()
+  finally:
+    chat_mod.discard_starting(cid)
+
+
+def test_restart_park_waiting_on_question_stays_manual(
+  owner_token, monkeypatch,
+):
+  del owner_token
+  notifications = []
+  monkeypatch.setattr(
+    "app.push.notify_owner",
+    lambda *args, **kwargs: notifications.append(kwargs) or "notif-id",
+  )
+  resumes = []
+
+  async def _fake_resume(*args, **kwargs):
+    resumes.append((args, kwargs))
+    return True
+
+  monkeypatch.setattr(chat_mod, "_auto_resume_chat", _fake_resume)
+  cid = "restart-question"
+  _due_park(
+    cid,
+    f"rt-{cid}",
+    auto_resume=True,
+    park_reason="restart",
+    messages=[
+      {"role": "user", "content": "help me choose", "ts": 1},
+      {
+        "role": "assistant",
+        "ts": 2,
+        "blocks": [
+          {
+            "type": "error",
+            "message": chat_mod.PAUSED_FOR_RESTART_MESSAGE,
+            "pause": {"kind": "restart"},
+          },
+          {
+            "type": "question",
+            "questions": [{"question": "Which one?"}],
+          },
+        ],
+      },
+    ],
+  )
+
+  assert _run_sweep() == [cid]
+  assert resumes == []
+  assert _run_row(f"rt-{cid}")["status"] == "interrupted"
+  assert notifications[0]["title"] == "Möbius restarted"
+
+
+def test_restart_park_policy_off_resolves_to_manual_interruption(
+  owner_token, monkeypatch,
+):
+  del owner_token
+  notifications = []
+  monkeypatch.setattr(
+    "app.push.notify_owner",
+    lambda *args, **kwargs: notifications.append(kwargs) or "notif-id",
+  )
+  cid = "restart-policy-off"
+  _due_park(cid, f"rt-{cid}", auto_resume=False, park_reason="restart")
+
+  assert _run_sweep() == [cid]
+  assert _run_row(f"rt-{cid}")["status"] == "interrupted"
+  assert notifications[0]["title"] == "Möbius restarted"
+  assert "limit" not in notifications[0]["body"].lower()
 
 
 def test_sweep_auto_resume_defers_while_any_turn_is_live(
@@ -993,6 +1116,27 @@ def test_auto_resume_rechecks_app_work_inside_queue_handoff():
   assert not chat_mod.is_chat_running(cid)
 
 
+def test_auto_resume_rechecks_app_run_at_locked_handoff():
+  """A direct or stale sweep caller cannot bypass durable attribution."""
+  cid = "auto-final-app-run-check"
+  park_token = f"rt-{cid}"
+  _seed_chat(cid, auto_resume=True)
+  _seed_run(
+    cid,
+    park_token,
+    status="resume_pending",
+    started_offset=-30,
+    initiated_by_app_id=11,
+  )
+
+  assert asyncio.run(
+    chat_mod._auto_resume_chat(cid, "claude", park_token=park_token)
+  ) is False
+  assert _chat_row(cid)["pending"] == []
+  assert _run_row(park_token)["status"] == "resume_pending"
+  assert not chat_mod.is_chat_running(cid)
+
+
 # -- (f) observability ----------------------------------------------------------
 
 def test_debug_status_lists_parked_runs(client, auth):
@@ -1098,7 +1242,7 @@ def test_parked_probe_tiebreak_is_deterministic():
 
 
 def _limit_complete_turn(cid, *, parked_until, monkeypatch=None,
-                         park_raises=False):
+                         park_raises=False, park_returns_false=False):
   """Drive _complete_turn's limit branch with a real bc + sink + seeded run."""
   from app.broadcast import create_broadcast
 
@@ -1114,6 +1258,10 @@ def _limit_complete_turn(cid, *, parked_until, monkeypatch=None,
     async def _boom(*a, **kw):
       raise RuntimeError("park exploded")
     monkeypatch.setattr(chat_mod, "_park_run_strict", _boom)
+  elif park_returns_false:
+    async def _not_parked(*a, **kw):
+      return False
+    monkeypatch.setattr(chat_mod, "_park_run_strict", _not_parked)
 
   db = SessionLocal()
   disposition = asyncio.run(chat_mod._complete_turn(
@@ -1148,6 +1296,24 @@ def test_park_failure_degrades_card_and_keeps_resume(monkeypatch):
   # The degraded follow-up carries no pause descriptor, so the coalesced block
   # stops rendering the "resets at …" card.
   assert "pause" not in tail
+
+
+def test_park_false_result_uses_same_manual_recovery_fallback(monkeypatch):
+  cid = "park-false-result"
+  until = datetime.now(UTC).replace(tzinfo=None) + timedelta(hours=1)
+
+  disposition = _limit_complete_turn(
+    cid,
+    parked_until=until,
+    monkeypatch=monkeypatch,
+    park_returns_false=True,
+  )
+
+  assert disposition.value == "failed_leave_marker"
+  assert _chat_row(cid)["run_status"] == "running"
+  tail = _chat_row(cid)["messages"][-1]["blocks"][-1]
+  assert "could not be scheduled" in tail["message"]
+  assert not tail.get("pause")
 
 
 def test_limit_park_releases_starting_claim_before_returning():

--- a/backend/tests/test_limit_park.py
+++ b/backend/tests/test_limit_park.py
@@ -314,6 +314,39 @@ def test_restart_park_carries_one_shot_intent_nonce():
   assert row["restart_nonce"] == "nonce-park-1234"
 
 
+def test_restart_park_idempotency_requires_the_same_nonce():
+  cid = "park-restart-idempotency"
+  token = "rt-park-restart-idempotency"
+  _seed_chat(cid)
+  _seed_run(
+    cid,
+    token,
+    status="parked",
+    parked_until=datetime(2026, 7, 11, 1, 40),
+    park_reason="restart",
+    restart_nonce="nonce-first-1234",
+  )
+
+  same = get_writer().submit(ParkRun(
+    chat_id=cid,
+    run_token=token,
+    parked_until=datetime(2026, 7, 11, 1, 40),
+    park_reason="restart",
+    restart_nonce="nonce-first-1234",
+  )).result(timeout=5)
+  different = get_writer().submit(ParkRun(
+    chat_id=cid,
+    run_token=token,
+    parked_until=datetime(2026, 7, 11, 1, 40),
+    park_reason="restart",
+    restart_nonce="nonce-second-1234",
+  )).result(timeout=5)
+
+  assert same is True
+  assert different is False
+  assert _run_row(token)["restart_nonce"] == "nonce-first-1234"
+
+
 def test_park_run_missing_exact_row_keeps_generic_marker():
   """Losing the exact identity must fail safe into manual crash recovery."""
   cid = "park-missing-exact-row"
@@ -834,6 +867,32 @@ def test_restart_park_without_current_boot_ack_stays_manual(
   assert notifications[0]["title"] == "Möbius restarted"
 
 
+def test_restart_park_rejects_ack_for_the_wrong_nonce(
+  owner_token, monkeypatch,
+):
+  del owner_token
+  cid = "restart-wrong-ack"
+  token = f"rt-{cid}"
+  monkeypatch.setattr(
+    "app.push.notify_owner", lambda *args, **kwargs: "notif-id",
+  )
+  monkeypatch.setattr(
+    "app.restart_ledger.authorized_runs",
+    lambda: {token: (cid, "different-nonce-1234")},
+  )
+  _due_park(
+    cid,
+    token,
+    auto_restart=True,
+    park_reason="restart",
+    restart_nonce="db-nonce-12345678",
+  )
+
+  assert _run_sweep() == [cid]
+  assert _run_row(token)["status"] == "interrupted"
+  assert _run_row(token)["restart_nonce"] is None
+
+
 def test_restart_spawn_failure_retires_one_shot_authorization(
   owner_token, monkeypatch,
 ):
@@ -914,6 +973,79 @@ def test_unacknowledged_restart_pending_cannot_bypass_via_idle_sweep(
     db.close()
   assert scheduled == []
   assert _chat_row(cid)["pending"]
+
+
+def test_owner_send_releases_restart_manual_hold():
+  """Manual recovery remains available after automatic replay fails closed."""
+  cid = "restart-manual-owner-send"
+  token = f"rt-{cid}"
+  _seed_chat(cid)
+  _seed_run(
+    cid, token, status="interrupted", park_reason="restart",
+    restart_nonce=None, started_offset=-60,
+  )
+
+  db = SessionLocal()
+  try:
+    assert chat_mod._restart_manual_hold_for_chat(db, cid) is True
+  finally:
+    db.close()
+
+  get_writer().submit(StartTurn(
+    chat_id=cid,
+    run_token=f"{token}-manual",
+    user_msg={
+      "role": "user",
+      "content": "continue",
+      "ts": 2,
+      "cid": f"manual-resume-{token}",
+    },
+    title_source="continue",
+    default_provider="claude",
+  )).result(timeout=5)
+
+  db = SessionLocal()
+  try:
+    assert chat_mod._restart_manual_hold_for_chat(db, cid) is False
+  finally:
+    db.close()
+  assert _run_row(f"{token}-manual")["status"] == "running"
+
+
+def test_owner_send_drains_preserved_queue_and_releases_restart_hold():
+  """The real stale-pending owner-send path is not blocked by the hold."""
+  cid = "restart-manual-pending-send"
+  token = f"rt-{cid}"
+  _seed_chat(
+    cid,
+    pending=[{
+      "role": "user",
+      "content": "continue",
+      "ts": 1,
+      "cid": f"restart-resume-{token}",
+      "kind": "auto_continuation",
+      "continuation_reason": "restart",
+    }],
+  )
+  _seed_run(
+    cid, token, status="interrupted", park_reason="restart",
+    restart_nonce=None, started_offset=-60,
+  )
+  promoted_token = f"{token}-owner"
+
+  result = get_writer().submit(PromotePending(
+    chat_id=cid,
+    run_token=promoted_token,
+  )).result(timeout=5)
+
+  assert result["promoted"]["content"] == "continue"
+  assert _chat_row(cid)["pending"] == []
+  assert _run_row(promoted_token)["status"] == "running"
+  db = SessionLocal()
+  try:
+    assert chat_mod._restart_manual_hold_for_chat(db, cid) is False
+  finally:
+    db.close()
 
 
 def test_sweep_auto_resume_defers_while_any_turn_is_live(

--- a/backend/tests/test_limit_park.py
+++ b/backend/tests/test_limit_park.py
@@ -72,7 +72,7 @@ def _drain_writer():
 
 def _seed_chat(
   chat_id: str, *, pending=None, run_status=None, deleted=False,
-  auto_resume=False, messages=None,
+  auto_resume=False, auto_restart=False, messages=None,
 ):
   db = SessionLocal()
   try:
@@ -88,6 +88,7 @@ def _seed_chat(
       session_id="sess",
       provider="claude",
       auto_resume_on_limit=auto_resume,
+      auto_resume_on_restart=auto_restart,
       run_status=run_status,
       run_started_at=(
         datetime.now(UTC).replace(tzinfo=None) if run_status else None
@@ -103,7 +104,7 @@ def _seed_chat(
 
 def _seed_run(chat_id: str, token: str, *, status="running",
               parked_until=None, park_reason=None, started_offset=0,
-              initiated_by_app_id=None):
+              initiated_by_app_id=None, restart_nonce=None):
   db = SessionLocal()
   try:
     db.add(models.ChatRun(
@@ -118,6 +119,7 @@ def _seed_run(chat_id: str, token: str, *, status="running",
       ),
       parked_until=parked_until,
       park_reason=park_reason,
+      restart_nonce=restart_nonce,
     ))
     db.commit()
   finally:
@@ -134,6 +136,7 @@ def _run_row(token: str):
       "status": run.status,
       "parked_until": run.parked_until,
       "park_reason": run.park_reason,
+      "restart_nonce": run.restart_nonce,
       "ended_at": run.ended_at,
     }
   finally:
@@ -290,6 +293,25 @@ def test_park_run_parks_row_and_clears_marker():
   assert row["ended_at"] is not None
   # The per-chat marker is cleared: the turn is over, the chat is not busy.
   assert _chat_row(cid)["run_status"] is None
+
+
+def test_restart_park_carries_one_shot_intent_nonce():
+  cid = "park-restart-nonce"
+  token = "rt-park-restart-nonce"
+  _seed_chat(cid, run_status="running")
+  _seed_run(cid, token)
+
+  get_writer().submit(ParkRun(
+    chat_id=cid,
+    run_token=token,
+    parked_until=datetime(2026, 7, 11, 1, 40),
+    park_reason="restart",
+    restart_nonce="nonce-park-1234",
+  )).result(timeout=5)
+
+  row = _run_row(token)
+  assert row["status"] == "parked"
+  assert row["restart_nonce"] == "nonce-park-1234"
 
 
 def test_park_run_missing_exact_row_keeps_generic_marker():
@@ -505,15 +527,16 @@ def test_park_run_strict_tokenless_falls_back_to_marker_clear():
 
 def _due_park(
   cid: str, token: str, *, pending=None, deleted=False, auto_resume=False,
-  park_reason=None, messages=None,
+  auto_restart=False, park_reason=None, messages=None, restart_nonce=None,
 ):
   _seed_chat(
     cid, pending=pending, deleted=deleted, auto_resume=auto_resume,
-    messages=messages,
+    auto_restart=auto_restart, messages=messages,
   )
   _seed_run(cid, token, status="parked",
             parked_until=datetime.now(UTC).replace(tzinfo=None)
-            - timedelta(minutes=1), park_reason=park_reason)
+            - timedelta(minutes=1), park_reason=park_reason,
+            restart_nonce=restart_nonce)
 
 
 def _run_sweep():
@@ -677,7 +700,15 @@ def test_restart_park_auto_continues_with_product_marker(
   )
   cid = "restart-auto"
   token = f"rt-{cid}"
-  _due_park(cid, token, auto_resume=True, park_reason="restart")
+  nonce = "restart-nonce-auto"
+  monkeypatch.setattr(
+    "app.restart_ledger.authorized_runs",
+    lambda: {token: (cid, nonce)},
+  )
+  _due_park(
+    cid, token, auto_resume=True, auto_restart=True,
+    park_reason="restart", restart_nonce=nonce,
+  )
 
   try:
     assert _run_sweep() == [cid]
@@ -711,11 +742,19 @@ def test_restart_park_waiting_on_question_stays_manual(
 
   monkeypatch.setattr(chat_mod, "_auto_resume_chat", _fake_resume)
   cid = "restart-question"
+  token = f"rt-{cid}"
+  nonce = "restart-nonce-question"
+  monkeypatch.setattr(
+    "app.restart_ledger.authorized_runs",
+    lambda: {token: (cid, nonce)},
+  )
   _due_park(
     cid,
-    f"rt-{cid}",
+    token,
     auto_resume=True,
+    auto_restart=True,
     park_reason="restart",
+    restart_nonce=nonce,
     messages=[
       {"role": "user", "content": "help me choose", "ts": 1},
       {
@@ -752,12 +791,129 @@ def test_restart_park_policy_off_resolves_to_manual_interruption(
     lambda *args, **kwargs: notifications.append(kwargs) or "notif-id",
   )
   cid = "restart-policy-off"
-  _due_park(cid, f"rt-{cid}", auto_resume=False, park_reason="restart")
+  token = f"rt-{cid}"
+  nonce = "restart-nonce-policy"
+  monkeypatch.setattr(
+    "app.restart_ledger.authorized_runs",
+    lambda: {token: (cid, nonce)},
+  )
+  # Provider-limit policy is deliberately ON. Separate restart consent remains
+  # off, proving the legacy preference cannot broaden into restart replay.
+  _due_park(
+    cid, token, auto_resume=True, auto_restart=False,
+    park_reason="restart", restart_nonce=nonce,
+  )
 
   assert _run_sweep() == [cid]
   assert _run_row(f"rt-{cid}")["status"] == "interrupted"
   assert notifications[0]["title"] == "Möbius restarted"
   assert "limit" not in notifications[0]["body"].lower()
+
+
+def test_restart_park_without_current_boot_ack_stays_manual(
+  owner_token, monkeypatch,
+):
+  """OOM after DB park but before supervisor acceptance cannot auto-replay."""
+  del owner_token
+  notifications = []
+  monkeypatch.setattr(
+    "app.push.notify_owner",
+    lambda *args, **kwargs: notifications.append(kwargs) or "notif-id",
+  )
+  monkeypatch.setattr("app.restart_ledger.authorized_runs", lambda: {})
+  cid = "restart-no-ack"
+  token = f"rt-{cid}"
+  _due_park(
+    cid, token, auto_restart=True, park_reason="restart",
+    restart_nonce="unaccepted-nonce-1234",
+  )
+
+  assert _run_sweep() == [cid]
+  assert _run_row(token)["status"] == "interrupted"
+  assert _run_row(token)["restart_nonce"] is None
+  assert notifications[0]["title"] == "Möbius restarted"
+
+
+def test_restart_spawn_failure_retires_one_shot_authorization(
+  owner_token, monkeypatch,
+):
+  del owner_token
+  cid = "restart-spawn-failure"
+  token = f"rt-{cid}"
+  nonce = "restart-nonce-spawn"
+  monkeypatch.setattr(
+    "app.push.notify_owner", lambda *args, **kwargs: "notif-id",
+  )
+  monkeypatch.setattr(
+    "app.restart_ledger.authorized_runs",
+    lambda: {token: (cid, nonce)},
+  )
+  _due_park(
+    cid, token, auto_restart=True, park_reason="restart",
+    restart_nonce=nonce,
+  )
+  original_create_broadcast = chat_mod.create_broadcast
+
+  def _spawn_fails(chat_id):
+    del chat_id
+    raise RuntimeError("spawn failed")
+
+  monkeypatch.setattr(chat_mod, "create_broadcast", _spawn_fails)
+  try:
+    assert _run_sweep() == []
+  finally:
+    monkeypatch.setattr(
+      chat_mod, "create_broadcast", original_create_broadcast,
+    )
+
+  row = _run_row(token)
+  assert row["status"] == "interrupted"
+  assert row["restart_nonce"] is None
+  state = _chat_row(cid)
+  assert state["run_status"] is None
+  assert state["pending"][-1]["cid"] == f"restart-resume-{token}"
+  assert _run_sweep() == []
+  db = SessionLocal()
+  try:
+    assert chat_mod._restart_manual_hold_for_chat(db, cid) is True
+    assert asyncio.run(chat_mod.sweep_idle_pending_chats(db)) == []
+  finally:
+    db.close()
+
+
+def test_unacknowledged_restart_pending_cannot_bypass_via_idle_sweep(
+  monkeypatch,
+):
+  cid = "restart-idle-bypass"
+  token = f"rt-{cid}"
+  _seed_chat(
+    cid,
+    pending=[{
+      "role": "user",
+      "content": "continue",
+      "ts": 1,
+      "cid": f"restart-resume-{token}",
+      "kind": "auto_continuation",
+      "continuation_reason": "restart",
+    }],
+  )
+  _seed_run(
+    cid, token, status="interrupted", park_reason="restart",
+    restart_nonce=None,
+  )
+  scheduled = []
+  monkeypatch.setattr(
+    chat_mod, "_schedule_continuation",
+    lambda **kwargs: scheduled.append(kwargs),
+  )
+
+  db = SessionLocal()
+  try:
+    assert asyncio.run(chat_mod.sweep_idle_pending_chats(db)) == []
+  finally:
+    db.close()
+  assert scheduled == []
+  assert _chat_row(cid)["pending"]
 
 
 def test_sweep_auto_resume_defers_while_any_turn_is_live(

--- a/backend/tests/test_restart_ledger.py
+++ b/backend/tests/test_restart_ledger.py
@@ -1,0 +1,190 @@
+"""One-shot planned-restart cause authentication across process boots."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+from app import restart_ledger as platform_ledger
+
+
+def _load_supervisor():
+  path = (
+    Path(__file__).resolve().parents[1]
+    / "recovery"
+    / "restart_ledger.py"
+  )
+  spec = importlib.util.spec_from_file_location("frozen_restart_ledger", path)
+  assert spec and spec.loader
+  module = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(module)
+  return module
+
+
+def _bind(supervisor, root: Path, monkeypatch) -> None:
+  monkeypatch.setattr(supervisor, "DATA_DIR", root)
+  monkeypatch.setattr(
+    supervisor, "INTENT_PATH",
+    root / ".restart-continuation-intent.json",
+  )
+  monkeypatch.setattr(
+    supervisor, "REQUEST_PATH", root / ".platform-restart-requested",
+  )
+  monkeypatch.setattr(supervisor, "LEDGER_DIR", root / ".restart-ledger")
+  monkeypatch.setattr(
+    supervisor, "ACCEPTED_PATH",
+    root / ".restart-ledger" / "accepted.json",
+  )
+  monkeypatch.setattr(
+    supervisor, "ACK_PATH", root / ".restart-ledger" / "ack.json",
+  )
+  monkeypatch.setattr(
+    supervisor, "BOOT_PATH", root / ".restart-ledger" / "boot-id",
+  )
+  monkeypatch.setattr(supervisor, "SUPERVISOR_UID", os.getuid())
+  monkeypatch.setattr(supervisor, "SUPERVISOR_GID", os.getgid())
+  monkeypatch.setattr(
+    platform_ledger,
+    "get_settings",
+    lambda: SimpleNamespace(data_dir=str(root)),
+  )
+
+
+def _request(root: Path, *, boot: str, nonce: str, now: float) -> None:
+  platform_ledger.request_restart(
+    boot_id=boot,
+    nonce=nonce,
+    runs=[{"chat_id": "chat-12345678", "run_token": "run-12345678"}],
+    now=now,
+  )
+
+
+def _authorized(root: Path, boot: str):
+  del root
+  return platform_ledger.authorized_runs(
+    boot,
+    trusted_uid=os.getuid(),
+    trusted_gid=os.getgid(),
+  )
+
+
+def test_exact_accepted_restart_is_bound_to_immediately_following_boot(
+  tmp_path, monkeypatch,
+):
+  supervisor = _load_supervisor()
+  _bind(supervisor, tmp_path, monkeypatch)
+  now = time.time()
+  source_boot = "boot-source-1234"
+  target_boot = "boot-target-1234"
+  nonce = "nonce-12345678"
+
+  assert supervisor.begin_boot(source_boot, now=now) is False
+  _request(tmp_path, boot=source_boot, nonce=nonce, now=now)
+  assert supervisor.accept(source_boot, now=now + 1) is True
+  assert supervisor.begin_boot(target_boot, now=now + 2) is True
+
+  assert _authorized(tmp_path, target_boot) == {
+    "run-12345678": ("chat-12345678", nonce),
+  }
+  assert _authorized(tmp_path, source_boot) == {}
+
+
+def test_crash_after_intent_before_supervisor_acceptance_is_not_authorized(
+  tmp_path, monkeypatch,
+):
+  supervisor = _load_supervisor()
+  _bind(supervisor, tmp_path, monkeypatch)
+  now = time.time()
+  source_boot = "boot-source-1234"
+
+  supervisor.begin_boot(source_boot, now=now)
+  _request(tmp_path, boot=source_boot, nonce="nonce-12345678", now=now)
+  # Simulate OOM/SIGKILL before the frozen poller accepts the request.
+  assert supervisor.begin_boot("boot-after-oom-1", now=now + 1) is False
+  assert _authorized(tmp_path, "boot-after-oom-1") == {}
+  assert not supervisor.INTENT_PATH.exists()
+  assert not supervisor.REQUEST_PATH.exists()
+
+
+def test_second_boot_before_claim_retires_one_shot_ack(tmp_path, monkeypatch):
+  supervisor = _load_supervisor()
+  _bind(supervisor, tmp_path, monkeypatch)
+  now = time.time()
+  source_boot = "boot-source-1234"
+
+  supervisor.begin_boot(source_boot, now=now)
+  _request(tmp_path, boot=source_boot, nonce="nonce-12345678", now=now)
+  assert supervisor.accept(source_boot, now=now + 1)
+  assert supervisor.begin_boot("boot-target-1234", now=now + 2)
+  assert _authorized(tmp_path, "boot-target-1234")
+
+  assert supervisor.begin_boot("boot-repeated-1234", now=now + 3) is False
+  assert _authorized(tmp_path, "boot-target-1234") == {}
+  assert _authorized(tmp_path, "boot-repeated-1234") == {}
+
+
+def test_recovery_restart_without_chat_intent_never_authorizes(
+  tmp_path, monkeypatch,
+):
+  supervisor = _load_supervisor()
+  _bind(supervisor, tmp_path, monkeypatch)
+  now = time.time()
+  source_boot = "boot-source-1234"
+  supervisor.begin_boot(source_boot, now=now)
+  supervisor.REQUEST_PATH.write_text("", encoding="utf-8")
+
+  assert supervisor.accept(source_boot, now=now + 1) is False
+  assert supervisor.begin_boot("boot-recovery-1234", now=now + 2) is False
+  assert _authorized(tmp_path, "boot-recovery-1234") == {}
+
+
+def test_mismatched_or_expired_request_is_consumed_without_ack(
+  tmp_path, monkeypatch,
+):
+  supervisor = _load_supervisor()
+  _bind(supervisor, tmp_path, monkeypatch)
+  now = time.time()
+  source_boot = "boot-source-1234"
+  supervisor.begin_boot(source_boot, now=now)
+  _request(
+    tmp_path,
+    boot=source_boot,
+    nonce="nonce-12345678",
+    now=now - supervisor.MAX_REQUEST_AGE_SECONDS - 1,
+  )
+
+  assert supervisor.accept(source_boot, now=now) is False
+  assert not supervisor.ACCEPTED_PATH.exists()
+  assert not supervisor.INTENT_PATH.exists()
+  assert not supervisor.REQUEST_PATH.exists()
+
+
+def test_platform_rejects_writable_or_tampered_ack(tmp_path, monkeypatch):
+  supervisor = _load_supervisor()
+  _bind(supervisor, tmp_path, monkeypatch)
+  now = time.time()
+  source_boot = "boot-source-1234"
+  target_boot = "boot-target-1234"
+  supervisor.begin_boot(source_boot, now=now)
+  _request(tmp_path, boot=source_boot, nonce="nonce-12345678", now=now)
+  assert supervisor.accept(source_boot, now=now + 1)
+  assert supervisor.begin_boot(target_boot, now=now + 2)
+
+  supervisor.ACK_PATH.chmod(0o644)
+  assert _authorized(tmp_path, target_boot) == {}
+  supervisor.ACK_PATH.chmod(0o444)
+  value = json.loads(supervisor.ACK_PATH.read_text(encoding="utf-8"))
+  value["runs"][0]["run_token"] = "forged-run-1234"
+  supervisor.ACK_PATH.chmod(0o644)
+  supervisor.ACK_PATH.write_text(json.dumps(value), encoding="utf-8")
+  supervisor.ACK_PATH.chmod(0o444)
+  # Filesystem ownership proves who wrote the ledger in production. This test
+  # process is the trusted uid, so content tampering is structurally valid; the
+  # exact DB run/nonce comparison remains the second authorization boundary.
+  assert _authorized(tmp_path, target_boot) == {
+    "forged-run-1234": ("chat-12345678", "nonce-12345678"),
+  }

--- a/backend/tests/test_restart_ledger.py
+++ b/backend/tests/test_restart_ledger.py
@@ -9,6 +9,8 @@ import time
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from app import restart_ledger as platform_ledger
 
 
@@ -125,6 +127,29 @@ def test_second_boot_before_claim_retires_one_shot_ack(tmp_path, monkeypatch):
   assert supervisor.begin_boot("boot-repeated-1234", now=now + 3) is False
   assert _authorized(tmp_path, "boot-target-1234") == {}
   assert _authorized(tmp_path, "boot-repeated-1234") == {}
+
+
+def test_boot_does_not_ack_when_accepted_intent_cannot_be_consumed(
+  tmp_path, monkeypatch,
+):
+  supervisor = _load_supervisor()
+  _bind(supervisor, tmp_path, monkeypatch)
+  now = time.time()
+  source_boot = "boot-source-1234"
+  supervisor.begin_boot(source_boot, now=now)
+  _request(tmp_path, boot=source_boot, nonce="nonce-12345678", now=now)
+  assert supervisor.accept(source_boot, now=now + 1)
+  real_remove = supervisor._remove
+
+  def _refuse_accepted(path):
+    if path == supervisor.ACCEPTED_PATH:
+      return False
+    return real_remove(path)
+
+  monkeypatch.setattr(supervisor, "_remove", _refuse_accepted)
+  with pytest.raises(OSError, match="consume"):
+    supervisor.begin_boot("boot-target-1234", now=now + 2)
+  assert not supervisor.ACK_PATH.exists()
 
 
 def test_recovery_restart_without_chat_intent_never_authorizes(

--- a/backend/tests/test_restart_util.py
+++ b/backend/tests/test_restart_util.py
@@ -10,6 +10,7 @@ import os
 import signal
 
 from app import chat as chat_mod
+from app import restart_ledger
 import app.restart_util as ru
 
 
@@ -27,16 +28,24 @@ class _FakeTimer:
     self.started = True
 
 
-def test_restart_drains_then_sigterms_and_arms_force_kill(monkeypatch):
+def test_restart_drains_then_requests_supervisor_and_arms_force_kill(monkeypatch):
   _FakeTimer.instances = []
   calls = []
   drained = {"n": 0}
   monkeypatch.setattr(ru.os, "kill", lambda pid, sig: calls.append((pid, sig)))
   monkeypatch.setattr(ru.threading, "Timer", _FakeTimer)
+  requests = []
+  monkeypatch.setattr(restart_ledger, "current_boot_id", lambda: "boot-12345678")
+  monkeypatch.setattr(restart_ledger, "new_nonce", lambda: "nonce-12345678")
+  monkeypatch.setattr(
+    restart_ledger, "request_restart",
+    lambda **kwargs: requests.append(kwargs),
+  )
 
-  async def _fake_drain(timeout=0):
+  async def _fake_drain(timeout=0, *, restart_nonce=""):
+    assert restart_nonce == "nonce-12345678"
     drained["n"] += 1
-    return []
+    return [{"chat_id": "chat-12345678", "run_token": "run-12345678"}]
 
   monkeypatch.setattr(chat_mod, "drain_all_for_restart", _fake_drain)
   # Start from a clean gate so the assertion below is meaningful.
@@ -47,8 +56,13 @@ def test_restart_drains_then_sigterms_and_arms_force_kill(monkeypatch):
   # The drain ran, and the gate was set so mid-restart sends queue.
   assert drained["n"] == 1
   assert chat_mod.draining is True
-  # The graceful ask: SIGTERM to our own worker, AFTER the drain.
-  assert calls == [(os.getpid(), signal.SIGTERM)]
+  # Only the frozen root-owned poller may acknowledge and terminate pid 1.
+  assert calls == []
+  assert requests == [{
+    "boot_id": "boot-12345678",
+    "nonce": "nonce-12345678",
+    "runs": [{"chat_id": "chat-12345678", "run_token": "run-12345678"}],
+  }]
   # A single force-kill fallback, armed as a daemon and started, so a hung
   # graceful shutdown can't leave the container "Up" with a dead worker. Its
   # window covers the drain budget + the post-SIGTERM grace floor.
@@ -63,19 +77,55 @@ def test_restart_drains_then_sigterms_and_arms_force_kill(monkeypatch):
   assert calls[-1] == (os.getpid(), signal.SIGKILL)
 
 
-def test_restart_sigterms_even_when_drain_fails(monkeypatch):
-  """A drain failure must never block the restart — SIGTERM + backstop still fire."""
+def test_restart_request_survives_drain_failure(monkeypatch):
   _FakeTimer.instances = []
   calls = []
   monkeypatch.setattr(ru.os, "kill", lambda pid, sig: calls.append((pid, sig)))
   monkeypatch.setattr(ru.threading, "Timer", _FakeTimer)
+  requests = []
+  monkeypatch.setattr(restart_ledger, "current_boot_id", lambda: "boot-12345678")
+  monkeypatch.setattr(restart_ledger, "new_nonce", lambda: "nonce-12345678")
+  monkeypatch.setattr(
+    restart_ledger, "request_restart",
+    lambda **kwargs: requests.append(kwargs),
+  )
 
-  async def _boom(timeout=0):
+  async def _boom(timeout=0, *, restart_nonce=""):
+    del timeout, restart_nonce
     raise RuntimeError("drain exploded")
 
   monkeypatch.setattr(chat_mod, "drain_all_for_restart", _boom)
 
   asyncio.run(ru.restart_this_worker())
 
-  assert calls == [(os.getpid(), signal.SIGTERM)]
+  assert calls == []
+  assert requests == [{
+    "boot_id": "boot-12345678",
+    "nonce": "nonce-12345678",
+    "runs": [],
+  }]
   assert len(_FakeTimer.instances) == 1
+
+
+def test_restart_handshake_failure_restarts_without_authorization(monkeypatch):
+  _FakeTimer.instances = []
+  calls = []
+  monkeypatch.setattr(ru.os, "kill", lambda pid, sig: calls.append((pid, sig)))
+  monkeypatch.setattr(ru.threading, "Timer", _FakeTimer)
+  monkeypatch.setattr(restart_ledger, "current_boot_id", lambda: "boot-12345678")
+  monkeypatch.setattr(restart_ledger, "new_nonce", lambda: "nonce-12345678")
+
+  async def _fake_drain(timeout=0, *, restart_nonce=""):
+    del timeout, restart_nonce
+    return [{"chat_id": "chat-12345678", "run_token": "run-12345678"}]
+
+  def _request_fails(**kwargs):
+    del kwargs
+    raise OSError("volume unavailable")
+
+  monkeypatch.setattr(chat_mod, "drain_all_for_restart", _fake_drain)
+  monkeypatch.setattr(restart_ledger, "request_restart", _request_fails)
+
+  asyncio.run(ru.restart_this_worker())
+
+  assert calls == [(os.getpid(), signal.SIGTERM)]

--- a/backend/tests/test_restart_util.py
+++ b/backend/tests/test_restart_util.py
@@ -1,9 +1,9 @@
 """restart_this_worker — the reliable, drain-gated in-process restart behind the
-Settings + platform "Restart" buttons (design §2.2). A bare SIGTERM hangs uvicorn
-on the open chat SSE stream, so this must ALSO arm a hard-kill fallback; and it
-must drain live turns first so a restart never simply kills a turn. These pin all
-three halves (drain → SIGTERM → armed SIGKILL) without killing the test process
-(os.kill is mocked) and without a real event loop turn (drain is stubbed)."""
+Settings + platform "Restart" buttons (design §2.2). The normal path asks the
+frozen supervisor to acknowledge the exact intent and terminate pid 1; a direct
+SIGTERM is only the fail-closed handshake fallback. Every path arms a hard-kill
+backstop and drains first. These tests pin those boundaries without killing the
+test process (os.kill is mocked)."""
 
 import asyncio
 import os

--- a/backend/tests/test_time_context.py
+++ b/backend/tests/test_time_context.py
@@ -4,7 +4,17 @@ Locks in the contract that the agent gets a clock every turn (issue: the
 agent only ever saw an IANA timezone NAME, and only on turn 1).
 """
 
-from app.chat import _build_time_context, _human_elapsed, _is_cli_slash_command
+import time
+import uuid
+
+from app import models
+from app.chat import (
+  _build_time_context,
+  _human_elapsed,
+  _is_cli_slash_command,
+  _last_user_message_elapsed,
+)
+from app.database import SessionLocal
 
 
 def test_includes_timezone_label_and_clock():
@@ -47,6 +57,37 @@ def test_elapsed_clause_only_when_present():
   assert "user's last message was" not in _build_time_context("UTC", None)
   out = _build_time_context("UTC", "3 days ago")
   assert "user's last message was 3 days ago" in out
+
+
+def test_elapsed_ignores_automatic_continuation_marker(monkeypatch):
+  now = 1_800_000_000.0
+  monkeypatch.setattr(time, "time", lambda: now)
+  cid = f"time-context-{uuid.uuid4()}"
+  db = SessionLocal()
+  try:
+    db.add(models.Chat(
+      id=cid,
+      title="time context",
+      messages=[
+        {
+          "role": "user", "content": "owner message",
+          "ts": (now - 3 * 86400) * 1000,
+        },
+        {"role": "assistant", "content": "reply"},
+        {
+          "role": "user", "content": "continue",
+          "kind": "auto_continuation",
+          "ts": (now - 5 * 60) * 1000,
+        },
+        {"role": "assistant", "content": "automatic reply"},
+        {"role": "user", "content": "current owner message", "ts": now * 1000},
+      ],
+    ))
+    db.commit()
+
+    assert _last_user_message_elapsed(db, cid) == "3 days ago"
+  finally:
+    db.close()
 
 
 def test_goal_slash_command_is_detected_without_matching_paths():

--- a/frontend/src/components/ChatView/AutoContinuationCard.jsx
+++ b/frontend/src/components/ChatView/AutoContinuationCard.jsx
@@ -1,0 +1,30 @@
+import MarkerCard from './MarkerCard.jsx'
+
+export default function AutoContinuationCard({ msg }) {
+  const restarted = msg?.continuation_reason === 'restart'
+  const title = restarted
+    ? 'Server restarted — continuing automatically'
+    : 'Usage available again — continuing automatically'
+
+  return (
+    <MarkerCard
+      title={title}
+      icon={
+        <svg
+          aria-hidden="true"
+          viewBox="0 0 16 16"
+          width="14"
+          height="14"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.4"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M13 7a5 5 0 1 0-1.5 4" />
+          <path d="M10.5 8H13V5.5" />
+        </svg>
+      }
+    />
+  )
+}

--- a/frontend/src/components/ChatView/ChatSettingsPanel.jsx
+++ b/frontend/src/components/ChatView/ChatSettingsPanel.jsx
@@ -834,7 +834,7 @@ export default function ChatSettingsPanel({
             onPointerDown={preserveFocusUnlessTouch}
           >
             <label className="csp__automation-copy" htmlFor={autoResumeSwitchId}>
-              <span className="csp__automation-title">Continue after rate limits</span>
+              <span className="csp__automation-title">Continue after limits and restarts</span>
             </label>
             <Switch
               className="chat-policy-switch"

--- a/frontend/src/components/ChatView/ChatSettingsPanel.jsx
+++ b/frontend/src/components/ChatView/ChatSettingsPanel.jsx
@@ -245,6 +245,10 @@ export default function ChatSettingsPanel({
   autoResumeSaving = false,
   autoResumeError = '',
   onAutoResumeChange,
+  restartResumeEnabled = false,
+  restartResumeSaving = false,
+  restartResumeError = '',
+  onRestartResumeChange,
   onChange,
   // Stale-PATCH guard: parent passes a ref that survives panel
   // mount/unmount. See ComposerPopover for the rationale.
@@ -646,6 +650,9 @@ export default function ChatSettingsPanel({
   const autoResumeSwitchId = chatId
     ? `chat-settings-auto-resume-${chatId}`
     : undefined
+  const restartResumeSwitchId = chatId
+    ? `chat-settings-restart-resume-${chatId}`
+    : undefined
   const appProviderLocked = chat?.created_by_app_id != null
 
   // Build the per-provider displayed-models list once per render.
@@ -826,28 +833,59 @@ export default function ChatSettingsPanel({
           )
         })
       })}
-      {onAutoResumeChange && (
+      {(onAutoResumeChange || onRestartResumeChange) && (
         <div className="csp__automation">
           <div className="csp__label csp__label--automation">Automation</div>
-          <div
-            className="csp__automation-row"
-            onPointerDown={preserveFocusUnlessTouch}
-          >
-            <label className="csp__automation-copy" htmlFor={autoResumeSwitchId}>
-              <span className="csp__automation-title">Continue after limits and restarts</span>
-            </label>
-            <Switch
-              className="chat-policy-switch"
-              id={autoResumeSwitchId}
-              checked={!!autoResumeEnabled}
-              onCheckedChange={onAutoResumeChange}
-              disabled={!!autoResumeSaving}
-            />
-          </div>
-          {autoResumeError && (
-            <p className="csp__automation-error" role="alert">
-              {autoResumeError}
-            </p>
+          {onAutoResumeChange && (
+            <>
+              <div
+                className="csp__automation-row"
+                onPointerDown={preserveFocusUnlessTouch}
+              >
+                <label className="csp__automation-copy" htmlFor={autoResumeSwitchId}>
+                  <span className="csp__automation-title">Continue after usage limits</span>
+                </label>
+                <Switch
+                  className="chat-policy-switch"
+                  id={autoResumeSwitchId}
+                  checked={!!autoResumeEnabled}
+                  onCheckedChange={onAutoResumeChange}
+                  disabled={!!autoResumeSaving}
+                />
+              </div>
+              {autoResumeError && (
+                <p className="csp__automation-error" role="alert">
+                  {autoResumeError}
+                </p>
+              )}
+            </>
+          )}
+          {onRestartResumeChange && (
+            <>
+              <div
+                className="csp__automation-row"
+                onPointerDown={preserveFocusUnlessTouch}
+              >
+                <label
+                  className="csp__automation-copy"
+                  htmlFor={restartResumeSwitchId}
+                >
+                  <span className="csp__automation-title">Continue after planned restarts</span>
+                </label>
+                <Switch
+                  className="chat-policy-switch"
+                  id={restartResumeSwitchId}
+                  checked={!!restartResumeEnabled}
+                  onCheckedChange={onRestartResumeChange}
+                  disabled={!!restartResumeSaving}
+                />
+              </div>
+              {restartResumeError && (
+                <p className="csp__automation-error" role="alert">
+                  {restartResumeError}
+                </p>
+              )}
+            </>
           )}
         </div>
       )}

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -341,6 +341,7 @@
 }
 
 .chat__msg--user { align-items: flex-end; }
+.chat__msg--marker { align-items: stretch; }
 .chat__msg--assistant {
   --activity-block-gap: 8px;
   --activity-row-gap: 4px;

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -61,6 +61,8 @@ import {
   canFastForwardQueue,
   cidOf,
   continuationRowsFromPromotedMessage,
+  isAutoContinuationMessage,
+  isOwnerUserMessage,
   mergeRecentMessagesIntoLoadedWindow,
   openAppCtaViewModel,
   shouldRetryStopAfterConfirm,
@@ -918,9 +920,7 @@ export default function ChatView({
   // messagesRef catches up, so state alone is not authoritative. A row is
   // first only when both the state mirror and rendered transcript are empty.
   function isFirstVisibleUserMessage() {
-    const stateHasUser = messagesRef.current.some(
-      m => m.role === 'user' && !m.hidden,
-    )
+    const stateHasUser = messagesRef.current.some(isOwnerUserMessage)
     const domHasUser = !!scrollRef.current?.querySelector('.chat__msg--user')
     return !stateHasUser && !domHasUser
   }
@@ -3311,7 +3311,9 @@ export default function ChatView({
   useLayoutEffect(() => {
     if (displayReady) onDisplayReady?.(chatId)
   }, [chatId, displayReady, onDisplayReady])
-  const lastUserIdx = messages.reduce((acc, m, i) => (m.role === 'user' && !m.hidden) ? i : acc, -1)
+  const lastUserIdx = messages.reduce((acc, m, i) => (
+    isOwnerUserMessage(m) ? i : acc
+  ), -1)
   // The captured bridge partial enters the active row before catch-up emits a
   // single item. That is the load-bearing part of Lever 1: when SSE becomes the
   // selected source, React updates MsgContent props instead of replacing the
@@ -3326,7 +3328,7 @@ export default function ChatView({
   const bridgeMsg = bridgeMsgIdx >= 0 ? messages[bridgeMsgIdx] : null
   const bridgeFollowedByVisibleUser = bridgeMsgIdx >= 0 && messages
     .slice(bridgeMsgIdx + 1)
-    .some(msg => msg?.role === 'user' && !msg.hidden)
+    .some(isOwnerUserMessage)
   const trailingAssistantPartialMsg = trailingAssistantPartialIdx >= 0
     ? messages[trailingAssistantPartialIdx]
     : null
@@ -3726,6 +3728,7 @@ export default function ChatView({
 
           {messages.map((msg, i) => {
             if (msg.hidden) return null
+            const continuationMarker = isAutoContinuationMessage(msg)
             const isLastMsg = i === lastVisibleMessageIndex
             // The mirrored DB row is rendered below by the SAME active
             // MsgContent instance that consumes live payloads. Suppress only
@@ -3771,20 +3774,23 @@ export default function ChatView({
             // User rows key + pin on the stable cid so the optimistic→confirm
             // display-ts update never remounts the row (which would drop the
             // pin target mid-swap). data-ts stays for the timestamp tooltip only.
-            const userCid = msg.role === 'user' ? cidOf(msg) : null
+            const ownerUserMessage = isOwnerUserMessage(msg)
+            const userCid = ownerUserMessage ? cidOf(msg) : null
             return (
             <li
               key={userCid || msg.id || msg.ts || `${msg.role}-${i}`}
-              className={`chat__msg chat__msg--${msg.role}`}
+              className={`chat__msg chat__msg--${continuationMarker ? 'marker' : msg.role}`}
               ref={i === lastUserIdx ? setLastUserMsgRef : null}
               data-key={dataKey}
               data-cid={userCid || undefined}
-              data-ts={msg.role === 'user' && msg.ts ? String(msg.ts) : undefined}
-              onPointerDown={(event) => handleMessagePointerDown(event, msg, dataKey)}
-              onPointerMove={handleMessagePointerMove}
-              onPointerUp={cancelMessageHold}
-              onPointerCancel={cancelMessageHold}
-              onContextMenu={_isTouchPrimary
+              data-ts={ownerUserMessage && msg.ts ? String(msg.ts) : undefined}
+              onPointerDown={continuationMarker
+                ? undefined
+                : (event) => handleMessagePointerDown(event, msg, dataKey)}
+              onPointerMove={continuationMarker ? undefined : handleMessagePointerMove}
+              onPointerUp={continuationMarker ? undefined : cancelMessageHold}
+              onPointerCancel={continuationMarker ? undefined : cancelMessageHold}
+              onContextMenu={_isTouchPrimary && !continuationMarker
                 ? (event) => {
                     if (event.target?.closest?.('button, a, input, textarea, summary, pre, code')) return
                     event.preventDefault()
@@ -3792,7 +3798,7 @@ export default function ChatView({
                     void copyMessage(msg, dataKey)
                   }
                 : undefined}
-              onClick={msg.ts && msg.role === 'user'
+              onClick={msg.ts && ownerUserMessage
                 ? (event) => showTimestamp(event, dataKey)
                 : undefined}
             >
@@ -3823,7 +3829,7 @@ export default function ChatView({
                 liveQuestionId={liveQuestionId}
                 suppressedQuestionKeys={streamItemQuestionKeys}
               />
-              {msg.ts && msg.role === 'user' && (
+              {msg.ts && ownerUserMessage && (
                 <time className={`chat__ts${visibleTimestampKey === dataKey ? ' chat__ts--visible' : ''}`}>
                   {new Date(msg.ts).toLocaleString([], {
                     month: 'short', day: 'numeric',

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -35,6 +35,7 @@ import {
   resetDeadlineDelay,
   resetDeadlineState,
   saveAutoResumePolicy,
+  saveRestartResumePolicy,
 } from './autoResumePolicy.js'
 import {
   EMPTY_CHAT_RUN_SIGNAL,
@@ -400,6 +401,8 @@ export default function ChatView({
   const [autoResumeSaving, setAutoResumeSaving] = useState(false)
   const [autoResumeError, setAutoResumeError] = useState('')
   const [autoResumeErrorSource, setAutoResumeErrorSource] = useState('')
+  const [restartResumeSaving, setRestartResumeSaving] = useState(false)
+  const [restartResumeError, setRestartResumeError] = useState('')
   const [embeddedRunSignal, setEmbeddedRunSignal] = useState(
     EMPTY_CHAT_RUN_SIGNAL,
   )
@@ -410,6 +413,8 @@ export default function ChatView({
   const [, setLimitResetClockTick] = useState(0)
   const autoResumeSavingRef = useRef(false)
   const autoResumeRequestRef = useRef(0)
+  const restartResumeSavingRef = useRef(false)
+  const restartResumeRequestRef = useRef(0)
   const armedEmbeddedResetRef = useRef(null)
   // This external per-chat state survives ChatView's keyed unmount/remount.
   // Send handlers also read the store directly, closing the same-frame gap
@@ -544,6 +549,10 @@ export default function ChatView({
     setAutoResumeSaving(false)
     setAutoResumeError('')
     setAutoResumeErrorSource('')
+    restartResumeRequestRef.current += 1
+    restartResumeSavingRef.current = false
+    setRestartResumeSaving(false)
+    setRestartResumeError('')
   }, [chatId])
 
   const handleAutoResumeChange = useCallback(async (next, source = 'card') => {
@@ -579,6 +588,34 @@ export default function ChatView({
     next => handleAutoResumeChange(next, 'settings'),
     [handleAutoResumeChange],
   )
+
+  const handleRestartResumeChange = useCallback(async next => {
+    if (restartResumeSavingRef.current) return
+    restartResumeSavingRef.current = true
+    const requestId = ++restartResumeRequestRef.current
+    setRestartResumeSaving(true)
+    setRestartResumeError('')
+    try {
+      const result = await saveRestartResumePolicy({
+        chatId,
+        next,
+        request: apiFetch,
+      })
+      if (requestId !== restartResumeRequestRef.current) return
+      if (result.value !== null) {
+        setChatInfo(prev => prev ? ({
+          ...prev,
+          auto_resume_on_restart: result.value,
+        }) : prev)
+      }
+      setRestartResumeError(result.error)
+    } finally {
+      if (requestId === restartResumeRequestRef.current) {
+        restartResumeSavingRef.current = false
+        setRestartResumeSaving(false)
+      }
+    }
+  }, [chatId])
 
   // Mirror `messages` in a ref so commitMessages can compute the next
   // value without putting a side-effect (setQueryData) inside a
@@ -1757,6 +1794,7 @@ export default function ChatView({
           effective: data.effective_agent_settings || {},
           has_assistant_turns: !!data.has_assistant_turns,
           auto_resume_on_limit: !!data.auto_resume_on_limit,
+          auto_resume_on_restart: !!data.auto_resume_on_restart,
         }
         setChatInfo(nextChatInfo)
         queryClient.setQueryData(chatMessagesQueryKey(chatId), (existing) => ({
@@ -3427,6 +3465,7 @@ export default function ChatView({
   const hasPendingResume = !!pendingResumeBlock
   const pendingLimitResetAt = pendingResumeBlock?.pause?.resets_at || null
   const autoResumeEnabled = !!chatInfo?.auto_resume_on_limit
+  const restartResumeEnabled = !!chatInfo?.auto_resume_on_restart
   useEffect(() => {
     if (!embedded || !autoResumeEnabled || !pendingLimitResetAt) {
       if (!pendingLimitResetAt) armedEmbeddedResetRef.current = null
@@ -4026,6 +4065,12 @@ export default function ChatView({
                 }
                 onAutoResumeChange={
                   embedded ? undefined : handleAutoResumeSettingsChange
+                }
+                restartResumeEnabled={restartResumeEnabled}
+                restartResumeSaving={restartResumeSaving}
+                restartResumeError={restartResumeError}
+                onRestartResumeChange={
+                  embedded ? undefined : handleRestartResumeChange
                 }
                 onChangeChatInfo={({ agent_settings_json, provider, effective }) => {
                   // Merge into chatInfo so the next render reflects the

--- a/frontend/src/components/ChatView/ComposerPopover.jsx
+++ b/frontend/src/components/ChatView/ComposerPopover.jsx
@@ -83,6 +83,10 @@ export default function ComposerPopover({
   autoResumeSaving,
   autoResumeError,
   onAutoResumeChange,
+  restartResumeEnabled,
+  restartResumeSaving,
+  restartResumeError,
+  onRestartResumeChange,
   providerSwitchState,
   onOpenInspector,
   onOpenSummary,
@@ -227,6 +231,10 @@ export default function ComposerPopover({
                 autoResumeSaving={autoResumeSaving}
                 autoResumeError={autoResumeError}
                 onAutoResumeChange={onAutoResumeChange}
+                restartResumeEnabled={restartResumeEnabled}
+                restartResumeSaving={restartResumeSaving}
+                restartResumeError={restartResumeError}
+                onRestartResumeChange={onRestartResumeChange}
                 onChange={onChangeChatInfo}
                 providerSwitchState={providerSwitchState}
                 reqIdRef={reqIdRef}

--- a/frontend/src/components/ChatView/MarkerCard.jsx
+++ b/frontend/src/components/ChatView/MarkerCard.jsx
@@ -2,10 +2,9 @@ import { useRef, useState } from 'react'
 import { preserveTogglePosition } from './preserveTogglePosition.js'
 
 // Shared shell for "marker" messages — system/product moments that are neither
-// agent prose nor a tool call. A compaction summary is the only marker today;
-// interrupted-turn and other system notes can adopt this shell later so every
-// marker reads as one family (one card shape, one disclosure motion) instead of
-// each inventing its own look or masquerading as a chat bubble.
+// agent prose nor a tool call. Compaction summaries and automatic continuation
+// actions share this family (one card shape and disclosure motion) instead of
+// inventing separate chrome or masquerading as chat bubbles.
 //
 // Extracted from CompactionCard with no visual change — the default look IS the
 // accent-tinted summary divider that card established (`.chat__marker*` CSS,

--- a/frontend/src/components/ChatView/MsgContent.jsx
+++ b/frontend/src/components/ChatView/MsgContent.jsx
@@ -226,7 +226,7 @@ function MsgContentInner({
                     className="chat__limit-option-label"
                     htmlFor={autoResumeSwitchId}
                   >
-                    Always continue after limits and restarts in this chat
+                    Always continue after usage limits in this chat
                   </label>
                 </div>
                 <Switch

--- a/frontend/src/components/ChatView/MsgContent.jsx
+++ b/frontend/src/components/ChatView/MsgContent.jsx
@@ -7,6 +7,7 @@ import QuestionCard from './QuestionCard.jsx'
 import MessageSources from './MessageSources.jsx'
 import Attachments from './Attachments.jsx'
 import CompactionCard from './CompactionCard.jsx'
+import AutoContinuationCard from './AutoContinuationCard.jsx'
 import { questionKey } from './questionKey.js'
 import {
   repairInterleavedQuestionText,
@@ -82,6 +83,10 @@ function MsgContentInner({
         <CompactionCard msg={msg} />
       </div>
     )
+  }
+
+  if (msg.kind === 'auto_continuation') {
+    return <AutoContinuationCard msg={msg} />
   }
 
   if (msg.blocks && msg.blocks.length > 0) {
@@ -221,7 +226,7 @@ function MsgContentInner({
                     className="chat__limit-option-label"
                     htmlFor={autoResumeSwitchId}
                   >
-                    Always continue after limits in this chat
+                    Always continue after limits and restarts in this chat
                   </label>
                 </div>
                 <Switch

--- a/frontend/src/components/ChatView/__tests__/autoResumePolicy.test.js
+++ b/frontend/src/components/ChatView/__tests__/autoResumePolicy.test.js
@@ -7,6 +7,7 @@ import {
   resetDeadlineDelay,
   resetDeadlineState,
   saveAutoResumePolicy,
+  saveRestartResumePolicy,
 } from '../autoResumePolicy.js'
 
 
@@ -34,6 +35,27 @@ test('policy PATCH is time-boxed and returns the authoritative response', async 
   assert.equal(calls.length, 1)
   assert.equal(calls[0][0], '/chats/chat%2Fa')
   assert.equal(calls[0][1].timeoutMs, AUTO_RESUME_REQUEST_TIMEOUT_MS)
+})
+
+
+test('restart policy uses a separate explicit wire field', async () => {
+  const calls = []
+  const result = await saveRestartResumePolicy({
+    chatId: 'chat-1',
+    next: true,
+    request: async (path, options) => {
+      calls.push({ path, options })
+      return jsonResponse({
+        auto_resume_on_limit: true,
+        auto_resume_on_restart: true,
+      })
+    },
+  })
+
+  assert.deepEqual(result, { value: true, error: '' })
+  assert.deepEqual(JSON.parse(calls[0].options.body), {
+    auto_resume_on_restart: true,
+  })
 })
 
 

--- a/frontend/src/components/ChatView/__tests__/chatRuntimeState.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatRuntimeState.test.js
@@ -8,6 +8,8 @@ import {
   canFastForwardQueue,
   cidOf,
   continuationRowsFromPromotedMessage,
+  isAutoContinuationMessage,
+  isOwnerUserMessage,
   mergeRecentMessagesIntoLoadedWindow,
   openAppCtaViewModel,
   previewReadyAnnouncement,
@@ -21,6 +23,19 @@ import {
   stripInternalUserMessageFields,
   systemEventForChat,
 } from '../chatRuntimeState.js'
+
+test('automatic continuations are product markers, not owner messages', () => {
+  const marker = {
+    role: 'user',
+    content: 'continue',
+    kind: 'auto_continuation',
+    continuation_reason: 'restart',
+  }
+  assert.equal(isAutoContinuationMessage(marker), true)
+  assert.equal(isOwnerUserMessage(marker), false)
+  assert.equal(isOwnerUserMessage({ role: 'user', content: 'hello' }), true)
+  assert.equal(isOwnerUserMessage({ role: 'user', hidden: true }), false)
+})
 
 test('an in-process question answer keeps ownership of the active assistant turn', () => {
   assert.equal(answerTurnDisposition({

--- a/frontend/src/components/ChatView/__tests__/contextMenuOrder.test.js
+++ b/frontend/src/components/ChatView/__tests__/contextMenuOrder.test.js
@@ -25,7 +25,8 @@ test('chat context actions follow model selection and continuation policy', () =
   assert.ok(picker !== -1 && summary !== -1 && inspector !== -1)
   assert.ok(picker < summary)
   assert.ok(summary < inspector)
-  assert.match(settingsSource, /Continue after limits and restarts/)
+  assert.match(settingsSource, /Continue after usage limits/)
+  assert.match(settingsSource, /Continue after planned restarts/)
   assert.doesNotMatch(settingsSource, /Chat summar(?:y|ies)/)
 })
 

--- a/frontend/src/components/ChatView/__tests__/contextMenuOrder.test.js
+++ b/frontend/src/components/ChatView/__tests__/contextMenuOrder.test.js
@@ -25,7 +25,7 @@ test('chat context actions follow model selection and continuation policy', () =
   assert.ok(picker !== -1 && summary !== -1 && inspector !== -1)
   assert.ok(picker < summary)
   assert.ok(summary < inspector)
-  assert.match(settingsSource, /Continue after rate limits/)
+  assert.match(settingsSource, /Continue after limits and restarts/)
   assert.doesNotMatch(settingsSource, /Chat summar(?:y|ies)/)
 })
 

--- a/frontend/src/components/ChatView/__tests__/messageCopy.test.js
+++ b/frontend/src/components/ChatView/__tests__/messageCopy.test.js
@@ -24,3 +24,12 @@ test('copyableMessageText removes hidden user augmentation', () => {
 test('copyableMessageText ignores hidden transcript rows', () => {
   assert.equal(copyableMessageText({ hidden: true, content: 'do not copy' }), '')
 })
+
+test('copyableMessageText ignores product-owned continuation markers', () => {
+  assert.equal(copyableMessageText({
+    role: 'user',
+    content: 'continue',
+    kind: 'auto_continuation',
+    continuation_reason: 'restart',
+  }), '')
+})

--- a/frontend/src/components/ChatView/__tests__/parkedCard.test.js
+++ b/frontend/src/components/ChatView/__tests__/parkedCard.test.js
@@ -106,7 +106,7 @@ test('the parked card has styling distinct from a plain error', () => {
 test('auto-resume is a chat-local switch shown only on the active rate-limit card', () => {
   assert.match(msgContent, /resumable && parked && autoResumeAvailable && onAutoResumeChange/,
     'the switch must require the tail resumable rate-limit state')
-  assert.match(msgContent, /Always continue after limits and restarts in this chat/,
+  assert.match(msgContent, /Always continue after usage limits in this chat/,
     'the switch label makes the persistent, chat-local scope explicit')
   assert.match(msgContent, /htmlFor=\{autoResumeSwitchId\}/,
     'the visible switch label must also be its accessible name')
@@ -118,8 +118,10 @@ test('auto-resume is a chat-local switch shown only on the active rate-limit car
     'the in-card control has a dedicated layout')
   assert.doesNotMatch(settingsView, /auto_resume_on_limit|Auto.?resume/i,
     'the removed global automatic option must not reappear in Settings')
-  assert.match(chatSettingsPanel, /Continue after limits and restarts/,
-    'the durable policy remains manageable in the per-chat settings surface')
+  assert.match(chatSettingsPanel, /Continue after usage limits/,
+    'the durable limit policy remains manageable in chat settings')
+  assert.match(chatSettingsPanel, /Continue after planned restarts/,
+    'restart continuation requires separate explicit consent')
   assert.doesNotMatch(chatSettingsPanel, /On for this chat|Off for this chat/,
     'the switch color communicates state without redundant state copy')
   assert.match(chatSettingsPanel, /className="chat-policy-switch"/,

--- a/frontend/src/components/ChatView/__tests__/parkedCard.test.js
+++ b/frontend/src/components/ChatView/__tests__/parkedCard.test.js
@@ -20,6 +20,9 @@ const shell = readFileSync(new URL('../../Shell/Shell.jsx', import.meta.url), 'u
 const paneChatView = readFileSync(new URL('../../Shell/PaneChatView.jsx', import.meta.url), 'utf8')
 const chatEmbed = readFileSync(new URL('../../ChatEmbed/ChatEmbed.jsx', import.meta.url), 'utf8')
 const chatSettingsPanel = readFileSync(new URL('../ChatSettingsPanel.jsx', import.meta.url), 'utf8')
+const autoContinuationCard = readFileSync(
+  new URL('../AutoContinuationCard.jsx', import.meta.url), 'utf8',
+)
 const settingsView = readFileSync(
   new URL('../../SettingsView/SettingsView.jsx', import.meta.url), 'utf8',
 )
@@ -103,7 +106,7 @@ test('the parked card has styling distinct from a plain error', () => {
 test('auto-resume is a chat-local switch shown only on the active rate-limit card', () => {
   assert.match(msgContent, /resumable && parked && autoResumeAvailable && onAutoResumeChange/,
     'the switch must require the tail resumable rate-limit state')
-  assert.match(msgContent, /Always continue after limits in this chat/,
+  assert.match(msgContent, /Always continue after limits and restarts in this chat/,
     'the switch label makes the persistent, chat-local scope explicit')
   assert.match(msgContent, /htmlFor=\{autoResumeSwitchId\}/,
     'the visible switch label must also be its accessible name')
@@ -115,7 +118,7 @@ test('auto-resume is a chat-local switch shown only on the active rate-limit car
     'the in-card control has a dedicated layout')
   assert.doesNotMatch(settingsView, /auto_resume_on_limit|Auto.?resume/i,
     'the removed global automatic option must not reappear in Settings')
-  assert.match(chatSettingsPanel, /Continue after rate limits/,
+  assert.match(chatSettingsPanel, /Continue after limits and restarts/,
     'the durable policy remains manageable in the per-chat settings surface')
   assert.doesNotMatch(chatSettingsPanel, /On for this chat|Off for this chat/,
     'the switch color communicates state without redundant state copy')
@@ -123,6 +126,17 @@ test('auto-resume is a chat-local switch shown only on the active rate-limit car
     'the settings surface uses the same full-size black/purple switch treatment')
   assert.match(css, /\.chat-policy-switch button\[role="switch"\]\[data-state="checked"\]/,
     'the chat switch restores the SDK checked track after the button reset')
+})
+
+test('automatic continuation renders as a product marker, not a user bubble', () => {
+  assert.match(msgContent, /msg\.kind === 'auto_continuation'/,
+    'the stored provider-facing user row must take the product-marker branch')
+  assert.match(msgContent, /<AutoContinuationCard msg=\{msg\}/,
+    'both restart and limit continuations share the marker renderer')
+  assert.match(autoContinuationCard, /Server restarted — continuing automatically/)
+  assert.match(autoContinuationCard, /Usage available again — continuing automatically/)
+  assert.match(chatView, /chat__msg--\$\{continuationMarker \? 'marker' : msg\.role\}/,
+    'the row shell must not inherit owner-user alignment')
 })
 
 test('an enabled policy stays cancellable after the viewer clock reaches reset', () => {

--- a/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
+++ b/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
@@ -833,6 +833,37 @@ test('an unresolvable saved location falls back to a settled bottom anchor', () 
   assert.notEqual(mode.kind, 'FOLLOW_BOTTOM')
 })
 
+test('a product continuation marker cannot take ownership of a saved user pin', () => {
+  const messages = [
+    { role: 'user', cid: 'owner-cid', content: 'do work' },
+    {
+      role: 'user',
+      cid: 'restart-resume-token',
+      content: 'continue',
+      kind: 'auto_continuation',
+    },
+  ]
+
+  assert.deepEqual(
+    _validateSavedMode(
+      { kind: 'PIN_USER_MSG', cid: 'owner-cid', followWhenFilled: true },
+      messages,
+      null,
+    ),
+    { kind: 'PIN_USER_MSG', cid: 'owner-cid' },
+    'the preceding owner row remains the latest real user message',
+  )
+  assert.deepEqual(
+    _validateSavedMode(
+      { kind: 'PIN_USER_MSG', cid: 'restart-resume-token' },
+      messages,
+      null,
+    ),
+    { kind: 'INITIAL' },
+    'the provider-facing marker is never restored as an owner-authored pin',
+  )
+})
+
 test('a saved anchor wholly inside reserved blank space self-heals to real content', () => {
   const last = {
     offsetTop: 500,

--- a/frontend/src/components/ChatView/autoResumePolicy.js
+++ b/frontend/src/components/ChatView/autoResumePolicy.js
@@ -2,8 +2,8 @@ export const AUTO_RESUME_REQUEST_TIMEOUT_MS = 15000
 export const MAX_TIMER_DELAY_MS = 2_147_483_647
 
 
-function policyValue(data) {
-  return !!data?.auto_resume_on_limit
+function policyValue(data, field) {
+  return !!data?.[field]
 }
 
 
@@ -30,14 +30,14 @@ function mutationErrorMessage(err) {
  * response is lost; treating that as a definite failure would leave an OFF
  * switch controlling an ON server policy.
  */
-export async function saveAutoResumePolicy({ chatId, next, request }) {
+async function saveBooleanPolicy({ chatId, next, request, field }) {
   const desired = !!next
   let mutationError = null
 
   try {
     const res = await request(`/chats/${encodeURIComponent(chatId)}`, {
       method: 'PATCH',
-      body: JSON.stringify({ auto_resume_on_limit: desired }),
+      body: JSON.stringify({ [field]: desired }),
       timeoutMs: AUTO_RESUME_REQUEST_TIMEOUT_MS,
     })
     if (!res.ok) {
@@ -45,7 +45,7 @@ export async function saveAutoResumePolicy({ chatId, next, request }) {
       throw new Error(detail || 'Could not save this chat setting.')
     }
     const data = await res.json()
-    return { value: policyValue(data), error: '' }
+    return { value: policyValue(data, field), error: '' }
   } catch (err) {
     mutationError = err
   }
@@ -56,7 +56,7 @@ export async function saveAutoResumePolicy({ chatId, next, request }) {
       { timeoutMs: AUTO_RESUME_REQUEST_TIMEOUT_MS },
     )
     if (!res.ok) throw new Error(`policy reconciliation failed (${res.status})`)
-    const value = policyValue(await res.json())
+    const value = policyValue(await res.json(), field)
     return {
       value,
       // A lost response after a successful commit is a success once GET proves
@@ -72,6 +72,16 @@ export async function saveAutoResumePolicy({ chatId, next, request }) {
       error: `${mutationErrorMessage(mutationError)} Current setting could not be verified.`,
     }
   }
+}
+
+
+export function saveAutoResumePolicy(args) {
+  return saveBooleanPolicy({...args, field: 'auto_resume_on_limit'})
+}
+
+
+export function saveRestartResumePolicy(args) {
+  return saveBooleanPolicy({...args, field: 'auto_resume_on_restart'})
 }
 
 

--- a/frontend/src/components/ChatView/chatRuntimeState.js
+++ b/frontend/src/components/ChatView/chatRuntimeState.js
@@ -16,6 +16,19 @@ export function cidOf(msg) {
   return msg.cid || null
 }
 
+export function isAutoContinuationMessage(message) {
+  return message?.kind === 'auto_continuation'
+}
+
+/** A visible transcript row authored by the owner, excluding product events
+ * that retain role=user only because the provider receives `continue`. */
+export function isOwnerUserMessage(message) {
+  return !!message
+    && message.role === 'user'
+    && !message.hidden
+    && !isAutoContinuationMessage(message)
+}
+
 export function stripInternalUserMessageFields(raw) {
   if (!raw) return null
   // KEEP `cid` — it is now the durable row identity and must survive the

--- a/frontend/src/components/ChatView/messageCopy.js
+++ b/frontend/src/components/ChatView/messageCopy.js
@@ -1,6 +1,7 @@
 // Message-to-plain-text helpers for the mobile hold-to-copy action.
 
 import { stripAugmentation } from './msgText.js'
+import { isAutoContinuationMessage } from './chatRuntimeState.js'
 
 function questionText(block) {
   return (block.questions || []).map(question => {
@@ -14,7 +15,7 @@ function questionText(block) {
 /** Resolve the owner-visible prose in one transcript row. Tool chrome and
  * hidden prompt augmentation stay out of copied text. */
 export function copyableMessageText(message) {
-  if (!message || message.hidden) return ''
+  if (!message || message.hidden || isAutoContinuationMessage(message)) return ''
   const parts = []
   if (Array.isArray(message.blocks) && message.blocks.length > 0) {
     for (const block of message.blocks) {

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -40,7 +40,7 @@
  */
 
 import { useState, useRef, useLayoutEffect, useCallback } from 'react'
-import { cidOf } from './chatRuntimeState.js'
+import { cidOf, isOwnerUserMessage } from './chatRuntimeState.js'
 import { BEFORE_SHELL_RELOAD_EVENT } from '../../lib/shellReloadEvents.js'
 
 
@@ -386,7 +386,7 @@ export function _validateSavedMode(saved, messages, scrollEl) {
     // resolve a pin target — use the explicit no-location fallback.
     if (saved.cid == null) return holdBottom()
     const lastUserMsg = [...messages].reverse()
-      .find(m => m.role === 'user' && !m.hidden)
+      .find(isOwnerUserMessage)
     // Automatic pin→follow is live-turn state, never restoration state. Strip
     // the armed flag even if a pagehide captured it mid-stream; mount/return
     // must not manufacture tail-follow from saved geometry.

--- a/frontend/src/components/Shell/__tests__/newChatPolicy.test.js
+++ b/frontend/src/components/Shell/__tests__/newChatPolicy.test.js
@@ -162,6 +162,7 @@ test('a canonical create response becomes an authoritative empty detail cache', 
       effective_agent_settings: { model: 'gpt-current', effort: 'medium' },
       has_assistant_turns: false,
       auto_resume_on_limit: true,
+      auto_resume_on_restart: false,
       offset: 0,
     }),
   })
@@ -180,6 +181,7 @@ test('a canonical create response becomes an authoritative empty detail cache', 
       effective: { model: 'gpt-current', effort: 'medium' },
       has_assistant_turns: false,
       auto_resume_on_limit: true,
+      auto_resume_on_restart: false,
     },
   })
 })

--- a/frontend/src/components/Shell/newChatPolicy.js
+++ b/frontend/src/components/Shell/newChatPolicy.js
@@ -112,6 +112,7 @@ export function createdChatDetailCache(created) {
       effective: detail.effective_agent_settings,
       has_assistant_turns: detail.has_assistant_turns,
       auto_resume_on_limit: !!detail.auto_resume_on_limit,
+      auto_resume_on_restart: !!detail.auto_resume_on_restart,
     },
   }
 }


### PR DESCRIPTION
## Outcome

Adds automatic continuation after a planned server restart without broadening provider-limit consent or guessing restart cause from transcript text. Closes #145.

The chat UI now exposes two independent policies:

- `Continue after usage limits` keeps the existing per-chat/default behavior and remains initially on.
- `Continue after planned restarts` is separately stored, migrates existing chats and owners off, and only seeds future chats after explicit owner consent.

## Authenticated restart boundary

1. The platform generates a fresh nonce, stops and fully finalizes each exact live run, then parks only successfully committed `(chat_id, run_id)` rows due-now with that nonce.
2. The platform publishes the exact intent and asks the frozen entrypoint supervisor to restart; it does not self-SIGTERM on the normal path.
3. The root-owned supervisor validates and consumes that request immediately before terminating pid 1, then binds the accepted tuple set to exactly the next boot id.
4. The app resumes only when current-boot acknowledgement, exact chat/run/nonce, separate restart policy, latest-run ownership, owner attribution, queue attribution, and question state all still match under the transition + queue locks.

A crash/OOM before supervisor acceptance, repeated boot, wrong nonce, policy-off chat, unanswered question, app-owned work, scheduling failure, or any missing write falls back to the existing manual resumable interruption.

## State-machine review

| Transition | Result |
|---|---|
| provider limit | durable park until reset; existing limit policy controls continuation |
| accepted planned restart | exact due-now restart park; separate restart policy controls continuation |
| unacknowledged or mismatched restart | interrupted/manual, nonce retired |
| successful claim | park completed and nonce retired as the newer run starts |
| task creation failure | exact promotion rolled back; restart becomes manual and cannot retry unattended |
| owner send / pending promotion | newer run releases the manual hold |
| supersession / provider handoff / terminal clear / boot reconciliation | old authorization retired |
| generic stale-pending sweep | cannot bypass an interrupted restart manual hold |

All `ChatRun` creators and status/nonce writers plus every automatic scheduling entry point were audited against this table.

## Resource profile

No per-chat workers or short polling were added. The continuation sweep performs one status-indexed due-row query immediately at boot, after `chat_run_finished`, and on a 60-second fallback. The root ledger is a bounded local file (64 KiB, at most 64 exact runs) and is read only when due parks exist, with one recheck at the actual claim.

## Validation so far

- focused restart/ledger/policy/drain/migration suite: 119 passed
- final state-machine + restart utility regression set: 63 passed
- frontend library tests: 1,804 passed
- frontend hook tests: 47 passed
- production frontend build: passed (1,227 modules)
- offline/PWA build integrity: passed
- `python3 -m py_compile`, `bash -n`, `git diff --check`: passed
- repository fast preship gate and pre-push hooks: passed

The full backend suite is also running locally; this PR will not merge until both it and all hosted checks are green.