### PR TITLE
Document durable, fix-forward platform design principles

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -10,6 +10,29 @@ The design has one line behind it: **low floor, high ceiling, no walls.** The ag
 
 **Intelligence over scripts.** A script, validator, or fixed procedure earns its place only for the unambiguous and identical-every-time — clone/pull to install or update recovery, rebuild the served frontend, a deterministic migration. Everything ambiguous — why something broke, how to reach the last good state, fixing what another agent did — is the agent reasoning in context. Branching logic to cover cases, or bespoke machinery to detect-and-auto-handle a situation, is the tell that you're building the wrong thing: script the certain step, **instruct** the agent to run it (sharpen the prompt if it forgets), and trust intelligence for the rest. The only automation worth keeping is one a tool already ships (a real watcher, HMR) — never flimsy glue invented to avoid instructing the agent. **Recovery** is this made concrete: a small, separate, always-up agent that can't break its own code (updated only by that one unambiguous script) but reaches and fixes everything else by *reasoning* about what broke, not from a menu of canned reversions.
 
+### Design for the next change
+
+**Solve at the core.** Prefer the smallest durable solution that fixes the
+cause and improves the path the next related change will use. Avoid both
+symptom patches and abstractions for imagined needs. If a reasonable change
+feels awkward, treat that friction as evidence about the underlying design:
+challenge and simplify it rather than adding a workaround. Revisit earlier
+choices as understanding grows — consolidate, remove, and simplify.
+
+**Fix forward.** Prefer a clean design and deliberate migration — even when it
+breaks an old path — over permanent shims, fallbacks, duplicated logic, or
+parallel systems. Preserve compatibility where it protects owner data or a
+genuine external contract; otherwise update every affected caller and move
+forward as one coherent system.
+
+**Keep the shared foundation lean.** Every owner runs their own copy of Möbius
+and may pay directly for its compute, memory, storage, network, and agent
+usage. Treat meaningful efficiency gains as user-facing improvements. Pursue
+material, evidenced gains without sacrificing behavior, correctness,
+maintainability, or future flexibility. Keep the platform small, general, and
+composable; put domain-specific complexity in apps and reserve platform
+complexity for shared primitives and hard invariants.
+
 The flip side: infrastructure the agent never sees — provider plumbing, the persistence actor, the streaming protocol, the navigation back-stack — gets whatever complexity makes it correct. Maximal expressive surface for the agent, ironclad substrate underneath.
 
 **If you're an agent building Möbius, attend to this on every change.** You were trained on products for careless or adversarial users, where the job is to validate, sanitize, and prevent. Here the user is the owner and you are trusted. When you reach for a guard, a validator, or background auto-magic to prevent a mistake, stop and ask whether you're policing — or substituting brittle automation for intelligence. A change that fights this philosophy is a sign you're solving the wrong problem.

--- a/skill/core.md
+++ b/skill/core.md
@@ -115,7 +115,31 @@ Name key decisions, give a concrete recommendation for each. Lead with the recom
 
 **Start minimal: a functional core + clean UI that nails the use case, built to expand on — go richer only when the request clearly warrants it** (see `building-apps.md`).
 
-**The problem must earn the machinery; the fix belongs at the layer that owns the behavior.** When you add a feature or fix a bug, extend the existing path or a shipped pattern and remove the cause — reach for a parallel mechanism only when that path genuinely can't carry the requirement. Downstream suppression that hides wrong output (or a timer/retry/early-return that dodges a symptom) is not a fix. "Proper" is not "fewest lines" — spend complexity where correctness or a real constraint needs it, and name that reason. The bar is that the *next* related change is cheaper to understand, test, and extend.
+**Design for the next change.** Apply this standard when building, fixing,
+reviewing, or simplifying. The problem must earn the machinery, and the fix
+belongs at the layer that owns the behavior. Prefer the smallest durable
+solution that removes the cause and improves the path the next related change
+will use — not a symptom patch, timer/retry/early-return dodge, parallel
+mechanism, or abstraction for imagined needs. If a reasonable change feels
+awkward or unnatural, treat that friction as evidence about the underlying
+design: challenge and simplify the owning primitive instead of working around
+it. Revisit earlier choices as understanding grows; consolidate, remove, and
+simplify. Keep the platform small, general, and composable; put
+domain-specific complexity in apps, and reserve platform complexity for shared
+primitives and hard invariants.
+
+**Fix forward; do not preserve accidental complexity.** Prefer a clean design
+and deliberate migration, even when it breaks an old path, over permanent
+shims, fallbacks, duplicated logic, or parallel systems. Preserve
+compatibility where it protects partner data or a genuine external contract;
+otherwise update every affected caller and move forward as one coherent
+system. "Proper" is not "fewest lines" — spend complexity where correctness or
+a real constraint needs it, and name that reason. Every owner runs their own
+copy of Möbius and may pay for its compute, memory, storage, network, and agent
+usage: pursue material, evidenced efficiency gains as user-facing
+improvements, but never buy them with worse behavior, correctness,
+maintainability, or future flexibility. The bar is that the next related
+change is cheaper to understand, test, and extend.
 
 Iterate on details freely (different library, CSS tweaks, polish). But **do not silently change what you agreed to build.** If you hit a blocker that can't be fixed within the plan — data source bot-protected, key API gone, chosen library doesn't fit the viewport — **stop and go back with the problem and options.** Don't ship a different app and hope they don't notice. Small course corrections stay inside the plan; anything that changes the subject, data source, or core concept is a new plan and needs new approval.
 
@@ -183,7 +207,7 @@ When about to stop tool-calling and write the final assistant message **on any t
 | Changed shell / CSS / cron | State what changed and why. |
 | Made an app / platform / shell change that would help other Möbius users | Offer to share it, every time, in plain words that name the button: "I can prepare this in Contribute for your review — you approve before anything goes public." A partner without a technical background won't know to ask, so the offer is yours to make — `contributing.md` has the how. |
 | About to overwrite `theme.css` | Snapshot first for a named undo (the server also auto-snapshots; `?reset-theme=1` rolls back). See `theming.md`. |
-| Changed code (app or platform) | Run the proper-build check: *does this fix the cause in the path that already owns the behavior, using only the machinery the problem earns — or does it add a parallel mechanism or hide a symptom?* Rework it unless a concrete requirement or invariant shows why the existing path can't carry it. |
+| Changed or reviewed code (app or platform) | Run the design-for-the-next-change check: *does this solve the cause in the path that owns it, make the next related change easier, avoid unearned machinery and permanent compatibility weight, and keep shared resources lean without compromising behavior or correctness?* Rework it unless a concrete requirement or invariant justifies the complexity. |
 | **(second to last)** | Scan this turn's tool calls for missed gotchas — wrong assumptions, workarounds, infra surprises — and state any durable one. |
 | **(final check)** | Re-read the partner's latest message; confirm every question/concern/change is addressed. Then ask: does this look right? Anything to change? |
 


### PR DESCRIPTION
## Summary

- document a durable design principle that favors root-cause improvements over patches and speculative abstractions
- prefer deliberate migrations and fixing forward over permanent compatibility layers
- treat material resource efficiency as user-facing quality while keeping the platform general and app-specific complexity in apps
- apply the principle directly to agent building and code review

## Validation

- `git diff --check`
- documentation-only change; no runtime behavior changes