### PR TITLE
Avoid comparing installed app projections with origin

### DIFF
--- a/backend/app/source_status.py
+++ b/backend/app/source_status.py
@@ -251,9 +251,20 @@ def _remote_topology(
   repo: Path,
   origin_repo: str | None,
   *,
+  compare_local: bool = True,
   classify_install: bool = False,
 ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
-  """Return sanitized, last-fetched origin/fork positions."""
+  """Return sanitized, last-fetched origin/fork positions.
+
+  Installed app checkouts are release projections: their editable tree may
+  intentionally omit the shared repository's source modules, tests, docs, and
+  build inputs.  Comparing that projected checkout directly with
+  ``origin/main`` turns packaging omissions into apparent owner deletions and
+  produces meaningless ancestry counts when the installer history is
+  synthetic.  App-local work already has the authoritative ``upstream``
+  comparison at the project level, so callers disable the local/origin
+  comparison while retaining origin identity and fork topology.
+  """
   origin_ref = _remote_default_ref(repo, "origin")
   origin_sha = _rev(repo, origin_ref) if origin_ref else None
   origin: dict[str, Any] = {
@@ -264,7 +275,7 @@ def _remote_topology(
     "local_behind": None,
     "local_tree": None,
   }
-  if origin_ref and _rev(repo, "HEAD"):
+  if compare_local and origin_ref and _rev(repo, "HEAD"):
     local_ahead, local_behind = _comparison_counts(repo, origin_ref, "HEAD")
     origin.update({
       "local_ahead": local_ahead,
@@ -394,6 +405,7 @@ def _project_status(
   origin, forks = _remote_topology(
     repo,
     response["canonical_repo"],
+    compare_local=(kind == "platform"),
     classify_install=(kind == "app"),
   )
   response.update({"origin": origin, "forks": forks})

--- a/backend/tests/test_source_status.py
+++ b/backend/tests/test_source_status.py
@@ -164,7 +164,7 @@ def test_history_subject_boundary_cannot_be_forged_by_a_filename():
   assert {item["group"] for item in result["tree"]["paths"]} == {"authored"}
 
 
-def test_sanitized_origin_and_fork_topology_uses_last_fetched_refs():
+def test_installed_app_origin_does_not_compare_full_source_with_release_projection():
   repo = _repo()
   base = _git(repo, "rev-parse", "HEAD")
   _git(repo, "remote", "add", "origin", "https://github.com/example/demo.git")
@@ -180,9 +180,12 @@ def test_sanitized_origin_and_fork_topology_uses_last_fetched_refs():
   assert result["origin"]["repo"] == "example/demo"
   assert result["origin"]["ref"] == "origin/main"
   assert result["origin"]["sha"] == base
-  assert result["origin"]["local_ahead"] == 1
-  assert result["origin"]["local_behind"] == 0
-  assert result["origin"]["local_tree"]["files"] == 1
+  assert result["origin"]["local_ahead"] is None
+  assert result["origin"]["local_behind"] is None
+  assert result["origin"]["local_tree"] is None
+  # Local app work remains authoritative against the installer-owned baseline.
+  assert result["ahead"] == 1
+  assert result["tree"]["files"] == 1
   assert len(result["forks"]) == 1
   fork = result["forks"][0]
   assert fork["repo"] == "owner/demo"
@@ -194,6 +197,25 @@ def test_sanitized_origin_and_fork_topology_uses_last_fetched_refs():
   payload = repr(result)
   assert "git@github.com" not in payload
   assert "https://github.com" not in payload
+
+
+def test_full_checkout_can_request_local_origin_topology():
+  repo = _repo("full-checkout")
+  base = _git(repo, "rev-parse", "HEAD")
+  _git(repo, "remote", "add", "origin", "https://github.com/example/demo.git")
+  _git(repo, "update-ref", "refs/remotes/origin/main", base)
+  (repo / "local.js").write_text("local\n", encoding="utf-8")
+  _git(repo, "add", "local.js")
+  _commit(repo, "local source edit")
+
+  origin, forks = source_status._remote_topology(
+    repo, "example/demo", compare_local=True,
+  )
+
+  assert forks == []
+  assert origin["local_ahead"] == 1
+  assert origin["local_behind"] == 0
+  assert origin["local_tree"]["files"] == 1
 
 
 def test_diverged_counts_and_sanitized_github_identity():


### PR DESCRIPTION
## Why

Installed app checkouts are release projections and may intentionally omit the shared repository's source modules, tests, documentation, and build inputs. Returning a direct local-versus-origin diff for those checkouts turns packaging omissions into apparent owner deletions and can produce meaningless ancestry counts for synthetic installer histories.

## What changed

- Stop calculating local/origin ancestry and tree differences for installed app source checkouts.
- Preserve origin identity and origin-to-fork topology for contribution mapping.
- Keep local/origin comparison available for full checkouts such as the Möbius platform.
- Continue reporting app-local work through the authoritative installer-owned `upstream` comparison.
- Add regressions for both projected app checkouts and full-clone origin comparison.

## Verification

- `python3 -m py_compile backend/app/source_status.py`
- `pytest -q backend/tests/test_source_status.py backend/tests/test_github_routes.py -k source_status` — 14 passing from the exact review branch.