### PR TITLE
Keep background app build failures out of owner UI

### DIFF
--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -42,7 +42,6 @@ import {
   ACTIVATE_FOREGROUND,
 } from './workspacePlacement.js'
 import {
-  appBuildFailureMessage,
   appUpdateStaleMessage,
   findAppStoreApp,
 } from '../../lib/appRecovery.js'
@@ -2466,12 +2465,12 @@ export default function Shell() {
         confirmAndPlace()
       }
     } else if (ev.type === 'app_build_failed') {
-      // System-bus-only (app_watcher publishes it there alone), so it arrives
-      // exactly once — no dedup stamp needed.
-      showToast(appBuildFailureMessage(ev), {
-        variant: 'error',
-        duration: 10000,
-      })
+      // A failed background build leaves the previous app version running.
+      // The owner has no useful action here, and a burst of watcher retries
+      // must never cover the composer. Keep the diagnostic in backend logs;
+      // actionable update drift uses app_update_stale below with a direct path
+      // back to the App Store.
+      return
     } else if (ev.type === 'app_update_stale') {
       // The reviewed candidate changed while a conflict was being resolved.
       // Keep the prior live version explicit and take the owner back to the

--- a/frontend/src/components/Shell/__tests__/shellFailurePresentation.test.js
+++ b/frontend/src/components/Shell/__tests__/shellFailurePresentation.test.js
@@ -4,12 +4,16 @@ import assert from 'node:assert/strict'
 
 const shellSource = readFileSync(new URL('../Shell.jsx', import.meta.url), 'utf8')
 
-test('automatic shell rebuild failures do not interrupt the owner UI', () => {
-  const failureBranch = shellSource.match(
-    /else if \(ev\.type === 'shell_rebuild_failed'\) \{([\s\S]*?)\n    \}/,
-  )
+for (const eventType of ['app_build_failed', 'shell_rebuild_failed']) {
+  test(`${eventType} does not interrupt the owner UI`, () => {
+    const failureBranch = shellSource.match(
+      new RegExp(
+        String.raw`else if \(ev\.type === '${eventType}'\) \{([\s\S]*?)\n    \}`,
+      ),
+    )
 
-  assert.ok(failureBranch, 'Shell should explicitly document the silent failure policy')
-  assert.doesNotMatch(failureBranch[1], /showToast|setToast|alert\s*\(/,
-    'a safe watcher failure must not cover or block the composer')
-})
+    assert.ok(failureBranch, 'Shell should explicitly document the silent failure policy')
+    assert.doesNotMatch(failureBranch[1], /showToast|setToast|alert\s*\(/,
+      'a safe watcher failure must not cover or block the composer')
+  })
+}

--- a/frontend/src/lib/__tests__/appRecovery.test.js
+++ b/frontend/src/lib/__tests__/appRecovery.test.js
@@ -2,36 +2,9 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 
 import {
-  appBuildFailureMessage,
   appUpdateStaleMessage,
   findAppStoreApp,
-  summarizeAppBuildFailure,
 } from '../appRecovery.js'
-
-test('formats app build failures with app name and reassurance', () => {
-  assert.equal(
-    appBuildFailureMessage({
-      appName: 'Planner',
-      summary: 'Expected "}" but found end of file',
-    }),
-    'Couldn\'t compile Planner — Expected "}" but found end of file. The previous version is still running.',
-  )
-})
-
-test('preserves terminal punctuation and uses a natural fallback name', () => {
-  assert.equal(
-    appBuildFailureMessage({ summary: 'Parser stopped.' }),
-    'Couldn\'t compile this app — Parser stopped. The previous version is still running.',
-  )
-})
-
-test('compacts and truncates app build summaries', () => {
-  const summary = summarizeAppBuildFailure({
-    summary: `Unexpected ${'x'.repeat(220)}`,
-  })
-  assert.equal(summary.length, 160)
-  assert.match(summary, /…$/)
-})
 
 test('explains how to recover a stale update without alarming about live state', () => {
   assert.equal(

--- a/frontend/src/lib/appRecovery.js
+++ b/frontend/src/lib/appRecovery.js
@@ -1,41 +1,13 @@
 const FALLBACK_APP_NAME = 'this app'
 const REASSURANCE = 'The previous version is still running.'
-const MAX_SUMMARY_LENGTH = 160
 const APP_STORE_MANIFEST_PREFIX = 'https://raw.githubusercontent.com/mobius-os/app-store/'
-const TERMINAL_PUNCTUATION = /[.!?…]$/
 
 function compact(text) {
   return String(text || '').replace(/\s+/g, ' ').trim()
 }
 
-function truncate(text, limit) {
-  if (text.length <= limit) return text
-  return `${text.slice(0, Math.max(0, limit - 1)).trimEnd()}…`
-}
-
 function appName(event) {
   return compact(event?.appName || event?.name || '') || FALLBACK_APP_NAME
-}
-
-function sentence(text) {
-  return TERMINAL_PUNCTUATION.test(text) ? text : `${text}.`
-}
-
-export function summarizeAppBuildFailure(eventOrError) {
-  if (typeof eventOrError === 'string') {
-    return truncate(compact(eventOrError), MAX_SUMMARY_LENGTH)
-  }
-  return truncate(
-    compact(eventOrError?.summary || eventOrError?.error || ''),
-    MAX_SUMMARY_LENGTH,
-  )
-}
-
-export function appBuildFailureMessage(eventOrError) {
-  const name = appName(eventOrError)
-  const summary = summarizeAppBuildFailure(eventOrError)
-  if (!summary) return `Couldn't compile ${name}. ${REASSURANCE}`
-  return `Couldn't compile ${name} — ${sentence(summary)} ${REASSURANCE}`
 }
 
 export function appUpdateStaleMessage(event) {


### PR DESCRIPTION
## Summary
- keep background app build failures in diagnostics instead of covering owner input
- preserve the actionable stale-update prompt that links back to the App Store
- remove formatting code that no longer has an owner-visible caller

## Why
#174 correctly made ordinary save-time compiler failures diagnostic-only, but intentionally preserved owner-visible failures for durable update and reconciliation paths. Those background paths can also retry in bursts while the last successful app version remains available, leaving the owner with no useful action and temporarily covering the composer.

This extends #174 by making `app_build_failed` silent in the shell. `app_update_stale` remains visible because it gives the owner a concrete review action.

## Tests
- `node --test src/components/Shell/__tests__/shellFailurePresentation.test.js src/lib/__tests__/appRecovery.test.js`
- `npm test` (1,902 tests)
- `npm run build`