### PR TITLE
Preserve replies when terminal chat persistence fails

### DIFF
--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -54,6 +54,7 @@ from app.chat_writer import (
   PersistTranscript,
   QuestionCommit,
   RecordRunMetrics,
+  RecoverWedgedRun,
   ResolvePark,
   RollbackAutoResume,
   StashThinkingTrace,
@@ -1437,6 +1438,20 @@ async def _clear_run_status_strict(
   await _await_ack(ack)
 
 
+async def _recover_wedged_run_strict(chat_id: str, run_token: str) -> None:
+  """Atomically leave a durable interruption marker and close a wedged run."""
+  ack = get_writer().submit(
+    RecoverWedgedRun(
+      chat_id=chat_id,
+      run_token=run_token,
+      interruption_block=_pause_note(
+        "This response could not be saved. You can resume the turn.",
+      ),
+    )
+  )
+  await _await_ack(ack)
+
+
 def reconcile_interrupted_chats(db: Session) -> list[str]:
   """Resolve chats stranded "running" by a process that died mid-turn.
 
@@ -1840,15 +1855,16 @@ async def sweep_wedged_run_markers(db: Session) -> list[str]:
       a live turn, only a definitively-finished one whose marker stuck.
     - `run_started_at` older than the floor — belt-and-suspenders.
 
-  The clear is IDENTITY-KEYED on the wedged run's `ChatRun.id` (never
+  Recovery is IDENTITY-KEYED on the wedged run's `ChatRun.id` (never
   tokenless): if a fresh turn raced in and took the marker, the actor no-ops
-  the clear rather than wiping the new run's marker. It runs under the per-chat
-  queue lock with an is_alive recheck, mirroring `stop_chat_for`'s clear
-  discipline. The transcript is NOT rewritten — a `ReplaceTranscript`
-  note-append would race a fresh send and could clobber its user message, and
-  any partial output already streamed is persisted. `pending_messages` is left
-  intact and self-heals on the next send; boot reconcile still adds the
-  interrupted-turn note on a real restart.
+  rather than wiping the new run's transcript or marker. It runs under the
+  per-chat queue lock with an is_alive recheck, mirroring `stop_chat_for`'s
+  clear discipline. The writer atomically materializes any saved live assistant,
+  appends a resumable interruption marker, closes the run, and clears the marker.
+  `pending_messages` is preserved. This atomic domain command is required: a
+  separate `ReplaceTranscript` + `ClearRunStatus` pair could race a fresh send,
+  while clearing only the marker can permanently erase the recovery handle for
+  a turn whose snapshots all failed to save.
   """
   log = _get_logger()
   swept: list[str] = []
@@ -1902,14 +1918,12 @@ async def sweep_wedged_run_markers(db: Session) -> list[str]:
           # owns a different token, so the actor no-ops instead of wiping it.
           # Strict variant so a failed ack RAISES — a marker we couldn't clear
           # must not be reported as swept (reconciliation repairs it on boot).
-          await _clear_run_status_strict(
-            chat_id, run.id, terminal_status="interrupted",
-          )
+          await _recover_wedged_run_strict(chat_id, run.id)
       _finalize_broadcast_if_running(chat_id)
       swept.append(chat_id)
     except (Exception, asyncio.TimeoutError):
       log.warning(
-        "sweep_wedged_run_markers: clear failed chat_id=%s "
+        "sweep_wedged_run_markers: recovery failed chat_id=%s "
         "(reconciliation will repair)", chat_id, exc_info=True,
       )
   if swept:

--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -534,6 +534,22 @@ class ClearRunStatus(_Command):
 
 
 @dataclass
+class RecoverWedgedRun(_Command):
+  """Atomically materialize an interrupted turn and clear its stale marker.
+
+  Runtime recovery must never clear the only durable recovery handle while
+  leaving a trailing user message unanswered.  This command folds the saved
+  live assistant snapshot (when one exists) into history, appends the supplied
+  interruption block, closes the exact run row, and clears the marker in one
+  commit.  It preserves ``pending_messages`` unchanged.
+  """
+
+  chat_id: str = ""
+  run_token: str = ""
+  interruption_block: dict = field(default_factory=dict)
+
+
+@dataclass
 class ParkRun(_Command):
   """Park a turn for a due continuation (design §2.4).
 
@@ -681,6 +697,7 @@ _FENCE_COMMANDS = (
   ClearPending,
   ReplaceTranscript,
   ClearRunStatus,
+  RecoverWedgedRun,
   ParkRun,
   ResolvePark,
   PrepareAutoResume,
@@ -1400,6 +1417,8 @@ class ChatWriterActor:
       return self._replace_transcript(db, cmd)
     if isinstance(cmd, ClearRunStatus):
       return self._clear_run_status(db, cmd)
+    if isinstance(cmd, RecoverWedgedRun):
+      return self._recover_wedged_run(db, cmd)
     if isinstance(cmd, ParkRun):
       return self._park_run(db, cmd)
     if isinstance(cmd, ResolvePark):
@@ -2529,6 +2548,101 @@ class ChatWriterActor:
       raise _PersistFailed("ClearRunStatus did not persist")
     self._run_token_owner.pop(cmd.chat_id, None)
     return None
+
+  def _recover_wedged_run(self, db, cmd: RecoverWedgedRun):
+    """Recover a finished turn without creating a silent transcript gap.
+
+    The ownership check is the same identity fence as ``ClearRunStatus``.  A
+    stale recovery command may close its own old run row, but it cannot alter a
+    newer owner's transcript or marker.  When this run still owns the marker,
+    transcript recovery and marker/run closure land in the same transaction.
+    """
+    from datetime import UTC, datetime
+
+    from app.models import Chat, ChatRun
+
+    owner = self._run_token_owner.get(cmd.chat_id)
+    marker_is_ours = not (
+      cmd.run_token and owner is not None and owner != cmd.run_token
+    )
+    changed = False
+    run = db.query(ChatRun).filter(
+      ChatRun.id == cmd.run_token,
+      ChatRun.chat_id == cmd.chat_id,
+    ).first()
+    if run is not None and run.status == "running":
+      run.status = "interrupted"
+      run.ended_at = datetime.now(UTC)
+      run.restart_nonce = None
+      changed = True
+
+    if not marker_is_ours:
+      if changed and not _commit_or_rollback(db):
+        raise _PersistFailed("RecoverWedgedRun did not persist stale close")
+      return False
+
+    chat = db.query(Chat).filter(Chat.id == cmd.chat_id).first()
+    if chat is not None and chat.deleted_at is None:
+      messages = list(chat.messages or [])
+      live = copy.deepcopy(chat.live_assistant)
+      if (
+        isinstance(live, dict)
+        and live.get("role") == "assistant"
+        and isinstance(live.get("blocks"), list)
+        and live["blocks"]
+      ):
+        if messages and messages[-1].get("role") == "assistant":
+          messages[-1] = live
+        else:
+          messages.append(live)
+
+      note = copy.deepcopy(cmd.interruption_block)
+      if not isinstance(note, dict) or note.get("type") != "error":
+        raise _PersistFailed("RecoverWedgedRun requires an error block")
+
+      if messages and messages[-1].get("role") == "assistant":
+        previous = messages[-1]
+        blocks = copy.deepcopy(previous.get("blocks") or [])
+        finalize_blocks(blocks)
+        # Keep unanswered question cards as the terminal affordance.  The
+        # recovery note belongs immediately before them and must not compete
+        # with a second Resume button.
+        open_question_start = len(blocks)
+        while open_question_start > 0:
+          block = blocks[open_question_start - 1]
+          if block.get("type") != "question" or block.get("answers"):
+            break
+          open_question_start -= 1
+        if open_question_start < len(blocks):
+          note.pop("resumable", None)
+          blocks.insert(open_question_start, note)
+        else:
+          blocks.append(note)
+        recovered = build_assistant_message(blocks)
+        recovered["ts"] = (
+          previous.get("ts")
+          if previous.get("ts") is not None
+          else next_message_ts(messages[:-1] + list(chat.pending_messages or []))
+        )
+        messages[-1] = recovered
+      else:
+        recovered = build_assistant_message([note])
+        recovered["ts"] = next_message_ts(
+          messages + list(chat.pending_messages or [])
+        )
+        messages.append(recovered)
+
+      chat.messages = messages
+      chat.live_assistant = None
+      if chat.run_status is not None or chat.run_started_at is not None:
+        chat.run_status = None
+        chat.run_started_at = None
+      changed = True
+
+    if changed and not _commit_or_rollback(db):
+      raise _PersistFailed("RecoverWedgedRun did not persist")
+    self._run_token_owner.pop(cmd.chat_id, None)
+    return True
 
   def _park_run(self, db, cmd: ParkRun):
     """Park the run's row for continuation + clear the per-chat marker.

--- a/backend/tests/test_chat_writer_contention.py
+++ b/backend/tests/test_chat_writer_contention.py
@@ -37,6 +37,7 @@ from app.chat_writer import (
   PersistTranscript,
   PromotePending,
   QuestionCommit,
+  RecoverWedgedRun,
   ReplaceTranscript,
   StartTurn,
 )
@@ -1194,6 +1195,38 @@ def test_clear_run_status_clears_durable_marker(actor):
   chat = _load_chat()
   assert chat["run_status"] is None
   assert chat["run_started_at"] is None
+
+
+def test_stale_wedged_recovery_cannot_clobber_new_run(actor):
+  """A delayed recovery for run A must not alter run B's marker or history."""
+  _seed_chat(messages=[])
+  _await(actor.submit(StartTurn(
+    chat_id="c1",
+    run_token="old-run",
+    user_msg={"role": "user", "content": "old", "ts": 1, "cid": "old"},
+    title_source="old",
+  )))
+  _await(actor.submit(StartTurn(
+    chat_id="c1",
+    run_token="new-run",
+    user_msg={"role": "user", "content": "new", "ts": 2, "cid": "new"},
+    title_source="new",
+  )))
+
+  result = _await(actor.submit(RecoverWedgedRun(
+    chat_id="c1",
+    run_token="old-run",
+    interruption_block={
+      "type": "error", "message": "old recovery", "resumable": True,
+    },
+  )))
+
+  assert result is False
+  chat = _load_chat()
+  assert chat["run_status"] == "running"
+  assert [message["content"] for message in chat["messages"]] == ["old", "new"]
+  assert _load_run("old-run")["status"] == "interrupted"
+  assert _load_run("new-run")["status"] == "running"
 
 
 def test_append_pending_bumps_colliding_ts(actor):

--- a/backend/tests/test_wedged_marker_sweep.py
+++ b/backend/tests/test_wedged_marker_sweep.py
@@ -25,7 +25,7 @@ def _drain_writer():
 
 
 def _seed(chat_id, *, age_secs=200, run_status="running", pending=None,
-          with_run=True):
+          messages=None, live_assistant=None, with_run=True):
   db = SessionLocal()
   try:
     started = None
@@ -34,7 +34,8 @@ def _seed(chat_id, *, age_secs=200, run_status="running", pending=None,
         seconds=age_secs
       )
     c = models.Chat(
-      id=chat_id, title="t", messages=[], pending_messages=pending or [],
+      id=chat_id, title="t", messages=messages or [],
+      live_assistant=live_assistant, pending_messages=pending or [],
       session_id="sess", provider="claude",
       run_status=run_status, run_started_at=started,
     )
@@ -56,7 +57,12 @@ def _state(chat_id):
   db = SessionLocal()
   try:
     c = db.query(models.Chat).filter(models.Chat.id == chat_id).first()
-    return c.run_status, list(c.pending_messages or [])
+    return (
+      c.run_status,
+      list(c.pending_messages or []),
+      list(c.messages or []),
+      c.live_assistant,
+    )
   finally:
     db.close()
 
@@ -80,16 +86,76 @@ def _sweep():
     db.close()
 
 
-def test_sweep_clears_orphaned_marker_and_preserves_queue():
-  _seed("wedged-1", age_secs=200, pending=[{"id": "p1", "ts": 1, "text": "hi"}])
+def test_sweep_recovers_orphaned_turn_and_preserves_queue():
+  _seed(
+    "wedged-1",
+    age_secs=200,
+    pending=[{"id": "p1", "ts": 1, "text": "hi"}],
+    messages=[{"role": "user", "content": "help", "ts": 10}],
+  )
   swept = _sweep()
   _drain_writer()
   assert "wedged-1" in swept
-  status, pending = _state("wedged-1")
+  status, pending, messages, live = _state("wedged-1")
   assert status is None, "orphaned marker should be cleared"
   assert _run_outcome("wedged-1") == "interrupted"
+  assert live is None
+  assert [message["role"] for message in messages] == ["user", "assistant"]
+  assert messages[-1]["blocks"] == [{
+    "type": "error",
+    "message": "This response could not be saved. You can resume the turn.",
+    "resumable": True,
+  }]
   # The queue is preserved for the next-send stale-pending self-heal.
   assert len(pending) == 1
+
+
+def test_sweep_materializes_live_reply_before_interruption_marker():
+  _seed(
+    "wedged-live",
+    messages=[{"role": "user", "content": "help", "ts": 10}],
+    live_assistant={
+      "role": "assistant",
+      "content": "Partial answer",
+      "ts": 11,
+      "blocks": [{"type": "text", "content": "Partial answer"}],
+    },
+  )
+  assert "wedged-live" in _sweep()
+  _drain_writer()
+  status, _pending, messages, live = _state("wedged-live")
+  assert status is None
+  assert live is None
+  assert messages[-1]["ts"] == 11
+  assert messages[-1]["content"] == "Partial answer"
+  assert [block["type"] for block in messages[-1]["blocks"]] == [
+    "text", "error",
+  ]
+
+
+def test_sweep_keeps_unanswered_question_terminal_without_second_resume():
+  _seed(
+    "wedged-question",
+    messages=[{"role": "user", "content": "choose", "ts": 10}],
+    live_assistant={
+      "role": "assistant",
+      "content": "",
+      "ts": 11,
+      "blocks": [{
+        "type": "question",
+        "id": "direction",
+        "question": "Which direction?",
+        "options": [{"label": "A"}, {"label": "B"}],
+      }],
+    },
+  )
+  assert "wedged-question" in _sweep()
+  _drain_writer()
+  _status, _pending, messages, _live = _state("wedged-question")
+  blocks = messages[-1]["blocks"]
+  assert [block["type"] for block in blocks] == ["error", "question"]
+  assert "resumable" not in blocks[0]
+  assert blocks[1]["id"] == "direction"
 
 
 def test_sweep_skips_recent_turn():


### PR DESCRIPTION
## Summary
- atomically materialize any saved live assistant before clearing a wedged run
- append a durable resumable interruption marker when no reply was saved
- preserve queued messages and unanswered question cards during recovery
- fence cleanup by run identity so a stale recovery cannot overwrite a newer turn

## Context
This hardening was discovered while testing #277. That PR should still normalize its typed image path at the provider boundary; this change independently guarantees that a future terminal persistence failure cannot clear the only recovery handle and leave a silent user-to-user gap.

## Tests
- `MOBIUS_TEST_RUNTIME=1 python3 -m pytest -q backend/tests/test_wedged_marker_sweep.py backend/tests/test_chat_writer_contention.py::test_stale_wedged_recovery_cannot_clobber_new_run` (13 passed)
- `python3 -m py_compile backend/app/chat.py backend/app/chat_writer.py`