### PR TITLE
Keep the composer + menu inside its pane so Attach files stays tappable

### DIFF
--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -2040,10 +2040,15 @@
   bottom: calc(100% + 8px);
   left: 0;
   width: 296px;
-  /* `dvh` (dynamic viewport height) shrinks when the soft keyboard
-     opens, so the popover never extends past the visible area. Cap
-     at ~50% of the visible viewport so the user can always see
-     some chat above; absolute 420px cap on tall screens. */
+  /* FALLBACK ONLY — the real cap is an inline `max-height` measured in
+     ComposerPopover.jsx from the space above the trigger inside
+     `visualViewport`, and it wins over this rule. `dvh` cannot do the job:
+     iOS Safari does NOT shrink the layout viewport (so not `dvh`/`vh`) for
+     the soft keyboard, so a dvh-derived cap let the panel's top — the
+     Attach files row — render above the top of the screen, unreachable,
+     whenever the keyboard was up. See composerPopoverHeight.js. This value
+     covers the frame before the measurement lands and non-visualViewport
+     environments (jsdom, very old browsers). */
   max-height: min(50dvh, 420px);
   overflow-y: auto;
   background: var(--surface); /* CONTRACT: opaque card/panel fill, sits on --bg */

--- a/frontend/src/components/ChatView/ComposerPopover.jsx
+++ b/frontend/src/components/ChatView/ComposerPopover.jsx
@@ -65,6 +65,7 @@ import { Plus, Paperclip } from '@openai/apps-sdk-ui/components/Icon'
 import FileText from 'lucide-react/dist/esm/icons/file-text.mjs'
 import Info from 'lucide-react/dist/esm/icons/info.mjs'
 import ChatSettingsPanel from './ChatSettingsPanel.jsx'
