### PR TITLE
Add resource pressure observability

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -242,12 +242,20 @@ Each module exposes a `router`; registration is in `routes/__init__.py`.
 | `self_reminders.py` | Agent self-scheduling endpoints |
 | `skills.py` | `GET /api/skills` (installed skills + provenance + 30-day usage), `POST /install` (fetch a `SKILL.md` dir or single markdown from GitHub via the same SSRF-safe fetcher as app installs; `.installed-skills.json` provenance sidecar; basename collision ⇒ 409), `DELETE /{name}` (installed-provenance only, git-snapshot before removal). Install/uninstall gated owner-or-`manage_skills` (the Skills app's permission, pattern of `manage_apps`) |
 | `admin.py` | Admin / introspection endpoints (service-token gated) |
-| `debug.py` | Observability: active SDK clients/sessions, broadcasts, chat logs |
+| `debug.py` | Observability: active SDK clients/sessions, broadcasts, chat logs, and resource facts/pressure |
 | `client_error.py` | `POST /api/client-error` — record an uncaught client/app JS error |
 | `recover.py` | Recovery page at `/recover` (reset/backup/rebuild) — frozen island |
 | `recover_html.py` | HTML templates for the recovery page (no `router`; used by `recover.py`) |
 
 Note: there is no `routes/ai.py` and no `POST /api/ai`. An older mini-app AI proxy lived there and was removed; mini-apps reach the agent via `window.mobius.chat`, `POST /api/apps/{id}/run-job`, or cron — not a synchronous AI endpoint.
+
+## Resource facts and pressure
+
+`resource_pressure.py` keeps observation separate from interpretation. Facts are
+an on-demand snapshot of `/data` capacity and cgroup memory; pressure classifies
+that snapshot as `normal`, `constrained`, `critical`, or `unknown`. The snapshot
+is exposed through authenticated debug status but is not polled or stored.
+Workload policy and owner communication remain separate future consumers.
 
 ## App execution tiers
 

--- a/backend/app/resource_pressure.py
+++ b/backend/app/resource_pressure.py
@@ -1,0 +1,324 @@
+"""Current resource facts and their pressure interpretation.
+
+This module deliberately stops before policy.  It answers two questions:
+
+* facts: what capacity exists and how much of it is currently in use;
+* pressure: whether those facts describe normal, constrained, or critical
+  headroom.
+
+Callers decide what to do.  Keeping observation and interpretation free of
+job, app, notification, hosting-provider, and pricing knowledge gives later
+policy and communication work one small, stable seam to consume.
+"""
+
+from __future__ import annotations
+
+import shutil
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Callable
+
+from app.memory_observability import cgroup_memory_snapshot
+
+
+MIB = 1024 * 1024
+GIB = 1024 * MIB
+
+# Disk thresholds combine a useful absolute floor on small volumes with a
+# bounded proportional margin on larger ones.  The caps prevent a large
+# self-hosted disk from being labelled constrained merely because ten percent
+# of it is many gigabytes.
+_DISK_CONSTRAINED_FRACTION = 0.10
+_DISK_CONSTRAINED_FLOOR = 64 * MIB
+_DISK_CONSTRAINED_CEILING = 2 * GIB
+_DISK_CRITICAL_FRACTION = 0.05
+_DISK_CRITICAL_FLOOR = 32 * MIB
+_DISK_CRITICAL_CEILING = 1 * GIB
+
+# memory.current includes reclaimable file cache, so pressure is based on the
+# existing cgroup working-set estimate.  PSI catches sustained contention that
+# a single ratio snapshot can miss.  PSI averages are percentages of wall time.
+_MEMORY_CONSTRAINED_RATIO = 0.75
+_MEMORY_CRITICAL_RATIO = 0.90
+_MEMORY_CONSTRAINED_SOME_AVG60 = 1.0
+_MEMORY_CONSTRAINED_FULL_AVG60 = 0.5
+_MEMORY_CRITICAL_SOME_AVG60 = 10.0
+_MEMORY_CRITICAL_FULL_AVG60 = 2.0
+
+_STATE_RANK = {
+  "unknown": -1,
+  "normal": 0,
+  "constrained": 1,
+  "critical": 2,
+}
+
+
+def _bounded_headroom(
+  total_bytes: int,
+  *,
+  fraction: float,
+  floor_bytes: int,
+  ceiling_bytes: int,
+) -> int:
+  """Return a capacity-relative threshold bounded for tiny and large disks."""
+  threshold = max(floor_bytes, int(total_bytes * fraction))
+  return min(total_bytes, threshold, ceiling_bytes)
+
+
+def _memory_facts(snapshot: dict[str, Any]) -> dict[str, Any]:
+  """Select the stable cgroup facts used by pressure and future consumers."""
+  keys = (
+    "available",
+    "current_bytes",
+    "working_set_bytes",
+    "limit_bytes",
+    "swap_current_bytes",
+    "anon_bytes",
+    "file_bytes",
+    "inactive_file_bytes",
+    "active_file_bytes",
+    "kernel_bytes",
+    "slab_bytes",
+    "pressure",
+  )
+  return {key: snapshot.get(key) for key in keys if key in snapshot}
+
+
+def resource_facts(
+  data_dir: str | Path,
+  *,
+  disk_usage: Callable[[str | Path], Any] = shutil.disk_usage,
+  memory: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+  """Read one cheap point-in-time capacity snapshot.
+
+  ``memory`` lets an existing caller reuse a cgroup snapshot it already read.
+  No directory walk, process inventory, heap traversal, or sampling loop is
+  implied by this function.
+  """
+  captured_at = datetime.now(UTC).isoformat()
+  try:
+    usage = disk_usage(data_dir)
+    disk = {
+      "available": True,
+      "path": str(data_dir),
+      "total_bytes": int(usage.total),
+      "used_bytes": int(usage.used),
+      "free_bytes": int(usage.free),
+    }
+  except OSError:
+    disk = {
+      "available": False,
+      "path": str(data_dir),
+    }
+
+  memory_snapshot = (
+    cgroup_memory_snapshot() if memory is None else memory
+  )
+  return {
+    "captured_at": captured_at,
+    "disk": disk,
+    "memory": _memory_facts(memory_snapshot),
+  }
+
+
+def _disk_pressure(disk: dict[str, Any]) -> dict[str, Any]:
+  if not disk.get("available"):
+    return {
+      "state": "unknown",
+      "reason": {
+        "resource": "disk",
+        "code": "disk_facts_unavailable",
+      },
+    }
+  try:
+    total = int(disk["total_bytes"])
+    free = int(disk["free_bytes"])
+  except (KeyError, TypeError, ValueError):
+    return {
+      "state": "unknown",
+      "reason": {
+        "resource": "disk",
+        "code": "disk_facts_unavailable",
+      },
+    }
+  if total <= 0 or free < 0:
+    return {
+      "state": "unknown",
+      "reason": {
+        "resource": "disk",
+        "code": "disk_facts_unavailable",
+      },
+    }
+
+  constrained_below = _bounded_headroom(
+    total,
+    fraction=_DISK_CONSTRAINED_FRACTION,
+    floor_bytes=_DISK_CONSTRAINED_FLOOR,
+    ceiling_bytes=_DISK_CONSTRAINED_CEILING,
+  )
+  critical_below = _bounded_headroom(
+    total,
+    fraction=_DISK_CRITICAL_FRACTION,
+    floor_bytes=_DISK_CRITICAL_FLOOR,
+    ceiling_bytes=_DISK_CRITICAL_CEILING,
+  )
+  state = "normal"
+  reason = None
+  if free < critical_below:
+    state = "critical"
+    reason = {
+      "resource": "disk",
+      "code": "disk_free_below_critical",
+      "observed_bytes": free,
+      "threshold_bytes": critical_below,
+    }
+  elif free < constrained_below:
+    state = "constrained"
+    reason = {
+      "resource": "disk",
+      "code": "disk_free_below_constrained",
+      "observed_bytes": free,
+      "threshold_bytes": constrained_below,
+    }
+  return {
+    "state": state,
+    "free_ratio": free / total,
+    "constrained_below_bytes": constrained_below,
+    "critical_below_bytes": critical_below,
+    "reason": reason,
+  }
+
+
+def _float(value: Any) -> float:
+  try:
+    return float(value)
+  except (TypeError, ValueError):
+    return 0.0
+
+
+def _memory_pressure(memory: dict[str, Any]) -> dict[str, Any]:
+  if not memory.get("available"):
+    return {
+      "state": "unknown",
+      "reason": {
+        "resource": "memory",
+        "code": "memory_facts_unavailable",
+      },
+    }
+  try:
+    working_set = int(memory["working_set_bytes"])
+    limit = int(memory["limit_bytes"])
+  except (KeyError, TypeError, ValueError):
+    return {
+      "state": "unknown",
+      "reason": {
+        "resource": "memory",
+        "code": "memory_limit_unavailable",
+      },
+    }
+  if working_set < 0 or limit <= 0:
+    return {
+      "state": "unknown",
+      "reason": {
+        "resource": "memory",
+        "code": "memory_limit_unavailable",
+      },
+    }
+
+  ratio = working_set / limit
+  pressure = memory.get("pressure")
+  pressure = pressure if isinstance(pressure, dict) else {}
+  some = pressure.get("some")
+  full = pressure.get("full")
+  some = some if isinstance(some, dict) else {}
+  full = full if isinstance(full, dict) else {}
+  some_avg60 = _float(some.get("avg60"))
+  full_avg60 = _float(full.get("avg60"))
+
+  state = "normal"
+  reason = None
+  if (
+    ratio >= _MEMORY_CRITICAL_RATIO
+    or some_avg60 >= _MEMORY_CRITICAL_SOME_AVG60
+    or full_avg60 >= _MEMORY_CRITICAL_FULL_AVG60
+  ):
+    state = "critical"
+    reason = {
+      "resource": "memory",
+      "code": "memory_pressure_critical",
+      "working_set_ratio": ratio,
+      "some_avg60": some_avg60,
+      "full_avg60": full_avg60,
+    }
+  elif (
+    ratio >= _MEMORY_CONSTRAINED_RATIO
+    or some_avg60 >= _MEMORY_CONSTRAINED_SOME_AVG60
+    or full_avg60 >= _MEMORY_CONSTRAINED_FULL_AVG60
+  ):
+    state = "constrained"
+    reason = {
+      "resource": "memory",
+      "code": "memory_pressure_constrained",
+      "working_set_ratio": ratio,
+      "some_avg60": some_avg60,
+      "full_avg60": full_avg60,
+    }
+  return {
+    "state": state,
+    "working_set_ratio": ratio,
+    "some_avg60": some_avg60,
+    "full_avg60": full_avg60,
+    "constrained_at_ratio": _MEMORY_CONSTRAINED_RATIO,
+    "critical_at_ratio": _MEMORY_CRITICAL_RATIO,
+    "reason": reason,
+  }
+
+
+def assess_resource_pressure(facts: dict[str, Any]) -> dict[str, Any]:
+  """Interpret resource facts without deciding what the platform should do."""
+  disk = _disk_pressure(
+    facts.get("disk") if isinstance(facts.get("disk"), dict) else {},
+  )
+  memory = _memory_pressure(
+    facts.get("memory") if isinstance(facts.get("memory"), dict) else {},
+  )
+  assessments = (disk, memory)
+  known = [
+    assessment["state"]
+    for assessment in assessments
+    if assessment["state"] != "unknown"
+  ]
+  state = (
+    max(known, key=lambda value: _STATE_RANK[value])
+    if known else "unknown"
+  )
+  reasons = [
+    assessment["reason"]
+    for assessment in assessments
+    if assessment.get("reason") is not None
+  ]
+  return {
+    "state": state,
+    "reasons": reasons,
+    "disk": disk,
+    "memory": memory,
+  }
+
+
+def resource_status(
+  data_dir: str | Path,
+  *,
+  disk_usage: Callable[[str | Path], Any] = shutil.disk_usage,
+  memory: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+  """Return the stable facts/pressure seam future policy can consume."""
+  facts = resource_facts(
+    data_dir,
+    disk_usage=disk_usage,
+    memory=memory,
+  )
+  return {
+    "facts": facts,
+    "pressure": assess_resource_pressure(facts),
+  }

--- a/backend/app/routes/debug.py
+++ b/backend/app/routes/debug.py
@@ -35,6 +35,7 @@ from app.memory_observability import (
   process_inventory,
 )
 from app.questions import question_memory_diagnostics
+from app.resource_pressure import resource_status
 from app.runner_registry import RunnerKind, registry
 
 router = APIRouter(prefix="/api/debug", tags=["debug"])
@@ -180,7 +181,12 @@ def debug_status(
   result["browser_profiles"] = browser_profile_status()
   # These are on-demand /proc reads plus bounded owner counters. Nothing
   # samples continuously merely because observability exists.
-  result["memory"] = memory_status()
+  memory = memory_status()
+  result["memory"] = memory
+  result["resources"] = resource_status(
+    get_settings().data_dir,
+    memory=memory["cgroup"],
+  )
   result["runtime_memory"] = _runtime_memory_ownership(include_payloads=False)
   if reconciliation_failed:
     result["reconciliation_failed"] = True

--- a/backend/tests/test_debug_status.py
+++ b/backend/tests/test_debug_status.py
@@ -49,6 +49,13 @@ def test_debug_status_shape_matches_golden(client, auth):
   assert memory["process"]["available"] is True
   assert memory["process"]["rss_bytes"] > 0
   assert memory["tracing"]["source"]
+  resources = payload.pop("resources")
+  assert set(resources) == {"facts", "pressure"}
+  assert resources["facts"]["disk"]["available"] is True
+  assert resources["facts"]["memory"]["available"] is True
+  assert resources["pressure"]["state"] in {
+    "normal", "constrained", "critical", "unknown",
+  }
   runtime_memory = payload.pop("runtime_memory")
   assert runtime_memory["runner_handles"]["claude_sdk"] == 1
   assert runtime_memory["runner_handles"]["codex_sdk"] == 1

--- a/backend/tests/test_resource_pressure.py
+++ b/backend/tests/test_resource_pressure.py
@@ -1,0 +1,170 @@
+"""Focused coverage for resource facts and pressure interpretation."""
+
+from types import SimpleNamespace
+
+from app.resource_pressure import (
+  MIB,
+  assess_resource_pressure,
+  resource_facts,
+  resource_status,
+)
+
+
+def _facts(*, total, free, working_set, limit, some=0.0, full=0.0):
+  return {
+    "disk": {
+      "available": True,
+      "total_bytes": total,
+      "used_bytes": total - free,
+      "free_bytes": free,
+    },
+    "memory": {
+      "available": True,
+      "working_set_bytes": working_set,
+      "limit_bytes": limit,
+      "pressure": {
+        "some": {"avg60": some},
+        "full": {"avg60": full},
+      },
+    },
+  }
+
+
+def test_resource_facts_reuses_existing_memory_snapshot():
+  memory = {
+    "available": True,
+    "current_bytes": 900,
+    "working_set_bytes": 400,
+    "limit_bytes": 1000,
+    "inactive_file_bytes": 500,
+    "pressure": {"some": {"avg60": 0.0}},
+    "internal_field": "not part of the facts contract",
+  }
+
+  facts = resource_facts(
+    "/data",
+    disk_usage=lambda _path: SimpleNamespace(
+      total=1000, used=700, free=300,
+    ),
+    memory=memory,
+  )
+
+  assert facts["disk"] == {
+    "available": True,
+    "path": "/data",
+    "total_bytes": 1000,
+    "used_bytes": 700,
+    "free_bytes": 300,
+  }
+  assert facts["memory"]["working_set_bytes"] == 400
+  assert facts["memory"]["inactive_file_bytes"] == 500
+  assert "internal_field" not in facts["memory"]
+  assert facts["captured_at"]
+
+
+def test_small_volume_is_critical_below_absolute_floor():
+  pressure = assess_resource_pressure(_facts(
+    total=512 * MIB,
+    free=31 * MIB,
+    working_set=450 * MIB,
+    limit=954 * MIB,
+  ))
+
+  assert pressure["state"] == "critical"
+  assert pressure["disk"]["state"] == "critical"
+  assert pressure["disk"]["critical_below_bytes"] == 32 * MIB
+  assert pressure["memory"]["state"] == "normal"
+  assert pressure["reasons"][0]["code"] == "disk_free_below_critical"
+
+
+def test_disk_thresholds_are_proportional_but_bounded_on_large_volumes():
+  pressure = assess_resource_pressure(_facts(
+    total=1000 * 1024**3,
+    free=1500 * MIB,
+    working_set=1,
+    limit=100,
+  ))
+
+  assert pressure["disk"]["constrained_below_bytes"] == 2 * 1024**3
+  assert pressure["disk"]["critical_below_bytes"] == 1024**3
+  assert pressure["disk"]["state"] == "constrained"
+
+
+def test_reclaimable_file_cache_does_not_create_false_memory_pressure():
+  facts = _facts(
+    total=10 * 1024**3,
+    free=5 * 1024**3,
+    working_set=450 * MIB,
+    limit=954 * MIB,
+  )
+  facts["memory"].update({
+    "current_bytes": 900 * MIB,
+    "inactive_file_bytes": 450 * MIB,
+  })
+
+  pressure = assess_resource_pressure(facts)
+
+  assert pressure["memory"]["state"] == "normal"
+  assert pressure["memory"]["working_set_ratio"] < 0.5
+  assert pressure["state"] == "normal"
+
+
+def test_memory_ratio_and_sustained_psi_raise_pressure():
+  constrained = assess_resource_pressure(_facts(
+    total=10 * 1024**3,
+    free=5 * 1024**3,
+    working_set=800,
+    limit=1000,
+  ))
+  critical = assess_resource_pressure(_facts(
+    total=10 * 1024**3,
+    free=5 * 1024**3,
+    working_set=500,
+    limit=1000,
+    full=2.5,
+  ))
+
+  assert constrained["state"] == "constrained"
+  assert constrained["memory"]["state"] == "constrained"
+  assert critical["state"] == "critical"
+  assert critical["memory"]["reason"]["full_avg60"] == 2.5
+
+
+def test_unknown_resource_does_not_hide_known_pressure():
+  facts = {
+    "disk": {"available": False},
+    "memory": {
+      "available": True,
+      "working_set_bytes": 950,
+      "limit_bytes": 1000,
+      "pressure": {},
+    },
+  }
+
+  pressure = assess_resource_pressure(facts)
+
+  assert pressure["state"] == "critical"
+  assert {reason["code"] for reason in pressure["reasons"]} == {
+    "disk_facts_unavailable",
+    "memory_pressure_critical",
+  }
+
+
+def test_resource_status_keeps_facts_and_pressure_separate():
+  status = resource_status(
+    "/data",
+    disk_usage=lambda _path: SimpleNamespace(
+      total=10 * 1024**3,
+      used=5 * 1024**3,
+      free=5 * 1024**3,
+    ),
+    memory={
+      "available": True,
+      "working_set_bytes": 400,
+      "limit_bytes": 1000,
+      "pressure": {},
+    },
+  )
+
+  assert set(status) == {"facts", "pressure"}
+  assert status["pressure"]["state"] == "normal"


### PR DESCRIPTION
## Summary

- add a cheap, on-demand snapshot of disk capacity and cgroup memory
- classify facts as normal, constrained, critical, or unknown without coupling them to workload behavior
- expose both layers in authenticated debug status and document the pull-based boundary

## Design

Memory pressure uses working set so reclaimable file cache does not create false alarms, while Linux PSI catches sustained contention. Disk headroom combines percentage thresholds with bounded floors and ceilings across deployment sizes.

This deliberately adds no polling, persistence, throttling, cleanup, or owner-facing messaging. Future policy can consume the seam at natural admission points.

## Testing

- `python3 -m py_compile backend/app/resource_pressure.py backend/app/routes/debug.py backend/tests/test_resource_pressure.py backend/tests/test_debug_status.py`
- `python3 -m pytest -q backend/tests/test_resource_pressure.py backend/tests/test_debug_status.py backend/tests/test_memory_observability.py` (18 passed)