### PR TITLE
Keep stacked contribution reviews independent through send

### DIFF
--- a/frontend/src/components/ChatView/ContributionReviewCard.jsx
+++ b/frontend/src/components/ChatView/ContributionReviewCard.jsx
@@ -13,6 +13,7 @@ import {
   passedDismissThreshold,
   payoffLine,
   rememberReviewItemDismissed,
+  reviewPanelSummary,
   sendBlocker,
   statusLabel,
   visibleReviewItems,
@@ -57,19 +58,31 @@ export default function ContributionReviewCard({ chatId, turnActive, onOpenApp }
 
   const [busyId, setBusyId] = useState(null)
   const [error, setError] = useState(null)
-  const [sent, setSent] = useState(null)
+  const [sentRows, setSentRows] = useState([])
+  // State disables the buttons on the next render; the ref closes the smaller
+  // same-frame window too. One owner press can therefore claim exactly one
+  // record, even if another click lands before React has painted the lock.
+  const activeSendRef = useRef(null)
   // Dismissals are persisted, so this only forces the re-render; the stored
   // decision is what actually filters the list.
   const [dismissRevision, setDismissRevision] = useState(0)
 
   const storage = typeof localStorage !== 'undefined' ? localStorage : null
-  const reviewItems = visibleReviewItems(data, storage)
-  const grouped = reviewItems.length > 1
+  const sentIds = new Set(sentRows.map(row => row.id))
+  // Remove a successful single record locally before the ledger refetch
+  // returns. Stack review items never send from chat and stay untouched.
+  const pendingItems = visibleReviewItems(data, storage).filter(
+    item => item.kind !== 'record' || !sentIds.has(item.record.id),
+  )
+  const panel = reviewPanelSummary(pendingItems.length, sentRows.length)
+  const grouped = panel.count > 1
   void dismissRevision
   if (!appId) return null
-  if (!reviewItems.length && !sent) return null
+  if (panel.count === 0) return null
 
   async function send(record) {
+    if (activeSendRef.current !== null) return
+    activeSendRef.current = record.id
     setBusyId(record.id)
     setError(null)
     try {
@@ -87,19 +100,24 @@ export default function ContributionReviewCard({ chatId, turnActive, onOpenApp }
         })
         return
       }
-      setSent({
+      const sent = {
         id: record.id,
         number: body?.number ?? body?.record?.number ?? null,
         url: body?.url || body?.record?.url || null,
         repo: record.repo,
-      })
+      }
+      setSentRows(rows => [
+        ...rows.filter(row => row.id !== sent.id),
+        sent,
+      ])
     } catch {
       setError({
         id: record.id,
         message: 'Could not reach the server. Nothing was contributed.',
       })
     } finally {
-      setBusyId(null)
+      if (activeSendRef.current === record.id) activeSendRef.current = null
+      setBusyId(current => current === record.id ? null : current)
       queryClient.invalidateQueries({ queryKey, exact: true })
     }
   }
