### PR TITLE
Unify automatic continuation under one chat setting

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -687,28 +687,28 @@ pins. Reservation lifetime and pin decisions are independent.
 
 ### Automatic continuation after limits and planned restarts
 
-Automatic continuation reuses one durable run transition but has two separate
-consent and cause boundaries. Provider-limit exits mark their exact `ChatRun` as
-`parked` until the parsed reset time. A planned restart creates a fresh nonce,
-stops and finalizes each exact live run, and parks it due-now with that nonce.
-The platform process then publishes an intent and restart request; it does not
-terminate itself on the normal path.
+Automatic continuation reuses one durable run transition and one chat-local
+policy while keeping distinct cause validation. Provider-limit exits mark their
+exact `ChatRun` as `parked` until the parsed reset time. A planned restart
+creates a fresh nonce, stops and finalizes each exact live run, and parks it
+due-now with that nonce. The platform process then publishes an intent and
+restart request; it does not terminate itself on the normal path.
 
 The frozen root-owned entrypoint poller validates and consumes the request,
 records its one-shot nonce in `/data/.restart-ledger`, and only then terminates
 pid 1. At the very start of the next entrypoint invocation, the ledger binds
 that accepted nonce to the new `MOBIUS_BOOT_ID`. The app only continues a
 restart park when the root-owned boot acknowledgement matches the nonce on the
-latest exact DB run and the separately stored restart policy is on. The
-supervisor attests the boot transition; the database owns run identity. An
-intent merely written before a crash/OOM, an acknowledgement skipped by a
-failed handshake, or an acknowledgement left across another boot authorizes
-nothing. Transcript text is presentation, never restart-cause evidence.
+latest exact DB run and the chat's continuation policy is on. The supervisor
+attests the boot transition; the database owns run identity. An intent merely
+written before a crash/OOM, an acknowledgement skipped by a failed handshake,
+or an acknowledgement left across another boot authorizes nothing. Transcript
+text is presentation, never restart-cause evidence.
 
 | Event | Durable result | Boot/sweep result |
 |-------|----------------|-------------------|
 | Provider usage/rate limit | exact run `parked` until reset | notify; continue if the chat policy is on |
-| Accepted planned restart, exact park + boot nonce match | exact run `parked`, reason `restart`, nonce, due now | continue immediately if separate restart consent is on |
+| Accepted planned restart, exact park + boot nonce match | exact run `parked`, reason `restart`, nonce, due now | continue immediately if the chat policy is on |
 | Crash/OOM before supervisor acknowledgement | unacknowledged park or generic `running` evidence | resolve/reconcile to manual resumable interruption |
 | Repeated/unrelated boot before claim | acknowledgement is retired by boot-id mismatch | manual resumable interruption |
 | Policy off, unanswered question, app-owned run, or app-queued work | due park resolves without an automatic send | notify/manual owner action |
@@ -727,9 +727,9 @@ The sweep is cheap: one indexed due-row query immediately at boot, on
 `chat_run_finished`, and on a 60-second fallback, plus one bounded local ledger
 read when due rows exist. It does not create per-chat workers or poll at a short
 interval. `auto_resume_on_limit` keeps its legacy initial default of on.
-`auto_resume_on_restart` is a separate chat-local preference and migrates
-existing chats and owners to off; enabling it is explicit consent and only
-seeds future chats without rewriting existing conversations.
+Despite its historical storage name, it is the single chat-local policy for
+both provider-limit and planned-restart continuation. Changing it also seeds
+future chats without rewriting existing conversations.
 
 ### Tool output rendering
 

--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -1747,9 +1747,9 @@ async def sweep_idle_pending_chats(db: Session) -> list[str]:
     # A limit-parked queue is NOT abandoned work: LIMIT_PARKED preserves
     # pending precisely so it is not fired back into the exhausted limit
     # (chat_queue.TerminalDisposition), and resuming it belongs to
-    # sweep_reset_parks (owner opt-in) or the user's own next send. The
-    # park row outlives run_status, so run_status IS NULL alone cannot
-    # distinguish "crashed drain" from "parked on purpose".
+    # sweep_reset_parks (when the chat policy is enabled) or the user's own
+    # next send. The park row outlives run_status, so run_status IS NULL alone
+    # cannot distinguish "crashed drain" from "parked on purpose".
     if _parked_until_for_chat(db, chat.id) is not None:
       continue
     if _restart_manual_hold_for_chat(db, chat.id):
@@ -2164,11 +2164,11 @@ def _has_unanswered_question(chat: models.Chat | None) -> bool:
 
 
 async def _auto_resume_chat(
-  chat_id: str, provider_id: str | None, park_token: str | None = None,
+  chat_id: str, park_token: str | None = None,
 ) -> bool:
   """Start one continuation for an eligible due park.
 
-  The opt-in half of design §2.4 — mirrors the stale-pending drain in
+  The policy-enabled half of design §2.4 — mirrors the stale-pending drain in
   chats_stream.send_message (the same claim → append → promote → schedule
   sequence), minus the HTTP request:
 
@@ -2200,12 +2200,9 @@ async def _auto_resume_chat(
   """
   from app.database import SessionLocal
 
-  # ``provider_id`` is retained in the private signature for compatibility
-  # with tests/extensions from the first auto-resume release.  Never trust
-  # that sweep-time snapshot: a provider handoff may have committed while the
-  # sweep was preparing this retry, so the authoritative provider is re-read
-  # under the same transition gate used by sends and provider switches.
-  del provider_id
+  # A provider handoff may have committed while the sweep was preparing this
+  # retry, so the authoritative provider is re-read under the same transition
+  # gate used by sends and provider switches.
   claimed = False
   try:
     # Lock order matches owner sends: provider transition, then queue.  The
