### PR TITLE
Restructure drawer navigation and pinned items

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -21,6 +21,8 @@ from sqlalchemy import (
   String, Text, event, false, true,
 )
 
+from sqlalchemy.orm import column_property
+
 from app.database import Base
 from app.timeutil import now_naive_utc
 
@@ -543,6 +545,9 @@ class App(Base):
   # are small (~10-50KB at 512x512) and per-app — avoids needing a
   # separate file store + cleanup path.
   icon_png = Column(LargeBinary, nullable=True, default=None)
+  # Lightweight drawer/catalog projection. This selects only an IS NOT NULL
+  # boolean, so list_apps can advertise artwork without hydrating icon bytes.
+  has_custom_icon = column_property(icon_png.isnot(None))
   # Absolute directory holding this app's source files. Editable app source lives
   # under `/data/apps/<dirname>`. Stored explicitly so source apply can map a
   # directory back to its DB row without slugify-guessing the name.

--- a/backend/app/routes/apps.py
+++ b/backend/app/routes/apps.py
@@ -2155,15 +2155,27 @@ async def update_app(
       app.capability_contract = contract_from_app_state(app)
     db.commit()
     db.refresh(app)
-    get_system_broadcast().publish(
-      {"type": "app_updated", "appId": str(app.id)}
+    # A pin toggle is drawer-local ORDERING, not a change to the app itself, so
+    # it must not ride the app_updated wire. Drag-reorder re-stamps every pinned
+    # app in sequence; one list-invalidating event per step would refetch the
+    # drawer repeatedly and visibly re-shuffle it mid-drop. Broadcast only when a
+    # meaningful app field actually changed (this also drops the stray "Preview
+    # updated ✓" flash a bare pin/unpin used to cause).
+    pin_only = body.pinned is not None and all(
+      field is None
+      for field in (
+        body.name, body.description, body.chat_id, body.share_with_apps,
+        body.cross_app_access, body.share_manifest_url, body.manage_skills,
+      )
     )
+    if not pin_only:
+      get_system_broadcast().publish(
+        {"type": "app_updated", "appId": str(app.id)}
+      )
     # The in-chat "Open <App>" CTA is DERIVED on the frontend from the apps
     # query's chat_id + updated_at, so app_updated alone surfaces it in the
-    # owning chat. A metadata-only PATCH still bumps updated_at, so a
-    # pin/rename can flash "Preview updated ✓" — sanctioned (see
-    # chatRuntimeState.builtAppPulseDecision), the wire carries no source-only
-    # version key to gate on.
+    # owning chat. A metadata-only PATCH still bumps updated_at; the wire carries
+    # no source-only version key to gate on.
   return app
 
 

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -890,8 +890,8 @@ async def patch_chat(
           chat.title = new_title
           chat.title_locked = True
 
-    # Drawer pin toggle. We stamp the time on pin so the pinned group
-    # sorts newest-pinned-first within itself.
+    # Drawer pin toggle. We stamp the time on pin so the shared pinned group
+    # can append the newest pin after the items already there.
     if body.pinned is not None:
       chat.pinned_at = now_naive_utc() if body.pinned else None
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -133,6 +133,9 @@ class AppOut(BaseModel):
   # Optional standalone PWA colors persisted from installed app manifests.
   theme_color: str | None = None
   background_color: str | None = None
+  # True when the raw app-icon endpoint can return stored artwork. Lets shell
+  # chrome avoid using expected 404 responses as an icon-existence probe.
+  has_custom_icon: bool = False
   # Optional PWA display mode (web-manifest `display`). Null → "standalone".
   display: str | None = None
   # Offline contract from the manifest `offline` block (P1-D). None when no

--- a/backend/tests/test_apps.py
+++ b/backend/tests/test_apps.py
@@ -70,10 +70,15 @@ def test_list_apps_does_not_hydrate_source_or_icon_payloads(client, auth, db):
     event.remove(engine, "before_cursor_execute", capture)
 
   assert response.status_code == 200
+  payload = response.json()
+  heavy = next(item for item in payload if item["id"] == app.id)
+  assert heavy["has_custom_icon"] is True
   assert len(statements) == 1
   projection = statements[0].split("FROM apps", 1)[0]
   assert "apps.jsx_source" not in projection
-  assert "apps.icon_png" not in projection
+  # The projection may contain `icon_png IS NOT NULL`; it must never select the
+  # blob itself into an ORM attribute.
+  assert "apps.icon_png AS apps_icon_png" not in projection
 
 
 def test_delete_then_purge_removes_non_slug_source_dir(client, auth, db):

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -408,6 +408,15 @@ export const api = {
       method: 'PATCH',
       body: JSON.stringify(payload),
     }),
+    // Re-stamp a chat's pin time WITHOUT invalidating the shell list. Used by
+    // drag-reorder, which re-stamps every pinned row in sequence: the shared
+    // per-mutation invalidation would refetch the list N times mid-sequence and
+    // visibly re-shuffle it. The caller has already applied the final order
+    // optimistically, so no refetch is wanted.
+    repin: (chatId) => apiFetch(`/chats/${chatId}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ pinned: true }),
+    }),
     remove: (chatId) => listAffectingMutation(
       'chats', `/chats/${chatId}`, { method: 'DELETE' },
     ),
@@ -428,6 +437,13 @@ export const api = {
     update: (appId, payload) => listAffectingMutation('apps', `/apps/${appId}`, {
       method: 'PATCH',
       body: JSON.stringify(payload),
+    }),
+    // Re-stamp an app's pin time WITHOUT invalidating the shell list — see
+    // chats.repin. Drag-reorder persists the whole pinned order this way so the
+    // list does not refetch-and-reshuffle on every step.
+    repin: (appId) => apiFetch(`/apps/${appId}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ pinned: true }),
     }),
     remove: (appId) => listAffectingMutation(
       'apps', `/apps/${appId}`, { method: 'DELETE' },

--- a/frontend/src/components/Drawer/AppsDirectory.css
+++ b/frontend/src/components/Drawer/AppsDirectory.css
@@ -1,0 +1,331 @@
+.apps-directory {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  color: var(--text);
+  background: var(--bg);
+}
+
+.apps-directory__header {
+  flex: 0 0 auto;
+  min-height: 72px;
+  display: grid;
+  grid-template-columns: minmax(180px, 1fr) minmax(280px, 360px);
+  align-items: center;
+  gap: 14px;
+  padding: 12px clamp(14px, 3vw, 34px);
+  border-bottom: 1px solid var(--border-light);
+  background: var(--bg);
+}
+
+.apps-directory__title {
+  min-width: 0;
+  display: flex;
+  align-items: baseline;
+}
+
+.apps-directory__title h1,
+.apps-directory__intro h2,
+.apps-directory__empty h2 {
+  margin: 0;
+  color: var(--text);
+}
+
+.apps-directory__title h1 {
+  font-size: clamp(22px, 2vw, 28px);
+  font-weight: 650;
+  letter-spacing: -0.035em;
+}
+
+.apps-directory__intro span {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.apps-directory__search {
+  min-width: 0;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 0 13px;
+  border: 1px solid var(--border-light);
+  border-radius: 13px;
+  background: var(--surface);
+  color: var(--muted);
+}
+
+.apps-directory__search:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-dim);
+}
+
+.apps-directory__search svg {
+  flex: 0 0 auto;
+  width: 18px;
+  height: 18px;
+}
+
+.apps-directory__search input {
+  min-width: 0;
+  width: 100%;
+  padding: 0;
+  border: 0;
+  outline: 0;
+  color: var(--text);
+  background: transparent;
+  font: inherit;
+  font-size: 14px;
+}
+
+.apps-directory__search input::placeholder {
+  color: var(--muted);
+}
+
+.apps-directory__scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding:
+    clamp(20px, 3vw, 36px)
+    clamp(16px, 4vw, 46px)
+    max(30px, env(safe-area-inset-bottom));
+  scrollbar-width: var(--shell-scrollbar-width, none);
+}
+
+.apps-directory__intro {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 22px;
+}
+
+.apps-directory__intro h2 {
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+.apps-directory__intro p,
+.apps-directory__empty p {
+  margin: 5px 0 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.apps-directory__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(104px, 1fr));
+  gap: 22px 14px;
+}
+
+.apps-directory__card {
+  position: relative;
+  min-width: 0;
+  min-height: 112px;
+  display: flex;
+  overflow: visible;
+  border: 0;
+  border-radius: 18px;
+  background: transparent;
+}
+
+.apps-directory__card-main {
+  min-width: 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 9px;
+  padding: 8px 6px;
+  border: 0;
+  border-radius: inherit;
+  color: var(--text);
+  background: transparent;
+  text-align: center;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  -webkit-touch-callout: none;
+  user-select: none;
+}
+
+.apps-directory__card-icon {
+  position: relative;
+  flex: 0 0 auto;
+  width: 64px;
+  height: 64px;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  border-radius: 17px;
+  background:
+    linear-gradient(145deg, color-mix(in srgb, var(--app-color, var(--accent)) 80%, white 8%), var(--app-color, var(--accent)));
+  color: var(--accent-fg, #fff);
+  font-size: 17px;
+  font-weight: 750;
+  letter-spacing: -0.025em;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, white 16%, transparent);
+}
+
+.apps-directory__card-icon img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: contain;
+  background: transparent;
+}
+
+.apps-directory__card-icon.is-image {
+  overflow: visible;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.apps-directory__card-icon.is-image > span {
+  visibility: hidden;
+}
+
+.apps-directory__card-meta {
+  min-width: 0;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.apps-directory__card-name {
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 590;
+  line-height: 1.3;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.apps-directory__card-menu-anchor.drawer__more {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.apps-directory__card--editing {
+  align-items: center;
+  min-height: 112px;
+  padding: 12px 4px;
+}
+
+.apps-directory__card--editing .drawer__rename-input {
+  font-size: 14px;
+}
+
+.apps-directory__card-main:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.apps-directory__card-main:active {
+  transform: scale(0.96);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .apps-directory__card-main:hover {
+    background: color-mix(in srgb, var(--surface) 72%, transparent);
+  }
+}
+
+.apps-directory__empty {
+  min-height: 240px;
+  display: grid;
+  place-content: center;
+  justify-items: center;
+  padding: 32px;
+  text-align: center;
+}
+
+.apps-directory__empty h2 {
+  font-size: 17px;
+  font-weight: 600;
+}
+
+@media (max-width: 720px) {
+  .apps-directory__header {
+    min-height: 64px;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 8px;
+    padding: 8px 10px;
+  }
+
+  .apps-directory__title {
+    padding: 0 5px;
+  }
+
+  .apps-directory__title h1 {
+    font-size: 18px;
+  }
+
+  .apps-directory__search {
+    width: calc(100% - 10px);
+    margin: 2px 5px 4px;
+  }
+
+  .apps-directory__scroll {
+    padding: 18px 13px max(28px, env(safe-area-inset-bottom));
+  }
+
+  .apps-directory__intro {
+    margin-bottom: 18px;
+  }
+
+  .apps-directory__grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 18px 7px;
+  }
+
+  .apps-directory__card {
+    min-height: 102px;
+  }
+
+  .apps-directory__card-main {
+    padding: 5px 2px;
+  }
+
+  .apps-directory__card-icon {
+    width: 58px;
+    height: 58px;
+    border-radius: 15px;
+  }
+}
+
+@media (max-width: 360px) {
+  .apps-directory__grid {
+    gap: 16px 4px;
+  }
+
+  .apps-directory__card-icon {
+    width: 54px;
+    height: 54px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .apps-directory__card-main {
+    transition: none;
+  }
+}

--- a/frontend/src/components/Drawer/AppsDirectory.jsx
+++ b/frontend/src/components/Drawer/AppsDirectory.jsx
@@ -1,0 +1,78 @@
+import { useEffect, useRef } from 'react'
+import Search from 'lucide-react/dist/esm/icons/search.mjs'
+import './AppsDirectory.css'
+
+export default function AppsDirectory({
+  empty,
+  resultCount,
+  query,
+  onQueryChange,
+  children,
+}) {
+  const searchRef = useRef(null)
+
+  useEffect(() => {
+    // Desktop users can type immediately; on touch devices, opening the app
+    // directory must not summon the software keyboard before they ask for it.
+    const shouldFocusSearch = window.matchMedia?.('(pointer: fine)').matches
+    const frame = shouldFocusSearch
+      ? requestAnimationFrame(() => searchRef.current?.focus())
+      : null
+    return () => {
+      if (frame !== null) cancelAnimationFrame(frame)
+    }
+  }, [])
+
+  const noMatches = !empty && resultCount === 0
+
+  return (
+    <section className="apps-directory" aria-label="Installed apps">
+      <header className="apps-directory__header">
+        <div className="apps-directory__title">
+          <h1>Apps</h1>
+        </div>
+        <label className="apps-directory__search">
+          <Search aria-hidden="true" />
+          <input
+            ref={searchRef}
+            type="search"
+            value={query}
+            placeholder="Search installed apps"
+            aria-label="Search installed apps"
+            autoComplete="off"
+            spellCheck="false"
+            onChange={event => onQueryChange(event.target.value)}
+          />
+        </label>
+      </header>
+
+      <div className="apps-directory__scroll">
+        <div className="apps-directory__intro">
+          <div>
+            <h2>Your apps</h2>
+            <p>Everything installed in this Möbius workspace.</p>
+          </div>
+          {query && !empty && (
+            <span aria-live="polite">
+              {resultCount} {resultCount === 1 ? 'match' : 'matches'}
+            </span>
+          )}
+        </div>
+
+        {empty ? (
+          <div className="apps-directory__empty">
+            <h2>No installed apps yet</h2>
+            <p>Installed apps will appear here as soon as you add one.</p>
+          </div>
+        ) : noMatches ? (
+          <div className="apps-directory__empty" aria-live="polite">
+            <h2>No apps found</h2>
+            <p>Try a different name or keyword.</p>
+          </div>
+        ) : (
+          <div className="apps-directory__grid">{children}</div>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/components/Drawer/Drawer.css
+++ b/frontend/src/components/Drawer/Drawer.css
@@ -418,17 +418,6 @@
   gap: 0;
 }
 
-.drawer__menu-anchor.drawer__more {
-  position: absolute;
-  top: 50%;
-  right: 8px;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  opacity: 0;
-  pointer-events: none;
-}
-
 .drawer__row .drawer__item {
   flex: 1;
   min-width: 0;

--- a/frontend/src/components/Drawer/Drawer.css
+++ b/frontend/src/components/Drawer/Drawer.css
@@ -158,19 +158,14 @@
   min-height: 0;
 }
 
-/* Wrapper around New chat + Chats + Apps. Holds the layout for
-   the per-section scroll model: New chat stays at the top, Chats
-   and Apps share the remaining space proportionally to their
-   content, and each scrolls INTERNALLY when its share is smaller
-   than its content. This means both sections are always visible
-   with roughly equal spacing — if you have 100 chats, you don't
-   have to scroll past all of them to reach Apps. A single
-   parent-scroll would force that. */
+/* New chat is the fixed primary action. Everything navigational beneath it
+   shares one natural scroll: Apps, Pinned, then the complete chat history. */
 .drawer__scroll-wrap {
   flex: 1;
   min-height: 0;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 }
 
 /* ── New chat ──────────────────────────────────────── */
@@ -199,11 +194,8 @@
   border-color: var(--border-light);
 }
 
-/* ── Groups (History, Apps) ───────────────────────── */
+/* ── Navigation sections ──────────────────────────── */
 
-/* Default group: size-to-content, can shrink. The two sections
-   that share space (chats + apps) get more specific rules below
-   so the chats-heavy / apps-heavy lopsidedness self-corrects. */
 .drawer__group {
   flex: 0 1 auto;
   min-height: 0;
@@ -212,44 +204,9 @@
   margin-top: 4px;
 }
 
-/* Chats + Apps: symmetric split. Both sections grow to share
-   available space proportionally (`flex: 1 1 0`), and both scroll
-   internally when their share is smaller than their content. With
-   the previous asymmetric rule (chats `flex: 1 1 0`, apps `flex: 0
-   1 auto` capped at 50%), apps' content size often won the layout
-   when you had a handful of chats and many apps — chats shrank to
-   its 80px floor and apps ballooned up to the 50% cap, so apps
-   visually took more space than chats. Symmetric grow keeps both
-   at the same vertical share regardless of content count. A small
-   min-height on each guarantees neither section disappears even
-   when one has many more rows. */
-.drawer__group--chats,
-.drawer__group--apps {
-  flex: 1 1 0;
-  min-height: 80px;
-  /* Anchors the ::after bottom-fade overlay to the group. */
-  position: relative;
-}
-
-/* Bottom fade — the same 16px "there's more below / this row is
-   clipped" cue the scroll container used to paint with mask-image,
-   moved OFF the scroller onto a static overlay. A mask on an
-   overflow:auto element forces the compositor to re-apply the mask
-   against the moving rows on every scroll frame (a real Android
-   scroll-jank source); a fixed ::after does not — the list scrolls
-   underneath it on a cheap layer. Visually identical: content fades
-   into --bg over the last 16px. pointer-events:none so it never eats
-   a tap/scroll on the row beneath it. */
-.drawer__group--chats::after,
-.drawer__group--apps::after {
-  content: '';
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  height: 16px;
-  pointer-events: none;
-  background: linear-gradient(to top, var(--bg), transparent);
+.drawer__section {
+  display: block;
+  margin: 0;
 }
 
 
@@ -284,14 +241,15 @@
 .drawer__label svg { flex-shrink: 0; opacity: 0.85; color: var(--muted); }
 .drawer__label span { line-height: 1; }
 
-/* Per-section row container — scrolls internally when its group has
-   been shrunk below its content size. The bottom "more below" fade is
-   painted by the static .drawer__group--*::after overlay above, NOT a
-   mask on this element: a mask-image on an overflow:auto container
-   makes the compositor re-apply the mask against the moving rows every
-   scroll frame (Android jank). overscroll-behavior:contain keeps a
-   boundary scroll from chaining out to the blurred scrim behind the
-   drawer. */
+.drawer__label .drawer__label-count {
+  margin-left: auto;
+  color: var(--muted);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+/* One scroll owner keeps long histories continuous and avoids nested-scroll
+   gesture arbitration on phones. */
 .drawer__scroll {
   flex: 1;
   min-height: 0;
@@ -300,12 +258,33 @@
   overflow-y: auto;
   overscroll-behavior: contain;
   scrollbar-width: var(--shell-scrollbar-width, none);
-  /* Bottom room equal to the 16px overlay fade, so the last row (e.g. the
-     selected app) can scroll clear of the dimmed band instead of reading as
-     pinned under the Settings divider. scroll-padding-bottom keeps
-     scroll-into-view from re-tucking it under the fade. */
+  /* Bottom room keeps the final chat clear of the Settings divider.
+     scroll-padding-bottom preserves the same clearance for focus reveals. */
   padding-bottom: 16px;
   scroll-padding-bottom: 16px;
+}
+
+.drawer__scroll--navigation {
+  margin-top: 2px;
+  padding-top: 2px;
+}
+
+.drawer__item--apps {
+  margin-bottom: 2px;
+  font-weight: 500;
+}
+
+.drawer__item-count {
+  flex: 0 0 auto;
+  min-width: 20px;
+  color: var(--muted);
+  font-size: 11px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.drawer__item--active .drawer__item-count {
+  color: inherit;
 }
 
 .drawer__progressive-sentinel {
@@ -356,6 +335,11 @@
   background: var(--accent-dim);
 }
 
+.drawer__item[data-reordering="true"] {
+  opacity: 0.58;
+  background: var(--surface);
+}
+
 /* Keyboard focus ring — applies to all interactive drawer rows.
    Without this, tab navigation lands on rows with no visual cue
    for screen-reader / keyboard users. The accent ring matches
@@ -376,6 +360,7 @@
   height: 18px;
   display: grid;
   place-items: center;
+  font-size: 18px;
   color: inherit;
   opacity: 0.85;
 }
@@ -388,19 +373,38 @@
   text-overflow: ellipsis;
 }
 
-
-/* Trailing pin badge on pinned rows — small, muted, sits flush to
-   the row's right edge. Doesn't compete with the chat title; just
-   signals the row is in the pinned group. */
-.drawer__item-pin {
+.drawer__app-icon {
+  position: relative;
   flex-shrink: 0;
-  display: inline-flex;
-  align-items: center;
-  margin-left: 6px;
-  color: var(--muted);
-  opacity: 0.85;
+  width: 24px;
+  height: 24px;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  border-radius: 7px;
+  background: var(--app-color, var(--accent));
+  color: var(--accent-fg, #fff);
+  font-size: 8px;
+  font-weight: 750;
 }
-.drawer__item--active .drawer__item-pin { color: inherit; opacity: 1; }
+
+.drawer__app-icon img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.drawer__app-icon.is-image {
+  overflow: visible;
+  border-radius: 0;
+  background: transparent;
+}
+
+.drawer__app-icon.is-image > span {
+  visibility: hidden;
+}
 
 /* ── Row + three-dots menu ─────────────────────────── */
 
@@ -412,7 +416,18 @@
   position: relative;
   display: flex;
   align-items: center;
-  gap: 2px;
+  gap: 0;
+}
+
+.drawer__menu-anchor.drawer__more {
+  position: absolute;
+  top: 50%;
+  right: 8px;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  opacity: 0;
+  pointer-events: none;
 }
 
 .drawer__row .drawer__item {
@@ -628,6 +643,29 @@
   margin-top: auto;
   padding-top: 8px;
   border-top: 1px solid var(--border-light);
+}
+
+/* Desktop's collapsed rail and expanded drawer are two presentations of the
+   same three actions. Match their 20px glyphs and exact centers; the slightly
+   larger 15px labels preserve the rail's stronger visual weight when expanded.
+   Mobile has no collapsed rail, so it keeps its existing compact drawer scale. */
+@media (min-width: 1024px) {
+  .drawer__body {
+    padding: 12px 8px max(12px, env(safe-area-inset-bottom));
+  }
+
+  .drawer__item,
+  .drawer__item--new {
+    min-height: 40px;
+    padding: 0 11px;
+    font-size: 15px;
+  }
+
+  .drawer__item-icon {
+    width: 20px;
+    height: 20px;
+    font-size: 20px;
+  }
 }
 
 /* ── Row status dots ───────────────────────────────── */

--- a/frontend/src/components/Drawer/Drawer.css
+++ b/frontend/src/components/Drawer/Drawer.css
@@ -335,9 +335,13 @@
   background: var(--accent-dim);
 }
 
+/* The lifted row while it is being dragged to a new spot. It reads as "picked
+   up" — raised surface + shadow — rather than faded, so the movement is legible.
+   The vertical follow/settle transform lives on the parent .drawer__row. */
 .drawer__item[data-reordering="true"] {
-  opacity: 0.58;
   background: var(--surface);
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.30);
+  cursor: grabbing;
 }
 
 /* Keyboard focus ring — applies to all interactive drawer rows.
@@ -540,7 +544,7 @@
   -webkit-tap-highlight-color: transparent;
 }
 
-/* Icon-bearing menu items (Pin to top / Unpin) get a flex row so
+/* Icon-bearing menu items (Pin / Unpin) get a flex row so
    the leading icon stays aligned with the row's text baseline. */
 .drawer__menu-item--icon {
   display: flex;

--- a/frontend/src/components/Drawer/Drawer.css
+++ b/frontend/src/components/Drawer/Drawer.css
@@ -210,23 +210,18 @@
 }
 
 
-/* Section labels: sentence case, plain muted color, no tracking.
-   The earlier uppercase-tracked-accent treatment read as ornament,
-   not structure. The leading icon already tells you which section
-   you're in; the label is just the readable hook.
+/* Section labels are navigation landmarks, not secondary metadata. Match the
+   type weight and contrast of New chat / Apps so Pinned and Chats remain easy
+   to scan; their non-button structure and lack of hover treatment still make
+   the action-vs-heading distinction clear.
 
-   Now an <h2> rather than a <p> — sighted users see the same
-   typography (the SDK reset + `margin: 0` here mean default heading
-   styles don't apply) but screen-reader users get a section-level
-   heading they can jump to via rotor / heading navigation. Size
-   bumped 12 → 13 to match `settings__section-title` so the platform
-   reads as one design system; stays quieter than the 14px rows
-   above so the action-vs-structure hierarchy still reads. */
+   These stay as <h2>s so screen-reader users can jump between sections via
+   rotor / heading navigation. */
 .drawer__label {
   display: flex;
   align-items: center;
   gap: 8px;
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 500;
   letter-spacing: 0;
   text-transform: none;
@@ -238,7 +233,7 @@
   padding: 8px 12px 6px;
   margin: 0;
 }
-.drawer__label svg { flex-shrink: 0; opacity: 0.85; color: var(--muted); }
+.drawer__label svg { flex-shrink: 0; opacity: 1; color: currentColor; }
 .drawer__label span { line-height: 1; }
 
 .drawer__label .drawer__label-count {

--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -1,10 +1,17 @@
-import { memo, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { useQueryClient } from '@tanstack/react-query'
-import { Plus, Chats, Grid, DotsVerticalMoreMenu, SettingsCog, Pin, PinFilled } from '@openai/apps-sdk-ui/components/Icon'
+import { Chats, DotsVerticalMoreMenu, Pin, PinFilled } from '@openai/apps-sdk-ui/components/Icon'
 import { Menu } from '@openai/apps-sdk-ui/components/Menu'
 import { EmptyMessage } from '@openai/apps-sdk-ui/components/EmptyMessage'
 import { api } from '../../api/client.js'
 import { appQueries, chatQueries } from '../../hooks/queries.js'
+import {
+  AppsNavIcon,
+  NewChatNavIcon,
+  SettingsNavIcon,
+} from '../navigationIcons.js'
+import { appIconUrl } from '../appIcon.js'
 import {
   drawerCloseWatchdogMs,
   drawerWidthFromPointerDelta,
@@ -15,6 +22,12 @@ import {
 } from '../../lib/drawerLifecycle.js'
 import { WORKSPACE_SPLITS_ENABLED } from '../Shell/paneModel.js'
 import InstallSheet from './InstallSheet.jsx'
+import AppsDirectory from './AppsDirectory.jsx'
+import {
+  appInitials,
+  buildDrawerSections,
+  filterInstalledApps,
+} from './drawerInformationArchitecture.js'
 import {
   clampDrawerChatCount,
   initialDrawerChatCount,
@@ -52,6 +65,9 @@ export default function Drawer({
   onDeleteApp,
   onDeleteAppData,
   onSettings,
+  appsActive = false,
+  onAppsOpen,
+  appsHost,
   // Set of chat ids whose agent is currently streaming. Used to
   // show a small accent dot next to the row label so the user can
   // see at a glance which background builds are still running.
@@ -83,32 +99,11 @@ export default function Drawer({
   const attentionSet = attentionChatIds || EMPTY_SET
   const newAppSet = newAppIds || EMPTY_SET
   const resizeRef = useRef(null)
-  // Pinned-first sort: pinned rows by pinned_at desc, then unpinned by
-  // activity_at desc (owner-send), with updated_at as a fallback. Server
-  // returns this order already (see routes/chats.py list_chats), but we
-  // mirror it defensively so the drawer stays correct if the cache holds
-  // an older response.
-  const allChats = useMemo(() => (chats || [])
-    .filter(c => c.has_messages)
-    .sort((a, b) => {
-      const ap = a.pinned_at, bp = b.pinned_at
-      if (ap && !bp) return -1
-      if (!ap && bp) return 1
-      if (ap && bp) return bp.localeCompare(ap)
-      return ((b.activity_at || b.updated_at) || '')
-        .localeCompare((a.activity_at || a.updated_at) || '')
-    }), [chats])
-  // Mirror the same sort for apps. Server delivers it, but the cache
-  // may carry a stale list. Unpinned apps stay in creation order so
-  // the existing "stable apps list" UX (oldest-first within unpinned)
-  // is preserved.
-  const sortedApps = useMemo(() => (apps || []).slice().sort((a, b) => {
-    const ap = a.pinned_at, bp = b.pinned_at
-    if (ap && !bp) return -1
-    if (!ap && bp) return 1
-    if (ap && bp) return bp.localeCompare(ap)
-    return (a.created_at || '').localeCompare(b.created_at || '')
-  }), [apps])
+  const {
+    pinned: pinnedItems,
+    chats: allChats,
+    apps: sortedApps,
+  } = useMemo(() => buildDrawerSections(chats, apps), [chats, apps])
   const [visibleChatCount, setVisibleChatCount] = useState(
     () => initialDrawerChatCount(allChats.length),
   )
@@ -176,10 +171,41 @@ export default function Drawer({
     if (!stillThere) setOpenMenu(null)
   }, [openMenu, chats, apps])
   const [renamingState, setRenamingState] = useState(null) // { kind, id } | null
+  // Mirrors `renaming` synchronously (not via useEffect — that's one render
+  // behind) so outside-tap cancellation sees the current edit immediately.
+  const renamingRef = useRef(null)
+  const overlayCancelRef = useRef(false)
+  const renaming = renamingState
+  const setRenaming = useCallback((next) => {
+    renamingRef.current = next
+    setRenamingState(next)
+  }, [])
   // The app whose "Add to home screen" sheet is open ({id,name,slug}),
   // or null. Mirrors openMenu/renamingState — one at a time, owned here
   // rather than in Shell so this stays drawer-local.
   const [installingApp, setInstallingApp] = useState(null)
+  const [appQuery, setAppQuery] = useState('')
+  const appsButtonRef = useRef(null)
+  const filteredApps = useMemo(
+    () => filterInstalledApps(sortedApps, appQuery),
+    [sortedApps, appQuery],
+  )
+
+  const resetAppsSurfaceUi = useCallback(({ restoreFocus = true } = {}) => {
+    setAppQuery('')
+    setOpenMenu(null)
+    setRenaming(null)
+    if (restoreFocus) {
+      requestAnimationFrame(() => appsButtonRef.current?.focus())
+    }
+  }, [setRenaming])
+
+  function openApps() {
+    setAppQuery('')
+    setOpenMenu(null)
+    setRenaming(null)
+    onAppsOpen?.()
+  }
 
   // The install sheet navigates the whole document away to the standalone
   // install surface (/apps/<slug>/?install=1). When the user comes back via the
@@ -194,21 +220,6 @@ export default function Drawer({
     return () => window.removeEventListener('pageshow', closeOnReshow)
   }, [])
 
-  // Mirrors `renaming` synchronously (not via useEffect — that's
-  // one render behind). The overlay's pointerdown handler must see
-  // the latest value the same task the user starts renaming, so we
-  // wrap the state setter and update the ref inline.
-  // `overlayCancelRef` is set by the overlay's pointerdown when a
-  // rename is active; read by the rename-submit callback to skip
-  // the PATCH (overlay-tap = cancel, not commit).
-  const renamingRef = useRef(null)
-  const overlayCancelRef = useRef(false)
-  const renaming = renamingState
-  const setRenaming = (next) => {
-    renamingRef.current = next
-    setRenamingState(next)
-  }
-
   // Rows receive one stable action surface instead of a new closure for every
   // action on every item. The ref supplies the latest props and local helpers,
   // while memoized rows can bail out when an unrelated row or drawer state changes.
@@ -216,14 +227,15 @@ export default function Drawer({
   const rowActions = useMemo(() => ({
     select(kind, id) {
       const current = rowActionInputsRef.current
+      current.resetAppsSurfaceUi({ restoreFocus: false })
       if (kind === 'chat') current.onChat(id)
       else current.onApp(id)
     },
-    toggleMenu(kind, id, next) {
-      rowActionInputsRef.current.setOpenMenu(next ? { kind, id } : null)
+    toggleMenu(kind, id, next, surface = 'drawer') {
+      rowActionInputsRef.current.setOpenMenu(next ? { kind, id, surface } : null)
     },
-    startRename(kind, id) {
-      rowActionInputsRef.current.setRenaming({ kind, id })
+    startRename(kind, id, surface = 'drawer') {
+      rowActionInputsRef.current.setRenaming({ kind, id, surface })
     },
     cancelRename() {
       rowActionInputsRef.current.setRenaming(null)
@@ -243,6 +255,9 @@ export default function Drawer({
       const current = rowActionInputsRef.current
       if (kind === 'chat') current.pinChat(id, next)
       else current.pinApp(id, next)
+    },
+    reorderPinnedApp(sourceId, targetId) {
+      rowActionInputsRef.current.reorderPinnedApp(sourceId, targetId)
     },
     remove(kind, id) {
       const current = rowActionInputsRef.current
@@ -344,6 +359,44 @@ export default function Drawer({
     }
   }
 
+  async function reorderPinnedApp(sourceId, targetId) {
+    if (sourceId === targetId) return
+    const key = appQueries.keys.all
+    const prev = queryClient.getQueryData(key)
+    const pinnedApps = (prev || [])
+      .filter(app => app.pinned_at)
+      .slice()
+      .sort((a, b) => String(b.pinned_at).localeCompare(String(a.pinned_at)))
+    const from = pinnedApps.findIndex(app => app.id === sourceId)
+    const to = pinnedApps.findIndex(app => app.id === targetId)
+    if (from < 0 || to < 0) return
+    const ordered = pinnedApps.slice()
+    const [moved] = ordered.splice(from, 1)
+    ordered.splice(to, 0, moved)
+    const rank = new Map()
+    const now = Date.now()
+    ordered.forEach((app, index) => {
+      rank.set(app.id, new Date(now - index).toISOString())
+    })
+    queryClient.setQueryData(key, (list) =>
+      (list || []).map(app => rank.has(app.id)
+        ? { ...app, pinned_at: rank.get(app.id) }
+        : app),
+    )
+    try {
+      // The existing pin timestamp is the ordering primitive. Re-pin bottom to
+      // top so each later stamp becomes newer, yielding the requested order
+      // without adding a parallel rank field or migration.
+      for (const app of [...ordered].reverse()) {
+        const res = await api.apps.update(app.id, { pinned: true })
+        if (!res.ok) throw new Error('Could not reorder pinned apps')
+      }
+      refreshApps()
+    } catch {
+      queryClient.setQueryData(key, prev)
+    }
+  }
+
   // deleteApp is handled by Shell (where showToast lives) — the local
   // implementation silently swallowed 409 and network errors. Calls are
   // forwarded via the onDeleteApp prop; the local function is removed.
@@ -383,7 +436,8 @@ export default function Drawer({
     }
   }, [open, persistent])
 
-  // Escape key closes the drawer while it is open.
+  // Escape key closes the drawer while it is open. Apps is ordinary workspace
+  // content, so it never takes ownership away from navigation layered above it.
   useEffect(() => {
     if (!open || persistent || interactionLocked) return
     function onKeyDown(e) {
@@ -720,11 +774,13 @@ export default function Drawer({
     setOpenMenu,
     setRenaming,
     setInstallingApp,
+    resetAppsSurfaceUi,
     overlayCancelRef,
     renameChat,
     renameApp,
     pinChat,
     pinApp,
+    reorderPinnedApp,
   }
 
   return (
@@ -756,7 +812,7 @@ export default function Drawer({
            touchmove), not via React's passive onTouch* props. */
         onTransitionEnd={handleDrawerTransitionEnd}
       >
-        {persistent && (
+        {persistent && open && (
           <div
             className="drawer__resize-handle"
             role="separator"
@@ -779,40 +835,92 @@ export default function Drawer({
           </div>
         )}
         <div className="drawer__body">
-          {/* Single scroll wrapper around New chat + Chats + Apps.
-              Earlier each group held its own scrolling region with
-              flex:1, which split the drawer height evenly even when
-              one section had a few rows and the other had many. With
-              one outer scroll, sections size to content; if total
-              content overflows, the whole column scrolls and the
-              bottom edge fades via mask-image so a half-row at the
-              boundary doesn't read as abruptly cut off. Settings
-              sits outside this wrapper at the drawer bottom. */}
           <div className="drawer__scroll-wrap">
-
-            <button className="drawer__item drawer__item--new" onClick={onNewChat}>
+            <button
+              className="drawer__item drawer__item--new"
+              onClick={() => {
+                resetAppsSurfaceUi({ restoreFocus: false })
+                onNewChat()
+              }}
+            >
               <span className="drawer__item-icon" aria-hidden="true">
-                <Plus width={18} height={18} />
+                <NewChatNavIcon />
               </span>
               <span className="drawer__item-text">New chat</span>
             </button>
 
-          <div className="drawer__group drawer__group--chats">
-            <h2 className="drawer__label drawer__label--chats">
-              <Chats width={16} height={16} aria-hidden="true" />
-              <span>Chats</span>
-            </h2>
-            <div className="drawer__scroll" ref={chatScrollRef}>
+            <div className="drawer__scroll drawer__scroll--navigation" ref={chatScrollRef}>
+              <button
+                ref={appsButtonRef}
+                type="button"
+                className={`drawer__item drawer__item--apps${appsActive ? ' drawer__item--active' : ''}`}
+                aria-current={appsActive ? 'page' : undefined}
+                onClick={openApps}
+              >
+                <span className="drawer__item-icon" aria-hidden="true">
+                  <AppsNavIcon />
+                </span>
+                <span className="drawer__item-text">Apps</span>
+              </button>
+
+              {pinnedItems.length > 0 && (
+                <section className="drawer__section" aria-labelledby="drawer-pinned-label">
+                  <h2 id="drawer-pinned-label" className="drawer__label">
+                    <PinFilled width={15} height={15} aria-hidden="true" />
+                    <span>Pinned</span>
+                  </h2>
+                  {pinnedItems.map(({ kind, item }) => (
+                    <DrawerRow
+                      key={`${kind}:${item.id}`}
+                      kind={kind}
+                      item={item}
+                      surface="drawer"
+                      streaming={kind === 'chat' && streamingSet.has(item.id)}
+                      building={kind === 'app' && !!(item.chat_id && streamingSet.has(item.chat_id))}
+                      attention={kind === 'chat'
+                        ? attentionSet.has(item.id)
+                        : newAppSet.has(Number(item.id))}
+                      active={!appsActive && (
+                        kind === 'chat'
+                          ? activeView === 'chat' && activeChatId === item.id
+                          : activeView === 'canvas' && Number(activeAppId) === Number(item.id)
+                      )}
+                      menuOpen={!!(openMenu
+                        && openMenu.surface === 'drawer'
+                        && openMenu.kind === kind
+                        && openMenu.id === item.id)}
+                      renaming={!!(renaming
+                        && renaming.surface === 'drawer'
+                        && renaming.kind === kind
+                        && renaming.id === item.id)}
+                      actions={rowActions}
+                    />
+                  ))}
+                </section>
+              )}
+
+              <section className="drawer__section" aria-labelledby="drawer-chats-label">
+                <h2 id="drawer-chats-label" className="drawer__label drawer__label--chats">
+                  <Chats width={16} height={16} aria-hidden="true" />
+                  <span>Chats</span>
+                </h2>
               {allChats.length > 0 ? visibleChats.map(chat => (
                 <DrawerRow
                   key={chat.id}
                   kind="chat"
                   item={chat}
+                  surface="drawer"
                   streaming={streamingSet.has(chat.id)}
                   attention={attentionSet.has(chat.id)}
-                  active={activeView === 'chat' && activeChatId === chat.id}
-                  menuOpen={!!(openMenu && openMenu.kind === 'chat' && openMenu.id === chat.id)}
-                  renaming={!!(renaming && renaming.kind === 'chat' && renaming.id === chat.id)}
+                  active={!appsActive && activeView === 'chat' && activeChatId === chat.id}
+                  menuOpen={!!(openMenu
+                    && openMenu.surface === 'drawer'
+                    && openMenu.kind === 'chat'
+                    && openMenu.id === chat.id)}
+                  renaming={!!(renaming
+                    && renaming.surface === 'drawer'
+                    && renaming.kind === 'chat'
+                    && renaming.id === chat.id)}
                   actions={rowActions}
                 />
               )) : (
@@ -829,33 +937,8 @@ export default function Drawer({
                   aria-hidden="true"
                 />
               )}
+              </section>
             </div>
-          </div>
-
-          {apps.length > 0 && (
-            <div className="drawer__group drawer__group--apps">
-              <h2 className="drawer__label drawer__label--apps">
-                <Grid width={16} height={16} aria-hidden="true" />
-                <span>Apps</span>
-              </h2>
-              <div className="drawer__scroll">
-                {sortedApps.map(app => (
-                  <DrawerRow
-                    key={app.id}
-                    kind="app"
-                    item={app}
-                    building={!!(app.chat_id && streamingSet.has(app.chat_id))}
-                    attention={newAppSet.has(Number(app.id))}
-                    active={activeView === 'canvas' && Number(activeAppId) === Number(app.id)}
-                    menuOpen={!!(openMenu && openMenu.kind === 'app' && openMenu.id === app.id)}
-                    renaming={!!(renaming && renaming.kind === 'app' && renaming.id === app.id)}
-                    actions={rowActions}
-                  />
-                ))}
-              </div>
-            </div>
-          )}
-
           </div>{/* /.drawer__scroll-wrap */}
 
           <div className="drawer__group drawer__group--bottom">
@@ -863,9 +946,14 @@ export default function Drawer({
               className={`drawer__item ${activeView === 'settings' ? 'drawer__item--active' : ''}`}
               aria-label="Settings"
               aria-current={activeView === 'settings' ? 'page' : undefined}
-              onClick={onSettings}
+              onClick={() => {
+                resetAppsSurfaceUi({ restoreFocus: false })
+                onSettings()
+              }}
             >
-              <SettingsCog width={16} height={16} aria-hidden="true" style={{ flexShrink: 0 }} />
+              <span className="drawer__item-icon" aria-hidden="true">
+                <SettingsNavIcon />
+              </span>
               <span className="drawer__item-text">Settings</span>
               {/* Passive nudge — any provider's refresh token is no
                   longer valid. No banner, no modal: just a quiet dot
@@ -883,6 +971,36 @@ export default function Drawer({
 
         </div>
       </nav>
+      {appsActive && appsHost && createPortal((
+        <AppsDirectory
+          empty={sortedApps.length === 0}
+          resultCount={filteredApps.length}
+          query={appQuery}
+          onQueryChange={setAppQuery}
+        >
+          {filteredApps.map(app => (
+            <DrawerRow
+              key={app.id}
+              kind="app"
+              item={app}
+              variant="card"
+              surface="directory"
+              building={!!(app.chat_id && streamingSet.has(app.chat_id))}
+              attention={newAppSet.has(Number(app.id))}
+              active={activeView === 'canvas' && Number(activeAppId) === Number(app.id)}
+              menuOpen={!!(openMenu
+                && openMenu.surface === 'directory'
+                && openMenu.kind === 'app'
+                && openMenu.id === app.id)}
+              renaming={!!(renaming
+                && renaming.surface === 'directory'
+                && renaming.kind === 'app'
+                && renaming.id === app.id)}
+              actions={rowActions}
+            />
+          ))}
+        </AppsDirectory>
+      ), appsHost)}
       {installingApp && (
         <InstallSheet
           appId={installingApp.id}
@@ -903,6 +1021,8 @@ export default function Drawer({
 const DrawerRow = memo(function DrawerRow({
   kind,
   item,
+  variant = 'row',
+  surface = 'drawer',
   active,
   streaming,
   // App rows only: the app's owning chat is streaming, i.e. the agent is
@@ -921,25 +1041,12 @@ const DrawerRow = memo(function DrawerRow({
   const slug = item.slug
   const wrapRef = useRef(null)
   const inputRef = useRef(null)
+  const holdTimerRef = useRef(null)
+  const holdOriginRef = useRef(null)
+  const suppressCardClickRef = useRef(false)
+  const suppressRowClickRef = useRef(false)
+  const reorderCleanupRef = useRef(null)
   const secondaryReleaseCleanupRef = useRef(null)
-  const [confirmingDelete, setConfirmingDelete] = useState(false)
-  // Separate two-step confirm for the app-only "Delete data" action, which
-  // wipes stored data but keeps the app installed. Independent of
-  // confirmingDelete so the two confirm chips can't collide.
-  const [confirmingDeleteData, setConfirmingDeleteData] = useState(false)
-
-  // Reset the inline-confirm two-steps (apps only) whenever the menu
-  // closes — otherwise reopening would land the user back on the
-  // primed "Confirm delete?" view. The SDK Menu (Radix) handles
-  // open/close, outside-click, escape, and collision-aware
-  // positioning natively; we just listen for the close.
-  useEffect(() => {
-    if (!menuOpen) {
-      setConfirmingDelete(false)
-      setConfirmingDeleteData(false)
-    }
-  }, [menuOpen])
-
   // Cancel-on-outside-tap during rename. Capture-phase listeners on
   // pointerdown AND click anywhere outside the rename input normally call
   // preventDefault + stopPropagation so another row, Settings, or New chat
@@ -980,6 +1087,12 @@ const DrawerRow = memo(function DrawerRow({
     }
   }, [renaming, actions])
 
+  useEffect(() => () => {
+    if (holdTimerRef.current) clearTimeout(holdTimerRef.current)
+    reorderCleanupRef.current?.()
+    secondaryReleaseCleanupRef.current?.()
+  }, [])
+
   // Autofocus + select-all on rename open so the user can either retype
   // from scratch or tap into the existing name to edit it.
   useEffect(() => {
@@ -988,10 +1101,6 @@ const DrawerRow = memo(function DrawerRow({
       inputRef.current.select()
     }
   }, [renaming])
-
-  useEffect(() => () => {
-    secondaryReleaseCleanupRef.current?.()
-  }, [])
 
   function commitRename() {
     if (cancelingRef.current) {
@@ -1008,6 +1117,20 @@ const DrawerRow = memo(function DrawerRow({
   }
 
   if (renaming) {
+    if (variant === 'card') {
+      return (
+        <div className="apps-directory__card apps-directory__card--editing">
+          <input
+            ref={inputRef}
+            className="drawer__rename-input"
+            defaultValue={label}
+            onKeyDown={onInputKeyDown}
+            onBlur={commitRename}
+            aria-label="Rename app"
+          />
+        </div>
+      )
+    }
     return (
       <div className={`drawer__item drawer__item--editing ${active ? 'drawer__item--active' : ''}`}>
         <input
@@ -1024,11 +1147,12 @@ const DrawerRow = memo(function DrawerRow({
 
   function openRowMenu(event) {
     event.preventDefault()
+    event.stopPropagation()
     // Chromium raises mouse contextmenu on secondary-button DOWN. The matching
     // UP is owned by beginSecondaryMenuPress below, which opens only after that
     // release; do not mount the collision-flipped menu underneath a held pointer.
     if (event.type === 'contextmenu' && secondaryReleaseCleanupRef.current) return
-    actions.toggleMenu(kind, id, true)
+    actions.toggleMenu(kind, id, true, surface)
   }
 
   function beginSecondaryMenuPress(event) {
@@ -1050,13 +1174,137 @@ const DrawerRow = memo(function DrawerRow({
       if (upEvent.pointerId !== pointerId || upEvent.button !== 2) return
       upEvent.preventDefault()
       cleanup()
-      actions.toggleMenu(kind, id, true)
+      actions.toggleMenu(kind, id, true, surface)
     }
     window.addEventListener('pointerup', onSecondaryPointerUp, true)
     window.addEventListener('pointercancel', cleanup, true)
     window.addEventListener('blur', cleanup, true)
     timer = setTimeout(cleanup, 1500)
     secondaryReleaseCleanupRef.current = cleanup
+  }
+
+  if (variant === 'card') {
+    function openCardMenu(event) {
+      openRowMenu(event)
+    }
+    function beginCardHold(event) {
+      if (event.pointerType === 'mouse' || event.button !== 0) return
+      if (holdTimerRef.current) clearTimeout(holdTimerRef.current)
+      holdOriginRef.current = { x: event.clientX, y: event.clientY }
+      holdTimerRef.current = setTimeout(() => {
+        holdTimerRef.current = null
+        suppressCardClickRef.current = true
+        actions.toggleMenu(kind, id, true, surface)
+      }, 520)
+    }
+    function cancelCardHold() {
+      if (holdTimerRef.current) clearTimeout(holdTimerRef.current)
+      holdTimerRef.current = null
+      holdOriginRef.current = null
+    }
+    return (
+      <div className="apps-directory__card">
+        <button
+          type="button"
+          className="apps-directory__card-main"
+          aria-label={`Open ${label}`}
+          onClick={() => {
+            if (suppressCardClickRef.current) {
+              suppressCardClickRef.current = false
+              return
+            }
+            actions.select(kind, id)
+          }}
+          onContextMenu={openCardMenu}
+          onPointerDown={event => {
+            beginSecondaryMenuPress(event)
+            beginCardHold(event)
+          }}
+          onPointerUp={cancelCardHold}
+          onPointerCancel={cancelCardHold}
+          onPointerMove={event => {
+            const origin = holdOriginRef.current
+            if (origin && Math.hypot(event.clientX - origin.x, event.clientY - origin.y) > 8) {
+              cancelCardHold()
+            }
+          }}
+          onKeyDown={event => {
+            if (event.key === 'ContextMenu' || (event.shiftKey && event.key === 'F10')) {
+              openCardMenu(event)
+            }
+          }}
+        >
+          <AppIcon
+            item={item}
+            label={label}
+            className="apps-directory__card-icon"
+            size={128}
+          />
+          <span className="apps-directory__card-meta">
+            <span className="apps-directory__card-name">{label}</span>
+          </span>
+        </button>
+        <DrawerItemMenu
+          kind={kind}
+          item={item}
+          surface={surface}
+          pinned={pinned}
+          menuOpen={menuOpen}
+          actions={actions}
+          triggerClassName="drawer__more apps-directory__card-menu-anchor"
+          triggerHidden
+        />
+      </div>
+    )
+  }
+
+  function beginPinnedReorder(event) {
+    if (kind !== 'app' || !pinned || event.pointerType !== 'mouse' || event.button !== 0) return
+    const pointerId = event.pointerId
+    const start = { x: event.clientX, y: event.clientY }
+    let dragging = false
+    let targetId = id
+    let cleaned = false
+    const source = event.currentTarget
+
+    function cleanup() {
+      if (cleaned) return
+      cleaned = true
+      source.removeAttribute('data-reordering')
+      window.removeEventListener('pointermove', onMove, true)
+      window.removeEventListener('pointerup', onUp, true)
+      window.removeEventListener('pointercancel', cleanup, true)
+      reorderCleanupRef.current = null
+    }
+    function onMove(moveEvent) {
+      if (moveEvent.pointerId !== pointerId) return
+      const dx = moveEvent.clientX - start.x
+      const dy = moveEvent.clientY - start.y
+      if (!dragging) {
+        if (Math.abs(dx) > Math.abs(dy) || Math.abs(dy) < 8) return
+        dragging = true
+        source.setAttribute('data-reordering', 'true')
+      }
+      moveEvent.preventDefault()
+      const target = document.elementFromPoint(moveEvent.clientX, moveEvent.clientY)
+        ?.closest?.('[data-pinned-app-id]')
+      if (target?.dataset.pinnedAppId) targetId = target.dataset.pinnedAppId
+    }
+    function onUp(upEvent) {
+      if (upEvent.pointerId !== pointerId) return
+      if (dragging) {
+        suppressRowClickRef.current = true
+        const numericTarget = Number(targetId)
+        actions.reorderPinnedApp(id, Number.isFinite(numericTarget) ? numericTarget : targetId)
+      }
+      cleanup()
+    }
+
+    reorderCleanupRef.current?.()
+    reorderCleanupRef.current = cleanup
+    window.addEventListener('pointermove', onMove, { capture: true, passive: false })
+    window.addEventListener('pointerup', onUp, true)
+    window.addEventListener('pointercancel', cleanup, true)
   }
 
   return (
@@ -1070,8 +1318,18 @@ const DrawerRow = memo(function DrawerRow({
         // pane. Only present when the splits flag is on; a plain tap still opens
         // in the focused pane (the controller never arms without slop/hold).
         data-drag-key={WORKSPACE_SPLITS_ENABLED ? `${kind}:${id}` : undefined}
-        onPointerDown={beginSecondaryMenuPress}
-        onClick={() => actions.select(kind, id)}
+        data-pinned-app-id={kind === 'app' && pinned ? id : undefined}
+        onPointerDown={event => {
+          beginSecondaryMenuPress(event)
+          beginPinnedReorder(event)
+        }}
+        onClick={() => {
+          if (suppressRowClickRef.current) {
+            suppressRowClickRef.current = false
+            return
+          }
+          actions.select(kind, id)
+        }}
         onDoubleClick={event => {
           event.preventDefault()
           actions.startRename(kind, id)
@@ -1083,6 +1341,9 @@ const DrawerRow = memo(function DrawerRow({
           }
         }}
       >
+        {kind === 'app' && (
+          <AppIcon item={item} label={label} className="drawer__app-icon" size={64} />
+        )}
         {/* Status dot. Sits before the text so the user's eye
             picks it up alongside the label rather than at the row's
             edge (where the pin lives). aria-label exposes the state. */}
@@ -1108,16 +1369,80 @@ const DrawerRow = memo(function DrawerRow({
           />
         ) : null}
         <span className="drawer__item-text">{label}</span>
-        {pinned && (
-          <span className="drawer__item-pin" aria-label="Pinned" title="Pinned">
-            <PinFilled width={14} height={14} />
-          </span>
-        )}
       </button>
-      <Menu
+      <DrawerItemMenu
+        kind={kind}
+        item={item}
+        surface={surface}
+        pinned={pinned}
+        menuOpen={menuOpen}
+        actions={actions}
+        triggerClassName="drawer__more drawer__menu-anchor"
+        triggerHidden
+      />
+    </div>
+  )
+})
+
+function AppIcon({ item, label, className, size }) {
+  const iconUrl = appIconUrl(item, size)
+  const [loadedUrl, setLoadedUrl] = useState(null)
+  const hasImage = Boolean(iconUrl && loadedUrl === iconUrl)
+  return (
+    <span
+      className={`${className}${hasImage ? ' is-image' : ''}`}
+      style={{ '--app-color': item.background_color || item.theme_color || 'var(--accent)' }}
+      aria-hidden="true"
+    >
+      <span>{appInitials(label)}</span>
+      {iconUrl && (
+        <img
+          src={iconUrl}
+          alt=""
+          loading="lazy"
+          decoding="async"
+          onLoad={event => {
+            event.currentTarget.hidden = false
+            setLoadedUrl(iconUrl)
+          }}
+          onError={event => {
+            event.currentTarget.hidden = true
+            setLoadedUrl(null)
+          }}
+        />
+      )}
+    </span>
+  )
+}
+
+function DrawerItemMenu({
+  kind,
+  item,
+  surface,
+  pinned,
+  menuOpen,
+  actions,
+  triggerClassName = 'drawer__more',
+  triggerHidden = false,
+}) {
+  const id = item.id
+  const label = kind === 'chat' ? item.title : item.name
+  const slug = item.slug
+  const [confirmingDelete, setConfirmingDelete] = useState(false)
+  const [confirmingDeleteData, setConfirmingDeleteData] = useState(false)
+
+  useEffect(() => {
+    if (!menuOpen) {
+      setConfirmingDelete(false)
+      setConfirmingDeleteData(false)
+    }
+  }, [menuOpen])
+
+  return (
+    <Menu
         forceOpen={menuOpen}
-        onOpen={() => actions.toggleMenu(kind, id, true)}
-        onClose={() => actions.toggleMenu(kind, id, false)}
+        onOpen={() => actions.toggleMenu(kind, id, true, surface)}
+        onClose={() => actions.toggleMenu(kind, id, false, surface)}
       >
         <Menu.Trigger>
           {/* No Tooltip wrap here. Both Menu.Trigger and Tooltip
@@ -1130,8 +1455,10 @@ const DrawerRow = memo(function DrawerRow({
               we can revisit later with a different composition. */}
           <button
             type="button"
-            className="drawer__more"
+            className={triggerClassName}
             aria-label={`More actions for ${label}`}
+            aria-hidden={triggerHidden ? 'true' : undefined}
+            tabIndex={triggerHidden ? -1 : undefined}
           >
             <DotsVerticalMoreMenu width={16} height={16} aria-hidden="true" />
           </button>
@@ -1148,7 +1475,7 @@ const DrawerRow = memo(function DrawerRow({
                   : <PinFilled width={14} height={14} aria-hidden="true" />}
                 <span>{pinned ? 'Unpin' : 'Pin to top'}</span>
               </Menu.Item>
-              <Menu.Item onSelect={() => actions.startRename(kind, id)}>Rename</Menu.Item>
+              <Menu.Item onSelect={() => actions.startRename(kind, id, surface)}>Rename</Menu.Item>
               {kind === 'app' && slug && (
                 // Opens the in-PWA InstallSheet to set the home-screen
                 // name + icon first; the sheet saves, then navigates
@@ -1172,7 +1499,7 @@ const DrawerRow = memo(function DrawerRow({
                 // whichever row slides up into the slot.
                 <Menu.Item
                   onSelect={() => {
-                    actions.toggleMenu(kind, id, false)
+                    actions.toggleMenu(kind, id, false, surface)
                     actions.remove(kind, id)
                   }}
                   className="drawer__menu-item--danger"
@@ -1227,7 +1554,7 @@ const DrawerRow = memo(function DrawerRow({
                     // open-trigger bookkeeping in sync. The app STAYS in the
                     // list here (only its data is wiped), so no row unmounts.
                     setConfirmingDeleteData(false)
-                    actions.toggleMenu(kind, id, false)
+                    actions.toggleMenu(kind, id, false, surface)
                     actions.removeData(id)
                   }}
                 >
@@ -1258,7 +1585,7 @@ const DrawerRow = memo(function DrawerRow({
                     // into the deleted slot looks stuck pressed
                     // because openMenu still references the dead id.
                     setConfirmingDelete(false)
-                    actions.toggleMenu(kind, id, false)
+                    actions.toggleMenu(kind, id, false, surface)
                     actions.remove(kind, id)
                   }}
                 >
@@ -1277,6 +1604,5 @@ const DrawerRow = memo(function DrawerRow({
           )}
         </Menu.Content>
       </Menu>
-    </div>
   )
-})
+}

--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -12,6 +12,7 @@ import {
   SettingsNavIcon,
 } from '../navigationIcons.js'
 import { appIconUrl } from '../appIcon.js'
+import { computePinnedDrag } from './pinnedReorder.js'
 import {
   drawerCloseWatchdogMs,
   drawerWidthFromPointerDelta,
@@ -256,8 +257,8 @@ export default function Drawer({
       if (kind === 'chat') current.pinChat(id, next)
       else current.pinApp(id, next)
     },
-    reorderPinnedApp(sourceId, targetId) {
-      rowActionInputsRef.current.reorderPinnedApp(sourceId, targetId)
+    reorderPinned(orderedKeys) {
+      rowActionInputsRef.current.reorderPinned(orderedKeys)
     },
     remove(kind, id) {
       const current = rowActionInputsRef.current
@@ -359,41 +360,49 @@ export default function Drawer({
     }
   }
 
-  async function reorderPinnedApp(sourceId, targetId) {
-    if (sourceId === targetId) return
-    const key = appQueries.keys.all
-    const prev = queryClient.getQueryData(key)
-    const pinnedApps = (prev || [])
-      .filter(app => app.pinned_at)
-      .slice()
-      .sort((a, b) => String(b.pinned_at).localeCompare(String(a.pinned_at)))
-    const from = pinnedApps.findIndex(app => app.id === sourceId)
-    const to = pinnedApps.findIndex(app => app.id === targetId)
-    if (from < 0 || to < 0) return
-    const ordered = pinnedApps.slice()
-    const [moved] = ordered.splice(from, 1)
-    ordered.splice(to, 0, moved)
+  // Persist a new order for the one combined pinned list (chats AND apps share
+  // it). `orderedKeys` is the desired top → bottom order as "kind:id" strings —
+  // exactly what the drag previewed, so the optimistic state matches pixel for
+  // pixel and nothing re-shuffles when the PATCHes land.
+  async function reorderPinned(orderedKeys) {
+    if (!Array.isArray(orderedKeys) || orderedKeys.length === 0) return
+    const chatKey = chatQueries.keys.all
+    const appKey = appQueries.keys.all
+    const prevChats = queryClient.getQueryData(chatKey)
+    const prevApps = queryClient.getQueryData(appKey)
+    // Ascending synthetic pinned_at (top oldest → bottom newest) matching the
+    // rendered order; pinned_at is the ordering primitive the drawer sorts on.
     const rank = new Map()
     const now = Date.now()
-    ordered.forEach((app, index) => {
-      rank.set(app.id, new Date(now - index).toISOString())
+    orderedKeys.forEach((key, index) => {
+      rank.set(key, new Date(now + index).toISOString())
     })
-    queryClient.setQueryData(key, (list) =>
-      (list || []).map(app => rank.has(app.id)
-        ? { ...app, pinned_at: rank.get(app.id) }
-        : app),
-    )
+    const applyRank = (kind) => (list) =>
+      (list || []).map(item => rank.has(`${kind}:${item.id}`)
+        ? { ...item, pinned_at: rank.get(`${kind}:${item.id}`) }
+        : item)
+    queryClient.setQueryData(chatKey, applyRank('chat'))
+    queryClient.setQueryData(appKey, applyRank('app'))
     try {
-      // The existing pin timestamp is the ordering primitive. Re-pin bottom to
-      // top so each later stamp becomes newer, yielding the requested order
-      // without adding a parallel rank field or migration.
-      for (const app of [...ordered].reverse()) {
-        const res = await api.apps.update(app.id, { pinned: true })
-        if (!res.ok) throw new Error('Could not reorder pinned apps')
+      // Persist the order by re-stamping pin times top → bottom (each later call
+      // is newer, so the bottom row ends newest — the ascending order rendered).
+      // These are the QUIET `repin` calls: they do NOT invalidate the shell list,
+      // and we deliberately do NOT refetch afterwards. The optimistic cache above
+      // already holds the exact order the drag previewed; refetching would swap
+      // client-clock stamps for server-clock ones item-by-item and visibly
+      // re-shuffle the list. A later natural refetch returns the same order.
+      for (const key of orderedKeys) {
+        const sep = key.indexOf(':')
+        const kind = key.slice(0, sep)
+        const rawId = key.slice(sep + 1)
+        const res = kind === 'chat'
+          ? await api.chats.repin(rawId)
+          : await api.apps.repin(Number(rawId))
+        if (!res.ok) throw new Error('Could not reorder pinned items')
       }
-      refreshApps()
     } catch {
-      queryClient.setQueryData(key, prev)
+      queryClient.setQueryData(chatKey, prevChats)
+      queryClient.setQueryData(appKey, prevApps)
     }
   }
 
@@ -780,7 +789,7 @@ export default function Drawer({
     renameApp,
     pinChat,
     pinApp,
-    reorderPinnedApp,
+    reorderPinned,
   }
 
   return (
@@ -1259,52 +1268,138 @@ const DrawerRow = memo(function DrawerRow({
   }
 
   function beginPinnedReorder(event) {
-    if (kind !== 'app' || !pinned || event.pointerType !== 'mouse' || event.button !== 0) return
+    // Any pinned row (chat OR app) reorders on a vertical MOUSE drag — the
+    // workspace controller reserves that axis for us and yields it (a rightward
+    // pull still lifts the row into a pane). Touch keeps the drawer's own
+    // vertical scroll, so reorder stays mouse-only.
+    if (!pinned || event.pointerType !== 'mouse' || event.button !== 0) return
+    // Finish any still-settling previous drag before measuring, so its lingering
+    // transforms can't poison the geometry of this one.
+    reorderCleanupRef.current?.()
+
     const pointerId = event.pointerId
     const start = { x: event.clientX, y: event.clientY }
+    const sourceBtn = event.currentTarget
+    const drawerEl = sourceBtn.closest('#navigation-drawer')
+    const wrapOf = (btn) => btn.closest('.drawer__row') || btn
+    // Measure every pinned row once, at drag start.
+    const rows = [...(drawerEl || document).querySelectorAll('[data-pinned-key]')]
+      .map((btn) => {
+        const wrap = wrapOf(btn)
+        const rect = wrap.getBoundingClientRect()
+        return {
+          btn, wrap,
+          key: btn.dataset.pinnedKey,
+          top: rect.top, height: rect.height, center: rect.top + rect.height / 2,
+        }
+      })
+    const fromIndex = rows.findIndex((r) => r.btn === sourceBtn)
+    if (fromIndex < 0) return
+    const src = rows[fromIndex]
     let dragging = false
-    let targetId = id
-    let cleaned = false
-    const source = event.currentTarget
+    let listenersOff = false
+    let last = { slotDelta: 0, finalKeys: null, changed: false, shifts: new Map() }
 
-    function cleanup() {
-      if (cleaned) return
-      cleaned = true
-      source.removeAttribute('data-reordering')
+    function clearStyles() {
+      for (const r of rows) {
+        const s = r.wrap.style
+        s.transition = ''; s.transform = ''; s.zIndex = ''
+        s.position = ''; s.willChange = ''
+      }
+      src.btn.removeAttribute('data-reordering')
+      document.body.style.userSelect = ''
+    }
+    function removeListeners() {
+      if (listenersOff) return
+      listenersOff = true
       window.removeEventListener('pointermove', onMove, true)
       window.removeEventListener('pointerup', onUp, true)
-      window.removeEventListener('pointercancel', cleanup, true)
-      reorderCleanupRef.current = null
+      window.removeEventListener('pointercancel', onCancel, true)
     }
+    // One-shot teardown for the whole session, guarded so a settle that resolves
+    // AFTER a superseding drag has taken over cannot double-commit or wipe the
+    // newer drag's styles.
+    let ended = false
+    function finalize(commit) {
+      if (ended) return
+      ended = true
+      removeListeners()
+      if (commit && last.changed && last.finalKeys) actions.reorderPinned(last.finalKeys)
+      clearStyles()
+      if (reorderCleanupRef.current === forceFinish) reorderCleanupRef.current = null
+    }
+    // A later drag (or unmount) calls this to snap this one shut with no commit.
+    const forceFinish = () => finalize(false)
+    reorderCleanupRef.current = forceFinish
+
+    function armDrag() {
+      dragging = true
+      src.btn.setAttribute('data-reordering', 'true')
+      const s = src.wrap.style
+      s.zIndex = '6'; s.position = 'relative'; s.transition = 'none'; s.willChange = 'transform'
+      for (const r of rows) {
+        if (r === src) continue
+        r.wrap.style.transition = 'transform 170ms cubic-bezier(0.2, 0, 0, 1)'
+        r.wrap.style.willChange = 'transform'
+      }
+      document.body.style.userSelect = 'none'
+    }
+
     function onMove(moveEvent) {
       if (moveEvent.pointerId !== pointerId) return
       const dx = moveEvent.clientX - start.x
       const dy = moveEvent.clientY - start.y
       if (!dragging) {
         if (Math.abs(dx) > Math.abs(dy) || Math.abs(dy) < 8) return
-        dragging = true
-        source.setAttribute('data-reordering', 'true')
+        armDrag()
       }
       moveEvent.preventDefault()
-      const target = document.elementFromPoint(moveEvent.clientX, moveEvent.clientY)
-        ?.closest?.('[data-pinned-app-id]')
-      if (target?.dataset.pinnedAppId) targetId = target.dataset.pinnedAppId
-    }
-    function onUp(upEvent) {
-      if (upEvent.pointerId !== pointerId) return
-      if (dragging) {
-        suppressRowClickRef.current = true
-        const numericTarget = Number(targetId)
-        actions.reorderPinnedApp(id, Number.isFinite(numericTarget) ? numericTarget : targetId)
+      last = computePinnedDrag(rows, fromIndex, dy)
+      src.wrap.style.transform = `translateY(${dy}px)` // lifted row tracks the pointer 1:1
+      for (const r of rows) {
+        if (r === src) continue
+        r.wrap.style.transform = `translateY(${last.shifts.get(r.key) || 0}px)`
       }
-      cleanup()
     }
 
-    reorderCleanupRef.current?.()
-    reorderCleanupRef.current = cleanup
+    // Glide the lifted row into the gap the others already opened, then commit
+    // and clear together. Because each previewed position equals its final
+    // natural position, dropping the transforms as React reorders paints no jump.
+    function settle(commit) {
+      let animDone = false
+      const done = () => {
+        if (animDone) return
+        animDone = true
+        src.wrap.removeEventListener('transitionend', onEnd)
+        finalize(commit)
+      }
+      const onEnd = (ev) => {
+        if (ev.target === src.wrap && ev.propertyName === 'transform') done()
+      }
+      src.wrap.addEventListener('transitionend', onEnd)
+      src.wrap.style.transition = 'transform 190ms cubic-bezier(0.2, 0, 0, 1)'
+      src.wrap.style.transform = `translateY(${commit ? last.slotDelta : 0}px)`
+      // Fallback if transitionend never fires (e.g. the offset was already 0).
+      setTimeout(done, 240)
+    }
+
+    function onUp(upEvent) {
+      if (upEvent.pointerId !== pointerId) return
+      removeListeners()
+      if (!dragging) { finalize(false); return }
+      suppressRowClickRef.current = true
+      settle(true)
+    }
+    function onCancel(cancelEvent) {
+      if (cancelEvent.pointerId !== pointerId) return
+      removeListeners()
+      if (dragging) settle(false)
+      else finalize(false)
+    }
+
     window.addEventListener('pointermove', onMove, { capture: true, passive: false })
     window.addEventListener('pointerup', onUp, true)
-    window.addEventListener('pointercancel', cleanup, true)
+    window.addEventListener('pointercancel', onCancel, true)
   }
 
   return (
@@ -1318,7 +1413,7 @@ const DrawerRow = memo(function DrawerRow({
         // pane. Only present when the splits flag is on; a plain tap still opens
         // in the focused pane (the controller never arms without slop/hold).
         data-drag-key={WORKSPACE_SPLITS_ENABLED ? `${kind}:${id}` : undefined}
-        data-pinned-app-id={kind === 'app' && pinned ? id : undefined}
+        data-pinned-key={pinned ? `${kind}:${id}` : undefined}
         onPointerDown={event => {
           beginSecondaryMenuPress(event)
           beginPinnedReorder(event)
@@ -1473,7 +1568,7 @@ function DrawerItemMenu({
                 {pinned
                   ? <Pin width={14} height={14} aria-hidden="true" />
                   : <PinFilled width={14} height={14} aria-hidden="true" />}
-                <span>{pinned ? 'Unpin' : 'Pin to top'}</span>
+                <span>{pinned ? 'Unpin' : 'Pin'}</span>
               </Menu.Item>
               <Menu.Item onSelect={() => actions.startRename(kind, id, surface)}>Rename</Menu.Item>
               {kind === 'app' && slug && (

--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -1261,6 +1261,7 @@ const DrawerRow = memo(function DrawerRow({
           menuOpen={menuOpen}
           actions={actions}
           triggerClassName="drawer__more apps-directory__card-menu-anchor"
+          triggerHidden
         />
       </div>
     )

--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -1261,7 +1261,6 @@ const DrawerRow = memo(function DrawerRow({
           menuOpen={menuOpen}
           actions={actions}
           triggerClassName="drawer__more apps-directory__card-menu-anchor"
-          triggerHidden
         />
       </div>
     )
@@ -1473,7 +1472,6 @@ const DrawerRow = memo(function DrawerRow({
         menuOpen={menuOpen}
         actions={actions}
         triggerClassName="drawer__more drawer__menu-anchor"
-        triggerHidden
       />
     </div>
   )

--- a/frontend/src/components/Drawer/drawerInformationArchitecture.js
+++ b/frontend/src/components/Drawer/drawerInformationArchitecture.js
@@ -1,17 +1,26 @@
 function pinnedAt(item) {
-  return item?.pinned_at || ''
+  // Normalize to a bare UTC wall-clock string so values from different sources
+  // compare consistently: optimistic client stamps are ISO-with-`Z`, while the
+  // server serializes naive-UTC without a suffix. Both denote UTC, so dropping a
+  // trailing `Z`/`+00:00` lets a plain lexicographic compare order them right
+  // even when a refetch has replaced only one kind (chats OR apps).
+  return (item?.pinned_at || '').replace(/(?:Z|\+00:00)$/, '')
 }
 
-function newestPinnedFirst(a, b) {
-  return pinnedAt(b.item).localeCompare(pinnedAt(a.item))
+// Oldest pin first, newest pin last. Pinning stamps pinned_at = now (the
+// largest value), so a freshly pinned item lands at the BOTTOM of the pinned
+// list, and drag-to-reorder re-stamps timestamps in this same ascending order.
+function oldestPinnedFirst(a, b) {
+  return pinnedAt(a.item).localeCompare(pinnedAt(b.item))
 }
 
 /**
  * Build the drawer's navigation projection without mutating query-cache arrays.
  *
- * Pinned chats and apps share one stable section, while the ordinary chat
- * history remains recency ordered. Apps preserve the drawer's familiar
- * pinned-first ordering, then the stable creation order within the rest.
+ * Pinned chats and apps share one stable section ordered oldest-pin-first, so a
+ * new pin appends at the bottom and manual drag-to-reorder owns the rest. The
+ * ordinary chat history stays recency ordered; the apps grid keeps its
+ * pinned-first ordering (also oldest-pin-first) then stable creation order.
  */
 export function buildDrawerSections(chats = [], apps = []) {
   const chatRows = chats
@@ -29,7 +38,7 @@ export function buildDrawerSections(chats = [], apps = []) {
       const bp = pinnedAt(b)
       if (ap && !bp) return -1
       if (!ap && bp) return 1
-      if (ap && bp) return bp.localeCompare(ap)
+      if (ap && bp) return ap.localeCompare(bp)
       return (a.created_at || '').localeCompare(b.created_at || '')
     })
 
@@ -40,7 +49,7 @@ export function buildDrawerSections(chats = [], apps = []) {
     ...appRows
       .filter(app => app.pinned_at)
       .map(item => ({ kind: 'app', item })),
-  ].sort(newestPinnedFirst)
+  ].sort(oldestPinnedFirst)
 
   return {
     pinned,

--- a/frontend/src/components/Drawer/drawerInformationArchitecture.js
+++ b/frontend/src/components/Drawer/drawerInformationArchitecture.js
@@ -1,0 +1,71 @@
+function pinnedAt(item) {
+  return item?.pinned_at || ''
+}
+
+function newestPinnedFirst(a, b) {
+  return pinnedAt(b.item).localeCompare(pinnedAt(a.item))
+}
+
+/**
+ * Build the drawer's navigation projection without mutating query-cache arrays.
+ *
+ * Pinned chats and apps share one stable section, while the ordinary chat
+ * history remains recency ordered. Apps preserve the drawer's familiar
+ * pinned-first ordering, then the stable creation order within the rest.
+ */
+export function buildDrawerSections(chats = [], apps = []) {
+  const chatRows = chats
+    .filter(chat => chat.has_messages)
+    .slice()
+    .sort((a, b) => (
+      ((b.activity_at || b.updated_at) || '')
+        .localeCompare((a.activity_at || a.updated_at) || '')
+    ))
+
+  const appRows = apps
+    .slice()
+    .sort((a, b) => {
+      const ap = pinnedAt(a)
+      const bp = pinnedAt(b)
+      if (ap && !bp) return -1
+      if (!ap && bp) return 1
+      if (ap && bp) return bp.localeCompare(ap)
+      return (a.created_at || '').localeCompare(b.created_at || '')
+    })
+
+  const pinned = [
+    ...chatRows
+      .filter(chat => chat.pinned_at)
+      .map(item => ({ kind: 'chat', item })),
+    ...appRows
+      .filter(app => app.pinned_at)
+      .map(item => ({ kind: 'app', item })),
+  ].sort(newestPinnedFirst)
+
+  return {
+    pinned,
+    chats: chatRows.filter(chat => !chat.pinned_at),
+    apps: appRows,
+  }
+}
+
+export function filterInstalledApps(apps = [], query = '') {
+  const needle = String(query).trim().toLocaleLowerCase()
+  if (!needle) return apps
+  return apps.filter(app => (
+    `${app.name || ''} ${app.description || ''} ${app.slug || ''}`
+      .toLocaleLowerCase()
+      .includes(needle)
+  ))
+}
+
+export function appInitials(name) {
+  const words = String(name || '')
+    .replace(/[^a-z0-9]+/gi, ' ')
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+  if (words.length === 0) return 'A'
+  if (words.length === 1) return words[0].slice(0, 2).toLocaleUpperCase()
+  return `${words[0][0]}${words[1][0]}`.toLocaleUpperCase()
+}

--- a/frontend/src/components/Drawer/pinnedReorder.js
+++ b/frontend/src/components/Drawer/pinnedReorder.js
@@ -1,0 +1,51 @@
+// Pure geometry for the drawer's pinned-row drag reorder. Given the pinned rows
+// measured at drag start (top / height / center / key, in DOM order), the index
+// of the row being dragged, and the pointer's vertical delta, it computes the
+// whole live preview WITHOUT touching the DOM: where the row will land, how far
+// each other row must slide to open the gap, where the lifted row rests, and the
+// resulting top-to-bottom key order. Keeping this pure makes the fiddly
+// index/offset math unit-testable; the imperative wiring in Drawer.jsx only
+// applies the numbers as transforms.
+//
+// The gap is exactly the dragged row's own height, so every displaced row's
+// previewed position equals its final natural position once the list commits —
+// that identity is what lets the drop settle with no jump, regardless of whether
+// rows have different heights (app rows are taller than chat rows).
+
+export function computePinnedDrag(rows, fromIndex, deltaY) {
+  const src = rows[fromIndex]
+  const anchorTop = rows[0].top // top edge of the pinned region — a fixed anchor
+  const others = rows.filter((_, i) => i !== fromIndex)
+  const draggedCenter = src.center + deltaY
+
+  // Insertion slot = how many other rows sit above the dragged row's center.
+  let above = 0
+  for (const o of others) if (o.center < draggedCenter) above += 1
+
+  // Per-row gap shift. others[p] maps to original full index p (p < fromIndex)
+  // or p + 1 (p >= fromIndex), so `p >= fromIndex` means it was below the source.
+  const shifts = new Map()
+  others.forEach((o, p) => {
+    const wasBelowSource = p >= fromIndex
+    let shift = 0
+    if (wasBelowSource && p < above) shift = -src.height // rises into the vacated slot
+    else if (!wasBelowSource && p >= above) shift = src.height // drops to open the gap
+    shifts.set(o.key, shift)
+  })
+
+  // Resting offset for the lifted row: the top of its destination slot (the
+  // anchor plus the heights of every row that ends up above it) minus its own
+  // natural top.
+  let stackedAbove = 0
+  for (let p = 0; p < above; p += 1) stackedAbove += others[p].height
+  const slotDelta = (anchorTop + stackedAbove) - src.top
+
+  const finalKeys = others.map((o) => o.key)
+  finalKeys.splice(above, 0, src.key)
+
+  // Rows originally above the source number exactly `fromIndex`, so landing at
+  // that same slot is a no-op.
+  const changed = above !== fromIndex
+
+  return { above, shifts, slotDelta, finalKeys, changed }
+}

--- a/frontend/src/components/Shell/PaneStrip.jsx
+++ b/frontend/src/components/Shell/PaneStrip.jsx
@@ -1,10 +1,13 @@
-import { useLayoutEffect, useRef } from 'react'
-import AppWindow from 'lucide-react/dist/esm/icons/app-window.mjs'
+import { useLayoutEffect, useRef, useState } from 'react'
 import Maximize2 from 'lucide-react/dist/esm/icons/maximize-2.mjs'
-import MessageSquare from 'lucide-react/dist/esm/icons/message-square.mjs'
 import Minimize2 from 'lucide-react/dist/esm/icons/minimize-2.mjs'
-import Settings from 'lucide-react/dist/esm/icons/settings.mjs'
 import X from 'lucide-react/dist/esm/icons/x.mjs'
+import {
+  AppsNavIcon,
+  ChatNavIcon,
+  SettingsNavIcon,
+} from '../navigationIcons.js'
+import { appIconUrl } from '../appIcon.js'
 import * as tabModel from './tabModel.js'
 import { STRIP_H, WORKSPACE_SPLITS_ENABLED } from './paneModel.js'
 
@@ -78,6 +81,7 @@ export function scrollStripWheel(e) {
 // (tabIndex 0); the rest and every close button are reached via stripKeyDown.
 export function PaneTab({
   tab, label, active, focused = true, revealKey = 0,
+  app = null,
   tabIndex, dragKey, role, tabId, controlsId,
   onActivate, onClose, onContextMenu,
 }) {
@@ -131,8 +135,11 @@ export function PaneTab({
   }, [active, focused, revealKey])
 
   const TabIcon = tab.kind === 'settings'
-    ? Settings
-    : (tab.kind === 'chat' ? MessageSquare : AppWindow)
+    ? SettingsNavIcon
+    : (tab.kind === 'chat' ? ChatNavIcon : AppsNavIcon)
+  const iconUrl = tab.kind === 'app' ? appIconUrl(app, 64) : null
+  const [loadedIconUrl, setLoadedIconUrl] = useState(null)
+  const hasAppIcon = Boolean(iconUrl && loadedIconUrl === iconUrl)
   return (
     <div ref={tabRef} className={`shell__tab${active ? ' shell__tab--active' : ''}`}>
       <button
@@ -170,7 +177,27 @@ export function PaneTab({
           data-touch-drag-handle={dragKey}
           aria-hidden="true"
         >
-          <TabIcon size={13} />
+          <span
+            className={`shell__tab-icon${hasAppIcon ? ' shell__tab-icon--app' : ''}`}
+          >
+            <TabIcon width={13} height={13} />
+            {iconUrl && (
+              <img
+                src={iconUrl}
+                alt=""
+                loading="lazy"
+                decoding="async"
+                onLoad={event => {
+                  event.currentTarget.hidden = false
+                  setLoadedIconUrl(iconUrl)
+                }}
+                onError={event => {
+                  event.currentTarget.hidden = true
+                  setLoadedIconUrl(null)
+                }}
+              />
+            )}
+          </span>
         </span>
         <span ref={titleRef} className="shell__tab-text">
           <span className="shell__tab-text-inner">{label}</span>
@@ -210,7 +237,7 @@ export function PaneFocusButton({ paneId, focused, onToggle }) {
 // pre-focusing on the tab's own pointerdown would advance the workspace ref
 // before navTo snapshots the source route (see WorkspaceChrome.activateTab).
 export function PaneStrip({
-  pane, paneRect, focused, labelForTab,
+  pane, paneRect, focused, labelForTab, appById,
   onActivate, onClose, onFocus, onTabContextMenu, motion = null,
   canFocusPane = false, paneFocused = false, onTogglePaneFocus,
   revealKey = 0,
@@ -244,6 +271,7 @@ export function PaneStrip({
             key={key}
             tab={tab}
             label={labelForTab(tab)}
+            app={tab.kind === 'app' ? appById?.get(String(tab.id)) : null}
             active={active}
             focused={focused}
             revealKey={revealKey}

--- a/frontend/src/components/Shell/Shell.css
+++ b/frontend/src/components/Shell/Shell.css
@@ -66,6 +66,12 @@
   gap: 8px;
 }
 
+/* Desktop-only quick actions. Declare the closed state outside the media query
+   so adding this shared markup can never leak controls into the phone header. */
+.shell__rail-actions {
+  display: none;
+}
+
 .shell__brand {
   display: flex;
   align-items: center;
@@ -352,6 +358,27 @@
 .shell__tab-kind > svg {
   flex: none;
 }
+.shell__tab-icon {
+  position: relative;
+  width: 13px;
+  height: 13px;
+  display: grid;
+  place-items: center;
+  flex: none;
+}
+.shell__tab-icon--app {
+  overflow: visible;
+}
+.shell__tab-icon--app > img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+.shell__tab-icon--app > svg {
+  visibility: hidden;
+}
 .shell__tab-text {
   display: block;
   min-width: 0;
@@ -431,6 +458,19 @@
      geometries (full-bleed overlay AND paned tab). inline-size only — vertical
      scroll of .settings is unaffected. */
   container: settings / inline-size;
+}
+
+.shell__apps-view {
+  background: var(--bg);
+  container: apps-directory / inline-size;
+}
+
+.shell__apps-host {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  min-width: 0;
+  min-height: 0;
 }
 
 .shell__settings-loading {
@@ -585,4 +625,159 @@
   .shell__brand.is-snapping .shell__logo,
   .shell__brand.is-beat-held-a .shell__logo,
   .shell__brand.is-beat-held-b .shell__logo { animation: none; }
+}
+
+/* Desktop productivity shell: the workspace starts at the very top, while a
+   narrow left rail remains as the only persistent chrome. Expanding navigation
+   turns that same rail into the drawer header (brand + notification bell);
+   collapsing it leaves a stable Möbius mark plus compact quick actions. Density
+   comes from removing redundant chrome, never by scaling the fixed viewport
+   (which clips composers and makes fixed edges drift). */
+@media (min-width: 1024px) {
+  .shell {
+    --desktop-rail-width: 58px;
+    --shell-bar-height: 0px;
+  }
+
+  .shell::before {
+    content: "";
+    position: fixed;
+    inset: 0 auto 0 0;
+    z-index: 2;
+    width: var(--desktop-rail-width);
+    background: var(--bg);
+    border-right: 1px solid var(--border-light);
+    pointer-events: none;
+  }
+
+  .shell--drawer-docked::before {
+    width: var(--desktop-sidebar-width);
+  }
+
+  .shell__bar {
+    position: absolute;
+    inset: 0 auto 0 0;
+    z-index: 100;
+    width: var(--desktop-rail-width);
+    height: 100%;
+    padding: 12px;
+    flex-direction: column;
+    align-items: center;
+    background: transparent;
+    border: 0;
+    pointer-events: none;
+  }
+
+  .shell__brand,
+  .shell__rail-actions,
+  .shell__bar-actions {
+    pointer-events: auto;
+  }
+
+  /* The mark owns one invariant desktop cell. The header may grow from rail to
+     drawer, but that cell never participates in either flex layout, so revealing
+     the wordmark cannot nudge the logo horizontally or vertically. */
+  .shell__brand,
+  .shell--drawer-docked .shell__brand {
+    position: absolute;
+    top: 12px;
+    left: 12px;
+    height: 34px;
+    min-height: 34px;
+    padding: 0;
+  }
+
+  .shell:not(.shell--drawer-docked) .shell__wordmark,
+  .shell:not(.shell--drawer-docked) .shell__bar-actions {
+    display: none;
+  }
+
+  .shell--drawer-docked .shell__bar {
+    width: var(--desktop-sidebar-width);
+    height: 58px;
+    padding: 8px 12px;
+    flex-direction: row;
+    align-items: center;
+    border-bottom: 1px solid var(--border-light);
+  }
+
+  .shell--drawer-docked .shell__bar-actions {
+    position: absolute;
+    top: 7px;
+    right: 12px;
+    margin: 0;
+  }
+
+  .shell__rail-actions {
+    width: 100%;
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    margin-top: 58px;
+  }
+
+  .shell__rail-action {
+    flex: 0 0 auto;
+    width: 40px;
+    height: 40px;
+    display: grid;
+    place-items: center;
+    padding: 0;
+    border: 0;
+    border-radius: 11px;
+    color: var(--muted);
+    background: transparent;
+    cursor: pointer;
+  }
+
+  .shell__rail-action svg {
+    width: 20px;
+    height: 20px;
+    stroke-width: 1.8;
+  }
+
+  .shell__rail-action:hover,
+  .shell__rail-action--active {
+    color: var(--text);
+    background: var(--surface);
+  }
+
+  .shell__rail-action:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+
+  .shell__rail-action--bottom {
+    margin-top: auto;
+  }
+
+  .shell--drawer-docked .shell__rail-actions {
+    display: none;
+  }
+
+  .shell--drawer-docked .notifications {
+    top: 66px;
+    right: auto;
+    left: 12px;
+    width: min(390px, calc(var(--desktop-sidebar-width) - 24px));
+    max-height: calc(100dvh - 78px);
+  }
+
+  .shell > .shell__tabstrip,
+  .shell > .shell__content {
+    margin-left: var(--desktop-rail-width);
+  }
+
+  .shell--drawer-docked > .shell__tabstrip,
+  .shell--drawer-docked > .shell__content {
+    margin-left: var(--desktop-sidebar-width);
+  }
+
+  .shell--immersive > .shell__tabstrip,
+  .shell--immersive > .shell__content {
+    margin-left: 0;
+  }
 }

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -3519,7 +3519,7 @@ export default function Shell() {
           <button
             type="button"
             className="shell__rail-action"
-            aria-label="New chat"
+            aria-label="New chat shortcut"
             title="New chat"
             onClick={() => newChat({ focusComposer: true, recordHistory: true })}
           >
@@ -3528,7 +3528,7 @@ export default function Shell() {
           <button
             type="button"
             className={`shell__rail-action${activeView === 'apps' ? ' shell__rail-action--active' : ''}`}
-            aria-label="Apps"
+            aria-label="Apps shortcut"
             title="Apps"
             aria-current={activeView === 'apps' ? 'page' : undefined}
             onClick={() => navTo('apps')}
@@ -3538,7 +3538,7 @@ export default function Shell() {
           <button
             type="button"
             className={`shell__rail-action shell__rail-action--bottom${activeView === 'settings' ? ' shell__rail-action--active' : ''}`}
-            aria-label="Settings"
+            aria-label="Settings shortcut"
             title="Settings"
             aria-current={activeView === 'settings' ? 'page' : undefined}
             onClick={() => {
@@ -3726,10 +3726,10 @@ export default function Shell() {
             // full-bleed beneath the deal (INV 5).
             data-mode-motion={motion ? motion.motion : undefined}
             className={underlay
-              ? 'shell__view shell__view--exit-underlay'
+              ? 'shell__view shell__app-view shell__view--exit-underlay'
               : (paned
-                ? 'shell__view shell__view--paned'
-                : `shell__view ${fullBleed ? 'shell__view--active' : ''}`)}
+                ? 'shell__view shell__app-view shell__view--paned'
+                : `shell__view shell__app-view ${fullBleed ? 'shell__view--active' : ''}`)}
             style={motion ? { ...(posStyle || {}), ...motion.vars } : (posStyle || undefined)}
             // INV 9 (inert beat): every moving surface — a participant pane OR the
             // underlay — is pointer/keyboard inert so a tap on an in-flight / covered

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -1,6 +1,11 @@
 import { lazy, Suspense, useState, useEffect, useLayoutEffect, useCallback, useMemo, useReducer, useRef } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import Minimize2 from 'lucide-react/dist/esm/icons/minimize-2.mjs'
+import {
+  AppsNavIcon,
+  NewChatNavIcon,
+  SettingsNavIcon,
+} from '../navigationIcons.js'
 import Drawer from '../Drawer/Drawer.jsx'
 import Toast from '../ui/Toast.jsx'
 import AppCanvas from '../AppCanvas/AppCanvas.jsx'
@@ -308,6 +313,8 @@ export default function Shell() {
   const drawerModeTransitioning = desktopSidebarMode && drawerOpen
   const navigationOpen = persistentDrawer ? desktopSidebarOpen : drawerOpen
   const modalDrawerOpen = !persistentDrawer && drawerOpen
+  const navigationSurfaceOpen = modalDrawerOpen
+  const [appsDirectoryHost, setAppsDirectoryHost] = useState(null)
   // This is the single semantic owner of reserved desktop navigation space.
   // Both the root class and the content-geometry transaction below read it.
   const desktopSidebarReserved = persistentDrawer && desktopSidebarOpen
@@ -1227,6 +1234,13 @@ export default function Shell() {
   // (fullBleedKey === settings key).
   const settingsFullBleed = !settingsPaned
     && (settingsOverlay || (settingsVisibleAsTab && SETTINGS_KEY === fullBleedKey))
+  // Apps is a normal canonical workspace item — no takeover state. It follows
+  // the same full-bleed/paned projection as chats and installed apps.
+  const APPS_KEY = tabModel.APPS_TAB_KEY
+  const appsVisibleAsTab = fullBleedKey === APPS_KEY
+    || projection.visibleLeaves.some(id => workspace.panes[id]?.activeTabKey === APPS_KEY)
+  const appsPaned = workspaceChromeActive ? visibleTabRects.get(APPS_KEY) : null
+  const appsFullBleed = !appsPaned && fullBleedKey === APPS_KEY
   // focusedActiveKey / fullBleedKey / visibleAppIds are derived once by
   // deriveContentVisibility above: focusedActiveKey drives the AppCanvas
   // focused-pane-only `active` prop (insets + immersive holder); fullBleedKey is
@@ -1433,6 +1447,7 @@ export default function Shell() {
     return m
   }, [apps])
   const labelForTab = useCallback((tab) => {
+    if (tab.kind === 'apps') return 'Apps'
     if (tab.kind === 'settings') return 'Settings'
     if (tab.kind === 'chat') return chatById.get(tab.id)?.title || 'Chat'
     return appById.get(tab.id)?.name || 'App'
@@ -2140,9 +2155,8 @@ export default function Shell() {
   // Stable refresh callbacks. Earlier versions used
   // `appsQuery.refetch` directly, but React Query returns a new
   // QueryObserverResult ref on every subscription tick — that made
-  // these `useCallback`s recreate identity each render, and the
-  // drawer-open effect below would re-fire on every SSE tick,
-  // hammering `/api/apps` and `/api/chats` while streaming.
+  // these `useCallback`s recreate identity each render and made every
+  // effect/caller that consumes them vulnerable to duplicate fetches.
   // Driving the refetch via the query client's stable
   // `refetchQueries` keeps the callback identity steady.
   const refreshApps = useCallback(() => {
@@ -2463,10 +2477,6 @@ export default function Shell() {
       chatsQuery.isFetchedAfterMount, chatsQuery.isFetching,
       refreshChats, dispatchWorkspace, applyModeDestination,
       requestEmptySingleNewChat, workspaceStateRef, activeChatIdRef])
-
-  useEffect(() => {
-    if (navigationOpen) { refreshApps(); refreshChats() }
-  }, [navigationOpen, refreshApps, refreshChats])
 
   // Deferred shell-update pickup: a service worker that finished installing and
   // is now WAITING (leashed — it never took over on its own), or index.html's
@@ -3505,6 +3515,40 @@ export default function Shell() {
           onToggleMode={handleToggleViewMode}
           onToggleNavigation={handleToggleNavigation}
         />
+        <nav className="shell__rail-actions" aria-label="Quick actions">
+          <button
+            type="button"
+            className="shell__rail-action"
+            aria-label="New chat"
+            title="New chat"
+            onClick={() => newChat({ focusComposer: true, recordHistory: true })}
+          >
+            <NewChatNavIcon aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            className={`shell__rail-action${activeView === 'apps' ? ' shell__rail-action--active' : ''}`}
+            aria-label="Apps"
+            title="Apps"
+            aria-current={activeView === 'apps' ? 'page' : undefined}
+            onClick={() => navTo('apps')}
+          >
+            <AppsNavIcon aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            className={`shell__rail-action shell__rail-action--bottom${activeView === 'settings' ? ' shell__rail-action--active' : ''}`}
+            aria-label="Settings"
+            title="Settings"
+            aria-current={activeView === 'settings' ? 'page' : undefined}
+            onClick={() => {
+              setSettingsFocusTarget(null)
+              navTo('settings')
+            }}
+          >
+            <SettingsNavIcon aria-hidden="true" />
+          </button>
+        </nav>
         <div className="shell__bar-actions">
           {!online && (
             <span className="shell__offline" role="status" aria-live="polite">
@@ -3551,6 +3595,9 @@ export default function Shell() {
           setSettingsFocusTarget(null)
           navTo('settings')
         }}
+        appsActive={appsVisibleAsTab}
+        onAppsOpen={() => navTo('apps')}
+        appsHost={appsDirectoryHost}
         streamingChatIds={streamingChatIds}
         attentionChatIds={attentionChatIds}
         newAppIds={appAttentionSet}
@@ -3603,7 +3650,7 @@ export default function Shell() {
           // an exit beat, so it is pointer/keyboard inert throughout — not just under
           // the drawer (M4). It matches the WorkspaceChrome strips, which already go
           // inert for the full mode beat.
-          inert={modalDrawerOpen || modeBeatActive}
+          inert={navigationSurfaceOpen || modeBeatActive}
           aria-label="Open tabs"
           // The single-pane strip is the PRIMARY drag source once the flag is on
           // Tag it with the sole pane's id so the drag controller resolves a
@@ -3626,6 +3673,7 @@ export default function Shell() {
                 key={key}
                 tab={tab}
                 label={labelForTab(tab)}
+                app={tab.kind === 'app' ? appById.get(String(tab.id)) : null}
                 active={active}
                 revealKey={tabRevealRevision}
                 tabIndex={active ? 0 : -1}
@@ -3644,7 +3692,7 @@ export default function Shell() {
         </nav>
         )
       })()}
-      <main className="shell__content" inert={modalDrawerOpen} ref={contentElRef}>
+      <main className="shell__content" inert={navigationSurfaceOpen} ref={contentElRef}>
         {/* Content layer (design §2): app-iframe wrappers (id-sorted) and chat
             wrappers (chatId-sorted) as ONE flat sibling set, never reparented.
             A wrapper is positioned (--paned) when its tab is a visible pane's
@@ -3709,7 +3757,7 @@ export default function Shell() {
               // Every visible pane remains painted beneath the modal scrim, but
               // suspend its iframe interaction while the drawer is open OR during any
               // exit beat (INV 9: cross-origin app interaction is inert throughout).
-              interactive={visibleAppIds.has(String(id)) && !modalDrawerOpen && !modeBeatActive}
+              interactive={visibleAppIds.has(String(id)) && !navigationSurfaceOpen && !modeBeatActive}
               version={versionForApp(id)}
               appName={app?.name}
               appSlug={app?.slug}
@@ -3812,6 +3860,42 @@ export default function Shell() {
             </div>
           )
         })}
+        {/* Apps launcher — one canonical workspace surface, positioned and
+            moved by the same tab/pane projection as chats and installed apps.
+            Drawer owns the launcher interactions and portals them into this
+            stable host so app management remains one implementation. */}
+        {(() => {
+          const appsUnderlay = isUnderlay(APPS_KEY)
+          const appsMotion = appsUnderlay ? null : wrapperMotion(APPS_KEY)
+          const appsPos = (!appsUnderlay && appsPaned)
+            ? { top: appsPaned.y, left: appsPaned.x, width: appsPaned.w, height: appsPaned.h }
+            : null
+          const appsTabPanel = !appsUnderlay && appsPaned
+          return (
+            <div
+              key="apps"
+              id={appsTabPanel ? panePanelDomId(appsPaned.paneId, APPS_KEY) : undefined}
+              role={appsTabPanel ? 'tabpanel' : undefined}
+              aria-labelledby={appsTabPanel ? paneTabDomId(appsPaned.paneId, APPS_KEY) : undefined}
+              data-tab-key={appsTabPanel ? APPS_KEY : undefined}
+              data-mode-motion={appsMotion ? appsMotion.motion : undefined}
+              className={appsUnderlay
+                ? 'shell__view shell__view--exit-underlay shell__apps-view'
+                : (appsPaned
+                  ? 'shell__view shell__view--paned shell__apps-view'
+                  : `shell__view shell__apps-view ${appsFullBleed ? 'shell__view--active' : ''}`)}
+              style={appsMotion
+                ? { ...(appsPos || {}), ...appsMotion.vars }
+                : (appsPos || undefined)}
+              inert={(modeBeatActive && (!!appsMotion || appsUnderlay)) || undefined}
+              onPointerDownCapture={appsPaned && !appsUnderlay && !modeBeatActive
+                ? () => dispatchWorkspace({ type: 'FOCUS', paneId: appsPaned.paneId })
+                : undefined}
+            >
+              <div className="shell__apps-host" ref={setAppsDirectoryHost} />
+            </div>
+          )
+        })()}
         {/* Settings surface — ONE wrapper, positioned like a chat/app content
             wrapper (paned) when it is a visible builder tab, full-bleed when the
             takeover overlay is up. Keyed 'settings' so React reconciles it by key
@@ -3906,7 +3990,7 @@ export default function Shell() {
             // pointer-transparent (CSS) but fully INERT — keyboard-unfocusable and
             // aria-hidden — so a tab/divider that already held focus can't process
             // Enter/arrow input while invisibly dealing away.
-            inert={modalDrawerOpen || modeBeatActive}
+            inert={navigationSurfaceOpen || modeBeatActive}
             workspace={workspace}
             projection={projection}
             mode={workspaceMode}
@@ -3915,6 +3999,7 @@ export default function Shell() {
             dispatchWorkspace={dispatchWorkspace}
             navTo={navTo}
             labelForTab={labelForTab}
+            appById={appById}
             onTabContextMenu={openTabMenu}
             // The ONE shared user-close action (INV 13) + the per-pane beat motion
             // (each strip deals with its pane) — WorkspaceChrome owns no private
@@ -3938,7 +4023,7 @@ export default function Shell() {
           type="button"
           className="shell__immersive-exit"
           aria-label="Exit full screen"
-          inert={modalDrawerOpen}
+          inert={navigationSurfaceOpen}
           onClick={() => dispatchImmersive({ type: 'exit' })}
         >
           <Minimize2 size={18} aria-hidden="true" />

--- a/frontend/src/components/Shell/WorkspaceChrome.jsx
+++ b/frontend/src/components/Shell/WorkspaceChrome.jsx
@@ -86,6 +86,7 @@ export default function WorkspaceChrome({
   dispatchWorkspace,
   navTo,
   labelForTab,
+  appById,
   onTabContextMenu,
   // The ONE shared user-close action (INV 13) — Shell owns it, this layer no longer
   // dispatches CLOSE_TAB itself. Called with a tab object.
@@ -251,6 +252,7 @@ export default function WorkspaceChrome({
             paneRect={rect}
             focused={paneId === workspace.focusedPaneId}
             labelForTab={labelForTab}
+            appById={appById}
             onActivate={activateTab}
             onClose={onCloseTab}
             onFocus={focusPane}

--- a/frontend/src/components/Shell/__tests__/appIcon.test.js
+++ b/frontend/src/components/Shell/__tests__/appIcon.test.js
@@ -1,0 +1,21 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { appIconUrl } from '../../appIcon.js'
+
+test('installed app chrome uses the raw transparent icon route with a bounded size', () => {
+  const app = {
+    id: 42,
+    slug: 'example-app',
+    updated_at: '2026-07-27T03:00:00+00:00',
+  }
+
+  assert.equal(
+    appIconUrl(app, 64),
+    '/api/apps/42/icon?size=64&v=2026-07-27T03%3A00%3A00%2B00%3A00',
+  )
+  assert.equal(
+    appIconUrl(app),
+    '/api/apps/42/icon?size=128&v=2026-07-27T03%3A00%3A00%2B00%3A00',
+  )
+  assert.equal(appIconUrl(null), null)
+})

--- a/frontend/src/components/Shell/__tests__/appIcon.test.js
+++ b/frontend/src/components/Shell/__tests__/appIcon.test.js
@@ -7,6 +7,7 @@ test('installed app chrome uses the raw transparent icon route with a bounded si
     id: 42,
     slug: 'example-app',
     updated_at: '2026-07-27T03:00:00+00:00',
+    has_custom_icon: true,
   }
 
   assert.equal(
@@ -17,5 +18,6 @@ test('installed app chrome uses the raw transparent icon route with a bounded si
     appIconUrl(app),
     '/api/apps/42/icon?size=128&v=2026-07-27T03%3A00%3A00%2B00%3A00',
   )
+  assert.equal(appIconUrl({ id: 7, has_custom_icon: false }), null)
   assert.equal(appIconUrl(null), null)
 })

--- a/frontend/src/components/Shell/__tests__/desktopSidebar.test.js
+++ b/frontend/src/components/Shell/__tests__/desktopSidebar.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import {
   clampDesktopSidebarWidth,
   desktopContentWidthAfterSidebarToggle,
+  DESKTOP_RAIL_WIDTH,
   DESKTOP_SIDEBAR_DEFAULT_WIDTH,
   DESKTOP_SIDEBAR_MAX_WIDTH,
   DESKTOP_SIDEBAR_MIN_WIDTH,
@@ -62,8 +63,8 @@ test('desktop content width projects drawer open and close from live geometry', 
     currentReserved: true,
     nextReserved: false,
     sidebarWidth: 320,
-  }), 1680)
-  assert.equal(desktopContentWidthAfterSidebarToggle(1680, {
+  }), 1680 - DESKTOP_RAIL_WIDTH)
+  assert.equal(desktopContentWidthAfterSidebarToggle(1680 - DESKTOP_RAIL_WIDTH, {
     currentReserved: false,
     nextReserved: true,
     sidebarWidth: 320,

--- a/frontend/src/components/Shell/__tests__/modeReviewFixes.test.js
+++ b/frontend/src/components/Shell/__tests__/modeReviewFixes.test.js
@@ -254,7 +254,7 @@ test('finding F5: handleBack restores the hidden app through applyModeDestinatio
 
 // -- Finding 10: exit chrome is keyboard-inert during the latched deal ---------
 test('finding 10: WorkspaceChrome is inert during either mode beat, not just pointer-blocked', () => {
-  assert.match(shell, /<WorkspaceChrome[\s\S]*?inert=\{modalDrawerOpen \|\| modeBeatActive\}/)
+  assert.match(shell, /<WorkspaceChrome[\s\S]*?inert=\{navigationSurfaceOpen \|\| modeBeatActive\}/)
 })
 
 // -- Finding 11: a live hold cancels on hide/blur/pagehide/lostpointercapture --

--- a/frontend/src/components/Shell/__tests__/singleScreenSlot.test.js
+++ b/frontend/src/components/Shell/__tests__/singleScreenSlot.test.js
@@ -270,13 +270,17 @@ test('INV 8: an explicit later toggle rebases a coupled undo to tree-only', () =
   assert.equal(state.ws.viewMode, 'panes', 'the owner\'s later mode choice is preserved')
 })
 
-test('singleScreenRoute: chat slot, app slot, and empty/home', () => {
+test('singleScreenRoute: chat, installed app, Apps launcher, and empty/home', () => {
   const base = paneModel.seedFromFlatTabs([])
   assert.deepEqual(paneModel.singleScreenRoute({ ...base, singleScreen: { kind: 'chat', id: '9' } }), {
     view: 'chat', chatId: '9', appId: null, paneId: base.focusedPaneId,
   })
   const appR = paneModel.singleScreenRoute({ ...base, singleScreen: { kind: 'app', id: '42' } })
   assert.equal(appR.view, 'canvas'); assert.equal(appR.appId, 42)
+  assert.deepEqual(
+    paneModel.singleScreenRoute({ ...base, singleScreen: tabModel.appsTab() }),
+    { view: 'apps', chatId: null, appId: null, paneId: base.focusedPaneId },
+  )
   // Null/empty slot → the empty chat home surface, never a fabricated id.
   assert.deepEqual(paneModel.singleScreenRoute({ ...base, singleScreen: null }), {
     view: 'chat', chatId: null, appId: null, paneId: base.focusedPaneId,

--- a/frontend/src/components/Shell/__tests__/tabModel.test.js
+++ b/frontend/src/components/Shell/__tests__/tabModel.test.js
@@ -109,10 +109,22 @@ test('readOpenTabs keeps the legacy projection chat/app-only (drops Settings)', 
   const store = fakeStorage(JSON.stringify([
     { kind: 'chat', id: 'a' },
     { kind: 'settings', id: 'settings' },
+    { kind: 'apps', id: 'apps' },
     { kind: 'app', id: 7 },
   ]))
   assert.deepEqual(tabModel.readOpenTabs(store), [
     { kind: 'chat', id: 'a' },
     { kind: 'app', id: '7' },
   ])
+})
+
+// ── Apps launcher tab ───────────────────────────────────────────────────────
+
+test('appsTab is one canonical workspace item with an ordinary nav target', () => {
+  assert.deepEqual(tabModel.appsTab(), { kind: 'apps', id: 'apps' })
+  assert.equal(tabModel.tabKey(tabModel.appsTab()), tabModel.APPS_TAB_KEY)
+  assert.equal(tabModel.APPS_TAB_KEY, 'apps:apps')
+  assert.ok(tabModel.isAppsTab(tabModel.appsTab()))
+  assert.ok(!tabModel.isAppsTab(tabModel.makeTab('app', '1')))
+  assert.deepEqual(tabModel.tabNavTarget(tabModel.appsTab()), { view: 'apps' })
 })

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -542,7 +542,7 @@ test('builder single-leaf: the strip deals with its pane, entry through the ONE 
   assert.match(shell, /data-mode-motion=\{navMotion \? navMotion\.motion : undefined\}/)
   // It is INERT throughout either direction (not just under the drawer), so a tap
   // on an in-flight strip cannot re-target the transition.
-  assert.match(shell, /className="shell__tabstrip"[\s\S]*?inert=\{modalDrawerOpen \|\| modeBeatActive\}/)
+  assert.match(shell, /className="shell__tabstrip"[\s\S]*?inert=\{navigationSurfaceOpen \|\| modeBeatActive\}/)
   // CSS: a strip deals in with its pane on enter (shared with the WorkspaceChrome
   // strips via .shell__tabstrip[data-mode-motion]).
   assert.match(css, /\.shell--builder-entering \.shell__tabstrip\[data-mode-motion="deal-in"\] \{[\s\S]*?shell-mode-deal-in/)
@@ -699,17 +699,37 @@ test('overflowing strips keep native pan and add a no-chrome wheel path', () => 
   assert.match(shell, /onWheel=\{scrollStripWheel\}/)
 })
 
-test('the mobile modal keeps its existing brand close path while the workspace is inert', () => {
+test('navigation surfaces keep the brand close path while the workspace is inert', () => {
   const header = shell.match(/<header className="shell__bar"[^>]*>/)?.[0] || ''
   assert.doesNotMatch(header, /inert=/)
-  assert.match(shell, /<main className="shell__content" inert=\{modalDrawerOpen\}/)
+  assert.match(shell, /const navigationSurfaceOpen = modalDrawerOpen/)
+  assert.doesNotMatch(shell, /const navigationSurfaceOpen = .*apps/,
+    'the canonical Apps tab is workspace content, not a modal navigation surface')
+  assert.match(shell, /<main className="shell__content" inert=\{navigationSurfaceOpen\}/)
   assert.match(shellBrand, /aria-expanded=\{navigationOpen\}/)
   assert.match(shell, /drawerOpen \? closeDrawer\(\) : openDrawer\(\)/)
 })
 
+test('the Apps tab never disables the mobile drawer layered above it', () => {
+  assert.doesNotMatch(drawer, /drawer__body" inert=/,
+    'workspace content is inert while the drawer is open; the drawer must stay interactive')
+  assert.doesNotMatch(drawer, /interactionLocked \|\| appsActive/,
+    'Apps is a tab underneath navigation, not a modal owner of Escape')
+  assert.match(drawer, /appsActive \? ' drawer__item--active'/)
+  assert.match(shell, /appsActive=\{appsVisibleAsTab\}/)
+})
+
+test('opening navigation is presentation-only and never refetches whole lists', () => {
+  assert.doesNotMatch(shell, /if \(navigationOpen\) \{ refreshApps\(\); refreshChats\(\) \}/)
+  assert.match(shell, /ev\.type === 'app_updated' \|\| ev\.type === 'app_created'[\s\S]*?refreshApps\(\)/,
+    'app lifecycle events still own their authoritative refresh')
+  assert.match(shell, /ev\.type === 'chat_run_finished'[\s\S]*?refreshChats\(\)/,
+    'chat lifecycle events still own their authoritative refresh')
+})
+
 test('large drawer lists memoize ordering and row actions without changing row ownership', () => {
-  assert.match(drawer, /const allChats = useMemo\(/)
-  assert.match(drawer, /const sortedApps = useMemo\(/)
+  assert.match(drawer, /useMemo\(\(\) => buildDrawerSections\(chats, apps\), \[chats, apps\]\)/)
+  assert.match(drawer, /const filteredApps = useMemo\(/)
   assert.match(drawer, /const rowActions = useMemo\(/)
   assert.match(drawer, /const DrawerRow = memo\(function DrawerRow/)
   assert.match(drawer, /item=\{chat\}[\s\S]*?actions=\{rowActions\}/)

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -738,7 +738,7 @@ test('large drawer lists memoize ordering and row actions without changing row o
 })
 
 test('drawer row menus use one semantic context-menu path across pointer types', () => {
-  assert.match(drawer, /function openRowMenu\(event\)[\s\S]*?actions\.toggleMenu\(kind, id, true\)/)
+  assert.match(drawer, /function openRowMenu\(event\)[\s\S]*?actions\.toggleMenu\(kind, id, true, surface\)/)
   assert.match(drawer, /onContextMenu=\{openRowMenu\}/)
   assert.match(dragBinding, /srcEl\.dispatchEvent\(new window\.MouseEvent\('contextmenu'/)
   assert.doesNotMatch(
@@ -753,7 +753,7 @@ test('a secondary-button release cannot immediately select a flipped drawer menu
   assert.match(drawer, /event\.pointerType !== 'mouse' \|\| event\.button !== 2/)
   assert.match(drawer, /window\.addEventListener\('pointerup', onSecondaryPointerUp, true\)/)
   assert.match(drawer, /upEvent\.pointerId !== pointerId \|\| upEvent\.button !== 2/)
-  assert.match(drawer, /cleanup\(\)[\s\S]*?actions\.toggleMenu\(kind, id, true\)/)
+  assert.match(drawer, /cleanup\(\)[\s\S]*?actions\.toggleMenu\(kind, id, true, surface\)/)
   assert.match(drawer, /timer = setTimeout\(cleanup, 1500\)/)
 })
 

--- a/frontend/src/components/Shell/paneModel.js
+++ b/frontend/src/components/Shell/paneModel.js
@@ -179,6 +179,9 @@ function clampRatio(ratio) {
 //     stored tabs into one key), it is dropped.
 function sanitizeTab(raw) {
   if (!raw || raw.id == null) return null
+  if (raw.kind === 'apps') {
+    return String(raw.id) === tabModel.APPS_ID ? tabModel.appsTab() : null
+  }
   if (raw.kind === 'settings') {
     return (BUILDER_SETTINGS_ENABLED && String(raw.id) === tabModel.SETTINGS_ID)
       ? tabModel.settingsTab()
@@ -211,6 +214,9 @@ function sanitizeTabs(tabs) {
 // migration marker; only a PRESENT-but-invalid value collapses to null here.
 function sanitizeSingleScreen(raw) {
   if (raw == null || typeof raw !== 'object') return null
+  if (raw.kind === 'apps' && String(raw.id) === tabModel.APPS_ID) {
+    return tabModel.appsTab()
+  }
   if (raw.kind === 'chat' && raw.id != null && String(raw.id).trim() !== '') {
     return { kind: 'chat', id: String(raw.id) }
   }
@@ -507,6 +513,7 @@ export function singleScreenKey(ws) {
   if (!slot || typeof slot !== 'object') return null
   if (slot.kind === 'app') return `app:${slot.id}`
   if (slot.kind === 'chat') return `chat:${slot.id}`
+  if (slot.kind === 'apps') return tabModel.APPS_TAB_KEY
   return null
 }
 
@@ -549,6 +556,7 @@ export function focusedSlotSeed(ws) {
   if (!tab) return null
   if (tab.kind === 'app') return { kind: 'app', id: String(tab.id) }
   if (tab.kind === 'chat') return { kind: 'chat', id: String(tab.id) }
+  if (tab.kind === 'apps') return tabModel.appsTab()
   return null
 }
 
@@ -617,6 +625,7 @@ export function focusedContentRoute(ws) {
       // apart via the SEPARATE settingsOverlayOpen flag, never via this route
       // (design: the overlay must not be conflated with focused-content-is-Settings).
       if (tab.kind === 'settings') return { view: 'settings', chatId: null, appId: null, paneId }
+      if (tab.kind === 'apps') return { view: 'apps', chatId: null, appId: null, paneId }
       const { view, opts } = tabModel.tabNavTarget(tab)
       if (view === 'canvas') return { view: 'canvas', chatId: null, appId: opts.appId, paneId }
       return { view: 'chat', chatId: opts.chatId, appId: null, paneId }
@@ -634,6 +643,9 @@ export function focusedContentRoute(ws) {
 export function singleScreenRoute(ws) {
   const slot = ws.singleScreen
   const paneId = ws.focusedPaneId
+  if (slot && slot.kind === 'apps') {
+    return { view: 'apps', chatId: null, appId: null, paneId }
+  }
   if (slot && slot.kind === 'app') {
     const appId = Number(slot.id)
     if (Number.isFinite(appId)) return { view: 'canvas', chatId: null, appId, paneId }
@@ -673,6 +685,7 @@ export function visibleAppIds(ws, visibleLeaves) {
 // no concrete workspace item (Settings, or a home-seed chat route).
 function routeItemKey(route) {
   if (!route || typeof route !== 'object') return null
+  if (route.view === 'apps') return tabModel.APPS_TAB_KEY
   if (route.view === 'canvas' && route.appId != null) return `app:${route.appId}`
   if (route.view === 'chat' && !route.homeSeed && route.chatId != null) return `chat:${route.chatId}`
   return null
@@ -1106,6 +1119,7 @@ function slotIsLive(slot, chats, apps) {
   if (!slot || typeof slot !== 'object') return true
   if (slot.kind === 'chat') return chats == null || chats.has(String(slot.id))
   if (slot.kind === 'app') return apps == null || apps.has(String(slot.id))
+  if (slot.kind === 'apps') return true
   return true
 }
 

--- a/frontend/src/components/Shell/tabModel.js
+++ b/frontend/src/components/Shell/tabModel.js
@@ -1,8 +1,8 @@
 // Tab model — the openable-item primitive behind the shell's tab strip.
 //
 // A tab is a pinned reference to a chat or app the owner can swap to:
-// `{ kind: 'chat' | 'app', id: string }`, plus the one canonical
-// `{ kind: 'settings', id: 'settings' }` builder tab (see below). This module
+// `{ kind: 'chat' | 'app', id: string }`, plus the canonical shell-owned
+// Apps and Settings tabs (see below). This module
 // owns the whole tab contract — construction, identity, the open-set invariants
 // (dedup + cap), persistence, how a tab maps to navigation, and whether it is
 // the one on screen — so no call site has to re-derive them.
@@ -37,6 +37,15 @@ export const SETTINGS_TAB_KEY = 'settings:settings'
 export function settingsTab() { return { kind: 'settings', id: SETTINGS_ID } }
 export function isSettingsTab(tab) { return !!tab && tab.kind === 'settings' }
 
+// Apps is an ordinary, single-instance workspace destination. Unlike Settings
+// it has no takeover/overlay mode: it opens wherever it is invoked, exactly
+// like a chat or installed app, and workspace-wide tab dedup focuses the
+// existing copy instead of creating another launcher.
+export const APPS_ID = 'apps'
+export const APPS_TAB_KEY = 'apps:apps'
+export function appsTab() { return { kind: 'apps', id: APPS_ID } }
+export function isAppsTab(tab) { return !!tab && tab.kind === 'apps' }
+
 // Ids are stored as strings for stable React keys + sessionStorage. App ids
 // are re-coerced to Number in tabNavTarget — the ONLY correct nav shape (the
 // iframe LRU dedups on strict !==, so a string id would double-mount).
@@ -62,6 +71,7 @@ export function tabKey(tab) {
 // no `opts`.
 export function tabNavTarget(tab) {
   if (tab.kind === 'settings') return { view: 'settings' }
+  if (tab.kind === 'apps') return { view: 'apps' }
   return tab.kind === 'app'
     ? { view: 'canvas', opts: { appId: Number(tab.id) } }
     : { view: 'chat', opts: { chatId: tab.id } }

--- a/frontend/src/components/Shell/useDesktopSidebar.js
+++ b/frontend/src/components/Shell/useDesktopSidebar.js
@@ -6,6 +6,7 @@ export const DESKTOP_SIDEBAR_WIDTH_STORAGE_KEY = 'mobius:desktop-sidebar-width:v
 export const DESKTOP_SIDEBAR_DEFAULT_WIDTH = 320
 export const DESKTOP_SIDEBAR_MIN_WIDTH = 240
 export const DESKTOP_SIDEBAR_MAX_WIDTH = 560
+export const DESKTOP_RAIL_WIDTH = 58
 
 export function clampDesktopSidebarWidth(width) {
   const numericWidth = Number(width)
@@ -32,10 +33,12 @@ export function desktopContentWidthAfterSidebarToggle(currentContentWidth, {
   const measured = Number(currentContentWidth)
   const contentWidth = Number.isFinite(measured) ? Math.max(0, measured) : 0
   const width = clampDesktopSidebarWidth(sidebarWidth)
+  const currentReservation = currentReserved ? width : DESKTOP_RAIL_WIDTH
+  const nextReservation = nextReserved ? width : DESKTOP_RAIL_WIDTH
   const shellWidth = contentWidth
-    + (currentReserved ? width : 0)
+    + currentReservation
   const projected = shellWidth
-    - (nextReserved ? width : 0)
+    - nextReservation
   return Math.max(0, Math.round(projected))
 }
 

--- a/frontend/src/components/Shell/useWorkspaceDrag.js
+++ b/frontend/src/components/Shell/useWorkspaceDrag.js
@@ -406,7 +406,19 @@ export default function useWorkspaceDrag({
             }
             if (!armed) return
           } else {
-            if (passedSlop(dx, dy)) arm()
+            if (sourceKind === 'drawer') {
+              // Drawer rows have two orthogonal mouse gestures: a deliberate
+              // rightward pull leaves navigation for the workspace, while a
+              // vertical drag belongs to pinned-item reordering. The previous
+              // any-axis arm contradicted that contract and stole vertical
+              // movement before the drawer could reorder it.
+              if (Math.abs(dy) > Math.abs(dx) && passedSlop(dx, dy)) {
+                cancelled = true
+                cleanup()
+                return
+              }
+              if (dx > 0 && Math.abs(dx) >= Math.abs(dy) && passedSlop(dx, dy)) arm()
+            } else if (passedSlop(dx, dy)) arm()
             if (!armed) return
           }
         }

--- a/frontend/src/components/appIcon.js
+++ b/frontend/src/components/appIcon.js
@@ -3,7 +3,7 @@
 // This is the raw stored artwork (including alpha), not the standalone-PWA icon
 // renderer, which may add an install-friendly background around that artwork.
 export function appIconUrl(app, size = 128) {
-  if (!app?.id) return null
+  if (!app?.id || !app.has_custom_icon) return null
   const version = app.updated_at ? `&v=${encodeURIComponent(app.updated_at)}` : ''
   return `/api/apps/${encodeURIComponent(app.id)}/icon?size=${size}${version}`
 }

--- a/frontend/src/components/appIcon.js
+++ b/frontend/src/components/appIcon.js
@@ -1,0 +1,9 @@
+// One canonical URL builder for installed-app artwork wherever the shell names
+// an app, so the drawer, launcher, and tab strip cannot drift on cache-busting.
+// This is the raw stored artwork (including alpha), not the standalone-PWA icon
+// renderer, which may add an install-friendly background around that artwork.
+export function appIconUrl(app, size = 128) {
+  if (!app?.id) return null
+  const version = app.updated_at ? `&v=${encodeURIComponent(app.updated_at)}` : ''
+  return `/api/apps/${encodeURIComponent(app.id)}/icon?size=${size}${version}`
+}

--- a/frontend/src/components/navigationIcons.js
+++ b/frontend/src/components/navigationIcons.js
@@ -1,0 +1,9 @@
+// One ChatGPT SDK icon vocabulary for actions that exist in both the collapsed
+// desktop rail and expanded drawer. These semantic aliases keep presentation
+// details out of both owners and prevent the two states silently drifting.
+export {
+  Chat as ChatNavIcon,
+  ComposeEditSquare as NewChatNavIcon,
+  Grid as AppsNavIcon,
+  SettingsSlider as SettingsNavIcon,
+} from '@openai/apps-sdk-ui/components/Icon'

--- a/frontend/src/hooks/useNavigation.js
+++ b/frontend/src/hooks/useNavigation.js
@@ -52,7 +52,7 @@ function navRoute(view, chatId, appId, paneId, extra = null) {
 }
 
 function isRestorableRoute(route) {
-  return route && ['chat', 'canvas', 'settings'].includes(route.view)
+  return route && ['chat', 'canvas', 'apps', 'settings'].includes(route.view)
 }
 
 function sameRoute(a, b) {
@@ -803,7 +803,7 @@ export default function useNavigation({
 
   // ── The ONE navigation decision point (two-worlds design) ──────────────────
   // applySettingsDestination generalized to ALL destinations. Every path that
-  // APPLIES a chat/app/settings destination — navTo, restoreRoute, boot/deep-link,
+  // APPLIES a chat/app/Apps/settings destination — navTo, restoreRoute, boot/deep-link,
   // no-history opens, app-history restoration — funnels here, so the single-vs-
   // builder branch lives in EXACTLY ONE place and no caller can accidentally
   // OPEN_TAB into the pane tree while in single mode (design risk 4: nav bypasses).
@@ -833,18 +833,22 @@ export default function useNavigation({
       settingsOpenRef.current = false
     }
     if (mode === 'single') {
-      const item = route.view === 'canvas'
-        ? (route.appId != null ? { kind: 'app', id: route.appId } : null)
-        : (route.chatId != null ? { kind: 'chat', id: route.chatId } : null)
+      const item = route.view === 'apps'
+        ? tabModel.appsTab()
+        : (route.view === 'canvas'
+          ? (route.appId != null ? { kind: 'app', id: route.appId } : null)
+          : (route.chatId != null ? { kind: 'chat', id: route.chatId } : null))
       dispatchWorkspace({ type: 'SET_SINGLE_SCREEN', item })
       return
     }
     const targetPaneId = (typeof route.paneId === 'string' && ws.panes[route.paneId])
       ? route.paneId
       : ws.focusedPaneId
-    const tab = route.view === 'canvas'
-      ? tabModel.makeTab('app', route.appId)
-      : tabModel.makeTab('chat', route.chatId)
+    const tab = route.view === 'apps'
+      ? tabModel.appsTab()
+      : (route.view === 'canvas'
+        ? tabModel.makeTab('app', route.appId)
+        : tabModel.makeTab('chat', route.chatId))
     dispatchWorkspace({ type: 'OPEN_TAB', paneId: targetPaneId, tab, activate: true })
   }, [applySettingsDestination, dispatchWorkspace, workspaceStateRef])
 
@@ -888,6 +892,9 @@ export default function useNavigation({
       // The destination is a Settings route; its paneId is the focused pane hint
       // behind the overlay.
       nextRoute = navRoute('settings', previousRoute.chatId, previousRoute.appId, targetPaneId)
+    } else if (view === 'apps') {
+      nextRoute = navRoute('apps', null, null, targetPaneId)
+      openTab = tabModel.appsTab()
     } else if (view === 'canvas') {
       const appId = 'appId' in opts ? opts.appId : activeAppIdRef.current
       const tab = tabModel.makeTab('app', appId)
@@ -986,7 +993,9 @@ export default function useNavigation({
     // ONE decision point so single restores the slot and builder the pane tab —
     // restoreRoute no longer dispatches OPEN_TAB directly (design risk 4).
     let itemRoute = null
-    if (route.view === 'canvas') {
+    if (route.view === 'apps') {
+      itemRoute = { view: 'apps', appId: null, chatId: null, paneId: route.paneId }
+    } else if (route.view === 'canvas') {
       if (route.appId != null) itemRoute = { view: 'canvas', appId: route.appId, chatId: null, paneId: route.paneId }
     } else {
       const chatId = route.homeSeed ? lastChatIdRef.current : route.chatId

--- a/frontend/src/lib/__tests__/appsDirectoryContract.test.js
+++ b/frontend/src/lib/__tests__/appsDirectoryContract.test.js
@@ -37,6 +37,11 @@ test('phone and web share one searchable launcher tab', () => {
   assert.match(css, /@media \(max-width: 720px\)[\s\S]*?grid-template-columns: repeat\(4/)
   assert.match(drawer, /onContextMenu=\{openCardMenu\}/)
   assert.match(drawer, /setTimeout\(\(\) => \{[\s\S]*?toggleMenu[\s\S]*?520\)/)
+  assert.match(
+    drawer,
+    /triggerClassName="drawer__more apps-directory__card-menu-anchor"\s+triggerHidden/,
+    'the invisible menu anchor must not add a ghost keyboard focus stop',
+  )
   assert.match(shell, /const navigationSurfaceOpen = modalDrawerOpen/)
 })
 

--- a/frontend/src/lib/__tests__/appsDirectoryContract.test.js
+++ b/frontend/src/lib/__tests__/appsDirectoryContract.test.js
@@ -1,0 +1,49 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const src = resolve(here, '../..')
+const drawer = readFileSync(resolve(src, 'components/Drawer/Drawer.jsx'), 'utf8')
+const directory = readFileSync(resolve(src, 'components/Drawer/AppsDirectory.jsx'), 'utf8')
+const css = readFileSync(resolve(src, 'components/Drawer/AppsDirectory.css'), 'utf8')
+const shell = readFileSync(resolve(src, 'components/Shell/Shell.jsx'), 'utf8')
+const tabModel = readFileSync(resolve(src, 'components/Shell/tabModel.js'), 'utf8')
+const navigationIcons = readFileSync(resolve(src, 'components/navigationIcons.js'), 'utf8')
+
+test('Apps is a single drawer destination and the old full app list is gone', () => {
+  assert.match(drawer, /className=\{`drawer__item drawer__item--apps/)
+  assert.match(drawer, /<span className="drawer__item-text">Apps<\/span>/)
+  assert.doesNotMatch(drawer, /drawer__group--apps/)
+  assert.match(drawer, /pinnedItems\.map\(\(\{ kind, item \}\)/)
+})
+
+test('the directory preserves app management on every card', () => {
+  assert.match(drawer, /variant="card"/)
+  assert.match(drawer, /<DrawerItemMenu[\s\S]*?surface=\{surface\}/)
+  for (const action of ['Install to home screen', 'Delete data', 'Rename']) {
+    assert.match(drawer, new RegExp(action))
+  }
+})
+
+test('phone and web share one searchable launcher tab', () => {
+  assert.doesNotMatch(directory, /Back to navigation/)
+  assert.match(directory, /aria-label="Search installed apps"/)
+  assert.match(directory, /matchMedia\?\.\('\(pointer: fine\)'\)/)
+  assert.match(tabModel, /APPS_TAB_KEY = 'apps:apps'/)
+  assert.match(shell, /const APPS_KEY = tabModel\.APPS_TAB_KEY/)
+  assert.match(css, /@media \(max-width: 720px\)[\s\S]*?grid-template-columns: repeat\(4/)
+  assert.match(drawer, /onContextMenu=\{openCardMenu\}/)
+  assert.match(drawer, /setTimeout\(\(\) => \{[\s\S]*?toggleMenu[\s\S]*?520\)/)
+  assert.match(shell, /const navigationSurfaceOpen = modalDrawerOpen/)
+})
+
+test('expanded and collapsed navigation share one ChatGPT SDK icon vocabulary', () => {
+  for (const icon of ['ComposeEditSquare', 'Grid', 'SettingsSlider']) {
+    assert.match(navigationIcons, new RegExp(icon))
+  }
+  assert.match(drawer, /from '\.\.\/navigationIcons\.js'/)
+  assert.match(shell, /from '\.\.\/navigationIcons\.js'/)
+})

--- a/frontend/src/lib/__tests__/drawerInformationArchitecture.test.js
+++ b/frontend/src/lib/__tests__/drawerInformationArchitecture.test.js
@@ -18,12 +18,48 @@ test('drawer separates pinned chats and apps from ordinary chat history', () => 
     { id: 2, created_at: '2026-07-02', pinned_at: '2026-07-26' },
   ])
 
+  // Oldest pin first: the chat (pinned 07-25) sits above the app (pinned 07-26).
   assert.deepEqual(sections.pinned.map(entry => [entry.kind, entry.item.id]), [
-    ['app', 2],
     ['chat', 'pinned-chat'],
+    ['app', 2],
   ])
   assert.deepEqual(sections.chats.map(chat => chat.id), ['new-chat', 'old-chat'])
   assert.deepEqual(sections.apps.map(app => app.id), [2, 1])
+})
+
+test('pinned order is stable across mixed timestamp formats (Z vs naive UTC)', () => {
+  // After a drag, optimistic chat stamps carry a trailing Z while a refetched
+  // app carries the server's naive-UTC form. Same instants must still interleave
+  // by time, not by the accident of the suffix.
+  const sections = buildDrawerSections([
+    { id: 'chat-early', has_messages: true, pinned_at: '2026-07-27T10:00:00.000Z' },
+    { id: 'chat-late', has_messages: true, pinned_at: '2026-07-27T10:00:02.000Z' },
+  ], [
+    { id: 9, created_at: '2026-07-01', pinned_at: '2026-07-27T10:00:01.123456' },
+  ])
+
+  assert.deepEqual(sections.pinned.map(entry => [entry.kind, entry.item.id]), [
+    ['chat', 'chat-early'],
+    ['app', 9],
+    ['chat', 'chat-late'],
+  ])
+})
+
+test('a freshly pinned item lands at the bottom of the pinned list', () => {
+  // Three items already pinned in chronological order; the newest pin (the app,
+  // stamped last) must render last so pinning appends rather than jumping to top.
+  const sections = buildDrawerSections([
+    { id: 'first-pinned', has_messages: true, pinned_at: '2026-07-25T09:00:00Z' },
+    { id: 'second-pinned', has_messages: true, pinned_at: '2026-07-25T10:00:00Z' },
+  ], [
+    { id: 7, created_at: '2026-07-01', pinned_at: '2026-07-25T11:00:00Z' },
+  ])
+
+  assert.deepEqual(sections.pinned.map(entry => [entry.kind, entry.item.id]), [
+    ['chat', 'first-pinned'],
+    ['chat', 'second-pinned'],
+    ['app', 7],
+  ])
 })
 
 test('app search covers names, descriptions, and slugs without reordering', () => {

--- a/frontend/src/lib/__tests__/drawerInformationArchitecture.test.js
+++ b/frontend/src/lib/__tests__/drawerInformationArchitecture.test.js
@@ -1,0 +1,46 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  appInitials,
+  buildDrawerSections,
+  filterInstalledApps,
+} from '../../components/Drawer/drawerInformationArchitecture.js'
+
+test('drawer separates pinned chats and apps from ordinary chat history', () => {
+  const sections = buildDrawerSections([
+    { id: 'empty', has_messages: false, updated_at: '2026-07-30' },
+    { id: 'old-chat', has_messages: true, updated_at: '2026-07-20' },
+    { id: 'new-chat', has_messages: true, activity_at: '2026-07-29' },
+    { id: 'pinned-chat', has_messages: true, pinned_at: '2026-07-25', updated_at: '2026-07-01' },
+  ], [
+    { id: 1, created_at: '2026-07-01' },
+    { id: 2, created_at: '2026-07-02', pinned_at: '2026-07-26' },
+  ])
+
+  assert.deepEqual(sections.pinned.map(entry => [entry.kind, entry.item.id]), [
+    ['app', 2],
+    ['chat', 'pinned-chat'],
+  ])
+  assert.deepEqual(sections.chats.map(chat => chat.id), ['new-chat', 'old-chat'])
+  assert.deepEqual(sections.apps.map(app => app.id), [2, 1])
+})
+
+test('app search covers names, descriptions, and slugs without reordering', () => {
+  const apps = [
+    { id: 1, name: 'Metro Board', description: 'Live departures', slug: 'underground' },
+    { id: 2, name: 'Atlas', description: 'Maps and places', slug: 'atlas' },
+  ]
+
+  assert.equal(filterInstalledApps(apps, '  LIVE  ')[0].id, 1)
+  assert.equal(filterInstalledApps(apps, 'underground')[0].id, 1)
+  assert.equal(filterInstalledApps(apps, 'places')[0].id, 2)
+  assert.equal(filterInstalledApps(apps, 'missing').length, 0)
+  assert.equal(filterInstalledApps(apps, ''), apps)
+})
+
+test('app initials remain useful for missing custom icons', () => {
+  assert.equal(appInitials('Beat Machine'), 'BM')
+  assert.equal(appInitials('Atlas'), 'AT')
+  assert.equal(appInitials('---'), 'A')
+})

--- a/frontend/src/lib/__tests__/frameInteractivityContract.test.js
+++ b/frontend/src/lib/__tests__/frameInteractivityContract.test.js
@@ -13,7 +13,7 @@ const shell = readFileSync(resolve(src, 'components/Shell/Shell.jsx'), 'utf8')
 test('drawer suspension reaches the live app frame before paint', () => {
   // Pane assembly/scatter also suspends iframe interaction throughout either beat:
   // painted apps stay visible, but a moving cross-origin frame cannot intercept input.
-  assert.match(shell, /interactive=\{visibleAppIds\.has\(String\(id\)\) && !modalDrawerOpen && !modeBeatActive\}/)
+  assert.match(shell, /interactive=\{visibleAppIds\.has\(String\(id\)\) && !navigationSurfaceOpen && !modeBeatActive\}/)
   assert.match(canvas, /useLayoutEffect\(\(\) => \{[\s\S]*sendInteractivity\(swap\.liveVersion, interactive, visible\)/)
   assert.match(canvas, /suspendScrolling:\s*visible\s*&&\s*!enabled/)
   assert.match(canvas, /moebius:frame-interactivity/)

--- a/frontend/src/lib/__tests__/pinnedReorder.test.js
+++ b/frontend/src/lib/__tests__/pinnedReorder.test.js
@@ -1,0 +1,74 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { computePinnedDrag } from '../../components/Drawer/pinnedReorder.js'
+
+// Four uniform 40px rows stacked from top 0.
+function uniformRows() {
+  return ['a', 'b', 'c', 'd'].map((key, i) => ({
+    key,
+    top: i * 40,
+    height: 40,
+    center: i * 40 + 20,
+  }))
+}
+
+test('dragging a row down lands it below the rows it passed', () => {
+  // Drag row b (index 1) down 60px: its center 60 -> 120, past c's center 100.
+  const { above, changed, finalKeys, slotDelta, shifts } = computePinnedDrag(uniformRows(), 1, 60)
+  assert.equal(changed, true)
+  assert.equal(above, 2)
+  assert.deepEqual(finalKeys, ['a', 'c', 'b', 'd'])
+  // b rests one slot lower; c rises into b's vacated slot; a and d hold.
+  assert.equal(slotDelta, 40)
+  assert.equal(shifts.get('c'), -40)
+  assert.equal(shifts.get('a'), 0)
+  assert.equal(shifts.get('d'), 0)
+})
+
+test('dragging a row up lands it above the rows it passed', () => {
+  // Drag row d (index 3) up 80px: center 140 -> 60, above b's center 60.
+  const { above, changed, finalKeys, slotDelta, shifts } = computePinnedDrag(uniformRows(), 3, -80)
+  assert.equal(changed, true)
+  assert.equal(above, 1)
+  assert.deepEqual(finalKeys, ['a', 'd', 'b', 'c'])
+  assert.equal(slotDelta, -80)
+  assert.equal(shifts.get('b'), 40)
+  assert.equal(shifts.get('c'), 40)
+  assert.equal(shifts.get('a'), 0)
+})
+
+test('a tiny wobble that stays in the same slot is a no-op', () => {
+  const { changed, above, finalKeys } = computePinnedDrag(uniformRows(), 1, 5)
+  assert.equal(changed, false)
+  assert.equal(above, 1)
+  assert.deepEqual(finalKeys, ['a', 'b', 'c', 'd'])
+})
+
+test('previewed positions equal final natural positions with non-uniform heights', () => {
+  // Chat rows 40px, an app row 56px. Dragging the app (index 0) to the bottom
+  // must leave every row exactly where the committed list will render it — the
+  // property that makes the drop seamless.
+  const rows = [
+    { key: 'app', top: 0, height: 56, center: 28 },
+    { key: 'c1', top: 56, height: 40, center: 76 },
+    { key: 'c2', top: 96, height: 40, center: 116 },
+  ]
+  const { finalKeys, slotDelta, shifts } = computePinnedDrag(rows, 0, 200)
+  assert.deepEqual(finalKeys, ['c1', 'c2', 'app'])
+
+  // Reconstruct previewed tops (natural top + applied transform) and compare to
+  // the natural layout of the committed order.
+  const previewTop = {
+    app: rows[0].top + slotDelta,
+    c1: rows[1].top + shifts.get('c1'),
+    c2: rows[2].top + shifts.get('c2'),
+  }
+  let y = rows[0].top
+  const finalTop = {}
+  for (const key of finalKeys) {
+    finalTop[key] = y
+    y += rows.find((r) => r.key === key).height
+  }
+  assert.deepEqual(previewTop, finalTop)
+})

--- a/tests/bootstrap.spec.mjs
+++ b/tests/bootstrap.spec.mjs
@@ -588,15 +588,13 @@ test.describe('Logout cache wipe', () => {
       return route.fulfill({ status: 401, body: '{"detail":"Not signed in"}' })
     })
 
-    // Trigger a real apiFetch through the live client: opening the
-    // drawer runs Shell's `if (drawerOpen) refreshChats()` effect,
-    // which calls api.chats.list() → apiFetch('/chats') → 401 → wipe.
-    // (No internal query-client handle needed.) The 401 clears the
-    // token, so the post-reload page lands on the login form.
-    await page.evaluate(() => {
-      const btn = document.querySelector('button[aria-label="Toggle navigation"]')
-      if (btn && btn.getAttribute('aria-expanded') !== 'true') btn.click()
-    })
+    // Trigger a real apiFetch through the live client's authenticated boot.
+    // Navigation presentation no longer owns data refreshes: tying this test to
+    // opening the drawer would make a cache-security contract depend on an
+    // unrelated UI implementation detail. A shell reload reliably requests the
+    // chat list through apiFetch, whose 401 path performs the production wipe.
+    // The handler then schedules its own logged-out reload.
+    await page.reload({ waitUntil: 'domcontentloaded' }).catch(() => {})
     await expect.poll(() => forced401Count, { timeout: 5000 }).toBeGreaterThan(0)
 
     // Wait through the apiFetch-deferred reload. The token was cleared,

--- a/tests/bootstrap.spec.mjs
+++ b/tests/bootstrap.spec.mjs
@@ -594,7 +594,7 @@ test.describe('Logout cache wipe', () => {
     // (No internal query-client handle needed.) The 401 clears the
     // token, so the post-reload page lands on the login form.
     await page.evaluate(() => {
-      const btn = document.querySelector('[aria-expanded]')
+      const btn = document.querySelector('button[aria-label="Toggle navigation"]')
       if (btn && btn.getAttribute('aria-expanded') !== 'true') btn.click()
     })
     await expect.poll(() => forced401Count, { timeout: 5000 }).toBeGreaterThan(0)

--- a/tests/navigation.spec.mjs
+++ b/tests/navigation.spec.mjs
@@ -317,7 +317,7 @@ test.describe('Desktop sidebar navigation', () => {
     ))).toBe('false')
     await expect.poll(() => page.locator('.shell__content').evaluate(
       element => element.getBoundingClientRect().left,
-    )).toBe(0)
+    )).toBe(58)
 
     await page.reload({ waitUntil: 'domcontentloaded' })
     await expect(toggle).toHaveAttribute('aria-expanded', 'false')

--- a/tests/tabs.spec.mjs
+++ b/tests/tabs.spec.mjs
@@ -367,7 +367,7 @@ test.describe('Tabs', () => {
     await page.waitForTimeout(400)
 
     // Exactly one iframe wrapper for the single app — no string/number duplicate.
-    await expect(page.locator('.shell__view')).toHaveCount(1)
+    await expect(page.locator('.shell__app-view')).toHaveCount(1)
     expect(keyErrors, keyErrors.join('\n')).toHaveLength(0)
   })
 


### PR DESCRIPTION
## Summary
- promote Apps to a first-class workspace destination with a searchable installed-app directory
- unify pinned chats and apps into one append-at-bottom section with persisted drag reordering
- improve the drawer hierarchy, desktop rail, icons, section headings, and responsive behavior
- preserve the newly-landed gesture contract: double-click renames, while right-click, keyboard context-menu, and touch hold open actions safely

## Review notes
This combines the three prepared drawer navigation contributions in their intended order, rebased onto current `main` after #280. The rebase conflict was resolved at the drawer-row interaction owner so the restructuring does not regress the menu gesture fixes.

## Validation
- `npm test` — 2,068 tests passed
- `npm run build`
- `python3 -m py_compile backend/app/routes/apps.py`
- `git diff --check`
- full source diff privacy review
- keyboard-only review: invisible app-card menu anchors are removed from the tab order
