### PR TITLE
refactor(ui): remove unreachable activity branch

### DIFF
--- a/frontend/src/components/ChatView/ActivityStretch.jsx
+++ b/frontend/src/components/ChatView/ActivityStretch.jsx
@@ -159,20 +159,14 @@ function SingleActivity({ entry, chatId, live, surfaceKey }) {
       />
     )
   }
-  const hasHelpers = item.subagent
-    && typeof item.subagent === 'object'
-    && Object.keys(item.subagent).length > 0
   return (
-    <>
-      <ToolBlock
-        key={assistantBlockKey(item, idx)}
-        t={item}
-        chatId={chatId}
-        compact
-        disclosureKey={`${surfaceKey}:tool:${blockKey}`}
-      />
-      {hasHelpers && <SubagentChips subagent={item.subagent} />}
-    </>
+    <ToolBlock
+      key={assistantBlockKey(item, idx)}
+      t={item}
+      chatId={chatId}
+      compact
+      disclosureKey={`${surfaceKey}:tool:${blockKey}`}
+    />
   )
 }
 

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -391,7 +391,7 @@ export default function Shell() {
     dispatchWorkspace({ type: 'FOCUS', paneId })
     setFocusedPaneViewId(paneId)
   }, [dispatchWorkspace, setFocusedPaneViewId])
-  // Builder mode = the committed 'panes' world (logo twist + living halo + power
+  // Builder mode = the committed 'panes' world (logo twist + static brand cue + power
   // chrome), clamped off by the splits kill switch (INV 16). Flips synchronously
   // with the toggle, matching the gesture's own spring/snap.
   const builderModeActive = modeMachine.builderModeActive(modeState, { splitsEnabled: SPLITS })
@@ -1595,8 +1595,8 @@ export default function Shell() {
     // flip and hand its compression to the descriptor (round 4 item 1).
     return mode.toggle({ cause, presentation })
   }, [dispatchWorkspace, mode, projection, contentRect])
-  // The single-tap navigation toggle passed to ShellBrand (which now owns the logo
-  // gesture + living halo). The HOLD / swipe / Shift+Enter mode toggle is
+  // The single-tap navigation toggle passed to ShellBrand (which owns the logo
+  // gesture and static Builder cue). The HOLD / swipe / Shift+Enter mode toggle is
   // handleToggleViewMode above, passed to ShellBrand as onToggleMode.
   const handleToggleNavigation = useCallback(() => {
     if (persistentDrawer) {

--- a/frontend/src/components/Shell/modeMachine.js
+++ b/frontend/src/components/Shell/modeMachine.js
@@ -258,10 +258,9 @@ export function transitionRootClass(state, { splitsEnabled = true } = {}) {
   return ''
 }
 
-// Builder mode is active (the logo's 180° twist + power chrome) whenever the
-// COMMITTED mode is panes — it flips synchronously with the toggle. The LIVING HALO
-// pauses during any beat (see Shell's haloActive), so this is builder chrome, not
-// the halo gate. Clamped off by the kill switch. INV 4/16.
+// Builder mode is active (the logo's 180° twist + static brand cue + power chrome)
+// whenever the COMMITTED mode is panes — it flips synchronously with the toggle.
+// Clamped off by the kill switch. INV 4/16.
 export function builderModeActive(state, { splitsEnabled = true } = {}) {
   return clampMode(state.committedMode, splitsEnabled) === 'panes'
 }


### PR DESCRIPTION
## What

- remove the helper-chip branch from `SingleActivity`
- update stale shell comments that still described the deleted living-halo runtime

## Why this is behavior-preserving

`ActivityStretch` calls `SingleActivity` only when `loneHasHelpers` is false. Every helper-bearing activity is routed to `GroupedActivityStretch`, which remains the sole owner of `SubagentChips`. The removed condition therefore could never render.

This makes the fragile chat activity boundary match its actual invariant and removes misleading documentation around the already-static Builder brand cue.

## Verification

- focused ChatView and Shell tests: 96/96
- full frontend suite: 1,957/1,957
- production frontend build passes
- pre-push frontend gate passes