### PR TITLE
perf(agent): compose app skills and stabilize visual verification

### DIFF
--- a/backend/app/routes/standalone.py
+++ b/backend/app/routes/standalone.py
@@ -1280,6 +1280,12 @@ def standalone_shell(slug: str, db: Session = Depends(get_db)):
     //     dismissed earlier this session.
     (function setupInstallCard() {{
       const platform = window.__mobiusPlatform || {{}};
+      let visualContentOnly = false;
+      try {{
+        visualContentOnly =
+          sessionStorage.getItem('mobius:visual-content-only') === '1';
+      }} catch (_) {{}}
+      if (visualContentOnly) return;
 
       // Element handles. All of these are rendered above in the same
       // template — a missing node here means the template was edited

--- a/backend/scripts/agent-screenshot.sh
+++ b/backend/scripts/agent-screenshot.sh
@@ -108,6 +108,18 @@ agent-browser open "${API_BASE_URL}/" >/dev/null
 # and JSON-encodes it so any character is a safe JS string literal.
 AGENT_TOKEN="$AGENT_TOKEN" python3 -c 'import json,os; print("localStorage.setItem(\"token\", "+json.dumps(os.environ["AGENT_TOKEN"])+")")' | agent-browser eval --stdin >/dev/null
 
+# Content mode is a browser-session presentation flag, not onboarding or
+# install completion state. Set it before the target document mounts so React
+# never opens its modal (and therefore never inerts the app workspace). Clear it
+# for ordinary captures so a prior content-only preview cannot affect them.
+if [ "$CONTENT_ONLY" -eq 1 ]; then
+  agent-browser eval \
+    "sessionStorage.setItem('mobius:visual-content-only', '1')" >/dev/null
+else
+  agent-browser eval \
+    "sessionStorage.removeItem('mobius:visual-content-only')" >/dev/null
+fi
+
 # Now navigate to the actual target route, authenticated.
 agent-browser open "${API_BASE_URL}${ROUTE}" >/dev/null
 
@@ -134,20 +146,6 @@ AUTH_OK="$(agent-browser eval \
 if [ "$AUTH_OK" != "true" ]; then
   echo "agent-screenshot.sh: authentication failed; the token was rejected or the login page remained visible" >&2
   exit 1
-fi
-
-# App-content verification should not mutate first-run or install state merely
-# to expose the surface under test. Remove only product-owned top-document
-# overlays for this capture/session; app-owned dialogs inside the opaque frame
-# remain intact and testable.
-if [ "$CONTENT_ONLY" -eq 1 ]; then
-  OVERLAYS_CLEAR="$(agent-browser eval \
-    "(() => { document.querySelectorAll('.wt__overlay, #install-backdrop').forEach((node) => node.remove()); return !document.querySelector('.wt__overlay, #install-backdrop'); })()" \
-    2>/dev/null || true)"
-  if [ "$OVERLAYS_CLEAR" != "true" ]; then
-    echo "agent-screenshot.sh: could not establish overlay-free content mode" >&2
-    exit 1
-  fi
 fi
 
 # A fresh phone-width shell can restore with the modal navigation drawer open

--- a/backend/scripts/agent-screenshot.sh
+++ b/backend/scripts/agent-screenshot.sh
@@ -18,21 +18,31 @@
 #   /settings              owner settings, etc.
 #
 # Usage:
-#   agent-screenshot.sh <route> <out.png>
+#   agent-screenshot.sh [--content-only] <route> <out.png>
 #   <route> is path-absolute (starts with /); it is appended to
 #   $API_BASE_URL.
+#
+# --content-only removes product-owned walkthrough/install overlays from this
+# browser document after auth. It is deliberately ephemeral: no completion or
+# dismissal state is written to the owner's account or browser storage.
 #
 # Prints the output path on stdout, or non-zero if the auth dance
 # fails (no token, no API_BASE_URL, no viewport, no agent-browser).
 
 set -euo pipefail
 
+CONTENT_ONLY=0
+if [ "${1:-}" = "--content-only" ]; then
+  CONTENT_ONLY=1
+  shift
+fi
+
 ROUTE="${1:-}"
 OUT="${2:-}"
 
 if [ -z "$ROUTE" ]; then
   echo "agent-screenshot.sh: route required" >&2
-  echo "Usage: agent-screenshot.sh <route> [out.png]" >&2
+  echo "Usage: agent-screenshot.sh [--content-only] <route> [out.png]" >&2
   exit 1
 fi
 
@@ -124,6 +134,20 @@ AUTH_OK="$(agent-browser eval \
 if [ "$AUTH_OK" != "true" ]; then
   echo "agent-screenshot.sh: authentication failed; the token was rejected or the login page remained visible" >&2
   exit 1
+fi
+
+# App-content verification should not mutate first-run or install state merely
+# to expose the surface under test. Remove only product-owned top-document
+# overlays for this capture/session; app-owned dialogs inside the opaque frame
+# remain intact and testable.
+if [ "$CONTENT_ONLY" -eq 1 ]; then
+  OVERLAYS_CLEAR="$(agent-browser eval \
+    "(() => { document.querySelectorAll('.wt__overlay, #install-backdrop').forEach((node) => node.remove()); return !document.querySelector('.wt__overlay, #install-backdrop'); })()" \
+    2>/dev/null || true)"
+  if [ "$OVERLAYS_CLEAR" != "true" ]; then
+    echo "agent-screenshot.sh: could not establish overlay-free content mode" >&2
+    exit 1
+  fi
 fi
 
 # A fresh phone-width shell can restore with the modal navigation drawer open

--- a/backend/scripts/init_skills.py
+++ b/backend/scripts/init_skills.py
@@ -34,7 +34,7 @@ from pathlib import Path
 DATA_DIR = Path(os.environ.get("DATA_DIR", "/data"))
 SKILLS = DATA_DIR / "shared" / "skills"
 VERSION_FILE = SKILLS / ".seed-version"
-SEED_VERSION = "16"  # v16: explicit app-skill dependencies + stable test/finalize tools
+SEED_VERSION = "17"  # v17: inert-safe visual mode + ref-based iframe testing
 # Update only byte-for-byte baked copies; an owner/agent-edited file is never
 # touched. A set preserves every known unmodified predecessor when one skill
 # needs more than one fix-forward migration over its lifetime.
@@ -65,12 +65,18 @@ _UNMODIFIED_MIGRATIONS = {
   },
   "building-apps-quickstart.md": {
     "7d8af2664b37a69b88e48c2a28140c15556202c3c7ce30d77816c203d1959fcb",
+    # v16 baked copy: replace the unreliable CSS iframe selector.
+    "4c2b080bcc91626f761c5823ea00d324667b9710f6757931823e22e9c8b5c2b1",
   },
   "app-component-shapes.md": {
     "0320609ff924a0954c20d5e5db91ed3681d421d76f6804b24552eb6e8fa5eb31",
+    # v16 baked copy: keep routine app builds from loading the catalog.
+    "91243377242700acb5093165af58c372bed0005f358d3a4b26774aeb2ef8a365",
   },
   "visual-testing.md": {
     "9525b36b945c2a0b4cb02806081bb674f38e865b6e1c3961226112e1dbbc16ec",
+    # v16 baked copy: use iframe refs and preserve React's inert cleanup.
+    "a0648921b9c9ea2423e8abd52aa57e71e7bebfa1736073fcf3bfcaec3749ad19",
   },
 }
 

--- a/backend/scripts/init_skills.py
+++ b/backend/scripts/init_skills.py
@@ -34,7 +34,7 @@ from pathlib import Path
 DATA_DIR = Path(os.environ.get("DATA_DIR", "/data"))
 SKILLS = DATA_DIR / "shared" / "skills"
 VERSION_FILE = SKILLS / ".seed-version"
-SEED_VERSION = "15"  # v15: native skill discovery + app quickstart split
+SEED_VERSION = "16"  # v16: explicit app-skill dependencies + stable test/finalize tools
 # Update only byte-for-byte baked copies; an owner/agent-edited file is never
 # touched. A set preserves every known unmodified predecessor when one skill
 # needs more than one fix-forward migration over its lifetime.
@@ -44,9 +44,12 @@ _UNMODIFIED_MIGRATIONS = {
     # Resource-stewardship predecessor: propagate the adaptive analytics
     # and self-throttling contract only to untouched copies.
     "865dd241a99668b026cd9be90c472cfde562210df51f729b2c25929f6b3bd60a",
+    # v15 baked copy: route app work through the base + matching extensions.
+    "cba6c0c7dd97384bbe3bfa19e78707bfa272085843bab5102279a937467e5d17",
   },
   "cron.md": {
     "289336d78ad4268110360f12faac5512d5a53b66aa31c2a6ddd1a44f538f2559",
+    "ed100cb496b887a7951adc967e92cda1449c4f8594f7859fbd32762221d24914",
   },
   "recovery.md": {
     "ef62abb0d03d740f99add1b6f3938f780b34439cb0025616cb9dc5f74f779633",
@@ -58,6 +61,16 @@ _UNMODIFIED_MIGRATIONS = {
   "building-apps.md": {
     "4126b40d209c422184e0135f611bb9f4197ea280fa27e63cd71c806f8b5ebd79",
     "91b655952d55b37fda0be82e3914c3b09e67ca7c5f5a575d315fb2ca75ef08f1",
+    "563dcd7bfa1ff7cbad074d98462eb9755a010a15bf340c7f594fc7f6825a6a86",
+  },
+  "building-apps-quickstart.md": {
+    "7d8af2664b37a69b88e48c2a28140c15556202c3c7ce30d77816c203d1959fcb",
+  },
+  "app-component-shapes.md": {
+    "0320609ff924a0954c20d5e5db91ed3681d421d76f6804b24552eb6e8fa5eb31",
+  },
+  "visual-testing.md": {
+    "9525b36b945c2a0b4cb02806081bb674f38e865b6e1c3961226112e1dbbc16ec",
   },
 }
 

--- a/backend/scripts/preview_app.sh
+++ b/backend/scripts/preview_app.sh
@@ -14,7 +14,9 @@
 # shell's `moebius:frame-init` postMessage before initializing — so we
 # go through /app/<id> in the authenticated shell. For the STANDALONE
 # PWA page of an app, call agent-screenshot.sh /apps/<slug>/ directly.
-# All auth/viewport/banner handling lives in agent-screenshot.sh.
+# All auth/viewport/banner handling lives in agent-screenshot.sh. App previews
+# use its ephemeral content-only mode so owner onboarding/install overlays do
+# not cover the app under test or mutate account completion state.
 
 set -euo pipefail
 
@@ -28,4 +30,4 @@ fi
 OUT="${2:-/data/chats/${CHAT_ID:-unknown}/media/app-${APP_ID}.png}"
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec "${DIR}/agent-screenshot.sh" "/app/${APP_ID}" "${OUT}"
+exec "${DIR}/agent-screenshot.sh" --content-only "/app/${APP_ID}" "${OUT}"

--- a/backend/scripts/register_app.py
+++ b/backend/scripts/register_app.py
@@ -23,6 +23,7 @@ import urllib.request
 # script normally runs by absolute path, so add the backend package root.
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from app.app_capabilities import local_manifest_runtime_fields  # noqa: E402
+from app import app_git  # noqa: E402
 
 
 def _call(url: str, token: str, method: str, data: dict | None = None):
@@ -142,6 +143,26 @@ def _read_capabilities(source_dir: str) -> dict:
   return _read_manifest_registration(source_dir)["capabilities"]
 
 
+def _finalize_source(source_dir: str, *, created: bool) -> None:
+  """Record the source accepted by registration in the per-app repository.
+
+  Registration owns the initial commit; the watcher owns later save commits.
+  ``commit_local`` treats an already-clean tree as success, so a delayed
+  watcher event cannot turn successful registration into a failing empty
+  ``git commit``.
+  """
+  message = "create app" if created else "register app update"
+  try:
+    app_git.commit_local(source_dir, message)
+  except Exception as exc:  # noqa: BLE001 - surface an actionable CLI failure
+    print(
+      "App registration succeeded, but its source commit failed: "
+      f"{exc}. Re-run register_app.py to retry safely.",
+      file=sys.stderr,
+    )
+    sys.exit(1)
+
+
 def main() -> None:
   if len(sys.argv) != 4:
     print(
@@ -220,6 +241,7 @@ def main() -> None:
       },
     )
 
+  _finalize_source(source_dir, created=existing is None)
   print(json.dumps(app))
   _notify(token, base, "app_updated", appId=str(app["id"]))
 

--- a/backend/scripts/seed-skills/app-component-shapes.md
+++ b/backend/scripts/seed-skills/app-component-shapes.md
@@ -1,13 +1,14 @@
 # Mini-app component shapes
 
-The canonical shape for every recurring piece of mini-app UI — markup +
-scoped CSS — so each app holds its OWN copy of a block. Copy the block you need
-into your app's `const CSS`, apply your per-app prefix, keep the kebab ROLE
-suffix + structure recognizable, and diverge the shape wherever your app needs
-to. This catalog is a starting set, not a closed enum — if your app needs a
-shape that isn't here, build it in the same idiom (scoped CSS, theme tokens, a
-fence) and own it. `Read` this when building or restyling any app's UI,
-alongside [building-apps.md].
+Optional UI-pattern catalog for Möbius mini-apps. Read only the relevant
+section, alongside `building-apps-quickstart.md` and `visual-testing.md`, when
+the app needs a recurring root, header, sheet, empty, card, form, tab, chat, or
+split-pane structure.
+
+Copy the selected markup + scoped CSS block into the app's `const CSS`, apply a
+per-app prefix, keep the kebab role suffix and structure recognizable, and
+diverge wherever the app needs to. This is a starting catalog, not a closed
+component API.
 
 Why copies and not a shared library yet: a shared component freezes an API
 before the shapes have proven stable, and then any app that needs something it
@@ -18,68 +19,17 @@ extraction into a real `@mobius/ui` you import — a `grep` of the fence names
 finds the kin. Until then, owning your fork is correct. This is the platform's
 "code empowers the agent; it does not police it," in CSS form.
 
-## The rules (read once, then copy blocks)
+## How to use this catalog
 
-- **One stylesheet, not inline objects.** Declare a module-level
-  ``const CSS = `...` `` and render it once at the app root as
-  `<style>{CSS}</style>`. Use the inline `style={}` prop ONLY for values
-  computed at render time (a measured height, a drag transform, a per-row
-  accent). Inline objects can't do `:hover`/`:focus`/`:active`, media
-  queries, `@keyframes`, or pseudo-elements — that's the friction wall this
-  avoids. The app runs in its own iframe, so the `<style>` is automatically
-  scoped to your app; no CSS Modules, no hashing, no BEM-for-isolation.
-- **GOTCHA — the CSS is a JS template literal.** A literal backtick or a `${`
-  anywhere in the CSS (an `url("data:image/svg+xml,…")`, a `content:` string, a
-  comment) breaks the esbuild compile. Keep backticks out of CSS, escape `${` as
-  `\${`, and quote inside `url()` / `content:`.
-- **Naming:** a short per-app prefix on every class (`mg-` memory, `cb-` atlas,
-  a 2–3-char mnemonic for yours — `ma-` is the placeholder below) + semantic
-  kebab role names (`ma-header`, `ma-sheet`, `ma-card`, `ma-btn`). States use
-  REAL pseudo-classes (`.ma-btn:hover`, `:disabled`, `:focus-visible`).
-  App-driven state CSS can't read uses an `is-`/`has-` modifier class
-  (`.ma-card.is-selected`). **Never** a `tab(active)` / `card(variant)`
-  JS-helper that returns a style object — that hides state in JS and blocks
-  extraction.
-- **Structural color is always a theme token** so the app follows light/dark:
-  `--bg --surface --surface2 --text --muted --accent --accent-fg --accent-hover
-  --accent-dim --border --border-light --danger --green --font --mono`. There
-  is **no `--red`** (use `--danger`) and **no `--fg`** (use `--text`).
-  Hardcoded hex only for an app-specific accent the theme can't express.
-- **`--accent-fg` is the ONLY legal foreground on an accent/danger FILL**
-  (a `.ma-btn-primary`, a `.ma-btn-danger`, an accent chip). It resolves a
-  prior three-way split — apps had been hardcoding `#fff` / `#0d0d0d` /
-  `#062016` for that foreground, so a custom theme broke one of them. Write
-  `color: var(--accent-fg)` with **NO fallback hex** (`var(--accent-fg, #fff)`
-  re-introduces the exact split the token exists to kill). Never hardcode the
-  foreground on a fill.
-- **Touch + radius:** every interactive control `min-height: 44px`; icon-only
-  buttons get an `aria-label`. Radius scale: 8px inputs/small, 10–12px
-  cards/primary buttons, 16px sheet top.
-- **Hard pre-ship checklist (don't skip — these are the gaps a grep found
-  recur in every app):**
-  - Every focusable input is `font-size: 16px` (anything smaller triggers
-    iOS Safari zoom-on-focus). Don't go lower on a field the user can tap into.
-  - Every tap target is `>= 44px`. A thin control (a resizer, a drag handle)
-    stays thin VISUALLY but gets a fat invisible hit-area (a transparent
-    `::before`/`::after` or padding that pushes the hit-box to 44px).
-  - No bare `outline: none` on an interactive control — keep a visible
-    `:focus-visible` ring (see the Focus shape) or the keyboard user is lost.
-  - One `mobius-ui:ReducedMotion` block per app (below); every `@keyframes`
-    animation also has a `prefers-reduced-motion` escape.
-  - Edge-pinned surfaces respect `env(safe-area-inset-*)` (below).
-- **No native `confirm/alert/prompt`** — the sandbox has no `allow-modals`,
-  so they silently no-op. Use the bottom-sheet (§3).
-- The app-frame already injects a global reset + the theme `:root`. **Do not
-  redeclare a reset.**
-- **Fence comments are harvest markers, not a sync contract.** Wrap each shared
-  block in its `/* mobius-ui:Name */` … `/* /mobius-ui:Name */` marker so a
-  `grep` finds every app on a shape when it's time to harvest a real library.
-  Your per-app prefix means class names legitimately differ — keep the kebab
-  ROLE suffix + markup recognizable and diverge the shape whenever your app needs
-  to; you owe no identical-name obligation. A rough block order reads well:
-  root → header → list → cards → empty → sheet → buttons/inputs → animations.
+The quickstart owns stylesheet, theme-token, accessibility, touch-target,
+reduced-motion, and native-dialog rules; do not duplicate them from here.
+Copy only the blocks the app actually needs and replace the `ma-` placeholder
+with a short app prefix.
 
-`app-latex` and `memory` are the cleanest on-standard references.
+Fence comments such as `/* mobius-ui:Card */` are harvest markers, not a sync
+contract. They make similar app-owned copies discoverable if a pattern later
+earns extraction into a real shared library. Until then, the app owns and may
+diverge its copy.
 
 ---
 

--- a/backend/scripts/seed-skills/app-component-shapes.md
+++ b/backend/scripts/seed-skills/app-component-shapes.md
@@ -1,9 +1,9 @@
 # Mini-app component shapes
 
-Optional UI-pattern catalog for Möbius mini-apps. Read only the relevant
-section, alongside `building-apps-quickstart.md` and `visual-testing.md`, when
-the app needs a recurring root, header, sheet, empty, card, form, tab, chat, or
-split-pane structure.
+Optional structural-pattern catalog for Möbius mini-apps. Read only a matching
+section alongside `building-apps-quickstart.md` and `visual-testing.md` when the
+brief needs a fixed app shell, modal sheet, tabs, chat, or split pane. Do not
+load it for an ordinary root, header, card, or form.
 
 Copy the selected markup + scoped CSS block into the app's `const CSS`, apply a
 per-app prefix, keep the kebab role suffix and structure recognizable, and

--- a/backend/scripts/seed-skills/building-apps-quickstart.md
+++ b/backend/scripts/seed-skills/building-apps-quickstart.md
@@ -2,8 +2,8 @@
 
 Base workflow for every local Möbius mini-app create or update. Read it with
 `visual-testing.md`; add `building-apps.md` for advanced runtime needs,
-`cron.md` for scheduled jobs, and `app-component-shapes.md` only for a relevant
-catalogued UI structure.
+`cron.md` for scheduled jobs, and `app-component-shapes.md` only for a complex
+catalogued structure such as a sheet, tabs, chat, or split pane.
 
 This is the complete workflow for a focused app with ordinary JSX,
 app-scoped storage, and no unusual host integration. Add `building-apps.md` to
@@ -200,18 +200,24 @@ For interaction testing, switch the browser driver into the app frame, then
 snapshot there so the shell and drawer do not consume the context:
 
 ```bash
-agent-browser frame 'iframe[data-app-id="<app-id>"]'
+agent-browser snapshot -i -d 2
+# Find: Iframe "<app name>" [ref=eN]
+agent-browser frame @eN
 agent-browser snapshot -i
 # interact and re-snapshot inside the frame
 agent-browser frame main
 ```
 
-Use the returned refs, re-snapshot after any DOM change, and verify one complete
-primary flow plus persistence when the app saves data. Do not use
+The shallow parent snapshot creates the documented iframe ref without dumping
+the full shell. Use that ref rather than a CSS frame selector: response-sandboxed
+opaque frames can be absent from the selector resolver even though their browser
+frame and accessibility subtree are healthy. Use returned refs, re-snapshot
+after any DOM change, and verify one complete primary flow plus persistence when
+the app saves data. Do not use
 `wait --text` for iframe content; it observes the top-level document. The
-preview helper already gates the initial frame readiness and removes only
-product-owned top-document walkthrough/install overlays for this browser
-session; it does not mark onboarding complete.
+preview helper already gates the initial frame readiness and prevents
+product-owned top-document walkthrough/install overlays from mounting in this
+isolated browser session; it does not mark onboarding complete.
 
 Check the partner's actual viewport first. Add one phone-sized check only when
 the supplied viewport is not already phone-sized or the layout materially

--- a/backend/scripts/seed-skills/building-apps-quickstart.md
+++ b/backend/scripts/seed-skills/building-apps-quickstart.md
@@ -1,12 +1,13 @@
 # Mini-app quickstart — ordinary local apps
 
-Use this skill for the common case: creating or making a straightforward
-update to a local Möbius mini-app under `/data/apps/<slug>/`. It is the fast
-path for a focused app with ordinary JSX, app-scoped storage, and no unusual
-host integration.
+Base workflow for every local Möbius mini-app create or update. Read it with
+`visual-testing.md`; add `building-apps.md` for advanced runtime needs,
+`cron.md` for scheduled jobs, and `app-component-shapes.md` only for a relevant
+catalogued UI structure.
 
-Do **not** read the full `building-apps.md` as well unless the request actually
-needs one of its advanced paths:
+This is the complete workflow for a focused app with ordinary JSX,
+app-scoped storage, and no unusual host integration. Add `building-apps.md` to
+the initial read only when the request already needs one of its advanced paths:
 
 - wrapping or packaging an existing site/game;
 - an installable or upstream-tracked app;
@@ -15,8 +16,12 @@ needs one of its advanced paths:
 - microphone/device capabilities;
 - an embedded agent, immersive mode, or internal navigation/back handling.
 
-For an ordinary one-screen or small multi-card app, this file is the complete
-workflow. Do not re-read it later in the same turn.
+Add `cron.md` instead for a scheduled/background job. Add the component catalog
+only when its summary names a structure the brief actually needs.
+
+For an ordinary one-screen or small multi-card app, do not load another build
+skill later in the turn unless a newly discovered requirement crosses one of
+those boundaries.
 
 ## Product target: fast, useful, and delightful
 
@@ -73,12 +78,9 @@ icon.png
 .gitignore
 ```
 
-Initialize the app directory as its own repository before any Git status or
-commit command:
-
-```bash
-git -C /data/apps/<slug> init -b main
-```
+Do not initialize or commit the app repository by hand. Registration creates
+the per-app repository and records the accepted initial source; the watcher
+records later successful saves.
 
 The entry shape is:
 
@@ -184,8 +186,8 @@ index or use `store.list()`. Do not use `localStorage`, IndexedDB, native
 
 ### 5. Verify the rendered app without exploring the whole shell
 
-Read `visual-testing.md` once before the first browser check. Use the
-readiness-gated helper:
+Use the already-loaded `visual-testing.md` workflow. Start with the
+readiness-gated, overlay-free app helper:
 
 ```bash
 bash "$SCRIPTS_DIR/preview_app.sh" <app-id>
@@ -194,17 +196,22 @@ bash "$SCRIPTS_DIR/preview_app.sh" <app-id>
 It waits for the app frame to mount, captures into the chat media directory,
 and prints the embed line. View that PNG before describing it.
 
-For interaction testing, scope the accessibility snapshot to the app frame so
-the shell and drawer do not consume the context:
+For interaction testing, switch the browser driver into the app frame, then
+snapshot there so the shell and drawer do not consume the context:
 
 ```bash
-agent-browser snapshot -i -s 'iframe[data-app-id="<app-id>"]'
+agent-browser frame 'iframe[data-app-id="<app-id>"]'
+agent-browser snapshot -i
+# interact and re-snapshot inside the frame
+agent-browser frame main
 ```
 
 Use the returned refs, re-snapshot after any DOM change, and verify one complete
 primary flow plus persistence when the app saves data. Do not use
 `wait --text` for iframe content; it observes the top-level document. The
-preview helper already gates the initial frame readiness.
+preview helper already gates the initial frame readiness and removes only
+product-owned top-document walkthrough/install overlays for this browser
+session; it does not mark onboarding complete.
 
 Check the partner's actual viewport first. Add one phone-sized check only when
 the supplied viewport is not already phone-sized or the layout materially
@@ -231,15 +238,9 @@ Run validation once:
 python "$SCRIPTS_DIR/validate-app.py" /data/apps/<slug>
 ```
 
-Commit only the app source you created:
-
-```bash
-git -C /data/apps/<slug> add index.jsx mobius.json README.md icon.png .gitignore
-git -C /data/apps/<slug> commit -m "Build <short app purpose>"
-```
-
-If the watcher already committed an edit, a clean app-repo status is success;
-inspect that app repo's log rather than the parent `/data` repository.
+Do not run a second `git add` or `git commit`. `register_app.py` owns the
+initial source commit and treats an already-clean tree as success; the watcher
+owns later save commits. Repository status is not a build gate.
 
 Send the app-complete notification using `notifications.md`, embed the useful
 render before describing it, state what the app does, and invite optional

--- a/backend/scripts/seed-skills/building-apps.md
+++ b/backend/scripts/seed-skills/building-apps.md
@@ -1,6 +1,13 @@
 # Building mini-apps
 
-The advanced mini-app contract: packaged/installable apps, services and fetching, secrets/concurrent storage, cross-app access, embedded agents, device capabilities, immersive mode, navigation, and uncommon runtime boundaries. For an ordinary local app create or straightforward update, read `building-apps-quickstart.md` instead and do not load this file.
+Advanced extension for Möbius mini-apps. Read it alongside
+`building-apps-quickstart.md` and `visual-testing.md` when work needs packaging,
+services/fetching, privileged storage, embedded agents, device capabilities,
+immersive mode, or navigation.
+
+This file contains only the advanced contract and deltas from the base
+workflow. For an ordinary local create or straightforward update, the
+quickstart plus visual-testing pair is complete.
 
 Mini-apps are JSX components in sandboxed iframes. Each gets `appId` and an app-scoped `token`, and persists through `window.mobius.storage`. Shell-mounted app frames intentionally omit `allow-same-origin`: their effective origin is opaque (`null`), they cannot read the shell's localStorage/owner JWT, and origin-bound browser stores such as IndexedDB/OPFS are unavailable. Root-relative API fetches still work when they present the scoped bearer; `window.mobius.storage` owns that transport and its offline fallbacks.
 
@@ -25,60 +32,13 @@ is a permission boundary, not a substitute for origin-bound browser features.
 
 ---
 
-## Which path: local-first or installable
+## How this extends the base workflow
 
-Two shapes of app ship through different entry points, but both should be
-repo-ready from day one:
-
-- **A local-first app for this instance** (the common case, and what you build when the partner asks for "an app"): write source under `/data/apps/<slug>/` and run `register_app.py` once (see *Lifecycle* below). The helper reads `index.jsx` plus the `capabilities` declaration from an adjacent `mobius.json`; later manifest edits synchronize through the same watcher as source. Keep a valid `mobius.json`, README, icon, and source `.gitignore` beside the source unless the app is truly throwaway; that makes "turn this into a repo/share it" a packaging step instead of archaeology.
-- **An installable app from a repo** (when the partner already wants to share/install it elsewhere): author `mobius.json` plus `index.jsx` in a root-level repo package, push it, then install with `POST /api/apps/install` and the raw manifest URL (see *Packaging / wrapping* above). The installer creates the `/data/apps/<slug>` repo and tracks upstream/local history.
-
-When unsure, build local-first, but leave the app repo-ready.
-
----
-
-## Start minimal — a functional core, designed to grow
-
-**Default to the smallest app that fully nails the core use case: a minimal set of functional features and a minimal, clean UI — then hand it back for the partner to expand on.** A first build is a starting point, not a finished product. Ship the feature that makes the app worth opening (the habit tracker tracks habits; the notes app captures and lists notes), styled to the design conventions, and stop there. The partner drives what comes next — richer views, more entry types, automation — and you add it when they ask. Deliver progressively, but do not manufacture extra conversational turns when the request is already clear.
-
-This is a default, **not a ceiling**. Möbius apps are low-floor / high-ceiling: a small first cut keeps the floor low and reversible (less surface to break, easy to reshape), and the architecture here — split-on-concept modules, scoped CSS, a storage layer — exists so that ceiling stays open. Build for the expansion you can't see yet; don't wall it off with a sprawling v1.
-
-So don't over-build, and don't artificially under-build either:
-
-- **The default is minimal-functional.** When the request is broad or vague ("make me a notes app"), build the clean core and let the partner pull it richer. Resist gold-plating a v1 with features nobody asked for — every speculative screen is more to get wrong and more to undo.
-- **Build richer when the request clearly warrants it.** If the partner spells out scope ("a reading tracker with covers, a star rating, a yearly goal, and a stats page"), build *that* — don't strip a detailed ask back to a toy to satisfy "minimal." Minimal-first governs your default for an under-specified request; it never overrides an explicit one.
-- **When unsure which it is, the clarify turn decides.** That's what the propose step is for — name the minimal core you'd ship and ask whether they want more, rather than guessing big and over-building.
-
----
-
-## Build in visible layers
-
-For new mini-apps, get to an openable first layer quickly, then keep improving
-it while the partner can watch and try it:
-
-1. Create a coherent first layer: themed shell, primary layout, empty/loading/error states, storage paths, and one real functional slice. Do not register a blank "coming soon" stub unless the partner explicitly asked for a placeholder.
-2. Register as soon as that first layer should compile and contains one real feature. In a live building chat, registration opens the app as a tab beside its owning chat without stealing focus, so the partner can keep talking while the preview becomes available. They can switch to that tab and watch it take shape while you keep working — every save the file watcher recompiles and refreshes it live. That makes registering the first coherent layer promptly worth even more: it is the moment the app becomes something to watch, not just a promise.
-3. Immediately smoke-check the shell preview before continuing: it renders coherently, has no missing imports/assets, and any storage-backed path used by the slice works.
-4. Continue in visible increments. Each save should leave the app in a coherent state; the file watcher recompiles source edits and an app open in the shell preview/canvas refreshes to the latest compiled bundle. Standalone `/apps/<slug>/` PWAs may need a manual refresh/reopen.
-5. Signal only milestones the partner benefits from: the first preview is available; verification/refinement is underway when substantial work remains; and completion. Combine `build_phase.py` with a tool call doing real work when possible—never add a separate call solely to announce a routine internal step.
-6. If the first visible layer will take more than a few minutes because of packaging, auth, data migration, or a risky dependency, say that early and explain the gating reason.
-
-Layered does **not** mean under-building. It means the first useful slice becomes
-interactive early, then the richer pieces land while the app is alive.
-
----
-
-## Before building: check existing apps
-
-Default to checking what already exists before creating a new one:
-
-```bash
-curl -s -H "Authorization: Bearer $AGENT_TOKEN" "$API_BASE_URL/api/apps/" | python3 -m json.tool
-```
-
-If an app with the same purpose exists, update it instead of duplicating. If the partner says "build X" and X already exists, confirm whether they want to update or replace it.
-
-Search the wider ecosystem only when the partner asked to find, install, share, or upstream something; named an existing product; or the request is likely to match a shipped app exactly. Do not load `contributing.md`, query GitHub, or search the catalog for a uniquely named personal local build.
+Keep the quickstart's product scope, visible-first sequence, registration,
+validation, and browser workflow. This extension changes only the mechanism
+required by the advanced feature below. An installable app starts as a
+root-level repository package and is installed from its raw `mobius.json` URL;
+an ordinary local app stays on the quickstart path.
 
 ---
 
@@ -171,54 +131,7 @@ The wrapper is a thin Möbius app around someone else's build. The gotchas, lear
 
 ---
 
-## Component shape
-
-```jsx
-export default function MyApp({ appId, token }) {
-  return <div>...</div>
-}
-```
-
----
-
-## Lifecycle — source folder, register on create, just save to edit
-
-1. Create a source folder at `/data/apps/<name>/`.
-2. Put the app entrypoint at `/data/apps/<name>/index.jsx`.
-3. Split larger apps into sibling `.js`, `.jsx`, `.ts`, or `.tsx` modules inside that same folder and import them relatively from `index.jsx`.
-4. Add repo-ready package files when the app might live beyond this instance: `mobius.json`, `README.md`, `icon.png`, and `.gitignore`.
-5. Keep durable static build assets under `static/`; keep runtime data in storage, not in the source folder.
-
-Example:
-
-```text
-/data/apps/mood-board/
-  mobius.json
-  README.md
-  icon.png
-  .gitignore
-  index.jsx
-  Board.jsx
-  cards.js
-  static/
-    sample.png
-```
-
-On first create only, register + compile as soon as the first usable layer has
-one real feature and should compile (mints the id + DB row and, in a live
-building chat, gives the partner an openable shell preview):
-
-```bash
-python "$SCRIPTS_DIR/register_app.py" "<name>" "<description>" /data/apps/<name>/index.jsx
-```
-
-`register_app.py` reads `$CHAT_ID` from the environment and stores it with the app so crash reports route back to this chat. It also reads the versioned `capabilities` block from the adjacent `mobius.json`, has the backend normalize it into the runtime contract, and emits the app-update signal that lets a live building chat surface the open-preview affordance.
-
-**For edits, just write source files — do NOT re-run `register_app.py`.** A file watcher recompiles when `index.jsx`, source-like modules, or `mobius.json` under `/data/apps/<slug>/` change (ignoring generated/static dirs such as `static/`, `.build/`, `dist/`, `node_modules/`, and `.git/`). For local apps, a manifest edit and its normalized capability contract land atomically with the rebuilt bundle; an invalid or unknown declaration leaves the prior app live. Store-installed capability changes remain gated by the reviewed update flow. If the partner already has the app open in the shell preview/canvas, each successful recompile refreshes them onto the newest compiled bundle; standalone PWAs may need refresh/reopen. The helper patches the existing row when the `source_dir` is the same, but registering from a different folder or bypassing the helper can still create duplicates. If the partner says it didn't change, read the App row's `compiled_path` from `GET /api/apps/<id>`, confirm that content-addressed file exists, and look for `compile failed for` in `/data/logs/chat.log` — a JSX syntax error, broken import, or invalid capability declaration blocks the recompile. If a duplicate appears, `DELETE /api/apps/<dup-id>`. **Don't be fooled by a clean git tree:** the watcher auto-commits each recompile as an `agent edit` commit, so right after you save, `git -C /data/apps/<slug> status` is clean and `git add`/`git diff` show nothing — that is your edit having *landed*, not lost. Use `git log` to see the source commit and the App row's changed `compiled_path` to confirm the new bundle landed; there is nothing to stage.
-
-**Use `register_app.py`, not raw `curl POST /api/apps/`.** The raw endpoint requires an undocumented `jsx_source` field (422 without it); updates are `PATCH` not `PUT` (405). The helper handles all of this — skipping it burns tool calls rediscovering the schema from error responses.
-
-### Share Later Checklist
+## Sharing a local app later
 
 When the partner asks to share a local-first app as a repo, make the existing source tree installable instead of rebuilding it elsewhere:
 

--- a/backend/scripts/seed-skills/cron.md
+++ b/backend/scripts/seed-skills/cron.md
@@ -1,6 +1,9 @@
 # Scheduled tasks (cron)
 
-How to create recurring jobs that survive a rebuild: manifest schedules, supervised app jobs, the scaffold for owner-managed jobs, and the scheduled-app UI rule. `Read` this before scheduling anything.
+Scheduled-job extension for Möbius. Read it alongside
+`building-apps-quickstart.md` and `visual-testing.md` when work includes a
+scheduled mini-app UI; it owns manifest schedules, supervised jobs,
+owner-managed scaffolds, and cadence controls.
 
 The container has `cron` installed. Cron tasks run as `mobius` and get the app id as `$1`.
 
@@ -71,7 +74,7 @@ curl -fsS \
 
 ## Scheduled-app UI — never ship a dead time-picker
 
-A mini-app whose cadence is fixed must NOT render a time-picker that writes a file nothing reads. If the cadence is NOT user-editable, show it in words ("Updates daily") plus "ask the Möbius agent to reschedule." If it IS editable, ship a `sync-cron.sh` that actually rewrites the crontab (via the scaffold above). Lead with the cadence either way. (Full app design conventions: `building-apps.md`.)
+A mini-app whose cadence is fixed must NOT render a time-picker that writes a file nothing reads. If the cadence is NOT user-editable, show it in words ("Updates daily") plus "ask the Möbius agent to reschedule." If it IS editable, ship a `sync-cron.sh` that actually rewrites the crontab (via the scaffold above). Lead with the cadence either way. The base app/UI contract is already supplied by `building-apps-quickstart.md` plus `visual-testing.md`; load `app-component-shapes.md` only for a relevant recurring structure.
 
 ---
 

--- a/backend/scripts/seed-skills/reflection.md
+++ b/backend/scripts/seed-skills/reflection.md
@@ -48,7 +48,15 @@ preserving the brief and safety contracts.
 - **Be conservative and reversible.** You are operating on the partner's live platform while they sleep. Everything you change is in `/data`'s git history — but prefer changes you'd be comfortable explaining in the morning. **Never auto-apply anything risky** (security fixes with behavior change, destructive data ops, dependency major-bumps, anything that hits paid external APIs or notifies other people). Surface those in the brief as a proposal with a one-tap question, don't do them.
 - **Commit as you go.** After each discrete chunk — a skill edit, a system-improvement note, an app fix — `pm-commit '<area>: <what and why>'`. One green-on-green sweep is hard to undo; small commits are easy.
 - **Anti-noise is the whole game.** Every item that reaches the brief MUST carry **trigger** (what you observed), **why** (why it matters to the partner), and **next-action** (the one concrete thing — ideally a tap). An item without all three is noise; drop it or keep digging until it has them. The same rule applies to your own diagnostics: a command without a fresh trigger or an explicit due date is resource noise. A short brief the partner reads fully beats a long one they skim.
-- **Leverage the other skills — don't reinvent them.** `Read /data/shared/skills/<name>.md` and follow it for the work it owns: `building-apps.md` for any app fix/feature, `theming.md` for shell/visual work, `cron.md` for scheduled jobs, `notifications.md` for the morning push, `images.md` for any brief illustration, and `/data/shared/skills/memory.md` only when interpreting Memory's update log or proposing memory-system improvements. This skill orchestrates; those skills hold the per-task contracts.
+- **Leverage the other skills — don't reinvent them.** Batch-read the complete
+  set implied by the work: `building-apps-quickstart.md` +
+  `visual-testing.md` for any app fix/feature; add `building-apps.md`,
+  `cron.md`, or `app-component-shapes.md` only when their inventory
+  descriptions match. Use `theming.md` + `visual-testing.md` for shell/visual
+  work, `notifications.md` for the morning push, `images.md` for any brief
+  illustration, and `/data/shared/skills/memory.md` only when interpreting
+  Memory's update log or proposing memory-system improvements. This skill
+  orchestrates; those skills hold the per-task contracts.
 - **Time-box and bail safely.** If you're running long, finish the current chunk, commit it, skip ahead to "Write the brief" — a partial-but-shipped brief beats a perfect one that never posts. Note in the brief what you skipped.
 - **The deliverable is non-negotiable: write the brief.** Reflection may improve skills, apps, and system routines before that, but a partial night with a truthful brief beats a perfect investigation that never ships.
 
@@ -286,7 +294,11 @@ usage, prevented a risk, changed user-visible behavior, or needs a decision.
 
 **Only improve apps the partner actually touched.** This is the leading rule. The `per-app-digest.json` staged in `inputs/` is your first stop — read it before reviewing any app. It gives you: `opens_24h` (how many times the partner opened the app today), `signal_counts` (what events fired), `app_errors_24h` + `recent_app_errors` (UNCAUGHT crashes the browser caught), `last_5_errors` (errors the app EXPLICITLY reported via `signal('error')`), `request_errors_24h` + `top_request_errors` (bounded, query-free HTTP failure groups with counts), and `has_signals` (whether the app emits analytics at all). The digest's top-level `shell_errors_24h` and `shell_request_errors_24h` cover the owner shell. Sort by `opens_24h` descending, but never skip an app with a high repeated-request count: a fetch retry loop may consume CPU and disk without throwing JavaScript. An app with `opens_24h == 0` and no recent errors does not need attention tonight unless an interview specifically flagged it.
 
-`Read /data/shared/skills/building-apps.md` before touching any app; it owns the component shape, storage traps, and lifecycle. List what's installed if you need the full set:
+Before touching an app, batch-read
+`/data/shared/skills/building-apps-quickstart.md` and
+`/data/shared/skills/visual-testing.md`; add the advanced, cron, or component
+catalog skill only when its inventory description matches the issue. List
+what's installed if you need the full set:
 
 ```bash
 curl -s -H "Authorization: Bearer $AGENT_TOKEN" "$API_BASE_URL/api/apps/" | python3 -m json.tool
@@ -475,7 +487,7 @@ Commit the brief + run artifacts: `pm-commit 'reflection: brief for <date>'`.
 
 The partner's taps on a brief's question cards don't reach a live agent — they're saved and surface at the **start of your NEXT run** as `inputs/prev-question-answers.json` (staged by `fetch.sh`). You read it in **phase 0** and **act on it in phase 2**. This is the most valuable signal you get; treat it as a first-class input, not an afterthought.
 
-- **Act.** Each answer is a decision: build the feature they picked, apply the security fix they approved, drop the ones they declined. Treat a card answer as approval for exactly what it offered — nothing more. Build/iterate following `building-apps.md`. Don't re-ask a question they already answered — `prev-question-answers.json` is the record of what's settled.
+- **Act.** Each answer is a decision: build the feature they picked, apply the security fix they approved, drop the ones they declined. Treat a card answer as approval for exactly what it offered — nothing more. Build/iterate with the quickstart + visual-testing base pair and only the matching extensions. Don't re-ask a question they already answered — `prev-question-answers.json` is the record of what's settled.
 - **Learn — update Memory.** Their pick is a fact about them (a confirmed preference, a priority, a thing they don't care about). Record it (`about-the-user`) so future briefs propose better and waste fewer of their taps. A declined suggestion is as informative as an accepted one.
 - **Learn — update the skills, including this one.** If the partner consistently declines a *kind* of suggestion, or always wants more/less detail, or a question landed wrong, that's a reflection-skill edit: change what you prioritize, prune, or how you phrase the next brief's questions. `pm-commit` it.
 

--- a/backend/scripts/seed-skills/visual-testing.md
+++ b/backend/scripts/seed-skills/visual-testing.md
@@ -1,6 +1,9 @@
 # Visual testing and screenshots
 
-Use this workflow whenever you visually test a Möbius shell or mini-app, drive `agent-browser`, capture a screenshot, inspect a rendered state, or describe screenshot evidence to the partner. The core constitution owns the invariant that visual claims need visible evidence; this skill owns the commands and mechanics.
+Visual-testing extension for Möbius shell and app work. Read it alongside
+`building-apps-quickstart.md` for every mini-app build/update, or alongside
+`theming.md` for shell UI changes; it owns browser interaction, screenshots,
+and visible evidence.
 
 ## Drive the rendered page with agent-browser
 
@@ -15,23 +18,33 @@ bash "$SCRIPTS_DIR/agent-screenshot.sh" <route> <out.png>
 # /apps/<slug>/    → a mini-app's standalone PWA page (by slug)
 ```
 
-`preview_app.sh <id>` and `preview_shell.sh [chat_id]` are thin wrappers over it for those two common cases. `preview_app.sh` is readiness-gated: it waits for the shell's real post-render frame-mounted state, so a successful capture is not merely the loading skeleton. Use the helper, then `Read`/`view_image` the PNG before describing it.
+`preview_app.sh <id>` and `preview_shell.sh [chat_id]` are thin wrappers over it
+for those two common cases. `preview_app.sh` is readiness-gated and uses
+ephemeral content-only mode: it waits for the real post-render frame-mounted
+state and removes product-owned walkthrough/install overlays from the current
+document without writing onboarding or dismissal state. Use the helper, then
+`Read`/`view_image` the PNG before describing it.
 
 Raw `agent-browser open <url>` is for **non-Möbius pages only** (an external site you're scraping or sanity-checking) — it has no auth dance, so it shows the login wall for any Möbius route.
 
 Core moves once a page is open: `set viewport "$VIEWPORT_WIDTH" "$VIEWPORT_HEIGHT"` (the helper sets this for you; needed when driving raw), `snapshot` (a11y tree with `@eN` refs), `click/fill/type @eN`, `screenshot <path>`, `wait` (on a signal — `wait @eN` / `--text` / `--fn` / `--url` — not a guessed duration), `batch "cmd1" "cmd2"` (ordered, fewer round-trips), `diff snapshot` / `diff screenshot --baseline <before>.png`.
 
-For a mini-app, scope the interaction tree to its iframe rather than dumping the
-whole workspace:
+For a mini-app, switch into its opaque iframe before taking the interaction
+snapshot rather than applying a parent-document selector:
 
 ```bash
-agent-browser snapshot -i -s 'iframe[data-app-id="<app-id>"]'
+agent-browser frame 'iframe[data-app-id="<app-id>"]'
+agent-browser snapshot -i
+# interact and re-snapshot in this frame
+agent-browser frame main
 ```
 
-This keeps chats, tabs, and the app drawer out of model context while retaining
-the app's interactive descendants. Do **not** use `--compact` with this iframe
-selector: current `agent-browser` can collapse it to the iframe node alone.
-Use the returned refs for interaction and re-snapshot after state changes.
+The explicit frame context keeps chats, tabs, and the app drawer out of model
+context while exposing the app's interactive descendants. A selector-scoped
+parent snapshot can return only the iframe node, because the app is an
+intentional opaque-origin security boundary; do not retry that form or weaken
+the iframe sandbox. Use returned refs, re-snapshot after state changes, and
+return to `frame main` before checking shell state.
 
 `agent-browser wait --text` observes the top-level document and is unreliable
 for text inside the opaque app iframe. For initial load, rely on

--- a/backend/scripts/seed-skills/visual-testing.md
+++ b/backend/scripts/seed-skills/visual-testing.md
@@ -21,8 +21,8 @@ bash "$SCRIPTS_DIR/agent-screenshot.sh" <route> <out.png>
 `preview_app.sh <id>` and `preview_shell.sh [chat_id]` are thin wrappers over it
 for those two common cases. `preview_app.sh` is readiness-gated and uses
 ephemeral content-only mode: it waits for the real post-render frame-mounted
-state and removes product-owned walkthrough/install overlays from the current
-document without writing onboarding or dismissal state. Use the helper, then
+state and prevents product-owned walkthrough/install overlays from mounting in
+that isolated browser session without writing onboarding or dismissal state. Use the helper, then
 `Read`/`view_image` the PNG before describing it.
 
 Raw `agent-browser open <url>` is for **non-Möbius pages only** (an external site you're scraping or sanity-checking) — it has no auth dance, so it shows the login wall for any Möbius route.
@@ -33,18 +33,21 @@ For a mini-app, switch into its opaque iframe before taking the interaction
 snapshot rather than applying a parent-document selector:
 
 ```bash
-agent-browser frame 'iframe[data-app-id="<app-id>"]'
+agent-browser snapshot -i -d 2
+# Find: Iframe "<app name>" [ref=eN]
+agent-browser frame @eN
 agent-browser snapshot -i
 # interact and re-snapshot in this frame
 agent-browser frame main
 ```
 
-The explicit frame context keeps chats, tabs, and the app drawer out of model
-context while exposing the app's interactive descendants. A selector-scoped
-parent snapshot can return only the iframe node, because the app is an
-intentional opaque-origin security boundary; do not retry that form or weaken
-the iframe sandbox. Use returned refs, re-snapshot after state changes, and
-return to `frame main` before checking shell state.
+The shallow parent snapshot creates the documented iframe ref while keeping
+shell output small; the explicit frame context then exposes only the app's
+interactive descendants. Use the ref rather than a CSS frame selector:
+response-sandboxed opaque frames can be absent from the selector resolver even
+when their browser frame and accessibility subtree are healthy. Do not weaken
+the iframe sandbox. Re-snapshot after state changes and return to `frame main`
+before checking shell state.
 
 `agent-browser wait --text` observes the top-level document and is unreliable
 for text inside the opaque app iframe. For initial load, rely on

--- a/backend/tests/test_agent_screenshot_auth.py
+++ b/backend/tests/test_agent_screenshot_auth.py
@@ -6,6 +6,7 @@ import subprocess
 
 
 SCRIPT = Path(__file__).parents[1] / "scripts" / "agent-screenshot.sh"
+PREVIEW_APP = Path(__file__).parents[1] / "scripts" / "preview_app.sh"
 
 
 def _fake_browser(tmp_path: Path) -> tuple[Path, Path]:
@@ -34,6 +35,7 @@ def _fake_browser(tmp_path: Path) -> tuple[Path, Path]:
 def _run_helper(
   tmp_path: Path, *, auth_ok: bool, route: str = "/chat/example",
   viewport_width: int = 412, viewport_height: int = 915,
+  content_only: bool = False,
 ) -> tuple[subprocess.CompletedProcess, Path, Path, Path]:
   _, marker = _fake_browser(tmp_path)
   output = tmp_path / "shot.png"
@@ -49,8 +51,12 @@ def _run_helper(
     "FAKE_BROWSER_LOG": str(browser_log),
     "FAKE_SCREENSHOT_MARKER": str(marker),
   }
+  args = ["bash", str(SCRIPT)]
+  if content_only:
+    args.append("--content-only")
+  args.extend([route, str(output)])
   result = subprocess.run(
-    ["bash", str(SCRIPT), route, str(output)],
+    args,
     env=env,
     text=True,
     capture_output=True,
@@ -143,3 +149,49 @@ def test_non_app_capture_skips_frame_readiness_wait(tmp_path: Path):
     and "iframe[data-app-id=" in command
     for command in commands
   )
+
+
+def test_content_only_mode_removes_product_overlays_before_capture(tmp_path: Path):
+  result, output, marker, browser_log = _run_helper(
+    tmp_path,
+    auth_ok=True,
+    route="/app/42",
+    content_only=True,
+  )
+
+  assert result.returncode == 0, result.stderr
+  assert output.exists()
+  assert marker.exists()
+  commands = browser_log.read_text(encoding="utf-8").splitlines()
+  overlay_index = next(
+    i for i, command in enumerate(commands)
+    if command.startswith("eval ")
+    and ".wt__overlay, #install-backdrop" in command
+  )
+  readiness_index = next(
+    i for i, command in enumerate(commands)
+    if command.startswith("wait --fn ")
+    and 'iframe[data-app-id="42"]' in command
+  )
+  screenshot_index = next(
+    i for i, command in enumerate(commands)
+    if command.startswith("screenshot ")
+  )
+  assert overlay_index < readiness_index < screenshot_index
+
+
+def test_default_mode_preserves_product_overlays(tmp_path: Path):
+  _, _, _, browser_log = _run_helper(tmp_path, auth_ok=True)
+
+  commands = browser_log.read_text(encoding="utf-8").splitlines()
+  assert not any(
+    command.startswith("eval ")
+    and ".wt__overlay, #install-backdrop" in command
+    for command in commands
+  )
+
+
+def test_app_preview_requests_ephemeral_content_only_mode():
+  source = PREVIEW_APP.read_text(encoding="utf-8")
+
+  assert 'agent-screenshot.sh" --content-only "/app/${APP_ID}"' in source

--- a/backend/tests/test_agent_screenshot_auth.py
+++ b/backend/tests/test_agent_screenshot_auth.py
@@ -7,6 +7,8 @@ import subprocess
 
 SCRIPT = Path(__file__).parents[1] / "scripts" / "agent-screenshot.sh"
 PREVIEW_APP = Path(__file__).parents[1] / "scripts" / "preview_app.sh"
+SHELL = Path(__file__).parents[2] / "frontend" / "src" / "components" / "Shell" / "Shell.jsx"
+STANDALONE = Path(__file__).parents[1] / "app" / "routes" / "standalone.py"
 
 
 def _fake_browser(tmp_path: Path) -> tuple[Path, Path]:
@@ -151,7 +153,7 @@ def test_non_app_capture_skips_frame_readiness_wait(tmp_path: Path):
   )
 
 
-def test_content_only_mode_removes_product_overlays_before_capture(tmp_path: Path):
+def test_content_only_mode_is_set_before_target_navigation(tmp_path: Path):
   result, output, marker, browser_log = _run_helper(
     tmp_path,
     auth_ok=True,
@@ -163,10 +165,14 @@ def test_content_only_mode_removes_product_overlays_before_capture(tmp_path: Pat
   assert output.exists()
   assert marker.exists()
   commands = browser_log.read_text(encoding="utf-8").splitlines()
-  overlay_index = next(
+  visual_mode_index = next(
     i for i, command in enumerate(commands)
     if command.startswith("eval ")
-    and ".wt__overlay, #install-backdrop" in command
+    and "sessionStorage.setItem('mobius:visual-content-only', '1')" in command
+  )
+  target_index = next(
+    i for i, command in enumerate(commands)
+    if command == "open http://mobius.test/app/42"
   )
   readiness_index = next(
     i for i, command in enumerate(commands)
@@ -177,18 +183,29 @@ def test_content_only_mode_removes_product_overlays_before_capture(tmp_path: Pat
     i for i, command in enumerate(commands)
     if command.startswith("screenshot ")
   )
-  assert overlay_index < readiness_index < screenshot_index
+  assert visual_mode_index < target_index < readiness_index < screenshot_index
 
 
-def test_default_mode_preserves_product_overlays(tmp_path: Path):
+def test_default_mode_clears_prior_visual_mode_before_navigation(tmp_path: Path):
   _, _, _, browser_log = _run_helper(tmp_path, auth_ok=True)
 
   commands = browser_log.read_text(encoding="utf-8").splitlines()
-  assert not any(
-    command.startswith("eval ")
-    and ".wt__overlay, #install-backdrop" in command
-    for command in commands
+  clear_index = next(
+    i for i, command in enumerate(commands)
+    if "sessionStorage.removeItem('mobius:visual-content-only')" in command
   )
+  target_index = commands.index("open http://mobius.test/chat/example")
+  assert clear_index < target_index
+
+
+def test_content_mode_suppresses_modals_without_dom_surgery():
+  helper = SCRIPT.read_text(encoding="utf-8")
+  shell = SHELL.read_text(encoding="utf-8")
+  standalone = STANDALONE.read_text(encoding="utf-8")
+
+  assert "querySelectorAll('.wt__overlay, #install-backdrop')" not in helper
+  assert "const showWalkthrough = !visualContentOnly" in shell
+  assert "if (visualContentOnly) return;" in standalone
 
 
 def test_app_preview_requests_ephemeral_content_only_mode():

--- a/backend/tests/test_chat_skills_context.py
+++ b/backend/tests/test_chat_skills_context.py
@@ -119,3 +119,37 @@ def test_core_prompt_has_no_static_skill_catalog():
     assert path.name not in core
   assert "skills-index.md" not in core
   assert "<available_skills>" in core
+
+
+def test_owned_app_skill_summaries_expose_complete_initial_read_sets():
+  repo = Path(__file__).resolve().parents[2]
+  seed_dir = repo / "backend" / "scripts" / "seed-skills"
+
+  def summary(name: str) -> str:
+    text = (seed_dir / name).read_text(encoding="utf-8")
+    return next(
+      paragraph.replace("\n", " ")
+      for paragraph in text.split("\n\n")
+      if paragraph.strip() and not paragraph.startswith("#")
+    )
+
+  quickstart = summary("building-apps-quickstart.md")
+  advanced = summary("building-apps.md")
+  shapes = summary("app-component-shapes.md")
+  visual = summary("visual-testing.md")
+  cron = summary("cron.md")
+
+  assert len(quickstart) <= 300
+  assert "visual-testing.md" in quickstart
+  assert "building-apps.md" in quickstart
+  assert "cron.md" in quickstart
+  assert "app-component-shapes.md" in quickstart
+
+  for extension in (advanced, shapes, cron):
+    assert len(extension) <= 300
+    assert "building-apps-quickstart.md" in extension
+    assert "visual-testing.md" in extension
+
+  assert len(visual) <= 300
+  assert "building-apps-quickstart.md" in visual
+  assert "theming.md" in visual

--- a/backend/tests/test_memory_boot.py
+++ b/backend/tests/test_memory_boot.py
@@ -103,7 +103,7 @@ def test_later_boot_migrates_only_unmodified_graph_aware_base_skill(
 def test_retired_image_provider_skills_have_fix_forward_migrations():
   module = _load("init_skills")
 
-  assert module.SEED_VERSION == "16"
+  assert module.SEED_VERSION == "17"
   assert module._UNMODIFIED_MIGRATIONS["images.md"] == {
     "248ea31e13d2d2d84a5acfca13526aa8ebfa3d90e9ee4bf55cfb72d47937f7d1",
   }
@@ -114,12 +114,15 @@ def test_retired_image_provider_skills_have_fix_forward_migrations():
   }
   assert module._UNMODIFIED_MIGRATIONS["building-apps-quickstart.md"] == {
     "7d8af2664b37a69b88e48c2a28140c15556202c3c7ce30d77816c203d1959fcb",
+    "4c2b080bcc91626f761c5823ea00d324667b9710f6757931823e22e9c8b5c2b1",
   }
   assert module._UNMODIFIED_MIGRATIONS["app-component-shapes.md"] == {
     "0320609ff924a0954c20d5e5db91ed3681d421d76f6804b24552eb6e8fa5eb31",
+    "91243377242700acb5093165af58c372bed0005f358d3a4b26774aeb2ef8a365",
   }
   assert module._UNMODIFIED_MIGRATIONS["visual-testing.md"] == {
     "9525b36b945c2a0b4cb02806081bb674f38e865b6e1c3961226112e1dbbc16ec",
+    "a0648921b9c9ea2423e8abd52aa57e71e7bebfa1736073fcf3bfcaec3749ad19",
   }
   assert (
     "6e6e82e02287e8bb38195fb021ea25cee2dc4e27da1a6ce1e2a0143fb1d82d87"

--- a/backend/tests/test_memory_boot.py
+++ b/backend/tests/test_memory_boot.py
@@ -103,13 +103,23 @@ def test_later_boot_migrates_only_unmodified_graph_aware_base_skill(
 def test_retired_image_provider_skills_have_fix_forward_migrations():
   module = _load("init_skills")
 
-  assert module.SEED_VERSION == "15"  # v15: native skill discovery + app quickstart split
+  assert module.SEED_VERSION == "16"
   assert module._UNMODIFIED_MIGRATIONS["images.md"] == {
     "248ea31e13d2d2d84a5acfca13526aa8ebfa3d90e9ee4bf55cfb72d47937f7d1",
   }
   assert module._UNMODIFIED_MIGRATIONS["building-apps.md"] == {
     "4126b40d209c422184e0135f611bb9f4197ea280fa27e63cd71c806f8b5ebd79",
     "91b655952d55b37fda0be82e3914c3b09e67ca7c5f5a575d315fb2ca75ef08f1",
+    "563dcd7bfa1ff7cbad074d98462eb9755a010a15bf340c7f594fc7f6825a6a86",
+  }
+  assert module._UNMODIFIED_MIGRATIONS["building-apps-quickstart.md"] == {
+    "7d8af2664b37a69b88e48c2a28140c15556202c3c7ce30d77816c203d1959fcb",
+  }
+  assert module._UNMODIFIED_MIGRATIONS["app-component-shapes.md"] == {
+    "0320609ff924a0954c20d5e5db91ed3681d421d76f6804b24552eb6e8fa5eb31",
+  }
+  assert module._UNMODIFIED_MIGRATIONS["visual-testing.md"] == {
+    "9525b36b945c2a0b4cb02806081bb674f38e865b6e1c3961226112e1dbbc16ec",
   }
   assert (
     "6e6e82e02287e8bb38195fb021ea25cee2dc4e27da1a6ce1e2a0143fb1d82d87"

--- a/backend/tests/test_register_app.py
+++ b/backend/tests/test_register_app.py
@@ -9,6 +9,7 @@ rename) is the fix.
 
 import importlib.util
 import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -271,3 +272,69 @@ def test_registration_rejects_empty_capability_array(tmp_path, capsys):
     raise AssertionError("capabilities must remain an object")
 
   assert "must be an object" in capsys.readouterr().err
+
+
+def test_registration_finalizes_source_and_clean_is_success(monkeypatch, tmp_path):
+  mod = _load_module()
+  calls = []
+  monkeypatch.setattr(
+    mod.app_git,
+    "commit_local",
+    lambda source_dir, message: calls.append((source_dir, message)) or None,
+  )
+
+  mod._finalize_source(str(tmp_path), created=True)
+
+  assert calls == [(str(tmp_path), "create app")]
+
+
+def test_registration_creates_clean_per_app_history(tmp_path):
+  mod = _load_module()
+  (tmp_path / "index.jsx").write_text(
+    "export default function App() { return null }\n",
+    encoding="utf-8",
+  )
+  (tmp_path / "mobius.json").write_text(
+    '{"id":"clean-app","name":"Clean App","entry":"index.jsx"}\n',
+    encoding="utf-8",
+  )
+
+  mod._finalize_source(str(tmp_path), created=True)
+  mod._finalize_source(str(tmp_path), created=True)
+
+  status = subprocess.run(
+    ["git", "-C", str(tmp_path), "status", "--porcelain"],
+    check=True,
+    capture_output=True,
+    text=True,
+  )
+  subject = subprocess.run(
+    ["git", "-C", str(tmp_path), "log", "-1", "--pretty=%s"],
+    check=True,
+    capture_output=True,
+    text=True,
+  )
+  assert status.stdout == ""
+  assert subject.stdout.strip() == "create app"
+
+
+def test_registration_reports_retryable_source_commit_failure(
+  monkeypatch, tmp_path, capsys,
+):
+  mod = _load_module()
+
+  def fail(_source_dir, _message):
+    raise RuntimeError("git busy")
+
+  monkeypatch.setattr(mod.app_git, "commit_local", fail)
+
+  try:
+    mod._finalize_source(str(tmp_path), created=False)
+  except SystemExit as exc:
+    assert exc.code == 1
+  else:
+    raise AssertionError("source commit failure must fail the helper")
+
+  error = capsys.readouterr().err
+  assert "registration succeeded" in error
+  assert "Re-run register_app.py" in error

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -1613,7 +1613,12 @@ export default function Shell() {
   // matter (rendering before resolution shows a flash for users who
   // are already past it).
   const walkthroughQuery = ownerQueries.walkthrough.useQuery()
-  const showWalkthrough = walkthroughQuery.isFetched
+  let visualContentOnly = false
+  try {
+    visualContentOnly = sessionStorage.getItem('mobius:visual-content-only') === '1'
+  } catch (_) {}
+  const showWalkthrough = !visualContentOnly
+    && walkthroughQuery.isFetched
     && walkthroughQuery.data
     && !walkthroughQuery.data.completed
 


### PR DESCRIPTION
## Summary

- split the owned mini-app guidance into a complete ordinary base path plus explicit advanced, scheduled, visual, and structural extensions; off-the-shelf skill summaries remain untouched
- make each owned extension declare the base skills it must be read with, remove duplicated base rules, and keep the optional component catalog out of ordinary one-screen builds
- replace direct overlay DOM removal with an ephemeral visual-session mode so React never inerts the workspace under test and no onboarding/install completion state is written
- use the browser tools' documented iframe-ref flow for opaque response-sandboxed app frames; preserve the security boundary and avoid standalone fallbacks
- make app registration own the accepted initial source commit and treat a clean Git tree as success, while the watcher owns later saves
- migrate only byte-for-byte untouched seeded skills to v17; preserve owner/agent edits

## Release-candidate benchmark

The full four-case matrix was rerun after rebasing onto current `main`, whose
agent-SDK refresh is therefore included. Exact served SHA
`8ed9583b51fcbdae2c78507d0f0e5487aa4489c2`, Codex CLI `0.145.0`,
`gpt-5.6-sol` high effort, 412×915 viewport. Build cases used isolated fresh
disposable volumes. Screenshot timing requires a real chat-media screenshot
artifact; an app's `icon.png` no longer counts.

| Case | Before | Rebased release candidate | Change |
|---|---:|---:|---:|
| Advice completion | 24.43s / 20,048 tok / 0 tools | 22.76s / 19,836 tok / 0 tools | 6.8% faster; 1.1% fewer tokens |
| Ambiguous question | 13.29s / 19,415 tok / 0 tools | 9.88s / 19,457 tok / 0 tools | 25.7% faster question; remains tool-free |
| Breathe first app | 150.14s | 102.82s | 31.5% faster |
| Breathe first screenshot | 159.23s | 119.24s | 25.1% faster |
| Breathe completion | 292.66s / 24 tools | 207.63s / 15 tools | 29.1% faster / 37.5% fewer tools |
| Breathe total tokens | 1,655,488 | 581,182 | 64.9% lower |
| Breathe uncached input | 130,578 | 50,681 | 61.2% lower |
| Spinner first app | 122.39s | 122.64s | stable (+0.2%) |
| Spinner first screenshot | 132.51s | 138.27s | 4.3% slower |
| Spinner completion | 324.48s / 24 tools | 255.49s / 12 tools | 21.3% faster / 50.0% fewer tools |
| Spinner total tokens | 1,187,780 | 509,997 | 57.1% lower |
| Spinner uncached input | 105,614 | 42,839 | 59.4% lower |

For app construction, both final traces loaded exactly Quickstart + Visual in
one batched read; neither loaded Component Shapes nor Advanced Building Apps.
Both entered the opaque iframe by ref on the first attempt, exercised the
primary flow, used no standalone fallback, reported no browser errors, and
left the app repository clean. Both final 412×915 screenshots passed visual
review with no walkthrough or install overlay.

The earlier pre-SDK-refresh candidate showed the same qualitative reduction in
completion time, tools, and tokens. The table above is the release-candidate
measurement, not an attempt to attribute SDK-refresh effects to this patch.

## Validation

- 306 focused/broad backend tests passed locally
- 1,822 frontend library tests passed locally
- 47 frontend hook tests passed locally
- rebased pre-push frontend-unit and source gates passed
- exact disposable runtime health/identity verifier passed at the PR SHA
- live breathing and spinner builds completed with screenshots, interaction checks, clean console output, and clean app repositories
- `git diff --check`, shell syntax, and Python compilation passed
