### PR TITLE
Fix stale deletion projections and dismiss notices

### DIFF
--- a/backend/app/broadcast.py
+++ b/backend/app/broadcast.py
@@ -271,7 +271,7 @@ def remove_broadcast(chat_id: str):
 
 class SystemBroadcast:
   """Process-lifetime event bus for shell-level system events
-  (theme_updated, app_updated, shell_rebuild_*).
+  (theme/app updates, exact resource deletion/recovery, shell rebuilds).
 
   Why this exists separately from ChatBroadcast: shell-level state
   (which app version is current, which theme is active) needs to

--- a/backend/app/routes/apps.py
+++ b/backend/app/routes/apps.py
@@ -419,16 +419,31 @@ async def _hard_delete_app(db: Session, app: models.App) -> None:
   db.delete(app)
   db.commit()
   get_system_broadcast().publish(
-    {"type": "app_updated", "appId": str(deleted_app_id)}
+    {"type": "app_deleted", "appId": str(deleted_app_id)}
   )
   from app.install import purge_app_skills
-  await purge_app_skills(deleted_app_id)
+  try:
+    await purge_app_skills(deleted_app_id)
+  except Exception:
+    # The id-keyed data is gone and the row has already been freed. Skill/source
+    # cleanup is no longer allowed to turn that committed state into an
+    # ambiguous failed deletion response.
+    log.exception(
+      "Hard-deleted app %s but could not purge all app skills",
+      deleted_app_id,
+    )
 
   resolved_source = _resolve_app_source_dir(app_source_dir, app_name, settings)
   if resolved_source is not None:
-    async with fs_locks.source_dir_lock(str(resolved_source)):
-      if _safe_to_rmtree_source(resolved_source, apps_root, db, deleted_app_id):
-        await asyncio.to_thread(_drop_cron_and_rmtree, resolved_source)
+    try:
+      async with fs_locks.source_dir_lock(str(resolved_source)):
+        if _safe_to_rmtree_source(resolved_source, apps_root, db, deleted_app_id):
+          await asyncio.to_thread(_drop_cron_and_rmtree, resolved_source)
+    except Exception:
+      log.exception(
+        "Hard-deleted app %s but could not remove its retired source tree",
+        deleted_app_id,
+      )
 
 
 def allocate_unique_slug(db: Session, name: str, exclude_id: int | None = None) -> str:
@@ -2207,23 +2222,41 @@ async def delete_app(
     app_slug = app.slug
     app_source_dir = app.source_dir
     db.commit()
+    # Publish the durable tombstone before best-effort job/skill/cron cleanup.
+    # Cleanup errors must not leave live shells projecting a row the database
+    # has already removed from the drawer.
+    get_system_broadcast().publish(
+      {"type": "app_deleted", "appId": str(app_id)}
+    )
     # A job wrapper publishes its lease before checking the live row.  Now that
     # the tombstone is durable, terminate every verified group; a wrapper that
     # races in afterward observes the tombstone and exits before spawning work.
-    await asyncio.to_thread(app_jobs.terminate_app_jobs, app_id)
+    try:
+      await asyncio.to_thread(app_jobs.terminate_app_jobs, app_id)
+    except Exception:
+      log.exception(
+        "App %s was deleted but its supervised jobs could not be terminated",
+        app_id,
+      )
     from app.install import deactivate_app_skills
-    for warning in await deactivate_app_skills(app_id):
-      log.warning("uninstall: %s", warning)
+    try:
+      for warning in await deactivate_app_skills(app_id):
+        log.warning("uninstall: %s", warning)
+    except Exception:
+      log.exception(
+        "App %s was deleted but its app skills could not be deactivated",
+        app_id,
+      )
     # Logical uninstall — pairs with the app_install event so churn analysis
     # (and the nightly digest) sees removals, not just installs. Best-effort,
     # after the tombstone commit.
-    activity.log_event("app_uninstall", app_id=app_id, slug=app_slug)
-
-    # The Shell refetches /api/apps/ and the now-tombstoned app drops out
-    # (list_apps filters deleted_at IS NULL).
-    get_system_broadcast().publish(
-      {"type": "app_updated", "appId": str(app_id)}
-    )
+    try:
+      activity.log_event("app_uninstall", app_id=app_id, slug=app_slug)
+    except Exception:
+      log.exception(
+        "App %s was deleted but uninstall activity could not be recorded",
+        app_id,
+      )
 
     # Stop the tombstoned app's scheduled jobs WITHOUT touching its files — the
     # job.sh stays in the preserved source tree so a reinstall/recover can
@@ -2233,15 +2266,27 @@ async def delete_app(
     resolved_source = _resolve_app_source_dir(
       app_source_dir, app_name, settings
     )
-    if resolved_source is not None:
-      async with fs_locks.source_dir_lock(str(resolved_source)):
-        await asyncio.to_thread(_drop_cron_only, resolved_source)
+    try:
+      if resolved_source is not None:
+        async with fs_locks.source_dir_lock(str(resolved_source)):
+          await asyncio.to_thread(_drop_cron_only, resolved_source)
+    except Exception:
+      log.exception(
+        "App %s was deleted but its source cron could not be disabled",
+        app_id,
+      )
     runtime_dir = _legacy_platform_runtime_dir_for_app(app)
-    if runtime_dir is not None and (
-      resolved_source is None or runtime_dir.resolve() != resolved_source
-    ):
-      async with fs_locks.source_dir_lock(str(runtime_dir)):
-        await asyncio.to_thread(_drop_cron_only, runtime_dir)
+    try:
+      if runtime_dir is not None and (
+        resolved_source is None or runtime_dir.resolve() != resolved_source
+      ):
+        async with fs_locks.source_dir_lock(str(runtime_dir)):
+          await asyncio.to_thread(_drop_cron_only, runtime_dir)
+    except Exception:
+      log.exception(
+        "App %s was deleted but its legacy cron could not be disabled",
+        app_id,
+      )
 
 
 @router.delete(
@@ -2391,6 +2436,12 @@ async def recover_app(
     app_name = app.name
     app_source_dir = app.source_dir
     db.commit()
+    # Recovery is durable at this point. Publish before ancillary cron/skill
+    # restoration so a later best-effort failure cannot leave the live drawer
+    # hidden behind a stale deletion tombstone.
+    get_system_broadcast().publish(
+      {"type": "app_recovered", "appId": str(app_id)}
+    )
 
     # Restore the durable declaration the tombstone moved aside. Do not execute
     # preserved scripts here: an older one may run the job directly. Once all
@@ -2400,15 +2451,21 @@ async def recover_app(
     resolved_source = _resolve_app_source_dir(
       app_source_dir, app_name, settings
     )
-    if resolved_source is not None:
-      async with fs_locks.source_dir_lock(str(resolved_source)):
-        await asyncio.to_thread(_reenable_init_cron_replay, resolved_source)
-    runtime_dir = _legacy_platform_runtime_dir_for_app(app)
-    if runtime_dir is not None and (
-      resolved_source is None or runtime_dir.resolve() != resolved_source
-    ):
-      async with fs_locks.source_dir_lock(str(runtime_dir)):
-        await asyncio.to_thread(_reenable_init_cron_replay, runtime_dir)
+    try:
+      if resolved_source is not None:
+        async with fs_locks.source_dir_lock(str(resolved_source)):
+          await asyncio.to_thread(_reenable_init_cron_replay, resolved_source)
+      runtime_dir = _legacy_platform_runtime_dir_for_app(app)
+      if runtime_dir is not None and (
+        resolved_source is None or runtime_dir.resolve() != resolved_source
+      ):
+        async with fs_locks.source_dir_lock(str(runtime_dir)):
+          await asyncio.to_thread(_reenable_init_cron_replay, runtime_dir)
+    except Exception:
+      log.exception(
+        "App %s was recovered but its cron declaration could not be restored",
+        app_id,
+      )
     def _reconcile_recovered_cron():
       # The request Session belongs to FastAPI's dependency worker. Give the
       # blocking subprocess reconciliation its own Session in its own thread.
@@ -2419,20 +2476,28 @@ async def recover_app(
       finally:
         cron_db.close()
 
-    _cron_count, _cron_warnings = await asyncio.to_thread(
-      _reconcile_recovered_cron,
-    )
-    if _cron_count:
-      log.info("recover supervised %d app cron schedule(s)", _cron_count)
-    for warning in _cron_warnings:
-      log.warning("recover cron supervision skipped: %s", warning)
+    try:
+      _cron_count, _cron_warnings = await asyncio.to_thread(
+        _reconcile_recovered_cron,
+      )
+      if _cron_count:
+        log.info("recover supervised %d app cron schedule(s)", _cron_count)
+      for warning in _cron_warnings:
+        log.warning("recover cron supervision skipped: %s", warning)
+    except Exception:
+      log.exception(
+        "App %s was recovered but cron supervision could not be reconciled",
+        app_id,
+      )
     from app.install import restore_app_skills
-    for warning in await restore_app_skills(app_id):
-      log.warning("recover: %s", warning)
-  # Refetch the drawer (app reappears) and bust any cached iframe for it.
-  get_system_broadcast().publish(
-    {"type": "app_updated", "appId": str(app_id)}
-  )
+    try:
+      for warning in await restore_app_skills(app_id):
+        log.warning("recover: %s", warning)
+    except Exception:
+      log.exception(
+        "App %s was recovered but its app skills could not be restored",
+        app_id,
+      )
   return {"ok": True}
 
 

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -25,6 +25,7 @@ from app.chat import (
   recover_chat_generation,
   stop_chat_for,
 )
+from app.broadcast import get_system_broadcast
 from app.database import get_db
 from app.deps import (
   Principal, get_owner_or_chat_embed_principal, get_current_owner, get_principal,
@@ -1323,6 +1324,12 @@ async def delete_chat(
   if chat:
     chat.deleted_at = now_naive_utc()
     db.commit()
+    # Publish the committed tombstone before best-effort run cleanup. If that
+    # cleanup fails after the commit, every live shell must still project the
+    # durable deletion rather than retain a stale drawer row.
+    get_system_broadcast().publish(
+      {"type": "chat_deleted", "chatId": str(chat_id)}
+    )
   # Flag the chat soft-deleted in the registry (NOT forget_chat, which resets
   # the generation counter to a reusable 0). mark_chat_deleted preserves the
   # finite counter and makes `current_run_generation` return +inf, so a run
@@ -1340,7 +1347,17 @@ async def delete_chat(
   # run_status + drops the actor's _run_token_owner entry; it is best-effort
   # and safe on a soft-deleted row (clear commands don't resurrect), and
   # idempotent when the run state is already clean (the common idle delete).
-  await _clear_run_status(chat_id, terminal_status="stopped")
+  try:
+    await _clear_run_status(chat_id, terminal_status="stopped")
+  except Exception:
+    # The tombstone is already committed and published. Returning a 500 now
+    # would make the client treat an authoritative deletion as inconclusive,
+    # recreating the exact stale-row ambiguity this route must eliminate. Boot
+    # reconciliation can repair a residual run marker.
+    log.exception(
+      "Chat %s was deleted but its durable run marker could not be cleared",
+      chat_id,
+    )
 
 
 @router.post("/{chat_id}/recover", dependencies=[Depends(reject_cross_site)])
@@ -1363,6 +1380,9 @@ def recover_chat(
   # Clear the registry's deleted flag and bump to a generation newer than every
   # pre-delete run, so a resurrected stale run can't reclaim the recovered chat.
   recover_chat_generation(chat_id)
+  get_system_broadcast().publish(
+    {"type": "chat_recovered", "chatId": str(chat_id)}
+  )
   return {"ok": True}
 
 

--- a/backend/tests/test_apps_install.py
+++ b/backend/tests/test_apps_install.py
@@ -2123,10 +2123,9 @@ def test_install_does_not_publish_when_install_fails(
   fake_sb.publish.assert_not_called()
 
 
-def test_delete_publishes_app_updated(client, auth):
-  """Uninstall must also refresh the drawer — Shell.jsx's app_updated
-  handler refetches /api/apps/, which then no longer contains the
-  deleted row, so the entry disappears without a page reload."""
+def test_delete_publishes_exact_app_deleted_event(client, auth):
+  """Uninstall publishes committed deletion evidence, not a staleable refetch
+  hint, so every live shell can remove the exact drawer row immediately."""
   r0 = client.post("/api/apps/", headers=auth, json={
     "name": "Doomed",
     "description": "",
@@ -2140,8 +2139,61 @@ def test_delete_publishes_app_updated(client, auth):
     r = client.delete(f"/api/apps/{app_id}", headers=auth)
   assert r.status_code == 204, r.text
   fake_sb.publish.assert_called_once_with({
-    "type": "app_updated", "appId": str(app_id),
+    "type": "app_deleted", "appId": str(app_id),
   })
+
+
+def test_delete_stays_successful_after_post_commit_job_cleanup_failure(
+  client, auth,
+):
+  """A committed tombstone remains a successful deletion when cleanup fails."""
+  r0 = client.post("/api/apps/", headers=auth, json={
+    "name": "Cleanup Failure",
+    "description": "",
+    "jsx_source": JSX,
+  })
+  assert r0.status_code == 201, r0.text
+  app_id = r0.json()["id"]
+
+  with (
+    patch(
+      "app.routes.apps.app_jobs.terminate_app_jobs",
+      side_effect=RuntimeError("cleanup failed"),
+    ),
+    patch("app.routes.apps.get_system_broadcast") as mock_get_sb,
+  ):
+    fake_sb = MagicMock()
+    mock_get_sb.return_value = fake_sb
+    deleted = client.delete(f"/api/apps/{app_id}", headers=auth)
+
+  assert deleted.status_code == 204, deleted.text
+  assert client.get(f"/api/apps/{app_id}", headers=auth).status_code == 404
+  fake_sb.publish.assert_called_once_with({
+    "type": "app_deleted", "appId": str(app_id),
+  })
+
+
+def test_recover_stays_successful_after_post_commit_skill_cleanup_failure(
+  client, auth,
+):
+  """Ancillary restoration cannot make a durably recovered app look failed."""
+  r0 = client.post("/api/apps/", headers=auth, json={
+    "name": "Recovery Cleanup Failure",
+    "description": "",
+    "jsx_source": JSX,
+  })
+  assert r0.status_code == 201, r0.text
+  app_id = r0.json()["id"]
+  assert client.delete(f"/api/apps/{app_id}", headers=auth).status_code == 204
+
+  with patch(
+    "app.install.restore_app_skills",
+    new=AsyncMock(side_effect=RuntimeError("restore failed")),
+  ):
+    recovered = client.post(f"/api/apps/{app_id}/recover", headers=auth)
+
+  assert recovered.status_code == 200, recovered.text
+  assert client.get(f"/api/apps/{app_id}", headers=auth).status_code == 200
 
 
 # --- Per-app git model (feature 084) ---------------------------------

--- a/backend/tests/test_chats.py
+++ b/backend/tests/test_chats.py
@@ -1,6 +1,7 @@
 """Chat route regression tests."""
 
 import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 from app import memory, models, questions
@@ -31,6 +32,47 @@ def test_delete_chat_cancels_orphan_pending_question(client, auth, chat):
     assert pending.future.done()
 
   asyncio.run(go())
+
+
+def test_delete_and_recover_publish_exact_projection_events(
+  client, auth, chat,
+):
+  """Shells receive authoritative ids for both sides of the tombstone."""
+  with patch("app.routes.chats.get_system_broadcast") as mock_get_sb:
+    fake_sb = MagicMock()
+    mock_get_sb.return_value = fake_sb
+
+    deleted = client.delete(f"/api/chats/{chat.id}", headers=auth)
+    recovered = client.post(f"/api/chats/{chat.id}/recover", headers=auth)
+
+  assert deleted.status_code == 204, deleted.text
+  assert recovered.status_code == 200, recovered.text
+  assert fake_sb.publish.call_args_list == [
+    (({"type": "chat_deleted", "chatId": str(chat.id)},), {}),
+    (({"type": "chat_recovered", "chatId": str(chat.id)},), {}),
+  ]
+
+
+def test_delete_response_stays_authoritative_after_cleanup_failure(
+  client, auth, chat,
+):
+  """Post-commit cleanup cannot turn a durable deletion into a false failure."""
+  with (
+    patch(
+      "app.routes.chats._clear_run_status",
+      new=AsyncMock(side_effect=RuntimeError("cleanup failed")),
+    ),
+    patch("app.routes.chats.get_system_broadcast") as mock_get_sb,
+  ):
+    fake_sb = MagicMock()
+    mock_get_sb.return_value = fake_sb
+    deleted = client.delete(f"/api/chats/{chat.id}", headers=auth)
+
+  assert deleted.status_code == 204, deleted.text
+  assert client.get(f"/api/chats/{chat.id}", headers=auth).status_code == 404
+  fake_sb.publish.assert_called_once_with({
+    "type": "chat_deleted", "chatId": str(chat.id),
+  })
 
 
 def test_agent_context_includes_evolving_chat_summary(

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -8,6 +8,7 @@ import * as setupSession from '../lib/setupSession.js'
 import { clearLatchedTokens } from '../lib/appToken.js'
 import { clearOwnerDraftStorage } from '../lib/ownerDraftStorage.js'
 import { verifyConnectivity } from '../lib/connectivityStore.js'
+import { SHELL_DATA_CACHE } from '../sw-cache-policy.js'
 
 export const BASE = (import.meta.env.BASE_URL || '/').replace(/\/$/, '')
 
@@ -261,6 +262,46 @@ export async function apiFetch(path, options = {}) {
 }
 
 /**
+ * Evict one offline shell projection after a confirmed list-affecting write.
+ *
+ * `/api/chats` and `/api/apps/` are NetworkFirst so the drawer remains useful
+ * offline. That cache is intentionally allowed to be stale for a read, but a
+ * successful mutation is stronger evidence: keeping the pre-write cached GET
+ * lets the very next refetch resurrect a deleted row (or hide a recovered
+ * one). CacheStorage is shared by every tab on this device, so this also
+ * repairs their fallback layer. Best-effort by contract: a storage/quota
+ * failure must never turn a committed server mutation into a client failure.
+ */
+export async function invalidateShellListCache(kind, {
+  cacheStorage = typeof caches === 'undefined' ? null : caches,
+  origin = typeof location === 'undefined' ? null : location.origin,
+} = {}) {
+  if (!cacheStorage || !origin) return false
+  const pathname = kind === 'chats'
+    ? `${BASE}/api/chats`
+    : kind === 'apps'
+      ? `${BASE}/api/apps/`
+      : null
+  if (!pathname) return false
+  try {
+    const cache = await cacheStorage.open(SHELL_DATA_CACHE)
+    return await cache.delete(new URL(pathname, origin).href)
+  } catch {
+    return false
+  }
+}
+
+async function listAffectingMutation(kind, path, options) {
+  const response = await apiFetch(path, options)
+  // A 404 on DELETE is authoritative too: the local projection is stale and
+  // must not keep falling back to a cache that claims the row still exists.
+  if (response.ok || (options?.method === 'DELETE' && response.status === 404)) {
+    await invalidateShellListCache(kind)
+  }
+  return response
+}
+
+/**
  * Decode a JSON API response at the client boundary. Endpoints that expose a
  * data-object contract (rather than the raw Fetch Response contract used by
  * most existing query hooks) should use this helper so callers cannot confuse
@@ -353,7 +394,7 @@ export const api = {
   },
   chats: {
     list: (options = {}) => apiFetch('/chats', options),
-    create: (payload) => apiFetch('/chats', {
+    create: (payload) => listAffectingMutation('chats', '/chats', {
       method: 'POST',
       body: JSON.stringify(payload),
     }),
@@ -363,12 +404,16 @@ export const api = {
       const query = params.toString()
       return apiFetch(`/chats/${chatId}${query ? `?${query}` : ''}`)
     },
-    update: (chatId, payload) => apiFetch(`/chats/${chatId}`, {
+    update: (chatId, payload) => listAffectingMutation('chats', `/chats/${chatId}`, {
       method: 'PATCH',
       body: JSON.stringify(payload),
     }),
-    remove: (chatId) => apiFetch(`/chats/${chatId}`, { method: 'DELETE' }),
-    recover: (chatId) => apiFetch(`/chats/${chatId}/recover`, { method: 'POST' }),
+    remove: (chatId) => listAffectingMutation(
+      'chats', `/chats/${chatId}`, { method: 'DELETE' },
+    ),
+    recover: (chatId) => listAffectingMutation(
+      'chats', `/chats/${chatId}/recover`, { method: 'POST' },
+    ),
   },
   apps: {
     list: () => apiFetch('/apps/'),
@@ -376,8 +421,16 @@ export const api = {
       method: 'POST',
       body: JSON.stringify({ activity_version: activityVersion }),
     }),
-    remove: (appId) => apiFetch(`/apps/${appId}`, { method: 'DELETE' }),
-    recover: (appId) => apiFetch(`/apps/${appId}/recover`, { method: 'POST' }),
+    update: (appId, payload) => listAffectingMutation('apps', `/apps/${appId}`, {
+      method: 'PATCH',
+      body: JSON.stringify(payload),
+    }),
+    remove: (appId) => listAffectingMutation(
+      'apps', `/apps/${appId}`, { method: 'DELETE' },
+    ),
+    recover: (appId) => listAffectingMutation(
+      'apps', `/apps/${appId}/recover`, { method: 'POST' },
+    ),
     // Wipes the app's runtime storage back to empty while KEEPING it
     // installed — distinct from `remove` (which tombstones the whole app).
     deleteData: (appId) => apiFetch(`/apps/${appId}/data`, { method: 'DELETE' }),

--- a/frontend/src/components/ChatView/__tests__/internalNavigation.test.js
+++ b/frontend/src/components/ChatView/__tests__/internalNavigation.test.js
@@ -33,7 +33,7 @@ test('shell intent callbacks keep identity while navTo changes per render', asyn
   const params = {
     appsRef: { current: [{ id: 42, slug: 'artifacts' }] },
     refreshApps: async () => refreshedApps,
-    setToast: (toast) => calls.push(['toast', toast]),
+    showToast: (...args) => calls.push(['toast', ...args]),
     setAppIntents: (update) => calls.push(['intent', update({})]),
     navToRef,
   }
@@ -57,6 +57,15 @@ test('shell intent callbacks keep identity while navTo changes per render', asyn
   refreshedApps = [{ id: 43, slug: 'delayed' }]
   await result.current.openAppWithIntent('delayed', null, () => false)
   assert.equal(calls.length, 2, 'cancelled delayed resolution must not navigate')
+
+  params.appsRef.current = []
+  refreshedApps = []
+  await result.current.openAppWithIntent('missing', null)
+  assert.deepEqual(calls.at(-1), [
+    'toast',
+    'App is not installed yet.',
+    { variant: 'info', duration: 6000 },
+  ])
 })
 
 test('internal navigation crosses stable markdown memo boundaries', () => {
@@ -82,7 +91,7 @@ test('shell resolves raw deep-link app targets through the intent rail', () => {
   assert.match(intentNavigation, /const openAppWithIntent = useCallback/)
   assert.match(intentNavigation, /findAppForOpenTarget\(updatedApps, target\)/)
   assert.match(intentNavigation, /navToRef\.current\('canvas'/)
-  assert.match(intentNavigation, /\}, \[refreshApps\]\)/)
+  assert.match(intentNavigation, /\}, \[refreshApps, showToast\]\)/)
   assert.match(intentNavigation, /\}, \[openAppWithIntent\]\)/)
   assert.match(shell, /if \(Number\.isFinite\(deepLink\.appId\)\)/)
   assert.match(shell, /navigationEpochRef\.current === startedAtEpoch/)

--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -3,7 +3,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { Plus, Chats, Grid, DotsVerticalMoreMenu, SettingsCog, Pin, PinFilled } from '@openai/apps-sdk-ui/components/Icon'
 import { Menu } from '@openai/apps-sdk-ui/components/Menu'
 import { EmptyMessage } from '@openai/apps-sdk-ui/components/EmptyMessage'
-import { apiFetch } from '../../api/client.js'
+import { api } from '../../api/client.js'
 import { appQueries, chatQueries } from '../../hooks/queries.js'
 import {
   DRAWER_CLOSE_FALLBACK_MS,
@@ -228,18 +228,12 @@ export default function Drawer({
   }
 
   async function renameChat(id, title) {
-    const res = await apiFetch(`/chats/${id}`, {
-      method: 'PATCH',
-      body: JSON.stringify({ title }),
-    })
+    const res = await api.chats.update(id, { title })
     if (res.ok) refreshChats()
   }
 
   async function renameApp(id, name) {
-    const res = await apiFetch(`/apps/${id}`, {
-      method: 'PATCH',
-      body: JSON.stringify({ name }),
-    })
+    const res = await api.apps.update(id, { name })
     if (res.ok) refreshApps()
   }
 
@@ -259,10 +253,7 @@ export default function Drawer({
       ),
     )
     try {
-      const res = await apiFetch(`/chats/${id}`, {
-        method: 'PATCH',
-        body: JSON.stringify({ pinned }),
-      })
+      const res = await api.chats.update(id, { pinned })
       if (res.ok) refreshChats()
       else queryClient.setQueryData(key, prev)
     } catch {
@@ -281,10 +272,7 @@ export default function Drawer({
       ),
     )
     try {
-      const res = await apiFetch(`/apps/${id}`, {
-        method: 'PATCH',
-        body: JSON.stringify({ pinned }),
-      })
+      const res = await api.apps.update(id, { pinned })
       if (res.ok) refreshApps()
       else queryClient.setQueryData(key, prev)
     } catch {

--- a/frontend/src/components/Shell/Shell.css
+++ b/frontend/src/components/Shell/Shell.css
@@ -9,6 +9,10 @@
    surface that paints it. */
 .shell {
   --desktop-sidebar-width: 320px;
+  /* Shared geometry contract for fixed shell-level overlays. The notice rail
+     reads these instead of guessing at chrome height from the root font size. */
+  --shell-bar-height: 58px;
+  --shell-tabstrip-height: 41px;
   position: fixed;
   inset: 0;
   display: flex;
@@ -42,7 +46,7 @@
 
 .shell__bar {
   flex-shrink: 0;
-  height: calc(58px + env(safe-area-inset-top));
+  height: calc(var(--shell-bar-height) + env(safe-area-inset-top));
   padding-top: env(safe-area-inset-top);
   display: flex;
   align-items: center;
@@ -272,6 +276,7 @@
 /* ── Tab strip: pinned chats/apps to swap between ─────────────────── */
 .shell__tabstrip {
   flex-shrink: 0;
+  height: var(--shell-tabstrip-height);
   display: flex;
   gap: 4px;
   align-items: stretch;

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -6,7 +6,10 @@ import Drawer from '../Drawer/Drawer.jsx'
 import Toast from '../ui/Toast.jsx'
 import AppCanvas from '../AppCanvas/AppCanvas.jsx'
 import WalkthroughOverlay from '../Walkthrough/WalkthroughOverlay.jsx'
-import { api, apiFetch, jsonOrThrow, probeDeletion, BASE, clearAppRuntimeData } from '../../api/client.js'
+import {
+  api, apiFetch, jsonOrThrow, probeDeletion, BASE, clearAppRuntimeData,
+  invalidateShellListCache,
+} from '../../api/client.js'
 import usePushSubscription from '../../hooks/usePushSubscription.js'
 import useNavigation, {
   coldRestoredCanvasAppId,
@@ -67,6 +70,12 @@ import {
   rememberCreatedChat,
   reusableChatDetailVerdict,
 } from './newChatPolicy.js'
+import {
+  forgetConfirmedDeletion,
+  forgetConfirmedDeletionIfExists,
+  rememberConfirmedDeletion,
+  withoutConfirmedDeletions,
+} from './confirmedDeletion.js'
 import {
   reloadWhenWorkerTakesOver,
   shouldRearmShellApply,
@@ -520,15 +529,27 @@ export default function Shell() {
 
   const { loadTheme } = useTheme()
   const queryClient = useQueryClient()
-  const appsQuery = appQueries.list.useQuery()
+  // Confirmed writes outrank offline-capable list reads. These session-scoped
+  // tombstones filter every query completion (including an in-flight,
+  // pre-delete NetworkFirst fallback) until a recovery succeeds.
+  const deletedChatIdsRef = useRef(new Set())
+  const deletedAppIdsRef = useRef(new Set())
+  const reconcileApps = useCallback(
+    rows => withoutConfirmedDeletions(rows, deletedAppIdsRef.current),
+    [],
+  )
+  const appsQuery = appQueries.list.useQuery({ reconcile: reconcileApps })
   // Create responses are authoritative even when the next NetworkFirst list
   // request has to fall back to a just-stale service-worker copy. Reconcile at
   // the query function boundary so the protected row never disappears from
   // cache/render between fetch settlement and an after-the-fact patch.
   const recentlyCreatedChatsRef = useRef(new Map())
   const reconcileCreatedChats = useCallback(
-    rows => mergeChatListWithCreatedGuards(
-      rows, recentlyCreatedChatsRef.current,
+    rows => withoutConfirmedDeletions(
+      mergeChatListWithCreatedGuards(
+        rows, recentlyCreatedChatsRef.current,
+      ),
+      deletedChatIdsRef.current,
     ),
     [],
   )
@@ -594,12 +615,22 @@ export default function Shell() {
   const initialSlotReconciledRef = useRef(false)
   // toast state: null | { message, variant, duration, action }
   // variant: 'info' | 'error'  (see components/ui/Toast.jsx)
+  const toastSequenceRef = useRef(0)
   const [toast, setToast] = useState(null)
   const [settingsFocusTarget, setSettingsFocusTarget] = useState(null)
-  function showToast(message, { variant = 'info', duration = 4000, action } = {}) {
-    setToast({ message, variant, duration, action })
-  }
-  function dismissToast() { setToast(null) }
+  const showToast = useCallback((
+    message,
+    { variant = 'info', duration = 4000, action } = {},
+  ) => {
+    toastSequenceRef.current += 1
+    setToast({
+      message, variant, duration, action, sequence: toastSequenceRef.current,
+    })
+  }, [])
+  // Stable identity is part of Toast's timer contract. Recreating this callback
+  // on every Shell render resets the effect timer while chats stream, making a
+  // nominal five-second notice linger indefinitely.
+  const dismissToast = useCallback(() => { setToast(null) }, [])
   const handleAppIntentDelivered = useCallback((appId, delivered) => {
     setAppIntents((prev) => {
       const key = String(appId)
@@ -2049,22 +2080,69 @@ export default function Shell() {
     return queryClient.cancelQueries({ queryKey: appQueries.keys.all })
       .then(() => queryClient.fetchQuery({
         queryKey: appQueries.keys.all,
-        queryFn: appQueries.list.fetch,
+        queryFn: async () => reconcileApps(await appQueries.list.fetch()),
         staleTime: 0,
       }))
       .then(data => data || [])
       .catch(() => queryClient.getQueryData(appQueries.keys.all) || [])
-  }, [queryClient])
+  }, [queryClient, reconcileApps])
   const refreshChats = useCallback(() => {
     return queryClient.refetchQueries({ queryKey: chatQueries.keys.all })
       .then(() => queryClient.getQueryData(chatQueries.keys.all) || [])
       .catch(() => [])
   }, [queryClient])
 
+  const confirmChatDeleted = useCallback((id) => {
+    const sid = String(id)
+    rememberConfirmedDeletion(deletedChatIdsRef.current, sid)
+    recentlyCreatedChatsRef.current.delete(sid)
+    queryClient.setQueryData(chatQueries.keys.all, current => {
+      const next = withoutConfirmedDeletions(
+        Array.isArray(current) ? current : [],
+        deletedChatIdsRef.current,
+      )
+      chatsRef.current = next
+      return next
+    })
+  }, [queryClient])
+
+  const confirmAppDeleted = useCallback((id) => {
+    const sid = String(id)
+    rememberConfirmedDeletion(deletedAppIdsRef.current, sid)
+    queryClient.setQueryData(appQueries.keys.all, current => {
+      const next = withoutConfirmedDeletions(
+        Array.isArray(current) ? current : [],
+        deletedAppIdsRef.current,
+      )
+      appsRef.current = next
+      return next
+    })
+  }, [queryClient])
+
+  const confirmChatRecovered = useCallback((id) => {
+    forgetConfirmedDeletion(deletedChatIdsRef.current, id)
+  }, [])
+
+  const confirmAppRecovered = useCallback((id) => {
+    forgetConfirmedDeletion(deletedAppIdsRef.current, id)
+  }, [])
+
+  const confirmAppIdentityIsLive = useCallback((id) => (
+    forgetConfirmedDeletionIfExists(
+      deletedAppIdsRef.current,
+      id,
+      appId => probeDeletion(`/apps/${encodeURIComponent(appId)}`),
+    )
+  ), [])
+
+  const reconcileDeletedAppIdentities = useCallback(() => Promise.all(
+    [...deletedAppIdsRef.current].map(confirmAppIdentityIsLive),
+  ), [confirmAppIdentityIsLive])
+
   const { openAppWithIntent, handleChatInternalNav } = useAppIntentNavigation({
     appsRef,
     refreshApps,
-    setToast,
+    showToast,
     setAppIntents,
     navToRef,
   })
@@ -2402,15 +2480,41 @@ export default function Shell() {
       // The durable marker was committed with an app-attributed notification.
       // A refetch surfaces the dot; if the app is already visible, the effect
       // above immediately acknowledges it instead of leaving a stale nudge.
-      refreshApps()
+      void invalidateShellListCache('apps').then(refreshApps)
+    } else if (ev.type === 'chat_deleted') {
+      // Exact mutation evidence from this or another live tab. Update the
+      // in-memory drawer synchronously; the normal missing-active-chat effect
+      // owns any route/view repair in tabs that happened to have it open.
+      if (ev.chatId) confirmChatDeleted(ev.chatId)
+      void invalidateShellListCache('chats')
+    } else if (ev.type === 'chat_recovered') {
+      // Recovery is the sole operation allowed to clear the session tombstone.
+      if (ev.chatId) confirmChatRecovered(ev.chatId)
+      void invalidateShellListCache('chats').then(refreshChats)
+    } else if (ev.type === 'app_deleted') {
+      if (ev.appId) confirmAppDeleted(ev.appId)
+      void invalidateShellListCache('apps')
+    } else if (ev.type === 'app_recovered') {
+      if (ev.appId) confirmAppRecovered(ev.appId)
+      void invalidateShellListCache('apps').then(refreshApps)
     } else if (ev.type === 'app_updated' || ev.type === 'app_created') {
       const placementRequest = workspaceRequestFromSystemEvent(ev)
+      // app_updated is also the reinstall event for a tombstoned store app,
+      // while app_created may carry an integer id freed by TTL purge and reused
+      // for a different installation. A direct resource probe—not a staleable
+      // list—is the proof that either id is live again.
+      const reconcileIdentity = ev.appId
+        ? confirmAppIdentityIsLive(ev.appId)
+        : Promise.resolve(false)
       // Refresh server truth before warming or placing. app_updated is
       // refresh-only; app_created may additionally issue one background
       // workspace placement after the returned row confirms the relationship.
       // `updated_at` drives the iframe cache-buster and the derived built-app
       // CTA, so neither needs a separate client mirror.
-      refreshApps().then(updatedApps => {
+      Promise.all([
+        invalidateShellListCache('apps'),
+        reconcileIdentity,
+      ]).then(() => refreshApps()).then(updatedApps => {
         // Warm the SW cache for the updated app immediately — the edit
         // rotated the `?v=` cache key, so without this the next open pays
         // the network round trip. Every app's read path is cached now
@@ -2546,6 +2650,8 @@ export default function Shell() {
     // activeAppIdRef, activeChatIdRef, drawerOpenRef) so stale closure values
     // can't be serialized. Refs themselves don't need to be in deps (they're
     // stable objects whose .current is read at call time, not at capture time).
+    confirmAppDeleted, confirmAppIdentityIsLive, confirmAppRecovered,
+    confirmChatDeleted, confirmChatRecovered,
     loadTheme, markChatRunActivity, markChatRunFinished,
     markStreamingEnd, markStreamingStart,
     placeInWorkspace, refreshApps, refreshChats, warmAppCode,
@@ -2561,7 +2667,17 @@ export default function Shell() {
   // the durable app list after every initial connection/reconnect; after the
   // first list establishes the session baseline, fresh chat-owned rows flow
   // through the same idempotent placement resolver as live app_created events.
-  useSystemEventStream(handleSystemEvent, { onOpen: refreshApps })
+  const reconcileSystemStateOnOpen = useCallback(() => {
+    void Promise.all([
+      invalidateShellListCache('apps'),
+      invalidateShellListCache('chats'),
+      reconcileDeletedAppIdentities(),
+    ]).then(() => {
+      refreshApps()
+      refreshChats()
+    })
+  }, [reconcileDeletedAppIdentities, refreshApps, refreshChats])
+  useSystemEventStream(handleSystemEvent, { onOpen: reconcileSystemStateOnOpen })
 
   // Listen for postMessage events from mini-app iframes:
   //   moebius:app-error — route crash report to the chat that built the app
@@ -2997,7 +3113,10 @@ export default function Shell() {
       }
       // A 404 means the server row is already gone; remove the local phantom.
     }
-    recentlyCreatedChatsRef.current.delete(String(id))
+    // DELETE/404 is authoritative. Publish that fact into the drawer before
+    // any navigation work; every later list completion is filtered by the same
+    // session tombstone until recovery succeeds.
+    confirmChatDeleted(id)
     try { sessionStorage.removeItem(`draft:${id}`) } catch {}
     // Evict the cached messages so a future chat-ID collision (e.g.
     // recovery) can't surface stale content.
@@ -3044,6 +3163,7 @@ export default function Shell() {
           try {
             const recoverRes = await api.chats.recover(id)
             await jsonOrThrow(recoverRes, 'Chat recovery failed')
+            confirmChatRecovered(id)
             // Guard against the newChat() reuse scan picking up this
             // recovered chat before its has_messages=true propagates from
             // the server. The guard is cleared once ChatView fires
@@ -3082,6 +3202,7 @@ export default function Shell() {
       }
       // A 404 means the server row is already gone; remove the local phantom.
     }
+    confirmAppDeleted(id)
     // Retire this app's physical history + evict any warm frame before unmount
     // (contract §4.1.5), tombstone its route so Back can't recreate the tab
     // (§5.1.1), then scrub the nav-stack, then close its tab. The
@@ -3112,6 +3233,7 @@ export default function Shell() {
           try {
             const recoverRes = await api.apps.recover(id)
             await jsonOrThrow(recoverRes, 'App recovery failed')
+            confirmAppRecovered(id)
             await refreshApps()
           } catch {
             showToast("Couldn't undo — app may be gone.", { variant: 'error' })
@@ -3678,6 +3800,7 @@ export default function Shell() {
         </div>
       )}
       <Toast
+        key={toast?.sequence || 'toast-empty'}
         message={toast?.message}
         variant={toast?.variant}
         duration={toast?.duration}

--- a/frontend/src/components/Shell/__tests__/confirmedDeletion.test.js
+++ b/frontend/src/components/Shell/__tests__/confirmedDeletion.test.js
@@ -1,0 +1,87 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+import {
+  forgetConfirmedDeletion,
+  forgetConfirmedDeletionIfExists,
+  rememberConfirmedDeletion,
+  withoutConfirmedDeletions,
+} from '../confirmedDeletion.js'
+
+test('confirmed deletion dominates a later stale-present list', () => {
+  const deleted = new Set()
+  const original = [{ id: 'a' }, { id: 'b' }]
+
+  rememberConfirmedDeletion(deleted, 'b')
+  assert.deepEqual(
+    withoutConfirmedDeletions(original, deleted),
+    [{ id: 'a' }],
+  )
+  // Numeric and string ids share one identity across app/chat projections.
+  assert.deepEqual(
+    withoutConfirmedDeletions([{ id: 2 }, { id: 3 }], new Set(['2'])),
+    [{ id: 3 }],
+  )
+})
+
+test('only confirmed recovery clears the tombstone', () => {
+  const deleted = new Set(['gone'])
+  forgetConfirmedDeletion(deleted, 'gone')
+  assert.deepEqual(
+    withoutConfirmedDeletions([{ id: 'gone' }], deleted),
+    [{ id: 'gone' }],
+  )
+})
+
+test('a reusable app id clears only after direct live-resource evidence', async () => {
+  const deleted = new Set(['42'])
+  const verdicts = []
+
+  assert.equal(await forgetConfirmedDeletionIfExists(
+    deleted,
+    42,
+    async id => {
+      verdicts.push(id)
+      return 'unknown'
+    },
+  ), false)
+  assert.deepEqual([...deleted], ['42'])
+
+  assert.equal(await forgetConfirmedDeletionIfExists(
+    deleted,
+    '42',
+    async id => {
+      verdicts.push(id)
+      return 'deleted'
+    },
+  ), false)
+  assert.deepEqual([...deleted], ['42'])
+
+  assert.equal(await forgetConfirmedDeletionIfExists(
+    deleted,
+    42,
+    async id => {
+      verdicts.push(id)
+      return 'exists'
+    },
+  ), true)
+  assert.deepEqual([...deleted], [])
+  assert.deepEqual(verdicts, ['42', '42', '42'])
+})
+
+test('Shell reconciles both query completion and direct mutation paths', () => {
+  const shell = readFileSync(new URL('../Shell.jsx', import.meta.url), 'utf8')
+  const queries = readFileSync(
+    new URL('../../../hooks/queries.js', import.meta.url),
+    'utf8',
+  )
+
+  assert.match(shell, /appsQuery = appQueries\.list\.useQuery\(\{ reconcile: reconcileApps \}\)/)
+  assert.match(shell, /mergeChatListWithCreatedGuards[\s\S]*deletedChatIdsRef\.current/)
+  assert.match(shell, /confirmChatDeleted\(id\)[\s\S]*showToast\('Chat deleted'/)
+  assert.match(shell, /confirmAppDeleted\(id\)[\s\S]*showToast\('App deleted'/)
+  assert.match(shell, /app_updated[\s\S]*confirmAppIdentityIsLive\(ev\.appId\)/)
+  assert.match(shell, /reconcileSystemStateOnOpen[\s\S]*reconcileDeletedAppIdentities\(\)/)
+  assert.match(queries, /function useAppsQuery\(\{ reconcile \} = \{\}\)/)
+})

--- a/frontend/src/components/Shell/__tests__/toastPlacement.test.js
+++ b/frontend/src/components/Shell/__tests__/toastPlacement.test.js
@@ -1,0 +1,57 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const jsx = readFileSync(
+  new URL('../../ui/Toast.jsx', import.meta.url),
+  'utf8',
+)
+const css = readFileSync(
+  new URL('../../ui/Toast.css', import.meta.url),
+  'utf8',
+)
+const shell = readFileSync(
+  new URL('../Shell.jsx', import.meta.url),
+  'utf8',
+)
+const shellCss = readFileSync(
+  new URL('../Shell.css', import.meta.url),
+  'utf8',
+)
+const intentNavigation = readFileSync(
+  new URL('../useAppIntentNavigation.js', import.meta.url),
+  'utf8',
+)
+
+test('every dismissible toast exposes an explicit accessible close', () => {
+  assert.match(jsx, /aria-label="Dismiss notification"/)
+  assert.match(jsx, /onClick=\{handleDismiss\}/)
+  assert.match(jsx, /clearTimeout\(timerRef\.current\)/)
+})
+
+test('Shell keeps timeout identity stable and remounts repeated notices', () => {
+  assert.match(shell, /const dismissToast = useCallback/)
+  assert.match(shell, /toastSequenceRef\.current \+= 1/)
+  assert.match(shell, /key=\{toast\?\.sequence \|\| 'toast-empty'\}/)
+  assert.match(shell, /useAppIntentNavigation\(\{[\s\S]*showToast,/)
+  assert.match(intentNavigation, /showToast\('App is not installed yet\.'/)
+  assert.doesNotMatch(intentNavigation, /setToast/)
+})
+
+test('toast uses shell-owned chrome geometry, not composer or font guesses', () => {
+  assert.match(css, /right:\s*max\(1rem,\s*env\(safe-area-inset-right/)
+  assert.match(css, /var\(--shell-bar-height,\s*58px\)/)
+  assert.match(css, /var\(--shell-tabstrip-height,\s*41px\)/)
+  assert.match(shellCss, /--shell-bar-height:\s*58px/)
+  assert.match(shellCss, /--shell-tabstrip-height:\s*41px/)
+  assert.match(shellCss, /height:\s*calc\(var\(--shell-bar-height\)/)
+  assert.match(shellCss, /height:\s*var\(--shell-tabstrip-height\)/)
+  assert.match(css, /@media \(max-width: 700px\)/)
+  assert.doesNotMatch(css, /@media \(max-width: 700px\)[\s\S]*?top:/)
+  assert.doesNotMatch(css, /bottom:/)
+})
+
+test('toast actions and dismissal have comfortable pointer targets', () => {
+  assert.match(css, /\.toast__action\s*\{[\s\S]*?min-height:\s*36px/)
+  assert.match(css, /\.toast__dismiss\s*\{[\s\S]*?width:\s*36px[\s\S]*?height:\s*36px/)
+})

--- a/frontend/src/components/Shell/__tests__/workspacePlacement.test.js
+++ b/frontend/src/components/Shell/__tests__/workspacePlacement.test.js
@@ -525,12 +525,12 @@ test('builder mode + FOREGROUND: unchanged tree placement (no slot write)', () =
 
 // ── the durable-list reconnect wiring is still in place ─────────────────────
 
-test('shell reconciles the durable app list whenever the system stream reconnects', () => {
+test('shell reconciles both durable drawer lists whenever the system stream reconnects', () => {
   const shellSource = readFileSync(new URL('../Shell.jsx', import.meta.url), 'utf8')
-  assert.match(
-    shellSource,
-    /useSystemEventStream\(handleSystemEvent, \{ onOpen: refreshApps \}\)/,
-  )
+  assert.match(shellSource, /const reconcileSystemStateOnOpen = useCallback/)
+  assert.match(shellSource, /reconcileSystemStateOnOpen[\s\S]*refreshApps\(\)/)
+  assert.match(shellSource, /reconcileSystemStateOnOpen[\s\S]*refreshChats\(\)/)
+  assert.match(shellSource, /useSystemEventStream\(handleSystemEvent, \{ onOpen: reconcileSystemStateOnOpen \}\)/)
 })
 
 test('stale pending updates offer the canonical review surface', () => {

--- a/frontend/src/components/Shell/confirmedDeletion.js
+++ b/frontend/src/components/Shell/confirmedDeletion.js
@@ -1,0 +1,57 @@
+/* Confirmed-deletion reconciliation for offline-capable drawer lists.
+ *
+ * A list read can be a stale service-worker fallback, so absence is never
+ * deletion evidence. The inverse is equally important: once a DELETE (or a
+ * system event from another tab) confirms a row is gone, a later stale list
+ * must not resurrect it. Shell owns these session-scoped tombstones and clears
+ * one only after recovery succeeds.
+ */
+
+function normalizedId(value) {
+  return value == null ? null : String(value)
+}
+
+export function rememberConfirmedDeletion(deletedIds, id) {
+  const key = normalizedId(id)
+  if (key == null || !deletedIds) return
+  deletedIds.add(key)
+}
+
+export function forgetConfirmedDeletion(deletedIds, id) {
+  const key = normalizedId(id)
+  if (key == null || !deletedIds) return
+  deletedIds.delete(key)
+}
+
+export function withoutConfirmedDeletions(rows, deletedIds) {
+  const list = Array.isArray(rows) ? rows : []
+  if (!deletedIds?.size) return list
+  return list.filter(row => !deletedIds.has(normalizedId(row?.id)))
+}
+
+/**
+ * Clear a prior deletion only when a direct resource probe proves that the id
+ * is live again. Apps use reusable integer ids, and reinstall revives a
+ * tombstoned row through the generic app_updated event. A list response cannot
+ * establish either case because its offline fallback may still contain the
+ * deleted predecessor.
+ */
+export async function forgetConfirmedDeletionIfExists(
+  deletedIds,
+  id,
+  probe,
+) {
+  const key = normalizedId(id)
+  if (key == null || !deletedIds?.has(key) || typeof probe !== 'function') {
+    return false
+  }
+  let verdict
+  try {
+    verdict = await probe(key)
+  } catch {
+    return false
+  }
+  if (verdict !== 'exists') return false
+  deletedIds.delete(key)
+  return true
+}

--- a/frontend/src/components/Shell/useAppIntentNavigation.js
+++ b/frontend/src/components/Shell/useAppIntentNavigation.js
@@ -9,7 +9,7 @@ export function findAppForOpenTarget(list, target) {
 export default function useAppIntentNavigation({
   appsRef,
   refreshApps,
-  setToast,
+  showToast,
   setAppIntents,
   navToRef,
 }) {
@@ -25,8 +25,7 @@ export default function useAppIntentNavigation({
     }
     if (!shouldContinue()) return
     if (!app) {
-      setToast({
-        message: 'App is not installed yet.',
+      showToast('App is not installed yet.', {
         variant: 'info',
         duration: 6000,
       })
@@ -40,7 +39,7 @@ export default function useAppIntentNavigation({
       }))
     }
     navToRef.current('canvas', { appId: app.id })
-  }, [refreshApps])
+  }, [refreshApps, showToast])
 
   const handleChatInternalNav = useCallback((url) => {
     const app = url.searchParams.get('app')

--- a/frontend/src/components/ui/Toast.css
+++ b/frontend/src/components/ui/Toast.css
@@ -1,22 +1,27 @@
-/* Toast notification — surface at the bottom-center of the viewport.
+/* Toast notification — clear of the primary composer interaction.
    Sits above all content (z-index 9000, matching the old inline toast).
    Two variants: info (neutral surface) and error (danger color). */
 
 .toast {
   position: fixed;
-  bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
-  left: 50%;
-  transform: translateX(-50%);
+  top: calc(
+    var(--shell-bar-height, 58px)
+    + var(--shell-tabstrip-height, 41px)
+    + 0.5rem
+    + env(safe-area-inset-top, 0px)
+  );
+  right: max(1rem, env(safe-area-inset-right, 0px));
   z-index: 9000;
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 0.75rem 1.25rem;
+  gap: 10px;
+  padding: 0.75rem;
+  padding-left: 1rem;
   border-radius: 10px;
   font-size: 0.875rem;
   font-family: var(--font);
-  max-width: 90vw;
-  text-align: center;
+  max-width: min(30rem, calc(100vw - 1.5rem));
+  text-align: left;
   /* Subtle entrance — short fade+slide from below. Reduced-motion
      rule in index.css collapses this to 1ms without removing it. */
   animation: toast-in 0.18s var(--ease-out-soft, cubic-bezier(0.16, 1, 0.3, 1));
@@ -26,8 +31,8 @@
 }
 
 @keyframes toast-in {
-  from { opacity: 0; transform: translateX(-50%) translateY(8px); }
-  to   { opacity: 1; transform: translateX(-50%) translateY(0); }
+  from { opacity: 0; transform: translateY(-8px); }
+  to   { opacity: 1; transform: translateY(0); }
 }
 
 .toast--info {
@@ -62,7 +67,8 @@
 .toast__action {
   background: transparent;
   border: none;
-  padding: 0 4px;
+  min-height: 36px;
+  padding: 0 8px;
   font-size: inherit;
   font-family: inherit;
   font-weight: 600;
@@ -94,4 +100,43 @@
 .toast__action:focus-visible {
   outline: 2px solid currentColor;
   outline-offset: 2px;
+}
+
+.toast__dismiss {
+  width: 36px;
+  height: 36px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: inherit;
+  opacity: 0.58;
+  cursor: pointer;
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  transition: opacity 0.15s, background 0.15s;
+}
+
+@media (hover: hover) {
+  .toast__dismiss:hover {
+    opacity: 1;
+    background: color-mix(in srgb, currentColor 10%, transparent);
+  }
+}
+
+.toast__dismiss:focus { outline: none; }
+.toast__dismiss:focus-visible {
+  opacity: 1;
+  outline: 2px solid currentColor;
+  outline-offset: 1px;
+}
+
+/* Keep the narrower inset on phones, but preserve the same below-chrome rail:
+   mobile still has both the shell bar and its tab strip. */
+@media (max-width: 700px) {
+  .toast {
+    right: max(0.75rem, env(safe-area-inset-right, 0px));
+  }
 }

--- a/frontend/src/components/ui/Toast.jsx
+++ b/frontend/src/components/ui/Toast.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react'
+import X from 'lucide-react/dist/esm/icons/x.mjs'
 import './Toast.css'
 
 /**
@@ -8,8 +9,8 @@ import './Toast.css'
  *   message   — string to display, or null/undefined to hide
  *   variant   — 'info' (default) | 'error'
  *   duration  — auto-dismiss timeout in ms (default 4000); 0 = no auto-dismiss
- *   onDismiss — called when the toast should disappear (timeout, or undo action
- *               if provided)
+ *   onDismiss — called when the toast should disappear (timeout, explicit
+ *               dismiss, or undo action if provided)
  *   action    — optional { label: string, onAction: fn } for an inline button
  *               (e.g. "Undo"); clicking it calls onAction then onDismiss.
  *
@@ -53,6 +54,14 @@ export default function Toast({ message, variant = 'info', duration = 4000, onDi
     onDismiss?.()
   }
 
+  function handleDismiss() {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+    onDismiss?.()
+  }
+
   return (
     <div
       className={`toast toast--${variant}`}
@@ -62,8 +71,18 @@ export default function Toast({ message, variant = 'info', duration = 4000, onDi
     >
       <span className="toast__message">{message}</span>
       {action && (
-        <button className="toast__action" onClick={handleAction}>
+        <button className="toast__action" type="button" onClick={handleAction}>
           {action.label}
+        </button>
+      )}
+      {onDismiss && (
+        <button
+          className="toast__dismiss"
+          type="button"
+          aria-label="Dismiss notification"
+          onClick={handleDismiss}
+        >
+          <X size={16} aria-hidden="true" />
         </button>
       )}
     </div>

--- a/frontend/src/hooks/queries.js
+++ b/frontend/src/hooks/queries.js
@@ -91,10 +91,13 @@ async function fetchApps() {
   return Array.isArray(data) ? data : []
 }
 
-function useAppsQuery() {
+function useAppsQuery({ reconcile } = {}) {
   return useQuery({
     queryKey: appsKey,
-    queryFn: fetchApps,
+    queryFn: async () => {
+      const rows = await fetchApps()
+      return reconcile ? reconcile(rows) : rows
+    },
   })
 }
 

--- a/frontend/src/lib/__tests__/shellListCacheInvalidation.test.js
+++ b/frontend/src/lib/__tests__/shellListCacheInvalidation.test.js
@@ -1,0 +1,49 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { invalidateShellListCache } from '../../api/client.js'
+import { SHELL_DATA_CACHE } from '../../sw-cache-policy.js'
+
+test('list invalidation evicts the exact shared offline projection', async () => {
+  const calls = []
+  const cacheStorage = {
+    async open(name) {
+      calls.push(['open', name])
+      return {
+        async delete(url) {
+          calls.push(['delete', url])
+          return true
+        },
+      }
+    },
+  }
+
+  assert.equal(await invalidateShellListCache('chats', {
+    cacheStorage,
+    origin: 'https://mobius.test',
+  }), true)
+  assert.equal(await invalidateShellListCache('apps', {
+    cacheStorage,
+    origin: 'https://mobius.test',
+  }), true)
+  assert.deepEqual(calls, [
+    ['open', SHELL_DATA_CACHE],
+    ['delete', 'https://mobius.test/api/chats'],
+    ['open', SHELL_DATA_CACHE],
+    ['delete', 'https://mobius.test/api/apps/'],
+  ])
+})
+
+test('list invalidation is best-effort and rejects unknown projections', async () => {
+  const broken = {
+    async open() { throw new Error('quota/storage unavailable') },
+  }
+  assert.equal(await invalidateShellListCache('chats', {
+    cacheStorage: broken,
+    origin: 'https://mobius.test',
+  }), false)
+  assert.equal(await invalidateShellListCache('other', {
+    cacheStorage: broken,
+    origin: 'https://mobius.test',
+  }), false)
+})

--- a/frontend/src/sw-cache-policy.js
+++ b/frontend/src/sw-cache-policy.js
@@ -14,6 +14,11 @@
 // names are stable so vendor/esm aren't re-fetched every release.
 export const VENDOR_CACHE = 'mobius-vendor-v2'
 export const ESM_CACHE = 'mobius-esm-v2'
+// Owner-scoped shell projections (theme, chat drawer, app drawer). Keep this
+// name shared with the page-side mutation boundary: after a confirmed
+// list-affecting write, the page evicts the corresponding cached GET so a
+// NetworkFirst fallback cannot resurrect the pre-mutation projection.
+export const SHELL_DATA_CACHE = 'mobius-shell-data'
 // Bumped -v2 → -v3 (2026-06-18): a one-time eviction of app-frame entries
 // cached under the pre-fix, un-revved key (`?v=<updated_at>` with NO
 // `-<frameRev>` suffix, because the SW-precached index.html lacked the
@@ -50,6 +55,7 @@ export const APP_ASSETS_MAX_ENTRIES = 600
 const KEEP_RUNTIME_CACHES = new Set([
   VENDOR_CACHE,
   ESM_CACHE,
+  SHELL_DATA_CACHE,
   OFFLINE_APPS_CACHE,
   STANDALONE_APPS_CACHE,
   APP_ASSETS_CACHE,

--- a/frontend/src/sw.js
+++ b/frontend/src/sw.js
@@ -61,6 +61,7 @@ import {
   isOpaqueFramePublicAssetPath,
   withOpaqueFramePublicAssetCors,
   isCacheableAppAssetResponse,
+  SHELL_DATA_CACHE,
   isImmutableAppAsset,
   isPackagedAppAsset,
   packagedAppAssetCacheKey,
@@ -560,7 +561,7 @@ registerRoute(
   ({ url }) =>
     url.origin === self.location.origin &&
     url.pathname === '/api/theme',
-  new StaleWhileRevalidate({ cacheName: 'mobius-shell-data' }),
+  new StaleWhileRevalidate({ cacheName: SHELL_DATA_CACHE }),
 )
 
 // `/api/chats` — same cache bucket as above (one logical
@@ -595,7 +596,7 @@ registerRoute(
     url.origin === self.location.origin &&
     (url.pathname === '/api/chats' || url.pathname === '/api/apps/'),
   new NetworkFirst({
-    cacheName: 'mobius-shell-data',
+    cacheName: SHELL_DATA_CACHE,
     // KEPT at 5s deliberately. Workbox returns a cache fallback as a
     // successful fetch that TanStack can't distinguish from a confirmed live
     // response (isFetchedAfterMount), so a too-fast fallback of a stale `[]`


### PR DESCRIPTION
## Summary

- Treat confirmed chat and app deletions as authoritative so cached drawer reads cannot bring removed rows back.
- Broadcast exact deletion and recovery events, reconcile both durable lists after reconnecting, and prove revived or reused app identities with a direct resource read.
- Keep post-commit deletion and recovery responses truthful even if ancillary cleanup fails.
- Give every notice the same stable lifecycle, an explicit dismiss control, and a below-chrome placement clear of the composer.

## Why

The offline-capable drawer uses network-first reads, so a successful fallback could return the pre-deletion list even after the server committed the deletion. That briefly restored a dead row; opening it then reached a missing chat and degraded to the new-chat surface. The reverse edge also mattered: reinstall can revive a tombstoned app and hard purge can free an integer id for reuse, so a session tombstone must clear only after the specific app resource is proven live.

The notice primitive also sat over the primary input, one producer bypassed the shared lifecycle, and unrelated shell renders could reset the timeout. Post-commit cleanup failures could additionally report a failed request after the durable state had already changed, recreating ambiguity at the mutation boundary.

## Testing

- `npm run test:lib` (1,832 passing)
- `npm run test:hooks` (47 passing)
- `npm run build`
- Backend chat and app route suites (168 passing)
- Rendered desktop and narrow-viewport checks for placement, action layout, and explicit dismissal