### PR TITLE
refactor(chat): simplify restart continuation protocol

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -697,19 +697,20 @@ The platform process then publishes an intent and restart request; it does not
 terminate itself on the normal path.
 
 The frozen root-owned entrypoint poller validates and consumes the request,
-records the exact `(chat_id, run_id, nonce)` set in `/data/.restart-ledger`, and
-only then terminates pid 1. At the very start of the next entrypoint invocation,
-the ledger binds that accepted intent to the new `MOBIUS_BOOT_ID`. The app only
-continues a restart park when this root-owned acknowledgement, the exact DB run
-and nonce, and the separately stored restart policy all match. An intent that
-was merely written before a crash/OOM, an acknowledgement skipped by a failed
-handshake, or an acknowledgement left across another boot authorizes nothing.
-Transcript text is presentation, never restart-cause evidence.
+records its one-shot nonce in `/data/.restart-ledger`, and only then terminates
+pid 1. At the very start of the next entrypoint invocation, the ledger binds
+that accepted nonce to the new `MOBIUS_BOOT_ID`. The app only continues a
+restart park when the root-owned boot acknowledgement matches the nonce on the
+latest exact DB run and the separately stored restart policy is on. The
+supervisor attests the boot transition; the database owns run identity. An
+intent merely written before a crash/OOM, an acknowledgement skipped by a
+failed handshake, or an acknowledgement left across another boot authorizes
+nothing. Transcript text is presentation, never restart-cause evidence.
 
 | Event | Durable result | Boot/sweep result |
 |-------|----------------|-------------------|
 | Provider usage/rate limit | exact run `parked` until reset | notify; continue if the chat policy is on |
-| Accepted planned restart, exact park + ledger tuple match | exact run `parked`, reason `restart`, nonce, due now | continue immediately if separate restart consent is on |
+| Accepted planned restart, exact park + boot nonce match | exact run `parked`, reason `restart`, nonce, due now | continue immediately if separate restart consent is on |
 | Crash/OOM before supervisor acknowledgement | unacknowledged park or generic `running` evidence | resolve/reconcile to manual resumable interruption |
 | Repeated/unrelated boot before claim | acknowledgement is retired by boot-id mismatch | manual resumable interruption |
 | Policy off, unanswered question, app-owned run, or app-queued work | due park resolves without an automatic send | notify/manual owner action |

