### PR TITLE
fix(shell): normalize pane assembly velocity

### DIFF
--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -543,8 +543,8 @@ test('entry assembles over a stationary Standard surface, compositor-only, insta
   assert.match(dealIn, /translate3d\(var\(--mode-offset-x\), var\(--mode-offset-y\), 0\)/)
   assert.doesNotMatch(dealIn, /opacity:/)
   assert.doesNotMatch(dealIn, /box-shadow|border-radius|filter|clip/)
-  assert.match(css, /--ease-mode-arrive:\s*cubic-bezier\(0\.25, 1, 0\.5, 1\)/,
-    'entry keeps readable quart-out travel without braking into the shared seam')
+  assert.match(css, /--ease-mode-arrive:\s*cubic-bezier\(0\.33, 1, 0\.68, 1\)/,
+    'entry keeps readable cubic-out travel without braking into the shared seam')
   assert.match(css, /--ease-mode-promote:\s*cubic-bezier\(0\.2, 0\.82, 0\.2, 1\)/,
     'the accepted exit promotion curve stays unchanged')
   // The old dead .workspace--resizing selector is gone entirely.
@@ -1021,7 +1021,7 @@ test('N1: dead exit-presentation plumbing is removed', () => {
   assert.match(css, /--ease-mode-chrome: cubic-bezier/)
   assert.match(css, /--ease-mode-promote: cubic-bezier/)
   assert.match(css, /shell-mode-chrome-out 90ms var\(--ease-mode-chrome\)/)
-  assert.match(css, /shell-mode-chrome-in 70ms var\(--ease-mode-chrome\)[\s\S]*?calc\(var\(--mode-total, 210ms\) - 70ms\) both/)
+  assert.match(css, /shell-mode-chrome-in 70ms var\(--ease-mode-chrome\)[\s\S]*?calc\(var\(--mode-total, 240ms\) - 70ms\) both/)
   assert.match(css, /shell-mode-strip-clear 100ms var\(--ease-mode-chrome\)/)
   assert.match(css, /shell-mode-promote\s*\n?\s*var\(--mode-duration\)\s*\n?\s*var\(--ease-mode-promote\)/)
   // The unused excludeChatId param is gone; the helper is now the New Chat request

--- a/frontend/src/components/Shell/__tests__/workspaceView.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceView.test.js
@@ -628,6 +628,37 @@ test('four-pane assemble/scatter preserves all four outer-edge vectors', () => {
   }
 })
 
+test('uneven entry normalizes pane velocity and lands every edge on one frame', () => {
+  // A deliberately asymmetric tree reproduces the production complaint: without
+  // distance-aware timing, the shortest and longest edge vectors differ by almost
+  // 2× while sharing one duration, so one pane visibly rushes into the seam.
+  let ws = paneModel.seedFromFlatTabs([makeTab('chat', '1')])
+  ws = paneModel.splitPaneWithTab(ws, makeTab('chat', '2'), {
+    paneId: ws.focusedPaneId, edge: 'right',
+  })
+  const rightId = paneModel.paneOf(ws, 'chat:2').id
+  ws = paneModel.splitPaneWithTab(ws, makeTab('chat', '3'), {
+    paneId: rightId, edge: 'bottom',
+  })
+  ws = paneModel.setRatio(ws, ws.layout.id, 0.7)
+  ws = paneModel.setRatio(ws, ws.layout.b.id, 0.25)
+  ws = { ...ws, singleScreen: { kind: 'chat', id: 'ghost' } }
+
+  const plan = deriveEnterPlan({ workspace: ws, projection: project(ws), contentRect: CONTENT })
+  assert.equal(plan.totalMs, MODE_MOTION.enterItemMs)
+  assert.ok(plan.participants.some(p => p.delayMs > 0),
+    'a shorter trip waits offscreen instead of racing a longer trip')
+  assert.ok(plan.participants.every(
+    p => p.delayMs + p.durationMs === MODE_MOTION.enterItemMs,
+  ), 'every pane lands on the same terminal frame')
+
+  const speeds = plan.participants.map((p) => (
+    Math.hypot(p.offset.x, p.offset.y) / p.durationMs
+  ))
+  assert.ok(Math.max(...speeds) / Math.min(...speeds) < 1.15,
+    'average pane velocities stay perceptually aligned despite asymmetric geometry')
+})
+
 test('N1: MODE_MOTION drops the unused chromeMs constant', () => {
   assert.equal(MODE_MOTION.chromeMs, undefined)
   // The live timings the plan builders use are still present.

--- a/frontend/src/components/Shell/workspace.css
+++ b/frontend/src/components/Shell/workspace.css
@@ -14,9 +14,9 @@
    workspaceView.js (MODE_MOTION / deriveExit·EnterPlan). Shell writes each
    participant's duration/delay and projection-derived transform variables inline. */
 .shell {
-  /* Quart-out keeps long edge travel readable across the beat instead of spending
-     most of the distance in its first few frames and braking into the shared seam. */
-  --ease-mode-arrive: cubic-bezier(0.25, 1, 0.5, 1);
+  /* Cubic-out keeps long edge travel readable without the ballistic first frames
+     that made panes appear to brake into the shared seam. */
+  --ease-mode-arrive: cubic-bezier(0.33, 1, 0.68, 1);
   --ease-mode-leave: cubic-bezier(0.4, 0, 0.7, 0.2);
   /* Chrome (dividers + strips) leads the panes with a faster, front-loaded curve so
      structure simplifies first (exit) / resolves after the focused card (entry). */
@@ -162,7 +162,7 @@
 .shell--builder-entering .workspace__divider {
   animation:
     shell-mode-chrome-in 70ms var(--ease-mode-chrome)
-    calc(var(--mode-total, 210ms) - 70ms) both;
+    calc(var(--mode-total, 240ms) - 70ms) both;
 }
 @keyframes shell-mode-chrome-out { from { opacity: 1; } to { opacity: 0; } }
 @keyframes shell-mode-chrome-in { from { opacity: 0; } to { opacity: 1; } }

--- a/frontend/src/components/Shell/workspaceView.js
+++ b/frontend/src/components/Shell/workspaceView.js
@@ -59,10 +59,12 @@ export function projectFocusedPane(baseProjection, workspace, paneId, contentRec
 // Timing (ms). Constants live here, NOT in the machine, so the reconcile clock
 // (INV 14) and the missing-target fallback (INV 13) reason about the plan's own
 // totalMs rather than a fixed per-phase maximum. Mode changes are intentionally one
-// short beat: every pane moves together, using only compositor transforms + opacity.
-// There is no per-pane stagger or second destination phase to make the owner wait.
+// short beat using only compositor transforms + opacity. Entry participants may
+// start at different instants to normalize unequal travel, but land together; there
+// is no pane-count stagger or second destination phase to make the owner wait.
 export const MODE_MOTION = Object.freeze({
-  enterItemMs: 210,
+  enterItemMs: 240,
+  enterMinItemMs: 120,
   exitItemMs: 180,
   promoteMs: 210,
   logoReleaseMs: 90,
@@ -337,23 +339,38 @@ export function deriveEnterPlan(input) {
   if (leaves.length === 0) return null
   const { target, immersiveInstant } = classifyExitDestination(input)
   if (immersiveInstant) return null
-  const duration = MODE_MOTION.enterItemMs
   const destinationRect = { x: 0, y: 0, w: contentRect.w, h: contentRect.h }
   const participants = []
   const completionNames = new Set()
   const underlayKey = target
 
-  for (const l of leaves) {
-    if (l.activeKey === target) continue
+  const incoming = leaves
+    .filter(l => l.activeKey !== target)
+    .map(l => ({ leaf: l, offset: edgeOffset(l.rect, contentRect, l.motionRect) }))
+  if (incoming.length === 0) return null
+  const maxDistance = Math.max(...incoming.map(({ offset }) => Math.hypot(offset.x, offset.y)))
+
+  for (const { leaf: l, offset } of incoming) {
+    // Projection-derived travel can differ by nearly 2× in an uneven three-pane
+    // tree. Start shorter trips later and give them proportionally less time so
+    // every pane travels at the same perceived speed and lands on the same frame.
+    // The floor prevents a very small pane from becoming a one-frame flash.
+    const distance = Math.hypot(offset.x, offset.y)
+    const proportionalMs = maxDistance > 0
+      ? Math.round(MODE_MOTION.enterItemMs * distance / maxDistance)
+      : MODE_MOTION.enterItemMs
+    const durationMs = Math.min(
+      MODE_MOTION.enterItemMs,
+      Math.max(MODE_MOTION.enterMinItemMs, proportionalMs),
+    )
     participants.push({
       key: l.activeKey, paneId: l.paneId, motion: 'deal-in',
-      delayMs: 0,
-      durationMs: duration,
-      offset: edgeOffset(l.rect, contentRect, l.motionRect),
+      delayMs: MODE_MOTION.enterItemMs - durationMs,
+      durationMs,
+      offset,
     })
     completionNames.add(DEAL_IN_NAME)
   }
-  if (participants.length === 0) return null
   const totalMs = participants.reduce((m, p) => Math.max(m, p.delayMs + p.durationMs), 0)
   return {
     kind: 'enter',

--- a/tests/mode-transition.spec.mjs
+++ b/tests/mode-transition.spec.mjs
@@ -71,6 +71,22 @@ function twoPaneBuilder(slot) {
   return ws // viewMode stays 'panes' (builder)
 }
 
+// An intentionally asymmetric three-pane tree. Its natural edge vectors differ
+// enough to expose same-duration entry as visibly different pane velocities.
+function unevenThreePaneBuilder(slot) {
+  let ws = paneModel.seedFromFlatTabs([{ kind: 'chat', id: 'aaa' }])
+  ws = paneModel.splitPaneWithTab(ws, tabModel.makeTab('chat', 'bbb'), {
+    paneId: ws.focusedPaneId, edge: 'right',
+  })
+  const rightId = paneModel.paneOf(ws, 'chat:bbb').id
+  ws = paneModel.splitPaneWithTab(ws, tabModel.makeTab('chat', 'ccc'), {
+    paneId: rightId, edge: 'bottom',
+  })
+  ws = paneModel.setRatio(ws, ws.layout.id, 0.7)
+  ws = paneModel.setRatio(ws, ws.layout.b.id, 0.25)
+  return paneModel.setSingleScreen(ws, slot)
+}
+
 // Frame-sample the exit beat: on every animation frame while .shell--builder-exiting
 // is present, record each motion wrapper's LAYOUT box (offset*, transform-independent)
 // + its computed transform + a stable node marker. Start this BEFORE triggering the
@@ -142,6 +158,8 @@ async function captureBeatPlan(page, rootClass) {
             motion: el.dataset.modeMotion,
             x: parseFloat(el.style.getPropertyValue('--mode-offset-x')) || 0,
             y: parseFloat(el.style.getPropertyValue('--mode-offset-y')) || 0,
+            duration: parseFloat(el.style.getPropertyValue('--mode-duration')) || 0,
+            delay: parseFloat(el.style.getPropertyValue('--mode-delay')) || 0,
           }))
         if (participants.length) {
           return {
@@ -453,6 +471,33 @@ test('v3 panes assemble over the stationary single screen from their correspondi
   expect(paint.paneFrames).toBeGreaterThan(2)
   expect(paint.minPaneOpacity, 'pane content never fades in over visible structure').toBeGreaterThan(0.99)
   expect(paint.earlyChromeOpacity, 'structure waits until pane content has arrived').toBeLessThan(0.05)
+  await expect.poll(() => modePhase(page), { timeout: 2000 }).toBe('idle')
+  await expect.poll(() => builderActive(page)).toBe(true)
+})
+
+test('uneven panes enter at one perceived velocity and land together', async ({ page }) => {
+  await bootSeededWorkspace(
+    page,
+    WIDE,
+    unevenThreePaneBuilder({ kind: 'chat', id: 'ghost' }),
+  )
+  await toggleMode(page)
+  await expect.poll(() => modePhase(page), { timeout: 2000 }).toBe('idle')
+  await expect.poll(() => builderActive(page)).toBe(false)
+
+  const sampler = captureBeatPlan(page, 'shell--builder-entering')
+  await page.waitForTimeout(30)
+  await toggleMode(page)
+  const r = await sampler
+
+  expect(r.participants).toHaveLength(3)
+  expect(r.participants.some(p => p.delay > 0),
+    'shorter vectors wait offscreen rather than rushing the seam').toBe(true)
+  const arrivals = r.participants.map(p => p.delay + p.duration)
+  expect(new Set(arrivals).size, 'all panes land on the same frame').toBe(1)
+  const speeds = r.participants.map(p => Math.hypot(p.x, p.y) / p.duration)
+  expect(Math.max(...speeds) / Math.min(...speeds),
+    'asymmetric panes keep a common average velocity').toBeLessThan(1.15)
   await expect.poll(() => modePhase(page), { timeout: 2000 }).toBe('idle')
   await expect.poll(() => builderActive(page)).toBe(true)
 })


### PR DESCRIPTION
## Summary
- derive pane-entry duration from each projection vector so uneven panes travel at a consistent perceived velocity
- hold shorter trips offscreen and synchronize every pane's landing frame
- soften only entry to a 240ms cubic-out beat; preserve the accepted exit/promote choreography exactly
- add unit and real-browser regression coverage for an asymmetric three-pane layout

## Why
A representative 70/30 three-pane tree currently gives its existing edge vectors the same 210ms duration even though they travel 472px, 761px, and 912px. That drives the panes at roughly 2,246–4,343px/s, so they appear to rush at different speeds and brake into one another at the seam. A curve-only change cannot correct that geometry-driven spread.

The new plan computes timing once when the transition is armed (at most four `Math.hypot` calls), performs no DOM reads or per-frame JS, and keeps all animation work on compositor transforms.

## Verification
- focused Shell motion/state tests: 159 passed
- full frontend library + hook suites passed
- production frontend build passed
- hosted E2E includes the new asymmetric-cadence contract
