### PR TITLE
Prune stale Node compile caches

### DIFF
--- a/backend/app/frontend_watcher.py
+++ b/backend/app/frontend_watcher.py
@@ -74,6 +74,13 @@ _TMP_DIR = _FRONTEND_DIR / ".vite-tmp"
 # vite's transform cache is not designed for concurrent writers.
 _REBUILD_CACHE_DIR = _FRONTEND_DIR / ".vite-cache-rebuild"
 _REBUILD_TMP_DIR = _FRONTEND_DIR / ".vite-tmp-rebuild"
+_NODE_COMPILE_CACHE_PROBE = (
+  "const m = require('node:module');"
+  "m.enableCompileCache();"
+  "const dir = m.getCompileCacheDir();"
+  "if (!dir) process.exit(1);"
+  "process.stdout.write(dir);"
+)
 # In-process serialization only — rebuild_shell.sh publishes from its own
 # process, so _publish_built_dir additionally takes an OS-level flock (derived
 # from _FRONTEND_DIR at call time so tests that repoint the dir stay isolated).
@@ -464,6 +471,72 @@ def _ensure_node_modules() -> None:
     log.warning("could not link frontend node_modules to %s", source)
 
 
+def _current_node_compile_cache_dir(
+  env: dict[str, str],
+) -> Path | None:
+  """Ask the active Node runtime for its exact compile-cache directory."""
+  try:
+    result = subprocess.run(
+      ["node", "-e", _NODE_COMPILE_CACHE_PROBE],
+      env=env,
+      capture_output=True,
+      text=True,
+      timeout=5,
+      check=False,
+    )
+  except (OSError, subprocess.SubprocessError) as exc:
+    log.warning("could not identify current Node compile cache: %s", exc)
+    return None
+  if result.returncode != 0 or not result.stdout.strip():
+    log.warning(
+      "could not identify current Node compile cache (exit %s): %s",
+      result.returncode,
+      result.stderr.strip(),
+    )
+    return None
+  return Path(result.stdout.strip())
+
+
+def _prune_node_compile_cache(tmp_dir: Path, env: dict[str, str]) -> None:
+  """Best-effort removal of cache generations from older Node runtimes."""
+  cache_root = tmp_dir / "node-compile-cache"
+  if not cache_root.is_dir():
+    # A first build has nothing to prune; Node will create its current
+    # generation as part of the actual Vite process.
+    return
+  current_dir = _current_node_compile_cache_dir(env)
+  if current_dir is None:
+    return
+  try:
+    relative = current_dir.relative_to(cache_root)
+  except ValueError:
+    # An operator-provided NODE_COMPILE_CACHE can deliberately move this
+    # outside the watcher temp root; leave both locations untouched.
+    return
+  if len(relative.parts) != 1:
+    log.warning("unexpected Node compile cache path: %s", current_dir)
+    return
+
+  try:
+    entries = tuple(cache_root.iterdir())
+  except OSError as exc:
+    log.warning("could not inspect Node compile cache at %s: %s", cache_root, exc)
+    return
+  for entry in entries:
+    if entry.name == relative.name:
+      continue
+    try:
+      if entry.is_symlink() or not entry.is_dir():
+        entry.unlink(missing_ok=True)
+      else:
+        shutil.rmtree(entry)
+    except FileNotFoundError:
+      # Another watcher setup may have pruned the same stale generation.
+      continue
+    except OSError as exc:
+      log.warning("could not prune stale Node compile cache %s: %s", entry, exc)
+
+
 def _vite_env(
   cache_dir: Path | None = None, tmp_dir: Path | None = None,
 ) -> dict[str, str]:
