### PR TITLE
Ground agent actions in observed UI and durable resource IDs

### DIFF
--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -4053,24 +4053,77 @@ def _build_app_context(
   chat_id: str,
   data_dir: str,
 ) -> tuple[str | None, dict[str, str]]:
-  """Return per-app chat context and environment for app-attributed chats.
+  """Return exact app identity context for app-attributed or owning chats.
 
   Embedded app chats need the agent to know which app invoked it and where
   that app's editable source lives. The chat row already carries
   `created_by_app_id`; this turns that attribution into prompt context.
+
+  Ordinary build chats can also own apps through ``App.chat_id``. Carry those
+  durable numeric identities into later turns so a resumed/compacted agent
+  does not have to rediscover an app by its non-unique display name.
   """
   if not chat_id:
     return None, {}
   chat = db.query(models.Chat).filter(models.Chat.id == chat_id).first()
-  if chat is None or chat.created_by_app_id is None:
+  if chat is None:
     return None, {}
+  data_root = Path(data_dir)
+
+  if chat.created_by_app_id is None:
+    linked = (
+      db.query(models.App)
+      .filter(
+        models.App.chat_id == chat_id,
+        models.App.deleted_at.is_(None),
+      )
+      .order_by(models.App.id)
+      .all()
+    )
+    if not linked:
+      return None, {}
+    identities = []
+    for linked_app in linked:
+      source_dir = (
+        Path(linked_app.source_dir)
+        if linked_app.source_dir
+        else data_root / "apps" / (linked_app.slug or str(linked_app.id))
+      )
+      identities.append({
+        "app_id": linked_app.id,
+        "name": linked_app.name,
+        "slug": linked_app.slug,
+        "source_dir": str(source_dir),
+        "storage_dir": str(data_root / "apps" / str(linked_app.id)),
+      })
+    compact = json.dumps(
+      identities, ensure_ascii=False, separators=(",", ":"),
+    )
+    block = "\n".join([
+      "The <linked_apps> block carries apps maintained by this chat.",
+      "App names are not unique; reuse the numeric app_id for later actions.",
+      "<linked_apps>",
+      compact,
+      "</linked_apps>",
+    ])
+    env = {"CHAT_APPS_JSON": compact}
+    if len(identities) == 1:
+      identity = identities[0]
+      env.update({
+        "APP_ID": str(identity["app_id"]),
+        "APP_NAME": identity["name"] or "",
+        "APP_SOURCE_DIR": identity["source_dir"],
+        "APP_PRIMARY_FILE": str(Path(identity["source_dir"]) / "index.jsx"),
+        "APP_STORAGE_DIR": identity["storage_dir"],
+      })
+    return block, env
+
   app = db.query(models.App).filter(
     models.App.id == chat.created_by_app_id
   ).first()
   if app is None:
     return None, {}
 
-  data_root = Path(data_dir)
   source_dir = Path(app.source_dir) if app.source_dir else (
     data_root / "apps" / (app.slug or str(app.id))
   )

--- a/backend/scripts/apply_app.py
+++ b/backend/scripts/apply_app.py
@@ -13,6 +13,23 @@ def _usage() -> None:
   print("Usage: apply_app.py <source-dir>", file=sys.stderr)
 
 
+def _receipt(result: dict) -> dict:
+  app = result.get("app")
+  if not isinstance(app, dict) or not isinstance(app.get("id"), int):
+    raise ValueError("App apply response did not include a numeric app id.")
+  app_id = app["id"]
+  return {
+    "mode": result.get("mode"),
+    "app_id": app_id,
+    "name": app.get("name"),
+    "slug": app.get("slug"),
+    "source_dir": app.get("source_dir"),
+    "chat_id": app.get("chat_id"),
+    "preview_path": f"/app/{app_id}",
+    "open_path": f"/shell/?app={app_id}",
+  }
+
+
 def main() -> None:
   if len(sys.argv) != 2:
     _usage()
@@ -62,7 +79,12 @@ def main() -> None:
   except urllib.error.URLError as exc:
     print(f"App apply failed: {exc.reason}", file=sys.stderr)
     raise SystemExit(1) from exc
-  print(json.dumps(result, ensure_ascii=False))
+  try:
+    receipt = _receipt(result)
+  except ValueError as exc:
+    print(f"App apply failed: {exc}", file=sys.stderr)
+    raise SystemExit(1) from exc
+  print(json.dumps(receipt, ensure_ascii=False, separators=(",", ":")))
 
 
 if __name__ == "__main__":

--- a/backend/scripts/delete_app.py
+++ b/backend/scripts/delete_app.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Soft-delete one exact app id and print its durable recovery receipt."""
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+
+def _args() -> argparse.Namespace:
+  parser = argparse.ArgumentParser(
+    description=(
+      "Soft-delete one numeric app id after partner confirmation and retain "
+      "the exact recovery handle."
+    ),
+  )
+  parser.add_argument("app_id", type=int)
+  parser.add_argument(
+    "--confirm",
+    action="store_true",
+    help="required acknowledgement that the partner confirmed this deletion",
+  )
+  args = parser.parse_args()
+  if not args.confirm:
+    parser.error("--confirm is required after the partner confirms deletion")
+  return args
+
+
+def _request(url: str, token: str, *, method: str = "GET") -> bytes:
+  request = urllib.request.Request(
+    url,
+    headers={"Authorization": f"Bearer {token}"},
+    method=method,
+  )
+  try:
+    with urllib.request.urlopen(request, timeout=120) as response:
+      return response.read()
+  except urllib.error.HTTPError as exc:
+    body = exc.read().decode(errors="replace")
+    try:
+      detail = json.loads(body).get("detail", body)
+    except json.JSONDecodeError:
+      detail = body
+    raise RuntimeError(
+      f"App delete failed ({exc.code}): "
+      f"{json.dumps(detail, ensure_ascii=False) if isinstance(detail, dict) else detail}"
+    ) from exc
+  except urllib.error.URLError as exc:
+    raise RuntimeError(f"App delete failed: {exc.reason}") from exc
+
+
+def main() -> None:
+  args = _args()
+  token = os.environ.get("AGENT_TOKEN")
+  if not token:
+    print("AGENT_TOKEN environment variable is not set.", file=sys.stderr)
+    raise SystemExit(1)
+  base = os.environ.get("API_BASE_URL", "http://localhost:8000").rstrip("/")
+  url = f"{base}/api/apps/{args.app_id}"
+  try:
+    app = json.loads(_request(url, token))
+    if not isinstance(app, dict) or app.get("id") != args.app_id:
+      raise RuntimeError("App lookup did not return the requested numeric id.")
+    _request(url, token, method="DELETE")
+  except (json.JSONDecodeError, RuntimeError) as exc:
+    print(str(exc), file=sys.stderr)
+    raise SystemExit(1) from exc
+  receipt = {
+    "status": "deleted",
+    "app_id": app["id"],
+    "name": app.get("name"),
+    "slug": app.get("slug"),
+    "source_dir": app.get("source_dir"),
+    "recover_path": f"/api/apps/{app['id']}/recover",
+    "recoverable_for_days": 7,
+  }
+  print(json.dumps(receipt, ensure_ascii=False, separators=(",", ":")))
+
+
+if __name__ == "__main__":
+  main()

