### PR TITLE
Avoid hydrating heavy payloads in recurring metadata reads

### DIFF
--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -1715,7 +1715,11 @@ async def sweep_wedged_run_markers(db: Session) -> list[str]:
   try:
     cutoff = datetime.now(UTC).replace(tzinfo=None) - _WEDGED_RUN_MIN_AGE
     stale = (
-      db.query(models.Chat)
+      # The watchdog needs only identity. A long-running chat can have a
+      # multi-megabyte transcript; hydrating it every minute while merely
+      # checking registry/broadcast state repeats the same allocator problem
+      # the idle-pending projection below avoids.
+      db.query(models.Chat.id)
       .filter(models.Chat.run_status == "running")
       .filter(models.Chat.deleted_at.is_(None))
       .filter(models.Chat.run_started_at.isnot(None))
@@ -1725,16 +1729,17 @@ async def sweep_wedged_run_markers(db: Session) -> list[str]:
   except Exception:
     log.exception("sweep_wedged_run_markers: query failed")
     return swept
-  for chat in stale:
-    if registry.is_alive(chat.id):
+  for row in stale:
+    chat_id = row.id
+    if registry.is_alive(chat_id):
       continue
-    bc = get_broadcast(chat.id)
+    bc = get_broadcast(chat_id)
     if bc is not None and bc.running:
       # Still streaming, in terminal cleanup, or a legitimately-long live turn.
       continue
     run = (
       db.query(models.ChatRun)
-      .filter(models.ChatRun.chat_id == chat.id)
+      .filter(models.ChatRun.chat_id == chat_id)
       .filter(models.ChatRun.status == "running")
       .order_by(models.ChatRun.started_at.desc())
       .first()
@@ -1745,22 +1750,22 @@ async def sweep_wedged_run_markers(db: Session) -> list[str]:
       continue
     try:
       async with asyncio.timeout(chat_queue.TERMINAL_LOCK_TIMEOUT_SECS):
-        async with chat_queue.get_lock(chat.id):
-          if registry.is_alive(chat.id):
+        async with chat_queue.get_lock(chat_id):
+          if registry.is_alive(chat_id):
             continue
           # Identity-keyed on the wedged run's token: a fresh turn that raced in
           # owns a different token, so the actor no-ops instead of wiping it.
           # Strict variant so a failed ack RAISES — a marker we couldn't clear
           # must not be reported as swept (reconciliation repairs it on boot).
           await _clear_run_status_strict(
-            chat.id, run.id, terminal_status="interrupted",
+            chat_id, run.id, terminal_status="interrupted",
           )
-      _finalize_broadcast_if_running(chat.id)
-      swept.append(chat.id)
+      _finalize_broadcast_if_running(chat_id)
+      swept.append(chat_id)
     except (Exception, asyncio.TimeoutError):
       log.warning(
         "sweep_wedged_run_markers: clear failed chat_id=%s "
-        "(reconciliation will repair)", chat.id, exc_info=True,
+        "(reconciliation will repair)", chat_id, exc_info=True,
       )
   if swept:
     log.info(
@@ -1792,8 +1797,14 @@ async def sweep_idle_pending_chats(db: Session) -> list[str]:
   if draining:
     return started
   try:
+    # Queue watchdog projection only. Selecting the Chat entity here hydrates
+    # every transcript JSON blob once per minute merely to discover that almost
+    # every pending queue is empty. On a mature instance that produced a
+    # ~204 MiB allocation spike and left ~169 MiB in CPython/glibc arenas after
+    # the rows were released. The queue is the candidate index; load one full
+    # Chat only after its projected pending head proves old enough to recover.
     candidates = (
-      db.query(models.Chat)
+      db.query(models.Chat.id, models.Chat.pending_messages)
       .filter(models.Chat.run_status.is_(None))
       .filter(models.Chat.deleted_at.is_(None))
       .all()
@@ -1803,8 +1814,9 @@ async def sweep_idle_pending_chats(db: Session) -> list[str]:
     return started
 
   now_ms = int(time.time() * 1000)
-  for chat in candidates:
-    pending = list(chat.pending_messages or [])
+  for candidate in candidates:
+    chat_id = candidate.id
+    pending = list(candidate.pending_messages or [])
     if not _pending_head_is_stale(pending, now_ms):
       continue
     # A limit-parked queue is NOT abandoned work: LIMIT_PARKED preserves
@@ -1813,59 +1825,66 @@ async def sweep_idle_pending_chats(db: Session) -> list[str]:
     # sweep_reset_parks (when the chat policy is enabled) or the user's own
     # next send. The park row outlives run_status, so run_status IS NULL alone
     # cannot distinguish "crashed drain" from "parked on purpose".
-    if _parked_until_for_chat(db, chat.id) is not None:
+    if _parked_until_for_chat(db, chat_id) is not None:
       continue
-    if _restart_manual_hold_for_chat(db, chat.id):
+    if _restart_manual_hold_for_chat(db, chat_id):
       continue
     claimed = False
     try:
       async with asyncio.timeout(chat_queue.TERMINAL_LOCK_TIMEOUT_SECS):
-        async with chat_queue.get_transition_lock(chat.id):
-          async with chat_queue.get_lock(chat.id):
-            db.expire(chat)
+        async with chat_queue.get_transition_lock(chat_id):
+          async with chat_queue.get_lock(chat_id):
+            # Re-read the one real candidate under the transition/queue locks.
+            # The projected row above is deliberately only a cheap hint.
+            chat = db.query(models.Chat).filter(
+              models.Chat.id == chat_id,
+              models.Chat.deleted_at.is_(None),
+            ).first()
+            if chat is None:
+              continue
             pending = list(chat.pending_messages or [])
             if (
               chat.run_status is not None
               or not _pending_head_is_stale(pending, now_ms)
-              or _parked_until_for_chat(db, chat.id) is not None
-              or _restart_manual_hold_for_chat(db, chat.id)
-              or not mark_starting(chat.id)
+              or _parked_until_for_chat(db, chat_id) is not None
+              or _restart_manual_hold_for_chat(db, chat_id)
+              or not mark_starting(chat_id)
             ):
               continue
             claimed = True
             run_token = alloc_run_token()
             messages, next_user, session_id = (
               await chat_queue.promote_pending_messages_locked(
-                db, chat.id, run_token,
+                db, chat_id, run_token,
               )
             )
             if next_user is None:
-              discard_starting(chat.id)
+              discard_starting(chat_id)
               claimed = False
               continue
             get_system_broadcast().publish({
               "type": "chat_run_started",
-              "chatId": chat.id,
+              "chatId": chat_id,
             })
             if _schedule_continuation(
-              chat_id=chat.id,
+              chat_id=chat_id,
               messages=messages,
               session_id=session_id,
               provider_id=chat.provider,
               next_user=next_user,
               run_token=run_token,
             ):
-              started.append(chat.id)
+              started.append(chat_id)
             claimed = False
     except asyncio.CancelledError:
       if claimed:
-        discard_starting(chat.id)
+        discard_starting(chat_id)
       raise
     except Exception:
       if claimed:
-        discard_starting(chat.id)
+        discard_starting(chat_id)
       log.warning(
-        "idle-pending sweep failed chat_id=%s", chat.id, exc_info=True,
+        "idle-pending sweep failed chat_id=%s", chat_id, exc_info=True,
       )
   if started:
     log.info(

--- a/backend/app/routes/apps.py
+++ b/backend/app/routes/apps.py
@@ -20,7 +20,7 @@ from typing import Literal
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi.responses import FileResponse, HTMLResponse, StreamingResponse
 from pydantic import BaseModel, Field
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, defer
 
 from app import (
   activity, app_activity, app_apply, app_git, app_jobs, app_preview, fs_locks,
@@ -696,6 +696,14 @@ async def list_apps(
             db.rollback()
   apps = (
     db.query(models.App)
+    # Drawer metadata only. AppOut excludes both payload columns, so hydrating
+    # every source file and icon blob here creates tens of MiB of avoidable
+    # allocation on each cold shell load. Keep ORM rows for the existing
+    # activity/preview annotators while deferring the two heavyweight fields.
+    .options(
+      defer(models.App.jsx_source),
+      defer(models.App.icon_png),
+    )
     .filter(models.App.deleted_at.is_(None))
     .order_by(
       models.App.pinned_at.is_(None),

--- a/backend/tests/test_apps.py
+++ b/backend/tests/test_apps.py
@@ -5,6 +5,8 @@ from unittest.mock import patch
 
 from app import models
 from app.config import get_settings
+from app.database import engine
+from sqlalchemy import event
 from test_app_fixtures import create_local_app
 
 
@@ -43,6 +45,35 @@ def test_update_app_rejects_cross_site_request(client, auth):
     headers={**auth, "Sec-Fetch-Site": "cross-site"},
   )
   assert cross.status_code == 403
+
+
+def test_list_apps_does_not_hydrate_source_or_icon_payloads(client, auth, db):
+  app = models.App(
+    name="Heavy metadata test",
+    description="drawer row",
+    jsx_source="x" * 1_000_000,
+    icon_png=b"x" * 1_000_000,
+    slug="heavy-metadata-test",
+  )
+  db.add(app)
+  db.commit()
+  statements = []
+
+  def capture(_conn, _cursor, statement, _parameters, _context, _many):
+    if "FROM apps" in statement and "ORDER BY apps.pinned_at" in statement:
+      statements.append(statement)
+
+  event.listen(engine, "before_cursor_execute", capture)
+  try:
+    response = client.get("/api/apps/", headers=auth)
+  finally:
+    event.remove(engine, "before_cursor_execute", capture)
+
+  assert response.status_code == 200
+  assert len(statements) == 1
+  projection = statements[0].split("FROM apps", 1)[0]
+  assert "apps.jsx_source" not in projection
+  assert "apps.icon_png" not in projection
 
 
 def test_delete_then_purge_removes_non_slug_source_dir(client, auth, db):

--- a/backend/tests/test_idle_pending_sweep.py
+++ b/backend/tests/test_idle_pending_sweep.py
@@ -7,8 +7,9 @@ from datetime import UTC, datetime
 from app import chat as chat_mod
 from app import models
 from app.chat_writer import cid_of
-from app.database import SessionLocal
+from app.database import SessionLocal, engine
 from app.runner_registry import registry
+from sqlalchemy import event
 
 
 def _seed_pending(
@@ -118,6 +119,45 @@ def test_idle_pending_sweep_respects_age_gate(monkeypatch):
   assert status is None
   assert [cid_of(row) for row in pending] == [f"cid-{chat_id}"]
   assert not registry.is_alive(chat_id)
+
+
+def test_idle_pending_sweep_candidate_query_does_not_load_transcripts(
+  monkeypatch,
+):
+  chat_id = "idle-empty-large-transcript"
+  db = SessionLocal()
+  try:
+    db.add(models.Chat(
+      id=chat_id,
+      title="large but idle",
+      provider="codex",
+      messages=[{"role": "assistant", "content": "x" * 1_000_000}],
+      pending_messages=[],
+      run_status=None,
+    ))
+    db.commit()
+  finally:
+    db.close()
+
+  statements = []
+
+  def capture(_conn, _cursor, statement, _parameters, _context, _many):
+    if "FROM chats" in statement and "chats.run_status IS NULL" in statement:
+      statements.append(statement)
+
+  event.listen(engine, "before_cursor_execute", capture)
+  try:
+    swept, scheduled = _sweep(monkeypatch)
+  finally:
+    event.remove(engine, "before_cursor_execute", capture)
+
+  assert swept == []
+  assert scheduled == []
+  assert len(statements) == 1
+  projection = statements[0].split("FROM chats", 1)[0]
+  assert "chats.id" in projection
+  assert "chats.pending_messages" in projection
+  assert "chats.messages" not in projection
 
 
 def _park_latest_run(chat_id: str, *, minutes_out: float) -> None:

--- a/backend/tests/test_wedged_marker_sweep.py
+++ b/backend/tests/test_wedged_marker_sweep.py
@@ -15,8 +15,9 @@ from app import chat as chat_mod
 from app import models
 from app.broadcast import create_broadcast
 from app.chat_writer import Barrier, get_writer
-from app.database import SessionLocal
+from app.database import SessionLocal, engine
 from app.runner_registry import registry
+from sqlalchemy import event
 
 
 def _drain_writer():
@@ -98,6 +99,38 @@ def test_sweep_skips_recent_turn():
   _drain_writer()
   assert "recent-1" not in swept
   assert _state("recent-1")[0] == "running"
+
+
+def test_wedged_candidate_query_does_not_load_transcripts():
+  _seed("wedged-projection", age_secs=200)
+  db = SessionLocal()
+  try:
+    chat = db.get(models.Chat, "wedged-projection")
+    chat.messages = [{"role": "assistant", "content": "x" * 1_000_000}]
+    db.commit()
+  finally:
+    db.close()
+
+  statements = []
+
+  def capture(_conn, _cursor, statement, _parameters, _context, _many):
+    if (
+      "FROM chats" in statement
+      and "chats.run_started_at <" in statement
+    ):
+      statements.append(statement)
+
+  event.listen(engine, "before_cursor_execute", capture)
+  try:
+    _sweep()
+  finally:
+    event.remove(engine, "before_cursor_execute", capture)
+  _drain_writer()
+
+  assert len(statements) == 1
+  projection = statements[0].split("FROM chats", 1)[0]
+  assert "chats.id" in projection
+  assert "chats.messages" not in projection
 
 
 def test_sweep_skips_live_turn():


### PR DESCRIPTION
## Summary
- Keep recurring chat watchdog queries to the identifiers and pending-queue metadata they actually inspect, loading a full chat only for the rare stale queue that needs recovery.
- Keep the app drawer metadata query from hydrating app source and icon payloads that are not returned by the list response.
- Add SQL projection regressions for both watchdogs and the app list.

## Measured impact
On a mature instance with 490 chats, the idle-pending watchdog's once-per-minute full-row query allocated 204 MiB and left 169 MiB retained in Python/glibc arenas after release. The projected query allocated 3.2 MiB and completed about 12x faster. The app-list path fell from a 23.5 MiB cold allocation to 2.5 MiB.

This follows #221, whose owner and first-use memory diagnostics made the remaining allocation attributable; #221 did not change these query projections.

## Validation
- 141 focused backend tests passed across idle recovery, wedged markers, app listing, queue parking, steering, and drain behavior.
- The broad backend run reached 2,918 passed and 1 skipped; the remaining live-container exclusions were the existing recovery-isolation and build-version guards, outside the changed paths.
- Changed Python files compile and the canonical diff passes whitespace checks.