### PR TITLE
Make drawer close and resize geometry-driven

### DIFF
--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -6,7 +6,8 @@ import { EmptyMessage } from '@openai/apps-sdk-ui/components/EmptyMessage'
 import { api } from '../../api/client.js'
 import { appQueries, chatQueries } from '../../hooks/queries.js'
 import {
-  DRAWER_CLOSE_FALLBACK_MS,
+  drawerCloseWatchdogMs,
+  drawerWidthFromPointerDelta,
   isGeneratedTouchClick,
   isHorizontalDrawerSwipe,
   shouldSuppressDrawerSwipeClick,
@@ -477,12 +478,17 @@ export default function Drawer({
     if (open && !persistent) setScrimBlocking(true)
     if (persistent) setScrimBlocking(false)
   }, [open, persistent])
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (open || !scrimBlocking) return undefined
-    const timer = setTimeout(
-      () => setScrimBlocking(false),
-      DRAWER_CLOSE_FALLBACK_MS,
-    )
+    const panel = drawerRef.current
+    const watchdogMs = panel
+      ? drawerCloseWatchdogMs(getComputedStyle(panel))
+      : 0
+    if (watchdogMs === 0) {
+      setScrimBlocking(false)
+      return undefined
+    }
+    const timer = setTimeout(() => setScrimBlocking(false), watchdogMs)
     return () => clearTimeout(timer)
   }, [open, scrimBlocking])
 