--- a/backend/scripts/init_skills.py
+++ b/backend/scripts/init_skills.py
@@ -34,7 +34,7 @@ from pathlib import Path
 DATA_DIR = Path(os.environ.get("DATA_DIR", "/data"))
 SKILLS = DATA_DIR / "shared" / "skills"
 VERSION_FILE = SKILLS / ".seed-version"
-SEED_VERSION = "20"  # v20: ground browser selectors in observed DOM
+SEED_VERSION = "21"  # v21: carry exact app and generated-image handles
 # Update only byte-for-byte baked copies; an owner/agent-edited file is never
 # touched. A set preserves every known unmodified predecessor when one skill
 # needs more than one fix-forward migration over its lifetime.
@@ -57,6 +57,8 @@ _UNMODIFIED_MIGRATIONS = {
   },
   "images.md": {
     "248ea31e13d2d2d84a5acfca13526aa8ebfa3d90e9ee4bf55cfb72d47937f7d1",
+    # v20 baked copy: publish the exact generated image, never newest-by-time.
+    "29039a6fc5c9281794247eda5d0bbf66e969a1a260e9ed56c69ee6e1cd175f7c",
   },
   "building-apps.md": {
     "4126b40d209c422184e0135f611bb9f4197ea280fa27e63cd71c806f8b5ebd79",
@@ -64,6 +66,8 @@ _UNMODIFIED_MIGRATIONS = {
     "563dcd7bfa1ff7cbad074d98462eb9755a010a15bf340c7f594fc7f6825a6a86",
     # v17 baked copy: replace watcher publication with explicit apply.
     "a8591f03bd5fb6eb0cfcd811d6d6d4309657f2f4e9e8e11ded4cbefbd77facfd",
+    # v20 baked copy: delete by exact id and retain its recovery receipt.
+    "5a6bafaa654071c4af5a5c7a201e23e4b0294c392ccb2b9afd7c2b18e17ff3fe",
   },
   "building-apps-quickstart.md": {
     "7d8af2664b37a69b88e48c2a28140c15556202c3c7ce30d77816c203d1959fcb",
@@ -73,6 +77,8 @@ _UNMODIFIED_MIGRATIONS = {
     "85a4b5ce5b47c81fa53bec90d530adfe433c0d2f7f31363427b6c792bd332e05",
     # v18 baked copy: co-read completion policy and use compact app discovery.
     "02fda2ea04f3c0ce808ef0db4b1fe4e893924bd019a5bf102a46749ef9142510",
+    # v20 baked copy: retain the apply receipt's numeric id across the flow.
+    "68c84158a9255ab53686968ed4ec8f594c460483bec0e90dcfa472682c1d9b70",
   },
   "resolving-app-git.md": {
     # v17 baked copy: resolution is an explicit installer replay.

--- a/backend/scripts/init_skills.py
+++ b/backend/scripts/init_skills.py
@@ -34,7 +34,7 @@ from pathlib import Path
 DATA_DIR = Path(os.environ.get("DATA_DIR", "/data"))
 SKILLS = DATA_DIR / "shared" / "skills"
 VERSION_FILE = SKILLS / ".seed-version"
-SEED_VERSION = "19"  # v19: compact app discovery and bounded visual checks
+SEED_VERSION = "20"  # v20: ground browser selectors in observed DOM
 # Update only byte-for-byte baked copies; an owner/agent-edited file is never
 # touched. A set preserves every known unmodified predecessor when one skill
 # needs more than one fix-forward migration over its lifetime.
@@ -89,6 +89,8 @@ _UNMODIFIED_MIGRATIONS = {
     "a0648921b9c9ea2423e8abd52aa57e71e7bebfa1736073fcf3bfcaec3749ad19",
     # v18 baked copy: avoid measured textbox and opaque-frame wait failures.
     "5db160b2d796d54ec320119cbdbbb2860a78cfd703cfe37667626d23abc8e4d9",
+    # v19 baked copy: replace speculative selector examples with grounding.
+    "bf58243aeb1779eb0a94d5404a99c2132e55d60542cbb555fc50bc5cf65349fe",
   },
 }
 

--- a/backend/scripts/list_apps.py
+++ b/backend/scripts/list_apps.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
-"""Print the compact app identity list an agent needs before a build."""
+"""Print compact app identities, optionally narrowed by an exact field."""
 
+import argparse
 import json
 import os
 import sys
@@ -8,10 +9,41 @@ import urllib.error
 import urllib.request
 
 
+def _args() -> argparse.Namespace:
+  parser = argparse.ArgumentParser(
+    description=(
+      "List live apps. Exact filters narrow the compact result without "
+      "turning a non-unique display name into an identity."
+    ),
+  )
+  filters = parser.add_mutually_exclusive_group()
+  filters.add_argument("--id", type=int, dest="app_id")
+  filters.add_argument("--slug")
+  filters.add_argument("--source-dir")
+  filters.add_argument("--chat-id")
+  filters.add_argument(
+    "--name",
+    help="exact display-name search; may return multiple apps",
+  )
+  return parser.parse_args()
+
+
+def _matches(app: dict, args: argparse.Namespace) -> bool:
+  if args.app_id is not None:
+    return app.get("id") == args.app_id
+  if args.slug is not None:
+    return app.get("slug") == args.slug
+  if args.source_dir is not None:
+    return app.get("source_dir") == args.source_dir
+  if args.chat_id is not None:
+    return app.get("chat_id") == args.chat_id
+  if args.name is not None:
+    return app.get("name") == args.name
+  return True
+
+
 def main() -> None:
-  if len(sys.argv) != 1:
-    print("Usage: list_apps.py", file=sys.stderr)
-    raise SystemExit(2)
+  args = _args()
   token = os.environ.get("AGENT_TOKEN")
   if not token:
     print("AGENT_TOKEN environment variable is not set.", file=sys.stderr)
@@ -34,7 +66,7 @@ def main() -> None:
   compact = [
     {"id": app.get("id"), "name": app.get("name"), "slug": app.get("slug")}
     for app in apps
-    if isinstance(app, dict)
+    if isinstance(app, dict) and _matches(app, args)
   ]
   print(json.dumps(compact, ensure_ascii=False, separators=(",", ":")))
 

--- a/backend/scripts/preview_app.sh
+++ b/backend/scripts/preview_app.sh
@@ -6,28 +6,83 @@
 # screenshot helper). Kept for its historical signature so recovery.md
 # and existing callers keep working:
 #
-#   preview_app.sh <app_id> [output_path]
+#   preview_app.sh [--standalone] <app_id> [output_path]
 #   defaults: output_path=/data/chats/$CHAT_ID/media/app-<id>.png
 #
 # Maps to the in-shell app route /app/<id>. The bare app-frame URL
 # can't be screenshotted directly — the frame waits for the parent
 # shell's `moebius:frame-init` postMessage before initializing — so we
-# go through /app/<id> in the authenticated shell. For the STANDALONE
-# PWA page of an app, call agent-screenshot.sh /apps/<slug>/ directly.
+# go through /app/<id> in the authenticated shell. `--standalone` keeps the
+# same numeric input and resolves the unique slug internally before opening
+# the PWA page.
 # All auth/viewport/banner handling lives in agent-screenshot.sh. App previews
 # use its ephemeral content-only mode so owner onboarding/install overlays do
 # not cover the app under test or mutate account completion state.
 
 set -euo pipefail
 
+STANDALONE=0
+if [ "${1:-}" = "--standalone" ]; then
+  STANDALONE=1
+  shift
+fi
+
 APP_ID="${1:-}"
 if [ -z "$APP_ID" ]; then
   echo "preview_app.sh: app_id required" >&2
-  echo "Usage: preview_app.sh <app_id> [output_path]" >&2
+  echo "Usage: preview_app.sh [--standalone] <app_id> [output_path]" >&2
   exit 1
 fi
+case "$APP_ID" in
+  *[!0-9]*)
+    echo "preview_app.sh: app_id must be numeric" >&2
+    exit 1 ;;
+esac
 
-OUT="${2:-/data/chats/${CHAT_ID:-unknown}/media/app-${APP_ID}.png}"
+if [ "$STANDALONE" -eq 1 ]; then
+  OUT="${2:-/data/chats/${CHAT_ID:-unknown}/media/app-${APP_ID}-standalone.png}"
+  SLUG="$(
+    APP_ID="$APP_ID" python3 - <<'PY'
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+token = os.environ.get("AGENT_TOKEN")
+base = os.environ.get("API_BASE_URL", "").rstrip("/")
+app_id = os.environ["APP_ID"]
+if not token or not base:
+  print(
+    "preview_app.sh: AGENT_TOKEN and API_BASE_URL must be set",
+    file=sys.stderr,
+  )
+  raise SystemExit(1)
+request = urllib.request.Request(
+  f"{base}/api/apps/{app_id}",
+  headers={"Authorization": f"Bearer {token}"},
+)
+try:
+  with urllib.request.urlopen(request, timeout=30) as response:
+    app = json.loads(response.read())
+except (urllib.error.URLError, json.JSONDecodeError) as exc:
+  print(f"preview_app.sh: could not resolve app {app_id}: {exc}", file=sys.stderr)
+  raise SystemExit(1) from exc
+slug = app.get("slug") if isinstance(app, dict) else None
+if not isinstance(slug, str) or not slug:
+  print(f"preview_app.sh: app {app_id} has no standalone slug", file=sys.stderr)
+  raise SystemExit(1)
+print(slug)
+PY
+  )"
+  ROUTE="/apps/${SLUG}/"
+else
+  OUT="${2:-/data/chats/${CHAT_ID:-unknown}/media/app-${APP_ID}.png}"
+  ROUTE="/app/${APP_ID}"
+fi
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec "${DIR}/agent-screenshot.sh" --content-only "/app/${APP_ID}" "${OUT}"
+if [ "$STANDALONE" -eq 1 ]; then
+  exec "${DIR}/agent-screenshot.sh" "${ROUTE}" "${OUT}"
+fi
+exec "${DIR}/agent-screenshot.sh" --content-only "${ROUTE}" "${OUT}"

