### PR TITLE
Match tiled pane density to focused chrome

### DIFF
--- a/frontend/src/components/Shell/__tests__/paneModel.test.js
+++ b/frontend/src/components/Shell/__tests__/paneModel.test.js
@@ -654,20 +654,20 @@ test('projectLayout returns the single-pane sentinel for a one-leaf tree', () =>
   }
 })
 
-test('projectLayout wide: a row split fills the box with a gap and one divider', () => {
+test('projectLayout wide: a row split fills the edge-to-edge box with a gap and divider', () => {
   const ws = twoPaneWs('right')     // layout: s? row a=p0 b=pNew
   const [left, right] = paneModel.projectLayout(ws, 'wide', { w: 1000, h: 700 }).visibleLeaves
   const proj = paneModel.projectLayout(ws, 'wide', { w: 1000, h: 700 })
   const L = proj.rects[left]
   const R = proj.rects[right]
-  assert.equal(L.x, paneModel.OUTER_MARGIN, 'left starts at the outer margin')
-  assert.equal(L.y, paneModel.OUTER_MARGIN)
-  assert.equal(L.h, 700 - 2 * paneModel.OUTER_MARGIN, 'full box height')
+  assert.equal(L.x, 0, 'left starts at the content edge')
+  assert.equal(L.y, 0)
+  assert.equal(L.h, 700, 'full box height')
   assert.equal(R.h, L.h)
   assert.equal(R.x, L.x + L.w + paneModel.PANE_GAP, 'right sits a gap past the left')
   assert.equal(
-    L.w + paneModel.PANE_GAP + R.w, 1000 - 2 * paneModel.OUTER_MARGIN,
-    'the two panes plus the gap fill the inset box',
+    L.w + paneModel.PANE_GAP + R.w, 1000,
+    'the two panes plus the gap fill the content box',
   )
   assert.equal(proj.dividers.length, 1)
   const d = proj.dividers[0]
@@ -1391,13 +1391,12 @@ test('projectLayout clamps a dragged ANCESTOR ratio against child SUBTREE minima
   assert.ok(proj.rects.p2.w >= paneModel.MIN_PANE_W, `p2 ${proj.rects.p2.w} >= ${paneModel.MIN_PANE_W}`)
 })
 
-test('canSplit judges the first split against the POST-inset box, not the full rect', () => {
+test('canSplit judges the first split against the edge-to-edge post-split box', () => {
   const ws = paneModel.seedFromFlatTabs([makeTab('chat', 'a')])
-  // 407px-high phone: (407-7)/2 == 200 looks OK, but after the multi-leaf inset
-  // (391-7)/2 == 192 < MIN_PANE_H, so the split must NOT be offered (finding E-ii).
-  assert.equal(paneModel.canSplit(ws, 'p0', 'top', 'phone', { w: 400, h: 407 }), false)
-  assert.equal(paneModel.canSplit(ws, 'p0', 'bottom', 'phone', { w: 400, h: 407 }), false)
-  // A taller phone clears MIN_PANE_H even after the inset.
+  // With no outer inset, 407px is the exact first legal height:
+  // (407 - 7px inter-pane gap) / 2 == MIN_PANE_H.
+  assert.equal(paneModel.canSplit(ws, 'p0', 'top', 'phone', { w: 400, h: 406 }), false)
+  assert.equal(paneModel.canSplit(ws, 'p0', 'bottom', 'phone', { w: 400, h: 407 }), true)
   assert.equal(paneModel.canSplit(ws, 'p0', 'bottom', 'phone', { w: 400, h: 520 }), true)
 })
 

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -724,6 +724,20 @@ test('the pane focus action uses one unambiguous accessible state contract', () 
     'a button whose label changes with the action must not also announce a toggle state')
 })
 
+test('the pane focus action stays compact at the far edge and reachable on overflow', () => {
+  const stripRule = css.match(/\.workspace__strip\s*\{[\s\S]*?\n\}/)?.[0] || ''
+  const focusRule = css.match(/\.workspace__pane-focus\s*\{[\s\S]*?\n\}/)?.[0] || ''
+  assert.match(stripRule, /padding-inline-end:\s*0/,
+    'the strip owns removal of its trailing gutter')
+  assert.match(focusRule, /position:\s*sticky/)
+  assert.match(focusRule, /right:\s*0/)
+  assert.match(focusRule, /flex:\s*0 0 28px/)
+  assert.match(focusRule, /margin-left:\s*auto/,
+    'free strip width belongs to the tabs; the focus action stays at the far edge')
+  assert.doesNotMatch(focusRule, /margin-right|translateX/,
+    'the control should not compensate for padding owned by its strip')
+})
+
 test('overflowing strips keep native pan and add a no-chrome wheel path', () => {
   assert.match(paneStrip, /export function scrollStripWheel\(e\)/)
   assert.match(paneStrip, /Math\.abs\(e\.deltaX\) >= Math\.abs\(e\.deltaY\)/)

--- a/frontend/src/components/Shell/paneModel.js
+++ b/frontend/src/components/Shell/paneModel.js
@@ -45,10 +45,9 @@ export const COMPACT_MIN_W = 700
 export const COMPACT_MIN_H = 520
 
 // Render geometry (pixels are a RENDER concern — the model never stores them).
-// PANE_GAP sits between two sibling panes and is where a divider is drawn;
-// OUTER_MARGIN insets the whole tiled area from the content-box edge.
+// PANE_GAP sits between two sibling panes and is where a divider is drawn.
+// Tiled and focused panes both use the full content rect edge-to-edge.
 export const PANE_GAP = 7
-export const OUTER_MARGIN = 8
 
 // Height of a per-pane tab strip. A pane's CONTENT rect is its pane rect minus
 // this strip row (design §2). The renderer and the divider drag both subtract
@@ -1284,16 +1283,6 @@ function normalizeRect(rect) {
   }
 }
 
-// Inset a rect by m on every side — the tiled area's outer margin.
-function insetRect(rect, m) {
-  return {
-    x: rect.x + m,
-    y: rect.y + m,
-    w: Math.max(0, rect.w - 2 * m),
-    h: Math.max(0, rect.h - 2 * m),
-  }
-}
-
 // A ratio-patched COPY of the tree for the divider drag preview — the renderer
 // re-projects each frame with the dragged split's live ratio without a reducer
 // dispatch (design §2: imperative, React-free per frame). Pure; ws untouched.
@@ -1415,7 +1404,7 @@ export function modeForRect({ w, h } = {}) {
 // - EXACTLY ONE visible leaf is the pixel-identical single-pane sentinel: rects
 //   is the full contentRect and dividers is empty. The renderer branches on
 //   `visibleLeaves.length === 1` to emit today's DOM verbatim (no pane chrome).
-// - 'wide'    → all leaves, full tree walk, gap + outer margin, a divider per
+// - 'wide'    → all leaves, full edge-to-edge tree walk with a gap + divider per
 //               split.
 // - 'compact' → the focused leaf + its immediate-parent split's sibling (first
 //               in-order leaf of the sibling subtree), laid along the parent's
@@ -1441,7 +1430,7 @@ export function projectLayout(ws, mode, contentRect, ratioOverride = null) {
   }
 
   const tree = ratioOverride ? withRatioOverride(ws.layout, ratioOverride) : ws.layout
-  const box = insetRect(content, OUTER_MARGIN)
+  const box = content
 
   // Wide renders EVERY leaf — but only while the box can still honor the pane
   // minimums. A 4-pane tree built legally at 1400px, shrunk to 960px, cannot fit
@@ -1516,11 +1505,6 @@ export function canSplit(ws, paneId, edge, mode, contentRect) {
   const projected = projectLayout(ws, mode, content)
   let rect = projected.rects[paneId]
   if (!rect) return false
-  // Going 1 leaf → 2 introduces the outer margin the single-pane projection
-  // omits (it returns the full content rect). Judge feasibility against the
-  // POST-split usable box, else a first split is offered that then lands
-  // children below the minimum once the inset applies (finding E-ii).
-  if (projected.visibleLeaves.length <= 1) rect = insetRect(content, OUTER_MARGIN)
   const row = edge === 'left' || edge === 'right'
   if (row) {
     const childW = (rect.w - PANE_GAP) / 2
@@ -1535,7 +1519,7 @@ export function canSplit(ws, paneId, edge, mode, contentRect) {
 // whole tree in a new split on `edge` is allowed: within MAX_PANES / MAX_DEPTH
 // (a root split adds ONE level above every existing leaf, so it needs
 // depthOf(layout) + 1 ≤ MAX_DEPTH), permitted by the mode (phone → top/bottom
-// only), and each half of the inset content box clears MIN_PANE_W × MIN_PANE_H.
+// only), and each half of the full content box clears MIN_PANE_W × MIN_PANE_H.
 // The drag layer greys the zone out on false — a cap or minimum is felt as "no
 // target", never an error, exactly like canSplit.
 export function canRootSplit(ws, edge, mode, contentRect) {
@@ -1545,7 +1529,7 @@ export function canRootSplit(ws, edge, mode, contentRect) {
   const leaves = leafIds(ws.layout).filter(id => ws.panes[id])
   if (leaves.length >= MAX_PANES) return false
   if (depthOf(ws.layout) + 1 > MAX_DEPTH) return false
-  const box = insetRect(normalizeRect(contentRect), OUTER_MARGIN)
+  const box = normalizeRect(contentRect)
   const row = edge === 'left' || edge === 'right'
   if (row) {
     const childW = (box.w - PANE_GAP) / 2

--- a/frontend/src/components/Shell/workspace.css
+++ b/frontend/src/components/Shell/workspace.css
@@ -178,6 +178,7 @@
 .workspace__strip {
   position: absolute;
   pointer-events: auto;
+  padding-inline-end: 0;
   border-radius: 8px 8px 0 0;
   /* No geometry transition (v2): a divider drag writes strip rects imperatively
      per frame and a mode beat animates the strip's transform, so an interpolated
@@ -191,16 +192,15 @@
   z-index: 5;
 }
 
-/* The explicitly requested per-pane focus toggle occupies one compact control at
-   the strip's trailing edge. Sticky positioning keeps the escape visible while
-   tabs scroll underneath it; focusing a pane is a presentation change only, so
-   the durable split tree and its ratios remain untouched. */
+/* Keep the pane-focus action anchored at the pane's trailing edge in both tiled
+   and focused presentations. Its narrow fixed width leaves more room for tabs;
+   sticky positioning keeps the escape visible when the strip overflows. */
 .workspace__pane-focus {
   position: sticky;
   right: 0;
   display: grid;
   place-items: center;
-  flex: 0 0 34px;
+  flex: 0 0 28px;
   align-self: stretch;
   margin-left: auto;
   border: 1px solid var(--border-light);
@@ -220,7 +220,7 @@
   outline-offset: -2px;
 }
 .workspace__strip .shell__tab {
-  scroll-margin-inline-end: 42px;
+  scroll-margin-inline-end: 34px;
 }
 
 /* Which tab is open in each pane, and which pane has focus, both read from the

--- a/tests/workspace-panes.spec.mjs
+++ b/tests/workspace-panes.spec.mjs
@@ -324,11 +324,11 @@ test.describe('Workspace panes (PR2 gate)', () => {
     ]) {
       expect(frames.every(Boolean), 'every sampled frame has two projected panes').toBe(true)
       for (const frame of frames) {
-        // Wide projection owns an 8px outer margin on both sides. If the content
-        // box and projection land in separate renders, one of these gaps differs
-        // by exactly the desktop drawer width for the first sampled frame.
-        expect(Math.abs((frame.firstPaneLeft - frame.contentLeft) - 8)).toBeLessThanOrEqual(1)
-        expect(Math.abs((frame.contentRight - frame.lastPaneRight) - 8)).toBeLessThanOrEqual(1)
+        // Tiled panes use focused-pane's edge-to-edge density. If the content box
+        // and projection land in separate renders, one edge differs by exactly
+        // the desktop drawer width for the first sampled frame.
+        expect(Math.abs(frame.firstPaneLeft - frame.contentLeft)).toBeLessThanOrEqual(1)
+        expect(Math.abs(frame.contentRight - frame.lastPaneRight)).toBeLessThanOrEqual(1)
       }
     }
   })


### PR DESCRIPTION
## Summary
- make tiled panes use the same edge-to-edge chrome density as a focused pane
- keep the focus/show-all control compact and pinned to the pane edge
- remove the obsolete outer-margin layout path and update split thresholds

## Testing
- `node --test frontend/src/components/Shell/__tests__/workspaceUi.test.js frontend/src/components/Shell/__tests__/paneModel.test.js`
- rendered two-pane verification at the desktop workspace viewport