### PR TITLE
Keep multiline Q&A answers pinned during growth

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -619,12 +619,15 @@ and attaches their rule ids to new diagnostic chats. The Playwright lock-in spec
   escape hatch for any interrupted no-scroll gesture.
   A marked Q&A custom-answer field is the deliberate exception to "ordinary
   typing cannot scroll": changing its value can grow the field and cause the
-  browser to move the transcript to keep the native caret visible. From
-  `beforeinput` through one complete rendered frame, that mutation uses the
-  same reader-ownership gate as a possible scroll. If no scroll lands, layout
-  resumes immediately after that frame; if one does, the ordinary quiet-settle
-  path records the resulting hold. The controller must not restore a stale
-  anchor between those two outcomes.
+  browser to move the transcript to keep the native caret visible. Only an
+  ordinary `ANCHOR_AT` reading hold yields from `beforeinput` through one
+  complete rendered frame; if no scroll lands, layout resumes immediately
+  after that frame, and if one does, the ordinary quiet-settle path records the
+  resulting hold. Stronger location contracts keep layout ownership:
+  `FOLLOW_BOTTOM` absorbs the new line in its normal ResizeObserver pass, while
+  pins, reserved-tail holds, and the question-submission overlay remain fixed.
+  The controller must not restore a stale anchor between those two outcomes or
+  interrupt live tail-follow with a delayed snap.
 - **R5a — Attention nudges reveal the usable tail.** Tapping an offscreen question
   or paused-turn nudge is an explicit one-shot reading action: it lands at the
   physical tail, including the list's composer-clearance padding, so the card's

