### PR TITLE
Cite the notes a turn recalled from memory

### DIFF
--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -76,9 +76,10 @@ from app.events import (
   excerpt_tool_output,
   finalize_blocks,
   process_event,
+  tool_output_exit_code,
   undo_question_scrub,
 )
-from app.memory_recall import recall_from_command, recall_from_output
+from app.memory_recall import recall_from_command, recall_from_result
 from app.providers import effective_agent_settings, get_provider, get_skill_path
 from app.runner_registry import registry
 from app.runtime_types import ChatEvent
@@ -414,19 +415,23 @@ class _ChatEventSink:
   def _stamp_memory_recall(self, event: ChatEvent) -> None:
     """Name a Memory-app recall on the event, in two lifecycle phases.
 
-    At input time the command identifies the lookup, so the live turn can say
-    it is remembering while the search still runs. At output time that same
-    tool's stdout is parsed into the notes it actually returned — including the
-    honest "found nothing" outcome, which is otherwise indistinguishable from
-    never having looked.
+    The documented simple command identifies the lookup, so the live turn can
+    say it is remembering while the search runs. Only the final output event
+    settles it from the Memory app's structured result; streaming deltas cannot
+    prematurely claim success, emptiness, or failure.
     """
-    if event.get("type") == "tool_input":
+    if event.get("type") in ("tool_start", "tool_input"):
+      if event.get("type") == "tool_start" and event.get("tool") != "Bash":
+        return
       recall = recall_from_command(event.get("input"))
       if recall is not None:
         event["recall"] = recall
       return
-    if self._tool_was_memory_recall(event.get("tool_use_id")):
-      event["recall"] = recall_from_output(event.get("content"))
+    if (event.get("output_complete")
+        and self._tool_was_memory_recall(event.get("tool_use_id"))):
+      event["recall"] = recall_from_result(
+        event.get("content"), event.get("output_exit_code"),
+      )
 
   def _reduce_tool_output(self, event: ChatEvent) -> None:
     """Move a large tool_output's full text OFF the wire (contract rule 6).
@@ -545,12 +550,14 @@ class _ChatEventSink:
     # and before the broadcast below, so the rewritten event is the single
     # source feeding the persisted block, the live wire, and the catch-up log.
     #
-    # Memory recall is stamped just BEFORE that reduction, for the same reason
-    # and on the same funnel: a full lookup's stdout exceeds the inline
-    # threshold, so parsing after rule-6 carving would silently lose the note
-    # titles that make a citation readable. One stamp here reaches the persisted
-    # block, the live wire, and the catch-up log alike, for both runners.
-    if event_type in ("tool_input", "tool_output"):
+    # Memory recall is stamped just BEFORE that reduction on the same funnel.
+    # The app prints its bounded structured result last, so one validated stamp
+    # reaches the persisted block, live wire, and catch-up log for both runners.
+    if event_type == "tool_output" and event.get("output_exit_code") is None:
+      exit_code = tool_output_exit_code(event.get("content"))
+      if exit_code is not None:
+        event["output_exit_code"] = exit_code
+    if event_type in ("tool_start", "tool_input", "tool_output"):
       self._stamp_memory_recall(event)
     if event_type == "tool_output":
       self._reduce_tool_output(event)

--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -78,6 +78,7 @@ from app.events import (
   process_event,
   undo_question_scrub,
 )
+from app.memory_recall import recall_from_command, recall_from_output
 from app.providers import effective_agent_settings, get_provider, get_skill_path
 from app.runner_registry import registry
 from app.runtime_types import ChatEvent
@@ -389,6 +390,44 @@ class _ChatEventSink:
 
     ack.add_done_callback(_log_if_failed)
 
+  def _tool_was_memory_recall(self, tool_use_id) -> bool:
+    """Whether this tool was identified as a Memory lookup at input time.
+
+    Read-only by design: resolving the block is a question, not the place to
+    adopt a legacy id (`process_event` still owns that a moment later). Only a
+    tool whose COMMAND named memory_search may go on to cite notes, so output
+    text alone can never mint a citation.
+    """
+    for blk in reversed(self.assistant_blocks):
+      if blk.get("type") != "tool":
+        continue
+      if tool_use_id:
+        if blk.get("tool_use_id") == tool_use_id:
+          return isinstance(blk.get("recall"), dict)
+        continue
+      # Legacy events without an id: the newest still-open tool is the only
+      # safe candidate, matching `_tool_block_for_event`'s fallback.
+      if blk.get("status") != "done":
+        return isinstance(blk.get("recall"), dict)
+    return False
+
+  def _stamp_memory_recall(self, event: ChatEvent) -> None:
+    """Name a Memory-app recall on the event, in two lifecycle phases.
+
+    At input time the command identifies the lookup, so the live turn can say
+    it is remembering while the search still runs. At output time that same
+    tool's stdout is parsed into the notes it actually returned — including the
+    honest "found nothing" outcome, which is otherwise indistinguishable from
+    never having looked.
+    """
+    if event.get("type") == "tool_input":
+      recall = recall_from_command(event.get("input"))
+      if recall is not None:
+        event["recall"] = recall
+      return
+    if self._tool_was_memory_recall(event.get("tool_use_id")):
+      event["recall"] = recall_from_output(event.get("content"))
+
   def _reduce_tool_output(self, event: ChatEvent) -> None:
     """Move a large tool_output's full text OFF the wire (contract rule 6).
 
@@ -505,6 +544,14 @@ class _ChatEventSink:
     # its full text BEFORE process_event (which copies content onto the block)
     # and before the broadcast below, so the rewritten event is the single
     # source feeding the persisted block, the live wire, and the catch-up log.
+    #
+    # Memory recall is stamped just BEFORE that reduction, for the same reason
+    # and on the same funnel: a full lookup's stdout exceeds the inline
+    # threshold, so parsing after rule-6 carving would silently lose the note
+    # titles that make a citation readable. One stamp here reaches the persisted
+    # block, the live wire, and the catch-up log alike, for both runners.
+    if event_type in ("tool_input", "tool_output"):
+      self._stamp_memory_recall(event)
     if event_type == "tool_output":
       self._reduce_tool_output(event)
     if event_type == "thinking":

--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -391,8 +391,8 @@ class _ChatEventSink:
 
     ack.add_done_callback(_log_if_failed)
 
-  def _tool_was_memory_recall(self, tool_use_id) -> bool:
-    """Whether this tool was identified as a Memory lookup at input time.
+  def _memory_recall_for_tool(self, tool_use_id) -> dict | None:
+    """Return the input-time Memory marker for this tool, if there is one.
 
     Read-only by design: resolving the block is a question, not the place to
     adopt a legacy id (`process_event` still owns that a moment later). Only a
@@ -404,13 +404,18 @@ class _ChatEventSink:
         continue
       if tool_use_id:
         if blk.get("tool_use_id") == tool_use_id:
-          return isinstance(blk.get("recall"), dict)
+          recall = blk.get("recall")
+          return recall if isinstance(recall, dict) else None
         continue
       # Legacy events without an id: the newest still-open tool is the only
       # safe candidate, matching `_tool_block_for_event`'s fallback.
       if blk.get("status") != "done":
-        return isinstance(blk.get("recall"), dict)
-    return False
+        recall = blk.get("recall")
+        return recall if isinstance(recall, dict) else None
+    return None
+
+  def _tool_was_memory_recall(self, tool_use_id) -> bool:
+    return self._memory_recall_for_tool(tool_use_id) is not None
 
   def _stamp_memory_recall(self, event: ChatEvent) -> None:
     """Name a Memory-app recall on the event, in two lifecycle phases.
@@ -423,17 +428,34 @@ class _ChatEventSink:
     if event.get("type") in ("tool_start", "tool_input"):
       if event.get("type") == "tool_start" and event.get("tool") != "Bash":
         return
+      # Both a tool_start AND a tool_input can arrive for one tool call on the
+      # Claude runner. Stamp the command-derived marker exactly once per block:
+      # if the block for this tool_use_id already carries a recall marker, leave
+      # it settled and skip. (Codex has no tool_input; Claude's tool_start input
+      # is empty, so in practice only one phase produces a marker — this keeps a
+      # future runner that populates both from double-stamping.)
+      if self._tool_was_memory_recall(event.get("tool_use_id")):
+        return
       recall = recall_from_command(event.get("input"))
       if recall is not None:
         event["recall"] = recall
       return
-    if (event.get("output_complete")
-        and self._tool_was_memory_recall(event.get("tool_use_id"))):
-      event["recall"] = recall_from_result(
+    pending = self._memory_recall_for_tool(event.get("tool_use_id"))
+    if event.get("output_complete") and pending is not None:
+      settled = recall_from_result(
         event.get("content"), event.get("output_exit_code"),
       )
+      # The command path is the authoritative installed-app identity. Stamp it
+      # onto each successful note so deep links keep working when the official
+      # system app had to install as memory-2 (or another numeric suffix).
+      app_slug = pending.get("app_slug")
+      if settled.get("status") == "hit" and isinstance(app_slug, str):
+        settled["notes"] = [
+          {**note, "app_slug": app_slug} for note in settled.get("notes", [])
+        ]
+      event["recall"] = settled
 
-  def _reduce_tool_output(self, event: ChatEvent) -> None:
+  def _reduce_tool_output(self, event: ChatEvent) -> bool:
     """Move a large tool_output's full text OFF the wire (contract rule 6).
 
     This is the single funnel where the live SSE push, the catch-up event_log,
@@ -460,11 +482,11 @@ class _ChatEventSink:
     content = event.get("content")
     if (not isinstance(content, str)
         or len(content) <= TOOL_OUTPUT_INLINE_THRESHOLD):
-      return
+      return False
     if not self.chat_id:
       # No chat to key a stash by (a detached/synthetic sink — chat_id is always
       # set on the live path). Can't move the text off-wire safely, so leave it.
-      return
+      return False
     tool_use_id = event.get("tool_use_id")
     if not tool_use_id:
       # Unexpected post-card-221: mint a stash id and stamp it on the event so
@@ -476,16 +498,21 @@ class _ChatEventSink:
         "minted stash id %s", self.chat_id, tool_use_id,
       )
     full = content
-    excerpt, full_len, exit_code = excerpt_tool_output(full)
+    excerpt, full_len, parsed_exit_code = excerpt_tool_output(full)
     event["content"] = excerpt
     event["output_truncated"] = True
     event["output_full_len"] = full_len
-    event["output_exit_code"] = exit_code
+    # Codex can supply a typed exit code independently of its display text.
+    # That runner-owned fact outranks best-effort parsing of the excerpt.
+    typed_exit_code = event.get("output_exit_code")
+    if not isinstance(typed_exit_code, int) or isinstance(typed_exit_code, bool):
+      event["output_exit_code"] = parsed_exit_code
     self._submit_fire_and_forget(
       StashToolOutput(
         chat_id=self.chat_id, tool_use_id=tool_use_id, output=full,
       )
     )
+    return True
 
   def record_lifecycle(self, event: dict) -> None:
     """Queue private lifecycle metadata without broadcasting it.
@@ -550,17 +577,18 @@ class _ChatEventSink:
     # and before the broadcast below, so the rewritten event is the single
     # source feeding the persisted block, the live wire, and the catch-up log.
     #
-    # Memory recall is stamped just BEFORE that reduction on the same funnel.
-    # The app prints its bounded structured result last, so one validated stamp
-    # reaches the persisted block, live wire, and catch-up log for both runners.
-    if event_type == "tool_output" and event.get("output_exit_code") is None:
-      exit_code = tool_output_exit_code(event.get("content"))
-      if exit_code is not None:
-        event["output_exit_code"] = exit_code
+    # Reduce first so a large JSON envelope is parsed only once. The app prints
+    # its bounded structured Memory result last, so the carved tail still
+    # contains the line that settles a recognized lookup.
+    output_reduced = False
+    if event_type == "tool_output":
+      output_reduced = self._reduce_tool_output(event)
+      if not output_reduced and event.get("output_exit_code") is None:
+        exit_code = tool_output_exit_code(event.get("content"))
+        if exit_code is not None:
+          event["output_exit_code"] = exit_code
     if event_type in ("tool_start", "tool_input", "tool_output"):
       self._stamp_memory_recall(event)
-    if event_type == "tool_output":
-      self._reduce_tool_output(event)
     if event_type == "thinking":
       self._prepare_thinking_event(event)
 

--- a/backend/app/chat_transcript.py
+++ b/backend/app/chat_transcript.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import re
 
+from app.memory_recall import RECALL_HIT, merge_recall_notes
+
 
 _QUESTION_TOOLS = {"AskUserQuestion", "request_user_input"}
 _IMAGE_PATH_RE = re.compile(
@@ -116,7 +118,14 @@ def historical_tool_output_ids(
 
 def _distinctive_activity(block: dict) -> bool:
   """Keep notable one-line activity beats out of a folded metadata run."""
-  if block.get("type") != "tool" or block.get("tool") != "Read":
+  if block.get("type") != "tool":
+    return False
+  # Consulting Memory is a beat worth seeing on its own, not shell housekeeping
+  # folded into "ran commands". The marker was stamped from the command itself,
+  # so this needs no knowledge of how that command is spelled.
+  if isinstance(block.get("recall"), dict):
+    return True
+  if block.get("tool") != "Read":
     return False
   raw = block.get("input")
   if isinstance(raw, dict):
@@ -161,6 +170,11 @@ def _compact_activity_item(block: dict) -> dict:
   # tool input remains in the on-demand activity detail.
   if block.get("tool") == "Read" and isinstance(block.get("input"), str):
     tool["input"] = block["input"][:2048]
+  # A Memory recall is already a bounded citation set, and it is what the
+  # collapsed line says ("Recalled 4 notes from Memory"). Dropping it here
+  # would make the beat visible live and gone on the next chat load.
+  if isinstance(block.get("recall"), dict):
+    tool["recall"] = block["recall"]
   return tool
 
 
@@ -242,6 +256,23 @@ def _compact_activity_run(
     if len(sources) >= _MAX_COMPACT_SOURCES:
       break
 
+  # Memory citations roll up for the same reason web sources do: the message
+  # renders them once per turn, so they must outlive the individual tool blocks
+  # this projection folds away. `_compact_activity_entries` keeps only two
+  # entries per tool name, so without this a third lookup's notes would vanish.
+  recall_notes: list[dict] = []
+  seen_recall_paths: set[str] = set()
+  recall_status = ""
+  for _, block in blocks:
+    recall = block.get("recall")
+    if not isinstance(recall, dict):
+      continue
+    # Any lookup that returned something outranks one that came back empty:
+    # the turn did remember, even if another probe found nothing.
+    if recall_status != RECALL_HIT:
+      recall_status = recall.get("status") or recall_status
+    merge_recall_notes(recall_notes, seen_recall_paths, recall)
+
   start = blocks[0][0]
   end = blocks[-1][0] + 1
   return {
@@ -255,6 +286,10 @@ def _compact_activity_run(
       block.get("type") == "tool" for _, block in blocks
     ),
     **({"sources": sources} if sources else {}),
+    **(
+      {"recall": {"status": recall_status, "notes": recall_notes}}
+      if recall_status else {}
+    ),
   }
 
 

--- a/backend/app/chat_transcript.py
+++ b/backend/app/chat_transcript.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 import re
 
-from app.memory_recall import RECALL_HIT, merge_recall_notes
+from app.memory_recall import (
+  RECALL_EMPTY,
+  RECALL_FAILED,
+  RECALL_HIT,
+  RECALL_SEARCHING,
+  merge_recall_notes,
+)
 
 
 _QUESTION_TOOLS = {"AskUserQuestion", "request_user_input"}
@@ -263,14 +269,22 @@ def _compact_activity_run(
   recall_notes: list[dict] = []
   seen_recall_paths: set[str] = set()
   recall_status = ""
+  recall_rank = {
+    RECALL_SEARCHING: 0,
+    RECALL_FAILED: 1,
+    RECALL_EMPTY: 2,
+    RECALL_HIT: 3,
+  }
   for _, block in blocks:
     recall = block.get("recall")
     if not isinstance(recall, dict):
       continue
-    # Any lookup that returned something outranks one that came back empty:
-    # the turn did remember, even if another probe found nothing.
-    if recall_status != RECALL_HIT:
-      recall_status = recall.get("status") or recall_status
+    # A real hit outranks an empty search, which outranks a failed probe. This
+    # preserves useful evidence without letting one failure erase a successful
+    # result elsewhere in the same folded run.
+    status = recall.get("status")
+    if recall_rank.get(status, -1) > recall_rank.get(recall_status, -1):
+      recall_status = status
     merge_recall_notes(recall_notes, seen_recall_paths, recall)
 
   start = blocks[0][0]

--- a/backend/app/claude_sdk_runner.py
+++ b/backend/app/claude_sdk_runner.py
@@ -1022,6 +1022,7 @@ def dispatch_sdk_message(
           "type": "tool_output",
           "content": output,
           "tool_use_id": block.tool_use_id,
+          "output_complete": True,
         })
         if output.startswith("Web search results for query"):
           sources = sources_from_websearch_text(output)

--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -1193,9 +1193,13 @@ def _tool_completed_events(item: Any, sdk: dict[str, Any]) -> list[dict[str, Any
 
   if isinstance(item, sdk["CommandExecutionThreadItem"]):
     output = (item.aggregated_output or "").strip()
-    events: list[dict[str, Any]] = []
-    if output:
-      events.append({"type": "tool_output", "content": output})
+    exit_code = getattr(item, "exit_code", None)
+    events: list[dict[str, Any]] = [{
+      "type": "tool_output",
+      "content": output,
+      "output_complete": True,
+      **({"output_exit_code": exit_code} if isinstance(exit_code, int) else {}),
+    }]
     events.append({"type": "tool_end"})
     return events
 

--- a/backend/app/events.py
+++ b/backend/app/events.py
@@ -334,6 +334,20 @@ def _tool_output_exit_code(content: str, parsed):
   return int(m.group(1)) if m else None
 
 
+def tool_output_exit_code(content: object):
+  """Return a typed command exit code from any sized tool output."""
+  if not isinstance(content, str):
+    return None
+  parsed = None
+  stripped = content.lstrip()
+  if stripped[:1] in ("{", "["):
+    try:
+      parsed = json.loads(content)
+    except (ValueError, TypeError):
+      parsed = None
+  return _tool_output_exit_code(content, parsed)
+
+
 def excerpt_tool_output(content: str):
   """Reduce a large tool_output string to (excerpt, full_len, exit_code).
 