--- a/backend/scripts/publish_chat_image.py
+++ b/backend/scripts/publish_chat_image.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Publish one exact local raster image into the current chat's media."""
+
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import tempfile
+import uuid
+
+
+_CHAT_ID_RE = re.compile(r"^[A-Za-z0-9-]{1,64}$")
+_IMAGE_SUFFIXES = frozenset({".png", ".jpg", ".jpeg", ".webp", ".gif"})
+_MAX_BYTES = 25 * 1024 * 1024
+
+
+def _args() -> argparse.Namespace:
+  parser = argparse.ArgumentParser(
+    description=(
+      "Copy the exact generated image named by SOURCE into this chat and "
+      "print its durable path, URL, and ready-to-paste embed."
+    ),
+  )
+  parser.add_argument("source")
+  parser.add_argument("--alt", default="generated image")
+  return parser.parse_args()
+
+
+def _publish(source_arg: str, chat_id: str, data_dir: Path, alt: str) -> dict:
+  if not _CHAT_ID_RE.fullmatch(chat_id):
+    raise ValueError("CHAT_ID must be 1-64 letters, digits, or hyphens.")
+  try:
+    source = Path(source_arg).resolve(strict=True)
+  except (OSError, RuntimeError) as exc:
+    raise ValueError(f"Cannot resolve image source: {exc}") from exc
+  if not source.is_file():
+    raise ValueError("Image source is not a file.")
+  suffix = source.suffix.lower()
+  if suffix not in _IMAGE_SUFFIXES:
+    allowed = ", ".join(sorted(_IMAGE_SUFFIXES))
+    raise ValueError(f"Image must use one of: {allowed}.")
+  size = source.stat().st_size
+  if size <= 0:
+    raise ValueError("Image source is empty.")
+  if size > _MAX_BYTES:
+    raise ValueError(f"Image exceeds the {_MAX_BYTES}-byte publishing limit.")
+
+  media_dir = data_dir / "chats" / chat_id / "media"
+  media_dir.mkdir(parents=True, exist_ok=True)
+  filename = f"generated-{uuid.uuid4().hex[:16]}{suffix}"
+  destination = media_dir / filename
+  temporary = None
+  try:
+    with tempfile.NamedTemporaryFile(
+      prefix=".publish-", suffix=suffix, dir=media_dir, delete=False,
+    ) as staged:
+      temporary = Path(staged.name)
+      with source.open("rb") as incoming:
+        shutil.copyfileobj(incoming, staged)
+      staged.flush()
+      os.fsync(staged.fileno())
+    temporary.chmod(0o644)
+    os.replace(temporary, destination)
+  finally:
+    if temporary is not None:
+      temporary.unlink(missing_ok=True)
+
+  media_url = f"/api/chats/{chat_id}/media/{filename}"
+  safe_alt = alt.replace("\\", "\\\\").replace("]", "\\]")
+  return {
+    "source_path": str(source),
+    "media_path": str(destination),
+    "media_url": media_url,
+    "embed": f"![{safe_alt}]({media_url})",
+  }
+
+
+def main() -> None:
+  args = _args()
+  chat_id = os.environ.get("CHAT_ID", "")
+  data_dir = Path(os.environ.get("DATA_DIR", "/data"))
+  try:
+    receipt = _publish(args.source, chat_id, data_dir, args.alt)
+  except (OSError, ValueError) as exc:
+    raise SystemExit(f"publish_chat_image.py: {exc}") from exc
+  print(json.dumps(receipt, ensure_ascii=False, separators=(",", ":")))
+
+
+if __name__ == "__main__":
+  main()

