### PR TITLE
Group stacked contribution reviews in chat

### DIFF
--- a/backend/app/routes/github.py
+++ b/backend/app/routes/github.py
@@ -3555,6 +3555,7 @@ def _diff_file_paths(diff_path: Path, limit: int = 40) -> list[str]:
 def _chat_review_projection(record: dict, app_id: int) -> dict:
   """The small, display-only view of one ledger record for the chat card."""
   plan = record.get("plan") if isinstance(record.get("plan"), dict) else {}
+  raw_stack = plan.get("stack") if isinstance(plan.get("stack"), dict) else None
   record_id = str(record.get("id") or "")
   _, diff_path = _record_paths(app_id, record_id)
 
@@ -3565,6 +3566,24 @@ def _chat_review_projection(record: dict, app_id: int) -> dict:
     value.strip() for value in plan.get("labels", [])
     if isinstance(value, str) and value.strip()
   ][:2] if isinstance(plan.get("labels"), list) else []
+  stack = None
+  if raw_stack is not None:
+    stack_id = text(raw_stack.get("id")).strip()
+    position = raw_stack.get("position")
+    total = raw_stack.get("total")
+    if stack_id:
+      stack = {
+        "id": stack_id,
+        "name": text(raw_stack.get("name")).strip(),
+        "position": (
+          position if isinstance(position, int) and not isinstance(position, bool)
+          and position > 0 else None
+        ),
+        "total": (
+          total if isinstance(total, int) and not isinstance(total, bool)
+          and total > 0 else None
+        ),
+      }
   return {
     "id": record_id,
     "type": text(record.get("type")),
@@ -3579,7 +3598,11 @@ def _chat_review_projection(record: dict, app_id: int) -> dict:
     "labels": labels,
     "last_submit_error": text(record.get("last_submit_error")),
     "updated_at": text(record.get("updated_at")),
-    "is_stack": isinstance(plan.get("stack"), dict),
+    # `is_stack` keeps an invalid/legacy stack safely non-sendable. `stack`
+    # carries only the display identity/order the chat needs to collapse every
+    # valid layer into one review-together card; branch ancestry stays private.
+    "is_stack": raw_stack is not None,
+    "stack": stack,
   }
 
 

