### PR TITLE
Keep grouped contribution sends independent

### DIFF
--- a/frontend/src/components/ChatView/ContributionReviewCard.jsx
+++ b/frontend/src/components/ChatView/ContributionReviewCard.jsx
@@ -13,6 +13,7 @@ import {
   passedDismissThreshold,
   payoffLine,
   rememberDismissed,
+  reviewPanelSummary,
   sendBlocker,
   statusLabel,
   visibleRecords,
@@ -57,19 +58,31 @@ export default function ContributionReviewCard({ chatId, turnActive, onOpenApp }
 
   const [busyId, setBusyId] = useState(null)
   const [error, setError] = useState(null)
-  const [sent, setSent] = useState(null)
+  const [sentRows, setSentRows] = useState([])
+  // State disables the buttons on the next render; the ref closes the smaller
+  // same-frame window too. One owner press can therefore claim exactly one
+  // record, even if another click lands before React has painted the lock.
+  const activeSendRef = useRef(null)
   // Dismissals are persisted, so this only forces the re-render; the stored
   // decision is what actually filters the list.
   const [dismissRevision, setDismissRevision] = useState(0)
 
   const storage = typeof localStorage !== 'undefined' ? localStorage : null
-  const records = visibleRecords(data, storage)
-  const grouped = records.length > 1
+  const sentIds = new Set(sentRows.map(row => row.id))
+  // Remove a successful record locally before the ledger refetch returns. This
+  // avoids briefly offering the same public action twice on a slow connection.
+  const records = visibleRecords(data, storage).filter(
+    record => !sentIds.has(record.id),
+  )
+  const panel = reviewPanelSummary(records.length, sentRows.length)
+  const grouped = panel.count > 1
   void dismissRevision
   if (!appId) return null
-  if (!records.length && !sent) return null
+  if (panel.count === 0) return null
 
   async function send(record) {
+    if (activeSendRef.current !== null) return
+    activeSendRef.current = record.id
     setBusyId(record.id)
     setError(null)
     try {
@@ -87,19 +100,24 @@ export default function ContributionReviewCard({ chatId, turnActive, onOpenApp }
         })
         return
       }
-      setSent({
+      const sent = {
         id: record.id,
         number: body?.number ?? body?.record?.number ?? null,
         url: body?.url || body?.record?.url || null,
         repo: record.repo,
-      })
+      }
+      setSentRows(rows => [
+        ...rows.filter(row => row.id !== sent.id),
+        sent,
+      ])
     } catch {
       setError({
         id: record.id,
         message: 'Could not reach the server. Nothing was contributed.',
       })
     } finally {
-      setBusyId(null)
+      if (activeSendRef.current === record.id) activeSendRef.current = null
+      setBusyId(current => current === record.id ? null : current)
       queryClient.invalidateQueries({ queryKey, exact: true })
     }
   }
