### PR TITLE
Stream Railway gateway uploads and supervise recoveryd

### DIFF
--- a/backend/recovery/recoveryd.py
+++ b/backend/recovery/recoveryd.py
@@ -275,11 +275,12 @@ _PULL_LOCK = RECOVERY_LIVE_ROOT / ".pull.lock"
 # Persistent crash-loop guard for the live copy. recoveryd (root) bumps this
 # counter just before it execs into the live copy and resets it once the live
 # copy reaches a bound, serving state. It lives on the recoveryd-only volume
-# (which persists across a container restart) — unlike the in-process exec
-# sentinel — so a trusted-but-crashing live copy that dies before serving
-# cannot loop past the baked floor forever: after _MAX_LIVE_ATTEMPTS the
-# launcher quarantines to baked. Written by recoveryd as root; kept off
-# /data so the agent cannot forge a low count to defeat the quarantine.
+# (which persists across a process or container restart) — unlike the
+# in-process exec sentinel — so a trusted-but-crashing live copy that dies
+# before serving cannot loop past the baked floor forever: after
+# _MAX_LIVE_ATTEMPTS the launcher quarantines to baked. Written by recoveryd
+# as root; kept off /data so the agent cannot forge a low count to defeat the
+# quarantine.
 ATTEMPTS_FILE = RECOVERY_LIVE_ROOT / ".attempts"
 _MAX_LIVE_ATTEMPTS = 3
 
@@ -687,10 +688,11 @@ def _maybe_reexec_into_run_dir() -> None:
   argv = [sys.executable, "-P", target, *sys.argv[1:]]
   # Count this live-copy start BEFORE handing off. execv never returns, and
   # if the live copy crashes before its serve loop resets the counter the
-  # bump persists across the container restart, so after _MAX_LIVE_ATTEMPTS
-  # resolve_run_dir quarantines to the baked floor. If the bump cannot be
-  # persisted, decline the live copy and run baked in-place — an untracked
-  # start could otherwise crash-loop forever with no way to reach the floor.
+  # bump persists across the next process or container launch, so after
+  # _MAX_LIVE_ATTEMPTS resolve_run_dir quarantines to the baked floor. If the
+  # bump cannot be persisted, decline the live copy and run baked in-place — an
+  # untracked start could otherwise crash-loop forever with no way to reach the
+  # floor.
   if not _bump_live_attempts():
     log.warning("launcher: cannot persist attempts counter — running baked "
                 "floor instead of the live copy")
@@ -1022,16 +1024,16 @@ def _pull_locked(timeout: float) -> tuple[bool, str]:
 
 
 def _restart_recoveryd() -> None:
-  """Exits the process so the container restart policy re-runs the launcher.
+  """Exits cleanly so the deployment's recovery supervisor re-runs the launcher.
 
   Called AFTER the update response has been written and flushed to the
   client (never mid-response — os.execv here would kill the reply in flight).
   A short-lived daemon thread gives the response bytes a moment to drain
