### PR TITLE
Consolidate shared maintenance primitives

### DIFF
--- a/backend/app/data_git.py
+++ b/backend/app/data_git.py
@@ -1,0 +1,73 @@
+"""Focused operations on the owner-visible ``/data`` safety-net repository.
+
+This is distinct from :mod:`app.app_git`, which owns each mini-app's private
+source history. Callers here preserve owner-authored shared data immediately
+before a managed lifecycle operation replaces or removes it.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+_REDIRECTING_GIT_ENV = ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE")
+
+
+def snapshot_path(
+  data_dir: Path,
+  relative_path: str,
+  commit_message: str,
+) -> tuple[bool, str]:
+  """Make one path durable in ``data_dir``'s git history before mutation.
+
+  A clean path is already durable and succeeds without a new commit. ``--only``
+  prevents unrelated staged changes from entering the snapshot commit or being
+  disturbed by it. The caller must leave the path untouched when ``ok`` is
+  false.
+  """
+  env = {
+    key: value
+    for key, value in os.environ.items()
+    if key not in _REDIRECTING_GIT_ENV
+  }
+  base = [
+    "git", "-C", str(data_dir),
+    "-c", "user.name=Mobius", "-c", "user.email=mobius@localhost",
+  ]
+
+  def run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+      [*base, *args],
+      capture_output=True,
+      text=True,
+      timeout=30,
+      env=env,
+    )
+
+  def failure_reason(proc: subprocess.CompletedProcess) -> str:
+    lines = (proc.stderr or proc.stdout or "").strip().splitlines()
+    return lines[0] if lines else f"git exited {proc.returncode}"
+
+  status = run("status", "--porcelain", "--", relative_path)
+  if status.returncode != 0:
+    return False, failure_reason(status)
+  if not status.stdout.strip():
+    return True, "already committed"
+
+  add = run("add", "--", relative_path)
+  if add.returncode != 0:
+    return False, failure_reason(add)
+
+  commit = run(
+    "commit",
+    "--only",
+    "-m",
+    commit_message,
+    "--",
+    relative_path,
+  )
+  if commit.returncode != 0:
+    return False, failure_reason(commit)
+  return True, "committed"

--- a/backend/app/install.py
+++ b/backend/app/install.py
@@ -45,7 +45,15 @@ from PIL import Image as _PILImage
 from sqlalchemy import case
 from sqlalchemy.orm import Session
 
-from app import activity, app_git, fs_locks, legacy_platform_apps, models, source_dirs
+from app import (
+  activity,
+  app_git,
+  data_git,
+  fs_locks,
+  legacy_platform_apps,
+  models,
+  source_dirs,
+)
 from app.app_capabilities import contract_and_digest
 from app.app_source_check import check_app_source
 from app.compiler import (
@@ -1341,69 +1349,6 @@ def _storage_path(app_id: int, sub: str) -> Path:
   return data_dir / "apps" / str(app_id) / sub
 
 
-# Env vars that would redirect the skill-snapshot git commands away from the
-# /data repo (git exports them into hook environments, where they OVERRIDE
-# `-C`). app_git._git_env is deliberately NOT reused for the snapshot: its
-# GIT_CEILING_DIRECTORIES is designed to STOP repo discovery at /data, which
-# is exactly the repo the snapshot targets.
-_SNAPSHOT_GIT_ENV_DROP = ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE")
-
-
-def _snapshot_shared_skill(
-  data_dir: Path, rel: str, slug: str, version: str,
-) -> tuple[bool, str]:
-  """Commits shared/skills/<rel>'s current bytes into the /data repo.
-
-  Returns (ok, detail). ok=True means the current content is durable in git
-  history — either a fresh pre-install snapshot commit, or the file was
-  already committed clean (the nightly /data safety-net commit got there
-  first, which IS the snapshot). ok=False means durability could not be
-  guaranteed (index.lock, dubious ownership, unborn HEAD, ...) and the
-  caller must NOT overwrite the file.
-
-  `--only` + the pathspec keeps the commit to this one file, so a racing
-  `git add -A` (the nightly pm-commit) can't be swept into it and unrelated
-  staged files stay staged.
-  """
-  env = {
-    k: v for k, v in os.environ.items() if k not in _SNAPSHOT_GIT_ENV_DROP
-  }
-  # Explicit identity: the /data repo normally carries user.name from
-  # entrypoint.sh, but a snapshot must not fail (and thereby block a skill
-  # update) just because that config is missing.
-  base = [
-    "git", "-C", str(data_dir),
-    "-c", "user.name=Mobius", "-c", "user.email=mobius@localhost",
-  ]
-
-  def _run(*args: str) -> subprocess.CompletedProcess:
-    return subprocess.run(
-      [*base, *args], capture_output=True, text=True, timeout=30, env=env,
-    )
-
-  def _reason(proc: subprocess.CompletedProcess) -> str:
-    lines = (proc.stderr or proc.stdout or "").strip().splitlines()
-    return lines[0] if lines else f"git exited {proc.returncode}"
-
-  path = f"shared/skills/{rel}"
-  status = _run("status", "--porcelain", "--", path)
-  if status.returncode != 0:
-    return False, _reason(status)
-  if not status.stdout.strip():
-    return True, "already committed"
-  add = _run("add", "--", path)
-  if add.returncode != 0:
-    return False, _reason(add)
-  commit = _run(
-    "commit", "--only",
-    "-m", f"pre-install snapshot of {rel} (app {slug} v{version})",
-    "--", path,
-  )
-  if commit.returncode != 0:
-    return False, _reason(commit)
-  return True, "committed"
-
-
 async def _sync_app_skills(
   db: Session,
   app: "models.App",
@@ -1540,7 +1485,10 @@ async def _sync_app_skills(
           if (data_dir / ".git").is_dir():
             try:
               ok, detail = await asyncio.to_thread(
-                _snapshot_shared_skill, data_dir, rel, app.slug, version,
+                data_git.snapshot_path,
+                data_dir,
+                f"shared/skills/{rel}",
+                f"pre-install snapshot of {rel} (app {app.slug} v{version})",
               )
             except Exception as exc:
               ok, detail = False, repr(exc)

--- a/backend/app/path_utils.py
+++ b/backend/app/path_utils.py
@@ -1,4 +1,4 @@
-"""Path-traversal validation shared across upload/media/storage routes.
+"""Filesystem identifier and path validation shared by serving routes.
 
 The three caller routes used to each implement this check with subtly
 different techniques (`str().startswith()`, string concatenation,
@@ -10,9 +10,21 @@ it operates on resolved Path objects and survives symlink escapes that
 prefix-string checks miss.
 """
 
