### PR TITLE
Restore cohesive pane choreography

### DIFF
--- a/frontend/src/components/Shell/__tests__/modeMachine.test.js
+++ b/frontend/src/components/Shell/__tests__/modeMachine.test.js
@@ -17,7 +17,7 @@ import {
 // modeMachine.js.
 
 // A minimal enter plan (one deal-in participant).
-function enterPlan({ totalMs = MODE_MOTION.itemMs } = {}) {
+function enterPlan({ totalMs = MODE_MOTION.enterItemMs } = {}) {
   return {
     kind: 'enter',
     participants: [{ key: 'chat:1', paneId: 'p1', motion: 'deal-in', delayMs: 0, durationMs: totalMs }],
@@ -26,7 +26,7 @@ function enterPlan({ totalMs = MODE_MOTION.itemMs } = {}) {
   }
 }
 // A minimal exit plan (one deal-out participant, a chat underlay).
-function exitPlan({ underlayKey = 'chat:5', target = 'chat:5', sig = 'sigA', totalMs = MODE_MOTION.itemMs } = {}) {
+function exitPlan({ underlayKey = 'chat:5', target = 'chat:5', sig = 'sigA', totalMs = MODE_MOTION.exitItemMs } = {}) {
   return {
     kind: 'exit',
     target,
@@ -44,10 +44,10 @@ function promotePlan({ sig = 'sigP' } = {}) {
     kind: 'exit',
     target: 'app:9',
     destinationRect: { x: 0, y: 0, w: 100, h: 200 },
-    participants: [{ key: 'app:9', paneId: 'p1', motion: 'promote', delayMs: 0, durationMs: MODE_MOTION.itemMs, flip: { x: 0, y: 0, sx: 1, sy: 1 } }],
+    participants: [{ key: 'app:9', paneId: 'p1', motion: 'promote', delayMs: 0, durationMs: MODE_MOTION.promoteMs, flip: { x: 0, y: 0, sx: 1, sy: 1 } }],
     underlayKey: null,
     completionNames: ['shell-mode-promote'],
-    totalMs: MODE_MOTION.itemMs,
+    totalMs: MODE_MOTION.promoteMs,
     snapshotSignature: sig,
   }
 }

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -540,10 +540,10 @@ test('entry assembles on keyed beat classes, compositor-only, instant under redu
   assert.match(dealIn, /translate3d\(var\(--mode-offset-x\), var\(--mode-offset-y\), 0\)/)
   assert.doesNotMatch(dealIn, /opacity:/)
   assert.doesNotMatch(dealIn, /box-shadow|border-radius|filter|clip/)
-  assert.match(css, /--ease-mode-arrive:\s*cubic-bezier\(0\.25, 1, 0\.5, 1\)/,
-    'edge travel must remain visible across the short entry beat')
-  assert.match(css, /--ease-mode-promote:\s*cubic-bezier\(0\.25, 1, 0\.5, 1\)/,
-    'the shared pane settles with the same readable arrival curve')
+  assert.match(css, /--ease-mode-arrive:\s*cubic-bezier\(0\.16, 1, 0\.3, 1\)/,
+    'entry keeps the accepted all-sides assembly curve')
+  assert.match(css, /--ease-mode-promote:\s*cubic-bezier\(0\.2, 0\.82, 0\.2, 1\)/,
+    'the shared pane keeps its accepted weighted settle curve')
   // The old dead .workspace--resizing selector is gone entirely.
   assert.doesNotMatch(css, /workspace--resizing/)
   assert.doesNotMatch(css, /shell-pane-deal|shell-strip-deal-in|shell-pane-settle/)
@@ -622,8 +622,8 @@ test('leaving builder plays the INVERSE deal: compositor-only promote/deal-out, 
   assert.match(dealOut, /translate3d\(var\(--mode-offset-x\), var\(--mode-offset-y\), 0\)/)
   assert.match(dealOut, /opacity: 0/)
   assert.doesNotMatch(dealOut, /box-shadow|border-radius|filter|clip/)
-  assert.match(css, /--ease-mode-leave:\s*cubic-bezier\(0\.4, 0, 0\.2, 1\)/,
-    'scatter must move promptly instead of saving most travel for its last frames')
+  assert.match(css, /--ease-mode-leave:\s*cubic-bezier\(0\.4, 0, 0\.7, 0\.2\)/,
+    'scatter keeps the accepted inverse departure curve')
   // The parent-chrome opacity fade is DELETED (strips deal with their panes now).
   assert.doesNotMatch(css, /\.shell--builder-exiting \.workspace__chrome \{[\s\S]*?opacity: 0/)
   // Reduced motion drops any beat.
@@ -1018,9 +1018,9 @@ test('N1: dead exit-presentation plumbing is removed', () => {
   assert.match(css, /--ease-mode-chrome: cubic-bezier/)
   assert.match(css, /--ease-mode-promote: cubic-bezier/)
   assert.match(css, /shell-mode-chrome-out 90ms var\(--ease-mode-chrome\)/)
-  assert.match(css, /shell-mode-chrome-in 70ms var\(--ease-mode-chrome\)[\s\S]*?calc\(var\(--mode-total, 220ms\) - 70ms\) both/)
+  assert.match(css, /shell-mode-chrome-in 70ms var\(--ease-mode-chrome\)[\s\S]*?calc\(var\(--mode-total, 210ms\) - 70ms\) both/)
   assert.match(css, /shell-mode-strip-clear 100ms var\(--ease-mode-chrome\)/)
-  assert.match(css, /shell-mode-promote\s*\n?\s*var\(--mode-duration\)\s*\n?\s*var\(--ease-mode-promote\)\s*\n?\s*var\(--mode-delay, 0ms\)/)
+  assert.match(css, /shell-mode-promote\s*\n?\s*var\(--mode-duration\)\s*\n?\s*var\(--ease-mode-promote\)/)
   // The unused excludeChatId param is gone; the helper is now the New Chat request
   // (round 4 item 3 — the old freshest-chat write is fully retired).
   assert.doesNotMatch(shell, /excludeChatId/)

--- a/frontend/src/components/Shell/__tests__/workspaceView.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceView.test.js
@@ -508,8 +508,7 @@ test('deriveExitPlan: PROMOTE when the target is a visible pane active key (INV 
   assert.equal(plan.underlayKey, null, 'physical continuity — no world reveal')
   const promote = plan.participants.find(p => p.motion === 'promote')
   assert.equal(promote.key, 'app:42')
-  assert.equal(promote.delayMs, MODE_MOTION.sharedLagMs,
-    'siblings open a seam before the shared surface expands')
+  assert.equal(promote.delayMs, 0, 'the assembled world moves as one beat')
   assert.ok(plan.completionNames.includes('shell-mode-promote'))
   // The FLIP grows the promote pane's content rect to the full destination.
   assert.equal(promote.flip.sx > 1, true, 'a half-width pane scales up to full width')
@@ -564,8 +563,8 @@ test('deriveExitPlan: siblings deal out together in one short beat', () => {
   const delays = plan.participants.map(p => p.delayMs).sort((a, b) => a - b)
   assert.deepEqual(delays, [0, 0])
   assert.equal(MODE_MOTION.staggerMs, undefined)
-  assert.ok(plan.participants.every(p => p.durationMs === MODE_MOTION.itemMs))
-  assert.equal(plan.totalMs, MODE_MOTION.itemMs)
+  assert.ok(plan.participants.every(p => p.durationMs === MODE_MOTION.exitItemMs))
+  assert.equal(plan.totalMs, MODE_MOTION.exitItemMs)
 })
 
 test('deriveExitPlan: a world reveal has no delayed destination phase', () => {
@@ -573,7 +572,7 @@ test('deriveExitPlan: a world reveal has no delayed destination phase', () => {
   const plan = deriveExitPlan({ workspace: ws, projection: project(ws), contentRect: CONTENT })
   assert.deepEqual(plan.completionNames, ['shell-mode-deal-out'])
   assert.equal('destinationMotion' in plan, false)
-  assert.equal(plan.totalMs, MODE_MOTION.itemMs)
+  assert.equal(plan.totalMs, MODE_MOTION.exitItemMs)
 })
 
 test('deriveExitPlan: a promote keeps its seamless continuity', () => {
@@ -600,7 +599,7 @@ test('deriveExitPlan: four panes cost the same 180ms beat as one pane', () => {
   ws = { ...ws, singleScreen: { kind: 'chat', id: 'ghost' } } // tree-absent → world reveal
   const plan = deriveExitPlan({ workspace: ws, projection: proj, contentRect: CONTENT })
   assert.ok(plan.participants.every(p => p.motion === 'deal-out'), 'all four deal out')
-  assert.equal(plan.totalMs, MODE_MOTION.itemMs)
+  assert.equal(plan.totalMs, MODE_MOTION.exitItemMs)
   assert.equal(plan.totalMs, 180)
 })
 
@@ -614,9 +613,9 @@ test('four-pane assemble/scatter preserves all four outer-edge vectors', () => {
   ws = { ...ws, singleScreen: { kind: 'chat', id: 'ghost' } }
   const projection = project(ws)
 
-  for (const plan of [
-    deriveExitPlan({ workspace: ws, projection, contentRect: CONTENT }),
-    deriveEnterPlan({ workspace: ws, projection, contentRect: CONTENT }),
+  for (const [plan, duration] of [
+    [deriveExitPlan({ workspace: ws, projection, contentRect: CONTENT }), MODE_MOTION.exitItemMs],
+    [deriveEnterPlan({ workspace: ws, projection, contentRect: CONTENT }), MODE_MOTION.enterItemMs],
   ]) {
     const offsets = new Map(plan.participants.map(p => [p.key, p.offset]))
     assert.ok(offsets.get('chat:1').x < 0 && offsets.get('chat:1').y < 0, 'top-left owns top+left')
@@ -625,14 +624,15 @@ test('four-pane assemble/scatter preserves all four outer-edge vectors', () => {
     assert.ok(offsets.get('chat:4').x > 0 && offsets.get('chat:4').y > 0, 'bottom-right owns bottom+right')
     assert.ok(plan.participants.every(p => p.delayMs === 0),
       'world-reveal edge panes move together; no pane-count stagger')
-    assert.equal(plan.totalMs, MODE_MOTION.itemMs)
+    assert.equal(plan.totalMs, duration)
   }
 })
 
 test('N1: MODE_MOTION drops the unused chromeMs constant', () => {
   assert.equal(MODE_MOTION.chromeMs, undefined)
   // The live timings the plan builders use are still present.
-  assert.equal(typeof MODE_MOTION.itemMs, 'number')
+  assert.equal(typeof MODE_MOTION.promoteMs, 'number')
+  assert.equal(typeof MODE_MOTION.exitItemMs, 'number')
 })
 
 // ── M4: the single-leaf promote FLIP must not overshoot ───────────────────────
@@ -733,24 +733,22 @@ test('deriveEnterPlan: the shared surface settles while siblings assemble from t
   const twoPlan = deriveEnterPlan({ workspace: two, projection: project(two), contentRect: CONTENT })
   assert.deepEqual(twoPlan.completionNames, ['shell-mode-settle', 'shell-mode-deal-in'])
   assert.equal(twoPlan.participants.length, 2)
-  assert.ok(twoPlan.participants.every(p => p.durationMs === MODE_MOTION.itemMs))
+  assert.ok(twoPlan.participants.every(p => p.durationMs === MODE_MOTION.enterItemMs))
   const settle = twoPlan.participants.find(p => p.motion === 'settle')
   const gather = twoPlan.participants.find(p => p.motion === 'deal-in')
   assert.equal(settle.key, 'app:42')
   assert.ok(settle.flip.sx > 1, 'the right pane starts at the single-world size')
   assert.equal(gather.key, 'chat:5')
   assert.ok(gather.offset.x < 0, 'the left pane assembles from the left edge')
-  // This is one bounded handoff, not a pane-count stagger: the shared surface
-  // settles first, then every sibling starts together after the same short gap.
-  assert.equal(settle.delayMs, 0)
-  assert.equal(gather.delayMs, MODE_MOTION.sharedLagMs)
-  assert.equal(twoPlan.totalMs, MODE_MOTION.itemMs + MODE_MOTION.sharedLagMs)
+  assert.ok(twoPlan.participants.every(p => p.delayMs === 0),
+    'the shared surface and siblings assemble together')
+  assert.equal(twoPlan.totalMs, MODE_MOTION.enterItemMs)
   const one = paneModel.seedFromFlatTabs([makeTab('app', '42')])
   const onePlan = deriveEnterPlan({ workspace: one, projection: project(one), contentRect: CONTENT })
   assert.equal(onePlan.participants.length, 1)
   assert.equal(onePlan.participants[0].motion, 'settle')
-  assert.equal(onePlan.participants[0].durationMs, MODE_MOTION.itemMs)
-  assert.equal(onePlan.totalMs, MODE_MOTION.itemMs)
+  assert.equal(onePlan.participants[0].durationMs, MODE_MOTION.enterSingleMs)
+  assert.equal(onePlan.totalMs, MODE_MOTION.enterSingleMs)
 })
 
 test('focused-pane mode keeps its original edge and its in-pane strip geometry', () => {
@@ -765,7 +763,7 @@ test('focused-pane mode keeps its original edge and its in-pane strip geometry',
   assert.ok(promote)
   assert.equal(promote.flip.y, -paneModel.STRIP_H)
   assert.ok(promote.flip.sy > 1)
-  assert.equal(promote.delayMs, 0, 'no sibling is painted, so no handoff gap is needed')
+  assert.equal(promote.delayMs, 0)
 
   // When Standard targets the left chat instead, the focused right pane scatters
   // right. Its full-size painted rect must clear the viewport completely; it must

--- a/frontend/src/components/Shell/workspace.css
+++ b/frontend/src/components/Shell/workspace.css
@@ -14,18 +14,15 @@
    workspaceView.js (MODE_MOTION / deriveExit·EnterPlan); Shell writes each
    participant's duration/delay and projection-derived transform variables inline. */
 .shell {
-  /* Quart-out keeps long edge travel visible across the beat instead of spending
-     ~80% of the distance in its first 50ms. The exit curve starts immediately and
-     distributes the inverse scatter through the whole shorter departure. */
-  --ease-mode-arrive: cubic-bezier(0.25, 1, 0.5, 1);
-  --ease-mode-leave: cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-mode-arrive: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-mode-leave: cubic-bezier(0.4, 0, 0.7, 0.2);
   /* Chrome (dividers + strips) leads the panes with a faster, front-loaded curve so
      structure simplifies first (exit) / resolves after the focused card (entry). */
   --ease-mode-chrome: cubic-bezier(0.2, 0.8, 0.2, 1);
   /* The promote FLIP reads with more MASS than the light deal-out cards: a slower
      middle and a clean, non-overshooting landing, so a half-pane grows to full-bleed
      without racing ahead of its still-opaque siblings. */
-  --ease-mode-promote: cubic-bezier(0.25, 1, 0.5, 1);
+  --ease-mode-promote: cubic-bezier(0.2, 0.82, 0.2, 1);
 }
 
 /* A content wrapper (app iframe or PaneChatView) that is the active tab of a
@@ -78,7 +75,6 @@
     shell-mode-promote
     var(--mode-duration)
     var(--ease-mode-promote)
-    var(--mode-delay, 0ms)
     both;
 }
 
@@ -187,7 +183,7 @@
 .shell--builder-entering .workspace__divider {
   animation:
     shell-mode-chrome-in 70ms var(--ease-mode-chrome)
-    calc(var(--mode-total, 220ms) - 70ms) both;
+    calc(var(--mode-total, 210ms) - 70ms) both;
 }
 @keyframes shell-mode-chrome-out { from { opacity: 1; } to { opacity: 0; } }
 @keyframes shell-mode-chrome-in { from { opacity: 0; } to { opacity: 1; } }

--- a/frontend/src/components/Shell/workspaceView.js
+++ b/frontend/src/components/Shell/workspaceView.js
@@ -59,14 +59,13 @@ export function projectFocusedPane(baseProjection, workspace, paneId, contentRec
 // Timing (ms). Constants live here, NOT in the machine, so the reconcile clock
 // (INV 14) and the missing-target fallback (INV 13) reason about the plan's own
 // totalMs rather than a fixed per-phase maximum. Mode changes are intentionally one
-// short beat using only compositor transforms + opacity. Edge panes share one
-// duration; the only offset is the fixed shared-surface handoff below, independent
-// of pane count (never a growing stagger or second destination phase).
+// short beat: every pane moves together, using only compositor transforms + opacity.
+// There is no per-pane stagger or second destination phase to make the owner wait.
 export const MODE_MOTION = Object.freeze({
-  itemMs: 180,
-  // Let departing panes clear a small gap before the shared surface expands;
-  // reverse that order on entry. This is still one compositor-only beat.
-  sharedLagMs: 40,
+  enterItemMs: 210,
+  enterSingleMs: 180,
+  exitItemMs: 180,
+  promoteMs: 210,
   logoReleaseMs: 90,
 })
 
@@ -279,10 +278,8 @@ export function deriveExitPlan(input) {
       key: promoteLeaf.activeKey,
       paneId: promoteLeaf.paneId,
       motion: 'promote',
-      // Open a visible seam before the shared surface grows beneath a sibling.
-      // With no sibling there is nothing to separate, so keep the direct beat.
-      delayMs: siblings.length ? MODE_MOTION.sharedLagMs : 0,
-      durationMs: MODE_MOTION.itemMs,
+      delayMs: 0,
+      durationMs: MODE_MOTION.promoteMs,
       flip: flipTo(fromRect, dest),
     })
     completionNames.add(PROMOTE_NAME)
@@ -290,7 +287,7 @@ export function deriveExitPlan(input) {
     siblings.forEach((l) => {
       participants.push({
         key: l.activeKey, paneId: l.paneId, motion: 'deal-out',
-        delayMs: 0, durationMs: MODE_MOTION.itemMs,
+        delayMs: 0, durationMs: MODE_MOTION.exitItemMs,
         offset: edgeOffset(l.rect, contentRect, l.motionRect),
       })
     })
@@ -309,7 +306,7 @@ export function deriveExitPlan(input) {
     ordered.forEach((l) => {
       participants.push({
         key: l.activeKey, paneId: l.paneId, motion: 'deal-out',
-        delayMs: 0, durationMs: MODE_MOTION.itemMs,
+        delayMs: 0, durationMs: MODE_MOTION.exitItemMs,
         offset: edgeOffset(l.rect, contentRect, l.motionRect),
       })
     })
@@ -342,7 +339,8 @@ export function deriveEnterPlan(input) {
   if (leaves.length === 0) return null
   const { target, immersiveInstant } = classifyExitDestination(input)
   if (immersiveInstant) return null
-  const duration = MODE_MOTION.itemMs
+  const single = leaves.length === 1
+  const duration = single ? MODE_MOTION.enterSingleMs : MODE_MOTION.enterItemMs
   const destinationRect = { x: 0, y: 0, w: contentRect.w, h: contentRect.h }
   const settleLeaf = target ? leaves.find(l => l.activeKey === target) : null
   const participants = []
@@ -368,9 +366,7 @@ export function deriveEnterPlan(input) {
     if (l === settleLeaf) continue
     participants.push({
       key: l.activeKey, paneId: l.paneId, motion: 'deal-in',
-      // Reverse the exit order: settle the shared live surface first, then let
-      // siblings arrive. A world reveal has no shared surface and no delay.
-      delayMs: settleLeaf ? MODE_MOTION.sharedLagMs : 0,
+      delayMs: 0,
       durationMs: duration,
       offset: edgeOffset(l.rect, contentRect, l.motionRect),
     })

--- a/tests/mode-transition.spec.mjs
+++ b/tests/mode-transition.spec.mjs
@@ -129,41 +129,6 @@ async function sampleExitBeat(page) {
   })
 }
 
-// A shared left surface used to expand under its right sibling immediately. Their
-// boundary overlapped for most of the beat, so the departing pane looked glued to
-// the survivor instead of scattering independently. Sample the painted boxes, not
-// just animation metadata, to lock the visible seam open.
-async function sampleSharedExitSeam(page) {
-  return page.evaluate(async () => {
-    const root = document.querySelector('.shell')
-    let started = false
-    let samples = 0
-    let minGap = Infinity
-    await new Promise((resolve) => {
-      let frames = 0
-      const tick = () => {
-        const exiting = root.classList.contains('shell--builder-exiting')
-        if (exiting) {
-          started = true
-          const shared = document.querySelector('.shell__view[data-mode-motion="promote"]')
-          const departing = document.querySelector('.shell__view[data-mode-motion="deal-out"]')
-          if (shared && departing) {
-            const sharedBox = shared.getBoundingClientRect()
-            const departingBox = departing.getBoundingClientRect()
-            minGap = Math.min(minGap, departingBox.left - sharedBox.right)
-            samples += 1
-          }
-        }
-        frames += 1
-        if ((started && !exiting) || frames > 90) { resolve(); return }
-        requestAnimationFrame(tick)
-      }
-      requestAnimationFrame(tick)
-    })
-    return { started, samples, minGap: Number.isFinite(minGap) ? minGap : null }
-  })
-}
-
 // Capture the latched inline geometry on the first frame of either directional
 // beat. These are the pure projection outputs that tell each pane which edge owns it.
 async function captureBeatPlan(page, rootClass) {
@@ -399,10 +364,9 @@ test('v3 scatter is compositor-only: layout boxes constant while transforms anim
   await expect.poll(() => builderActive(page)).toBe(true)
   await expect(page.locator('.workspace__strip')).toHaveCount(2)
   const sampler = sampleExitBeat(page)
-  const seamSampler = sampleSharedExitSeam(page)
   await page.waitForTimeout(30) // let the rAF sampler install before the toggle
   await toggleMode(page)
-  const [r, seam] = await Promise.all([sampler, seamSampler])
+  const r = await sampler
   expect(r.started, 'an exit beat ran').toBe(true)
   expect(r.dualClass, 'INV 1: never both beat classes at once').toBe(false)
   expect(r.wrappers.length, 'the participant wrappers were sampled').toBeGreaterThanOrEqual(2)
@@ -416,10 +380,6 @@ test('v3 scatter is compositor-only: layout boxes constant while transforms anim
   const departing = r.wrappers.find(w => w.motion === 'deal-out')
   expect(departing.offsetX, 'the right sibling scatters toward the right edge').toBeGreaterThan(0)
   expect(departing.offsetY).toBe(0)
-  expect(seam.started).toBe(true)
-  expect(seam.samples).toBeGreaterThan(2)
-  expect(seam.minGap, 'the right pane separates instead of overlapping the shared left pane')
-    .toBeGreaterThanOrEqual(-1)
   // INV 4 (stable identity): the same DOM nodes survived completion.
   for (const w of r.wrappers) expect(w.survived, 'same node survives completion').toBe(true)
   // The beat settled clean.


### PR DESCRIPTION
## What changed
- restore the last accepted all-sides pane choreography from 41a3809b4
- remove the later 40ms shared-surface stagger that split the transition into two visible phases
- restore the accepted entry/exit/promote timing and easing curves
- retain focused-pane durable edge geometry and all later non-motion behavior
- remove the browser assertion that encoded the regressed stagger

## Verification
- frontend unit tests: 1804 passed
- frontend hook tests: 47 passed
- production frontend build: passed
- focused mode/state tests: 158 passed

Local Docker Playwright was not bypassed: the runner correctly refused at 17 GiB free (20 GiB required). Hosted E2E should validate this exact committed revision.