### PR TITLE
Improve chat typing responsiveness in long sessions

### DIFF
--- a/frontend/src/components/ChatView/ActiveAssistantSurface.jsx
+++ b/frontend/src/components/ChatView/ActiveAssistantSurface.jsx
@@ -1,0 +1,71 @@
+/* ActiveAssistantSurface isolates the live answer from composer-only renders. */
+
+import { memo, useMemo } from 'react'
+import StreamingMessage from './StreamingMessage.jsx'
+import { streamItemsToAssistantPayload } from './streamPromotion.js'
+
+
+/**
+ * The active answer is often the most expensive subtree in the shell: a long
+ * turn can contain dozens of tool, thinking, text, and question blocks.
+ * Composer text belongs to a separate interaction, so a keystroke must not
+ * rebuild that tree while the stream inputs themselves are unchanged.
+ *
+ * React.memo supplies the component boundary. The memoized payload also keeps
+ * MsgContent's existing identity comparison effective when some other
+ * ChatView-only state changes without advancing the stream.
+ */
+function ActiveAssistantSurface({
+  activeMirrorMsg,
+  useDbActivePayload,
+  hasLivePayload,
+  streamItems,
+  dataKey,
+  chatId,
+  onAnswer,
+  onResume,
+  onInternalNav,
+  autoResumeEnabled,
+  autoResumeAvailable,
+  autoResumeSaving,
+  autoResumeError,
+  onAutoResumeChange,
+  submissionBlocked,
+  liveQuestionId,
+  isStreaming,
+}) {
+  const msg = useMemo(() => {
+    if (useDbActivePayload) return activeMirrorMsg
+    if (!hasLivePayload) return null
+    return {
+      ...(activeMirrorMsg || {}),
+      role: 'assistant',
+      // Live rendering keeps running tool state and thinking clock anchors;
+      // final promotion converts the same items with finalize=true.
+      ...streamItemsToAssistantPayload(streamItems, { finalize: false }),
+    }
+  }, [activeMirrorMsg, hasLivePayload, streamItems, useDbActivePayload])
+
+  if (!msg) return null
+
+  return (
+    <StreamingMessage
+      msg={msg}
+      dataKey={dataKey}
+      chatId={chatId}
+      onAnswer={onAnswer}
+      onResume={onResume}
+      onInternalNav={onInternalNav}
+      autoResumeEnabled={autoResumeEnabled}
+      autoResumeAvailable={autoResumeAvailable}
+      autoResumeSaving={autoResumeSaving}
+      autoResumeError={autoResumeError}
+      onAutoResumeChange={onAutoResumeChange}
+      submissionBlocked={submissionBlocked}
+      liveQuestionId={liveQuestionId}
+      isStreaming={isStreaming}
+    />
+  )
+}
+
+export default memo(ActiveAssistantSurface)

--- a/frontend/src/components/ChatView/ChatInputBar.jsx
+++ b/frontend/src/components/ChatView/ChatInputBar.jsx
@@ -76,6 +76,10 @@ import { BASE } from '../../api/client.js'
 import { mediaTokenParam } from '../../api/mediaToken.js'
 import { resolveComposerEnterAction } from './composerShortcuts.js'
 import { filePasteNeedsDefaultPrevented, pastedFiles } from './pasteUpload.js'
+import {
+  composerUsesNativeSizing,
+  syncComposerTallClass,
+} from './composerTextareaSizing.js'
 
 
 // Detect touch-primary once (same heuristic ChatView uses).
@@ -424,6 +428,31 @@ export default function ChatInputBar({
       if (attachTriggerRef.current) attachTriggerRef.current = null
     }
   }, [attachTriggerRef, inputRef])
+
+  // Modern browsers size the textarea from CSS (`field-sizing: content`).
+  // Observe the resulting box rather than measuring scrollHeight on every
+  // character; the pill alignment changes only when the textarea really
+  // crosses from one visual line to multiple lines.
+  useLayoutEffect(() => {
+    const textarea = inputRef?.current
+    if (
+      !textarea
+      || !composerUsesNativeSizing()
+      || typeof ResizeObserver === 'undefined'
+    ) return undefined
+    const observer = new ResizeObserver(entries => {
+      const entry = entries[0]
+      const borderSize = Array.isArray(entry?.borderBoxSize)
+        ? entry.borderBoxSize[0]?.blockSize
+        : entry?.borderBoxSize?.blockSize
+      syncComposerTallClass(
+        textarea,
+        borderSize ?? entry?.target?.getBoundingClientRect?.().height,
+      )
+    })
+    observer.observe(textarea)
+    return () => observer.disconnect()
+  }, [chatId, inputRef])
 
   const hasInput = !!input.trim()
   const hasUploading = pendingFiles?.some(c => c.status === 'uploading') ?? false

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -1781,6 +1781,18 @@
   -webkit-tap-highlight-color: transparent;
 }
 
