### PR TITLE
Publish a daily Railway image

### DIFF
--- a/.github/workflows/image-cache.yml
+++ b/.github/workflows/image-cache.yml
@@ -1,38 +1,81 @@
-name: Image cache
+name: Daily image
 
 on:
   push:
     branches: [main]
+  schedule:
+    # Rebuild pinned source and refresh base-system packages once per day.
+    - cron: '17 3 * * *'
+  workflow_dispatch:
 
 permissions:
   contents: read
+  packages: write
 
 env:
   # Keep the useful build summary without retaining an unused Buildx record.
   DOCKER_BUILD_RECORD_UPLOAD: 'false'
 
-# A newer main contains every older merge, so an obsolete cache refresh has no
+# A newer main contains every older merge, so an obsolete image publish has no
 # value once the next one starts.
 concurrency:
-  group: image-cache-main
+  group: daily-image-main
   cancel-in-progress: true
 
 jobs:
-  image-cache:
+  publish:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Refresh shared image cache
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve build identity
+        id: identity
+        run: echo "date=$(git show -s --format=%cs HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Build and publish daily image
         uses: docker/build-push-action@v7
         with:
           context: .
-          outputs: type=cacheonly
+          push: true
+          tags: ghcr.io/mobius-os/mobius:daily
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
           build-args: |
             BUILD_SHA=${{ github.sha }}
+            BUILD_DATE=${{ steps.identity.outputs.date }}
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
+          # Scheduled/manual runs deliberately refresh moving system packages;
+          # pushes still take the fast cached path for the new source revision.
+          no-cache: ${{ github.event_name != 'push' }}
+
+      - name: Verify the open-source image is public
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          for attempt in 1 2 3 4 5; do
+            if gh api --method PATCH \
+              "/orgs/${GITHUB_REPOSITORY_OWNER}/packages/container/mobius" \
+              -f visibility=public; then
+              break
+            fi
+            if [ "$attempt" = 5 ]; then
+              echo "Could not make ghcr.io/mobius-os/mobius public" >&2
+              exit 1
+            fi
+            sleep 3
+          done
+          docker logout ghcr.io
+          docker buildx imagetools inspect ghcr.io/mobius-os/mobius:daily

--- a/backend/tests/test_verify_test_runtime.py
+++ b/backend/tests/test_verify_test_runtime.py
@@ -432,7 +432,7 @@ def test_documented_browser_commands_use_disposable_runner():
   assert '/home/' not in test_script
 
 
-def test_pull_requests_run_required_suites_and_main_only_refreshes_cache():
+def test_pull_requests_run_required_suites_and_main_publishes_daily_image():
   test_workflow = (ROOT / ".github" / "workflows" / "test.yml").read_text(
     encoding="utf-8"
   )
@@ -460,8 +460,13 @@ def test_pull_requests_run_required_suites_and_main_only_refreshes_cache():
 
   assert "push:\n" in cache_triggers
   assert "    branches: [main]\n" in cache_triggers
+  assert "schedule:\n" in cache_triggers
+  assert "workflow_dispatch:\n" in cache_triggers
   assert "pull_request:\n" not in cache_triggers
-  assert "outputs: type=cacheonly" in cache_workflow
+  assert "packages: write" in cache_workflow
+  assert "push: true" in cache_workflow
+  assert "tags: ghcr.io/mobius-os/mobius:daily" in cache_workflow
+  assert "docker buildx imagetools inspect ghcr.io/mobius-os/mobius:daily" in cache_workflow
   assert "cache-to: type=gha,mode=max,ignore-error=true" in cache_workflow
   assert "load: true" not in cache_workflow
 


### PR DESCRIPTION
## Summary

- publish `ghcr.io/mobius-os/mobius:daily` on every main update and on a daily schedule
- reuse the existing GitHub Actions layer cache for push builds while forcing scheduled builds to refresh moving system packages
- mark the open-source GHCR package public and fail unless it is anonymously pullable
- preserve exact source/build identity in the image

This prebuilt image lets Railway skip the repository build phase and only pull/start the container.

## Verification

- `actionlint .github/workflows/image-cache.yml`
- workflow YAML parse
- `git diff --check`
