### PR TITLE
Hide visible chat attention cues before paint

### DIFF
--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -23,6 +23,7 @@ import { getOnlineSnapshot } from '../../lib/connectivityStore.js'
 import useSystemEventStream from '../../hooks/useSystemEventStream.js'
 import usePendingQueue from './hooks/usePendingQueue.js'
 import useBridgePartial from './hooks/useBridgePartial.js'
+import useOffscreenNudge from './hooks/useOffscreenNudge.js'
 import ChatInputBar from './ChatInputBar.jsx'
 import { hasSendablePayload } from './composerSubmission.js'
 import AgentContextInspector from './AgentContextInspector.jsx'
@@ -223,44 +224,6 @@ function readInitialComposer(chatId) {
 // composer) don't hand ChatView a fresh array each render and re-fire its
 // list-keyed effects.
 const NO_BUILT_APPS = []
-
-// One offscreen-visibility observer for a sticky footer nudge, used twice (the
-// pending-question card and the resume card). Returns whether the found card is
-// currently scrolled OUT of the scroll container's viewport, so the caller can
-// show a "tap to jump to it" chip.
-//
-// `findCard` is a fresh closure every render (it reads scrollRef.current, a
-// ref, so even a stale one queries live DOM), so it is deliberately kept OUT of
-// the reactive dep array and read through a ref. The observer rebinds only on
-// `active` flips and the explicit `rebindDeps` — the rendering-surface signals
-// that can move the card's DOM node — exactly as the two hand-written effects
-// did. Listing `findCard` in the deps would recreate the observer on every
-// streaming re-render (a per-token IntersectionObserver thrash); the card's DOM
-// node is stable across those, so it must not.
-function useOffscreenNudge(scrollRef, active, findCard, rebindDeps) {
-  const [offscreen, setOffscreen] = useState(false)
-  const findCardRef = useRef(findCard)
-  findCardRef.current = findCard
-  useEffect(() => {
-    if (!active) {
-      setOffscreen(false)
-      return undefined
-    }
-    const scrollEl = scrollRef.current
-    const card = findCardRef.current()
-    if (!scrollEl || !card || typeof IntersectionObserver === 'undefined') {
-      setOffscreen(false)
-      return undefined
-    }
-    const io = new IntersectionObserver(entries => {
-      setOffscreen(!entries[0]?.isIntersecting)
-    }, { root: scrollEl, threshold: 0 })
-    io.observe(card)
-    return () => io.disconnect()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [active, scrollRef, ...rebindDeps])
-  return offscreen
-}
 
 export default function ChatView({
   chatId,

--- a/frontend/src/components/ChatView/hooks/__tests__/useOffscreenNudge.test.js
+++ b/frontend/src/components/ChatView/hooks/__tests__/useOffscreenNudge.test.js
@@ -1,0 +1,67 @@
+/**
+ * Regression tests for the sticky question / Resume attention cue.
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { renderHook } from './react-hook-shim.mjs'
+import useOffscreenNudge, {
+  isElementOffscreen,
+} from '../useOffscreenNudge.js'
+
+
+function rect(top, bottom) {
+  return { top, bottom }
+}
+
+function elementAt(top, bottom) {
+  return { getBoundingClientRect: () => rect(top, bottom) }
+}
+
+
+test('visible targets are not offscreen, including partial visibility', () => {
+  const viewport = elementAt(100, 500)
+  assert.equal(isElementOffscreen(viewport, elementAt(150, 450)), false)
+  assert.equal(isElementOffscreen(viewport, elementAt(50, 101)), false)
+  assert.equal(isElementOffscreen(viewport, elementAt(499, 600)), false)
+})
+
+test('targets entirely above or below the chat viewport are offscreen', () => {
+  const viewport = elementAt(100, 500)
+  assert.equal(isElementOffscreen(viewport, elementAt(20, 100)), true)
+  assert.equal(isElementOffscreen(viewport, elementAt(500, 700)), true)
+})
+
+test('mount computes committed geometry before observer delivery', () => {
+  const originalObserver = globalThis.IntersectionObserver
+  class IdleObserver {
+    observe() {}
+    disconnect() {}
+  }
+  globalThis.IntersectionObserver = IdleObserver
+
+  try {
+    const scrollRef = { current: elementAt(100, 500) }
+    const visible = elementAt(200, 400)
+    const { result, rerender } = renderHook(
+      useOffscreenNudge,
+      scrollRef,
+      true,
+      () => visible,
+      ['messages-v1'],
+    )
+    assert.equal(result.current, false,
+      'a visible question must not wait for IntersectionObserver to hide the cue')
+
+    const hiddenBelow = elementAt(600, 800)
+    rerender(
+      scrollRef,
+      true,
+      () => hiddenBelow,
+      ['messages-v2'],
+    )
+    assert.equal(result.current, true,
+      'a newly rebound offscreen question is exposed in the same layout pass')
+  } finally {
+    globalThis.IntersectionObserver = originalObserver
+  }
+})

--- a/frontend/src/components/ChatView/hooks/__tests__/useOffscreenNudge.test.js
+++ b/frontend/src/components/ChatView/hooks/__tests__/useOffscreenNudge.test.js
@@ -6,6 +6,7 @@ import assert from 'node:assert/strict'
 import { renderHook } from './react-hook-shim.mjs'
 import useOffscreenNudge, {
   isElementOffscreen,
+  isIntersectionOffscreen,
 } from '../useOffscreenNudge.js'
 
 
@@ -29,6 +30,21 @@ test('targets entirely above or below the chat viewport are offscreen', () => {
   const viewport = elementAt(100, 500)
   assert.equal(isElementOffscreen(viewport, elementAt(20, 100)), true)
   assert.equal(isElementOffscreen(viewport, elementAt(500, 700)), true)
+})
+
+test('observer delivery requires positive visible area', () => {
+  assert.equal(isIntersectionOffscreen({
+    isIntersecting: true,
+    intersectionRatio: 0,
+  }), true, 'edge adjacency has no visible pixels')
+  assert.equal(isIntersectionOffscreen({
+    isIntersecting: true,
+    intersectionRatio: 0.01,
+  }), false)
+  assert.equal(isIntersectionOffscreen({
+    isIntersecting: false,
+    intersectionRatio: 0,
+  }), true)
 })
 
 test('mount computes committed geometry before observer delivery', () => {

--- a/frontend/src/components/ChatView/hooks/useOffscreenNudge.js
+++ b/frontend/src/components/ChatView/hooks/useOffscreenNudge.js
@@ -1,0 +1,59 @@
+/* Tracks whether a footer attention target is outside the chat viewport. */
+import {
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react'
+
+
+export function isElementOffscreen(scrollEl, element) {
+  if (!scrollEl || !element) return false
+  const viewport = scrollEl.getBoundingClientRect()
+  const target = element.getBoundingClientRect()
+  return target.bottom <= viewport.top || target.top >= viewport.bottom
+}
+
+
+// `findElement` is a fresh closure every render (it reads the live scroll
+// ref), so keep it out of the dependency list. Rebinding on every streamed
+// token would replace the observer continuously; callers instead provide the
+// rendering-surface values that can replace the target node.
+export default function useOffscreenNudge(
+  scrollRef,
+  active,
+  findElement,
+  rebindDeps,
+) {
+  const [offscreen, setOffscreen] = useState(false)
+  const findElementRef = useRef(findElement)
+  findElementRef.current = findElement
+
+  useLayoutEffect(() => {
+    if (!active) {
+      setOffscreen(false)
+      return undefined
+    }
+
+    const scrollEl = scrollRef.current
+    const element = findElementRef.current()
+    if (!scrollEl || !element) {
+      setOffscreen(false)
+      return undefined
+    }
+
+    // IntersectionObserver reports after paint. Recompute from the committed
+    // geometry first so a newly visible card cannot paint beneath a stale
+    // "tap to answer" cue while that callback is still queued.
+    setOffscreen(isElementOffscreen(scrollEl, element))
+
+    if (typeof IntersectionObserver === 'undefined') return undefined
+    const observer = new IntersectionObserver(entries => {
+      setOffscreen(!entries[0]?.isIntersecting)
+    }, { root: scrollEl, threshold: 0 })
+    observer.observe(element)
+    return () => observer.disconnect()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active, scrollRef, ...rebindDeps])
+
+  return offscreen
+}

--- a/frontend/src/components/ChatView/hooks/useOffscreenNudge.js
+++ b/frontend/src/components/ChatView/hooks/useOffscreenNudge.js
@@ -14,6 +14,14 @@ export function isElementOffscreen(scrollEl, element) {
 }
 
 
+export function isIntersectionOffscreen(entry) {
+  if (!entry) return false
+  // Edge-adjacent rectangles count as intersecting even when they share zero
+  // pixels. Keep observer delivery aligned with the synchronous geometry path.
+  return !entry.isIntersecting || entry.intersectionRatio <= 0
+}
+
+
 // `findElement` is a fresh closure every render (it reads the live scroll
 // ref), so keep it out of the dependency list. Rebinding on every streamed
 // token would replace the observer continuously; callers instead provide the
@@ -48,7 +56,7 @@ export default function useOffscreenNudge(
 
     if (typeof IntersectionObserver === 'undefined') return undefined
     const observer = new IntersectionObserver(entries => {
-      setOffscreen(!entries[0]?.isIntersecting)
+      setOffscreen(isIntersectionOffscreen(entries[0]))
     }, { root: scrollEl, threshold: 0 })
     observer.observe(element)
     return () => observer.disconnect()


### PR DESCRIPTION
## Summary

- measure the committed question or Resume card before paint so a stale off-screen cue cannot flash over a visible card
- retain IntersectionObserver updates while the reader scrolls
- cover fully visible, partially visible, and off-screen targets

## Testing

- `npm test` (1,949 tests)
- `npm run build`
- manually verified the cue appears off-screen and disappears after returning to the card