### PR TITLE
Deduplicate agent CLI payloads in the container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,11 +113,16 @@ RUN git clone --depth 1 --branch v1.0.6 \
 WORKDIR /app
 
 COPY backend/requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt \
+    && python -c \
+      'from pathlib import Path; import claude_agent_sdk; p = Path(claude_agent_sdk.__file__).parent / "_bundled" / "claude"; p.unlink(missing_ok=True); assert not p.exists()'
 
-# openai-codex Python SDK: installed in a separate step because its
-# upstream pyproject pins a specific openai-codex-cli-bin. Install
-# --no-deps so Docker keeps the exact runtime pin below explicit.
+# openai-codex Python SDK: its upstream pyproject pins a second, older
+# openai-codex-cli-bin payload. Keep that declared package so `pip check` and
+# owner-authored Python SDK code retain the documented default constructor, but
+# replace its private payload in the SAME image layer with a link to Möbius's
+# lockstep npm CLI. This preserves the external SDK contract without storing a
+# second ~350 MB runtime or running a second protocol version.
 # Pinned to commit SHA (not tag) for full reproducibility — tags are
 # mutable on GitHub. SHA corresponds to refs/tags/rust-v0.145.0
 # as of 2026-07-24, and is kept in lockstep with the npm @openai/codex
@@ -136,7 +141,17 @@ RUN pip install --no-cache-dir -r requirements.txt
 # client's `_approval_handler`.
 RUN pip install --no-cache-dir --no-deps \
       'openai-codex @ git+https://github.com/openai/codex.git@25af12f7e61572b0bc18ddb1008be543b91519b0#subdirectory=sdk/python' \
-    && pip install --no-cache-dir 'openai-codex-cli-bin==0.144.4'
+    && pip install --no-cache-dir 'openai-codex-cli-bin==0.144.4' \
+    && _codex_cli_bin="$(python -c \
+      'from pathlib import Path; import codex_cli_bin; print(Path(codex_cli_bin.__file__).parent)')" \
+    && rm -rf "${_codex_cli_bin}/bin" \
+      "${_codex_cli_bin}/codex-path" \
+      "${_codex_cli_bin}/codex-resources" \
+    && mkdir -p "${_codex_cli_bin}/bin" \
+    && ln -s /usr/local/bin/codex "${_codex_cli_bin}/bin/codex" \
+    && python -c \
+      'from pathlib import Path; import openai_codex; from codex_cli_bin import bundled_codex_path; assert bundled_codex_path().samefile(Path("/usr/local/bin/codex"))' \
+    && pip check
 
 # Capture each installed agent CLI's npm publish date into a small JSON the
 # Settings row reads (routes/settings._cli_release_dates), keyed by the

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,6 +15,6 @@ pytest>=8.0
 pytest-asyncio>=0.23
 watchdog>=4.0.0
 claude-agent-sdk==0.2.126
-# openai-codex is installed in a separate Dockerfile step:
-# its upstream pyproject pins a specific openai-codex-cli-bin, so Docker
-# installs --no-deps and pins the cli-bin explicitly there.
+# openai-codex is installed --no-deps from a pinned Git SHA in Dockerfile.
+# Its declared cli-bin package is retained for SDK compatibility, but its
+# duplicate payload is replaced in-layer with a link to the pinned npm CLI.

--- a/backend/tests/test_verify_test_runtime.py
+++ b/backend/tests/test_verify_test_runtime.py
@@ -140,6 +140,37 @@ def test_node_runtime_satisfies_the_pinned_agent_browser_engine():
   assert "node:22" not in preship
 
 
+def test_image_deduplicates_agent_cli_payloads_without_breaking_sdk_contracts():
+  dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+  requirements = (ROOT / "backend" / "requirements.txt").read_text(
+    encoding="utf-8"
+  )
+
+  requirements_layer = dockerfile[
+    dockerfile.index("COPY backend/requirements.txt ."):
+    dockerfile.index("# openai-codex Python SDK:")
+  ]
+  assert "pip install --no-cache-dir -r requirements.txt" in requirements_layer
+  assert (
+    'Path(claude_agent_sdk.__file__).parent / "_bundled" / "claude"'
+    in requirements_layer
+    and "unlink(missing_ok=True)" in requirements_layer
+    and "assert not p.exists()" in requirements_layer
+  )
+
+  codex_layer = dockerfile[
+    dockerfile.index("# openai-codex Python SDK:"):
+    dockerfile.index("# Capture each installed agent CLI")
+  ]
+  assert "pip install --no-cache-dir --no-deps" in codex_layer
+  assert "pip install --no-cache-dir 'openai-codex-cli-bin==0.144.4'" in codex_layer
+  assert 'rm -rf "${_codex_cli_bin}/bin"' in codex_layer
+  assert 'ln -s /usr/local/bin/codex "${_codex_cli_bin}/bin/codex"' in codex_layer
+  assert "bundled_codex_path().samefile" in codex_layer
+  assert "pip check" in codex_layer
+  assert "declared cli-bin package is retained for SDK compatibility" in requirements
+
+
 def test_pre_push_syntax_check_keeps_bytecode_out_of_checkout():
   hook = (ROOT / "scripts" / "githooks" / "pre-push").read_text(
     encoding="utf-8"


### PR DESCRIPTION
## Summary
- remove the SDK-bundled Claude CLI in the same image layer that installs the Python requirements
- keep the Codex runtime package contract, but replace its private payload with a link to the authoritative npm CLI
- verify the compatibility link and Python dependency consistency during the image build

## Why
The container currently stores both npm-installed CLIs and provider-SDK copies of the same large runtimes. The duplicate payloads add roughly 596 MiB of uncompressed files without serving a distinct Möbius runtime path.

The Codex package metadata remains installed so owner-authored Python SDK code can still use the documented default constructor. Only the duplicate executable resources are replaced, keeping one authoritative runtime version without reducing agent, browser, or concurrency capacity.

## Testing
- `MOBIUS_TEST_RUNTIME=1 python3 -m pytest -q backend/tests/test_verify_test_runtime.py` (26 passed)
- build-stage assertions cover Claude bundle removal, the Codex default runtime locator, and `pip check`

Docker is not available in the running Möbius container, so the final compressed image size remains for CI to measure.