### PR TITLE
Make Send transition directly into Steer

### DIFF
--- a/frontend/src/components/ChatView/ChatInputBar.jsx
+++ b/frontend/src/components/ChatView/ChatInputBar.jsx
@@ -105,30 +105,31 @@ let _isTouchPrimary = _touchMql?.matches ?? false
 _touchMql?.addEventListener('change', (e) => { _isTouchPrimary = e.matches })
 
 
-/** The primary action button — FastForward / Send / Stop / Mic —
+/** The primary action button — Steer / Send / Stop / Mic —
  *  auto-resolved from the bar's input/sending/listening/uploading state.
  *
- *  When there are queued messages ready to try (`canSteer`), the Stop square
- *  is swapped for a fast-forward button. The handler reconciles server state
- *  before acting: if a live turn exists, it injects the queued messages into
- *  that turn; if local running state was stale, this still gives the user one
- *  immediate affordance instead of waiting for focus/remount to reveal it.
- *  Stop is NOT lost: clearing the queue (the tray's X) flips canSteer back to
+ *  When queued work exists (`showSteer`), the Stop square is swapped for a
+ *  fast-forward button immediately — including the brief persistence
+ *  round-trip. Its handler waits for that write before acting, so the semantic
+ *  control does not flash Send → Stop → Steer while the server confirms it.
+ *  Stop is NOT lost: clearing the queue (the tray's X) flips showSteer back to
  *  false and the Stop square returns, and while the composer has text the Send
  *  button (queue-another) still wins over both.
  *
- *  Each state's button carries a distinct `key`, and that is load-bearing:
- *  state swaps replace the semantic control, while the shared `.chat__action`
- *  base keeps geometry and box model stable across Send / Stop / Steer / Mic. */
+ *  Send and Steer are two states of the same forward action. They deliberately
+ *  share the `forward` key so React preserves the accent circle and swaps only
+ *  its icon, label, and handler—there must be no empty/black replacement frame.
+ *  Stop and Mic remain distinct controls because their semantics and visual
+ *  shells genuinely differ. */
 function PrimaryAction({
-  sending, listening, hasInput, hasUploading, offline, canSteer,
+  sending, listening, hasInput, hasUploading, offline, showSteer, steerReady,
   submissionBlocked,
   onSubmit, onStop, onSteer, onToggleVoice,
 }) {
-  if (sending && !hasInput && canSteer) {
+  if (sending && !hasInput && showSteer) {
     return (
       <button
-        key="steer"
+        key="forward"
         className="chat__action chat__steer"
         type="button"
         // Keep focus stable through pointerdown, then let ChatView dismiss
@@ -138,6 +139,8 @@ function PrimaryAction({
         onTouchEnd={(e) => { e.preventDefault(); onSteer() }}
         onClick={onSteer}
         aria-label="Send queued message now"
+        aria-busy={!steerReady}
+        disabled={!steerReady}
       >
         <DoubleChevronRight width={20} height={20} />
       </button>
@@ -167,7 +170,7 @@ function PrimaryAction({
   if (hasInput && !listening) {
     return (
       <button
-        key="send"
+        key="forward"
         className="chat__action chat__send"
         type="button"
         // Keep the textarea focused until ChatView snapshots the scroll
@@ -405,10 +408,11 @@ function FileChips({ files, onRemove, chatId }) {
  *   onStop             — stop button handler
  *   onSteer            — fast-forward handler (steer queued msgs into the
  *                        live turn). Shown in place of Stop while a turn
- *                        is streaming AND `canSteer` is true.
- *   canSteer           — true when there are queued messages that can be
- *                        steered right now (all server-confirmed). Drives
- *                        the FastForward-vs-Stop choice in PrimaryAction.
+ *                        is streaming AND `showSteer` is true.
+ *   showSteer          — true as soon as queued work exists for a live turn;
+ *                        drives the Steer-vs-Stop identity without waiting for
+ *                        the queue persistence round-trip.
+ *   steerReady         — false only while a steer tap is already in flight.
  *   canRequestSteer    — true when the keyboard shortcut may ask the
  *                        existing steer handler to reconcile/steer queued
  *                        messages, even before the visual fast-forward gate
@@ -453,6 +457,8 @@ export default function ChatInputBar({
   onStop,
   onSteer,
   canSteer,
+  showSteer = canSteer,
+  steerReady = true,
   canRequestSteer = canSteer,
   canSubmitSteer = canRequestSteer,
   offline,
@@ -739,7 +745,8 @@ export default function ChatInputBar({
               hasInput={hasInput}
               hasUploading={hasUploading}
               offline={offline}
-              canSteer={canSteer}
+              showSteer={showSteer}
+              steerReady={steerReady}
               submissionBlocked={submissionBlocked}
               onSubmit={handleSubmit}
               onStop={onStop}

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -1878,10 +1878,10 @@
     transform 0.08s ease;
 }
 
-/* Primary meanings share one slot. Hold the replacement invisible for a
-   brief beat so Send/Fast-forward clears before Stop is revealed. */
-.chat__send,
-.chat__steer,
+/* Stop is a destructive replacement, so let the prior forward icon clear
+   before revealing it. Send and Steer intentionally do NOT use this animation:
+   they share one forward-action DOM identity and the accent shell must remain
+   continuously visible while only its arrow icon changes. */
 .chat__stop {
   animation: chat-action-reveal 0.16s ease-out both;
 }
@@ -1948,6 +1948,9 @@
   color: #fff;
 }
 .chat__steer:hover { background: var(--accent-hover); /* CONTRACT: vivid opaque accent on hover */ }
+.chat__steer:disabled {
+  cursor: wait;
+}
 
 /* Pending-question nudge — shown in the foot when an unanswered
    AskUserQuestion card sits outside the viewport, so the frozen turn

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -2005,6 +2005,11 @@ export default function ChatView({
   // synchronously so repeated keydowns cannot submit a duplicate before the
   // request settles.
   const submitSteerInFlightRef = useRef(false)
+  // Queue POSTs are optimistic: the tray row exists before the backend has
+  // confirmed it. The primary Steer control is visible immediately, and one
+  // early tap waits on these exact requests rather than becoming an inert
+  // click or briefly showing Stop.
+  const queuedSendRequestsRef = useRef(new Map())
 
   const doSend = useCallback(async (text, opts = {}) => {
     if (isProviderSwitchBlocking(chatId)) return
@@ -2149,14 +2154,17 @@ export default function ChatView({
         // on each committed value, but the synchronous reset keeps the
         // send transition correct before React commits the empty value.
       }
+      let queueRequest = null
       try {
-        const result = await streamSend(
+        queueRequest = streamSend(
           text,
           attachments.length > 0 ? attachments : undefined,
           directSteer
             ? { directSteer: true, cid }
             : { queueOnly: true, cid },
         )
+        if (!directSteer) queuedSendRequestsRef.current.set(cid, queueRequest)
+        const result = await queueRequest
         clearFailedAttempt()
         releaseComposerFilesAfterAccepted()
         if (result?.status === 'duplicate') {
@@ -2371,6 +2379,11 @@ export default function ChatView({
         })
         restoreComposerAfterFailedSend()
         setSendFailure(sendFailureMessage(err, { online: getOnlineSnapshot() }))
+      } finally {
+        if (!directSteer
+            && queuedSendRequestsRef.current.get(cid) === queueRequest) {
+          queuedSendRequestsRef.current.delete(cid)
+        }
       }
       return
     }
@@ -3220,6 +3233,12 @@ export default function ChatView({
     handlingSteerRef.current = true
     setSteerBusy(true)
     try {
+      // The UI changes Send → Steer in the same render that adds the
+      // optimistic queue row. If the owner taps during its persistence
+      // round-trip, wait for those exact writes; doSend's continuation
+      // confirms/removes each row before this continuation reads the queue.
+      const queueWrites = [...queuedSendRequestsRef.current.values()]
+      if (queueWrites.length > 0) await Promise.allSettled(queueWrites)
       const snapshot = pendingQueue.pendingMessagesRef.current
       // Only server-confirmed entries can be force-steered: the backend
       // reconstructs the durable rows from chat.pending_messages, so an
@@ -3520,15 +3539,17 @@ export default function ChatView({
   // steer button here is a dead end. Keep the existing deterministic Stop path
   // available instead: Stop cancels the question first, interrupts the turn,
   // and re-sends the queued rows as one fresh continuation.
-  const canSteer = !hasPendingQuestion
-    && connectionError !== 'disconnected' && !steerBusy
+  const showSteer = !hasPendingQuestion
+    && connectionError !== 'disconnected'
+    && turnActive
+    && pendingQueue.pendingMessages.length > 0
+  const canRequestSteer = showSteer && !steerBusy
+  const canSteer = canRequestSteer
     && canFastForwardQueue(pendingQueue.pendingMessages, turnActive)
   const canSubmitSteer = !hasPendingQuestion
     && connectionError !== 'disconnected'
     && !steerBusy
     && turnActive
-  const canRequestSteer = canSubmitSteer
-    && pendingQueue.pendingMessages.length > 0
 
   // ── Sticky "tap to resume" affordance ──────────────────────────────
   // A turn paused by a drain-gated restart, a stall, or a provider-limit park
@@ -4143,6 +4164,8 @@ export default function ChatView({
           onStop={handleStop}
           onSteer={handleSteer}
           canSteer={canSteer}
+          showSteer={showSteer}
+          steerReady={!steerBusy}
           canRequestSteer={canRequestSteer}
           canSubmitSteer={canSubmitSteer}
           offline={!online}

--- a/frontend/src/components/ChatView/__tests__/chatUiPolish.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatUiPolish.test.js
@@ -90,17 +90,24 @@ test('message sources stay inside the assistant row on narrow screens', () => {
     'browser list indentation must not reduce the source card width')
 })
 
-test('primary chat actions leave a brief empty beat before replacement', () => {
+test('Send changes to Steer without an empty or black replacement frame', () => {
   const css = stripComments(chatCss)
-  const actionRule = css.match(/\.chat__send,\s*\.chat__steer,\s*\.chat__stop\s*\{[^}]*\}/)?.[0] || ''
+  const stopRule = css.match(/\.chat__stop\s*\{[^}]*\}/g)
+    ?.find(rule => /animation:\s*chat-action-reveal/.test(rule)) || ''
+  const sendRule = css.match(/\.chat__send\s*\{[^}]*\}/)?.[0] || ''
+  const steerRule = css.match(/\.chat__steer\s*\{[^}]*\}/)?.[0] || ''
   const revealFrames = css.match(/@keyframes\s+chat-action-reveal\s*\{[\s\S]*?\n\}/)?.[0] || ''
 
-  assert.match(actionRule, /animation:\s*chat-action-reveal/,
-    'each keyed primary action should run the replacement reveal')
+  assert.match(stopRule, /animation:\s*chat-action-reveal/,
+    'the genuinely different destructive Stop control may still reveal separately')
+  assert.doesNotMatch(sendRule, /animation:/,
+    'Send must keep its accent shell continuously visible')
+  assert.doesNotMatch(steerRule, /animation:/,
+    'Steer must not replay the opacity-zero replacement animation')
   assert.match(revealFrames, /0%,\s*44%\s*\{\s*opacity:\s*0/,
-    'the incoming action should remain hidden at the start')
+    'the Stop-only reveal should still clear the prior semantic control')
   assert.match(revealFrames, /100%\s*\{\s*opacity:\s*1/,
-    'the incoming action should then appear')
+    'the Stop-only reveal should then appear')
 })
 
 test('running activity uses a masked solid-text sweep, not gradient-clipped text', () => {

--- a/frontend/src/components/ChatView/__tests__/composerSteerTouch.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerSteerTouch.test.js
@@ -8,7 +8,7 @@ const chatView = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8
 
 test('composer fast-forward dispatches immediately without an incidental blur', () => {
   const steerBlock = inputBar.match(
-    /key="steer"[\s\S]*?aria-label="Send queued message now"/,
+    /className="chat__action chat__steer"[\s\S]*?aria-label="Send queued message now"/,
   )?.[0] || ''
   assert.match(steerBlock, /onPointerDown=\{\(e\) => e\.preventDefault\(\)\}/)
   assert.match(
@@ -16,6 +16,34 @@ test('composer fast-forward dispatches immediately without an incidental blur', 
     /onTouchEnd=\{\(e\) => \{ e\.preventDefault\(\); onSteer\(\) \}\}/,
   )
   assert.match(steerBlock, /onClick=\{onSteer\}/)
+})
+
+test('optimistic queueing changes Send directly to an actionable Steer control', () => {
+  assert.match(
+    inputBar,
+    /if \(sending && !hasInput && showSteer\)[\s\S]*?key="forward"[\s\S]*?disabled=\{!steerReady\}/,
+    'the semantic Steer identity must not wait for serverTs confirmation',
+  )
+  assert.match(
+    chatView,
+    /const showSteer = !hasPendingQuestion[\s\S]*?turnActive[\s\S]*?pendingQueue\.pendingMessages\.length > 0/,
+    'an optimistic visible queue row should choose Steer immediately',
+  )
+  assert.match(
+    chatView,
+    /const queueWrites = \[\.\.\.queuedSendRequestsRef\.current\.values\(\)\][\s\S]*?await Promise\.allSettled\(queueWrites\)[\s\S]*?const snapshot = pendingQueue\.pendingMessagesRef\.current/,
+    'an early Steer tap must await the queue write before reading steerable rows',
+  )
+  const steerBlock = inputBar.match(
+    /if \(sending && !hasInput && showSteer\)[\s\S]*?<button[\s\S]*?<\/button>/,
+  )?.[0] || ''
+  const sendBlock = inputBar.match(
+    /if \(hasInput && !listening\)[\s\S]*?<button[\s\S]*?<\/button>/,
+  )?.[0] || ''
+  assert.match(steerBlock, /key="forward"/,
+    'Steer should reuse the forward action DOM node')
+  assert.match(sendBlock, /key="forward"/,
+    'Send should hand the same forward action DOM node to Steer')
 })
 
 test('per-row fast-forward dispatches on touchend too', () => {

--- a/frontend/src/components/ChatView/__tests__/offlineFooter.test.js
+++ b/frontend/src/components/ChatView/__tests__/offlineFooter.test.js
@@ -51,12 +51,14 @@ test('offline explanation has one owner while send failures stay in the composer
 test('connection failure hides queued actions and disables composer steering', () => {
   assert.match(chatView, /\{connectionError !== 'disconnected' && \([\s\S]*?<QueuedMessages/,
     'the lost-connection state should own the footer stack until Retry succeeds')
-  assert.match(chatView, /const canSteer = !hasPendingQuestion[\s\S]*?connectionError !== 'disconnected' && !steerBusy[\s\S]*?canFastForwardQueue/,
-    'the visible composer steer action must be gated by pending QA and connection health')
+  assert.match(chatView, /const showSteer = !hasPendingQuestion[\s\S]*?connectionError !== 'disconnected'[\s\S]*?turnActive[\s\S]*?pendingQueue\.pendingMessages\.length > 0/,
+    'the visible composer steer identity must be gated by pending QA and connection health')
+  assert.match(chatView, /const canSteer = canRequestSteer[\s\S]*?canFastForwardQueue/,
+    'server-confirmed steering must remain stricter than the optimistic visual identity')
   assert.match(chatView, /const canSubmitSteer = !hasPendingQuestion[\s\S]*?connectionError !== 'disconnected'[\s\S]*?!steerBusy[\s\S]*?turnActive/,
     'the composed-text keyboard steer path must be gated by pending QA and connection health too')
-  assert.match(chatView, /const canRequestSteer = canSubmitSteer[\s\S]*?pendingQueue\.pendingMessages\.length > 0/,
-    'the empty-composer keyboard path must share the same gate and require queued work')
+  assert.match(chatView, /const canRequestSteer = showSteer && !steerBusy/,
+    'the empty-composer keyboard path must share the optimistic visible steer gate')
 })
 
 test('connection status matches the composer column while the offline note stays compact', () => {

--- a/frontend/src/components/ChatView/__tests__/questionCardState.test.js
+++ b/frontend/src/components/ChatView/__tests__/questionCardState.test.js
@@ -90,7 +90,7 @@ test('question submission freezes the visible anchor before the async handoff', 
 test('a pending question exposes Stop instead of an impossible steer', () => {
   assert.match(
     chatView,
-    /const canSteer = !hasPendingQuestion[\s\S]*?canFastForwardQueue/,
+    /const showSteer = !hasPendingQuestion[\s\S]*?const canSteer = canRequestSteer[\s\S]*?canFastForwardQueue/,
     'the composer must fall back to Stop while request_user_input owns the turn',
   )
   assert.match(


### PR DESCRIPTION
## Summary

- switch the active-turn composer from Send directly to Steer as soon as the queued message appears
- keep the same accent action visible while its icon and meaning change, without an opacity-zero replacement frame
- make an immediate Steer tap wait for the exact queue write instead of becoming inert
- preserve Stop for unanswered questions, disconnected chats, and active turns with no queued work

## Prior work

This is a follow-up to #282, which removed the visible queued intermediate state for modified-Enter direct steering. Ordinary Send during a live reply still passed through Stop while the queue write settled, and the primary-action reveal animation then hid the replacement briefly. This change covers that separate ordinary-send transition.

## Validation

- frontend library suite: 1,989 passed
- frontend hook suite: 63 passed
- production frontend/PWA build passed
- `git diff --check` passed