@@ -108,28 +126,30 @@ export default function ContributionReviewCard({ chatId, turnActive, onOpenApp }
     <div
       className={`contrib-card-stack${grouped ? ' contrib-card-stack--grouped' : ''}`}
       role={grouped ? 'region' : undefined}
-      aria-label={grouped ? `${records.length} contributions ready` : undefined}
+      aria-label={grouped ? panel.title : undefined}
     >
       {grouped && (
         <div className="contrib-card-stack__heading">
           <div>
             <div className="contrib-card-stack__title">
-              {records.length} contributions ready
+              {panel.title}
             </div>
             <div className="contrib-card-stack__copy">
-              Review each one separately.
+              {panel.copy}
             </div>
           </div>
-          <span className="contrib-card-stack__count">{records.length}</span>
+          <span className="contrib-card-stack__count">{panel.count}</span>
         </div>
       )}
-      {sent && (
+      {sentRows.map(sent => (
         <SentRow
           key={`sent:${sent.id}`}
           sent={sent}
-          onDismiss={() => setSent(null)}
+          onDismiss={() => setSentRows(rows => (
+            rows.filter(row => row.id !== sent.id)
+          ))}
         />
-      )}
+      ))}
       {records.map(record => (
         <ReviewRow
           key={record.id}
@@ -137,6 +157,7 @@ export default function ContributionReviewCard({ chatId, turnActive, onOpenApp }
           connected={data?.connected !== false}
           autopilot={autopilotOnSend(data)}
           busy={busyId === record.id}
+          locked={busyId !== null}
           error={error?.id === record.id ? error.message : null}
           onSend={send}
           onOpenContribute={contributeApp && onOpenApp
@@ -299,7 +320,8 @@ function SentRow({ sent, onDismiss }) {
 }
 
 function ReviewRow({
-  record, connected, autopilot, busy, error, onSend, onOpenContribute, onDismiss,
+  record, connected, autopilot, busy, locked, error, onSend, onOpenContribute,
+  onDismiss,
 }) {
   const [open, setOpen] = useState(false)
   const blocker = sendBlocker(record, { connected })
@@ -352,7 +374,7 @@ function ReviewRow({
         <button
           type="button"
           className="contrib-card__send"
-          disabled={busy || submitting || !!blocker}
+          disabled={locked || submitting || !!blocker}
           onClick={() => onSend(record)}
         >
           {submitting || busy ? 'Contributing…' : contributeLabel(record)}

--- a/frontend/src/components/ChatView/__tests__/contributionReviewModel.test.js
+++ b/frontend/src/components/ChatView/__tests__/contributionReviewModel.test.js
@@ -17,6 +17,7 @@ import {
   isHorizontalSwipe,
   passedDismissThreshold,
   rememberDismissed,
+  reviewPanelSummary,
   sendBlocker,
   statusLabel,
   visibleRecords,
@@ -125,13 +126,45 @@ test('the status word distinguishes waiting, blocked, and in-flight', () => {
 })
 
 test('multiple independent contributions share one bounded review panel', () => {
-  assert.match(cardSrc, /const grouped = records\.length > 1/)
+  assert.match(cardSrc, /const panel = reviewPanelSummary\(records\.length, sentRows\.length\)/)
+  assert.match(cardSrc, /const grouped = panel\.count > 1/)
   assert.match(cardSrc, /contrib-card-stack--grouped/)
-  assert.match(cardSrc, /\{records\.length\} contributions ready/)
-  assert.match(cardSrc, /Review each one separately\./)
+  assert.match(cardSrc, /\{panel\.title\}/)
+  assert.match(cardSrc, /\{panel\.copy\}/)
   assert.match(cardCss, /\.contrib-card-stack\s*\{[\s\S]*?width:\s*min\(100%, 640px\);[\s\S]*?margin-inline:\s*auto;/)
   assert.match(cardCss, /\.contrib-card-stack--grouped\s*\{[\s\S]*?max-height:\s*min\(52vh, 520px\);/)
   assert.match(cardCss, /\.contrib-card-stack--grouped \.contrib-card\s*\{[\s\S]*?border-radius:\s*0;/)
+})
+
+test('the grouped panel survives pending-to-contributed transitions', () => {
+  assert.deepEqual(reviewPanelSummary(3, 0), {
+    count: 3,
+    title: '3 contributions ready',
+    copy: 'Each button contributes only its own item.',
+  })
+  assert.deepEqual(reviewPanelSummary(2, 1), {
+    count: 3,
+    title: '2 remaining · 1 contributed',
+    copy: 'Each button contributes only its own item.',
+  })
+  assert.deepEqual(reviewPanelSummary(0, 2), {
+    count: 2,
+    title: '2 contributions contributed',
+    copy: 'Each item was contributed separately.',
+  })
+  assert.match(cardSrc, /const \[sentRows, setSentRows\] = useState\(\[\]\)/)
+  assert.match(cardSrc, /setSentRows\(rows => \[/)
+  assert.match(cardSrc, /\{sentRows\.map\(sent => \(/)
+  assert.match(cardSrc, /rows\.filter\(row => row\.id !== sent\.id\)/)
+})
+
+test('one card press can own only one public submission at a time', () => {
+  assert.match(cardSrc, /const activeSendRef = useRef\(null\)/)
+  assert.match(cardSrc, /if \(activeSendRef\.current !== null\) return/)
+  assert.match(cardSrc, /activeSendRef\.current = record\.id/)
+  assert.match(cardSrc, /locked=\{busyId !== null\}/)
+  assert.match(cardSrc, /disabled=\{locked \|\| submitting \|\| !!blocker\}/)
+  assert.match(cardSrc, /record => !sentIds\.has\(record\.id\)/)
 })
 
 // The action names the value of contributing, not the mechanism of sending, and

--- a/frontend/src/components/ChatView/contributionReviewModel.js
+++ b/frontend/src/components/ChatView/contributionReviewModel.js
@@ -114,6 +114,37 @@ export function diffStatSummary(value) {
   return lines.at(-1) || ''
 }
 
+/**
+ * Copy for the grouped panel across its whole transition, not just its pending
+ * records. A sent acknowledgement is still a visible row, so it must count
+ * toward the grouping decision until that acknowledgement leaves.
+ */
+export function reviewPanelSummary(pendingCount, sentCount) {
+  const pending = Math.max(0, Number(pendingCount) || 0)
+  const sent = Math.max(0, Number(sentCount) || 0)
+  const count = pending + sent
+
+  if (sent === 0) {
+    return {
+      count,
+      title: `${pending} contributions ready`,
+      copy: 'Each button contributes only its own item.',
+    }
+  }
+  if (pending === 0) {
+    return {
+      count,
+      title: `${sent} contribution${sent === 1 ? '' : 's'} contributed`,
+      copy: 'Each item was contributed separately.',
+    }
+  }
+  return {
+    count,
+    title: `${pending} remaining · ${sent} contributed`,
+    copy: 'Each button contributes only its own item.',
+  }
+}
+
 // ── Swipe-to-dismiss ────────────────────────────────────────────────────────
 //
 // Dismissing is a VIEW decision, never a data one: the contribution stays


### PR DESCRIPTION
## Summary

- keep successful contribution acknowledgements inside the grouped review panel
- preserve several completed acknowledgements without replacing earlier ones
- allow only one contribution request at a time and disable sibling actions while it settles
- make the grouped heading show remaining and completed counts

## Context

Follow-up to #286, which introduced the compact grouped contribution panel. After one item was contributed, the remaining count could collapse the panel and detach the acknowledgement. The client also left sibling actions available while a submission was in flight.

This keeps each owner approval scoped to one contribution and preserves the grouped review context throughout the sequence.

## Testing

- focused contribution review checks passed
- full frontend unit suite passed
- production frontend build passed
- rendered with three independent contributions through two sequential successful sends