### PR TITLE
fix(chat): publish the steer cut where the transcript actually splits

### DIFF
--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -61,6 +61,7 @@ from app.chat_writer import (
   StashToolOutput,
   alloc_run_token,
   await_ack as _await_ack,
+  cid_of,
   get_writer,
   next_message_ts as _next_message_ts,
   update_last_assistant_message as _update_last_assistant_message,
@@ -224,6 +225,44 @@ def active_sink_memory_diagnostics(*, include_payloads: bool = True) -> list[dic
       "pending_lifecycle_writes": len(sink._lifecycle_writes),
     })
   return diagnostics
+
+
+def steered_into_turn_event(stored_messages: list[dict]) -> dict:
+  """Build the `steered_into_turn` SSE payload for a batch of steered rows.
+
+  `steered_into_turn` is the AUTHORITATIVE CUT and the client's ONLY "seal the
+  live stream here and re-base it" signal. It means the transcript split has
+  COMMITTED: A1 sealed, these rows appended after it, the sink reset for A2. So
+  it may only be published from the instant the split really happens — by the
+  Claude runner immediately after `split_for_steer`, and by the steer route for
+  Codex (whose `turn.steer()` has no interrupt boundary, so the route IS the
+  seal point). Two publishers, one builder, so the wire shape cannot drift.
+
+  Publishing it at HTTP arrival on the deferred (Claude) path is what made a
+  steer paint duplicated output for the rest of the turn: every block the runner
+  streamed between arrival and the real seal was accumulated into the sealed A1
+  AND left at the head of the client's freshly re-based stream. The deferred
+  path publishes NOTHING at arrival — the 202's own `pending_messages` is what
+  keeps the accepted row visible until the cut, so there is no second channel
+  reconciling the same tray.
+  """
+  return {
+    "type": "steered_into_turn",
+    "messages": [
+      {
+        "role": "user",
+        "ts": msg.get("ts"),
+        "cid": cid_of(msg),
+        "content": msg.get("content", ""),
+        **({"attachments": msg.get("attachments")} if msg.get("attachments") else {}),
+      }
+      for msg in stored_messages
+    ],
+    # Backward-compatible shape for any existing client still expecting a
+    # single steered row.
+    "ts": stored_messages[-1].get("ts"),
+    "content": stored_messages[-1].get("content", ""),
+  }
 
 
 class _ChatEventSink:

--- a/backend/app/claude_sdk_runner.py
+++ b/backend/app/claude_sdk_runner.py
@@ -408,13 +408,26 @@ class ActiveClaudeClient:
     bound at the call site; this inner timeout protects any other
     direct caller.
 
-    Stop is the hard, immediate-cut path: it drops any buffered steer
-    (clearing `pending_steer` + `_steer_requested` so no boundary cut or
-    requery fires for work the user just abandoned) and interrupts the
-    live turn right now, without waiting for a content-block boundary.
+    Stop is the hard, immediate-cut path: it drops the buffered steer
+    ENTIRELY — the provider-facing text (`pending_steer` + `_steer_requested`,
+    so no boundary cut or requery fires for work the user just abandoned) AND
+    the transcript-side rows (`_steer_user_msgs` + `_steer_consume_cids`, so the
+    turn-end seal appends nothing).
+
+    Both halves have to go, because Stop OWNS those rows from here on: a
+    deferred steer's row is still a durable entry in `chat.pending_messages`
+    (the split that would consume it never ran), `/chat/stop` clears that queue
+    and reports the cleared cids, and the client re-sends exactly them as one
+    fresh turn. Leaving the rows buffered meant the dying turn's seal appended
+    the same row into the transcript while the client re-sent it — the row
+    appeared twice, once interrupted and once answered. Nothing is lost by
+    dropping them here: they were never in the transcript, and Stop's own
+    clear-and-resend path is what preserves them.
     """
     self.pending_steer = []
     self._steer_requested = False
+    self._steer_user_msgs = []
+    self._steer_consume_cids = []
     await self._client.interrupt()
     try:
       await asyncio.wait_for(asyncio.shield(self._finished), timeout=5.0)
@@ -506,18 +519,32 @@ async def _seal_steer_split(bc, active_client, chat_id: str) -> None:
 
   Called at each requery boundary (so A1 is sealed before the answer A2
   streams) AND unconditionally in the turn-end `finally` (so a steer that was
-  buffered but never sealed — an exception/early-return before the requery, or
-  a hard Stop that cleared `pending_steer` — is still persisted rather than
-  discarded with the handle). A1 is the sink's accumulated pre-interrupt
-  content — complete once the turn closes — so `split_for_steer` seals it as
-  its own message, appends the steered row(s) after it, and resets the sink so
-  A2 lands fresh: reload order Q1, A1, Q2, A2.
+  buffered but never sealed — an exception/early-return before the requery — is
+  still persisted rather than discarded with the handle). A hard Stop is NOT one
+  of those cases: `interrupt()` drops the buffered rows outright because Stop's
+  clear-and-resend path owns them from that point (see `interrupt`), so the
+  finally finds an empty buffer and appends nothing to the turn it just killed.
+
+  A1 is the sink's accumulated pre-interrupt content — complete once the turn
+  closes — so `split_for_steer` seals it as its own message, appends the steered
+  row(s) after it, and resets the sink so A2 lands fresh: reload order Q1, A1,
+  Q2, A2.
 
   This is the fix for the steer-merge: the route cannot know where A1 ends (at
   HTTP arrival A1 has not streamed yet, so a route-side split sealed an empty
   A1 and the real A1 then merged with A2 after the steered row), but the runner
   does. `bc` is the live `_ChatEventSink`; a non-sink `bc` (legacy path / a
   test double) cannot persist here and drops the buffered rows.
+
+  This is ALSO where the client's cut lands. `steered_into_turn` is the client's
+  only "seal the live stream here and re-base it" signal, so it must be
+  published from the same instant as the durable split — deferring the split to
+  here while the route published the cut at HTTP arrival meant every block
+  streamed in between was BOTH folded into the sealed A1 and left at the head of
+  the client's re-based stream, painting twice for the rest of the turn. No
+  split (no live sink, or a failed write) publishes no cut: the client must
+  never re-base earlier than the server's actual seal. A split with no
+  publisher is the one asymmetric case — it commits and logs, see below.
 
   Durability contract (adversarial-review hardening):
   - The rows are snapshotted BEFORE the await and only the snapshotted count is
@@ -535,6 +562,27 @@ async def _seal_steer_split(bc, active_client, chat_id: str) -> None:
     return
   consume = list(active_client._steer_consume_cids)
   split = getattr(bc, "split_for_steer", None)
+  # Resolve the client-facing publisher BEFORE committing anything. Take the
+  # broadcast off the SINK rather than re-resolving it by chat_id: the cut
+  # belongs in the same event log that carries A1's blocks (so a reconnect
+  # replays the boundary at its true position), and a lookup could hand back a
+  # successor turn's broadcast when this runs from the turn-end `finally`.
+  #
+  # A missing publisher does NOT abort the split: the rows are already durable
+  # in the pending queue and the client was told the steer landed, so
+  # persistence wins over notification. It does mean this seal produces no cut,
+  # leaving the client's live stream un-rebased until its next authoritative
+  # fetch — a real divergence, so it is logged loudly here rather than returned
+  # away silently after the write has already committed.
+  raw_bc = getattr(bc, "bc", None)
+  if raw_bc is not None and not callable(getattr(raw_bc, "publish", None)):
+    raw_bc = None
+  if split is not None and raw_bc is None:
+    log.error(
+      "steer split has no broadcast to publish the cut on chat_id=%s; "
+      "the transcript will be split but the client stream cannot re-base "
+      "until it refetches", chat_id,
+    )
   if split is None:
     # No live sink (legacy/test caller): there is no streamed A1 to seal
     # against and no way to persist here — drop the buffer.
@@ -544,7 +592,7 @@ async def _seal_steer_split(bc, active_client, chat_id: str) -> None:
     )
     return
   try:
-    await split(rows, consume)
+    stored_result = await split(rows, consume)
   except Exception:
     # Leave the buffer intact so the turn-end finally retries the write.
     log.exception(
@@ -557,6 +605,33 @@ async def _seal_steer_split(bc, active_client, chat_id: str) -> None:
   active_client._steer_consume_cids = (
     active_client._steer_consume_cids[len(consume):]
   )
+  # Publish the cut now that A1 + Q2 are committed, on the broadcast resolved
+  # above. No await separates the split from this publish, so no continuation
+  # block can slip in front of it.
+  if raw_bc is None:
+    return
+  from app.chat import steered_into_turn_event
+
+  stored_messages = (
+    stored_result.get("stored_messages") if isinstance(stored_result, dict)
+    else None
+  )
+  if not isinstance(stored_messages, list) or not stored_messages:
+    # The writer echoes the rows it stored; fall back to the rows we handed it
+    # so an older/leaner ack shape still produces a well-formed cut.
+    stored_messages = rows
+  try:
+    raw_bc.publish(steered_into_turn_event(stored_messages))
+  except Exception:
+    # The split already COMMITTED, so failing to announce it is a notification
+    # loss, not a durability one — same asymmetry as the missing-publisher case
+    # above. Swallow and log: this function is awaited from the turn-end
+    # `finally`, where a raise would skip unregistering the handle and
+    # disconnecting the client, leaving the chat looking permanently live.
+    log.exception(
+      "publishing the steer cut failed chat_id=%s; the split committed but the "
+      "client stream cannot re-base until it refetches", chat_id,
+    )
 
 
 def _skill_file_read_name(

--- a/backend/app/routes/chats_stream.py
+++ b/backend/app/routes/chats_stream.py
@@ -21,6 +21,7 @@ from app.chat import (
   is_draining,
   mark_starting,
   run_chat,
+  steered_into_turn_event,
 )
 from app import chat_queue
 from app.chat_writer import (
@@ -409,16 +410,30 @@ async def _split_steer_at_route(
 
 
 def _steered_response(
-  chat_id: str, pending_messages: list[dict] | None = None,
+  chat_id: str,
+  pending_messages: list[dict] | None = None,
+  *,
+  cut_deferred: bool = False,
 ) -> JSONResponse:
   """202 for a message steered into the live turn.
 
