### PR TITLE
Protect visible Builder workspaces from shell reloads

### DIFF
--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -360,9 +360,10 @@ export default function Shell() {
   // preview holds the tiled world; the committed mode otherwise. The single source
   // (INV 4) — no scattered override.
   const effectiveViewMode = modeMachine.effectiveViewMode(modeState, { splitsEnabled: SPLITS })
-  const builderWorkspaceVisible = effectiveViewMode === 'panes'
-  const builderWorkspaceVisibleRef = useRef(builderWorkspaceVisible)
-  builderWorkspaceVisibleRef.current = builderWorkspaceVisible
+  const multiPaneBuilderVisible = effectiveViewMode === 'panes'
+    && paneModel.paneIdsInOrder(workspace).length > 1
+  const multiPaneBuilderVisibleRef = useRef(multiPaneBuilderVisible)
+  multiPaneBuilderVisibleRef.current = multiPaneBuilderVisible
   // The latched presentation plan for the live animated beat. Either direction may
   // carry a stationary single-world underlay while panes scatter or assemble over it.
   const beatPlan = modeMachine.transitionPresentation(modeState)
@@ -760,7 +761,7 @@ export default function Shell() {
       activeElement: document.activeElement,
       activeView: activeViewRef.current,
       activeChatId: activeChatIdRef.current,
-      builderWorkspaceVisible: builderWorkspaceVisibleRef.current,
+      multiPaneBuilderVisible: multiPaneBuilderVisibleRef.current,
       streamingChatIds: streamingChatIdsRef.current,
       passiveRebuild: passive,
       voiceDictationActive: voiceDictationActiveRef.current,
@@ -771,7 +772,7 @@ export default function Shell() {
 
   function shellReloadHasStableVisibleHold(passive) {
     if (document.visibilityState === 'hidden') return false
-    if (builderWorkspaceVisibleRef.current) return true
+    if (multiPaneBuilderVisibleRef.current) return true
     return passive
       && activeViewRef.current === 'chat'
       && activeChatIdRef.current != null
@@ -844,7 +845,7 @@ export default function Shell() {
   // protected for a passive generation.
   useEffect(() => {
     checkPendingShellReload()
-  }, [activeView, activeChatId, builderWorkspaceVisible])
+  }, [activeView, activeChatId, multiPaneBuilderVisible])
   // Global connectivity indicator. The composer already disables send when
   // offline (ChatView); this surfaces the state shell-wide so the user is
   // never tapping in the dark about whether they're connected.

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -360,6 +360,9 @@ export default function Shell() {
   // preview holds the tiled world; the committed mode otherwise. The single source
   // (INV 4) — no scattered override.
   const effectiveViewMode = modeMachine.effectiveViewMode(modeState, { splitsEnabled: SPLITS })
+  const builderWorkspaceVisible = effectiveViewMode === 'panes'
+  const builderWorkspaceVisibleRef = useRef(builderWorkspaceVisible)
+  builderWorkspaceVisibleRef.current = builderWorkspaceVisible
   // The latched presentation plan for the live animated beat. Either direction may
   // carry a stationary single-world underlay while panes scatter or assemble over it.
   const beatPlan = modeMachine.transitionPresentation(modeState)
@@ -757,6 +760,7 @@ export default function Shell() {
       activeElement: document.activeElement,
       activeView: activeViewRef.current,
       activeChatId: activeChatIdRef.current,
+      builderWorkspaceVisible: builderWorkspaceVisibleRef.current,
       streamingChatIds: streamingChatIdsRef.current,
       passiveRebuild: passive,
       voiceDictationActive: voiceDictationActiveRef.current,
@@ -765,9 +769,10 @@ export default function Shell() {
     })
   }
 
-  function passiveChatReloadIsReadingHold(passive) {
+  function shellReloadHasStableVisibleHold(passive) {
+    if (document.visibilityState === 'hidden') return false
+    if (builderWorkspaceVisibleRef.current) return true
     return passive
-      && document.visibilityState !== 'hidden'
       && activeViewRef.current === 'chat'
       && activeChatIdRef.current != null
   }
@@ -776,10 +781,10 @@ export default function Shell() {
     if (!pendingShellReloadRef.current) return
     const passive = pendingShellReloadPassiveRef.current
     if (shellReloadWouldDisruptUser({ passive })) {
-      // A passive watcher generation has no deadline while somebody is reading
-      // a visible chat. Wait for the view/visibility effects below instead of
-      // waking the page every six seconds for the whole reading session.
-      if (!passiveChatReloadIsReadingHold(passive)) scheduleShellReloadCheck()
+      // Stable visible holds (the whole Builder workspace, or a passive watcher
+      // while reading a chat) have no deadline. Wait for the view/mode/visibility
+      // effects below instead of waking the page every six seconds.
+      if (!shellReloadHasStableVisibleHold(passive)) scheduleShellReloadCheck()
     } else {
       performShellReload({ passive })
     }
@@ -798,7 +803,7 @@ export default function Shell() {
       ? (pendingShellReloadPassiveRef.current && passive)
       : passive
     pendingShellReloadRef.current = true
-    if (!passiveChatReloadIsReadingHold(pendingShellReloadPassiveRef.current)) {
+    if (!shellReloadHasStableVisibleHold(pendingShellReloadPassiveRef.current)) {
       scheduleShellReloadCheck()
     }
   }
@@ -834,11 +839,12 @@ export default function Shell() {
     }
   }, [])
 
-  // A passive generation held for a visible chat should land as soon as the
-  // owner leaves the chat surface. Switching between chats remains protected.
+  // Release a stable visible hold as soon as the owner leaves the chat surface
+  // or returns from Builder to Standard. Switching between chats remains
+  // protected for a passive generation.
   useEffect(() => {
     checkPendingShellReload()
-  }, [activeView, activeChatId])
+  }, [activeView, activeChatId, builderWorkspaceVisible])
   // Global connectivity indicator. The composer already disables send when
   // offline (ChatView); this surfaces the state shell-wide so the user is
   // never tapping in the dark about whether they're connected.

--- a/frontend/src/components/Shell/__tests__/shellReloadPolicy.test.js
+++ b/frontend/src/components/Shell/__tests__/shellReloadPolicy.test.js
@@ -95,6 +95,35 @@ test('passive watcher rebuilds coalesce while an idle chat is visible', () => {
   }), false, 'a hidden page is a safe apply boundary')
 })
 
