### PR TITLE
Integrate reviewed production runtime improvements

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -869,6 +869,19 @@ All chat-domain mutations — transcript writes, run-markers, question rows, ans
 
 Streaming state is physically bounded: `PersistTranscript`/`PersistError` replace `Chat.live_assistant`, never the historical `Chat.messages` JSON blob. Read routes overlay that current assistant on immutable history. `QuestionCommit` merges the card into history before broadcast, `Finalize` performs the terminal merge and clears the live value, and startup reconciliation performs the same merge after a crash. This keeps one-second crash-resilient snapshots without quadratic transcript rewrites as chats grow.
 
+Settled transcript reads have a separate bounded presentation contract.
+`GET /api/chats/{id}?compact=1` keeps prose, cards, distinctive image-view
+beats, and small collapsed activity metadata, but replaces each multi-step
+thinking/tool run with an `activity` reference into the immutable stored
+message. Repeated steps are bounded by activity variety rather than raw call
+count. Only an explicit disclosure resolves that exact range through
+`GET /api/chats/{id}/activity-detail`; the live assistant stays self-contained.
+Mounted runtime reconciliation uses `GET /api/chats/{id}/runtime`, whose ORM
+projection raiseloads every unrequested field so polling can never silently
+decode `Chat.messages`. These are read projections, never a second persistence
+format: provider context, recovery, export, and writer commands continue to
+use the full transcript.
+
 - **Commit-before-ack (strict paths):** the caller's `await` on `QuestionCommit`/`Finalize`/`AnswerQuestion`/`Barrier`/`DrainAndStop` doesn't unblock until the commit succeeds; `PersistTranscript` and `PersistError` are fire-and-forget (submitted without awaiting the ack).
 - **Questions commit-before-broadcast:** a question row is durable before its SSE push fires, so a reconnect's catch-up burst always finds it.
 - **Concurrency invariant:** ack `Future`s are NEVER resolved while a producer lock is held — collect `(ack, value)` under the lock, resolve after release — so even a synchronous done-callback that re-enters `submit()`/`stop()` can't deadlock. Do not move an ack resolution back inside a `with` block.