@@ -2249,12 +2246,7 @@ async def _auto_resume_chat(
                 and accepted_nonce == park.restart_nonce
               )
             policy_enabled = bool(
-              chat is not None
-              and (
-                chat.auto_resume_on_restart
-                if park is not None and park.park_reason == "restart"
-                else chat.auto_resume_on_limit
-              )
+              chat is not None and chat.auto_resume_on_limit
             )
             if (
               chat is None
@@ -2371,9 +2363,9 @@ async def sweep_reset_parks(db: Session) -> list[str]:
       failure cannot silently consume the promised continuation. The narrow
       post-promote SIGKILL boundary is documented on `_auto_resume_chat`.
     - A park whose chat was deleted resolves silently.
-    - Auto-resume is a per-chat opt-in and STRICTLY SERIAL: at most one
-      opted-in park starts per tick, and none while any turn is live anywhere.
-      A blocked opted-in chat stays pending for a later tick, while notify-only
+    - Auto-resume is controlled per chat and STRICTLY SERIAL: at most one
+      enabled park starts per tick, and none while any turn is live anywhere.
+      A blocked enabled chat stays pending for a later tick, while notify-only
       chats in the same due batch still resolve normally. App-attributed runs
       and queues never auto-resume.
 
@@ -2462,13 +2454,7 @@ async def sweep_reset_parks(db: Session) -> list[str]:
       for msg in pending
     )
     restart_park = run.park_reason == "restart"
-    policy_enabled = bool(
-      chat is not None
-      and (
-        chat.auto_resume_on_restart
-        if restart_park else chat.auto_resume_on_limit
-      )
-    )
+    policy_enabled = bool(chat is not None and chat.auto_resume_on_limit)
     restart_authorized = (
       not restart_park
       or (
@@ -2497,7 +2483,7 @@ async def sweep_reset_parks(db: Session) -> list[str]:
       auto_resume_started or _any_chat_turn_active()
     ):
       # Strictly-serial gate: a live turn (an earlier auto-resume, or the
-      # owner's own send) must settle before this opted-in park is processed.
+      # owner's own send) must settle before this enabled park is processed.
       # Leave this park untouched, but keep walking so a later notify-only
       # chat is not held hostage by another chat's auto-resume preference.
       continue
@@ -2558,7 +2544,7 @@ async def sweep_reset_parks(db: Session) -> list[str]:
         # dropping the promised continuation.
         continue
       auto_resume_started = await _auto_resume_chat(
-        chat_id, chat.provider, park_token=run.id,
+        chat_id, park_token=run.id,
       )
       if auto_resume_started:
         resolved.append(chat_id)

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -583,18 +583,11 @@ def run_migrations(eng) -> None:
         "ALTER TABLE chats ADD COLUMN system_prompt_snapshot_id VARCHAR(64) NULL"
       )
     if "auto_resume_on_limit" not in chats_cols:
-      # Chat-local provider-limit recovery policy. Automatic continuation is
-      # the initial default; any later owner selection remains stored per chat.
+      # Chat-local automatic continuation policy for provider limits and
+      # planned restarts. Any later owner selection remains stored per chat.
       _add.append(
         "ALTER TABLE chats ADD COLUMN auto_resume_on_limit BOOLEAN "
         "NOT NULL DEFAULT TRUE"
-      )
-    if "auto_resume_on_restart" not in chats_cols:
-      # Separate consent boundary. Every existing chat is explicitly off even
-      # when its legacy provider-limit preference is on.
-      _add.append(
-        "ALTER TABLE chats ADD COLUMN auto_resume_on_restart BOOLEAN "
-        "NOT NULL DEFAULT FALSE"
       )
     if "pinned_at" not in chats_cols:
       # NOT NULL = pinned. Drawer sort key (see routes/chats.py).
@@ -650,11 +643,6 @@ def run_migrations(eng) -> None:
       _add_owner.append(
         "ALTER TABLE owner ADD COLUMN auto_resume_on_limit_default BOOLEAN "
         "NOT NULL DEFAULT TRUE"
-      )
-    if "auto_resume_on_restart_default" not in owner_cols:
-      _add_owner.append(
-        "ALTER TABLE owner ADD COLUMN auto_resume_on_restart_default BOOLEAN "
-        "NOT NULL DEFAULT FALSE"
       )
     if "model_prefs_json" not in owner_cols:
       # Nullable JSON blob holding the owner's model-picker

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -39,17 +39,12 @@ class Owner(Base):
   hashed_password = Column(String(255), nullable=False)
   # Must stay in sync with providers.PROVIDER_NAMES.
   provider = Column(String(32), nullable=False, default="claude")
-  # Default provider-limit recovery policy for newly-created chats. Each chat
+  # Default automatic-continuation policy for newly-created chats. Each chat
   # stores its own copy; changing a chat's switch updates this seed for the
-  # next chat without rewriting any existing conversation.
+  # next chat without rewriting any existing conversation. The historical
+  # column name is retained to avoid rewriting every local SQLite database.
   auto_resume_on_limit_default = Column(
     Boolean, nullable=False, default=True, server_default=true()
-  )
-  # Separately consented planned-restart policy for newly created chats.
-  # Existing owners migrate to false: consenting to provider-limit recovery
-  # never silently opts them into replay after a process restart.
-  auto_resume_on_restart_default = Column(
-    Boolean, nullable=False, default=False, server_default=false()
   )
   # Per-owner model-picker preferences. Shape:
   #   {"hidden_ids": ["claude-haiku-4-5-20251001", ...]}
@@ -134,15 +129,11 @@ class Chat(Base):
   # start afterwards. Nullable is the migration/empty-chat state: the first
   # turn snapshots it atomically before invoking a provider.
   system_prompt_snapshot_id = Column(String(64), nullable=True, default=None)
