### PR TITLE
Make app schedules timezone-durable via IANA identity

### DIFF
--- a/backend/app/cron_tz.py
+++ b/backend/app/cron_tz.py
@@ -1,0 +1,128 @@
+"""Zone-aware cron schedules — durable IANA identity, materialized entries.
+
+Cron itself evaluates wall-clock time in the server's local timezone, which
+is not a durable way to express "5:00 AM in Europe/Belgrade": the server's
+offset to that zone changes at daylight-saving transitions, in either zone.
+
+The durable schedule identity is therefore an IANA timezone name plus a
+zone-local daily cron expression, declared in the app's ``init-cron.sh``
+(``SCHEDULE_TZ`` / ``SCHEDULE_SOURCE``). The crontab line cron actually runs
+is a *materialization* of that identity into the server's current clock,
+recomputed at boot and periodically at runtime so an offset change in either
+zone reschedules the entry instead of silently drifting the wall time.
+
+Only simple daily expressions (numeric minute + hour, ``* * *`` date fields)
+may carry a timezone: shifting an expression across an offset can cross a day
+boundary, which is well-defined for a daily job and ambiguous for date-pinned
+ones.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+_DAILY_CRON_RE = re.compile(
+  r"^\s*(\d{1,2})\s+(\d{1,2})\s+\*\s+\*\s+\*\s*$"
+)
+# Written by init-cron-scaffold.sh; parsed (never executed) from init-cron.sh.
+_DECL_TZ_RE = re.compile(r'^SCHEDULE_TZ="([A-Za-z0-9_+/-]+)"\s*$', re.M)
+_DECL_SOURCE_RE = re.compile(r'^SCHEDULE_SOURCE="([^"\n]+)"\s*$', re.M)
+
+
+def valid_timezone(name: str) -> bool:
+  """True when ``name`` is a resolvable IANA timezone identifier."""
+  if not isinstance(name, str) or not name or len(name) > 64:
+    return False
+  if not re.fullmatch(r"[A-Za-z0-9_+/-]+", name):
+    return False
+  try:
+    ZoneInfo(name)
+  except Exception:
+    return False
+  return True
+
+
+def parse_daily_cron(expr: str) -> tuple[int, int] | None:
+  """Returns (minute, hour) for a plain daily cron, else None."""
+  m = _DAILY_CRON_RE.match(expr or "")
+  if not m:
+    return None
+  minute, hour = int(m.group(1)), int(m.group(2))
+  if minute > 59 or hour > 23:
+    return None
+  return minute, hour
+
+
+def materialize_zone_cron(
+  zone_cron: str,
+  tz_name: str,
+  *,
+  now: datetime | None = None,
+  server_tz=None,
+) -> str:
+  """Expresses a zone-local daily cron in the server's current clock.
+
+  ``now`` and ``server_tz`` exist for tests; production uses the real clock
+  and the process-local timezone. The conversion is exact for the current
+  offset pair — the caller re-materializes when offsets change, which is the
+  whole durability contract.
+
+  Raises ValueError for a non-daily expression or unknown timezone.
+  """
+  parsed = parse_daily_cron(zone_cron)
+  if parsed is None:
+    raise ValueError(
+      "A timezone-owned schedule must be a plain daily cron "
+      f"('m h * * *'), got: {zone_cron!r}"
+    )
+  minute, hour = parsed
+  if not valid_timezone(tz_name):
+    raise ValueError(f"Unknown IANA timezone: {tz_name!r}")
+  tz = ZoneInfo(tz_name)
+  moment = (now or datetime.now(tz)).astimezone(tz)
+  local = moment.replace(hour=hour, minute=minute, second=0, microsecond=0)
+  server = local.astimezone(server_tz)
+  return f"{server.minute} {server.hour} * * *"
+
+
+def parse_zone_declaration(init_cron_text: str) -> tuple[str, str] | None:
+  """Extracts (timezone, zone_cron) from init-cron.sh text, if declared.
+
+  Returns None when either variable is absent or invalid — an app whose
+  declaration was hand-edited into an inconsistent state falls back to plain
+  server-local scheduling rather than guessing.
+  """
+  tz_match = _DECL_TZ_RE.search(init_cron_text or "")
+  source_match = _DECL_SOURCE_RE.search(init_cron_text or "")
+  if not tz_match or not source_match:
+    return None
+  tz_name = tz_match.group(1)
+  zone_cron = source_match.group(1).strip()
+  if not valid_timezone(tz_name) or parse_daily_cron(zone_cron) is None:
+    return None
+  return tz_name, zone_cron
+
+
+def server_timezone_name() -> str:
+  """The server clock's IANA identity: TZ env, /etc/localtime, else UTC.
+
+  Containers conventionally run UTC with neither signal present; "UTC" is a
+  valid IANA identifier, so the fallback stays truthful for them.
+  """
+  tz_env = os.environ.get("TZ", "").strip()
+  if tz_env and valid_timezone(tz_env):
+    return tz_env
+  try:
+    target = Path("/etc/localtime").resolve()
+    parts = target.parts
+    if "zoneinfo" in parts:
+      name = "/".join(parts[parts.index("zoneinfo") + 1:])
+      if valid_timezone(name):
+        return name
+  except OSError:
+    pass
+  return "UTC"

--- a/backend/app/install.py
+++ b/backend/app/install.py
@@ -1127,8 +1127,17 @@ def _process_icon(raw: bytes) -> bytes:
 
 
 def _register_cron(slug: str, schedule_expr: str, job_path: Path,
-                   app_id: int | None = None) -> None:
+                   app_id: int | None = None,
+                   timezone: str | None = None,
+                   zone_cron: str | None = None) -> None:
   """Runs init-cron-scaffold.sh to install the crontab entry.
