### PR TITLE
Reconcile landed contributions by provenance

### DIFF
--- a/backend/app/app_git.py
+++ b/backend/app/app_git.py
@@ -56,7 +56,9 @@ app with no source_dir has no `.git`.
 
 from __future__ import annotations
 
+import hashlib
 import json
+import logging
 import os
 import re
 import shutil
@@ -64,6 +66,8 @@ import subprocess
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
+
+log = logging.getLogger(__name__)
 
 # Branch names. `upstream` is installer-only pristine history; `main` is
 # the local working branch explicit apply commits to and the working
@@ -159,6 +163,17 @@ _GIT_EMAIL = "mobius@localhost"
 # slow.
 _GIT_TIMEOUT = 30
 
+# Contribute records a reviewed change as a Git object in the repository that
+# owns the live source.  The pending ref proves the reviewed diff came from a
+# specific local commit; terminal contribution cleanup promotes it to landed
+# only after GitHub reports the PR merged.  Neither ref touches the working
+# tree, and both survive branch rewrites because they are ordinary Git refs.
+_EQUIVALENCE_PENDING_PREFIX = "refs/mobius/equivalences/pending"
+_EQUIVALENCE_LANDED_PREFIX = "refs/mobius/equivalences/landed"
+_EQUIVALENCE_VERSION = 1
+_HEX_OID = re.compile(r"^[0-9a-f]{40,64}$")
+_DIFF_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
 
 @dataclass
 class MergeResult:
@@ -178,6 +193,30 @@ class MergeResult:
   status: str
   conflict_paths: list[str] = field(default_factory=list)
   merged_tree_oid: str | None = None
+  equivalent_change_refs: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class EquivalentChange:
+  """One reviewed local change that Contribute observed landing upstream.
+
+  ``anchor_sha`` is a synthetic commit whose parent is ``base_sha`` and whose
+  tree is the exact reviewed head tree.  ``source_sha`` is the local commit in
+  which Contribute proved that reviewed delta was already present.  The updater
+  may use the anchor only while ``source_sha`` remains an ancestor of local.
+  ``upstream_sha`` is GitHub's merge commit when it was available; it must both
+  contain the reviewed delta and be an ancestor of the target. Otherwise a
+  conservative tree-subsumption proof is required against the update target.
+  """
+
+  ref: str
+  anchor_sha: str
+  base_sha: str
+  source_sha: str
+  upstream_sha: str | None
+  diff_sha256: str
+  contribution_id: str
+  proof_mode: str
 
 
 @dataclass(frozen=True)
@@ -461,6 +500,643 @@ def ref_exists(source_dir: str | Path, ref: str) -> bool:
     Path(source_dir), "rev-parse", "--verify", "--quiet", ref, check=False,
   )
   return proc.returncode == 0