--- a/backend/scripts/seed-skills/building-apps-quickstart.md
+++ b/backend/scripts/seed-skills/building-apps-quickstart.md
@@ -147,9 +147,11 @@ python "$SCRIPTS_DIR/apply_app.py" /data/apps/<slug>
 ```
 
 The helper validates the manifest and complete source tree, compiles and
-commits that exact revision, returns the app JSON (including its numeric ID),
-and opens the live preview beside the owning chat. Do not send a separate
-`open_item`.
+commits that exact revision, returns a compact receipt with `app_id`,
+`preview_path`, and `open_path`, and opens the live preview beside the owning
+chat. Reuse that numeric ID for preview, storage, notifications, and later
+actions; do not list apps again after a successful apply. Do not send a
+separate `open_item`.
 
 Afterward, edit source files normally and run the same command once the change
 is coherent enough to preview. A failed apply keeps the prior version live and

--- a/backend/scripts/seed-skills/building-apps.md
+++ b/backend/scripts/seed-skills/building-apps.md
@@ -3,7 +3,7 @@
 Advanced extension for Möbius mini-apps. Read it alongside
 `building-apps-quickstart.md` and `visual-testing.md` when work needs packaging,
 services/fetching, privileged storage, embedded agents, device capabilities,
-immersive mode, or navigation.
+immersive mode, navigation, or app deletion/recovery.
 
 This file contains only the advanced contract and deltas from the base
 workflow. For an ordinary local create or straightforward update, the
@@ -214,8 +214,8 @@ imports `index.jsx`):
 ### Deleting an app — reversible for 7 days
 
 ```bash
-curl -s -H "Authorization: Bearer $AGENT_TOKEN" "$API_BASE_URL/api/apps/" | python3 -m json.tool   # find the id
-curl -s -X DELETE -H "Authorization: Bearer $AGENT_TOKEN" "$API_BASE_URL/api/apps/<id>"
+python "$SCRIPTS_DIR/list_apps.py" --name "<exact display name>"
+python "$SCRIPTS_DIR/delete_app.py" <id> --confirm
 ```
 
 Delete is a **soft delete**: the app is tombstoned and its saved data is kept for
@@ -223,9 +223,10 @@ Delete is a **soft delete**: the app is tombstoned and its saved data is kept fo
 (or, for a store app, just reinstall it) — see `recovery.md`. Before deleting:
 verify the app exists, tell the partner which one (name, id, description), and
 ask for confirmation ("Delete [name]? You can recover it for 7 days."), then
-delete. Record creates and deletions in this chat's note (`chats/$CHAT_ID/index.md`)
-in the same turn (the id is your recovery handle); updates skip the note unless
-they revealed something non-obvious.
+delete. Exact-name lookup can return several apps; choose by numeric ID and
+never by list position. The delete helper returns the recovery receipt. Record
+creates and deletions in this chat's note (`chats/$CHAT_ID/index.md`) in the
+same turn; updates skip the note unless they revealed something non-obvious.
 
 ---
 

--- a/backend/scripts/seed-skills/images.md
+++ b/backend/scripts/seed-skills/images.md
@@ -14,27 +14,15 @@ Codex includes a built-in image generator covered by the plan, with no separate 
 $imagegen "a serene mountain landscape"
 ```
 
-The PNG saves under `/data/cli-auth/codex/generated_images/...` and is NOT automatically visible in Möbius chat. Copy it into the chat's media dir, then embed:
+The PNG saves under `/data/cli-auth/codex/generated_images/...` and is not
+automatically visible in Möbius chat. Publish the exact returned path:
 
 ```bash
-IMG=$(ls -t /data/cli-auth/codex/generated_images/*.png 2>/dev/null | head -1)
-mkdir -p /data/chats/$CHAT_ID/media
-FNAME="$(basename "$IMG")"
-cp "$IMG" /data/chats/$CHAT_ID/media/"$FNAME"
+python "$SCRIPTS_DIR/publish_chat_image.py" "<exact path returned by imagegen>" \
+  --alt "short description"
 ```
 
