### PR TITLE
Report a self-requested Codex stop as interrupted, not a provider error

### DIFF
--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -571,7 +571,6 @@ def _sdk_imports() -> dict[str, Any]:
   from openai_codex.client import CodexConfig
   from openai_codex.errors import (
     CodexRpcError,
-    InvalidParamsError,
     TransportClosedError,
   )
   from openai_codex.types import ReasoningEffort, ReasoningSummary
@@ -650,7 +649,6 @@ def _sdk_imports() -> dict[str, Any]:
     "ErrorNotification": ErrorNotification,
     "FileChangePatchUpdatedNotification": FileChangePatchUpdatedNotification,
     "FileChangeThreadItem": FileChangeThreadItem,
-    "InvalidParamsError": InvalidParamsError,
     "ReasoningEffort": ReasoningEffort,
     "ReasoningSummary": ReasoningSummary,
     "Sandbox": Sandbox,
@@ -1500,7 +1498,9 @@ def _is_transport_death(exc: BaseException) -> bool:
     return False
   if isinstance(exc, sdk["TransportClosedError"]):
     return True
-  if isinstance(exc, (sdk["InvalidParamsError"], sdk["CodexRpcError"])):
+  # InvalidParamsError is a subclass of CodexRpcError, so matching the base
+  # class alone already covers it.
+  if isinstance(exc, sdk["CodexRpcError"]):
     text = str(exc).lower()
     return "closed" in text or "not running" in text or "broken pipe" in text
   return False

