### PR TITLE
Keep chat composer actions visible during transitions

### DIFF
--- a/frontend/src/components/ChatView/ChatInputBar.jsx
+++ b/frontend/src/components/ChatView/ChatInputBar.jsx
@@ -117,9 +117,11 @@ _touchMql?.addEventListener('change', (e) => { _isTouchPrimary = e.matches })
  *  false and the Stop square returns, and while the composer has text the Send
  *  button (queue-another) still wins over both.
  *
- *  Each state's button carries a distinct `key`, and that is load-bearing:
- *  state swaps replace the semantic control, while the shared `.chat__action`
- *  base keeps geometry and box model stable across Send / Stop / Steer / Mic. */
+ *  Send, Steer, and Stop are states of the same primary action. They
+ *  deliberately share the `primary` key so React preserves the 40px action
+ *  target and swaps only its icon, label, handler, and semantic colour—there
+ *  must be no empty/black replacement frame between any of them. Mic remains
+ *  distinct because it is the idle input affordance rather than a turn action. */
 function PrimaryAction({
   sending, listening, hasInput, hasUploading, offline, canSteer,
   submissionBlocked,
@@ -128,7 +130,7 @@ function PrimaryAction({
   if (sending && !hasInput && canSteer) {
     return (
       <button
-        key="steer"
+        key="primary"
         className="chat__action chat__steer"
         type="button"
         // Keep focus stable through pointerdown, then let ChatView dismiss
@@ -146,7 +148,7 @@ function PrimaryAction({
   if (sending && !hasInput) {
     return (
       <button
-        key="stop"
+        key="primary"
         className="chat__action chat__stop"
         type="button"
         // Match Send's touch handling: the composer keeps focus on
@@ -167,7 +169,7 @@ function PrimaryAction({
   if (hasInput && !listening) {
     return (
       <button
-        key="send"
+        key="primary"
         className="chat__action chat__send"
         type="button"
         // Keep the textarea focused until ChatView snapshots the scroll

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -1878,18 +1878,6 @@
     transform 0.08s ease;
 }
 
-/* Primary meanings share one slot. Hold the replacement invisible for a
-   brief beat so Send/Fast-forward clears before Stop is revealed. */
-.chat__send,
-.chat__steer,
-.chat__stop {
-  animation: chat-action-reveal 0.16s ease-out both;
-}
-
-@keyframes chat-action-reveal {
-  0%, 44% { opacity: 0; }
-  100% { opacity: 1; }
-}
 .chat__action:focus { outline: none; }
 .chat__action:focus-visible {
   outline: 2px solid var(--accent);
@@ -2647,9 +2635,6 @@
 @media (prefers-reduced-motion: reduce) {
   .chat__build-rail,
   .chat__copy-toast { animation: none; }
-  .chat__send,
-  .chat__steer,
-  .chat__stop { animation: none; }
 }
 
 /* ── Queued messages tray ──────────────────────────── */

--- a/frontend/src/components/ChatView/__tests__/chatUiPolish.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatUiPolish.test.js
@@ -90,17 +90,20 @@ test('message sources stay inside the assistant row on narrow screens', () => {
     'browser list indentation must not reduce the source card width')
 })
 
-test('primary chat actions leave a brief empty beat before replacement', () => {
+test('Send, Steer, and Stop never fade through an empty replacement frame', () => {
   const css = stripComments(chatCss)
-  const actionRule = css.match(/\.chat__send,\s*\.chat__steer,\s*\.chat__stop\s*\{[^}]*\}/)?.[0] || ''
-  const revealFrames = css.match(/@keyframes\s+chat-action-reveal\s*\{[\s\S]*?\n\}/)?.[0] || ''
+  const sendRule = css.match(/\.chat__send\s*\{[^}]*\}/)?.[0] || ''
+  const steerRule = css.match(/\.chat__steer\s*\{[^}]*\}/)?.[0] || ''
+  const stopRules = css.match(/\.chat__stop\s*\{[^}]*\}/g)?.join('\n') || ''
 
-  assert.match(actionRule, /animation:\s*chat-action-reveal/,
-    'each keyed primary action should run the replacement reveal')
-  assert.match(revealFrames, /0%,\s*44%\s*\{\s*opacity:\s*0/,
-    'the incoming action should remain hidden at the start')
-  assert.match(revealFrames, /100%\s*\{\s*opacity:\s*1/,
-    'the incoming action should then appear')
+  assert.doesNotMatch(sendRule, /animation:/,
+    'Send must keep the shared action target continuously visible')
+  assert.doesNotMatch(steerRule, /animation:/,
+    'Steer must keep the shared action target continuously visible')
+  assert.doesNotMatch(stopRules, /animation:/,
+    'Stop must appear immediately instead of starting at opacity zero')
+  assert.doesNotMatch(css, /@keyframes\s+chat-action-reveal/,
+    'the empty-frame reveal must not remain available to a primary action')
 })
 
 test('running activity uses a masked solid-text sweep, not gradient-clipped text', () => {

--- a/frontend/src/components/ChatView/__tests__/composerSteerTouch.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerSteerTouch.test.js
@@ -8,7 +8,7 @@ const chatView = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8
 
 test('composer fast-forward dispatches immediately without an incidental blur', () => {
   const steerBlock = inputBar.match(
-    /key="steer"[\s\S]*?aria-label="Send queued message now"/,
+    /className="chat__action chat__steer"[\s\S]*?aria-label="Send queued message now"/,
   )?.[0] || ''
   assert.match(steerBlock, /onPointerDown=\{\(e\) => e\.preventDefault\(\)\}/)
   assert.match(
@@ -16,6 +16,22 @@ test('composer fast-forward dispatches immediately without an incidental blur', 
     /onTouchEnd=\{\(e\) => \{ e\.preventDefault\(\); onSteer\(\) \}\}/,
   )
   assert.match(steerBlock, /onClick=\{onSteer\}/)
+})
+
+test('Send, Steer, and Stop reuse one continuously visible primary action', () => {
+  const steerBlock = inputBar.match(
+    /if \(sending && !hasInput && canSteer\)[\s\S]*?<button[\s\S]*?<\/button>/,
+  )?.[0] || ''
+  const stopBlock = inputBar.match(
+    /if \(sending && !hasInput\)[\s\S]*?<button[\s\S]*?<\/button>/,
+  )?.[0] || ''
+  const sendBlock = inputBar.match(
+    /if \(hasInput && !listening\)[\s\S]*?<button[\s\S]*?<\/button>/,
+  )?.[0] || ''
+
+  assert.match(steerBlock, /key="primary"/)
+  assert.match(stopBlock, /key="primary"/)
+  assert.match(sendBlock, /key="primary"/)
 })
 
 test('per-row fast-forward dispatches on touchend too', () => {

--- a/frontend/src/components/ChatView/__tests__/composerStopTouch.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerStopTouch.test.js
@@ -3,7 +3,9 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 
 const src = readFileSync(new URL('../ChatInputBar.jsx', import.meta.url), 'utf8')
-const stopBlock = src.match(/key="stop"[\s\S]*?aria-label="Stop"/)?.[0] || ''
+const stopBlock = src.match(
+  /className="chat__action chat__stop"[\s\S]*?aria-label="Stop"/,
+)?.[0] || ''
 
 test('Stop dispatches on touchend and preserves composer focus on pointerdown', () => {
   assert.match(stopBlock, /onPointerDown=\{\(e\) => e\.preventDefault\(\)\}/,


### PR DESCRIPTION
## Summary
- keep Send, Steer, and Stop on one stable primary action control
- remove the opacity-zero reveal that caused a blank frame between actions
- cover both the shared control identity and the no-fade visual contract

## Testing
- `npm test`
- `npm run build`
- rendered check confirmed Send → Stop and Steer → Stop remain fully opaque with no action animation