+import re
 from pathlib import Path
 
 from fastapi import HTTPException
+
+_CHAT_ID_RE = re.compile(
+  r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+  re.IGNORECASE,
+)
+
+
+def validate_chat_id(chat_id: str) -> None:
+  """Raise HTTP 400 unless ``chat_id`` is a dashed UUID4 string."""
+  if not _CHAT_ID_RE.match(chat_id):
+    raise HTTPException(status_code=400, detail="Invalid chat id.")
 
 
 def validate_path_within_base(path: Path | str, base: Path) -> Path:

--- a/backend/app/routes/media.py
+++ b/backend/app/routes/media.py
@@ -1,7 +1,6 @@
 """Authenticated chat-media serving routes."""
 
 import mimetypes
-import re
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -14,22 +13,7 @@ from app.config import get_settings
 from app.database import get_db
 from app.deps import resolve_media_or_header_owner
 from app.image_previews import display_image_preview
-from app.path_utils import validate_path_within_base
-
-# Chat IDs are dashed UUID4 strings produced by str(uuid.uuid4()).
-# Rejecting early prevents using a crafted chat_id as a filesystem path
-# component to escape the chats/ subtree.
-_CHAT_ID_RE = re.compile(
-  r'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$',
-  re.IGNORECASE,
-)
-
-
-def _validate_chat_id(chat_id: str) -> None:
-  """Raises 400 if chat_id doesn't look like a UUID4."""
-  if not _CHAT_ID_RE.match(chat_id):
-    raise HTTPException(status_code=400, detail="Invalid chat id.")
-
+from app.path_utils import validate_chat_id, validate_path_within_base
 
 router = APIRouter(prefix="/api/chats", tags=["media"])
 