+
+  ``timezone``/``zone_cron`` (given together) declare the schedule's durable
+  zone-aware identity: ``schedule_expr`` is then its server-local
+  materialization, and the identity is appended to ``init-cron.sh`` after the
+  scaffold rewrites it, so reconciliation can re-materialize the entry when
+  either zone's UTC offset changes. The scaffold's own contract stays
+  unchanged; the platform owns the declaration lines (see app.cron_tz).
 
   The scaffold writes both the durable ``init-cron.sh`` declaration and the
   live crontab entry. On restart, lifespan parses that declaration and rewrites
@@ -1180,6 +1189,37 @@ def _register_cron(slug: str, schedule_expr: str, job_path: Path,
       500,
       f"Cron registration failed: {result.stderr.strip()[:400]}",
     )
+  if (timezone is None) != (zone_cron is None):
+    raise HTTPException(
+      500, "Cron registration bug: timezone and zone_cron must be paired.",
+    )
+  if timezone is not None:
+    from app import cron_tz
+
+    if not cron_tz.valid_timezone(timezone):
+      raise HTTPException(500, f"Unknown IANA timezone: {timezone!r}")
+    if cron_tz.parse_daily_cron(zone_cron) is None:
+      raise HTTPException(
+        500, f"Zone-owned schedule must be a plain daily cron: {zone_cron!r}",
+      )
+    init_path = job_path.parent / "init-cron.sh"
+    try:
+      # The scaffold just rewrote init-cron.sh from its template, so a plain
+      # append is deterministic and repeat-registration cannot duplicate.
+      with init_path.open("a", encoding="utf-8") as fh:
+        fh.write(
+          "\n# --- Zone-aware schedule identity "
+          "(platform-managed; parsed, never executed).\n"
+          "# ENTRY above is the server-local materialization of this durable\n"
+          "# identity, recomputed at boot and periodically so DST transitions\n"
+          "# reschedule the entry instead of drifting its wall time.\n"
+          f'SCHEDULE_TZ="{timezone}"\n'
+          f'SCHEDULE_SOURCE="{zone_cron}"\n'
+        )
+    except OSError as exc:
+      raise HTTPException(
+        500, f"Could not persist schedule timezone: {exc}",
+      ) from exc
 
 
 def _reconcile_cron_after_install_rollback() -> None:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -442,6 +442,50 @@ async def lifespan(app):
       _cron_ready.write_text(f"{_BOOT_ID}\n", encoding="utf-8")
   except Exception as exc:
     _log.error("app cron supervision wiring failed: %s", exc, exc_info=True)
