### PR TITLE
Keep background app previews non-displacing

### DIFF
--- a/backend/scripts/seed-skills/building-apps-quickstart.md
+++ b/backend/scripts/seed-skills/building-apps-quickstart.md
@@ -157,11 +157,11 @@ python "$SCRIPTS_DIR/apply_app.py" /data/apps/<slug>
 The helper validates the manifest and complete source tree, compiles and
 commits that exact revision, returns a compact receipt with `app_id`,
 `preview_path`, and `open_path`, and emits one live-preview action tied to this
-building chat. On a phone the shell enters Builder and activates the app tab;
-on a wider screen it opens the app in a companion pane while keyboard focus
-stays in the chat. Reuse that numeric ID for preview, storage, notifications,
-and later actions; do not list apps again after a successful apply. Do not send
-a separate `open_item`.
+building chat. The preview may bloom into a separate visible pane when that
+adds space without hiding anything. When it would have to share a pane, it
+parks as an inactive tab instead of replacing what the partner is using. Reuse
+that numeric ID for preview, storage, notifications, and later actions; do not
+list apps again after a successful apply. Do not send a separate `open_item`.
 
 Afterward, edit source files normally and run the same command once the change
 is coherent enough to preview. Each successful apply live-swaps the already

--- a/backend/scripts/seed-skills/building-apps-quickstart.md
+++ b/backend/scripts/seed-skills/building-apps-quickstart.md
@@ -160,8 +160,7 @@ commits that exact revision, returns a compact receipt with `app_id`,
 building chat. The preview may bloom into a separate visible pane when that
 adds space without hiding anything. When it would have to share a pane, it
 parks as an inactive tab instead of replacing what the partner is using. Reuse
-that numeric ID for preview, storage, notifications, and later actions; do not
-list apps again after a successful apply. Do not send a separate `open_item`.
+that numeric ID for preview, storage, notifications, and later actions; do not list apps again after a successful apply. Do not send a separate `open_item`.
 
 Afterward, edit source files normally and run the same command once the change
 is coherent enough to preview. Each successful apply live-swaps the already

