### PR TITLE
Test chat activity ordering and drawer attention states

### DIFF
--- a/backend/tests/test_chat_activity_ordering.py
+++ b/backend/tests/test_chat_activity_ordering.py
@@ -1,0 +1,37 @@
+"""Chat drawer recency follows owner actions, not generic row updates."""
+
+from datetime import UTC, datetime
+
+from app import models
+from app.chat_writer import AppendSteeredUserMessage, get_writer
+
+
+def test_steered_message_advances_drawer_recency(db):
+  old_activity = datetime(2000, 1, 1, tzinfo=UTC)
+  chat = models.Chat(
+    id="steer-recency",
+    title="Steer recency",
+    messages=[
+      {"role": "user", "content": "start", "ts": 1},
+      {"role": "assistant", "content": "working", "ts": 2},
+    ],
+    activity_at=old_activity,
+  )
+  db.add(chat)
+  db.commit()
+
+  result = get_writer().submit(AppendSteeredUserMessage(
+    chat_id=chat.id,
+    run_token="steer-recency-run",
+    user_msg={
+      "role": "user",
+      "content": "change course",
+      "ts": 3,
+      "cid": "steer-recency-cid",
+    },
+  )).result(timeout=5)
+
+  assert result["stored"]["content"] == "change course"
+  db.expire_all()
+  persisted = db.query(models.Chat).filter(models.Chat.id == chat.id).one()
+  assert persisted.activity_at.replace(tzinfo=UTC) > old_activity

--- a/backend/tests/test_chats.py
+++ b/backend/tests/test_chats.py
@@ -250,6 +250,35 @@ def test_chat_list_projects_summaries_without_hydrating_transcripts(
   )
 
 
+def test_chat_list_orders_by_owner_activity_not_agent_updates(
+  client, auth, db,
+):
+  """A later agent write must not outrank a newer owner send or steer."""
+  db.add_all([
+    models.Chat(
+      id="agent-finished",
+      title="Agent finished",
+      messages=[{"role": "user", "content": "older owner activity"}],
+      activity_at=datetime(2026, 7, 28, 9, 0, tzinfo=UTC),
+      updated_at=datetime(2026, 7, 28, 12, 0, tzinfo=UTC),
+    ),
+    models.Chat(
+      id="owner-steered",
+      title="Owner steered",
+      messages=[{"role": "user", "content": "newer owner activity"}],
+      activity_at=datetime(2026, 7, 28, 11, 0, tzinfo=UTC),
+      updated_at=datetime(2026, 7, 28, 11, 0, tzinfo=UTC),
+    ),
+  ])
+  db.commit()
+
+  listed = client.get("/api/chats", headers=auth)
+
+  assert listed.status_code == 200
+  ids = [row["id"] for row in listed.json()]
+  assert ids.index("owner-steered") < ids.index("agent-finished")
+
+
 def test_update_chat_rejects_cross_site_request(client, auth, chat):
   cross = client.put(
     f"/api/chats/{chat.id}",

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -760,6 +760,31 @@ test('opening navigation is presentation-only and never refetches whole lists', 
     'chat lifecycle events still own their authoritative refresh')
 })
 
+test('chat drawer dots distinguish active work from unseen completion', () => {
+  assert.match(
+    shell,
+    /ev\.type === 'chat_run_started'[\s\S]*?markStreamingStart\(ev\.chatId\)/,
+    'a started run must raise the active-work dot',
+  )
+  assert.match(
+    shell,
+    /ev\.type === 'chat_run_finished'[\s\S]*?!visibleChatIdsRef\.current\.has\(String\(chatId\)\)[\s\S]*?setAttentionChatIds/,
+    'a finished run must raise attention only while the chat is not visible',
+  )
+  assert.match(
+    shell,
+    /for \(const cid of visibleChatIds\) clearChatAttention\(cid\)/,
+    'viewing a chat must clear its completion dot',
+  )
+  assert.match(
+    drawer,
+    /streaming \? \([\s\S]*?drawer__streaming-dot[\s\S]*?: attention \? \([\s\S]*?drawer__attention-dot/,
+    'active work must take precedence over unseen completion in a row',
+  )
+  assert.match(drawerCss, /\.drawer__streaming-dot\s*\{[\s\S]*?background:\s*var\(--accent\)/)
+  assert.match(drawerCss, /\.drawer__attention-dot\s*\{[\s\S]*?border:\s*1\.5px solid var\(--green\)/)
+})
+
 test('live preview reveal keeps the workspace controller distinct from device mode', () => {
   assert.match(shell, /const deviceMode = paneModel\.modeForRect\(contentRect\)/)
   assert.match(shell, /mode\.toggle\(\{ cause: 'auto', to: 'panes' \}\)/)

--- a/frontend/src/lib/__tests__/drawerInformationArchitecture.test.js
+++ b/frontend/src/lib/__tests__/drawerInformationArchitecture.test.js
@@ -27,6 +27,28 @@ test('drawer separates pinned chats and apps from ordinary chat history', () => 
   assert.deepEqual(sections.apps.map(app => app.id), [2, 1])
 })
 
+test('ordinary chat order follows owner activity rather than generic row updates', () => {
+  const sections = buildDrawerSections([
+    {
+      id: 'agent-finished',
+      has_messages: true,
+      activity_at: '2026-07-28T09:00:00Z',
+      updated_at: '2026-07-28T12:00:00Z',
+    },
+    {
+      id: 'owner-steered',
+      has_messages: true,
+      activity_at: '2026-07-28T11:00:00Z',
+      updated_at: '2026-07-28T11:00:00Z',
+    },
+  ], [])
+
+  assert.deepEqual(
+    sections.chats.map(chat => chat.id),
+    ['owner-steered', 'agent-finished'],
+  )
+})
+
 test('pinned order is stable across mixed timestamp formats (Z vs naive UTC)', () => {
   // After a drag, optimistic chat stamps carry a trailing Z while a refetched
   // app carries the server's naive-UTC form. Same instants must still interleave


### PR DESCRIPTION
## Summary
- protect chat ordering from background transcript updates
- verify steering refreshes drawer recency
- cover active-work and unseen-completion dot states

## Testing
- `scripts/wt-pytest.sh tests/test_chat_activity_ordering.py tests/test_chats.py -q`
- targeted drawer ordering and workspace UI unit tests