### PR TITLE
Enforce browser profile storage as a hard quota

### DIFF
--- a/backend/app/browser_profiles.py
+++ b/backend/app/browser_profiles.py
@@ -238,13 +238,14 @@ def enforce_browser_profile_quota(
   inactive_days: int | None = None,
   active_profile_names: set[str] | None = None,
 ) -> dict:
-  """Prune caches, then enough inactive profiles to honor the byte budget.
+  """Prune caches, then inactive chat profiles to honor the byte budget.
 
   ``inactive_days`` is a preferred retention window, not permission for the
-  profile tree to grow past ``max_bytes``. Deleted, missing, and expired chat
-  profiles yield first. If those cannot restore the low-water mark, the oldest
-  remaining inactive profiles yield too; live browser and chat sessions never
-  do.
+  ordinary per-chat tree to grow past ``max_bytes``. Deleted, missing, and
+  expired chat profiles yield first. If those cannot restore the low-water
+  mark, the oldest remaining inactive chat profiles yield too. Live sessions
+  never do, and deliberately named sessions retain their full inactivity grace.
+  Any protected overage is reported rather than mislabelled as reclaimed.
   """
   root = Path(data_dir) / "agent-browser-profiles"
   now = now or datetime.now(UTC).replace(tzinfo=None)
@@ -291,8 +292,9 @@ def enforce_browser_profile_quota(
       )
       if chat_id is None:
         # Named/legacy profiles are included in the byte budget and cache
-        # pruning. Their durable state gets the preferred inactivity grace,
-        # then joins the pressure fallback if the hard budget still cannot hold.
+        # pruning, but their durable state receives the full inactivity grace.
+        # Named sessions are deliberately long-lived; unlike ordinary chat
+        # profiles, a recent one never joins the pressure fallback.
         retire_first = not active and age_seconds >= cutoff_seconds
       else:
         retire_first = not active and (
@@ -324,7 +326,14 @@ def enforce_browser_profile_quota(
       key=lambda profile: profile["activity"],
     )
     profile_candidates = sorted(
-      (profile for profile in profiles if not profile["active"]),
+      (
+        profile for profile in profiles
+        if not profile["active"]
+        and (
+          profile["chat_id"] is not None
+          or profile["retire_first"]
+        )
+      ),
       key=lambda profile: (
         not profile["retire_first"],
         profile["activity"],

--- a/backend/app/browser_profiles.py
+++ b/backend/app/browser_profiles.py
@@ -37,6 +37,9 @@ _status = {
   "profile_count": 0,
   "bytes_before": 0,
   "bytes_after": 0,
+  "max_bytes": 0,
+  "low_water_bytes": 0,
+  "over_quota_bytes": 0,
   "reclaimed_bytes": 0,
   "cache_dirs_pruned": 0,
   "profiles_pruned": 0,
@@ -95,7 +98,10 @@ def _tree_bytes(path: Path) -> int:
     for root, _dirs, files in os.walk(path):
       for name in files:
         try:
-          total += (Path(root) / name).stat().st_size
+          candidate = Path(root) / name
+          if candidate.is_symlink():
+            continue
+          total += candidate.stat().st_size
         except OSError:
           pass
   except OSError:
@@ -232,7 +238,14 @@ def enforce_browser_profile_quota(
   inactive_days: int | None = None,
   active_profile_names: set[str] | None = None,
 ) -> dict:
-  """Prune regenerable caches, then oldest inactive profiles, at high water."""
+  """Prune caches, then enough inactive profiles to honor the byte budget.
+
+  ``inactive_days`` is a preferred retention window, not permission for the
+  profile tree to grow past ``max_bytes``. Deleted, missing, and expired chat
+  profiles yield first. If those cannot restore the low-water mark, the oldest
+  remaining inactive profiles yield too; live browser and chat sessions never
+  do.
+  """
   root = Path(data_dir) / "agent-browser-profiles"
   now = now or datetime.now(UTC).replace(tzinfo=None)
   default_max_bytes, default_low_water_bytes = default_browser_profile_quota()
@@ -278,10 +291,11 @@ def enforce_browser_profile_quota(
       )
       if chat_id is None:
         # Named/legacy profiles are included in the byte budget and cache
-        # pruning, but their durable state receives the full inactivity grace.
-        eligible = not active and age_seconds >= cutoff_seconds
+        # pruning. Their durable state gets the preferred inactivity grace,
+        # then joins the pressure fallback if the hard budget still cannot hold.
+        retire_first = not active and age_seconds >= cutoff_seconds
       else:
-        eligible = not active and (
+        retire_first = not active and (
           chat is None
           or chat.get("deleted_at") is not None
           or age_seconds >= cutoff_seconds
@@ -290,16 +304,17 @@ def enforce_browser_profile_quota(
         "path": path,
         "chat_id": chat_id,
         "activity": activity,
-        "eligible": eligible,
+        "retire_first": retire_first,
         "active": active,
         "size": _tree_bytes(path),
       })
 
   bytes_before = sum(profile["size"] for profile in profiles)
   total = bytes_before
+  pressure_triggered = total > max_bytes
   cache_dirs_pruned = 0
   profiles_pruned = 0
-  if total > max_bytes:
+  if pressure_triggered:
     # Chromium caches are disposable even for recently used chats. Prune them
     # from every CLOSED profile before considering deletion of any durable
     # profile state. Active profiles are excluded because Chromium may have
@@ -309,8 +324,11 @@ def enforce_browser_profile_quota(
       key=lambda profile: profile["activity"],
     )
     profile_candidates = sorted(
-      (profile for profile in profiles if profile["eligible"]),
-      key=lambda profile: profile["activity"],
+      (profile for profile in profiles if not profile["active"]),
+      key=lambda profile: (
+        not profile["retire_first"],
+        profile["activity"],
+      ),
     )
     for profile in cache_candidates:
       for rel in _CACHE_PATHS:
@@ -325,7 +343,7 @@ def enforce_browser_profile_quota(
       if total <= low_water_bytes:
         break
 
-    if total > max_bytes:
+    if total > low_water_bytes:
       for profile in profile_candidates:
         if not profile["path"].exists():
           continue
@@ -345,6 +363,9 @@ def enforce_browser_profile_quota(
     ),
     "bytes_before": bytes_before,
     "bytes_after": total,
+    "max_bytes": max_bytes,
+    "low_water_bytes": low_water_bytes,
+    "over_quota_bytes": max(0, total - max_bytes),
     "reclaimed_bytes": max(0, bytes_before - total),
     "cache_dirs_pruned": cache_dirs_pruned,
     "profiles_pruned": profiles_pruned,

--- a/backend/tests/test_browser_profiles.py
+++ b/backend/tests/test_browser_profiles.py
@@ -515,6 +515,40 @@ def test_quota_never_prunes_live_named_profile(tmp_path):
   assert result["reclaimed_bytes"] == 0
 
 
+def test_quota_preserves_recent_inactive_named_profile_under_pressure(tmp_path):
+  profile = _named_profile(
+    tmp_path, "reflection", cache_bytes=0, durable_bytes=20,
+  )
+  now = datetime.now(UTC).replace(tzinfo=None)
+
+  result = enforce_browser_profile_quota(
+    tmp_path, {}, set(), now=now, max_bytes=10, low_water_bytes=0,
+    inactive_days=30, active_profile_names=set(),
+  )
+
+  assert profile.exists()
+  assert result["profiles_pruned"] == 0
+  assert result["bytes_after"] == 20
+  assert result["over_quota_bytes"] == 10
+
+
+def test_quota_prunes_named_profile_after_its_full_grace(tmp_path):
+  profile = _named_profile(
+    tmp_path, "reflection", cache_bytes=0, durable_bytes=20,
+  )
+  now = datetime.now(UTC).replace(tzinfo=None) + timedelta(days=31)
+
+  result = enforce_browser_profile_quota(
+    tmp_path, {}, set(), now=now, max_bytes=10, low_water_bytes=0,
+    inactive_days=30, active_profile_names=set(),
+  )
+
+  assert not profile.exists()
+  assert result["profiles_pruned"] == 1
+  assert result["bytes_after"] == 0
+  assert result["over_quota_bytes"] == 0
+
+
 def test_quota_ignores_symlinked_profile_directory(tmp_path):
   root = tmp_path / "agent-browser-profiles"
   root.mkdir()

--- a/backend/tests/test_browser_profiles.py
+++ b/backend/tests/test_browser_profiles.py
@@ -383,6 +383,103 @@ def test_quota_prunes_recent_closed_cache_before_old_durable_profile(tmp_path):
   assert result["profiles_pruned"] == 0
 
 
+def test_quota_retires_oldest_recent_profile_when_grace_exceeds_budget(
+  tmp_path,
+):
+  older = "55555555-5555-5555-5555-555555555555"
+  newer = "66666666-6666-6666-6666-666666666666"
+  older_profile = _profile(
+    tmp_path, older, cache_bytes=0, durable_bytes=40,
+  )
+  newer_profile = _profile(
+    tmp_path, newer, cache_bytes=0, durable_bytes=70,
+  )
+  now = datetime.now(UTC).replace(tzinfo=None)
+
+  result = enforce_browser_profile_quota(
+    tmp_path,
+    {
+      older: {"activity_at": now - timedelta(days=2),
+              "deleted_at": None, "run_status": None},
+      newer: {"activity_at": now - timedelta(days=1),
+              "deleted_at": None, "run_status": None},
+    },
+    set(),
+    now=now,
+    max_bytes=100,
+    low_water_bytes=70,
+    inactive_days=30,
+  )
+
+  assert not older_profile.exists()
+  assert newer_profile.exists()
+  assert result["profiles_pruned"] == 1
+  assert result["bytes_after"] == 70
+  assert result["over_quota_bytes"] == 0
+
+
+def test_triggered_quota_finishes_at_low_water_after_partial_cache_reclaim(
+  tmp_path,
+):
+  older = "88888888-8888-8888-8888-888888888888"
+  newer = "99999999-9999-9999-9999-999999999999"
+  older_profile = _profile(
+    tmp_path, older, cache_bytes=20, durable_bytes=30,
+  )
+  newer_profile = _profile(
+    tmp_path, newer, cache_bytes=0, durable_bytes=60,
+  )
+  now = datetime.now(UTC).replace(tzinfo=None)
+
+  result = enforce_browser_profile_quota(
+    tmp_path,
+    {
+      older: {"activity_at": now - timedelta(days=2),
+              "deleted_at": None, "run_status": None},
+      newer: {"activity_at": now - timedelta(days=1),
+              "deleted_at": None, "run_status": None},
+    },
+    set(),
+    now=now,
+    max_bytes=100,
+    low_water_bytes=70,
+    inactive_days=30,
+  )
+
+  # Cache pruning lowers 110 to 90, below the high-water ceiling but above the
+  # low-water target. The already-triggered sweep completes the cycle instead
+  # of leaving the next small write to retrigger it.
+  assert not older_profile.exists()
+  assert newer_profile.exists()
+  assert result["cache_dirs_pruned"] == 2
+  assert result["profiles_pruned"] == 1
+  assert result["bytes_after"] == 60
+
+
+def test_quota_reports_when_live_profiles_alone_exceed_the_budget(tmp_path):
+  live = "77777777-7777-7777-7777-777777777777"
+  profile = _profile(tmp_path, live, cache_bytes=80, durable_bytes=20)
+  now = datetime.now(UTC).replace(tzinfo=None)
+
+  result = enforce_browser_profile_quota(
+    tmp_path,
+    {live: {"activity_at": now, "deleted_at": None,
+            "run_status": "running"}},
+    {live},
+    now=now,
+    max_bytes=50,
+    low_water_bytes=25,
+    inactive_days=30,
+  )
+
+  assert profile.exists()
+  assert result["reclaimed_bytes"] == 0
+  assert result["bytes_after"] == 100
+  assert result["max_bytes"] == 50
+  assert result["low_water_bytes"] == 25
+  assert result["over_quota_bytes"] == 50
+
+
 def test_quota_counts_and_prunes_cache_from_closed_named_profile(tmp_path):
   profile = _named_profile(
     tmp_path, "reflection", cache_bytes=100, durable_bytes=20,
@@ -451,10 +548,33 @@ def test_quota_ignores_symlinked_cache_directory(tmp_path):
 
   result = enforce_browser_profile_quota(
     tmp_path, {}, set(), max_bytes=1, low_water_bytes=0,
-    inactive_days=30, active_profile_names=set(),
+    inactive_days=30, active_profile_names={"reflection"},
   )
 
   assert outside_cache.exists()
   assert (outside_cache / "cache.bin").exists()
   assert (default / "Cache").is_symlink()
   assert result["cache_dirs_pruned"] == 0
+  assert result["over_quota_bytes"] == 19
+
+
+def test_quota_does_not_count_or_reclaim_symlinked_file_targets(tmp_path):
+  profile = tmp_path / "agent-browser-profiles" / "reflection"
+  durable = profile / "Default" / "IndexedDB"
+  durable.mkdir(parents=True)
+  (durable / "state.bin").write_bytes(b"d" * 20)
+  outside = tmp_path / "outside.bin"
+  outside.write_bytes(b"x" * 100)
+  (durable / "outside.bin").symlink_to(outside)
+
+  result = enforce_browser_profile_quota(
+    tmp_path, {}, set(), max_bytes=10, low_water_bytes=0,
+    inactive_days=30, active_profile_names={"reflection"},
+  )
+
+  assert outside.read_bytes() == b"x" * 100
+  assert (durable / "outside.bin").is_symlink()
+  assert result["bytes_before"] == 20
+  assert result["bytes_after"] == 20
+  assert result["reclaimed_bytes"] == 0
+  assert result["over_quota_bytes"] == 10


### PR DESCRIPTION
## Summary

- reclaim inactive per-chat browser profiles when cache pruning alone cannot restore the low-water target
- preserve active profiles and recent deliberately named sessions
- ignore symlink targets while measuring and reclaiming profile storage
- report protected overage instead of claiming a quota was restored when live or named state prevents it

## Why

The existing inactivity grace acts as a soft retention rule, so closed per-chat profiles can leave a small volume above its configured browser budget. This change makes the configured high/low-water policy real while preserving the sessions that are active or deliberately long-lived.

This advances the browser-profile part of #160. The broader issue also covers platform recovery trees, capacity diagnostics, and admission checks, which remain outside this PR.

## Testing

- `backend/tests/test_browser_profiles.py` (20 passed)
- combined current-base platform review suite for this change, provider accounting, and stack landing (162 passed)
- canonical diff and attribution checks