### PR TITLE
Refine first-run web experience

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,10 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <!-- Möbius chrome is a fixed application surface. Browser page zoom would
-         scale the toolbar and drawer with the active app; zoomable content owns
-         its gesture locally so it can transform without moving the shell. -->
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1, user-scalable=no, viewport-fit=cover, interactive-widget=resizes-content" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content" />
     <!-- Default theme-color; applyTheme updates this to the active theme's --bg. -->
     <meta name="theme-color" content="#0d0d0d" />
     <!-- Android/Chrome consults color-scheme before JS/CSS fully applies.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -215,7 +215,9 @@ function AppRoot() {
     }
   }, [hasToken, setupStatusQuery.isError, setupStatusQuery.isSuccess, setupStatusQuery.data])
 
-  if (status === 'loading' || isRestoring) return null
+  if (status === 'loading' || isRestoring) {
+    return <RouteLoading label={isRestoring ? 'Restoring Möbius' : 'Loading Möbius'} />
+  }
   if (status === 'sso') return <RouteLoading label="Signing in to Möbius" />
   if (status === 'sso-error') return (
     <ManagedSignInError
@@ -258,7 +260,9 @@ function AppRoot() {
 
 function RouteLoading({ label }) {
   return (
-    <div className="app-route-loading" role="status" aria-label={label} />
+    <div className="app-route-loading" role="status">
+      <span>{label}…</span>
+    </div>
   )
 }
 

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -107,12 +107,12 @@
 }
 
 /* Empty state: centered in the available chat area, with a FIXED
-   bottom reservation so the composer doesn't overlap the logo.
-   Centering means the cluster moves up when the visible viewport
+   bottom reservation so the composer doesn't overlap the prompt.
+   Centering means the prompt moves up when the visible viewport
    shrinks (keyboard open via `interactive-widget=resizes-content`)
    — the chat container itself gets shorter, so the centerpoint
    moves up. The bottom padding is a CONSTANT (not --composer-h)
-   so multi-line input growth doesn't push the cluster up; only
+   so multi-line input growth doesn't push the prompt up; only
    the keyboard does. 140px clears a typical multi-line composer;
    if the user composes a wall of text on the empty state, slight
    overlap is acceptable. */
@@ -193,21 +193,10 @@
   flex-direction: column;
   align-items: center;
   text-align: center;
-  padding: 72px 24px 24px;
+  padding: 24px;
   gap: 12px;
   max-width: 768px;
   margin: 0 auto;
-  /* Lift the empty-state cluster (logo + title + sub) ~5% above
-     the visual centerline so it doesn't feel buried by the
-     composer at the bottom. */
-  transform: translateY(-5%);
-}
-
-.chat__empty-glyph {
-  width: 96px;
-  height: 96px;
-  opacity: 0.88;
-  margin-bottom: 2px;
 }
 
 /* .chat__empty-title lives in index.css so theme toggles keep it stable. */

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -9,7 +9,6 @@ import {
 } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import Check from 'lucide-react/dist/esm/icons/check.mjs'
-import mobiusLogoUrl from '../../assets/moebius.svg'
 import { apiFetch, getAuthHeaders, jsonOrThrow, BASE } from '../../api/client.js'
 import { chatMessagesQueryKey } from '../../hooks/queries.js'
 import useStreamConnection from './useStreamConnection.js'
@@ -3814,7 +3813,6 @@ export default function ChatView({
             )
           ) : (
             <div className="chat__empty">
-              <img className="chat__empty-glyph" src={mobiusLogoUrl} alt="" width="120" height="120" />
               <p className="chat__empty-title">What's on your mind?</p>
             </div>
           )}

