### PR TITLE
Give apps a reliable first-turn chat primitive

### DIFF
--- a/backend/scripts/seed-skills/building-apps.md
+++ b/backend/scripts/seed-skills/building-apps.md
@@ -910,9 +910,24 @@ useEffect(() => {
 ## Communicating with the shell
 
 ```jsx
-// Open a new chat with pre-filled text
+// Open a new chat with pre-filled text. The owner reviews and sends it.
 window.parent.postMessage({ type: 'moebius:new-chat', draft: 'Hello!' }, '*')
+
+// Create an owner-visible chat and submit its first turn reliably.
+// Open it only after the runtime confirms that the turn was accepted.
+const { chatId } = await window.mobius.chat.start({
+  title: 'Prepare projects',
+  draft: 'Inspect every ready project and prepare the worthwhile ones.',
+})
+window.parent.postMessage({ type: 'moebius:open-chat', chatId }, '*')
 ```
+
+Use `moebius:new-chat` only for an editable draft. Do not add an `autoSend`
+field to that shell message: retained panes and navigation make a
+create-then-send handoff inherently timing-sensitive. `window.mobius.chat.start`
+is the shared first-turn primitive. It creates a visible app-owned chat, waits
+for the first message to be accepted, then returns its id for navigation. Catch
+errors and preserve the source UI so the owner can retry without losing work.
 
 The opaque app document cannot name the shell as a target origin, so raw
 app-to-shell messages use `'*'`. For reply protocols, require

--- a/frontend/public/mobius-runtime.js
+++ b/frontend/public/mobius-runtime.js
@@ -2334,7 +2334,10 @@ let _embedSeq = 0
 
 const hasOwn = (obj, key) => Object.prototype.hasOwnProperty.call(obj || {}, key)
 
-export function appChatMetadataBody(opts = {}, { includeProvider = true } = {}) {
+export function appChatMetadataBody(
+  opts = {},
+  { includeProvider = true, includeOwnerVisible = false } = {},
+) {
   const body = {}
   if (hasOwn(opts, 'systemPrompt')) {
     body.system_prompt = opts.systemPrompt == null ? '' : String(opts.systemPrompt)
@@ -2363,6 +2366,9 @@ export function appChatMetadataBody(opts = {}, { includeProvider = true } = {}) 
   if (hasOwn(opts, 'scopeLabel')) {
     const label = opts.scopeLabel == null ? '' : String(opts.scopeLabel).trim()
     if (label) body.scope_label = label
+  }
+  if (includeOwnerVisible && hasOwn(opts, 'ownerVisible')) {
+    body.owner_visible = opts.ownerVisible === true
   }
   return body
 }
@@ -2462,7 +2468,7 @@ export function makeEmbedAuthorizationHandoff({
   }
 }
 
-function makeChat({ appId, getToken, storage }) {
+export function makeChat({ appId, getToken, storage }) {
   // Lazily create a chat the agent turn can be attributed to, via the
   // app-attributed backend contract (design §1.1: POST /api/app-chats).
   // The ordinary /api/chats create route is owner-only and intentionally
@@ -2500,7 +2506,10 @@ function makeChat({ appId, getToken, storage }) {
         // small design, design §1.5). Forward them so they're honored
         // the moment the backend accepts them; harmless extra fields
         // until then.
-        ...appChatMetadataBody(opts, { includeProvider: true }),
+        ...appChatMetadataBody(opts, {
+          includeProvider: true,
+          includeOwnerVisible: true,
+        }),
       }),
     })
     if (!res.ok) {
@@ -2557,6 +2566,54 @@ function makeChat({ appId, getToken, storage }) {
     } catch (e) {}
   }
 
+  // Start a first-class owner-visible chat and submit its first turn without
+  // depending on shell navigation, retained ChatView state, or browser draft
+  // storage. Navigation is deliberately left to the caller: after this
+  // promise resolves, an app can post moebius:open-chat for the returned id.
+  async function startChat(opts = {}) {
+    const content = String(opts.content ?? opts.draft ?? '').trim()
+    if (!content) {
+      throw new Error('window.mobius.chat.start: opts.draft must not be empty')
+    }
+    const chatId = await createChat({
+      ...opts,
+      ownerVisible: opts.ownerVisible !== false,
+    })
+    const cid = (
+      typeof crypto !== 'undefined'
+      && typeof crypto.randomUUID === 'function'
+    )
+      ? crypto.randomUUID()
+      : `cid-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`
+    let timezone = 'UTC'
+    try {
+      timezone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
+    } catch (e) {}
+    const body = { content, cid, timezone }
+    if (typeof window !== 'undefined') {
+      body.viewport = {
+        width: window.innerWidth,
+        height: window.visualViewport?.height || window.innerHeight,
+      }
+    }
+    const res = await appChatFetch(
+      `/api/chats/${encodeURIComponent(chatId)}/messages`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      },
+    )
+    if (!res.ok) {
+      const error = new Error(`window.mobius.chat.start: send failed (${res.status})`)
+      error.chatId = chatId
+      throw error
+    }
+    let response = null
+    try { response = await res.json() } catch (e) {}
+    return { chatId, response }
+  }
+
   // Open the embed in a nested iframe inside `mount` (an element the app
   // controls). Returns a handle: { chatId, instanceId, iframe, destroy,
   // on(event, cb) }. Events: 'ready' | 'message-sent' | 'turn-done' |
@@ -2574,7 +2631,7 @@ function makeChat({ appId, getToken, storage }) {
   // So the common app usage is one call:
   //   const h = await window.mobius.chat({ mount, persist: 'chat_id.json',
   //     systemPrompt, picker: false, onTurnDone: refresh })  // h.destroy() on unmount
-  return async function chat(opts = {}) {
+  const chat = async function chat(opts = {}) {
     const mount = opts.mount
     if (!mount || typeof mount.appendChild !== 'function') {
       throw new Error('window.mobius.chat: opts.mount must be a DOM element')
@@ -3005,6 +3062,8 @@ function makeChat({ appId, getToken, storage }) {
       },
     }
   }
+  chat.start = startChat
+  return chat
 }
 
 // ── ChatSplit — window.mobius.split(opts) ────────────────────────────────────

--- a/frontend/src/lib/__tests__/mobiusRuntime.test.js
+++ b/frontend/src/lib/__tests__/mobiusRuntime.test.js
@@ -15,6 +15,7 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import {
   appChatMetadataBody,
+  makeChat,
   makeCapabilities,
   makeNav,
   makeSignal,
@@ -93,6 +94,72 @@ test('app chat metadata body forwards scoped chat fields', () => {
     scope: 'workout-session:session-123',
     scope_label: 'Workout Jul 11',
   })
+})
+
+test('app chat metadata body exposes owner visibility only on create', () => {
+  assert.deepEqual(appChatMetadataBody({
+    ownerVisible: true,
+  }, { includeOwnerVisible: true }), {
+    owner_visible: true,
+  })
+  assert.deepEqual(appChatMetadataBody({ ownerVisible: true }), {})
+})
+
+test('chat.start creates one owner-visible app chat and submits its first turn', async () => {
+  const previousFetch = globalThis.fetch
+  const calls = []
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({ url, init })
+    if (url === '/api/app-chats') {
+      return new Response(JSON.stringify({ id: 'chat-started' }), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+    if (url === '/api/chats/chat-started/messages') {
+      return new Response(JSON.stringify({ status: 'started' }), {
+        status: 202,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+    return new Response(null, { status: 404 })
+  }
+  try {
+    const chat = makeChat({
+      appId: 80,
+      getToken: async () => 'app-token',
+      storage: null,
+    })
+    const result = await chat.start({
+      title: 'Address Contribute follow-ups',
+      draft: 'Address every active follow-up.',
+    })
+
+    assert.equal(result.chatId, 'chat-started')
+    assert.equal(calls.length, 2)
+    assert.deepEqual(JSON.parse(calls[0].init.body), {
+      title: 'Address Contribute follow-ups',
+      owner_visible: true,
+    })
+    const sent = JSON.parse(calls[1].init.body)
+    assert.equal(sent.content, 'Address every active follow-up.')
+    assert.equal(typeof sent.cid, 'string')
+    assert.equal(typeof sent.timezone, 'string')
+  } finally {
+    globalThis.fetch = previousFetch
+  }
+})
+
+test('chat.start rejects an empty first turn before creating a chat', async () => {
+  const chat = makeChat({
+    appId: 80,
+    getToken: async () => 'app-token',
+    storage: null,
+  })
+  await assert.rejects(
+    chat.start({ draft: '   ' }),
+    /opts\.draft must not be empty/,
+  )
 })
 
 async function withFakeWindow(fn) {


### PR DESCRIPTION
## Problem

Apps that created a chat and then asked the shell to submit its first draft depended on navigation and retained pane timing. A long-lived workspace could keep running an older shell, leaving an automatic handoff as an unsent draft even after the app frame had updated.

## Fix

- add `window.mobius.chat.start(...)` as one runtime-owned operation that creates an owner-visible app chat and submits its first turn before navigation
- return the chat id only after the message is accepted, while preserving it on send errors so callers can recover honestly
- keep `moebius:new-chat` as the editable draft path and document the runtime primitive for automatic first turns
- cover owner visibility, successful submission, and empty-input rejection at the runtime boundary

The installed automatic callers are migrated separately; this platform change deliberately avoids adding another shell-timing workaround.

## Verification

- focused runtime and chat-handoff tests: 36 passed
- frontend unit tests: 2,114 passed
- frontend hook tests: 66 passed
- production frontend build passed