### PR TITLE
test(platform-update): disable git auto-gc to fix intermittent exit-128 flake

### DIFF
--- a/backend/tests/test_platform_update.py
+++ b/backend/tests/test_platform_update.py
@@ -31,8 +31,14 @@ from app import platform_update as pu
 
 
 def _git(cwd: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess:
+  # gc.auto=0: tests that build many commits in a tight loop (e.g. the
+  # beyond-the-render-cap commit-count preview test) otherwise let a `git commit`
+  # fork a detached background `git gc`, which then races the NEXT commit for the
+  # repo lock and fails it with a fatal exit 128 — an intermittent CI flake.
+  # Disabling auto-gc for these throwaway repos removes the race.
   return subprocess.run(
-    ["git", "-c", "user.name=t", "-c", "user.email=t@t", "-C", str(cwd), *args],
+    ["git", "-c", "gc.auto=0", "-c", "user.name=t", "-c", "user.email=t@t",
+     "-C", str(cwd), *args],
     capture_output=True, text=True, check=check,
   )
 


### PR DESCRIPTION
## Problem

`backend/tests/test_platform_update.py` builds many commits in a tight loop through the shared `_git` helper (e.g. `test_update_preview_reports_exact_total_beyond_rendered_commit_cap` creates 100+ commits). A `git commit` can fork a **detached background `git gc`** (auto-gc), which then races the *next* commit for the repository lock and fails it with a fatal **exit 128** — an intermittent CI flake. It red-failed a recent batch and, earlier, PR #246.

## Fix

Add `-c gc.auto=0` to the `_git` test helper, disabling auto-gc for these throwaway test repos. No background gc means no lock race. Test-only change — no product code, no test semantics affected.

## Verification

- The target `...beyond_rendered_commit_cap` test passes **5/5** run back-to-back.
- The full `test_platform_update.py` suite (**66 tests**) is green.

## Why `gc.auto=0` (not a retry)

The failure is a *lock race* created by git's own background maintenance, not a product bug or a legitimately-failing assertion. Disabling auto-gc removes the cause outright, rather than papering over it with a retry that would still occasionally pay the race's latency and could mask a real future failure.