### PR TITLE
Allow chat messages with only an attachment

### DIFF
--- a/backend/tests/test_chats.py
+++ b/backend/tests/test_chats.py
@@ -1,6 +1,7 @@
 """Chat route regression tests."""
 
 import asyncio
+import io
 from uuid import uuid4
 
 from app import memory, models, questions
@@ -212,6 +213,41 @@ def test_fresh_send_response_includes_stored_user_message(
   assert body["message"]["role"] == "user"
   assert body["message"]["content"] == "build forge"
   assert isinstance(body["message"]["ts"], int)
+
+  db.refresh(chat)
+  assert chat.messages == [body["message"]]
+
+
+def test_uploaded_file_can_start_a_turn_without_typed_text(
+  client, auth, chat, db, monkeypatch,
+):
+  async def _noop_run_chat(*args, **kwargs):
+    return None
+
+  monkeypatch.setattr("app.routes.chats_stream.run_chat", _noop_run_chat)
+  uploaded = client.post(
+    f"/api/chats/{chat.id}/uploads",
+    files=[("files", ("brief.txt", io.BytesIO(b"review this"), "text/plain"))],
+    headers=auth,
+  )
+  assert uploaded.status_code == 200, uploaded.text
+  attachment = {
+    key: uploaded.json()[0][key]
+    for key in ("name", "size", "mime_type")
+  }
+
+  response = client.post(
+    f"/api/chats/{chat.id}/messages",
+    json={"content": "", "attachments": [attachment]},
+    headers=auth,
+  )
+
+  assert response.status_code == 202, response.text
+  body = response.json()
+  assert body["status"] == "started"
+  assert body["message"]["attachments"] == [attachment]
+  assert "[Files in this session:" in body["message"]["content"]
+  assert "brief.txt" in body["message"]["content"]
 
   db.refresh(chat)
   assert chat.messages == [body["message"]]

--- a/frontend/src/components/ChatView/ChatInputBar.jsx
+++ b/frontend/src/components/ChatView/ChatInputBar.jsx
@@ -76,6 +76,7 @@ import { BASE } from '../../api/client.js'
 import { mediaTokenParam } from '../../api/mediaToken.js'
 import { resolveComposerEnterAction } from './composerShortcuts.js'
 import { filePasteNeedsDefaultPrevented, pastedFiles } from './pasteUpload.js'
+import { hasSendablePayload } from './composerSubmission.js'
 
 
 // Detect touch-primary once (same heuristic ChatView uses).
@@ -425,7 +426,10 @@ export default function ChatInputBar({
     }
   }, [attachTriggerRef, inputRef])
 
