### PR TITLE
Recover every authenticated turn after planned restarts

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -740,26 +740,33 @@ completion or a particular scroll mode.
 
 Automatic continuation reuses one durable run transition with separate
 chat-local policies and cause validation. Provider-limit exits mark their exact
-`ChatRun` as `parked` until the parsed reset time. A planned restart
-creates a fresh nonce, stops and finalizes each exact live run, and parks it
-due-now with that nonce. The platform process then publishes an intent and
-restart request; it does not terminate itself on the normal path.
+`ChatRun` as `parked` until the parsed reset time. A planned restart creates a
+fresh nonce and, **before provider interruption**, stamps it onto every exact
+live run in one writer transaction. Provider stops then run concurrently; clean
+stops finalize and become due-now parks immediately, while a slow stop or failed
+terminal transcript write keeps its exact nonce-stamped `running` row for boot
+recovery. The platform process then publishes an intent and restart request; it
+does not terminate itself on the normal path.
 
 The frozen root-owned entrypoint poller validates and consumes the request,
 records its one-shot nonce in `/data/.restart-ledger`, and only then terminates
 pid 1. At the very start of the next entrypoint invocation, the ledger binds
 that accepted nonce to the new `MOBIUS_BOOT_ID`. The app only continues a
 restart park when the root-owned boot acknowledgement matches the nonce on the
-latest exact DB run and the restart policy is on. The supervisor
-attests the boot transition; the database owns run identity. An intent merely
-written before a crash/OOM, an acknowledgement skipped by a failed handshake,
-or an acknowledgement left across another boot authorizes nothing. Transcript
-text is presentation, never restart-cause evidence.
+latest exact DB run and the restart policy is on. At startup, the same
+authorization converts matching stranded `running` rows into due restart parks
+after finalizing their persisted partial transcript; this happens before the
+writer starts and before the initial continuation sweep. The supervisor attests
+the boot transition; the database owns run identity. An intent merely written
+before a crash/OOM, an acknowledgement skipped by a failed handshake, or an
+acknowledgement left across another boot authorizes nothing. Transcript text is
+presentation, never restart-cause evidence.
 
 | Event | Durable result | Boot/sweep result |
 |-------|----------------|-------------------|
 | Provider usage/rate limit | exact run `parked` until reset | notify; continue if the usage policy is on |
 | Accepted planned restart, exact park + boot nonce match | exact run `parked`, reason `restart`, nonce, due now | continue immediately if the restart policy is on |
+| Accepted planned restart, stop/finalize did not settle | exact latest run remains `running` with the authenticated nonce | finalize partials, convert to due restart park, then continue in the same pre-yield pass |
 | Crash/OOM before supervisor acknowledgement | unacknowledged park or generic `running` evidence | resolve/reconcile to manual resumable interruption |
 | Repeated/unrelated boot before claim | acknowledgement is retired by boot-id mismatch | manual resumable interruption |
 | Policy off, unanswered question, app-owned run, or app-queued work | due park resolves without an automatic send | notify/manual owner action |
@@ -767,20 +774,24 @@ text is presentation, never restart-cause evidence.
 | Restart task creation fails after promotion | exact promoted rows roll back; restart park becomes `interrupted` | manual recovery; one-shot cause is not retried |
 
 Eligibility is rechecked under the per-chat transition lock immediately before
-promotion, and the global idle gate permits only one automatic turn at a time.
-The provider still receives a synthetic user `continue`, but the durable row is
-tagged `kind="auto_continuation"` with reason `restart` or `usage_limit`; the UI,
-copy behavior, title selection, time context, compaction, provider-switch
-handoff, chat-note summarization, and redacted chat logs treat it as a product
-marker rather than owner speech.
+promotion. Provider-limit retries are staggered one at a time; an authenticated
+planned restart restores the exact set that was already concurrent, so its
+eligible batch may start together. The provider still receives a synthetic user
+`continue`, but the durable row is tagged `kind="auto_continuation"` with reason
+`restart` or `usage_limit`; the UI, copy behavior, title selection, time
+context, compaction, provider-switch handoff, chat-note summarization, and
+redacted chat logs treat it as a product marker rather than owner speech.
 
 The sweep is cheap: one indexed due-row query immediately at boot, on
-`chat_run_finished`, and on a 60-second fallback, plus one bounded local ledger
-read when due rows exist. It does not create per-chat workers or poll at a short
-interval. Paid provider-limit continuation (`auto_resume_on_limit`) initially
-defaults off; planned-restart continuation (`auto_resume_on_restart`) initially
-defaults on. Each chat stores both choices independently, and changing either
-choice seeds future chats without rewriting existing conversations.
+`chat_run_finished`, and on a 60-second fallback. Startup captures the boot
+authorization once and threads that exact value through reconciliation and the
+pre-yield sweep, so a second ledger read cannot make the two phases disagree;
+later sweeps perform one bounded local ledger read only when due restart rows
+exist. It does not create per-chat workers or poll at a short interval. Paid
+provider-limit continuation (`auto_resume_on_limit`) initially defaults off;
+planned-restart continuation (`auto_resume_on_restart`) initially defaults on.
+Each chat stores both choices independently, and changing either choice seeds
+future chats without rewriting existing conversations.
 
 ### Tool output rendering
 

