### PR TITLE
Keep memory sampling off the chat turn path

### DIFF
--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -79,7 +79,6 @@ from app.events import (
   undo_question_scrub,
 )
 from app.providers import effective_agent_settings, get_provider, get_skill_path
-from app.memory_observability import record_memory_checkpoint
 from app.runner_registry import registry
 from app.runtime_types import ChatEvent
 
@@ -4425,12 +4424,6 @@ async def run_chat(
   # (which `_run_chat_impl` doesn't catch) leaves the marker set for
   # reconciliation rather than silently wiping it — the safe default.
   disposition = chat_queue.TerminalDisposition.FAILED_LEAVE_MARKER
-  record_memory_checkpoint(
-    "turn_start",
-    chat_id=chat_id,
-    provider_id=provider_id,
-    run_generation=run_gen,
-  )
   try:
     disposition = await _run_chat_impl(
       messages, chat_id=chat_id, session_id=session_id,
@@ -4549,16 +4542,6 @@ async def run_chat(
         )
     except Exception:
       _get_logger().debug("chat-note guarantee skipped", exc_info=True)
-    # One terminal sample after provider teardown, browser cleanup, queue
-    # transition, and the settled-chat publisher. Comparing it with turn_start
-    # exposes memory that a completed turn failed to release without polling
-    # continuously during ordinary operation.
-    record_memory_checkpoint(
-      "turn_end",
-      chat_id=chat_id,
-      provider_id=provider_id,
-      disposition=disposition.value,
-    )
 
 
 def _chat_note_mtime(data_dir: str, chat_id: str) -> float:

--- a/backend/scripts/seed-skills/reflection.md
+++ b/backend/scripts/seed-skills/reflection.md
@@ -236,6 +236,12 @@ Start with `inputs/resource-snapshot.json`, the bounded
 - **Use trends and thresholds.** Compare the cheap pulse with recent history.
   Inspect the deep inventory only when `deep_scan.ran` and note whether it was
   complete. One large category is a lead, not permission to delete it.
+- **Attribute memory before acting.** The snapshot's `memory` block separates
+  Möbius server PSS, container working set/reclaimable cache, and aggregate
+  owner categories such as browsers, agents, installed services, and frontend
+  tools. Compare `trend.memory` across comparable nights. A single active-work
+  spike is context, not a leak; surface memory only when an owner-specific rise
+  persists, swap/pressure appears, or a recorded review trigger fires.
 - **Make review cadence adaptive.** Every resource area has a next review and
   an early trigger. A new or unstable leak may be checked tomorrow. After a
   programmatic cap has held through several observations, stretch the cadence


### PR DESCRIPTION
Every chat turn recorded two memory checkpoints, and each one reads
`/proc/<pid>/smaps_rollup` synchronously from inside the turn coroutine —
measured at ~8.5ms per call on a live server, so ~17ms per turn of blocked
event loop shared with every concurrent stream and database operation. The
cost scales with the process's mapping count, so it grows as the instance
does.

Nothing consumed those per-turn samples. The checkpoint deque is read only by
the debug memory endpoint, and the nightly resource snapshot that actually
reports memory trends never looks at it. Meanwhile turn traffic evicted the
128-entry deque continuously, so the startup boundary samples — the ones that
are genuinely diagnostic — were gone after a few dozen turns.

Drop the two per-turn calls and point the Reflection guidance at the nightly
snapshot's owner-attributed memory block, which is where the durable trend
already lives. The startup boundaries now survive for the whole process
lifetime.

`record_memory_checkpoint` remains in use at the eleven startup boundaries and
in the chat routes and Codex runner; only the two hot-path calls are removed.