### PR TITLE
Add cross-platform PWA installation to first-run welcome

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,7 @@ import { setupQueries } from './hooks/queries.js'
 import { queryClient, persistOptions } from './queryClient.js'
 import { shellReload } from './lib/shellReloadState.js'
 import { beginEmbedBootstrap } from './lib/chatEmbedBootstrap.js'
+import { startInstallPromptCapture } from './lib/installPrompt.js'
 
 // These flows are mutually exclusive. Keep setup, login, the full shell, and
 // the opaque embed out of one another's startup path; first boot should not
@@ -38,6 +39,10 @@ const EMBED_ROUTE = isEmbedRoute()
 if (EMBED_ROUTE) {
   beginEphemeralAuth()
   beginEmbedBootstrap()
+} else {
+  // Capture Chromium's one-shot install event before setup or sign-in can keep
+  // the first-use shell card from mounting.
+  startInstallPromptCapture()
 }
 
 // Validate a ?return= target: same-origin in-app path only. Rejects

--- a/frontend/src/components/ChatView/__tests__/accessibilityHardening.test.js
+++ b/frontend/src/components/ChatView/__tests__/accessibilityHardening.test.js
@@ -45,6 +45,9 @@ test('first-use guidance is a labeled non-modal region with a dismiss action', (
   assert.match(source, /role="region"/)
   assert.match(source, /aria-labelledby="wt-title"/)
   assert.match(source, /aria-label="Dismiss welcome"/)
+  assert.match(source, /aria-labelledby="wt-install-title"/)
+  assert.match(source, /aria-expanded=/)
+  assert.match(source, /role="status"/)
   assert.doesNotMatch(source, /aria-modal="true"/)
 })
 

