### PR TITLE
Add sent-message history to the chat composer

### DIFF
--- a/frontend/src/components/ChatView/ChatInputBar.jsx
+++ b/frontend/src/components/ChatView/ChatInputBar.jsx
@@ -67,6 +67,13 @@
  * ║      turn when possible, otherwise it sends normally.            ║
  * ║      Shift+Enter always inserts a newline.                        ║
  * ║                                                                  ║
+ * ║   8. SENT-MESSAGE HISTORY                                        ║
+ * ║      Up recalls sent messages only after native textarea movement ║
+ * ║      has reached the visual top; once browsing, Up/Down walk       ║
+ * ║      history and Down past the newest restores the unfinished     ║
+ * ║      draft. Manual edits and sends exit history. Modifier chords   ║
+ * ║      and IME composition stay native.                              ║
+ * ║                                                                  ║
  * ╚══════════════════════════════════════════════════════════════════╝
  */
 
@@ -74,6 +81,11 @@ import { useRef, useState, useEffect, useLayoutEffect } from 'react'
 import { ArrowUp, Mic, DoubleChevronRight } from '@openai/apps-sdk-ui/components/Icon'
 import { BASE } from '../../api/client.js'
 import { mediaTokenParam } from '../../api/mediaToken.js'
+import {
+  composerHistoryNativeProbe,
+  composerHistoryProbeReachedBoundary,
+  resolveComposerHistoryMove,
+} from './composerHistory.js'
 import { resolveComposerEnterAction } from './composerShortcuts.js'
 import { filePasteNeedsDefaultPrevented, pastedFiles } from './pasteUpload.js'
 
