### PR TITLE
shell: copy button in the corner of every markdown code block

### DIFF
--- a/frontend/src/components/ChatView/__tests__/codeBlockCopy.test.js
+++ b/frontend/src/components/ChatView/__tests__/codeBlockCopy.test.js
@@ -42,6 +42,7 @@ test('copy button is pinned outside the scrolling pre', () => {
 
   const css = stripComments(markdownCss)
   const wrapRule = css.match(/\.md-code-wrap\s*\{[^}]*\}/)?.[0] || ''
+  const blockRule = css.match(/\.md-code-block\s*\{[^}]*\}/)?.[0] || ''
   const copyRule = css.match(/\.md-code-copy\s*\{[^}]*\}/)?.[0] || ''
 
   assert.match(wrapRule, /position:\s*relative/,
@@ -49,6 +50,8 @@ test('copy button is pinned outside the scrolling pre', () => {
   assert.match(copyRule, /position:\s*absolute/, 'button floats over the block')
   assert.match(copyRule, /right:\s*\d/, 'anchored to the right edge')
   assert.match(copyRule, /bottom:\s*\d/, 'anchored to the bottom edge (lower-right)')
+  assert.match(blockRule, /padding:\s*14px\s+16px\s+40px/,
+    'the code block reserves a row so the button cannot obscure its last line')
 })
 
 test('copied acknowledgement resets and cleans up its timer', () => {

--- a/frontend/src/components/ChatView/__tests__/codeBlockCopy.test.js
+++ b/frontend/src/components/ChatView/__tests__/codeBlockCopy.test.js
@@ -1,0 +1,59 @@
+/**
+ * Markdown code blocks carry a copy button in the lower-right corner.
+ *
+ * Source-wiring tests: the button copies the raw token text through the
+ * shared copyPlainText helper (clipboard API + textarea fallback), sits in a
+ * non-scrolling wrapper so it stays pinned while long lines scroll, and
+ * acknowledges with a check icon.
+ *
+ * Run with:
+ *   cd frontend && node --test \
+ *     src/components/ChatView/__tests__/codeBlockCopy.test.js
+ */
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+const blocksJsx = readFileSync(
+  new URL('../markdown/blocks.jsx', import.meta.url), 'utf8')
+const markdownCss = readFileSync(
+  new URL('../markdown.css', import.meta.url), 'utf8')
+
+function stripComments(css) {
+  return css.replace(/\/\*[\s\S]*?\*\//g, '')
+}
+
+test('code block copy button copies raw text via the shared helper', () => {
+  assert.match(blocksJsx, /import \{ copyPlainText \} from '\.\.\/messageCopy\.js'/,
+    'reuse the shared clipboard helper (API + textarea fallback), not a bespoke path')
+  assert.match(blocksJsx, /copyPlainText\(code\)/,
+    'the raw token text is copied — never the highlighted HTML')
+  assert.match(blocksJsx, /className=\{`md-code-copy/,
+    'CodeBlock renders the md-code-copy button')
+  assert.match(blocksJsx, /aria-label=\{copied \? 'Copied' : 'Copy code'\}/,
+    'button announces its state to assistive tech')
+})
+
+test('copy button is pinned outside the scrolling pre', () => {
+  // An absolutely positioned child of the scrolling <pre> would ride along
+  // with long lines; the wrapper must own the positioning context.
+  assert.match(blocksJsx, /<div className="md-code-wrap">\s*<pre className="md-code-block">/,
+    'the button anchors to a wrapper around the <pre>, not inside it')
+
+  const css = stripComments(markdownCss)
+  const wrapRule = css.match(/\.md-code-wrap\s*\{[^}]*\}/)?.[0] || ''
+  const copyRule = css.match(/\.md-code-copy\s*\{[^}]*\}/)?.[0] || ''
+
+  assert.match(wrapRule, /position:\s*relative/,
+    'wrapper establishes the positioning context')
+  assert.match(copyRule, /position:\s*absolute/, 'button floats over the block')
+  assert.match(copyRule, /right:\s*\d/, 'anchored to the right edge')
+  assert.match(copyRule, /bottom:\s*\d/, 'anchored to the bottom edge (lower-right)')
+})
+
+test('copied acknowledgement resets and cleans up its timer', () => {
+  assert.match(blocksJsx, /setTimeout\(\(\) => setCopied\(false\)/,
+    'check icon reverts to the copy glyph after a beat')
+  assert.match(blocksJsx, /useEffect\(\(\) => \(\) => clearTimeout\(copyTimerRef\.current\), \[\]\)/,
+    'pending timer is cleared on unmount')
+})

--- a/frontend/src/components/ChatView/markdown.css
+++ b/frontend/src/components/ChatView/markdown.css
@@ -42,7 +42,9 @@
   background: var(--surface);
   border: 1px solid var(--border-light);
   border-radius: 10px;
-  padding: 14px 16px;
+  /* Reserve the button's row so the last code line never sits underneath the
+     always-visible touch target. Horizontal overflow remains owned by <pre>. */
+  padding: 14px 16px 40px;
   font-size: 13px;
   font-family: var(--mono);
   overflow-x: auto;

--- a/frontend/src/components/ChatView/markdown.css
+++ b/frontend/src/components/ChatView/markdown.css
@@ -30,6 +30,14 @@
 .md-heading--3 { font-size: 15px; }
 .md-heading--4, .md-heading--5, .md-heading--6 { font-size: 14.5px; }
 
+/* The wrapper (not the <pre>) anchors the copy button: an absolutely
+   positioned child of a scrolling <pre> would ride along with long lines,
+   so the button lives beside the <pre> and stays pinned to the corner. */
+.md-code-wrap {
+  position: relative;
+  min-width: 0;
+}
+
 .md-code-block {
   background: var(--surface);
   border: 1px solid var(--border-light);
@@ -40,6 +48,38 @@
   overflow-x: auto;
   white-space: pre;
   line-height: 1.6;
+}
+
+.md-code-copy {
+  position: absolute;
+  right: 7px;
+  bottom: 7px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: 1px solid var(--border-light);
+  border-radius: 7px;
+  background: var(--surface);
+  color: var(--muted);
+  cursor: pointer;
+}
+
+.md-code-copy--copied { color: var(--accent); }
+
+.md-code-copy:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .md-code-copy:hover {
+    background: var(--surface2);
+    color: var(--text);
+  }
+  .md-code-copy--copied:hover { color: var(--accent); }
 }
 
 .md-code-lang {

--- a/frontend/src/components/ChatView/markdown/blocks.jsx
+++ b/frontend/src/components/ChatView/markdown/blocks.jsx
@@ -1,6 +1,9 @@
-import { useEffect, useState, memo } from 'react'
+import { useEffect, useRef, useState, memo } from 'react'
 import DOMPurify from 'dompurify'
+import Check from 'lucide-react/dist/esm/icons/check.mjs'
+import Copy from 'lucide-react/dist/esm/icons/copy.mjs'
 import InlineContent from './InlineContent.jsx'
+import { copyPlainText } from '../messageCopy.js'
 import { useMathHtml } from './math.js'
 import { highlightSync, highlightCode } from './highlight.js'
 
@@ -36,6 +39,11 @@ export function CodeBlock({ token }) {
   const syncHtml = highlightSync(code, lang)
   const [asyncHtml, setAsyncHtml] = useState(null)
 
+  // Copy affordance: the raw token text goes to the clipboard (never the
+  // highlighted HTML), with a brief check-icon acknowledgement.
+  const [copied, setCopied] = useState(false)
+  const copyTimerRef = useRef(null)
+
   useEffect(() => {
     if (syncHtml) return  // already highlighted synchronously
     let cancelled = false
@@ -45,22 +53,44 @@ export function CodeBlock({ token }) {
     return () => { cancelled = true }
   }, [code, lang, syncHtml])
 
+  useEffect(() => () => clearTimeout(copyTimerRef.current), [])
+
+  async function copyCode() {
+    if (!(await copyPlainText(code))) return
+    setCopied(true)
+    clearTimeout(copyTimerRef.current)
+    copyTimerRef.current = setTimeout(() => setCopied(false), 1600)
+  }
+
   const html = syncHtml || asyncHtml
 
   return (
-    <pre className="md-code-block">
-      {lang && <span className="md-code-lang">{lang}</span>}
-      {html ? (
-        <code
-          className={`md-code language-${lang}`}
-          dangerouslySetInnerHTML={{
-            __html: DOMPurify.sanitize(html),
-          }}
-        />
-      ) : (
-        <code className={`md-code language-${lang}`}>{code}</code>
-      )}
-    </pre>
+    <div className="md-code-wrap">
+      <pre className="md-code-block">
+        {lang && <span className="md-code-lang">{lang}</span>}
+        {html ? (
+          <code
+            className={`md-code language-${lang}`}
+            dangerouslySetInnerHTML={{
+              __html: DOMPurify.sanitize(html),
+            }}
+          />
+        ) : (
+          <code className={`md-code language-${lang}`}>{code}</code>
+        )}
+      </pre>
+      <button
+        type="button"
+        className={`md-code-copy${copied ? ' md-code-copy--copied' : ''}`}
+        onClick={copyCode}
+        aria-label={copied ? 'Copied' : 'Copy code'}
+        title="Copy code"
+      >
+        {copied
+          ? <Check size={13} strokeWidth={2.3} aria-hidden="true" />
+          : <Copy size={13} strokeWidth={2} aria-hidden="true" />}
+      </button>
+    </div>
   )
 }
 


### PR DESCRIPTION
Every fenced code block rendered in chat now carries a small copy button pinned to its lower-right corner.

- Copies the raw token text (never the highlighted HTML) through the shared `copyPlainText` helper, so clipboard behavior (API + textarea fallback) matches the existing tool-output copy action.
- Acknowledges with a brief check icon and an aria-label flip to "Copied"; the acknowledgement only fires when the copy actually succeeded.
- The button anchors to a wrapper around the `<pre>` rather than inside it — an absolutely positioned child of the scrolling `<pre>` would ride along with long lines, so this keeps it pinned to the corner while code scrolls underneath.
- Always visible (not hover-gated) so it works on touch devices; hover and focus-visible styles match the existing tool-output copy affordance.

Tested with three source-wiring unit tests (frontend `node --test`), plus manual verification in the running shell: buttons render on every block, a real click copies and shows the check, and a denied clipboard write shows no false acknowledgement.