### PR TITLE
Unify shell navigation ownership and offline fallback

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,6 +9,7 @@ import { queryClient, persistOptions } from './queryClient.js'
 import { shellReload } from './lib/shellReloadState.js'
 import { beginEmbedBootstrap } from './lib/chatEmbedBootstrap.js'
 import { startInstallPromptCapture } from './lib/installPrompt.js'
+import { safeReturnPath } from './lib/safeReturnPath.js'
 
 // These flows are mutually exclusive. Keep setup, login, the full shell, and
 // the opaque embed out of one another's startup path; first boot should not
@@ -43,22 +44,6 @@ if (EMBED_ROUTE) {
   // Capture Chromium's one-shot install event before setup or sign-in can keep
   // the first-use shell card from mounting.
   startInstallPromptCapture()
-}
-
-// Validate a ?return= target: same-origin in-app path only. Rejects
-// backslashes (browsers normalize '/\\evil' to '//evil' -> open redirect),
-// absolute/cross-origin URLs, and protocol-relative '//'. Returns the safe
-// path+query+hash, or null.
-function safeReturnPath(raw) {
-  if (!raw) return null
-  if (!raw.startsWith('/')) return null            // absolute in-app path only
-  if (raw.includes('\\') || /%5c/i.test(raw)) return null  // (encoded) backslash -> // -> open redirect
-  let u
-  try { u = new URL(raw, window.location.origin) } catch { return null }
-  if (u.origin !== window.location.origin) return null
-  if (!u.pathname.startsWith('/') || u.pathname.startsWith('//')) return null
-  if (decodeURIComponent(u.pathname).includes('\\')) return null  // belt-and-suspenders
-  return u.pathname + u.search + u.hash
 }
 
 export default function App() {
@@ -139,7 +124,7 @@ function AppRoot() {
           setStatus('shell')
           return
         }
-        const ret = safeReturnPath(data.return_path)
+        const ret = safeReturnPath(data.return_path, window.location.origin)
         if (ret && ret !== '/') {
           window.location.replace(ret)
           return
@@ -168,8 +153,10 @@ function AppRoot() {
   // restored chat. One-shot sessionStorage guard prevents a cross-partition
   // redirect loop. Same-origin in-app paths only (no open-redirect).
   useEffect(() => {
-    let ret
-    try { ret = safeReturnPath(new URLSearchParams(window.location.search).get('return')) } catch { return }
+    const ret = safeReturnPath(
+      new URLSearchParams(window.location.search).get('return'),
+      window.location.origin,
+    )
     if (!ret) { try { sessionStorage.removeItem('mobius_return_bounced') } catch { /* ignore */ } return }
     if (!hasToken) return  // no token: the login path honors return post-login
     // Target-scoped one-shot: only suppress a repeat bounce to the SAME
@@ -244,8 +231,10 @@ function AppRoot() {
   if (status === 'login') return (
     <Suspense fallback={<RouteLoading label="Loading sign in" />}>
       <LoginForm onLogin={() => {
-        let ret
-        try { ret = safeReturnPath(new URLSearchParams(window.location.search).get('return')) } catch { /* ignore */ }
+        const ret = safeReturnPath(
+          new URLSearchParams(window.location.search).get('return'),
+          window.location.origin,
+        )
         if (ret) { window.location.replace(ret); return }
         setStatus('shell')
       }} />

--- a/frontend/src/lib/__tests__/safeReturnPath.test.js
+++ b/frontend/src/lib/__tests__/safeReturnPath.test.js
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { safeReturnPath } from '../safeReturnPath.js'
+
+const ORIGIN = 'https://mobius.example'
+
+test('safe return paths preserve same-origin path, query, and hash', () => {
+  assert.equal(
+    safeReturnPath('/apps/demo/?x=1#section', ORIGIN),
+    '/apps/demo/?x=1#section',
+  )
+  assert.equal(
+    safeReturnPath('/hello%20world?raw=%#still-%', ORIGIN),
+    '/hello%20world?raw=%#still-%',
+  )
+})
+
+test('malformed pathname escapes are rejected without throwing', () => {
+  for (const path of ['/%', '/%2', '/%GG', '/%E0%A4%A']) {
+    assert.doesNotThrow(() => safeReturnPath(path, ORIGIN))
+    assert.equal(safeReturnPath(path, ORIGIN), null)
+  }
+})
+
+test('return paths reject cross-origin and backslash forms', () => {
+  for (const path of [
+    null,
+    42,
+    'apps/demo',
+    'https://evil.example/path',
+    '//evil.example/path',
+    '/\\evil',
+    '/%5cevil',
+    '/%5Cevil',
+  ]) {
+    assert.equal(safeReturnPath(path, ORIGIN), null)
+  }
+})
+
+test('double-encoded backslashes retain the existing normalization policy', () => {
+  assert.equal(safeReturnPath('/%255cstill-encoded', ORIGIN), '/%255cstill-encoded')
+})

--- a/frontend/src/lib/__tests__/swNavigationDenylist.test.js
+++ b/frontend/src/lib/__tests__/swNavigationDenylist.test.js
@@ -2,32 +2,31 @@ import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { test } from 'node:test'
 
+import {
+  isShellNavigationDenied,
+  PROXIED_APP_SUBTREES,
+} from '../swNavigationPolicy.js'
+
 const SOURCE = readFileSync(
   new URL('../../sw.js', import.meta.url),
   'utf8',
 )
 
-// The denylist spreads the legacy instance-local extension point. Keep that
-// binding available while also testing the stock reserved /services subtree.
-function shellNavigationDenylist(proxied = null) {
-  const match = SOURCE.match(/denylist:\s*\[([\s\S]*?)\n\s*\]/)
-  assert.ok(match, 'shell NavigationRoute denylist exists')
-  let declaration
-  if (proxied === null) {
-    const constMatch = SOURCE.match(/^const PROXIED_APP_SUBTREES = (\[[\s\S]*?\])/m)
-    assert.ok(constMatch, 'PROXIED_APP_SUBTREES extension point exists')
-    declaration = constMatch[1]
-  } else {
-    declaration = `[${proxied}]`
-  }
-  return Function(
-    `"use strict"; const PROXIED_APP_SUBTREES = ${declaration}; return [${match[1]}]`,
-  )()
-}
+test('shell route and offline fallback consume one navigation policy', () => {
+  assert.match(
+    SOURCE,
+    /request\.mode === 'navigate' && !isShellNavigationDenied\(url\.pathname\)/,
+  )
+  assert.match(
+    SOURCE,
+    /request\.mode === 'navigate' && isShellNavigationDenied\(url\.pathname\),\s+new NetworkOnly\(\)/,
+  )
+  assert.match(SOURCE, /if \(isShellNavigationDenied\(url\.pathname\)\)/)
+  assert.doesNotMatch(SOURCE, /new NavigationRoute|NavigationRoute,/)
+})
 
 test('shell app navigation does not intercept top-level app-like routes', () => {
-  const denylist = shellNavigationDenylist()
-  const denied = path => denylist.some(re => re.test(path))
+  const denied = isShellNavigationDenied
 
   assert.equal(denied('/cuberun'), true)
   assert.equal(denied('/cuberun/'), true)
@@ -48,8 +47,7 @@ test('shell embed navigation reaches the server, not the non-injected precache',
   // The embed renders OUTSIDE Shell and needs the server-injected theme
   // block on its FIRST paint; the precached index.html omits that block,
   // so /shell/embed/* must be denylisted (mirrors how /recover is handled).
-  const denylist = shellNavigationDenylist()
-  const denied = path => denylist.some(re => re.test(path))
+  const denied = isShellNavigationDenied
 
   assert.equal(denied('/shell/embed/chat'), true)
   assert.equal(denied('/shell/embed'), true)
@@ -60,7 +58,7 @@ test('shell embed navigation reaches the server, not the non-injected precache',
 })
 
 test('guarded local services bypass the shell at every depth', () => {
-  const denied = path => shellNavigationDenylist().some(re => re.test(path))
+  const denied = isShellNavigationDenied
 
   assert.equal(denied('/services'), true)
   assert.equal(denied('/services/'), true)
@@ -75,18 +73,39 @@ test('guarded local services bypass the shell at every depth', () => {
 })
 
 test('legacy reverse-proxy extension still ships empty', () => {
-  const constMatch = SOURCE.match(/^const PROXIED_APP_SUBTREES = (\[[\s\S]*?\])/m)
-  assert.ok(constMatch, 'PROXIED_APP_SUBTREES extension point exists')
-  assert.equal(constMatch[1].replace(/\s/g, ''), '[]')
+  assert.deepEqual(PROXIED_APP_SUBTREES, [])
 })
 
-test('a configured legacy proxy subtree still bypasses the shell deeply', () => {
-  const denylist = shellNavigationDenylist(String.raw`/^\/recipes(\/|$)/`)
-  const denied = path => denylist.some(re => re.test(path))
+test('server-owned and standalone navigations never catch-fallback to shell', () => {
+  const denied = value => {
+    const url = new URL(value, 'https://mobius.example')
+    return isShellNavigationDenied(url.pathname)
+  }
 
-  assert.equal(denied('/recipes'), true)
-  assert.equal(denied('/recipes/setup/step/2'), true)
-  assert.equal(denied('/other/deep/path'), false)
+  for (const path of [
+    '/api/health',
+    '/api/chats/demo',
+    '/api?source=browser',
+    '/recover',
+    '/recover/chat',
+    '/recover?source=notification',
+    '/shell/embed',
+    '/shell/embed/chat',
+    '/shell/embed?chat=demo',
+    '/sites/demo/index.html',
+    '/sites?published=demo',
+    '/services/recipes/accounts/login/',
+    '/services?app=recipes',
+    '/apps/cuberun/',
+    '/app-assets/cuberun/index.html',
+    '/app-embeds/by-id/60/index.html',
+    '/cuberun?install=1',
+  ]) {
+    assert.equal(denied(path), true, `${path} stays server/app owned`)
+  }
+  for (const path of ['/', '/shell/', '/shell/chat/abc']) {
+    assert.equal(denied(path), false, `${path} remains an offline shell route`)
+  }
 })
 
 test('offline app cache key ignores install intent query', () => {

--- a/frontend/src/lib/safeReturnPath.js
+++ b/frontend/src/lib/safeReturnPath.js
@@ -1,0 +1,19 @@
+// Validate a post-authentication destination at one boundary. The returned
+// value is always a same-origin absolute path with its query/hash preserved.
+export function safeReturnPath(raw, origin) {
+  if (typeof raw !== 'string' || !raw || typeof origin !== 'string' || !origin) {
+    return null
+  }
+  if (!raw.startsWith('/')) return null
+  if (raw.includes('\\') || /%5c/i.test(raw)) return null
+
+  try {
+    const url = new URL(raw, origin)
+    if (url.origin !== origin) return null
+    if (!url.pathname.startsWith('/') || url.pathname.startsWith('//')) return null
+    if (decodeURIComponent(url.pathname).includes('\\')) return null
+    return url.pathname + url.search + url.hash
+  } catch {
+    return null
+  }
+}

--- a/frontend/src/lib/swNavigationPolicy.js
+++ b/frontend/src/lib/swNavigationPolicy.js
@@ -1,0 +1,20 @@
+// Legacy instance-local mounts remain an extension point for installations
+// that predate the reserved /services namespace. Stock Möbius ships none.
+export const PROXIED_APP_SUBTREES = []
+
+const SHELL_NAVIGATION_DENYLIST = [
+  /^\/api(\/|$)/,
+  /^\/app-assets\//,
+  /^\/app-embeds\//,
+  /^\/apps\//,
+  /^\/recover(\/|$)/,
+  /^\/shell\/embed(\/|$)/,
+  /^\/sites(\/|$)/,
+  /^\/services(\/|$)/,
+  ...PROXIED_APP_SUBTREES,
+  /^\/(?!(?:shell|apps|recover)(?:\/|$))[A-Za-z0-9_-]+(?:\/(?:index\.html)?)?$/,
+]
+
+export function isShellNavigationDenied(pathname) {
+  return SHELL_NAVIGATION_DENYLIST.some(pattern => pattern.test(pathname))
+}

--- a/frontend/src/sw.js
+++ b/frontend/src/sw.js
@@ -30,9 +30,9 @@
  *     non-capable app's /apps/<slug>/ page is never stored, so its offline
  *     open keeps showing the branded offline page exactly as before. Only the
  *     in-shell read path (frame/module) is flag-independent.
- *   - HTML/shell navigations: served from the Workbox precache via
- *     `NavigationRoute(createHandlerBoundToURL('/index.html'))` — NOT
- *     StaleWhileRevalidate; the shell deliberately avoids SWR.
+ *   - HTML/shell navigations: served from the Workbox precache via a pathname
+ *     route bound to `/index.html` — NOT StaleWhileRevalidate; the shell
+ *     deliberately avoids SWR.
  *   - Several `/api/*` routes are cached rather than going straight to
  *     network: `/api/theme` is StaleWhileRevalidate, `/api/chats` and
  *     `/api/apps/` are NetworkFirst (cache fallback when offline), and
@@ -44,11 +44,9 @@ import {
   precacheAndRoute, cleanupOutdatedCaches, matchPrecache,
   createHandlerBoundToURL, addPlugins,
 } from 'workbox-precaching'
+import { registerRoute, setCatchHandler } from 'workbox-routing'
 import {
-  registerRoute, setCatchHandler, NavigationRoute,
-} from 'workbox-routing'
-import {
-  CacheFirst, StaleWhileRevalidate, NetworkFirst,
+  CacheFirst, StaleWhileRevalidate, NetworkFirst, NetworkOnly,
 } from 'workbox-strategies'
 import {
   VENDOR_CACHE,
@@ -77,6 +75,7 @@ import {
   entriesToTrim,
 } from './sw-cache-policy.js'
 import { RETAINED_RUNTIME_ASSETS } from './sw-precache-assets.js'
+import { isShellNavigationDenied } from './lib/swNavigationPolicy.js'
 
 const isOpaqueFramePublicAssetRequest = request => {
   try {
@@ -658,37 +657,19 @@ registerRoute(
 // cached index.html for /recover, so the user landed on the shell instead of the
 // recovery page (and recovery was unreachable exactly when it's needed most).
 
-// Legacy instance-local mounts remain an extension point for installations
-// that predate the reserved /services namespace. Stock Möbius ships none.
-const PROXIED_APP_SUBTREES = []
-
 // Owner-configured backend web services live under one reserved namespace.
 // They are server-served, multi-page applications rather than SPA routes, so
 // every depth below /services/ must reach the guarded backend proxy.  The
 // concrete service map is private data (`/data/local-services.json`), never
 // compiled into the stock shell or edited into this service worker.
-
-registerRoute(new NavigationRoute(
+// Use pathname directly rather than NavigationRoute's pathname+search
+// matching. One predicate now owns online routing and offline fallback, and
+// legacy extension regexes do not need query-string-specific variants.
+registerRoute(
+  ({ request, url }) =>
+    request.mode === 'navigate' && !isShellNavigationDenied(url.pathname),
   createHandlerBoundToURL('/index.html'),
-  {
-    denylist: [
-      /^\/app-assets\//,
-      /^\/app-embeds\//,
-      /^\/apps\//,
-      /^\/recover(\/|$)/,
-      /^\/shell\/embed(\/|$)/,
-      // Published Web Studio sites (/sites/<token>/...) are served by the
-      // backend, NOT the SPA shell. Without this the root-scoped SW served the
-      // cached index.html for a published URL, so opening it showed the Möbius
-      // app instead of the built website.
-      /^\/sites(\/|$)/,
-      /^\/services(\/|$)/,
-      // Legacy instance-local mounts remain supported as an extension point.
-      ...PROXIED_APP_SUBTREES,
-      /^\/(?!(?:shell|apps|recover)(?:\/|$))[A-Za-z0-9_-]+(?:\/(?:index\.html)?)?$/,
-    ],
-  },
-))
+)
 
 // Standalone mini-app navigations: network-first, then stored for
 // offline-capable apps ONLY (gated). The stable `/apps/<slug>/` URL has no
@@ -703,23 +684,28 @@ registerRoute(
   appCodeHandler(STANDALONE_APPS_CACHE, { gated: true }),
 )
 
-// Last resort for any document we still couldn't serve: the cached
-// shell for /shell/*, the branded offline page for standalone +
-// everything else. matchPrecache resolves the content-hashed entry.
+// Give every other server/app-owned document a matched network route. If the
+// network is unavailable, Workbox invokes the shared catch handler below and
+// serves Möbius's branded offline page rather than the browser's generic error.
+registerRoute(
+  ({ request, url }) =>
+    request.mode === 'navigate' && isShellNavigationDenied(url.pathname),
+  new NetworkOnly(),
+)
+
+// Last resort for any document we still couldn't serve: the cached shell for
+// shell-owned routes, and the branded offline page for every server/app-owned
+// route above. matchPrecache resolves the content-hashed entry.
 setCatchHandler(async ({ request, url }) => {
   if (request.destination !== 'document') return Response.error()
-  if (url.pathname.startsWith('/app-assets/')
-      || url.pathname.startsWith('/app-embeds/')) {
+  if (isShellNavigationDenied(url.pathname)) {
     return (await matchPrecache('/offline.html')) || Response.error()
   }
-  if (!url.pathname.startsWith('/apps/')) {
-    return (
-      (await matchPrecache('/index.html')) ||
-      (await matchPrecache('/offline.html')) ||
-      Response.error()
-    )
-  }
-  return (await matchPrecache('/offline.html')) || Response.error()
+  return (
+    (await matchPrecache('/index.html')) ||
+    (await matchPrecache('/offline.html')) ||
+    Response.error()
+  )
 })
 
 // ── Precache warming ────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- move post-authentication return validation into a small non-throwing helper
- use one pathname ownership predicate for shell routing, server-owned routing, and offline fallback
- give denied server and app pages a network-only route so offline failures reach the branded offline page

## Why
Malformed percent escapes in a return path could throw during authentication navigation, and the service worker had separate route and fallback policies. Workbox evaluated one policy with the query string while the fallback used only the pathname, allowing reserved URLs with queries to receive cached shell HTML.

Routing now classifies ownership from the pathname at one boundary. API, recovery, embed, published-site, local-service, standalone-app, and app-asset pages stay server/app owned; ordinary shell routes retain precached offline behavior.

## Testing
- focused return-path and service-worker policy tests (11 passed)
- production frontend and PWA build, including offline precache verification
- full frontend unit suite (2,176 passed)