### PR TITLE
Keep tab strip height consistent across pane layouts

### DIFF
--- a/frontend/src/components/Shell/Shell.css
+++ b/frontend/src/components/Shell/Shell.css
@@ -10,9 +10,9 @@
 .shell {
   --desktop-sidebar-width: 320px;
   /* Shared geometry contract for fixed shell-level overlays. The notice rail
-     reads these instead of guessing at chrome height from the root font size. */
+     reads this instead of guessing at chrome height from the root font size.
+     Shell publishes --shell-tabstrip-height from paneModel.STRIP_H. */
   --shell-bar-height: 58px;
-  --shell-tabstrip-height: 41px;
   position: fixed;
   inset: 0;
   display: flex;

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -474,6 +474,7 @@ export default function Shell() {
   const shellRootStyle = useMemo(() => ({
     ...(beatRootVars || {}),
     '--desktop-sidebar-width': `${desktopSidebarWidth}px`,
+    '--shell-tabstrip-height': `${paneModel.STRIP_H}px`,
   }), [beatRootVars, desktopSidebarWidth])
   // The key SINGLE mode paints beneath / within either directional beat. It drives
   // destination AppCanvas insets before the first frame so neither direction jumps.

--- a/frontend/src/components/Shell/__tests__/tabStripHeight.test.js
+++ b/frontend/src/components/Shell/__tests__/tabStripHeight.test.js
@@ -1,0 +1,20 @@
+// Tab-strip geometry stays identical when a workspace changes leaf count.
+
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const shell = readFileSync(new URL('../Shell.jsx', import.meta.url), 'utf8')
+const shellCss = readFileSync(new URL('../Shell.css', import.meta.url), 'utf8')
+const paneStrip = readFileSync(new URL('../PaneStrip.jsx', import.meta.url), 'utf8')
+
+test('single-pane and tiled tab strips share the pane-model height', () => {
+  assert.match(shell, /'--shell-tabstrip-height': `\$\{paneModel\.STRIP_H\}px`/)
+  assert.match(shellCss, /height:\s*var\(--shell-tabstrip-height\)/)
+  assert.match(paneStrip, /height:\s*STRIP_H/)
+  assert.doesNotMatch(
+    shellCss,
+    /^\s*--shell-tabstrip-height:\s*\d+px/m,
+    'the single-pane strip must not introduce a second numeric height source',
+  )
+})

--- a/frontend/src/components/Shell/__tests__/toastPlacement.test.js
+++ b/frontend/src/components/Shell/__tests__/toastPlacement.test.js
@@ -18,6 +18,10 @@ const shellCss = readFileSync(
   new URL('../Shell.css', import.meta.url),
   'utf8',
 )
+const paneModel = readFileSync(
+  new URL('../paneModel.js', import.meta.url),
+  'utf8',
+)
 const intentNavigation = readFileSync(
   new URL('../useAppIntentNavigation.js', import.meta.url),
   'utf8',
@@ -39,11 +43,13 @@ test('Shell keeps timeout identity stable and remounts repeated notices', () => 
 })
 
 test('toast uses shell-owned chrome geometry, not composer or font guesses', () => {
+  const stripHeight = paneModel.match(/export const STRIP_H = (\d+)/)?.[1]
+  assert.ok(stripHeight, 'paneModel must publish a numeric tab-strip height')
   assert.match(css, /right:\s*max\(1rem,\s*env\(safe-area-inset-right/)
   assert.match(css, /var\(--shell-bar-height,\s*58px\)/)
-  assert.match(css, /var\(--shell-tabstrip-height,\s*41px\)/)
+  assert.match(css, new RegExp(`var\\(--shell-tabstrip-height,\\s*${stripHeight}px\\)`))
   assert.match(shellCss, /--shell-bar-height:\s*58px/)
-  assert.match(shellCss, /--shell-tabstrip-height:\s*41px/)
+  assert.match(shell, /'--shell-tabstrip-height': `\$\{paneModel\.STRIP_H\}px`/)
   assert.match(shellCss, /height:\s*calc\(var\(--shell-bar-height\)/)
   assert.match(shellCss, /height:\s*var\(--shell-tabstrip-height\)/)
   assert.match(css, /@media \(max-width: 700px\)/)

--- a/frontend/src/components/Shell/paneModel.js
+++ b/frontend/src/components/Shell/paneModel.js
@@ -44,9 +44,10 @@ export const COMPACT_MIN_H = 520
 // Tiled and focused panes both use the full content rect edge-to-edge.
 export const PANE_GAP = 7
 
-// Height of a per-pane tab strip. A pane's CONTENT rect is its pane rect minus
-// this strip row (design §2). The renderer and the divider drag both subtract
-// it, so it lives here as the single source of truth.
+// Height of every workspace tab strip, including the flow strip used by a
+// one-leaf workspace. A pane's CONTENT rect is its pane rect minus this strip
+// row (design §2). Shell publishes it as --shell-tabstrip-height so the flow
+// and positioned renderers cannot drift.
 export const STRIP_H = 34
 
 // Multi-pane exposure waits for the pane-aware back/sentinel work (stage B).

--- a/frontend/src/components/ui/Toast.css
+++ b/frontend/src/components/ui/Toast.css
@@ -6,7 +6,7 @@
   position: fixed;
   top: calc(
     var(--shell-bar-height, 58px)
-    + var(--shell-tabstrip-height, 41px)
+    + var(--shell-tabstrip-height, 34px)
     + 0.5rem
     + env(safe-area-inset-top, 0px)
   );


### PR DESCRIPTION
## Summary
- use the workspace strip height for both one-pane and tiled layouts
- keep toast placement aligned with the shared chrome geometry
- add regression coverage preventing a separate single-pane height

## Testing
- `npm run test:lib` (2,145 tests)