### PR TITLE
Batch platform updates before one restart

### DIFF
--- a/frontend/src/components/SettingsView/SettingsView.css
+++ b/frontend/src/components/SettingsView/SettingsView.css
@@ -284,6 +284,18 @@
   min-width: 0;
 }
 
+/* A staged update is not a dead end: the owner can check/review another release
+   and still restart once. Keep both choices together, with the batching action
+   first when another release exists and the restart action visually primary
+   when there is nothing else waiting. */
+.settings__update-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
 /* The build sha as a quiet, monospaced identity line — tabular glyphs make a
    hex sha read AS a build id rather than stray text. */
 .settings__build {
@@ -488,6 +500,16 @@
   .settings__row {
     flex-wrap: wrap;
     gap: 8px;
+  }
+
+  .settings__update-actions {
+    width: 100%;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .settings__update-actions .settings__btn {
+    width: 100%;
   }
 }
 

--- a/frontend/src/components/SettingsView/SettingsView.jsx
+++ b/frontend/src/components/SettingsView/SettingsView.jsx
@@ -7,6 +7,10 @@ import Sun from 'lucide-react/dist/esm/icons/sun.mjs'
 import { api, clearQueryCache, clearToken } from '../../api/client.js'
 import { authQueries, modelQueries, settingsQueries, themeQueries, versionQueries } from '../../hooks/queries.js'
 import { platformVersionIdentity } from '../../lib/platformVersionIdentity.js'
+import {
+  platformStatusFromApply,
+  platformUpdateStatusLabel,
+} from '../../lib/platformUpdateState.js'
 import { settleBackgroundAgentSave } from '../../lib/backgroundAgentSave.js'
 import {
   PROVIDER_AVAILABILITY_PHASE,
@@ -60,32 +64,6 @@ const FALLBACK_MODEL_ROWS = {
 const DEFAULT_BACKGROUND_MODELS = {
   claude: 'claude-opus-4-8',
   codex: 'gpt-5.6-terra',
-}
-
-// POST /platform/apply is the authoritative outcome of the mutation it just
-// performed. Project that result into the status shape immediately so a failed
-// follow-up GET /status cannot leave Settings claiming the old state. A fresh
-// successful status response still replaces this fallback in refreshPlatform.
-function platformStatusFromApply(previous, result) {
-  const state = result.state
-  const upstream = result.upstream_commit || previous?.recorded_upstream_sha || null
-  const clean = state === 'restart_needed' || state === 'up_to_date'
-  return {
-    ...(previous || {}),
-    state,
-    available: state === 'rolled_back',
-    needs_restart: state === 'restart_needed' || !!result.needs_restart,
-    current_build_sha: previous?.current_build_sha || null,
-    recorded_upstream_sha: upstream,
-    contained_upstream_sha: clean
-      ? (result.upstream_commit || previous?.contained_upstream_sha || null)
-      : (previous?.contained_upstream_sha || null),
-    seed_required: false,
-    conflict_paths: Array.isArray(result.conflict_paths)
-      ? result.conflict_paths
-      : [],
-    conflict_chat_id: state === 'conflict' ? (result.chat_id || null) : null,
-  }
 }
 
 function defaultEffort(provider) {
@@ -367,9 +345,10 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
   // it so the owner reviews the incoming changes before applying, rather than
   // Apply firing on the first click.
   const [reviewOpen, setReviewOpen] = useState(false)
-  // Every update-row action occupies the same conditional slot. Keep one ref
-  // on that slot so closing the review can focus the live replacement button
-  // after refreshPlatform swaps Review for Restart/Resolve/Check.
+  // Keep one ref on the recommended next action so closing the review can
+  // focus its live replacement. A restart-pending row can now have TWO actions
+  // (check/review another release + restart), so this is no longer a single
+  // conditional action slot.
   const platformActionRef = useRef(null)
   // 'idle' | 'checking' | 'checked' | 'error' — the "Check for updates" button
   // asks the service worker to re-check cached frontend assets and re-reads
@@ -916,6 +895,7 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
   async function checkForUpdates() {
     if (updatePhase === 'checking') return
     setUpdatePhase('checking')
+    let freshPlatform = null
     const frontendP = (async () => {
       if ('serviceWorker' in navigator) {
         const reg = await navigator.serviceWorker.getRegistration()
@@ -936,10 +916,19 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
       // resolved probe as success, so a swallowed !ok let updateCheckOutcome
       // report "No updates found" on a real 500 (feature 20).
       if (!res.ok) throw new Error(`platform check failed: ${res.status}`)
-      setPlatform(await res.json())
+      freshPlatform = await res.json()
+      setPlatform(freshPlatform)
     })()
     const results = await Promise.allSettled([frontendP, platformP])
     setUpdatePhase(updateCheckOutcome(results))
+    // Discovering an update replaces the focused Check button with Review.
+    // Carry focus across that state transition instead of dropping keyboard
+    // users back onto the page body.
+    if (freshPlatform?.available) {
+      requestAnimationFrame(() => {
+        platformActionRef.current?.focus({ preventScroll: true })
+      })
+    }
   }
 
   // Reload onto the FRESH service worker so the new precache — including the
@@ -1486,16 +1475,12 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
           )}
         </section>
 
-        {/* ONE honest "Möbius" update surface. Folds platform availability,
-            conflict repair, and restart-to-finish into a single row: one status
-            line, one action. Priority: an in-progress conflict, then a pending
-            restart, then an available update, then up to date. Per-layer
-            mechanics stay invisible (the SW + platform_update.py). Always
-            renders (it carries the Möbius build identity), so there is no second
-            surface. The action slot holds exactly one contextual button; when
-            up to date that button is an explicit "Check for updates" (git fetch
-            + SW re-check) with its own "Checking…" text — it never mutates the
-            status label beside it. */}
+        {/* ONE honest "Möbius" update surface. Restart readiness and update
+            availability are independent: once an update is staged, the owner
+            can still check for or review a newer release and fold it into the
+            SAME eventual restart. A conflict remains the sole blocking state.
+            Per-layer mechanics stay invisible (the SW + platform_update.py).
+            The row always carries the current build identity. */}
         <section className="settings__section settings__section--compact">
           <h2 className="settings__section-title">Möbius</h2>
           <div className="settings__row settings__row--top">
@@ -1503,15 +1488,7 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
               <StatusDot
                 color={platformConflict || platformRolledBack || platformRestart || updateAvailable ? '--accent' : '--green'}
               >
-                {platformConflict
-                  ? 'Update blocked'
-                  : platformRolledBack
-                    ? 'Update needs repair'
-                    : platformRestart
-                      ? 'Restart to finish'
-                      : updateAvailable
-                        ? 'New update available'
-                        : 'Up to date'}
+                {platformUpdateStatusLabel(platform)}
               </StatusDot>
               {mobiusVersion.primarySha && (
                 <p className="settings__build">
@@ -1538,19 +1515,44 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
                 </button>
               ) : null
             ) : platformRestart ? (
-              <button
-                ref={platformActionRef}
-                className="settings__btn settings__btn--sm settings__btn--nowrap"
-                type="button"
-                onClick={restartToFinish}
-                disabled={platformPhase === 'restarting'}
+              <div
+                className="settings__update-actions"
+                role="group"
+                aria-label="Update ready actions"
               >
-                {/* "Restart to finish", not bare "Restart" — the Server section's
-                    standalone "Restart" sits in the same view, so the word
-                    "Restart" must mean exactly one thing. This one completes a
-                    pending update; the label says so. */}
-                {platformPhase === 'restarting' ? 'Restarting…' : 'Restart to finish'}
-              </button>
+                {updateAvailable ? (
+                  <button
+                    ref={platformActionRef}
+                    className="settings__btn settings__btn--sm settings__btn--nowrap"
+                    type="button"
+                    onClick={openUpdateReview}
+                    disabled={mobiusUpdating || platformPhase !== 'idle'}
+                  >
+                    {mobiusUpdating ? 'Updating…' : 'Review update'}
+                  </button>
+                ) : (
+                  <button
+                    className="settings__btn settings__btn--outline settings__btn--sm settings__btn--nowrap"
+                    type="button"
+                    onClick={checkForUpdates}
+                    disabled={updatePhase === 'checking' || platformPhase !== 'idle'}
+                  >
+                    {updatePhase === 'idle' ? 'Check for more' : checkUpdatesLabel}
+                  </button>
+                )}
+                <button
+                  ref={updateAvailable ? null : platformActionRef}
+                  className={`settings__btn settings__btn--sm settings__btn--nowrap${updateAvailable ? ' settings__btn--outline' : ''}`}
+                  type="button"
+                  onClick={restartToFinish}
+                  disabled={platformPhase !== 'idle' || updatePhase === 'checking'}
+                >
+                  {/* This completes every release staged since the last boot.
+                      A second update joins this same restart instead of forcing
+                      an intermediate one. */}
+                  {platformPhase === 'restarting' ? 'Restarting…' : 'Restart to finish'}
+                </button>
+              </div>
             ) : updateAvailable ? (
               <button
                 ref={platformActionRef}

--- a/frontend/src/lib/__tests__/platformUpdateState.test.js
+++ b/frontend/src/lib/__tests__/platformUpdateState.test.js
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  platformStatusFromApply,
+  platformUpdateStatusLabel,
+} from '../platformUpdateState.js'
+
+test('a clean apply consumes the reviewed target but preserves restart readiness', () => {
+  const projected = platformStatusFromApply(
+    {
+      state: 'available',
+      available: true,
+      needs_restart: false,
+      current_build_sha: 'served',
+      contained_upstream_sha: 'before',
+    },
+    {
+      state: 'restart_needed',
+      needs_restart: true,
+      upstream_commit: 'applied',
+    },
+  )
+
+  assert.equal(projected.available, false)
+  assert.equal(projected.needs_restart, true)
+  assert.equal(projected.contained_upstream_sha, 'applied')
+})
+
+test('a failed newer release does not forget an earlier staged update', () => {
+  const projected = platformStatusFromApply(
+    {
+      state: 'restart_needed',
+      available: true,
+      needs_restart: true,
+      current_build_sha: 'served',
+      contained_upstream_sha: 'staged',
+    },
+    {
+      state: 'rolled_back',
+      needs_restart: false,
+      upstream_commit: 'newer',
+    },
+  )
+
+  assert.equal(projected.available, true)
+  assert.equal(projected.needs_restart, true)
+  assert.equal(projected.contained_upstream_sha, 'staged')
+})
+
+test('update-row copy represents restart and availability independently', () => {
+  assert.equal(
+    platformUpdateStatusLabel({
+      state: 'restart_needed',
+      needs_restart: true,
+      available: false,
+    }),
+    'Ready to restart',
+  )
+  assert.equal(
+    platformUpdateStatusLabel({
+      state: 'restart_needed',
+      needs_restart: true,
+      available: true,
+    }),
+    'More updates available',
+  )
+  assert.equal(
+    platformUpdateStatusLabel({
+      state: 'available',
+      needs_restart: false,
+      available: true,
+    }),
+    'New update available',
+  )
+})
+
+test('blocking and repair states keep priority over batching copy', () => {
+  assert.equal(
+    platformUpdateStatusLabel({
+      state: 'conflict',
+      needs_restart: true,
+      available: true,
+    }),
+    'Update blocked',
+  )
+  assert.equal(
+    platformUpdateStatusLabel({
+      state: 'rolled_back',
+      needs_restart: true,
+      available: true,
+    }),
+    'Update needs repair',
+  )
+})

--- a/frontend/src/lib/__tests__/platformUpdateState.test.js
+++ b/frontend/src/lib/__tests__/platformUpdateState.test.js
@@ -47,6 +47,31 @@ test('a failed newer release does not forget an earlier staged update', () => {
   assert.equal(projected.contained_upstream_sha, 'staged')
 })
 
+test('a conflicting newer release also preserves an earlier staged restart', () => {
+  const projected = platformStatusFromApply(
+    {
+      state: 'restart_needed',
+      available: true,
+      needs_restart: true,
+      current_build_sha: 'served',
+      contained_upstream_sha: 'staged',
+    },
+    {
+      state: 'conflict',
+      needs_restart: false,
+      upstream_commit: 'newer',
+      conflict_paths: ['frontend/src/example.js'],
+      chat_id: 'resolver-chat',
+    },
+  )
+
+  assert.equal(projected.available, false)
+  assert.equal(projected.needs_restart, true)
+  assert.equal(projected.contained_upstream_sha, 'staged')
+  assert.deepEqual(projected.conflict_paths, ['frontend/src/example.js'])
+  assert.equal(projected.conflict_chat_id, 'resolver-chat')
+})
+
 test('update-row copy represents restart and availability independently', () => {
   assert.equal(
     platformUpdateStatusLabel({

--- a/frontend/src/lib/__tests__/updateReviewModal.test.js
+++ b/frontend/src/lib/__tests__/updateReviewModal.test.js
@@ -7,6 +7,7 @@ const read = relative => readFileSync(new URL(relative, import.meta.url), 'utf8'
 const modal = read('../../components/SettingsView/UpdateReviewModal.jsx')
 const modalCss = read('../../components/SettingsView/UpdateReviewModal.css')
 const settingsView = read('../../components/SettingsView/SettingsView.jsx')
+const updateState = read('../platformUpdateState.js')
 const diffView = read('../../components/DiffView/DiffView.jsx')
 const diffStyles = read('../../components/DiffView/styles.js')
 
@@ -38,10 +39,10 @@ test('apply outcomes close only for explicit clean states and preserve actionabl
 })
 
 test('the apply response is a truthful fallback when status refresh fails', () => {
-  assert.match(settingsView, /function platformStatusFromApply\(previous, result\)/)
-  assert.match(settingsView, /available: state === 'rolled_back'/)
-  assert.match(settingsView, /conflict_paths: Array\.isArray\(result\.conflict_paths\)/)
-  assert.match(settingsView, /conflict_chat_id: state === 'conflict' \? \(result\.chat_id \|\| null\) : null/)
+  assert.match(updateState, /function platformStatusFromApply\(previous, result\)/)
+  assert.match(updateState, /available: state === 'rolled_back'/)
+  assert.match(updateState, /conflict_paths: Array\.isArray\(result\.conflict_paths\)/)
+  assert.match(updateState, /conflict_chat_id: state === 'conflict' \? \(result\.chat_id \|\| null\) : null/)
   assert.match(
     settingsView,
     /setPlatform\(current => platformStatusFromApply\(current, body\)\)[\s\S]*await refreshPlatform\(\)/,
@@ -59,6 +60,14 @@ test('result and close focus always land on live tabbable controls', () => {
   assert.doesNotMatch(modal, /resultHeadingRef|tabIndex=\{blocked/)
   assert.match(settingsView, /ref=\{platformActionRef\}/)
   assert.match(settingsView, /requestAnimationFrame\(\(\) => \{[\s\S]*platformActionRef\.current\?\.focus/)
+})
+
+test('a newly discovered update inherits focus from the replaced check action', () => {
+  assert.match(settingsView, /freshPlatform = await res\.json\(\)/)
+  assert.match(
+    settingsView,
+    /if \(freshPlatform\?\.available\) \{[\s\S]*requestAnimationFrame\(\(\) => \{[\s\S]*platformActionRef\.current\?\.focus/,
+  )
 })
 
 test('DiffView stays generic, semantic, and keyboard-scrollable', () => {

--- a/frontend/src/lib/platformUpdateState.js
+++ b/frontend/src/lib/platformUpdateState.js
@@ -1,0 +1,50 @@
+/**
+ * Pure state projection for the combined platform-update Settings row.
+ *
+ * Restart readiness and update availability are deliberately independent:
+ * another reviewed release can be staged while one restart is already pending.
+ */
+
+export function platformStatusFromApply(previous, result) {
+  const state = result.state
+  const upstream = result.upstream_commit || previous?.recorded_upstream_sha || null
+  const clean = state === 'restart_needed' || state === 'up_to_date'
+  const rolledBackOntoStagedUpdate = (
+    state === 'rolled_back' && !!previous?.needs_restart
+  )
+  return {
+    ...(previous || {}),
+    state,
+    // A clean apply consumed the exact reviewed target. Do not briefly carry
+    // the OLD `available:true` through the render before the status refresh:
+    // the batched-update UI would otherwise offer the update that just applied.
+    available: state === 'rolled_back',
+    needs_restart:
+      state === 'restart_needed'
+      || !!result.needs_restart
+      || rolledBackOntoStagedUpdate,
+    current_build_sha: previous?.current_build_sha || null,
+    recorded_upstream_sha: upstream,
+    contained_upstream_sha: clean
+      ? (result.upstream_commit || previous?.contained_upstream_sha || null)
+      : (previous?.contained_upstream_sha || null),
+    seed_required: false,
+    conflict_paths: Array.isArray(result.conflict_paths)
+      ? result.conflict_paths
+      : [],
+    conflict_chat_id: state === 'conflict' ? (result.chat_id || null) : null,
+  }
+}
+
+export function platformUpdateStatusLabel(platform) {
+  const state = platform?.state
+  const needsRestart = !!platform?.needs_restart
+  const available = !!platform?.available
+
+  if (state === 'conflict') return 'Update blocked'
+  if (state === 'rolled_back') return 'Update needs repair'
+  if (needsRestart && available) return 'More updates available'
+  if (needsRestart) return 'Ready to restart'
+  if (available) return 'New update available'
+  return 'Up to date'
+}

--- a/frontend/src/lib/platformUpdateState.js
+++ b/frontend/src/lib/platformUpdateState.js
@@ -9,8 +9,9 @@ export function platformStatusFromApply(previous, result) {
   const state = result.state
   const upstream = result.upstream_commit || previous?.recorded_upstream_sha || null
   const clean = state === 'restart_needed' || state === 'up_to_date'
-  const rolledBackOntoStagedUpdate = (
-    state === 'rolled_back' && !!previous?.needs_restart
+  const failedOntoStagedUpdate = (
+    (state === 'rolled_back' || state === 'conflict')
+    && !!previous?.needs_restart
   )
   return {
     ...(previous || {}),
@@ -22,7 +23,7 @@ export function platformStatusFromApply(previous, result) {
     needs_restart:
       state === 'restart_needed'
       || !!result.needs_restart
-      || rolledBackOntoStagedUpdate,
+      || failedOntoStagedUpdate,
     current_build_sha: previous?.current_build_sha || null,
     recorded_upstream_sha: upstream,
     contained_upstream_sha: clean

--- a/tests/platform-update-modal.spec.mjs
+++ b/tests/platform-update-modal.spec.mjs
@@ -362,7 +362,7 @@ test('a clean apply remains truthful when every follow-up status read fails', as
 
   await expect(review).toHaveCount(0)
   await expect(
-    page.locator('.settings__update').getByText('Restart to finish', { exact: true }),
+    page.locator('.settings__update').getByText('Ready to restart', { exact: true }),
   ).toBeVisible()
   await expect(page.getByRole('button', { name: 'Restart to finish' })).toBeFocused()
 })

--- a/tests/platform-update-modal.spec.mjs
+++ b/tests/platform-update-modal.spec.mjs
@@ -12,7 +12,7 @@ const BASE = process.env.MOBIUS_URL || 'http://localhost:8001'
 
 test.use({ serviceWorkers: 'block' })
 
-function platformStatus(state = 'available') {
+function platformStatus(state = 'available', overrides = {}) {
   return {
     state,
     available: state === 'available' || state === 'rolled_back',
@@ -23,6 +23,7 @@ function platformStatus(state = 'available') {
     seed_required: false,
     conflict_paths: state === 'conflict' ? ['frontend/src/example.js'] : [],
     conflict_chat_id: null,
+    ...overrides,
   }
 }
 
@@ -59,7 +60,7 @@ async function mockPlatform(page, stateRef) {
     return route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify(platformStatus(stateRef.current)),
+      body: JSON.stringify(platformStatus(stateRef.current, stateRef.overrides)),
     })
   })
   await page.route('**/api/platform/update-preview', route => route.fulfill({
@@ -140,6 +141,105 @@ test('a clean apply closes the review and exposes the restart step', async ({ pa
   const restart = page.getByRole('button', { name: 'Restart to finish' })
   await expect(restart).toBeVisible()
   await expect(restart).toBeFocused()
+})
+
+test('a staged update can check for and review another release before one restart', async ({ page }) => {
+  const state = {
+    current: 'restart_needed',
+    overrides: { available: false, needs_restart: true },
+  }
+  await mockPlatform(page, state)
+  await page.route('**/api/platform/check', route => {
+    state.overrides = { available: true, needs_restart: true }
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(platformStatus('restart_needed', state.overrides)),
+    })
+  })
+  await page.route('**/api/platform/apply', route => {
+    state.overrides = { available: false, needs_restart: true }
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        state: 'restart_needed',
+        needs_restart: true,
+        upstream_commit: preview.target_sha,
+        merge_commit: '3333333333333333333333333333333333333333',
+        conflict_paths: [],
+        chat_id: null,
+      }),
+    })
+  })
+
+  await page.setViewportSize({ width: 900, height: 800 })
+  await page.goto(BASE, { waitUntil: 'domcontentloaded' })
+  await page.waitForFunction(
+    () => !!(document.querySelector('.chat__empty-wrap')
+      || document.querySelector('.chat__scroll')
+      || document.querySelector('.chat__form')),
+    { timeout: 10000 },
+  )
+  const navigationToggle = page.getByLabel('Toggle navigation')
+  if (await navigationToggle.getAttribute('aria-expanded') !== 'true') {
+    await navigationToggle.click()
+  }
+  await page.getByRole('button', { name: 'Settings', exact: true }).click()
+
+  await expect(page.getByText('Ready to restart', { exact: true })).toBeVisible()
+  const check = page.getByRole('button', { name: 'Check for more' })
+  await expect(check).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Restart to finish' })).toBeVisible()
+  await check.click()
+
+  await expect(page.getByText('More updates available', { exact: true })).toBeVisible()
+  const review = page.getByRole('button', { name: 'Review update' })
+  await expect(review).toBeVisible()
+  await expect(review).toBeFocused()
+  await expect(page.getByRole('button', { name: 'Restart to finish' })).toBeVisible()
+  await review.click()
+
+  const dialog = page.getByRole('dialog', { name: 'Review update' })
+  await expect(dialog).toBeVisible()
+  await dialog.getByRole('button', { name: 'Apply update' }).click()
+
+  await expect(dialog).toHaveCount(0)
+  await expect(page.getByText('Ready to restart', { exact: true })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Check for more' })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Restart to finish' })).toBeFocused()
+})
+
+test('staged-update actions stack without overflow in a narrow settings pane', async ({ page }) => {
+  const state = {
+    current: 'restart_needed',
+    overrides: { available: true, needs_restart: true },
+  }
+  await mockPlatform(page, state)
+
+  await page.setViewportSize({ width: 360, height: 780 })
+  await page.goto(BASE, { waitUntil: 'domcontentloaded' })
+  await page.waitForFunction(
+    () => !!(document.querySelector('.chat__empty-wrap')
+      || document.querySelector('.chat__scroll')
+      || document.querySelector('.chat__form')),
+    { timeout: 10000 },
+  )
+  const navigationToggle = page.getByLabel('Toggle navigation')
+  if (await navigationToggle.getAttribute('aria-expanded') !== 'true') {
+    await navigationToggle.click()
+  }
+  await page.getByRole('button', { name: 'Settings', exact: true }).click()
+
+  const actions = page.getByRole('group', { name: 'Update ready actions' })
+  await expect(actions).toBeVisible()
+  const box = await actions.boundingBox()
+  const viewport = page.viewportSize()
+  expect(box).not.toBeNull()
+  expect(box.x).toBeGreaterThanOrEqual(0)
+  expect(box.x + box.width).toBeLessThanOrEqual(viewport.width)
+  await expect(page.getByRole('button', { name: 'Review update' })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Restart to finish' })).toBeVisible()
 })
 
 test('a blocked apply stays open, focuses its result, and shows resolver failures', async ({ page }) => {


### PR DESCRIPTION
## Summary

- keep update discovery and review available while a restart is already pending
- let newer releases join the same pending restart instead of forcing an intermediate restart
- keep status copy, responsive actions, and keyboard focus coherent across each transition

## Testing

- `npm test`
- `npm run build`
- added Playwright coverage for batching and narrow Settings layouts
- manually verified the pending-restart flow at desktop and mobile widths