@@ -574,6 +588,8 @@ def process_event(event: dict, assistant_blocks: list) -> bool:
     tool_use_id = event.get("tool_use_id")
     if tool_use_id:
       block["tool_use_id"] = tool_use_id
+    if isinstance(event.get("recall"), dict):
+      block["recall"] = event["recall"]
     assistant_blocks.append(block)
     return True
 
@@ -624,12 +640,12 @@ def process_event(event: dict, assistant_blocks: list) -> bool:
       # the full text and read a failure exit code from a field, not a parse
       # of the possibly-carved excerpt. Absent fields leave the block shape
       # unchanged (a small, un-reduced output).
+      exit_code = event.get("output_exit_code")
+      if exit_code is not None:
+        blk["output_exit_code"] = exit_code
       if event.get("output_truncated"):
         blk["output_truncated"] = True
         blk["output_full_len"] = event.get("output_full_len")
-        exit_code = event.get("output_exit_code")
-        if exit_code is not None:
-          blk["output_exit_code"] = exit_code
       # Settle a Memory lookup from "searching" to what it actually recalled.
       # The sink parsed this from the FULL output, before the carving above.
       if isinstance(event.get("recall"), dict):

--- a/backend/app/events.py
+++ b/backend/app/events.py
@@ -647,7 +647,8 @@ def process_event(event: dict, assistant_blocks: list) -> bool:
         blk["output_truncated"] = True
         blk["output_full_len"] = event.get("output_full_len")
       # Settle a Memory lookup from "searching" to what it actually recalled.
-      # The sink parsed this from the FULL output, before the carving above.
+      # The app prints its bounded result last, so it survives any head+tail
+      # carving the sink performed before parsing.
       if isinstance(event.get("recall"), dict):
         blk["recall"] = event["recall"]
       return True

--- a/backend/app/events.py
+++ b/backend/app/events.py
@@ -581,12 +581,21 @@ def process_event(event: dict, assistant_blocks: list) -> bool:
     # Backfill the input summary. Prefer an exact tool_use_id match (Codex
     # backfills a WebSearch query at completion, when several searches may be
     # in flight); older id-less events retain the earliest input-less fallback.
+    def _apply_tool_input(blk: dict) -> None:
+      blk["input"] = event.get("input", "")
+      # A Memory lookup is identified from the command it runs (stamped on the
+      # event by the sink). Carrying that marker onto the block is what lets the
+      # turn name the recall while it is still running, and is the ONLY thing
+      # that authorizes the later output phase to cite notes.
+      if isinstance(event.get("recall"), dict):
+        blk["recall"] = event["recall"]
+
     tool_use_id = event.get("tool_use_id")
     if tool_use_id:
       for blk in assistant_blocks:
         if (blk.get("type") == "tool"
             and blk.get("tool_use_id") == tool_use_id):
-          blk["input"] = event.get("input", "")
+          _apply_tool_input(blk)
           return True
       candidates = [
         blk for blk in assistant_blocks
@@ -596,12 +605,12 @@ def process_event(event: dict, assistant_blocks: list) -> bool:
       ]
       if len(candidates) == 1:
         candidates[0]["tool_use_id"] = tool_use_id
-        candidates[0]["input"] = event.get("input", "")
+        _apply_tool_input(candidates[0])
         return True
       return False
     for blk in assistant_blocks:
       if blk.get("type") == "tool" and not blk.get("input"):
-        blk["input"] = event.get("input", "")
+        _apply_tool_input(blk)
         break
     return True
 
@@ -621,6 +630,10 @@ def process_event(event: dict, assistant_blocks: list) -> bool:
         exit_code = event.get("output_exit_code")
         if exit_code is not None:
           blk["output_exit_code"] = exit_code
+      # Settle a Memory lookup from "searching" to what it actually recalled.
+      # The sink parsed this from the FULL output, before the carving above.
+      if isinstance(event.get("recall"), dict):
+        blk["recall"] = event["recall"]
       return True
     return False
 

--- a/backend/app/memory_recall.py
+++ b/backend/app/memory_recall.py
@@ -67,6 +67,8 @@ _RESULT_RE = re.compile(
 # anything else keeps traversal, absolute paths, and control characters out of
 # a value the client turns into a deep link.
 _PATH_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]*\.md$")
+_NOTE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+_MAX_NOTE_ID_CHARS = 128
 
 
 def _clean(value: str, limit: int) -> str:
@@ -82,6 +84,24 @@ def _note_id(path: str) -> str:
   """The graph node id for a citation path: its file stem."""
   tail = path.rsplit("/", 1)[-1]
   return tail[:-3] if tail.endswith(".md") else tail
+
+
+def _safe_note_id(value: object, path: str) -> str:
+  """Keep the graph's real node id, with a path-stem fallback for old apps.
+
+  A graph id is not required to equal its markdown filename. The Memory app
+  opens nodes by id, so replacing a valid structured id with the path stem
+  makes a well-formed citation navigate to nowhere whenever those differ.
+  """
+  if isinstance(value, str):
+    candidate = value.strip()
+    if (
+      candidate
+      and len(candidate) <= _MAX_NOTE_ID_CHARS
+      and _NOTE_ID_RE.fullmatch(candidate)
+    ):
+      return candidate
+  return _note_id(path)
 
 
 def _title_from_path(path: str) -> str:
@@ -211,7 +231,7 @@ def recall_from_result(text: object, exit_code: object = None) -> dict:
     title = _clean(raw_note.get("title"), MAX_RECALL_TITLE_CHARS)
     excerpt = _clean(raw_note.get("excerpt"), MAX_RECALL_EXCERPT_CHARS)
     note = {
-      "id": _note_id(path),
+      "id": _safe_note_id(raw_note.get("id"), path),
       "path": path,
       "title": title or _title_from_path(path) or path,
     }

--- a/backend/app/memory_recall.py
+++ b/backend/app/memory_recall.py
@@ -52,7 +52,9 @@ RECALL_FAILED = "failed"
 _MAX_COMMAND_SCAN_CHARS = 8192
 _ENV_ASSIGN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
 _INTERPRETER_RE = re.compile(r"^(?:.*/)?python[0-9.]*$")
-_SCRIPT_RE = re.compile(r"^/data/apps/memory(?:-[0-9]+)?/memory_search\.py$")
+_SCRIPT_RE = re.compile(
+  r"^/data/apps/(?P<app_slug>memory(?:-[0-9]+)?)/memory_search\.py$"
+)
 _CONTROL_TOKEN_RE = re.compile(r"^[;&|()<>]+$")
 
 _RESULT_PREFIX = "MOBIUS_MEMORY_RESULT_V1:"
@@ -115,22 +117,34 @@ def _simple_command_tokens(command: str) -> list[str] | None:
   return tokens
 
 
-def _tokens_run_search(tokens: list[str]) -> bool:
+def _tokens_search_slug(tokens: list[str]) -> str | None:
+  """Return the invoked Memory app slug for the exact documented command.
+
+  Exact arity is a security boundary, not mere tidiness: ``shlex`` treats a
+  newline as whitespace, so accepting arbitrary trailing tokens would also
+  accept a second shell command whose output could forge the structured result
+  line. The supported command is env assignments + Python flags + script +
+  query + chat id, and then it must end.
+  """
   index = 0
   while index < len(tokens) and _ENV_ASSIGN_RE.match(tokens[index]):
     index += 1
   if index >= len(tokens):
-    return False
+    return None
   head = tokens[index]
-  if _SCRIPT_RE.match(head):
-    return len(tokens) > index + 2
+  direct = _SCRIPT_RE.fullmatch(head)
+  if direct:
+    return direct.group("app_slug") if len(tokens) == index + 3 else None
   if not _INTERPRETER_RE.match(head):
-    return False
+    return None
   for script_index, token in enumerate(tokens[index + 1:], start=index + 1):
     if token.startswith("-"):
       continue
-    return bool(_SCRIPT_RE.match(token) and len(tokens) > script_index + 2)
-  return False
+    script = _SCRIPT_RE.fullmatch(token)
+    if script and len(tokens) == script_index + 3:
+      return script.group("app_slug")
+    return None
+  return None
 
 
 def recall_from_command(command: object) -> dict | None:
@@ -150,7 +164,11 @@ def recall_from_command(command: object) -> dict | None:
   if "memory_search.py" not in command:
     return None
   tokens = _simple_command_tokens(command)
-  return {"status": RECALL_SEARCHING} if tokens and _tokens_run_search(tokens) else None
+  app_slug = _tokens_search_slug(tokens) if tokens else None
+  return (
+    {"status": RECALL_SEARCHING, "app_slug": app_slug}
+    if app_slug else None
+  )
 
 
 def recall_from_result(text: object, exit_code: object = None) -> dict:

