### PR TITLE
Prevent stalled steering from blocking chat controls

### DIFF
--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -262,11 +262,10 @@ def steered_into_turn_event(stored_messages: list[dict]) -> dict:
   live stream here and re-base it" signal. It means the transcript split has
   COMMITTED: A1 sealed, these rows appended after it, the sink reset for A2. So
   it may only be published from the instant the split really happens — by the
-  Claude runner immediately after `split_for_steer`, and by the steer route for
-  Codex (whose `turn.steer()` has no interrupt boundary, so the route IS the
-  seal point). Two publishers, one builder, so the wire shape cannot drift.
+  live provider handle through the owning sink, after provider acknowledgement
+  and ``split_for_steer`` both complete.
 
-  Publishing it at HTTP arrival on the deferred (Claude) path is what made a
+  Publishing it at HTTP arrival on a deferred path is what made a
   steer paint duplicated output for the rest of the turn: every block the runner
   streamed between arrival and the real seal was accumulated into the sealed A1
   AND left at the head of the client's freshly re-based stream. The deferred
@@ -290,6 +289,21 @@ def steered_into_turn_event(stored_messages: list[dict]) -> dict:
     # single steered row.
     "ts": stored_messages[-1].get("ts"),
     "content": stored_messages[-1].get("content", ""),
+  }
+
+
+def steer_delivery_failed_event(consume_pending_cids: list[str]) -> dict:
+  """Tell the client that an admitted steer stayed in the durable queue.
+
+  Provider steering is settled by the live runner after the HTTP request has
+  returned. If that provider-side delivery fails or the turn ends first, the
+  rows remain in ``pending_messages`` and are still safe, but the client must
+  release their temporary "being steered" presentation reservation and show
+  them as ordinary queued work again.
+  """
+  return {
+    "type": "steer_delivery_failed",
+    "consume_pending_cids": list(consume_pending_cids),
   }
 
 
@@ -792,20 +806,16 @@ class _ChatEventSink:
     Codex. Stop (interrupt + fresh turn) is the path with a real boundary on
     both providers.
 
-    Called from the RUNNER at turn-end for Claude (`_seal_steer_split`, where
-    the pre-interrupt A1 is complete — the route cannot split at HTTP arrival
-    because A1 has not streamed yet, which merged A1+A2 after the steered row)
-    and from the steer ROUTE for Codex (`_split_steer_at_route`, which injects
-    into the running turn with no interrupt boundary). Both run on the one
-    FastAPI event loop, so it is serialized with this sink's `publish()`
-    snapshots. The pre-steer assistant text (A1) becomes its own trailing
-    assistant message, the steered user message (Q2) is appended at the END,
-    and the
-    sink resets its blocks so the post-steer continuation (A2) accumulates
-    fresh and the next snapshot appends it as a NEW assistant message. The
-    reset is what preserves the durable order A1, Q2, A2: without it A1+A2
-    persist as one message with Q2 inserted before them, reloading as
-    Q1, Q2, A1A2.
+    Called by the live provider handle after steering delivery is acknowledged:
+    Claude at its interrupt boundary, Codex when ``turn.steer()`` returns.
+    Both run on the one FastAPI event loop, so the cut is serialized with this
+    sink's ``publish()`` snapshots. The pre-steer assistant text (A1) becomes
+    its own trailing assistant message, the steered user message (Q2) is
+    appended at the END, and the sink resets its blocks so the post-steer
+    continuation (A2) accumulates fresh and the next snapshot appends it as a
+    NEW assistant message. The reset is what preserves the durable order A1,
+    Q2, A2: without it A1+A2 persist as one message with Q2 inserted before
+    them, reloading as Q1, Q2, A1A2.
 
     Race-free without a lock: `_steering` is set and the blocks captured +
     reset SYNCHRONOUSLY before the first `await`, so any continuation delta
@@ -875,6 +885,41 @@ class _ChatEventSink:
     finally:
       self._steering = False
 
+  async def commit_steer_cut(
+    self, user_msg: dict | list[dict], consume_pending_cids: list[str],
+  ) -> dict:
+    """Commit and publish one authoritative steering cut.
+
+    The sink owns both sides of the boundary: ``split_for_steer`` persists
+    Q1/A1/Q2 ordering, then this method publishes ``steered_into_turn`` on the
+    same broadcast before any caller can mistake provider acceptance for a
+    durable cut. Provider runners call this only after their control channel
+    has acknowledged the steering input.
+    """
+    user_msgs = user_msg if isinstance(user_msg, list) else [user_msg]
+    stored_result = await self.split_for_steer(
+      user_msgs, consume_pending_cids,
+    )
+    stored_messages = (
+      stored_result.get("stored_messages")
+      if isinstance(stored_result, dict)
+      else None
+    )
+    if not isinstance(stored_messages, list) or not stored_messages:
+      stored_messages = user_msgs
+    try:
+      self.bc.publish(steered_into_turn_event(stored_messages))
+    except Exception:
+      # The transcript cut already committed. A lost notification must not be
+      # reported as a delivery failure (which would falsely claim the rows are
+      # still queued and invite a duplicate retry). Turn completion/refetch
+      # repairs the client; durability and exactly-once ownership win here.
+      _get_logger().exception(
+        "publishing the steer cut failed chat_id=%s; the split committed but "
+        "the client must refetch", self.chat_id,
+      )
+    return stored_result
+
   async def publish_question(self, event: ChatEvent) -> None:
     """Save-before-broadcast for an AskUserQuestion card.
 
@@ -941,6 +986,50 @@ class _ChatEventSink:
     # snapshot in publish() doesn't redundantly re-commit the same state
     # immediately after.
     self._last_save = time.monotonic()
+
+
+async def commit_steer_cut(
+  chat_id: str,
+  user_msg: dict | list[dict],
+  consume_pending_cids: list[str],
+  *,
+  sink=None,
+) -> dict:
+  """Commit a provider-acknowledged cut through the owning live sink.
+
+  Production runners pass their exact sink so the cut lands on the same event
+  log as the streamed A1/A2 blocks. The fallback is for out-of-band callers and
+  isolated tests that have no sink: it still consumes the durable rows and
+  publishes on the chat broadcast, preserving the same exactly-once contract.
+  """
+  target = sink or get_active_sink(chat_id)
+  commit = getattr(target, "commit_steer_cut", None)
+  if callable(commit):
+    return await commit(user_msg, consume_pending_cids)
+
+  user_msgs = user_msg if isinstance(user_msg, list) else [user_msg]
+  ack = get_writer().submit(
+    AppendSteeredUserMessage(
+      chat_id=chat_id,
+      run_token="",
+      user_msgs=user_msgs,
+      consume_pending_cids=consume_pending_cids,
+    )
+  )
+  stored_result = await _await_ack(ack)
+  raw_bc = get_broadcast(chat_id)
+  if raw_bc is not None:
+    stored_messages = stored_result.get("stored_messages")
+    if not isinstance(stored_messages, list) or not stored_messages:
+      stored_messages = user_msgs
+    try:
+      raw_bc.publish(steered_into_turn_event(stored_messages))
+    except Exception:
+      _get_logger().exception(
+        "publishing the fallback steer cut failed chat_id=%s; the split "
+        "committed but the client must refetch", chat_id,
+      )
+  return stored_result
 
 
 _SKILL_TEXT_CACHE: str | None = None

--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -383,19 +383,19 @@ class AppendPending(_Command):
 class AppendSteeredUserMessage(_Command):
   """Append a mid-turn steered user message at the END of the transcript.
 
-  Used by both steer paths (routes/chats_stream.py + the sink's
-  `split_for_steer`): when a send lands while a turn is streaming and
-  `steer_into_active_turn` accepts it, the user message belongs in the
-  TRANSCRIPT, not the pending queue — the live turn already saw the text,
-  so it is part of this turn rather than a queued follow-up.
+  Used by the live sink's `split_for_steer`: when a send lands while a turn
+  is streaming and the provider acknowledges it, the user message belongs
+  in the TRANSCRIPT, not the pending queue — the live turn already saw the
+  text, so it is part of this turn rather than a queued follow-up.
 
   Placement is at the END so a reload renders Q1, A1, Q2, A2 (the steered
   user row BETWEEN the pre-steer assistant text and the post-steer
   continuation). That ordering is exact for Claude; for Codex the A1/A2 cut
   is best-effort because turn.steer() has no turn boundary (see
-  `_ChatEventSink.split_for_steer`). The split path seals the streamed-so-far assistant text
-  as its own message FIRST, so when this command runs the trailing message
-  is that sealed assistant — appending the user row after it leaves
+  `_ChatEventSink.split_for_steer`). The split path seals the
+  streamed-so-far assistant text as its own message FIRST, so when this
+  command runs the trailing message is that sealed assistant — appending the
+  user row after it leaves
   `chat.messages[-1]` a user message, which makes the runner's next
   `update_last_assistant_message` / `Finalize` snapshot APPEND the
   continuation as a fresh assistant rather than merging it into the

--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -67,6 +67,7 @@ import re
 import signal
 import shutil
 import time
+from dataclasses import dataclass
 from typing import Any, Callable
 
 from app.codex_appserver import _extract_bash_command
@@ -443,6 +444,19 @@ async def _persist_session_id(db, chat_id: str, session_id: str | None) -> None:
     )
 
 
