### PR TITLE
Keep Marked root imports on the ESM runtime

### DIFF
--- a/backend/app/app_compile_contract.py
+++ b/backend/app/app_compile_contract.py
@@ -39,7 +39,7 @@ COMPILED_RUNTIME_ABI = 1
 # compiled-runtime change that remains host-compatible. Keep ABI for actual
 # host/runtime incompatibilities: a revision-only rollout is safe while the
 # live checkout and backend process briefly run different generations.
-COMPILED_RUNTIME_ARTIFACT_REVISION = 3
+COMPILED_RUNTIME_ARTIFACT_REVISION = 4
 COMPILED_RUNTIME_GLOBAL = "__mobiusCompiledRuntime"
 COMPILED_RUNTIME_BANNER = (
   f"/* mobius-compiled-runtime-abi:{COMPILED_RUNTIME_ABI};"
@@ -107,11 +107,25 @@ def runtime_library_aliases() -> tuple[tuple[str, Path], ...]:
   package root is replaced with an absolute alias, esbuild no longer consults
   Three's package exports for that subpath. Pin the public addons spelling to
   its runtime-owned physical directory before adding the package roots.
+
+  Marked's ``browser`` field points at a UMD build that does not preserve its
+  documented named ESM export through this absolute-directory resolution.
+  Pin the public root spelling to the ESM entry instead; app source keeps using
+  the package's public import rather than a private file path.
   """
   node_path = runtime_node_path()
   roots = sorted({_package_root(specifier) for specifier in BUNDLED_RUNTIME_LIBS})
-  subpaths = (("three/addons", node_path / "three" / "examples" / "jsm"),)
-  return subpaths + tuple((root, node_path / root) for root in roots)
+  overrides = (
+    ("three/addons", node_path / "three" / "examples" / "jsm"),
+    # Marked's browser field is a UMD build. Point the public root import at
+    # its ESM entry so `import { marked } from "marked"` keeps the documented
+    # named export inside mini-app bundles.
+    ("marked", node_path / "marked" / "lib" / "marked.esm.js"),
+  )
+  overridden = {specifier for specifier, _path in overrides}
+  return overrides + tuple(
+    (root, node_path / root) for root in roots if root not in overridden
+  )
 
 
 NO_DEFAULT_EXPORT_ERROR = (

--- a/backend/tests/test_runtime_libs.py
+++ b/backend/tests/test_runtime_libs.py
@@ -166,6 +166,41 @@ export default function ThreeAddonsFixture() {
   assert output.is_file() and output.stat().st_size > 0
 
 
+def test_marked_root_import_uses_the_pinned_esm_entry(tmp_path):
+  """The documented named export must not collapse through Marked's UMD build."""
+  aliases = dict(runtime_library_aliases())
+  assert (
+    aliases["marked"]
+    == runtime_node_path() / "marked" / "lib" / "marked.esm.js"
+  )
+
+  entry = tmp_path / "marked.jsx"
+  output = tmp_path / "marked.js"
+  metafile = tmp_path / "marked-meta.json"
+  entry.write_text(
+    """import { marked } from 'marked'
+
+export default function MarkedFixture() {
+  return marked.parse('# Working')
+}
+"""
+  )
+
+  completed = subprocess.run(
+    esbuild_command(entry, output, metafile=metafile),
+    capture_output=True,
+    check=False,
+    env=esbuild_environment(),
+    text=True,
+    timeout=ESBUILD_TIMEOUT_SECS,
+  )
+  assert completed.returncode == 0, completed.stderr
+
+  inputs = json.loads(metafile.read_text())["inputs"]
+  assert any(path.endswith("/marked/lib/marked.esm.js") for path in inputs)
+  assert not any(path.endswith("/marked/lib/marked.umd.js") for path in inputs)
+
+
 def test_app_hosts_have_no_runtime_import_map_or_static_module_imports():
   frame = FRAME.read_text()
   standalone = STANDALONE.read_text()


### PR DESCRIPTION
## Summary
- resolve the public `marked` root import to the platform-pinned ESM entry
- preserve the documented `import { marked } from "marked"` API for mini-apps
- rebuild installed app bundles through the existing runtime artifact revision

## Why
The app compiler pins supported packages to the platform installation. For Marked, resolving that absolute package directory selected its browser UMD build, which lost the named ESM export and made apps fall back to plain text. Fixing the compiler keeps app code on the package’s public API instead of requiring private-file imports in each app.

## Tests
- `pytest -q tests/test_runtime_libs.py`