### PR TITLE
fix(scripts): local e2e runner survives Docker Desktop's VM-internal root dir

### DIFF
--- a/scripts/playwright-local.sh
+++ b/scripts/playwright-local.sh
@@ -116,6 +116,12 @@ if [[ ! "$min_free_gb" =~ ^[0-9]+$ ]]; then
 fi
 docker_root="$(docker info --format '{{.DockerRootDir}}' 2>/dev/null || true)"
 disk_path="${docker_root:-$ROOT}"
+# Docker Desktop (macOS/Windows) reports the VM-internal root
+# (/var/lib/docker), which does not exist on the host — df would abort the
+# whole run under `set -e`. Fall back to the checkout's disk: on Docker
+# Desktop the VM disk image lives on the same volume, so the free-space
+# signal stays honest.
+[[ -d "$disk_path" ]] || disk_path="$ROOT"
 available_kb="$(df -Pk "$disk_path" | awk 'NR == 2 {print $4}')"
 minimum_kb="$((min_free_gb * 1024 * 1024))"
 if (( available_kb < minimum_kb )); then


### PR DESCRIPTION
## What

One 6-line guard in `scripts/playwright-local.sh`: if the `DockerRootDir` reported by `docker info` does not exist on the host, fall back to the checkout's disk for the free-space check.

## Why

On macOS/Windows Docker Desktop, `docker info` reports the VM-internal root (`/var/lib/docker`), which doesn't exist on the host filesystem. `df -Pk` on that path fails, and under `set -e` that aborts the entire runner before it does anything — so `--allow-local-e2e` is currently unusable on Docker Desktop hosts.

The fallback keeps the free-space signal honest: on Docker Desktop the VM disk image lives on the same volume as the checkout, so measuring the checkout's disk measures the space Docker actually has. Linux hosts (where `DockerRootDir` is a real path) are unaffected.

## Provenance

This is the runner fix that rode along in #239 and was dropped there as unrelated scope (correctly — it has nothing to do with notifications). Verified in practice: every notifications e2e run in #239 (6/6 spec + 74/74 regression) executed through this guard on a Docker Desktop host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)