### PR TITLE
Start fresh workspaces in standard mode

### DIFF
--- a/frontend/src/components/Shell/__tests__/singleScreenSlot.test.js
+++ b/frontend/src/components/Shell/__tests__/singleScreenSlot.test.js
@@ -12,10 +12,13 @@ const { makeTab } = tabModel
 
 function reduce(state, action) { return paneModel.workspaceReducer(state, action) }
 function init(ws) { return paneModel.initialWorkspaceState(ws) }
+function builderSeed(tabs) {
+  return paneModel.setViewMode(paneModel.seedFromFlatTabs(tabs), 'panes')
+}
 
 // A two-pane builder workspace: chat 5 on the left (focused), app 42 on the right.
 function tiledBuilder() {
-  let ws = paneModel.seedFromFlatTabs([makeTab('chat', '5')])
+  let ws = builderSeed([makeTab('chat', '5')])
   ws = paneModel.splitPaneWithTab(ws, makeTab('app', '42'), {
     paneId: ws.focusedPaneId, edge: 'right',
   })
@@ -222,14 +225,14 @@ test('activeContentRoute reflects the SLOT in single mode, the focused pane in b
 
 test('closing the LAST builder tab auto-returns to single', () => {
   // Single-pane builder with one chat; close it → the tree empties → auto-return.
-  const ws = paneModel.seedFromFlatTabs([makeTab('chat', '5')]) // viewMode panes
+  const ws = builderSeed([makeTab('chat', '5')])
   const s = reduce(init(ws), { type: 'CLOSE_TAB', tabKey: 'chat:5' })
   assert.equal(s.ws.viewMode, 'single', 'empty builder auto-returns to single')
   assert.equal(s.undo.restoreViewMode, true, 'the undo is flagged one-gesture')
 })
 
 test('undo of the last-tab close restores the tab AND builder mode as one gesture', () => {
-  const ws = paneModel.seedFromFlatTabs([makeTab('chat', '5')])
+  const ws = builderSeed([makeTab('chat', '5')])
   let state = reduce(init(ws), { type: 'CLOSE_TAB', tabKey: 'chat:5' })
   state = reduce(state, { type: 'UNDO_LAST' })
   assert.equal(state.ws.viewMode, 'panes', 'builder mode restored')
@@ -237,7 +240,7 @@ test('undo of the last-tab close restores the tab AND builder mode as one gestur
 })
 
 test('closing a tab that leaves others does NOT auto-return', () => {
-  const ws = paneModel.seedFromFlatTabs([makeTab('chat', '5'), makeTab('chat', '6')])
+  const ws = builderSeed([makeTab('chat', '5'), makeTab('chat', '6')])
   const s = reduce(init(ws), { type: 'CLOSE_TAB', tabKey: 'chat:5' })
   assert.equal(s.ws.viewMode, 'panes', 'still builder — other tabs remain')
   assert.equal(s.undo.restoreViewMode, false)
@@ -251,7 +254,7 @@ test('closing the last tab in SINGLE mode does not auto-return (already single)'
 })
 
 test('CLOSE_PANE that empties the builder auto-returns to single', () => {
-  const ws = paneModel.seedFromFlatTabs([makeTab('chat', '5')])
+  const ws = builderSeed([makeTab('chat', '5')])
   const s = reduce(init(ws), { type: 'CLOSE_PANE', paneId: ws.focusedPaneId })
   assert.equal(s.ws.viewMode, 'single')
   assert.equal(s.undo.restoreViewMode, true)
@@ -260,7 +263,7 @@ test('CLOSE_PANE that empties the builder auto-returns to single', () => {
 test('INV 8: an explicit later toggle rebases a coupled undo to tree-only', () => {
   // Auto-return arms a mode-coupled undo (restoreViewMode). The owner then toggles
   // the mode explicitly; undo must restore the TREE but not yank the mode back.
-  const ws = paneModel.seedFromFlatTabs([makeTab('chat', '5')]) // panes
+  const ws = builderSeed([makeTab('chat', '5')])
   let state = reduce(init(ws), { type: 'CLOSE_TAB', tabKey: 'chat:5' }) // → single, coupled undo
   assert.equal(state.undo.restoreViewMode, true)
   state = reduce(state, { type: 'SET_VIEW_MODE', mode: 'panes' }) // explicit later intent

--- a/frontend/src/components/Shell/__tests__/singleScreenSlot.test.js
+++ b/frontend/src/components/Shell/__tests__/singleScreenSlot.test.js
@@ -37,6 +37,19 @@ test('normalize preserves property ABSENCE as the migration marker', () => {
   assert.equal('singleScreen' in n, false, 'absence survives normalize')
 })
 
+test('a fresh standard seed routes through its focused fallback until the slot initializes', () => {
+  const chat = paneModel.seedFromFlatTabs([makeTab('chat', '5')])
+  assert.equal('singleScreen' in chat, false)
+  assert.equal(paneModel.activeContentRoute(chat).chatId, '5')
+
+  const app = paneModel.seedFromFlatTabs([makeTab('chat', '5'), makeTab('app', '42')])
+  assert.equal('singleScreen' in app, false)
+  assert.equal(paneModel.activeContentRoute(app).appId, 42)
+
+  const empty = paneModel.seedFromFlatTabs([])
+  assert.equal(paneModel.activeContentRoute(empty).chatId, null, 'an empty first boot starts at home')
+})
+
 test('normalize sanitizes a present slot; corrupt/settings → explicit null', () => {
   const base = paneModel.seedFromFlatTabs([makeTab('chat', '5')])
   const withGarbage = paneModel.normalize({ ...base, singleScreen: { kind: 'wat', id: 9 } })

--- a/frontend/src/components/Shell/__tests__/viewMode.test.js
+++ b/frontend/src/components/Shell/__tests__/viewMode.test.js
@@ -25,10 +25,12 @@ function twoPanes() {
 
 test('first boot and fallback workspaces default to standard single-screen mode', () => {
   assert.equal(freshWorkspace().viewMode, 'single')
+  assert.equal(paneModel.activeContentRoute(freshWorkspace()).chatId, '5')
   const firstBoot = paneModel.parseWorkspace(null, {
     fallbackTabs: [makeTab('chat', '5')],
   })
   assert.equal(firstBoot.viewMode, 'single')
+  assert.equal(paneModel.activeContentRoute(firstBoot).chatId, '5')
 })
 
 test('setViewMode sets the mode and is same-reference on a no-op', () => {

--- a/frontend/src/components/Shell/__tests__/viewMode.test.js
+++ b/frontend/src/components/Shell/__tests__/viewMode.test.js
@@ -5,13 +5,17 @@ import * as tabModel from '../tabModel.js'
 
 const { makeTab } = tabModel
 
-// A fresh workspace and a two-pane one, both seeded through the public ops so
-// their viewMode is whatever the model assigns by default.
-function onePane() {
+function freshWorkspace() {
   return paneModel.seedFromFlatTabs([makeTab('chat', '5')])
 }
+
+// Builder-world fixtures opt into panes explicitly. This keeps the remainder of
+// the mode-machine tests about mode transitions rather than the first-boot policy.
+function onePane() {
+  return paneModel.setViewMode(freshWorkspace(), 'panes')
+}
 function twoPanes() {
-  let ws = paneModel.seedFromFlatTabs([makeTab('chat', '5')])
+  let ws = onePane()
   return paneModel.splitPaneWithTab(ws, makeTab('app', '42'), {
     paneId: ws.focusedPaneId, edge: 'right',
   })
@@ -19,9 +23,12 @@ function twoPanes() {
 
 // ── viewMode field + persistence (design: view-mode toggle, forgiving parse) ──
 
-test('a fresh workspace defaults to panes view-mode', () => {
-  assert.equal(onePane().viewMode, 'panes')
-  assert.equal(twoPanes().viewMode, 'panes')
+test('first boot and fallback workspaces default to standard single-screen mode', () => {
+  assert.equal(freshWorkspace().viewMode, 'single')
+  const firstBoot = paneModel.parseWorkspace(null, {
+    fallbackTabs: [makeTab('chat', '5')],
+  })
+  assert.equal(firstBoot.viewMode, 'single')
 })
 
 test('setViewMode sets the mode and is same-reference on a no-op', () => {
@@ -170,14 +177,11 @@ test('UNDO_LAST restores the captured tree but KEEPS the current view-mode', () 
   assert.equal(undone.ws.viewMode, 'single', 'the view-mode flip is NOT reverted')
 })
 
-// ── M3: the kill switch clamps the fresh/fallback seed to ONE world ───────────
+// ── M3: the fresh/fallback seed has one standard world in every flag state ────
 // parseWorkspace returns seedFromFlatTabs directly on the fresh/fallback/invalid
-// paths (no re-normalize), and the seed was always viewMode:'panes'. With splits
-// OFF the presentation clamps to single, but activeContentRoute reads the RAW
-// ws.viewMode — 'panes' made it project the hidden builder focus while single
-// mode painted the slot: two conflicting worlds. Clamping the seed's viewMode at
-// the parse layer (coerceViewMode, the same clamp the valid-blob path gets) keeps
-// the blob itself single, so both readers agree.
+// paths (no re-normalize), so the seed itself must carry the mode both rendering
+// and activeContentRoute read. The splits kill switch still clamps every other
+// candidate to that same single-screen world.
 test('M3: with splits OFF a fresh/fallback seed is single and activeContentRoute reads the slot', async () => {
   const prevLS = globalThis.localStorage
   globalThis.localStorage = { getItem: (k) => (k === 'mobius:workspace-splits' ? '0' : null) }
@@ -200,11 +204,10 @@ test('M3: with splits OFF a fresh/fallback seed is single and activeContentRoute
   }
 })
 
-test('M3: with splits ON the seed keeps the tiled panes default (no regression)', () => {
-  // The clamp only fires under the kill switch; the default (tests + prod) is the
-  // tiled builder world, and activeContentRoute reads the focused pane there.
+test('M3: with splits ON a fresh seed still starts in standard mode', () => {
   assert.equal(paneModel.WORKSPACE_SPLITS_ENABLED, true)
-  const ws = paneModel.seedFromFlatTabs([makeTab('chat', 'A')])
-  assert.equal(ws.viewMode, 'panes')
-  assert.equal(paneModel.activeContentRoute(ws).chatId, 'A')
+  let ws = paneModel.seedFromFlatTabs([makeTab('chat', 'A')])
+  assert.equal(ws.viewMode, 'single')
+  ws = paneModel.setSingleScreen(ws, { kind: 'chat', id: 'B' })
+  assert.equal(paneModel.activeContentRoute(ws).chatId, 'B')
 })

--- a/frontend/src/components/Shell/__tests__/workspacePlacement.test.js
+++ b/frontend/src/components/Shell/__tests__/workspacePlacement.test.js
@@ -22,6 +22,10 @@ import {
 const CHAT = (id) => makeTab('chat', id)
 const APP = (id) => makeTab('app', id)
 
+function builderSeed(tabs) {
+  return paneModel.setViewMode(paneModel.seedFromFlatTabs(tabs), 'panes')
+}
+
 // A two-pane row workspace: p0 | p1. Each pane's last tab is active unless named.
 function twoPaneWs(aTabs, bTabs, { focused = 'p0', activeA, activeB } = {}) {
   return paneModel.normalize({
@@ -211,7 +215,7 @@ test('resolver ignores an unsupported (future) placement as a strict no-op', () 
 // ── resolver: beside-source × mode (the §6.2 table) ─────────────────────────
 
 test('beside-source + background · phone: a tab after source, no on-screen switch', () => {
-  const ws = paneModel.seedFromFlatTabs([CHAT('a')])
+  const ws = builderSeed([CHAT('a')])
   const out = resolveWorkspaceRequest(
     ws, req(APP(9), CHAT('a'), PLACE_BESIDE_SOURCE, ACTIVATE_IN_BACKGROUND),
     env(ws, { mode: 'phone', rect: { w: 400, h: 800 } }),
@@ -222,7 +226,7 @@ test('beside-source + background · phone: a tab after source, no on-screen swit
 })
 
 test('beside-source + foreground · phone: insert and activate', () => {
-  const ws = paneModel.seedFromFlatTabs([CHAT('a')])
+  const ws = builderSeed([CHAT('a')])
   const out = resolveWorkspaceRequest(
     ws, req(APP(9), CHAT('a'), PLACE_BESIDE_SOURCE, ACTIVATE_FOREGROUND),
     env(ws, { mode: 'phone', rect: { w: 400, h: 800 } }),
@@ -231,7 +235,7 @@ test('beside-source + foreground · phone: insert and activate', () => {
 })
 
 test('beside-source + background · tile single pane: split, item active in the NEW pane, focus stays', () => {
-  const ws = paneModel.seedFromFlatTabs([CHAT('a')])
+  const ws = builderSeed([CHAT('a')])
   const out = resolveWorkspaceRequest(
     ws, req(APP(9), CHAT('a'), PLACE_BESIDE_SOURCE, ACTIVATE_IN_BACKGROUND),
     env(ws, { mode: 'wide', rect: { w: 1400, h: 900 } }),
@@ -246,7 +250,7 @@ test('beside-source + background · tile single pane: split, item active in the 
 })
 
 test('beside-source + foreground · tile single pane: split AND focus the new pane', () => {
-  const ws = paneModel.seedFromFlatTabs([CHAT('a')])
+  const ws = builderSeed([CHAT('a')])
   const out = resolveWorkspaceRequest(
     ws, req(APP(9), CHAT('a'), PLACE_BESIDE_SOURCE, ACTIVATE_FOREGROUND),
     env(ws, { mode: 'wide' }),

--- a/frontend/src/components/Shell/paneModel.js
+++ b/frontend/src/components/Shell/paneModel.js
@@ -647,7 +647,13 @@ export function singleScreenRoute(ws) {
 // and the reload snapshot — so a single-world reload restores the slot, not the
 // builder focus (design: derive activeView from the current world).
 export function activeContentRoute(ws) {
-  return ws.viewMode === 'single' ? singleScreenRoute(ws) : focusedContentRoute(ws)
+  // An absent slot is the migration marker for a fresh/legacy workspace. The
+  // renderer already falls back to the focused pane in that state; route
+  // projection must do the same or first boot paints one surface while
+  // navigation reports the empty home screen. Once singleScreen is initialized
+  // (including explicit null), the independent Standard world is authoritative.
+  if (ws.viewMode === 'single' && 'singleScreen' in ws) return singleScreenRoute(ws)
+  return focusedContentRoute(ws)
 }
 
 // The string app ids that are the active tab of one of `visibleLeaves` (or every

--- a/frontend/src/components/Shell/paneModel.js
+++ b/frontend/src/components/Shell/paneModel.js
@@ -430,21 +430,18 @@ function commitBounded(ws, candidate) {
 
 // Seed a single-pane workspace from today's flat open set. Tabs are sanitized,
 // deduped, and capped to the last MAX_PANE_TABS (legacy readOpenTabs posture);
-// the last tab is active (the on-screen one under the flat model). A fresh
-// workspace opens in the tiled 'panes' view-mode by default, but the SPLITS
-// KILL SWITCH clamps it to 'single' HERE — the same coercion the valid-blob path
-// gets in normalize() (M3). parseWorkspace returns this seed DIRECTLY on the
-// fresh/fallback/invalid paths without re-normalizing, so without the clamp the
-// seed keeps viewMode 'panes' while the presentation clamps to single: the raw-
-// viewMode reader `activeContentRoute` then projects the hidden BUILDER world
-// (focused pane) while single mode paints the SLOT — two conflicting worlds.
+// the last tab is active (the on-screen one under the flat model). A fresh or
+// fallback workspace starts in the standard single-screen world. Persisted valid
+// workspaces keep their chosen mode through normalize(); this seed is only used
+// when there is no usable workspace blob. parseWorkspace returns it DIRECTLY on
+// the fresh/fallback/invalid paths, so the seed itself must carry the render mode.
 export function seedFromFlatTabs(tabs) {
   const clean = capTabs(dedupTabs(sanitizeTabs(tabs)))
   const paneId = 'p0'
   const keys = clean.map(tabModel.tabKey)
   return {
     v: 1,
-    viewMode: coerceViewMode('panes'),
+    viewMode: coerceViewMode('single'),
     layout: paneId,
     panes: {
       [paneId]: {

--- a/tests/mode-transition.spec.mjs
+++ b/tests/mode-transition.spec.mjs
@@ -63,7 +63,8 @@ async function bootSeededWorkspace(page, viewport, ws) {
 // `slotKey` seeds the single-screen slot so an exit can be steered to a promote
 // (slot === a visible pane's active key) or a world reveal (slot tree-absent).
 function twoPaneBuilder(slot) {
-  let ws = paneModel.seedFromFlatTabs([{ kind: 'chat', id: 'aaa' }])
+  let ws = paneModel.setViewMode(
+    paneModel.seedFromFlatTabs([{ kind: 'chat', id: 'aaa' }]), 'panes')
   ws = paneModel.splitPaneWithTab(ws, tabModel.makeTab('chat', 'bbb'), { paneId: ws.focusedPaneId, edge: 'right' })
   const leftId = paneModel.paneOf(ws, 'chat:aaa').id
   ws = paneModel.focusPane(ws, leftId)
@@ -74,7 +75,8 @@ function twoPaneBuilder(slot) {
 // An intentionally asymmetric three-pane tree. Its natural edge vectors differ
 // enough to expose same-duration entry as visibly different pane velocities.
 function unevenThreePaneBuilder(slot) {
-  let ws = paneModel.seedFromFlatTabs([{ kind: 'chat', id: 'aaa' }])
+  let ws = paneModel.setViewMode(
+    paneModel.seedFromFlatTabs([{ kind: 'chat', id: 'aaa' }]), 'panes')
   ws = paneModel.splitPaneWithTab(ws, tabModel.makeTab('chat', 'bbb'), {
     paneId: ws.focusedPaneId, edge: 'right',
   })
@@ -755,7 +757,9 @@ test('round4-3: a superseding NULL-slot request drains after the older POST with
 // (logo/builder class) and the emptied tree flip in the SAME commit — never an
 // intermediate frame where builder is still true over an emptied single tree.
 test('v2 auto-return flips the descriptor and the tree atomically (no lagging frame)', async ({ page }) => {
-  await bootSeededWorkspace(page, WIDE, paneModel.seedFromFlatTabs([{ kind: 'chat', id: 'aaa' }]))
+  const builder = paneModel.setViewMode(
+    paneModel.seedFromFlatTabs([{ kind: 'chat', id: 'aaa' }]), 'panes')
+  await bootSeededWorkspace(page, WIDE, builder)
   await expect.poll(() => builderActive(page)).toBe(true)
   await expect(page.locator('.shell__tabstrip, .workspace__strip').first()).toBeVisible()
   // Sample builder-class vs strip-presence on every frame across the close.

--- a/tests/navigation.spec.mjs
+++ b/tests/navigation.spec.mjs
@@ -1422,6 +1422,7 @@ function twoAppPanes() {
   let ws = paneModel.seedFromFlatTabs([
     { kind: 'app', id: PANE_APP_A }, { kind: 'app', id: PANE_APP_B },
   ])
+  ws = paneModel.setViewMode(ws, 'panes')
   ws = paneModel.moveTab(ws, `app:${PANE_APP_B}`, { root: true, edge: 'right' })
   return paneModel.focusPane(ws, 'p0')
 }

--- a/tests/shell-update-idle.spec.mjs
+++ b/tests/shell-update-idle.spec.mjs
@@ -149,6 +149,7 @@ async function seedTwoPaneBuilder(page, firstChatId, secondChatId) {
     { kind: 'chat', id: firstChatId },
     { kind: 'chat', id: secondChatId },
   ])
+  workspace = paneModel.setViewMode(workspace, 'panes')
   workspace = paneModel.moveTab(workspace, `chat:${secondChatId}`, {
     root: true,
     edge: 'right',

--- a/tests/tabs.spec.mjs
+++ b/tests/tabs.spec.mjs
@@ -204,12 +204,14 @@ async function toggleAndSamplePaneChrome(page) {
   })
 }
 
-async function seedTabs(page, tabs, { viewMode } = {}) {
-  // Two-worlds: the strip is builder chrome only. Builder ('panes', the default)
-  // ALWAYS shows it — even at one tab — and single-screen NEVER does; there is no
+async function seedTabs(page, tabs, { viewMode = 'panes' } = {}) {
+  // Two-worlds: the strip is builder chrome only. This helper opts into Builder
+  // by default because every caller except the explicit single-mode case is a
+  // strip contract; production first boot now intentionally defaults to Standard.
+  // Builder always shows it — even at one tab — and single-screen never does; there is no
   // single-mode strip contract left to seed.
   let ws = paneModel.seedFromFlatTabs(tabs)
-  if (viewMode) ws = paneModel.setViewMode(ws, viewMode)
+  ws = paneModel.setViewMode(ws, viewMode)
   const workspace = paneModel.serializeWorkspace(ws)
   await page.addInitScript(([workspaceKey, workspaceRaw, legacyKey, t]) => {
     try {

--- a/tests/workspace-panes.spec.mjs
+++ b/tests/workspace-panes.spec.mjs
@@ -32,6 +32,10 @@ const PHONE = { width: 412, height: 760 }
 test.use({ serviceWorkers: 'block' })
 attachCleanup()
 
+function builderSeed(tabs) {
+  return paneModel.setViewMode(paneModel.seedFromFlatTabs(tabs), 'panes')
+}
+
 // A short, clean terminal stream: pins the user send with no streamed content.
 const EMPTY_STREAM = [{ type: 'catch_up_done' }, { type: 'done' }]
 // A long streamed reply so a chat can reach + hold FOLLOW_BOTTOM.
@@ -175,7 +179,7 @@ async function seedFallbackSingleLeaf(page) {
 
 /** Two chat panes side by side: p0 = chatA (focused), p1 = chatB. */
 function twoChatPanes(chatA, chatB) {
-  let ws = paneModel.seedFromFlatTabs([
+  let ws = builderSeed([
     { kind: 'chat', id: chatA }, { kind: 'chat', id: chatB },
   ])
   ws = paneModel.moveTab(ws, `chat:${chatB}`, { root: true, edge: 'right' })
@@ -492,7 +496,7 @@ test.describe('Workspace panes (PR2 gate)', () => {
     await mockApps(page, [])
     await exposeChatsInDrawer(page, [a.id, b.id, c.id, d.id, e.id])
 
-    let ws = paneModel.seedFromFlatTabs([
+    let ws = builderSeed([
       { kind: 'chat', id: a.id }, { kind: 'chat', id: b.id },
       { kind: 'chat', id: c.id }, { kind: 'chat', id: d.id },
       { kind: 'chat', id: e.id },
@@ -548,7 +552,7 @@ test.describe('Workspace panes (PR2 gate)', () => {
 
     // p0 = [chatA, app] (app active), p1 = [chatB]. Moving the app to p1 keeps
     // both panes (chatA survives in p0), so it is a true cross-pane move.
-    let ws = paneModel.seedFromFlatTabs([
+    let ws = builderSeed([
       { kind: 'chat', id: b.id }, { kind: 'chat', id: a.id }, { kind: 'app', id: APP_ID },
     ])
     ws = paneModel.moveTab(ws, `chat:${b.id}`, { root: true, edge: 'right' })
@@ -602,7 +606,7 @@ test.describe('Workspace panes (PR2 gate)', () => {
     // A depth-2 tree row(p0, col(p1, p2)) where p1 holds two tabs. p1 is at the
     // depth cap, so canSplit is false on every edge even though the pane has ≥2
     // tabs (which is what would otherwise offer a split).
-    let ws = paneModel.seedFromFlatTabs([
+    let ws = builderSeed([
       { kind: 'chat', id: a.id }, { kind: 'chat', id: c.id },
       { kind: 'chat', id: d.id }, { kind: 'chat', id: b.id },
     ])
@@ -690,7 +694,7 @@ test.describe('Workspace panes (PR2 gate)', () => {
 // p0 = [chatA, chatC] (focused, C active), p1 = [chatB]. A two-tab source pane
 // so a drag OUT of it leaves the pane alive and the moves are unambiguous.
 function twoPanesThreeTabs(a, b, c) {
-  let ws = paneModel.seedFromFlatTabs([
+  let ws = builderSeed([
     { kind: 'chat', id: a }, { kind: 'chat', id: b }, { kind: 'chat', id: c },
   ])
   ws = paneModel.moveTab(ws, `chat:${b}`, { root: true, edge: 'right' })
@@ -698,7 +702,7 @@ function twoPanesThreeTabs(a, b, c) {
 }
 
 function twoStackedPanesThreeTabs(a, b, c) {
-  let ws = paneModel.seedFromFlatTabs([
+  let ws = builderSeed([
     { kind: 'chat', id: a }, { kind: 'chat', id: b }, { kind: 'chat', id: c },
   ])
   ws = paneModel.moveTab(ws, `chat:${b}`, { root: true, edge: 'bottom' })
@@ -706,7 +710,7 @@ function twoStackedPanesThreeTabs(a, b, c) {
 }
 
 function singlePaneThreeTabs(a, b, c) {
-  return paneModel.seedFromFlatTabs([
+  return builderSeed([
     { kind: 'chat', id: a }, { kind: 'chat', id: b }, { kind: 'chat', id: c },
   ])
 }
@@ -1335,7 +1339,7 @@ test.describe('Workspace view-mode toggle', () => {
   // single-mode + ONE leaf: dragging stays enabled; the drop's shape decides
   // split-vs-join, but ANY drop commits builder mode (point 15).
   function singleLeafTwoTabs(a, b) {
-    let ws = paneModel.seedFromFlatTabs([{ kind: 'chat', id: a }, { kind: 'chat', id: b }])
+    let ws = builderSeed([{ kind: 'chat', id: a }, { kind: 'chat', id: b }])
     return paneModel.setViewMode(paneModel.focusPane(ws, 'p0'), 'single')
   }
 
@@ -1605,7 +1609,7 @@ test.describe('Logo activation + middle-click', () => {
     const b = await createTaggedChat(page, 'midB')
     await mockApps(page, [])
     // A single-pane workspace with two tabs renders the top strip.
-    await seedWorkspace(page, paneModel.seedFromFlatTabs([
+    await seedWorkspace(page, builderSeed([
       { kind: 'chat', id: a.id }, { kind: 'chat', id: b.id },
     ]))
     await page.goto(`${BASE}/shell/?chat=${a.id}`, { waitUntil: 'domcontentloaded' })


### PR DESCRIPTION
## Summary
- start fresh and fallback workspaces in Standard mode while preserving every valid saved mode
- keep the visible fallback chat or app and the navigation route aligned on first boot
- make Builder-only end-to-end scenarios enter Builder explicitly instead of inheriting a product default

## Testing
- `npm test` (1,989 frontend tests + 63 hook tests)
- `npm run build`
- syntax-checked every adjusted Playwright scenario
- full hosted backend and browser suites are running on this revision
