### PR TITLE
Keep chat handoffs visible and trim active reloads

### DIFF
--- a/backend/app/chat_transcript.py
+++ b/backend/app/chat_transcript.py
@@ -19,3 +19,85 @@ def materialized_messages(chat) -> list[dict]:
   else:
     messages.append(live)
   return messages
+
+
+def project_messages_for_detail(
+  messages: list[dict],
+  *,
+  fetchable_tool_output_ids: set[str],
+  live_message: dict | None = None,
+) -> list[dict]:
+  """Remove non-live large-output excerpts that already have a sidecar.
+
+  Large tool output is stored once in ``tool_outputs`` and exposed lazily when
+  its disclosure opens.  The current live assistant message keeps its bounded
+  excerpts so the streaming surface stays self-contained.  Historical messages
+  do not need to repeat those excerpts merely because a newer turn is running.
+
+  Copy only messages and blocks that change.  This keeps the persisted JSON and
+  live-assistant snapshot immutable, and preserves the common small-chat path.
+  A legacy truncated block without a stable sidecar key stays inline.
+  """
+  projected: list[dict] | None = None
+  for message_index, message in enumerate(messages):
+    if message is live_message:
+      continue
+    blocks = message.get("blocks")
+    if not isinstance(blocks, list):
+      continue
+
+    next_blocks: list[dict] | None = None
+    for block_index, block in enumerate(blocks):
+      if not (
+        isinstance(block, dict)
+        and block.get("type") == "tool"
+        and block.get("output_truncated") is True
+        and isinstance(block.get("tool_use_id"), str)
+        and block["tool_use_id"]
+        and block["tool_use_id"] in fetchable_tool_output_ids
+        and "output" in block
+      ):
+        continue
+
+      if next_blocks is None:
+        next_blocks = list(blocks)
+      next_block = dict(block)
+      next_block.pop("output", None)
+      next_blocks[block_index] = next_block
+
+    if next_blocks is None:
+      continue
+    if projected is None:
+      projected = list(messages)
+    next_message = dict(message)
+    next_message["blocks"] = next_blocks
+    projected[message_index] = next_message
+
+  return projected if projected is not None else messages
+
+
+def historical_tool_output_ids(
+  messages: list[dict],
+  *,
+  live_message: dict | None = None,
+) -> set[str]:
+  """Return stable tool ids whose historical excerpts could be projected."""
+  ids: set[str] = set()
+  for message in messages:
+    if message is live_message:
+      continue
+    blocks = message.get("blocks")
+    if not isinstance(blocks, list):
+      continue
+    for block in blocks:
+      if not (
+        isinstance(block, dict)
+        and block.get("type") == "tool"
+        and block.get("output_truncated") is True
+        and isinstance(block.get("tool_use_id"), str)
+        and block["tool_use_id"]
+        and "output" in block
+      ):
+        continue
+      ids.add(block["tool_use_id"])
+  return ids

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -287,15 +287,29 @@ def _owner_chat_summary_projection(chat) -> dict:
 def _chat_detail_response(
   chat: models.Chat,
   *,
+  db: Session,
   limit: int = 20,
   before: int | None = None,
   expose_session: bool = True,
 ) -> dict:
   """Canonical paginated chat payload shared by create and detail reads."""
-  from app.chat_transcript import materialized_messages
+  from app.chat_transcript import (
+    historical_tool_output_ids,
+    materialized_messages,
+    project_messages_for_detail,
+  )
   from app.providers import effective_agent_settings
 
   all_msgs = materialized_messages(chat)
+  running = is_chat_running(chat.id)
+  live_snapshot = chat.live_assistant
+  live_message = (
+    all_msgs[-1]
+    if running
+    and all_msgs
+    and all_msgs[-1] is live_snapshot
+    else None
+  )
   total = len(all_msgs)
   if before is not None:
     start = max(0, before - limit)
