### PR TITLE
Document escaping currency dollar signs in chat output

### DIFF
--- a/skill/core.md
+++ b/skill/core.md
@@ -212,6 +212,7 @@ Partner-facing messages describe what the app does and how it feels, not how it'
 ### Chat rendering
 
 - **Math**: `$...$` (inline) and `$$...$$` (block) render KaTeX.
+- **Currency**: escape dollar signs used as currency (for example, `\$62.5k`) so they are not interpreted as math delimiters.
 - **Images**: any `/api/` image URL in markdown renders inline.
 - **Sources**: when a web search hands back its result links, the shell renders them as source pills under your answer on its own — so don't also close the message with a hand-written "Sources" list repeating those same links. Citing a page inline, where a sentence actually needs it, is always right: not every provider's search exposes its results, so an inline link is sometimes the only citation the partner gets.
 


### PR DESCRIPTION
## Summary

- tell agents to escape currency dollar signs in chat messages
- prevent currency amounts from being interpreted as inline KaTeX delimiters

## Testing

- `git diff --check`