### PR TITLE
Make the lost-reply marker resumable

### DIFF
--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -617,13 +617,11 @@ class _ChatEventSink:
         # fixes stop those at the source; this guarantees the turn is never a
         # SILENT user->user gap — persist a neutral marker the client can retry.
         #
-        # Every pause-shaped block is built by `_pause_note`, the one builder
-        # that owns the `resumable` contract — the flag MsgContent keys the
-        # one-tap Resume button on. A marker that skips the builder is a
-        # dead-end notice offering no way out of the exact gap it marks. No
-        # `kind` here, so it stays in the plain error family: a lost reply is
-        # a failure, not a benign pause. The button is the affordance, so the
-        # message only states the fact.
+        # Built via _pause_note so the marker carries `resumable` — the flag
+        # MsgContent gates the one-tap Resume button on. No `kind`, so no
+        # `pause` descriptor: a lost reply is a failure, not a benign pause,
+        # and stays in the Error family. The button is the affordance; the
+        # message just states the fact.
         blocks = [_pause_note("This turn ended without a response.")]
       else:
         # Genuinely empty turn (no content, no error, not a lost reply) —

--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -616,10 +616,15 @@ class _ChatEventSink:
         # resume no-op, or a codex message whose text was lost). The runner-side
         # fixes stop those at the source; this guarantees the turn is never a
         # SILENT user->user gap — persist a neutral marker the client can retry.
-        blocks = [{
-          "type": "error",
-          "message": "This turn ended without a response — tap to retry.",
-        }]
+        #
+        # Every pause-shaped block is built by `_pause_note`, the one builder
+        # that owns the `resumable` contract — the flag MsgContent keys the
+        # one-tap Resume button on. A marker that skips the builder is a
+        # dead-end notice offering no way out of the exact gap it marks. No
+        # `kind` here, so it stays in the plain error family: a lost reply is
+        # a failure, not a benign pause. The button is the affordance, so the
+        # message only states the fact.
+        blocks = [_pause_note("This turn ended without a response.")]
       else:
         # Genuinely empty turn (no content, no error, not a lost reply) —
         # nothing to persist.

--- a/backend/tests/test_terminal_completion.py
+++ b/backend/tests/test_terminal_completion.py
@@ -304,9 +304,13 @@ def test_empty_provider_result_persists_retryable_failure(monkeypatch, queued):
     for block in message.get("blocks", [])
     if block.get("type") == "error"
   ]
+  # `resumable` is the point of the marker, not incidental: it is what renders
+  # the one-tap Resume button, so a lost reply is recoverable instead of a
+  # dead-end notice. Pinned in the block shape so it cannot regress silently.
   assert retry_blocks == [{
     "type": "error",
-    "message": "This turn ended without a response — tap to retry.",
+    "message": "This turn ended without a response.",
+    "resumable": True,
   }]
   outcomes = _run_outcomes(cid)
   assert outcomes[run_token] == "failed"


### PR DESCRIPTION
## Problem

When a turn reached a clean provider terminal but produced no renderable content, the sink persisted a marker so the transcript never showed a silent gap. Its copy read:

> This turn ended without a response — tap to retry.

There was nothing to tap. The card rendered as dead text promising an affordance the frontend never drew — in the exact spot whose whole purpose is to give the owner a way out of a dropped turn.

## Cause

The marker was hand-rolled at the call site as a bare `{"type": "error", "message": ...}` instead of going through `_pause_note(...)`, the single builder every other pause/failure producer in `chat.py` uses. `_pause_note` is what stamps `resumable: True`, and `resumable` is the flag `MsgContent` gates the Resume button on (`block.resumable && isLastMsg && onResume`). Skipping the builder silently dropped the flag.

## Fix

`backend/app/chat.py`
- Build the marker with `_pause_note("This turn ended without a response.")` so it carries `resumable: True` and the button renders.
- Drop the "— tap to retry" clause: the button is the affordance now.
- Pass no `kind`, deliberately. `_pause_note` only attaches a `pause` descriptor when given a `kind`, and `ErrorCard.errorCardViewModel` keys the calm "Paused" family off `!!block.pause`. A lost reply is a genuine failure, so it stays in the danger-red "Error" family. Wire shape is unchanged (`events.ERROR_PASSTHROUGH_FIELDS` already carries `resumable`).
- The comment states the durable invariant — every pause-shaped block comes from the one builder that owns the `resumable` contract — rather than narrating the historical bug.

`backend/tests/test_terminal_completion.py`
- The empty-provider-result test now pins the full block shape including `resumable: True`, so the flag cannot regress silently.

No frontend change is needed: both promotion paths already whitelist `resumable`, and `MsgContent` already renders Resume from it.

### Known follow-up (not in this PR)

`ChatView.jsx` derives the offscreen resume nudge and the aria-live status solely from `pendingResumeBlock.pause?.resets_at`, so anything resumable without a `pause` descriptor falls through to "Turn paused — tap to resume". For this block that over-generalises: the turn failed, it did not pause. The transcript card itself is already correct. This is not introduced here — the pre-existing kind-less resumable note at `chat.py:3855` has the same mismatch — and fixing it means new copy branches plus `resumeAffordance.test.js` updates, so it belongs in its own change. Routing this block through `_pause_note` *with* a `kind` would be the wrong fix: it would attach a `pause` descriptor and demote the card from "Error" to "Paused".

## Verification

The containerised runner was unavailable in this environment, so pytest ran directly with an isolated tmp `DATA_DIR`/SQLite DB as `conftest.py` provisions.

- `pytest tests/test_terminal_completion.py -q` → **37 passed**
- Full backend suite → **3073 passed, 7 failed, 1 skipped**. All 7 failures reproduce identically on unpatched `main` in this environment (they need the Docker image's built frontend dist, version stamp, and platform clone). **Zero new failures.**
- The frontend tests that pin the `block.resumable && isLastMsg && onResume` gate this fix depends on (`resumeAffordance.test.js`, `parkedCard.test.js`) → **20 passed**.

Mutation-checked: reverting only the mechanism (keeping the new message text) fails the assertion on both params with `'resumable': True` missing — so the added assertion is load-bearing, not decorative.
