### PR TITLE
Fix chat scroll bounce and preserve composer drafts

### DIFF
--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -7,6 +7,7 @@ import { del as idbDel } from 'idb-keyval'
 import * as setupSession from '../lib/setupSession.js'
 import { clearLatchedTokens } from '../lib/appToken.js'
 import { clearOwnerDraftStorage } from '../lib/ownerDraftStorage.js'
+import { clearDurableComposerDrafts } from '../components/ChatView/composerDraft.js'
 import { verifyConnectivity } from '../lib/connectivityStore.js'
 import { SHELL_DATA_CACHE } from '../sw-cache-policy.js'
 
@@ -133,6 +134,7 @@ export function clearQueryCache() {
     import('./mediaToken.js').then(m => m.clearMediaTokenCache()).catch(() => {})
   } catch {}
   return Promise.all([
+    clearDurableComposerDrafts().catch(() => {}),
     idbDel('mobius-query-cache').catch(() => {}),
     delOutboxDb().catch(() => {}),
     delDatabase('mobius-signals', 'signal queue').catch(() => {}),

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -2013,11 +2013,22 @@
    — the no-auto-scroll contract stays intact). Same frosted accent chip
    recipe as .chat__open-app-btn: it must read as a card over the chat
    scrolling behind the transparent foot. Centered, because it speaks for
-   the whole conversation rather than the queued tray. */
+   the whole conversation rather than the queued tray. The positioning layer
+   sits immediately above the flow-owned footer: viewport visibility may mount
+   or unmount either nudge without changing transcript geometry. */
+.chat__offscreen-nudges {
+  position: absolute;
+  right: 12px;
+  bottom: 100%;
+  left: 12px;
+  pointer-events: none;
+}
+
 .chat__question-nudge,
 .chat__resume-nudge {
   display: block;
-  margin: 0 auto 8px;
+  max-width: 100%;
+  margin: 0 auto;
   padding: 5px 14px;
   border-radius: 999px;
   border: 1px solid var(--accent); /* CONTRACT: vivid accent line */
@@ -2042,6 +2053,8 @@
 }
 .chat__question-nudge:active,
 .chat__resume-nudge:active { transform: scale(0.96); }
+
+.chat__offscreen-nudges > button + button { margin-top: 8px; }
 
 /* ── Voice input ──────────────────────────────────── */
 .chat__mic {

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -92,7 +92,13 @@ import {
   saveFailedSendAttempt,
   sendAttemptIsDurable,
 } from './sendAttemptRecovery.js'
-import { persistComposerDraft, readComposerDraft } from './composerDraft.js'
+import {
+  clearComposerDraft,
+  composerDraftRevision,
+  persistComposerDraft,
+  readComposerDraft,
+  readComposerDraftAsync,
+} from './composerDraft.js'
 import {
   reconcileComposerTextarea,
   resetComposerTextarea,
@@ -183,7 +189,7 @@ function findUserIndexByCid(messages, cid) {
 // NOTE: if deletion ever moves inside ChatView's own scope, call this inline
 // instead of leaving the orphaned key behind.
 export function deleteChatDraft(chatId) {
-  try { sessionStorage.removeItem(`draft:${chatId}`) } catch { /* private browsing */ }
+  clearComposerDraft(chatId)
   clearFailedSendAttempt(chatId)
   clearChatQuestionDrafts(chatId)
 }
@@ -221,13 +227,20 @@ function readInitialComposer(chatId, { acceptPending = true } = {}) {
     return {
       input,
       autoSend: !!input && autoSendDraft === input,
+      source: pending ? 'pending' : (failedAttempt ? 'failed' : 'saved'),
       failedAttempt: pending ? null : failedAttempt,
       attachments: pending
         ? []
         : (failedAttempt?.attachments || saved.attachments),
     }
   } catch {
-    return { input: '', autoSend: false, failedAttempt: null, attachments: [] }
+    return {
+      input: '',
+      autoSend: false,
+      source: 'empty',
+      failedAttempt: null,
+      attachments: [],
+    }
   }
 }
 
@@ -371,7 +384,15 @@ export default function ChatView({
 
   useEffect(() => {
     if (hidden) return
-    const initial = initialComposerRef.current.input
+    const initialComposer = initialComposerRef.current
+    const initial = initialComposer.input
+    if ((initialComposer.source === 'pending' || initialComposer.source === 'failed')
+        && (initial || initialComposer.attachments.length > 0)) {
+      // A global navigation handoff or failed-send recovery outranks any older
+      // per-chat draft. Adopt it into the live + durable draft owner before the
+      // one-shot handoff keys are removed.
+      persistComposerDraft(chatId, initial, initialComposer.attachments)
+    }
     try {
       if (sessionStorage.getItem(PENDING_DRAFT_KEY) === initial) {
         sessionStorage.removeItem(PENDING_DRAFT_KEY)
@@ -841,6 +862,7 @@ export default function ChatView({
     reapplyActiveMode,
     settleSendIntent,
     settleStreamingPin,
+    composerResized,
     paneResized,
   } = useScrollMode({
     chatId,
@@ -1431,6 +1453,31 @@ export default function ChatView({
     },
   })
 
+  useEffect(() => {
+    let cancelled = false
+    const revision = composerDraftRevision(chatId)
+    readComposerDraftAsync(chatId).then(saved => {
+      if (cancelled || composerDraftRevision(chatId) !== revision) return
+
+      const currentFiles = draftAttachmentsRef.current
+      const sameFiles = currentFiles.length === saved.attachments.length
+        && currentFiles.every((file, index) => {
+          const other = saved.attachments[index]
+          return file?.name === other?.name
+            && file?.size === other?.size
+            && file?.mime_type === other?.mime_type
+            && file?.status === other?.status
+        })
+      if (saved.input === inputValueRef.current && sameFiles) return
+
+      inputValueRef.current = saved.input
+      setInputState(saved.input)
+      draftAttachmentsRef.current = saved.attachments
+      restoreFiles(saved.attachments)
+    }).catch(() => {})
+    return () => { cancelled = true }
+  }, [chatId, restoreFiles])
+
   const wasHiddenRef = useRef(hidden)
   useLayoutEffect(() => {
     const becameVisible = wasHiddenRef.current && !hidden
@@ -1682,12 +1729,12 @@ export default function ChatView({
     let raf1 = 0
     let raf2 = 0
     const applySoon = () => {
-      measureComposerHeight()
+      composerResized()
       if (raf1) cancelAnimationFrame(raf1)
       if (raf2) cancelAnimationFrame(raf2)
       raf1 = requestAnimationFrame(() => {
-        measureComposerHeight()
-        raf2 = requestAnimationFrame(measureComposerHeight)
+        composerResized()
+        raf2 = requestAnimationFrame(composerResized)
       })
     }
     const reconcileForegroundGeometry = () => {
@@ -1723,13 +1770,13 @@ export default function ChatView({
       window.visualViewport?.removeEventListener('scroll', applySoon)
       document.removeEventListener('visibilitychange', onVisible)
     }
-  }, [measureComposerHeight])
+  }, [composerResized])
 
   useEffect(() => {
-    measureComposerHeight()
-    const raf = requestAnimationFrame(measureComposerHeight)
+    composerResized()
+    const raf = requestAnimationFrame(composerResized)
     return () => cancelAnimationFrame(raf)
-  }, [builtApps, sending, buildPhases, measureComposerHeight])
+  }, [builtApps, sending, buildPhases, composerResized])
 
   useEffect(() => {
     const latest = buildPhases[buildPhases.length - 1]
@@ -4042,26 +4089,28 @@ export default function ChatView({
               })}
             </div>
           )}
-          {hasPendingQuestion && pendingCardOffscreen && (
-            <button
-              type="button"
-              className="chat__question-nudge"
-              onClick={revealConversationTail}
-            >
-              Möbius asked you something — tap to answer
-            </button>
-          )}
-          {hasPendingResume && resumeCardOffscreen && (
-            <button
-              type="button"
-              className="chat__resume-nudge"
-              onClick={revealConversationTail}
-            >
-              {pendingResumeBlock?.pause?.resets_at
-                ? 'Rate limit reached — tap to resume'
-                : 'Turn paused — tap to resume'}
-            </button>
-          )}
+          <div className="chat__offscreen-nudges">
+            {hasPendingQuestion && pendingCardOffscreen && (
+              <button
+                type="button"
+                className="chat__question-nudge"
+                onClick={revealConversationTail}
+              >
+                Möbius asked you something — tap to answer
+              </button>
+            )}
+            {hasPendingResume && resumeCardOffscreen && (
+              <button
+                type="button"
+                className="chat__resume-nudge"
+                onClick={revealConversationTail}
+              >
+                {pendingResumeBlock?.pause?.resets_at
+                  ? 'Rate limit reached — tap to resume'
+                  : 'Turn paused — tap to resume'}
+              </button>
+            )}
+          </div>
           <ProgressRail
             items={progressRail}
             ariaLabel={visibleGoalObjective ? 'Goal progress' : 'Build progress'}

--- a/frontend/src/components/ChatView/__tests__/composerDraft.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerDraft.test.js
@@ -1,8 +1,18 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
+import 'fake-indexeddb/auto'
 
-import { persistComposerDraft, readComposerDraft } from '../composerDraft.js'
+import {
+  _clearComposerDraftMemoryForTests,
+  clearComposerDraft,
+  clearDurableComposerDrafts,
+  flushComposerDraftPersistence,
+  persistComposerDraft,
+  readComposerDraft,
+  readComposerDraftAsync,
+} from '../composerDraft.js'
+import { streamSnapshotKey } from '../streamSnapshotCache.js'
 
 function storageStub(initial = {}) {
   const values = new Map(Object.entries(initial))
@@ -18,7 +28,15 @@ function storageStub(initial = {}) {
 test('persists and clears a chat draft synchronously', () => {
   const storage = storageStub()
   assert.equal(persistComposerDraft('chat-a', 'unfinished thought', storage), true)
-  assert.equal(storage.getItem('draft:chat-a'), 'unfinished thought')
+  const stored = JSON.parse(storage.getItem('draft:chat-a'))
+  assert.equal(stored.type, 'mobius-composer-draft')
+  assert.equal(stored.version, 2)
+  assert.equal(stored.input, 'unfinished thought')
+  assert.equal(Number.isFinite(stored.updated_at), true)
+  assert.deepEqual(readComposerDraft('chat-a', storage), {
+    input: 'unfinished thought',
+    attachments: [],
+  })
 
   assert.equal(persistComposerDraft('chat-a', '', storage), true)
   assert.equal(storage.getItem('draft:chat-a'), null)
@@ -108,23 +126,105 @@ test('rejects status-bearing attachments injected into a stored envelope', () =>
   )
 })
 
-test('evicts one draft and retries when session storage is full', () => {
-  const storage = storageStub({ 'draft:chat-a': 'older' })
-  const normalSet = storage.setItem.bind(storage)
-  let first = true
-  storage.setItem = (key, value) => {
-    if (first) {
-      first = false
-      const error = new Error('full')
-      error.name = 'QuotaExceededError'
-      throw error
-    }
-    normalSet(key, value)
-  }
+test('quota recovery sacrifices only transient cache and keeps every owner draft', async () => {
+  const previous = Object.getOwnPropertyDescriptor(globalThis, 'sessionStorage')
+  const storage = storageStub()
+  Object.defineProperty(globalThis, 'sessionStorage', {
+    configurable: true,
+    value: storage,
+  })
 
-  assert.equal(persistComposerDraft('chat-b', 'latest', [], storage), true)
-  assert.equal(storage.getItem('draft:chat-a'), null)
-  assert.equal(storage.getItem('draft:chat-b'), 'latest')
+  try {
+    await clearDurableComposerDrafts()
+
+    persistComposerDraft('chat-a', 'older owner draft')
+    storage.setItem(streamSnapshotKey('running-chat'), JSON.stringify([
+      { type: 'text', content: 'regenerable partial' },
+    ]))
+
+    const normalSet = storage.setItem.bind(storage)
+    storage.setItem = (key, value) => {
+      if (key === 'draft:chat-b' && storage.getItem(streamSnapshotKey('running-chat'))) {
+        const error = new Error('full')
+        error.name = 'QuotaExceededError'
+        throw error
+      }
+      normalSet(key, value)
+    }
+
+    assert.equal(persistComposerDraft('chat-b', 'new owner draft'), true)
+    assert.equal(storage.getItem(streamSnapshotKey('running-chat')), null)
+    assert.equal(readComposerDraft('chat-a').input, 'older owner draft')
+    assert.equal(readComposerDraft('chat-b').input, 'new owner draft')
+
+    // If Web Storage remains unavailable even after cache reclamation, the
+    // dedicated draft database still survives a document-memory reset. Rapid
+    // updates are coalesced latest-wins rather than queuing one transaction per
+    // keystroke.
+    storage.setItem = (key, value) => {
+      if (key === 'draft:chat-c') {
+        const error = new Error('still full')
+        error.name = 'QuotaExceededError'
+        throw error
+      }
+      normalSet(key, value)
+    }
+    persistComposerDraft('chat-c', 'one')
+    persistComposerDraft('chat-c', 'one two')
+    persistComposerDraft('chat-c', 'one two three')
+    await flushComposerDraftPersistence()
+
+    _clearComposerDraftMemoryForTests()
+    assert.equal(storage.getItem('draft:chat-c'), null)
+    assert.deepEqual(await readComposerDraftAsync('chat-c'), {
+      input: 'one two three',
+      attachments: [],
+    })
+
+    // Session may contain an older successful write while later writes fit
+    // only in IndexedDB. Even several changes inside one wall-clock tick carry
+    // a strict order, so hydration selects the actual latest value.
+    persistComposerDraft('chat-d', 'old session copy')
+    storage.setItem = (key, value) => {
+      if (key === 'draft:chat-d') {
+        const error = new Error('full again')
+        error.name = 'QuotaExceededError'
+        throw error
+      }
+      normalSet(key, value)
+    }
+    const realNow = Date.now
+    Date.now = () => 1_000
+    try {
+      persistComposerDraft('chat-d', 'newer durable copy')
+      persistComposerDraft('chat-d', 'newest durable copy')
+    } finally {
+      Date.now = realNow
+    }
+    await flushComposerDraftPersistence()
+    _clearComposerDraftMemoryForTests()
+    assert.equal(readComposerDraft('chat-d').input, 'old session copy')
+    assert.equal((await readComposerDraftAsync('chat-d')).input, 'newest durable copy')
+
+    clearComposerDraft('chat-d')
+    await flushComposerDraftPersistence()
+    _clearComposerDraftMemoryForTests()
+    assert.deepEqual(await readComposerDraftAsync('chat-d'), {
+      input: '',
+      attachments: [],
+    })
+
+    await clearDurableComposerDrafts()
+    _clearComposerDraftMemoryForTests()
+    assert.deepEqual(await readComposerDraftAsync('chat-c'), {
+      input: '',
+      attachments: [],
+    })
+  } finally {
+    await clearDurableComposerDrafts()
+    if (previous) Object.defineProperty(globalThis, 'sessionStorage', previous)
+    else delete globalThis.sessionStorage
+  }
 })
 
 test('the composer state boundary saves before scheduling React state', () => {
@@ -137,4 +237,22 @@ test('the composer state boundary saves before scheduling React state', () => {
   const render = body.indexOf('setInputState(nextInput)')
   assert.ok(save >= 0, 'all composer changes must be persisted directly')
   assert.ok(render > save, 'draft persistence must happen before navigation can unmount React')
+})
+
+test('shell draft handoffs use the same owner instead of writing around its live mirror', () => {
+  const shellSource = readFileSync(
+    new URL('../../Shell/Shell.jsx', import.meta.url),
+    'utf8',
+  )
+  const chatSource = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8')
+  const directDraftWrite = /sessionStorage\.(?:setItem|removeItem)\(`draft:/
+  assert.doesNotMatch(shellSource, directDraftWrite,
+    'shell handoffs and deletion must not bypass the draft owner')
+  assert.doesNotMatch(chatSource, directDraftWrite,
+    'chat cleanup must clear memory, session, and durable copies together')
+  assert.match(shellSource, /persistComposerDraft\(buildingChatId, report\)/)
+  assert.match(shellSource, /persistComposerDraft\(e\.data\.chatId, draftText\)/)
+  assert.match(shellSource, /persistComposerDraft\(chatId, draftText\)/)
+  assert.match(shellSource, /clearComposerDraft\(id\)/)
+  assert.match(chatSource, /clearComposerDraft\(chatId\)/)
 })

--- a/frontend/src/components/ChatView/__tests__/resumeAffordance.test.js
+++ b/frontend/src/components/ChatView/__tests__/resumeAffordance.test.js
@@ -165,6 +165,30 @@ test('ChatView routes both offscreen attention nudges through the controller', (
     'the resume nudge reuses the question-nudge visual style')
 })
 
+test('viewport-derived nudges never participate in footer geometry', () => {
+  const layer = sliceElement(chatView, '<div className="chat__offscreen-nudges">')
+  assert.match(layer, /className="chat__question-nudge"/,
+    'the question cue belongs to the geometry-neutral layer')
+  assert.match(layer, /className="chat__resume-nudge"/,
+    'the resume cue shares the same geometry owner')
+
+  const layerCss = css.match(/\.chat__offscreen-nudges\s*\{[\s\S]*?\}/)?.[0] ?? ''
+  assert.match(layerCss, /position:\s*absolute/,
+    'showing or hiding a viewport cue must not resize the footer')
+  assert.match(layerCss, /bottom:\s*100%/,
+    'the cue remains immediately above the flow-owned footer controls')
+  assert.match(layerCss, /pointer-events:\s*none/,
+    'the overlay lane itself must not block transcript interaction')
+
+  const nudgeCss = css.match(
+    /\.chat__question-nudge,\s*\n\.chat__resume-nudge\s*\{[\s\S]*?\}/,
+  )?.[0] ?? ''
+  assert.match(nudgeCss, /margin:\s*0 auto/,
+    'the absolute lane, not a flow margin, owns nudge placement')
+  assert.doesNotMatch(nudgeCss, /margin:\s*0 auto 8px/,
+    'a viewport-derived nudge cannot reserve footer height')
+})
+
 test('both attention nudges observe a node published by the card, not a lookup', () => {
   // The nudges track a card that changes DOM node mid-turn: the live streaming
   // surface renders the pending question while the turn runs, the durable

--- a/frontend/src/components/ChatView/__tests__/sendLandingGeometry.test.js
+++ b/frontend/src/components/ChatView/__tests__/sendLandingGeometry.test.js
@@ -30,3 +30,39 @@ test('ChatView gives its existing composer measurement to the scroll owner', () 
   const args = chatView.slice(callStart, callEnd)
   assert.match(args, /syncComposerGeometry:\s*measureComposerHeight/)
 })
+
+test('footer resizes enter through the scroll owner instead of mutating geometry directly', () => {
+  const commentStart = chatView.indexOf("// Publish `.chat__foot`'s rendered height")
+  const effectStart = chatView.indexOf('useEffect(() => {', commentStart)
+  const effectEnd = chatView.indexOf('\n  useEffect(() => {', effectStart + 20)
+  assert.ok(commentStart >= 0 && effectStart > commentStart && effectEnd > effectStart,
+    'footer resize effect exists')
+  const footerEffect = chatView.slice(effectStart, effectEnd)
+
+  assert.match(footerEffect, /new ResizeObserver\(applySoon\)/)
+  assert.match(footerEffect, /composerResized\(\)/)
+  assert.doesNotMatch(footerEffect, /measureComposerHeight\(\)/,
+    'the footer observer must not bypass reader-gesture ownership')
+
+  const bridgeStart = controller.indexOf('function runComposerResize()')
+  const bridgeEnd = controller.indexOf('\n    composerResizeRunRef.current', bridgeStart)
+  assert.ok(bridgeStart >= 0 && bridgeEnd > bridgeStart, 'composer resize bridge exists')
+  const bridge = controller.slice(bridgeStart, bridgeEnd)
+  assert.match(bridge, /deferLayoutUntilReaderYields\(\)/)
+  assert.match(bridge, /syncLayout\(\)/)
+})
+
+test('gesture settlement replays deferred footer geometry and mode in one task', () => {
+  const replayStart = controller.indexOf('const replayDeferredLayoutNow = () => {')
+  const replayEnd = controller.indexOf('\n    const resumeLayoutAfterGesture', replayStart)
+  assert.ok(replayStart >= 0 && replayEnd > replayStart, 'atomic replay exists')
+  const replay = controller.slice(replayStart, replayEnd)
+  assert.match(replay, /syncLayout\(\{ forceApply: true \}\)/)
+
+  const settleStart = controller.indexOf('const settleReaderScroll = () => {')
+  const settleEnd = controller.indexOf('\n    const scheduleReaderSettle', settleStart)
+  assert.ok(settleStart >= 0 && settleEnd > settleStart, 'reader settlement exists')
+  const settle = controller.slice(settleStart, settleEnd)
+  assert.match(settle, /if \(!replayDeferredLayoutNow\(\)\) sizeSpacer\(\)/,
+    'settlement must not publish footer geometry before its compensating mode write')
+})

--- a/frontend/src/components/ChatView/__tests__/streamSnapshotCache.test.js
+++ b/frontend/src/components/ChatView/__tests__/streamSnapshotCache.test.js
@@ -9,6 +9,7 @@ import {
   readStoredStreamSnapshot,
   writeStoredStreamSnapshot,
   clearStoredStreamSnapshot,
+  reclaimStoredStreamSnapshots,
   flushStoredStreamSnapshot,
   flushAllStreamSnapshots,
   registerMountedChat,
@@ -22,6 +23,8 @@ function makeStorage() {
   const map = new Map()
   return {
     map,
+    get length() { return map.size },
+    key(index) { return [...map.keys()][index] ?? null },
     getItem(key) { return map.has(key) ? map.get(key) : null },
     setItem(key, value) { map.set(key, value) },
     removeItem(key) { map.delete(key) },
@@ -69,6 +72,23 @@ test('clear removes the current key', () => {
   clearStoredStreamSnapshot('chat-a', storage)
 
   assert.equal(storage.map.has(streamSnapshotKey('chat-a')), false)
+})
+
+test('quota reclamation drops only stream cache, including pending writes', (t) => {
+  _resetStreamSnapshotThrottleForTests()
+  t.mock.timers.enable({ apis: ['setTimeout'] })
+  const storage = makeStorage()
+  storage.setItem('draft:chat-a', 'owner data')
+  storage.setItem(streamSnapshotKey('settled'), '[{"type":"text"}]')
+  registerMountedChat(); registerMountedChat()
+  writeStoredStreamSnapshot('pending', [{ type: 'text', content: 'later' }], storage)
+
+  assert.equal(reclaimStoredStreamSnapshots(storage), 1)
+  assert.equal(storage.getItem('draft:chat-a'), 'owner data')
+  assert.equal(storage.getItem(streamSnapshotKey('settled')), null)
+  t.mock.timers.tick(STREAM_SNAPSHOT_THROTTLE_MS + 10)
+  assert.equal(storage.getItem(streamSnapshotKey('pending')), null)
+  _resetStreamSnapshotThrottleForTests()
 })
 
 test('read returns [] for corrupt or absent values', () => {

--- a/frontend/src/components/ChatView/composerDraft.js
+++ b/frontend/src/components/ChatView/composerDraft.js
@@ -1,9 +1,121 @@
+import {
+  clear as clearIdbStore,
+  createStore,
+  del as delIdbValue,
+  get as getIdbValue,
+  set as setIdbValue,
+} from 'idb-keyval'
+import { reclaimStoredStreamSnapshots } from './streamSnapshotCache.js'
+
 function availableStorage(storage) {
   if (storage !== undefined) return storage
   try { return globalThis.sessionStorage ?? null } catch { return null }
 }
 
 const DRAFT_ENVELOPE = 'mobius-composer-draft'
+const DRAFT_VERSION = 2
+const DURABLE_DRAFT_DB = 'mobius-owner-drafts'
+const DURABLE_DRAFT_STORE = 'drafts-v1'
+const durableDraftStore = createStore(DURABLE_DRAFT_DB, DURABLE_DRAFT_STORE)
+
+// Same-document navigation must never depend on a fallible browser-storage
+// round-trip. A present entry with raw:null is an intentional empty tombstone;
+// absence means this module has not learned the chat's current value yet.
+const liveDrafts = new Map()
+const draftRevisions = new Map()
+
+const NO_DURABLE_WRITE = Symbol('no-durable-draft-write')
+const durableWrites = new Map()
+let durableGeneration = 0
+let lastDraftTimestamp = 0
+
+function draftId(chatId) {
+  return String(chatId)
+}
+
+function revisionOf(chatId) {
+  return draftRevisions.get(draftId(chatId)) || 0
+}
+
+function rememberLiveDraft(chatId, raw, source, { advance = false } = {}) {
+  const id = draftId(chatId)
+  if (advance) draftRevisions.set(id, revisionOf(id) + 1)
+  liveDrafts.set(id, { raw, source })
+}
+
+function queueDurableDraftWrite(chatId, raw) {
+  const id = draftId(chatId)
+  let state = durableWrites.get(id)
+  if (state) {
+    state.latest = raw
+    return state.done
+  }
+
+  const generation = durableGeneration
+  let resolveDone
+  state = {
+    latest: raw,
+    done: new Promise(resolve => { resolveDone = resolve }),
+  }
+  durableWrites.set(id, state)
+
+  const drain = async () => {
+    while (state.latest !== NO_DURABLE_WRITE && generation === durableGeneration) {
+      const next = state.latest
+      state.latest = NO_DURABLE_WRITE
+      try {
+        if (next == null) await delIdbValue(id, durableDraftStore)
+        else await setIdbValue(id, next, durableDraftStore)
+      } catch {
+        // The synchronous memory mirror remains authoritative for this page.
+        // Session storage is attempted independently by persistComposerDraft.
+      }
+    }
+  }
+
+  const finishDrain = () => {
+    // A microtask may enqueue a fresher value after drain's final loop check
+    // but before its promise continuation runs. Re-open the drain rather than
+    // resolving a write that never reached the database.
+    if (state.latest !== NO_DURABLE_WRITE && generation === durableGeneration) {
+      void drain().finally(finishDrain)
+      return
+    }
+    if (durableWrites.get(id) === state) durableWrites.delete(id)
+    resolveDone()
+  }
+  void drain().finally(finishDrain)
+  return state.done
+}
+
+export function composerDraftRevision(chatId) {
+  if (chatId == null) return 0
+  return revisionOf(chatId)
+}
+
+export async function flushComposerDraftPersistence() {
+  while (durableWrites.size > 0) {
+    await Promise.all([...durableWrites.values()].map(state => state.done))
+  }
+}
+
+/** Clear both the live mirror and the dedicated owner-draft database on logout. */
+export async function clearDurableComposerDrafts() {
+  durableGeneration += 1
+  liveDrafts.clear()
+  draftRevisions.clear()
+  lastDraftTimestamp = 0
+  for (const state of durableWrites.values()) state.latest = NO_DURABLE_WRITE
+  await Promise.all([...durableWrites.values()].map(state => state.done))
+  try { await clearIdbStore(durableDraftStore) } catch {}
+}
+
+// Test-only: emulate a document reload without deleting the durable database.
+export function _clearComposerDraftMemoryForTests() {
+  liveDrafts.clear()
+  draftRevisions.clear()
+  lastDraftTimestamp = 0
+}
 
 function attachmentMetadata(attachment) {
   return {
@@ -46,45 +158,129 @@ function storedAttachments(attachments) {
     .map(attachment => ({ ...attachmentMetadata(attachment), status: 'done' }))
 }
 
+function decodeDraft(raw) {
+  if (!raw) return { input: '', attachments: [], updatedAt: null }
+  try {
+    const parsed = JSON.parse(raw)
+    if (parsed?.type === DRAFT_ENVELOPE
+        && (parsed.version === 1 || parsed.version === DRAFT_VERSION)) {
+      if (Number.isFinite(parsed.updated_at)) {
+        lastDraftTimestamp = Math.max(lastDraftTimestamp, parsed.updated_at)
+      }
+      return {
+        input: typeof parsed.input === 'string' ? parsed.input : '',
+        attachments: storedAttachments(parsed.attachments),
+        updatedAt: Number.isFinite(parsed.updated_at) ? parsed.updated_at : null,
+      }
+    }
+  } catch { /* legacy plain text */ }
+  return {
+    input: typeof raw === 'string' ? raw : '',
+    attachments: [],
+    updatedAt: null,
+  }
+}
+
+function publicDraft(decoded) {
+  return { input: decoded.input, attachments: decoded.attachments }
+}
+
+function encodeDraft(input, attachments) {
+  const safeAttachments = completedAttachments(attachments)
+  if (!input && safeAttachments.length === 0) return null
+  // Date.now() can repeat across several keystrokes. A strictly monotonic
+  // value lets async hydration distinguish a newer durable write from the
+  // older session copy even when quota failed within the same millisecond.
+  lastDraftTimestamp = Math.max(Date.now(), lastDraftTimestamp + 1)
+  return JSON.stringify({
+    type: DRAFT_ENVELOPE,
+    version: DRAFT_VERSION,
+    updated_at: lastDraftTimestamp,
+    input: typeof input === 'string' ? input : '',
+    attachments: safeAttachments.map(({ status: _status, ...attachment }) => attachment),
+  })
+}
+
 /**
  * Reads either the current structured draft or a legacy plain-text draft.
  * Object URLs are deliberately not stored: they stop working when the chat
  * unmounts. Restored image cards point at the already-uploaded chat file.
  */
 export function readComposerDraft(chatId, storage) {
+  if (chatId == null) return { input: '', attachments: [] }
+  const useLiveMirror = storage === undefined
+  const id = draftId(chatId)
+  if (useLiveMirror && liveDrafts.has(id)) {
+    return publicDraft(decodeDraft(liveDrafts.get(id).raw))
+  }
+
   const target = availableStorage(storage)
-  if (!target || chatId == null) return { input: '', attachments: [] }
+  if (!target) return { input: '', attachments: [] }
   try {
     const raw = target.getItem(`draft:${chatId}`)
-    if (!raw) return { input: '', attachments: [] }
-    try {
-      const parsed = JSON.parse(raw)
-      if (parsed?.type === DRAFT_ENVELOPE && parsed.version === 1) {
-        return {
-          input: typeof parsed.input === 'string' ? parsed.input : '',
-          attachments: storedAttachments(parsed.attachments),
-        }
-      }
-    } catch { /* legacy plain text */ }
-    return { input: raw, attachments: [] }
+    if (useLiveMirror && raw) rememberLiveDraft(id, raw, 'session')
+    return publicDraft(decodeDraft(raw))
   } catch {
     return { input: '', attachments: [] }
   }
 }
 
-function evictOneDraft(storage) {
-  try {
-    const draftKeys = []
-    for (let i = 0; i < storage.length; i++) {
-      const key = storage.key(i)
-      if (key?.startsWith('draft:')) draftKeys.push(key)
-    }
-    if (draftKeys.length === 0) return
-    // Chat ids may be integers or UUIDs. Stable lexical order is sufficient:
-    // quota recovery only needs to free one older best-effort draft.
-    draftKeys.sort()
-    storage.removeItem(draftKeys[0])
-  } catch { /* best-effort storage */ }
+/**
+ * Resolve the durable fallback after mount without overwriting a newer local
+ * edit. Versioned session and IndexedDB values carry the same timestamp, so a
+ * reload can recover a newer durable write even when quota left an older
+ * session value behind. Legacy plain-text session drafts win over durable data
+ * because app-to-chat handoffs still intentionally use that format.
+ */
+export async function readComposerDraftAsync(chatId) {
+  if (chatId == null) return { input: '', attachments: [] }
+  const id = draftId(chatId)
+  const revisionAtStart = revisionOf(id)
+  const current = liveDrafts.get(id)
+  if (current?.source === 'live' || current?.source === 'durable') {
+    return publicDraft(decodeDraft(current.raw))
+  }
+
+  let durableRaw = null
+  try { durableRaw = await getIdbValue(id, durableDraftStore) } catch {}
+
+  if (revisionOf(id) !== revisionAtStart) {
+    return publicDraft(decodeDraft(liveDrafts.get(id)?.raw))
+  }
+
+  const latestCurrent = liveDrafts.get(id)
+  const currentDecoded = decodeDraft(latestCurrent?.raw)
+  const durableDecoded = decodeDraft(durableRaw)
+  const currentIsLegacy = latestCurrent?.raw && currentDecoded.updatedAt == null
+  const durableIsNewer = durableRaw && !currentIsLegacy && (
+    !latestCurrent?.raw
+    || (durableDecoded.updatedAt ?? -1) > (currentDecoded.updatedAt ?? -1)
+  )
+
+  if (durableIsNewer) {
+    rememberLiveDraft(id, durableRaw, 'durable')
+    return publicDraft(durableDecoded)
+  }
+  if (latestCurrent?.raw) {
+    queueDurableDraftWrite(id, latestCurrent.raw)
+    return publicDraft(currentDecoded)
+  }
+  if (durableRaw) {
+    rememberLiveDraft(id, durableRaw, 'durable')
+    return publicDraft(durableDecoded)
+  }
+  return { input: '', attachments: [] }
+}
+
+export function clearComposerDraft(chatId, storage) {
+  if (chatId == null) return
+  if (storage === undefined) {
+    rememberLiveDraft(chatId, null, 'live', { advance: true })
+    queueDurableDraftWrite(chatId, null)
+  }
+  const target = availableStorage(storage)
+  if (!target) return
+  try { target.removeItem(`draft:${chatId}`) } catch {}
 }
 
 /**
@@ -103,32 +299,44 @@ export function persistComposerDraft(chatId, input, attachments = [], storage) {
     ? attachments
     : undefined
   const draftAttachments = Array.isArray(attachments) ? attachments : []
-  const target = availableStorage(storage ?? legacyStorage)
-  if (!target || chatId == null) return false
+  const storageOverride = storage ?? legacyStorage
+  const useDurableStore = storageOverride === undefined
+  if (chatId == null) return false
   const key = `draft:${chatId}`
-  const safeAttachments = completedAttachments(draftAttachments)
-  const value = safeAttachments.length > 0
-    ? JSON.stringify({
-        type: DRAFT_ENVELOPE,
-        version: 1,
-        input: typeof input === 'string' ? input : '',
-        attachments: safeAttachments,
-      })
-    : (typeof input === 'string' ? input : '')
+  const value = encodeDraft(input, draftAttachments)
+
+  if (useDurableStore) {
+    rememberLiveDraft(chatId, value, 'live', { advance: true })
+    queueDurableDraftWrite(chatId, value)
+  }
+
+  const target = availableStorage(storageOverride)
+  // Dedicated memory + IndexedDB ownership does not depend on Web Storage
+  // being exposed (private/opaque contexts can deny it altogether).
+  if (!target) return useDurableStore
 
   try {
     if (value) target.setItem(key, value)
     else target.removeItem(key)
     return true
   } catch (error) {
-    if (error?.name !== 'QuotaExceededError' && error?.code !== 22) return false
-    evictOneDraft(target)
+    const quotaExceeded = error?.name === 'QuotaExceededError' || error?.code === 22
+    if (!useDurableStore) return false
+    if (!quotaExceeded) {
+      // Security/privacy modes may expose a Storage object whose writes still
+      // fail. The live mirror and independent durable write remain valid.
+      return true
+    }
+
+    // Owner text outranks a regenerable stream-remount cache. Reclaim that
+    // cache and retry once, but never delete this or another chat's draft.
+    reclaimStoredStreamSnapshots(target)
     try {
       if (value) target.setItem(key, value)
       else target.removeItem(key)
-      return true
     } catch {
-      return false
+      // The live mirror + dedicated IndexedDB write still preserve the draft.
     }
+    return true
   }
 }

--- a/frontend/src/components/ChatView/streamSnapshotCache.js
+++ b/frontend/src/components/ChatView/streamSnapshotCache.js
@@ -25,6 +25,7 @@
  */
 
 export const STREAM_SNAPSHOT_VERSION = 2
+const STREAM_SNAPSHOT_PREFIX = `chat-stream-items:v${STREAM_SNAPSHOT_VERSION}:`
 
 // Trailing-edge coalescing window applied only while >1 chat is mounted.
 export const STREAM_SNAPSHOT_THROTTLE_MS = 250
@@ -39,7 +40,7 @@ let mountedChatCount = 0
 const pendingWrites = new Map()
 
 export function streamSnapshotKey(chatId) {
-  return `chat-stream-items:v${STREAM_SNAPSHOT_VERSION}:${chatId}`
+  return `${STREAM_SNAPSHOT_PREFIX}${chatId}`
 }
 
 function defaultStorage() {
@@ -145,6 +146,40 @@ export function clearStoredStreamSnapshot(chatId, storage = defaultStorage()) {
   } catch {
     // Best-effort cache; ignore storage failures.
   }
+}
+
+/**
+ * Reclaim every regenerable stream snapshot in one storage area.
+ *
+ * Composer drafts are owner-authored data; stream snapshots are a remount cache
+ * backed by the durable partial plus SSE catch-up. If Web Storage fills up,
+ * callers may clear this cache before retrying an owner-data write. Pending
+ * throttled writes for the same storage are dropped as part of the transaction
+ * so they cannot immediately resurrect the bytes that were just reclaimed.
+ */
+export function reclaimStoredStreamSnapshots(storage = defaultStorage()) {
+  if (!storage) return 0
+
+  for (const [chatId, entry] of pendingWrites) {
+    if (entry.storage === storage) dropPending(chatId)
+  }
+
+  let reclaimed = 0
+  try {
+    const keys = []
+    for (let index = 0; index < storage.length; index++) {
+      const key = storage.key(index)
+      if (key?.startsWith(STREAM_SNAPSHOT_PREFIX)) keys.push(key)
+    }
+    for (const key of keys) {
+      storage.removeItem(key)
+      reclaimed += 1
+    }
+  } catch {
+    // Best-effort emergency cleanup. The draft store still has its independent
+    // memory + IndexedDB path when Web Storage is unavailable.
+  }
+  return reclaimed
 }
 
 // Test-only: reset the module's throttle state so specs run in isolation

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -1000,6 +1000,7 @@ export function modeForQueuedSubmission(scrollEl, currentMode) {
  *   revealConversationTail: () => void,
  *   settleSendIntent: (event?: object) => void,
  *   settleStreamingPin: () => void,
+ *   composerResized: () => void,
  * }}
  */
 export default function useScrollMode({
@@ -1073,6 +1074,11 @@ export default function useScrollMode({
   // paneResized() forwards to it (null when no scroll DOM is mounted). Mirrors
   // the forceRevealRef / resumeLayoutAfterGestureRef effect-bridge pattern.
   const paneResizeRunRef = useRef(null)
+  // Footer height changes are scroll geometry: `.chat__list` consumes the
+  // published composer height and the dynamic spacer compensates that padding.
+  // The observer in ChatView notifies this runner rather than writing the CSS
+  // variable itself, so both mutations share the reader-gesture gate.
+  const composerResizeRunRef = useRef(null)
   // Tracks physical tail position independently from modeRef. A stale
   // PIN_USER_MSG can survive after the reader manually returns to the bottom;
   // when the keyboard opens, visualViewport fires AFTER the viewport has
@@ -1469,6 +1475,18 @@ export default function useScrollMode({
         if (scrollRef.current === scrollEl) syncLayout({ forceApply: true })
       }, delay)
     }
+    const replayDeferredLayoutNow = () => {
+      if (!deferredGestureLayoutPending || !layoutOwnsScroll()) return false
+      clearTimeout(deferredGestureLayoutTimer)
+      deferredGestureLayoutTimer = 0
+      deferredGestureLayoutPending = false
+      // The footer CSS variable, compensating spacer, and semantic mode write
+      // must commit in ONE task. If CSS padding + spacer land first and the
+      // HOLD/ANCHOR write waits for the next timer, browser scroll anchoring
+      // can paint one frame 36px away before the controller corrects it.
+      syncLayout({ forceApply: true })
+      return true
+    }
     const resumeLayoutAfterGesture = () => {
       if (!deferredGestureLayoutPending) return
       deferLayoutUntilReaderYields()
@@ -1676,6 +1694,15 @@ export default function useScrollMode({
       settlePinnedMode()
       nearScrollBottomRef.current = isNearScrollBottom(scrollEl)
     }
+    function runComposerResize() {
+      if (!layoutOwnsScroll()) {
+        deferLayoutUntilReaderYields()
+        return
+      }
+      syncLayout()
+    }
+    composerResizeRunRef.current = runComposerResize
+
     syncLayout()
 
     // The scrollApi.paneResized(projectedHeightPx) contract (design §2,
@@ -1901,9 +1928,12 @@ export default function useScrollMode({
           if (anchor) transitionMode(anchor, 'reader:hold-anchor')
         }
         persistMode()
-        // Visibility, not mode, owns reservation. Recompute once against the
-        // final viewport after momentum, never underneath the gesture itself.
-        sizeSpacer()
+        // Recompute once against the final viewport after momentum, never
+        // underneath the gesture itself.
+        // When a footer resize was deferred, replay geometry + the newly
+        // settled semantic mode atomically; a bare sizeSpacer here would let
+        // native scroll anchoring paint an intermediate displaced frame.
+        if (!replayDeferredLayoutNow()) sizeSpacer()
       }
 
       nearScrollBottomRef.current = isNearScrollBottom(scrollEl)
@@ -2217,6 +2247,9 @@ export default function useScrollMode({
       mountMutationObserver?.disconnect()
       ro.disconnect()
       if (paneResizeRunRef.current === runPaneResize) paneResizeRunRef.current = null
+      if (composerResizeRunRef.current === runComposerResize) {
+        composerResizeRunRef.current = null
+      }
       scrollEl.removeEventListener('scroll', onScroll)
       scrollEl.removeEventListener('pointerdown', onUserInput)
       scrollEl.removeEventListener('touchstart', onTouchStartInput)
@@ -2377,6 +2410,10 @@ export default function useScrollMode({
     if (run) run(projectedHeightPx)
   }, [])
 
+  const composerResized = useCallback(() => {
+    composerResizeRunRef.current?.()
+  }, [])
+
   return {
     gestureWindowUntilRef,
     revealed,
@@ -2391,6 +2428,7 @@ export default function useScrollMode({
     reapplyActiveMode,
     settleSendIntent,
     settleStreamingPin,
+    composerResized,
     paneResized,
   }
 }

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -86,6 +86,10 @@ import {
   withoutConfirmedDeletions,
 } from './confirmedDeletion.js'
 import {
+  clearComposerDraft,
+  persistComposerDraft,
+} from '../ChatView/composerDraft.js'
+import {
   reloadWhenWorkerTakesOver,
   shouldRearmShellApply,
   watchForShellUpdateOnForeground,
@@ -2377,9 +2381,9 @@ export default function Shell() {
     const buildingChat = buildingChatId
       && chatsRef.current.find(c => c.id === buildingChatId)
     if (buildingChat) {
+      persistComposerDraft(buildingChatId, report)
       try {
         sessionStorage.setItem('pending-draft', report)
-        sessionStorage.setItem(`draft:${buildingChatId}`, report)
         sessionStorage.removeItem('pending-draft-autosend')
         sessionStorage.removeItem(`draft-autosend:${buildingChatId}`)
       } catch {}
@@ -2959,9 +2963,9 @@ export default function Shell() {
           return
         }
         if (draftText != null) {
+          persistComposerDraft(e.data.chatId, draftText)
           try {
             sessionStorage.setItem('pending-draft', draftText)
-            sessionStorage.setItem(`draft:${e.data.chatId}`, draftText)
             sessionStorage.removeItem('pending-draft-autosend')
             sessionStorage.removeItem(`draft-autosend:${e.data.chatId}`)
           } catch {}
@@ -3269,9 +3273,9 @@ export default function Shell() {
       && !!(draft || forceNew || drawerPushedRef.current || recordHistory)
     if (draft) {
       const draftText = String(draft)
+      persistComposerDraft(chatId, draftText)
       try {
         sessionStorage.setItem('pending-draft', draftText)
-        sessionStorage.setItem(`draft:${chatId}`, draftText)
         if (autoSend) {
           sessionStorage.setItem('pending-draft-autosend', draftText)
           sessionStorage.setItem(`draft-autosend:${chatId}`, draftText)
@@ -3359,7 +3363,7 @@ export default function Shell() {
     // any navigation work; every later list completion is filtered by the same
     // session tombstone until recovery succeeds.
     confirmChatDeleted(id)
-    try { sessionStorage.removeItem(`draft:${id}`) } catch {}
+    clearComposerDraft(id)
     // Evict the cached messages so a future chat-ID collision (e.g.
     // recovery) can't surface stale content.
     chatQueries.messages.remove(queryClient, id)

--- a/tests/second-send-pin.spec.mjs
+++ b/tests/second-send-pin.spec.mjs
@@ -221,10 +221,10 @@ test('A tall-composer send lands once without a visible post-paint correction', 
   ].join('\n')
   await input.fill(multiline)
   await expect(page.locator('[data-chat-surface="painted"] .chat__pill')).toHaveClass(/chat__pill--tall/)
-  // Growing the absolutely-positioned composer increases the list's bottom
-  // clearance. Re-establish the test's stated send-rule precondition after
-  // that geometry change: this case is about the collapse race while the
-  // reader is following, not about overriding a reader away from the tail.
+  // Re-establish FOLLOW_BOTTOM after the composer grows. Footer geometry may
+  // intentionally remain deferred while this gesture owns the viewport, so
+  // the semantic mode — not an intermediate raw content gap — is the send-rule
+  // precondition this test needs.
   await gestureToBottom(page)
 
   // Recreate the real race deterministically: the passive foot observer still
@@ -237,14 +237,7 @@ test('A tall-composer send lands once without a visible post-paint correction', 
     const scroll = document.querySelector('[data-chat-surface="painted"] .chat__scroll')
     if (!chat || !foot || !scroll) throw new Error('missing chat geometry')
     chat.style.setProperty('--composer-h', `${foot.offsetHeight + 48}px`)
-    const spacer = scroll.querySelector('.spacer-dynamic')
     window.__tallComposerPreSend = {
-      contentGap: Math.round(
-        scroll.scrollHeight
-          - (spacer?.offsetHeight || 0)
-          - scroll.scrollTop
-          - scroll.clientHeight,
-      ),
       composer: getComputedStyle(chat).getPropertyValue('--composer-h').trim(),
       foot: foot.offsetHeight,
       mode: scroll.dataset.scrollMode || null,
@@ -266,8 +259,8 @@ test('A tall-composer send lands once without a visible post-paint correction', 
     }, { passive: true })
     return window.__tallComposerPreSend
   })
-  expect(preSend.contentGap).toBeGreaterThanOrEqual(0)
-  expect(preSend.contentGap).toBeLessThan(50)
+  expect(preSend.mode).toBe('FOLLOW_BOTTOM')
+  expect(Number.parseFloat(preSend.composer)).toBe(preSend.foot + 48)
 
   await page.keyboard.press('Enter')
   await expect(page.locator('[data-chat-surface="painted"] .chat__msg--user')).toHaveCount(2, { timeout: 3000 })

--- a/tests/second-send-pin.spec.mjs
+++ b/tests/second-send-pin.spec.mjs
@@ -237,9 +237,17 @@ test('A tall-composer send lands once without a visible post-paint correction', 
     const scroll = document.querySelector('[data-chat-surface="painted"] .chat__scroll')
     if (!chat || !foot || !scroll) throw new Error('missing chat geometry')
     chat.style.setProperty('--composer-h', `${foot.offsetHeight + 48}px`)
+    // The synthetic stale measurement changes list height after the reader's
+    // gesture. Restore the same real-content-tail precondition so this test
+    // isolates the post-submit collapse race rather than manufacturing a
+    // scrolled-up send.
+    scroll.scrollTop = scroll.scrollHeight
     window.__tallComposerPreSend = {
       composer: getComputedStyle(chat).getPropertyValue('--composer-h').trim(),
       foot: foot.offsetHeight,
+      contentGap: Math.round(
+        scroll.scrollHeight - scroll.scrollTop - scroll.clientHeight,
+      ),
       mode: scroll.dataset.scrollMode || null,
     }
     window.__mobiusChatScrollTrace = {
@@ -261,6 +269,7 @@ test('A tall-composer send lands once without a visible post-paint correction', 
   })
   expect(preSend.mode).toBe('FOLLOW_BOTTOM')
   expect(Number.parseFloat(preSend.composer)).toBe(preSend.foot + 48)
+  expect(preSend.contentGap).toBeLessThanOrEqual(1)
 
   await page.keyboard.press('Enter')
   await expect(page.locator('[data-chat-surface="painted"] .chat__msg--user')).toHaveCount(2, { timeout: 3000 })


### PR DESCRIPTION
## Summary
- keep footer height, tail spacing, and scroll ownership atomic after reader gestures
- keep viewport-derived question and resume cues out of footer flow
- preserve unfinished text and completed attachments across chat switches, reloads, and storage quota pressure
- route draft handoffs, clearing, deletion, and logout through one state owner

## Why
Chat footer controls can appear or disappear while a reader moves through a long conversation. Publishing footer height before its compensating spacer and scroll-mode update allowed a displaced frame to paint before the controller corrected it.

The offscreen question and resume cues created a second feedback path: scrolling their target card into view removed the cue from footer flow, shortened the page, and reversed the viewport. They now float above the composer without participating in transcript geometry.

Draft quota recovery could also delete another conversation's unfinished message. Drafts now keep an immediate in-page mirror plus an independent durable copy, reclaim only regenerable stream cache under pressure, and reject stale hydration after a newer edit.

## Testing
- `npm test` (2,149 regular tests and 66 hook tests)
- `npm run build`
- authenticated browser regression checks for long-chat reader scrolling, Q&A cue visibility, activity disclosure expansion, chat switching, and reload recovery under forced storage failure