### PR TITLE
Declare the server timezone in the app schedules response

### DIFF
--- a/backend/app/routes/apps.py
+++ b/backend/app/routes/apps.py
@@ -724,6 +724,12 @@ def list_app_schedules(
 ):
   """Returns read-only recurring app schedules visible to owners and apps."""
   live_crontab = _read_live_crontab()
+  # Cron entries run in the server's local timezone; report which one so
+  # schedule UIs can show the time in terms the owner understands.
+  now = datetime.now().astimezone()
+  offset = now.utcoffset()
+  tz_offset_minutes = int(offset.total_seconds() // 60) if offset else 0
+  tz_name = now.tzname() or "UTC"
   rows = []
   apps = (
     db.query(models.App)
@@ -742,6 +748,8 @@ def list_app_schedules(
       slug=app.slug,
       cron=cron,
       job=job,
+      tz_name=tz_name,
+      tz_offset_minutes=tz_offset_minutes,
     ))
   return rows
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -236,7 +236,12 @@ class AppScheduleUpdate(BaseModel):
 
 
 class AppScheduleOut(BaseModel):
-  """Read-only metadata for an installed app's recurring cron job."""
+  """Read-only metadata for an installed app's recurring cron job.
+
+  ``cron`` is interpreted in the server's local timezone; ``tz_name`` and
+  ``tz_offset_minutes`` declare which one that is so UIs can translate the
+  time honestly. Defaults describe the conventional UTC container.
+  """
 
   id: int
   name: str
@@ -244,6 +249,8 @@ class AppScheduleOut(BaseModel):
   cron: str
   job: str
   next_run: datetime | None = None
+  tz_name: str = "UTC"
+  tz_offset_minutes: int = 0
 
 
 class ConflictFile(BaseModel):

--- a/backend/tests/test_apps.py
+++ b/backend/tests/test_apps.py
@@ -309,6 +309,9 @@ def test_app_schedules_are_readable_by_app_tokens(client, auth):
     headers={"Authorization": f"Bearer {token}"},
   )
   assert r.status_code == 200, r.text
+  from datetime import datetime
+  now = datetime.now().astimezone()
+  server_offset = now.utcoffset()
   assert r.json() == [{
     "id": 1,
     "name": "News",
@@ -316,6 +319,10 @@ def test_app_schedules_are_readable_by_app_tokens(client, auth):
     "cron": "0 10 * * *",
     "job": "fetch.sh",
     "next_run": None,
+    "tz_name": now.tzname() or "UTC",
+    "tz_offset_minutes": (
+      int(server_offset.total_seconds() // 60) if server_offset else 0
+    ),
   }]
 
 


### PR DESCRIPTION
Cron schedules are interpreted in the server's local timezone, but `GET /api/apps/schedules` never said which one that is — so schedule UIs (e.g. the Memory app's run-time setting) could only show a bare wall-clock time the owner couldn't place.

Each schedule row now carries `tz_name` and `tz_offset_minutes` describing the server's current local timezone, computed once per request from the system clock. Schema defaults describe the conventional UTC container, so existing constructors and older clients are unaffected; the change is purely additive.

A companion app-memory PR (“Show the maintenance run time with AM/PM and a timezone picker”) consumes these fields; it falls back to UTC against an older backend, so the two can land independently.

Tested: `test_app_schedules_are_readable_by_app_tokens` now pins the exact response including the new fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)