### PR TITLE
Test gallery click jitter and boundary drags

### DIFF
--- a/tests/image-gallery.spec.mjs
+++ b/tests/image-gallery.spec.mjs
@@ -143,6 +143,33 @@ test('desktop filmstrip is compact and supports buttons, keyboard, and viewer na
 
   const railBox = await rail.boundingBox()
   if (!railBox) throw new Error('Gallery rail did not render')
+
+  const forestPreview = page.getByRole('button', { name: 'Open Forest path preview' })
+  const previewBox = await forestPreview.boundingBox()
+  if (!previewBox) throw new Error('Gallery preview did not render')
+  await page.mouse.move(previewBox.x + previewBox.width / 2, previewBox.y + previewBox.height / 2)
+  await page.mouse.down()
+  await page.mouse.move(
+    previewBox.x + previewBox.width / 2 + 2,
+    previewBox.y + previewBox.height / 2,
+  )
+  await page.mouse.up()
+  await expect(page.getByRole('dialog', { name: /Image 2 of 4/ })).toBeVisible()
+  await page.keyboard.press('Escape')
+
+  // A deliberate drag still owns the gesture when the rail is already at its
+  // boundary and therefore cannot report a changed scrollLeft.
+  await page.mouse.move(railBox.x + railBox.width * 0.38, railBox.y + railBox.height / 2)
+  await page.mouse.down()
+  await page.mouse.move(
+    railBox.x + railBox.width * 0.68,
+    railBox.y + railBox.height / 2,
+    { steps: 6 },
+  )
+  await page.mouse.up()
+  await expect.poll(() => rail.evaluate(element => element.scrollLeft)).toBeLessThan(20)
+  await expect(page.locator('.lightbox-overlay')).toHaveCount(0)
+
   await page.mouse.move(railBox.x + railBox.width * 0.62, railBox.y + railBox.height / 2)
   await page.mouse.down()
   await page.mouse.move(
@@ -154,7 +181,7 @@ test('desktop filmstrip is compact and supports buttons, keyboard, and viewer na
   await expect.poll(() => rail.evaluate(element => element.scrollLeft)).toBeGreaterThan(100)
   await expect(page.locator('.lightbox-overlay')).toHaveCount(0)
 
-  await page.getByRole('button', { name: 'Open Forest path preview' }).click()
+  await forestPreview.click()
   await expect(page.getByRole('dialog', { name: /Image 2 of 4/ })).toBeVisible()
   await expect(page.locator('.lightbox-count')).toHaveText('2 / 4')
   await page.keyboard.press('ArrowRight')


### PR DESCRIPTION
## Context
PR #194 shipped reliable click-to-open and continuous gallery scrolling. This follow-up changes no production behavior; it adds regression coverage for the gesture boundary cases found during a second review.

## Summary
- verify slight pointer movement still opens the full-screen viewer as a click
- verify a deliberate drag at the rail boundary suppresses the click even when `scrollLeft` cannot change
- keep the continuous-drag and post-drag click checks in the same browser flow

## Testing
- frontend library tests: 1,822 passed
- frontend hook tests: 47 passed
- `npm run build`
- `node --check tests/image-gallery.spec.mjs`
- rendered Chromium checks: 2px click jitter opens, a boundary drag does not, free dragging moves continuously, and a later click opens normally