### PR TITLE
Keep the chat stop glyph legible

### DIFF
--- a/frontend/src/components/ChatView/ChatInputBar.jsx
+++ b/frontend/src/components/ChatView/ChatInputBar.jsx
@@ -43,9 +43,9 @@
  * ║      Without it, tapping × steals focus → iOS collapses kb.      ║
  * ║                                                                  ║
  * ║   4. ICONS COME FROM THE APPS-SDK-UI PACKAGE                     ║
- * ║      Primary action: `ArrowUp` (22) for send, `Mic` (24) for     ║
- * ║      voice, inlined stop-square SVG for stop. The package        ║
- * ║      ships these — don't substitute hand-rolled paths.           ║
+ * ║      Primary action: `ArrowUp` (22) for send, `Mic` (24), and    ║
+ * ║      `Stop` (24). The package ships these — don't substitute     ║
+ * ║      hand-rolled paths.                                          ║
  * ║                                                                  ║
  * ║   5. ATTACH CARD CLASSIFIER (`classifyFile`) drives the badge    ║
  * ║      colour (PDF red, DOC blue, others muted). `stripExt`        ║
@@ -171,7 +171,7 @@ function PrimaryAction({
         onClick={onStop}
         aria-label="Stop"
       >
-        <Stop width={16} height={16} aria-hidden="true" />
+        <Stop width={24} height={24} aria-hidden="true" />
       </button>
     )
   }

--- a/frontend/src/components/ChatView/__tests__/chatUiPolish.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatUiPolish.test.js
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict'
 
 const indexCss = readFileSync(new URL('../../../index.css', import.meta.url), 'utf8')
 const chatCss = readFileSync(new URL('../ChatView.css', import.meta.url), 'utf8')
+const chatInputBar = readFileSync(new URL('../ChatInputBar.jsx', import.meta.url), 'utf8')
 const chatView = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8')
 const queuedMessages = readFileSync(new URL('../QueuedMessages.jsx', import.meta.url), 'utf8')
 const chatSettingsPanel = readFileSync(
@@ -79,6 +80,14 @@ test('stop action has no visible circular shell', () => {
     'Stop must override the circular action-slot focus outline')
   assert.match(stopGlyphFocusRule, /outline:\s*2px solid var\(--accent\)/,
     'Stop keyboard focus should move to the square glyph')
+})
+
+test('stop action keeps a legible glyph inside its full touch target', () => {
+  assert.match(
+    chatInputBar,
+    /<Stop width=\{24\} height=\{24\} aria-hidden="true" \/>/,
+    'the SDK Stop icon needs a 24px box because its square occupies only part of the viewBox',
+  )
 })
 
 test('mobile messages preserve native text selection and its action menu', () => {


### PR DESCRIPTION
## Summary
- enlarge the SDK stop glyph to match the composer’s other primary actions
- preserve the existing 40px tap target and stable composer layout
- keep the change as the second, isolated layer above #312

## Verification
- full frontend suite — 2,141 unit tests and 66 hook tests passed
- production, PWA, and offline builds passed
- `git diff --check`
