### PR TITLE
shell: add 'Close all other tabs' to the tab context menu

### DIFF
--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -4019,6 +4019,22 @@ export default function Shell() {
             >
               Close tab
             </button>
+            {/* Close all other tabs — keep only the right-clicked tab in its
+                pane. Only when a sibling exists (never a no-op menu item);
+                other panes are untouched — the menu stays pane-scoped. */}
+            {menuPane && menuPane.tabs.length >= 2 && (
+              <button
+                type="button"
+                role="menuitem"
+                className="workspace__menu-item"
+                onClick={() => {
+                  dispatchWorkspace({ type: 'CLOSE_OTHER_TABS', tabKey: tabMenu.tabKey })
+                  closeTabMenu()
+                }}
+              >
+                Close all other tabs
+              </button>
+            )}
             {/* Close pane — a keyboard/menu affordance so a multi-tab pane need
                 not be dismissed one ✕ at a time (design §3.6). Only when there is
                 another pane to fall back to (never the single-pane strip). */}

--- a/frontend/src/components/Shell/__tests__/paneModel.test.js
+++ b/frontend/src/components/Shell/__tests__/paneModel.test.js
@@ -1137,6 +1137,36 @@ test('CLOSE_PANE closes a whole pane, is undoable, and names itself', () => {
   assert.equal(undone.ws, ws, 'Undo restores the closed pane and its tabs')
 })
 
+test('CLOSE_OTHER_TABS keeps only the clicked tab, is undoable, and names itself', () => {
+  const ws = paneModel.seedFromFlatTabs([makeTab('chat', 'a'), makeTab('app', 42), makeTab('chat', 'c')])
+  const paneId = ws.focusedPaneId
+  const start = paneModel.initialWorkspaceState(ws)
+  const closed = paneModel.workspaceReducer(start, { type: 'CLOSE_OTHER_TABS', tabKey: 'app:42' })
+  assert.deepEqual(closed.ws.panes[paneId].tabs.map(tabKey), ['app:42'], 'only the kept tab survives')
+  assert.equal(closed.ws.panes[paneId].activeTabKey, 'app:42', 'the kept tab becomes active')
+  assert.equal(closed.undo.toast, 'Closed other tabs')
+  const undone = paneModel.workspaceReducer(closed, { type: 'UNDO_LAST' })
+  assert.equal(undone.ws, ws, 'Undo restores every closed sibling at once')
+  // Already alone or unknown tab: same reference — no undo slot burned.
+  assert.equal(paneModel.workspaceReducer(closed, { type: 'CLOSE_OTHER_TABS', tabKey: 'app:42' }), closed)
+  assert.equal(paneModel.closeOtherTabs(ws, 'chat:nope'), ws)
+})
+
+test('CLOSE_OTHER_TABS is pane-scoped — a sibling pane keeps its tabs', () => {
+  let ws = paneModel.seedFromFlatTabs([makeTab('chat', 'a'), makeTab('chat', 'b')])
+  const leftPane = ws.focusedPaneId
+  ws = paneModel.splitPaneWithTab(ws, makeTab('app', 42), { paneId: leftPane, edge: 'right' })
+  const closed = paneModel.workspaceReducer(
+    paneModel.initialWorkspaceState(ws),
+    { type: 'CLOSE_OTHER_TABS', tabKey: 'chat:a' },
+  )
+  assert.deepEqual(closed.ws.panes[leftPane].tabs.map(tabKey), ['chat:a'])
+  assert.ok(
+    paneModel.flatten(closed.ws).map(tabKey).includes('app:42'),
+    'the other pane is untouched',
+  )
+})
+
 test('reducer APPLY_PLACEMENT composes batched dispatches instead of clobbering', () => {
   // The former bug: two placements resolved against the same stale render
   // snapshot, so the second REPLACED the first. A resolve function run against

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -144,6 +144,12 @@ test('the context menu offers Close pane when another pane can absorb the space'
   assert.match(shell, /Close pane/)
 })
 
+test('the context menu offers Close all other tabs only when a sibling tab exists', () => {
+  assert.match(shell, /menuPane && menuPane\.tabs\.length >= 2/)
+  assert.match(shell, /type: 'CLOSE_OTHER_TABS', tabKey: tabMenu\.tabKey/)
+  assert.match(shell, /Close all other tabs/)
+})
+
 test('tab labels resolve through memoized id Maps, not per-render linear scans', () => {
   // labelForTab and the single-pane strip use O(1) Map lookups keyed by id.
   assert.match(shell, /const chatById = useMemo/)

--- a/frontend/src/components/Shell/paneModel.js
+++ b/frontend/src/components/Shell/paneModel.js
@@ -907,6 +907,23 @@ export function closePane(ws, paneId) {
   })
 }
 
+// Close every OTHER tab in the kept tab's pane (the context-menu "Close all
+// other tabs" affordance). The kept tab becomes the pane's active tab — the
+// gesture's intent is "just this one". Scoped to ONE pane on purpose: other
+// panes are surfaces the owner arranged deliberately, and this menu never
+// reaches across them. The pane can never empty (the kept tab survives), so
+// no auto-return applies. Reversible — the reducer snapshot restores the
+// closed tabs. Same reference on a no-op (unknown tab, or already alone).
+export function closeOtherTabs(ws, tabKey) {
+  const pane = paneOf(ws, tabKey)
+  if (!pane || pane.tabs.length <= 1) return ws
+  const kept = pane.tabs.find(tab => tabModel.tabKey(tab) === tabKey)
+  return commit(ws, {
+    ...ws,
+    panes: { ...ws.panes, [pane.id]: { ...pane, tabs: [kept], activeTabKey: tabKey } },
+  })
+}
+
 // Move a tab within/between panes. target is one of:
 //   { paneId, index? }  insert into an existing pane at index (append if absent)
 //   { paneId, edge }    split that pane on the edge, the tab alone in the new one
@@ -1689,6 +1706,15 @@ export function workspaceReducer(state, action) {
       const paneLabel = action.label || 'Closed pane'
       const { ws: closed, autoReturned } = autoReturnIfEmptied(ws, next)
       return { ws: closed, undo: { ws, label: paneLabel, toast: paneLabel, restoreViewMode: autoReturned } }
+    }
+    case 'CLOSE_OTHER_TABS': {
+      // Keep only the named tab in its pane. The kept tab survives, so the pane
+      // never empties — no auto-return branch. One reversible gesture: the
+      // snapshot restores every closed sibling at once.
+      const next = closeOtherTabs(ws, action.tabKey)
+      if (next === ws) return state
+      const label = action.label || 'Closed other tabs'
+      return { ws: next, undo: { ws, label, toast: label } }
     }
     case 'MOVE_TAB': {
       const next = moveTab(ws, action.tabKey, action.target)


### PR DESCRIPTION
## Feature

The tab context menu gains **Close all other tabs**: it keeps only the right-clicked tab in its pane and makes it the pane's active tab.

Semantics:

- **Pane-scoped.** Only siblings in the clicked tab's pane close; tabs in other panes are untouched, matching the menu's existing pane-scoped actions (Split / Move / Close pane).
- **Never a no-op item.** The item renders only when a sibling tab exists, in both the single-pane strip and the per-pane strips.
- **One reversible gesture.** A single undo snapshot ("Closed other tabs" toast) restores every closed sibling at once — the same pattern as `CLOSE_PANE`.
- **No auto-return branch.** The kept tab survives, so the pane can never empty.

## Implementation

- `paneModel.js`: a pure `closeOtherTabs(ws, tabKey)` (same-reference no-op when the tab is unknown or already alone) plus a `CLOSE_OTHER_TABS` reducer case with one undo slot.
- `Shell.jsx`: one gated menu item between "Close tab" and "Close pane".
- Tests: reducer behavior (keep / activate / undo / no-op) and pane-scoping in `paneModel.test.js`; the menu-item contract in `workspaceUi.test.js`.

## Verification

Unit: the Shell test suite passes (151 tests). Live: drove the running shell end-to-end — opened three tabs, right-clicked one, picked "Close all other tabs"; only the clicked tab remained, in both the menu screenshot and the resulting strip. Undo semantics are covered by the reducer tests.