### PR TITLE
Validate provider usage counter deltas

### DIFF
--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -1234,10 +1234,10 @@ async def _record_run_metrics(
   """
   if not chat_id or not run_token:
     return
-  # A provider can legitimately omit usage (and Codex currently omits cost).
-  # With no accounting signal there is nothing to record; avoiding a no-op
-  # actor round-trip also preserves the runner's connection-release contract.
-  if usage is None and cost_usd in (None, 0):
+  # A provider can legitimately omit any one signal (Codex currently omits
+  # cost). An explicit zero cost and the provider session/thread identity are
+  # still measured facts; only a wholly empty result is a true no-op.
+  if usage is None and cost_usd is None and provider_session_id is None:
     return
   try:
     await _await_ack(get_writer().submit(RecordRunMetrics(

--- a/backend/app/usage_metrics.py
+++ b/backend/app/usage_metrics.py
@@ -138,6 +138,7 @@ def normalize_codex_usage(
   first_last = _codex_breakdown(_member(first_usage, "last"))
   baseline = _subtract_counts(first_total, first_last)
   final_total = _codex_breakdown(_member(final_usage, "total"))
+  final_last = _codex_breakdown(_member(final_usage, "last"))
 
   # A cumulative provider counter must contain its own latest call and never
   # move backwards between notifications. If an SDK/server reset violates
@@ -146,10 +147,11 @@ def normalize_codex_usage(
   counter_reset = any(
     first_total[field] < first_last[field]
     or final_total[field] < first_total[field]
+    or final_total[field] < final_last[field]
     for field in _CODEX_FIELDS
   )
   if counter_reset:
-    turn = _codex_breakdown(_member(final_usage, "last"))
+    turn = final_last
     calculation = "last_call_fallback"
   else:
     turn = _subtract_counts(final_total, baseline)

--- a/backend/app/usage_metrics.py
+++ b/backend/app/usage_metrics.py
@@ -139,10 +139,16 @@ def normalize_codex_usage(
   baseline = _subtract_counts(first_total, first_last)
   final_total = _codex_breakdown(_member(final_usage, "total"))
 
-  # A cumulative provider counter should never go backwards. If an SDK/server
-  # reset makes it do so, the only honest bounded fallback is the latest call;
+  # A cumulative provider counter must contain its own latest call and never
+  # move backwards between notifications. If an SDK/server reset violates
+  # either invariant, the only honest bounded fallback is the latest call;
   # retain the calculation label so benchmark consumers can exclude it.
-  if any(final_total[field] < baseline[field] for field in _CODEX_FIELDS):
+  counter_reset = any(
+    first_total[field] < first_last[field]
+    or final_total[field] < first_total[field]
+    for field in _CODEX_FIELDS
+  )
+  if counter_reset:
     turn = _codex_breakdown(_member(final_usage, "last"))
     calculation = "last_call_fallback"
   else:

--- a/backend/tests/test_agent_turn_releases_db_connection.py
+++ b/backend/tests/test_agent_turn_releases_db_connection.py
@@ -176,6 +176,13 @@ async def test_agent_turn_returns_connection_while_provider_is_running(
     chat_mod, "get_provider", lambda _provider_id: _Provider(provider_name),
   )
   monkeypatch.setattr(chat_mod, "_complete_turn", fake_complete_turn)
+  # This test intentionally bypasses the normal durable run claim. Isolate
+  # its connection-ownership assertion from the post-provider accounting
+  # write, which is covered by the chat-run metrics tests.
+  async def fake_record_run_metrics(**_kwargs):
+    return None
+
+  monkeypatch.setattr(chat_mod, "_record_run_metrics", fake_record_run_metrics)
   if provider_id == "codex":
     from app import codex_sdk_runner
     monkeypatch.setattr(codex_sdk_runner, "run_codex_sdk_turn", fake_runner)

--- a/backend/tests/test_chat_runs.py
+++ b/backend/tests/test_chat_runs.py
@@ -10,6 +10,9 @@ starts one bound to the test DB) and the real `reconcile_interrupted_chats`, so
 they cover the wired dual-write + reconciliation maintenance, not a mock.
 """
 
+import asyncio
+from concurrent.futures import Future
+
 from app import chat as chat_mod
 from app import models
 from app.chat_writer import (
@@ -168,6 +171,41 @@ def test_record_run_metrics_updates_exact_run_without_touching_transcript():
     assert chat.messages == [{"role": "user", "content": "keep me", "ts": 1}]
   finally:
     db.close()
+
+
+def test_record_run_metrics_keeps_session_identity_and_explicit_zero_cost(
+  monkeypatch,
+):
+  commands = []
+
+  class Writer:
+    def submit(self, command):
+      commands.append(command)
+      ack = Future()
+      ack.set_result(True)
+      return ack
+
+  monkeypatch.setattr(chat_mod, "get_writer", lambda: Writer())
+
+  asyncio.run(chat_mod._record_run_metrics(
+    chat_id="r-metrics",
+    run_token="rt-session-only",
+    provider_session_id="provider-thread",
+    cost_usd=0,
+    usage=None,
+  ))
+  asyncio.run(chat_mod._record_run_metrics(
+    chat_id="r-metrics",
+    run_token="rt-empty",
+    provider_session_id=None,
+    cost_usd=None,
+    usage=None,
+  ))
+
+  assert len(commands) == 1
+  assert commands[0].provider_session_id == "provider-thread"
+  assert commands[0].cost_usd == 0
+  assert commands[0].usage is None
 
 
 # -- continuation handoff -------------------------------------------------

--- a/backend/tests/test_usage_metrics.py
+++ b/backend/tests/test_usage_metrics.py
@@ -140,3 +140,91 @@ def test_codex_counter_reset_uses_labelled_latest_call_fallback():
   assert usage["calculation"] == "last_call_fallback"
   assert usage["input_tokens"] == 80
   assert usage["total_tokens"] == 100
+
+
+def test_codex_partial_counter_rollback_uses_latest_call_fallback():
+  first = {
+    "last": {
+      "inputTokens": 200,
+      "cachedInputTokens": 100,
+      "outputTokens": 100,
+      "reasoningOutputTokens": 50,
+      "totalTokens": 300,
+    },
+    "total": {
+      "inputTokens": 1_000,
+      "cachedInputTokens": 400,
+      "outputTokens": 100,
+      "reasoningOutputTokens": 50,
+      "totalTokens": 1_100,
+    },
+  }
+  final = {
+    "last": {
+      "inputTokens": 80,
+      "cachedInputTokens": 40,
+      "outputTokens": 20,
+      "reasoningOutputTokens": 10,
+      "totalTokens": 100,
+    },
+    # Still above the inferred 800-token baseline, but below the first
+    # cumulative total. Treating this as a delta would silently report only 50
+    # tokens even though the latest call alone used 100.
+    "total": {
+      "inputTokens": 820,
+      "cachedInputTokens": 350,
+      "outputTokens": 90,
+      "reasoningOutputTokens": 40,
+      "totalTokens": 850,
+    },
+  }
+
+  usage = normalize_codex_usage(first, final)
+
+  assert usage is not None
+  assert usage["calculation"] == "last_call_fallback"
+  assert usage["input_tokens"] == 80
+  assert usage["total_tokens"] == 100
+
+
+def test_codex_impossible_initial_total_uses_latest_call_fallback():
+  first = {
+    "last": {
+      "inputTokens": 100,
+      "cachedInputTokens": 50,
+      "outputTokens": 20,
+      "reasoningOutputTokens": 10,
+      "totalTokens": 120,
+    },
+    # A cumulative total cannot be smaller than the call it contains.
+    "total": {
+      "inputTokens": 80,
+      "cachedInputTokens": 40,
+      "outputTokens": 10,
+      "reasoningOutputTokens": 5,
+      "totalTokens": 90,
+    },
+  }
+  final = {
+    "last": {
+      "inputTokens": 60,
+      "cachedInputTokens": 30,
+      "outputTokens": 20,
+      "reasoningOutputTokens": 10,
+      "totalTokens": 80,
+    },
+    "total": {
+      "inputTokens": 140,
+      "cachedInputTokens": 70,
+      "outputTokens": 30,
+      "reasoningOutputTokens": 15,
+      "totalTokens": 170,
+    },
+  }
+
+  usage = normalize_codex_usage(first, final)
+
+  assert usage is not None
+  assert usage["calculation"] == "last_call_fallback"
+  assert usage["input_tokens"] == 60
+  assert usage["total_tokens"] == 80

--- a/backend/tests/test_usage_metrics.py
+++ b/backend/tests/test_usage_metrics.py
@@ -228,3 +228,47 @@ def test_codex_impossible_initial_total_uses_latest_call_fallback():
   assert usage["calculation"] == "last_call_fallback"
   assert usage["input_tokens"] == 60
   assert usage["total_tokens"] == 80
+
+
+def test_codex_impossible_final_total_uses_latest_call_fallback():
+  first = {
+    "last": {
+      "inputTokens": 20,
+      "cachedInputTokens": 10,
+      "outputTokens": 10,
+      "reasoningOutputTokens": 5,
+      "totalTokens": 30,
+    },
+    "total": {
+      "inputTokens": 100,
+      "cachedInputTokens": 50,
+      "outputTokens": 40,
+      "reasoningOutputTokens": 20,
+      "totalTokens": 140,
+    },
+  }
+  final = {
+    # The cumulative snapshot moved forward from the first notification, but
+    # it still cannot be smaller than the latest call it claims to contain.
+    "last": {
+      "inputTokens": 180,
+      "cachedInputTokens": 90,
+      "outputTokens": 60,
+      "reasoningOutputTokens": 30,
+      "totalTokens": 240,
+    },
+    "total": {
+      "inputTokens": 160,
+      "cachedInputTokens": 80,
+      "outputTokens": 50,
+      "reasoningOutputTokens": 25,
+      "totalTokens": 210,
+    },
+  }
+
+  usage = normalize_codex_usage(first, final)
+
+  assert usage is not None
+  assert usage["calculation"] == "last_call_fallback"
+  assert usage["input_tokens"] == 180
+  assert usage["total_tokens"] == 240


### PR DESCRIPTION
## Summary

- validate cumulative provider counters before deriving per-run usage
- fall back to the latest bounded call when counters reset or contradict their own latest call
- preserve explicit zero-cost and provider-session metadata instead of dropping measured facts
- keep the connection-ownership test isolated from the separately covered accounting write

## Why

SDK counters can reset or arrive in inconsistent snapshots. Subtracting them blindly can undercount or misclassify a run while still looking valid. An explicit zero cost and a provider session identifier are also useful observations, not missing data.

## Testing

- `backend/tests/test_usage_metrics.py`, `test_chat_runs.py`, and `test_agent_turn_releases_db_connection.py` (27 passed)
- combined current-base platform review suite for this change, browser quota, and stack landing (162 passed)
- canonical diff and attribution checks