### PR TITLE
Fix drawer action menu placement

### DIFF
--- a/frontend/src/components/Drawer/AppsDirectory.css
+++ b/frontend/src/components/Drawer/AppsDirectory.css
@@ -214,17 +214,6 @@
   white-space: nowrap;
 }
 
-.apps-directory__card-menu-anchor.drawer__more {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  opacity: 0;
-  pointer-events: none;
-}
-
 .apps-directory__card--editing {
   align-items: center;
   min-height: 112px;

--- a/frontend/src/components/Drawer/Drawer.css
+++ b/frontend/src/components/Drawer/Drawer.css
@@ -345,9 +345,6 @@
    the composer pill's focus halo so the platform reads as a
    single design system. */
 .drawer__item:focus-visible,
-.drawer__more:focus-visible,
-.drawer__menu-item:focus-visible,
-.drawer__menu-confirm-btn:focus-visible,
 .drawer__rename-input:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
@@ -405,12 +402,8 @@
   visibility: hidden;
 }
 
-/* ── Row + three-dots menu ─────────────────────────── */
+/* ── Context-menu row ──────────────────────────────── */
 
-/* The row stacks two siblings (button + menu trigger) horizontally so
- * the trigger isn't nested inside the row button (nested <button>
- * elements are invalid HTML and Chrome silently hoists the inner one
- * out, breaking layout). The menu floats below the row absolutely. */
 .drawer__row {
   position: relative;
   display: flex;
@@ -429,168 +422,287 @@
   touch-action: pan-y pinch-zoom;
 }
 