+test('builder holds every shell generation until the workspace is not visible', () => {
+  const base = {
+    activeElement: el('body'),
+    activeView: 'chat',
+    activeChatId: 'focused',
+    builderWorkspaceVisible: true,
+    streamingChatIds: new Set(),
+    lastUserInteractionAt: 0,
+    now: 10000,
+  }
+  assert.equal(shouldDeferShellReload({
+    ...base,
+    passiveRebuild: true,
+  }), true)
+  assert.equal(shouldDeferShellReload({
+    ...base,
+    passiveRebuild: false,
+  }), true, 'an explicit generation cannot tear down the other visible panes')
+  assert.equal(shouldDeferShellReload({
+    ...base,
+    activeView: 'canvas',
+    passiveRebuild: false,
+  }), true, 'the protection follows the whole builder workspace, not route kind')
+  assert.equal(shouldDeferShellReload({
+    ...base,
+    visibilityState: 'hidden',
+  }), false, 'backgrounding the page remains a safe apply boundary')
+})
+
 test('hidden pages can reload without disrupting focus', () => {
   assert.equal(shouldDeferShellReload({
     activeElement: el('textarea'),

--- a/frontend/src/components/Shell/__tests__/shellReloadPolicy.test.js
+++ b/frontend/src/components/Shell/__tests__/shellReloadPolicy.test.js
@@ -95,12 +95,12 @@ test('passive watcher rebuilds coalesce while an idle chat is visible', () => {
   }), false, 'a hidden page is a safe apply boundary')
 })
 
-test('builder holds every shell generation until the workspace is not visible', () => {
+test('multi-pane builder holds every shell generation until the workspace is not visible', () => {
   const base = {
     activeElement: el('body'),
     activeView: 'chat',
     activeChatId: 'focused',
-    builderWorkspaceVisible: true,
+    multiPaneBuilderVisible: true,
     streamingChatIds: new Set(),
     lastUserInteractionAt: 0,
     now: 10000,
@@ -122,6 +122,10 @@ test('builder holds every shell generation until the workspace is not visible', 
     ...base,
     visibilityState: 'hidden',
   }), false, 'backgrounding the page remains a safe apply boundary')
+  assert.equal(shouldDeferShellReload({
+    ...base,
+    multiPaneBuilderVisible: false,
+  }), false, 'a one-pane Builder keeps the existing deliberate idle-apply path')
 })
 
 test('hidden pages can reload without disrupting focus', () => {

--- a/frontend/src/components/Shell/shellReloadPolicy.js
+++ b/frontend/src/components/Shell/shellReloadPolicy.js
@@ -71,6 +71,7 @@ export function shouldDeferShellReload({
   activeElement,
   activeView,
   activeChatId,
+  builderWorkspaceVisible = false,
   streamingChatIds,
   passiveRebuild = false,
   voiceDictationActive = false,
@@ -79,6 +80,13 @@ export function shouldDeferShellReload({
   visibilityState = 'visible',
 } = {}) {
   if (visibilityState === 'hidden') return false
+  // Builder is one live workspace, not merely the focused route. Reloading it
+  // at the focused chat's idle boundary tears down every visible chat and app
+  // pane together, producing a workspace-wide blank/reload even when the other
+  // panes are actively being read or used. Keep all shell generations queued
+  // until the page is backgrounded or the owner returns to Standard. This is
+  // the multi-pane counterpart of the visible-canvas protection below.
+  if (builderWorkspaceVisible) return true
   // Canvas apps may contain games, unsaved work, media, or nested fullscreen
   // documents whose state is opaque to the shell. Never tear down that visible
   // surface for a background shell generation. The existing active-view and

--- a/frontend/src/components/Shell/shellReloadPolicy.js
+++ b/frontend/src/components/Shell/shellReloadPolicy.js
@@ -71,7 +71,7 @@ export function shouldDeferShellReload({
   activeElement,
   activeView,
   activeChatId,
-  builderWorkspaceVisible = false,
+  multiPaneBuilderVisible = false,
   streamingChatIds,
   passiveRebuild = false,
   voiceDictationActive = false,
@@ -86,7 +86,7 @@ export function shouldDeferShellReload({
   // panes are actively being read or used. Keep all shell generations queued
   // until the page is backgrounded or the owner returns to Standard. This is
   // the multi-pane counterpart of the visible-canvas protection below.
-  if (builderWorkspaceVisible) return true
+  if (multiPaneBuilderVisible) return true
   // Canvas apps may contain games, unsaved work, media, or nested fullscreen
   // documents whose state is opaque to the shell. Never tear down that visible
   // surface for a background shell generation. The existing active-view and

--- a/tests/shell-update-idle.spec.mjs
+++ b/tests/shell-update-idle.spec.mjs
@@ -41,6 +41,7 @@
  */
 import { test, expect } from '@playwright/test'
 import { createTaggedChat, attachCleanup } from './_chatTracker.mjs'
+import * as paneModel from '../frontend/src/components/Shell/paneModel.js'
 
 const BASE = process.env.MOBIUS_URL || 'http://localhost:8001'
 
@@ -141,6 +142,26 @@ async function gotoEmptyChat(page) {
   await page.goto(`${BASE}/shell/?chat=${chat.id}`, { waitUntil: 'domcontentloaded' })
   await expect(page.locator('.chat__empty-wrap')).toBeVisible({ timeout: 8000 })
   return chat
+}
+
+async function seedTwoPaneBuilder(page, firstChatId, secondChatId) {
+  let workspace = paneModel.seedFromFlatTabs([
+    { kind: 'chat', id: firstChatId },
+    { kind: 'chat', id: secondChatId },
+  ])
+  workspace = paneModel.moveTab(workspace, `chat:${secondChatId}`, {
+    root: true,
+    edge: 'right',
+  })
+  workspace = paneModel.focusPane(workspace, 'p0')
+  const blob = paneModel.serializeWorkspace(workspace)
+  const legacy = JSON.stringify(paneModel.flatten(workspace)
+    .map(tab => ({ kind: tab.kind, id: tab.id })))
+  await page.addInitScript(([workspaceKey, workspaceBlob, openTabs]) => {
+    localStorage.setItem('mobius:workspace-splits', '1')
+    sessionStorage.setItem(workspaceKey, workspaceBlob)
+    sessionStorage.setItem('mobius-open-tabs', openTabs)
+  }, [paneModel.STORAGE_KEY, blob, legacy])
 }
 
 async function sendMessage(page, text) {
@@ -264,6 +285,37 @@ test.describe('shell update — apply on idle, SW on a leash', () => {
     // hello (no replay), so nothing re-applies.
     await page.waitForTimeout(2000)
     expect(await loadCount(page)).toBe(1)
+  })
+
+  test('a deliberate apply waits for a visible multi-pane Builder and releases in the background', async ({ page }) => {
+    let armApply
+    const armed = new Promise(resolve => { armApply = resolve })
+    await setup(page, {
+      streamRoute: route => route.fulfill(fulfillStream(sse([{ type: 'done' }]))),
+      systemRoute: oneShotSystemEventRoute('shell_apply_now', armed),
+    })
+    const first = await createTaggedChat(page)
+    const second = await createTaggedChat(page)
+    await seedTwoPaneBuilder(page, first.id, second.id)
+    await page.goto(`${BASE}/shell/?chat=${first.id}`, { waitUntil: 'domcontentloaded' })
+    await expect(page.locator('.workspace__divider')).toBeVisible({ timeout: 8000 })
+    await resetLoadCount(page)
+
+    armApply()
+    await page.waitForTimeout(1000)
+    expect(await loadCount(page)).toBe(0)
+
+    await page.evaluate(() => {
+      Object.defineProperty(document, 'visibilityState', {
+        configurable: true,
+        value: 'hidden',
+      })
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+    await page.waitForFunction(
+      () => Number(sessionStorage.getItem('__load_count') || '0') === 1,
+      { timeout: 8000 },
+    )
   })
 
   test('passive shell_rebuilt stays queued while an idle chat is visible', async ({ page }) => {

--- a/tests/shell-update-idle.spec.mjs
+++ b/tests/shell-update-idle.spec.mjs
@@ -298,7 +298,8 @@ test.describe('shell update — apply on idle, SW on a leash', () => {
     const second = await createTaggedChat(page)
     await seedTwoPaneBuilder(page, first.id, second.id)
     await page.goto(`${BASE}/shell/?chat=${first.id}`, { waitUntil: 'domcontentloaded' })
-    await expect(page.locator('.workspace__divider')).toBeVisible({ timeout: 8000 })
+    await expect(page.locator('.workspace__chrome')).toBeVisible({ timeout: 8000 })
+    await expect(page.locator('.shell__view--paned')).toHaveCount(2)
     await resetLoadCount(page)
 
     armApply()


### PR DESCRIPTION
## Summary
- defer shell generation reloads while Builder is visibly presenting multiple panes
- apply the queued generation after the page is backgrounded or the owner returns to one pane or Standard
- preserve the existing deliberate idle-apply path for a one-pane workspace
- cover both the protected multi-pane path and the one-pane release path with regression tests

## Why
A shell generation could reload at the focused chat's idle boundary while Builder displayed several panes. That tore down every visible pane together and could leave chats appearing blank while their history and live state reconstructed. The guard is deliberately tied to multiple visible panes so ordinary one-pane shell updates still land safely at idle.

## Testing
- `npm test` (1,870 passed)
- `npm run build`
- focused reload-policy tests (9 passed)
- added browser coverage for multi-pane hold and background release; hosted browser rerun pending