### PR TITLE
Fix disconnected first-run provider settings

### DIFF
--- a/frontend/src/components/ChatView/ManageModelsModal.jsx
+++ b/frontend/src/components/ChatView/ManageModelsModal.jsx
@@ -27,12 +27,14 @@ import { useQueryClient } from '@tanstack/react-query'
 import { api } from '../../api/client.js'
 import useDialogFocus from '../../hooks/useDialogFocus.js'
 import { modelQueries } from '../../hooks/queries.js'
+import { configuredProviderOrder } from '../../lib/providerAvailability.js'
 import './ManageModelsModal.css'
 
 export default function ManageModelsModal({
   onClose,
   providerOrder,
   providerInfo,
+  configuredProviders,
 }) {
   const queryClient = useQueryClient()
   // Read straight from cache — by the time the modal opens, the
@@ -171,6 +173,10 @@ export default function ManageModelsModal({
   }, [queryClient])
 
   const ready = !!registry
+  const visibleProviderOrder = configuredProviderOrder(
+    providerOrder,
+    configuredProviders,
+  )
 
   return (
     <div
@@ -210,7 +216,7 @@ export default function ManageModelsModal({
               </div>
             )}
 
-            {ready && providerOrder.map(pid => {
+            {ready && visibleProviderOrder.map(pid => {
               const info = providerInfo[pid]
               const entries = registry[pid] || []
               if (entries.length === 0) return null

--- a/frontend/src/components/ProviderAuth/ProviderAuth.css
+++ b/frontend/src/components/ProviderAuth/ProviderAuth.css
@@ -270,6 +270,14 @@
   transition: border-color 0.15s;
 }
 
+.provider-row--disabled {
+  opacity: 0.56;
+}
+
+.provider-row__action:disabled {
+  cursor: not-allowed;
+}
+
 /* Light mode: subtle elevation so the row reads as a distinct
    card surface against the light page bg. Mirrors the
    .settings__section shadow contract — dark mode stays flat. */

--- a/frontend/src/components/ProviderAuth/ProviderRow.jsx
+++ b/frontend/src/components/ProviderAuth/ProviderRow.jsx
@@ -29,10 +29,11 @@ import './ProviderAuth.css'
  *   actionLabel     — optional override for the action button text
  *                     (e.g. "Reconfigure" / "Configure"); the default
  *                     is the Connect/Reconnect/Close verb below.
+ *   disabled        — greys the informational row and disables its action.
  */
 export default function ProviderRow({
   name, connected, expanded, onToggleExpand, children,
-  badge, version, subtitle, statusNode, actionLabel,
+  badge, version, subtitle, statusNode, actionLabel, disabled = false,
 }) {
   // Name + installed CLI/SDK version + status are informational. The explicit
   // action button is the only interactive target in the row.
@@ -63,12 +64,13 @@ export default function ProviderRow({
   )
 
   return (
-    <div className="provider-row">
+    <div className={`provider-row${disabled ? ' provider-row--disabled' : ''}`}>
       <div className="provider-row__main">{info}</div>
       <button
         type="button"
         className="provider-row__action"
         onClick={() => onToggleExpand?.()}
+        disabled={disabled}
         aria-expanded={expanded}
         aria-label={(() => {
           const verb = expanded

--- a/frontend/src/components/SettingsView/SettingsView.css
+++ b/frontend/src/components/SettingsView/SettingsView.css
@@ -243,6 +243,10 @@
   scroll-margin-top: 24px;
 }
 
+.settings-agent-group--disabled {
+  opacity: 0.56;
+}
+
 .settings__section:focus,
 .settings-agent-group:focus {
   outline: none;
@@ -363,6 +367,11 @@
 .settings-bg-row--off {
   background: transparent;
   opacity: 0.78;
+}
+
+.settings-bg-row--disconnected .settings-bg-row__drag-handle,
+.settings-bg-row--disconnected .model-trigger {
+  cursor: not-allowed;
 }
 
 .settings-bg-row__drag-handle {

--- a/frontend/src/components/SettingsView/SettingsView.jsx
+++ b/frontend/src/components/SettingsView/SettingsView.jsx
@@ -141,7 +141,8 @@ function BackgroundProviderRow({
 }) {
   const info = PROVIDER_INFO[row.provider]
   const Logo = info?.Logo
-  const enabled = row.enabled !== false
+  const configured = configuredProviders.has(row.provider)
+  const enabled = configured && row.enabled !== false
   const selectedModel = enabled ? (row.model || defaultModel(row.provider)) : ''
   const selectedRow = models.find((m) => m.id === selectedModel)
   const efforts = info?.efforts || []
@@ -164,7 +165,7 @@ function BackgroundProviderRow({
     key: row.provider,
     label: info?.label || row.provider,
     Logo,
-    models: orderSelectedFirst(models, enabled ? selectedModel : null),
+    models: configured ? orderSelectedFirst(models, enabled ? selectedModel : null) : [],
   }]
   const triggerLabel = enabled
     ? (selectedRow?.label || selectedModel || 'Choose model')
@@ -175,6 +176,7 @@ function BackgroundProviderRow({
       className={
         'settings-bg-row'
         + (enabled ? '' : ' settings-bg-row--off')
+        + (configured ? '' : ' settings-bg-row--disconnected')
         + (reorderMode ? ' settings-bg-row--reordering' : '')
         + (dragging ? ' settings-bg-row--dragging' : '')
         + (dropTarget ? ' settings-bg-row--drop-target' : '')
@@ -198,6 +200,7 @@ function BackgroundProviderRow({
             })
           }}
           onClick={(event) => event.preventDefault()}
+          disabled={!configured}
           onKeyDown={(event) => {
             if (event.key === 'ArrowUp') {
               event.preventDefault()
@@ -216,6 +219,7 @@ function BackgroundProviderRow({
           type="button"
           className={`model-trigger${enabled ? '' : ' model-trigger--off'}`}
           onClick={() => setSheetOpen(true)}
+          disabled={!configured}
           aria-haspopup="dialog"
           aria-label={`${info?.label || row.provider} background model${effortLabel ? `, ${effortLabel} effort` : ''}`}
         >
@@ -381,6 +385,7 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
   const claudeVersion = settingsQuery.data?.claude_version
   const codexVersion = settingsQuery.data?.codex_version
   const claudeAuthenticated = configuredProviders.has('claude')
+  const hasConfiguredProvider = configuredProviders.size > 0
   // Three-state gate for the AI-providers section, in priority order:
   //
   //   READY   — at least the cached data is present (data !== undefined).
@@ -1327,11 +1332,14 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
 
                 <ProviderRow
                   name="Chat model"
-                  connected
-                  subtitle="Choose which models appear. New chats use your last pick."
+                  connected={hasConfiguredProvider}
+                  disabled={!hasConfiguredProvider}
+                  subtitle={hasConfiguredProvider
+                    ? 'Choose which models appear. New chats use your last pick.'
+                    : 'Connect an AI provider to choose chat models.'}
                   statusNode={
                     <span className="provider-row__status-text settings__last-model">
-                      {lastModelLabel ? (
+                      {!hasConfiguredProvider ? 'No provider connected' : lastModelLabel ? (
                         <>
                           Last model: <span className="settings__standard-highlight">{lastModelLabel}</span>
                         </>
@@ -1345,7 +1353,10 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
               </div>
 
               <div
-                className={`settings-agent-group${attentionSection === 'background-agents' ? ' settings-setup-target' : ''}`}
+                className={
+                  `settings-agent-group${hasConfiguredProvider ? '' : ' settings-agent-group--disabled'}`
+                  + (attentionSection === 'background-agents' ? ' settings-setup-target' : '')
+                }
                 id="settings-background-agents"
                 ref={(node) => setSetupFocusRef('background-agents', node)}
                 tabIndex={-1}
@@ -1355,7 +1366,9 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
                     <h3 className="settings__agent-title">Background agents</h3>
                   </div>
                   <p className="settings__subtext settings__subtext--tight">
-                    Used for memory, reflection, and other automatic tasks. Tried in order.
+                    {hasConfiguredProvider
+                      ? 'Used for memory, reflection, and other automatic tasks. Tried in order.'
+                      : 'Connect an AI provider to configure automatic tasks.'}
                   </p>
                 </div>
                 <div
@@ -1408,6 +1421,7 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
                   onClose={() => setManageModelsOpen(false)}
                   providerOrder={PROVIDER_ORDER}
                   providerInfo={PROVIDER_INFO}
+                  configuredProviders={configuredProviders}
                 />
               )}
             </>

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -1,7 +1,6 @@
 import { lazy, Suspense, useState, useEffect, useLayoutEffect, useCallback, useMemo, useReducer, useRef } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import Minimize2 from 'lucide-react/dist/esm/icons/minimize-2.mjs'
-import X from 'lucide-react/dist/esm/icons/x.mjs'
 import Drawer from '../Drawer/Drawer.jsx'
 import Toast from '../ui/Toast.jsx'
 import AppCanvas from '../AppCanvas/AppCanvas.jsx'
@@ -82,9 +81,7 @@ import WorkspaceChrome from './WorkspaceChrome.jsx'
 import useWorkspaceDrag from './useWorkspaceDrag.js'
 import useModeController from './useModeController.js'
 import * as modeMachine from './modeMachine.js'
-import {
-  HINT_KEY, coachmarkArmed, coachmarkDismissed, undoKeyPressed, isEditableTarget,
-} from './workspaceOnboarding.js'
+import { undoKeyPressed, isEditableTarget } from './workspaceOnboarding.js'
 import PaneChatView from './PaneChatView.jsx'
 import ErrorBoundary from '../ErrorBoundary/ErrorBoundary.jsx'
 import {
@@ -1423,9 +1420,6 @@ export default function Shell() {
   labelForTabRef.current = labelForTab
   const openTabMenuAtRef = useRef(openTabMenuAt)
   openTabMenuAtRef.current = openTabMenuAt
-  // Filled by the first-use coachmark (§7); the first real drag dismisses it.
-  const coachmarkDismissRef = useRef(null)
-  const onWorkspaceDragStart = useCallback(() => { coachmarkDismissRef.current?.() }, [])
   // A single-mode drag previews the builder world through the ONE descriptor
   // (INV 5): arm is phase 'drag-preview', and the id it mints is carried to the
   // matching commit/cancel so a stale end-event from a superseded drag is
@@ -1509,42 +1503,14 @@ export default function Shell() {
     closeDrawer,
     openDrawer,
     openTabMenuAtRef,
-    onDragStart: onWorkspaceDragStart,
     onPreviewBuilder: onModeDragPreview,
   })
 
-  // ── Undo chord + first-use coachmark (design §3.5 / §7) ───────────────────
+  // ── Workspace undo chord (design §3.5) ────────────────────────────────────
   // Workspace mutations update the reducer's single undo slot SILENTLY; the
   // owner found the "Moved X · Undo" / "Agent arranged your workspace" toasts
-  // noise, so there is no per-mutation toast (owner call, live testing). Undo is
-  // the Cmd/Ctrl+Z chord below plus the discoverability coachmark.
-  const [wsCoachmarkDismissed, setWsCoachmarkDismissed] = useState(
-    () => coachmarkDismissed(typeof localStorage !== 'undefined'
-      ? localStorage
-      : { getItem: () => '1' }),
-  )
-  const dismissWorkspaceCoachmark = useCallback(() => {
-    setWsCoachmarkDismissed(true)
-    try { localStorage.setItem(HINT_KEY, '1') } catch { /* private mode — shows once in memory */ }
-  }, [])
-  // The first real drag dismisses it (wired through the ref the drag hook calls).
-  coachmarkDismissRef.current = dismissWorkspaceCoachmark
-  const workspaceCoachmarkVisible = coachmarkArmed({
-    enabled: paneModel.WORKSPACE_SPLITS_ENABLED,
-    tabCount: openTabs.length,
-    dismissed: wsCoachmarkDismissed,
-    // M6: only where the tab strip actually exists — the EFFECTIVE builder world —
-    // and never over an immersive lease (z-120). Immersive may temporarily cover
-    // either durable world, so the explicit check keeps the hint with the chrome it
-    // teaches instead of painting it over the focused app.
-    builderWorld: effectiveViewMode === 'panes' && !immersiveActive,
-  })
-  // Auto-dismiss after 12s — deliberately NOT on an unrelated pointerdown (§7.2).
-  useEffect(() => {
-    if (!workspaceCoachmarkVisible) return undefined
-    const t = setTimeout(dismissWorkspaceCoachmark, 12000)
-    return () => clearTimeout(t)
-  }, [workspaceCoachmarkVisible, dismissWorkspaceCoachmark])
+  // noise, so there is no per-mutation toast (owner call, live testing). Undo
+  // remains available through Cmd/Ctrl+Z while focus is outside an editor.
   // Cmd/Ctrl+Z restores the single-slot pre-mutation snapshot while no input is
   // focused (design §3.5). Flag-gated; a text field's own undo always wins.
   // Documented limitation (PR3): key events do not cross the iframe boundary, so
@@ -3322,10 +3288,9 @@ export default function Shell() {
           inert={modalDrawerOpen || modeBeatActive}
           aria-label="Open tabs"
           // The single-pane strip is the PRIMARY drag source once the flag is on
-          // (the coachmark teaches "drag tabs to split" here). Tag it with the
-          // sole pane's id so the drag controller resolves a source pane exactly
-          // as it does for a WorkspaceChrome strip; dragging a tab out with ≥2
-          // tabs present splits the pane.
+          // Tag it with the sole pane's id so the drag controller resolves a
+          // source pane exactly as it does for a WorkspaceChrome strip; dragging
+          // a tab out with ≥2 tabs present splits the pane.
           data-pane-strip={paneModel.WORKSPACE_SPLITS_ENABLED ? workspace.focusedPaneId : undefined}
           data-mode-motion={navMotion ? navMotion.motion : undefined}
           style={navMotion ? navMotion.vars : undefined}
@@ -3657,25 +3622,6 @@ export default function Shell() {
         >
           <Minimize2 size={18} aria-hidden="true" />
         </button>
-      )}
-      {/* First-use coachmark (design §7.2) — the discoverability path for the
-          existing user base (the walkthrough never re-fires). Arms at ≥2 tabs
-          with the splits flag on; dismissed by a drag, its ✕, or 12s — never by
-          an unrelated tap. */}
-      {workspaceCoachmarkVisible && (
-        <div className="workspace__coachmark" role="status" aria-live="polite" inert={modalDrawerOpen}>
-          <span className="workspace__coachmark-text">
-            Drag a tab to move or split it
-          </span>
-          <button
-            type="button"
-            className="workspace__coachmark-close"
-            aria-label="Dismiss hint"
-            onClick={dismissWorkspaceCoachmark}
-          >
-            <X size={14} aria-hidden="true" />
-          </button>
-        </div>
       )}
       <Toast
         message={toast?.message}

--- a/frontend/src/components/Shell/__tests__/workspaceOnboarding.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceOnboarding.test.js
@@ -1,34 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import {
-  HINT_KEY, coachmarkArmed, coachmarkDismissed,
-  undoKeyPressed, isEditableTarget,
-} from '../workspaceOnboarding.js'
-
-// ── coachmark arming (design §7.2) ───────────────────────────────────────────
-
-test('the coachmark arms only with the flag on, ≥2 tabs, and not dismissed', () => {
-  assert.equal(coachmarkArmed({ enabled: true, tabCount: 2, dismissed: false }), true)
-  assert.equal(coachmarkArmed({ enabled: true, tabCount: 1, dismissed: false }), false) // needs ≥2
-  assert.equal(coachmarkArmed({ enabled: false, tabCount: 5, dismissed: false }), false) // flag off
-  assert.equal(coachmarkArmed({ enabled: true, tabCount: 3, dismissed: true }), false) // already dismissed
-})
-
-test('M6: the coachmark is gated to the effective builder world (never single/immersive)', () => {
-  // It teaches "drag tabs to split", so it only shows where the strip exists — the
-  // effective builder world. Single mode / an immersive-solo pass builderWorld:false.
-  assert.equal(coachmarkArmed({ enabled: true, tabCount: 2, dismissed: false, builderWorld: false }), false)
-  assert.equal(coachmarkArmed({ enabled: true, tabCount: 2, dismissed: false, builderWorld: true }), true)
-  // Absent builderWorld defaults to true so the pure helper's other callers/tests
-  // are unaffected — the Shell call site supplies the world gate.
-  assert.equal(coachmarkArmed({ enabled: true, tabCount: 2, dismissed: false }), true)
-})
-
-test('coachmarkDismissed reads the flag and treats broken storage as dismissed', () => {
-  assert.equal(coachmarkDismissed({ getItem: (k) => (k === HINT_KEY ? '1' : null) }), true)
-  assert.equal(coachmarkDismissed({ getItem: () => null }), false)
-  assert.equal(coachmarkDismissed({ getItem: () => { throw new Error('blocked') } }), true)
-})
+import { undoKeyPressed, isEditableTarget } from '../workspaceOnboarding.js'
 
 // ── undo chord (design §3.5) ─────────────────────────────────────────────────
 

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -97,20 +97,9 @@ test('reduced motion makes the drop preview instant', () => {
   assert.match(block, /\.workspace__drop-preview\s*\{\s*transition:\s*none/)
 })
 
-test('the coachmark gives one direct drag instruction and dismisses without a stray tap', () => {
-  assert.match(shell, /workspaceCoachmarkVisible/)
-  // M6: gated to the effective builder world + non-immersive, so it never shows in
-  // single mode (no tabs) or over an immersive-solo (z-120).
-  assert.match(shell, /builderWorld: effectiveViewMode === 'panes' && !immersiveActive/)
-  assert.match(shell, /Drag a tab to move or split it/)
-  assert.match(shell, /onClick=\{dismissWorkspaceCoachmark\}/)
-  // 12s auto-dismiss, never an unrelated pointerdown.
-  assert.match(shell, /setTimeout\(dismissWorkspaceCoachmark, 12000\)/)
-  assert.doesNotMatch(shell, /coachmark[\s\S]{0,80}addEventListener\('pointerdown'/)
-  const hintRule = css.match(/\.workspace__coachmark\s*\{[\s\S]*?\}/)?.[0] || ''
-  const closeRule = css.match(/\.workspace__coachmark-close\s*\{[\s\S]*?\}/)?.[0] || ''
-  assert.match(hintRule, /pointer-events:\s*none/)
-  assert.match(closeRule, /pointer-events:\s*auto/)
+test('the retired first-use drag hint cannot reappear in the shell', () => {
+  assert.doesNotMatch(shell, /workspaceCoachmarkVisible|Drag a tab to move or split it/)
+  assert.doesNotMatch(css, /\.workspace__coachmark/)
 })
 
 test('post-drag click suppression is source-scoped and expires on fresh input', () => {
@@ -858,12 +847,7 @@ test('the splits kill-switch forces the single-pane fallback so a rolled-back pa
   assert.match(paneModelSrc, /function coerceViewMode\(mode\) \{\s*\n\s*if \(!WORKSPACE_SPLITS_ENABLED\) return 'single'/)
 })
 
-test('visual nits V3-V6: coachmark clears the strip, focus underline reads, drag label clamps, cancel blurs', () => {
-  // V3: the first-use coachmark anchors BELOW the strip (bar 58px + safe-area + strip
-  // 34px + 8px gap), so its pill never covers a tab label.
-  const coach = css.match(/\.workspace__coachmark \{[\s\S]*?\n\}/)?.[0] || ''
-  assert.match(coach, /top: calc\(58px \+ env\(safe-area-inset-top\) \+ 42px\)/)
-  assert.doesNotMatch(coach, /top: 60px/)
+test('workspace focus, drag label, and cancel visuals remain coherent', () => {
   // V4: the FOCUSED pane's active pill softens the base full-accent border so the 2px
   // underline is what carries focus (the border used to mask it).
   const focused = css.match(/\.workspace__strip--focused \.shell__tab--active \{[\s\S]*?\n\}/)?.[0] || ''

--- a/frontend/src/components/Shell/useWorkspaceDrag.js
+++ b/frontend/src/components/Shell/useWorkspaceDrag.js
@@ -81,7 +81,6 @@ export default function useWorkspaceDrag({
   closeDrawer,
   openDrawer,
   openTabMenuAtRef, // ref → (clientX, clientY, tab, paneId) => void
-  onDragStart, // dismiss the coachmark on the first real drag
   onPreviewBuilder, // (active, { committed }) => void — enter/leave the LIVE
   // builder preview a single-mode drag unfolds (point 15: dragging IS
   // building). Render-only: the reducer viewMode stays 'single' until the drop
@@ -290,7 +289,6 @@ export default function useWorkspaceDrag({
         // mutation, and a committed drop flips 'panes' via OPEN_TAB_AT (one undo
         // reverts both). There is no drag-deny anymore — dragging is always allowed.
         if (workspaceStateRef.current.ws.viewMode === 'single') onPreviewBuilder?.(true)
-        onDragStart?.() // dismiss the coachmark
         try { srcEl.setPointerCapture?.(pointerId) } catch { /* capture optional */ }
         if (!isTouch) {
           prevBodySelect = document.body.style.userSelect

--- a/frontend/src/components/Shell/workspace.css
+++ b/frontend/src/components/Shell/workspace.css
@@ -434,69 +434,12 @@
 }
 .workspace__drag-chip[hidden] { display: none; }
 
-/* First-use coachmark (design §7.2) — a quiet pill near the top that names the
-   gesture once. Anchored to the strip region; dismisses on drag / ✕ / 12s. */
-.workspace__coachmark {
-  position: fixed;
-  /* V3 (vizreview): anchor BELOW the strip row, never over it — a top:60px pill sat
-     across the tab strip and covered the third tab's label. This clears the bar
-     (58px + safe-area) + the strip (STRIP_H 34px) + an 8px gap, so it floats over
-     content and no tab label is occluded. */
-  top: calc(58px + env(safe-area-inset-top) + 42px);
-  left: 50%;
-  transform: translateX(-50%);
-  z-index: 120;
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  max-width: calc(100vw - 24px);
-  padding: 8px 8px 8px 14px;
-  border-radius: 999px;
-  border: 1px solid var(--border-light);
-  background: color-mix(in srgb, var(--accent) 14%, var(--bg));
-  color: var(--text);
-  font-size: 13px;
-  font-weight: 500;
-  box-shadow: 0 6px 16px color-mix(in srgb, #000 24%, transparent);
-  animation: workspace-coachmark-in 200ms ease-out;
-  /* The hint overlaps the strip by design, but must not make tabs inert for its
-     12-second lifetime. Only its explicit close control owns pointer input. */
-  pointer-events: none;
-}
-.workspace__coachmark-text { white-space: nowrap; }
-.workspace__coachmark-close {
-  display: grid;
-  place-items: center;
-  width: 26px;
-  height: 26px;
-  border: 0;
-  border-radius: 999px;
-  background: transparent;
-  color: var(--muted);
-  cursor: pointer;
-  flex-shrink: 0;
-  pointer-events: auto;
-}
-.workspace__coachmark-close:hover {
-  background: color-mix(in srgb, var(--text) 10%, transparent);
-  color: var(--text);
-}
-.workspace__coachmark-close:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: -2px;
-}
-@keyframes workspace-coachmark-in {
-  from { opacity: 0; transform: translate(-50%, -6px); }
-  to { opacity: 1; transform: translate(-50%, 0); }
-}
-
 @media (prefers-reduced-motion: reduce) {
   /* Instant swap — no draw-in flourish (design item 5, reduced-motion). */
   .workspace__divider-bar { transition: none; animation: none; }
   /* Reduced motion: instant geometry + color, no fade or morph (design §3.3). */
   .workspace__drop-preview { transition: none; }
   .workspace__drop-preglow { transition: none; }
-  .workspace__coachmark { animation: none; }
   /* Reduced motion never arms a mode descriptor (the controller commits directly),
      so nothing carries data-mode-motion; this is defensive parity — any element
      that somehow did gets no beat. Covers wrappers, strips, and dividers. */

--- a/frontend/src/components/Shell/workspaceOnboarding.js
+++ b/frontend/src/components/Shell/workspaceOnboarding.js
@@ -1,39 +1,6 @@
-// Onboarding + keyboard-undo gating for the workspace drag feature (design §7 /
-// §3.5). Pure, dependency-free helpers so the arming/insertion/keymatch logic is
-// unit-tested without a DOM, and Shell/WalkthroughOverlay stay declarative.
-
-// localStorage key: the first-use coachmark shows at most once per browser.
-export const HINT_KEY = 'mobius:hint-workspace'
-
-// The coachmark arms when the workspace first holds ≥2 tabs, the splits flag is
-// on, it has not already been dismissed this browser (design §7.2), AND the
-// current presentation is the effective builder world with no immersive-solo up
-// (`builderWorld`, M6). It teaches "drag tabs to split", so it may only appear
-// where the tab strip actually exists — this branch removed the strip from single
-// mode, so arming on tab count alone showed it for 12s where no tabs were onscreen,
-// including over immersive content at z-120. It is deliberately NOT gated on a
-// pointer event — an unrelated first tap must never kill it unread, so the caller
-// dismisses only on a drag, the ✕, or a timeout.
-export function coachmarkArmed({ enabled, tabCount, dismissed, builderWorld = true }) {
-  return !!enabled && !dismissed && !!builderWorld && (tabCount || 0) >= 2
-}
-
-// Read the persisted dismissal flag. A storage that throws (private mode,
-// disabled) reports "already dismissed" so a browser that cannot remember the
-// dismissal never nags every session.
-export function coachmarkDismissed(storage) {
-  try {
-    return storage.getItem(HINT_KEY) === '1'
-  } catch {
-    return true
-  }
-}
-
-// The workspace gesture is taught by the first-use coachmark above, which arms
-// at the moment the owner actually holds two tabs. A walkthrough step for it
-// used to exist as well; it was retired with the shortened walkthrough rather
-// than re-anchored, so there is one teaching path at the right moment instead
-// of two at different ones.
+// Keyboard-undo gating for the workspace drag feature (design §3.5). Pure,
+// dependency-free helpers keep Shell's global shortcut declarative and tested
+// without a DOM.
 
 // Cmd/Ctrl+Z (no Shift, no Alt) — the workspace-undo chord (design §3.5). Shift
 // is excluded so it never steals redo.

--- a/frontend/src/lib/__tests__/providerAvailability.test.js
+++ b/frontend/src/lib/__tests__/providerAvailability.test.js
@@ -2,6 +2,7 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import {
   PROVIDER_AVAILABILITY_PHASE,
+  configuredProviderOrder,
   configuredProviderSet,
   providerAvailabilityNeedsAttention,
   resolveProviderAvailability,
@@ -20,6 +21,17 @@ test('availability has explicit loading, ready, and error phases', () => {
   assert.equal(
     resolveProviderAvailability({ data: undefined, isError: true }).phase,
     PROVIDER_AVAILABILITY_PHASE.ERROR,
+  )
+})
+
+test('provider-specific settings list only connected providers', () => {
+  assert.deepEqual(
+    configuredProviderOrder(['claude', 'codex'], new Set(['codex'])),
+    ['codex'],
+  )
+  assert.deepEqual(
+    configuredProviderOrder(['claude', 'codex'], new Set()),
+    [],
   )
 })
 

--- a/frontend/src/lib/__tests__/settingsViewAppearance.test.js
+++ b/frontend/src/lib/__tests__/settingsViewAppearance.test.js
@@ -48,6 +48,15 @@ test('background agents are always draggable without reorder chrome or a trailin
   assert.doesNotMatch(css, /settings-bg-row--drop-before|settings-bg-row--drop-after/)
 })
 
+test('provider-dependent settings stay unavailable until a provider is connected', () => {
+  assert.match(view, /disabled=\{!hasConfiguredProvider\}/)
+  assert.match(view, /No provider connected/)
+  assert.match(view, /Connect an AI provider to choose chat models\./)
+  assert.match(view, /settings-agent-group--disabled/)
+  assert.match(view, /Connect an AI provider to configure automatic tasks\./)
+  assert.match(view, /configuredProviders=\{configuredProviders\}/)
+})
+
 test('new provider connections use the curated unattended defaults', () => {
   assert.match(view, /claude: 'claude-opus-4-8'/)
   assert.match(view, /codex: 'gpt-5\.6-terra'/)

--- a/frontend/src/lib/providerAvailability.js
+++ b/frontend/src/lib/providerAvailability.js
@@ -25,6 +25,14 @@ export function configuredProviderSet(statusByProvider) {
   )
 }
 
+export function configuredProviderOrder(providerOrder, configuredProviders) {
+  const configured = configuredProviders instanceof Set
+    ? configuredProviders
+    : new Set()
+  return (Array.isArray(providerOrder) ? providerOrder : [])
+    .filter(providerId => configured.has(providerId))
+}
+
 export function resolveProviderAvailability(statusQuery) {
   if (statusQuery?.data !== undefined) {
     return {


### PR DESCRIPTION
## Summary
- remove the obsolete drag-tab coachmark from the workspace
- keep chat-model and background-agent controls unavailable until an AI provider is connected
- show models only for providers that are actually connected

## Why
On a fresh install, fallback catalog data made provider-specific choices look configured even though no provider could run them.

## Testing
- `npm test` (1,909 tests)
- `npm run build`