+/* Let current browsers own textarea growth. The JavaScript fallback remains
+   for older Safari/Firefox builds that do not support field-sizing. This
+   removes the per-character height:auto → scrollHeight forced-layout cycle;
+   max-height and overflow preserve the existing 280px cap. */
+@supports (field-sizing: content) {
+  .chat__input {
+    field-sizing: content;
+    height: auto;
+    min-width: 0;
+  }
+}
+
 .chat__input::placeholder { color: var(--muted); /* CONTRACT: low-contrast text on opaque fill */ }
 .chat__input:disabled { opacity: 0.5; }
 

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -5,6 +5,7 @@ import {
   useLayoutEffect,
   useCallback,
   useSyncExternalStore,
+  useMemo,
 } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import Check from 'lucide-react/dist/esm/icons/check.mjs'
@@ -26,7 +27,7 @@ import AgentContextInspector from './AgentContextInspector.jsx'
 import ChatSummaryViewer from './ChatSummaryViewer.jsx'
 import ComposerPopover from './ComposerPopover.jsx'
 import ConnectionStatus from './ConnectionStatus.jsx'
-import StreamingMessage from './StreamingMessage.jsx'
+import ActiveAssistantSurface from './ActiveAssistantSurface.jsx'
 import QueuedMessages from './QueuedMessages.jsx'
 import MsgContent from './MsgContent.jsx'
 import ActivityLineHeader from './ActivityLineHeader.jsx'
@@ -55,7 +56,8 @@ import { focusComposerElement, shouldApplyComposerFocusRequest } from './compose
 import { sameMessageList } from './chatMessageList.js'
 import { copyableMessageText, copyPlainText } from './messageCopy.js'
 import { sendFailureMessage } from './sendFailure.js'