--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -2385,10 +2385,11 @@ async def run_codex_sdk_turn(
       # the new event omits — taking the note's one-tap Resume with it and
       # leaving the owner an unexplained error and no way back.
       #
-      # Expected, so INFO — but the transport's dying words are the only
-      # forensics a kill leaves behind, and nothing downstream logs them
-      # once `error` is None.
-      log.info(
+      # Usually expected after escalation, but WARNING is deliberate: a real
+      # app-server crash can coincide with a requested stop and has the same
+      # transport shape. The dying words are the only forensic evidence left
+      # once the owner-facing error is suppressed.
+      log.warning(
         "Codex transport closed by our own stop chat_id=%s: %s", chat_id, exc,
       )
       return with_usage({

--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -569,7 +569,11 @@ def _sdk_imports() -> dict[str, Any]:
   """
   from openai_codex import ApprovalMode, AsyncCodex, Sandbox
   from openai_codex.client import CodexConfig
-  from openai_codex.errors import CodexRpcError, InvalidParamsError
+  from openai_codex.errors import (
+    CodexRpcError,
+    InvalidParamsError,
+    TransportClosedError,
+  )
   from openai_codex.types import ReasoningEffort, ReasoningSummary
   from openai_codex.generated.v2_all import (
     AgentMessageDeltaNotification,
@@ -667,6 +671,7 @@ def _sdk_imports() -> dict[str, Any]:
     "ThreadTokenUsageUpdatedNotification": (
       ThreadTokenUsageUpdatedNotification
     ),
+    "TransportClosedError": TransportClosedError,
     "TurnCompletedNotification": TurnCompletedNotification,
     "TurnStatus": TurnStatus,
     "WebSearchThreadItem": WebSearchThreadItem,
@@ -1463,19 +1468,52 @@ def _file_change_patch_summary(changes: list[Any]) -> str:
   return "\n".join(lines)
 
 
-def _is_closed_turn_error(exc: BaseException) -> bool:
-  """Returns True when the live turn handle is already closed/dead."""
+def _is_transport_death(exc: BaseException) -> bool:
+  """Returns True when the app-server connection itself died.
+
+  Strictly the transport: the SDK's own TransportClosedError, or an RPC
+  error the app-server raised about a closed/dead channel. Deliberately
+  excludes plain RuntimeErrors, because the runner reraises every
+  non-retryable provider ErrorNotification as `RuntimeError(message)` —
+  an MCP server "is not running" is a provider fault to report, not a
+  dead pipe.
+
+  The transport class comes from `_sdk_imports()` and is matched with
+  isinstance, not by class name: this predicate decides whether an error
+  reaches the owner at all, so it must be bound to the real symbol (and
+  must match its subclasses) rather than to anything that happens to
+  share a name.
+  """
   sdk: dict[str, Any] | None = None
   try:
     sdk = _sdk_imports()
-  except ModuleNotFoundError:
+  except ImportError:
+    # ImportError, not ModuleNotFoundError: an SDK that renames or drops
+    # TransportClosedError fails the `from ... import` the same way a missing
+    # package does, and this predicate runs INSIDE the turn's except handler —
+    # raising here would mask the very exception it was asked to classify.
     sdk = None
-  if sdk is not None and isinstance(
-    exc, (sdk["InvalidParamsError"], sdk["CodexRpcError"])
-  ):
+  if sdk is None:
+    # Without the SDK no turn can have started, so no transport of ours can
+    # have died. Matching on a class name alone would be worse than useless
+    # here: it would let any look-alike be mistaken for the real thing.
+    return False
+  if isinstance(exc, sdk["TransportClosedError"]):
+    return True
+  if isinstance(exc, (sdk["InvalidParamsError"], sdk["CodexRpcError"])):
     text = str(exc).lower()
     return "closed" in text or "not running" in text or "broken pipe" in text
-  if exc.__class__.__name__ == "TransportClosedError":
+  return False
+
+
+def _is_closed_turn_error(exc: BaseException) -> bool:
+  """Returns True when the live turn handle is already closed/dead.
+
+  Wider than `_is_transport_death`: a steer against a finished turn also
+  surfaces as a plain RuntimeError, and there the cost of a false positive
+  is only a refused steer.
+  """
+  if _is_transport_death(exc):
     return True
   if isinstance(exc, RuntimeError):
     text = str(exc).lower()
@@ -1917,6 +1955,33 @@ async def run_codex_sdk_turn(
   def abort_requested() -> bool:
     return bool(should_abort and should_abort())
 
+  def stop_requested() -> bool:
+    """True when Möbius, not the provider, ended this turn.
+
+    The single definition of "we did this to ourselves", shared by terminal
+    validation (which sees a clean TurnStatus.interrupted) and the except
+    path (which sees the transport die mid-stream because force_stop killed
+    the turn's process group). Both need the same fact.
+
+    Includes the superseded-generation abort: a newer turn taking over this
+    chat is still Möbius ending this one. That leg can be true before
+    `active_turn` exists, which is deliberate — a teardown during startup is
+    no more the provider's fault than one mid-stream.
+    """
+    return bool(
+      (active_turn is not None and active_turn.interrupt_requested)
+      or abort_requested()
+    )
+
+  def with_usage(result: RunnerResult) -> RunnerResult:
+    """Attaches whatever the turn spent before it ended, however it ended."""
+    if final_token_usage is not None:
+      result["usage"] = _model_dump(final_token_usage)
+      result["usage_metrics"] = normalize_codex_usage(
+        first_token_usage, final_token_usage,
+      )
+    return result
+
   def aborted_result() -> RunnerResult:
     return {
       "session_id": current_session_id,
@@ -2295,33 +2360,48 @@ async def run_codex_sdk_turn(
       error_text, terminal_status, final_message_phase = _codex_terminal_error(
         completed_turn,
         sdk,
-        interrupt_requested=bool(
-          (active_turn and active_turn.interrupt_requested)
-          or abort_requested()
-        ),
+        interrupt_requested=stop_requested(),
         completed_message_phases=completed_message_phases,
       )
-      result: RunnerResult = {
+      result: RunnerResult = with_usage({
         "session_id": current_session_id,
         "cost_usd": None,
         "error": error_text,
-      }
-      if final_token_usage is not None:
-        result["usage"] = _model_dump(final_token_usage)
-        result["usage_metrics"] = normalize_codex_usage(
-          first_token_usage, final_token_usage,
-        )
+      })
       if terminal_status is not None:
         result["terminal_status"] = terminal_status
       if final_message_phase is not None:
         result["final_message_phase"] = final_message_phase
       return result
   except Exception as exc:
-    return {
+    if _is_transport_death(exc) and stop_requested():
+      # Our own teardown, seen from the inside. A stop interrupts the turn;
+      # when that times out the escalation SIGTERMs the turn's private
+      # process group, so the transport dies mid-stream instead of
+      # delivering turn/completed. Surfacing that as a provider failure is
+      # both wrong and destructive: the raw string overwrites the stall note
+      # (chat._pause_note) published moments earlier, because error blocks
+      # coalesce latest-wins and drop every events.ERROR_PASSTHROUGH_FIELDS
+      # the new event omits — taking the note's one-tap Resume with it and
+      # leaving the owner an unexplained error and no way back.
+      #
+      # Expected, so INFO — but the transport's dying words are the only
+      # forensics a kill leaves behind, and nothing downstream logs them
+      # once `error` is None.
+      log.info(
+        "Codex transport closed by our own stop chat_id=%s: %s", chat_id, exc,
+      )
+      return with_usage({
+        "session_id": current_session_id,
+        "cost_usd": None,
+        "error": None,
+        "terminal_status": _enum_wire_value(sdk["TurnStatus"].interrupted),
+      })
+    return with_usage({
       "session_id": current_session_id,
       "cost_usd": None,
       "error": str(exc),
-    }
+    })
   finally:
     deferred_cancel: asyncio.CancelledError | None = None
     if process_group_capture_stop is not None:

--- a/backend/tests/test_codex_sdk_contract.py
+++ b/backend/tests/test_codex_sdk_contract.py
@@ -239,3 +239,21 @@ def test_reasoning_effort_enum_tolerates_unknown_efforts():
 
   for value in ("high", "xhigh", "max", "ultra", "some-future-effort"):
     assert ReasoningEffort(value).value == value
+
+
+def test_transport_closed_error_is_still_exposed_by_the_sdk():
+  """_is_transport_death decides whether an error reaches the owner at all.
+
+  It binds to this class by isinstance, and a stop that SIGTERMs the turn's
+  process group is reclassified as a clean interrupt only when the raised
+  exception is one. If a future SDK renames or drops the symbol, the runner
+  would stop recognizing its own teardown and go back to publishing a raw
+  provider error over the pause note — so fail here first.
+  """
+  pytest.importorskip("openai_codex")
+  from openai_codex.errors import CodexError, TransportClosedError
+
+  assert issubclass(TransportClosedError, CodexError)
+  # Not a RuntimeError: the runner relies on that to keep provider
+  # ErrorNotifications (reraised as plain RuntimeErrors) out of this branch.
+  assert not issubclass(TransportClosedError, RuntimeError)

--- a/backend/tests/test_codex_sdk_runner.py
+++ b/backend/tests/test_codex_sdk_runner.py
@@ -17,6 +17,18 @@ from app.runner_registry import RunnerKind, registry
 # - CodexRpcError: /usr/local/lib/python3.12/site-packages/openai_codex/errors.py:24
 # - InvalidParamsError: /usr/local/lib/python3.12/site-packages/openai_codex/errors.py:40
 
+try:
+  from openai_codex.errors import (
+    TransportClosedError as _SdkTransportClosedError,
+  )
+except ImportError:  # pragma: no cover - SDK is an optional install
+  # openai-codex is installed in its own Docker step, not via
+  # requirements.txt, so this module must still import without it. The real
+  # symbol's continued existence is pinned by test_codex_sdk_contract, which
+  # is where its disappearance should be reported.
+  class _SdkTransportClosedError(Exception):
+    pass
+
 
 class _FakeBroadcast:
   def __init__(self):
@@ -177,6 +189,7 @@ def _fake_sdk(async_codex_cls):
     "ReasoningSummaryTextDeltaNotification": _Dummy,
     "ReasoningTextDeltaNotification": _Dummy,
     "ThreadTokenUsageUpdatedNotification": _Dummy,
+    "TransportClosedError": _SdkTransportClosedError,
     "TurnCompletedNotification": _FakeTurnCompletedNotification,
     "TurnStatus": _FakeTurnStatus,
     "WebSearchThreadItem": _Dummy,
@@ -566,6 +579,50 @@ def test_is_closed_turn_error_matches_sdk_rpc_errors(monkeypatch):
 
 def test_is_closed_turn_error_does_not_treat_arbitrary_oserror_as_closed():
   assert codex_sdk_runner._is_closed_turn_error(OSError("disk full")) is False
+
+
+def test_is_transport_death_rejects_provider_runtime_error_about_not_running(
+  monkeypatch,
+):
+  """The narrow predicate is the whole reason the two exist separately.
+
+  The runner reraises every non-retryable provider ErrorNotification as a
+  plain `RuntimeError(message)`, and those messages routinely say "is not
+  running". _is_closed_turn_error accepts that text because the only cost
+  of a false positive there is a refused steer; the except-path
+  reclassification must not, or a stop racing a genuine MCP failure would
+  swallow the only report the owner ever gets. Widening the guard back to
+  _is_closed_turn_error fails here.
+  """
+  sdk = _fake_sdk(async_codex_cls=object)
+  monkeypatch.setattr(codex_sdk_runner, "_sdk_imports", lambda: sdk)
+
+  provider_fault = RuntimeError("MCP server 'x' is not running")
+
+  assert codex_sdk_runner._is_transport_death(provider_fault) is False
+  assert codex_sdk_runner._is_closed_turn_error(provider_fault) is True
+
+
+def test_is_transport_death_binds_to_the_sdk_class_not_to_its_name():
+  """Uses the installed SDK, because the binding is what is under test.
+
+  isinstance against the symbol `_sdk_imports()` exposes means a genuine
+  subclass matches and a same-named impostor does not — neither of which a
+  class-name comparison could get right.
+  """
+  pytest.importorskip("openai_codex")
+
+  class _MoreSpecificTransportError(_SdkTransportClosedError):
+    pass
+
+  impostor = type("TransportClosedError", (Exception,), {})
+
+  assert codex_sdk_runner._is_transport_death(
+    _MoreSpecificTransportError("closed stdout")
+  ) is True
+  assert codex_sdk_runner._is_transport_death(
+    impostor("closed stdout")
+  ) is False
 
 
 def test_run_codex_sdk_turn_resume_mismatch_returns_error(monkeypatch):
@@ -1286,6 +1343,243 @@ def test_run_codex_sdk_turn_cleans_up_active_session_on_stream_exception(
   assert result["error"] == "stream blew up"
   assert registry.get_handle("chat-1", RunnerKind.CODEX_SDK) is None
   assert mark_finished_calls == [True]
+
+
+class _KilledTransportError(_SdkTransportClosedError):
+  """A subclass of the SDK's own TransportClosedError.
+
+  Subclassing the real symbol rather than redeclaring its name is the point:
+  the runner reclassifies on isinstance, so a look-alike would prove nothing
+  and a genuine subclass would not match a name check. It is also not a
+  RuntimeError, which keeps the narrow transport branch distinguishable from
+  the looser bare-RuntimeError-text branch that belongs to
+  _is_closed_turn_error alone.
+  """
+
+
+def _run_turn_whose_stream_dies(
+  monkeypatch,
+  exc: Exception,
+  *,
+  on_register=None,
+  should_abort=None,
+  notifications=None,
+  sdk_patch=None,
+):
+  """Runs one turn whose stream raises `exc`, optionally mid-teardown.
+
+  `on_register` fires against the handle the runner has just registered —
+  the same window in which the real Stop / stall watchdog reaches a live
+  turn — so a test can mark the teardown as ours before the stream dies.
+  `notifications` are delivered before the death, so a test can give the
+  turn something to have spent; `sdk_patch` supplies the payload classes
+  those notifications need to be recognized as.
+  """
+  turn_handle = _FakeTurnHandle(notifications, stream_exc=exc)
+  thread = _FakeThread("thread-1", turn_handle)
+
+  class FakeAsyncCodex:
+    def __init__(self, config=None):
+      self.config = config
+
+    async def __aenter__(self):
+      return self
+
+    async def __aexit__(self, _exc_type, _exc, _tb):
+      return None
+
+    async def thread_start(self, *_args, **_kwargs):
+      return thread
+
+  sdk = _fake_sdk(FakeAsyncCodex)
+  sdk.update(sdk_patch or {})
+  monkeypatch.setattr(codex_sdk_runner, "_sdk_imports", lambda: sdk)
+
+  if on_register is not None:
+    original_register = registry.register
+
+    def _register(handle):
+      on_register(handle)
+      return original_register(handle)
+
+    monkeypatch.setattr(registry, "register", _register)
+
+  bc = _FakeBroadcast()
+  result = asyncio.run(
+    codex_sdk_runner.run_codex_sdk_turn(
+      user_message="hello",
+      session_id=None,
+      base_env={},
+      cwd="/tmp",
+      chat_id="chat-1",
+      bc=bc,
+      pending_questions={},
+      db=None,
+      **({"should_abort": should_abort} if should_abort else {}),
+    )
+  )
+  return result, bc
+
+
+def _mark_interrupted(handle):
+  handle._interrupt_requested = True
+
+
+def test_run_codex_sdk_turn_reports_self_requested_kill_as_interrupted(
+  monkeypatch,
+):
+  """A stop we asked for must not read as a provider failure.
+
+  Stop and the stall watchdog both interrupt first and then, on timeout,
+  SIGTERM the turn's private process group — so the transport dies
+  mid-stream instead of delivering turn/completed. Reporting the resulting
+  "closed stdout" as an error is wrong twice over: it blames Codex for our
+  own teardown, and the error block overwrites the stop/stall note in the
+  transcript and strips its one-tap Resume.
+  """
+  result, bc = _run_turn_whose_stream_dies(
+    monkeypatch,
+    _KilledTransportError("Codex process closed stdout. stderr_tail="),
+    on_register=_mark_interrupted,
+  )
+
+  assert result["error"] is None
+  assert result["terminal_status"] == "interrupted"
+  assert [e for e in bc.events if e.get("type") == "error"] == []
+  assert registry.get_handle("chat-1", RunnerKind.CODEX_SDK) is None
+
+
+def test_run_codex_sdk_turn_unrequested_transport_death_stays_an_error(
+  monkeypatch,
+):
+  """The same transport death with no stop pending is still a real failure.
+
+  Only a teardown we asked for may be reclassified, so a provider-side
+  crash keeps its error.
+  """
+  result, _bc = _run_turn_whose_stream_dies(
+    monkeypatch,
+    _KilledTransportError("Codex process closed stdout. stderr_tail="),
+  )
+
+  assert result["error"] == "Codex process closed stdout. stderr_tail="
+  assert result.get("terminal_status") is None
+  assert registry.get_handle("chat-1", RunnerKind.CODEX_SDK) is None
+
+
+def test_run_codex_sdk_turn_non_transport_failure_during_stop_stays_an_error(
+  monkeypatch,
+):
+  """A pending stop must not launder an unrelated bug into a clean stop.
+
+  Without this, any defect that happens to fire inside a stop window
+  returns "interrupted" with no error and no log line — invisible in both
+  the transcript and chat.log.
+  """
+  result, _bc = _run_turn_whose_stream_dies(
+    monkeypatch,
+    ValueError("unexpected notification payload"),
+    on_register=_mark_interrupted,
+  )
+
+  assert result["error"] == "unexpected notification payload"
+  assert result.get("terminal_status") is None
+
+
+def test_run_codex_sdk_turn_provider_fault_during_stop_keeps_its_error(
+  monkeypatch,
+):
+  """A provider fault that merely looks closed-ish must still be reported.
+
+  Non-retryable provider errors reach this except path as plain
+  RuntimeErrors carrying the app-server's own words, and "is not running"
+  is ordinary phrasing for a broken MCP server. Only the transport itself
+  dying may be reclassified: if the guard is widened to
+  _is_closed_turn_error, a stop in flight turns a real failure into a
+  silent clean interrupt.
+  """
+  result, _bc = _run_turn_whose_stream_dies(
+    monkeypatch,
+    RuntimeError("MCP server 'x' is not running"),
+    on_register=_mark_interrupted,
+  )
+
+  assert result["error"] == "MCP server 'x' is not running"
+  assert result.get("terminal_status") is None
+
+
+def test_run_codex_sdk_turn_failed_turn_still_reports_what_it_spent(
+  monkeypatch,
+):
+  """Tokens burned before a crash are still tokens burned.
+
+  Every other exit routes its usage through with_usage; the raw error exit
+  used to drop it, so a turn that streamed for minutes and then died looked
+  free in the budget ledger.
+  """
+  class TokenUsageUpdated:
+    def __init__(self, token_usage):
+      self.token_usage = token_usage
+
+  class Usage:
+    def __init__(self, total_tokens):
+      self.last = SimpleNamespace(
+        input_tokens=200, cached_input_tokens=100, output_tokens=100,
+        reasoning_output_tokens=50, total_tokens=300,
+      )
+      self.total = SimpleNamespace(
+        input_tokens=1_000, cached_input_tokens=400, output_tokens=100,
+        reasoning_output_tokens=50, total_tokens=total_tokens,
+      )
+      self.model_context_window = 200_000
+
+    def model_dump(self, **_kwargs):
+      return {
+        "last": vars(self.last),
+        "total": vars(self.total),
+        "modelContextWindow": self.model_context_window,
+      }
+
+  result, _bc = _run_turn_whose_stream_dies(
+    monkeypatch,
+    ValueError("unexpected notification payload"),
+    notifications=[
+      SimpleNamespace(
+        method="thread/tokenUsage/updated",
+        payload=TokenUsageUpdated(Usage(1_100)),
+      ),
+    ],
+    sdk_patch={"ThreadTokenUsageUpdatedNotification": TokenUsageUpdated},
+  )
+
+  assert result["error"] == "unexpected notification payload"
+  assert result["usage"]["total"]["total_tokens"] == 1_100
+  # One update means no thread delta to compute, so the exact numbers are
+  # normalize_codex_usage's business; what this test owns is that the error
+  # exit carries the metrics at all.
+  assert "usage_metrics" in result
+
+
+def test_run_codex_sdk_turn_superseded_generation_kill_is_interrupted(
+  monkeypatch,
+):
+  """A newer turn taking over the chat is also Möbius ending this one.
+
+  This leg needs no ActiveCodexTurn at all, so it is the one that reaches
+  a teardown during startup — pinned here so a later narrowing of
+  stop_requested() to the interrupt flag alone goes red.
+  """
+  superseded = {"value": False}
+
+  result, _bc = _run_turn_whose_stream_dies(
+    monkeypatch,
+    _KilledTransportError("Codex process closed stdout. stderr_tail="),
+    on_register=lambda _handle: superseded.update(value=True),
+    should_abort=lambda: superseded["value"],
+  )
+
+  assert result["error"] is None
+  assert result["terminal_status"] == "interrupted"
 
 
 def test_run_codex_sdk_turn_error_notification_will_retry_continues(monkeypatch):

--- a/backend/tests/test_codex_sdk_runner.py
+++ b/backend/tests/test_codex_sdk_runner.py
@@ -1449,6 +1449,58 @@ def test_run_codex_sdk_turn_reports_self_requested_kill_as_interrupted(
   assert registry.get_handle("chat-1", RunnerKind.CODEX_SDK) is None
 
 
+def test_run_codex_sdk_turn_self_requested_kill_still_reports_usage(
+  monkeypatch,
+):
+  """A stop we asked for is a clean interrupt, but the tokens still count.
+
+  Usage delivered before the self-kill must survive the transport-death
+  reclassification: the interrupted (error=None) exit routes through
+  with_usage just like every other exit, so a stopped turn is not free in
+  the budget ledger.
+  """
+  class TokenUsageUpdated:
+    def __init__(self, token_usage):
+      self.token_usage = token_usage
+
+  class Usage:
+    def __init__(self, total_tokens):
+      self.last = SimpleNamespace(
+        input_tokens=200, cached_input_tokens=100, output_tokens=100,
+        reasoning_output_tokens=50, total_tokens=300,
+      )
+      self.total = SimpleNamespace(
+        input_tokens=1_000, cached_input_tokens=400, output_tokens=100,
+        reasoning_output_tokens=50, total_tokens=total_tokens,
+      )
+      self.model_context_window = 200_000
+
+    def model_dump(self, **_kwargs):
+      return {
+        "last": vars(self.last),
+        "total": vars(self.total),
+        "modelContextWindow": self.model_context_window,
+      }
+
+  result, _bc = _run_turn_whose_stream_dies(
+    monkeypatch,
+    _KilledTransportError("Codex process closed stdout. stderr_tail="),
+    on_register=_mark_interrupted,
+    notifications=[
+      SimpleNamespace(
+        method="thread/tokenUsage/updated",
+        payload=TokenUsageUpdated(Usage(1_100)),
+      ),
+    ],
+    sdk_patch={"ThreadTokenUsageUpdatedNotification": TokenUsageUpdated},
+  )
+
+  assert result["error"] is None
+  assert result["terminal_status"] == "interrupted"
+  assert result["usage"]["total"]["total_tokens"] == 1_100
+  assert "usage_metrics" in result
+
+
 def test_run_codex_sdk_turn_unrequested_transport_death_stays_an_error(
   monkeypatch,
 ):

--- a/backend/tests/test_codex_sdk_runner.py
+++ b/backend/tests/test_codex_sdk_runner.py
@@ -1426,7 +1426,7 @@ def _mark_interrupted(handle):
 
 
 def test_run_codex_sdk_turn_reports_self_requested_kill_as_interrupted(
-  monkeypatch,
+  monkeypatch, caplog,
 ):
   """A stop we asked for must not read as a provider failure.
 
@@ -1447,6 +1447,12 @@ def test_run_codex_sdk_turn_reports_self_requested_kill_as_interrupted(
   assert result["terminal_status"] == "interrupted"
   assert [e for e in bc.events if e.get("type") == "error"] == []
   assert registry.get_handle("chat-1", RunnerKind.CODEX_SDK) is None
+  assert any(
+    record.levelname == "WARNING"
+    and "Codex transport closed by our own stop" in record.message
+    and "closed stdout" in record.message
+    for record in caplog.records
+  )
 
 
 def test_run_codex_sdk_turn_self_requested_kill_still_reports_usage(

--- a/backend/tests/test_runner_registry_integration.py
+++ b/backend/tests/test_runner_registry_integration.py
@@ -152,6 +152,7 @@ def test_codex_runner_registers_then_unregisters_handle(monkeypatch):
     "AsyncCodex": FakeAsyncCodex,
     "CodexConfig": lambda **kwargs: SimpleNamespace(**kwargs),
     "CodexRpcError": RuntimeError,
+    "TransportClosedError": type("TransportClosedError", (Exception,), {}),
     "CommandExecutionOutputDeltaNotification": type(
       "CommandExecutionOutputDeltaNotification", (), {}
     ),


### PR DESCRIPTION
## Problem

When a turn is stopped — the owner pressing Stop, the stall watchdog, or a newer turn superseding this one — Möbius interrupts the turn and, if that interrupt times out, escalates to SIGTERM against the turn's private process group. The Codex transport then dies mid-stream instead of delivering `turn/completed`, and the runner's generic `except` path reported that death as a provider error string (e.g. `"Codex process closed stdout. stderr_tail="`).

That string is not merely wrong attribution — it is destructive. `chat.py` publishes a non-null `error` as an error block, and `events.process_event` coalesces error blocks latest-wins: the newer block pops every `ERROR_PASSTHROUGH_FIELDS` key it does not itself carry. The stop/stall pause note published moments earlier is an error block too, so it is overwritten and its one-tap Resume disappears. The owner is left with an unexplained provider error and no way back into the conversation.

## Cause

`run_codex_sdk_turn`'s `except Exception` path had no way to tell "the provider broke" from "we killed this turn ourselves". Both arrive as an exception out of the stream, and both were returned as `{"error": str(exc)}`.

Telling them apart needs two facts the runner already had but never combined:

- whether the exception is the *transport* dying, as opposed to a provider fault — the runner reraises every non-retryable provider `ErrorNotification` as a plain `RuntimeError(message)`, and those messages routinely contain closed-ish phrasing such as `"MCP server 'x' is not running"`;
- whether a stop was in flight — either `active_turn.interrupt_requested`, or the superseded-generation abort, which can be true before an `ActiveCodexTurn` exists at all.

The existing `_is_closed_turn_error` is deliberately loose about the first: it accepts bare `RuntimeError` text because its only caller is the steer path, where a false positive costs a refused steer. It is far too loose to decide whether an error reaches the owner.

## Fix

`backend/app/codex_sdk_runner.py`

- Split `_is_transport_death()` out of `_is_closed_turn_error()`. The new predicate matches only the SDK's own `TransportClosedError` (by `isinstance` against the real symbol from `_sdk_imports()`, so genuine subclasses match and same-named impostors do not) or an RPC error about a closed/dead channel. `_is_closed_turn_error` stays wide and keeps its steer-path caller.
- Add `stop_requested()` — one definition of "we did this to ourselves", shared by the terminal-validation path (which sees a clean `TurnStatus.interrupted`) and the except path (which sees the transport die because `force_stop` killed the process group). It includes the superseded-generation abort, which can be true before `active_turn` exists: a teardown during startup is no more the provider's fault than one mid-stream.
- Add `with_usage()` and route the error returns through it, so a turn that spent tokens and then ended reports them however it ended.
- In the except path, a transport death *while a stop is in flight* returns a clean `interrupted` terminal status with `error: None` instead of a raw provider string. Logged at WARNING: the owner still receives a clean interrupted outcome, while a coincident real transport crash remains visible to operators because the transport's dying words are the only forensics left after `error` is intentionally cleared downstream.
- `_sdk_imports()` now exposes `TransportClosedError`, and the guard around it catches `ImportError` rather than `ModuleNotFoundError`: an SDK that renames or drops the symbol fails the `from … import` the same way a missing package does, and this predicate runs *inside* the turn's except handler — raising there would mask the very exception it was asked to classify.

## Verification

The containerised runner was unavailable here, so pytest ran directly with an isolated tmp `DATA_DIR`/SQLite DB as `conftest.py` provisions.

- `test_codex_sdk_runner.py` + `test_codex_sdk_contract.py` + `test_runner_registry.py` + `test_runner_registry_integration.py` → **112 passed**
- the focused runner suite, including the warning-level forensic assertion, passed with **96 tests** in the final review
- `test_chat*.py` → **318 passed**
- `test_events.py` + `test_runner_registry.py` → **90 passed**

Every new test is mutation-verified — each mutation applied, suite re-run, then reverted:

| Mutation | Result |
| --- | --- |
| Except-path guard widened to `_is_closed_turn_error` | 1 fail (provider fault during stop loses its error) |
| `isinstance` replaced by class-name comparison | 3 fail |
| `with_usage` dropped from the sibling error return | 1 fail |
| `and stop_requested()` dropped | 1 fail (unrequested transport death must stay an error) |
| `stop_requested()` narrowed to the interrupt flag only | 1 fail (superseded-generation kill) |
| Transport check dropped entirely | 2 fail |

A new contract test pins that the SDK still exposes `TransportClosedError`, so a future SDK that renames it fails loudly rather than silently degrading.

### Residual notes

- The SDK is an optional install, so the runner tests keep a local stand-in class for environments without it; there the `isinstance` binding is exercised against a real subclass of the stand-in. The contract test (skipped without the SDK) is what pins the real symbol.
- Reclassification still turns on `stop_requested()`, so any future exception that is genuinely a transport death but is neither a `TransportClosedError` subclass nor a closed/not-running/broken-pipe RPC error keeps being reported as a provider error — the safe direction.
- The Claude runner has the same shape of bug and is untouched here; it deserves its own change.

