### PR TITLE
Reduce passive backend memory overhead

### DIFF
--- a/backend/app/activity.py
+++ b/backend/app/activity.py
@@ -78,17 +78,18 @@ ROTATION_DAYS = 7
 RETENTION_DAYS = 90
 
 # Cache for storage_write debounce. Key: (app_id, path). Value: the
-# ISO8601 timestamp string of the most recent emit. Module-level so it
+# timestamp of the most recent emit. Module-level so it
 # survives across requests within the same worker process. Reset by
 # tests via `_reset_for_tests()` so suite ordering doesn't matter.
 _DEBOUNCE_WINDOW_SEC = 60
-_debounce: dict[tuple[int, str], str] = {}
+_debounce: dict[tuple[int, str], datetime] = {}
 
 # Same debounce shape for app_error: a render loop or a retrying fetch can
 # throw the identical error many times a second; collapse to one per window
 # per (app_id, message) so one broken app can't flood the 90-day log file.
 _ERROR_DEBOUNCE_WINDOW_SEC = 60
-_error_debounce: dict[tuple[int | None, str], str] = {}
+_error_debounce: dict[tuple[int | None, str], datetime] = {}
+_debounce_lock = threading.Lock()
 
 # Repeated HTTP failures need their frequency preserved, but emitting one
 # activity row per response would turn the observer into the resource problem.
@@ -282,6 +283,32 @@ def log_event(ev: str, **fields: Any) -> bool:
   return log_events([(ev, fields)])
 
 
+def _should_emit_debounced(
+  cache: dict[tuple, datetime],
+  key: tuple,
+  now: datetime,
+  *,
+  window_seconds: int,
+) -> bool:
+  """Apply one debounce decision and forget keys outside its window."""
+  with _debounce_lock:
+    cutoff = now - timedelta(seconds=window_seconds)
+    while cache:
+      candidate, emitted_at = next(iter(cache.items()))
+      if emitted_at > cutoff:
+        break
+      cache.pop(candidate)
+
+    last = cache.get(key)
+    if last is not None:
+      if (now - last).total_seconds() < window_seconds:
+        return False
+      cache.pop(key, None)
+
+    cache[key] = now
+  return True
+
+
 def should_emit_storage_write(app_id: int, path: str, now: datetime | None = None) -> bool:
   """Debounce gate for storage_write events. Returns True at most
   once per `_DEBOUNCE_WINDOW_SEC` seconds per (app_id, path).
@@ -296,17 +323,12 @@ def should_emit_storage_write(app_id: int, path: str, now: datetime | None = Non
   per (app_id, path), no correctness issue.
   """
   now = now or datetime.now(timezone.utc)
