### PR TITLE
Fix the package settings link

### DIFF
--- a/.github/workflows/image-cache.yml
+++ b/.github/workflows/image-cache.yml
@@ -71,7 +71,7 @@ jobs:
             if [ "$attempt" = 6 ]; then
               echo "ghcr.io/mobius-os/mobius:daily is not public" >&2
               echo "Set the package visibility once at:" >&2
-              echo "https://github.com/orgs/mobius-os/packages/container/package/mobius/settings" >&2
+              echo "https://github.com/orgs/mobius-os/packages/container/mobius/settings" >&2
               exit 1
             fi
             sleep 5


### PR DESCRIPTION
## Summary
- correct the GitHub Container package settings URL shown when the daily image is private

## Verification
- actionlint passes
- workflow contract test passes
- git diff --check passes