### PR TITLE
Surface native Codex image views

### DIFF
--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -584,6 +584,7 @@ def _sdk_imports() -> dict[str, Any]:
     ErrorNotification,
     FileChangePatchUpdatedNotification,
     FileChangeThreadItem,
+    ImageViewThreadItem,
     ItemCompletedNotification,
     ItemGuardianApprovalReviewCompletedNotification,
     ItemGuardianApprovalReviewStartedNotification,
@@ -661,6 +662,7 @@ def _sdk_imports() -> dict[str, Any]:
     "ErrorNotification": ErrorNotification,
     "FileChangePatchUpdatedNotification": FileChangePatchUpdatedNotification,
     "FileChangeThreadItem": FileChangeThreadItem,
+    "ImageViewThreadItem": ImageViewThreadItem,
     "ReasoningEffort": ReasoningEffort,
     "ReasoningSummary": ReasoningSummary,
     "Sandbox": Sandbox,
@@ -1148,6 +1150,13 @@ async def _record_collab_child_links(
 
 def _tool_start_event(item: Any, sdk: dict[str, Any]) -> dict[str, Any] | None:
   """Builds one Möbius `tool_start` event from a typed item."""
+  image_view_cls = sdk.get("ImageViewThreadItem")
+  if image_view_cls is not None and isinstance(item, image_view_cls):
+    return {
+      "type": "tool_start",
+      "tool": "ViewImage",
+      "input": getattr(item, "path", ""),
+    }
   # The invariant is that Codex collab items are ordinary tool activity because
   # the parent stream exposes no per-helper identity. RUNTIME REALITY (verified
   # live on codex 0.144.5, gpt-5.6-sol delegating a sub-task): the SDK streams
@@ -1221,6 +1230,9 @@ def _tool_start_event(item: Any, sdk: dict[str, Any]) -> dict[str, Any] | None:
 
 def _tool_completed_events(item: Any, sdk: dict[str, Any]) -> list[dict[str, Any]]:
   """Builds Möbius tool-end events from a completed typed item."""
+  image_view_cls = sdk.get("ImageViewThreadItem")
+  if image_view_cls is not None and isinstance(item, image_view_cls):
+    return [{"type": "tool_end"}]
   # The invariant is that a Codex collab completion closes the ordinary tool
   # activity opened by _tool_start_event and never manufactures task_done. The
   # optional summary remains defensive for a future SDK that populates

--- a/backend/tests/test_codex_sdk_contract.py
+++ b/backend/tests/test_codex_sdk_contract.py
@@ -173,6 +173,26 @@ def test_subagent_activity_is_natively_modeled_and_fallback_removed():
   assert not hasattr(codex_sdk_runner, "_is_subagent_activity_resume_validation_error")
 
 
+def test_native_image_view_item_is_wired_to_tool_dispatch():
+  """Codex image inspection must not disappear from the visible transcript."""
+  import inspect
+
+  pytest.importorskip("openai_codex")
+  from openai_codex.generated import v2_all
+  from app import codex_sdk_runner
+
+  assert getattr(v2_all, "ImageViewThreadItem", None) is not None
+  assert codex_sdk_runner._sdk_imports()["ImageViewThreadItem"] is (
+    v2_all.ImageViewThreadItem
+  )
+  assert "ImageViewThreadItem" in inspect.getsource(
+    codex_sdk_runner._tool_start_event
+  )
+  assert "ImageViewThreadItem" in inspect.getsource(
+    codex_sdk_runner._tool_completed_events
+  )
+
+
 def test_lifecycle_notification_fields_and_status_enums_are_pinned():
   """Fail loudly if the generated lifecycle surface drifts under the runner."""
   pytest.importorskip("openai_codex")

--- a/backend/tests/test_codex_sdk_runner.py
+++ b/backend/tests/test_codex_sdk_runner.py
@@ -176,6 +176,7 @@ def _fake_sdk(async_codex_cls):
     "ErrorNotification": _FakeErrorNotification,
     "FileChangePatchUpdatedNotification": _Dummy,
     "FileChangeThreadItem": _Dummy,
+    "ImageViewThreadItem": type("_FakeImageViewThreadItem", (), {}),
     "InvalidParamsError": _FakeInvalidParamsError,
     "ReasoningEffort": _FakeReasoningEffort(),
     "ReasoningSummary": _FakeReasoningSummary(),
@@ -250,6 +251,31 @@ def test_tool_completed_events_emit_output_before_end():
       "type": "tool_output", "content": "",
       "output_complete": True, "output_exit_code": 7,
     },
+    {"type": "tool_end"},
+  ]
+
+
+def test_native_image_view_item_uses_shared_view_image_activity():
+  class ImageViewThreadItem:
+    id = "image-1"
+    path = "/data/chats/chat-1/media/diagram.png"
+
+  sdk = {
+    "ImageViewThreadItem": ImageViewThreadItem,
+    "CommandExecutionThreadItem": type("CommandExecutionThreadItem", (), {}),
+    "FileChangeThreadItem": type("FileChangeThreadItem", (), {}),
+    "McpToolCallThreadItem": type("McpToolCallThreadItem", (), {}),
+    "DynamicToolCallThreadItem": type("DynamicToolCallThreadItem", (), {}),
+    "WebSearchThreadItem": type("WebSearchThreadItem", (), {}),
+  }
+
+  item = ImageViewThreadItem()
+  assert codex_sdk_runner._tool_start_event(item, sdk) == {
+    "type": "tool_start",
+    "tool": "ViewImage",
+    "input": "/data/chats/chat-1/media/diagram.png",
+  }
+  assert codex_sdk_runner._tool_completed_events(item, sdk) == [
     {"type": "tool_end"},
   ]
 


### PR DESCRIPTION
## Summary
- import Codex's native `ImageViewThreadItem`
- translate image inspection into the shared `ViewImage` activity used by the transcript
- pin the SDK contract and start/completion event shape with focused tests

## Tests
- `MOBIUS_TEST_RUNTIME=1 pytest -q backend/tests/test_codex_sdk_contract.py backend/tests/test_codex_sdk_runner.py -q`