### PR TITLE
Group contribution prompts into compact panels

### DIFF
--- a/frontend/src/components/ChatView/ContributionReviewCard.css
+++ b/frontend/src/components/ChatView/ContributionReviewCard.css
@@ -15,10 +15,66 @@
 }
 
 .contrib-card-stack {
+  box-sizing: border-box;
+  width: min(100%, 640px);
+  margin-inline: auto;
   display: flex;
   flex-direction: column;
   gap: 8px;
   padding: 8px 12px 0;
+}
+
+.contrib-card-stack--grouped {
+  gap: 0;
+  margin-top: 8px;
+  padding: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  max-height: min(52vh, 520px);
+  border: 1px solid var(--border-light);
+  border-radius: 14px;
+  background: var(--surface);
+}
+
+.contrib-card-stack__heading {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border-light);
+  background: color-mix(in srgb, var(--accent) 8%, var(--surface));
+}
+
+.contrib-card-stack__title {
+  color: var(--text);
+  font-size: 0.8125rem;
+  font-weight: 650;
+  line-height: 1.3;
+}
+
+.contrib-card-stack__copy {
+  margin-top: 2px;
+  color: var(--muted);
+  font-size: 0.71875rem;
+  line-height: 1.35;
+}
+
+.contrib-card-stack__count {
+  flex: none;
+  display: grid;
+  place-items: center;
+  width: 26px;
+  height: 26px;
+  border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--border));
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 9%, var(--surface));
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 700;
 }
 
 .contrib-card {
@@ -34,6 +90,41 @@
      card tracks the finger 1:1 instead of lagging behind it. */
   transition: transform 160ms cubic-bezier(0.2, 0, 0.2, 1),
               opacity 160ms linear;
+}
+
+.contrib-card-stack--grouped .contrib-card {
+  flex: none;
+  gap: 5px;
+  padding: 11px 14px 12px;
+  border: 0;
+  border-left: 2px solid var(--accent);
+  border-radius: 0;
+  background: transparent;
+}
+
+.contrib-card-stack--grouped .contrib-card + .contrib-card {
+  border-top: 1px solid var(--border-light);
+}
+
+.contrib-card-stack--grouped .contrib-card--blocked {
+  border-left-color: var(--muted);
+}
+
+.contrib-card-stack--grouped .contrib-card__badge {
+  margin: 0;
+  padding: 0;
+  border-bottom: 0;
+  background: transparent;
+}
+
+.contrib-card-stack--grouped .contrib-card--blocked .contrib-card__badge {
+  background: transparent;
+}
+
+.contrib-card-stack--grouped .contrib-card__details {
+  max-height: none;
+  overflow: visible;
+  overscroll-behavior: auto;
 }
 
 .contrib-card--dragging {
@@ -243,4 +334,16 @@
   font-weight: 600;
   color: var(--accent);
   text-decoration: none;
+}
+
+@media (max-width: 560px) {
+  .contrib-card-stack {
+    width: 100%;
+  }
+
+  .contrib-card-stack--grouped {
+    max-height: 46vh;
+    margin-inline: 12px;
+    width: calc(100% - 24px);
+  }
 }

--- a/frontend/src/components/ChatView/ContributionReviewCard.css
+++ b/frontend/src/components/ChatView/ContributionReviewCard.css
@@ -160,20 +160,19 @@
   color: var(--muted);
 }
 
-/* The swipe's visible equivalent. Quiet by default — the card is an offer, not
-   an alert — but a real control, so a pointer or keyboard can dismiss too. */
+/* The swipe's visible equivalent. This follows the shell's quiet Lucide close
+   controls rather than the heavier filled icon that made the button look off. */
 .contrib-card__dismiss {
   flex-shrink: 0;
+  display: grid;
+  place-items: center;
   width: 28px;
-  height: 22px;
+  height: 28px;
   padding: 0;
   border: none;
-  border-radius: 5px;
+  border-radius: 7px;
   background: transparent;
   color: var(--muted);
-  font-family: var(--font);
-  font-size: 0.75rem;
-  line-height: 1;
   cursor: pointer;
 }
 