@@ -605,8 +611,17 @@ export default function Drawer({
     if (e.button !== 0) return
     e.preventDefault()
     e.stopPropagation()
+    const panelRect = drawerRef.current?.getBoundingClientRect()
+    const handleRect = e.currentTarget.getBoundingClientRect()
+    const handleCenter = handleRect.left + (handleRect.width / 2)
+    const panelCenter = panelRect
+      ? panelRect.left + (panelRect.width / 2)
+      : handleCenter
     resizeRef.current = {
       pointerId: e.pointerId,
+      startX: e.clientX,
+      startWidth: clampDesktopSidebarWidth(width),
+      edgeDirection: handleCenter < panelCenter ? -1 : 1,
       width: clampDesktopSidebarWidth(width),
     }
     e.currentTarget.setPointerCapture(e.pointerId)
@@ -615,7 +630,12 @@ export default function Drawer({
 
   function onResizePointerMove(e) {
     if (resizeRef.current?.pointerId !== e.pointerId) return
-    applyResizeWidth(e.clientX)
+    applyResizeWidth(drawerWidthFromPointerDelta({
+      startWidth: resizeRef.current.startWidth,
+      startX: resizeRef.current.startX,
+      currentX: e.clientX,
+      edgeDirection: resizeRef.current.edgeDirection,
+    }))
   }
 
   function finishResize(e) {
@@ -703,6 +723,7 @@ export default function Drawer({
             onPointerMove={onResizePointerMove}
             onPointerUp={finishResize}
             onPointerCancel={finishResize}
+            onLostPointerCapture={finishResize}
             onKeyDown={onResizeKeyDown}
             onDoubleClick={() => onWidthChange?.(DESKTOP_SIDEBAR_DEFAULT_WIDTH)}
           >

--- a/frontend/src/lib/__tests__/drawerLifecycle.test.js
+++ b/frontend/src/lib/__tests__/drawerLifecycle.test.js
@@ -2,7 +2,9 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 
 import {
-  DRAWER_CLOSE_FALLBACK_MS,
+  DRAWER_CLOSE_WATCHDOG_BUFFER_MS,
+  drawerCloseWatchdogMs,
+  drawerWidthFromPointerDelta,
   isGeneratedTouchClick,
   isHorizontalDrawerSwipe,
   shouldSuppressDrawerSwipeClick,
@@ -36,8 +38,53 @@ test('drawer cleanup is safe before the panel ref mounts', () => {
   assert.doesNotThrow(() => clearDrawerGestureStyles(null))
 })
 
-test('close fallback outlasts the 100ms panel transition', () => {
-  assert.ok(DRAWER_CLOSE_FALLBACK_MS > 100)
+test('close watchdog follows the computed transform transition', () => {
+  assert.equal(drawerCloseWatchdogMs({
+    transitionProperty: 'transform',
+    transitionDuration: '100ms',
+    transitionDelay: '0s',
+  }), 100 + DRAWER_CLOSE_WATCHDOG_BUFFER_MS)
+
+  assert.equal(drawerCloseWatchdogMs({
+    transitionProperty: 'opacity, transform',
+    transitionDuration: '50ms, 0.25s',
+    transitionDelay: '0s, 20ms',
+  }), 270 + DRAWER_CLOSE_WATCHDOG_BUFFER_MS)
+})
+
+test('close watchdog releases immediately when transform motion is disabled', () => {
+  assert.equal(drawerCloseWatchdogMs({
+    transitionProperty: 'transform',
+    transitionDuration: '0s',
+    transitionDelay: '0s',
+  }), 0)
+  // Chromium's reduced-motion rule computes as `none` plus a nominal 1ms
+  // duration. The absent property wins: there is no transform transition to
+  // wait for.
+  assert.equal(drawerCloseWatchdogMs({
+    transitionProperty: 'none',
+    transitionDuration: '0.001s',
+    transitionDelay: '0s',
+  }), 0)
+  assert.equal(drawerCloseWatchdogMs({
+    transitionProperty: 'opacity',
+    transitionDuration: '500ms',
+    transitionDelay: '0s',
+  }), 0)
+})
+
+test('drawer resize follows pointer delta from either panel edge', () => {
+  assert.equal(drawerWidthFromPointerDelta({
+    startWidth: 320,
+    startX: 400,
+    currentX: 448,
+  }), 368)
+  assert.equal(drawerWidthFromPointerDelta({
+    startWidth: 320,
+    startX: 1000,
+    currentX: 952,
+    edgeDirection: -1,
+  }), 368)
 })
 
 test('drawer swipe classification rejects vertical and ambiguous movement', () => {

--- a/frontend/src/lib/__tests__/drawerLifecycle.test.js
+++ b/frontend/src/lib/__tests__/drawerLifecycle.test.js
@@ -50,6 +50,12 @@ test('close watchdog follows the computed transform transition', () => {
     transitionDuration: '50ms, 0.25s',
     transitionDelay: '0s, 20ms',
   }), 270 + DRAWER_CLOSE_WATCHDOG_BUFFER_MS)
+
+  assert.equal(drawerCloseWatchdogMs({
+    transitionProperty: 'transform',
+    transitionDuration: '100ms, 5s',
+    transitionDelay: '0s',
+  }), 100 + DRAWER_CLOSE_WATCHDOG_BUFFER_MS)
 })
 
 test('close watchdog releases immediately when transform motion is disabled', () => {

--- a/frontend/src/lib/drawerLifecycle.js
+++ b/frontend/src/lib/drawerLifecycle.js
@@ -28,11 +28,14 @@ export function drawerCloseWatchdogMs(style) {
   const properties = String(style?.transitionProperty || '').split(',').map(v => v.trim())
   const durations = String(style?.transitionDuration || '').split(',').map(cssTimeMs)
   const delays = String(style?.transitionDelay || '').split(',').map(cssTimeMs)
-  const count = Math.max(properties.length, durations.length, delays.length)
   let longest = 0
 
-  for (let index = 0; index < count; index += 1) {
-    const property = properties[index % properties.length]
+  // transition-property defines how many transitions exist. CSS repeats a
+  // shorter duration/delay list to that length and truncates surplus values;
+  // treating a surplus duration as another `transform` could strand the scrim
+  // behind a watchdog the browser itself never scheduled.
+  for (let index = 0; index < properties.length; index += 1) {
+    const property = properties[index]
     if (property !== 'transform' && property !== 'all') continue
     const duration = durations[index % durations.length]
     const delay = delays[index % delays.length]

--- a/frontend/src/lib/drawerLifecycle.js
+++ b/frontend/src/lib/drawerLifecycle.js
@@ -1,12 +1,67 @@
 // Drawer lifecycle helpers keep imperative swipe styling subordinate to the
 // shell's authoritative open/closed state.
 
-// Longer than Drawer.css's 100ms close transition. This is only
-// a fallback for reduced-motion / interrupted transitions where transitionend
-// does not fire; the normal path releases on the real transform event.
-export const DRAWER_CLOSE_FALLBACK_MS = 180
+// Extra time beyond the browser's computed transition. This is only a watchdog
+// for interrupted transitions where transitionend does not fire; the normal
+// path releases on the real transform event. A zero-duration transition needs
+// no watchdog (notably prefers-reduced-motion).
+export const DRAWER_CLOSE_WATCHDOG_BUFFER_MS = 80
 export const DRAWER_SWIPE_THRESHOLD_PX = 10
 export const DRAWER_SWIPE_DOMINANCE = 1.15
+
+function cssTimeMs(value) {
+  const text = String(value || '').trim()
+  const numeric = Number.parseFloat(text)
+  if (!Number.isFinite(numeric)) return 0
+  return text.endsWith('ms') ? numeric : numeric * 1000
+}
+
+/**
+ * Return a last-resort close watchdog derived from the panel's computed style.
+ *
+ * CSS transition lists repeat shorter property/duration/delay lists, so index
+ * each value modulo its own list length. `all` also owns the transform. The
+ * real transitionend remains authoritative; this only prevents a stranded
+ * modal scrim if the browser cancels or omits that event.
+ */
+export function drawerCloseWatchdogMs(style) {
+  const properties = String(style?.transitionProperty || '').split(',').map(v => v.trim())
+  const durations = String(style?.transitionDuration || '').split(',').map(cssTimeMs)
+  const delays = String(style?.transitionDelay || '').split(',').map(cssTimeMs)
+  const count = Math.max(properties.length, durations.length, delays.length)
+  let longest = 0
+
+  for (let index = 0; index < count; index += 1) {
+    const property = properties[index % properties.length]
+    if (property !== 'transform' && property !== 'all') continue
+    const duration = durations[index % durations.length]
+    const delay = delays[index % delays.length]
+    longest = Math.max(longest, Math.max(0, duration + delay))
+  }
+
+  return longest > 0
+    ? Math.ceil(longest + DRAWER_CLOSE_WATCHDOG_BUFFER_MS)
+    : 0
+}
+
+/**
+ * Resize from the gesture's starting geometry rather than an absolute screen
+ * coordinate. `edgeDirection` is 1 for a right-edge handle and -1 for a
+ * left-edge handle, so future insets or opposite-side navigation stay correct.
+ */
+export function drawerWidthFromPointerDelta({
+  startWidth,
+  startX,
+  currentX,
+  edgeDirection = 1,
+}) {
+  const width = Number(startWidth)
+  const origin = Number(startX)
+  const current = Number(currentX)
+  const direction = Number(edgeDirection) < 0 ? -1 : 1
+  if (![width, origin, current].every(Number.isFinite)) return width
+  return width + ((current - origin) * direction)
+}
 
 /** True only when the current displacement is decisively sideways. */
 export function isHorizontalDrawerSwipe(dx, dy) {

--- a/tests/navigation.spec.mjs
+++ b/tests/navigation.spec.mjs
@@ -1305,6 +1305,75 @@ test.describe('Drawer close paths converge through handleBack', () => {
     await expect(page.locator('.drawer-overlay')).toHaveCSS('pointer-events', 'none')
   })
 
+  test('22f. Reduced motion releases the scrim in the committed close layout', async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' })
+    await setup(page, { width: 426, height: 860 })
+    await openDrawer(page)
+
+    const committedClose = page.evaluate(() => new Promise((resolve) => {
+      const drawer = document.querySelector('.drawer')
+      const overlay = document.querySelector('.drawer-overlay')
+      const observer = new MutationObserver(() => {
+        if (drawer.classList.contains('drawer--open')) return
+        observer.disconnect()
+        resolve({
+          blocking: overlay.classList.contains('drawer-overlay--blocking'),
+          pointerEvents: getComputedStyle(overlay).pointerEvents,
+          transitionProperty: getComputedStyle(drawer).transitionProperty,
+        })
+      })
+      observer.observe(drawer, { attributes: true, attributeFilter: ['class'] })
+      observer.observe(overlay, { attributes: true, attributeFilter: ['class'] })
+    }))
+
+    await page.locator('.drawer-overlay').dispatchEvent('pointerdown', {
+      button: 0,
+      isPrimary: true,
+      pointerId: 8,
+      pointerType: 'touch',
+    })
+
+    expect(await committedClose).toEqual({
+      blocking: false,
+      pointerEvents: 'none',
+      transitionProperty: 'none',
+    })
+  })
+
+  test('22g. Desktop drawer resize follows pointer delta and settles lost capture', async ({ page }) => {
+    await setup(page, { width: 1280, height: 800 })
+    const drawer = page.locator('.drawer--persistent')
+    const handle = page.getByRole('separator', { name: 'Resize navigation drawer' })
+    await expect(handle).toBeVisible()
+
+    const startWidth = await drawer.evaluate((element) => {
+      element.style.left = '40px'
+      return element.getBoundingClientRect().width
+    })
+    const box = await handle.boundingBox()
+    expect(box).not.toBeNull()
+
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+    await page.mouse.down()
+    await page.mouse.move(box.x + box.width / 2 + 48, box.y + box.height / 2)
+    const released = await handle.evaluate((element) => {
+      for (let pointerId = 1; pointerId <= 5; pointerId += 1) {
+        if (!element.hasPointerCapture(pointerId)) continue
+        element.releasePointerCapture(pointerId)
+        return true
+      }
+      return false
+    })
+    expect(released).toBe(true)
+
+    await expect(drawer).not.toHaveClass(/drawer--resizing/)
+    expect(await drawer.evaluate(element => element.getBoundingClientRect().width))
+      .toBe(startWidth + 48)
+    expect(await page.evaluate(() => localStorage.getItem('mobius:desktop-sidebar-width:v1')))
+      .toBe(String(startWidth + 48))
+    await page.mouse.up()
+  })
+
   test('23. Brand toggle close does not navigate, even from a deep view', async ({ page }) => {
     // Same regression as test 22 but via the existing mobile brand toggle.
     // Test 9 covers the basic case from a non-default view; this test keeps


### PR DESCRIPTION
## Summary
- derive the modal drawer scrim watchdog from the browser's actual transform transition
- release the scrim immediately when reduced motion disables that transition
- resize the desktop drawer from pointer delta and settle interrupted pointer capture
- cover reduced-motion close and inset, interrupted resize paths with regressions

## Why
The mobile drawer used a fixed 180ms fallback tied to a 100ms CSS transition. A later motion change could make that fallback release too early or leave an invisible scrim blocking the workspace, while reduced motion always paid the delay despite having no transform transition.

Desktop resizing also treated the pointer's absolute horizontal screen position as the drawer width. That worked only while the drawer began at the left edge and could leave resize state behind if pointer capture was interrupted.

The close path now reads the computed transition and keeps its timer only as a last-resort watchdog; the real transition event remains authoritative. Resizing is based on the gesture's starting width and pointer delta, with edge direction and lost-capture cleanup kept explicit.

## Testing
- `npm test` (1,898 unit tests and 47 hook tests)
- `npm run build`
- authenticated browser verification at 390×844 with reduced motion: close state and scrim release committed together
- authenticated browser verification at 1680×957: an inset drawer followed a 48px pointer delta exactly and settled after forced pointer-capture loss
- focused Playwright regressions added; the isolated local runner requires Docker and was unavailable in the app container