@@ -303,6 +317,25 @@ def _chat_detail_response(
   else:
     start = max(0, total - limit)
     page = all_msgs[start:]
+  candidate_tool_ids = historical_tool_output_ids(
+    page,
+    live_message=live_message,
+  )
+  fetchable_tool_ids = (
+    {
+      row[0]
+      for row in db.query(models.ToolOutput.tool_use_id).filter(
+        models.ToolOutput.chat_id == chat.id,
+      ).all()
+    }
+    if candidate_tool_ids
+    else set()
+  )
+  page = project_messages_for_detail(
+    page,
+    fetchable_tool_output_ids=fetchable_tool_ids,
+    live_message=live_message,
+  )
 
   provider = chat.provider or "claude"
   pending_question = questions.get(chat.id)
@@ -310,13 +343,14 @@ def _chat_detail_response(
   return {
     "id": chat.id,
     "title": chat.title,
-    # Persisted blocks are already bounded at the write funnel; the detail
-    # serializer returns them as stored instead of doing work on every read.
+    # Settled large-output excerpts are omitted here because the disclosure
+    # already fetches them from their durable sidecar on demand. Live turns
+    # retain excerpts so the in-progress surface remains self-contained.
     "messages": page,
     "pending_messages": list(chat.pending_messages or []),
     "total": total,
     "offset": start,
-    "running": is_chat_running(chat.id),
+    "running": running,
     "pending_question_id": (
       pending_question.question_id if pending_question is not None else None
     ),
@@ -687,7 +721,7 @@ def create_chat(
   activity.log_event("chat_created", chat_id=chat.id)
   # Preserve the flat summary + messages fields existing callers consume while
   # carrying the exact detail contract under its own forward-compatible key.
-  detail = _chat_detail_response(chat)
+  detail = _chat_detail_response(chat, db=db)
   return {
     **_owner_chat_summary(chat),
     "messages": detail["messages"],
@@ -1057,6 +1091,7 @@ def get_chat(
   chat = get_active_chat_for_principal(db, chat_id, principal)
   return _chat_detail_response(
     chat,
+    db=db,
     limit=limit,
     before=before,
     # Provider thread ids are backend continuity state, not part of the

--- a/backend/tests/test_tool_output_stash.py
+++ b/backend/tests/test_tool_output_stash.py
@@ -9,7 +9,13 @@ import uuid
 from sqlalchemy import event as sqlalchemy_event
 
 from app import models
-from app.chat_writer import Barrier, StashToolOutput, get_writer
+from app.chat_transcript import project_messages_for_detail
+from app.chat_writer import (
+    Barrier,
+    ReplaceTranscript,
+    StashToolOutput,
+    get_writer,
+)
 from app.events import (
     TOOL_OUTPUT_INLINE_THRESHOLD,
     process_event,
@@ -167,6 +173,203 @@ def test_tool_output_by_id_endpoint_requires_owner(client, db):
     db.commit()
     r = client.get(f"/api/chats/{chat_id}/tool-output/tu_x")
     assert r.status_code == 401
+
+
+def test_settled_chat_detail_uses_lazy_sidecar_for_large_output(
+    client, auth, db,
+):
+    chat_id = str(uuid.uuid4())
+    db.add(models.Chat(id=chat_id, title="t", messages=[]))
+    db.commit()
+    block = {
+        "type": "tool",
+        "tool": "Bash",
+        "input": "long command",
+        "output": "bounded excerpt",
+        "status": "complete",
+        "tool_use_id": "tu_detail",
+        "output_truncated": True,
+        "output_full_len": 40000,
+        "output_exit_code": 0,
+    }
+    get_writer().submit(ReplaceTranscript(
+        chat_id=chat_id,
+        messages=[{"role": "assistant", "blocks": [block]}],
+    )).result(timeout=5)
+    get_writer().submit(StashToolOutput(
+        chat_id=chat_id,
+        tool_use_id="tu_detail",
+        output="complete output",
+    )).result(timeout=5)
+
+    detail = client.get(f"/api/chats/{chat_id}", headers=auth)
+
+    assert detail.status_code == 200
+    projected = detail.json()["messages"][0]["blocks"][0]
+    assert "output" not in projected
+    assert projected["tool_use_id"] == "tu_detail"
+    assert projected["output_truncated"] is True
+    preview = client.get(
+        f"/api/chats/{chat_id}/tool-output/tu_detail?preview=1",
+        headers=auth,
+    )
+    assert preview.status_code == 200
+    assert preview.text == "complete output"
+
+
+def test_running_chat_detail_strips_history_but_keeps_live_excerpt(
+    client, auth, db, monkeypatch,
+):
+    chat_id = str(uuid.uuid4())
+    historical_block = {
+        "type": "tool",
+        "output": "historical excerpt",
+        "tool_use_id": "tu_history",
+        "output_truncated": True,
+    }
+    live_block = {
+        "type": "tool",
+        "output": "live excerpt",
+        "tool_use_id": "tu_live",
+        "output_truncated": True,
+    }
+    db.add(models.Chat(
+        id=chat_id,
+        title="t",
+        messages=[
+            {"role": "assistant", "blocks": [historical_block], "ts": 1},
+            {"role": "user", "content": "continue", "ts": 2},
+        ],
+        live_assistant={"role": "assistant", "blocks": [live_block], "ts": 3},
+    ))
+    db.commit()
+    get_writer().submit(StashToolOutput(
+        chat_id=chat_id,
+        tool_use_id="tu_history",
+        output="complete historical output",
+    )).result(timeout=5)
+    monkeypatch.setattr("app.routes.chats.is_chat_running", lambda _: True)
+
+    detail = client.get(f"/api/chats/{chat_id}", headers=auth)
+
+    assert detail.status_code == 200
+    messages = detail.json()["messages"]
+    assert "output" not in messages[0]["blocks"][0]
+    assert messages[-1]["blocks"][0]["output"] == "live excerpt"
+
+
+def test_settled_detail_omits_fetchable_large_output_excerpt_without_mutation():
+    messages = [{
+        "role": "assistant",
+        "blocks": [{
+            "type": "tool",
+            "tool": "Bash",
+            "input": "long command",
+            "output": "bounded excerpt",
+            "status": "complete",
+            "tool_use_id": "tu_large",
+            "output_truncated": True,
+            "output_full_len": 50000,
+            "output_exit_code": 1,
+        }],
+    }]
+
+    projected = project_messages_for_detail(
+        messages,
+        fetchable_tool_output_ids={"tu_large"},
+    )
+
+    assert projected is not messages
+    assert projected[0] is not messages[0]
+    assert projected[0]["blocks"] is not messages[0]["blocks"]
+    block = projected[0]["blocks"][0]
+    assert "output" not in block
+    assert block["input"] == "long command"
+    assert block["tool_use_id"] == "tu_large"
+    assert block["output_truncated"] is True
+    assert block["output_full_len"] == 50000
+    assert block["output_exit_code"] == 1
+    assert messages[0]["blocks"][0]["output"] == "bounded excerpt"
+
+
+def test_detail_projection_keeps_only_live_and_unfetchable_outputs_inline():
+    messages = [
+        {
+            "role": "assistant",
+            "blocks": [
+                {
+                    "type": "tool",
+                    "output": "historical excerpt",
+                    "tool_use_id": "tu_history",
+                    "output_truncated": True,
+                },
+                {"type": "tool", "output": "small", "tool_use_id": "tu_small"},
+                {
+                    "type": "tool",
+                    "output": "legacy excerpt",
+                    "output_truncated": True,
+                },
+            ],
+        },
+        {
+            "role": "assistant",
+            "blocks": [{
+                "type": "tool",
+                "output": "live excerpt",
+                "tool_use_id": "tu_live",
+                "output_truncated": True,
+            }],
+        },
+    ]
+
+    projected = project_messages_for_detail(
+        messages,
+        fetchable_tool_output_ids={"tu_history"},
+        live_message=messages[-1],
+    )
+
+    assert projected is not messages
+    assert "output" not in projected[0]["blocks"][0]
+    assert projected[0]["blocks"][1]["output"] == "small"
+    assert projected[0]["blocks"][2]["output"] == "legacy excerpt"
+    assert projected[1] is messages[1]
+    assert projected[1]["blocks"][0]["output"] == "live excerpt"
+
+
+def test_detail_projection_with_only_a_live_message_is_identity_stable():
+    live = {
+        "role": "assistant",
+        "blocks": [{
+            "type": "tool",
+            "output": "live excerpt",
+            "tool_use_id": "tu_live",
+            "output_truncated": True,
+        }],
+    }
+    messages = [live]
+
+    assert project_messages_for_detail(
+        messages,
+        fetchable_tool_output_ids={"tu_live"},
+        live_message=live,
+    ) is messages
+
+
+def test_detail_projection_keeps_excerpt_when_sidecar_is_missing():
+    messages = [{
+        "role": "assistant",
+        "blocks": [{
+            "type": "tool",
+            "output": "still useful excerpt",
+            "tool_use_id": "tu_missing",
+            "output_truncated": True,
+        }],
+    }]
+
+    assert project_messages_for_detail(
+        messages,
+        fetchable_tool_output_ids=set(),
+    ) is messages
 
 
 # -- sink reduction + stash ----------------------------------------------

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -3363,7 +3363,11 @@ export default function ChatView({
     : null
   const showLoadError = loadError && messages.length === 0 && !loading && !turnActive
 
-  const displayReady = revealed || showEmpty || showLoadError
+  // The scroll safety cap may reveal an otherwise empty DOM while the initial
+  // request is still in flight. That protects a standalone ChatView from being
+  // hidden forever, but it is not a valid shell handoff: keep the outgoing chat
+  // painted until this chat has authoritative content, emptiness, or an error.
+  const displayReady = !loading && (revealed || showEmpty || showLoadError)
   useLayoutEffect(() => {
     if (displayReady) onDisplayReady?.(chatId)
   }, [chatId, displayReady, onDisplayReady])

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -1214,10 +1214,10 @@ export default function Shell() {
   const handlePaneChatDisplayReady = useCallback((paneId, readyChatId) => {
     const id = String(readyChatId)
     const paneKey = String(paneId)
-    const pane = workspaceStateRef.current.ws.panes[paneId]
-      || workspaceStateRef.current.ws.panes[paneKey]
     // Ignore a late ready signal from staging B after rapid navigation reached C.
-    if (pane?.activeTabKey !== `chat:${id}`) return
+    // Surface owners include both real builder panes and the single world's
+    // synthetic slot, so resolve the selected key through their shared boundary.
+    if (paneModel.activeKeyForOwner(workspaceStateRef.current.ws, paneKey) !== `chat:${id}`) return
     setPresentedChatByPane(prev => {
       if (String(prev.get(paneKey) ?? '') === id) return prev
       const next = new Map(prev)

--- a/frontend/src/components/Shell/__tests__/chatHandoff.test.js
+++ b/frontend/src/components/Shell/__tests__/chatHandoff.test.js
@@ -13,8 +13,11 @@ function ruleBody(selector) {
 }
 
 test('chat display readiness preserves the existing transcript reveal gate', () => {
-  assert.match(chatView, /const displayReady = revealed \|\| showEmpty \|\| showLoadError/,
-    'a transcript may hand off only after useScrollMode reveals it')
+  assert.match(
+    chatView,
+    /const displayReady = !loading && \(revealed \|\| showEmpty \|\| showLoadError\)/,
+    'a transcript may hand off only after its initial load and reveal gate settle',
+  )
   assert.match(chatView, /useLayoutEffect\(\(\) => \{[\s\S]*onDisplayReady\?\.\(chatId\)/,
     'readiness must reach Shell before the browser paints the hidden transcript')
   assert.match(chatView,
@@ -46,8 +49,11 @@ test('each pane holds one outgoing chat over one staging chat', () => {
     'the transition keeps only the last painted chat in its pane')
   assert.match(shell, /role: transitioning \? 'staging' : 'active'/,
     'the destination stages only while a different painted chat exists')
-  assert.match(shell, /pane\?\.activeTabKey !== `chat:\$\{id\}`/,
-    'a stale ready signal from rapid navigation must not complete the handoff')
+  assert.match(
+    shell,
+    /paneModel\.activeKeyForOwner\(workspaceStateRef\.current\.ws, paneKey\) !== `chat:\$\{id\}`/,
+    'late readiness must be validated against either a real pane or the synthetic single owner',
+  )
   // A held/staging chat is inert (the takeover is PAINTING OR not the active role);
   // the condition now also folds in a leaving pane during the exit beat (INV 9), so
   // match the leading clause rather than the exact full expression. The takeover

--- a/frontend/src/components/Shell/__tests__/singleScreenSlot.test.js
+++ b/frontend/src/components/Shell/__tests__/singleScreenSlot.test.js
@@ -78,6 +78,20 @@ test('singleScreenKey matches tabModel.tabKey shape', () => {
   assert.equal(paneModel.singleScreenKey({ ...base, singleScreen: null }), null, 'empty slot → null')
 })
 
+test('activeKeyForOwner resolves real panes and the synthetic single owner', () => {
+  const ws = {
+    ...tiledBuilder(),
+    singleScreen: { kind: 'chat', id: 'single-chat' },
+  }
+  const chatPane = paneModel.paneOf(ws, 'chat:5')
+  assert.equal(paneModel.activeKeyForOwner(ws, chatPane.id), 'chat:5')
+  assert.equal(
+    paneModel.activeKeyForOwner(ws, paneModel.SINGLE_SLOT_PANE),
+    'chat:single-chat',
+  )
+  assert.equal(paneModel.activeKeyForOwner(ws, 'missing-pane'), null)
+})
+
 // ── Seed-once on first builder→single switch ─────────────────────────────────
 
 test('SET_VIEW_MODE to single seeds the slot from the focused item, once', () => {

--- a/frontend/src/components/Shell/paneModel.js
+++ b/frontend/src/components/Shell/paneModel.js
@@ -510,6 +510,15 @@ export function singleScreenKey(ws) {
   return null
 }
 
+// The content currently selected by a mounted surface owner. Real builder
+// panes select through activeTabKey; the single world's stable synthetic owner
+// selects through its independent slot. Callers that bind lifecycle events to
+// an owner use this instead of assuming every owner exists in ws.panes.
+export function activeKeyForOwner(ws, ownerPaneId) {
+  if (String(ownerPaneId) === SINGLE_SLOT_PANE) return singleScreenKey(ws)
+  return ws.panes?.[ownerPaneId]?.activeTabKey ?? null
+}
+
 // Set the single-screen slot to a concrete item (or null for the empty/home
 // screen). Sanitized like the parse path — an invalid item collapses to null,
 // never to builder focus. Same reference on a no-op so React can bail. This is


### PR DESCRIPTION
## Summary

- Keep the outgoing conversation painted while a single-screen chat loads.
- Resolve selected content consistently for both Builder panes and the single-screen slot.
- Prevent the layout safety timer from completing a handoff before the initial chat load settles.
- Omit fetchable historical tool excerpts from chat detail responses while retaining the current live output and the inline fallback when a sidecar is unavailable.

## Testing

- `npm test` (1,870 passing frontend tests)
- `npm run build`
- `python3 -m pytest -q backend/tests/test_tool_output_stash.py backend/tests/test_chat_live_assistant.py backend/tests/test_chats.py backend/tests/test_chat_lifecycle.py backend/tests/test_chat_runs_lifecycle.py` (48 passing backend tests)
- Rendered a single-slot switch with the incoming chat fetch delayed for three seconds; the outgoing transcript stayed visible past the safety threshold and swapped only after populated content arrived.
- Measured representative active, tool-heavy chat responses at 37–45% smaller after settled excerpts moved to their existing lazy fetch path.