-  through the reverse proxy to the browser, then os._exit(0) drops the
-  process; the recoveryd container's `restart: unless-stopped` policy
-  immediately recreates it, and the fresh main() runs the launcher, which now
-  execs into the just-pulled live copy. os._exit (not sys.exit) so no
-  atexit/finally can intercept — this is a deliberate, unconditional restart.
+  through the reverse proxy to the browser, then os._exit(0) drops the process.
+  Compose's recoveryd container policy or Railway's bounded recovery component
+  supervisor immediately relaunches it; fresh main() runs the launcher, which
+  now execs into the just-pulled live copy. os._exit (not sys.exit) keeps
+  atexit/finally from intercepting this deliberate, unconditional reload.
   """
   def _die() -> None:
     time.sleep(1.0)

--- a/backend/scripts/boot_attempt_counter.py
+++ b/backend/scripts/boot_attempt_counter.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Locked owner for the platform boot-attempt counter.
+
+The entrypoint, health probe, and Railway component supervisor run
+concurrently. Every mutation therefore carries the current boot id and passes
+through this file's lock; a late writer from an older boot cannot overwrite a
+newer boot, and a component rollback cannot undo a health reset.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import os
+import stat
+import sys
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Counter:
+  count: int
+  boot_id: str | None
+
+
+def _read(path: Path) -> Counter:
+  try:
+    parts = path.read_text(encoding="utf-8").split()
+  except OSError:
+    return Counter(0, None)
+  try:
+    count = int(parts[0])
+  except (IndexError, ValueError):
+    count = 0
+  if count < 0:
+    count = 0
+  # Legacy records have only "count timestamp". They remain valid inputs and
+  # acquire the current boot id on the next begin.
+  boot_id = parts[2] if len(parts) >= 3 else None
+  return Counter(count, boot_id)
+
+
+def _write(path: Path, count: int, boot_id: str) -> None:
+  timestamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+  payload = f"{count} {timestamp} {boot_id}\n".encode()
+  tmp = path.with_name(f".{path.name}.tmp-{os.getpid()}-{time.time_ns()}")
+  try:
+    existing = path.lstat()
+  except FileNotFoundError:
+    existing = None
+  fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+  try:
+    if existing is not None and stat.S_ISREG(existing.st_mode):
+      os.fchmod(fd, stat.S_IMODE(existing.st_mode))
+      if os.geteuid() == 0:
+        os.fchown(fd, existing.st_uid, existing.st_gid)
+    with os.fdopen(fd, "wb") as stream:
+      fd = -1
+      stream.write(payload)
+      stream.flush()
+      os.fsync(stream.fileno())
+  finally:
+    if fd >= 0:
+      os.close(fd)
+  try:
+    os.replace(tmp, path)
+    dir_fd = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+      os.fsync(dir_fd)
+    finally:
+      os.close(dir_fd)
+  finally:
+    try:
+      tmp.unlink()
+    except FileNotFoundError:
+      pass
+
+
+@contextmanager
+def _locked(path: Path):
+  path.parent.mkdir(parents=True, exist_ok=True)
+  lock_path = path.with_name(f"{path.name}.lock")
+  fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+  try:
+    fcntl.flock(fd, fcntl.LOCK_EX)
+    yield
+  finally:
+    fcntl.flock(fd, fcntl.LOCK_UN)
+    os.close(fd)
+
+
+def begin(path: Path, boot_id: str) -> tuple[int, int]:
+  with _locked(path):
+    prior = _read(path).count
+    current = prior + 1
+    _write(path, current, boot_id)
+    return prior, current
+
+
+def reset(path: Path, boot_id: str) -> bool:
+  with _locked(path):
+    current = _read(path)
+    if current.boot_id != boot_id:
+      return False
+    _write(path, 0, boot_id)
+    return True
+
+
+def rollback(
+  path: Path,
+  boot_id: str,
+  expected_current: int,
+  prior: int,
+) -> bool:
+  with _locked(path):
+    current = _read(path)
+    if (
+      current.boot_id != boot_id
+      or current.count != expected_current
+    ):
+      return False
+    _write(path, prior, boot_id)
+    return True
+
+
+def _boot_id(value: str) -> str:
+  if not value or any(char.isspace() for char in value):
+    raise argparse.ArgumentTypeError("boot id must be one non-empty token")
+  return value
+
+
+def _non_negative(value: str) -> int:
+  parsed = int(value)
+  if parsed < 0:
+    raise argparse.ArgumentTypeError("counter values must be non-negative")
+  return parsed
+
+
+def main(argv: list[str] | None = None) -> int:
+  parser = argparse.ArgumentParser()
+  subparsers = parser.add_subparsers(dest="command", required=True)
+
+  begin_parser = subparsers.add_parser("begin")
+  begin_parser.add_argument("path", type=Path)
+  begin_parser.add_argument("boot_id", type=_boot_id)
+
+  reset_parser = subparsers.add_parser("reset")
+  reset_parser.add_argument("path", type=Path)
+  reset_parser.add_argument("boot_id", type=_boot_id)
+
+  rollback_parser = subparsers.add_parser("rollback")
+  rollback_parser.add_argument("path", type=Path)
+  rollback_parser.add_argument("boot_id", type=_boot_id)
+  rollback_parser.add_argument("expected_current", type=_non_negative)
+  rollback_parser.add_argument("prior", type=_non_negative)
+
+  args = parser.parse_args(argv)
+  if args.command == "begin":
+    prior, current = begin(args.path, args.boot_id)
+    print(prior, current)
+    return 0
+  if args.command == "reset":
+    print("1" if reset(args.path, args.boot_id) else "0")
+    return 0
+  if args.command == "rollback":
+    applied = rollback(
+      args.path,
+      args.boot_id,
+      args.expected_current,
+      args.prior,
+    )
+    print("1" if applied else "0")
+    return 0
+  raise AssertionError(f"unhandled command: {args.command}")
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/backend/scripts/entrypoint.sh
+++ b/backend/scripts/entrypoint.sh
@@ -50,24 +50,37 @@ fi
 
 # PHASE 3: Boot-attempt counter. Written BEFORE starting uvicorn so a
 # crash during startup (or a SIGKILL before the health probe writes the
-# success sentinel) increments the count on the next boot. Counter is a
-# plain integer in /data/.boot-attempt. On >=3 failures without an
+# success sentinel) increments the count on the next boot. The first field in
+# /data/.boot-attempt is the count. On >=3 failures without an
 # intervening /data/.last-successful-boot reset, we trigger a
 # platform-baked restore and reset the counter, then log a flag that
 # /api/debug/status surfaces.
 #
-# The counter file stores "N TIMESTAMP" — two fields so we can correlate
-# crash times in the log. We read just the first field.
-_boot_counter=0
-if [ -f /data/.boot-attempt ]; then
-  _boot_counter=$(cut -d' ' -f1 /data/.boot-attempt 2>/dev/null || echo 0)
-  # Validate: must be a non-negative integer.
-  case "$_boot_counter" in
-    ''|*[!0-9]*) _boot_counter=0 ;;
-  esac
+# The frozen helper serializes this writer with the health reset and Railway's
+# component-aware rollback. It accepts legacy "N TIMESTAMP" records, then adds
+# this boot id so a delayed writer from another boot cannot overwrite us.
+_boot_counter_enabled=1
+_boot_counter_helper=/app/scripts/boot_attempt_counter.py
+_boot_counter_state=$(
+  python3 -P /app/scripts/boot_attempt_counter.py \
+    begin /data/.boot-attempt "$MOBIUS_BOOT_ID"
+) || _boot_counter_state=""
+set -- $_boot_counter_state
+if [ "$#" -eq 2 ]; then
+  _boot_counter_prior=$1
+  _boot_counter=$2
+  _boot_counter_charged=$2
+else
+  # Recovery and the public gateway must still start when this optional
+  # self-heal ledger is unavailable. Disable only counter-based auto-restore
+  # and component rollback for this boot; never trade away the recovery floor.
+  echo "WARNING: platform boot-attempt ledger unavailable; automatic crash-loop restore is disabled for this boot." >&2
+  _boot_counter_enabled=0
+  _boot_counter_helper=""
+  _boot_counter_prior=0
+  _boot_counter=0
+  _boot_counter_charged=0
 fi
-_boot_counter=$((_boot_counter + 1))
-echo "$_boot_counter $(date -u +%Y-%m-%dT%H:%M:%SZ)" > /data/.boot-attempt
 # chown deferred until after the broad /data chown below; done explicitly
 # here only if that chown is not going to happen (Railway fallback path).
 
@@ -76,7 +89,9 @@ echo "$_boot_counter $(date -u +%Y-%m-%dT%H:%M:%SZ)" > /data/.boot-attempt
 # loop. Threshold = 3 because a transient OOM or SIGKILL can cause 1-2
 # false failures; three consecutive failures without a health success
 # strongly implies the platform code itself is broken.
-if [ "$_boot_counter" -ge 3 ] && [ -f /data/.last-successful-boot ]; then
+if [ "$_boot_counter_enabled" -eq 1 ] &&
+   [ "$_boot_counter" -ge 3 ] &&
+   [ -f /data/.last-successful-boot ]; then
   echo "PLATFORM-RESTORE: boot-attempt counter = $_boot_counter, re-cloning platform..." >&2
   # Crash-loop escape hatch: the platform imported OK (else the probe would
   # have already fallen back to baked) but keeps crashing at runtime. Move the
@@ -108,13 +123,25 @@ if [ "$_boot_counter" -ge 3 ] && [ -f /data/.last-successful-boot ]; then
   # auto-restores. If it didn't fix things, we'll restore again after 3
   # more attempts (an explicit loop so the operator can see what's
   # happening via the counter file).
-  echo "0 $(date -u +%Y-%m-%dT%H:%M:%SZ)" > /data/.boot-attempt
+  python3 -P /app/scripts/boot_attempt_counter.py \
+    reset /data/.boot-attempt "$MOBIUS_BOOT_ID" >/dev/null || {
+    echo "WARNING: could not reset the platform boot-attempt ledger." >&2
+    _boot_counter_enabled=0
+    _boot_counter_helper=""
+  }
   _boot_counter=0
-elif [ "$_boot_counter" -ge 3 ] && [ ! -f /data/.last-successful-boot ]; then
+elif [ "$_boot_counter_enabled" -eq 1 ] &&
+     [ "$_boot_counter" -ge 3 ] &&
+     [ ! -f /data/.last-successful-boot ]; then
   # Fresh volume or first-ever boot — last-successful-boot not yet written.
   # Don't trigger restore on what is literally the first few boots.
   # Reset counter so it doesn't grow forever on a slow-starting instance.
-  echo "0 $(date -u +%Y-%m-%dT%H:%M:%SZ)" > /data/.boot-attempt
+  python3 -P /app/scripts/boot_attempt_counter.py \
+    reset /data/.boot-attempt "$MOBIUS_BOOT_ID" >/dev/null || {
+    echo "WARNING: could not reset the platform boot-attempt ledger." >&2
+    _boot_counter_enabled=0
+    _boot_counter_helper=""
+  }
   _boot_counter=0
 fi
 
@@ -206,6 +233,13 @@ _gateway_pid=""
 _recovery_pid=""
 _restart_poller_started=0
 
+if [ "$_railway_gateway" -eq 1 ]; then
+  # Baked alongside this entrypoint. recoveryd needs a bounded component-local
+  # relaunch path so its trusted-live crash guard can reach the baked floor
+  # without consuming Railway's whole-container restart budget.
+  . /app/scripts/railway_supervision.sh
+fi
+
 _shutdown_railway_gateway() {
   _status="${1:-0}"
   trap - TERM INT
@@ -219,43 +253,15 @@ _shutdown_railway_gateway() {
   exit "$_status"
 }
 
-_railway_child_running() {
-  _child_pid="$1"
-  _child_state=$(awk '/^State:/ { print $2; exit }' "/proc/${_child_pid}/status" 2>/dev/null) || return 1
-  [ -n "$_child_state" ] && [ "$_child_state" != "Z" ]
-}
-
 _wait_for_railway_child_exit() {
   # Railway sees the gateway as pid1's public service, but the gateway can stay
   # alive after uvicorn or recoveryd crashes and return 502 forever. Watch all
   # essential children. Any unexpected exit brings the whole container down so
   # Railway's ON_FAILURE policy restarts a coherent process set.
-  # kill -0 still succeeds for an exited child that has become a zombie. Read
-  # procfs state so either critical process is reaped and reported promptly.
-  while _railway_child_running "$_gateway_pid" &&
-        _railway_child_running "$_app_pid" &&
-        _railway_child_running "$_recovery_pid"; do
-    sleep 1
-  done
-
-  if ! _railway_child_running "$_recovery_pid"; then
-    wait "$_recovery_pid"
-    _child_status=$?
-    echo "FATAL: Railway recovery process exited with status $_child_status." >&2
-  elif ! _railway_child_running "$_app_pid"; then
-    wait "$_app_pid"
-    _child_status=$?
-    echo "FATAL: Railway app process exited with status $_child_status." >&2
-  else
-    wait "$_gateway_pid"
-    _child_status=$?
-    echo "FATAL: Railway gateway process exited with status $_child_status." >&2
-  fi
-
-  # A clean child exit is still a service failure: with ON_FAILURE, returning
-  # zero would leave the stopped deployment down instead of restarting it.
-  [ "$_child_status" -ne 0 ] || _child_status=1
-  return "$_child_status"
+  railway_wait_for_essential_child_exit \
+    "$_gateway_pid" "$_app_pid" "$_recovery_pid" \
+    "$_boot_counter_helper" /data/.boot-attempt \
+    "$MOBIUS_BOOT_ID" "$_boot_counter_prior" "$_boot_counter_charged"
 }
 
 _start_platform_restart_poller() {
@@ -352,11 +358,15 @@ if [ "$_railway_gateway" -eq 1 ]; then
     _recovery_allowed_hosts="${RAILWAY_PUBLIC_DOMAIN:-${DOMAIN:-}}"
   fi
   echo "Railway gateway mode: public :$_public_port, app :$_app_port, recovery :$_recovery_port." >&2
-  DATA_DIR="${DATA_DIR:-/data}" \
-  RECOVERY_PORT="$_recovery_port" \
-  RECOVERY_PLATFORM_HEALTH_URL="http://127.0.0.1:${_app_port}/api/health" \
-  RECOVERY_ALLOWED_HOSTS="$_recovery_allowed_hosts" \
-    python3 -P /app/recovery/recoveryd.py &
+  (
+    export DATA_DIR="${DATA_DIR:-/data}"
+    export RECOVERY_PORT="$_recovery_port"
+    export RECOVERY_PLATFORM_HEALTH_URL="http://127.0.0.1:${_app_port}/api/health"
+    export RECOVERY_ALLOWED_HOSTS="$_recovery_allowed_hosts"
+    railway_supervise_recovery \
+      "http://127.0.0.1:${_recovery_port}/recover/health" \
+      python3 -P /app/recovery/recoveryd.py
+  ) &
   _recovery_pid=$!
 
   python3 /app/scripts/railway_gateway.py \
@@ -1131,6 +1141,7 @@ platform.pre-clone.*
 platform.crashloop-prev.*
 # Phase 3 boot-state files — runtime counters, not content the agent manages.
 .boot-attempt
+.boot-attempt.lock
 .last-successful-boot
 .platform-restore-active
 .platform-upgrade-available
@@ -1361,7 +1372,12 @@ fi
       fi
       # Health probe passed — record the success sentinel and reset counter.
       echo "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > /data/.last-successful-boot
-      echo "0 $(date -u +%Y-%m-%dT%H:%M:%SZ)" > /data/.boot-attempt
+      if [ "$_boot_counter_enabled" -eq 1 ]; then
+        python3 -P /app/scripts/boot_attempt_counter.py \
+          reset /data/.boot-attempt "$MOBIUS_BOOT_ID" >/dev/null || {
+          echo "WARNING: platform health passed but the boot-attempt ledger could not be reset." >&2
+        }
+      fi
       # Remove the restore-active flag if set — the server is healthy now.
       rm -f /data/.platform-restore-active 2>/dev/null || true
       echo "Platform health probe: /api/health OK — boot success recorded."
@@ -1403,8 +1419,15 @@ fi
 if [ "$_railway_gateway" -eq 1 ]; then
   su -s /bin/sh mobius -c "$_start_cmd" &
   _app_pid=$!
-  if ! kill -0 "$_gateway_pid" 2>/dev/null; then
+  if ! railway_child_running "$_gateway_pid"; then
     echo "FATAL: Railway gateway exited before app startup." >&2
+    if railway_child_running "$_app_pid"; then
+      railway_rollback_platform_boot_attempt \
+        "$_boot_counter_helper" /data/.boot-attempt "$MOBIUS_BOOT_ID" \
+        "$_boot_counter_prior" "$_boot_counter_charged" || {
+        echo "WARNING: could not roll back the early gateway boot attempt." >&2
+      }
+    fi
     _shutdown_railway_gateway 1
   fi
   _wait_for_railway_child_exit

--- a/backend/scripts/entrypoint.sh
+++ b/backend/scripts/entrypoint.sh
@@ -227,16 +227,22 @@ _railway_child_running() {
 
 _wait_for_railway_child_exit() {
   # Railway sees the gateway as pid1's public service, but the gateway can stay
-  # alive after uvicorn crashes and return 502 forever. Watch BOTH essential
-  # children. Any unexpected exit brings the whole container down so Railway's
-  # ON_FAILURE policy can restart a coherent gateway/app/recovery process set.
+  # alive after uvicorn or recoveryd crashes and return 502 forever. Watch all
+  # essential children. Any unexpected exit brings the whole container down so
+  # Railway's ON_FAILURE policy restarts a coherent process set.
   # kill -0 still succeeds for an exited child that has become a zombie. Read
   # procfs state so either critical process is reaped and reported promptly.
-  while _railway_child_running "$_gateway_pid" && _railway_child_running "$_app_pid"; do
+  while _railway_child_running "$_gateway_pid" &&
+        _railway_child_running "$_app_pid" &&
+        _railway_child_running "$_recovery_pid"; do
     sleep 1
   done
 
-  if ! _railway_child_running "$_app_pid"; then
+  if ! _railway_child_running "$_recovery_pid"; then
+    wait "$_recovery_pid"
+    _child_status=$?
+    echo "FATAL: Railway recovery process exited with status $_child_status." >&2
+  elif ! _railway_child_running "$_app_pid"; then
     wait "$_app_pid"
     _child_status=$?
     echo "FATAL: Railway app process exited with status $_child_status." >&2
@@ -346,18 +352,11 @@ if [ "$_railway_gateway" -eq 1 ]; then
     _recovery_allowed_hosts="${RAILWAY_PUBLIC_DOMAIN:-${DOMAIN:-}}"
   fi
   echo "Railway gateway mode: public :$_public_port, app :$_app_port, recovery :$_recovery_port." >&2
-  (
-    while true; do
-      DATA_DIR="${DATA_DIR:-/data}" \
-      RECOVERY_PORT="$_recovery_port" \
-      RECOVERY_PLATFORM_HEALTH_URL="http://127.0.0.1:${_app_port}/api/health" \
-      RECOVERY_ALLOWED_HOSTS="$_recovery_allowed_hosts" \
-        python3 -P /app/recovery/recoveryd.py
-      _code=$?
-      echo "WARNING: recoveryd exited with status $_code; restarting in 1s." >&2
-      sleep 1
-    done
-  ) &
+  DATA_DIR="${DATA_DIR:-/data}" \
+  RECOVERY_PORT="$_recovery_port" \
+  RECOVERY_PLATFORM_HEALTH_URL="http://127.0.0.1:${_app_port}/api/health" \
+  RECOVERY_ALLOWED_HOSTS="$_recovery_allowed_hosts" \
+    python3 -P /app/recovery/recoveryd.py &
   _recovery_pid=$!
 
   python3 /app/scripts/railway_gateway.py \

--- a/backend/scripts/railway_gateway.py
+++ b/backend/scripts/railway_gateway.py
@@ -32,6 +32,111 @@ HOP_BY_HOP_HEADERS = {
   "upgrade",
 }
 UPSTREAM_TIMEOUT_SECONDS = float(os.environ.get("MOBIUS_GATEWAY_TIMEOUT", "1200"))
+BODY_CHUNK_BYTES = 64 * 1024
+MAX_CHUNK_LINE_BYTES = 64 * 1024
+MAX_CONTENT_LENGTH_DIGITS = 20
+MAX_CHUNK_SIZE_DIGITS = 16
+MAX_TRAILER_BYTES = 64 * 1024
+
+
+class RequestBodyError(ValueError):
+  """The downstream request body has invalid or incomplete framing."""
+
+  status = HTTPStatus.BAD_REQUEST
+
+
+class UnsupportedTransferEncoding(RequestBodyError):
+  """The gateway cannot safely decode the requested transfer coding."""
+
+  status = HTTPStatus.NOT_IMPLEMENTED
+
+
+def _readline_crlf(stream) -> bytes:
+  line = stream.readline(MAX_CHUNK_LINE_BYTES + 1)
+  if len(line) > MAX_CHUNK_LINE_BYTES:
+    raise RequestBodyError("request body framing line is too long")
+  if not line.endswith(b"\r\n"):
+    raise RequestBodyError("request body ended during chunk framing")
+  return line[:-2]
+
+
+def _comma_separated_tokens(values) -> set[str]:
+  return {
+    item.strip().lower()
+    for value in values
+    for item in value.split(",")
+    if item.strip()
+  }
+
+
+class FixedLengthBody:
+  """Expose exactly one Content-Length body as bounded streaming reads."""
+
+  def __init__(self, stream, length: int):
+    self.stream = stream
+    self.remaining = length
+
+  def read(self, size: int = -1) -> bytes:
+    if self.remaining == 0:
+      return b""
+    if size == 0:
+      return b""
+    requested = self.remaining if size < 0 else min(size, self.remaining)
+    requested = min(requested, BODY_CHUNK_BYTES)
+    read = getattr(self.stream, "read1", self.stream.read)
+    chunk = read(requested)
+    if not chunk:
+      raise RequestBodyError("request body ended before Content-Length")
+    self.remaining -= len(chunk)
+    return chunk
+
+
+class ChunkedBody:
+  """Decode downstream HTTP chunks while the upstream re-chunks the stream."""
+
+  def __init__(self, stream):
+    self.stream = stream
+    self.remaining = 0
+    self.done = False
+
+  def __iter__(self):
+    return self
+
+  def __next__(self) -> bytes:
+    if self.done:
+      raise StopIteration
+
+    while self.remaining == 0:
+      size_line = _readline_crlf(self.stream)
+      size_text = size_line.split(b";", 1)[0].strip()
+      if (
+        not size_text
+        or len(size_text) > MAX_CHUNK_SIZE_DIGITS
+        or any(char not in b"0123456789abcdefABCDEF" for char in size_text)
+      ):
+        raise RequestBodyError("invalid chunk size")
+      size = int(size_text, 16)
+      if size == 0:
+        trailer_bytes = 0
+        while True:
+          trailer = _readline_crlf(self.stream)
+          trailer_bytes += len(trailer) + 2
+          if trailer_bytes > MAX_TRAILER_BYTES:
+            raise RequestBodyError("request body trailers are too long")
+          if not trailer:
+            break
+        self.done = True
+        raise StopIteration
+      self.remaining = size
+
+    read = getattr(self.stream, "read1", self.stream.read)
+    chunk = read(min(self.remaining, BODY_CHUNK_BYTES))
+    if not chunk:
+      raise RequestBodyError("request body ended during chunk data")
+    self.remaining -= len(chunk)
+    if self.remaining == 0 and self.stream.read(2) != b"\r\n":
+      raise RequestBodyError("chunk data is missing its terminator")
+    return chunk
 
 
 def is_recovery_path(path: str) -> bool:
@@ -68,19 +173,46 @@ class Gateway(BaseHTTPRequestHandler):
     path = urllib.parse.urlparse(self.path).path
     return self.recovery_upstream if is_recovery_path(path) else self.app_upstream
 
-  def _read_body(self) -> bytes | None:
-    try:
-      length = int(self.headers.get("Content-Length", "0") or "0")
-    except (TypeError, ValueError):
-      length = 0
-    return self.rfile.read(length) if length > 0 else None
+  def _request_body(self) -> tuple[object | None, bool]:
+    content_lengths = self.headers.get_all("Content-Length", [])
+    transfer_encodings = self.headers.get_all("Transfer-Encoding", [])
+    if content_lengths and transfer_encodings:
+      raise RequestBodyError(
+        "Content-Length and Transfer-Encoding cannot be combined"
+      )
+
+    if content_lengths:
+      if len(content_lengths) != 1:
+        raise RequestBodyError("multiple Content-Length headers")
+      raw_length = content_lengths[0].strip()
+      if (
+        not raw_length.isascii()
+        or not raw_length.isdecimal()
+        or len(raw_length) > MAX_CONTENT_LENGTH_DIGITS
+      ):
+        raise RequestBodyError("invalid Content-Length")
+      length = int(raw_length)
+      return (
+        FixedLengthBody(self.rfile, length) if length > 0 else None,
+        False,
+      )
+
+    if transfer_encodings:
+      if (
+        len(transfer_encodings) != 1
+        or transfer_encodings[0].strip().lower() != "chunked"
+      ):
+        raise UnsupportedTransferEncoding(
+          "only chunked Transfer-Encoding is supported"
+        )
+      return ChunkedBody(self.rfile), True
+
+    return None, False
 
   def _headers(self) -> dict[str, str]:
-    connection_tokens = {
-      item.strip().lower()
-      for item in self.headers.get("Connection", "").split(",")
-      if item.strip()
-    }
+    connection_tokens = _comma_separated_tokens(
+      self.headers.get_all("Connection", [])
+    )
     blocked = HOP_BY_HOP_HEADERS | connection_tokens
     headers = {
       key: value
@@ -118,24 +250,49 @@ class Gateway(BaseHTTPRequestHandler):
     self.close_connection = True
 
   def _proxy(self) -> None:
+    try:
+      body, encode_chunked = self._request_body()
+    except RequestBodyError as exc:
+      self._plain(exc.status, str(exc))
+      return
+
     host, port = self._target()
     conn = http.client.HTTPConnection(host, port, timeout=UPSTREAM_TIMEOUT_SECONDS)
     try:
       conn.request(
         self.command,
         self.path,
-        body=self._read_body(),
+        body=body,
         headers=self._headers(),
+        encode_chunked=encode_chunked,
       )
       resp = conn.getresponse()
+    except RequestBodyError as exc:
+      conn.close()
+      self._plain(exc.status, str(exc))
+      return
     except OSError as exc:
+      conn.close()
       self._plain(HTTPStatus.BAD_GATEWAY, f"Mobius upstream unavailable: {exc}")
       return
 
     try:
       self.send_response(resp.status, resp.reason)
-      for key, value in resp.getheaders():
-        if key.lower() in HOP_BY_HOP_HEADERS:
+      response_headers = resp.getheaders()
+      response_connection_tokens = _comma_separated_tokens(
+        value for key, value in response_headers
+        if key.lower() == "connection"
+      )
+      blocked_response_headers = (
+        HOP_BY_HOP_HEADERS | response_connection_tokens
+      )
+      # HTTPResponse decodes upstream chunk framing before read1() returns.
+      # A stray Content-Length alongside Transfer-Encoding therefore no longer
+      # describes the bytes sent downstream; close-delimit that response.
+      if resp.chunked:
+        blocked_response_headers.add("content-length")
+      for key, value in response_headers:
+        if key.lower() in blocked_response_headers:
           continue
         self.send_header(key, value)
       self.send_header("Connection", "close")

--- a/backend/scripts/railway_supervision.sh
+++ b/backend/scripts/railway_supervision.sh
@@ -1,0 +1,156 @@
+#!/bin/sh
+# Railway's single container needs two levels of supervision:
+# - this component supervisor lets recoveryd exercise its trusted-live fallback;
+# - pid 1 restarts the whole service only when an essential component cannot
+#   recover locally.
+#
+# This file is sourced by entrypoint.sh. Keep it POSIX-sh compatible.
+
+railway_child_running() {
+  _railway_child_pid="$1"
+  _railway_child_state=$(
+    awk '/^State:/ { print $2; exit }' \
+      "/proc/${_railway_child_pid}/status" 2>/dev/null
+  ) || return 1
+  [ -n "$_railway_child_state" ] && [ "$_railway_child_state" != "Z" ]
+}
+
+railway_recovery_live_attempts() {
+  _railway_attempts_file="${RECOVERY_LIVE_ROOT:-/recovery-live}/.attempts"
+  _railway_attempts=$(
+    cat "$_railway_attempts_file" 2>/dev/null
+  ) || _railway_attempts=0
+  case "$_railway_attempts" in
+    ''|*[!0-9]*) _railway_attempts=0 ;;
+  esac
+  printf '%s\n' "$_railway_attempts"
+}
+
+railway_supervise_recovery() {
+  _railway_recovery_health_url="$1"
+  shift
+  if [ "$#" -eq 0 ]; then
+    echo "FATAL: Railway recovery supervisor has no child command." >&2
+    exit 64
+  fi
+
+  _railway_recovery_child=""
+  _railway_recovery_stopping=0
+
+  _railway_stop_recovery() {
+    _railway_recovery_stopping=1
+    if [ -n "$_railway_recovery_child" ]; then
+      kill "$_railway_recovery_child" 2>/dev/null || true
+    fi
+  }
+  trap '_railway_stop_recovery' TERM INT
+
+  while [ "$_railway_recovery_stopping" -eq 0 ]; do
+    _railway_attempts_before=$(railway_recovery_live_attempts)
+    "$@" &
+    _railway_recovery_child=$!
+    _railway_recovery_ready=0
+
+    while [ "$_railway_recovery_stopping" -eq 0 ] &&
+          railway_child_running "$_railway_recovery_child"; do
+      if curl -fsS --max-time 1 "$_railway_recovery_health_url" \
+          >/dev/null 2>&1; then
+        _railway_recovery_ready=1
+        break
+      fi
+      sleep 1
+    done
+
+    wait "$_railway_recovery_child" 2>/dev/null
+    _railway_recovery_status=$?
+    _railway_recovery_child=""
+
+    if [ "$_railway_recovery_stopping" -eq 1 ]; then
+      exit 0
+    fi
+
+    if [ "$_railway_recovery_ready" -eq 1 ]; then
+      if [ "$_railway_recovery_status" -eq 0 ]; then
+        echo "Railway recovery process requested a planned reload." >&2
+        continue
+      fi
+      echo "FATAL: Railway recovery process exited after readiness with status $_railway_recovery_status." >&2
+      exit "$_railway_recovery_status"
+    fi
+
+    _railway_attempts_after=$(railway_recovery_live_attempts)
+    if [ "$_railway_attempts_after" -gt "$_railway_attempts_before" ]; then
+      echo "WARNING: Railway trusted-live recovery attempt $_railway_attempts_after exited before readiness with status $_railway_recovery_status; relaunching so recoveryd can advance its fallback." >&2
+      sleep 1
+      continue
+    fi
+
+    echo "FATAL: Railway recovery process exited before readiness with status $_railway_recovery_status without advancing its trusted-live attempts; baked recovery failed." >&2
+    [ "$_railway_recovery_status" -ne 0 ] || _railway_recovery_status=1
+    exit "$_railway_recovery_status"
+  done
+
+  exit 0
+}
+
+railway_rollback_platform_boot_attempt() {
+  _railway_counter_helper="$1"
+  _railway_boot_file="$2"
+  _railway_boot_id="$3"
+  _railway_boot_prior="$4"
+  _railway_boot_charged="$5"
+  [ -n "$_railway_counter_helper" ] || return 0
+  python3 -P "$_railway_counter_helper" rollback \
+    "$_railway_boot_file" "$_railway_boot_id" \
+    "$_railway_boot_charged" "$_railway_boot_prior" \
+    >/dev/null
+}
+
+railway_wait_for_essential_child_exit() {
+  _railway_gateway_pid="$1"
+  _railway_app_pid="$2"
+  _railway_recovery_pid="$3"
+  _railway_counter_helper="$4"
+  _railway_boot_file="$5"
+  _railway_boot_id="$6"
+  _railway_boot_prior="$7"
+  _railway_boot_charged="$8"
+
+  while railway_child_running "$_railway_gateway_pid" &&
+        railway_child_running "$_railway_app_pid" &&
+        railway_child_running "$_railway_recovery_pid"; do
+    sleep 1
+  done
+
+  # App failure owns platform rollback decisions. Check it first so a
+  # simultaneous recovery/gateway exit cannot disguise a dead app and undo the
+  # platform attempt. Non-app failures roll back only this boot's exact CAS.
+  if ! railway_child_running "$_railway_app_pid"; then
+    wait "$_railway_app_pid"
+    _railway_child_status=$?
+    echo "FATAL: Railway app process exited with status $_railway_child_status." >&2
+  elif ! railway_child_running "$_railway_recovery_pid"; then
+    wait "$_railway_recovery_pid"
+    _railway_child_status=$?
+    echo "FATAL: Railway recovery supervisor exited with status $_railway_child_status." >&2
+    if ! railway_rollback_platform_boot_attempt \
+        "$_railway_counter_helper" "$_railway_boot_file" "$_railway_boot_id" \
+        "$_railway_boot_prior" "$_railway_boot_charged"; then
+      echo "WARNING: could not roll back the non-platform boot attempt." >&2
+    fi
+  else
+    wait "$_railway_gateway_pid"
+    _railway_child_status=$?
+    echo "FATAL: Railway gateway process exited with status $_railway_child_status." >&2
+    if ! railway_rollback_platform_boot_attempt \
+        "$_railway_counter_helper" "$_railway_boot_file" "$_railway_boot_id" \
+        "$_railway_boot_prior" "$_railway_boot_charged"; then
+      echo "WARNING: could not roll back the non-platform boot attempt." >&2
+    fi
+  fi
+
+  # A clean essential-child exit is still a service failure: Railway's
+  # ON_FAILURE policy must restart the incoherent process set.
+  [ "$_railway_child_status" -ne 0 ] || _railway_child_status=1
+  return "$_railway_child_status"
+}

--- a/backend/tests/test_boot_attempt_counter.py
+++ b/backend/tests/test_boot_attempt_counter.py
@@ -1,0 +1,93 @@
+import stat
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+
+_HELPER = (
+  Path(__file__).resolve().parents[1] / "scripts" / "boot_attempt_counter.py"
+)
+
+
+def _run(*args: object) -> str:
+  return subprocess.run(
+    [sys.executable, "-P", str(_HELPER), *map(str, args)],
+    check=True,
+    capture_output=True,
+    text=True,
+  ).stdout.strip()
+
+
+def _record(path: Path) -> tuple[int, str]:
+  parts = path.read_text().split()
+  return int(parts[0]), parts[2]
+
+
+def test_begin_upgrades_legacy_record_and_returns_prior_and_current(tmp_path):
+  counter = tmp_path / ".boot-attempt"
+  counter.write_text("2 2026-07-28T00:00:00Z\n")
+
+  assert _run("begin", counter, "boot-a") == "2 3"
+  assert _record(counter) == (3, "boot-a")
+
+
+def test_begin_treats_malformed_or_negative_legacy_count_as_zero(tmp_path):
+  for index, legacy in enumerate((
+    "not-a-count 2026-07-28T00:00:00Z\n",
+    "-7 2026-07-28T00:00:00Z\n",
+  )):
+    counter = tmp_path / f".boot-attempt-{index}"
+    counter.write_text(legacy)
+
+    assert _run("begin", counter, "boot-a") == "0 1"
+    assert _record(counter) == (1, "boot-a")
+
+
+def test_stale_boot_cannot_reset_or_roll_back_a_newer_boot(tmp_path):
+  counter = tmp_path / ".boot-attempt"
+  assert _run("begin", counter, "boot-a") == "0 1"
+  assert _run("begin", counter, "boot-b") == "1 2"
+
+  assert _run("reset", counter, "boot-a") == "0"
+  assert _run("rollback", counter, "boot-a", 1, 0) == "0"
+  assert _record(counter) == (2, "boot-b")
+
+
+def test_rollback_is_an_exact_compare_and_swap(tmp_path):
+  counter = tmp_path / ".boot-attempt"
+  assert _run("begin", counter, "boot-a") == "0 1"
+
+  assert _run("rollback", counter, "boot-a", 2, 0) == "0"
+  assert _record(counter) == (1, "boot-a")
+  assert _run("rollback", counter, "boot-a", 1, 0) == "1"
+  assert _record(counter) == (0, "boot-a")
+
+
+def test_atomic_replacement_preserves_existing_counter_mode(tmp_path):
+  counter = tmp_path / ".boot-attempt"
+  counter.write_text("0 2026-07-28T00:00:00Z\n")
+  counter.chmod(0o640)
+
+  _run("begin", counter, "boot-a")
+  _run("reset", counter, "boot-a")
+
+  assert stat.S_IMODE(counter.stat().st_mode) == 0o640
+
+
+def test_concurrent_health_reset_and_component_rollback_converge_to_zero(
+  tmp_path,
+):
+  # Whichever command acquires the lock first, reset wins: rollback-first is
+  # followed by reset(0), while reset-first makes rollback's expected count
+  # stale. Repeat to exercise both scheduler orders without timing hooks.
+  for index in range(12):
+    counter = tmp_path / f".boot-attempt-{index}"
+    assert _run("begin", counter, "boot-a") == "0 1"
+    commands = (
+      ("reset", counter, "boot-a"),
+      ("rollback", counter, "boot-a", 1, 0),
+    )
+    with ThreadPoolExecutor(max_workers=2) as pool:
+      list(pool.map(lambda args: _run(*args), commands))
+    assert _record(counter) == (0, "boot-a")

--- a/backend/tests/test_railway_gateway.py
+++ b/backend/tests/test_railway_gateway.py
@@ -1,6 +1,9 @@
 import importlib.util
+import io
 import http.client
+import socket
 import threading
+from email.message import Message
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
@@ -51,6 +54,298 @@ def test_gateway_has_no_app_imports():
     assert not stripped.startswith("import app"), stripped
     assert not stripped.startswith("from app "), stripped
     assert not stripped.startswith("from app."), stripped
+
+
+def _body_handler(gateway, headers, body=b""):
+  handler = object.__new__(gateway.Gateway)
+  parsed = Message()
+  for key, value in headers:
+    parsed[key] = value
+  handler.headers = parsed
+  handler.rfile = io.BytesIO(body)
+  return handler
+
+
+def test_fixed_length_body_is_bounded_and_never_reads_the_next_request():
+  gateway = _load_gateway()
+  following_request = b"GET /next HTTP/1.1\r\n\r\n"
+  stream = io.BytesIO(b"x" * (gateway.BODY_CHUNK_BYTES + 5) + following_request)
+  body = gateway.FixedLengthBody(stream, gateway.BODY_CHUNK_BYTES + 5)
+
+  chunks = []
+  while chunk := body.read(1_000_000):
+    chunks.append(chunk)
+
+  assert max(map(len, chunks)) <= gateway.BODY_CHUNK_BYTES
+  assert b"".join(chunks) == b"x" * (gateway.BODY_CHUNK_BYTES + 5)
+  assert stream.read() == following_request
+
+
+def test_chunked_body_decodes_incrementally_and_consumes_trailers():
+  gateway = _load_gateway()
+  handler = _body_handler(gateway, [("Transfer-Encoding", "chunked")], (
+    b"4;fixture=yes\r\nWiki\r\n"
+    b"5\r\npedia\r\n"
+    b"0\r\nIgnored-Trailer: value\r\n\r\n"
+    b"GET /next HTTP/1.1\r\n\r\n"
+  ))
+
+  body, encode_chunked = handler._request_body()
+
+  assert encode_chunked is True
+  assert b"".join(body) == b"Wikipedia"
+  assert handler.rfile.read() == b"GET /next HTTP/1.1\r\n\r\n"
+
+
+def test_chunked_body_bounds_one_large_downstream_chunk():
+  gateway = _load_gateway()
+  payload = b"x" * (gateway.BODY_CHUNK_BYTES + 5)
+  framed = (
+    f"{len(payload):X}\r\n".encode("ascii")
+    + payload
+    + b"\r\n0\r\n\r\n"
+  )
+
+  chunks = list(gateway.ChunkedBody(io.BytesIO(framed)))
+
+  assert max(map(len, chunks)) <= gateway.BODY_CHUNK_BYTES
+  assert b"".join(chunks) == payload
+
+
+@pytest.mark.parametrize(
+  ("headers", "error", "status"),
+  [
+    (
+      [("Content-Length", "1"), ("Transfer-Encoding", "chunked")],
+      "Content-Length and Transfer-Encoding cannot be combined",
+      400,
+    ),
+    ([("Content-Length", "-1")], "invalid Content-Length", 400),
+    ([("Transfer-Encoding", "gzip")], "only chunked", 501),
+    ([("Transfer-Encoding", "gzip, chunked")], "only chunked", 501),
+  ],
+)
+def test_request_body_rejects_ambiguous_or_unsupported_framing(
+  headers, error, status,
+):
+  gateway = _load_gateway()
+  handler = _body_handler(gateway, headers)
+
+  with pytest.raises(gateway.RequestBodyError, match=error) as exc:
+    handler._request_body()
+  assert exc.value.status == status
+
+
+def test_request_body_rejects_unbounded_numeric_framing_fields():
+  gateway = _load_gateway()
+  handler = _body_handler(
+    gateway,
+    [("Content-Length", "9" * (gateway.MAX_CONTENT_LENGTH_DIGITS + 1))],
+  )
+  with pytest.raises(gateway.RequestBodyError, match="invalid Content-Length"):
+    handler._request_body()
+
+  framed = (
+    b"f" * (gateway.MAX_CHUNK_SIZE_DIGITS + 1)
+    + b"\r\n0\r\n\r\n"
+  )
+  with pytest.raises(gateway.RequestBodyError, match="invalid chunk size"):
+    next(iter(gateway.ChunkedBody(io.BytesIO(framed))))
+
+
+def test_zero_length_request_body_is_an_ordinary_empty_body():
+  gateway = _load_gateway()
+  handler = _body_handler(gateway, [("Content-Length", "0")])
+
+  body, encode_chunked = handler._request_body()
+
+  assert body is None
+  assert encode_chunked is False
+
+
+def test_gateway_removes_tokens_from_every_connection_header():
+  gateway = _load_gateway()
+  handler = _body_handler(
+    gateway,
+    [
+      ("Connection", "X-First"),
+      ("Connection", "X-Second, keep-alive"),
+      ("X-First", "private"),
+      ("X-Second", "private"),
+      ("X-End-To-End", "public"),
+    ],
+  )
+  handler.client_address = ("127.0.0.1", 1234)
+
+  headers = handler._headers()
+
+  assert "X-First" not in headers
+  assert "X-Second" not in headers
+  assert headers["X-End-To-End"] == "public"
+
+
+def test_gateway_streams_fixed_length_upload_before_client_finishes():
+  gateway = _load_gateway()
+  first_received = threading.Event()
+  received = []
+
+  class UploadTarget(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def do_POST(self):  # noqa: N802
+      length = int(self.headers["Content-Length"])
+      received.append(self.rfile.read(5))
+      first_received.set()
+      received.append(self.rfile.read(length - 5))
+      self.send_response(204)
+      self.send_header("Content-Length", "0")
+      self.end_headers()
+
+    def log_message(self, _format, *_args):
+      pass
+
+  upstream = ThreadingHTTPServer(("127.0.0.1", 0), UploadTarget)
+  gateway.Gateway.app_upstream = ("127.0.0.1", upstream.server_port)
+  gateway.Gateway.recovery_upstream = gateway.Gateway.app_upstream
+  proxy = ThreadingHTTPServer(("127.0.0.1", 0), gateway.Gateway)
+  threads = [
+    threading.Thread(target=server.serve_forever, daemon=True)
+    for server in (upstream, proxy)
+  ]
+  for thread in threads:
+    thread.start()
+
+  client = socket.create_connection(("127.0.0.1", proxy.server_port), timeout=2)
+  try:
+    client.sendall(
+      b"POST /upload HTTP/1.1\r\n"
+      b"Host: example.test\r\n"
+      b"Content-Length: 10\r\n"
+      b"Connection: close\r\n\r\n"
+      b"first"
+    )
+    assert first_received.wait(timeout=1), (
+      "the gateway buffered the body instead of forwarding available bytes"
+    )
+    client.sendall(b"last!")
+    response = b""
+    while chunk := client.recv(4096):
+      response += chunk
+    assert b" 204 " in response.split(b"\r\n", 1)[0]
+    assert received == [b"first", b"last!"]
+  finally:
+    client.close()
+    for server in (proxy, upstream):
+      server.shutdown()
+      server.server_close()
+
+
+def test_gateway_decodes_and_rechunks_streaming_uploads():
+  gateway = _load_gateway()
+  received = []
+
+  class ChunkedUploadTarget(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def do_POST(self):  # noqa: N802
+      assert self.headers["Transfer-Encoding"].lower() == "chunked"
+      while True:
+        size = int(self.rfile.readline().strip(), 16)
+        if size == 0:
+          assert self.rfile.readline() == b"\r\n"
+          break
+        received.append(self.rfile.read(size))
+        assert self.rfile.read(2) == b"\r\n"
+      self.send_response(204)
+      self.send_header("Content-Length", "0")
+      self.end_headers()
+
+    def log_message(self, _format, *_args):
+      pass
+
+  upstream = ThreadingHTTPServer(("127.0.0.1", 0), ChunkedUploadTarget)
+  gateway.Gateway.app_upstream = ("127.0.0.1", upstream.server_port)
+  gateway.Gateway.recovery_upstream = gateway.Gateway.app_upstream
+  proxy = ThreadingHTTPServer(("127.0.0.1", 0), gateway.Gateway)
+  threads = [
+    threading.Thread(target=server.serve_forever, daemon=True)
+    for server in (upstream, proxy)
+  ]
+  for thread in threads:
+    thread.start()
+
+  client = http.client.HTTPConnection(
+    "127.0.0.1", proxy.server_port, timeout=2,
+  )
+  try:
+    client.request(
+      "POST",
+      "/upload",
+      body=iter((b"Wiki", b"pedia")),
+      encode_chunked=True,
+    )
+    response = client.getresponse()
+    assert response.status == 204
+    assert response.read() == b""
+    assert received == [b"Wiki", b"pedia"]
+  finally:
+    client.close()
+    for server in (proxy, upstream):
+      server.shutdown()
+      server.server_close()
+
+
+def test_gateway_close_delimits_decoded_chunked_responses():
+  gateway = _load_gateway()
+  payload = b"decoded response"
+
+  class ChunkedTarget(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def do_GET(self):  # noqa: N802
+      self.send_response(200)
+      self.send_header("Transfer-Encoding", "chunked")
+      self.send_header("Content-Length", "999")
+      self.send_header("Connection", "X-Upstream-Only")
+      self.send_header("X-Upstream-Only", "private")
+      self.end_headers()
+      self.wfile.write(
+        f"{len(payload):X}\r\n".encode("ascii")
+        + payload
+        + b"\r\n0\r\n\r\n"
+      )
+      self.wfile.flush()
+
+    def log_message(self, _format, *_args):
+      pass
+
+  upstream = ThreadingHTTPServer(("127.0.0.1", 0), ChunkedTarget)
+  gateway.Gateway.app_upstream = ("127.0.0.1", upstream.server_port)
+  gateway.Gateway.recovery_upstream = gateway.Gateway.app_upstream
+  proxy = ThreadingHTTPServer(("127.0.0.1", 0), gateway.Gateway)
+  threads = [
+    threading.Thread(target=server.serve_forever, daemon=True)
+    for server in (upstream, proxy)
+  ]
+  for thread in threads:
+    thread.start()
+
+  client = http.client.HTTPConnection(
+    "127.0.0.1", proxy.server_port, timeout=2,
+  )
+  try:
+    client.request("GET", "/")
+    response = client.getresponse()
+    assert response.status == 200
+    assert response.getheader("Content-Length") is None
+    assert response.getheader("Transfer-Encoding") is None
+    assert response.getheader("X-Upstream-Only") is None
+    assert response.read() == payload
+  finally:
+    client.close()
+    for server in (proxy, upstream):
+      server.shutdown()
+      server.server_close()
 
 
 def test_gateway_forwards_sse_before_the_upstream_stream_finishes():
@@ -107,14 +402,23 @@ def test_gateway_forwards_sse_before_the_upstream_stream_finishes():
       server.server_close()
 
 
-def test_railway_entrypoint_supervises_gateway_and_app_processes():
+def test_railway_entrypoint_supervises_every_essential_process():
   entrypoint = (
     Path(__file__).resolve().parents[1] / "scripts" / "entrypoint.sh"
   ).read_text()
   assert "_wait_for_railway_child_exit" in entrypoint
   assert '_railway_child_running "$_gateway_pid"' in entrypoint
   assert '_railway_child_running "$_app_pid"' in entrypoint
+  assert '_railway_child_running "$_recovery_pid"' in entrypoint
   assert '"/proc/${_child_pid}/status"' in entrypoint
   assert 'wait "$_gateway_pid"' in entrypoint
   assert 'wait "$_app_pid"' in entrypoint
+  assert 'wait "$_recovery_pid"' in entrypoint
+  assert "Railway recovery process exited" in entrypoint
+  assert "recoveryd exited with status" not in entrypoint
   assert "A clean child exit is still a service failure" in entrypoint
+
+  railway = Path(__file__).resolve().parents[2] / "railway.toml"
+  config = railway.read_text()
+  assert 'restartPolicyType = "ON_FAILURE"' in config
+  assert "restartPolicyMaxRetries" in config

--- a/backend/tests/test_railway_gateway.py
+++ b/backend/tests/test_railway_gateway.py
@@ -400,25 +400,3 @@ def test_gateway_forwards_sse_before_the_upstream_stream_finishes():
     for server in (proxy, upstream):
       server.shutdown()
       server.server_close()
-
-
-def test_railway_entrypoint_supervises_every_essential_process():
-  entrypoint = (
-    Path(__file__).resolve().parents[1] / "scripts" / "entrypoint.sh"
-  ).read_text()
-  assert "_wait_for_railway_child_exit" in entrypoint
-  assert '_railway_child_running "$_gateway_pid"' in entrypoint
-  assert '_railway_child_running "$_app_pid"' in entrypoint
-  assert '_railway_child_running "$_recovery_pid"' in entrypoint
-  assert '"/proc/${_child_pid}/status"' in entrypoint
-  assert 'wait "$_gateway_pid"' in entrypoint
-  assert 'wait "$_app_pid"' in entrypoint
-  assert 'wait "$_recovery_pid"' in entrypoint
-  assert "Railway recovery process exited" in entrypoint
-  assert "recoveryd exited with status" not in entrypoint
-  assert "A clean child exit is still a service failure" in entrypoint
-
-  railway = Path(__file__).resolve().parents[2] / "railway.toml"
-  config = railway.read_text()
-  assert 'restartPolicyType = "ON_FAILURE"' in config
-  assert "restartPolicyMaxRetries" in config

--- a/backend/tests/test_railway_supervision.py
+++ b/backend/tests/test_railway_supervision.py
@@ -1,0 +1,368 @@
+import os
+import signal
+import socket
+import subprocess
+import sys
+import textwrap
+import time
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+
+_SUPERVISION_PATH = (
+  Path(__file__).resolve().parents[1] / "scripts" / "railway_supervision.sh"
+)
+_COUNTER_PATH = (
+  Path(__file__).resolve().parents[1] / "scripts" / "boot_attempt_counter.py"
+)
+
+
+def _free_port() -> int:
+  with socket.socket() as sock:
+    sock.bind(("127.0.0.1", 0))
+    return sock.getsockname()[1]
+
+
+def _write_fake_recovery(tmp_path: Path) -> Path:
+  child = tmp_path / "fake_recovery.py"
+  child.write_text(textwrap.dedent("""
+    import os
+    import signal
+    import threading
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+    from pathlib import Path
+
+    count_path = Path(os.environ["FAKE_RECOVERY_COUNT"])
+    count = int(count_path.read_text()) + 1 if count_path.exists() else 1
+    count_path.write_text(str(count))
+    scenario = os.environ["FAKE_RECOVERY_SCENARIO"]
+    attempts = Path(os.environ["RECOVERY_LIVE_ROOT"]) / ".attempts"
+
+    if scenario in {"fallback", "terminal"} and count <= 3:
+      attempts.parent.mkdir(parents=True, exist_ok=True)
+      prior = int(attempts.read_text()) if attempts.exists() else 0
+      attempts.write_text(str(prior + 1))
+      raise SystemExit(7)
+    if scenario == "terminal":
+      raise SystemExit(9)
+    if scenario == "clean-unready":
+      raise SystemExit(0)
+
+    class Handler(BaseHTTPRequestHandler):
+      def do_GET(self):
+        self.send_response(200)
+        self.send_header("Content-Length", "2")
+        self.end_headers()
+        self.wfile.write(b"ok")
+
+      def log_message(self, _format, *_args):
+        pass
+
+    class Server(ThreadingHTTPServer):
+      allow_reuse_address = True
+
+    server = Server(("127.0.0.1", int(os.environ["FAKE_RECOVERY_PORT"])), Handler)
+
+    def stop(_signum, _frame):
+      marker = os.environ.get("FAKE_RECOVERY_TERM")
+      if marker:
+        Path(marker).write_text("terminated")
+      os._exit(0)
+
+    signal.signal(signal.SIGTERM, stop)
+    signal.signal(signal.SIGINT, stop)
+    if scenario in {"planned", "ready-crash"} and count == 1:
+      exit_status = 0 if scenario == "planned" else 11
+      timer = threading.Timer(2.5, lambda: os._exit(exit_status))
+      timer.daemon = True
+      timer.start()
+    server.serve_forever()
+  """))
+  return child
+
+
+def _start_recovery_supervisor(
+  tmp_path: Path,
+  scenario: str,
+) -> tuple[subprocess.Popen, int, Path, Path]:
+  port = _free_port()
+  count = tmp_path / "launch-count"
+  term = tmp_path / "term-marker"
+  live_root = tmp_path / "recovery-live"
+  child = _write_fake_recovery(tmp_path)
+  env = os.environ.copy()
+  env.update({
+    "FAKE_RECOVERY_COUNT": str(count),
+    "FAKE_RECOVERY_PORT": str(port),
+    "FAKE_RECOVERY_SCENARIO": scenario,
+    "FAKE_RECOVERY_TERM": str(term),
+    "RECOVERY_LIVE_ROOT": str(live_root),
+  })
+  process = subprocess.Popen(
+    [
+      "sh", "-c",
+      '. "$1"; shift; railway_supervise_recovery "$@"',
+      "railway-recovery-supervisor",
+      str(_SUPERVISION_PATH),
+      f"http://127.0.0.1:{port}/recover/health",
+      sys.executable,
+      str(child),
+    ],
+    env=env,
+    stdout=subprocess.DEVNULL,
+    stderr=subprocess.PIPE,
+    text=True,
+  )
+  return process, port, count, term
+
+
+def _wait_until(predicate, *, timeout: float = 8) -> None:
+  deadline = time.monotonic() + timeout
+  while time.monotonic() < deadline:
+    if predicate():
+      return
+    time.sleep(0.05)
+  raise AssertionError("condition did not become true before timeout")
+
+
+def _health_ok(port: int) -> bool:
+  try:
+    with urllib.request.urlopen(
+      f"http://127.0.0.1:{port}/recover/health",
+      timeout=0.2,
+    ) as response:
+      return response.status == 200 and response.read() == b"ok"
+  except OSError:
+    return False
+
+
+def _stop_supervisor(process: subprocess.Popen) -> tuple[str, str]:
+  if process.poll() is None:
+    process.terminate()
+  try:
+    return process.communicate(timeout=5)
+  except subprocess.TimeoutExpired:
+    os.kill(process.pid, signal.SIGKILL)
+    return process.communicate(timeout=2)
+
+
+def test_ready_recovery_clean_exit_reloads_without_exiting_supervisor(tmp_path):
+  process, port, count, _term = _start_recovery_supervisor(tmp_path, "planned")
+  try:
+    _wait_until(
+      lambda: count.exists() and int(count.read_text()) >= 2 and _health_ok(port),
+    )
+    assert process.poll() is None
+    assert int(count.read_text()) == 2
+  finally:
+    _stop_supervisor(process)
+
+
+def test_ready_recovery_nonzero_exit_is_terminal_without_relaunch(tmp_path):
+  process, _port, count, _term = _start_recovery_supervisor(
+    tmp_path,
+    "ready-crash",
+  )
+  _stdout, stderr = process.communicate(timeout=5)
+
+  assert process.returncode == 11
+  assert int(count.read_text()) == 1
+  assert "exited after readiness with status 11" in stderr
+
+
+def test_three_live_failures_earn_a_fourth_baked_launch(tmp_path):
+  process, port, count, _term = _start_recovery_supervisor(tmp_path, "fallback")
+  try:
+    _wait_until(
+      lambda: count.exists() and int(count.read_text()) == 4 and _health_ok(port),
+    )
+    assert process.poll() is None
+  finally:
+    _stop_supervisor(process)
+
+
+def test_fourth_pre_ready_failure_is_terminal(tmp_path):
+  process, _port, count, _term = _start_recovery_supervisor(tmp_path, "terminal")
+  _stdout, stderr = process.communicate(timeout=8)
+
+  assert process.returncode == 9
+  assert int(count.read_text()) == 4
+  assert "without advancing its trusted-live attempts" in stderr
+
+
+def test_clean_exit_before_readiness_is_terminal_not_an_unbounded_reload(
+  tmp_path,
+):
+  process, _port, count, _term = _start_recovery_supervisor(
+    tmp_path,
+    "clean-unready",
+  )
+  _stdout, stderr = process.communicate(timeout=5)
+
+  assert process.returncode == 1
+  assert int(count.read_text()) == 1
+  assert "without advancing its trusted-live attempts" in stderr
+
+
+def test_supervisor_term_forwards_to_child_without_relaunch(tmp_path):
+  process, port, count, term = _start_recovery_supervisor(tmp_path, "term")
+  _wait_until(lambda: count.exists() and _health_ok(port))
+
+  process.terminate()
+  process.communicate(timeout=5)
+  time.sleep(1.2)
+
+  assert process.returncode == 0
+  assert term.read_text() == "terminated"
+  assert int(count.read_text()) == 1
+
+
+@pytest.mark.parametrize(
+  ("component", "child_status", "expected_status", "expected_count"),
+  [
+    ("recovery", 0, 1, 7),
+    ("app", 7, 7, 8),
+    ("gateway", 9, 9, 7),
+  ],
+)
+def test_essential_child_exit_attributes_boot_attempt_to_owning_component(
+  tmp_path,
+  component,
+  child_status,
+  expected_status,
+  expected_count,
+):
+  counter = tmp_path / ".boot-attempt"
+  subprocess.run(
+    [
+      sys.executable, "-P", str(_COUNTER_PATH),
+      "begin", str(counter), "boot-a",
+    ],
+    check=True,
+    capture_output=True,
+    text=True,
+  )
+  # Raise the exact current charge while keeping the helper-authenticated boot
+  # id. The wait helper should restore 7 only for a non-app component.
+  counter.write_text("8 2026-07-28T00:00:00Z boot-a\n")
+  script = textwrap.dedent("""
+    . "$1"
+    component="$2"
+    child_status="$3"
+    (sleep 10) & gateway=$!
+    (sleep 10) & app=$!
+    (sleep 10) & recovery=$!
+    case "$component" in
+      gateway) kill "$gateway"; wait "$gateway" 2>/dev/null || true
+               (exit "$child_status") & gateway=$! ;;
+      app) kill "$app"; wait "$app" 2>/dev/null || true
+           (exit "$child_status") & app=$! ;;
+      recovery) kill "$recovery"; wait "$recovery" 2>/dev/null || true
+                (exit "$child_status") & recovery=$! ;;
+    esac
+    railway_wait_for_essential_child_exit \
+      "$gateway" "$app" "$recovery" "$4" "$5" boot-a 7 8
+    result=$?
+    kill "$gateway" "$app" "$recovery" 2>/dev/null || true
+    wait "$gateway" 2>/dev/null || true
+    wait "$app" 2>/dev/null || true
+    wait "$recovery" 2>/dev/null || true
+    printf '%s %s\n' "$result" "$(cut -d' ' -f1 "$5")"
+  """)
+  completed = subprocess.run(
+    [
+      "sh", "-c", script, "railway-child-wait",
+      str(_SUPERVISION_PATH), component, str(child_status),
+      str(_COUNTER_PATH), str(counter),
+    ],
+    check=True,
+    capture_output=True,
+    text=True,
+    timeout=8,
+  )
+
+  assert completed.stdout.strip() == f"{expected_status} {expected_count}"
+
+
+def test_simultaneous_app_and_recovery_exit_is_charged_to_app(tmp_path):
+  counter = tmp_path / ".boot-attempt"
+  subprocess.run(
+    [
+      sys.executable, "-P", str(_COUNTER_PATH),
+      "begin", str(counter), "boot-a",
+    ],
+    check=True,
+    capture_output=True,
+    text=True,
+  )
+  counter.write_text("1 2026-07-28T00:00:00Z boot-a\n")
+  script = textwrap.dedent("""
+    . "$1"
+    (sleep 10) & gateway=$!
+    (exit 6) & app=$!
+    (exit 7) & recovery=$!
+    railway_wait_for_essential_child_exit \
+      "$gateway" "$app" "$recovery" "$2" "$3" boot-a 0 1
+    result=$?
+    kill "$gateway" 2>/dev/null || true
+    wait "$gateway" 2>/dev/null || true
+    printf '%s %s\n' "$result" "$(cut -d' ' -f1 "$3")"
+  """)
+  completed = subprocess.run(
+    [
+      "sh", "-c", script, "railway-child-wait",
+      str(_SUPERVISION_PATH), str(_COUNTER_PATH), str(counter),
+    ],
+    check=True,
+    capture_output=True,
+    text=True,
+    timeout=8,
+  )
+
+  assert completed.stdout.strip() == "6 1"
+
+
+def test_railway_entrypoint_supervises_every_essential_process():
+  entrypoint = (
+    Path(__file__).resolve().parents[1] / "scripts" / "entrypoint.sh"
+  ).read_text()
+  supervision = _SUPERVISION_PATH.read_text()
+  assert "_wait_for_railway_child_exit" in entrypoint
+  assert ". /app/scripts/railway_supervision.sh" in entrypoint
+  assert "railway_supervise_recovery" in entrypoint
+  assert "railway_wait_for_essential_child_exit" in entrypoint
+  assert "boot_attempt_counter.py" in entrypoint
+  assert (
+    "automatic crash-loop restore is disabled for this boot"
+    in entrypoint
+  )
+  early_gateway = entrypoint[
+    entrypoint.index("Railway gateway exited before app startup."):
+    entrypoint.index("_wait_for_railway_child_exit", entrypoint.index(
+      "Railway gateway exited before app startup.",
+    ))
+  ]
+  assert "railway_rollback_platform_boot_attempt" in early_gateway
+  assert 'railway_child_running "$_app_pid"' in early_gateway
+  assert 'railway_child_running "$_railway_app_pid"' in supervision
+  assert 'wait "$_railway_app_pid"' in supervision
+  assert 'wait "$_railway_gateway_pid"' in supervision
+  assert 'wait "$_railway_recovery_pid"' in supervision
+  assert "railway_recovery_live_attempts" in supervision
+  assert "_MAX_LIVE_ATTEMPTS" not in supervision
+  assert "recoveryd exited with status" not in entrypoint
+  assert "A clean essential-child exit is still a service failure" in supervision
+  assert ".boot-attempt.lock" in entrypoint
+
+  protected = (
+    Path(__file__).resolve().parents[2] / "protected-files.txt"
+  ).read_text()
+  assert "/app/scripts/boot_attempt_counter.py" in protected
+  assert "/app/scripts/railway_supervision.sh" in protected
+
+  railway = Path(__file__).resolve().parents[2] / "railway.toml"
+  config = railway.read_text()
+  assert 'restartPolicyType = "ON_FAILURE"' in config
+  assert "restartPolicyMaxRetries" in config

--- a/protected-files.txt
+++ b/protected-files.txt
@@ -20,4 +20,6 @@
 # Recovery no longer depends on freezing the boot chain; the separate recoveryd
 # container is the floor. Only the baked boot/restore scripts stay frozen.
 /app/scripts/entrypoint.sh
+/app/scripts/boot_attempt_counter.py
+/app/scripts/railway_supervision.sh
 /app/scripts/recovery_restore.sh


### PR DESCRIPTION
## Summary
- stream fixed-length and chunked uploads through the Railway gateway with bounded per-read buffers, reject ambiguous framing, and remove connection-scoped headers in both directions
- keep gateway and app exits deployment-fatal while giving recoveryd a bounded component-local relaunch path for planned updates and its trusted-live-to-baked fallback
- serialize boot-attempt updates behind a boot-scoped lock and compare-and-set so gateway or recovery failures cannot be mischarged as platform failures or race a successful health reset

## Why
The gateway previously buffered each fixed-length request body in one allocation and could not safely accept downstream chunked uploads. Large uploads therefore scaled process memory with payload size, and valid streaming clients were unsupported.

Recovery supervision has a separate lifecycle contract: recoveryd intentionally exits after a self-update, and a bad trusted live copy may need three failed launches before the fourth launch selects the baked recovery floor. Spending Railway's three whole-container retries on those expected handoffs can make Recovery unavailable exactly when it is needed.

The bounded design allows only earned local relaunches. A ready process may exit cleanly for its documented update reload. Before readiness, a retry must advance recoveryd's persisted trusted-live attempt counter; the unchanged counter identifies a failed baked floor and terminates the component. Clean pre-ready exits and non-zero post-ready crashes are terminal, so there is no unbounded inner restart loop. A separate locked boot ledger attributes app failures to the platform while rolling back only the exact current boot charge for gateway or recovery failures.

Payload totals, concurrency, agent browsers, and power-user capacity remain unrestricted. Only individual buffer reads, framing metadata, and recovery state transitions are bounded.

## Testing
- `MOBIUS_TEST_RUNTIME=1 python3 -m pytest -q backend/tests/test_boot_attempt_counter.py backend/tests/test_railway_supervision.py backend/tests/test_railway_gateway.py backend/tests/test_recovery_launcher.py backend/tests/test_recovery_update.py` (100 passed)
- black-box regressions cover planned reload, three live failures plus the baked fourth launch, baked failure, clean pre-ready exit, non-zero post-ready crash, TERM forwarding, and boot-attempt attribution
- `sh -n backend/scripts/entrypoint.sh backend/scripts/railway_supervision.sh`
- Python compilation checks for all changed Python sources and tests
- `git diff --check`