--- a/frontend/src/components/Shell/Shell.css
+++ b/frontend/src/components/Shell/Shell.css
@@ -397,11 +397,10 @@
 
 /* The install affordance lives in the first-sign-in walkthrough now
    (see frontend/src/components/Walkthrough/WalkthroughOverlay.jsx).
-   beforeinstallprompt capture and the drawer banner that used to
-   live here are gone — the walkthrough's "Add to home screen" step
-   tells the user how to install for their platform exactly once,
-   then never appears again. Sub-app install lives in the standalone
-   card surfaced from drawer ⋮ on a mini-app. */
+   App.jsx captures beforeinstallprompt early enough to survive account
+   setup; the walkthrough consumes it or shows platform-specific manual
+   guidance. The old drawer banner stays retired. Sub-app installation
+   lives in the standalone card surfaced from drawer ⋮ on a mini-app. */
 
   /* Global offline indicator pill in the top bar. Shown only when the
      browser reports offline (useOnlineStatus). Keeps the user oriented

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -122,6 +122,8 @@ test('the first-run walkthrough stays short and action-first', () => {
   assert.match(walkthrough, /Your Möbius is ready/)
   assert.match(walkthrough, /Connect an agent/)
   assert.match(walkthrough, /Open the App Store/)
+  assert.match(walkthrough, /Keep Möbius close/)
+  assert.match(walkthrough, /requestInstall/)
   assert.match(walkthrough, /I’ll explore/)
   assert.match(walkthrough, /mobius:walkthrough-completed/)
 })

--- a/frontend/src/components/Walkthrough/WalkthroughOverlay.css
+++ b/frontend/src/components/Walkthrough/WalkthroughOverlay.css
@@ -62,6 +62,7 @@
 }
 
 .wt__close:focus-visible,
+.wt__install-btn:focus-visible,
 .wt__path:focus-visible,
 .wt__dismiss:focus-visible {
   outline: 2px solid var(--accent, #8b6cf7);
@@ -114,6 +115,92 @@
   color: var(--muted, #a1a1aa);
   font-size: 14px;
   line-height: 1.55;
+}
+
+.wt__install {
+  display: grid;
+  grid-template-columns: 36px minmax(0, 1fr) auto;
+  gap: 4px 10px;
+  align-items: center;
+  margin-top: 18px;
+  padding: 12px;
+  background: color-mix(in srgb, var(--accent, #8b6cf7) 8%, var(--surface2, #1a1f28));
+  border: 1px solid color-mix(in srgb, var(--accent, #8b6cf7) 22%, var(--border, #252b36));
+  border-radius: 12px;
+}
+
+.wt__install-icon {
+  display: grid;
+  place-items: center;
+  width: 36px;
+  height: 36px;
+  color: var(--accent, #a78bfa);
+  background: color-mix(in srgb, var(--accent, #8b6cf7) 15%, transparent);
+  border-radius: 10px;
+}
+
+.wt__install-copy {
+  min-width: 0;
+}
+
+.wt__install-copy h3 {
+  margin: 0;
+  color: var(--text, #e4e4e7);
+  font-size: 14px;
+  font-weight: 680;
+  line-height: 1.25;
+}
+
+.wt__install-copy p {
+  margin: 3px 0 0;
+  color: var(--muted, #a1a1aa);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.wt__install-btn {
+  min-height: 34px;
+  padding: 6px 10px;
+  color: var(--accent, #a78bfa);
+  background: color-mix(in srgb, var(--accent, #8b6cf7) 11%, transparent);
+  border: 0;
+  border-radius: 9px;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.wt__install-btn:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--accent, #8b6cf7) 18%, transparent);
+}
+
+.wt__install-btn:disabled {
+  opacity: 0.64;
+  cursor: wait;
+}
+
+.wt__install-help,
+.wt__install-feedback {
+  grid-column: 2 / -1;
+  margin: 7px 0 0;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.wt__install-help {
+  display: grid;
+  gap: 2px;
+  color: var(--muted, #a1a1aa);
+}
+
+.wt__install-help strong {
+  color: var(--text, #e4e4e7);
+  font-weight: 650;
+}
+
+.wt__install-feedback {
+  color: var(--muted, #a1a1aa);
 }
 
 .wt__paths {
@@ -194,6 +281,11 @@
 
   .wt__path small {
     white-space: normal;
+  }
+
+  .wt__install {
+    grid-template-columns: 34px minmax(0, 1fr) auto;
+    padding: 10px;
   }
 }
 

--- a/frontend/src/components/Walkthrough/WalkthroughOverlay.jsx
+++ b/frontend/src/components/Walkthrough/WalkthroughOverlay.jsx
@@ -1,12 +1,32 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState, useSyncExternalStore } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
+import { Download } from 'lucide-react'
 import { api } from '../../api/client.js'
 import { ownerQueries } from '../../hooks/queries.js'
+import {
+  getInstallPromptSnapshot,
+  requestInstall,
+  subscribeInstallPrompt,
+} from '../../lib/installPrompt.js'
+import {
+  detectInstallPlatform,
+  installCopyForPlatform,
+} from '../../utils/installPlatform.js'
 import './WalkthroughOverlay.css'
 
 export default function WalkthroughOverlay({ onDone, onOpenSettings, onExploreApps }) {
   const queryClient = useQueryClient()
   const closingRef = useRef(false)
+  const [platform] = useState(() => detectInstallPlatform())
+  const [installCopy] = useState(() => installCopyForPlatform(platform))
+  const [showInstallHelp, setShowInstallHelp] = useState(false)
+  const [installBusy, setInstallBusy] = useState(false)
+  const [installFeedback, setInstallFeedback] = useState('')
+  const installState = useSyncExternalStore(
+    subscribeInstallPrompt,
+    getInstallPromptSnapshot,
+    getInstallPromptSnapshot,
+  )
 
   function finish() {
     if (closingRef.current) return
@@ -25,16 +45,41 @@ export default function WalkthroughOverlay({ onDone, onOpenSettings, onExploreAp
     action?.()
   }
 
+  async function handleInstall() {
+    setInstallFeedback('')
+    if (installState !== 'ready') {
+      setShowInstallHelp((visible) => !visible)
+      return
+    }
+
+    setInstallBusy(true)
+    const result = await requestInstall()
+    setInstallBusy(false)
+    if (result.outcome === 'accepted') {
+      finish()
+      return
+    }
+
+    setShowInstallHelp(true)
+    setInstallFeedback(
+      result.outcome === 'dismissed'
+        ? 'Not installed. You can use the browser menu whenever you’re ready.'
+        : 'The browser prompt wasn’t available. Use the steps below instead.',
+    )
+  }
+
   useEffect(() => {
-    const standalone =
-      (typeof window !== 'undefined' &&
-        window.matchMedia &&
-        window.matchMedia('(display-mode: standalone)').matches) ||
-      (typeof navigator !== 'undefined' && navigator.standalone === true)
-    if (standalone) finish()
-    // finish is guarded and this should run only once on mount.
+    if (installState === 'installed') finish()
+    // The event can arrive after mount; finish is guarded across rerenders.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [installState])
+
+  const nativeInstallReady = installState === 'ready'
+  const installButtonLabel = installBusy
+    ? 'Opening…'
+    : (nativeInstallReady
+        ? 'Install'
+        : (showInstallHelp ? 'Hide' : installCopy.ctaLabel))
 
   return (
     <aside
@@ -59,6 +104,40 @@ export default function WalkthroughOverlay({ onDone, onOpenSettings, onExploreAp
         You can explore now. Add an agent only when you want chats to act and
         build on your behalf.
       </p>
+      <section className="wt__install" aria-labelledby="wt-install-title">
+        <span className="wt__install-icon" aria-hidden="true">
+          <Download size={18} strokeWidth={2} />
+        </span>
+        <div className="wt__install-copy">
+          <h3 id="wt-install-title">Keep Möbius close</h3>
+          <p>
+            {nativeInstallReady
+              ? 'Install it on this device for a full-screen, one-tap launch.'
+              : installCopy.summary}
+          </p>
+        </div>
+        <button
+          type="button"
+          className="wt__install-btn"
+          onClick={handleInstall}
+          disabled={installBusy}
+          aria-expanded={nativeInstallReady ? undefined : showInstallHelp}
+          aria-controls={nativeInstallReady ? undefined : 'wt-install-help'}
+        >
+          {installButtonLabel}
+        </button>
+        {showInstallHelp && (
+          <div className="wt__install-help" id="wt-install-help">
+            <strong>{installCopy.title}</strong>
+            <span>{installCopy.body}</span>
+          </div>
+        )}
+        {installFeedback && (
+          <p className="wt__install-feedback" role="status">
+            {installFeedback}
+          </p>
+        )}
+      </section>
       <div className="wt__paths">
         <button
           type="button"

--- a/frontend/src/lib/__tests__/installPrompt.test.js
+++ b/frontend/src/lib/__tests__/installPrompt.test.js
@@ -1,0 +1,90 @@
+/**
+ * Unit tests for the early PWA install-prompt capture.
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+async function freshModule() {
+  return import(new URL(`../installPrompt.js?t=${Math.random()}`, import.meta.url))
+}
+
+function makeTarget({ standalone = false } = {}) {
+  const handlers = new Map()
+  return {
+    navigator: { standalone: false },
+    matchMedia: () => ({ matches: standalone }),
+    addEventListener(type, handler) {
+      handlers.set(type, handler)
+    },
+    dispatch(type, event = {}) {
+      handlers.get(type)?.(event)
+    },
+  }
+}
+
+test('captures and consumes a one-shot native install prompt', async () => {
+  const installPrompt = await freshModule()
+  const target = makeTarget()
+  let prevented = false
+  let promptCalls = 0
+  installPrompt.startInstallPromptCapture(target)
+
+  target.dispatch('beforeinstallprompt', {
+    preventDefault() { prevented = true },
+    async prompt() {
+      promptCalls += 1
+      return { outcome: 'accepted' }
+    },
+  })
+
+  assert.equal(prevented, true)
+  assert.equal(installPrompt.getInstallPromptSnapshot(), 'ready')
+  assert.deepEqual(await installPrompt.requestInstall(), { outcome: 'accepted' })
+  assert.equal(promptCalls, 1)
+  assert.equal(installPrompt.getInstallPromptSnapshot(), 'manual')
+  assert.deepEqual(await installPrompt.requestInstall(), { outcome: 'unavailable' })
+  assert.equal(promptCalls, 1)
+})
+
+test('falls back to userChoice for older Chromium prompt results', async () => {
+  const installPrompt = await freshModule()
+  const target = makeTarget()
+  installPrompt.startInstallPromptCapture(target)
+  target.dispatch('beforeinstallprompt', {
+    preventDefault() {},
+    async prompt() {},
+    userChoice: Promise.resolve({ outcome: 'dismissed' }),
+  })
+
+  assert.deepEqual(await installPrompt.requestInstall(), { outcome: 'dismissed' })
+})
+
+test('appinstalled and standalone launch suppress the install invitation', async () => {
+  const captured = await freshModule()
+  const target = makeTarget()
+  captured.startInstallPromptCapture(target)
+  target.dispatch('appinstalled')
+  assert.equal(captured.getInstallPromptSnapshot(), 'installed')
+
+  const standalone = await freshModule()
+  standalone.startInstallPromptCapture(makeTarget({ standalone: true }))
+  assert.equal(standalone.getInstallPromptSnapshot(), 'installed')
+})
+
+test('subscribers are notified when prompt availability changes', async () => {
+  const installPrompt = await freshModule()
+  const target = makeTarget()
+  let changes = 0
+  installPrompt.startInstallPromptCapture(target)
+  const unsubscribe = installPrompt.subscribeInstallPrompt(() => { changes += 1 })
+
+  target.dispatch('beforeinstallprompt', {
+    preventDefault() {},
+    async prompt() { return { outcome: 'dismissed' } },
+  })
+  await installPrompt.requestInstall()
+  unsubscribe()
+  target.dispatch('appinstalled')
+
+  assert.equal(changes, 2)
+})

--- a/frontend/src/lib/installPrompt.js
+++ b/frontend/src/lib/installPrompt.js
@@ -1,0 +1,80 @@
+/**
+ * Captures the browser's one-shot PWA install prompt for later user action.
+ *
+ * Chromium can emit `beforeinstallprompt` while account setup is still on
+ * screen, before the first-use card has mounted. App.jsx therefore starts
+ * this module eagerly and the card subscribes to its small external-store
+ * interface when it eventually appears.
+ */
+
+let captureStarted = false
+let deferredPrompt = null
+let installed = false
+const listeners = new Set()
+
+function emitChange() {
+  for (const listener of listeners) listener()
+}
+
+function isStandalone(target) {
+  try {
+    if (target?.navigator?.standalone === true) return true
+    return target?.matchMedia?.('(display-mode: standalone)')?.matches === true
+  } catch {
+    return false
+  }
+}
+
+export function startInstallPromptCapture(
+  target = typeof window !== 'undefined' ? window : null,
+) {
+  if (!target || captureStarted) return
+  captureStarted = true
+  installed = isStandalone(target)
+
+  target.addEventListener('beforeinstallprompt', (event) => {
+    if (installed) return
+    event.preventDefault?.()
+    deferredPrompt = event
+    emitChange()
+  })
+
+  target.addEventListener('appinstalled', () => {
+    deferredPrompt = null
+    installed = true
+    emitChange()
+  })
+}
+
+export function getInstallPromptSnapshot() {
+  if (installed) return 'installed'
+  if (deferredPrompt) return 'ready'
+  return 'manual'
+}
+
+export function subscribeInstallPrompt(listener) {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+export async function requestInstall() {
+  const promptEvent = deferredPrompt
+  if (!promptEvent) return { outcome: 'unavailable' }
+
+  // A BeforeInstallPromptEvent can only be used once. Clear it before
+  // awaiting browser UI so a fast second tap cannot call prompt() twice.
+  deferredPrompt = null
+  emitChange()
+
+  try {
+    const promptResult = await promptEvent.prompt()
+    const choice = typeof promptResult?.outcome === 'string'
+      ? promptResult
+      : await promptEvent.userChoice
+    return {
+      outcome: choice?.outcome === 'accepted' ? 'accepted' : 'dismissed',
+    }
+  } catch {
+    return { outcome: 'unavailable' }
+  }
+}

--- a/frontend/src/utils/__tests__/installPlatform.test.js
+++ b/frontend/src/utils/__tests__/installPlatform.test.js
@@ -1,25 +1,5 @@
 /**
- * Unit tests for installPlatform.js (UA detection + per-platform install
- * copy + clipboard helper).
- *
- * Run with:
- *   cd frontend && node --test src/utils/__tests__/installPlatform.test.js
- *
- * Pure functions only — detectInstallPlatform takes an explicit UA
- * string, installCopyForPlatform takes a plain object, copyOriginUrl
- * touches navigator.clipboard (covered by a stub).
- *
- * Coverage focuses on the branches today's walkthrough relies on:
- *   - iosSafari → arrowDir 'down', includes Share-button copy
- *   - iosNonSafari (CriOS/FxiOS/etc.) → unsupported=true, ctaLabel
- *     'Copy link' (drives WalkthroughOverlay's STEPS_NO_INSTALL filter)
- *   - chromium-on-Android / Chromium-on-desktop → arrowDir 'up'
- *   - firefox-on-desktop → unsupported (Firefox desktop has no PWA
- *     install API)
- *   - empty UA / SSR-style call (no navigator) → no crash
- *
- * If any of these regress, walkthrough renders wrong copy for the
- * platform OR crashes during SSR, both of which are user-visible.
+ * Unit tests for platform detection and manual install instructions.
  */
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
@@ -29,138 +9,133 @@ import {
   installCopyForPlatform,
 } from '../installPlatform.js'
 
-// Real UA strings observed in the wild — keep these literal so a
-// regex tweak in installPlatform.js can be validated against real
-// device output rather than a synthesized minimal string.
 const UA = {
   iosSafari: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Mobile/15E148 Safari/604.1',
   iosChrome: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/120.0.6099.119 Mobile/15E148 Safari/604.1',
   iosFirefox: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/121.0 Mobile/15E148 Safari/605.1.15',
+  ipadDesktop: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Safari/605.1.15',
   androidChrome: 'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.6099.144 Mobile Safari/537.36',
   androidFirefox: 'Mozilla/5.0 (Android 14; Mobile; rv:121.0) Gecko/121.0 Firefox/121.0',
   androidSamsung: 'Mozilla/5.0 (Linux; Android 14; SAMSUNG SM-G991B) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/23.0 Chrome/115.0.0.0 Mobile Safari/537.36',
   desktopChrome: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
   desktopEdge: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0',
-  desktopFirefox: 'Mozilla/5.0 (X11; Linux x86_64; rv:121.0) Gecko/20100101 Firefox/121.0',
+  windowsFirefox: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:143.0) Gecko/20100101 Firefox/143.0',
+  linuxFirefox: 'Mozilla/5.0 (X11; Linux x86_64; rv:143.0) Gecko/20100101 Firefox/143.0',
+  macSafari: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15',
 }
 
