### PR TITLE
Seed manager sessions with one-call evidence

### DIFF
--- a/backend/scripts/seed-skills/manager-session-evidence.py
+++ b/backend/scripts/seed-skills/manager-session-evidence.py
@@ -1,0 +1,561 @@
+#!/usr/bin/env python3
+# Usage: python3 /data/shared/skills/manager-session-evidence.py [--hours 72] [--limit 5] [--traces 12] [--memory-writer-packet] [CHAT_ID]
+"""One consolidated performance bundle for a manager session, in ONE call.
+
+Instead of running many sequential tools (read the memory run-status, tail the
+update log, cross-check read-traces against the chat DB, tail reflection
+metrics, list interview artifacts, curl the skills API), this prints all of it
+as a single readable report so a 1-on-1 can start from one command.
+
+Read-only, defensive (missing pieces are skipped, never fatal), python3 stdlib
++ sqlite3 only. It gathers evidence; it does not judge — the manager session
+reads the bundle and forms the coaching.
+"""
+
+import argparse
+import ast
+import datetime as dt
+import json
+import os
+import sqlite3
+import subprocess
+import urllib.parse
+import urllib.request
+
+DB_PATH = "/data/db/ultimate.db"
+MEM_STATE = "/data/shared/memory/app-state"
+MEM_RUN_STATUS = os.path.join(MEM_STATE, "run-status.json")
+MEM_UPDATE_LOG = os.path.join(MEM_STATE, "update-log")
+MEM_READ_TRACE = os.path.join(MEM_STATE, "read-trace")
+MEM_RECALL_STATS = os.path.join(MEM_STATE, "recall-stats.json")
+MEM_RECALL_AUDIT = os.path.join(MEM_STATE, "recall-audit")
+MEM_REPOSITORY = "/data/shared/memory/repository"
+MEMORY_SKILL = "/data/shared/skills/memory.md"
+MEMORY_RUNNER = "/data/apps/memory/memory_runner.py"
+REFLECTION_DIR = "/data/apps/reflection"
+REFLECTION_METRICS = os.path.join(REFLECTION_DIR, "reflection-run-metrics.jsonl")
+REFLECTION_RUNS = os.path.join(REFLECTION_DIR, "runs")
+TOOL_FRICTION = os.path.join(REFLECTION_DIR, "tool_friction.py")
+
+# Filename tokens that identify a reflection run's interview capture.
+INTERVIEW_HINTS = ("interview", "int-", "fork", "1on1", "1-on-1")
+
+
+def now_utc():
+    return dt.datetime.now(dt.timezone.utc)
+
+
+def parse_ts(value):
+    """Parse an ISO-8601 timestamp defensively; return an aware datetime or None."""
+    if not value or not isinstance(value, str):
+        return None
+    try:
+        d = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return d if d.tzinfo else d.replace(tzinfo=dt.timezone.utc)
+    except (ValueError, TypeError):
+        return None
+
+
+def short(text, width=64):
+    text = " ".join(str(text or "").split())
+    return text if len(text) <= width else text[: width - 1] + "…"
+
+
+def header(title):
+    print("\n" + "=" * 78)
+    print(title)
+    print("=" * 78)
+
+
+def sub(title):
+    print("\n" + title)
+    print("-" * len(title))
+
+
+def open_db():
+    """Open the chat DB read-only so this tool can never mutate live data."""
+    if not os.path.exists(DB_PATH):
+        return None
+    try:
+        return sqlite3.connect(f"file:{DB_PATH}?mode=ro", uri=True, timeout=5)
+    except sqlite3.Error:
+        return None
+
+
+def chat_titles(con, ids):
+    """Map chat id -> title for the given ids (best effort; missing ids omitted)."""
+    out = {}
+    if not con or not ids:
+        return out
+    ids = list(ids)
+    try:
+        for i in range(0, len(ids), 400):
+            chunk = ids[i : i + 400]
+            q = "select id, title from chats where id in (%s)" % ",".join("?" * len(chunk))
+            for cid, title in con.execute(q, chunk):
+                out[cid] = title
+    except sqlite3.Error:
+        pass
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Section: Memory consolidation agent
+# --------------------------------------------------------------------------- #
+def section_memory(limit):
+    sub("MEMORY — scheduled consolidation agent")
+
+    status = None
+    try:
+        with open(MEM_RUN_STATUS) as fh:
+            status = json.load(fh)
+    except (OSError, ValueError):
+        pass
+
+    if not status:
+        print("  run-status: (not found — Memory app may not be installed)")
+    else:
+        started, finished = parse_ts(status.get("started_at")), parse_ts(status.get("finished_at"))
+        dur = f"{(finished - started).total_seconds():.0f}s" if started and finished else "?"
+        topo = (status.get("topology") or {})
+        before, after = topo.get("before") or {}, topo.get("after") or {}
+        print(f"  status={status.get('status','?')}  model={status.get('model','?')}  "
+              f"provider={status.get('provider','?')}  new_commit={status.get('new_commit')}")
+        print(f"  last run: started {status.get('started_at','?')}  ({dur})")
+        if after:
+            dn = _delta(after.get("nodes"), before.get("nodes"))
+            de = _delta(after.get("edges"), before.get("edges"))
+            print(f"  graph now: {after.get('nodes','?')} nodes ({dn}) / "
+                  f"{after.get('edges','?')} edges ({de}) / {after.get('problems','?')} problems")
+        queued = status.get("queued_chat_count")
+        sourced = status.get("source_chat_count")
+        starved = status.get("chat_input_starved")
+        if starved is None:
+            starved = isinstance(queued, int) and queued > 0 and sourced == 0
+        print(f"  queued_chats={status.get('queued_chat_count','?')}  "
+              f"source_chats={status.get('source_chat_count','?')}  "
+              f"input_starved={'yes' if starved else 'no'}  "
+              f"changed={len(status.get('changed_paths') or [])}  "
+              f"deleted={len(status.get('deleted_paths') or [])}")
+
+    # Last few consolidation outcomes from the append-only update log.
+    entries = _read_update_log(limit)
+    if not entries:
+        print("  update-log: (none found)")
+        return
+    print(f"  recent update-log outcomes (last {len(entries)}):")
+    print(f"  aggregate: changed={sum(len(e.get('changed_paths') or []) for e in entries)}  "
+          f"deleted={sum(len(e.get('deleted_paths') or []) for e in entries)}  "
+          f"published={sum(1 for e in entries if e.get('status') == 'published')}/{len(entries)}")
+    for e in entries:
+        counts = e.get("counts") or {}
+        ts = (e.get("timestamp") or "")[:16]
+        print(f"    {ts or '?':16}  changed={len(e.get('changed_paths') or [])}  "
+              f"deleted={len(e.get('deleted_paths') or [])}  "
+              f"problems={counts.get('problems','?')}  "
+              f"followups={len(e.get('followups') or [])}  status={e.get('status','?')}")
+        if e.get("summary"):
+            print(f"        summary: {short(e['summary'], 88)}")
+        for fu in (e.get("followups") or [])[:2]:
+            print(f"        followup: {short(fu, 88)}")
+
+    try:
+        with open(MEM_RECALL_STATS) as fh:
+            recall = json.load(fh)
+    except (OSError, ValueError):
+        recall = None
+    if recall:
+        print("  recall audit: "
+              f"reads={recall.get('reads_audited', 0)}  "
+              f"miss={float(recall.get('miss_rate', recall.get('important_miss_rate', 0)) or 0):.1%}  "
+              f"overreach={float(recall.get('overreach_rate', 0) or 0):.1%}  "
+              f"no-memory={float(recall.get('no_memory_rate', 0) or 0):.1%}  "
+              f"host-override={float(recall.get('model_to_host_selection_override_rate', 0) or 0):.1%}")
+        print("  miss classes: "
+              f"route={recall.get('route_misses', 0)}  "
+              f"continuation={recall.get('continuation_misses', 0)}  "
+              f"selection={recall.get('selection_misses', 0)}")
+
+
+def _delta(a, b):
+    try:
+        d = int(a) - int(b)
+        return f"{d:+d}"
+    except (TypeError, ValueError):
+        return "?"
+
+
+def _read_update_log(limit):
+    if not os.path.isdir(MEM_UPDATE_LOG):
+        return []
+    files = sorted(f for f in os.listdir(MEM_UPDATE_LOG) if f.endswith(".jsonl"))
+    entries = []
+    for name in files:
+        try:
+            with open(os.path.join(MEM_UPDATE_LOG, name)) as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        entries.append(json.loads(line))
+                    except ValueError:
+                        continue
+        except OSError:
+            continue
+    entries.sort(key=lambda e: e.get("timestamp") or "")
+    return entries[-limit:]
+
+
+def _read_json(path):
+    try:
+        with open(path) as fh:
+            value = json.load(fh)
+        return value if isinstance(value, dict) else None
+    except (OSError, ValueError):
+        return None
+
+
+def _read_text(path, limit=80_000):
+    try:
+        with open(path) as fh:
+            value = fh.read(limit + 1)
+    except OSError:
+        return None
+    if len(value) > limit:
+        return value[:limit] + "\n[bounded by evidence helper]\n"
+    return value
+
+
+def _function_source(path, function_name):
+    """Return one current function without importing live app code."""
+    source = _read_text(path, limit=300_000)
+    if source is None:
+        return None
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return None
+    for node in tree.body:
+        if (
+            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == function_name
+        ):
+            return ast.get_source_segment(source, node)
+    return None
+
+
+def _recall_audits_for_run(run_id):
+    rows = []
+    if not run_id or not os.path.isdir(MEM_RECALL_AUDIT):
+        return rows
+    for name in sorted(os.listdir(MEM_RECALL_AUDIT)):
+        if not name.endswith(".jsonl"):
+            continue
+        try:
+            with open(os.path.join(MEM_RECALL_AUDIT, name)) as fh:
+                for line in fh:
+                    try:
+                        row = json.loads(line)
+                    except ValueError:
+                        continue
+                    if isinstance(row, dict) and row.get("run_id") == run_id:
+                        rows.append(row)
+        except OSError:
+            continue
+    return rows
+
+
+def _applied_memory_diff(outcome):
+    previous = outcome.get("previous_commit")
+    commit = outcome.get("commit")
+    paths = list(dict.fromkeys(
+        list(outcome.get("changed_paths") or [])
+        + list(outcome.get("deleted_paths") or [])
+    ))
+    if not previous or not commit or not paths or not os.path.isdir(MEM_REPOSITORY):
+        return "(no changed memory paths to diff)"
+    try:
+        proc = subprocess.run(
+            [
+                "git", "-C", MEM_REPOSITORY, "diff", "--no-ext-diff",
+                "--unified=3", str(previous), str(commit), "--", *paths,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return f"(diff unavailable: {type(exc).__name__})"
+    if proc.returncode != 0:
+        return f"(diff unavailable: git rc={proc.returncode})"
+    value = proc.stdout or "(changed paths produced no textual diff)"
+    if len(value) > 80_000:
+        return value[:80_000] + "\n[bounded by evidence helper]\n"
+    return value
+
+
+def section_memory_writer_packet():
+    """One bounded, read-only packet for a stateless writer interview."""
+    sub("MEMORY WRITER — latest reconstructed-interview packet")
+    outcomes = _read_update_log(1)
+    if not outcomes:
+        print("  (no published Memory outcome available)")
+        return
+    outcome = outcomes[-1]
+    run_id = outcome.get("run_id")
+    audits = _recall_audits_for_run(run_id)
+    status = _read_json(MEM_RUN_STATUS)
+    skill = _read_text(MEMORY_SKILL)
+    prompt_builder = _function_source(MEMORY_RUNNER, "_proposal_prompt")
+
+    print(f"  run_id={run_id or '?'}  status={outcome.get('status','?')}  "
+          f"audits={len(audits)}  changed={len(outcome.get('changed_paths') or [])}  "
+          f"deleted={len(outcome.get('deleted_paths') or [])}")
+    if status and status.get("run_id") != run_id:
+        print("  WARNING: current run-status belongs to a different run; "
+              "the outcome below is the latest published writer outcome.")
+    print("\nLATEST RUN STATUS (operational input):")
+    print(json.dumps(status or {}, ensure_ascii=False, indent=2, sort_keys=True))
+    print("\nLATEST WRITER OUTCOME:")
+    print(json.dumps(outcome, ensure_ascii=False, indent=2, sort_keys=True))
+    print("\nAPPLIED MEMORY DIFF (changed/deleted paths only):")
+    print(_applied_memory_diff(outcome))
+    print("\nRECALL AUDIT VERDICTS FOR THIS RUN:")
+    print(json.dumps(audits, ensure_ascii=False, indent=2, sort_keys=True))
+    print("\nCURRENT MEMORY GOVERNING SKILL:")
+    print(skill or "(Memory skill unavailable)")
+    print("\nCURRENT WRITER PROMPT BUILDER:")
+    print(prompt_builder or "(writer prompt builder unavailable)")
+
+
+# --------------------------------------------------------------------------- #
+# Section: Reflection nightly agent
+# --------------------------------------------------------------------------- #
+def section_reflection(limit):
+    sub("REFLECTION — nightly run agent")
+
+    runs = []
+    recent = []
+    try:
+        with open(REFLECTION_METRICS) as fh:
+            for line in fh:
+                line = line.strip()
+                if line:
+                    try:
+                        runs.append(json.loads(line))
+                    except ValueError:
+                        continue
+    except OSError:
+        pass
+
+    if not runs:
+        print("  run metrics: (none found)")
+    else:
+        recent = runs[-limit:]
+        ok = sum(1 for r in recent if r.get("exit_code") == 0)
+        wrote = sum(1 for r in recent if r.get("brief_written"))
+        print(f"  recent runs (last {len(recent)}): {ok}/{len(recent)} exit=0, "
+              f"{wrote}/{len(recent)} brief written")
+        for r in recent:
+            started = (r.get("started_at") or "")[:16]
+            print(f"    {started or '?':16}  exit={r.get('exit_code','?')}  "
+                  f"{r.get('duration_seconds','?')}s  "
+                  f"brief={'yes' if r.get('brief_written') else 'no'}"
+                  f"{'  DRY-RUN' if r.get('dry_run') else ''}")
+
+    # Enumerate actual metric-backed run days, including days that left no
+    # artifact directory. Listing only existing directories hid the exact
+    # failure this section is meant to reveal: a completed run that skipped
+    # its interviews entirely.
+    run_days = list(dict.fromkeys(
+        str(row.get("started_at") or "")[:10]
+        for row in recent
+        if len(str(row.get("started_at") or "")) >= 10
+    ))
+    if not run_days and os.path.isdir(REFLECTION_RUNS):
+        run_days = sorted(
+            day for day in os.listdir(REFLECTION_RUNS)
+            if os.path.isdir(os.path.join(REFLECTION_RUNS, day))
+        )[-limit:]
+    print(f"  interview artifacts for recent runs ({len(run_days)} days):")
+    for day in run_days:
+        directory = os.path.join(REFLECTION_RUNS, day)
+        files = sorted(os.listdir(directory)) if os.path.isdir(directory) else []
+        interview = [f for f in files if any(h in f.lower() for h in INTERVIEW_HINTS)]
+        tag = f"  [interview: {', '.join(interview)}]" if interview else "  [no interview capture]"
+        print(f"    {day}: {', '.join(files) if files else '(empty)'}{tag}")
+
+
+def section_tool_friction(hours):
+    """Print the shared mechanical-friction baseline without re-scanning here."""
+    sub(f"TOOL FRICTION — recurring mechanical work (last {hours}h)")
+    if not os.path.isfile(TOOL_FRICTION):
+        print("  (tool-friction collector not installed)")
+        return
+    try:
+        result = subprocess.run(
+            ["python3", TOOL_FRICTION, "--hours", str(hours)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        print(f"  (collector unavailable: {exc})")
+        return
+    output = (result.stdout or result.stderr).strip()
+    print(output or f"  (collector exited {result.returncode} without output)")
+
+
+# --------------------------------------------------------------------------- #
+# Section: Memory read-traces cross-referenced to chat titles
+# --------------------------------------------------------------------------- #
+def section_read_traces(con, hours, traces_n):
+    sub(f"MEMORY READ-TRACES — what recall actually served (last {hours}h)")
+
+    if not os.path.isdir(MEM_READ_TRACE):
+        print("  (read-trace dir not found)")
+        return
+
+    cutoff = now_utc() - dt.timedelta(hours=hours)
+    rows = []
+    for name in os.listdir(MEM_READ_TRACE):
+        if not name.endswith(".json"):
+            continue
+        try:
+            with open(os.path.join(MEM_READ_TRACE, name)) as fh:
+                obj = json.load(fh)
+        except (OSError, ValueError):
+            continue
+        at = parse_ts(obj.get("at"))
+        if not at or at < cutoff:
+            continue
+        rows.append((at, name[:-5], len(obj.get("files") or [])))
+
+    rows.sort(reverse=True)
+    if not rows:
+        print(f"  0 read-traces in the last {hours}h.")
+        return
+
+    titles = chat_titles(con, [cid for _, cid, _ in rows])
+    chat_attributed = sum(1 for _, cid, _ in rows if cid in titles)
+    print(f"  {len(rows)} read-traces in window "
+          f"({chat_attributed} map to a chat, {len(rows) - chat_attributed} app/acceptance):")
+    for at, cid, nfiles in rows[:traces_n]:
+        title = titles.get(cid)
+        label = short(title, 52) if title else f"(non-chat: {cid[:12]})"
+        print(f"    {at.strftime('%Y-%m-%d %H:%M')}  {label:52}  {nfiles} notes")
+
+
+# --------------------------------------------------------------------------- #
+# Section: platform-wide skill loads
+# --------------------------------------------------------------------------- #
+def section_skill_loads(hours):
+    sub(f"SKILL LOADS — platform-wide (last {hours}h, /api/admin/activity/skills)")
+
+    base = os.environ.get("API_BASE_URL", "http://localhost:8000").rstrip("/")
+    token = os.environ.get("AGENT_TOKEN")
+    if not token:
+        print("  (AGENT_TOKEN not set — skipping API call)")
+        return
+    since = (now_utc() - dt.timedelta(hours=hours)).isoformat()
+    url = f"{base}/api/admin/activity/skills?since={urllib.parse.quote(since)}"
+    req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+    except Exception as exc:  # noqa: BLE001 - any failure is non-fatal here
+        print(f"  (skills API unavailable: {exc})")
+        return
+
+    skills = data.get("skills") if isinstance(data, dict) else None
+    if not skills:
+        print("  (no skill loads recorded — Codex-only window or skills disabled)")
+        return
+    for row in skills:
+        print(f"    {short(row.get('skill','?'), 32):32}  {row.get('count','?')}")
+
+
+# --------------------------------------------------------------------------- #
+# Section: optional focus chat
+# --------------------------------------------------------------------------- #
+def section_focus_chat(con, chat_id):
+    sub(f"FOCUS CHAT — {chat_id}")
+    if not con:
+        print("  (chat DB unavailable)")
+        return
+    try:
+        row = con.execute(
+            "select title, provider, created_at, updated_at, run_status, "
+            "coalesce(session_id,''), messages from chats where id=?",
+            (chat_id,),
+        ).fetchone()
+    except sqlite3.Error as exc:
+        print(f"  (query failed: {exc})")
+        return
+    if not row:
+        print("  (no such chat)")
+        return
+    title, provider, created, updated, run_status, session, messages = row
+    try:
+        nmsg = len(json.loads(messages)) if messages else 0
+    except (ValueError, TypeError):
+        nmsg = "?"
+    print(f"  title:    {title}")
+    print(f"  provider: {provider or 'claude'}   messages: {nmsg}   run_status: {run_status or '-'}")
+    print(f"  created:  {created}   updated: {updated}")
+    print(f"  session:  {session or '(none)'}")
+
+    trace_path = os.path.join(MEM_READ_TRACE, f"{chat_id}.json")
+    if os.path.exists(trace_path):
+        try:
+            obj = json.load(open(trace_path))
+            print(f"  memory recall: {len(obj.get('files') or [])} notes served, "
+                  f"last at {obj.get('at','?')}")
+        except (OSError, ValueError):
+            print("  memory recall: trace present but unreadable")
+    else:
+        print("  memory recall: no read-trace for this chat")
+
+    fork = "fork-chat.sh" if not session else "fork-session.sh"
+    print(f"  fork with: /data/apps/reflection/{fork} "
+          f"{chat_id if fork == 'fork-chat.sh' else session + ' <cwd>'} \"<interview>\"")
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="One-call performance bundle for a manager session.")
+    ap.add_argument("--hours", type=int, default=72,
+                    help="lookback window for read-traces and skill loads (default 72)")
+    ap.add_argument("--limit", type=int, default=5,
+                    help="how many recent memory/reflection runs to list (default 5)")
+    ap.add_argument("--traces", type=int, default=12,
+                    help="how many recent read-traces to list (default 12)")
+    ap.add_argument("--memory-writer-packet", action="store_true",
+                    help="append a bounded packet for the latest Memory writer interview")
+    ap.add_argument("chat_id", nargs="?", default=None,
+                    help="optional chat id to profile as a focus block")
+    args = ap.parse_args()
+
+    con = open_db()
+    header(f" MANAGER-SESSION EVIDENCE BUNDLE   generated {now_utc().strftime('%Y-%m-%d %H:%M UTC')}"
+           f"   window: last {args.hours}h")
+
+    section_memory(args.limit)
+    if args.memory_writer_packet:
+        section_memory_writer_packet()
+    section_reflection(args.limit)
+    section_tool_friction(args.hours)
+    section_read_traces(con, args.hours, args.traces)
+    section_skill_loads(args.hours)
+    if args.chat_id:
+        section_focus_chat(con, args.chat_id)
+
+    if con:
+        con.close()
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/seed-skills/manager-session.md
+++ b/backend/scripts/seed-skills/manager-session.md
@@ -1,0 +1,232 @@
+# Manager session — the on-demand 1-on-1
+
+Run this when the partner asks for a "manager session", a "1-on-1", or a
+"performance review" of one of their agents (Memory, Reflection, a cron/app
+agent, a chat agent) or of a whole pipeline. It is a structured coaching review:
+open with genuine, evidence-cited **praise**, name the specific things that
+could be **improved**, then co-design **changes that target future improvement
+across every relevant surface** — the agent's skills, its governing/system
+prompt, *and* the scripts and tools it runs. You interview the agent about its
+own behaviour, verify what it tells you, and apply the smallest durable fix once
+the partner approves anything behaviour-changing. `Read` this before starting one
+so the ritual is consistent every time and the partner never has to re-explain
+it.
+
+This is a *manager's* review, not a bug hunt: the deliverable is a balanced
+1-on-1 that makes the agent measurably better next week, not a defect list. It
+scales from one agent to a whole pipeline (one 1-on-1 per role).
+
+This skill is agent-editable (it lives under `/data/shared/skills/`) — sharpen
+it when a session teaches you a better move, but keep it a clean, de-dated
+ruleset. Incidents belong in Memory, not here.
+
+---
+
+## The shape of one session
+
+Every session, for every agent reviewed, walks the same five beats in order:
+
+1. **Gather evidence in one call** — start from the companion script, not a
+   dozen sequential tool calls.
+2. **Coach** — evidence-cited praise first, then specific, fair improvements.
+   A balanced 1-on-1, never just what broke.
+3. **Interview the agent** — fork its real session and ask it to introspect.
+   Capture answers verbatim. Verify before you trust.
+4. **Design the fix across all surfaces** — skills, system/governing prompt,
+   *and* the scripts/tools it runs. Consolidating tool output is a first-class
+   lever, not an afterthought.
+5. **Co-design and apply** — agree the smallest durable fix with the agent, then
+   apply it only after the partner approves any behaviour-changing edit.
+
+Do not force a beat that has no signal — a healthy agent earns a short session —
+but do them in this order, because the interview reshapes the coaching and the
+coaching reshapes the fix.
+
+---
+
+## 1. Start from one call — the evidence bundle
+
+Before opening any transcript, run the companion script. It exists precisely so
+a session starts from **one consolidated report** instead of six sequential
+tools (read Memory's run-status, tail the update log, cross-check read-traces
+against the chat DB, tail Reflection's metrics, list interview artifacts, curl
+the skills API). One call, one readable bundle:
+
+```bash
+python3 /data/shared/skills/manager-session-evidence.py [--hours 72] [--limit 5] [--traces 12] [CHAT_ID]
+```
+
+It prints, for the memory + reflection agents: run-status and the last few
+consolidation outcomes (counts, deletes, problems, followups); recent reflection
+exit codes / durations / brief-written; the recent read-trace count with the
+last N traces mapped to their chat titles; which reflection runs left interview
+artifacts; and platform-wide skill-load counts. Pass a `CHAT_ID` to profile one
+chat (title, provider, message count, whether Memory recalled into it, and the
+exact fork command to use in beat 3). It is read-only and defensive: missing
+pieces are skipped, never fatal.
+
+For a Memory writer 1-on-1, add `--memory-writer-packet`. The same call appends
+the latest run status and writer outcome, the applied diff limited to changed
+or deleted memory paths, that run's recall verdicts, and the current Memory
+governing skill plus writer prompt builder. It includes no raw chat bodies and
+is bounded for a stateless reconstructed interview.
+
+Read the bundle first and let it *point* you — a run that failed, a followup that
+keeps recurring, a skill an agent leaned on hard, a chat where recall served
+nothing. That is where the session's value is. Only reach for raw logs to
+resolve a specific uncertainty the bundle raised.
+
+**The script itself is in scope for improvement.** If a session needed a number
+the bundle did not carry, the right fix is often to teach the script to emit it
+(beat 4), so the *next* session starts even closer to the answer.
+
+---
+
+## 2. Coach — praise with proof, then fair improvement
+
+A manager session is a balanced 1-on-1. Open with **genuine praise, cited to
+evidence** — not "good job", but "your last consolidation promoted nine durable
+facts with zero bad deletes and flagged two honest followups" (from the update
+log), or "five clean nightly runs, every one shipped a brief" (from the metrics).
+If
+you cannot cite it, it is not praise, it is flattery — dig until you find the
+real thing the agent did well, because there almost always is one and naming it
+is what makes the improvement land.
+
+Then name the **specific things that could be improved**, each tied to the same
+kind of evidence: a recurring followup that never closes, a skill the agent
+complained about, a read that served stale notes, a run that timed out. Be
+concrete and fair. One well-evidenced improvement the agent can act on beats a
+long list it will tune out. Keep the ratio honest — this is coaching, so the
+praise is real and the critique is specific, and neither is padding.
+
+---
+
+## 3. Interview the agent — fork, ask, verify
+
+The agent that did the work holds context the artifacts don't: *why* it made a
+call, *what in its instructions* pushed it there, *what would have helped*. You
+recover that by **forking its real session and asking it** — never by editing
+the original.
+
+**Fork mechanics.** The bundle's focus block prints the right command; the
+general forms are:
+
+```bash
+# a chat agent (chat id from the DB / the bundle):
+/data/apps/reflection/fork-chat.sh <chat_id> "<interview question>"
+
+# an app or cron/background session (session id + its cwd):
+/data/apps/reflection/fork-session.sh <session_id> <cwd> "<interview question>"
+```
+
+**Time-box every fork.** Pass the Bash tool `timeout: 300000` and set the inner
+shell just below it (`timeout 280 ...`) so the inner limit wins and you capture
+partial output instead of an empty file. **Large codex forks are slow to first
+token** — even a modest codex session can blow past the default 120s wall, so
+budget the higher timeout for any codex fork, not just big ones. After the fork,
+check `[ -s <out> ]`: if it came back **empty, stateless, or junk** (an aged-off
+session resumes with no output; a provider out of credits errors), fall back to
+the raw record — read the chat's `messages` JSON from `/data/db/ultimate.db` (or
+the session jsonl) and synthesise from the last several messages. Forks are a
+convenience; the transcript is always there.
+
+**What to ask** (specialise per agent — read what it actually did first):
+
+1. **Why did this happen?** Walk me through the call you made and why.
+2. **What in your instructions led here?** Which skill, prompt line, or tool
+   output shaped the decision? (This is the lever you will pull in beat 4.)
+3. **What would have helped?** A missing rule, a sharper contract, a tool that
+   returned the answer in one call instead of five.
+
+**Capture answers VERBATIM** into the session's working notes — the agent's own
+words are the primary signal, and paraphrase loses the tell. If you fell back to
+empirical analysis because the fork was empty or the agent is stateless, **say
+so plainly** ("fork returned nothing; the following is reconstructed from the
+transcript / from instantiating its prompt against the evidence"), and mark it as
+your inference, not its testimony.
+
+**Testimony is not ground truth — verify before acting.** A forked agent missing
+recent state will confidently invent a plausible cause or claim a fix that never
+landed. Make it cheap to check: whenever the agent cites a change, `grep` the
+cited token in the file it named, `stat` the mtime, or confirm the commit. If the
+claim isn't on disk, the interview confabulated — trust the filesystem and put
+the issue back on the table. Treat mismatches as the expected case, not the rare
+one.
+
+---
+
+## 4. Design the fix across ALL surfaces
+
+The interview's answer to "what in your instructions led here?" tells you which
+surface to change. A manager session's distinguishing move is that it looks at
+**every** surface, not just the obvious one:
+
+- **Skills** — the reusable procedure the agent reads (`/data/shared/skills/`).
+  A missing gotcha, a stale contract, a rule that misled. Smallest surgical edit.
+- **System / governing prompt** — the agent's own instructions (its runner
+  prompt, its app-owned skill, its cron scaffold). When the *prompt* pushed the
+  wrong call, fix the prompt — that is often the true root cause a skill edit
+  only papers over.
+- **Scripts and tools — a first-class lens.** If the agent had to run many tools
+  sequentially to assemble something it needed, the durable fix is to make the
+  script or tool **return the relevant information in ONE call**. Batch and
+  consolidate output so the agent spends its turns on judgment, not plumbing.
+  The evidence script in beat 1 is the worked example of this principle; apply
+  the same lens to whatever the reviewed agent runs. Weak or missing analytics
+  is itself a finding — an agent can't improve on a signal it never sees.
+
+Pick the surface that owns the cause. Do not patch a script-shaped problem with a
+skill line, or a prompt-shaped problem with a symptom check.
+
+---
+
+## 5. Co-design and apply
+
+**Co-design the fix WITH the agent.** You already asked "what would have helped?"
+— use its answer as the starting proposal, then converge on the **smallest
+durable, future-proof change**: no symptom patch, no timer/retry/early-return to
+dodge the cause, no speculative abstraction. The agent that hit the wall usually
+knows the shape of the doorway; your job is to keep the fix minimal and general.
+
+**Apply on the right authority.** A pure skill/script/analytics improvement that
+changes no behaviour you can apply directly and commit. **Anything that changes
+the agent's behaviour — a governing-prompt edit, a new default, a
+behaviour-altering script change — waits for the partner's approval** before it
+lands. Present it as a crisp proposal (what changes, why, the one-line diff),
+apply on the nod, and verify the change is actually on disk.
+
+---
+
+## Scaling to a pipeline
+
+A pipeline gets **one 1-on-1 per role**, not one blurred review of everything.
+Run the five beats for each agent in turn (e.g. Memory, then Reflection, then a
+cron agent), keeping each agent's praise/critique/fix separate — a fix for one
+role rarely transfers cleanly to another, and merging them buries the specific
+signal. Then, at the end, note the **cross-cutting** findings: a skill two agents
+both tripped on, a tool every role had to call five times, a handoff between
+roles that dropped context. Those shared fixes are the highest-leverage output of
+a pipeline review.
+
+For several agents, or for parallel sessions, this ritual **runs cleanly via
+subagents or a workflow** — spawn one session per role so the interviews and
+evidence-gathering happen in parallel, then collect each role's coaching + fix
+proposal and consolidate the cross-cutting findings for the partner. The beats
+and the one-call evidence bundle are identical whether a session runs inline or
+as a spawned agent.
+
+---
+
+## Relationship to Reflection
+
+This ritual is **adjacent to but distinct from** `reflection.md`'s phase-1
+interviews. Reflection interviews run **unattended, overnight, on the strongest
+signal**, and their output is aimed at **skills and the morning brief**. A
+manager session is **on-demand, partner-initiated, and coaching-shaped**: it
+produces balanced praise-and-improvement feedback and deliberately widens the fix
+surface to include the **governing prompt and the scripts/tools** the agent runs,
+not just its skills. The fork mechanics and the verify-before-you-trust rule are
+shared; the framing, the cadence, and the deliverable are not. When both could
+apply, let Reflection own the nightly sweep and reach for a manager session when
+the partner wants to sit down with a specific agent and make it better.

--- a/backend/tests/test_manager_session_evidence.py
+++ b/backend/tests/test_manager_session_evidence.py
@@ -1,0 +1,106 @@
+import contextlib
+import importlib.util
+import io
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest import mock
+
+
+SCRIPT = (
+  Path(__file__).resolve().parents[1]
+  / "scripts"
+  / "seed-skills"
+  / "manager-session-evidence.py"
+)
+SPEC = importlib.util.spec_from_file_location("manager_session_evidence", SCRIPT)
+manager_evidence = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(manager_evidence)
+
+
+class ManagerSessionEvidenceTests(unittest.TestCase):
+  def test_reflection_section_marks_metric_backed_run_without_interview(self):
+    with tempfile.TemporaryDirectory() as raw:
+      root = Path(raw)
+      metrics = root / "reflection-run-metrics.jsonl"
+      metrics.write_text(json.dumps({
+        "started_at": "2026-07-28T02:00:00+00:00",
+        "exit_code": 0,
+        "duration_seconds": 42,
+        "brief_written": True,
+      }) + "\n")
+      output = io.StringIO()
+      with (
+        mock.patch.object(manager_evidence, "REFLECTION_METRICS", str(metrics)),
+        mock.patch.object(
+          manager_evidence,
+          "REFLECTION_RUNS",
+          str(root / "missing-runs"),
+        ),
+        contextlib.redirect_stdout(output),
+      ):
+        manager_evidence.section_reflection(5)
+
+    self.assertIn("2026-07-28", output.getvalue())
+    self.assertIn("[no interview capture]", output.getvalue())
+
+  def test_writer_diff_is_limited_to_reported_memory_paths(self):
+    with tempfile.TemporaryDirectory() as raw:
+      repo = Path(raw)
+      subprocess.run(["git", "init", "-q", repo], check=True)
+      subprocess.run(
+        ["git", "-C", repo, "config", "user.name", "Test"],
+        check=True,
+      )
+      subprocess.run(
+        ["git", "-C", repo, "config", "user.email", "test@example.com"],
+        check=True,
+      )
+      notes = repo / "notes"
+      notes.mkdir()
+      selected = notes / "selected.md"
+      unrelated = notes / "unrelated.md"
+      selected.write_text("before\n")
+      unrelated.write_text("before\n")
+      subprocess.run(["git", "-C", repo, "add", "notes"], check=True)
+      subprocess.run(
+        ["git", "-C", repo, "commit", "-qm", "base"],
+        check=True,
+      )
+      before = subprocess.check_output(
+        ["git", "-C", repo, "rev-parse", "HEAD"],
+        text=True,
+      ).strip()
+
+      selected.write_text("selected update\n")
+      unrelated.write_text("unrelated update\n")
+      subprocess.run(["git", "-C", repo, "add", "notes"], check=True)
+      subprocess.run(
+        ["git", "-C", repo, "commit", "-qm", "update"],
+        check=True,
+      )
+      after = subprocess.check_output(
+        ["git", "-C", repo, "rev-parse", "HEAD"],
+        text=True,
+      ).strip()
+
+      with mock.patch.object(
+        manager_evidence,
+        "MEM_REPOSITORY",
+        str(repo),
+      ):
+        diff = manager_evidence._applied_memory_diff({
+          "previous_commit": before,
+          "commit": after,
+          "changed_paths": ["notes/selected.md"],
+        })
+
+    self.assertIn("selected update", diff)
+    self.assertNotIn("unrelated update", diff)
+    self.assertNotIn("notes/unrelated.md", diff)
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
## Summary

Adds a reusable manager-session skill and a read-only evidence helper so performance reviews begin with verified operational context instead of a long sequence of ad hoc commands.

## Changes

- define a praise-first, evidence-cited coaching loop that interviews the real agent session and verifies testimony before acting
- review skills, governing prompts, and scripts/tools as equal improvement surfaces
- gather recent Memory outcomes, recall miss classes, Reflection runs, interview captures, tool friction, read traces, and skill usage in one bounded command
- provide an optional Memory-writer packet with the current governing skill, prompt builder, scoped applied diff, and recall verdicts without raw chat bodies
- surface metric-backed Reflection days that produced no interview artifact instead of hiding missing run directories
- add focused tests for missing-interview detection and path-scoped Memory diffs

## Verification

- `scripts/wt-pytest.sh tests/test_manager_session_evidence.py tests/test_skills_platform.py -q` — 56 passed
- Python compilation and command help checks passed
- `git diff --check` passed