@@ -182,6 +181,11 @@
     background: color-mix(in srgb, var(--text) 10%, transparent);
     color: var(--text);
   }
+}
+
+.contrib-card__dismiss:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
 }
 
 .contrib-card__summary {

--- a/frontend/src/components/ChatView/ContributionReviewCard.jsx
+++ b/frontend/src/components/ChatView/ContributionReviewCard.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { X } from '@openai/apps-sdk-ui/components/Icon'
+import X from 'lucide-react/dist/esm/icons/x.mjs'
 import { api } from '../../api/client.js'
 import { appQueries } from '../../hooks/queries.js'
 import {
@@ -271,10 +271,9 @@ function SentRow({ sent, onDismiss }) {
           type="button"
           className="contrib-card__dismiss"
           aria-label="Dismiss"
-          title="Dismiss"
           onClick={() => onDismiss?.()}
         >
-          <X width={13} height={13} aria-hidden="true" />
+          <X size={14} strokeWidth={2} aria-hidden="true" />
         </button>
       </div>
       <p className="contrib-card__summary">
@@ -322,13 +321,9 @@ function ReviewRow({
           type="button"
           className="contrib-card__dismiss"
           aria-label="Dismiss — keeps it in Contribute"
-          title="Dismiss — keeps it in Contribute"
           onClick={() => onDismiss?.()}
         >
-          {/* The shell's icon set rather than a close CHARACTER: Inter has no
-              glyph for U+2715, so the literal rendered as a tofu box on the
-              real device. */}
-          <X width={13} height={13} aria-hidden="true" />
+          <X size={14} strokeWidth={2} aria-hidden="true" />
         </button>
       </div>
       <p className="contrib-card__summary">

--- a/frontend/src/components/ChatView/ContributionReviewCard.jsx
+++ b/frontend/src/components/ChatView/ContributionReviewCard.jsx
@@ -8,6 +8,7 @@ import {
   contributeApp as findContributeApp,
   contributeAppId,
   contributeLabel,
+  diffStatSummary,
   isHorizontalSwipe,
   passedDismissThreshold,
   payoffLine,
@@ -63,6 +64,7 @@ export default function ContributionReviewCard({ chatId, turnActive, onOpenApp }
 
   const storage = typeof localStorage !== 'undefined' ? localStorage : null
   const records = visibleRecords(data, storage)
+  const grouped = records.length > 1
   void dismissRevision
   if (!appId) return null
   if (!records.length && !sent) return null
@@ -103,7 +105,24 @@ export default function ContributionReviewCard({ chatId, turnActive, onOpenApp }
   }
 
   return (
-    <div className="contrib-card-stack">
+    <div
+      className={`contrib-card-stack${grouped ? ' contrib-card-stack--grouped' : ''}`}
+      role={grouped ? 'region' : undefined}
+      aria-label={grouped ? `${records.length} contributions ready` : undefined}
+    >
+      {grouped && (
+        <div className="contrib-card-stack__heading">
+          <div>
+            <div className="contrib-card-stack__title">
+              {records.length} contributions ready
+            </div>
+            <div className="contrib-card-stack__copy">
+              Review each one separately.
+            </div>
+          </div>
+          <span className="contrib-card-stack__count">{records.length}</span>
+        </div>
+      )}
       {sent && (
         <SentRow
           key={`sent:${sent.id}`}
@@ -285,6 +304,7 @@ function ReviewRow({
 }) {
   const [open, setOpen] = useState(false)
   const blocker = sendBlocker(record, { connected })
+  const diffStat = diffStatSummary(record.diff_stat)
   const submitting = record.status === 'submitting'
   const cardRef = useSwipeToDismiss(onDismiss)
 
@@ -317,7 +337,7 @@ function ReviewRow({
 
       <p className="contrib-card__meta">
         {record.repo}
-        {record.diff_stat ? <span> · {record.diff_stat}</span> : null}
+        {diffStat ? <span> · {diffStat}</span> : null}
       </p>
 
       {/* The payoff, but never next to a problem: a blocked review needs the

--- a/frontend/src/components/ChatView/QuestionCard.css
+++ b/frontend/src/components/ChatView/QuestionCard.css
@@ -1,7 +1,9 @@
 .qcard {
-  margin: 8px 0;
-  padding: 14px;
-  border-radius: 12px;
+  box-sizing: border-box;
+  width: min(100%, 640px);
+  margin: 10px auto;
+  padding: 16px;
+  border-radius: 14px;
   background: var(--surface, rgba(255,255,255,.06));
   border: 1px solid var(--border-light, var(--border));
 }
@@ -10,10 +12,65 @@
      are disabled, while the Submit slot remains visible as "Submitted". */
 }
 
+.qcard--grouped {
+  padding: 0;
+  overflow: hidden;
+}
+
+.qcard__group-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 16px 12px;
+  border-bottom: 1px solid var(--border-light, var(--border));
+  background: color-mix(in srgb, var(--accent) 7%, transparent);
+}
+
+.qcard__group-title {
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 650;
+  line-height: 1.3;
+}
+
+.qcard__group-copy {
+  margin-top: 2px;
+  color: var(--muted);
+  font-size: 11.5px;
+  line-height: 1.35;
+}
+
+.qcard__group-count {
+  flex: none;
+  display: grid;
+  place-items: center;
+  width: 26px;
+  height: 26px;
+  border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--border));
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 9%, var(--surface));
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.qcard--grouped .qcard__questions {
+  padding: 0 16px;
+}
+
+.qcard--grouped .qcard__q {
+  padding: 14px 0;
+}
+
 .qcard__q + .qcard__q {
   margin-top: 14px;
   padding-top: 14px;
   border-top: 1px solid var(--border-light, var(--border));
+}
+
+.qcard--grouped .qcard__q + .qcard__q {
+  margin-top: 0;
 }
 
 .qcard__header {
@@ -67,6 +124,7 @@
    on touch). Quiet by design: small, muted, left-aligned with the label. The
    mark stays top-aligned so a two-line option still reads as one choice. */
 .qcard__opt:has(.qcard__opt-body) {
+  flex: 1 1 220px;
   align-items: flex-start;
   text-align: left;
 }
@@ -204,6 +262,10 @@
   margin-top: 8px;
 }
 
+.qcard--grouped .qcard__submit-error {
+  margin: 0 16px 8px;
+}
+
 .qcard__submit {
   display: block;
   width: 100%;
@@ -218,6 +280,13 @@
   cursor: pointer;
   transition: background .15s, opacity .15s;
 }
+.qcard--grouped .qcard__submit {
+  width: calc(100% - 32px);
+  margin: 0 16px 16px;
+}
+.qcard--grouped .qcard__submit-error + .qcard__submit {
+  margin-top: 0;
+}
 .qcard__submit:hover:not(:disabled) {
   background: var(--accent-hover, var(--accent));
 }
@@ -228,4 +297,32 @@
 .qcard__submit:disabled {
   opacity: .4;
   cursor: default;
+}
+
+@media (max-width: 560px) {
+  .qcard {
+    margin: 8px 0;
+    padding: 14px;
+  }
+
+  .qcard--grouped {
+    padding: 0;
+  }
+
+  .qcard__group-head {
+    padding-inline: 14px;
+  }
+
+  .qcard--grouped .qcard__questions {
+    padding-inline: 14px;
+  }
+
+  .qcard--grouped .qcard__submit {
+    width: calc(100% - 28px);
+    margin-inline: 14px;
+  }
+
+  .qcard--grouped .qcard__submit-error {
+    margin-inline: 14px;
+  }
 }

--- a/frontend/src/components/ChatView/QuestionCard.jsx
+++ b/frontend/src/components/ChatView/QuestionCard.jsx
@@ -47,6 +47,7 @@ export default function QuestionCard({
 
   const answered = submitted || !!answeredMap
   const displayAnswers = answeredMap || {}
+  const grouped = questions.length > 1
 
   // ChatView is keyed by chat, so switching away remounts this card. Keep an
   // unsubmitted selection in the same per-tab cache as composer drafts; the
@@ -144,11 +145,24 @@ export default function QuestionCard({
 
   return (
     <div
-      className={`qcard${answered ? ' qcard--answered' : ''}`}
+      className={`qcard${grouped ? ' qcard--grouped' : ''}${answered ? ' qcard--answered' : ''}`}
       ref={answered ? null : pendingCardRef}
       aria-disabled={disabled && !answered ? true : undefined}
+      aria-label={grouped ? `${questions.length} decisions` : undefined}
     >
-      {questions.map((q, qi) => {
+      {grouped && (
+        <div className="qcard__group-head">
+          <div>
+            <div className="qcard__group-title">{questions.length} decisions</div>
+            <div className="qcard__group-copy">
+              Choose each one, then submit them together.
+            </div>
+          </div>
+          <span className="qcard__group-count">{questions.length}</span>
+        </div>
+      )}
+      <div className="qcard__questions">
+        {questions.map((q, qi) => {
         const selected = answers[q.question]
         const isMulti = q.multiSelect
         const selectedArr = isMulti
@@ -280,7 +294,8 @@ export default function QuestionCard({
             )}
           </div>
         )
-      })}
+        })}
+      </div>
       {(answered || !disabled) && (
         <>
           {submitError && !answered && (

--- a/frontend/src/components/ChatView/__tests__/contributionReviewModel.test.js
+++ b/frontend/src/components/ChatView/__tests__/contributionReviewModel.test.js
@@ -291,9 +291,14 @@ test('the swipe has a visible, focusable equivalent', () => {
   assert.match(cardSrc, /className="contrib-card__dismiss"/)
   assert.match(cardSrc, /aria-label="Dismiss — keeps it in Contribute"/)
   assert.match(cardSrc, /onClick=\{\(\) => onDismiss\?\.\(\)\}/)
-  // An icon from the shell's set, never a bare ✕ character — Inter has no glyph
-  // for U+2715, so the literal rendered as a tofu box on the real device.
-  assert.match(cardSrc, /<X width=\{13\} height=\{13\} aria-hidden="true" \/>/)
+  // Use the same outlined close icon as the shell's other compact dismiss
+  // controls; the heavier Apps SDK glyph made this one look out of place.
+  assert.match(cardSrc, /import X from 'lucide-react\/dist\/esm\/icons\/x\.mjs'/)
+  assert.equal(
+    (cardSrc.match(/<X size=\{14\} strokeWidth=\{2\} aria-hidden="true" \/>/g) || []).length,
+    2,
+  )
+  assert.doesNotMatch(cardSrc, /title="Dismiss/)
   assert.doesNotMatch(cardSrc, /✕|✖|❌/)
 })
 

--- a/frontend/src/components/ChatView/__tests__/contributionReviewModel.test.js
+++ b/frontend/src/components/ChatView/__tests__/contributionReviewModel.test.js
@@ -10,6 +10,7 @@ import {
   contributeApp,
   contributeAppId,
   contributeLabel,
+  diffStatSummary,
   payoffLine,
   dismissKey,
   isDismissed,
@@ -123,6 +124,16 @@ test('the status word distinguishes waiting, blocked, and in-flight', () => {
   assert.equal(statusLabel({ status: 'submitting' }, false), 'Publishing')
 })
 
+test('multiple independent contributions share one bounded review panel', () => {
+  assert.match(cardSrc, /const grouped = records\.length > 1/)
+  assert.match(cardSrc, /contrib-card-stack--grouped/)
+  assert.match(cardSrc, /\{records\.length\} contributions ready/)
+  assert.match(cardSrc, /Review each one separately\./)
+  assert.match(cardCss, /\.contrib-card-stack\s*\{[\s\S]*?width:\s*min\(100%, 640px\);[\s\S]*?margin-inline:\s*auto;/)
+  assert.match(cardCss, /\.contrib-card-stack--grouped\s*\{[\s\S]*?max-height:\s*min\(52vh, 520px\);/)
+  assert.match(cardCss, /\.contrib-card-stack--grouped \.contrib-card\s*\{[\s\S]*?border-radius:\s*0;/)
+})
+
 // The action names the value of contributing, not the mechanism of sending, and
 // never uses "upstream" — precise to anyone who works with open source, opaque to
 // everyone else. It only names a destination it actually knows.
@@ -146,6 +157,18 @@ test('the payoff line matches who benefits and keeps acceptance conditional', ()
   const app = payoffLine({ repo: 'mobius-os/app-example' })
   assert.match(app, /everyone using this app/)
   for (const line of [platform, app]) assert.match(line, /^If it's accepted/)
+})
+
+test('the docked card reduces a multi-line diff stat to its aggregate', () => {
+  assert.equal(
+    diffStatSummary(
+      ' frontend/src/a.js | 12 +++++\n backend/app/b.py | 3 ---\n 2 files changed, 12 insertions(+), 3 deletions(-)',
+    ),
+    '2 files changed, 12 insertions(+), 3 deletions(-)',
+  )
+  assert.equal(diffStatSummary(' 1 file changed, 4 insertions(+)\n'), '1 file changed, 4 insertions(+)')
+  assert.equal(diffStatSummary(null), '')
+  assert.match(cardSrc, /diffStatSummary\(record\.diff_stat\)/)
 })
 
 test('the card discloses the continuing review authority granted by Send', () => {

--- a/frontend/src/components/ChatView/__tests__/questionCardState.test.js
+++ b/frontend/src/components/ChatView/__tests__/questionCardState.test.js
@@ -48,6 +48,16 @@ test('question card css has no stale styling hook', () => {
     'a failed answer should keep its retry notice attached to the card')
 })
 
+test('multiple questions read as one compact decision panel', () => {
+  assert.match(component, /const grouped = questions\.length > 1/)
+  assert.match(component, /className=\{`qcard\$\{grouped \? ' qcard--grouped'/)
+  assert.match(component, /\{questions\.length\} decisions/)
+  assert.match(component, /Choose each one, then submit them together\./)
+  assert.match(css, /\.qcard\s*\{[\s\S]*?width:\s*min\(100%, 640px\);[\s\S]*?margin:\s*10px auto;/)
+  assert.match(css, /\.qcard--grouped\s*\{[\s\S]*?overflow:\s*hidden;/)
+  assert.match(css, /\.qcard--grouped \.qcard__q \+ \.qcard__q\s*\{[\s\S]*?margin-top:\s*0;/)
+})
+
 test('a failed question submission does not append a transcript row', () => {
   const start = chatView.indexOf('const doSendSilent = useCallback')
   const end = chatView.indexOf('function handleSubmit(e)', start)

--- a/frontend/src/components/ChatView/contributionReviewModel.js
+++ b/frontend/src/components/ChatView/contributionReviewModel.js
@@ -104,6 +104,16 @@ export function payoffLine(record) {
     : "If it's accepted, everyone using this app gets it."
 }
 
+/**
+ * Reduce git's multi-line per-file table to the aggregate final line for the
+ * docked summary card. Full file details remain available in the disclosure.
+ */
+export function diffStatSummary(value) {
+  if (typeof value !== 'string') return ''
+  const lines = value.split(/\r?\n/).map(line => line.trim()).filter(Boolean)
+  return lines.at(-1) || ''
+}
+
 // ── Swipe-to-dismiss ────────────────────────────────────────────────────────
 //
 // Dismissing is a VIEW decision, never a data one: the contribution stays


### PR DESCRIPTION
## Summary

- cap contribution prompts and source-chat review cards at a readable desktop width
- present several questions or prepared contributions as one headed panel with compact internal rows
- keep every decision, dismissal, and contribution action independent
- bound multi-item review panels to one scroll area and preserve the phone-width layout
- show the aggregate change total in compact rows while keeping complete file details behind Details

## Context

This is a focused follow-up to #250, which introduced the source-chat contribution review card and noted that a chat would normally have zero or one prepared record. Real working chats can accumulate several independent contributions, and one agent question can carry several contribution decisions. The existing surfaces then stretch across a wide transcript and read as a wall of separate cards.

This keeps the existing review and publication trust boundaries unchanged; it only improves how those decisions are presented.

## Testing

- 1,991 frontend library checks passed
- 63 frontend hook checks passed
- production frontend build passed
- rendered against a live three-item state at desktop and phone-sized viewports