### PR TITLE
Support OpenAI SDK icons in mini-apps

### DIFF
--- a/backend/app/app_compile_contract.py
+++ b/backend/app/app_compile_contract.py
@@ -32,6 +32,7 @@ BUNDLED_RUNTIME_LIBS: tuple[str, ...] = (
   "marked-highlight",
   "highlight.js/*",
   "dompurify",
+  "@openai/apps-sdk-ui/components/Icon",
 )
 
 COMPILED_RUNTIME_ABI = 1
@@ -116,6 +117,11 @@ def runtime_library_aliases() -> tuple[tuple[str, Path], ...]:
   node_path = runtime_node_path()
   roots = sorted({_package_root(specifier) for specifier in BUNDLED_RUNTIME_LIBS})
   overrides = (
+    (
+      "@openai/apps-sdk-ui/components/Icon",
+      node_path / "@openai" / "apps-sdk-ui" / "dist" / "es"
+      / "components" / "Icon" / "index.js",
+    ),
     ("three/addons", node_path / "three" / "examples" / "jsm"),
     # Marked's browser field is a UMD build. Point the public root import at
     # its ESM entry so `import { marked } from "marked"` keeps the documented

--- a/backend/scripts/seed-skills/building-apps-quickstart.md
+++ b/backend/scripts/seed-skills/building-apps-quickstart.md
@@ -108,8 +108,16 @@ const CSS = `
 Use Möbius theme variables (`--bg`, `--surface`, `--surface-2`, `--text`,
 `--muted`, `--border`, `--accent`, `--font`). Add a short app-specific prefix
 to classes. Prefer CSS classes over inline style objects except for truly
-computed values. Use lucide icons already supported by the app runtime rather
-than hand-drawn SVG.
+computed values. Use generic interface icons from the OpenAI Apps SDK UI rather
+than Lucide, hand-drawn SVG, emoji, or text characters:
+
+```jsx
+import { Plus, Search, Trash } from '@openai/apps-sdk-ui/components/Icon'
+```
+
+Keep custom imagery only when it carries real domain identity, such as a flag,
+provider logo, chart, sport, instrument, or game object. App-brand artwork is
+also separate from interface chrome and remains the app's own asset.
 
 For an ordinary app, make one strong visual decision—a calm breathing orb, a
 bright decision wheel, a tactile stack of cards—then support it with restrained

--- a/backend/tests/test_runtime_libs.py
+++ b/backend/tests/test_runtime_libs.py
@@ -338,3 +338,46 @@ export default function MarkdownFixture() {
     "Markdown runtime dependencies escaped the self-contained app bundle"
   )
   assert output.is_file() and output.stat().st_size > 0
+
+
+def test_openai_app_icons_compile_from_the_supported_public_entry(tmp_path):
+  """Generic mini-app chrome uses the same maintained icon set as the shell."""
+  aliases = dict(runtime_library_aliases())
+  icon_entry = (
+    runtime_node_path() / "@openai" / "apps-sdk-ui" / "dist" / "es"
+    / "components" / "Icon" / "index.js"
+  )
+  assert aliases["@openai/apps-sdk-ui/components/Icon"] == icon_entry
+
+  entry = tmp_path / "openai-icons.jsx"
+  output = tmp_path / "openai-icons.js"
+  metafile = tmp_path / "openai-icons-meta.json"
+  entry.write_text(
+    """import { ArrowLeft, Chat, Check, Copy, Search, Trash } from '@openai/apps-sdk-ui/components/Icon'
+
+export default function OpenAIIconsFixture() {
+  return <div>{[ArrowLeft, Chat, Check, Copy, Search, Trash].map((Icon) => <Icon key={Icon.name} />)}</div>
+}
+"""
+  )
+
+  completed = subprocess.run(
+    esbuild_command(entry, output, metafile=metafile),
+    capture_output=True,
+    check=False,
+    env=esbuild_environment(),
+    text=True,
+    timeout=ESBUILD_TIMEOUT_SECS,
+  )
+  assert completed.returncode == 0, completed.stderr
+
+  metadata = json.loads(metafile.read_text())
+  entry_outputs = [
+    details for details in metadata["outputs"].values()
+    if details.get("entryPoint")
+  ]
+  assert len(entry_outputs) == 1
+  assert entry_outputs[0].get("imports") == [], (
+    "OpenAI app icons escaped the pinned self-contained app bundle"
+  )
+  assert output.is_file() and output.stat().st_size > 0


### PR DESCRIPTION
## Summary
- bundle the supported OpenAI Apps SDK icon entry into self-contained mini-apps
- guide app authors to use that family for generic controls while preserving domain artwork
- add a compile-contract regression test for the public icon entry

## Verification
- `MOBIUS_TEST_RUNTIME=1 pytest -q backend/tests/test_runtime_libs.py`
- 13 tests passed