-Then in your reply:
-
-```markdown
-![description](/api/chats/$CHAT_ID/media/<filename>)
-```
-
-## Embedding — always show it after creating
-
-Embed the image in chat after creating it (an image you generated but didn't embed is invisible to the partner — same trap as screenshots):
-
-```markdown
-![description](/api/chats/$CHAT_ID/media/<filename>)
-```
-
-`$CHAT_ID` above is a shell placeholder — it only expands inside a bash command. In the markdown link you write, the path must carry the RESOLVED chat id, never the literal `$CHAT_ID` segment: the renderer extracts the chat id from the path, so an unexpanded `$CHAT_ID` matches no real chat and 404s. Two-part discipline: put the real chat id in the link, and make sure the file physically lives in `/data/chats/<resolved-id>/media/` before you embed it.
+Paste the returned `embed` value into the reply before describing the image.
+The helper writes to the resolved current chat and deliberately requires the
+exact generated path; never rediscover an output by modification time, which
+can select another run's image.

--- a/backend/scripts/seed-skills/visual-testing.md
+++ b/backend/scripts/seed-skills/visual-testing.md
@@ -66,7 +66,7 @@ by that snapshot is preferable to a 25-second timeout.
 
 Two gotchas every session:
 
-- **`@eN` refs are ephemeral** — regenerated on every `snapshot`, invalidated by any DOM change. Re-snapshot before targeting by `@ref` after any mutation. For repeated targets prefer stable selectors (`button[aria-label="..."]`, `[data-testid="..."]`). `:has-text()` silently no-ops.
+- **`@eN` refs are ephemeral** — regenerated on every `snapshot`, invalidated by any DOM change. Re-snapshot before targeting by `@ref` after any mutation. For repeated targets, use a selector only when its matching DOM attribute or structure is verified in the current DOM or source; otherwise re-snapshot and use a fresh ref. A quoted control name in a snapshot is an accessible name, not evidence that a matching DOM attribute exists. `:has-text()` silently no-ops.
 - **`✓ Done` only confirms dispatch, not state change** — the CLI returns it the instant the command reaches Chromium, not after the UI changed. Verify with `snapshot` or a screenshot after any click meant to transition UI.
 - **Keep screenshots purposeful** — retain the first useful render, a materially changed or error state, and the final evidence. A loader, drawer transition, or near-identical recapture is not a partner-visible milestone.
 

--- a/backend/tests/test_agent_screenshot_auth.py
+++ b/backend/tests/test_agent_screenshot_auth.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 import os
+import shutil
 import subprocess
 
 
@@ -211,4 +212,56 @@ def test_content_mode_suppresses_modals_without_dom_surgery():
 def test_app_preview_requests_ephemeral_content_only_mode():
   source = PREVIEW_APP.read_text(encoding="utf-8")
 
-  assert 'agent-screenshot.sh" --content-only "/app/${APP_ID}"' in source
+  assert 'ROUTE="/app/${APP_ID}"' in source
+  assert 'agent-screenshot.sh" --content-only "${ROUTE}"' in source
+
+
+def test_standalone_app_preview_keeps_numeric_id_as_input():
+  source = PREVIEW_APP.read_text(encoding="utf-8")
+
+  assert "preview_app.sh [--standalone] <app_id>" in source
+  assert 'f"{base}/api/apps/{app_id}"' in source
+  assert 'ROUTE="/apps/${SLUG}/"' in source
+  assert "app_id must be numeric" in source
+
+
+def test_standalone_preview_resolves_slug_without_exposing_it_to_caller(
+  tmp_path: Path,
+):
+  preview = tmp_path / "preview_app.sh"
+  shutil.copy2(PREVIEW_APP, preview)
+  fake_python = tmp_path / "python3"
+  fake_python.write_text(
+    "#!/bin/sh\ncat >/dev/null\nprintf '%s\\n' 'duplicate-name-2'\n",
+    encoding="utf-8",
+  )
+  fake_python.chmod(0o755)
+  fake_screenshot = tmp_path / "agent-screenshot.sh"
+  fake_screenshot.write_text(
+    "#!/bin/sh\nprintf '%s\\n' \"$*\" > \"$PREVIEW_LOG\"\n",
+    encoding="utf-8",
+  )
+  fake_screenshot.chmod(0o755)
+  log = tmp_path / "preview.log"
+
+  result = subprocess.run(
+    [
+      "bash", str(preview), "--standalone", "42",
+      str(tmp_path / "standalone.png"),
+    ],
+    env={
+      **os.environ,
+      "PATH": f"{tmp_path}:{os.environ['PATH']}",
+      "AGENT_TOKEN": "test-token",
+      "API_BASE_URL": "http://mobius.test",
+      "PREVIEW_LOG": str(log),
+    },
+    text=True,
+    capture_output=True,
+    check=False,
+  )
+
+  assert result.returncode == 0, result.stderr
+  assert log.read_text(encoding="utf-8").strip() == (
+    f"/apps/duplicate-name-2/ {tmp_path / 'standalone.png'}"
+  )

--- a/backend/tests/test_app_project_context.py
+++ b/backend/tests/test_app_project_context.py
@@ -79,3 +79,67 @@ def test_non_app_chat_has_no_context(db):
   block, env = _build_app_context(db, chat.id, _DATA_DIR)
   assert block is None
   assert env == {}
+
+
+def test_build_chat_with_one_linked_app_gets_exact_identity(db):
+  chat = models.Chat(id="builder-one", title="build", messages=[])
+  db.add(chat)
+  db.commit()
+  app = models.App(
+    name="Duplicate name", description="", jsx_source="",
+    slug="duplicate-name-2", source_dir="/data/apps/duplicate-name-2",
+    chat_id=chat.id,
+  )
+  db.add(app)
+  db.commit()
+  db.refresh(app)
+
+  block, env = _build_app_context(db, chat.id, _DATA_DIR)
+
+  assert block is not None
+  assert "App names are not unique" in block
+  assert f'"app_id":{app.id}' in block
+  assert env["APP_ID"] == str(app.id)
+  assert env["APP_SOURCE_DIR"] == "/data/apps/duplicate-name-2"
+  assert env["APP_STORAGE_DIR"].endswith(f"/apps/{app.id}")
+  assert env["CHAT_APPS_JSON"] in block
+
+
+def test_build_chat_with_multiple_apps_never_guesses_one_app(db):
+  chat = models.Chat(id="builder-many", title="build", messages=[])
+  db.add(chat)
+  db.commit()
+  apps = [
+    models.App(
+      name="Same", description="", jsx_source="", slug=f"same-{index}",
+      source_dir=f"/data/apps/same-{index}", chat_id=chat.id,
+    )
+    for index in (1, 2)
+  ]
+  db.add_all(apps)
+  db.commit()
+
+  block, env = _build_app_context(db, chat.id, _DATA_DIR)
+
+  assert block is not None
+  assert env.keys() == {"CHAT_APPS_JSON"}
+  assert all(f'"app_id":{app.id}' in block for app in apps)
+
+
+def test_deleted_linked_app_is_not_injected(db):
+  from datetime import UTC, datetime
+
+  chat = models.Chat(id="builder-deleted", title="build", messages=[])
+  db.add(chat)
+  db.commit()
+  db.add(models.App(
+    name="Gone", description="", jsx_source="", slug="gone",
+    source_dir="/data/apps/gone", chat_id=chat.id,
+    deleted_at=datetime.now(UTC).replace(tzinfo=None),
+  ))
+  db.commit()
+
+  block, env = _build_app_context(db, chat.id, _DATA_DIR)
+
+  assert block is None
+  assert env == {}

--- a/backend/tests/test_apply_app_script.py
+++ b/backend/tests/test_apply_app_script.py
@@ -1,0 +1,96 @@
+"""Compact apply receipt contract for the agent-facing helper."""
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "apply_app.py"
+
+
+def _load():
+  spec = importlib.util.spec_from_file_location("apply_app_script", SCRIPT)
+  module = importlib.util.module_from_spec(spec)
+  assert spec.loader is not None
+  spec.loader.exec_module(module)
+  return module
+
+
+class _Response:
+  def __init__(self, payload):
+    self.payload = payload
+
+  def __enter__(self):
+    return self
+
+  def __exit__(self, *_args):
+    return False
+
+  def read(self):
+    return json.dumps(self.payload).encode()
+
+
+def test_apply_prints_compact_reusable_identity_receipt(
+  monkeypatch, capsys, tmp_path,
+):
+  module = _load()
+  source = tmp_path / "same-name"
+  source.mkdir()
+  monkeypatch.setattr(sys, "argv", ["apply_app.py", str(source)])
+  monkeypatch.setenv("AGENT_TOKEN", "agent-token")
+  monkeypatch.setenv("CHAT_ID", "building-chat")
+  monkeypatch.setattr(
+    module.urllib.request,
+    "urlopen",
+    lambda request, timeout: _Response({
+      "mode": "created",
+      "app": {
+        "id": 73,
+        "name": "Same name",
+        "slug": "same-name-2",
+        "source_dir": str(source.resolve()),
+        "chat_id": "building-chat",
+        "capability_contract": {"large": "payload"},
+        "compiled_path": "/private/runtime/path",
+      },
+    }),
+  )
+
+  module.main()
+
+  assert json.loads(capsys.readouterr().out) == {
+    "mode": "created",
+    "app_id": 73,
+    "name": "Same name",
+    "slug": "same-name-2",
+    "source_dir": str(source.resolve()),
+    "chat_id": "building-chat",
+    "preview_path": "/app/73",
+    "open_path": "/shell/?app=73",
+  }
+
+
+def test_apply_fails_loudly_when_response_loses_numeric_identity(
+  monkeypatch, capsys, tmp_path,
+):
+  module = _load()
+  source = tmp_path / "bad"
+  source.mkdir()
+  monkeypatch.setattr(sys, "argv", ["apply_app.py", str(source)])
+  monkeypatch.setenv("AGENT_TOKEN", "agent-token")
+  monkeypatch.setattr(
+    module.urllib.request,
+    "urlopen",
+    lambda request, timeout: _Response({
+      "mode": "created", "app": {"name": "No id"},
+    }),
+  )
+
+  with pytest.raises(SystemExit) as exc:
+    module.main()
+
+  assert exc.value.code == 1
+  assert "numeric app id" in capsys.readouterr().err

--- a/backend/tests/test_chat_skills_context.py
+++ b/backend/tests/test_chat_skills_context.py
@@ -153,3 +153,15 @@ def test_owned_app_skill_summaries_expose_complete_initial_read_sets():
   assert len(visual) <= 300
   assert "building-apps-quickstart.md" in visual
   assert "theming.md" in visual
+
+
+def test_visual_testing_selector_guidance_requires_observed_evidence():
+  repo = Path(__file__).resolve().parents[2]
+  visual = (
+    repo / "backend" / "scripts" / "seed-skills" / "visual-testing.md"
+  ).read_text(encoding="utf-8")
+
+  assert "verified in the current DOM or source" in visual
+  assert "an accessible name, not evidence" in visual
+  assert 'button[aria-label="..."]' not in visual
+  assert '[data-testid="..."]' not in visual

--- a/backend/tests/test_chat_skills_context.py
+++ b/backend/tests/test_chat_skills_context.py
@@ -165,3 +165,38 @@ def test_visual_testing_selector_guidance_requires_observed_evidence():
   assert "an accessible name, not evidence" in visual
   assert 'button[aria-label="..."]' not in visual
   assert '[data-testid="..."]' not in visual
+
+
+def test_image_skill_publishes_exact_generated_path():
+  repo = Path(__file__).resolve().parents[2]
+  images = (
+    repo / "backend" / "scripts" / "seed-skills" / "images.md"
+  ).read_text(encoding="utf-8")
+
+  assert "publish_chat_image.py" in images
+  assert "<exact path returned by imagegen>" in images
+  assert "IMG=$(ls -t" not in images
+
+
+def test_quickstart_reuses_apply_receipt_id_without_relisting():
+  repo = Path(__file__).resolve().parents[2]
+  quickstart = (
+    repo / "backend" / "scripts" / "seed-skills"
+    / "building-apps-quickstart.md"
+  ).read_text(encoding="utf-8")
+
+  assert "compact receipt with `app_id`" in quickstart
+  assert "do not list apps again after a successful apply" in quickstart
+
+
+def test_advanced_app_skill_deletes_by_id_and_retains_recovery_receipt():
+  repo = Path(__file__).resolve().parents[2]
+  advanced = (
+    repo / "backend" / "scripts" / "seed-skills" / "building-apps.md"
+  ).read_text(encoding="utf-8")
+
+  summary = advanced.split("\n\n", 2)[1]
+  assert "app deletion/recovery" in summary
+  assert "delete_app.py" in advanced
+  assert "Exact-name lookup can return several apps" in advanced
+  assert "returns the recovery receipt" in advanced

--- a/backend/tests/test_delete_app_script.py
+++ b/backend/tests/test_delete_app_script.py
@@ -1,0 +1,94 @@
+"""Deletion helper preserves the exact recovery handle."""
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "delete_app.py"
+
+
+def _load():
+  spec = importlib.util.spec_from_file_location("delete_app_script", SCRIPT)
+  module = importlib.util.module_from_spec(spec)
+  assert spec.loader is not None
+  spec.loader.exec_module(module)
+  return module
+
+
+class _Response:
+  def __init__(self, payload=b""):
+    self.payload = payload
+
+  def __enter__(self):
+    return self
+
+  def __exit__(self, *_args):
+    return False
+
+  def read(self):
+    return self.payload
+
+
+def test_delete_fetches_exact_id_then_returns_recovery_receipt(
+  monkeypatch, capsys,
+):
+  module = _load()
+  monkeypatch.setattr(
+    sys, "argv", ["delete_app.py", "17", "--confirm"],
+  )
+  monkeypatch.setenv("AGENT_TOKEN", "agent-token")
+  monkeypatch.setenv("API_BASE_URL", "http://mobius.test/")
+  requests = []
+
+  def respond(request, timeout):
+    requests.append((request.full_url, request.get_method()))
+    if request.get_method() == "GET":
+      return _Response(json.dumps({
+        "id": 17,
+        "name": "Duplicate name",
+        "slug": "duplicate-name-2",
+        "source_dir": "/data/apps/duplicate-name-2",
+      }).encode())
+    return _Response()
+
+  monkeypatch.setattr(module.urllib.request, "urlopen", respond)
+
+  module.main()
+
+  assert requests == [
+    ("http://mobius.test/api/apps/17", "GET"),
+    ("http://mobius.test/api/apps/17", "DELETE"),
+  ]
+  assert json.loads(capsys.readouterr().out) == {
+    "status": "deleted",
+    "app_id": 17,
+    "name": "Duplicate name",
+    "slug": "duplicate-name-2",
+    "source_dir": "/data/apps/duplicate-name-2",
+    "recover_path": "/api/apps/17/recover",
+    "recoverable_for_days": 7,
+  }
+
+
+def test_delete_refuses_mismatched_lookup_identity(monkeypatch, capsys):
+  module = _load()
+  monkeypatch.setattr(
+    sys, "argv", ["delete_app.py", "17", "--confirm"],
+  )
+  monkeypatch.setenv("AGENT_TOKEN", "agent-token")
+  monkeypatch.setattr(
+    module.urllib.request,
+    "urlopen",
+    lambda request, timeout: _Response(json.dumps({"id": 18}).encode()),
+  )
+
+  try:
+    module.main()
+  except SystemExit as exc:
+    assert exc.code == 1
+  else:
+    raise AssertionError("mismatched app identity should fail")
+
+  assert "requested numeric id" in capsys.readouterr().err

--- a/backend/tests/test_list_apps_script.py
+++ b/backend/tests/test_list_apps_script.py
@@ -47,6 +47,8 @@ def test_list_apps_prints_only_compact_identity_fields(
       "id": 7,
       "name": "Decision Spinner",
       "slug": "decision-spinner",
+      "source_dir": "/data/apps/decision-spinner",
+      "chat_id": "chat-7",
       "permissions": {"large": "payload"},
       "compiled_path": "/private/runtime/path",
     }]),
