### PR TITLE
Fix chat image gallery scrolling and clicks

### DIFF
--- a/frontend/src/components/ChatView/__tests__/imageGallery.test.js
+++ b/frontend/src/components/ChatView/__tests__/imageGallery.test.js
@@ -80,12 +80,17 @@ test('prose ends one gallery run before a later image run', () => {
   )
 })
 
-test('the rail preserves native momentum instead of emulating touch scrolling', () => {
-  assert.doesNotMatch(gallerySource, /onPointerMove|scrollLeft\s*=/)
+test('the rail scrolls freely with native touch and mouse or pen grabbing', () => {
+  assert.match(gallerySource, /event\.pointerType === 'touch'\) return/)
+  assert.match(gallerySource, /drag\.axis = Math\.abs\(deltaX\)/)
+  assert.match(gallerySource, /if \(!drag\.captured\)/)
+  assert.match(gallerySource, /drag\.captured = true[\s\S]*setPointerCapture/)
+  assert.match(gallerySource, /scrollLeft = drag\.startScrollLeft - deltaX/)
+  assert.match(gallerySource, /onClickCapture/)
   assert.match(markdownCss, /touch-action:\s*pan-x pan-y/)
   assert.match(markdownCss, /-webkit-overflow-scrolling:\s*touch/)
-  assert.match(markdownCss, /scroll-snap-type:\s*x proximity/)
-  assert.doesNotMatch(markdownCss, /scroll-snap-type:\s*x mandatory/)
+  assert.doesNotMatch(markdownCss, /scroll-snap-type/)
+  assert.doesNotMatch(gallerySource, /md-image-gallery__dots/)
 })
 
 test('an image-only assistant reply stretches the gallery instead of collapsing', () => {

--- a/frontend/src/components/ChatView/__tests__/imageGallery.test.js
+++ b/frontend/src/components/ChatView/__tests__/imageGallery.test.js
@@ -86,6 +86,8 @@ test('the rail scrolls freely with native touch and mouse or pen grabbing', () =
   assert.match(gallerySource, /if \(!drag\.captured\)/)
   assert.match(gallerySource, /drag\.captured = true[\s\S]*setPointerCapture/)
   assert.match(gallerySource, /scrollLeft = drag\.startScrollLeft - deltaX/)
+  assert.match(gallerySource, /onLostPointerCapture=\{endPointerDrag\}/)
+  assert.match(gallerySource, /clearTimeout\(suppressTimerRef\.current\)/)
   assert.match(gallerySource, /onClickCapture/)
   assert.match(markdownCss, /touch-action:\s*pan-x pan-y/)
   assert.match(markdownCss, /-webkit-overflow-scrolling:\s*touch/)

--- a/frontend/src/components/ChatView/markdown.css
+++ b/frontend/src/components/ChatView/markdown.css
@@ -243,8 +243,6 @@ ol.md-list ol.md-list ol.md-list { list-style: lower-roman; }
   min-width: 0;
   overflow-x: auto;
   overscroll-behavior-x: contain;
-  scroll-snap-type: x proximity;
-  scroll-padding-inline: 4px;
   scrollbar-width: none;
   -webkit-overflow-scrolling: touch;
   touch-action: pan-x pan-y;
@@ -265,7 +263,6 @@ ol.md-list ol.md-list ol.md-list { list-style: lower-roman; }
   min-width: 0;
   aspect-ratio: 4 / 3;
   overflow: hidden;
-  scroll-snap-align: start;
   border-radius: 10px;
   background: var(--surface);
 }
@@ -281,6 +278,19 @@ ol.md-list ol.md-list ol.md-list { list-style: lower-roman; }
 .md-image-gallery__item .md-image {
   border-radius: inherit;
   object-fit: cover;
+  -webkit-user-drag: none;
+  user-select: none;
+}
+
+@media (pointer: fine) {
+  .md-image-gallery__rail {
+    cursor: grab;
+  }
+
+  .md-image-gallery__rail.is-dragging {
+    cursor: grabbing;
+    user-select: none;
+  }
 }
 
 .md-image-gallery__nav {

--- a/frontend/src/components/ChatView/markdown/ImageGallery.jsx
+++ b/frontend/src/components/ChatView/markdown/ImageGallery.jsx
@@ -104,6 +104,12 @@ export default function ImageGallery({ images }) {
     if (viewerKey !== null && viewerIndex < 0) setViewerKey(null)
   }, [viewerIndex, viewerKey])
 
+  useEffect(() => () => {
+    clearTimeout(suppressTimerRef.current)
+    dragRef.current = null
+    suppressClickRef.current = false
+  }, [])
+
   function beginPointerDrag(event) {
     if (!event.isPrimary || event.pointerType === 'touch') return
     if (event.pointerType === 'mouse' && event.button !== 0) return
@@ -170,6 +176,7 @@ export default function ImageGallery({ images }) {
         onPointerMove={movePointerDrag}
         onPointerUp={endPointerDrag}
         onPointerCancel={endPointerDrag}
+        onLostPointerCapture={endPointerDrag}
         onClickCapture={(event) => {
           if (!suppressClickRef.current) return
           suppressClickRef.current = false

--- a/frontend/src/components/ChatView/markdown/ImageGallery.jsx
+++ b/frontend/src/components/ChatView/markdown/ImageGallery.jsx
@@ -15,14 +15,17 @@ function smoothBehavior() {
 /**
  * Compact, copy-friendly image filmstrip.
  *
- * mobius-ui:ImageRail — touch/trackpad scrolling is deliberately native. Do
- * not add pointer-move scroll emulation here: it removes mobile momentum and
- * competes with the chat's vertical scroll. Desktop buttons and Arrow keys are
- * the explicit non-gesture alternatives.
+ * mobius-ui:ImageRail — touch/trackpad scrolling is deliberately native so it
+ * keeps momentum and cooperates with the chat's vertical scroll. Mouse and pen
+ * get grab-to-scroll only after a horizontal gesture is established. Desktop
+ * buttons and Arrow keys remain the explicit non-gesture alternatives.
  */
 export default function ImageGallery({ images }) {
   const count = images.length
   const railRef = useRef(null)
+  const dragRef = useRef(null)
+  const suppressClickRef = useRef(false)
+  const suppressTimerRef = useRef(0)
   const [canPrevious, setCanPrevious] = useState(false)
   const [canNext, setCanNext] = useState(false)
   const [viewerKey, setViewerKey] = useState(null)
@@ -101,6 +104,55 @@ export default function ImageGallery({ images }) {
     if (viewerKey !== null && viewerIndex < 0) setViewerKey(null)
   }, [viewerIndex, viewerKey])
 
+  function beginPointerDrag(event) {
+    if (!event.isPrimary || event.pointerType === 'touch') return
+    if (event.pointerType === 'mouse' && event.button !== 0) return
+    dragRef.current = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      startScrollLeft: event.currentTarget.scrollLeft,
+      axis: null,
+      moved: false,
+      captured: false,
+    }
+  }
+
+  function movePointerDrag(event) {
+    const drag = dragRef.current
+    if (!drag || drag.pointerId !== event.pointerId) return
+    const deltaX = event.clientX - drag.startX
+    const deltaY = event.clientY - drag.startY
+    if (!drag.axis && Math.hypot(deltaX, deltaY) > 4) {
+      drag.axis = Math.abs(deltaX) > Math.abs(deltaY) ? 'x' : 'y'
+    }
+    if (drag.axis !== 'x') return
+    if (!drag.captured) {
+      drag.captured = true
+      event.currentTarget.setPointerCapture?.(event.pointerId)
+      event.currentTarget.classList.add('is-dragging')
+    }
+    drag.moved = true
+    event.preventDefault()
+    event.currentTarget.scrollLeft = drag.startScrollLeft - deltaX
+  }
+
+  function endPointerDrag(event) {
+    const drag = dragRef.current
+    if (!drag || drag.pointerId !== event.pointerId) return
+    dragRef.current = null
+    event.currentTarget.classList.remove('is-dragging')
+    if (event.currentTarget.hasPointerCapture?.(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId)
+    }
+    if (!drag.moved) return
+    suppressClickRef.current = true
+    clearTimeout(suppressTimerRef.current)
+    suppressTimerRef.current = window.setTimeout(() => {
+      suppressClickRef.current = false
+    }, 0)
+  }
+
   return (
     <section
       className={`md-image-gallery md-image-gallery--${Math.min(count, 3)}`}
@@ -114,6 +166,16 @@ export default function ImageGallery({ images }) {
         tabIndex={0}
         onScroll={syncOverflow}
         onKeyDown={handleKeyDown}
+        onPointerDown={beginPointerDrag}
+        onPointerMove={movePointerDrag}
+        onPointerUp={endPointerDrag}
+        onPointerCancel={endPointerDrag}
+        onClickCapture={(event) => {
+          if (!suppressClickRef.current) return
+          suppressClickRef.current = false
+          event.preventDefault()
+          event.stopPropagation()
+        }}
       >
         {images.map((image, index) => (
           <div className="md-image-gallery__item" key={resolvedItems[index].key}>

--- a/tests/image-gallery.spec.mjs
+++ b/tests/image-gallery.spec.mjs
@@ -141,6 +141,19 @@ test('desktop filmstrip is compact and supports buttons, keyboard, and viewer na
   await page.keyboard.press('ArrowLeft')
   await expect.poll(() => rail.evaluate(element => element.scrollLeft)).toBeLessThan(20)
 
+  const railBox = await rail.boundingBox()
+  if (!railBox) throw new Error('Gallery rail did not render')
+  await page.mouse.move(railBox.x + railBox.width * 0.62, railBox.y + railBox.height / 2)
+  await page.mouse.down()
+  await page.mouse.move(
+    railBox.x + railBox.width * 0.22,
+    railBox.y + railBox.height / 2,
+    { steps: 6 },
+  )
+  await page.mouse.up()
+  await expect.poll(() => rail.evaluate(element => element.scrollLeft)).toBeGreaterThan(100)
+  await expect(page.locator('.lightbox-overlay')).toHaveCount(0)
+
   await page.getByRole('button', { name: 'Open Forest path preview' }).click()
   await expect(page.getByRole('dialog', { name: /Image 2 of 4/ })).toBeVisible()
   await expect(page.locator('.lightbox-count')).toHaveText('2 / 4')


### PR DESCRIPTION
## Summary
- keep chat image rails continuously scrollable instead of snapping between cards
- restore reliable click-to-open by claiming the pointer only after a horizontal drag begins
- preserve native touch and trackpad momentum while adding mouse and pen grab-to-scroll
- cleanly end captured drags if pointer capture is lost or the gallery unmounts

## Testing
- frontend library tests: 1,822 passed
- frontend hook tests: 47 passed
- `npm run build`
- rendered Chromium checks: a click opens the viewer, a drag scrolls without opening it, and a later click still opens normally