### PR TITLE
Fix stale scroll settlement during message steering

### DIFF
--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -12,9 +12,7 @@ import Check from 'lucide-react/dist/esm/icons/check.mjs'
 import { apiFetch, getAuthHeaders, jsonOrThrow, BASE } from '../../api/client.js'
 import { chatMessagesQueryKey } from '../../hooks/queries.js'
 import useStreamConnection from './useStreamConnection.js'
-import useScrollMode, {
-  shouldPinSend,
-} from './useScrollMode.js'
+import useScrollMode from './useScrollMode.js'
 import useVoiceInput from './useVoiceInput.js'
 import useFileUpload from './useFileUpload.js'
 import useOnlineStatus from '../../hooks/useOnlineStatus.js'
@@ -583,11 +581,12 @@ export default function ChatView({
   // synchronous access (handleStop's pre-await clear, fetchMessages'
   // cid preservation).
   const pendingQueue = usePendingQueue(cached?.pending_messages || [])
-  const queuedContinuationLocalPromotedRef = useRef(null)
-  const queuedContinuationPinIntentRef = useRef(null)
-  const queuedPinIntentByCidRef = useRef(new Map())
-  const steerPinIntentRef = useRef(null)
-  const inlineSteerPinIntentRef = useRef(null)
+  // Every delayed visible user row carries one opaque scroll intent under the
+  // same stable cid that owns its queue/transcript identity. A queued
+  // continuation temporarily moves its rows + intent into one envelope while
+  // the previous assistant turn finishes.
+  const queuedContinuationRef = useRef(null)
+  const sendIntentByCidRef = useRef(new Map())
   const runtimeReconnectInFlightRef = useRef(false)
   const swReloadHoldTimerRef = useRef(null)
 
@@ -812,35 +811,29 @@ export default function ChatView({
   // keyboard handling, diagnostics, and hide-then-reveal restore on mount.
   //
   // The hook returns:
-  //   • modeRef               — read-only to ChatView for submit snapshots.
-  //                             Lifecycle changes go through the returned
-  //                             semantic controller methods below.
   //   • gestureWindowUntilRef — read by handleScroll to gate pagination
   //                             on user-driven scrolls only.
-  //   • userScrollIntentVersionRef
-  //                           — bumped only by human scroll input; delayed
-  //                             queued/steered sends honor their pin intent
-  //                             only if this has not changed since submit.
+  //   • capture/commit/settle send intent
+  //                           — the only boundary for submit geometry,
+  //                             stale-gesture cancellation, and delayed pins.
   //   • revealed              — apply to .chat__scroll style for the
   //                             hide-then-reveal scroll restore.
   //
   // See useScrollMode.js + ARCHITECTURE.md "Chat scroll + steer
   // contract" for full design.
   const {
-    modeRef,
     gestureWindowUntilRef,
-    userScrollIntentVersionRef,
     revealed,
     anchorPagination,
-    armSentMessage,
-    closePreSendGestureWindow,
+    captureSendIntent,
+    commitSendIntent,
     freezeChatExit,
     freezeForegroundReturn,
     freezeQuestionSubmission,
     freezeQueuedSubmission,
     revealConversationTail,
     reapplyActiveMode,
-    settleNonPin,
+    settleSendIntent,
     settleStreamingPin,
     paneResized,
   } = useScrollMode({
@@ -883,41 +876,41 @@ export default function ChatView({
     if (hidden) freezeChatExit()
   }, [hidden, freezeChatExit])
 
-  function makeSendPinIntent(willPin) {
-    return {
-      willPin: !!willPin,
-      userScrollIntentVersion: userScrollIntentVersionRef.current,
-    }
-  }
-
-  function pinIntentStillCurrent(intent) {
-    return !!intent
-      && intent.userScrollIntentVersion === userScrollIntentVersionRef.current
-  }
-
-  function rememberQueuedPinIntent(cid, intent) {
+  function rememberSendIntent(cid, intent) {
     if (!cid || !intent) return
-    queuedPinIntentByCidRef.current.set(cid, intent)
+    sendIntentByCidRef.current.set(cid, intent)
   }
 
-  function forgetQueuedPinIntent({ cid = null, cidList = null } = {}) {
-    if (cid) queuedPinIntentByCidRef.current.delete(cid)
+  function forgetSendIntent({ cid = null, cidList = null } = {}) {
+    if (cid) sendIntentByCidRef.current.delete(cid)
     if (Array.isArray(cidList)) {
-      for (const value of cidList) queuedPinIntentByCidRef.current.delete(value)
+      for (const value of cidList) sendIntentByCidRef.current.delete(value)
     }
   }
 
-  function takeQueuedPinIntent(cid) {
+  function takeSendIntent(cid) {
     if (!cid) return null
-    const intent = queuedPinIntentByCidRef.current.get(cid) || null
-    queuedPinIntentByCidRef.current.delete(cid)
+    const intent = sendIntentByCidRef.current.get(cid) || null
+    sendIntentByCidRef.current.delete(cid)
     return intent
   }
 
-  function forgetAllQueuedPinIntents() {
-    queuedPinIntentByCidRef.current.clear()
-    queuedContinuationPinIntentRef.current = null
-    inlineSteerPinIntentRef.current = null
+  function replaceSendIntent(cid, intent) {
+    if (!cid || !intent) return null
+    const previous = sendIntentByCidRef.current.get(cid) || null
+    sendIntentByCidRef.current.set(cid, intent)
+    return previous
+  }
+
+  function restoreReplacedSendIntent(cid, replacement, previous) {
+    if (!cid || sendIntentByCidRef.current.get(cid) !== replacement) return
+    if (previous) sendIntentByCidRef.current.set(cid, previous)
+    else sendIntentByCidRef.current.delete(cid)
+  }
+
+  function forgetAllSendIntents() {
+    sendIntentByCidRef.current.clear()
+    queuedContinuationRef.current = null
   }
 
   // The first-message exception is shared by every direct/promotion/steer
@@ -930,16 +923,11 @@ export default function ChatView({
     return !stateHasUser && !domHasUser
   }
 
-  // Every send/steer/promote enters the scroll controller through this one
-  // semantic event. ChatView resolves delayed-intent staleness; the controller
-  // owns the actual PIN-vs-hold transition and the later automatic writes. The
-  // pin targets the stable `cid` carried by the DOM row from mint.
-  function pinSentMessage(cid, { willPin, intent } = {}) {
-    armSentMessage({
-      cid,
-      willPin,
-      intentCurrent: !intent || pinIntentStillCurrent(intent),
-    })
+  // Every send/steer/promote lands through one semantic controller event. The
+  // intent stays opaque here; the controller alone decides whether a later real
+  // reader scroll invalidated it.
+  function landSentMessage(cid, { intent, fallbackWillPin = false } = {}) {
+    commitSendIntent({ cid, intent, fallbackWillPin })
   }
 
   // Re-fetch messages from the API. Called when the SSE stream reconnects
@@ -1147,10 +1135,10 @@ export default function ChatView({
         // The local queue was already trimmed when the
         // queued_turn_starting event arrived, so a message queued after
         // that event cannot be accidentally folded into this turn here.
-        const localPromoted = queuedContinuationLocalPromotedRef.current
-        queuedContinuationLocalPromotedRef.current = null
-        const continuationPinIntent = queuedContinuationPinIntentRef.current
-        queuedContinuationPinIntentRef.current = null
+        const continuation = queuedContinuationRef.current
+        queuedContinuationRef.current = null
+        const localPromoted = continuation?.rows || null
+        const continuationPinIntent = continuation?.intent || null
         const promotedRows = continuationRowsFromPromotedMessage(
           promotedMessage,
           localPromoted,
@@ -1164,23 +1152,13 @@ export default function ChatView({
           // below without moving the scroll.
           const contIsFirstUser = isFirstVisibleUserMessage()
           const pinCid = cidOf(promotedRows[0])
-          const fallbackWillPin = () => shouldPinSend({
-            scrollEl: scrollRef.current,
-            mode: modeRef.current,
-            isFirstUserMsg: contIsFirstUser,
-            // The original submit-time intent is unavailable (for example
-            // after a remount). Never infer a delayed pin from the reader's
-            // later position; only the first-message exception remains.
-            wasAtContentBottom: false,
-          })
-          const contWillPin = continuationPinIntent
-            ? continuationPinIntent.willPin
-            : fallbackWillPin()
           commitMessages(prev => appendMessageBatch(prev, promotedRows))
           promotedRef.current = false
-          pinSentMessage(pinCid, {
-            willPin: contWillPin,
+          landSentMessage(pinCid, {
             intent: continuationPinIntent,
+            // A missing delayed intent (for example after remount) degrades to
+            // hold; the first-visible-message exception is the only fallback.
+            fallbackWillPin: contIsFirstUser,
           })
         } else {
           // Server's promoted ts isn't in our local queue (cancel raced
@@ -1191,8 +1169,7 @@ export default function ChatView({
         setSending(true)
         setServerRunningState(true)
       } else {
-        queuedContinuationLocalPromotedRef.current = null
-        queuedContinuationPinIntentRef.current = null
+        queuedContinuationRef.current = null
         setSending(false)
         sendingRef.current = false
         setServerRunningState(false)
@@ -1233,8 +1210,7 @@ export default function ChatView({
       const localPromoted = Array.isArray(consumedCids)
         ? pendingQueue.promoteManyByCid(consumedCids)
         : pendingQueue.promoteAll()
-      queuedContinuationLocalPromotedRef.current =
-        serverRows?.length ? serverRows : localPromoted
+      const continuationRows = serverRows?.length ? serverRows : localPromoted
       // The pin intent was stamped at submit under the queued row's cid; the
       // backend echoes those cids back as _consumed_cids (or the promoted row
       // carries the head cid). Look it up by the head cid.
@@ -1243,7 +1219,11 @@ export default function ChatView({
         || localPromoted
         || (Array.isArray(consumedCids) ? { cid: consumedCids[0] } : null),
       )
-      queuedContinuationPinIntentRef.current = takeQueuedPinIntent(pinCid)
+      queuedContinuationRef.current = {
+        rows: continuationRows,
+        intent: takeSendIntent(pinCid),
+      }
+      forgetSendIntent({ cidList: consumedCids })
     },
     onLiveQuestion: setLiveQuestionId,
     onSteeredIntoTurn: ({ ts, content, messages: steeredBatch }) => {
@@ -1285,26 +1265,18 @@ export default function ChatView({
           }
         })
       const pinCid = cidOf(steeredMessages[0])
-      const pinIntent = steerPinIntentRef.current
-        || inlineSteerPinIntentRef.current
-        || takeQueuedPinIntent(pinCid)
-      inlineSteerPinIntentRef.current = null
+      const pinIntent = takeSendIntent(pinCid)
       promoteStreamToMessages({ keepTurnOpen: true })
       const steeredIsFirstUser = isFirstVisibleUserMessage()
-      const fallbackWillPin = () => shouldPinSend({
-        scrollEl: scrollRef.current,
-        mode: modeRef.current,
-        isFirstUserMsg: steeredIsFirstUser,
-        // A missing submit-time intent must degrade to hold, not infer a pin
-        // from wherever the reader happens to be when the SSE event arrives.
-        wasAtContentBottom: false,
-      })
-      const steerWillPin = pinIntent ? pinIntent.willPin : fallbackWillPin()
       // Arm the scroll mode BEFORE rendering the steered row. EventSource
       // callbacks are outside React's synthetic event layer, and query-cache
       // listeners can observe the transcript update immediately; setting the
       // mode first prevents a one-frame "row appears low, then snaps up" steer.
-      pinSentMessage(pinCid, { willPin: steerWillPin, intent: pinIntent })
+      landSentMessage(pinCid, {
+        intent: pinIntent,
+        // Never infer a delayed pin from the reader's later position.
+        fallbackWillPin: steeredIsFirstUser,
+      })
       // Dedup by ts so a reconnect's catch-up replay of the same event
       // can't double-insert the steered user message. Insert by transcript ts
       // instead of blindly appending: if a fetch/replay already committed the
@@ -1319,7 +1291,7 @@ export default function ChatView({
         const cid = cidOf(msg)
         if (cid != null) pendingQueue.cancelByCid(cid)
       }
-      steerPinIntentRef.current = null
+      forgetSendIntent({ cidList: steeredMessages.map(cidOf) })
     },
   })
 
@@ -2055,20 +2027,13 @@ export default function ChatView({
     // gesture/layout by a frame. Mobile blur can resize/clamp the viewport, so
     // capture the complete decision before it.
     const isFirstUserMsgAtSubmit = isFirstVisibleUserMessage()
-    const willPinAtSubmit = pin && shouldPinSend({
-      scrollEl: scrollRef.current,
-      mode: modeRef.current,
+    const sendPinIntent = captureSendIntent({
+      canPin: pin,
       isFirstUserMsg: isFirstUserMsgAtSubmit,
     })
-    const sendPinIntent = makeSendPinIntent(willPinAtSubmit)
-    // Sending is a newer explicit action than the wheel/touch gesture that
-    // positioned the viewport for that send. Browsers update scrollTop
-    // synchronously but may dispatch the matching `scroll` event later; if the
-    // old gesture window stays open, that delayed event can land after this
-    // snapshot and cancel the brand-new PIN before its spacer is measured.
-    // Close only the PRE-SEND ownership window. Any wheel/touch/key input that
-    // begins after this line opens a fresh window and still wins normally.
-    closePreSendGestureWindow()
+    // captureSendIntent atomically snapshots current geometry and supersedes
+    // the older gesture that positioned it. Any input begun after this point
+    // opens fresh reader ownership and still wins normally.
 
     const queuesBehindActiveTurn = !!(
       sendingRef.current
@@ -2148,12 +2113,10 @@ export default function ChatView({
       // rule as a fresh send. The at-bottom / following decision and the
       // first-user check must reflect the moment of sending — reading them
       // AFTER `await streamSend(...)` lets a scroll during the POST flip the
-      // decision. The user-scroll intent version lets us detect such a scroll
-      // and yield to it (a user-driven scroll after send is the newer intent).
-      const queuedWillPin = willPinAtSubmit
+      // decision. The opaque controller intent detects such a scroll and yields
+      // to it (a user-driven scroll after send is the newer intent).
       const queuedPinIntent = sendPinIntent
-      rememberQueuedPinIntent(cid, queuedPinIntent)
-      inlineSteerPinIntentRef.current = queuedPinIntent
+      rememberSendIntent(cid, queuedPinIntent)
       setComposerInput('')
       clearComposerFilesForSend()
       if (inputRef.current) {
@@ -2185,8 +2148,7 @@ export default function ChatView({
           // Remove only this send's optimistic tray row; an unrelated live
           // turn may still be streaming and must remain attached.
           if (!directSteer) pendingQueue.cancelByCid(queuedMsg.cid)
-          forgetQueuedPinIntent({ cid: queuedMsg.cid })
-          inlineSteerPinIntentRef.current = null
+          forgetSendIntent({ cid: queuedMsg.cid })
           const durableRows = startedMessagesFromResponse(result)
           if (durableRows) {
             commitMessages(prev => appendMessageBatch(prev, durableRows))
@@ -2258,11 +2220,8 @@ export default function ChatView({
             // it's a new visible user message and follows the send rule just
             // like a fresh send. The pin targets the stable cid (the started
             // row carries the same cid the client minted).
-            pinSentMessage(cid, {
-              willPin: queuedWillPin,
-              intent: queuedPinIntent,
-            })
-            forgetQueuedPinIntent({
+            landSentMessage(cid, { intent: queuedPinIntent })
+            forgetSendIntent({
               cid,
               cidList: result.message?._consumed_cids,
             })
@@ -2277,7 +2236,8 @@ export default function ChatView({
             // the message inline; Claude's deferred cut will do so when its
             // interrupt boundary lands. Until then the durable server reserve
             // stays intentionally invisible rather than flashing as queued.
-            forgetQueuedPinIntent({ cid: queuedMsg.cid })
+            // Keep its cid-keyed intent until that authoritative cut consumes
+            // it; response and SSE delivery can arrive in either order.
           } else if (result.cut_deferred) {
             // Claude: the transcript split waits for the runner's interrupt
             // boundary, so the row is STILL queued server-side and its tray
@@ -2304,18 +2264,13 @@ export default function ChatView({
               position: serverRow?.position,
               serverMsg: serverRow,
             })
-            // The pin intent lives on in `inlineSteerPinIntentRef` (set at
-            // submit), which is what `onSteeredIntoTurn` reads at the cut. Its
-            // `takeQueuedPinIntent` fallback is short-circuited by that ref, so
-            // without this the map entry would never be taken and would leak
-            // for the life of the mounted chat.
-            forgetQueuedPinIntent({ cid: queuedMsg.cid })
+            // Its cid-keyed intent remains beside the durable queued row until
+            // the cut consumes both, regardless of response/event order.
           } else {
             // Codex: the split already ran at the route, so the row is in the
             // transcript and `steered_into_turn` (already sent) renders it
             // inline — drop the optimistic queued-tray entry, it never queued.
             pendingQueue.cancelByCid(queuedMsg.cid)
-            forgetQueuedPinIntent({ cid: queuedMsg.cid })
           }
         }
         // Race: server said "started" though we expected queued.
@@ -2330,8 +2285,8 @@ export default function ChatView({
           // the first message of a NEW run, so the rail resets here too.
           setBuildPhases(railAtRunStart())
           setActiveGoalState(goalObjectiveFromText(text))
-          // Apply the send rule before appending — see shouldPinSend and
-          // the fresh-send path. A message that raced into a started turn
+          // Apply the shared send-intent rule before appending. A message that
+          // raced into a started turn
           // is still a new send becoming the active turn, so it pins only
           // when first-or-at-bottom. The decision was captured at send time.
           const startedMessages = startedMessagesFromResponse(result)
@@ -2347,11 +2302,8 @@ export default function ChatView({
           // New visible user msg → pin the stable cid to the top when the rule
           // allows; otherwise the funnel retires any stale pin to the reader's
           // anchor and reservation stays available below.
-          pinSentMessage(cid, {
-            willPin: queuedWillPin,
-            intent: queuedPinIntent,
-          })
-          forgetQueuedPinIntent({
+          landSentMessage(cid, { intent: queuedPinIntent })
+          forgetSendIntent({
             cid,
             cidList: result.message?._consumed_cids,
           })
@@ -2360,9 +2312,6 @@ export default function ChatView({
           // fresh assistant instead of replacing whichever message
           // is currently last.
           bridgeHook.markBridged()
-        }
-        if (result?.status !== 'steered') {
-          inlineSteerPinIntentRef.current = null
         }
         // Invariant: every observable queue-path status must resolve
         // the optimistic entry's in-flight flag. queued/steered/started
@@ -2384,8 +2333,7 @@ export default function ChatView({
       } catch (err) {
         // Roll back optimistic + restore input.
         if (!directSteer) pendingQueue.cancelByCid(queuedMsg.cid)
-        forgetQueuedPinIntent({ cid: queuedMsg.cid })
-        inlineSteerPinIntentRef.current = null
+        forgetSendIntent({ cid: queuedMsg.cid })
         rememberFailedAttempt({
           cid,
           draftIdentity,
@@ -2417,7 +2365,6 @@ export default function ChatView({
     // Direct sends use the same submit-time decision as queued/steered sends.
     // A legitimate pin changes FOLLOW_BOTTOM to PIN_USER_MSG, so reply growth
     // stays below the prompt until the user manually scrolls to the bottom.
-    const willPin = willPinAtSubmit
     // The send-time pin intent, carried across the async POST so a user scroll
     // that lands during it can still win. The pinned row's identity is the
     // minted `cid`, which the optimistic row and the confirmed server row
@@ -2440,7 +2387,7 @@ export default function ChatView({
     // on every send and, when not pinning, retires any stale PIN to the
     // reader's anchor so their viewport stays fixed. The row carries its final
     // cid from mint, so the pin lands on the first apply.
-    pinSentMessage(cid, { willPin, intent: freshPinIntent })
+    landSentMessage(cid, { intent: freshPinIntent })
     // Fresh turn — not a bridge from a mounted DB partial.
     bridgeHook.markBridged()
 
@@ -2525,20 +2472,18 @@ export default function ChatView({
             pendingQueue.promoteManyByCid(result.message._consumed_cids)
           }
           const startedMessages = startedMessagesFromResponse(result)
-          pinSentMessage(cid, { willPin, intent: freshPinIntent })
+          landSentMessage(cid, { intent: freshPinIntent })
           if (startedMessages) {
             commitMessages(prev => appendMessageBatch(prev, startedMessages))
           }
           return
         }
         if (!result.started) {
-          const queuedPinStillValid = pinIntentStillCurrent(freshPinIntent)
-          if (queuedPinStillValid) {
-            settleNonPin({
-              retireFollow: pin,
-              event: 'send:not-started-hold',
-            })
-          }
+          settleSendIntent({
+            intent: freshPinIntent,
+            retireFollow: pin,
+            event: 'send:not-started-hold',
+          })
           setSending(false)
           setServerRunningState(false)
         }
@@ -2549,7 +2494,7 @@ export default function ChatView({
         // The started row carries the same cid the client minted, so the pin
         // targets that cid directly — no retarget from optimistic to canonical
         // ts, and no last-row fallback. The funnel owns arming + staleness.
-        pinSentMessage(cid, { willPin, intent: freshPinIntent })
+        landSentMessage(cid, { intent: freshPinIntent })
         commitMessages(prev => {
           return replaceOptimisticWithBatch(prev, cid, startedMessages)
         })
@@ -2787,7 +2732,7 @@ export default function ChatView({
     const cancelledIndex = currentQueue.findIndex(row => cidOf(row) === cid)
     const cancelledRow = cancelledIndex >= 0 ? currentQueue[cancelledIndex] : null
     pendingQueue.cancelByCid(cid)
-    forgetQueuedPinIntent({ cid })
+    forgetSendIntent({ cid })
     try {
       const res = await apiFetch(`/chats/${chatId}/pending/${encodeURIComponent(cid)}`, {
         method: 'DELETE',
@@ -2895,7 +2840,7 @@ export default function ChatView({
       // at all. pendingQueue.clear() updates pendingMessagesRef.current to
       // [] before this line returns (synchronous).
       fetchGenRef.current += 1
-      forgetAllQueuedPinIntents()
+      forgetAllSendIntents()
       pendingQueue.clear()
 
       let stoppedCleanly = false
@@ -3130,18 +3075,21 @@ export default function ChatView({
     }
     if (!hasSendablePayload(content, attachments)) return
 
+    const steerCid = consumePendingCids[0] || null
+    let explicitSteerIntent = null
+    let previousSendIntent = null
     try {
       const steerIsFirstUser = isFirstVisibleUserMessage()
       // Fast-forward is a deliberate visibility action, unlike automatic
       // queue drain. Capture the reader's ACTUAL position now: bottom pins,
       // reading elsewhere holds. A later real scroll during the POST still
-      // invalidates this snapshot through the intent version.
-      const steerWillPin = shouldPinSend({
-        scrollEl: scrollRef.current,
-        mode: modeRef.current,
+      // invalidates this opaque intent inside the scroll controller. Capturing
+      // also cancels any older quiet settlement, which is what previously
+      // overwrote the new pin and made the row bounce before settling.
+      explicitSteerIntent = captureSendIntent({
         isFirstUserMsg: steerIsFirstUser,
       })
-      steerPinIntentRef.current = makeSendPinIntent(steerWillPin)
+      previousSendIntent = replaceSendIntent(steerCid, explicitSteerIntent)
       // Queue-only sends deliberately retain mobile focus. Fast-forward is
       // the explicit hand-off point, but snapshot reader position BEFORE
       // blurring: keyboard dismissal resizes the viewport and can otherwise
@@ -3178,17 +3126,24 @@ export default function ChatView({
           // cids.
           for (const c of consumePendingCids) pendingQueue.cancelByCid(c)
         }
-        forgetQueuedPinIntent({ cidList: consumePendingCids })
       }
       if (result?.status !== 'steered') {
-        steerPinIntentRef.current = null
+        restoreReplacedSendIntent(
+          steerCid,
+          explicitSteerIntent,
+          previousSendIntent,
+        )
         pendingQueue.releaseSteerReservation(consumePendingCids)
       }
       // not_steered (the turn closed between the gate and the POST) or any
       // other status: release the unchanged queue back to the tray and let it
       // drain at turn-end.
     } catch {
-      steerPinIntentRef.current = null
+      restoreReplacedSendIntent(
+        steerCid,
+        explicitSteerIntent,
+        previousSendIntent,
+      )
       pendingQueue.releaseSteerReservation(consumePendingCids)
       // Network/POST error — show the unchanged queue for the turn-end drain.
     }

--- a/frontend/src/components/ChatView/__tests__/composerSteerTouch.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerSteerTouch.test.js
@@ -61,6 +61,6 @@ test('per-row fast-forward dispatches on touchend too', () => {
 test('the shared steer path snapshots scroll before dismissing the mobile composer', () => {
   assert.match(
     chatView,
-    /async function steerRowsImpl\(steerRowsList\) \{[\s\S]*?steerPinIntentRef\.current = makeSendPinIntent\(steerWillPin\)[\s\S]*?if \(_isTouchPrimary\) inputRef\.current\?\.blur\(\)[\s\S]*?pendingQueue\.reserveForSteer\(consumePendingCids\)/,
+    /async function steerRowsImpl\(steerRowsList\) \{[\s\S]*?explicitSteerIntent = captureSendIntent\(\{[\s\S]*?previousSendIntent = replaceSendIntent\(steerCid, explicitSteerIntent\)[\s\S]*?if \(_isTouchPrimary\) inputRef\.current\?\.blur\(\)[\s\S]*?pendingQueue\.reserveForSteer\(consumePendingCids\)/,
   )
 })

--- a/frontend/src/components/ChatView/__tests__/composerSubmission.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerSubmission.test.js
@@ -43,7 +43,7 @@ test('sendability is decided before submit-time UI and scroll side effects', () 
   for (const sideEffect of [
     'setSendFailure(null)',
     'stopVoiceRef.current?.()',
-    'closePreSendGestureWindow()',
+    'captureSendIntent({',
     'freezeQueuedSubmission()',
     'inputRef.current?.blur()',
   ]) {

--- a/frontend/src/components/ChatView/__tests__/scrollOwnership.test.js
+++ b/frontend/src/components/ChatView/__tests__/scrollOwnership.test.js
@@ -93,12 +93,48 @@ test('gesture scroll frames defer anchor, spacer, and persistence work until set
 })
 
 test('newer semantic actions cannot be overwritten by an older quiet settlement', () => {
-  const closeStart = ownerSource.indexOf('const closePreSendGestureWindow =')
-  const closeEnd = ownerSource.indexOf('useLayoutEffect(() => () => {', closeStart)
-  const closePath = ownerSource.slice(closeStart, closeEnd)
-  assert.ok(closeStart >= 0 && closeEnd > closeStart,
-    'pre-send ownership handoff must remain discoverable')
-  assert.match(closePath, /discardPendingReaderSettleRef\.current\?\.\(\)/)
+  const supersedeStart = ownerSource.indexOf(
+    'const supersedePendingReaderGesture =',
+  )
+  const supersedeEnd = ownerSource.indexOf(
+    'const captureSendIntent =',
+    supersedeStart,
+  )
+  const supersedePath = ownerSource.slice(supersedeStart, supersedeEnd)
+  assert.ok(supersedeStart >= 0 && supersedeEnd > supersedeStart,
+    'semantic-action ownership handoff must remain discoverable')
+  assert.match(supersedePath, /discardPendingReaderSettleRef\.current\?\.\(\)/)
+
+  const captureStart = supersedeEnd
+  const captureEnd = ownerSource.indexOf(
+    'const sendIntentIsCurrent =',
+    captureStart,
+  )
+  const capturePath = ownerSource.slice(captureStart, captureEnd)
+  assert.ok(
+    capturePath.indexOf('shouldPinSend({')
+      < capturePath.indexOf('supersedePendingReaderGesture()'),
+    'send must snapshot current geometry before retiring the gesture that positioned it',
+  )
+
+  const questionStart = ownerSource.indexOf(
+    'const freezeQuestionSubmission =',
+  )
+  const questionEnd = ownerSource.indexOf(
+    'const anchorPagination =',
+    questionStart,
+  )
+  const questionPath = ownerSource.slice(questionStart, questionEnd)
+  assert.ok(
+    questionPath.indexOf('modeForQuestionSubmission(')
+      < questionPath.indexOf('supersedePendingReaderGesture()'),
+    'question submit must snapshot its card before retiring older settlement',
+  )
+  assert.ok(
+    questionPath.indexOf('supersedePendingReaderGesture()')
+      < questionPath.indexOf('transitionMode('),
+    'older settlement must be retired before the question anchor is committed',
+  )
 
   const hotStart = ownerSource.indexOf('const onScroll = () => {')
   const hotEnd = ownerSource.indexOf(

--- a/frontend/src/components/ChatView/__tests__/steerCutBoundary.test.js
+++ b/frontend/src/components/ChatView/__tests__/steerCutBoundary.test.js
@@ -125,17 +125,31 @@ test('a deferred steer resolves only its OWN row, in any order', () => {
     'a wholesale reconcile against the pre-cut snapshot is what drops a '
     + 'concurrently-queued row and resurrects a retired one',
   )
-  assert.match(
-    deferred,
-    /forgetQueuedPinIntent\(\{ cid: queuedMsg\.cid \}\)/,
-    'the cut reads the pin intent from inlineSteerPinIntentRef, so the map '
-    + 'entry must be released here or it leaks for the life of the chat',
+  assert.ok(
+    !deferred.includes('forgetSendIntent'),
+    'response and SSE delivery can race, so only the authoritative cut may '
+    + 'consume the cid-keyed send intent',
   )
   assert.match(
     steeredBranch,
     /\} else \{[\s\S]*?pendingQueue\.cancelByCid\(queuedMsg\.cid\)/,
     'a route-split (Codex) steer still drops the tray entry immediately',
   )
+})
+
+test('every delayed send intent uses the same cid-keyed ledger', () => {
+  assert.match(chatViewSource, /const sendIntentByCidRef = useRef\(new Map\(\)\)/)
+  assert.ok(!chatViewSource.includes('steerPinIntentRef'))
+  assert.ok(!chatViewSource.includes('inlineSteerPinIntentRef'))
+  assert.ok(!chatViewSource.includes('queuedPinIntentByCidRef'))
+
+  const cut = sliceBranch(
+    chatViewSource,
+    'onSteeredIntoTurn: ({',
+    '\n  })\n',
+  )
+  assert.match(cut, /const pinIntent = takeSendIntent\(pinCid\)/)
+  assert.match(cut, /forgetSendIntent\(\{ cidList: steeredMessages\.map\(cidOf\) \}\)/)
 })
 
 test('every steered branch resolves the optimistic in-flight mark', () => {

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -981,24 +981,17 @@ export function modeForQueuedSubmission(scrollEl, currentMode) {
  *   Whether authoritative history and any first mount catch-up have settled.
  *
  * @returns {{
- *   modeRef: React.MutableRefObject<
- *     | {kind: 'INITIAL'}
- *     | {kind: 'PIN_USER_MSG', cid: string, followWhenFilled?: boolean}
- *     | {kind: 'FOLLOW_BOTTOM'}
- *     | {kind: 'ANCHOR_AT', key: string, offset: number}
- *   >,
  *   gestureWindowUntilRef: React.MutableRefObject<number>,
- *   userScrollIntentVersionRef: React.MutableRefObject<number>,
  *   revealed: boolean,
  *   anchorPagination: (key: string, offset: number) => void,
- *   armSentMessage: (event: object) => void,
- *   closePreSendGestureWindow: () => void,
+ *   captureSendIntent: (event: object) => object,
+ *   commitSendIntent: (event: object) => void,
  *   freezeChatExit: () => void,
  *   freezeForegroundReturn: () => void,
  *   freezeQuestionSubmission: () => void,
  *   freezeQueuedSubmission: () => void,
  *   revealConversationTail: () => void,
- *   settleNonPin: (event?: object) => void,
+ *   settleSendIntent: (event?: object) => void,
  *   settleStreamingPin: () => void,
  * }}
  */
@@ -1215,18 +1208,56 @@ export default function useScrollMode({
     return anchor ? transitionMode(anchor, event) : modeRef.current
   }, [scrollRef, transitionMode])
 
-  const armSentMessage = useCallback(({
+  // A semantic action snapshots the geometry that the reader just chose, then
+  // supersedes every unfinished part of the older gesture. Keep that ordering
+  // inside the scroll owner: exposing the gesture timer + intent generation to
+  // ChatView made each new send entrypoint responsible for reproducing the same
+  // easy-to-miss sequence.
+  const supersedePendingReaderGesture = useCallback(() => {
+    discardPendingReaderSettleRef.current?.()
+    gestureSequenceRef.current += 1
+    gestureWindowUntilRef.current = 0
+    clearTimeout(pendingGestureTimerRef.current)
+    pendingGestureTimerRef.current = 0
+    cancelAnimationFrame(pendingGestureReleaseRafRef.current)
+    pendingGestureReleaseRafRef.current = 0
+    resumeLayoutAfterGestureRef.current?.()
+  }, [])
+
+  const captureSendIntent = useCallback(({
+    canPin = true,
+    isFirstUserMsg = false,
+  } = {}) => {
+    const intent = {
+      willPin: canPin && shouldPinSend({
+        scrollEl: scrollRef.current,
+        mode: modeRef.current,
+        isFirstUserMsg,
+      }),
+      userScrollIntentVersion: userScrollIntentVersionRef.current,
+    }
+    supersedePendingReaderGesture()
+    return intent
+  }, [scrollRef, supersedePendingReaderGesture])
+
+  const sendIntentIsCurrent = useCallback(intent => (
+    !!intent
+    && intent.userScrollIntentVersion === userScrollIntentVersionRef.current
+  ), [])
+
+  const commitSendIntent = useCallback(({
     cid,
-    willPin,
-    intentCurrent = true,
+    intent,
+    fallbackWillPin = false,
   }) => {
     readerLocationExplicitRef.current = true
-    if (!intentCurrent) {
+    if (intent && !sendIntentIsCurrent(intent)) {
       return settleNonPin({
         retireFollow: true,
         event: 'send:reader-overrode-delayed-pin',
       })
     }
+    const willPin = intent ? intent.willPin : fallbackWillPin
     if (willPin && cid != null) {
       return transitionMode({
         kind: 'PIN_USER_MSG',
@@ -1238,7 +1269,16 @@ export default function useScrollMode({
       retireFollow: true,
       event: 'send:hold-current',
     })
-  }, [settleNonPin, transitionMode])
+  }, [sendIntentIsCurrent, settleNonPin, transitionMode])
+
+  const settleSendIntent = useCallback(({
+    intent,
+    retireFollow = false,
+    event = 'send:hold-current',
+  } = {}) => {
+    if (intent && !sendIntentIsCurrent(intent)) return modeRef.current
+    return settleNonPin({ retireFollow, event })
+  }, [sendIntentIsCurrent, settleNonPin])
 
   const freezeQueuedSubmission = useCallback(() => {
     readerLocationExplicitRef.current = true
@@ -1249,12 +1289,17 @@ export default function useScrollMode({
   }, [scrollRef, transitionMode])
 
   const freezeQuestionSubmission = useCallback(() => {
+    const nextMode = modeForQuestionSubmission(scrollRef.current, modeRef.current)
+    // Submit is a newer semantic reading action. Its current-geometry snapshot
+    // must not be replaced a few milliseconds later by the quiet settlement of
+    // the scroll that positioned the question card.
+    supersedePendingReaderGesture()
     readerLocationExplicitRef.current = true
     return transitionMode(
-      modeForQuestionSubmission(scrollRef.current, modeRef.current),
+      nextMode,
       'send:question-freeze',
     )
-  }, [scrollRef, transitionMode])
+  }, [scrollRef, supersedePendingReaderGesture, transitionMode])
 
   const anchorPagination = useCallback((key, offset) => {
     if (!key) return modeRef.current
@@ -1304,17 +1349,6 @@ export default function useScrollMode({
     nearScrollBottomRef.current = isNearScrollBottom(scrollEl)
     persistMode()
   }, [persistMode, scrollRef, transitionMode, writeMode])
-
-  const closePreSendGestureWindow = useCallback(() => {
-    discardPendingReaderSettleRef.current?.()
-    gestureSequenceRef.current += 1
-    gestureWindowUntilRef.current = 0
-    clearTimeout(pendingGestureTimerRef.current)
-    pendingGestureTimerRef.current = 0
-    cancelAnimationFrame(pendingGestureReleaseRafRef.current)
-    pendingGestureReleaseRafRef.current = 0
-    resumeLayoutAfterGestureRef.current?.()
-  }, [])
 
   useLayoutEffect(() => () => {
     clearTimeout(pendingGestureTimerRef.current)
@@ -2333,20 +2367,18 @@ export default function useScrollMode({
   }, [])
 
   return {
-    modeRef,
     gestureWindowUntilRef,
-    userScrollIntentVersionRef,
     revealed,
     anchorPagination,
-    armSentMessage,
-    closePreSendGestureWindow,
+    captureSendIntent,
+    commitSendIntent,
     freezeChatExit,
     freezeForegroundReturn,
     freezeQuestionSubmission,
     freezeQueuedSubmission,
     revealConversationTail,
     reapplyActiveMode,
-    settleNonPin,
+    settleSendIntent,
     settleStreamingPin,
     paneResized,
   }

--- a/tests/chat-redesign.spec.mjs
+++ b/tests/chat-redesign.spec.mjs
@@ -510,6 +510,10 @@ test.describe('Q&A atomic write', () => {
     )
     const streamBody = [
       `data: ${JSON.stringify({
+        type: 'text',
+        content: 'Context before the atomic question. '.repeat(160),
+      })}\n\n`,
+      `data: ${JSON.stringify({
         type: 'question',
         question_id: 'q-pick-atomic',
         questions: [{
@@ -546,9 +550,19 @@ test.describe('Q&A atomic write', () => {
       window.__mobiusChatScrollTrace = {
         version: 1, transitions: [], writes: [], events: [],
       }
+      const scroll = document.querySelector('.chat__scroll')
+      const submit = document.querySelector('.qcard__submit')
+      if (!scroll || !submit) throw new Error('question race fixture is incomplete')
+      // The answer action is newer than this just-finished bottom gesture. Its
+      // exact card anchor must not be replaced by the older quiet settlement.
+      scroll.dispatchEvent(new PointerEvent('pointerdown', {
+        bubbles: true,
+        button: 0,
+      }))
+      scroll.scrollTop = scroll.scrollHeight
+      scroll.dispatchEvent(new Event('scroll'))
+      submit.click()
     })
-    await page.locator('[data-chat-surface="painted"] .qcard__submit').click()
-
     await expect.poll(() => sentBodies.length).toBe(2)
     // The hidden answer message MUST carry the answers field
     // (atomic backend write — no separate /question-answers POST).
@@ -562,6 +576,17 @@ test.describe('Q&A atomic write', () => {
     ))
     expect(questionFreeze).toBeTruthy()
     expect(questionFreeze.to?.kind).toBe('ANCHOR_AT')
+    await page.waitForTimeout(250)
+    const laterReaderBottom = await page.evaluate(() => {
+      const transitions = window.__mobiusChatScrollTrace?.transitions || []
+      const freezeIndex = transitions.findIndex(
+        row => row.event === 'send:question-freeze',
+      )
+      return transitions.slice(freezeIndex + 1).some(
+        row => row.event === 'reader:physical-bottom',
+      )
+    })
+    expect(laterReaderBottom).toBe(false)
   })
 
   test('an Android viewport growth releases a submitted question to its unanswered mode', async ({ page }) => {

--- a/tests/steer-queued.spec.mjs
+++ b/tests/steer-queued.spec.mjs
@@ -482,6 +482,187 @@ test.describe('Steer queued messages (fast-forward into the live turn)', () => {
     await expect(page.locator('[data-chat-surface="painted"] .queued__row')).not.toContainText(TEXT1)
   })
 
+  test('an immediate bottom gesture cannot overwrite a newer fast-forward pin', async ({ page }) => {
+    const QUEUE_TS = Date.now() + 50_000
+    const QUEUED_TEXT = 'pin this steer without a bounce'
+    const PRE_STEER = 'streaming room before fast-forward '.repeat(220)
+    const messagePosts = []
+
+    await page.route(/\/api\/chats\/[0-9a-f-]+\/messages$/, async (route) => {
+      let body = {}
+      try { body = JSON.parse(route.request().postData() || '{}') } catch { /* empty */ }
+      messagePosts.push(body)
+      if (body.force_steer) {
+        return route.fulfill({
+          status: 202,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            status: 'steered', chat_id: 'mock', pending_messages: [],
+          }),
+        })
+      }
+      if (body.content === 'first message') {
+        return route.fulfill({
+          status: 202,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            status: 'started',
+            message: {
+              role: 'user', content: body.content, ts: Date.now(), cid: body.cid,
+            },
+          }),
+        })
+      }
+      const pendingMessage = {
+        role: 'user', content: body.content, ts: QUEUE_TS, cid: body.cid,
+      }
+      return route.fulfill({
+        status: 202,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          status: 'queued',
+          ts: QUEUE_TS,
+          position: 1,
+          pending_message: pendingMessage,
+        }),
+      })
+    })
+
+    // Keep one real fetch stream open so the cut can be emitted in a separate
+    // browser task after the steer response. That response/event ordering is
+    // intentional: the cid ledger must preserve the intent in either order.
+    await page.addInitScript(({ preSteer, queueTs, queuedText }) => {
+      const originalFetch = window.fetch.bind(window)
+      const encoder = new TextEncoder()
+      const encodeSse = events => encoder.encode(
+        events.map(event => `data: ${JSON.stringify(event)}\n\n`).join(''),
+      )
+      window.__immediateSteerMock = {
+        initialRequested: false,
+        emitInitial: null,
+        emitSteer: null,
+      }
+      window.fetch = async (input, init) => {
+        const url = typeof input === 'string' ? input : input?.url
+        if (typeof url === 'string' && /\/api\/chats\/[0-9a-f-]+\/stream$/.test(url)) {
+          let emitSteer
+          const body = new ReadableStream({
+            start(controller) {
+              const emitInitial = () => controller.enqueue(encodeSse([
+                { type: 'catch_up_done' },
+                { type: 'text', content: preSteer },
+              ]))
+              window.__immediateSteerMock.emitInitial = emitInitial
+              if (window.__immediateSteerMock.initialRequested) emitInitial()
+              emitSteer = cid => controller.enqueue(encodeSse([{
+                type: 'steered_into_turn',
+                ts: queueTs,
+                content: queuedText,
+                messages: [{
+                  role: 'user', ts: queueTs, cid, content: queuedText,
+                }],
+              }]))
+            },
+            cancel() {},
+          })
+          window.__immediateSteerMock.emitSteer = cid => emitSteer?.(cid)
+          return new Response(body, {
+            status: 200,
+            headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
+          })
+        }
+        return originalFetch(input, init)
+      }
+    }, { preSteer: PRE_STEER, queueTs: QUEUE_TS, queuedText: QUEUED_TEXT })
+
+    await setupChat(page)
+    await newChat(page)
+    await page.setViewportSize({ width: 1280, height: 900 })
+    await sendMessage(page, 'first message')
+    await expect(page.locator('.chat__msg--user')).toBeVisible({ timeout: 5000 })
+    await page.evaluate(() => {
+      const mock = window.__immediateSteerMock
+      if (!mock) return
+      mock.initialRequested = true
+      mock.emitInitial?.()
+    })
+    await expect(page.locator('.chat__stop')).toBeVisible({ timeout: 5000 })
+    await sendMessage(page, QUEUED_TEXT)
+    const steerBtn = page.getByRole('button', { name: 'Send queued message now' })
+    await expect(steerBtn).toBeVisible({ timeout: 5000 })
+
+    // Reproduce the race in one task: the reader reaches the physical bottom,
+    // its quiet settlement is now pending, and Fast-forward begins before that
+    // timer fires. The newer semantic action must discard the older decision.
+    await page.evaluate(() => {
+      window.__mobiusChatScrollTrace = {
+        version: 1, transitions: [], writes: [], events: [],
+      }
+      const scroll = document.querySelector('.chat__scroll')
+      const steer = document.querySelector(
+        'button[aria-label="Send queued message now"]',
+      )
+      if (!scroll || !steer) throw new Error('steer race fixture is incomplete')
+      scroll.dispatchEvent(new PointerEvent('pointerdown', {
+        bubbles: true,
+        button: 0,
+      }))
+      scroll.scrollTop = scroll.scrollHeight
+      scroll.dispatchEvent(new Event('scroll'))
+      steer.click()
+    })
+
+    await expect.poll(
+      () => messagePosts.filter(body => body.force_steer).length,
+      { timeout: 5000 },
+    ).toBe(1)
+    const steerPost = messagePosts.find(body => body.force_steer)
+    const cid = steerPost?.consume_pending_cids?.[0]
+    expect(typeof cid).toBe('string')
+    await page.evaluate(
+      steeredCid => window.__immediateSteerMock?.emitSteer?.(steeredCid),
+      cid,
+    )
+
+    const result = await page.evaluate(async (steeredCid) => {
+      const frames = []
+      for (let i = 0; i < 12; i += 1) {
+        await new Promise(resolve => requestAnimationFrame(resolve))
+        const scroll = document.querySelector('.chat__scroll')
+        const row = document.querySelector(`.chat__msg--user[data-cid="${steeredCid}"]`)
+        const sr = scroll?.getBoundingClientRect()
+        const rr = row?.getBoundingClientRect()
+        frames.push(sr && rr ? rr.top - sr.top : null)
+      }
+      return {
+        frames,
+        transitions: window.__mobiusChatScrollTrace?.transitions || [],
+      }
+    }, cid)
+
+    const landedFrames = result.frames.filter(Number.isFinite)
+    expect(landedFrames.length, JSON.stringify(result)).toBeGreaterThanOrEqual(4)
+    for (const visualTop of landedFrames) {
+      expect(visualTop, JSON.stringify(result)).toBeGreaterThanOrEqual(-2)
+      expect(visualTop, JSON.stringify(result)).toBeLessThanOrEqual(12)
+    }
+    expect(
+      Math.max(...landedFrames) - Math.min(...landedFrames),
+      JSON.stringify(result),
+    ).toBeLessThanOrEqual(2)
+
+    const pinIndex = result.transitions.findIndex(
+      row => row.event === 'send:pin-user-message',
+    )
+    expect(pinIndex, JSON.stringify(result.transitions)).toBeGreaterThanOrEqual(0)
+    expect(
+      result.transitions.slice(pinIndex + 1).some(
+        row => row.event === 'reader:physical-bottom',
+      ),
+      JSON.stringify(result.transitions),
+    ).toBe(false)
+  })
+
   test('a steer while reading above the tail preserves the live stream and held position', async ({ page }) => {
     // Regression for bug #1: a force_steer must inject into the LIVE turn,
     // not trigger the fresh-send reset. The old code ran sendMessage's


### PR DESCRIPTION
## Summary
- make send-intent capture and stale gesture retirement a single scroll-controller operation
- keep delayed positioning intent in one CID-keyed ledger across queued, direct-steer, and continuation paths
- prevent question submission from being overwritten by an older scroll settlement

## Testing
- `cd frontend && npm test`
- `cd frontend && npm run build`
- focused Playwright regressions in `tests/steer-queued.spec.mjs` and `tests/chat-redesign.spec.mjs`