### PR TITLE
fix(shell): assemble panes over the stationary Standard view

### DIFF
--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -396,7 +396,7 @@ export default function Shell() {
     const p = beatParticipants.get(key)
     if (!p) return null
     const vars = { '--mode-duration': `${p.durationMs}ms`, '--mode-delay': `${p.delayMs}ms` }
-    if ((p.motion === 'promote' || p.motion === 'settle') && p.flip) {
+    if (p.motion === 'promote' && p.flip) {
       vars['--flip-x'] = `${p.flip.x}px`
       vars['--flip-y'] = `${p.flip.y}px`
       vars['--flip-sx'] = p.flip.sx

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -525,15 +525,18 @@ test('the living halo lifecycle: lit only in builder mode, one allocation-free r
   assert.match(livingHaloSrc, /clearHaloStyles\(el\)/)
 })
 
-test('entry assembles on keyed beat classes, compositor-only, instant under reduced motion (v3)', () => {
-  // v3: entry is an opaque transform-only DEAL-IN or inverse-FLIP SETTLE keyed to the transient
-  // .shell--builder-entering class, applied per-wrapper via data-mode-motion (never
-  // the permanent .shell__view--paned). No animated layout property, shadow, or radius.
+test('entry assembles over a stationary Standard surface, compositor-only, instant under reduced motion (v3)', () => {
+  // v3: entry is an opaque transform-only DEAL-IN keyed to the transient
+  // .shell--builder-entering class, applied per-wrapper via data-mode-motion
+  // (never the permanent .shell__view--paned). The Standard wrapper is the
+  // stationary underlay and carries no competing scale animation.
   const panedBase = css.match(/\.shell__view--paned \{[\s\S]*?\n\}/)?.[0] || ''
   assert.doesNotMatch(panedBase, /animation:/)
   assert.doesNotMatch(panedBase, /transition:/)
   assert.match(css, /\.shell--builder-entering\s*\n\.shell__view\[data-mode-motion="deal-in"\] \{[\s\S]*?animation:\s*\n?\s*shell-mode-deal-in/)
-  assert.match(css, /\.shell--builder-entering\s*\n\.shell__view\[data-mode-motion="settle"\] \{[\s\S]*?shell-mode-settle/)
+  assert.match(css, /\.shell--builder-entering\s*\n\.shell__view\[data-mode-motion="deal-in"\] \{[\s\S]*?z-index:\s*2/,
+    'every moving pane must paint above the stationary underlay regardless of app/chat DOM order')
+  assert.doesNotMatch(css, /shell-mode-settle/)
   // Deal-in is transform-only: an opaque pane physically covers the retained single
   // screen as it arrives instead of exposing pane structure before fading content in.
   const dealIn = css.match(/@keyframes shell-mode-deal-in\s*\{[\s\S]*?\n\}/)?.[0] || ''
@@ -543,7 +546,7 @@ test('entry assembles on keyed beat classes, compositor-only, instant under redu
   assert.match(css, /--ease-mode-arrive:\s*cubic-bezier\(0\.16, 1, 0\.3, 1\)/,
     'entry keeps the accepted all-sides assembly curve')
   assert.match(css, /--ease-mode-promote:\s*cubic-bezier\(0\.2, 0\.82, 0\.2, 1\)/,
-    'the shared pane keeps its accepted weighted settle curve')
+    'the accepted exit promotion curve stays unchanged')
   // The old dead .workspace--resizing selector is gone entirely.
   assert.doesNotMatch(css, /workspace--resizing/)
   assert.doesNotMatch(css, /shell-pane-deal|shell-strip-deal-in|shell-pane-settle/)

--- a/frontend/src/components/Shell/__tests__/workspaceView.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceView.test.js
@@ -728,27 +728,24 @@ test('deriveExitPlan: M2 a builder Settings tab that IS the destination does not
   assert.ok(plan.participants.some(p => p.key === 'chat:5'), 'the sibling pane still deals out')
 })
 
-test('deriveEnterPlan: the shared surface settles while siblings assemble from their edges', () => {
+test('deriveEnterPlan: the shared Standard surface stays still while siblings assemble', () => {
   const two = twoPaneChatAndApp() // the app:42 pane is focused
   const twoPlan = deriveEnterPlan({ workspace: two, projection: project(two), contentRect: CONTENT })
-  assert.deepEqual(twoPlan.completionNames, ['shell-mode-settle', 'shell-mode-deal-in'])
-  assert.equal(twoPlan.participants.length, 2)
+  assert.deepEqual(twoPlan.completionNames, ['shell-mode-deal-in'])
+  assert.equal(twoPlan.underlayKey, 'app:42')
+  assert.equal(twoPlan.participants.length, 1)
   assert.ok(twoPlan.participants.every(p => p.durationMs === MODE_MOTION.enterItemMs))
-  const settle = twoPlan.participants.find(p => p.motion === 'settle')
   const gather = twoPlan.participants.find(p => p.motion === 'deal-in')
-  assert.equal(settle.key, 'app:42')
-  assert.ok(settle.flip.sx > 1, 'the right pane starts at the single-world size')
   assert.equal(gather.key, 'chat:5')
   assert.ok(gather.offset.x < 0, 'the left pane assembles from the left edge')
-  assert.ok(twoPlan.participants.every(p => p.delayMs === 0),
-    'the shared surface and siblings assemble together')
+  assert.ok(twoPlan.participants.every(p => p.delayMs === 0))
   assert.equal(twoPlan.totalMs, MODE_MOTION.enterItemMs)
+
+  // There is no visible assembly when the Standard surface is the only leaf.
+  // Returning null makes the controller commit that world flip instantly.
   const one = paneModel.seedFromFlatTabs([makeTab('app', '42')])
   const onePlan = deriveEnterPlan({ workspace: one, projection: project(one), contentRect: CONTENT })
-  assert.equal(onePlan.participants.length, 1)
-  assert.equal(onePlan.participants[0].motion, 'settle')
-  assert.equal(onePlan.participants[0].durationMs, MODE_MOTION.enterSingleMs)
-  assert.equal(onePlan.totalMs, MODE_MOTION.enterSingleMs)
+  assert.equal(onePlan, null)
 })
 
 test('focused-pane mode keeps its original edge and its in-pane strip geometry', () => {

--- a/frontend/src/components/Shell/workspace.css
+++ b/frontend/src/components/Shell/workspace.css
@@ -7,11 +7,11 @@
    The mode beat is COMPOSITOR-ONLY: every keyframe touches transform + opacity
    and NOTHING that forces layout on the live iframe/ChatView surfaces (no
    box-shadow, border-radius, filter, clip, or animated top/left/width/height).
-   Panes hold their tiled content rect through the beat; promote/settle use inverse
-   FLIP transforms, while siblings travel to/from their corresponding outer edge.
+   Panes hold their tiled content rect through the beat; exit promotion uses a
+   FLIP transform, while siblings travel to/from their corresponding outer edge.
    clears in one commit that snaps the destination to ordinary full-bleed at
    visually identical bounds. Timing constants + the per-beat plan live in
-   workspaceView.js (MODE_MOTION / deriveExit·EnterPlan); Shell writes each
+   workspaceView.js (MODE_MOTION / deriveExit·EnterPlan). Shell writes each
    participant's duration/delay and projection-derived transform variables inline. */
 .shell {
   --ease-mode-arrive: cubic-bezier(0.16, 1, 0.3, 1);
@@ -49,19 +49,6 @@
   z-index: 0;
 }
 
-/* Assemble continuity: the single-world surface is already laid out in its final
-   pane rect, so an inverse FLIP makes its first frame look full-bleed and settles it
-   into place. This is the reverse of promote and touches only transform. */
-.shell--builder-entering
-.shell__view[data-mode-motion="settle"] {
-  z-index: 1;
-  transform-origin: 0 0;
-  animation:
-    shell-mode-settle
-    var(--mode-duration)
-    var(--ease-mode-promote)
-    both;
-}
 /* Promote: the survivor pane keeps its tiled content rect and FLIPs to cover the
    full destination (transform-origin at its own top-left; Shell latches --flip-*
    from the projection, never a DOM read). Its OWN curve (--ease-mode-promote) gives
@@ -98,6 +85,7 @@
    two worlds look like separate transitions. */
 .shell--builder-entering
 .shell__view[data-mode-motion="deal-in"] {
+  z-index: 2;
   animation:
     shell-mode-deal-in
     var(--mode-duration)
@@ -114,17 +102,6 @@
     transform:
       translate3d(var(--flip-x), var(--flip-y), 0)
       scale(var(--flip-sx), var(--flip-sy));
-  }
-}
-
-@keyframes shell-mode-settle {
-  from {
-    transform:
-      translate3d(var(--flip-x), var(--flip-y), 0)
-      scale(var(--flip-sx), var(--flip-sy));
-  }
-  to {
-    transform: translate3d(0, 0, 0) scale(1, 1);
   }
 }
 
@@ -168,9 +145,9 @@
 }
 
 /* Dividers + the overflow chip simplify first on exit, then resolve only over the
-   LAST 70ms of entry. A settling strip follows the same rule: structure cannot appear
-   over the old screen before the panes themselves arrive. Opacity-only; small
-   elements. The chip selector is
+   LAST 70ms of entry. The stationary underlay's strip follows the same rule:
+   structure cannot appear over the old screen before the panes themselves arrive.
+   Opacity-only; small elements. The chip selector is
    listed FIRST (before the divider) so it is followed by a comma, never a brace — a
    css-shape test that greps the base chip rule still finds it. */
 .shell--builder-exiting .workspace__pane-chip,
@@ -178,7 +155,7 @@
   pointer-events: none;
   animation: shell-mode-chrome-out 90ms var(--ease-mode-chrome) both;
 }
-.shell--builder-entering .shell__tabstrip[data-mode-motion="settle"],
+.shell--builder-entering .shell__tabstrip:not([data-mode-motion]),
 .shell--builder-entering .workspace__pane-chip,
 .shell--builder-entering .workspace__divider {
   animation:

--- a/frontend/src/components/Shell/workspaceView.js
+++ b/frontend/src/components/Shell/workspaceView.js
@@ -63,7 +63,6 @@ export function projectFocusedPane(baseProjection, workspace, paneId, contentRec
 // There is no per-pane stagger or second destination phase to make the owner wait.
 export const MODE_MOTION = Object.freeze({
   enterItemMs: 210,
-  enterSingleMs: 180,
   exitItemMs: 180,
   promoteMs: 210,
   logoReleaseMs: 90,
@@ -79,7 +78,6 @@ export const RECONCILE_SLACK_MS = 250
 // keyframes so a name typo is caught by one grep. Strip-clear + chrome fades are
 // deliberately ABSENT: they are shorter and must not gate completion.
 export const PROMOTE_NAME = 'shell-mode-promote'
-export const SETTLE_NAME = 'shell-mode-settle'
 export const DEAL_OUT_NAME = 'shell-mode-deal-out'
 export const DEAL_IN_NAME = 'shell-mode-deal-in'
 
@@ -327,11 +325,11 @@ export function deriveExitPlan(input) {
 }
 
 // deriveEnterPlan(input) → the latched entry plan, or null when there is nothing
-// to assemble. The single-screen surface keeps physical continuity when it is an
-// active builder leaf: it starts full-bleed and settles into its pane via the inverse
-// FLIP. Every sibling gathers from its nearest outer edge. If the single-screen
-// surface is absent/inactive in the tree, it remains a stationary underlay while all
-// visible panes assemble over it. This is the exact inverse of deriveExitPlan.
+// to assemble. The single-screen surface remains a stationary full-bleed underlay
+// while every OTHER visible pane gathers from its nearest outer edge. When that
+// surface is also a builder leaf, completion simply crops the retained wrapper
+// into its pane. This keeps the Standard world visually still instead of scaling
+// it like a foreground card, and needs no duplicate ChatView/AppCanvas.
 //
 export function deriveEnterPlan(input) {
   const { workspace, projection, contentRect } = input
@@ -339,31 +337,14 @@ export function deriveEnterPlan(input) {
   if (leaves.length === 0) return null
   const { target, immersiveInstant } = classifyExitDestination(input)
   if (immersiveInstant) return null
-  const single = leaves.length === 1
-  const duration = single ? MODE_MOTION.enterSingleMs : MODE_MOTION.enterItemMs
+  const duration = MODE_MOTION.enterItemMs
   const destinationRect = { x: 0, y: 0, w: contentRect.w, h: contentRect.h }
-  const settleLeaf = target ? leaves.find(l => l.activeKey === target) : null
   const participants = []
   const completionNames = new Set()
-  let underlayKey = null
-
-  if (settleLeaf) {
-    const fromRect = paintedContentRect(settleLeaf, projection, leaves.length)
-    participants.push({
-      key: settleLeaf.activeKey,
-      paneId: settleLeaf.paneId,
-      motion: 'settle',
-      delayMs: 0,
-      durationMs: duration,
-      flip: flipTo(fromRect, destinationRect),
-    })
-    completionNames.add(SETTLE_NAME)
-  } else {
-    underlayKey = target
-  }
+  const underlayKey = target
 
   for (const l of leaves) {
-    if (l === settleLeaf) continue
+    if (l.activeKey === target) continue
     participants.push({
       key: l.activeKey, paneId: l.paneId, motion: 'deal-in',
       delayMs: 0,
@@ -372,6 +353,7 @@ export function deriveEnterPlan(input) {
     })
     completionNames.add(DEAL_IN_NAME)
   }
+  if (participants.length === 0) return null
   const totalMs = participants.reduce((m, p) => Math.max(m, p.delayMs + p.durationMs), 0)
   return {
     kind: 'enter',

--- a/tests/mode-transition.spec.mjs
+++ b/tests/mode-transition.spec.mjs
@@ -457,6 +457,72 @@ test('v3 panes assemble over the stationary single screen from their correspondi
   await expect.poll(() => builderActive(page)).toBe(true)
 })
 
+test('shared Standard chat stays still while its sibling pane assembles above it', async ({ page }) => {
+  // slot === the focused LEFT pane's chat. Exit still promotes that pane; entry
+  // deliberately does not shrink the Standard surface back into place. It stays
+  // full-bleed underneath while the right sibling arrives, then the completion
+  // commit crops it into the left pane.
+  await bootSeededWorkspace(page, WIDE, twoPaneBuilder({ kind: 'chat', id: 'aaa' }))
+  await toggleMode(page)
+  await expect.poll(() => modePhase(page), { timeout: 2000 }).toBe('idle')
+  await expect.poll(() => builderActive(page)).toBe(false)
+
+  const sampler = page.evaluate(async () => {
+    const root = document.querySelector('.shell')
+    let started = false
+    let minUnderlayOpacity = 1
+    const underlayTransforms = new Set()
+    const participants = []
+    await new Promise(resolve => {
+      let frames = 0
+      const tick = () => {
+        const entering = root.classList.contains('shell--builder-entering')
+        if (entering) {
+          started = true
+          const underlay = document.querySelector('.shell__view--exit-underlay')
+          if (underlay) {
+            const style = getComputedStyle(underlay)
+            minUnderlayOpacity = Math.min(minUnderlayOpacity, parseFloat(style.opacity))
+            underlayTransforms.add(style.transform)
+          }
+          if (participants.length === 0) {
+            for (const pane of document.querySelectorAll(
+              '.shell__view[data-mode-motion="deal-in"]',
+            )) {
+              participants.push({
+                x: parseFloat(pane.style.getPropertyValue('--mode-offset-x')) || 0,
+                y: parseFloat(pane.style.getPropertyValue('--mode-offset-y')) || 0,
+              })
+            }
+          }
+        }
+        frames += 1
+        if ((started && !entering) || frames > 120) { resolve(); return }
+        requestAnimationFrame(tick)
+      }
+      requestAnimationFrame(tick)
+    })
+    return {
+      started,
+      minUnderlayOpacity,
+      underlayTransforms: [...underlayTransforms],
+      participants,
+    }
+  })
+  await page.waitForTimeout(30)
+  await toggleMode(page)
+  const r = await sampler
+
+  expect(r.started).toBe(true)
+  expect(r.underlayTransforms, 'the Standard chat never scales or translates').toEqual(['none'])
+  expect(r.minUnderlayOpacity, 'the Standard chat never fades').toBeGreaterThanOrEqual(0.99)
+  expect(r.participants).toHaveLength(1)
+  expect(r.participants[0].x, 'the right sibling enters from the right edge').toBeGreaterThan(0)
+  expect(r.participants[0].y).toBe(0)
+  await expect.poll(() => modePhase(page), { timeout: 2000 }).toBe('idle')
+  await expect.poll(() => builderActive(page)).toBe(true)
+})
+
 // Frame-sample the destination across a world reveal. It is ready and stationary
 // beneath one short leftward departure; there is no delayed second phase.
 async function sampleStationaryUnderlay(page) {


### PR DESCRIPTION
## What changed
- keep the current Standard chat/app full-bleed, opaque, and transform-free throughout pane entry
- animate only the other pane surfaces from their nearest outer edge
- remove the inverse-FLIP settle path that made the background shrink and exposed pane structure before content
- leave the accepted pane-exit promote/scatter motion unchanged

## Why
The old entry treated the Standard surface as a foreground pane and scaled it into the grid while the sibling panes arrived. That made the background move and produced a wobbly structure-then-content reveal. The entry now matches the intended layer model: Standard is the stationary underlay; opaque panes assemble above it; the completion commit crops the retained surface into its pane.

## Performance
The beat remains compositor-only. This deletes one animated participant/keyframe and does not duplicate ChatView or AppCanvas.

## Validation
- frontend unit + hook suite: 1,850 passed
- focused workspace/motion contracts after rebasing onto current main: 121 passed
- production build passed
- added a frame-sampling Playwright regression for an opaque, transform-free shared Standard chat

Local Playwright was not run because the host currently has 12 GiB free and the isolated runner correctly requires 20 GiB; the focused browser regression is included for CI.