### PR TITLE
Let the composer's attached image be opened full screen

### DIFF
--- a/frontend/src/components/ChatView/ChatInputBar.jsx
+++ b/frontend/src/components/ChatView/ChatInputBar.jsx
@@ -78,6 +78,8 @@
  */
 
 import { useRef, useState, useEffect, useLayoutEffect } from 'react'
+import { createPortal } from 'react-dom'
+import ImageLightbox from './markdown/ImageLightbox.jsx'
 import { ArrowUp, Mic, DoubleChevronRight } from '@openai/apps-sdk-ui/components/Icon'
 import { BASE } from '../../api/client.js'
 import { mediaTokenParam } from '../../api/mediaToken.js'
@@ -243,6 +245,8 @@ function FileChips({ files, onRemove, chatId }) {
     param: '',
     failed: false,
   })
+  // Index into the attached-image gallery currently shown full-screen.
+  const [lightboxIndex, setLightboxIndex] = useState(null)
   const hasRestoredImage = files?.some(file => (
     file.mime_type?.startsWith('image/') && !file.objectUrl
   ))
@@ -268,18 +272,41 @@ function FileChips({ files, onRemove, chatId }) {
     : { param: '', failed: false }
 
   if (!files?.length) return null
+
+  const cards = files.map(chip => {
+    const isImage = !!chip.objectUrl || chip.mime_type?.startsWith('image/')
+    const previewSrc = chip.objectUrl || (
+      isImage && currentTokenState.param
+        ? `${BASE}/api/chats/${chatId}/uploads/${encodeURIComponent(chip.name)}${currentTokenState.param}`
+        : ''
+    )
+    return {
+      chip,
+      isImage,
+      previewSrc,
+      previewFailed: !!(isImage && !chip.objectUrl && currentTokenState.failed),
+    }
+  })
+  // Every viewable attached image, in tray order, so the full-screen
+  // viewer can page/swipe between them like a sent-message gallery. Each
+  // card records its own gallery position: two attachments can share a
+  // preview URL (same restored filename), so looking the index up by src
+  // would open the wrong one.
+  const gallery = []
+  for (const card of cards) {
+    if (!card.isImage || !card.previewSrc) continue
+    card.galleryIndex = gallery.length
+    gallery.push({ src: card.previewSrc, alt: card.chip.name })
+  }
+  // Removing an attachment while open can invalidate the index; treat
+  // an out-of-range index as closed rather than showing the wrong image.
+  const openIndex = lightboxIndex !== null && lightboxIndex < gallery.length
+    ? lightboxIndex
+    : null
+
   return (
     <div className="chat__attach-tray">
-      {files.map(chip => {
-        const isImage = !!chip.objectUrl || chip.mime_type?.startsWith('image/')
-        const previewSrc = chip.objectUrl || (
-          isImage && currentTokenState.param
-            ? `${BASE}/api/chats/${chatId}/uploads/${encodeURIComponent(chip.name)}${currentTokenState.param}`
-            : ''
-        )
-        const previewFailed = !!(
-          isImage && !chip.objectUrl && currentTokenState.failed
-        )
+      {cards.map(({ chip, isImage, previewSrc, previewFailed, galleryIndex }) => {
         const cls = classifyFile(chip.name || '')
         const errorMark = chip.status === 'error' ? ' chat__attach-card--error' : ''
         return (
@@ -295,7 +322,18 @@ function FileChips({ files, onRemove, chatId }) {
               : (chip.status === 'error' ? chip.error : chip.name)}
           >
             {isImage && previewSrc ? (
-              <img className="chat__attach-card-thumb" src={previewSrc} alt="" />
+              <button
+                type="button"
+                className="chat__attach-card-thumb-button"
+                // Same keyboard-preserving trick as the × button: without
+                // this, the tap moves focus off the textarea and iOS
+                // collapses the soft keyboard behind the viewer.
+                onPointerDown={(e) => e.preventDefault()}
+                onClick={() => setLightboxIndex(galleryIndex)}
+                aria-label={`View ${chip.name} full screen`}
+              >
+                <img className="chat__attach-card-thumb" src={previewSrc} alt="" />
+              </button>
             ) : previewFailed ? (
               <span className="chat__attach-card-preview-error" role="status">
                 Preview unavailable
@@ -328,6 +366,17 @@ function FileChips({ files, onRemove, chatId }) {
           </div>
         )
       })}
+      {openIndex !== null && createPortal(
+        <ImageLightbox
+          src={gallery[openIndex].src}
+          alt={gallery[openIndex].alt}
+          items={gallery}
+          index={openIndex}
+          onNavigate={setLightboxIndex}
+          onClose={() => setLightboxIndex(null)}
+        />,
+        document.body,
+      )}
     </div>
   )
 }

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -2245,6 +2245,23 @@
   text-align: center;
 }
 
+/* The thumbnail itself is the "open full screen" affordance, so it fills
+   the card edge-to-edge and carries no chrome of its own. */
+.chat__attach-card-thumb-button {
+  all: unset;
+  display: block;
+  width: 100%;
+  height: 100%;
+  cursor: zoom-in;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.chat__attach-card-thumb-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+  border-radius: 13px;
+}
+
 .chat__attach-card-thumb {
   width: 100%;
   height: 100%;

--- a/frontend/src/components/ChatView/__tests__/attachmentSizing.test.js
+++ b/frontend/src/components/ChatView/__tests__/attachmentSizing.test.js
@@ -35,3 +35,17 @@ test('sent attachments render above message text in both message paths', () => {
   assert.ok(firstAttachments >= 0 && firstAttachments < blockContent)
   assert.ok(secondAttachments >= 0 && secondAttachments < plainText)
 })
+
+test('a pending composer image opens the same full-screen viewer as a sent one', () => {
+  const bar = readFileSync(new URL('../ChatInputBar.jsx', import.meta.url), 'utf8')
+
+  // The thumbnail must be a real button (keyboard + a11y reachable), not a
+  // click handler on the <img>, and must render the shared lightbox.
+  assert.match(bar, /className="chat__attach-card-thumb-button"/)
+  assert.match(bar, /setLightboxIndex\(/)
+  assert.match(bar, /<ImageLightbox/)
+  // Gallery paging across every attached image, so multi-attach can be checked
+  // without closing and reopening.
+  assert.match(bar, /items=\{gallery\}/)
+  ruleBody('.chat__attach-card-thumb-button')
+})


### PR DESCRIPTION
## What

An image attached in the composer could only be removed, never viewed. There was no way to confirm the right picture was picked before sending it — the 96×96 thumbnail was the only look you got.

The thumbnail is now a button that opens the existing `ImageLightbox` in a portal, so a pending attachment gets exactly the viewer a sent attachment already has: pointer-centred zoom, drag pan, double-tap zoom, and download. Every viewable attached image is passed as `items`, so a multi-attachment tray can be paged/swiped through without closing and reopening.

## Details

- `FileChips` now derives its per-file preview data once into a `cards` array, then builds the gallery from it. Each card records its own `galleryIndex` while the gallery is built — two attachments can resolve to the same preview URL (same restored filename), so looking the index up by `src` could open the wrong image.
- The thumbnail button keeps the `onPointerDown` `preventDefault` used by the `×` button and the other composer controls, so the iOS soft keyboard is not collapsed by the tap.
- Removing an attachment while the viewer is open can invalidate the open index; an out-of-range index is treated as closed rather than silently rendering a different image.
- CSS: the button is `all: unset` and fills the card edge-to-edge (the image *is* the affordance), with `cursor: zoom-in` and a `:focus-visible` ring inset to the card radius.

## Verification

- `npm test` in `frontend/` green (unit + hooks).
- New structural assertions in `attachmentSizing.test.js` pin the button (not a click handler on the `<img>`), the shared lightbox, the gallery hand-off, and the CSS rule.
- Driven live in the running shell at 393×793: attached one image, tapped the thumbnail, viewer opened; closed it and the attachment was still pending and sendable. Attached two, opened the second (`Image 2 of 2`), paged back to the first with the previous control, closed, and removed both.