### PR TITLE
Steer modified-Enter messages without queue flash

### DIFF
--- a/backend/app/routes/chats_stream.py
+++ b/backend/app/routes/chats_stream.py
@@ -765,12 +765,13 @@ async def _send_message_locked(
     provider=chat.provider or "claude",
   )
 
-  # One choke point for every genuine user send (initial / queued / steered all
-  # pass here, after the answer-delivery returns above). Skip force_steer —
-  # Stop's queue-collapse re-send of already-counted messages. Counts a turn
-  # ARRIVAL, not a durable commit (a rare failed store can overcount by one) —
-  # fine for a usage signal, not a billing counter. app_id = the originating
-  # app for window.mobius.chat sends, null for the owner; metadata only.
+  # One choke point for every genuine user send (initial / queued / direct
+  # steer all pass here, after the answer-delivery returns above). Skip
+  # force_steer — it converts already-counted queued messages. direct_steer is
+  # a new composer send and is counted normally. Counts a turn ARRIVAL, not a
+  # durable commit (a rare failed store can overcount by one) — fine for a
+  # usage signal, not a billing counter. app_id = the originating app for
+  # window.mobius.chat sends, null for the owner; metadata only.
   if not body.force_steer:
     activity.log_event(
       "chat_sent",
@@ -830,20 +831,23 @@ async def _send_message_locked(
     if body.force_steer and selected_force_pending is None:
       return _not_steered_response(chat_id)
 
-    # Mid-turn steering: ordinary sends require the opt-in flag, while
-    # Stop's queue-collapse path may pass force_steer to turn already
-    # queued messages into a live steer. Codex injects into the running
-    # SDK turn; Claude interrupts and re-prompts on the same client. On
-    # success a `steered_into_turn` event tells the client the transcript has
-    # been split and the user row is in it — published here for Codex (the
-    # route is its seal point) and by the runner for Claude, whose split waits
-    # for the interrupt boundary (see the publish below).
+    # Mid-turn steering:
+    #   - ordinary sends require the chat's opt-in flag;
+    #   - direct_steer requests this new composer row explicitly;
+    #   - force_steer converts named already-queued rows.
+    # The direct and ordinary new-message paths both reserve the row durably
+    # before provider delivery. Codex injects into the running SDK turn;
+    # Claude interrupts and re-prompts on the same client.
     provider = chat.provider or "claude"
     if (
       is_chat_running(chat_id)
       and not questions.is_waiting(chat_id)
-      and (body.force_steer or _steer_enabled(chat))
-      and (body.force_steer or not chat.pending_messages)
+      and (body.force_steer or body.direct_steer or _steer_enabled(chat))
+      and (
+        body.force_steer
+        or body.direct_steer
+        or not chat.pending_messages
+      )
       and _has_live_steerable_turn(chat_id, provider)
     ):
       # Every provider delivery names a row already durable in pending.
@@ -873,7 +877,7 @@ async def _send_message_locked(
       # handle buffer is only a delivery cache.
       defer_to_runner = provider == "claude"
       if questions.is_waiting(chat_id):
-        # An ordinary auto-steer awaits AppendPending above. A question can
+        # A new-message steer awaits AppendPending above. A question can
         # register during that actor round-trip even though the entry gate was
         # clear, so re-check immediately before touching the provider channel.
         steered = False
@@ -927,9 +931,11 @@ async def _send_message_locked(
         # seconds later — publishing the cut here re-based the client's stream
         # while the runner was still emitting blocks that the deferred seal then
         # folded into A1, so those blocks painted twice for the rest of the turn.
-        # The deferred path publishes NOTHING here: the 202 below carries the
-        # still-queued row, which is the single signal that keeps it visible
-        # until `_seal_steer_split` publishes the cut.
+        # The deferred path publishes NOTHING here. An ordinary auto-steer or
+        # existing queued-row conversion remains visible until
+        # `_seal_steer_split` publishes the cut; a direct composer steer has no
+        # tray row and keeps its durable reserve intentionally hidden over the
+        # same interval.
         if not defer_to_runner:
           bc = get_broadcast(chat_id)
           if bc is not None:
@@ -944,7 +950,7 @@ async def _send_message_locked(
         )
       if body.force_steer:
         return _not_steered_response(chat_id)
-      # A failed ordinary steer reports the existing reservation as queued.
+      # A failed new-message steer reports its existing reservation as queued.
       db.expire(chat)
       remaining = list(chat.pending_messages or [])
       try:

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -454,6 +454,12 @@ class SendMessage(BaseModel):
   # the backend to steer them into the live turn even when the chat's
   # normal send-while-running behavior is queueing.
   force_steer: bool = False
+  # A new composer message that should be durably reserved and steered in one
+  # request. Unlike force_steer, this does not name an existing queued row:
+  # the route first appends this message to pending_messages, then converts
+  # that exact cid into the live turn. If delivery cannot be accepted, the
+  # reserved row remains queued and the response exposes that fallback.
+  direct_steer: bool = False
   # Which already-queued rows a force-steer should pull into the live
   # turn, selected by their stable `cid` (the server still reconstructs
   # the durable rows from Chat.pending_messages so the browser cannot

--- a/backend/tests/test_chats_stream_steer.py
+++ b/backend/tests/test_chats_stream_steer.py
@@ -2,9 +2,12 @@
 
 Möbius normally appends every send-while-running to `pending_messages`
 and drains it at turn-end. For chats with `steer_enabled` set (DEFAULT
-OFF), a send that arrives while a turn is streaming is steered into the
-live provider handle. Codex uses true SDK injection; Claude interrupts
-and re-prompts on the same connected SDK client.
+OFF), an ordinary send that arrives while a turn is streaming is steered
+into the live provider handle. `direct_steer` explicitly requests the same
+durable reserve-and-steer operation for a new composer row regardless of
+that flag, exposing the reservation as queued only when delivery cannot be
+accepted. Codex uses true SDK injection; Claude interrupts and re-prompts
+on the same connected SDK client.
 
 These tests pin the provider-gated branch in
 `routes/chats_stream.send_message`:
@@ -17,6 +20,9 @@ These tests pin the provider-gated branch in
   3. Claude with the flag on uses its live-client fallback.
   4. steer returns False (no live turn / closed-turn race) → queue.
   5. steer raises → queue (a steer failure must never break a send).
+  6. direct_steer reserves a new cid before delivery; success converts it
+     without a queue round-trip, while failure returns the reserved row as
+     the ordinary queued fallback.
 
 The steering primitive itself (the SDK `TurnHandle.steer()` wrapper) is
 covered by `test_codex_sdk_runner.py`; here we only exercise the wiring.
@@ -183,6 +189,114 @@ def test_steers_into_live_codex_turn_when_flag_on(
       "content": "actually use blue",
     }
   ]
+
+
+def test_direct_steer_reserves_and_converts_new_codex_message_in_one_request(
+  client, auth, monkeypatch,
+):
+  """Cmd/Ctrl+Enter must not require a visible queue acknowledgement first."""
+  chat_id = "codexdirectsteer"
+  message_cid = "direct-steer-cid"
+  _make_codex_chat(chat_id, steer_enabled=False)
+  registry.register(_make_active_codex_turn(chat_id))
+  create_broadcast(chat_id)
+  steered_calls = []
+
+  async def _fake_steer(cid, message):
+    reserved = _read_chat(chat_id).pending_messages
+    assert [cid_of(row) for row in reserved] == [message_cid]
+    assert [row["content"] for row in reserved] == ["change course now"]
+    steered_calls.append((cid, message))
+    return True
+
+  monkeypatch.setattr(
+    "app.codex_sdk_runner.steer_into_active_turn", _fake_steer,
+  )
+
+  res = client.post(
+    f"/api/chats/{chat_id}/messages",
+    json={
+      "content": "change course now",
+      "cid": message_cid,
+      "direct_steer": True,
+    },
+    headers=auth,
+  )
+
+  assert res.status_code == 202, res.text
+  assert res.json()["status"] == "steered"
+  assert steered_calls == [(chat_id, "change course now")]
+  chat = _read_chat(chat_id)
+  assert chat.pending_messages in (None, [])
+  assert [cid_of(row) for row in chat.messages].count(message_cid) == 1
+  assert chat.messages[-1]["content"] == "change course now"
+
+
+def test_direct_steer_failure_reveals_single_reserved_queue_fallback(
+  client, auth, monkeypatch,
+):
+  """A closed-turn race preserves the message without a second POST."""
+  chat_id = "codexdirectfallback"
+  message_cid = "direct-fallback-cid"
+  _make_codex_chat(chat_id, steer_enabled=False)
+  registry.register(_make_active_codex_turn(chat_id))
+  create_broadcast(chat_id)
+
+  async def _closed_turn(_chat_id, _message):
+    return False
+
+  monkeypatch.setattr(
+    "app.codex_sdk_runner.steer_into_active_turn", _closed_turn,
+  )
+
+  res = client.post(
+    f"/api/chats/{chat_id}/messages",
+    json={
+      "content": "keep this even if steering races",
+      "cid": message_cid,
+      "direct_steer": True,
+    },
+    headers=auth,
+  )
+
+  assert res.status_code == 202, res.text
+  body = res.json()
+  assert body["status"] == "queued"
+  assert body["position"] == 1
+  assert cid_of(body["pending_message"]) == message_cid
+  chat = _read_chat(chat_id)
+  assert [cid_of(row) for row in chat.pending_messages] == [message_cid]
+  assert not [row for row in chat.messages if cid_of(row) == message_cid]
+
+
+def test_direct_claude_steer_keeps_reserve_until_deferred_cut(
+  client, auth,
+):
+  """The one-request contract also preserves Claude's real cut boundary."""
+  chat_id = "claudedirectsteer"
+  message_cid = "claude-direct-cid"
+  _make_claude_chat(chat_id, steer_enabled=False)
+  handle = _make_active_claude_client(chat_id)
+  registry.register(handle)
+  create_broadcast(chat_id)
+
+  res = client.post(
+    f"/api/chats/{chat_id}/messages",
+    json={
+      "content": "change Claude course now",
+      "cid": message_cid,
+      "direct_steer": True,
+    },
+    headers=auth,
+  )
+
+  assert res.status_code == 202, res.text
+  assert res.json()["status"] == "steered"
+  assert res.json()["cut_deferred"] is True
+  chat = _read_chat(chat_id)
+  assert [cid_of(row) for row in chat.pending_messages] == [message_cid]
+  assert [cid_of(row) for row in handle._steer_user_msgs] == [message_cid]
+  assert handle._steer_consume_cids == [message_cid]
 
 
 def test_pending_question_refuses_force_steer_without_holding_queue(

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -2001,14 +2001,10 @@ export default function ChatView({
   //     they just stopped) → original turn 1 user msg + partial get
   //     pushed above the viewport. Keep their current scroll mode
   //     instead — the new turn streams into view from where they were.
-  // Modified-Enter spans two requests (durable queue acknowledgement, then
-  // force-steer). Claim that whole operation synchronously so repeated
-  // keydowns cannot submit a second message before the steer busy state flips.
+  // Modified-Enter is a single durable direct-steer request. Claim it
+  // synchronously so repeated keydowns cannot submit a duplicate before the
+  // request settles.
   const submitSteerInFlightRef = useRef(false)
-  // doSend is intentionally stable and therefore must not capture the
-  // render-local steer implementation. Dereference the current function only
-  // after the queue POST settles, when a newer render may have replaced it.
-  const handleSteerOneRef = useRef(null)
 
   const doSend = useCallback(async (text, opts = {}) => {
     if (isProviderSwitchBlocking(chatId)) return
@@ -2062,7 +2058,8 @@ export default function ChatView({
       || serverRunningRef.current
       || pendingQueue.pendingMessagesRef.current.length > 0
     )
-    if (queuesBehindActiveTurn) {
+    const directSteer = opts.directSteer === true && queuesBehindActiveTurn
+    if (queuesBehindActiveTurn && !directSteer) {
       // Queueing changes the footer immediately (new chip, cleared composer)
       // but adds no transcript row yet. Freeze the exact visible message
       // before that layout change. The captured submit intent above is kept
@@ -2077,7 +2074,7 @@ export default function ChatView({
     if (shouldDismissComposerKeyboardOnSubmit({
       isTouchPrimary: _isTouchPrimary,
       queuesBehindActiveTurn,
-      steerAfterQueue: opts.steerAfterQueue === true,
+      directSteer,
     })) {
       inputRef.current?.blur()
     }
@@ -2111,10 +2108,10 @@ export default function ChatView({
         : `cid-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`),
     })
 
-    // QUEUE PATH: agent is streaming or queue isn't empty. Optimistic
-    // entry carrying the minted `cid` — the row identity is stable across
-    // the optimistic→server-ts display update. Backend writes to
-    // chat.pending_messages via POST /messages returning {status, ts, position}.
+    // ACTIVE-TURN PATH: ordinary sends add an optimistic queue row immediately.
+    // A direct steer does not: the backend durably reserves and steers this cid
+    // in the same request, so pending_messages is an invisible safety reserve.
+    // Only a `queued` response exposes that reserve as the fallback tray row.
     //
     // Read from refs (not React state) so doSend stays closure-safe.
     // Callers like handleStop invoke doSend AFTER calling
@@ -2125,7 +2122,7 @@ export default function ChatView({
     if (queuesBehindActiveTurn) {
       const queuedMsg = { role: 'user', content: text, ts: Date.now(), cid, queued: true }
       if (attachments.length > 0) queuedMsg.attachments = attachments
-      pendingQueue.add(queuedMsg, { inFlight: true })
+      if (!directSteer) pendingQueue.add(queuedMsg, { inFlight: true })
       // The shared send decision was captured AT SEND TIME, before blur or the
       // POST. If this queued send is promoted into the active turn (the backend
       // returns started, either as `queued+started` or the `started` race),
@@ -2156,7 +2153,9 @@ export default function ChatView({
         const result = await streamSend(
           text,
           attachments.length > 0 ? attachments : undefined,
-          { queueOnly: true, cid },
+          directSteer
+            ? { directSteer: true, cid }
+            : { queueOnly: true, cid },
         )
         clearFailedAttempt()
         releaseComposerFilesAfterAccepted()
@@ -2164,7 +2163,7 @@ export default function ChatView({
           // A stale local queue decision can race an already-durable retry.
           // Remove only this send's optimistic tray row; an unrelated live
           // turn may still be streaming and must remain attached.
-          pendingQueue.cancelByCid(queuedMsg.cid)
+          if (!directSteer) pendingQueue.cancelByCid(queuedMsg.cid)
           forgetQueuedPinIntent({ cid: queuedMsg.cid })
           inlineSteerPinIntentRef.current = null
           const durableRows = startedMessagesFromResponse(result)
@@ -2183,6 +2182,24 @@ export default function ChatView({
         }
         if (result?.status === 'queued') {
           const canonicalPending = result.pending_message || null
+          if (
+            directSteer
+            && !pendingQueue.pendingMessagesRef.current.some(
+              row => cidOf(row) === cid
+            )
+          ) {
+            // The one-request steer could not be accepted. Its server-reserved
+            // row is now a real queue fallback, so reveal it only at this point.
+            pendingQueue.add({
+              ...queuedMsg,
+              ...(canonicalPending || {}),
+              cid,
+              ts: canonicalPending?.ts ?? result.ts ?? queuedMsg.ts,
+              position: result.position,
+              queued: true,
+              serverTs: !!canonicalPending,
+            })
+          }
           // Update the DISPLAY ts + canonical content on the cid-matched row.
           // Identity (cid) never changes, so there is no swap — just a confirm.
           const ackTs = canonicalPending?.ts ?? result.ts
@@ -2228,18 +2245,18 @@ export default function ChatView({
               cidList: result.message?._consumed_cids,
             })
             bridgeHook.markBridged()
-          } else if (opts.steerAfterQueue) {
-            // Ctrl/Cmd+Enter uses the same durable queue -> force-steer path
-            // as the visible per-row arrow. The queue acknowledgement gives
-            // the new row a canonical ts before steering, so a failed or
-            // racing steer naturally leaves the message safely queued.
-            await handleSteerOneRef.current?.(cid)
           }
         }
         // Mid-turn steer: the backend delivered the send into the live provider
         // turn. Where the row LIVES right now is what `cut_deferred` states.
         if (result?.status === 'steered') {
-          if (result.cut_deferred) {
+          if (directSteer) {
+            // No tray row was ever created. Codex's cut event has already made
+            // the message inline; Claude's deferred cut will do so when its
+            // interrupt boundary lands. Until then the durable server reserve
+            // stays intentionally invisible rather than flashing as queued.
+            forgetQueuedPinIntent({ cid: queuedMsg.cid })
+          } else if (result.cut_deferred) {
             // Claude: the transcript split waits for the runner's interrupt
             // boundary, so the row is STILL queued server-side and its tray
             // entry stays — dropping it here left the owner's message with
@@ -2334,7 +2351,8 @@ export default function ChatView({
         // entry as an ordinary queued row, so clear the flag here or it
         // leaks forever and a later hydrate would wrongly preserve it.
         if (
-          result?.status !== 'queued'
+          !directSteer
+          && result?.status !== 'queued'
           && result?.status !== 'steered'
           && result?.status !== 'started'
         ) {
@@ -2342,7 +2360,7 @@ export default function ChatView({
         }
       } catch (err) {
         // Roll back optimistic + restore input.
-        pendingQueue.cancelByCid(queuedMsg.cid)
+        if (!directSteer) pendingQueue.cancelByCid(queuedMsg.cid)
         forgetQueuedPinIntent({ cid: queuedMsg.cid })
         inlineSteerPinIntentRef.current = null
         rememberFailedAttempt({
@@ -2726,7 +2744,7 @@ export default function ChatView({
     if (isProviderSwitchBlocking(chatId)) return
     if (submitSteerInFlightRef.current) return
     submitSteerInFlightRef.current = true
-    void doSend(input.trim(), { steerAfterQueue: true })
+    void doSend(input.trim(), { directSteer: true })
       .finally(() => { submitSteerInFlightRef.current = false })
   }
 
@@ -3260,8 +3278,6 @@ export default function ChatView({
       setSteerBusy(false)
     }
   }
-  handleSteerOneRef.current = handleSteerOne
-
   // Re-anchor the scroll mode when the tab returns to the foreground
   // (visibilitychange/pageshow/online) while a turn is active, so a
   // backgrounded-then-resumed streaming chat doesn't snap away from where the

--- a/frontend/src/components/ChatView/__tests__/composerKeyboardPolicy.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerKeyboardPolicy.test.js
@@ -20,7 +20,7 @@ test('mobile fresh send and explicit steer dismiss the composer keyboard', () =>
   assert.equal(shouldDismissComposerKeyboardOnSubmit({
     isTouchPrimary: true,
     queuesBehindActiveTurn: true,
-    steerAfterQueue: true,
+    directSteer: true,
   }), true)
 })
 
@@ -32,6 +32,6 @@ test('desktop submits retain composer focus', () => {
   assert.equal(shouldDismissComposerKeyboardOnSubmit({
     isTouchPrimary: false,
     queuesBehindActiveTurn: true,
-    steerAfterQueue: true,
+    directSteer: true,
   }), false)
 })

--- a/frontend/src/components/ChatView/__tests__/optimisticSteerQueue.test.js
+++ b/frontend/src/components/ChatView/__tests__/optimisticSteerQueue.test.js
@@ -75,32 +75,35 @@ test('a steer request disables sibling row actions until it settles', () => {
     'the queued tray should receive the in-flight state for its row buttons')
 })
 
-test('the modified-Enter submit waits for durability, then reuses per-row steer', () => {
-  const refDeclaration = source.indexOf('const handleSteerOneRef = useRef(null)')
-  const doSendDeclaration = source.indexOf('const doSend = useCallback')
-  assert.ok(
-    refDeclaration >= 0 && refDeclaration < doSendDeclaration,
-    'the stable doSend callback must reach the current steer implementation through a ref',
+test('the modified-Enter submit uses one direct request and reveals only queue fallback', () => {
+  assert.match(
+    source,
+    /const directSteer = opts\.directSteer === true && queuesBehindActiveTurn/,
+    'the send path must distinguish direct steering from ordinary queueing',
   )
   assert.match(
     source,
-    /pendingQueue\.confirmQueued\(cid,[\s\S]*?else if \(opts\.steerAfterQueue\) \{[\s\S]*?await handleSteerOneRef\.current\?\.\(cid\)/,
-    'the composed message must be server-confirmed before the existing row steer consumes it',
+    /if \(!directSteer\) pendingQueue\.add\(queuedMsg, \{ inFlight: true \}\)/,
+    'a direct steer must not create an optimistic queued-tray row',
+  )
+  assert.match(
+    source,
+    /directSteer\s*\? \{ directSteer: true, cid \}\s*: \{ queueOnly: true, cid \}/,
+    'Cmd/Ctrl+Enter must make one direct-steer POST instead of queue then force-steer',
+  )
+  assert.match(
+    source,
+    /if \(\s*directSteer\s*&& !pendingQueue\.pendingMessagesRef\.current\.some[\s\S]*?pendingQueue\.add\(/,
+    'the server-reserved row should appear only after a queued fallback response',
   )
   assert.doesNotMatch(
     source,
-    /else if \(opts\.steerAfterQueue\) \{[\s\S]*?await handleSteerOne\(cid\)/,
-    'doSend must not capture a render-local steer function across the queue request',
-  )
-  const steerOneDeclaration = source.indexOf('async function handleSteerOne(cid)')
-  const currentAssignment = source.indexOf('handleSteerOneRef.current = handleSteerOne')
-  assert.ok(
-    steerOneDeclaration >= 0 && currentAssignment > steerOneDeclaration,
-    'each render must publish the current per-row steer implementation',
+    /steerAfterQueue|handleSteerOneRef/,
+    'the former two-request queue-then-steer mechanism must be gone',
   )
   assert.match(
     source,
-    /function handleSubmitSteer\(e\) \{[\s\S]*?if \(submitSteerInFlightRef\.current\) return[\s\S]*?submitSteerInFlightRef\.current = true[\s\S]*?doSend\(input\.trim\(\), \{ steerAfterQueue: true \}\)[\s\S]*?\.finally\(\(\) => \{ submitSteerInFlightRef\.current = false \}\)/,
-    'the keyboard handler must synchronously guard the full queue-to-steer operation',
+    /function handleSubmitSteer\(e\) \{[\s\S]*?if \(submitSteerInFlightRef\.current\) return[\s\S]*?submitSteerInFlightRef\.current = true[\s\S]*?doSend\(input\.trim\(\), \{ directSteer: true \}\)[\s\S]*?\.finally\(\(\) => \{ submitSteerInFlightRef\.current = false \}\)/,
+    'the keyboard handler must synchronously guard the one direct request',
   )
 })

--- a/frontend/src/components/ChatView/__tests__/streamingRobustness.test.js
+++ b/frontend/src/components/ChatView/__tests__/streamingRobustness.test.js
@@ -55,11 +55,11 @@ test('R6: answering in-process keeps the active bridge through settlement', () =
     'an in-process answer must not retire the same-turn bridge before its POST result')
 })
 
-test('R6: a rejected answer POST does not tear down its existing stream', () => {
+test('R6: rejected injected POSTs do not tear down their existing stream', () => {
   assert.match(
     streamHookSource,
-    /if \(!forceSteer && !isAnswerSubmission\) \{\s*wantsReconnectRef\.current = false\s*setIsStreaming\(false\)/,
-    'an injected answer failure must leave the parked live turn attached',
+    /if \(!forceSteer && !directSteer && !isAnswerSubmission\) \{\s*wantsReconnectRef\.current = false\s*setIsStreaming\(false\)/,
+    'answer and steer failures must leave the live turn they target attached',
   )
 })
 

--- a/frontend/src/components/ChatView/composerKeyboardPolicy.js
+++ b/frontend/src/components/ChatView/composerKeyboardPolicy.js
@@ -3,16 +3,16 @@
  *
  * A normal send starts a turn, so dismissing the keyboard gives the reply the
  * viewport. A queue-only send is different: the owner is still composing
- * follow-ups, so keep the textarea focused. An explicit queue-and-steer submit
+ * follow-ups, so keep the textarea focused. An explicit direct-steer submit
  * carries the same dismiss intent as tapping either fast-forward control.
  */
 export function shouldDismissComposerKeyboardOnSubmit({
   isTouchPrimary = false,
   queuesBehindActiveTurn = false,
-  steerAfterQueue = false,
+  directSteer = false,
 } = {}) {
   return !!(
     isTouchPrimary
-    && (!queuesBehindActiveTurn || steerAfterQueue)
+    && (!queuesBehindActiveTurn || directSteer)
   )
 }

--- a/frontend/src/components/ChatView/useStreamConnection.js
+++ b/frontend/src/components/ChatView/useStreamConnection.js
@@ -138,10 +138,11 @@ const BROADCAST_REGISTRATION_WINDOW_MS = 1500
  *                         promotes the live stream into its own message,
  *                         re-bases streamItems for the continuation, and
  *                         renders the row inline as content growth. There is
- *                         no separate "accepted" event: on the deferred
- *                         (Claude) path the send's own 202 echoes the row as
- *                         the still-queued row it is, so the tray has ONE
- *                         reconciler until the cut arrives.
+ *                         no separate "accepted" event. On the deferred
+ *                         (Claude) path an existing queued-row conversion
+ *                         remains in the tray until the cut; a direct composer
+ *                         steer has no tray row and keeps its durable reserve
+ *                         hidden until either the cut or a queued fallback.
  *   catch_up_done         Replay burst finished; live events follow.
  *   error                 { message }. Surfaced inline.
  *   done                  Turn complete; SSE closes.
@@ -190,8 +191,9 @@ const BROADCAST_REGISTRATION_WINDOW_MS = 1500
  *   catchUpCommitSeq: number,
  *   sendMessage: (text: string, attachments?: Array<object>,
  *                 opts?: {hidden?: boolean, queueOnly?: boolean, cid?: string,
- *                         forceSteer?: boolean, consumePendingCids?: string[],
- *                         answers?: object}) => Promise<object>,
+ *                         forceSteer?: boolean, directSteer?: boolean,
+ *                         consumePendingCids?: string[], answers?: object})
+ *                 => Promise<object>,
  *   connectToStream: () => void,
  *   retry: () => void,
  *   disconnect: (opts?: {clearStreaming?: boolean}) => void,
@@ -1269,6 +1271,7 @@ export default function useStreamConnection(chatId, {
       hidden = false,
       queueOnly = false,
       forceSteer = false,
+      directSteer = false,
       cid = undefined,
       consumePendingCids = undefined,
       steeredMessages = undefined,
@@ -1283,7 +1286,8 @@ export default function useStreamConnection(chatId, {
     // answered. If the backend reports `started` instead, it recovered a
     // restarted question as a fresh hidden continuation and we reset below.
     const isAnswerSubmission = !!answers
-    // A force_steer injects into the LIVE turn — it is not a new turn.
+    // force_steer and direct_steer inject into the LIVE turn — neither starts
+    // a new turn on the expected path.
     // The fresh-send reset below (setStreamItems([]) + setIsStreaming +
     // wantsReconnect) is for STARTING a turn: wiping streamItems here would
     // discard the pre-steer assistant text the live SSE has already
@@ -1294,7 +1298,7 @@ export default function useStreamConnection(chatId, {
     // the existing SSE keeps streaming the post-steer continuation inline, so
     // there is no reconnect/replay to set up either. Skip the reset; the live
     // stream stays attached and the steered message renders inline.
-    if (!queueOnly && !isAnswerSubmission && !forceSteer) {
+    if (!queueOnly && !isAnswerSubmission && !forceSteer && !directSteer) {
       wantsReconnectRef.current = true
       justSentAtRef.current = Date.now()
       clearStoredStreamSnapshot(activeStreamChatIdRef.current)
@@ -1313,6 +1317,7 @@ export default function useStreamConnection(chatId, {
       if (hidden) body.hidden = true
       if (cid) body.cid = cid
       if (forceSteer) body.force_steer = true
+      if (directSteer) body.direct_steer = true
       if (consumePendingCids && consumePendingCids.length > 0) {
         body.consume_pending_cids = consumePendingCids
       }
@@ -1443,7 +1448,11 @@ export default function useStreamConnection(chatId, {
       }
       // Started: ensure streaming state is set even if the caller
       // passed queueOnly:true expecting it would be queued.
-      if (queueOnly || data.status === 'queued') {
+      if (
+        queueOnly
+        || data.status === 'queued'
+        || (directSteer && data.status === 'started')
+      ) {
         wantsReconnectRef.current = true
         justSentAtRef.current = Date.now()
         clearStoredStreamSnapshot(activeStreamChatIdRef.current)
@@ -1461,12 +1470,12 @@ export default function useStreamConnection(chatId, {
       // when a queueOnly send raced the server's `status: 'started'`
       // branch and then the POST itself failed mid-flight.
       //
-      // EXCEPT requests that inject into an existing turn. A force_steer and
-      // an AskUserQuestion answer do not start the live turn they target, so
-      // their POST failures must not tear down that turn's stream. The caller
-      // keeps the queued steer / retryable question intact while the existing
-      // connection remains authoritative.
-      if (!forceSteer && !isAnswerSubmission) {
+      // EXCEPT requests that inject into an existing turn. force_steer,
+      // direct_steer, and AskUserQuestion answers do not start the live turn
+      // they target, so their POST failures must not tear down that turn's
+      // stream. The caller keeps the queued/direct-steer fallback or retryable
+      // question intact while the existing connection remains authoritative.
+      if (!forceSteer && !directSteer && !isAnswerSubmission) {
         wantsReconnectRef.current = false
         setIsStreaming(false)
       }

--- a/tests/steer-queued.spec.mjs
+++ b/tests/steer-queued.spec.mjs
@@ -195,17 +195,32 @@ test.describe('Steer queued messages (fast-forward into the live turn)', () => {
     expect(await page.locator('.queued__row').count()).toBe(0)
   })
 
-  test('Ctrl+Enter queues durably, then automatically steers only the composed message', async ({ page }) => {
+  test('Ctrl+Enter sends one direct-steer request without rendering a queue row', async ({ page }) => {
     const STEER_TEXT = 'change course immediately'
     const messagePosts = []
-    let releaseQueueAck
-    const queueAckGate = new Promise(resolve => { releaseQueueAck = resolve })
+    let releaseDirectSteer
+    const directSteerGate = new Promise(resolve => { releaseDirectSteer = resolve })
 
     await page.route(/\/api\/chats\/[0-9a-f-]+\/messages$/, async (route) => {
       let body = {}
       try { body = JSON.parse(route.request().postData() || '{}') } catch { /* empty */ }
       messagePosts.push(body)
 
+      if (body.direct_steer) {
+        // Hold the one request open: the draft is already cleared, but it must
+        // never appear in the queued tray while the atomic reserve+steer is
+        // settling on the server.
+        await directSteerGate
+        return route.fulfill({
+          status: 202,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            status: 'steered',
+            chat_id: 'mock',
+            pending_messages: [],
+          }),
+        })
+      }
       if (body.force_steer) {
         return route.fulfill({
           status: 202,
@@ -229,13 +244,20 @@ test.describe('Steer queued messages (fast-forward into the live turn)', () => {
           }),
         })
       }
-      // Hold the durable queue acknowledgement open so a repeated shortcut
-      // exercises the synchronous submit guard, before steerBusy can flip.
-      await queueAckGate
       return route.fulfill({
         status: 202,
         contentType: 'application/json',
-        body: JSON.stringify({ status: 'queued', ts: 778001, position: 1 }),
+        body: JSON.stringify({
+          status: 'queued',
+          ts: 778001,
+          position: 1,
+          pending_message: {
+            role: 'user',
+            content: body.content,
+            ts: 778001,
+            cid: body.cid,
+          },
+        }),
       })
     })
 
@@ -257,27 +279,26 @@ test.describe('Steer queued messages (fast-forward into the live turn)', () => {
     await input.fill(STEER_TEXT)
     await page.keyboard.press('Control+Enter')
     await expect.poll(() => messagePosts.filter(body => (
-      !body.force_steer && body.content === STEER_TEXT
+      body.direct_steer && body.content === STEER_TEXT
     )).length).toBe(1)
+    await expect(page.locator('.queued__row')).toHaveCount(0)
+
     await page.keyboard.press('Control+Enter')
     await page.waitForTimeout(100)
     expect(messagePosts.filter(body => (
-      !body.force_steer && body.content === STEER_TEXT
+      body.direct_steer && body.content === STEER_TEXT
     ))).toHaveLength(1)
-    releaseQueueAck()
+    releaseDirectSteer()
 
-    await expect.poll(
-      () => messagePosts.filter(body => body.force_steer).length,
-      { timeout: 5000 },
-    ).toBe(1)
-
-    const queuePost = messagePosts.find(body => (
-      !body.force_steer && body.content === STEER_TEXT
+    const directPost = messagePosts.find(body => (
+      body.direct_steer && body.content === STEER_TEXT
     ))
-    const steerPost = messagePosts.find(body => body.force_steer)
-    expect(typeof queuePost.cid).toBe('string')
-    expect(steerPost.content).toBe(STEER_TEXT)
-    expect(steerPost.consume_pending_cids).toEqual([queuePost.cid])
+    expect(typeof directPost.cid).toBe('string')
+    expect(directPost.force_steer).toBeUndefined()
+    expect(directPost.consume_pending_cids).toBeUndefined()
+    expect(messagePosts.filter(body => (
+      body.content === STEER_TEXT
+    ))).toHaveLength(1)
     await expect(page.locator('.queued__row')).toHaveCount(0, { timeout: 5000 })
   })
 


### PR DESCRIPTION
## Summary

- replace the two-request queue-then-force-steer shortcut from #118 with one direct-steer request
- reserve the composed message durably before provider delivery without rendering that reserve in the queue tray
- reveal exactly one ordinary queued fallback if the live turn cannot accept the steer
- preserve Codex and Claude transcript-cut behavior as well as the separate chat-wide auto-steer preference

## Prior work

#118 introduced the durable queue-then-steer shortcut and landed through #147. This is a distinct correction: the earlier design protected the message but necessarily exposed the queued intermediate state; this change uses the backend's newer reserve-before-delivery path to keep the same durability without the tray flash.

## Validation

- backend steering suite: 35 passed
- frontend library suite: 1,988 passed
- frontend hook suite: 63 passed
- production frontend/PWA build passed
- `git diff --check` passed