-  # Per-chat policy for automatic recovery after provider limits.
+  # Per-chat policy for automatic continuation after provider limits and
+  # supervisor-authenticated planned restarts. The historical column name is
+  # retained to avoid rewriting every local SQLite database.
   auto_resume_on_limit = Column(
     Boolean, nullable=False, default=True, server_default=true()
-  )
-  # Planned restart continuation is materially broader than provider-limit
-  # recovery and therefore has separate, explicit consent. Existing and fresh
-  # chats start off until the owner enables it in that chat.
-  auto_resume_on_restart = Column(
-    Boolean, nullable=False, default=False, server_default=false()
   )
   # Vestigial: the named-agent feature was removed; column retained
   # nullable to avoid a prod migration. Nothing reads or writes it.

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -324,7 +324,6 @@ def _chat_detail_response(
     "provider": provider,
     "created_by_app_id": chat.created_by_app_id,
     "auto_resume_on_limit": bool(chat.auto_resume_on_limit),
-    "auto_resume_on_restart": bool(chat.auto_resume_on_restart),
     "agent_settings_json": settings_obj,
     "effective_agent_settings": effective_agent_settings(
       get_settings().data_dir,
@@ -677,9 +676,6 @@ def create_chat(
     auto_resume_on_limit=(
       bool(owner.auto_resume_on_limit_default) if owner else True
     ),
-    auto_resume_on_restart=(
-      bool(owner.auto_resume_on_restart_default) if owner else False
-    ),
   )
   db.add(chat)
   db.commit()
@@ -798,7 +794,6 @@ async def patch_chat(
     body.title is not None
     or body.pinned is not None
     or body.auto_resume_on_limit is not None
-    or body.auto_resume_on_restart is not None
     or body.by_agent
     or body.clear_title
   ):
@@ -859,12 +854,6 @@ async def patch_chat(
       # chat, matching other "last picked" defaults without making the setting
       # global at runtime.
       principal.owner.auto_resume_on_limit_default = body.auto_resume_on_limit
-
-    if body.auto_resume_on_restart is not None:
-      chat.auto_resume_on_restart = body.auto_resume_on_restart
-      principal.owner.auto_resume_on_restart_default = (
-        body.auto_resume_on_restart
-      )
 
     # Determine the effective target provider. The body may set it
     # explicitly, OR it may be implied by a model-only PATCH whose
@@ -1023,7 +1012,6 @@ async def patch_chat(
       "agent_settings_json": _coerce_agent_settings(chat.agent_settings_json) or None,
       "provider": chat.provider or "claude",
       "auto_resume_on_limit": bool(chat.auto_resume_on_limit),
-      "auto_resume_on_restart": bool(chat.auto_resume_on_restart),
       "effective": effective_agent_settings(
         data_dir,
         _coerce_agent_settings(chat.agent_settings_json) or None,

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -405,11 +405,8 @@ class ChatPatch(BaseModel):
   title: str | None = Field(default=None, max_length=500)
   # Drawer pin toggle. True sets pinned_at = now, False clears it.
   pinned: bool | None = None
-  # Per-chat opt-in to continuing after a provider-limit reset.
+  # Per-chat automatic continuation after provider limits and planned restarts.
   auto_resume_on_limit: bool | None = None
-  # Separate explicit consent for a supervisor-authenticated planned restart.
-  # Existing chats migrate off; provider-limit consent never broadens into it.
-  auto_resume_on_restart: bool | None = None
   # Naming precedence. by_agent marks an AGENT title-sync — it fills the name
   # only when the owner hasn't locked it via a manual rename. clear_title resets
   # the name (unlock + drop to the first-message default; re-derived next turn).

--- a/backend/tests/test_chat_agent_settings.py
+++ b/backend/tests/test_chat_agent_settings.py
@@ -153,7 +153,7 @@ def test_patch_chat_clear_reverts_to_default(client, auth, chat):
 def test_auto_resume_is_per_chat_and_survives_runtime_clear(
   client, auth, chat, db,
 ):
-  """The limit preference is chat-local and independent of model settings."""
+  """The continuation preference is chat-local and independent of models."""
   from app import models
 
   chat.agent_settings_json = {"model": "historical-model", "effort": "high"}
@@ -174,6 +174,7 @@ def test_auto_resume_is_per_chat_and_survives_runtime_clear(
   )
   assert enabled.status_code == 200
   assert enabled.json()["auto_resume_on_limit"] is True
+  assert "auto_resume_on_restart" not in enabled.json()
   assert enabled.json()["agent_settings_json"] == {
     "model": "historical-model", "effort": "high",
   }
@@ -244,42 +245,6 @@ def test_new_chat_inherits_last_auto_resume_selection(client, auth, chat):
   assert client.get(
     f"/api/chats/{inherited_on['id']}", headers=auth,
   ).json()["auto_resume_on_limit"] is True
-
-
-def test_restart_resume_requires_separate_explicit_consent(
-  client, auth, chat,
-):
-  """Legacy limit consent stays on while every existing restart policy is off."""
-  initial = client.get(f"/api/chats/{chat.id}", headers=auth).json()
-  assert initial["auto_resume_on_limit"] is True
-  assert initial["auto_resume_on_restart"] is False
-
-  existing = client.post(
-    "/api/chats", headers=auth, json={"title": "existing off"},
-  ).json()
-  assert client.get(
-    f"/api/chats/{existing['id']}", headers=auth,
-  ).json()["auto_resume_on_restart"] is False
-
-  enabled = client.patch(
-    f"/api/chats/{chat.id}",
-    headers=auth,
-    json={"auto_resume_on_restart": True},
-  )
-  assert enabled.status_code == 200
-  assert enabled.json()["auto_resume_on_restart"] is True
-  assert enabled.json()["auto_resume_on_limit"] is True
-
-  inherited = client.post(
-    "/api/chats", headers=auth, json={"title": "explicitly inherited on"},
-  ).json()
-  assert client.get(
-    f"/api/chats/{inherited['id']}", headers=auth,
-  ).json()["auto_resume_on_restart"] is True
-  # Explicit consent seeds future chats only; it never rewrites older rows.
-  assert client.get(
-    f"/api/chats/{existing['id']}", headers=auth,
-  ).json()["auto_resume_on_restart"] is False
 
 
 def test_stale_global_auto_resume_setting_is_not_a_chat_default(

--- a/backend/tests/test_chat_compact.py
+++ b/backend/tests/test_chat_compact.py
@@ -189,7 +189,7 @@ def test_switch_atomically_supersedes_park_and_stale_auto_resume(
     chat_mod, "_schedule_continuation", lambda **kw: scheduled.append(kw),
   )
   resumed = asyncio.run(chat_mod._auto_resume_chat(
-    chat_id, "claude", park_token="park-before-switch",
+    chat_id, park_token="park-before-switch",
   ))
   assert resumed is False
   assert scheduled == []

--- a/backend/tests/test_db_migrations.py
+++ b/backend/tests/test_db_migrations.py
@@ -193,9 +193,7 @@ def test_run_migrations_adds_chat_auto_resume_policy(tmp_path):
   assert "auto_resume_on_limit" in cols
   assert cols["auto_resume_on_limit"]["nullable"] is False
   assert cols["auto_resume_on_limit"]["default"] is not None
-  assert "auto_resume_on_restart" in cols
-  assert cols["auto_resume_on_restart"]["nullable"] is False
-  assert cols["auto_resume_on_restart"]["default"] is not None
+  assert "auto_resume_on_restart" not in cols
   assert "system_prompt_snapshot_id" in cols
   with eng.connect() as conn:
     value = conn.execute(text(
@@ -208,12 +206,8 @@ def test_run_migrations_adds_chat_auto_resume_policy(tmp_path):
       "SELECT auto_resume_on_limit FROM chats "
       "WHERE id = 'new-after-upgrade'"
     )).scalar_one()
-    restart_values = conn.execute(text(
-      "SELECT id, auto_resume_on_restart FROM chats ORDER BY id"
-    )).all()
   assert value in (True, 1)
   assert future_value in (True, 1)
-  assert all(restart in (False, 0) for _, restart in restart_values)
 
 
 def test_run_migrations_adds_bounded_live_assistant_snapshot(tmp_path):
@@ -244,11 +238,6 @@ def test_fresh_chat_schema_has_database_auto_resume_default():
   assert column.default is not None
   assert column.server_default is not None
   assert str(column.server_default.arg).lower() == "true"
-  restart = models.Chat.__table__.c.auto_resume_on_restart
-  assert restart.nullable is False
-  assert restart.default is not None
-  assert restart.server_default is not None
-  assert str(restart.server_default.arg).lower() == "false"
 
 
 def test_run_migrations_adds_owner_auto_resume_default(tmp_path):
@@ -274,17 +263,11 @@ def test_run_migrations_adds_owner_auto_resume_default(tmp_path):
   cols = {c["name"]: c for c in inspect(eng).get_columns("owner")}
   assert "auto_resume_on_limit_default" in cols
   assert cols["auto_resume_on_limit_default"]["nullable"] is False
-  assert "auto_resume_on_restart_default" in cols
-  assert cols["auto_resume_on_restart_default"]["nullable"] is False
   with eng.connect() as conn:
     value = conn.execute(text(
       "SELECT auto_resume_on_limit_default FROM owner WHERE id = 1"
     )).scalar_one()
-    restart_value = conn.execute(text(
-      "SELECT auto_resume_on_restart_default FROM owner WHERE id = 1"
-    )).scalar_one()
   assert value in (True, 1)
-  assert restart_value in (False, 0)
 
 
 def test_fresh_owner_schema_has_auto_resume_default():
@@ -294,8 +277,3 @@ def test_fresh_owner_schema_has_auto_resume_default():
   assert column.default is not None
   assert column.server_default is not None
   assert str(column.server_default.arg).lower() == "true"
-  restart = models.Owner.__table__.c.auto_resume_on_restart_default
-  assert restart.nullable is False
-  assert restart.default is not None
-  assert restart.server_default is not None
-  assert str(restart.server_default.arg).lower() == "false"

--- a/backend/tests/test_limit_park.py
+++ b/backend/tests/test_limit_park.py
@@ -14,9 +14,9 @@ Locks in the six contracts of the limit-park feature:
       an opted park
       retryable until its continuation starts, skips future parks, stands down
       while draining, and resolves deleted chats silently.
-  (e) Auto-resume is opt-in (off = notify only) and strictly serial: one
-      park per tick, none while any turn is live; the resumed turn combines
-      the preserved queue + a "continue" into one continuation.
+  (e) Auto-resume is policy-controlled (off = notify only) and strictly
+      serial: one park per tick, none while any turn is live; the resumed turn
+      combines the preserved queue + a "continue" into one continuation.
   (f) The parks are observable: /api/debug/status lists parked runs.
   (g) A planned restart reuses the same exact-run state with a due-now time;
       crashes, unanswered questions, and app-owned work stay manual.
@@ -72,7 +72,7 @@ def _drain_writer():
 
 def _seed_chat(
   chat_id: str, *, pending=None, run_status=None, deleted=False,
-  auto_resume=False, auto_restart=False, messages=None,
+  auto_resume=False, messages=None,
 ):
   db = SessionLocal()
   try:
@@ -88,7 +88,6 @@ def _seed_chat(
       session_id="sess",
       provider="claude",
       auto_resume_on_limit=auto_resume,
-      auto_resume_on_restart=auto_restart,
       run_status=run_status,
       run_started_at=(
         datetime.now(UTC).replace(tzinfo=None) if run_status else None
@@ -560,11 +559,11 @@ def test_park_run_strict_tokenless_falls_back_to_marker_clear():
 
 def _due_park(
   cid: str, token: str, *, pending=None, deleted=False, auto_resume=False,
-  auto_restart=False, park_reason=None, messages=None, restart_nonce=None,
+  park_reason=None, messages=None, restart_nonce=None,
 ):
   _seed_chat(
     cid, pending=pending, deleted=deleted, auto_resume=auto_resume,
-    auto_restart=auto_restart, messages=messages,
+    messages=messages,
   )
   _seed_run(cid, token, status="parked",
             parked_until=datetime.now(UTC).replace(tzinfo=None)
@@ -761,7 +760,7 @@ def test_restart_park_auto_continues_with_product_marker(
     lambda: nonce,
   )
   _due_park(
-    cid, token, auto_resume=True, auto_restart=True,
+    cid, token, auto_resume=True,
     park_reason="restart", restart_nonce=nonce,
   )
 
@@ -807,7 +806,6 @@ def test_restart_park_waiting_on_question_stays_manual(
     cid,
     token,
     auto_resume=True,
-    auto_restart=True,
     park_reason="restart",
     restart_nonce=nonce,
     messages=[
@@ -852,10 +850,9 @@ def test_restart_park_policy_off_resolves_to_manual_interruption(
     "app.restart_ledger.authorized_restart_nonce",
     lambda: nonce,
   )
-  # Provider-limit policy is deliberately ON. Separate restart consent remains
-  # off, proving the legacy preference cannot broaden into restart replay.
+  # The one shared continuation policy is off, so restart recovery is manual.
   _due_park(
-    cid, token, auto_resume=True, auto_restart=False,
+    cid, token, auto_resume=False,
     park_reason="restart", restart_nonce=nonce,
   )
 
@@ -881,7 +878,7 @@ def test_restart_park_without_current_boot_ack_stays_manual(
   cid = "restart-no-ack"
   token = f"rt-{cid}"
   _due_park(
-    cid, token, auto_restart=True, park_reason="restart",
+    cid, token, auto_resume=True, park_reason="restart",
     restart_nonce="unaccepted-nonce-1234",
   )
 
@@ -904,7 +901,7 @@ def test_restart_park_with_no_nonce_never_matches_missing_ack(
   cid = "restart-no-nonce"
   token = f"rt-{cid}"
   _due_park(
-    cid, token, auto_restart=True, park_reason="restart",
+    cid, token, auto_resume=True, park_reason="restart",
     restart_nonce=None,
   )
 
@@ -928,7 +925,7 @@ def test_restart_park_rejects_ack_for_the_wrong_nonce(
   _due_park(
     cid,
     token,
-    auto_restart=True,
+    auto_resume=True,
     park_reason="restart",
     restart_nonce="db-nonce-12345678",
   )
@@ -953,7 +950,7 @@ def test_restart_spawn_failure_retires_one_shot_authorization(
     lambda: nonce,
   )
   _due_park(
-    cid, token, auto_restart=True, park_reason="restart",
+    cid, token, auto_resume=True, park_reason="restart",
     restart_nonce=nonce,
   )
   original_create_broadcast = chat_mod.create_broadcast
@@ -1117,10 +1114,10 @@ def test_sweep_auto_resume_defers_while_any_turn_is_live(
   assert _run_row("rt-sweep-serial")["status"] == "parked"
 
 
-def test_live_turn_defers_opted_chat_but_not_notify_only_chat(
+def test_live_turn_defers_enabled_chat_but_not_notify_only_chat(
   owner_token, monkeypatch,
 ):
-  """One chat's opt-in must not hold another chat's reset notice hostage."""
+  """One enabled chat must not hold another chat's reset notice hostage."""
   del owner_token
   calls = []
   monkeypatch.setattr(
@@ -1324,7 +1321,7 @@ def test_auto_resume_global_idle_check_is_repeated_at_locked_claim():
     lock = chat_mod.chat_queue.get_lock(cid)
     await lock.acquire()
     task = asyncio.create_task(
-      chat_mod._auto_resume_chat(cid, "claude", park_token="rt-race")
+      chat_mod._auto_resume_chat(cid, park_token="rt-race")
     )
     await asyncio.sleep(0)
     registry.register(blocker)
@@ -1348,7 +1345,7 @@ def test_auto_resume_locked_claim_rejects_superseded_park():
   _seed_run(cid, f"newer-{cid}", status="completed", started_offset=-10)
 
   assert asyncio.run(
-    chat_mod._auto_resume_chat(cid, "claude", park_token=park_token)
+    chat_mod._auto_resume_chat(cid, park_token=park_token)
   ) is False
   assert _chat_row(cid)["pending"] == []
   assert not chat_mod.is_chat_running(cid)
@@ -1366,7 +1363,7 @@ def test_auto_resume_global_gate_includes_running_terminal_broadcast():
   broadcast = create_broadcast(other)
   try:
     assert asyncio.run(
-      chat_mod._auto_resume_chat(cid, "claude", park_token=park_token)
+      chat_mod._auto_resume_chat(cid, park_token=park_token)
     ) is False
   finally:
     broadcast.mark_completed()
@@ -1441,7 +1438,7 @@ def test_auto_resume_rechecks_app_work_inside_queue_handoff():
   _seed_chat(cid, auto_resume=True, pending=[app_msg])
 
   assert asyncio.run(
-    chat_mod._auto_resume_chat(cid, "claude", park_token="rt-final-check")
+    chat_mod._auto_resume_chat(cid, park_token="rt-final-check")
   ) is False
   state = _chat_row(cid)
   assert state["pending"] == [app_msg]
@@ -1463,7 +1460,7 @@ def test_auto_resume_rechecks_app_run_at_locked_handoff():
   )
 
   assert asyncio.run(
-    chat_mod._auto_resume_chat(cid, "claude", park_token=park_token)
+    chat_mod._auto_resume_chat(cid, park_token=park_token)
   ) is False
   assert _chat_row(cid)["pending"] == []
   assert _run_row(park_token)["status"] == "resume_pending"

--- a/frontend/src/components/ChatView/ChatSettingsPanel.jsx
+++ b/frontend/src/components/ChatView/ChatSettingsPanel.jsx
@@ -245,10 +245,6 @@ export default function ChatSettingsPanel({
   autoResumeSaving = false,
   autoResumeError = '',
   onAutoResumeChange,
-  restartResumeEnabled = false,
-  restartResumeSaving = false,
-  restartResumeError = '',
-  onRestartResumeChange,
   onChange,
   // Stale-PATCH guard: parent passes a ref that survives panel
   // mount/unmount. See ComposerPopover for the rationale.
@@ -650,9 +646,6 @@ export default function ChatSettingsPanel({
   const autoResumeSwitchId = chatId
     ? `chat-settings-auto-resume-${chatId}`
     : undefined
-  const restartResumeSwitchId = chatId
-    ? `chat-settings-restart-resume-${chatId}`
-    : undefined
   const appProviderLocked = chat?.created_by_app_id != null
 
   // Build the per-provider displayed-models list once per render.
@@ -833,59 +826,30 @@ export default function ChatSettingsPanel({
           )
         })
       })}
-      {(onAutoResumeChange || onRestartResumeChange) && (
+      {onAutoResumeChange && (
         <div className="csp__automation">
           <div className="csp__label csp__label--automation">Automation</div>
-          {onAutoResumeChange && (
-            <>
-              <div
-                className="csp__automation-row"
-                onPointerDown={preserveFocusUnlessTouch}
-              >
-                <label className="csp__automation-copy" htmlFor={autoResumeSwitchId}>
-                  <span className="csp__automation-title">Continue after usage limits</span>
-                </label>
-                <Switch
-                  className="chat-policy-switch"
-                  id={autoResumeSwitchId}
-                  checked={!!autoResumeEnabled}
-                  onCheckedChange={onAutoResumeChange}
-                  disabled={!!autoResumeSaving}
-                />
-              </div>
-              {autoResumeError && (
-                <p className="csp__automation-error" role="alert">
-                  {autoResumeError}
-                </p>
-              )}
-            </>
-          )}
-          {onRestartResumeChange && (
-            <>
-              <div
-                className="csp__automation-row"
-                onPointerDown={preserveFocusUnlessTouch}
-              >
-                <label
-                  className="csp__automation-copy"
-                  htmlFor={restartResumeSwitchId}
-                >
-                  <span className="csp__automation-title">Continue after planned restarts</span>
-                </label>
-                <Switch
-                  className="chat-policy-switch"
-                  id={restartResumeSwitchId}
-                  checked={!!restartResumeEnabled}
-                  onCheckedChange={onRestartResumeChange}
-                  disabled={!!restartResumeSaving}
-                />
-              </div>
-              {restartResumeError && (
-                <p className="csp__automation-error" role="alert">
-                  {restartResumeError}
-                </p>
-              )}
-            </>
+          <div
+            className="csp__automation-row"
+            onPointerDown={preserveFocusUnlessTouch}
+          >
+            <label className="csp__automation-copy" htmlFor={autoResumeSwitchId}>
+              <span className="csp__automation-title">
+                Continue after usage limits and restarts
+              </span>
+            </label>
+            <Switch
+              className="chat-policy-switch"
+              id={autoResumeSwitchId}
+              checked={!!autoResumeEnabled}
+              onCheckedChange={onAutoResumeChange}
+              disabled={!!autoResumeSaving}
+            />
+          </div>
+          {autoResumeError && (
+            <p className="csp__automation-error" role="alert">
+              {autoResumeError}
+            </p>
           )}
         </div>
       )}

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -35,7 +35,6 @@ import {
   resetDeadlineDelay,
   resetDeadlineState,
   saveAutoResumePolicy,
-  saveRestartResumePolicy,
 } from './autoResumePolicy.js'
 import {
   EMPTY_CHAT_RUN_SIGNAL,
@@ -401,8 +400,6 @@ export default function ChatView({
   const [autoResumeSaving, setAutoResumeSaving] = useState(false)
   const [autoResumeError, setAutoResumeError] = useState('')
   const [autoResumeErrorSource, setAutoResumeErrorSource] = useState('')
-  const [restartResumeSaving, setRestartResumeSaving] = useState(false)
-  const [restartResumeError, setRestartResumeError] = useState('')
   const [embeddedRunSignal, setEmbeddedRunSignal] = useState(
     EMPTY_CHAT_RUN_SIGNAL,
   )
@@ -413,8 +410,6 @@ export default function ChatView({
   const [, setLimitResetClockTick] = useState(0)
   const autoResumeSavingRef = useRef(false)
   const autoResumeRequestRef = useRef(0)
-  const restartResumeSavingRef = useRef(false)
-  const restartResumeRequestRef = useRef(0)
   const armedEmbeddedResetRef = useRef(null)
   // This external per-chat state survives ChatView's keyed unmount/remount.
   // Send handlers also read the store directly, closing the same-frame gap
@@ -549,10 +544,6 @@ export default function ChatView({
     setAutoResumeSaving(false)
     setAutoResumeError('')
     setAutoResumeErrorSource('')
-    restartResumeRequestRef.current += 1
-    restartResumeSavingRef.current = false
-    setRestartResumeSaving(false)
-    setRestartResumeError('')
   }, [chatId])
 
   const handleAutoResumeChange = useCallback(async (next, source = 'card') => {
@@ -588,34 +579,6 @@ export default function ChatView({
     next => handleAutoResumeChange(next, 'settings'),
     [handleAutoResumeChange],
   )
-
-  const handleRestartResumeChange = useCallback(async next => {
-    if (restartResumeSavingRef.current) return
-    restartResumeSavingRef.current = true
-    const requestId = ++restartResumeRequestRef.current
-    setRestartResumeSaving(true)
-    setRestartResumeError('')
-    try {
-      const result = await saveRestartResumePolicy({
-        chatId,
-        next,
-        request: apiFetch,
-      })
-      if (requestId !== restartResumeRequestRef.current) return
-      if (result.value !== null) {
-        setChatInfo(prev => prev ? ({
-          ...prev,
-          auto_resume_on_restart: result.value,
-        }) : prev)
-      }
-      setRestartResumeError(result.error)
-    } finally {
-      if (requestId === restartResumeRequestRef.current) {
-        restartResumeSavingRef.current = false
-        setRestartResumeSaving(false)
-      }
-    }
-  }, [chatId])
 
   // Mirror `messages` in a ref so commitMessages can compute the next
   // value without putting a side-effect (setQueryData) inside a
@@ -1794,7 +1757,6 @@ export default function ChatView({
           effective: data.effective_agent_settings || {},
           has_assistant_turns: !!data.has_assistant_turns,
           auto_resume_on_limit: !!data.auto_resume_on_limit,
-          auto_resume_on_restart: !!data.auto_resume_on_restart,
         }
         setChatInfo(nextChatInfo)
         queryClient.setQueryData(chatMessagesQueryKey(chatId), (existing) => ({
@@ -3465,7 +3427,6 @@ export default function ChatView({
   const hasPendingResume = !!pendingResumeBlock
   const pendingLimitResetAt = pendingResumeBlock?.pause?.resets_at || null
   const autoResumeEnabled = !!chatInfo?.auto_resume_on_limit
-  const restartResumeEnabled = !!chatInfo?.auto_resume_on_restart
   useEffect(() => {
     if (!embedded || !autoResumeEnabled || !pendingLimitResetAt) {
       if (!pendingLimitResetAt) armedEmbeddedResetRef.current = null
@@ -3497,7 +3458,7 @@ export default function ChatView({
     ))
   }, [])
   // Embedded chats do not have Shell's process stream. Subscribe only while
-  // an opted-in limit park is waiting (and through its observed run), rather
+  // an enabled limit park is waiting (and through its observed run), rather
   // than holding one permanent SSE connection per retained app iframe.
   useSystemEventStream(handleEmbeddedRunEvent, {
     enabled: !!(
@@ -4065,12 +4026,6 @@ export default function ChatView({
                 }
                 onAutoResumeChange={
                   embedded ? undefined : handleAutoResumeSettingsChange
-                }
-                restartResumeEnabled={restartResumeEnabled}
-                restartResumeSaving={restartResumeSaving}
-                restartResumeError={restartResumeError}
-                onRestartResumeChange={
-                  embedded ? undefined : handleRestartResumeChange
                 }
                 onChangeChatInfo={({ agent_settings_json, provider, effective }) => {
                   // Merge into chatInfo so the next render reflects the

--- a/frontend/src/components/ChatView/ComposerPopover.jsx
+++ b/frontend/src/components/ChatView/ComposerPopover.jsx
@@ -83,10 +83,6 @@ export default function ComposerPopover({
   autoResumeSaving,
   autoResumeError,
   onAutoResumeChange,
-  restartResumeEnabled,
-  restartResumeSaving,
-  restartResumeError,
-  onRestartResumeChange,
   providerSwitchState,
   onOpenInspector,
   onOpenSummary,
@@ -231,10 +227,6 @@ export default function ComposerPopover({
                 autoResumeSaving={autoResumeSaving}
                 autoResumeError={autoResumeError}
                 onAutoResumeChange={onAutoResumeChange}
-                restartResumeEnabled={restartResumeEnabled}
-                restartResumeSaving={restartResumeSaving}
-                restartResumeError={restartResumeError}
-                onRestartResumeChange={onRestartResumeChange}
                 onChange={onChangeChatInfo}
                 providerSwitchState={providerSwitchState}
                 reqIdRef={reqIdRef}

--- a/frontend/src/components/ChatView/MsgContent.jsx
+++ b/frontend/src/components/ChatView/MsgContent.jsx
@@ -226,7 +226,7 @@ function MsgContentInner({
                     className="chat__limit-option-label"
                     htmlFor={autoResumeSwitchId}
                   >
-                    Always continue after usage limits in this chat
+                    Always continue automatically in this chat
                   </label>
                 </div>
                 <Switch

--- a/frontend/src/components/ChatView/__tests__/autoResumePolicy.test.js
+++ b/frontend/src/components/ChatView/__tests__/autoResumePolicy.test.js
@@ -7,7 +7,6 @@ import {
   resetDeadlineDelay,
   resetDeadlineState,
   saveAutoResumePolicy,
-  saveRestartResumePolicy,
 } from '../autoResumePolicy.js'
 
 
@@ -35,27 +34,6 @@ test('policy PATCH is time-boxed and returns the authoritative response', async 
   assert.equal(calls.length, 1)
   assert.equal(calls[0][0], '/chats/chat%2Fa')
   assert.equal(calls[0][1].timeoutMs, AUTO_RESUME_REQUEST_TIMEOUT_MS)
-})
-
-
-test('restart policy uses a separate explicit wire field', async () => {
-  const calls = []
-  const result = await saveRestartResumePolicy({
-    chatId: 'chat-1',
-    next: true,
-    request: async (path, options) => {
-      calls.push({ path, options })
-      return jsonResponse({
-        auto_resume_on_limit: true,
-        auto_resume_on_restart: true,
-      })
-    },
-  })
-
-  assert.deepEqual(result, { value: true, error: '' })
-  assert.deepEqual(JSON.parse(calls[0].options.body), {
-    auto_resume_on_restart: true,
-  })
 })
 
 

--- a/frontend/src/components/ChatView/__tests__/contextMenuOrder.test.js
+++ b/frontend/src/components/ChatView/__tests__/contextMenuOrder.test.js
@@ -25,8 +25,7 @@ test('chat context actions follow model selection and continuation policy', () =
   assert.ok(picker !== -1 && summary !== -1 && inspector !== -1)
   assert.ok(picker < summary)
   assert.ok(summary < inspector)
-  assert.match(settingsSource, /Continue after usage limits/)
-  assert.match(settingsSource, /Continue after planned restarts/)
+  assert.match(settingsSource, /Continue after usage limits and restarts/)
   assert.doesNotMatch(settingsSource, /Chat summar(?:y|ies)/)
 })
 

--- a/frontend/src/components/ChatView/__tests__/parkedCard.test.js
+++ b/frontend/src/components/ChatView/__tests__/parkedCard.test.js
@@ -106,7 +106,7 @@ test('the parked card has styling distinct from a plain error', () => {
 test('auto-resume is a chat-local switch shown only on the active rate-limit card', () => {
   assert.match(msgContent, /resumable && parked && autoResumeAvailable && onAutoResumeChange/,
     'the switch must require the tail resumable rate-limit state')
-  assert.match(msgContent, /Always continue after usage limits in this chat/,
+  assert.match(msgContent, /Always continue automatically in this chat/,
     'the switch label makes the persistent, chat-local scope explicit')
   assert.match(msgContent, /htmlFor=\{autoResumeSwitchId\}/,
     'the visible switch label must also be its accessible name')
@@ -118,10 +118,10 @@ test('auto-resume is a chat-local switch shown only on the active rate-limit car
     'the in-card control has a dedicated layout')
   assert.doesNotMatch(settingsView, /auto_resume_on_limit|Auto.?resume/i,
     'the removed global automatic option must not reappear in Settings')
-  assert.match(chatSettingsPanel, /Continue after usage limits/,
-    'the durable limit policy remains manageable in chat settings')
-  assert.match(chatSettingsPanel, /Continue after planned restarts/,
-    'restart continuation requires separate explicit consent')
+  assert.match(chatSettingsPanel, /Continue after usage limits and restarts/,
+    'one durable policy controls both automatic continuation reasons')
+  assert.doesNotMatch(chatSettingsPanel, /restartResume|RestartResume/,
+    'restart continuation must not grow a second switch')
   assert.doesNotMatch(chatSettingsPanel, /On for this chat|Off for this chat/,
     'the switch color communicates state without redundant state copy')
   assert.match(chatSettingsPanel, /className="chat-policy-switch"/,

--- a/frontend/src/components/ChatView/autoResumePolicy.js
+++ b/frontend/src/components/ChatView/autoResumePolicy.js
@@ -80,11 +80,6 @@ export function saveAutoResumePolicy(args) {
 }
 
 
-export function saveRestartResumePolicy(args) {
-  return saveBooleanPolicy({...args, field: 'auto_resume_on_restart'})
-}
-
-
 export function resetDeadlineState(resetAt, now = Date.now()) {
   if (!resetAt) return { elapsed: false, remainingMs: null }
   const remainingMs = Date.parse(resetAt) - now

--- a/frontend/src/components/Shell/__tests__/newChatPolicy.test.js
+++ b/frontend/src/components/Shell/__tests__/newChatPolicy.test.js
@@ -162,7 +162,6 @@ test('a canonical create response becomes an authoritative empty detail cache', 
       effective_agent_settings: { model: 'gpt-current', effort: 'medium' },
       has_assistant_turns: false,
       auto_resume_on_limit: true,
-      auto_resume_on_restart: false,
       offset: 0,
     }),
   })
@@ -181,7 +180,6 @@ test('a canonical create response becomes an authoritative empty detail cache', 
       effective: { model: 'gpt-current', effort: 'medium' },
       has_assistant_turns: false,
       auto_resume_on_limit: true,
-      auto_resume_on_restart: false,
     },
   })
 })

--- a/frontend/src/components/Shell/newChatPolicy.js
+++ b/frontend/src/components/Shell/newChatPolicy.js
@@ -112,7 +112,6 @@ export function createdChatDetailCache(created) {
       effective: detail.effective_agent_settings,
       has_assistant_turns: detail.has_assistant_turns,
       auto_resume_on_limit: !!detail.auto_resume_on_limit,
-      auto_resume_on_restart: !!detail.auto_resume_on_restart,
     },
   }
 }


### PR DESCRIPTION
## Summary

- use the existing `auto_resume_on_limit` chat policy for both usage-limit and supervisor-authenticated restart continuation
- keep the policy default-on for fresh owners and chats, and keep each explicit chat choice as the seed for future chats
- remove the duplicate restart setting from the model, API, frontend state, controls, and fresh-database migrations
- leave already-created legacy restart columns inert instead of rebuilding users local SQLite databases
- remove the obsolete provider snapshot argument from the locked continuation path; the provider remains re-read under the transition lock

## Safety and performance

Restart continuation still requires the exact latest parked run and the current boot nonce. The locked claim rechecks policy, nonce, run identity, deletion, unanswered questions, app attribution, queued app work, global liveness, and provider ownership. Manual restart outcomes remain protected from the generic idle-pending sweep.

The runtime cost remains one bounded indexed sweep at boot/events/60-second fallback, with no per-chat workers or short polling. This change reduces the implementation by 230 net lines and avoids a local database table rewrite.

## Validation

- focused backend continuation, restart, migration, API, and contract suites: 181 passed against an image built from this worktree
- post-cleanup backend continuation/compaction/settings/migration suites: 124 passed
- broader backend suite: 2,902 passed; its eight stale shared-image contract failures all passed in the worktree-built image above
- full frontend unit suites: 1,803 library tests and 47 hook tests passed
- frontend production build passed
- Python compile, diff check, fast preship gate, and pre-push frontend gate passed