+import { popoverMaxHeight, nearestClipTop } from './composerPopoverHeight.js'
 
 export default function ComposerPopover({
   chatInfo,
@@ -113,6 +114,36 @@ export default function ComposerPopover({
   // between the click handler and the post-commit effect, leaving
   // the ref stale. Sync capture in onClick is reliable.
   const wasInputFocusedRef = useRef(false)
+  // Measured cap on the panel's height: the space above the trigger inside both
+  // the chat pane (which clips with `overflow: hidden`) and the keyboard-shrunk
+  // visible viewport. See composerPopoverHeight.js for why CSS viewport units
+  // can't express either boundary.
+  const [maxHeight, setMaxHeight] = useState(null)
+
+  useEffect(() => {
+    if (!open) return
+    const measure = () => {
+      const trigger = triggerRef.current
+      if (!trigger) return
+      setMaxHeight(popoverMaxHeight({
+        triggerTop: trigger.getBoundingClientRect().top,
+        viewportTop: window.visualViewport?.offsetTop || 0,
+        clipTop: nearestClipTop(trigger),
+      }))
+    }
+    measure()
+    // The keyboard animates in/out, and iOS scrolls the layout viewport during
+    // that animation, so re-measure on every viewport event for as long as the
+    // panel is open rather than trusting the open-time measurement.
+    window.addEventListener('resize', measure)
+    window.visualViewport?.addEventListener('resize', measure)
+    window.visualViewport?.addEventListener('scroll', measure)
+    return () => {
+      window.removeEventListener('resize', measure)
+      window.visualViewport?.removeEventListener('resize', measure)
+      window.visualViewport?.removeEventListener('scroll', measure)
+    }
+  }, [open])
 
   useEffect(() => {
     if (!open) return
@@ -200,7 +231,12 @@ export default function ComposerPopover({
         <Plus width={26} height={26} />
       </button>
       {open && (
-        <div className="composer-popover" role="dialog" aria-label="Chat options">
+        <div
+          className="composer-popover"
+          role="dialog"
+          aria-label="Chat options"
+          style={maxHeight ? { maxHeight: `${maxHeight}px` } : undefined}
+        >
           <div className="composer-popover__section">
             <button
               type="button"

--- a/frontend/src/components/ChatView/__tests__/composerPopoverHeight.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerPopoverHeight.test.js
@@ -1,0 +1,40 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  popoverMaxHeight,
+  POPOVER_CAP,
+  POPOVER_FLOOR,
+} from '../composerPopoverHeight.js'
+
+test('caps at POPOVER_CAP when there is plenty of room above the trigger', () => {
+  // Keyboard down on a 793px-tall phone: trigger near the bottom.
+  assert.equal(popoverMaxHeight({ triggerTop: 700 }), POPOVER_CAP)
+})
+
+test('fits the space above the trigger when the keyboard shrinks the viewport', () => {
+  // The old dvh cap asked for 420px here, which put the panel's top ~120px
+  // above the visible area.
+  assert.equal(popoverMaxHeight({ triggerTop: 300 }), 284)
+})
+
+test('subtracts the visual viewport offset (iOS scrolls the layout viewport)', () => {
+  // Same trigger position on screen, but iOS has scrolled the layout viewport
+  // down by 200px, so rect.top is 200 larger while the room is unchanged.
+  assert.equal(popoverMaxHeight({ triggerTop: 500, viewportTop: 200 }), 284)
+})
+
+test('stays inside the clipping pane, which is stricter than the viewport', () => {
+  // Phone, keyboard up: `.chat` starts at y=99 (below the shell header) and the
+  // + button sits at y=294. Anything above 99 is clipped by the pane's
+  // `overflow: hidden` and hit-tests to the shell header — the reported bug.
+  assert.equal(popoverMaxHeight({ triggerTop: 294, viewportTop: 0, clipTop: 99 }), 179)
+})
+
+test('takes the viewport boundary when it is below the pane top', () => {
+  assert.equal(popoverMaxHeight({ triggerTop: 500, viewportTop: 200, clipTop: 40 }), 284)
+})
+
+test('never returns less than POPOVER_FLOOR', () => {
+  assert.equal(popoverMaxHeight({ triggerTop: 40 }), POPOVER_FLOOR)
+  assert.equal(popoverMaxHeight({ triggerTop: 0 }), POPOVER_FLOOR)
+})

--- a/frontend/src/components/ChatView/composerPopoverHeight.js
+++ b/frontend/src/components/ChatView/composerPopoverHeight.js
@@ -1,0 +1,79 @@
+/**
+ * How tall the composer popover is allowed to be.
+ *
+ * The popover drops UP from the `+` trigger, so its usable height is the space
+ * between the trigger's top edge and the nearest boundary above it. There are
+ * TWO such boundaries and the fix needs the lower (more restrictive) one:
+ *
+ *   1. The popover's CLIPPING ANCESTOR. `.chat` is `overflow: hidden`, so
+ *      anything the panel renders above the chat pane's top edge is clipped
+ *      away — invisible AND untappable (hit-testing lands on the shell header
+ *      painted there instead). The panel cannot escape by z-index either: the
+ *      pane is its own stacking layer below the shell chrome, by design.
+ *   2. The VISIBLE VIEWPORT top (`visualViewport`), for the case where the
+ *      pane itself extends above the visible area.
+ *
+ * WHY NOT `dvh`: iOS Safari does not shrink the layout viewport — and therefore
+ * not `dvh`/`vh` — when the soft keyboard opens; `interactive-widget` is a
+ * Chromium feature. So `max-height: min(50dvh, 420px)` measured ~420px of
+ * FULL-screen height while the keyboard had pushed the trigger up to ~1/3 of
+ * the screen. The panel's top rows — Attach files first — landed outside the
+ * pane and were unreachable: scrolling the panel moves content further up, and
+ * the page behind it can't scroll to them either.
+ */
+
+/** Gap between the popover's bottom edge and the trigger (matches the CSS). */
+export const POPOVER_GAP = 8
+/** Breathing room so the panel never kisses the boundary above it. */
+export const POPOVER_TOP_MARGIN = 8
+/** Upper bound on tall screens — a full-height panel reads as a takeover. */
+export const POPOVER_CAP = 420
+/**
+ * Floor. Below this the panel is useless, so we'd rather let it overflow than
+ * render a 40px slit; in practice only reachable on a landscape phone with the
+ * keyboard up, where the trigger sits very near the top of its pane.
+ */
+export const POPOVER_FLOOR = 160
+
+/**
+ * Top edge (in client coordinates) of the nearest ancestor that would clip the
+ * popover. Returns 0 when nothing clips, so the caller falls back to the
+ * viewport boundary alone.
+ *
+ * `overflow: visible` is the only non-clipping value; `hidden`, `auto`,
+ * `scroll`, and `clip` all cut the panel off. Checking the computed value
+ * rather than hardcoding `.chat` keeps this correct for tiled panes, embedded
+ * app chats, and any future container that wraps the composer.
+ */
+export function nearestClipTop(el) {
+  let node = el?.parentElement || null
+  while (node && node !== document.body) {
+    const style = window.getComputedStyle(node)
+    if (style.overflowY !== 'visible' || style.overflowX !== 'visible') {
+      return node.getBoundingClientRect().top
+    }
+    node = node.parentElement
+  }
+  return 0
+}
+
+/**
+ * @param {object} m
+ * @param {number} m.triggerTop     trigger's `getBoundingClientRect().top`
+ * @param {number} [m.viewportTop]  `visualViewport.offsetTop` (0 when absent)
+ * @param {number} [m.clipTop]      `nearestClipTop(trigger)` (0 when none)
+ * @param {number} [m.cap]
+ * @param {number} [m.floor]
+ * @returns {number} max-height in CSS pixels
+ */
+export function popoverMaxHeight({
+  triggerTop,
+  viewportTop = 0,
+  clipTop = 0,
+  cap = POPOVER_CAP,
+  floor = POPOVER_FLOOR,
+}) {
+  const boundary = Math.max(viewportTop, clipTop)
+  const space = triggerTop - boundary - POPOVER_GAP - POPOVER_TOP_MARGIN
+  return Math.max(floor, Math.min(cap, Math.floor(space)))
+}


### PR DESCRIPTION
On a phone with the soft keyboard open, tapping `+` in the chat composer opened the options popover with its top rows — **Attach files** first — cut off and impossible to reach. Scrolling the panel made it worse rather than better, so attaching a file mid-message was simply not possible without dismissing the keyboard first.

| Before | After |
| --- | --- |
| ![Attach files clipped away above the pane](https://raw.githubusercontent.com/eldarkurtic/mobius/assets/composer-popover-pane-clip/before-keyboard-open.png) | ![Attach files visible at the top of the panel](https://raw.githubusercontent.com/eldarkurtic/mobius/assets/composer-popover-pane-clip/after-keyboard-open.png) |

*A 393px-wide viewport with the bottom ~440px covered, i.e. the keyboard-open geometry of an iPhone.*

## Root cause

The panel's height was capped in CSS with `max-height: min(50dvh, 420px)`, on the assumption that `dvh` shrinks when the soft keyboard opens. It does not on iOS Safari: `interactive-widget=resizes-content` is a Chromium feature, and WebKit leaves the layout viewport (and therefore `dvh`/`vh`) at full screen height while the keyboard covers the bottom of the screen.

So with the keyboard up the panel still asked for ~420px of a ~790px screen, while the trigger had been pushed to roughly a third of the way down. The panel drops *upward* from the trigger, so its top rows landed outside `.chat`, which clips with `overflow: hidden`. Those rows were not merely off-screen: they were clipped away entirely, and hit-testing at their coordinates returned the shell header painted there instead. Scrolling the panel could not recover them either, since scrolling moves content further up and out of the pane. The panel also cannot escape by `z-index` — the pane is its own stacking layer beneath the shell chrome by design.

## Fix

Measure the cap instead of expressing it in viewport units, taking the more restrictive of two boundaries above the trigger:

1. the top edge of the nearest **clipping ancestor** (any computed `overflow` other than `visible`), which is what actually cut the panel off, and
2. `visualViewport`'s top — the only surface that reports the keyboard-shrunk region on both engines — for the case where the pane itself extends above the visible area.

The measurement re-runs on viewport `resize`/`scroll` while the panel is open, because the keyboard animates in and out and iOS scrolls the layout viewport during that animation. Walking to the clipping ancestor rather than hardcoding `.chat` keeps this correct for tiled panes and embedded app chats. The CSS value stays as a pre-measurement fallback for jsdom and engines without `visualViewport`.

Keyboard-down behaviour is unchanged: with room to spare the panel still caps at 420px.

## Testing

- New unit tests for the sizing rule (`composerPopoverHeight.test.js`), covering the cap, the keyboard-shrunk viewport, the `visualViewport` offset, the clipping-pane boundary, and the floor.
- `npm test` green (1949 lib/component + 51 hook tests).
- Verified in a headless browser reproducing the iOS geometry — full-height layout viewport with the bottom covered — confirming the panel now fits inside the pane and `elementFromPoint` on the Attach files row returns the row itself rather than the shell header.
- Not yet exercised on physical iOS hardware; the real WebKit keyboard animation is outside what a headless browser can drive.

Co-authored-by: Möbius Agent <mobius-agent@users.noreply.github.com>