### PR TITLE
Show live Codex helper lifecycles

### DIFF
--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -972,6 +972,52 @@ def _record_private_lifecycle(bc: Any, event: dict[str, Any] | None) -> None:
     recorder(event)
 
 
+def _public_task_event(
+  lifecycle: dict[str, Any] | None,
+  *,
+  tool_use_id: str,
+) -> dict[str, Any] | None:
+  """Translate one provider-neutral lifecycle fact into the shared chip wire.
+
+  Durable Workflows attribution keeps the richer ``agent_lifecycle`` record.
+  The transcript needs only the same task_start/task_done contract Claude
+  already uses. An activation id, rather than a child thread id, is the public
+  task identity because Codex can resume one helper multiple times in a turn.
+  """
+  if not lifecycle:
+    return None
+  task_id = (
+    lifecycle.get("provider_activation_id")
+    or lifecycle.get("provider_agent_id")
+  )
+  if not task_id:
+    return None
+  event_type = lifecycle.get("event_type")
+  if event_type in ("agent_spawned", "agent_started"):
+    agent_type = str(lifecycle.get("agent_type") or "").strip()
+    return {
+      "type": "task_start",
+      "task_id": str(task_id),
+      "description": (
+        agent_type[:_COLLAB_DESCRIPTION_MAX] or "Background helper"
+      ),
+      "task_type": agent_type or None,
+      "tool_use_id": tool_use_id,
+    }
+  if event_type == "agent_terminal":
+    summary = lifecycle.get("summary")
+    return {
+      "type": "task_done",
+      "task_id": str(task_id),
+      "status": lifecycle.get("state") or "done",
+      "summary": (
+        str(summary)[:_COLLAB_SUMMARY_MAX] if summary is not None else None
+      ),
+      "tool_use_id": tool_use_id,
+    }
+  return None
+
+
 def _collab_reactivation_events(
   item: Any, sdk: dict[str, Any], *, root_thread_id: str | None,
   occurred_at: Any, active: dict[str, str], known: set[str],
@@ -1148,16 +1194,10 @@ async def _record_collab_child_links(
 
 def _tool_start_event(item: Any, sdk: dict[str, Any]) -> dict[str, Any] | None:
   """Builds one Möbius `tool_start` event from a typed item."""
-  # The invariant is that Codex collab items are ordinary tool activity because
-  # the parent stream exposes no per-helper identity. RUNTIME REALITY (verified
-  # live on codex 0.144.5, gpt-5.6-sol delegating a sub-task): the SDK streams
-  # the collab tool ONLY as the `wait` op (a
-  # CollabAgentToolCallThreadItem, unwrapped at payload.item.root), whose
-  # ``receiver_thread_ids`` and ``agents_states`` are both EMPTY. The `Task`
-  # vocabulary folds this generic wait into ActivityStretch as "Working in the
-  # background" without falsely opening Claude's task lifecycle contract. The
-  # named child and its result remain the Workflows app parser's job via the
-  # forked child rollout's parent_thread_id.
+  # Standalone dispatch keeps collab items as ordinary Task activity. The live
+  # loop now groups all such items under one per-turn host and enriches it with
+  # ThreadStarted/ThreadStatus task events, avoiding duplicate Task rows while
+  # retaining this safe fallback for isolated callers and older SDKs.
   collab_cls = sdk.get("CollabAgentToolCallThreadItem")
   if collab_cls is not None and isinstance(item, collab_cls):
     return {
@@ -1221,10 +1261,9 @@ def _tool_start_event(item: Any, sdk: dict[str, Any]) -> dict[str, Any] | None:
 
 def _tool_completed_events(item: Any, sdk: dict[str, Any]) -> list[dict[str, Any]]:
   """Builds Möbius tool-end events from a completed typed item."""
-  # The invariant is that a Codex collab completion closes the ordinary tool
-  # activity opened by _tool_start_event and never manufactures task_done. The
-  # optional summary remains defensive for a future SDK that populates
-  # agents_states; it is always absent at runtime on codex 0.144.5.
+  # Standalone dispatch closes the ordinary Task activity above. The live loop
+  # owns its one per-turn host and bypasses this branch, publishing normalized
+  # task_done events from lifecycle notifications before closing that host.
   collab_cls = sdk.get("CollabAgentToolCallThreadItem")
   if collab_cls is not None and isinstance(item, collab_cls):
     events: list[dict[str, Any]] = []
@@ -2007,6 +2046,9 @@ async def run_codex_sdk_turn(
   first_token_usage: Any | None = None
   final_token_usage: Any | None = None
   process_group_id: int | None = None
+  task_host_open = False
+  task_host_tool_use_id: str | None = None
+  public_task_ids: set[str] = set()
   codex_context = sdk["AsyncCodex"](config=config)
   process_group_capture_stop: asyncio.Event | None = None
   process_group_capture_task: asyncio.Task[int | None] | None = None
@@ -2248,6 +2290,39 @@ async def run_codex_sdk_turn(
       last_activation_by_child: dict[str, str] = {}
       activation_by_call_child: dict[tuple[str, str], str] = {}
       activation_counts: dict[str, int] = {}
+      task_host_tool_use_id = (
+        f"codex-agents:{getattr(turn, 'id', None) or id(turn)}"
+      )
+
+      def ensure_task_host() -> None:
+        nonlocal task_host_open
+        if task_host_open:
+          return
+        bc.publish({
+          "type": "tool_start",
+          "tool": "Task",
+          "input": "Working in the background",
+          "tool_use_id": task_host_tool_use_id,
+        })
+        task_host_open = True
+
+      def record_task_lifecycle(
+        lifecycle: dict[str, Any] | None,
+      ) -> None:
+        _record_private_lifecycle(bc, lifecycle)
+        event = _public_task_event(
+          lifecycle,
+          tool_use_id=task_host_tool_use_id,
+        )
+        if event is None:
+          return
+        ensure_task_host()
+        task_id = str(event["task_id"])
+        if event["type"] == "task_start":
+          public_task_ids.add(task_id)
+        else:
+          public_task_ids.discard(task_id)
+        bc.publish(event)
 
       # Structured rate-limit state, mirroring the Claude runner. Captured from
       # AccountRateLimitsUpdatedNotification during the turn so a Codex quota
@@ -2306,10 +2381,18 @@ async def run_codex_sdk_turn(
           if isinstance(item, sdk["AgentMessageThreadItem"]):
             bc.publish({"type": "text_boundary"})
             continue
-          event = _tool_start_event(item, sdk)
-          if event is not None:
-            _stamp_tool_use_id(event, item)
-            bc.publish(event)
+          collab_cls = sdk.get("CollabAgentToolCallThreadItem")
+          if collab_cls is not None and isinstance(item, collab_cls):
+            # One provider-neutral Task block hosts every helper activation in
+            # this turn. Codex may announce ThreadStarted before or after its
+            # collab item, so opening it here is a fallback while the lifecycle
+            # path below can also open it on demand.
+            ensure_task_host()
+          else:
+            event = _tool_start_event(item, sdk)
+            if event is not None:
+              _stamp_tool_use_id(event, item)
+              bc.publish(event)
           _observe_skill_reads(item, sdk, bc=bc, chat_id=chat_id)
           # A spawn's child thread ids first appear on its collab item; record
           # the session->chat link now so the child rollout stays attributed
@@ -2322,7 +2405,7 @@ async def run_codex_sdk_turn(
             activation_by_call_child=activation_by_call_child,
             last_activation_by_child=last_activation_by_child,
           ):
-            _record_private_lifecycle(bc, lifecycle)
+            record_task_lifecycle(lifecycle)
           child_id = str(getattr(item, "agent_thread_id", None) or "")
           kind = getattr(getattr(item, "kind", None), "value", None)
           kind = kind or str(getattr(item, "kind", ""))
@@ -2338,7 +2421,7 @@ async def run_codex_sdk_turn(
             occurred_at=getattr(payload, "started_at_ms", None),
             provider_activation_id=activation,
           )
-          _record_private_lifecycle(bc, lifecycle)
+          record_task_lifecycle(lifecycle)
           if lifecycle is not None and lifecycle.get("event_type") == "agent_terminal":
             activation = str(lifecycle.get("provider_activation_id") or "")
             if activation:
@@ -2359,9 +2442,11 @@ async def run_codex_sdk_turn(
           item = payload.item.root if hasattr(payload.item, "root") else payload.item
           if isinstance(item, sdk["AgentMessageThreadItem"]):
             completed_message_phases.append(_agent_message_phase(item, sdk))
-          for event in _tool_completed_events(item, sdk):
-            _stamp_tool_use_id(event, item)
-            bc.publish(event)
+          collab_cls = sdk.get("CollabAgentToolCallThreadItem")
+          if collab_cls is None or not isinstance(item, collab_cls):
+            for event in _tool_completed_events(item, sdk):
+              _stamp_tool_use_id(event, item)
+              bc.publish(event)
           # Also record child links here (idempotent) in case receiver_thread_ids
           # only populates on completion — a missed link silently loses the
           # attribution this recording exists to provide.
@@ -2373,7 +2458,7 @@ async def run_codex_sdk_turn(
             activation_by_call_child=activation_by_call_child,
             last_activation_by_child=last_activation_by_child,
           ):
-            _record_private_lifecycle(bc, lifecycle)
+            record_task_lifecycle(lifecycle)
           continue
 
         if isinstance(payload, sdk["ThreadTokenUsageUpdatedNotification"]):
@@ -2433,12 +2518,12 @@ async def run_codex_sdk_turn(
             )
             last_activation_by_child[child_id] = activation
             lifecycle["provider_activation_id"] = activation
-            _record_private_lifecycle(bc, lifecycle)
+            record_task_lifecycle(lifecycle)
           continue
 
         status_cls = sdk.get("ThreadStatusChangedNotification")
         if status_cls is not None and isinstance(payload, status_cls):
-          _record_private_lifecycle(bc, _thread_status_lifecycle_event(
+          record_task_lifecycle(_thread_status_lifecycle_event(
             payload, root_thread_id=current_session_id,
             active=active_activation_by_child, known=known_child_ids,
             activation_counts=activation_counts,
@@ -2532,6 +2617,21 @@ async def run_codex_sdk_turn(
       "error": str(exc),
     })
   finally:
+    if task_host_open and task_host_tool_use_id is not None:
+      # A provider error/interrupt may skip terminal child notifications.
+      # Close every still-live chip honestly before closing its Task host.
+      for task_id in sorted(public_task_ids):
+        bc.publish({
+          "type": "task_done",
+          "task_id": task_id,
+          "status": "stopped",
+          "summary": None,
+          "tool_use_id": task_host_tool_use_id,
+        })
+      bc.publish({
+        "type": "tool_end",
+        "tool_use_id": task_host_tool_use_id,
+      })
     deferred_cancel: asyncio.CancelledError | None = None
     if process_group_capture_stop is not None:
       process_group_capture_stop.set()

--- a/backend/app/events.py
+++ b/backend/app/events.py
@@ -701,7 +701,9 @@ def process_event(event: dict, assistant_blocks: list) -> bool:
     # the parent turn's Task tool call that spawned it. Enrich that block in
     # place so the persisted transcript carries the chip data for historical
     # chats (ToolBlock.jsx / SubagentChips read block["subagent"]); the same
-    # events also drive the LIVE chip on the wire. Route-through-the-actor is
+    # events also drive the LIVE chip on the wire. Codex opens one synthetic
+    # Task host per delegating turn and points each activation at it, so the
+    # same persistence path serves both providers. Route-through-the-actor is
     # implicit: process_event mutates assistant_blocks and returns True, so the
     # sink's normal PersistTranscript/Finalize path persists it — this never
     # writes Chat.messages directly (the single-writer guardrail).
@@ -710,9 +712,8 @@ def process_event(event: dict, assistant_blocks: list) -> bool:
     # summary}} — status is "running" until task_done, then the terminal status
     # verbatim (done/failed/killed/stopped). task_progress stays LIVE-ONLY: its
     # per-tick usage/last_tool_name is not worth persisting (it falls through to
-    # `return False` below). Codex has no host Task tool block, so this enriches
-    # Claude turns only. A missing id, or a tool_use_id with no matching block
-    # (unknown), no-ops so a stray event can never append a phantom block.
+    # `return False` below). A missing id, or a tool_use_id with no matching
+    # block (unknown), no-ops so a stray event can never append a phantom block.
     task_id = event.get("task_id")
     if task_id is None:
       return False

--- a/backend/tests/test_codex_sdk_runner.py
+++ b/backend/tests/test_codex_sdk_runner.py
@@ -1116,6 +1116,40 @@ def test_codex_input_to_running_child_is_progress_and_nested_spawn_uses_current_
   assert "Confidential customer list" not in repr(normalized)
 
 
+def test_codex_lifecycle_maps_to_shared_task_chip_contract():
+  started = {
+    "event_type": "agent_spawned",
+    "provider_agent_id": "child",
+    "provider_activation_id": "thread-started:child",
+    "agent_type": "researcher",
+    "state": "running",
+  }
+  done = {
+    **started,
+    "event_type": "agent_terminal",
+    "state": "done",
+    "summary": "Found the cause",
+  }
+  assert codex_sdk_runner._public_task_event(
+    started, tool_use_id="host-1",
+  ) == {
+    "type": "task_start",
+    "task_id": "thread-started:child",
+    "description": "researcher",
+    "task_type": "researcher",
+    "tool_use_id": "host-1",
+  }
+  assert codex_sdk_runner._public_task_event(
+    done, tool_use_id="host-1",
+  ) == {
+    "type": "task_done",
+    "task_id": "thread-started:child",
+    "status": "done",
+    "summary": "Found the cause",
+    "tool_use_id": "host-1",
+  }
+
+
 def test_run_codex_sdk_turn_dispatches_lifecycle_sequence_with_late_exact_fact(
   monkeypatch,
 ):
@@ -1240,6 +1274,39 @@ def test_run_codex_sdk_turn_dispatches_lifecycle_sequence_with_late_exact_fact(
   assert completed["provider_activation_id"] == "call-b:child"
   assert interrupted["provider_activation_id"] == "call-b:child"
   assert all(event.get("type") != "agent_lifecycle" for event in bus.events)
+  hosts = [
+    event for event in bus.events
+    if event.get("type") == "tool_start" and event.get("tool") == "Task"
+  ]
+  assert len(hosts) == 1
+  host_id = hosts[0]["tool_use_id"]
+  starts = {
+    event["task_id"]
+    for event in bus.events if event.get("type") == "task_start"
+  }
+  assert starts == {
+    "thread-started:child",
+    "call-b:child",
+    "thread-started:grandchild",
+  }
+  assert any(
+    event.get("type") == "task_done"
+    and event.get("task_id") == "thread-started:child"
+    and event.get("status") == "done"
+    for event in bus.events
+  )
+  assert any(
+    event.get("type") == "task_done"
+    and event.get("task_id") == "thread-started:grandchild"
+    and event.get("status") == "stopped"
+    for event in bus.events
+  )
+  assert all(
+    event.get("tool_use_id") == host_id
+    for event in bus.events
+    if event.get("type") in ("task_start", "task_done")
+  )
+  assert bus.events[-1] == {"type": "tool_end", "tool_use_id": host_id}
 
 
 def test_run_codex_sdk_turn_aborts_after_turn_before_stream_registration(monkeypatch):


### PR DESCRIPTION
## Summary
- translate Codex child-thread lifecycle facts into the same task events Claude already uses
- group helper activations under one per-turn activity host without duplicating Codex collab rows
- use activation identity so resumed helpers remain distinct and close unfinished helpers honestly on teardown
- retain the richer private lifecycle facts used by Workflows

## Tests
- `MOBIUS_TEST_RUNTIME=1 pytest -q backend/tests/test_codex_sdk_runner.py backend/tests/test_events.py -q`
- `node --test frontend/src/components/ChatView/__tests__/subagentChips.test.js`