### PR TITLE
Align tab drag geometry under desktop scale

### DIFF
--- a/frontend/src/components/Shell/__tests__/dragController.test.js
+++ b/frontend/src/components/Shell/__tests__/dragController.test.js
@@ -7,6 +7,7 @@ import {
   CHIP_MOUSE_DX, CHIP_MOUSE_DY, CHIP_TOUCH_ABOVE,
   EDGE_BAND_MIN, EDGE_BAND_FRACTION,
   passedSlop, touchMoveIntent, releasedInPlace, holdMsFor, chipOffset,
+  clientPointToLocal,
   crossedDrawerExit, edgeBands, edgePreviewRect, caretZone, edgeZone, centerZone,
   rootEdgeZone, hitTest, zoneTarget, releaseZone, zoneEq, buildScene, paneAcceptsJoin,
 } from '../dragController.js'
@@ -33,6 +34,35 @@ function scene(panes, opts = {}) {
     rootCanSplit: { left: true, right: true, top: true, bottom: true, ...(opts.rootCanSplit || {}) },
   }
 }
+
+// ── Client-to-layout coordinate bridge ───────────────────────────────────────
+
+test('clientPointToLocal reverses ancestor scaling before workspace hit-testing', () => {
+  // The desktop shell paints at 90%: a 1360×960 layout box is observed through
+  // getBoundingClientRect() as 1224×864, starting 288px into the visual viewport.
+  const clientRect = { left: 288, top: 0, width: 1224, height: 864 }
+  const localSize = { w: 1360, h: 960 }
+
+  assert.deepEqual(
+    clientPointToLocal({ x: 738, y: 27 }, clientRect, localSize),
+    { x: 500, y: 30 },
+  )
+  assert.deepEqual(
+    clientPointToLocal({ x: clientRect.left + clientRect.width, y: clientRect.height }, clientRect, localSize),
+    { x: localSize.w, y: localSize.h },
+  )
+})
+
+test('clientPointToLocal keeps ordinary unscaled coordinates unchanged', () => {
+  assert.deepEqual(
+    clientPointToLocal(
+      { x: 235, y: 120 },
+      { left: 200, top: 80, width: 500, height: 300 },
+      { w: 500, h: 300 },
+    ),
+    { x: 35, y: 40 },
+  )
+})
 
 // ── Threshold predicates ─────────────────────────────────────────────────────
 

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -947,9 +947,15 @@ test('workspace focus, drag label, and cancel visuals remain coherent', () => {
   const focused = css.match(/\.workspace__strip--focused \.shell__tab--active \{[\s\S]*?\n\}/)?.[0] || ''
   assert.match(focused, /box-shadow: inset 0 -2px 0 0 var\(--accent\)/)
   assert.match(focused, /border-color: color-mix\(in srgb, var\(--accent\) 45%, var\(--border-light\)\)/)
-  // V5: the drag chip clamps within the viewport so its label never clips at the
-  // right edge (measured offsetWidth + an 8px margin).
-  assert.match(dragBinding, /const maxLeft = Math\.max\(margin, window\.innerWidth - chipWidth - margin\)/)
+  // V5: pointer and tab-client measurements cross the scale boundary before the
+  // preview/chip write layout pixels. The chip then clamps against that same
+  // layout viewport so its label never clips at the right edge.
+  assert.match(dragBinding, /return clientPointToLocal\(\{ x: clientX, y: clientY \}, box\.rect, box\.localSize\)/)
+  assert.match(dragBinding, /left: toLocal\(r\.left, r\.top, box\)\.x/)
+  assert.match(dragBinding, /chipOffset\(toViewportLayout\(clientX, clientY\), isTouch\)/)
+  assert.match(dragBinding, /w: root\.offsetWidth \|\| root\.clientWidth \|\| rect\.width/)
+  assert.match(dragBinding, /const viewportWidth = document\.documentElement\.offsetWidth\s*\n\s*\|\| document\.documentElement\.clientWidth\s*\n\s*\|\| window\.innerWidth/)
+  assert.match(dragBinding, /const maxLeft = Math\.max\(margin, viewportWidth - chipWidth - margin\)/)
   assert.match(dragBinding, /Math\.max\(margin, Math\.min\(left, maxLeft\)\)/)
   // V6: a CANCELLED drag blurs the drag-origin row so its focus ring clears; a
   // committed drop keeps focus (the tab moved).

--- a/frontend/src/components/Shell/dragController.js
+++ b/frontend/src/components/Shell/dragController.js
@@ -161,6 +161,24 @@ export function crossedDrawerExit(pointX, edgeX, gap = DRAWER_EXIT_PX) {
 
 // ── Small geometry helpers ───────────────────────────────────────────────────
 
+// Pointer events and getBoundingClientRect() report painted/client pixels, while
+// projectLayout and inline left/top values use the element's unscaled CSS layout
+// pixels. Those spaces are normally identical, but a CSS zoom/scale on an
+// ancestor makes them diverge. Bridge that boundary once so hit-testing,
+// measured tab edges, and rendered preview rects all use layout-local pixels.
+export function clientPointToLocal(point, clientRect, localSize) {
+  const clientW = Number(clientRect?.width)
+  const clientH = Number(clientRect?.height)
+  const localW = Number(localSize?.w)
+  const localH = Number(localSize?.h)
+  const scaleX = clientW > 0 && localW > 0 ? localW / clientW : 1
+  const scaleY = clientH > 0 && localH > 0 ? localH / clientH : 1
+  return {
+    x: (Number(point?.x) - (Number(clientRect?.left) || 0)) * scaleX,
+    y: (Number(point?.y) - (Number(clientRect?.top) || 0)) * scaleY,
+  }
+}
+
 function contains(rect, point) {
   return point.x >= rect.x && point.x <= rect.x + rect.w
     && point.y >= rect.y && point.y <= rect.y + rect.h

--- a/frontend/src/components/Shell/useWorkspaceDrag.js
+++ b/frontend/src/components/Shell/useWorkspaceDrag.js
@@ -4,7 +4,7 @@ import { STRIP_H } from './paneModel.js'
 import {
   buildScene, hitTest, zoneTarget, releaseZone, chipOffset, STRIP_CARET_PAD,
   passedSlop, touchMoveIntent, releasedInPlace, holdMsFor, crossedDrawerExit,
-  rootEdgeAllowed,
+  rootEdgeAllowed, clientPointToLocal,
 } from './dragController.js'
 
 // The thin React binding for the workspace drag controller (design §3). It owns
@@ -113,10 +113,38 @@ export default function useWorkspaceDrag({
     let clearPendingSourceClick = null
 
     function contentBox() {
-      return contentElRef.current?.getBoundingClientRect() || { left: 0, top: 0 }
+      const host = contentElRef.current
+      if (!host) {
+        return {
+          rect: { left: 0, top: 0, width: window.innerWidth, height: window.innerHeight },
+          localSize: { w: window.innerWidth, h: window.innerHeight },
+        }
+      }
+      const rect = host.getBoundingClientRect()
+      return {
+        rect,
+        localSize: {
+          w: host.clientWidth || rect.width,
+          h: host.clientHeight || rect.height,
+        },
+      }
     }
     function toLocal(clientX, clientY, box = contentBox()) {
-      return { x: clientX - box.left, y: clientY - box.top }
+      return clientPointToLocal({ x: clientX, y: clientY }, box.rect, box.localSize)
+    }
+    function toViewportLayout(clientX, clientY) {
+      const root = document.documentElement
+      const rect = root.getBoundingClientRect()
+      return clientPointToLocal(
+        { x: clientX, y: clientY },
+        rect,
+        {
+          // CSS zoom leaves the root's client box in painted pixels, but its
+          // offset box remains in the layout pixels fixed descendants consume.
+          w: root.offsetWidth || root.clientWidth || rect.width,
+          h: root.offsetHeight || root.clientHeight || rect.height,
+        },
+      )
     }
 
     function ensureOverlays() {
@@ -167,11 +195,14 @@ export default function useWorkspaceDrag({
         chipEl.hidden = false
         chipWidth = chipEl.offsetWidth || 0
       }
-      const { left, top } = chipOffset({ x: clientX, y: clientY }, isTouch)
+      const { left, top } = chipOffset(toViewportLayout(clientX, clientY), isTouch)
       // V5 (vizreview): clamp the chip within the viewport so its label never clips
       // at the right edge (the +12 offset pushed a right-edge drag off-screen).
       const margin = 8
-      const maxLeft = Math.max(margin, window.innerWidth - chipWidth - margin)
+      const viewportWidth = document.documentElement.offsetWidth
+        || document.documentElement.clientWidth
+        || window.innerWidth
+      const maxLeft = Math.max(margin, viewportWidth - chipWidth - margin)
       chipEl.style.left = `${Math.max(margin, Math.min(left, maxLeft))}px`
       chipEl.style.top = `${top}px`
     }
@@ -220,7 +251,10 @@ export default function useWorkspaceDrag({
       if (!strip) return []
       return [...strip.querySelectorAll('.shell__tab')].map((el) => {
         const r = el.getBoundingClientRect()
-        return { left: r.left - box.left, right: r.right - box.left }
+        return {
+          left: toLocal(r.left, r.top, box).x,
+          right: toLocal(r.right, r.bottom, box).x,
+        }
       })
     }
 
@@ -328,8 +362,7 @@ export default function useWorkspaceDrag({
       // Strip auto-scroll (§3.2): near an overflowing strip's edge, scroll it
       // 6px/frame and re-measure so the caret keeps tracking under the pointer.
       function updateAutoScroll(clientX, clientY, box = contentBox()) {
-        const xL = clientX - box.left
-        const yL = clientY - box.top
+        const { x: xL, y: yL } = toLocal(clientX, clientY, box)
         let stripEl = null
         let dir = 0
         let pid = null


### PR DESCRIPTION
## Summary
- keep tab hit-testing, the drop marker, and the dragged chip in one coordinate system when the desktop shell is scaled
- convert painted pointer and element measurements back to layout pixels before computing a reorder
- cover scaled and unscaled coordinate conversion plus the shell binding contract

## Testing
- focused Shell drag-controller and workspace UI tests
- authenticated browser reproduction at the desktop shell's 90% scale, including marker placement and final reorder
- frontend production build