### PR TITLE
Hard-stop wedged SDK turns after bounded interrupt

### DIFF
--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -1813,6 +1813,61 @@ async def sweep_idle_pending_chats(db: Session) -> list[str]:
   return started
 
 
+async def _stop_handle_with_escalation(
+  chat_id: str,
+  handle,
+  *,
+  source: str,
+) -> tuple[bool, bool]:
+  """Gracefully stop one handle, then hard-stop only that same identity.
+
+  Returns ``(stopped, escalated)``. The registry identity recheck is the
+  successor guard: a late timeout can never signal a replacement handle.
+  """
+  log = _get_logger()
+  kind = getattr(handle, "kind", None)
+  try:
+    stopped = await handle.stop(timeout=2.0)
+  except asyncio.CancelledError:
+    raise
+  except Exception:
+    log.warning(
+      "%s graceful stop failed chat_id=%s kind=%s",
+      source, chat_id, kind or "?", exc_info=True,
+    )
+    stopped = False
+  if stopped:
+    return True, False
+
+  current = registry.get_handle(chat_id, kind)
+  if current is None:
+    # The runner completed in the narrow race after stop() timed out.
+    return True, False
+  if current is not handle:
+    # A different identity owns the slot. Never act on the stale handle.
+    return False, False
+
+  force_stop = getattr(handle, "force_stop", None)
+  if not callable(force_stop):
+    return False, False
+
+  log.warning(
+    "%s graceful stop timed out chat_id=%s kind=%s; "
+    "hard-stopping the same isolated runner",
+    source, chat_id, kind or "?",
+  )
+  try:
+    return await force_stop(timeout=5.0), True
+  except asyncio.CancelledError:
+    raise
+  except Exception:
+    log.warning(
+      "%s hard stop failed chat_id=%s kind=%s",
+      source, chat_id, kind or "?", exc_info=True,
+    )
+    return False, True
+
+
 async def sweep_stalled_live_runs(db: Session) -> list[str]:
   """Interrupt live SDK turns whose broadcast has been silent too long.
 
@@ -1882,23 +1937,19 @@ async def sweep_stalled_live_runs(db: Session) -> list[str]:
     _clear_after_terminal_status[chat_id] = "interrupted"
 
     all_interrupted = True
+    escalated = False
     for handle in handles:
-      try:
-        stopped = await handle.stop(timeout=2.0)
-      except asyncio.CancelledError:
-        raise
-      except Exception:
-        log.warning(
-          "stalled-live watchdog interrupt failed chat_id=%s kind=%s",
-          chat_id, getattr(handle, "kind", "?"), exc_info=True,
-        )
-        stopped = False
-      if not stopped:
-        all_interrupted = False
-        log.warning(
-          "stalled-live watchdog interrupt timed out chat_id=%s kind=%s",
-          chat_id, getattr(handle, "kind", "?"),
-        )
+      stopped, used_force = await _stop_handle_with_escalation(
+        chat_id,
+        handle,
+        source="stalled-live watchdog",
+      )
+      escalated = escalated or used_force
+      all_interrupted = all_interrupted and stopped
+    if escalated:
+      # agent-browser daemons intentionally detach from the SDK group. Their
+      # CHAT_ID/session routing is the separate, identity-safe cleanup key.
+      await _close_browser_session(chat_id)
     if all_interrupted:
       interrupted.append(chat_id)
   if interrupted:
@@ -2716,8 +2767,14 @@ async def stop_chat_for(
       )
   questions.cancel(chat_id)
   all_stopped = True
+  escalated = False
   for handle in handles:
-    stopped = await handle.stop(timeout=2.0)
+    stopped, used_force = await _stop_handle_with_escalation(
+      chat_id,
+      handle,
+      source="stop_chat_for",
+    )
+    escalated = escalated or used_force
     if not stopped:
       # SDK subprocess is still draining — do NOT unregister/finalize-broadcast
       # here. Unregistering while the runner is alive lets it later finalize
@@ -2742,6 +2799,8 @@ async def stop_chat_for(
       all_stopped = False
       continue
     registry.unregister(chat_id, handle.kind)
+  if escalated:
+    await _close_browser_session(chat_id)
   # Broadcast and run-status cleanup only when EVERY handle stopped cleanly.
   # A still-draining runner owns both; it will finalize and clear in its own
   # finally block (guarded by _clear_after_terminal_generation). Only the

--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -2781,13 +2781,13 @@ async def stop_chat_for(
       # against a reclaimed chat (zombie-run clobber). Leave the registry entry
       # and broadcast intact so the runner's own finally does teardown; the
       # generation guard already protects the transcript from a stale write.
-      # A stop() returning False is ambiguous (wedged-but-alive vs dead), and
-      # the signals that could distinguish them — the handle's `_finished`
-      # future — are corrupted by Stop's own 2s wait_for cancellation AND
-      # resolve before chat.py's final sink save, so there is no safe in-process
-      # "this runner is truly dead" test. A genuinely dead in-process runner is
-      # rare and self-heals on the next restart via reconcile_interrupted_chats
-      # (which clears the stuck marker and preserves the queue). The
+      # A stop() returning False after escalation means the runner still did
+      # not acknowledge its terminal cleanup. Keep its registry/broadcast
+      # ownership intact: `_finished` resolves before chat.py's final sink save,
+      # so it is not a safe "all durable teardown finished" signal. A genuinely
+      # dead in-process runner self-heals on the next restart via
+      # reconcile_interrupted_chats (which clears the stuck marker and
+      # preserves the queue). The
       # orphaned-run-AFTER-RESTART case the user reported has an EMPTY registry
       # (no handles), so it takes the `not handles` clear below — it never lands
       # here.

--- a/backend/app/claude_sdk_runner.py
+++ b/backend/app/claude_sdk_runner.py
@@ -62,6 +62,7 @@ import inspect
 import json
 import logging
 import os
+import shutil
 import time
 from collections import deque
 from typing import Any
@@ -105,6 +106,10 @@ except ImportError:
 
 from app import activity
 from app.pending_questions import PendingQuestion
+from app.process_groups import (
+  isolated_process_group_id,
+  terminate_process_group,
+)
 from app.runner_registry import RunnerKind, registry
 from app.runtime_types import RunnerResult
 from app.sdk_emit import emit_unknown_enabled, unknown_event
@@ -112,6 +117,43 @@ from app.tool_summaries import summarize_tool_input
 from app.tool_sources import normalize_tool_sources, sources_from_websearch_text
 
 log = logging.getLogger(__name__)
+
+_CLAUDE_CLI = "/usr/local/bin/claude"
+_ISOLATED_CLAUDE_CLI = "/app/scripts/claude-isolated"
+
+
+def _claude_cli_path() -> str:
+  """Use the baked process-group wrapper when its runtime is available."""
+  if (
+    os.path.isfile(_ISOLATED_CLAUDE_CLI)
+    and os.access(_ISOLATED_CLAUDE_CLI, os.X_OK)
+    and shutil.which("setsid")
+  ):
+    return _ISOLATED_CLAUDE_CLI
+  return _CLAUDE_CLI
+
+
+def _claude_process_group_id(client: ClaudeSDKClient) -> int | None:
+  """Return the isolated Claude CLI PGID through the SDK transport."""
+  transport = getattr(client, "_transport", None)
+  process = getattr(transport, "_process", None)
+  pid = getattr(process, "pid", None)
+  pgid = isolated_process_group_id(pid)
+  if pgid is None and isinstance(pid, int):
+    log.error(
+      "Claude CLI process group is not isolated pid=%s; "
+      "descendant cleanup disabled",
+      pid,
+    )
+  return pgid
+
+
+def _terminate_claude_process_group(pgid: int | None) -> bool:
+  return terminate_process_group(
+    pgid,
+    logger=log,
+    label="Claude descendant",
+  )
 
 # The SDK's 1 MiB default is smaller than a single base64-encoded screenshot
 # tool result, so the subprocess transport can reject an otherwise healthy
@@ -258,6 +300,10 @@ class ActiveClaudeClient:
     self.chat_id = chat_id
     self.kind = RunnerKind.CLAUDE_SDK
     self._client = client
+    self._process_group_id: int | None = None
+    # Never signal a retained PGID twice; the kernel can eventually reuse it
+    # after the first hard stop.
+    self._force_stop_started = False
     # FIFO of mid-turn steer texts: two rapid sends must both reach Claude
     # (both are already persisted to the transcript), so a single slot would
     # silently drop the first. The runner drains the whole list on interrupt.
@@ -370,7 +416,7 @@ class ActiveClaudeClient:
     self._steer_requested = False
     await self._client.interrupt()
     try:
-      await asyncio.wait_for(self._finished, timeout=5.0)
+      await asyncio.wait_for(asyncio.shield(self._finished), timeout=5.0)
     except asyncio.TimeoutError:
       import logging
       logging.getLogger("moebius.chat").warning(
@@ -393,6 +439,31 @@ class ActiveClaudeClient:
     except Exception:
       log.exception(
         "Claude SDK stop failed chat_id=%s", self.chat_id,
+      )
+      return False
+
+  def set_process_group_id(self, pgid: int | None) -> None:
+    self._process_group_id = pgid
+
+  async def force_stop(self, timeout: float = 5.0) -> bool:
+    """One-shot hard stop for this turn's verified private process group."""
+    if not self._force_stop_started:
+      if self._process_group_id is None:
+        return False
+      self._force_stop_started = True
+      await asyncio.to_thread(
+        _terminate_claude_process_group, self._process_group_id,
+      )
+    try:
+      await asyncio.wait_for(
+        asyncio.shield(self._finished), timeout=max(0.0, timeout),
+      )
+      return True
+    except asyncio.CancelledError:
+      raise
+    except asyncio.TimeoutError:
+      log.warning(
+        "Claude SDK hard stop did not finish chat_id=%s", self.chat_id,
       )
       return False
 
