### PR TITLE
Keep autopilot follow-up chats out of the drawer until they need the owner

### DIFF
--- a/backend/app/contribution_autopilot.py
+++ b/backend/app/contribution_autopilot.py
@@ -549,10 +549,10 @@ def set_enabled(
     # and a zombie round can never become valid again.
     _release_claim(row)
   row.updated_at = now_naive_utc()
-  db.commit()
   # The owner has taken control (paused or resumed), so the chat no longer needs
-  # their attention — tuck it back out of the drawer.
-  set_followup_drawer_hidden(db, row, True)
+  # their attention. Land the state and visibility together.
+  stage_followup_drawer_hidden(db, row, True)
+  db.commit()
   return row
 
 
@@ -564,9 +564,9 @@ def close_out(db: Session, app_id: int, record_id: str) -> None:
   _release_claim(row)
   row.enabled = False
   row.updated_at = now_naive_utc()
-  db.commit()
   # PR merged/closed: the round is over for good, so hide the chat again.
-  set_followup_drawer_hidden(db, row, True)
+  stage_followup_drawer_hidden(db, row, True)
+  db.commit()
 
 
 def escalate(db: Session, app_id: int, record_id: str) -> bool:
@@ -702,9 +702,8 @@ def stage_followup_drawer_hidden(
   self-resolving rounds never clutter the chat list. Best-effort: a missing row
   or chat just means there is nothing to toggle.
 
-  Callers that own a wider transaction stage the flip inside it so the
-  visibility can never disagree with the state change that motivated it;
-  ``set_followup_drawer_hidden`` is the standalone commit-it-now variant.
+  Callers stage the flip inside the transition's transaction so visibility
+  cannot disagree with the state change that motivated it.
   """
   if row is None or not row.followup_chat_id:
     return
@@ -721,14 +720,6 @@ def stage_followup_drawer_hidden(
   settings["drawer_hidden"] = bool(hidden)
   # Reassign the whole dict so SQLAlchemy tracks the JSON column mutation.
   chat.agent_settings_json = settings
-
-
-def set_followup_drawer_hidden(
-  db: Session, row: "models.ContributionAutopilot | None", hidden: bool,
-) -> None:
-  """Show or hide the record's follow-up chat in the owner drawer, committed."""
-  stage_followup_drawer_hidden(db, row, hidden)
-  db.commit()
 
 
 def ensure_followup_chat(

--- a/backend/app/contribution_autopilot.py
+++ b/backend/app/contribution_autopilot.py
@@ -585,11 +585,16 @@ def escalate(db: Session, app_id: int, record_id: str) -> bool:
       updated_at=now_naive_utc(),
     )
   )
-  db.commit()
   won = result.rowcount == 1
   if won:
     # The one moment an autopilot chat needs the owner: surface it in the drawer.
-    set_followup_drawer_hidden(db, get_row(db, app_id, record_id), False)
+    # Staged into THIS transaction on purpose. The UPDATE above is gated on
+    # ``enabled.is_(True)``, so it wins exactly once and no retry can ever
+    # re-run it; surfacing the chat in a second transaction would let a crash or
+    # a locked commit in between leave the record escalated but the chat hidden,
+    # with nothing able to repair it.
+    stage_followup_drawer_hidden(db, get_row(db, app_id, record_id), False)
+  db.commit()
   return won
 
 
@@ -686,16 +691,20 @@ async def set_ledger_attention(
 # ─────────────────────────── chat spawn ─────────────────────────────
 
 
-def set_followup_drawer_hidden(
+def stage_followup_drawer_hidden(
   db: Session, row: "models.ContributionAutopilot | None", hidden: bool,
 ) -> None:
-  """Show or hide the record's follow-up chat in the owner drawer.
+  """Stage the drawer visibility flip without committing.
 
   Autopilot chats are ordinary owner chats that stay hidden from the drawer
   except while an escalation is waiting on the owner. This flips the explicit
   ``drawer_hidden`` bit that ``_visible_in_owner_drawer`` honors, so routine
   self-resolving rounds never clutter the chat list. Best-effort: a missing row
   or chat just means there is nothing to toggle.
+
+  Callers that own a wider transaction stage the flip inside it so the
+  visibility can never disagree with the state change that motivated it;
+  ``set_followup_drawer_hidden`` is the standalone commit-it-now variant.
   """
   if row is None or not row.followup_chat_id:
     return
@@ -712,6 +721,13 @@ def set_followup_drawer_hidden(
   settings["drawer_hidden"] = bool(hidden)
   # Reassign the whole dict so SQLAlchemy tracks the JSON column mutation.
   chat.agent_settings_json = settings
+
+
+def set_followup_drawer_hidden(
+  db: Session, row: "models.ContributionAutopilot | None", hidden: bool,
+) -> None:
+  """Show or hide the record's follow-up chat in the owner drawer, committed."""
+  stage_followup_drawer_hidden(db, row, hidden)
   db.commit()
 
 

--- a/backend/app/contribution_autopilot.py
+++ b/backend/app/contribution_autopilot.py
@@ -550,6 +550,9 @@ def set_enabled(
     _release_claim(row)
   row.updated_at = now_naive_utc()
   db.commit()
+  # The owner has taken control (paused or resumed), so the chat no longer needs
+  # their attention — tuck it back out of the drawer.
+  set_followup_drawer_hidden(db, row, True)
   return row
 
 
@@ -562,6 +565,8 @@ def close_out(db: Session, app_id: int, record_id: str) -> None:
   row.enabled = False
   row.updated_at = now_naive_utc()
   db.commit()
+  # PR merged/closed: the round is over for good, so hide the chat again.
+  set_followup_drawer_hidden(db, row, True)
 
 
 def escalate(db: Session, app_id: int, record_id: str) -> bool:
@@ -581,7 +586,11 @@ def escalate(db: Session, app_id: int, record_id: str) -> bool:
     )
   )
   db.commit()
-  return result.rowcount == 1
+  won = result.rowcount == 1
+  if won:
+    # The one moment an autopilot chat needs the owner: surface it in the drawer.
+    set_followup_drawer_hidden(db, get_row(db, app_id, record_id), False)
+  return won
 
 
 # ─────────────────────────── ledger mirror ──────────────────────────
@@ -677,14 +686,44 @@ async def set_ledger_attention(
 # ─────────────────────────── chat spawn ─────────────────────────────
 
 
+def set_followup_drawer_hidden(
+  db: Session, row: "models.ContributionAutopilot | None", hidden: bool,
+) -> None:
+  """Show or hide the record's follow-up chat in the owner drawer.
+
+  Autopilot chats are ordinary owner chats that stay hidden from the drawer
+  except while an escalation is waiting on the owner. This flips the explicit
+  ``drawer_hidden`` bit that ``_visible_in_owner_drawer`` honors, so routine
+  self-resolving rounds never clutter the chat list. Best-effort: a missing row
+  or chat just means there is nothing to toggle.
+  """
+  if row is None or not row.followup_chat_id:
+    return
+  chat = (
+    db.query(models.Chat)
+    .filter(models.Chat.id == row.followup_chat_id)
+    .first()
+  )
+  if chat is None:
+    return
+  settings = dict(chat.agent_settings_json or {})
+  if settings.get("drawer_hidden") == bool(hidden):
+    return
+  settings["drawer_hidden"] = bool(hidden)
+  # Reassign the whole dict so SQLAlchemy tracks the JSON column mutation.
+  chat.agent_settings_json = settings
+  db.commit()
+
+
 def ensure_followup_chat(
   db: Session, app_id: int, record_id: str, *, title: str, provider: str,
 ) -> str | None:
   """Return the record's dedicated autopilot chat id, creating it once.
 
-  Reuses the stored chat when it still exists and is owner-visible; otherwise
-  creates a fresh owner-visible chat and persists its id on the DB row. Returns
-  None if there is no autopilot row (should not happen on the claimed path).
+  Reuses the stored chat when it still exists; otherwise creates a fresh chat and
+  persists its id on the DB row. The chat is an ordinary owner chat kept out of
+  the drawer (``drawer_hidden``) until an escalation surfaces it. Returns None if
+  there is no autopilot row (should not happen on the claimed path).
   """
   row = get_row(db, app_id, record_id)
   if row is None:
@@ -711,6 +750,7 @@ def ensure_followup_chat(
     pending_messages=[],
     provider=provider,
     created_by_app_id=None,
+    agent_settings_json={"drawer_hidden": True},
   )
   db.add(chat)
   db.commit()

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -193,9 +193,16 @@ def _switch_request_fingerprint(provider_id: str, settings_patch: dict) -> str:
 
 
 def _visible_in_owner_drawer(chat: models.Chat) -> bool:
+  settings = _coerce_agent_settings(chat.agent_settings_json)
+  # An explicit ``drawer_hidden`` bit overrides the default rule in either
+  # direction. Autopilot follow-up chats are ordinary owner chats that use it to
+  # stay out of the drawer except while an escalation is waiting on the owner, so
+  # routine self-resolving rounds never clutter the chat list.
+  hidden = settings.get("drawer_hidden")
+  if hidden is not None:
+    return not bool(hidden)
   if chat.created_by_app_id is None:
     return True
-  settings = _coerce_agent_settings(chat.agent_settings_json)
   return settings.get("owner_visible") is True
 
 

--- a/backend/tests/test_contribution_autopilot.py
+++ b/backend/tests/test_contribution_autopilot.py
@@ -307,6 +307,65 @@ def test_resume_resets_round_limit_and_close_out(db):
   assert autopilot.get_row(db, 1, "rec").enabled is False
 
 
+def test_visible_in_owner_drawer_honors_explicit_flag():
+  from app.routes.chats import _visible_in_owner_drawer
+
+  # An ordinary owner chat (no creating app) is visible by default...
+  owner_chat = models.Chat(
+    id="c-owner", title="t", messages=[], pending_messages=[],
+  )
+  assert _visible_in_owner_drawer(owner_chat) is True
+  # ...but an explicit drawer_hidden bit overrides in either direction.
+  owner_chat.agent_settings_json = {"drawer_hidden": True}
+  assert _visible_in_owner_drawer(owner_chat) is False
+  owner_chat.agent_settings_json = {"drawer_hidden": False}
+  assert _visible_in_owner_drawer(owner_chat) is True
+
+
+def test_followup_chat_hidden_until_escalation(db):
+  from app.routes.chats import _visible_in_owner_drawer
+
+  autopilot.stamp_grant(db, 1, "rec", head_sha="abc")
+  chat_id = autopilot.ensure_followup_chat(
+    db, 1, "rec", title="Autopilot: fix thing", provider="claude",
+  )
+  assert chat_id
+
+  def _chat():
+    db.expire_all()
+    return db.query(models.Chat).filter(models.Chat.id == chat_id).first()
+
+  # A routine round is kept out of the owner's chat list.
+  assert _visible_in_owner_drawer(_chat()) is False
+
+  # Escalation is the one moment it needs the owner → surface it.
+  assert autopilot.escalate(db, 1, "rec") is True
+  assert _visible_in_owner_drawer(_chat()) is True
+
+  # Resuming hands control back to autopilot → tuck it away again.
+  autopilot.set_enabled(db, 1, "rec", True)
+  assert _visible_in_owner_drawer(_chat()) is False
+
+
+def test_followup_chat_hidden_on_close_out(db):
+  from app.routes.chats import _visible_in_owner_drawer
+
+  autopilot.stamp_grant(db, 1, "rec", head_sha="abc")
+  chat_id = autopilot.ensure_followup_chat(
+    db, 1, "rec", title="Autopilot: fix thing", provider="claude",
+  )
+  autopilot.escalate(db, 1, "rec")
+
+  def _chat():
+    db.expire_all()
+    return db.query(models.Chat).filter(models.Chat.id == chat_id).first()
+
+  assert _visible_in_owner_drawer(_chat()) is True
+  # PR merged/closed: terminal cleanup hides the chat for good.
+  autopilot.close_out(db, 1, "rec")
+  assert _visible_in_owner_drawer(_chat()) is False
+
+
 def test_round_log_capped(db):
   autopilot.stamp_grant(db, 1, "rec", head_sha="abc")
   for i in range(40):

--- a/backend/tests/test_contribution_autopilot.py
+++ b/backend/tests/test_contribution_autopilot.py
@@ -406,6 +406,39 @@ def test_failed_surfacing_leaves_escalation_retryable(db):
   assert _visible_in_owner_drawer(_chat()) is True
 
 
+def test_failed_hiding_leaves_resume_retryable(db):
+  """Resume and its drawer transition land together or remain retryable."""
+  from app.routes.chats import _visible_in_owner_drawer
+
+  autopilot.stamp_grant(db, 1, "rec", head_sha="abc")
+  chat_id = autopilot.ensure_followup_chat(
+    db, 1, "rec", title="Autopilot: fix thing", provider="claude",
+  )
+  assert autopilot.escalate(db, 1, "rec") is True
+
+  def _chat():
+    db.expire_all()
+    return db.query(models.Chat).filter(models.Chat.id == chat_id).first()
+
+  boom = RuntimeError("database is locked")
+  original = autopilot.stage_followup_drawer_hidden
+  autopilot.stage_followup_drawer_hidden = lambda *a, **k: (_ for _ in ()).throw(boom)
+  try:
+    with pytest.raises(RuntimeError):
+      autopilot.set_enabled(db, 1, "rec", True)
+    db.rollback()
+  finally:
+    autopilot.stage_followup_drawer_hidden = original
+
+  db.expire_all()
+  assert autopilot.get_row(db, 1, "rec").enabled is False
+  assert _visible_in_owner_drawer(_chat()) is True
+
+  autopilot.set_enabled(db, 1, "rec", True)
+  assert autopilot.get_row(db, 1, "rec").enabled is True
+  assert _visible_in_owner_drawer(_chat()) is False
+
+
 def test_round_log_capped(db):
   autopilot.stamp_grant(db, 1, "rec", head_sha="abc")
   for i in range(40):

--- a/backend/tests/test_contribution_autopilot.py
+++ b/backend/tests/test_contribution_autopilot.py
@@ -366,6 +366,46 @@ def test_followup_chat_hidden_on_close_out(db):
   assert _visible_in_owner_drawer(_chat()) is False
 
 
+def test_failed_surfacing_leaves_escalation_retryable(db):
+  """A crash while surfacing must not consume the one-shot escalate latch.
+
+  ``escalate`` wins exactly once (its UPDATE is gated on ``enabled``), and the
+  caller only notifies the owner when it wins. If surfacing the chat committed
+  separately, a failure between the two commits would leave the record
+  escalated, the chat hidden, and the owner never told — with no retry able to
+  repair it. Staging both in one transaction makes the failure recoverable.
+  """
+  from app.routes.chats import _visible_in_owner_drawer
+
+  autopilot.stamp_grant(db, 1, "rec", head_sha="abc")
+  chat_id = autopilot.ensure_followup_chat(
+    db, 1, "rec", title="Autopilot: fix thing", provider="claude",
+  )
+
+  def _chat():
+    db.expire_all()
+    return db.query(models.Chat).filter(models.Chat.id == chat_id).first()
+
+  boom = RuntimeError("database is locked")
+  original = autopilot.stage_followup_drawer_hidden
+  autopilot.stage_followup_drawer_hidden = lambda *a, **k: (_ for _ in ()).throw(boom)
+  try:
+    with pytest.raises(RuntimeError):
+      autopilot.escalate(db, 1, "rec")
+    db.rollback()
+  finally:
+    autopilot.stage_followup_drawer_hidden = original
+
+  # Nothing was consumed: the grant is still live and the chat still tucked away.
+  db.expire_all()
+  assert autopilot.get_row(db, 1, "rec").enabled is True
+  assert _visible_in_owner_drawer(_chat()) is False
+
+  # The retry that the cron pass makes next wins and surfaces the chat.
+  assert autopilot.escalate(db, 1, "rec") is True
+  assert _visible_in_owner_drawer(_chat()) is True
+
+
 def test_round_log_capped(db):
   autopilot.stamp_grant(db, 1, "rec", head_sha="abc")
   for i in range(40):


### PR DESCRIPTION
## Summary
Autopilot review-followup chats are created as ordinary owner chats, so every automated round appears in the chat drawer. Most rounds resolve themselves — a check flake clears, a fix is pushed — and never need the owner, yet each one leaves a lingering "Autopilot: …" entry cluttering the chat list.

This keeps those chats hidden by default and surfaces them only when a round escalates and genuinely needs the owner's decision, then hides them again once the owner takes control (pause/resume) or the PR merges or closes.

## What changes
- `_visible_in_owner_drawer` now honors an explicit `drawer_hidden` bit on a chat's `agent_settings_json`, overriding the default rule in either direction. This is a small, general per-chat switch, not autopilot-specific.
- Autopilot creates its follow-up chat with `drawer_hidden = True`, flips it visible when `escalate()` wins, and back to hidden on `set_enabled()` (pause/resume) and `close_out()` (terminal merge/close).
- The follow-up chat stays an ordinary owner chat (`created_by_app_id = None`), so agent turns, notifications, and the conversation itself are unchanged — only its presence in the drawer list is gated.

## Tests
- Added unit coverage for the visibility override and the full autopilot chat lifecycle: created hidden → surfaced on escalation → hidden on resume → hidden on close-out.

## Notes
- No schema change: reuses the existing `agent_settings_json` JSON column, so no migration is needed.
- A chat created before this change carries no flag and stays visible until its next pause/resume or close-out, at which point it is hidden — so existing autopilot chats converge to the new behavior without a backfill.