### PR TITLE
fix(chat): observe the node the card publishes, not a lookup

### DIFF
--- a/frontend/src/components/ChatView/ActiveAssistantSurface.jsx
+++ b/frontend/src/components/ChatView/ActiveAssistantSurface.jsx
@@ -32,6 +32,8 @@ function ActiveAssistantSurface({
   onAutoResumeChange,
   submissionBlocked,
   liveQuestionId,
+  pendingQuestionRef,
+  resumeCardRef,
   isStreaming,
 }) {
   const msg = useMemo(() => {
@@ -63,6 +65,8 @@ function ActiveAssistantSurface({
       onAutoResumeChange={onAutoResumeChange}
       submissionBlocked={submissionBlocked}
       liveQuestionId={liveQuestionId}
+      pendingQuestionRef={pendingQuestionRef}
+      resumeCardRef={resumeCardRef}
       isStreaming={isStreaming}
     />
   )

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -23,7 +23,7 @@ import { getOnlineSnapshot } from '../../lib/connectivityStore.js'
 import useSystemEventStream from '../../hooks/useSystemEventStream.js'
 import usePendingQueue from './hooks/usePendingQueue.js'
 import useBridgePartial from './hooks/useBridgePartial.js'
-import useOffscreenNudge from './hooks/useOffscreenNudge.js'
+import useOffscreenNudge, { useNudgeTargetRef } from './hooks/useOffscreenNudge.js'
 import ChatInputBar from './ChatInputBar.jsx'
 import { hasSendablePayload } from './composerSubmission.js'
 import AgentContextInspector from './AgentContextInspector.jsx'
@@ -421,7 +421,8 @@ export default function ChatView({
   // The pending-question and resume "tap to jump to it" nudges each track
   // whether their card is scrolled out of the viewport. Both use one shared
   // observer hook (useOffscreenNudge, below); their booleans are computed near
-  // hasPendingQuestion / hasPendingResume where the card finders live.
+  // hasPendingQuestion / hasPendingResume, alongside the callback refs the
+  // cards themselves use to publish the node being observed.
   const [showInspector, setShowInspector] = useState(false)
   const [showSummary, setShowSummary] = useState(false)
   const [visibleTimestampKey, setVisibleTimestampKey] = useState(null)
@@ -3518,30 +3519,30 @@ export default function ChatView({
     }
   }, [pendingLimitResetAt])
 
-  // Visibility of that card is a pure viewport question — an
-  // IntersectionObserver rooted at the scroll container is the signal,
-  // no scroll math and no interaction with the spacer machinery. The
-  // card's DOM node is stable across streaming ticks (keyed children),
-  // so the observer only needs re-binding when the rendering surface
-  // can change: pending-flag flips, stream↔messages promotion, or a
-  // messages commit. Both nudges share useOffscreenNudge (above).
-  // The LAST un-answered card is the pending one: it lives in the last
-  // assistant message or the streaming <li>.
-  const findPendingQuestionCard = () =>
-    [...(scrollRef.current?.querySelectorAll('.qcard:not(.qcard--answered)') ?? [])].pop()
+  // Visibility of either card is a pure viewport question — an
+  // IntersectionObserver rooted at the scroll container is the signal, no
+  // scroll math and no interaction with the spacer machinery. ChatView must
+  // NOT look the card up: the pending question moves between two rendering
+  // surfaces (the live streaming <li> and the durable message row) at a moment
+  // ChatView cannot enumerate, and a lookup taken at bind time then observes a
+  // node React has since detached — with the turn parked on the answer nothing
+  // re-renders, so the cue would stick forever. Instead the element that IS
+  // the card publishes its node through these refs (see useNudgeTargetRef);
+  // both surfaces publish through the same channel, so the live→durable
+  // handoff reaches the observer as an ordinary node swap.
+  const [pendingQuestionEl, pendingQuestionRef] = useNudgeTargetRef()
   const pendingCardOffscreen = useOffscreenNudge(
-    scrollRef, hasPendingQuestion, findPendingQuestionCard,
-    [showActiveAssistantSurface, messages],
+    scrollRef, hasPendingQuestion, pendingQuestionEl,
   )
 
-  // The resume card: only the tail resumable note renders `.chat__resume`
-  // (MsgContent gates the button on isLastMsg), so observing that button is
-  // enough to know the card's visibility; a tap on the nudge scrolls it in.
-  const findResumeCard = () =>
-    [...(scrollRef.current?.querySelectorAll('.chat__resume') ?? [])].pop()
+  // The resume card publishes the same way, from the TAIL resumable note only
+  // — the same block tailResumableBlock arms the cue on. (MsgContent renders a
+  // Resume button on every resumable block of the last message, so the tail
+  // gate lives at the publication site; one shared ref can only hold one
+  // node.) A tap on the nudge scrolls that node in.
+  const [resumeCardEl, resumeCardRef] = useNudgeTargetRef()
   const resumeCardOffscreen = useOffscreenNudge(
-    scrollRef, hasPendingResume, findResumeCard,
-    [showActiveAssistantSurface, messages],
+    scrollRef, hasPendingResume, resumeCardEl,
   )
 
   // The ONE active <li> carries this data-key for both DB and live payloads.
@@ -3846,6 +3847,8 @@ export default function ChatView({
                 isLastMsg={isLastMsg}
                 liveQuestionId={liveQuestionId}
                 suppressedQuestionKeys={streamItemQuestionKeys}
+                pendingQuestionRef={pendingQuestionRef}
+                resumeCardRef={resumeCardRef}
               />
               {msg.ts && ownerUserMessage && (
                 <time className={`chat__ts${visibleTimestampKey === dataKey ? ' chat__ts--visible' : ''}`}>
@@ -3879,6 +3882,11 @@ export default function ChatView({
               onAutoResumeChange={handleAutoResumeChange}
               submissionBlocked={providerSwitching}
               liveQuestionId={liveQuestionId}
+              // Same publication channel as the durable rows above: while the
+              // turn is live THIS surface owns the pending question card, so
+              // the offscreen observer follows the handoff automatically.
+              pendingQuestionRef={pendingQuestionRef}
+              resumeCardRef={resumeCardRef}
               // Liveness for the ACTIVE surface follows the TURN, not the
               // payload source: when a richer DB partial wins source selection
               // (useDbActivePayload, e.g. through the reconnect catch-up

--- a/frontend/src/components/ChatView/MsgContent.jsx
+++ b/frontend/src/components/ChatView/MsgContent.jsx
@@ -56,6 +56,15 @@ function MsgContentInner({
   // fresh function reference every render and defeat it.
   isLastMsg,
   liveQuestionId,
+  // Callback refs (ChatView's useNudgeTargetRef) that publish the DOM node of
+  // the card each footer nudge watches. This renderer serves BOTH surfaces of
+  // the active answer — the durable message row and the live streaming <li> —
+  // so a mid-turn surface handoff reaches the observer as a plain node swap
+  // instead of leaving it bound to a node React has detached. Only the card
+  // that actually blocks the turn publishes: the answerable tail question and
+  // the resumable tail note.
+  pendingQuestionRef,
+  resumeCardRef,
   // Active answers always use this renderer for both their DB partial and
   // live SSE payload. isStreaming only enables the cursor, aria-live, and the
   // active thinking timer; it never selects a different component tree.
@@ -209,6 +218,7 @@ function MsgContentInner({
               answeredMap={answers}
               onAnswer={answerable ? onQuestionAnswer : undefined}
               disabled={!answerable && !answers}
+              pendingCardRef={answerable ? pendingQuestionRef : undefined}
             />
           </div>
         )
@@ -268,6 +278,18 @@ function MsgContentInner({
               <button
                 type="button"
                 className="chat__resume"
+                // Publish ONLY the tail note's button. `resumable` gates on
+                // isLastMsg, not on tail position, so a last message holding
+                // two resumable error blocks renders two buttons — and one
+                // shared callback ref has ONE slot: the later mount wins, then
+                // an unmount of the OTHER button calls the ref with null and
+                // the cue goes dark while the real target is still on screen
+                // and offscreen. The tail is also exactly what arms the cue
+                // (ChatView's tailResumableBlock), so gating here keeps the
+                // observed node and the `active` flag talking about the same
+                // block. The old querySelectorAll lookup took `.pop()`, which
+                // is what this reproduces.
+                ref={i === lastEntryIdx ? resumeCardRef : undefined}
                 onClick={() => onResume('continue')}
                 disabled={submissionBlocked}
                 title={submissionBlocked
@@ -387,6 +409,15 @@ export default memo(MsgContentInner, (prev, next) => {
     && prev.submissionBlocked === next.submissionBlocked
     && prev.isLastMsg === next.isLastMsg
     && prev.liveQuestionId === next.liveQuestionId
+    // The nudge refs are props, so an exhaustive comparator has to include
+    // them: a ref whose identity changed must reach the DOM node, or React
+    // never re-invokes it and the observer keeps the old channel. In practice
+    // they never change (useNudgeTargetRef memoizes both with []), which is
+    // why these two lines cost nothing. Skipping a re-render does NOT
+    // unpublish anything — React only re-runs a callback ref when the ref or
+    // the host node changes, and a bailed-out render changes neither.
+    && prev.pendingQuestionRef === next.pendingQuestionRef
+    && prev.resumeCardRef === next.resumeCardRef
     && prev.isActiveAnswer === next.isActiveAnswer
     && prev.isStreaming === next.isStreaming
     // suppressedQuestionKeys is a Set (new reference each render) or null.

--- a/frontend/src/components/ChatView/QuestionCard.jsx
+++ b/frontend/src/components/ChatView/QuestionCard.jsx
@@ -25,6 +25,14 @@ export default function QuestionCard({
   answeredMap,
   onAnswer,
   disabled,
+  // Callback ref that publishes this card's node to the "Möbius asked you
+  // something — tap to answer" offscreen observer. Set only by the surface
+  // rendering the answerable tail question, and only while the card is still
+  // unanswered — the cue exists to send the owner back to a card that is
+  // blocking the turn, and a submitted card no longer is. Because a live→
+  // durable surface handoff remounts this component, the observer's target
+  // has to come from here (the node's own render) rather than a lookup.
+  pendingCardRef,
 }) {
   const draftKey = questionDraftKey(chatId, questionId, questions)
   const [answers, setAnswers] = useState(
@@ -137,6 +145,7 @@ export default function QuestionCard({
   return (
     <div
       className={`qcard${answered ? ' qcard--answered' : ''}`}
+      ref={answered ? null : pendingCardRef}
       aria-disabled={disabled && !answered ? true : undefined}
     >
       {questions.map((q, qi) => {

--- a/frontend/src/components/ChatView/StreamingMessage.jsx
+++ b/frontend/src/components/ChatView/StreamingMessage.jsx
@@ -22,6 +22,8 @@ export default function StreamingMessage({
   onAutoResumeChange,
   submissionBlocked,
   liveQuestionId,
+  pendingQuestionRef,
+  resumeCardRef,
   isStreaming,
 }) {
   return (
@@ -45,6 +47,8 @@ export default function StreamingMessage({
         submissionBlocked={submissionBlocked}
         isLastMsg
         liveQuestionId={liveQuestionId}
+        pendingQuestionRef={pendingQuestionRef}
+        resumeCardRef={resumeCardRef}
         isActiveAnswer
         isStreaming={isStreaming}
         suppressedQuestionKeys={null}

--- a/frontend/src/components/ChatView/__tests__/resumeAffordance.test.js
+++ b/frontend/src/components/ChatView/__tests__/resumeAffordance.test.js
@@ -15,15 +15,81 @@ const css = readFileSync(new URL('../ChatView.css', import.meta.url), 'utf8')
 // with an unbounded `[\s\S]*?` between the tag and the prop, a DIFFERENT
 // element's props further down the file satisfy the match, so "both render
 // paths pass the ref" can pass with one of them not passing it at all.
+// Scan the opening tag that begins at `start` (source[start] === '<'), skipping
+// over quoted strings ('...', "...", `...`) and balanced { } JSX expression
+// containers so that a '>' inside an arrow prop (onClick={() => ...}), a
+// comparison, or a comment does NOT prematurely end the tag. Returns the index
+// of the tag-closing '>' and whether the tag is self-closing ('/>').
+function scanOpeningTag(source, start) {
+  for (let i = start + 1, brace = 0; i < source.length; i++) {
+    const c = source[i]
+    if (c === '"' || c === "'" || c === '`') {
+      i++
+      while (i < source.length && source[i] !== c) i++
+      continue
+    }
+    if (c === '{') { brace++; continue }
+    if (c === '}') { brace--; continue }
+    if (brace > 0) continue
+    if (c === '/' && source[i + 1] === '>') return { gt: i + 1, selfClosing: true }
+    if (c === '>') return { gt: i, selfClosing: false }
+  }
+  return { gt: -1, selfClosing: false }
+}
+
 function sliceElement(source, openTag) {
   const from = source.indexOf(openTag)
   assert.ok(from >= 0, `expected to find ${openTag}`)
-  let depth = 0
-  for (let i = from; i < source.length; i++) {
-    if (source[i] === '<') depth++
-    if (source[i] === '>') {
+  // Recover the tag name from the opening tag (e.g. '<button' -> 'button',
+  // '<div\n className=...' -> 'div') so we can find its real close.
+  const nameMatch = /^<\s*([A-Za-z][\w.]*)/.exec(openTag)
+  assert.ok(nameMatch, `openTag must start with a tag name: ${openTag}`)
+  const tagName = nameMatch[1]
+
+  const opening = scanOpeningTag(source, from)
+  assert.notEqual(opening.gt, -1, `unterminated opening tag ${openTag}`)
+
+  if (opening.selfClosing) {
+    const slice = source.slice(from, opening.gt + 1)
+    assert.ok(slice.endsWith('/>'),
+      `self-closing slice for ${openTag} must end with '/>'`)
+    return slice
+  }
+
+  // Not self-closing: walk forward, quote/brace aware, tracking nesting of
+  // same-named tags, until the matching '</tagName>' close.
+  const close = `</${tagName}`
+  const nestedOpen = new RegExp(`^<\\s*${tagName}[\\s/>]`)
+  let depth = 1
+  for (let i = opening.gt + 1, brace = 0; i < source.length; i++) {
+    const c = source[i]
+    if (c === '"' || c === "'" || c === '`') {
+      i++
+      while (i < source.length && source[i] !== c) i++
+      continue
+    }
+    if (c === '{') { brace++; continue }
+    if (c === '}') { brace--; continue }
+    if (brace > 0) continue
+    if (c !== '<') continue
+    if (source.startsWith(close, i)) {
       depth--
-      if (depth === 0) return source.slice(from, i + 1)
+      if (depth === 0) {
+        const gt = source.indexOf('>', i)
+        assert.notEqual(gt, -1, `unterminated close for ${openTag}`)
+        const slice = source.slice(from, gt + 1)
+        const tail = slice.replace(/\s+/g, ' ')
+        assert.ok(tail.endsWith(`${close}>`) || tail.endsWith(`${close} >`),
+          `slice for ${openTag} must end with ${close}>`)
+        return slice
+      }
+      continue
+    }
+    // A nested opening tag of the same name deepens the nesting — unless it is
+    // self-closing, which needs no matching close.
+    if (nestedOpen.test(source.slice(i))) {
+      const nested = scanOpeningTag(source, i)
+      if (nested.gt !== -1 && !nested.selfClosing) depth++
     }
   }
   assert.fail(`unterminated element ${openTag}`)

--- a/frontend/src/components/ChatView/__tests__/resumeAffordance.test.js
+++ b/frontend/src/components/ChatView/__tests__/resumeAffordance.test.js
@@ -10,6 +10,25 @@ const msgContent = readFileSync(new URL('../MsgContent.jsx', import.meta.url), '
 const chatView = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8')
 const css = readFileSync(new URL('../ChatView.css', import.meta.url), 'utf8')
 
+// Slice ONE JSX element's own text, from its tag to the matching close of that
+// tag. A source assertion about an element's props is worthless without this:
+// with an unbounded `[\s\S]*?` between the tag and the prop, a DIFFERENT
+// element's props further down the file satisfy the match, so "both render
+// paths pass the ref" can pass with one of them not passing it at all.
+function sliceElement(source, openTag) {
+  const from = source.indexOf(openTag)
+  assert.ok(from >= 0, `expected to find ${openTag}`)
+  let depth = 0
+  for (let i = from; i < source.length; i++) {
+    if (source[i] === '<') depth++
+    if (source[i] === '>') {
+      depth--
+      if (depth === 0) return source.slice(from, i + 1)
+    }
+  }
+  assert.fail(`unterminated element ${openTag}`)
+}
+
 test('MsgContent gates the Resume button on a resumable tail note', () => {
   assert.match(msgContent, /onResume/,
     'MsgContent must accept an onResume prop')
@@ -78,6 +97,73 @@ test('ChatView routes both offscreen attention nudges through the controller', (
     'nearest-element scrolling can strand either primary action behind the composer')
   assert.match(css, /\.chat__resume-nudge/,
     'the resume nudge reuses the question-nudge visual style')
+})
+
+test('both attention nudges observe a node published by the card, not a lookup', () => {
+  // The nudges track a card that changes DOM node mid-turn: the live streaming
+  // surface renders the pending question while the turn runs, the durable
+  // message row renders it once the turn parks. A querySelector taken when the
+  // observer binds cannot see that swap, so the observer was left on a detached
+  // node — and with the turn parked awaiting the answer nothing re-renders, so
+  // the pill stuck forever. Node identity has to be the hook's input.
+  assert.doesNotMatch(chatView, /querySelectorAll\('\.qcard|querySelectorAll\('\.chat__resume/,
+    'neither nudge may locate its card by query')
+  assert.match(chatView, /const \[pendingQuestionEl, pendingQuestionRef\] = useNudgeTargetRef\(\)/,
+    'the pending question card publishes its node through a callback ref')
+  assert.match(chatView, /useOffscreenNudge\(\s*scrollRef, hasPendingQuestion, pendingQuestionEl,/,
+    'the question nudge observes the published node')
+  assert.match(chatView, /const \[resumeCardEl, resumeCardRef\] = useNudgeTargetRef\(\)/,
+    'the resume card publishes its node the same way — no parallel mechanism')
+  assert.match(chatView, /useOffscreenNudge\(\s*scrollRef, hasPendingResume, resumeCardEl,/,
+    'the resume nudge observes the published node')
+
+  // BOTH render paths must publish through the SAME ref so the live→durable
+  // handoff reaches the observer as an ordinary node swap. Each element is
+  // sliced to its OWN text first: an unbounded wildcard between the tag and the
+  // prop lets one call site satisfy both patterns, which makes deleting the
+  // refs from the durable row — the reported bug, exactly — undetectable.
+  for (const [label, openTag] of [
+    ['durable message rows', '<MsgContent'],
+    ['the live active surface', '<ActiveAssistantSurface'],
+  ]) {
+    const element = sliceElement(chatView, openTag)
+    assert.match(element, /pendingQuestionRef=\{pendingQuestionRef\}/,
+      `${label} must publish the question card through the shared ref`)
+    assert.match(element, /resumeCardRef=\{resumeCardRef\}/,
+      `${label} must publish the resume card through the shared ref`)
+  }
+  // The live surface reaches MsgContent through two more components, and a hop
+  // that accepts the prop without forwarding it kills the cue for the whole
+  // live half of the turn — silently, since the durable half still works.
+  for (const [file, child] of [
+    ['../ActiveAssistantSurface.jsx', '<StreamingMessage'],
+    ['../StreamingMessage.jsx', '<MsgContent'],
+  ]) {
+    const source = readFileSync(new URL(file, import.meta.url), 'utf8')
+    const element = sliceElement(source, child)
+    for (const prop of ['pendingQuestionRef', 'resumeCardRef']) {
+      assert.match(element, new RegExp(`${prop}=\\{${prop}\\}`),
+        `${file} must forward ${prop} to ${child}`)
+    }
+  }
+  // Only the card that actually blocks the turn registers: an answered question
+  // or a scrolled-back history card is not somewhere to send the owner back to.
+  assert.match(msgContent, /pendingCardRef=\{answerable \? pendingQuestionRef : undefined\}/,
+    'only the answerable tail question publishes its node')
+  // ONE publisher per ref. `resumable` gates on isLastMsg, not tail position, so
+  // a last message with two resumable blocks renders two Resume buttons; a
+  // shared single-slot ref would then be nulled by whichever unmounts first and
+  // the cue would go dark with the real button still offscreen. The tail is also
+  // what arms the cue (tailResumableBlock), so both must name the same block.
+  const resumeButton = sliceElement(msgContent, '<button')
+  assert.match(resumeButton, /className="chat__resume"/,
+    'the sliced element is the Resume button')
+  assert.match(resumeButton, /ref=\{i === lastEntryIdx \? resumeCardRef : undefined\}/,
+    'only the TAIL resumable note may publish the observed node')
+  const questionCard = readFileSync(new URL('../QuestionCard.jsx', import.meta.url), 'utf8')
+  const qcard = sliceElement(questionCard, '<div\n      className={`qcard')
+  assert.match(qcard, /ref=\{answered \? (null|undefined) : pendingCardRef\}/,
+    'a submitted card retires itself from the cue')
 })
 
 test('ariaStatus announces the recovery state instead of "Response ready."', () => {

--- a/frontend/src/components/ChatView/hooks/__tests__/react-hook-shim.mjs
+++ b/frontend/src/components/ChatView/hooks/__tests__/react-hook-shim.mjs
@@ -15,7 +15,10 @@
 // matching React's "layout effects fire after commit" timing without a
 // real DOM commit cycle. Dep semantics follow React: Object.is per
 // element; undefined deps = fire every render; [] = fire once; [a,b] =
-// fire when a or b changes by identity.
+// fire when a or b changes by identity. A function returned by an effect
+// is retained as its cleanup and invoked before that effect fires again,
+// like React — a hook that owns an external subscription (an
+// IntersectionObserver) cannot be tested honestly without that teardown.
 //
 // Why this instead of @testing-library/react-hooks: zero new
 // devDependencies, fits the Möbius preference for keeping the
@@ -80,7 +83,7 @@ export function useCallback(fn, deps) {
 function _scheduleEffect(fn, deps) {
   const i = _slotIndex++
   if (_slots[i] === undefined) {
-    _slots[i] = { prevDeps: _UNSET }
+    _slots[i] = { prevDeps: _UNSET, cleanup: null }
   }
   const slot = _slots[i]
   // Fire on: first render (prevDeps === _UNSET), no dep array
@@ -92,7 +95,7 @@ function _scheduleEffect(fn, deps) {
     deps.length !== slot.prevDeps.length ||
     deps.some((d, idx) => !Object.is(d, slot.prevDeps[idx]))
   slot.prevDeps = deps === undefined ? _UNSET : deps
-  if (shouldFire) _pendingEffects.push(fn)
+  if (shouldFire) _pendingEffects.push({ slot, fn })
 }
 
 // useLayoutEffect and useEffect collapse to the same scheduling here:
@@ -110,28 +113,44 @@ export function useEffect(fn, deps) {
 function _flushEffects() {
   // Drain in registration order. Effects that call setState would
   // re-trigger _rerender → run → another flush; the hooks tested here
-  // only mutate refs inside effects, so the recursion concern is
-  // theoretical. If you hit it, gate _flushEffects behind a depth
-  // counter or move setState callers to useEffect-with-deferred-flush.
+  // only mutate refs or re-set the same state inside effects, so the
+  // recursion concern is theoretical. If you hit it, gate _flushEffects
+  // behind a depth counter or move setState callers to
+  // useEffect-with-deferred-flush.
   const toRun = _pendingEffects.splice(0)
-  for (const fn of toRun) fn()
+  for (const { slot, fn } of toRun) {
+    // Tear down the previous subscription before re-establishing it, so a
+    // re-fire cannot leave two live observers behind (React's order too).
+    if (typeof slot.cleanup === 'function') slot.cleanup()
+    const cleanup = fn()
+    slot.cleanup = typeof cleanup === 'function' ? cleanup : null
+  }
 }
 
 /**
  * Run a hook function as if React were mounting it. Returns a
- * { result, rerender } pair; `result.current` reflects the latest
- * return value, and `rerender(...args)` re-invokes the hook with
- * fresh arguments while preserving slot state.
+ * { result, rerender, unmount } triple; `result.current` reflects the
+ * latest return value, `rerender(...args)` re-invokes the hook with
+ * fresh arguments while preserving slot state, and `unmount()` runs
+ * every retained effect cleanup like React's teardown.
  *
  * Effects (useLayoutEffect / useEffect) registered during the hook
  * call are flushed synchronously after hookFn returns, so callers
  * can assert on ref values that effects set without an `act` wrapper.
+ *
+ * `unmount` exists because a hook that owns an external subscription
+ * (an IntersectionObserver) has a teardown path that no dep change can
+ * reach: without it, "the observer is disconnected when the component
+ * goes away" is untestable and a leaked observer looks identical to a
+ * released one.
  */
 export function renderHook(hookFn, ...initialArgs) {
   __reset()
   const result = { current: undefined }
   let currentArgs = initialArgs
+  let unmounted = false
   function run() {
+    if (unmounted) return
     _slotIndex = 0
     result.current = hookFn(...currentArgs)
     _flushEffects()
@@ -143,6 +162,17 @@ export function renderHook(hookFn, ...initialArgs) {
     rerender: (...nextArgs) => {
       currentArgs = nextArgs.length > 0 ? nextArgs : currentArgs
       run()
+    },
+    unmount: () => {
+      if (unmounted) return
+      unmounted = true
+      // React tears effects down in the order they were registered.
+      for (const slot of _slots) {
+        if (slot && typeof slot.cleanup === 'function') {
+          slot.cleanup()
+          slot.cleanup = null
+        }
+      }
     },
   }
 }

--- a/frontend/src/components/ChatView/hooks/__tests__/useOffscreenNudge.test.js
+++ b/frontend/src/components/ChatView/hooks/__tests__/useOffscreenNudge.test.js
@@ -7,6 +7,7 @@ import { renderHook } from './react-hook-shim.mjs'
 import useOffscreenNudge, {
   isElementOffscreen,
   isIntersectionOffscreen,
+  useNudgeTargetRef,
 } from '../useOffscreenNudge.js'
 
 
@@ -16,6 +17,47 @@ function rect(top, bottom) {
 
 function elementAt(top, bottom) {
   return { getBoundingClientRect: () => rect(top, bottom) }
+}
+
+
+// Records every observer the hook creates so a test can prove WHICH node is
+// actually being watched. The defect class here is an observer left on a node
+// React has detached — invisible if you only read the returned boolean.
+function withObserverSpy(run) {
+  const original = globalThis.IntersectionObserver
+  const created = []
+  class SpyObserver {
+    constructor(callback) {
+      this.callback = callback
+      this.observed = []
+      this.disconnected = false
+      created.push(this)
+    }
+
+    observe(element) { this.observed.push(element) }
+
+    disconnect() { this.disconnected = true }
+
+    // Drive the async half of the contract: the browser invokes this after
+    // paint whenever the observed node crosses the root's bounds.
+    report(isIntersecting) { this.callback([{ isIntersecting }]) }
+  }
+  globalThis.IntersectionObserver = SpyObserver
+  try {
+    return run(created)
+  } finally {
+    globalThis.IntersectionObserver = original
+  }
+}
+
+
+// The real wiring: the card publishes its own node through a callback ref and
+// the hook watches whatever is currently published. Mirrors ChatView, which
+// hands the SAME ref to the live streaming surface and the durable message row.
+function useNudgedCard(scrollRef, active) {
+  const [element, cardRef] = useNudgeTargetRef()
+  const offscreen = useOffscreenNudge(scrollRef, active, element)
+  return { offscreen, cardRef }
 }
 
 
@@ -48,36 +90,184 @@ test('observer delivery requires positive visible area', () => {
 })
 
 test('mount computes committed geometry before observer delivery', () => {
-  const originalObserver = globalThis.IntersectionObserver
-  class IdleObserver {
-    observe() {}
-    disconnect() {}
-  }
-  globalThis.IntersectionObserver = IdleObserver
-
-  try {
+  withObserverSpy(() => {
     const scrollRef = { current: elementAt(100, 500) }
     const visible = elementAt(200, 400)
     const { result, rerender } = renderHook(
-      useOffscreenNudge,
-      scrollRef,
-      true,
-      () => visible,
-      ['messages-v1'],
+      useOffscreenNudge, scrollRef, true, visible,
     )
     assert.equal(result.current, false,
       'a visible question must not wait for IntersectionObserver to hide the cue')
 
     const hiddenBelow = elementAt(600, 800)
-    rerender(
-      scrollRef,
-      true,
-      () => hiddenBelow,
-      ['messages-v2'],
-    )
+    rerender(scrollRef, true, hiddenBelow)
     assert.equal(result.current, true,
-      'a newly rebound offscreen question is exposed in the same layout pass')
-  } finally {
-    globalThis.IntersectionObserver = originalObserver
-  }
+      'a newly bound offscreen question is exposed in the same layout pass')
+  })
+})
+
+test('a card publishing through the target ref is observed once it mounts', () => {
+  withObserverSpy(created => {
+    const scrollRef = { current: elementAt(100, 500) }
+    const { result } = renderHook(useNudgedCard, scrollRef, true)
+    assert.equal(result.current.offscreen, false,
+      'no card has mounted yet, so there is nowhere to nudge the owner toward')
+    assert.equal(created.length, 0)
+
+    const card = elementAt(600, 800)
+    result.current.cardRef(card)
+    assert.equal(result.current.offscreen, true)
+    assert.equal(created.length, 1)
+    assert.deepEqual(created[0].observed, [card])
+  })
+})
+
+test('a question card that re-mounts onto a new DOM node keeps the offscreen cue truthful', () => {
+  withObserverSpy(created => {
+    // The turn is parked on the question, so nothing but the card's own node
+    // changes in this commit — exactly the case the old find-at-bind contract
+    // missed. The observer stayed on the detached streaming node, and with no
+    // further renders coming the pill could never clear again.
+    const scrollRef = { current: elementAt(100, 500) }
+    const { result } = renderHook(useNudgedCard, scrollRef, true)
+
+    const liveCard = elementAt(600, 800)
+    result.current.cardRef(liveCard)
+    assert.equal(created.length, 1)
+
+    // Live streaming surface → durable message row: React detaches the removed
+    // node's ref, then attaches the new row's.
+    result.current.cardRef(null)
+    const durableCard = elementAt(620, 820)
+    result.current.cardRef(durableCard)
+
+    assert.equal(created[0].disconnected, true,
+      'the observer on the detached streaming node must be torn down')
+    const bound = created[created.length - 1]
+    assert.deepEqual(bound.observed, [durableCard],
+      'the node currently rendering the card is the node being observed')
+    assert.equal(bound.disconnected, false)
+    assert.equal(result.current.offscreen, true,
+      'the card is still out of view, so the cue must still be showing')
+  })
+})
+
+test('the cue clears when the card scrolls into view after a live-to-durable handoff', () => {
+  withObserverSpy(created => {
+    const scrollRef = { current: elementAt(100, 500) }
+    const { result } = renderHook(useNudgedCard, scrollRef, true)
+
+    result.current.cardRef(elementAt(600, 800))
+    result.current.cardRef(null)
+    result.current.cardRef(elementAt(620, 820))
+    assert.equal(result.current.offscreen, true)
+
+    // Post-handoff scroll. Only an observer bound to the CURRENT node can
+    // report this, so a stale binding surfaces here as a stuck cue.
+    created[created.length - 1].report(true)
+    assert.equal(result.current.offscreen, false)
+  })
+})
+
+test('a handoff onto an already-visible row clears the cue without waiting for the observer', () => {
+  withObserverSpy(() => {
+    const scrollRef = { current: elementAt(100, 500) }
+    const { result } = renderHook(useNudgedCard, scrollRef, true)
+
+    result.current.cardRef(elementAt(600, 800))
+    assert.equal(result.current.offscreen, true)
+
+    // The durable row renders where the owner is already looking. The
+    // synchronous pre-paint recompute owns this: IntersectionObserver does not
+    // deliver until after the next paint, which would leave a frame of cue
+    // pointing at a card that is on screen.
+    result.current.cardRef(null)
+    result.current.cardRef(elementAt(200, 400))
+    assert.equal(result.current.offscreen, false)
+  })
+})
+
+test('an unmounting card clears the cue and releases its observer', () => {
+  withObserverSpy(created => {
+    const scrollRef = { current: elementAt(100, 500) }
+    const { result } = renderHook(useNudgedCard, scrollRef, true)
+
+    result.current.cardRef(elementAt(600, 800))
+    assert.equal(result.current.offscreen, true)
+
+    result.current.cardRef(null)
+    assert.equal(result.current.offscreen, false,
+      'there is no card left to send the owner back to')
+    assert.equal(created[0].disconnected, true)
+  })
+})
+
+test('the cue retires when the pending state ends even with the card still mounted', () => {
+  withObserverSpy(created => {
+    const scrollRef = { current: elementAt(100, 500) }
+    const offscreenCard = elementAt(600, 800)
+    const { result, rerender } = renderHook(
+      useOffscreenNudge, scrollRef, true, offscreenCard,
+    )
+    assert.equal(result.current, true)
+
+    rerender(scrollRef, false, offscreenCard)
+    assert.equal(result.current, false,
+      'an answered question retires the cue regardless of geometry')
+    assert.equal(created[0].disconnected, true)
+  })
+})
+
+test('the target ref is stable across renders so memoized rows keep publishing', () => {
+  const { result } = renderHook(useNudgeTargetRef)
+  const [, first] = result.current
+  const node = elementAt(0, 10)
+  first(node)
+  const [element, second] = result.current
+  assert.equal(element, node)
+  assert.equal(second, first,
+    'a fresh ref identity every render would churn every card it is passed to')
+})
+
+test('leaving the chat disconnects the observer', () => {
+  // The teardown no dep change can reach. Without it a chat switch leaves a
+  // live IntersectionObserver rooted at the old scroll container for every
+  // parked question the owner ever scrolled away from.
+  withObserverSpy(created => {
+    const scrollRef = { current: elementAt(100, 500) }
+    const { result, unmount } = renderHook(useNudgedCard, scrollRef, true)
+
+    result.current.cardRef(elementAt(600, 800))
+    assert.equal(created.length, 1)
+    assert.equal(created[0].disconnected, false)
+
+    unmount()
+    assert.equal(created[0].disconnected, true,
+      'the observer must be released with the component, not leaked')
+  })
+})
+
+test('a batched live-to-durable handoff never blanks the cue', () => {
+  // React commits the retiring surface's `ref(null)` and the arriving
+  // surface's `ref(node)` in ONE pass, so the intermediate "no element" state
+  // is never rendered. The hook must therefore reach the new node's geometry
+  // from a single effect run — a handoff that only works because it was
+  // observed as two commits would flicker the cue for a frame in the browser.
+  withObserverSpy(created => {
+    const scrollRef = { current: elementAt(100, 500) }
+    const offscreenLive = elementAt(600, 800)
+    const offscreenDurable = elementAt(700, 900)
+    const { result, rerender } = renderHook(
+      useOffscreenNudge, scrollRef, true, offscreenLive,
+    )
+    assert.equal(result.current, true)
+    assert.deepEqual(created[0].observed, [offscreenLive])
+
+    // One render, one new node: exactly what a batched handoff commits.
+    rerender(scrollRef, true, offscreenDurable)
+    assert.equal(result.current, true, 'the cue stays up across the handoff')
+    assert.equal(created.length, 2, 'the observer re-binds to the new node')
+    assert.deepEqual(created[1].observed, [offscreenDurable])
+    assert.equal(created[0].disconnected, true, 'the old observer is released')
+  })
 })

--- a/frontend/src/components/ChatView/hooks/useOffscreenNudge.js
+++ b/frontend/src/components/ChatView/hooks/useOffscreenNudge.js
@@ -1,7 +1,7 @@
 /* Tracks whether a footer attention target is outside the chat viewport. */
 import {
+  useCallback,
   useLayoutEffect,
-  useRef,
   useState,
 } from 'react'
 
@@ -22,19 +22,38 @@ export function isIntersectionOffscreen(entry) {
 }
 
 
-// `findElement` is a fresh closure every render (it reads the live scroll
-// ref), so keep it out of the dependency list. Rebinding on every streamed
-// token would replace the observer continuously; callers instead provide the
-// rendering-surface values that can replace the target node.
-export default function useOffscreenNudge(
-  scrollRef,
-  active,
-  findElement,
-  rebindDeps,
-) {
+/**
+ * Publishes the DOM node a nudge watches, as a render input.
+ *
+ * The watched card is NOT one durable node. A pending question is rendered by
+ * the live streaming <li> while the turn runs and by the DURABLE message row
+ * once the turn parks (streamItemQuestionKeys suppresses whichever copy is not
+ * current), so React genuinely mounts a NEW element mid-turn. Node identity is
+ * therefore the only honest dependency for the observer below, and it must
+ * arrive through STATE: a `useRef` mutation does not re-render, so the effect
+ * would never re-run and the observer would stay bound to the detached node.
+ * With the turn parked awaiting an answer nothing else re-renders, so that
+ * observer is the only signal that could ever clear the cue.
+ *
+ * Returns `[element, ref]`. Attach `ref` to the element that IS the target,
+ * and only while it is the pending one; every render path for that card must
+ * publish through this same channel so a surface handoff is just a node swap.
+ */
+export function useNudgeTargetRef() {
+  const [element, setElement] = useState(null)
+  // Stable identity: this ref is passed as a prop across memoized component
+  // boundaries (MsgContent, ActiveAssistantSurface), which compare by identity.
+  const ref = useCallback(node => setElement(node ?? null), [])
+  return [element, ref]
+}
+
+
+// `element` is the node to watch — the hook is not given a way to FIND it.
+// Handing it the node makes a stale observer unrepresentable: any swap of the
+// rendering surface changes this identity, so the effect re-binds by
+// construction instead of relying on a caller to enumerate rebind triggers.
+export default function useOffscreenNudge(scrollRef, active, element) {
   const [offscreen, setOffscreen] = useState(false)
-  const findElementRef = useRef(findElement)
-  findElementRef.current = findElement
 
   useLayoutEffect(() => {
     if (!active) {
@@ -43,7 +62,6 @@ export default function useOffscreenNudge(
     }
 
     const scrollEl = scrollRef.current
-    const element = findElementRef.current()
     if (!scrollEl || !element) {
       setOffscreen(false)
       return undefined
@@ -60,8 +78,7 @@ export default function useOffscreenNudge(
     }, { root: scrollEl, threshold: 0 })
     observer.observe(element)
     return () => observer.disconnect()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [active, scrollRef, ...rebindDeps])
+  }, [active, scrollRef, element])
 
   return offscreen
 }


### PR DESCRIPTION
## Problem

The "tap to answer" cue for a pending question could stick on screen while the
question card was fully visible — and, because the turn is parked waiting on the
answer, it could never clear on its own. Only a reload cleared it. Same steps,
different outcome, so it read as random. The resume cue had the identical shape.

## Root cause

`useOffscreenNudge` resolved its observed target with a one-shot `querySelector`
inside its own layout effect, while callers passed a hand-maintained list of
rebind triggers. The pending question card genuinely changes DOM node mid-turn:
it is rendered by the live streaming surface first and by the durable message
row after promotion. Any commit that performed that handoff without one of the
enumerated triggers changing left the `IntersectionObserver` bound to a node
React had already detached — so it reported nothing, ever again. With the turn
parked awaiting an answer, nothing re-renders to rebind it. Whether a refresh
landed inside that particular commit was a race, which is exactly why it was
intermittent.

## Fix

The hook now takes the ELEMENT rather than a finder plus a trigger list, so node
identity IS the effect dependency and a stale observer becomes unrepresentable —
there is no list to keep in sync and no way to forget an entry.

Identity is published by `useNudgeTargetRef()`, a `useState`-backed callback ref
that is stable across renders, threaded to `QuestionCard` through both render
paths. Both surfaces publish through the same channel, so the live-to-durable
handoff reaches the observer as an ordinary node swap.

Only the card that actually blocks the turn publishes: the unanswered tail
question, and the tail resumable note. The tail gate lives at the publication
site because `MsgContent` renders a Resume button on every resumable block of
the last message, and one shared callback ref has exactly one slot — the same
`.pop()` semantics the old `querySelectorAll` lookup had, now expressed where it
can't drift from what arms the cue.

The pre-paint recompute that keeps a newly visible card from painting beneath a
stale cue is unchanged; it now runs on the published node.

## Test evidence

Applied alone on `main` (c00b9bd7e), with no other change present:
`frontend/` `npm test` → **1977 passed, 0 failed** (1967 on `main`).

Nine new `useOffscreenNudge` cases cover a card remounting onto a new node, the
live-to-durable handoff (including a batched one, which must never blank the
cue), a handoff onto an already-visible row, the cue retiring when the pending
state ends, ref stability across renders so memoized rows keep publishing, and
observer release on unmount. `resumeAffordance.test.js` pins that both nudges
observe a node published by the card rather than a lookup.

The hook test shim gained real effect cleanup and `unmount()` semantics, without
which a leaked observer is indistinguishable from a released one and the
teardown path is untestable.

Mutation-checked: restoring the lookup-based bind fails a named test.

Frontend only; no restart required.