### PR TITLE
fix(shell): coordinate pane entry as one beat

### DIFF
--- a/frontend/src/components/Shell/__tests__/workspaceView.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceView.test.js
@@ -628,10 +628,7 @@ test('four-pane assemble/scatter preserves all four outer-edge vectors', () => {
   }
 })
 
-test('uneven entry normalizes pane velocity and lands every edge on one frame', () => {
-  // A deliberately asymmetric tree reproduces the production complaint: without
-  // distance-aware timing, the shortest and longest edge vectors differ by almost
-  // 2× while sharing one duration, so one pane visibly rushes into the seam.
+test('uneven entry uses one coordinated progress clock for every edge', () => {
   let ws = paneModel.seedFromFlatTabs([makeTab('chat', '1')])
   ws = paneModel.splitPaneWithTab(ws, makeTab('chat', '2'), {
     paneId: ws.focusedPaneId, edge: 'right',
@@ -646,17 +643,11 @@ test('uneven entry normalizes pane velocity and lands every edge on one frame', 
 
   const plan = deriveEnterPlan({ workspace: ws, projection: project(ws), contentRect: CONTENT })
   assert.equal(plan.totalMs, MODE_MOTION.enterItemMs)
-  assert.ok(plan.participants.some(p => p.delayMs > 0),
-    'a shorter trip waits offscreen instead of racing a longer trip')
+  assert.ok(plan.participants.every(p => p.delayMs === 0),
+    'every pane starts on the same frame')
   assert.ok(plan.participants.every(
     p => p.delayMs + p.durationMs === MODE_MOTION.enterItemMs,
   ), 'every pane lands on the same terminal frame')
-
-  const speeds = plan.participants.map((p) => (
-    Math.hypot(p.offset.x, p.offset.y) / p.durationMs
-  ))
-  assert.ok(Math.max(...speeds) / Math.min(...speeds) < 1.15,
-    'average pane velocities stay perceptually aligned despite asymmetric geometry')
 })
 
 test('N1: MODE_MOTION drops the unused chromeMs constant', () => {

--- a/frontend/src/components/Shell/workspaceView.js
+++ b/frontend/src/components/Shell/workspaceView.js
@@ -59,12 +59,11 @@ export function projectFocusedPane(baseProjection, workspace, paneId, contentRec
 // Timing (ms). Constants live here, NOT in the machine, so the reconcile clock
 // (INV 14) and the missing-target fallback (INV 13) reason about the plan's own
 // totalMs rather than a fixed per-phase maximum. Mode changes are intentionally one
-// short beat using only compositor transforms + opacity. Entry participants may
-// start at different instants to normalize unequal travel, but land together; there
-// is no pane-count stagger or second destination phase to make the owner wait.
+// short beat using only compositor transforms + opacity. Every participant in a
+// direction shares one progress clock: coordinated interface motion matters more
+// than equalizing raw pixels-per-millisecond across differently sized panes.
 export const MODE_MOTION = Object.freeze({
   enterItemMs: 240,
-  enterMinItemMs: 120,
   exitItemMs: 180,
   promoteMs: 210,
   logoReleaseMs: 90,
@@ -327,11 +326,10 @@ export function deriveExitPlan(input) {
 }
 
 // deriveEnterPlan(input) → the latched entry plan, or null when there is nothing
-// to assemble. The single-screen surface remains a stationary full-bleed underlay
-// while every OTHER visible pane gathers from its nearest outer edge. When that
-// surface is also a builder leaf, completion simply crops the retained wrapper
-// into its pane. This keeps the Standard world visually still instead of scaling
-// it like a foreground card, and needs no duplicate ChatView/AppCanvas.
+// to assemble. The single-screen surface remains the live, stationary full-bleed
+// underlay while every OTHER visible pane gathers from its nearest outer edge.
+// That background never joins the motion plan or changes geometry during the beat;
+// completion alone hands it back to the tiled layout.
 //
 export function deriveEnterPlan(input) {
   const { workspace, projection, contentRect } = input
@@ -343,31 +341,14 @@ export function deriveEnterPlan(input) {
   const participants = []
   const completionNames = new Set()
   const underlayKey = target
-
-  const incoming = leaves
-    .filter(l => l.activeKey !== target)
-    .map(l => ({ leaf: l, offset: edgeOffset(l.rect, contentRect, l.motionRect) }))
+  const incoming = leaves.filter(l => l.activeKey !== target)
   if (incoming.length === 0) return null
-  const maxDistance = Math.max(...incoming.map(({ offset }) => Math.hypot(offset.x, offset.y)))
-
-  for (const { leaf: l, offset } of incoming) {
-    // Projection-derived travel can differ by nearly 2× in an uneven three-pane
-    // tree. Start shorter trips later and give them proportionally less time so
-    // every pane travels at the same perceived speed and lands on the same frame.
-    // The floor prevents a very small pane from becoming a one-frame flash.
-    const distance = Math.hypot(offset.x, offset.y)
-    const proportionalMs = maxDistance > 0
-      ? Math.round(MODE_MOTION.enterItemMs * distance / maxDistance)
-      : MODE_MOTION.enterItemMs
-    const durationMs = Math.min(
-      MODE_MOTION.enterItemMs,
-      Math.max(MODE_MOTION.enterMinItemMs, proportionalMs),
-    )
+  for (const l of incoming) {
     participants.push({
       key: l.activeKey, paneId: l.paneId, motion: 'deal-in',
-      delayMs: MODE_MOTION.enterItemMs - durationMs,
-      durationMs,
-      offset,
+      delayMs: 0,
+      durationMs: MODE_MOTION.enterItemMs,
+      offset: edgeOffset(l.rect, contentRect, l.motionRect),
     })
     completionNames.add(DEAL_IN_NAME)
   }

--- a/tests/mode-transition.spec.mjs
+++ b/tests/mode-transition.spec.mjs
@@ -450,7 +450,7 @@ test('v3 world-reveal scatter paints the mounted destination underlay beneath th
   await expect.poll(() => modePhase(page), { timeout: 2000 }).toBe('idle')
 })
 
-test('v3 panes assemble over the stationary single screen from their corresponding edges', async ({ page }) => {
+test('v3 panes assemble from their corresponding edges on one coordinated beat', async ({ page }) => {
   await bootSeededWorkspace(page, WIDE, twoPaneBuilder({ kind: 'chat', id: 'ghost' }))
   await toggleMode(page)
   await expect.poll(() => modePhase(page), { timeout: 2000 }).toBe('idle')
@@ -475,7 +475,7 @@ test('v3 panes assemble over the stationary single screen from their correspondi
   await expect.poll(() => builderActive(page)).toBe(true)
 })
 
-test('uneven panes enter at one perceived velocity and land together', async ({ page }) => {
+test('uneven panes start and land together on one coordinated progress clock', async ({ page }) => {
   await bootSeededWorkspace(
     page,
     WIDE,
@@ -491,13 +491,12 @@ test('uneven panes enter at one perceived velocity and land together', async ({ 
   const r = await sampler
 
   expect(r.participants).toHaveLength(3)
-  expect(r.participants.some(p => p.delay > 0),
-    'shorter vectors wait offscreen rather than rushing the seam').toBe(true)
+  expect(r.participants.every(p => p.delay === 0),
+    'every pane starts on the same frame').toBe(true)
   const arrivals = r.participants.map(p => p.delay + p.duration)
   expect(new Set(arrivals).size, 'all panes land on the same frame').toBe(1)
-  const speeds = r.participants.map(p => Math.hypot(p.x, p.y) / p.duration)
-  expect(Math.max(...speeds) / Math.min(...speeds),
-    'asymmetric panes keep a common average velocity').toBeLessThan(1.15)
+  expect(new Set(r.participants.map(p => p.duration)).size,
+    'every pane shares one progress duration').toBe(1)
   await expect.poll(() => modePhase(page), { timeout: 2000 }).toBe('idle')
   await expect.poll(() => builderActive(page)).toBe(true)
 })


### PR DESCRIPTION
## Summary
- start every entering pane on the same frame and run them on one shared 240ms progress clock
- keep the Standard surface mounted as the stationary full-bleed underlay while only incoming sibling panes transform
- remove distance-normalized delays and durations that made shorter panes visibly wait before joining the transition
- preserve the existing edge geometry, synchronized landing, compositor-only animation, and reduced-motion behavior
- update unit and browser regression coverage for uneven workspaces

## Why
Follow-up to #183. Equalizing average pixel velocity made asymmetric workspaces enter in pieces: shorter panes deliberately stayed off-screen while longer panes had already begun moving. The panes still landed together, but the start no longer read as one interface transition.

#191 extends that velocity-normalization approach at extreme split ratios. This PR takes a different path based on the rendered interaction: all panes share one progress clock, while the live Standard surface remains untouched in the background throughout the beat.

## Verification
- full frontend suites: 1,822 library tests and 47 hook tests passed on current `main`
- focused Shell workspace tests: 121 passed
- generated planner audit: 420 cases across split directions, 10–90% ratios, and three viewport classes passed
- production frontend build passed on current `main`
- rendered two-pane check at 1680×957 confirmed the Standard underlay stayed at `transform: none` and `opacity: 1`; only the incoming pane carried motion, with zero delay