### PR TITLE
Keep the commit helper on live platform source

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,6 +10,7 @@ import logging
 import mimetypes
 import os
 import re
+import shlex
 import time
 from contextlib import asynccontextmanager
 from datetime import timezone
@@ -41,6 +42,7 @@ from app.database import (
 )
 from app.http_caching import strip_range
 from app.memory_observability import record_memory_checkpoint
+from app.storage_io import atomic_write
 from app import activity, models
 # providers and push are on the agent's write surface; deferred into
 # lifespan with try/except so a SyntaxError in either doesn't prevent
@@ -58,6 +60,23 @@ from app.routes import (
 )
 
 _BOOT_ID = os.environ.get("MOBIUS_BOOT_ID") or f"{os.getpid()}-{time.time_ns()}"
+
+
+def _install_pm_commit_launcher(source: Path, target: Path) -> bool:
+  """Point the stable command path at the helper in the served checkout."""
+  if not source.is_file():
+    raise FileNotFoundError(source)
+  launcher = (
+    f"#!/bin/sh\nexec {shlex.quote(str(source))} \"$@\"\n"
+  ).encode()
+  try:
+    if target.read_bytes() == launcher and target.stat().st_mode & 0o111:
+      return False
+  except FileNotFoundError:
+    pass
+  atomic_write(target, launcher)
+  target.chmod(0o755)
+  return True
 
 
 def _init_db():
@@ -142,6 +161,14 @@ async def lifespan(app):
   import asyncio as _asyncio
   import logging as _logging
   _log = _logging.getLogger(__name__)
+  try:
+    _install_pm_commit_launcher(
+      Path(__file__).resolve().parents[1] / "scripts" / "pm-commit",
+      Path(get_settings().data_dir) / ".pm-commit",
+    )
+  except Exception as exc:
+    # Agent commit tooling must never make the owner-facing service unbootable.
+    _log.error("pm-commit launcher refresh failed: %s", exc, exc_info=True)
   record_memory_checkpoint("lifespan_start")
   # Wrapped: providers.py is on the agent's write surface. A broken
   # providers.py shouldn't take down the server — log and skip the

--- a/backend/scripts/entrypoint.sh
+++ b/backend/scripts/entrypoint.sh
@@ -1268,9 +1268,9 @@ su -s /bin/sh mobius -c '
   git config --global credential.helper "!gh auth git-credential"
 ' 2>/dev/null || true
 
-# Only copy the pm-commit helper if missing or if the image version
-# differs from the on-disk copy. Blindly overwriting on every boot wipes
-# any instance-local edits the agent or operator may have made.
+# Seed a usable image-floor helper before the app starts. FastAPI lifespan
+# replaces this target with a launcher to the served platform copy, so later
+# source updates remain authoritative without another container rebuild.
 if [ ! -f /data/.pm-commit ] || ! cmp -s /app/scripts/pm-commit /data/.pm-commit; then
   cp /app/scripts/pm-commit /data/.pm-commit
   chmod +x /data/.pm-commit

--- a/backend/tests/test_pm_commit.py
+++ b/backend/tests/test_pm_commit.py
@@ -6,6 +6,10 @@ import os
 from pathlib import Path
 import subprocess
 
+import pytest
+
+from app.main import _install_pm_commit_launcher
+
 
 SCRIPT = Path(__file__).parents[1] / "scripts" / "pm-commit"
 
@@ -84,3 +88,36 @@ def test_broad_snapshot_mode_does_not_exist(tmp_path):
 
   assert result.returncode == 2
   assert git(work, "status", "--short") == "M owned.txt"
+
+
+def test_launcher_follows_live_helper_updates_without_reinstall(tmp_path):
+  source = tmp_path / "platform" / "pm-commit"
+  target = tmp_path / "data" / ".pm-commit"
+  source.parent.mkdir()
+  target.parent.mkdir()
+  target.write_text("stale image copy\n")
+
+  source.write_text("#!/bin/sh\nprintf 'first:%s\\n' \"$1\"\n")
+  source.chmod(0o755)
+  assert _install_pm_commit_launcher(source, target)
+  assert subprocess.run(
+    [str(target), "one argument"], check=True, capture_output=True, text=True,
+  ).stdout == "first:one argument\n"
+
+  source.write_text("#!/bin/sh\nprintf 'second:%s\\n' \"$1\"\n")
+  assert subprocess.run(
+    [str(target), "same launcher"], check=True, capture_output=True, text=True,
+  ).stdout == "second:same launcher\n"
+  assert not _install_pm_commit_launcher(source, target)
+
+
+def test_launcher_preserves_seed_when_live_helper_is_missing(tmp_path):
+  source = tmp_path / "platform" / "pm-commit"
+  target = tmp_path / "data" / ".pm-commit"
+  target.parent.mkdir()
+  target.write_text("usable image copy\n")
+
+  with pytest.raises(FileNotFoundError):
+    _install_pm_commit_launcher(source, target)
+
+  assert target.read_text() == "usable image copy\n"


### PR DESCRIPTION
## Summary
- replace the image-baked command at app startup with a tiny launcher to the helper in the live platform checkout
- keep one intuitive `pm-commit` command while later helper updates activate automatically, without agent preflight calls
- preserve the usable baked fallback if a damaged live checkout is missing the helper
- cover stale-copy replacement, argument forwarding, future live updates, and missing-source fallback

This is a follow-up to #335, which fixed the helper's exact-path behavior. It closes the remaining activation gap where the command on `PATH` could still be an older baked copy.

## Testing
- `python3 -m py_compile backend/app/main.py backend/tests/test_pm_commit.py`
- `bash -n backend/scripts/entrypoint.sh`
- `scripts/wt-pytest.sh tests/test_pm_commit.py tests/test_test_entrypoint.py tests/test_routes_init_resilience.py -q` (14 passed)
- `scripts/test.sh --fast` (60 passed)
- complete host backend sweep on the preceding reviewed revision, excluding the host-incompatible no-clone route fixture (3,397 passed, 4 skipped, 1 deselected); focused and fast gates rerun after the final fallback guard
- containerized full gate unavailable in this runtime; required CI on submission