--- a/backend/tests/test_github_routes.py
+++ b/backend/tests/test_github_routes.py
@@ -4471,7 +4471,7 @@ def test_for_chat_marks_a_stack_layer_so_chat_never_sends_one_alone(
   app_id, _ = _app_token(client, owner_token, github_access=True)
   _, record = _prepared_for_chat(app_id, "layer-2", "chat-a")
   record["plan"]["stack"] = {
-    "id": "demo", "position": 2, "total": 3,
+    "id": "demo", "name": "Demo stack", "position": 2, "total": 3,
     "parent_record_id": "layer-1", "base_branch": "stack/demo/01",
   }
   _write_contribution(app_id, "layer-2", record, "")
@@ -4483,6 +4483,11 @@ def test_for_chat_marks_a_stack_layer_so_chat_never_sends_one_alone(
   assert r.status_code == 200, r.text
   item = r.json()["records"][0]
   assert item["is_stack"] is True
+  assert item["stack"] == {
+    "id": "demo", "name": "Demo stack", "position": 2, "total": 3,
+  }
+  assert "parent_record_id" not in item["stack"]
+  assert "base_branch" not in item["stack"]
   # A stack layer is never preflighted here: the whole chain is reviewed and
   # sent together in the app, so the card must not offer a single-layer Send.
   assert item["review"] is None

--- a/frontend/src/components/ChatView/ContributionReviewCard.css
+++ b/frontend/src/components/ChatView/ContributionReviewCard.css
@@ -135,6 +135,10 @@
   border-left-color: var(--muted);
 }
 
+.contrib-card--stack {
+  border-left-color: color-mix(in srgb, var(--accent) 70%, var(--muted));
+}
+
 /* The status is a full-width header BAND, not a chip beside the text. As a chip
    it sat next to a summary that wraps to several lines, leaving an obvious hole
    under the short label. Spanning the card's padding (negative margins cancel it)
@@ -298,6 +302,33 @@
   color: var(--text);
   /* Long paths stay inside the card rather than widening the chat column. */
   overflow-wrap: anywhere;
+}
+
+.contrib-card__layers {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.contrib-card__layers li {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 0.75rem;
+  line-height: 1.35;
+  color: var(--text);
+}
+
+.contrib-card__layers li > span {
+  font-weight: 600;
+}
+
+.contrib-card__layers p {
+  margin: 0;
+  color: var(--muted);
 }
 
 /* Quoted verbatim; it flows inside the disclosure's single scroller above. */

--- a/frontend/src/components/ChatView/ContributionReviewCard.jsx
+++ b/frontend/src/components/ChatView/ContributionReviewCard.jsx
@@ -108,16 +108,16 @@ export default function ContributionReviewCard({ chatId, turnActive, onOpenApp }
     <div
       className={`contrib-card-stack${grouped ? ' contrib-card-stack--grouped' : ''}`}
       role={grouped ? 'region' : undefined}
-      aria-label={grouped ? `${reviewItems.length} contributions ready` : undefined}
+      aria-label={grouped ? `${reviewItems.length} reviews ready` : undefined}
     >
       {grouped && (
         <div className="contrib-card-stack__heading">
           <div>
             <div className="contrib-card-stack__title">
-              {reviewItems.length} contributions ready
+              {reviewItems.length} reviews ready
             </div>
             <div className="contrib-card-stack__copy">
-              Review each one separately.
+              Review each item separately.
             </div>
           </div>
           <span className="contrib-card-stack__count">{reviewItems.length}</span>

--- a/frontend/src/components/ChatView/ContributionReviewCard.jsx
+++ b/frontend/src/components/ChatView/ContributionReviewCard.jsx
@@ -12,10 +12,10 @@ import {
   isHorizontalSwipe,
   passedDismissThreshold,
   payoffLine,
-  rememberDismissed,
+  rememberReviewItemDismissed,
   sendBlocker,
   statusLabel,
-  visibleRecords,
+  visibleReviewItems,
 } from './contributionReviewModel.js'
 import './ContributionReviewCard.css'
 
@@ -63,11 +63,11 @@ export default function ContributionReviewCard({ chatId, turnActive, onOpenApp }
   const [dismissRevision, setDismissRevision] = useState(0)
 
   const storage = typeof localStorage !== 'undefined' ? localStorage : null
-  const records = visibleRecords(data, storage)
-  const grouped = records.length > 1
+  const reviewItems = visibleReviewItems(data, storage)
+  const grouped = reviewItems.length > 1
   void dismissRevision
   if (!appId) return null
-  if (!records.length && !sent) return null
+  if (!reviewItems.length && !sent) return null
 
   async function send(record) {
     setBusyId(record.id)
@@ -108,19 +108,19 @@ export default function ContributionReviewCard({ chatId, turnActive, onOpenApp }
     <div
       className={`contrib-card-stack${grouped ? ' contrib-card-stack--grouped' : ''}`}
       role={grouped ? 'region' : undefined}
-      aria-label={grouped ? `${records.length} contributions ready` : undefined}
+      aria-label={grouped ? `${reviewItems.length} contributions ready` : undefined}
     >
       {grouped && (
         <div className="contrib-card-stack__heading">
           <div>
             <div className="contrib-card-stack__title">
-              {records.length} contributions ready
+              {reviewItems.length} contributions ready
             </div>
             <div className="contrib-card-stack__copy">
               Review each one separately.
             </div>
           </div>
-          <span className="contrib-card-stack__count">{records.length}</span>
+          <span className="contrib-card-stack__count">{reviewItems.length}</span>
         </div>
       )}
       {sent && (
@@ -130,24 +130,39 @@ export default function ContributionReviewCard({ chatId, turnActive, onOpenApp }
           onDismiss={() => setSent(null)}
         />
       )}
-      {records.map(record => (
-        <ReviewRow
-          key={record.id}
-          record={record}
-          connected={data?.connected !== false}
-          autopilot={autopilotOnSend(data)}
-          busy={busyId === record.id}
-          error={error?.id === record.id ? error.message : null}
-          onSend={send}
-          onOpenContribute={contributeApp && onOpenApp
-            ? () => onOpenApp(contributeApp, { final: true })
-            : null}
-          onDismiss={() => {
-            rememberDismissed(record, storage)
-            setDismissRevision(value => value + 1)
-          }}
-        />
-      ))}
+      {reviewItems.map(item => {
+        const onOpenContribute = contributeApp && onOpenApp
+          ? () => onOpenApp(contributeApp, { final: true })
+          : null
+        const onDismiss = () => {
+          rememberReviewItemDismissed(item, storage)
+          setDismissRevision(value => value + 1)
+        }
+        if (item.kind === 'stack') {
+          return (
+            <StackReviewRow
+              key={item.id}
+              item={item}
+              onOpenContribute={onOpenContribute}
+              onDismiss={onDismiss}
+            />
+          )
+        }
+        const record = item.record
+        return (
+          <ReviewRow
+            key={item.id}
+            record={record}
+            connected={data?.connected !== false}
+            autopilot={autopilotOnSend(data)}
+            busy={busyId === record.id}
+            error={error?.id === record.id ? error.message : null}
+            onSend={send}
+            onOpenContribute={onOpenContribute}
+            onDismiss={onDismiss}
+          />
+        )
+      })}
     </div>
   )
 }
@@ -292,6 +307,68 @@ function SentRow({ sent, onDismiss }) {
           >
             View on GitHub
           </a>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function StackReviewRow({ item, onOpenContribute, onDismiss }) {
+  const [open, setOpen] = useState(false)
+  const cardRef = useSwipeToDismiss(onDismiss)
+  const total = Number(item.stack?.total) || item.records.length
+  const name = item.stack?.name || 'This improvement'
+
+  return (
+    <div ref={cardRef} className="contrib-card contrib-card--stack">
+      <div className="contrib-card__badge">
+        <span>Review together</span>
+        <button
+          type="button"
+          className="contrib-card__dismiss"
+          aria-label="Dismiss — keeps the stack in Contribute"
+          onClick={() => onDismiss?.()}
+        >
+          <X size={14} strokeWidth={2} aria-hidden="true" />
+        </button>
+      </div>
+      <p className="contrib-card__summary">
+        {name} is ready as a {total}-part contribution stack.
+      </p>
+      <p className="contrib-card__meta">
+        {item.repo} · {item.records.length} linked layer{item.records.length === 1 ? '' : 's'}
+      </p>
+      <p className="contrib-card__payoff">
+        The layers build on each other and are reviewed in order.
+      </p>
+      <div className="contrib-card__actions">
+        <button
+          type="button"
+          className="contrib-card__send"
+          disabled={!onOpenContribute}
+          onClick={onOpenContribute}
+        >
+          Review in Contribute
+        </button>
+        <button
+          type="button"
+          className="contrib-card__toggle"
+          aria-expanded={open}
+          onClick={() => setOpen(value => !value)}
+        >
+          {open ? 'Hide layers' : 'Layers'}
+        </button>
+      </div>
+      {open && (
+        <div className="contrib-card__details">
+          <ol className="contrib-card__layers">
+            {item.records.map((record, index) => (
+              <li key={record.id}>
+                <span>{record.stack?.position || index + 1}. {record.title}</span>
+                {record.summary && <p>{record.summary}</p>}
+              </li>
+            ))}
+          </ol>
         </div>
       )}
     </div>

--- a/frontend/src/components/ChatView/__tests__/contributionReviewModel.test.js
+++ b/frontend/src/components/ChatView/__tests__/contributionReviewModel.test.js
@@ -17,8 +17,11 @@ import {
   isHorizontalSwipe,
   passedDismissThreshold,
   rememberDismissed,
+  rememberReviewItemDismissed,
+  reviewItems,
   sendBlocker,
   statusLabel,
+  visibleReviewItems,
   visibleRecords,
 } from '../contributionReviewModel.js'
 
@@ -89,7 +92,10 @@ test('a disconnected GitHub blocks Send before any request is made', () => {
 })
 
 test('a stack layer is never sendable from chat — the chain is reviewed together', () => {
-  const record = { status: 'prepared', is_stack: true, review: { state: 'ready' } }
+  const record = {
+    status: 'prepared', stack: { id: 'demo', position: 1, total: 2 },
+    review: { state: 'ready' },
+  }
   assert.match(sendBlocker(record, { connected: true }), /stacked set/)
 })
 
@@ -120,18 +126,81 @@ test('autopilot on send mirrors the owner default and the backend capability', (
 
 test('the status word distinguishes waiting, blocked, and in-flight', () => {
   assert.equal(statusLabel({ status: 'prepared' }, false), 'Ready to contribute')
-  assert.equal(statusLabel({ status: 'prepared' }, true), 'Needs an update')
+  assert.equal(statusLabel({ status: 'prepared' }, true), 'Needs attention')
+  assert.equal(
+    statusLabel({ status: 'prepared', stack: { id: 'demo' } }, true),
+    'Review together',
+  )
   assert.equal(statusLabel({ status: 'submitting' }, false), 'Publishing')
 })
 
-test('multiple independent contributions share one bounded review panel', () => {
-  assert.match(cardSrc, /const grouped = records\.length > 1/)
+test('multiple independent review items share one bounded review panel', () => {
+  assert.match(cardSrc, /const grouped = reviewItems\.length > 1/)
   assert.match(cardSrc, /contrib-card-stack--grouped/)
-  assert.match(cardSrc, /\{records\.length\} contributions ready/)
+  assert.match(cardSrc, /\{reviewItems\.length\} contributions ready/)
   assert.match(cardSrc, /Review each one separately\./)
   assert.match(cardCss, /\.contrib-card-stack\s*\{[\s\S]*?width:\s*min\(100%, 640px\);[\s\S]*?margin-inline:\s*auto;/)
   assert.match(cardCss, /\.contrib-card-stack--grouped\s*\{[\s\S]*?max-height:\s*min\(52vh, 520px\);/)
   assert.match(cardCss, /\.contrib-card-stack--grouped \.contrib-card\s*\{[\s\S]*?border-radius:\s*0;/)
+})
+
+test('stack layers collapse into one ordered review item', () => {
+  const payload = { records: [
+    { id: 'three', status: 'prepared', repo: PLATFORM_REPO, stack: {
+      id: 'drawer', name: 'Drawer navigation', position: 3, total: 3,
+    } },
+    { id: 'single', status: 'prepared' },
+    { id: 'one', status: 'prepared', repo: PLATFORM_REPO, stack: {
+      id: 'drawer', name: 'Drawer navigation', position: 1, total: 3,
+    } },
+    { id: 'two', status: 'prepared', repo: PLATFORM_REPO, stack: {
+      id: 'drawer', name: 'Drawer navigation', position: 2, total: 3,
+    } },
+  ] }
+  const items = reviewItems(payload)
+  assert.equal(items.length, 2)
+  assert.equal(items[0].kind, 'stack')
+  assert.deepEqual(items[0].records.map(record => record.id), ['one', 'two', 'three'])
+  assert.equal(items[1].record.id, 'single')
+})
+
+test('loaded older backends group canonical stack branches during hot reload', () => {
+  const payload = { records: [
+    // Deliberately opposite lexical order: branch position, not record id,
+    // owns the chain ordering during a frontend-before-backend rollout.
+    { id: 'a-second', status: 'prepared', repo: PLATFORM_REPO, is_stack: true,
+      branch: 'stack/drawer-navigation/02-pins' },
+    { id: 'z-first', status: 'prepared', repo: PLATFORM_REPO, is_stack: true,
+      branch: 'stack/drawer-navigation/01-apps' },
+  ] }
+  const items = reviewItems(payload)
+  assert.equal(items.length, 1)
+  assert.equal(items[0].kind, 'stack')
+  assert.equal(items[0].stack.name, 'Drawer navigation')
+  assert.deepEqual(items[0].records.map(record => record.id), ['z-first', 'a-second'])
+})
+
+test('dismissing a stack hides one card and any revised layer brings it back', () => {
+  const storage = fakeStorage()
+  const payload = { records: [
+    { id: 'one', status: 'prepared', updated_at: '1', repo: PLATFORM_REPO,
+      stack: { id: 'drawer', position: 1, total: 2 } },
+    { id: 'two', status: 'prepared', updated_at: '1', repo: PLATFORM_REPO,
+      stack: { id: 'drawer', position: 2, total: 2 } },
+  ] }
+  const item = visibleReviewItems(payload, storage)[0]
+  assert.equal(item.kind, 'stack')
+  assert.equal(rememberReviewItemDismissed(item, storage), true)
+  assert.equal(visibleReviewItems(payload, storage).length, 0)
+  payload.records[0].updated_at = '2'
+  assert.equal(visibleReviewItems(payload, storage).length, 1)
+})
+
+test('the renderer gives a stack one review-together card, not one card per layer', () => {
+  assert.match(cardSrc, /visibleReviewItems\(data, storage\)/)
+  assert.match(cardSrc, /item\.kind === 'stack'/)
+  assert.match(cardSrc, /<StackReviewRow/)
+  assert.match(cardSrc, /Review in Contribute/)
 })
 
 // The action names the value of contributing, not the mechanism of sending, and
@@ -291,12 +360,12 @@ test('the swipe has a visible, focusable equivalent', () => {
   assert.match(cardSrc, /className="contrib-card__dismiss"/)
   assert.match(cardSrc, /aria-label="Dismiss — keeps it in Contribute"/)
   assert.match(cardSrc, /onClick=\{\(\) => onDismiss\?\.\(\)\}/)
-  // Use the same outlined close icon as the shell's other compact dismiss
-  // controls; the heavier Apps SDK glyph made this one look out of place.
+  // Every card shape uses the same outlined close icon as the shell's other
+  // compact dismiss controls; the heavier Apps SDK glyph looked out of place.
   assert.match(cardSrc, /import X from 'lucide-react\/dist\/esm\/icons\/x\.mjs'/)
   assert.equal(
     (cardSrc.match(/<X size=\{14\} strokeWidth=\{2\} aria-hidden="true" \/>/g) || []).length,
-    2,
+    3,
   )
   assert.doesNotMatch(cardSrc, /title="Dismiss/)
   assert.doesNotMatch(cardSrc, /✕|✖|❌/)
@@ -317,7 +386,7 @@ test('the dismissal gesture is claimed with a non-passive touchmove', () => {
 test('the post-send acknowledgement is dismissible and self-clearing', () => {
   const sentRow = cardSrc.slice(
     cardSrc.indexOf('function SentRow('),
-    cardSrc.indexOf('function ReviewRow('),
+    cardSrc.indexOf('function StackReviewRow('),
   )
   assert.ok(sentRow.length > 0, 'the acknowledgement is its own card shape')
   // Same swipe binding as every other card, not a bespoke layout.
@@ -334,7 +403,7 @@ test('the post-send acknowledgement is dismissible and self-clearing', () => {
 // acknowledgement ended up without one.
 test('every card shape shares one swipe implementation', () => {
   assert.equal((cardSrc.match(/function useSwipeToDismiss\(/g) || []).length, 1)
-  assert.equal((cardSrc.match(/= useSwipeToDismiss\(onDismiss\)/g) || []).length, 2)
+  assert.equal((cardSrc.match(/= useSwipeToDismiss\(onDismiss\)/g) || []).length, 3)
   assert.equal((cardSrc.match(/addEventListener\('touchmove'/g) || []).length, 1)
 })
 

--- a/frontend/src/components/ChatView/__tests__/contributionReviewModel.test.js
+++ b/frontend/src/components/ChatView/__tests__/contributionReviewModel.test.js
@@ -137,8 +137,8 @@ test('the status word distinguishes waiting, blocked, and in-flight', () => {
 test('multiple independent review items share one bounded review panel', () => {
   assert.match(cardSrc, /const grouped = reviewItems\.length > 1/)
   assert.match(cardSrc, /contrib-card-stack--grouped/)
-  assert.match(cardSrc, /\{reviewItems\.length\} contributions ready/)
-  assert.match(cardSrc, /Review each one separately\./)
+  assert.match(cardSrc, /\{reviewItems\.length\} reviews ready/)
+  assert.match(cardSrc, /Review each item separately\./)
   assert.match(cardCss, /\.contrib-card-stack\s*\{[\s\S]*?width:\s*min\(100%, 640px\);[\s\S]*?margin-inline:\s*auto;/)
   assert.match(cardCss, /\.contrib-card-stack--grouped\s*\{[\s\S]*?max-height:\s*min\(52vh, 520px\);/)
   assert.match(cardCss, /\.contrib-card-stack--grouped \.contrib-card\s*\{[\s\S]*?border-radius:\s*0;/)

--- a/frontend/src/components/ChatView/contributionReviewModel.js
+++ b/frontend/src/components/ChatView/contributionReviewModel.js
@@ -41,7 +41,7 @@ export function actionableRecords(payload) {
  */
 export function sendBlocker(record, { connected } = {}) {
   if (!record || record.status !== 'prepared') return null
-  if (record.is_stack) {
+  if (record.stack || record.is_stack) {
     return 'This is one layer of a stacked set — review and send the whole chain in Contribute.'
   }
   if (connected === false) return 'Connect GitHub in Contribute first.'
@@ -73,7 +73,8 @@ export const PLATFORM_REPO = 'mobius-os/mobius'
 /** The one-line status word shown on the card. */
 export function statusLabel(record, blocked) {
   if (record?.status === 'submitting') return 'Publishing'
-  if (blocked) return 'Needs an update'
+  if (record?.stack || record?.is_stack) return 'Review together'
+  if (blocked) return 'Needs attention'
   return 'Ready to contribute'
 }
 
@@ -184,4 +185,91 @@ export function rememberDismissed(record, storage) {
 /** Records that still deserve the composer's attention. */
 export function visibleRecords(payload, storage) {
   return actionableRecords(payload).filter(record => !isDismissed(record, storage))
+}
+
+function stackDescriptor(record) {
+  const stackId = record?.stack?.id
+  if (typeof stackId === 'string' && stackId.trim()) return record.stack
+  // Frontend source hot-reloads while backend Python waits for a restart. Keep
+  // that real rolling-upgrade seam coherent by recognizing the canonical stack
+  // branch emitted by older loaded backends; the next backend start supplies
+  // the explicit descriptor above. Unknown legacy shapes stay safely ungrouped.
+  if (!record?.is_stack || typeof record?.branch !== 'string') return null
+  const match = record.branch.match(/^stack\/([^/]+)\/(\d+)(?:-|$)/)
+  if (!match) return null
+  const id = match[1]
+  return {
+    id,
+    name: id.split('-').filter(Boolean)
+      .map((part, index) => index === 0
+        ? part.charAt(0).toUpperCase() + part.slice(1)
+        : part)
+      .join(' '),
+    position: Number(match[2]),
+    total: null,
+  }
+}
+
+/** Collapse every valid contribution stack into one logical review item. */
+export function reviewItems(payload) {
+  const items = []
+  const stacks = new Map()
+  for (const record of actionableRecords(payload)) {
+    const stack = stackDescriptor(record)
+    if (!stack) {
+      items.push({ kind: 'record', id: record.id, record })
+      continue
+    }
+    const groupKey = `${record?.repo || ''}:${stack.id}`
+    let item = stacks.get(groupKey)
+    if (!item) {
+      item = {
+        kind: 'stack',
+        id: `stack:${groupKey}`,
+        stack,
+        repo: record.repo,
+        records: [],
+      }
+      stacks.set(groupKey, item)
+      items.push(item)
+    }
+    item.records.push(record)
+  }
+  for (const item of stacks.values()) {
+    item.records.sort((left, right) => {
+      const a = stackDescriptor(left)?.position
+      const b = stackDescriptor(right)?.position
+      const hasA = typeof a === 'number' && Number.isFinite(a)
+      const hasB = typeof b === 'number' && Number.isFinite(b)
+      if (hasA && hasB) return a - b
+      if (hasA) return -1
+      if (hasB) return 1
+      return String(left?.id || '').localeCompare(String(right?.id || ''))
+    })
+  }
+  return items
+}
+
+function reviewItemDismissIdentity(item) {
+  if (item?.kind === 'record') return item.record
+  if (item?.kind !== 'stack') return null
+  return {
+    id: item.id,
+    // Any revised layer makes this a fresh stack decision, even when a newer
+    // sibling still has the group's greatest timestamp.
+    updated_at: item.records
+      .map(record => `${record.id}:${record.updated_at || ''}`)
+      .sort()
+      .join('|'),
+  }
+}
+
+export function visibleReviewItems(payload, storage) {
+  return reviewItems(payload).filter(
+    item => !isDismissed(reviewItemDismissIdentity(item), storage),
+  )
+}
+
+export function rememberReviewItemDismissed(item, storage) {
+  return rememberDismissed(reviewItemDismissIdentity(item), storage)
 }


### PR DESCRIPTION
## Summary
- project a small sanitized stack identity and order into the chat review response
- collapse every prepared stack into one ordered review card while retaining the compact multi-review panel from #286
- replace the misleading “Needs an update” status with “Review together” for stacks and “Needs attention” for actual blockers
- preserve dismissal, details, and rolling frontend/backend activation behavior

## Tests
- `MOBIUS_TEST_RUNTIME=1 python3 -m pytest -q backend/tests/test_github_routes.py -k for_chat` (6 passed)
- `node --loader=./src/lib/__tests__/vite-env-loader.mjs --test src/components/ChatView/__tests__/contributionReviewModel.test.js` (32 passed)
- `python3 -m py_compile backend/app/routes/github.py`
- `npm run build`