@@ -362,6 +374,7 @@ function FileChips({ files, onRemove, chatId }) {
  *   submissionBlocked  — true while an atomic provider handoff owns the
  *                        chat; drafting stays available but send/mic-start do
  *                        not race the transition.
+ *   messageHistory     — visible owner-authored message text, oldest first.
  *
  * The bar does NOT own send state — ChatView's doSend handles that.
  * The bar's only job: composition + the Send/Stop/Mic resolution.
@@ -392,8 +405,13 @@ export default function ChatInputBar({
   leftButtons,
   rightButtons,
   attachTriggerRef,
+  messageHistory = [],
 }) {
   const fileInputRef = useRef(null)
+  const historyIndexRef = useRef(null)
+  const historyDraftRef = useRef('')
+  const historyCaretRef = useRef(null)
+  const historyProbeVersionRef = useRef(0)
   // Captures whether the textarea was focused at the moment the file
   // picker opened. Read by `handleFileSelect` to decide whether to
   // refocus the textarea after the picker closes — refocusing
@@ -425,6 +443,31 @@ export default function ChatInputBar({
     }
   }, [attachTriggerRef, inputRef])
 
+  function resetMessageHistory() {
+    historyProbeVersionRef.current += 1
+    historyIndexRef.current = null
+    historyDraftRef.current = ''
+    historyCaretRef.current = null
+  }
+
+  // Never carry a traversal or its saved draft into another chat. History
+  // list refreshes deliberately do not reset this: a queued message can move
+  // into the transcript while the owner is browsing, and that must not erase
+  // the draft that Down will restore.
+  useEffect(() => {
+    resetMessageHistory()
+  }, [chatId])
+
+  // History values arrive through the controlled composer boundary. Restore
+  // the caret after React commits that value without changing focus or scroll.
+  useLayoutEffect(() => {
+    const pending = historyCaretRef.current
+    const textarea = inputRef?.current
+    if (!pending || pending.value !== input || !textarea) return
+    try { textarea.setSelectionRange(pending.caret, pending.caret) } catch {}
+    historyCaretRef.current = null
+  }, [input, inputRef])
+
   const hasInput = !!input.trim()
   const hasUploading = pendingFiles?.some(c => c.status === 'uploading') ?? false
 
@@ -444,6 +487,7 @@ export default function ChatInputBar({
   }
 
   function handleTextareaChange(e) {
+    resetMessageHistory()
     if (listeningRef?.current) onManualVoiceEdit?.(e.target.value)
     onInputChange(e.target.value)
   }
@@ -458,6 +502,70 @@ export default function ChatInputBar({
   }
 
   function handleKeyDown(e) {
+    function applyHistoryMove(historyMove) {
+      historyIndexRef.current = historyMove.index
+      historyDraftRef.current = historyMove.draft
+      historyCaretRef.current = {
+        value: historyMove.value,
+        caret: historyMove.value.length,
+      }
+      if (listeningRef?.current) {
+        onManualVoiceEdit?.(historyMove.value)
+      }
+      onInputChange(historyMove.value)
+      // At the oldest entry another Up resolves to the same controlled value,
+      // so React may not commit a render for the layout effect above.
+      if (historyMove.value === input) {
+        try {
+          inputRef?.current?.setSelectionRange(
+            historyMove.value.length,
+            historyMove.value.length,
+          )
+        } catch {}
+        historyCaretRef.current = null
+      }
+    }
+
+    const historyMove = resolveComposerHistoryMove(e, {
+      history: messageHistory,
+      index: historyIndexRef.current,
+      draft: historyDraftRef.current,
+      value: input,
+    })
+    if (historyMove) {
+      e.preventDefault()
+      applyHistoryMove(historyMove)
+      return
+    }
+
+    const historyProbe = composerHistoryNativeProbe(e, {
+      history: messageHistory,
+      index: historyIndexRef.current,
+      value: input,
+    })
+    if (historyProbe) {
+      const probeVersion = ++historyProbeVersionRef.current
+      requestAnimationFrame(() => {
+        const textarea = inputRef?.current
+        if (
+          historyProbeVersionRef.current !== probeVersion
+          || !composerHistoryProbeReachedBoundary(historyProbe, textarea)
+        ) return
+        const deferredMove = resolveComposerHistoryMove({
+          key: 'ArrowUp',
+          target: textarea,
+        }, {
+          history: messageHistory,
+          index: historyIndexRef.current,
+          draft: historyDraftRef.current,
+          value: input,
+          nativeBoundary: true,
+        })
+        if (deferredMove) applyHistoryMove(deferredMove)
+      })
+      return
+    }
+
     const action = resolveComposerEnterAction(e, {
       hasInput,
       canSteer,
@@ -468,22 +576,34 @@ export default function ChatInputBar({
     if (!action) return
     e.preventDefault()
     if (action === 'steer') {
+      resetMessageHistory()
       onSteer()
       return
     }
     if (action === 'submit-steer') {
-      if (!submissionBlocked) onSubmitSteer(e)
+      if (!submissionBlocked) {
+        resetMessageHistory()
+        onSubmitSteer(e)
+      }
       return
     }
     if (action === 'submit') {
-      if (!submissionBlocked) onSubmit(e)
+      if (!submissionBlocked) {
+        resetMessageHistory()
+        onSubmit(e)
+      }
     }
+  }
+
+  function handleSubmit(e) {
+    resetMessageHistory()
+    onSubmit(e)
   }
 
   const hasFiles = !!pendingFiles?.length
 
   return (
-    <form className="chat__form" onSubmit={onSubmit}>
+    <form className="chat__form" onSubmit={handleSubmit}>
       <input
         type="file"
         multiple
@@ -534,7 +654,7 @@ export default function ChatInputBar({
               offline={offline}
               canSteer={canSteer}
               submissionBlocked={submissionBlocked}
-              onSubmit={onSubmit}
+              onSubmit={handleSubmit}
               onStop={onStop}
               onSteer={onSteer}
               onToggleVoice={onToggleVoice}

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -4,6 +4,7 @@ import {
   useEffect,
   useLayoutEffect,
   useCallback,
+  useMemo,
   useSyncExternalStore,
 } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
@@ -54,6 +55,7 @@ import { resolveStopResend } from './resolveStopResend.js'
 import { focusComposerElement, shouldApplyComposerFocusRequest } from './composerFocusPolicy.js'
 import { sameMessageList } from './chatMessageList.js'
 import { copyableMessageText, copyPlainText } from './messageCopy.js'
+import { composerHistoryFromMessages } from './composerHistory.js'
 import { sendFailureMessage } from './sendFailure.js'
 import { assistantStreamCoversMessage, chooseActiveAssistantDataKey, chooseActiveAssistantMirrorIndex, chooseActiveAssistantSurface, findTrailingAssistantPartialIndex, promoteAssistantStream, streamItemsHaveRenderableContent, streamItemsToAssistantPayload } from './streamPromotion.js'
 import {
@@ -315,6 +317,10 @@ export default function ChatView({
   // back via `commitMessages`, so any miss self-heals on next remount.
   const cached = queryClient.getQueryData(chatMessagesQueryKey(chatId))
   const [messages, setMessages] = useState(() => cached?.messages ?? [])
+  const messageHistory = useMemo(
+    () => composerHistoryFromMessages(messages),
+    [messages],
+  )
   const [offset, setOffset] = useState(() => cached?.offset ?? 0)
   const offsetRef = useRef(offset)
   offsetRef.current = offset
@@ -4059,6 +4065,7 @@ export default function ChatView({
           onAddFiles={handleComposerAddFiles}
           onRemoveFile={handleComposerRemoveFile}
           attachTriggerRef={attachTriggerRef}
+          messageHistory={messageHistory}
           leftButtons={
             <>
               <ComposerPopover

--- a/frontend/src/components/ChatView/__tests__/composerHistory.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerHistory.test.js
@@ -1,0 +1,140 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  composerHistoryNativeProbe,
+  composerHistoryProbeReachedBoundary,
+  composerHistoryFromMessages,
+  resolveComposerHistoryMove,
+} from '../composerHistory.js'
+
+function key(keyName, {
+  selectionStart = 0,
+  selectionEnd = selectionStart,
+  ...overrides
+} = {}) {
+  return {
+    key: keyName,
+    target: { selectionStart, selectionEnd },
+    ...overrides,
+  }
+}
+
+test('history contains only visible owner-authored text', () => {
+  assert.deepEqual(composerHistoryFromMessages([
+    { role: 'user', content: 'first' },
+    { role: 'assistant', content: 'reply' },
+    { role: 'user', content: 'hidden', hidden: true },
+    { role: 'user', content: 'continue', kind: 'auto_continuation' },
+    { role: 'user', content: '   ' },
+    {
+      role: 'user',
+      content: [
+        'review this',
+        '',
+        '[Files in this session:',
+        '- brief.txt → /data/chats/private/uploads/brief.txt (text/plain, 1 KB)]',
+      ].join('\n'),
+    },
+    { role: 'user', content: 'second' },
+  ]), ['first', 'review this', 'second'])
+})
+
+test('Up walks older sent messages and Down returns toward newer ones', () => {
+  const history = ['first', 'second', 'third']
+  let state = resolveComposerHistoryMove(key('ArrowUp'), {
+    history,
+    value: '',
+  })
+  assert.deepEqual(state, { value: 'third', index: 2, draft: '' })
+
+  state = resolveComposerHistoryMove(key('ArrowUp'), {
+    history,
+    ...state,
+  })
+  assert.deepEqual(state, { value: 'second', index: 1, draft: '' })
+
+  state = resolveComposerHistoryMove(key('ArrowDown'), {
+    history,
+    ...state,
+  })
+  assert.deepEqual(state, { value: 'third', index: 2, draft: '' })
+})
+
+test('Down past the newest message restores an exact multiline draft', () => {
+  const draft = 'unfinished first line\nand the second line'
+  const history = ['previous message']
+  const recalled = resolveComposerHistoryMove(key('ArrowUp', {
+    selectionStart: 5,
+  }), {
+    history,
+    value: draft,
+    nativeBoundary: true,
+  })
+  assert.deepEqual(recalled, {
+    value: 'previous message',
+    index: 0,
+    draft,
+  })
+
+  assert.deepEqual(resolveComposerHistoryMove(key('ArrowDown'), {
+    history,
+    ...recalled,
+  }), {
+    value: draft,
+    index: null,
+    draft: '',
+  })
+})
+
+test('non-empty drafts leave the first ArrowUp to native visual-line movement', () => {
+  const value = 'a long visually wrapped draft without source newlines'
+  assert.equal(resolveComposerHistoryMove(key('ArrowUp', {
+    selectionStart: value.length,
+  }), {
+    history: ['previous'],
+    value,
+  }), null)
+})
+
+test('a native probe recalls history only when ArrowUp leaves the caret unchanged', () => {
+  const target = {
+    value: 'visually wrapped draft',
+    selectionStart: 18,
+    selectionEnd: 18,
+  }
+  const probe = composerHistoryNativeProbe({
+    key: 'ArrowUp',
+    target,
+  }, {
+    history: ['previous'],
+    value: target.value,
+  })
+  assert.ok(probe)
+  assert.equal(composerHistoryProbeReachedBoundary(probe, target), true)
+
+  target.selectionStart = 6
+  target.selectionEnd = 6
+  assert.equal(composerHistoryProbeReachedBoundary(probe, target), false)
+})
+
+test('selection, modifier chords, and IME composition remain native', () => {
+  const options = { history: ['previous'], value: 'draft' }
+  assert.equal(resolveComposerHistoryMove(key('ArrowUp', {
+    selectionStart: 0,
+    selectionEnd: 2,
+  }), options), null)
+  assert.equal(resolveComposerHistoryMove(key('ArrowUp', {
+    ctrlKey: true,
+  }), options), null)
+  assert.equal(resolveComposerHistoryMove(key('ArrowUp', {
+    isComposing: true,
+  }), options), null)
+})
+
+test('Down does nothing until history browsing has started', () => {
+  assert.equal(resolveComposerHistoryMove(key('ArrowDown'), {
+    history: ['previous'],
+    value: 'draft',
+  }), null)
+})

--- a/frontend/src/components/ChatView/__tests__/composerVoiceEditing.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerVoiceEditing.test.js
@@ -7,6 +7,9 @@ const chatViewSrc = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'u
 const changeHandler = inputBarSrc.match(
   /function handleTextareaChange\(e\) \{[\s\S]*?\n  \}/,
 )?.[0] || ''
+const historyMoveHandler = inputBarSrc.match(
+  /function applyHistoryMove\(historyMove\) \{[\s\S]*?\n    \}/,
+)?.[0] || ''
 
 test('manual textarea changes remain enabled while voice input is active', () => {
   assert.doesNotMatch(changeHandler, /listeningRef\?\.current\) return/,
@@ -20,4 +23,15 @@ test('manual textarea changes remain enabled while voice input is active', () =>
 
 test('ChatView connects manual voice edits to the voice-input session', () => {
   assert.match(chatViewSrc, /onManualVoiceEdit=\{acceptManualEdit\}/)
+})
+
+test('sent-message recall rebases live dictation before changing the draft', () => {
+  assert.match(historyMoveHandler,
+    /if \(listeningRef\?\.current\) \{[\s\S]*?onManualVoiceEdit\?\.\(historyMove\.value\)/,
+    'history recall must take the same voice-session ownership as typed edits')
+  assert.ok(
+    historyMoveHandler.indexOf('onManualVoiceEdit?.(historyMove.value)')
+      < historyMoveHandler.indexOf('onInputChange(historyMove.value)'),
+    'the voice baseline must update before the controlled composer value',
+  )
 })

--- a/frontend/src/components/ChatView/composerHistory.js
+++ b/frontend/src/components/ChatView/composerHistory.js
@@ -1,0 +1,134 @@
+import { isOwnerUserMessage } from './chatRuntimeState.js'
+import { stripAugmentation } from './msgText.js'
+
+/** Visible owner-authored text, oldest to newest. Attachment-only rows cannot
+ * be reconstructed by the composer, so they are deliberately skipped. */
+export function composerHistoryFromMessages(messages) {
+  if (!Array.isArray(messages)) return []
+  return messages
+    .filter(isOwnerUserMessage)
+    .map(message => (
+      typeof message?.content === 'string'
+        ? stripAugmentation(message.content)
+        : ''
+    ))
+    .filter(content => content.trim().length > 0)
+}
+
+function hasModifier(event) {
+  return !!(
+    event?.altKey
+    || event?.ctrlKey
+    || event?.metaKey
+    || event?.shiftKey
+  )
+}
+
+function collapsedSelection(event) {
+  const start = Number(event?.target?.selectionStart)
+  const end = Number(event?.target?.selectionEnd)
+  if (!Number.isInteger(start) || start !== end) return null
+  return { start, end }
+}
+
+/**
+ * Snapshot a non-empty draft before letting the browser perform ArrowUp.
+ * Visual wrapping depends on the rendered textarea, so source newlines cannot
+ * tell us whether the caret actually has another displayed line above it.
+ */
+export function composerHistoryNativeProbe(event, {
+  history = [],
+  index = null,
+  value = '',
+} = {}) {
+  if (
+    event?.key !== 'ArrowUp'
+    || event.isComposing
+    || event.nativeEvent?.isComposing
+    || hasModifier(event)
+    || index != null
+    || !String(value).length
+    || !Array.isArray(history)
+    || history.length === 0
+  ) {
+    return null
+  }
+  const selection = collapsedSelection(event)
+  if (!selection) return null
+  return {
+    target: event.target,
+    value: String(value),
+    ...selection,
+  }
+}
+
+/** The native ArrowUp reached the visual top only when it left the caret
+ * unchanged. Value and target checks discard stale probes after an edit. */
+export function composerHistoryProbeReachedBoundary(probe, target) {
+  return !!(
+    probe
+    && target
+    && probe.target === target
+    && target.value === probe.value
+    && target.selectionStart === probe.start
+    && target.selectionEnd === probe.end
+  )
+}
+
+function mayStartHistory(event, value, nativeBoundary) {
+  if (!collapsedSelection(event)) return false
+  // Empty composers have no native caret movement to preserve. Non-empty
+  // drafts are eligible only after the browser proves ArrowUp did not move.
+  return !String(value).length || nativeBoundary
+}
+
+/**
+ * Resolve an Up/Down key into the next composer-history state.
+ *
+ * `index=null` means the owner is editing their current draft. The first Up
+ * snapshots that draft and recalls the newest sent message. Down from the
+ * newest history entry restores the snapshot and leaves history mode.
+ */
+export function resolveComposerHistoryMove(event, {
+  history = [],
+  index = null,
+  draft = '',
+  value = '',
+  nativeBoundary = false,
+} = {}) {
+  if (!event || (event.key !== 'ArrowUp' && event.key !== 'ArrowDown')) {
+    return null
+  }
+  if (event.isComposing || event.nativeEvent?.isComposing || hasModifier(event)) {
+    return null
+  }
+
+  const entries = Array.isArray(history) ? history : []
+  if (event.key === 'ArrowUp') {
+    if (entries.length === 0) return null
+    if (index == null && !mayStartHistory(event, value, nativeBoundary)) return null
+    const nextIndex = index == null
+      ? entries.length - 1
+      : Math.max(0, index - 1)
+    return {
+      value: entries[nextIndex],
+      index: nextIndex,
+      draft: index == null ? String(value) : draft,
+    }
+  }
+
+  if (index == null || entries.length === 0) return null
+  if (index >= entries.length - 1) {
+    return {
+      value: draft,
+      index: null,
+      draft: '',
+    }
+  }
+  const nextIndex = index + 1
+  return {
+    value: entries[nextIndex],
+    index: nextIndex,
+    draft,
+  }
+}


### PR DESCRIPTION
## Summary

- add Up/Down keyboard history for visible owner-authored chat messages
- preserve the unfinished draft when moving into and back out of history
- defer to native textarea navigation for wrapped lines, selections, modifier chords, and IME composition
- keep hidden file-session details out of recalled text and rebase live dictation before recall changes the draft

## Testing

- `npm test` (1,866 tests passed)
- `npm run build`
- verified in Chromium that ArrowUp moves through wrapped visual lines, recalls only after the visual top, and then stops at the oldest entry