+  # Periodic re-materialization for timezone-owned schedules (app.cron_tz):
+  # a schedule declared as "wall time in an IANA zone" must be rescheduled
+  # when either that zone's or the server's UTC offset changes (DST). Boot
+  # reconciliation covers restarts; this hourly pass covers long-running
+  # containers crossing a transition. It reuses the same idempotent
+  # reconciler, and only runs while any zone declaration actually exists.
+  _cron_tz_task = None
+  try:
+    from app.routes.apps import (
+      _app_zone_declaration as _zone_decl,
+      reconcile_app_cron_supervision as _cron_reconcile,
+    )
+    from app.database import SessionLocal as _CronTzSession
+
+    async def _cron_tz_loop():
+      while True:
+        await _asyncio.sleep(3600)
+        try:
+          def _pass():
+            from app import models as _tz_models
+            _db = _CronTzSession()
+            try:
+              _live = _db.query(_tz_models.App).filter(
+                _tz_models.App.deleted_at.is_(None)
+              ).all()
+              if not any(_zone_decl(_a) for _a in _live):
+                return None
+              return _cron_reconcile(_db)
+            finally:
+              _db.close()
+          _result = await _asyncio.to_thread(_pass)
+          if _result is not None:
+            for _warning in _result[1]:
+              _log.warning("cron tz re-materialization: %s", _warning)
+        except _asyncio.CancelledError:
+          raise
+        except Exception as _exc:
+          _log.error(
+            "cron tz re-materialization failed: %s", _exc, exc_info=True,
+          )
+
+    _cron_tz_task = _asyncio.create_task(_cron_tz_loop())
+  except Exception as exc:
+    _log.error("cron tz loop wiring failed: %s", exc, exc_info=True)
   record_memory_checkpoint("startup_metadata_reconciled")
   # Route provider model-registry and memory diagnostics to the durable
   # rotating chat.log handler. These loggers otherwise land only on
@@ -665,6 +709,8 @@ async def lifespan(app):
       _reset_park_task.cancel()
     if _browser_profile_task is not None:
       _browser_profile_task.cancel()
+    if _cron_tz_task is not None:
+      _cron_tz_task.cancel()
     if _writer_supervisor_task is not None:
       _writer_supervisor_task.cancel()
     # Drain + join the chat-writer actor so any in-flight persistence

--- a/backend/app/routes/apps.py
+++ b/backend/app/routes/apps.py
@@ -590,6 +590,26 @@ def _app_schedule(app: models.App, live_crontab: str) -> tuple[str, str] | None:
   return _manifest_schedule(source_dir)
 
 
+def _app_zone_declaration(app: models.App) -> tuple[str, str] | None:
+  """The schedule's durable (timezone, zone_cron) identity, if declared.
+
+  Read from the init-cron.sh declaration lines the platform appends when a
+  schedule is owned in an IANA zone (see app.cron_tz / _register_cron).
+  """
+  from app import cron_tz
+
+  if not app.source_dir:
+    return None
+  source_dir = Path(app.source_dir)
+  for replay_dir in _cron_replay_dirs_for_app(app, source_dir):
+    declaration = cron_tz.parse_zone_declaration(
+      _read_init_cron_text(replay_dir),
+    )
+    if declaration is not None:
+      return declaration
+  return None
+
+
 def reconcile_app_cron_supervision(db: Session) -> tuple[int, list[str]]:
   """Converge every live managed schedule through the common job runner.
 
@@ -600,7 +620,13 @@ def reconcile_app_cron_supervision(db: Session) -> tuple[int, list[str]]:
   crontab entry and its durable declaration via the current
   scaffold. Tombstoned apps are excluded and source trees must be ordinary,
   non-symlink direct children of ``/data/apps``.
+
+  A schedule owned in an IANA timezone (see ``app.cron_tz``) is
+  re-materialized here from its durable (timezone, zone_cron) identity
+  rather than preserved verbatim — this pass, run at boot and periodically
+  at runtime, is what reschedules the entry across DST transitions.
   """