-test('iOS Safari is detected and NOT treated as iOS-non-Safari', () => {
-  const p = detectInstallPlatform(UA.iosSafari)
-  assert.equal(p.ios, true)
-  assert.equal(p.iosSafari, true)
-  assert.equal(p.iosNonSafari, false)
-  assert.equal(p.bipCapable, false)
-  assert.equal(p.installPossible, true)
+test('iOS Safari and third-party browsers are all install-capable', () => {
+  const safari = detectInstallPlatform(UA.iosSafari)
+  const chrome = detectInstallPlatform(UA.iosChrome)
+  const firefox = detectInstallPlatform(UA.iosFirefox)
+
+  assert.equal(safari.iosSafari, true)
+  assert.equal(safari.iosNonSafari, false)
+  assert.equal(chrome.iosNonSafari, true)
+  assert.equal(firefox.iosNonSafari, true)
+  assert.equal(safari.installPossible, true)
+  assert.equal(chrome.installPossible, true)
+  assert.equal(firefox.installPossible, true)
 })
 
-test('iOS Chrome (CriOS) is detected as iOS-non-Safari', () => {
-  const p = detectInstallPlatform(UA.iosChrome)
-  assert.equal(p.ios, true)
-  assert.equal(p.iosSafari, false)
-  assert.equal(p.iosNonSafari, true)
-  // Walkthrough relies on this to drop the install step.
-  assert.equal(p.installPossible, false)
+test('iPadOS desktop UA is not mistaken for desktop Safari', () => {
+  const platform = detectInstallPlatform(UA.ipadDesktop, 5)
+  const copy = installCopyForPlatform(platform)
+
+  assert.equal(platform.ios, true)
+  assert.equal(platform.desktopSafari, false)
+  assert.match(copy.body, /Add to Home Screen/)
 })
 
-test('iOS Firefox (FxiOS) is detected as iOS-non-Safari', () => {
-  const p = detectInstallPlatform(UA.iosFirefox)
-  assert.equal(p.iosSafari, false)
-  assert.equal(p.iosNonSafari, true)
+test('Android install-capable browsers are detected without iOS overlap', () => {
+  const chrome = detectInstallPlatform(UA.androidChrome)
+  const firefox = detectInstallPlatform(UA.androidFirefox)
+  const samsung = detectInstallPlatform(UA.androidSamsung)
+
+  assert.equal(chrome.android, true)
+  assert.equal(chrome.chromium, true)
+  assert.equal(chrome.bipCapable, true)
+  assert.equal(firefox.android, true)
+  assert.equal(firefox.firefox, true)
+  assert.equal(samsung.samsung, true)
+  assert.equal(samsung.chromium, true)
 })
 
-test('Android Chrome is chromium + android + bipCapable', () => {
-  const p = detectInstallPlatform(UA.androidChrome)
-  assert.equal(p.android, true)
-  assert.equal(p.chromium, true)
-  assert.equal(p.ios, false)
-  assert.equal(p.bipCapable, true)
+test('Chromium desktop includes Chrome and Edge', () => {
+  const chrome = detectInstallPlatform(UA.desktopChrome)
+  const edge = detectInstallPlatform(UA.desktopEdge)
+
+  assert.equal(chrome.chromium, true)
+  assert.equal(chrome.desktop, true)
+  assert.equal(edge.edge, true)
+  assert.equal(edge.chromium, true)
 })
 
-test('Android Firefox is firefox + android (not iosNonSafari)', () => {
-  const p = detectInstallPlatform(UA.androidFirefox)
-  assert.equal(p.firefox, true)
-  assert.equal(p.android, true)
-  assert.equal(p.iosNonSafari, false)
-  assert.equal(p.installPossible, true)
+test('Firefox on Windows exposes current web-app instructions', () => {
+  const platform = detectInstallPlatform(UA.windowsFirefox)
+  const copy = installCopyForPlatform(platform)
+
+  assert.equal(platform.firefox, true)
+  assert.equal(platform.windows, true)
+  assert.equal(platform.installPossible, true)
+  assert.equal(copy.unsupported, undefined)
+  assert.match(copy.body, /web-app button/)
 })
 
-test('Samsung Internet is chromium-family on Android', () => {
-  const p = detectInstallPlatform(UA.androidSamsung)
-  assert.equal(p.samsung, true)
-  assert.equal(p.chromium, true)
-  assert.equal(p.android, true)
-})
+test('Firefox on Linux offers an honest cross-browser fallback', () => {
+  const platform = detectInstallPlatform(UA.linuxFirefox)
+  const copy = installCopyForPlatform(platform)
 
-test('Desktop Chrome is chromium + desktop + bipCapable', () => {
-  const p = detectInstallPlatform(UA.desktopChrome)
-  assert.equal(p.chromium, true)
-  assert.equal(p.desktop, true)
-  assert.equal(p.android, false)
-  assert.equal(p.ios, false)
-})
-
-test('Desktop Edge is chromium-family (matches Edg/ regex)', () => {
-  const p = detectInstallPlatform(UA.desktopEdge)
-  assert.equal(p.edge, true)
-  assert.equal(p.chromium, true)
-})
-
-test('Desktop Firefox is firefox + desktop and installCopy marks unsupported', () => {
-  const p = detectInstallPlatform(UA.desktopFirefox)
-  assert.equal(p.firefox, true)
-  assert.equal(p.desktop, true)
-  const copy = installCopyForPlatform(p)
+  assert.equal(platform.windows, false)
+  assert.equal(platform.installPossible, false)
   assert.equal(copy.unsupported, true)
-  assert.equal(copy.arrowDir, null)
+  assert.match(copy.body, /Chrome|Edge|Safari/)
 })
 
-test('Empty UA does not crash (SSR/test safety)', () => {
-  const p = detectInstallPlatform('')
-  assert.equal(typeof p, 'object')
-  assert.equal(p.ios, false)
-  assert.equal(p.android, false)
+test('desktop Safari offers Add to Dock', () => {
+  const platform = detectInstallPlatform(UA.macSafari)
+  const copy = installCopyForPlatform(platform)
+
+  assert.equal(platform.desktopSafari, true)
+  assert.equal(platform.mac, true)
+  assert.match(copy.body, /Add to Dock/)
 })
 
-test('installCopyForPlatform: iOS Safari shows Share + arrow-down + Got it', () => {
-  const p = detectInstallPlatform(UA.iosSafari)
-  const copy = installCopyForPlatform(p)
-  assert.equal(copy.arrowDir, 'down')
-  assert.equal(copy.ctaLabel, 'Got it')
-  assert.match(copy.body, /Share/)
+test('empty UA does not crash in non-browser contexts', () => {
+  const platform = detectInstallPlatform('')
+  assert.equal(platform.ios, false)
+  assert.equal(platform.android, false)
+  assert.equal(typeof installCopyForPlatform(platform).summary, 'string')
 })
 
-test('installCopyForPlatform: iOS Chrome shows unsupported + Copy link CTA', () => {
-  const p = detectInstallPlatform(UA.iosChrome)
-  const copy = installCopyForPlatform(p)
-  assert.equal(copy.unsupported, true)
-  assert.equal(copy.ctaLabel, 'Copy link')
+test('iOS instructions use the Share menu in Safari, Chrome, and Firefox', () => {
+  for (const ua of [UA.iosSafari, UA.iosChrome, UA.iosFirefox]) {
+    const copy = installCopyForPlatform(detectInstallPlatform(ua))
+    assert.equal(copy.unsupported, undefined)
+    assert.equal(copy.ctaLabel, 'Show me')
+    assert.match(copy.body, /Share/)
+    assert.match(copy.body, /Add to Home Screen/)
+  }
 })
 
-test('installCopyForPlatform: Android Chrome shows arrow-up + menu instruction', () => {
-  const p = detectInstallPlatform(UA.androidChrome)
-  const copy = installCopyForPlatform(p)
-  assert.equal(copy.arrowDir, 'up')
-  assert.match(copy.body, /menu/)
+test('Android browsers get their own menu wording', () => {
+  const chrome = installCopyForPlatform(detectInstallPlatform(UA.androidChrome))
+  const firefox = installCopyForPlatform(detectInstallPlatform(UA.androidFirefox))
+
+  assert.match(chrome.body, /browser menu/)
+  assert.match(firefox.body, /Firefox menu/)
 })
 
-test('installCopyForPlatform: Android Firefox shows arrow-up + menu instruction', () => {
-  const p = detectInstallPlatform(UA.androidFirefox)
-  const copy = installCopyForPlatform(p)
-  assert.equal(copy.arrowDir, 'up')
+test('desktop Chromium manual fallback names the address bar', () => {
+  const copy = installCopyForPlatform(detectInstallPlatform(UA.desktopChrome))
+  assert.match(copy.body, /address bar/)
 })
 
-test('installCopyForPlatform: Desktop Chrome shows arrow-up + address-bar copy', () => {
-  const p = detectInstallPlatform(UA.desktopChrome)
-  const copy = installCopyForPlatform(p)
-  assert.equal(copy.arrowDir, 'up')
-  assert.match(copy.body, /address bar|address-bar/)
-})
-
-test('installCopyForPlatform: fallback for unknown UA returns generic copy', () => {
-  const p = detectInstallPlatform('SomeWeirdEngine/1.0')
-  const copy = installCopyForPlatform(p)
-  // Generic branch: still has a title and body, ctaLabel, no arrow.
-  assert.equal(typeof copy.title, 'string')
-  assert.equal(typeof copy.body, 'string')
-  assert.equal(typeof copy.ctaLabel, 'string')
+test('standalone mode reports installation instead of browser-chrome steps', () => {
+  const copy = installCopyForPlatform(
+    detectInstallPlatform(UA.iosSafari),
+    true,
+  )
+  assert.equal(copy.title, 'Möbius is installed')
+  assert.match(copy.body, /already/)
 })

--- a/frontend/src/utils/installPlatform.js
+++ b/frontend/src/utils/installPlatform.js
@@ -1,161 +1,138 @@
-// Platform-aware install-instruction helpers.
+// Platform-aware instructions for installing the main Möbius shell.
 //
-// Mirrors the logic baked into `backend/app/routes/standalone.py`'s
-// per-app standalone shell, but for the main Möbius shell. The two
-// can't share source (standalone is Python-rendered HTML, this is an
-// ES module the bundler picks up), but they MUST stay logically in
-// sync — the walkthrough's "Add to home screen" step and the sub-app
-// install card should agree on which arrow points where on a given
-// device.
-//
-// UA-based, fragile-but-fine: we use this for hint copy only. If we
-// guess wrong on an edge case the browser still has its own menu.
-// Feature-detect when possible (matchMedia, navigator.standalone).
+// UA detection is intentionally limited to hint copy. Native install
+// availability is feature-detected separately through `beforeinstallprompt`;
+// if a browser changes its menu, Möbius still leaves installation to the
+// browser rather than pretending a guessed instruction is an API.
 
-export function detectInstallPlatform(ua) {
-  // Default to navigator.userAgent only if we're in a browser. Tests
-  // and any future SSR path can pass an explicit UA without crashing
-  // on undefined `navigator`. The `window.MSStream` check is the same
-  // — only consult it when window exists.
+export function detectInstallPlatform(ua, maxTouchPoints) {
   if (ua === undefined) {
     ua = typeof navigator !== 'undefined' ? (navigator.userAgent || '') : ''
   }
+  if (maxTouchPoints === undefined) {
+    maxTouchPoints = typeof navigator !== 'undefined'
+      ? (navigator.maxTouchPoints || 0)
+      : 0
+  }
   const hasWindow = typeof window !== 'undefined'
-  const ios = /iPad|iPhone|iPod/.test(ua) && !(hasWindow && window.MSStream)
-  // Every iOS browser uses WebKit (Apple gates engine choice until
-  // iOS 17.4 EU). CriOS = Chrome on iOS, FxiOS = Firefox on iOS, etc.
+  // iPadOS can request a desktop UA and identify as Macintosh. Touch points
+  // distinguish that mode from a real Mac for install-copy purposes.
+  const ipadDesktop = /Macintosh/.test(ua) && maxTouchPoints > 1
+  const ios = (/iPad|iPhone|iPod/.test(ua) || ipadDesktop) &&
+    !(hasWindow && window.MSStream)
   const iosNonSafari = ios && /CriOS|FxiOS|EdgiOS|OPiOS|GSA/.test(ua)
   const iosSafari = ios && !iosNonSafari
   const android = /Android/.test(ua)
   const samsung = /SamsungBrowser/.test(ua)
   const edge = /\bEdg\//.test(ua)
   const firefox = /Firefox|FxiOS/.test(ua)
-  // Chromium-family install-capable browsers — Chrome, Edge,
-  // Samsung Internet. CriOS is excluded because Apple forces it to
-  // be WebKit-engined on iOS.
+  const windows = /Windows/.test(ua)
+  const mac = /Macintosh|Mac OS X/.test(ua) && !ios
+  const desktopSafari = !ios && /Safari/.test(ua) &&
+    !/Chrome|Chromium|CriOS|Edg|OPR|Firefox/.test(ua)
   const chromium = !ios && (
     (/Chrome/.test(ua) && !/Edge\//.test(ua)) || edge || samsung
   )
   const desktop = !ios && !android
+
   return {
     ua,
     ios, iosSafari, iosNonSafari,
     android, chromium, edge, firefox, samsung, desktop,
+    desktopSafari, mac, windows,
     // `beforeinstallprompt` can fire here.
     bipCapable: chromium,
-    // PWA install is possible at all on this platform.
-    installPossible: iosSafari || chromium || (firefox && !ios),
+    // iOS 16.4+ allows third-party browsers to expose Add to Home Screen.
+    // Firefox desktop currently supports web apps on Windows only.
+    installPossible: ios || chromium || desktopSafari ||
+      (firefox && (android || windows)),
   }
 }
 
-// Returns rendering hints for the "Add to home screen" walkthrough
-// step. Each shape:
-//   {
-//     title:     short heading
-//     body:      one or two sentences explaining the path
-//     ctaLabel:  the primary-action button label
-//     arrowDir:  'up' | 'down' | null — for any directional UI accent
-//     unsupported: true on platforms where install is impossible
-//                  (renders an alternate CTA, e.g. copy-link)
-//   }
-//
-// The walkthrough overlay doesn't need to know about BIP — by the
-// time the user reaches step 2 they're on a Möbius origin where the
-// real install action is "tap your browser's menu" (Möbius can't
-// reliably auto-fire prompt() at walkthrough-step-2 time, especially
-// for first-time visitors who haven't built engagement yet). The
-// honest copy matches that reality.
-//
-// `standaloneMode` (optional, default false) flags that the caller is
-// ALREADY running inside an installed standalone PWA. On iOS Safari the
-// Share button only exists in the in-browser chrome; a standalone
-// launch has none, so the "tap the Share button below" copy would point
-// at an absent control. When standaloneMode is true on iOS Safari we
-// advise opening the page in Safari proper instead. Default-false keeps
-// the return shape and copy identical for every existing caller — an
-// unset param means "behave exactly as before"; callers that care detect
-// navigator.standalone===true themselves and pass it in.
+// Manual fallback for browsers that do not expose `beforeinstallprompt`.
+// Native prompt availability always wins in the UI; these instructions keep
+// iOS, Android, and desktop useful without it.
 export function installCopyForPlatform(
   p = detectInstallPlatform(),
   standaloneMode = false,
 ) {
-  if (p.iosSafari) {
-    if (standaloneMode) {
-      // Already launched standalone — the Share button isn't on screen.
-      // Tell the user to open the page in Safari, where it lives.
-      return {
-        title: 'Open Möbius in Safari',
-        body: 'You’re already in the installed app, so the Share button isn’t shown here. Open this page in Safari to add another app to your home screen.',
-        ctaLabel: 'Got it',
-        arrowDir: null,
-      }
-    }
+  if (standaloneMode) {
     return {
-      title: 'Add Möbius to your home screen',
-      body: 'Tap the Share button below (the square with the up-arrow), then choose Add to Home Screen.',
+      title: 'Möbius is installed',
+      summary: 'It already opens as an app on this device.',
+      body: 'You’re already using the installed app.',
       ctaLabel: 'Got it',
-      arrowDir: 'down',
     }
   }
-  if (p.iosNonSafari) {
+
+  if (p.ios) {
     return {
-      title: 'Open Möbius in Safari',
-      body: 'On iPhone and iPad, only Safari can install web apps. Copy this page’s link and open it in Safari, then tap Share → Add to Home Screen.',
-      ctaLabel: 'Copy link',
-      arrowDir: null,
-      unsupported: true,
+      title: 'Add Möbius to your Home Screen',
+      summary: 'Use Share, then Add to Home Screen.',
+      body: 'Open your browser’s Share menu, choose Add to Home Screen, keep Open as Web App turned on, then tap Add.',
+      ctaLabel: 'Show me',
     }
   }
+
   if (p.firefox && p.android) {
     return {
-      title: 'Add Möbius to your home screen',
-      body: 'Tap the ⋮ menu at the top right, then choose Install.',
-      ctaLabel: 'Got it',
-      arrowDir: 'up',
+      title: 'Install Möbius',
+      summary: 'Use the Firefox menu to add it.',
+      body: 'Open the Firefox menu, tap Install, then add Möbius to your Home Screen.',
+      ctaLabel: 'Show me',
     }
   }
-  if (p.firefox && p.desktop) {
+
+  if (p.firefox && p.windows) {
     return {
-      title: 'Install isn’t supported in Firefox',
-      body: 'Firefox on desktop doesn’t install web apps. Open Möbius in Chrome or Edge to add it as a desktop app, or just bookmark it.',
-      ctaLabel: 'Got it',
-      arrowDir: null,
-      unsupported: true,
+      title: 'Install Möbius',
+      summary: 'Pin it to your Windows taskbar.',
+      body: 'Click the web-app button in the Firefox address bar. Möbius will open in its own window and appear in your taskbar and Start menu.',
+      ctaLabel: 'Show me',
     }
   }
+
   if (p.chromium && p.android) {
     return {
-      title: 'Add Möbius to your home screen',
-      body: 'Tap the ⋮ menu in the address bar, then Install app (or Add to Home screen).',
-      ctaLabel: 'Got it',
-      arrowDir: 'up',
+      title: 'Install Möbius',
+      summary: 'Use your browser menu to add it.',
+      body: 'Open the browser menu, then choose Install app or Add to Home screen.',
+      ctaLabel: 'Show me',
     }
   }
+
   if (p.chromium && p.desktop) {
     return {
       title: 'Install Möbius',
-      body: 'Click the install icon on the right side of the address bar, or open the ⋮ menu and choose Install Möbius.',
-      ctaLabel: 'Got it',
-      arrowDir: 'up',
+      summary: 'Keep it in your dock or taskbar.',
+      body: 'Click the install icon in the address bar, or open the browser menu and choose Install Möbius.',
+      ctaLabel: 'Show me',
     }
   }
-  return {
-    title: 'Add Möbius to your home screen',
-    body: 'Look for an Install or Add to Home Screen option in your browser’s menu (usually ⋮ or ⋯).',
-    ctaLabel: 'Got it',
-    arrowDir: null,
-  }
-}
 
-// Attempts to copy the current URL to the clipboard. Used by the
-// iOS-non-Safari path where the only escape hatch is paste-into-
-// Safari. Returns true on success, false on any clipboard failure
-// (typically lack of permission or the page not being foregrounded).
-export async function copyOriginUrl() {
-  try {
-    await navigator.clipboard.writeText(window.location.href)
-    return true
-  } catch {
-    return false
+  if (p.desktopSafari && p.mac) {
+    return {
+      title: 'Add Möbius to your Dock',
+      summary: 'Open it like a Mac app.',
+      body: 'In Safari, open the File menu and choose Add to Dock.',
+      ctaLabel: 'Show me',
+    }
+  }
+
+  if (p.firefox && p.desktop) {
+    return {
+      title: 'Keep Möbius close',
+      summary: 'This Firefox version cannot install web apps.',
+      body: 'Open Möbius in Chrome, Edge, or Safari to install it as an app, or bookmark this page in Firefox.',
+      ctaLabel: 'Options',
+      unsupported: true,
+    }
+  }
+
+  return {
+    title: 'Install Möbius',
+    summary: 'Keep it one click away.',
+    body: 'Look for Install, Add to Home Screen, or Add to Dock in your browser’s address bar or menu.',
+    ctaLabel: 'Show me',
   }
 }


### PR DESCRIPTION
## Summary

- add an install block to the existing first-run welcome card
- capture Chromium’s native install prompt before account setup can miss it
- fall back to current iOS/iPadOS, Android, Safari, Firefox, and desktop instructions
- hide the invitation once Möbius is running as an installed app

## Why

Möbius already ships the manifest, icons, and service worker needed for installation, but new owners had no visible path from first setup to their Home Screen, dock, or taskbar. The install event is one-shot, so capturing it only when the welcome card mounts can also miss the browser’s native prompt.

This keeps the existing short, non-modal welcome experience and adds one focused action instead of introducing another onboarding flow.

## Validation

- `npm test` — 2,160 tests passed
- `npm run build` — production and offline/PWA builds passed
- focused staged-checkout tests — 95 passed
- authenticated first-run render verified at the owner viewport with the native install action available