### PR TITLE
fix(shell): restore readable pane assembly cadence

### DIFF
--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -543,8 +543,8 @@ test('entry assembles over a stationary Standard surface, compositor-only, insta
   assert.match(dealIn, /translate3d\(var\(--mode-offset-x\), var\(--mode-offset-y\), 0\)/)
   assert.doesNotMatch(dealIn, /opacity:/)
   assert.doesNotMatch(dealIn, /box-shadow|border-radius|filter|clip/)
-  assert.match(css, /--ease-mode-arrive:\s*cubic-bezier\(0\.16, 1, 0\.3, 1\)/,
-    'entry keeps the accepted all-sides assembly curve')
+  assert.match(css, /--ease-mode-arrive:\s*cubic-bezier\(0\.25, 1, 0\.5, 1\)/,
+    'entry keeps readable quart-out travel without braking into the shared seam')
   assert.match(css, /--ease-mode-promote:\s*cubic-bezier\(0\.2, 0\.82, 0\.2, 1\)/,
     'the accepted exit promotion curve stays unchanged')
   // The old dead .workspace--resizing selector is gone entirely.

--- a/frontend/src/components/Shell/workspace.css
+++ b/frontend/src/components/Shell/workspace.css
@@ -14,7 +14,9 @@
    workspaceView.js (MODE_MOTION / deriveExit·EnterPlan). Shell writes each
    participant's duration/delay and projection-derived transform variables inline. */
 .shell {
-  --ease-mode-arrive: cubic-bezier(0.16, 1, 0.3, 1);
+  /* Quart-out keeps long edge travel readable across the beat instead of spending
+     most of the distance in its first few frames and braking into the shared seam. */
+  --ease-mode-arrive: cubic-bezier(0.25, 1, 0.5, 1);
   --ease-mode-leave: cubic-bezier(0.4, 0, 0.7, 0.2);
   /* Chrome (dividers + strips) leads the panes with a faster, front-loaded curve so
      structure simplifies first (exit) / resolves after the focused card (entry). */


### PR DESCRIPTION
## Summary
- restore the earlier quart-out cadence for panes assembling from viewport edges
- keep the accepted exit/promote choreography, geometry, duration, and solid-content reveal unchanged
- lock the entry curve against a return to the ballistic expo cadence

## Why
The current expo-out curve covers roughly 81% of a long pane trajectory in its first 50 ms, then brakes at the shared seam. With multiple edge vectors arriving together, that reads as panes rushing into and colliding with each other even though the curve never technically overshoots. Quart-out spreads the same compositor-only transform over the existing 210 ms beat, with no new work or state.

## Verification
- focused Shell motion/state tests: 158 passed
- full frontend library tests: 1804 passed
- full frontend hook tests: 47 passed
- production frontend build passed
