### PR TITLE
Approve a staged contribution from the chat that produced it

### DIFF
--- a/backend/app/routes/github.py
+++ b/backend/app/routes/github.py
@@ -45,6 +45,7 @@ import time
 from contextlib import AsyncExitStack, asynccontextmanager
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from typing import Literal
 from urllib.parse import quote, urljoin, urlparse
 
 import httpx
@@ -151,6 +152,13 @@ class ContributionSubmitBody(BaseModel):
   # Omitted/legacy request bodies stay on the classic manual path: the backend
   # lands before the UI that explains this authority and asks for it.
   autopilot: bool = False
+  # Where the owner pressed Send. Recorded on the claim purely as provenance, so
+  # the ledger says whether a PR was approved from the Contribute app or from the
+  # review card in its source chat. Constrained so the ledger cannot carry
+  # arbitrary caller-supplied text.
+  submitter: Literal["contribute-button", "chat-review-card"] = (
+    "contribute-button"
+  )
 
 
 class AutopilotRespondBody(BaseModel):
@@ -1008,7 +1016,8 @@ def _assert_fresh(
 
 
 def _claim_record(
-  *, app_id: int, record_id: str, db: Session, expected_nonce: str | None
+  *, app_id: int, record_id: str, db: Session, expected_nonce: str | None,
+  submitter: str = "contribute-button",
 ) -> tuple[dict, Path, Path]:
   record_path, diff_path = _record_paths(app_id, record_id)
   _recheck_submit_app(db, app_id, expected_nonce)
@@ -1041,7 +1050,7 @@ def _claim_record(
   claimed = {
     **record,
     "status": "submitting",
-    "submitter": "contribute-button",
+    "submitter": submitter,
     "submit_started_at": now,
     "updated_at": now,
   }
@@ -3493,6 +3502,137 @@ async def contribution_review_status(
   }
 
 
+# Paths touched by a stored diff, for the chat card's "what am I sending" list.
+# Deliberately a header scan rather than a real patch parser: the card only needs
+# names, and the app owns full diff rendering.
+def _diff_file_paths(diff_path: Path, limit: int = 40) -> list[str]:
+  paths: list[str] = []
+  try:
+    with diff_path.open("r", encoding="utf-8", errors="replace") as handle:
+      for line in handle:
+        if not line.startswith("+++ "):
+          continue
+        target = line[4:].strip()
+        if target == "/dev/null":
+          continue
+        if target.startswith("b/"):
+          target = target[2:]
+        if target and target not in paths:
+          paths.append(target)
+        if len(paths) >= limit:
+          break
+  except OSError:
+    return paths
+  return paths
+
+
+def _chat_review_projection(record: dict, app_id: int) -> dict:
+  """The small, display-only view of one ledger record for the chat card."""
+  plan = record.get("plan") if isinstance(record.get("plan"), dict) else {}
+  record_id = str(record.get("id") or "")
+  _, diff_path = _record_paths(app_id, record_id)
+  return {
+    "id": record_id,
+    "type": record.get("type"),
+    "status": record.get("status"),
+    "title": plan.get("title") or record.get("title"),
+    "summary": record.get("summary"),
+    "repo": plan.get("repo") or record.get("repo"),
+    "branch": plan.get("branch") or record.get("branch"),
+    "body_draft": plan.get("body_draft"),
+    "diff_stat": plan.get("diff_stat"),
+    "files": _diff_file_paths(diff_path),
+    "labels": plan.get("labels") if isinstance(plan.get("labels"), list) else [],
+    "url": record.get("url"),
+    "number": record.get("number"),
+    "last_submit_error": record.get("last_submit_error"),
+    "updated_at": record.get("updated_at"),
+    "is_stack": isinstance(plan.get("stack"), dict),
+  }
+
+
+@router.get("/contributions/{app_id}/for-chat/{chat_id}")
+@_limiter.limit("60/minute")
+async def contributions_for_chat(
+  request: Request,
+  app_id: int,
+  chat_id: str,
+  db: Session = Depends(get_db),
+  principal: Principal = Depends(get_principal),
+):
+  """Contribution records staged from ONE chat, for that chat's review card.
+
+  The chat card is a second view over the same ledger the Contribute app reads,
+  so the owner can approve a staged PR where the work happened instead of
+  navigating to the app. It is strictly read-only and stays a projection: Send
+  still goes through the submit endpoint below, which owns every freshness,
+  attribution, and fork check.
+
+  Filtering by chat first is what keeps this cheap. The local preflight below is
+  the same one the app's review cards use, but a single chat normally has zero or
+  one prepared record, so it runs on that bounded set rather than the whole
+  ledger.
+  """
+  _validate_submit_app(app_id, principal, db)
+  db.close()
+  contribution_dir = _contributions_dir(app_id)
+  async with fs_locks.app_storage_lock(app_id):
+    records = []
+    if contribution_dir.exists():
+      for path in sorted(contribution_dir.glob("*.json"))[:500]:
+        record = _read_record_tolerant(path)
+        if (
+          record is not None
+          and record.get("id")
+          and str(record.get("chat_id") or "") == chat_id
+          and record.get("type") == "pr"
+          and record.get("status") != "abandoned"
+        ):
+          records.append(record)
+    settings_path = (
+      Path(get_settings().data_dir) / "apps" / str(app_id) / "settings.json"
+    )
+    app_settings = _read_record_tolerant(settings_path) or {}
+
+  records.sort(key=lambda item: str(item.get("updated_at") or ""), reverse=True)
+  records = records[:5]
+
+  github_state = github_auth.read_state() or {}
+  projections = []
+  for record in records:
+    view = _chat_review_projection(record, app_id)
+    review = None
+    if record.get("status") == "prepared" and not view["is_stack"]:
+      plan = record.get("plan") if isinstance(record.get("plan"), dict) else {}
+      _, diff_path = _record_paths(app_id, str(record.get("id") or ""))
+      try:
+        repo = _safe_repo_path(plan.get("repo_path"))
+      except ContributionSubmitError as exc:
+        review = _review_status_problem(
+          str(record.get("id") or ""),
+          code=exc.code or "invalid_checkout",
+          detail=exc.message,
+        )
+      else:
+        async with fs_locks.source_dir_lock(str(repo)):
+          review = await asyncio.to_thread(
+            _inspect_prepared_review, record, diff_path, github_state,
+          )
+    view["review"] = review
+    projections.append(view)
+
+  autopilot_default = app_settings.get("autopilot_default")
+  return {
+    "generated_at": _now_iso(),
+    "connected": bool(github_state.get("token")),
+    "autopilot_available": True,
+    "autopilot_default": (
+      True if autopilot_default is None else bool(autopilot_default)
+    ),
+    "records": projections,
+  }
+
+
 @router.post(
   "/contributions/{app_id}/{record_id}/submit",
   dependencies=[Depends(reject_cross_site)],
@@ -3525,6 +3665,7 @@ async def submit_contribution(
       record_id=record_id,
       db=db,
       expected_nonce=expected_nonce,
+      submitter=body.submitter if body is not None else "contribute-button",
     )
   # The durable claim is complete. Git/fork/GitHub work below can take tens of
   # seconds; return the checkout now and let each short nonce recheck lazily
@@ -3972,8 +4113,9 @@ def _contributions_dir(app_id: int) -> Path:
 
 
 def _read_record_tolerant(path: Path) -> dict | None:
-  """Reads a contribution record, returning None (not raising) on a missing
-  or corrupt file so one bad record can't abort a whole refresh sweep."""
+  """Reads a small JSON object — a contribution record, or the app's settings
+  file — returning None (not raising) on a missing, oversized, or corrupt file so
+  one bad record can't abort a whole refresh sweep."""
   try:
     with path.open("rb") as handle:
       raw = handle.read(_MAX_CONTRIBUTION_RECORD_BYTES + 1)

--- a/backend/tests/test_github_routes.py
+++ b/backend/tests/test_github_routes.py
@@ -4336,3 +4336,175 @@ def test_refresh_skips_non_open_and_success_without_notifying(
   assert checks["state"] == "SUCCESS"
   assert "notified_sha" not in checks
   assert _all_notifications() == []
+
+
+# ── The chat review card's read endpoint ─────────────────────────────────────
+# The card lets the owner approve a staged PR in the chat where the work
+# happened instead of navigating to the Contribute app. It is a projection over
+# the same ledger, so these tests pin what it exposes, what it filters, and that
+# it stays scoped to ONE chat.
+
+def _prepared_for_chat(app_id, record_id, chat_id, **overrides):
+  repo, record, diff_text = _prepared_real_review(app_id, record_id)
+  record["chat_id"] = chat_id
+  record["summary"] = "A plain sentence about the improvement."
+  record["plan"]["title"] = "Reviewed fix"
+  record["plan"]["body_draft"] = "## Summary\n\nThe exact published text.\n"
+  record["plan"]["diff_stat"] = "1 file changed, 1 insertion(+), 1 deletion(-)"
+  record["plan"]["labels"] = ["bug", "area: ui"]
+  record.update(overrides)
+  _write_contribution(app_id, record_id, record, diff_text)
+  return repo, record
+
+
+def test_for_chat_returns_only_this_chat_s_prepared_reviews(client, owner_token):
+  _write_token(login="octocat", user_id=42)
+  app_id, _ = _app_token(client, owner_token, github_access=True)
+  _prepared_for_chat(app_id, "mine", "chat-a")
+  _prepared_for_chat(app_id, "someone-elses", "chat-b")
+  headers = {"Authorization": f"Bearer {owner_token}"}
+
+  r = client.get(
+    f"/api/github/contributions/{app_id}/for-chat/chat-a", headers=headers,
+  )
+  assert r.status_code == 200, r.text
+  body = r.json()
+  assert [item["id"] for item in body["records"]] == ["mine"]
+  record = body["records"][0]
+  # Everything the card needs to show what would be published, and nothing that
+  # would let it publish anything itself.
+  assert record["title"] == "Reviewed fix"
+  assert record["summary"] == "A plain sentence about the improvement."
+  assert record["body_draft"] == "## Summary\n\nThe exact published text.\n"
+  assert record["files"] == ["index.jsx"]
+  assert record["labels"] == ["bug", "area: ui"]
+  assert record["diff_stat"].startswith("1 file changed")
+  assert record["review"] == {
+    "id": "mine",
+    "state": "ready",
+    "code": "ready",
+    "message": "Still matches the exact source you reviewed.",
+  }
+  assert "diff_sha256" not in record and "repo_path" not in record
+  assert body["connected"] is True
+  assert body["autopilot_available"] is True
+  # No stored preference means the same default the Contribute app applies.
+  assert body["autopilot_default"] is True
+
+
+def test_for_chat_reports_local_drift_so_the_card_can_block_send(
+  client, owner_token,
+):
+  _write_token(login="octocat", user_id=42)
+  app_id, _ = _app_token(client, owner_token, github_access=True)
+  repo, _record = _prepared_for_chat(app_id, "drifted", "chat-a")
+  headers = {"Authorization": f"Bearer {owner_token}"}
+
+  (repo / "index.jsx").write_text("export default 3\n")
+  r = client.get(
+    f"/api/github/contributions/{app_id}/for-chat/chat-a", headers=headers,
+  )
+  assert r.status_code == 200, r.text
+  review = r.json()["records"][0]["review"]
+  assert review["state"] == "needs_refresh"
+  assert review["code"] == "working_changes"
+  # Read-only: inspecting a review never commits or discards the owner's edit.
+  assert (repo / "index.jsx").read_text() == "export default 3\n"
+
+
+def test_for_chat_drops_abandoned_and_leaves_settled_to_the_client(
+  client, owner_token,
+):
+  _write_token(login="octocat", user_id=42)
+  app_id, _ = _app_token(client, owner_token, github_access=True)
+  _prepared_for_chat(app_id, "dropped", "chat-a", status="abandoned")
+  _prepared_for_chat(
+    app_id, "already-open", "chat-a", status="open", number=7,
+    url="https://github.com/mobius-os/app-demo/pull/7",
+  )
+  headers = {"Authorization": f"Bearer {owner_token}"}
+
+  r = client.get(
+    f"/api/github/contributions/{app_id}/for-chat/chat-a", headers=headers,
+  )
+  assert r.status_code == 200, r.text
+  ids = [item["id"] for item in r.json()["records"]]
+  # An abandoned record is gone for good; an open one is history the app owns,
+  # but it is still returned so the client can decide (it carries no review).
+  assert "dropped" not in ids
+  assert ids == ["already-open"]
+  assert r.json()["records"][0]["review"] is None
+  assert r.json()["records"][0]["number"] == 7
+
+
+def test_for_chat_honors_the_owner_s_autopilot_default(client, owner_token):
+  _write_token(login="octocat", user_id=42)
+  app_id, _ = _app_token(client, owner_token, github_access=True)
+  _prepared_for_chat(app_id, "autopilot-default", "chat-a")
+  settings_path = (
+    Path(get_settings().data_dir) / "apps" / str(app_id) / "settings.json"
+  )
+  atomic_write(settings_path, json.dumps({"autopilot_default": False}))
+  headers = {"Authorization": f"Bearer {owner_token}"}
+
+  r = client.get(
+    f"/api/github/contributions/{app_id}/for-chat/chat-a", headers=headers,
+  )
+  assert r.status_code == 200, r.text
+  assert r.json()["autopilot_default"] is False
+
+
+def test_for_chat_marks_a_stack_layer_so_chat_never_sends_one_alone(
+  client, owner_token,
+):
+  _write_token(login="octocat", user_id=42)
+  app_id, _ = _app_token(client, owner_token, github_access=True)
+  _, record = _prepared_for_chat(app_id, "layer-2", "chat-a")
+  record["plan"]["stack"] = {
+    "id": "demo", "position": 2, "total": 3,
+    "parent_record_id": "layer-1", "base_branch": "stack/demo/01",
+  }
+  _write_contribution(app_id, "layer-2", record, "")
+  headers = {"Authorization": f"Bearer {owner_token}"}
+
+  r = client.get(
+    f"/api/github/contributions/{app_id}/for-chat/chat-a", headers=headers,
+  )
+  assert r.status_code == 200, r.text
+  item = r.json()["records"][0]
+  assert item["is_stack"] is True
+  # A stack layer is never preflighted here: the whole chain is reviewed and
+  # sent together in the app, so the card must not offer a single-layer Send.
+  assert item["review"] is None
+
+
+def test_for_chat_requires_the_owner_or_that_app(client, owner_token):
+  _write_token(login="octocat", user_id=42)
+  app_id, _ = _app_token(client, owner_token, github_access=True)
+  other_id, other_token = _app_token(client, owner_token, github_access=True)
+  _prepared_for_chat(app_id, "scoped", "chat-a")
+
+  r = client.get(
+    f"/api/github/contributions/{app_id}/for-chat/chat-a",
+    headers={"Authorization": f"Bearer {other_token}"},
+  )
+  assert r.status_code == 403, r.text
+  assert other_id != app_id
+
+  anon = client.get(f"/api/github/contributions/{app_id}/for-chat/chat-a")
+  assert anon.status_code == 401
+
+
+def test_submit_records_where_the_owner_pressed_send(client, owner_token):
+  """Provenance only: the ledger says which surface approved the publish."""
+  _write_token(login="octocat", user_id=42)
+  app_id, _ = _app_token(client, owner_token, github_access=True)
+  _prepared_for_chat(app_id, "provenance", "chat-a")
+
+  r = client.post(
+    f"/api/github/contributions/{app_id}/provenance/submit",
+    headers={"Authorization": f"Bearer {owner_token}"},
+    json={"autopilot": False, "submitter": "not-a-real-surface"},
+  )
+  # An unknown surface is rejected by the schema rather than stored.
+  assert r.status_code == 422, r.text

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -544,6 +544,25 @@ export const api = {
     }),
     restart: () => apiFetch('/platform/restart', { method: 'POST' }),
   },
+  // The chat's contribution review card. A read-only projection of the same
+  // ledger the Contribute app shows, plus the one owner-confirmed public action.
+  // Send deliberately calls the SAME submit endpoint as the app's button, so the
+  // server-side freshness, attribution, and fork checks are never bypassed.
+  contributions: {
+    forChat: (appId, chatId) => apiFetch(
+      `/github/contributions/${appId}/for-chat/${encodeURIComponent(chatId)}`,
+    ),
+    submit: (appId, recordId, { autopilot }) => apiFetch(
+      `/github/contributions/${appId}/${encodeURIComponent(recordId)}/submit`,
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          autopilot: !!autopilot,
+          submitter: 'chat-review-card',
+        }),
+      },
+    ),
+  },
   push: {
     vapidKey: () => apiFetch('/push/vapid-key'),
     subscribe: (payload) => apiFetch('/push/subscribe', {

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -32,6 +32,7 @@ import ComposerPopover from './ComposerPopover.jsx'
 import ConnectionStatus from './ConnectionStatus.jsx'
 import ActiveAssistantSurface from './ActiveAssistantSurface.jsx'
 import QueuedMessages from './QueuedMessages.jsx'
+import ContributionReviewCard from './ContributionReviewCard.jsx'
 import MsgContent from './MsgContent.jsx'
 import ActivityLineHeader from './ActivityLineHeader.jsx'
 import { formatResetTime } from './resetTime.js'
@@ -3996,6 +3997,13 @@ export default function ChatView({
           )}
           </>
         )}
+        {/* Contribution staged from THIS chat: approve it where the work
+            happened. Renders nothing unless something is actually waiting. */}
+        <ContributionReviewCard
+          chatId={chatId}
+          turnActive={turnActive}
+          onOpenApp={onOpenApp}
+        />
         <ConnectionStatus
           error={connectionError}
           reconnecting={reconnecting}

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -3998,12 +3998,18 @@ export default function ChatView({
           </>
         )}
         {/* Contribution staged from THIS chat: approve it where the work
-            happened. Renders nothing unless something is actually waiting. */}
-        <ContributionReviewCard
-          chatId={chatId}
-          turnActive={turnActive}
-          onOpenApp={onOpenApp}
-        />
+            happened. Renders nothing unless something is actually waiting.
+            Owner-shell only: an app-embedded chat runs on a capability token
+            that is deliberately scoped to one chat, so it can neither list apps
+            nor take a public GitHub action, and there is no owner surface there
+            to approve one. */}
+        {!embedded && (
+          <ContributionReviewCard
+            chatId={chatId}
+            turnActive={turnActive}
+            onOpenApp={onOpenApp}
+          />
+        )}
         <ConnectionStatus
           error={connectionError}
           reconnecting={reconnecting}

