### PR TITLE
Streamline first-run onboarding

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,69 @@
+# Product
+
+<!-- impeccable:product-schema 1 -->
+
+## Platform
+
+web
+
+## Users
+
+Möbius is for a mixed audience, including people who are not technical and may
+be cautious around infrastructure, authentication, and agent setup. They want a
+personal system they can use and shape without first learning how it is hosted.
+
+## Product Purpose
+
+Möbius gives each person a private, persistent place for conversations, apps,
+files, memory, and agentic work. First-run success means reaching the working
+Möbius shell quickly; connecting an agent and installing more apps are optional,
+contextual next steps.
+
+## Positioning
+
+Möbius is a personal computing environment whose agent can build and change the
+apps and platform around it. The user retains control of the deployment and can
+choose how it is hosted and authenticated.
+
+## Operating Context
+
+Users may enter through a managed Railway deployment or install Möbius
+themselves. Managed deployments can reuse the mobius.you identity; self-hosted
+installs use a username and password created on first boot. Agent providers are
+connected later from Settings. Apps are discovered through the drawer and App
+Store.
+
+## Capabilities and Constraints
+
+- A usable shell does not require an AI provider to be connected.
+- Chat and agentic actions do require a configured provider.
+- OpenAI Codex on a headless server uses device-code authorization.
+- Provider credentials and user data stay with the Möbius instance.
+- First-run guidance must be dismissible and must not block exploration.
+
+## Brand Commitments
+
+Use the Möbius name and existing mark. Explain technical boundaries in plain,
+calm language. Treat ownership, freedom, privacy, and user choice as product
+truth rather than decorative claims.
+
+## Evidence on Hand
+
+The existing shell, Settings provider controls, drawer, App Store integration,
+and first-sign-in walkthrough are implemented in `frontend/src`. Do not invent
+customer claims, benchmarks, or privacy guarantees beyond the documented
+deployment boundary.
+
+## Product Principles
+
+- Open the product before teaching the product.
+- Make advanced capability available, never compulsory.
+- Put guidance beside the action it explains.
+- Be exact about where data and credentials live.
+- Preserve user ownership and reversibility.
+
+## Accessibility & Inclusion
+
+The experience must work with keyboard navigation, reduced motion, narrow
+mobile screens, and clear language for people unfamiliar with hosting or AI
+provider terminology.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -85,12 +85,12 @@ function AppRoot() {
   // until restoration completes so ChatView's useState initializer
   // sees the hydrated cache (no flash on cold reload).
   const isRestoring = useIsRestoring()
-  // If a previous tab created an account but the user closed before
-  // finishing the provider step, resume the wizard there
-  // instead of dropping them into a Shell with no AI configured.
-  // Read BEFORE the token fast path so we don't briefly mount Shell.
+  // Provider setup is deliberately contextual now: a usable Möbius opens
+  // immediately and Settings owns agent connections. Ignore the legacy
+  // `provider` resume marker left by older first-run flows.
   const hasToken = !!getToken()
-  const resumeStep = hasToken ? setupSession.getResumeStep() : null
+  const savedResumeStep = hasToken ? setupSession.getResumeStep() : null
+  const resumeStep = savedResumeStep === 'account' ? savedResumeStep : null
   let ssoSignal = ''
   try {
     const params = new URLSearchParams(window.location.search)
@@ -108,9 +108,6 @@ function AppRoot() {
   const setupStatusQuery = setupQueries.status.useQuery({
     enabled: !hasToken && !ssoSignal,
   })
-  // Stable across renders — we only need the value captured on mount.
-  const [initialSetupStep, setInitialSetupStep] = useState(resumeStep || 'account')
-
   useEffect(() => {
     if (status !== 'sso') return undefined
     let cancelled = false
@@ -129,10 +126,12 @@ function AppRoot() {
         } catch { /* ignore */ }
         if (cancelled) return
         if (data.new_owner) {
-          setupSession.setInProgress(true)
-          setupSession.saveStep('provider')
-          setInitialSetupStep('provider')
-          setStatus('setup')
+          // Managed sign-in already established the owner. Open the product;
+          // provider setup belongs in Settings and must not become a second
+          // onboarding funnel.
+          setupSession.clearResumeStep()
+          setupSession.setInProgress(false)
+          setStatus('shell')
           return
         }
         const ret = safeReturnPath(data.return_path)
@@ -187,8 +186,8 @@ function AppRoot() {
     }
 
     if (hasToken) {
-      // Either resuming setup or going to shell — both already set
-      // synchronously above. Just hide the splash.
+      // Clear stale provider-wizard state from pre-contextual onboarding.
+      if (savedResumeStep && !resumeStep) setupSession.clearResumeStep()
       removeSplash()
       return
     }
@@ -227,7 +226,6 @@ function AppRoot() {
   if (status === 'setup') return (
     <Suspense fallback={<RouteLoading label="Loading setup" />}>
       <SetupWizard
-        initialStep={initialSetupStep}
         onDone={() => {
           setupSession.clearResumeStep()
           setupSession.setInProgress(false)

--- a/frontend/src/components/ChatView/__tests__/accessibilityHardening.test.js
+++ b/frontend/src/components/ChatView/__tests__/accessibilityHardening.test.js
@@ -24,7 +24,6 @@ test('full-screen dialogs share one focus, inerting, and Escape contract', () =>
     read('../ManageModelsModal.jsx'),
     read('../../SettingsView/UpdateReviewModal.jsx'),
     read('../markdown/ImageLightbox.jsx'),
-    read('../../Walkthrough/WalkthroughOverlay.jsx'),
     read('../AgentContextInspector.jsx'),
     read('../ChatSummaryViewer.jsx'),
   ]
@@ -39,6 +38,14 @@ test('full-screen dialogs share one focus, inerting, and Escape contract', () =>
   const updateReview = dialogs[2]
   assert.match(manageModels, /ref=\{keepEditingRef\}/)
   assert.match(updateReview, /closeOnEscape: !applying/)
+})
+
+test('first-use guidance is a labeled non-modal region with a dismiss action', () => {
+  const source = read('../../Walkthrough/WalkthroughOverlay.jsx')
+  assert.match(source, /role="region"/)
+  assert.match(source, /aria-labelledby="wt-title"/)
+  assert.match(source, /aria-label="Dismiss welcome"/)
+  assert.doesNotMatch(source, /aria-modal="true"/)
 })
 
 test('chat image preview actions use labeled buttons', () => {

--- a/frontend/src/components/ProviderAuth/CodexAuth.jsx
+++ b/frontend/src/components/ProviderAuth/CodexAuth.jsx
@@ -4,6 +4,9 @@ import { api } from '../../api/client.js'
 import { authQueries } from '../../hooks/queries.js'
 import { closeAuthWindow, navigateAuthWindow, reserveAuthWindow } from '../../utils/authWindow.js'
 
+const CHATGPT_SECURITY_URL = 'https://chatgpt.com/#settings/Security'
+const OPENAI_DATA_CONTROLS_URL = 'https://help.openai.com/en/articles/7730893-data-controls-faq'
+
 /**
  * Codex device-auth flow. Lifted out of SettingsView so SetupWizard
  * can reuse the same component instead of duplicating the polling
@@ -303,21 +306,49 @@ export default function CodexAuth({ onConnected, showSetupHint = true }) {
   return (
     <div className="codex-auth">
       {showSetupHint && (
-        <p className="pa__muted codex-auth__hint">
-          First time? In your ChatGPT account, open
-          {' '}<strong>Settings → Security</strong> and turn on
-          {' '}<strong>Enable device code authorization for Codex</strong>.
-          Without it, sign-in below will fail with a "contact your
-          workspace admin" message.
-        </p>
+        <div className="codex-auth__preflight">
+          <div className="codex-auth__preflight-head">
+            <span className="codex-auth__step-num" aria-hidden="true">1</span>
+            <div>
+              <strong>Allow device access</strong>
+              <p className="pa__muted codex-auth__hint">
+                In ChatGPT, open <strong>Settings → Security</strong> and turn on
+                {' '}<strong>Enable device code authorization for Codex</strong>.
+                This is a one-time account setting.
+              </p>
+            </div>
+          </div>
+          <a
+            className="pa__btn pa__btn--sm codex-auth__settings-link"
+            href={CHATGPT_SECURITY_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Open ChatGPT security
+          </a>
+          <p className="pa__muted codex-auth__privacy">
+            Prefer not to have new conversations used to improve OpenAI’s
+            models? In ChatGPT, open <strong>Settings → Data Controls</strong>
+            {' '}and turn off <strong>Improve the model for everyone</strong>.
+            {' '}<a href={OPENAI_DATA_CONTROLS_URL} target="_blank" rel="noopener noreferrer">
+              OpenAI’s data-controls guide
+            </a>
+          </p>
+        </div>
       )}
-      <button
-        className="pa__btn"
-        onClick={startLogin}
-        disabled={status === 'connecting'}
-      >
-        {status === 'connecting' ? 'Starting…' : 'Connect to Codex'}
-      </button>
+      <div className="codex-auth__connect-step">
+        {showSetupHint && <span className="codex-auth__step-num" aria-hidden="true">2</span>}
+        <div>
+          {showSetupHint && <strong>Connect Codex</strong>}
+          <button
+            className="pa__btn"
+            onClick={startLogin}
+            disabled={status === 'connecting'}
+          >
+            {status === 'connecting' ? 'Starting…' : 'Continue with ChatGPT'}
+          </button>
+        </div>
+      </div>
       {error && <p className="pa__error" role="alert">{error}</p>}
     </div>
   )

--- a/frontend/src/components/ProviderAuth/ProviderAuth.css
+++ b/frontend/src/components/ProviderAuth/ProviderAuth.css
@@ -146,6 +146,54 @@
   line-height: 1.5;
 }
 
+.codex-auth__preflight {
+  display: grid;
+  gap: 12px;
+  padding: 14px;
+  background: color-mix(in srgb, var(--accent, #8b6cf7) 7%, var(--bg));
+  border: 1px solid color-mix(in srgb, var(--accent, #8b6cf7) 20%, var(--border));
+  border-radius: 12px;
+}
+
+.codex-auth__preflight-head,
+.codex-auth__connect-step {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.codex-auth__preflight-head > div,
+.codex-auth__connect-step > div {
+  display: grid;
+  gap: 8px;
+  flex: 1;
+  min-width: 0;
+}
+
+.codex-auth__preflight-head strong,
+.codex-auth__connect-step strong {
+  color: var(--text);
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.codex-auth__settings-link {
+  justify-self: start;
+  margin-left: 32px;
+  text-decoration: none !important;
+}
+
+.codex-auth__privacy {
+  margin: 2px 0 0 32px;
+  padding-top: 11px;
+  border-top: 1px solid var(--border-light);
+  line-height: 1.5;
+}
+
+.codex-auth__connect-step > div > .pa__btn {
+  align-self: start;
+}
+
 .codex-auth__device {
   display: flex;
   flex-direction: column;
@@ -245,6 +293,13 @@
 .codex-auth__waiting {
   margin: 0;
   margin-right: auto;
+}
+
+@media (max-width: 520px) {
+  .codex-auth__settings-link,
+  .codex-auth__privacy {
+    margin-left: 0;
+  }
 }
 
 /* ── Unified provider rows (shared by Settings + Setup) ──── */

--- a/frontend/src/components/SettingsView/SettingsView.jsx
+++ b/frontend/src/components/SettingsView/SettingsView.jsx
@@ -350,6 +350,7 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
   // (check/review another release + restart), so this is no longer a single
   // conditional action slot.
   const platformActionRef = useRef(null)
+  const restorePlatformActionFocusRef = useRef(false)
   // 'idle' | 'checking' | 'checked' | 'error' — the "Check for updates" button
   // asks the service worker to re-check cached frontend assets and re-reads
   // /api/version. 'checked' is a short-lived success label when no update is
@@ -1119,14 +1120,30 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
   }
 
   function closeUpdateReview() {
+    restorePlatformActionFocusRef.current = true
     setReviewOpen(false)
-    // useDialogFocus first restores the opener captured at mount. A successful
-    // apply can replace that node during refreshPlatform, so focus the live
-    // conditional action after React commits the close and replacement.
-    requestAnimationFrame(() => {
-      platformActionRef.current?.focus({ preventScroll: true })
-    })
   }
+
+  useEffect(() => {
+    if (
+      reviewOpen
+      || platformPhase !== 'idle'
+      || !restorePlatformActionFocusRef.current
+    ) return undefined
+
+    // useDialogFocus first restores the opener captured at mount. A successful
+    // apply replaces that opener with "Restart to finish", so wait for the
+    // parent state and its live ref to commit before moving focus. Scheduling
+    // directly inside closeUpdateReview raced that commit and repeatedly left
+    // focus on <body> under CI/browser load.
+    const frame = window.requestAnimationFrame(() => {
+      const action = platformActionRef.current
+      if (!action?.isConnected || action.disabled) return
+      restorePlatformActionFocusRef.current = false
+      action.focus({ preventScroll: true })
+    })
+    return () => window.cancelAnimationFrame(frame)
+  }, [platform, platformPhase, reviewOpen, updatePhase])
 
   // Poll until the restart is actually safe to navigate. A plain successful
   // /api/health response can still be the OLD worker answering before its

--- a/frontend/src/components/SetupWizard/SetupWizard.jsx
+++ b/frontend/src/components/SetupWizard/SetupWizard.jsx
@@ -1,60 +1,10 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useEffect, useState } from 'react'
 import mobiusLogoUrl from '../../assets/moebius.png'
 import { api, setToken } from '../../api/client.js'
 import * as setupSession from '../../lib/setupSession.js'
-import { authQueries } from '../../hooks/queries.js'
-import {
-  PROVIDER_AVAILABILITY_PHASE,
-  resolveProviderAvailability,
-} from '../../lib/providerAvailability.js'
-import ProviderAuth from '../ProviderAuth/ProviderAuth.jsx'
-import CodexAuth from '../ProviderAuth/CodexAuth.jsx'
-import ProviderRow from '../ProviderAuth/ProviderRow.jsx'
 import './SetupWizard.css'
 
-const SETUP_STEPS = [
-  { id: 'account', label: 'Account' },
-  { id: 'provider', label: 'AI' },
-]
-const PROVIDERS = [
-  { id: 'codex', label: 'OpenAI Codex' },
-  { id: 'claude', label: 'Claude Code' },
-]
-
-export default function SetupWizard({ onDone, initialStep = 'account' }) {
-  const [step, setStep] = useState(initialStep)
-  // Hoisted from ProviderStep so ProviderAuth (which is a
-  // grandchild) doesn't need to re-run the same query. Gated on
-  // step !== 'account': there's no token yet during account
-  // creation, so an eager fetch here 401s, and apiFetch's global
-  // 401 handler (client.js) treats that as an expired session and
-  // reloads the page — an infinite reload loop on first load.
-  const providerStatusQuery = authQueries.provider.statuses.useQuery({
-    enabled: step !== 'account',
-    // Credentials are the action this screen is responsible for. Re-probe on
-    // entry even when IndexedDB restored a still-fresh disconnected snapshot.
-    refetchOnMount: 'always',
-  })
-  const providerAvailability = resolveProviderAvailability(providerStatusQuery)
-  // Setup is the one place where a persisted disconnected value should not
-  // present as final while its live credential probe is running or failed.
-  // Keep any positively-connected rows usable, but make unknown negative state
-  // explicit so a stale local cache cannot masquerade as server truth.
-  const providerPhase = providerStatusQuery.isError
-    ? PROVIDER_AVAILABILITY_PHASE.ERROR
-    : (providerStatusQuery.isFetching
-        && providerAvailability.configuredProviders.size === 0
-      ? PROVIDER_AVAILABILITY_PHASE.LOADING
-      : providerAvailability.phase)
-
-  // Persists step synchronously alongside setStep so a refresh in
-  // the microsecond gap between setStep and a useEffect flush can't
-  // lose the resume position. saveStep is a no-op for 'account'
-  // because there's no token yet — see setupSession.js.
-  function goToStep(next) {
-    setupSession.saveStep(next)
-    setStep(next)
-  }
+export default function SetupWizard({ onDone }) {
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
@@ -112,8 +62,9 @@ export default function SetupWizard({ onDone, initialStep = 'account' }) {
       }
       const data = await res.json()
       setToken(data.access_token)
-      setupSession.setInProgress(true)
-      goToStep('provider')
+      setupSession.clearResumeStep()
+      setupSession.setInProgress(false)
+      onDone?.()
     } catch {
       setError('Network error. Is the backend running?')
     } finally {
@@ -121,27 +72,13 @@ export default function SetupWizard({ onDone, initialStep = 'account' }) {
     }
   }
 
-  if (step === 'provider') {
-    return (
-      <ProviderStep
-        onSkip={onDone}
-        onContinue={onDone}
-        configuredProviders={providerAvailability.configuredProviders}
-        providerPhase={providerPhase}
-        onRetryProviders={() => providerStatusQuery.refetch()}
-      />
-    )
-  }
-
   return (
     <div className="setup">
       <div className="setup__card">
         <img src={mobiusLogoUrl} alt="Möbius" className="setup__logo" />
-        <SetupProgress step="account" />
-        <h1 className="setup__title">Create your home key</h1>
+        <h1 className="setup__title">Set up your Möbius</h1>
         <p className="setup__subtitle">
-          This account unlocks your private Möbius. Your agent, apps, and data
-          live in the container you just made.
+          Choose the username and password you will use to open this Möbius.
         </p>
         <form
           className="setup__form"
@@ -198,201 +135,10 @@ export default function SetupWizard({ onDone, initialStep = 'account' }) {
             type="submit"
             disabled={loading}
           >
-            {loading ? 'Setting up…' : 'Continue'}
+            {loading ? 'Setting up…' : 'Enter Möbius'}
           </button>
         </form>
       </div>
-    </div>
-  )
-}
-
-/**
- * Connect-AI step: mirrors the Settings page's provider list but
- * with no default-selection radio. Each provider has one explicit
- * action that expands its auth panel. Codex is listed first because
- * it works on a free ChatGPT account; an inline hint about the
- * ChatGPT-account device-auth toggle lives inside CodexAuth. Either
- * provider connecting advances the wizard.
- */
-function ProviderStep({
-  onSkip,
-  onContinue,
-  configuredProviders,
-  providerPhase,
-  onRetryProviders,
-}) {
-  const [expanded, setExpanded] = useState('codex')
-  const codexConnected = configuredProviders.has('codex')
-  const claudeConnected = configuredProviders.has('claude')
-  const connectedAny = codexConnected || claudeConnected
-  const [agentSaving, setAgentSaving] = useState(false)
-  const [agentSaved, setAgentSaved] = useState(false)
-  const [agentError, setAgentError] = useState('')
-  const [agentProvider, setAgentProvider] = useState('')
-
-  function toggle(id) {
-    setExpanded(prev => prev === id ? null : id)
-  }
-
-  function connectedMap(extraProvider = '') {
-    return {
-      codex: codexConnected || extraProvider === 'codex',
-      claude: claudeConnected || extraProvider === 'claude',
-    }
-  }
-
-  function firstConnectedProvider(extraProvider = '') {
-    const connected = connectedMap(extraProvider)
-    return PROVIDERS.find(provider => connected[provider.id])?.id || ''
-  }
-
-  const saveConnectedProvider = useCallback(async (provider) => {
-    if (!provider) return false
-    setAgentSaving(true)
-    setAgentSaved(false)
-    setAgentError('')
-    try {
-      const res = await api.settings.save({
-        provider,
-      })
-      if (!res.ok) {
-        let detail = ''
-        try { detail = (await res.json()).detail || '' } catch {}
-        throw new Error(detail || 'Could not save agent defaults.')
-      }
-      setAgentSaved(true)
-      setTimeout(() => setAgentSaved(false), 1600)
-      return true
-    } catch (err) {
-      setAgentError(err.message || 'Could not save agent defaults.')
-      return false
-    } finally {
-      setAgentSaving(false)
-    }
-  }, [])
-
-  async function handleConnected(provider) {
-    const preferred = firstConnectedProvider(provider) || provider
-    setAgentProvider(preferred)
-    if (await saveConnectedProvider(preferred)) setExpanded(null)
-  }
-
-  async function retryProviderSave() {
-    const preferred = agentProvider || firstConnectedProvider()
-    if (await saveConnectedProvider(preferred)) setExpanded(null)
-  }
-
-  const readyToContinue = connectedAny && !agentSaving && !agentError
-  const providerStatusNode = providerPhase === PROVIDER_AVAILABILITY_PHASE.READY
-    ? undefined
-    : (
-        <span className="setup__provider-status">
-          {providerPhase === PROVIDER_AVAILABILITY_PHASE.ERROR
-            ? 'Status unavailable'
-            : 'Checking…'}
-        </span>
-      )
-
-  return (
-    <div className="setup">
-      <div className="setup__card">
-        <img src={mobiusLogoUrl} alt="Möbius" className="setup__logo" />
-        <SetupProgress step="provider" />
-        <h1 className="setup__title">Wake up your AI</h1>
-        <p className="setup__subtitle">
-          Connect Codex or Claude. Möbius will choose simple defaults now;
-          you can tune models later in Settings.
-        </p>
-
-        <div className="settings__providers">
-          <ProviderRow
-            name="OpenAI Codex"
-            badge="Free ChatGPT account"
-            connected={codexConnected}
-            statusNode={providerStatusNode}
-            expanded={expanded === 'codex'}
-            onToggleExpand={() => toggle('codex')}
-          >
-            <CodexAuth onConnected={() => handleConnected('codex')} />
-          </ProviderRow>
-
-          <ProviderRow
-            name="Claude Code"
-            connected={claudeConnected}
-            statusNode={providerStatusNode}
-            expanded={expanded === 'claude'}
-            onToggleExpand={() => toggle('claude')}
-          >
-            <ProviderAuth
-              authenticated={claudeConnected}
-              compact={providerPhase === PROVIDER_AVAILABILITY_PHASE.READY}
-              onDone={() => handleConnected('claude')}
-            />
-          </ProviderRow>
-        </div>
-
-        {providerPhase === PROVIDER_AVAILABILITY_PHASE.ERROR && (
-          <div className="setup__provider-error" role="alert">
-            <span>Could not verify provider status.</span>
-            <button type="button" onClick={onRetryProviders}>Retry</button>
-          </div>
-        )}
-
-        {agentSaved && <p className="setup__success" role="status">Provider connected. Ready when you are.</p>}
-        {agentError && <p className="setup__error" role="alert">{agentError}</p>}
-        {agentError && (
-          <button
-            className="setup__btn setup__btn--full"
-            type="button"
-            onClick={retryProviderSave}
-            disabled={agentSaving || !agentProvider}
-          >
-            {agentSaving ? 'Saving…' : 'Try saving again'}
-          </button>
-        )}
-
-        {!connectedAny && (
-          <p className="setup__skip-warn">
-            You can explore without AI, but chats need a provider before they can run.
-          </p>
-        )}
-        <button
-          className="setup__btn setup__btn--full"
-          type="button"
-          onClick={onContinue}
-          disabled={!readyToContinue}
-        >
-          {agentSaving ? 'Saving…' : 'Enter Möbius'}
-        </button>
-        <button className="setup__skip" type="button" onClick={onSkip} disabled={agentSaving}>
-          Explore without AI
-        </button>
-      </div>
-    </div>
-  )
-}
-
-function SetupProgress({ step }) {
-  const currentIndex = SETUP_STEPS.findIndex(item => item.id === step)
-  const safeIndex = currentIndex >= 0 ? currentIndex : 0
-  const currentStep = SETUP_STEPS[safeIndex]
-
-  return (
-    <div
-      className="setup__progress"
-      aria-label={`Step ${safeIndex + 1} of ${SETUP_STEPS.length}: ${currentStep.label}`}
-    >
-      <span className="setup__progress-text">
-        Step {safeIndex + 1} of {SETUP_STEPS.length}
-      </span>
-      <span className="setup__progress-track" aria-hidden="true">
-        {SETUP_STEPS.map((item, index) => (
-          <span
-            key={item.id}
-            className={`setup__progress-dot${index <= safeIndex ? ' setup__progress-dot--active' : ''}`}
-          />
-        ))}
-      </span>
     </div>
   )
 }

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -3292,6 +3292,15 @@ export default function Shell() {
 
       {showWalkthrough && (
         <WalkthroughOverlay
+          onOpenSettings={() => {
+            setSettingsFocusTarget({ section: 'ai-providers', nonce: Date.now() })
+            navTo('settings')
+          }}
+          onExploreApps={() => {
+            const appStore = findAppStoreApp(apps)
+            if (appStore) navTo('canvas', { appId: appStore.id })
+            else openDrawer()
+          }}
           onDone={() => {
             // Query invalidation inside WalkthroughOverlay flips
             // `showWalkthrough` to false on the next render. Nothing

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -129,12 +129,11 @@ test('the undo chord is flag-gated and defers to focused inputs', () => {
 })
 
 test('the first-run walkthrough stays short and action-first', () => {
-  assert.match(walkthrough, /const STEPS = \['intro', 'home', 'first-chat'\]/)
-  assert.doesNotMatch(walkthrough, /step === 'workspace'/)
-  // The recovery net is named next to the capability it backstops; a future
-  // trim of the walkthrough must not silently drop it.
-  assert.match(walkthrough, /\/recover runs outside Möbius/)
-  assert.match(walkthrough, /Meet my Möbius/)
+  assert.doesNotMatch(walkthrough, /const STEPS/)
+  assert.match(walkthrough, /Your Möbius is ready/)
+  assert.match(walkthrough, /Connect an agent/)
+  assert.match(walkthrough, /Open the App Store/)
+  assert.match(walkthrough, /I’ll explore/)
   assert.match(walkthrough, /mobius:walkthrough-completed/)
 })
 
@@ -767,10 +766,11 @@ test('the builder no-full-screen invariant scopes to DESTINATIONS, not transient
   const urmCss = readFileSync(
     new URL('../../SettingsView/UpdateReviewModal.css', import.meta.url), 'utf8',
   )
-  // The walkthrough is a dismissible dialog (skip + onClose:skip) — reloading it
-  // over a builder workspace can never trap; and the update-review modal stays fixed.
-  assert.match(walkthrough, /const skip = useCallback/)
-  assert.match(walkthrough, /onClose: skip/)
+  // First-use guidance is now a non-modal region layered over the live shell,
+  // with an explicit dismiss action; update review remains a fixed modal.
+  assert.match(walkthrough, /role="region"/)
+  assert.match(walkthrough, /aria-label="Dismiss welcome"/)
+  assert.doesNotMatch(walkthrough, /aria-modal="true"/)
   assert.match(urmCss, /\.urm__overlay\s*\{[\s\S]*?position:\s*fixed/)
 })
 

--- a/frontend/src/components/Walkthrough/WalkthroughOverlay.css
+++ b/frontend/src/components/Walkthrough/WalkthroughOverlay.css
@@ -1,216 +1,204 @@
-/* Centered modal walkthrough, styled to match the sub-app install
-   card in `standalone.py`. Single visible card at a time; the
-   internal state machine swaps content but reuses the shell so
-   transitions feel smooth.
-
-   The card never grows tall enough to crowd a mobile viewport — body
-   text is bounded; a phone in portrait still leaves the chat input
-   visible behind the card so the user knows where they're headed. */
-
-.wt__overlay {
-  position: fixed;
-  inset: 0;
-  z-index: 1000;
-  background: rgba(0, 0, 0, 0.55);
-  backdrop-filter: blur(4px);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 16px;
-  animation: wt-fade-in 0.18s ease both;
-}
-
-.wt__overlay--closing {
-  animation: wt-fade-out 0.16s ease both;
-}
-
-@keyframes wt-fade-in {
-  from { opacity: 0; }
-  to   { opacity: 1; }
-}
-@keyframes wt-fade-out {
-  from { opacity: 1; }
-  to   { opacity: 0; }
-}
+/* First-use guidance lives inside the working shell. It is intentionally a
+   non-modal coach card: owners can dismiss it, act from it, or simply use the
+   product around it. Completion remains durable through the existing owner
+   walkthrough endpoint. */
 
 .wt__card {
-  width: 100%;
-  max-width: 420px;
-  max-height: calc(100% - 32px);
-  overflow-y: auto;
-  background: var(--surface, #14181f);
-  color: var(--text, #d4d4d8);
-  border: 1px solid var(--border, #252b36);
-  border-radius: 8px;
-  padding: 26px 24px 22px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.32);
-  animation: wt-scale-in 0.22s cubic-bezier(.2, .7, .2, 1) both;
-}
-
-[data-theme="light"] .wt__card {
+  position: fixed;
+  z-index: 900;
+  top: calc(62px + env(safe-area-inset-top, 0px));
+  right: 18px;
+  width: min(390px, calc(100vw - 32px));
+  box-sizing: border-box;
+  padding: 22px;
+  overflow: hidden;
+  color: var(--text, #e4e4e7);
+  background:
+    radial-gradient(circle at 100% 0%, color-mix(in srgb, var(--accent, #8b6cf7) 24%, transparent), transparent 48%),
+    var(--surface, #14181f);
+  border: 1px solid color-mix(in srgb, var(--accent, #8b6cf7) 26%, var(--border, #252b36));
+  border-radius: 16px;
   box-shadow:
-    0 4px 12px rgba(0, 0, 0, 0.08),
-    0 1px 3px rgba(0, 0, 0, 0.06);
+    0 18px 42px rgba(0, 0, 0, 0.34),
+    0 4px 12px rgba(0, 0, 0, 0.22);
+  animation: wt-arrive 420ms cubic-bezier(.16, 1, .3, 1) both;
 }
 
-@keyframes wt-scale-in {
-  from { transform: scale(0.92); opacity: 0; }
-  to   { transform: scale(1);    opacity: 1; }
-}
-
-.wt__steps {
-  display: flex;
-  gap: 6px;
-  justify-content: center;
-  margin-bottom: 18px;
-}
-
-.wt__step-dot {
-  width: 24px;
-  height: 4px;
-  border-radius: 2px;
-  background: var(--surface2, #1a1f28);
-  transition: background 0.18s ease;
-}
-
-.wt__step-dot--active {
-  background: var(--accent, #a78bfa);
-}
-
-.wt__step-dot--done {
-  background: var(--accent, #a78bfa);
-  opacity: 0.55;
-}
-
-.wt__title {
-  font-size: 19px;
-  font-weight: 600;
-  margin: 0 0 12px;
-  line-height: 1.3;
-}
-
-.wt__body {
-  font-size: 14px;
-  line-height: 1.55;
-  color: var(--text, #d4d4d8);
-  margin: 0;
-}
-
-/* A secondary note under the step's own point -- quieter, never competing with
-   it for attention. */
-.wt__body--aside {
-  margin-top: 10px;
-  font-size: 13px;
-  color: var(--muted, #a1a1aa);
-}
-
-.wt__sigil {
-  position: relative;
-  width: 82px;
-  height: 82px;
-  margin: 2px auto 18px;
-}
-
-.wt__sigil-ring,
-.wt__sigil-loop {
-  position: absolute;
-  inset: 8px;
-  border: 1px solid color-mix(in srgb, var(--accent, #a78bfa) 44%, var(--border, #252b36));
-}
-
-.wt__sigil-ring {
-  border-radius: 50%;
-  opacity: 0.5;
-}
-
-.wt__sigil-loop {
-  border-radius: 50%;
-  transform: rotate(28deg) scaleX(0.56);
-  box-shadow: 0 0 18px color-mix(in srgb, var(--accent, #a78bfa) 18%, transparent);
-  animation: wt-loop-breathe 3.4s ease-in-out infinite;
-}
-
-@keyframes wt-loop-breathe {
-  0%, 100% { transform: rotate(28deg) scaleX(0.56); opacity: 0.74; }
-  50% { transform: rotate(208deg) scaleX(0.56); opacity: 1; }
-}
-
-.wt__duo {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 8px;
-  margin: 2px 0 18px;
-}
-
-.wt__duo span {
-  min-height: 46px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 8px;
-  border: 1px solid var(--border, #252b36);
-  background: color-mix(in srgb, var(--text, #d4d4d8) 5%, transparent);
-  color: var(--text, #d4d4d8);
-  font-size: 12px;
-  font-weight: 650;
-}
-
-.wt__actions {
-  display: flex;
-  gap: 10px;
-  margin-top: 22px;
-}
-
-.wt__btn {
-  flex: 1;
-  padding: 12px 16px;
-  border-radius: 8px;
-  border: none;
-  font-family: inherit;
-  font-size: 14px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: opacity 0.15s ease, background 0.15s ease;
-}
-
-.wt__btn:focus-visible {
-  outline: 2px solid var(--accent, #a78bfa);
-  outline-offset: 2px;
-}
-
-.wt__btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.wt__btn--primary {
-  background: var(--accent, #a78bfa);
-  color: var(--accent-fg, #ffffff);
-}
-
-@media (hover: hover) and (pointer: fine) {
-  .wt__btn--primary:hover {
-    background: var(--accent-hover, #c4b5fd);
+@keyframes wt-arrive {
+  from {
+    opacity: 0;
+    transform: translateY(-10px) scale(0.98);
+    clip-path: inset(0 0 22% 0 round 16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+    clip-path: inset(0 round 16px);
   }
 }
 
-.wt__btn--ghost {
+.wt__close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: grid;
+  place-items: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  color: var(--muted, #a1a1aa);
   background: transparent;
-  color: var(--muted, #9ca3af);
-  border: 1px solid var(--border, #252b36);
+  border: 0;
+  border-radius: 10px;
+  font: inherit;
+  font-size: 24px;
+  line-height: 1;
+  cursor: pointer;
 }
 
-.wt__btn--single {
-  flex: 0 1 auto;
-  margin: 0 auto;
-  padding: 12px 28px;
+.wt__close:hover {
+  color: var(--text, #e4e4e7);
+  background: color-mix(in srgb, var(--text, #e4e4e7) 7%, transparent);
+}
+
+.wt__close:focus-visible,
+.wt__path:focus-visible,
+.wt__dismiss:focus-visible {
+  outline: 2px solid var(--accent, #8b6cf7);
+  outline-offset: 2px;
+}
+
+.wt__mark {
+  position: relative;
+  width: 42px;
+  height: 42px;
+  margin-bottom: 18px;
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--accent, #8b6cf7) 16%, var(--surface2, #1a1f28));
+}
+
+.wt__mark::before,
+.wt__mark span {
+  content: "";
+  position: absolute;
+  inset: 10px 9px;
+  border: 1.5px solid var(--accent, #8b6cf7);
+  border-radius: 50%;
+}
+
+.wt__mark span {
+  transform: rotate(32deg) scaleX(0.48);
+}
+
+.wt__kicker {
+  margin: 0 0 6px;
+  color: var(--accent, #a78bfa);
+  font-size: 12px;
+  font-weight: 720;
+}
+
+.wt__title {
+  max-width: 15ch;
+  margin: 0 0 10px;
+  color: var(--text, #e4e4e7);
+  font-size: clamp(22px, 5vw, 28px);
+  font-weight: 720;
+  line-height: 1.08;
+  letter-spacing: -0.025em;
+  text-wrap: balance;
+}
+
+.wt__body {
+  max-width: 38ch;
+  margin: 0;
+  color: var(--muted, #a1a1aa);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.wt__paths {
+  display: grid;
+  gap: 1px;
+  margin-top: 18px;
+  overflow: hidden;
+  background: var(--border, #252b36);
+  border: 1px solid var(--border, #252b36);
+  border-radius: 12px;
+}
+
+.wt__path {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  min-height: 58px;
+  padding: 10px 12px;
+  color: var(--text, #e4e4e7);
+  background: var(--surface2, #1a1f28);
+  border: 0;
+  border-radius: 0;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background 160ms ease, color 160ms ease;
+}
+
+.wt__path:hover {
+  background: color-mix(in srgb, var(--accent, #8b6cf7) 11%, var(--surface2, #1a1f28));
+}
+
+.wt__path span {
+  font-size: 14px;
+  font-weight: 680;
+}
+
+.wt__path small {
+  color: var(--muted, #a1a1aa);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.wt__dismiss {
+  display: block;
+  margin: 14px auto -4px;
+  padding: 8px 12px;
+  color: var(--muted, #a1a1aa);
+  background: transparent;
+  border: 0;
+  border-radius: 8px;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 620;
+  cursor: pointer;
+}
+
+.wt__dismiss:hover {
+  color: var(--text, #e4e4e7);
+}
+
+@media (max-width: 520px) {
+  .wt__card {
+    top: calc(54px + env(safe-area-inset-top, 0px));
+    right: 12px;
+    width: calc(100vw - 24px);
+    max-height: calc(100dvh - 78px - env(safe-area-inset-top, 0px));
+    overflow-y: auto;
+    padding: 20px;
+  }
+
+  .wt__path {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .wt__path small {
+    white-space: normal;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .wt__overlay,
-  .wt__overlay--closing,
-  .wt__card,
-  .wt__sigil-loop {
+  .wt__card {
     animation: none;
   }
 }

--- a/frontend/src/components/Walkthrough/WalkthroughOverlay.jsx
+++ b/frontend/src/components/Walkthrough/WalkthroughOverlay.jsx
@@ -1,24 +1,16 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useEffect, useRef } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { api } from '../../api/client.js'
 import { ownerQueries } from '../../hooks/queries.js'
-import useDialogFocus from '../../hooks/useDialogFocus.js'
 import './WalkthroughOverlay.css'
 
-const STEPS = ['intro', 'home', 'first-chat']
-
-export default function WalkthroughOverlay({ onDone }) {
+export default function WalkthroughOverlay({ onDone, onOpenSettings, onExploreApps }) {
   const queryClient = useQueryClient()
-  const [stepIdx, setStepIdx] = useState(0)
-  const [closing, setClosing] = useState(false)
   const closingRef = useRef(false)
-  const dialogRef = useRef(null)
-  const step = STEPS[stepIdx]
 
   function finish() {
     if (closingRef.current) return
     closingRef.current = true
-    setClosing(true)
     queryClient.setQueryData(ownerQueries.walkthrough.key, (prev) => ({
       ...(prev || { completed_at: null }),
       completed: true,
@@ -28,26 +20,10 @@ export default function WalkthroughOverlay({ onDone }) {
     onDone?.()
   }
 
-  const next = useCallback(() => {
-    if (stepIdx < STEPS.length - 1) {
-      setStepIdx((s) => s + 1)
-    } else {
-      finish()
-    }
-    // finish is guarded by closingRef; stale callbacks cannot complete twice.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [stepIdx])
-
-  const skip = useCallback(() => {
+  function takeAction(action) {
     finish()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
-  useDialogFocus({
-    containerRef: dialogRef,
-    initialFocusRef: dialogRef,
-    onClose: skip,
-  })
+    action?.()
+  }
 
   useEffect(() => {
     const standalone =
@@ -61,95 +37,49 @@ export default function WalkthroughOverlay({ onDone }) {
   }, [])
 
   return (
-    <div
-      className={`wt__overlay${closing ? ' wt__overlay--closing' : ''}`}
-      role="presentation"
+    <aside
+      className="wt__card"
+      role="region"
+      aria-labelledby="wt-title"
     >
-      <div
-        ref={dialogRef}
-        className={`wt__card wt__card--${step}`}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="wt-title"
-        tabIndex={-1}
+      <button
+        type="button"
+        className="wt__close"
+        onClick={finish}
+        aria-label="Dismiss welcome"
       >
-        <div className="wt__steps" aria-hidden="true">
-          {STEPS.map((s, i) => (
-            <span
-              key={s}
-              className={`wt__step-dot${i === stepIdx ? ' wt__step-dot--active' : ''}${i < stepIdx ? ' wt__step-dot--done' : ''}`}
-            />
-          ))}
-        </div>
-
-        {step === 'intro' && (
-          <>
-            <div className="wt__sigil" aria-hidden="true">
-              <span className="wt__sigil-ring" />
-              <span className="wt__sigil-loop" />
-            </div>
-            <h2 id="wt-title" className="wt__title">This is your agent's home</h2>
-            <p className="wt__body">
-              You are inside a private Möbius install: chat, apps, code, and data
-              in one place. No separate control room. No inside and outside.
-            </p>
-            <div className="wt__actions">
-              <button type="button" className="wt__btn wt__btn--ghost" onClick={skip}>
-                Skip
-              </button>
-              <button type="button" className="wt__btn wt__btn--primary" onClick={next}>
-                Next
-              </button>
-            </div>
-          </>
-        )}
-
-        {step === 'home' && (
-          <>
-            <div className="wt__duo" aria-hidden="true">
-              <span>Platform</span>
-              <span>Apps</span>
-              <span>Community</span>
-            </div>
-            <h2 id="wt-title" className="wt__title">Build the place and the things in it</h2>
-            <p className="wt__body">
-              Möbius can build apps, install community work, and change the platform
-              around them. The Contribute app is where improvements can flow back.
-            </p>
-            <p className="wt__body wt__body--aside">
-              Changing the platform can break it. /recover runs outside Möbius and
-              can put it back.
-            </p>
-            <div className="wt__actions">
-              <button type="button" className="wt__btn wt__btn--ghost" onClick={skip}>
-                Skip
-              </button>
-              <button type="button" className="wt__btn wt__btn--primary" onClick={next}>
-                Next
-              </button>
-            </div>
-          </>
-        )}
-
-        {step === 'first-chat' && (
-          <>
-            <h2 id="wt-title" className="wt__title">Make the first move</h2>
-            <p className="wt__body">
-              Start with something small and real: change the theme, build a tiny
-              app, or ask Möbius what it can improve in its own home.
-            </p>
-            <div className="wt__actions">
-              <button
-                type="button"
-                className="wt__btn wt__btn--primary wt__btn--single"
-                onClick={next}
-              >
-                Meet my Möbius
-              </button>
-            </div>
-          </>
-        )}
+        <span aria-hidden="true">×</span>
+      </button>
+      <div className="wt__mark" aria-hidden="true">
+        <span />
       </div>
-    </div>
+      <p className="wt__kicker">Your Möbius is ready</p>
+      <h2 id="wt-title" className="wt__title">Start wherever you like.</h2>
+      <p className="wt__body">
+        You can explore now. Add an agent only when you want chats to act and
+        build on your behalf.
+      </p>
+      <div className="wt__paths">
+        <button
+          type="button"
+          className="wt__path"
+          onClick={() => takeAction(onOpenSettings)}
+        >
+          <span>Connect an agent</span>
+          <small>Open Settings</small>
+        </button>
+        <button
+          type="button"
+          className="wt__path"
+          onClick={() => takeAction(onExploreApps)}
+        >
+          <span>Find useful apps</span>
+          <small>Open the App Store</small>
+        </button>
+      </div>
+      <button type="button" className="wt__dismiss" onClick={finish}>
+        I’ll explore
+      </button>
+    </aside>
   )
 }

--- a/frontend/src/lib/__tests__/updateReviewModal.test.js
+++ b/frontend/src/lib/__tests__/updateReviewModal.test.js
@@ -59,7 +59,11 @@ test('result and close focus always land on live tabbable controls', () => {
   assert.match(modal, /tabIndex=\{-1\}/)
   assert.doesNotMatch(modal, /resultHeadingRef|tabIndex=\{blocked/)
   assert.match(settingsView, /ref=\{platformActionRef\}/)
-  assert.match(settingsView, /requestAnimationFrame\(\(\) => \{[\s\S]*platformActionRef\.current\?\.focus/)
+  assert.match(settingsView, /restorePlatformActionFocusRef\.current = true/)
+  assert.match(
+    settingsView,
+    /if \([\s\S]*reviewOpen[\s\S]*platformPhase !== 'idle'[\s\S]*requestAnimationFrame\(\(\) => \{[\s\S]*platformActionRef\.current/,
+  )
 })
 
 test('a newly discovered update inherits focus from the replaced check action', () => {

--- a/tests/bootstrap.spec.mjs
+++ b/tests/bootstrap.spec.mjs
@@ -407,7 +407,7 @@ test.describe('Unauthenticated startup', () => {
 
     await page.getByRole('button', { name: 'Try again' }).click()
     await expect.poll(() => checks).toBe(2)
-    await expect(page.getByRole('heading', { name: 'Create your home key' }))
+    await expect(page.getByRole('heading', { name: 'Set up your Möbius' }))
       .toBeVisible({ timeout: 10000 })
   })
 
@@ -438,12 +438,25 @@ test.describe('Unauthenticated startup', () => {
 
     expect(setupChecks).toBe(1)
     expect(new URL(request.url()).searchParams.get('return_path')).toBe('/shell/')
-    await expect(page.getByRole('heading', { name: 'Create your home key' }))
+    await expect(page.getByRole('heading', { name: 'Set up your Möbius' }))
       .toHaveCount(0)
     await expect(page.locator('.login')).toHaveCount(0)
   })
 
   test('managed handoff signs in and skips separate account setup', async ({ page }) => {
+    // The handoff response must carry a token the real test backend accepts.
+    // A made-up token used to work only because the retired provider wizard
+    // delayed the first authenticated API request; opening the shell
+    // immediately correctly exercises the token now.
+    const storageState = await page.context().storageState()
+    const ownerOrigin = storageState.origins.find(
+      origin => origin.origin === new URL(BASE).origin,
+    )
+    const ownerToken = ownerOrigin?.localStorage.find(
+      entry => entry.name === 'token',
+    )?.value
+    expect(ownerToken).toBeTruthy()
+
     let handoffCalls = 0
     let setupChecks = 0
     await page.route(/\/api\/auth\/setup\/status$/, route => {
@@ -456,7 +469,7 @@ test.describe('Unauthenticated startup', () => {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          access_token: 'managed-owner-token',
+          access_token: ownerToken,
           token_type: 'bearer',
           new_owner: true,
           return_path: '/',
@@ -473,13 +486,14 @@ test.describe('Unauthenticated startup', () => {
 
     await page.goto(`${BASE}/shell/?mobius_sso=1`, { waitUntil: 'domcontentloaded' })
 
-    await expect(page.getByRole('heading', { name: 'Wake up your AI' }))
-      .toBeVisible({ timeout: 10000 })
+    await waitForShell(page)
     expect(handoffCalls).toBe(1)
     expect(setupChecks).toBe(0)
     expect(await page.evaluate(() => localStorage.getItem('token')))
-      .toBe('managed-owner-token')
-    await expect(page.getByRole('heading', { name: 'Create your home key' }))
+      .toBe(ownerToken)
+    await expect(page.getByRole('heading', { name: 'Set up your Möbius' }))
+      .toHaveCount(0)
+    await expect(page.getByRole('heading', { name: 'Wake up your AI' }))
       .toHaveCount(0)
     await expect(page).toHaveURL(
       new RegExp(`${BASE.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}/shell/?$`)

--- a/tests/setup-provider-status.spec.mjs
+++ b/tests/setup-provider-status.spec.mjs
@@ -4,16 +4,30 @@ const BASE = process.env.MOBIUS_URL || 'http://localhost:8001'
 
 test.use({ serviceWorkers: 'block' })
 
-test('successful Codex setup stays authoritative when status revalidation fails', async ({ page }) => {
+test('Codex connects from Settings and stays authoritative when status revalidation fails', async ({ page }) => {
   await page.addInitScript(() => {
+    // Older builds persisted this provider-wizard marker. It must never pull a
+    // returning owner out of the shell now that agent setup is contextual.
     localStorage.setItem('setup-step', 'provider')
   })
 
-  await page.route(/\/api\/auth\/providers\/status$/, route => route.fulfill({
-    status: 503,
-    contentType: 'application/json',
-    body: JSON.stringify({ detail: 'probe unavailable' }),
-  }))
+  let authenticationComplete = false
+  await page.route(/\/api\/auth\/providers\/status$/, route => (
+    authenticationComplete
+      ? route.fulfill({
+          status: 503,
+          contentType: 'application/json',
+          body: JSON.stringify({ detail: 'probe unavailable' }),
+        })
+      : route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            codex: { authenticated: false },
+            claude: { authenticated: false },
+          }),
+        })
+  ))
   await page.route(/\/api\/auth\/provider\/codex\/login$/, route => route.fulfill({
     status: 200,
     contentType: 'application/json',
@@ -27,13 +41,18 @@ test('successful Codex setup stays authoritative when status revalidation fails'
     contentType: 'text/html',
     body: '<title>Codex test login</title>',
   }))
-  await page.route(/\/api\/auth\/provider\/codex\/status$/, route => route.fulfill({
-    status: 200,
-    contentType: 'application/json',
-    body: JSON.stringify({ status: 'complete' }),
-  }))
+  await page.route(/\/api\/auth\/provider\/codex\/status$/, route => {
+    authenticationComplete = true
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ status: 'complete' }),
+    })
+  })
+  let settingsWrites = 0
   await page.route(/\/api\/settings$/, async route => {
     if (route.request().method() !== 'POST') return route.continue()
+    settingsWrites += 1
     return route.fulfill({
       status: 200,
       contentType: 'application/json',
@@ -42,13 +61,27 @@ test('successful Codex setup stays authoritative when status revalidation fails'
   })
 
   await page.goto(BASE, { waitUntil: 'domcontentloaded' })
-  await expect(page.getByRole('heading', { name: 'Wake up your AI' })).toBeVisible()
-  await expect(page.getByRole('alert')).toContainText('Could not verify provider status')
+  await expect(page.getByLabel('Toggle navigation')).toBeVisible()
+  expect(await page.evaluate(() => localStorage.getItem('setup-step'))).toBeNull()
 
-  await page.getByRole('button', { name: 'Connect to Codex' }).click()
+  const navigationToggle = page.getByLabel('Toggle navigation')
+  if (await navigationToggle.getAttribute('aria-expanded') !== 'true') {
+    await navigationToggle.click()
+  }
+  await page.getByRole('button', { name: 'Settings', exact: true }).click()
+  await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible()
+
+  const codexRow = page.locator('.provider-row').filter({ hasText: 'OpenAI Codex' })
+  await codexRow.getByRole('button', { name: 'Connect OpenAI Codex' }).click()
+  await expect(codexRow.getByText('Allow device access', { exact: true })).toBeVisible()
+  await expect(codexRow.getByRole('link', { name: 'Open ChatGPT security' }))
+    .toHaveAttribute('href', 'https://chatgpt.com/#settings/Security')
+  await expect(codexRow.getByText(/Improve the model for everyone/)).toBeVisible()
+
+  await codexRow.getByRole('button', { name: 'Continue with ChatGPT' }).click()
   await expect(page.getByText('Complete sign-in in your browser.')).toBeVisible()
   await page.evaluate(() => window.dispatchEvent(new Event('pageshow')))
 
-  await expect(page.getByRole('status')).toContainText('Provider connected')
-  await expect(page.getByRole('button', { name: 'Enter Möbius' })).toBeEnabled()
+  await expect(codexRow.getByText('Connected', { exact: true })).toBeVisible()
+  await expect.poll(() => settingsWrites).toBe(1)
 })


### PR DESCRIPTION
## Summary
- open new Möbius instances directly in the working shell instead of requiring an agent connection
- replace the blocking walkthrough with dismissible Settings and App Store guidance
- make Codex setup a clear device-access then connection flow with an official Data Controls link
- keep self-hosted first boot focused on username, password, and password confirmation

## Verification
- npm test -- --runInBand (1,823 frontend tests + 47 hook tests)
- npm run build
- targeted ProviderAuth tests (6)