### PR TITLE
ci: run required checks on merge_group (enable a merge queue)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
     # same suite for every layer so the chain is reviewable in parallel; main's
     # strict required checks still decide when each retargeted layer can merge.
     branches: [main, 'stack/**']
+  # Run the same required suite on the merge queue's synthetic groups so
+  # 'Require merge queue' has its four checks in the merge_group context.
+  merge_group:
 
 permissions:
   contents: read
@@ -19,7 +22,7 @@ env:
 # number is the canonical identity: unlike a source branch it is unique in this
 # repository, stable across head updates, and independent of fork naming.
 concurrency:
-  group: tests-pr-${{ github.event.pull_request.number }}
+  group: tests-pr-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/backend/tests/test_verify_test_runtime.py
+++ b/backend/tests/test_verify_test_runtime.py
@@ -480,6 +480,12 @@ def test_hosted_concurrency_is_scoped_to_the_pull_request():
   workflow = (ROOT / ".github" / "workflows" / "test.yml").read_text(
     encoding="utf-8"
   )
-  assert "group: tests-pr-${{ github.event.pull_request.number }}" in workflow
+  assert (
+    "group: tests-pr-${{ github.event.pull_request.number || github.ref }}"
+    in workflow
+  )
+  # A required-check merge queue needs the suite to run on merge_group too,
+  # where pull_request.number is null (hence the github.ref fallback above).
+  assert "merge_group:" in workflow
   assert "github.event.pull_request.head.ref" not in workflow
   assert "cancel-in-progress: true" in workflow


### PR DESCRIPTION
Prereq for turning on a merge queue on `main`. Adds the `merge_group` trigger to the Tests workflow so privacy/backend/frontend-unit/e2e run on the queue's synthetic groups (otherwise a required-check merge queue hangs forever), and makes the concurrency key fall back to `github.ref` since `pull_request.number` is null in a merge group.

Once this lands, a `merge_queue` ruleset can be enabled on `main` to serialize update→CI→merge automatically and end the current 20+-PR livelock.