@@ -52,7 +36,7 @@ def _serve_chat_image(chat_id, filename, token_src, db, *, preview=False):
 
   App tokens are rejected on both paths.
   """
-  _validate_chat_id(chat_id)
+  validate_chat_id(chat_id)
   resolve_media_or_header_owner(
     token_src.token, db, chat_id=chat_id, from_query=token_src.from_query,
   )

--- a/backend/app/routes/skills.py
+++ b/backend/app/routes/skills.py
@@ -50,7 +50,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
-from app import activity, catalog_index, install, models, skills
+from app import activity, catalog_index, data_git, install, models, skills
 from app.config import get_settings
 from app.database import get_db
 from app.deps import (
@@ -394,50 +394,6 @@ def _source_label(source: str) -> str:
   from urllib.parse import urlparse
 
   return urlparse(source).hostname or source
-
-
-def _snapshot_skill_dir(data_dir: Path, name: str) -> tuple[bool, str]:
-  """Commit shared/skills/<name>/ into the /data repo before removal.
-
-  Mirrors install._snapshot_shared_skill but scopes the pathspec to the whole
-  skill directory so a directory skill's resources are captured too. Returns
-  (ok, detail); ok=False means durability could not be guaranteed and the
-  caller must not delete.
-  """
-  env = {
-    k: v for k, v in os.environ.items()
-    if k not in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE")
-  }
-  base = [
-    "git", "-C", str(data_dir),
-    "-c", "user.name=Mobius", "-c", "user.email=mobius@localhost",
-  ]
-
-  def _run(*args: str) -> subprocess.CompletedProcess:
-    return subprocess.run(
-      [*base, *args], capture_output=True, text=True, timeout=30, env=env,
-    )
-
-  def _reason(proc: subprocess.CompletedProcess) -> str:
-    lines = (proc.stderr or proc.stdout or "").strip().splitlines()
-    return lines[0] if lines else f"git exited {proc.returncode}"
-
-  path = f"shared/skills/{name}"
-  status = _run("status", "--porcelain", "--", path)
-  if status.returncode != 0:
-    return False, _reason(status)
-  if not status.stdout.strip():
-    return True, "already committed"
-  add = _run("add", "--", path)
-  if add.returncode != 0:
-    return False, _reason(add)
-  commit = _run(
-    "commit", "--only", "-m", f"pre-uninstall snapshot of skill {name}",
-    "--", path,
-  )
-  if commit.returncode != 0:
-    return False, _reason(commit)
-  return True, "committed"
 
 
 def _skill_row(
@@ -819,7 +775,12 @@ async def uninstall_skill(
 
     if target_kind == "dir" and (data_dir / ".git").is_dir():
       try:
-        ok, detail = await asyncio.to_thread(_snapshot_skill_dir, data_dir, name)
+        ok, detail = await asyncio.to_thread(
+          data_git.snapshot_path,
+          data_dir,
+          f"shared/skills/{name}",
+          f"pre-uninstall snapshot of skill {name}",
+        )
       except Exception as exc:  # pragma: no cover - defensive
         ok, detail = False, repr(exc)
       if not ok:

--- a/backend/app/routes/uploads.py
+++ b/backend/app/routes/uploads.py
@@ -20,23 +20,9 @@ from app.deps import (
   require_chat_embed_operation, resolve_media_or_header_owner,
 )
 from app.image_previews import discard_image_preview, display_image_preview
-from app.path_utils import validate_path_within_base
+from app.path_utils import validate_chat_id, validate_path_within_base
 from app.resource_access import get_active_chat_for_principal
 from app.storage_io import atomic_write, app_dir_usage
-
-# Chat IDs are UUID4 strings (str(uuid.uuid4()), 36 chars with dashes).
-# Validating the format before constructing any filesystem path prevents
-# a crafted chat_id from escaping the /data/chats/ subtree.
-_CHAT_ID_RE = re.compile(
-  r'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$',
-  re.IGNORECASE,
-)
-
-
-def _validate_chat_id(chat_id: str) -> None:
-  """Raises 400 if chat_id doesn't look like a UUID4."""
-  if not _CHAT_ID_RE.match(chat_id):
-    raise HTTPException(status_code=400, detail="Invalid chat id.")
 
 router = APIRouter(prefix="/api/chats", tags=["uploads"])
 
@@ -106,7 +92,7 @@ async def upload_files(
   db: Session = Depends(get_db),
 ):
   """Saves uploaded files to /data/chats/{id}/uploads/ and records metadata."""