--- a/backend/app/memory_recall.py
+++ b/backend/app/memory_recall.py
@@ -1,0 +1,255 @@
+"""Recognize Memory-app recall lookups so a turn can cite what it remembered.
+
+The Memory app is an ordinary installed app: the agent consults it by running
+``memory_search.py`` through Bash, and the notes it read come back as ordinary
+tool output. Without this module that lookup is indistinguishable from any
+other shell command, so the owner cannot tell "it remembered something" from
+"it ran housekeeping" — nor, more importantly, "it looked and found nothing"
+from "it never looked".
+
+Detection is deliberately two-phase and keyed off the tool's own lifecycle
+rather than the shape of its output:
+
+* ``recall_from_command`` matches the *command being run*. This is the only
+  positive identification; nothing here ever concludes "this was a memory
+  lookup" from output text alone, so an unrelated command that happens to
+  print ``FILES:`` can never mint a citation.
+* ``recall_from_output`` is then trusted to parse that command's stdout, and is
+  only ever called for a tool already identified by the first phase.
+
+The stdout contract belongs to the Memory app (``memory_search.py``'s
+``retrieve``/``run``) and is stable::
+
+    Relevant memories:
+    - <title>: <excerpt> [<relative/path.md>]
+    - <title>: <excerpt> [<relative/path.md>]
+    FILES: notes/a.md, notes/b.md
+
+or, for a lookup that matched nothing::
+
+    No relevant memories.
+
+``FILES:`` is authoritative: those paths were opened by confined Python after
+the graph commit was pinned, whereas the ``- title: excerpt [path]`` lines are
+presentation. So paths come from ``FILES:`` and the section lines only enrich
+them with a title and excerpt. That split also makes the parse robust to the
+head+tail carving a large tool output receives (``events.py``
+``excerpt_tool_output``): both markers sit at the very start and very end of
+the stream, so a carved middle costs some titles but never the citation set.
+
+Every failure mode degrades to *less* metadata, never to a wrong citation:
+an unparseable body still yields a bounded "hit" with path-derived titles, and
+a missing command summary yields no recall at all.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Recall metadata rides inline on the SSE event, the persisted tool block, and
+# the compacted activity summary — the same budget the web-source citations
+# live within. memory_search.py itself returns at most 6 files with 900-char
+# excerpts; these ceilings leave headroom without letting a malformed or
+# hostile stdout inflate every transcript read.
+MAX_RECALL_NOTES = 12
+MAX_RECALL_TITLE_CHARS = 120
+MAX_RECALL_EXCERPT_CHARS = 300
+MAX_RECALL_PATH_CHARS = 256
+_MAX_OUTPUT_SCAN_CHARS = 262_144
+_MAX_SECTION_LINES_SCANNED = 256
+
+RECALL_SEARCHING = "searching"
+RECALL_HIT = "hit"
+RECALL_EMPTY = "empty"
+
+# The command summary the backend builds for Bash is the verbatim command
+# string, so identification means answering "did this command RUN the search
+# script?" — not "does this command mention it?". Substring matching gets that
+# wrong in the most ordinary way possible: `grep -rn memory_search.py …` and
+# `cat memory_search.py` both name the script while doing something else
+# entirely, and either would mint a citation from unrelated output.
+#
+# So the command is split into segments and each segment's HEAD is inspected:
+# a lookup is either the script executed directly or an interpreter invoked on
+# it. Anything where the script is a mere argument is correctly ignored.
+_MAX_COMMAND_SCAN_CHARS = 8192
+_SEGMENT_RE = re.compile(r"[;&|\n]+")
+_ENV_ASSIGN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+_INTERPRETER_RE = re.compile(r"^(?:.*/)?python[0-9.]*$")
+_SCRIPT_RE = re.compile(r"^(?:.*/)?memory_search\.py$")
+
+_EMPTY_RE = re.compile(r"^No relevant memories\.\s*$", re.MULTILINE)
+_FILES_RE = re.compile(r"^FILES:[ \t]*(.+)$", re.MULTILINE)
+# "- <title>: <excerpt> [<path>]" — the excerpt is greedy-free and the path is
+# anchored to the end of the line, matching how memory_search.py builds it.
+_SECTION_RE = re.compile(r"^- (.*?): (.*) \[([^\]]+)\]$", re.MULTILINE)
+
+# A citation path is only ever a repository-relative markdown pointer. Refusing
+# anything else keeps traversal, absolute paths, and control characters out of
+# a value the client turns into a deep link.
+_PATH_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]*\.md$")
+
+
+def _clean(value: str, limit: int) -> str:
+  """Collapse whitespace and bound a label taken from tool output."""
+  if not isinstance(value, str):
+    return ""
+  # Slice before normalizing so a pathological line cannot allocate another
+  # full-size string merely to produce a short label.
+  return re.sub(r"\s+", " ", value[: limit * 2]).strip()[:limit]
+
+
+def _note_id(path: str) -> str:
+  """The graph node id for a citation path: its file stem."""
+  tail = path.rsplit("/", 1)[-1]
+  return tail[:-3] if tail.endswith(".md") else tail
+
+
+def _title_from_path(path: str) -> str:
+  """A readable fallback when the titled section line was carved away."""
+  return _note_id(path).replace("-", " ").replace("_", " ").strip()
+
+
+def _safe_path(value: str) -> str:
+  if not isinstance(value, str):
+    return ""
+  candidate = value.strip()
+  if not candidate or len(candidate) > MAX_RECALL_PATH_CHARS:
+    return ""
+  if ".." in candidate or candidate.startswith("/"):
+    return ""
+  return candidate if _PATH_RE.match(candidate) else ""
+
+
+def _segment_runs_search(segment: str) -> bool:
+  """Whether one command segment EXECUTES the memory search script."""
+  tokens = [token.strip("'\"") for token in segment.split()]
+  tokens = [token for token in tokens if token]
+  # `FOO=bar python3 script.py` — leading environment assignments are not the
+  # command being run.
+  index = 0
+  while index < len(tokens) and _ENV_ASSIGN_RE.match(tokens[index]):
+    index += 1
+  if index >= len(tokens):
+    return False
+  head = tokens[index]
+  if _SCRIPT_RE.match(head):
+    return True
+  if not _INTERPRETER_RE.match(head):
+    return False
+  # `python3 -u script.py` — interpreter flags may precede the script, but the
+  # first non-flag token is the thing actually being run.
+  for token in tokens[index + 1:]:
+    if token.startswith("-"):
+      continue
+    return bool(_SCRIPT_RE.match(token))
+  return False
+
+
+def recall_from_command(command: object) -> dict | None:
+  """Return a pending recall marker when this command RUNS a memory lookup.
+
+  Called at tool-input time so the live turn can name what it is doing while
+  the lookup is still in flight. Returning ``None`` means "not a memory
+  lookup", which is also the safe answer for a missing or oversized command
+  summary — and, deliberately, for any command that merely names the script.
+  """
+  if not isinstance(command, str) or not command:
+    return None
+  if len(command) > _MAX_COMMAND_SCAN_CHARS:
+    return None
+  # Cheap reject before tokenizing: the overwhelming majority of commands are
+  # not memory lookups and should cost one substring scan.
+  if "memory_search.py" not in command:
+    return None
+  for segment in _SEGMENT_RE.split(command):
+    if _segment_runs_search(segment):
+      return {"status": RECALL_SEARCHING}
+  return None
+
+
+def recall_from_output(text: object) -> dict:
+  """Parse a known memory lookup's stdout into a bounded citation set.
+
+  Only ever called for a tool ``recall_from_command`` already identified, so
+  an unrecognized body is a lookup whose output we could not read — not a
+  reason to claim nothing was found. That case returns a note-less ``hit``,
+  which renders as a plain "recalled from Memory" beat rather than the far
+  stronger (and possibly false) "nothing relevant" claim.
+  """
+  if not isinstance(text, str) or not text.strip():
+    # No output at all: the command produced nothing readable. Keep the beat,
+    # drop the claim.
+    return {"status": RECALL_HIT, "notes": []}
+
+  body = text[:_MAX_OUTPUT_SCAN_CHARS]
+
+  files_match = None
+  for files_match in _FILES_RE.finditer(body):
+    # The last FILES: line wins — a head+tail carve keeps the tail, and the
+    # real one is always the final line memory_search.py prints.
+    pass
+
+  if files_match is None:
+    if _EMPTY_RE.search(body):
+      return {"status": RECALL_EMPTY}
+    return {"status": RECALL_HIT, "notes": []}
+
+  titles: dict[str, tuple[str, str]] = {}
+  for index, section in enumerate(_SECTION_RE.finditer(body)):
+    if index >= _MAX_SECTION_LINES_SCANNED:
+      break
+    raw_title, raw_excerpt, raw_path = section.groups()
+    path = _safe_path(raw_path)
+    if path and path not in titles:
+      titles[path] = (
+        _clean(raw_title, MAX_RECALL_TITLE_CHARS),
+        _clean(raw_excerpt, MAX_RECALL_EXCERPT_CHARS),
+      )
+
+  notes: list[dict[str, str]] = []
+  seen: set[str] = set()
+  for raw_path in files_match.group(1).split(","):
+    path = _safe_path(raw_path)
+    if not path or path in seen:
+      continue
+    seen.add(path)
+    title, excerpt = titles.get(path, ("", ""))
+    note = {
+      "id": _note_id(path),
+      "path": path,
+      "title": title or _title_from_path(path) or path,
+    }
+    if excerpt:
+      note["excerpt"] = excerpt
+    notes.append(note)
+    if len(notes) >= MAX_RECALL_NOTES:
+      break
+
+  # A FILES: line whose every entry failed validation is a malformed citation
+  # set, not an empty lookup — same conservative fallback as an unreadable body.
+  return {"status": RECALL_HIT, "notes": notes}
+
+
+def merge_recall_notes(
+  target: list[dict[str, str]],
+  seen: set[str],
+  recall: object,
+) -> None:
+  """Accumulate one block's notes into a deduped, bounded citation list.
+
+  Shared by the transcript compaction rollup so the projection and the live
+  block agree on ordering (first occurrence owns the position) and on the cap.
+  """
+  if not isinstance(recall, dict):
+    return
+  for note in recall.get("notes") or []:
+    if not isinstance(note, dict):
+      continue
+    path = note.get("path")
+    if not isinstance(path, str) or not path or path in seen:
+      continue
+    seen.add(path)
+    target.append(note)
+    if len(target) >= MAX_RECALL_NOTES:
+      return

--- a/backend/app/memory_recall.py
+++ b/backend/app/memory_recall.py
@@ -7,48 +7,29 @@ other shell command, so the owner cannot tell "it remembered something" from
 "it ran housekeeping" — nor, more importantly, "it looked and found nothing"
 from "it never looked".
 
-Detection is deliberately two-phase and keyed off the tool's own lifecycle
-rather than the shape of its output:
+Detection is deliberately two-phase and keyed off the tool's own lifecycle:
 
-* ``recall_from_command`` matches the *command being run*. This is the only
-  positive identification; nothing here ever concludes "this was a memory
-  lookup" from output text alone, so an unrelated command that happens to
-  print ``FILES:`` can never mint a citation.
-* ``recall_from_output`` is then trusted to parse that command's stdout, and is
-  only ever called for a tool already identified by the first phase.
+* ``recall_from_command`` accepts only the simple absolute invocation documented
+  by the Memory skill. It deliberately rejects shell composition rather than
+  trying to partially parse Bash.
+* ``recall_from_result`` reads the Memory app's bounded structured result line
+  and is only called for a tool already identified by the first phase.
 
-The stdout contract belongs to the Memory app (``memory_search.py``'s
-``retrieve``/``run``) and is stable::
-
-    Relevant memories:
-    - <title>: <excerpt> [<relative/path.md>]
-    - <title>: <excerpt> [<relative/path.md>]
-    FILES: notes/a.md, notes/b.md
-
-or, for a lookup that matched nothing::
-
-    No relevant memories.
-
-``FILES:`` is authoritative: those paths were opened by confined Python after
-the graph commit was pinned, whereas the ``- title: excerpt [path]`` lines are
-presentation. So paths come from ``FILES:`` and the section lines only enrich
-them with a title and excerpt. That split also makes the parse robust to the
-head+tail carving a large tool output receives (``events.py``
-``excerpt_tool_output``): both markers sit at the very start and very end of
-the stream, so a carved middle costs some titles but never the citation set.
-
-Every failure mode degrades to *less* metadata, never to a wrong citation:
-an unparseable body still yields a bounded "hit" with path-derived titles, and
-a missing command summary yields no recall at all.
+The structured line is printed last, so head+tail carving preserves it. Human
+prose and the legacy ``FILES:`` line remain useful to the agent, but neither is
+parsed for product state. Missing, malformed, or contradictory result metadata
+is an explicit failed lookup, never a successful note-less recall.
 """
 
 from __future__ import annotations
 
+import json
 import re
+import shlex
 
 # Recall metadata rides inline on the SSE event, the persisted tool block, and
 # the compacted activity summary — the same budget the web-source citations
-# live within. memory_search.py itself returns at most 6 files with 900-char
+# live within. memory_search.py itself returns at most 4 files with 900-char
 # excerpts; these ceilings leave headroom without letting a malformed or
 # hostile stdout inflate every transcript read.
 MAX_RECALL_NOTES = 12
@@ -61,28 +42,24 @@ _MAX_SECTION_LINES_SCANNED = 256
 RECALL_SEARCHING = "searching"
 RECALL_HIT = "hit"
 RECALL_EMPTY = "empty"
+RECALL_FAILED = "failed"
 
-# The command summary the backend builds for Bash is the verbatim command
-# string, so identification means answering "did this command RUN the search
-# script?" — not "does this command mention it?". Substring matching gets that
-# wrong in the most ordinary way possible: `grep -rn memory_search.py …` and
-# `cat memory_search.py` both name the script while doing something else
-# entirely, and either would mint a citation from unrelated output.
-#
-# So the command is split into segments and each segment's HEAD is inspected:
-# a lookup is either the script executed directly or an interpreter invoked on
-# it. Anything where the script is a mere argument is correctly ignored.
+# The command summary is the verbatim Bash command. Accept only Memory's
+# documented simple absolute invocation. This is intentionally a narrow
+# protocol, not a growing shell grammar: composition, redirection, substitution,
+# and relative scripts all yield no observability marker while the command
+# itself continues to run normally.
 _MAX_COMMAND_SCAN_CHARS = 8192
-_SEGMENT_RE = re.compile(r"[;&|\n]+")
 _ENV_ASSIGN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
 _INTERPRETER_RE = re.compile(r"^(?:.*/)?python[0-9.]*$")
-_SCRIPT_RE = re.compile(r"^(?:.*/)?memory_search\.py$")
+_SCRIPT_RE = re.compile(r"^/data/apps/memory(?:-[0-9]+)?/memory_search\.py$")
+_CONTROL_TOKEN_RE = re.compile(r"^[;&|()<>]+$")
 
-_EMPTY_RE = re.compile(r"^No relevant memories\.\s*$", re.MULTILINE)
-_FILES_RE = re.compile(r"^FILES:[ \t]*(.+)$", re.MULTILINE)
-# "- <title>: <excerpt> [<path>]" — the excerpt is greedy-free and the path is
-# anchored to the end of the line, matching how memory_search.py builds it.
-_SECTION_RE = re.compile(r"^- (.*?): (.*) \[([^\]]+)\]$", re.MULTILINE)
+_RESULT_PREFIX = "MOBIUS_MEMORY_RESULT_V1:"
+_RESULT_RE = re.compile(
+  rf"^{re.escape(_RESULT_PREFIX)}(?P<payload>\{{.*\}})[ \t]*$",
+  re.MULTILINE,
+)
 
 # A citation path is only ever a repository-relative markdown pointer. Refusing
 # anything else keeps traversal, absolute paths, and control characters out of
@@ -121,12 +98,24 @@ def _safe_path(value: str) -> str:
   return candidate if _PATH_RE.match(candidate) else ""
 
 
-def _segment_runs_search(segment: str) -> bool:
-  """Whether one command segment EXECUTES the memory search script."""
-  tokens = [token.strip("'\"") for token in segment.split()]
-  tokens = [token for token in tokens if token]
-  # `FOO=bar python3 script.py` — leading environment assignments are not the
-  # command being run.
+def _simple_command_tokens(command: str) -> list[str] | None:
+  try:
+    lexer = shlex.shlex(command, posix=True, punctuation_chars=True)
+    lexer.whitespace_split = True
+    lexer.commenters = ""
+    tokens = list(lexer)
+  except ValueError:
+    return None
+  if not tokens or any(_CONTROL_TOKEN_RE.fullmatch(token) for token in tokens):
+    return None
+  # Reject substitutions/backticks conservatively. They are not part of the
+  # documented call and would turn this recognizer back into a shell parser.
+  if any("`" in token or "$(" in token for token in tokens):
+    return None
+  return tokens
+
+
+def _tokens_run_search(tokens: list[str]) -> bool:
   index = 0
   while index < len(tokens) and _ENV_ASSIGN_RE.match(tokens[index]):
     index += 1
@@ -134,15 +123,13 @@ def _segment_runs_search(segment: str) -> bool:
     return False
   head = tokens[index]
   if _SCRIPT_RE.match(head):
-    return True
+    return len(tokens) > index + 2
   if not _INTERPRETER_RE.match(head):
     return False
-  # `python3 -u script.py` — interpreter flags may precede the script, but the
-  # first non-flag token is the thing actually being run.
-  for token in tokens[index + 1:]:
+  for script_index, token in enumerate(tokens[index + 1:], start=index + 1):
     if token.startswith("-"):
       continue
-    return bool(_SCRIPT_RE.match(token))
+    return bool(_SCRIPT_RE.match(token) and len(tokens) > script_index + 2)
   return False
 
 
@@ -162,59 +149,49 @@ def recall_from_command(command: object) -> dict | None:
   # not memory lookups and should cost one substring scan.
   if "memory_search.py" not in command:
     return None
-  for segment in _SEGMENT_RE.split(command):
-    if _segment_runs_search(segment):
-      return {"status": RECALL_SEARCHING}
-  return None
+  tokens = _simple_command_tokens(command)
+  return {"status": RECALL_SEARCHING} if tokens and _tokens_run_search(tokens) else None
 
 
-def recall_from_output(text: object) -> dict:
-  """Parse a known memory lookup's stdout into a bounded citation set.
-
-  Only ever called for a tool ``recall_from_command`` already identified, so
-  an unrecognized body is a lookup whose output we could not read — not a
-  reason to claim nothing was found. That case returns a note-less ``hit``,
-  which renders as a plain "recalled from Memory" beat rather than the far
-  stronger (and possibly false) "nothing relevant" claim.
-  """
+def recall_from_result(text: object, exit_code: object = None) -> dict:
+  """Validate a known Memory command's final structured result."""
+  if isinstance(exit_code, bool):
+    exit_code = None
+  if isinstance(exit_code, int) and exit_code != 0:
+    return {"status": RECALL_FAILED}
   if not isinstance(text, str) or not text.strip():
-    # No output at all: the command produced nothing readable. Keep the beat,
-    # drop the claim.
-    return {"status": RECALL_HIT, "notes": []}
+    return {"status": RECALL_FAILED}
 
-  body = text[:_MAX_OUTPUT_SCAN_CHARS]
+  body = text[-_MAX_OUTPUT_SCAN_CHARS:]
+  matches = list(_RESULT_RE.finditer(body))
+  if not matches:
+    return {"status": RECALL_FAILED}
+  try:
+    payload = json.loads(matches[-1].group("payload"))
+  except (TypeError, ValueError, json.JSONDecodeError):
+    return {"status": RECALL_FAILED}
+  if not isinstance(payload, dict):
+    return {"status": RECALL_FAILED}
 
