### PR TITLE
Refresh chat drawer order after steering

### DIFF
--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -246,7 +246,7 @@ export default function ChatView({
   onOpenApp,
   onInternalNav,
   onMessageStart,
-  onQuestionAnswered,
+  onOwnerActivity,
   onVoiceListeningChange,
   showPicker = true,
   embedded = false,
@@ -774,8 +774,8 @@ export default function ChatView({
   // declared further down.
   const onMessageStartRef = useRef(onMessageStart)
   onMessageStartRef.current = onMessageStart
-  const onQuestionAnsweredRef = useRef(onQuestionAnswered)
-  onQuestionAnsweredRef.current = onQuestionAnswered
+  const onOwnerActivityRef = useRef(onOwnerActivity)
+  onOwnerActivityRef.current = onOwnerActivity
   const onFirstMessageRef = useRef(onFirstMessage)
   onFirstMessageRef.current = onFirstMessage
   const onStreamEndRef = useRef(onStreamEnd)
@@ -1298,6 +1298,10 @@ export default function ChatView({
         if (cid != null) pendingQueue.cancelByCid(cid)
       }
       forgetSendIntent({ cidList: steeredMessages.map(cidOf) })
+      // This event is the backend's authoritative transcript commit. Refresh
+      // the shell's chat list here so a deferred steer advances drawer recency
+      // at the cut, rather than waiting for the entire agent turn to finish.
+      onOwnerActivityRef.current?.()
     },
   })
   useEffect(() => {
@@ -2290,6 +2294,13 @@ export default function ChatView({
             pendingQueue.cancelByCid(queuedMsg.cid)
           }
         }
+        if (result?.status === 'queued' || result?.status === 'steered') {
+          // The server has accepted deliberate owner activity. In particular,
+          // queueing behind an active turn does not emit a new-run event, so
+          // the drawer must refresh from this commit boundary instead of
+          // remaining stale until the current run ends.
+          onOwnerActivityRef.current?.()
+        }
         // Race: server said "started" though we expected queued.
         if (result?.status === 'started') {
           if (Array.isArray(result.message?._consumed_cids)) {
@@ -2694,7 +2705,7 @@ export default function ChatView({
       // owner's chat list now makes this deliberate interaction visible in
       // drawer recency immediately, instead of waiting for the resumed turn to
       // finish and emit its terminal refresh.
-      onQuestionAnsweredRef.current?.()
+      onOwnerActivityRef.current?.()
       if (questionId) setLiveQuestionId(prev => prev === questionId ? null : prev)
       return true
     } catch (err) {
@@ -3143,6 +3154,10 @@ export default function ChatView({
           // cids.
           for (const c of consumePendingCids) pendingQueue.cancelByCid(c)
         }
+        // This can expose the row's already-durable enqueue recency
+        // immediately. The later steered_into_turn event refreshes again at
+        // the authoritative transcript cut, when steer recency itself moves.
+        onOwnerActivityRef.current?.()
       }
       if (result?.status !== 'steered') {
         restoreReplacedSendIntent(

--- a/frontend/src/components/ChatView/__tests__/ownerActivityRefresh.test.js
+++ b/frontend/src/components/ChatView/__tests__/ownerActivityRefresh.test.js
@@ -1,0 +1,82 @@
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+const chatView = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8')
+const paneChatView = readFileSync(
+  new URL('../../Shell/PaneChatView.jsx', import.meta.url),
+  'utf8',
+)
+
+function slice(source, fromNeedle, toNeedle) {
+  const from = source.indexOf(fromNeedle)
+  assert.ok(from >= 0, `expected to find ${fromNeedle}`)
+  const to = source.indexOf(toNeedle, from)
+  assert.ok(to > from, `expected to find ${toNeedle} after ${fromNeedle}`)
+  return source.slice(from, to)
+}
+
+test('the pane gives all committed owner activity one stable drawer refresh', () => {
+  assert.match(paneChatView, /onOwnerActivity=\{refreshChats\}/)
+  assert.doesNotMatch(paneChatView, /onQuestionAnswered/,
+    'question answers must not keep a one-off parallel refresh callback')
+  assert.match(chatView, /const onOwnerActivityRef = useRef\(onOwnerActivity\)/)
+})
+
+test('an accepted mid-turn queue or direct steer refreshes drawer recency', () => {
+  const queuePath = slice(
+    chatView,
+    'const result = await queueRequest',
+    '// Race: server said "started" though we expected queued.',
+  )
+  assert.match(
+    queuePath,
+    /if \(result\?\.status === 'queued' \|\| result\?\.status === 'steered'\) \{[\s\S]*?onOwnerActivityRef\.current\?\.\(\)/,
+    'accepted owner activity behind an existing run must not wait for run-end',
+  )
+  const duplicate = slice(
+    queuePath,
+    "if (result?.status === 'duplicate') {",
+    "if (result?.status === 'queued') {",
+  )
+  assert.doesNotMatch(duplicate, /onOwnerActivityRef/,
+    'a duplicate acknowledgement must not manufacture new recency')
+})
+
+test('a deferred steer refreshes again at its authoritative transcript cut', () => {
+  const cut = slice(
+    chatView,
+    'onSteeredIntoTurn: ({',
+    '// System run activity is a structured sequence',
+  )
+  const commit = cut.indexOf('commitMessages(prev => insertMessageBatchByTs')
+  const refresh = cut.indexOf('onOwnerActivityRef.current?.()')
+  assert.ok(commit >= 0 && refresh > commit,
+    'drawer refresh must follow the committed steer event, not predict its cut')
+})
+
+test('fast-forward exposes durable enqueue recency while the cut settles', () => {
+  const fastForward = slice(
+    chatView,
+    'async function steerRowsImpl(steerRowsList) {',
+    '// STEER (fast-forward): inject the queued messages into the LIVE turn',
+  )
+  const accepted = slice(
+    fastForward,
+    "if (result?.status === 'steered') {",
+    "if (result?.status !== 'steered') {",
+  )
+  assert.match(accepted, /onOwnerActivityRef\.current\?\.\(\)/)
+})
+
+test('question answers share the same owner-activity refresh boundary', () => {
+  const answerPath = slice(
+    chatView,
+    'const doSendSilent = useCallback',
+    'function handleSubmit(e)',
+  )
+  const response = answerPath.indexOf('const response = await streamSend')
+  const refresh = answerPath.indexOf('onOwnerActivityRef.current?.()')
+  assert.ok(response >= 0 && refresh > response,
+    'a question answer refresh belongs after its successful write')
+})

--- a/frontend/src/components/Shell/PaneChatView.jsx
+++ b/frontend/src/components/Shell/PaneChatView.jsx
@@ -102,7 +102,7 @@ function PaneChatView({
         onOpenApp={handleOpenApp}
         onInternalNav={onInternalNav}
         onMessageStart={handleMessageStart}
-        onQuestionAnswered={refreshChats}
+        onOwnerActivity={refreshChats}
         onVoiceListeningChange={markVoiceListening}
         composerRequest={composerRequest}
         onComposerRequestHandled={onComposerRequestHandled}


### PR DESCRIPTION
## Summary
- refresh the chat drawer after queued owner messages and accepted direct steers
- refresh again when a deferred steer commits its transcript cut
- share the same owner-activity refresh boundary with question answers

Follow-up to #332, which established owner-activity ordering on the server; this fixes the client list remaining stale until the active turn finishes.

## Testing
- `npm test`