--- a/backend/app/app_compile_contract.py
+++ b/backend/app/app_compile_contract.py
@@ -154,6 +154,16 @@ def esbuild_command(
     "--format=esm",
     "--jsx=automatic",
     "--platform=browser",
+    # Mini-apps are runtime artifacts, not development builds. Without an
+    # explicit production define React selects its development branches and
+    # every app carries nearly a megabyte of validation/debug code that the
+    # opaque frame must copy, parse, and execute on every cold mount.
+    '--define:process.env.NODE_ENV="production"',
+    # Keep the one-module offline contract while reducing transfer, cache,
+    # parse, and evaluation cost. Preserve Function.name/Class.name for apps
+    # that use names in labels or diagnostics.
+    "--minify",
+    "--keep-names",
     f"--banner:js={COMPILED_RUNTIME_BANNER}",
     f"--inject:{runtime_inject_path()}",
     f"--alias:mobius-runtime={mobius_runtime_path()}",

--- a/backend/app/app_preview.py
+++ b/backend/app/app_preview.py
@@ -1,0 +1,96 @@
+"""Durable per-build acknowledgement for an app's owning-chat open button."""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import update
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app import models
+
+
+def naive_utc(value: datetime) -> datetime:
+  """Normalize an API datetime to the naive-UTC shape SQLite returns."""
+  if value.tzinfo is not None:
+    return value.astimezone(UTC).replace(tzinfo=None)
+  return value
+
+
+def _advance_existing(
+  db: Session, app_id: int, seen_updated_at: datetime, seen_as_final: bool,
+) -> bool:
+  """Advance one row without letting an older acknowledgement move it back."""
+  advanced = db.execute(
+    update(models.AppPreviewState)
+    .where(
+      models.AppPreviewState.app_id == app_id,
+      models.AppPreviewState.seen_updated_at < seen_updated_at,
+    )
+    .values(
+      seen_updated_at=seen_updated_at,
+      seen_as_final=seen_as_final,
+    )
+  )
+  if advanced.rowcount:
+    return True
+  if seen_as_final:
+    promoted = db.execute(
+      update(models.AppPreviewState)
+      .where(
+        models.AppPreviewState.app_id == app_id,
+        models.AppPreviewState.seen_updated_at == seen_updated_at,
+        models.AppPreviewState.seen_as_final.is_(False),
+      )
+      .values(seen_as_final=True)
+    )
+    if promoted.rowcount:
+      return True
+  return db.get(models.AppPreviewState, app_id) is not None
+
+
+def mark_seen(
+  db: Session,
+  app_id: int,
+  seen_updated_at: datetime,
+  *,
+  seen_as_final: bool,
+) -> None:
+  """Acknowledge only the build the opening shell actually observed.
+
+  An older request may arrive after a newer build was opened on another device.
+  The monotonic timestamp update keeps that late request from hiding or
+  downgrading the newer acknowledgement.
+  """
+  seen_updated_at = naive_utc(seen_updated_at)
+  if _advance_existing(db, app_id, seen_updated_at, seen_as_final):
+    return
+  try:
+    with db.begin_nested():
+      db.add(models.AppPreviewState(
+        app_id=app_id,
+        seen_updated_at=seen_updated_at,
+        seen_as_final=seen_as_final,
+      ))
+      db.flush()
+  except IntegrityError:
+    # Two devices acknowledged the first visible build concurrently. The
+    # savepoint preserves the outer request; replay the monotonic update.
+    _advance_existing(db, app_id, seen_updated_at, seen_as_final)
+
+
+def annotate_apps(db: Session, apps: list[models.App]) -> list[models.App]:
+  """Attach response-only preview acknowledgement fields to app rows."""
+  ids = [app.id for app in apps]
+  state_by_id = {}
+  if ids:
+    state_by_id = {
+      row.app_id: row
+      for row in db.query(models.AppPreviewState).filter(
+        models.AppPreviewState.app_id.in_(ids)
+      ).all()
+    }
+  for app in apps:
+    state = state_by_id.get(app.id)
+    app.preview_seen_updated_at = state.seen_updated_at if state else None
+    app.preview_seen_final = bool(state and state.seen_as_final)
+  return apps

--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -2253,10 +2253,12 @@ async def _auto_resume_chat(
         # Share the queue lock with owner/app sends. The outer sweep check can
         # go stale while this task waits, so re-check global liveness, policy,
         # attribution, the exact latest park, and provider ownership at the
-        # actual claim point.
+        # actual claim point. Provider-limit retries are globally serial to
+        # avoid a reset storm. Planned-restart continuations are different:
+        # they are the exact, owner-opted set that was already live together
+        # before the restart, so each chat may reclaim its own slot
+        # independently.
         async with chat_queue.get_lock(chat_id):
-          if _any_chat_turn_active():
-            return False
           with SessionLocal() as check_db:
             chat = check_db.query(models.Chat).filter(
               models.Chat.id == chat_id,
@@ -2315,6 +2317,11 @@ async def _auto_resume_chat(
             resume_reason = (
               "restart" if park.park_reason == "restart" else "usage_limit"
             )
+          if (
+            resume_reason != "restart"
+            and _any_chat_turn_active()
+          ):
+            return False
           if not mark_starting(chat_id):
             return False
           claimed = True
@@ -2409,11 +2416,13 @@ async def sweep_reset_parks(db: Session) -> list[str]:
       failure cannot silently consume the promised continuation. The narrow
       post-promote SIGKILL boundary is documented on `_auto_resume_chat`.
     - A park whose chat was deleted resolves silently.
-    - Auto-resume is controlled per chat and STRICTLY SERIAL: at most one
-      enabled park starts per tick, and none while any turn is live anywhere.
-      A blocked enabled chat stays pending for a later tick, while notify-only
-      chats in the same due batch still resolve normally. App-attributed runs
-      and queues never auto-resume.
+    - Auto-resume is controlled per chat. Provider-limit retries are strictly
+      serial: at most one starts per tick, and none while any turn is live
+      anywhere. Planned-restart continuations reclaim the exact set that was
+      already live before the restart, so every eligible chat in the batch may
+      resume independently. A blocked enabled chat stays pending for a later
+      tick, while notify-only chats in the same due batch still resolve
+      normally. App-attributed runs and queues never auto-resume.
 
   Stands down while draining — a restart is in progress, and the fresh
   process's immediate sweep picks everything up. Never raises.
@@ -2525,14 +2534,15 @@ async def sweep_reset_parks(db: Session) -> list[str]:
       and restart_authorized
     )
 
-  auto_resume_started = False
+  limit_resume_started = False
   for run in due:
     chat_id = run.chat_id
     chat = chats.get(chat_id)
     chat_gone = chat is None or chat.deleted_at is not None
     auto_resume = wants_auto_resume(chat, run)
-    if auto_resume and (
-      auto_resume_started or _any_chat_turn_active()
+    restart_auto_resume = auto_resume and run.park_reason == "restart"
+    if auto_resume and not restart_auto_resume and (
+      limit_resume_started or _any_chat_turn_active()
     ):
       # Strictly-serial gate: a live turn (an earlier auto-resume, or the
       # owner's own send) must settle before this enabled park is processed.
@@ -2590,16 +2600,18 @@ async def sweep_reset_parks(db: Session) -> list[str]:
 
       if prepared.get("notify"):
         notify_due(chat_id, run)
-      if _any_chat_turn_active():
+      if not restart_auto_resume and _any_chat_turn_active():
         # The notification or refresh window admitted another turn. Keep the
         # durable pending state so the next sweep retries instead of silently
         # dropping the promised continuation.
         continue
-      auto_resume_started = await _auto_resume_chat(
+      resume_started = await _auto_resume_chat(
         chat_id, park_token=run.id,
       )
-      if auto_resume_started:
+      if resume_started:
         resolved.append(chat_id)
+        if not restart_auto_resume:
+          limit_resume_started = True
       continue
 
     # Notify-only/app/deleted path: resolve before the best-effort push so a

--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -54,6 +54,7 @@ from app.chat_writer import (
   PersistError,
   PersistTranscript,
   QuestionCommit,
+  RecordRunMetrics,
   ResolvePark,
   RollbackAutoResume,
   StashThinkingTrace,
@@ -1191,6 +1192,45 @@ async def _clear_run_status(
     _get_logger().warning(
       "ClearRunStatus did not persist chat_id=%s (reconciliation will "
       "repair)", chat_id, exc_info=True,
+    )
+
+
+async def _record_run_metrics(
+  *,
+  chat_id: str,
+  run_token: str,
+  provider_session_id: str | None,
+  cost_usd: float | None,
+  usage: dict | None,
+) -> None:
+  """Best-effort durable accounting for one provider run.
+
+  Usage must not be able to turn an otherwise successful chat response into a
+  failed turn. The exact run identity keeps a delayed completion from
+  attributing counters to a successor, and the writer actor keeps this scalar
+  update ordered with the later terminal transition.
+  """
+  if not chat_id or not run_token:
+    return
+  # A provider can legitimately omit usage (and Codex currently omits cost).
+  # With no accounting signal there is nothing to record; avoiding a no-op
+  # actor round-trip also preserves the runner's connection-release contract.
+  if usage is None and cost_usd in (None, 0):
+    return
+  try:
+    await _await_ack(get_writer().submit(RecordRunMetrics(
+      chat_id=chat_id,
+      run_token=run_token,
+      provider_session_id=provider_session_id,
+      cost_usd=cost_usd,
+      usage=usage,
+    )))
+  except Exception:
+    _get_logger().warning(
+      "RecordRunMetrics did not persist chat_id=%s run_token=%s",
+      chat_id,
+      run_token,
+      exc_info=True,
     )
 
 
@@ -3647,7 +3687,8 @@ async def _complete_turn(
   # legitimately-silent turn: a user Stop lands as stop_handoff_successor (or
   # disowns the generation above), a park sets limit_reached, an errored/refused
   # turn sets _last_error, and any real text/thinking/tool_use makes the blocks
-  # renderable. cost_usd is unusable (None for every run here) and not consulted.
+  # renderable. Provider usage/cost is accounting data, not proof of a reply,
+  # and is deliberately not consulted.
   lost_reply = (
     we_own_gen
     and not stop_handoff_successor
@@ -5144,6 +5185,14 @@ async def _run_chat_impl_with_db(
       )
       new_session_id = runner_result.get("session_id")
       err = runner_result.get("error")
+      usage_metrics = runner_result.get("usage_metrics")
+      await _record_run_metrics(
+        chat_id=chat_id,
+        run_token=run_token or "",
+        provider_session_id=new_session_id or session_id,
+        cost_usd=runner_result.get("cost_usd"),
+        usage=usage_metrics,
+      )
       if not err and new_session_id and chat_id:
         chat_obj = db.query(models.Chat).filter(
           models.Chat.id == chat_id
@@ -5161,10 +5210,14 @@ async def _run_chat_impl_with_db(
         )
       else:
         log.info(
-          "chat done chat_id=%s cost_usd=%.4f sdk=codex status=%s phase=%s",
+          "chat done chat_id=%s cost_usd=%.4f sdk=codex status=%s phase=%s "
+          "input_tokens=%s output_tokens=%s total_tokens=%s",
           chat_id, runner_result.get("cost_usd") or 0.0,
           runner_result.get("terminal_status"),
           runner_result.get("final_message_phase"),
+          (usage_metrics or {}).get("input_tokens"),
+          (usage_metrics or {}).get("output_tokens"),
+          (usage_metrics or {}).get("total_tokens"),
         )
     except Exception as exc:
       log.exception("codex SDK turn failed chat_id=%s: %s", chat_id, exc)
@@ -5266,6 +5319,14 @@ async def _run_chat_impl_with_db(
       )
       new_session_id = runner_result.get("session_id")
       err = runner_result.get("error")
+      usage_metrics = runner_result.get("usage_metrics")
+      await _record_run_metrics(
+        chat_id=chat_id,
+        run_token=run_token or "",
+        provider_session_id=new_session_id or claude_session_id,
+        cost_usd=runner_result.get("cost_usd"),
+        usage=usage_metrics,
+      )
       if not err and new_session_id and chat_id:
         chat_obj = db.query(models.Chat).filter(
           models.Chat.id == chat_id
@@ -5277,8 +5338,12 @@ async def _run_chat_impl_with_db(
         log.error("claude SDK error chat_id=%s: %s", chat_id, err)
       else:
         log.info(
-          "chat done chat_id=%s cost_usd=%.4f sdk=claude",
+          "chat done chat_id=%s cost_usd=%.4f sdk=claude "
+          "input_tokens=%s output_tokens=%s total_tokens=%s",
           chat_id, runner_result.get("cost_usd") or 0.0,
+          (usage_metrics or {}).get("input_tokens"),
+          (usage_metrics or {}).get("output_tokens"),
+          (usage_metrics or {}).get("total_tokens"),
         )
     except Exception as exc:
       log.exception("claude SDK turn failed chat_id=%s: %s", chat_id, exc)

--- a/backend/app/chat_transcript.py
+++ b/backend/app/chat_transcript.py
@@ -11,6 +11,7 @@ _IMAGE_PATH_RE = re.compile(
   re.IGNORECASE,
 )
 _MAX_COMPACT_SOURCES = 24
+MAX_ACTIVITY_DETAIL_BLOCKS = 2000
 
 
 def materialized_messages(chat) -> list[dict]:
@@ -294,14 +295,17 @@ def compact_messages_for_detail(
 
     def flush() -> None:
       nonlocal changed
-      if len(run) >= 2:
-        next_blocks.append(_compact_activity_run(
-          run,
-          message_index=message_offset + page_index,
-        ))
-        changed = True
-      else:
-        next_blocks.extend(block for _, block in run)
+      while run:
+        chunk = run[:MAX_ACTIVITY_DETAIL_BLOCKS]
+        del run[:MAX_ACTIVITY_DETAIL_BLOCKS]
+        if len(chunk) >= 2:
+          next_blocks.append(_compact_activity_run(
+            chunk,
+            message_index=message_offset + page_index,
+          ))
+          changed = True
+        else:
+          next_blocks.extend(block for _, block in chunk)
       run.clear()
 
     for raw_index, block in enumerate(blocks):

--- a/backend/app/chat_transcript.py
+++ b/backend/app/chat_transcript.py
@@ -2,6 +2,16 @@
 
 from __future__ import annotations
 
+import re
+
+
+_QUESTION_TOOLS = {"AskUserQuestion", "request_user_input"}
+_IMAGE_PATH_RE = re.compile(
+  r"\.(?:avif|bmp|gif|heic|heif|jpe?g|png|svg|webp)(?:[?#].*)?$",
+  re.IGNORECASE,
+)
+_MAX_COMPACT_SOURCES = 24
+
 
 def materialized_messages(chat) -> list[dict]:
   """Return history with a visible in-flight assistant snapshot overlaid."""
@@ -101,3 +111,231 @@ def historical_tool_output_ids(
         continue
       ids.add(block["tool_use_id"])
   return ids
+
+
+def _distinctive_activity(block: dict) -> bool:
+  """Keep notable one-line activity beats out of a folded metadata run."""
+  if block.get("type") != "tool" or block.get("tool") != "Read":
+    return False
+  raw = block.get("input")
+  if isinstance(raw, dict):
+    raw = raw.get("file_path") or raw.get("path") or ""
+  return isinstance(raw, str) and bool(_IMAGE_PATH_RE.search(raw))
+
+
+def _compact_activity_item(block: dict) -> dict:
+  """Return only the metadata needed to paint a collapsed activity line."""
+  if block.get("type") == "thinking":
+    return {
+      "type": "thinking",
+      **(
+        {"thinking_id": block["thinking_id"]}
+        if isinstance(block.get("thinking_id"), str)
+        and block["thinking_id"]
+        else {}
+      ),
+      **(
+        {"duration_ms": block["duration_ms"]}
+        if isinstance(block.get("duration_ms"), (int, float))
+        else {}
+      ),
+    }
+
+  tool = {
+    "type": "tool",
+    "tool": block.get("tool") or "Tool",
+    # This projection never touches the live assistant. A stale persisted
+    # "running" flag belongs to an interrupted historical step, not current
+    # liveness, so normalize it at the read boundary.
+    "status": (
+      "done" if block.get("status") == "running"
+      else block.get("status") or "done"
+    ),
+  }
+  for key in ("tool_use_id", "output_exit_code", "subagent"):
+    if key in block:
+      tool[key] = block[key]
+  # Read's path is the only input that affects the collapsed presentation:
+  # image reads are intentionally a distinctive beat. Keep it bounded; full
+  # tool input remains in the on-demand activity detail.
+  if block.get("tool") == "Read" and isinstance(block.get("input"), str):
+    tool["input"] = block["input"][:2048]
+  return tool
+
+
+def _compact_activity_entries(
+  blocks: list[tuple[int, dict]],
+) -> list[dict]:
+  """Bound header metadata by activity variety, not raw step count.
+
+  Repeated shell/edit loops are the pathological transcripts this projection
+  exists for. The collapsed label needs first-seen activity order and whether
+  an activity occurred once or repeatedly, so two entries per tool name are
+  sufficient. Keep every helper-bearing or failed entry because those facts
+  remain visible while collapsed. Thinking contributes one entry with the
+  run's total measured duration.
+  """
+  entries: list[dict] = []
+  tool_counts: dict[str, int] = {}
+  first_thinking_entry: dict | None = None
+  thinking_duration = 0.0
+  has_thinking_duration = False
+
+  for raw_index, block in blocks:
+    if block.get("type") == "thinking":
+      duration = block.get("duration_ms")
+      if isinstance(duration, (int, float)) and not isinstance(duration, bool):
+        thinking_duration += duration
+        has_thinking_duration = True
+      if first_thinking_entry is None:
+        first_thinking_entry = {
+          "item": _compact_activity_item(block),
+          "idx": raw_index,
+        }
+        entries.append(first_thinking_entry)
+      continue
+
+    tool_name = block.get("tool") or "Tool"
+    occurrence = tool_counts.get(tool_name, 0) + 1
+    tool_counts[tool_name] = occurrence
+    has_helpers = isinstance(block.get("subagent"), dict) and block["subagent"]
+    exit_code = block.get("output_exit_code")
+    failed = (
+      isinstance(exit_code, (int, float))
+      and not isinstance(exit_code, bool)
+      and exit_code != 0
+    )
+    if occurrence <= 2 or has_helpers or failed:
+      entries.append({
+        "item": _compact_activity_item(block),
+        "idx": raw_index,
+      })
+
+  if first_thinking_entry is not None:
+    item = first_thinking_entry["item"]
+    if has_thinking_duration:
+      item["duration_ms"] = thinking_duration
+    else:
+      item.pop("duration_ms", None)
+  return entries
+
+
+def _compact_activity_run(
+  blocks: list[tuple[int, dict]],
+  *,
+  message_index: int,
+) -> dict:
+  sources: list[dict] = []
+  seen_source_urls: set[str] = set()
+  for _, block in blocks:
+    for source in block.get("sources") or []:
+      if not isinstance(source, dict):
+        continue
+      url = source.get("url")
+      if not isinstance(url, str) or not url or url in seen_source_urls:
+        continue
+      seen_source_urls.add(url)
+      sources.append(source)
+      if len(sources) >= _MAX_COMPACT_SOURCES:
+        break
+    if len(sources) >= _MAX_COMPACT_SOURCES:
+      break
+
+  start = blocks[0][0]
+  end = blocks[-1][0] + 1
+  return {
+    "type": "activity",
+    "activity_id": f"{message_index}:{start}:{end}",
+    "message_index": message_index,
+    "start": start,
+    "end": end,
+    "entries": _compact_activity_entries(blocks),
+    "tool_count": sum(
+      block.get("type") == "tool" for _, block in blocks
+    ),
+    **({"sources": sources} if sources else {}),
+  }
+
+
+def compact_messages_for_detail(
+  messages: list[dict],
+  *,
+  message_offset: int,
+  live_message: dict | None = None,
+) -> list[dict]:
+  """Project settled activity runs into small, lazily expandable summaries.
+
+  Stored ``Chat.messages`` remains the full source of truth. The normal chat
+  read only needs prose, cards, and the metadata that paints each collapsed
+  activity header. Expanding a header reads its original block range through
+  the activity-detail endpoint.
+
+  Single activity entries stay inline: introducing a network boundary for one
+  ordinary tool/thought would cost more complexity than it saves. Distinctive
+  image-view beats also stay independent, preserving the transcript's visual
+  punctuation. Question-tool twins are omitted when the message already owns
+  the canonical question card, matching the frontend's historical repair.
+  """
+  projected: list[dict] | None = None
+  for page_index, message in enumerate(messages):
+    if message is live_message or message.get("role") != "assistant":
+      continue
+    blocks = message.get("blocks")
+    if not isinstance(blocks, list) or len(blocks) < 2:
+      continue
+
+    has_question = any(
+      isinstance(block, dict) and block.get("type") == "question"
+      for block in blocks
+    )
+    next_blocks: list[dict] = []
+    run: list[tuple[int, dict]] = []
+    changed = False
+
+    def flush() -> None:
+      nonlocal changed
+      if len(run) >= 2:
+        next_blocks.append(_compact_activity_run(
+          run,
+          message_index=message_offset + page_index,
+        ))
+        changed = True
+      else:
+        next_blocks.extend(block for _, block in run)
+      run.clear()
+
+    for raw_index, block in enumerate(blocks):
+      activity = (
+        isinstance(block, dict)
+        and block.get("type") in {"tool", "thinking"}
+      )
+      question_twin = (
+        activity
+        and block.get("type") == "tool"
+        and has_question
+        and block.get("tool") in _QUESTION_TOOLS
+      )
+      if question_twin:
+        flush()
+        changed = True
+        continue
+      if activity and not _distinctive_activity(block):
+        run.append((raw_index, block))
+        continue
+      flush()
+      next_blocks.append(block)
+    flush()
+
+    if not changed:
+      continue
+    if projected is None:
+      projected = list(messages)
+    next_message = dict(message)
+    next_message["blocks"] = next_blocks
+    # Assistant content duplicates its text blocks. Once blocks are present,
+    # copying and rendering already read those blocks, so the duplicate string
+    # only inflates parse/cache cost.
+    next_message.pop("content", None)
+    projected[page_index] = next_message
+
+  return projected if projected is not None else messages

--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -224,6 +224,23 @@ class PersistSessionId(_Command):
 
 
 @dataclass
+class RecordRunMetrics(_Command):
+  """Persist provider-neutral usage/cost counters on one ChatRun.
+
+  This is separate from transcript Finalize because a stale/stop handoff may
+  intentionally skip transcript mutation while its own run row still deserves
+  the provider usage reported for it. Identity is the run token; this command
+  never reads or mutates Chat.messages.
+  """
+
+  chat_id: str = ""
+  run_token: str = ""
+  provider_session_id: str | None = None
+  cost_usd: float | None = None
+  usage: dict | None = None
+
+
+@dataclass
 class RecordAgentLifecycle(_Command):
   """Append one normalized helper lifecycle milestone.
 
@@ -1352,6 +1369,8 @@ class ChatWriterActor:
       return self._answer_question(db, cmd)
     if isinstance(cmd, PersistSessionId):
       return self._persist_session_id(db, cmd)
+    if isinstance(cmd, RecordRunMetrics):
+      return self._record_run_metrics(db, cmd)
     if isinstance(cmd, RecordAgentLifecycle):
       from app.agent_lifecycle import record_event
       return record_event(db, cmd.values)
@@ -1540,6 +1559,45 @@ class ChatWriterActor:
     chat.session_id = cmd.session_id
     if not _commit_or_rollback(db):
       raise _PersistFailed("PersistSessionId did not persist")
+    return True
+
+  def _record_run_metrics(self, db, cmd: RecordRunMetrics) -> bool:
+    """Attach provider usage/cost to the exact durable run row."""
+    if not cmd.chat_id or not cmd.run_token:
+      return False
+    from app.models import ChatRun
+
+    run = db.query(ChatRun).filter(
+      ChatRun.id == cmd.run_token,
+      ChatRun.chat_id == cmd.chat_id,
+    ).first()
+    if run is None:
+      raise _PersistFailed("RecordRunMetrics: run not found")
+
+    if cmd.provider_session_id:
+      run.provider_session_id = cmd.provider_session_id
+    if cmd.cost_usd is not None:
+      run.cost_usd = float(cmd.cost_usd)
+    usage = copy.deepcopy(cmd.usage) if cmd.usage else None
+    if usage is not None:
+      run.usage_json = usage
+      for field_name in (
+        "input_tokens",
+        "output_tokens",
+        "cache_read_input_tokens",
+        "cache_creation_input_tokens",
+        "reasoning_output_tokens",
+        "total_tokens",
+        "model_context_window",
+      ):
+        value = usage.get(field_name)
+        setattr(
+          run,
+          field_name,
+          int(value) if value is not None else None,
+        )
+    if not _commit_or_rollback(db):
+      raise _PersistFailed("RecordRunMetrics did not persist")
     return True
 
   def _stash_tool_output(self, db, cmd: "StashToolOutput") -> bool:

--- a/backend/app/claude_sdk_runner.py
+++ b/backend/app/claude_sdk_runner.py
@@ -115,6 +115,7 @@ from app.runtime_types import RunnerResult
 from app.sdk_emit import emit_unknown_enabled, unknown_event
 from app.tool_summaries import summarize_tool_input
 from app.tool_sources import normalize_tool_sources, sources_from_websearch_text
+from app.usage_metrics import normalize_claude_usage
 
 log = logging.getLogger(__name__)
 
@@ -1065,6 +1066,9 @@ def dispatch_sdk_message(
       "session_id": current_session_id,
       "cost_usd": sdk_msg.total_cost_usd,
       "usage": dict(sdk_msg.usage) if sdk_msg.usage else None,
+      "usage_metrics": normalize_claude_usage(
+        sdk_msg.usage, sdk_msg.model_usage,
+      ),
       "model_usage": (
         dict(sdk_msg.model_usage) if sdk_msg.model_usage else None
       ),

--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -72,6 +72,7 @@ from typing import Any, Callable
 from app.codex_appserver import _extract_bash_command
 from app.providers import get_skill_path
 from app.runtime_types import RunnerResult
+from app.usage_metrics import normalize_codex_usage
 from app.runner_registry import RunnerKind, registry
 from app.tool_sources import normalize_tool_sources
 
@@ -1892,6 +1893,8 @@ async def run_codex_sdk_turn(
   current_session_id = session_id
   completed_turn: Any | None = None
   completed_message_phases: list[str | None] = []
+  first_token_usage: Any | None = None
+  final_token_usage: Any | None = None
   process_group_id: int | None = None
   codex_context = sdk["AsyncCodex"](config=config)
   process_group_capture_stop: asyncio.Event | None = None
@@ -2193,9 +2196,9 @@ async def run_codex_sdk_turn(
           continue
 
         if isinstance(payload, sdk["ThreadTokenUsageUpdatedNotification"]):
-          # Token usage is reported but currently not surfaced; the
-          # SDK already exposes it via the thread handle for any
-          # consumer that needs it.
+          if first_token_usage is None:
+            first_token_usage = payload.token_usage
+          final_token_usage = payload.token_usage
           continue
 
         if isinstance(
@@ -2283,6 +2286,11 @@ async def run_codex_sdk_turn(
         "cost_usd": None,
         "error": error_text,
       }
+      if final_token_usage is not None:
+        result["usage"] = _model_dump(final_token_usage)
+        result["usage_metrics"] = normalize_codex_usage(
+          first_token_usage, final_token_usage,
+        )
       if terminal_status is not None:
         result["terminal_status"] = terminal_status
       if final_message_phase is not None:

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -724,6 +724,28 @@ def run_migrations(eng) -> None:
       _add_runs.append(
         "ALTER TABLE chat_runs ADD COLUMN restart_nonce VARCHAR(128) NULL"
       )
+    if "provider_session_id" not in chat_runs_cols:
+      _add_runs.append(
+        "ALTER TABLE chat_runs ADD COLUMN provider_session_id "
+        "VARCHAR(128) NULL"
+      )
+    for column in (
+      "input_tokens",
+      "output_tokens",
+      "cache_read_input_tokens",
+      "cache_creation_input_tokens",
+      "reasoning_output_tokens",
+      "total_tokens",
+      "model_context_window",
+    ):
+      if column not in chat_runs_cols:
+        _add_runs.append(
+          f"ALTER TABLE chat_runs ADD COLUMN {column} INTEGER NULL"
+        )
+    if "usage_json" not in chat_runs_cols:
+      _add_runs.append(
+        "ALTER TABLE chat_runs ADD COLUMN usage_json JSON NULL"
+      )
     if _add_runs:
       with eng.connect() as conn:
         for stmt in _add_runs:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -529,38 +529,45 @@ async def lifespan(app):
     _stalled_live_task = _asyncio.create_task(_stalled_live_loop())
 
     # Durable-continuation sweep (design §2.4): handles provider-limit resets
-    # and exact runs parked by a planned restart. It runs immediately on boot,
-    # then after a turn finishes or at the 60s fallback cadence. This is
-    # event-driven in the common path (one indexed query per completed turn),
-    # with no per-chat worker or short polling loop.
+    # and exact runs parked by a planned restart. The first pass is awaited
+    # BEFORE lifespan yields, so a reconnecting client cannot win the startup
+    # race and turn an opted-in restart into manual recovery. Later passes run
+    # after a turn finishes or at the 60s fallback cadence. This is event-
+    # driven in the common path (one indexed query per completed turn), with
+    # no per-chat worker or short polling loop.
+    from app.broadcast import get_system_broadcast as _system_broadcast
+    _reset_park_events = _system_broadcast().subscribe()
+
+    async def _sweep_reset_parks_once():
+      try:
+        _rp_db = _SweepSession()
+        try:
+          await sweep_reset_parks(_rp_db)
+        finally:
+          _rp_db.close()
+      except _asyncio.CancelledError:
+        raise
+      except Exception as _exc:
+        _log.error("reset-park sweep failed: %s", _exc, exc_info=True)
+
+    await _sweep_reset_parks_once()
+
     async def _reset_park_loop():
-      from app.broadcast import get_system_broadcast as _system_broadcast
-      _events = _system_broadcast().subscribe()
       try:
         while True:
-          try:
-            _rp_db = _SweepSession()
-            try:
-              await sweep_reset_parks(_rp_db)
-            finally:
-              _rp_db.close()
-          except _asyncio.CancelledError:
-            raise
-          except Exception as _exc:
-            _log.error("reset-park sweep failed: %s", _exc, exc_info=True)
-
           try:
             # One absolute fallback window. Unrelated system events must not
             # keep resetting a per-get timer and starve a future limit reset.
             async with _asyncio.timeout(60):
               while True:
-                _event = await _events.get()
+                _event = await _reset_park_events.get()
                 if _event and _event.get("type") == "chat_run_finished":
                   break
           except _asyncio.TimeoutError:
             pass
+          await _sweep_reset_parks_once()
       finally:
-        _system_broadcast().unsubscribe(_events)
+        _system_broadcast().unsubscribe(_reset_park_events)
 
     _reset_park_task = _asyncio.create_task(_reset_park_loop())
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -674,6 +674,25 @@ class AppActivityState(Base):
   unseen = Column(Boolean, nullable=False, default=True, server_default=true())
 
 
+class AppPreviewState(Base):
+  """Durable acknowledgement of the exact app build opened from its chat CTA.
+
+  This is separate from ``apps`` so acknowledging a preview never advances
+  ``App.updated_at`` — the executable-bundle version the acknowledgement is
+  meant to record. ``seen_as_final`` distinguishes opening a live preview from
+  opening the settled result: finishing the turn may surface the same build one
+  last time even when no final source write was needed.
+  """
+
+  __tablename__ = "app_preview_state"
+
+  app_id = Column(Integer, ForeignKey("apps.id"), primary_key=True)
+  seen_updated_at = Column(DateTime, nullable=False)
+  seen_as_final = Column(
+    Boolean, nullable=False, default=False, server_default=false()
+  )
+
+
 class PushSubscription(Base):
   """Browser push subscription for Web Push delivery."""
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -250,9 +250,24 @@ class ChatRun(Base):
   initiated_by_app_id = Column(
     Integer, ForeignKey("apps.id"), nullable=True, default=None
   )
-  # Reserved for per-run cost attribution (Capability B). No code path writes
-  # this yet, so reads are NULL until the Step-3b follow-up wires a producer.
+  # Per-run provider cost. Rows created before usage telemetry remain NULL.
   cost_usd = Column(Float, nullable=True, default=None)
+  # Provider session/thread id active for this run. This lets diagnostics
+  # distinguish a fresh provider context from a resumed one without relying on
+  # Chat.session_id, which is only the latest pointer.
+  provider_session_id = Column(String(128), nullable=True, default=None)
+  # Provider-neutral per-turn totals. `input_tokens` means total context
+  # processed for the turn, including cached input; the cache columns split
+  # that total where the provider exposes the distinction. Raw/provider-
+  # specific cumulative detail stays in usage_json for forward compatibility.
+  input_tokens = Column(Integer, nullable=True, default=None)
+  output_tokens = Column(Integer, nullable=True, default=None)
+  cache_read_input_tokens = Column(Integer, nullable=True, default=None)
+  cache_creation_input_tokens = Column(Integer, nullable=True, default=None)
+  reasoning_output_tokens = Column(Integer, nullable=True, default=None)
+  total_tokens = Column(Integer, nullable=True, default=None)
+  model_context_window = Column(Integer, nullable=True, default=None)
+  usage_json = Column(JSON, nullable=True, default=None)
   started_at = Column(DateTime, default=lambda: datetime.now(UTC))
   ended_at = Column(DateTime, nullable=True, default=None)
   # Provider rate/usage-limit parking (design §2.4). When a turn dies on a

--- a/backend/app/resource_access.py
+++ b/backend/app/resource_access.py
@@ -16,14 +16,18 @@ every caller.
 """
 
 from fastapi import HTTPException
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, load_only
 
 from app import models
 from app.deps import Principal
 
 
 def get_active_chat_for_principal(
-  db: Session, chat_id: str, principal: Principal,
+  db: Session,
+  chat_id: str,
+  principal: Principal,
+  *,
+  load_fields: tuple | None = None,
 ) -> models.Chat:
   """Fetches an active chat the principal may DRIVE, else 404/403.
 
@@ -44,7 +48,12 @@ def get_active_chat_for_principal(
       the owner sees, so an app can't probe existence of chats it can't
       reach); 403 when an app token targets a chat it doesn't own.
   """
-  chat = get_active_chat_or_404(db, chat_id)
+  required_fields = (
+    (models.Chat.id, models.Chat.created_by_app_id, *load_fields)
+    if load_fields
+    else None
+  )
+  chat = get_active_chat_or_404(db, chat_id, load_fields=required_fields)
   if principal.scope == "chat_embed" and principal.chat_id != chat_id:
     raise HTTPException(
       status_code=403,
@@ -61,7 +70,10 @@ def get_active_chat_for_principal(
 
 
 def get_active_chat_or_404(
-  db: Session, chat_id: str,
+  db: Session,
+  chat_id: str,
+  *,
+  load_fields: tuple | None = None,
 ) -> models.Chat:
   """Fetches a non-soft-deleted Chat by id, raising 404 otherwise.
 
@@ -84,7 +96,13 @@ def get_active_chat_or_404(
   Raises:
     HTTPException: 404 when no row matches OR the row is soft-deleted.
   """
-  chat = db.query(models.Chat).filter(
+  query = db.query(models.Chat)
+  if load_fields:
+    # A narrow read must stay narrow. ``raiseload`` turns an accidental future
+    # field access into a test-visible failure rather than silently decoding a
+    # multi-megabyte transcript and erasing the endpoint's reason to exist.
+    query = query.options(load_only(*load_fields, raiseload=True))
+  chat = query.filter(
     models.Chat.id == chat_id,
     models.Chat.deleted_at.is_(None),
   ).first()

--- a/backend/app/routes/apps.py
+++ b/backend/app/routes/apps.py
@@ -23,7 +23,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from app import (
-  activity, app_activity, app_git, app_jobs, fs_locks, icon_cache,
+  activity, app_activity, app_git, app_jobs, app_preview, fs_locks, icon_cache,
   legacy_platform_apps,
   models, providers, schemas,
   source_dirs, theme,
@@ -416,6 +416,9 @@ async def _hard_delete_app(db: Session, app: models.App) -> None:
   db.query(models.AppActivityState).filter(
     models.AppActivityState.app_id == deleted_app_id,
   ).delete(synchronize_session=False)
+  db.query(models.AppPreviewState).filter(
+    models.AppPreviewState.app_id == deleted_app_id,
+  ).delete(synchronize_session=False)
   db.delete(app)
   db.commit()
   get_system_broadcast().publish(
@@ -702,7 +705,9 @@ async def list_apps(
     )
     .all()
   )
-  return app_activity.annotate_apps(db, apps)
+  return app_preview.annotate_apps(
+    db, app_activity.annotate_apps(db, apps)
+  )
 
 
 @router.get("/schedules", response_model=list[schemas.AppScheduleOut])
@@ -1837,7 +1842,9 @@ def get_app(
 ):
   """Returns a single mini-app by ID (404 for a tombstoned one)."""
   app = live_app_or_404(db, app_id)
-  return app_activity.annotate_apps(db, [app])[0]
+  return app_preview.annotate_apps(
+    db, app_activity.annotate_apps(db, [app])
+  )[0]
 
 
 class AppActivitySeenRequest(BaseModel):
@@ -1858,6 +1865,43 @@ def mark_app_activity_seen(
   """Clear an app's durable activity dot when the owner opens the app."""
   live_app_or_404(db, app_id)
   app_activity.mark_seen(db, app_id, body.activity_version)
+  db.commit()
+  return Response(status_code=204)
+
+
+class AppPreviewSeenRequest(BaseModel):
+  updated_at: datetime
+  final: bool = False
+
+
+@router.post(
+  "/{app_id}/preview/seen",
+  status_code=204,
+  dependencies=[Depends(reject_cross_site)],
+)
+def mark_app_preview_seen(
+  app_id: int,
+  body: AppPreviewSeenRequest,
+  db: Session = Depends(get_db),
+  _: models.Owner = Depends(get_current_owner),
+):
+  """Acknowledge the exact app build opened from its owning chat.
+
+  The client sends the version it rendered, not merely the app id. If a newer
+  compile races this request, the older acknowledgement remains older and the
+  new build's CTA stays visible.
+  """
+  app = live_app_or_404(db, app_id)
+  observed = app_preview.naive_utc(body.updated_at)
+  current = app_preview.naive_utc(app.updated_at)
+  if observed > current:
+    raise HTTPException(
+      status_code=409,
+      detail="Cannot acknowledge a preview newer than the installed app.",
+    )
+  app_preview.mark_seen(
+    db, app_id, observed, seen_as_final=body.final,
+  )
   db.commit()
   return Response(status_code=204)
 

--- a/backend/app/routes/apps.py
+++ b/backend/app/routes/apps.py
@@ -2677,6 +2677,10 @@ def get_app_job_context(
   choices = resolve_background_agents(get_settings().data_dir, {})
   return {
     "app_id": app_id,
+    # The supervisor binds the scheduled script to this exact app before
+    # granting its token and filesystem contract. This is non-secret durable
+    # identity, not owner configuration.
+    "source_dir": app.source_dir,
     "primary": choices.get("primary"),
     "fallback": choices.get("fallback"),
     # This is the same normalized, non-secret receipt the owner reviewed.

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -1153,17 +1153,18 @@ def get_chat_activity_detail(
   metadata. This endpoint resolves that metadata back to the exact stored
   blocks only after the owner opens the line. It never rewrites the transcript.
   """
-  if principal.scope == "app":
-    raise HTTPException(status_code=403, detail="App token is not valid here.")
-  require_chat_embed_operation(principal, "chat:read")
-  if end <= start or end - start > 2000:
-    raise HTTPException(status_code=422, detail="Invalid activity range.")
-
   from app.chat_transcript import (
+    MAX_ACTIVITY_DETAIL_BLOCKS,
     historical_tool_output_ids,
     materialized_messages,
     project_messages_for_detail,
   )
+
+  if principal.scope == "app":
+    raise HTTPException(status_code=403, detail="App token is not valid here.")
+  require_chat_embed_operation(principal, "chat:read")
+  if end <= start or end - start > MAX_ACTIVITY_DETAIL_BLOCKS:
+    raise HTTPException(status_code=422, detail="Invalid activity range.")
 
   chat = get_active_chat_for_principal(db, chat_id, principal)
   messages = materialized_messages(chat)
@@ -1198,6 +1199,7 @@ def get_chat_activity_detail(
       row[0]
       for row in db.query(models.ToolOutput.tool_use_id).filter(
         models.ToolOutput.chat_id == chat.id,
+        models.ToolOutput.tool_use_id.in_(candidate_tool_ids),
       ).all()
     }
     if candidate_tool_ids

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -1323,6 +1323,71 @@ def get_chat_agent_context(
   }
 
 
+@router.get("/{chat_id}/usage")
+def get_chat_usage(
+  chat_id: str,
+  _: models.Owner = Depends(get_current_owner),
+  db: Session = Depends(get_db),
+):
+  """Return provider-neutral token accounting for every durable chat run.
+
+  Historical rows created before usage capture remain visible with null
+  counters, so callers can distinguish zero usage from missing coverage.
+  This owner-only diagnostic is deliberately independent of the transcript:
+  benchmark tooling can read it without parsing user-visible messages.
+  """
+  get_active_chat_or_404(db, chat_id)
+  runs = (
+    db.query(models.ChatRun)
+    .filter(models.ChatRun.chat_id == chat_id)
+    .order_by(models.ChatRun.started_at.asc(), models.ChatRun.id.asc())
+    .all()
+  )
+  count_fields = (
+    "input_tokens",
+    "output_tokens",
+    "cache_read_input_tokens",
+    "cache_creation_input_tokens",
+    "reasoning_output_tokens",
+    "total_tokens",
+  )
+  totals = {}
+  for field in count_fields:
+    values = [
+      int(getattr(run, field))
+      for run in runs
+      if getattr(run, field) is not None
+    ]
+    totals[field] = sum(values) if values else None
+  costs = [float(run.cost_usd) for run in runs if run.cost_usd is not None]
+  totals["cost_usd"] = sum(costs) if costs else None
+
+  return {
+    "chat_id": chat_id,
+    "coverage": {
+      "runs": len(runs),
+      "runs_with_usage": sum(run.usage_json is not None for run in runs),
+      "runs_with_cost": len(costs),
+    },
+    "totals": totals,
+    "runs": [
+      {
+        "id": run.id,
+        "status": run.status,
+        "provider": run.provider,
+        "provider_session_id": run.provider_session_id,
+        "started_at": run.started_at,
+        "ended_at": run.ended_at,
+        "cost_usd": run.cost_usd,
+        **{field: getattr(run, field) for field in count_fields},
+        "model_context_window": run.model_context_window,
+        "usage": run.usage_json,
+      }
+      for run in runs
+    ],
+  }
+
+
 @router.delete(
   "/{chat_id}", status_code=204, dependencies=[Depends(reject_cross_site)],
 )

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -292,9 +292,11 @@ def _chat_detail_response(
   limit: int = 20,
   before: int | None = None,
   expose_session: bool = True,
+  compact: bool = False,
 ) -> dict:
   """Canonical paginated chat payload shared by create and detail reads."""
   from app.chat_transcript import (
+    compact_messages_for_detail,
     historical_tool_output_ids,
     materialized_messages,
     project_messages_for_detail,
@@ -338,6 +340,12 @@ def _chat_detail_response(
     fetchable_tool_output_ids=fetchable_tool_ids,
     live_message=live_message,
   )
+  if compact:
+    page = compact_messages_for_detail(
+      page,
+      message_offset=start,
+      live_message=live_message,
+    )
 
   provider = chat.provider or "claude"
   pending_question = questions.get(chat.id)
@@ -1073,6 +1081,7 @@ def get_chat(
   chat_id: str,
   limit: int = 20,
   before: int | None = None,
+  compact: bool = False,
   principal: Principal = Depends(get_owner_or_chat_embed_principal),
   db: Session = Depends(get_db),
 ):
@@ -1096,10 +1105,114 @@ def get_chat(
     db=db,
     limit=limit,
     before=before,
+    compact=compact,
     # Provider thread ids are backend continuity state, not part of the
     # embedded participant surface.
     expose_session=principal.scope != "chat_embed",
   )
+
+
+@router.get("/{chat_id}/runtime")
+def get_chat_runtime(
+  chat_id: str,
+  principal: Principal = Depends(get_owner_or_chat_embed_principal),
+  db: Session = Depends(get_db),
+):
+  """Return only the mutable runtime fields used by mounted chat controls."""
+  if principal.scope == "app":
+    raise HTTPException(status_code=403, detail="App token is not valid here.")
+  require_chat_embed_operation(principal, "chat:read")
+  chat = get_active_chat_for_principal(
+    db,
+    chat_id,
+    principal,
+    load_fields=(models.Chat.pending_messages,),
+  )
+  pending_question = questions.get(chat.id)
+  return {
+    "running": is_chat_running(chat.id),
+    "pending_messages": list(chat.pending_messages or []),
+    "pending_question_id": (
+      pending_question.question_id if pending_question is not None else None
+    ),
+  }
+
+
+@router.get("/{chat_id}/activity-detail")
+def get_chat_activity_detail(
+  chat_id: str,
+  message_index: int = Query(ge=0),
+  start: int = Query(ge=0),
+  end: int = Query(gt=0),
+  principal: Principal = Depends(get_owner_or_chat_embed_principal),
+  db: Session = Depends(get_db),
+):
+  """Return one deliberately expanded historical activity range.
+
+  The ordinary transcript read projects multi-step activity into collapsed
+  metadata. This endpoint resolves that metadata back to the exact stored
+  blocks only after the owner opens the line. It never rewrites the transcript.
+  """
+  if principal.scope == "app":
+    raise HTTPException(status_code=403, detail="App token is not valid here.")
+  require_chat_embed_operation(principal, "chat:read")
+  if end <= start or end - start > 2000:
+    raise HTTPException(status_code=422, detail="Invalid activity range.")
+
+  from app.chat_transcript import (
+    historical_tool_output_ids,
+    materialized_messages,
+    project_messages_for_detail,
+  )
+
+  chat = get_active_chat_for_principal(db, chat_id, principal)
+  messages = materialized_messages(chat)
+  if message_index >= len(messages):
+    raise HTTPException(status_code=404, detail="Activity message not found.")
+  message = messages[message_index]
+  blocks = message.get("blocks") if isinstance(message, dict) else None
+  if not isinstance(blocks, list) or end > len(blocks):
+    raise HTTPException(status_code=404, detail="Activity range not found.")
+
+  selected = [
+    (raw_index, block)
+    for raw_index, block in enumerate(blocks[start:end], start=start)
+    if isinstance(block, dict)
+    and block.get("type") in {"tool", "thinking"}
+    and not (
+      block.get("type") == "tool"
+      and block.get("tool") in {"AskUserQuestion", "request_user_input"}
+      and any(
+        isinstance(candidate, dict) and candidate.get("type") == "question"
+        for candidate in blocks
+      )
+    )
+  ]
+  detail_message = {
+    "role": "assistant",
+    "blocks": [block for _, block in selected],
+  }
+  candidate_tool_ids = historical_tool_output_ids([detail_message])
+  fetchable_tool_ids = (
+    {
+      row[0]
+      for row in db.query(models.ToolOutput.tool_use_id).filter(
+        models.ToolOutput.chat_id == chat.id,
+      ).all()
+    }
+    if candidate_tool_ids
+    else set()
+  )
+  projected = project_messages_for_detail(
+    [detail_message],
+    fetchable_tool_output_ids=fetchable_tool_ids,
+  )[0]["blocks"]
+  return {
+    "entries": [
+      {"item": block, "idx": raw_index}
+      for (raw_index, _), block in zip(selected, projected, strict=True)
+    ],
+  }
 
 
 @router.get("/{chat_id}/tool-output/{tool_use_id}", response_class=PlainTextResponse)

--- a/backend/app/runtime_types.py
+++ b/backend/app/runtime_types.py
@@ -12,6 +12,7 @@ class RunnerResult(TypedDict):
   cost_usd: float | None
   error: str | None
   usage: NotRequired[dict | None]
+  usage_metrics: NotRequired[dict | None]
   terminal_status: NotRequired[str | None]
   final_message_phase: NotRequired[str | None]
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -113,6 +113,11 @@ class AppOut(BaseModel):
   # opened. The shell renders the same quiet activity dot used for chats.
   has_unseen_activity: bool = False
   unseen_activity_version: int | None = None
+  # Exact executable build last opened from the owning chat's CTA. Opening a
+  # live preview and opening the settled result are separate acknowledgements:
+  # the same build may surface once more when its agent turn finishes.
+  preview_seen_updated_at: datetime | None = None
+  preview_seen_final: bool = False
   cross_app_access: ShareLevel = "none"
   share_with_apps: ShareLevel = "none"
   offline_capable: bool = False

--- a/backend/app/usage_metrics.py
+++ b/backend/app/usage_metrics.py
@@ -1,0 +1,173 @@
+"""Provider-neutral per-turn token-usage normalization.
+
+Claude reports one aggregate usage dict on its terminal ResultMessage. Codex
+reports a sequence of ThreadTokenUsage updates containing:
+
+- ``last``: the latest model call;
+- ``total``: cumulative usage for the provider thread.
+
+For Codex, the first update implies the pre-turn baseline
+(``first.total - first.last``). Subtracting that baseline from the final total
+produces the sum of every model call in this Möbius turn — the quantity needed
+to compare harness context efficiency.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _count(value: Any) -> int:
+  """Return a non-negative integer counter; unknown SDK values become zero."""
+  if isinstance(value, bool):
+    return 0
+  try:
+    return max(0, int(value or 0))
+  except (TypeError, ValueError):
+    return 0
+
+
+def _plain(value: Any) -> Any:
+  """Convert generated SDK models into JSON-safe plain values."""
+  if value is None:
+    return None
+  if hasattr(value, "model_dump"):
+    return value.model_dump(mode="json", by_alias=True)
+  if isinstance(value, dict):
+    return {str(k): _plain(v) for k, v in value.items()}
+  if isinstance(value, (list, tuple)):
+    return [_plain(v) for v in value]
+  if isinstance(value, (str, int, float, bool)):
+    return value
+  return str(value)
+
+
+def normalize_claude_usage(
+  usage: dict[str, Any] | None,
+  model_usage: dict[str, Any] | None = None,
+) -> dict | None:
+  """Normalize Claude's terminal turn aggregate.
+
+  Anthropic reports uncached input, cache creation, and cache reads as separate
+  counters. ``input_tokens`` below intentionally adds all three so it measures
+  total context processed/re-fed for the turn, matching the harness-efficiency
+  quantity Codex exposes.
+  """
+  if not usage:
+    return None
+  uncached = _count(usage.get("input_tokens"))
+  cache_write = _count(usage.get("cache_creation_input_tokens"))
+  cache_read = _count(usage.get("cache_read_input_tokens"))
+  output = _count(usage.get("output_tokens"))
+  input_total = uncached + cache_write + cache_read
+  context_windows = [
+    _count(details.get("contextWindow"))
+    for details in (model_usage or {}).values()
+    if isinstance(details, dict)
+  ]
+  return {
+    "provider": "claude",
+    "scope": "turn",
+    "calculation": "result_aggregate",
+    "input_tokens": input_total,
+    "uncached_input_tokens": uncached,
+    "output_tokens": output,
+    "cache_read_input_tokens": cache_read,
+    "cache_creation_input_tokens": cache_write,
+    "reasoning_output_tokens": _count(usage.get("reasoning_tokens")),
+    "total_tokens": input_total + output,
+    "model_context_window": max(context_windows, default=0) or None,
+    "provider_usage": _plain(usage),
+    "provider_model_usage": _plain(model_usage),
+  }
+
+
+_CODEX_FIELDS = (
+  "input_tokens",
+  "cached_input_tokens",
+  "output_tokens",
+  "reasoning_output_tokens",
+  "total_tokens",
+)
+
+
+def _codex_breakdown(value: Any) -> dict[str, int]:
+  if value is None:
+    return {field: 0 for field in _CODEX_FIELDS}
+  def read(field: str) -> Any:
+    if not isinstance(value, dict):
+      return getattr(value, field, None)
+    camel = field.split("_")[0] + "".join(
+      part.title() for part in field.split("_")[1:]
+    )
+    return value.get(field, value.get(camel))
+  return {
+    field: _count(read(field))
+    for field in _CODEX_FIELDS
+  }
+
+
+def _member(value: Any, field: str) -> Any:
+  if isinstance(value, dict):
+    camel = field.split("_")[0] + "".join(
+      part.title() for part in field.split("_")[1:]
+    )
+    return value.get(field, value.get(camel))
+  return getattr(value, field, None)
+
+
+def _subtract_counts(
+  current: dict[str, int],
+  baseline: dict[str, int],
+) -> dict[str, int]:
+  return {
+    field: max(0, current[field] - baseline[field])
+    for field in _CODEX_FIELDS
+  }
+
+
+def normalize_codex_usage(
+  first_usage: Any | None,
+  final_usage: Any | None,
+) -> dict | None:
+  """Derive one Möbius-turn aggregate from Codex thread usage updates."""
+  if final_usage is None:
+    return None
+  first_usage = first_usage or final_usage
+  first_total = _codex_breakdown(_member(first_usage, "total"))
+  first_last = _codex_breakdown(_member(first_usage, "last"))
+  baseline = _subtract_counts(first_total, first_last)
+  final_total = _codex_breakdown(_member(final_usage, "total"))
+
+  # A cumulative provider counter should never go backwards. If an SDK/server
+  # reset makes it do so, the only honest bounded fallback is the latest call;
+  # retain the calculation label so benchmark consumers can exclude it.
+  if any(final_total[field] < baseline[field] for field in _CODEX_FIELDS):
+    turn = _codex_breakdown(_member(final_usage, "last"))
+    calculation = "last_call_fallback"
+  else:
+    turn = _subtract_counts(final_total, baseline)
+    calculation = "thread_delta"
+
+  input_total = turn["input_tokens"]
+  cached = min(turn["cached_input_tokens"], input_total)
+  return {
+    "provider": "codex",
+    "scope": "turn",
+    "calculation": calculation,
+    "input_tokens": input_total,
+    "uncached_input_tokens": max(0, input_total - cached),
+    "output_tokens": turn["output_tokens"],
+    "cache_read_input_tokens": cached,
+    "cache_creation_input_tokens": 0,
+    "reasoning_output_tokens": turn["reasoning_output_tokens"],
+    "total_tokens": turn["total_tokens"],
+    "model_context_window": _count(
+      _member(final_usage, "model_context_window")
+    ) or None,
+    "provider_thread_total": final_total,
+    "provider_usage": {
+      "first": _plain(first_usage),
+      "final": _plain(final_usage),
+    },
+  }

--- a/backend/scripts/app-job-runner.py
+++ b/backend/scripts/app-job-runner.py
@@ -100,12 +100,11 @@ def _job_context(app_id: int, token: str) -> dict | None:
 def _job_matches_context(resolved: Path, context: dict) -> bool:
   """Bind a scheduled script to the exact app whose authority it receives.
 
-  Older backends omit ``source_dir``; accept that response during a rolling
-  platform/image update. Once the field is present, malformed, missing, or
-  mismatched paths fail closed before the app token reaches a child process.
+  Missing, malformed, or mismatched identity fails closed before the app token
+  reaches a child process. During a platform-update window, an older backend
+  may omit ``source_dir``; skipping that run is safer than retaining a
+  permanent compatibility path around this capability boundary.
   """
-  if "source_dir" not in context:
-    return True
   source_dir = context.get("source_dir")
   if not isinstance(source_dir, str) or not source_dir:
     return False

--- a/backend/scripts/app-job-runner.py
+++ b/backend/scripts/app-job-runner.py
@@ -97,6 +97,25 @@ def _job_context(app_id: int, token: str) -> dict | None:
     return None
 
 
+def _job_matches_context(resolved: Path, context: dict) -> bool:
+  """Bind a scheduled script to the exact app whose authority it receives.
+
+  Older backends omit ``source_dir``; accept that response during a rolling
+  platform/image update. Once the field is present, malformed, missing, or
+  mismatched paths fail closed before the app token reaches a child process.
+  """
+  if "source_dir" not in context:
+    return True
+  source_dir = context.get("source_dir")
+  if not isinstance(source_dir, str) or not source_dir:
+    return False
+  try:
+    expected = Path(source_dir).resolve(strict=True)
+  except (OSError, RuntimeError):
+    return False
+  return expected == resolved.parent
+
+
 def _mint_app_token(app_id: int) -> str | None:
   """Exchange the owner service credential for one short-lived app token."""
   try:
@@ -280,6 +299,9 @@ def run() -> int:
     context = _job_context(app_id, app_token)
     if context is None:
       _log(app_id, "failed: job-context fetch")
+      return 4
+    if not _job_matches_context(resolved, context):
+      _log(app_id, f"rejected: job does not belong to app: {resolved}")
       return 4
     command = _sandboxed_command(app_id, resolved, context)
     if command is None:

--- a/backend/tests/test_app_jobs.py
+++ b/backend/tests/test_app_jobs.py
@@ -176,6 +176,40 @@ def test_wrapper_runs_job_only_after_live_check(tmp_path, monkeypatch):
   assert "AGENT_TOKEN" not in child_env
 
 
+def test_wrapper_rejects_a_job_from_another_live_app(tmp_path, monkeypatch):
+  runner = _load_runner()
+  data_dir = tmp_path / "data"
+  memory_source = data_dir / "apps" / "memory"
+  reflection_source = data_dir / "apps" / "reflection"
+  memory_source.mkdir(parents=True)
+  reflection_source.mkdir()
+  job = memory_source / "fetch.sh"
+  job.write_text("#!/bin/sh\nexit 0\n")
+  monkeypatch.setattr(runner, "DATA_DIR", data_dir)
+  monkeypatch.setattr(runner, "_mint_app_token", lambda app_id: "app-token")
+  monkeypatch.setattr(
+    runner, "_app_is_live", lambda app_id, token=None: True,
+  )
+  monkeypatch.setattr(
+    runner,
+    "_job_context",
+    lambda app_id, token: {"source_dir": str(reflection_source)},
+  )
+  monkeypatch.setattr(runner.os, "getsid", lambda _pid: os.getpid())
+  calls = []
+  monkeypatch.setattr(
+    runner.subprocess,
+    "Popen",
+    lambda *args, **kwargs: calls.append((args, kwargs)),
+  )
+  monkeypatch.setattr(runner.sys, "argv", [
+    "app-job-runner.py", "56", str(job),
+  ])
+
+  assert runner.run() == 4
+  assert calls == []
+
+
 def test_background_agent_command_masks_platform_data_and_mounts_declared_scope(
   tmp_path, monkeypatch,
 ):
@@ -321,6 +355,7 @@ def test_job_context_is_nonsecret_and_self_scoped(client, owner_token, db):
   assert response.status_code == 200, response.text
   body = response.json()
   assert body["app_id"] == own.id
+  assert body["source_dir"] == own.source_dir
   serialized = json.dumps(body).lower()
   assert "token" not in serialized
   assert "credential" not in serialized

--- a/backend/tests/test_app_jobs.py
+++ b/backend/tests/test_app_jobs.py
@@ -155,7 +155,11 @@ def test_wrapper_runs_job_only_after_live_check(tmp_path, monkeypatch):
     runner, "_app_is_live", lambda app_id, token=None: True,
   )
   monkeypatch.setattr(runner.os, "getsid", lambda _pid: os.getpid())
-  monkeypatch.setattr(runner, "_job_context", lambda app_id, token: {})
+  monkeypatch.setattr(
+    runner,
+    "_job_context",
+    lambda app_id, token: {"source_dir": str(source)},
+  )
   popen = types.SimpleNamespace(wait=lambda: 0)
   calls = []
   monkeypatch.setattr(
@@ -195,6 +199,35 @@ def test_wrapper_rejects_a_job_from_another_live_app(tmp_path, monkeypatch):
     "_job_context",
     lambda app_id, token: {"source_dir": str(reflection_source)},
   )
+  monkeypatch.setattr(runner.os, "getsid", lambda _pid: os.getpid())
+  calls = []
+  monkeypatch.setattr(
+    runner.subprocess,
+    "Popen",
+    lambda *args, **kwargs: calls.append((args, kwargs)),
+  )
+  monkeypatch.setattr(runner.sys, "argv", [
+    "app-job-runner.py", "56", str(job),
+  ])
+
+  assert runner.run() == 4
+  assert calls == []
+
+
+def test_wrapper_rejects_job_context_without_exact_app_identity(
+  tmp_path, monkeypatch,
+):
+  runner = _load_runner()
+  source = tmp_path / "data" / "apps" / "memory"
+  source.mkdir(parents=True)
+  job = source / "fetch.sh"
+  job.write_text("#!/bin/sh\nexit 0\n")
+  monkeypatch.setattr(runner, "DATA_DIR", tmp_path / "data")
+  monkeypatch.setattr(runner, "_mint_app_token", lambda app_id: "app-token")
+  monkeypatch.setattr(
+    runner, "_app_is_live", lambda app_id, token=None: True,
+  )
+  monkeypatch.setattr(runner, "_job_context", lambda app_id, token: {})
   monkeypatch.setattr(runner.os, "getsid", lambda _pid: os.getpid())
   calls = []
   monkeypatch.setattr(

--- a/backend/tests/test_app_preview.py
+++ b/backend/tests/test_app_preview.py
@@ -1,0 +1,91 @@
+"""Owning-chat app CTAs acknowledge exact preview builds durably."""
+
+from datetime import timedelta
+
+from app import models
+
+
+def _app(db):
+  app = models.App(
+    name="Atlas", description="", chat_id="chat-a",
+    jsx_source="export default function App(){}",
+    compiled_path="/tmp/app.js",
+  )
+  db.add(app)
+  db.commit()
+  db.refresh(app)
+  return app
+
+
+def _listed(client, auth, app_id):
+  response = client.get("/api/apps/", headers=auth)
+  assert response.status_code == 200, response.text
+  return next(row for row in response.json() if row["id"] == app_id)
+
+
+def test_preview_then_final_acknowledgement_is_durable(client, auth, db):
+  app = _app(db)
+  row = _listed(client, auth, app.id)
+  assert row["preview_seen_updated_at"] is None
+  assert row["preview_seen_final"] is False
+
+  preview = client.post(
+    f"/api/apps/{app.id}/preview/seen",
+    headers=auth,
+    json={"updated_at": row["updated_at"], "final": False},
+  )
+  assert preview.status_code == 204, preview.text
+  row = _listed(client, auth, app.id)
+  assert row["preview_seen_updated_at"] == row["updated_at"]
+  assert row["preview_seen_final"] is False
+
+  final = client.post(
+    f"/api/apps/{app.id}/preview/seen",
+    headers=auth,
+    json={"updated_at": row["updated_at"], "final": True},
+  )
+  assert final.status_code == 204, final.text
+  row = _listed(client, auth, app.id)
+  assert row["preview_seen_updated_at"] == row["updated_at"]
+  assert row["preview_seen_final"] is True
+
+
+def test_stale_open_never_hides_a_newer_build(client, auth, db):
+  app = _app(db)
+  old_version = app.updated_at
+
+  app.updated_at = old_version + timedelta(seconds=1)
+  db.commit()
+  db.refresh(app)
+  new_version = app.updated_at
+
+  current = client.post(
+    f"/api/apps/{app.id}/preview/seen",
+    headers=auth,
+    json={"updated_at": new_version.isoformat(), "final": False},
+  )
+  assert current.status_code == 204, current.text
+
+  # A delayed click from another pane/device cannot move the acknowledgement
+  # back or incorrectly promote the current build to its final phase.
+  stale = client.post(
+    f"/api/apps/{app.id}/preview/seen",
+    headers=auth,
+    json={"updated_at": old_version.isoformat(), "final": True},
+  )
+  assert stale.status_code == 204, stale.text
+  row = _listed(client, auth, app.id)
+  assert row["preview_seen_updated_at"] == row["updated_at"]
+  assert row["preview_seen_final"] is False
+
+
+def test_future_preview_version_is_rejected(client, auth, db):
+  app = _app(db)
+  future = app.updated_at + timedelta(days=1)
+  response = client.post(
+    f"/api/apps/{app.id}/preview/seen",
+    headers=auth,
+    json={"updated_at": future.isoformat(), "final": True},
+  )
+  assert response.status_code == 409, response.text
+  assert db.get(models.AppPreviewState, app.id) is None

--- a/backend/tests/test_chat_runs.py
+++ b/backend/tests/test_chat_runs.py
@@ -14,7 +14,7 @@ from app import chat as chat_mod
 from app import models
 from app.chat_writer import (
   AppendPending, Barrier, ClearRunStatus, PromotePending, StartTurn,
-  alloc_run_token, get_writer,
+  RecordRunMetrics, alloc_run_token, get_writer,
 )
 from app.database import SessionLocal
 
@@ -125,6 +125,49 @@ def test_clear_run_status_preserves_failed_outcome():
   _drain()
   assert _runs("r2-failed")["rt-2-failed"] == ("failed", True)
   assert _run_status("r2-failed") is None
+
+
+def test_record_run_metrics_updates_exact_run_without_touching_transcript():
+  _seed_chat("r-metrics", messages=[{
+    "role": "user", "content": "keep me", "ts": 1,
+  }])
+  _seed_run("rt-metrics", "r-metrics")
+
+  get_writer().submit(RecordRunMetrics(
+    chat_id="r-metrics",
+    run_token="rt-metrics",
+    provider_session_id="provider-thread",
+    cost_usd=0.125,
+    usage={
+      "provider": "codex",
+      "input_tokens": 900,
+      "output_tokens": 200,
+      "cache_read_input_tokens": 500,
+      "cache_creation_input_tokens": 0,
+      "reasoning_output_tokens": 100,
+      "total_tokens": 1_100,
+      "model_context_window": 200_000,
+    },
+  )).result(timeout=5)
+
+  db = SessionLocal()
+  try:
+    run = db.query(models.ChatRun).filter(
+      models.ChatRun.id == "rt-metrics",
+    ).one()
+    chat = db.query(models.Chat).filter(models.Chat.id == "r-metrics").one()
+    assert run.provider_session_id == "provider-thread"
+    assert run.cost_usd == 0.125
+    assert run.input_tokens == 900
+    assert run.output_tokens == 200
+    assert run.cache_read_input_tokens == 500
+    assert run.reasoning_output_tokens == 100
+    assert run.total_tokens == 1_100
+    assert run.model_context_window == 200_000
+    assert run.usage_json["provider"] == "codex"
+    assert chat.messages == [{"role": "user", "content": "keep me", "ts": 1}]
+  finally:
+    db.close()
 
 
 # -- continuation handoff -------------------------------------------------

--- a/backend/tests/test_chat_transcript_compact.py
+++ b/backend/tests/test_chat_transcript_compact.py
@@ -115,6 +115,37 @@ def test_repeated_activity_metadata_is_bounded_by_variety():
   ] == ["Bash", "Bash", "Edit"]
 
 
+def test_long_activity_runs_are_split_into_fetchable_ranges():
+  blocks = [
+    {
+      "type": "tool",
+      "tool": "Bash",
+      "status": "done",
+      "output": f"step {index}",
+    }
+    for index in range(2001)
+  ]
+
+  compact = compact_messages_for_detail(
+    [{"role": "assistant", "blocks": blocks}],
+    message_offset=4,
+  )
+
+  assert compact[0]["blocks"] == [
+    {
+      **compact[0]["blocks"][0],
+      "activity_id": "4:0:2000",
+      "message_index": 4,
+      "start": 0,
+      "end": 2000,
+      "tool_count": 2000,
+    },
+    blocks[2000],
+  ]
+  assert compact[0]["blocks"][0]["type"] == "activity"
+  assert compact[0]["blocks"][0]["end"] - compact[0]["blocks"][0]["start"] == 2000
+
+
 def test_single_activity_and_live_message_remain_self_contained():
   single = {
     "role": "assistant",
@@ -218,6 +249,57 @@ def test_compact_route_defers_activity_detail_until_expansion(client, auth):
   entries = detail.json()["entries"]
   assert entries[0]["item"]["content"] == "private trace"
   assert entries[1]["item"]["output"] == "hello"
+
+
+def test_activity_detail_queries_only_candidate_tool_sidecars(
+  client,
+  auth,
+  db,
+):
+  messages = [{
+    "role": "assistant",
+    "blocks": [
+      {"type": "thinking", "content": "trace"},
+      {
+        "type": "tool",
+        "tool": "Bash",
+        "tool_use_id": "tool-candidate",
+        "status": "done",
+        "output": "preview",
+        "output_truncated": True,
+      },
+    ],
+  }]
+  created = client.post(
+    "/api/chats",
+    headers=auth,
+    json={"title": "Scoped sidecars", "messages": messages},
+  )
+  chat_id = created.json()["id"]
+  statements = []
+  engine = db.get_bind()
+
+  def capture_sql(_, __, statement, *args):
+    statements.append(statement.lower())
+
+  event.listen(engine, "before_cursor_execute", capture_sql)
+  try:
+    detail = client.get(
+      f"/api/chats/{chat_id}/activity-detail"
+      "?message_index=0&start=0&end=2",
+      headers=auth,
+    )
+  finally:
+    event.remove(engine, "before_cursor_execute", capture_sql)
+
+  assert detail.status_code == 200
+  sidecar_select = next(
+    statement
+    for statement in statements
+    if "from tool_outputs" in statement
+  )
+  assert "tool_outputs.chat_id =" in sidecar_select
+  assert "tool_outputs.tool_use_id in (" in sidecar_select
 
 
 def test_runtime_route_does_not_select_transcript_json(

--- a/backend/tests/test_chat_transcript_compact.py
+++ b/backend/tests/test_chat_transcript_compact.py
@@ -1,0 +1,260 @@
+"""Compact chat reads keep the transcript light without changing stored truth."""
+
+from app.chat_transcript import compact_messages_for_detail
+from sqlalchemy import event
+
+
+def test_compacts_multi_step_activity_and_preserves_render_metadata():
+  source = {"title": "Reference", "url": "https://example.com/reference"}
+  messages = [{
+    "role": "assistant",
+    "content": "Answer",
+    "blocks": [
+      {"type": "text", "content": "Before"},
+      {"type": "thinking", "thinking_id": "thought-1", "duration_ms": 1200},
+      {
+        "type": "tool",
+        "tool": "WebSearch",
+        "tool_use_id": "tool-1",
+        "status": "done",
+        "input": {"query": "large private input"},
+        "output": "large output",
+        "sources": [source],
+        "subagent": {"helper": {"status": "done"}},
+      },
+      {
+        "type": "tool",
+        "tool": "Bash",
+        "tool_use_id": "tool-2",
+        "status": "done",
+        "output": "more output",
+        "output_exit_code": 0,
+      },
+      {"type": "text", "content": "After"},
+    ],
+  }]
+
+  compact = compact_messages_for_detail(messages, message_offset=40)
+
+  assert compact is not messages
+  assert compact[0] is not messages[0]
+  assert "content" not in compact[0]
+  assert compact[0]["blocks"][0] == {"type": "text", "content": "Before"}
+  summary = compact[0]["blocks"][1]
+  assert summary == {
+    "type": "activity",
+    "activity_id": "40:1:4",
+    "message_index": 40,
+    "start": 1,
+    "end": 4,
+    "tool_count": 2,
+    "entries": [
+      {
+        "item": {
+          "type": "thinking",
+          "thinking_id": "thought-1",
+          "duration_ms": 1200,
+        },
+        "idx": 1,
+      },
+      {
+        "item": {
+          "type": "tool",
+          "tool": "WebSearch",
+          "status": "done",
+          "tool_use_id": "tool-1",
+          "subagent": {"helper": {"status": "done"}},
+        },
+        "idx": 2,
+      },
+      {
+        "item": {
+          "type": "tool",
+          "tool": "Bash",
+          "status": "done",
+          "tool_use_id": "tool-2",
+          "output_exit_code": 0,
+        },
+        "idx": 3,
+      },
+    ],
+    "sources": [source],
+  }
+  assert compact[0]["blocks"][2] == {"type": "text", "content": "After"}
+  assert messages[0]["blocks"][2]["output"] == "large output"
+
+
+def test_repeated_activity_metadata_is_bounded_by_variety():
+  blocks = [
+    {"type": "thinking", "duration_ms": 100},
+    *[
+      {
+        "type": "tool",
+        "tool": "Bash",
+        "status": "done",
+        "output": f"step {index}",
+      }
+      for index in range(100)
+    ],
+    {"type": "thinking", "duration_ms": 200},
+    {"type": "tool", "tool": "Edit", "status": "done"},
+  ]
+
+  compact = compact_messages_for_detail(
+    [{"role": "assistant", "blocks": blocks}],
+    message_offset=0,
+  )
+  summary = compact[0]["blocks"][0]
+
+  assert summary["tool_count"] == 101
+  assert len(summary["entries"]) == 4
+  assert summary["entries"][0]["item"]["duration_ms"] == 300
+  assert [
+    entry["item"].get("tool")
+    for entry in summary["entries"][1:]
+  ] == ["Bash", "Bash", "Edit"]
+
+
+def test_single_activity_and_live_message_remain_self_contained():
+  single = {
+    "role": "assistant",
+    "content": "One step",
+    "blocks": [
+      {"type": "tool", "tool": "Read", "input": "/tmp/note.txt"},
+      {"type": "text", "content": "Done"},
+    ],
+  }
+  live = {
+    "role": "assistant",
+    "blocks": [
+      {"type": "thinking", "content": "working"},
+      {"type": "tool", "tool": "Bash", "output": "live"},
+    ],
+  }
+  messages = [single, live]
+
+  compact = compact_messages_for_detail(
+    messages,
+    message_offset=0,
+    live_message=live,
+  )
+
+  assert compact is messages
+  assert compact[0] is single
+  assert compact[1] is live
+
+
+def test_image_reads_stay_distinctive_and_question_twins_are_not_rendered():
+  messages = [{
+    "role": "assistant",
+    "content": "Picked",
+    "blocks": [
+      {"type": "thinking", "duration_ms": 10},
+      {"type": "tool", "tool": "Read", "input": "/tmp/photo.webp"},
+      {"type": "tool", "tool": "Bash", "output": "one"},
+      {"type": "thinking", "duration_ms": 20},
+      {"type": "tool", "tool": "request_user_input", "status": "done"},
+      {"type": "question", "question_id": "q1", "questions": []},
+    ],
+  }]
+
+  compact = compact_messages_for_detail(messages, message_offset=7)
+  blocks = compact[0]["blocks"]
+
+  assert blocks[0]["type"] == "thinking"
+  assert blocks[1] == messages[0]["blocks"][1]
+  assert blocks[2]["type"] == "activity"
+  assert blocks[2]["start"] == 2
+  assert blocks[2]["end"] == 4
+  assert blocks[3]["type"] == "question"
+  assert all(
+    block.get("tool") != "request_user_input"
+    for block in blocks
+    if isinstance(block, dict)
+  )
+
+
+def test_compact_route_defers_activity_detail_until_expansion(client, auth):
+  messages = [{
+    "role": "assistant",
+    "content": "Complete answer",
+    "blocks": [
+      {"type": "thinking", "content": "private trace", "duration_ms": 500},
+      {
+        "type": "tool",
+        "tool": "Bash",
+        "tool_use_id": "tool-full",
+        "status": "done",
+        "input": "printf hello",
+        "output": "hello",
+      },
+      {"type": "text", "content": "Complete answer"},
+    ],
+  }]
+  created = client.post(
+    "/api/chats",
+    headers=auth,
+    json={"title": "Compact route", "messages": messages},
+  )
+  assert created.status_code == 200
+  chat_id = created.json()["id"]
+
+  compact = client.get(
+    f"/api/chats/{chat_id}?limit=20&compact=1",
+    headers=auth,
+  )
+  assert compact.status_code == 200
+  summary = compact.json()["messages"][0]["blocks"][0]
+  assert summary["type"] == "activity"
+  assert "content" not in summary["entries"][0]["item"]
+  assert "output" not in summary["entries"][1]["item"]
+
+  detail = client.get(
+    f"/api/chats/{chat_id}/activity-detail"
+    "?message_index=0&start=0&end=2",
+    headers=auth,
+  )
+  assert detail.status_code == 200
+  entries = detail.json()["entries"]
+  assert entries[0]["item"]["content"] == "private trace"
+  assert entries[1]["item"]["output"] == "hello"
+
+
+def test_runtime_route_does_not_select_transcript_json(
+  client,
+  auth,
+  db,
+  monkeypatch,
+):
+  created = client.post(
+    "/api/chats",
+    headers=auth,
+    json={"title": "Runtime projection"},
+  )
+  chat_id = created.json()["id"]
+  monkeypatch.setattr("app.routes.chats.is_chat_running", lambda _: True)
+  statements = []
+  engine = db.get_bind()
+
+  def capture_sql(_, __, statement, *args):
+    statements.append(statement.lower())
+
+  event.listen(engine, "before_cursor_execute", capture_sql)
+  try:
+    runtime = client.get(f"/api/chats/{chat_id}/runtime", headers=auth)
+  finally:
+    event.remove(engine, "before_cursor_execute", capture_sql)
+
+  assert runtime.status_code == 200
+  assert runtime.json() == {
+    "running": True,
+    "pending_messages": [],
+    "pending_question_id": None,
+  }
+  chat_select = next(
+    statement
+    for statement in statements
+    if "from chats" in statement and "chats.pending_messages" in statement
+  )
+  assert "chats.pending_messages" in chat_select
+  assert "chats.messages as" not in chat_select

--- a/backend/tests/test_chats.py
+++ b/backend/tests/test_chats.py
@@ -1,6 +1,7 @@
 """Chat route regression tests."""
 
 import asyncio
+from datetime import UTC, datetime
 import io
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
@@ -128,6 +129,63 @@ def test_agent_context_includes_evolving_chat_summary(
     "digest": "A bounded digest.",
   }]
   assert payload["system_prompt_origin"] == "platform"
+
+
+def test_chat_usage_reports_totals_and_historic_coverage(
+  client, auth, chat, db,
+):
+  db.add_all([
+    models.ChatRun(
+      id="historic-run",
+      chat_id=chat.id,
+      status="completed",
+      provider="claude",
+      started_at=datetime.now(UTC),
+    ),
+    models.ChatRun(
+      id="measured-run",
+      chat_id=chat.id,
+      status="completed",
+      provider="codex",
+      provider_session_id="thread-1",
+      cost_usd=0.125,
+      input_tokens=900,
+      output_tokens=200,
+      cache_read_input_tokens=500,
+      cache_creation_input_tokens=0,
+      reasoning_output_tokens=100,
+      total_tokens=1_100,
+      model_context_window=200_000,
+      usage_json={"provider": "codex", "calculation": "thread_delta"},
+      started_at=datetime.now(UTC),
+    ),
+  ])
+  db.commit()
+
+  response = client.get(f"/api/chats/{chat.id}/usage", headers=auth)
+
+  assert response.status_code == 200
+  payload = response.json()
+  assert payload["coverage"] == {
+    "runs": 2,
+    "runs_with_usage": 1,
+    "runs_with_cost": 1,
+  }
+  assert payload["totals"] == {
+    "input_tokens": 900,
+    "output_tokens": 200,
+    "cache_read_input_tokens": 500,
+    "cache_creation_input_tokens": 0,
+    "reasoning_output_tokens": 100,
+    "total_tokens": 1_100,
+    "cost_usd": 0.125,
+  }
+  measured = next(
+    run for run in payload["runs"] if run["id"] == "measured-run"
+  )
+  assert measured["provider_session_id"] == "thread-1"
+  assert measured["model_context_window"] == 200_000
+  assert measured["usage"]["calculation"] == "thread_delta"
 
 
 def test_create_chat_rejects_cross_site_request(client, auth):

--- a/backend/tests/test_claude_sdk_runner.py
+++ b/backend/tests/test_claude_sdk_runner.py
@@ -1260,6 +1260,21 @@ def test_dispatch_result_message_returns_terminal():
   assert terminal["cost_usd"] == 0.05
   assert terminal["session_id"] == "sess-1"
   assert terminal["usage"] == {"input_tokens": 100, "output_tokens": 200}
+  assert terminal["usage_metrics"] == {
+    "provider": "claude",
+    "scope": "turn",
+    "calculation": "result_aggregate",
+    "input_tokens": 100,
+    "uncached_input_tokens": 100,
+    "output_tokens": 200,
+    "cache_read_input_tokens": 0,
+    "cache_creation_input_tokens": 0,
+    "reasoning_output_tokens": 0,
+    "total_tokens": 300,
+    "model_context_window": None,
+    "provider_usage": {"input_tokens": 100, "output_tokens": 200},
+    "provider_model_usage": None,
+  }
   # ResultMessage also fires usage + stop_reason side-channels.
   types = [e["type"] for e in bus.events]
   assert "usage" in types

--- a/backend/tests/test_codex_sdk_runner.py
+++ b/backend/tests/test_codex_sdk_runner.py
@@ -676,6 +676,99 @@ def test_run_codex_sdk_turn_resume_skips_skill_lookup(monkeypatch):
   assert registry.get_handle("chat-1", RunnerKind.CODEX_SDK) is None
 
 
+def test_run_codex_sdk_turn_reports_all_model_calls_in_turn(monkeypatch):
+  class TokenUsageUpdated:
+    def __init__(self, token_usage):
+      self.token_usage = token_usage
+
+  class Usage:
+    def __init__(self, last, total):
+      self.last = SimpleNamespace(**last)
+      self.total = SimpleNamespace(**total)
+      self.model_context_window = 200_000
+
+    def model_dump(self, **_kwargs):
+      return {
+        "last": vars(self.last),
+        "total": vars(self.total),
+        "modelContextWindow": self.model_context_window,
+      }
+
+  first = Usage(
+    last={
+      "input_tokens": 200, "cached_input_tokens": 100,
+      "output_tokens": 100, "reasoning_output_tokens": 50,
+      "total_tokens": 300,
+    },
+    total={
+      "input_tokens": 1_000, "cached_input_tokens": 400,
+      "output_tokens": 100, "reasoning_output_tokens": 50,
+      "total_tokens": 1_100,
+    },
+  )
+  final = Usage(
+    last={
+      "input_tokens": 300, "cached_input_tokens": 150,
+      "output_tokens": 100, "reasoning_output_tokens": 50,
+      "total_tokens": 400,
+    },
+    total={
+      "input_tokens": 1_700, "cached_input_tokens": 800,
+      "output_tokens": 200, "reasoning_output_tokens": 100,
+      "total_tokens": 1_900,
+    },
+  )
+  completed_turn = SimpleNamespace(id="turn-1", usage=None, error=None)
+  notifications = [
+    SimpleNamespace(
+      method="thread/tokenUsage/updated",
+      payload=TokenUsageUpdated(first),
+    ),
+    SimpleNamespace(
+      method="thread/tokenUsage/updated",
+      payload=TokenUsageUpdated(final),
+    ),
+    SimpleNamespace(
+      method="turn/completed",
+      payload=_FakeTurnCompletedNotification(completed_turn),
+    ),
+  ]
+  thread = _FakeThread("thread-usage", _FakeTurnHandle(notifications))
+
+  class FakeAsyncCodex:
+    def __init__(self, config=None):
+      self.config = config
+
+    async def __aenter__(self):
+      return self
+
+    async def __aexit__(self, _exc_type, _exc, _tb):
+      return None
+
+    async def thread_start(self, *_args, **_kwargs):
+      return thread
+
+  sdk = _fake_sdk(FakeAsyncCodex)
+  sdk["ThreadTokenUsageUpdatedNotification"] = TokenUsageUpdated
+  monkeypatch.setattr(codex_sdk_runner, "_sdk_imports", lambda: sdk)
+
+  result = asyncio.run(codex_sdk_runner.run_codex_sdk_turn(
+    user_message="measure this turn",
+    session_id=None,
+    base_env={},
+    cwd="/tmp",
+    chat_id="chat-usage",
+    bc=_FakeBroadcast(),
+    pending_questions={},
+    db=None,
+  ))
+
+  assert result["usage"]["total"]["total_tokens"] == 1_900
+  assert result["usage_metrics"]["calculation"] == "thread_delta"
+  assert result["usage_metrics"]["input_tokens"] == 900
+  assert result["usage_metrics"]["total_tokens"] == 1_100
+
+
 def test_run_codex_sdk_turn_resume_validation_error_now_propagates(monkeypatch, caplog):
   # Inverse of the old subAgentActivity resume test. The SDK now models
   # subAgentActivity natively, so thread_resume no longer raises on that

--- a/backend/tests/test_db_migrations.py
+++ b/backend/tests/test_db_migrations.py
@@ -109,6 +109,17 @@ def test_run_migrations_adds_park_columns_to_existing_chat_runs(tmp_path):
   assert "parked_until" in cols
   assert "park_reason" in cols
   assert "restart_nonce" in cols
+  assert {
+    "provider_session_id",
+    "input_tokens",
+    "output_tokens",
+    "cache_read_input_tokens",
+    "cache_creation_input_tokens",
+    "reasoning_output_tokens",
+    "total_tokens",
+    "model_context_window",
+    "usage_json",
+  } <= cols
 
 
 def test_agent_lifecycle_width_migration_is_postgres_only_and_idempotent():

--- a/backend/tests/test_limit_park.py
+++ b/backend/tests/test_limit_park.py
@@ -14,9 +14,10 @@ Locks in the six contracts of the limit-park feature:
       an opted park
       retryable until its continuation starts, skips future parks, stands down
       while draining, and resolves deleted chats silently.
-  (e) Auto-resume is policy-controlled (off = notify only) and strictly
-      serial: one park per tick, none while any turn is live; the resumed turn
-      combines the preserved queue + a "continue" into one continuation.
+  (e) Auto-resume is policy-controlled (off = notify only). Provider-limit
+      retries are strictly serial, while an accepted planned restart resumes
+      the exact previously-live set together. Each resumed turn combines its
+      preserved queue + a "continue" into one continuation.
   (f) The parks are observable: /api/debug/status lists parked runs.
   (g) A planned restart reuses the same exact-run state with a due-now time;
       crashes, unanswered questions, and app-owned work stay manual.
@@ -1201,6 +1202,39 @@ def test_sweep_starts_only_one_of_two_opted_chats(owner_token, monkeypatch):
     assert _run_row(f"rt-{untouched}")["status"] == "parked"
   finally:
     for cid in ("sweep-auto-a", "sweep-auto-b"):
+      chat_mod.discard_starting(cid)
+
+
+def test_sweep_restarts_every_opted_chat_in_the_accepted_batch(
+  owner_token, monkeypatch,
+):
+  """A restart restores the exact set that was already concurrent."""
+  del owner_token
+  nonce = "restart-nonce-batch"
+  monkeypatch.setattr(
+    "app.restart_ledger.authorized_restart_nonce", lambda: nonce,
+  )
+  monkeypatch.setattr(
+    "app.push.notify_owner", lambda *args, **kwargs: "notif-id",
+  )
+  scheduled = []
+  monkeypatch.setattr(
+    chat_mod, "_schedule_continuation", lambda **kw: scheduled.append(kw),
+  )
+  chat_ids = ("restart-batch-a", "restart-batch-b", "restart-batch-c")
+  for cid in chat_ids:
+    _due_park(
+      cid, f"rt-{cid}", auto_restart=True,
+      park_reason="restart", restart_nonce=nonce,
+    )
+
+  try:
+    assert set(_run_sweep()) == set(chat_ids)
+    assert {item["chat_id"] for item in scheduled} == set(chat_ids)
+    for cid in chat_ids:
+      assert _run_row(f"rt-{cid}")["status"] == "completed"
+  finally:
+    for cid in chat_ids:
       chat_mod.discard_starting(cid)
 
 

--- a/backend/tests/test_routes_init_resilience.py
+++ b/backend/tests/test_routes_init_resilience.py
@@ -12,8 +12,10 @@ These tests lock in the stub contract + verify the scaffold doesn't
 collapse when a real route module is forced to fail.
 """
 
+import asyncio
 import importlib
 import sys
+import threading
 
 import pytest
 from fastapi import APIRouter, FastAPI
@@ -156,6 +158,47 @@ def test_main_boots_when_app_watcher_start_raises(monkeypatch):
     body = resp.json()
     assert body["status"] == "ok"
     assert body["boot_id"]
+
+
+def test_lifespan_waits_for_initial_restart_resume_sweep(monkeypatch):
+  """The server must not accept a manual send before restart recovery claims."""
+  from app import chat as chat_mod
+  from app.main import app as main_app
+
+  sweep_entered = threading.Event()
+  release_sweep = threading.Event()
+  lifespan_ready = threading.Event()
+  boot_errors = []
+
+  async def held_sweep(db):
+    del db
+    sweep_entered.set()
+    await asyncio.to_thread(release_sweep.wait)
+    return []
+
+  monkeypatch.setattr(chat_mod, "sweep_reset_parks", held_sweep)
+
+  def boot_app():
+    try:
+      with TestClient(main_app):
+        lifespan_ready.set()
+    except BaseException as exc:  # surface a lifespan-thread failure below
+      boot_errors.append(exc)
+
+  thread = threading.Thread(target=boot_app, daemon=True)
+  thread.start()
+  try:
+    assert sweep_entered.wait(timeout=20)
+    # The old fire-and-forget startup reached the usable server while this
+    # sweep was still blocked. The fixed lifecycle awaits it before yielding.
+    assert not lifespan_ready.wait(timeout=1.0)
+  finally:
+    release_sweep.set()
+
+  thread.join(timeout=30)
+  assert not thread.is_alive()
+  assert boot_errors == []
+  assert lifespan_ready.is_set()
 
 
 def test_lifespan_does_not_shadow_module_session_factory():

--- a/backend/tests/test_runtime_libs.py
+++ b/backend/tests/test_runtime_libs.py
@@ -67,6 +67,9 @@ def test_supported_runtime_packages_are_production_dependencies():
 def test_compile_command_bundles_the_complete_runtime_graph():
   command = esbuild_command("entry.jsx", "app.js")
   assert "--bundle" in command
+  assert '--define:process.env.NODE_ENV="production"' in command
+  assert "--minify" in command
+  assert "--keep-names" in command
   assert not any(arg.startswith("--external:") for arg in command)
   assert f"--banner:js={COMPILED_RUNTIME_BANNER}" in command
   assert f"--inject:{runtime_inject_path()}" in command
@@ -77,6 +80,48 @@ def test_compile_command_bundles_the_complete_runtime_graph():
     assert f"--alias:{specifier}={path}" in command
   assert runtime_inject_path().is_file()
   assert mobius_runtime_path().is_file()
+
+
+def test_compile_command_selects_production_react_and_keeps_one_module(tmp_path):
+  """The size win must come from the real production graph, not externals."""
+  entry = tmp_path / "entry.jsx"
+  output = tmp_path / "app.js"
+  metafile = tmp_path / "app-meta.json"
+  entry.write_text(
+    """import { useState } from 'react'
+
+export default function NamedFixture() {
+  const [value] = useState('ready')
+  return <div>{value}</div>
+}
+"""
+  )
+
+  completed = subprocess.run(
+    esbuild_command(entry, output, metafile=metafile),
+    capture_output=True,
+    check=False,
+    env=esbuild_environment(),
+    text=True,
+    timeout=ESBUILD_TIMEOUT_SECS,
+  )
+  assert completed.returncode == 0, completed.stderr
+
+  metadata = json.loads(metafile.read_text())
+  inputs = set(metadata["inputs"])
+  react_inputs = {name for name in inputs if "/react" in name}
+  assert react_inputs
+  assert not any(".development.js" in name for name in react_inputs)
+  assert any(".production.js" in name for name in react_inputs)
+
+  entry_outputs = [
+    details for details in metadata["outputs"].values()
+    if details.get("entryPoint")
+  ]
+  assert len(entry_outputs) == 1
+  assert entry_outputs[0].get("imports") == []
+  assert output.stat().st_size < 400_000
+  assert "NamedFixture" in output.read_text()
 
 
 def test_app_local_or_transitive_react_cannot_shadow_platform_runtime(tmp_path):

--- a/backend/tests/test_usage_metrics.py
+++ b/backend/tests/test_usage_metrics.py
@@ -1,0 +1,142 @@
+"""Provider-neutral token accounting regression tests."""
+
+from types import SimpleNamespace
+
+from app.usage_metrics import normalize_claude_usage, normalize_codex_usage
+
+
+def _breakdown(
+  *,
+  input_tokens: int,
+  cached_input_tokens: int,
+  output_tokens: int,
+  reasoning_output_tokens: int,
+  total_tokens: int,
+):
+  return SimpleNamespace(
+    input_tokens=input_tokens,
+    cached_input_tokens=cached_input_tokens,
+    output_tokens=output_tokens,
+    reasoning_output_tokens=reasoning_output_tokens,
+    total_tokens=total_tokens,
+  )
+
+
+def test_claude_input_includes_cache_reads_and_writes():
+  usage = normalize_claude_usage({
+    "input_tokens": 100,
+    "cache_creation_input_tokens": 20,
+    "cache_read_input_tokens": 30,
+    "output_tokens": 40,
+  }, {
+    "claude-main": {
+      "contextWindow": 200_000,
+      "inputTokens": 150,
+      "outputTokens": 40,
+    },
+  })
+
+  assert usage is not None
+  assert usage["input_tokens"] == 150
+  assert usage["uncached_input_tokens"] == 100
+  assert usage["cache_creation_input_tokens"] == 20
+  assert usage["cache_read_input_tokens"] == 30
+  assert usage["output_tokens"] == 40
+  assert usage["total_tokens"] == 190
+  assert usage["model_context_window"] == 200_000
+  assert usage["provider_model_usage"]["claude-main"]["inputTokens"] == 150
+
+
+def test_codex_thread_delta_sums_every_model_call_in_the_turn():
+  # The first notification says this thread had 800 tokens before the turn:
+  # first.total (1,100) - first.last (300). The final cumulative total is
+  # 1,900, so this turn processed 1,100 tokens across all model calls.
+  first = SimpleNamespace(
+    last=_breakdown(
+      input_tokens=200,
+      cached_input_tokens=100,
+      output_tokens=100,
+      reasoning_output_tokens=50,
+      total_tokens=300,
+    ),
+    total=_breakdown(
+      input_tokens=1_000,
+      cached_input_tokens=400,
+      output_tokens=100,
+      reasoning_output_tokens=50,
+      total_tokens=1_100,
+    ),
+    model_context_window=200_000,
+  )
+  final = SimpleNamespace(
+    last=_breakdown(
+      input_tokens=300,
+      cached_input_tokens=150,
+      output_tokens=100,
+      reasoning_output_tokens=50,
+      total_tokens=400,
+    ),
+    total=_breakdown(
+      input_tokens=1_700,
+      cached_input_tokens=800,
+      output_tokens=200,
+      reasoning_output_tokens=100,
+      total_tokens=1_900,
+    ),
+    model_context_window=200_000,
+  )
+
+  usage = normalize_codex_usage(first, final)
+
+  assert usage is not None
+  assert usage["calculation"] == "thread_delta"
+  assert usage["input_tokens"] == 900
+  assert usage["cache_read_input_tokens"] == 500
+  assert usage["uncached_input_tokens"] == 400
+  assert usage["output_tokens"] == 200
+  assert usage["reasoning_output_tokens"] == 100
+  assert usage["total_tokens"] == 1_100
+  assert usage["model_context_window"] == 200_000
+
+
+def test_codex_counter_reset_uses_labelled_latest_call_fallback():
+  first = {
+    "last": {
+      "inputTokens": 100,
+      "cachedInputTokens": 50,
+      "outputTokens": 20,
+      "reasoningOutputTokens": 10,
+      "totalTokens": 120,
+    },
+    "total": {
+      "inputTokens": 1_000,
+      "cachedInputTokens": 500,
+      "outputTokens": 200,
+      "reasoningOutputTokens": 100,
+      "totalTokens": 1_200,
+    },
+  }
+  final = {
+    "last": {
+      "inputTokens": 80,
+      "cachedInputTokens": 40,
+      "outputTokens": 20,
+      "reasoningOutputTokens": 10,
+      "totalTokens": 100,
+    },
+    # Lower than the inferred 1,080-token baseline: the thread counter reset.
+    "total": {
+      "inputTokens": 80,
+      "cachedInputTokens": 40,
+      "outputTokens": 20,
+      "reasoningOutputTokens": 10,
+      "totalTokens": 100,
+    },
+  }
+
+  usage = normalize_codex_usage(first, final)
+
+  assert usage is not None
+  assert usage["calculation"] == "last_call_fallback"
+  assert usage["input_tokens"] == 80
+  assert usage["total_tokens"] == 100

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -421,6 +421,10 @@ export const api = {
       method: 'POST',
       body: JSON.stringify({ activity_version: activityVersion }),
     }),
+    markPreviewSeen: (appId, updatedAt, final = false) => apiFetch(`/apps/${appId}/preview/seen`, {
+      method: 'POST',
+      body: JSON.stringify({ updated_at: updatedAt, final }),
+    }),
     update: (appId, payload) => listAffectingMutation('apps', `/apps/${appId}`, {
       method: 'PATCH',
       body: JSON.stringify(payload),

--- a/frontend/src/components/ChatView/ActivityStretch.jsx
+++ b/frontend/src/components/ChatView/ActivityStretch.jsx
@@ -1,6 +1,7 @@
-import { useId, useMemo, useRef } from 'react'
+import { useEffect, useId, useMemo, useRef, useState } from 'react'
 import { StandardMarkdown } from './markdown/BlockRenderer.jsx'
 import ToolBlock from './ToolBlock.jsx'
+import { apiFetch, jsonOrThrow } from '../../api/client.js'
 import {
   activityStreamState,
   activityDisplayState,
@@ -175,7 +176,22 @@ function SingleActivity({ entry, chatId, live, surfaceKey }) {
   )
 }
 
-function GroupedActivityStretch({ entries, chatId, live = false, surfaceKey }) {
+export function activityDetailUrl(chatId, detailRef) {
+  const messageIndex = encodeURIComponent(detailRef.message_index)
+  const start = encodeURIComponent(detailRef.start)
+  const end = encodeURIComponent(detailRef.end)
+  return `/chats/${encodeURIComponent(chatId)}/activity-detail`
+    + `?message_index=${messageIndex}&start=${start}&end=${end}`
+}
+
+function GroupedActivityStretch({
+  entries,
+  chatId,
+  live = false,
+  surfaceKey,
+  detailRef = null,
+  summaryToolCount = null,
+}) {
   const stretchKey = assistantBlockKey(entries[0]?.item, entries[0]?.idx)
   const [userOpen, setUserOpen] = useDisclosureState(
     chatId,
@@ -184,6 +200,56 @@ function GroupedActivityStretch({ entries, chatId, live = false, surfaceKey }) {
   const headerRef = useRef(null)
   const timelineRef = useRef(null)
   const timelineId = useId()
+  const [detailEntries, setDetailEntries] = useState(null)
+  const [detailError, setDetailError] = useState(false)
+  const [detailAttempt, setDetailAttempt] = useState(0)
+  const detailMessageIndex = detailRef?.message_index
+  const detailStart = detailRef?.start
+  const detailEnd = detailRef?.end
+  const detailKey = detailRef
+    ? `${detailMessageIndex}:${detailStart}:${detailEnd}`
+    : ''
+
+  useEffect(() => {
+    setDetailEntries(null)
+    setDetailError(false)
+  }, [detailKey])
+
+  useEffect(() => {
+    if (!userOpen || !detailRef || detailEntries || detailError) return undefined
+    const controller = new AbortController()
+    let current = true
+    apiFetch(activityDetailUrl(chatId, {
+      message_index: detailMessageIndex,
+      start: detailStart,
+      end: detailEnd,
+    }), {
+      signal: controller.signal,
+    })
+      .then(res => jsonOrThrow(res, 'Activity detail failed'))
+      .then(data => {
+        if (!current) return
+        setDetailEntries(Array.isArray(data.entries) ? data.entries : [])
+      })
+      .catch(error => {
+        if (!current || error?.name === 'AbortError') return
+        setDetailError(true)
+      })
+    return () => {
+      current = false
+      controller.abort()
+    }
+  }, [
+    chatId,
+    detailAttempt,
+    detailEntries,
+    detailError,
+    detailEnd,
+    detailKey,
+    detailMessageIndex,
+    detailStart,
+    userOpen,
+  ])
 
   const lastItem = entries[entries.length - 1]?.item
   const liveThinkingTail = live && lastItem?.type === 'thinking'
@@ -245,8 +311,15 @@ function GroupedActivityStretch({ entries, chatId, live = false, surfaceKey }) {
         if (code != null && code !== 0) exitCode = code
       }
     }
-    return { state, exitCode, toolCount: tools.length, thinkingOnly: tools.length === 0 }
-  }, [sig]) // eslint-disable-line react-hooks/exhaustive-deps
+    return {
+      state,
+      exitCode,
+      toolCount: Number.isInteger(summaryToolCount)
+        ? summaryToolCount
+        : tools.length,
+      thinkingOnly: tools.length === 0,
+    }
+  }, [sig, summaryToolCount]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const { state, exitCode, toolCount, thinkingOnly } = meta
   // The one presentation authority for icon, chip, and state class: a live
@@ -278,6 +351,7 @@ function GroupedActivityStretch({ entries, chatId, live = false, surfaceKey }) {
       ? ', in progress'
       : ''
   const iconKind = thinkingOnly ? 'reasoning' : leadToolIcon
+  const timelineEntries = detailRef ? detailEntries : entries
 
   return (
     <div className={
@@ -316,7 +390,29 @@ function GroupedActivityStretch({ entries, chatId, live = false, surfaceKey }) {
         />
       ))}
       <div ref={timelineRef} id={timelineId} className="chat__activity-timeline" hidden={!open}>
-        {open && entries.map(({ item, idx }) => {
+        {open && detailRef && !timelineEntries && !detailError && (
+          <span className="chat__reasoning-load" role="status" aria-live="polite">
+            Loading activity…
+          </span>
+        )}
+        {open && detailError && (
+          <div className="chat__lazy-status">
+            <span className="chat__reasoning-load" role="status" aria-live="polite">
+              Activity details unavailable.
+            </span>
+            <button
+              type="button"
+              className="chat__lazy-retry"
+              onClick={() => {
+                setDetailError(false)
+                setDetailAttempt(attempt => attempt + 1)
+              }}
+            >
+              Retry
+            </button>
+          </div>
+        )}
+        {open && timelineEntries?.map(({ item, idx }) => {
           if (item.type === 'thinking') {
             const key = assistantBlockKey(item, idx)
             return (
@@ -345,8 +441,15 @@ function GroupedActivityStretch({ entries, chatId, live = false, surfaceKey }) {
   )
 }
 
-export default function ActivityStretch({ entries, chatId, live = false, surfaceKey }) {
-  if (entries.length === 1) {
+export default function ActivityStretch({
+  entries,
+  chatId,
+  live = false,
+  surfaceKey,
+  detailRef = null,
+  summaryToolCount = null,
+}) {
+  if (entries.length === 1 && !detailRef) {
     return (
       <SingleActivity
         entry={entries[0]}
@@ -362,6 +465,8 @@ export default function ActivityStretch({ entries, chatId, live = false, surface
       chatId={chatId}
       live={live}
       surfaceKey={surfaceKey}
+      detailRef={detailRef}
+      summaryToolCount={summaryToolCount}
     />
   )
 }

--- a/frontend/src/components/ChatView/ChatInputBar.jsx
+++ b/frontend/src/components/ChatView/ChatInputBar.jsx
@@ -129,6 +129,11 @@ function PrimaryAction({
         key="steer"
         className="chat__action chat__steer"
         type="button"
+        // Keep focus stable through pointerdown, then let ChatView dismiss
+        // the keyboard deliberately as part of the steer action. Dispatching
+        // on touchend avoids waiting for Safari's synthesized click.
+        onPointerDown={(e) => e.preventDefault()}
+        onTouchEnd={(e) => { e.preventDefault(); onSteer() }}
         onClick={onSteer}
         aria-label="Send queued message now"
       >

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -54,6 +54,7 @@ import { questionKey } from './questionKey.js'
 import { clearChatQuestionDrafts } from './questionDraft.js'
 import { resolveStopResend } from './resolveStopResend.js'
 import { focusComposerElement, shouldApplyComposerFocusRequest } from './composerFocusPolicy.js'
+import { shouldDismissComposerKeyboardOnSubmit } from './composerKeyboardPolicy.js'
 import { sameMessageList } from './chatMessageList.js'
 import { copyableMessageText, copyPlainText } from './messageCopy.js'
 import { composerHistoryFromMessages } from './composerHistory.js'
@@ -2076,17 +2077,24 @@ export default function ChatView({
       || pendingQueue.pendingMessagesRef.current.length > 0
     )
     if (queuesBehindActiveTurn) {
-      // Queueing changes the footer immediately (new chip, cleared composer,
-      // mobile keyboard close) but adds no transcript row yet. Freeze the
-      // exact visible message before any of those layout changes. The captured
-      // submit intent above is kept for the later promotion/steer, while the
-      // current in-flight answer stays where the reader left it now.
+      // Queueing changes the footer immediately (new chip, cleared composer)
+      // but adds no transcript row yet. Freeze the exact visible message
+      // before that layout change. The captured submit intent above is kept
+      // for the later promotion/steer, while the current in-flight answer
+      // stays where the reader left it now.
       freezeQueuedSubmission()
     }
 
-    // On touch devices, blur to dismiss the soft keyboard. Desktop keeps
-    // focus so the cursor stays ready for the next message.
-    if (_isTouchPrimary) inputRef.current?.blur()
+    // Keep the mobile keyboard open for queue-only sends so another follow-up
+    // can be typed immediately. Fresh sends and explicit queue+steer submits
+    // dismiss it; desktop retains its existing cursor-ready behaviour.
+    if (shouldDismissComposerKeyboardOnSubmit({
+      isTouchPrimary: _isTouchPrimary,
+      queuesBehindActiveTurn,
+      steerAfterQueue: opts.steerAfterQueue === true,
+    })) {
+      inputRef.current?.blur()
+    }
 
     function clearComposerFilesForSend() {
       if (!usesComposerFiles) return
@@ -3083,6 +3091,12 @@ export default function ChatView({
         isFirstUserMsg: steerIsFirstUser,
       })
       steerPinIntentRef.current = makeSendPinIntent(steerWillPin)
+      // Queue-only sends deliberately retain mobile focus. Fast-forward is
+      // the explicit hand-off point, but snapshot reader position BEFORE
+      // blurring: keyboard dismissal resizes the viewport and can otherwise
+      // corrupt the pin decision. Both composer and per-row steer actions
+      // share this path.
+      if (_isTouchPrimary) inputRef.current?.blur()
       // The queued tray is part of the footer height. If it stays visible
       // until after the steered row is inserted, the scroll system pins with
       // one layout and then immediately reflows when the tray disappears — the

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -3973,7 +3973,7 @@ export default function ChatView({
                     key={app.id}
                     className={`chat__open-app-btn${pulsing ? ' chat__open-app-btn--pulse' : ''}`}
                     aria-label={pulsing ? `Preview updated for ${app.name || 'app'}` : vm.ariaLabel}
-                    onClick={() => onOpenApp?.(app.id)}
+                    onClick={() => onOpenApp?.(app, { final: !turnActive })}
                   >
                     {pulsing ? 'Preview updated ✓' : `${vm.label} →`}
                   </button>

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -329,9 +329,9 @@ export default function ChatView({
   const offsetRef = useRef(offset)
   offsetRef.current = offset
   const [loading, setLoading] = useState(!cached)
-  // A settled warm cache is a complete renderable transcript and may reveal
-  // while freshness loads. A cached running turn is different: its live bridge
-  // still needs the first refresh/catch-up handshake before takeover.
+  // Warm cache content is useful immediately, but it is not authoritative for
+  // entry layout. The first refresh decides whether an already-running turn's
+  // catch-up must settle before the transcript can be revealed.
   const cachedEntryPhase = cached && !cached.running ? 'cached' : 'history'
   const [initialEntryPhase, setInitialEntryPhase] = useState(cachedEntryPhase)
   // On a failed initial /chats/{id} fetch, loadError flips in the catch so
@@ -3393,15 +3393,11 @@ export default function ChatView({
     : null
   const showLoadError = loadError && messages.length === 0 && !loading && !turnActive
 
-  // A settled cache is already a complete renderable transcript, so let the
-  // shell hand it over as soon as scroll restoration reveals it while the
-  // freshness request continues in the background. Running caches stay on the
-  // strict path: their bridge/catch-up handshake must settle before takeover.
-  // Cold loads likewise keep the outgoing chat painted until authoritative
-  // content, confirmed emptiness, or a real error exists.
-  const cachedDisplayReady = initialEntryPhase === 'cached' && revealed
-  const displayReady = cachedDisplayReady
-    || (!loading && (revealed || showEmpty || showLoadError))
+  // The scroll safety cap may reveal an otherwise empty DOM while the initial
+  // request is still in flight. That protects a standalone ChatView from being
+  // hidden forever, but it is not a valid shell handoff: keep the outgoing chat
+  // painted until this chat has authoritative content, emptiness, or an error.
+  const displayReady = !loading && (revealed || showEmpty || showLoadError)
   useLayoutEffect(() => {
     if (displayReady) onDisplayReady?.(chatId)
   }, [chatId, displayReady, onDisplayReady])

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -329,9 +329,9 @@ export default function ChatView({
   const offsetRef = useRef(offset)
   offsetRef.current = offset
   const [loading, setLoading] = useState(!cached)
-  // Warm cache content is useful immediately, but it is not authoritative for
-  // entry layout. The first refresh decides whether an already-running turn's
-  // catch-up must settle before the transcript can be revealed.
+  // A settled warm cache is a complete renderable transcript and may reveal
+  // while freshness loads. A cached running turn is different: its live bridge
+  // still needs the first refresh/catch-up handshake before takeover.
   const cachedEntryPhase = cached && !cached.running ? 'cached' : 'history'
   const [initialEntryPhase, setInitialEntryPhase] = useState(cachedEntryPhase)
   // On a failed initial /chats/{id} fetch, loadError flips in the catch so
@@ -1008,7 +1008,7 @@ export default function ChatView({
     const gen = fetchGenRef.current
     try {
       const res = await apiFetch(
-        `/chats/${chatId}?limit=20`,
+        `/chats/${chatId}?limit=20&compact=1`,
         { timeoutMs: CHAT_FETCH_TIMEOUT_MS },
       )
       if (!res.ok) throw new Error(`CHAT_FETCH_FAILED_${res.status}`)
@@ -1106,7 +1106,7 @@ export default function ChatView({
     const gen = fetchGenRef.current
     try {
       const res = await apiFetch(
-        `/chats/${chatId}?limit=1`,
+        `/chats/${chatId}/runtime`,
         { timeoutMs: CHAT_FETCH_TIMEOUT_MS },
       )
       const data = await jsonOrThrow(res, 'Runtime refresh failed')
@@ -1778,7 +1778,7 @@ export default function ChatView({
     setInitialEntryPhase(cachedEntryPhase)
 
     const gen = fetchGenRef.current
-    apiFetch(`/chats/${chatId}?limit=20`, {
+    apiFetch(`/chats/${chatId}?limit=20&compact=1`, {
       timeoutMs: CHAT_FETCH_TIMEOUT_MS,
       signal: initialLoadController.signal,
     })
@@ -1947,7 +1947,7 @@ export default function ChatView({
     // them at the new anchor; the next gesture (or send) writes a
     // fresh mode.
     apiFetch(
-      `/chats/${chatId}?limit=20&before=${offset}`,
+      `/chats/${chatId}?limit=20&before=${offset}&compact=1`,
       { timeoutMs: CHAT_FETCH_TIMEOUT_MS },
     )
       .then(r => jsonOrThrow(r, 'Earlier messages failed to load'))
@@ -2728,7 +2728,7 @@ export default function ChatView({
       // response cannot overwrite unrelated queue mutations.
       try {
         const res = await apiFetch(
-          `/chats/${chatId}?limit=1`,
+          `/chats/${chatId}/runtime`,
           { timeoutMs: CHAT_FETCH_TIMEOUT_MS },
         )
         const data = await jsonOrThrow(res, 'Queue refresh failed')
@@ -2864,7 +2864,7 @@ export default function ChatView({
       }
       const confirmStopIdle = async () => {
         try {
-          const res = await apiFetch(`/chats/${chatId}?limit=1`, { timeoutMs: 5000 })
+          const res = await apiFetch(`/chats/${chatId}/runtime`, { timeoutMs: 5000 })
           if (!res.ok) return { failed: true, running: null }
           const data = await res.json()
           return { failed: false, running: data?.running }
@@ -3393,11 +3393,15 @@ export default function ChatView({
     : null
   const showLoadError = loadError && messages.length === 0 && !loading && !turnActive
 
-  // The scroll safety cap may reveal an otherwise empty DOM while the initial
-  // request is still in flight. That protects a standalone ChatView from being
-  // hidden forever, but it is not a valid shell handoff: keep the outgoing chat
-  // painted until this chat has authoritative content, emptiness, or an error.
-  const displayReady = !loading && (revealed || showEmpty || showLoadError)
+  // A settled cache is already a complete renderable transcript, so let the
+  // shell hand it over as soon as scroll restoration reveals it while the
+  // freshness request continues in the background. Running caches stay on the
+  // strict path: their bridge/catch-up handshake must settle before takeover.
+  // Cold loads likewise keep the outgoing chat painted until authoritative
+  // content, confirmed emptiness, or a real error exists.
+  const cachedDisplayReady = initialEntryPhase === 'cached' && revealed
+  const displayReady = cachedDisplayReady
+    || (!loading && (revealed || showEmpty || showLoadError))
   useLayoutEffect(() => {
     if (displayReady) onDisplayReady?.(chatId)
   }, [chatId, displayReady, onDisplayReady])

--- a/frontend/src/components/ChatView/MsgContent.jsx
+++ b/frontend/src/components/ChatView/MsgContent.jsx
@@ -137,6 +137,27 @@ function MsgContentInner({
     // are folded into an ActivityStretch below; this renders only the `single`
     // nodes — text, question, error.
     const renderBlock = (block, i) => {
+      if (block.type === 'activity' && Array.isArray(block.entries)) {
+        return (
+          <div
+            key={block.activity_id || `activity-${i}`}
+            className="chat__tools"
+          >
+            <ActivityStretch
+              entries={block.entries}
+              chatId={chatId}
+              live={false}
+              surfaceKey={messageKey}
+              detailRef={{
+                message_index: block.message_index,
+                start: block.start,
+                end: block.end,
+              }}
+              summaryToolCount={block.tool_count}
+            />
+          </div>
+        )
+      }
       if (block.type === 'text') {
         const text = msg.role === 'user'
           ? stripAugmentation(block.content) : block.content

--- a/frontend/src/components/ChatView/QueuedMessages.jsx
+++ b/frontend/src/components/ChatView/QueuedMessages.jsx
@@ -142,6 +142,10 @@ export default function QueuedMessages({
                     type="button"
                     className="queued__steer"
                     onPointerDown={(e) => e.preventDefault()}
+                    onTouchEnd={(e) => {
+                      e.preventDefault()
+                      onSteerOne?.(cidOf(msg))
+                    }}
                     onClick={() => onSteerOne?.(cidOf(msg))}
                     aria-label="Send this queued message now"
                     title="Send now"

--- a/frontend/src/components/ChatView/__tests__/activityLineStructure.test.js
+++ b/frontend/src/components/ChatView/__tests__/activityLineStructure.test.js
@@ -85,8 +85,9 @@ test('every thinking entry remains the same collapsed nested disclosure', () => 
     'reasoning remains available inside the nested disclosure')
 })
 
-test('a single activity discloses directly without a redundant parent row', () => {
-  assert.match(activityStretch, /if \(entries\.length === 1\)/)
+test('a single self-contained activity discloses directly without a redundant parent row', () => {
+  assert.match(activityStretch, /if \(entries\.length === 1 && !detailRef\)/,
+    'a one-entry lazy summary still owns its multi-step detail disclosure')
   assert.match(activityStretch, /<SingleActivity[\s\S]*entry=\{entries\[0\]\}/)
   assert.match(activityStretch,
     /item\.type === 'thinking'[\s\S]*<TimelineThought[\s\S]*direct[\s\S]*live=\{live\}/)

--- a/frontend/src/components/ChatView/__tests__/activityNoAutoOpen.test.js
+++ b/frontend/src/components/ChatView/__tests__/activityNoAutoOpen.test.js
@@ -23,8 +23,11 @@ test('the stretch restores saved user state and open is exactly userOpen', () =>
   assert.match(body, /\n\s*const open = userOpen\n/,
     'open derives from userOpen alone — no force-open expression')
   // No `open = running || userOpen` / `userOpen || live` style force-open.
-  assert.doesNotMatch(body, /\|\|\s*userOpen/, 'nothing ORs into userOpen to force it open')
-  assert.doesNotMatch(body, /userOpen\s*\|\|/, 'userOpen does not OR with a liveness flag')
+  assert.doesNotMatch(
+    body,
+    /const open\s*=\s*[^\n]*\|\|/,
+    'the rendered open state does not OR user intent with a liveness flag',
+  )
   assert.doesNotMatch(body, /defaultOpen/, 'no defaultOpen escape hatch')
 })
 
@@ -38,10 +41,17 @@ test('the only open-state write is the user toggle, guarded by preserveTogglePos
     'the toggle preserves the anchor before flipping open state')
 })
 
-test('no effect derives open state from running/live/props', () => {
-  // Since the 1Hz thinking ticker was retired (bare "Thinking" has no clock),
-  // the component has NO effects at all — the strongest possible form of the
-  // no-auto-open guarantee: nothing can flip `open` outside the user's tap.
-  assert.doesNotMatch(src, /useEffect/,
-    'ActivityStretch has no effects; open state can only change in the tap handler')
+test('background detail loading cannot derive or write open state', () => {
+  assert.match(src, /useEffect/,
+    'historical activity detail is fetched only after the user opens it')
+  assert.match(
+    body,
+    /if \(!userOpen \|\| !detailRef \|\| detailEntries \|\| detailError\) return undefined/,
+    'the compact transcript stays closed and network-free until the user opens it',
+  )
+  assert.doesNotMatch(
+    body.slice(0, body.indexOf('onToggle={() =>')),
+    /setUserOpen\(/,
+    'loading/reset effects never write the disclosure state',
+  )
 })

--- a/frontend/src/components/ChatView/__tests__/chatRuntimeState.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatRuntimeState.test.js
@@ -225,6 +225,36 @@ test('shouldShowOpenAppCta is tied to the built app, not turn completion', () =>
   assert.equal(shouldShowOpenAppCta({ id: 42, name: 'Habits' }), true)
 })
 
+test('opening a preview hides it until the turn settles, then final open hides it', () => {
+  const previewSeen = {
+    id: 42,
+    name: 'Habits',
+    updated_at: 't1',
+    preview_seen_updated_at: 't1',
+    preview_seen_final: false,
+  }
+  assert.equal(shouldShowOpenAppCta(previewSeen, true), false)
+  assert.equal(shouldShowOpenAppCta(previewSeen, false), true)
+  assert.equal(openAppCtaViewModel(previewSeen, true), null)
+  assert.equal(openAppCtaViewModel(previewSeen, false)?.label, 'Open Habits')
+
+  const finalSeen = { ...previewSeen, preview_seen_final: true }
+  assert.equal(shouldShowOpenAppCta(finalSeen, false), false)
+  assert.equal(openAppCtaViewModel(finalSeen, false), null)
+})
+
+test('a newer app build resurfaces after the prior build was opened', () => {
+  const updated = {
+    id: 42,
+    name: 'Habits',
+    updated_at: 't2',
+    preview_seen_updated_at: 't1',
+    preview_seen_final: true,
+  }
+  assert.equal(shouldShowOpenAppCta(updated, true), true)
+  assert.equal(openAppCtaViewModel(updated, true)?.label, 'Open Habits preview')
+})
+
 test('openAppCtaViewModel names the active preview and idle app action', () => {
   assert.equal(openAppCtaViewModel(null, true), null)
   assert.deepEqual(openAppCtaViewModel({ id: 42, name: 'Habits' }, true), {

--- a/frontend/src/components/ChatView/__tests__/composerKeyboardPolicy.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerKeyboardPolicy.test.js
@@ -1,0 +1,37 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  shouldDismissComposerKeyboardOnSubmit,
+} from '../composerKeyboardPolicy.js'
+
+test('mobile queue-only send keeps the composer keyboard open', () => {
+  assert.equal(shouldDismissComposerKeyboardOnSubmit({
+    isTouchPrimary: true,
+    queuesBehindActiveTurn: true,
+  }), false)
+})
+
+test('mobile fresh send and explicit steer dismiss the composer keyboard', () => {
+  assert.equal(shouldDismissComposerKeyboardOnSubmit({
+    isTouchPrimary: true,
+    queuesBehindActiveTurn: false,
+  }), true)
+  assert.equal(shouldDismissComposerKeyboardOnSubmit({
+    isTouchPrimary: true,
+    queuesBehindActiveTurn: true,
+    steerAfterQueue: true,
+  }), true)
+})
+
+test('desktop submits retain composer focus', () => {
+  assert.equal(shouldDismissComposerKeyboardOnSubmit({
+    isTouchPrimary: false,
+    queuesBehindActiveTurn: false,
+  }), false)
+  assert.equal(shouldDismissComposerKeyboardOnSubmit({
+    isTouchPrimary: false,
+    queuesBehindActiveTurn: true,
+    steerAfterQueue: true,
+  }), false)
+})

--- a/frontend/src/components/ChatView/__tests__/composerSteerTouch.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerSteerTouch.test.js
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+const inputBar = readFileSync(new URL('../ChatInputBar.jsx', import.meta.url), 'utf8')
+const queuedMessages = readFileSync(new URL('../QueuedMessages.jsx', import.meta.url), 'utf8')
+const chatView = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8')
+
+test('composer fast-forward dispatches immediately without an incidental blur', () => {
+  const steerBlock = inputBar.match(
+    /key="steer"[\s\S]*?aria-label="Send queued message now"/,
+  )?.[0] || ''
+  assert.match(steerBlock, /onPointerDown=\{\(e\) => e\.preventDefault\(\)\}/)
+  assert.match(
+    steerBlock,
+    /onTouchEnd=\{\(e\) => \{ e\.preventDefault\(\); onSteer\(\) \}\}/,
+  )
+  assert.match(steerBlock, /onClick=\{onSteer\}/)
+})
+
+test('per-row fast-forward dispatches on touchend too', () => {
+  const steerBlock = queuedMessages.match(
+    /className="queued__steer"[\s\S]*?aria-label="Send this queued message now"/,
+  )?.[0] || ''
+  assert.match(steerBlock, /onPointerDown=\{\(e\) => e\.preventDefault\(\)\}/)
+  assert.match(steerBlock, /onTouchEnd=\{\(e\) => \{/)
+  assert.match(steerBlock, /e\.preventDefault\(\)[\s\S]*?onSteerOne\?\.\(cidOf\(msg\)\)/)
+})
+
+test('the shared steer path snapshots scroll before dismissing the mobile composer', () => {
+  assert.match(
+    chatView,
+    /async function steerRowsImpl\(steerRowsList\) \{[\s\S]*?steerPinIntentRef\.current = makeSendPinIntent\(steerWillPin\)[\s\S]*?if \(_isTouchPrimary\) inputRef\.current\?\.blur\(\)[\s\S]*?pendingQueue\.promoteManyByCid\(consumePendingCids\)/,
+  )
+})

--- a/frontend/src/components/ChatView/__tests__/messageSources.test.js
+++ b/frontend/src/components/ChatView/__tests__/messageSources.test.js
@@ -28,6 +28,18 @@ test('collects sources across every tool block in the message', () => {
   assert.deepEqual(messageSources(blocks).map(s => s.title), ['A', 'B'])
 })
 
+test('compact activity summaries preserve message-level source chips', () => {
+  const blocks = [{
+    type: 'activity',
+    entries: [],
+    sources: [{ title: 'Compact', url: 'https://compact.example/source' }],
+  }]
+  assert.deepEqual(messageSources(blocks), [{
+    title: 'Compact',
+    url: 'https://compact.example/source',
+  }])
+})
+
 test('dedupes across searches, first occurrence wins so search order is kept', () => {
   const blocks = [
     tool([{ title: 'First', url: 'https://x.example/p' }]),

--- a/frontend/src/components/ChatView/chatRuntimeState.js
+++ b/frontend/src/components/ChatView/chatRuntimeState.js
@@ -169,12 +169,21 @@ export function answerKeepsCurrentTurn(response) {
   return answerTurnDisposition(response) === 'same'
 }
 
-export function shouldShowOpenAppCta(builtApp) {
-  return Boolean(builtApp?.id)
+export function shouldShowOpenAppCta(builtApp, turnActive = false) {
+  if (!builtApp?.id) return false
+  const seenCurrentBuild = Boolean(
+    builtApp.updated_at
+    && builtApp.preview_seen_updated_at === builtApp.updated_at
+  )
+  if (!seenCurrentBuild) return true
+  // Opening during the live turn acknowledges that preview only. The settled
+  // result surfaces once more even if the last source write happened before
+  // the turn ended; opening it then is the durable final acknowledgement.
+  return !turnActive && !builtApp.preview_seen_final
 }
 
 export function openAppCtaViewModel(builtApp, turnActive) {
-  if (!shouldShowOpenAppCta(builtApp)) return null
+  if (!shouldShowOpenAppCta(builtApp, turnActive)) return null
   const name = builtApp.name || 'app'
   if (turnActive) {
     return {

--- a/frontend/src/components/ChatView/composerKeyboardPolicy.js
+++ b/frontend/src/components/ChatView/composerKeyboardPolicy.js
@@ -1,0 +1,18 @@
+/**
+ * Mobile submit keyboard policy.
+ *
+ * A normal send starts a turn, so dismissing the keyboard gives the reply the
+ * viewport. A queue-only send is different: the owner is still composing
+ * follow-ups, so keep the textarea focused. An explicit queue-and-steer submit
+ * carries the same dismiss intent as tapping either fast-forward control.
+ */
+export function shouldDismissComposerKeyboardOnSubmit({
+  isTouchPrimary = false,
+  queuesBehindActiveTurn = false,
+  steerAfterQueue = false,
+} = {}) {
+  return !!(
+    isTouchPrimary
+    && (!queuesBehindActiveTurn || steerAfterQueue)
+  )
+}

--- a/frontend/src/components/ChatView/messageSources.js
+++ b/frontend/src/components/ChatView/messageSources.js
@@ -105,7 +105,11 @@ export function messageSources(blocks) {
   let scannedRows = 0
   outer:
   for (const block of blocks) {
-    if (block?.type !== 'tool' || !Array.isArray(block.sources)) continue
+    // Compact historical activity carries the same bounded source metadata on
+    // its summary block, so citations remain visible without loading the full
+    // tool timeline merely to rediscover them.
+    if (!['tool', 'activity'].includes(block?.type)
+        || !Array.isArray(block.sources)) continue
     for (const rawSource of block.sources) {
       scannedRows += 1
       if (scannedRows > MAX_SOURCE_ROWS_SCANNED) break outer

--- a/frontend/src/components/Drawer/Drawer.css
+++ b/frontend/src/components/Drawer/Drawer.css
@@ -5,8 +5,6 @@
   inset: 0;
   z-index: 90;
   background: rgba(0, 0, 0, 0.4);
-  backdrop-filter: blur(4px);
-  -webkit-backdrop-filter: blur(4px);
   opacity: 0;
   pointer-events: none;
   /* The scrim is a modal boundary, not a transparent continuation of the
@@ -17,11 +15,15 @@
      panel sits above this element and has its own scroll containers. */
   touch-action: none;
   overscroll-behavior: none;
-  transition: opacity var(--transition-duration-basic, 220ms) var(--cubic-exit, ease);
+  /* A plain dim scrim avoids compositing a live full-screen blur on every
+     phone frame. Closing is intentionally a touch quicker than opening. */
+  transition: opacity 90ms cubic-bezier(0.3, 0.6, 0.6, 1);
 }
 
 .drawer-overlay--visible {
   opacity: 1;
+  transition-duration: 110ms;
+  transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
 }
 
 /* `open` becomes false when the close transition STARTS, not when the panel
@@ -51,10 +53,10 @@
      main thread with the synchronous Navigation-API state write in
      handleBack, and the first frame of the close stuttered. */
   will-change: transform;
-  /* Use the apps-sdk-ui motion tokens so all platform transitions
-     read as part of the same design system. --cubic-move is the
-     ease curve the SDK uses for sliding panels. */
-  transition: transform var(--transition-duration-basic, 250ms) var(--cubic-move, cubic-bezier(0.4, 0, 0.2, 1));
+  /* Drawer motion is deliberately quicker than the generic design-system
+     transition. The old shared curve barely moved at first, so a logically
+     immediate tap still felt hesitant. Closing is the shorter path. */
+  transition: transform 100ms cubic-bezier(0.3, 0.6, 0.6, 1);
   /* Vertical gestures belong to the drawer list; horizontal gestures are
      reserved for Drawer.jsx's swipe-to-close interaction. Keeping this modal
      boundary explicit also stops a pan begun on non-scrollable drawer chrome
@@ -74,6 +76,8 @@
 .drawer--open {
   transform: translateX(0);
   box-shadow: 8px 0 48px rgba(0, 0, 0, 0.5);
+  transition-duration: 120ms;
+  transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
 }
 
 /* Semantic desktop mode: Shell owns the breakpoint and only applies this class
@@ -375,8 +379,8 @@
   min-width: 0;
 }
 
-/* Drawer rows scroll vertically. Horizontal touch movement stays available to the
-   workspace controller as an immediate drag-out gesture. */
+/* Drawer rows scroll vertically. Gesture arbitration gives leftward movement to
+   swipe-close and only a deliberate rightward pull to workspace drag-out. */
 .drawer__row .drawer__item[data-drag-key] {
   touch-action: pan-y pinch-zoom;
 }

--- a/frontend/src/components/Shell/PaneChatView.jsx
+++ b/frontend/src/components/Shell/PaneChatView.jsx
@@ -34,6 +34,7 @@ function PaneChatView({
   markStreamingEnd,
   markVoiceListening,
   refreshApps,
+  acknowledgeAppPreview,
   refreshChats,
   loadTheme,
   navTo,
@@ -69,9 +70,10 @@ function PaneChatView({
   // Open the app the CTA points at into THIS pane (design §5, finding D-ii), so
   // a background chat's "Open app" lands beside it rather than in the globally
   // focused pane.
-  const handleOpenApp = useCallback((appId) => {
-    navTo('canvas', { appId, paneId })
-  }, [navTo, paneId])
+  const handleOpenApp = useCallback((app, { final = false } = {}) => {
+    navTo('canvas', { appId: app.id, paneId })
+    acknowledgeAppPreview?.(app, final)
+  }, [navTo, paneId, acknowledgeAppPreview])
 
   const handleChatMissing = useCallback((missingId) => {
     onChatMissing?.(missingId, chatId)

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -295,7 +295,9 @@ export default function Shell() {
   const closeDrawerRef = useRef(closeDrawer)
   closeDrawerRef.current = closeDrawer
   useEffect(() => {
-    if (desktopSidebarMode && drawerOpen) closeDrawerRef.current()
+    if (desktopSidebarMode && drawerOpen) {
+      closeDrawerRef.current({ preserveModalUntilTraversal: true })
+    }
   }, [desktopSidebarMode, drawerOpen])
 
   const brandButtonRef = useRef(null)

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -92,6 +92,10 @@ import useModeController from './useModeController.js'
 import * as modeMachine from './modeMachine.js'
 import { undoKeyPressed, isEditableTarget } from './workspaceOnboarding.js'
 import PaneChatView from './PaneChatView.jsx'
+import {
+  acknowledgeAppPreview,
+  withAppPreviewSeen,
+} from './builtAppState.js'
 import ErrorBoundary from '../ErrorBoundary/ErrorBoundary.jsx'
 import {
   deriveContentVisibility, deriveExitPlan, deriveEnterPlan, projectFocusedPane,
@@ -559,6 +563,24 @@ export default function Shell() {
   })
   const apps = appsQuery.data ?? []
   const chats = chatsQuery.data ?? []
+  const appPreviewAckRef = useRef(new Set())
+  const handleAppPreviewSeen = useCallback((app, final) => {
+    acknowledgeAppPreview({
+      app,
+      final,
+      inFlight: appPreviewAckRef.current,
+      request: api.apps.markPreviewSeen,
+      clearCached: (appId, updatedAt, seenAsFinal) => {
+        queryClient.setQueryData(
+          appQueries.keys.all,
+          rows => withAppPreviewSeen(
+            rows, appId, updatedAt, seenAsFinal,
+          ),
+        )
+      },
+      restoreServerTruth: () => appQueries.list.invalidate(queryClient),
+    })
+  }, [queryClient])
   // Warm the model registry as soon as a chat is open so the composer's
   // model picker is instant on the first '+'. The /api/models fetch
   // otherwise runs cold on the first picker open (it's 5-min cached after
@@ -3678,6 +3700,7 @@ export default function Shell() {
                 markStreamingEnd={markStreamingEnd}
                 markVoiceListening={markVoiceListening}
                 refreshApps={refreshApps}
+                acknowledgeAppPreview={handleAppPreviewSeen}
                 refreshChats={refreshChats}
                 loadTheme={loadTheme}
                 navTo={navTo}

--- a/frontend/src/components/Shell/__tests__/builtAppState.test.js
+++ b/frontend/src/components/Shell/__tests__/builtAppState.test.js
@@ -1,9 +1,21 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 
-import { builtAppsSignature, derivedBuiltApps } from '../builtAppState.js'
+import {
+  acknowledgeAppPreview,
+  builtAppsSignature,
+  derivedBuiltApps,
+  withAppPreviewSeen,
+} from '../builtAppState.js'
 
 const app = (id, name, updated_at, chat_id) => ({ id, name, updated_at, chat_id })
+const derived = (id, name, updated_at) => ({
+  id,
+  name,
+  updated_at,
+  preview_seen_updated_at: null,
+  preview_seen_final: false,
+})
 
 test('built apps are derived from the apps that carry this chat_id', () => {
   const apps = [
@@ -11,7 +23,7 @@ test('built apps are derived from the apps that carry this chat_id', () => {
     app(9, 'Other', '2026-07-12T00:00:00Z', 'chat-b'),
   ]
   assert.deepEqual(derivedBuiltApps(apps, 'chat-a'), [
-    { id: 7, name: 'Habits', updated_at: '2026-07-12T00:00:00Z' },
+    derived(7, 'Habits', '2026-07-12T00:00:00Z'),
   ])
   assert.deepEqual(derivedBuiltApps(apps, 'chat-c'), [])
 })
@@ -22,8 +34,8 @@ test('a chat can own several built apps, oldest updated first', () => {
     app(7, 'Notes', '2026-07-12T01:00:00Z', 'chat-a'),
   ]
   assert.deepEqual(derivedBuiltApps(apps, 'chat-a'), [
-    { id: 7, name: 'Notes', updated_at: '2026-07-12T01:00:00Z' },
-    { id: 8, name: 'Habits', updated_at: '2026-07-12T02:00:00Z' },
+    derived(7, 'Notes', '2026-07-12T01:00:00Z'),
+    derived(8, 'Habits', '2026-07-12T02:00:00Z'),
   ])
 })
 
@@ -85,4 +97,71 @@ test('signature changes when this chat owns a new app or a recompile', () => {
     builtAppsSignature(base, 'chat-a'), builtAppsSignature(recompiled, 'chat-a'))
   assert.notEqual(
     builtAppsSignature(base, 'chat-a'), builtAppsSignature(added, 'chat-a'))
+})
+
+test('signature changes when the current build or final result is acknowledged', () => {
+  const base = [app(7, 'Habits', 't1', 'chat-a')]
+  const previewSeen = [{
+    ...base[0], preview_seen_updated_at: 't1', preview_seen_final: false,
+  }]
+  const finalSeen = [{
+    ...base[0], preview_seen_updated_at: 't1', preview_seen_final: true,
+  }]
+  assert.notEqual(
+    builtAppsSignature(base, 'chat-a'),
+    builtAppsSignature(previewSeen, 'chat-a'),
+  )
+  assert.notEqual(
+    builtAppsSignature(previewSeen, 'chat-a'),
+    builtAppsSignature(finalSeen, 'chat-a'),
+  )
+})
+
+test('withAppPreviewSeen never lets a stale click hide a newer build', () => {
+  const rows = [app(7, 'Habits', 't2', 'chat-a')]
+  assert.equal(withAppPreviewSeen(rows, 7, 't1', true), rows)
+  assert.deepEqual(withAppPreviewSeen(rows, 7, 't2', false), [{
+    ...rows[0],
+    preview_seen_updated_at: 't2',
+    preview_seen_final: false,
+  }])
+})
+
+test('a final acknowledgement promotes the same build monotonically', () => {
+  const previewSeen = [{
+    ...app(7, 'Habits', 't1', 'chat-a'),
+    preview_seen_updated_at: 't1',
+    preview_seen_final: false,
+  }]
+  const finalSeen = withAppPreviewSeen(previewSeen, 7, 't1', true)
+  assert.deepEqual(finalSeen, [{
+    ...previewSeen[0], preview_seen_final: true,
+  }])
+  assert.equal(withAppPreviewSeen(finalSeen, 7, 't1', false), finalSeen)
+})
+
+test('preview acknowledgement deduplicates an exact build phase', async () => {
+  const inFlight = new Set()
+  const clears = []
+  let release
+  let requests = 0
+  const options = {
+    app: app(7, 'Habits', 't1', 'chat-a'),
+    final: false,
+    inFlight,
+    request: () => {
+      requests += 1
+      return new Promise(resolve => { release = resolve })
+    },
+    clearCached: (...args) => clears.push(args),
+    restoreServerTruth: () => assert.fail('success must not restore'),
+  }
+  const first = acknowledgeAppPreview(options)
+  const duplicate = acknowledgeAppPreview(options)
+  assert.equal(await duplicate, false)
+  assert.equal(requests, 1)
+  assert.deepEqual(clears, [[7, 't1', false]])
+  release({ ok: true, status: 204 })
+  assert.equal(await first, true)
+  assert.deepEqual(clears, [[7, 't1', false], [7, 't1', false]])
 })

--- a/frontend/src/components/Shell/__tests__/chatHandoff.test.js
+++ b/frontend/src/components/Shell/__tests__/chatHandoff.test.js
@@ -12,11 +12,16 @@ function ruleBody(selector) {
   return shellCss.match(new RegExp(`${escaped}\\s*\\{([\\s\\S]*?)\\}`))?.[1] || ''
 }
 
-test('chat display readiness preserves the existing transcript reveal gate', () => {
+test('chat display readiness trusts settled cache but keeps cold/running gates', () => {
   assert.match(
     chatView,
-    /const displayReady = !loading && \(revealed \|\| showEmpty \|\| showLoadError\)/,
-    'a transcript may hand off only after its initial load and reveal gate settle',
+    /const cachedDisplayReady = initialEntryPhase === 'cached' && revealed/,
+    'a settled cached transcript can hand off without waiting on network freshness',
+  )
+  assert.match(
+    chatView,
+    /const displayReady = cachedDisplayReady\s*\|\| \(!loading && \(revealed \|\| showEmpty \|\| showLoadError\)\)/,
+    'cold and running transcripts keep the authoritative load and reveal gates',
   )
   assert.match(chatView, /useLayoutEffect\(\(\) => \{[\s\S]*onDisplayReady\?\.\(chatId\)/,
     'readiness must reach Shell before the browser paints the hidden transcript')
@@ -31,7 +36,7 @@ test('a staging chat cannot leave the outgoing transcript held on a wedged reque
   assert.match(chatView, /const CHAT_FETCH_TIMEOUT_MS = 15000/)
   assert.match(
     chatView,
-    /apiFetch\(`\/chats\/\$\{chatId\}\?limit=20`, \{\s*timeoutMs: CHAT_FETCH_TIMEOUT_MS,\s*signal: initialLoadController\.signal,\s*\}\)/,
+    /apiFetch\(`\/chats\/\$\{chatId\}\?limit=20&compact=1`, \{\s*timeoutMs: CHAT_FETCH_TIMEOUT_MS,\s*signal: initialLoadController\.signal,\s*\}\)/,
     'the initial load must share the bounded message-fetch deadline',
   )
   assert.match(chatView, /initialLoadController\.abort\(\)/,

--- a/frontend/src/components/Shell/__tests__/chatHandoff.test.js
+++ b/frontend/src/components/Shell/__tests__/chatHandoff.test.js
@@ -12,16 +12,11 @@ function ruleBody(selector) {
   return shellCss.match(new RegExp(`${escaped}\\s*\\{([\\s\\S]*?)\\}`))?.[1] || ''
 }
 
-test('chat display readiness trusts settled cache but keeps cold/running gates', () => {
+test('chat display readiness preserves the authoritative transcript reveal gate', () => {
   assert.match(
     chatView,
-    /const cachedDisplayReady = initialEntryPhase === 'cached' && revealed/,
-    'a settled cached transcript can hand off without waiting on network freshness',
-  )
-  assert.match(
-    chatView,
-    /const displayReady = cachedDisplayReady\s*\|\| \(!loading && \(revealed \|\| showEmpty \|\| showLoadError\)\)/,
-    'cold and running transcripts keep the authoritative load and reveal gates',
+    /const displayReady = !loading && \(revealed \|\| showEmpty \|\| showLoadError\)/,
+    'a cached transcript cannot paint before the live chat read confirms it',
   )
   assert.match(chatView, /useLayoutEffect\(\(\) => \{[\s\S]*onDisplayReady\?\.\(chatId\)/,
     'readiness must reach Shell before the browser paints the hidden transcript')

--- a/frontend/src/components/Shell/__tests__/dragController.test.js
+++ b/frontend/src/components/Shell/__tests__/dragController.test.js
@@ -2,6 +2,7 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import {
   POINTER_SLOP, TAB_HOLD_MS, DRAWER_HOLD_MS, PRE_HOLD_MOVE_PX, RELEASE_IN_PLACE_PX,
+  DRAWER_DRAG_INTENT_PX, DRAWER_DRAG_DOMINANCE,
   HYSTERESIS_PX, ROOT_EDGE_PX, CARET_W, CARET_H, CENTER_INSET, DRAWER_EXIT_PX,
   CHIP_MOUSE_DX, CHIP_MOUSE_DY, CHIP_TOUCH_ABOVE,
   EDGE_BAND_MIN, EDGE_BAND_FRACTION,
@@ -48,10 +49,19 @@ test('touchMoveIntent preserves tab-body scrolling and gives the kind icon eithe
   assert.equal(touchMoveIntent(8.1, 0, 'tab'), 'scroll', 'horizontal pull scrolls over a tab body')
   assert.equal(touchMoveIntent(8.1, 0, 'tab-handle'), 'drag', 'the icon reorders horizontally')
   assert.equal(touchMoveIntent(0, 8.1, 'tab-handle'), 'drag', 'the icon can move across panes')
-  assert.equal(touchMoveIntent(8.1, 0, 'drawer'), 'drag', 'horizontal pull drags a vertical drawer row')
+  assert.equal(touchMoveIntent(-8.1, 0, 'drawer'), 'swipe-close',
+    'leftward pull belongs exclusively to drawer close')
+  assert.equal(touchMoveIntent(18, 0, 'drawer'), 'pending',
+    'a small rightward thumb movement does not lift a row')
+  assert.equal(touchMoveIntent(18.1, 0, 'drawer'), 'drag',
+    'a deliberate rightward pull toward the workspace lifts the row')
+  assert.equal(touchMoveIntent(24, 21, 'drawer'), 'pending',
+    'a shallow rightward diagonal remains undecided rather than latching')
   assert.equal(touchMoveIntent(0, 8.1, 'drawer'), 'scroll', 'vertical pull scrolls the drawer')
   assert.equal(touchMoveIntent(10, 10, 'drawer'), 'scroll', 'ambiguous diagonals favor native scroll')
   assert.equal(PRE_HOLD_MOVE_PX, 8)
+  assert.equal(DRAWER_DRAG_INTENT_PX, 18)
+  assert.equal(DRAWER_DRAG_DOMINANCE, 1.2)
 })
 
 test('releasedInPlace is true only within the release radius', () => {

--- a/frontend/src/components/Shell/builtAppState.js
+++ b/frontend/src/components/Shell/builtAppState.js
@@ -1,10 +1,10 @@
 // The built-app CTA row is DERIVED from server truth — the apps query's own
-// `chat_id` column — never mirrored in client state. Every app row carries the
-// chat_id of the turn that built it (register_app.py stamps it), so the CTA
-// list for a chat is exactly "the apps this chat owns," durably, across
-// sessions and devices. A chat can build several apps in one turn ("a notes app
-// and a habit tracker"), so it is a LIST, newest last, capped so the chat foot
-// can't grow without bound.
+// `chat_id` column plus its durable preview acknowledgement — never mirrored
+// in ad-hoc component state. Every app row carries the chat_id of the turn that
+// built it (register_app.py stamps it), so the CTA list for a chat is exactly
+// "the apps this chat owns," durably, across sessions and devices. A chat can
+// build several apps in one turn ("a notes app and a habit tracker"), so it is
+// a LIST, newest last, capped so the chat foot can't grow without bound.
 const MAX_BUILT_APPS_PER_CHAT = 3
 
 // Shared frozen empty list so a chat with no built apps always yields the SAME
@@ -39,7 +39,12 @@ function scopedApps(apps, chatId) {
 // without it every app_updated (any app, any chat) would churn the CTA effects.
 export function builtAppsSignature(apps, chatId) {
   return scopedApps(apps, chatId)
-    .map(a => `${a.id}:${a.updated_at ?? ''}`)
+    .map(a => [
+      a.id,
+      a.updated_at ?? '',
+      a.preview_seen_updated_at ?? '',
+      a.preview_seen_final ? 'final' : 'preview',
+    ].join(':'))
     .join(',')
 }
 
@@ -49,5 +54,71 @@ export function builtAppsSignature(apps, chatId) {
 export function derivedBuiltApps(apps, chatId) {
   const scoped = scopedApps(apps, chatId)
   if (scoped.length === 0) return EMPTY_BUILT_APPS
-  return scoped.map(a => ({ id: a.id, name: a.name, updated_at: a.updated_at }))
+  return scoped.map(a => ({
+    id: a.id,
+    name: a.name,
+    updated_at: a.updated_at,
+    preview_seen_updated_at: a.preview_seen_updated_at ?? null,
+    preview_seen_final: Boolean(a.preview_seen_final),
+  }))
+}
+
+// Optimistically acknowledge only the exact build the CTA opened. A concurrent
+// app_updated may already have advanced the cached row; in that case the stale
+// click must not hide the newer build.
+export function withAppPreviewSeen(apps, appId, updatedAt, final = false) {
+  const id = Number(appId)
+  if (!Array.isArray(apps) || Number.isNaN(id) || !updatedAt) return apps
+  let changed = false
+  const next = apps.map(app => {
+    if (Number(app?.id) !== id || app.updated_at !== updatedAt) return app
+    const sameVersion = app.preview_seen_updated_at === updatedAt
+    const seenFinal = sameVersion && app.preview_seen_final
+    if (sameVersion && (seenFinal || !final)) return app
+    changed = true
+    return {
+      ...app,
+      preview_seen_updated_at: updatedAt,
+      preview_seen_final: Boolean(seenFinal || final),
+    }
+  })
+  return changed ? next : apps
+}
+
+// Own one exact app/build/phase acknowledgement. A failed write restores
+// server truth; a successful one re-applies the optimistic value in case an
+// unrelated refetch settled while the request was in flight.
+export async function acknowledgeAppPreview({
+  app,
+  final,
+  inFlight,
+  request,
+  clearCached,
+  restoreServerTruth,
+}) {
+  const appId = Number(app?.id)
+  const updatedAt = app?.updated_at
+  if (Number.isNaN(appId) || !updatedAt) return false
+  const key = `${appId}:${updatedAt}:${final ? 'final' : 'preview'}`
+  if (inFlight.has(key)) return false
+  inFlight.add(key)
+  clearCached(appId, updatedAt, final)
+  try {
+    const response = await request(appId, updatedAt, final)
+    if (!response?.ok) {
+      throw new Error(`preview acknowledgement failed (${response?.status ?? 'unknown'})`)
+    }
+    clearCached(appId, updatedAt, final)
+    return true
+  } catch {
+    inFlight.delete(key)
+    try {
+      await restoreServerTruth()
+    } catch {
+      // Reconnect/foreground refresh remains the durable recovery path.
+    }
+    return false
+  } finally {
+    inFlight.delete(key)
+  }
 }

--- a/frontend/src/components/Shell/dragController.js
+++ b/frontend/src/components/Shell/dragController.js
@@ -39,6 +39,12 @@ export const DRAWER_HOLD_MS = 450
 // Movement past this before the hold resolves is enough to classify the gesture
 // against the source scroller's axis (touchMoveIntent below).
 export const PRE_HOLD_MOVE_PX = 8
+// A drawer row only lifts when it is deliberately pulled TOWARD the workspace.
+// The opposite (leftward) direction is the drawer's swipe-to-close gesture, so
+// it must never arm row dragging. The larger threshold also lets ordinary thumb
+// jitter settle before a rightward drag-out takes ownership.
+export const DRAWER_DRAG_INTENT_PX = 18
+export const DRAWER_DRAG_DOMINANCE = 1.2
 // After a touch lift, a release that never moved past this opens the context
 // menu instead of dropping (lift → release-in-place = menu; lift → move = drag).
 export const RELEASE_IN_PLACE_PX = 5
@@ -95,16 +101,23 @@ export function passedSlop(dx, dy, slop = POINTER_SLOP) {
   return hypot(dx, dy) > slop
 }
 
-// Drawer rows live in a vertical list, so vertical movement stays native scrolling
-// and a horizontal pull becomes a drag. Tab bodies live in a horizontal strip: a
-// horizontal move stays native scrolling, while a vertical pull lifts the tab. The
-// dedicated tab handle owns its pointer stream in CSS and can therefore reorder on
-// either axis without taking horizontal scrolling away from the tab body.
+// Drawer rows live in a vertical list: vertical movement stays native scrolling,
+// a LEFTWARD pull belongs to the drawer's swipe-close handler, and only a
+// deliberate RIGHTWARD pull toward the workspace becomes a row drag. Tab bodies
+// live in a horizontal strip: a horizontal move stays native scrolling, while a
+// vertical pull lifts the tab. The dedicated tab handle owns its pointer stream in
+// CSS and can therefore reorder on either axis without taking horizontal scrolling
+// away from the tab body.
 export function touchMoveIntent(dx, dy, sourceKind, limit = PRE_HOLD_MOVE_PX) {
   if (hypot(dx, dy) <= limit) return 'pending'
   const x = Math.abs(dx)
   const y = Math.abs(dy)
-  if (sourceKind === 'drawer') return x > y ? 'drag' : 'scroll'
+  if (sourceKind === 'drawer') {
+    if (dx < 0 && x > y) return 'swipe-close'
+    if (dx > DRAWER_DRAG_INTENT_PX && x > y * DRAWER_DRAG_DOMINANCE) return 'drag'
+    if (y >= x) return 'scroll'
+    return 'pending'
+  }
   if (sourceKind === 'tab-handle') return 'drag'
   return y > x ? 'drag' : 'scroll'
 }

--- a/frontend/src/components/Shell/useWorkspaceDrag.js
+++ b/frontend/src/components/Shell/useWorkspaceDrag.js
@@ -306,10 +306,12 @@ export default function useWorkspaceDrag({
         }
       }
 
-      // A vertical tab-body move, either-axis kind-icon move, or cross-axis drawer-row
-      // move arms immediately. A stationary hold is the alternate path to the
-      // tab/row menu; it deliberately does not unfold the workspace just because
-      // time passed.
+      // A vertical tab-body move, either-axis kind-icon move, or deliberate
+      // RIGHTWARD drawer-row pull arms immediately. A leftward drawer movement is
+      // reserved for swipe-to-close and retires this controller before it can set
+      // dragActiveRef (which would otherwise make Drawer stand down). A stationary
+      // hold is the alternate path to the tab/row menu; it deliberately does not
+      // unfold the workspace just because time passed.
       if (isTouch) {
         holdTimer = setTimeout(() => {
           if (cancelled || cleaned) return
@@ -393,7 +395,11 @@ export default function useWorkspaceDrag({
         if (!armed) {
           if (isTouch) {
             const intent = touchMoveIntent(dx, dy, touchIntentKind)
-            if (intent === 'scroll') { cancelled = true; cleanup(); return }
+            if (intent === 'scroll' || intent === 'swipe-close') {
+              cancelled = true
+              cleanup()
+              return
+            }
             if (intent === 'drag') {
               clearTimeout(holdTimer)
               arm()

--- a/frontend/src/hooks/useNavigation.js
+++ b/frontend/src/hooks/useNavigation.js
@@ -538,7 +538,7 @@ export default function useNavigation({
     setDrawerVisible(true)
   }
 
-  function closeDrawer() {
+  function closeDrawer({ preserveModalUntilTraversal = false } = {}) {
     // A modal close owns one serialized traversal. Escape, overlay, toggle, and
     // breakpoint cleanup can arrive in the same frame; a second back() would
     // skip past the drawer's sentinel before the first traversal settles.
@@ -548,9 +548,10 @@ export default function useNavigation({
       // A tap/swipe close should acknowledge immediately. Keep the logical ref
       // true until Back consumes the drawer sentinel (so handleBack still owns
       // navigation correctness), but begin the visual close before that async
-      // traversal and its anti-stutter rAF settle. Real browser Back gestures
-      // still enter through handleBack and retain the deferred close path.
-      setDrawerVisible(false)
+      // traversal and its anti-stutter rAF settle. A breakpoint transition is
+      // different: desktop content must remain behind the complete mobile
+      // modal boundary until the sentinel is actually consumed.
+      if (!preserveModalUntilTraversal) setDrawerVisible(false)
       // Funnel through history.back() so handleBack handles the state
       // transition. This makes back-gesture and overlay-tap follow
       // exactly the same code path through handleBack, with the

--- a/frontend/src/hooks/useNavigation.js
+++ b/frontend/src/hooks/useNavigation.js
@@ -538,11 +538,17 @@ export default function useNavigation({
     // skip past the drawer's sentinel before the first traversal settles.
     if (!drawerOpenRef.current || drawerClosePendingRef.current) return
     if (drawerPushedRef.current) {
+      drawerClosePendingRef.current = true
+      // A tap/swipe close should acknowledge immediately. Keep the logical ref
+      // true until Back consumes the drawer sentinel (so handleBack still owns
+      // navigation correctness), but begin the visual close before that async
+      // traversal and its anti-stutter rAF settle. Real browser Back gestures
+      // still enter through handleBack and retain the deferred close path.
+      setDrawerOpen(false)
       // Funnel through history.back() so handleBack handles the state
       // transition. This makes back-gesture and overlay-tap follow
       // exactly the same code path through handleBack, with the
       // drawer-first guard there preventing navStack over-pop.
-      drawerClosePendingRef.current = true
       history.back()
     } else {
       // Defensive: drawer open without a sentinel (shouldn't happen

--- a/frontend/src/hooks/useNavigation.js
+++ b/frontend/src/hooks/useNavigation.js
@@ -213,7 +213,10 @@ export default function useNavigation({
     initialNav.view === 'settings'
     && !(paneModel.BUILDER_SETTINGS_ENABLED && workspace.viewMode === 'panes'),
   )
-  const [drawerOpen, setDrawerOpen] = useState(false)
+  // Visual visibility is intentionally separate from history ownership.
+  // An explicit tap/swipe close can start the panel transition immediately
+  // while drawerOpenRef remains true until Back consumes the drawer sentinel.
+  const [drawerVisible, setDrawerVisible] = useState(false)
 
   // ── Derived legacy triple (the projection, design §1) ────────────────────
   // World-aware (two-worlds design): the single world's slot in single mode, the
@@ -269,8 +272,11 @@ export default function useNavigation({
   activeAppIdRef.current = activeAppId
   const settingsOpenRef = useRef(settingsOpen)
   settingsOpenRef.current = settingsOpen
-  const drawerOpenRef = useRef(drawerOpen)
-  drawerOpenRef.current = drawerOpen
+  // Logical/history ownership — never mirror drawerVisible during render.
+  // Every history transition advances this ref synchronously at its owning
+  // boundary; coupling it back to the visual state made an early close render
+  // turn the subsequent drawer-sentinel Back into ordinary navigation.
+  const drawerOpenRef = useRef(false)
   // The PAINTED Settings takeover for a given workspace snapshot — the render-time
   // `overlayShowing` above, generalized to any `ws` and read from the ref for the
   // async callbacks below. The takeover only PAINTS where the world is single (or
@@ -529,7 +535,7 @@ export default function useNavigation({
     // Advance the ref synchronously so a same-batch open→close sees "open" and
     // does not leave the just-pushed sentinel dangling (§5.3.2).
     drawerOpenRef.current = true
-    setDrawerOpen(true)
+    setDrawerVisible(true)
   }
 
   function closeDrawer() {
@@ -544,7 +550,7 @@ export default function useNavigation({
       // navigation correctness), but begin the visual close before that async
       // traversal and its anti-stutter rAF settle. Real browser Back gestures
       // still enter through handleBack and retain the deferred close path.
-      setDrawerOpen(false)
+      setDrawerVisible(false)
       // Funnel through history.back() so handleBack handles the state
       // transition. This makes back-gesture and overlay-tap follow
       // exactly the same code path through handleBack, with the
@@ -555,7 +561,7 @@ export default function useNavigation({
       // in normal flow). Just close it directly.
       drawerOpenRef.current = false
       drawerClosePendingRef.current = false
-      setDrawerOpen(false)
+      setDrawerVisible(false)
     }
   }
 
@@ -921,7 +927,7 @@ export default function useNavigation({
     }
     navStackRef.current.push(previousRoute)
     drawerOpenRef.current = false
-    setDrawerOpen(false)
+    setDrawerVisible(false)
 
     // One reducer action makes payload+view atomic (§1.3.2). The ONE decision
     // point applies the destination to the correct world: a chat/app nav in single
@@ -1177,11 +1183,11 @@ export default function useNavigation({
       if (destination?.kind === 'drawer') {
         drawerPushedRef.current = true
         drawerOpenRef.current = true
-        setDrawerOpen(true)
+        setDrawerVisible(true)
       } else {
         drawerPushedRef.current = false
         drawerOpenRef.current = false
-        setDrawerOpen(false)
+        setDrawerVisible(false)
       }
     }
 
@@ -1226,9 +1232,9 @@ export default function useNavigation({
       setTimeout(() => { backFiredRef.current = false }, 400)
       const closeDrawerNextFrame = () => {
         if (typeof requestAnimationFrame === 'function') {
-          requestAnimationFrame(() => setDrawerOpen(false))
+          requestAnimationFrame(() => setDrawerVisible(false))
         } else {
-          setDrawerOpen(false)
+          setDrawerVisible(false)
         }
       }
       // (1) Drawer-first: a back that consumes the drawer's own sentinel closes
@@ -1353,7 +1359,7 @@ export default function useNavigation({
       drawerPushedRef.current = false
       drawerClosePendingRef.current = false
       drawerOpenRef.current = false
-      setDrawerOpen(false)
+      setDrawerVisible(false)
       const entry = navStackRef.current.pop()
       if (entry) restoreRoute(entry)
       else if (isRestorableRoute(destination?.route)) restoreRoute(destination.route)
@@ -1551,7 +1557,7 @@ export default function useNavigation({
     activeView,
     activeAppId,
     activeChatId,
-    drawerOpen,
+    drawerOpen: drawerVisible,
     // Strictly "the full-workspace takeover overlay is up" — NOT "focused content
     // is Settings" (a builder tab is the latter without the overlay). The render
     // gates pane suppression on THIS, never on activeView, so builder Settings

--- a/frontend/src/lib/__tests__/drawerLifecycle.test.js
+++ b/frontend/src/lib/__tests__/drawerLifecycle.test.js
@@ -36,8 +36,8 @@ test('drawer cleanup is safe before the panel ref mounts', () => {
   assert.doesNotThrow(() => clearDrawerGestureStyles(null))
 })
 
-test('close fallback outlasts the 250ms panel transition', () => {
-  assert.ok(DRAWER_CLOSE_FALLBACK_MS > 250)
+test('close fallback outlasts the 100ms panel transition', () => {
+  assert.ok(DRAWER_CLOSE_FALLBACK_MS > 100)
 })
 
 test('drawer swipe classification rejects vertical and ambiguous movement', () => {

--- a/frontend/src/lib/__tests__/navigationWorkspaceContract.test.js
+++ b/frontend/src/lib/__tests__/navigationWorkspaceContract.test.js
@@ -23,12 +23,19 @@ test('an explicit drawer close starts visually before consuming its history sent
     navigation.indexOf('function closeDrawer()'),
     navigation.indexOf('/**\n   * Mini-app nav-bridge'),
   )
-  const visualClose = close.indexOf('setDrawerOpen(false)')
+  const visualClose = close.indexOf('setDrawerVisible(false)')
   const traversal = close.indexOf('history.back()')
   assert.ok(visualClose >= 0)
   assert.ok(traversal > visualClose,
     'tap/swipe dismissal must acknowledge before the asynchronous Back traversal')
-  assert.match(close, /drawerClosePendingRef\.current = true[\s\S]*setDrawerOpen\(false\)[\s\S]*history\.back\(\)/)
+  assert.match(close, /drawerClosePendingRef\.current = true[\s\S]*setDrawerVisible\(false\)[\s\S]*history\.back\(\)/)
+})
+
+test('drawer visual visibility cannot overwrite logical history ownership during render', () => {
+  assert.match(navigation, /const \[drawerVisible, setDrawerVisible\] = useState\(false\)/)
+  assert.match(navigation, /const drawerOpenRef = useRef\(false\)/)
+  assert.doesNotMatch(navigation, /drawerOpenRef\.current = drawerVisible/)
+  assert.match(navigation, /drawerOpen: drawerVisible/)
 })
 
 test('ordinary Back restores a hidden sentinel owner before messaging it', () => {

--- a/frontend/src/lib/__tests__/navigationWorkspaceContract.test.js
+++ b/frontend/src/lib/__tests__/navigationWorkspaceContract.test.js
@@ -20,7 +20,7 @@ test('one open drawer owns at most one physical sentinel', () => {
 
 test('an explicit drawer close starts visually before consuming its history sentinel', () => {
   const close = navigation.slice(
-    navigation.indexOf('function closeDrawer()'),
+    navigation.indexOf('function closeDrawer('),
     navigation.indexOf('/**\n   * Mini-app nav-bridge'),
   )
   const visualClose = close.indexOf('setDrawerVisible(false)')
@@ -28,7 +28,14 @@ test('an explicit drawer close starts visually before consuming its history sent
   assert.ok(visualClose >= 0)
   assert.ok(traversal > visualClose,
     'tap/swipe dismissal must acknowledge before the asynchronous Back traversal')
-  assert.match(close, /drawerClosePendingRef\.current = true[\s\S]*setDrawerVisible\(false\)[\s\S]*history\.back\(\)/)
+  assert.match(close, /drawerClosePendingRef\.current = true[\s\S]*if \(!preserveModalUntilTraversal\) setDrawerVisible\(false\)[\s\S]*history\.back\(\)/)
+})
+
+test('a breakpoint close preserves the mobile modal boundary until history settles', () => {
+  assert.match(
+    shell,
+    /desktopSidebarMode && drawerOpen[\s\S]*closeDrawerRef\.current\(\{ preserveModalUntilTraversal: true \}\)/,
+  )
 })
 
 test('drawer visual visibility cannot overwrite logical history ownership during render', () => {

--- a/frontend/src/lib/__tests__/navigationWorkspaceContract.test.js
+++ b/frontend/src/lib/__tests__/navigationWorkspaceContract.test.js
@@ -18,6 +18,19 @@ test('one open drawer owns at most one physical sentinel', () => {
   )
 })
 
+test('an explicit drawer close starts visually before consuming its history sentinel', () => {
+  const close = navigation.slice(
+    navigation.indexOf('function closeDrawer()'),
+    navigation.indexOf('/**\n   * Mini-app nav-bridge'),
+  )
+  const visualClose = close.indexOf('setDrawerOpen(false)')
+  const traversal = close.indexOf('history.back()')
+  assert.ok(visualClose >= 0)
+  assert.ok(traversal > visualClose,
+    'tap/swipe dismissal must acknowledge before the asynchronous Back traversal')
+  assert.match(close, /drawerClosePendingRef\.current = true[\s\S]*setDrawerOpen\(false\)[\s\S]*history\.back\(\)/)
+})
+
 test('ordinary Back restores a hidden sentinel owner before messaging it', () => {
   const ordinaryBack = navigation.slice(
     navigation.indexOf('// (4) Ordinary app sentinel'),

--- a/frontend/src/lib/drawerLifecycle.js
+++ b/frontend/src/lib/drawerLifecycle.js
@@ -1,10 +1,10 @@
 // Drawer lifecycle helpers keep imperative swipe styling subordinate to the
 // shell's authoritative open/closed state.
 
-// Slightly longer than Drawer.css's 250ms transform transition. This is only
+// Longer than Drawer.css's 100ms close transition. This is only
 // a fallback for reduced-motion / interrupted transitions where transitionend
 // does not fire; the normal path releases on the real transform event.
-export const DRAWER_CLOSE_FALLBACK_MS = 350
+export const DRAWER_CLOSE_FALLBACK_MS = 180
 export const DRAWER_SWIPE_THRESHOLD_PX = 10
 export const DRAWER_SWIPE_DOMINANCE = 1.15
 

--- a/tests/navigation.spec.mjs
+++ b/tests/navigation.spec.mjs
@@ -376,7 +376,7 @@ test.describe('Desktop sidebar navigation', () => {
     await expect.poll(() => page.evaluate(() => history.state?.kind)).not.toBe('drawer')
   })
 
-  test('31. breakpoint cleanup stays modal and seeks through phantom history', async ({ page }) => {
+  test('31. breakpoint cleanup closes visually while seeking through phantom history', async ({ page }) => {
     await page.addInitScript(() => {
       localStorage.setItem('mobius:desktop-sidebar-open:v1', 'true')
     })
@@ -399,10 +399,12 @@ test.describe('Desktop sidebar navigation', () => {
     await page.setViewportSize({ width: 1280, height: 800 })
     await page.waitForFunction(() => typeof window.__releaseBreakpointBack === 'function')
 
-    // Desktop mode is requested, but the still-open mobile sentinel retains its
-    // complete modal boundary until the traversal is allowed to finish.
-    await expect(page.locator('.drawer-overlay')).toBeVisible()
-    await expect(page.locator('.shell__content')).toHaveAttribute('inert', '')
+    // Desktop mode is requested immediately even while the mobile sentinel's
+    // history traversal is held. History ownership remains pending internally,
+    // but it must not keep a stale modal overlay painted over desktop content.
+    await expect(page.locator('.drawer.drawer--persistent')).toBeVisible()
+    await expect(page.locator('.drawer-overlay')).toHaveCount(0)
+    await expect(page.locator('.shell__content')).not.toHaveAttribute('inert', '')
 
     await page.evaluate(() => window.__releaseBreakpointBack())
     await expect(page.locator('.drawer.drawer--persistent')).toBeVisible()

--- a/tests/stream-reconnect.spec.mjs
+++ b/tests/stream-reconnect.spec.mjs
@@ -161,7 +161,7 @@ test.describe('Stream reconnection', () => {
     let streamRequestCount = 0
     let refreshReady = false
 
-    await page.route(/\/api\/chats\/[0-9a-f-]+\?limit=20$/, route => {
+    await page.route(/\/api\/chats\/[0-9a-f-]+\?limit=20&compact=1$/, route => {
       if (!refreshReady || route.request().method() !== 'GET') {
         route.continue()
         return
@@ -749,7 +749,7 @@ test.describe('Stream reconnection', () => {
     // all of them with DB state that does NOT contain the resent turn,
     // so if the bug path clobbers, the live response visibly disappears.
     const dbRefetchTimes = []
-    await page.route(/\/api\/chats\/[0-9a-f-]+\?limit=20$/, route => {
+    await page.route(/\/api\/chats\/[0-9a-f-]+\?limit=20&compact=1$/, route => {
       if (route.request().method() !== 'GET') { route.continue(); return }
       dbRefetchTimes.push(Date.now())
       route.fulfill({
@@ -983,7 +983,7 @@ test.describe('Stream reconnection', () => {
     // frozen on an unanswered question. Crucially `pending_question_id`
     // is null (the live in-process registry hint is absent — the path
     // that used to wedge), forcing the durable fallback.
-    await page.route(/\/api\/chats\/[0-9a-f-]+\?limit=20$/, route => {
+    await page.route(/\/api\/chats\/[0-9a-f-]+\?limit=20&compact=1$/, route => {
       if (route.request().method() !== 'GET') { route.continue(); return }
       route.fulfill({
         status: 200,

--- a/tests/stream-reconnect.spec.mjs
+++ b/tests/stream-reconnect.spec.mjs
@@ -161,7 +161,7 @@ test.describe('Stream reconnection', () => {
     let streamRequestCount = 0
     let refreshReady = false
 
-    await page.route(/\/api\/chats\/[0-9a-f-]+\?limit=20$/, route => {
+    await page.route(/\/api\/chats\/[0-9a-f-]+\?limit=20(?:&compact=1)?$/, route => {
       if (!refreshReady || route.request().method() !== 'GET') {
         route.continue()
         return
@@ -749,7 +749,7 @@ test.describe('Stream reconnection', () => {
     // all of them with DB state that does NOT contain the resent turn,
     // so if the bug path clobbers, the live response visibly disappears.
     const dbRefetchTimes = []
-    await page.route(/\/api\/chats\/[0-9a-f-]+\?limit=20$/, route => {
+    await page.route(/\/api\/chats\/[0-9a-f-]+\?limit=20(?:&compact=1)?$/, route => {
       if (route.request().method() !== 'GET') { route.continue(); return }
       dbRefetchTimes.push(Date.now())
       route.fulfill({
@@ -983,7 +983,7 @@ test.describe('Stream reconnection', () => {
     // frozen on an unanswered question. Crucially `pending_question_id`
     // is null (the live in-process registry hint is absent — the path
     // that used to wedge), forcing the durable fallback.
-    await page.route(/\/api\/chats\/[0-9a-f-]+\?limit=20$/, route => {
+    await page.route(/\/api\/chats\/[0-9a-f-]+\?limit=20(?:&compact=1)?$/, route => {
       if (route.request().method() !== 'GET') { route.continue(); return }
       route.fulfill({
         status: 200,


### PR DESCRIPTION
## Summary

This brings the reviewed, still-useful production-only runtime work back upstream after #212:

- persist app-preview acknowledgement per exact build
- keep the mobile keyboard open for queue-only sends
- compile mini-app runtime bundles in production builds
- persist provider token usage against the exact chat run
- restore every opted-in running turn after a planned restart
- make drawer ownership and fast-close navigation deterministic
- project long historical activity into bounded, lazy detail ranges

## Two review rounds

The first pass reviewed each feature against its owning persistence, navigation, capability, and runtime contracts. The second pass exercised the combined tree, migrations, live-data shapes, and failure boundaries.

Review fixes now included:

- cap every compact activity range at the activity-detail endpoint's 2,000-block contract, so every generated disclosure remains fetchable
- query tool-output sidecars only for IDs in the requested activity page
- bind each scheduled script path to the exact live app whose token and filesystem contract it receives
- fail closed when that scheduled-job identity is absent, instead of retaining a permanent compatibility bypass during updates
- preserve the authoritative chat handoff gate, so warm cached content cannot flash a deleted or stale destination
- keep the complete mobile modal boundary during a breakpoint transition until its history sentinel is consumed
- align browser fixtures with the compact transcript request so reconnect and persisted-question paths test the production contract

## Deliberately excluded

- the production viewport zoom lock: it disables browser zoom and fails the current accessibility interface guidelines
- the cross-recompile quiet-CTA patch: its acknowledgement was not scoped to a turn, so an unopened final build from one turn could suppress the next turn's first preview
- superseded transcript-cache experiments; their useful performance behavior is replaced by bounded projection without weakening destination validation

## Validation

- focused backend review suite: 282 passed
- scheduled-job follow-up suite: 12 passed
- frontend unit tests: 1,880 passed
- frontend hook tests: 47 passed
- production frontend build passed
- `git diff --check` and privacy/invariant scans passed
- read-only structural replay over 487 live chat shapes produced 4,697 valid lazy ranges with zero contract violations; recent-page payload was 83.7% smaller in aggregate (content was not printed or exported)

The final pushed head reruns the complete isolated backend, frontend, privacy, and browser suites.
