### PR TITLE
Prevent image zoom crash after touch pan

### DIFF
--- a/frontend/src/components/ChatView/__tests__/imageGallery.test.js
+++ b/frontend/src/components/ChatView/__tests__/imageGallery.test.js
@@ -114,6 +114,18 @@ test('gallery navigation has explicit keyboard and lightbox alternatives', () =>
   assert.match(lightboxSource, /\{index \+ 1\} \/ \{galleryItems\.length\}/)
 })
 
+test('zoomed touch pan keeps its gesture snapshot through a queued render', () => {
+  assert.match(
+    lightboxSource,
+    /const pan = panRef\.current[\s\S]{0,180}setTransform\(\(current\) =>[\s\S]{0,180}touch\.clientX - pan\.x[\s\S]{0,80}touch\.clientY - pan\.y/,
+    'lifting a finger may clear panRef before React evaluates the queued state update',
+  )
+  assert.doesNotMatch(
+    lightboxSource,
+    /setTransform\(\(current\) =>[\s\S]{0,220}panRef\.current\.[xy]/,
+  )
+})
+
 test('resolved images follow their URL rather than a streamed array position', () => {
   const sources = new Map([
     ['/one.png', '/resolved/one.png'],

--- a/frontend/src/components/ChatView/markdown/ImageLightbox.jsx
+++ b/frontend/src/components/ChatView/markdown/ImageLightbox.jsx
@@ -239,10 +239,11 @@ export default function ImageLightbox({
       } else if (event.touches.length === 1 && panRef.current && transformRef.current.scale > 1) {
         event.preventDefault()
         const touch = event.touches[0]
+        const pan = panRef.current
         setTransform((current) => clampImageTransform({
           ...current,
-          x: touch.clientX - panRef.current.x,
-          y: touch.clientY - panRef.current.y,
+          x: touch.clientX - pan.x,
+          y: touch.clientY - pan.y,
         }, metrics()))
       }
     }


### PR DESCRIPTION
## Summary

- snapshot the active touch-pan origin before queuing an image transform update
- prevent finger-up from clearing gesture state that a pending zoomed pan still needs
- cover the queued-render lifecycle with a focused regression test

## Validation

- reproduced the original failure sequence at a phone viewport
- verified two-finger pinch to 2×, one-finger pan, and immediate lift keeps the viewer open and positioned
- `npm test` (1,957 tests)
- `npm run build`