--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -2127,6 +2127,7 @@ async def drain_all_for_restart(
 # (design §2.4 step "at parked_until, push-notify").
 LIMIT_RESET_NOTIFY_TITLE = "Your limit has reset"
 LIMIT_RESET_NOTIFY_BODY = "Your limit has reset."
+CONTINUATION_SWEEP_BATCH_SIZE = 100
 
 
 def _has_unanswered_question(chat: models.Chat | None) -> bool:
@@ -2240,10 +2241,12 @@ async def _auto_resume_chat(
             latest_id = latest[0] if latest is not None else None
             restart_authorized = True
             if park is not None and park.park_reason == "restart":
-              from app.restart_ledger import authorized_runs
+              from app.restart_ledger import authorized_restart_nonce
+              accepted_nonce = authorized_restart_nonce()
               restart_authorized = (
-                authorized_runs().get(park.id)
-                == (chat_id, park.restart_nonce)
+                bool(accepted_nonce)
+                and bool(park.restart_nonce)
+                and accepted_nonce == park.restart_nonce
               )
             policy_enabled = bool(
               chat is not None
@@ -2357,8 +2360,9 @@ async def sweep_reset_parks(db: Session) -> list[str]:
   stalled-live sweeps). A due park is a `chat_runs` row still
   ``status`` is ``parked`` or ``resume_pending`` and whose
   `parked_until` has passed. Provider limits use their reset time; a planned
-  restart is parked by the drain itself with a due time of now. For each,
-  oldest due row first:
+  restart is parked by the drain itself with a due time of now. Each pass
+  processes a bounded oldest-first batch so a large backlog cannot monopolize
+  the event loop or produce an unbounded burst of database work. For each row:
 
     - Notify-only parks resolve first, then send one best-effort notification.
     - Auto-resume parks first become ``resume_pending``. That durable
@@ -2384,10 +2388,11 @@ async def sweep_reset_parks(db: Session) -> list[str]:
   try:
     due = (
       db.query(models.ChatRun)
-      .filter(models.ChatRun.status.in_(("parked", "resume_pending")))
+      .filter(models.ChatRun.status.in_(models.CONTINUATION_RUN_STATUSES))
       .filter(models.ChatRun.parked_until.isnot(None))
       .filter(models.ChatRun.parked_until <= now)
-      .order_by(models.ChatRun.parked_until.asc())
+      .order_by(models.ChatRun.parked_until.asc(), models.ChatRun.id.asc())
+      .limit(CONTINUATION_SWEEP_BATCH_SIZE)
       .all()
     )
   except Exception:
@@ -2395,20 +2400,39 @@ async def sweep_reset_parks(db: Session) -> list[str]:
     return resolved
   if not due:
     return resolved
+  chat_ids = {run.chat_id for run in due}
   try:
-    from app.restart_ledger import authorized_runs
-    restart_authorizations = authorized_runs()
+    chats = {
+      chat.id: chat
+      for chat in (
+        db.query(models.Chat)
+        .filter(models.Chat.id.in_(chat_ids))
+        .all()
+      )
+    }
   except Exception:
-    log.warning(
-      "sweep_reset_parks: restart ledger read failed; restart parks will "
-      "fall back to manual recovery",
-      exc_info=True,
-    )
-    restart_authorizations = {}
+    log.exception("sweep_reset_parks: chat batch query failed")
+    return resolved
+  restart_authorization = None
+  if any(run.park_reason == "restart" for run in due):
+    try:
+      from app.restart_ledger import authorized_restart_nonce
+      restart_authorization = authorized_restart_nonce()
+    except Exception:
+      log.warning(
+        "sweep_reset_parks: restart ledger read failed; restart parks will "
+        "fall back to manual recovery",
+        exc_info=True,
+      )
+  owner_loaded = False
+  owner = None
 
   def notify_due(chat_id: str, run: models.ChatRun) -> None:
+    nonlocal owner, owner_loaded
     try:
-      owner = db.query(models.Owner).first()
+      if not owner_loaded:
+        owner = db.query(models.Owner).first()
+        owner_loaded = True
       if owner is not None:
         from app import push
         restarted = run.park_reason == "restart"
@@ -2426,6 +2450,7 @@ async def sweep_reset_parks(db: Session) -> list[str]:
           target=f"/shell/?chat={chat_id}",
         )
     except Exception:
+      owner_loaded = True
       log.warning(
         "continuation notify failed chat_id=%s", chat_id, exc_info=True,
       )
@@ -2446,8 +2471,11 @@ async def sweep_reset_parks(db: Session) -> list[str]:
     )
     restart_authorized = (
       not restart_park
-      or restart_authorizations.get(run.id)
-      == (run.chat_id, run.restart_nonce)
+      or (
+        bool(restart_authorization)
+        and bool(run.restart_nonce)
+        and restart_authorization == run.restart_nonce
+      )
     )
     return bool(
       chat is not None
@@ -2462,7 +2490,7 @@ async def sweep_reset_parks(db: Session) -> list[str]:
   auto_resume_started = False
   for run in due:
     chat_id = run.chat_id
-    chat = db.query(models.Chat).filter(models.Chat.id == chat_id).first()
+    chat = chats.get(chat_id)
     chat_gone = chat is None or chat.deleted_at is not None
     auto_resume = wants_auto_resume(chat, run)
     if auto_resume and (

--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -51,7 +51,7 @@ from dataclasses import dataclass, field
 from sqlalchemy import select, text, update
 from sqlalchemy.exc import SQLAlchemyError
 
-from app import schemas
+from app import models, schemas
 from app.events import (
   TOOL_OUTPUT_INLINE_THRESHOLD,
   build_assistant_message,
@@ -2129,7 +2129,7 @@ class ChatWriterActor:
     # chat.  Already-resolved ``parked_notified`` rows remain historical.
     for run in db.query(ChatRun).filter(
       ChatRun.chat_id == cmd.chat_id,
-      ChatRun.status.in_(("parked", "resume_pending")),
+      ChatRun.status.in_(models.CONTINUATION_RUN_STATUSES),
     ).all():
       run.status = "interrupted"
       run.ended_at = datetime.now(UTC)
@@ -2155,7 +2155,7 @@ class ChatWriterActor:
     messages = list(chat.messages or [])
     has_active_run = db.query(ChatRun).filter(
       ChatRun.chat_id == cmd.chat_id,
-      ChatRun.status.in_(("running", "parked", "resume_pending")),
+      ChatRun.status.in_(models.NONTERMINAL_RUN_STATUSES),
     ).first() is not None
     if chat.run_status is not None or chat.pending_messages or has_active_run:
       return {"status": "conflict", "reason": "busy"}
@@ -2391,7 +2391,7 @@ class ChatWriterActor:
     # resolved and stay untouched.
     q = db.query(ChatRun).filter(
       ChatRun.chat_id == chat_id,
-      ChatRun.status.in_(("running", "parked", "resume_pending")),
+      ChatRun.status.in_(models.NONTERMINAL_RUN_STATUSES),
     )
     if except_token is not None:
       q = q.filter(ChatRun.id != except_token)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -25,6 +25,10 @@ from app.database import Base
 from app.timeutil import now_naive_utc
 
 
+CONTINUATION_RUN_STATUSES = ("parked", "resume_pending")
+NONTERMINAL_RUN_STATUSES = ("running", *CONTINUATION_RUN_STATUSES)
+
+
 class Owner(Base):
   """Single owner account for this installation."""
 

--- a/backend/app/restart_ledger.py
+++ b/backend/app/restart_ledger.py
@@ -41,37 +41,35 @@ def _atomic_json(path: Path, value: dict[str, Any]) -> None:
   tmp = path.with_name(f".{path.name}.{secrets.token_hex(8)}.tmp")
   flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
   flags |= getattr(os, "O_NOFOLLOW", 0)
-  fd = os.open(tmp, flags, 0o600)
   try:
-    offset = 0
-    while offset < len(payload):
-      offset += os.write(fd, payload[offset:])
-    os.fsync(fd)
-  finally:
-    os.close(fd)
-  os.replace(tmp, path)
+    fd = os.open(tmp, flags, 0o600)
+    try:
+      offset = 0
+      while offset < len(payload):
+        offset += os.write(fd, payload[offset:])
+      os.fsync(fd)
+    finally:
+      os.close(fd)
+    os.replace(tmp, path)
+  except Exception:
+    tmp.unlink(missing_ok=True)
+    raise
 
 
 def request_restart(
   *,
   boot_id: str,
   nonce: str,
-  runs: list[dict[str, str]],
   now: float | None = None,
 ) -> None:
   """Publish intent first, then the sentinel the frozen poller consumes."""
   intent_path, request_path, _ = _paths()
   created_at = time.time() if now is None else now
-  normalized = [
-    {"chat_id": str(item["chat_id"]), "run_token": str(item["run_token"])}
-    for item in runs
-  ]
   _atomic_json(intent_path, {
     "version": PROTOCOL_VERSION,
     "nonce": nonce,
     "source_boot_id": boot_id,
     "created_at": created_at,
-    "runs": normalized,
   })
   _atomic_json(request_path, {
     "nonce": nonce,
@@ -79,16 +77,16 @@ def request_restart(
   })
 
 
-def authorized_runs(
+def authorized_restart_nonce(
   boot_id: str | None = None,
   *,
   trusted_uid: int = 0,
   trusted_gid: int = 0,
-) -> dict[str, tuple[str, str]]:
-  """Return ``run_token -> (chat_id, nonce)`` for this authenticated boot."""
+) -> str | None:
+  """Return the planned-restart nonce accepted for this exact boot."""
   expected_boot = boot_id if boot_id is not None else current_boot_id()
   if not expected_boot:
-    return {}
+    return None
   _, _, ledger_dir = _paths()
   ack_path = ledger_dir / "ack.json"
   try:
@@ -106,7 +104,7 @@ def authorized_runs(
       or ack_st.st_mode & (stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH)
       or ack_st.st_size > MAX_ACK_BYTES
     ):
-      return {}
+      return None
     flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
     fd = os.open(ack_path, flags)
     try:
@@ -115,25 +113,14 @@ def authorized_runs(
       os.close(fd)
     value = json.loads(raw.decode("utf-8"))
   except (OSError, UnicodeError, json.JSONDecodeError):
-    return {}
+    return None
   if (
     not isinstance(value, dict)
     or value.get("version") != PROTOCOL_VERSION
     or value.get("target_boot_id") != expected_boot
     or not isinstance(value.get("nonce"), str)
-    or not isinstance(value.get("runs"), list)
+    or not value["nonce"]
+    or len(value["nonce"]) > 160
   ):
-    return {}
-  nonce = value["nonce"]
-  result: dict[str, tuple[str, str]] = {}
-  for item in value["runs"]:
-    if not isinstance(item, dict):
-      return {}
-    chat_id = item.get("chat_id")
-    run_token = item.get("run_token")
-    if not isinstance(chat_id, str) or not isinstance(run_token, str):
-      return {}
-    if run_token in result:
-      return {}
-    result[run_token] = (chat_id, nonce)
-  return result
+    return None
+  return value["nonce"]

--- a/backend/app/restart_util.py
+++ b/backend/app/restart_util.py
@@ -79,9 +79,8 @@ async def restart_this_worker() -> None:
 
   boot_id = restart_ledger.current_boot_id()
   restart_nonce = restart_ledger.new_nonce()
-  parked_runs: list[dict[str, str]] = []
   try:
-    parked_runs = await asyncio.wait_for(
+    await asyncio.wait_for(
       chat.drain_all_for_restart(
         timeout=chat.DRAIN_TIMEOUT,
         restart_nonce=restart_nonce,
@@ -103,7 +102,6 @@ async def restart_this_worker() -> None:
     restart_ledger.request_restart(
       boot_id=boot_id,
       nonce=restart_nonce,
-      runs=parked_runs,
     )
   except Exception:
     # Restart reliability and continuation authorization are independent.

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -912,7 +912,7 @@ async def patch_chat(
     if provider_changing:
       active_run = db.query(models.ChatRun).filter(
         models.ChatRun.chat_id == chat_id,
-        models.ChatRun.status.in_(("running", "parked", "resume_pending")),
+        models.ChatRun.status.in_(models.NONTERMINAL_RUN_STATUSES),
       ).first()
       if (
         is_chat_running(chat_id)
@@ -1619,7 +1619,7 @@ async def compact_chat(
       )
     active_run = db.query(models.ChatRun).filter(
       models.ChatRun.chat_id == chat_id,
-      models.ChatRun.status.in_(("running", "parked", "resume_pending")),
+      models.ChatRun.status.in_(models.NONTERMINAL_RUN_STATUSES),
     ).first()
     if (
       is_chat_running(chat_id)
@@ -2016,7 +2016,7 @@ async def patch_app_chat(
     if body.system_prompt is not None:
       active_run = db.query(models.ChatRun).filter(
         models.ChatRun.chat_id == chat_id,
-        models.ChatRun.status.in_(("running", "parked", "resume_pending")),
+        models.ChatRun.status.in_(models.NONTERMINAL_RUN_STATUSES),
       ).first()
       if (
         chat.system_prompt_snapshot_id
@@ -2050,7 +2050,7 @@ async def patch_app_chat(
       if chat.provider != body.provider:
         active_run = db.query(models.ChatRun).filter(
           models.ChatRun.chat_id == chat_id,
-          models.ChatRun.status.in_(("running", "parked", "resume_pending")),
+          models.ChatRun.status.in_(models.NONTERMINAL_RUN_STATUSES),
         ).first()
         if (
           is_chat_running(chat_id)

--- a/backend/app/routes/debug.py
+++ b/backend/app/routes/debug.py
@@ -122,7 +122,7 @@ def debug_status(
     }
     for run in (
       db.query(models.ChatRun)
-      .filter(models.ChatRun.status.in_(("parked", "resume_pending")))
+      .filter(models.ChatRun.status.in_(models.CONTINUATION_RUN_STATUSES))
       # id.asc() tiebreak keeps the listing stable across reads when two
       # rows share a started_at (same rationale as the latest-run probe in
       # chat._parked_until_for_chat).

--- a/backend/recovery/restart_ledger.py
+++ b/backend/recovery/restart_ledger.py
@@ -6,8 +6,8 @@ cause of the next boot by writing a transcript row or database flag itself. This
 helper runs from the baked, root-owned recovery bundle and maintains a
 root-owned ledger under ``/data/.restart-ledger``:
 
-* ``accept`` validates and consumes one untrusted platform request, records the
-  exact run identities, and is called immediately before the entrypoint poller
+* ``accept`` validates and consumes one untrusted platform request, records its
+  one-shot nonce, and is called immediately before the entrypoint poller
   terminates pid 1.
 * ``begin-boot`` binds that accepted request to exactly the next boot id.
 * ``harden`` restores root ownership after the entrypoint's broad compatibility
@@ -42,7 +42,6 @@ BOOT_PATH = LEDGER_DIR / "boot-id"
 
 PROTOCOL_VERSION = 1
 MAX_REQUEST_BYTES = 64 * 1024
-MAX_RUNS = 64
 MAX_REQUEST_AGE_SECONDS = 120
 MAX_ACCEPTED_AGE_SECONDS = 10 * 60
 _TOKEN_RE = re.compile(r"^[A-Za-z0-9._:-]{8,160}$")
@@ -86,18 +85,22 @@ def _atomic_write(path: Path, payload: bytes, mode: int) -> None:
   tmp = path.parent / f".{path.name}.{secrets.token_hex(8)}.tmp"
   flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
   flags |= getattr(os, "O_NOFOLLOW", 0)
-  fd = os.open(tmp, flags, mode)
   try:
-    offset = 0
-    while offset < len(payload):
-      offset += os.write(fd, payload[offset:])
-    os.fsync(fd)
-    os.fchmod(fd, mode)
-    if hasattr(os, "fchown"):
-      os.fchown(fd, SUPERVISOR_UID, SUPERVISOR_GID)
-  finally:
-    os.close(fd)
-  os.replace(tmp, path)
+    fd = os.open(tmp, flags, mode)
+    try:
+      offset = 0
+      while offset < len(payload):
+        offset += os.write(fd, payload[offset:])
+      os.fsync(fd)
+      os.fchmod(fd, mode)
+      if hasattr(os, "fchown"):
+        os.fchown(fd, SUPERVISOR_UID, SUPERVISOR_GID)
+    finally:
+      os.close(fd)
+    os.replace(tmp, path)
+  except Exception:
+    tmp.unlink(missing_ok=True)
+    raise
   _fsync_dir(path.parent)
 
 
@@ -155,26 +158,6 @@ def _prepare_ledger_dir() -> None:
     _recreate_ledger_dir()
 
 
-def _valid_runs(value: Any) -> list[dict[str, str]] | None:
-  if not isinstance(value, list) or len(value) > MAX_RUNS:
-    return None
-  seen: set[tuple[str, str]] = set()
-  runs: list[dict[str, str]] = []
-  for item in value:
-    if not isinstance(item, dict):
-      return None
-    chat_id = item.get("chat_id")
-    run_token = item.get("run_token")
-    if not _valid_token(chat_id) or not _valid_token(run_token):
-      return None
-    key = (chat_id, run_token)
-    if key in seen:
-      return None
-    seen.add(key)
-    runs.append({"chat_id": chat_id, "run_token": run_token})
-  return runs
-
-
 def _valid_intent(
   intent: dict[str, Any] | None,
   request: dict[str, Any] | None,
@@ -200,16 +183,12 @@ def _valid_intent(
     return None
   if created_at > now + 5 or now - created_at > MAX_REQUEST_AGE_SECONDS:
     return None
-  runs = _valid_runs(intent.get("runs"))
-  if runs is None:
-    return None
   return {
     "version": PROTOCOL_VERSION,
     "nonce": nonce,
     "source_boot_id": source_boot_id,
     "created_at": created_at,
     "accepted_at": now,
-    "runs": runs,
   }
 
 
@@ -228,19 +207,16 @@ def begin_boot(boot_id: str, *, now: float | None = None) -> bool:
       accepted_at = float(accepted.get("accepted_at"))
     except (TypeError, ValueError):
       accepted_at = 0
-    runs = _valid_runs(accepted.get("runs"))
     if (
       accepted.get("version") == PROTOCOL_VERSION
       and _valid_token(accepted.get("nonce"))
       and _valid_token(accepted.get("source_boot_id"))
       and accepted.get("source_boot_id") != boot_id
-      and runs is not None
       and accepted_at <= current + 5
       and current - accepted_at <= MAX_ACCEPTED_AGE_SECONDS
     ):
       authorized_payload = {
         **accepted,
-        "runs": runs,
         "target_boot_id": boot_id,
       }
   # Consume before acknowledging. If the volume refuses this deletion, the
@@ -288,7 +264,7 @@ def harden(boot_id: str) -> bool:
 
 
 def accept(boot_id: str, *, now: float | None = None) -> bool:
-  """Consume one restart request and record exact externally accepted runs."""
+  """Consume one restart request and record its externally accepted nonce."""
   current = time.time() if now is None else now
   _prepare_ledger_dir()
   try:

--- a/backend/tests/test_limit_park.py
+++ b/backend/tests/test_limit_park.py
@@ -653,6 +653,28 @@ def test_sweep_resolves_deleted_chat_without_notify(owner_token, monkeypatch):
   assert _run_row("rt-sweep-deleted")["status"] == "parked_notified"
 
 
+def test_sweep_processes_a_bounded_batch(owner_token, monkeypatch):
+  del owner_token
+  monkeypatch.setattr(chat_mod, "CONTINUATION_SWEEP_BATCH_SIZE", 2)
+  monkeypatch.setattr(
+    "app.push.notify_owner",
+    lambda db, owner_id, **kw: "notif-id",
+  )
+  for suffix in ("a", "b", "c"):
+    _due_park(f"sweep-batch-{suffix}", f"rt-sweep-batch-{suffix}")
+
+  first = _run_sweep()
+
+  assert len(first) == 2
+  remaining = {
+    token
+    for token in ("rt-sweep-batch-a", "rt-sweep-batch-b", "rt-sweep-batch-c")
+    if _run_row(token)["status"] == "parked"
+  }
+  assert len(remaining) == 1
+  assert _run_sweep() == [next(iter(remaining)).removeprefix("rt-")]
+
+
 # -- (e) auto-resume -----------------------------------------------------------
 
 def test_sweep_auto_resume_off_by_default(owner_token, monkeypatch):
@@ -735,8 +757,8 @@ def test_restart_park_auto_continues_with_product_marker(
   token = f"rt-{cid}"
   nonce = "restart-nonce-auto"
   monkeypatch.setattr(
-    "app.restart_ledger.authorized_runs",
-    lambda: {token: (cid, nonce)},
+    "app.restart_ledger.authorized_restart_nonce",
+    lambda: nonce,
   )
   _due_park(
     cid, token, auto_resume=True, auto_restart=True,
@@ -778,8 +800,8 @@ def test_restart_park_waiting_on_question_stays_manual(
   token = f"rt-{cid}"
   nonce = "restart-nonce-question"
   monkeypatch.setattr(
-    "app.restart_ledger.authorized_runs",
-    lambda: {token: (cid, nonce)},
+    "app.restart_ledger.authorized_restart_nonce",
+    lambda: nonce,
   )
   _due_park(
     cid,
@@ -827,8 +849,8 @@ def test_restart_park_policy_off_resolves_to_manual_interruption(
   token = f"rt-{cid}"
   nonce = "restart-nonce-policy"
   monkeypatch.setattr(
-    "app.restart_ledger.authorized_runs",
-    lambda: {token: (cid, nonce)},
+    "app.restart_ledger.authorized_restart_nonce",
+    lambda: nonce,
   )
   # Provider-limit policy is deliberately ON. Separate restart consent remains
   # off, proving the legacy preference cannot broaden into restart replay.
@@ -853,7 +875,9 @@ def test_restart_park_without_current_boot_ack_stays_manual(
     "app.push.notify_owner",
     lambda *args, **kwargs: notifications.append(kwargs) or "notif-id",
   )
-  monkeypatch.setattr("app.restart_ledger.authorized_runs", lambda: {})
+  monkeypatch.setattr(
+    "app.restart_ledger.authorized_restart_nonce", lambda: None,
+  )
   cid = "restart-no-ack"
   token = f"rt-{cid}"
   _due_park(
@@ -867,6 +891,27 @@ def test_restart_park_without_current_boot_ack_stays_manual(
   assert notifications[0]["title"] == "Möbius restarted"
 
 
+def test_restart_park_with_no_nonce_never_matches_missing_ack(
+  owner_token, monkeypatch,
+):
+  del owner_token
+  monkeypatch.setattr(
+    "app.push.notify_owner", lambda *args, **kwargs: "notif-id",
+  )
+  monkeypatch.setattr(
+    "app.restart_ledger.authorized_restart_nonce", lambda: None,
+  )
+  cid = "restart-no-nonce"
+  token = f"rt-{cid}"
+  _due_park(
+    cid, token, auto_restart=True, park_reason="restart",
+    restart_nonce=None,
+  )
+
+  assert _run_sweep() == [cid]
+  assert _run_row(token)["status"] == "interrupted"
+
+
 def test_restart_park_rejects_ack_for_the_wrong_nonce(
   owner_token, monkeypatch,
 ):
@@ -877,8 +922,8 @@ def test_restart_park_rejects_ack_for_the_wrong_nonce(
     "app.push.notify_owner", lambda *args, **kwargs: "notif-id",
   )
   monkeypatch.setattr(
-    "app.restart_ledger.authorized_runs",
-    lambda: {token: (cid, "different-nonce-1234")},
+    "app.restart_ledger.authorized_restart_nonce",
+    lambda: "different-nonce-1234",
   )
   _due_park(
     cid,
@@ -904,8 +949,8 @@ def test_restart_spawn_failure_retires_one_shot_authorization(
     "app.push.notify_owner", lambda *args, **kwargs: "notif-id",
   )
   monkeypatch.setattr(
-    "app.restart_ledger.authorized_runs",
-    lambda: {token: (cid, nonce)},
+    "app.restart_ledger.authorized_restart_nonce",
+    lambda: nonce,
   )
   _due_park(
     cid, token, auto_restart=True, park_reason="restart",

--- a/backend/tests/test_restart_ledger.py
+++ b/backend/tests/test_restart_ledger.py
@@ -56,18 +56,17 @@ def _bind(supervisor, root: Path, monkeypatch) -> None:
   )
 
 
-def _request(root: Path, *, boot: str, nonce: str, now: float) -> None:
+def _request(*, boot: str, nonce: str, now: float) -> None:
   platform_ledger.request_restart(
     boot_id=boot,
     nonce=nonce,
-    runs=[{"chat_id": "chat-12345678", "run_token": "run-12345678"}],
     now=now,
   )
 
 
 def _authorized(root: Path, boot: str):
   del root
-  return platform_ledger.authorized_runs(
+  return platform_ledger.authorized_restart_nonce(
     boot,
     trusted_uid=os.getuid(),
     trusted_gid=os.getgid(),
@@ -85,14 +84,12 @@ def test_exact_accepted_restart_is_bound_to_immediately_following_boot(
   nonce = "nonce-12345678"
 
   assert supervisor.begin_boot(source_boot, now=now) is False
-  _request(tmp_path, boot=source_boot, nonce=nonce, now=now)
+  _request(boot=source_boot, nonce=nonce, now=now)
   assert supervisor.accept(source_boot, now=now + 1) is True
   assert supervisor.begin_boot(target_boot, now=now + 2) is True
 
-  assert _authorized(tmp_path, target_boot) == {
-    "run-12345678": ("chat-12345678", nonce),
-  }
-  assert _authorized(tmp_path, source_boot) == {}
+  assert _authorized(tmp_path, target_boot) == nonce
+  assert _authorized(tmp_path, source_boot) is None
 
 
 def test_crash_after_intent_before_supervisor_acceptance_is_not_authorized(
@@ -104,10 +101,10 @@ def test_crash_after_intent_before_supervisor_acceptance_is_not_authorized(
   source_boot = "boot-source-1234"
 
   supervisor.begin_boot(source_boot, now=now)
-  _request(tmp_path, boot=source_boot, nonce="nonce-12345678", now=now)
+  _request(boot=source_boot, nonce="nonce-12345678", now=now)
   # Simulate OOM/SIGKILL before the frozen poller accepts the request.
   assert supervisor.begin_boot("boot-after-oom-1", now=now + 1) is False
-  assert _authorized(tmp_path, "boot-after-oom-1") == {}
+  assert _authorized(tmp_path, "boot-after-oom-1") is None
   assert not supervisor.INTENT_PATH.exists()
   assert not supervisor.REQUEST_PATH.exists()
 
@@ -119,14 +116,14 @@ def test_second_boot_before_claim_retires_one_shot_ack(tmp_path, monkeypatch):
   source_boot = "boot-source-1234"
 
   supervisor.begin_boot(source_boot, now=now)
-  _request(tmp_path, boot=source_boot, nonce="nonce-12345678", now=now)
+  _request(boot=source_boot, nonce="nonce-12345678", now=now)
   assert supervisor.accept(source_boot, now=now + 1)
   assert supervisor.begin_boot("boot-target-1234", now=now + 2)
   assert _authorized(tmp_path, "boot-target-1234")
 
   assert supervisor.begin_boot("boot-repeated-1234", now=now + 3) is False
-  assert _authorized(tmp_path, "boot-target-1234") == {}
-  assert _authorized(tmp_path, "boot-repeated-1234") == {}
+  assert _authorized(tmp_path, "boot-target-1234") is None
+  assert _authorized(tmp_path, "boot-repeated-1234") is None
 
 
 def test_boot_does_not_ack_when_accepted_intent_cannot_be_consumed(
@@ -137,7 +134,7 @@ def test_boot_does_not_ack_when_accepted_intent_cannot_be_consumed(
   now = time.time()
   source_boot = "boot-source-1234"
   supervisor.begin_boot(source_boot, now=now)
-  _request(tmp_path, boot=source_boot, nonce="nonce-12345678", now=now)
+  _request(boot=source_boot, nonce="nonce-12345678", now=now)
   assert supervisor.accept(source_boot, now=now + 1)
   real_remove = supervisor._remove
 
@@ -164,7 +161,7 @@ def test_recovery_restart_without_chat_intent_never_authorizes(
 
   assert supervisor.accept(source_boot, now=now + 1) is False
   assert supervisor.begin_boot("boot-recovery-1234", now=now + 2) is False
-  assert _authorized(tmp_path, "boot-recovery-1234") == {}
+  assert _authorized(tmp_path, "boot-recovery-1234") is None
 
 
 def test_mismatched_or_expired_request_is_consumed_without_ack(
@@ -176,7 +173,6 @@ def test_mismatched_or_expired_request_is_consumed_without_ack(
   source_boot = "boot-source-1234"
   supervisor.begin_boot(source_boot, now=now)
   _request(
-    tmp_path,
     boot=source_boot,
     nonce="nonce-12345678",
     now=now - supervisor.MAX_REQUEST_AGE_SECONDS - 1,
@@ -195,21 +191,18 @@ def test_platform_rejects_writable_or_tampered_ack(tmp_path, monkeypatch):
   source_boot = "boot-source-1234"
   target_boot = "boot-target-1234"
   supervisor.begin_boot(source_boot, now=now)
-  _request(tmp_path, boot=source_boot, nonce="nonce-12345678", now=now)
+  _request(boot=source_boot, nonce="nonce-12345678", now=now)
   assert supervisor.accept(source_boot, now=now + 1)
   assert supervisor.begin_boot(target_boot, now=now + 2)
 
   supervisor.ACK_PATH.chmod(0o644)
-  assert _authorized(tmp_path, target_boot) == {}
+  assert _authorized(tmp_path, target_boot) is None
   supervisor.ACK_PATH.chmod(0o444)
   value = json.loads(supervisor.ACK_PATH.read_text(encoding="utf-8"))
-  value["runs"][0]["run_token"] = "forged-run-1234"
+  value["nonce"] = "forged-nonce-1234"
   supervisor.ACK_PATH.chmod(0o644)
   supervisor.ACK_PATH.write_text(json.dumps(value), encoding="utf-8")
   supervisor.ACK_PATH.chmod(0o444)
-  # Filesystem ownership proves who wrote the ledger in production. This test
-  # process is the trusted uid, so content tampering is structurally valid; the
-  # exact DB run/nonce comparison remains the second authorization boundary.
-  assert _authorized(tmp_path, target_boot) == {
-    "forged-run-1234": ("chat-12345678", "nonce-12345678"),
-  }
+  # This test process is the trusted uid, so structurally valid content written
+  # by it is accepted. In production only the frozen supervisor owns this file.
+  assert _authorized(tmp_path, target_boot) == "forged-nonce-1234"

--- a/backend/tests/test_restart_util.py
+++ b/backend/tests/test_restart_util.py
@@ -61,7 +61,6 @@ def test_restart_drains_then_requests_supervisor_and_arms_force_kill(monkeypatch
   assert requests == [{
     "boot_id": "boot-12345678",
     "nonce": "nonce-12345678",
-    "runs": [{"chat_id": "chat-12345678", "run_token": "run-12345678"}],
   }]
   # A single force-kill fallback, armed as a daemon and started, so a hung
   # graceful shutdown can't leave the container "Up" with a dead worker. Its
@@ -102,7 +101,6 @@ def test_restart_request_survives_drain_failure(monkeypatch):
   assert requests == [{
     "boot_id": "boot-12345678",
     "nonce": "nonce-12345678",
-    "runs": [],
   }]
   assert len(_FakeTimer.instances) == 1
 


### PR DESCRIPTION
## Summary

- reduce planned-restart authorization to one supervisor-accepted boot nonce
- keep exact-run safety in the durable run row, latest-run fence, policy gate, and queue lock
- process due continuations in bounded 100-row batches with one bulk chat query
- load the owner and restart ledger lazily only when the batch needs them
- centralize continuation/nonterminal run-state sets
- remove failed atomic-write temporary files

## Why

The root supervisor needs to attest that a deliberate restart crossed the boot boundary. It does not need to repeat every app-supplied run identity: the application already owns those database rows, so repeating the list adds protocol and validation cost without adding trust. A one-shot nonce preserves the important guarantees while making the boundary smaller and easier to audit.

The continuation sweep is now bounded, deterministic, and avoids per-row chat and owner lookups. Empty and provider-limit-only paths do not touch the restart ledger.

## Behavior preserved

- crashes before supervisor acceptance remain manual
- acknowledgements are bound to one immediately following boot
- missing, empty, or wrong nonces fail closed
- policy-off, unanswered-question, app-owned, deleted, and superseded work remains manual or silent as before
- auto-resume remains globally serial and rechecks eligibility under the transition and queue locks
- usage-limit and planned-restart consent remain separate

## Validation

- full backend: 2,802 passed, 6 skipped
- focused restart/ledger/sweep: 72 passed
- post-rebase restart + stalled-stop integration: 262 passed
- frontend libraries: 1,804 passed
- frontend hooks: 47 passed
- production frontend build: 1,227 modules
- preship and pre-push gates passed
