### PR TITLE
Recover existing contribution PRs and deleted feedback chats

### DIFF
--- a/backend/app/routes/github.py
+++ b/backend/app/routes/github.py
@@ -1291,16 +1291,23 @@ def _find_existing_pr(
 ) -> str | None:
   if not _GIT_SHA.match(str(expected_head_sha or "")):
     return None
-  head = branch if same_repo else f"{login}:{branch}"
+  # `gh pr create --head` accepts owner:branch for a fork, but `gh pr list
+  # --head` only matches the branch name. Passing owner:branch here returns an
+  # empty list even when GitHub's create response says that exact PR already
+  # exists. Query by branch, then prove the expected repository owner and
+  # pushed commit from the returned metadata.
+  expected_owner = upstream_repo.split("/", 1)[0] if same_repo else login
   args = [
     "pr", "list",
     "-R", upstream_repo,
-    "--head", head,
+    "--head", branch,
   ]
   if base_branch:
     args.extend(("--base", _validate_branch(base_branch)))
   args.extend((
-    "--state", "open", "--json", "url,headRefOid", "--limit", "10",
+    "--state", "open",
+    "--json", "url,headRefName,headRefOid,headRepositoryOwner",
+    "--limit", "10",
   ))
   try:
     proc = _gh(
@@ -1319,6 +1326,12 @@ def _find_existing_pr(
   if isinstance(rows, list):
     for row in rows:
       if not isinstance(row, dict):
+        continue
+      owner = row.get("headRepositoryOwner")
+      owner_login = owner.get("login") if isinstance(owner, dict) else ""
+      if str(owner_login or "").casefold() != expected_owner.casefold():
+        continue
+      if str(row.get("headRefName") or "") != branch:
         continue
       if str(row.get("headRefOid") or "") != expected_head_sha:
         continue

--- a/backend/tests/test_github_routes.py
+++ b/backend/tests/test_github_routes.py
@@ -2321,6 +2321,7 @@ def test_submit_contribution_keeps_accepted_pr_open_on_label_transport_failure(
     ("timeout", "absent"),
     ("launch-error", "absent"),
     ("timeout", "wrong-head"),
+    ("timeout", "wrong-owner"),
   ],
 )
 def test_submit_contribution_recovers_ambiguous_create_by_exact_pushed_head(
@@ -2410,10 +2411,14 @@ def test_submit_contribution_recovers_ambiguous_create_by_exact_pushed_head(
     if args[:2] == ("pr", "list"):
       if existing_mode == "absent":
         return _cp("[]")
-      found_head = head if existing_mode == "match" else "c" * 40
+      found_head = head if existing_mode != "wrong-head" else "c" * 40
       return _cp(json.dumps([{
         "url": "https://github.com/mobius-os/app-demo/pull/42",
+        "headRefName": "fix/demo-polish",
         "headRefOid": found_head,
+        "headRepositoryOwner": {
+          "login": "someone-else" if existing_mode == "wrong-owner" else "octocat",
+        },
       }]))
     if args[:2] == ("api", "--paginate"):
       return _cp("bug\n")
@@ -2434,8 +2439,9 @@ def test_submit_contribution_recovers_ambiguous_create_by_exact_pushed_head(
   assert len(creates) == 1, "an ambiguous response must never trigger a second create"
   assert len(probes) == 1
   assert creates[0][-2:] == ("--base", "main")
-  assert "url,headRefOid" in probes[0]
-  assert "octocat:fix/demo-polish" in probes[0]
+  assert "url,headRefName,headRefOid,headRepositoryOwner" in probes[0]
+  assert probes[0][probes[0].index("--head") + 1] == "fix/demo-polish"
+  assert "octocat:fix/demo-polish" not in probes[0]
   assert probes[0][probes[0].index("--base") + 1] == "main"
   assert ("checkout", "-q", "develop") in git_calls
 

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -2579,6 +2579,8 @@ export default function Shell() {
   //     Payload may include autoSend:true, which sends that exact draft after
   //     ChatView mounts. Used only for explicit app approval flows.
   //   moebius:open-chat — open an existing chat, optionally pre-filling a draft.
+  //     A direct 404 falls back to a fresh chat carrying that draft; apps can
+  //     safely link durable records to chats that the owner may later delete.
   //   moebius:open-app — switch the shell to an installed app. Payload
   //     {appId} accepts either the numeric DB id or the slug; we match
   //     against the installed apps list and silently ignore unknown ids
@@ -2616,8 +2618,26 @@ export default function Shell() {
         })
       } else if (e.data?.type === 'moebius:open-chat') {
         if (typeof e.data.chatId !== 'string' || !e.data.chatId) return
+        let draftText = null
         if (e.data.draft) {
-          const draftText = String(e.data.draft)
+          draftText = String(e.data.draft)
+        }
+        // Do not stage a dead chat and wait for ChatView's later 404 repair:
+        // that briefly paints a destination which immediately disappears. The
+        // direct resource probe is the shell's authoritative deletion signal.
+        // Unknown (offline/timeout/auth) is deliberately not deletion evidence.
+        const targetState = await probeDeletion(
+          `/chats/${encodeURIComponent(e.data.chatId)}?limit=1&compact=1`,
+        )
+        if (targetState === 'deleted') {
+          await newChatRef.current?.({
+            draft: draftText || undefined,
+            forceNew: true,
+          })
+          refreshChats()
+          return
+        }
+        if (draftText != null) {
           try {
             sessionStorage.setItem('pending-draft', draftText)
             sessionStorage.setItem(`draft:${e.data.chatId}`, draftText)

--- a/frontend/src/components/Shell/__tests__/appChatTarget.test.js
+++ b/frontend/src/components/Shell/__tests__/appChatTarget.test.js
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+const shell = readFileSync(new URL('../Shell.jsx', import.meta.url), 'utf8')
+
+test('app chat handoffs prove the target before navigating and preserve feedback', () => {
+  const handler = shell.match(
+    /else if \(e\.data\?\.type === 'moebius:open-chat'\) \{([\s\S]*?)\n      \} else if \(e\.data\?\.type === 'moebius:open-app'\)/,
+  )?.[1] || ''
+
+  const probeAt = handler.indexOf('await probeDeletion(')
+  const navigateAt = handler.indexOf("navTo('chat', { chatId: e.data.chatId })")
+  assert.ok(probeAt >= 0 && navigateAt > probeAt,
+    'a missing target must not flash into the workspace before its 404 is known')
+  assert.match(handler, /targetState === 'deleted'[\s\S]*newChatRef\.current\?\.\(\{[\s\S]*draft: draftText \|\| undefined,[\s\S]*forceNew: true,/,
+    'deleted source chats must preserve the app draft in a durable fresh chat')
+  assert.match(handler, /targetState === 'deleted'[\s\S]*return/,
+    'the deleted-target fallback must not continue into stale navigation')
+})


### PR DESCRIPTION
## Summary
- recognize an already-open fork pull request by branch, owner, and exact pushed commit
- check app-linked chats before navigation and preserve feedback in a fresh chat when the source was deleted
- cover wrong-owner, wrong-commit, and deleted-target regressions

## Why
A send whose public pull request existed but whose local bookkeeping was incomplete could be left in a retry loop. The GitHub CLI accepts `owner:branch` while creating a pull request but does not match that form when listing one. Deleted feedback targets also briefly opened and then disappeared after the later 404 repair.

## Testing
- `pytest -q backend/tests/test_github_routes.py` (107 passed)
- `npm test`
- `npm run build`