-  key = (app_id, path)
-  last_iso = _debounce.get(key)
-  if last_iso is not None:
-    try:
-      last = datetime.fromisoformat(last_iso)
-    except ValueError:
-      last = None
-    if last is not None and (now - last).total_seconds() < _DEBOUNCE_WINDOW_SEC:
-      return False
-  _debounce[key] = now.isoformat(timespec="seconds")
-  return True
+  return _should_emit_debounced(
+    _debounce,
+    (app_id, path),
+    now,
+    window_seconds=_DEBOUNCE_WINDOW_SEC,
+  )
 
 
 def should_emit_app_error(
@@ -317,17 +339,12 @@ def should_emit_app_error(
   loop throwing the same error 60x/sec would otherwise flood the log.
   Mirrors should_emit_storage_write (in-memory, reset-on-restart)."""
   now = now or datetime.now(timezone.utc)
-  key = (app_id, message)
-  last_iso = _error_debounce.get(key)
-  if last_iso is not None:
-    try:
-      last = datetime.fromisoformat(last_iso)
-    except ValueError:
-      last = None
-    if last is not None and (now - last).total_seconds() < _ERROR_DEBOUNCE_WINDOW_SEC:
-      return False
-  _error_debounce[key] = now.isoformat(timespec="seconds")
-  return True
+  return _should_emit_debounced(
+    _error_debounce,
+    (app_id, message),
+    now,
+    window_seconds=_ERROR_DEBOUNCE_WINDOW_SEC,
+  )
 
 
 def _request_error_event(
@@ -410,8 +427,9 @@ def _reset_for_tests() -> None:
   """Clears the debounce cache. Called from conftest's fresh_db
   fixture so a debounce entry from a prior test can't suppress a
   later test's emit. Underscore-prefixed: not a public API."""
-  _debounce.clear()
-  _error_debounce.clear()
+  with _debounce_lock:
+    _debounce.clear()
+    _error_debounce.clear()
   with _request_error_lock:
     _request_error_buckets.clear()
 

--- a/backend/app/push.py
+++ b/backend/app/push.py
@@ -9,7 +9,6 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from py_vapid import Vapid
-from pywebpush import webpush, WebPushException
 from sqlalchemy.orm import Session
 
 from app import models, presence
@@ -107,6 +106,10 @@ def send_push(subscription_info: dict, payload: dict) -> bool:
   """Send a Web Push notification. Returns True on success, False on gone."""
   if _vapid is None:
     raise RuntimeError("VAPID not initialized — call init_vapid() first")
+  # Startup and suppressed notifications do not need the delivery stack.
+  # Import it only once a push is actually ready to be sent.
+  from pywebpush import WebPushException, webpush
+
   try:
     # Pass the Vapid instance directly — pywebpush accepts it and
     # avoids the PEM-vs-raw-key parsing ambiguity in from_string().

--- a/backend/app/resource_access.py
+++ b/backend/app/resource_access.py
@@ -50,7 +50,7 @@ def get_active_chat_for_principal(
   """
   required_fields = (
     (models.Chat.id, models.Chat.created_by_app_id, *load_fields)
-    if load_fields
+    if load_fields is not None
     else None
   )
   chat = get_active_chat_or_404(db, chat_id, load_fields=required_fields)
@@ -67,6 +67,22 @@ def get_active_chat_for_principal(
       detail="This chat is not owned by your app.",
     )
   return chat
+
+
+def require_active_chat_access(
+  db: Session,
+  chat_id: str,
+  principal: Principal,
+) -> None:
+  """Require access to an active chat without hydrating its transcript.
+
+  Use this for existence/ownership gates whose route never reads the returned
+  chat. The empty ``load_fields`` tuple deliberately selects only the identity
+  fields added by ``get_active_chat_for_principal``; ``raiseload`` keeps a
+  future accidental transcript access visible instead of silently decoding
+  the chat's JSON blobs.
+  """
+  get_active_chat_for_principal(db, chat_id, principal, load_fields=())
 
 
 def get_active_chat_or_404(

--- a/backend/app/routes/chat.py
+++ b/backend/app/routes/chat.py
@@ -10,7 +10,7 @@ from app.deps import (
   Principal, get_owner_or_chat_embed_principal, reject_cross_site,
   require_chat_embed_operation,
 )
-from app.resource_access import get_active_chat_for_principal
+from app.resource_access import require_active_chat_access
 
 router = APIRouter(prefix="/api/chat", tags=["chat"])
 
@@ -34,6 +34,6 @@ async def chat_stop(
   if principal.scope == "chat_embed" and not body.chat_id:
     raise HTTPException(status_code=403, detail="Embedded chat id is required.")
   if body.chat_id:
-    get_active_chat_for_principal(db, body.chat_id, principal)
+    require_active_chat_access(db, body.chat_id, principal)
   stopped, cleared_pending_cids = await stop_chat(body.chat_id or None, db=db)
   return {"stopped": stopped, "cleared_pending_cids": cleared_pending_cids}

--- a/backend/app/routes/chat_embed.py
+++ b/backend/app/routes/chat_embed.py
@@ -22,7 +22,7 @@ from app.deps import (
   Principal, chat_embed_grant_is_latest_consumed, get_principal,
   reject_cross_site,
 )
-from app.resource_access import get_active_chat_for_principal
+from app.resource_access import require_active_chat_access
 from app.timeutil import now_naive_utc
 from app.theme import theme_data
 
@@ -83,7 +83,7 @@ def mint_embed_capability(
       status_code=403,
       detail="Only an app token may mint an embedded-chat capability.",
     )
-  get_active_chat_for_principal(db, chat_id, principal)
+  require_active_chat_access(db, chat_id, principal)
   app = db.query(models.App).filter(
     models.App.id == principal.app_id,
     models.App.deleted_at.is_(None),
@@ -267,7 +267,7 @@ def revoke_embed_sessions(
   """Revoke active/pending sessions for an app-owned frame instance."""
   if principal.scope != "app" or principal.app_id is None:
     raise HTTPException(status_code=403, detail="Only an app token may revoke embeds.")
-  get_active_chat_for_principal(db, chat_id, principal)
+  require_active_chat_access(db, chat_id, principal)
   now = now_naive_utc()
   count = db.query(models.ChatEmbedGrant).filter(
     models.ChatEmbedGrant.app_id == principal.app_id,

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -33,7 +33,11 @@ from app.deps import (
   reject_cross_site,
   require_chat_embed_operation,
 )
-from app.resource_access import get_active_chat_for_principal, get_active_chat_or_404
+from app.resource_access import (
+  get_active_chat_for_principal,
+  get_active_chat_or_404,
+  require_active_chat_access,
+)
 from app.schemas import ChatPatch, ChatProviderSwitch
 from app.timeutil import now_naive_utc, SOFT_DELETE_TTL
 
@@ -231,7 +235,7 @@ def issue_media_token(
   if principal.scope == "app":
     raise HTTPException(status_code=403, detail="App token is not valid here.")
   require_chat_embed_operation(principal, "chat:media")
-  get_active_chat_for_principal(db, chat_id, principal)
+  require_active_chat_access(db, chat_id, principal)
   if principal.scope == "chat_embed":
     if (
       principal.app_id is None
@@ -1285,14 +1289,14 @@ def get_tool_output_by_id(
   if principal.scope == "app":
     raise HTTPException(status_code=403, detail="App token is not valid here.")
   require_chat_embed_operation(principal, "chat:read")
-  get_active_chat_for_principal(db, chat_id, principal)
+  require_active_chat_access(db, chat_id, principal)
 
   # This sync route runs in FastAPI's worker pool, so waiting on the concurrent
   # Future does not block the event loop.
   _drain_writer_before_sidecar_read(db, chat_id, "tool output")
   # The barrier refreshes the request transaction. Recheck the chat so a
   # concurrent soft-delete cannot expose a sidecar after its parent vanished.
-  get_active_chat_for_principal(db, chat_id, principal)
+  require_active_chat_access(db, chat_id, principal)
   query = db.query(models.ToolOutput).filter(
     models.ToolOutput.chat_id == chat_id,
     models.ToolOutput.tool_use_id == tool_use_id,
@@ -1340,9 +1344,9 @@ def get_thinking_trace_by_id(
   if principal.scope == "app":
     raise HTTPException(status_code=403, detail="App token is not valid here.")
   require_chat_embed_operation(principal, "chat:read")
-  get_active_chat_for_principal(db, chat_id, principal)
+  require_active_chat_access(db, chat_id, principal)
   _drain_writer_before_sidecar_read(db, chat_id, "thinking trace")
-  get_active_chat_for_principal(db, chat_id, principal)
+  require_active_chat_access(db, chat_id, principal)
   query = db.query(models.ThinkingTrace).filter(
     models.ThinkingTrace.chat_id == chat_id,
     models.ThinkingTrace.thinking_id == thinking_id,
@@ -1493,7 +1497,11 @@ def get_chat_usage(
   This owner-only diagnostic is deliberately independent of the transcript:
   benchmark tooling can read it without parsing user-visible messages.
   """
-  get_active_chat_or_404(db, chat_id)
+  get_active_chat_or_404(
+    db,
+    chat_id,
+    load_fields=(models.Chat.id,),
+  )
   runs = (
     db.query(models.ChatRun)
     .filter(models.ChatRun.chat_id == chat_id)

--- a/backend/app/routes/chats_stream.py
+++ b/backend/app/routes/chats_stream.py
@@ -49,6 +49,7 @@ from app.deps import (
 )
 from app.resource_access import (
   get_active_chat_for_principal, get_active_chat_or_404,
+  require_active_chat_access,
 )
 
 router = APIRouter(prefix="/api/chats", tags=["chats"])
@@ -1177,7 +1178,7 @@ async def cancel_pending_message(
   if principal.scope == "app":
     raise HTTPException(status_code=403, detail="App token is not valid here.")
   require_chat_embed_operation(principal, "chat:send")
-  get_active_chat_for_principal(db, chat_id, principal)
+  require_active_chat_access(db, chat_id, principal)
 
   # The actor's CancelPending removes the matching cid and commits — the
   # SOLE runtime mutator of pending_messages, so a DELETE racing a
@@ -1213,7 +1214,7 @@ async def stream_chat(
   # Gate before touching the broadcast. Raises 404 (missing/deleted) or
   # 403 (app token, foreign chat) — matching send_message's surface.
   require_chat_embed_operation(principal, "chat:stream")
-  get_active_chat_for_principal(db, chat_id, principal)
+  require_active_chat_access(db, chat_id, principal)
   embed_session_id = (
     principal.embed_session_id if principal.scope == "chat_embed" else None
   )

--- a/backend/app/routes/client_signal.py
+++ b/backend/app/routes/client_signal.py
@@ -11,7 +11,7 @@ import math
 import json
 import threading
 import time
-from collections import deque
+from collections import OrderedDict, deque
 from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -36,6 +36,28 @@ _ingest_lock = threading.Lock()
 _AppInstanceKey = tuple[int, str | None]
 _recent_by_app: dict[_AppInstanceKey, deque[tuple[object, float, int, int]]] = {}
 _seen_ids_by_app: dict[_AppInstanceKey, dict[str, float]] = {}
+_rate_owner_activity: OrderedDict[_AppInstanceKey, float] = OrderedDict()
+
+
+def _drop_rate_owner(app_key: _AppInstanceKey) -> None:
+  _recent_by_app.pop(app_key, None)
+  _seen_ids_by_app.pop(app_key, None)
+  _rate_owner_activity.pop(app_key, None)
+
+
+def _mark_rate_owner_active(app_key: _AppInstanceKey, accepted_at: float) -> None:
+  _rate_owner_activity.pop(app_key, None)
+  _rate_owner_activity[app_key] = accepted_at
+
+
+def _reclaim_rate_owners(now: float) -> None:
+  """Forget app-instance state after its rolling rate window closes."""
+  cutoff = now - _RATE_WINDOW_SECONDS
+  while _rate_owner_activity:
+    app_key, last_seen = next(iter(_rate_owner_activity.items()))
+    if last_seen >= cutoff:
+      break
+    _drop_rate_owner(app_key)
 
 
 def _reserve_rate(
@@ -44,6 +66,7 @@ def _reserve_rate(
   now = time.monotonic()
   cutoff = now - _RATE_WINDOW_SECONDS
   with _rate_lock:
+    _reclaim_rate_owners(now)
     recent = _recent_by_app.setdefault(app_key, deque())
     while recent and recent[0][1] < cutoff:
       recent.popleft()
@@ -86,6 +109,7 @@ def _reserve_rate(
     recent.append((token, now, len(novel), batch_bytes))
     for signal_id, _ in novel:
       seen[signal_id] = now
+    _mark_rate_owner_active(app_key, now)
     return token, {signal_id for signal_id, _ in novel}
 
 
@@ -99,12 +123,15 @@ def _rollback_rate(
     seen = _seen_ids_by_app.get(app_key, {})
     for signal_id in signal_ids:
       seen.pop(signal_id, None)
+    if not _recent_by_app.get(app_key) and not _seen_ids_by_app.get(app_key):
+      _drop_rate_owner(app_key)
 
 
 def _reset_for_tests() -> None:
   with _rate_lock:
     _recent_by_app.clear()
     _seen_ids_by_app.clear()
+    _rate_owner_activity.clear()
 
 
 class ClientSignal(BaseModel):

--- a/backend/tests/test_activity.py
+++ b/backend/tests/test_activity.py
@@ -134,6 +134,36 @@ def test_storage_write_debounce_per_key():
   assert activity.should_emit_storage_write(1, "a.json", now=now) is False
 
 
+def test_storage_write_debounce_reclaims_expired_keys_under_churn():
+  """Expired paths leave the cache instead of accumulating for process life."""
+  start = datetime(2026, 7, 1, tzinfo=timezone.utc)
+  for i in range(3):
+    assert activity.should_emit_storage_write(1, f"{i}.json", now=start)
+  assert activity.should_emit_storage_write(
+    1, "hot.json", now=start + timedelta(seconds=30),
+  )
+
+  later = start + timedelta(seconds=61)
+  assert not activity.should_emit_storage_write(1, "hot.json", now=later)
+  assert list(activity._debounce) == [(1, "hot.json")]
+
+
+def test_debounce_caches_preserve_every_key_inside_window():
+  """Active keys remain debounced without an arbitrary working-set limit."""
+  now = datetime(2026, 7, 1, tzinfo=timezone.utc)
+
+  for path in ("a", "b", "c"):
+    assert activity.should_emit_storage_write(1, path, now=now)
+  for message in ("a", "b", "c"):
+    assert activity.should_emit_app_error(1, message, now=now)
+
+  assert len(activity._debounce) == 3
+  assert len(activity._error_debounce) == 3
+  for key in ("a", "b", "c"):
+    assert activity.should_emit_storage_write(1, key, now=now) is False
+    assert activity.should_emit_app_error(1, key, now=now) is False
+
+
 def test_request_error_storm_appends_only_one_summary_per_window():
   start = datetime(2026, 7, 21, 12, 0, tzinfo=timezone.utc)
   for offset_ms in range(1000):

--- a/backend/tests/test_client_signal.py
+++ b/backend/tests/test_client_signal.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from app.config import get_settings
 from app import activity, auth
+from app.routes import client_signal
 from test_app_fixtures import create_local_app
 
 
@@ -263,3 +264,40 @@ def test_signal_serialized_bytes_and_future_timestamp_are_bounded(
     "name": "app_ready",
   }]), headers=headers)
   assert future.status_code == 422
+
+
+def test_signal_rate_owners_expire_without_evicting_active_apps(monkeypatch):
+  """Only app instances outside the existing rate window are reclaimed."""
+  clock = [100.0]
+  monkeypatch.setattr(client_signal.time, "monotonic", lambda: clock[0])
+
+  for i in range(4):
+    clock[0] += 1
+    reservation = client_signal._reserve_rate(
+      (i, f"instance-{i}"), [(f"signal-{i}", 10)],
+    )
+    assert not isinstance(reservation, float)
+
+  assert len(client_signal._recent_by_app) == 4
+  assert len(client_signal._seen_ids_by_app) == 4
+  assert (0, "instance-0") in client_signal._recent_by_app
+  # A retained ID remains a deduplicated no-op.
+  _token, novel = client_signal._reserve_rate(
+    (3, "instance-3"), [("signal-3", 10)],
+  )
+  assert novel == set()
+
+  clock[0] += client_signal._RATE_WINDOW_SECONDS + 1
+  client_signal._reserve_rate((9, "fresh"), [("fresh", 10)])
+  assert set(client_signal._recent_by_app) == {(9, "fresh")}
+  assert set(client_signal._seen_ids_by_app) == {(9, "fresh")}
+
+
+def test_failed_signal_reservation_releases_empty_owner(monkeypatch):
+  """Rollback drops the app-instance owner when it retained no other budget."""
+  monkeypatch.setattr(client_signal.time, "monotonic", lambda: 100.0)
+  app_key = (1, "rolled-back")
+  token, novel = client_signal._reserve_rate(app_key, [("retry", 10)])
+  client_signal._rollback_rate(app_key, token, novel)
+  assert app_key not in client_signal._recent_by_app
+  assert app_key not in client_signal._seen_ids_by_app

--- a/backend/tests/test_push_lazy_import.py
+++ b/backend/tests/test_push_lazy_import.py
@@ -1,0 +1,127 @@
+"""The Web Push delivery stack stays outside ordinary backend startup."""
+
+import json
+import os
+import subprocess
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from app import push
+
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.parametrize("module_name", ["app.push", "app.main"])
+def test_backend_import_does_not_load_pywebpush(module_name: str):
+  code = (
+    "import sys\n"
+    "assert 'pywebpush' not in sys.modules\n"
+    f"__import__({module_name!r})\n"
+    "assert 'pywebpush' not in sys.modules\n"
+  )
+  env = os.environ.copy()
+  existing_pythonpath = env.get("PYTHONPATH")
+  env["PYTHONPATH"] = (
+    str(BACKEND_ROOT)
+    if not existing_pythonpath
+    else f"{BACKEND_ROOT}{os.pathsep}{existing_pythonpath}"
+  )
+
+  result = subprocess.run(
+    [sys.executable, "-c", code],
+    cwd=BACKEND_ROOT,
+    env=env,
+    capture_output=True,
+    text=True,
+    timeout=20,
+    check=False,
+  )
+
+  assert result.returncode == 0, result.stderr
+
+
+class FakeWebPushException(Exception):
+  def __init__(self, message: str, *, response=None):
+    super().__init__(message)
+    self.response = response
+
+
+def install_fake_pywebpush(monkeypatch, webpush):
+  fake_module = types.ModuleType("pywebpush")
+  fake_module.webpush = webpush
+  fake_module.WebPushException = FakeWebPushException
+  monkeypatch.setitem(sys.modules, "pywebpush", fake_module)
+
+
+def test_send_push_loads_delivery_dependency_and_preserves_arguments(monkeypatch):
+  calls = []
+  fake_vapid = object()
+  claims = {"sub": "mailto:test@example.com"}
+  subscription = {"endpoint": "https://push.example/subscription"}
+  payload = {"title": "Ready", "body": "The job finished."}
+
+  def fake_webpush(**kwargs):
+    calls.append(kwargs)
+
+  install_fake_pywebpush(monkeypatch, fake_webpush)
+  monkeypatch.setattr(push, "_vapid", fake_vapid)
+  monkeypatch.setattr(push, "get_vapid_claims", lambda: claims)
+
+  assert push.send_push(subscription, payload) is True
+  assert calls == [
+    {
+      "subscription_info": subscription,
+      "data": json.dumps(payload),
+      "vapid_private_key": fake_vapid,
+      "vapid_claims": claims,
+      "content_encoding": "aes128gcm",
+    }
+  ]
+
+
+def test_send_push_returns_false_when_subscription_is_gone(monkeypatch):
+  error = FakeWebPushException(
+    "subscription is gone",
+    response=SimpleNamespace(status_code=410),
+  )
+
+  def fake_webpush(**_kwargs):
+    raise error
+
+  install_fake_pywebpush(monkeypatch, fake_webpush)
+  monkeypatch.setattr(push, "_vapid", object())
+
+  assert push.send_push({}, {}) is False
+
+
+def test_send_push_reraises_other_delivery_failures(monkeypatch):
+  error = FakeWebPushException(
+    "delivery failed",
+    response=SimpleNamespace(status_code=503),
+  )
+
+  def fake_webpush(**_kwargs):
+    raise error
+
+  install_fake_pywebpush(monkeypatch, fake_webpush)
+  monkeypatch.setattr(push, "_vapid", object())
+
+  with pytest.raises(FakeWebPushException) as raised:
+    push.send_push({}, {})
+
+  assert raised.value is error
+
+
+def test_uninitialized_vapid_fails_before_loading_delivery_dependency(monkeypatch):
+  monkeypatch.setattr(push, "_vapid", None)
+  monkeypatch.delitem(sys.modules, "pywebpush", raising=False)
+
+  with pytest.raises(RuntimeError, match="VAPID not initialized"):
+    push.send_push({}, {})
+
+  assert "pywebpush" not in sys.modules

--- a/backend/tests/test_resource_access.py
+++ b/backend/tests/test_resource_access.py
@@ -10,9 +10,14 @@ from datetime import UTC, datetime
 
 import pytest
 from fastapi import HTTPException
+from sqlalchemy import event
 
 from app import models
-from app.resource_access import get_active_chat_or_404
+from app.deps import Principal
+from app.resource_access import (
+  get_active_chat_or_404,
+  require_active_chat_access,
+)
 
 
 def test_returns_active_chat(db):
@@ -56,3 +61,73 @@ def test_returns_same_row_callers_can_mutate(db):
   db.commit()
   refetched = get_active_chat_or_404(db, "mut")
   assert refetched.title == "renamed"
+
+
+def test_access_only_gate_does_not_select_transcript_json(db):
+  """An ownership check never decodes the large chat payload columns."""
+  chat = models.Chat(
+    id="large",
+    title="large transcript",
+    messages=[{"role": "user", "content": "x" * 100_000}],
+    live_assistant={"role": "assistant", "blocks": [{"type": "text"}]},
+    pending_messages=[{"role": "user", "content": "queued"}],
+  )
+  db.add(chat)
+  db.commit()
+  db.expunge_all()
+
+  statements: list[str] = []
+
+  def capture_select(_conn, _cursor, statement, _params, _context, _many):
+    if "FROM chats" in statement:
+      statements.append(statement)
+
+  event.listen(db.bind, "before_cursor_execute", capture_select)
+  try:
+    require_active_chat_access(
+      db,
+      "large",
+      Principal(owner=models.Owner(username="owner"), app_id=None),
+    )
+  finally:
+    event.remove(db.bind, "before_cursor_execute", capture_select)
+
+  assert len(statements) == 1
+  selected = statements[0].partition("FROM chats")[0]
+  assert "chats.id" in selected
+  assert "chats.created_by_app_id" in selected
+  assert "chats.messages" not in selected
+  assert "chats.live_assistant" not in selected
+  assert "chats.pending_messages" not in selected
+
+
+def test_access_only_gate_preserves_app_chat_ownership(db):
+  """The minimal projection keeps the same app-vs-foreign authorization."""
+  db.add_all([
+    models.App(
+      id=7,
+      name="owner app",
+      description="",
+      jsx_source="",
+      compiled_path="",
+    ),
+    models.Chat(
+      id="app-chat",
+      title="owned",
+      messages=[],
+      created_by_app_id=7,
+    ),
+  ])
+  db.commit()
+  db.expunge_all()
+
+  owner = models.Owner(username="owner")
+  require_active_chat_access(
+    db, "app-chat", Principal(owner=owner, app_id=7, scope="app"),
+  )
+
+  with pytest.raises(HTTPException) as exc:
+    require_active_chat_access(
+      db, "app-chat", Principal(owner=owner, app_id=8, scope="app"),
+    )
+  assert exc.value.status_code == 403

--- a/backend/tests/test_sse_releases_db_connection.py
+++ b/backend/tests/test_sse_releases_db_connection.py
@@ -31,7 +31,7 @@ covers production SQLite's NullPool and deployed Postgres's QueuePool.
 """
 
 import pytest
-from sqlalchemy import text
+from sqlalchemy import event, text
 
 from app import models
 from app.broadcast import create_broadcast, remove_broadcast
@@ -117,7 +117,13 @@ async def test_chat_stream_releases_db_connection_while_open():
   baseline = checked_out_connections()
   db = _pinned_session(baseline)
   setup = SessionLocal()
-  setup.add(models.Chat(id=chat_id, title="sse pool test"))
+  setup.add(models.Chat(
+    id=chat_id,
+    title="sse pool test",
+    messages=[{"role": "user", "content": "x" * 100_000}],
+    live_assistant={"role": "assistant", "blocks": []},
+    pending_messages=[{"role": "user", "content": "queued"}],
+  ))
   setup.commit()
   setup.close()
 
@@ -126,6 +132,13 @@ async def test_chat_stream_releases_db_connection_while_open():
   bc = create_broadcast(chat_id)
   bc.publish({"type": "text", "content": "hello"})
 
+  chat_selects: list[str] = []
+
+  def capture_chat_select(_conn, _cursor, statement, _params, _context, _many):
+    if "FROM chats" in statement:
+      chat_selects.append(statement)
+
+  event.listen(db.bind, "before_cursor_execute", capture_chat_select)
   try:
     response = await stream_chat(
       request=_ConnectedRequest(),
@@ -133,6 +146,11 @@ async def test_chat_stream_releases_db_connection_while_open():
       principal=Principal(owner=models.Owner(username="test"), app_id=None),
       db=db,
     )
+    assert len(chat_selects) == 1
+    selected = chat_selects[0].partition("FROM chats")[0]
+    assert "chats.messages" not in selected
+    assert "chats.live_assistant" not in selected
+    assert "chats.pending_messages" not in selected
     gen = response.body_iterator
     try:
       first = await gen.__anext__()
@@ -141,5 +159,6 @@ async def test_chat_stream_releases_db_connection_while_open():
     finally:
       await gen.aclose()
   finally:
+    event.remove(db.bind, "before_cursor_execute", capture_chat_select)
     db.close()
     remove_broadcast(chat_id)


### PR DESCRIPTION
## Summary
- load Web Push delivery only when a notification is actually sent
- authorize chat-scoped requests without deserializing transcript payloads
- expire telemetry debounce and app-instance bookkeeping only after their existing semantic windows
- preserve every active key, app instance, question, and workload without cardinality caps

## Design
This deliberately does not add active-turn admission controls or browser/process limits. Issue #130 tracks that separate product decision; this change only removes passive overhead and stale bookkeeping.

## Verification
- 177 focused backend tests
- Python compilation checks
- diff checks