### PR TITLE
Integrate latest production recovery and memory improvements

### DIFF
--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -75,6 +75,7 @@ from app.runtime_types import RunnerResult
 from app.usage_metrics import normalize_codex_usage
 from app.runner_registry import RunnerKind, registry
 from app.tool_sources import normalize_tool_sources
+from app.memory_observability import record_memory_checkpoint_once
 
 log = logging.getLogger("moebius.chat")
 
@@ -1807,7 +1808,13 @@ async def run_codex_sdk_turn(
   Returns:
     Dict with `session_id`, `cost_usd`, and `error`.
   """
+  record_memory_checkpoint_once(
+    "codex_first_runner_enter",
+    chat_id=chat_id,
+    resuming=session_id is not None,
+  )
   sdk = _sdk_imports()
+  record_memory_checkpoint_once("codex_first_sdk_loaded", chat_id=chat_id)
   # chat.py always pre-merges the per-chat overrides on top of the
   # global file defaults; treat a missing dict as empty rather than
   # re-reading the file here. Standalone callers (tests) pass `{}`.
@@ -1920,6 +1927,10 @@ async def run_codex_sdk_turn(
   try:
     codex, entry_cancel = await _enter_codex_context_owned(codex_context)
     async with _EnteredCodexContext(codex_context, codex) as codex:
+      record_memory_checkpoint_once(
+        "codex_first_client_connected",
+        chat_id=chat_id,
+      )
       process_group_id = _codex_process_group_id(codex)
       if process_group_capture_stop is not None:
         process_group_capture_stop.set()
@@ -2008,6 +2019,11 @@ async def run_codex_sdk_turn(
           cwd=cwd,
           model=model,
         )
+      record_memory_checkpoint_once(
+        "codex_first_thread_ready",
+        chat_id=chat_id,
+        resumed=session_id is not None,
+      )
 
       current_session_id = thread.id
       if abort_requested():
@@ -2061,6 +2077,10 @@ async def run_codex_sdk_turn(
         process_group_id=process_group_id,
       )
       registry.register(active_turn)
+      record_memory_checkpoint_once(
+        "codex_first_turn_ready",
+        chat_id=chat_id,
+      )
 
       # Persist the session id AFTER registering the live turn: this is a
       # best-effort write (the actor persist + the append-only session-link

--- a/backend/app/memory_observability.py
+++ b/backend/app/memory_observability.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import gc
 import logging
 import os
+import re
 import time
 from collections import Counter, defaultdict, deque
 from datetime import UTC, datetime
@@ -288,23 +289,41 @@ def estimate_payload_bytes(value: Any, _seen: set[int] | None = None) -> int:
   return sum(estimate_payload_bytes(item, seen) for item in value)
 
 
-def _process_category(pid: int, comm: str, cmdline: str) -> str:
+def _process_identity(
+  pid: int,
+  comm: str,
+  cmdline: str,
+) -> tuple[str, str | None]:
+  """Return a stable category and a safe, useful owner label.
+
+  Executable names alone are not ownership: installed services commonly run
+  behind generic hosts such as gunicorn, and browser workers are only useful
+  when tied back to their profile. Keep the label deliberately derived from
+  known local paths rather than exposing arbitrary command lines, which can
+  contain credentials.
+  """
   if pid == os.getpid():
-    return "mobius_server"
+    return "mobius_server", "platform"
   value = f"{comm} {cmdline}".lower()
   if any(token in value for token in ("chromium", "chrome", "headless_shell")):
-    return "browser"
+    match = re.search(r"agent-browser-profiles/([^/\\s]+)", cmdline)
+    return "browser", match.group(1) if match else None
   if "codex" in value:
-    return "codex"
+    return "codex", None
   if "claude" in value:
-    return "claude"
+    return "claude", None
   if any(token in value for token in ("node", "npm", "esbuild", "vite")):
-    return "frontend_tools"
+    return "frontend_tools", None
   if "caddy" in value:
-    return "proxy"
+    return "proxy", "platform"
   if "tandoor" in value:
-    return "recovery"
-  return "other"
+    return "app_service", "tandoor"
+  match = re.search(r"/data/apps/([^/\\s]+)", cmdline)
+  if match:
+    return "app_service", match.group(1)
+  if "recover" in value:
+    return "recovery", "platform"
+  return "other", None
 
 
 def process_inventory(
@@ -335,11 +354,12 @@ def process_inventory(
     cmdline = (
       _read_text(proc_root / str(pid) / "cmdline") or ""
     ).replace("\x00", " ")
-    category = _process_category(pid, comm, cmdline)
+    category, owner = _process_identity(pid, comm, cmdline)
     row = {
       "pid": pid,
       "name": comm[:80],
       "category": category,
+      "owner": owner,
       "rss_bytes": snapshot.get("rss_bytes") or 0,
       "pss_bytes": snapshot.get("pss_bytes") or 0,
       "anonymous_bytes": snapshot.get("anonymous_bytes") or 0,

--- a/backend/app/memory_observability.py
+++ b/backend/app/memory_observability.py
@@ -31,6 +31,7 @@ log = logging.getLogger("moebius.memory")
 _CHECKPOINT_LIMIT = 128
 _checkpoints: deque[dict[str, Any]] = deque(maxlen=_CHECKPOINT_LIMIT)
 _checkpoint_lock = Lock()
+_checkpoint_once_labels: set[str] = set()
 _trace_status: dict[str, Any] = {
   "enabled": False,
   "frames": 0,
@@ -525,6 +526,25 @@ def record_memory_checkpoint(label: str, **context: Any) -> dict[str, Any]:
     cgroup.get("current_bytes"),
   )
   return entry
+
+
+def record_memory_checkpoint_once(
+  label: str,
+  **context: Any,
+) -> dict[str, Any] | None:
+  """Capture one process-lifetime boundary without recurring request cost.
+
+  These probes bracket first-use initialization: initial shell hydration,
+  initial chat materialization, and the first provider client. A lock-protected
+  reservation makes concurrent first requests collapse to one sample. Later
+  requests do only the small set lookup and never read procfs.
+  """
+  normalized = str(label)[:80]
+  with _checkpoint_lock:
+    if normalized in _checkpoint_once_labels:
+      return None
+    _checkpoint_once_labels.add(normalized)
+  return record_memory_checkpoint(normalized, **context)
 
 
 def memory_status(*, include_checkpoints: bool = False) -> dict[str, Any]:

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -27,6 +27,7 @@ from app.chat import (
 )
 from app.broadcast import get_system_broadcast
 from app.database import get_db
+from app.memory_observability import record_memory_checkpoint_once
 from app.deps import (
   Principal, get_owner_or_chat_embed_principal, get_current_owner, get_principal,
   reject_cross_site,
@@ -388,6 +389,7 @@ def list_chats(
   db: Session = Depends(get_db),
 ):
   """Returns all active chats ordered by most recently updated."""
+  record_memory_checkpoint_once("shell_chat_list_first_request")
   # Purge chats soft-deleted more than TTL ago.
   # Use naive datetime to match SQLite's naive UTC storage — comparing an
   # aware datetime against a naive DB value throws TypeError in Python 3.11+.
@@ -540,6 +542,10 @@ def list_chats(
     # embedded app panels and stay hidden; an app can opt a spawned, first-class
     # owner conversation into the drawer by setting owner_visible at creation.
     chats = [c for c in chats if _visible_in_owner_drawer(c)]
+  record_memory_checkpoint_once(
+    "shell_chat_list_first_response",
+    chat_count=len(chats),
+  )
   return [_owner_chat_summary_projection(c) for c in chats]
 
 
@@ -1099,8 +1105,14 @@ def get_chat(
   if principal.scope == "app":
     raise HTTPException(status_code=403, detail="App token is not valid here.")
   require_chat_embed_operation(principal, "chat:read")
+  record_memory_checkpoint_once(
+    "chat_detail_first_request",
+    chat_id=chat_id,
+    limit=limit,
+    compact=compact,
+  )
   chat = get_active_chat_for_principal(db, chat_id, principal)
-  return _chat_detail_response(
+  response = _chat_detail_response(
     chat,
     db=db,
     limit=limit,
@@ -1110,6 +1122,13 @@ def get_chat(
     # embedded participant surface.
     expose_session=principal.scope != "chat_embed",
   )
+  record_memory_checkpoint_once(
+    "chat_detail_first_response",
+    chat_id=chat_id,
+    total_messages=response.get("total"),
+    returned_messages=len(response.get("messages") or []),
+  )
+  return response
 
 
 @router.get("/{chat_id}/runtime")

--- a/backend/app/routes/chats_stream.py
+++ b/backend/app/routes/chats_stream.py
@@ -40,6 +40,7 @@ from app.providers import _load_agent_settings, resolve_default_provider
 from app.runner_registry import RunnerKind, registry
 from app.config import get_settings
 from app.database import get_db
+from app.memory_observability import record_memory_checkpoint_once
 from app.deps import (
   Principal, get_chat_view_principal, get_owner_or_chat_embed_principal,
   get_current_owner, reject_cross_site,
@@ -743,6 +744,11 @@ async def _send_message_locked(
   duplicate = _duplicate_send_response(chat_id, chat, body.cid)
   if duplicate is not None:
     return duplicate
+  record_memory_checkpoint_once(
+    "chat_send_first_request",
+    chat_id=chat_id,
+    provider=chat.provider or "claude",
+  )
 
   # One choke point for every genuine user send (initial / queued / steered all
   # pass here, after the answer-delivery returns above). Skip force_steer —
@@ -1082,6 +1088,12 @@ async def _send_message_locked(
     msgs = result["history"]
     session_id = result["session_id"]
     provider = result["provider"]
+    record_memory_checkpoint_once(
+      "chat_history_first_prepared",
+      chat_id=chat_id,
+      provider=provider,
+      history_messages=len(msgs),
+    )
 
     if current_run_generation(chat_id) == start_gen:
       # No Stop raced during the StartTurn commit. Create the broadcast

--- a/backend/tests/test_memory_observability.py
+++ b/backend/tests/test_memory_observability.py
@@ -4,12 +4,34 @@ from pathlib import Path
 
 import app.memory_observability as memory_observability
 from app.memory_observability import (
+  _process_identity,
   allocation_report,
   cgroup_memory_snapshot,
   estimate_payload_bytes,
   memory_map_summary,
   process_memory_snapshot,
 )
+
+
+def test_process_identity_uses_command_ownership_not_generic_host_name():
+  assert _process_identity(
+    123,
+    "gunicorn",
+    "/data/tandoor/venv/bin/gunicorn recipes.wsgi",
+  ) == ("app_service", "tandoor")
+  assert _process_identity(
+    124,
+    "chrome",
+    "--user-data-dir=/data/agent-browser-profiles/chat-example",
+  ) == ("browser", "chat-example")
+
+
+def test_process_identity_does_not_expose_arbitrary_command_arguments():
+  assert _process_identity(
+    125,
+    "worker",
+    "worker --api-key secret-value",
+  ) == ("other", None)
 
 
 def test_process_memory_snapshot_reads_current_linux_process():

--- a/backend/tests/test_memory_observability.py
+++ b/backend/tests/test_memory_observability.py
@@ -10,6 +10,7 @@ from app.memory_observability import (
   estimate_payload_bytes,
   memory_map_summary,
   process_memory_snapshot,
+  record_memory_checkpoint_once,
 )
 
 
@@ -156,3 +157,32 @@ def test_zero_allocation_limit_does_not_materialize_heap_snapshot(monkeypatch):
   monkeypatch.setattr(memory_observability, "tracing_status", lambda: status)
 
   assert allocation_report(limit=0) == status
+
+
+def test_checkpoint_once_collapses_repeated_boundary(monkeypatch):
+  process_calls = 0
+
+  def process_snapshot():
+    nonlocal process_calls
+    process_calls += 1
+    return {"available": True, "rss_bytes": 1}
+
+  monkeypatch.setattr(
+    memory_observability,
+    "process_memory_snapshot",
+    process_snapshot,
+  )
+  monkeypatch.setattr(
+    memory_observability,
+    "cgroup_memory_snapshot",
+    lambda: {"available": True, "current_bytes": 2},
+  )
+  label = "test_checkpoint_once_collapses_repeated_boundary"
+
+  first = record_memory_checkpoint_once(label, stage="first")
+  second = record_memory_checkpoint_once(label, stage="second")
+
+  assert first is not None
+  assert first["context"] == {"stage": "first"}
+  assert second is None
+  assert process_calls == 1

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -19,6 +19,7 @@ import useScrollMode, {
 import useVoiceInput from './useVoiceInput.js'
 import useFileUpload from './useFileUpload.js'
 import useOnlineStatus from '../../hooks/useOnlineStatus.js'
+import { getOnlineSnapshot } from '../../lib/connectivityStore.js'
 import useSystemEventStream from '../../hooks/useSystemEventStream.js'
 import usePendingQueue from './hooks/usePendingQueue.js'
 import useBridgePartial from './hooks/useBridgePartial.js'
@@ -2329,7 +2330,7 @@ export default function ChatView({
           attachments: composerFileSnapshot,
         })
         restoreComposerAfterFailedSend()
-        setSendFailure(sendFailureMessage(err, { online }))
+        setSendFailure(sendFailureMessage(err, { online: getOnlineSnapshot() }))
       }
       return
     }
@@ -2499,17 +2500,17 @@ export default function ChatView({
         attachments: composerFileSnapshot,
       })
       restoreComposerAfterFailedSend()
-      // The POST never reached/finished on the server, so remove the optimistic
-      // user bubble and keep the text in the composer. Otherwise a transient
-      // "Failed to fetch" looks like the message was accepted locally but
-      // silently disappears from the durable chat after refresh.
+      // Ambiguity recovery already verified reachability and safely replayed
+      // this exact cid once. If even that acknowledgement was lost, keep the
+      // same cid with the restored draft so a manual retry can only reconcile
+      // the existing server row, never create a duplicate turn.
       commitMessages(prev => {
         const next = [...prev]
         const idx = findUserIndexByCid(next, cid)
         if (idx >= 0) next.splice(idx, 1)
         return next
       })
-      setSendFailure(sendFailureMessage(err, { online }))
+      setSendFailure(sendFailureMessage(err, { online: getOnlineSnapshot() }))
       onStreamEndRef.current?.({ continues: false })
     }
     // doSend doesn't need `sending` / `isStreaming` in deps anymore —

--- a/frontend/src/components/ChatView/__tests__/sendFailure.test.js
+++ b/frontend/src/components/ChatView/__tests__/sendFailure.test.js
@@ -11,7 +11,7 @@ import {
 test('send failures distinguish connection, timeout, service, and generic errors', () => {
   assert.match(
     sendFailureMessage(new ChatTransportError(new TypeError('Failed to fetch'))),
-    /check your connection/,
+    /couldn’t confirm the send/,
   )
 
   const timeout = new Error('aborted')
@@ -37,7 +37,7 @@ test('an unrelated programming TypeError is not mislabeled as offline', () => {
 test('known offline state wins over the transport error shape', () => {
   assert.match(
     sendFailureMessage(new Error('anything'), { online: false }),
-    /check your connection/,
+    /You’re offline/,
   )
 })
 

--- a/frontend/src/components/ChatView/__tests__/sendTransportRecovery.test.js
+++ b/frontend/src/components/ChatView/__tests__/sendTransportRecovery.test.js
@@ -1,0 +1,89 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { sendWithAmbiguityRecovery } from '../sendTransportRecovery.js'
+
+const ambiguous = error => error?.name === 'ChatTransportError'
+
+test('a lost acknowledgement retries the exact send once and confirms reachability', async () => {
+  const calls = []
+  let reachableReports = 0
+  const response = await sendWithAmbiguityRecovery({
+    send: async () => {
+      calls.push('send')
+      if (calls.length === 1) {
+        const error = new Error('lost response')
+        error.name = 'ChatTransportError'
+        throw error
+      }
+      return { ok: true, status: 200 }
+    },
+    verifyReachability: async () => {
+      calls.push('verify')
+      return true
+    },
+    reportReachable: () => { reachableReports += 1 },
+    isAmbiguousError: ambiguous,
+  })
+
+  assert.equal(response.status, 200)
+  assert.deepEqual(calls, ['send', 'verify', 'send'])
+  assert.equal(reachableReports, 1)
+})
+
+test('a confirmed outage leaves the draft recovery path in control', async () => {
+  let sends = 0
+  const error = new Error('offline')
+  error.name = 'ChatTransportError'
+
+  await assert.rejects(
+    sendWithAmbiguityRecovery({
+      send: async () => {
+        sends += 1
+        throw error
+      },
+      verifyReachability: async () => false,
+      reportReachable: () => assert.fail('offline must not report reachable'),
+      isAmbiguousError: ambiguous,
+    }),
+    error,
+  )
+  assert.equal(sends, 1)
+})
+
+test('HTTP failures are definitive and are never replayed', async () => {
+  let sends = 0
+  const error = Object.assign(new Error('HTTP 503'), { name: 'ChatHttpError' })
+
+  await assert.rejects(
+    sendWithAmbiguityRecovery({
+      send: async () => {
+        sends += 1
+        throw error
+      },
+      verifyReachability: async () => assert.fail('HTTP response proves reachability'),
+      isAmbiguousError: ambiguous,
+    }),
+    error,
+  )
+  assert.equal(sends, 1)
+})
+
+test('a second ambiguous failure stops after one safe replay', async () => {
+  let sends = 0
+  const error = new Error('still ambiguous')
+  error.name = 'ChatTransportError'
+
+  await assert.rejects(
+    sendWithAmbiguityRecovery({
+      send: async () => {
+        sends += 1
+        throw error
+      },
+      verifyReachability: async () => true,
+      isAmbiguousError: ambiguous,
+    }),
+    error,
+  )
+  assert.equal(sends, 2)
+})

--- a/frontend/src/components/ChatView/sendFailure.js
+++ b/frontend/src/components/ChatView/sendFailure.js
@@ -1,9 +1,12 @@
 export function sendFailureMessage(error, { online = true } = {}) {
-  if (!online || error?.name === 'ChatTransportError') {
-    return 'Möbius couldn’t reach the server. Your message is back in the composer—check your connection and try again.'
+  if (!online) {
+    return 'You’re offline. Your message is back in the composer—send it when you reconnect.'
+  }
+  if (error?.name === 'ChatTransportError') {
+    return 'Möbius couldn’t confirm the send. Your message is back in the composer—retrying won’t send it twice.'
   }
   if (error?.name === 'AbortError') {
-    return 'Möbius took too long to respond. Your message is back in the composer—try again.'
+    return 'Möbius took too long to confirm the send. Your message is back in the composer—retrying won’t send it twice.'
   }
   const status = Number(error?.status)
   if (status === 503 || status >= 500) {

--- a/frontend/src/components/ChatView/sendTransportRecovery.js
+++ b/frontend/src/components/ChatView/sendTransportRecovery.js
@@ -1,0 +1,33 @@
+/**
+ * A chat send is ambiguous when the browser loses the response: the server
+ * may have committed the cid even though fetch rejected or timed out. Verify
+ * reachability and replay the exact same request once. The backend's cid gate
+ * turns that replay into either the original acknowledgement or a duplicate
+ * acknowledgement, never a second user turn.
+ */
+export async function sendWithAmbiguityRecovery({
+  send,
+  verifyReachability,
+  reportReachable,
+  isAmbiguousError,
+}) {
+  let attempt = 0
+  while (attempt < 2) {
+    attempt += 1
+    try {
+      const response = await send()
+      reportReachable?.()
+      return response
+    } catch (error) {
+      if (attempt >= 2 || !isAmbiguousError(error)) throw error
+      let reachable = false
+      try {
+        reachable = await verifyReachability()
+      } catch {
+        reachable = false
+      }
+      if (!reachable) throw error
+    }
+  }
+  throw new Error('unreachable')
+}

--- a/frontend/src/components/ChatView/useStreamConnection.js
+++ b/frontend/src/components/ChatView/useStreamConnection.js
@@ -29,6 +29,11 @@ import {
 import { BEFORE_SHELL_RELOAD_EVENT } from '../../lib/shellReloadEvents.js'
 import { ChatTransportError, chatHttpError } from './sendErrors.js'
 import {
+  reportNetworkReachable,
+  verifyConnectivity,
+} from '../../lib/connectivityStore.js'
+import { sendWithAmbiguityRecovery } from './sendTransportRecovery.js'
+import {
   TEXT_REVEAL_MIN_COMMIT_MS,
   textRevealBudget,
 } from './streamCadence.js'
@@ -1328,27 +1333,39 @@ export default function useStreamConnection(chatId, {
       // never settles, leaving the composer optimistically locked in Stop mode
       // forever (its catch below resets streaming state on the abort). No
       // in-flight guard needed here: doSend already gates re-entry.
-      const sendCtrl = new AbortController()
-      const sendTimer = setTimeout(() => sendCtrl.abort(), SEND_POST_TIMEOUT_MS)
       let res
-      const requestInit = {
-        method: 'POST',
-        headers: getAuthHeaders({ 'Content-Type': 'application/json' }),
-        body: JSON.stringify(body),
-        signal: sendCtrl.signal,
-      }
-      try {
+      const sendOnce = async () => {
+        // Each ambiguity retry needs a fresh controller. Reusing the aborted
+        // first attempt's signal would make the idempotent replay fail before
+        // it reached the server.
+        const sendCtrl = new AbortController()
+        const sendTimer = setTimeout(() => sendCtrl.abort(), SEND_POST_TIMEOUT_MS)
         try {
-          res = await fetch(
-            `${BASE}/api/chats/${chatIdRef.current}/messages`, requestInit,
+          return await fetch(
+            `${BASE}/api/chats/${chatIdRef.current}/messages`,
+            {
+              method: 'POST',
+              headers: getAuthHeaders({ 'Content-Type': 'application/json' }),
+              body: JSON.stringify(body),
+              signal: sendCtrl.signal,
+            },
           )
         } catch (error) {
           if (error?.name === 'AbortError') throw error
           throw new ChatTransportError(error)
+        } finally {
+          clearTimeout(sendTimer)
         }
-      } finally {
-        clearTimeout(sendTimer)
       }
+      res = await sendWithAmbiguityRecovery({
+        send: sendOnce,
+        verifyReachability: verifyConnectivity,
+        reportReachable: reportNetworkReachable,
+        isAmbiguousError: error => (
+          error?.name === 'ChatTransportError'
+          || error?.name === 'AbortError'
+        ),
+      })
       if (!res.ok) {
         throw await chatHttpError(res)
       }

--- a/frontend/src/components/SettingsView/SettingsView.jsx
+++ b/frontend/src/components/SettingsView/SettingsView.jsx
@@ -16,7 +16,10 @@ import {
   PROVIDER_AVAILABILITY_PHASE,
   resolveProviderAvailability,
 } from '../../lib/providerAvailability.js'
-import { restartCanReload } from '../../lib/restartReadiness.js'
+import {
+  restartCanReload,
+  restartPollDecision,
+} from '../../lib/restartReadiness.js'
 import { updateCheckOutcome, updateCheckLabel } from '../../lib/updateCheckPhase.js'
 import * as themeService from '../../lib/themeService.js'
 import { CLAUDE_MODELS, CODEX_MODELS } from '../ProviderModelPicker/ProviderModelPicker.jsx'
@@ -47,8 +50,6 @@ function orderSelectedFirst(models, selectedId) {
 
 const UPDATE_CHECKED_RESET_MS = 2200
 const RETURN_VIEW_KEY = 'mobius:return-view'
-const RESTART_POLL_INTERVAL_MS = 1500
-const RESTART_POLL_MAX = 40
 const RESTART_SHELL_READY_PATH = '/shell/'
 const PLATFORM_APPLY_STATES = new Set([
   'restart_needed', 'up_to_date', 'conflict', 'rolled_back',
@@ -334,6 +335,7 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
   const [themeError, setThemeError] = useState('')
   const [restartPhase, setRestartPhase] = useState('idle')
   const [restartError, setRestartError] = useState('')
+  const [restartSlow, setRestartSlow] = useState(false)
   // A manual restart interrupts any live chat, so it's a deliberate two-step:
   // the first tap arms the confirm, the second actually restarts.
   const [restartConfirm, setRestartConfirm] = useState(false)
@@ -345,6 +347,7 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
   const [platformPhase, setPlatformPhase] = useState('idle')
   const [platformProgress, setPlatformProgress] = useState(null)
   const [platformError, setPlatformError] = useState('')
+  const [platformRestartSlow, setPlatformRestartSlow] = useState(false)
   // Whether the update-review sheet is open. The "Update" button routes through
   // it so the owner reviews the incoming changes before applying, rather than
   // Apply firing on the first click.
@@ -856,6 +859,7 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
     if (restartPhase === 'restarting') return
     setRestartPhase('restarting')
     setRestartError('')
+    setRestartSlow(false)
     try {
       const previousBootId = await readRestartBootId()
       const res = await api.admin.restart()
@@ -867,8 +871,12 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
       returnToSettingsAfterReload()
       pollRestartThenReload({
         previousBootId,
-        onTimeout: () => {
-          setRestartError("Server hasn't come back yet — check the container.")
+        onSlow: () => setRestartSlow(true),
+        onTimeout: ({ freshServerSeen }) => {
+          setRestartSlow(false)
+          setRestartError(freshServerSeen
+            ? 'The server restarted, but Möbius couldn’t reload the shell. Refresh the page or open Recovery.'
+            : 'Möbius still can’t confirm the restart. Open Recovery if the container needs attention.')
           setRestartPhase('idle')
           setRestartConfirm(false)
         },
@@ -876,6 +884,7 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
     } catch (err) {
       setRestartPhase('idle')
       setRestartConfirm(false)
+      setRestartSlow(false)
       setRestartError(err.message || 'Restart request failed.')
     }
   }
@@ -1155,11 +1164,17 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
   // BackgroundTask sends SIGTERM, so prefer a changed boot id. When updating
   // from an older server that does not expose boot ids, require either a
   // down/up cycle or a conservative wait before trying to reload.
-  function pollRestartThenReload({ previousBootId = '', onTimeout }) {
+  function pollRestartThenReload({
+    previousBootId = '',
+    onSlow = () => {},
+    onTimeout,
+  }) {
     clearRestartPoll()
     const startedAt = Date.now()
     let attempts = 0
     let sawUnavailable = false
+    let freshServerSeen = false
+    let slowNotified = false
 
     const poll = async () => {
       restartPollRef.current = null
@@ -1174,20 +1189,29 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
           sawUnavailable,
           elapsedMs: Date.now() - startedAt,
         })) {
+          freshServerSeen = true
           const reloaded = await reloadOntoFreshSW()
           if (reloaded) return
         }
       } catch {
         sawUnavailable = true
       }
-      if (attempts >= RESTART_POLL_MAX) {
-        onTimeout()
+      const decision = restartPollDecision(attempts)
+      if (decision.slow && !slowNotified) {
+        slowNotified = true
+        onSlow({ freshServerSeen })
+      }
+      if (decision.timedOut) {
+        onTimeout({ freshServerSeen })
         return
       }
-      restartPollRef.current = window.setTimeout(poll, RESTART_POLL_INTERVAL_MS)
+      restartPollRef.current = window.setTimeout(poll, decision.delayMs)
     }
 
-    restartPollRef.current = window.setTimeout(poll, RESTART_POLL_INTERVAL_MS)
+    restartPollRef.current = window.setTimeout(
+      poll,
+      restartPollDecision(0).delayMs,
+    )
   }
 
   // The owner's explicit confirmation that finishes a platform update: clicking
@@ -1196,6 +1220,7 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
     if (platformPhase === 'restarting') return
     setPlatformError('')
     setPlatformPhase('restarting')
+    setPlatformRestartSlow(false)
     try {
       const previousBootId = await readRestartBootId()
       // apiFetch resolves for any non-401, so a 5xx is NOT a thrown error —
@@ -1212,12 +1237,17 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
       returnToSettingsAfterReload()
       pollRestartThenReload({
         previousBootId,
-        onTimeout: () => {
-          setPlatformError("Server hasn't come back yet — check the container.")
+        onSlow: () => setPlatformRestartSlow(true),
+        onTimeout: ({ freshServerSeen }) => {
+          setPlatformRestartSlow(false)
+          setPlatformError(freshServerSeen
+            ? 'The server restarted, but Möbius couldn’t reload the shell. Refresh the page or open Recovery.'
+            : 'Möbius still can’t confirm the restart. Open Recovery if the container needs attention.')
           setPlatformPhase('idle')
         },
       })
     } catch {
+      setPlatformRestartSlow(false)
       setPlatformError('Restart signal failed.')
       setPlatformPhase('idle')
     }
@@ -1613,7 +1643,9 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
           </div>
           {platformPhase === 'restarting' && (
             <div className="settings__notice" role="status">
-              Restart signal sent. The page will reload shortly.
+              {platformRestartSlow
+                ? 'This is taking longer than usual. Möbius is still checking.'
+                : 'Restart signal sent. The page will reload shortly.'}
             </div>
           )}
           {platformError && (
@@ -1673,7 +1705,9 @@ export default function SettingsView({ onThemeChange, onOpenChat, focusTarget = 
           )}
           {restartPhase === 'restarting' && (
             <div className="settings__notice" role="status">
-              Restart signal sent. The page will reload shortly.
+              {restartSlow
+                ? 'This is taking longer than usual. Möbius is still checking.'
+                : 'Restart signal sent. The page will reload shortly.'}
             </div>
           )}
           {restartError && (

--- a/frontend/src/lib/__tests__/connectivityStore.test.js
+++ b/frontend/src/lib/__tests__/connectivityStore.test.js
@@ -128,6 +128,21 @@ test('verification without subscribers is bounded and never starts a monitor', a
   assert.equal(h.documentTarget.listenerCount('visibilitychange'), 0)
 })
 
+test('a live mutation response repairs a stale offline verdict immediately', async () => {
+  const h = harness(async () => { throw new TypeError('offline') })
+  let notifications = 0
+  const stop = h.store.subscribe(() => { notifications += 1 })
+  await flushMicrotasks()
+  h.timers.runTimeout(AMBIGUOUS_FAILURE_CONFIRM_MS)
+  await flushMicrotasks()
+  assert.equal(h.store.getSnapshot(), false)
+
+  h.store.reportReachable()
+  assert.equal(h.store.getSnapshot(), true)
+  assert.equal(notifications, 2)
+  stop()
+})
+
 test('the hook and API client consume the shared store contract', () => {
   const hook = readFileSync(new URL('../../hooks/useOnlineStatus.js', import.meta.url), 'utf8')
   const client = readFileSync(new URL('../../api/client.js', import.meta.url), 'utf8')

--- a/frontend/src/lib/__tests__/restartReadiness.test.js
+++ b/frontend/src/lib/__tests__/restartReadiness.test.js
@@ -2,8 +2,13 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 
 import {
+  RESTART_POLL_FAST_ATTEMPTS,
+  RESTART_POLL_FAST_INTERVAL_MS,
+  RESTART_POLL_MAX_ATTEMPTS,
+  RESTART_POLL_SLOW_INTERVAL_MS,
   RESTART_UNTRACKED_MIN_WAIT_MS,
   restartCanReload,
+  restartPollDecision,
 } from '../restartReadiness.js'
 
 test('restartCanReload waits for a changed boot id when both ids are known', () => {
@@ -21,4 +26,22 @@ test('restartCanReload falls back to down cycle or conservative wait without boo
   assert.equal(restartCanReload({ elapsedMs: RESTART_UNTRACKED_MIN_WAIT_MS - 1 }), false)
   assert.equal(restartCanReload({ sawUnavailable: true }), true)
   assert.equal(restartCanReload({ elapsedMs: RESTART_UNTRACKED_MIN_WAIT_MS }), true)
+})
+
+test('restart polling keeps checking gently after the ordinary one-minute window', () => {
+  assert.deepEqual(restartPollDecision(RESTART_POLL_FAST_ATTEMPTS - 1), {
+    slow: false,
+    timedOut: false,
+    delayMs: RESTART_POLL_FAST_INTERVAL_MS,
+  })
+  assert.deepEqual(restartPollDecision(RESTART_POLL_FAST_ATTEMPTS), {
+    slow: true,
+    timedOut: false,
+    delayMs: RESTART_POLL_SLOW_INTERVAL_MS,
+  })
+  assert.deepEqual(restartPollDecision(RESTART_POLL_MAX_ATTEMPTS), {
+    slow: true,
+    timedOut: true,
+    delayMs: RESTART_POLL_SLOW_INTERVAL_MS,
+  })
 })

--- a/frontend/src/lib/connectivityStore.js
+++ b/frontend/src/lib/connectivityStore.js
@@ -86,6 +86,19 @@ export function createConnectivityStore({
     return connectivityState
   }
 
+  // An uncached mutation response is stronger evidence than navigator.onLine
+  // or a cacheable health probe: it could only have come from the live server.
+  // Let owning write paths repair a stale offline verdict immediately instead
+  // of waiting for the next poll or Android's delayed `online` event.
+  function reportReachable() {
+    connectivityState = {
+      successStreak: Math.max(1, connectivityState.successStreak),
+      failureStreak: 0,
+      online: true,
+    }
+    publish(true)
+  }
+
   function startMonitor() {
     if (monitor) return monitor
     if (!windowTarget?.addEventListener || !documentTarget?.addEventListener) return null
@@ -196,7 +209,7 @@ export function createConnectivityStore({
     return verificationCheck
   }
 
-  return { getSnapshot, subscribe, verify }
+  return { getSnapshot, subscribe, verify, reportReachable }
 }
 
 const connectivityStore = createConnectivityStore()
@@ -204,3 +217,4 @@ const connectivityStore = createConnectivityStore()
 export const getOnlineSnapshot = connectivityStore.getSnapshot
 export const subscribeOnline = connectivityStore.subscribe
 export const verifyConnectivity = connectivityStore.verify
+export const reportNetworkReachable = connectivityStore.reportReachable

--- a/frontend/src/lib/restartReadiness.js
+++ b/frontend/src/lib/restartReadiness.js
@@ -1,4 +1,8 @@
 export const RESTART_UNTRACKED_MIN_WAIT_MS = 7000
+export const RESTART_POLL_FAST_ATTEMPTS = 40
+export const RESTART_POLL_MAX_ATTEMPTS = 88
+export const RESTART_POLL_FAST_INTERVAL_MS = 1500
+export const RESTART_POLL_SLOW_INTERVAL_MS = 5000
 
 export function restartCanReload({
   previousBootId = '',
@@ -10,4 +14,20 @@ export function restartCanReload({
     return currentBootId !== previousBootId
   }
   return sawUnavailable || elapsedMs >= RESTART_UNTRACKED_MIN_WAIT_MS
+}
+
+/**
+ * Poll quickly for the ordinary restart window, then keep checking gently for
+ * another four minutes. A delayed container must self-heal instead of leaving
+ * a permanent error at the old one-minute boundary.
+ */
+export function restartPollDecision(attempts = 0) {
+  const count = Math.max(0, Number(attempts) || 0)
+  return {
+    slow: count >= RESTART_POLL_FAST_ATTEMPTS,
+    timedOut: count >= RESTART_POLL_MAX_ATTEMPTS,
+    delayMs: count >= RESTART_POLL_FAST_ATTEMPTS
+      ? RESTART_POLL_SLOW_INTERVAL_MS
+      : RESTART_POLL_FAST_INTERVAL_MS,
+  }
 }


### PR DESCRIPTION
## Summary
- Recover ambiguous chat sends by verifying reachability and replaying the same CID once, so lost acknowledgements neither lose nor duplicate a turn.
- Let successful live mutations repair stale offline status immediately.
- Extend restart readiness polling with a slower self-healing window and clearer recovery guidance.
- Attribute memory inventory rows to safe process owners such as app services and browser profiles without exposing arbitrary command arguments.
- Record bounded, once-per-process memory checkpoints around the first shell chat-list request, first chat detail, first send/history preparation, and Codex client/thread/turn boundaries.

## Review notes
- The send replay is serialized by the existing per-chat transition/queue locks, and the durable CID gate makes both in-flight and completed replays idempotent.
- The memory owner label is derived only from known local paths; arbitrary command-line arguments remain hidden.
- First-use checkpoints reserve labels under a lock and release it before taking a checkpoint, avoiding nested lock contention while keeping measurements bounded.

## Validation
- Frontend: 1,943 tests passed (1,896 library + 47 hooks).
- Production frontend build passed.
- Focused memory observability backend tests: 8 passed.
- Full CI required before merge.