--- a/frontend/src/components/ChatView/ChatInputBar.jsx
+++ b/frontend/src/components/ChatView/ChatInputBar.jsx
@@ -102,7 +102,7 @@ import {
 import { filePasteNeedsDefaultPrevented, pastedFiles } from './pasteUpload.js'
 import { hasSendablePayload } from './composerSubmission.js'
 import {
-  composerUsesNativeSizing,
+  textareaUsesNativeSizing,
   syncComposerTallClass,
 } from './composerTextareaSizing.js'
 
@@ -588,7 +588,7 @@ export default function ChatInputBar({
     const textarea = inputRef?.current
     if (
       !textarea
-      || !composerUsesNativeSizing()
+      || !textareaUsesNativeSizing()
       || typeof ResizeObserver === 'undefined'
     ) return undefined
     const observer = new ResizeObserver(entries => {

--- a/frontend/src/components/ChatView/QuestionCard.css
+++ b/frontend/src/components/ChatView/QuestionCard.css
@@ -234,11 +234,16 @@
   font-family: inherit;
   line-height: 1.45;
   outline: none;
-  overflow-y: hidden;
+  /* Unknown declarations are ignored, so older browsers fall through to the
+     measured QuestionCard.jsx path without a second CSS branch. */
+  field-sizing: content;
+  max-height: 180px;
+  overflow-y: auto;
   resize: none;
   box-sizing: border-box;
   transition: border-color .15s, box-shadow .15s;
 }
+
 .qcard__input::placeholder {
   color: var(--muted);
   opacity: .85;

--- a/frontend/src/components/ChatView/QuestionCard.jsx
+++ b/frontend/src/components/ChatView/QuestionCard.jsx
@@ -6,6 +6,7 @@ import {
   readQuestionDraft,
   writeQuestionDraft,
 } from './questionDraft.js'
+import { textareaUsesNativeSizing } from './composerTextareaSizing.js'
 
 
 function resolveAnswer(answer, otherText) {
@@ -22,7 +23,7 @@ const CUSTOM_ANSWER_MAX_HEIGHT = 180
 
 
 function resizeCustomAnswer(textarea) {
-  if (!textarea) return
+  if (!textarea || textareaUsesNativeSizing()) return
   textarea.style.height = 'auto'
   const contentHeight = textarea.scrollHeight
   textarea.style.height = `${Math.min(contentHeight, CUSTOM_ANSWER_MAX_HEIGHT)}px`
@@ -43,25 +44,23 @@ function CustomAnswerArea({
 }) {
   const textareaRef = useRef(null)
 
-  // Re-measure both while writing and when a live answer becomes its
-  // confirmed transcript value. The field therefore keeps the same natural
-  // content height instead of collapsing during the submission handoff.
+  // The fallback re-measures both while writing and when a live answer becomes
+  // its confirmed transcript value. Native content sizing takes this no-op
+  // path and keeps the same natural height through the submission handoff.
   useLayoutEffect(() => {
     resizeCustomAnswer(textareaRef.current)
   }, [value])
 
-  // scrollHeight depends on the field's WIDTH, so the layout-phase measure
-  // above is only correct if the field is already at its final width. During
-  // the live→durable answered-state handoff the card remounts and that measure
-  // can land at a pre-layout width: a one-paragraph answer then wraps into far
-  // more lines than the settled width needs, blows past CUSTOM_ANSWER_MAX_HEIGHT,
-  // and freezes at that clamp — a tall box holding two lines of text. Observe
-  // width and re-measure whenever it settles or later changes so the height
-  // self-corrects. The width guard makes our own height writes (which fire the
-  // observer with an unchanged width) no-ops, so there is no resize loop.
+  // Older browsers still need measured fallback sizing. scrollHeight depends
+  // on WIDTH, so re-measure when the field settles or later changes width. The
+  // guard makes our own height write a no-op resize instead of a loop.
   useEffect(() => {
     const textarea = textareaRef.current
-    if (!textarea || typeof ResizeObserver === 'undefined') return undefined
+    if (
+      !textarea
+      || textareaUsesNativeSizing()
+      || typeof ResizeObserver === 'undefined'
+    ) return undefined
     let lastWidth = -1
     const observer = new ResizeObserver(() => {
       const width = textarea.clientWidth

--- a/frontend/src/components/ChatView/__tests__/composerTextareaSizing.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerTextareaSizing.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 
 import {
-  composerUsesNativeSizing,
+  textareaUsesNativeSizing,
   reconcileComposerTextarea,
   resetComposerTextarea,
   resizeComposerTextarea,
@@ -89,13 +89,13 @@ test('authoritative empty state clears stale native inline geometry', () => {
 })
 
 test('native content sizing is capability-gated without browser sniffing', () => {
-  assert.equal(composerUsesNativeSizing({
+  assert.equal(textareaUsesNativeSizing({
     supports: (property, value) => (
       property === 'field-sizing' && value === 'content'
     ),
   }), true)
-  assert.equal(composerUsesNativeSizing({ supports: () => false }), false)
-  assert.equal(composerUsesNativeSizing(null), false)
+  assert.equal(textareaUsesNativeSizing({ supports: () => false }), false)
+  assert.equal(textareaUsesNativeSizing(null), false)
 })
 
 test('native resize observation owns only the tall alignment class', () => {

--- a/frontend/src/components/ChatView/__tests__/questionCardState.test.js
+++ b/frontend/src/components/ChatView/__tests__/questionCardState.test.js
@@ -30,12 +30,14 @@ test('unanswered question cards do not have a stale gray state', () => {
     'the custom answer should publish its native caret-scroll ownership')
   assert.doesNotMatch(component, /onInput=\{e => resizeCustomAnswer/,
     'one post-commit measurement should own growth instead of resizing twice per edit')
+  assert.match(component, /if \(!textarea \|\| textareaUsesNativeSizing\(\)\) return/,
+    'current browsers should not run a per-character height measurement cycle')
   assert.match(component, /textarea\.style\.height = 'auto'[\s\S]*?Math\.min\(contentHeight, CUSTOM_ANSWER_MAX_HEIGHT\)/,
-    'the custom answer should grow with its content up to the phone-safe cap')
+    'the older-browser fallback should grow with content up to the phone-safe cap')
   assert.match(component, /useLayoutEffect\(\(\) => \{\s*resizeCustomAnswer\(textareaRef\.current\)\s*\}, \[value\]\)/,
     'confirmed answer values should retain their natural content height')
-  assert.match(component, /new ResizeObserver\(\(\) => \{[\s\S]*?const width = textarea\.clientWidth[\s\S]*?if \(width === lastWidth\) return[\s\S]*?resizeCustomAnswer\(textarea\)/,
-    'settled width changes should trigger one fresh content-height measurement')
+  assert.match(component, /textareaUsesNativeSizing\(\)[\s\S]*?new ResizeObserver\(\(\) => \{[\s\S]*?const width = textarea\.clientWidth[\s\S]*?if \(width === lastWidth\) return[\s\S]*?resizeCustomAnswer\(textarea\)/,
+    'only the measured fallback should observe width changes')
   assert.match(component, /observer\.observe\(textarea\)[\s\S]*?return \(\) => observer\.disconnect\(\)/,
     'the width observer should be released with the answered card')
   assert.match(component, /e\.key === 'Enter' && \(e\.metaKey \|\| e\.ctrlKey\)/,
@@ -67,7 +69,7 @@ test('question card css has no stale styling hook', () => {
     'expiration status styling should not come back')
   assert.match(css, /\.qcard__input:disabled\s*\{[\s\S]*?color:\s*var\(--muted\);[\s\S]*?-webkit-text-fill-color:\s*var\(--muted\);[\s\S]*?\}/,
     'a submitted custom answer should visibly gray out in every browser')
-  assert.match(css, /\.qcard__input\s*\{[\s\S]*?width:\s*100%;[\s\S]*?min-height:\s*38px;[\s\S]*?overflow-y:\s*hidden;[\s\S]*?resize:\s*none;/,
+  assert.match(css, /\.qcard__input\s*\{[\s\S]*?width:\s*100%;[\s\S]*?min-height:\s*38px;[\s\S]*?field-sizing:\s*content;[\s\S]*?overflow-y:\s*auto;[\s\S]*?resize:\s*none;/,
     'the custom answer should span the card and begin as a single growing line')
   assert.match(css, /\.qcard__submit-error\s*\{/,
     'a failed answer should keep its retry notice attached to the card')
@@ -91,8 +93,8 @@ test('question editing lets native caret movement settle before layout reclaims 
   )
   assert.match(
     scrollMode,
-    /scheduleQuestionEditNoScrollRelease[\s\S]*?requestAnimationFrame\(\(\) => \{[\s\S]*?requestAnimationFrame\(\(\) => \{[\s\S]*?releasePendingGesture/,
-    'a no-scroll edit should yield one rendered frame before layout resumes',
+    /onQuestionEditMutation[\s\S]*?!isOrdinaryReadingHold\(modeRef\.current\)\) return[\s\S]*?onUserInput\(event\)/,
+    'tail-follow and other stronger modes must keep layout ownership while the field grows',
   )
   assert.match(
     scrollMode,

--- a/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
+++ b/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
@@ -616,6 +616,13 @@ test('question editing rebases only an ordinary held viewport to native caret mo
     { kind: 'PIN_USER_MSG', cid: 'c-1' },
     { kind: 'HOLD_RESERVED_TAIL', cid: 'c-1' },
     { kind: 'FOLLOW_BOTTOM' },
+    {
+      kind: 'ANCHOR_AT',
+      key: 'question-row',
+      offset: 84,
+      questionSubmitViewportH: 600,
+      questionSubmitBaseMode: { kind: 'FOLLOW_BOTTOM' },
+    },
   ]) {
     assert.equal(
       modeForQuestionEditingViewportChange(strongerMode, caretHold),

--- a/frontend/src/components/ChatView/composerTextareaSizing.js
+++ b/frontend/src/components/ChatView/composerTextareaSizing.js
@@ -6,7 +6,7 @@ function composerPill(textarea) {
   return textarea?.closest?.('.chat__pill') || null
 }
 
-export function composerUsesNativeSizing(css = globalThis.CSS) {
+export function textareaUsesNativeSizing(css = globalThis.CSS) {
   // An injected CSS object keeps the capability boundary directly testable.
   // Cache only the real browser verdict; tests and non-browser runtimes should
   // not freeze a synthetic result for later calls.
@@ -46,7 +46,7 @@ export function resizeComposerTextarea(textarea, value = textarea?.value) {
   // document layout, whose cost grows with every mounted drawer/transcript
   // row. ResizeObserver in ChatInputBar updates the tall alignment only when
   // the browser reports an actual size change.
-  if (composerUsesNativeSizing()) return 0
+  if (textareaUsesNativeSizing()) return 0
 
   // Empty is a semantic one-line state, not a geometry question. During a
   // multi-pane mount / foreground transition Chromium can briefly report an
@@ -75,7 +75,7 @@ export function resizeComposerTextarea(textarea, value = textarea?.value) {
 /** Collapse immediately while React is still committing an empty value. */
 export function resetComposerTextarea(textarea) {
   if (!textarea?.style) return
-  textarea.style.height = composerUsesNativeSizing() ? '' : 'auto'
+  textarea.style.height = textareaUsesNativeSizing() ? '' : 'auto'
   composerPill(textarea)?.classList?.remove?.('chat__pill--tall')
 }
 

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -663,13 +663,20 @@ export function modeForViewportChange(mode, wasNearScrollBottom, anchorMode = nu
 }
 
 
+/** The plain reading-position hold, excluding the question-submission overlay
+ * that uses the same ANCHOR_AT shape with a stronger transient contract. */
+export function isOrdinaryReadingHold(mode) {
+  return mode?.kind === 'ANCHOR_AT'
+    && !Number.isFinite(mode.questionSubmitViewportH)
+}
+
 /** A focused, content-growing question field gives the browser temporary
  * ownership of caret visibility. If that native adjustment moved an ordinary
  * held viewport, rebase the hold to what is visible now instead of restoring
- * the stale pre-edit anchor. Send pins, reserved-tail holds, and live following
- * keep their stronger contracts and therefore pass through unchanged. */
+ * the stale pre-edit anchor. Send pins, reserved-tail holds, live following,
+ * and the submission overlay keep their stronger contracts. */
 export function modeForQuestionEditingViewportChange(mode, anchorMode = null) {
-  if (mode?.kind !== 'ANCHOR_AT' || !anchorMode) return mode
+  if (!isOrdinaryReadingHold(mode) || !anchorMode) return mode
   if (mode.key === anchorMode.key
       && Math.abs(mode.offset - anchorMode.offset) <= 0.5) return mode
   return anchorMode
@@ -2016,6 +2023,10 @@ export default function useScrollMode({
     const onQuestionEditMutation = (event) => {
       if (!questionEditField(event.target)) return
       questionEditSessionRef.current = true
+      // Stronger modes already know where this resize belongs. In particular,
+      // FOLLOW_BOTTOM must absorb the new line in the same ResizeObserver pass
+      // instead of yielding for two painted frames and then snapping back.
+      if (!isOrdinaryReadingHold(modeRef.current)) return
       if (layoutMayOwnScroll(
         gestureWindowUntilRef.current,
         performance.now(),


### PR DESCRIPTION
## Summary
- use browser-owned content sizing for Q&A custom answers when supported, with the existing measured fallback for older browsers
- let bottom-follow and stronger pinned modes retain scroll ownership while the field grows
- keep caret-driven rebasing for ordinary held reading positions

## Why
When a custom answer gained a visual line at the bottom, each edit could collapse and remeasure the field while the scroll controller yielded for caret movement. The transcript remained visibly off the tail for several frames before snapping back.

## Testing
- `npm test` (2,173 tests)
- `npm run build`
- rendered traces at phone and 1512×861 viewports; growth returned to the tail within the same render cycle