@@ -108,29 +126,31 @@ export default function ContributionReviewCard({ chatId, turnActive, onOpenApp }
     <div
       className={`contrib-card-stack${grouped ? ' contrib-card-stack--grouped' : ''}`}
       role={grouped ? 'region' : undefined}
-      aria-label={grouped ? `${reviewItems.length} reviews ready` : undefined}
+      aria-label={grouped ? panel.title : undefined}
     >
       {grouped && (
         <div className="contrib-card-stack__heading">
           <div>
             <div className="contrib-card-stack__title">
-              {reviewItems.length} reviews ready
+              {panel.title}
             </div>
             <div className="contrib-card-stack__copy">
-              Review each item separately.
+              {panel.copy}
             </div>
           </div>
-          <span className="contrib-card-stack__count">{reviewItems.length}</span>
+          <span className="contrib-card-stack__count">{panel.count}</span>
         </div>
       )}
-      {sent && (
+      {sentRows.map(sent => (
         <SentRow
           key={`sent:${sent.id}`}
           sent={sent}
-          onDismiss={() => setSent(null)}
+          onDismiss={() => setSentRows(rows => (
+            rows.filter(row => row.id !== sent.id)
+          ))}
         />
-      )}
-      {reviewItems.map(item => {
+      ))}
+      {pendingItems.map(item => {
         const onOpenContribute = contributeApp && onOpenApp
           ? () => onOpenApp(contributeApp, { final: true })
           : null
@@ -156,6 +176,7 @@ export default function ContributionReviewCard({ chatId, turnActive, onOpenApp }
             connected={data?.connected !== false}
             autopilot={autopilotOnSend(data)}
             busy={busyId === record.id}
+            locked={busyId !== null}
             error={error?.id === record.id ? error.message : null}
             onSend={send}
             onOpenContribute={onOpenContribute}
@@ -376,7 +397,8 @@ function StackReviewRow({ item, onOpenContribute, onDismiss }) {
 }
 
 function ReviewRow({
-  record, connected, autopilot, busy, error, onSend, onOpenContribute, onDismiss,
+  record, connected, autopilot, busy, locked, error, onSend, onOpenContribute,
+  onDismiss,
 }) {
   const [open, setOpen] = useState(false)
   const blocker = sendBlocker(record, { connected })
@@ -429,7 +451,7 @@ function ReviewRow({
         <button
           type="button"
           className="contrib-card__send"
-          disabled={busy || submitting || !!blocker}
+          disabled={locked || submitting || !!blocker}
           onClick={() => onSend(record)}
         >
           {submitting || busy ? 'Contributing…' : contributeLabel(record)}

--- a/frontend/src/components/ChatView/__tests__/contributionReviewModel.test.js
+++ b/frontend/src/components/ChatView/__tests__/contributionReviewModel.test.js
@@ -19,6 +19,7 @@ import {
   rememberDismissed,
   rememberReviewItemDismissed,
   reviewItems,
+  reviewPanelSummary,
   sendBlocker,
   statusLabel,
   visibleReviewItems,
@@ -135,10 +136,11 @@ test('the status word distinguishes waiting, blocked, and in-flight', () => {
 })
 
 test('multiple independent review items share one bounded review panel', () => {
-  assert.match(cardSrc, /const grouped = reviewItems\.length > 1/)
+  assert.match(cardSrc, /const panel = reviewPanelSummary\(pendingItems\.length, sentRows\.length\)/)
+  assert.match(cardSrc, /const grouped = panel\.count > 1/)
   assert.match(cardSrc, /contrib-card-stack--grouped/)
-  assert.match(cardSrc, /\{reviewItems\.length\} reviews ready/)
-  assert.match(cardSrc, /Review each item separately\./)
+  assert.match(cardSrc, /\{panel\.title\}/)
+  assert.match(cardSrc, /\{panel\.copy\}/)
   assert.match(cardCss, /\.contrib-card-stack\s*\{[\s\S]*?width:\s*min\(100%, 640px\);[\s\S]*?margin-inline:\s*auto;/)
   assert.match(cardCss, /\.contrib-card-stack--grouped\s*\{[\s\S]*?max-height:\s*min\(52vh, 520px\);/)
   assert.match(cardCss, /\.contrib-card-stack--grouped \.contrib-card\s*\{[\s\S]*?border-radius:\s*0;/)
@@ -201,6 +203,37 @@ test('the renderer gives a stack one review-together card, not one card per laye
   assert.match(cardSrc, /item\.kind === 'stack'/)
   assert.match(cardSrc, /<StackReviewRow/)
   assert.match(cardSrc, /Review in Contribute/)
+})
+
+test('the grouped panel survives pending-to-contributed transitions', () => {
+  assert.deepEqual(reviewPanelSummary(3, 0), {
+    count: 3,
+    title: '3 reviews ready',
+    copy: 'Each item keeps its own review and action.',
+  })
+  assert.deepEqual(reviewPanelSummary(2, 1), {
+    count: 3,
+    title: '2 remaining · 1 contributed',
+    copy: 'Each item keeps its own review and action.',
+  })
+  assert.deepEqual(reviewPanelSummary(0, 2), {
+    count: 2,
+    title: '2 items contributed',
+    copy: 'Each item was contributed separately.',
+  })
+  assert.match(cardSrc, /const \[sentRows, setSentRows\] = useState\(\[\]\)/)
+  assert.match(cardSrc, /setSentRows\(rows => \[/)
+  assert.match(cardSrc, /\{sentRows\.map\(sent => \(/)
+  assert.match(cardSrc, /rows\.filter\(row => row\.id !== sent\.id\)/)
+})
+
+test('one card press can own only one public submission at a time', () => {
+  assert.match(cardSrc, /const activeSendRef = useRef\(null\)/)
+  assert.match(cardSrc, /if \(activeSendRef\.current !== null\) return/)
+  assert.match(cardSrc, /activeSendRef\.current = record\.id/)
+  assert.match(cardSrc, /locked=\{busyId !== null\}/)
+  assert.match(cardSrc, /disabled=\{locked \|\| submitting \|\| !!blocker\}/)
+  assert.match(cardSrc, /item => item\.kind !== 'record' \|\| !sentIds\.has\(item\.record\.id\)/)
 })
 
 // The action names the value of contributing, not the mechanism of sending, and

--- a/frontend/src/components/ChatView/contributionReviewModel.js
+++ b/frontend/src/components/ChatView/contributionReviewModel.js
@@ -115,6 +115,37 @@ export function diffStatSummary(value) {
   return lines.at(-1) || ''
 }
 
+/**
+ * Copy for the grouped panel across its whole transition, not just its pending
+ * records. A sent acknowledgement is still a visible row, so it must count
+ * toward the grouping decision until that acknowledgement leaves.
+ */
+export function reviewPanelSummary(pendingCount, sentCount) {
+  const pending = Math.max(0, Number(pendingCount) || 0)
+  const sent = Math.max(0, Number(sentCount) || 0)
+  const count = pending + sent
+
+  if (sent === 0) {
+    return {
+      count,
+      title: `${pending} ${pending === 1 ? 'review' : 'reviews'} ready`,
+      copy: 'Each item keeps its own review and action.',
+    }
+  }
+  if (pending === 0) {
+    return {
+      count,
+      title: `${sent} item${sent === 1 ? '' : 's'} contributed`,
+      copy: 'Each item was contributed separately.',
+    }
+  }
+  return {
+    count,
+    title: `${pending} remaining · ${sent} contributed`,
+    copy: 'Each item keeps its own review and action.',
+  }
+}
+
 // ── Swipe-to-dismiss ────────────────────────────────────────────────────────
 //
 // Dismissing is a VIEW decision, never a data one: the contribution stays


### PR DESCRIPTION
## Summary

- preserve stacked contribution groups as one ordered review item
- keep every successful single contribution acknowledgement inside the grouped panel
- prevent same-frame double sends and disable sibling public actions while one request settles
- keep the grouped heading accurate across pending and contributed items

This is the reviewed integration of #298 and #301. #301 was authored against the pre-stack card, so the two changes were reconciled at the review-item model rather than allowing either stack grouping or independent-send locking to overwrite the other.

## Verification

- 34 focused contribution review checks passed
- 2,014 frontend unit checks passed
- 63 hook checks passed
- production frontend build passed

#298 is already in the merge queue. Once it lands, this PR's diff reduces to the independent-send follow-up and can enter the queue behind it.

Supersedes #301 once merged.
