### PR TITLE
Fix pane handoff reliability and simplify pane chrome

### DIFF
--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -203,16 +203,21 @@ export async function apiFetch(path, options = {}) {
   )
 
   // Opt-in timeout: callers that must not hang forever (e.g. the background
-  // reconcile poll and the message fetch — see ChatView) pass `timeoutMs`.
-  // Existing callers omit it and keep the un-timed behaviour, so this can't
-  // regress a legitimately-slow endpoint. A caller-supplied `signal` wins.
+  // reconcile poll and message fetches — see ChatView) pass `timeoutMs`.
+  // Compose it with a caller-owned lifecycle signal instead of making the two
+  // mutually exclusive: a visible request is time-boxed, while hiding/unmounting
+  // its owner can still release the connection immediately.
   const { timeoutMs, ...fetchOptions } = options
   let signal = fetchOptions.signal
   let timeoutTimer
-  if (timeoutMs && !signal) {
+  if (timeoutMs) {
     const ctrl = new AbortController()
-    timeoutTimer = setTimeout(() => ctrl.abort(), timeoutMs)
-    signal = ctrl.signal
+    timeoutTimer = setTimeout(() => {
+      const error = new Error('Request timed out')
+      error.name = 'TimeoutError'
+      ctrl.abort(error)
+    }, timeoutMs)
+    signal = signal ? AbortSignal.any([signal, ctrl.signal]) : ctrl.signal
   }
 
   let res
@@ -221,8 +226,11 @@ export async function apiFetch(path, options = {}) {
   } catch (error) {
     // The request is evidence, not a verdict. Ask the shared reachability store
     // to verify promptly; its hysteresis still prevents one transient failure
-    // from flapping every retained chat offline.
-    void verifyConnectivity()
+    // from flapping every retained chat offline. A caller-owned lifecycle abort
+    // is not network evidence; checking connectivity for routine pane switches
+    // would add needless requests. Our deadline aborts with TimeoutError and does
+    // still enter the verification path.
+    if (error?.name !== 'AbortError') void verifyConnectivity()
     throw error
   } finally {
     if (timeoutTimer) clearTimeout(timeoutTimer)

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -107,6 +107,7 @@ let _isTouchPrimary = _touchMql?.matches ?? false
 _touchMql?.addEventListener('change', (e) => { _isTouchPrimary = e.matches })
 
 const STOP_RETRY_DELAYS_MS = [0, 250, 700, 1200]
+const CHAT_FETCH_TIMEOUT_MS = 15000
 
 function delay(ms) {
   return new Promise(resolve => setTimeout(resolve, ms))
@@ -986,7 +987,10 @@ export default function ChatView({
     if (sendingRef.current && !force) return
     const gen = fetchGenRef.current
     try {
-      const res = await apiFetch(`/chats/${chatId}?limit=20`, { timeoutMs: 15000 })
+      const res = await apiFetch(
+        `/chats/${chatId}?limit=20`,
+        { timeoutMs: CHAT_FETCH_TIMEOUT_MS },
+      )
       if (!res.ok) throw new Error(`CHAT_FETCH_FAILED_${res.status}`)
       const data = await res.json()
       if (chatIdStaleRef.current) return
@@ -1081,7 +1085,10 @@ export default function ChatView({
   const reconcileRuntimeState = useCallback(async () => {
     const gen = fetchGenRef.current
     try {
-      const res = await apiFetch(`/chats/${chatId}?limit=1`, { timeoutMs: 15000 })
+      const res = await apiFetch(
+        `/chats/${chatId}?limit=1`,
+        { timeoutMs: CHAT_FETCH_TIMEOUT_MS },
+      )
       const data = await jsonOrThrow(res, 'Runtime refresh failed')
       if (chatIdStaleRef.current) return
       if (fetchGenRef.current !== gen) return
@@ -1752,12 +1759,16 @@ export default function ChatView({
     // the pane's DOM identity.
     if (hidden) return
     let cancelled = false
+    const initialLoadController = new AbortController()
     chatIdStaleRef.current = false
     setLoadError(false)
     setInitialEntryPhase(cachedEntryPhase)
 
     const gen = fetchGenRef.current
-    apiFetch(`/chats/${chatId}?limit=20`)
+    apiFetch(`/chats/${chatId}?limit=20`, {
+      timeoutMs: CHAT_FETCH_TIMEOUT_MS,
+      signal: initialLoadController.signal,
+    })
       .then(r => {
         if (r.status === 404) throw new Error('CHAT_NOT_FOUND')
         if (!r.ok) throw new Error(`CHAT_LOAD_FAILED_${r.status}`)
@@ -1886,6 +1897,7 @@ export default function ChatView({
         // cleanup, so modeRef is captured for the chat we're leaving.)
       } catch {}
       cancelled = true
+      initialLoadController.abort()
       chatIdStaleRef.current = true
       loadingOlder.current = false
       disconnect()
@@ -1921,7 +1933,10 @@ export default function ChatView({
     // them to the bottom, undoing the pagination. Pagination leaves
     // them at the new anchor; the next gesture (or send) writes a
     // fresh mode.
-    apiFetch(`/chats/${chatId}?limit=20&before=${offset}`, { timeoutMs: 15000 })
+    apiFetch(
+      `/chats/${chatId}?limit=20&before=${offset}`,
+      { timeoutMs: CHAT_FETCH_TIMEOUT_MS },
+    )
       .then(r => jsonOrThrow(r, 'Earlier messages failed to load'))
       .then(data => {
         if (chatIdStaleRef.current) return
@@ -2680,7 +2695,7 @@ export default function ChatView({
     try {
       const res = await apiFetch(`/chats/${chatId}/pending/${encodeURIComponent(cid)}`, {
         method: 'DELETE',
-        timeoutMs: 15000,
+        timeoutMs: CHAT_FETCH_TIMEOUT_MS,
       })
       await jsonOrThrow(res, 'Queued-message cancellation failed')
     } catch {
@@ -2688,7 +2703,10 @@ export default function ChatView({
       // Read server truth, but restore only this operation's row so an older
       // response cannot overwrite unrelated queue mutations.
       try {
-        const res = await apiFetch(`/chats/${chatId}?limit=1`, { timeoutMs: 15000 })
+        const res = await apiFetch(
+          `/chats/${chatId}?limit=1`,
+          { timeoutMs: CHAT_FETCH_TIMEOUT_MS },
+        )
         const data = await jsonOrThrow(res, 'Queue refresh failed')
         const serverQueue = Array.isArray(data.pending_messages) ? data.pending_messages : []
         const serverIndex = serverQueue.findIndex(row => cidOf(row) === cid)

--- a/frontend/src/components/Shell/PaneStrip.jsx
+++ b/frontend/src/components/Shell/PaneStrip.jsx
@@ -9,11 +9,22 @@ import * as tabModel from './tabModel.js'
 import { STRIP_H, WORKSPACE_SPLITS_ENABLED } from './paneModel.js'
 
 // Each direction owns 40% of the one-shot cycle, so 1000/12 ms per clipped pixel
-// keeps travel at a readable 30px/s: longer titles take proportionally longer, not
-// move faster. The short 5% opening rest cannot make a running animation look dead
-// for almost nine seconds. Only extreme manual renames hit the resource-safety cap.
-const TITLE_CYCLE_MAX_MS = 32000
+// keeps travel at a readable 30px/s. The cycle runs once, returns to the beginning,
+// and stops; duration therefore scales with distance instead of making long manual
+// titles accelerate.
 const TITLE_CYCLE_MS_PER_PX = 1000 / 12
+
+function paneDomToken(value) {
+  return encodeURIComponent(String(value))
+}
+
+export function paneTabDomId(paneId, tabKey) {
+  return `pane-tab-${paneDomToken(paneId)}-${paneDomToken(tabKey)}`
+}
+
+export function panePanelDomId(paneId, tabKey) {
+  return `pane-panel-${paneDomToken(paneId)}-${paneDomToken(tabKey)}`
+}
 
 // The ONE strip implementation, shared by the multi-pane chrome overlay AND the
 // single-pane top nav (design §2/§3.6). The two CONTAINERS differ by a scroll
@@ -22,24 +33,28 @@ const TITLE_CYCLE_MS_PER_PX = 1000 / 12
 // the workspace's own active tab, never a legacy nav triple) are identical, so
 // they live here once instead of being hand-rolled twice.
 
-// Roving-tabindex keyboard navigation (WAI-ARIA toolbar): a strip is one tab
-// stop, and arrows move focus between its tab buttons, Home/End jump to the ends,
-// Delete/Backspace closes the focused tab. `tabs` is the strip's tab list in
-// render order (the i-th `.shell__tab-open` button is the i-th tab); `onClose`
-// closes one. Works for either container because it keys on the shared class, not
-// a role.
+// Roving-tabindex keyboard navigation: a strip is one tab stop; Left/Right wrap,
+// Home/End jump to the ends, and Delete/Backspace closes the focused tab after
+// moving focus to its neighbour. Up/Down stay native in this horizontal widget.
+// `tabs` is the strip's tab list in render order (the i-th `.shell__tab-open`
+// button is the i-th tab); `onClose` closes one.
 export function stripKeyDown(e, tabs, onClose) {
   const buttons = [...e.currentTarget.querySelectorAll('.shell__tab-open')]
   const i = buttons.indexOf(document.activeElement)
   if (i === -1) return
   let next = -1
-  if (e.key === 'ArrowRight' || e.key === 'ArrowDown') next = Math.min(i + 1, buttons.length - 1)
-  else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') next = Math.max(i - 1, 0)
+  if (e.key === 'ArrowRight') next = (i + 1) % buttons.length
+  else if (e.key === 'ArrowLeft') next = (i - 1 + buttons.length) % buttons.length
   else if (e.key === 'Home') next = 0
   else if (e.key === 'End') next = buttons.length - 1
   else if (e.key === 'Delete' || e.key === 'Backspace') {
     e.preventDefault()
-    if (tabs[i]) onClose(tabs[i])
+    if (tabs[i]) {
+      const neighbour = buttons[i + 1] || buttons[i - 1]
+      if (neighbour) neighbour.focus()
+      else document.querySelector('.shell__brand')?.focus()
+      onClose(tabs[i])
+    }
     return
   } else return
   e.preventDefault()
@@ -63,7 +78,8 @@ export function scrollStripWheel(e) {
 // (tabIndex 0); the rest and every close button are reached via stripKeyDown.
 export function PaneTab({
   tab, label, active, focused = true, revealKey = 0,
-  tabIndex, dragKey, role, onActivate, onClose, onContextMenu,
+  tabIndex, dragKey, role, tabId, controlsId,
+  onActivate, onClose, onContextMenu,
 }) {
   const tabRef = useRef(null)
   const titleRef = useRef(null)
@@ -86,10 +102,7 @@ export function PaneTab({
     const measure = () => {
       const shift = Math.ceil(text.scrollWidth - title.clientWidth)
       if (shift > 3) {
-        const duration = Math.min(
-          TITLE_CYCLE_MAX_MS,
-          Math.round(shift * TITLE_CYCLE_MS_PER_PX),
-        )
+        const duration = Math.round(shift * TITLE_CYCLE_MS_PER_PX)
         title.dataset.overflow = 'true'
         title.style.setProperty('--tab-title-shift', `-${shift}px`)
         title.style.setProperty('--tab-title-duration', `${duration}ms`)
@@ -126,6 +139,8 @@ export function PaneTab({
         type="button"
         className="shell__tab-open"
         role={role}
+        id={tabId}
+        aria-controls={role === 'tab' ? controlsId : undefined}
         aria-selected={role === 'tab' ? (active ? 'true' : 'false') : undefined}
         aria-current={role !== 'tab' && active ? 'true' : undefined}
         tabIndex={tabIndex}
@@ -233,6 +248,8 @@ export function PaneStrip({
             focused={focused}
             revealKey={revealKey}
             role="tab"
+            tabId={paneTabDomId(pane.id, key)}
+            controlsId={panePanelDomId(pane.id, key)}
             tabIndex={active ? 0 : -1}
             dragKey={WORKSPACE_SPLITS_ENABLED ? key : undefined}
             onActivate={() => onActivate(pane.id, tab)}

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -92,7 +92,9 @@ import {
   transitionSignature, MODE_MOTION, EMPTY_SINGLE_SURFACE_KEY,
 } from './workspaceView.js'
 import NewChatLanding from './NewChatLanding.jsx'
-import { PaneTab, scrollStripWheel, stripKeyDown } from './PaneStrip.jsx'
+import {
+  PaneTab, panePanelDomId, paneTabDomId, scrollStripWheel, stripKeyDown,
+} from './PaneStrip.jsx'
 import useAppIntentNavigation from './useAppIntentNavigation.js'
 import useDesktopSidebar from './useDesktopSidebar.js'
 import ShellBrand from './ShellBrand.jsx'
@@ -3382,6 +3384,9 @@ export default function Shell() {
           return (
           <div
             key={id}
+            id={paned ? panePanelDomId(paned.paneId, tabKey) : undefined}
+            role={paned ? 'tabpanel' : undefined}
+            aria-labelledby={paned ? paneTabDomId(paned.paneId, tabKey) : undefined}
             data-tab-key={(multiPane || focusedPaneViewId != null) && !underlay ? tabKey : undefined}
             // COMPOSITOR-ONLY beat motion (v2): the wrapper HOLDS its tiled content
             // rect and animates only transform/opacity via data-mode-motion + the
@@ -3458,6 +3463,7 @@ export default function Shell() {
           const paned = !underlay && workspaceChromeActive ? visibleTabRects.get(paneActiveKey) : null
           const fullBleed = !underlay && !paned && paneActiveKey === fullBleedKey
           const motion = isActiveLayer ? wrapperMotion(paneActiveKey) : null
+          const tabPanel = role !== 'held' && paned
           const handoffClass = !settingsOverlay && role !== 'active'
             ? ` shell__chat-view--${role}`
             : ''
@@ -3465,6 +3471,9 @@ export default function Shell() {
           return (
             <div
               key={chatId}
+              id={tabPanel ? panePanelDomId(paneId, tabKey) : undefined}
+              role={tabPanel ? 'tabpanel' : undefined}
+              aria-labelledby={tabPanel ? paneTabDomId(paneId, tabKey) : undefined}
               data-tab-key={(multiPane || focusedPaneViewId != null) && role !== 'held' && !underlay
                 ? tabKey : undefined}
               // Compositor-only beat motion (v2): see the app wrapper. The world-
@@ -3535,9 +3544,17 @@ export default function Shell() {
           const settingsPos = (!settingsUnderlay && settingsPaned)
             ? { top: settingsPaned.y, left: settingsPaned.x, width: settingsPaned.w, height: settingsPaned.h }
             : null
+          const settingsTabPanel = !settingsUnderlay && settingsPaned
           return (
           <div
             key="settings"
+            id={settingsTabPanel
+              ? panePanelDomId(settingsPaned.paneId, SETTINGS_KEY)
+              : undefined}
+            role={settingsTabPanel ? 'tabpanel' : undefined}
+            aria-labelledby={settingsTabPanel
+              ? paneTabDomId(settingsPaned.paneId, SETTINGS_KEY)
+              : undefined}
             data-tab-key={(!settingsUnderlay && settingsPaned) ? SETTINGS_KEY : undefined}
             data-mode-motion={settingsMotion ? settingsMotion.motion : undefined}
             className={settingsUnderlay
@@ -3595,8 +3612,8 @@ export default function Shell() {
         })()}
         {/* Chrome layer — sibling AFTER the content wrappers, over the whole
             content box, carrying its own inert. Only at ≥2 visible leaves and
-            never while Settings overlays. Draws per-pane strips, dividers, and
-            the phone overflow chip; no content lives here. */}
+            never while Settings overlays. Draws per-pane strips and dividers;
+            no content lives here. */}
         {workspaceChromeActive && (
           <WorkspaceChrome
             // INV 9 / finding 10: during the exit deal the chrome is not just
@@ -3621,9 +3638,6 @@ export default function Shell() {
             onTogglePaneFocus={toggleFocusedPaneView}
             revealKey={tabRevealRevision}
             stripMotion={wrapperMotion}
-            streamingChatIds={streamingChatIds}
-            attentionChatIds={attentionChatIds}
-            newAppIds={appAttentionSet}
           />
         )}
       </main>

--- a/frontend/src/components/Shell/WorkspaceChrome.jsx
+++ b/frontend/src/components/Shell/WorkspaceChrome.jsx
@@ -1,20 +1,17 @@
-import { useCallback, useMemo, useRef, useState } from 'react'
-import Layers from 'lucide-react/dist/esm/icons/layers.mjs'
-import X from 'lucide-react/dist/esm/icons/x.mjs'
+import { useCallback } from 'react'
 import * as tabModel from './tabModel.js'
 import {
-  projectLayout, STRIP_H, WORKSPACE_SPLITS_ENABLED,
+  projectLayout, STRIP_H,
 } from './paneModel.js'
 import { ARROW_STEP_RATIO } from '../../lib/splitHelper.js'
-import useDialogFocus from '../../hooks/useDialogFocus.js'
 import { PaneStrip } from './PaneStrip.jsx'
 
 // The chrome layer for a tiled (≥2 visible leaves) workspace (design §2). It is
 // a sibling AFTER the flat content wrappers, absolute inset:0, pointer-events
 // none except its own children, and carries its OWN `inert` (Shell passes it).
 // Nothing here reparents content — panes are rectangles the content wrappers are
-// positioned into; this layer only draws the strips, dividers, and the phone
-// overflow chip/sheet over them. There is no always-on focused-pane ring: which
+// positioned into; this layer only draws the strips and dividers. There is no
+// always-on focused-pane ring: which
 // tab each pane shows and which pane has focus both read from the strips' active
 // tab (see workspace.css), so no chrome frames any pane's content.
 //
@@ -24,20 +21,6 @@ import { PaneStrip } from './PaneStrip.jsx'
 // No reducer dispatch happens per move.
 
 const HIT = 44 // divider hit target (the visible hairline is 1px inside it)
-
-// A shared empty set so the default props don't mint a new one each render.
-const EMPTY_SET = new Set()
-
-// A pane "has activity" if any of its tabs is a streaming/attention chat or a
-// newly-built app — the cue the phone chip + sheet surface for a HIDDEN pane so a
-// background change is visible without opening the sheet (design §4).
-function paneHasActivity(pane, streaming, attention, newApps) {
-  if (!pane) return false
-  return pane.tabs.some((t) => {
-    if (t.kind === 'chat') return streaming.has(String(t.id)) || attention.has(String(t.id))
-    return newApps.has(Number(t.id)) || newApps.has(String(t.id))
-  })
-}
 
 function cssEsc(v) {
   return (typeof CSS !== 'undefined' && CSS.escape) ? CSS.escape(String(v)) : String(v)
@@ -113,21 +96,7 @@ export default function WorkspaceChrome({
   // key → { motion, vars } for the live mode beat, so each strip deals WITH its pane
   // (Shell's wrapperMotion). Null/absent when no beat is live.
   stripMotion = null,
-  streamingChatIds = EMPTY_SET,
-  attentionChatIds = EMPTY_SET,
-  newAppIds = EMPTY_SET,
 }) {
-  const [sheetOpen, setSheetOpen] = useState(false)
-  const sheetRef = useRef(null)
-  const sheetCloseRef = useRef(null)
-  const closeSheet = useCallback(() => setSheetOpen(false), [])
-  useDialogFocus({
-    open: sheetOpen,
-    containerRef: sheetRef,
-    initialFocusRef: sheetCloseRef,
-    onClose: closeSheet,
-  })
-
   const focusPane = useCallback((paneId) => {
     dispatchWorkspace({ type: 'FOCUS', paneId })
   }, [dispatchWorkspace])
@@ -267,38 +236,7 @@ export default function WorkspaceChrome({
     dispatchWorkspace({ type: 'SET_RATIO', splitId: divider.splitId, ratio: 0.5 })
   }, [dispatchWorkspace])
 
-  // ── Phone/compact overflow: the pane chip + bottom sheet (design §4) ──────
-  const allLeaves = useMemo(
-    () => Object.keys(workspace.panes),
-    [workspace.panes],
-  )
-  const hasOverflow = allLeaves.length > projection.visibleLeaves.length
-  // Overflow can occur in ANY mode: a wide viewport too small to fit every pane
-  // at its minimum degrades to the compact focused-pair projection, so the chip
-  // must reach the hidden panes regardless of the raw mode (finding: wide
-  // min-width degrade would otherwise strand them).
-  const showChip = WORKSPACE_SPLITS_ENABLED && hasOverflow && focusedPaneViewId == null
-  const hiddenActivity = useMemo(() => {
-    const visible = new Set(projection.visibleLeaves)
-    return allLeaves.some(id => !visible.has(id)
-      && paneHasActivity(workspace.panes[id], streamingChatIds, attentionChatIds, newAppIds))
-  }, [allLeaves, projection.visibleLeaves, workspace.panes,
-    streamingChatIds, attentionChatIds, newAppIds])
-
-  const pickPane = useCallback((paneId) => {
-    closeSheet()
-    const pane = workspace.panes[paneId]
-    const active = pane?.tabs.find(t => tabModel.tabKey(t) === pane.activeTabKey)
-    if (active) {
-      const { view, opts } = tabModel.tabNavTarget(active)
-      navTo(view, { ...opts, paneId })
-    } else {
-      dispatchWorkspace({ type: 'FOCUS', paneId })
-    }
-  }, [closeSheet, dispatchWorkspace, navTo, workspace.panes])
-
-  const focusRect = projection.rects[workspace.focusedPaneId]
-  const chipHostRect = focusRect || projection.rects[projection.visibleLeaves[0]]
+  const canFocusPane = Object.keys(workspace.panes).length > 1
 
   return (
     <div className="workspace__chrome" data-workspace-chrome inert={inert || undefined}>
@@ -317,7 +255,7 @@ export default function WorkspaceChrome({
             onClose={onCloseTab}
             onFocus={focusPane}
             onTabContextMenu={onTabContextMenu}
-            canFocusPane={allLeaves.length > 1}
+            canFocusPane={canFocusPane}
             paneFocused={focusedPaneViewId === paneId}
             onTogglePaneFocus={onTogglePaneFocus}
             revealKey={revealKey}
@@ -336,69 +274,6 @@ export default function WorkspaceChrome({
           onDoubleClick={resetDivider}
         />
       ))}
-
-      {showChip && chipHostRect && (
-        <button
-          type="button"
-          className="workspace__pane-chip"
-          style={{ left: chipHostRect.x + chipHostRect.w - 60, top: chipHostRect.y + 5 }}
-          aria-haspopup="dialog"
-          aria-expanded={sheetOpen}
-          aria-label={`Show panes, ${projection.visibleLeaves.length} of ${allLeaves.length} visible`}
-          onClick={() => setSheetOpen(true)}
-        >
-          <Layers size={13} aria-hidden="true" />
-          <span>{projection.visibleLeaves.length}/{allLeaves.length}</span>
-          {hiddenActivity && <span className="workspace__pane-chip-dot" aria-hidden="true" />}
-        </button>
-      )}
-
-      {showChip && sheetOpen && (
-        <div className="workspace__sheet-scrim" onPointerDown={closeSheet}>
-          <div
-            ref={sheetRef}
-            className="workspace__sheet"
-            role="dialog"
-            aria-modal="true"
-            aria-label="Switch pane"
-            onPointerDown={(e) => e.stopPropagation()}
-          >
-            <div className="workspace__sheet-head">
-              <div className="workspace__sheet-title">Panes</div>
-              <button
-                ref={sheetCloseRef}
-                type="button"
-                className="workspace__sheet-close"
-                aria-label="Close pane switcher"
-                onClick={closeSheet}
-              >
-                <X size={16} aria-hidden="true" />
-              </button>
-            </div>
-            {allLeaves.map(paneId => {
-              const pane = workspace.panes[paneId]
-              const active = pane?.tabs.find(t => tabModel.tabKey(t) === pane.activeTabKey)
-              const label = active ? labelForTab(active) : 'Empty'
-              const visible = projection.visibleLeaves.includes(paneId)
-              return (
-                <button
-                  key={paneId}
-                  type="button"
-                  className={`workspace__sheet-row${visible ? ' workspace__sheet-row--visible' : ''}`}
-                  onClick={() => pickPane(paneId)}
-                >
-                  <span className="workspace__sheet-row-title">{label}</span>
-                  <span className="workspace__sheet-row-meta">
-                    {paneHasActivity(pane, streamingChatIds, attentionChatIds, newAppIds)
-                      && <span className="workspace__sheet-row-dot" aria-hidden="true" />}
-                    <span className="workspace__sheet-row-count">{pane?.tabs.length || 0}</span>
-                  </span>
-                </button>
-              )
-            })}
-          </div>
-        </div>
-      )}
     </div>
   )
 }

--- a/frontend/src/components/Shell/__tests__/chatHandoff.test.js
+++ b/frontend/src/components/Shell/__tests__/chatHandoff.test.js
@@ -5,6 +5,7 @@ import assert from 'node:assert/strict'
 const shell = readFileSync(new URL('../Shell.jsx', import.meta.url), 'utf8')
 const shellCss = readFileSync(new URL('../Shell.css', import.meta.url), 'utf8')
 const chatView = readFileSync(new URL('../../ChatView/ChatView.jsx', import.meta.url), 'utf8')
+const apiClient = readFileSync(new URL('../../../api/client.js', import.meta.url), 'utf8')
 
 function ruleBody(selector) {
   const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
@@ -21,6 +22,23 @@ test('chat display readiness preserves the existing transcript reveal gate', () 
     'an already-ready chat must re-announce when a cross-pane move changes its handoff owner')
   assert.doesNotMatch(chatView, /onDisplayReadyRef/,
     'the callback dependency is the owner-change signal; a parallel mutable ref would obscure it')
+})
+
+test('a staging chat cannot leave the outgoing transcript held on a wedged request', () => {
+  assert.match(chatView, /const CHAT_FETCH_TIMEOUT_MS = 15000/)
+  assert.match(
+    chatView,
+    /apiFetch\(`\/chats\/\$\{chatId\}\?limit=20`, \{\s*timeoutMs: CHAT_FETCH_TIMEOUT_MS,\s*signal: initialLoadController\.signal,\s*\}\)/,
+    'the initial load must share the bounded message-fetch deadline',
+  )
+  assert.match(chatView, /initialLoadController\.abort\(\)/,
+    'hiding or unmounting a staging chat must release its request immediately')
+  assert.match(apiClient, /AbortSignal\.any\(\[signal, ctrl\.signal\]\)/,
+    'apiFetch must compose lifecycle cancellation with its deadline')
+  assert.match(apiClient, /error\.name = 'TimeoutError'\s*ctrl\.abort\(error\)/,
+    'a deadline remains distinguishable from routine lifecycle cancellation')
+  assert.match(apiClient, /if \(error\?\.name !== 'AbortError'\) void verifyConnectivity\(\)/,
+    'switching panes must not trigger a redundant connectivity probe')
 })
 
 test('each pane holds one outgoing chat over one staging chat', () => {

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -19,11 +19,6 @@ const walkthrough = readFileSync(
   new URL('../../Walkthrough/WalkthroughOverlay.jsx', import.meta.url), 'utf8',
 )
 
-test('the phone pane switcher keeps a 44px touch target', () => {
-  const rule = css.match(/\.workspace__pane-chip\s*\{[\s\S]*?\}/)?.[0] || ''
-  assert.match(rule, /min-height:\s*44px/)
-})
-
 test('the workspace menu avoids an oversized border-and-shadow card', () => {
   const rule = css.match(/\.workspace__menu\s*\{[\s\S]*?\}/)?.[0] || ''
   assert.match(rule, /border:\s*1px/)
@@ -38,10 +33,6 @@ test('the workspace menu is labeled, edge-clamped, and arrow-key navigable', () 
   assert.match(shell, /querySelector\('\[role="menuitem"\]'\)\?\.focus\(\)/)
   assert.match(shell, /tabMenuReturnFocusRef\.current = e\.currentTarget/)
   assert.match(shell, /returnTarget\?\.focus\?\.\(\{ preventScroll: true \}\)/)
-})
-
-test('the compact pane switcher describes its visible pane count', () => {
-  assert.match(chrome, /aria-label=\{`Show panes, \$\{projection\.visibleLeaves\.length\} of \$\{allLeaves\.length\} visible`\}/)
 })
 
 test('an implicit home tab does not engage the single-pane tab strip', () => {
@@ -62,13 +53,6 @@ test('an implicit home tab does not engage the single-pane tab strip', () => {
   // single. The ONE unified close takes a tab object + opts (INV 13).
   assert.doesNotMatch(shell, /openTabs\.length === 1 && kind !== 'settings'/)
   assert.match(shell, /const closeTab = useCallback\(\(tab, \{ reason \} = \{\}\)/)
-})
-
-test('the pane switcher uses the shared modal focus and dismissal contract', () => {
-  assert.match(chrome, /useDialogFocus\(\{[\s\S]*?open: sheetOpen/)
-  assert.match(chrome, /initialFocusRef: sheetCloseRef/)
-  assert.match(chrome, /aria-modal="true"/)
-  assert.match(chrome, /aria-label="Close pane switcher"/)
 })
 
 test('the drop preview reads as an 18% accent fill with a 2px border and morph', () => {
@@ -204,10 +188,28 @@ test('strips sit above dividers so the 44px grab never occludes a tab', () => {
   assert.match(rule, /z-index:\s*5/)
 })
 
-test('the strips are roving-tabindex toolbars (one shared implementation)', () => {
+test('divider hover feedback stays compositor-only', () => {
+  const rule = css.match(/\.workspace__divider-bar\s*\{[\s\S]*?\}/)?.[0] || ''
+  assert.match(rule, /transition:\s*background 120ms ease, transform 120ms ease/)
+  assert.doesNotMatch(rule, /transition:[^;]*(?:width|height)/)
+  assert.match(css, /workspace__divider--v:focus-visible \.workspace__divider-bar \{ transform: scaleX\(3\); \}/)
+  assert.match(css, /workspace__divider--h:focus-visible \.workspace__divider-bar \{ transform: scaleY\(3\); \}/)
+})
+
+test('pane strips use a complete horizontal tab keyboard and ownership contract', () => {
   assert.match(paneStrip, /export function stripKeyDown/)
   assert.match(paneStrip, /tabIndex=\{active \? 0 : -1\}/)
-  assert.match(paneStrip, /e\.key === 'ArrowRight'/)
+  assert.match(paneStrip, /\(i \+ 1\) % buttons\.length/)
+  assert.match(paneStrip, /\(i - 1 \+ buttons\.length\) % buttons\.length/)
+  assert.doesNotMatch(paneStrip, /e\.key === 'ArrowDown'/)
+  assert.doesNotMatch(paneStrip, /e\.key === 'ArrowUp'/)
+  assert.match(paneStrip, /if \(neighbour\) neighbour\.focus\(\)/)
+  assert.match(paneStrip, /document\.querySelector\('\.shell__brand'\)\?\.focus\(\)/)
+  assert.match(paneStrip, /aria-controls=\{role === 'tab' \? controlsId : undefined\}/)
+  assert.match(paneStrip, /export function paneTabDomId/)
+  assert.match(paneStrip, /export function panePanelDomId/)
+  assert.match(shell, /role=\{paned \? 'tabpanel' : undefined\}/)
+  assert.match(shell, /aria-labelledby=\{paned \? paneTabDomId\(paned\.paneId, tabKey\) : undefined\}/)
   // Both containers route their keydown through the shared roving helper.
   assert.match(paneStrip, /stripKeyDown\(e, pane\.tabs, onClose\)/)
   assert.match(shell, /stripKeyDown\(e, openTabs,/)
@@ -232,11 +234,9 @@ test('the single-pane strip derives active from the workspace, retiring isTabAct
   assert.doesNotMatch(paneStrip, /isTabActive\(/)
 })
 
-test('the pane chip and sheet rows carry an activity dot for hidden panes', () => {
-  assert.match(chrome, /function paneHasActivity/)
-  assert.match(chrome, /workspace__pane-chip-dot/)
-  assert.match(chrome, /workspace__sheet-row-dot/)
-  assert.match(shell, /streamingChatIds=\{streamingChatIds\}/)
+test('builder mode has no extra top-right pane affordance', () => {
+  assert.doesNotMatch(chrome, /Layers|Show panes|workspace__pane-chip|workspace__sheet/)
+  assert.doesNotMatch(css, /\.workspace__pane-chip|\.workspace__sheet/)
 })
 
 test('workspace mutations update the undo slot silently, with no toast', () => {
@@ -688,7 +688,8 @@ test('an active overflowing chat title cycles once, then becomes idle', () => {
   assert.match(paneStrip, /Math\.round\(shift \* TITLE_CYCLE_MS_PER_PX\)/)
   assert.doesNotMatch(paneStrip, /TITLE_CYCLE_MIN_MS/,
     'clipped titles must not share a fixed duration; distance owns the cadence')
-  assert.match(paneStrip, /const TITLE_CYCLE_MAX_MS = 32000/)
+  assert.doesNotMatch(paneStrip, /TITLE_CYCLE_MAX_MS|Math\.min/,
+    'long titles must not accelerate through a duration cap')
   assert.match(paneStrip, /const TITLE_CYCLE_MS_PER_PX = 1000 \/ 12/)
   assert.match(paneStrip, /className="shell__tab-text-inner"/)
   const cycle = shellCss.match(/\.shell__tabstrip:not\(\.workspace__strip\)[\s\S]*?shell-tab-title-cycle var\(--tab-title-duration\) linear 700ms 1 both/)?.[0] || ''
@@ -857,7 +858,7 @@ test('the splits kill-switch forces the single-pane fallback so a rolled-back pa
   assert.match(paneModelSrc, /function coerceViewMode\(mode\) \{\s*\n\s*if \(!WORKSPACE_SPLITS_ENABLED\) return 'single'/)
 })
 
-test('visual nits V3-V6: coachmark clears the strip, focus underline reads, chip clamps, cancel blurs', () => {
+test('visual nits V3-V6: coachmark clears the strip, focus underline reads, drag label clamps, cancel blurs', () => {
   // V3: the first-use coachmark anchors BELOW the strip (bar 58px + safe-area + strip
   // 34px + 8px gap), so its pill never covers a tab label.
   const coach = css.match(/\.workspace__coachmark \{[\s\S]*?\n\}/)?.[0] || ''
@@ -870,11 +871,23 @@ test('visual nits V3-V6: coachmark clears the strip, focus underline reads, chip
   assert.match(focused, /border-color: color-mix\(in srgb, var\(--accent\) 45%, var\(--border-light\)\)/)
   // V5: the drag chip clamps within the viewport so its label never clips at the
   // right edge (measured offsetWidth + an 8px margin).
-  assert.match(dragBinding, /const maxLeft = Math\.max\(margin, window\.innerWidth - w - margin\)/)
+  assert.match(dragBinding, /const maxLeft = Math\.max\(margin, window\.innerWidth - chipWidth - margin\)/)
   assert.match(dragBinding, /Math\.max\(margin, Math\.min\(left, maxLeft\)\)/)
   // V6: a CANCELLED drag blurs the drag-origin row so its focus ring clears; a
   // committed drop keeps focus (the tab moved).
   assert.match(dragBinding, /if \(suppressClick && !committed\) srcEl\.blur\?\.\(\)/)
+})
+
+test('workspace drag batches geometry reads before frame writes', () => {
+  assert.match(dragBinding, /chipWidth = chipEl\.offsetWidth \|\| 0/,
+    'the drag label width is measured once when it becomes visible')
+  const frame = dragBinding.match(/const doMoveWork = \(\) => \{[\s\S]*?\n      \}/)?.[0] || ''
+  assert.ok(frame.indexOf('const box = contentBox()') >= 0)
+  assert.ok(frame.indexOf('const box = contentBox()') < frame.lastIndexOf('positionChip(cx, cy, isTouch, key)'))
+  assert.match(frame, /updateAutoScroll\(cx, cy, box\)/)
+  assert.match(frame, /toLocal\(cx, cy, box\)/)
+  assert.match(dragBinding, /measureTabs\(autoPaneId, box\)/,
+    'auto-scroll shares its content rect across strip and pointer measurements')
 })
 
 // ── H1 (was M5): a slot app uninstalled while closed must not survive the first

--- a/frontend/src/components/Shell/useWorkspaceDrag.js
+++ b/frontend/src/components/Shell/useWorkspaceDrag.js
@@ -97,6 +97,7 @@ export default function useWorkspaceDrag({
     // ── Reusable overlay DOM (created lazily on the first arm) ────────────────
     let shieldEl = null
     let chipEl = null
+    let chipWidth = 0
     let previewEl = null
     // The one in-flight session's teardown, so an unmount / disable can tear a
     // live drag down cleanly — no orphaned shield. activePointerId / activeSrcEl
@@ -115,8 +116,7 @@ export default function useWorkspaceDrag({
     function contentBox() {
       return contentElRef.current?.getBoundingClientRect() || { left: 0, top: 0 }
     }
-    function toLocal(clientX, clientY) {
-      const box = contentBox()
+    function toLocal(clientX, clientY, box = contentBox()) {
       return { x: clientX - box.left, y: clientY - box.top }
     }
 
@@ -153,7 +153,7 @@ export default function useWorkspaceDrag({
 
     function removeOverlays() {
       shieldEl?.remove(); shieldEl = null
-      chipEl?.remove(); chipEl = null
+      chipEl?.remove(); chipEl = null; chipWidth = 0
       previewEl?.remove(); previewEl = null
       clearPreGlow()
     }
@@ -166,13 +166,13 @@ export default function useWorkspaceDrag({
         const label = (labelForTabRef.current && tab) ? labelForTabRef.current(tab) : ''
         chipEl.textContent = label
         chipEl.hidden = false
+        chipWidth = chipEl.offsetWidth || 0
       }
       const { left, top } = chipOffset({ x: clientX, y: clientY }, isTouch)
       // V5 (vizreview): clamp the chip within the viewport so its label never clips
       // at the right edge (the +12 offset pushed a right-edge drag off-screen).
       const margin = 8
-      const w = chipEl.offsetWidth || 0
-      const maxLeft = Math.max(margin, window.innerWidth - w - margin)
+      const maxLeft = Math.max(margin, window.innerWidth - chipWidth - margin)
       chipEl.style.left = `${Math.max(margin, Math.min(left, maxLeft))}px`
       chipEl.style.top = `${top}px`
     }
@@ -215,11 +215,10 @@ export default function useWorkspaceDrag({
     }
 
     // Measure a pane's strip tab rects (content-local) for the caret index.
-    function measureTabs(paneId) {
+    function measureTabs(paneId, box = contentBox()) {
       const host = contentElRef.current
       const strip = host?.querySelector(`[data-pane-strip="${cssEscape(paneId)}"]`)
       if (!strip) return []
-      const box = contentBox()
       return [...strip.querySelectorAll('.shell__tab')].map((el) => {
         const r = el.getBoundingClientRect()
         return { left: r.left - box.left, right: r.right - box.left }
@@ -329,8 +328,7 @@ export default function useWorkspaceDrag({
       }
       // Strip auto-scroll (§3.2): near an overflowing strip's edge, scroll it
       // 6px/frame and re-measure so the caret keeps tracking under the pointer.
-      function updateAutoScroll(clientX, clientY) {
-        const box = contentBox()
+      function updateAutoScroll(clientX, clientY, box = contentBox()) {
         const xL = clientX - box.left
         const yL = clientY - box.top
         let stripEl = null
@@ -358,32 +356,34 @@ export default function useWorkspaceDrag({
       function autoStep() {
         if (!armed || autoDir === 0 || !autoStripEl) { autoRAF = null; return }
         autoStripEl.scrollLeft += autoDir * AUTO_SCROLL_STEP
+        const box = contentBox()
         const p = scene?.panes.find(pp => pp.paneId === autoPaneId)
-        if (p) p.tabs = measureTabs(autoPaneId) // re-measure the scrolled strip
-        const next = hitTest(toLocal(lastPoint.x, lastPoint.y), scene, curZone)
+        if (p) p.tabs = measureTabs(autoPaneId, box) // re-measure the scrolled strip
+        const next = hitTest(toLocal(lastPoint.x, lastPoint.y, box), scene, curZone)
         renderPreview(next)
         curZone = next
         autoRAF = requestAnimationFrame(autoStep)
       }
 
-      // The per-frame drag work (chip follow, hit-test, preview, auto-scroll) is
-      // rAF-coalesced: a pointermove fires several times per frame, and each pass
-      // writes the fixed chip, forces a layout read (contentBox), allocates a
-      // fresh hit-test result, and writes preview styles. Batching to one pass per
-      // frame drops the forced-reflow + GC churn to at most one per frame.
+      // The per-frame drag work is rAF-coalesced and batches geometry reads before
+      // style writes. A pointermove can fire several times per frame; one content
+      // rect feeds both auto-scroll and hit-testing, while the chip width is
+      // measured only once when the drag arms.
       let moveRAF = 0
       const doMoveWork = () => {
         moveRAF = 0
         if (!armed || cleaned) return
         const { x: cx, y: cy } = lastPoint
-        positionChip(cx, cy, isTouch, key)
         // While the drawer still covers the panes, show no preview (the glide-close
         // crossing is handled synchronously in onMove).
         if (sourceKind === 'drawer' && drawerOpenRef.current && !glided) {
+          positionChip(cx, cy, isTouch, key)
           curZone = null; renderPreview(null); stopAutoScroll(); return
         }
-        updateAutoScroll(cx, cy)
-        const next = hitTest(toLocal(cx, cy), scene, curZone)
+        const box = contentBox()
+        updateAutoScroll(cx, cy, box)
+        const next = hitTest(toLocal(cx, cy, box), scene, curZone)
+        positionChip(cx, cy, isTouch, key)
         renderPreview(next)
         curZone = next
       }

--- a/frontend/src/components/Shell/workspace.css
+++ b/frontend/src/components/Shell/workspace.css
@@ -146,19 +146,15 @@
   to { transform: translate3d(0, -6px, 0); opacity: 0; }
 }
 
-/* Dividers + the overflow chip simplify first on exit, then resolve only over the
-   LAST 70ms of entry. The stationary underlay's strip follows the same rule:
+/* Dividers simplify first on exit, then resolve only over the LAST 70ms of
+   entry. The stationary underlay's strip follows the same rule:
    structure cannot appear over the old screen before the panes themselves arrive.
-   Opacity-only; small elements. The chip selector is
-   listed FIRST (before the divider) so it is followed by a comma, never a brace — a
-   css-shape test that greps the base chip rule still finds it. */
-.shell--builder-exiting .workspace__pane-chip,
+   Opacity-only; small elements. */
 .shell--builder-exiting .workspace__divider {
   pointer-events: none;
   animation: shell-mode-chrome-out 90ms var(--ease-mode-chrome) both;
 }
 .shell--builder-entering .shell__tabstrip:not([data-mode-motion]),
-.shell--builder-entering .workspace__pane-chip,
 .shell--builder-entering .workspace__divider {
   animation:
     shell-mode-chrome-in 70ms var(--ease-mode-chrome)
@@ -283,10 +279,18 @@
 .workspace__divider-bar {
   background: var(--border-light);
   border-radius: 2px;
-  transition: background 120ms ease, width 120ms ease, height 120ms ease;
+  transition: background 120ms ease, transform 120ms ease;
 }
-.workspace__divider--v .workspace__divider-bar { width: 1px; height: 100%; }
-.workspace__divider--h .workspace__divider-bar { height: 1px; width: 100%; }
+.workspace__divider--v .workspace__divider-bar {
+  width: 1px;
+  height: 100%;
+  transform: scaleX(1);
+}
+.workspace__divider--h .workspace__divider-bar {
+  height: 1px;
+  width: 100%;
+  transform: scaleY(1);
+}
 
 /* PROPOSED builder power-chrome (design item 6, default OFF — gated by
    .shell--builder-power on the shell root). Accent-energized resting dividers. */
@@ -295,151 +299,12 @@
 }
 
 .workspace__divider--v:hover .workspace__divider-bar,
-.workspace__divider--v:focus-visible .workspace__divider-bar { width: 3px; }
+.workspace__divider--v:focus-visible .workspace__divider-bar { transform: scaleX(3); }
 .workspace__divider--h:hover .workspace__divider-bar,
-.workspace__divider--h:focus-visible .workspace__divider-bar { height: 3px; }
+.workspace__divider--h:focus-visible .workspace__divider-bar { transform: scaleY(3); }
 .workspace__divider:hover .workspace__divider-bar,
 .workspace__divider:focus-visible .workspace__divider-bar {
   background: var(--accent);
-}
-
-/* Phone/compact overflow chip — opens the pane switcher sheet. */
-.workspace__pane-chip {
-  position: absolute;
-  pointer-events: auto;
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  min-height: 44px;
-  padding: 0 12px;
-  border-radius: 999px;
-  border: 1px solid var(--border-light);
-  background: color-mix(in srgb, var(--bg) 88%, var(--text) 6%);
-  color: var(--text);
-  font-size: 12px;
-  font-weight: 600;
-  cursor: pointer;
-  z-index: 5;
-  -webkit-tap-highlight-color: transparent;
-}
-.workspace__pane-chip:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
-
-/* Activity dot: a hidden pane whose chat finished streaming / drew attention or
-   whose app is new gets a small accent dot on the chip and its sheet row, so a
-   background change is visible without opening the sheet (design §4). */
-.workspace__pane-chip-dot,
-.workspace__sheet-row-dot {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  background: var(--accent);
-  flex: 0 0 auto;
-}
-/* The dot + count sit together at the row's trailing edge. */
-.workspace__sheet-row-meta {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex-shrink: 0;
-}
-
-/* Bottom sheet: pane switcher. */
-.workspace__sheet-scrim {
-  position: absolute;
-  inset: 0;
-  pointer-events: auto;
-  background: color-mix(in srgb, #000 40%, transparent);
-  display: flex;
-  align-items: flex-end;
-  z-index: 6;
-}
-.workspace__sheet {
-  width: 100%;
-  max-height: 60%;
-  overflow-y: auto;
-  background: var(--bg);
-  border-top: 1px solid var(--border-light);
-  border-radius: 16px 16px 0 0;
-  padding: 12px 12px calc(12px + env(safe-area-inset-bottom, 0px));
-  /* Match the shell's named scrollers: coarse pointers must not render a
-     persistent scrollbar track (Chromium Android). */
-  scrollbar-width: none;
-  animation: workspace-sheet-in 180ms ease-out;
-}
-.workspace__sheet::-webkit-scrollbar { width: 0; height: 0; }
-
-@keyframes workspace-sheet-in {
-  from { transform: translateY(100%); }
-  to { transform: translateY(0); }
-}
-
-.workspace__sheet-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  min-height: 44px;
-}
-.workspace__sheet-title {
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--muted);
-  padding: 4px 8px;
-}
-.workspace__sheet-close {
-  display: grid;
-  place-items: center;
-  width: 44px;
-  height: 44px;
-  border: 0;
-  border-radius: 999px;
-  background: transparent;
-  color: var(--muted);
-  cursor: pointer;
-}
-.workspace__sheet-close:hover {
-  background: color-mix(in srgb, var(--text) 8%, transparent);
-  color: var(--text);
-}
-.workspace__sheet-close:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: -2px;
-}
-.workspace__sheet-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  width: 100%;
-  gap: 10px;
-  padding: 12px;
-  border: none;
-  background: none;
-  border-radius: 10px;
-  color: var(--text);
-  cursor: pointer;
-  font-size: 14px;
-  text-align: left;
-  -webkit-tap-highlight-color: transparent;
-}
-.workspace__sheet-row--visible {
-  background: color-mix(in srgb, var(--accent) 12%, var(--bg));
-}
-.workspace__sheet-row-title {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.workspace__sheet-row-count {
-  flex-shrink: 0;
-  min-width: 20px;
-  text-align: center;
-  font-size: 12px;
-  color: var(--muted);
-  background: color-mix(in srgb, var(--bg) 80%, var(--text) 8%);
-  border-radius: 999px;
-  padding: 1px 6px;
 }
 
 /* Tab context menu — the split path. Fixed at the pointer. */
@@ -626,7 +491,6 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .workspace__sheet { animation: none; }
   /* Instant swap — no draw-in flourish (design item 5, reduced-motion). */
   .workspace__divider-bar { transition: none; animation: none; }
   /* Reduced motion: instant geometry + color, no fade or morph (design §3.3). */
@@ -635,10 +499,8 @@
   .workspace__coachmark { animation: none; }
   /* Reduced motion never arms a mode descriptor (the controller commits directly),
      so nothing carries data-mode-motion; this is defensive parity — any element
-     that somehow did gets no beat. Covers wrappers, strips, dividers, and chip. */
+     that somehow did gets no beat. Covers wrappers, strips, and dividers. */
   .shell [data-mode-motion] { animation: none !important; }
   .shell--builder-exiting .workspace__divider,
-  .shell--builder-exiting .workspace__pane-chip,
-  .shell--builder-entering .workspace__divider,
-  .shell--builder-entering .workspace__pane-chip { animation: none; }
+  .shell--builder-entering .workspace__divider { animation: none; }
 }

--- a/tests/mode-transition.spec.mjs
+++ b/tests/mode-transition.spec.mjs
@@ -201,7 +201,7 @@ async function sampleEnterPaint(page) {
             const progress = panes[0].getAnimations()[0]?.effect?.getComputedTiming?.().progress
             if (progress != null && progress < 0.5) {
               for (const chrome of document.querySelectorAll(
-                '.workspace__divider, .workspace__pane-chip',
+                '.workspace__divider',
               )) {
                 earlyChromeOpacity = Math.max(
                   earlyChromeOpacity,


### PR DESCRIPTION
## Summary
- time-box and lifecycle-cancel initial chat loads so a wedged request cannot leave the outgoing pane snapshot held indefinitely
- remove the unrequested top-right pane switcher, complete tab keyboard/ARIA ownership, and keep tab-title travel at a constant speed
- batch drag geometry reads and make divider feedback transform-only to reduce per-frame layout work

## Validation
- frontend: 1810 unit tests passed
- hooks: 47 tests passed
- focused pane/handoff source contracts: 71 passed
- production frontend build + built-global audit passed
- local disk-heavy e2e intentionally deferred to hosted CI because the repository safety gate requires 20 GiB free and the host has less