--- a/backend/scripts/seed-skills/notifications.md
+++ b/backend/scripts/seed-skills/notifications.md
@@ -24,7 +24,7 @@ The `open_item` system event (see `core.md`, "Opening something in the partner's
 
 The platform does NOT auto-notify when you call `AskUserQuestion` or end a turn with a prose clarifying question. You own this explicitly: same `curl POST /api/notifications/send` pattern you use after building an app, with a question-shaped title and body. Firing it from bash means the HTTP response lands in your tool output, so you see success/failure and can react (re-try, fall back to text) on the same turn.
 
-Title: "Möbius needs your answer". Body: the first ~80 chars of your question. Include `source_id: "$CHAT_ID"` and `target: "/shell/?chat=$CHAT_ID"` so the tap routes back here **inside the PWA** — the bare `/chat/<id>` form escapes the service-worker scope and a cold tap opens a browser tab instead. Skip the notify only when you delivered something useful in the same turn AND that delivery already sent a notification.
+Title: "Möbius needs your answer". Body: the first ~80 chars of your question. Include `source_id: "$CHAT_ID"` and `target: "/shell/?chat=$CHAT_ID"` so the tap routes back here **inside the PWA** — the bare `/chat/<id>` form escapes the service-worker scope and a cold tap opens a browser tab instead. Skip the notify only when you delivered something useful in the same turn AND that delivery already sent a notification whose **default target is this chat**. An app-targeted completion notification does not cover an open question: its tap lands in the wrong place, so send the chat-targeted question notification too.
 
 ---
 

--- a/frontend/src/components/Shell/__tests__/workspacePlacement.test.js
+++ b/frontend/src/components/Shell/__tests__/workspacePlacement.test.js
@@ -236,8 +236,11 @@ test('beside-source + foreground · phone: insert and activate', () => {
   assert.equal(out.panes.p0.activeTabKey, 'app:9', 'foreground activates the item')
 })
 
-test('live preview · phone: enters Builder, keeps a chat tab, and activates the app', () => {
-  const ws = paneModel.setViewMode(paneModel.seedFromFlatTabs([CHAT('a')]), 'single')
+test('live preview · phone: enters Builder without replacing its source chat', () => {
+  const ws = {
+    ...paneModel.setViewMode(builderSeed([CHAT('a')]), 'single'),
+    singleScreen: { kind: 'chat', id: 'a' },
+  }
   const out = resolveWorkspaceRequest(
     ws,
     builtAppWorkspaceRequest('a', 9),
@@ -245,8 +248,25 @@ test('live preview · phone: enters Builder, keeps a chat tab, and activates the
   )
   assert.equal(out.viewMode, 'panes', 'the live preview reveals the Builder world')
   assert.deepEqual(keysOf(out.panes.p0), ['chat:a', 'app:9'])
-  assert.equal(out.panes.p0.activeTabKey, 'app:9', 'the phone switches to the preview tab')
+  assert.equal(out.panes.p0.activeTabKey, 'chat:a',
+    'the preview is parked until the owner opens it')
   assert.equal(out.focusedPaneId, 'p0')
+})
+
+test('live preview · Standard elsewhere: parks without changing the visible surface', () => {
+  const ws = {
+    ...paneModel.setViewMode(builderSeed([CHAT('a')]), 'single'),
+    singleScreen: { kind: 'chat', id: 'elsewhere' },
+  }
+  const out = resolveWorkspaceRequest(
+    ws,
+    builtAppWorkspaceRequest('a', 9),
+    env(ws, { mode: 'wide', rect: { w: 1400, h: 900 } }),
+  )
+  assert.equal(out.viewMode, 'single', 'background work does not leave Standard')
+  assert.deepEqual(out.singleScreen, { kind: 'chat', id: 'elsewhere' },
+    'the owner keeps the surface they were using')
+  assert.ok(paneModel.paneOf(out, 'app:9'), 'the preview is parked in Builder')
 })
 
 test('beside-source + background · tile single pane: split, item active in the NEW pane, focus stays', () => {
@@ -265,7 +285,10 @@ test('beside-source + background · tile single pane: split, item active in the 
 })
 
 test('live preview · wide: enters Builder and blooms beside the focused chat', () => {
-  const ws = paneModel.setViewMode(paneModel.seedFromFlatTabs([CHAT('a')]), 'single')
+  const ws = {
+    ...paneModel.setViewMode(builderSeed([CHAT('a')]), 'single'),
+    singleScreen: { kind: 'chat', id: 'a' },
+  }
   const out = resolveWorkspaceRequest(
     ws,
     builtAppWorkspaceRequest('a', 9),
@@ -278,6 +301,36 @@ test('live preview · wide: enters Builder and blooms beside the focused chat', 
   const appPane = paneModel.paneOf(out, 'app:9')
   assert.ok(appPane)
   assert.equal(appPane.activeTabKey, 'app:9', 'the preview is visible in its pane')
+})
+
+test('live preview · compact fallback: parks in the source pane without replacing it', () => {
+  const ws = twoPaneWs([CHAT('a')], [CHAT('b')])
+  const rect = { w: 800, h: 560 }
+  const out = resolveWorkspaceRequest(
+    ws,
+    builtAppWorkspaceRequest('a', 9),
+    env(ws, { mode: 'compact', rect, liveApps: [{ id: 9, chat_id: 'a' }] }),
+  )
+  assert.equal(paneModel.paneIdsInOrder(out).length, 2,
+    'a projection-unsafe third pane is not created')
+  assert.deepEqual(keysOf(out.panes.p0), ['chat:a', 'app:9'])
+  assert.equal(out.panes.p0.activeTabKey, 'chat:a',
+    'the preview cannot take over the shared pane')
+  assertNoVisibleContentVanished(ws, out, 'compact', rect)
+})
+
+test('live preview · occupied companion: joins without replacing the visible app', () => {
+  const ws = twoPaneWs([CHAT('a')], [APP(5)])
+  const liveApps = [{ id: 5, chat_id: 'a' }, { id: 9, chat_id: 'a' }]
+  const out = resolveWorkspaceRequest(
+    ws,
+    builtAppWorkspaceRequest('a', 9),
+    env(ws, { mode: 'wide', liveApps }),
+  )
+  assert.deepEqual(keysOf(out.panes.p1), ['app:5', 'app:9'])
+  assert.equal(out.panes.p1.activeTabKey, 'app:5',
+    'a preview never replaces content in an existing companion pane')
+  assert.equal(out.focusedPaneId, 'p0')
 })
 
 test('beside-source + foreground · tile single pane: split AND focus the new pane', () => {
@@ -444,10 +497,13 @@ test('item already open: background is a strict no-op; foreground focuses its pa
 })
 
 test('live preview · wide update: an app parked with its chat moves into a visible companion pane', () => {
-  const ws = paneModel.setViewMode(
-    paneModel.seedFromFlatTabs([CHAT('a'), APP(5)]),
-    'single',
-  )
+  const ws = {
+    ...paneModel.setViewMode(
+      paneModel.seedFromFlatTabs([CHAT('a'), APP(5)]),
+      'single',
+    ),
+    singleScreen: { kind: 'chat', id: 'a' },
+  }
   const out = resolveWorkspaceRequest(
     ws,
     builtAppWorkspaceRequest('a', 5),

--- a/frontend/src/components/Shell/workspacePlacement.js
+++ b/frontend/src/components/Shell/workspacePlacement.js
@@ -11,10 +11,10 @@ export const PLACE_WITH_SOURCE = 'with-source'
 export const PLACE_WITH_FOCUS = 'with-focus'
 export const ACTIVATE_IN_BACKGROUND = 'background'
 export const ACTIVATE_FOREGROUND = 'foreground'
-// A live build preview is visible by definition, but visibility means different
-// things across devices: phones activate the app tab, while wider workspaces
-// activate the app inside a companion pane and keep keyboard focus in the chat.
-// This is an internal lifecycle intent, not an `open_item` wire value.
+// A live build preview is non-displacing: it may reveal the app in a new pane,
+// but it never replaces an already-visible tab. When no separate pane is
+// available it parks beside its source until the owner opens it. This is an
+// internal lifecycle intent, not an `open_item` wire value.
 export const ACTIVATE_LIVE_PREVIEW = 'live-preview'
 
 const PLACEMENTS = new Set([PLACE_BESIDE_SOURCE, PLACE_WITH_SOURCE, PLACE_WITH_FOCUS])
@@ -27,9 +27,9 @@ const REQUEST_ACTIVATIONS = new Set([
 
 // A runnable build preview expresses product intent without naming a tab strip,
 // pane, split direction, or breakpoint. The resolver interprets `beside-source`
-// as a visible companion pane when the device supports one, or an activated tab
-// on a phone. In either case the app is visible as soon as a coherent revision
-// lands, and subsequent app_updated events can live-swap further layers in place.
+// as a visible companion pane only when it can add one without hiding anything;
+// otherwise it parks the app beside its source. Subsequent app_updated events
+// still live-swap an app that is already visible.
 export function builtAppWorkspaceRequest(chatId, appId) {
   const normalizedAppId = Number(appId)
   if (
@@ -218,8 +218,7 @@ function tryAutoSplit(ws, item, sourcePane, env, { focus, preserveVisible }) {
 }
 
 // Insert the item as a tab directly after its source in the source's pane. The
-// caller controls activation and focus separately: a live preview on a wide
-// screen activates the app while keeping keyboard focus in the building chat.
+// caller controls activation and focus separately.
 function insertBesideSource(ws, item, sourcePane, source, { activate, focus }) {
   return paneModel.openTab(ws, item, {
     paneId: sourcePane.id,
@@ -271,8 +270,11 @@ export function resolveWorkspaceRequest(ws, request, env = {}) {
   const preview = activation === ACTIVATE_LIVE_PREVIEW
   const foreground = activation === ACTIVATE_FOREGROUND
   const mode = env.mode || 'wide'
-  const activateItem = foreground || preview
-  const focusItem = foreground || (preview && mode === 'phone')
+  // Foreground is the ONLY permission to replace an active tab. A preview can
+  // still become visible by creating a new pane, whose sole tab is naturally
+  // active, but an existing pane keeps whatever the owner is using.
+  const activateItem = foreground
+  const focusItem = foreground
 
   // Two-worlds (finding F4): in the SINGLE world the only visible surface is the
   // slot, so a FOREGROUND agent open must SET THE SLOT — mutating the hidden pane
@@ -287,31 +289,41 @@ export function resolveWorkspaceRequest(ws, request, env = {}) {
     return paneModel.setSingleScreen(ws, { kind: item.kind, id: String(item.id) })
   }
 
-  // A live preview owns the transition into Builder. Background placement used
-  // to park the app in the hidden builder tree while Standard remained on screen,
-  // which made a successful build look like nothing happened. Folding the mode
-  // flip into the same pure request keeps reconnect/live delivery idempotent and
-  // lets Shell mirror it into the transition descriptor in one React batch.
-  let working = preview && paneModel.WORKSPACE_SPLITS_ENABLED
+  const sourceKey = source ? tabKey(source) : null
+  const singleShowsSource = (
+    world === 'single'
+    && sourceKey != null
+    && ws.singleScreen != null
+    && tabKey(ws.singleScreen) === sourceKey
+  )
+
+  // A preview may enter Builder when the owner is already looking at its source:
+  // the source remains the foreground surface and the app can bloom beside it.
+  // If the owner has moved elsewhere in Standard, keep that surface untouched
+  // and park the preview in the hidden Builder tree for an explicit later open.
+  let working = (
+    preview
+    && paneModel.WORKSPACE_SPLITS_ENABLED
+    && (world === 'panes' || singleShowsSource)
+  )
     ? paneModel.setViewMode(ws, 'panes')
     : ws
   const itemKey = tabKey(item)
 
-  // A preview is a two-surface workspace on wider screens. Reveal and focus the
-  // building chat first (or add it to the parked builder tree when Standard was
-  // opened from a chat the tree did not yet know). Phone keeps an already-open
-  // app stable; for a new app it still adds the chat tab so switching back works.
+  // Keep the relational source in the Builder tree, but never surface it over
+  // another active tab. The one safe activation is Standard → Builder while
+  // Standard already shows that exact source, preserving what the owner sees.
   let sourcePane = source ? paneModel.paneOf(working, tabKey(source)) : null
-  if (preview && source && (mode !== 'phone' || !sourcePane)) {
+  if (preview && source) {
     if (!sourcePane) {
       working = paneModel.openTab(working, source, {
         paneId: working.focusedPaneId,
-        activate: true,
-        focus: true,
+        activate: singleShowsSource,
+        focus: singleShowsSource,
         protect: protectKeys(working, [source, item]),
       })
       sourcePane = paneModel.paneOf(working, tabKey(source))
-    } else {
+    } else if (singleShowsSource) {
       working = paneModel.focusPane(
         paneModel.setActiveTab(working, sourcePane.id, tabKey(source)),
         sourcePane.id,
@@ -321,11 +333,10 @@ export function resolveWorkspaceRequest(ws, request, env = {}) {
   }
 
   // Already open anywhere → background is a no-op; foreground focuses it. A
-  // live preview activates it but, on wider screens, leaves focus in the chat.
+  // live preview only reveals an inactive app by moving it into a new pane; if
+  // that cannot preserve every visible tab, it remains parked.
   const existing = paneModel.paneOf(working, itemKey)
   if (existing) {
-    if (!activateItem) return working
-
     // If an earlier narrow-screen build parked chat + app in one pane, widen the
     // same relationship into two real panes now instead of hiding the chat behind
     // an activated app tab. Moving an existing tab is the correct primitive;
@@ -337,16 +348,18 @@ export function resolveWorkspaceRequest(ws, request, env = {}) {
           paneId: sourcePane.id,
           edge,
         })
-        if (moved !== working) {
+        if (
+          moved !== working
+          && preservesVisibleContent(working, moved, mode, env.contentRect)
+        ) {
           return paneModel.focusPane(moved, sourcePane.id)
         }
       }
     }
 
+    if (!activateItem) return working
     const activated = paneModel.setActiveTab(working, existing.id, itemKey)
-    return focusItem
-      ? paneModel.focusPane(activated, existing.id)
-      : activated
+    return paneModel.focusPane(activated, existing.id)
   }
 
   sourcePane = source ? paneModel.paneOf(working, tabKey(source)) : null
@@ -372,8 +385,8 @@ export function resolveWorkspaceRequest(ws, request, env = {}) {
 
   // beside-source, the device-aware table.
   if (mode === 'phone') {
-    // Phone stack: a live preview activates the app tab; a generic background
-    // placement remains parked without changing the on-screen item.
+    // Phone stack: previews and generic background placements remain parked;
+    // only an explicit foreground request changes the on-screen item.
     return insertBesideSource(working, item, sourcePane, source, {
       activate: activateItem,
       focus: focusItem,
@@ -382,7 +395,7 @@ export function resolveWorkspaceRequest(ws, request, env = {}) {
 
   const splitPolicy = {
     focus: focusItem,
-    preserveVisible: !activateItem,
+    preserveVisible: !foreground,
   }
   const paneCount = paneModel.paneIdsInOrder(working).length
   if (paneCount <= 1) {
@@ -400,8 +413,8 @@ export function resolveWorkspaceRequest(ws, request, env = {}) {
   // background tab beside the source (the degradation ladder, design §6.2).
   const companion = companionPaneFor(working, source, env.liveApps)
   if (companion) {
-    // A background request preserves the companion's visible tab. A live preview
-    // activates the new revision there while leaving keyboard focus in the chat.
+    // Background work and live previews preserve the companion's visible tab.
+    // A foreground request is the only path that replaces it.
     return paneModel.openTab(working, item, {
       paneId: companion.id,
       activate: activateItem,


### PR DESCRIPTION
## Summary
- make live app previews non-displacing across phone, compact, and wide workspaces
- reveal a preview only when a new pane preserves everything already visible; otherwise park it as an inactive tab
- keep Standard mode on the surface the owner chose when background work belongs elsewhere
- ensure open-question notifications route back to the waiting chat

## Why
The preview lifecycle treated visibility as permission to activate a tab. When pane placement degraded to a shared tab, background work replaced the content the owner was using.

This fixes the behavior at the workspace-placement primitive, so every app gets the same rule without app-specific exceptions or timing workarounds.

## Testing
- `node --test frontend/src/components/Shell/__tests__/workspacePlacement.test.js`
- `npm test`
- `npm run build`
- rendered phone-sized shell verification: a live preview was added as an inactive tab while the current chat remained visible