### PR TITLE
Keep the activity error-window test independent of wall-clock date

### DIFF
--- a/backend/tests/test_activity.py
+++ b/backend/tests/test_activity.py
@@ -135,7 +135,10 @@ def test_storage_write_debounce_per_key():
 
 
 def test_request_error_storm_appends_only_one_summary_per_window():
-  start = datetime(2026, 7, 21, 12, 0, tzinfo=timezone.utc)
+  # This test owns the minute-bucket boundary, not weekly log rotation. Keep
+  # its simulated burst near the real write clock so the active file cannot
+  # rotate merely because a fixed fixture date aged past ROTATION_DAYS.
+  start = datetime.now(timezone.utc)
   for offset_ms in range(1000):
     activity.record_request_error(
       "GET", "/api/storage/apps/{app_id}/{path:path}", 404, 66,


### PR DESCRIPTION
## Problem

`test_request_error_storm_appends_only_one_summary_per_window` anchored its simulated request burst to July 21, 2026. The activity log rotates when its first event reaches seven days old, so after July 28 at 12:00 UTC the second summary moved into a fresh active file and the assertion saw `[1]` instead of `[1000, 1]`. Unchanged `main` therefore began failing based only on the date the suite ran.

## Fix

Start this test's simulated minute bucket at the current UTC time. That keeps it inside the active log's weekly rotation window and isolates the contract the test owns: one aggregated request-error summary per minute. The separate rotation tests retain explicit old timestamps and continue covering weekly rollover.

## Verification

- Reproduced the focused failure on unchanged current `main`: `[1]` versus `[1000, 1]`.
- Focused regression passed after the change.
- Complete activity suite: 54 passed.
- `git diff --check` passed.