+  from app import cron_tz
   from app.install import _register_cron
 
   settings = get_settings()
@@ -632,9 +658,19 @@ def reconcile_app_cron_supervision(db: Session) -> tuple[int, list[str]]:
     try:
       if job_path.is_symlink() or not job_path.is_file():
         raise ValueError(f"job is missing or a symlink: {job_name}")
-      _register_cron(
-        resolved_source.name, cron, job_path, app.id,
-      )
+      declaration = _app_zone_declaration(app)
+      if declaration is not None:
+        timezone, zone_cron = declaration
+        _register_cron(
+          resolved_source.name,
+          cron_tz.materialize_zone_cron(zone_cron, timezone),
+          job_path, app.id,
+          timezone=timezone, zone_cron=zone_cron,
+        )
+      else:
+        _register_cron(
+          resolved_source.name, cron, job_path, app.id,
+        )
     except Exception as exc:
       warnings.append(f"app {app.id}: {exc}")
       continue
@@ -723,7 +759,10 @@ def list_app_schedules(
   _: models.Owner = Depends(get_current_owner_or_app),
 ):
   """Returns read-only recurring app schedules visible to owners and apps."""
+  from app import cron_tz
+
   live_crontab = _read_live_crontab()
+  server_timezone = cron_tz.server_timezone_name()
   rows = []
   apps = (
     db.query(models.App)
@@ -736,12 +775,16 @@ def list_app_schedules(
     if schedule is None:
       continue
     cron, job = schedule
+    declaration = _app_zone_declaration(app)
     rows.append(schemas.AppScheduleOut(
       id=app.id,
       name=app.name,
       slug=app.slug,
       cron=cron,
       job=job,
+      timezone=declaration[0] if declaration else None,
+      zone_cron=declaration[1] if declaration else None,
+      server_timezone=server_timezone,
     ))
   return rows
 
@@ -2863,11 +2906,27 @@ def update_app_schedule(
     raise HTTPException(
       status_code=400, detail="App has no source_dir; cannot locate job.",
     )
+  from app import cron_tz
   from app.install import _register_cron
   try:
     validate_cron_expr(body.cron)
   except ManifestContractError as exc:
     raise HTTPException(status_code=400, detail=str(exc)) from exc
+  timezone = (body.timezone or "").strip() or None
+  if timezone is not None:
+    # A zone-owned schedule is durable data: body.cron is the daily wall
+    # time in that zone, and the crontab entry is its server-local
+    # materialization, re-materialized when either zone's offset changes.
+    if not cron_tz.valid_timezone(timezone):
+      raise HTTPException(
+        status_code=400, detail=f"Unknown IANA timezone: {timezone!r}",
+      )
+    if cron_tz.parse_daily_cron(body.cron) is None:
+      raise HTTPException(
+        status_code=400,
+        detail="A timezone-owned schedule must be a plain daily cron "
+               "('m h * * *').",
+      )
   source_dir = Path(app.source_dir)
   job_name = body.job or "fetch.sh"
   if "/" in job_name or "\\" in job_name or not job_name.strip():
@@ -2876,8 +2935,19 @@ def update_app_schedule(
   if not job_path.is_file():
     raise HTTPException(status_code=400, detail="Job script not found.")
   slug = app.slug or _slugify_for_source_dir(app.name)
+  if timezone is not None:
+    materialized = cron_tz.materialize_zone_cron(body.cron, timezone)
+    _register_cron(
+      slug, materialized, job_path, app_id,
+      timezone=timezone, zone_cron=body.cron,
+    )
+    return {
+      "cron": materialized, "job": job_name,
+      "timezone": timezone, "zone_cron": body.cron,
+    }
   _register_cron(slug, body.cron, job_path, app_id)
-  return {"cron": body.cron, "job": job_name}
+  return {"cron": body.cron, "job": job_name, "timezone": None,
+          "zone_cron": None}
 
 
 def _etag_for_app(app: models.App) -> str | None:

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -258,14 +258,28 @@ class AppInstallOut(AppOut):
 
 
 class AppScheduleUpdate(BaseModel):
-  """Body for updating one installed app's cron schedule."""
+  """Body for updating one installed app's cron schedule.
+
+  When ``timezone`` (an IANA identifier) is set, ``cron`` is a plain daily
+  expression owned in that zone; the platform stores that identity durably
+  and materializes/re-materializes the server-local crontab entry itself.
+  Without it, ``cron`` is interpreted in the server's local timezone as
+  before.
+  """
 
   cron: str
   job: str | None = None
+  timezone: str | None = None
 
 
 class AppScheduleOut(BaseModel):
-  """Read-only metadata for an installed app's recurring cron job."""
+  """Read-only metadata for an installed app's recurring cron job.
+
+  ``cron`` is always the materialized server-local entry. When the schedule
+  is owned in an IANA zone, ``timezone``/``zone_cron`` carry that durable
+  identity (the platform re-materializes ``cron`` when offsets change).
+  ``server_timezone`` is the server clock's own IANA identity.
+  """
 
   id: int
   name: str
@@ -273,6 +287,9 @@ class AppScheduleOut(BaseModel):
   cron: str
   job: str
   next_run: datetime | None = None
+  timezone: str | None = None
+  zone_cron: str | None = None
+  server_timezone: str = "UTC"
 
 
 class ConflictFile(BaseModel):

--- a/backend/tests/test_apps.py
+++ b/backend/tests/test_apps.py
@@ -300,6 +300,123 @@ def test_app_token_can_update_own_schedule_only(client, auth, monkeypatch):
   assert r.status_code == 403
 
 
+def test_schedule_update_with_timezone_materializes_and_declares(
+  client, auth, monkeypatch,
+):
+  """A timezone-owned schedule registers its MATERIALIZED server-local cron
+  plus the durable (timezone, zone_cron) identity; invalid zones and
+  non-daily expressions are rejected before any registration."""
+  calls = []
+
+  def fake_register(slug, schedule_expr, job_path, app_id=None,
+                    timezone=None, zone_cron=None):
+    calls.append((slug, schedule_expr, job_path.name, app_id,
+                  timezone, zone_cron))
+
+  monkeypatch.setattr("app.install._register_cron", fake_register)
+  monkeypatch.setattr(
+    "app.cron_tz.materialize_zone_cron",
+    lambda zone_cron, tz_name, **kw: "0 3 * * *",
+  )
+  source_dir = Path(get_settings().data_dir) / "apps" / "memory"
+  source_dir.mkdir(parents=True, exist_ok=True)
+  (source_dir / "fetch.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+  app_id = create_local_app(
+    client, auth, name="Memory", description="test", source_dir=source_dir,
+  )["id"]
+
+  r = client.post(
+    f"/api/apps/{app_id}/schedule",
+    json={"cron": "0 5 * * *", "job": "fetch.sh",
+          "timezone": "Europe/Belgrade"},
+    headers=auth,
+  )
+  assert r.status_code == 200, r.text
+  assert r.json() == {
+    "cron": "0 3 * * *", "job": "fetch.sh",
+    "timezone": "Europe/Belgrade", "zone_cron": "0 5 * * *",
+  }
+  assert calls == [
+    ("memory", "0 3 * * *", "fetch.sh", app_id,
+     "Europe/Belgrade", "0 5 * * *"),
+  ]
+
+  r = client.post(
+    f"/api/apps/{app_id}/schedule",
+    json={"cron": "0 5 * * *", "timezone": "Not/AZone"},
+    headers=auth,
+  )
+  assert r.status_code == 400
+  r = client.post(
+    f"/api/apps/{app_id}/schedule",
+    json={"cron": "0 5 * * 1", "timezone": "Europe/Belgrade"},
+    headers=auth,
+  )
+  assert r.status_code == 400
+  assert len(calls) == 1
+
+
+def test_reconcile_rematerializes_zone_owned_schedule(client, auth, db):
+  """Reconciliation recomputes a zone-owned entry from its durable identity —
+  the mechanism that reschedules it across a DST transition."""
+  source_dir = Path(get_settings().data_dir) / "apps" / "memory"
+  source_dir.mkdir(parents=True)
+  (source_dir / "fetch.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+  (source_dir / "init-cron.sh").write_text(
+    f'ENTRY="0 4 * * * {source_dir}/fetch.sh 56"\n'
+    'SCHEDULE_TZ="Europe/Belgrade"\n'
+    'SCHEDULE_SOURCE="0 5 * * *"\n',
+    encoding="utf-8",
+  )
+  app_id = create_local_app(
+    client, _service_auth(), name="Memory", description="test",
+    source_dir=source_dir,
+  )["id"]
+
+  from app.routes import apps as apps_module
+  calls = []
+
+  def fake_register(slug, schedule_expr, job_path, app_id=None,
+                    timezone=None, zone_cron=None):
+    calls.append((slug, schedule_expr, timezone, zone_cron))
+
+  # The offset changed since the entry was written (0 4 → materializes 0 3
+  # now): reconciliation must register the RECOMPUTED entry, not preserve
+  # the stale one.
+  with patch("app.install._register_cron", fake_register), \
+       patch("app.cron_tz.materialize_zone_cron",
+             lambda zone_cron, tz_name, **kw: "0 3 * * *"):
+    count, warnings = apps_module.reconcile_app_cron_supervision(db)
+
+  assert warnings == []
+  assert count == 1
+  assert calls == [("memory", "0 3 * * *", "Europe/Belgrade", "0 5 * * *")]
+
+
+def test_app_schedules_expose_zone_declaration(client, auth):
+  """A schedule owned in an IANA zone surfaces its durable identity."""
+  source_dir = Path(get_settings().data_dir) / "apps" / "memory"
+  source_dir.mkdir(parents=True)
+  (source_dir / "fetch.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+  (source_dir / "init-cron.sh").write_text(
+    f'ENTRY="0 3 * * * {source_dir}/fetch.sh 56"\n'
+    "# --- Zone-aware schedule identity (platform-managed).\n"
+    'SCHEDULE_TZ="Europe/Belgrade"\n'
+    'SCHEDULE_SOURCE="0 5 * * *"\n',
+    encoding="utf-8",
+  )
+  create_local_app(
+    client, _service_auth(), name="Memory", description="test",
+    source_dir=source_dir,
+  )
+  r = client.get("/api/apps/schedules", headers=auth)
+  assert r.status_code == 200, r.text
+  rows = r.json()
+  assert [(j["cron"], j["timezone"], j["zone_cron"]) for j in rows] == [
+    ("0 3 * * *", "Europe/Belgrade", "0 5 * * *"),
+  ]
+
+
 def test_platform_source_patch_rejected_and_store_identity_preserved(client, auth, db):
   from app import models
   data_dir = Path(get_settings().data_dir)
@@ -363,6 +480,7 @@ def test_app_schedules_are_readable_by_app_tokens(client, auth):
     headers={"Authorization": f"Bearer {token}"},
   )
   assert r.status_code == 200, r.text
+  from app import cron_tz
   assert r.json() == [{
     "id": 1,
     "name": "News",
@@ -370,6 +488,9 @@ def test_app_schedules_are_readable_by_app_tokens(client, auth):
     "cron": "0 10 * * *",
     "job": "fetch.sh",
     "next_run": None,
+    "timezone": None,
+    "zone_cron": None,
+    "server_timezone": cron_tz.server_timezone_name(),
   }]
 
 

--- a/backend/tests/test_cron_tz.py
+++ b/backend/tests/test_cron_tz.py
@@ -1,0 +1,138 @@
+"""Zone-aware schedule materialization — including DST boundaries.
+
+The durable schedule identity is (IANA timezone, zone-local daily cron);
+the crontab entry is a server-local materialization recomputed when either
+zone's UTC offset changes. These tests pin the conversion on both sides of
+the 2026 European transitions (spring forward 2026-03-29, fall back
+2026-10-25) and in both directions of ownership.
+"""
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from app import cron_tz
+
+UTC = ZoneInfo("UTC")
+BELGRADE = ZoneInfo("Europe/Belgrade")
+
+
+def test_parse_daily_cron_accepts_plain_daily():
+  assert cron_tz.parse_daily_cron("0 5 * * *") == (0, 5)
+  assert cron_tz.parse_daily_cron("30 23 * * *") == (30, 23)
+
+
+@pytest.mark.parametrize("expr", [
+  "0 5 * * 1",       # weekday-pinned
+  "0 5 1 * *",       # date-pinned
+  "*/5 5 * * *",     # stepped minute
+  "0 24 * * *",      # invalid hour
+  "60 5 * * *",      # invalid minute
+  "0 5 * *",         # too few fields
+  "",
+])
+def test_parse_daily_cron_rejects_non_daily(expr):
+  assert cron_tz.parse_daily_cron(expr) is None
+
+
+def test_materialize_summer_offset_on_utc_server():
+  # 2026-07-01: Belgrade is UTC+2 → 5:00 local = 3:00 server.
+  now = datetime(2026, 7, 1, 12, 0, tzinfo=UTC)
+  assert cron_tz.materialize_zone_cron(
+    "0 5 * * *", "Europe/Belgrade", now=now, server_tz=UTC,
+  ) == "0 3 * * *"
+
+
+def test_materialize_winter_offset_on_utc_server():
+  # 2026-12-01: Belgrade is UTC+1 → 5:00 local = 4:00 server.
+  now = datetime(2026, 12, 1, 12, 0, tzinfo=UTC)
+  assert cron_tz.materialize_zone_cron(
+    "0 5 * * *", "Europe/Belgrade", now=now, server_tz=UTC,
+  ) == "0 4 * * *"
+
+
+def test_materialize_across_spring_forward_boundary():
+  # Europe's 2026 spring transition: 2026-03-29 02:00 CET → 03:00 CEST.
+  before = datetime(2026, 3, 28, 12, 0, tzinfo=UTC)
+  after = datetime(2026, 3, 29, 12, 0, tzinfo=UTC)
+  materialize = lambda now: cron_tz.materialize_zone_cron(
+    "0 5 * * *", "Europe/Belgrade", now=now, server_tz=UTC,
+  )
+  assert materialize(before) == "0 4 * * *"   # +1 before the switch
+  assert materialize(after) == "0 3 * * *"    # +2 after — entry rescheduled
+
+
+def test_materialize_across_fall_back_boundary():
+  # Europe's 2026 fall transition: 2026-10-25 03:00 CEST → 02:00 CET.
+  before = datetime(2026, 10, 24, 12, 0, tzinfo=UTC)
+  after = datetime(2026, 10, 25, 12, 0, tzinfo=UTC)
+  materialize = lambda now: cron_tz.materialize_zone_cron(
+    "0 5 * * *", "Europe/Belgrade", now=now, server_tz=UTC,
+  )
+  assert materialize(before) == "0 3 * * *"
+  assert materialize(after) == "0 4 * * *"
+
+
+def test_materialize_when_server_itself_observes_dst():
+  # Server clock in Berlin, schedule owned in UTC: the SERVER side of the
+  # conversion moves at ITS transition, the schedule's identity does not.
+  berlin = ZoneInfo("Europe/Berlin")
+  materialize = lambda now: cron_tz.materialize_zone_cron(
+    "0 5 * * *", "UTC", now=now, server_tz=berlin,
+  )
+  assert materialize(datetime(2026, 7, 1, 12, 0, tzinfo=UTC)) == "0 7 * * *"
+  assert materialize(datetime(2026, 12, 1, 12, 0, tzinfo=UTC)) == "0 6 * * *"
+
+
+def test_materialize_wraps_across_the_day_boundary():
+  # 00:30 in Kathmandu (UTC+5:45) is 18:45 the previous day in UTC; a
+  # daily job simply wraps — date fields are '*' by contract.
+  now = datetime(2026, 7, 1, 12, 0, tzinfo=UTC)
+  assert cron_tz.materialize_zone_cron(
+    "30 0 * * *", "Asia/Kathmandu", now=now, server_tz=UTC,
+  ) == "45 18 * * *"
+
+
+def test_materialize_rejects_non_daily_and_unknown_zone():
+  now = datetime(2026, 7, 1, 12, 0, tzinfo=UTC)
+  with pytest.raises(ValueError):
+    cron_tz.materialize_zone_cron("0 5 * * 1", "UTC", now=now, server_tz=UTC)
+  with pytest.raises(ValueError):
+    cron_tz.materialize_zone_cron(
+      "0 5 * * *", "Not/AZone", now=now, server_tz=UTC,
+    )
+
+
+def test_parse_zone_declaration_round_trip():
+  text = (
+    "#!/bin/sh\n"
+    'ENTRY="0 3 * * * python3 /app/scripts/app-job-runner.py 4 '
+    '/data/apps/memory/fetch.sh"\n'
+    "# --- Zone-aware schedule identity (platform-managed).\n"
+    'SCHEDULE_TZ="Europe/Belgrade"\n'
+    'SCHEDULE_SOURCE="0 5 * * *"\n'
+  )
+  assert cron_tz.parse_zone_declaration(text) == (
+    "Europe/Belgrade", "0 5 * * *",
+  )
+
+
+@pytest.mark.parametrize("text", [
+  "",
+  'SCHEDULE_TZ="Europe/Belgrade"\n',                     # half a declaration
+  'SCHEDULE_SOURCE="0 5 * * *"\n',                       # half a declaration
+  'SCHEDULE_TZ="Nope"\nSCHEDULE_SOURCE="0 5 * * *"\n',   # unknown zone
+  'SCHEDULE_TZ="UTC"\nSCHEDULE_SOURCE="0 5 * * 1"\n',    # non-daily source
+])
+def test_parse_zone_declaration_rejects_incomplete(text):
+  assert cron_tz.parse_zone_declaration(text) is None
+
+
+def test_server_timezone_name_prefers_valid_tz_env(monkeypatch):
+  monkeypatch.setenv("TZ", "Europe/Belgrade")
+  assert cron_tz.server_timezone_name() == "Europe/Belgrade"
+  monkeypatch.setenv("TZ", "Total/Nonsense")
+  # Invalid TZ falls through to /etc/localtime or the UTC default —
+  # either way a valid IANA identifier comes back.
+  assert cron_tz.valid_timezone(cron_tz.server_timezone_name())


### PR DESCRIPTION
Follow-up to #290, redesigned per its review: the offset-snapshot fields (`tz_name`/`tz_offset_minutes`) are gone. The durable schedule identity is now an IANA timezone plus a zone-local daily cron, and the scheduler owns it end to end.

**Design**
- `POST /api/apps/{id}/schedule` accepts an optional `timezone` (IANA). The identity is declared as `SCHEDULE_TZ`/`SCHEDULE_SOURCE` lines in the app's `init-cron.sh` (parsed, never executed — same contract as `ENTRY`), written by the platform after the scaffold runs; the scaffold's own interface is unchanged.
- The crontab entry is that identity's server-local **materialization** (`app/cron_tz.py`), recomputed by the existing boot reconciliation and by an hourly in-process pass — so a DST transition in either zone explicitly reschedules the entry instead of drifting its wall time. The periodic pass only runs while a zone declaration exists.
- `GET /api/apps/schedules` exposes the durable identity (`timezone`, `zone_cron`) plus `server_timezone`, the server clock's own IANA name (TZ env, `/etc/localtime`, else UTC) — no abbreviations, no offsets.
- Only plain daily expressions (`m h * * *`) may carry a zone: shifting across an offset can cross a day boundary, which is well-defined daily and ambiguous for date-pinned expressions. Anything else is rejected with a 400.

**Tests** cover both 2026 European DST boundaries in both directions of ownership (zone-owned schedule on a UTC server; UTC-owned schedule on a DST-observing server), day-boundary wrap (UTC+5:45), declaration parsing incl. malformed halves, endpoint validation, and reconciliation re-materializing a stale entry from its declaration.

The companion app-memory PR feeds this from the schedule settings UI and degrades to server-local against an older backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)