### PR TITLE
fix(chat): terminate externally fatal writer

### DIFF
--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -2685,7 +2685,7 @@ class ChatWriterActor:
     return True
 
   def _go_fatal(self) -> None:
-    """Mark the actor fatal and fail every queued ack — under `_fatal_lock`.
+    """Mark the actor fatal, wake an idle consumer, and fail every queued ack.
 
     Holding the lock across set-fatal + drain serializes with `submit`,
     which checks `_fatal` and enqueues under the same lock.  So a
@@ -2696,6 +2696,12 @@ class ChatWriterActor:
     ack is the submitter's, already failed by submit or by being in
     `_pending`), so failing them is a harmless no-op.  Also fail any
     pending coalesced snapshots so their acks don't hang.
+
+    A caller outside the consumer thread must also wake a consumer blocked
+    in `Queue.get()`. Enqueue one private `DrainAndStop` AFTER the drain so
+    it cannot be removed by a concurrent `stop()`/fatal race and no command
+    can queue behind it once `_fatal` is set. Fatal paths running on the
+    consumer itself return directly from `_run`, so they need no marker.
 
     Ack resolution is hoisted OUT of both locks: the queue is fully drained
     (and `_pending` snapshotted) under the lock — preserving the
@@ -2713,6 +2719,11 @@ class ChatWriterActor:
         except queue.Empty:
           break
         drained.append(cmd.ack)
+      if (
+        self._thread is not None
+        and threading.current_thread() is not self._thread
+      ):
+        self._q.put(DrainAndStop())
     with self._pending_lock:
       pending = list(self._pending.values())
       self._pending.clear()

--- a/backend/tests/test_chat_writer.py
+++ b/backend/tests/test_chat_writer.py
@@ -476,6 +476,21 @@ def test_coalesced_commit_baseexception_resolves_originating_ack_and_goes_fatal(
     actor.stop(timeout=5)
 
 
+def test_external_fatal_wakes_idle_writer_thread():
+  """A fatal transition must not leave an idle consumer blocked in get()."""
+  actor = ChatWriterActor(session_factory=lambda: _RecordingSession([]))
+  actor.start()
+  thread = actor._thread
+  try:
+    # The barrier proves startup completed and the consumer reached its loop.
+    actor.submit(Barrier()).result(timeout=5)
+    actor._go_fatal()
+    thread.join(timeout=1)
+    assert not thread.is_alive()
+  finally:
+    actor.stop(timeout=0.1)
+
+
 # -- CRITICAL 2: a stale pre-fence marker must not commit a post-fence snapshot
 def test_stale_marker_does_not_reorder_finalize_before_post_fence_snapshot():
   # Interleaving: submit S1 (marker M1 queued) -> consumer dequeues M1 but


### PR DESCRIPTION
## Summary
- make an externally triggered fatal transition wake an idle writer consumer after draining queued work
- preserve the existing worker-originated fatal exit and normal FIFO shutdown paths
- add a regression that proves an idle fatal writer thread terminates instead of surviving teardown

## Why
`_go_fatal()` failed queued acknowledgements but left an idle consumer blocked in `Queue.get()`. `stop_writer(timeout=5)` then waited the full timeout and discarded the singleton while its daemon thread and DB session remained alive. Three backend tests each paid that five-second teardown penalty, and runtime recovery could briefly accumulate orphaned writer resources.

The fatal transition now owns its termination invariant. When fatal is triggered outside the consumer thread, it enqueues one private stop marker after the queue drain while holding the same producer gate. That ordering also closes the stop/fatal race where fatal handling could drain the normal shutdown marker.

## Validation
- 47 focused writer, supervisor, readiness, unavailable-send, and fatal-reconciliation tests pass
- observed affected fatal teardown: 0.05s maximum in the post-rebase run (previously 5.00s each)
- `git diff --check`