### PR TITLE
Integrate four reviewed contributions (batch 2)

### DIFF
--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -38,7 +38,6 @@ from app.broadcast import (
   create_broadcast,
   get_broadcast,
   get_system_broadcast,
-  has_running_chat_broadcast,
   set_active_broadcast,
 )
 from app.chat_writer import (
@@ -2356,6 +2355,35 @@ async def drain_all_for_restart(
 LIMIT_RESET_NOTIFY_TITLE = "Your limit has reset"
 LIMIT_RESET_NOTIFY_BODY = "Your limit has reset."
 CONTINUATION_SWEEP_BATCH_SIZE = 100
+# Start due provider-limit continuations gradually. Unrelated live work must
+# not delay an opted-in chat after its reset, but a bad/early reset timestamp
+# also must not launch a whole parked batch in one burst.
+LIMIT_AUTO_RESUME_STAGGER_SECS = 30.0
+_next_limit_auto_resume_at = 0.0
+
+
+def _limit_auto_resume_now() -> float:
+  """Monotonic clock seam for the launch stagger."""
+  return time.monotonic()
+
+
+def _claim_limit_auto_resume_slot(now: float | None = None) -> bool:
+  """Claim the process-wide stagger slot for one due limit continuation.
+
+  The parked rows themselves are durable. This small in-process gate only
+  spaces their launches: one sweep starts at most one, and a fresh process
+  starts with an empty slot rather than consuming persisted state.
+  Claiming before scheduling deliberately keeps the delay when task creation
+  loses a race or fails — the durable ``resume_pending`` row retries later
+  without turning a local failure into a burst.
+  """
+  global _next_limit_auto_resume_at
+  if now is None:
+    now = _limit_auto_resume_now()
+  if now < _next_limit_auto_resume_at:
+    return False
+  _next_limit_auto_resume_at = now + LIMIT_AUTO_RESUME_STAGGER_SECS
+  return True
 
 
 def _has_unanswered_question(chat: models.Chat | None) -> bool:
@@ -2440,11 +2468,11 @@ async def _auto_resume_chat(
         # Share the queue lock with owner/app sends. The outer sweep check can
         # go stale while this task waits, so re-check global liveness, policy,
         # attribution, the exact latest park, and provider ownership at the
-        # actual claim point. Provider-limit retries are globally serial to
-        # avoid a reset storm. Planned-restart continuations are different:
-        # they are the exact, owner-opted set that was already live together
-        # before the restart, so each chat may reclaim its own slot
-        # independently.
+        # actual claim point. Provider-limit retries are staggered by the
+        # reset sweep, rather than blocked on unrelated live chats. Planned-
+        # restart continuations are different: they are the exact, owner-opted
+        # set that was already live together before the restart, so each chat
+        # may reclaim its own slot independently.
         async with chat_queue.get_lock(chat_id):
           with SessionLocal() as check_db:
             chat = check_db.query(models.Chat).filter(
@@ -2504,11 +2532,6 @@ async def _auto_resume_chat(
             resume_reason = (
               "restart" if park.park_reason == "restart" else "usage_limit"
             )
-          if (
-            resume_reason != "restart"
-            and _any_chat_turn_active()
-          ):
-            return False
           if not mark_starting(chat_id):
             return False
           claimed = True
@@ -2603,12 +2626,12 @@ async def sweep_reset_parks(db: Session) -> list[str]:
       failure cannot silently consume the promised continuation. The narrow
       post-promote SIGKILL boundary is documented on `_auto_resume_chat`.
     - A park whose chat was deleted resolves silently.
-    - Auto-resume is controlled per chat. Provider-limit retries are strictly
-      serial: at most one starts per tick, and none while any turn is live
-      anywhere. Planned-restart continuations reclaim the exact set that was
-      already live before the restart, so every eligible chat in the batch may
-      resume independently. A blocked enabled chat stays pending for a later
-      tick, while notify-only chats in the same due batch still resolve
+    - Auto-resume is controlled per chat. Provider-limit retries are staggered:
+      at most one starts per sweep and launches are spaced even when unrelated
+      chats are live. Planned-restart continuations reclaim the exact set that
+      was already live before the restart, so every eligible chat in the batch
+      may resume independently. A staggered enabled chat stays pending for a
+      later tick, while notify-only chats in the same due batch still resolve
       normally. App-attributed runs and queues never auto-resume.
 
   Stands down while draining — a restart is in progress, and the fresh
@@ -2728,13 +2751,10 @@ async def sweep_reset_parks(db: Session) -> list[str]:
     chat_gone = chat is None or chat.deleted_at is not None
     auto_resume = wants_auto_resume(chat, run)
     restart_auto_resume = auto_resume and run.park_reason == "restart"
-    if auto_resume and not restart_auto_resume and (
-      limit_resume_started or _any_chat_turn_active()
-    ):
-      # Strictly-serial gate: a live turn (an earlier auto-resume, or the
-      # owner's own send) must settle before this enabled park is processed.
-      # Leave this park untouched, but keep walking so a later notify-only
-      # chat is not held hostage by another chat's auto-resume preference.
+    if auto_resume and not restart_auto_resume and limit_resume_started:
+      # One provider-limit continuation per sweep. Leave this park untouched,
+      # but keep walking so a later notify-only chat is not held hostage by
+      # another chat's auto-resume preference.
       continue
     if auto_resume:
       try:
@@ -2787,10 +2807,12 @@ async def sweep_reset_parks(db: Session) -> list[str]:
 
       if prepared.get("notify"):
         notify_due(chat_id, run)
-      if not restart_auto_resume and _any_chat_turn_active():
-        # The notification or refresh window admitted another turn. Keep the
-        # durable pending state so the next sweep retries instead of silently
-        # dropping the promised continuation.
+      if (
+        not restart_auto_resume
+        and not _claim_limit_auto_resume_slot()
+      ):
+        # Keep the durable pending state so the next sweep retries after the
+        # stagger window instead of silently consuming the continuation.
         continue
       resume_started = await _auto_resume_chat(
         chat_id, park_token=run.id,
@@ -2907,11 +2929,6 @@ def is_chat_running(chat_id: str) -> bool:
     return True
   bc = get_broadcast(chat_id)
   return bc is not None and bc.running
-
-
-def _any_chat_turn_active() -> bool:
-  """Include the terminal window after a provider handle unregisters."""
-  return bool(registry.all_alive_chat_ids()) or has_running_chat_broadcast()
 
 
 def mark_starting(chat_id: str) -> bool:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -156,6 +156,7 @@ def fresh_db():
   chat_mod._clear_after_terminal_generation.clear()
   chat_mod._clear_after_terminal_status.clear()
   chat_mod._restart_draining_chats.clear()
+  chat_mod._next_limit_auto_resume_at = 0.0
   bc_mod._broadcasts.clear() if hasattr(bc_mod, "_broadcasts") else None
   # Activity log: clear the per-process debounce cache and delete any
   # /data/logs/activity*.jsonl files written by an earlier test so a

--- a/backend/tests/test_limit_park.py
+++ b/backend/tests/test_limit_park.py
@@ -15,9 +15,10 @@ Locks in the six contracts of the limit-park feature:
       retryable until its continuation starts, skips future parks, stands down
       while draining, and resolves deleted chats silently.
   (e) Auto-resume is policy-controlled (off = notify only). Provider-limit
-      retries are strictly serial, while an accepted planned restart resumes
-      the exact previously-live set together. Each resumed turn combines its
-      preserved queue + a "continue" into one continuation.
+      retries ignore unrelated live work and launch with a short stagger,
+      while an accepted planned restart resumes the exact previously-live set
+      together. Each resumed turn combines its preserved queue + a "continue"
+      into one continuation.
   (f) The parks are observable: /api/debug/status lists parked runs.
   (g) A planned restart reuses the same exact-run state with a due-now time;
       crashes, unanswered questions, and app-owned work stay manual.
@@ -699,7 +700,7 @@ def test_sweep_auto_resume_off_by_default(owner_token, monkeypatch):
   assert resumes == []
 
 
-def test_sweep_auto_resume_on_starts_one_serial_continue(
+def test_sweep_auto_resume_on_starts_one_staggered_continue(
   owner_token, monkeypatch,
 ):
   del owner_token
@@ -738,6 +739,49 @@ def test_sweep_auto_resume_on_starts_one_serial_continue(
     # _schedule_continuation was stubbed, so release the claim it would have
     # handed to the spawned turn.
     chat_mod.discard_starting("sweep-auto")
+
+
+def test_limit_auto_resumes_are_staggered_not_blocked_by_live_work(
+  owner_token, monkeypatch,
+):
+  del owner_token
+  monkeypatch.setattr(
+    "app.push.notify_owner",
+    lambda db, owner_id, **kw: "notif-id",
+  )
+  clock = [100.0]
+  monkeypatch.setattr(chat_mod, "_limit_auto_resume_now", lambda: clock[0])
+  scheduled = []
+  monkeypatch.setattr(
+    chat_mod, "_schedule_continuation",
+    lambda **kwargs: scheduled.append(kwargs),
+  )
+  first, second = "stagger-a", "stagger-b"
+  _due_park(first, f"rt-{first}", auto_resume=True)
+  _due_park(second, f"rt-{second}", auto_resume=True)
+  unrelated = _Handle(f"unrelated-live-{uuid.uuid4()}")
+  registry.register(unrelated)
+
+  try:
+    assert len(_run_sweep()) == 1
+    assert len(scheduled) == 1
+    first_started = scheduled[0]["chat_id"]
+    assert first_started in {first, second}
+
+    # A repeated event-driven sweep inside the stagger does not launch the
+    # rest of the due batch, even though its durable row stays retryable.
+    assert _run_sweep() == []
+    assert len(scheduled) == 1
+
+    # Once the short stagger elapses, the next chat starts even while both the
+    # unrelated turn and the first continuation are still live.
+    clock[0] += chat_mod.LIMIT_AUTO_RESUME_STAGGER_SECS
+    assert len(_run_sweep()) == 1
+    assert {item["chat_id"] for item in scheduled} == {first, second}
+  finally:
+    registry.unregister(unrelated.chat_id, unrelated.kind)
+    chat_mod.discard_starting(first)
+    chat_mod.discard_starting(second)
 
 
 def test_restart_park_auto_continues_with_product_marker(
@@ -1093,7 +1137,7 @@ def test_owner_send_drains_preserved_queue_and_releases_restart_hold():
     db.close()
 
 
-def test_sweep_auto_resume_defers_while_any_turn_is_live(
+def test_sweep_auto_resume_starts_while_unrelated_turn_is_live(
   owner_token, monkeypatch,
 ):
   del owner_token
@@ -1102,25 +1146,30 @@ def test_sweep_auto_resume_defers_while_any_turn_is_live(
     "app.push.notify_owner",
     lambda db, owner_id, **kw: calls.append(kw) or "notif-id",
   )
-  _due_park("sweep-serial", "rt-sweep-serial", auto_resume=True)
-  # An unrelated live turn: strictly-serial auto-resume must wait for it.
+  cid = "sweep-independent"
+  _due_park(cid, f"rt-{cid}", auto_resume=True)
+  scheduled = []
+  monkeypatch.setattr(
+    chat_mod, "_schedule_continuation",
+    lambda **kwargs: scheduled.append(kwargs),
+  )
   other = f"live-{uuid.uuid4()}"
   handle = _Handle(other)
   registry.register(handle)
   try:
-    assert _run_sweep() == []
+    assert _run_sweep() == [cid]
   finally:
     registry.unregister(other, handle.kind)
-  # Untouched: still parked, not notified — deferred to a later tick, never
-  # lost.
-  assert calls == []
-  assert _run_row("rt-sweep-serial")["status"] == "parked"
+    chat_mod.discard_starting(cid)
+  assert len(calls) == 1
+  assert len(scheduled) == 1
+  assert _run_row(f"rt-{cid}")["status"] == "completed"
 
 
-def test_live_turn_defers_enabled_chat_but_not_notify_only_chat(
+def test_live_turn_allows_enabled_and_notify_only_chats_to_resolve(
   owner_token, monkeypatch,
 ):
-  """One enabled chat must not hold another chat's reset notice hostage."""
+  """Unrelated work delays neither continuation nor reset notification."""
   del owner_token
   calls = []
   monkeypatch.setattr(
@@ -1129,23 +1178,32 @@ def test_live_turn_defers_enabled_chat_but_not_notify_only_chat(
   )
   _due_park("sweep-opted", "rt-sweep-opted", auto_resume=True)
   _due_park("sweep-notify", "rt-sweep-notify")
+  scheduled = []
+  monkeypatch.setattr(
+    chat_mod, "_schedule_continuation",
+    lambda **kwargs: scheduled.append(kwargs),
+  )
   other = f"live-{uuid.uuid4()}"
   handle = _Handle(other)
   registry.register(handle)
   try:
-    assert _run_sweep() == ["sweep-notify"]
+    assert set(_run_sweep()) == {"sweep-opted", "sweep-notify"}
   finally:
     registry.unregister(other, handle.kind)
+    chat_mod.discard_starting("sweep-opted")
 
-  assert _run_row("rt-sweep-opted")["status"] == "parked"
+  assert _run_row("rt-sweep-opted")["status"] == "completed"
   assert _run_row("rt-sweep-notify")["status"] == "parked_notified"
-  assert [call["source_id"] for call in calls] == ["sweep-notify"]
+  assert {call["source_id"] for call in calls} == {
+    "sweep-opted", "sweep-notify",
+  }
+  assert [item["chat_id"] for item in scheduled] == ["sweep-opted"]
 
 
-def test_auto_resume_race_after_notify_stays_retryable(
+def test_unrelated_turn_starting_during_notify_does_not_cancel_resume(
   owner_token, monkeypatch,
 ):
-  """A turn starting during the notify window must not consume auto-resume."""
+  """A notify callback admitting other work must not restore the global gate."""
   del owner_token
   cid = "sweep-notify-race"
   blocker_id = f"live-{uuid.uuid4()}"
@@ -1167,19 +1225,13 @@ def test_auto_resume_race_after_notify_stays_retryable(
   _due_park(cid, f"rt-{cid}", auto_resume=True)
 
   try:
-    assert _run_sweep() == []
-    assert _run_row(f"rt-{cid}")["status"] == "resume_pending"
+    assert _run_sweep() == [cid]
+    assert _run_row(f"rt-{cid}")["status"] == "completed"
     assert len(notifications) == 1
   finally:
     registry.unregister(blocker_id, blocker.kind)
-
-  try:
-    assert _run_sweep() == [cid]
-    assert len(scheduled) == 1
-    assert len(notifications) == 1
-    assert _run_row(f"rt-{cid}")["status"] == "completed"
-  finally:
     chat_mod.discard_starting(cid)
+  assert len(scheduled) == 1
 
 
 def test_sweep_starts_only_one_of_two_opted_chats(owner_token, monkeypatch):
@@ -1250,6 +1302,8 @@ def test_auto_resume_spawn_failure_rolls_back_and_retries_once(
     "app.push.notify_owner",
     lambda *args, **kwargs: notifications.append(kwargs) or "notif-id",
   )
+  clock = [100.0]
+  monkeypatch.setattr(chat_mod, "_limit_auto_resume_now", lambda: clock[0])
   queued = {
     "role": "user", "content": "preserve me", "ts": 5,
     "cid": "queued-before-limit",
@@ -1291,6 +1345,7 @@ def test_auto_resume_spawn_failure_rolls_back_and_retries_once(
     chat_mod, "_schedule_continuation",
     lambda **kwargs: scheduled.append(kwargs),
   )
+  clock[0] += chat_mod.LIMIT_AUTO_RESUME_STAGGER_SECS
   try:
     assert _run_sweep() == [cid]
     assert len(scheduled) == 1
@@ -1346,18 +1401,25 @@ def test_post_promote_process_death_recovers_as_manual_resume_boundary():
   )).result(timeout=5)
 
 
-def test_auto_resume_global_idle_check_is_repeated_at_locked_claim():
-  """A different chat starting while this chat waits on its lock wins."""
+def test_auto_resume_locked_claim_ignores_an_unrelated_live_chat(monkeypatch):
+  """Unrelated work must not turn automatic continuation into global idle."""
   cid = "auto-global-claim-race"
+  park_token = "rt-race"
   _seed_chat(cid, auto_resume=True)
+  _seed_run(cid, park_token, status="resume_pending", started_offset=-30)
   other = f"live-{uuid.uuid4()}"
   blocker = _Handle(other)
+  scheduled = []
+  monkeypatch.setattr(
+    chat_mod, "_schedule_continuation",
+    lambda **kwargs: scheduled.append(kwargs),
+  )
 
   async def scenario():
     lock = chat_mod.chat_queue.get_lock(cid)
     await lock.acquire()
     task = asyncio.create_task(
-      chat_mod._auto_resume_chat(cid, park_token="rt-race")
+      chat_mod._auto_resume_chat(cid, park_token=park_token)
     )
     await asyncio.sleep(0)
     registry.register(blocker)
@@ -1367,9 +1429,12 @@ def test_auto_resume_global_idle_check_is_repeated_at_locked_claim():
     finally:
       registry.unregister(other, blocker.kind)
 
-  assert asyncio.run(scenario()) is False
-  assert _chat_row(cid)["pending"] == []
-  assert not chat_mod.is_chat_running(cid)
+  try:
+    assert asyncio.run(scenario()) is True
+    assert len(scheduled) == 1
+    assert scheduled[0]["chat_id"] == cid
+  finally:
+    chat_mod.discard_starting(cid)
 
 
 def test_auto_resume_locked_claim_rejects_superseded_park():
@@ -1387,8 +1452,8 @@ def test_auto_resume_locked_claim_rejects_superseded_park():
   assert not chat_mod.is_chat_running(cid)
 
 
-def test_auto_resume_global_gate_includes_running_terminal_broadcast():
-  """Provider unregister is not idle until its broadcast completes."""
+def test_auto_resume_ignores_an_unrelated_terminal_broadcast(monkeypatch):
+  """Another chat finalizing must not delay a due continuation."""
   from app.broadcast import create_broadcast
 
   cid = "auto-terminal-broadcast-gate"
@@ -1397,14 +1462,20 @@ def test_auto_resume_global_gate_includes_running_terminal_broadcast():
   _seed_chat(cid, auto_resume=True)
   _seed_run(cid, park_token, status="resume_pending", started_offset=-30)
   broadcast = create_broadcast(other)
+  scheduled = []
+  monkeypatch.setattr(
+    chat_mod, "_schedule_continuation",
+    lambda **kwargs: scheduled.append(kwargs),
+  )
   try:
     assert asyncio.run(
       chat_mod._auto_resume_chat(cid, park_token=park_token)
-    ) is False
+    ) is True
   finally:
     broadcast.mark_completed()
-  assert _chat_row(cid)["pending"] == []
-  assert not chat_mod.is_chat_running(cid)
+    chat_mod.discard_starting(cid)
+  assert len(scheduled) == 1
+  assert scheduled[0]["chat_id"] == cid
 
 
 def test_app_initiated_park_never_auto_resumes(owner_token, monkeypatch):

--- a/frontend/src/components/ChatView/ChatSettingsPanel.jsx
+++ b/frontend/src/components/ChatView/ChatSettingsPanel.jsx
@@ -843,7 +843,7 @@ export default function ChatSettingsPanel({
                 onPointerDown={preserveFocusUnlessTouch}
               >
                 <label className="csp__automation-copy" htmlFor={autoResumeSwitchId}>
-                  <span className="csp__automation-title">Continue after usage limits</span>
+                  <span className="csp__automation-title">Automatically continue after usage limits</span>
                 </label>
                 <Switch
                   className="chat-policy-switch"

--- a/frontend/src/components/ChatView/MsgContent.jsx
+++ b/frontend/src/components/ChatView/MsgContent.jsx
@@ -257,7 +257,7 @@ function MsgContentInner({
                     className="chat__limit-option-label"
                     htmlFor={autoResumeSwitchId}
                   >
-                    Always continue after usage limits in this chat
+                    Automatically continue after usage limits
                   </label>
                 </div>
                 <Switch

--- a/frontend/src/components/ChatView/__tests__/appLinkCard.test.js
+++ b/frontend/src/components/ChatView/__tests__/appLinkCard.test.js
@@ -1,0 +1,52 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { appLinkCardFromParagraph } from '../markdown/appLinkCard.js'
+
+const paragraph = (href, text = 'Open "Where to eat" →') => ({
+  type: 'paragraph',
+  tokens: [{ type: 'link', href, tokens: [{ type: 'text', text }] }],
+})
+
+test('internal artifact and map links become app preview cards', () => {
+  assert.deepEqual(
+    appLinkCardFromParagraph(
+      paragraph('/shell/?app=mapbook&intent=map:city-restaurants'),
+    ),
+    {
+      href: '/shell/?app=mapbook&intent=map:city-restaurants',
+      app: 'mapbook',
+      appName: 'Maps',
+      intent: 'map:city-restaurants',
+      itemId: 'city-restaurants',
+      kindKey: 'map',
+      kind: 'Saved map',
+      title: 'Where to eat',
+      iconSrc: '/apps/mapbook/icon-192.png',
+    },
+  )
+  assert.equal(
+    appLinkCardFromParagraph(
+      paragraph('/shell/?app=artifacts&intent=artifact:tip-calculator', 'Open "Tip Calculator" →'),
+    )?.kind,
+    'Artifact',
+  )
+  assert.equal(
+    appLinkCardFromParagraph(paragraph('/shell/?app=maps&intent=map:future-native-map'))?.appName,
+    'Maps',
+  )
+})
+
+test('ordinary, mixed, external, and malformed links stay ordinary markdown', () => {
+  assert.equal(appLinkCardFromParagraph(paragraph('https://example.com/shell/?app=mapbook&intent=map:x')), null)
+  assert.equal(appLinkCardFromParagraph(paragraph('/shell/?app=mapbook')), null)
+  assert.equal(appLinkCardFromParagraph(paragraph('/shell/?app=mapbook&intent=artifact:x')), null)
+  assert.equal(appLinkCardFromParagraph(paragraph('/shell/?app=artifacts&intent=artifact:../private')), null)
+  assert.equal(appLinkCardFromParagraph(paragraph('/shell/?app=notes&intent=artifact:x')), null)
+  assert.equal(appLinkCardFromParagraph({
+    type: 'paragraph',
+    tokens: [
+      { type: 'text', text: 'See ' },
+      { type: 'link', href: '/shell/?app=mapbook&intent=map:x', tokens: [{ type: 'text', text: 'map' }] },
+    ],
+  }), null)
+})

--- a/frontend/src/components/ChatView/__tests__/contextMenuOrder.test.js
+++ b/frontend/src/components/ChatView/__tests__/contextMenuOrder.test.js
@@ -25,7 +25,7 @@ test('chat context actions follow model selection and continuation policy', () =
   assert.ok(picker !== -1 && summary !== -1 && inspector !== -1)
   assert.ok(picker < summary)
   assert.ok(summary < inspector)
-  assert.match(settingsSource, /Continue after usage limits/)
+  assert.match(settingsSource, /Automatically continue after usage limits/)
   assert.match(settingsSource, /Continue after planned restarts/)
   assert.doesNotMatch(settingsSource, /Chat summar(?:y|ies)/)
 })

--- a/frontend/src/components/ChatView/__tests__/parkedCard.test.js
+++ b/frontend/src/components/ChatView/__tests__/parkedCard.test.js
@@ -106,8 +106,8 @@ test('the parked card has styling distinct from a plain error', () => {
 test('auto-resume is a chat-local switch shown only on the active rate-limit card', () => {
   assert.match(msgContent, /resumable && parked && autoResumeAvailable && onAutoResumeChange/,
     'the switch must require the tail resumable rate-limit state')
-  assert.match(msgContent, /Always continue after usage limits in this chat/,
-    'the switch label makes the persistent, chat-local scope explicit')
+  assert.match(msgContent, /Automatically continue after usage limits/,
+    'the switch label describes the automatic behavior directly')
   assert.match(msgContent, /htmlFor=\{autoResumeSwitchId\}/,
     'the visible switch label must also be its accessible name')
   assert.doesNotMatch(msgContent, /This chat only/,
@@ -118,7 +118,7 @@ test('auto-resume is a chat-local switch shown only on the active rate-limit car
     'the in-card control has a dedicated layout')
   assert.doesNotMatch(settingsView, /auto_resume_on_limit|Auto.?resume/i,
     'the removed global automatic option must not reappear in Settings')
-  assert.match(chatSettingsPanel, /Continue after usage limits/,
+  assert.match(chatSettingsPanel, /Automatically continue after usage limits/,
     'the paid-usage policy remains manageable in chat settings')
   assert.match(chatSettingsPanel, /Continue after planned restarts/,
     'restart continuation has an independent switch')

--- a/frontend/src/components/ChatView/markdown.css
+++ b/frontend/src/components/ChatView/markdown.css
@@ -365,3 +365,131 @@ ol.md-list ol.md-list ol.md-list { list-style: lower-roman; }
 .md-blocks a:hover { color: var(--accent-hover); }
 
 .md-blocks strong { font-weight: 600; }
+
+/* A standalone internal app link becomes a real item preview while retaining
+   the anchor as its no-JavaScript and modified-click fallback. */
+.md-app-card {
+  width: min(100%, 34rem);
+  min-height: 13rem;
+  display: flex;
+  flex-direction: column;
+  margin: 0.75rem 0;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  color: var(--text);
+  background: var(--surface);
+  text-decoration: none;
+  touch-action: pan-y;
+  transition: border-color 150ms ease, background 150ms ease, transform 90ms ease;
+}
+.md-app-card:hover {
+  border-color: color-mix(in srgb, var(--accent) 52%, var(--border));
+  background: color-mix(in srgb, var(--accent) 4%, var(--surface));
+}
+.md-app-card:active { transform: scale(0.992); }
+.md-app-card:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.md-app-card__visual {
+  position: relative;
+  width: 100%;
+  height: 8.5rem;
+  min-height: 8.5rem;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  border-bottom: 1px solid var(--border);
+  background:
+    radial-gradient(circle at 55% 38%, color-mix(in srgb, var(--accent) 23%, transparent), transparent 46%),
+    var(--surface2);
+  isolation: isolate;
+}
+.md-app-card__visual--mapbook,
+.md-app-card__visual--maps {
+  background:
+    radial-gradient(circle at 55% 38%, color-mix(in srgb, var(--green) 24%, transparent), transparent 48%),
+    var(--surface2);
+}
+.md-app-card__preview-fallback {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+}
+.md-app-card__preview-fallback img {
+  width: 4.75rem;
+  height: 4.75rem;
+  object-fit: contain;
+  filter: drop-shadow(0 0.375rem 0.75rem rgba(0,0,0,.18));
+}
+.md-app-card__visual iframe {
+  position: absolute;
+  inset: 0;
+  width: 200%;
+  height: 200%;
+  border: 0;
+  background: white;
+  zoom: 0.5;
+  pointer-events: none;
+}
+@supports not (zoom: 0.5) {
+  .md-app-card__visual iframe {
+    transform: scale(0.5);
+    transform-origin: 0 0;
+  }
+}
+.md-app-card__map,
+.md-app-card__map-tiles { position: absolute; inset: 0; }
+.md-app-card__map-tiles { display: grid; grid-template-columns: repeat(3, 1fr); }
+.md-app-card__map-tiles img { width: 100%; height: 100%; object-fit: cover; }
+.md-app-card__map i {
+  position: absolute;
+  width: 0.625rem;
+  height: 0.625rem;
+  border: 2px solid white;
+  border-radius: 999px;
+  background: #f4745f;
+  box-shadow: 0 1px 4px rgba(0,0,0,.32);
+  transform: translate(-50%, -50%);
+}
+.md-app-card__map small {
+  position: absolute;
+  right: 0.3rem;
+  bottom: 0.2rem;
+  color: #26312e;
+  font-size: 0.5rem;
+  text-shadow: 0 1px 2px white;
+}
+.md-app-card__copy {
+  min-width: 0;
+  width: 100%;
+  display: grid;
+  grid-template-columns: 2.25rem minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem;
+}
+.md-app-card__app-icon { width: 2.25rem; height: 2.25rem; object-fit: contain; }
+.md-app-card__text { min-width: 0; display: flex; flex-direction: column; gap: 0.25rem; }
+.md-app-card__eyebrow {
+  color: var(--accent);
+  font-size: 0.6875rem;
+  line-height: 1.2;
+  font-weight: 760;
+  letter-spacing: 0.075em;
+  text-transform: uppercase;
+}
+.md-app-card__text strong {
+  overflow: hidden;
+  color: var(--text);
+  font-size: 0.9375rem;
+  line-height: 1.3;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.md-app-card__text > span:last-child { color: var(--muted); font-size: 0.75rem; }
+.md-app-card__chevron { flex: none; color: var(--muted); }
+
+@media (max-width: 32rem) {
+  .md-app-card { min-height: 12rem; }
+  .md-app-card__visual { height: 7.5rem; min-height: 7.5rem; }
+}

--- a/frontend/src/components/ChatView/markdown/AppLinkCard.jsx
+++ b/frontend/src/components/ChatView/markdown/AppLinkCard.jsx
@@ -1,0 +1,42 @@
+/* Render an internal app deep link as a compact preview that retains normal link fallback. */
+
+import { ChevronRight } from 'lucide-react'
+import { appQueries } from '../../../hooks/queries.js'
+import AppLinkPreview from './AppLinkPreview.jsx'
+
+export default function AppLinkCard({ card, onInternalNav }) {
+  const appsQuery = appQueries.list.useQuery()
+  const app = (appsQuery.data || []).find((candidate) => candidate.slug === card.app)
+  const iconSrc = app?.id ? `/api/apps/${app.id}/icon?size=64` : card.iconSrc
+  return (
+    <a
+      className="md-app-card"
+      href={card.href}
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={(event) => {
+        if (
+          !onInternalNav
+          || event.metaKey
+          || event.ctrlKey
+          || event.shiftKey
+          || event.altKey
+          || event.button !== 0
+        ) return
+        event.preventDefault()
+        onInternalNav(new URL(card.href, window.location.href))
+      }}
+    >
+      <AppLinkPreview appId={app?.id} card={card} fallbackIcon={iconSrc} />
+      <span className="md-app-card__copy">
+        <img className="md-app-card__app-icon" src={iconSrc} alt="" aria-hidden="true" />
+        <span className="md-app-card__text">
+          <span className="md-app-card__eyebrow">{card.appName} · {card.kind}</span>
+          <strong>{card.title}</strong>
+          <span>Open in {card.appName}</span>
+        </span>
+        <ChevronRight className="md-app-card__chevron" size={20} aria-hidden="true" />
+      </span>
+    </a>
+  )
+}

--- a/frontend/src/components/ChatView/markdown/AppLinkPreview.jsx
+++ b/frontend/src/components/ChatView/markdown/AppLinkPreview.jsx
@@ -1,0 +1,152 @@
+import { useEffect, useRef, useState } from 'react'
+import { apiFetch } from '../../../api/client.js'
+
+function staticArtifactDocument(source) {
+  const parser = new DOMParser()
+  const document = parser.parseFromString(source, 'text/html')
+  document.querySelectorAll(
+    'script, iframe, frame, object, embed, portal, base, link[rel="stylesheet"], meta[http-equiv="refresh"]',
+  ).forEach((node) => node.remove())
+  const policy = document.createElement('meta')
+  policy.httpEquiv = 'Content-Security-Policy'
+  policy.content = "default-src 'none'; style-src 'unsafe-inline'; img-src data: blob:; font-src data:; media-src 'none'; frame-src 'none'; connect-src 'none'"
+  document.head.prepend(policy)
+  return `<!doctype html>${document.documentElement.outerHTML}`
+}
+
+function longitudeToTile(value, zoom) {
+  return ((Number(value) + 180) / 360) * (2 ** zoom)
+}
+
+function latitudeToTile(value, zoom) {
+  const latitude = Math.max(-85.0511, Math.min(85.0511, Number(value)))
+  const radians = latitude * Math.PI / 180
+  return (1 - Math.asinh(Math.tan(radians)) / Math.PI) / 2 * (2 ** zoom)
+}
+
+function useNearViewport() {
+  const ref = useRef(null)
+  const [near, setNear] = useState(false)
+  useEffect(() => {
+    const node = ref.current
+    if (!node) return undefined
+    if (typeof IntersectionObserver === 'undefined') {
+      setNear(true)
+      return undefined
+    }
+    const observer = new IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting) setNear(true)
+    }, { rootMargin: '240px' })
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [])
+  return [ref, near]
+}
+
+async function responseJson(path, signal) {
+  const response = await apiFetch(path, { signal, timeoutMs: 8000 })
+  if (!response.ok) throw new Error(`Preview read failed: ${response.status}`)
+  return response.json()
+}
+
+async function artifactPreview(appId, itemId, signal) {
+  const safeId = encodeURIComponent(itemId)
+  const record = await responseJson(`/storage/apps/${appId}/artifacts/${safeId}.json`, signal)
+  const version = Number(record?.current_version) || 1
+  const response = await apiFetch(
+    `/storage/apps/${appId}/versions/${safeId}/v${version}.html`,
+    { signal, timeoutMs: 8000 },
+  )
+  if (!response.ok) throw new Error(`Artifact preview failed: ${response.status}`)
+  return { type: 'artifact', html: staticArtifactDocument(await response.text()) }
+}
+
+async function mapPreview(appId, itemId, signal) {
+  const record = await responseJson(
+    `/storage/apps/${appId}/maps/${encodeURIComponent(itemId)}.json`,
+    signal,
+  )
+  const center = record?.center || record?.origin
+  if (!center) throw new Error('Map preview has no center.')
+  const zoom = Math.max(11, Math.min(15, Math.floor(Number(record.zoom) || 15) - 2))
+  const centerX = longitudeToTile(center.lon, zoom)
+  const centerY = latitudeToTile(center.lat, zoom)
+  const baseX = Math.floor(centerX) - 1
+  const baseY = Math.floor(centerY)
+  const modulus = 2 ** zoom
+  const blobs = await Promise.all([0, 1, 2].map(async (index) => {
+    const x = ((baseX + index) % modulus + modulus) % modulus
+    const source = `https://tile.openstreetmap.org/${zoom}/${x}/${baseY}.png`
+    const response = await apiFetch(`/proxy?url=${encodeURIComponent(source)}`, {
+      signal,
+      timeoutMs: 8000,
+    })
+    if (!response.ok) throw new Error(`Map tile failed: ${response.status}`)
+    return response.blob()
+  }))
+  const tiles = blobs.map((blob) => URL.createObjectURL(blob))
+  const pins = (record.places || []).map((place) => ({
+    id: place.id,
+    left: (longitudeToTile(place.lon, zoom) - baseX) / 3 * 100,
+    top: (latitudeToTile(place.lat, zoom) - baseY) * 100,
+  })).filter((pin) => pin.left >= 0 && pin.left <= 100 && pin.top >= 0 && pin.top <= 100)
+  return { type: 'map', tiles, pins }
+}
+
+export default function AppLinkPreview({ appId, card, fallbackIcon }) {
+  const [hostRef, near] = useNearViewport()
+  const [preview, setPreview] = useState(null)
+
+  useEffect(() => {
+    if (!near || !appId) return undefined
+    const controller = new AbortController()
+    let ownedUrls = []
+    let disposed = false
+    setPreview(null)
+    const load = card.kindKey === 'artifact'
+      ? artifactPreview(appId, card.itemId, controller.signal)
+      : card.kindKey === 'map'
+        ? mapPreview(appId, card.itemId, controller.signal)
+        : Promise.reject(new Error('Unsupported preview kind.'))
+    load.then((next) => {
+      const nextUrls = next.tiles || []
+      if (disposed) {
+        nextUrls.forEach((url) => URL.revokeObjectURL(url))
+        return
+      }
+      ownedUrls = nextUrls
+      setPreview(next)
+    }).catch(() => {
+      if (!disposed) setPreview({ type: 'fallback' })
+    })
+    return () => {
+      disposed = true
+      controller.abort()
+      ownedUrls.forEach((url) => URL.revokeObjectURL(url))
+    }
+  }, [appId, card.itemId, card.kindKey, near])
+
+  return (
+    <span ref={hostRef} className={`md-app-card__visual md-app-card__visual--${card.app}`} aria-hidden="true">
+      {preview?.type === 'artifact' && (
+        <iframe title="" sandbox="" srcDoc={preview.html} tabIndex="-1" />
+      )}
+      {preview?.type === 'map' && (
+        <span className="md-app-card__map">
+          <span className="md-app-card__map-tiles">
+            {preview.tiles.map((source) => <img src={source} alt="" key={source} />)}
+          </span>
+          {preview.pins.map((pin) => (
+            <i key={pin.id} style={{ left: `${pin.left}%`, top: `${pin.top}%` }} />
+          ))}
+          <small>© OpenStreetMap</small>
+        </span>
+      )}
+      {(!preview || preview.type === 'fallback') && (
+        <span className="md-app-card__preview-fallback">
+          <img src={fallbackIcon} alt="" loading="lazy" />
+        </span>
+      )}
+    </span>
+  )
+}

--- a/frontend/src/components/ChatView/markdown/BlockRenderer.jsx
+++ b/frontend/src/components/ChatView/markdown/BlockRenderer.jsx
@@ -4,6 +4,8 @@ import { MemoBlock, BlockToken, MathBlock } from './blocks.jsx'
 import { mathTokens } from './mathTokens.js'
 import { groupMarkdownImages } from './imageGallery.js'
 import ImageGallery from './ImageGallery.jsx'
+import AppLinkCard from './AppLinkCard.jsx'
+import { appLinkCardFromParagraph } from './appLinkCard.js'
 import '../markdown.css'
 
 /**
@@ -42,6 +44,10 @@ export function ProgressiveMarkdown({
         aria-atomic={isStreaming ? 'false' : undefined}
       >
         {tokens.map((token, i) => {
+          const appCard = appLinkCardFromParagraph(token, window.location.href)
+          if (appCard) {
+            return <AppLinkCard key={i} card={appCard} onInternalNav={onInternalNav} />
+          }
           if (token.type === 'blockKatex') {
             return <MathBlock key={i} tex={token.text} />
           }
@@ -73,6 +79,10 @@ export function StandardMarkdown({ text, onInternalNav }) {
   return (
     <div className="standard-markdown md-blocks">
       {tokens.map((token, i) => {
+        const appCard = appLinkCardFromParagraph(token, window.location.href)
+        if (appCard) {
+          return <AppLinkCard key={i} card={appCard} onInternalNav={onInternalNav} />
+        }
         if (token.type === 'blockKatex') {
           return <MathBlock key={i} tex={token.text} />
         }

--- a/frontend/src/components/ChatView/markdown/appLinkCard.js
+++ b/frontend/src/components/ChatView/markdown/appLinkCard.js
@@ -1,0 +1,60 @@
+/* Derive a safe, generic app-preview card from a standalone internal Markdown link. */
+
+const ITEM_ID_RE = /^[A-Za-z0-9_-]{1,64}$/
+const CARD_TYPES = Object.freeze({
+  artifacts: { kindKey: 'artifact', appName: 'Artifacts', kind: 'Artifact' },
+  mapbook: { kindKey: 'map', appName: 'Maps', kind: 'Saved map' },
+  maps: { kindKey: 'map', appName: 'Maps', kind: 'Saved map' },
+})
+
+function inlineText(tokens) {
+  return (tokens || []).map((token) => {
+    if (typeof token?.text === 'string') return token.text
+    return inlineText(token?.tokens)
+  }).join('')
+}
+
+function previewTitle(value) {
+  const text = String(value || '').trim().replace(/\s*→\s*$/, '')
+  const quoted = /^Open\s+["“](.+)["”]$/i.exec(text)
+  if (quoted) return quoted[1].trim()
+  return text.replace(/^Open\s+/i, '').trim() || 'Open app item'
+}
+
+export function appLinkCardFromParagraph(token, base = 'https://mobius.local') {
+  if (token?.type !== 'paragraph') return null
+  const meaningful = (token.tokens || []).filter((child) => (
+    child?.type !== 'text' || String(child.text || '').trim()
+  ))
+  if (meaningful.length !== 1 || meaningful[0]?.type !== 'link') return null
+
+  let url
+  let root
+  try {
+    root = new URL(base)
+    url = new URL(meaningful[0].href, root)
+  } catch {
+    return null
+  }
+  if (url.origin !== root.origin || !/^\/shell\/?$/.test(url.pathname)) return null
+
+  const app = String(url.searchParams.get('app') || '')
+  const intent = String(url.searchParams.get('intent') || '')
+  const type = CARD_TYPES[app]
+  if (!type || !/^[a-z][a-z0-9-]*:[^\s]{1,256}$/.test(intent)) return null
+
+  const kindKey = intent.slice(0, intent.indexOf(':'))
+  const itemId = intent.slice(intent.indexOf(':') + 1)
+  if (kindKey !== type.kindKey || !ITEM_ID_RE.test(itemId)) return null
+  return {
+    href: `${url.pathname}${url.search}`,
+    app,
+    appName: type.appName,
+    intent,
+    itemId,
+    kindKey,
+    kind: type.kind,
+    title: previewTitle(inlineText(meaningful[0].tokens)),
+    iconSrc: `/apps/${encodeURIComponent(app)}/icon-192.png`,
+  }
+}

--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -921,6 +921,7 @@ const DrawerRow = memo(function DrawerRow({
   const slug = item.slug
   const wrapRef = useRef(null)
   const inputRef = useRef(null)
+  const secondaryReleaseCleanupRef = useRef(null)
   const [confirmingDelete, setConfirmingDelete] = useState(false)
   // Separate two-step confirm for the app-only "Delete data" action, which
   // wipes stored data but keeps the app installed. Independent of
@@ -988,6 +989,10 @@ const DrawerRow = memo(function DrawerRow({
     }
   }, [renaming])
 
+  useEffect(() => () => {
+    secondaryReleaseCleanupRef.current?.()
+  }, [])
+
   function commitRename() {
     if (cancelingRef.current) {
       cancelingRef.current = false
@@ -1017,6 +1022,43 @@ const DrawerRow = memo(function DrawerRow({
     )
   }
 
+  function openRowMenu(event) {
+    event.preventDefault()
+    // Chromium raises mouse contextmenu on secondary-button DOWN. The matching
+    // UP is owned by beginSecondaryMenuPress below, which opens only after that
+    // release; do not mount the collision-flipped menu underneath a held pointer.
+    if (event.type === 'contextmenu' && secondaryReleaseCleanupRef.current) return
+    actions.toggleMenu(kind, id, true)
+  }
+
+  function beginSecondaryMenuPress(event) {
+    if (event.pointerType !== 'mouse' || event.button !== 2) return
+    event.preventDefault()
+    secondaryReleaseCleanupRef.current?.()
+    const pointerId = event.pointerId
+    let timer = null
+    const cleanup = () => {
+      window.removeEventListener('pointerup', onSecondaryPointerUp, true)
+      window.removeEventListener('pointercancel', cleanup, true)
+      window.removeEventListener('blur', cleanup, true)
+      if (timer !== null) clearTimeout(timer)
+      if (secondaryReleaseCleanupRef.current === cleanup) {
+        secondaryReleaseCleanupRef.current = null
+      }
+    }
+    const onSecondaryPointerUp = upEvent => {
+      if (upEvent.pointerId !== pointerId || upEvent.button !== 2) return
+      upEvent.preventDefault()
+      cleanup()
+      actions.toggleMenu(kind, id, true)
+    }
+    window.addEventListener('pointerup', onSecondaryPointerUp, true)
+    window.addEventListener('pointercancel', cleanup, true)
+    window.addEventListener('blur', cleanup, true)
+    timer = setTimeout(cleanup, 1500)
+    secondaryReleaseCleanupRef.current = cleanup
+  }
+
   return (
     <div className="drawer__row" ref={wrapRef}>
       <button
@@ -1028,7 +1070,18 @@ const DrawerRow = memo(function DrawerRow({
         // pane. Only present when the splits flag is on; a plain tap still opens
         // in the focused pane (the controller never arms without slop/hold).
         data-drag-key={WORKSPACE_SPLITS_ENABLED ? `${kind}:${id}` : undefined}
+        onPointerDown={beginSecondaryMenuPress}
         onClick={() => actions.select(kind, id)}
+        onDoubleClick={event => {
+          event.preventDefault()
+          actions.startRename(kind, id)
+        }}
+        onContextMenu={openRowMenu}
+        onKeyDown={event => {
+          if (event.key === 'ContextMenu' || (event.shiftKey && event.key === 'F10')) {
+            openRowMenu(event)
+          }
+        }}
       >
         {/* Status dot. Sits before the text so the user's eye
             picks it up alongside the label rather than at the row's

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -717,6 +717,30 @@ test('large drawer lists memoize ordering and row actions without changing row o
   assert.doesNotMatch(drawer, /onSelect=\{\(\) => on(?:Chat|App)/)
 })
 
+test('drawer row menus use one semantic context-menu path across pointer types', () => {
+  assert.match(drawer, /function openRowMenu\(event\)[\s\S]*?actions\.toggleMenu\(kind, id, true\)/)
+  assert.match(drawer, /onContextMenu=\{openRowMenu\}/)
+  assert.match(dragBinding, /srcEl\.dispatchEvent\(new window\.MouseEvent\('contextmenu'/)
+  assert.doesNotMatch(
+    dragBinding,
+    /srcEl\.closest\('\.drawer__row'\)\?\.querySelector\('\.drawer__more'\)\?\.click\(\)/,
+    'touch hold must not depend on a synthetic trigger click',
+  )
+})
+
+test('a secondary-button release cannot immediately select a flipped drawer menu item', () => {
+  assert.match(drawer, /event\.type === 'contextmenu' && secondaryReleaseCleanupRef\.current/)
+  assert.match(drawer, /event\.pointerType !== 'mouse' \|\| event\.button !== 2/)
+  assert.match(drawer, /window\.addEventListener\('pointerup', onSecondaryPointerUp, true\)/)
+  assert.match(drawer, /upEvent\.pointerId !== pointerId \|\| upEvent\.button !== 2/)
+  assert.match(drawer, /cleanup\(\)[\s\S]*?actions\.toggleMenu\(kind, id, true\)/)
+  assert.match(drawer, /timer = setTimeout\(cleanup, 1500\)/)
+})
+
+test('double-click edits a drawer row name instead of duplicating its context menu', () => {
+  assert.match(drawer, /onDoubleClick=\{event => \{[\s\S]*?actions\.startRename\(kind, id\)/)
+})
+
 test('the Settings surface responds to PANE width via a query container', () => {
   const settingsCss = readFileSync(
     new URL('../../SettingsView/SettingsView.css', import.meta.url), 'utf8',

--- a/frontend/src/components/Shell/useWorkspaceDrag.js
+++ b/frontend/src/components/Shell/useWorkspaceDrag.js
@@ -474,7 +474,19 @@ export default function useWorkspaceDrag({
           if (sourceKind === 'tab' && openTabMenuAtRef.current) {
             openTabMenuAtRef.current(ev.clientX, ev.clientY, tabFromKey(key), paneId)
           } else if (sourceKind === 'drawer') {
-            srcEl.closest('.drawer__row')?.querySelector('.drawer__more')?.click()
+            // Re-enter the row's real context-menu boundary instead of
+            // programmatically clicking its menu trigger. `contextmenu` is the
+            // one semantic path shared with desktop right-click and keyboard
+            // access, so touch hold cannot drift when the trigger composition
+            // changes.
+            srcEl.dispatchEvent(new window.MouseEvent('contextmenu', {
+              bubbles: true,
+              cancelable: true,
+              view: window,
+              button: 2,
+              clientX: ev.clientX,
+              clientY: ev.clientY,
+            }))
           }
         }
         if (!armed) {


### PR DESCRIPTION
Four more independently-reviewed, verified contributions, rebased onto current `main` with authorship + Möbius co-author trailer. Disjoint from batch 1 (#271).

- Rich in-chat preview cards for saved Artifacts/Maps deep links
- Drawer row actions via right-click / press-and-hold (contextmenu path)
- Opt-in on-device shell performance probe + deferred layout-forcing read
- Paused chats resume on time after a provider limit resets