### PR TITLE
Preserve composer drafts across shell navigation

### DIFF
--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -271,8 +271,8 @@ export default function ChatView({
   embedded = false,
   quickActions = null,
   getContext = null,
-  composerFocusRequest = null,
-  onComposerFocusHandled = null,
+  composerRequest = null,
+  onComposerRequestHandled = null,
   externalRunSignal = EMPTY_CHAT_RUN_SIGNAL,
   onExternalRunEvent = null,
   // Multi-pane workspace (design §2): when this chat renders inside a tiled
@@ -726,23 +726,33 @@ export default function ChatView({
     chatEl.style.setProperty('--composer-h', `${footEl.offsetHeight}px`)
   }, [])
 
-  // A drawer "New chat" tap should leave desktop-web users ready to type.
-  // Keep this as an explicit one-shot request from Shell instead of a blanket
-  // autofocus-on-mount: selecting existing chats should not steal focus, and
-  // touch-primary devices should not pop the soft keyboard unexpectedly.
+  // One explicit Shell-to-composer handoff owns both New-chat focus and drafts
+  // supplied by app navigation. Storage restores unmounted chats; applying the
+  // same request here is what updates a retained ChatView without sacrificing
+  // its transcript, scroll, or stream identity through a forced remount.
   useEffect(() => {
-    const token = composerFocusRequest?.token
+    const token = composerRequest?.token
     if (token == null) return
-    const requestChatId = composerFocusRequest?.chatId
+    const requestChatId = composerRequest?.chatId
     if (requestChatId == null || String(requestChatId) !== String(chatId)) return
 
+    if (typeof composerRequest.draft === 'string'
+        && inputValueRef.current !== composerRequest.draft) {
+      handleComposerInputChange(composerRequest.draft)
+    }
+
+    if (!composerRequest.focus) {
+      onComposerRequestHandled?.(token)
+      return
+    }
+
     if (!shouldApplyComposerFocusRequest({
-      focusRequest: composerFocusRequest,
+      focusRequest: composerRequest,
       chatId,
       embedded,
       isTouchPrimary: _isTouchPrimary,
     })) {
-      onComposerFocusHandled?.(token)
+      onComposerRequestHandled?.(token)
       return
     }
 
@@ -750,13 +760,13 @@ export default function ChatView({
     const raf = requestAnimationFrame(() => {
       if (cancelled) return
       focusComposerElement(inputRef.current)
-      onComposerFocusHandled?.(token)
+      onComposerRequestHandled?.(token)
     })
     return () => {
       cancelled = true
       cancelAnimationFrame(raf)
     }
-  }, [chatId, composerFocusRequest, embedded, onComposerFocusHandled])
+  }, [chatId, composerRequest, embedded, onComposerRequestHandled])
 
   // Lifecycle guards. `hadMessagesRef` reflects the cached length so
   // doSend's "first message" branch doesn't fire spuriously.

--- a/frontend/src/components/Shell/PaneChatView.jsx
+++ b/frontend/src/components/Shell/PaneChatView.jsx
@@ -27,8 +27,8 @@ function PaneChatView({
   visible = true,
   paneContentHeight,
   chatRunSignals,
-  composerFocusRequest,
-  onComposerFocusHandled,
+  composerRequest,
+  onComposerRequestHandled,
   onSystemEvent,
   markStreamingStart,
   markStreamingEnd,
@@ -99,8 +99,8 @@ function PaneChatView({
         onMessageStart={handleMessageStart}
         onQuestionAnswered={refreshChats}
         onVoiceListeningChange={markVoiceListening}
-        composerFocusRequest={composerFocusRequest}
-        onComposerFocusHandled={onComposerFocusHandled}
+        composerRequest={composerRequest}
+        onComposerRequestHandled={onComposerRequestHandled}
         onDisplayReady={onDisplayReady ? handleDisplayReady : null}
       />
     </ErrorBoundary>

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -63,6 +63,7 @@ import {
   currentReusableEmptyChat,
   enteredEmptySingleScreen,
   mergeChatListWithCreatedGuards,
+  mostRecentConcreteChatId,
   reconcileCreatedChatGuard,
   rememberCreatedChat,
   reusableChatDetailVerdict,
@@ -618,20 +619,23 @@ export default function Shell() {
   // Guards the once-per-mount deferred shell-update pickup effect below.
   const shellUpdatePickupRef = useRef(false)
   const shellUpdatePickupCheckStartedRef = useRef(false)
-  const [composerFocusRequest, setComposerFocusRequest] = useState(null)
-  const composerFocusTokenRef = useRef(0)
+  const [composerRequest, setComposerRequest] = useState(null)
+  const composerRequestTokenRef = useRef(0)
 
-  function requestComposerFocus(chatId) {
+  function requestComposer(chatId, { draft, focus = false } = {}) {
     if (chatId == null) return
-    composerFocusTokenRef.current += 1
-    setComposerFocusRequest({
+    if (draft == null && !focus) return
+    composerRequestTokenRef.current += 1
+    setComposerRequest({
       chatId,
-      token: composerFocusTokenRef.current,
+      token: composerRequestTokenRef.current,
+      draft: draft == null ? null : String(draft),
+      focus: focus === true,
     })
   }
 
-  const handleComposerFocusHandled = useCallback((token) => {
-    setComposerFocusRequest(prev => (
+  const handleComposerRequestHandled = useCallback((token) => {
+    setComposerRequest(prev => (
       prev?.token === token ? null : prev
     ))
   }, [])
@@ -2609,8 +2613,9 @@ export default function Shell() {
         })
       } else if (e.data?.type === 'moebius:open-chat') {
         if (typeof e.data.chatId !== 'string' || !e.data.chatId) return
+        let draftText = null
         if (e.data.draft) {
-          const draftText = String(e.data.draft)
+          draftText = String(e.data.draft)
           try {
             sessionStorage.setItem('pending-draft', draftText)
             sessionStorage.setItem(`draft:${e.data.chatId}`, draftText)
@@ -2619,6 +2624,10 @@ export default function Shell() {
           } catch {}
         }
         navTo('chat', { chatId: e.data.chatId })
+        // Storage covers an unmounted target. The explicit request also updates
+        // an already-retained ChatView, whose controlled composer state would
+        // otherwise keep showing its old value until a full remount.
+        if (draftText != null) requestComposer(e.data.chatId, { draft: draftText })
         refreshChats()
       } else if (e.data?.type === 'moebius:open-app') {
         // Match against installed apps by numeric id OR slug, so the
@@ -2895,7 +2904,38 @@ export default function Shell() {
     //
     // Resolve chatId BEFORE switching views — setting activeView='chat'
     // with the old chatId causes a visible flash of the previous chat.
-    const { chatId, reason } = await resolveNewChatId({ draft, forceNew, exclude })
+    // Standard mode has one foreground surface. If the owner temporarily
+    // replaced an unfinished blank chat with an app, "New chat" means return to
+    // that in-progress compose surface rather than silently allocate another
+    // blank and strand its saved draft. Builder mode deliberately does NOT take
+    // this branch: opening another chat there is additive by design.
+    //
+    // The history route only supplies a candidate id. The existing list guards
+    // plus fresh detail probe still prove that it is untouched before reuse, so
+    // a send from another browser cannot turn this convenience into reopening a
+    // conversation that has already started.
+    const ws = workspaceStateRef.current.ws
+    const resumeId = (
+      (!SPLITS || ws.viewMode === 'single')
+      && activeChatIdRef.current == null
+      && !draft
+      && !forceNew
+    )
+      ? mostRecentConcreteChatId(navStackRef.current)
+      : null
+    const resumeCandidate = resumeId == null
+      ? undefined
+      : currentReusableEmptyChat(chatsRef.current, {
+        activeChatId: resumeId,
+        exclude,
+        recoveredChatIds: recoveredChatIdsRef.current,
+        streamingChatIds: streamingChatIdsRef.current,
+      })
+    const { chatId, reason } = await resolveNewChatId(
+      resumeCandidate === undefined
+        ? { draft, forceNew, exclude }
+        : { candidate: resumeCandidate, draft, forceNew, exclude },
+    )
     if (chatId == null) {
       // Don't leave a dead, drawer-still-open tap. Offline / failed create surface a
       // toast; an in-flight second tap just closes the drawer (the first create lands).
@@ -2936,7 +2976,7 @@ export default function Shell() {
       const ws = workspaceStateRef.current.ws
       applyModeDestination({ view: 'chat', chatId, appId: null, paneId: ws.focusedPaneId })
     }
-    if (focusComposer) requestComposerFocus(chatId)
+    if (focusComposer) requestComposer(chatId, { focus: true })
   }
   // Keep the latest-newChat ref current so handleAppError's crash-report
   // fallback starts a chat with this render's live closure.
@@ -3504,9 +3544,9 @@ export default function Shell() {
               visible={chatPanesVisible && role !== 'held' && visibleChatKeys.has(`chat:${chatId}`)}
                 paneContentHeight={paned ? paned.h : null}
                 chatRunSignals={chatRunSignals}
-                composerFocusRequest={role === 'active' ? composerFocusRequest : null}
-                onComposerFocusHandled={role === 'active'
-                  ? handleComposerFocusHandled
+                composerRequest={role === 'active' ? composerRequest : null}
+                onComposerRequestHandled={role === 'active'
+                  ? handleComposerRequestHandled
                   : null}
                 onSystemEvent={handleSystemEvent}
                 markStreamingStart={markStreamingStart}

--- a/frontend/src/components/Shell/__tests__/chatHandoff.test.js
+++ b/frontend/src/components/Shell/__tests__/chatHandoff.test.js
@@ -54,8 +54,19 @@ test('each pane holds one outgoing chat over one staging chat', () => {
   // gate is the EFFECTIVE-mode `settingsOverlay` (finding F3), not the committed one.
   assert.match(shell, /inert=\{settingsOverlay \|\| role !== 'active'/,
     'neither the held nor staging chat may accept interaction')
-  assert.match(shell, /composerFocusRequest=\{role === 'active' \? composerFocusRequest : null\}/,
-    'an inert staging composer must not consume the one-shot focus request')
+  assert.match(shell, /composerRequest=\{role === 'active' \? composerRequest : null\}/,
+    'an inert staging composer must not consume a one-shot composer request')
+})
+
+test('app-supplied drafts update retained composers as well as remounted chats', () => {
+  assert.match(shell,
+    /navTo\('chat', \{ chatId: e\.data\.chatId \}\)[\s\S]*requestComposer\(e\.data\.chatId, \{ draft: draftText \}\)/,
+    'the open-chat handoff must target the live composer after navigation')
+  assert.match(chatView,
+    /typeof composerRequest\.draft === 'string'[\s\S]*handleComposerInputChange\(composerRequest\.draft\)/,
+    'a retained ChatView must apply the requested draft to controlled state')
+  assert.match(chatView, /if \(!composerRequest\.focus\) \{[\s\S]*onComposerRequestHandled\?\.\(token\)/,
+    'a draft-only handoff must settle without stealing focus')
 })
 
 test('the held chat is an opaque layer above staging until the atomic swap', () => {

--- a/frontend/src/components/Shell/__tests__/newChatPolicy.test.js
+++ b/frontend/src/components/Shell/__tests__/newChatPolicy.test.js
@@ -9,6 +9,7 @@ import {
   detailIsUntouchedEmptyChat,
   enteredEmptySingleScreen,
   mergeChatListWithCreatedGuards,
+  mostRecentConcreteChatId,
   reconcileCreatedChatGuard,
   rememberCreatedChat,
   reusableChatDetailVerdict,
@@ -80,6 +81,21 @@ test('drafts and force-new callers always require a fresh chat', () => {
   assert.equal(currentReusableEmptyChat([active], {
     activeChatId: 'active', forceNew: true,
   }), null)
+})
+
+test('the most recent concrete chat route can resume standard-mode composition', () => {
+  assert.equal(mostRecentConcreteChatId([
+    { view: 'chat', chatId: 'older' },
+    { view: 'canvas', appId: 4 },
+    { view: 'settings' },
+    { view: 'chat', chatId: 'draft' },
+    { view: 'canvas', appId: 7 },
+  ]), 'draft')
+  assert.equal(mostRecentConcreteChatId([
+    { view: 'chat', chatId: null, homeSeed: true },
+    { view: 'canvas', appId: 4 },
+  ]), null)
+  assert.equal(mostRecentConcreteChatId(null), null)
 })
 
 test('running, excluded, recovered, and populated active chats are rejected', () => {

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -1003,8 +1003,12 @@ test('round4-3: materializeNewChatHome is stale-guarded and writes a history-fre
 
 test('round4-3: resolveNewChatId is the shared reuse-and-create policy; newChat + materialize both use it', () => {
   assert.match(shell, /async function resolveNewChatId\(\{ candidate, draft, forceNew, exclude \} = \{\}\)/)
-  // newChat consumes the shared resolver, not its own inline reuse/create.
-  assert.match(shell, /const \{ chatId, reason \} = await resolveNewChatId\(\{ draft, forceNew, exclude \}\)/)
+  // newChat consumes the shared resolver, optionally supplying the standard-mode
+  // resume candidate rather than growing a second create path.
+  const fn = shell.match(/async function newChat\([\s\S]*?\n  \}/)?.[0] || ''
+  assert.ok(fn.length > 0, 'found newChat')
+  assert.match(fn, /const \{ chatId, reason \} = await resolveNewChatId\(/)
+  assert.doesNotMatch(fn, /api\.chats\.create|apiFetch\(\s*['"`]\/chats/)
 })
 
 test('round4-3: the New Chat landing renders for a null slot / reveal underlay and reuses ChatView empty visuals', () => {

--- a/frontend/src/components/Shell/newChatPolicy.js
+++ b/frontend/src/components/Shell/newChatPolicy.js
@@ -53,6 +53,25 @@ export function currentReusableEmptyChat(chats, {
 }
 
 /**
+ * Find the concrete chat route the single-screen world most recently left.
+ *
+ * The navigation stack is newest-last. Home seed entries intentionally carry
+ * no concrete id, so they are skipped along with app/settings routes. This is
+ * only a candidate source: callers must still run the normal empty-chat checks
+ * and authoritative detail probe before reusing the row.
+ */
+export function mostRecentConcreteChatId(routes) {
+  const rows = Array.isArray(routes) ? routes : []
+  for (let index = rows.length - 1; index >= 0; index -= 1) {
+    const route = rows[index]
+    if (route?.view !== 'chat' || route.chatId == null) continue
+    const id = String(route.chatId).trim()
+    if (id) return id
+  }
+  return null
+}
+
+/**
  * Validate the fresh detail response before keeping an active blank open.
  * Fail closed when the response is partial or unfamiliar: creating a fresh
  * row is preferable to navigating into a conversation that has started in


### PR DESCRIPTION
## Summary
- resume the untouched Standard-mode chat after a temporary app visit instead of allocating a second blank chat
- keep Builder mode additive when opening another chat
- deliver app-supplied `open-chat` drafts to retained ChatViews as well as remounted ones
- share the existing one-shot composer handoff for draft updates and focus without forcing chat remounts

## Why
Möbius already persisted each composer draft, but two navigation paths could make it appear lost. In Standard mode, using New chat after visiting an app allocated another blank chat instead of returning to the unfinished one. App handoffs such as Contribute's Refresh in chat wrote only to browser storage, so a ChatView that remained mounted kept its old controlled composer state.

The fix keeps the existing authoritative empty-chat verification, limits resume behavior to Standard mode, and updates retained composers without resetting transcript, scroll, or stream state.

## Related work
#117 preserves unfinished attachment drafts across chat remounts. This addresses the separate shell-routing and retained-component paths, including app-provided drafts when no remount occurs.

## Testing
- focused Shell draft, navigation, and handoff tests (92 passed)
- complete frontend unit suite (1,860 passed)
- production frontend build
- exact browser checks for Standard chat → app → New chat and Contribute → already-mounted source chat