-  _validate_chat_id(chat_id)
+  validate_chat_id(chat_id)
   if principal.scope == "app":
     raise HTTPException(status_code=403, detail="App token is not valid here.")
   require_chat_embed_operation(principal, "chat:uploads")
@@ -187,7 +173,7 @@ def list_uploads(
   db: Session = Depends(get_db),
 ):
   """Returns uploads for an owner or the exact authorized chat embed."""
-  _validate_chat_id(chat_id)
+  validate_chat_id(chat_id)
   if principal.scope == "app":
     raise HTTPException(status_code=403, detail="App token is not valid here.")
   require_chat_embed_operation(principal, "chat:uploads")
@@ -207,7 +193,7 @@ def delete_upload(
   db: Session = Depends(get_db),
 ):
   """Removes an uploaded file from disk and from the chat's upload list."""
-  _validate_chat_id(chat_id)
+  validate_chat_id(chat_id)
   if principal.scope == "app":
     raise HTTPException(status_code=403, detail="App token is not valid here.")
   require_chat_embed_operation(principal, "chat:uploads")
@@ -244,7 +230,7 @@ def serve_upload(
   Owner JWTs are rejected in query strings because they would leak into access
   logs, history and Referer headers. App/chat_embed tokens are rejected here.
   """
-  _validate_chat_id(chat_id)
+  validate_chat_id(chat_id)
   resolve_media_or_header_owner(
     token_src.token, db, chat_id=chat_id, from_query=token_src.from_query,
   )

--- a/backend/tests/test_data_git.py
+++ b/backend/tests/test_data_git.py
@@ -1,0 +1,100 @@
+"""Focused contract tests for snapshots in the shared /data repository."""
+
+from __future__ import annotations
+
+import subprocess
+
+from app import data_git
+
+
+def _git(repo, *args: str) -> subprocess.CompletedProcess:
+  return subprocess.run(
+    ["git", "-C", str(repo), *args],
+    capture_output=True,
+    text=True,
+    check=True,
+  )
+
+
+def _init_repo(repo) -> None:
+  _git(repo, "init", "-q", "-b", "main")
+  _git(
+    repo,
+    "-c",
+    "user.name=Test",
+    "-c",
+    "user.email=test@example.invalid",
+    "commit",
+    "-q",
+    "--allow-empty",
+    "-m",
+    "init",
+  )
+
+
+def test_snapshot_commits_only_target_and_preserves_unrelated_staging(
+  tmp_path,
+  monkeypatch,
+):
+  """A safety snapshot neither captures nor unstages another pending change."""
+  _init_repo(tmp_path)
+  target = tmp_path / "shared" / "skills" / "demo.md"
+  target.parent.mkdir(parents=True)
+  target.write_text("owner edit\n")
+  unrelated = tmp_path / "unrelated.txt"
+  unrelated.write_text("keep staged\n")
+  _git(tmp_path, "add", "unrelated.txt")
+
+  # Inherited hook variables override `git -C`; the helper must scrub them.
+  monkeypatch.setenv("GIT_DIR", str(tmp_path / "wrong-repository"))
+  monkeypatch.setenv("GIT_WORK_TREE", str(tmp_path / "wrong-worktree"))
+  monkeypatch.setenv("GIT_INDEX_FILE", str(tmp_path / "wrong-index"))
+
+  result = data_git.snapshot_path(
+    tmp_path,
+    "shared/skills/demo.md",
+    "preserve demo before mutation",
+  )
+  for variable in data_git._REDIRECTING_GIT_ENV:
+    monkeypatch.delenv(variable)
+
+  assert result == (True, "committed")
+  assert _git(tmp_path, "show", "HEAD:shared/skills/demo.md").stdout == (
+    "owner edit\n"
+  )
+  assert _git(tmp_path, "show", "--pretty=", "--name-only", "HEAD").stdout == (
+    "shared/skills/demo.md\n"
+  )
+  assert _git(tmp_path, "diff", "--cached", "--name-only").stdout == (
+    "unrelated.txt\n"
+  )
+
+
+def test_snapshot_reuses_clean_history_without_creating_commit(tmp_path):
+  """Already-recorded bytes are durable without manufacturing history."""
+  _init_repo(tmp_path)
+  target = tmp_path / "shared" / "skills" / "demo.md"
+  target.parent.mkdir(parents=True)
+  target.write_text("recorded\n")
+  _git(tmp_path, "add", "shared/skills/demo.md")
+  _git(
+    tmp_path,
+    "-c",
+    "user.name=Test",
+    "-c",
+    "user.email=test@example.invalid",
+    "commit",
+    "-q",
+    "-m",
+    "record demo",
+  )
+  before = _git(tmp_path, "rev-parse", "HEAD").stdout
+
+  result = data_git.snapshot_path(
+    tmp_path,
+    "shared/skills/demo.md",
+    "should not be created",
+  )
+
+  assert result == (True, "already committed")
+  assert _git(tmp_path, "rev-parse", "HEAD").stdout == before

--- a/backend/tests/test_path_utils.py
+++ b/backend/tests/test_path_utils.py
@@ -1,4 +1,4 @@
-"""Unit tests for `app.path_utils.validate_path_within_base`.
+"""Unit tests for the shared filesystem identifier and path validators.
 
 Covers the three escape vectors the helper exists to block: symlink
 escape, `..` traversal, and absolute-path injection. Also verifies
@@ -12,7 +12,27 @@ from pathlib import Path
 import pytest
 from fastapi import HTTPException
 
-from app.path_utils import validate_path_within_base
+from app.path_utils import validate_chat_id, validate_path_within_base
+
+
+@pytest.mark.parametrize("chat_id", [
+  "123e4567-e89b-42d3-a456-426614174000",
+  "123E4567-E89B-42D3-A456-426614174000",
+])
+def test_validate_chat_id_accepts_dashed_uuid4(chat_id):
+  assert validate_chat_id(chat_id) is None
+
+
+@pytest.mark.parametrize("chat_id", [
+  "not-a-uuid",
+  "123e4567-e89b-12d3-a456-426614174000",
+  "../123e4567-e89b-42d3-a456-426614174000",
+])
+def test_validate_chat_id_preserves_invalid_id_response(chat_id):
+  with pytest.raises(HTTPException) as exc:
+    validate_chat_id(chat_id)
+  assert exc.value.status_code == 400
+  assert exc.value.detail == "Invalid chat id."
 
 
 def test_returns_resolved_path_for_relative_input():

--- a/backend/tests/test_skills_platform.py
+++ b/backend/tests/test_skills_platform.py
@@ -428,6 +428,43 @@ def test_uninstall_removes_dir_and_sidecar_record(client, auth, skills_dir):
   assert "tips" not in sidecar
 
 
+def test_uninstall_snapshots_the_owned_directory_before_removal(
+  client, auth, skills_dir, monkeypatch,
+):
+  """The route delegates its exact path and lifecycle intent before deletion."""
+  from app.routes import skills as rs
+
+  d = skills_dir / "tips"
+  d.mkdir()
+  (d / "SKILL.md").write_text("# tips\n")
+  (skills_dir / skills_mod.INSTALLED_SKILLS_SIDECAR).write_text(
+    json.dumps({"tips": {"source": "o/r"}}),
+  )
+  data_dir = skills_dir.parents[1]
+  git_dir = data_dir / ".git"
+  git_dir.mkdir()
+  calls = []
+
+  def snapshot(data_dir_, relative_path, commit_message):
+    calls.append((data_dir_, relative_path, commit_message, d.is_dir()))
+    return True, "committed"
+
+  monkeypatch.setattr(rs.data_git, "snapshot_path", snapshot)
+  try:
+    r = client.delete("/api/skills/tips", headers=auth)
+  finally:
+    git_dir.rmdir()
+
+  assert r.status_code == 200, r.text
+  assert calls == [(
+    data_dir,
+    "shared/skills/tips",
+    "pre-uninstall snapshot of skill tips",
+    True,
+  )]
+  assert not d.exists()
+
+
 def test_uninstall_rejects_traversal_name(client, auth, skills_dir):
   r = client.delete("/api/skills/..%2Fetc", headers=auth)
   assert r.status_code in (400, 404, 409)


### PR DESCRIPTION
## Summary
- share one focused /data snapshot primitive across skill install and uninstall
- share one UUID4 chat-id validator across upload and media routes
- preserve snapshot isolation, ownership checks, status codes, and error details

## Verification
- focused snapshot, skill lifecycle, and path-validation tests
- Python compilation checks
- diff checks