### PR TITLE
Preserve Codex web search sources

### DIFF
--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -593,9 +593,17 @@ def _sdk_imports() -> dict[str, Any]:
     ReasoningSummaryTextDeltaNotification,
     ReasoningTextDeltaNotification,
     ThreadTokenUsageUpdatedNotification,
+    ThreadItem,
     TurnCompletedNotification,
     TurnStatus,
     WebSearchThreadItem,
+  )
+
+  _enable_web_search_results_passthrough(
+    web_search_type=WebSearchThreadItem,
+    thread_item_type=ThreadItem,
+    started_notification_type=ItemStartedNotification,
+    completed_notification_type=ItemCompletedNotification,
   )
 
   # Multi-agent (collab) types exist only on multi-agent-capable SDKs (the
@@ -686,6 +694,39 @@ def _sdk_imports() -> dict[str, Any]:
     "TurnStatus": TurnStatus,
     "WebSearchThreadItem": WebSearchThreadItem,
   }
+
+
+def _enable_web_search_results_passthrough(
+  *,
+  web_search_type: Any,
+  thread_item_type: Any,
+  started_notification_type: Any,
+  completed_notification_type: Any,
+) -> None:
+  """Preserve structured search results during temporary SDK schema drift.
+
+  Codex app-server 0.145 emits ``webSearch.results`` and its Rust protocol plus
+  public app-server documentation declare the field. The generated Python SDK
+  at the same release still omits it and Pydantic silently drops the unknown
+  value before Möbius can turn URLs into source pills.
+
+  Keep extra fields only on this one leaf item, then rebuild the discriminated
+  union and its two notification envelopes. Once the generated type gains a
+  real ``results`` field this is a no-op and normal typed parsing takes over.
+  """
+  if "results" in getattr(web_search_type, "model_fields", {}):
+    return
+  if getattr(web_search_type, "model_config", {}).get("extra") == "allow":
+    return
+  from pydantic import ConfigDict
+
+  config = dict(getattr(web_search_type, "model_config", {}))
+  config["extra"] = "allow"
+  web_search_type.model_config = ConfigDict(**config)
+  web_search_type.model_rebuild(force=True)
+  thread_item_type.model_rebuild(force=True)
+  started_notification_type.model_rebuild(force=True)
+  completed_notification_type.model_rebuild(force=True)
 
 
 def _extract_rate_limit_reset(snapshot) -> tuple[int | None, bool]:

--- a/backend/tests/test_codex_sdk_contract.py
+++ b/backend/tests/test_codex_sdk_contract.py
@@ -209,6 +209,44 @@ def test_lifecycle_notification_fields_and_status_enums_are_pinned():
   }
 
 
+def test_web_search_results_survive_generated_sdk_schema_lag():
+  """App-server result URLs must reach the source-pill extractor.
+
+  Codex 0.145's Rust protocol emits ``webSearch.results`` while the generated
+  Python leaf model still omits that field. The runner installs a narrow
+  passthrough at import time; validate the real notification union so a future
+  SDK refactor cannot silently resume dropping every search result.
+  """
+  pytest.importorskip("openai_codex")
+  from openai_codex.generated import v2_all
+  from app import codex_sdk_runner
+
+  codex_sdk_runner._sdk_imports()
+  payload = v2_all.ItemCompletedNotification.model_validate({
+    "completedAtMs": 1,
+    "threadId": "thread-1",
+    "turnId": "turn-1",
+    "item": {
+      "id": "search-1",
+      "type": "webSearch",
+      "query": "Möbius parity",
+      "results": [{
+        "title": "Structured search result",
+        "url": "https://example.test/result",
+      }],
+    },
+  })
+  item = payload.item.root
+  assert getattr(item, "results") == [{
+    "title": "Structured search result",
+    "url": "https://example.test/result",
+  }]
+  assert codex_sdk_runner._web_search_sources(item) == [{
+    "title": "Structured search result",
+    "url": "https://example.test/result",
+  }]
+
+
 def test_turn_terminal_status_and_message_phase_contracts_are_pinned():
   """The runner must not confuse a terminal envelope with a final answer."""
   pytest.importorskip("openai_codex")


### PR DESCRIPTION
## Summary
- retain structured `webSearch.results` emitted by Codex app-server 0.145
- rebuild only the generated web-search union affected by the temporary Python schema lag
- feed the preserved result URLs into the existing provider-neutral source-pill path

## Tests
- `MOBIUS_TEST_RUNTIME=1 pytest -q backend/tests/test_codex_sdk_contract.py backend/tests/test_codex_sdk_runner.py -q`