--- a/frontend/src/components/ChatView/__tests__/accessibilityHardening.test.js
+++ b/frontend/src/components/ChatView/__tests__/accessibilityHardening.test.js
@@ -55,7 +55,6 @@ test('first-use guidance is a labeled non-modal region with a dismiss action', (
   assert.match(source, /role="region"/)
   assert.match(source, /aria-labelledby="wt-title"/)
   assert.match(source, /aria-label="Dismiss welcome"/)
-  assert.match(source, /aria-labelledby="wt-install-title"/)
   assert.match(source, /aria-expanded=/)
   assert.match(source, /role="status"/)
   assert.doesNotMatch(source, /aria-modal="true"/)

--- a/frontend/src/components/Drawer/AppsDirectory.css
+++ b/frontend/src/components/Drawer/AppsDirectory.css
@@ -25,10 +25,10 @@
   min-width: 0;
   display: flex;
   align-items: baseline;
+  gap: 10px;
 }
 
 .apps-directory__title h1,
-.apps-directory__intro h2,
 .apps-directory__empty h2 {
   margin: 0;
   color: var(--text);
@@ -40,7 +40,7 @@
   letter-spacing: -0.035em;
 }
 
-.apps-directory__intro span {
+.apps-directory__title span {
   color: var(--muted);
   font-size: 13px;
 }
@@ -97,21 +97,6 @@
   scrollbar-width: var(--shell-scrollbar-width, none);
 }
 
-.apps-directory__intro {
-  display: flex;
-  align-items: end;
-  justify-content: space-between;
-  gap: 18px;
-  margin-bottom: 22px;
-}
-
-.apps-directory__intro h2 {
-  font-size: 18px;
-  font-weight: 600;
-  letter-spacing: -0.02em;
-}
-
-.apps-directory__intro p,
 .apps-directory__empty p {
   margin: 5px 0 0;
   color: var(--muted);
@@ -264,6 +249,29 @@
   font-weight: 600;
 }
 
+.apps-directory__empty button {
+  min-height: 44px;
+  margin-top: 14px;
+  padding: 8px 13px;
+  color: var(--text);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.apps-directory__empty button:hover {
+  border-color: var(--accent);
+}
+
+.apps-directory__empty button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 @media (max-width: 720px) {
   .apps-directory__header {
     min-height: 64px;
@@ -287,10 +295,6 @@
 
   .apps-directory__scroll {
     padding: 18px 13px max(28px, env(safe-area-inset-bottom));
-  }
-
-  .apps-directory__intro {
-    margin-bottom: 18px;
   }
 
   .apps-directory__grid {

--- a/frontend/src/components/Drawer/AppsDirectory.jsx
+++ b/frontend/src/components/Drawer/AppsDirectory.jsx
@@ -4,6 +4,8 @@ import './AppsDirectory.css'
 
 export default function AppsDirectory({
   empty,
+  status = 'success',
+  onRetry,
   resultCount,
   query,
   onQueryChange,
@@ -23,13 +25,18 @@ export default function AppsDirectory({
     }
   }, [])
 
-  const noMatches = !empty && resultCount === 0
+  const noMatches = status === 'success' && !empty && resultCount === 0
 
   return (
     <section className="apps-directory" aria-label="Installed apps">
       <header className="apps-directory__header">
         <div className="apps-directory__title">
           <h1>Apps</h1>
+          {status === 'success' && query && !empty && (
+            <span aria-live="polite">
+              {resultCount} {resultCount === 1 ? 'match' : 'matches'}
+            </span>
+          )}
         </div>
         <label className="apps-directory__search">
           <Search aria-hidden="true" />
@@ -47,19 +54,17 @@ export default function AppsDirectory({
       </header>
 
       <div className="apps-directory__scroll">
-        <div className="apps-directory__intro">
-          <div>
-            <h2>Your apps</h2>
-            <p>Everything installed in this Möbius workspace.</p>
+        {status === 'loading' ? (
+          <div className="apps-directory__empty" role="status">
+            <p>Loading apps…</p>
           </div>
-          {query && !empty && (
-            <span aria-live="polite">
-              {resultCount} {resultCount === 1 ? 'match' : 'matches'}
-            </span>
-          )}
-        </div>
-
-        {empty ? (
+        ) : status === 'error' ? (
+          <div className="apps-directory__empty" role="alert">
+            <h2>Apps unavailable</h2>
+            <p>Check your connection, then try again.</p>
+            <button type="button" onClick={onRetry}>Try again</button>
+          </div>
+        ) : empty ? (
           <div className="apps-directory__empty">
             <h2>No installed apps yet</h2>
             <p>Installed apps will appear here as soon as you add one.</p>

--- a/frontend/src/components/Drawer/Drawer.css
+++ b/frontend/src/components/Drawer/Drawer.css
@@ -613,16 +613,38 @@
   -webkit-tap-highlight-color: transparent;
 }
 
-/* ── Empty state ──────────────────────────────────── */
+/* ── List status ──────────────────────────────────── */
 
-/* SDK EmptyMessage carries its own internal padding + typography.
-   We only tighten the surrounding scope (keep it left-aligned and
-   not centred-block) so the empty hint sits flush with the rest
-   of the list. */
-.drawer__empty {
-  padding: 4px 10px 8px;
-  text-align: left;
-  align-items: flex-start;
+.drawer__list-status {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin: 4px 10px 8px;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.drawer__list-status button {
+  min-height: 44px;
+  padding: 7px 10px;
+  color: var(--text);
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.drawer__list-status button:hover {
+  background: var(--surface);
+}
+
+.drawer__list-status button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 /* ── Bottom group (Settings) ───────────────────────── */

--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -3,7 +3,6 @@ import { createPortal } from 'react-dom'
 import { useQueryClient } from '@tanstack/react-query'
 import { Chats, DotsVerticalMoreMenu, Pin, PinFilled } from '@openai/apps-sdk-ui/components/Icon'
 import { Menu } from '@openai/apps-sdk-ui/components/Menu'
-import { EmptyMessage } from '@openai/apps-sdk-ui/components/EmptyMessage'
 import { api } from '../../api/client.js'
 import { appQueries, chatQueries } from '../../hooks/queries.js'
 import {
@@ -57,9 +56,13 @@ export default function Drawer({
   interactionLocked = false,
   onClose,
   apps,
+  appsStatus = 'success',
+  onRetryApps,
   activeView,
   activeAppId,
   chats,
+  chatsStatus = 'success',
+  onRetryChats,
   activeChatId,
   onChat,
   onApp,
@@ -917,45 +920,50 @@ export default function Drawer({
                 </section>
               )}
 
-              <section className="drawer__section" aria-labelledby="drawer-chats-label">
-                <h2 id="drawer-chats-label" className="drawer__label drawer__label--chats">
-                  <Chats width={16} height={16} aria-hidden="true" />
-                  <span>Chats</span>
-                </h2>
-              {allChats.length > 0 ? visibleChats.map(chat => (
-                <DrawerRow
-                  key={chat.id}
-                  kind="chat"
-                  item={chat}
-                  surface="drawer"
-                  streaming={streamingSet.has(chat.id)}
-                  attention={attentionSet.has(chat.id)}
-                  active={!appsActive && activeView === 'chat' && activeChatId === chat.id}
-                  menuOpen={!!(openMenu
-                    && openMenu.surface === 'drawer'
-                    && openMenu.kind === 'chat'
-                    && openMenu.id === chat.id)}
-                  renaming={!!(renaming
-                    && renaming.surface === 'drawer'
-                    && renaming.kind === 'chat'
-                    && renaming.id === chat.id)}
-                  actions={rowActions}
-                />
-              )) : (
-                <EmptyMessage className="drawer__empty" fill="static">
-                  <EmptyMessage.Description>
-                    No conversations yet
-                  </EmptyMessage.Description>
-                </EmptyMessage>
+              {chatsStatus === 'loading' && (
+                <p className="drawer__list-status" role="status">Loading chats…</p>
               )}
-              {visibleChatCount < allChats.length && (
-                <div
-                  ref={chatSentinelRef}
-                  className="drawer__progressive-sentinel"
-                  aria-hidden="true"
-                />
+              {chatsStatus === 'error' && (
+                <div className="drawer__list-status" role="alert">
+                  <span>Chats unavailable.</span>
+                  <button type="button" onClick={onRetryChats}>Retry</button>
+                </div>
               )}
-              </section>
+              {chatsStatus === 'success' && allChats.length > 0 && (
+                <section className="drawer__section" aria-labelledby="drawer-chats-label">
+                  <h2 id="drawer-chats-label" className="drawer__label drawer__label--chats">
+                    <Chats width={16} height={16} aria-hidden="true" />
+                    <span>Chats</span>
+                  </h2>
+                  {visibleChats.map(chat => (
+                    <DrawerRow
+                      key={chat.id}
+                      kind="chat"
+                      item={chat}
+                      surface="drawer"
+                      streaming={streamingSet.has(chat.id)}
+                      attention={attentionSet.has(chat.id)}
+                      active={!appsActive && activeView === 'chat' && activeChatId === chat.id}
+                      menuOpen={!!(openMenu
+                        && openMenu.surface === 'drawer'
+                        && openMenu.kind === 'chat'
+                        && openMenu.id === chat.id)}
+                      renaming={!!(renaming
+                        && renaming.surface === 'drawer'
+                        && renaming.kind === 'chat'
+                        && renaming.id === chat.id)}
+                      actions={rowActions}
+                    />
+                  ))}
+                  {visibleChatCount < allChats.length && (
+                    <div
+                      ref={chatSentinelRef}
+                      className="drawer__progressive-sentinel"
+                      aria-hidden="true"
+                    />
+                  )}
+                </section>
+              )}
             </div>
           </div>{/* /.drawer__scroll-wrap */}
 
@@ -992,6 +1000,8 @@ export default function Drawer({
       {appsActive && appsHost && createPortal((
         <AppsDirectory
           empty={sortedApps.length === 0}
+          status={appsStatus}
+          onRetry={onRetryApps}
           resultCount={filteredApps.length}
           query={appQuery}
           onQueryChange={setAppQuery}

--- a/frontend/src/components/Shell/NewChatLanding.jsx
+++ b/frontend/src/components/Shell/NewChatLanding.jsx
@@ -1,11 +1,9 @@
-import mobiusLogoUrl from '../../assets/moebius.svg'
-
 /**
  * The first-class New Chat landing painted for a null single-screen slot
  * (round 4 item 3). A null slot is a DEFINITE New Chat destination now — never the
  * freshest transcript — so the honest beat destination is this cheap, always-available
  * surface. It shares ChatView's empty-treatment visuals (the same .chat__empty-wrap /
- * .chat__empty glyph + title) so the swap to a real empty ChatView, once the row
+ * .chat__empty title) so the swap to a real empty ChatView, once the row
  * materializes, is visually seamless. It also doubles as the stationary world-reveal
  * underlay while the panes slide away.
  *
@@ -23,7 +21,6 @@ export default function NewChatLanding({ failure = null, onRetry }) {
     <div className="chat chat--empty">
       <div className="chat__empty-wrap">
         <div className="chat__empty">
-          <img className="chat__empty-glyph" src={mobiusLogoUrl} alt="" width="120" height="120" />
           <p className="chat__empty-title">What&apos;s on your mind?</p>
           {failure && (
             <>

--- a/frontend/src/components/Shell/Shell.css
+++ b/frontend/src/components/Shell/Shell.css
@@ -38,6 +38,28 @@
   z-index: 0;
 }
 
+.shell__skip-link {
+  position: fixed;
+  top: calc(env(safe-area-inset-top, 0px) + 8px);
+  left: 12px;
+  z-index: 1000;
+  padding: 9px 12px;
+  color: var(--text);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 650;
+  text-decoration: none;
+  transform: translateY(calc(-100% - 18px));
+}
+
+.shell__skip-link:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  transform: translateY(0);
+}
+
 .shell--immersive::after {
   display: none;
 }

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -653,6 +653,12 @@ export default function Shell() {
   })
   const apps = appsQuery.data ?? []
   const chats = chatsQuery.data ?? []
+  const appsStatus = apps.length > 0 || appsQuery.isSuccess
+    ? 'success'
+    : (appsQuery.isError ? 'error' : 'loading')
+  const chatsStatus = chats.length > 0 || chatsQuery.isSuccess
+    ? 'success'
+    : (chatsQuery.isError ? 'error' : 'loading')
   // Prime only the two most-recent chats that are not already open, including
   // active chats: their cached transcript is useful while stream catch-up runs.
   // ChatView still revalidates on mount, but this gives its synchronous cache
@@ -3575,6 +3581,16 @@ export default function Shell() {
       + `${modeMachine.transitionRootClass(modeState, { splitsEnabled: SPLITS })
         ? ` ${modeMachine.transitionRootClass(modeState, { splitsEnabled: SPLITS })}` : ''}`
       + `${builderModeActive && paneModel.BUILDER_POWER_CHROME ? ' shell--builder-power' : ''}`}>
+      <a
+        className="shell__skip-link"
+        href="#main-content"
+        onClick={(event) => {
+          event.preventDefault()
+          contentElRef.current?.focus({ preventScroll: true })
+        }}
+      >
+        Skip to content
+      </a>
       {/* The existing brand toggle remains the visible close affordance while the
           mobile drawer is modal. Keep the workspace inert below, but do not inert
           the header: doing so lets the scrim intercept the toggle and strands the
@@ -3659,9 +3675,13 @@ export default function Shell() {
         interactionLocked={drawerModeTransitioning}
         onClose={drawerModeTransitioning ? undefined : closeDrawer}
         apps={apps}
+        appsStatus={appsStatus}
+        onRetryApps={() => appsQuery.refetch()}
         activeView={activeView}
         activeAppId={activeAppId}
         chats={chats}
+        chatsStatus={chatsStatus}
+        onRetryChats={() => chatsQuery.refetch()}
         activeChatId={activeChatId}
         onChat={selectChat}
         onApp={(id) => navTo('canvas', { appId: id })}
@@ -3769,7 +3789,7 @@ export default function Shell() {
         </nav>
         )
       })()}
-      <main className="shell__content" inert={navigationSurfaceOpen} ref={contentElRef}>
+      <main className="shell__content" id="main-content" tabIndex={-1} inert={navigationSurfaceOpen} ref={contentElRef}>
         {/* Content layer (design §2): app-iframe wrappers (id-sorted) and chat
             wrappers (chatId-sorted) as ONE flat sibling set, never reparented.
             A wrapper is positioned (--paned) when its tab is a visible pane's

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -123,12 +123,28 @@ test('the undo chord is flag-gated and defers to focused inputs', () => {
 test('the first-run walkthrough stays short and action-first', () => {
   assert.doesNotMatch(walkthrough, /const STEPS/)
   assert.match(walkthrough, /Your Möbius is ready/)
-  assert.match(walkthrough, /Connect an agent/)
-  assert.match(walkthrough, /Open the App Store/)
-  assert.match(walkthrough, /Keep Möbius close/)
+  assert.match(walkthrough, /Connect agent/)
+  assert.match(walkthrough, /Explore apps/)
+  assert.match(walkthrough, /Install Möbius/)
+  assert.match(walkthrough, /How to install/)
   assert.match(walkthrough, /requestInstall/)
-  assert.match(walkthrough, /I’ll explore/)
+  assert.doesNotMatch(walkthrough, /wt__kicker|wt__mark|Open Settings|Open the App Store|I’ll explore/)
   assert.match(walkthrough, /mobius:walkthrough-completed/)
+})
+
+test('the authenticated shell offers a keyboard skip link', () => {
+  assert.match(shell, /href="#main-content"/)
+  assert.match(shell, /event\.preventDefault\(\)[\s\S]*?contentElRef\.current\?\.focus\(\{ preventScroll: true \}\)/)
+  assert.match(shell, /<main className="shell__content" id="main-content" tabIndex=\{-1\}/)
+})
+
+test('drawer lists distinguish loading, error, and confirmed empty data', () => {
+  assert.match(shell, /appsStatus=\{appsStatus\}/)
+  assert.match(shell, /chatsStatus=\{chatsStatus\}/)
+  assert.match(drawer, /chatsStatus === 'loading'/)
+  assert.match(drawer, /chatsStatus === 'error'/)
+  assert.match(drawer, /chatsStatus === 'success' && allChats\.length > 0/)
+  assert.doesNotMatch(drawer, /No conversations yet/)
 })
 
 test('a crashed app pane is isolated by a per-pane ErrorBoundary', () => {
@@ -722,7 +738,7 @@ test('navigation surfaces keep the brand close path while the workspace is inert
   assert.match(shell, /const navigationSurfaceOpen = modalDrawerOpen/)
   assert.doesNotMatch(shell, /const navigationSurfaceOpen = .*apps/,
     'the canonical Apps tab is workspace content, not a modal navigation surface')
-  assert.match(shell, /<main className="shell__content" inert=\{navigationSurfaceOpen\}/)
+  assert.match(shell, /<main className="shell__content"[^>]*inert=\{navigationSurfaceOpen\}/)
   assert.match(shellBrand, /aria-expanded=\{navigationOpen\}/)
   assert.match(shell, /drawerOpen \? closeDrawer\(\) : openDrawer\(\)/)
 })

--- a/frontend/src/components/Walkthrough/WalkthroughOverlay.css
+++ b/frontend/src/components/Walkthrough/WalkthroughOverlay.css
@@ -8,10 +8,12 @@
   z-index: 900;
   top: calc(62px + env(safe-area-inset-top, 0px));
   right: 18px;
-  width: min(390px, calc(100vw - 32px));
+  width: min(360px, calc(100vw - 32px));
+  max-height: calc(100dvh - 80px - env(safe-area-inset-top, 0px));
   box-sizing: border-box;
-  padding: 22px;
-  overflow: hidden;
+  padding: 20px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
   color: var(--text, #e4e4e7);
   background:
     radial-gradient(circle at 100% 0%, color-mix(in srgb, var(--accent, #8b6cf7) 24%, transparent), transparent 48%),
@@ -39,12 +41,12 @@
 
 .wt__close {
   position: absolute;
-  top: 10px;
-  right: 10px;
+  top: 6px;
+  right: 6px;
   display: grid;
   place-items: center;
-  width: 36px;
-  height: 36px;
+  width: 44px;
+  height: 44px;
   padding: 0;
   color: var(--muted, #a1a1aa);
   background: transparent;
@@ -63,48 +65,17 @@
 
 .wt__close:focus-visible,
 .wt__install-btn:focus-visible,
-.wt__path:focus-visible,
-.wt__dismiss:focus-visible {
+.wt__path:focus-visible {
   outline: 2px solid var(--accent, #8b6cf7);
   outline-offset: 2px;
 }
 
-.wt__mark {
-  position: relative;
-  width: 42px;
-  height: 42px;
-  margin-bottom: 18px;
-  border-radius: 14px;
-  background: color-mix(in srgb, var(--accent, #8b6cf7) 16%, var(--surface2, #1a1f28));
-}
-
-.wt__mark::before,
-.wt__mark span {
-  content: "";
-  position: absolute;
-  inset: 10px 9px;
-  border: 1.5px solid var(--accent, #8b6cf7);
-  border-radius: 50%;
-}
-
-.wt__mark span {
-  transform: rotate(32deg) scaleX(0.48);
-}
-
-.wt__kicker {
-  margin: 0 0 6px;
-  color: var(--accent, #a78bfa);
-  font-size: 12px;
-  font-weight: 720;
-}
-
 .wt__title {
-  max-width: 15ch;
-  margin: 0 0 10px;
+  margin: 0 34px 7px 0;
   color: var(--text, #e4e4e7);
-  font-size: clamp(22px, 5vw, 28px);
-  font-weight: 720;
-  line-height: 1.08;
+  font-size: 21px;
+  font-weight: 700;
+  line-height: 1.2;
   letter-spacing: -0.025em;
   text-wrap: balance;
 }
@@ -114,65 +85,31 @@
   margin: 0;
   color: var(--muted, #a1a1aa);
   font-size: 14px;
-  line-height: 1.55;
+  line-height: 1.5;
 }
 
 .wt__install {
-  display: grid;
-  grid-template-columns: 36px minmax(0, 1fr) auto;
-  gap: 4px 10px;
-  align-items: center;
-  margin-top: 18px;
-  padding: 12px;
-  background: color-mix(in srgb, var(--accent, #8b6cf7) 8%, var(--surface2, #1a1f28));
-  border: 1px solid color-mix(in srgb, var(--accent, #8b6cf7) 22%, var(--border, #252b36));
-  border-radius: 12px;
-}
-
-.wt__install-icon {
-  display: grid;
-  place-items: center;
-  width: 36px;
-  height: 36px;
-  color: var(--accent, #a78bfa);
-  background: color-mix(in srgb, var(--accent, #8b6cf7) 15%, transparent);
-  border-radius: 10px;
-}
-
-.wt__install-copy {
-  min-width: 0;
-}
-
-.wt__install-copy h3 {
-  margin: 0;
-  color: var(--text, #e4e4e7);
-  font-size: 14px;
-  font-weight: 680;
-  line-height: 1.25;
-}
-
-.wt__install-copy p {
-  margin: 3px 0 0;
-  color: var(--muted, #a1a1aa);
-  font-size: 12px;
-  line-height: 1.35;
+  margin: 5px 0 -6px;
 }
 
 .wt__install-btn {
-  min-height: 34px;
-  padding: 6px 10px;
-  color: var(--accent, #a78bfa);
-  background: color-mix(in srgb, var(--accent, #8b6cf7) 11%, transparent);
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 44px;
+  padding: 8px 4px;
+  color: var(--muted, #a1a1aa);
+  background: transparent;
   border: 0;
-  border-radius: 9px;
+  border-radius: 8px;
   font: inherit;
-  font-size: 12px;
-  font-weight: 700;
+  font-size: 13px;
+  font-weight: 620;
   cursor: pointer;
 }
 
 .wt__install-btn:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--accent, #8b6cf7) 18%, transparent);
+  color: var(--text, #e4e4e7);
 }
 
 .wt__install-btn:disabled {
@@ -182,15 +119,12 @@
 
 .wt__install-help,
 .wt__install-feedback {
-  grid-column: 2 / -1;
-  margin: 7px 0 0;
+  margin: 2px 0 6px;
   font-size: 12px;
   line-height: 1.45;
 }
 
 .wt__install-help {
-  display: grid;
-  gap: 2px;
   color: var(--muted, #a1a1aa);
 }
 
@@ -205,27 +139,25 @@
 
 .wt__paths {
   display: grid;
-  gap: 1px;
-  margin-top: 18px;
-  overflow: hidden;
-  background: var(--border, #252b36);
-  border: 1px solid var(--border, #252b36);
-  border-radius: 12px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  margin-top: 16px;
 }
 
 .wt__path {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 18px;
-  min-height: 58px;
+  justify-content: center;
+  min-height: 44px;
   padding: 10px 12px;
   color: var(--text, #e4e4e7);
-  background: var(--surface2, #1a1f28);
-  border: 0;
-  border-radius: 0;
+  background: color-mix(in srgb, var(--accent, #8b6cf7) 10%, var(--surface2, #1a1f28));
+  border: 1px solid color-mix(in srgb, var(--accent, #8b6cf7) 20%, var(--border, #252b36));
+  border-radius: 10px;
   font: inherit;
-  text-align: left;
+  font-size: 14px;
+  font-weight: 660;
+  text-align: center;
   cursor: pointer;
   transition: background 160ms ease, color 160ms ease;
 }
@@ -234,58 +166,13 @@
   background: color-mix(in srgb, var(--accent, #8b6cf7) 11%, var(--surface2, #1a1f28));
 }
 
-.wt__path span {
-  font-size: 14px;
-  font-weight: 680;
-}
-
-.wt__path small {
-  color: var(--muted, #a1a1aa);
-  font-size: 12px;
-  white-space: nowrap;
-}
-
-.wt__dismiss {
-  display: block;
-  margin: 14px auto -4px;
-  padding: 8px 12px;
-  color: var(--muted, #a1a1aa);
-  background: transparent;
-  border: 0;
-  border-radius: 8px;
-  font: inherit;
-  font-size: 13px;
-  font-weight: 620;
-  cursor: pointer;
-}
-
-.wt__dismiss:hover {
-  color: var(--text, #e4e4e7);
-}
-
 @media (max-width: 520px) {
   .wt__card {
     top: calc(54px + env(safe-area-inset-top, 0px));
     right: 12px;
     width: calc(100vw - 24px);
-    max-height: calc(100dvh - 78px - env(safe-area-inset-top, 0px));
-    overflow-y: auto;
-    padding: 20px;
-  }
-
-  .wt__path {
-    align-items: flex-start;
-    flex-direction: column;
-    gap: 2px;
-  }
-
-  .wt__path small {
-    white-space: normal;
-  }
-
-  .wt__install {
-    grid-template-columns: 34px minmax(0, 1fr) auto;
-    padding: 10px;
+    max-height: calc(100dvh - 70px - env(safe-area-inset-top, 0px));
+    padding: 18px;
   }
 }
 

--- a/frontend/src/components/Walkthrough/WalkthroughOverlay.jsx
+++ b/frontend/src/components/Walkthrough/WalkthroughOverlay.jsx
@@ -78,8 +78,8 @@ export default function WalkthroughOverlay({ onDone, onOpenSettings, onExploreAp
   const installButtonLabel = installBusy
     ? 'Opening…'
     : (nativeInstallReady
-        ? 'Install'
-        : (showInstallHelp ? 'Hide' : installCopy.ctaLabel))
+        ? 'Install Möbius'
+        : (showInstallHelp ? 'Hide install help' : 'How to install'))
 
   return (
     <aside
@@ -95,27 +95,27 @@ export default function WalkthroughOverlay({ onDone, onOpenSettings, onExploreAp
       >
         <span aria-hidden="true">×</span>
       </button>
-      <div className="wt__mark" aria-hidden="true">
-        <span />
-      </div>
-      <p className="wt__kicker">Your Möbius is ready</p>
-      <h2 id="wt-title" className="wt__title">Start wherever you like.</h2>
+      <h2 id="wt-title" className="wt__title">Your Möbius is ready.</h2>
       <p className="wt__body">
-        You can explore now. Add an agent only when you want chats to act and
-        build on your behalf.
+        Explore now. Connect an agent when you want Möbius to build with you.
       </p>
-      <section className="wt__install" aria-labelledby="wt-install-title">
-        <span className="wt__install-icon" aria-hidden="true">
-          <Download size={18} strokeWidth={2} />
-        </span>
-        <div className="wt__install-copy">
-          <h3 id="wt-install-title">Keep Möbius close</h3>
-          <p>
-            {nativeInstallReady
-              ? 'Install it on this device for a full-screen, one-tap launch.'
-              : installCopy.summary}
-          </p>
-        </div>
+      <div className="wt__paths">
+        <button
+          type="button"
+          className="wt__path"
+          onClick={() => takeAction(onOpenSettings)}
+        >
+          Connect agent
+        </button>
+        <button
+          type="button"
+          className="wt__path"
+          onClick={() => takeAction(onExploreApps)}
+        >
+          Explore apps
+        </button>
+      </div>
+      <div className="wt__install">
         <button
           type="button"
           className="wt__install-btn"
@@ -124,41 +124,20 @@ export default function WalkthroughOverlay({ onDone, onOpenSettings, onExploreAp
           aria-expanded={nativeInstallReady ? undefined : showInstallHelp}
           aria-controls={nativeInstallReady ? undefined : 'wt-install-help'}
         >
+          <Download size={15} strokeWidth={2} aria-hidden="true" />
           {installButtonLabel}
         </button>
         {showInstallHelp && (
-          <div className="wt__install-help" id="wt-install-help">
-            <strong>{installCopy.title}</strong>
-            <span>{installCopy.body}</span>
-          </div>
+          <p className="wt__install-help" id="wt-install-help">
+            <strong>{installCopy.title}.</strong> {installCopy.body}
+          </p>
         )}
         {installFeedback && (
           <p className="wt__install-feedback" role="status">
             {installFeedback}
           </p>
         )}
-      </section>
-      <div className="wt__paths">
-        <button
-          type="button"
-          className="wt__path"
-          onClick={() => takeAction(onOpenSettings)}
-        >
-          <span>Connect an agent</span>
-          <small>Open Settings</small>
-        </button>
-        <button
-          type="button"
-          className="wt__path"
-          onClick={() => takeAction(onExploreApps)}
-        >
-          <span>Find useful apps</span>
-          <small>Open the App Store</small>
-        </button>
       </div>
-      <button type="button" className="wt__dismiss" onClick={finish}>
-        I’ll explore
-      </button>
     </aside>
   )
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -243,7 +243,11 @@ html, body, #root {
 .app-route-loading {
   position: fixed;
   inset: 0;
+  display: grid;
+  place-items: center;
   background: var(--bg, #0d0d0d);
+  color: var(--muted, #a1a1aa);
+  font-size: 13px;
 }
 
 /* Paint the ROOT element with the theme background so it propagates to the
@@ -257,15 +261,6 @@ html, body, #root {
    landed. Uses var(--bg) (already set pre-paint) so there's no theme flash. */
 html {
   background-color: var(--bg, #0d0d0d);
-}
-
-/* The shell is fixed chrome: pan normally, but never let page-level pinch zoom
-   scale the toolbar, drawer, chat, and active app as one document. The viewport
-   meta is the primary lock; this closes the iOS gap where user-scalable=no may
-   be ignored. Local zoom surfaces still own their gesture with touch-action:none
-   and transform only their content. */
-html, body {
-  touch-action: pan-x pan-y;
 }
 
 /* Accessibility: respect prefers-reduced-motion. Collapses all
@@ -466,8 +461,8 @@ textarea:focus-visible {
 }
 
 .chat__empty-title {
-  font-size: 30px;
-  font-weight: 700;
+  font-size: clamp(22px, 4vw, 26px);
+  font-weight: 650;
   letter-spacing: 0;
   line-height: 1.05;
   color: var(--text);

--- a/frontend/src/lib/__tests__/appsDirectoryContract.test.js
+++ b/frontend/src/lib/__tests__/appsDirectoryContract.test.js
@@ -45,6 +45,15 @@ test('phone and web share one searchable launcher tab', () => {
   assert.match(shell, /const navigationSurfaceOpen = modalDrawerOpen/)
 })
 
+test('the app directory distinguishes loading, errors, and confirmed emptiness', () => {
+  assert.match(drawer, /status=\{appsStatus\}/)
+  assert.match(directory, /status === 'loading'/)
+  assert.match(directory, /status === 'error'/)
+  assert.match(directory, /Apps unavailable/)
+  assert.match(directory, /onClick=\{onRetry\}/)
+  assert.match(directory, /No installed apps yet/)
+})
+
 test('expanded and collapsed navigation share one ChatGPT SDK icon vocabulary', () => {
   for (const icon of ['ComposeEditSquare', 'Grid', 'SettingsSlider']) {
     assert.match(navigationIcons, new RegExp(icon))

--- a/frontend/src/lib/__tests__/shellViewportZoom.test.js
+++ b/frontend/src/lib/__tests__/shellViewportZoom.test.js
@@ -1,4 +1,4 @@
-/* Browser zoom never scales the Möbius shell chrome; each app owns local zoom. */
+/* Browser zoom remains available for the shell; apps may also own local zoom. */
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
@@ -15,18 +15,16 @@ function viewportContent(html) {
   return html.match(/<meta name="viewport" content="([^"]+)"/)?.[1] || ''
 }
 
-test('browser pinch cannot scale the shell chrome and active app together', () => {
+test('browser zoom remains available throughout the shell', () => {
   const viewport = viewportContent(indexHtml)
   assert.match(viewport, /width=device-width/)
   assert.match(viewport, /initial-scale=1(?:\.0)?/)
-  assert.match(viewport, /maximum-scale=1/)
-  assert.match(viewport, /user-scalable=no/)
+  assert.doesNotMatch(viewport, /maximum-scale=1/)
+  assert.doesNotMatch(viewport, /user-scalable=no/)
   assert.match(viewport, /viewport-fit=cover/)
   assert.match(viewport, /interactive-widget=resizes-content/)
 
-  const rootTouchRule = indexCss.match(/html,\s*body\s*\{[\s\S]*?\}/)?.[0] || ''
-  assert.match(rootTouchRule, /touch-action:\s*pan-x pan-y/)
-  assert.doesNotMatch(rootTouchRule, /pinch-zoom|manipulation/)
+  assert.doesNotMatch(indexCss, /touch-action:\s*pan-x pan-y/)
 })
 
 test('the app frame adds no second viewport lock and leaves local zoom to the app', () => {


### PR DESCRIPTION
## Summary
- simplify first-run guidance and empty chat/app surfaces
- distinguish list loading, errors, and confirmed empty states
- restore browser zoom, add history-safe skip navigation, and improve loading/touch accessibility

## Verification
- npm test (2,173 tests)
- npm run build
- independent simplicity and adversarial reviews
- design detector (only pre-existing Inter/logo-motion warnings)

Local isolated Playwright was blocked by the repo disk guard (15 GiB available; 20 GiB required), so hosted browser checks remain the merge gate.