@@ -59,6 +61,105 @@ def test_list_apps_prints_only_compact_identity_fields(
     "name": "Decision Spinner",
     "slug": "decision-spinner",
   }]
+
+
+def test_exact_name_filter_returns_every_duplicate_name(
+  monkeypatch, capsys,
+):
+  module = _load()
+  monkeypatch.setattr(
+    sys, "argv", ["list_apps.py", "--name", "Shared name"],
+  )
+  monkeypatch.setenv("AGENT_TOKEN", "agent-token")
+  monkeypatch.setattr(
+    module.urllib.request,
+    "urlopen",
+    lambda request, timeout: _Response([
+      {
+        "id": 2, "name": "Shared name", "slug": "first",
+        "source_dir": "/data/apps/first", "chat_id": "chat-a",
+      },
+      {
+        "id": 9, "name": "Shared name", "slug": "second",
+        "source_dir": "/data/apps/second", "chat_id": "chat-b",
+      },
+      {
+        "id": 10, "name": "Other", "slug": "other",
+        "source_dir": "/data/apps/other", "chat_id": "chat-a",
+      },
+    ]),
+  )
+
+  module.main()
+
+  result = json.loads(capsys.readouterr().out)
+  assert [app["id"] for app in result] == [2, 9]
+
+
+@pytest.mark.parametrize(
+  ("argv", "expected_id"),
+  [
+    (["--id", "9"], 9),
+    (["--slug", "second"], 9),
+    (["--source-dir", "/data/apps/second"], 9),
+  ],
+)
+def test_unique_identity_filters_narrow_without_name_resolution(
+  monkeypatch, capsys, argv, expected_id,
+):
+  module = _load()
+  monkeypatch.setattr(sys, "argv", ["list_apps.py", *argv])
+  monkeypatch.setenv("AGENT_TOKEN", "agent-token")
+  monkeypatch.setattr(
+    module.urllib.request,
+    "urlopen",
+    lambda request, timeout: _Response([
+      {
+        "id": 2, "name": "Same", "slug": "first",
+        "source_dir": "/data/apps/first", "chat_id": "chat-a",
+      },
+      {
+        "id": 9, "name": "Same", "slug": "second",
+        "source_dir": "/data/apps/second", "chat_id": "chat-b",
+      },
+    ]),
+  )
+
+  module.main()
+
+  result = json.loads(capsys.readouterr().out)
+  assert [app["id"] for app in result] == [expected_id]
+
+
+def test_chat_filter_preserves_all_apps_owned_by_chat(monkeypatch, capsys):
+  module = _load()
+  monkeypatch.setattr(
+    sys, "argv", ["list_apps.py", "--chat-id", "chat-a"],
+  )
+  monkeypatch.setenv("AGENT_TOKEN", "agent-token")
+  monkeypatch.setattr(
+    module.urllib.request,
+    "urlopen",
+    lambda request, timeout: _Response([
+      {
+        "id": 2, "name": "One", "slug": "one",
+        "source_dir": "/data/apps/one", "chat_id": "chat-a",
+      },
+      {
+        "id": 3, "name": "Two", "slug": "two",
+        "source_dir": "/data/apps/two", "chat_id": "chat-a",
+      },
+      {
+        "id": 4, "name": "Three", "slug": "three",
+        "source_dir": "/data/apps/three", "chat_id": "chat-b",
+      },
+    ]),
+  )
+
+  module.main()
+
+  result = json.loads(capsys.readouterr().out)
+  assert [app["id"] for app in result] == [2, 3]
 
 
 def test_list_apps_requires_agent_token(monkeypatch, capsys):

