### PR TITLE
Keep startup context out of slash command arguments

### DIFF
--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -5344,10 +5344,17 @@ async def _run_chat_impl_with_db(
   # the separate Stop-handoff marker clear; continuation handoff keeps the
   # marker continuously set across the whole chain of turns.
 
-  # On the first message of a session, prepend only bounded recent-chat digests.
-  # Knowledge-graph data is never pulled here; an installed system app may teach
-  # the agent to make a separate prompt-scoped recall call. The system prompt
-  # stays static for API-level caching; dynamic chat continuity travels here.
+  # On the first message of a session, gather bounded recent-chat digests and
+  # the skills inventory as one-time startup context. Knowledge-graph data is
+  # never pulled here; an installed system app may teach the agent to make a
+  # separate prompt-scoped recall call.
+  #
+  # Startup context belongs to the first-turn system prompt, not the user
+  # message. CLI slash commands claim their entire message as an argument, so
+  # appending this context to `/goal` both pollutes its objective and can exceed
+  # the command's length limit. Keep it out of the persisted prompt snapshot as
+  # well, so later turns reuse the stable constitution bytes.
+  startup_context = ""
   if not session_id:
     # `build_memory_block` is pure; the activity emit + envelope live here.
     eligible_chat_ids = {
@@ -5406,10 +5413,6 @@ async def _run_chat_impl_with_db(
       startup_context = experience_block
       if skills_block:
         startup_context = f"{startup_context}\n\n{skills_block}"
-      if is_slash_command:
-        user_message = f"{user_message}\n\n{startup_context}"
-      else:
-        user_message = f"{startup_context}\n\n{user_message}"
 
   if app_context_block:
     # The report BODY goes right after the </app_context> line, but only on
@@ -5619,6 +5622,11 @@ async def _run_chat_impl_with_db(
       _publish_chat_run_finished(chat_id)
     db.close()
     return disposition
+
+  # This is deliberately request-scoped rather than part of the immutable
+  # snapshot persisted above. On resumed turns `startup_context` is empty.
+  if startup_context:
+    system_prompt = f"{system_prompt}\n\n{startup_context}"
 
   # A close() below detaches chat_row. Precompute the only provider-time value
   # that still reads it (the bounded Claude fallback for a missing CLI

--- a/backend/tests/test_chat_agent_settings.py
+++ b/backend/tests/test_chat_agent_settings.py
@@ -731,7 +731,8 @@ def test_run_chat_passes_deployed_skill_and_picker_settings(
        ):
     asyncio.run(_scenario())
 
-  assert captured["skill_text"] == "DEPLOYED-SKILL"
+  assert captured["skill_text"].startswith("DEPLOYED-SKILL\n\n")
+  assert "<agent_experience>" in captured["skill_text"]
   assert captured["agent_settings"]["model"] == "claude-opus-4-5"
   db.expire_all()
   persisted = db.query(models.Chat).filter(models.Chat.id == chat.id).one()

--- a/backend/tests/test_goal_startup_context.py
+++ b/backend/tests/test_goal_startup_context.py
@@ -1,0 +1,69 @@
+"""First-turn startup context stays out of CLI slash-command arguments."""
+
+import asyncio
+
+from app import chat as chat_mod, memory, models, schemas
+from app.broadcast import create_broadcast
+
+
+def test_goal_receives_startup_context_only_through_system_prompt(
+  client, auth, db, monkeypatch,
+):
+  chat_id = client.post(
+    "/api/chats", json={"title": "Goal prompt routing"}, headers=auth,
+  ).json()["id"]
+  digest = "RECENT_CHAT_DIGEST_SENTINEL"
+  skills = "<available_skills>SKILL_SENTINEL</available_skills>"
+
+  monkeypatch.setattr(
+    chat_mod.memory,
+    "build_memory_block",
+    lambda *_args, **_kwargs: memory.MemoryBlock(text=digest),
+  )
+  monkeypatch.setattr(
+    chat_mod, "_build_available_skills_block", lambda _data_dir: skills,
+  )
+  monkeypatch.setattr(
+    "app.providers.ClaudeProvider.check_auth",
+    lambda self, _data_dir: None,
+  )
+  monkeypatch.setattr(
+    "app.providers.ClaudeProvider.ensure_auth",
+    lambda self, _data_dir: asyncio.sleep(0),
+  )
+  captured = {}
+
+  async def _runner(**kwargs):
+    captured.update(kwargs)
+    return {"session_id": "goal-session", "cost_usd": 0.0, "error": None}
+
+  monkeypatch.setattr(
+    "app.claude_sdk_runner.run_claude_sdk_turn", _runner,
+  )
+  create_broadcast(chat_id)
+  asyncio.run(chat_mod._run_chat_impl(
+    messages=[schemas.ChatMessage(
+      role="user", content="/goal keep the objective clean",
+    )],
+    chat_id=chat_id,
+    session_id=None,
+    provider_id="claude",
+    run_gen=chat_mod.current_run_generation(chat_id),
+  ))
+
+  assert captured["user_message"].startswith(
+    "/goal keep the objective clean"
+  )
+  assert digest not in captured["user_message"]
+  assert skills not in captured["user_message"]
+  assert digest in captured["skill_text"]
+  assert skills in captured["skill_text"]
+
+  db.expire_all()
+  chat = db.query(models.Chat).filter(models.Chat.id == chat_id).one()
+  snapshot = db.get(
+    models.SystemPromptSnapshot, chat.system_prompt_snapshot_id,
+  )
+  assert snapshot is not None
+  assert digest not in snapshot.content
+  assert skills not in snapshot.content


### PR DESCRIPTION
## Summary
- route first-session recent-chat digests and the skills inventory through the request-scoped system prompt
- keep startup context out of slash-command arguments and out of the stable prompt snapshot
- align the existing provider contract test and add regression coverage for provider input plus snapshot persistence

## Testing
- `scripts/wt-pytest.sh tests/test_goal_startup_context.py tests/test_chat_agent_settings.py tests/test_time_context.py tests/test_app_system_prompt.py -q` (55 passed)
- `scripts/test.sh --fast` (58 passed)
- complete host backend sweep excluding the host-incompatible no-clone route fixture (3,397 passed, 4 skipped, 1 deselected)
- containerized full gate unavailable in this runtime; required CI rerun after the reviewed head is pushed
