### PR TITLE
Make green app-stack landing recoverable

### DIFF
--- a/backend/app/routes/github.py
+++ b/backend/app/routes/github.py
@@ -1246,6 +1246,11 @@ def _claim_stack_landing(
   except ContributionSubmitError as exc:
     raise HTTPException(status_code=409, detail=exc.message) from exc
   statuses = {item["record"].get("status") for item in validated}
+  by_id = {row["record"]["id"]: row for row in rows}
+  ordered = [
+    {**by_id[item["record"]["id"]], "stack": item["stack"]}
+    for item in validated
+  ]
   if statuses == {"merged"}:
     targets = {
       (
@@ -1265,17 +1270,70 @@ def _claim_stack_landing(
         status_code=409,
         detail="This pull request stack is already settled.",
       )
-    by_id = {row["record"]["id"]: row for row in rows}
-    return [
-      {**by_id[item["record"]["id"]], "stack": item["stack"]}
-      for item in validated
-    ], "merged"
-  if statuses == {"landing"}:
-    by_id = {row["record"]["id"]: row for row in rows}
-    return [
-      {**by_id[item["record"]["id"]], "stack": item["stack"]}
-      for item in validated
-    ], "recover"
+    return ordered, "merged"
+  if statuses.issubset({"landing", "merged"}) and "landing" in statuses:
+    # Marking a successful multi-record landing is intentionally idempotent but
+    # cannot be one filesystem transaction. A process exit between record
+    # writes leaves a truthful merged/landing mix; keep reconciling the shared
+    # pre-push journal instead of stranding the stack.
+    return ordered, "recover"
+  if statuses.issubset({"open", "landing"}) and "landing" in statuses:
+    # The same partial-write window exists while first claiming the stack or
+    # reopening it after a proven pre-push failure. Complete the saved claim,
+    # then let upstream-ref reconciliation decide whether to settle or reopen.
+    # The journal values must still match the reviewed chain exactly.
+    target_branch = validated[0]["stack"]["base_branch"]
+    expected_base = str(
+      (validated[0]["record"].get("plan") or {}).get("base_sha") or ""
+    )
+    landed_sha = str(
+      (validated[-1]["record"].get("plan") or {}).get("head_sha") or ""
+    )
+    expected_journal = (target_branch, expected_base, landed_sha)
+    if (
+      not _GIT_SHA.match(expected_base)
+      or not _GIT_SHA.match(landed_sha)
+      or any(
+        item["record"].get("status") == "landing"
+        and (
+          str(item["record"].get("land_target_branch") or ""),
+          str(item["record"].get("land_expected_base_sha") or ""),
+          str(item["record"].get("land_head_sha") or ""),
+        ) != expected_journal
+        for item in validated
+      )
+    ):
+      raise HTTPException(
+        status_code=409,
+        detail=(
+          "This stack has a partial landing journal that no longer matches "
+          "the reviewed chain. Refresh Contribute before trying again."
+        ),
+      )
+    started_at = next(
+      (
+        str(item["record"].get("land_started_at"))
+        for item in validated
+        if item["record"].get("land_started_at")
+      ),
+      _now_iso(),
+    )
+    now = _now_iso()
+    repaired = []
+    for row in ordered:
+      record = {
+        **row["record"],
+        "status": "landing",
+        "land_started_at": started_at,
+        "land_target_branch": target_branch,
+        "land_expected_base_sha": expected_base,
+        "land_head_sha": landed_sha,
+        "updated_at": now,
+      }
+      record.pop("last_land_error", None)
+      _write_record(row["record_path"], record)
+      repaired.append({**row, "record": record})
+    return repaired, "recover"
   if statuses != {"open"}:
     raise HTTPException(
       status_code=409,
@@ -1285,8 +1343,7 @@ def _claim_stack_landing(
       ),
     )
 
-  by_id = {row["record"]["id"]: row for row in rows}
-  ordered = []
+  claimed = []
   now = _now_iso()
   target_branch = validated[0]["stack"]["base_branch"]
   expected_base = str((validated[0]["record"].get("plan") or {}).get("base_sha") or "")
@@ -1296,10 +1353,9 @@ def _claim_stack_landing(
       status_code=409,
       detail="This stack has no complete reviewed landing journal. Prepare it again.",
     )
-  for item in validated:
-    row = by_id[item["record"]["id"]]
+  for row in ordered:
     record = {
-      **item["record"],
+      **row["record"],
       "status": "landing",
       "land_started_at": now,
       "land_target_branch": target_branch,
@@ -1309,8 +1365,8 @@ def _claim_stack_landing(
     }
     record.pop("last_land_error", None)
     _write_record(row["record_path"], record)
-    ordered.append({**row, "record": record, "stack": item["stack"]})
-  return ordered, "new"
+    claimed.append({**row, "record": record})
+  return claimed, "new"
 
 
 def _landing_journal(rows: list[dict]) -> tuple[str, str, str]:
@@ -1346,7 +1402,7 @@ def _reconcile_stack_landing(rows: list[dict]) -> tuple[str, str]:
     target = str(currents[0].get("last_land_target_branch") or "")
     head = str(currents[0].get("last_land_head_sha") or "")
     return _validate_branch(target), head
-  if any(current.get("status") != "landing" for current in currents):
+  if any(current.get("status") not in {"landing", "merged"} for current in currents):
     raise ContributionSubmitError(
       "This landing changed while it was being recovered. Refresh Contribute."
     )

--- a/backend/app/routes/github.py
+++ b/backend/app/routes/github.py
@@ -17,8 +17,10 @@ prepared record, rechecks its reviewed branch/diff, pushes to the owner's
 fork, and creates the pull request. An explicitly enumerated stack Send
 validates every parent link and diff before publishing dedicated upstream
 stack branches in order; it is available only when the connected owner can
-push there. An app-scoped github_access token may submit only records from its
-own storage; it cannot act as a general GitHub write proxy.
+push there. A second explicitly confirmed stack action can atomically land a
+fully green chain on an unchanged, unprotected app branch; protected refs are
+never bypassed. An app-scoped github_access token may act only on records from
+its own storage; it cannot use either path as a general GitHub write proxy.
 
 The fetch-free /source-status read is the local companion for Contribute's
 Sources view. It exposes only sanitized repository identity, refs, diff
@@ -189,6 +191,10 @@ class AutopilotEscalateBody(BaseModel):
 
 class AutopilotToggleBody(BaseModel):
   enabled: bool
+
+
+class ContributionStackLandRequest(BaseModel):
+  record_ids: list[str]
 
 
 class ContributionSubmitError(Exception):
@@ -659,6 +665,22 @@ def _assert_upstream_push_permission(repo: Path, upstream_repo: str) -> None:
     )
 
 
+def _upstream_branch_sha(
+  repo: Path, upstream_repo: str, branch: str,
+) -> str | None:
+  """Read one upstream branch tip, returning ``None`` on an invalid response."""
+  branch = _validate_branch(branch)
+  proc = _gh(
+    repo,
+    "api",
+    f"repos/{upstream_repo}/git/ref/heads/{quote(branch, safe='')}",
+    "--jq", ".object.sha",
+    check=False,
+  )
+  actual_sha = (proc.stdout or "").strip() if proc.returncode == 0 else ""
+  return actual_sha if _GIT_SHA.match(actual_sha) else None
+
+
 def _assert_upstream_branch_at(
   repo: Path,
   upstream_repo: str,
@@ -672,15 +694,8 @@ def _assert_upstream_branch_at(
       "An existing PR stack parent has no valid reviewed commit. Leave "
       "feedback so your agent can prepare the remaining layers again."
     )
-  proc = _gh(
-    repo,
-    "api",
-    f"repos/{upstream_repo}/git/ref/heads/{quote(branch, safe='')}",
-    "--jq", ".object.sha",
-    check=False,
-  )
-  actual_sha = (proc.stdout or "").strip() if proc.returncode == 0 else ""
-  if not _GIT_SHA.match(actual_sha):
+  actual_sha = _upstream_branch_sha(repo, upstream_repo, branch)
+  if actual_sha is None:
     raise ContributionSubmitError(
       f"The existing stack base {branch} is no longer available upstream. "
       "Nothing was sent; leave feedback so your agent can refresh the "
@@ -690,6 +705,154 @@ def _assert_upstream_branch_at(
     raise ContributionSubmitError(
       f"The existing stack base {branch} changed after review. Nothing was "
       "sent; leave feedback so your agent can refresh the remaining layers."
+    )
+
+
+def _assert_unprotected_landing_target(
+  repo: Path, upstream_repo: str, branch: str,
+) -> None:
+  """Atomic stack landing is deliberately limited to unprotected app refs.
+
+  The platform repository and any app that has opted into branch protection
+  keep GitHub's ordinary merge/queue path.  Admin bypass is not treated as
+  permission to skip those repository-owned invariants.
+  """
+  encoded = quote(_validate_branch(branch), safe="")
+  protection = _gh(
+    repo,
+    "api", f"repos/{upstream_repo}/branches/{encoded}/protection",
+    check=False,
+  )
+  protection_detail = (protection.stderr or protection.stdout or "").lower()
+  if protection.returncode == 0:
+    raise ContributionSubmitError(
+      f"{branch} is protected, so Contribute will not bypass its merge rules. "
+      "Use GitHub's normal merge or merge queue for this stack."
+    )
+  if "404" not in protection_detail and "not protected" not in protection_detail:
+    raise ContributionSubmitError(
+      f"Contribute could not verify that {branch} is safe for atomic landing. "
+      "Nothing was changed; try again after GitHub is reachable."
+    )
+
+  rules = _gh(
+    repo,
+    "api", f"repos/{upstream_repo}/rules/branches/{encoded}",
+    check=False,
+  )
+  if rules.returncode != 0:
+    raise ContributionSubmitError(
+      f"Contribute could not inspect the active rules for {branch}. Nothing "
+      "was changed; use GitHub's normal merge flow."
+    )
+  try:
+    active_rules = json.loads(rules.stdout or "[]")
+  except ValueError:
+    active_rules = None
+  if not isinstance(active_rules, list):
+    raise ContributionSubmitError(
+      f"Contribute could not understand the active rules for {branch}. "
+      "Nothing was changed; use GitHub's normal merge flow."
+    )
+  if active_rules:
+    raise ContributionSubmitError(
+      f"{branch} has repository rules, so Contribute will not bypass them. "
+      "Use GitHub's normal merge or merge queue for this stack."
+    )
+
+
+def _assert_pr_checks_green(
+  repo: Path,
+  *,
+  upstream_repo: str,
+  record: dict,
+  base_branch: str,
+  head_branch: str,
+) -> None:
+  number = record.get("number")
+  if not isinstance(number, int) or number <= 0:
+    raise ContributionSubmitError(
+      "A pull request in this stack has no verified GitHub number. Refresh "
+      "Contribute before landing it."
+    )
+  proc = _gh(
+    repo,
+    "pr", "view", str(number),
+    "-R", upstream_repo,
+    "--json",
+    "state,isDraft,baseRefName,headRefName,headRepositoryOwner,statusCheckRollup,url",
+    check=False,
+  )
+  if proc.returncode != 0:
+    raise ContributionSubmitError(
+      f"Contribute could not verify pull request #{number}. Nothing was "
+      "changed; refresh and try again."
+    )
+  try:
+    data = json.loads(proc.stdout or "{}")
+  except ValueError:
+    data = None
+  if not isinstance(data, dict):
+    raise ContributionSubmitError(
+      f"GitHub returned an invalid result for pull request #{number}."
+    )
+  owner = data.get("headRepositoryOwner")
+  owner_login = owner.get("login") if isinstance(owner, dict) else ""
+  upstream_owner = upstream_repo.split("/", 1)[0]
+  if (
+    data.get("state") != "OPEN"
+    or bool(data.get("isDraft"))
+    or data.get("baseRefName") != base_branch
+    or data.get("headRefName") != head_branch
+    or str(owner_login).lower() != upstream_owner.lower()
+  ):
+    raise ContributionSubmitError(
+      f"Pull request #{number} no longer matches the reviewed stack. Nothing "
+      "was changed; refresh Contribute before landing it."
+    )
+  expected_url = str(record.get("url") or "")
+  if expected_url and data.get("url") != expected_url:
+    raise ContributionSubmitError(
+      f"Pull request #{number} no longer matches its Contribute record."
+    )
+
+  checks = data.get("statusCheckRollup")
+  if not isinstance(checks, list) or not checks:
+    raise ContributionSubmitError(
+      f"Pull request #{number} has no completed CI checks yet. Nothing was "
+      "changed; wait for CI and try again."
+    )
+  unfinished = []
+  failed = []
+  for check in checks:
+    if not isinstance(check, dict):
+      failed.append("unknown check")
+      continue
+    name = str(check.get("name") or check.get("context") or "check")
+    if check.get("__typename") == "StatusContext":
+      state = str(check.get("state") or "").upper()
+      if state == "SUCCESS":
+        continue
+      if state in {"PENDING", "EXPECTED"}:
+        unfinished.append(name)
+      else:
+        failed.append(name)
+      continue
+    status = str(check.get("status") or "").upper()
+    conclusion = str(check.get("conclusion") or "").upper()
+    if status != "COMPLETED" or not conclusion:
+      unfinished.append(name)
+    elif conclusion not in {"SUCCESS", "NEUTRAL", "SKIPPED"}:
+      failed.append(name)
+  if failed:
+    raise ContributionSubmitError(
+      f"Pull request #{number} has failing CI ({', '.join(failed[:3])}). "
+      "Nothing was changed."
+    )
+  if unfinished:
+    raise ContributionSubmitError(
+      f"Pull request #{number} still has CI running ({', '.join(unfinished[:3])}). "
+      "Nothing was changed; try again when it is green."
     )
 
 
@@ -945,7 +1108,7 @@ def _validate_stack_records(records: list[dict]) -> list[dict]:
   # A draft PR is already public and owner-approved; it is a valid durable
   # parent for a later private layer just like an open PR. `prepared` remains
   # the only private state this request is allowed to claim.
-  allowed_statuses = {"prepared", "draft", "open", "merged"}
+  allowed_statuses = {"prepared", "submitting", "draft", "open", "landing", "merged"}
   for record, meta in decorated:
     plan = record.get("plan") if isinstance(record.get("plan"), dict) else {}
     record_id = str(record.get("id") or "")
@@ -1051,6 +1214,221 @@ def _claim_stack_records(
       detail="Every PR in this stack has already been submitted.",
     )
   return ordered
+
+
+def _claim_stack_landing(
+  *,
+  app_id: int,
+  record_ids: list[str],
+  db: Session,
+  expected_nonce: str | None,
+) -> tuple[list[dict], str]:
+  """Claim a new landing or reopen its durable journal for reconciliation."""
+  if not 2 <= len(record_ids) <= 12 or len(set(record_ids)) != len(record_ids):
+    raise HTTPException(
+      status_code=400,
+      detail="Choose one complete PR stack of 2 to 12 unique records.",
+    )
+  _recheck_submit_app(db, app_id, expected_nonce)
+  rows = []
+  for record_id in record_ids:
+    record_path, diff_path = _record_paths(app_id, record_id)
+    record = _read_record(record_path)
+    if str(record.get("id") or "") != record_id:
+      raise HTTPException(status_code=409, detail="A stack record id changed.")
+    rows.append({
+      "record": record,
+      "record_path": record_path,
+      "diff_path": diff_path,
+    })
+  try:
+    validated = _validate_stack_records([row["record"] for row in rows])
+  except ContributionSubmitError as exc:
+    raise HTTPException(status_code=409, detail=exc.message) from exc
+  statuses = {item["record"].get("status") for item in validated}
+  if statuses == {"merged"}:
+    targets = {
+      (
+        item["record"].get("last_land_target_branch"),
+        item["record"].get("last_land_head_sha"),
+      )
+      for item in validated
+    }
+    if (
+      any(
+        item["record"].get("last_land_mode") != "atomic-fast-forward"
+        for item in validated
+      )
+      or len(targets) != 1
+    ):
+      raise HTTPException(
+        status_code=409,
+        detail="This pull request stack is already settled.",
+      )
+    by_id = {row["record"]["id"]: row for row in rows}
+    return [
+      {**by_id[item["record"]["id"]], "stack": item["stack"]}
+      for item in validated
+    ], "merged"
+  if statuses == {"landing"}:
+    by_id = {row["record"]["id"]: row for row in rows}
+    return [
+      {**by_id[item["record"]["id"]], "stack": item["stack"]}
+      for item in validated
+    ], "recover"
+  if statuses != {"open"}:
+    raise HTTPException(
+      status_code=409,
+      detail=(
+        "Every pull request in this stack must be open before it can land. "
+        "Refresh Contribute and try again."
+      ),
+    )
+
+  by_id = {row["record"]["id"]: row for row in rows}
+  ordered = []
+  now = _now_iso()
+  target_branch = validated[0]["stack"]["base_branch"]
+  expected_base = str((validated[0]["record"].get("plan") or {}).get("base_sha") or "")
+  landed_sha = str((validated[-1]["record"].get("plan") or {}).get("head_sha") or "")
+  if not _GIT_SHA.match(expected_base) or not _GIT_SHA.match(landed_sha):
+    raise HTTPException(
+      status_code=409,
+      detail="This stack has no complete reviewed landing journal. Prepare it again.",
+    )
+  for item in validated:
+    row = by_id[item["record"]["id"]]
+    record = {
+      **item["record"],
+      "status": "landing",
+      "land_started_at": now,
+      "land_target_branch": target_branch,
+      "land_expected_base_sha": expected_base,
+      "land_head_sha": landed_sha,
+      "updated_at": now,
+    }
+    record.pop("last_land_error", None)
+    _write_record(row["record_path"], record)
+    ordered.append({**row, "record": record, "stack": item["stack"]})
+  return ordered, "new"
+
+
+def _landing_journal(rows: list[dict]) -> tuple[str, str, str]:
+  """Return one consistent durable landing intent from claimed records."""
+  journals = {
+    (
+      str(row["record"].get("land_target_branch") or ""),
+      str(row["record"].get("land_expected_base_sha") or ""),
+      str(row["record"].get("land_head_sha") or ""),
+    )
+    for row in rows
+  }
+  if len(journals) != 1:
+    raise ContributionSubmitError(
+      "This landing journal is incomplete. Nothing new was pushed; refresh Contribute."
+    )
+  target_branch, expected_base, landed_sha = journals.pop()
+  if (
+    not target_branch
+    or not _GIT_SHA.match(expected_base)
+    or not _GIT_SHA.match(landed_sha)
+  ):
+    raise ContributionSubmitError(
+      "This landing journal is invalid. Nothing new was pushed; refresh Contribute."
+    )
+  return _validate_branch(target_branch), expected_base, landed_sha
+
+
+def _reconcile_stack_landing(rows: list[dict]) -> tuple[str, str]:
+  """Resolve a previously claimed landing without ever issuing another push."""
+  currents = [_read_record(row["record_path"]) for row in rows]
+  if all(current.get("status") == "merged" for current in currents):
+    target = str(currents[0].get("last_land_target_branch") or "")
+    head = str(currents[0].get("last_land_head_sha") or "")
+    return _validate_branch(target), head
+  if any(current.get("status") != "landing" for current in currents):
+    raise ContributionSubmitError(
+      "This landing changed while it was being recovered. Refresh Contribute."
+    )
+  live_rows = [
+    {**row, "record": current}
+    for row, current in zip(rows, currents, strict=True)
+  ]
+  target_branch, expected_base, landed_sha = _landing_journal(live_rows)
+  first_plan = live_rows[0]["record"].get("plan") or {}
+  upstream_repo = _validate_repo_slug(
+    first_plan.get("repo") or live_rows[0]["record"].get("repo")
+  )
+  repo = _safe_repo_path(first_plan.get("repo_path"))
+  actual = _upstream_branch_sha(repo, upstream_repo, target_branch)
+  if actual == landed_sha:
+    return target_branch, landed_sha
+  if actual == expected_base:
+    raise ContributionSubmitError(
+      "The earlier landing stopped before changing upstream. The stack is open again."
+    )
+  raise ContributionSubmitError(
+    f"Upstream {target_branch} changed while the earlier landing was unresolved. "
+    "Nothing was overwritten; refresh the stack before trying again."
+  )
+
+
+def _mark_stack_land_failure(rows: list[dict], message: str) -> list[dict]:
+  snapshots = []
+  now = _now_iso()
+  for row in rows:
+    current = _read_record(row["record_path"])
+    if current.get("status") == "landing":
+      current = {
+        **current,
+        "status": "open",
+        "last_land_error": message,
+        "updated_at": now,
+      }
+      _write_record(row["record_path"], current)
+    snapshots.append(current)
+  return snapshots
+
+
+def _mark_stack_land_success(
+  rows: list[dict], *, target_branch: str, landed_sha: str,
+) -> list[dict]:
+  currents = [_read_record(row["record_path"]) for row in rows]
+  settled = [
+    current.get("status") == "merged"
+    and current.get("last_land_target_branch") == target_branch
+    and current.get("last_land_head_sha") == landed_sha
+    for current in currents
+  ]
+  if all(settled):
+    return currents
+  if any(
+    current.get("status") != "landing" and not is_settled
+    for current, is_settled in zip(currents, settled, strict=True)
+  ):
+    raise ContributionSubmitError(
+      "This PR stack changed while it was landing. Refresh Contribute."
+    )
+  snapshots = []
+  now = _now_iso()
+  for row, current, is_settled in zip(rows, currents, settled, strict=True):
+    if is_settled:
+      snapshots.append(current)
+      continue
+    current = {
+      **current,
+      "status": "merged",
+      "merged_at": now,
+      "landed_at": now,
+      "last_land_mode": "atomic-fast-forward",
+      "last_land_target_branch": target_branch,
+      "last_land_head_sha": landed_sha,
+      "updated_at": now,
+    }
+    current.pop("last_land_error", None)
+    _write_record(row["record_path"], current)
+    snapshots.append(current)
+  return snapshots
 
 
 def _mark_submit_failure(
@@ -2170,6 +2548,173 @@ def _preflight_prepared_stack(rows: list[dict]) -> None:
         _git(repo, "checkout", "-q", checkout_back, check=False)
 
 
+def _push_stack_tip_with_lease(
+  repo: Path,
+  *,
+  upstream_repo: str,
+  target_branch: str,
+  expected_base: str,
+  landed_sha: str,
+) -> None:
+  """Atomically advance one unchanged upstream ref to a proven stack tip."""
+  remote = f"https://github.com/{upstream_repo}.git"
+  last_error = ""
+  for attempt in range(_PUSH_RETRIES):
+    proc = _git(
+      repo,
+      "push",
+      f"--force-with-lease=refs/heads/{target_branch}:{expected_base}",
+      remote,
+      f"{landed_sha}:refs/heads/{target_branch}",
+      check=False,
+    )
+    if proc.returncode == 0:
+      return
+    last_error = (proc.stderr or proc.stdout or "").strip()
+    # A transport can fail after GitHub has accepted the ref update. Re-read the
+    # target before reporting failure or retrying: the exact landed tip is proof
+    # that this compare-and-swap succeeded, while every other value remains a
+    # safe failure. This mirrors submission's lost-response reconciliation and
+    # prevents the ledger from reopening a stack that is already live.
+    if _upstream_branch_sha(repo, upstream_repo, target_branch) == landed_sha:
+      return
+    if not _is_transient_push_error(last_error):
+      break
+    if attempt + 1 < _PUSH_RETRIES:
+      time.sleep(_PUSH_RETRY_BASE_SECONDS * (2 ** attempt))
+  if "stale info" in last_error.lower() or "fetch first" in last_error.lower():
+    raise ContributionSubmitError(
+      f"Upstream {target_branch} moved while this stack was landing. Nothing "
+      "was overwritten; refresh the stack and run CI again."
+    )
+  raise ContributionSubmitError(
+    (last_error[:600] if last_error else "GitHub rejected the atomic landing.")
+  )
+
+
+def _land_reviewed_stack(rows: list[dict]) -> tuple[str, str]:
+  """Prove and atomically fast-forward an open, green PR stack."""
+  if not shutil.which("git") or not shutil.which("gh"):
+    raise ContributionSubmitError(
+      "This platform needs git and gh installed before it can land PR stacks."
+    )
+  token = github_auth.get_token()
+  state = github_auth.read_state() or {}
+  login = str(state.get("login") or "")
+  if not token or not login:
+    raise ContributionSubmitError("Connect GitHub before landing this PR stack.", 401)
+
+  first_record = rows[0]["record"]
+  first_plan = first_record.get("plan") or {}
+  upstream_repo = _validate_repo_slug(
+    first_plan.get("repo") or first_record.get("repo")
+  )
+  anchor_repo = _safe_repo_path(first_plan.get("repo_path"))
+  target_branch = _upstream_default_branch(anchor_repo, upstream_repo)
+  if rows[0]["stack"]["base_branch"] != target_branch:
+    raise ContributionSubmitError(
+      f"The first PR in this stack no longer targets {target_branch}."
+    )
+  expected_base = _resolve_reviewed_commit(
+    anchor_repo, first_plan.get("base_sha"), "base sha",
+  )
+
+  _assert_upstream_push_permission(anchor_repo, upstream_repo)
+  _assert_unprotected_landing_target(anchor_repo, upstream_repo, target_branch)
+  _assert_upstream_branch_at(
+    anchor_repo, upstream_repo, target_branch, expected_base,
+  )
+
+  previous_head = ""
+  top_repo = anchor_repo
+  landed_sha = ""
+  reviewed_refs = []
+  for index, row in enumerate(rows):
+    record = row["record"]
+    if record.get("status") != "landing":
+      raise ContributionSubmitError(
+        "This PR stack changed while it was being verified. Refresh Contribute."
+      )
+    plan = record.get("plan") or {}
+    repo = _safe_repo_path(plan.get("repo_path"))
+    if not (repo / ".git").exists():
+      raise ContributionSubmitError("A staged stack checkout is no longer available.")
+    branch = _validate_branch(plan.get("branch") or record.get("branch"))
+    base_sha = str(plan.get("base_sha") or "")
+    head_sha = str(plan.get("head_sha") or record.get("head_sha") or "")
+    if index > 0 and base_sha != previous_head:
+      raise ContributionSubmitError(
+        "This public stack no longer has the exact reviewed parent chain. "
+        "Nothing was changed; refresh it before landing."
+      )
+
+    checkout_back = None
+    try:
+      current_branch = _git(repo, "rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
+      checkout_back = (
+        _git(repo, "rev-parse", "HEAD").stdout.strip()
+        if current_branch == "HEAD"
+        else current_branch
+      )
+      _assert_clean_worktree(repo)
+      _git(repo, "checkout", "-q", branch)
+      _assert_clean_worktree(repo)
+      _, resolved_head, _ = _assert_fresh(
+        record, row["diff_path"], repo, branch,
+      )
+      _assert_coauthor_trailer(repo, branch)
+      _assert_upstream_branch_at(
+        repo, upstream_repo, branch, resolved_head,
+      )
+      _assert_pr_checks_green(
+        repo,
+        upstream_repo=upstream_repo,
+        record=record,
+        base_branch=row["stack"]["base_branch"],
+        head_branch=branch,
+      )
+      previous_head = resolved_head
+      top_repo = repo
+      landed_sha = resolved_head
+      reviewed_refs.append((branch, resolved_head))
+    finally:
+      if checkout_back:
+        _git(repo, "checkout", "-q", checkout_back, check=False)
+
+  ancestry = _git(
+    top_repo,
+    "merge-base", "--is-ancestor", expected_base, landed_sha,
+    check=False,
+  )
+  if ancestry.returncode != 0:
+    raise ContributionSubmitError(
+      "The top of this stack is no longer a fast-forward from upstream. "
+      "Nothing was changed."
+    )
+
+  # Recheck every public ref after reading CI so a concurrent branch update
+  # cannot make the checks describe a different commit. The target ref is
+  # also guarded by the push lease, making the final update compare-and-swap.
+  _assert_upstream_branch_at(
+    anchor_repo, upstream_repo, target_branch, expected_base,
+  )
+  for branch, head_sha in reviewed_refs:
+    _assert_upstream_branch_at(
+      anchor_repo,
+      upstream_repo,
+      branch,
+      head_sha,
+    )
+  _push_stack_tip_with_lease(
+    top_repo,
+    upstream_repo=upstream_repo,
+    target_branch=target_branch,
+    expected_base=expected_base,
+    landed_sha=landed_sha,
+  )
+  return target_branch, landed_sha
+
+
 async def _github_user(token: str) -> tuple[int, str, int | None, list[str]]:
   """GET /user with `token`; returns (status, login, user_id, scopes).
 
@@ -3131,6 +3676,93 @@ async def submit_contribution_stack(
     db.close()
     snapshots = _stack_record_snapshots(rows)
   return {"records": snapshots, "submitted": submitted_urls}
+
+
+@router.post(
+  "/contributions/{app_id}/land-stack",
+  dependencies=[Depends(reject_cross_site)],
+)
+@_limiter.limit("5/minute")
+async def land_contribution_stack(
+  request: Request,
+  app_id: int,
+  body: ContributionStackLandRequest,
+  db: Session = Depends(get_db),
+  principal: Principal = Depends(get_principal),
+):
+  """Atomically fast-forward one unchanged, unprotected app stack.
+
+  The partner's confirmation enumerates the complete public stack. Before the
+  single upstream ref update, the server rechecks every stored review diff,
+  public branch tip, PR topology, and CI result. Protected branches are never
+  bypassed, even when the connected owner is an administrator.
+  """
+  expected_nonce = _validate_submit_app(app_id, principal, db)
+  db.close()
+  async with fs_locks.app_storage_lock(app_id):
+    rows, landing_mode = _claim_stack_landing(
+      app_id=app_id,
+      record_ids=body.record_ids,
+      db=db,
+      expected_nonce=expected_nonce,
+    )
+  db.close()
+
+  try:
+    repo_paths = sorted({
+      str(_safe_repo_path((row["record"].get("plan") or {}).get("repo_path")))
+      for row in rows
+    })
+    async with AsyncExitStack() as source_locks:
+      for repo_path in repo_paths:
+        await source_locks.enter_async_context(
+          fs_locks.source_dir_lock(repo_path)
+        )
+      if landing_mode == "merged":
+        target_branch = str(rows[0]["record"].get("last_land_target_branch") or "")
+        landed_sha = str(rows[0]["record"].get("last_land_head_sha") or "")
+      elif landing_mode == "recover":
+        target_branch, landed_sha = await asyncio.to_thread(
+          _reconcile_stack_landing, rows,
+        )
+      else:
+        target_branch, landed_sha = await asyncio.to_thread(
+          _land_reviewed_stack, rows,
+        )
+  except ContributionSubmitError as exc:
+    async with fs_locks.app_storage_lock(app_id):
+      _recheck_submit_app(db, app_id, expected_nonce)
+      db.close()
+      snapshots = _mark_stack_land_failure(rows, exc.message)
+    raise HTTPException(
+      status_code=exc.status_code,
+      detail={"message": exc.message, "records": snapshots},
+    ) from exc
+  except Exception as exc:
+    log.exception("Contribution stack landing failed for app %s", app_id)
+    message = "Could not land this PR stack. Nothing was intentionally changed."
+    async with fs_locks.app_storage_lock(app_id):
+      _recheck_submit_app(db, app_id, expected_nonce)
+      db.close()
+      snapshots = _mark_stack_land_failure(rows, message)
+    raise HTTPException(
+      status_code=500,
+      detail={"message": message, "records": snapshots},
+    ) from exc
+
+  async with fs_locks.app_storage_lock(app_id):
+    _recheck_submit_app(db, app_id, expected_nonce)
+    db.close()
+    snapshots = _mark_stack_land_success(
+      rows,
+      target_branch=target_branch,
+      landed_sha=landed_sha,
+    )
+  return {
+    "records": snapshots,
+    "target_branch": target_branch,
+    "landed_sha": landed_sha,
+  }
 
 
 @router.post(

--- a/backend/app/routes/github.py
+++ b/backend/app/routes/github.py
@@ -1367,6 +1367,13 @@ def _reconcile_stack_landing(rows: list[dict]) -> tuple[str, str]:
     raise ContributionSubmitError(
       "The earlier landing stopped before changing upstream. The stack is open again."
     )
+  if actual is None:
+    raise ContributionSubmitError(
+      "GitHub has not yet confirmed whether the saved landing completed. "
+      "The recovery journal is still intact; check again shortly.",
+      status_code=503,
+      code="landing_unconfirmed",
+    )
   raise ContributionSubmitError(
     f"Upstream {target_branch} changed while the earlier landing was unresolved. "
     "Nothing was overwritten; refresh the stack before trying again."
@@ -2559,6 +2566,7 @@ def _push_stack_tip_with_lease(
   """Atomically advance one unchanged upstream ref to a proven stack tip."""
   remote = f"https://github.com/{upstream_repo}.git"
   last_error = ""
+  last_actual = expected_base
   for attempt in range(_PUSH_RETRIES):
     proc = _git(
       repo,
@@ -2576,13 +2584,25 @@ def _push_stack_tip_with_lease(
     # that this compare-and-swap succeeded, while every other value remains a
     # safe failure. This mirrors submission's lost-response reconciliation and
     # prevents the ledger from reopening a stack that is already live.
-    if _upstream_branch_sha(repo, upstream_repo, target_branch) == landed_sha:
+    last_actual = _upstream_branch_sha(repo, upstream_repo, target_branch)
+    if last_actual == landed_sha:
       return
     if not _is_transient_push_error(last_error):
       break
     if attempt + 1 < _PUSH_RETRIES:
       time.sleep(_PUSH_RETRY_BASE_SECONDS * (2 ** attempt))
-  if "stale info" in last_error.lower() or "fetch first" in last_error.lower():
+  if last_actual is None:
+    raise ContributionSubmitError(
+      "GitHub did not confirm whether the atomic landing completed. The "
+      "recovery journal is still intact; check again shortly.",
+      status_code=503,
+      code="landing_unconfirmed",
+    )
+  if (
+    last_actual != expected_base
+    or "stale info" in last_error.lower()
+    or "fetch first" in last_error.lower()
+  ):
     raise ContributionSubmitError(
       f"Upstream {target_branch} moved while this stack was landing. Nothing "
       "was overwritten; refresh the stack and run CI again."
@@ -3733,10 +3753,18 @@ async def land_contribution_stack(
     async with fs_locks.app_storage_lock(app_id):
       _recheck_submit_app(db, app_id, expected_nonce)
       db.close()
-      snapshots = _mark_stack_land_failure(rows, exc.message)
+      snapshots = (
+        _stack_record_snapshots(rows)
+        if exc.code == "landing_unconfirmed"
+        else _mark_stack_land_failure(rows, exc.message)
+      )
     raise HTTPException(
       status_code=exc.status_code,
-      detail={"message": exc.message, "records": snapshots},
+      detail={
+        "message": exc.message,
+        "records": snapshots,
+        **({"code": exc.code} if exc.code else {}),
+      },
     ) from exc
   except Exception as exc:
     log.exception("Contribution stack landing failed for app %s", app_id)

--- a/backend/tests/test_github_routes.py
+++ b/backend/tests/test_github_routes.py
@@ -3230,6 +3230,291 @@ def test_direct_stack_layer_pushes_upstream_and_uses_reviewed_base(
   assert not any(call[:2] == ("repo", "fork") for call in gh_calls)
 
 
+def test_land_contribution_stack_marks_every_layer_merged(
+  client, owner_token, monkeypatch,
+):
+  _write_token(login="octocat")
+  app_id, app_token = _app_token(client, owner_token, github_access=True)
+  stack_id = "green-app-stack"
+  record_ids = ["green-stack-01", "green-stack-02"]
+  base = "b" * 40
+  parent_head = "a" * 40
+  top_head = "c" * 40
+  for position, record_id in enumerate(record_ids, 1):
+    repo = Path(get_settings().data_dir) / "contributions" / record_id / "repo"
+    (repo / ".git").mkdir(parents=True)
+    branch = f"stack/{stack_id}/0{position}-layer"
+    diff_text = f"diff --git a/layer-{position} b/layer-{position}\n+green\n"
+    record = {
+      "id": record_id,
+      "type": "pr",
+      "repo": "mobius-os/app-demo",
+      "status": "open",
+      "title": f"Layer {position}",
+      "branch": branch,
+      "number": 90 + position,
+      "url": f"https://github.com/mobius-os/app-demo/pull/{90 + position}",
+      "plan": {
+        "action": "pr",
+        "repo": "mobius-os/app-demo",
+        "branch": branch,
+        "repo_path": str(repo),
+        "base_sha": base if position == 1 else parent_head,
+        "head_sha": parent_head if position == 1 else top_head,
+        "diff_sha256": hashlib.sha256(diff_text.encode()).hexdigest(),
+        "stack": {
+          "id": stack_id,
+          "position": position,
+          "total": 2,
+          "parent_record_id": "" if position == 1 else record_ids[0],
+          "base_branch": "main" if position == 1 else f"stack/{stack_id}/01-layer",
+        },
+      },
+    }
+    _write_contribution(app_id, record_id, record, diff_text)
+
+  seen = {}
+
+  def fake_land(rows):
+    seen["calls"] = seen.get("calls", 0) + 1
+    seen["statuses"] = [row["record"]["status"] for row in rows]
+    seen["ids"] = [row["record"]["id"] for row in rows]
+    seen["journals"] = [
+      (
+        row["record"]["land_target_branch"],
+        row["record"]["land_expected_base_sha"],
+        row["record"]["land_head_sha"],
+      )
+      for row in rows
+    ]
+    return "main", top_head
+
+  monkeypatch.setattr("app.routes.github._land_reviewed_stack", fake_land)
+  response = client.post(
+    f"/api/github/contributions/{app_id}/land-stack",
+    headers={"Authorization": f"Bearer {app_token}"},
+    json={"record_ids": record_ids},
+  )
+
+  assert response.status_code == 200, response.text
+  assert seen == {
+    "calls": 1,
+    "statuses": ["landing", "landing"],
+    "ids": record_ids,
+    "journals": [("main", base, top_head), ("main", base, top_head)],
+  }
+  body = response.json()
+  assert body["target_branch"] == "main"
+  assert body["landed_sha"] == top_head
+  assert [record["status"] for record in body["records"]] == ["merged", "merged"]
+  assert all(record["last_land_mode"] == "atomic-fast-forward" for record in body["records"])
+
+  # A lost HTTP response may repeat the exact request. The durable merged
+  # journal makes that retry idempotent; it must never call the pusher again.
+  repeated = client.post(
+    f"/api/github/contributions/{app_id}/land-stack",
+    headers={"Authorization": f"Bearer {app_token}"},
+    json={"record_ids": record_ids},
+  )
+  assert repeated.status_code == 200, repeated.text
+  assert seen["calls"] == 1
+  assert [record["status"] for record in repeated.json()["records"]] == [
+    "merged", "merged",
+  ]
+
+
+def test_land_contribution_stack_restores_open_records_on_preflight_failure(
+  client, owner_token, monkeypatch,
+):
+  from app.routes.github import ContributionSubmitError
+
+  _write_token(login="octocat")
+  app_id, _ = _app_token(client, owner_token, github_access=True)
+  stack_id = "red-app-stack"
+  ids = ["red-stack-01", "red-stack-02"]
+  for position, record_id in enumerate(ids, 1):
+    repo = Path(get_settings().data_dir) / "contributions" / record_id / "repo"
+    (repo / ".git").mkdir(parents=True)
+    parent = "a" * 40
+    branch = f"stack/{stack_id}/0{position}-layer"
+    record = {
+      "id": record_id, "type": "pr", "repo": "mobius-os/app-demo",
+      "status": "open", "branch": branch, "number": position,
+      "plan": {
+        "action": "pr", "repo": "mobius-os/app-demo", "branch": branch,
+        "repo_path": str(repo),
+        "base_sha": "b" * 40 if position == 1 else parent,
+        "head_sha": parent if position == 1 else "c" * 40,
+        "stack": {
+          "id": stack_id, "position": position, "total": 2,
+          "parent_record_id": "" if position == 1 else ids[0],
+          "base_branch": "main" if position == 1 else f"stack/{stack_id}/01-layer",
+        },
+      },
+    }
+    _write_contribution(app_id, record_id, record, "reviewed")
+
+  monkeypatch.setattr(
+    "app.routes.github._land_reviewed_stack",
+    lambda rows: (_ for _ in ()).throw(ContributionSubmitError("CI is still running.")),
+  )
+  response = client.post(
+    f"/api/github/contributions/{app_id}/land-stack",
+    headers={"Authorization": f"Bearer {owner_token}"},
+    json={"record_ids": ids},
+  )
+
+  assert response.status_code == 409
+  assert [record["status"] for record in response.json()["detail"]["records"]] == [
+    "open", "open",
+  ]
+  assert all(
+    record["last_land_error"] == "CI is still running."
+    for record in response.json()["detail"]["records"]
+  )
+
+
+def test_stack_landing_requires_every_pr_check_to_be_green(monkeypatch, tmp_path):
+  from app.routes.github import ContributionSubmitError, _assert_pr_checks_green
+
+  record = {
+    "number": 17,
+    "url": "https://github.com/mobius-os/app-demo/pull/17",
+  }
+
+  def fake_gh(repo, *args, check=True):
+    return _cp(json.dumps({
+      "state": "OPEN",
+      "isDraft": False,
+      "baseRefName": "main",
+      "headRefName": "stack/demo/01-layer",
+      "headRepositoryOwner": {"login": "mobius-os"},
+      "url": record["url"],
+      "statusCheckRollup": [{
+        "__typename": "CheckRun", "name": "test",
+        "status": "IN_PROGRESS", "conclusion": "",
+      }],
+    }))
+
+  monkeypatch.setattr("app.routes.github._gh", fake_gh)
+  with pytest.raises(ContributionSubmitError, match="still has CI running"):
+    _assert_pr_checks_green(
+      tmp_path,
+      upstream_repo="mobius-os/app-demo",
+      record=record,
+      base_branch="main",
+      head_branch="stack/demo/01-layer",
+    )
+
+
+def test_stack_landing_accepts_successful_neutral_and_skipped_checks(
+  monkeypatch, tmp_path,
+):
+  from app.routes.github import _assert_pr_checks_green
+
+  record = {
+    "number": 18,
+    "url": "https://github.com/mobius-os/app-demo/pull/18",
+  }
+
+  def fake_gh(repo, *args, check=True):
+    return _cp(json.dumps({
+      "state": "OPEN",
+      "isDraft": False,
+      "baseRefName": "main",
+      "headRefName": "stack/demo/01-layer",
+      "headRepositoryOwner": {"login": "mobius-os"},
+      "url": record["url"],
+      "statusCheckRollup": [
+        {"__typename": "CheckRun", "name": "test", "status": "COMPLETED", "conclusion": "SUCCESS"},
+        {"__typename": "CheckRun", "name": "optional", "status": "COMPLETED", "conclusion": "NEUTRAL"},
+        {"__typename": "CheckRun", "name": "paths", "status": "COMPLETED", "conclusion": "SKIPPED"},
+        {"__typename": "StatusContext", "context": "external", "state": "SUCCESS"},
+      ],
+    }))
+
+  monkeypatch.setattr("app.routes.github._gh", fake_gh)
+  _assert_pr_checks_green(
+    tmp_path,
+    upstream_repo="mobius-os/app-demo",
+    record=record,
+    base_branch="main",
+    head_branch="stack/demo/01-layer",
+  )
+
+
+def test_stack_landing_never_bypasses_protected_branch(monkeypatch, tmp_path):
+  from app.routes.github import ContributionSubmitError, _assert_unprotected_landing_target
+
+  calls = []
+
+  def fake_gh(repo, *args, check=True):
+    calls.append(args)
+    return _cp('{"required_status_checks": {}}')
+
+  monkeypatch.setattr("app.routes.github._gh", fake_gh)
+  with pytest.raises(ContributionSubmitError, match="is protected"):
+    _assert_unprotected_landing_target(tmp_path, "mobius-os/mobius", "main")
+  assert len(calls) == 1
+
+
+def test_stack_tip_push_uses_exact_base_lease(monkeypatch, tmp_path):
+  from app.routes.github import _push_stack_tip_with_lease
+
+  calls = []
+
+  def fake_git(repo, *args, check=True):
+    calls.append(args)
+    return _cp("")
+
+  monkeypatch.setattr("app.routes.github._git", fake_git)
+  _push_stack_tip_with_lease(
+    tmp_path,
+    upstream_repo="mobius-os/app-demo",
+    target_branch="main",
+    expected_base="b" * 40,
+    landed_sha="c" * 40,
+  )
+  assert calls == [(
+    "push",
+    f"--force-with-lease=refs/heads/main:{'b' * 40}",
+    "https://github.com/mobius-os/app-demo.git",
+    f"{'c' * 40}:refs/heads/main",
+  )]
+
+
+def test_stack_tip_push_reconciles_a_lost_success_response(monkeypatch, tmp_path):
+  from app.routes.github import _push_stack_tip_with_lease
+
+  landed_sha = "c" * 40
+  git_calls = []
+  gh_calls = []
+
+  def fake_git(repo, *args, check=True):
+    git_calls.append(args)
+    return _cp("", returncode=1, stderr="remote end hung up unexpectedly")
+
+  def fake_gh(repo, *args, check=True):
+    gh_calls.append(args)
+    return _cp(landed_sha)
+
+  monkeypatch.setattr("app.routes.github._git", fake_git)
+  monkeypatch.setattr("app.routes.github._gh", fake_gh)
+  _push_stack_tip_with_lease(
+    tmp_path,
+    upstream_repo="mobius-os/app-demo",
+    target_branch="main",
+    expected_base="b" * 40,
+    landed_sha=landed_sha,
+  )
+
+  assert len(git_calls) == 1
+  assert gh_calls == [(
+    "api", "repos/mobius-os/app-demo/git/ref/heads/main",
+    "--jq", ".object.sha",
+  )]
+
+
 def test_submit_contribution_rejects_branch_diff_mismatch(
   client, owner_token, monkeypatch,
 ):

--- a/backend/tests/test_github_routes.py
+++ b/backend/tests/test_github_routes.py
@@ -3322,6 +3322,55 @@ def test_land_contribution_stack_marks_every_layer_merged(
     "merged", "merged",
   ]
 
+  storage = (
+    Path(get_settings().data_dir) / "apps" / str(app_id) / "contributions"
+  )
+  reconcile_statuses = []
+
+  def fake_reconcile(rows):
+    reconcile_statuses.append([row["record"]["status"] for row in rows])
+    return "main", top_head
+
+  monkeypatch.setattr(
+    "app.routes.github._reconcile_stack_landing", fake_reconcile,
+  )
+
+  # A process exit while recording success can leave one durable layer merged
+  # and its sibling still landing. The next identical request reconciles the
+  # shared journal and finishes the record writes without another push.
+  first = json.loads((storage / f"{record_ids[0]}.json").read_text())
+  second = json.loads((storage / f"{record_ids[1]}.json").read_text())
+  second["status"] = "landing"
+  atomic_write(storage / f"{record_ids[1]}.json", json.dumps(second))
+  mixed_success = client.post(
+    f"/api/github/contributions/{app_id}/land-stack",
+    headers={"Authorization": f"Bearer {app_token}"},
+    json={"record_ids": record_ids},
+  )
+  assert mixed_success.status_code == 200, mixed_success.text
+  assert reconcile_statuses[-1] == ["merged", "landing"]
+  assert [record["status"] for record in mixed_success.json()["records"]] == [
+    "merged", "merged",
+  ]
+
+  # A process exit during the initial claim (or while reopening a proven
+  # pre-push failure) leaves open/landing. Complete the exact saved journal
+  # first, then reconcile upstream just like an all-landing retry.
+  first["status"] = "open"
+  second["status"] = "landing"
+  atomic_write(storage / f"{record_ids[0]}.json", json.dumps(first))
+  atomic_write(storage / f"{record_ids[1]}.json", json.dumps(second))
+  mixed_claim = client.post(
+    f"/api/github/contributions/{app_id}/land-stack",
+    headers={"Authorization": f"Bearer {app_token}"},
+    json={"record_ids": record_ids},
+  )
+  assert mixed_claim.status_code == 200, mixed_claim.text
+  assert reconcile_statuses[-1] == ["landing", "landing"]
+  assert [record["status"] for record in mixed_claim.json()["records"]] == [
+    "merged", "merged",
+  ]
+
 
 def test_land_contribution_stack_restores_open_records_on_preflight_failure(
   client, owner_token, monkeypatch,

--- a/backend/tests/test_github_routes.py
+++ b/backend/tests/test_github_routes.py
@@ -3373,6 +3373,29 @@ def test_land_contribution_stack_restores_open_records_on_preflight_failure(
     for record in response.json()["detail"]["records"]
   )
 
+  # Once the irreversible push has started, an unreadable upstream ref is not
+  # proof of failure. Keep the journal claimed so a later request can reconcile
+  # the accepted push instead of reopening the stack and risking a duplicate.
+  monkeypatch.setattr(
+    "app.routes.github._land_reviewed_stack",
+    lambda rows: (_ for _ in ()).throw(ContributionSubmitError(
+      "Landing result is not confirmed.",
+      status_code=503,
+      code="landing_unconfirmed",
+    )),
+  )
+  uncertain = client.post(
+    f"/api/github/contributions/{app_id}/land-stack",
+    headers={"Authorization": f"Bearer {owner_token}"},
+    json={"record_ids": ids},
+  )
+
+  assert uncertain.status_code == 503
+  assert uncertain.json()["detail"]["code"] == "landing_unconfirmed"
+  assert [record["status"] for record in uncertain.json()["detail"]["records"]] == [
+    "landing", "landing",
+  ]
+
 
 def test_stack_landing_requires_every_pr_check_to_be_green(monkeypatch, tmp_path):
   from app.routes.github import ContributionSubmitError, _assert_pr_checks_green
@@ -3513,6 +3536,36 @@ def test_stack_tip_push_reconciles_a_lost_success_response(monkeypatch, tmp_path
     "api", "repos/mobius-os/app-demo/git/ref/heads/main",
     "--jq", ".object.sha",
   )]
+
+
+def test_stack_tip_push_keeps_journal_when_result_cannot_be_read(
+  monkeypatch, tmp_path,
+):
+  from app.routes.github import ContributionSubmitError, _push_stack_tip_with_lease
+
+  monkeypatch.setattr("app.routes.github._PUSH_RETRIES", 1)
+  monkeypatch.setattr(
+    "app.routes.github._git",
+    lambda repo, *args, check=True: _cp(
+      "", returncode=1, stderr="remote end hung up unexpectedly",
+    ),
+  )
+  monkeypatch.setattr(
+    "app.routes.github._upstream_branch_sha",
+    lambda *args, **kwargs: None,
+  )
+
+  with pytest.raises(ContributionSubmitError) as caught:
+    _push_stack_tip_with_lease(
+      tmp_path,
+      upstream_repo="mobius-os/app-demo",
+      target_branch="main",
+      expected_base="b" * 40,
+      landed_sha="c" * 40,
+    )
+
+  assert caught.value.status_code == 503
+  assert caught.value.code == "landing_unconfirmed"
 
 
 def test_submit_contribution_rejects_branch_diff_mismatch(


### PR DESCRIPTION
## Summary

- journal the exact target branch, expected base, and reviewed stack tip before any irreversible push
- revalidate every stored diff, commit, public branch, pull-request relationship, CI result, protection rule, and repository rule
- advance an unchanged unprotected app branch with an exact OID lease
- reconcile accepted pushes after lost responses or restarts without issuing a second push
- reopen records only when GitHub proves the push did not happen; preserve the landing journal while the result is unknowable

## Safety model

This path is deliberately limited to complete green stacks in app repositories whose target branch has no protection or active repository rules. The Möbius platform keeps GitHub's normal protected merge flow. A changed base, branch, PR topology, check result, reviewed diff, or commit stops the operation without overwriting upstream.

## Prior work

This reworks and supersedes closed PR #125. That version could lose the distinction between “push accepted” and “response lost,” allowing the ledger to reopen after an ambiguous result. The revised design writes the recovery journal first, uses an exact-base lease, treats an unreadable post-push ref as unresolved rather than failed, and converges repeated requests by reading upstream before deciding whether to settle or reopen.

## Testing

- `backend/tests/test_github_routes.py` (115 passed)
- combined current-base platform review suite for this change, provider accounting, and browser quota (162 passed)
- crash/lost-response, exact-lease, protected-branch, PR-topology, and CI-result coverage
- canonical diff and attribution checks