### PR TITLE
Keep attachment-only turns out of slash dispatch

### DIFF
--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -4431,8 +4431,8 @@ def _is_cli_slash_command(text: str) -> bool:
   without turning path-like prose such as `/data/apps/x is broken` into
   a command-shaped prompt.
   """
-  first = (text or "").lstrip("\n").split(None, 1)[0].strip()
-  return first in {"/goal"}
+  words = (text or "").lstrip("\n").split(None, 1)
+  return bool(words) and words[0].strip() in {"/goal"}
 
 
 async def run_chat(

--- a/backend/tests/test_time_context.py
+++ b/backend/tests/test_time_context.py
@@ -93,6 +93,8 @@ def test_elapsed_ignores_automatic_continuation_marker(monkeypatch):
 def test_goal_slash_command_is_detected_without_matching_paths():
   assert _is_cli_slash_command("/goal say PONG")
   assert _is_cli_slash_command("\n/goal clear")
+  assert not _is_cli_slash_command("")
+  assert not _is_cli_slash_command("\n\n")
   assert not _is_cli_slash_command("/")
   assert not _is_cli_slash_command("/data/apps/x is broken")
   assert not _is_cli_slash_command("please run /goal later")


### PR DESCRIPTION
## Summary

Attachment-only messages now legitimately reach the backend with empty text. `_is_cli_slash_command()` indexed the first split word unconditionally, so those turns could raise `IndexError` before the provider started.

Treat an empty/whitespace-only message as an ordinary non-slash turn. This keeps the existing `/goal` and path-like-text behavior unchanged.

## Validation

- `backend/tests/test_time_context.py`: 8 passed
- pre-push privacy and Python syntax gates passed