### PR TITLE
fix(chat): bridge restart supervisor protocol versions

### DIFF
--- a/backend/app/restart_ledger.py
+++ b/backend/app/restart_ledger.py
@@ -60,16 +60,29 @@ def request_restart(
   *,
   boot_id: str,
   nonce: str,
+  runs: list[dict[str, str]],
   now: float | None = None,
 ) -> None:
-  """Publish intent first, then the sentinel the frozen poller consumes."""
+  """Publish intent first, then the sentinel the frozen poller consumes.
+
+  ``runs`` is retained in protocol v1 for supervisors baked before the
+  nonce-only simplification. Newer supervisors ignore the extra field and
+  attest only the nonce; older supervisors require it before accepting the
+  restart. Keeping the field lets a platform-only update cross either frozen
+  image generation safely.
+  """
   intent_path, request_path, _ = _paths()
   created_at = time.time() if now is None else now
+  normalized = [
+    {"chat_id": str(item["chat_id"]), "run_token": str(item["run_token"])}
+    for item in runs
+  ]
   _atomic_json(intent_path, {
     "version": PROTOCOL_VERSION,
     "nonce": nonce,
     "source_boot_id": boot_id,
     "created_at": created_at,
+    "runs": normalized,
   })
   _atomic_json(request_path, {
     "nonce": nonce,

--- a/backend/app/restart_util.py
+++ b/backend/app/restart_util.py
@@ -79,8 +79,9 @@ async def restart_this_worker() -> None:
 
   boot_id = restart_ledger.current_boot_id()
   restart_nonce = restart_ledger.new_nonce()
+  parked_runs: list[dict[str, str]] = []
   try:
-    await asyncio.wait_for(
+    parked_runs = await asyncio.wait_for(
       chat.drain_all_for_restart(
         timeout=chat.DRAIN_TIMEOUT,
         restart_nonce=restart_nonce,
@@ -102,6 +103,7 @@ async def restart_this_worker() -> None:
     restart_ledger.request_restart(
       boot_id=boot_id,
       nonce=restart_nonce,
+      runs=parked_runs,
     )
   except Exception:
     # Restart reliability and continuation authorization are independent.

--- a/backend/tests/test_restart_ledger.py
+++ b/backend/tests/test_restart_ledger.py
@@ -60,6 +60,7 @@ def _request(*, boot: str, nonce: str, now: float) -> None:
   platform_ledger.request_restart(
     boot_id=boot,
     nonce=nonce,
+    runs=[{"chat_id": "chat-12345678", "run_token": "run-12345678"}],
     now=now,
   )
 
@@ -90,6 +91,27 @@ def test_exact_accepted_restart_is_bound_to_immediately_following_boot(
 
   assert _authorized(tmp_path, target_boot) == nonce
   assert _authorized(tmp_path, source_boot) is None
+
+
+def test_restart_intent_keeps_exact_runs_for_older_frozen_supervisors(
+  tmp_path, monkeypatch,
+):
+  supervisor = _load_supervisor()
+  _bind(supervisor, tmp_path, monkeypatch)
+  now = time.time()
+  source_boot = "boot-source-1234"
+
+  assert supervisor.begin_boot(source_boot, now=now) is False
+  _request(boot=source_boot, nonce="nonce-12345678", now=now)
+
+  intent = json.loads(supervisor.INTENT_PATH.read_text(encoding="utf-8"))
+  assert intent["runs"] == [{
+    "chat_id": "chat-12345678",
+    "run_token": "run-12345678",
+  }]
+  # The current nonce-only supervisor accepts the same payload, proving the
+  # compatibility field does not alter the simplified authorization model.
+  assert supervisor.accept(source_boot, now=now + 1) is True
 
 
 def test_crash_after_intent_before_supervisor_acceptance_is_not_authorized(

--- a/backend/tests/test_restart_util.py
+++ b/backend/tests/test_restart_util.py
@@ -61,6 +61,7 @@ def test_restart_drains_then_requests_supervisor_and_arms_force_kill(monkeypatch
   assert requests == [{
     "boot_id": "boot-12345678",
     "nonce": "nonce-12345678",
+    "runs": [{"chat_id": "chat-12345678", "run_token": "run-12345678"}],
   }]
   # A single force-kill fallback, armed as a daemon and started, so a hung
   # graceful shutdown can't leave the container "Up" with a dead worker. Its
@@ -101,6 +102,7 @@ def test_restart_request_survives_drain_failure(monkeypatch):
   assert requests == [{
     "boot_id": "boot-12345678",
     "nonce": "nonce-12345678",
+    "runs": [],
   }]
   assert len(_FakeTimer.instances) == 1
 


### PR DESCRIPTION
## Summary

- preserve the nonce-only restart authorization model introduced in #162
- include exact parked-run identities as a protocol-v1 compatibility field for supervisors baked before that simplification
- cover successful and failed drains so the handoff always publishes the run list it actually received

## Problem

A platform-only update can load the nonce-only client from #162 while the running container still has the exact-run supervisor introduced by #157. The older frozen supervisor requires a `runs` field before it accepts the restart intent, while the newer client stopped sending one. The restart still happens, but the next boot receives no acknowledgement, so an opted-in chat falls back to manual Resume.

## Fix

Keep `runs` as an additive protocol-v1 compatibility field. Older supervisors validate and preserve it; newer supervisors ignore the extra field and continue attesting only the one-shot restart nonce. Application-side authorization remains the simplified nonce model, so this does not restore the protocol complexity removed by #162.

## Validation

- focused restart, ledger, drain, crash-recovery, and park suite: 102 passed
- direct handoff through the older frozen exact-run supervisor: passed
- full backend run: 2,932 passed, 1 skipped; seven unrelated environment failures were limited to unchanged frontend-watcher/version tests in the isolated worktree (missing frontend dependency and root-owned build sentinel)
- Python compilation and canonical diff check: passed