-  const hasInput = !!input.trim()
+  // A completed attachment is a complete message in its own right. Feed that
+  // through the same primary-action and keyboard-shortcut gate as typed text
+  // so an image/file-only draft exposes Send instead of Mic.
+  const hasInput = hasSendablePayload(input, pendingFiles)
   const hasUploading = pendingFiles?.some(c => c.status === 'uploading') ?? false
 
   function handleFileSelect(e) {

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -22,6 +22,7 @@ import useSystemEventStream from '../../hooks/useSystemEventStream.js'
 import usePendingQueue from './hooks/usePendingQueue.js'
 import useBridgePartial from './hooks/useBridgePartial.js'
 import ChatInputBar from './ChatInputBar.jsx'
+import { hasSendablePayload } from './composerSubmission.js'
 import AgentContextInspector from './AgentContextInspector.jsx'
 import ChatSummaryViewer from './ChatSummaryViewer.jsx'
 import ComposerPopover from './ComposerPopover.jsx'
@@ -2013,9 +2014,24 @@ export default function ChatView({
 
   const doSend = useCallback(async (text, opts = {}) => {
     if (isProviderSwitchBlocking(chatId)) return
-    const pin = opts.pin !== false  // default true
-    if (!text.trim()) return
+
+    // Callers can pre-supply attachments (e.g. handleStop collapsing
+    // a queue that had files attached to queued items). When provided,
+    // they replace the pendingFiles-derived list so data isn't lost.
+    // Resolve and validate the payload before ANY submit-time side effect:
+    // a stale callback or failed-file-only draft must not close the keyboard,
+    // claim scroll ownership, or freeze queue geometry when nothing will send.
+    const usesComposerFiles = !Array.isArray(opts.attachments)
+    const composerFileSnapshot = usesComposerFiles ? [...pendingFiles] : []
+    const attachments = Array.isArray(opts.attachments)
+      ? opts.attachments
+      : pendingFiles
+          .filter(f => f.status === 'done')
+          .map(f => ({ name: f.name, size: f.size, mime_type: f.mime_type }))
     if (pendingFiles.some(c => c.status === 'uploading')) return
+    if (!hasSendablePayload(text, attachments)) return
+
+    const pin = opts.pin !== false  // default true
     setSendFailure(null)
 
     // Stop voice recognition so a late onresult doesn't refill input
@@ -2060,17 +2076,6 @@ export default function ChatView({
     // On touch devices, blur to dismiss the soft keyboard. Desktop keeps
     // focus so the cursor stays ready for the next message.
     if (_isTouchPrimary) inputRef.current?.blur()
-
-    // Callers can pre-supply attachments (e.g. handleStop collapsing
-    // a queue that had files attached to queued items). When provided,
-    // they replace the pendingFiles-derived list so data isn't lost.
-    const usesComposerFiles = !Array.isArray(opts.attachments)
-    const composerFileSnapshot = usesComposerFiles ? [...pendingFiles] : []
-    const attachments = Array.isArray(opts.attachments)
-      ? opts.attachments
-      : pendingFiles
-          .filter(f => f.status === 'done')
-          .map(f => ({ name: f.name, size: f.size, mime_type: f.mime_type }))
 
     function clearComposerFilesForSend() {
       if (!usesComposerFiles) return
@@ -2923,7 +2928,7 @@ export default function ChatView({
         // genuine re-queue POST failure (doSend's catch) shows a block.
         const { text: resendText, attachments: resendAttachments } =
           resolveResend(clearedPendingCids)
-        if (resendText) {
+        if (hasSendablePayload(resendText, resendAttachments)) {
           doSend(resendText, {
             pin: false,
             attachments: resendAttachments.length > 0 ? resendAttachments : undefined,
@@ -2955,7 +2960,7 @@ export default function ChatView({
       const { text: resendText, attachments: resendAttachments } =
         resolveResend(clearedPendingCids)
 
-      if (resendText) {
+      if (hasSendablePayload(resendText, resendAttachments)) {
         // doSend's guard reads sendingRef/isStreamingRef (just synced to false
         // above) → fresh-send path. pin:false so the synthetic combined-from-
         // queue message doesn't yank the viewport to top, pushing the partial
@@ -3037,7 +3042,7 @@ export default function ChatView({
         }
       }
     }
-    if (!content) return
+    if (!hasSendablePayload(content, attachments)) return
 
     const fullConfirmedSnapshot = (pendingQueue.pendingMessagesRef.current || [])
       .filter(m => typeof m.ts === 'number' && m.serverTs === true)

--- a/frontend/src/components/ChatView/__tests__/composerSubmission.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerSubmission.test.js
@@ -1,0 +1,55 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+import { hasSendablePayload } from '../composerSubmission.js'
+
+test('plain text remains sendable without an attachment', () => {
+  assert.equal(hasSendablePayload('hello', []), true)
+})
+
+test('a completed attachment is sendable without text', () => {
+  assert.equal(hasSendablePayload('', [{
+    name: 'photo.png',
+    status: 'done',
+  }]), true)
+})
+
+test('queued attachment metadata is sendable without a live upload status', () => {
+  assert.equal(hasSendablePayload('   ', [{
+    name: 'notes.pdf',
+    mime_type: 'application/pdf',
+  }]), true)
+})
+
+test('uploading, failed, and malformed attachment-only drafts are not sendable', () => {
+  assert.equal(hasSendablePayload('', [{ name: 'photo.png', status: 'uploading' }]), false)
+  assert.equal(hasSendablePayload('', [{ name: 'photo.png', status: 'error' }]), false)
+  assert.equal(hasSendablePayload('', [{ status: 'done' }]), false)
+})
+
+test('an empty draft remains unsendable', () => {
+  assert.equal(hasSendablePayload(' \n ', []), false)
+})
+
+test('sendability is decided before submit-time UI and scroll side effects', () => {
+  const source = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8')
+  const start = source.indexOf('const doSend = useCallback')
+  const end = source.indexOf('\n  }, [', start)
+  const doSend = source.slice(start, end)
+
+  const validation = doSend.indexOf('if (!hasSendablePayload(text, attachments)) return')
+  assert.ok(validation >= 0)
+  for (const sideEffect of [
+    'setSendFailure(null)',
+    'stopVoiceRef.current?.()',
+    'closePreSendGestureWindow()',
+    'freezeQueuedSubmission()',
+    'inputRef.current?.blur()',
+  ]) {
+    assert.ok(
+      validation < doSend.indexOf(sideEffect),
+      `payload validation must precede ${sideEffect}`,
+    )
+  }
+})

--- a/frontend/src/components/ChatView/composerSubmission.js
+++ b/frontend/src/components/ChatView/composerSubmission.js
@@ -1,0 +1,15 @@
+/**
+ * A composer draft is sendable when it contains visible text or at least one
+ * completed attachment. Live upload chips carry a status; attachment metadata
+ * restored from storage or copied from a queued message is already complete
+ * and therefore has no status.
+ */
+export function hasSendablePayload(text, attachments = []) {
+  if (String(text || '').trim()) return true
+  return (attachments || []).some(attachment => (
+    attachment
+    && typeof attachment.name === 'string'
+    && attachment.name.length > 0
+    && (attachment.status === undefined || attachment.status === 'done')
+  ))
+}


### PR DESCRIPTION
## Summary
- allow completed image and file attachments to be sent without accompanying text
- preserve attachment-only messages through queued Stop/re-send and Send-now flows
- validate the payload before keyboard, scroll, voice, or queue-layout side effects
- cover the real upload-to-empty-message backend contract

## Testing
- `npm test` (1,864 tests)
- `npm run build`
- `pytest tests/test_chats.py tests/test_uploads.py -q` (35 passed)
- rendered browser check: an empty textarea with a completed image exposes an enabled Send action