--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -15,6 +15,7 @@ import os
 import re
 import time
 import uuid
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
@@ -49,6 +50,7 @@ from app.chat_writer import (
   Finalize,
   ParkRun,
   PrepareAutoResume,
+  PrepareRestartIntents,
   RecordAgentLifecycle,
   PersistError,
   PersistTranscript,
@@ -980,6 +982,12 @@ _restart_draining_chats: set[str] = set()
 # utility arms its SIGKILL backstop at DRAIN_TIMEOUT + grace; the existing short
 # hard-kill stays as the crash floor once SIGTERM is sent.
 DRAIN_TIMEOUT = 25.0
+# Provider interrupts run together, not serially. Five live turns exposed that
+# the old two-second-per-handle loop was both too short for ordinary Codex
+# teardown and spent the drain budget on early chats while later chats waited.
+# Ten seconds leaves the outer 25-second drain ample time to finalize/park the
+# stopped set while giving every provider the same useful shutdown window.
+RESTART_HANDLE_STOP_TIMEOUT_SECS = 10.0
 
 # The terminal note a drained turn persists (design §2.2). Boot reconcile keys
 # on this exact text to mark the block resumable rather than stacking a second
@@ -1437,8 +1445,20 @@ async def _clear_run_status_strict(
   await _await_ack(ack)
 
 
-def reconcile_interrupted_chats(db: Session) -> list[str]:
-  """Resolve chats stranded "running" by a process that died mid-turn.
+@dataclass(frozen=True)
+class StartupReconcileResult:
+  """Distinct boot outcomes: manual crash recovery vs authenticated replay."""
+
+  manual: list[str]
+  restart_parks: list[str]
+
+
+def reconcile_startup_chats(
+  db: Session,
+  *,
+  restart_authorization: str | None = None,
+) -> StartupReconcileResult:
+  """Resolve chats stranded "running" by the previous process.
 
   Called once from the FastAPI lifespan startup, BEFORE the server
   accepts requests. The runner registry is in-memory, so at boot it is
@@ -1459,13 +1479,13 @@ def reconcile_interrupted_chats(db: Session) -> list[str]:
       holds only the SUBSEQUENT sends the user queued while that turn ran,
       so preserving them does NOT re-run the interrupted turn — it just
       keeps the unsent queue. We deliberately do NOT auto-drain it here:
-      clearing only the run marker (below) leaves the chat in the SAME
-      markerless state (``run_status=None`` + non-empty queue) the bottom
-      of this function already documents, which self-heals on the NEXT user
-      POST via the stale-pending drain in ``chats_stream.send_message``
-      (it claims ``mark_starting`` and promotes the head). Auto-promoting
-      at boot is what the crash-loop concern below forbids; a drain gated
-      on an explicit user interaction does not re-spawn turns during boot;
+      generic crashes clear only the run marker (below), leaving the chat in
+      the SAME markerless state (``run_status=None`` + non-empty queue) the
+      bottom of this function documents; that self-heals on the NEXT user POST
+      via the stale-pending drain in ``chats_stream.send_message``. The sole
+      boot auto-promotion exception is an exact run whose restart nonce matches
+      the root-owned authorization for this boot — that external proof removes
+      the crash-loop ambiguity;
     - clear the durable run marker.
 
   No queue lock is taken: this runs single-threaded at startup before
@@ -1515,12 +1535,19 @@ def reconcile_interrupted_chats(db: Session) -> list[str]:
   a still-alive chat is skipped above). So the lost-update race the actor
   exists to close cannot occur here.
 
-  Returns the ids of the chats it reconciled (empty list if none) so
-  the caller can log/observe the recovery rather than have it happen
-  silently.
+  An exact running ChatRun stamped with the root-authorized restart nonce is
+  different from a generic crash. After the same transcript finalization, an
+  opted-in owner turn with no unanswered question or app-attributed work is
+  converted to a due ``restart`` park. The initial continuation sweep then
+  resumes it before lifespan yields. Every other stranded turn remains the
+  conservative manual-resume outcome.
+
+  Returns both outcomes separately so startup can notify only genuinely manual
+  recoveries and can report authenticated fallbacks without conflating them.
   """
   log = _get_logger()
-  reconciled: list[str] = []
+  manual: list[str] = []
+  restart_parks: list[str] = []
   try:
     stale = (
       db.query(models.Chat)
@@ -1529,8 +1556,8 @@ def reconcile_interrupted_chats(db: Session) -> list[str]:
       .all()
     )
   except Exception:
-    log.exception("reconcile_interrupted_chats: query failed")
-    return reconciled
+    log.exception("reconcile_startup_chats: query failed")
+    return StartupReconcileResult(manual=manual, restart_parks=restart_parks)
 
   for chat in stale:
     # Belt-and-suspenders: if a live registry entry somehow exists for
@@ -1542,6 +1569,42 @@ def reconcile_interrupted_chats(db: Session) -> list[str]:
       continue
     try:
       queued = len(chat.pending_messages or [])
+      running_runs = (
+        db.query(models.ChatRun)
+        .filter(models.ChatRun.chat_id == chat.id)
+        .filter(models.ChatRun.status == "running")
+        .all()
+      )
+      latest = (
+        db.query(models.ChatRun.id)
+        .filter(models.ChatRun.chat_id == chat.id)
+        .order_by(
+          models.ChatRun.started_at.desc(), models.ChatRun.id.desc(),
+        )
+        .first()
+      )
+      latest_id = latest[0] if latest is not None else None
+      restart_run = next((
+        run for run in running_runs
+        if (
+          restart_authorization
+          and run.id == latest_id
+          and run.restart_nonce == restart_authorization
+        )
+      ), None)
+      pending = list(chat.pending_messages or [])
+      app_work_queued = any(
+        isinstance(msg, dict)
+        and msg.get("_initiated_by_app_id") is not None
+        for msg in pending
+      )
+      restart_eligible = bool(
+        restart_run is not None
+        and restart_run.initiated_by_app_id is None
+        and chat.auto_resume_on_restart
+        and not app_work_queued
+        and not _has_unanswered_question(chat)
+      )
       from app.chat_transcript import materialized_messages
       msgs = materialized_messages(chat)
       note = "This turn was paused when Möbius restarted."
@@ -1552,7 +1615,7 @@ def reconcile_interrupted_chats(db: Session) -> list[str]:
         plural = "s" if queued != 1 else ""
         note += (
           f" {queued} queued message{plural} {'are' if queued != 1 else 'is'}"
-          " still queued and will be sent with your next message."
+          " still queued and will be included when this turn resumes."
         )
       # `message` (not `content`) is the error-block field the
       # transcript renderer reads — see MsgContent.jsx's error branch
@@ -1683,28 +1746,41 @@ def reconcile_interrupted_chats(db: Session) -> list[str]:
       # so the run record matches reality. (Flipping the destructive read onto
       # chat_runs + retiring run_status is the Step-3b follow-up, once the
       # record is proven in prod.)
-      for run in (
-        db.query(models.ChatRun)
-        .filter(models.ChatRun.chat_id == chat.id)
-        .filter(models.ChatRun.status == "running")
-        .all()
-      ):
-        run.status = "interrupted"
-        run.ended_at = datetime.now(UTC)
-        run.restart_nonce = None
+      recovered_at = datetime.now(UTC)
+      for run in running_runs:
+        if restart_eligible and restart_run is not None and run.id == restart_run.id:
+          run.status = "parked"
+          run.parked_until = recovered_at.replace(tzinfo=None)
+          run.park_reason = "restart"
+          run.ended_at = recovered_at
+          # Keep restart_nonce: the reset sweep rechecks it against the same
+          # root-owned boot authorization immediately before continuation.
+        else:
+          run.status = "interrupted"
+          run.ended_at = recovered_at
+          run.restart_nonce = None
       db.commit()
-      reconciled.append(chat.id)
+      if restart_eligible:
+        restart_parks.append(chat.id)
+      else:
+        manual.append(chat.id)
     except Exception:
       db.rollback()
       log.exception(
-        "reconcile_interrupted_chats: failed to reconcile chat_id=%s",
+        "reconcile_startup_chats: failed to reconcile chat_id=%s",
         chat.id,
       )
 
-  if reconciled:
+  if manual:
     log.info(
-      "reconciled %d interrupted chat(s) on startup: %s",
-      len(reconciled), ", ".join(reconciled),
+      "reconciled %d interrupted chat(s) for manual recovery: %s",
+      len(manual), ", ".join(manual),
+    )
+  if restart_parks:
+    log.info(
+      "recovered %d authenticated restart fallback(s) for immediate "
+      "continuation: %s",
+      len(restart_parks), ", ".join(restart_parks),
     )
 
   # Orphaned run records (077 Step 3): a chat_runs row left "running" whose
@@ -1752,7 +1828,7 @@ def reconcile_interrupted_chats(db: Session) -> list[str]:
       log.info("closed %d orphaned running run record(s) on startup", closed)
   except Exception:
     db.rollback()
-    log.exception("reconcile_interrupted_chats: orphan run sweep failed")
+    log.exception("reconcile_startup_chats: orphan run sweep failed")
 
   # Boot never starts markerless work; the age-gated runtime sweep claims it.
   try:
@@ -1765,14 +1841,22 @@ def reconcile_interrupted_chats(db: Session) -> list[str]:
     for chat_id, pending_messages in markerless:
       if pending_messages:
         log.warning(
-          "reconcile_interrupted_chats: markerless pending queue chat_id=%s "
+          "reconcile_startup_chats: markerless pending queue chat_id=%s "
           "count=%d; left intact for the age-gated pending sweep",
           chat_id, len(pending_messages),
         )
   except Exception:
-    log.exception("reconcile_interrupted_chats: markerless-queue scan failed")
+    log.exception("reconcile_startup_chats: markerless-queue scan failed")
 
-  return reconciled
+  return StartupReconcileResult(
+    manual=manual,
+    restart_parks=restart_parks,
+  )
+
+
+def reconcile_interrupted_chats(db: Session) -> list[str]:
+  """Backward-compatible generic-crash recovery used outside boot wiring."""
+  return reconcile_startup_chats(db).manual
 
 
 def notify_after_reconcile(db: Session, reconciled: list[str]) -> str | None:
@@ -2191,6 +2275,7 @@ async def drain_all_for_restart(
   timeout: float = DRAIN_TIMEOUT,
   *,
   restart_nonce: str = "",
+  prepared_runs: list[dict[str, str]] | None = None,
 ) -> list[dict[str, str]]:
   """Interrupt every live turn for a graceful restart, preserving queues.
 
@@ -2201,8 +2286,15 @@ async def drain_all_for_restart(
   remains available for the owner's next action on the manual fallback path.
 
   Sets the `draining` gate first (idempotent) so a send arriving mid-drain
-  queues rather than starting, and both liveness sweeps stand down. Then, for
-  each live turn:
+  queues rather than starting, and both liveness sweeps stand down. Before any
+  provider is interrupted, ``prepare_restart_intents`` stamps the accepted
+  restart nonce onto every exact live ChatRun in one writer transaction. That
+  stamp is deliberately independent of transcript serialization and provider
+  teardown: after the root-owned supervisor authenticates the nonce for the
+  next boot, startup can safely auto-resume a turn even when its stop timed out
+  or its terminal snapshot failed.
+
+  Then, for each live turn:
 
     - publishes a one-line "paused for a platform update" note through the
       turn's sink, so the note + the accumulated partial blocks are persisted
@@ -2221,17 +2313,26 @@ async def drain_all_for_restart(
       text. If that transition cannot commit, the generic run marker remains for
       manual crash reconciliation.
 
-  Best-effort and bounded: a handle that won't interrupt in time keeps today's
-  contract — the restart utility's SIGKILL backstop kills the worker and boot
-  reconcile finalizes the marker for manual Resume. Handle
-  stops run serially at up to 2s each, so with many concurrent live turns the
-  tail may not drain before the backstop — accepted for the single-owner
-  reality (a handful of turns at most); parallelize the stops before this
-  assumption breaks. Returns only the exact chat/run pairs that finalized and
-  parked successfully; the restart supervisor binds precisely that set.
+  Best-effort and bounded: every provider stop starts concurrently and receives
+  the same shutdown window. A slow stop or failed Finalize leaves its exact
+  running row + restart nonce intact; authenticated startup finalizes that
+  transcript and converts it to the same due restart park as the clean path.
+  Returns every exact run covered by the restart intent, not merely the subset
+  that finalized before process exit.
   """
   begin_drain()
   log = _get_logger()
+  restart_runs = list(prepared_runs or [])
+  if prepared_runs is None:
+    try:
+      restart_runs = await prepare_restart_intents(restart_nonce)
+    except Exception:
+      # The restart still proceeds, but without an exact durable binding boot
+      # recovery must fail closed to the existing manual-resume path.
+      log.warning(
+        "drain-for-restart intent preparation failed; fallbacks stay manual",
+        exc_info=True,
+      )
   parked_runs: list[dict[str, str]] = []
   # `resumable` rides the event LIVE (events.process_event carries the
   # whitelisted extras onto the persisted block), so a drained turn's manual
@@ -2241,6 +2342,7 @@ async def drain_all_for_restart(
   # lets the card render in the calm "Paused" family instead of the danger-red
   # error styling reserved for genuine failures.
   note = _pause_note(PAUSED_FOR_RESTART_MESSAGE, kind="restart")
+  candidates: list[tuple[str, list, object | None]] = []
   for chat_id in sorted(registry.all_alive_chat_ids()):
     handles = registry.get_handles(chat_id)
     if not handles:
@@ -2248,15 +2350,6 @@ async def drain_all_for_restart(
       # interrupt. Its send is durable and reconciles on the next boot.
       continue
     sink = get_active_sink(chat_id)
-    if sink is not None:
-      sink.publish(dict(note))
-    else:
-      bc = get_broadcast(chat_id)
-      if bc is not None:
-        # Transport-only fallback (handle live but no sink). The note isn't
-        # persisted here; boot reconcile still adds the resumable interrupted
-        # note for this marker.
-        bc.publish(dict(note))
     stopped_gen = current_run_generation(chat_id)
     if not isinstance(stopped_gen, int):
       # Soft-deleted chat (+inf generation) — leave it to delete's own cleanup.
@@ -2267,10 +2360,25 @@ async def drain_all_for_restart(
     bump_run_generation(chat_id)
     _clear_after_terminal_generation[chat_id] = stopped_gen
     _clear_after_terminal_status[chat_id] = "interrupted"
+
+    if sink is not None:
+      sink.publish(dict(note))
+    else:
+      bc = get_broadcast(chat_id)
+      if bc is not None:
+        # Transport-only fallback (handle live but no sink). The note isn't
+        # persisted here; boot reconcile still adds the resumable interrupted
+        # note for this marker.
+        bc.publish(dict(note))
+    candidates.append((chat_id, handles, sink))
+
+  async def _stop_candidate(chat_id: str, handles: list) -> bool:
     all_interrupted = True
     for handle in handles:
       try:
-        stopped = await handle.stop(timeout=2.0)
+        stopped = await handle.stop(
+          timeout=min(RESTART_HANDLE_STOP_TIMEOUT_SECS, timeout)
+        )
       except asyncio.CancelledError:
         raise
       except Exception:
@@ -2280,20 +2388,36 @@ async def drain_all_for_restart(
         )
         stopped = False
       if not stopped:
+        log.warning(
+          "drain-for-restart stop timed out; authenticated boot recovery "
+          "will continue chat_id=%s kind=%s",
+          chat_id, getattr(handle, "kind", "?"),
+        )
         all_interrupted = False
+    return all_interrupted
+
+  stop_results = await asyncio.gather(*(
+    _stop_candidate(chat_id, handles)
+    for chat_id, handles, _sink in candidates
+  ))
+
+  for (chat_id, _handles, sink), all_interrupted in zip(
+    candidates, stop_results, strict=True,
+  ):
     if all_interrupted:
       run_token = sink.run_token if sink is not None else None
       # Own the terminal snapshot fence here instead of assuming the runner's
       # teardown won the scheduling race. This force-completes running tool
       # blocks/thinking sidecars before ParkRun clears the generic boot-reconcile
-      # marker. A failed Finalize leaves that marker intact for manual recovery.
+      # marker. A failed Finalize leaves that marker + its already-committed
+      # restart nonce intact for authenticated startup recovery.
       if sink is not None:
         try:
           await sink.finalize()
         except Exception:
           log.warning(
-            "drain-for-restart terminal snapshot failed; leaving manual "
-            "recovery chat_id=%s run_token=%s",
+            "drain-for-restart terminal snapshot failed; authenticated boot "
+            "recovery will continue chat_id=%s run_token=%s",
             chat_id, run_token, exc_info=True,
           )
           continue
@@ -2313,8 +2437,8 @@ async def drain_all_for_restart(
             })
           else:
             log.warning(
-              "drain-for-restart could not park exact run; leaving manual "
-              "recovery chat_id=%s run_token=%s",
+              "drain-for-restart could not park exact run; authenticated boot "
+              "recovery will continue chat_id=%s run_token=%s",
               chat_id,
               run_token,
             )
@@ -2322,7 +2446,8 @@ async def drain_all_for_restart(
           # Restart must still proceed. ParkRun is transactional; on failure
           # the generic running marker remains for safe manual reconciliation.
           log.warning(
-            "drain-for-restart park failed; leaving manual recovery "
+            "drain-for-restart park failed; authenticated boot recovery "
+            "will continue "
             "chat_id=%s run_token=%s",
             chat_id,
             run_token,
@@ -2347,7 +2472,56 @@ async def drain_all_for_restart(
       len(parked_runs),
       ", ".join(item["chat_id"] for item in parked_runs),
     )
-  return parked_runs
+  if restart_runs:
+    parked_ids = {item["chat_id"] for item in parked_runs}
+    fallback_ids = [
+      item["chat_id"] for item in restart_runs
+      if item["chat_id"] not in parked_ids
+    ]
+    log.info(
+      "drain-for-restart authenticated %d exact turn(s); parked=%d "
+      "boot-recovery=%d%s",
+      len(restart_runs),
+      len(parked_ids),
+      len(fallback_ids),
+      f" ({', '.join(fallback_ids)})" if fallback_ids else "",
+    )
+  return restart_runs
+
+
+async def prepare_restart_intents(
+  restart_nonce: str,
+) -> list[dict[str, str]]:
+  """Durably bind a planned restart to every exact live run before stopping.
+
+  The writer actor revalidates the registry snapshot and commits all accepted
+  ChatRun nonce stamps atomically. This operation intentionally does not touch
+  Chat.messages or Chat.pending_messages, so a transcript value that cannot be
+  serialized cannot suppress restart authorization.
+  """
+  begin_drain()
+  if not restart_nonce:
+    return []
+  candidates: list[dict[str, str]] = []
+  for chat_id in sorted(registry.all_alive_chat_ids()):
+    if not registry.get_handles(chat_id):
+      continue
+    sink = get_active_sink(chat_id)
+    run_token = sink.run_token if sink is not None else None
+    if run_token:
+      candidates.append({
+        "chat_id": chat_id,
+        "run_token": run_token,
+      })
+  if not candidates:
+    return []
+  prepared = await _await_ack(get_writer().submit(
+    PrepareRestartIntents(
+      restart_nonce=restart_nonce,
+      runs=candidates,
+    )
+  ))
+  return list(prepared or [])
 
 
 # One-shot notify copy for a limit park whose reset time has arrived
@@ -2360,6 +2534,7 @@ CONTINUATION_SWEEP_BATCH_SIZE = 100
 # also must not launch a whole parked batch in one burst.
 LIMIT_AUTO_RESUME_STAGGER_SECS = 30.0
 _next_limit_auto_resume_at = 0.0
+_RESTART_AUTHORIZATION_UNSET = object()
 
 
 def _limit_auto_resume_now() -> float:
@@ -2421,6 +2596,10 @@ def _has_unanswered_question(chat: models.Chat | None) -> bool:
 
 async def _auto_resume_chat(
   chat_id: str, park_token: str | None = None,
+  *,
+  restart_authorization: str | None | object = (
+    _RESTART_AUTHORIZATION_UNSET
+  ),
 ) -> bool:
   """Start one continuation for an eligible due park.
 
@@ -2496,8 +2675,11 @@ async def _auto_resume_chat(
             latest_id = latest[0] if latest is not None else None
             restart_authorized = True
             if park is not None and park.park_reason == "restart":
-              from app.restart_ledger import authorized_restart_nonce
-              accepted_nonce = authorized_restart_nonce()
+              if restart_authorization is _RESTART_AUTHORIZATION_UNSET:
+                from app.restart_ledger import authorized_restart_nonce
+                accepted_nonce = authorized_restart_nonce()
+              else:
+                accepted_nonce = restart_authorization
               restart_authorized = (
                 bool(accepted_nonce)
                 and bool(park.restart_nonce)
@@ -2608,7 +2790,13 @@ async def _auto_resume_chat(
     return False
 
 
-async def sweep_reset_parks(db: Session) -> list[str]:
+async def sweep_reset_parks(
+  db: Session,
+  *,
+  restart_authorization: str | None | object = (
+    _RESTART_AUTHORIZATION_UNSET
+  ),
+) -> list[str]:
   """Notify and optionally continue due durable recovery rows.
 
   The third lifespan sweep (same 60s loop shape as the wedged-marker and
@@ -2670,17 +2858,19 @@ async def sweep_reset_parks(db: Session) -> list[str]:
   except Exception:
     log.exception("sweep_reset_parks: chat batch query failed")
     return resolved
-  restart_authorization = None
+  accepted_restart_nonce = restart_authorization
   if any(run.park_reason == "restart" for run in due):
-    try:
-      from app.restart_ledger import authorized_restart_nonce
-      restart_authorization = authorized_restart_nonce()
-    except Exception:
-      log.warning(
-        "sweep_reset_parks: restart ledger read failed; restart parks will "
-        "fall back to manual recovery",
-        exc_info=True,
-      )
+    if restart_authorization is _RESTART_AUTHORIZATION_UNSET:
+      try:
+        from app.restart_ledger import authorized_restart_nonce
+        accepted_restart_nonce = authorized_restart_nonce()
+      except Exception:
+        accepted_restart_nonce = None
+        log.warning(
+          "sweep_reset_parks: restart ledger read failed; restart parks will "
+          "fall back to manual recovery",
+          exc_info=True,
+        )
   owner_loaded = False
   owner = None
 
@@ -2712,37 +2902,35 @@ async def sweep_reset_parks(db: Session) -> list[str]:
         "continuation notify failed chat_id=%s", chat_id, exc_info=True,
       )
 
-  def wants_auto_resume(chat, run) -> bool:
+  def auto_resume_rejection(chat, run) -> str | None:
     pending = list(chat.pending_messages or []) if chat is not None else []
     app_work_queued = any(
       isinstance(msg, dict) and msg.get("_initiated_by_app_id") is not None
       for msg in pending
     )
+    if chat is None or chat.deleted_at is not None:
+      return "chat unavailable"
+    if run.initiated_by_app_id is not None or app_work_queued:
+      return "app-attributed work"
+    if _has_unanswered_question(chat):
+      return "waiting for an answer"
     restart_park = run.park_reason == "restart"
     policy_enabled = bool(
-      chat is not None
-      and (
-        chat.auto_resume_on_restart
-        if restart_park else chat.auto_resume_on_limit
-      )
+      chat.auto_resume_on_restart
+      if restart_park else chat.auto_resume_on_limit
     )
-    restart_authorized = (
-      not restart_park
-      or (
-        bool(restart_authorization)
-        and bool(run.restart_nonce)
-        and restart_authorization == run.restart_nonce
-      )
-    )
-    return bool(
-      chat is not None
-      and chat.deleted_at is None
-      and run.initiated_by_app_id is None
-      and not app_work_queued
-      and not _has_unanswered_question(chat)
-      and policy_enabled
-      and restart_authorized
-    )
+    if not policy_enabled:
+      return "policy disabled"
+    if restart_park and not (
+      bool(accepted_restart_nonce)
+      and bool(run.restart_nonce)
+      and accepted_restart_nonce == run.restart_nonce
+    ):
+      return "boot authorization missing or mismatched"
+    return None
+
+  def wants_auto_resume(chat, run) -> bool:
+    return auto_resume_rejection(chat, run) is None
 
   limit_resume_started = False
   for run in due:
@@ -2751,6 +2939,11 @@ async def sweep_reset_parks(db: Session) -> list[str]:
     chat_gone = chat is None or chat.deleted_at is not None
     auto_resume = wants_auto_resume(chat, run)
     restart_auto_resume = auto_resume and run.park_reason == "restart"
+    if run.park_reason == "restart" and not auto_resume:
+      log.info(
+        "restart continuation stays manual chat_id=%s run_token=%s reason=%s",
+        chat_id, run.id, auto_resume_rejection(chat, run),
+      )
     if auto_resume and not restart_auto_resume and limit_resume_started:
       # One provider-limit continuation per sweep. Leave this park untouched,
       # but keep walking so a later notify-only chat is not held hostage by
@@ -2815,12 +3008,20 @@ async def sweep_reset_parks(db: Session) -> list[str]:
         # stagger window instead of silently consuming the continuation.
         continue
       resume_started = await _auto_resume_chat(
-        chat_id, park_token=run.id,
+        chat_id,
+        park_token=run.id,
+        restart_authorization=accepted_restart_nonce,
       )
       if resume_started:
         resolved.append(chat_id)
         if not restart_auto_resume:
           limit_resume_started = True
+      elif restart_auto_resume:
+        log.warning(
+          "restart continuation remained pending after scheduling attempt "
+          "chat_id=%s run_token=%s; next event/fallback sweep will retry",
+          chat_id, run.id,
+        )
       continue
 
     # Notify-only/app/deleted path: resolve before the best-effort push so a
@@ -3740,8 +3941,18 @@ def _limit_exit(
   the park fields on a limit kill — is persisted alongside any partial
   response. A limit kill with NO error text (a bare 429 result) still gets a
   synthetic message: the persisted block IS the parked card, so it must
-  exist. Returns the `_complete_turn` kwargs for the limit disposition.
+  exist.
+
+  A planned restart is already the authoritative terminal outcome by the time
+  the provider exits: ``drain_all_for_restart`` publishes the resumable pause
+  before interrupting the handle and records the chat in
+  ``_restart_draining_chats``. Provider teardown errors after that point
+  describe HOW the requested interrupt completed, not a second user-visible
+  outcome, so they must not replace the pause card. Returns the
+  `_complete_turn` kwargs for the limit disposition.
   """
+  if getattr(sink, "chat_id", None) in _restart_draining_chats:
+    return {"limit_reached": False}
   if runner_result is not None:
     limit = _is_limit_terminal(runner_result)
   else:

--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -559,6 +559,27 @@ class ParkRun(_Command):
 
 
 @dataclass
+class PrepareRestartIntents(_Command):
+  """Stamp the exact live runs covered by one planned restart.
+
+  This happens BEFORE provider interruption. A slow provider stop or failed
+  terminal transcript write must not erase the one fact startup needs to
+  distinguish an authenticated planned restart from an unrelated crash.
+  The root-owned boot acknowledgement still authorizes the nonce; this command
+  only binds that nonce to the exact currently-running database rows.
+
+  ``runs`` is a bounded process snapshot of ``chat_id``/``run_token`` pairs.
+  The actor revalidates each pair against the latest running row and its
+  in-process token owner, commits every accepted stamp in one transaction, and
+  returns only the accepted pairs. Invalid/stale pairs are ordinary skips so
+  one turn finishing during preparation cannot block the other live turns.
+  """
+
+  restart_nonce: str = ""
+  runs: list[dict[str, str]] = field(default_factory=list)
+
+
+@dataclass
 class ResolvePark(_Command):
   """Resolve a parked/pending run without starting a continuation.
 
@@ -1402,6 +1423,8 @@ class ChatWriterActor:
       return self._clear_run_status(db, cmd)
     if isinstance(cmd, ParkRun):
       return self._park_run(db, cmd)
+    if isinstance(cmd, PrepareRestartIntents):
+      return self._prepare_restart_intents(db, cmd)
     if isinstance(cmd, ResolvePark):
       return self._resolve_park(db, cmd)
     if isinstance(cmd, PrepareAutoResume):
@@ -2601,6 +2624,50 @@ class ChatWriterActor:
       raise _PersistFailed("ParkRun did not persist")
     self._run_token_owner.pop(cmd.chat_id, None)
     return parked
+
+  def _prepare_restart_intents(
+    self, db, cmd: PrepareRestartIntents,
+  ) -> list[dict[str, str]]:
+    """Bind one authenticated-restart nonce to exact live run rows."""
+    from app.models import Chat, ChatRun
+
+    if not cmd.restart_nonce:
+      return []
+
+    accepted: list[dict[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    changed = False
+    for item in cmd.runs:
+      chat_id = str(item.get("chat_id") or "")
+      run_token = str(item.get("run_token") or "")
+      key = (chat_id, run_token)
+      if not chat_id or not run_token or key in seen:
+        continue
+      seen.add(key)
+
+      owner = self._run_token_owner.get(chat_id)
+      if owner is not None and owner != run_token:
+        continue
+      run = db.query(ChatRun).filter(
+        ChatRun.id == run_token,
+        ChatRun.chat_id == chat_id,
+        ChatRun.status == "running",
+      ).first()
+      chat = db.query(Chat).filter(
+        Chat.id == chat_id,
+        Chat.deleted_at.is_(None),
+        Chat.run_status == "running",
+      ).first()
+      if run is None or chat is None or not self._run_is_latest(db, run):
+        continue
+      if run.restart_nonce != cmd.restart_nonce:
+        run.restart_nonce = cmd.restart_nonce
+        changed = True
+      accepted.append({"chat_id": chat_id, "run_token": run_token})
+
+    if changed and not _commit_or_rollback(db):
+      raise _PersistFailed("PrepareRestartIntents did not persist")
+    return accepted
 
   def _resolve_park(self, db, cmd: ResolvePark):
     """Resolve a parked/pending row without continuing; idempotent."""

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -231,18 +231,34 @@ async def lifespan(app):
   # "running" forever and stranding queued messages. Wrapped like the
   # other lifespan steps: a failure here must not brick the recovery
   # surface. Runs single-threaded pre-serving, so no queue-lock
-  # contention — see reconcile_interrupted_chats for the argument.
-  # Chats reconciled at boot (crashes plus a planned drain whose exact park did
-  # not commit) are carried to the post-`init_vapid` manual-recovery notify
-  # below. Exact planned-restart parks bypass this destructive reconciliation
-  # and are handled by the continuation sweep after the writer starts.
-  _reconciled_chats: list[str] = []
+  # contention — see reconcile_startup_chats for the argument.
+  # Crashes reconciled at boot are carried to the post-`init_vapid`
+  # manual-recovery notify below. A planned drain whose exact park did not
+  # commit is instead converted to a restart park when its nonce matches the
+  # root-owned authorization; both it and exact pre-shutdown parks are handled
+  # by the continuation sweep after the writer starts.
+  _restart_authorization: str | None = None
   try:
-    from app.chat import reconcile_interrupted_chats
+    from app.restart_ledger import authorized_restart_nonce
+    _restart_authorization = authorized_restart_nonce()
+  except Exception as exc:
+    _log.error(
+      "startup restart authorization read failed: %s", exc, exc_info=True,
+    )
+
+  _manual_reconciled_chats: list[str] = []
+  _restart_fallback_chats: list[str] = []
+  try:
+    from app.chat import reconcile_startup_chats
     from app.database import SessionLocal as _ReconcileSession
     _rc_db = _ReconcileSession()
     try:
-      _reconciled_chats = reconcile_interrupted_chats(_rc_db) or []
+      _reconcile_result = reconcile_startup_chats(
+        _rc_db,
+        restart_authorization=_restart_authorization,
+      )
+      _manual_reconciled_chats = _reconcile_result.manual
+      _restart_fallback_chats = _reconcile_result.restart_parks
     finally:
       _rc_db.close()
   except Exception as exc:
@@ -297,8 +313,8 @@ async def lifespan(app):
     _log.error("compiled-bundle reconcile wiring failed: %s", exc, exc_info=True)
   record_memory_checkpoint("startup_bundles_reconciled")
   # Start the single-writer chat-persistence actor AFTER db init and
-  # crash reconciliation. Order is load-bearing: reconcile_interrupted_chats
-  # must run BEFORE the actor exists — recovery has to work even when
+  # crash reconciliation. Order is load-bearing: reconcile_startup_chats must
+  # run BEFORE the actor exists — recovery has to work even when
   # persistence is degraded, so it never routes through the actor.
   # start_writer catches its own startup failure (marks the writer fatal
   # rather than raising), so a writer that can't start can't brick boot
@@ -323,12 +339,12 @@ async def lifespan(app):
   # Best-effort — the resumable note is already durable in the transcript, so a
   # notify failure never blocks boot.
   try:
-    if _reconciled_chats:
+    if _manual_reconciled_chats:
       from app.chat import notify_after_reconcile
       from app.database import SessionLocal as _NotifySession
       _nt_db = _NotifySession()
       try:
-        notify_after_reconcile(_nt_db, _reconciled_chats)
+        notify_after_reconcile(_nt_db, _manual_reconciled_chats)
       finally:
         _nt_db.close()
   except Exception as exc:
@@ -463,7 +479,7 @@ async def lifespan(app):
   except Exception as exc:
     _log.error("start_frontend_watcher failed: %s", exc, exc_info=True)
   record_memory_checkpoint("startup_frontend_watcher_started")
-  # Runtime liveness watchdog. reconcile_interrupted_chats only runs at boot,
+  # Runtime liveness watchdog. reconcile_startup_chats only runs at boot,
   # so a turn that leaves its run marker set without a process restart (a
   # FAILED_LEAVE_MARKER terminal, or the late-promote gap) would hold the chat
   # "running" forever and make the app look permanently busy. This periodic
@@ -531,19 +547,33 @@ async def lifespan(app):
     from app.broadcast import get_system_broadcast as _system_broadcast
     _reset_park_events = _system_broadcast().subscribe()
 
-    async def _sweep_reset_parks_once():
+    async def _sweep_reset_parks_once(*, startup: bool = False):
       try:
         _rp_db = _SweepSession()
         try:
-          await sweep_reset_parks(_rp_db)
+          if startup:
+            return await sweep_reset_parks(
+              _rp_db,
+              restart_authorization=_restart_authorization,
+            )
+          return await sweep_reset_parks(_rp_db)
         finally:
           _rp_db.close()
       except _asyncio.CancelledError:
         raise
       except Exception as _exc:
         _log.error("reset-park sweep failed: %s", _exc, exc_info=True)
+        return []
 
-    await _sweep_reset_parks_once()
+    _startup_continuations = await _sweep_reset_parks_once(startup=True)
+    if _restart_authorization:
+      _log.info(
+        "startup restart continuation pass authorized=%d fallback_recovered=%d "
+        "started_or_resolved=%d",
+        1,
+        len(_restart_fallback_chats),
+        len(_startup_continuations),
+      )
 
     async def _reset_park_loop():
       try:

--- a/backend/app/restart_util.py
+++ b/backend/app/restart_util.py
@@ -44,12 +44,13 @@ async def restart_this_worker() -> None:
     2. Arm an ABSOLUTE SIGKILL backstop at ``DRAIN_TIMEOUT + grace`` — the
        worker dies no matter what, so a wedged drain or a hung graceful shutdown
        can never leave the container "Up" with a dead worker.
-    3. Drain every live turn (interrupt → finalize partials + a "paused for a
-       platform update" note → mark that exact run due now using the existing
-       continuation row; preserve the pending queue). Bounded by
-       ``DRAIN_TIMEOUT``; best-effort — a turn that won't drain, or whose exact
-       transition cannot commit, leaves its generic marker for manual boot
-       reconciliation.
+    3. Before interruption, bind the one-shot restart nonce to every exact live
+       run in a transcript-independent writer transaction. Then drain every
+       turn (interrupt → finalize partials + a "paused for a platform update"
+       note → mark clean stops due now; preserve the pending queue). Bounded by
+       ``DRAIN_TIMEOUT``; a slow stop or failed terminal save retains its exact
+       nonce-stamped running row, which authenticated startup converts to the
+       same due continuation state.
     4. Publish the exact intent + restart sentinel. The frozen root-owned
        poller acknowledges it in the boot ledger, then SIGTERMs pid 1. If that
        path wedges, the backstop force-exits the worker without an
@@ -79,19 +80,44 @@ async def restart_this_worker() -> None:
 
   boot_id = restart_ledger.current_boot_id()
   restart_nonce = restart_ledger.new_nonce()
-  parked_runs: list[dict[str, str]] = []
+  restart_runs: list[dict[str, str]] = []
   try:
-    parked_runs = await asyncio.wait_for(
+    # Bind the authenticated nonce to every exact live run BEFORE provider
+    # interruption. This small writer-only transaction is independent of
+    # transcript serialization and survives a later stop/finalize timeout.
+    restart_runs = await asyncio.wait_for(
+      chat.prepare_restart_intents(restart_nonce),
+      timeout=min(10.0, chat.DRAIN_TIMEOUT),
+    )
+  except Exception:
+    # Fail closed: without an exact DB binding the next boot treats stranded
+    # turns as generic crash recovery and leaves them for manual Resume.
+    log.warning(
+      "restart-intent preparation failed; fallbacks will remain manual",
+      exc_info=True,
+    )
+  try:
+    drained_runs = await asyncio.wait_for(
       chat.drain_all_for_restart(
         timeout=chat.DRAIN_TIMEOUT,
         restart_nonce=restart_nonce,
+        prepared_runs=restart_runs,
       ),
       timeout=chat.DRAIN_TIMEOUT,
+    )
+    # The drain may discover a just-materialized handle after the initial
+    # snapshot. Keep every exact run it successfully authenticated.
+    known = {
+      (item["chat_id"], item["run_token"]) for item in restart_runs
+    }
+    restart_runs.extend(
+      item for item in drained_runs
+      if (item["chat_id"], item["run_token"]) not in known
     )
   except Exception:
     # Never let a drain failure block the restart — the backstop timer and the
     # fallback path still reboots the worker. Exact runs already transitioned
-    # remain due; any marker left set falls back to manual boot reconciliation.
+    # remain due; nonce-stamped running markers use authenticated boot recovery.
     log.warning("drain-for-restart failed; restarting anyway", exc_info=True)
 
   try:
@@ -103,7 +129,7 @@ async def restart_this_worker() -> None:
     restart_ledger.request_restart(
       boot_id=boot_id,
       nonce=restart_nonce,
-      runs=parked_runs,
+      runs=restart_runs,
     )
   except Exception:
     # Restart reliability and continuation authorization are independent.

--- a/backend/tests/test_drain_for_restart.py
+++ b/backend/tests/test_drain_for_restart.py
@@ -1,6 +1,6 @@
 """Drain-gated restart (design §2.2, DrainForRestart path).
 
-Locks in the four contracts that distinguish a restart-drain from a Stop:
+Locks in the five contracts that distinguish a restart-drain from a Stop:
 
   (a) DrainForRestart PRESERVES pending_messages and moves the exact run to a
       due restart park, while stop_chat_for CLEARS the queue (contrast).
@@ -9,6 +9,8 @@ Locks in the four contracts that distinguish a restart-drain from a Stop:
   (c) Generic boot reconciliation stays manual; display text alone never
       manufactures planned-restart intent.
   (d) A send arriving while draining QUEUES instead of starting a turn.
+  (e) Stop/finalize failures retain authenticated exact-run intent, and startup
+      converts every opted fallback to the same immediate continuation path.
 """
 
 import asyncio
@@ -154,6 +156,40 @@ def test_drain_persists_paused_note_and_preserves_partials():
   assert _run("drain-note-1")["restart_nonce"] == "restart-nonce-drain"
 
 
+def test_drain_pause_survives_claude_interrupt_terminal(monkeypatch):
+  """Claude reports a provider error while honoring the drain interrupt."""
+  cid = "drain-claude-interrupt"
+  _, sink, handle = _live_turn(cid)
+
+  async def _stop_with_claude_terminal(timeout=2.0):
+    del timeout
+    handle.stop_calls += 1
+    # This is the terminal result Claude emits after the drain has already
+    # published the authoritative, resumable restart pause.
+    chat_mod._limit_exit(sink, {}, "Execution interrupted.")
+    registry.unregister(cid, handle.kind)
+    return True
+
+  monkeypatch.setattr(handle, "stop", _stop_with_claude_terminal)
+
+  assert _run_drain() == [{
+    "chat_id": cid,
+    "run_token": f"rt-{cid}",
+  }]
+  _drain_writer()
+
+  errors = [
+    block for block in _chat(cid)["messages"][-1]["blocks"]
+    if block.get("type") == "error"
+  ]
+  assert errors == [{
+    "type": "error",
+    "message": chat_mod.PAUSED_FOR_RESTART_MESSAGE,
+    "resumable": True,
+    "pause": {"kind": "restart"},
+  }]
+
+
 def test_drain_finalizes_running_tool_before_clearing_reconcile_marker():
   cid = "drain-running-tool"
   _, sink, _ = _live_turn(cid, partial="")
@@ -231,7 +267,7 @@ def test_drain_does_not_promote_the_queue():
   assert "drain-nopromote" in chat_mod._restart_draining_chats
 
 
-def test_drain_park_failure_leaves_generic_marker_for_manual_recovery(
+def test_drain_park_failure_leaves_authenticated_marker_for_boot_recovery(
   monkeypatch,
 ):
   cid = "drain-park-failure"
@@ -242,11 +278,96 @@ def test_drain_park_failure_leaves_generic_marker_for_manual_recovery(
     raise RuntimeError("writer unavailable")
 
   monkeypatch.setattr(chat_mod, "_park_run_strict", _fail_park)
-  assert _run_drain() == []
+  assert _run_drain() == [{
+    "chat_id": cid,
+    "run_token": f"rt-{cid}",
+  }]
   _drain_writer()
 
   assert _chat(cid)["run_status"] == "running"
   assert _run(cid)["status"] == "running"
+  assert _run(cid)["restart_nonce"] == "restart-nonce-drain"
+
+
+def test_drain_stop_timeout_keeps_authenticated_restart_intent():
+  """A provider that misses the stop window must still auto-recover on boot."""
+  cid = "drain-stop-timeout"
+  _seed(cid)
+  bc = create_broadcast(cid)
+  sink = chat_mod._ChatEventSink(
+    bc, cid, run_token=f"rt-{cid}",
+  )
+  chat_mod.register_active_sink(cid, sink)
+  handle = _Handle(cid, stops=False)
+  registry.register(handle)
+
+  assert _run_drain() == [{
+    "chat_id": cid,
+    "run_token": f"rt-{cid}",
+  }]
+  _drain_writer()
+
+  assert handle.stop_calls == 1
+  assert _chat(cid)["run_status"] == "running"
+  run = _run(cid)
+  assert run["status"] == "running"
+  assert run["restart_nonce"] == "restart-nonce-drain"
+
+
+def test_drain_interrupts_live_providers_concurrently(monkeypatch):
+  """One slow provider must not consume every later chat's stop window."""
+  ids = [
+    "drain-parallel-a",
+    "drain-parallel-b",
+    "drain-parallel-c",
+  ]
+  handles = {}
+  for cid in ids:
+    _, _sink, handle = _live_turn(cid)
+    handles[cid] = handle
+  entered = set()
+  all_entered = asyncio.Event()
+  completed = set()
+
+  for cid, handle in handles.items():
+    async def _stop(timeout=2.0, *, _cid=cid, _handle=handle):
+      del timeout
+      entered.add(_cid)
+      if len(entered) == len(ids):
+        all_entered.set()
+      await asyncio.wait_for(all_entered.wait(), timeout=0.5)
+      registry.unregister(_cid, _handle.kind)
+      completed.add(_cid)
+      return True
+
+    monkeypatch.setattr(handle, "stop", _stop)
+
+  _run_drain()
+  assert completed == set(ids)
+  assert all(_run(cid)["status"] == "parked" for cid in ids)
+
+
+def test_drain_terminal_snapshot_failure_keeps_authenticated_restart_intent(
+  monkeypatch,
+):
+  """Transcript serialization failure no longer downgrades to manual."""
+  cid = "drain-finalize-failure"
+  _, sink, _ = _live_turn(cid)
+
+  async def _fail_finalize():
+    raise TypeError("Object is not JSON serializable")
+
+  monkeypatch.setattr(sink, "finalize", _fail_finalize)
+  assert _run_drain() == [{
+    "chat_id": cid,
+    "run_token": f"rt-{cid}",
+  }]
+  _drain_writer()
+
+  assert _chat(cid)["run_status"] == "running"
+  run = _run(cid)
+  assert run["status"] == "running"
+  assert run["restart_nonce"] == "restart-nonce-drain"
 
 
 def test_drain_without_exact_run_token_stays_manual():
@@ -263,6 +384,145 @@ def test_drain_without_exact_run_token_stays_manual():
 
   assert _chat(cid)["run_status"] == "running"
   assert _run(cid)["status"] == "running"
+
+
+def test_authenticated_restart_fallback_becomes_due_park():
+  cid = "reco-authenticated-restart"
+  nonce = "restart-nonce-authorized"
+  _seed(cid, messages=[
+    {"role": "user", "content": "do work", "ts": 1},
+    {"role": "assistant", "content": "partial", "ts": 2, "blocks": [
+      {"type": "text", "content": "partial"},
+      {"type": "error", "message": chat_mod.PAUSED_FOR_RESTART_MESSAGE},
+    ]},
+  ])
+  db = SessionLocal()
+  try:
+    run = db.query(models.ChatRun).filter(
+      models.ChatRun.id == f"rt-{cid}",
+    ).one()
+    run.restart_nonce = nonce
+    db.commit()
+    result = chat_mod.reconcile_startup_chats(
+      db, restart_authorization=nonce,
+    )
+  finally:
+    db.close()
+
+  assert result.manual == []
+  assert result.restart_parks == [cid]
+  assert _chat(cid)["run_status"] is None
+  run = _run(cid)
+  assert run["status"] == "parked"
+  assert run["park_reason"] == "restart"
+  assert run["parked_until"] is not None
+  assert run["restart_nonce"] == nonce
+  errors = [
+    block for block in _chat(cid)["messages"][-1]["blocks"]
+    if block.get("type") == "error"
+  ]
+  assert len(errors) == 1
+  assert errors[0]["resumable"] is True
+
+
+def test_unacknowledged_restart_intent_remains_manual():
+  cid = "reco-unacknowledged-restart"
+  _seed(cid)
+  db = SessionLocal()
+  try:
+    run = db.query(models.ChatRun).filter(
+      models.ChatRun.id == f"rt-{cid}",
+    ).one()
+    run.restart_nonce = "restart-nonce-unaccepted"
+    db.commit()
+    result = chat_mod.reconcile_startup_chats(
+      db, restart_authorization="different-authorized-nonce",
+    )
+  finally:
+    db.close()
+
+  assert result.manual == [cid]
+  assert result.restart_parks == []
+  run = _run(cid)
+  assert run["status"] == "interrupted"
+  assert run["restart_nonce"] is None
+
+
+def test_five_chat_restart_recovers_timeouts_and_finalize_failure(
+  monkeypatch,
+):
+  """Regression for the production incident: all five opted turns resume."""
+  nonce = "restart-nonce-five-chat"
+  clean_id = "restart-five-clean"
+  timeout_ids = [
+    "restart-five-timeout-a",
+    "restart-five-timeout-b",
+    "restart-five-timeout-c",
+  ]
+  finalize_id = "restart-five-finalize"
+  all_ids = [clean_id, *timeout_ids, finalize_id]
+  sinks = {}
+  handles = {}
+  for cid in all_ids:
+    _, sink, handle = _live_turn(cid)
+    sinks[cid] = sink
+    handles[cid] = handle
+  for cid in timeout_ids:
+    handles[cid]._stops = False
+
+  async def _fail_finalize():
+    raise TypeError("legacy path is not JSON serializable")
+
+  monkeypatch.setattr(sinks[finalize_id], "finalize", _fail_finalize)
+
+  covered = asyncio.run(chat_mod.drain_all_for_restart(
+    restart_nonce=nonce,
+  ))
+  assert {item["chat_id"] for item in covered} == set(all_ids)
+  assert _run(clean_id)["status"] == "parked"
+  for cid in [*timeout_ids, finalize_id]:
+    run = _run(cid)
+    assert run["status"] == "running"
+    assert run["restart_nonce"] == nonce
+
+  # Simulate the new process: no old registry/sink survives the boot.
+  registry.reset_for_tests()
+  for cid, sink in sinks.items():
+    chat_mod.unregister_active_sink(cid, sink)
+  chat_mod._restart_draining_chats.clear()
+  chat_mod.draining = False
+
+  db = SessionLocal()
+  try:
+    result = chat_mod.reconcile_startup_chats(
+      db, restart_authorization=nonce,
+    )
+  finally:
+    db.close()
+  assert set(result.restart_parks) == {*timeout_ids, finalize_id}
+  assert result.manual == []
+  assert all(_run(cid)["status"] == "parked" for cid in all_ids)
+
+  scheduled = []
+
+  async def _record_resume(
+    chat_id, park_token=None, *, restart_authorization=None,
+  ):
+    scheduled.append((chat_id, park_token, restart_authorization))
+    return True
+
+  monkeypatch.setattr(chat_mod, "_auto_resume_chat", _record_resume)
+  db = SessionLocal()
+  try:
+    resumed = asyncio.run(chat_mod.sweep_reset_parks(
+      db, restart_authorization=nonce,
+    ))
+  finally:
+    db.close()
+
+  assert set(resumed) == set(all_ids)
+  assert {item[0] for item in scheduled} == set(all_ids)
+  assert all(item[2] == nonce for item in scheduled)
 
 
 # -- (c) boot reconcile marks the note resumable (no double note) + notify once

--- a/backend/tests/test_limit_park.py
+++ b/backend/tests/test_limit_park.py
@@ -825,6 +825,46 @@ def test_restart_park_auto_continues_with_product_marker(
     chat_mod.discard_starting(cid)
 
 
+def test_startup_sweep_uses_one_captured_restart_authorization(
+  owner_token, monkeypatch,
+):
+  """The pre-yield pass must not depend on a second ledger read."""
+  del owner_token
+  monkeypatch.setattr(
+    "app.push.notify_owner", lambda *args, **kwargs: "notif-id",
+  )
+  monkeypatch.setattr(
+    "app.restart_ledger.authorized_restart_nonce",
+    lambda: (_ for _ in ()).throw(AssertionError("unexpected reread")),
+  )
+  scheduled = []
+  monkeypatch.setattr(
+    chat_mod, "_schedule_continuation",
+    lambda **kwargs: scheduled.append(kwargs),
+  )
+  cid = "restart-captured-authorization"
+  token = f"rt-{cid}"
+  nonce = "restart-nonce-captured"
+  _due_park(
+    cid, token, auto_restart=True,
+    park_reason="restart", restart_nonce=nonce,
+  )
+
+  db = SessionLocal()
+  try:
+    resolved = asyncio.run(chat_mod.sweep_reset_parks(
+      db, restart_authorization=nonce,
+    ))
+  finally:
+    db.close()
+
+  try:
+    assert resolved == [cid]
+    assert len(scheduled) == 1
+  finally:
+    chat_mod.discard_starting(cid)
+
+
 def test_restart_park_waiting_on_question_stays_manual(
   owner_token, monkeypatch,
 ):

--- a/backend/tests/test_restart_util.py
+++ b/backend/tests/test_restart_util.py
@@ -42,7 +42,10 @@ def test_restart_drains_then_requests_supervisor_and_arms_force_kill(monkeypatch
     lambda **kwargs: requests.append(kwargs),
   )
 
-  async def _fake_drain(timeout=0, *, restart_nonce=""):
+  async def _fake_drain(
+    timeout=0, *, restart_nonce="", prepared_runs=None,
+  ):
+    del timeout, prepared_runs
     assert restart_nonce == "nonce-12345678"
     drained["n"] += 1
     return [{"chat_id": "chat-12345678", "run_token": "run-12345678"}]
@@ -89,9 +92,19 @@ def test_restart_request_survives_drain_failure(monkeypatch):
     restart_ledger, "request_restart",
     lambda **kwargs: requests.append(kwargs),
   )
+  prepared = [{
+    "chat_id": "chat-prepared-1234",
+    "run_token": "run-prepared-1234",
+  }]
 
-  async def _boom(timeout=0, *, restart_nonce=""):
-    del timeout, restart_nonce
+  async def _prepare(nonce):
+    assert nonce == "nonce-12345678"
+    return prepared
+
+  monkeypatch.setattr(chat_mod, "prepare_restart_intents", _prepare)
+
+  async def _boom(timeout=0, *, restart_nonce="", prepared_runs=None):
+    del timeout, restart_nonce, prepared_runs
     raise RuntimeError("drain exploded")
 
   monkeypatch.setattr(chat_mod, "drain_all_for_restart", _boom)
@@ -102,7 +115,7 @@ def test_restart_request_survives_drain_failure(monkeypatch):
   assert requests == [{
     "boot_id": "boot-12345678",
     "nonce": "nonce-12345678",
-    "runs": [],
+    "runs": prepared,
   }]
   assert len(_FakeTimer.instances) == 1
 
@@ -115,8 +128,10 @@ def test_restart_handshake_failure_restarts_without_authorization(monkeypatch):
   monkeypatch.setattr(restart_ledger, "current_boot_id", lambda: "boot-12345678")
   monkeypatch.setattr(restart_ledger, "new_nonce", lambda: "nonce-12345678")
 
-  async def _fake_drain(timeout=0, *, restart_nonce=""):
-    del timeout, restart_nonce
+  async def _fake_drain(
+    timeout=0, *, restart_nonce="", prepared_runs=None,
+  ):
+    del timeout, restart_nonce, prepared_runs
     return [{"chat_id": "chat-12345678", "run_token": "run-12345678"}]
 
   def _request_fails(**kwargs):

--- a/backend/tests/test_routes_init_resilience.py
+++ b/backend/tests/test_routes_init_resilience.py
@@ -198,8 +198,8 @@ def test_lifespan_waits_for_initial_restart_resume_sweep(monkeypatch):
   lifespan_ready = threading.Event()
   boot_errors = []
 
-  async def held_sweep(db):
-    del db
+  async def held_sweep(db, **kwargs):
+    del db, kwargs
     sweep_entered.set()
     await asyncio.to_thread(release_sweep.wait)
     return []


### PR DESCRIPTION
## Summary

- bind each exact live turn to the planned restart before provider shutdown begins
- stop providers concurrently and preserve safe automatic recovery when a stop times out or the final transcript save fails
- use one captured boot authorization for startup reconciliation and the first continuation sweep
- keep the calm restart pause authoritative across provider teardown and log every reason a turn remains manual

## Why

The existing authenticated restart design only recorded a turn after its provider had stopped and its final transcript had saved successfully. With several live turns, the old serial two-second stop window timed out ordinary provider teardown, while one invalid legacy transcript value could prevent another exact run from being parked. Those turns were then indistinguishable from generic crash recovery and remained manual after boot.

This extends the authenticated design from #157 and the nonce-only supervisor boundary from #162. It also preserves the safety requirement documented in #153: a database nonce never authorizes continuation by itself. The same nonce must still match the root-owned acknowledgement for this exact boot, the latest exact run, the chat policy, ownership, queued-work attribution, and question state.

## Safety

- a crash before supervisor acknowledgement still falls back to manual recovery
- a missing or mismatched acknowledgement, policy-off chat, unanswered question, app-owned run, app-queued work, or superseded run still cannot continue automatically
- startup finalizes the persisted partial transcript before converting an authenticated running row into a due restart continuation
- provider-limit continuation keeps its existing stagger; only the exact set already live before a planned restart may resume together

## Validation

- 225 focused restart, continuation, lifecycle, writer, crash-recovery, terminal-completion, and provider-contract tests passed
- Python compilation and whitespace checks passed
- the production five-turn failure shape is covered: one clean stop, three stop timeouts, and one terminal-save failure all reach the immediate authorized continuation sweep