### PR TITLE
Make the drawer resize regression test reproduce capture loss

### DIFF
--- a/tests/navigation.spec.mjs
+++ b/tests/navigation.spec.mjs
@@ -1359,7 +1359,13 @@ test.describe('Drawer close paths converge through handleBack', () => {
     const released = await handle.evaluate((element) => {
       for (let pointerId = 1; pointerId <= 5; pointerId += 1) {
         if (!element.hasPointerCapture(pointerId)) continue
-        element.releasePointerCapture(pointerId)
+        // A programmatic releasePointerCapture() only flushes lostpointercapture
+        // on the next pointer-event dispatch, so dispatch the capture-loss event
+        // the browser itself delivers when a drag's capture is interrupted.
+        element.dispatchEvent(new PointerEvent('lostpointercapture', {
+          pointerId,
+          bubbles: true,
+        }))
         return true
       }
       return false


### PR DESCRIPTION
The drawer resize regression added in #223 asserts that the drawer leaves its
resizing state when a drag's pointer capture is interrupted. It released the
capture programmatically, and a programmatic `releasePointerCapture()` only
queues `lostpointercapture` — the browser withholds it until the next pointer
event is dispatched. The assertion therefore polled its whole budget before
anything arrived, and the test merged red.

Dispatch the `lostpointercapture` event the browser itself delivers on a real
capture interruption, so the handler runs when the test expects it and the
three assertions after it — the resizing class, the persisted width, and the
stored width — are reachable for the first time.

Verified in the browser this suite actually runs rather than by reading the
spec: with the old form no `lostpointercapture` is delivered for 300ms+ until
another pointer event flushes it; with the new one the handler runs
synchronously, the drag's own release still happens, and the later trusted
event is a clean no-op.

Test-only. No production code changes.