+@dataclass
+class _CodexSteerAttempt:
+  """One admitted, durably-reserved Codex steering delivery."""
+
+  message: str
+  user_msgs: list[dict]
+  consume_pending_cids: list[str]
+  task: asyncio.Task[None] | None = None
+  commit_started: bool = False
+  settled: bool = False
+  failure_published: bool = False
+
+
 class ActiveCodexTurn:
   """Stop + steer handle registered for SDK-backed Codex turns.
 
@@ -461,11 +475,13 @@ class ActiveCodexTurn:
     turn: Any,
     chat_id: str,
     process_group_id: int | None = None,
+    sink: Any | None = None,
   ):
     self.chat_id = chat_id
     self.kind = RunnerKind.CODEX_SDK
     self.thread = thread
     self.turn = turn
+    self._sink = sink
     self._process_group_id = process_group_id
     # A retained PGID must never be signalled twice: after the first kill the
     # kernel may eventually reuse that number for an unrelated process group.
@@ -474,6 +490,7 @@ class ActiveCodexTurn:
     # synchronously before turn.steer's first await so a not-yet-registered
     # question cannot park the SDK reader ahead of the steer acknowledgement.
     self._steer_in_flight = False
+    self._steer_attempt: _CodexSteerAttempt | None = None
     # Set synchronously before interrupt()'s first await. The SDK reports both
     # user-requested stops and unexpected provider interruption with the same
     # TurnStatus.interrupted value; this local fact is what lets terminal
@@ -489,12 +506,22 @@ class ActiveCodexTurn:
     return self._steer_in_flight
 
   @property
+  def is_steerable(self) -> bool:
+    """Whether this registered handle exposes a live Codex turn."""
+    return (
+      self.turn is not None
+      and not self._finished.done()
+      and not self._interrupt_requested
+    )
+
+  @property
   def interrupt_requested(self) -> bool:
     return self._interrupt_requested
 
   async def interrupt(self) -> None:
     """Signals the live turn and waits for runner-side drain."""
     self._interrupt_requested = True
+    self._reject_pending_steer()
     try:
       await self.turn.interrupt()
     except Exception as exc:
@@ -527,6 +554,7 @@ class ActiveCodexTurn:
 
   async def force_stop(self, timeout: float = 5.0) -> bool:
     """One-shot hard stop for this turn's verified private process group."""
+    self._reject_pending_steer()
     if not self._force_stop_started:
       if self._process_group_id is None:
         return False
@@ -549,8 +577,176 @@ class ActiveCodexTurn:
 
   def mark_finished(self) -> None:
     """Resolves the stop waiter once the runner is fully drained."""
+    self._reject_pending_steer()
     if not self._finished.done():
       self._finished.set_result(None)
+
+  def _steer_broadcast(self):
+    raw_bc = getattr(self._sink, "bc", None)
+    if raw_bc is not None and callable(getattr(raw_bc, "publish", None)):
+      return raw_bc
+    from app.broadcast import get_broadcast
+    return get_broadcast(self.chat_id)
+
+  def _reject_pending_steer(
+    self,
+    attempt: _CodexSteerAttempt | None = None,
+    *,
+    after_commit_failure: bool = False,
+  ) -> None:
+    """Release one uncommitted steer back to the durable pending queue."""
+    attempt = attempt or self._steer_attempt
+    if attempt is None or attempt.settled:
+      return
+    # Once the transcript cut has begun under the queue lock, it owns the row:
+    # Stop waits behind that lock and must observe the consumed queue rather
+    # than simultaneously restoring/resending the same cid.
+    if attempt.commit_started and not after_commit_failure:
+      return
+    attempt.settled = True
+    if attempt.failure_published:
+      return
+    attempt.failure_published = True
+    raw_bc = self._steer_broadcast()
+    if raw_bc is None:
+      return
+    from app.chat import steer_delivery_failed_event
+    raw_bc.publish(
+      steer_delivery_failed_event(attempt.consume_pending_cids)
+    )
+
+  async def _commit_steer_cut(
+    self, attempt: _CodexSteerAttempt,
+  ) -> None:
+    """Persist + publish the accepted cut through the turn's owning sink."""
+    from app.chat import commit_steer_cut
+    await commit_steer_cut(
+      self.chat_id,
+      attempt.user_msgs,
+      attempt.consume_pending_cids,
+      sink=self._sink,
+    )
+
+  async def _deliver_steer(
+    self, attempt: _CodexSteerAttempt,
+  ) -> None:
+    """Settle provider delivery away from the HTTP request and queue lock."""
+    try:
+      await self.turn.steer(attempt.message)
+      if (
+        attempt.settled
+        or self._finished.done()
+        or self._interrupt_requested
+        or registry.get_handle(self.chat_id, RunnerKind.CODEX_SDK) is not self
+      ):
+        self._reject_pending_steer(attempt)
+        return
+
+      # Only the short durable cut takes the queue lock. Provider I/O above can
+      # wait forever without blocking Send or Stop. Recheck after acquisition:
+      # Stop bumps/clears first when it wins, while a cut that wins consumes the
+      # cid before Stop decides which queued rows to resend.
+      from app import chat_queue
+      async with chat_queue.get_lock(self.chat_id):
+        if (
+          attempt.settled
+          or self._finished.done()
+          or self._interrupt_requested
+          or registry.get_handle(
+            self.chat_id, RunnerKind.CODEX_SDK,
+          ) is not self
+        ):
+          self._reject_pending_steer(attempt)
+          return
+        attempt.commit_started = True
+        try:
+          await self._commit_steer_cut(attempt)
+        except Exception:
+          log.exception(
+            "Codex steer cut failed chat_id=%s; row remains queued",
+            self.chat_id,
+          )
+          self._reject_pending_steer(
+            attempt, after_commit_failure=True,
+          )
+          return
+        attempt.settled = True
+    except asyncio.CancelledError:
+      self._reject_pending_steer(attempt)
+      raise
+    except (AttributeError, TypeError):
+      self._reject_pending_steer(attempt)
+    except Exception as exc:
+      if _is_closed_turn_error(exc):
+        log.info(
+          "Codex steer reached a closed turn chat_id=%s", self.chat_id,
+        )
+      else:
+        log.warning(
+          "Codex steer delivery failed chat_id=%s: %s",
+          self.chat_id, exc,
+        )
+      self._reject_pending_steer(attempt)
+    finally:
+      if self._steer_attempt is attempt:
+        self._steer_attempt = None
+        self._steer_in_flight = False
+
+  async def finish_steer_before_turn_end(self) -> None:
+    """Settle a committing cut or reject a still-provider-pending attempt."""
+    attempt = self._steer_attempt
+    if attempt is None or attempt.settled:
+      return
+    if not attempt.commit_started:
+      self._reject_pending_steer(attempt)
+      # The provider control RPC may be the very thing that wedged. Once the
+      # owning turn is ending there is no future acknowledgement worth
+      # retaining, so release its task too; otherwise each recovered turn could
+      # leave one permanently suspended task behind.
+      if attempt.task is not None and not attempt.task.done():
+        attempt.task.cancel()
+      return
+    if attempt.task is not None:
+      await asyncio.shield(attempt.task)
+
+  async def steer(
+    self,
+    message: str,
+    user_msgs: list[dict] | None = None,
+    consume_pending_cids: list[str] | None = None,
+  ) -> bool:
+    """Admit a durable steer and settle its provider RPC in the background."""
+    if not self.is_steerable:
+      return False
+    rows = [dict(row) for row in list(user_msgs or [])]
+    consume = list(consume_pending_cids or [])
+    if not rows or not consume:
+      # A provider delivery without its durable queue identity cannot be
+      # settled exactly once after this request returns.
+      return False
+
+    current = self._steer_attempt
+    if current is not None and not current.settled:
+      # Ambiguous HTTP retries may re-admit the same cids. The first attempt
+      # already owns them; report accepted without delivering twice.
+      if set(consume).issubset(set(current.consume_pending_cids)):
+        return True
+      return False
+
+    attempt = _CodexSteerAttempt(
+      message=message,
+      user_msgs=rows,
+      consume_pending_cids=consume,
+    )
+    self._steer_attempt = attempt
+    self._steer_in_flight = True
+    attempt.task = asyncio.create_task(self._deliver_steer(attempt))
+    # Let the owned task enter the provider call before acknowledging
+    # admission. This is one event-loop turn, not a provider wait: a wedged RPC
+    # remains detached while immediate failures can publish their queue
+    # restoration promptly.
+    await asyncio.sleep(0)
+    return True
 
 
 def _sdk_imports() -> dict[str, Any]:
@@ -2355,6 +2551,7 @@ async def run_codex_sdk_turn(
         turn,
         chat_id=chat_id,
         process_group_id=process_group_id,
+        sink=bc,
       )
       registry.register(active_turn)
       record_memory_checkpoint_once(
@@ -2756,6 +2953,19 @@ async def run_codex_sdk_turn(
     group_already_terminated = False
     if isinstance(current, ActiveCodexTurn) and current.turn is turn:
       group_already_terminated = current._force_stop_started
+      try:
+        await current.finish_steer_before_turn_end()
+      except asyncio.CancelledError as exc:
+        # A committing cut owns its durable queue row. Finish that bounded
+        # writer settlement before honoring cancellation so the wrapper's
+        # terminal Finalize cannot race it and reorder Q1/A1/Q2.
+        deferred_cancel = deferred_cancel or exc
+        await asyncio.shield(current.finish_steer_before_turn_end())
+      except Exception:
+        log.exception(
+          "Codex steer settlement failed during turn teardown chat_id=%s",
+          chat_id,
+        )
       registry.unregister(chat_id, RunnerKind.CODEX_SDK)
       current.mark_finished()
     # AsyncCodex.close() terminates only its direct Popen PID.  Reap the
@@ -2783,43 +2993,24 @@ async def run_codex_sdk_turn(
 async def steer_into_active_turn(
   chat_id: str,
   message: str,
+  user_msgs: list[dict] | None = None,
+  consume_pending_cids: list[str] | None = None,
 ) -> bool:
-  """Delivers a message into the active Codex turn via `steer()`.
+  """Admit a durably-reserved message into the active Codex turn.
 
   Args:
     chat_id: Möbius chat identifier to look up in the registry.
     message: Text to inject into the in-flight turn.
+    user_msgs: Durable queued rows to move into the transcript after provider
+      acknowledgement.
+    consume_pending_cids: Stable ids of those queued rows.
 
   Returns:
-    True when the turn existed and accepted the steering input.
+    True when the live handle accepted ownership of provider settlement.
   """
   current = registry.get_handle(chat_id, RunnerKind.CODEX_SDK)
-  if not isinstance(current, ActiveCodexTurn) or current.turn is None:
+  if not isinstance(current, ActiveCodexTurn):
     return False
-  if current.steer_in_flight:
-    return False
-
-  # The pinned SDK's async steer is asyncio.to_thread(sync.turn_steer). The
-  # sync request waits for the sole reader thread to route its response; that
-  # same reader invokes request_user_input handlers synchronously. Mark
-  # admission BEFORE the first await so park_question can reject the losing
-  # side of that race. Do not impose a route-side timeout: cancelling
-  # asyncio.to_thread cannot cancel its underlying JSON-RPC request, so a late
-  # success would be indistinguishable from failure and could duplicate the
-  # still-durable pending row when it later drains.
-  current._steer_in_flight = True
-
-  try:
-    await current.turn.steer(message)
-  except (AttributeError, TypeError):
-    return False
-  except Exception as exc:
-    if _is_closed_turn_error(exc):
-      if registry.get_handle(chat_id, RunnerKind.CODEX_SDK) is current:
-        registry.unregister(chat_id, RunnerKind.CODEX_SDK)
-        current.mark_finished()
-      return False
-    raise
-  finally:
-    current._steer_in_flight = False
-  return True
+  return await current.steer(
+    message, user_msgs, consume_pending_cids,
+  )

--- a/backend/app/routes/chats_stream.py
+++ b/backend/app/routes/chats_stream.py
@@ -16,18 +16,15 @@ from app.broadcast import create_broadcast, get_broadcast, get_system_broadcast
 from app.chat import (
   _schedule_continuation,
   discard_starting,
-  get_active_sink,
   is_chat_running,
   is_draining,
   mark_starting,
   run_chat,
-  steered_into_turn_event,
 )
 from app import chat_queue
 from app.chat_writer import (
   AnswerQuestion,
   AppendPending,
-  AppendSteeredUserMessage,
   CancelPending,
   StartTurn,
   alloc_run_token,
@@ -357,7 +354,7 @@ def _has_live_steerable_turn(chat_id: str, provider: str) -> bool:
   handle = registry.get_handle(chat_id, RunnerKind.CODEX_SDK)
   return (
     isinstance(handle, codex_sdk_runner.ActiveCodexTurn)
-    and handle.turn is not None
+    and handle.is_steerable
   )
 
 
@@ -368,46 +365,20 @@ async def _steer_into_active_turn(
   user_msgs: list[dict] | None = None,
   consume_pending_cids: list[str] | None = None,
 ) -> bool:
-  """Routes a steer request to the active provider-specific handle.
+  """Admit a steer to the live handle without awaiting provider I/O.
 
-  For Claude the `user_msgs` / `consume_pending_cids` payload is buffered on
-  the handle so the RUNNER performs the transcript split (seal A1, append the
-  steered rows, reset for A2) when the interrupted turn ends — the first point
-  the true A1/A2 boundary is known. Codex still splits at the route below
-  (its `turn.steer()` injects into the same running turn, so there is no
-  interrupt boundary to defer to).
+  Both provider handles buffer the durable rows and own the eventual
+  acknowledgement + transcript cut. The HTTP route stays only the atomic
+  durability/admission boundary, so a wedged provider control call cannot hold
+  the per-chat queue lock or its database checkout.
   """
   if provider == "claude":
     return await claude_sdk_runner.steer_into_active_turn(
       chat_id, content, user_msgs, consume_pending_cids,
     )
-  return await codex_sdk_runner.steer_into_active_turn(chat_id, content)
-
-
-async def _split_steer_at_route(
-  chat_id: str, user_msgs: list[dict], consume_pending_cids: list[str],
-) -> dict:
-  """Route-driven transcript split for Codex (seal A1, append steered rows).
-
-  Claude defers the split to the runner (there is a real interrupt boundary
-  where A1 is complete); Codex injects into the same running turn with no such
-  boundary, so the route drives the split here on this event loop, serialized
-  with the sink's streaming snapshots. A turn with no registered sink (a
-  closed-turn race or a non-SDK path) has no streamed text to seal, so it
-  falls back to a plain end-of-transcript append of the steered rows.
-  """
-  sink = get_active_sink(chat_id)
-  if sink is not None:
-    return await sink.split_for_steer(user_msgs, consume_pending_cids)
-  ack = get_writer().submit(
-    AppendSteeredUserMessage(
-      chat_id=chat_id,
-      run_token="",
-      user_msgs=user_msgs,
-      consume_pending_cids=consume_pending_cids,
-    )
+  return await codex_sdk_runner.steer_into_active_turn(
+    chat_id, content, user_msgs, consume_pending_cids,
   )
-  return await await_ack(ack)
 
 
 def _steered_response(
@@ -418,17 +389,15 @@ def _steered_response(
 ) -> JSONResponse:
   """202 for a message steered into the live turn.
 
-  The live turn has seen the message via `steer()`. Where the message LIVES
-  right now depends on the provider, and `cut_deferred` states which:
+  The live handle has admitted the durable row via `steer()`. Where the message
+  lives right now depends on whether its transcript cut has settled, and
+  `cut_deferred` states which:
 
-  - absent/False (Codex): the transcript split already ran at the route, so the
-    row is in the TRANSCRIPT and out of the pending queue. The client drops its
-    queued-tray entry and renders the row inline as content growth.
-  - True (Claude): the split is deferred to the runner's interrupt boundary, so
-    the row is STILL in `pending_messages` (echoed above) and will move into the
-    transcript when the runner publishes `steered_into_turn` at the real seal.
-    The client keeps showing the queued row until then — dropping it here left
-    the owner's message with nowhere to render for the length of the window.
+  Both providers now return ``cut_deferred=True``: admission is complete, but
+  the row remains in ``pending_messages`` until the live handle receives its
+  provider acknowledgement and publishes the authoritative
+  ``steered_into_turn`` cut. This keeps provider I/O outside the route's queue
+  lock while preserving an exactly-once durable reserve.
   """
   payload = {"status": "steered", "chat_id": chat_id}
   if pending_messages is not None:
@@ -836,9 +805,9 @@ async def _send_message_locked(
     #   - ordinary sends require the chat's opt-in flag;
     #   - direct_steer requests this new composer row explicitly;
     #   - force_steer converts named already-queued rows.
-    # The direct and ordinary new-message paths both reserve the row durably
-    # before provider delivery. Codex injects into the running SDK turn;
-    # Claude interrupts and re-prompts on the same client.
+    # Every new-message path reserves the row durably before provider delivery.
+    # Each live handle admits those rows immediately, then owns provider
+    # settlement and the eventual transcript cut outside this queue lock.
     provider = chat.provider or "claude"
     if (
       is_chat_running(chat_id)
@@ -869,14 +838,6 @@ async def _send_message_locked(
         user_msgs = [reserved]
         consume_cids = [reserved_cid] if reserved_cid is not None else []
         steer_content = reserved.get("content", "")
-      # Claude defers the A1/Q2 transcript split to the runner: at HTTP
-      # arrival the pre-interrupt text A1 has often not streamed yet, so
-      # a route-side split seals an EMPTY A1 and the real A1 then merges
-      # with A2 after the steered row (the fast-forward dropped-message
-      # bug). The runner splits at the interrupt boundary where A1 is
-      # complete. The reserved pending row is the durable copy; the
-      # handle buffer is only a delivery cache.
-      defer_to_runner = provider == "claude"
       if questions.is_waiting(chat_id):
         # A new-message steer awaits AppendPending above. A question can
         # register during that actor round-trip even though the entry gate was
@@ -886,68 +847,23 @@ async def _send_message_locked(
         try:
           steered = await _steer_into_active_turn(
             provider, chat_id, steer_content,
-            user_msgs if defer_to_runner else None,
-            consume_cids if defer_to_runner else None,
+            user_msgs, consume_cids,
           )
         except Exception:
           # A failed delivery leaves the reserved row pending.
           steered = False
       if steered:
-        if defer_to_runner:
-          # Nothing has been converted yet: the rows are buffered on the handle
-          # and remain in `chat.pending_messages` until the runner's seal
-          # consumes them. So report the queue AS IT IS — an optimistic list
-          # with the rows already subtracted told the client they had left the
-          # queue while the server still held them there, which is precisely
-          # the window the client must keep showing them (see `cut_deferred`
-          # on the response below).
-          stored_result = {
-            "stored_messages": user_msgs,
-            "pending": list(chat.pending_messages or []),
-          }
-        else:
-          # Codex append and pending removal commit atomically for one cid.
-          try:
-            stored_result = await _split_steer_at_route(
-              chat_id, user_msgs, consume_cids,
-            )
-          except Exception:
-            # The live turn has already absorbed the steer — it cannot be
-            # un-steered. The reserved pending row is still durable, so
-            # nothing is lost: a retry on the same cid re-converts without
-            # re-steering, and an abandoned retry drains via the idle
-            # sweep or the next send.
-            log.warning(
-              "steered transcript write did not persist chat_id=%s", chat_id,
-            )
-            raise HTTPException(
-              status_code=503,
-              detail="Could not save your message; please refresh.",
-            )
-        # `steered_into_turn` is the client's ONLY "cut the live stream here"
-        # signal, so it may only be published where the transcript is really
-        # split. Codex splits HERE (`_split_steer_at_route` above ran to
-        # completion), so the route is its seal point and publishes the cut
-        # unchanged. Claude defers the split to the runner's interrupt boundary,
-        # seconds later — publishing the cut here re-based the client's stream
-        # while the runner was still emitting blocks that the deferred seal then
-        # folded into A1, so those blocks painted twice for the rest of the turn.
-        # The deferred path publishes NOTHING here. An ordinary auto-steer or
-        # existing queued-row conversion remains visible until
-        # `_seal_steer_split` publishes the cut; a direct composer steer has no
-        # tray row and keeps its durable reserve intentionally hidden over the
-        # same interval.
-        if not defer_to_runner:
-          bc = get_broadcast(chat_id)
-          if bc is not None:
-            stored_messages = stored_result.get("stored_messages")
-            if not isinstance(stored_messages, list) or not stored_messages:
-              stored = stored_result.get("stored") or user_msg
-              stored_messages = [stored]
-            bc.publish(steered_into_turn_event(stored_messages))
+        # Nothing has been converted yet: the handle owns provider settlement,
+        # then commits + publishes the authoritative cut. Echo the durable
+        # queue exactly as it stands so the client can retain the accepted row
+        # through this deferred window.
+        stored_result = {
+          "stored_messages": user_msgs,
+          "pending": list(chat.pending_messages or []),
+        }
         return _steered_response(
           chat_id, stored_result.get("pending"),
-          cut_deferred=defer_to_runner,
+          cut_deferred=True,
         )
       if body.force_steer:
         return _not_steered_response(chat_id)

--- a/backend/tests/test_chats_stream_steer.py
+++ b/backend/tests/test_chats_stream_steer.py
@@ -5,17 +5,18 @@ and drains it at turn-end. For chats with `steer_enabled` set (DEFAULT
 OFF), an ordinary send that arrives while a turn is streaming is steered
 into the live provider handle. `direct_steer` explicitly requests the same
 durable reserve-and-steer operation for a new composer row regardless of
-that flag, exposing the reservation as queued only when delivery cannot be
-accepted. Codex uses true SDK injection; Claude interrupts and re-prompts
-on the same connected SDK client.
+that flag; `force_steer` converts already-queued rows by stable `cid`. Every
+path reserves the row durably before delivery. Both live handles admit those
+rows immediately and own the eventual provider acknowledgement plus transcript
+cut outside the route lock.
 
 These tests pin the provider-gated branch in
 `routes/chats_stream.send_message`:
 
   1. provider + running + flag-on + live turn → steer is called, the
-     message is appended to the TRANSCRIPT (not pending), a
-     `steered_into_turn` event is broadcast, and the response is
-     `{"status": "steered"}`.
+     message remains reserved until the runner-owned cut, a
+     `steered_into_turn` event is broadcast at that cut, and the response is
+     `{"status": "steered", "cut_deferred": true}`.
   2. flag OFF → falls back to the queue (the default; deploy-safe).
   3. Claude with the flag on uses its live-client fallback.
   4. steer returns False (no live turn / closed-turn race) → queue.
@@ -69,6 +70,43 @@ def _make_active_claude_client(chat_id: str):
     return ActiveClaudeClient(_Client(), chat_id=chat_id)
 
   return asyncio.run(_build())
+
+
+def _patch_codex_steer(monkeypatch, steer) -> None:
+  """Replace provider I/O while synchronously settling route-wiring tests.
+
+  The real ActiveCodexTurn owns this commit in a background task; these tests
+  exercise route selection rather than task scheduling, so settle through the
+  same chat-owned helper before returning to keep their DB assertions direct.
+  """
+  async def _handle_steer(
+    self, message, user_msgs=None, consume_pending_cids=None,
+  ):
+    accepted = await steer(self.chat_id, message)
+    if accepted and user_msgs and consume_pending_cids:
+      from app.chat import commit_steer_cut
+      await commit_steer_cut(
+        self.chat_id, user_msgs, consume_pending_cids,
+      )
+    return accepted
+
+  monkeypatch.setattr(
+    "app.codex_sdk_runner.ActiveCodexTurn.steer", _handle_steer,
+  )
+
+
+def _patch_claude_steer(monkeypatch, steer) -> None:
+  """Replace Claude's handle-owned steer method for route wiring tests."""
+  async def _handle_steer(
+    self, message, user_msgs=None, consume_pending_cids=None,
+  ):
+    return await steer(
+      self.chat_id, message, user_msgs, consume_pending_cids,
+    )
+
+  monkeypatch.setattr(
+    "app.claude_sdk_runner.ActiveClaudeClient.steer", _handle_steer,
+  )
 
 
 def _make_codex_chat(chat_id: str, *, steer_enabled: bool) -> None:
@@ -139,15 +177,13 @@ def test_steers_into_live_codex_turn_when_flag_on(
 
   steered_calls = []
 
-  async def _fake_steer(cid, message):
+  async def _fake_steer(cid, message, *_durable):
     reserved = _read_chat(chat_id).pending_messages
     assert [row["content"] for row in reserved] == ["actually use blue"]
     steered_calls.append((cid, message))
     return True
 
-  monkeypatch.setattr(
-    "app.codex_sdk_runner.steer_into_active_turn", _fake_steer,
-  )
+  _patch_codex_steer(monkeypatch, _fake_steer)
 
   res = client.post(
     f"/api/chats/{chat_id}/messages",
@@ -202,16 +238,14 @@ def test_direct_steer_reserves_and_converts_new_codex_message_in_one_request(
   create_broadcast(chat_id)
   steered_calls = []
 
-  async def _fake_steer(cid, message):
+  async def _fake_steer(cid, message, *_durable):
     reserved = _read_chat(chat_id).pending_messages
     assert [cid_of(row) for row in reserved] == [message_cid]
     assert [row["content"] for row in reserved] == ["change course now"]
     steered_calls.append((cid, message))
     return True
 
-  monkeypatch.setattr(
-    "app.codex_sdk_runner.steer_into_active_turn", _fake_steer,
-  )
+  _patch_codex_steer(monkeypatch, _fake_steer)
 
   res = client.post(
     f"/api/chats/{chat_id}/messages",
@@ -242,7 +276,7 @@ def test_direct_steer_failure_reveals_single_reserved_queue_fallback(
   registry.register(_make_active_codex_turn(chat_id))
   create_broadcast(chat_id)
 
-  async def _closed_turn(_chat_id, _message):
+  async def _closed_turn(_chat_id, _message, *_durable):
     return False
 
   monkeypatch.setattr(
@@ -339,7 +373,7 @@ def test_pending_question_refuses_force_steer_without_holding_queue(
   ))
   registry.register(_make_active_codex_turn(chat_id))
 
-  async def _fail_if_called(_cid, _message):
+  async def _fail_if_called(_cid, _message, *_durable):
     raise AssertionError("pending QA must block provider steer")
 
   monkeypatch.setattr(
@@ -397,7 +431,7 @@ def test_question_registered_during_append_blocks_ordinary_auto_steer(
 
   monkeypatch.setattr(chats_stream, "_append_to_pending", _append_then_register)
 
-  async def _fail_if_called(_cid, _message):
+  async def _fail_if_called(_cid, _message, *_durable):
     raise AssertionError("pending QA must block provider auto-steer")
 
   monkeypatch.setattr(
@@ -468,12 +502,10 @@ def test_steer_drops_empty_pre_steer_partial(client, auth, monkeypatch):
   # Only a whitespace token streamed before the steer landed.
   sink = _register_sink_with_partial(chat_id, run_token, " ")
 
-  async def _fake_steer(cid, message):
+  async def _fake_steer(cid, message, *_durable):
     return True
 
-  monkeypatch.setattr(
-    "app.codex_sdk_runner.steer_into_active_turn", _fake_steer,
-  )
+  _patch_codex_steer(monkeypatch, _fake_steer)
 
   res = client.post(
     f"/api/chats/{chat_id}/messages",
@@ -543,12 +575,10 @@ def test_steer_splits_assistant_turn_for_reload_order(
   run_token = "run-split"
   sink = _register_sink_with_partial(chat_id, run_token, "A1")
 
-  async def _fake_steer(cid, message):
+  async def _fake_steer(cid, message, *_durable):
     return True
 
-  monkeypatch.setattr(
-    "app.codex_sdk_runner.steer_into_active_turn", _fake_steer,
-  )
+  _patch_codex_steer(monkeypatch, _fake_steer)
 
   res = client.post(
     f"/api/chats/{chat_id}/messages",
@@ -815,6 +845,35 @@ def test_a_failing_publisher_cannot_escape_the_seal():
   asyncio.run(_run())
 
 
+def test_sink_commit_publish_failure_does_not_reclassify_committed_cut():
+  """A committed Codex cut stays successful if only its broadcast is gone.
+
+  Provider settlement treats a raised commit as "row remains queued". Once
+  the writer has consumed that row, letting a publish exception escape would
+  send the opposite outcome and invite a duplicate retry.
+  """
+  from app.chat import _ChatEventSink
+
+  class _ExplodingBroadcast:
+    def publish(self, event):
+      raise RuntimeError("broadcast is gone")
+
+  async def _run():
+    row = {"role": "user", "content": "Q2", "ts": 10, "cid": "c-q2"}
+    sink = _ChatEventSink(_ExplodingBroadcast(), "commit-publish-fail")
+
+    async def _committed_split(rows, consume):
+      assert rows == [row]
+      assert consume == ["c-q2"]
+      return {"stored_messages": [row], "pending": []}
+
+    sink.split_for_steer = _committed_split
+    result = await sink.commit_steer_cut([row], ["c-q2"])
+    assert result["stored_messages"] == [row]
+
+  asyncio.run(_run())
+
+
 def test_stop_drops_the_buffered_steer_instead_of_appending_it():
   """A hard Stop abandons a deferred steer ENTIRELY.
 
@@ -1019,13 +1078,11 @@ def test_force_steer_consumes_existing_queued_messages(
 
   steered_calls = []
 
-  async def _fake_steer(cid, message):
+  async def _fake_steer(cid, message, *_durable):
     steered_calls.append((cid, message))
     return True
 
-  monkeypatch.setattr(
-    "app.codex_sdk_runner.steer_into_active_turn", _fake_steer,
-  )
+  _patch_codex_steer(monkeypatch, _fake_steer)
 
   res = client.post(
     f"/api/chats/{chat_id}/messages",
@@ -1084,13 +1141,11 @@ def test_api_send_without_cid_can_be_force_steered(
 
   steered_calls = []
 
-  async def _fake_steer(cid, message):
+  async def _fake_steer(cid, message, *_durable):
     steered_calls.append((cid, message))
     return True
 
-  monkeypatch.setattr(
-    "app.codex_sdk_runner.steer_into_active_turn", _fake_steer,
-  )
+  _patch_codex_steer(monkeypatch, _fake_steer)
   steered = client.post(
     f"/api/chats/{chat_id}/messages",
     json={
@@ -1127,12 +1182,10 @@ def test_force_steer_failure_does_not_append_duplicate_queue(
   registry.register(_make_active_codex_turn(chat_id))
   create_broadcast(chat_id)
 
-  async def _fake_steer(_cid, _message):
+  async def _fake_steer(_cid, _message, *_durable):
     return False
 
-  monkeypatch.setattr(
-    "app.codex_sdk_runner.steer_into_active_turn", _fake_steer,
-  )
+  _patch_codex_steer(monkeypatch, _fake_steer)
 
   res = client.post(
     f"/api/chats/{chat_id}/messages",
@@ -1171,7 +1224,7 @@ def test_force_steer_requires_known_cids(
   registry.register(_make_active_codex_turn(chat_id))
   create_broadcast(chat_id)
 
-  async def _fail_if_called(_cid, _message):
+  async def _fail_if_called(_cid, _message, *_durable):
     raise AssertionError("forced steer should require matching queue rows")
 
   monkeypatch.setattr(
@@ -1212,7 +1265,7 @@ def test_ordinary_steer_does_not_jump_existing_queue(
   registry.register(_make_active_codex_turn(chat_id))
   create_broadcast(chat_id)
 
-  async def _fail_if_called(_cid, _message):
+  async def _fail_if_called(_cid, _message, *_durable):
     raise AssertionError("ordinary steer must not skip older pending messages")
 
   monkeypatch.setattr(
@@ -1242,7 +1295,7 @@ def test_falls_back_to_queue_when_flag_off(client, auth, monkeypatch):
   registry.register(_make_active_codex_turn(chat_id))
   create_broadcast(chat_id)
 
-  async def _fail_if_called(cid, message):
+  async def _fail_if_called(cid, message, *_durable):
     raise AssertionError("steer must not be called when the flag is off")
 
   monkeypatch.setattr(
@@ -1477,16 +1530,10 @@ def test_claude_steer_cut_event_is_published_at_the_seal_not_at_http_arrival(
   ]
 
 
-def test_codex_steer_still_publishes_the_cut_at_the_route(
+def test_codex_steer_publishes_cut_from_handle_owned_settlement(
   client, auth, monkeypatch,
 ):
-  """Codex is unaffected by moving the Claude cut.
-
-  Its `turn.steer()` injects into the SAME running turn, so the route's own
-  `_split_steer_at_route` IS the seal: signal and cut are the same instant
-  there. The route must therefore keep publishing `steered_into_turn` at
-  arrival, with the response shape unchanged (no `cut_deferred`).
-  """
+  """The handle-owned settlement commits and publishes the authoritative cut."""
   chat_id = "codexcutroute"
   db = SessionLocal()
   try:
@@ -1501,12 +1548,10 @@ def test_codex_steer_still_publishes_the_cut_at_the_route(
   registry.register(_make_active_codex_turn(chat_id))
   sink = _register_sink_with_partial(chat_id, "run-codex-cut", "A1")
 
-  async def _fake_steer(cid, message):
+  async def _fake_steer(cid, message, *_durable):
     return True
 
-  monkeypatch.setattr(
-    "app.codex_sdk_runner.steer_into_active_turn", _fake_steer,
-  )
+  _patch_codex_steer(monkeypatch, _fake_steer)
 
   res = client.post(
     f"/api/chats/{chat_id}/messages",
@@ -1515,16 +1560,18 @@ def test_codex_steer_still_publishes_the_cut_at_the_route(
   assert res.status_code == 202, res.text
   body = res.json()
   assert body["status"] == "steered"
-  assert "cut_deferred" not in body
-  # The row left pending at the route, so the echoed queue no longer holds it.
+  assert body["cut_deferred"] is True
+  # This route-wiring double settles synchronously, so its echoed queue already
+  # reflects the committed cut. The real handle cannot settle under the
+  # route-held queue lock; the never-ack regression below pins that deferred
+  # production window.
   assert body["pending_messages"] == []
 
   bc = get_broadcast(chat_id)
   assert [e.get("type") for e in bc.event_log] == ["steered_into_turn"]
   cut = [e for e in bc.event_log if e.get("type") == "steered_into_turn"][0]
   assert [m["content"] for m in cut["messages"]] == ["Q2"]
-  # The route sealed A1 and appended Q2 before publishing — the cut is
-  # truthful at the instant it is sent.
+  # The owning sink sealed A1 and appended Q2 before publishing.
   assert [(m["role"], m.get("content")) for m in _read_chat(chat_id).messages] == [
     ("user", "Q1"),
     ("assistant", "A1"),
@@ -1618,7 +1665,7 @@ def test_claude_falls_back_to_queue_when_flag_off(
   registry.register(_make_active_claude_client(chat_id))
   create_broadcast(chat_id)
 
-  async def _fail_if_called(cid, message):
+  async def _fail_if_called(cid, message, *_durable):
     raise AssertionError("steer must not be called when the flag is off")
 
   monkeypatch.setattr(
@@ -1676,7 +1723,7 @@ def test_falls_back_to_queue_when_steer_returns_false(
   registry.register(_make_active_codex_turn(chat_id))
   create_broadcast(chat_id)
 
-  async def _steer_false(cid, message):
+  async def _steer_false(cid, message, *_durable):
     return False
 
   monkeypatch.setattr(
@@ -1708,7 +1755,7 @@ def test_falls_back_to_queue_when_steer_raises(client, auth, monkeypatch):
   registry.register(_make_active_codex_turn(chat_id))
   create_broadcast(chat_id)
 
-  async def _steer_raises(cid, message):
+  async def _steer_raises(cid, message, *_durable):
     raise RuntimeError("SDK blew up")
 
   monkeypatch.setattr(
@@ -1727,7 +1774,7 @@ def test_falls_back_to_queue_when_steer_raises(client, auth, monkeypatch):
   assert [m["content"] for m in chat.pending_messages] == ["queued please"]
 
 
-def test_codex_split_failure_keeps_one_reserved_row(
+def test_codex_deferred_admission_keeps_one_reserved_row(
   client, auth, monkeypatch,
 ):
   chat_id = "codex-split-failure"
@@ -1737,20 +1784,20 @@ def test_codex_split_failure_keeps_one_reserved_row(
   create_broadcast(chat_id)
   steer_calls = []
 
-  async def _steer(_chat_id, content):
-    steer_calls.append(content)
+  async def _admit_without_settling(
+    self, message, user_msgs=None, consume_pending_cids=None,
+  ):
+    del self, user_msgs, consume_pending_cids
+    steer_calls.append(message)
     return True
 
-  async def _split(*_args):
-    raise RuntimeError("writer unavailable")
-
   monkeypatch.setattr(
-    "app.codex_sdk_runner.steer_into_active_turn", _steer,
-  )
-  monkeypatch.setattr(
-    "app.routes.chats_stream._split_steer_at_route", _split,
+    "app.codex_sdk_runner.ActiveCodexTurn.steer",
+    _admit_without_settling,
   )
 
+  # Admission returns immediately while provider settlement is outstanding.
+  # The exact row remains durably queued, and a same-cid retry dedups to it.
   first = client.post(
     f"/api/chats/{chat_id}/messages",
     json={"content": "keep this", "cid": message_cid},
@@ -1762,7 +1809,9 @@ def test_codex_split_failure_keeps_one_reserved_row(
     headers=auth,
   )
 
-  assert first.status_code == 503
+  assert first.status_code == 202
+  assert first.json()["status"] == "steered"
+  assert first.json()["cut_deferred"] is True
   assert retry.status_code == 202
   assert retry.json()["status"] == "queued"
   assert steer_calls == ["keep this"]
@@ -1771,6 +1820,109 @@ def test_codex_split_failure_keeps_one_reserved_row(
   assert not [
     row for row in chat.messages if cid_of(row) == message_cid
   ]
+
+
+def test_codex_never_acknowledged_steer_does_not_lock_send_or_stop():
+  """A wedged provider control RPC stays outside the per-chat queue lock."""
+  from app import chat as chat_mod
+  from app import schemas
+  from app.codex_sdk_runner import ActiveCodexTurn
+  from app.deps import Principal
+  from app.routes import chats_stream
+
+  chat_id = "codex-never-ack-steer"
+  message_cid = "never-ack-cid"
+  _make_codex_chat(chat_id, steer_enabled=True)
+  db0 = SessionLocal()
+  try:
+    chat = db0.query(models.Chat).filter(models.Chat.id == chat_id).first()
+    chat.pending_messages = [{
+      "role": "user",
+      "content": "change course",
+      "ts": 10,
+      "cid": message_cid,
+    }]
+    db0.commit()
+  finally:
+    db0.close()
+  create_broadcast(chat_id)
+
+  async def _run():
+    provider_entered = asyncio.Event()
+    release_provider = asyncio.Event()
+
+    class _NeverAckTurn:
+      async def steer(self, _message):
+        provider_entered.set()
+        await release_provider.wait()
+
+      async def interrupt(self):
+        return None
+
+    handle = ActiveCodexTurn(
+      thread=object(),
+      turn=_NeverAckTurn(),
+      chat_id=chat_id,
+    )
+    registry.register(handle)
+    first_db = SessionLocal()
+    second_db = SessionLocal()
+    try:
+      owner = first_db.query(models.Owner).first()
+      principal = Principal(owner=owner, app_id=None)
+      first = await asyncio.wait_for(
+        chats_stream.send_message(
+          schemas.SendMessage(
+            content="change course",
+            force_steer=True,
+            consume_pending_cids=[message_cid],
+          ),
+          chat_id,
+          principal,
+          first_db,
+        ),
+        timeout=1,
+      )
+      assert first.status_code == 202
+      assert b'"cut_deferred":true' in first.body
+      await asyncio.wait_for(provider_entered.wait(), timeout=1)
+
+      # The provider call above is still waiting, yet an ordinary send acquires
+      # the same queue lock and durably queues without waiting behind it.
+      second = await asyncio.wait_for(
+        chats_stream.send_message(
+          schemas.SendMessage(
+            content="also preserve this",
+            cid="second-cid",
+          ),
+          chat_id,
+          principal,
+          second_db,
+        ),
+        timeout=1,
+      )
+      assert second.status_code == 202
+      assert b'"status":"queued"' in second.body
+
+      async def _bounded_stop(*_args, **_kwargs):
+        handle.mark_finished()
+        return True
+
+      handle.stop = _bounded_stop
+      stopped, _cleared = await asyncio.wait_for(
+        chat_mod.stop_chat_for(chat_id), timeout=1,
+      )
+      assert stopped is True
+    finally:
+      release_provider.set()
+      attempt = handle._steer_attempt
+      if attempt is not None and attempt.task is not None:
+        await asyncio.wait_for(attempt.task, timeout=1)
+      registry.unregister(chat_id, RunnerKind.CODEX_SDK)
+      first_db.close()
+      second_db.close()
+
+  asyncio.run(_run())
 
 
 def test_request_cancellation_after_reserve_keeps_pending(
@@ -1787,7 +1939,7 @@ def test_request_cancellation_after_reserve_keeps_pending(
   create_broadcast(chat_id)
   provider_entered = asyncio.Event()
 
-  async def _blocked_steer(_chat_id, _content):
+  async def _blocked_steer(_chat_id, _content, *_durable):
     provider_entered.set()
     await asyncio.Event().wait()
 
@@ -1816,67 +1968,6 @@ def test_request_cancellation_after_reserve_keeps_pending(
   chat = _read_chat(chat_id)
   assert [cid_of(row) for row in chat.pending_messages] == [message_cid]
   assert not [row for row in chat.messages if cid_of(row) == message_cid]
-
-
-def test_steer_wins_stop_race_converts_before_clear(
-  client, auth, monkeypatch,
-):
-  from app import chat as chat_mod
-  from app import schemas
-  from app.deps import Principal
-  from app.routes import chats_stream
-
-  chat_id = "steer-wins-stop"
-  message_cid = "steer-wins-stop-cid"
-  _make_codex_chat(chat_id, steer_enabled=True)
-  handle = _make_active_codex_turn(chat_id)
-  registry.register(handle)
-  create_broadcast(chat_id)
-  provider_entered = asyncio.Event()
-  allow_provider = asyncio.Event()
-
-  async def _steer(_chat_id, _content):
-    provider_entered.set()
-    await allow_provider.wait()
-    return True
-
-  async def _stop(*_args, **_kwargs):
-    return True
-
-  handle.stop = _stop
-  monkeypatch.setattr(
-    "app.codex_sdk_runner.steer_into_active_turn", _steer,
-  )
-
-  async def _run():
-    db = SessionLocal()
-    try:
-      owner = db.query(models.Owner).first()
-      send = asyncio.create_task(chats_stream.send_message(
-        schemas.SendMessage(content="convert me", cid=message_cid),
-        chat_id,
-        Principal(owner=owner, app_id=None),
-        db,
-      ))
-      await asyncio.wait_for(provider_entered.wait(), timeout=2)
-      stop = asyncio.create_task(chat_mod.stop_chat_for(chat_id))
-      await asyncio.sleep(0)
-      assert not stop.done()
-      allow_provider.set()
-      response, _ = await asyncio.gather(send, stop)
-      assert response.status_code == 202
-      assert response.body
-    finally:
-      db.close()
-
-  asyncio.run(_run())
-  chat = _read_chat(chat_id)
-  durable = [
-    row for row in list(chat.messages or []) + list(chat.pending_messages or [])
-    if cid_of(row) == message_cid
-  ]
-  assert len(durable) == 1
-  assert durable[0] in chat.messages
 
 
 def test_stop_wins_steer_race_send_rechecks_idle(

--- a/backend/tests/test_codex_sdk_runner.py
+++ b/backend/tests/test_codex_sdk_runner.py
@@ -42,6 +42,19 @@ class _FakeBroadcast:
     self.lifecycle_events.append(event)
 
 
+class _FakeSteerSink:
+  def __init__(self):
+    self.bc = _FakeBroadcast()
+    self.cuts: list[tuple[list[dict], list[str]]] = []
+
+  async def commit_steer_cut(self, user_msgs, consume_pending_cids):
+    self.cuts.append((list(user_msgs), list(consume_pending_cids)))
+    return {
+      "stored_messages": list(user_msgs),
+      "pending": [],
+    }
+
+
 class _FakeCodexConfig:
   def __init__(self, **kwargs):
     self.kwargs = kwargs
@@ -385,40 +398,99 @@ def test_websearch_completed_events_extract_current_sdk_action_url(action_type):
   }]} in events
 
 
-def test_steer_into_active_turn_cleans_dead_handle(monkeypatch):
+def test_steer_closed_turn_releases_reserved_row_without_dropping_handle(
+  monkeypatch,
+):
   sdk = _fake_sdk(async_codex_cls=object)
 
-  async def _scenario() -> bool:
+  async def _scenario():
+    sink = _FakeSteerSink()
     active_turn = codex_sdk_runner.ActiveCodexTurn(
       object(),
       _FakeTurnHandle(
         steer_exc=sdk["InvalidParamsError"](-32602, "turn is not running"),
       ),
       chat_id="chat-1",
+      sink=sink,
     )
     registry.register(active_turn)
-    return await codex_sdk_runner.steer_into_active_turn(
-      "chat-1", "ping",
+    accepted = await active_turn.steer(
+      "ping",
+      [{"role": "user", "content": "ping", "cid": "ping-cid"}],
+      ["ping-cid"],
     )
+    while active_turn.steer_in_flight:
+      await asyncio.sleep(0)
+    return accepted, sink, active_turn
 
   monkeypatch.setattr(codex_sdk_runner, "_sdk_imports", lambda: sdk)
-  assert asyncio.run(_scenario()) is False
-  assert registry.get_handle("chat-1", RunnerKind.CODEX_SDK) is None
+  accepted, sink, active = asyncio.run(_scenario())
+  assert accepted is True
+  assert sink.cuts == []
+  assert sink.bc.events == [{
+    "type": "steer_delivery_failed",
+    "consume_pending_cids": ["ping-cid"],
+  }]
+  # The runner lifecycle still owns unregistering the live handle. A failed
+  # side-channel steer must not make Stop lose reachability to the main turn.
+  assert registry.get_handle("chat-1", RunnerKind.CODEX_SDK) is active
+  registry.unregister("chat-1", RunnerKind.CODEX_SDK)
 
 
-def test_steer_into_active_turn_reraises_real_errors():
-  async def _scenario() -> None:
-    registry.register(codex_sdk_runner.ActiveCodexTurn(
+def test_steer_provider_error_is_reported_as_queued_delivery_failure():
+  async def _scenario():
+    sink = _FakeSteerSink()
+    active = codex_sdk_runner.ActiveCodexTurn(
       object(),
       _FakeTurnHandle(steer_exc=RuntimeError("real failure")),
       chat_id="chat-1",
-    ))
-    await codex_sdk_runner.steer_into_active_turn(
-      "chat-1", "ping",
+      sink=sink,
     )
+    registry.register(active)
+    accepted = await active.steer(
+      "ping",
+      [{"role": "user", "content": "ping", "cid": "ping-cid"}],
+      ["ping-cid"],
+    )
+    while active.steer_in_flight:
+      await asyncio.sleep(0)
+    registry.unregister("chat-1", RunnerKind.CODEX_SDK)
+    return accepted, sink
 
-  with pytest.raises(RuntimeError, match="real failure"):
-    asyncio.run(_scenario())
+  accepted, sink = asyncio.run(_scenario())
+  assert accepted is True
+  assert sink.cuts == []
+  assert sink.bc.events[-1]["type"] == "steer_delivery_failed"
+
+
+def test_steer_cut_failure_releases_reserved_row():
+  class _FailingSink(_FakeSteerSink):
+    async def commit_steer_cut(self, user_msgs, consume_pending_cids):
+      del user_msgs, consume_pending_cids
+      raise RuntimeError("writer unavailable")
+
+  async def _scenario():
+    sink = _FailingSink()
+    active = codex_sdk_runner.ActiveCodexTurn(
+      object(), _FakeTurnHandle(), chat_id="cut-failure", sink=sink,
+    )
+    registry.register(active)
+    try:
+      assert await active.steer(
+        "ping",
+        [{"role": "user", "content": "ping", "cid": "ping-cid"}],
+        ["ping-cid"],
+      ) is True
+      while active.steer_in_flight:
+        await asyncio.sleep(0)
+      assert sink.bc.events == [{
+        "type": "steer_delivery_failed",
+        "consume_pending_cids": ["ping-cid"],
+      }]
+    finally:
+      registry.unregister("cut-failure", RunnerKind.CODEX_SDK)
+
+  asyncio.run(_scenario())
 
 
 def test_concurrent_steer_is_refused_while_ack_is_pending():
@@ -434,26 +506,74 @@ def test_concurrent_steer_is_refused_while_ack_is_pending():
         await release.wait()
 
     turn = _BlockingTurn()
+    sink = _FakeSteerSink()
     active = codex_sdk_runner.ActiveCodexTurn(
-      object(), turn, chat_id="atomic-steer",
+      object(), turn, chat_id="atomic-steer", sink=sink,
     )
     registry.register(active)
     try:
-      first = asyncio.create_task(codex_sdk_runner.steer_into_active_turn(
-        "atomic-steer", "first",
-      ))
+      assert await active.steer(
+        "first",
+        [{"role": "user", "content": "first", "cid": "first-cid"}],
+        ["first-cid"],
+      ) is True
       await asyncio.wait_for(entered.wait(), timeout=1)
       assert active.steer_in_flight
-      assert await codex_sdk_runner.steer_into_active_turn(
-        "atomic-steer", "second",
+      settlement = active._steer_attempt.task
+      assert await active.steer(
+        "second",
+        [{"role": "user", "content": "second", "cid": "second-cid"}],
+        ["second-cid"],
       ) is False
       assert turn.steered == ["first"]
 
       release.set()
-      assert await asyncio.wait_for(first, timeout=1) is True
+      await asyncio.wait_for(settlement, timeout=1)
       assert not active.steer_in_flight
+      assert sink.cuts == [(
+        [{"role": "user", "content": "first", "cid": "first-cid"}],
+        ["first-cid"],
+      )]
     finally:
       registry.unregister("atomic-steer", RunnerKind.CODEX_SDK)
+
+  asyncio.run(_scenario())
+
+
+def test_turn_teardown_cancels_a_never_acknowledged_steer():
+  async def _scenario():
+    entered = asyncio.Event()
+
+    class _NeverAckTurn:
+      async def steer(self, _message):
+        entered.set()
+        await asyncio.Event().wait()
+
+    sink = _FakeSteerSink()
+    active = codex_sdk_runner.ActiveCodexTurn(
+      object(), _NeverAckTurn(), chat_id="teardown-steer", sink=sink,
+    )
+    registry.register(active)
+    try:
+      assert await active.steer(
+        "first",
+        [{"role": "user", "content": "first", "cid": "first-cid"}],
+        ["first-cid"],
+      ) is True
+      await asyncio.wait_for(entered.wait(), timeout=1)
+      task = active._steer_attempt.task
+
+      await active.finish_steer_before_turn_end()
+      await asyncio.sleep(0)
+
+      assert task.cancelled()
+      assert sink.cuts == []
+      assert sink.bc.events == [{
+        "type": "steer_delivery_failed",
+        "consume_pending_cids": ["first-cid"],
+      }]
+    finally:
+      registry.unregister("teardown-steer", RunnerKind.CODEX_SDK)
 
   asyncio.run(_scenario())
 

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -1241,9 +1241,9 @@ export default function ChatView({
       // `messages`, then append the steered user row, then let future text
       // deltas build a fresh streaming assistant block.
       //
-      // The split is the route's own write for Codex and the runner's seal for
-      // Claude, so this event always arrives AFTER the last block belonging to
-      // the sealed segment. That ordering is what makes promoting the live
+      // The split is owned by the live provider handle through the sink, so
+      // this event always arrives AFTER the last block belonging to the sealed
+      // segment. That ordering is what makes promoting the live
       // stream here correct; it is not a guess about where the server cut.
       //
       // It still follows the one visible-row scroll rule. Automatic queue
@@ -1290,14 +1290,23 @@ export default function ChatView({
       commitMessages(prev => insertMessageBatchByTs(prev, steeredMessages))
       // The rows have now genuinely left `chat.pending_messages`, so retire the
       // tray entries the deferred-cut window kept durably queued but hidden.
-      // A no-op on the route-split (Codex) path, where the send's own 202
-      // already dropped them — the cut is simply the one place that owns the
-      // hand-off.
+      // The cut is the one place that owns the hand-off for both providers.
       for (const msg of steeredMessages) {
         const cid = cidOf(msg)
         if (cid != null) pendingQueue.cancelByCid(cid)
       }
       forgetSendIntent({ cidList: steeredMessages.map(cidOf) })
+    },
+    onSteerDeliveryFailed: ({ consumePendingCids } = {}) => {
+      const cids = Array.isArray(consumePendingCids)
+        ? consumePendingCids
+        : []
+      pendingQueue.releaseSteerReservation(cids)
+      forgetSendIntent({ cidList: cids })
+      // A direct Cmd/Ctrl+Enter steer has no local tray row. The same
+      // authoritative refresh restores it from the durable reserve; existing
+      // fast-forward rows simply become actionable again.
+      fetchMessages({ force: true })
     },
   })
   useEffect(() => {
@@ -2249,20 +2258,18 @@ export default function ChatView({
         // turn. Where the row LIVES right now is what `cut_deferred` states.
         if (result?.status === 'steered') {
           if (directSteer) {
-            // No tray row was ever created. Codex's cut event has already made
-            // the message inline; Claude's deferred cut will do so when its
-            // interrupt boundary lands. Until then the durable server reserve
-            // stays intentionally invisible rather than flashing as queued.
-            // Keep its cid-keyed intent until that authoritative cut consumes
-            // it; response and SSE delivery can arrive in either order.
+            // No tray row was ever created. The deferred cut will make the
+            // message inline when provider delivery settles. Until then the
+            // durable server reserve stays intentionally invisible rather
+            // than flashing as queued. Keep its cid-keyed intent until that
+            // authoritative cut consumes it; response and SSE delivery can
+            // arrive in either order.
           } else if (result.cut_deferred) {
-            // Claude: the transcript split waits for the runner's interrupt
-            // boundary, so the row is STILL queued server-side and its tray
-            // entry stays — dropping it here left the owner's message with
-            // nowhere to render for the whole deferred window. Resolve THIS
-            // send's own row and nothing else: confirm it by cid against the
-            // server's echoed entry (which carries the durable ts fast-forward
-            // needs).
+            // The transcript split waits for provider acknowledgement, so the
+            // row is STILL queued server-side and its tray entry stays.
+            // Resolve THIS send's own row and nothing else: confirm it by cid
+            // against the server's echoed entry (which carries the durable ts
+            // fast-forward needs).
             //
             // Not `hydrate(result.pending_messages)`: that list is a snapshot
             // taken at steer time, and a wholesale reconcile against it is
@@ -2284,9 +2291,8 @@ export default function ChatView({
             // Its cid-keyed intent remains beside the durable queued row until
             // the cut consumes both, regardless of response/event order.
           } else {
-            // Codex: the split already ran at the route, so the row is in the
-            // transcript and `steered_into_turn` (already sent) renders it
-            // inline — drop the optimistic queued-tray entry, it never queued.
+            // Compatibility with an older immediate-cut backend: the row is in
+            // the transcript and `steered_into_turn` renders it inline.
             pendingQueue.cancelByCid(queuedMsg.cid)
           }
         }
@@ -3117,7 +3123,7 @@ export default function ChatView({
       // presentation before the request so the tray closes once, at the
       // deliberate steer action. The records remain in pendingQueue until the
       // authoritative cut, which keeps Stop/reconnect recovery honest while a
-      // Claude cut is deferred.
+      // provider cut is deferred.
       pendingQueue.reserveForSteer(consumePendingCids)
       const result = await streamSend(content, attachments, {
         forceSteer: true,
@@ -3131,12 +3137,11 @@ export default function ChatView({
       })
       if (result?.status === 'steered') {
         if (result.cut_deferred) {
-          // Claude: the split waits for the runner's interrupt boundary. Keep
-          // the accepted rows reserved (and therefore out of the tray) until
-          // onSteeredIntoTurn retires them at that authoritative cut.
+          // The handle owns provider settlement. Keep accepted rows reserved
+          // (and therefore out of the tray) until onSteeredIntoTurn retires
+          // them at the authoritative cut.
         } else if (Array.isArray(result.pending_messages)) {
-          // Codex: the route already split, so the echoed queue no longer holds
-          // these rows and onSteeredIntoTurn has rendered them inline.
+          // Compatibility with an older immediate-cut backend.
           pendingQueue.hydrate(result.pending_messages)
         } else {
           // A backend that echoes no queue at all: remove exactly the steered
@@ -3173,10 +3178,8 @@ export default function ChatView({
   // interrupts the running turn. The backend force-steers (bypassing the
   // steer_enabled opt-in) for BOTH providers; the rows render inline when the
   // `steered_into_turn` SSE event reports the transcript split (onSteeredIntoTurn
-  // above), and THAT is when they leave the local tray. Codex splits at the
-  // route, so the split is already done when the POST resolves; Claude splits at
-  // its next content-block boundary, so its 202 comes back `cut_deferred` and
-  // the rows stay durably queued—but presentation-reserved—until the cut lands.
+  // above), and THAT is when they leave the local tray. Both providers defer
+  // the cut until their live handle settles delivery.
   async function handleSteer() {
     if (handlingSteerRef.current) return
     handlingSteerRef.current = true

--- a/frontend/src/components/ChatView/__tests__/steerCutBoundary.test.js
+++ b/frontend/src/components/ChatView/__tests__/steerCutBoundary.test.js
@@ -39,11 +39,12 @@ function sliceBranch(source, fromNeedle, toNeedle) {
   return source.slice(from, to)
 }
 
-test('a steer has exactly one event and one tray reconciler', () => {
+test('a steer has no duplicate accepted event beside its settlement outcomes', () => {
   // The send's own 202 already carries `cut_deferred` + the still-queued row,
   // so a second "accepted" SSE event would be a parallel channel reconciling
   // the same tray from the same pre-cut snapshot — racing the response it
-  // duplicates. The steer wire has one event: the cut.
+  // duplicates. The steer wire has only terminal settlement outcomes: the
+  // committed cut or a delivery failure that leaves the row queued.
   assert.ok(
     !streamSource.includes('steer_accepted'),
     'no second steer event may reconcile the tray beside the 202',
@@ -54,14 +55,17 @@ test('a steer has exactly one event and one tray reconciler', () => {
   )
   const steerEvents = [...streamSource.matchAll(/event\.type === '(steer[^']*)'/g)]
     .map(m => m[1])
-  assert.deepEqual(steerEvents, ['steered_into_turn'])
+  assert.deepEqual(steerEvents, [
+    'steered_into_turn',
+    'steer_delivery_failed',
+  ])
 })
 
 test('only the cut re-bases the stream, and a replay refetches instead', () => {
   const cut = sliceBranch(
     streamSource,
     "event.type === 'steered_into_turn'",
-    "event.type === 'done'",
+    "event.type === 'steer_delivery_failed'",
   )
   assert.match(
     cut, /flushBuffer\(\)/,
@@ -82,6 +86,35 @@ test('only the cut re-bases the stream, and a replay refetches instead', () => {
     'dropping the replayed segment is only truthful if the sealed message and '
     + 'the steered row are loaded — a socket that died before the cut arrived '
     + 'live has neither, so the replay asks for the authoritative read',
+  )
+})
+
+test('a failed provider settlement restores the durable queued row', () => {
+  const streamHandler = sliceBranch(
+    streamSource,
+    "event.type === 'steer_delivery_failed'",
+    "event.type === 'done'",
+  )
+  assert.match(streamHandler, /onSteerDeliveryFailedRef\.current\?\./)
+
+  const chatHandler = sliceBranch(
+    chatViewSource,
+    'onSteerDeliveryFailed: ({',
+    '\n    },\n  })',
+  )
+  assert.match(
+    chatHandler,
+    /pendingQueue\.releaseSteerReservation\(cids\)/,
+    'the still-pending row must become actionable again',
+  )
+  assert.match(
+    chatHandler,
+    /fetchMessages\(\{ force: true \}\)/,
+    'direct steers have no local tray row, so restore from durable state',
+  )
+  assert.ok(
+    !streamHandler.includes('flushBuffer()'),
+    'a failed delivery is not a transcript cut and must not re-base output',
   )
 })
 
@@ -133,7 +166,7 @@ test('a deferred steer resolves only its OWN row, in any order', () => {
   assert.match(
     steeredBranch,
     /\} else \{[\s\S]*?pendingQueue\.cancelByCid\(queuedMsg\.cid\)/,
-    'a route-split (Codex) steer still drops the tray entry immediately',
+    'an older immediate-cut response still drops the tray entry immediately',
   )
 })
 

--- a/frontend/src/components/ChatView/useStreamConnection.js
+++ b/frontend/src/components/ChatView/useStreamConnection.js
@@ -133,17 +133,19 @@ const BROADCAST_REGISTRATION_WINDOW_MS = 1500
  *   steered_into_turn     THE CUT. The transcript split has committed: the
  *                         pre-steer assistant segment is sealed and the
  *                         steered user row(s) are in the transcript
- *                         { ts, content, messages }. Published by the steer
- *                         route for Codex (which splits there) and by the
- *                         Claude runner at its seal. Notifies caller so it
- *                         promotes the live stream into its own message,
+ *                         { ts, content, messages }. Published by the live
+ *                         provider handle at its durable seal. Notifies caller
+ *                         so it promotes the live stream into its own message,
  *                         re-bases streamItems for the continuation, and
  *                         renders the row inline as content growth. There is
- *                         no separate "accepted" event. On the deferred
- *                         (Claude) path an existing queued-row conversion
+ *                         no separate "accepted" event. During deferred
+ *                         settlement an existing queued-row conversion
  *                         remains in the tray until the cut; a direct composer
  *                         steer has no tray row and keeps its durable reserve
  *                         hidden until either the cut or a queued fallback.
+ *   steer_delivery_failed Provider delivery did not settle before the turn
+ *                         ended. The named cids remain durably queued; release
+ *                         their temporary steer reservation and reconcile.
  *   catch_up_done         Replay burst finished; live events follow.
  *   error                 { message }. Surfaced inline.
  *   done                  Turn complete; SSE closes.
@@ -215,6 +217,7 @@ export default function useStreamConnection(chatId, {
   onNeedsRefresh,
   onQueuedTurnStarting,
   onSteeredIntoTurn,
+  onSteerDeliveryFailed,
   onLiveQuestion,
 }) {
   const initialStoredStreamItems = readStoredStreamSnapshot(chatId)
@@ -611,6 +614,8 @@ export default function useStreamConnection(chatId, {
   onQueuedTurnStartingRef.current = onQueuedTurnStarting
   const onSteeredIntoTurnRef = useRef(onSteeredIntoTurn)
   onSteeredIntoTurnRef.current = onSteeredIntoTurn
+  const onSteerDeliveryFailedRef = useRef(onSteerDeliveryFailed)
+  onSteerDeliveryFailedRef.current = onSteerDeliveryFailed
   const onLiveQuestionRef = useRef(onLiveQuestion)
   onLiveQuestionRef.current = onLiveQuestion
   const queuedContinuationRef = useRef(false)
@@ -1123,6 +1128,16 @@ export default function useStreamConnection(chatId, {
                 messages: Array.isArray(event.messages) ? event.messages : null,
               })
             }
+          } else if (event.type === 'steer_delivery_failed') {
+            // Admission succeeded, but the provider control channel never
+            // settled it. The rows are still durable in pending_messages; the
+            // caller releases their temporary hidden reservation and fetches
+            // the authoritative queue.
+            onSteerDeliveryFailedRef.current?.({
+              consumePendingCids: Array.isArray(event.consume_pending_cids)
+                ? event.consume_pending_cids
+                : [],
+            })
           } else if (event.type === 'done') {
             flushBuffer()
             commitCatchUp()


### PR DESCRIPTION
## Problem

Codex steering waited for the provider control acknowledgement while the message route held the per-chat transition and queue locks. If that acknowledgement stalled, later Send and Stop requests for the chat could not acquire the lock, so the chat appeared stuck.

## Fix

- make steering admission return after the durable queued row is owned by the live handle
- settle the provider acknowledgement and transcript cut asynchronously, taking the queue lock only for the short committed cut
- preserve exactly-once behavior across retries, Stop races, closed turns, write failures, and turn teardown
- restore the queued row in the client when provider settlement fails
- keep the transcript cut as the only event that rebases live output

## Prior work

#253 established that the steering cut must be published where the transcript actually splits. This follow-up keeps that cut contract but moves the Codex provider acknowledgement out of the request lock, covering the control-channel stall case that #253 did not address.

## Validation

- backend steering and Codex runner tests: 131 passed
- backend fast contract suite: 58 passed
- frontend library tests: 2,145 passed
- frontend hook tests: 66 passed
- production PWA/offline build passed