### PR TITLE
test(platform-update): surface git stderr so the intermittent exit-128 is diagnosable

### DIFF
--- a/backend/tests/test_platform_update.py
+++ b/backend/tests/test_platform_update.py
@@ -31,10 +31,23 @@ from app import platform_update as pu
 
 
 def _git(cwd: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess:
-  return subprocess.run(
+  proc = subprocess.run(
     ["git", "-c", "user.name=t", "-c", "user.email=t@t", "-C", str(cwd), *args],
-    capture_output=True, text=True, check=check,
+    capture_output=True, text=True,
   )
+  if check and proc.returncode != 0:
+    # Preserve the CalledProcessError type, but attach git's stderr as an
+    # exception note so the traceback shows git's actual `fatal:` line. The
+    # default check=True message is only "... exit status N", which is why the
+    # intermittent exit-128 failure this suite has hit in CI was undiagnosable:
+    # git's own error text was swallowed. Surfacing it lets the next occurrence
+    # name its own cause instead of leaving us to guess.
+    err = subprocess.CalledProcessError(
+      proc.returncode, proc.args, output=proc.stdout, stderr=proc.stderr,
+    )
+    err.add_note(f"git stderr: {proc.stderr.strip() or '(empty)'}")
+    raise err
+  return proc
 
 
 # A trivially-importable backend so the import probe (`import app.main` with cwd


### PR DESCRIPTION
## Problem

`test_platform_update.py` intermittently fails in CI with a git **exit 128** (it red-failed a recent batch and PR #246 before). But the cause has never been visible: `_git` runs with `check=True`, and `CalledProcessError`'s message is only *"Command … returned non-zero exit status N"* — **git's own `fatal:` line is swallowed**, so CI logs never say *what* failed.

## What this is NOT

An earlier hypothesis blamed git auto-gc. That's wrong at this scale: the test's ~100-commit repo triggers **no** gc work (0 packs, no commit-graph/packed-refs, well under git's 6,700-object threshold), so the spawned `git gc --auto` child is a no-op that takes no lock and can't race. The flake also did not reproduce locally across ~13k commits including 16-way parallel load — it's CI-environment-specific.

## Fix

Surface git's stderr. On a failing `_git`, attach git's stderr as an **exception note** (`err.add_note(...)`), preserving the `CalledProcessError` type. The next time this flakes in CI, the traceback will show git's actual `fatal:` line — turning an undiagnosable flake into one we can fix at the root.

This is deliberately a *diagnosis* change, not a blind "fix": the honest blocker to fixing the real cause is that the cause is invisible. This makes it visible.

## Verification

- Full `test_platform_update.py` suite: **66 passed**.
- A real `exit 128` (`git commit` outside a repo) now reports `git stderr: fatal: not a git repository …` via the note.