### PR TITLE
Allow parallel contribution reviews

### DIFF
--- a/frontend/src/components/ChatView/ContributionReviewCard.jsx
+++ b/frontend/src/components/ChatView/ContributionReviewCard.jsx
@@ -20,11 +20,6 @@ import {
 } from './contributionReviewModel.js'
 import './ContributionReviewCard.css'
 
-// How long the post-send acknowledgement stays before clearing itself. Long
-// enough to read and tap through to GitHub, short enough that walking away never
-// leaves a stale box wedged above the composer.
-const SENT_VISIBLE_MS = 4000
-
 export default function ContributionReviewCard({ chatId, turnActive, onOpenApp }) {
   const queryClient = useQueryClient()
   const { data: apps } = appQueries.list.useQuery()
@@ -271,20 +266,13 @@ function useSwipeToDismiss(onDismiss) {
  * The acknowledgement after this card's own Send.
  *
  * It is an acknowledgement, NOT a permanent record — the Contribute app owns the
- * history and the chat reply carries the link. So it gets every exit the other
- * cards have (swipe, the band control) AND clears itself, because the first
- * version shipped with no exit at all and became an undismissable box above the
- * composer.
+ * history and the chat reply carries the link. It gets every explicit exit the
+ * other cards have (swipe and the band control), but no timed exit: the
+ * acknowledgement and its GitHub link stay available until the owner dismisses
+ * it or leaves the current chat surface.
  */
 function SentRow({ sent, onDismiss }) {
   const cardRef = useSwipeToDismiss(onDismiss)
-  const dismissRef = useRef(onDismiss)
-  dismissRef.current = onDismiss
-
-  useEffect(() => {
-    const timer = window.setTimeout(() => dismissRef.current?.(), SENT_VISIBLE_MS)
-    return () => window.clearTimeout(timer)
-  }, [])
 
   return (
     <div ref={cardRef} className="contrib-card contrib-card--sent" role="status">

--- a/frontend/src/components/ChatView/ContributionReviewCard.jsx
+++ b/frontend/src/components/ChatView/ContributionReviewCard.jsx
@@ -23,7 +23,7 @@ import './ContributionReviewCard.css'
 // How long the post-send acknowledgement stays before clearing itself. Long
 // enough to read and tap through to GitHub, short enough that walking away never
 // leaves a stale box wedged above the composer.
-const SENT_VISIBLE_MS = 12000
+const SENT_VISIBLE_MS = 4000
 
 export default function ContributionReviewCard({ chatId, turnActive, onOpenApp }) {
   const queryClient = useQueryClient()
@@ -56,13 +56,7 @@ export default function ContributionReviewCard({ chatId, turnActive, onOpenApp }
     wasActive.current = turnActive
   }, [turnActive, queryClient, queryKey])
 
-  const [busyId, setBusyId] = useState(null)
-  const [error, setError] = useState(null)
   const [sentRows, setSentRows] = useState([])
-  // State disables the buttons on the next render; the ref closes the smaller
-  // same-frame window too. One owner press can therefore claim exactly one
-  // record, even if another click lands before React has painted the lock.
-  const activeSendRef = useRef(null)
   // Dismissals are persisted, so this only forces the re-render; the stored
   // decision is what actually filters the list.
   const [dismissRevision, setDismissRevision] = useState(0)
@@ -80,11 +74,7 @@ export default function ContributionReviewCard({ chatId, turnActive, onOpenApp }
   if (!appId) return null
   if (panel.count === 0) return null
 
-  async function send(record) {
-    if (activeSendRef.current !== null) return
-    activeSendRef.current = record.id
-    setBusyId(record.id)
-    setError(null)
+  async function submit(record) {
     try {
       const res = await api.contributions.submit(appId, record.id, {
         autopilot: autopilotOnSend(data),
@@ -92,34 +82,32 @@ export default function ContributionReviewCard({ chatId, turnActive, onOpenApp }
       const body = await res.json().catch(() => null)
       if (!res.ok) {
         const detail = body?.detail?.message || body?.detail
-        setError({
-          id: record.id,
-          message: typeof detail === 'string'
+        return {
+          error: typeof detail === 'string'
             ? detail
             : 'Could not contribute this. Open Contribute for the details.',
-        })
-        return
+        }
       }
-      const sent = {
-        id: record.id,
-        number: body?.number ?? body?.record?.number ?? null,
-        url: body?.url || body?.record?.url || null,
-        repo: record.repo,
+      return {
+        sent: {
+          id: record.id,
+          number: body?.number ?? body?.record?.number ?? null,
+          url: body?.url || body?.record?.url || null,
+          repo: record.repo,
+        },
       }
-      setSentRows(rows => [
-        ...rows.filter(row => row.id !== sent.id),
-        sent,
-      ])
     } catch {
-      setError({
-        id: record.id,
-        message: 'Could not reach the server. Nothing was contributed.',
-      })
+      return { error: 'Could not reach the server. Nothing was contributed.' }
     } finally {
-      if (activeSendRef.current === record.id) activeSendRef.current = null
-      setBusyId(current => current === record.id ? null : current)
       queryClient.invalidateQueries({ queryKey, exact: true })
     }
+  }
+
+  function rememberSent(sent) {
+    setSentRows(rows => [
+      ...rows.filter(row => row.id !== sent.id),
+      sent,
+    ])
   }
 
   return (
@@ -175,10 +163,9 @@ export default function ContributionReviewCard({ chatId, turnActive, onOpenApp }
             record={record}
             connected={data?.connected !== false}
             autopilot={autopilotOnSend(data)}
-            busy={busyId === record.id}
-            locked={busyId !== null}
-            error={error?.id === record.id ? error.message : null}
-            onSend={send}
+            showPayoff={!grouped}
+            onSubmit={submit}
+            onSent={rememberSent}
             onOpenContribute={onOpenContribute}
             onDismiss={onDismiss}
           />
@@ -397,14 +384,38 @@ function StackReviewRow({ item, onOpenContribute, onDismiss }) {
 }
 
 function ReviewRow({
-  record, connected, autopilot, busy, locked, error, onSend, onOpenContribute,
-  onDismiss,
+  record, connected, autopilot, showPayoff, onSubmit, onSent,
+  onOpenContribute, onDismiss,
 }) {
   const [open, setOpen] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState(null)
+  // Each row owns its own in-flight guard. That keeps sibling rows independent
+  // while closing the same-frame double-click window for this record.
+  const activeSendRef = useRef(false)
   const blocker = sendBlocker(record, { connected })
   const diffStat = diffStatSummary(record.diff_stat)
   const submitting = record.status === 'submitting'
   const cardRef = useSwipeToDismiss(onDismiss)
+
+  async function send() {
+    if (activeSendRef.current) return
+    activeSendRef.current = true
+    setBusy(true)
+    setError(null)
+    let outcome
+    try {
+      outcome = await onSubmit(record)
+    } finally {
+      activeSendRef.current = false
+      setBusy(false)
+    }
+    if (outcome?.error) {
+      setError(outcome.error)
+    } else if (outcome?.sent) {
+      onSent(outcome.sent)
+    }
+  }
 
   return (
     <div
@@ -436,7 +447,7 @@ function ReviewRow({
 
       {/* The payoff, but never next to a problem: a blocked review needs the
           reason, not encouragement. */}
-      {!blocker && !error && !submitting && (
+      {showPayoff && !blocker && !error && !submitting && (
         <p className="contrib-card__payoff">{payoffLine(record)}</p>
       )}
       {autopilot && !blocker && !error && !submitting && (
@@ -451,8 +462,8 @@ function ReviewRow({
         <button
           type="button"
           className="contrib-card__send"
-          disabled={locked || submitting || !!blocker}
-          onClick={() => onSend(record)}
+          disabled={busy || submitting || !!blocker}
+          onClick={send}
         >
           {submitting || busy ? 'Contributing…' : contributeLabel(record)}
         </button>

--- a/frontend/src/components/ChatView/__tests__/contributionReviewModel.test.js
+++ b/frontend/src/components/ChatView/__tests__/contributionReviewModel.test.js
@@ -420,10 +420,10 @@ test('the dismissal gesture is claimed with a non-passive touchmove', () => {
 })
 
 // The first version of the acknowledgement had NO exit: no swipe (its handlers
-// lived in the other card shape), no control in a band it never rendered, and no
-// timeout. It became an undismissable box wedged above the composer. Every card
-// shape must be dismissible, and this one must also clear itself.
-test('the post-send acknowledgement is dismissible and self-clearing', () => {
+// lived in the other card shape) and no control in a band it never rendered.
+// Every card shape must remain explicitly dismissible, while the acknowledgement
+// and its interactive GitHub link must never disappear on a timer.
+test('the post-send acknowledgement persists until an explicit user or navigation exit', () => {
   const sentRow = cardSrc.slice(
     cardSrc.indexOf('function SentRow('),
     cardSrc.indexOf('function StackReviewRow('),
@@ -434,9 +434,11 @@ test('the post-send acknowledgement is dismissible and self-clearing', () => {
   // A band with a real dismiss control.
   assert.match(sentRow, /className="contrib-card__badge"/)
   assert.match(sentRow, /className="contrib-card__dismiss"/)
-  // And it does not outlive its usefulness.
-  assert.match(sentRow, /setTimeout\(\(\) => dismissRef\.current\?\.\(\), SENT_VISIBLE_MS\)/)
-  assert.match(cardSrc, /const SENT_VISIBLE_MS = 4000/)
+  // Interactive content stays until one of those user exits or component
+  // navigation owns its lifecycle; elapsed time never removes it.
+  assert.doesNotMatch(sentRow, /setTimeout|setInterval/)
+  assert.doesNotMatch(cardSrc, /SENT_VISIBLE_MS/)
+  assert.match(sentRow, /View on GitHub/)
 })
 
 // One gesture implementation for every card shape here. Two copies is how the

--- a/frontend/src/components/ChatView/__tests__/contributionReviewModel.test.js
+++ b/frontend/src/components/ChatView/__tests__/contributionReviewModel.test.js
@@ -227,13 +227,20 @@ test('the grouped panel survives pending-to-contributed transitions', () => {
   assert.match(cardSrc, /rows\.filter\(row => row\.id !== sent\.id\)/)
 })
 
-test('one card press can own only one public submission at a time', () => {
-  assert.match(cardSrc, /const activeSendRef = useRef\(null\)/)
-  assert.match(cardSrc, /if \(activeSendRef\.current !== null\) return/)
-  assert.match(cardSrc, /activeSendRef\.current = record\.id/)
-  assert.match(cardSrc, /locked=\{busyId !== null\}/)
-  assert.match(cardSrc, /disabled=\{locked \|\| submitting \|\| !!blocker\}/)
+test('independent cards can submit in parallel without duplicating one record', () => {
+  assert.match(cardSrc, /function ReviewRow\(/)
+  assert.match(cardSrc, /const activeSendRef = useRef\(false\)/)
+  assert.match(cardSrc, /if \(activeSendRef\.current\) return/)
+  assert.match(cardSrc, /activeSendRef\.current = true/)
+  assert.match(cardSrc, /const \[busy, setBusy\] = useState\(false\)/)
+  assert.match(cardSrc, /disabled=\{busy \|\| submitting \|\| !!blocker\}/)
+  assert.doesNotMatch(cardSrc, /busyIds|errorsById/)
   assert.match(cardSrc, /item => item\.kind !== 'record' \|\| !sentIds\.has\(item\.record\.id\)/)
+})
+
+test('a grouped panel does not repeat the same audience payoff on every card', () => {
+  assert.match(cardSrc, /showPayoff=\{!grouped\}/)
+  assert.match(cardSrc, /showPayoff && !blocker && !error && !submitting/)
 })
 
 // The action names the value of contributing, not the mechanism of sending, and
@@ -429,7 +436,7 @@ test('the post-send acknowledgement is dismissible and self-clearing', () => {
   assert.match(sentRow, /className="contrib-card__dismiss"/)
   // And it does not outlive its usefulness.
   assert.match(sentRow, /setTimeout\(\(\) => dismissRef\.current\?\.\(\), SENT_VISIBLE_MS\)/)
-  assert.match(cardSrc, /const SENT_VISIBLE_MS = \d+/)
+  assert.match(cardSrc, /const SENT_VISIBLE_MS = 4000/)
 })
 
 // One gesture implementation for every card shape here. Two copies is how the
@@ -441,6 +448,6 @@ test('every card shape shares one swipe implementation', () => {
 })
 
 test('a failed send is shown only on the record that failed', () => {
-  assert.match(cardSrc, /setError\(\{\s*id: record\.id,/)
-  assert.match(cardSrc, /error=\{error\?\.id === record\.id \? error\.message : null\}/)
+  assert.match(cardSrc, /const \[error, setError\] = useState\(null\)/)
+  assert.match(cardSrc, /setError\(outcome\.error\)/)
 })


### PR DESCRIPTION
## Summary

- keep each contribution card actionable while another is publishing
- keep duplicate protection, progress, and errors inside the card that owns them
- avoid repeating the audience-benefit line across grouped cards
- shorten the contributed acknowledgement from 12 seconds to 4 seconds

## Context

This refines #302, which preserved grouped review state with one global send lock. The full Contribute app already scopes publishing progress to each card; this change gives the compact chat panel the same independent behavior. The submission path still claims each record individually and safely queues work that touches the same source.

The compact grouped-panel foundation from #286 and the successful-acknowledgement behavior from #301 remain intact; only send-state ownership and repeated copy change.

## Testing

- 2,108 frontend library tests passed
- 66 frontend hook tests passed
- production frontend build passed
- verified a grouped phone-width state with one contribution publishing and another still available