-  files_match = None
-  for files_match in _FILES_RE.finditer(body):
-    # The last FILES: line wins — a head+tail carve keeps the tail, and the
-    # real one is always the final line memory_search.py prints.
-    pass
-
-  if files_match is None:
-    if _EMPTY_RE.search(body):
-      return {"status": RECALL_EMPTY}
-    return {"status": RECALL_HIT, "notes": []}
-
-  titles: dict[str, tuple[str, str]] = {}
-  for index, section in enumerate(_SECTION_RE.finditer(body)):
-    if index >= _MAX_SECTION_LINES_SCANNED:
-      break
-    raw_title, raw_excerpt, raw_path = section.groups()
-    path = _safe_path(raw_path)
-    if path and path not in titles:
-      titles[path] = (
-        _clean(raw_title, MAX_RECALL_TITLE_CHARS),
-        _clean(raw_excerpt, MAX_RECALL_EXCERPT_CHARS),
-      )
+  status = payload.get("status")
+  if status == RECALL_FAILED:
+    return {"status": RECALL_FAILED}
+  if status == RECALL_EMPTY:
+    return {"status": RECALL_EMPTY}
+  if status != RECALL_HIT or not isinstance(payload.get("notes"), list):
+    return {"status": RECALL_FAILED}
 
   notes: list[dict[str, str]] = []
   seen: set[str] = set()
-  for raw_path in files_match.group(1).split(","):
-    path = _safe_path(raw_path)
+  for raw_note in payload["notes"][:_MAX_SECTION_LINES_SCANNED]:
+    if not isinstance(raw_note, dict):
+      continue
+    path = _safe_path(raw_note.get("path"))
     if not path or path in seen:
       continue
     seen.add(path)
