### PR TITLE
Fix offline chat footer status order

### DIFF
--- a/frontend/src/components/ChatView/ChatInputBar.jsx
+++ b/frontend/src/components/ChatView/ChatInputBar.jsx
@@ -491,14 +491,14 @@ export default function ChatInputBar({
         onChange={handleFileSelect}
         style={{ display: 'none' }}
       />
-      {(sendFailure || offline) && (
+      {sendFailure && (
         <div
-          className={`chat__offline-note${sendFailure ? ' chat__offline-note--error' : ''}`}
+          className="chat__offline-note chat__offline-note--error"
           role="status"
           aria-live="polite"
           aria-atomic="true"
         >
-          {sendFailure || "You're offline — chat needs a connection."}
+          {sendFailure}
         </div>
       )}
       <div className="chat__input-row">

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -674,11 +674,16 @@
   align-items: center;
   justify-content: center;
   gap: 8px;
-  padding: 6px 16px;
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 720px;
+  margin: 0 auto 6px;
+  padding: 4px 10px;
   font-size: 12px;
   color: var(--muted); /* CONTRACT: low-contrast text on opaque fill */
   background: var(--surface); /* CONTRACT: opaque card/panel fill, sits on --bg */
-  border-top: 1px solid var(--border-light); /* CONTRACT: subtle 1px hairline on opaque fill */
+  border: 1px solid var(--border-light); /* CONTRACT: subtle 1px hairline on opaque fill */
+  border-radius: 999px;
 }
 
 .connection-status__text { opacity: 0.8; }
@@ -695,6 +700,11 @@
 
 .connection-status__retry:hover {
   background: var(--surface2); /* CONTRACT: opaque hover/raised fill, slightly above --surface */
+}
+
+.connection-status__retry:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 /* ── Tool activity blocks ──────────────────────────── */
@@ -1697,9 +1707,10 @@
 }
 
 .chat__offline-note {
-  max-width: min(680px, calc(100vw - 32px));
-  align-self: center;
-  margin: 0 0 6px;
+  box-sizing: border-box;
+  width: fit-content;
+  max-width: min(680px, 100%);
+  margin: 0 auto 6px;
   padding: 4px 10px;
   border-radius: 999px;
   background: color-mix(in srgb, var(--surface) 82%, transparent);

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -3951,17 +3951,21 @@ export default function ChatView({
       )}
 
       <div ref={footRef} className="chat__foot">
-        {/* Foot order, top to bottom (owner spec, 2026-07-17):
-            connection/retry → attention actions (open-app CTA, question
-            and resume nudges) → build-progress rail → queued messages →
-            composer. Queued messages sit directly ON the composer — they
-            are the input's extension (your next sends) — and everything
-            transient stacks above them. */}
-        <ConnectionStatus
-          error={connectionError}
-          reconnecting={reconnecting}
-          onRetry={retry}
-        />
+        {/* Foot order, top to bottom:
+            offline explanation → attention actions → build-progress rail →
+            connection/retry → queued messages → composer. Queued messages are
+            the input's extension, and connection recovery belongs immediately
+            above that input area. */}
+        {!online && (
+          <div
+            className="chat__offline-note"
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            You're offline — chat needs a connection.
+          </div>
+        )}
         {/* A LOST connection empties the stack: while the terminal
             'disconnected' state is set, nudges, rail, and the queued tray
             hide so the one thing on screen is the problem and its Retry
@@ -4026,6 +4030,14 @@ export default function ChatView({
               ))}
             </div>
           )}
+          </>
+        )}
+        <ConnectionStatus
+          error={connectionError}
+          reconnecting={reconnecting}
+          onRetry={retry}
+        />
+        {connectionError !== 'disconnected' && (
           <QueuedMessages
             items={pendingQueue.pendingMessages}
             onCancel={handleCancelPending}
@@ -4033,7 +4045,6 @@ export default function ChatView({
             steerActive={turnActive && !hasPendingQuestion}
             steerBusy={steerBusy}
           />
-          </>
         )}
         <ChatInputBar
           chatId={chatId}

--- a/frontend/src/components/ChatView/ConnectionStatus.jsx
+++ b/frontend/src/components/ChatView/ConnectionStatus.jsx
@@ -38,7 +38,11 @@ export default function ConnectionStatus({ error, reconnecting, onRetry }) {
       ) : (
         <>
           <span className="connection-status__text">Connection lost</span>
-          <button className="connection-status__retry" onClick={onRetry}>
+          <button
+            type="button"
+            className="connection-status__retry"
+            onClick={onRetry}
+          >
             Retry
           </button>
         </>

--- a/frontend/src/components/ChatView/__tests__/buildPhaseRail.test.js
+++ b/frontend/src/components/ChatView/__tests__/buildPhaseRail.test.js
@@ -1,4 +1,3 @@
-import { readFileSync } from 'node:fs'
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 
@@ -10,8 +9,6 @@ import {
   latestBuildPhaseAnnouncement,
   railAtRunStart,
 } from '../buildPhaseRail.js'
-
-const chatView = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8')
 
 test('buildPhaseFromEvent extracts label + ts and trims the label', () => {
   assert.deepEqual(
@@ -72,47 +69,6 @@ test('latestBuildPhaseAnnouncement announces the newest phase, empty when none',
 
 test('railAtRunStart resets to the shared empty rail', () => {
   assert.equal(railAtRunStart(), EMPTY_BUILD_PHASE_RAIL)
-})
-
-test('footer stacks connection → notices → rail → queued → composer', () => {
-  // Owner spec 2026-07-17: queued messages sit directly ON the composer (they
-  // are the input's extension — the next sends), the build rail directly
-  // above them, attention notices above that, and the connection/retry row
-  // tops the stack. Pinned as a source scan so a refactor can't silently
-  // reshuffle the foot.
-  const footStart = chatView.indexOf('<div ref={footRef} className="chat__foot">')
-  const composer = chatView.indexOf('<ChatInputBar', footStart)
-  const foot = chatView.slice(footStart, composer)
-  const rail = foot.indexOf('className="chat__build-rail"')
-  const queued = foot.indexOf('<QueuedMessages')
-  const connection = foot.indexOf('<ConnectionStatus')
-
-  assert.ok(footStart >= 0 && composer > footStart && rail >= 0 && queued >= 0,
-    'the footer, build rail, queued tray, and composer must all be present')
-  assert.ok(rail < queued, 'the build rail stacks above the queued tray')
-  for (const notice of [
-    'className="chat__open-app"',
-    'className="chat__question-nudge"',
-    'className="chat__resume-nudge"',
-  ]) {
-    const noticeIndex = foot.indexOf(notice)
-    assert.ok(noticeIndex >= 0, `${notice} must be present in the footer`)
-    assert.ok(noticeIndex < rail,
-      `${notice} must stack above the build rail`)
-    assert.ok(connection >= 0 && connection < noticeIndex,
-      'the connection/retry row tops the stack')
-  }
-})
-
-test('connection failure hides queued actions and disables composer steering', () => {
-  assert.match(chatView, /\{connectionError !== 'disconnected' && \([\s\S]*?<QueuedMessages/,
-    'the lost-connection state should own the footer stack until Retry succeeds')
-  assert.match(chatView, /const canSteer = !hasPendingQuestion[\s\S]*?connectionError !== 'disconnected' && !steerBusy[\s\S]*?canFastForwardQueue/,
-    'the visible composer steer action must be gated by pending QA and connection health')
-  assert.match(chatView, /const canSubmitSteer = !hasPendingQuestion[\s\S]*?connectionError !== 'disconnected'[\s\S]*?!steerBusy[\s\S]*?turnActive/,
-    'the composed-text keyboard steer path must be gated by pending QA and connection health too')
-  assert.match(chatView, /const canRequestSteer = canSubmitSteer[\s\S]*?pendingQueue\.pendingMessages\.length > 0/,
-    'the empty-composer keyboard path must share the same gate and require queued work')
 })
 
 test('a send that merely enqueues preserves the in-flight build rail', () => {

--- a/frontend/src/components/ChatView/__tests__/offlineFooter.test.js
+++ b/frontend/src/components/ChatView/__tests__/offlineFooter.test.js
@@ -1,0 +1,89 @@
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+const chatView = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8')
+const chatInputBar = readFileSync(new URL('../ChatInputBar.jsx', import.meta.url), 'utf8')
+const connectionStatus = readFileSync(new URL('../ConnectionStatus.jsx', import.meta.url), 'utf8')
+const chatCss = readFileSync(new URL('../ChatView.css', import.meta.url), 'utf8')
+
+test('footer stacks offline note → notices → rail → connection → queued → composer', () => {
+  const footStart = chatView.indexOf('<div ref={footRef} className="chat__foot">')
+  const composer = chatView.indexOf('<ChatInputBar', footStart)
+  const foot = chatView.slice(footStart, composer)
+  const rail = foot.indexOf('className="chat__build-rail"')
+  const queued = foot.indexOf('<QueuedMessages')
+  const connection = foot.indexOf('<ConnectionStatus')
+  const offline = foot.indexOf('className="chat__offline-note"')
+
+  assert.ok(
+    footStart >= 0 && composer > footStart && rail >= 0 && queued >= 0
+      && connection >= 0 && offline >= 0,
+    'the complete footer stack must be present',
+  )
+  assert.ok(offline < connection, 'the offline explanation stacks above connection/retry')
+  assert.ok(rail < connection, 'the build rail stacks above connection/retry')
+  assert.ok(connection < queued, 'connection/retry stacks directly above the queued input tray')
+  for (const notice of [
+    'className="chat__open-app"',
+    'className="chat__question-nudge"',
+    'className="chat__resume-nudge"',
+  ]) {
+    const noticeIndex = foot.indexOf(notice)
+    assert.ok(noticeIndex >= 0, `${notice} must be present in the footer`)
+    assert.ok(noticeIndex < rail,
+      `${notice} must stack above the build rail`)
+  }
+})
+
+test('offline explanation has one owner while send failures stay in the composer', () => {
+  const offlineText = "You're offline — chat needs a connection."
+
+  assert.equal(chatView.split(offlineText).length - 1, 1)
+  assert.doesNotMatch(chatInputBar, /You're offline — chat needs a connection\./)
+  assert.match(
+    chatInputBar,
+    /\{sendFailure && \([\s\S]*?chat__offline-note--error[\s\S]*?\{sendFailure\}/,
+    'moving the persistent offline state must not remove a failed-send explanation',
+  )
+})
+
+test('connection failure hides queued actions and disables composer steering', () => {
+  assert.match(chatView, /\{connectionError !== 'disconnected' && \([\s\S]*?<QueuedMessages/,
+    'the lost-connection state should own the footer stack until Retry succeeds')
+  assert.match(chatView, /const canSteer = !hasPendingQuestion[\s\S]*?connectionError !== 'disconnected' && !steerBusy[\s\S]*?canFastForwardQueue/,
+    'the visible composer steer action must be gated by pending QA and connection health')
+  assert.match(chatView, /const canSubmitSteer = !hasPendingQuestion[\s\S]*?connectionError !== 'disconnected'[\s\S]*?!steerBusy[\s\S]*?turnActive/,
+    'the composed-text keyboard steer path must be gated by pending QA and connection health too')
+  assert.match(chatView, /const canRequestSteer = canSubmitSteer[\s\S]*?pendingQueue\.pendingMessages\.length > 0/,
+    'the empty-composer keyboard path must share the same gate and require queued work')
+})
+
+test('connection status matches the composer column while the offline note stays compact', () => {
+  assert.match(
+    chatCss,
+    /\.connection-status\s*\{[\s\S]*?width:\s*100%;[\s\S]*?max-width:\s*720px;/,
+    'connection status should fill the bounded composer column',
+  )
+  assert.match(
+    chatCss,
+    /\.chat__form\s*\{[\s\S]*?max-width:\s*720px;/,
+    'connection status and composer must share the same maximum width',
+  )
+  assert.match(
+    chatCss,
+    /\.chat__offline-note\s*\{[\s\S]*?box-sizing:\s*border-box;[\s\S]*?width:\s*fit-content;[\s\S]*?max-width:\s*min\(680px,\s*100%\);/,
+    'the compact note must be bounded by its pane rather than the global viewport',
+  )
+})
+
+test('Retry is a non-submitting button with a visible keyboard focus ring', () => {
+  assert.match(
+    connectionStatus,
+    /<button[\s\S]*?type="button"[\s\S]*?className="connection-status__retry"/,
+  )
+  assert.match(
+    chatCss,
+    /\.connection-status__retry:focus-visible\s*\{[\s\S]*?outline:\s*2px solid var\(--accent\);/,
+  )
+})


### PR DESCRIPTION
## Summary
- show the compact offline explanation above connection recovery
- keep Connection lost and Retry immediately above the queue or composer
- align the recovery row to the composer width while keeping the offline note pane-safe and compact
- preserve failed-send guidance and give Retry an explicit keyboard focus treatment

## Testing
- `npm test`
- `npm run build`
- verified combined offline and disconnected layouts at wide and phone-sized viewports
- verified Retry through keyboard navigation