-/* The ⋮ button matches the row height so its hit area aligns
-   with the row's vertical bounds. Width bumped 32 → 40 for a
-   compliant touch target (44 is the strict guideline but the
-   button stretches vertically so the full hit area is the row
-   height ≈ 40px). align-self: stretch makes it grow to the row's
-   full height set by the .drawer__item padding. */
-.drawer__more {
-  flex-shrink: 0;
-  align-self: stretch;
-  width: 40px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: none;
-  border: none;
-  border-radius: 8px;
-  color: var(--muted);
-  cursor: pointer;
-  opacity: 0;
-  transition: opacity 0.12s, color 0.12s, background 0.12s, transform 0.08s;
-  -webkit-tap-highlight-color: transparent;
+/* App cards and drawer rows share one action-menu placement path. Pointer
+   coordinates are converted to root layout space so shell density never shifts
+   a menu away from the click. */
+.drawer__item-action-layer {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: transparent;
 }
 
-/* Pressed — the load-bearing feedback fix. tap-highlight is transparent
-   above, so without an explicit :active the kebab reads as dead on touch
-   until the menu portal paints. Scale + tint acknowledges the tap instantly. */
-.drawer__more:active {
-  color: var(--text);
-  background: var(--surface);
-  transform: scale(0.92);
-}
-
-/* Open trigger — Radix stamps data-state="open" on the trigger; keep it lit
-   and accent-tinted (and fully opaque, overriding the touch opacity:0 reveal)
-   so the open menu visibly belongs to this row's kebab. */
-.drawer__more[data-state="open"] {
-  opacity: 1;
-  color: var(--accent);
-  background: var(--accent-dim);
-}
-
-.drawer__row:focus-within .drawer__more { opacity: 1; }
-
-/* Hover-only desktop reveal — keeps the trigger hidden until the
-   user actually hovers a row with a mouse. */
-@media (hover: hover) and (pointer: fine) {
-  .drawer__row:hover .drawer__more { opacity: 1; }
-  .drawer__more:hover {
-    color: var(--text);
-    background: var(--surface);
-  }
-}
-
-/* Always show on touch devices — :hover never fires there, and the
- * menu trigger has to be reachable without a hover state. */
-@media (hover: none) {
-  .drawer__more { opacity: 0.5; }
-}
-
-/* Menu roundness — outer 12px so the floating popover reads as a
-   softer surface than the underlying 8px rows; inner items match
-   row radius (8px) so a hovered menu item visually rhymes with
-   the row's selected/active background. */
-.drawer__menu {
-  position: absolute;
-  right: 4px;
-  top: calc(100% - 4px);
-  z-index: 2;
-  min-width: 200px;
+.drawer__item-action-menu {
+  position: fixed;
+  left: var(--item-action-x);
+  top: var(--item-action-y);
+  width: 220px;
+  max-width: calc(100vw - 24px);
+  max-height: calc(100dvh - 24px);
+  overflow: auto;
+  visibility: hidden;
   padding: 6px;
-  background: var(--bg);
   border: 1px solid var(--border-light);
   border-radius: 12px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
-}
-
-/* Flip the menu upward when the parent .drawer__row has the
-   --flip-up modifier (set by DrawerRow when there's not enough
-   space below — last row in the scroll area). */
-.drawer__row--flip-up .drawer__menu {
-  top: auto;
-  bottom: calc(100% - 4px);
-}
-
-.drawer__menu-item {
-  width: 100%;
-  display: block;
-  padding: 8px 10px;
-  background: none;
-  border: none;
-  border-radius: 8px;
+  background: var(--surface);
   color: var(--text);
+  box-shadow: 0 14px 38px rgba(0, 0, 0, 0.38);
+  scrollbar-width: none;
+}
+
+.drawer__item-action-menu[data-positioned="true"] {
+  visibility: visible;
+}
+
+.drawer__item-action-handle,
+.drawer__item-action-header {
+  display: none;
+}
+
+.drawer__item-action-items {
+  display: grid;
+  gap: 1px;
+}
+
+.drawer__item-action-item {
+  width: 100%;
+  min-height: 36px;
+  display: flex;
+  align-items: center;
+  padding: 8px 10px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
   font-size: 13px;
-  font-family: var(--font);
   text-align: left;
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
 }
 
-/* Icon-bearing menu items (Pin / Unpin) get a flex row so
-   the leading icon stays aligned with the row's text baseline. */
-.drawer__menu-item--icon {
-  display: flex;
-  align-items: center;
+.drawer__item-action-item--icon {
   gap: 8px;
 }
-.drawer__menu-item--icon svg { flex-shrink: 0; opacity: 0.85; }
 
-@media (hover: hover) and (pointer: fine) {
-  .drawer__menu-item:hover {
-    background: var(--surface);
-  }
+.drawer__item-action-item--icon svg {
+  flex: 0 0 auto;
+  opacity: 0.85;
 }
 
-.drawer__menu-item--danger {
+.drawer__item-action-item--danger {
   color: var(--danger);
 }
 
-.drawer__menu-confirm {
-  padding: 6px 10px 8px;
+.drawer__item-action-item:focus-visible,
+.drawer__item-action-close:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
 }
 
-.drawer__menu-confirm-label {
-  display: block;
-  font-size: 12px;
-  color: var(--muted);
-  margin-bottom: 6px;
+@media (hover: hover) and (pointer: fine) {
+  .drawer__item-action-item:hover {
+    background: color-mix(in srgb, var(--bg) 68%, transparent);
+  }
 }
 
-.drawer__menu-confirm-actions {
-  display: flex;
-  gap: 6px;
+.drawer__item-action-separator {
+  height: 1px;
+  margin: 5px 4px;
+  background: var(--border-light);
 }
 
-.drawer__menu-confirm-btn {
-  flex: 1;
-  padding: 6px 8px;
-  background: var(--surface);
-  border: 1px solid var(--border-light);
-  border-radius: 6px;
-  color: var(--text);
-  font-size: 12px;
-  font-family: var(--font);
-  cursor: pointer;
-  -webkit-tap-highlight-color: transparent;
-}
-
-.drawer__menu-confirm-btn--yes {
-  background: var(--danger);
-  border-color: var(--danger);
-  color: #fff;
-}
-
-.drawer__menu-note {
-  margin: 6px 4px 0;
-  padding: 4px 6px;
+.drawer__item-action-note {
+  margin: 5px 4px 0;
+  padding: 8px 6px 4px;
   border-top: 1px solid var(--border-light);
-  padding-top: 8px;
+  color: var(--muted);
   font-size: 11px;
   font-style: italic;
-  color: var(--muted);
   line-height: 1.35;
+}
+
+.drawer__item-action-confirm {
+  display: grid;
+  gap: 7px;
+  padding: 8px;
+}
+
+.drawer__item-action-confirm > strong {
+  font-size: 14px;
+  font-weight: 650;
+}
+
+.drawer__item-action-confirm > span {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.drawer__item-action-confirm > div {
+  display: flex;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+.drawer__item-action-confirm .drawer__item-action-item {
+  justify-content: center;
+  border: 1px solid var(--border-light);
+  text-align: center;
+}
+
+@media (max-width: 720px) {
+  .drawer__item-action-layer {
+    background: rgba(0, 0, 0, 0.46);
+    backdrop-filter: blur(2px);
+  }
+
+  .drawer__item-action-menu,
+  .drawer__item-action-menu[data-positioned="true"] {
+    top: auto;
+    right: 12px;
+    bottom: max(12px, env(safe-area-inset-bottom));
+    left: 12px;
+    width: auto;
+    max-width: none;
+    max-height: calc(100dvh - 24px - env(safe-area-inset-bottom));
+    visibility: visible;
+    padding: 7px;
+    border-radius: 20px;
+    background: var(--surface);
+    box-shadow: 0 22px 54px rgba(0, 0, 0, 0.46);
+    animation: drawer-item-sheet-in 170ms cubic-bezier(0.2, 0.75, 0.2, 1);
+  }
+
+  .drawer__item-action-handle {
+    width: 34px;
+    height: 4px;
+    display: block;
+    margin: 2px auto 7px;
+    border-radius: 999px;
+    background: var(--border);
+  }
+
+  .drawer__item-action-header {
+    display: flex;
+    align-items: center;
+    gap: 11px;
+    padding: 4px 5px 10px;
+  }
+
+  .drawer__item-action-icon {
+    position: relative;
+    width: 42px;
+    height: 42px;
+    flex: 0 0 42px;
+    display: grid;
+    place-items: center;
+    overflow: hidden;
+    border-radius: 11px;
+    background: var(--app-color, var(--accent));
+    color: var(--accent-fg, #fff);
+    font-size: 12px;
+    font-weight: 750;
+  }
+
+  .drawer__item-action-icon img {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+  }
+
+  .drawer__item-action-icon.is-image {
+    overflow: visible;
+    border-radius: 0;
+    background: transparent;
+  }
+
+  .drawer__item-action-icon.is-image > span {
+    visibility: hidden;
+  }
+
+  .drawer__item-action-icon--chat {
+    background: var(--accent-dim);
+    color: var(--accent);
+  }
+
+  .drawer__item-action-heading {
+    min-width: 0;
+    flex: 1;
+    display: grid;
+    gap: 2px;
+  }
+
+  .drawer__item-action-heading > span {
+    color: var(--muted);
+    font-size: 11px;
+    font-weight: 650;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .drawer__item-action-heading > strong {
+    overflow: hidden;
+    font-size: 16px;
+    font-weight: 650;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .drawer__item-action-close {
+    width: 40px;
+    height: 40px;
+    flex: 0 0 40px;
+    display: grid;
+    place-items: center;
+    padding: 0;
+    border: 0;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--bg) 72%, transparent);
+    color: var(--muted);
+  }
+
+  .drawer__item-action-items {
+    gap: 2px;
+  }
+
+  .drawer__item-action-item {
+    min-height: 48px;
+    padding: 11px 13px;
+    border-radius: 12px;
+    font-size: 15px;
+  }
+
+  .drawer__item-action-note {
+    margin: 5px 7px 2px;
+    padding: 9px 6px 5px;
+    font-size: 11px;
+  }
+
+  .drawer__item-action-confirm {
+    gap: 9px;
+    padding: 10px 8px 6px;
+  }
+
+  .drawer__item-action-confirm > strong {
+    font-size: 16px;
+  }
+
+  .drawer__item-action-confirm > span {
+    font-size: 13px;
+  }
+
+  .drawer__item-action-confirm > div {
+    gap: 8px;
+    margin-top: 6px;
+  }
+}
+
+@keyframes drawer-item-sheet-in {
+  from { opacity: 0; transform: translateY(18px); }
+  to { opacity: 1; transform: translateY(0); }
 }
 
 /* ── Inline rename ─────────────────────────────────── */
@@ -742,7 +854,7 @@
 @media (prefers-reduced-motion: reduce) {
   .drawer,
   .drawer-overlay { transition: none; }
-  .drawer__more:active { transform: none; }
+  .drawer__item-action-menu { animation: none; }
 }
 
 /* ── Settings warning dot ──────────────────────────── */

--- a/frontend/src/components/Drawer/Drawer.css
+++ b/frontend/src/components/Drawer/Drawer.css
@@ -422,6 +422,47 @@
   touch-action: pan-y pinch-zoom;
 }
 
+.drawer__more {
+  flex: 0 0 40px;
+  align-self: stretch;
+  display: grid;
+  place-items: center;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.12s, color 0.12s, background 0.12s, transform 0.08s;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.drawer__more:active {
+  color: var(--text);
+  background: var(--surface);
+  transform: scale(0.92);
+}
+
+.drawer__more[aria-expanded="true"] {
+  opacity: 1;
+  color: var(--accent);
+  background: var(--accent-dim);
+}
+
+.drawer__row:focus-within .drawer__more { opacity: 1; }
+
+@media (hover: hover) and (pointer: fine) {
+  .drawer__row:hover .drawer__more { opacity: 1; }
+  .drawer__more:hover {
+    color: var(--text);
+    background: var(--surface);
+  }
+}
+
+@media (hover: none) {
+  .drawer__more { opacity: 0.5; }
+}
+
 /* App cards and drawer rows share one action-menu placement path. Pointer
    coordinates are converted to root layout space so shell density never shifts
    a menu away from the click. */

--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -1,8 +1,7 @@
 import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useQueryClient } from '@tanstack/react-query'
-import { Chats, DotsVerticalMoreMenu, Pin, PinFilled } from '@openai/apps-sdk-ui/components/Icon'
-import { Menu } from '@openai/apps-sdk-ui/components/Menu'
+import { Chats, PinFilled } from '@openai/apps-sdk-ui/components/Icon'
 import { EmptyMessage } from '@openai/apps-sdk-ui/components/EmptyMessage'
 import { api } from '../../api/client.js'
 import { appQueries, chatQueries } from '../../hooks/queries.js'
@@ -22,8 +21,10 @@ import {
   clearDrawerGestureStyles,
 } from '../../lib/drawerLifecycle.js'
 import { WORKSPACE_SPLITS_ENABLED } from '../Shell/paneModel.js'
+import { DRAWER_HOLD_MS, PRE_HOLD_MOVE_PX } from '../Shell/dragController.js'
 import InstallSheet from './InstallSheet.jsx'
 import AppsDirectory from './AppsDirectory.jsx'
+import DrawerItemActionMenu from './DrawerItemActionMenu.jsx'
 import {
   appInitials,
   buildDrawerSections,
@@ -163,9 +164,8 @@ export default function Drawer({
 
   // One row at a time can be in rename or open-menu mode. Tracking the
   // active id (rather than per-row state) lets a click on another row's
-  // ⋮ button close any open menu without needing a global outside-click
-  // handler per row.
-  const [openMenu, setOpenMenu] = useState(null) // { kind, id } | null
+  // context action replace any open menu without a global listener per row.
+  const [openMenu, setOpenMenu] = useState(null) // { kind, id, surface, placement } | null
   // Belt-and-braces orphan cleanup: if the row whose menu was open
   // disappears from the list (delete, chat soft-delete, agent-side
   // removal), openMenu would still reference a dead id and the next
@@ -241,8 +241,13 @@ export default function Drawer({
       if (kind === 'chat') current.onChat(id)
       else current.onApp(id)
     },
-    toggleMenu(kind, id, next, surface = 'drawer') {
-      rowActionInputsRef.current.setOpenMenu(next ? { kind, id, surface } : null)
+    toggleMenu(kind, id, next, surface = 'drawer', placement = null) {
+      rowActionInputsRef.current.setOpenMenu(next ? {
+        kind,
+        id,
+        surface,
+        placement,
+      } : null)
     },
     startRename(kind, id, surface = 'drawer') {
       rowActionInputsRef.current.setRenaming({ kind, id, surface })
@@ -458,13 +463,17 @@ export default function Drawer({
     if (!open || persistent || interactionLocked) return
     function onKeyDown(e) {
       if (e.key === 'Escape') {
+        // A row-owned menu is the topmost surface. Its own Escape handler
+        // closes it and restores focus to the row; only a second Escape should
+        // dismiss the mobile drawer underneath.
+        if (openMenu) return
         e.stopPropagation()
         onClose?.()
       }
     }
     document.addEventListener('keydown', onKeyDown, { capture: true })
     return () => document.removeEventListener('keydown', onKeyDown, { capture: true })
-  }, [open, persistent, interactionLocked, onClose])
+  }, [open, persistent, interactionLocked, onClose, openMenu])
 
   // Swipe-left-to-close. Mirror of the mobius-design-iter pattern:
   // touchstart captures origin, touchmove drags the panel 1:1 with
@@ -906,6 +915,12 @@ export default function Drawer({
                         && openMenu.surface === 'drawer'
                         && openMenu.kind === kind
                         && openMenu.id === item.id)}
+                      menuPlacement={openMenu
+                        && openMenu.surface === 'drawer'
+                        && openMenu.kind === kind
+                        && openMenu.id === item.id
+                        ? openMenu.placement
+                        : null}
                       renaming={!!(renaming
                         && renaming.surface === 'drawer'
                         && renaming.kind === kind
@@ -944,6 +959,12 @@ export default function Drawer({
                         && openMenu.surface === 'drawer'
                         && openMenu.kind === 'chat'
                         && openMenu.id === chat.id)}
+                      menuPlacement={openMenu
+                        && openMenu.surface === 'drawer'
+                        && openMenu.kind === 'chat'
+                        && openMenu.id === chat.id
+                        ? openMenu.placement
+                        : null}
                       renaming={!!(renaming
                         && renaming.surface === 'drawer'
                         && renaming.kind === 'chat'
@@ -1022,6 +1043,12 @@ export default function Drawer({
                 && openMenu.surface === 'directory'
                 && openMenu.kind === 'app'
                 && openMenu.id === app.id)}
+              menuPlacement={openMenu
+                && openMenu.surface === 'directory'
+                && openMenu.kind === 'app'
+                && openMenu.id === app.id
+                ? openMenu.placement
+                : null}
               renaming={!!(renaming
                 && renaming.surface === 'directory'
                 && renaming.kind === 'app'
@@ -1067,6 +1094,7 @@ const DrawerRow = memo(function DrawerRow({
   building,
   attention,
   menuOpen,
+  menuPlacement,
   renaming,
   actions,
 }) {
@@ -1078,6 +1106,7 @@ const DrawerRow = memo(function DrawerRow({
   const inputRef = useRef(null)
   const holdTimerRef = useRef(null)
   const holdOriginRef = useRef(null)
+  const itemButtonRef = useRef(null)
   const suppressCardClickRef = useRef(false)
   const suppressRowClickRef = useRef(false)
   const reorderCleanupRef = useRef(null)
@@ -1151,6 +1180,63 @@ const DrawerRow = memo(function DrawerRow({
     else if (e.key === 'Escape') { e.preventDefault(); actions.cancelRename() }
   }
 
+  // Every app card and drawer row enters the same placed action-menu path.
+  // Pointer gestures use their real release point; keyboard invocations fall
+  // back to the bottom-center of the focused item instead of the event's 0,0.
+  function itemMenuPlacement(point) {
+    const rect = itemButtonRef.current?.getBoundingClientRect()
+    const hasPoint = Number.isFinite(Number(point?.x))
+      && Number.isFinite(Number(point?.y))
+      && (Number(point.x) !== 0 || Number(point.y) !== 0)
+    return {
+      clientX: hasPoint ? Number(point.x) : (rect?.left || 0) + (rect?.width || 0) / 2,
+      clientY: hasPoint ? Number(point.y) : rect?.bottom || 0,
+    }
+  }
+
+  function openItemMenu(event) {
+    event.preventDefault()
+    event.stopPropagation()
+    // Chromium raises mouse contextmenu on secondary-button DOWN. The matching
+    // UP below owns that gesture and opens only after release, so focus cannot
+    // snap back to the source or select a collision-flipped menu item.
+    if (event.type === 'contextmenu' && secondaryReleaseCleanupRef.current) return
+    actions.toggleMenu(kind, id, true, surface, itemMenuPlacement({
+      x: event.clientX,
+      y: event.clientY,
+    }))
+  }
+
+  function beginSecondaryMenuPress(event) {
+    if (event.pointerType !== 'mouse' || event.button !== 2) return false
+    event.preventDefault()
+    secondaryReleaseCleanupRef.current?.()
+    const pointerId = event.pointerId
+    const placement = itemMenuPlacement({ x: event.clientX, y: event.clientY })
+    let timer = null
+    const cleanup = () => {
+      window.removeEventListener('pointerup', onSecondaryPointerUp, true)
+      window.removeEventListener('pointercancel', cleanup, true)
+      window.removeEventListener('blur', cleanup, true)
+      if (timer !== null) clearTimeout(timer)
+      if (secondaryReleaseCleanupRef.current === cleanup) {
+        secondaryReleaseCleanupRef.current = null
+      }
+    }
+    const onSecondaryPointerUp = upEvent => {
+      if (upEvent.pointerId !== pointerId || upEvent.button !== 2) return
+      upEvent.preventDefault()
+      cleanup()
+      actions.toggleMenu(kind, id, true, surface, placement)
+    }
+    window.addEventListener('pointerup', onSecondaryPointerUp, true)
+    window.addEventListener('pointercancel', cleanup, true)
+    window.addEventListener('blur', cleanup, true)
+    timer = setTimeout(cleanup, 1500)
+    secondaryReleaseCleanupRef.current = cleanup
+    return true
+  }
+
   if (renaming) {
     if (variant === 'card') {
       return (
@@ -1180,48 +1266,7 @@ const DrawerRow = memo(function DrawerRow({
     )
   }
 
-  function openRowMenu(event) {
-    event.preventDefault()
-    event.stopPropagation()
-    // Chromium raises mouse contextmenu on secondary-button DOWN. The matching
-    // UP is owned by beginSecondaryMenuPress below, which opens only after that
-    // release; do not mount the collision-flipped menu underneath a held pointer.
-    if (event.type === 'contextmenu' && secondaryReleaseCleanupRef.current) return
-    actions.toggleMenu(kind, id, true, surface)
-  }
-
-  function beginSecondaryMenuPress(event) {
-    if (event.pointerType !== 'mouse' || event.button !== 2) return
-    event.preventDefault()
-    secondaryReleaseCleanupRef.current?.()
-    const pointerId = event.pointerId
-    let timer = null
-    const cleanup = () => {
-      window.removeEventListener('pointerup', onSecondaryPointerUp, true)
-      window.removeEventListener('pointercancel', cleanup, true)
-      window.removeEventListener('blur', cleanup, true)
-      if (timer !== null) clearTimeout(timer)
-      if (secondaryReleaseCleanupRef.current === cleanup) {
-        secondaryReleaseCleanupRef.current = null
-      }
-    }
-    const onSecondaryPointerUp = upEvent => {
-      if (upEvent.pointerId !== pointerId || upEvent.button !== 2) return
-      upEvent.preventDefault()
-      cleanup()
-      actions.toggleMenu(kind, id, true, surface)
-    }
-    window.addEventListener('pointerup', onSecondaryPointerUp, true)
-    window.addEventListener('pointercancel', cleanup, true)
-    window.addEventListener('blur', cleanup, true)
-    timer = setTimeout(cleanup, 1500)
-    secondaryReleaseCleanupRef.current = cleanup
-  }
-
   if (variant === 'card') {
-    function openCardMenu(event) {
-      openRowMenu(event)
-    }
     function beginCardHold(event) {
       if (event.pointerType === 'mouse' || event.button !== 0) return
       if (holdTimerRef.current) clearTimeout(holdTimerRef.current)
@@ -1229,8 +1274,14 @@ const DrawerRow = memo(function DrawerRow({
       holdTimerRef.current = setTimeout(() => {
         holdTimerRef.current = null
         suppressCardClickRef.current = true
-        actions.toggleMenu(kind, id, true, surface)
-      }, 520)
+        actions.toggleMenu(
+          kind,
+          id,
+          true,
+          surface,
+          itemMenuPlacement(holdOriginRef.current),
+        )
+      }, DRAWER_HOLD_MS)
     }
     function cancelCardHold() {
       if (holdTimerRef.current) clearTimeout(holdTimerRef.current)
@@ -1240,6 +1291,7 @@ const DrawerRow = memo(function DrawerRow({
     return (
       <div className="apps-directory__card">
         <button
+          ref={itemButtonRef}
           type="button"
           className="apps-directory__card-main"
           aria-label={`Open ${label}`}
@@ -1250,22 +1302,22 @@ const DrawerRow = memo(function DrawerRow({
             }
             actions.select(kind, id)
           }}
-          onContextMenu={openCardMenu}
+          onContextMenu={openItemMenu}
           onPointerDown={event => {
-            beginSecondaryMenuPress(event)
+            if (beginSecondaryMenuPress(event)) return
             beginCardHold(event)
           }}
           onPointerUp={cancelCardHold}
           onPointerCancel={cancelCardHold}
           onPointerMove={event => {
             const origin = holdOriginRef.current
-            if (origin && Math.hypot(event.clientX - origin.x, event.clientY - origin.y) > 8) {
+            if (origin && Math.hypot(event.clientX - origin.x, event.clientY - origin.y) > PRE_HOLD_MOVE_PX) {
               cancelCardHold()
             }
           }}
           onKeyDown={event => {
             if (event.key === 'ContextMenu' || (event.shiftKey && event.key === 'F10')) {
-              openCardMenu(event)
+              openItemMenu(event)
             }
           }}
         >
@@ -1286,8 +1338,8 @@ const DrawerRow = memo(function DrawerRow({
           pinned={pinned}
           menuOpen={menuOpen}
           actions={actions}
-          triggerClassName="drawer__more apps-directory__card-menu-anchor"
-          triggerHidden
+          menuPlacement={menuPlacement}
+          restoreFocusRef={itemButtonRef}
         />
       </div>
     )
@@ -1428,9 +1480,15 @@ const DrawerRow = memo(function DrawerRow({
     window.addEventListener('pointercancel', onCancel, true)
   }
 
+  function onRowPointerDown(event) {
+    if (beginSecondaryMenuPress(event)) return
+    beginPinnedReorder(event)
+  }
+
   return (
     <div className="drawer__row" ref={wrapRef}>
       <button
+        ref={itemButtonRef}
         type="button"
         className={`drawer__item ${active ? 'drawer__item--active' : ''}`}
         aria-current={active ? 'page' : undefined}
@@ -1440,10 +1498,7 @@ const DrawerRow = memo(function DrawerRow({
         // in the focused pane (the controller never arms without slop/hold).
         data-drag-key={WORKSPACE_SPLITS_ENABLED ? `${kind}:${id}` : undefined}
         data-pinned-key={pinned ? `${kind}:${id}` : undefined}
-        onPointerDown={event => {
-          beginSecondaryMenuPress(event)
-          beginPinnedReorder(event)
-        }}
+        onPointerDown={onRowPointerDown}
         onClick={() => {
           if (suppressRowClickRef.current) {
             suppressRowClickRef.current = false
@@ -1453,12 +1508,12 @@ const DrawerRow = memo(function DrawerRow({
         }}
         onDoubleClick={event => {
           event.preventDefault()
-          actions.startRename(kind, id)
+          actions.startRename(kind, id, surface)
         }}
-        onContextMenu={openRowMenu}
+        onContextMenu={openItemMenu}
         onKeyDown={event => {
           if (event.key === 'ContextMenu' || (event.shiftKey && event.key === 'F10')) {
-            openRowMenu(event)
+            openItemMenu(event)
           }
         }}
       >
@@ -1498,7 +1553,8 @@ const DrawerRow = memo(function DrawerRow({
         pinned={pinned}
         menuOpen={menuOpen}
         actions={actions}
-        triggerClassName="drawer__more drawer__menu-anchor"
+        menuPlacement={menuPlacement}
+        restoreFocusRef={itemButtonRef}
       />
     </div>
   )
@@ -1541,193 +1597,40 @@ function DrawerItemMenu({
   surface,
   pinned,
   menuOpen,
+  menuPlacement,
+  restoreFocusRef,
   actions,
-  triggerClassName = 'drawer__more',
-  triggerHidden = false,
 }) {
   const id = item.id
   const label = kind === 'chat' ? item.title : item.name
-  const slug = item.slug
-  const [confirmingDelete, setConfirmingDelete] = useState(false)
-  const [confirmingDeleteData, setConfirmingDeleteData] = useState(false)
-
-  useEffect(() => {
-    if (!menuOpen) {
-      setConfirmingDelete(false)
-      setConfirmingDeleteData(false)
-    }
-  }, [menuOpen])
 
   return (
-    <Menu
-        forceOpen={menuOpen}
-        onOpen={() => actions.toggleMenu(kind, id, true, surface)}
-        onClose={() => actions.toggleMenu(kind, id, false, surface)}
-      >
-        <Menu.Trigger>
-          {/* No Tooltip wrap here. Both Menu.Trigger and Tooltip
-              are Radix asChild wrappers that merge their props
-              onto the first child element. Nesting them breaks
-              the click-prop chain — Menu's onClick lands on the
-              Tooltip wrapper instead of the button, so tapping
-              ⋮ did nothing. The aria-label below covers screen
-              readers; visible tooltip discovery is a nice-to-have
-              we can revisit later with a different composition. */}
-          <button
-            type="button"
-            className={triggerClassName}
-            aria-label={`More actions for ${label}`}
-            aria-hidden={triggerHidden ? 'true' : undefined}
-            tabIndex={triggerHidden ? -1 : undefined}
-          >
-            <DotsVerticalMoreMenu width={16} height={16} aria-hidden="true" />
-          </button>
-        </Menu.Trigger>
-        <Menu.Content side="bottom" align="end" sideOffset={4} minWidth={200}>
-          {!confirmingDelete && !confirmingDeleteData ? (
-            <>
-              <Menu.Item
-                onSelect={() => actions.pin(kind, id, !pinned)}
-                className="drawer__menu-item--icon"
-              >
-                {pinned
-                  ? <Pin width={14} height={14} aria-hidden="true" />
-                  : <PinFilled width={14} height={14} aria-hidden="true" />}
-                <span>{pinned ? 'Unpin' : 'Pin'}</span>
-              </Menu.Item>
-              <Menu.Item onSelect={() => actions.startRename(kind, id, surface)}>Rename</Menu.Item>
-              {kind === 'app' && slug && (
-                // Opens the in-PWA InstallSheet to set the home-screen
-                // name + icon first; the sheet saves, then navigates
-                // same-tab to `/apps/<slug>/?install=1`. Same-tab keeps
-                // the user in the installed Möbius PWA context — no
-                // jarring browser-tab pop-out — and lets engagement
-                // from the parent shell count toward the per-origin
-                // Site Engagement score that gates beforeinstallprompt.
-                <Menu.Item onSelect={() => actions.install(item)}>
-                  Install to home screen
-                </Menu.Item>
-              )}
-              {kind === 'app' && isDrawerAppShareEligible(item) && (
-                <Menu.Item onSelect={() => actions.share(item)}>
-                  Share app
-                </Menu.Item>
-              )}
-              {kind === 'chat' ? (
-                // Chats soft-delete with 7-day recovery, so no
-                // confirm step — one tap deletes, the note below
-                // tells the user how to undo via the agent.
-                // Close the parent's menu state BEFORE onDelete fires:
-                // the row unmounts as soon as the refetch lands, but
-                // the parent's openMenu still references this row's
-                // id, leaving a Radix trigger looking "pressed" on
-                // whichever row slides up into the slot.
-                <Menu.Item
-                  onSelect={() => {
-                    actions.toggleMenu(kind, id, false, surface)
-                    actions.remove(kind, id)
-                  }}
-                  className="drawer__menu-item--danger"
-                >
-                  Delete
-                </Menu.Item>
-              ) : (
-                // Deleting an app is a reversible soft-delete (the agent
-                // can recover it for 7 days, like a chat), but we still
-                // want a confirm step. `preventDefault` on onSelect stops
-                // Radix from auto-closing the menu when the item is
-                // selected — we want the menu to stay open and swap
-                // to the confirm-chip below.
-                <Menu.Item
-                  onSelect={(e) => { e.preventDefault(); setConfirmingDelete(true) }}
-                  className="drawer__menu-item--danger"
-                >
-                  Delete
-                </Menu.Item>
-              )}
-              {kind === 'app' && (
-                // Wipes the app's stored data but keeps it installed — a
-                // separate action from Delete (which removes the whole app).
-                // Same preventDefault-to-hold-open + confirm-chip pattern as
-                // the app Delete above; the wording stays exactly "Delete
-                // data" (no "keeps your data" phrasing).
-                <Menu.Item
-                  onSelect={(e) => { e.preventDefault(); setConfirmingDeleteData(true) }}
-                  className="drawer__menu-item--danger"
-                >
-                  Delete data
-                </Menu.Item>
-              )}
-            </>
-          ) : confirmingDeleteData ? (
-            <div className="drawer__menu-confirm">
-              <span className="drawer__menu-confirm-label">Delete data?</span>
-              <div className="drawer__menu-confirm-actions">
-                <button
-                  type="button"
-                  className="drawer__menu-confirm-btn drawer__menu-confirm-btn--cancel"
-                  onClick={() => setConfirmingDeleteData(false)}
-                >
-                  Cancel
-                </button>
-                <button
-                  type="button"
-                  className="drawer__menu-confirm-btn drawer__menu-confirm-btn--yes"
-                  onClick={() => {
-                    // Close the parent's menu state before the wipe fires,
-                    // matching the Delete confirm below — keeps Radix's
-                    // open-trigger bookkeeping in sync. The app STAYS in the
-                    // list here (only its data is wiped), so no row unmounts.
-                    setConfirmingDeleteData(false)
-                    actions.toggleMenu(kind, id, false, surface)
-                    actions.removeData(id)
-                  }}
-                >
-                  Delete data
-                </button>
-              </div>
-            </div>
-          ) : (
-            <div className="drawer__menu-confirm">
-              <span className="drawer__menu-confirm-label">Confirm delete?</span>
-              <div className="drawer__menu-confirm-actions">
-                <button
-                  type="button"
-                  className="drawer__menu-confirm-btn drawer__menu-confirm-btn--cancel"
-                  onClick={() => setConfirmingDelete(false)}
-                >
-                  Cancel
-                </button>
-                <button
-                  type="button"
-                  className="drawer__menu-confirm-btn drawer__menu-confirm-btn--yes"
-                  onClick={() => {
-                    // Order matters. Closing the parent's openMenu
-                    // state BEFORE the delete fires keeps Radix's
-                    // open-trigger bookkeeping in sync with the row
-                    // that's about to unmount. Without this, the
-                    // three-dots button on whatever row slides up
-                    // into the deleted slot looks stuck pressed
-                    // because openMenu still references the dead id.
-                    setConfirmingDelete(false)
-                    actions.toggleMenu(kind, id, false, surface)
-                    actions.remove(kind, id)
-                  }}
-                >
-                  Delete
-                </button>
-              </div>
-            </div>
-          )}
-          {/* The 7-day recovery note applies to Delete (soft-delete), not
-              to the immediate, non-recoverable "Delete data" wipe — hide it
-              while that confirm chip is showing. */}
-          {!confirmingDeleteData && (
-            <p className="drawer__menu-note">
-              The agent can recover deleted {kind === 'chat' ? 'chats' : 'apps'} for 7 days.
-            </p>
-          )}
-        </Menu.Content>
-      </Menu>
+    <DrawerItemActionMenu
+      open={menuOpen}
+      itemKind={kind}
+      itemName={label}
+      icon={kind === 'app'
+        ? (
+          <AppIcon
+            item={item}
+            label={label}
+            className="drawer__item-action-icon"
+            size={64}
+          />
+        )
+        : null}
+      pinned={pinned}
+      canInstall={kind === 'app' && Boolean(item.slug)}
+      canShare={kind === 'app' && isDrawerAppShareEligible(item)}
+      placement={menuPlacement}
+      restoreFocusRef={restoreFocusRef}
+      onClose={() => actions.toggleMenu(kind, id, false, surface)}
+      onPin={() => actions.pin(kind, id, !pinned)}
+      onRename={() => actions.startRename(kind, id, surface)}
+      onInstall={() => actions.install(item)}
+      onShare={() => actions.share(item)}
+      onDelete={() => actions.remove(kind, id)}
+      onDeleteData={() => actions.removeData(id)}
+    />
   )
 }

--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -1,7 +1,7 @@
 import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useQueryClient } from '@tanstack/react-query'
-import { Chats, PinFilled } from '@openai/apps-sdk-ui/components/Icon'
+import { Chats, DotsVerticalMoreMenu, PinFilled } from '@openai/apps-sdk-ui/components/Icon'
 import { EmptyMessage } from '@openai/apps-sdk-ui/components/EmptyMessage'
 import { api } from '../../api/client.js'
 import { appQueries, chatQueries } from '../../hooks/queries.js'
@@ -1545,6 +1545,16 @@ const DrawerRow = memo(function DrawerRow({
           />
         ) : null}
         <span className="drawer__item-text">{label}</span>
+      </button>
+      <button
+        type="button"
+        className="drawer__more"
+        aria-label={`More actions for ${label}`}
+        aria-haspopup="menu"
+        aria-expanded={menuOpen}
+        onClick={openItemMenu}
+      >
+        <DotsVerticalMoreMenu width={16} height={16} aria-hidden="true" />
       </button>
       <DrawerItemMenu
         kind={kind}

--- a/frontend/src/components/Drawer/DrawerItemActionMenu.jsx
+++ b/frontend/src/components/Drawer/DrawerItemActionMenu.jsx
@@ -1,0 +1,310 @@
+/* DrawerItemActionMenu gives app launcher cards and drawer rows one
+   pointer-accurate desktop menu and one named, thumb-friendly compact-screen
+   action sheet. */
+
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { Chat, Pin, PinFilled, X } from '@openai/apps-sdk-ui/components/Icon'
+import { placeContextMenu } from '../../lib/contextMenuGeometry.js'
+
+function focusableMenuItems(menu) {
+  return [...(menu?.querySelectorAll('[role="menuitem"]:not([disabled])') || [])]
+}
+
+export default function DrawerItemActionMenu({
+  open,
+  itemKind,
+  itemName,
+  icon,
+  pinned,
+  canInstall,
+  canShare,
+  placement,
+  restoreFocusRef,
+  onClose,
+  onPin,
+  onRename,
+  onInstall,
+  onShare,
+  onDelete,
+  onDeleteData,
+}) {
+  const menuRef = useRef(null)
+  const wasOpenRef = useRef(false)
+  const restoreOnCloseRef = useRef(true)
+  const [confirmation, setConfirmation] = useState(null)
+  const [position, setPosition] = useState(null)
+
+  function close({ restoreFocus = true } = {}) {
+    restoreOnCloseRef.current = restoreFocus
+    onClose()
+  }
+
+  useEffect(() => {
+    if (open) {
+      wasOpenRef.current = true
+      return
+    }
+    setConfirmation(null)
+    setPosition(null)
+    if (!wasOpenRef.current) return
+    wasOpenRef.current = false
+    if (!restoreOnCloseRef.current) return
+    const frame = requestAnimationFrame(() => restoreFocusRef?.current?.focus())
+    return () => cancelAnimationFrame(frame)
+  }, [open, restoreFocusRef])
+
+  useEffect(() => {
+    if (!open) return
+    function closeFromKeyboard(event) {
+      if (event.key !== 'Escape' && event.key !== 'Tab') return
+      event.preventDefault()
+      event.stopPropagation()
+      event.stopImmediatePropagation()
+      restoreOnCloseRef.current = true
+      onClose()
+    }
+    document.addEventListener('keydown', closeFromKeyboard, true)
+    return () => document.removeEventListener('keydown', closeFromKeyboard, true)
+  }, [open, onClose])
+
+  useLayoutEffect(() => {
+    if (!open || !menuRef.current) return
+    const root = document.documentElement
+    const rootRect = root.getBoundingClientRect()
+    const menuRect = menuRef.current
+    const placementX = Number(placement?.clientX)
+    const placementY = Number(placement?.clientY)
+    setPosition(placeContextMenu({
+      clientPoint: {
+        x: Number.isFinite(placementX)
+          ? placementX
+          : rootRect.left + rootRect.width / 2,
+        y: Number.isFinite(placementY)
+          ? placementY
+          : rootRect.top + rootRect.height / 2,
+      },
+      clientViewport: rootRect,
+      layoutViewport: {
+        width: root.offsetWidth || root.clientWidth || rootRect.width,
+        height: root.offsetHeight || root.clientHeight || rootRect.height,
+      },
+      menuSize: {
+        width: menuRect.offsetWidth,
+        height: menuRect.offsetHeight,
+      },
+    }))
+  }, [open, placement, confirmation])
+
+  useLayoutEffect(() => {
+    if (!open || !position || !menuRef.current) return
+    const frame = requestAnimationFrame(() => {
+      focusableMenuItems(menuRef.current)[0]?.focus()
+    })
+    return () => cancelAnimationFrame(frame)
+  }, [open, position, confirmation])
+
+  if (!open) return null
+
+  function run(action, { restoreFocus = true } = {}) {
+    close({ restoreFocus })
+    action()
+  }
+
+  function handleDeleteAction() {
+    if (itemKind === 'chat') {
+      run(onDelete, { restoreFocus: false })
+      return
+    }
+    setConfirmation('delete')
+  }
+
+  function onMenuKeyDown(event) {
+    if (!['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(event.key)) return
+    const items = focusableMenuItems(menuRef.current)
+    if (!items.length) return
+    event.preventDefault()
+    const current = items.indexOf(document.activeElement)
+    const next = event.key === 'Home'
+      ? 0
+      : event.key === 'End'
+        ? items.length - 1
+        : event.key === 'ArrowDown'
+          ? (current + 1 + items.length) % items.length
+          : (current - 1 + items.length) % items.length
+    items[next].focus()
+  }
+
+  const kindLabel = itemKind === 'chat' ? 'Chat' : 'App'
+  const recoveryLabel = itemKind === 'chat' ? 'chats' : 'apps'
+  const identityIcon = itemKind === 'chat'
+    ? (
+      <span
+        className="drawer__item-action-icon drawer__item-action-icon--chat"
+        aria-hidden="true"
+      >
+        <Chat width={20} height={20} />
+      </span>
+    )
+    : icon
+
+  const layer = (
+    <div
+      className="drawer__item-action-layer"
+      onPointerDown={event => {
+        if (event.target === event.currentTarget) close()
+      }}
+      onContextMenu={event => event.preventDefault()}
+      onWheel={event => {
+        if (event.target === event.currentTarget) close()
+      }}
+    >
+      <div
+        ref={menuRef}
+        className="drawer__item-action-menu"
+        role="menu"
+        aria-label={`${itemName} actions`}
+        data-positioned={position ? 'true' : 'false'}
+        style={{
+          '--item-action-x': `${position?.x || 0}px`,
+          '--item-action-y': `${position?.y || 0}px`,
+        }}
+        onPointerDown={event => event.stopPropagation()}
+        onKeyDown={onMenuKeyDown}
+      >
+        <div className="drawer__item-action-handle" aria-hidden="true" />
+        <header className="drawer__item-action-header">
+          {identityIcon}
+          <div className="drawer__item-action-heading">
+            <span>{kindLabel} actions</span>
+            <strong>{itemName}</strong>
+          </div>
+          <button
+            type="button"
+            className="drawer__item-action-close"
+            aria-label={`Close ${kindLabel.toLowerCase()} actions`}
+            onClick={() => close()}
+          >
+            <X width={18} height={18} aria-hidden="true" />
+          </button>
+        </header>
+
+        {confirmation === 'delete-data' ? (
+          <div className="drawer__item-action-confirm">
+            <strong>Delete this app’s data?</strong>
+            <span>The app stays installed, but its saved information is removed.</span>
+            <div>
+              <button
+                type="button"
+                role="menuitem"
+                className="drawer__item-action-item"
+                onClick={() => setConfirmation(null)}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                role="menuitem"
+                className="drawer__item-action-item drawer__item-action-item--danger"
+                onClick={() => run(onDeleteData)}
+              >
+                Delete data
+              </button>
+            </div>
+          </div>
+        ) : confirmation === 'delete' ? (
+          <div className="drawer__item-action-confirm">
+            <strong>Delete {itemName}?</strong>
+            <span>The agent can recover deleted {recoveryLabel} for 7 days.</span>
+            <div>
+              <button
+                type="button"
+                role="menuitem"
+                className="drawer__item-action-item"
+                onClick={() => setConfirmation(null)}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                role="menuitem"
+                className="drawer__item-action-item drawer__item-action-item--danger"
+                onClick={() => run(onDelete, { restoreFocus: false })}
+              >
+                Delete {itemKind}
+              </button>
+            </div>
+          </div>
+        ) : (
+          <>
+            <div className="drawer__item-action-items">
+              <button
+                type="button"
+                role="menuitem"
+                className="drawer__item-action-item drawer__item-action-item--icon"
+                onClick={() => run(onPin)}
+              >
+                {pinned
+                  ? <Pin width={15} height={15} aria-hidden="true" />
+                  : <PinFilled width={15} height={15} aria-hidden="true" />}
+                <span>{pinned ? 'Unpin' : 'Pin'}</span>
+              </button>
+              <button
+                type="button"
+                role="menuitem"
+                className="drawer__item-action-item"
+                onClick={() => run(onRename, { restoreFocus: false })}
+              >
+                Rename
+              </button>
+              {canInstall && (
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="drawer__item-action-item"
+                  onClick={() => run(onInstall, { restoreFocus: false })}
+                >
+                  Install to home screen
+                </button>
+              )}
+              {canShare && (
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="drawer__item-action-item"
+                  onClick={() => run(onShare, { restoreFocus: false })}
+                >
+                  Share app
+                </button>
+              )}
+              <div className="drawer__item-action-separator" role="separator" />
+              <button
+                type="button"
+                role="menuitem"
+                className="drawer__item-action-item drawer__item-action-item--danger"
+                onClick={handleDeleteAction}
+              >
+                Delete
+              </button>
+              {itemKind === 'app' && (
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="drawer__item-action-item drawer__item-action-item--danger"
+                  onClick={() => setConfirmation('delete-data')}
+                >
+                  Delete data
+                </button>
+              )}
+            </div>
+            <p className="drawer__item-action-note">
+              The agent can recover deleted {recoveryLabel} for 7 days.
+            </p>
+          </>
+        )}
+      </div>
+    </div>
+  )
+
+  return createPortal(layer, document.body)
+}

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -841,10 +841,14 @@ test('large drawer lists memoize ordering and row actions without changing row o
   assert.doesNotMatch(drawer, /onSelect=\{\(\) => on(?:Chat|App)/)
 })
 
-test('row-owned context menus have no detached hidden-anchor path', () => {
+test('row-owned context menus keep a visible trigger without hidden anchors', () => {
   assert.match(drawer, /<DrawerItemActionMenu[\s\S]*?itemKind=\{kind\}/)
   assert.doesNotMatch(drawer, /triggerHidden|drawer__menu-anchor/)
-  assert.doesNotMatch(drawerCss, /drawer__more|drawer__menu-anchor/)
+  assert.match(drawer,
+    /className="drawer__more"[\s\S]*?aria-label=\{`More actions for \$\{label\}`\}/,
+    'drawer rows must retain an explicit keyboard and touch action trigger')
+  assert.match(drawerCss, /\.drawer__more\s*\{/)
+  assert.doesNotMatch(drawerCss, /drawer__menu-anchor/)
   assert.match(drawer, /if \(openMenu\) return[\s\S]*?onClose\?\.\(\)/,
     'Escape must close a row menu before dismissing the mobile drawer beneath it')
 })

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -11,6 +11,10 @@ const shellBrand = readFileSync(new URL('../ShellBrand.jsx', import.meta.url), '
 const newChatLanding = readFileSync(new URL('../NewChatLanding.jsx', import.meta.url), 'utf8')
 const workspaceViewSrc = readFileSync(new URL('../workspaceView.js', import.meta.url), 'utf8')
 const drawer = readFileSync(new URL('../../Drawer/Drawer.jsx', import.meta.url), 'utf8')
+const drawerItemActionMenu = readFileSync(
+  new URL('../../Drawer/DrawerItemActionMenu.jsx', import.meta.url),
+  'utf8',
+)
 const paneModelSrc = readFileSync(new URL('../paneModel.js', import.meta.url), 'utf8')
 const chrome = readFileSync(new URL('../WorkspaceChrome.jsx', import.meta.url), 'utf8')
 const dragBinding = readFileSync(new URL('../useWorkspaceDrag.js', import.meta.url), 'utf8')
@@ -837,9 +841,34 @@ test('large drawer lists memoize ordering and row actions without changing row o
   assert.doesNotMatch(drawer, /onSelect=\{\(\) => on(?:Chat|App)/)
 })
 
+test('row-owned context menus have no detached hidden-anchor path', () => {
+  assert.match(drawer, /<DrawerItemActionMenu[\s\S]*?itemKind=\{kind\}/)
+  assert.doesNotMatch(drawer, /triggerHidden|drawer__menu-anchor/)
+  assert.doesNotMatch(drawerCss, /drawer__more|drawer__menu-anchor/)
+  assert.match(drawer, /if \(openMenu\) return[\s\S]*?onClose\?\.\(\)/,
+    'Escape must close a row menu before dismissing the mobile drawer beneath it')
+})
+
+test('chat deletion is immediate while app deletion still requires confirmation', () => {
+  assert.match(
+    drawerItemActionMenu,
+    /function handleDeleteAction\(\)[\s\S]*?itemKind === 'chat'[\s\S]*?run\(onDelete, \{ restoreFocus: false \}\)[\s\S]*?return[\s\S]*?setConfirmation\('delete'\)/,
+  )
+  assert.match(
+    drawerItemActionMenu,
+    /className="drawer__item-action-item drawer__item-action-item--danger"\s*\n\s*onClick=\{handleDeleteAction\}/,
+  )
+  assert.match(
+    drawerItemActionMenu,
+    /confirmation === 'delete-data'[\s\S]*?confirmation === 'delete'/,
+    'app and app-data deletion must retain their confirmation paths',
+  )
+})
+
 test('drawer row menus use one semantic context-menu path across pointer types', () => {
-  assert.match(drawer, /function openRowMenu\(event\)[\s\S]*?actions\.toggleMenu\(kind, id, true, surface\)/)
-  assert.match(drawer, /onContextMenu=\{openRowMenu\}/)
+  assert.match(drawer, /function openItemMenu\(event\)[\s\S]*?actions\.toggleMenu\(kind, id, true, surface,/)
+  assert.equal((drawer.match(/onContextMenu=\{openItemMenu\}/g) || []).length, 2,
+    'app cards, app rows, and chat rows must share one opening function')
   assert.match(dragBinding, /srcEl\.dispatchEvent\(new window\.MouseEvent\('contextmenu'/)
   assert.doesNotMatch(
     dragBinding,
@@ -853,12 +882,19 @@ test('a secondary-button release cannot immediately select a flipped drawer menu
   assert.match(drawer, /event\.pointerType !== 'mouse' \|\| event\.button !== 2/)
   assert.match(drawer, /window\.addEventListener\('pointerup', onSecondaryPointerUp, true\)/)
   assert.match(drawer, /upEvent\.pointerId !== pointerId \|\| upEvent\.button !== 2/)
-  assert.match(drawer, /cleanup\(\)[\s\S]*?actions\.toggleMenu\(kind, id, true, surface\)/)
+  assert.match(drawer, /cleanup\(\)[\s\S]*?actions\.toggleMenu\(kind, id, true, surface, placement\)/)
   assert.match(drawer, /timer = setTimeout\(cleanup, 1500\)/)
 })
 
+test('launcher cards and drawer rows share the same long-press threshold and movement slop', () => {
+  assert.match(drawer, /import \{ DRAWER_HOLD_MS, PRE_HOLD_MOVE_PX \} from '\.\.\/Shell\/dragController\.js'/)
+  assert.match(drawer, /\}, DRAWER_HOLD_MS\)/)
+  assert.match(drawer, /> PRE_HOLD_MOVE_PX/)
+  assert.doesNotMatch(drawer, /520/)
+})
+
 test('double-click edits a drawer row name instead of duplicating its context menu', () => {
-  assert.match(drawer, /onDoubleClick=\{event => \{[\s\S]*?actions\.startRename\(kind, id\)/)
+  assert.match(drawer, /onDoubleClick=\{event => \{[\s\S]*?actions\.startRename\(kind, id, surface\)/)
 })
 
 test('the Settings surface responds to PANE width via a query container', () => {

--- a/frontend/src/lib/__tests__/appsDirectoryContract.test.js
+++ b/frontend/src/lib/__tests__/appsDirectoryContract.test.js
@@ -9,7 +9,13 @@ const src = resolve(here, '../..')
 const drawer = readFileSync(resolve(src, 'components/Drawer/Drawer.jsx'), 'utf8')
 const directory = readFileSync(resolve(src, 'components/Drawer/AppsDirectory.jsx'), 'utf8')
 const css = readFileSync(resolve(src, 'components/Drawer/AppsDirectory.css'), 'utf8')
+const drawerCss = readFileSync(resolve(src, 'components/Drawer/Drawer.css'), 'utf8')
+const itemActionMenu = readFileSync(
+  resolve(src, 'components/Drawer/DrawerItemActionMenu.jsx'),
+  'utf8',
+)
 const shell = readFileSync(resolve(src, 'components/Shell/Shell.jsx'), 'utf8')
+const shellCss = readFileSync(resolve(src, 'components/Shell/Shell.css'), 'utf8')
 const tabModel = readFileSync(resolve(src, 'components/Shell/tabModel.js'), 'utf8')
 const navigationIcons = readFileSync(resolve(src, 'components/navigationIcons.js'), 'utf8')
 
@@ -23,8 +29,8 @@ test('Apps is a single drawer destination and the old full app list is gone', ()
 test('the directory preserves app management on every card', () => {
   assert.match(drawer, /variant="card"/)
   assert.match(drawer, /<DrawerItemMenu[\s\S]*?surface=\{surface\}/)
-  for (const action of ['Install to home screen', 'Delete data', 'Rename']) {
-    assert.match(drawer, new RegExp(action))
+  for (const action of ['Install to home screen', 'Share app', 'Delete data', 'Rename']) {
+    assert.match(itemActionMenu, new RegExp(action))
   }
 })
 
@@ -35,14 +41,34 @@ test('phone and web share one searchable launcher tab', () => {
   assert.match(tabModel, /APPS_TAB_KEY = 'apps:apps'/)
   assert.match(shell, /const APPS_KEY = tabModel\.APPS_TAB_KEY/)
   assert.match(css, /@media \(max-width: 720px\)[\s\S]*?grid-template-columns: repeat\(4/)
-  assert.match(drawer, /onContextMenu=\{openCardMenu\}/)
-  assert.match(drawer, /setTimeout\(\(\) => \{[\s\S]*?toggleMenu[\s\S]*?520\)/)
-  assert.match(
-    drawer,
-    /triggerClassName="drawer__more apps-directory__card-menu-anchor"\s+triggerHidden/,
-    'the invisible menu anchor must not add a ghost keyboard focus stop',
-  )
+  assert.equal((drawer.match(/onContextMenu=\{openItemMenu\}/g) || []).length, 2,
+    'launcher cards and drawer rows must enter the same context-menu path')
+  assert.match(drawer, /DRAWER_HOLD_MS, PRE_HOLD_MOVE_PX/)
+  assert.match(drawer, /setTimeout\(\(\) => \{[\s\S]*?toggleMenu[\s\S]*?DRAWER_HOLD_MS\)/)
+  assert.doesNotMatch(drawer, /520/)
+  assert.match(drawer, /menuPlacement=\{openMenu/)
+  assert.match(itemActionMenu, /placeContextMenu/)
+  assert.match(itemActionMenu, /stopImmediatePropagation/)
+  assert.match(drawerCss, /@media \(max-width: 720px\)[\s\S]*?drawer__item-action-menu/)
+  assert.match(drawerCss, /bottom: max\(12px, env\(safe-area-inset-bottom\)\)/)
   assert.match(shell, /const navigationSurfaceOpen = modalDrawerOpen/)
+})
+
+test('chat and app rows share one placed action menu contract', () => {
+  assert.match(drawer, /<DrawerItemActionMenu[\s\S]*?itemKind=\{kind\}[\s\S]*?itemName=\{label\}/)
+  assert.doesNotMatch(drawer, /@openai\/apps-sdk-ui\/components\/Menu/)
+  assert.doesNotMatch(drawer, /triggerHidden|drawer__menu-anchor/)
+  assert.match(itemActionMenu, /itemKind === 'chat' \? 'Chat' : 'App'/)
+  assert.match(itemActionMenu, /itemKind === 'chat' \? 'chats' : 'apps'/)
+  assert.match(itemActionMenu, /<Chat width=\{20\} height=\{20\}/)
+  assert.match(itemActionMenu, /itemKind === 'app' && \(/,
+    'Delete data must stay app-only')
+})
+
+test('desktop density keeps shell chrome and pointer geometry in one coordinate system', () => {
+  const desktop = shellCss.match(/@media \(min-width: 1024px\) \{[\s\S]*$/)?.[0] || ''
+  assert.doesNotMatch(desktop, /(?:^|[;{])\s*zoom\s*:/,
+    'desktop density must not scale the viewport away from pointer coordinates')
 })
 
 test('the app directory distinguishes loading, errors, and confirmed emptiness', () => {

--- a/frontend/src/lib/__tests__/contextMenuGeometry.test.js
+++ b/frontend/src/lib/__tests__/contextMenuGeometry.test.js
@@ -1,0 +1,37 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { placeContextMenu } from '../contextMenuGeometry.js'
+
+test('a desktop context menu stays beside the painted pointer through root zoom', () => {
+  const position = placeContextMenu({
+    clientPoint: { x: 380, y: 215 },
+    clientViewport: { left: 0, top: 0, width: 1512, height: 861 },
+    layoutViewport: { width: 1680, height: 956.6667 },
+    menuSize: { width: 220, height: 190 },
+  })
+
+  assert.ok(Math.abs(position.x * 0.9 - 388) < 0.1)
+  assert.ok(Math.abs(position.y * 0.9 - 223) < 0.1)
+})
+
+test('a context menu flips before the right and bottom viewport edges', () => {
+  const position = placeContextMenu({
+    clientPoint: { x: 790, y: 590 },
+    clientViewport: { left: 0, top: 0, width: 800, height: 600 },
+    layoutViewport: { width: 800, height: 600 },
+    menuSize: { width: 220, height: 180 },
+  })
+
+  assert.deepEqual(position, { x: 562, y: 402 })
+})
+
+test('an oversized context menu clamps to the viewport padding', () => {
+  const position = placeContextMenu({
+    clientPoint: { x: 10, y: 10 },
+    clientViewport: { left: 0, top: 0, width: 200, height: 150 },
+    layoutViewport: { width: 200, height: 150 },
+    menuSize: { width: 240, height: 180 },
+  })
+
+  assert.deepEqual(position, { x: 12, y: 12 })
+})

--- a/frontend/src/lib/contextMenuGeometry.js
+++ b/frontend/src/lib/contextMenuGeometry.js
@@ -1,0 +1,50 @@
+/* Context-menu geometry bridges painted pointer coordinates to the root
+   layout space, then keeps the menu beside the pointer and inside the viewport. */
+
+function positiveNumber(value, fallback) {
+  const number = Number(value)
+  return Number.isFinite(number) && number > 0 ? number : fallback
+}
+
+function clamp(value, minimum, maximum) {
+  return Math.min(Math.max(value, minimum), Math.max(minimum, maximum))
+}
+
+export function placeContextMenu({
+  clientPoint,
+  clientViewport,
+  layoutViewport,
+  menuSize,
+  gap = 8,
+  padding = 12,
+}) {
+  const clientWidth = positiveNumber(clientViewport?.width, 1)
+  const clientHeight = positiveNumber(clientViewport?.height, 1)
+  const layoutWidth = positiveNumber(layoutViewport?.width, clientWidth)
+  const layoutHeight = positiveNumber(layoutViewport?.height, clientHeight)
+  const scaleX = layoutWidth / clientWidth
+  const scaleY = layoutHeight / clientHeight
+  const pointX = (Number(clientPoint?.x) - (Number(clientViewport?.left) || 0)) * scaleX
+  const pointY = (Number(clientPoint?.y) - (Number(clientViewport?.top) || 0)) * scaleY
+  const menuWidth = positiveNumber(menuSize?.width, 0)
+  const menuHeight = positiveNumber(menuSize?.height, 0)
+  const gapX = Math.max(0, Number(gap) || 0) * scaleX
+  const gapY = Math.max(0, Number(gap) || 0) * scaleY
+  const paddingX = Math.max(0, Number(padding) || 0) * scaleX
+  const paddingY = Math.max(0, Number(padding) || 0) * scaleY
+
+  let x = pointX + gapX
+  if (x + menuWidth > layoutWidth - paddingX) {
+    x = pointX - menuWidth - gapX
+  }
+
+  let y = pointY + gapY
+  if (y + menuHeight > layoutHeight - paddingY) {
+    y = pointY - menuHeight - gapY
+  }
+
+  return {
+    x: clamp(x, paddingX, layoutWidth - menuWidth - paddingX),
+    y: clamp(y, paddingY, layoutHeight - menuHeight - paddingY),
+  }
+}


### PR DESCRIPTION
## Summary
- place app and chat action menus beside the invoking pointer or keyboard-focused item
- use one shared drawer-item action surface across app cards, pinned apps, and chats
- present the same named, touch-friendly action sheet on compact screens
- keep dismissal, focus restoration, edge clamping, and destructive-action behavior consistent

This builds on the drawer interaction model introduced in #281 by replacing the remaining hidden-anchor placement path with one item-owned menu contract.

## Validation
- `npm run build`
- `npm test`
- focused drawer/menu contract and geometry tests
- `git diff --check`
- desktop pointer, keyboard, and compact-screen interaction review