--- a/backend/tests/test_memory_boot.py
+++ b/backend/tests/test_memory_boot.py
@@ -103,7 +103,7 @@ def test_later_boot_migrates_only_unmodified_graph_aware_base_skill(
 def test_controlled_skills_have_fix_forward_migrations():
   module = _load("init_skills")
 
-  assert module.SEED_VERSION == "19"
+  assert module.SEED_VERSION == "20"
   assert module._UNMODIFIED_MIGRATIONS["images.md"] == {
     "248ea31e13d2d2d84a5acfca13526aa8ebfa3d90e9ee4bf55cfb72d47937f7d1",
   }
@@ -130,6 +130,7 @@ def test_controlled_skills_have_fix_forward_migrations():
     "9525b36b945c2a0b4cb02806081bb674f38e865b6e1c3961226112e1dbbc16ec",
     "a0648921b9c9ea2423e8abd52aa57e71e7bebfa1736073fcf3bfcaec3749ad19",
     "5db160b2d796d54ec320119cbdbbb2860a78cfd703cfe37667626d23abc8e4d9",
+    "bf58243aeb1779eb0a94d5404a99c2132e55d60542cbb555fc50bc5cf65349fe",
   }
   assert (
     "6e6e82e02287e8bb38195fb021ea25cee2dc4e27da1a6ce1e2a0143fb1d82d87"

--- a/backend/tests/test_memory_boot.py
+++ b/backend/tests/test_memory_boot.py
@@ -103,21 +103,24 @@ def test_later_boot_migrates_only_unmodified_graph_aware_base_skill(
 def test_controlled_skills_have_fix_forward_migrations():
   module = _load("init_skills")
 
-  assert module.SEED_VERSION == "20"
+  assert module.SEED_VERSION == "21"
   assert module._UNMODIFIED_MIGRATIONS["images.md"] == {
     "248ea31e13d2d2d84a5acfca13526aa8ebfa3d90e9ee4bf55cfb72d47937f7d1",
+    "29039a6fc5c9281794247eda5d0bbf66e969a1a260e9ed56c69ee6e1cd175f7c",
   }
   assert module._UNMODIFIED_MIGRATIONS["building-apps.md"] == {
     "4126b40d209c422184e0135f611bb9f4197ea280fa27e63cd71c806f8b5ebd79",
     "91b655952d55b37fda0be82e3914c3b09e67ca7c5f5a575d315fb2ca75ef08f1",
     "563dcd7bfa1ff7cbad074d98462eb9755a010a15bf340c7f594fc7f6825a6a86",
     "a8591f03bd5fb6eb0cfcd811d6d6d4309657f2f4e9e8e11ded4cbefbd77facfd",
+    "5a6bafaa654071c4af5a5c7a201e23e4b0294c392ccb2b9afd7c2b18e17ff3fe",
   }
   assert module._UNMODIFIED_MIGRATIONS["building-apps-quickstart.md"] == {
     "7d8af2664b37a69b88e48c2a28140c15556202c3c7ce30d77816c203d1959fcb",
     "4c2b080bcc91626f761c5823ea00d324667b9710f6757931823e22e9c8b5c2b1",
     "85a4b5ce5b47c81fa53bec90d530adfe433c0d2f7f31363427b6c792bd332e05",
     "02fda2ea04f3c0ce808ef0db4b1fe4e893924bd019a5bf102a46749ef9142510",
+    "68c84158a9255ab53686968ed4ec8f594c460483bec0e90dcfa472682c1d9b70",
   }
   assert module._UNMODIFIED_MIGRATIONS["resolving-app-git.md"] == {
     "6d462f1711891a182c26e212a1ec8fc922eeb02faee45e70ab9b2becfba24f5a",

--- a/backend/tests/test_publish_chat_image.py
+++ b/backend/tests/test_publish_chat_image.py
@@ -1,0 +1,58 @@
+"""Exact generated-image handoff into chat media."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT = (
+  Path(__file__).resolve().parents[1] / "scripts" / "publish_chat_image.py"
+)
+
+
+def _load():
+  spec = importlib.util.spec_from_file_location("publish_chat_image", SCRIPT)
+  module = importlib.util.module_from_spec(spec)
+  assert spec.loader is not None
+  spec.loader.exec_module(module)
+  return module
+
+
+def test_publish_copies_the_exact_named_image_and_returns_embed(tmp_path):
+  module = _load()
+  first = tmp_path / "first.png"
+  newest_but_wrong = tmp_path / "newest.png"
+  first.write_bytes(b"\x89PNG exact requested bytes")
+  newest_but_wrong.write_bytes(b"\x89PNG wrong bytes")
+
+  receipt = module._publish(
+    str(first), "chat-7", tmp_path / "data", "first result",
+  )
+
+  destination = Path(receipt["media_path"])
+  assert destination.read_bytes() == first.read_bytes()
+  assert destination.read_bytes() != newest_but_wrong.read_bytes()
+  assert receipt["source_path"] == str(first.resolve())
+  assert receipt["media_url"].startswith("/api/chats/chat-7/media/generated-")
+  assert receipt["embed"] == (
+    f"![first result]({receipt['media_url']})"
+  )
+
+
+@pytest.mark.parametrize(
+  ("chat_id", "filename", "message"),
+  [
+    ("../other-chat", "image.png", "CHAT_ID"),
+    ("chat-7", "notes.txt", "Image must use"),
+  ],
+)
+def test_publish_rejects_unsafe_chat_or_non_image(
+  tmp_path, chat_id, filename, message,
+):
+  module = _load()
+  source = tmp_path / filename
+  source.write_bytes(b"content")
+
+  with pytest.raises(ValueError, match=message):
+    module._publish(str(source), chat_id, tmp_path / "data", "image")


### PR DESCRIPTION
## Summary

- ground browser selectors in the currently observed DOM instead of assuming ARIA or test attributes
- return and propagate durable app IDs through apply, chat context, listing, preview, and reversible deletion
- publish the exact generated-image path into chat media instead of rediscovering files by modification time
- keep owned skill routing explicit, including paired reads and deletion/recovery discovery, with hash-gated migrations that preserve edited and third-party skills

## Validation

- full local backend suite: 3,064 passed, 7 skipped
- focused integrated suite: 92 passed
- post-review skill discovery and migration checks: 20 passed
- required PR checks: backend, end-to-end, frontend unit, and privacy all passed
- Python syntax, shell syntax, diff integrity, and repository privacy gates passed
