### PR TITLE
Prevent pytest from mutating production cron

### DIFF
--- a/backend/app/install.py
+++ b/backend/app/install.py
@@ -240,10 +240,26 @@ _HTTP_TIMEOUT = 15.0
 # different host.
 _MAX_REDIRECTS = 5
 
-# Cron scaffold lives at this path in the built image. Tests override
-# the module attribute to bypass the scaffold (which hardcodes
-# `/data/apps/<slug>/` and doesn't accept the test's `/tmp/testdata`).
+# Cron scaffold lives at this path in the built image. Tests normally override
+# the module attribute; the test-runtime mutation guard below is the backstop
+# when the baked scaffold is present (as it is inside the production image).
 CRON_SCAFFOLD = Path("/app/scripts/init-cron-scaffold.sh")
+_ALLOW_TEST_CRON_ENV = "MOBIUS_ALLOW_TEST_CRON"
+
+
+def _cron_mutation_blocked_in_test_runtime() -> bool:
+  """Whether host crontab writes must fail closed in this process.
+
+  Pytest is occasionally run from inside the production container, where the
+  real scaffold and crontab binary are both available. Its database and
+  DATA_DIR are isolated, but a low-id test app must never escape that boundary
+  and replace a production schedule. Narrow unit tests can opt in only while
+  their crontab/scaffold subprocess is explicitly faked.
+  """
+  return (
+    os.environ.get("MOBIUS_TEST_RUNTIME") == "1"
+    and os.environ.get(_ALLOW_TEST_CRON_ENV) != "1"
+  )
 
 
 def _validate_manifest(m: dict) -> None:
@@ -1121,6 +1137,11 @@ def _register_cron(slug: str, schedule_expr: str, job_path: Path,
   such a job runs with no id and exits early — which is exactly how a
   freshly-installed news app's cron lands dead on arrival.
   """
+  if _cron_mutation_blocked_in_test_runtime():
+    raise HTTPException(
+      500,
+      "Cron mutation is disabled in the test runtime.",
+    )
   scaffold = CRON_SCAFFOLD
   if not scaffold.exists():
     # In tests we mock this away; in containers it's always present.
@@ -1230,6 +1251,8 @@ def _unregister_cron(source_dir: Path) -> None:
   source-tree rmtree this accompanies. Runs `crontab -u mobius` (the
   server runs as mobius, which may edit its own crontab).
   """
+  if _cron_mutation_blocked_in_test_runtime():
+    return
   try:
     listing = subprocess.run(
       ["crontab", "-u", "mobius", "-l"],

--- a/backend/scripts/init-cron-scaffold.sh
+++ b/backend/scripts/init-cron-scaffold.sh
@@ -36,6 +36,17 @@
 
 set -euo pipefail
 
+# Pytest may be launched from inside the production container, where this
+# script and the real crontab binary are available. The Python test database is
+# isolated, but cron is process-external host state; refuse before writing
+# either the durable declaration or the live crontab. The scaffold's own
+# hermetic unit tests opt in while supplying a fake crontab and temp app base.
+if [ "${MOBIUS_TEST_RUNTIME:-}" = "1" ] \
+    && [ "${MOBIUS_ALLOW_TEST_CRON:-}" != "1" ]; then
+  echo "ERROR: cron mutation is disabled in the test runtime" >&2
+  exit 78
+fi
+
 if [ $# -lt 2 ]; then
   echo "Usage: $0 <slug> \"<cron-schedule>\" [job-filename] [app-id]" >&2
   echo "Example: $0 news \"0 9 * * *\" fetch.sh 12" >&2

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -6,6 +6,23 @@ import tempfile
 import pytest
 from fastapi.testclient import TestClient
 
+# Never turn a live application process into a test runner. This check must
+# happen before the test overrides below: docker exec inherits production's
+# DATA_DIR/DATABASE_URL, while the disposable test services declare
+# MOBIUS_TEST_RUNTIME=1 before pytest starts.
+_inherited_data_dir = os.environ.get("DATA_DIR", "").rstrip("/")
+_inherited_database_url = os.environ.get("DATABASE_URL", "")
+if (
+  os.environ.get("MOBIUS_TEST_RUNTIME") != "1"
+  and _inherited_data_dir == "/data"
+  and "/data/db/" in _inherited_database_url
+):
+  pytest.exit(
+    "Refusing to run pytest against the live Mobius runtime. "
+    "Use scripts/test.sh or docker-compose.test.yml.",
+    returncode=2,
+  )
+
 # Set env vars before importing app modules.
 _tmp = tempfile.mkdtemp()
 os.environ["SECRET_KEY"] = "test-secret-key-at-least-32-characters-long"
@@ -13,6 +30,12 @@ os.environ["DATABASE_URL"] = f"sqlite:///{_tmp}/test.db"
 os.environ["DATA_DIR"] = _tmp
 os.environ["FRONTEND_ORIGIN"] = "http://localhost:5173"
 os.environ["MOBIUS_TEST_RUNTIME"] = "1"
+# Fail closed when pytest is launched from inside a running production
+# container. DATA_DIR isolates Python file writes, but subprocess-facing
+# defaults historically still pointed at the live service and /data/apps.
+os.environ["MOBIUS_APP_BASE"] = f"{_tmp}/apps"
+os.environ["API_BASE_URL"] = "http://127.0.0.1:9"
+os.environ["MOEBIUS_SKIP_BOOTSTRAP"] = "1"
 
 # Ensure the baked static dir exists with an index.html carrying the
 # __mobius-theme__ slot BEFORE importing app.main — main.py registers the SPA

--- a/backend/tests/test_apps_install.py
+++ b/backend/tests/test_apps_install.py
@@ -10,6 +10,7 @@ and force failure modes.
 import asyncio
 import io
 import json
+import os
 import subprocess
 from pathlib import Path
 from unittest.mock import patch, AsyncMock, MagicMock
@@ -521,6 +522,7 @@ def test_register_cron_passes_job_name_to_scaffold(tmp_path):
   # The inner CRON_SCAFFOLD patch overrides the autouse bypass so we reach
   # the subprocess call; subprocess.run is mocked so nothing shells out.
   with patch("app.install.CRON_SCAFFOLD", fake_scaffold), \
+       patch.dict(os.environ, {"MOBIUS_ALLOW_TEST_CRON": "1"}), \
        patch("app.install.subprocess.run") as mock_run:
     mock_run.return_value = MagicMock(returncode=0, stderr="")
     install._register_cron("reflection", "0 6 * * *", job_path, 42)
@@ -545,6 +547,7 @@ def test_register_cron_omits_app_id_when_none(tmp_path):
   fake_scaffold.write_text("#!/bin/bash\n")
 
   with patch("app.install.CRON_SCAFFOLD", fake_scaffold), \
+       patch.dict(os.environ, {"MOBIUS_ALLOW_TEST_CRON": "1"}), \
        patch("app.install.subprocess.run") as mock_run:
     mock_run.return_value = MagicMock(returncode=0, stderr="")
     install._register_cron("selfcontained", "0 6 * * *", job_path)
@@ -552,6 +555,41 @@ def test_register_cron_omits_app_id_when_none(tmp_path):
   assert mock_run.call_args.args[0] == [
     str(fake_scaffold), "selfcontained", "0 6 * * *", "job.sh",
   ]
+
+
+def test_register_cron_refuses_real_subprocess_in_test_runtime(
+  tmp_path, monkeypatch,
+):
+  """The Python boundary blocks the exact production-container pytest leak."""
+  from app import install
+
+  fake_scaffold = tmp_path / "init-cron-scaffold.sh"
+  fake_scaffold.write_text("#!/bin/sh\n")
+  monkeypatch.setattr(install, "CRON_SCAFFOLD", fake_scaffold)
+  monkeypatch.delenv("MOBIUS_ALLOW_TEST_CRON", raising=False)
+
+  with patch("app.install.subprocess.run") as mock_run, \
+       pytest.raises(install.HTTPException) as exc:
+    install._register_cron(
+      "memory", "30 5 * * *", tmp_path / "fetch.sh", 3,
+    )
+
+  assert exc.value.status_code == 500
+  assert "disabled in the test runtime" in exc.value.detail
+  mock_run.assert_not_called()
+
+
+def test_unregister_cron_refuses_real_subprocess_in_test_runtime(
+  tmp_path, monkeypatch,
+):
+  """Uninstall cleanup cannot rewrite a production crontab during pytest."""
+  from app import install
+
+  monkeypatch.delenv("MOBIUS_ALLOW_TEST_CRON", raising=False)
+  with patch("app.install.subprocess.run") as mock_run:
+    install._unregister_cron(tmp_path / "apps" / "memory")
+
+  mock_run.assert_not_called()
 
 
 def test_crontab_without_app_is_prefix_safe_and_preserves_header():

--- a/backend/tests/test_cron_scaffold_script.py
+++ b/backend/tests/test_cron_scaffold_script.py
@@ -43,6 +43,7 @@ def test_init_cron_scaffold_does_not_splice_existing_crontab_into_comments(
     "PATH": f"{fake_bin}:{os.environ['PATH']}",
     "CRONTAB_STATE": str(state),
     "MOBIUS_APP_BASE": str(app_base),
+    "MOBIUS_ALLOW_TEST_CRON": "1",
     "DATA_DIR": str(tmp_path / "data"),
   }
   script = Path(__file__).parents[1] / "scripts" / "init-cron-scaffold.sh"
@@ -62,3 +63,42 @@ def test_init_cron_scaffold_does_not_splice_existing_crontab_into_comments(
   live_crontab = state.read_text()
   assert existing.strip() in live_crontab
   assert "0 6 * * *" in live_crontab
+
+
+def test_init_cron_scaffold_refuses_test_runtime_before_any_write(tmp_path):
+  """A production-container pytest must not reach durable or live cron state."""
+  app_base = tmp_path / "apps"
+  app_dir = app_base / "memory"
+  app_dir.mkdir(parents=True)
+  sentinel = tmp_path / "crontab-was-called"
+  fake_bin = tmp_path / "bin"
+  fake_bin.mkdir()
+  crontab = fake_bin / "crontab"
+  crontab.write_text(
+    "#!/bin/sh\n"
+    f"touch {sentinel}\n"
+  )
+  crontab.chmod(0o755)
+
+  env = {
+    **os.environ,
+    "PATH": f"{fake_bin}:{os.environ['PATH']}",
+    "MOBIUS_TEST_RUNTIME": "1",
+    "MOBIUS_APP_BASE": str(app_base),
+  }
+  env.pop("MOBIUS_ALLOW_TEST_CRON", None)
+  script = Path(__file__).parents[1] / "scripts" / "init-cron-scaffold.sh"
+
+  result = subprocess.run(
+    [str(script), "memory", "30 5 * * *", "fetch.sh", "57"],
+    text=True,
+    capture_output=True,
+    env=env,
+    check=False,
+  )
+
+  assert result.returncode == 78
+  assert "disabled in the test runtime" in result.stderr
+  assert not sentinel.exists()
+  assert not (app_dir / "fetch.sh").exists()
+  assert not (app_dir / "init-cron.sh").exists()

--- a/backend/tests/test_routes_init_resilience.py
+++ b/backend/tests/test_routes_init_resilience.py
@@ -160,6 +160,58 @@ def test_main_boots_when_app_watcher_start_raises(monkeypatch):
     assert body["boot_id"]
 
 
+def test_lifespan_cannot_mutate_cron_for_a_low_id_test_app(
+  monkeypatch, db, tmp_path,
+):
+  """Reproduce the production-container leak and prove it fails closed.
+
+  Entering the real lifespan with a scheduled row used to invoke the baked
+  scaffold. Since the isolated test DB assigns low IDs, that could replace a
+  production Memory/Reflection crontab entry when pytest ran in the live
+  container.
+  """
+  from pathlib import Path
+
+  from app import install, models
+  from app.config import get_settings
+  from app.routes import apps as apps_module
+  from app.main import app as main_app
+
+  source_dir = Path(get_settings().data_dir) / "apps" / "memory"
+  source_dir.mkdir(parents=True)
+  (source_dir / "fetch.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+  (source_dir / "mobius.json").write_text(
+    '{"schedule":{"default":"30 5 * * *","job":"fetch.sh"}}',
+    encoding="utf-8",
+  )
+  app_row = models.App(
+    name="Memory",
+    slug="memory",
+    description="scheduled test app",
+    jsx_source="export default function App() { return <div/> }",
+    source_dir=str(source_dir),
+  )
+  db.add(app_row)
+  db.commit()
+  assert app_row.id < 10  # Preserve the low-id shape that caused the incident.
+
+  sentinel = tmp_path / "scaffold-was-called"
+  fake_scaffold = tmp_path / "init-cron-scaffold.sh"
+  fake_scaffold.write_text(
+    f"#!/bin/sh\ntouch {sentinel}\n",
+    encoding="utf-8",
+  )
+  fake_scaffold.chmod(0o755)
+  monkeypatch.setattr(install, "CRON_SCAFFOLD", fake_scaffold)
+  monkeypatch.setattr(apps_module, "_read_live_crontab", lambda: "")
+  monkeypatch.delenv("MOBIUS_ALLOW_TEST_CRON", raising=False)
+
+  with TestClient(main_app) as client:
+    assert client.get("/api/health").status_code == 200
+
+  assert not sentinel.exists()
+
+
 def test_lifespan_waits_for_initial_restart_resume_sweep(monkeypatch):
   """The server must not accept a manual send before restart recovery claims."""
   from app import chat as chat_mod

--- a/scripts/wt-pytest.sh
+++ b/scripts/wt-pytest.sh
@@ -79,6 +79,9 @@ cd "$ROOT/backend" || exit 1
 # of the enclosing repo, and the app-git tests use explicit -C <tmp_path>.
 exec env \
   GIT_CEILING_DIRECTORIES="$ROOT" \
+  MOBIUS_TEST_RUNTIME=1 \
+  MOEBIUS_SKIP_BOOTSTRAP=1 \
+  API_BASE_URL=http://127.0.0.1:9 \
   PATH="$ESB_DIR:${PATH:-}" \
   NODE_PATH="$NODE_MODULES${NODE_PATH:+:$NODE_PATH}" \
   SECRET_KEY="${SECRET_KEY:-$(python3 -c 'import secrets;print(secrets.token_hex(32))')}" \


### PR DESCRIPTION
## Summary
- refuse pytest startup when it inherits the live `/data` production database
- block cron registration/removal in test runtimes at both Python and shell boundaries
- isolate test subprocess defaults from live app storage, API, and bootstrap
- reproduce the low-ID lifespan leak that changed Memory/Reflection cron entries

## Validation
- 158 affected install/lifespan/scaffold tests passed
- 128 adjacent app lifecycle/bootstrap/job tests passed, 1 skipped
- full isolated suite: 3,019 passed, 2 skipped; 8 dependency-contract tests failed because the available `mobius-test:ci` image is unverified/stale (missing the pinned Codex SDK and current Node packages). The normal `scripts/test.sh` preflight rejects this image.
- explicit live-runtime guard check aborts pytest before app imports
