### PR TITLE
Keep newer reachability evidence authoritative

### DIFF
--- a/frontend/src/lib/__tests__/connectivityStore.test.js
+++ b/frontend/src/lib/__tests__/connectivityStore.test.js
@@ -68,7 +68,7 @@ function harness(fetchImpl) {
     fetchImpl,
     ...timers,
   })
-  return { store, windowTarget, documentTarget, timers }
+  return { store, windowTarget, documentTarget, navigatorTarget, timers }
 }
 
 test('all subscribers share one monitor and the last unsubscribe removes it', async () => {
@@ -140,6 +140,21 @@ test('a live mutation response repairs a stale offline verdict immediately', asy
   h.store.reportReachable()
   assert.equal(h.store.getSnapshot(), true)
   assert.equal(notifications, 2)
+  stop()
+})
+
+test('a live mutation response outranks an older in-flight failed probe', async () => {
+  let settleProbe
+  const h = harness(() => new Promise((resolve) => { settleProbe = resolve }))
+  h.navigatorTarget.onLine = false
+  const stop = h.store.subscribe(() => {})
+
+  h.store.reportReachable()
+  settleProbe({ ok: false })
+  await flushMicrotasks()
+
+  assert.equal(h.store.getSnapshot(), true)
+  assert.equal(h.timers.timeoutCount(), 0)
   stop()
 })
 

--- a/frontend/src/lib/connectivityStore.js
+++ b/frontend/src/lib/connectivityStore.js
@@ -44,6 +44,7 @@ export function createConnectivityStore({
   let connectivityState = { successStreak: 0, failureStreak: 0, online: snapshot }
   let monitor = null
   let verificationCheck = null
+  let authoritativeReachabilityRevision = 0
 
   function getSnapshot() {
     return snapshot
@@ -91,6 +92,7 @@ export function createConnectivityStore({
   // Let owning write paths repair a stale offline verdict immediately instead
   // of waiting for the next poll or Android's delayed `online` event.
   function reportReachable() {
+    authoritativeReachabilityRevision += 1
     connectivityState = {
       successStreak: Math.max(1, connectivityState.successStreak),
       failureStreak: 0,
@@ -116,8 +118,14 @@ export function createConnectivityStore({
         return activeCheck
       }
       activeCheck = (async () => {
+        const startedRevision = authoritativeReachabilityRevision
         const reachable = await probeReachable()
         if (cancelled) return reachable
+        if (!reachable && startedRevision !== authoritativeReachabilityRevision) {
+          // A mutation response arrived after this probe began. Its live-server
+          // evidence is newer and stronger than the stale failed read.
+          return true
+        }
         const next = applyProbe(reachable)
         if (confirmTimer !== null) clearTimeoutFn(confirmTimer)
         confirmTimer = null
@@ -200,8 +208,13 @@ export function createConnectivityStore({
   function verify() {
     if (monitor) return monitor.check()
     if (verificationCheck) return verificationCheck
+    const startedRevision = authoritativeReachabilityRevision
     verificationCheck = probeReachable()
       .then((reachable) => {
+        if (
+          !reachable
+          && startedRevision !== authoritativeReachabilityRevision
+        ) return true
         applyProbe(reachable)
         return reachable
       })


### PR DESCRIPTION
## Summary
- keep a successful live mutation response authoritative over any older health probe that is still in flight
- preserve the existing connectivity hysteresis for genuinely newer failures
- cover the race where an operating-system offline hint and a stale probe would otherwise undo confirmed reachability

## Why
The broader chat-send and restart recovery change already reached `main` through #221 while this PR was waiting. The remaining review finding is narrower: a request can succeed after a health check begins, then that older check can fail and incorrectly restore the offline verdict. Mutation evidence is both newer and stronger, so only probes begun after it may demote connectivity again.

## Testing
- connectivity store unit suite (7 passed)
- canonical diff, attribution, and pre-push privacy checks