-  The message is in the TRANSCRIPT (not the pending queue) and the live
-  turn already saw it via `steer()`, so the client renders it inline as
-  content growth rather than a queued-tray entry."""
+  The live turn has seen the message via `steer()`. Where the message LIVES
+  right now depends on the provider, and `cut_deferred` states which:
+
+  - absent/False (Codex): the transcript split already ran at the route, so the
+    row is in the TRANSCRIPT and out of the pending queue. The client drops its
+    queued-tray entry and renders the row inline as content growth.
+  - True (Claude): the split is deferred to the runner's interrupt boundary, so
+    the row is STILL in `pending_messages` (echoed above) and will move into the
+    transcript when the runner publishes `steered_into_turn` at the real seal.
+    The client keeps showing the queued row until then — dropping it here left
+    the owner's message with nowhere to render for the length of the window.
+  """
   payload = {"status": "steered", "chat_id": chat_id}
   if pending_messages is not None:
     payload["pending_messages"] = pending_messages
+  if cut_deferred:
+    payload["cut_deferred"] = True
   return JSONResponse(status_code=202, content=payload)
 
 
@@ -819,8 +834,10 @@ async def _send_message_locked(
     # Stop's queue-collapse path may pass force_steer to turn already
     # queued messages into a live steer. Codex injects into the running
     # SDK turn; Claude interrupts and re-prompts on the same client. On
-    # success the user message goes into the transcript and a
-    # `steered_into_turn` event tells the client to render it inline.
+    # success a `steered_into_turn` event tells the client the transcript has
+    # been split and the user row is in it — published here for Codex (the
+    # route is its seal point) and by the runner for Claude, whose split waits
+    # for the interrupt boundary (see the publish below).
     provider = chat.provider or "claude"
     if (
       is_chat_running(chat_id)
@@ -872,14 +889,16 @@ async def _send_message_locked(
           steered = False
       if steered:
         if defer_to_runner:
-          # The optimistic response mirrors the runner's cid conversion.
-          consumed = set(consume_cids)
+          # Nothing has been converted yet: the rows are buffered on the handle
+          # and remain in `chat.pending_messages` until the runner's seal
+          # consumes them. So report the queue AS IT IS — an optimistic list
+          # with the rows already subtracted told the client they had left the
+          # queue while the server still held them there, which is precisely
+          # the window the client must keep showing them (see `cut_deferred`
+          # on the response below).
           stored_result = {
             "stored_messages": user_msgs,
-            "pending": [
-              m for m in (chat.pending_messages or [])
-              if cid_of(m) not in consumed
-            ],
+            "pending": list(chat.pending_messages or []),
           }
         else:
           # Codex append and pending removal commit atomically for one cid.
@@ -900,31 +919,28 @@ async def _send_message_locked(
               status_code=503,
               detail="Could not save your message; please refresh.",
             )
-        bc = get_broadcast(chat_id)
-        if bc is not None:
-          stored_messages = stored_result.get("stored_messages")
-          if not isinstance(stored_messages, list) or not stored_messages:
-            stored = stored_result.get("stored") or user_msg
-            stored_messages = [stored]
-          bc.publish({
-            "type": "steered_into_turn",
-            "messages": [
-              {
-                "role": "user",
-                "ts": msg.get("ts"),
-                "cid": cid_of(msg),
-                "content": msg.get("content", ""),
-                **({"attachments": msg.get("attachments")} if msg.get("attachments") else {}),
-              }
-              for msg in stored_messages
-            ],
-            # Backward-compatible shape for any existing client still
-            # expecting a single steered row.
-            "ts": stored_messages[-1].get("ts"),
-            "content": stored_messages[-1].get("content", ""),
-          })
+        # `steered_into_turn` is the client's ONLY "cut the live stream here"
+        # signal, so it may only be published where the transcript is really
+        # split. Codex splits HERE (`_split_steer_at_route` above ran to
+        # completion), so the route is its seal point and publishes the cut
+        # unchanged. Claude defers the split to the runner's interrupt boundary,
+        # seconds later — publishing the cut here re-based the client's stream
+        # while the runner was still emitting blocks that the deferred seal then
+        # folded into A1, so those blocks painted twice for the rest of the turn.
+        # The deferred path publishes NOTHING here: the 202 below carries the
+        # still-queued row, which is the single signal that keeps it visible
+        # until `_seal_steer_split` publishes the cut.
+        if not defer_to_runner:
+          bc = get_broadcast(chat_id)
+          if bc is not None:
+            stored_messages = stored_result.get("stored_messages")
+            if not isinstance(stored_messages, list) or not stored_messages:
+              stored = stored_result.get("stored") or user_msg
+              stored_messages = [stored]
+            bc.publish(steered_into_turn_event(stored_messages))
         return _steered_response(
           chat_id, stored_result.get("pending"),
+          cut_deferred=defer_to_runner,
         )
       if body.force_steer:
         return _not_steered_response(chat_id)

--- a/backend/tests/test_chats_stream_steer.py
+++ b/backend/tests/test_chats_stream_steer.py
@@ -561,6 +561,154 @@ def test_seal_steer_split_retains_buffer_on_failure_and_delta_clears():
   asyncio.run(_run())
 
 
+def test_seal_publishes_the_cut_on_the_sinks_own_broadcast():
+  """The cut goes to the broadcast the SINK holds, never to a fresh lookup.
+
+  `_seal_steer_split` also runs from the turn-end `finally`, by which point a
+  successor turn can already have registered a NEW broadcast for the same chat.
+  Resolving by chat_id there would strand the cut in an event log no client is
+  reading: A1's blocks live in the old log, so the client would never re-base
+  and would paint the continuation onto the sealed segment for the rest of the
+  turn. Also covers a leaner writer ack (no `stored_messages`): the cut still
+  names the buffered rows rather than going out empty.
+  """
+  from app.broadcast import create_broadcast, get_broadcast
+  from app.claude_sdk_runner import _seal_steer_split
+
+  chat_id = "sealbroadcast"
+  handle = _make_active_claude_client(chat_id)
+  turn_bc = create_broadcast(chat_id)
+
+  async def _run():
+    handle._steer_user_msgs = [
+      {"role": "user", "content": "Q2", "ts": 10, "cid": "c-q2"}
+    ]
+    handle._steer_consume_cids = ["c-q2"]
+
+    class _SinkLike:
+      """Mirrors `_ChatEventSink`: holds the broadcast it was built with."""
+
+      def __init__(self, bc):
+        self.bc = bc
+
+      async def split_for_steer(self, rows, consume):
+        # The writer ack shape without the echoed rows.
+        return {"pending": []}
+
+    # A successor turn registers its own broadcast before this seal runs.
+    successor_bc = create_broadcast(chat_id)
+    assert get_broadcast(chat_id) is successor_bc
+    assert successor_bc is not turn_bc
+
+    await _seal_steer_split(_SinkLike(turn_bc), handle, chat_id)
+
+    assert [e.get("type") for e in successor_bc.event_log] == []
+    cuts = [e for e in turn_bc.event_log if e.get("type") == "steered_into_turn"]
+    assert len(cuts) == 1
+    assert [m["content"] for m in cuts[0]["messages"]] == ["Q2"]
+    assert [m["cid"] for m in cuts[0]["messages"]] == ["c-q2"]
+
+  asyncio.run(_run())
+
+
+def test_a_failing_publisher_cannot_escape_the_seal():
+  """Announcing the cut must never raise out of `_seal_steer_split`.
+
+  The turn-end `finally` awaits this function BEFORE it unregisters the handle
+  and disconnects the client, so an escaping exception would strand a live
+  handle in the registry and leave the chat looking permanently busy. The split
+  has already COMMITTED by the time the cut is published, so a broken publisher
+  is a notification loss, not a durability one — exactly the asymmetry the
+  missing-publisher branch already takes. Swallow it, log it, and still consume
+  the sealed rows so the turn-end retry does not double-append them.
+  """
+  from app.claude_sdk_runner import _seal_steer_split
+
+  chat_id = "sealpublishfail"
+  handle = _make_active_claude_client(chat_id)
+
+  async def _run():
+    handle._steer_user_msgs = [
+      {"role": "user", "content": "Q2", "ts": 10, "cid": "c-q2"}
+    ]
+    handle._steer_consume_cids = ["c-q2"]
+
+    class _ExplodingBroadcast:
+      def publish(self, event):
+        raise RuntimeError("broadcast is gone")
+
+    class _SinkLike:
+      def __init__(self, bc):
+        self.bc = bc
+        self.splits = 0
+
+      async def split_for_steer(self, rows, consume):
+        self.splits += 1
+        return {"stored_messages": list(rows)}
+
+    sink = _SinkLike(_ExplodingBroadcast())
+    await _seal_steer_split(sink, handle, chat_id)
+
+    assert sink.splits == 1
+    # The rows were committed, so they must not be re-appended by the retry.
+    assert handle._steer_user_msgs == []
+    assert handle._steer_consume_cids == []
+
+  asyncio.run(_run())
+
+
+def test_stop_drops_the_buffered_steer_instead_of_appending_it():
+  """A hard Stop abandons a deferred steer ENTIRELY.
+
+  Stop's contract: `/chat/stop` clears `chat.pending_messages`, reports the
+  cleared cids, and the client re-sends exactly them as one fresh turn. A
+  deferred steer's row is still IN that queue (its split never ran), so if the
+  runner kept the row buffered, the turn-end seal appended it to the turn Stop
+  had just killed while the client re-sent it — the same message twice, once
+  interrupted and once answered. `interrupt()` therefore clears the
+  transcript-side buffer too, which makes the finally's seal a no-op.
+  """
+  from app.claude_sdk_runner import ActiveClaudeClient, _seal_steer_split
+
+  class _Client:
+    async def interrupt(self):
+      return None
+
+  async def _run():
+    # Built inside THIS loop: interrupt() waits on `_finished`, which is
+    # loop-bound, so a handle constructed in a throwaway loop cannot be awaited
+    # here. mark_finished() stands in for the runner's own teardown.
+    handle = ActiveClaudeClient(_Client(), chat_id="stopsteer")
+    handle.mark_finished()
+    handle.pending_steer = ["Q2"]
+    handle._steer_requested = True
+    handle._steer_user_msgs = [
+      {"role": "user", "content": "Q2", "ts": 10, "cid": "c-q2"}
+    ]
+    handle._steer_consume_cids = ["c-q2"]
+
+    await handle.interrupt()
+
+    assert handle.pending_steer == []
+    assert handle._steer_requested is False
+    assert handle._steer_user_msgs == []
+    assert handle._steer_consume_cids == []
+
+    # The turn-end catch-all now has nothing to append.
+    class _Bc:
+      def __init__(self):
+        self.splits = 0
+
+      async def split_for_steer(self, rows, consume):
+        self.splits += 1
+
+    bc = _Bc()
+    await _seal_steer_split(bc, handle, "stopsteer")
+    assert bc.splits == 0
+
+  asyncio.run(_run())
+
+
 def test_claude_force_steer_defers_to_runner_and_reorders(client, auth):
   """A Claude fast-forward (force_steer) defers its split to the runner, same
   as an ordinary steer, so the fast-forwarded rows land AFTER the sealed
@@ -974,6 +1122,12 @@ def test_steers_into_live_claude_turn_reserves_durable_pending(
 
   assert res.status_code == 202, res.text
   assert res.json()["status"] == "steered"
+  # The split is deferred, so the response says so and echoes the row as the
+  # still-queued row it is; the client keeps showing it until the cut.
+  assert res.json()["cut_deferred"] is True
+  assert [m["content"] for m in res.json()["pending_messages"]] == [
+    "actually use blue"
+  ]
 
   chat = _read_chat(chat_id)
   assert [m["content"] for m in chat.pending_messages] == ["actually use blue"]
@@ -986,21 +1140,14 @@ def test_steers_into_live_claude_turn_reserves_durable_pending(
   assert cid_of(handle._steer_user_msgs[0]) == reserved_cid
   assert handle._steer_consume_cids == [reserved_cid]
 
-  # A `steered_into_turn` event was broadcast for the inline render.
+  # NO event at HTTP arrival on the deferred path. The 202's own
+  # `pending_messages` (asserted above) is the single signal that keeps the row
+  # visible; the CUT (`steered_into_turn`) belongs to the runner's seal — see
+  # test_claude_steer_cut_event_is_published_at_the_seal_not_at_http_arrival.
+  # A second "accepted" event reconciling the same tray would be a parallel
+  # channel racing the response it duplicates.
   bc = get_broadcast(chat_id)
-  steered_events = [
-    e for e in bc.event_log if e.get("type") == "steered_into_turn"
-  ]
-  assert len(steered_events) == 1
-  assert steered_events[0]["content"] == "actually use blue"
-  assert steered_events[0]["messages"] == [
-    {
-      "role": "user",
-      "ts": handle._steer_user_msgs[0]["ts"],
-      "cid": reserved_cid,
-      "content": "actually use blue",
-    }
-  ]
+  assert bc.event_log == []
 
 
 def test_claude_runner_splits_steer_at_boundary_not_http_arrival(
@@ -1072,6 +1219,160 @@ def test_claude_runner_splits_steer_at_boundary_not_http_arrival(
   # The runner consumed the buffered payload (no double-split on turn end).
   assert handle._steer_user_msgs == []
   assert _read_chat(chat_id).pending_messages in (None, [])
+
+
+def test_claude_steer_cut_event_is_published_at_the_seal_not_at_http_arrival(
+  client, auth,
+):
+  """`steered_into_turn` is the client's only "cut the live stream here" signal,
+  so on the deferred (Claude) path it must be published by the runner at the
+  seal — AFTER every block that belongs to A1 — and never by the route.
+
+  The regression this pins: the route published the cut at HTTP arrival while
+  the split stayed at the runner's interrupt boundary seconds later. Everything
+  Claude streamed in the gap was accumulated into the sealed A1 AND kept at the
+  head of the client's freshly re-based stream, so it painted twice for the rest
+  of the turn. The window is never empty — the AssistantMessage that triggers
+  the boundary interrupt is dispatched to the broadcast before the interrupt
+  check runs — so this duplicated on EVERY Claude steer.
+  """
+  from app.chat import _ChatEventSink, register_active_sink
+  from app.claude_sdk_runner import _seal_steer_split
+
+  chat_id = "claudecutorder"
+  db = SessionLocal()
+  try:
+    db.add(models.Chat(
+      id=chat_id, title="Claude chat", provider="claude",
+      messages=[{"role": "user", "content": "Q1", "ts": 1}],
+      agent_settings_json={"steer_enabled": True},
+    ))
+    db.commit()
+  finally:
+    db.close()
+  handle = _make_active_claude_client(chat_id)
+  registry.register(handle)
+  bc = create_broadcast(chat_id)
+  sink = _ChatEventSink(bc, chat_id, run_token="run-cut-order")
+  register_active_sink(chat_id, sink)
+
+  # A1's first block is already on the wire when the steer POST arrives.
+  sink.publish({"type": "text", "content": "A1 first"})
+
+  res = client.post(
+    f"/api/chats/{chat_id}/messages",
+    json={"content": "Q2"}, headers=auth,
+  )
+  assert res.status_code == 202, res.text
+  assert res.json()["status"] == "steered"
+
+  # HTTP arrival publishes NOTHING on the deferred path: the response body is
+  # the display signal. Publishing the cut here re-based the client's stream
+  # too early.
+  assert [e.get("type") for e in bc.event_log] == ["text"]
+
+  async def _drive_runner():
+    # The rest of A1 streams AFTER arrival — the duplication window.
+    sink.publish({"type": "text", "content": " A1 rest"})
+    await _seal_steer_split(sink, handle, chat_id)
+    # A2's first block follows the seal. It exists here so the cut's position
+    # is pinned from BOTH sides: a cut that slipped in front of a continuation
+    # block would fold A2's head into the sealed A1 and re-base after it —
+    # the mirror image of the fixed bug, and invisible to a lower bound alone.
+    sink.publish({"type": "text", "content": "A2 head"})
+
+  asyncio.run(_drive_runner())
+
+  # The cut is published exactly once, at the seal: after every A1 block and
+  # before every A2 block.
+  cut_positions = [
+    i for i, e in enumerate(bc.event_log)
+    if e.get("type") == "steered_into_turn"
+  ]
+  assert len(cut_positions) == 1
+  # The sink coalesces contiguous text into one event per segment, so the whole
+  # of A1 is one event and A2's head is another. Both bounds matter: after the
+  # last A1 event (the fixed bug) AND before the first A2 event (its mirror
+  # image, which would fold A2's head into the sealed A1).
+  text_positions = [
+    i for i, e in enumerate(bc.event_log) if e.get("type") == "text"
+  ]
+  assert [bc.event_log[i].get("content") for i in text_positions] == [
+    "A1 first A1 rest", "A2 head",
+  ]
+  assert text_positions[0] < cut_positions[0] < text_positions[1]
+  # The cut names the DURABLE rows the split committed, so the client inserts
+  # the same identity the transcript now holds.
+  cut = bc.event_log[cut_positions[0]]
+  steered_row = [m for m in _read_chat(chat_id).messages if m["role"] == "user"][-1]
+  assert cut["messages"] == [{
+    "role": "user",
+    "ts": steered_row["ts"],
+    "cid": cid_of(steered_row),
+    "content": "Q2",
+  }]
+  # And A1 really was sealed at the boundary the cut names.
+  assert [(m["role"], m.get("content")) for m in _read_chat(chat_id).messages] == [
+    ("user", "Q1"),
+    ("assistant", "A1 first A1 rest"),
+    ("user", "Q2"),
+  ]
+
+
+def test_codex_steer_still_publishes_the_cut_at_the_route(
+  client, auth, monkeypatch,
+):
+  """Codex is unaffected by moving the Claude cut.
+
+  Its `turn.steer()` injects into the SAME running turn, so the route's own
+  `_split_steer_at_route` IS the seal: signal and cut are the same instant
+  there. The route must therefore keep publishing `steered_into_turn` at
+  arrival, with the response shape unchanged (no `cut_deferred`).
+  """
+  chat_id = "codexcutroute"
+  db = SessionLocal()
+  try:
+    db.add(models.Chat(
+      id=chat_id, title="Codex chat", provider="codex",
+      messages=[{"role": "user", "content": "Q1", "ts": 1}],
+      agent_settings_json={"steer_enabled": True},
+    ))
+    db.commit()
+  finally:
+    db.close()
+  registry.register(_make_active_codex_turn(chat_id))
+  sink = _register_sink_with_partial(chat_id, "run-codex-cut", "A1")
+
+  async def _fake_steer(cid, message):
+    return True
+
+  monkeypatch.setattr(
+    "app.codex_sdk_runner.steer_into_active_turn", _fake_steer,
+  )
+
+  res = client.post(
+    f"/api/chats/{chat_id}/messages",
+    json={"content": "Q2"}, headers=auth,
+  )
+  assert res.status_code == 202, res.text
+  body = res.json()
+  assert body["status"] == "steered"
+  assert "cut_deferred" not in body
+  # The row left pending at the route, so the echoed queue no longer holds it.
+  assert body["pending_messages"] == []
+
+  bc = get_broadcast(chat_id)
+  assert [e.get("type") for e in bc.event_log] == ["steered_into_turn"]
+  cut = [e for e in bc.event_log if e.get("type") == "steered_into_turn"][0]
+  assert [m["content"] for m in cut["messages"]] == ["Q2"]
+  # The route sealed A1 and appended Q2 before publishing — the cut is
+  # truthful at the instant it is sent.
+  assert [(m["role"], m.get("content")) for m in _read_chat(chat_id).messages] == [
+    ("user", "Q1"),
+    ("assistant", "A1"),
+    ("user", "Q2"),
+  ]
+  assert sink.assistant_blocks == []
 
 
 def test_claude_reserved_row_survives_process_loss_and_sweep(

--- a/backend/tests/test_chats_stream_steer.py
+++ b/backend/tests/test_chats_stream_steer.py
@@ -611,6 +611,50 @@ def test_seal_publishes_the_cut_on_the_sinks_own_broadcast():
   asyncio.run(_run())
 
 
+def test_writer_dedup_still_publishes_the_committed_cut():
+  """An empty stored-row echo does not undo the split that just committed.
+
+  `split_for_steer` seals A1 and resets the sink BEFORE the writer appends the
+  steered row. `stored_messages: []` means only that cid dedup found the row
+  already in the durable transcript; it does not mean the A1/A2 boundary was
+  skipped. Suppressing the cut here would leave the client appending A2 to the
+  segment the server has already sealed. The handed row still supplies the cid
+  that retires its tray entry and identifies the already-durable user turn.
+  """
+  from app.broadcast import create_broadcast
+  from app.claude_sdk_runner import _seal_steer_split
+
+  chat_id = "sealdedup"
+  handle = _make_active_claude_client(chat_id)
+  turn_bc = create_broadcast(chat_id)
+
+  async def _run():
+    row = {"role": "user", "content": "Q2", "ts": 10, "cid": "c-q2"}
+    handle._steer_user_msgs = [row]
+    handle._steer_consume_cids = ["c-q2"]
+
+    class _SinkLike:
+      def __init__(self, bc):
+        self.bc = bc
+
+      async def split_for_steer(self, rows, consume):
+        assert rows == [row]
+        assert consume == ["c-q2"]
+        # The durable writer already has this cid, but the sink-side split still
+        # sealed A1 and reset its accumulator for A2.
+        return {"stored_messages": []}
+
+    await _seal_steer_split(_SinkLike(turn_bc), handle, chat_id)
+
+    cuts = [e for e in turn_bc.event_log if e.get("type") == "steered_into_turn"]
+    assert len(cuts) == 1
+    assert cuts[0]["messages"][0]["cid"] == "c-q2"
+    assert handle._steer_user_msgs == []
+    assert handle._steer_consume_cids == []
+
+  asyncio.run(_run())
+
+
 def test_a_failing_publisher_cannot_escape_the_seal():
   """Announcing the cut must never raise out of `_seal_steer_split`.
 

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -1262,13 +1262,18 @@ export default function ChatView({
     },
     onLiveQuestion: setLiveQuestionId,
     onSteeredIntoTurn: ({ ts, content, messages: steeredBatch }) => {
-      // A send was injected mid-turn into a live turn (steering — fired for
-      // both providers when Stop is pressed with a queued message). The
-      // backend seals the assistant text streamed so far, persists the user
-      // message, and then continues the assistant after that boundary. Mirror
-      // that exact shape locally: first promote the current live stream
-      // segment into `messages`, then append the steered user row, then let
-      // future text deltas build a fresh streaming assistant block.
+      // The steer's transcript split has COMMITTED (fired for both providers,
+      // including when Stop is pressed with a queued message): the backend has
+      // sealed the assistant text streamed up to the split, persisted the user
+      // message after it, and reset for the continuation. Mirror that exact
+      // shape locally: first promote the current live stream segment into
+      // `messages`, then append the steered user row, then let future text
+      // deltas build a fresh streaming assistant block.
+      //
+      // The split is the route's own write for Codex and the runner's seal for
+      // Claude, so this event always arrives AFTER the last block belonging to
+      // the sealed segment. That ordering is what makes promoting the live
+      // stream here correct; it is not a guess about where the server cut.
       //
       // It still follows the one visible-row scroll rule. Automatic queue
       // promotion keeps the original submit snapshot; an explicit fast-forward
@@ -1320,6 +1325,14 @@ export default function ChatView({
       // instead of blindly appending: if a fetch/replay already committed the
       // post-steer assistant row, the steered user still belongs before it.
       commitMessages(prev => insertMessageBatchByTs(prev, steeredMessages))
+      // The rows have now genuinely left `chat.pending_messages`, so retire the
+      // tray entries the deferred-cut window kept visible. A no-op on the
+      // route-split (Codex) path, where the send's own 202 already dropped
+      // them — the cut is simply the one place that owns the hand-off.
+      for (const msg of steeredMessages) {
+        const cid = cidOf(msg)
+        if (cid != null) pendingQueue.cancelByCid(cid)
+      }
       steerPinIntentRef.current = null
     },
   })
@@ -2214,14 +2227,48 @@ export default function ChatView({
             await handleSteerOneRef.current?.(cid)
           }
         }
-        // Mid-turn steer: the backend delivered the send into the live
-        // provider turn and persisted it in the transcript. The
-        // `steered_into_turn` SSE event (handled in useStreamConnection's
-        // onSteeredIntoTurn) renders the message inline, so drop the
-        // optimistic queued-tray entry here — it never queued.
+        // Mid-turn steer: the backend delivered the send into the live provider
+        // turn. Where the row LIVES right now is what `cut_deferred` states.
         if (result?.status === 'steered') {
-          pendingQueue.cancelByCid(queuedMsg.cid)
-          forgetQueuedPinIntent({ cid: queuedMsg.cid })
+          if (result.cut_deferred) {
+            // Claude: the transcript split waits for the runner's interrupt
+            // boundary, so the row is STILL queued server-side and its tray
+            // entry stays — dropping it here left the owner's message with
+            // nowhere to render for the whole deferred window. Resolve THIS
+            // send's own row and nothing else: confirm it by cid against the
+            // server's echoed entry (which carries the durable ts fast-forward
+            // needs).
+            //
+            // Not `hydrate(result.pending_messages)`: that list is a snapshot
+            // taken at steer time, and a wholesale reconcile against it is
+            // wrong in both directions. It would DROP a row queued and
+            // confirmed while this 202 was in flight (absent from the snapshot,
+            // no longer in-flight), and it would RESURRECT this row if the
+            // runner's cut landed first (the cut retires the tray entry, then
+            // the snapshot puts it back while it is already inline). Confirming
+            // one cid is a no-op once the cut has retired it, so the two can
+            // land in either order.
+            const serverRow = Array.isArray(result.pending_messages)
+              ? result.pending_messages.find(m => cidOf(m) === queuedMsg.cid)
+              : null
+            pendingQueue.confirmQueued(queuedMsg.cid, {
+              ts: serverRow?.ts ?? queuedMsg.ts,
+              position: serverRow?.position,
+              serverMsg: serverRow,
+            })
+            // The pin intent lives on in `inlineSteerPinIntentRef` (set at
+            // submit), which is what `onSteeredIntoTurn` reads at the cut. Its
+            // `takeQueuedPinIntent` fallback is short-circuited by that ref, so
+            // without this the map entry would never be taken and would leak
+            // for the life of the mounted chat.
+            forgetQueuedPinIntent({ cid: queuedMsg.cid })
+          } else {
+            // Codex: the split already ran at the route, so the row is in the
+            // transcript and `steered_into_turn` (already sent) renders it
+            // inline — drop the optimistic queued-tray entry, it never queued.
+            pendingQueue.cancelByCid(queuedMsg.cid)
+            forgetQueuedPinIntent({ cid: queuedMsg.cid })
+          }
         }
         // Race: server said "started" though we expected queued.
         if (result?.status === 'started') {
@@ -2270,7 +2317,10 @@ export default function ChatView({
         }
         // Invariant: every observable queue-path status must resolve
         // the optimistic entry's in-flight flag. queued/steered/started
-        // each clear it above (confirmQueued / cancelByCid). Any
+        // each clear it above, unconditionally, via confirmQueued or
+        // cancelByCid — including BOTH steered branches (confirmQueued when
+        // the cut is deferred, cancelByCid when the route already split), so
+        // no response shape can slip through leaving the mark set. Any
         // other status — e.g. streamSend's `not_steered` — leaves the
         // entry as an ordinary queued row, so clear the flag here or it
         // leaks forever and a later hydrate would wrongly preserve it.
@@ -2984,10 +3034,12 @@ export default function ChatView({
   // or waiting for turn-end (the default queue drain). Mirrors handleStop's
   // structure — re-entry guard, snapshot-before-await — but never
   // interrupts the running turn. The backend force-steers (bypassing the
-  // steer_enabled opt-in) for BOTH providers; on success the steered
-  // message lands in the transcript and renders inline via the
-  // `steered_into_turn` SSE event (onSteeredIntoTurn above), so we just
-  // drop those rows from the local tray.
+  // steer_enabled opt-in) for BOTH providers; the rows render inline when the
+  // `steered_into_turn` SSE event reports the transcript split (onSteeredIntoTurn
+  // above), and THAT is when they leave the local tray. Codex splits at the
+  // route, so the split is already done when the POST resolves; Claude splits at
+  // its next content-block boundary, so its 202 comes back `cut_deferred` and
+  // the rows stay in the tray until the cut lands.
   // The shared force-steer core: given serverTs-CONFIRMED queue rows (in
   // queue order), optimistically hide them, POST one force_steer selecting
   // them by cid, and reconcile or restore. Restore re-hydrates the full
@@ -3032,9 +3084,10 @@ export default function ChatView({
     let queueAfterOptimisticPromote = null
     function restoreOptimisticSteerQueue() {
       // If another path touched the queue while the POST was in flight
-      // (notably the natural turn-end drain), every pendingQueue mutation
-      // assigns a fresh array. In that case the other path won the race,
-      // so restoring our stale snapshot would resurrect duplicate chips.
+      // (notably the natural turn-end drain, or a deferred steer's own cut
+      // arriving before its 202 resolves), every pendingQueue mutation assigns
+      // a fresh array. In that case the other path won the race, so restoring
+      // our stale snapshot would resurrect duplicate chips.
       if (
         queueAfterOptimisticPromote !== null
         && pendingQueue.pendingMessagesRef.current === queueAfterOptimisticPromote
@@ -3067,6 +3120,13 @@ export default function ChatView({
       // visible "down, then up" fast-forward jump. Hide only the confirmed
       // rows this request is steering; restore the snapshot below if the
       // backend says the turn was not steered.
+      //
+      // A `cut_deferred` steer (Claude) puts these rows straight back below:
+      // they are still queued server-side until the runner's seal, and the pin
+      // is armed at the cut, not here, so this hide buys nothing there. We
+      // cannot know which case it is before the POST resolves, and the response
+      // restores them in the same round-trip, so the deferred path just doesn't
+      // get the pre-pin hide.
       pendingQueue.promoteManyByCid(consumePendingCids)
       queueAfterOptimisticPromote = pendingQueue.pendingMessagesRef.current
       const result = await streamSend(content, attachments, {
@@ -3080,13 +3140,24 @@ export default function ChatView({
         })),
       })
       if (result?.status === 'steered') {
-        // The steered rows now render inline (onSteeredIntoTurn promotes
-        // them from the SSE event + transcript). Drop them from the local
-        // tray. Reconcile against the server's authoritative remaining
-        // queue when present, else remove exactly the steered cids.
-        if (Array.isArray(result.pending_messages)) {
+        if (result.cut_deferred) {
+          // Claude: the split waits for the runner's interrupt boundary, so
+          // these rows are still queued server-side and the optimistic hide
+          // above has to come back. Undo it with the SAME identity-guarded
+          // restore the not_steered path uses, not with the response's echoed
+          // queue: that list is a snapshot from steer time, so re-adding from
+          // it would resurrect a row the cut had already retired (the cut can
+          // land before this 202 resolves) and would drop a row queued while
+          // the POST was in flight. The guard makes the restore a no-op exactly
+          // when something else — the cut included — already owns the queue.
+          restoreOptimisticSteerQueue()
+        } else if (Array.isArray(result.pending_messages)) {
+          // Codex: the route already split, so the echoed queue no longer holds
+          // these rows and onSteeredIntoTurn has rendered them inline.
           pendingQueue.hydrate(result.pending_messages)
         } else {
+          // A backend that echoes no queue at all: remove exactly the steered
+          // cids.
           for (const c of consumePendingCids) pendingQueue.cancelByCid(c)
         }
         forgetQueuedPinIntent({ cidList: consumePendingCids })
@@ -3111,10 +3182,12 @@ export default function ChatView({
   // or waiting for turn-end (the default queue drain). Mirrors handleStop's
   // structure — re-entry guard, snapshot-before-await — but never
   // interrupts the running turn. The backend force-steers (bypassing the
-  // steer_enabled opt-in) for BOTH providers; on success the steered
-  // message lands in the transcript and renders inline via the
-  // `steered_into_turn` SSE event (onSteeredIntoTurn above), so we just
-  // drop those rows from the local tray.
+  // steer_enabled opt-in) for BOTH providers; the rows render inline when the
+  // `steered_into_turn` SSE event reports the transcript split (onSteeredIntoTurn
+  // above), and THAT is when they leave the local tray. Codex splits at the
+  // route, so the split is already done when the POST resolves; Claude splits at
+  // its next content-block boundary, so its 202 comes back `cut_deferred` and
+  // the rows stay in the tray until the cut lands.
   async function handleSteer() {
     if (handlingSteerRef.current) return
     handlingSteerRef.current = true

--- a/frontend/src/components/ChatView/__tests__/steerCutBoundary.test.js
+++ b/frontend/src/components/ChatView/__tests__/steerCutBoundary.test.js
@@ -1,0 +1,195 @@
+/*
+ * Where a steer's CUT is published, and who reconciles the tray.
+ *
+ * `steered_into_turn` is the client's only "seal the live stream here and
+ * re-base it" signal. Publishing it at HTTP arrival while the transcript split
+ * waited for the Claude runner's interrupt boundary is what made a live turn
+ * paint duplicated output for the rest of the turn: every block streamed in
+ * between was folded into the sealed pre-steer message AND left at the head of
+ * the client's re-based stream. The cut now comes from the seal itself.
+ *
+ * The event POSITION and the resulting durable order are proven by execution in
+ * backend/tests/test_chats_stream_steer.py (the cut lands after the last
+ * pre-steer block and before the first continuation block, on the sink's own
+ * broadcast). What these tests pin is the client half of the same contract:
+ * ONE steer event, ONE tray reconciler per steer, and an order-independent
+ * reconcile on the deferred path. The queue mechanics that make it
+ * order-independent are executed against the real hook in
+ * hooks/__tests__/usePendingQueue.test.js.
+ */
+
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+const streamSource = readFileSync(
+  new URL('../useStreamConnection.js', import.meta.url),
+  'utf8',
+)
+const chatViewSource = readFileSync(
+  new URL('../ChatView.jsx', import.meta.url),
+  'utf8',
+)
+
+function sliceBranch(source, fromNeedle, toNeedle) {
+  const from = source.indexOf(fromNeedle)
+  assert.ok(from >= 0, `expected to find ${fromNeedle}`)
+  const to = source.indexOf(toNeedle, from)
+  assert.ok(to > from, `expected to find ${toNeedle} after ${fromNeedle}`)
+  return source.slice(from, to)
+}
+
+test('a steer has exactly one event and one tray reconciler', () => {
+  // The send's own 202 already carries `cut_deferred` + the still-queued row,
+  // so a second "accepted" SSE event would be a parallel channel reconciling
+  // the same tray from the same pre-cut snapshot — racing the response it
+  // duplicates. The steer wire has one event: the cut.
+  assert.ok(
+    !streamSource.includes('steer_accepted'),
+    'no second steer event may reconcile the tray beside the 202',
+  )
+  assert.ok(
+    !chatViewSource.includes('onSteerAccepted'),
+    'ChatView takes the accepted row from its own response, not a second event',
+  )
+  const steerEvents = [...streamSource.matchAll(/event\.type === '(steer[^']*)'/g)]
+    .map(m => m[1])
+  assert.deepEqual(steerEvents, ['steered_into_turn'])
+})
+
+test('only the cut re-bases the stream, and a replay refetches instead', () => {
+  const cut = sliceBranch(
+    streamSource,
+    "event.type === 'steered_into_turn'",
+    "event.type === 'done'",
+  )
+  assert.match(
+    cut, /flushBuffer\(\)/,
+    'the buffered pre-steer frame belongs to the sealed segment, not the next',
+  )
+  const replay = sliceBranch(cut, 'if (isCatchUp) {', '} else {')
+  assert.match(
+    replay, /catchUpItems = \[\]/,
+    'the cut is the boundary a reconnect reconstructs: drop everything '
+    + 'replayed before it, keep the continuation',
+  )
+  assert.ok(
+    !replay.includes('onSteeredIntoTurnRef'),
+    'promoting replayed items would duplicate the already-sealed segment',
+  )
+  assert.match(
+    replay, /onNeedsRefreshRef\.current\?\./,
+    'dropping the replayed segment is only truthful if the sealed message and '
+    + 'the steered row are loaded — a socket that died before the cut arrived '
+    + 'live has neither, so the replay asks for the authoritative read',
+  )
+})
+
+test('the cut hands the steered rows off the tray and into the transcript', () => {
+  const handler = sliceBranch(
+    chatViewSource,
+    'onSteeredIntoTurn: ({',
+    '\n  })\n',
+  )
+  assert.match(
+    handler,
+    /promoteStreamToMessages\(\{ keepTurnOpen: true \}\)/,
+    'the cut seals the live segment as its own message',
+  )
+  assert.match(
+    handler,
+    /pendingQueue\.cancelByCid\(cid\)/,
+    'the cut is when the rows genuinely leave chat.pending_messages',
+  )
+})
+
+test('a deferred steer resolves only its OWN row, in any order', () => {
+  // The 202's `pending_messages` is a snapshot from steer time, so the runner's
+  // cut can already have retired the row by the time it resolves. Confirming
+  // one cid is a no-op then; reconciling the whole tray against the snapshot
+  // would resurrect that row and drop anything queued since (proven on the
+  // real hook in usePendingQueue.test.js).
+  const steeredBranch = sliceBranch(
+    chatViewSource,
+    "if (result?.status === 'steered') {",
+    "if (result?.status === 'started') {",
+  )
+  const deferred = sliceBranch(steeredBranch, 'if (result.cut_deferred) {', '} else {')
+  assert.match(
+    deferred,
+    /pendingQueue\.confirmQueued\(queuedMsg\.cid, \{/,
+    'the deferred 202 confirms this send\'s row and keeps it in the tray',
+  )
+  assert.ok(
+    !deferred.includes('pendingQueue.hydrate'),
+    'a wholesale reconcile against the pre-cut snapshot is what drops a '
+    + 'concurrently-queued row and resurrects a retired one',
+  )
+  assert.match(
+    deferred,
+    /forgetQueuedPinIntent\(\{ cid: queuedMsg\.cid \}\)/,
+    'the cut reads the pin intent from inlineSteerPinIntentRef, so the map '
+    + 'entry must be released here or it leaks for the life of the chat',
+  )
+  assert.match(
+    steeredBranch,
+    /\} else \{[\s\S]*?pendingQueue\.cancelByCid\(queuedMsg\.cid\)/,
+    'a route-split (Codex) steer still drops the tray entry immediately',
+  )
+})
+
+test('every steered branch resolves the optimistic in-flight mark', () => {
+  // `clearInFlight`'s fallthrough deliberately excludes `steered`, so a steered
+  // branch that resolves nothing would leak the mark forever and every later
+  // hydrate would preserve the row as a permanent ghost chip.
+  const steeredBranch = sliceBranch(
+    chatViewSource,
+    "if (result?.status === 'steered') {",
+    "if (result?.status === 'started') {",
+  )
+  for (const resolver of [
+    /pendingQueue\.confirmQueued\(/,
+    /pendingQueue\.cancelByCid\(/,
+  ]) {
+    assert.match(steeredBranch, resolver)
+  }
+  // Neither resolver may sit behind a shape check on the response body: a
+  // stripped/older `pending_messages` must not leave the mark set.
+  const deferred = sliceBranch(steeredBranch, 'if (result.cut_deferred) {', '} else {')
+  const confirmAt = deferred.indexOf('pendingQueue.confirmQueued(')
+  const guardAt = deferred.indexOf('Array.isArray(result.pending_messages)')
+  assert.ok(guardAt >= 0 && confirmAt > guardAt)
+  assert.ok(
+    !/if \(Array\.isArray\(result\.pending_messages\)\) \{[\s\S]*?confirmQueued/
+      .test(deferred),
+    'the confirm must run for every deferred response shape, not only when the '
+    + 'server echoed a usable queue',
+  )
+})
+
+test('the fast-forward path undoes its own optimistic hide, guarded', () => {
+  const ff = sliceBranch(
+    chatViewSource,
+    'async function steerRowsImpl(steerRowsList) {',
+    '\n  // STEER (fast-forward): inject the queued messages into the LIVE turn',
+  )
+  const deferred = sliceBranch(ff, 'if (result.cut_deferred) {', '} else if (')
+  assert.match(
+    deferred, /restoreOptimisticSteerQueue\(\)/,
+    'the rows are still queued server-side, so the pre-pin hide is undone with '
+    + 'the identity-guarded local restore',
+  )
+  assert.ok(
+    !deferred.includes('pendingQueue.hydrate'),
+    're-adding rows from the pre-cut snapshot resurrects whatever the cut '
+    + 'already retired',
+  )
+  // The guard is what makes it order-independent: any other writer to the
+  // queue (the cut included) wins and the restore becomes a no-op.
+  const restore = sliceBranch(ff, 'function restoreOptimisticSteerQueue() {', '\n    }\n')
+  assert.match(
+    restore,
+    /pendingQueue\.pendingMessagesRef\.current === queueAfterOptimisticPromote/,
+    'restore only when nothing else has touched the queue since the promote',
+  )
+})

--- a/frontend/src/components/ChatView/hooks/__tests__/usePendingQueue.test.js
+++ b/frontend/src/components/ChatView/hooks/__tests__/usePendingQueue.test.js
@@ -392,3 +392,59 @@ test('two distinct in-flight rows with identical text stay distinct (cid disambi
   assert.ok(list.find(m => m.cid === 'local-1'))
   assert.ok(list.find(m => m.cid === 'local-2'))
 })
+
+// ── The deferred steer's 202 must confirm one row, not hydrate the tray ──────
+// A Claude steer is accepted at HTTP arrival but its transcript split (and so
+// the cut that retires the tray row) happens later, at the runner's interrupt
+// boundary. The 202 therefore echoes a queue snapshot taken BEFORE the cut,
+// and the two can land in either order. These pin why doSend confirms the one
+// cid it owns instead of reconciling the whole tray against that snapshot.
+
+test('confirming the deferred steer row is a no-op once the cut retired it', () => {
+  const { result } = renderHook(usePendingQueue)
+  result.current.add(fixtureMsg({ cid: 'steered', ts: 500 }), { inFlight: true })
+  // The runner's cut lands first: onSteeredIntoTurn renders the row inline and
+  // cancels its tray entry.
+  result.current.cancelByCid('steered')
+  // ...and only then does the steer's own 202 resolve.
+  result.current.confirmQueued('steered', { ts: 500 })
+  assert.deepEqual(
+    result.current.pendingMessagesRef.current, [],
+    'the row is already inline in the transcript; confirming must not put a '
+    + 'second copy back in the tray',
+  )
+})
+
+test('hydrating the deferred steer snapshot WOULD resurrect and drop rows', () => {
+  // The failure mode the confirm avoids, asserted on the real hook so the
+  // reason for not calling hydrate here is executable rather than a comment.
+  const { result } = renderHook(usePendingQueue)
+  result.current.add(fixtureMsg({ cid: 'steered', ts: 500 }), { inFlight: true })
+  // A second send queues and its own POST acks while the steer's 202 is still
+  // in flight, so it is confirmed and no longer in-flight.
+  result.current.add(fixtureMsg({ cid: 'later', ts: 600 }), { inFlight: true })
+  result.current.confirmQueued('later', { ts: 600 })
+  // The cut retires the steered row.
+  result.current.cancelByCid('steered')
+  // Now the stale snapshot arrives.
+  result.current.hydrate([{ role: 'user', content: 'hi', ts: 500, cid: 'steered' }])
+  assert.deepEqual(
+    result.current.pendingMessagesRef.current.map(m => m.cid), ['steered'],
+    'wholesale reconcile against a pre-cut snapshot resurrects the row the cut '
+    + 'retired AND drops the row queued after the snapshot was taken',
+  )
+})
+
+test('confirming one cid leaves a concurrently-queued row alone', () => {
+  const { result } = renderHook(usePendingQueue)
+  result.current.add(fixtureMsg({ cid: 'steered', ts: 500 }), { inFlight: true })
+  result.current.add(fixtureMsg({ cid: 'later', ts: 600 }), { inFlight: true })
+  result.current.confirmQueued('later', { ts: 600 })
+  result.current.confirmQueued('steered', { ts: 500 })
+  const list = result.current.pendingMessagesRef.current
+  assert.deepEqual(list.map(m => m.cid), ['steered', 'later'])
+  assert.ok(
+    list.every(m => m.serverTs === true),
+    'both rows are server-confirmed, so fast-forward stays available on both',
+  )
+})

--- a/frontend/src/components/ChatView/useStreamConnection.js
+++ b/frontend/src/components/ChatView/useStreamConnection.js
@@ -128,12 +128,19 @@ const BROADCAST_REGISTRATION_WINDOW_MS = 1500
  *                         block in place (see streamReducers.js).
  *   queued_turn_starting  Backend about to promote a queued message
  *                         { ts }. Notifies caller via callback.
- *   steered_into_turn     A send was steered into a live provider turn
- *                         instead of queued { ts, content }. Codex uses
- *                         true SDK steer; Claude interrupts and
- *                         re-prompts. Notifies caller so it drops the
- *                         optimistic queued-tray entry and renders the
- *                         message inline as content growth.
+ *   steered_into_turn     THE CUT. The transcript split has committed: the
+ *                         pre-steer assistant segment is sealed and the
+ *                         steered user row(s) are in the transcript
+ *                         { ts, content, messages }. Published by the steer
+ *                         route for Codex (which splits there) and by the
+ *                         Claude runner at its seal. Notifies caller so it
+ *                         promotes the live stream into its own message,
+ *                         re-bases streamItems for the continuation, and
+ *                         renders the row inline as content growth. There is
+ *                         no separate "accepted" event: on the deferred
+ *                         (Claude) path the send's own 202 echoes the row as
+ *                         the still-queued row it is, so the tray has ONE
+ *                         reconciler until the cut arrives.
  *   catch_up_done         Replay burst finished; live events follow.
  *   error                 { message }. Surfaced inline.
  *   done                  Turn complete; SSE closes.
@@ -159,8 +166,9 @@ const BROADCAST_REGISTRATION_WINDOW_MS = 1500
  *   identifies the first pending entry in the promoted group and `message`
  *   is the backend-authoritative combined user message when available.
  * @param {(info: {ts: number|null, content: string}) => void} [callbacks.onSteeredIntoTurn]
- *   Fired when a send was steered into a live provider turn. The caller
- *   drops the optimistic queued-tray entry and renders the message inline.
+ *   Fired when the steer's transcript split has COMMITTED. The caller seals the
+ *   live stream into its own message, drops the queued-tray entry, and renders
+ *   the steered message inline.
  * @param {(questionId: string|null) => void} [callbacks.onLiveQuestion]
  *   Fired when the stream shows the currently-live AskUserQuestion card.
  *
@@ -1061,9 +1069,10 @@ export default function useStreamConnection(chatId, {
               message: event.message || null,
             })
           } else if (event.type === 'steered_into_turn') {
-            // The backend already put the user message in the transcript;
-            // the caller drops the optimistic queued-tray entry and renders
-            // it inline as content growth (no send-time spacer/scroll-pin).
+            // THE CUT. The backend has committed the split — the pre-steer
+            // assistant segment is sealed and the user message is in the
+            // transcript — so the caller drops the queued-tray entry and
+            // renders it inline as content growth (no send-time spacer/pin).
             // Flush the typewriter buffer FIRST so the pre-steer assistant
             // text is fully in latestItemsRef before the caller promotes it
             // to its own finished message — without this, the last frame of
@@ -1072,16 +1081,35 @@ export default function useStreamConnection(chatId, {
             flushBuffer()
             if (isCatchUp) {
               // Replay during the catch-up burst (a mid-A2 reconnect or
-              // remount): the DB fetch already returned the sealed pre-steer
-              // assistant (A1) AND the steered user row (Q2), so promoting the
-              // replayed pre-steer text into a fresh message would DUPLICATE
-              // A1, and re-inserting Q2 is redundant. Drop the replayed
+              // remount): the sealed pre-steer assistant (A1) and the steered
+              // user row (Q2) are DB rows now, so promoting the replayed
+              // pre-steer text into a fresh message would DUPLICATE A1 and
+              // re-inserting Q2 would duplicate the row. Drop the replayed
               // pre-steer segment from streamItems so the post-steer
               // continuation (A2) accumulates fresh and promotes as its own
               // assistant after Q2. Clear the off-screen catch-up buffer; the
               // visible stream is replaced only when catch-up commits.
+              //
+              // This reconstructs the SERVER's boundary because the cut sits at
+              // its true position in the replayed log: the publisher is the seal
+              // itself, so every event before it belongs to A1 and every event
+              // after it belongs to A2. While the cut was published at HTTP
+              // arrival instead, the A1 blocks that followed it survived here
+              // and replayed as the head of A2 — the duplication, reproduced on
+              // every reconnect.
               catchUpItems = []
               forceNewTextBlockRef.current = false
+              // Dropping the replayed segment only reconstructs the transcript
+              // if those DB rows are actually loaded, and this branch is exactly
+              // the case where they may not be: a socket that died before the
+              // cut arrived live means A1 was never promoted locally and Q2 was
+              // never inserted, so discarding the replay here would erase A1
+              // from view and leave Q2 sitting in the tray until turn end. The
+              // cut cannot be applied on replay (promoting replayed items is
+              // the duplication), so the DB is the only place both rows exist —
+              // ask for it. One authoritative read at a known boundary; the
+              // event log replays the cut once per connection, not on a timer.
+              onNeedsRefreshRef.current?.({ force: true })
             } else {
               onSteeredIntoTurnRef.current?.({
                 ts: event.ts ?? null,


### PR DESCRIPTION
## Problem

Steering a message into a live Claude turn — typing while it works, or pressing
Stop with a queued message — made the assistant's output paint twice for the
rest of that turn: everything streamed inside a multi-second window appeared
once in the sealed pre-steer message and again at the head of the continuation.
Reconnecting did not clear it; the bad boundary replayed out of the event log,
so it reproduced on every reconnect. In a reported incident the duplicated
window was 8.5 seconds of output.

## Root cause

`steered_into_turn` is the client's only "seal the live stream here and re-base
it" instruction. On the Claude path the steer route published it the moment the
HTTP request arrived — but `ActiveClaudeClient.steer()` merely BUFFERS the
request there. The runner performs the real transcript split much later, at its
next interrupt boundary. Every block emitted inside that window was persisted
into the sealed pre-steer message AND retained at the head of the client's
freshly cleared stream. Two copies, for the remainder of the turn.

The same 202 also reported an optimistically emptied queue on that path, so the
steered row left the tray while the server still held it — leaving that message
with nowhere to render for the whole deferred window.

Codex was never affected: `turn.steer()` has no interrupt boundary, so for Codex
the route genuinely *is* the split point.

**Regression provenance:** 8d4d0c81b ("fix(chat): fast-forward/steer no longer
drops or merges messages") moved the split from the route to the runner and left
the signal behind at the route.

## Fix

- One builder for the event, `steered_into_turn_event()` in `app/chat.py`, so
  the two publishers cannot drift on the wire shape.
- The route publishes the cut only on the non-deferred (Codex) path, where the
  split really happens. Codex behaviour is unchanged.
- The Claude cut is published by `_seal_steer_split()` itself, immediately after
  `split_for_steer` commits, on the sink's own broadcast — so a reconnect
  replays the boundary at its true position — with no `await` between the split
  and the publish, so no continuation block can slip in front of it. A split
  with no resolvable broadcast still commits, and logs loudly.
- The 202 now reports the pending queue as it actually is and marks the deferred
  case with `cut_deferred: true`. The client keeps the row in the tray until the
  cut retires it, and resolves only its own row by cid, so the 202 and the cut
  may land in either order.
- `interrupt()` (Stop) now drops the buffered transcript rows as well as the
  provider-facing text: Stop's clear-and-resend path owns those rows from that
  point, and leaving them buffered let the dying turn's seal append the very row
  the client was re-sending.
- There is no separate "accepted" channel — one event, one tray reconciler.

## Test evidence

Applied alone on `main` (c00b9bd7e), with no other change present:

- `backend/tests/test_chats_stream_steer.py`: **32 passed** (26 on `main`), incl.
  `test_claude_steer_cut_event_is_published_at_the_seal_not_at_http_arrival`,
  `test_codex_steer_still_publishes_the_cut_at_the_route`,
  `test_seal_publishes_the_cut_on_the_sinks_own_broadcast`,
  `test_a_failing_publisher_cannot_escape_the_seal`,
  `test_stop_drops_the_buffered_steer_instead_of_appending_it`, and
  `test_writer_dedup_still_publishes_the_committed_cut`.
- `frontend/`: `npm test` → **1976 passed, 0 failed** (1967 on `main`). New
  `steerCutBoundary.test.js` pins the client half of the contract — one event
  and one reconciler, only the cut re-bases the stream, a replay refetches
  instead, and every steered branch resolves its optimistic in-flight mark.
  `usePendingQueue.test.js` adds three deferred-window ordering cases.
- Mutation-checked: re-introducing the arrival-time publish, or letting a
  publish error escape the seal, each fail a named test.

Backend changes require a server restart to take effect.