-import { assistantStreamCoversMessage, chooseActiveAssistantDataKey, chooseActiveAssistantMirrorIndex, chooseActiveAssistantSurface, findTrailingAssistantPartialIndex, promoteAssistantStream, streamItemsHaveRenderableContent, streamItemsToAssistantPayload } from './streamPromotion.js'
+import { assistantStreamCoversMessage, chooseActiveAssistantDataKey, findTrailingAssistantPartialIndex, promoteAssistantStream, streamItemsHaveRenderableContent } from './streamPromotion.js'
+import { deriveActiveAssistantSelection } from './activeAssistantSelection.js'
 import {
   answerKeepsCurrentTurn,
   builtAppPulseDecision,
@@ -1459,6 +1461,7 @@ export default function ChatView({
   })
 
   function clearFailedAttempt() {
+    if (!failedSendAttemptRef.current) return
     failedSendAttemptRef.current = null
     clearFailedSendAttempt(chatId)
   }
@@ -1632,14 +1635,6 @@ export default function ChatView({
       promotedRef.current = false
     }
   }
-
-  // Persist draft so it survives leaving and re-entering the chat.
-  // This remains as a safety net for programmatic input changes (restores,
-  // voice transcription, send cleanup). Direct owner edits are saved
-  // synchronously in handleComposerInputChange above.
-  useEffect(() => {
-    persistComposerDraft(chatId, input, draftAttachmentsRef.current)
-  }, [input, chatId])
 
   // Text changes through input, restores, voice, send cleanup, and
   // authoritative foreground reconciliation. Reconcile after every committed
@@ -3371,66 +3366,29 @@ export default function ChatView({
     isOwnerUserMessage(m) ? i : acc
   ), -1)
   // The captured bridge partial enters the active row before catch-up emits a
-  // single item. That is the load-bearing part of Lever 1: when SSE becomes the
-  // selected source, React updates MsgContent props instead of replacing the
-  // DB row with a different renderer subtree.
-  const bridgeMsgIdx = turnActive
-    ? bridgeHook.findBridgeIndex(messages)
-    : -1
-  const trailingAssistantPartialIdx = turnActive
-    ? findTrailingAssistantPartialIndex(messages)
-    : -1
-  const hasLiveAssistantPayload = turnActive && streamItems.length > 0
-  const bridgeMsg = bridgeMsgIdx >= 0 ? messages[bridgeMsgIdx] : null
-  const bridgeFollowedByVisibleUser = bridgeMsgIdx >= 0 && messages
-    .slice(bridgeMsgIdx + 1)
-    .some(isOwnerUserMessage)
-  const trailingAssistantPartialMsg = trailingAssistantPartialIdx >= 0
-    ? messages[trailingAssistantPartialIdx]
-    : null
-  // Select DATA, never a component tree. A mount-time bridge is only
-  // authoritative while the live payload still proves it is the same answer.
-  // A stale in-memory cache can otherwise nominate the completed PREVIOUS
-  // answer just as a new turn starts, suppressing that whole reply and showing
-  // only the question card that happened to be cached. If the bridge and live
-  // surfaces are unrelated, fall through to the real trailing DB partial.
-  const bridgeAssistantSurface = chooseActiveAssistantSurface(bridgeMsg, streamItems)
-  const trailingAssistantSurface = chooseActiveAssistantSurface(
-    trailingAssistantPartialMsg,
-    streamItems,
-  )
-  const activeMirrorMsgIdx = chooseActiveAssistantMirrorIndex({
+  // single item. Source comparison can walk and normalize the complete live
+  // block list several times, so memoize it on transcript/stream ownership:
+  // composer input cannot change which assistant source owns this row.
+  const {
+    activeMirrorMsg,
+    activeMirrorMsgIdx,
     bridgeMsgIdx,
+    hasLiveAssistantPayload,
+    showActiveAssistantSurface,
     trailingAssistantPartialIdx,
-    bridgeFollowedByVisibleUser,
-    hasLivePayload: hasLiveAssistantPayload,
-    bridgeSurface: bridgeAssistantSurface,
-    surface: trailingAssistantSurface,
-  })
-  const activeMirrorMsg = activeMirrorMsgIdx >= 0 ? messages[activeMirrorMsgIdx] : null
-  const activeAssistantSurface = activeMirrorMsgIdx === bridgeMsgIdx
-    ? bridgeAssistantSurface
-    : (activeMirrorMsgIdx === trailingAssistantPartialIdx
-        ? trailingAssistantSurface
-        : { hideMessage: false, suppressStream: false })
-  const useDbActivePayload = !!(
-    activeMirrorMsg
-    && (!hasLiveAssistantPayload || activeAssistantSurface.suppressStream)
-  )
-  const activeAssistantMsg = useDbActivePayload
-    ? activeMirrorMsg
-    : (hasLiveAssistantPayload
-        ? {
-            ...(activeMirrorMsg || {}),
-            role: 'assistant',
-            // Live rendering keeps running tool state and thinking clock
-            // anchors; final promotion uses the converter's default finalize
-            // mode and still seals running tools as done.
-            ...streamItemsToAssistantPayload(streamItems, { finalize: false }),
-          }
-        : null)
-  const showActiveAssistantSurface = !!activeAssistantMsg
-  const activeAssistantIsStreaming = !!(activeAssistantMsg && !useDbActivePayload)
+    useDbActivePayload,
+    activeAssistantIsStreaming,
+  } = useMemo(() => deriveActiveAssistantSelection({
+    turnActive,
+    messages,
+    streamItems,
+    findBridgeIndex: bridgeHook.findBridgeIndex,
+  }), [
+    bridgeMountInputs,
+    messages,
+    streamItems,
+    turnActive,
+  ])
 
   // ── Sticky "needs your answer" affordance ──────────────────────────
   // A pending AskUserQuestion freezes the turn until the user answers,
@@ -3898,9 +3856,12 @@ export default function ChatView({
           )})}
 
           {showActiveAssistantSurface && (
-            <StreamingMessage
+            <ActiveAssistantSurface
               key={streamingDataKey}
-              msg={activeAssistantMsg}
+              activeMirrorMsg={activeMirrorMsg}
+              useDbActivePayload={useDbActivePayload}
+              hasLivePayload={hasLiveAssistantPayload}
+              streamItems={streamItems}
               dataKey={streamingDataKey}
               chatId={chatId}
               onAnswer={doSendSilent}

--- a/frontend/src/components/ChatView/__tests__/activeAssistantSelection.test.js
+++ b/frontend/src/components/ChatView/__tests__/activeAssistantSelection.test.js
@@ -1,0 +1,30 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { deriveActiveAssistantSelection } from '../activeAssistantSelection.js'
+
+
+test('an idle chat exposes no active assistant surface', () => {
+  const result = deriveActiveAssistantSelection({
+    turnActive: false,
+    messages: [],
+    streamItems: [],
+    findBridgeIndex: () => {
+      throw new Error('idle selection must not probe a bridge')
+    },
+  })
+  assert.equal(result.showActiveAssistantSurface, false)
+  assert.equal(result.activeAssistantIsStreaming, false)
+  assert.equal(result.activeMirrorMsg, null)
+})
+
+test('a live-only answer selects the streaming surface', () => {
+  const result = deriveActiveAssistantSelection({
+    turnActive: true,
+    messages: [{ role: 'user', content: 'hello', ts: 1 }],
+    streamItems: [{ type: 'text', content: 'hi' }],
+    findBridgeIndex: () => -1,
+  })
+  assert.equal(result.showActiveAssistantSurface, true)
+  assert.equal(result.activeAssistantIsStreaming, true)
+  assert.equal(result.useDbActivePayload, false)
+})

--- a/frontend/src/components/ChatView/__tests__/composerRenderIsolation.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerRenderIsolation.test.js
@@ -1,0 +1,34 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+
+const chatView = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8')
+const activeSurface = readFileSync(
+  new URL('../ActiveAssistantSurface.jsx', import.meta.url),
+  'utf8',
+)
+
+test('composer edits cannot recreate the active assistant payload', () => {
+  assert.match(activeSurface, /export default memo\(ActiveAssistantSurface\)/)
+  assert.match(activeSurface, /const msg = useMemo\(/)
+  assert.match(activeSurface, /streamItemsToAssistantPayload\(streamItems/)
+  assert.match(chatView, /<ActiveAssistantSurface/)
+  assert.match(
+    chatView,
+    /useMemo\(\(\) => deriveActiveAssistantSelection\(/,
+  )
+  assert.doesNotMatch(chatView, /const activeAssistantMsg\s*=/)
+})
+
+test('draft persistence has one state-boundary owner', () => {
+  const setter = chatView.match(
+    /function setComposerInput\(nextInput\) \{[\s\S]*?\n  \}/,
+  )?.[0] || ''
+  assert.match(setter, /persistComposerDraft\(/)
+  assert.match(setter, /setInputState\(/)
+  assert.doesNotMatch(
+    chatView,
+    /useEffect\(\(\) => \{\s*persistComposerDraft\(chatId, input,/,
+  )
+})

--- a/frontend/src/components/ChatView/__tests__/composerTextareaSizing.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerTextareaSizing.test.js
@@ -3,8 +3,10 @@ import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 
 import {
+  composerUsesNativeSizing,
   resetComposerTextarea,
   resizeComposerTextarea,
+  syncComposerTallClass,
 } from '../composerTextareaSizing.js'
 
 function textareaStub({ value = '', scrollHeight = 31, tall = false } = {}) {
@@ -73,6 +75,24 @@ test('reset collapses immediately before React commits the empty value', () => {
   assert.equal(pill.classList.contains('chat__pill--tall'), false)
 })
 
+test('native content sizing is capability-gated without browser sniffing', () => {
+  assert.equal(composerUsesNativeSizing({
+    supports: (property, value) => (
+      property === 'field-sizing' && value === 'content'
+    ),
+  }), true)
+  assert.equal(composerUsesNativeSizing({ supports: () => false }), false)
+  assert.equal(composerUsesNativeSizing(null), false)
+})
+
+test('native resize observation owns only the tall alignment class', () => {
+  const { textarea, pill } = textareaStub()
+  assert.equal(syncComposerTallClass(textarea, 31), 31)
+  assert.equal(pill.classList.contains('chat__pill--tall'), false)
+  assert.equal(syncComposerTallClass(textarea, 55), 55)
+  assert.equal(pill.classList.contains('chat__pill--tall'), true)
+})
+
 test('ChatView reconciles textarea geometry on value commits and foreground return', () => {
   const source = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8')
   const inputBarSource = readFileSync(new URL('../ChatInputBar.jsx', import.meta.url), 'utf8')
@@ -80,7 +100,8 @@ test('ChatView reconciles textarea geometry on value commits and foreground retu
   assert.match(source, /useLayoutEffect\(\(\) => \{[\s\S]*resizeComposerTextarea\(el, input\)[\s\S]*\}, \[chatId, hidden, input\]\)/)
   assert.match(source, /const reconcileForegroundGeometry = \(\) => \{[\s\S]*resizeComposerTextarea\(inputRef\.current, inputValueRef\.current\)[\s\S]*applySoon\(\)/)
   assert.match(source, /window\.addEventListener\('pageshow', reconcileForegroundGeometry\)/)
-  assert.doesNotMatch(inputBarSource, /resizeComposerTextarea/)
+  assert.match(inputBarSource, /new ResizeObserver\(/)
+  assert.match(inputBarSource, /syncComposerTallClass\(/)
   assert.doesNotMatch(voiceSource, /resizeComposerTextarea/)
   const resets = source.match(/resetComposerTextarea\(inputRef\.current\)/g) || []
   assert.equal(resets.length, 2, 'both queued and immediate sends collapse stale textarea geometry')

--- a/frontend/src/components/ChatView/__tests__/streamingRobustness.test.js
+++ b/frontend/src/components/ChatView/__tests__/streamingRobustness.test.js
@@ -16,6 +16,10 @@ const chatViewSource = readFileSync(new URL('../ChatView.jsx', import.meta.url),
 const streamHookSource = readFileSync(new URL('../useStreamConnection.js', import.meta.url), 'utf8')
 const msgContentSource = readFileSync(new URL('../MsgContent.jsx', import.meta.url), 'utf8')
 const streamingMessageSource = readFileSync(new URL('../StreamingMessage.jsx', import.meta.url), 'utf8')
+const activeAssistantSource = readFileSync(
+  new URL('../ActiveAssistantSurface.jsx', import.meta.url),
+  'utf8',
+)
 const blockRendererSource = readFileSync(new URL('../markdown/BlockRenderer.jsx', import.meta.url), 'utf8')
 
 test('active DB and live sources share one row shell and one block renderer', () => {
@@ -23,7 +27,7 @@ test('active DB and live sources share one row shell and one block renderer', ()
     'the stable active <li> must always delegate its selected payload to MsgContent')
   assert.doesNotMatch(streamingMessageSource, /ToolBlock|QuestionCard|ErrorCard|ProgressiveMarkdown/,
     'StreamingMessage must not mount a competing assistant block tree')
-  assert.match(chatViewSource, /streamItemsToAssistantPayload\(streamItems, \{ finalize: false \}\)/,
+  assert.match(activeAssistantSource, /streamItemsToAssistantPayload\(streamItems, \{ finalize: false \}\)/,
     'the live source must feed the same DB-shaped payload consumed by MsgContent')
   assert.match(chatViewSource, /key=\{streamingDataKey\}[\s\S]*dataKey=\{streamingDataKey\}/,
     'the active row key and scroll-anchor data-key must remain stable across source selection')

--- a/frontend/src/components/ChatView/activeAssistantSelection.js
+++ b/frontend/src/components/ChatView/activeAssistantSelection.js
@@ -1,0 +1,78 @@
+/* Active-assistant selection derives the stable DB/live rendering surface. */
+
+import { isOwnerUserMessage } from './chatRuntimeState.js'
+import {
+  chooseActiveAssistantMirrorIndex,
+  chooseActiveAssistantSurface,
+  findTrailingAssistantPartialIndex,
+} from './streamPromotion.js'
+
+
+/**
+ * Source selection can compare the complete live block list with persisted
+ * partials several times. Keep that work behind one memoizable pure boundary;
+ * draft text has no bearing on which assistant source owns the active row.
+ */
+export function deriveActiveAssistantSelection({
+  turnActive,
+  messages,
+  streamItems,
+  findBridgeIndex,
+}) {
+  const bridgeMsgIdx = turnActive ? findBridgeIndex(messages) : -1
+  const trailingAssistantPartialIdx = turnActive
+    ? findTrailingAssistantPartialIndex(messages)
+    : -1
+  const hasLiveAssistantPayload = turnActive && streamItems.length > 0
+  const bridgeMsg = bridgeMsgIdx >= 0 ? messages[bridgeMsgIdx] : null
+  const bridgeFollowedByVisibleUser = bridgeMsgIdx >= 0 && messages
+    .slice(bridgeMsgIdx + 1)
+    .some(isOwnerUserMessage)
+  const trailingAssistantPartialMsg = trailingAssistantPartialIdx >= 0
+    ? messages[trailingAssistantPartialIdx]
+    : null
+  const bridgeAssistantSurface = chooseActiveAssistantSurface(
+    bridgeMsg,
+    streamItems,
+  )
+  const trailingAssistantSurface = chooseActiveAssistantSurface(
+    trailingAssistantPartialMsg,
+    streamItems,
+  )
+  const activeMirrorMsgIdx = chooseActiveAssistantMirrorIndex({
+    bridgeMsgIdx,
+    trailingAssistantPartialIdx,
+    bridgeFollowedByVisibleUser,
+    hasLivePayload: hasLiveAssistantPayload,
+    bridgeSurface: bridgeAssistantSurface,
+    surface: trailingAssistantSurface,
+  })
+  const activeMirrorMsg = activeMirrorMsgIdx >= 0
+    ? messages[activeMirrorMsgIdx]
+    : null
+  const selectedSurface = activeMirrorMsgIdx === bridgeMsgIdx
+    ? bridgeAssistantSurface
+    : (activeMirrorMsgIdx === trailingAssistantPartialIdx
+        ? trailingAssistantSurface
+        : { hideMessage: false, suppressStream: false })
+  const useDbActivePayload = !!(
+    activeMirrorMsg
+    && (!hasLiveAssistantPayload || selectedSurface.suppressStream)
+  )
+  const showActiveAssistantSurface = !!(
+    useDbActivePayload ? activeMirrorMsg : hasLiveAssistantPayload
+  )
+
+  return {
+    activeMirrorMsg,
+    activeMirrorMsgIdx,
+    bridgeMsgIdx,
+    hasLiveAssistantPayload,
+    showActiveAssistantSurface,
+    trailingAssistantPartialIdx,
+    useDbActivePayload,
+    activeAssistantIsStreaming: !!(
+      showActiveAssistantSurface && !useDbActivePayload
+    ),
+  }
+}

--- a/frontend/src/components/ChatView/composerTextareaSizing.js
+++ b/frontend/src/components/ChatView/composerTextareaSizing.js
@@ -1,8 +1,34 @@
 export const COMPOSER_TEXTAREA_MAX_HEIGHT = 280
 export const COMPOSER_TEXTAREA_TALL_THRESHOLD = 45
+let nativeSizingSupport
 
 function composerPill(textarea) {
   return textarea?.closest?.('.chat__pill') || null
+}
+
+export function composerUsesNativeSizing(css = globalThis.CSS) {
+  // An injected CSS object keeps the capability boundary directly testable.
+  // Cache only the real browser verdict; tests and non-browser runtimes should
+  // not freeze a synthetic result for later calls.
+  if (css !== globalThis.CSS) {
+    return !!css?.supports?.('field-sizing', 'content')
+  }
+  if (nativeSizingSupport === undefined) {
+    nativeSizingSupport = !!css?.supports?.('field-sizing', 'content')
+  }
+  return nativeSizingSupport
+}
+
+export function syncComposerTallClass(
+  textarea,
+  height = textarea?.offsetHeight,
+) {
+  const measured = Number(height) || 0
+  composerPill(textarea)?.classList?.toggle(
+    'chat__pill--tall',
+    measured > COMPOSER_TEXTAREA_TALL_THRESHOLD,
+  )
+  return measured
 }
 
 /**
@@ -15,6 +41,12 @@ function composerPill(textarea) {
  */
 export function resizeComposerTextarea(textarea, value = textarea?.value) {
   if (!textarea?.style) return 0
+  // Current browsers can own content sizing entirely in CSS. Avoid touching
+  // height or reading scrollHeight on the keystroke path: that read forces a
+  // document layout, whose cost grows with every mounted drawer/transcript
+  // row. ResizeObserver in ChatInputBar updates the tall alignment only when
+  // the browser reports an actual size change.
+  if (composerUsesNativeSizing()) return 0
 
   // Empty is a semantic one-line state, not a geometry question. During a
   // multi-pane mount / foreground transition Chromium can briefly report an
@@ -36,16 +68,13 @@ export function resizeComposerTextarea(textarea, value = textarea?.value) {
 
   const height = Math.min(measured, COMPOSER_TEXTAREA_MAX_HEIGHT)
   textarea.style.height = `${height}px`
-  composerPill(textarea)?.classList?.toggle(
-    'chat__pill--tall',
-    height > COMPOSER_TEXTAREA_TALL_THRESHOLD,
-  )
+  syncComposerTallClass(textarea, height)
   return height
 }
 
 /** Collapse immediately while React is still committing an empty value. */
 export function resetComposerTextarea(textarea) {
   if (!textarea?.style) return
-  textarea.style.height = 'auto'
+  textarea.style.height = composerUsesNativeSizing() ? '' : 'auto'
   composerPill(textarea)?.classList?.remove?.('chat__pill--tall')
 }

--- a/frontend/src/components/Drawer/Drawer.css
+++ b/frontend/src/components/Drawer/Drawer.css
@@ -263,6 +263,13 @@
   scroll-padding-bottom: 16px;
 }
 
+.drawer__progressive-sentinel {
+  flex: 0 0 1px;
+  width: 100%;
+  height: 1px;
+  pointer-events: none;
+}
+
 /* ── Items ─────────────────────────────────────────── */
 
 .drawer__item {

--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -14,6 +14,11 @@ import {
 } from '../../lib/drawerLifecycle.js'
 import { WORKSPACE_SPLITS_ENABLED } from '../Shell/paneModel.js'
 import InstallSheet from './InstallSheet.jsx'
+import {
+  clampDrawerChatCount,
+  initialDrawerChatCount,
+  nextDrawerChatCount,
+} from './drawerProgressiveRows.js'
 import './Drawer.css'
 
 // Module-level constant so default Set props are stable across renders.
@@ -94,6 +99,55 @@ export default function Drawer({
     if (ap && bp) return bp.localeCompare(ap)
     return (a.created_at || '').localeCompare(b.created_at || '')
   }), [apps])
+  const [visibleChatCount, setVisibleChatCount] = useState(
+    () => initialDrawerChatCount(allChats.length),
+  )
+  const chatScrollRef = useRef(null)
+  const chatSentinelRef = useRef(null)
+  const visibleChats = useMemo(
+    () => allChats.slice(0, visibleChatCount),
+    [allChats, visibleChatCount],
+  )
+
+  // Preserve the revealed window across recency reorders. Only clamp when
+  // deletion/reconciliation makes the list shorter, and always keep the first
+  // batch available. Resetting to one batch on every query-cache refresh would
+  // make rows disappear beneath someone who was already scrolling.
+  useEffect(() => {
+    setVisibleChatCount(current => clampDrawerChatCount(
+      current,
+      allChats.length,
+    ))
+  }, [allChats.length])
+
+  // One continuous list, progressively materialized as its sentinel nears the
+  // viewport. The chat summaries are already the shell's small navigation
+  // projection; this boundary avoids mounting hundreds of interactive menu
+  // trees before they can be seen. Browsers without IntersectionObserver keep
+  // the old fully-rendered behavior rather than making history unreachable.
+  useEffect(() => {
+    if (!open || visibleChatCount >= allChats.length) return undefined
+    const root = chatScrollRef.current
+    const sentinel = chatSentinelRef.current
+    if (!root || !sentinel) return undefined
+    if (typeof IntersectionObserver === 'undefined') {
+      setVisibleChatCount(allChats.length)
+      return undefined
+    }
+    const observer = new IntersectionObserver(entries => {
+      if (!entries.some(entry => entry.isIntersecting)) return
+      setVisibleChatCount(current => nextDrawerChatCount(
+        current,
+        allChats.length,
+      ))
+    }, {
+      root,
+      // Reveal the next rows before the sentinel itself reaches the fade.
+      rootMargin: '0px 0px 320px 0px',
+    })
+    observer.observe(sentinel)
+    return () => observer.disconnect()
+  }, [allChats.length, open, visibleChatCount])
 
   // One row at a time can be in rename or open-menu mode. Tracking the
   // active id (rather than per-row state) lets a click on another row's
@@ -612,8 +666,8 @@ export default function Drawer({
               <Chats width={16} height={16} aria-hidden="true" />
               <span>Chats</span>
             </h2>
-            <div className="drawer__scroll">
-              {allChats.length > 0 ? allChats.map(chat => (
+            <div className="drawer__scroll" ref={chatScrollRef}>
+              {allChats.length > 0 ? visibleChats.map(chat => (
                 <DrawerRow
                   key={chat.id}
                   kind="chat"
@@ -631,6 +685,13 @@ export default function Drawer({
                     No conversations yet
                   </EmptyMessage.Description>
                 </EmptyMessage>
+              )}
+              {visibleChatCount < allChats.length && (
+                <div
+                  ref={chatSentinelRef}
+                  className="drawer__progressive-sentinel"
+                  aria-hidden="true"
+                />
               )}
             </div>
           </div>

--- a/frontend/src/components/Drawer/drawerProgressiveRows.js
+++ b/frontend/src/components/Drawer/drawerProgressiveRows.js
@@ -1,0 +1,22 @@
+/* Progressive drawer-row sizing keeps one continuous list without mounting it all. */
+
+export const DRAWER_CHAT_BATCH_SIZE = 48
+
+export function initialDrawerChatCount(total) {
+  return Math.min(Math.max(0, total), DRAWER_CHAT_BATCH_SIZE)
+}
+
+export function nextDrawerChatCount(current, total) {
+  const boundedTotal = Math.max(0, total)
+  return Math.min(
+    boundedTotal,
+    Math.max(0, current) + DRAWER_CHAT_BATCH_SIZE,
+  )
+}
+
+export function clampDrawerChatCount(current, total) {
+  return Math.min(
+    Math.max(initialDrawerChatCount(total), current),
+    Math.max(0, total),
+  )
+}

--- a/frontend/src/lib/__tests__/drawerProgressiveRows.test.js
+++ b/frontend/src/lib/__tests__/drawerProgressiveRows.test.js
@@ -1,0 +1,26 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  DRAWER_CHAT_BATCH_SIZE,
+  clampDrawerChatCount,
+  initialDrawerChatCount,
+  nextDrawerChatCount,
+} from '../../components/Drawer/drawerProgressiveRows.js'
+
+
+test('drawer starts with one bounded batch and grows continuously', () => {
+  assert.equal(initialDrawerChatCount(0), 0)
+  assert.equal(initialDrawerChatCount(12), 12)
+  assert.equal(initialDrawerChatCount(426), DRAWER_CHAT_BATCH_SIZE)
+  assert.equal(
+    nextDrawerChatCount(DRAWER_CHAT_BATCH_SIZE, 426),
+    DRAWER_CHAT_BATCH_SIZE * 2,
+  )
+  assert.equal(nextDrawerChatCount(400, 426), 426)
+})
+
+test('drawer count survives reorder and clamps only when the list shrinks', () => {
+  assert.equal(clampDrawerChatCount(144, 426), 144)
+  assert.equal(clampDrawerChatCount(144, 80), 80)
+  assert.equal(clampDrawerChatCount(12, 426), DRAWER_CHAT_BATCH_SIZE)
+})


### PR DESCRIPTION
## Summary
- isolate live assistant source selection and rendering from composer-only updates
- use native textarea content sizing when supported while keeping the existing fallback
- progressively render drawer chat rows as the user scrolls

## Why
Draft keystrokes currently rerun active-answer normalization and rendering, synchronously persist the same draft twice, force textarea layout measurement, and pay layout cost for every chat row mounted in the drawer. Long live responses and large histories can therefore make typing miss multiple frames.

The change gives these interactions separate ownership boundaries without changing chat or drawer behavior. The drawer remains one continuous history with no “recent” section or “show older” control.

In a long active chat, median input work fell from 42.8 ms to 13.3 ms and p95 from 110.8 ms to 20 ms. In a settled chat, median input work fell from 5.4 ms to 3.5 ms. Initial drawer descendants fell from about 2,883 to 604.

## Validation
- `npm test` (1,877 tests)
- `npm run build`
- browser benchmark on settled and long active chats
- desktop and phone-width checks for composer growth and progressive drawer scrolling