+
+
+def _resolve_commit(repo: Path, ref: str) -> str | None:
+  """Resolve ``ref`` to a full commit oid, failing closed on bad metadata."""
+  proc = _run(
+    repo, "rev-parse", "--verify", "--quiet", "--end-of-options",
+    f"{ref}^{{commit}}",
+    check=False,
+  )
+  oid = proc.stdout.strip().lower()
+  return oid if proc.returncode == 0 and _HEX_OID.fullmatch(oid) else None
+
+
+def _tree_oid(repo: Path, ref: str) -> str | None:
+  proc = _run(
+    repo, "rev-parse", "--verify", "--quiet", "--end-of-options",
+    f"{ref}^{{tree}}",
+    check=False,
+  )
+  oid = proc.stdout.strip().lower()
+  return oid if proc.returncode == 0 and _HEX_OID.fullmatch(oid) else None
+
+
+def _canonical_diff(repo: Path, base_sha: str, head_sha: str) -> bytes | None:
+  """The byte-exact diff shape Contribute hashes before a PR can be sent."""
+  try:
+    proc = subprocess.run(
+      [
+        "git", "-c", "core.quotePath=false", "-C", str(repo),
+        "diff", "--no-ext-diff", "--no-color", "--binary", "--full-index",
+        "--src-prefix=a/", "--dst-prefix=b/", f"{base_sha}..{head_sha}",
+      ],
+      capture_output=True, timeout=_GIT_TIMEOUT, check=False,
+      env=_git_env(repo),
+    )
+  except (OSError, subprocess.SubprocessError):
+    return None
+  return proc.stdout if proc.returncode == 0 else None
+
+
+def merge_refs(
+  source_dir: str | Path,
+  left: str,
+  right: str,
+  *,
+  merge_base: str | None = None,
+) -> MergeResult:
+  """Off-tree three-way merge of two refs, optionally with an explicit base.
+
+  This is the one parser for ``git merge-tree --write-tree`` used by ordinary
+  app updates, provenance proofs, and the platform updater's conflict fallback.
+  It never moves a ref, index, or working tree.
+  """
+  repo = Path(source_dir)
+  args = ["merge-tree", "--write-tree", "--name-only"]
+  if merge_base is not None:
+    args.extend(("--merge-base", merge_base))
+  args.extend((left, right))
+  proc = _run(repo, *args, check=False)
+  if proc.returncode > 1:
+    detail = proc.stderr.strip() or proc.stdout.strip()
+    raise RuntimeError(
+      f"git merge-tree failed (rc={proc.returncode}): {detail}"
+    )
+  lines = proc.stdout.splitlines()
+  tree_oid = lines[0].strip() if lines else ""
+  if not tree_oid:
+    raise RuntimeError("git merge-tree returned no merged tree")
+  if proc.returncode == 1:
+    paths: list[str] = []
+    for line in lines[1:]:
+      if not line.strip():
+        break
+      paths.append(line.strip())
+    return MergeResult(status="conflict", conflict_paths=paths)
+  return MergeResult(status="clean", merged_tree_oid=tree_oid)
+
+
+def _change_is_subsumed(
+  repo: Path, base_sha: str, anchor_sha: str, descendant: str,
+) -> bool:
+  """Prove ``base..anchor`` is already contained in ``descendant``'s tree.
+
+  A clean three-way result equal to the descendant tree means adding the
+  reviewed delta contributes no bytes.  This proof is intentionally stricter
+  than patch-id: later edits to the same lines make it fail rather than guess.
+  Causal provenance (the source/upstream witness SHAs) covers that later-edit
+  case once the pending/landed refs have been recorded.
+  """
+  try:
+    merged = merge_refs(repo, anchor_sha, descendant, merge_base=base_sha)
+  except (OSError, subprocess.SubprocessError, RuntimeError):
+    return False
+  descendant_tree = _tree_oid(repo, descendant)
+  return bool(
+    merged.status == "clean"
+    and descendant_tree
+    and merged.merged_tree_oid == descendant_tree
+  )
+
+
+def _diff_paths(repo: Path, left: str, right: str) -> set[str] | None:
+  proc = _run(
+    repo, "diff", "--name-only", "--no-renames", "-z", f"{left}..{right}",
+    check=False,
+  )
+  if proc.returncode != 0:
+    return None
+  return {path for path in proc.stdout.split("\0") if path}
+
+
+def _source_is_resolved_projection(
+  repo: Path,
+  reviewed_base: str,
+  reviewed_head: str,
+  source_sha: str,
+) -> bool:
+  """Prove ``source_sha`` is a conflict resolution of the reviewed delta.
+
+  A platform/app contribution is often projected onto current upstream for a
+  clean PR after the same change was integrated into a busier local tree. The
+  local integration commit can therefore differ from the PR patch on conflict
+  lines even though it is causally the same change. This proof accepts that
+  shape only for a one-parent source commit that changes exactly the reviewed
+  path set. A temporary three-way index then requires every non-conflicting
+  entry to equal the source tree and at least one reviewed path to remain
+  independently checkable; only Git's explicit conflict paths may carry the
+  local resolution. No branch, real index, or worktree is touched.
+
+  This is deliberately narrower than arbitrary patch similarity. It captures
+  the agent-resolved projection once, at owner-reviewed Send time, so later
+  updates are deterministic; any extra path or unexplained non-conflict byte
+  fails closed to the ordinary resolver.
+  """
+  parent_line = _run(
+    repo, "rev-list", "--parents", "-n", "1", source_sha, check=False,
+  ).stdout.split()
+  if len(parent_line) != 2:
+    return False
+  source_parent = parent_line[1]
+  reviewed_paths = _diff_paths(repo, reviewed_base, reviewed_head)
+  source_paths = _diff_paths(repo, source_parent, source_sha)
+  if not reviewed_paths or source_paths != reviewed_paths:
+    return False
+
+  try:
+    with tempfile.TemporaryDirectory(prefix="mobius-equivalence-") as tmp:
+      index = Path(tmp) / "index"
+      read = _run_with_index(
+        repo, index,
+        "read-tree", "-m", reviewed_base, source_parent, reviewed_head,
+        check=False,
+      )
+      if read.returncode != 0:
+        return False
+      staged = _run_with_index(
+        repo, index, "ls-files", "--stage", "-z", check=False,
+      )
+      if staged.returncode != 0:
+        return False
+  except (OSError, subprocess.SubprocessError):
+    return False
+
+  stage_zero: dict[str, tuple[str, str]] = {}
+  unmerged: dict[str, dict[int, tuple[str, str]]] = {}
+  for record in staged.stdout.split("\0"):
+    if not record:
+      continue
+    try:
+      metadata, path = record.split("\t", 1)
+      mode, oid, stage_text = metadata.split()
+      stage = int(stage_text)
+    except (ValueError, TypeError):
+      return False
+    if stage == 0:
+      stage_zero[path] = (mode, oid)
+    else:
+      unmerged.setdefault(path, {})[stage] = (mode, oid)
+
+  source_entries: dict[str, tuple[str, str]] = {}
+  source_tree = _run(
+    repo, "ls-tree", "-r", "-z", "--full-tree", source_sha, check=False,
+  )
+  if source_tree.returncode != 0:
+    return False
+  for record in source_tree.stdout.split("\0"):
+    if not record:
+      continue
+    try:
+      metadata, path = record.split("\t", 1)
+      mode, _kind, oid = metadata.split()
+    except ValueError:
+      return False
+    source_entries[path] = (mode, oid)
+
+  # read-tree intentionally leaves some one-sided delete/change cases staged
+  # even though the reviewed side equals the base. Resolve those mechanically
+  # and compare them too; only paths where BOTH source and review changed from
+  # the base are genuine agent-owned conflicts.
+  expected_entries: dict[str, tuple[str, str] | None] = dict(stage_zero)
+  conflicts: set[str] = set()
+  for path, stages in unmerged.items():
+    base_entry = stages.get(1)
+    source_entry = stages.get(2)
+    reviewed_entry = stages.get(3)
+    if reviewed_entry == base_entry:
+      expected_entries[path] = source_entry
+    elif source_entry == base_entry:
+      expected_entries[path] = reviewed_entry
+    else:
+      conflicts.add(path)
+  if (
+    not conflicts
+    or not conflicts.issubset(reviewed_paths)
+    or not reviewed_paths.difference(conflicts)
+  ):
+    return False
+  return all(
+    source_entries.get(path) == entry
+    for path, entry in expected_entries.items()
+  )
+
+
+def primary_worktree_path(source_dir: str | Path) -> Path | None:
+  """Primary live checkout path when ``source_dir`` is a linked worktree.
+
+  Contribute stages reviews in linked worktrees.  Their common Git directory is
+  the live platform/app checkout's ``.git`` directory. A standalone/separate
+  staging clone deliberately returns ``None`` because it cannot prove a
+  relationship to any installed source tree.
+  """
+  repo = Path(source_dir)
+  proc = _run(
+    repo, "rev-parse", "--path-format=absolute", "--git-dir", "--git-common-dir",
+    check=False,
+  )
+  if proc.returncode != 0:
+    return None
+  paths = [Path(line).resolve() for line in proc.stdout.splitlines() if line]
+  if len(paths) != 2:
+    return None
+  git_dir, common = paths
+  if git_dir == common:
+    return None
+  if common.name != ".git":
+    return None
+  primary = common.parent
+  if not (primary / ".git").is_dir():
+    return None
+  return primary
+
+
+def primary_worktree_head(source_dir: str | Path) -> str | None:
+  """HEAD of the primary live checkout linked to ``source_dir``, if any."""
+  primary = primary_worktree_path(source_dir)
+  return _resolve_commit(primary, "HEAD") if primary else None
+
+
+def _equivalence_ref(prefix: str, diff_sha256: str) -> str:
+  return f"{prefix}/{diff_sha256}"
+
+
+def _write_equivalence_anchor(
+  repo: Path,
+  *,
+  prefix: str,
+  base_sha: str,
+  head_sha: str,
+  source_sha: str,
+  diff_sha256: str,
+  contribution_id: str,
+  upstream_sha: str | None,
+  proof_mode: str,
+) -> str:
+  tree = _tree_oid(repo, head_sha)
+  if tree is None:
+    raise RuntimeError("reviewed contribution tree is unavailable")
+  metadata = {
+    "version": _EQUIVALENCE_VERSION,
+    "diff_sha256": diff_sha256,
+    "source_sha": source_sha,
+    "upstream_sha": upstream_sha,
+    "contribution_id": contribution_id[:128],
+    "proof_mode": proof_mode,
+  }
+  anchor = _run(
+    repo, "commit-tree", tree, "-p", base_sha,
+    "-m", json.dumps(metadata, sort_keys=True, separators=(",", ":")),
+  ).stdout.strip()
+  ref = _equivalence_ref(prefix, diff_sha256)
+  _run(repo, "update-ref", ref, anchor)
+  return ref
+
+
+def record_pending_equivalent_change(
+  source_dir: str | Path,
+  *,
+  base_sha: str,
+  head_sha: str,
+  source_sha: str,
+  diff_sha256: str,
+  contribution_id: str,
+  review_source_dir: str | Path | None = None,
+) -> str | None:
+  """Record a reviewed contribution only after proving its local provenance.
+
+  The caller invokes this after the owner sends the reviewed PR.  The canonical
+  diff hash must still match, and ``base..head`` must be fully present in the
+  supplied local ``source_sha``.  A later local edit may overlap the contributed
+  lines: the immutable source witness remains the causal proof as long as it is
+  still an ancestor of the local update branch. ``review_source_dir`` is the
+  durable review checkout when it does not share Git objects with the installed
+  source (the standalone-clone app workflow). Only the two verified reviewed
+  commits are imported into the installed repository; no branch or worktree is
+  moved.
+  """
+  repo = Path(source_dir)
+  review_repo = Path(review_source_dir) if review_source_dir else repo
+  digest = str(diff_sha256 or "").lower()
+  review_base = _resolve_commit(review_repo, base_sha)
+  review_head = _resolve_commit(review_repo, head_sha)
+  source = _resolve_commit(repo, source_sha)
+  if (
+    not _DIFF_SHA256.fullmatch(digest)
+    or review_base is None
+    or review_head is None
+    or source is None
+  ):
+    return None
+  reviewed_diff = _canonical_diff(review_repo, review_base, review_head)
+  if reviewed_diff is None or hashlib.sha256(reviewed_diff).hexdigest() != digest:
+    return None
+  base = _resolve_commit(repo, review_base)
+  head = _resolve_commit(repo, review_head)
+  if base is None or head is None:
+    try:
+      # A raw-oid local fetch transfers the immutable reviewed commits and their
+      # trees without creating a remote, branch, FETCH_HEAD, or worktree. The
+      # review path is already restricted to owner-controlled durable staging
+      # roots by Contribute before this function is called.
+      _run(
+        repo,
+        "fetch", "--quiet", "--no-tags", "--no-write-fetch-head",
+        str(review_repo), review_base, review_head,
+      )
+    except (OSError, subprocess.SubprocessError, RuntimeError):
+      return None
+    base = _resolve_commit(repo, review_base)
+    head = _resolve_commit(repo, review_head)
+  if base is None or head is None:
+    return None
+  proof_mode = "exact_tree"
+  if not _change_is_subsumed(repo, base, head, source):
+    if not _source_is_resolved_projection(repo, base, head, source):
+      return None
+    proof_mode = "resolved_projection"
+  return _write_equivalence_anchor(
+    repo,
+    prefix=_EQUIVALENCE_PENDING_PREFIX,
+    base_sha=base,
+    head_sha=head,
+    source_sha=source,
+    diff_sha256=digest,
+    contribution_id=str(contribution_id or ""),
+    upstream_sha=None,
+    proof_mode=proof_mode,
+  )
+
+
+def _read_equivalent_change(repo: Path, ref: str) -> EquivalentChange | None:
+  anchor = _resolve_commit(repo, ref)
+  if anchor is None:
+    return None
+  parent_line = _run(
+    repo, "rev-list", "--parents", "-n", "1", anchor, check=False,
+  ).stdout.split()
+  if len(parent_line) != 2:
+    return None
+  try:
+    metadata = json.loads(
+      _run(repo, "show", "-s", "--format=%B", anchor).stdout.strip()
+    )
+  except (ValueError, TypeError):
+    return None
+  if not isinstance(metadata, dict) or metadata.get("version") != _EQUIVALENCE_VERSION:
+    return None
+  digest = str(metadata.get("diff_sha256") or "").lower()
+  source = str(metadata.get("source_sha") or "").lower()
+  upstream_raw = metadata.get("upstream_sha")
+  upstream = str(upstream_raw).lower() if upstream_raw else None
+  proof_mode = str(metadata.get("proof_mode") or "exact_tree")
+  if (
+    not _DIFF_SHA256.fullmatch(digest)
+    or not ref.endswith(f"/{digest}")
+    or not _HEX_OID.fullmatch(source)
+    or (upstream is not None and not _HEX_OID.fullmatch(upstream))
+    or proof_mode not in {"exact_tree", "resolved_projection"}
+  ):
+    return None
+  return EquivalentChange(
+    ref=ref,
+    anchor_sha=anchor,
+    base_sha=parent_line[1].lower(),
+    source_sha=source,
+    upstream_sha=upstream,
+    diff_sha256=digest,
+    contribution_id=str(metadata.get("contribution_id") or "")[:128],
+    proof_mode=proof_mode,
+  )
+
+
+def mark_equivalent_change_landed(
+  source_dir: str | Path,
+  diff_sha256: str,
+  *,
+  upstream_sha: str | None = None,
+) -> str | None:
+  """Promote one owner-sent reviewed change after its PR is confirmed merged."""
+  repo = Path(source_dir)
+  digest = str(diff_sha256 or "").lower()
+  if not _DIFF_SHA256.fullmatch(digest):
+    return None
+  pending_ref = _equivalence_ref(_EQUIVALENCE_PENDING_PREFIX, digest)
+  pending = _read_equivalent_change(repo, pending_ref)
+  if pending is None:
+    return None
+  upstream = _resolve_commit(repo, upstream_sha) if upstream_sha else None
+  # The merge commit may not have been fetched into this checkout yet.  Keep a
+  # validated hex oid as provenance; the updater verifies ancestry only after
+  # it fetches the target that should contain it.
+  if upstream is None and upstream_sha:
+    candidate = str(upstream_sha).lower()
+    upstream = candidate if _HEX_OID.fullmatch(candidate) else None
+  ref = _write_equivalence_anchor(
+    repo,
+    prefix=_EQUIVALENCE_LANDED_PREFIX,
+    base_sha=pending.base_sha,
+    head_sha=pending.anchor_sha,
+    source_sha=pending.source_sha,
+    diff_sha256=pending.diff_sha256,
+    contribution_id=pending.contribution_id,
+    upstream_sha=upstream,
+    proof_mode=pending.proof_mode,
+  )
+  _run(repo, "update-ref", "-d", pending_ref, check=False)
+  return ref
+
+
+def discard_pending_equivalent_change(
+  source_dir: str | Path, diff_sha256: str,
+) -> None:
+  digest = str(diff_sha256 or "").lower()
+  if _DIFF_SHA256.fullmatch(digest):
+    _run(
+      Path(source_dir), "update-ref", "-d",
+      _equivalence_ref(_EQUIVALENCE_PENDING_PREFIX, digest), check=False,
+    )
+
+
+def _equivalent_changes(repo: Path, prefix: str) -> list[EquivalentChange]:
+  proc = _run(
+    repo, "for-each-ref", "--format=%(refname)",
+    f"{prefix}/", check=False,
+  )
+  if proc.returncode != 0:
+    return []
+  changes = []
+  for ref in sorted(line.strip() for line in proc.stdout.splitlines() if line.strip()):
+    change = _read_equivalent_change(repo, ref)
+    if change is not None:
+      changes.append(change)
+  return changes
+
+
+def _landed_equivalent_changes(repo: Path) -> list[EquivalentChange]:
+  return _equivalent_changes(repo, _EQUIVALENCE_LANDED_PREFIX)
+
+
+def carry_equivalent_change_sources(
+  source_dir: str | Path, old_local: str, new_local: str,
+) -> int:
+  """Carry local witnesses across the app model's intentional replay rewrite.
+
+  ``commit_replay`` and resolved-conflict finalization preserve the accepted
+  source tree but replace its ancestry with the new upstream tip. Any pending
+  or not-yet-integrated landed contribution whose source witness was reachable
+  from the old local tip therefore needs the new replay commit as its witness
+  only if the exact reviewed delta is still present there. For an
+  agent-resolved projection whose bytes intentionally differ on conflict lines,
+  preserving the old branch's complete local delta is the equivalent proof.
+  Both checks reject the explicit take-upstream path when it drops those edits.
+  Anchors unrelated to ``old_local`` remain untouched.
+  """
+  repo = Path(source_dir)
+  old = _resolve_commit(repo, old_local)
+  new = _resolve_commit(repo, new_local)
+  if old is None or new is None:
+    return 0
+  whole_local_delta_preserved = False
+  new_parent_line = _run(
+    repo, "rev-list", "--parents", "-n", "1", new, check=False,
+  ).stdout.split()
+  if len(new_parent_line) == 2:
+    replay_base = _run(
+      repo, "merge-base", old, new_parent_line[1], check=False,
+    )
+    if replay_base.returncode == 0 and replay_base.stdout.strip():
+      whole_local_delta_preserved = _change_is_subsumed(
+        repo, replay_base.stdout.strip(), old, new,
+      )
+  carried = 0
+  for prefix in (_EQUIVALENCE_PENDING_PREFIX, _EQUIVALENCE_LANDED_PREFIX):
+    for change in _equivalent_changes(repo, prefix):
+      if ref_is_ancestor(repo, change.source_sha, old) is not True:
+        continue
+      reviewed_delta_preserved = _change_is_subsumed(
+        repo, change.base_sha, change.anchor_sha, new,
+      )
+      if not reviewed_delta_preserved and not (
+        change.proof_mode == "resolved_projection"
+        and whole_local_delta_preserved
+      ):
+        continue
+      _write_equivalence_anchor(
+        repo,
+        prefix=prefix,
+        base_sha=change.base_sha,
+        head_sha=change.anchor_sha,
+        source_sha=new,
+        diff_sha256=change.diff_sha256,
+        contribution_id=change.contribution_id,
+        upstream_sha=change.upstream_sha,
+        proof_mode=change.proof_mode,
+      )
+      carried += 1
+  return carried
+
+
+def _change_landed_in_target(
+  repo: Path, change: EquivalentChange, target: str,
+) -> bool:
+  if change.upstream_sha:
+    return bool(
+      ref_is_ancestor(repo, change.upstream_sha, target) is True
+      and _change_is_subsumed(
+        repo, change.base_sha, change.anchor_sha, change.upstream_sha,
+      )
+    )
+  return _change_is_subsumed(
+    repo, change.base_sha, change.anchor_sha, target,
+  )
+
+
+def merge_with_equivalent_changes(
+  source_dir: str | Path, local: str, upstream: str,
+) -> MergeResult | None:
+  """Resolve a duplicate-contribution conflict from proven shared changes.
+
+  Start at Git's real merge base.  Each applicable reviewed anchor contributes
+  only its ``reviewed-base..reviewed-head`` delta to a synthetic shared TREE.
+  The anchor is applicable only when its immutable local source witness is an
+  ancestor of ``local`` and its GitHub merge witness is an ancestor of
+  ``upstream`` *and still contains the exact reviewed delta* (or strict
+  tree-subsumption proves the latter directly against the target when GitHub
+  could not provide a merge oid). A final off-tree merge with that semantic
+  base is accepted only when Git itself produces a clean tree. No ref or
+  working tree moves here; callers keep their existing rollback transaction.
+
+  Anchors are applied in deterministic passes.  A dependent anchor that cannot
+  merge onto the current shared tree is deferred until another anchor supplies
+  its prerequisite.  Any anchor still unprovable is simply omitted; the final
+  merge then remains conflicted and the existing agent fallback owns it.
+  """
+  repo = Path(source_dir)
+  real_base = _run(repo, "merge-base", local, upstream, check=False)
+  if real_base.returncode != 0 or not real_base.stdout.strip():
+    return None
+  shared_tree = _tree_oid(repo, real_base.stdout.strip())
+  if shared_tree is None:
+    return None
+
+  pending = [
+    change for change in _landed_equivalent_changes(repo)
+    if ref_is_ancestor(repo, change.source_sha, local) is True
+    and _change_landed_in_target(repo, change, upstream)
+  ]
+  if not pending:
+    return None
+
+  applied: list[EquivalentChange] = []
+  while pending:
+    deferred: list[EquivalentChange] = []
+    progressed = False
+    for change in pending:
+      try:
+        combined = merge_refs(
+          repo,
+          shared_tree,
+          change.anchor_sha,
+          merge_base=change.base_sha,
+        )
+      except (OSError, subprocess.SubprocessError, RuntimeError):
+        deferred.append(change)
+        continue
+      if combined.status != "clean" or not combined.merged_tree_oid:
+        deferred.append(change)
+        continue
+      shared_tree = combined.merged_tree_oid
+      applied.append(change)
+      progressed = True
+    if not progressed:
+      break
+    pending = deferred
+
+  if not applied:
+    return None
+  try:
+    merged = merge_refs(repo, local, upstream, merge_base=shared_tree)
+  except (OSError, subprocess.SubprocessError, RuntimeError):
+    return None
+  if merged.status != "clean" or not merged.merged_tree_oid:
+    return None
+  merged.equivalent_change_refs = tuple(change.ref for change in applied)
+  return merged
+
+
+def retire_landed_equivalent_changes(
+  source_dir: str | Path, integrated_upstream: str,
+) -> int:
+  """Drop landed anchors made obsolete by a successfully integrated target."""
+  repo = Path(source_dir)
+  retired = 0
+  for change in _landed_equivalent_changes(repo):
+    if _change_landed_in_target(repo, change, integrated_upstream):
+      proc = _run(repo, "update-ref", "-d", change.ref, check=False)
+      retired += int(proc.returncode == 0)
+  return retired
 
 
 def restore_upstream_ref(source_dir: str | Path, expected_sha: str | None) -> bool:
@@ -975,11 +1651,20 @@ def commit_local(source_dir: str | Path, msg: str) -> str | None:
     # MERGE_HEAD is set), fanning history into a 2-parent merge; we want the
     # squashed `A -> B -> X` shape instead, identical to commit_replay.
     merge_head = merge_head_path.read_text(encoding="utf-8").strip()
+    old_local = head_sha(repo, LOCAL_BRANCH)
     tree = _run(repo, "write-tree").stdout.strip()
     sha = _run(
       repo, "commit-tree", tree, "-p", merge_head, "-m", msg,
     ).stdout.strip()
     _run(repo, "update-ref", f"refs/heads/{LOCAL_BRANCH}", sha)
+    try:
+      carry_equivalent_change_sources(repo, old_local, sha)
+    except Exception:
+      # The accepted replay is already committed. A stale witness only means a
+      # later update may ask the agent; it must not make this resolution appear
+      # failed after the source branch has moved.
+      log.warning("could not carry contribution provenance across replay",
+                  exc_info=True)
     for name in ("MERGE_HEAD", "MERGE_MSG", "MERGE_MODE"):
       (repo / ".git" / name).unlink(missing_ok=True)
     return sha
@@ -1019,6 +1704,7 @@ def commit_replay(
   """
   repo = Path(source_dir)
   ensure_repo(repo)
+  old_local = head_sha(repo, LOCAL_BRANCH)
   _refresh_ignore_rules(repo)
   _run(repo, "add", *_tracked_source(repo))
   tree = _run(repo, "write-tree").stdout.strip()
@@ -1033,6 +1719,11 @@ def commit_replay(
     repo, "commit-tree", tree, "-p", upstream_tip, "-m", msg,
   ).stdout.strip()
   _run(repo, "update-ref", f"refs/heads/{LOCAL_BRANCH}", sha)
+  try:
+    carry_equivalent_change_sources(repo, old_local, sha)
+  except Exception:
+    log.warning("could not carry contribution provenance across replay",
+                exc_info=True)
   return sha
 
 
@@ -1115,31 +1806,18 @@ def merge_upstream(source_dir: str | Path) -> MergeResult:
   repo = Path(source_dir)
   ensure_repo(repo)
   _unshallow_if_no_merge_base(repo)
-  proc = _run(
-    repo, "merge-tree", "--write-tree", "--name-only",
-    LOCAL_BRANCH, UPSTREAM_BRANCH,
-    check=False,
+  ordinary = merge_refs(repo, LOCAL_BRANCH, UPSTREAM_BRANCH)
+  if ordinary.status == "clean":
+    return ordinary
+  # A normal three-way merge can conflict when both sides carry the same
+  # contributed change under different commit identities and local work later
+  # evolved those lines.  Only replace the base when Contribute recorded both
+  # causal witnesses; otherwise preserve the ordinary conflict verbatim for the
+  # owner-gated agent resolver.
+  equivalent = merge_with_equivalent_changes(
+    repo, LOCAL_BRANCH, UPSTREAM_BRANCH,
   )
-  # merge-tree exits 0 on a clean merge, 1 on conflicts, >1 on real
-  # errors. stdout's first line is always the merged tree oid. On a
-  # conflict the `--name-only` section follows: the conflicting file
-  # paths are the lines AFTER the oid up to the first blank line; the
-  # lines after that blank are human-readable "CONFLICT (...)" messages,
-  # not paths.
-  if proc.returncode > 1:
-    raise RuntimeError(
-      f"git merge-tree failed (rc={proc.returncode}): {proc.stderr.strip()}"
-    )
-  lines = proc.stdout.splitlines()
-  tree_oid = lines[0].strip() if lines else ""
-  if proc.returncode == 1:
-    conflict_paths: list[str] = []
-    for ln in lines[1:]:
-      if not ln.strip():
-        break  # blank line ends the path section
-      conflict_paths.append(ln.strip())
-    return MergeResult(status="conflict", conflict_paths=conflict_paths)
-  return MergeResult(status="clean", merged_tree_oid=tree_oid)
+  return equivalent or ordinary
 
 
 def read_merged_tree(source_dir: str | Path, tree_oid: str) -> dict[str, bytes]:

--- a/backend/app/install.py
+++ b/backend/app/install.py
@@ -2330,6 +2330,7 @@ async def install_from_manifest(
   # means a plain local commit (fresh install, or a conflict that left local
   # untouched).
   merge_applied = False
+  equivalence_target_to_retire: str | None = None
   if icon_warning:
     warnings.append(icon_warning)
 
@@ -2845,6 +2846,11 @@ async def install_from_manifest(
                 source_tree = merged_source
                 divergence = "clean_merge"
                 merge_applied = True
+                if merge.equivalent_change_refs:
+                  warnings.append(
+                    "reconciled reviewed changes that were already present "
+                    "upstream"
+                  )
                 # Read exec bits only now that we WILL write this tree — a
                 # conflict/unreadable verdict never ls-tree's the (possibly
                 # degenerate) merged oid.
@@ -3112,6 +3118,7 @@ async def install_from_manifest(
                 app_git.commit_replay, source_dir_path,
                 app.upstream_commit, commit_msg,
               )
+              equivalence_target_to_retire = app.upstream_commit
             else:
               await asyncio.to_thread(
                 app_git.commit_local, source_dir_path, commit_msg,
@@ -3178,6 +3185,24 @@ async def install_from_manifest(
     rollback_actions.clear()
     created_paths.clear()
     db.refresh(app)
+
+    # Only the durable update may retire provenance.  Doing this before the DB
+    # commit would lose the witness if a later storage/row failure rolled the
+    # install back.  Ref deletion is best-effort post-commit housekeeping: the
+    # replay already parents `main` directly on this upstream target, so keeping
+    # an obsolete ref is harmless while deleting it bounds metadata growth.
+    if app.source_dir and equivalence_target_to_retire:
+      try:
+        async with fs_locks.source_dir_lock(str(app.source_dir)):
+          await asyncio.to_thread(
+            app_git.retire_landed_equivalent_changes,
+            app.source_dir, equivalence_target_to_retire,
+          )
+      except Exception:
+        log.warning(
+          "install: could not retire integrated contribution provenance",
+          exc_info=True,
+        )
 
     # app_install: log only after the row is durable so the timestamp
     # in the activity log reflects when the install actually landed,

--- a/backend/app/platform_update.py
+++ b/backend/app/platform_update.py
@@ -629,6 +629,37 @@ def _merge_target(repo: Path, target: str) -> int:
     return _MERGE_TIMEOUT
 
 
+def _commit_equivalent_merge_tree(
+  repo: Path,
+  *,
+  local: str,
+  pre_sha: str,
+  target: str,
+  tree_oid: str,
+) -> str:
+  """Commit a proven semantic merge while preserving both real histories.
+
+  ``merge_with_equivalent_changes`` computes the tree entirely off-worktree.
+  The compare-and-swap update refuses if another writer moved the local branch
+  after ``pre_sha``; only after that succeeds do we reset the checked-out tree
+  to the new two-parent merge commit.  The target remains an explicit parent,
+  so every later update falls back to ordinary ancestry with no side metadata.
+  """
+  sha = app_git._run(
+    repo,
+    "commit-tree", tree_oid,
+    "-p", pre_sha,
+    "-p", target,
+    "-m", f"platform: merge equivalent upstream {target[:12]}",
+  ).stdout.strip()
+  _git(
+    "update-ref", f"refs/heads/{local}", sha, pre_sha,
+    repo=repo,
+  )
+  _git("reset", "--hard", sha, repo=repo)
+  return sha
+
+
 def _reset_hard_to(repo: Path, local: str, sha: str) -> None:
   """Return the working branch to ``sha`` (the pre-reconcile served commit),
   updating the working tree. Used to serve OLD after a conflict/rollback."""
@@ -1278,12 +1309,32 @@ def reconcile_clone(
           _clear_reconcile_pre()
           err = "merge_timeout" if rc == _MERGE_TIMEOUT else "merge_failed"
           return ReconcileResult("error", pre, pre, target, error=err)
-        # Content conflict: record it, clear any stale rollback flag, and let the
-        # caller open a resolver chat.
-        _write_conflict_flag(target, paths)
-        ROLLED_BACK_FLAG.unlink(missing_ok=True)
-        _clear_reconcile_pre()
-        return ReconcileResult("conflict", pre, pre, target, conflict_paths=paths)
+        # Before asking the owner to resolve a content conflict, let the shared
+        # app/platform provenance engine replace Git's historical base with a
+        # semantic base made ONLY from reviewed changes proven to come from this
+        # local history and to have landed in this target history.  This is the
+        # squash/batch case: ordinary Git sees two edits to the same lines, while
+        # the causal record says one side is the already-contributed predecessor
+        # of the other.  The engine is off-tree and fail-closed; no proof (or a
+        # genuine later conflict) returns None and preserves the resolver path.
+        equivalent = app_git.merge_with_equivalent_changes(repo, pre, target)
+        if equivalent is not None and equivalent.merged_tree_oid:
+          _commit_equivalent_merge_tree(
+            repo,
+            local=local,
+            pre_sha=pre,
+            target=target,
+            tree_oid=equivalent.merged_tree_oid,
+          )
+        else:
+          # Genuine/unproven content conflict: record it, clear any stale
+          # rollback flag, and let the caller open a resolver chat.
+          _write_conflict_flag(target, paths)
+          ROLLED_BACK_FLAG.unlink(missing_ok=True)
+          _clear_reconcile_pre()
+          return ReconcileResult(
+            "conflict", pre, pre, target, conflict_paths=paths,
+          )
 
     # Post-reconcile import probe: a text-clean ff/merge can still produce a
     # tree that fails to import (upstream dropped a module a local edit imports;
@@ -1315,6 +1366,13 @@ def reconcile_clone(
   # restart the flag would ask for); an owner Apply marks a restart via the
   # caller.
   new_sha = _rev(repo, local)
+  try:
+    app_git.retire_landed_equivalent_changes(repo, target)
+  except Exception:
+    # The target is already committed and validated.  A stale provenance ref is
+    # harmless and can be retired by the next update; never turn housekeeping
+    # into a false failed-update report after source has moved.
+    log.warning("platform: could not retire contribution provenance", exc_info=True)
   _set_upstream(repo, target)
   CONFLICT_FLAG.unlink(missing_ok=True)
   ROLLED_BACK_FLAG.unlink(missing_ok=True)

--- a/backend/app/routes/github.py
+++ b/backend/app/routes/github.py
@@ -57,7 +57,7 @@ from slowapi import Limiter
 from slowapi.util import get_remote_address
 from sqlalchemy.orm import Session
 
-from app import fs_locks, github_auth, models, source_status
+from app import app_git, fs_locks, github_auth, models, source_status
 from app.config import get_settings
 from app.database import get_db
 from app.deps import (
@@ -386,6 +386,173 @@ def _safe_repo_path(raw: object) -> Path:
     "Ask the agent to prepare it again from /data/contrib, /data/apps, or "
     "/data/platform; nothing was sent to GitHub."
   )
+
+
+def _safe_equivalence_source_path(raw: object) -> Path:
+  """Installed app/platform repo allowed to own durable provenance refs."""
+  repo = _safe_repo_path(raw)
+  data_dir = Path(get_settings().data_dir).resolve()
+  platform = data_dir / "platform"
+  apps = data_dir / "apps"
+  if repo != platform and not repo.is_relative_to(apps):
+    raise ContributionSubmitError(
+      "The contribution source must be an installed app or the live platform."
+    )
+  if not app_git.is_repo(repo):
+    raise ContributionSubmitError(
+      "The contribution source is no longer a Git-backed app or platform."
+    )
+  return repo
+
+
+def _equivalence_source_repo(record: dict) -> tuple[Path, Path] | None:
+  """Return ``(installed source, review checkout)`` for one contribution."""
+  plan = record.get("plan") if isinstance(record.get("plan"), dict) else {}
+  review_repo = _safe_repo_path(plan.get("repo_path"))
+  raw_source_repo = plan.get("source_repo_path")
+  if raw_source_repo:
+    return _safe_equivalence_source_path(raw_source_repo), review_repo
+  primary = app_git.primary_worktree_path(review_repo)
+  if primary is not None:
+    return _safe_equivalence_source_path(str(primary)), review_repo
+  # Legacy prepared records sometimes used the installed source checkout
+  # directly rather than a linked worktree. It is already under the stricter
+  # apps/platform allowlist, so it can safely own the witness itself.
+  try:
+    return _safe_equivalence_source_path(str(review_repo)), review_repo
+  except ContributionSubmitError:
+    return None
+
+
+def _record_pending_equivalence(record: dict) -> str | None:
+  """Persist the reviewed local-history witness after the owner sends a PR.
+
+  Linked review worktrees derive their primary live checkout automatically.
+  Standalone app review clones carry an explicit ``plan.source_repo_path``;
+  :mod:`app_git` copies only the verified reviewed commits into that installed
+  repo before recording the witness. A prepared record should pin
+  ``plan.source_sha``; old linked records safely use the primary HEAD observed
+  at send time.
+  """
+  plan = record.get("plan") if isinstance(record.get("plan"), dict) else {}
+  repos = _equivalence_source_repo(record)
+  if repos is None:
+    return None
+  source_repo, review_repo = repos
+  source_sha = str(plan.get("source_sha") or "").strip()
+  current_source = app_git.head_sha(source_repo, "HEAD")
+  if not source_sha:
+    source_sha = current_source
+  elif (
+    current_source
+    and source_sha != current_source
+    and app_git.ref_is_ancestor(source_repo, source_sha, current_source) is not True
+  ):
+    # The app model may have replayed the accepted tree onto a new upstream
+    # parent before Send, so the captured commit is no longer causal history.
+    # Use the stable current tip; the exact diff/tree proof below still decides.
+    source_sha = current_source
+  if not source_sha:
+    return None
+  kwargs = {
+    "base_sha": str(plan.get("base_sha") or ""),
+    "head_sha": str(plan.get("head_sha") or ""),
+    "diff_sha256": str(plan.get("diff_sha256") or ""),
+    "contribution_id": str(record.get("id") or ""),
+    "review_source_dir": review_repo,
+  }
+  recorded = app_git.record_pending_equivalent_change(
+    source_repo, source_sha=source_sha, **kwargs,
+  )
+  if recorded is not None:
+    return recorded
+  # An App Store update can intentionally replay the accepted source tree onto
+  # a new upstream parent between preparation and Send. Under the source lock,
+  # retry the *current* immutable tip: record_pending repeats the exact diff-hash
+  # and tree-subsumption proofs, so this carries a preserved change across that
+  # pre-witness rewrite without blessing a source that removed the change.
+  if current_source and current_source != source_sha:
+    return app_git.record_pending_equivalent_change(
+      source_repo, source_sha=current_source, **kwargs,
+    )
+  return None
+
+
+async def _record_pending_equivalence_locked(
+  record: dict,
+  *,
+  already_locked: frozenset[str] = frozenset(),
+) -> str | None:
+  """Serialize witness creation with an App Store source-history replay."""
+  repos = await asyncio.to_thread(_equivalence_source_repo, record)
+  if repos is None:
+    return None
+  source_repo, _review_repo = repos
+  if str(source_repo) in already_locked:
+    return await asyncio.to_thread(_record_pending_equivalence, record)
+  async with fs_locks.source_dir_lock(str(source_repo)):
+    return await asyncio.to_thread(_record_pending_equivalence, record)
+
+
+def _merged_upstream_sha(record: dict, repo: Path) -> str | None:
+  """Best available immutable upstream commit for a terminal merged record."""
+  for value in (
+    record.get("last_land_head_sha"),
+    record.get("merge_commit_sha"),
+    (record.get("checks") or {}).get("merge_commit_sha")
+    if isinstance(record.get("checks"), dict) else None,
+  ):
+    candidate = str(value or "").strip().lower()
+    if _GIT_SHA.fullmatch(candidate):
+      return candidate
+
+  plan = record.get("plan") if isinstance(record.get("plan"), dict) else {}
+  repo_slug = plan.get("repo") or record.get("repo")
+  number = record.get("number")
+  if not isinstance(repo_slug, str) or not _GITHUB_REPO.fullmatch(repo_slug):
+    return None
+  if not isinstance(number, int) or number <= 0:
+    return None
+  try:
+    proc = _gh(
+      repo,
+      "pr", "view", str(number),
+      "-R", repo_slug,
+      "--json", "state,mergeCommit",
+      check=False,
+    )
+  except (OSError, subprocess.SubprocessError):
+    return None
+  if proc.returncode != 0:
+    return None
+  try:
+    payload = json.loads(proc.stdout or "{}")
+  except ValueError:
+    return None
+  merge_commit = payload.get("mergeCommit") if isinstance(payload, dict) else None
+  candidate = (
+    str(merge_commit.get("oid") or "").strip().lower()
+    if isinstance(merge_commit, dict) and payload.get("state") == "MERGED"
+    else ""
+  )
+  return candidate if _GIT_SHA.fullmatch(candidate) else None
+
+
+def _settle_equivalence(record: dict, upstream_sha: str | None = None) -> str | None:
+  """Promote or discard the pending witness when GitHub settles the PR."""
+  plan = record.get("plan") if isinstance(record.get("plan"), dict) else {}
+  repos = _equivalence_source_repo(record)
+  if repos is None:
+    return None
+  repo, _review_repo = repos
+  digest = str(plan.get("diff_sha256") or "")
+  if record.get("status") == "merged":
+    return app_git.mark_equivalent_change_landed(
+      repo, digest, upstream_sha=upstream_sha,
+    )
+  if record.get("status") == "closed":
+    app_git.discard_pending_equivalent_change(repo, digest)
+  return None
 
 
 def _cleanup_terminal_staging_checkout(record: dict) -> bool:
@@ -3716,10 +3883,36 @@ async def submit_contribution(
   try:
     plan = claimed.get("plan") or {}
     repo_path = _safe_repo_path(plan.get("repo_path"))
-    async with fs_locks.source_dir_lock(str(repo_path)):
+    lock_paths = {str(repo_path)}
+    try:
+      equivalence_repos = _equivalence_source_repo(claimed)
+      if equivalence_repos is not None:
+        lock_paths.add(str(equivalence_repos[0]))
+    except Exception:
+      # An absent/legacy provenance destination must not block the reviewed PR.
+      pass
+    async with AsyncExitStack() as source_locks:
+      for lock_path in sorted(lock_paths):
+        await source_locks.enter_async_context(
+          fs_locks.source_dir_lock(lock_path)
+        )
       pr_url, number, record_patch = await asyncio.to_thread(
         _submit_prepared_pr, claimed, diff_path,
       )
+      try:
+        await _record_pending_equivalence_locked(
+          {**claimed, **record_patch},
+          already_locked=frozenset(lock_paths),
+        )
+      except Exception:
+        # The PR already exists at this point.  Provenance is an automatic
+        # conflict-avoidance optimization, never a reason to misreport the
+        # owner-approved public action as failed; an absent witness simply keeps
+        # the conservative agent resolver fallback.
+        log.warning(
+          "contribution equivalence witness failed %s/%s",
+          app_id, record_id, exc_info=True,
+        )
   except ContributionSubmitError as exc:
     async with fs_locks.app_storage_lock(app_id):
       _recheck_submit_app(db, app_id, expected_nonce)
@@ -3839,11 +4032,19 @@ async def submit_contribution_stack(
   db.close()
 
   try:
-    repo_paths = sorted({
+    lock_paths = {
       str(_safe_repo_path((row["record"].get("plan") or {}).get("repo_path")))
       for row in rows
       if row["record"].get("status") == "submitting"
-    })
+    }
+    for row in rows:
+      try:
+        repos = _equivalence_source_repo(row["record"])
+        if repos is not None:
+          lock_paths.add(str(repos[0]))
+      except Exception:
+        pass
+    repo_paths = sorted(lock_paths)
     async with AsyncExitStack() as source_locks:
       for repo_path in repo_paths:
         await source_locks.enter_async_context(
@@ -3863,6 +4064,16 @@ async def submit_contribution_stack(
             row["diff_path"],
             direct_base_branch=row["stack"]["base_branch"],
           )
+          try:
+            await _record_pending_equivalence_locked(
+              {**record, **record_patch},
+              already_locked=frozenset(repo_paths),
+            )
+          except Exception:
+            log.warning(
+              "stack contribution equivalence witness failed %s/%s",
+              app_id, record.get("id"), exc_info=True,
+            )
         except ContributionSubmitError as exc:
           async with fs_locks.app_storage_lock(app_id):
             _recheck_submit_app(db, app_id, expected_nonce)
@@ -3967,10 +4178,18 @@ async def land_contribution_stack(
   db.close()
 
   try:
-    repo_paths = sorted({
+    lock_paths = {
       str(_safe_repo_path((row["record"].get("plan") or {}).get("repo_path")))
       for row in rows
-    })
+    }
+    for row in rows:
+      try:
+        repos = _equivalence_source_repo(row["record"])
+        if repos is not None:
+          lock_paths.add(str(repos[0]))
+      except Exception:
+        pass
+    repo_paths = sorted(lock_paths)
     async with AsyncExitStack() as source_locks:
       for repo_path in repo_paths:
         await source_locks.enter_async_context(
@@ -3987,6 +4206,35 @@ async def land_contribution_stack(
         target_branch, landed_sha = await asyncio.to_thread(
           _land_reviewed_stack, rows,
         )
+      # Atomic app-stack landing already knows the exact upstream commit; do
+      # not wait for a later cron cleanup to promote the pending witnesses.
+      for row in rows:
+        record = row["record"]
+        plan = record.get("plan") if isinstance(record.get("plan"), dict) else {}
+        try:
+          repos = _equivalence_source_repo(record)
+          if repos is None:
+            continue
+          if str(repos[0]) in repo_paths:
+            await asyncio.to_thread(
+              app_git.mark_equivalent_change_landed,
+              repos[0],
+              str(plan.get("diff_sha256") or ""),
+              upstream_sha=landed_sha,
+            )
+          else:
+            async with fs_locks.source_dir_lock(str(repos[0])):
+              await asyncio.to_thread(
+                app_git.mark_equivalent_change_landed,
+                repos[0],
+                str(plan.get("diff_sha256") or ""),
+                upstream_sha=landed_sha,
+              )
+        except Exception:
+          log.warning(
+            "landed stack equivalence promotion failed %s/%s",
+            app_id, record.get("id"), exc_info=True,
+          )
   except ContributionSubmitError as exc:
     async with fs_locks.app_storage_lock(app_id):
       _recheck_submit_app(db, app_id, expected_nonce)
@@ -4052,7 +4300,19 @@ async def cleanup_contribution_staging(
     record = _read_record(record_path)
   plan = record.get("plan") if isinstance(record.get("plan"), dict) else {}
   repo = _safe_repo_path(plan.get("repo_path"))
-  async with fs_locks.source_dir_lock(str(repo)):
+  equivalence_repos = _equivalence_source_repo(record)
+  upstream_sha = None
+  if record.get("status") == "merged":
+    upstream_sha = await asyncio.to_thread(_merged_upstream_sha, record, repo)
+  lock_repo = equivalence_repos[0] if equivalence_repos else repo
+  async with fs_locks.source_dir_lock(str(lock_repo)):
+    try:
+      await asyncio.to_thread(_settle_equivalence, record, upstream_sha)
+    except Exception:
+      log.warning(
+        "terminal contribution equivalence settlement failed %s/%s",
+        app_id, record_id, exc_info=True,
+      )
     cleaned = await asyncio.to_thread(_cleanup_terminal_staging_checkout, record)
   # Terminal cleanup also ends autopilot: the PR merged/closed, so release any
   # claim and disable the grant (symmetric with the submit-time grant stamp).

--- a/backend/tests/test_app_git.py
+++ b/backend/tests/test_app_git.py
@@ -8,6 +8,7 @@ combined edits) and a conflict must name the file WITHOUT touching the
 working tree.
 """
 
+import hashlib
 import os
 import stat
 import subprocess
@@ -975,6 +976,515 @@ def test_merge_conflict_names_paths_and_leaves_worktree_intact(tmp_path):
   assert result.merged_tree_oid is None
   # The verdict must NOT have written conflict markers into the live file.
   assert (repo / "index.jsx").read_text() == worktree_before
+
+
+def _review_digest(repo: Path, base: str, head: str) -> str:
+  reviewed = app_git._canonical_diff(repo, base, head)
+  assert reviewed is not None
+  return hashlib.sha256(reviewed).hexdigest()
+
+
+def test_primary_worktree_path_distinguishes_linked_from_standalone(tmp_path):
+  repo = tmp_path / "app"
+  _install(repo, b"base\n")
+  linked = tmp_path / "review"
+  app_git._run(repo, "worktree", "add", "-q", "-b", "review", str(linked))
+
+  assert app_git.primary_worktree_path(repo) is None
+  assert app_git.primary_worktree_path(linked) == repo.resolve()
+
+
+def test_landed_equivalent_change_rebases_later_local_edit_without_agent(
+  tmp_path,
+):
+  """A squash merge of an already-contributed line is a semantic base.
+
+  Ordinary Git conflicts because local evolved ``base -> shared -> followup``
+  while the fetched upstream commit independently says ``base -> shared``.
+  The reviewed source witness plus landed target witness lets the off-tree merge
+  use ``shared`` as the base, preserving the follow-up and the genuinely new
+  upstream file.
+  """
+  repo = tmp_path / "app"
+  _install(repo, b'mode = "base"\n')
+  base = app_git.head_sha(repo, app_git.UPSTREAM_BRANCH)
+
+  _write(repo, 'mode = "shared contribution"\n')
+  reviewed_head = app_git.commit_local(repo, "reviewed contribution")
+  assert reviewed_head
+  digest = _review_digest(repo, base, reviewed_head)
+  pending = app_git.record_pending_equivalent_change(
+    repo,
+    base_sha=base,
+    head_sha=reviewed_head,
+    source_sha=reviewed_head,
+    diff_sha256=digest,
+    contribution_id="reviewed-change",
+  )
+  assert pending
+
+  _write(repo, 'mode = "local followup"\n')
+  local_head = app_git.commit_local(repo, "later local edit")
+  assert local_head
+  upstream = app_git.record_upstream(
+    repo,
+    {
+      "index.jsx": b'mode = "shared contribution"\n',
+      "upstream.js": b"export const upstream = true\n",
+    },
+    "https://x/mobius.json",
+    "2.0.0",
+  )
+
+  # Pending provenance alone grants no update authority.
+  assert app_git.merge_refs(
+    repo, app_git.LOCAL_BRANCH, app_git.UPSTREAM_BRANCH,
+  ).status == "conflict"
+  assert app_git.merge_upstream(repo).status == "conflict"
+
+  landed = app_git.mark_equivalent_change_landed(
+    repo, digest, upstream_sha=upstream,
+  )
+  assert landed
+  result = app_git.merge_upstream(repo)
+
+  assert result.status == "clean"
+  assert result.equivalent_change_refs == (landed,)
+  tree = app_git.read_merged_tree(repo, result.merged_tree_oid)
+  assert tree["index.jsx"] == b'mode = "local followup"\n'
+  assert tree["upstream.js"] == b"export const upstream = true\n"
+  # The proof is off-tree: neither the accepted branch nor live source moved.
+  assert app_git.head_sha(repo, app_git.LOCAL_BRANCH) == local_head
+  assert (repo / "index.jsx").read_text() == 'mode = "local followup"\n'
+
+
+def test_agent_resolved_local_projection_becomes_a_durable_shared_base(
+  tmp_path,
+):
+  """A reviewed PR projected from a busier local base is recognized later."""
+  repo = tmp_path / "app"
+  app_git.ensure_repo(repo)
+  app_git.record_upstream(
+    repo,
+    {"index.jsx": b"base\n", "helper.js": b"helper base\n"},
+    "https://x/mobius.json", "1.0.0",
+  )
+  app_git.align_local_to_upstream(repo)
+  base = app_git.head_sha(repo, app_git.UPSTREAM_BRANCH)
+
+  # The clean review projection on current upstream changes these two paths.
+  _write(repo, "reviewed\n")
+  (repo / "helper.js").write_text("helper reviewed\n")
+  reviewed = app_git.commit_local(repo, "review projection")
+  assert reviewed
+  digest = _review_digest(repo, base, reviewed)
+
+  # Live source had a conflicting local context first. Its integration commit
+  # changes the same reviewed path set, matches Git's automatic result on every
+  # non-conflict entry, and owns the two explicit conflict resolutions.
+  app_git._run(repo, "reset", "--hard", base)
+  _write(repo, "local context\n")
+  assert app_git.commit_local(repo, "pre-existing local context")
+  _write(repo, "local context + reviewed behavior\n")
+  (repo / "helper.js").write_text("helper reviewed\n")
+  source = app_git.commit_local(repo, "integrate reviewed behavior locally")
+  assert source
+  assert not app_git._change_is_subsumed(repo, base, reviewed, source)
+
+  pending = app_git.record_pending_equivalent_change(
+    repo,
+    base_sha=base,
+    head_sha=reviewed,
+    source_sha=source,
+    diff_sha256=digest,
+    contribution_id="resolved-local-projection",
+  )
+  assert pending
+  recorded = app_git._read_equivalent_change(repo, pending)
+  assert recorded is not None
+  assert recorded.proof_mode == "resolved_projection"
+
+  upstream = app_git.record_upstream(
+    repo,
+    {
+      "index.jsx": b"reviewed\n",
+      "helper.js": b"helper reviewed\n",
+      "upstream.js": b"release\n",
+    },
+    "https://x/mobius.json", "2.0.0",
+  )
+  assert app_git.mark_equivalent_change_landed(
+    repo, digest, upstream_sha=upstream,
+  )
+  result = app_git.merge_upstream(repo)
+
+  assert result.status == "clean"
+  tree = app_git.read_merged_tree(repo, result.merged_tree_oid)
+  assert tree["index.jsx"] == b"local context + reviewed behavior\n"
+  assert tree["helper.js"] == b"helper reviewed\n"
+  assert tree["upstream.js"] == b"release\n"
+
+
+def test_all_conflict_projection_is_too_ambiguous_to_record(tmp_path):
+  """One arbitrary conflict resolution is not evidence of shared history."""
+  repo = tmp_path / "app"
+  _install(repo, b"base\n")
+  base = app_git.head_sha(repo, app_git.UPSTREAM_BRANCH)
+  _write(repo, "reviewed\n")
+  reviewed = app_git.commit_local(repo, "review projection")
+  assert reviewed
+  digest = _review_digest(repo, base, reviewed)
+
+  app_git._run(repo, "reset", "--hard", base)
+  _write(repo, "different local context\n")
+  assert app_git.commit_local(repo, "local context")
+  _write(repo, "arbitrary resolution\n")
+  source = app_git.commit_local(repo, "resolve one conflicted path")
+  assert source
+
+  assert app_git.record_pending_equivalent_change(
+    repo,
+    base_sha=base,
+    head_sha=reviewed,
+    source_sha=source,
+    diff_sha256=digest,
+    contribution_id="all-conflict-is-ambiguous",
+  ) is None
+
+
+def test_multiple_landed_changes_form_one_shared_base_for_a_squash_batch(
+  tmp_path,
+):
+  """Several reviewed records mapped to one squash commit combine safely.
+
+  This is the shape that previously forced a hand merge: each local follow-up
+  conflicts with its contributed predecessor in the batch, while neither
+  individual anchor is enough.  Deterministic anchor composition produces the
+  reviewed shared tree before the final merge.
+  """
+  repo = tmp_path / "app"
+  app_git.ensure_repo(repo)
+  app_git.record_upstream(
+    repo,
+    {"index.jsx": b"A base\n", "panel.js": b"B base\n"},
+    "https://x/mobius.json",
+    "1.0.0",
+  )
+  app_git.align_local_to_upstream(repo)
+  base = app_git.head_sha(repo, app_git.UPSTREAM_BRANCH)
+
+  _write(repo, "A shared\n")
+  first = app_git.commit_local(repo, "first reviewed change")
+  assert first
+  first_digest = _review_digest(repo, base, first)
+  assert app_git.record_pending_equivalent_change(
+    repo,
+    base_sha=base,
+    head_sha=first,
+    source_sha=first,
+    diff_sha256=first_digest,
+    contribution_id="first",
+  )
+
+  (repo / "panel.js").write_text("B shared\n")
+  second = app_git.commit_local(repo, "second reviewed change")
+  assert second
+  second_digest = _review_digest(repo, first, second)
+  assert app_git.record_pending_equivalent_change(
+    repo,
+    base_sha=first,
+    head_sha=second,
+    source_sha=second,
+    diff_sha256=second_digest,
+    contribution_id="second",
+  )
+
+  _write(repo, "A local followup\n")
+  (repo / "panel.js").write_text("B local followup\n")
+  assert app_git.commit_local(repo, "follow up both contributed changes")
+  upstream = app_git.record_upstream(
+    repo,
+    {
+      "index.jsx": b"A shared\n",
+      "panel.js": b"B shared\n",
+      "new.js": b"upstream only\n",
+    },
+    "https://x/mobius.json",
+    "2.0.0",
+  )
+  assert app_git.merge_refs(
+    repo, app_git.LOCAL_BRANCH, app_git.UPSTREAM_BRANCH,
+  ).status == "conflict"
+
+  assert app_git.mark_equivalent_change_landed(
+    repo, first_digest, upstream_sha=upstream,
+  )
+  assert app_git.mark_equivalent_change_landed(
+    repo, second_digest, upstream_sha=upstream,
+  )
+  result = app_git.merge_upstream(repo)
+
+  assert result.status == "clean"
+  assert len(result.equivalent_change_refs) == 2
+  tree = app_git.read_merged_tree(repo, result.merged_tree_oid)
+  assert tree["index.jsx"] == b"A local followup\n"
+  assert tree["panel.js"] == b"B local followup\n"
+  assert tree["new.js"] == b"upstream only\n"
+
+
+def test_equivalent_change_is_ignored_when_source_witness_left_local_history(
+  tmp_path,
+):
+  """A landed PR from another/replaced local line cannot authorize a merge."""
+  repo = tmp_path / "app"
+  _install(repo, b"base\n")
+  base = app_git.head_sha(repo, app_git.UPSTREAM_BRANCH)
+  _write(repo, "shared\n")
+  reviewed = app_git.commit_local(repo, "reviewed")
+  assert reviewed
+  digest = _review_digest(repo, base, reviewed)
+  assert app_git.record_pending_equivalent_change(
+    repo,
+    base_sha=base,
+    head_sha=reviewed,
+    source_sha=reviewed,
+    diff_sha256=digest,
+    contribution_id="replaced-history",
+  )
+
+  # Replace main with a sibling edit that never descends from the witnessed
+  # source commit.  The upstream side still lands the reviewed bytes.
+  app_git._run(repo, "reset", "--hard", base)
+  _write(repo, "different local\n")
+  assert app_git.commit_local(repo, "replacement branch")
+  upstream = app_git.record_upstream(
+    repo, {"index.jsx": b"shared\n"},
+    "https://x/mobius.json", "2.0.0",
+  )
+  assert app_git.mark_equivalent_change_landed(
+    repo, digest, upstream_sha=upstream,
+  )
+
+  assert app_git.merge_upstream(repo).status == "conflict"
+
+
+def test_equivalent_change_is_ignored_when_merge_witness_is_not_in_target(
+  tmp_path,
+):
+  """A PR merged on another branch cannot authorize this update target."""
+  repo = tmp_path / "app"
+  _install(repo, b"base\n")
+  base = app_git.head_sha(repo, app_git.UPSTREAM_BRANCH)
+  _write(repo, "shared\n")
+  reviewed = app_git.commit_local(repo, "reviewed")
+  assert reviewed
+  digest = _review_digest(repo, base, reviewed)
+  assert app_git.record_pending_equivalent_change(
+    repo,
+    base_sha=base,
+    head_sha=reviewed,
+    source_sha=reviewed,
+    diff_sha256=digest,
+    contribution_id="wrong-upstream-line",
+  )
+
+  _write(repo, "local followup\n")
+  assert app_git.commit_local(repo, "later local edit")
+  target = app_git.record_upstream(
+    repo, {"index.jsx": b"shared\n"},
+    "https://x/mobius.json", "2.0.0",
+  )
+  # The reviewed tree exists under a different, root commit identity, but that
+  # commit is not reachable from the fetched update target.
+  reviewed_tree = app_git._tree_oid(repo, reviewed)
+  assert reviewed_tree
+  other_line = app_git._run(
+    repo, "commit-tree", reviewed_tree, "-m", "merged elsewhere",
+  ).stdout.strip()
+  assert app_git.mark_equivalent_change_landed(
+    repo, digest, upstream_sha=other_line,
+  )
+
+  assert app_git.ref_is_ancestor(repo, other_line, target) is False
+  assert app_git.merge_upstream(repo).status == "conflict"
+
+
+def test_merge_witness_that_dropped_reviewed_bytes_cannot_authorize_merge(
+  tmp_path,
+):
+  """A merged status cannot bless merge-queue conflict-resolution drift."""
+  repo = tmp_path / "app"
+  _install(repo, b"base\n")
+  base = app_git.head_sha(repo, app_git.UPSTREAM_BRANCH)
+  _write(repo, "reviewed\n")
+  reviewed = app_git.commit_local(repo, "reviewed")
+  assert reviewed
+  digest = _review_digest(repo, base, reviewed)
+  assert app_git.record_pending_equivalent_change(
+    repo,
+    base_sha=base,
+    head_sha=reviewed,
+    source_sha=reviewed,
+    diff_sha256=digest,
+    contribution_id="dropped-by-merge-resolution",
+  )
+  _write(repo, "local followup\n")
+  assert app_git.commit_local(repo, "later local edit")
+
+  # The PR is reported merged at this exact commit, but its tree does not carry
+  # the reviewed delta (for example, a bad merge-queue conflict resolution).
+  target = app_git.record_upstream(
+    repo, {"index.jsx": b"different upstream\n"},
+    "https://x/mobius.json", "2.0.0",
+  )
+  assert app_git.mark_equivalent_change_landed(
+    repo, digest, upstream_sha=target,
+  )
+
+  assert app_git.merge_upstream(repo).status == "conflict"
+
+
+def test_pending_equivalent_change_rejects_stale_review_hash(tmp_path):
+  """The send-time witness cannot silently bless a different reviewed diff."""
+  repo = tmp_path / "app"
+  _install(repo, b"base\n")
+  base = app_git.head_sha(repo, app_git.UPSTREAM_BRANCH)
+  _write(repo, "reviewed\n")
+  reviewed = app_git.commit_local(repo, "reviewed")
+  assert reviewed
+
+  assert app_git.record_pending_equivalent_change(
+    repo,
+    base_sha=base,
+    head_sha=reviewed,
+    source_sha=reviewed,
+    diff_sha256="0" * 64,
+    contribution_id="stale-review",
+  ) is None
+  assert not app_git.ref_exists(
+    repo, f"refs/mobius/equivalences/pending/{'0' * 64}",
+  )
+
+
+def test_successful_update_retires_landed_equivalence_refs(tmp_path):
+  repo = tmp_path / "app"
+  _install(repo, b"base\n")
+  base = app_git.head_sha(repo, app_git.UPSTREAM_BRANCH)
+  _write(repo, "shared\n")
+  reviewed = app_git.commit_local(repo, "reviewed")
+  assert reviewed
+  digest = _review_digest(repo, base, reviewed)
+  assert app_git.record_pending_equivalent_change(
+    repo,
+    base_sha=base,
+    head_sha=reviewed,
+    source_sha=reviewed,
+    diff_sha256=digest,
+    contribution_id="retire-me",
+  )
+  upstream = app_git.record_upstream(
+    repo, {"index.jsx": b"shared\n"},
+    "https://x/mobius.json", "2.0.0",
+  )
+  landed = app_git.mark_equivalent_change_landed(
+    repo, digest, upstream_sha=upstream,
+  )
+  assert landed and app_git.ref_exists(repo, landed)
+
+  assert app_git.retire_landed_equivalent_changes(repo, upstream) == 1
+  assert not app_git.ref_exists(repo, landed)
+
+
+def test_pending_source_witness_survives_unrelated_app_replay(tmp_path):
+  """An open contribution remains recognizable across an intervening update."""
+  repo = tmp_path / "app"
+  _install(repo, b"base\n")
+  base = app_git.head_sha(repo, app_git.UPSTREAM_BRANCH)
+  _write(repo, "shared\n")
+  reviewed = app_git.commit_local(repo, "reviewed contribution")
+  assert reviewed
+  digest = _review_digest(repo, base, reviewed)
+  pending = app_git.record_pending_equivalent_change(
+    repo,
+    base_sha=base,
+    head_sha=reviewed,
+    source_sha=reviewed,
+    diff_sha256=digest,
+    contribution_id="open-across-update",
+  )
+  assert pending
+
+  # Upstream v2 is unrelated to the open contribution. The clean app replay
+  # intentionally replaces local ancestry while preserving the accepted tree.
+  v2 = app_git.record_upstream(
+    repo,
+    {"index.jsx": b"base\n", "helper.js": b"v2\n"},
+    "https://x/mobius.json", "2.0.0",
+  )
+  merged_v2 = app_git.merge_upstream(repo)
+  assert merged_v2.status == "clean"
+  tree_v2 = app_git.read_merged_tree(repo, merged_v2.merged_tree_oid)
+  for rel, body in tree_v2.items():
+    target = repo / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(body)
+  replay = app_git.commit_replay(repo, v2, "install v2")
+  assert replay
+  carried = app_git._read_equivalent_change(repo, pending)
+  assert carried is not None
+  assert carried.source_sha == replay
+
+  # Local evolves the reviewed line after v2; v3 now contains the squash of the
+  # original reviewed predecessor. The carried witness keeps it automatic.
+  _write(repo, "local followup\n")
+  assert app_git.commit_local(repo, "later local edit")
+  v3 = app_git.record_upstream(
+    repo,
+    {"index.jsx": b"shared\n", "helper.js": b"v3\n"},
+    "https://x/mobius.json", "3.0.0",
+  )
+  landed = app_git.mark_equivalent_change_landed(
+    repo, digest, upstream_sha=v3,
+  )
+  assert landed
+  result = app_git.merge_upstream(repo)
+  assert result.status == "clean"
+  tree = app_git.read_merged_tree(repo, result.merged_tree_oid)
+  assert tree["index.jsx"] == b"local followup\n"
+  assert tree["helper.js"] == b"v3\n"
+
+
+def test_take_upstream_replay_does_not_carry_a_dropped_contribution(tmp_path):
+  """An intentional source replacement must retire causal local provenance."""
+  repo = tmp_path / "app"
+  _install(repo, b"base\n")
+  base = app_git.head_sha(repo, app_git.UPSTREAM_BRANCH)
+  _write(repo, "reviewed local\n")
+  reviewed = app_git.commit_local(repo, "reviewed contribution")
+  assert reviewed
+  digest = _review_digest(repo, base, reviewed)
+  pending = app_git.record_pending_equivalent_change(
+    repo,
+    base_sha=base,
+    head_sha=reviewed,
+    source_sha=reviewed,
+    diff_sha256=digest,
+    contribution_id="dropped-by-take-upstream",
+  )
+  assert pending
+
+  replacement = app_git.record_upstream(
+    repo, {"index.jsx": b"upstream replacement\n"},
+    "https://x/mobius.json", "2.0.0",
+  )
+  _write(repo, "upstream replacement\n")
+  replay = app_git.commit_replay(repo, replacement, "take upstream")
+  assert replay
+
+  retained = app_git._read_equivalent_change(repo, pending)
+  assert retained is not None
+  assert retained.source_sha == reviewed
+  assert app_git.ref_is_ancestor(repo, reviewed, replay) is False
 
 
 def test_start_conflict_merge_leaves_real_markers_and_merge_head(tmp_path):

--- a/backend/tests/test_apps_install.py
+++ b/backend/tests/test_apps_install.py
@@ -8,6 +8,7 @@ and force failure modes.
 """
 
 import asyncio
+import hashlib
 import io
 import json
 import os
@@ -2644,6 +2645,58 @@ def test_flag_on_static_asset_update_leaves_clean_app_repo(
   assert not (data_dir / "apps" / ".static-clean.mobius-static-bak").exists()
   assert app_git._run(source_dir, "status", "--porcelain").stdout == ""
   assert app_git._run(source_dir, "ls-files", "*.mobius-bak").stdout == ""
+
+
+def test_app_store_update_recognizes_squashed_local_contribution(
+  client, auth, bypass_url_validation,
+):
+  """App Store update uses the same provenance engine as the shell updater."""
+  from app import app_git
+
+  base_url = "https://equivalent.test/repo/"
+  manifest = {**MANIFEST_NEWS, "id": "equivalent-update"}
+  r1 = _install_v1(client, auth, base_url, manifest, JSX_MULTI)
+  assert r1.status_code == 201, r1.text
+  source = Path(get_settings().data_dir) / "apps" / "equivalent-update"
+  entry = source / "index.jsx"
+  base_sha = app_git.head_sha(source, app_git.UPSTREAM_BRANCH)
+
+  shared = JSX_MULTI.replace("ORIGINAL TITLE", "SHARED REVIEW")
+  entry.write_text(shared)
+  reviewed = app_git.commit_local(source, "reviewed contribution")
+  assert reviewed
+  reviewed_diff = app_git._canonical_diff(source, base_sha, reviewed)
+  assert reviewed_diff is not None
+  digest = hashlib.sha256(reviewed_diff).hexdigest()
+  assert app_git.record_pending_equivalent_change(
+    source,
+    base_sha=base_sha,
+    head_sha=reviewed,
+    source_sha=reviewed,
+    diff_sha256=digest,
+    contribution_id="app-store-reviewed-change",
+  )
+  landed = app_git.mark_equivalent_change_landed(source, digest)
+  assert landed
+
+  # Local keeps evolving the contributed line before the Store fetches the
+  # squash result, which is exactly the shape ordinary three-way Git conflicts.
+  entry.write_text(shared.replace("SHARED REVIEW", "LOCAL FOLLOWUP"))
+  r2 = _update_v2(
+    client,
+    auth,
+    base_url,
+    {**manifest, "version": "2.0.0"},
+    shared,
+  )
+
+  assert r2.status_code == 201, r2.text
+  body = r2.json()
+  assert body["mode"] == "update"
+  assert body["divergence"] == "clean_merge"
+  assert any("already present upstream" in item for item in body["warnings"])
+  assert "LOCAL FOLLOWUP" in entry.read_text()
+  assert not app_git.ref_exists(source, landed)
 
 
 def test_flag_on_conflicting_update_leaves_source_unchanged_until_resolve(

--- a/backend/tests/test_github_routes.py
+++ b/backend/tests/test_github_routes.py
@@ -2100,6 +2100,182 @@ def test_cleanup_terminal_staging_checkout_only_removes_disposable_clone():
   assert live_repo.exists()
 
 
+def test_contribution_lifecycle_persists_equivalence_in_live_linked_repo():
+  """Send records the local witness; merged cleanup promotes it before delete."""
+  from app import app_git
+  from app.routes.github import (
+    _cleanup_terminal_staging_checkout,
+    _record_pending_equivalence,
+    _settle_equivalence,
+  )
+
+  data_dir = Path(get_settings().data_dir)
+  live = data_dir / "apps" / "equivalence-live"
+  review = data_dir / "contrib" / "equivalence-review" / "worktree"
+  live.mkdir(parents=True)
+  subprocess.run(["git", "init", "-qb", "main", str(live)], check=True)
+  subprocess.run(["git", "-C", str(live), "config", "user.name", "Test"], check=True)
+  subprocess.run(
+    ["git", "-C", str(live), "config", "user.email", "test@example.invalid"],
+    check=True,
+  )
+  (live / "index.jsx").write_text("base\n")
+  subprocess.run(["git", "-C", str(live), "add", "index.jsx"], check=True)
+  subprocess.run(["git", "-C", str(live), "commit", "-qm", "base"], check=True)
+  base = subprocess.check_output(
+    ["git", "-C", str(live), "rev-parse", "HEAD"], text=True,
+  ).strip()
+  (live / "index.jsx").write_text("reviewed\n")
+  subprocess.run(["git", "-C", str(live), "commit", "-qam", "reviewed"], check=True)
+  head = subprocess.check_output(
+    ["git", "-C", str(live), "rev-parse", "HEAD"], text=True,
+  ).strip()
+  review.parent.mkdir(parents=True)
+  subprocess.run(
+    ["git", "-C", str(live), "worktree", "add", "-qb", "fix/review", str(review), head],
+    check=True,
+  )
+  diff = app_git._canonical_diff(review, base, head)
+  assert diff is not None
+  digest = hashlib.sha256(diff).hexdigest()
+  record = {
+    "id": "equivalence-review",
+    "status": "open",
+    "plan": {
+      "repo_path": str(review),
+      "base_sha": base,
+      "head_sha": head,
+      "diff_sha256": digest,
+    },
+  }
+
+  pending = _record_pending_equivalence(record)
+  assert pending and app_git.ref_exists(live, pending)
+  # Simulate GitHub's squash commit: a new identity with the reviewed tree.
+  tree = subprocess.check_output(
+    ["git", "-C", str(live), "rev-parse", f"{head}^{{tree}}"], text=True,
+  ).strip()
+  upstream = subprocess.check_output(
+    [
+      "git", "-c", "user.name=Test", "-c", "user.email=test@example.invalid",
+      "-C", str(live), "commit-tree", tree, "-p", base, "-m", "squash",
+    ],
+    text=True,
+  ).strip()
+  record["status"] = "merged"
+  landed = _settle_equivalence(record, upstream)
+  assert landed and app_git.ref_exists(live, landed)
+  assert not app_git.ref_exists(live, pending)
+
+  assert _cleanup_terminal_staging_checkout(record) is True
+  assert not review.exists()
+  assert app_git.ref_exists(live, landed)
+
+
+def test_standalone_app_review_persists_equivalence_in_installed_repo():
+  """A no-origin app's disposable review clone cannot own the only witness."""
+  from app import app_git
+  from app.routes.github import (
+    _cleanup_terminal_staging_checkout,
+    _record_pending_equivalence,
+    _settle_equivalence,
+  )
+
+  data_dir = Path(get_settings().data_dir)
+  live = data_dir / "apps" / "equivalence-standalone-live"
+  review = data_dir / "contrib" / "equivalence-standalone" / "worktree"
+  for repo in (live, review):
+    repo.mkdir(parents=True)
+    subprocess.run(["git", "init", "-qb", "main", str(repo)], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.name", "Test"], check=True)
+    subprocess.run(
+      ["git", "-C", str(repo), "config", "user.email", "test@example.invalid"],
+      check=True,
+    )
+
+  (review / "index.jsx").write_text("base\n")
+  subprocess.run(["git", "-C", str(review), "add", "index.jsx"], check=True)
+  subprocess.run(["git", "-C", str(review), "commit", "-qm", "review base"], check=True)
+  base = subprocess.check_output(
+    ["git", "-C", str(review), "rev-parse", "HEAD"], text=True,
+  ).strip()
+  (review / "index.jsx").write_text("reviewed\n")
+  subprocess.run(["git", "-C", str(review), "commit", "-qam", "review head"], check=True)
+  head = subprocess.check_output(
+    ["git", "-C", str(review), "rev-parse", "HEAD"], text=True,
+  ).strip()
+
+  # The installed synthetic app has the same accepted content but unrelated
+  # commit identities. It does not contain either reviewed commit beforehand.
+  (live / "index.jsx").write_text("reviewed\n")
+  subprocess.run(["git", "-C", str(live), "add", "index.jsx"], check=True)
+  subprocess.run(
+    ["git", "-C", str(live), "commit", "-qm", "installed synthetic source"],
+    check=True,
+  )
+  source_sha = subprocess.check_output(
+    ["git", "-C", str(live), "rev-parse", "HEAD"], text=True,
+  ).strip()
+  live_tree = subprocess.check_output(
+    ["git", "-C", str(live), "rev-parse", "HEAD^{tree}"], text=True,
+  ).strip()
+  replayed_source = subprocess.check_output(
+    [
+      "git", "-c", "user.name=Test", "-c", "user.email=test@example.invalid",
+      "-C", str(live), "commit-tree", live_tree, "-m", "store replay",
+    ],
+    text=True,
+  ).strip()
+  subprocess.run(
+    [
+      "git", "-C", str(live), "update-ref", "refs/heads/main",
+      replayed_source, source_sha,
+    ],
+    check=True,
+  )
+  subprocess.run(["git", "-C", str(live), "reset", "--hard", "-q"], check=True)
+  assert app_git.ref_is_ancestor(live, source_sha, replayed_source) is False
+  assert subprocess.run(
+    ["git", "-C", str(live), "cat-file", "-e", f"{head}^{{commit}}"],
+    check=False,
+  ).returncode != 0
+
+  diff = app_git._canonical_diff(review, base, head)
+  assert diff is not None
+  digest = hashlib.sha256(diff).hexdigest()
+  record = {
+    "id": "equivalence-standalone",
+    "status": "open",
+    "plan": {
+      "repo_path": str(review),
+      "source_repo_path": str(live),
+      "source_sha": source_sha,
+      "base_sha": base,
+      "head_sha": head,
+      "diff_sha256": digest,
+    },
+  }
+
+  pending = _record_pending_equivalence(record)
+  assert pending and app_git.ref_exists(live, pending)
+  assert not app_git.ref_exists(review, pending)
+  # The exact reviewed commits were imported without moving the installed app.
+  assert app_git.head_sha(live, "HEAD") == replayed_source
+  recorded = app_git._read_equivalent_change(live, pending)
+  assert recorded is not None and recorded.source_sha == replayed_source
+  assert subprocess.run(
+    ["git", "-C", str(live), "cat-file", "-e", f"{head}^{{commit}}"],
+    check=False,
+  ).returncode == 0
+
+  record["status"] = "merged"
+  landed = _settle_equivalence(record)
+  assert landed and app_git.ref_exists(live, landed)
+  assert _cleanup_terminal_staging_checkout(record) is True
+  assert not review.exists()
+  assert app_git.ref_exists(live, landed)
+
+
 def test_ensure_owner_fork_remote_runs_in_repo_after_pinning_origin(
   tmp_path, monkeypatch,
 ):

--- a/backend/tests/test_platform_update.py
+++ b/backend/tests/test_platform_update.py
@@ -18,6 +18,7 @@ crash-interrupted merge is aborted on the next pass. A legacy interrupted rebase
 is still cleaned up because an update can cross this implementation boundary.
 """
 
+import hashlib
 import subprocess
 import stat
 import textwrap
@@ -27,6 +28,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from app import app_git
 from app import platform_update as pu
 
 
@@ -266,6 +268,64 @@ def test_conflict_serves_old_and_flags(clone_env):
   status = pu.platform_status(platform)
   assert status["state"] == pu.PlatformUpdateState.CONFLICT.value
   assert any("main.py" in p for p in status["conflict_paths"])
+
+
+def test_contributed_squash_uses_provenance_for_both_histories(clone_env):
+  """The shell auto-reconciles a reviewed change returned under a new SHA.
+
+  The local line evolves after review, while upstream squash-merges the reviewed
+  predecessor and adds a separate release edit.  Ordinary Git conflicts on the
+  line; the two provenance witnesses make the reviewed tree a semantic base,
+  preserving the follow-up and recording the real target as merge parent.
+  """
+  origin, platform = clone_env
+  base = _served_sha(platform)
+  shared = _MAIN_PY.replace("LINE_A = 1", "LINE_A = 'SHARED REVIEW'")
+  reviewed = _local_commit(
+    platform,
+    edits={"backend/app/main.py": shared},
+    msg="reviewed contribution",
+  )
+  diff = app_git._canonical_diff(platform, base, reviewed)
+  assert diff is not None
+  digest = hashlib.sha256(diff).hexdigest()
+  pending = app_git.record_pending_equivalent_change(
+    platform,
+    base_sha=base,
+    head_sha=reviewed,
+    source_sha=reviewed,
+    diff_sha256=digest,
+    contribution_id="shell-reviewed-change",
+  )
+  assert pending
+
+  followup = shared.replace("SHARED REVIEW", "LOCAL FOLLOWUP")
+  pre = _local_commit(
+    platform,
+    edits={"backend/app/main.py": followup},
+    msg="local followup",
+  )
+  target_body = shared.replace("LINE_C = 3", "LINE_C = 9001")
+  target = _advance_origin(
+    origin,
+    edits={"backend/app/main.py": target_body},
+    msg="squash reviewed contribution",
+  )
+  landed = app_git.mark_equivalent_change_landed(
+    platform, digest, upstream_sha=target,
+  )
+  assert landed
+
+  res = pu.reconcile_clone(platform, at_boot=True)
+
+  assert res.status == "updated"
+  served = (platform / "backend/app/main.py").read_text()
+  assert "LINE_A = 'LOCAL FOLLOWUP'" in served
+  assert "LINE_C = 9001" in served
+  parents = _git(platform, "show", "-s", "--format=%P", "HEAD").stdout.split()
+  assert parents == [pre, target]
+  assert not pu.CONFLICT_FLAG.exists()
+  assert not app_git.ref_exists(platform, landed)
 
 
 def test_diverged_update_surfaces_all_net_conflicts_together(clone_env):


### PR DESCRIPTION
## Summary

- record a durable, hash-verified relationship between an owner-reviewed contribution, the local source commit it came from, and the GitHub commit where it landed
- let both shell updates and App Store updates use those proven shared changes as a semantic merge base when squash, rebase, or integration batching changed commit identities
- preserve later local edits, import only verified review commits for standalone app checkouts, and carry app witnesses across history replay only when the local change survived
- keep ordinary Git and the owner-gated resolver as the fail-closed path whenever source ancestry, reviewed bytes, upstream containment, or the final merge cannot be proved

## Safety model

The updater never infers equivalence from a clean result alone. A witness is created only after the stored review diff re-hashes exactly and is proven in the local source, including a narrow agent-resolved projection proof that requires the same changed path set and independently verifiable non-conflict paths. It becomes authoritative only after GitHub reports the PR merged and the exact reviewed delta is present in that merge commit. Resolution is computed off-tree; shell commits retain both real parents, app updates retain their existing replay transaction, and obsolete landed witnesses are retired only after the update is durable.

## Prior work

#147 and #280 manually integrated batches of already-reviewed production changes, preserving provenance but requiring bespoke reconciliation. #282 then reproduced the underlying failure mode directly: its reviewed local commit and GitHub squash commit have identical trees and parents but different identities, while later local work on the same lines made ordinary Git report a three-file conflict. This PR turns that repeated manual reasoning into one shared, fail-closed mechanism.

## Validation

- exact upstream review branch: 421 focused backend tests passed
- integrated local branch: 426 focused backend tests passed
- frontend: 2,098 library tests and 63 hook tests passed; production/PWA build passed
- Contribute app: 122 JavaScript tests and 7 Python tests passed; app validation passed
- full backend sweep reached 3,023 passes; its two failures reproduce outside this diff in existing live-context/update-preview fixtures
- replayed the real #282 history in an isolated clone: ordinary Git reported the same three conflicts, the provenance engine selected the verified resolved projection, and the resulting tree was byte-for-byte the current local tree
- `git diff --check` passed