@@ -481,6 +554,7 @@ def _vite_env(
   node_options = env.get("NODE_OPTIONS", "")
   if "--max-old-space-size" not in node_options and "--max_old_space_size" not in node_options:
     env["NODE_OPTIONS"] = f"{node_options} --max-old-space-size=384".strip()
+  _prune_node_compile_cache(tmp_dir, env)
   return env
 
 

--- a/backend/tests/test_frontend_watcher_compile_cache.py
+++ b/backend/tests/test_frontend_watcher_compile_cache.py
@@ -1,0 +1,108 @@
+"""Node compile-cache retention at the Vite environment boundary."""
+
+from pathlib import Path
+
+import app.frontend_watcher as fw
+
+
+def _cache_entry(root: Path, name: str, marker: str) -> Path:
+  entry = root / "node-compile-cache" / name
+  entry.mkdir(parents=True)
+  (entry / "marker").write_text(marker, encoding="utf-8")
+  return entry
+
+
+def test_vite_env_preserves_current_compile_cache_and_prunes_stale(
+  tmp_path,
+  monkeypatch,
+):
+  cache_dir = tmp_path / ".vite-cache"
+  tmp_dir = tmp_path / ".vite-tmp"
+  current = _cache_entry(tmp_dir, "v24.18.0-x64-current-1000", "current")
+  stale = _cache_entry(tmp_dir, "v22.23.1-x64-stale-1000", "stale")
+
+  monkeypatch.setattr(
+    fw,
+    "_current_node_compile_cache_dir",
+    lambda env: Path(env["TMPDIR"]) / "node-compile-cache" / current.name,
+  )
+
+  env = fw._vite_env(cache_dir, tmp_dir)
+
+  assert env["TMPDIR"] == str(tmp_dir)
+  assert (current / "marker").read_text(encoding="utf-8") == "current"
+  assert not stale.exists()
+
+
+def test_compile_cache_pruning_is_scoped_to_each_watcher_temp_root(
+  tmp_path,
+  monkeypatch,
+):
+  warm = tmp_path / ".vite-tmp"
+  rebuild = tmp_path / ".vite-tmp-rebuild"
+  warm_current = _cache_entry(warm, "v24-current", "warm current")
+  warm_stale = _cache_entry(warm, "v22-stale", "warm stale")
+  rebuild_stale = _cache_entry(rebuild, "v22-stale", "rebuild stale")
+
+  monkeypatch.setattr(
+    fw,
+    "_current_node_compile_cache_dir",
+    lambda env: Path(env["TMPDIR"]) / "node-compile-cache" / "v24-current",
+  )
+
+  fw._vite_env(tmp_path / ".vite-cache", warm)
+
+  assert warm_current.exists()
+  assert not warm_stale.exists()
+  assert rebuild_stale.exists()
+
+
+def test_compile_cache_pruning_handles_malformed_and_vanished_entries(
+  tmp_path,
+  monkeypatch,
+):
+  tmp_dir = tmp_path / ".vite-tmp"
+  root = tmp_dir / "node-compile-cache"
+  current = _cache_entry(tmp_dir, "v24-current", "current")
+  malformed = root / "not-a-directory"
+  malformed.write_text("junk", encoding="utf-8")
+  vanished = _cache_entry(tmp_dir, "v22-vanished", "stale")
+  real_rmtree = fw.shutil.rmtree
+
+  def concurrent_rmtree(path):
+    if path == vanished:
+      real_rmtree(path)
+      raise FileNotFoundError(path)
+    real_rmtree(path)
+
+  monkeypatch.setattr(
+    fw,
+    "_current_node_compile_cache_dir",
+    lambda _env: current,
+  )
+  monkeypatch.setattr(fw.shutil, "rmtree", concurrent_rmtree)
+
+  fw._vite_env(tmp_path / ".vite-cache", tmp_dir)
+
+  assert current.exists()
+  assert not malformed.exists()
+  assert not vanished.exists()
+
+
+def test_compile_cache_pruning_skips_operator_override_outside_temp_root(
+  tmp_path,
+  monkeypatch,
+):
+  tmp_dir = tmp_path / ".vite-tmp"
+  stale = _cache_entry(tmp_dir, "v22-stale", "stale")
+  external = tmp_path / "operator-cache" / "v24-current"
+
+  monkeypatch.setattr(
+    fw,
+    "_current_node_compile_cache_dir",
+    lambda _env: external,
+  )
+
+  fw._vite_env(tmp_path / ".vite-cache", tmp_dir)
+
+  assert stale.exists()


### PR DESCRIPTION
## Summary
- identify the active Node runtime's exact compile-cache generation
- remove only stale sibling generations inside watcher-owned temporary roots
- preserve warm and rebuild caches independently
- leave external operator overrides untouched

## Verification
- 26 focused watcher and publisher tests
- Python compilation checks
- diff checks