### PR TITLE
Show expandable active goals in the chat progress rail

### DIFF
--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -1725,6 +1725,7 @@
 .chat__foot .chat__question-nudge,
 .chat__foot .chat__resume-nudge,
 .chat__foot .chat__open-app,
+.chat__foot .chat__progress-step--toggle,
 .chat__foot .chat__pill,
 .chat__foot .composer-plus { pointer-events: auto; }
 

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -2581,17 +2581,17 @@
   to   { box-shadow: inset 0 0 0 2px transparent; }
 }
 
-/* ── Build-milestone rail ──────────────────────────── */
-/* A slim, non-interactive progress rail in the foot, directly above the composer:
-   one dot+label per milestone the building agent emitted this turn. Attention,
-   connection, queue, and open-app notices deliberately stack ABOVE this rail so
-   nothing interrupts its relationship to the chat controls. Frosted so it reads
-   as a card over the chat scrolling behind the transparent foot, muted so it
-   stays quiet next to the composer. The most recent phase is emphasized; earlier
-   ones dim to compact history. Entrance is transform/opacity ONLY — the foot's
-   ResizeObserver publishes --composer-h off its height, so a height animation
-   would fight the composer clearance. */
-.chat__build-rail {
+/* ── Goal/build progress rail ──────────────────────── */
+/* A slim progress rail in the foot, directly above the composer:
+   the active goal (when present) followed by each build milestone emitted this
+   turn. Attention, connection, queue, and open-app notices deliberately stack
+   ABOVE this rail so nothing interrupts its relationship to the chat controls.
+   Frosted so it reads as a card over the chat scrolling behind the transparent
+   foot, muted so it stays quiet next to the composer. The most recent phase is
+   emphasized; earlier ones dim to compact history. Entrance is
+   transform/opacity ONLY — the foot's ResizeObserver publishes --composer-h off
+   its height, so a height animation would fight the composer clearance. */
+.chat__progress-rail {
   max-width: 720px;
   margin: 0 auto 8px;
   display: flex;
@@ -2606,46 +2606,78 @@
   -webkit-backdrop-filter: blur(16px) saturate(140%);
   font-size: 12px;
   line-height: 1.3;
-  animation: build-rail-in 0.22s ease both;
+  animation: progress-rail-in 0.22s ease both;
 }
 
-@keyframes build-rail-in {
+@keyframes progress-rail-in {
   from { opacity: 0; transform: translateY(6px); }
   to { opacity: 1; transform: none; }
 }
 
-.chat__build-phase {
+.chat__progress-step {
   display: inline-flex;
   align-items: center;
   gap: 6px;
   min-width: 0;
+  max-width: 100%;
   color: var(--muted); /* CONTRACT: low-contrast text — earlier phases read as dim history */
 }
 
-.chat__build-phase-label {
+.chat__progress-step-label {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
+.chat__progress-step--button {
+  appearance: none;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  font: inherit;
+  text-align: left;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.chat__progress-step--toggle {
+  cursor: pointer;
+}
+
+.chat__progress-step--toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+  border-radius: 3px;
+}
+
+.chat__progress-step--expanded {
+  flex-basis: 100%;
+}
+
+.chat__progress-step--expanded .chat__progress-step-label {
+  overflow: visible;
+  text-overflow: clip;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
 /* Milestones separate with a small neutral "›" (text-first — the dots were
    retired 2026-07-17, owner spec); the most recent phase carries the eye with
    full-contrast weight. */
-.chat__build-phase + .chat__build-phase::before {
+.chat__progress-step + .chat__progress-step::before {
   content: "›";
   color: var(--muted);
   margin-right: 8px;
   font-weight: 400;
 }
 
-.chat__build-phase--current {
+.chat__progress-step--current {
   color: var(--text); /* CONTRACT: high-contrast text on the current milestone */
   font-weight: 600;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .chat__build-rail,
+  .chat__progress-rail,
   .chat__copy-toast { animation: none; }
   .chat__send,
   .chat__steer,

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -30,6 +30,7 @@ import AgentContextInspector from './AgentContextInspector.jsx'
 import ChatSummaryViewer from './ChatSummaryViewer.jsx'
 import ComposerPopover from './ComposerPopover.jsx'
 import ConnectionStatus from './ConnectionStatus.jsx'
+import ProgressRail from './ProgressRail.jsx'
 import ActiveAssistantSurface from './ActiveAssistantSurface.jsx'
 import QueuedMessages from './QueuedMessages.jsx'
 import ContributionReviewCard from './ContributionReviewCard.jsx'
@@ -105,6 +106,11 @@ import {
   latestBuildPhaseAnnouncement,
   railAtRunStart,
 } from './buildPhaseRail.js'
+import {
+  goalObjectiveFromText,
+  latestGoalObjective,
+  progressRailViewModel,
+} from './goalProgress.js'
 import './ChatView.css'
 
 
@@ -451,6 +457,19 @@ export default function ChatView({
   const [buildPhases, setBuildPhases] = useState(EMPTY_BUILD_PHASE_RAIL)
   const [buildPhaseStatus, setBuildPhaseStatus] = useState('')
   const lastAnnouncedPhaseRef = useRef(null)
+  // The active goal is run-scoped, just like build phases. It is set at every
+  // real run-start seam and left intact across mid-turn steers; a fresh mount
+  // can recover it from the visible run-start message once liveness is known.
+  const [activeGoalObjective, setActiveGoalObjective] = useState(
+    () => cached?.running ? (cached?.activeGoalObjective ?? '') : '',
+  )
+  const setActiveGoalState = useCallback((objective) => {
+    setActiveGoalObjective(objective)
+    queryClient.setQueryData(chatMessagesQueryKey(chatId), existing => {
+      if (existing?.activeGoalObjective === objective) return existing
+      return { ...(existing || {}), activeGoalObjective: objective }
+    })
+  }, [chatId, queryClient])
 
   useEffect(() => () => {
     if (timestampTimerRef.current) clearTimeout(timestampTimerRef.current)
@@ -530,7 +549,11 @@ export default function ChatView({
     restartResumeSavingRef.current = false
     setRestartResumeSaving(false)
     setRestartResumeError('')
-  }, [chatId])
+    setActiveGoalObjective(
+      queryClient.getQueryData(chatMessagesQueryKey(chatId))
+        ?.activeGoalObjective ?? '',
+    )
+  }, [chatId, queryClient])
 
   const handleAutoResumeChange = useCallback(async (next, source = 'card') => {
     if (autoResumeSavingRef.current) return
@@ -1250,6 +1273,7 @@ export default function ChatView({
       // position the live stream did (old-run phases, then reset) and the
       // rail always lands on the run being displayed.
       setBuildPhases(railAtRunStart())
+      setActiveGoalState(goalObjectiveFromText(message?.content))
       const consumedCids = message?._consumed_cids
       const serverRows = Array.isArray(message?._messages)
         ? message._messages.map(stripInternalUserMessageFields).filter(Boolean)
@@ -2230,6 +2254,7 @@ export default function ChatView({
             // the rail resets. A plain enqueue (started falsy) must NOT
             // touch the in-flight build's rail.
             setBuildPhases(railAtRunStart())
+            setActiveGoalState(goalObjectiveFromText(text))
             setSending(true)
             setServerRunningState(true)
             // The queued send was promoted straight into the active turn, so
@@ -2307,6 +2332,7 @@ export default function ChatView({
           // Same run-start semantics as the branch above: this send became
           // the first message of a NEW run, so the rail resets here too.
           setBuildPhases(railAtRunStart())
+          setActiveGoalState(goalObjectiveFromText(text))
           // Apply the send rule before appending — see shouldPinSend and
           // the fresh-send path. A message that raced into a started turn
           // is still a new send becoming the active turn, so it pins only
@@ -2384,6 +2410,7 @@ export default function ChatView({
     // above) wiped the in-flight build's rail, which the next catch-up
     // replay then silently repopulated (see buildPhaseRail.js).
     setBuildPhases(railAtRunStart())
+    setActiveGoalState(goalObjectiveFromText(text))
 
     // Direct sends use the same submit-time decision as queued/steered sends.
     // A legitimate pin changes FOLLOW_BOTTOM to PIN_USER_MSG, so reply growth
@@ -2572,6 +2599,7 @@ export default function ChatView({
     restoreFiles,
     releaseFiles,
     online,
+    setActiveGoalState,
   ])
 
   useEffect(() => {
@@ -3288,6 +3316,21 @@ export default function ChatView({
   // (The fast-forward affordance is computed separately at `canSteer` below.)
   const turnActive = sending || isStreaming || serverRunning
   useEffect(() => {
+    if (!turnActive) {
+      if (activeGoalObjective) setActiveGoalState('')
+      return
+    }
+    // Ordinary live turns set this synchronously at their run-start seam. This
+    // branch is the cold remount/reconnect recovery path. The query cache
+    // retains a known goal across keyed chat switches, including after a
+    // steer; latestGoalObjective covers a truly cold attach before this client
+    // has seen that run.
+    if (!activeGoalObjective) {
+      const recovered = latestGoalObjective(messages)
+      if (recovered) setActiveGoalState(recovered)
+    }
+  }, [turnActive, messages, activeGoalObjective, setActiveGoalState])
+  useEffect(() => {
     function freezeStreamingReturn() {
       if (typeof document !== 'undefined'
           && document.visibilityState
@@ -3695,7 +3738,9 @@ export default function ChatView({
     return 'Turn paused — Resume available.'
   })()
   const ariaStatus = turnActive
-    ? 'Assistant is responding…'
+    ? (activeGoalObjective
+        ? `Following goal: ${activeGoalObjective}.`
+        : 'Assistant is responding…')
     : (resumeStatus
         ?? (messages.length > 0
             && messages[messages.length - 1]?.role === 'assistant'
@@ -3707,6 +3752,11 @@ export default function ChatView({
     .map(app => ({ app, vm: openAppCtaViewModel(app, turnActive) }))
     .filter(entry => entry.vm)
   const buildPhaseRail = buildPhaseRailViewModel(buildPhases)
+  const visibleGoalObjective = turnActive ? activeGoalObjective : ''
+  const progressRail = progressRailViewModel(
+    visibleGoalObjective,
+    buildPhaseRail,
+  )
   let lastVisibleMessageIndex = -1
   for (let i = messages.length - 1; i >= 0; i -= 1) {
     if (!messages[i].hidden) {
@@ -4084,21 +4134,10 @@ export default function ChatView({
                 : 'Turn paused — tap to resume'}
             </button>
           )}
-          {buildPhaseRail.length > 0 && (
-            <div className="chat__build-rail" role="group" aria-label="Build progress">
-              {buildPhaseRail.map(phase => (
-                <span
-                  key={phase.ts}
-                  className={`chat__build-phase${
-                    phase.current ? ' chat__build-phase--current' : ''
-                  }`}
-                  aria-current={phase.current ? 'step' : undefined}
-                >
-                  <span className="chat__build-phase-label">{phase.label}</span>
-                </span>
-              ))}
-            </div>
-          )}
+          <ProgressRail
+            items={progressRail}
+            ariaLabel={visibleGoalObjective ? 'Goal progress' : 'Build progress'}
+          />
           </>
         )}
         {/* Contribution staged from THIS chat: approve it where the work

--- a/frontend/src/components/ChatView/ProgressRail.jsx
+++ b/frontend/src/components/ChatView/ProgressRail.jsx
@@ -1,0 +1,85 @@
+/* ProgressRail renders the shared compact status sequence above the composer. */
+
+import { useLayoutEffect, useRef, useState } from 'react'
+
+function ProgressStep({ item }) {
+  const stepRef = useRef(null)
+  const labelRef = useRef(null)
+  const [expanded, setExpanded] = useState(false)
+  const [canExpand, setCanExpand] = useState(false)
+
+  useLayoutEffect(() => {
+    setExpanded(false)
+    setCanExpand(false)
+  }, [item.label])
+
+  useLayoutEffect(() => {
+    const step = stepRef.current
+    const label = labelRef.current
+    if (!step || !label || expanded || !item.expandable) return undefined
+
+    const measure = () => {
+      setCanExpand(label.scrollWidth > step.clientWidth + 1)
+    }
+    measure()
+
+    if (typeof ResizeObserver === 'undefined') return undefined
+    const observer = new ResizeObserver(measure)
+    observer.observe(step)
+    return () => observer.disconnect()
+  }, [expanded, item.expandable, item.label])
+
+  const toggleable = item.expandable && (canExpand || expanded)
+  const className = `chat__progress-step${
+    item.current ? ' chat__progress-step--current' : ''
+  }${toggleable ? ' chat__progress-step--toggle' : ''}${
+    expanded ? ' chat__progress-step--expanded' : ''
+  }`
+  const label = (
+    <span ref={labelRef} className="chat__progress-step-label">
+      {item.label}
+    </span>
+  )
+
+  if (!item.expandable) {
+    return (
+      <span
+        ref={stepRef}
+        className={className}
+        aria-current={item.current ? 'step' : undefined}
+        title={item.label}
+      >
+        {label}
+      </span>
+    )
+  }
+
+  return (
+    <button
+      ref={stepRef}
+      type="button"
+      className={`${className} chat__progress-step--button`}
+      aria-current={item.current ? 'step' : undefined}
+      aria-expanded={expanded}
+      aria-label={toggleable
+        ? `${expanded ? 'Collapse' : 'Expand'}: ${item.label}`
+        : item.label}
+      title={toggleable ? (expanded ? 'Collapse' : item.label) : item.label}
+      disabled={!toggleable}
+      onClick={() => setExpanded(value => !value)}
+    >
+      {label}
+    </button>
+  )
+}
+
+export default function ProgressRail({ items, ariaLabel }) {
+  if (!items.length) return null
+  return (
+    <div className="chat__progress-rail" role="group" aria-label={ariaLabel}>
+      {items.map(item => (
+        <ProgressStep key={item.key} item={item} />
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/ChatView/__tests__/goalProgress.test.js
+++ b/frontend/src/components/ChatView/__tests__/goalProgress.test.js
@@ -10,6 +10,7 @@ import {
 
 const chatView = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8')
 const progressRail = readFileSync(new URL('../ProgressRail.jsx', import.meta.url), 'utf8')
+const chatCss = readFileSync(new URL('../ChatView.css', import.meta.url), 'utf8')
 
 test('goalObjectiveFromText follows the backend command boundary', () => {
   assert.equal(goalObjectiveFromText('/goal Ship the review'), 'Ship the review')
@@ -103,6 +104,11 @@ test('ChatView binds goal state to the existing run-start and turn-end lifecycle
   assert.match(progressRail, /chat__progress-rail/)
   assert.match(progressRail, /aria-expanded=\{expanded\}/)
   assert.match(progressRail, /label\.scrollWidth > step\.clientWidth/)
+  assert.match(
+    chatCss,
+    /\.chat__foot \.chat__progress-step--toggle[\s\S]*?\{ pointer-events: auto; \}/,
+    'an expandable step must opt back into pointer input inside the transparent footer',
+  )
   assert.doesNotMatch(progressRail, /goal|build/i,
     'the shared rail should not encode one producer’s domain')
 })

--- a/frontend/src/components/ChatView/__tests__/goalProgress.test.js
+++ b/frontend/src/components/ChatView/__tests__/goalProgress.test.js
@@ -1,0 +1,108 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+import {
+  goalObjectiveFromText,
+  latestGoalObjective,
+  progressRailViewModel,
+} from '../goalProgress.js'
+
+const chatView = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8')
+const progressRail = readFileSync(new URL('../ProgressRail.jsx', import.meta.url), 'utf8')
+
+test('goalObjectiveFromText follows the backend command boundary', () => {
+  assert.equal(goalObjectiveFromText('/goal Ship the review'), 'Ship the review')
+  assert.equal(
+    goalObjectiveFromText('\n/goal   Build the first slice\nthen verify it'),
+    'Build the first slice then verify it',
+  )
+  assert.equal(goalObjectiveFromText('please /goal later'), '')
+  assert.equal(goalObjectiveFromText(' /goal indented is prose'), '')
+  assert.equal(goalObjectiveFromText('/data/apps/x'), '')
+})
+
+test('goalObjectiveFromText does not present clear or an empty command as active', () => {
+  assert.equal(goalObjectiveFromText('/goal'), '')
+  assert.equal(goalObjectiveFromText('/goal   '), '')
+  assert.equal(goalObjectiveFromText('/goal clear'), '')
+  assert.equal(goalObjectiveFromText('/goal CLEAR'), '')
+})
+
+test('latestGoalObjective recovers only the latest visible owner turn', () => {
+  assert.equal(latestGoalObjective([
+    { role: 'user', content: '/goal old objective' },
+    { role: 'assistant', content: 'Done' },
+    { role: 'user', content: 'ordinary follow-up' },
+  ]), '')
+  assert.equal(latestGoalObjective([
+    { role: 'user', content: '/goal build the indicator' },
+    { role: 'user', content: 'hidden answer', hidden: true },
+    { role: 'assistant', content: 'Working', partial: true },
+  ]), 'build the indicator')
+})
+
+test('the goal reuses the progress rail and stays as context for build phases', () => {
+  assert.deepEqual(
+    progressRailViewModel('Build the indicator', []),
+    [{
+      key: 'goal',
+      label: 'Goal · Build the indicator',
+      current: true,
+      expandable: true,
+    }],
+  )
+  assert.deepEqual(
+    progressRailViewModel('Build the indicator', [
+      { ts: 1, label: 'First slice ready' },
+      { ts: 2, label: 'Verifying' },
+    ]),
+    [
+      {
+        key: 'goal',
+        label: 'Goal · Build the indicator',
+        current: false,
+        expandable: true,
+      },
+      { key: 'phase-1', label: 'First slice ready', current: false },
+      { key: 'phase-2', label: 'Verifying', current: true },
+    ],
+  )
+})
+
+test('ChatView binds goal state to the existing run-start and turn-end lifecycle', () => {
+  const runStarts = chatView.split('setBuildPhases(railAtRunStart())').slice(1)
+  assert.equal(runStarts.length, 4, 'every current run-start seam should be covered')
+  for (const suffix of runStarts) {
+    assert.match(
+      suffix.slice(0, 260),
+      /setActiveGoalState\(goalObjectiveFromText\(/,
+      'goal and build progress must reset together at each run boundary',
+    )
+  }
+  assert.match(
+    chatView,
+    /if \(!turnActive\) \{\s*if \(activeGoalObjective\) setActiveGoalState\(''\)/,
+    'a completed or stopped turn must retire its goal indication',
+  )
+  assert.match(
+    chatView,
+    /activeGoalObjective: objective/,
+    'the existing chat cache should retain a goal across chat switches and steers',
+  )
+  assert.match(
+    chatView,
+    /<ProgressRail\s+items=\{progressRail\}/,
+    'the goal should render through the shared progress rail',
+  )
+  assert.match(
+    chatView,
+    /`Following goal: \$\{activeGoalObjective\}\.`/,
+    'screen readers should receive the same active-goal status',
+  )
+  assert.match(progressRail, /chat__progress-rail/)
+  assert.match(progressRail, /aria-expanded=\{expanded\}/)
+  assert.match(progressRail, /label\.scrollWidth > step\.clientWidth/)
+  assert.doesNotMatch(progressRail, /goal|build/i,
+    'the shared rail should not encode one producer’s domain')
+})

--- a/frontend/src/components/ChatView/__tests__/offlineFooter.test.js
+++ b/frontend/src/components/ChatView/__tests__/offlineFooter.test.js
@@ -11,7 +11,7 @@ test('footer stacks offline note → notices → rail → connection → queued 
   const footStart = chatView.indexOf('<div ref={footRef} className="chat__foot">')
   const composer = chatView.indexOf('<ChatInputBar', footStart)
   const foot = chatView.slice(footStart, composer)
-  const rail = foot.indexOf('className="chat__build-rail"')
+  const rail = foot.indexOf('<ProgressRail')
   const queued = foot.indexOf('<QueuedMessages')
   const connection = foot.indexOf('<ConnectionStatus')
   const offline = foot.indexOf('className="chat__offline-note"')
@@ -22,7 +22,7 @@ test('footer stacks offline note → notices → rail → connection → queued 
     'the complete footer stack must be present',
   )
   assert.ok(offline < connection, 'the offline explanation stacks above connection/retry')
-  assert.ok(rail < connection, 'the build rail stacks above connection/retry')
+  assert.ok(rail < connection, 'the progress rail stacks above connection/retry')
   assert.ok(connection < queued, 'connection/retry stacks directly above the queued input tray')
   for (const notice of [
     'className="chat__open-app"',
@@ -32,7 +32,7 @@ test('footer stacks offline note → notices → rail → connection → queued 
     const noticeIndex = foot.indexOf(notice)
     assert.ok(noticeIndex >= 0, `${notice} must be present in the footer`)
     assert.ok(noticeIndex < rail,
-      `${notice} must stack above the build rail`)
+      `${notice} must stack above the progress rail`)
   }
 })
 

--- a/frontend/src/components/ChatView/goalProgress.js
+++ b/frontend/src/components/ChatView/goalProgress.js
@@ -1,0 +1,66 @@
+/* Goal-command parsing and the shared footer progress-rail view model. */
+
+/**
+ * Return the objective carried by a real leading `/goal` command.
+ *
+ * The backend intentionally recognizes commands only at character zero (with
+ * leading newlines tolerated), so the indicator follows that same boundary
+ * instead of lighting up for ordinary prose that happens to mention `/goal`.
+ * Whitespace is collapsed because the footer is a one-line status surface.
+ */
+export function goalObjectiveFromText(text) {
+  if (typeof text !== 'string') return ''
+  const normalized = text.replace(/^\n+/, '')
+  const match = normalized.match(/^\/goal(?:[ \t]+([\s\S]*))?$/)
+  if (!match) return ''
+  const objective = (match[1] || '').trim().replace(/\s+/g, ' ')
+  if (!objective || objective.toLowerCase() === 'clear') return ''
+  return objective
+}
+
+/**
+ * Recover a goal when mounting into a turn that is already running.
+ *
+ * The latest visible owner message is the run-start message on an ordinary
+ * attach. Live steers do not replace the in-memory goal state; this fallback is
+ * only for a fresh mount/reconnect where that local state does not yet exist.
+ */
+export function latestGoalObjective(messages) {
+  if (!Array.isArray(messages)) return ''
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const message = messages[i]
+    if (message?.role !== 'user' || message.hidden) continue
+    return goalObjectiveFromText(message.content)
+  }
+  return ''
+}
+
+/**
+ * Put the active goal and ordinary build phases on one existing progress rail.
+ *
+ * The last item is current: before a build phase arrives that is the goal
+ * itself; afterwards the goal remains as quiet context while the newest phase
+ * carries emphasis.
+ */
+export function progressRailViewModel(goalObjective, buildPhases) {
+  const items = []
+  if (goalObjective) {
+    items.push({
+      key: 'goal',
+      label: `Goal · ${goalObjective}`,
+      expandable: true,
+    })
+  }
+  for (const phase of Array.isArray(buildPhases) ? buildPhases : []) {
+    if (!phase?.label) continue
+    items.push({
+      key: `phase-${phase.ts}`,
+      label: phase.label,
+    })
+  }
+  const lastIndex = items.length - 1
+  return items.map((item, index) => ({
+    ...item,
+    current: index === lastIndex,
+  }))
+}

--- a/tests/attention-nudges.spec.mjs
+++ b/tests/attention-nudges.spec.mjs
@@ -152,7 +152,7 @@ for (const scenario of SCENARIOS) {
     })
     const nudge = page.locator(scenario.nudgeSelector)
     await expect(nudge).toBeVisible({ timeout: 5000 })
-    const rail = page.locator('.chat__build-rail')
+    const rail = page.locator('.chat__progress-rail')
     const composer = page.locator('.chat__pill')
     await expect(rail).toBeVisible({ timeout: 5000 })
 


### PR DESCRIPTION
## Summary

- show the active `/goal` objective in the compact progress rail above the composer
- let truncated goals expand and collapse by click or keyboard while short goals remain quiet
- keep the goal visible across mid-turn steering and cached chat remounts
- reuse the same rail for build milestones, then retire the goal when the run settles or stops
- announce the active objective through the chat's existing accessible status

## Testing

- `npm test`
- `npm run build`
- focused goal, build-rail, and footer lifecycle tests
- rendered expand-and-collapse verification in the live shell