--- a/frontend/src/components/ChatView/ContributionReviewCard.css
+++ b/frontend/src/components/ChatView/ContributionReviewCard.css
@@ -1,0 +1,246 @@
+/* The chat's contribution review card — docked between the transcript and the
+   composer, so approving the work happens where the work happened. Deliberately
+   quieter than a chat message: it is a pending action, not part of the
+   conversation, and it disappears the moment nothing is staged. */
+
+/* The card is a child of `.chat__foot`, which is a transparent absolutely
+   positioned overlay with `pointer-events: none` so the transcript scrolls behind
+   the composer. Every real control in there has to opt back in — the composer
+   pill, the `+` button, the open-app row all do. Without this the card renders
+   perfectly and silently ignores every tap, because the hit test falls straight
+   through to the messages underneath. */
+.contrib-card-stack,
+.contrib-card {
+  pointer-events: auto;
+}
+
+.contrib-card-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px 12px 0;
+}
+
+.contrib-card {
+  border: 1px solid var(--border-light);
+  border-left: 2px solid var(--accent);
+  border-radius: 10px;
+  background: var(--surface);
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  /* Eases the snap-back and the flight off-screen. Suppressed mid-drag so the
+     card tracks the finger 1:1 instead of lagging behind it. */
+  transition: transform 160ms cubic-bezier(0.2, 0, 0.2, 1),
+              opacity 160ms linear;
+}
+
+.contrib-card--dragging {
+  transition: none;
+}
+
+.contrib-card--blocked {
+  border-left-color: var(--muted);
+}
+
+/* The status is a full-width header BAND, not a chip beside the text. As a chip
+   it sat next to a summary that wraps to several lines, leaving an obvious hole
+   under the short label. Spanning the card's padding (negative margins cancel it)
+   makes the band read as the card's header and removes that hole entirely. */
+.contrib-card__badge {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin: -10px -12px 0;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--border-light);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.contrib-card--blocked .contrib-card__badge {
+  background: color-mix(in srgb, var(--muted) 12%, transparent);
+  color: var(--muted);
+}
+
+/* The swipe's visible equivalent. Quiet by default — the card is an offer, not
+   an alert — but a real control, so a pointer or keyboard can dismiss too. */
+.contrib-card__dismiss {
+  flex-shrink: 0;
+  width: 28px;
+  height: 22px;
+  padding: 0;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--muted);
+  font-family: var(--font);
+  font-size: 0.75rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+@media (hover: hover) {
+  .contrib-card__dismiss:hover {
+    background: color-mix(in srgb, var(--text) 10%, transparent);
+    color: var(--text);
+  }
+}
+
+.contrib-card__summary {
+  min-width: 0;
+  font-size: 0.875rem;
+  line-height: 1.35;
+  color: var(--text);
+}
+
+.contrib-card__meta,
+.contrib-card__blocker {
+  font-size: 0.75rem;
+  line-height: 1.35;
+  color: var(--muted);
+}
+
+.contrib-card__blocker {
+  color: var(--danger);
+}
+
+/* The motivation the button cannot carry on its own: who actually benefits.
+   Accent-tinted so it reads as encouragement rather than another metadata line,
+   and hidden whenever the card is showing a problem instead. */
+.contrib-card__payoff {
+  font-size: 0.75rem;
+  line-height: 1.35;
+  color: color-mix(in srgb, var(--accent) 78%, var(--text));
+}
+
+.contrib-card__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 2px;
+}
+
+.contrib-card__send {
+  flex: 1;
+  min-height: 36px;
+  border: none;
+  border-radius: 8px;
+  background: var(--accent);
+  color: var(--bg);
+  font-family: var(--font);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.contrib-card__send:disabled {
+  background: var(--surface2);
+  color: var(--muted);
+  cursor: default;
+}
+
+.contrib-card__toggle {
+  flex-shrink: 0;
+  min-height: 36px;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--muted);
+  font-family: var(--font);
+  font-size: 0.8125rem;
+  cursor: pointer;
+}
+
+/* ONE scroller for the whole disclosure. An expanded review can be long (the
+   published text is quoted verbatim), and it is docked above the composer, so it
+   must not push the conversation off the screen. Nesting a second scroller
+   inside the quoted text made the two fight on a phone. */
+.contrib-card__details {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding-top: 6px;
+  border-top: 1px solid var(--border-light);
+  max-height: 42vh;
+  overflow: auto;
+  overscroll-behavior: contain;
+}
+
+.contrib-card__detail-title {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.contrib-card__detail-line {
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.contrib-card__detail-label {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  color: var(--muted);
+}
+
+.contrib-card__files {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-family: var(--mono);
+  font-size: 0.6875rem;
+  color: var(--text);
+  /* Long paths stay inside the card rather than widening the chat column. */
+  overflow-wrap: anywhere;
+}
+
+/* Quoted verbatim; it flows inside the disclosure's single scroller above. */
+.contrib-card__body {
+  margin: 0;
+  padding: 8px;
+  border-radius: 6px;
+  background: var(--bg);
+  font-family: var(--mono);
+  font-size: 0.6875rem;
+  line-height: 1.45;
+  color: var(--text);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+/* The acknowledgement after this card's own Send. Same shape as every other card
+   — band, body, actions — so it inherits the swipe and the band's dismiss control
+   instead of being a special layout with no way out. */
+.contrib-card--sent {
+  border-left-color: var(--green, var(--accent));
+}
+
+.contrib-card--sent .contrib-card__badge {
+  background: color-mix(in srgb, var(--green, var(--accent)) 12%, transparent);
+  color: var(--green, var(--accent));
+}
+
+.contrib-card__link-btn {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 36px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--accent);
+  text-decoration: none;
+}

--- a/frontend/src/components/ChatView/ContributionReviewCard.jsx
+++ b/frontend/src/components/ChatView/ContributionReviewCard.jsx
@@ -1,0 +1,381 @@
+import { useEffect, useRef, useState } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { X } from '@openai/apps-sdk-ui/components/Icon'
+import { api } from '../../api/client.js'
+import { appQueries } from '../../hooks/queries.js'
+import {
+  autopilotOnSend,
+  contributeApp as findContributeApp,
+  contributeAppId,
+  contributeLabel,
+  isHorizontalSwipe,
+  passedDismissThreshold,
+  payoffLine,
+  rememberDismissed,
+  sendBlocker,
+  statusLabel,
+  visibleRecords,
+} from './contributionReviewModel.js'
+import './ContributionReviewCard.css'
+
+// How long the post-send acknowledgement stays before clearing itself. Long
+// enough to read and tap through to GitHub, short enough that walking away never
+// leaves a stale box wedged above the composer.
+const SENT_VISIBLE_MS = 12000
+
+export default function ContributionReviewCard({ chatId, turnActive, onOpenApp }) {
+  const queryClient = useQueryClient()
+  const { data: apps } = appQueries.list.useQuery()
+  const appId = contributeAppId(apps)
+  const contributeApp = findContributeApp(apps, appId)
+
+  const queryKey = ['contributions-for-chat', appId, chatId]
+  // Read-only, and cheap because the server filters by chat before it inspects
+  // anything. A 404 (older backend) resolves to null and the card stays hidden.
+  const { data } = useQuery({
+    queryKey,
+    queryFn: () => api.contributions.forChat(appId, chatId)
+      .then(r => (r.ok ? r.json() : null)),
+    enabled: !!appId && !!chatId,
+    staleTime: 15000,
+    retry: false,
+  })
+
+  // The agent stages a review during a turn, so refetch exactly once when a turn
+  // SETTLES — not on every render and not on a timer. Nothing else can add a
+  // record for this chat behind the owner's back.
+  const wasActive = useRef(turnActive)
+  useEffect(() => {
+    if (wasActive.current && !turnActive) {
+      queryClient.invalidateQueries({ queryKey: ['contributions-for-chat'] })
+    }
+    wasActive.current = turnActive
+  }, [turnActive, queryClient])
+
+  const [busyId, setBusyId] = useState(null)
+  const [error, setError] = useState(null)
+  const [sent, setSent] = useState(null)
+  // Dismissals are persisted, so this only forces the re-render; the stored
+  // decision is what actually filters the list.
+  const [dismissRevision, setDismissRevision] = useState(0)
+
+  const storage = typeof localStorage !== 'undefined' ? localStorage : null
+  const records = visibleRecords(data, storage)
+  void dismissRevision
+  if (!appId) return null
+  if (!records.length && !sent) return null
+
+  async function send(record) {
+    setBusyId(record.id)
+    setError(null)
+    try {
+      const res = await api.contributions.submit(appId, record.id, {
+        autopilot: autopilotOnSend(data),
+      })
+      const body = await res.json().catch(() => null)
+      if (!res.ok) {
+        setError(body?.detail?.message || body?.detail
+          || 'Could not contribute this. Open Contribute for the details.')
+        return
+      }
+      setSent({
+        id: record.id,
+        number: body?.number ?? body?.record?.number ?? null,
+        url: body?.url || body?.record?.url || null,
+        repo: record.repo,
+      })
+    } catch {
+      setError('Could not reach the server. Nothing was contributed.')
+    } finally {
+      setBusyId(null)
+      queryClient.invalidateQueries({ queryKey: ['contributions-for-chat'] })
+    }
+  }
+
+  return (
+    <div className="contrib-card-stack">
+      {sent && (
+        <SentRow
+          key={`sent:${sent.id}`}
+          sent={sent}
+          onDismiss={() => setSent(null)}
+        />
+      )}
+      {records.map(record => (
+        <ReviewRow
+          key={record.id}
+          record={record}
+          connected={data?.connected !== false}
+          busy={busyId === record.id}
+          error={busyId === record.id ? null : error}
+          onSend={send}
+          onOpenContribute={contributeApp && onOpenApp
+            ? () => onOpenApp(contributeApp, { final: true })
+            : null}
+          onDismiss={() => {
+            rememberDismissed(record, storage)
+            setDismissRevision(value => value + 1)
+          }}
+        />
+      ))}
+    </div>
+  )
+}
+
+
+/**
+ * Swipe-to-dismiss, either direction, for any card shape in this file.
+ *
+ * Bound NATIVELY with a non-passive touchmove for the same reason the navigation
+ * drawer's handlers are: React's touch props are passive, so they can watch a
+ * gesture but never claim it, and `touch-action` cannot cover for that on iOS
+ * (WebKit does not implement the pan-* keywords). Claiming is what stops the
+ * surface underneath from taking the drag.
+ *
+ * It lives as a hook rather than inside one card because EVERY card here needs an
+ * exit — the confirmation shipped without one, and an undismissable box above the
+ * composer is worse than no confirmation at all.
+ */
+function useSwipeToDismiss(onDismiss) {
+  const cardRef = useRef(null)
+  const swipe = useRef({ x: 0, y: 0, active: false, claimed: false })
+  const dismissRef = useRef(onDismiss)
+  dismissRef.current = onDismiss
+
+  useEffect(() => {
+    const el = cardRef.current
+    if (!el) return undefined
+
+    const clear = () => {
+      el.classList.remove('contrib-card--dragging')
+      el.style.transform = ''
+      el.style.opacity = ''
+    }
+    const onStart = (event) => {
+      if (event.touches.length !== 1) { swipe.current.active = false; return }
+      swipe.current = {
+        x: event.touches[0].clientX, y: event.touches[0].clientY,
+        active: true, claimed: false,
+      }
+    }
+    const onMove = (event) => {
+      const state = swipe.current
+      if (!state.active || event.touches.length !== 1) return
+      const dx = event.touches[0].clientX - state.x
+      const dy = event.touches[0].clientY - state.y
+      // Vertical movement belongs to the expanded details scroller; only a
+      // decisively sideways drag becomes a dismissal, and once claimed it stays
+      // claimed for the rest of the gesture.
+      if (!state.claimed && !isHorizontalSwipe(dx, dy)) return
+      state.claimed = true
+      event.preventDefault()
+      el.classList.add('contrib-card--dragging')
+      el.style.transform = `translateX(${dx}px)`
+      el.style.opacity = String(Math.max(0.3, 1 - Math.abs(dx) / 260))
+    }
+    const onEnd = (event) => {
+      const state = swipe.current
+      state.active = false
+      if (!state.claimed) return
+      state.claimed = false
+      const touch = event.changedTouches[0]
+      const dx = touch.clientX - state.x
+      const dy = touch.clientY - state.y
+      el.classList.remove('contrib-card--dragging')
+      if (passedDismissThreshold(dx, dy)) {
+        el.style.transform = `translateX(${dx > 0 ? '110%' : '-110%'})`
+        el.style.opacity = '0'
+        window.setTimeout(() => dismissRef.current?.(), 160)
+        return
+      }
+      clear()
+    }
+    const onCancel = () => {
+      swipe.current.active = false
+      swipe.current.claimed = false
+      clear()
+    }
+
+    el.addEventListener('touchstart', onStart, { passive: true })
+    el.addEventListener('touchmove', onMove, { passive: false })
+    el.addEventListener('touchend', onEnd, { passive: true })
+    el.addEventListener('touchcancel', onCancel, { passive: true })
+    return () => {
+      el.removeEventListener('touchstart', onStart)
+      el.removeEventListener('touchmove', onMove)
+      el.removeEventListener('touchend', onEnd)
+      el.removeEventListener('touchcancel', onCancel)
+    }
+  }, [])
+
+  return cardRef
+}
+
+
+/**
+ * The acknowledgement after this card's own Send.
+ *
+ * It is an acknowledgement, NOT a permanent record — the Contribute app owns the
+ * history and the chat reply carries the link. So it gets every exit the other
+ * cards have (swipe, the band control) AND clears itself, because the first
+ * version shipped with no exit at all and became an undismissable box above the
+ * composer.
+ */
+function SentRow({ sent, onDismiss }) {
+  const cardRef = useSwipeToDismiss(onDismiss)
+  const dismissRef = useRef(onDismiss)
+  dismissRef.current = onDismiss
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => dismissRef.current?.(), SENT_VISIBLE_MS)
+    return () => window.clearTimeout(timer)
+  }, [])
+
+  return (
+    <div ref={cardRef} className="contrib-card contrib-card--sent" role="status">
+      <div className="contrib-card__badge">
+        <span>Contributed</span>
+        <button
+          type="button"
+          className="contrib-card__dismiss"
+          aria-label="Dismiss"
+          title="Dismiss"
+          onClick={() => onDismiss?.()}
+        >
+          <X width={13} height={13} aria-hidden="true" />
+        </button>
+      </div>
+      <p className="contrib-card__summary">
+        {sent.number
+          ? `Pull request #${sent.number} is with the maintainers.`
+          : 'It is with the maintainers now.'}
+      </p>
+      {sent.repo && <p className="contrib-card__meta">{sent.repo}</p>}
+      {sent.url && (
+        <div className="contrib-card__actions">
+          <a
+            className="contrib-card__link-btn"
+            href={sent.url}
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            View on GitHub
+          </a>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ReviewRow({
+  record, connected, busy, error, onSend, onOpenContribute, onDismiss,
+}) {
+  const [open, setOpen] = useState(false)
+  const blocker = sendBlocker(record, { connected })
+  const submitting = record.status === 'submitting'
+  const cardRef = useSwipeToDismiss(onDismiss)
+
+  return (
+    <div
+      ref={cardRef}
+      className={`contrib-card${blocker ? ' contrib-card--blocked' : ''}`}
+    >
+      {/* Header band, then what it is, then the actions. The band also carries
+          dismissal, so the swipe has a visible, pointer- and keyboard-reachable
+          equivalent rather than being a touch-only secret. */}
+      <div className="contrib-card__badge">
+        <span>{statusLabel(record, !!blocker)}</span>
+        <button
+          type="button"
+          className="contrib-card__dismiss"
+          aria-label="Dismiss — keeps it in Contribute"
+          title="Dismiss — keeps it in Contribute"
+          onClick={() => onDismiss?.()}
+        >
+          {/* The shell's icon set rather than a close CHARACTER: Inter has no
+              glyph for U+2715, so the literal rendered as a tofu box on the
+              real device. */}
+          <X width={13} height={13} aria-hidden="true" />
+        </button>
+      </div>
+      <p className="contrib-card__summary">
+        {record.summary || record.title || 'An improvement is ready to contribute'}
+      </p>
+
+      <p className="contrib-card__meta">
+        {record.repo}
+        {record.diff_stat ? <span> · {record.diff_stat}</span> : null}
+      </p>
+
+      {/* The payoff, but never next to a problem: a blocked review needs the
+          reason, not encouragement. */}
+      {!blocker && !error && !submitting && (
+        <p className="contrib-card__payoff">{payoffLine(record)}</p>
+      )}
+      {blocker && <p className="contrib-card__blocker">{blocker}</p>}
+      {error && <p className="contrib-card__blocker">{error}</p>}
+
+      <div className="contrib-card__actions">
+        <button
+          type="button"
+          className="contrib-card__send"
+          disabled={busy || submitting || !!blocker}
+          onClick={() => onSend(record)}
+        >
+          {submitting || busy ? 'Contributing…' : contributeLabel(record)}
+        </button>
+        <button
+          type="button"
+          className="contrib-card__toggle"
+          aria-expanded={open}
+          onClick={() => setOpen(value => !value)}
+        >
+          {open ? 'Hide details' : 'Details'}
+        </button>
+        {/* Only when something needs sorting out — the happy path stays two
+            buttons, and Contribute owns every state this card cannot fix. */}
+        {(blocker || error) && onOpenContribute && (
+          <button
+            type="button"
+            className="contrib-card__toggle"
+            onClick={onOpenContribute}
+          >
+            Open Contribute
+          </button>
+        )}
+      </div>
+
+      {open && (
+        <div className="contrib-card__details">
+          {record.title && (
+            <p className="contrib-card__detail-title">{record.title}</p>
+          )}
+          {record.branch && (
+            <p className="contrib-card__detail-line">Branch {record.branch}</p>
+          )}
+          {record.labels?.length > 0 && (
+            <p className="contrib-card__detail-line">
+              Labels {record.labels.join(', ')}
+            </p>
+          )}
+          {record.files?.length > 0 && (
+            <>
+              <p className="contrib-card__detail-label">Files</p>
+              <ul className="contrib-card__files">
+                {record.files.map(file => <li key={file}>{file}</li>)}
+              </ul>
+            </>
+          )}
+          {record.body_draft && (
+            <>
+              <p className="contrib-card__detail-label">
+                The exact text that will be published
+              </p>
+              <pre className="contrib-card__body">{record.body_draft}</pre>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/ChatView/__tests__/contributionReviewModel.test.js
+++ b/frontend/src/components/ChatView/__tests__/contributionReviewModel.test.js
@@ -1,0 +1,303 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import {
+  ACTIONABLE_STATUSES,
+  DISMISS_DX_PX,
+  PLATFORM_REPO,
+  actionableRecords,
+  autopilotOnSend,
+  contributeApp,
+  contributeAppId,
+  contributeLabel,
+  payoffLine,
+  dismissKey,
+  isDismissed,
+  isHorizontalSwipe,
+  passedDismissThreshold,
+  rememberDismissed,
+  sendBlocker,
+  statusLabel,
+  visibleRecords,
+} from '../contributionReviewModel.js'
+
+const cardSrc = readFileSync(
+  new URL('../ContributionReviewCard.jsx', import.meta.url), 'utf8',
+)
+const clientSrc = readFileSync(
+  new URL('../../../api/client.js', import.meta.url), 'utf8',
+)
+const cardCss = readFileSync(
+  new URL('../ContributionReviewCard.css', import.meta.url), 'utf8',
+)
+
+const APPS = [
+  { id: 3, slug: 'some-other-app' },
+  { id: 8, slug: 'contribute' },
+]
+
+test('the ledger owner is resolved by slug, and a missing app hides the card', () => {
+  assert.equal(contributeAppId(APPS), 8)
+  assert.equal(contributeAppId([{ id: 3, slug: 'some-other-app' }]), null)
+  assert.equal(contributeAppId([]), null)
+  assert.equal(contributeAppId(undefined), null)
+  assert.equal(contributeApp(APPS, 8).slug, 'contribute')
+  assert.equal(contributeApp(APPS, 99), null)
+})
+
+test('only records awaiting an owner decision reach the composer', () => {
+  const payload = { records: [
+    { id: 'a', status: 'prepared' },
+    { id: 'b', status: 'submitting' },
+    { id: 'c', status: 'open' },
+    { id: 'd', status: 'merged' },
+    { id: 'e', status: 'closed' },
+    { id: 'f' },
+  ] }
+  assert.deepEqual(actionableRecords(payload).map(r => r.id), ['a', 'b'])
+  assert.deepEqual(actionableRecords(null), [])
+  assert.deepEqual([...ACTIONABLE_STATUSES], ['prepared', 'submitting'])
+})
+
+test('a ready prepared record is sendable', () => {
+  const record = {
+    status: 'prepared', review: { state: 'ready', message: 'Still matches' },
+  }
+  assert.equal(sendBlocker(record, { connected: true }), null)
+})
+
+test('a drifted record cannot be sent, and says why in the server’s words', () => {
+  const record = {
+    status: 'prepared',
+    review: { state: 'needs_refresh', message: 'The branch moved since you reviewed it.' },
+  }
+  assert.equal(
+    sendBlocker(record, { connected: true }),
+    'The branch moved since you reviewed it.',
+  )
+})
+
+test('a verdict with no message still blocks, with a generic reason', () => {
+  const record = { status: 'prepared', review: { state: 'needs_refresh' } }
+  assert.match(sendBlocker(record, { connected: true }), /prepared again/)
+})
+
+test('a disconnected GitHub blocks Send before any request is made', () => {
+  const record = { status: 'prepared', review: { state: 'ready' } }
+  assert.match(sendBlocker(record, { connected: false }), /Connect GitHub/)
+})
+
+test('a stack layer is never sendable from chat — the chain is reviewed together', () => {
+  const record = { status: 'prepared', is_stack: true, review: { state: 'ready' } }
+  assert.match(sendBlocker(record, { connected: true }), /stacked set/)
+})
+
+// The submit endpoint re-runs every check before it pushes. If this card treated
+// a missing verdict as "blocked" it would strand a sendable review; if it treated
+// a verdict as authoritative it would be claiming an authority it does not have.
+test('an absent verdict defers to the server rather than blocking', () => {
+  assert.equal(sendBlocker({ status: 'prepared' }, { connected: true }), null)
+  assert.equal(sendBlocker({ status: 'submitting' }, { connected: true }), null)
+  assert.equal(sendBlocker(null, { connected: true }), null)
+})
+
+test('autopilot on send mirrors the owner default and the backend capability', () => {
+  assert.equal(autopilotOnSend({ autopilot_available: true }), true)
+  assert.equal(
+    autopilotOnSend({ autopilot_available: true, autopilot_default: true }), true,
+  )
+  assert.equal(
+    autopilotOnSend({ autopilot_available: true, autopilot_default: false }), false,
+  )
+  // An older backend that cannot run the loop must never have one granted.
+  assert.equal(autopilotOnSend({ autopilot_default: true }), false)
+  assert.equal(autopilotOnSend(null), false)
+})
+
+test('the status word distinguishes waiting, blocked, and in-flight', () => {
+  assert.equal(statusLabel({ status: 'prepared' }, false), 'Ready to contribute')
+  assert.equal(statusLabel({ status: 'prepared' }, true), 'Needs an update')
+  assert.equal(statusLabel({ status: 'submitting' }, false), 'Publishing')
+})
+
+// The action names the value of contributing, not the mechanism of sending, and
+// never uses "upstream" — precise to anyone who works with open source, opaque to
+// everyone else. It only names a destination it actually knows.
+test('the action label says contribute, and only names Möbius for Möbius', () => {
+  assert.equal(contributeLabel({ repo: PLATFORM_REPO }), 'Contribute to Möbius')
+  assert.equal(
+    contributeLabel({ repo: 'mobius-os/app-example' }),
+    'Contribute this improvement',
+  )
+  assert.equal(contributeLabel(null), 'Contribute this improvement')
+  for (const label of [contributeLabel({ repo: PLATFORM_REPO }), contributeLabel({})]) {
+    assert.doesNotMatch(label, /upstream|pull request|PR\b/i)
+  }
+})
+
+// The payoff line motivates without overpromising: acceptance stays the
+// maintainers' decision, not a consequence of the tap.
+test('the payoff line matches who benefits and keeps acceptance conditional', () => {
+  const platform = payoffLine({ repo: PLATFORM_REPO })
+  assert.match(platform, /everyone running Möbius/)
+  const app = payoffLine({ repo: 'mobius-os/app-example' })
+  assert.match(app, /everyone using this app/)
+  for (const line of [platform, app]) assert.match(line, /^If it's accepted/)
+})
+
+// The whole safety argument for a one-tap chat button is that it reuses the app's
+// verified path. If the card ever grew its own push/PR-creation logic, or dropped
+// the provenance tag, that argument would quietly stop being true.
+test('Send routes through the same verified submit endpoint as the app button', () => {
+  assert.match(clientSrc, /\/github\/contributions\/\$\{appId\}\/\$\{encodeURIComponent\(recordId\)\}\/submit/)
+  assert.match(clientSrc, /submitter: 'chat-review-card'/)
+  assert.match(cardSrc, /api\.contributions\.submit\(appId, record\.id/)
+  // Anchored on real invocations. A bare /gh / also matches ordinary English
+  // ("through the", "enough room"), which made this fire on a prose comment.
+  const forbidden = [
+    /\bgh\s+(?:pr|api|issue|repo)\b/,
+    /api\.github\.com/,
+    /\/repos\//,
+    /git\s+push/,
+  ]
+  for (const pattern of forbidden) {
+    assert.doesNotMatch(cardSrc, pattern,
+      'the card must not talk to GitHub itself — the platform endpoint owns that')
+  }
+})
+
+// A public, irreversible action must show what it will publish. The expander is
+// what makes one tap honest rather than blind.
+test('the card exposes the exact text and file list that would be published', () => {
+  assert.match(cardSrc, /record\.body_draft/)
+  assert.match(cardSrc, /record\.files\?\.length > 0/)
+  assert.match(cardSrc, /The exact text that will be published/)
+})
+
+// `.chat__foot` is a transparent overlay with `pointer-events: none` so the
+// transcript scrolls behind the composer; every real control inside it opts back
+// in. A card that forgets renders perfectly and ignores every tap — the hit test
+// falls through to the messages underneath — which no amount of programmatic
+// clicking in a test reveals.
+test('the card opts back into pointer events inside the pass-through foot', () => {
+  assert.match(
+    cardCss,
+    /\.contrib-card-stack,\s*\n\.contrib-card \{\s*\n\s*pointer-events: auto;/,
+  )
+})
+
+// ── Swipe-to-dismiss ────────────────────────────────────────────────────────
+
+function fakeStorage(initial = {}) {
+  const map = new Map(Object.entries(initial))
+  return {
+    getItem: key => (map.has(key) ? map.get(key) : null),
+    setItem: (key, value) => { map.set(key, String(value)) },
+    size: () => map.size,
+  }
+}
+
+test('only a decisively sideways drag counts, in either direction', () => {
+  assert.equal(isHorizontalSwipe(20, 0), true)
+  assert.equal(isHorizontalSwipe(-20, 0), true)
+  // Vertical and near-diagonal movement belongs to the details scroller.
+  assert.equal(isHorizontalSwipe(0, 30), false)
+  assert.equal(isHorizontalSwipe(20, 19), false)
+  // Below the slop nothing is a gesture yet.
+  assert.equal(isHorizontalSwipe(8, 0), false)
+})
+
+test('dismissal needs real travel, so a tap or a nudge cannot lose the card', () => {
+  assert.equal(passedDismissThreshold(DISMISS_DX_PX, 0), true)
+  assert.equal(passedDismissThreshold(-DISMISS_DX_PX, 0), true)
+  assert.equal(passedDismissThreshold(DISMISS_DX_PX - 1, 0), false)
+  assert.equal(passedDismissThreshold(0, 0), false)
+  // Travel far enough but mostly downward: still the scroller's gesture.
+  assert.equal(passedDismissThreshold(70, 90), false)
+})
+
+// Dismissing is a VIEW decision. The record stays prepared in the ledger, so an
+// accidental swipe can never drop staged work — it only stops the card asking.
+test('dismissal hides a record without touching the ledger', () => {
+  const record = { id: 'r1', status: 'prepared', updated_at: 'T1' }
+  const store = fakeStorage()
+  const payload = { records: [record] }
+  assert.equal(visibleRecords(payload, store).length, 1)
+  rememberDismissed(record, store)
+  assert.equal(isDismissed(record, store), true)
+  assert.equal(visibleRecords(payload, store).length, 0)
+  // The record object itself is untouched — nothing about it says "dismissed".
+  assert.deepEqual(record, { id: 'r1', status: 'prepared', updated_at: 'T1' })
+})
+
+// A dismissal means "not this version". Re-staging is a fresh decision, so the
+// card must come back rather than the first swipe burying every later revision.
+test('a re-staged record reappears after being dismissed', () => {
+  const store = fakeStorage()
+  const first = { id: 'r1', status: 'prepared', updated_at: 'T1' }
+  rememberDismissed(first, store)
+  const restaged = { id: 'r1', status: 'prepared', updated_at: 'T2' }
+  assert.equal(isDismissed(restaged, store), false)
+  assert.equal(visibleRecords({ records: [restaged] }, store).length, 1)
+})
+
+test('dismissal degrades safely without usable storage', () => {
+  const record = { id: 'r1', status: 'prepared', updated_at: 'T1' }
+  const hostile = {
+    getItem() { throw new Error('denied') },
+    setItem() { throw new Error('denied') },
+  }
+  assert.equal(rememberDismissed(record, hostile), false)
+  assert.equal(isDismissed(record, hostile), false)
+  assert.equal(isDismissed(record, null), false)
+  // A record with no id has no dismissal identity at all.
+  assert.equal(dismissKey({ updated_at: 'T1' }), null)
+  assert.equal(rememberDismissed({}, fakeStorage()), false)
+})
+
+// A touch-only dismissal would be unreachable with a mouse or a keyboard.
+test('the swipe has a visible, focusable equivalent', () => {
+  assert.match(cardSrc, /className="contrib-card__dismiss"/)
+  assert.match(cardSrc, /aria-label="Dismiss — keeps it in Contribute"/)
+  assert.match(cardSrc, /onClick=\{\(\) => onDismiss\?\.\(\)\}/)
+  // An icon from the shell's set, never a bare ✕ character — Inter has no glyph
+  // for U+2715, so the literal rendered as a tofu box on the real device.
+  assert.match(cardSrc, /<X width=\{13\} height=\{13\} aria-hidden="true" \/>/)
+  assert.doesNotMatch(cardSrc, /✕|✖|❌/)
+})
+
+// Same lesson as the navigation drawer: a passive listener can watch a gesture
+// but never claim it, and touch-action cannot cover for that on WebKit.
+test('the dismissal gesture is claimed with a non-passive touchmove', () => {
+  assert.match(cardSrc, /addEventListener\('touchmove', onMove, \{ passive: false \}\)/)
+  assert.match(cardSrc, /event\.preventDefault\(\)/)
+  assert.doesNotMatch(cardSrc, /onTouchMove=\{/)
+})
+
+// The first version of the acknowledgement had NO exit: no swipe (its handlers
+// lived in the other card shape), no control in a band it never rendered, and no
+// timeout. It became an undismissable box wedged above the composer. Every card
+// shape must be dismissible, and this one must also clear itself.
+test('the post-send acknowledgement is dismissible and self-clearing', () => {
+  const sentRow = cardSrc.slice(
+    cardSrc.indexOf('function SentRow('),
+    cardSrc.indexOf('function ReviewRow('),
+  )
+  assert.ok(sentRow.length > 0, 'the acknowledgement is its own card shape')
+  // Same swipe binding as every other card, not a bespoke layout.
+  assert.match(sentRow, /useSwipeToDismiss\(onDismiss\)/)
+  // A band with a real dismiss control.
+  assert.match(sentRow, /className="contrib-card__badge"/)
+  assert.match(sentRow, /className="contrib-card__dismiss"/)
+  // And it does not outlive its usefulness.
+  assert.match(sentRow, /setTimeout\(\(\) => dismissRef\.current\?\.\(\), SENT_VISIBLE_MS\)/)
+  assert.match(cardSrc, /const SENT_VISIBLE_MS = \d+/)
+})
+
+// One gesture implementation for every card shape here. Two copies is how the
+// acknowledgement ended up without one.
+test('every card shape shares one swipe implementation', () => {
+  assert.equal((cardSrc.match(/function useSwipeToDismiss\(/g) || []).length, 1)
+  assert.equal((cardSrc.match(/= useSwipeToDismiss\(onDismiss\)/g) || []).length, 2)
+  assert.equal((cardSrc.match(/addEventListener\('touchmove'/g) || []).length, 1)
+})

--- a/frontend/src/components/ChatView/contributionReviewModel.js
+++ b/frontend/src/components/ChatView/contributionReviewModel.js
@@ -1,0 +1,176 @@
+// Pure model for the chat's contribution review card (view in
+// ContributionReviewCard.jsx). Every decision the card makes about what to show
+// and whether Send may be offered lives here, so the rules are unit-testable
+// without a DOM and the component stays a renderer.
+//
+// The card is a SECOND view over the ledger the Contribute app owns. It never
+// relaxes a gate: Send calls the same submit endpoint as the app's button, and
+// that endpoint re-runs every freshness, attribution, and fork check before it
+// pushes anything public. Nothing here can authorize a publish on its own.
+
+// The ledger lives in the Contribute app's storage, so the card resolves that
+// app by slug. Not installed → nothing staged → the card never renders.
+export const CONTRIBUTE_SLUG = 'contribute'
+
+// Records the owner can still act on. Settled ones (open/merged/closed) are
+// history and belong in the Contribute app, not above the composer.
+export const ACTIONABLE_STATUSES = new Set(['prepared', 'submitting'])
+
+export function contributeAppId(apps) {
+  const match = (apps || []).find(app => app && app.slug === CONTRIBUTE_SLUG)
+  return match ? Number(match.id) : null
+}
+
+export function contributeApp(apps, appId) {
+  return (apps || []).find(app => app && Number(app.id) === appId) || null
+}
+
+export function actionableRecords(payload) {
+  return (payload?.records || []).filter(
+    record => ACTIONABLE_STATUSES.has(record?.status),
+  )
+}
+
+/**
+ * Why this record cannot be sent right now, or null when it can be.
+ *
+ * The server already ran the same local preflight the Contribute app's review
+ * cards use; this only turns its verdict into one owner-facing sentence. A
+ * missing verdict is treated as sendable because the submit endpoint remains
+ * authoritative — this card must never be the thing that decides a push is safe.
+ */
+export function sendBlocker(record, { connected } = {}) {
+  if (!record || record.status !== 'prepared') return null
+  if (record.is_stack) {
+    return 'This is one layer of a stacked set — review and send the whole chain in Contribute.'
+  }
+  if (connected === false) return 'Connect GitHub in Contribute first.'
+  const review = record.review
+  if (!review || review.state === 'ready') return null
+  return review.message
+    || 'This needs to be prepared again before it can be sent.'
+}
+
+/**
+ * Whether a successful send should grant the background review-response loop.
+ *
+ * Mirrors the Contribute app's Send: the owner's stored default, and only when
+ * the backend advertises the capability. An unreadable/absent default means ON,
+ * exactly as the app treats it, so the two surfaces cannot disagree about what a
+ * press authorizes.
+ */
+export function autopilotOnSend(payload) {
+  if (!payload || payload.autopilot_available !== true) return false
+  return payload.autopilot_default !== false
+}
+
+// The platform's own repository. A contribution to it reaches every Möbius
+// owner, which is what the card's action and payoff line can honestly promise;
+// an app's repository reaches that app's users instead.
+export const PLATFORM_REPO = 'mobius-os/mobius'
+
+/** The one-line status word shown on the card. */
+export function statusLabel(record, blocked) {
+  if (record?.status === 'submitting') return 'Publishing'
+  if (blocked) return 'Needs an update'
+  return 'Ready to contribute'
+}
+
+/**
+ * The action label.
+ *
+ * "Contribute" carries the value of the act where "Send for review" only named
+ * the mechanism, and it avoids "upstream" — precise to anyone who works with
+ * open source, and opaque to everyone else. The destination is only named when
+ * we actually know it is the platform, so the button can never point someone at
+ * the wrong project.
+ */
+export function contributeLabel(record) {
+  return record?.repo === PLATFORM_REPO
+    ? 'Contribute to Möbius'
+    : 'Contribute this improvement'
+}
+
+/**
+ * One quiet line making the payoff concrete.
+ *
+ * It carries the motivation the button cannot, and stays honest about the
+ * review: acceptance is the maintainers' call, not a consequence of the tap.
+ */
+export function payoffLine(record) {
+  return record?.repo === PLATFORM_REPO
+    ? "If it's accepted, everyone running Möbius gets this."
+    : "If it's accepted, everyone using this app gets it."
+}
+
+// ── Swipe-to-dismiss ────────────────────────────────────────────────────────
+//
+// Dismissing is a VIEW decision, never a data one: the contribution stays
+// prepared in the ledger and the Contribute app still lists it. A swipe is easy
+// to perform by accident, so it must never be able to drop staged work.
+//
+// The gesture geometry deliberately mirrors the navigation drawer's swipe-close
+// (see lib/drawerLifecycle.js). Both live in their own module for now rather
+// than sharing one: the drawer's copy is in review upstream, and consolidating
+// them here would collide with that. Worth folding into one shared predicate
+// once it lands.
+
+// Travel before a touch counts as a horizontal intent at all.
+export const SWIPE_SLOP_PX = 10
+// How decisively sideways it must be. Anything less belongs to the vertical
+// scroller inside an expanded card.
+export const SWIPE_DOMINANCE = 1.15
+// Travel past which a release dismisses instead of snapping back.
+export const DISMISS_DX_PX = 64
+
+/** True only when this displacement is decisively sideways, either direction. */
+export function isHorizontalSwipe(dx, dy) {
+  return Math.abs(dx) > SWIPE_SLOP_PX
+    && Math.abs(dx) > Math.abs(dy) * SWIPE_DOMINANCE
+}
+
+/** True when a release at this displacement should dismiss the card. */
+export function passedDismissThreshold(dx, dy) {
+  return isHorizontalSwipe(dx, dy) && Math.abs(dx) >= DISMISS_DX_PX
+}
+
+/**
+ * The dismissal identity of a record.
+ *
+ * Keyed on the record's last update as well as its id, so dismissing means "not
+ * this version". If the agent re-stages the contribution — new code, new
+ * wording — there is a fresh decision to make and the card comes back. Without
+ * the timestamp a single swipe would bury every later revision of the same work.
+ */
+export function dismissKey(record) {
+  if (!record?.id) return null
+  return `mobius:contrib-dismissed:${record.id}:${record.updated_at || ''}`
+}
+
+export function isDismissed(record, storage) {
+  const key = dismissKey(record)
+  if (!key || !storage) return false
+  try {
+    return storage.getItem(key) === '1'
+  } catch {
+    return false
+  }
+}
+
+export function rememberDismissed(record, storage) {
+  const key = dismissKey(record)
+  if (!key || !storage) return false
+  try {
+    storage.setItem(key, '1')
+    return true
+  } catch {
+    // Private browsing or a full quota: the card simply reappears next time,
+    // which is the safe direction to fail.
+    return false
+  }
+}
+
+/** Records that still deserve the composer's attention. */
+export function visibleRecords(payload, storage) {
+  return actionableRecords(payload).filter(record => !isDismissed(record, storage))
+}


### PR DESCRIPTION
## Summary

Sending a prepared contribution meant leaving the conversation: open the Contribute app, find the record, press Send there. The approval was the only step in the whole flow that could not happen where the work happened.

This adds a review card docked above the composer for records staged **from that chat**.

![Chat review card, ready to contribute](https://raw.githubusercontent.com/eldarkurtic/mobius/docs/chat-review-card-screenshots/docs/chat-review-card/card-ready.png)

- a plain-language summary, the target repo and the diff stat
- one quiet line making the payoff concrete — *"If it's accepted, everyone running Möbius gets this"* — kept conditional, since acceptance is the maintainers' decision and not a consequence of the tap
- one **Contribute to Möbius** action (an app's own project reads *Contribute this improvement*, so it never names the wrong destination)
- **Details**: the exact title, labels, changed files, and the verbatim body that would be published

![Details expanded](https://raw.githubusercontent.com/eldarkurtic/mobius/docs/chat-review-card-screenshots/docs/chat-review-card/card-details.png)

The disclosure is what makes one tap honest rather than blind — a public PR under the owner's name is irreversible, so the card shows what will be published instead of asking them to trust a summary. It scrolls inside a single capped scroller so it can never push the conversation off a phone screen.

When the server's local preflight finds the review no longer matches what was reviewed, the action is disabled, the reason is shown in the server's own words, and a route into the Contribute app appears. The encouragement line is hidden here deliberately: a blocked review needs its reason, not motivation.

![Blocked, showing the drift reason](https://raw.githubusercontent.com/eldarkurtic/mobius/docs/chat-review-card-screenshots/docs/chat-review-card/card-blocked.png)

## Why this adds no new trust

The action calls the same `POST /contributions/{app_id}/{record_id}/submit` endpoint as the Contribute app's button. That endpoint keeps sole ownership of every gate — branch-tip freshness, the reviewed diff hash, the co-author trailer, owner attribution, fork adaptation, and the proof that the upstream merge result still matches the reviewed diff. The card never touches GitHub, and a unit test fails if it ever grows a publish path of its own.

The new read-only `for-chat` projection returns only what the card renders — never `repo_path`, `base_sha`, or the diff hashes — and filters by chat *before* inspecting anything, so the same preflight the app's cards run happens on a bounded set (a chat normally has zero or one prepared record) rather than the whole ledger.

Two boundaries are kept deliberately: **settled records stay the app's history**, and **a stack layer is marked and never sendable alone**, since a chain has to be reviewed and published together. `submit` gained an optional, value-constrained `submitter` field so the ledger records which surface approved a publish; unknown values are rejected by the schema rather than stored.

## Dismissal

Every card shape can be swiped away in either direction, or dismissed with the labelled control in its header band. Dismissing is a **view decision only**: the record stays `prepared` and the Contribute app still lists it, because a swipe is far too easy to perform by accident to be allowed to drop staged work. It is keyed on the record id *and* its last update, so it means "not this version" — a re-staged contribution comes back rather than one swipe burying every later revision. The post-send acknowledgement shares the same shape and additionally clears itself, since it is an acknowledgement rather than a record.

The gesture is claimed with a non-passive native `touchmove`. React's touch props are registered passive, so they can watch a gesture but never claim it, and `touch-action` cannot cover for that on WebKit, which does not implement the `pan-*` keywords. Vertical movement is left entirely to the expanded details scroller.

## Testing

- backend: 7 new route tests — chat scoping, the drift verdict, abandoned filtering, the owner's autopilot default, stack marking, authorization (another app 403, anonymous 401), and a rejected `submitter` value
- frontend: 21 new model and contract tests; full unit suite green; `npm run build` clean; `scripts/check-private-paths.sh` clean
- verified against the running shell at 393px in every state above. Dismissal checked three ways — the control is hit-testable and removes the card, a 144px swipe claims every move and removes it, an untouched acknowledgement clears itself — and a vertical drag is not claimed at all, so the details panel still scrolls.

The screenshots show a **neutral synthetic example**, and the card is cropped away from its surrounding conversation, since a real transcript is owner content. They are hosted on a separate branch of the contributor's fork to keep this diff free of binaries.

This supersedes #249, which is the same feature without the dismissal fix. Closing that one in favour of this single review.

No Playwright spec is included: this environment cannot run the e2e suite, and an unverified browser spec seemed worse than none. Happy to add one if you'd like it.