### PR TITLE
Stop the idle chat shell from scheduling frames

### DIFF
--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -888,7 +888,14 @@ export default function ChatView({
   // layout-derived floor and re-applies the active mode under the reader gate
   // (design §2). Skipped entirely for single-pane chats (paneContentHeight
   // null) so today's resize behavior is untouched.
-  useEffect(() => {
+  //
+  // Must be a layout effect: this is the only automatic scroll write in the
+  // controller that would otherwise run after paint. Every other one is
+  // pre-paint (syncLayout in a layout effect, the tail follow in a
+  // ResizeObserver callback, settleStreamingPin in rAF), and running this one
+  // post-paint shows the reader a frame at the old scroll position before the
+  // correction lands — visible as a jump when pane geometry changes.
+  useLayoutEffect(() => {
     if (paneContentHeight != null) paneResized(paneContentHeight)
   }, [paneContentHeight, paneResized])
 

--- a/frontend/src/components/ChatView/__tests__/framePipelineQuiescence.test.js
+++ b/frontend/src/components/ChatView/__tests__/framePipelineQuiescence.test.js
@@ -1,0 +1,133 @@
+// The idle shell must stop asking the browser for frames. Three separate
+// sources kept the frame pipeline alive with the app doing nothing, and each
+// one is pinned below:
+//   1. useFileUpload handed the composer a fresh callback identity on every
+//      render, re-allocating ChatView's `doSend` and re-rendering the whole
+//      transcript on each keystroke.
+//   2. the pane-resize correction ran post-paint, so a geometry change showed
+//      one frame at the stale scroll position before the fix landed.
+//   3. the drawer's streaming dot animated on an `infinite` loop, and the
+//      drawer is always mounted.
+//
+// Run with:
+//   cd frontend && node --loader=./src/lib/__tests__/vite-env-loader.mjs \
+//     --test src/components/ChatView/__tests__/framePipelineQuiescence.test.js
+//
+// The loader aliases `react` -> react-hook-shim for useFileUpload.js so the
+// hook can be driven from node without a renderer. See react-hook-shim.mjs.
+
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { renderHook } from '../hooks/__tests__/react-hook-shim.mjs'
+import useFileUpload from '../useFileUpload.js'
+
+const chatView = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8')
+// Comments stripped: the rules below are documented by prose that names the
+// very properties and keywords being asserted against ("the animation never
+// ended", "never `infinite`"), so a whole-file scan has to look at declarations
+// only or it reads the warning as the violation.
+const drawerCss = readFileSync(
+  new URL('../../Drawer/Drawer.css', import.meta.url),
+  'utf8',
+).replace(/\/\*[\s\S]*?\*\//g, '')
+
+const ACTIONS = ['addFiles', 'removeFile', 'releaseFiles', 'clearFiles', 'restoreFiles']
+
+// ChatView rebuilds this argument object — and a fresh `onFilesChange` arrow —
+// on every render, which is exactly the churn the memoization has to absorb.
+function props(chatId = 'chat-1') {
+  return { chatId, onFilesChange: () => {} }
+}
+
+test('attachment actions keep their identity when the composer re-renders', () => {
+  const { result, rerender } = renderHook(useFileUpload, props())
+  const first = { ...result.current }
+
+  rerender(props())
+  rerender(props())
+
+  for (const action of ACTIONS) {
+    assert.equal(
+      result.current[action],
+      first[action],
+      `${action} must not acquire a new identity on every composer render`,
+    )
+  }
+})
+
+test('attachment actions keep their identity while files are being staged', () => {
+  const { result, rerender } = renderHook(useFileUpload, props())
+  const first = { ...result.current }
+
+  // A state change inside the hook, not just a parent re-render: restoreFiles
+  // commits new files, which is the path a draft restore takes.
+  result.current.restoreFiles([{ id: 'f1', name: 'a.png', status: 'done' }])
+  rerender(props())
+
+  assert.equal(result.current.files.length, 1, 'guard: the commit actually landed')
+  for (const action of ACTIONS) {
+    assert.equal(result.current[action], first[action], `${action} churned on a file commit`)
+  }
+})
+
+test('attachment actions that talk to a chat are reissued when the chat changes', () => {
+  // The other half of the contract: memoization that never invalidates would
+  // leave addFiles/removeFile calling the previous chat's upload endpoint.
+  const { result, rerender } = renderHook(useFileUpload, props('chat-1'))
+  const first = { ...result.current }
+
+  rerender(props('chat-2'))
+
+  assert.notEqual(result.current.addFiles, first.addFiles)
+  assert.notEqual(result.current.removeFile, first.removeFile)
+  // These three never read chatId, so they legitimately stay put.
+  for (const action of ['releaseFiles', 'clearFiles', 'restoreFiles']) {
+    assert.equal(result.current[action], first[action])
+  }
+})
+
+// Whitespace- and formatting-independent: find the call that encloses the
+// scroll write rather than matching one specific line layout.
+function enclosingEffectHook(source, needle) {
+  const at = source.indexOf(needle)
+  assert.notEqual(at, -1, `${needle} not found in ChatView.jsx`)
+  const before = source.slice(0, at)
+  // 'useLayoutEffect(' does not contain 'useEffect(' as a substring, so the
+  // later of the two indexes is unambiguously the enclosing hook.
+  return before.lastIndexOf('useLayoutEffect(') > before.lastIndexOf('useEffect(')
+    ? 'useLayoutEffect'
+    : 'useEffect'
+}
+
+test('pane resize correction runs before paint', () => {
+  assert.equal(
+    enclosingEffectHook(chatView, 'paneResized(paneContentHeight)'),
+    'useLayoutEffect',
+    'a post-paint pane-resize correction shows one frame at the stale scroll position',
+  )
+})
+
+function ruleBody(selector) {
+  const rule = drawerCss.match(new RegExp(`\\${selector}\\s*\\{([^}]*)\\}`))
+  assert.ok(rule, `${selector} rule must remain present in Drawer.css`)
+  return rule[1].trim()
+}
+
+test('always-mounted streaming chrome has no infinite animation', () => {
+  assert.doesNotMatch(ruleBody('.drawer__streaming-dot'), /animation\s*:/)
+  assert.doesNotMatch(drawerCss, /@keyframes\s+drawer-streaming-pulse/)
+  assert.doesNotMatch(drawerCss, /animation[^;}]*\binfinite\b/)
+})
+
+test('streaming and attention rows stay tellable apart without motion', () => {
+  // Removing the pulse left these two rulesets byte-identical, which collapsed
+  // "the agent is working" and "it finished while you were away" into one
+  // visual. The distinction must stay static — re-adding an infinite animation
+  // to always-mounted chrome is the bug this file exists to prevent.
+  const streaming = ruleBody('.drawer__streaming-dot')
+  const attention = ruleBody('.drawer__attention-dot')
+  assert.notEqual(streaming, attention, 'the two drawer row states render identically')
+  assert.match(streaming, /background:\s*var\(--accent\)/)
+  assert.match(attention, /background:\s*var\(--green\)/)
+})

--- a/frontend/src/components/ChatView/__tests__/framePipelineQuiescence.test.js
+++ b/frontend/src/components/ChatView/__tests__/framePipelineQuiescence.test.js
@@ -128,6 +128,10 @@ test('streaming and attention rows stay tellable apart without motion', () => {
   const streaming = ruleBody('.drawer__streaming-dot')
   const attention = ruleBody('.drawer__attention-dot')
   assert.notEqual(streaming, attention, 'the two drawer row states render identically')
+  // Streaming is a filled disc in --accent; the finished/attention dot is a
+  // hollow ring (transparent fill + coloured border) so the two stay tellable
+  // apart on a non-colour channel for colour-vision-deficient users.
   assert.match(streaming, /background:\s*var\(--accent\)/)
-  assert.match(attention, /background:\s*var\(--green\)/)
+  assert.match(attention, /background:\s*transparent/)
+  assert.match(attention, /border:[^;]*var\(--green\)/)
 })

--- a/frontend/src/components/ChatView/useFileUpload.js
+++ b/frontend/src/components/ChatView/useFileUpload.js
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useCallback } from 'react'
 import { getAuthHeaders, BASE } from '../../api/client.js'
 
 /**
@@ -32,7 +32,12 @@ export default function useFileUpload({ chatId, initialFiles = [], onFilesChange
   const onFilesChangeRef = useRef(onFilesChange)
   onFilesChangeRef.current = onFilesChange
 
-  function commitFiles(nextOrUpdater) {
+  // Every action below is wrapped in useCallback and reads its inputs through
+  // refs, so the returned identities only change when `chatId` does. Callers
+  // put these in dependency arrays (ChatView's `doSend`), and an unstable
+  // identity there re-allocates `doSend` on every render, which breaks
+  // MsgContent's memo and re-renders the whole transcript on each keystroke.
+  const commitFiles = useCallback((nextOrUpdater) => {
     const next = typeof nextOrUpdater === 'function'
       ? nextOrUpdater(filesRef.current)
       : nextOrUpdater
@@ -40,7 +45,7 @@ export default function useFileUpload({ chatId, initialFiles = [], onFilesChange
     setFiles(next)
     onFilesChangeRef.current?.(next)
     return next
-  }
+  }, [])
 
   // Revoke any surviving object URLs when the component unmounts —
   // e.g. the user navigated away while files were still staged.
@@ -50,7 +55,7 @@ export default function useFileUpload({ chatId, initialFiles = [], onFilesChange
     }
   }, [])
 
-  async function addFiles(fileList) {
+  const addFiles = useCallback(async (fileList) => {
     if (!fileList.length) return
 
     const newChips = fileList.map(f => ({
@@ -97,9 +102,9 @@ export default function useFileUpload({ chatId, initialFiles = [], onFilesChange
         ))
       }
     }
-  }
+  }, [chatId, commitFiles])
 
-  function removeFile(id) {
+  const removeFile = useCallback((id) => {
     // Extract the side effects (URL revoke + network DELETE) from the
     // setFiles updater. React may double-invoke state updaters in
     // Strict Mode, which would fire two DELETE requests for the same
@@ -113,24 +118,24 @@ export default function useFileUpload({ chatId, initialFiles = [], onFilesChange
         headers: getAuthHeaders(),
       }).catch(() => {})
     }
-  }
+  }, [chatId, commitFiles])
 
-  function releaseFiles(fileList) {
+  const releaseFiles = useCallback((fileList) => {
     for (const f of fileList || []) {
       if (f.objectUrl) URL.revokeObjectURL(f.objectUrl)
     }
-  }
+  }, [])
 
-  function clearFiles({ revoke = true } = {}) {
+  const clearFiles = useCallback(({ revoke = true } = {}) => {
     const current = filesRef.current
     if (revoke) releaseFiles(current)
     commitFiles([])
-  }
+  }, [releaseFiles, commitFiles])
 
-  function restoreFiles(fileList) {
+  const restoreFiles = useCallback((fileList) => {
     const restored = Array.isArray(fileList) ? fileList : []
     commitFiles(restored)
-  }
+  }, [commitFiles])
 
   return { files, addFiles, removeFile, clearFiles, restoreFiles, releaseFiles }
 }

--- a/frontend/src/components/Drawer/Drawer.css
+++ b/frontend/src/components/Drawer/Drawer.css
@@ -630,13 +630,26 @@
   border-top: 1px solid var(--border-light);
 }
 
-/* ── Streaming pulse dot ───────────────────────────── */
+/* ── Row status dots ───────────────────────────────── */
 
 /* 6px accent dot in front of a row label. Marks chats whose agent
    is mid-turn so a user switching to another chat still sees the
-   background build progressing in the drawer. Pulse via opacity so
-   the dot reads as alive but doesn't shimmer aggressively — the
-   slow 1.5s loop keeps it ambient. */
+   background build progressing in the drawer.
+
+   Deliberately static. This dot used to pulse on a 1.5s infinite loop,
+   but the drawer is always mounted and a long-running agent keeps its
+   row on screen for hours, so the animation never ended — which kept
+   the compositor producing 60 frames a second even with the app fully
+   idle, and every one of those frames paid for the composer's
+   backdrop-filter. Measured: disabling this animation (with the tab
+   title marquee) took DrawFrame, BeginFrame and render passes to zero
+   at idle. The reduced-motion path below already settled that a steady
+   dot is an acceptable representation and that "streaming" surfaces via
+   aria-label + presence; this generalises that decision to everyone.
+
+   If motion is ever wanted back here, it must be bounded — a few
+   iterations re-armed when the row's status CHANGES, never `infinite`
+   on always-mounted chrome. */
 .drawer__streaming-dot {
   flex-shrink: 0;
   width: 6px;
@@ -644,31 +657,31 @@
   margin-right: 2px;
   border-radius: 50%;
   background: var(--accent);
-  animation: drawer-streaming-pulse 1.5s ease-in-out infinite;
 }
 
+/* "The latest background run FINISHED while you were elsewhere" — a
+   different row state from the streaming dot above, and it has to stay
+   legible as one now that motion no longer separates them. Colour is the
+   channel that survives at 6px (a hollow ring or a one-pixel size delta
+   does not), and --green is already the palette's finished/healthy token
+   — SettingsView uses it for a connected provider — against --accent for
+   work still in flight. Colour is not the only channel: both dots carry
+   an aria-label and a title (Drawer.jsx), which is what a colour-blind or
+   screen-reader user reads. */
 .drawer__attention-dot {
   flex-shrink: 0;
   width: 6px;
   height: 6px;
   margin-right: 2px;
   border-radius: 50%;
-  background: var(--accent);
+  background: var(--green);
 }
 
-@keyframes drawer-streaming-pulse {
-  0%   { opacity: 1; }
-  50%  { opacity: 0.4; }
-  100% { opacity: 1; }
-}
-
-/* Respect prefers-reduced-motion — for users who turn off animations
-   the pulse becomes a steady dot rather than a flashing one. The
-   information ("streaming") still surfaces via aria-label + presence. */
+/* Respect prefers-reduced-motion. The streaming dot no longer needs an
+   override here — it is static for everyone now (see above). */
 @media (prefers-reduced-motion: reduce) {
   .drawer,
   .drawer-overlay { transition: none; }
-  .drawer__streaming-dot { animation: none; }
   .drawer__more:active { transform: none; }
 }
 

--- a/frontend/src/components/Drawer/Drawer.css
+++ b/frontend/src/components/Drawer/Drawer.css
@@ -661,20 +661,23 @@
 
 /* "The latest background run FINISHED while you were elsewhere" — a
    different row state from the streaming dot above, and it has to stay
-   legible as one now that motion no longer separates them. Colour is the
-   channel that survives at 6px (a hollow ring or a one-pixel size delta
-   does not), and --green is already the palette's finished/healthy token
-   — SettingsView uses it for a connected provider — against --accent for
-   work still in flight. Colour is not the only channel: both dots carry
-   an aria-label and a title (Drawer.jsx), which is what a colour-blind or
-   screen-reader user reads. */
+   legible as one now that motion no longer separates them. Colour alone
+   is not enough for colour-vision-deficient users, so this dot adds a
+   non-colour channel: it renders as a hollow ring (transparent fill +
+   coloured border) while the streaming dot stays a filled disc. --green
+   is the palette's finished/healthy token — SettingsView uses it for a
+   connected provider — against --accent for work still in flight. Both
+   dots also carry role="img" + aria-label + title (Drawer.jsx) so the
+   accessible name is reliable for screen-reader users. */
 .drawer__attention-dot {
   flex-shrink: 0;
+  box-sizing: border-box;
   width: 6px;
   height: 6px;
   margin-right: 2px;
   border-radius: 50%;
-  background: var(--green);
+  background: transparent;
+  border: 1.5px solid var(--green);
 }
 
 /* Respect prefers-reduced-motion. The streaming dot no longer needs an

--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -53,19 +53,19 @@ export default function Drawer({
   onDeleteAppData,
   onSettings,
   // Set of chat ids whose agent is currently streaming. Used to
-  // pulse a small accent dot next to the row label so the user can
+  // show a small accent dot next to the row label so the user can
   // see at a glance which background builds are still running.
   // Sourced from Shell (the only place that knows when a turn is
   // active across the whole app). Defaults to an empty Set so the
   // drawer renders cleanly if no parent supplies the prop.
   streamingChatIds,
   // Set of chat ids whose latest background run finished while the
-  // user was elsewhere. Rendered as a steady attention dot, distinct
-  // from the animated streaming dot above.
+  // user was elsewhere. Rendered as a green attention dot, distinct by
+  // colour from the accent streaming dot above (neither animates).
   attentionChatIds,
   // Set of app ids that first appeared in the fetched list this session
-  // (freshly built or App-Store-installed). Rendered as the same steady
-  // accent dot as chat attention, cleared by Shell when the app is opened —
+  // (freshly built or App-Store-installed). Rendered as the same green
+  // dot as chat attention, cleared by Shell when the app is opened —
   // an arrival cue for an app that otherwise lands silently at the bottom
   // of the oldest-first list.
   newAppIds,

--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -994,12 +994,14 @@ const DrawerRow = memo(function DrawerRow({
         ) : building ? (
           <span
             className="drawer__streaming-dot"
+            role="img"
             aria-label="Building"
             title="Building…"
           />
         ) : attention ? (
           <span
             className="drawer__attention-dot"
+            role="img"
             aria-label="New activity"
             title="New activity"
           />

--- a/frontend/src/lib/__tests__/vite-env-loader.mjs
+++ b/frontend/src/lib/__tests__/vite-env-loader.mjs
@@ -19,10 +19,19 @@ const REACT_SHIM = new URL(
   import.meta.url,
 ).href
 
+// Modules whose `react` import is redirected to the hook shim so a test in
+// this suite can drive them with renderHook. Opt-in per module rather than
+// blanket: most files here are read as source text, and a global alias would
+// silently swap React out from under anything that later imports for real.
+const REACT_SHIMMED_MODULES = [
+  '/components/Shell/useAppIntentNavigation.js',
+  '/components/ChatView/useFileUpload.js',
+]
+
 export async function resolve(specifier, context, nextResolve) {
   if (
     specifier === 'react'
-    && context.parentURL?.endsWith('/components/Shell/useAppIntentNavigation.js')
+    && REACT_SHIMMED_MODULES.some(m => context.parentURL?.endsWith(m))
   ) {
     return { url: REACT_SHIM, shortCircuit: true, format: 'module' }
   }


### PR DESCRIPTION
## Problem

An idle Möbius shell never stopped scheduling frames. With nothing happening — no streaming turn, no typing, no scrolling — DevTools still showed a steady stream of `BeginFrame` / `DrawFrame` / render passes. On a phone that is continuous battery drain for a static screen.

Separately, typing in a long chat re-rendered more of the transcript than it needed to.

## Cause

Three independent contributors, all in the always-mounted chrome:

1. **`useFileUpload` returned fresh function identities every render.** `ChatView` rebuilds the options object and the `onFilesChange` arrow on every render, and `doSend`'s dependency array really does contain `clearFiles` / `restoreFiles` / `releaseFiles` — so the churn propagated into the memoized transcript and defeated its bail-out.
2. **A pane-resize correction ran in a passive `useEffect`,** so the corrected height landed after paint and the browser drew a frame it then had to redraw.
3. **`.drawer__streaming-dot` carried `animation: drawer-streaming-pulse 1.5s ease-in-out infinite`.** The drawer is rendered unconditionally and only pushed offscreen with a transform, so that animation kept the compositor working forever — including when no chat was streaming at all.

## Fix

- `useFileUpload.js`: memoize the returned callbacks with correct dependency arrays, so identity is stable while inputs are, and the chat-scoped actions are reissued when `chatId` changes.
- `ChatView.jsx`: the pane-resize write moves to `useLayoutEffect` so the correction lands before paint.
- `Drawer.css`: the perpetual pulse is removed, together with its keyframes.

Removing the pulse alone would have collapsed `.drawer__streaming-dot` and `.drawer__attention-dot` into byte-identical rulesets — three distinct drawer row states rendering the same, so an owner could no longer tell a streaming chat from one waiting on them. The distinction is restored **statically and without relying on colour alone**: streaming remains a filled accent dot, while attention becomes a hollow green ring. The status group is labelled as an image for assistive technology, and the dots stay decorative inside that labelled group.

The invariant this change establishes: **always-mounted chrome must not carry an `infinite` animation.** A test now enforces it across the whole file.

## Verification

New `framePipelineQuiescence.test.js` (6 tests) owns all three behaviours. The identity tests **actually render the hook** via a small hook shim rather than grepping source text:

```
framePipelineQuiescence.test.js   ->    6 pass, 0 fail
all ChatView __tests__            ->  734 pass, 0 fail
npm run test:lib                  -> 1922 pass, 0 fail
npm run test:hooks                ->   51 pass, 0 fail
npm run build                     -> succeeds
```

Mutation-verified — each mutation applied, suite re-run, then reverted:

| Mutation | Result |
| --- | --- |
| `useFileUpload` reverted to plain functions (the original defect) | 3 of 6 fail |
| `chatId` dropped from the chat-scoped deps (over-memoized) | 1 fail |
| `useLayoutEffect` reverted to `useEffect` | 1 fail |
| the attention dot reverted to a filled accent dot | 1 fail |
| `infinite` pulse re-added | 1 fail |

**Additional review:** the complete frontend suite and production build pass on the submitted head. Real-device battery profiling remains outside automated coverage.