-    title, excerpt = titles.get(path, ("", ""))
+    title = _clean(raw_note.get("title"), MAX_RECALL_TITLE_CHARS)
+    excerpt = _clean(raw_note.get("excerpt"), MAX_RECALL_EXCERPT_CHARS)
     note = {
       "id": _note_id(path),
       "path": path,
@@ -225,10 +202,10 @@ def recall_from_output(text: object) -> dict:
     notes.append(note)
     if len(notes) >= MAX_RECALL_NOTES:
       break
-
-  # A FILES: line whose every entry failed validation is a malformed citation
-  # set, not an empty lookup — same conservative fallback as an unreadable body.
-  return {"status": RECALL_HIT, "notes": notes}
+  return (
+    {"status": RECALL_HIT, "notes": notes}
+    if notes else {"status": RECALL_FAILED}
+  )
 
 
 def merge_recall_notes(

--- a/backend/tests/test_claude_sdk_runner.py
+++ b/backend/tests/test_claude_sdk_runner.py
@@ -1074,7 +1074,10 @@ def test_dispatch_client_web_search_tool_result_emits_sources():
     {"type": "tool_start", "tool": "WebSearch", "input": "", "tool_use_id": "t1"},
     {"type": "tool_input", "tool": "WebSearch", "input": "mobius docs",
      "tool_use_id": "t1"},
-    {"type": "tool_output", "content": result_text, "tool_use_id": "t1"},
+    {
+      "type": "tool_output", "content": result_text, "tool_use_id": "t1",
+      "output_complete": True,
+    },
     # tool_use_id binds these sources to the search that produced them, so a
     # batch of parallel WebSearch calls does not collapse onto one block.
     {"type": "tool_sources", "tool_use_id": "t1", "sources": [

--- a/backend/tests/test_codex_sdk_runner.py
+++ b/backend/tests/test_codex_sdk_runner.py
@@ -205,8 +205,9 @@ def test_stamp_tool_use_id_uses_stable_item_id():
 
 def test_tool_completed_events_emit_output_before_end():
   class CommandExecutionThreadItem:
-    def __init__(self, output: str):
+    def __init__(self, output: str, exit_code: int = 0):
       self.aggregated_output = output
+      self.exit_code = exit_code
 
   sdk = {"CommandExecutionThreadItem": CommandExecutionThreadItem}
   sdk.update({
@@ -222,7 +223,20 @@ def test_tool_completed_events_emit_output_before_end():
   )
 
   assert events == [
-    {"type": "tool_output", "content": "hello"},
+    {
+      "type": "tool_output", "content": "hello",
+      "output_complete": True, "output_exit_code": 0,
+    },
+    {"type": "tool_end"},
+  ]
+
+  assert codex_sdk_runner._tool_completed_events(
+    CommandExecutionThreadItem("", exit_code=7), sdk,
+  ) == [
+    {
+      "type": "tool_output", "content": "",
+      "output_complete": True, "output_exit_code": 7,
+    },
     {"type": "tool_end"},
   ]
 

--- a/backend/tests/test_memory_recall.py
+++ b/backend/tests/test_memory_recall.py
@@ -1,0 +1,209 @@
+"""Memory recall citations: identification, parsing, and survival on read.
+
+The behaviour under test is what lets an owner tell three states apart —
+the turn recalled these notes / it looked and Memory had nothing / it never
+looked. The third is the absence of a citation, so the tests below care as
+much about what is NOT stamped as about what is.
+"""
+
+from app.chat_transcript import (
+  _compact_activity_item,
+  _compact_activity_run,
+  _distinctive_activity,
+)
+from app.events import process_event
+from app.memory_recall import (
+  MAX_RECALL_NOTES,
+  RECALL_EMPTY,
+  RECALL_HIT,
+  RECALL_SEARCHING,
+  recall_from_command,
+  recall_from_output,
+)
+
+MEMORY_CMD = 'python3 /data/apps/memory/memory_search.py "what does he prefer" "chat-1"'
+
+# Synthetic notes. Fixtures here become a public diff, so they must never carry
+# anything from a real owner's graph — a memory note is personal by definition.
+HIT_OUTPUT = """Relevant memories:
+- Apps render in a sandboxed frame: Each mini-app runs isolated. [notes/apps-render-in-a-sandboxed-frame.md]
+- Theme variables are shared: Colors come from one stylesheet. [notes/theme-variables-are-shared.md]
+FILES: notes/apps-render-in-a-sandboxed-frame.md, notes/theme-variables-are-shared.md"""
+
+
+# --- identification -------------------------------------------------------
+
+def test_a_memory_search_command_is_identified_as_a_lookup():
+  assert recall_from_command(MEMORY_CMD) == {"status": RECALL_SEARCHING}
+
+
+def test_a_command_merely_mentioning_memory_search_is_not_a_lookup():
+  # Identification gates everything downstream, so a false positive here would
+  # mint citations from an unrelated command's output.
+  # Every one of these is an ordinary thing to do WHILE working on Memory, and
+  # each names the script without running it.
+  assert recall_from_command("grep -rn memory_search.py /data/platform") is None
+  assert recall_from_command("cat /data/apps/memory/memory_search.py") is None
+  assert recall_from_command("wc -l memory_search.py") is None
+  assert recall_from_command("ls -la /data/apps/memory/memory_search.py") is None
+  assert recall_from_command("vim memory_search.py") is None
+  assert recall_from_command("python3 -m py_compile app/memory_search.py") is None
+  assert recall_from_command("echo memory_search.python") is None
+  assert recall_from_command("ls /data/apps/memory/") is None
+  assert recall_from_command("") is None
+  assert recall_from_command(None) is None
+
+
+def test_the_script_is_recognized_however_it_is_invoked():
+  assert recall_from_command("memory_search.py 'q'") is not None
+  assert recall_from_command('cd /x && python3 ./memory_search.py "q"') is not None
+  assert recall_from_command('python3 -u "/a/b/memory_search.py" "q"') is not None
+  assert recall_from_command('MEMORY_READER_PROVIDER=none python3 /a/memory_search.py "q"') is not None
+  assert recall_from_command('/usr/bin/python3.12 /a/memory_search.py "q"') is not None
+
+
+# --- parsing --------------------------------------------------------------
+
+def test_a_successful_lookup_cites_the_notes_it_opened():
+  recall = recall_from_output(HIT_OUTPUT)
+  assert recall["status"] == RECALL_HIT
+  assert [note["id"] for note in recall["notes"]] == [
+    "apps-render-in-a-sandboxed-frame", "theme-variables-are-shared",
+  ]
+  assert recall["notes"][0]["title"] == "Apps render in a sandboxed frame"
+  assert recall["notes"][0]["excerpt"] == "Each mini-app runs isolated."
+
+
+def test_a_lookup_that_found_nothing_says_so():
+  assert recall_from_output("No relevant memories.") == {"status": RECALL_EMPTY}
+
+
+def test_a_carved_output_keeps_every_citation_and_falls_back_on_titles():
+  # A full lookup exceeds the inline threshold and is reduced to head+tail, so
+  # the titled section lines in the middle can be lost. The FILES: line is
+  # authoritative and sits in the tail, so the citation SET must survive whole.
+  carved = "Relevant memories:\n- A: b [notes/a.md]\n…\nFILES: notes/a.md, notes/z.md"
+  recall = recall_from_output(carved)
+  assert [note["id"] for note in recall["notes"]] == ["a", "z"]
+  assert recall["notes"][1]["title"] == "z", "a title-less note still reads"
+
+
+def test_an_unreadable_body_never_claims_nothing_was_found():
+  # "Nothing relevant" is a strong claim about the owner's memory. Only the
+  # app's own marker may make it; anything else degrades to a note-less beat.
+  for body in ("", "   ", "some unrelated text", "Traceback (most recent call last):"):
+    recall = recall_from_output(body)
+    assert recall["status"] == RECALL_HIT
+    assert recall["notes"] == []
+
+
+def test_a_citation_path_may_not_escape_the_graph():
+  recall = recall_from_output(
+    "FILES: ../../etc/passwd, /abs/x.md, notes/../secret.md, notes/ok.md"
+  )
+  assert [note["path"] for note in recall["notes"]] == ["notes/ok.md"]
+
+
+def test_repeated_and_excessive_citations_are_bounded():
+  paths = ", ".join(f"notes/n{i}.md" for i in range(40))
+  recall = recall_from_output(f"FILES: notes/dup.md, notes/dup.md, {paths}")
+  assert len(recall["notes"]) == MAX_RECALL_NOTES
+  assert recall["notes"][0]["path"] == "notes/dup.md"
+  assert len({note["path"] for note in recall["notes"]}) == len(recall["notes"])
+
+
+def test_the_last_files_line_wins_after_a_head_tail_carve():
+  # A carve keeps the head, so a stale FILES: from the head could linger above
+  # the real one. memory_search.py always prints it last.
+  recall = recall_from_output(
+    "FILES: notes/stale.md\n…carved…\nRelevant memories:\nFILES: notes/real.md"
+  )
+  assert [note["path"] for note in recall["notes"]] == ["notes/real.md"]
+
+
+# --- the block carries it through persistence ------------------------------
+
+def _tool_blocks(recall_in, recall_out, output=HIT_OUTPUT):
+  blocks: list = []
+  process_event({"type": "tool_start", "tool": "Bash", "tool_use_id": "t1"}, blocks)
+  event_in = {"type": "tool_input", "tool_use_id": "t1", "input": MEMORY_CMD}
+  if recall_in is not None:
+    event_in["recall"] = recall_in
+  process_event(event_in, blocks)
+  event_out = {"type": "tool_output", "tool_use_id": "t1", "content": output}
+  if recall_out is not None:
+    event_out["recall"] = recall_out
+  process_event(event_out, blocks)
+  return blocks
+
+
+def test_the_lookup_marker_reaches_the_persisted_block_and_then_settles():
+  blocks = _tool_blocks(
+    {"status": RECALL_SEARCHING},
+    {"status": RECALL_HIT, "notes": [{"id": "a", "path": "notes/a.md", "title": "A"}]},
+  )
+  assert blocks[0]["recall"]["status"] == RECALL_HIT
+  assert blocks[0]["recall"]["notes"][0]["id"] == "a"
+
+
+def test_an_ordinary_command_gains_no_recall_field():
+  blocks = _tool_blocks(None, None, output="total 0\n")
+  assert "recall" not in blocks[0]
+
+
+# --- survival through the read-side projection -----------------------------
+
+def test_consulting_memory_is_its_own_activity_beat():
+  assert _distinctive_activity({"type": "tool", "tool": "Bash",
+                                "recall": {"status": RECALL_HIT, "notes": []}})
+  assert not _distinctive_activity({"type": "tool", "tool": "Bash"})
+
+
+def test_the_compacted_line_still_knows_what_it_recalled():
+  # Without this the beat renders live and reverts to "Ran a command" on the
+  # next chat load, which is worse for trust than never having shown it.
+  item = _compact_activity_item({
+    "type": "tool", "tool": "Bash", "status": "done",
+    "input": MEMORY_CMD,
+    "recall": {"status": RECALL_HIT, "notes": [{"id": "a", "path": "notes/a.md"}]},
+  })
+  assert item["recall"]["notes"][0]["id"] == "a"
+
+
+def test_citations_roll_up_so_a_folded_run_keeps_them():
+  # _compact_activity_entries keeps only two entries per tool name, so a third
+  # lookup's notes exist ONLY on the run summary.
+  blocks = [
+    (i, {"type": "tool", "tool": "Bash", "status": "done",
+         "recall": {"status": RECALL_HIT,
+                    "notes": [{"id": f"n{i}", "path": f"notes/n{i}.md"}]}})
+    for i in range(3)
+  ]
+  run = _compact_activity_run(blocks, message_index=0)
+  assert [note["id"] for note in run["recall"]["notes"]] == ["n0", "n1", "n2"]
+  assert run["recall"]["status"] == RECALL_HIT
+
+
+def test_a_run_with_no_lookup_carries_no_recall_key():
+  blocks = [(0, {"type": "tool", "tool": "Bash", "status": "done"})]
+  assert "recall" not in _compact_activity_run(blocks, message_index=0)
+
+
+def test_a_remembered_note_outranks_an_empty_probe_in_the_same_run():
+  blocks = [
+    (0, {"type": "tool", "tool": "Bash", "status": "done",
+         "recall": {"status": RECALL_EMPTY}}),
+    (1, {"type": "tool", "tool": "Bash", "status": "done",
+         "recall": {"status": RECALL_HIT,
+                    "notes": [{"id": "a", "path": "notes/a.md"}]}}),
+  ]
+  run = _compact_activity_run(blocks, message_index=0)
+  assert run["recall"]["status"] == RECALL_HIT
+  assert [note["id"] for note in run["recall"]["notes"]] == ["a"]
+
+
+def test_an_all_empty_run_still_reports_that_it_looked():
+  blocks = [(0, {"type": "tool", "tool": "Bash", "status": "done",
+                 "recall": {"status": RECALL_EMPTY}})]
+  run = _compact_activity_run(blocks, message_index=0)
+  assert run["recall"] == {"status": RECALL_EMPTY, "notes": []}

--- a/backend/tests/test_memory_recall.py
+++ b/backend/tests/test_memory_recall.py
@@ -43,7 +43,9 @@ MOBIUS_MEMORY_RESULT_V1:{"status":"failed"}"""
 # --- identification -------------------------------------------------------
 
 def test_a_memory_search_command_is_identified_as_a_lookup():
-  assert recall_from_command(MEMORY_CMD) == {"status": RECALL_SEARCHING}
+  assert recall_from_command(MEMORY_CMD) == {
+    "status": RECALL_SEARCHING, "app_slug": "memory",
+  }
 
 
 def test_a_command_merely_mentioning_memory_search_is_not_a_lookup():
@@ -68,7 +70,7 @@ def test_the_documented_simple_invocation_is_recognized():
   assert recall_from_command(
     'MEMORY_READER_PROVIDER=none python3 -u '
     '/data/apps/memory-2/memory_search.py "q" "chat-1"'
-  ) is not None
+  ) == {"status": RECALL_SEARCHING, "app_slug": "memory-2"}
 
 
 def test_shell_composition_and_non_memory_paths_are_rejected_conservatively():
@@ -82,6 +84,13 @@ def test_shell_composition_and_non_memory_paths_are_rejected_conservatively():
   assert recall_from_command('python3 /a/b/memory_search.py "q"') is None
   assert recall_from_command(
     'python3 /data/apps/memory/memory_search.py "q" > /tmp/result'
+  ) is None
+
+
+def test_trailing_arguments_and_newline_commands_cannot_mint_recall_metadata():
+  assert recall_from_command(MEMORY_CMD + ' "unexpected"') is None
+  assert recall_from_command(
+    MEMORY_CMD + '\nprintf \'MOBIUS_MEMORY_RESULT_V1:{"status":"hit"}\\n\''
   ) is None
 
 
@@ -186,6 +195,25 @@ def test_codex_tool_start_carries_the_lookup_marker_without_tool_input():
   assert blocks[0]["recall"]["status"] == RECALL_HIT
 
 
+def test_the_claude_path_does_not_double_stamp_a_single_lookup():
+  # Simulate a runner that supplies the memory_search command on BOTH the
+  # tool_start and a following tool_input for the same tool_use_id. The block
+  # must be stamped once: the second phase sees the block already carries a
+  # recall marker and is skipped, so no duplicate/overwriting stamp occurs.
+  sink = object.__new__(_ChatEventSink)
+  sink.assistant_blocks = []
+  start = {"type": "tool_start", "tool": "Bash", "input": MEMORY_CMD,
+           "tool_use_id": "t1"}
+  sink._stamp_memory_recall(start)
+  process_event(start, sink.assistant_blocks)
+  assert sink.assistant_blocks[0]["recall"]["status"] == RECALL_SEARCHING
+  follow = {"type": "tool_input", "tool_use_id": "t1", "input": MEMORY_CMD}
+  sink._stamp_memory_recall(follow)
+  assert "recall" not in follow
+  process_event(follow, sink.assistant_blocks)
+  assert sink.assistant_blocks[0]["recall"]["status"] == RECALL_SEARCHING
+
+
 def test_partial_output_does_not_settle_the_lookup_before_completion():
   blocks: list = []
   process_event({
@@ -232,6 +260,7 @@ def test_claude_and_codex_lifecycles_settle_to_identical_recall_metadata():
   assert [note["id"] for note in codex["notes"]] == [
     "apps-render-in-a-sandboxed-frame", "theme-variables-are-shared",
   ]
+  assert {note["app_slug"] for note in codex["notes"]} == {"memory"}
 
 
 def test_an_ordinary_command_gains_no_recall_field():

--- a/backend/tests/test_memory_recall.py
+++ b/backend/tests/test_memory_recall.py
@@ -6,19 +6,23 @@ looked. The third is the absence of a citation, so the tests below care as
 much about what is NOT stamped as about what is.
 """
 
+import json
+
 from app.chat_transcript import (
   _compact_activity_item,
   _compact_activity_run,
   _distinctive_activity,
 )
+from app.chat import _ChatEventSink
 from app.events import process_event
 from app.memory_recall import (
   MAX_RECALL_NOTES,
   RECALL_EMPTY,
+  RECALL_FAILED,
   RECALL_HIT,
   RECALL_SEARCHING,
   recall_from_command,
-  recall_from_output,
+  recall_from_result,
 )
 
 MEMORY_CMD = 'python3 /data/apps/memory/memory_search.py "what does he prefer" "chat-1"'
@@ -28,7 +32,12 @@ MEMORY_CMD = 'python3 /data/apps/memory/memory_search.py "what does he prefer" "
 HIT_OUTPUT = """Relevant memories:
 - Apps render in a sandboxed frame: Each mini-app runs isolated. [notes/apps-render-in-a-sandboxed-frame.md]
 - Theme variables are shared: Colors come from one stylesheet. [notes/theme-variables-are-shared.md]
-FILES: notes/apps-render-in-a-sandboxed-frame.md, notes/theme-variables-are-shared.md"""
+FILES: notes/apps-render-in-a-sandboxed-frame.md, notes/theme-variables-are-shared.md
+MOBIUS_MEMORY_RESULT_V1:{"status":"hit","notes":[{"id":"apps-render-in-a-sandboxed-frame","path":"notes/apps-render-in-a-sandboxed-frame.md","title":"Apps render in a sandboxed frame","excerpt":"Each mini-app runs isolated."},{"id":"theme-variables-are-shared","path":"notes/theme-variables-are-shared.md","title":"Theme variables are shared","excerpt":"Colors come from one stylesheet."}]}"""
+EMPTY_OUTPUT = """No relevant memories.
+MOBIUS_MEMORY_RESULT_V1:{"status":"empty"}"""
+FAILED_OUTPUT = """Memory lookup failed.
+MOBIUS_MEMORY_RESULT_V1:{"status":"failed"}"""
 
 
 # --- identification -------------------------------------------------------
@@ -54,18 +63,32 @@ def test_a_command_merely_mentioning_memory_search_is_not_a_lookup():
   assert recall_from_command(None) is None
 
 
-def test_the_script_is_recognized_however_it_is_invoked():
-  assert recall_from_command("memory_search.py 'q'") is not None
-  assert recall_from_command('cd /x && python3 ./memory_search.py "q"') is not None
-  assert recall_from_command('python3 -u "/a/b/memory_search.py" "q"') is not None
-  assert recall_from_command('MEMORY_READER_PROVIDER=none python3 /a/memory_search.py "q"') is not None
-  assert recall_from_command('/usr/bin/python3.12 /a/memory_search.py "q"') is not None
+def test_the_documented_simple_invocation_is_recognized():
+  assert recall_from_command(MEMORY_CMD) is not None
+  assert recall_from_command(
+    'MEMORY_READER_PROVIDER=none python3 -u '
+    '/data/apps/memory-2/memory_search.py "q" "chat-1"'
+  ) is not None
+
+
+def test_shell_composition_and_non_memory_paths_are_rejected_conservatively():
+  assert recall_from_command(
+    'python3 /data/apps/memory/memory_search.py "q"'
+  ) is None
+  assert recall_from_command(
+    'cd /x && python3 /data/apps/memory/memory_search.py "q"'
+  ) is None
+  assert recall_from_command('python3 ./memory_search.py "q"') is None
+  assert recall_from_command('python3 /a/b/memory_search.py "q"') is None
+  assert recall_from_command(
+    'python3 /data/apps/memory/memory_search.py "q" > /tmp/result'
+  ) is None
 
 
 # --- parsing --------------------------------------------------------------
 
 def test_a_successful_lookup_cites_the_notes_it_opened():
-  recall = recall_from_output(HIT_OUTPUT)
+  recall = recall_from_result(HIT_OUTPUT, 0)
   assert recall["status"] == RECALL_HIT
   assert [note["id"] for note in recall["notes"]] == [
     "apps-render-in-a-sandboxed-frame", "theme-variables-are-shared",
@@ -75,59 +98,67 @@ def test_a_successful_lookup_cites_the_notes_it_opened():
 
 
 def test_a_lookup_that_found_nothing_says_so():
-  assert recall_from_output("No relevant memories.") == {"status": RECALL_EMPTY}
+  assert recall_from_result(EMPTY_OUTPUT, 0) == {"status": RECALL_EMPTY}
 
 
-def test_a_carved_output_keeps_every_citation_and_falls_back_on_titles():
-  # A full lookup exceeds the inline threshold and is reduced to head+tail, so
-  # the titled section lines in the middle can be lost. The FILES: line is
-  # authoritative and sits in the tail, so the citation SET must survive whole.
-  carved = "Relevant memories:\n- A: b [notes/a.md]\n…\nFILES: notes/a.md, notes/z.md"
-  recall = recall_from_output(carved)
-  assert [note["id"] for note in recall["notes"]] == ["a", "z"]
-  assert recall["notes"][1]["title"] == "z", "a title-less note still reads"
+def test_a_carved_output_keeps_the_structured_tail_result():
+  carved = "presentation head\n…[large middle carved]…\n" + HIT_OUTPUT.splitlines()[-1]
+  recall = recall_from_result(carved, 0)
+  assert [note["id"] for note in recall["notes"]] == [
+    "apps-render-in-a-sandboxed-frame", "theme-variables-are-shared",
+  ]
 
 
-def test_an_unreadable_body_never_claims_nothing_was_found():
-  # "Nothing relevant" is a strong claim about the owner's memory. Only the
-  # app's own marker may make it; anything else degrades to a note-less beat.
+def test_unreadable_or_failed_results_are_explicit_failures():
   for body in ("", "   ", "some unrelated text", "Traceback (most recent call last):"):
-    recall = recall_from_output(body)
-    assert recall["status"] == RECALL_HIT
-    assert recall["notes"] == []
+    assert recall_from_result(body, 0) == {"status": RECALL_FAILED}
+  assert recall_from_result(FAILED_OUTPUT, 1) == {"status": RECALL_FAILED}
+  assert recall_from_result(HIT_OUTPUT, 1) == {"status": RECALL_FAILED}
 
 
 def test_a_citation_path_may_not_escape_the_graph():
-  recall = recall_from_output(
-    "FILES: ../../etc/passwd, /abs/x.md, notes/../secret.md, notes/ok.md"
+  recall = recall_from_result(
+    'MOBIUS_MEMORY_RESULT_V1:{"status":"hit","notes":['
+    '{"path":"../../etc/passwd"},{"path":"/abs/x.md"},'
+    '{"path":"notes/../secret.md"},{"path":"notes/ok.md"}]}',
+    0,
   )
   assert [note["path"] for note in recall["notes"]] == ["notes/ok.md"]
 
 
 def test_repeated_and_excessive_citations_are_bounded():
-  paths = ", ".join(f"notes/n{i}.md" for i in range(40))
-  recall = recall_from_output(f"FILES: notes/dup.md, notes/dup.md, {paths}")
+  notes = [{"path": "notes/dup.md"}, {"path": "notes/dup.md"}] + [
+    {"path": f"notes/n{i}.md"} for i in range(40)
+  ]
+  recall = recall_from_result(
+    "MOBIUS_MEMORY_RESULT_V1:" + json.dumps({"status": "hit", "notes": notes}),
+    0,
+  )
   assert len(recall["notes"]) == MAX_RECALL_NOTES
   assert recall["notes"][0]["path"] == "notes/dup.md"
   assert len({note["path"] for note in recall["notes"]}) == len(recall["notes"])
 
 
-def test_the_last_files_line_wins_after_a_head_tail_carve():
-  # A carve keeps the head, so a stale FILES: from the head could linger above
-  # the real one. memory_search.py always prints it last.
-  recall = recall_from_output(
-    "FILES: notes/stale.md\n…carved…\nRelevant memories:\nFILES: notes/real.md"
+def test_the_last_structured_result_line_wins():
+  recall = recall_from_result(
+    'MOBIUS_MEMORY_RESULT_V1:{"status":"hit","notes":[{"path":"notes/stale.md"}]}\n'
+    'MOBIUS_MEMORY_RESULT_V1:{"status":"hit","notes":[{"path":"notes/real.md"}]}',
+    0,
   )
   assert [note["path"] for note in recall["notes"]] == ["notes/real.md"]
 
 
 # --- the block carries it through persistence ------------------------------
 
-def _tool_blocks(recall_in, recall_out, output=HIT_OUTPUT):
+def _tool_blocks(recall_in, recall_out, output=HIT_OUTPUT, recall_on_start=False):
   blocks: list = []
-  process_event({"type": "tool_start", "tool": "Bash", "tool_use_id": "t1"}, blocks)
+  start = {"type": "tool_start", "tool": "Bash", "input": MEMORY_CMD,
+           "tool_use_id": "t1"}
+  if recall_on_start and recall_in is not None:
+    start["recall"] = recall_in
+  process_event(start, blocks)
   event_in = {"type": "tool_input", "tool_use_id": "t1", "input": MEMORY_CMD}
-  if recall_in is not None:
+  if not recall_on_start and recall_in is not None:
     event_in["recall"] = recall_in
   process_event(event_in, blocks)
   event_out = {"type": "tool_output", "tool_use_id": "t1", "content": output}
@@ -146,6 +177,63 @@ def test_the_lookup_marker_reaches_the_persisted_block_and_then_settles():
   assert blocks[0]["recall"]["notes"][0]["id"] == "a"
 
 
+def test_codex_tool_start_carries_the_lookup_marker_without_tool_input():
+  blocks = _tool_blocks(
+    {"status": RECALL_SEARCHING},
+    {"status": RECALL_HIT, "notes": [{"id": "a", "path": "notes/a.md"}]},
+    recall_on_start=True,
+  )
+  assert blocks[0]["recall"]["status"] == RECALL_HIT
+
+
+def test_partial_output_does_not_settle_the_lookup_before_completion():
+  blocks: list = []
+  process_event({
+    "type": "tool_start", "tool": "Bash", "input": MEMORY_CMD,
+    "tool_use_id": "t1", "recall": {"status": RECALL_SEARCHING},
+  }, blocks)
+  process_event({"type": "tool_output", "tool_use_id": "t1", "content": "partial"}, blocks)
+  assert blocks[0]["recall"]["status"] == RECALL_SEARCHING
+  process_event({
+    "type": "tool_output", "tool_use_id": "t1", "content": HIT_OUTPUT,
+    "recall": {"status": RECALL_HIT, "notes": [{"id": "a", "path": "notes/a.md"}]},
+  }, blocks)
+  assert blocks[0]["recall"]["status"] == RECALL_HIT
+
+
+def _sink_lifecycle(events):
+  sink = object.__new__(_ChatEventSink)
+  sink.assistant_blocks = []
+  for event in events:
+    sink._stamp_memory_recall(event)
+    process_event(event, sink.assistant_blocks)
+  return sink.assistant_blocks[0]["recall"]
+
+
+def test_claude_and_codex_lifecycles_settle_to_identical_recall_metadata():
+  final = {
+    "type": "tool_output", "tool_use_id": "t1", "content": HIT_OUTPUT,
+    "output_complete": True, "output_exit_code": 0,
+  }
+  codex = _sink_lifecycle([
+    {"type": "tool_start", "tool": "Bash", "input": MEMORY_CMD,
+     "tool_use_id": "t1"},
+    {"type": "tool_output", "tool_use_id": "t1", "content": "partial"},
+    dict(final),
+  ])
+  claude = _sink_lifecycle([
+    {"type": "tool_start", "tool": "Bash", "input": "",
+     "tool_use_id": "t1"},
+    {"type": "tool_input", "input": MEMORY_CMD, "tool_use_id": "t1"},
+    dict(final),
+  ])
+  assert codex == claude
+  assert codex["status"] == RECALL_HIT
+  assert [note["id"] for note in codex["notes"]] == [
+    "apps-render-in-a-sandboxed-frame", "theme-variables-are-shared",
+  ]
+
+
 def test_an_ordinary_command_gains_no_recall_field():
   blocks = _tool_blocks(None, None, output="total 0\n")
   assert "recall" not in blocks[0]
@@ -157,6 +245,12 @@ def test_consulting_memory_is_its_own_activity_beat():
   assert _distinctive_activity({"type": "tool", "tool": "Bash",
                                 "recall": {"status": RECALL_HIT, "notes": []}})
   assert not _distinctive_activity({"type": "tool", "tool": "Bash"})
+
+
+def test_a_failed_lookup_remains_an_activity_without_citations():
+  assert _distinctive_activity({
+    "type": "tool", "tool": "Bash", "recall": {"status": RECALL_FAILED},
+  })
 
 
 def test_the_compacted_line_still_knows_what_it_recalled():
@@ -205,5 +299,16 @@ def test_a_remembered_note_outranks_an_empty_probe_in_the_same_run():
 def test_an_all_empty_run_still_reports_that_it_looked():
   blocks = [(0, {"type": "tool", "tool": "Bash", "status": "done",
                  "recall": {"status": RECALL_EMPTY}})]
+  run = _compact_activity_run(blocks, message_index=0)
+  assert run["recall"] == {"status": RECALL_EMPTY, "notes": []}
+
+
+def test_a_successful_empty_lookup_outranks_a_failed_probe_in_the_same_run():
+  blocks = [
+    (0, {"type": "tool", "tool": "Bash", "status": "done",
+         "recall": {"status": RECALL_FAILED}}),
+    (1, {"type": "tool", "tool": "Bash", "status": "done",
+         "recall": {"status": RECALL_EMPTY}}),
+  ]
   run = _compact_activity_run(blocks, message_index=0)
   assert run["recall"] == {"status": RECALL_EMPTY, "notes": []}

--- a/backend/tests/test_memory_recall.py
+++ b/backend/tests/test_memory_recall.py
@@ -106,6 +106,34 @@ def test_a_successful_lookup_cites_the_notes_it_opened():
   assert recall["notes"][0]["excerpt"] == "Each mini-app runs isolated."
 
 
+def test_a_citation_keeps_the_graph_node_id_when_it_differs_from_the_file():
+  recall = recall_from_result(
+    'MOBIUS_MEMORY_RESULT_V1:{"status":"hit","notes":['
+    '{"id":"canonical-node","path":"notes/readable-filename.md",'
+    '"title":"Canonical node"}]}',
+    0,
+  )
+
+  assert recall["notes"] == [{
+    "id": "canonical-node",
+    "path": "notes/readable-filename.md",
+    "title": "Canonical node",
+  }]
+
+
+def test_an_unsafe_or_missing_graph_node_id_falls_back_to_the_file_stem():
+  recall = recall_from_result(
+    'MOBIUS_MEMORY_RESULT_V1:{"status":"hit","notes":['
+    '{"id":"../escape","path":"notes/safe-fallback.md"},'
+    '{"path":"notes/legacy-note.md"}]}',
+    0,
+  )
+
+  assert [note["id"] for note in recall["notes"]] == [
+    "safe-fallback", "legacy-note",
+  ]
+
+
 def test_a_lookup_that_found_nothing_says_so():
   assert recall_from_result(EMPTY_OUTPUT, 0) == {"status": RECALL_EMPTY}
 

--- a/backend/tests/test_tool_output_excerpt.py
+++ b/backend/tests/test_tool_output_excerpt.py
@@ -9,6 +9,7 @@ from app.events import (
     TOOL_OUTPUT_HEAD,
     TOOL_OUTPUT_INLINE_THRESHOLD,
     excerpt_tool_output,
+    tool_output_exit_code,
 )
 
 
@@ -36,6 +37,12 @@ def test_bash_failure_head_and_exit_code_survive_truncation():
     assert excerpt.startswith("Exit code 137\n")
     assert exit_code == 137
     assert full_len == len(content)
+
+
+def test_small_tool_outputs_expose_the_same_typed_exit_code():
+    assert tool_output_exit_code("Exit code 7\nfailed") == 7
+    assert tool_output_exit_code(json.dumps({"stderr": "x", "exit_code": 2})) == 2
+    assert tool_output_exit_code("success") is None
 
 
 def test_json_envelope_stays_valid_json_with_exit_code_intact():

--- a/backend/tests/test_tool_output_stash.py
+++ b/backend/tests/test_tool_output_stash.py
@@ -4,6 +4,7 @@ tool_use_id); the sink reduces the wire event and submits the stash; the
 GET /tool-output/{tool_use_id} endpoint serves a bounded expansion preview and
 the exact text on explicit copy. Also covers the reducer
 carrying tool identity + truncation metadata onto the persisted block."""
+import json
 import uuid
 
 from sqlalchemy import event as sqlalchemy_event
@@ -422,6 +423,49 @@ def test_sink_reduces_large_tagged_output_and_stashes_full(db):
         models.ToolOutput.tool_use_id == "tu_big",
     ).first()
     assert row is not None and row.output == big
+
+
+def test_sink_keeps_a_runner_supplied_exit_code_on_large_plain_output(db):
+    sink = _sink()
+    sink.publish({
+        "type": "tool_start", "tool": "Bash", "input": "run",
+        "tool_use_id": "tu_typed",
+    })
+    big = "plain output\n" + ("x" * (TOOL_OUTPUT_INLINE_THRESHOLD + 100))
+    event = {
+        "type": "tool_output", "content": big, "tool_use_id": "tu_typed",
+        "output_exit_code": 7,
+    }
+
+    sink.publish(event)
+
+    assert event["output_truncated"] is True
+    assert event["output_exit_code"] == 7
+    assert sink.assistant_blocks[-1]["output_exit_code"] == 7
+
+
+def test_sink_parses_a_large_json_envelope_once(monkeypatch, db):
+    import app.events as events
+
+    sink = _sink()
+    big = json.dumps({
+        "stdout": "x" * (TOOL_OUTPUT_INLINE_THRESHOLD + 100),
+        "exit_code": 3,
+    })
+    loads = events.json.loads
+    calls = 0
+
+    def counting_loads(value):
+        nonlocal calls
+        calls += 1
+        return loads(value)
+
+    monkeypatch.setattr(events.json, "loads", counting_loads)
+    event = {"type": "tool_output", "content": big, "tool_use_id": "tu_json"}
+    sink.publish(event)
+
+    assert calls == 1
+    assert event["output_exit_code"] == 3
 
 
 def test_sink_passes_through_small_output(db):

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -978,6 +978,51 @@
   line-height: 1;
 }
 
+/* A recalled note reads as the same KIND of citation as a web source, so it
+   shares the chip entirely and diverges only in its mark: a glyph rather than
+   a domain letter, tinted to separate "remembered" from "read on the web"
+   without becoming a second visual language. */
+.chat__source-glyph {
+  width: 13px;
+  height: 13px;
+}
+
+/* A note title is prose, not a domain, so it needs more room than a host chip
+   and is the part that should absorb any shortfall. */
+.chat__source-chip--memory {
+  max-width: 320px;
+}
+
+.chat__source-chip--memory .chat__source-icon {
+  color: color-mix(in srgb, var(--accent) 62%, var(--text));
+  background: color-mix(in srgb, var(--accent-dim) 52%, var(--surface2));
+}
+
+/* "Memory" is a fixed six-character label; letting it share the shrink budget
+   with the title collapses it to "Me…" and says nothing. */
+.chat__source-chip--memory .chat__source-host {
+  flex: 0 0 auto;
+}
+
+/* An empty lookup is a fact about the answer, not a destination — so it is
+   stated plainly and styled back, with no hover or pointer affordance. */
+.chat__source-chip--quiet {
+  max-width: none;
+  color: var(--muted); /* CONTRACT: low-contrast text on opaque fill */
+  background: color-mix(in srgb, var(--surface2) 34%, var(--surface));
+  border-style: dashed;
+}
+
+.chat__source-chip--quiet .chat__source-icon {
+  color: var(--muted); /* CONTRACT: low-contrast text on opaque fill */
+  background: color-mix(in srgb, var(--surface2) 60%, var(--surface));
+  border-color: transparent;
+}
+
+.chat__source-chip--quiet .chat__source-title {
+  font-style: italic;
+}
+
 .chat__source-copy {
   display: flex;
   align-items: baseline;

--- a/frontend/src/components/ChatView/MessageSources.jsx
+++ b/frontend/src/components/ChatView/MessageSources.jsx
@@ -1,3 +1,4 @@
+import BrainCircuit from 'lucide-react/dist/esm/icons/brain-circuit.mjs'
 import { messageSources, sourceHost, sourceLabel } from './messageSources.js'
 import { messageRecall, noteHref, noteLabel } from './memoryRecall.js'
 
@@ -6,29 +7,8 @@ function sourceMark(host) {
   return displayHost.match(/[a-z0-9]/i)?.[0]?.toUpperCase() || '•'
 }
 
-// A recalled note is not a website, so it gets a mark of its own rather than a
-// domain letter. Local and inline for the same reason the web chip's mark is:
-// nothing about viewing an answer should contact a remote server.
 function MemoryMark() {
-  return (
-    <svg
-      className="chat__source-glyph"
-      viewBox="0 0 16 16"
-      aria-hidden="true"
-      focusable="false"
-    >
-      <path
-        d="M8 2.2c-1.5 0-2.6 1-2.8 2.3-1.1.3-1.9 1.2-1.9 2.4 0 .5.2 1 .4 1.4-.3.4-.5.9-.5 1.5 0 1.4 1.2 2.5 2.7 2.5.5 0 1-.1 1.4-.4.2.5.4.9.7 1.2V2.2z"
-        fill="currentColor"
-        opacity="0.85"
-      />
-      <path
-        d="M8 2.2c1.5 0 2.6 1 2.8 2.3 1.1.3 1.9 1.2 1.9 2.4 0 .5-.2 1-.4 1.4.3.4.5.9.5 1.5 0 1.4-1.2 2.5-2.7 2.5-.5 0-1-.1-1.4-.4-.2.5-.4.9-.7 1.2V2.2z"
-        fill="currentColor"
-        opacity="0.55"
-      />
-    </svg>
-  )
+  return <BrainCircuit className="chat__source-glyph" aria-hidden="true" />
 }
 
 // Everything that informed an answer, surfaced ONCE at the end of the message:

--- a/frontend/src/components/ChatView/MessageSources.jsx
+++ b/frontend/src/components/ChatView/MessageSources.jsx
@@ -1,26 +1,131 @@
 import { messageSources, sourceHost, sourceLabel } from './messageSources.js'
+import { messageRecall, noteHref, noteLabel } from './memoryRecall.js'
 
 function sourceMark(host) {
   const displayHost = String(host || '').replace(/^www\./i, '')
   return displayHost.match(/[a-z0-9]/i)?.[0]?.toUpperCase() || '•'
 }
 
-// The web sources that informed an answer, surfaced ONCE at the end of the
-// message — see messageSources.js for where the data comes from and why it is
-// derived rather than carried as its own content block.
+// A recalled note is not a website, so it gets a mark of its own rather than a
+// domain letter. Local and inline for the same reason the web chip's mark is:
+// nothing about viewing an answer should contact a remote server.
+function MemoryMark() {
+  return (
+    <svg
+      className="chat__source-glyph"
+      viewBox="0 0 16 16"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path
+        d="M8 2.2c-1.5 0-2.6 1-2.8 2.3-1.1.3-1.9 1.2-1.9 2.4 0 .5.2 1 .4 1.4-.3.4-.5.9-.5 1.5 0 1.4 1.2 2.5 2.7 2.5.5 0 1-.1 1.4-.4.2.5.4.9.7 1.2V2.2z"
+        fill="currentColor"
+        opacity="0.85"
+      />
+      <path
+        d="M8 2.2c1.5 0 2.6 1 2.8 2.3 1.1.3 1.9 1.2 1.9 2.4 0 .5-.2 1-.4 1.4.3.4.5.9.5 1.5 0 1.4-1.2 2.5-2.7 2.5-.5 0-1-.1-1.4-.4-.2.5-.4.9-.7 1.2V2.2z"
+        fill="currentColor"
+        opacity="0.55"
+      />
+    </svg>
+  )
+}
+
+// Everything that informed an answer, surfaced ONCE at the end of the message:
+// the notes the agent recalled from Memory, then the web sources it read. See
+// memoryRecall.js / messageSources.js for where each comes from and why both
+// are derived rather than carried as their own content blocks.
 //
-// Message level rather than inside the tool row, because a source is a
+// Message level rather than inside the tool row, because a citation is a
 // property of the ANSWER, not of the individual search that happened to find
 // it: collapsed tool rows hid them, and one search's results are rarely the
 // whole citation set.
+//
+// The recall row exists to make three states distinguishable at a glance —
+// remembered these notes / looked and found nothing / never looked (no row).
+// The middle state is the one that earns trust, and it is also the prompt to
+// write the note that was missing.
 
-export default function MessageSources({ blocks }) {
+export default function MessageSources({ blocks, onInternalNav }) {
   const sources = messageSources(blocks)
-  if (sources.length === 0) return null
+  const recall = messageRecall(blocks)
+  const notes = recall?.notes || []
+  if (sources.length === 0 && !recall) return null
+
+  const handleNoteClick = (event, href) => {
+    if (!onInternalNav || !href) return
+    // Let the browser own a modified click (new tab, download, middle button)
+    // exactly as it does for an ordinary link.
+    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey
+        || event.button !== 0) return
+    let url
+    try {
+      url = new URL(href, window.location.href)
+    } catch {
+      return
+    }
+    event.preventDefault()
+    onInternalNav(url)
+  }
 
   return (
-    <section className="chat__sources" aria-label="Source links">
+    <section className="chat__sources" aria-label="What informed this answer">
       <ul className="chat__sources-list">
+        {notes.map(note => {
+          const label = noteLabel(note)
+          const href = noteHref(note)
+          const body = (
+            <>
+              <span className="chat__source-icon" aria-hidden="true">
+                <MemoryMark />
+              </span>
+              <span className="chat__source-copy">
+                <span className="chat__source-title">{label}</span>
+                <span className="chat__source-host" aria-hidden="true">
+                  Memory
+                </span>
+              </span>
+            </>
+          )
+          return (
+            <li key={note.path || note.id} className="chat__source-item">
+              {href ? (
+                <a
+                  className="chat__source-chip chat__source-chip--memory"
+                  href={href}
+                  title={note.excerpt || label}
+                  aria-label={`${label} — recalled from Memory`}
+                  onClick={event => handleNoteClick(event, href)}
+                >
+                  {body}
+                </a>
+              ) : (
+                <span
+                  className="chat__source-chip chat__source-chip--memory"
+                  title={note.excerpt || label}
+                >
+                  {body}
+                </span>
+              )}
+            </li>
+          )
+        })}
+        {/* A lookup that came back empty. Deliberately quiet and unclickable:
+            it is a fact about the answer, not a destination. */}
+        {recall?.empty && (
+          <li className="chat__source-item">
+            <span className="chat__source-chip chat__source-chip--memory chat__source-chip--quiet">
+              <span className="chat__source-icon" aria-hidden="true">
+                <MemoryMark />
+              </span>
+              <span className="chat__source-copy">
+                <span className="chat__source-title">
+                  Looked back — nothing on this yet
+                </span>
+              </span>
+            </span>
+          </li>
+        )}
         {sources.map(source => {
           const label = sourceLabel(source)
           const host = sourceHost(source.url)

--- a/frontend/src/components/ChatView/MsgContent.jsx
+++ b/frontend/src/components/ChatView/MsgContent.jsx
@@ -324,11 +324,12 @@ function MsgContentInner({
           }
           return renderBlock(node.single.item, node.single.idx)
         })}
-        {/* The turn's web sources, collected from its tool blocks and shown
-            once after the answer. Renders nothing when the turn did no web
-            search, so an ordinary reply is unchanged. */}
+        {/* What informed the turn — notes recalled from Memory, then web
+            sources — collected from its tool blocks and shown once after the
+            answer. Renders nothing when the turn neither searched the web nor
+            consulted Memory, so an ordinary reply is unchanged. */}
         {msg.role === 'assistant' && !isStreaming && (
-          <MessageSources blocks={msg.blocks} />
+          <MessageSources blocks={msg.blocks} onInternalNav={onInternalNav} />
         )}
       </>
     )

--- a/frontend/src/components/ChatView/__tests__/accessibilityHardening.test.js
+++ b/frontend/src/components/ChatView/__tests__/accessibilityHardening.test.js
@@ -75,7 +75,10 @@ test('message sources expose list semantics, keyboard focus, and touch targets',
   const msgContent = read('../MsgContent.jsx')
   const css = read('../ChatView.css')
 
-  assert.match(source, /<section className="chat__sources" aria-label="Source links">/)
+  // The section carries both web sources and notes recalled from Memory, so
+  // its accessible name names the shared idea rather than only the web half.
+  assert.match(source,
+    /<section className="chat__sources" aria-label="What informed this answer">/)
   assert.doesNotMatch(source, />Sources</,
     'source links should stand on their own at the end of the answer')
   assert.match(source, /<ul className="chat__sources-list">/)
@@ -92,4 +95,35 @@ test('message sources expose list semantics, keyboard focus, and touch targets',
   assert.match(css, /\.chat__source-chip:focus-visible\s*\{[^}]*outline:\s*2px solid var\(--accent\)/s)
   assert.match(css, /\.chat__source-chip\s*\{[^}]*border-radius:\s*999px/s)
   assert.match(css, /@media\s*\(pointer:\s*coarse\)\s*\{\s*\.chat__source-chip\s*\{\s*min-height:\s*44px/s)
+})
+
+test('recalled memory notes are named, navigable in-shell, and honest when empty', () => {
+  const source = read('../MessageSources.jsx')
+
+  // A recalled note reads as a citation, not a bare file name: its accessible
+  // name says where it came from, since "Memory" is only a visual sibling chip.
+  assert.match(source, /aria-label=\{`\$\{label\} — recalled from Memory`\}/)
+  assert.match(source, /<li key=\{note\.path \|\| note\.id\} className="chat__source-item">/)
+
+  // A note lives inside this Möbius instance, so it navigates the shell rather
+  // than opening a tab. Guarding the absence of target=_blank on the memory
+  // chip keeps that from being "fixed" back into the web-source shape.
+  assert.doesNotMatch(
+    source,
+    /chat__source-chip--memory"[\s\S]{0,200}target="_blank"/,
+    'a recalled note opens in the workspace, not a new browser tab',
+  )
+  assert.match(source, /onClick=\{event => handleNoteClick\(event, href\)\}/)
+  // A modified click must stay the browser's to handle.
+  assert.match(source, /event\.metaKey \|\| event\.ctrlKey \|\| event\.shiftKey \|\| event\.altKey/)
+
+  // The empty outcome is the whole point of the row: it separates "looked and
+  // found nothing" from "never looked". It states that in words, and is inert
+  // rather than a link to nowhere.
+  assert.match(source, /Looked back — nothing on this yet/)
+  assert.match(
+    source,
+    /chat__source-chip--quiet">\s*<span className="chat__source-icon"/,
+    'an empty lookup is a statement, not a destination',
+  )
 })

--- a/frontend/src/components/ChatView/__tests__/groupBlocks.test.js
+++ b/frontend/src/components/ChatView/__tests__/groupBlocks.test.js
@@ -11,6 +11,7 @@ import {
   toolCallLabel,
   effectiveToolName,
   isDistinctiveActivityTool,
+  memoryRecallLabel,
 } from '../toolActivityLabel.js'
 
 const e = item => ({ item })
@@ -221,6 +222,15 @@ test('toolCallLabel names the concrete nested step in progressive and past tense
     toolCallLabel({ tool: 'custom_tool', input: 'mode=fast', status: 'done' }),
     'custom_tool: mode=fast',
   )
+})
+
+test('failed Memory activity is honest and remains distinctive', () => {
+  const failed = {
+    type: 'tool', tool: 'Bash', status: 'done',
+    recall: { status: 'failed' },
+  }
+  assert.equal(memoryRecallLabel(failed), 'Memory lookup failed')
+  assert.equal(isDistinctiveActivityTool(failed), true)
 })
 
 

--- a/frontend/src/components/ChatView/__tests__/memoryRecall.test.js
+++ b/frontend/src/components/ChatView/__tests__/memoryRecall.test.js
@@ -6,6 +6,7 @@ import {
   messageRecall,
   noteHref,
   noteLabel,
+  safeMemoryAppSlug,
   safeNoteId,
 } from '../memoryRecall.js'
 
@@ -97,6 +98,14 @@ test('a note links into the Memory app through the shell intent contract', () =>
   )
   assert.equal(noteHref({ id: '../evil' }), '',
     'an unsafe id yields no link rather than an unsafe one')
+  assert.equal(
+    noteHref({ id: 'alpha', app_slug: 'memory-2' }),
+    '/shell/?app=memory-2&intent=note%3Aalpha',
+    'a suffixed official install links to the app that performed the recall',
+  )
+  assert.equal(safeMemoryAppSlug('memory-12'), 'memory-12')
+  assert.equal(noteHref({ id: 'alpha', app_slug: '../memory' }), '',
+    'a present but invalid app slug fails closed')
 })
 
 test('a note without a title still reads as words, never blank', () => {

--- a/frontend/src/components/ChatView/__tests__/memoryRecall.test.js
+++ b/frontend/src/components/ChatView/__tests__/memoryRecall.test.js
@@ -70,10 +70,8 @@ test('compacted activity carries citations so they survive a reload', () => {
   assert.deepEqual(recall.notes.map(n => n.id), ['alpha'])
 })
 
-test('a lookup whose output could not be parsed still counts as looking', () => {
-  const recall = messageRecall([toolBlock({ status: 'hit', notes: [] })])
-  assert.deepEqual(recall, { notes: [], empty: false },
-    'no notes to cite, but no false "nothing relevant" claim either')
+test('a failed lookup creates no citation section or empty-memory claim', () => {
+  assert.equal(messageRecall([toolBlock({ status: 'failed' })]), null)
 })
 
 test('citations are bounded so one turn cannot flood the transcript', () => {

--- a/frontend/src/components/ChatView/__tests__/memoryRecall.test.js
+++ b/frontend/src/components/ChatView/__tests__/memoryRecall.test.js
@@ -1,0 +1,120 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  MAX_RECALLED_NOTES,
+  messageRecall,
+  noteHref,
+  noteLabel,
+  safeNoteId,
+} from '../memoryRecall.js'
+
+const note = (id, extra = {}) => ({
+  id,
+  path: `notes/${id}.md`,
+  title: id.replace(/-/g, ' '),
+  ...extra,
+})
+
+const toolBlock = recall => ({ type: 'tool', tool: 'Bash', recall })
+
+test('a turn that never consulted Memory yields no row at all', () => {
+  assert.equal(messageRecall([{ type: 'text', content: 'hi' }]), null)
+  assert.equal(messageRecall([{ type: 'tool', tool: 'Bash' }]), null)
+  assert.equal(messageRecall([]), null)
+  assert.equal(messageRecall(null), null)
+})
+
+test('a lookup that found nothing is reported, not silently dropped', () => {
+  // The distinction this whole row exists for: an owner must be able to tell a
+  // gap in their memory from an agent that ignored it.
+  const recall = messageRecall([toolBlock({ status: 'empty' })])
+  assert.deepEqual(recall, { notes: [], empty: true })
+})
+
+test('an in-flight lookup is a live beat, not yet a citation', () => {
+  assert.equal(messageRecall([toolBlock({ status: 'searching' })]), null)
+})
+
+test('recalled notes are collected in first-seen order', () => {
+  const recall = messageRecall([
+    toolBlock({ status: 'hit', notes: [note('alpha'), note('beta')] }),
+  ])
+  assert.deepEqual(recall.notes.map(n => n.id), ['alpha', 'beta'])
+  assert.equal(recall.empty, false)
+})
+
+test('the same note recalled twice in a turn is cited once', () => {
+  const recall = messageRecall([
+    toolBlock({ status: 'hit', notes: [note('alpha')] }),
+    toolBlock({ status: 'hit', notes: [note('alpha'), note('beta')] }),
+  ])
+  assert.deepEqual(recall.notes.map(n => n.id), ['alpha', 'beta'])
+})
+
+test('one empty probe does not erase what another lookup remembered', () => {
+  const recall = messageRecall([
+    toolBlock({ status: 'empty' }),
+    toolBlock({ status: 'hit', notes: [note('alpha')] }),
+  ])
+  assert.deepEqual(recall.notes.map(n => n.id), ['alpha'])
+  assert.equal(recall.empty, false, 'the turn did remember something')
+})
+
+test('compacted activity carries citations so they survive a reload', () => {
+  // _compact_activity_run rolls recall onto the activity summary for exactly
+  // this reason: the individual tool blocks are folded away on read.
+  const recall = messageRecall([
+    { type: 'activity', recall: { status: 'hit', notes: [note('alpha')] } },
+  ])
+  assert.deepEqual(recall.notes.map(n => n.id), ['alpha'])
+})
+
+test('a lookup whose output could not be parsed still counts as looking', () => {
+  const recall = messageRecall([toolBlock({ status: 'hit', notes: [] })])
+  assert.deepEqual(recall, { notes: [], empty: false },
+    'no notes to cite, but no false "nothing relevant" claim either')
+})
+
+test('citations are bounded so one turn cannot flood the transcript', () => {
+  const many = Array.from({ length: 40 }, (_, i) => note(`note-${i}`))
+  const recall = messageRecall([toolBlock({ status: 'hit', notes: many })])
+  assert.equal(recall.notes.length, MAX_RECALLED_NOTES)
+})
+
+test('only a well-formed note id may build a deep link', () => {
+  assert.equal(safeNoteId('theme-variables-are-shared'), 'theme-variables-are-shared')
+  assert.equal(safeNoteId('../../etc/passwd'), '')
+  assert.equal(safeNoteId('notes/alpha'), '')
+  assert.equal(safeNoteId('a b'), '')
+  assert.equal(safeNoteId(''), '')
+  assert.equal(safeNoteId(null), '')
+  assert.equal(safeNoteId('x'.repeat(200)), '')
+})
+
+test('a note links into the Memory app through the shell intent contract', () => {
+  assert.equal(
+    noteHref({ id: 'theme-variables-are-shared' }),
+    '/shell/?app=memory&intent=note%3Atheme-variables-are-shared',
+  )
+  assert.equal(noteHref({ id: '../evil' }), '',
+    'an unsafe id yields no link rather than an unsafe one')
+})
+
+test('a note without a title still reads as words, never blank', () => {
+  assert.equal(noteLabel({ id: 'x', title: 'Real Title' }), 'Real Title')
+  // A large tool output is carved head+tail, which can drop the titled section
+  // lines; the id is the fallback and must not surface raw dashes.
+  assert.equal(noteLabel({ id: 'theme-variables-are-shared' }), 'theme variables are shared')
+  assert.equal(noteLabel({ id: '../evil' }), '')
+})
+
+test('a malformed note is skipped without dropping its siblings', () => {
+  const recall = messageRecall([
+    toolBlock({
+      status: 'hit',
+      notes: [{ id: '../evil', path: 'notes/evil.md' }, note('alpha'), null],
+    }),
+  ])
+  assert.deepEqual(recall.notes.map(n => n.id), ['alpha'])
+})

--- a/frontend/src/components/ChatView/__tests__/streamReducers.test.js
+++ b/frontend/src/components/ChatView/__tests__/streamReducers.test.js
@@ -30,6 +30,7 @@ import {
   appendTextItem,
   repairInterleavedQuestionText,
   replaceTextItem,
+  startToolLifecycle,
 } from '../streamReducers.js'
 import { questionKey } from '../questionKey.js'
 
@@ -45,6 +46,17 @@ function questionEvent(id, text) {
     questions: [{ question: text, options: [{ label: 'A' }, { label: 'B' }] }],
   }
 }
+
+test('Codex tool start preserves provider-neutral Memory recall metadata', () => {
+  const items = startToolLifecycle([], {
+    tool: 'Bash',
+    input: 'python3 /data/apps/memory/memory_search.py "q"',
+    tool_use_id: 'cmd-1',
+    recall: { status: 'searching' },
+  })
+  assert.deepEqual(items[0].recall, { status: 'searching' })
+  assert.equal(items[0].tool_use_id, 'cmd-1')
+})
 
 test('text item identity keeps late deltas before an interleaved question', () => {
   let items = appendTextItem([], 'Build it', { textItemId: 'msg-1' })
@@ -257,6 +269,15 @@ test('large live tool output keeps the metadata needed for lazy full fetch', () 
     output_full_len: 120_000,
     output_exit_code: 0,
   })
+})
+
+test('small completed command output keeps its typed exit code', () => {
+  const prev = [toolItem('Bash', { input: 'false' })]
+  const next = attachToolOutput(prev, 'failed', {
+    tool_use_id: 'toolu_small_failure',
+    output_exit_code: 1,
+  })
+  assert.equal(next[0].output_exit_code, 1)
 })
 
 test('live output metadata cannot replace a runner-assigned tool identity', () => {

--- a/frontend/src/components/ChatView/memoryRecall.js
+++ b/frontend/src/components/ChatView/memoryRecall.js
@@ -25,6 +25,7 @@ const MAX_RECALL_ROWS_SCANNED = 256
 // path, but this value builds a URL that navigates the shell, so re-check here
 // rather than trusting an upstream call site to stay correct forever.
 const SAFE_NOTE_ID = /^[A-Za-z0-9][A-Za-z0-9._-]*$/
+const SAFE_MEMORY_APP_SLUG = /^memory(?:-[0-9]+)?$/
 
 export function safeNoteId(value) {
   if (typeof value !== 'string') return ''
@@ -33,13 +34,25 @@ export function safeNoteId(value) {
   return SAFE_NOTE_ID.test(candidate) ? candidate : ''
 }
 
+export function safeMemoryAppSlug(value) {
+  if (typeof value !== 'string') return ''
+  const candidate = value.trim()
+  return SAFE_MEMORY_APP_SLUG.test(candidate) ? candidate : ''
+}
+
 // Where a pill points: the Memory app, asked to open this note. `?app=<slug>&
 // intent=<text>` is the shell's existing internal-nav contract (the same one
 // artifact links use), so this adds no new navigation mechanism.
 export function noteHref(note) {
   const id = safeNoteId(note?.id)
-  return id
-    ? `/shell/?app=memory&intent=${encodeURIComponent(`note:${id}`)}`
+  if (!id) return ''
+  // Old persisted citations predate app_slug and necessarily came from the
+  // original unsuffixed install. New citations carry the slug validated from
+  // the command path; a present-but-invalid value fails closed.
+  const hasAppSlug = typeof note?.app_slug === 'string'
+  const appSlug = hasAppSlug ? safeMemoryAppSlug(note.app_slug) : 'memory'
+  return appSlug
+    ? `/shell/?app=${appSlug}&intent=${encodeURIComponent(`note:${id}`)}`
     : ''
 }
 

--- a/frontend/src/components/ChatView/memoryRecall.js
+++ b/frontend/src/components/ChatView/memoryRecall.js
@@ -82,6 +82,9 @@ export function messageRecall(blocks) {
     if (!recall || typeof recall !== 'object') continue
     // A lookup still in flight is a live activity beat, not yet a citation.
     if (recall.status === 'searching') continue
+    // A failed lookup remains visible in its activity row, but it did not
+    // successfully consult the graph and must not mint a source section.
+    if (recall.status === 'failed') continue
     looked = true
     if (recall.status === 'empty') empty = true
     if (!Array.isArray(recall.notes)) continue

--- a/frontend/src/components/ChatView/memoryRecall.js
+++ b/frontend/src/components/ChatView/memoryRecall.js
@@ -1,0 +1,104 @@
+// Pure derivation behind the Memory citations on an answer, kept separate so
+// the collection/dedupe contract is directly testable.
+//
+// Sibling of messageSources.js and deliberately the same shape of idea: a
+// recalled note is the same KIND of fact as a cited web page — something from
+// outside the model's turn that shaped the reply — so it is derived from the
+// turn's tool blocks and rendered once, after the answer, rather than carried
+// as its own content block (which would fragment a continuous thinking run).
+//
+// It does NOT reuse the `sources` field. Both `_safe_http_url` (backend) and
+// `safeSourceUrl` here hard-require a complete http(s) URL because that value
+// goes straight into an `<a href>`; a local note pointer would be silently
+// dropped, and relaxing that gate for non-web data would weaken a shared XSS
+// path for every citation. A sibling field riding the same tool block keeps it
+// intact.
+//
+// The data itself is stamped by the backend (`memory_recall.py`, applied on the
+// one `publish()` funnel), so both runners are covered by construction and the
+// live wire, the catch-up log, and the persisted transcript agree.
+
+export const MAX_RECALLED_NOTES = 12
+const MAX_RECALL_ROWS_SCANNED = 256
+
+// Only a note id may reach a deep link. The backend already validates the
+// path, but this value builds a URL that navigates the shell, so re-check here
+// rather than trusting an upstream call site to stay correct forever.
+const SAFE_NOTE_ID = /^[A-Za-z0-9][A-Za-z0-9._-]*$/
+
+export function safeNoteId(value) {
+  if (typeof value !== 'string') return ''
+  const candidate = value.trim()
+  if (!candidate || candidate.length > 128) return ''
+  return SAFE_NOTE_ID.test(candidate) ? candidate : ''
+}
+
+// Where a pill points: the Memory app, asked to open this note. `?app=<slug>&
+// intent=<text>` is the shell's existing internal-nav contract (the same one
+// artifact links use), so this adds no new navigation mechanism.
+export function noteHref(note) {
+  const id = safeNoteId(note?.id)
+  return id
+    ? `/shell/?app=memory&intent=${encodeURIComponent(`note:${id}`)}`
+    : ''
+}
+
+// Titles come from the Memory app's own graph. A lookup whose titled section
+// lines were carved out of a large tool output still yields a readable label
+// from the note id, so a pill is never blank.
+export function noteLabel(note) {
+  const title = typeof note?.title === 'string' ? note.title.trim() : ''
+  if (title) return title
+  const id = safeNoteId(note?.id)
+  return id ? id.replace(/[-_]+/g, ' ') : ''
+}
+
+/**
+ * What the turn recalled from Memory, or null when it never looked.
+ *
+ * Three outcomes, and the difference between them is the whole point:
+ *   { notes: [...] }        — it remembered these notes
+ *   { notes: [], empty: true }  — it looked and Memory had nothing
+ *   null                    — it never looked
+ *
+ * Without the middle case an owner cannot tell a memory gap from an agent that
+ * ignored its memory, which is exactly the distinction that earns trust.
+ */
+export function messageRecall(blocks) {
+  if (!Array.isArray(blocks)) return null
+  const notes = []
+  const seen = new Set()
+  let looked = false
+  let empty = false
+  let scannedRows = 0
+
+  outer:
+  for (const block of blocks) {
+    // Compact historical activity carries the same bounded recall metadata on
+    // its summary block, so citations remain visible without loading the full
+    // tool timeline merely to rediscover them.
+    if (!['tool', 'activity'].includes(block?.type)) continue
+    const recall = block.recall
+    if (!recall || typeof recall !== 'object') continue
+    // A lookup still in flight is a live activity beat, not yet a citation.
+    if (recall.status === 'searching') continue
+    looked = true
+    if (recall.status === 'empty') empty = true
+    if (!Array.isArray(recall.notes)) continue
+    for (const note of recall.notes) {
+      scannedRows += 1
+      if (scannedRows > MAX_RECALL_ROWS_SCANNED) break outer
+      const id = safeNoteId(note?.id)
+      const key = typeof note?.path === 'string' && note.path ? note.path : id
+      if (!id || !key || seen.has(key)) continue
+      if (notes.length >= MAX_RECALLED_NOTES) continue
+      seen.add(key)
+      notes.push(note)
+    }
+  }
+
+  if (!looked) return null
+  // A lookup that returned notes is a hit even if another probe came back
+  // empty: the turn did remember something, and the notes say what.
+  return { notes, empty: notes.length === 0 && empty }
+}

--- a/frontend/src/components/ChatView/streamReducers.js
+++ b/frontend/src/components/ChatView/streamReducers.js
@@ -38,6 +38,19 @@ import {
 // Mirrors backend/app/tool_summaries.py's question-tool branch.
 const QUESTION_TOOLS = new Set(['AskUserQuestion', 'request_user_input'])
 
+/** Build the one live tool-block shape shared by every provider. */
+export function startToolLifecycle(prev, event) {
+  return [...prev, {
+    type: 'tool',
+    tool: event?.tool,
+    input: event?.input || '',
+    output: '',
+    status: 'running',
+    ...(event?.recall ? { recall: event.recall } : {}),
+    ...(event?.tool_use_id ? { tool_use_id: event.tool_use_id } : {}),
+  }]
+}
+
 /**
  * Append a streamed text delta to its provider message item.
  *
@@ -342,12 +355,12 @@ export function attachToolOutput(prev, content, event = null) {
   if (event?.recall) {
     block.recall = event.recall
   }
+  if (event?.output_exit_code != null) {
+    block.output_exit_code = event.output_exit_code
+  }
   if (event?.output_truncated) {
     block.output_truncated = true
     block.output_full_len = event.output_full_len
-    if (event.output_exit_code != null) {
-      block.output_exit_code = event.output_exit_code
-    }
   }
   updated[i] = block
   return updated

--- a/frontend/src/components/ChatView/streamReducers.js
+++ b/frontend/src/components/ChatView/streamReducers.js
@@ -337,6 +337,11 @@ export function attachToolOutput(prev, content, event = null) {
   if (event?.tool_use_id && !block.tool_use_id) {
     block.tool_use_id = event.tool_use_id
   }
+  // Settle a Memory lookup from "searching" to the notes it actually returned.
+  // The backend parsed these from the full output, before the reduction below.
+  if (event?.recall) {
+    block.recall = event.recall
+  }
   if (event?.output_truncated) {
     block.output_truncated = true
     block.output_full_len = event.output_full_len

--- a/frontend/src/components/ChatView/streamReducers.js
+++ b/frontend/src/components/ChatView/streamReducers.js
@@ -351,7 +351,8 @@ export function attachToolOutput(prev, content, event = null) {
     block.tool_use_id = event.tool_use_id
   }
   // Settle a Memory lookup from "searching" to the notes it actually returned.
-  // The backend parsed these from the full output, before the reduction below.
+  // The backend stamps this from the bounded structured tail that survives any
+  // large-output carving.
   if (event?.recall) {
     block.recall = event.recall
   }

--- a/frontend/src/components/ChatView/toolActivityLabel.js
+++ b/frontend/src/components/ChatView/toolActivityLabel.js
@@ -212,7 +212,7 @@ export function effectiveToolName(tool) {
 // swallowed into a chip, not a tool block).
 const DISTINCTIVE_ACTIVITIES = new Set(['ViewImage', 'MemoryRecall'])
 
-// The one-line story of a memory lookup, in the three states that matter.
+// The one-line story of a memory lookup, including honest operational failure.
 // Reading the count from the citation set the backend already parsed keeps the
 // label and the pills under the answer from ever disagreeing.
 export function memoryRecallLabel(tool) {
@@ -221,6 +221,7 @@ export function memoryRecallLabel(tool) {
     return 'Searching Memory'
   }
   if (recall?.status === 'empty') return 'Searched Memory — nothing relevant'
+  if (recall?.status === 'failed') return 'Memory lookup failed'
   const count = Array.isArray(recall?.notes) ? recall.notes.length : 0
   if (count === 0) return 'Recalled from Memory'
   return `Recalled ${count} note${count === 1 ? '' : 's'} from Memory`

--- a/frontend/src/components/ChatView/toolActivityLabel.js
+++ b/frontend/src/components/ChatView/toolActivityLabel.js
@@ -31,6 +31,10 @@ const ACTIVITY_LABELS = new Map([
   // image file, mapped here by extension via effectiveToolName. Plural here —
   // the summary swaps to the singular "Viewing an image" for a lone one.
   ['ViewImage', 'Viewing images'],
+  // Consulting the Memory app. A Bash call to its search script, classified by
+  // the `recall` marker the backend stamps from the command — see
+  // effectiveToolName. Uncountable, so it has no singular twin.
+  ['MemoryRecall', 'Searching Memory'],
 ])
 
 // Past-tense twins for SETTLED lines — "Ran commands", not a "Running
@@ -57,6 +61,7 @@ const PAST_LABELS = new Map([
   ['AskUserQuestion', 'Asked you'],
   ['Skill', 'Used a skill'],
   ['ViewImage', 'Viewed images'],
+  ['MemoryRecall', 'Recalled from Memory'],
 ])
 
 // Singular twins for a ONE-occurrence activity: a lone Bash reads "Ran a
@@ -97,6 +102,7 @@ const ACTIVITY_ICONS = new Map([
   ['AskUserQuestion', 'dot'],
   ['Skill', 'dot'],
   ['ViewImage', 'image'],
+  ['MemoryRecall', 'search'],
 ])
 
 // An unknown tool falls back to its raw name (then the generic 'Tool' for a
@@ -149,6 +155,11 @@ const INSTANCE_VERBS = new Map([
 
 export function toolCallLabel(tool) {
   const name = effectiveToolName(tool) || 'Tool'
+  // A memory lookup says what it FOUND, not what it ran: the raw command is
+  // implementation vocabulary, and the count is the fact worth reading at a
+  // glance. "Nothing relevant" is stated explicitly, because a silent recall
+  // is indistinguishable from never having looked.
+  if (name === 'MemoryRecall') return memoryRecallLabel(tool)
   const input = typeof tool?.input === 'string' ? tool.input.trim() : ''
   const verbs = INSTANCE_VERBS.get(name)
   if (!verbs) return name + (input ? `: ${input}` : '')
@@ -171,6 +182,12 @@ export function toolCallLabel(tool) {
 const IMAGE_PATH_RE = /\.(png|jpe?g|gif|webp|bmp|avif)(?:[?#].*)?$/i
 export function effectiveToolName(tool) {
   const name = tool?.tool
+  // A Memory lookup is a Bash call the backend already identified from its
+  // command (memory_recall.py, stamped on the one publish() funnel). Keying off
+  // that stamp rather than re-matching the command here means one detection
+  // point for both runners, and it keeps working after transcript compaction
+  // strips the command string from a settled activity block.
+  if (tool?.recall && typeof tool.recall === 'object') return 'MemoryRecall'
   if (name === 'Read') {
     // On the wire tool.input is the STRING summary the backend builds
     // (summarize_tool_input -> the bare file_path for a Read), never the raw
@@ -193,7 +210,21 @@ export function effectiveToolName(tool) {
 // compaction, and subagent spawns join here once the backend surfaces their
 // events (today only image views are frontend-detectable — a Skill load is
 // swallowed into a chip, not a tool block).
-const DISTINCTIVE_ACTIVITIES = new Set(['ViewImage'])
+const DISTINCTIVE_ACTIVITIES = new Set(['ViewImage', 'MemoryRecall'])
+
+// The one-line story of a memory lookup, in the three states that matter.
+// Reading the count from the citation set the backend already parsed keeps the
+// label and the pills under the answer from ever disagreeing.
+export function memoryRecallLabel(tool) {
+  const recall = tool?.recall
+  if (recall?.status === 'searching' || tool?.status === 'running') {
+    return 'Searching Memory'
+  }
+  if (recall?.status === 'empty') return 'Searched Memory — nothing relevant'
+  const count = Array.isArray(recall?.notes) ? recall.notes.length : 0
+  if (count === 0) return 'Recalled from Memory'
+  return `Recalled ${count} note${count === 1 ? '' : 's'} from Memory`
+}
 export function isDistinctiveActivityTool(item) {
   return item?.type === 'tool' && DISTINCTIVE_ACTIVITIES.has(effectiveToolName(item))
 }

--- a/frontend/src/components/ChatView/useStreamConnection.js
+++ b/frontend/src/components/ChatView/useStreamConnection.js
@@ -17,6 +17,7 @@ import {
   applyTaskEvent,
   appendTextItem,
   replaceTextItem,
+  startToolLifecycle,
 } from './streamReducers.js'
 import {
   readStoredStreamSnapshot,
@@ -874,21 +875,9 @@ export default function useStreamConnection(chatId, {
             }
           } else if (event.type === 'tool_start') {
             flushBuffer()
-            applyStreamItems(prev => [...prev, {
-              type: 'tool',
-              tool: event.tool,
-              input: event.input || '',
-              output: '',
-              status: 'running',
-              // Carry the real per-tool identity from the wire (lever 2a). It
-              // keys the tool block (StreamingMessage/MsgContent) and lets a
-              // catch-up commit reconcile onto it by identity instead of
-              // remounting the heaviest block (expanded state, <img>, lazy
-              // fullOutput). streamItemToBlock spreads ...item, so it flows to
-              // the promoted message too. Undefined on a legacy/tokenless wire,
-              // where the ordinal fallback key still applies.
-              tool_use_id: event.tool_use_id,
-            }])
+            // Codex identifies Memory here; Claude may add the same marker on
+            // a later tool_input. One reducer owns the shared live block shape.
+            applyStreamItems(prev => startToolLifecycle(prev, event))
           } else if (event.type === 'tool_input') {
             // Backfill by stable identity. Older id-less events retain their
             // earliest-input-less fallback; a late id may be adopted only when

--- a/frontend/src/components/ChatView/useStreamConnection.js
+++ b/frontend/src/components/ChatView/useStreamConnection.js
@@ -920,6 +920,10 @@ export default function useStreamConnection(chatId, {
                 updated[i] = {
                   ...updated[i],
                   input: event.input,
+                  // A Memory lookup names itself from its command, so the live
+                  // line can read "Searching Memory…" while the search runs
+                  // rather than a generic "Running a command".
+                  ...(event.recall ? { recall: event.recall } : {}),
                   ...(event.tool_use_id && !updated[i].tool_use_id
                     ? { tool_use_id: event.tool_use_id }
                     : {}),


### PR DESCRIPTION
## The problem

Memory is consulted through an ordinary command, so the transcript previously rendered a recall as generic housekeeping. An owner could not distinguish:

- the turn recalled specific saved notes,
- it looked and found nothing relevant,
- the lookup failed,
- it never looked at all.

The original draft surfaced citations for Claude-shaped tool events, but Codex provides the complete command earlier in the lifecycle. It also treated an unreadable result as a successful note-less recall. That made provider behavior inconsistent and could display “Recalled from Memory” after a traceback.

## The change

- recognize only the documented simple absolute Memory invocation; shell composition and commands that merely mention the script cannot mint citations
- consume the Memory app’s versioned structured result instead of parsing human prose
- carry the lookup marker from Codex `tool_start` or Claude `tool_input`, then settle it only from final output
- retain typed command exit codes for small and large outputs and classify missing, malformed, or contradictory results as failures
- preserve the graph's structured node ID for deep links, with a bounded filename fallback only for older/malformed records
- show recalled notes beside web sources, show a quiet explicit no-match state, and keep failures visible only in the activity row
- preserve the bounded recall metadata through transcript compaction so citations survive a reload

A recalled note remains a sibling of a web source rather than weakening the existing HTTP-only source-link contract. Paths, titles, excerpts, IDs, counts, and output scans are bounded before they enter the transcript or build a local deep link.

## Companion app and landing order

This requires [mobius-os/app-memory#14](https://github.com/mobius-os/app-memory/pull/14), which emits `MOBIUS_MEMORY_RESULT_V1` and handles the resulting `note:<id>` intent inside Memory. Merge and release the app PR first, then this platform PR.

The app keeps its existing human-readable answer and verified `FILES:` line for older agents. The platform deliberately has no permanent prose-parser fallback: the versioned result is the one owning boundary.

## Scope

Nothing renders for a turn that did not consult Memory. Existing stored recall metadata remains readable, while new citations accumulate going forward.

## Validation

- 190 focused backend tests passed across result parsing, identity preservation, event persistence, transcript compaction, and both agent runners
- 111 focused frontend tests passed across stream reduction, rendering, grouping, accessibility, and deep links
- the complete frontend suite and production build passed on the submitted head
- the companion app passed 46 JavaScript tests, its offline harness, 57 Python tests, and syntax checks
- full-diff metadata, privacy, and whitespace checks passed in both repositories
