### PR TITLE
Focus chat composer after desktop navigation

### DIFF
--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -829,12 +829,16 @@ export default function Shell() {
     requestComposer(chatId, { focus: true })
   }
 
-  // Route restoration and direct chat links do not pass through a click
-  // handler. Treat the active desktop chat as the same open intent so a web
-  // session always lands at the next typing point. The modality gate keeps
-  // phones and tablets from opening their software keyboard on navigation.
+  // A restored single-screen chat has no click handler to request focus. Keep
+  // that one startup intent separate from later workspace projection changes:
+  // entering Standard mode must not turn a mode toggle into composer focus.
+  const startupChatComposerFocusPendingRef = useRef(
+    activeView === 'chat' && effectiveViewMode === 'single',
+  )
   useEffect(() => {
+    if (!startupChatComposerFocusPendingRef.current) return
     if (activeView !== 'chat' || activeChatId == null) return
+    startupChatComposerFocusPendingRef.current = false
     focusDesktopChatPaneComposer(activeChatId)
   }, [activeView, activeChatId])
 

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -829,6 +829,15 @@ export default function Shell() {
     requestComposer(chatId, { focus: true })
   }
 
+  // Route restoration and direct chat links do not pass through a click
+  // handler. Treat the active desktop chat as the same open intent so a web
+  // session always lands at the next typing point. The modality gate keeps
+  // phones and tablets from opening their software keyboard on navigation.
+  useEffect(() => {
+    if (activeView !== 'chat' || activeChatId == null) return
+    focusDesktopChatPaneComposer(activeChatId)
+  }, [activeView, activeChatId])
+
   const handleComposerRequestHandled = useCallback((token) => {
     setComposerRequest(prev => (
       prev?.token === token ? null : prev
@@ -3328,6 +3337,7 @@ export default function Shell() {
   function selectChat(id) {
     clearChatAttention(id)
     navTo('chat', { chatId: id })
+    focusDesktopChatPaneComposer(id)
   }
 
   async function deleteChat(id) {
@@ -3792,6 +3802,7 @@ export default function Shell() {
                 onActivate={() => {
                   const { view, opts } = tabModel.tabNavTarget(tab)
                   navTo(view, opts)
+                  if (tab.kind === 'chat') focusDesktopChatPaneComposer(tab.id)
                 }}
                 onClose={() => closeTab(tab)}
                 onContextMenu={paneModel.WORKSPACE_SPLITS_ENABLED

--- a/frontend/src/components/Shell/WorkspaceChrome.jsx
+++ b/frontend/src/components/Shell/WorkspaceChrome.jsx
@@ -113,19 +113,19 @@ export default function WorkspaceChrome({
   // ALREADY-ACTIVE tab, though, is a focus-only action — focus is UI-local and
   // must NOT push history (design §5); navTo would push a duplicate entry so Back
   // appears to do nothing (finding: dup history entry for a focus-only click). So
-  // that case just focuses the pane.
+  // that case just focuses the pane. Either route hands a selected chat to its
+  // composer on desktop, so the tab click finishes where typing begins.
   const activateTab = useCallback((paneId, tab) => {
     const pane = workspace.panes[paneId]
     const key = tabModel.tabKey(tab)
-    const newlyFocused = workspace.focusedPaneId !== paneId
     if (pane && pane.activeTabKey === key) {
       dispatchWorkspace({ type: 'FOCUS', paneId })
-      if (newlyFocused && tab.kind === 'chat') onChatPaneSelected?.(tab.id)
+      if (tab.kind === 'chat') onChatPaneSelected?.(tab.id)
       return
     }
     const { view, opts } = tabModel.tabNavTarget(tab)
     navTo(view, { ...opts, paneId })
-    if (newlyFocused && tab.kind === 'chat') onChatPaneSelected?.(tab.id)
+    if (tab.kind === 'chat') onChatPaneSelected?.(tab.id)
   }, [navTo, workspace, dispatchWorkspace, onChatPaneSelected])
 
   // ── Divider drag (imperative, React-free per frame) ──────────────────────

--- a/frontend/src/components/Shell/__tests__/chatHandoff.test.js
+++ b/frontend/src/components/Shell/__tests__/chatHandoff.test.js
@@ -112,8 +112,11 @@ test('app-supplied drafts update retained composers as well as remounted chats',
 
 test('direct desktop chat opens hand focus to the destination composer', () => {
   assert.match(shell,
-    /useEffect\(\(\) => \{[\s\S]*activeView !== 'chat' \|\| activeChatId == null[\s\S]*focusDesktopChatPaneComposer\(activeChatId\)[\s\S]*\}, \[activeView, activeChatId\]\)/,
-    'restored and directly linked chats must focus without relying on a click handler')
+    /startupChatComposerFocusPendingRef = useRef\([\s\S]*activeView === 'chat' && effectiveViewMode === 'single'[\s\S]*\)/,
+    'only a restored single-screen chat may retain the startup focus intent')
+  assert.match(shell,
+    /if \(!startupChatComposerFocusPendingRef\.current\) return[\s\S]*activeView !== 'chat' \|\| activeChatId == null[\s\S]*startupChatComposerFocusPendingRef\.current = false[\s\S]*focusDesktopChatPaneComposer\(activeChatId\)/,
+    'restored chat focus must be one-shot rather than following later mode changes')
   assert.match(shell,
     /newChat\(\{ focusComposer: true, recordHistory: true \}\)/,
     'the direct New chat action must request composer focus')

--- a/frontend/src/components/Shell/__tests__/chatHandoff.test.js
+++ b/frontend/src/components/Shell/__tests__/chatHandoff.test.js
@@ -5,6 +5,7 @@ import assert from 'node:assert/strict'
 const shell = readFileSync(new URL('../Shell.jsx', import.meta.url), 'utf8')
 const shellCss = readFileSync(new URL('../Shell.css', import.meta.url), 'utf8')
 const chatSurfaceModel = readFileSync(new URL('../chatSurfaceModel.js', import.meta.url), 'utf8')
+const workspaceChrome = readFileSync(new URL('../WorkspaceChrome.jsx', import.meta.url), 'utf8')
 const chatView = readFileSync(new URL('../../ChatView/ChatView.jsx', import.meta.url), 'utf8')
 const apiClient = readFileSync(new URL('../../../api/client.js', import.meta.url), 'utf8')
 
@@ -107,6 +108,30 @@ test('app-supplied drafts update retained composers as well as remounted chats',
     'a retained ChatView must apply the requested draft to controlled state')
   assert.match(chatView, /if \(!composerRequest\.focus\) \{[\s\S]*onComposerRequestHandled\?\.\(token\)/,
     'a draft-only handoff must settle without stealing focus')
+})
+
+test('direct desktop chat opens hand focus to the destination composer', () => {
+  assert.match(shell,
+    /useEffect\(\(\) => \{[\s\S]*activeView !== 'chat' \|\| activeChatId == null[\s\S]*focusDesktopChatPaneComposer\(activeChatId\)[\s\S]*\}, \[activeView, activeChatId\]\)/,
+    'restored and directly linked chats must focus without relying on a click handler')
+  assert.match(shell,
+    /newChat\(\{ focusComposer: true, recordHistory: true \}\)/,
+    'the direct New chat action must request composer focus')
+  assert.match(shell,
+    /if \(focusComposer\) requestComposer\(chatId, \{ focus: true \}\)/,
+    'New chat must deliver its focus request after the destination is known')
+  const selectChat = shell.match(/function selectChat\(id\) \{([\s\S]*?)\n  \}/)?.[1] || ''
+  assert.match(selectChat,
+    /navTo\('chat', \{ chatId: id \}\)[\s\S]*focusDesktopChatPaneComposer\(id\)/,
+    'drawer and settings chat selection must focus after requesting navigation')
+  assert.match(shell,
+    /onActivate=\{\(\) => \{[\s\S]*tabModel\.tabNavTarget\(tab\)[\s\S]*navTo\(view, opts\)[\s\S]*tab\.kind === 'chat'[\s\S]*focusDesktopChatPaneComposer\(tab\.id\)/,
+    'the single-pane tab strip must focus a selected chat composer')
+  const selectedChatHandoffs = workspaceChrome.match(
+    /if \(tab\.kind === 'chat'\) onChatPaneSelected\?\.\(tab\.id\)/g,
+  ) || []
+  assert.equal(selectedChatHandoffs.length, 2,
+    'both active-tab and tab-switch paths in a tiled pane must focus chat composers')
 })
 
 test('the held chat is an opaque layer above staging until the atomic swap', () => {


### PR DESCRIPTION
## Summary
- focus the message composer when a desktop session restores or directly opens a chat
- keep the focus handoff consistent for drawer selections and tab activation
- preserve touch-primary navigation so mobile keyboards are not summoned automatically

## Testing
- `npm test`
- `npm run build`