@@ -1272,7 +1343,7 @@ async def run_claude_sdk_turn(
       "include_partial_messages": True,
       "max_buffer_size": _CLAUDE_SDK_MAX_BUFFER_SIZE,
       "can_use_tool": can_use_tool,
-      "cli_path": "/usr/local/bin/claude",
+      "cli_path": _claude_cli_path(),
       "stderr": _capture_stderr,
       "hooks": {
         "PreToolUse": [
@@ -1317,6 +1388,7 @@ async def run_claude_sdk_turn(
           "cost_usd": None,
           "error": "connect timeout",
         }
+      active_client.set_process_group_id(_claude_process_group_id(client))
       await client.query(turn_message)
 
       # At most one automatic re-query per turn (see the synthetic-resume
@@ -1498,7 +1570,34 @@ async def run_claude_sdk_turn(
       try:
         await client.disconnect()
       finally:
+        # The SDK closes only its direct CLI PID. Reap the verified private
+        # group as a bounded backstop for tool children, and do not let a
+        # repeated task cancellation skip the SIGKILL worker once it starts.
+        deferred_cancel: asyncio.CancelledError | None = None
+        if (
+          active_client._process_group_id is not None
+          and not active_client._force_stop_started
+        ):
+          reap_task = asyncio.create_task(asyncio.to_thread(
+            _terminate_claude_process_group,
+            active_client._process_group_id,
+          ))
+          while not reap_task.done():
+            try:
+              await asyncio.shield(reap_task)
+            except asyncio.CancelledError as exc:
+              deferred_cancel = deferred_cancel or exc
+          try:
+            reap_task.result()
+          except Exception:
+            log.warning(
+              "Claude process-group cleanup failed chat_id=%s",
+              chat_id,
+              exc_info=True,
+            )
         active_client.mark_finished()
+        if deferred_cancel is not None:
+          raise deferred_cancel
 
   result = await _run_once(_model)
   if _model and _should_retry_without_model(result.get("error")):

--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -453,11 +453,21 @@ class ActiveCodexTurn:
   Same shape as Claude's `ActiveClaudeClient`.
   """
 
-  def __init__(self, thread: Any, turn: Any, chat_id: str):
+  def __init__(
+    self,
+    thread: Any,
+    turn: Any,
+    chat_id: str,
+    process_group_id: int | None = None,
+  ):
     self.chat_id = chat_id
     self.kind = RunnerKind.CODEX_SDK
     self.thread = thread
     self.turn = turn
+    self._process_group_id = process_group_id
+    # A retained PGID must never be signalled twice: after the first kill the
+    # kernel may eventually reuse that number for an unrelated process group.
+    self._force_stop_started = False
     # Admission flag shared with request_user_input on the runner loop. Set
     # synchronously before turn.steer's first await so a not-yet-registered
     # question cannot park the SDK reader ahead of the steer acknowledgement.
@@ -477,7 +487,7 @@ class ActiveCodexTurn:
     except Exception as exc:
       log.warning("codex interrupt() raised: %s", exc)
     try:
-      await asyncio.wait_for(self._finished, timeout=5.0)
+      await asyncio.wait_for(asyncio.shield(self._finished), timeout=5.0)
     except asyncio.TimeoutError:
       log.warning(
         "codex active_turn._finished never resolved within 5s; runner is wedged"
@@ -499,6 +509,28 @@ class ActiveCodexTurn:
     except Exception:
       log.exception(
         "Codex SDK stop failed chat_id=%s", self.chat_id,
+      )
+      return False
+
+  async def force_stop(self, timeout: float = 5.0) -> bool:
+    """One-shot hard stop for this turn's verified private process group."""
+    if not self._force_stop_started:
+      if self._process_group_id is None:
+        return False
+      self._force_stop_started = True
+      await asyncio.to_thread(
+        _terminate_codex_process_group, self._process_group_id,
+      )
+    try:
+      await asyncio.wait_for(
+        asyncio.shield(self._finished), timeout=max(0.0, timeout),
+      )
+      return True
+    except asyncio.CancelledError:
+      raise
+    except asyncio.TimeoutError:
+      log.warning(
+        "Codex SDK hard stop did not finish chat_id=%s", self.chat_id,
       )
       return False
 
@@ -1867,7 +1899,12 @@ async def run_codex_sdk_turn(
           )
         log.info("Codex turn aborted before stream registration chat_id=%s", chat_id)
         return aborted_result()
-      active_turn = ActiveCodexTurn(thread, turn, chat_id=chat_id)
+      active_turn = ActiveCodexTurn(
+        thread,
+        turn,
+        chat_id=chat_id,
+        process_group_id=process_group_id,
+      )
       registry.register(active_turn)
 
       # Persist the session id AFTER registering the live turn: this is a
@@ -2122,7 +2159,9 @@ async def run_codex_sdk_turn(
       except Exception as exc:
         log.warning("Codex process-group capture failed: %s", exc)
     current = registry.get_handle(chat_id, RunnerKind.CODEX_SDK)
+    group_already_terminated = False
     if isinstance(current, ActiveCodexTurn) and current.turn is turn:
+      group_already_terminated = current._force_stop_started
       registry.unregister(chat_id, RunnerKind.CODEX_SDK)
       current.mark_finished()
     # AsyncCodex.close() terminates only its direct Popen PID.  Reap the
@@ -2131,7 +2170,7 @@ async def run_codex_sdk_turn(
     # worker keeps the short grace period off the FastAPI event loop; shield
     # ensures task cancellation cannot prevent the SIGKILL backstop from
     # running in that worker once cleanup has started.
-    if process_group_id is not None:
+    if process_group_id is not None and not group_already_terminated:
       reap_task = asyncio.create_task(asyncio.to_thread(
         _terminate_codex_process_group, process_group_id,
       ))

--- a/backend/app/process_groups.py
+++ b/backend/app/process_groups.py
@@ -1,0 +1,58 @@
+"""Small, fail-closed helpers for isolated Unix process groups."""
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import time
+
+
+def isolated_process_group_id(pid: object) -> int | None:
+  """Return ``pid`` only when it provably leads a private process group."""
+  if not isinstance(pid, int) or pid <= 1:
+    return None
+  try:
+    pgid = os.getpgid(pid)
+  except (OSError, ProcessLookupError):
+    return None
+  if pgid != pid or pgid == os.getpgrp():
+    return None
+  return pgid
+
+
+def terminate_process_group(
+  pgid: int | None,
+  *,
+  logger: logging.Logger,
+  label: str,
+  grace_seconds: float = 0.25,
+) -> bool:
+  """TERM then KILL one already-verified private process group."""
+  if not isinstance(pgid, int) or pgid <= 1 or pgid == os.getpgrp():
+    return False
+  try:
+    os.killpg(pgid, signal.SIGTERM)
+  except ProcessLookupError:
+    return False
+  except OSError as exc:
+    logger.warning("%s SIGTERM failed pgid=%s: %s", label, pgid, exc)
+    return False
+
+  deadline = time.monotonic() + max(0.0, grace_seconds)
+  while time.monotonic() < deadline:
+    try:
+      os.killpg(pgid, 0)
+    except ProcessLookupError:
+      return True
+    except OSError:
+      break
+    time.sleep(min(0.025, max(0.0, deadline - time.monotonic())))
+
+  try:
+    os.killpg(pgid, signal.SIGKILL)
+  except ProcessLookupError:
+    pass
+  except OSError as exc:
+    logger.warning("%s SIGKILL failed pgid=%s: %s", label, pgid, exc)
+  return True

--- a/backend/app/runner_registry.py
+++ b/backend/app/runner_registry.py
@@ -28,6 +28,9 @@ class RunnerHandle(Protocol):
     log and return False on failure or timeout.
     """
 
+  async def force_stop(self, timeout: float = 5.0) -> bool:
+    """Hard-stops only this handle's verified private runtime identity."""
+
 
 class RunnerRegistry:
   """Single source of truth for per-chat runner state."""

--- a/backend/scripts/claude-isolated
+++ b/backend/scripts/claude-isolated
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Put Claude and its ordinary tool descendants in a private process group. If
+# a future SDK already supplies isolation, reuse it instead of calling setsid
+# twice.
+_pgid=$(ps -o pgid= -p "$$" 2>/dev/null | tr -d ' ')
+if [ -n "$_pgid" ] && [ "$_pgid" = "$$" ]; then
+  exec /usr/local/bin/claude "$@"
+fi
+exec /usr/bin/setsid /usr/local/bin/claude "$@"

--- a/backend/tests/test_chat_stop_delete_safety.py
+++ b/backend/tests/test_chat_stop_delete_safety.py
@@ -59,6 +59,56 @@ def test_stop_chat_for_timeout_leaves_chat_running():
   assert registry.is_alive(chat_id) is True
 
 
+def test_stop_chat_for_escalates_same_handle_and_closes_browser(monkeypatch):
+  chat_id = "chat-hard-stop"
+  calls: list[str] = []
+
+  class _EscalatingHandle(_FailingHandle):
+    async def force_stop(self, timeout: float = 5.0) -> bool:
+      del timeout
+      calls.append("force")
+      return True
+
+  async def _close_browser(closed_chat_id: str) -> None:
+    calls.append(f"browser:{closed_chat_id}")
+
+  monkeypatch.setattr(chat_mod, "_close_browser_session", _close_browser)
+  handle = _EscalatingHandle(chat_id)
+  registry.register(handle)
+
+  stopped, _ = asyncio.run(chat_mod.stop_chat_for(chat_id))
+
+  assert stopped is True
+  assert calls == ["force", f"browser:{chat_id}"]
+  assert registry.get_handle(chat_id, handle.kind) is None
+
+
+def test_stop_chat_for_never_escalates_replaced_handle(monkeypatch):
+  chat_id = "chat-successor-guard"
+  calls: list[str] = []
+
+  class _OldHandle(_FailingHandle):
+    async def stop(self, timeout: float = 2.0) -> bool:
+      del timeout
+      registry.register(successor)
+      return False
+
+    async def force_stop(self, timeout: float = 5.0) -> bool:
+      del timeout
+      calls.append("unsafe-force")
+      return True
+
+  successor = _FailingHandle(chat_id)
+  old = _OldHandle(chat_id)
+  registry.register(old)
+
+  stopped, _ = asyncio.run(chat_mod.stop_chat_for(chat_id))
+
+  assert stopped is False
+  assert calls == []
+  assert registry.get_handle(chat_id, old.kind) is successor
+
+
 def test_stop_on_orphaned_run_after_restart_succeeds(client, auth, db):
   """Stop on an orphaned run — run_status stuck 'running' with an EMPTY
   registry (the exact shape a prior restart leaves: the in-memory registry

--- a/backend/tests/test_claude_sdk_runner.py
+++ b/backend/tests/test_claude_sdk_runner.py
@@ -560,6 +560,45 @@ async def test_stop_drops_buffered_steer_and_clears_flags(monkeypatch):
     registry.unregister("stop-chat", handle.kind)
 
 
+@pytest.mark.asyncio
+async def test_stop_timeout_preserves_runner_completion_future():
+  class _Client:
+    async def interrupt(self):
+      return None
+
+  handle = ActiveClaudeClient(_Client(), chat_id="timeout-identity")
+
+  assert await handle.stop(timeout=0.01) is False
+  assert handle._finished.done() is False
+  handle.mark_finished()
+  assert handle._finished.done() is True
+
+
+@pytest.mark.asyncio
+async def test_force_stop_signals_claude_group_only_once(monkeypatch):
+  calls: list[int] = []
+  monkeypatch.setattr(
+    claude_sdk_runner,
+    "_terminate_claude_process_group",
+    lambda pgid: calls.append(pgid) or True,
+  )
+
+  class _Client:
+    async def interrupt(self):
+      return None
+
+  handle = ActiveClaudeClient(_Client(), chat_id="hard-stop")
+  handle.set_process_group_id(4321)
+  first = asyncio.create_task(handle.force_stop(timeout=1))
+  while not calls:
+    await asyncio.sleep(0)
+  handle.mark_finished()
+
+  assert await first is True
+  assert await handle.force_stop(timeout=1) is True
+  assert calls == [4321]
+
+
 def test_run_claude_sdk_turn_persists_session_id_before_terminal_result(
   monkeypatch,
 ):

--- a/backend/tests/test_codex_sdk_runner.py
+++ b/backend/tests/test_codex_sdk_runner.py
@@ -496,6 +496,46 @@ def test_active_codex_turn_interrupt_times_out_if_runner_never_finishes(caplog):
   )
 
 
+def test_active_codex_stop_timeout_preserves_runner_completion_future():
+  async def _scenario() -> None:
+    active = codex_sdk_runner.ActiveCodexTurn(
+      object(), _FakeTurnHandle(), chat_id="timeout-identity",
+    )
+
+    assert await active.stop(timeout=0.01) is False
+    assert active._finished.done() is False
+    active.mark_finished()
+    assert active._finished.done() is True
+
+  asyncio.run(_scenario())
+
+
+def test_active_codex_force_stop_signals_group_only_once(monkeypatch):
+  calls: list[int] = []
+  monkeypatch.setattr(
+    codex_sdk_runner,
+    "_terminate_codex_process_group",
+    lambda pgid: calls.append(pgid) or True,
+  )
+
+  async def _scenario() -> None:
+    active = codex_sdk_runner.ActiveCodexTurn(
+      object(),
+      _FakeTurnHandle(),
+      chat_id="hard-stop",
+      process_group_id=4321,
+    )
+    first = asyncio.create_task(active.force_stop(timeout=1))
+    while not calls:
+      await asyncio.sleep(0)
+    active.mark_finished()
+    assert await first is True
+    assert await active.force_stop(timeout=1) is True
+
+  asyncio.run(_scenario())
+  assert calls == [4321]
+
+
 def test_is_closed_turn_error_matches_sdk_rpc_errors(monkeypatch):
   sdk = _fake_sdk(async_codex_cls=object)
   monkeypatch.setattr(codex_sdk_runner, "_sdk_imports", lambda: sdk)

--- a/backend/tests/test_process_groups.py
+++ b/backend/tests/test_process_groups.py
@@ -1,0 +1,32 @@
+import logging
+import signal
+
+from app import process_groups
+
+
+def test_isolated_process_group_id_refuses_shared_group(monkeypatch):
+  monkeypatch.setattr(process_groups.os, "getpgid", lambda _pid: 4000)
+  monkeypatch.setattr(process_groups.os, "getpgrp", lambda: 4000)
+
+  assert process_groups.isolated_process_group_id(4321) is None
+
+
+def test_terminate_process_group_has_sigkill_backstop(monkeypatch):
+  calls = []
+  monkeypatch.setattr(process_groups.os, "getpgrp", lambda: 9999)
+  monkeypatch.setattr(
+    process_groups.os,
+    "killpg",
+    lambda pgid, sig: calls.append((pgid, sig)),
+  )
+
+  assert process_groups.terminate_process_group(
+    4321,
+    logger=logging.getLogger(__name__),
+    label="test",
+    grace_seconds=0,
+  ) is True
+  assert calls == [
+    (4321, signal.SIGTERM),
+    (4321, signal.SIGKILL),
+  ]


### PR DESCRIPTION
## Summary

- preserve each SDK handle's completion future when the 2s graceful Stop bound expires
- isolate Claude CLI turns in their own Unix process groups, matching Codex's existing containment
- escalate a timed-out Stop/watchdog interrupt once, only while the exact handle still owns the registry slot
- close the same chat's attributed detached agent-browser sessions after escalation
- reap Claude tool descendants on ordinary terminal cleanup as well as hard Stop

## Why

A Railway Trial deployment with a ~953 MiB cgroup reported one chat whose `handle.stop()` timed out, followed by repeated stalled-live watchdog timeouts for roughly two hours. The container was already at ~820 MiB in a quiet moment and had hit its cgroup ceiling eight times since restart. A restart reconciled exactly that one interrupted chat.

The watchdog previously retried the same graceful SDK interrupt indefinitely. It never escalated, and `asyncio.wait_for()` could cancel the shared `_finished` future that later teardown uses as its identity-safe acknowledgement. A wedged agent plus its detached Chromium session could therefore remain resident until the whole container restarted.

This change keeps the existing graceful path first. Hard cleanup is fail-closed:

- the registry is rechecked by object identity before escalation
- only a verified private process group is signalled
- the retained PGID is signalled at most once, avoiding later PID/PGID reuse
- a replacement handle is never touched
- detached browser daemons are selected separately by their inherited `CHAT_ID` and opaque session routing
- a runner that still does not finish remains registered for normal boot reconciliation

Refs #130; this is the concrete stop-escalation slice, not the broader memory-pressure/admission work in that issue.

## Verification

- `pytest -q backend/tests`: **2809 passed, 6 skipped**
- focused runner/Stop/watchdog/process-group suite after final review: **129 passed**
- same focused Claude suite against `claude-agent-sdk==0.2.126` (current registry release): **63 passed**
- `sh -n backend/scripts/claude-isolated`
- `git diff --check`
