### PR TITLE
Recover screenshot capture from poisoned browser sessions

### DIFF
--- a/backend/scripts/agent-screenshot.sh
+++ b/backend/scripts/agent-screenshot.sh
@@ -43,18 +43,51 @@ set -euo pipefail
 # process-level `timeout` utility instead, which preserves daemon identity and
 # lets the caller inspect/close the same session after this helper returns.
 
+ORIGINAL_ARGS=("$@")
 BROWSER_ERROR_FILE=""
+BROWSER_TIMEOUT_FILE=""
 WARMUP_OUT=""
 CAPTURE_OUT=""
+BROWSER_PHASE="browser startup"
+SCREENSHOT_RECOVERY_COUNT="${MOBIUS_SCREENSHOT_RECOVERY_COUNT:-0}"
+
+case "$SCREENSHOT_RECOVERY_COUNT" in
+  0|1) : ;;
+  *) SCREENSHOT_RECOVERY_COUNT=1 ;;
+esac
 
 cleanup() {
   local path
-  for path in "$BROWSER_ERROR_FILE" "$WARMUP_OUT" "$CAPTURE_OUT"; do
+  for path in \
+    "$BROWSER_ERROR_FILE" "$BROWSER_TIMEOUT_FILE" "$WARMUP_OUT" "$CAPTURE_OUT"
+  do
     [ -z "$path" ] || rm -f "$path"
   done
 }
 
 die() {
+  local timed_out_phase=""
+  if [ -n "$BROWSER_TIMEOUT_FILE" ] && [ -s "$BROWSER_TIMEOUT_FILE" ]; then
+    timed_out_phase="$(head -n 1 "$BROWSER_TIMEOUT_FILE")"
+    if [ "$SCREENSHOT_RECOVERY_COUNT" -eq 0 ]; then
+      printf 'agent-screenshot.sh: %s timed out; restarting this chat\047s isolated browser session once\n' \
+        "$timed_out_phase" >&2
+      # Do not queue `agent-browser close` behind the timed-out daemon. It can
+      # create a competing supervisor while the old command is still in flight.
+      # Go straight to the exact profile-owned process boundary instead.
+      if python3 "$(dirname "${BASH_SOURCE[0]}")/agent_browser_session_reset.py" \
+          "$AGENT_BROWSER_PROFILE"; then
+        clear_stale_browser_profile_lock
+        cleanup
+        export MOBIUS_SCREENSHOT_RECOVERY_COUNT=1
+        exec bash "${BASH_SOURCE[0]}" "${ORIGINAL_ARGS[@]}"
+      fi
+      echo "agent-screenshot.sh: the isolated browser session could not be reset safely" >&2
+    else
+      printf 'agent-screenshot.sh: %s timed out again after one isolated browser-session restart\n' \
+        "$timed_out_phase" >&2
+    fi
+  fi
   printf 'agent-screenshot.sh: %s\n' "$*" >&2
   if [ -n "$BROWSER_ERROR_FILE" ] && [ -s "$BROWSER_ERROR_FILE" ]; then
     tail -n 2 "$BROWSER_ERROR_FILE" | sed 's/^/agent-browser: /' >&2
@@ -66,21 +99,30 @@ browser_command() {
   local timeout_seconds="$1"
   local status=0
   shift
+  if [ -n "$BROWSER_TIMEOUT_FILE" ] && [ -s "$BROWSER_TIMEOUT_FILE" ]; then
+    return 124
+  fi
   : > "$BROWSER_ERROR_FILE"
-  timeout "${timeout_seconds}s" agent-browser "$@" \
+  # The browser daemon outlives this process. Never let it inherit the capture
+  # transaction's flock descriptor or every later capture would block behind a
+  # lock whose owning helper already exited.
+  timeout "${timeout_seconds}s" agent-browser "$@" 9>&- \
     2>"$BROWSER_ERROR_FILE" || status=$?
   if [ "$status" -eq 124 ] && [ ! -s "$BROWSER_ERROR_FILE" ]; then
     printf 'command timed out after %ss\n' "$timeout_seconds" \
       > "$BROWSER_ERROR_FILE"
   fi
+  if [ "$status" -eq 124 ] && [ -n "$BROWSER_TIMEOUT_FILE" ]; then
+    printf '%s\n' "$BROWSER_PHASE" > "$BROWSER_TIMEOUT_FILE"
+  fi
   return "$status"
 }
 
 browser_wait() {
-  local status=0
-  : > "$BROWSER_ERROR_FILE"
-  agent-browser wait "$@" 2>"$BROWSER_ERROR_FILE" || status=$?
-  return "$status"
+  # agent-browser's DOM wait normally returns after its own 25s deadline. The
+  # outer bound is solely for a daemon already poisoned by an earlier caller;
+  # it converts that infrastructure hang into the same one-reset recovery path.
+  browser_command 30 wait "$@"
 }
 
 browser_eval_retry() {
@@ -92,6 +134,7 @@ browser_eval_retry() {
       printf '%s' "$output"
       return 0
     fi
+    [ ! -s "$BROWSER_TIMEOUT_FILE" ] || return 1
     sleep 0.3
   done
   return 1
@@ -137,6 +180,7 @@ PY
         "new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve(true))))" \
         >/dev/null || true
     fi
+    [ ! -s "$BROWSER_TIMEOUT_FILE" ] || return 1
     sleep 0.5
   done
   return 1
@@ -151,14 +195,17 @@ browser_open_origin_retry() {
   local attempt
   for attempt in 1 2 3 4 5; do
     browser_command 5 open "$url" >/dev/null || true
+    [ ! -s "$BROWSER_TIMEOUT_FILE" ] || return 1
     sleep 0.2
     current="$(
       browser_command 5 get url || true
     )"
+    [ ! -s "$BROWSER_TIMEOUT_FILE" ] || return 1
     sleep 0.2
     confirmed="$(
       browser_command 5 get url || true
     )"
+    [ ! -s "$BROWSER_TIMEOUT_FILE" ] || return 1
     if [ "$current" != "$confirmed" ]; then
       # In-shell deep links intentionally canonicalize to `/shell/` after the
       # router consumes their intent. That redirect can land between these two
@@ -199,14 +246,17 @@ browser_open_exact_retry() {
   local attempt
   for attempt in 1 2 3 4 5; do
     browser_command 5 open "$url" >/dev/null || true
+    [ ! -s "$BROWSER_TIMEOUT_FILE" ] || return 1
     sleep 0.2
     current="$(
       browser_command 5 get url || true
     )"
+    [ ! -s "$BROWSER_TIMEOUT_FILE" ] || return 1
     sleep 0.2
     confirmed="$(
       browser_command 5 get url || true
     )"
+    [ ! -s "$BROWSER_TIMEOUT_FILE" ] || return 1
     [ "$current" = "$url" ] && [ "$confirmed" = "$url" ] && return 0
   done
   return 1
@@ -219,6 +269,7 @@ browser_set_viewport_retry() {
         >/dev/null; then
       return 0
     fi
+    [ ! -s "$BROWSER_TIMEOUT_FILE" ] || return 1
     sleep 0.2
   done
   return 1
@@ -377,6 +428,7 @@ fi
 
 clear_stale_browser_profile_lock
 BROWSER_ERROR_FILE="$(mktemp "${TMPDIR:-/tmp}/mobius-agent-browser-error.XXXXXX")"
+BROWSER_TIMEOUT_FILE="$(mktemp "${TMPDIR:-/tmp}/mobius-agent-browser-timeout.XXXXXX")"
 trap cleanup EXIT
 
 # Start the browser, then wait narrowly for its command socket before applying
@@ -395,6 +447,7 @@ fi
 # bootstrap URL below. The later detach still protects the final target
 # navigation from a controller installed between authentication and capture.
 if [ "$PRESERVE_CACHE" -eq 0 ]; then
+  BROWSER_PHASE="retained browser-state cleanup"
   browser_eval_retry \
     "(async () => { try { const regs = await navigator.serviceWorker?.getRegistrations?.() || []; await Promise.all(regs.map((r) => r.unregister())); } catch {} return true })()" \
     >/dev/null || true
@@ -408,6 +461,7 @@ fi
 # cannot restore the last chat or disappear like Chromium's JSON viewer.
 # The JWT travels via stdin, never argv or /proc/<pid>/cmdline.
 TOKEN_READY=0
+BROWSER_PHASE="authentication setup"
 for attempt in 1 2 3; do
   if ! browser_open_origin_retry \
     "${API_BASE_URL}/api/browser-bootstrap" bootstrap; then
@@ -452,6 +506,7 @@ fi
 # and bounded. The owner's real browser/profile is never touched.
 TARGET_ROUTE="$ROUTE"
 if [ "$PRESERVE_CACHE" -eq 0 ]; then
+  BROWSER_PHASE="target controller detachment"
   if ! browser_open_exact_retry "about:blank"; then
     die "browser did not detach before target navigation"
   fi
@@ -463,6 +518,7 @@ if [ "$PRESERVE_CACHE" -eq 0 ]; then
 fi
 
 # Now navigate to the actual target route, authenticated.
+BROWSER_PHASE="target navigation"
 if ! browser_open_origin_retry "${API_BASE_URL}${TARGET_ROUTE}" target; then
   die "browser did not reach the target route"
 fi
@@ -471,6 +527,7 @@ fi
 # Applying device metrics during that gap reports success on the outgoing page,
 # then the newly-created shell page falls back to Chromium's default viewport.
 # Wait on browser paint ownership before configuring the final page.
+BROWSER_PHASE="target initial paint"
 if ! browser_wait --fn \
   "document.readyState === 'complete' && performance.getEntriesByName('first-contentful-paint').length > 0" \
   >/dev/null; then
@@ -485,6 +542,7 @@ sleep 0.3
 
 # Dismiss the PWA install banner if it surfaces — it covers the bottom
 # of the view and would distract from the actual page.
+BROWSER_PHASE="target preparation"
 browser_command 2 find text "Not now" click >/dev/null || true
 sleep 0.3
 
@@ -493,6 +551,7 @@ sleep 0.3
 # clear it, and reload onto LoginForm. Verify the token with a protected request
 # at the FINAL capture boundary, after the settle/banner work above. The token is
 # read inside the page and never appears in argv or output.
+BROWSER_PHASE="authentication verification"
 AUTH_OK="$(browser_eval_retry \
   "(async () => { const token = localStorage.getItem('token'); if (!token || document.querySelector('input[type=password]')) return false; try { const res = await fetch('/api/chats?agent-screenshot-auth=' + Date.now(), { cache: 'no-store', headers: { Authorization: 'Bearer ' + token } }); return res.status === 200 && !!localStorage.getItem('token') && !document.querySelector('input[type=password]'); } catch { return false; } })()" \
   || true)"
@@ -534,6 +593,7 @@ PY
       )" || {
         die "current shell entry asset could not be resolved"
       }
+      BROWSER_PHASE="shell freshness verification"
       LOADED_SHELL_ENTRY_RAW="$(
         browser_eval_retry \
           "(() => { const src = document.querySelector('script[type=\"module\"][src*=\"/assets/index-\"]')?.src || ''; return src.split('/').pop() })()" \
@@ -555,6 +615,7 @@ PY
     # its private handoff classes or compositor attributes. Once the owner says
     # settled, give style/layout two frames to commit.
     SHELL_SETTLED_EXPR="document.querySelector('.shell[data-workspace-visual-state=\"settled\"]') !== null && performance.getEntriesByName('first-contentful-paint').length > 0"
+    BROWSER_PHASE="shell visual readiness"
     if ! browser_wait --fn "$SHELL_SETTLED_EXPR" >/dev/null; then
       die "shell did not reach a settled visual state before capture"
     fi
@@ -570,6 +631,7 @@ esac
 # handoff, or agent-browser's about:blank detach can replace that page after the
 # startup viewport command. Reapply before drawer/app checks and immediately
 # before every capture attempt; the kept PNG's IHDR is the race-free proof.
+BROWSER_PHASE="final viewport configuration"
 if ! browser_set_viewport_retry; then
   die "target page did not retain the requested viewport"
 fi
@@ -578,6 +640,7 @@ fi
 # or still exiting, which makes an otherwise-correct app screenshot capture the
 # scrim/drawer transition. Close only the mobile modal form; the desktop docked
 # sidebar is part of the partner's actual layout and stays untouched.
+BROWSER_PHASE="mobile navigation preparation"
 browser_eval_retry \
   "(() => { const b = document.querySelector('button[aria-label=\"Toggle navigation\"][aria-expanded=\"true\"]'); if (window.innerWidth < 768 && b) b.click(); return true })()" \
   >/dev/null || true
@@ -597,6 +660,7 @@ fi
 # agent-browser's wait parser has timed out on equivalent IIFE forms.
 case "$ROUTE" in
   /app/*)
+    BROWSER_PHASE="app frame readiness"
     APP_ID="${ROUTE#/app/}"
     APP_ID="${APP_ID%%[/?#]*}"
     case "$APP_ID" in
@@ -622,6 +686,7 @@ WARMUP_OUT="$(mktemp "${TMPDIR:-/tmp}/mobius-screenshot-warmup.XXXXXX.png")"
 # friendly paths such as shell.png and app-42.png; a failed capture must never
 # replace the last known-good image with a partial or misleading frame.
 CAPTURE_OUT="$(mktemp "$(dirname "$OUT")/.mobius-screenshot.XXXXXX.png")"
+BROWSER_PHASE="screenshot capture"
 if ! browser_screenshot_retry "$WARMUP_OUT"; then
   die "page remained too busy to prime capture"
 fi

--- a/backend/scripts/agent_browser_session_reset.py
+++ b/backend/scripts/agent_browser_session_reset.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Reset one poisoned agent-browser session without touching other sessions.
+
+An agent-browser client can be killed while its daemon is still evaluating a
+page command. Later clients then queue behind that unfinished command, so even
+``agent-browser close`` cannot recover the session. The browser profile is the
+stable ownership boundary: Chromium exposes it as an exact ``--user-data-dir``
+argument. Its daemon preserves the same exact ``AGENT_BROWSER_PROFILE`` value
+in its environment, including after Chromium is reparented or exits.
+
+This helper terminates only that validated browser/daemon pair. It deliberately
+does not match process command lines by substring and never targets another
+profile or every agent-browser session.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from pathlib import Path
+import signal
+import sys
+import time
+
+
+PROC_ROOT = Path("/proc")
+
+
+class SessionResetError(RuntimeError):
+  """The requested profile could not be mapped to one safe process pair."""
+
+
+@dataclass(frozen=True)
+class ProcessIdentity:
+  pid: int
+  start_ticks: int
+
+
+@dataclass(frozen=True)
+class SessionProcesses:
+  browser: ProcessIdentity | None
+  daemon: ProcessIdentity | None
+
+
+def _process_state(pid: int, proc_root: Path = PROC_ROOT) -> tuple[int, int]:
+  raw = (proc_root / str(pid) / "stat").read_text(encoding="utf-8")
+  # comm can contain spaces and parentheses. Everything after the final ") "
+  # begins at proc(5) field 3: state, ppid, ... starttime (field 22).
+  fields = raw.rsplit(") ", 1)[1].split()
+  return int(fields[1]), int(fields[19])
+
+
+def _cmdline(pid: int, proc_root: Path = PROC_ROOT) -> tuple[str, ...]:
+  raw = (proc_root / str(pid) / "cmdline").read_bytes()
+  return tuple(
+    part.decode("utf-8", errors="replace")
+    for part in raw.split(b"\0")
+    if part
+  )
+
+
+def _environ(pid: int, proc_root: Path = PROC_ROOT) -> dict[bytes, bytes]:
+  values: dict[bytes, bytes] = {}
+  for raw in (proc_root / str(pid) / "environ").read_bytes().split(b"\0"):
+    key, separator, value = raw.partition(b"=")
+    if separator:
+      values[key] = value
+  return values
+
+
+def _identity(pid: int, proc_root: Path = PROC_ROOT) -> ProcessIdentity:
+  _, start_ticks = _process_state(pid, proc_root)
+  return ProcessIdentity(pid=pid, start_ticks=start_ticks)
+
+
+def _profile_processes(profile: str, proc_root: Path = PROC_ROOT) -> tuple[int, ...]:
+  profile_arg = f"--user-data-dir={os.path.abspath(profile)}"
+  matches: list[int] = []
+  for entry in proc_root.iterdir():
+    if not entry.name.isdigit():
+      continue
+    try:
+      if profile_arg in _cmdline(int(entry.name), proc_root):
+        matches.append(int(entry.name))
+    except (FileNotFoundError, PermissionError, ProcessLookupError):
+      continue
+  return tuple(matches)
+
+
+def find_session_processes(
+  profile: str,
+  proc_root: Path = PROC_ROOT,
+) -> SessionProcesses | None:
+  """Return the one validated daemon/browser pair that owns ``profile``."""
+
+  profile_arg = f"--user-data-dir={os.path.abspath(profile)}"
+  browsers: list[ProcessIdentity] = []
+  daemons: list[ProcessIdentity] = []
+  for entry in proc_root.iterdir():
+    if not entry.name.isdigit():
+      continue
+    pid = int(entry.name)
+    try:
+      args = _cmdline(pid, proc_root)
+      if not args:
+        continue
+      executable = Path(args[0]).name.lower()
+      if (
+        profile_arg in args
+        and "chrome" in executable
+        and not any(arg.startswith("--type=") for arg in args)
+      ):
+        browsers.append(_identity(pid, proc_root))
+      elif executable.startswith("agent-browser"):
+        environment = _environ(pid, proc_root)
+        if environment.get(b"AGENT_BROWSER_PROFILE", b"").decode(
+          "utf-8", errors="surrogateescape",
+        ) == os.path.abspath(profile):
+          daemons.append(_identity(pid, proc_root))
+    except (FileNotFoundError, PermissionError, ProcessLookupError, ValueError):
+      continue
+
+  if not browsers and not daemons:
+    return None
+  if len(browsers) > 1 or len(daemons) > 1:
+    raise SessionResetError(
+      "profile ownership is ambiguous "
+      f"({len(browsers)} browser roots, {len(daemons)} daemons); refusing to guess"
+    )
+  return SessionProcesses(
+    browser=browsers[0] if browsers else None,
+    daemon=daemons[0] if daemons else None,
+  )
+
+
+def _still_same_process(
+  process: ProcessIdentity,
+  proc_root: Path = PROC_ROOT,
+) -> bool:
+  try:
+    return _identity(process.pid, proc_root) == process
+  except (FileNotFoundError, PermissionError, ProcessLookupError, ValueError):
+    return False
+
+
+def terminate_session_processes(
+  processes: SessionProcesses,
+  *,
+  wait_seconds: float = 1.0,
+  proc_root: Path = PROC_ROOT,
+) -> None:
+  """Hard-stop the exact poisoned pair, guarding against PID reuse."""
+
+  # Stop the supervisor first so it cannot launch a replacement Chrome during
+  # shutdown. The browser identity was captured before that reparenting and is
+  # guarded by its start time, so it remains safe to terminate second.
+  ordered = tuple(
+    process
+    for process in (processes.daemon, processes.browser)
+    if process is not None and _still_same_process(process, proc_root)
+  )
+  if not ordered:
+    return
+  # The daemon RPC path is poisoned at this boundary. A graceful signal can let
+  # its supervisor launch a replacement Chrome during shutdown, recreating the
+  # profile race. Kill only the identities verified above, then prove they
+  # disappeared.
+  for process in ordered:
+    try:
+      os.kill(process.pid, signal.SIGKILL)
+    except ProcessLookupError:
+      pass
+
+  deadline = time.monotonic() + wait_seconds
+  while time.monotonic() < deadline:
+    if not any(_still_same_process(process, proc_root) for process in ordered):
+      return
+    time.sleep(0.05)
+  raise SessionResetError("browser session processes did not exit after SIGKILL")
+
+
+def reset_profile(profile: str) -> bool:
+  """Reset the active session for ``profile``; return whether one existed."""
+
+  processes = find_session_processes(profile)
+  if processes is None:
+    return False
+  terminate_session_processes(processes)
+  # Chromium's renderers can outlive their root for a fraction of a second.
+  # Starting a replacement during that handoff races the profile singleton and
+  # correctly makes Chrome refuse the launch. Require the exact profile to be
+  # quiet before the caller removes stale singleton symlinks and restarts.
+  deadline = time.monotonic() + 2.0
+  while time.monotonic() < deadline:
+    if not _profile_processes(profile):
+      return True
+    time.sleep(0.05)
+  raise SessionResetError("browser profile remained active after session reset")
+
+
+def main(argv: list[str]) -> int:
+  if len(argv) != 2:
+    print(f"Usage: {Path(argv[0]).name} <agent-browser-profile>", file=sys.stderr)
+    return 2
+  try:
+    reset_profile(argv[1])
+  except SessionResetError as exc:
+    print(f"agent-browser session reset: {exc}", file=sys.stderr)
+    return 1
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main(sys.argv))

--- a/backend/tests/test_agent_browser_session_reset.py
+++ b/backend/tests/test_agent_browser_session_reset.py
@@ -1,0 +1,178 @@
+"""Safety contract for resetting one poisoned agent-browser profile."""
+
+import importlib.util
+from pathlib import Path
+import sys
+
+import pytest
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "agent_browser_session_reset.py"
+SPEC = importlib.util.spec_from_file_location("agent_browser_session_reset", SCRIPT)
+assert SPEC and SPEC.loader
+RESET = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = RESET
+SPEC.loader.exec_module(RESET)
+
+
+def _write_process(
+  proc_root: Path,
+  pid: int,
+  *,
+  ppid: int,
+  start_ticks: int,
+  args: tuple[str, ...],
+  environment: dict[str, str] | None = None,
+) -> None:
+  process = proc_root / str(pid)
+  process.mkdir()
+  fields = ["S", str(ppid), *("0" for _ in range(17)), str(start_ticks)]
+  (process / "stat").write_text(
+    f"{pid} (process with spaces) {' '.join(fields)}\n",
+    encoding="utf-8",
+  )
+  (process / "cmdline").write_bytes(
+    b"\0".join(arg.encode("utf-8") for arg in args) + b"\0"
+  )
+  (process / "environ").write_bytes(b"\0".join(
+    f"{key}={value}".encode("utf-8")
+    for key, value in (environment or {}).items()
+  ) + b"\0")
+
+
+def test_profile_maps_to_its_exact_browser_root_and_daemon(tmp_path: Path):
+  proc_root = tmp_path / "proc"
+  proc_root.mkdir()
+  profile = str(tmp_path / "profile")
+  _write_process(
+    proc_root,
+    100,
+    ppid=1,
+    start_ticks=10,
+    args=("/opt/agent-browser-linux-x64",),
+    environment={"AGENT_BROWSER_PROFILE": profile},
+  )
+  _write_process(
+    proc_root,
+    101,
+    ppid=1,
+    start_ticks=11,
+    args=("/opt/chrome", f"--user-data-dir={profile}"),
+  )
+  _write_process(
+    proc_root,
+    102,
+    ppid=101,
+    start_ticks=12,
+    args=("/opt/chrome", "--type=renderer", f"--user-data-dir={profile}"),
+  )
+  _write_process(
+    proc_root,
+    201,
+    ppid=100,
+    start_ticks=20,
+    args=("/opt/chrome", "--user-data-dir=/another/profile"),
+  )
+
+  processes = RESET.find_session_processes(profile, proc_root)
+
+  assert processes == RESET.SessionProcesses(
+    browser=RESET.ProcessIdentity(pid=101, start_ticks=11),
+    daemon=RESET.ProcessIdentity(pid=100, start_ticks=10),
+  )
+
+
+def test_ambiguous_profile_ownership_is_never_guessed(tmp_path: Path):
+  proc_root = tmp_path / "proc"
+  proc_root.mkdir()
+  profile = str(tmp_path / "profile")
+  for daemon, browser in ((100, 101), (200, 201)):
+    _write_process(
+      proc_root,
+      daemon,
+      ppid=1,
+      start_ticks=daemon,
+      args=("/opt/agent-browser-linux-x64",),
+      environment={"AGENT_BROWSER_PROFILE": profile},
+    )
+    _write_process(
+      proc_root,
+      browser,
+      ppid=daemon,
+      start_ticks=browser,
+      args=("/opt/chrome", f"--user-data-dir={profile}"),
+    )
+
+  with pytest.raises(RESET.SessionResetError, match="refusing to guess"):
+    RESET.find_session_processes(profile, proc_root)
+
+
+def test_orphaned_browser_root_is_still_owned_by_the_exact_profile(tmp_path: Path):
+  proc_root = tmp_path / "proc"
+  proc_root.mkdir()
+  profile = str(tmp_path / "profile")
+  _write_process(
+    proc_root,
+    101,
+    ppid=1,
+    start_ticks=11,
+    args=("/opt/chrome", f"--user-data-dir={profile}"),
+  )
+
+  assert RESET.find_session_processes(profile, proc_root) == RESET.SessionProcesses(
+    browser=RESET.ProcessIdentity(pid=101, start_ticks=11),
+    daemon=None,
+  )
+
+
+def test_daemon_remains_resettable_before_chrome_starts(tmp_path: Path):
+  proc_root = tmp_path / "proc"
+  proc_root.mkdir()
+  profile = str(tmp_path / "profile")
+  _write_process(
+    proc_root,
+    100,
+    ppid=1,
+    start_ticks=10,
+    args=("/opt/agent-browser-linux-x64",),
+    environment={"AGENT_BROWSER_PROFILE": profile},
+  )
+
+  assert RESET.find_session_processes(profile, proc_root) == RESET.SessionProcesses(
+    browser=None,
+    daemon=RESET.ProcessIdentity(pid=100, start_ticks=10),
+  )
+
+
+def test_pid_reuse_is_rechecked_before_any_signal(tmp_path: Path, monkeypatch):
+  proc_root = tmp_path / "proc"
+  proc_root.mkdir()
+  _write_process(
+    proc_root,
+    100,
+    ppid=1,
+    start_ticks=10,
+    args=("/opt/agent-browser-linux-x64",),
+    environment={"AGENT_BROWSER_PROFILE": str(tmp_path / "profile")},
+  )
+  _write_process(
+    proc_root,
+    101,
+    ppid=100,
+    start_ticks=11,
+    args=("/opt/chrome", f"--user-data-dir={tmp_path / 'profile'}"),
+  )
+  processes = RESET.SessionProcesses(
+    browser=RESET.ProcessIdentity(pid=101, start_ticks=8),
+    daemon=RESET.ProcessIdentity(pid=100, start_ticks=9),
+  )
+  signals: list[tuple[int, int]] = []
+  monkeypatch.setattr(RESET.os, "kill", lambda pid, sig: signals.append((pid, sig)))
+
+  RESET.terminate_session_processes(
+    processes,
+    wait_seconds=0,
+    proc_root=proc_root,
+  )
+
+  assert signals == []

--- a/backend/tests/test_agent_screenshot_auth.py
+++ b/backend/tests/test_agent_screenshot_auth.py
@@ -11,6 +11,9 @@ import pytest
 
 
 SCRIPT = Path(__file__).parents[1] / "scripts" / "agent-screenshot.sh"
+SESSION_RESET = (
+  Path(__file__).parents[1] / "scripts" / "agent_browser_session_reset.py"
+)
 PREVIEW_APP = Path(__file__).parents[1] / "scripts" / "preview_app.sh"
 SHELL = Path(__file__).parents[2] / "frontend" / "src" / "components" / "Shell" / "Shell.jsx"
 STANDALONE = Path(__file__).parents[1] / "app" / "routes" / "standalone.py"
@@ -28,6 +31,7 @@ def _fixture_script(tmp_path: Path) -> Path:
   script = root / "backend" / "scripts" / SCRIPT.name
   script.parent.mkdir(parents=True)
   shutil.copy2(SCRIPT, script)
+  shutil.copy2(SESSION_RESET, script.with_name(SESSION_RESET.name))
   dist = root / "frontend" / "dist"
   dist.mkdir(parents=True)
   (dist / "index.html").write_text(
@@ -60,9 +64,28 @@ def _fake_browser(tmp_path: Path) -> tuple[Path, Path]:
     "\"${AGENT_BROWSER_SESSION-}\" \"${AGENT_BROWSER_PROFILE-}\" "
     "\"${AGENT_BROWSER_ARGS-}\" \"${AGENT_BROWSER_DEFAULT_TIMEOUT-}\" "
     ">> \"$FAKE_BROWSER_IDENTITY_LOG\"\n"
+    "if [ -e /proc/$$/fd/9 ]; then : > \"$FAKE_CAPTURE_LOCK_INHERITED\"; fi\n"
+    "if [ \"$1\" = eval ] && [ \"${2:-}\" != --stdin ]; then\n"
+    "  case \"${FAKE_TIMEOUT_EVAL_MODE:-}\" in\n"
+    "    always) exit 124 ;;\n"
+    "    once)\n"
+    "      if [ ! -e \"$FAKE_TIMEOUT_EVAL_MARKER\" ]; then\n"
+    "        : > \"$FAKE_TIMEOUT_EVAL_MARKER\"\n"
+    "        exit 124\n"
+    "      fi\n"
+    "      ;;\n"
+    "  esac\n"
+    "fi\n"
     "case \"$1\" in\n"
     "  open)\n"
-    "    printf '%s\\n' \"$2\" > \"$FAKE_BROWSER_URL_FILE\"\n"
+    "    if [ \"${FAKE_BOOTSTRAP_INTERCEPT_ONCE:-0}\" = 1 ] "
+    "&& [ \"$2\" = http://mobius.test/api/browser-bootstrap ] "
+    "&& [ ! -e \"$FAKE_BOOTSTRAP_INTERCEPT_MARKER\" ]; then\n"
+    "      : > \"$FAKE_BOOTSTRAP_INTERCEPT_MARKER\"\n"
+    "      printf '%s\\n' http://mobius.test/shell/ > \"$FAKE_BROWSER_URL_FILE\"\n"
+    "    else\n"
+    "      printf '%s\\n' \"$2\" > \"$FAKE_BROWSER_URL_FILE\"\n"
+    "    fi\n"
     "    if [ -n \"${FAKE_CANONICAL_TARGET_URL:-}\" ]; then\n"
     "      case \"$2\" in\n"
     "        */chat/*) printf '%s\\n' \"$FAKE_CANONICAL_TARGET_URL\" > \"$FAKE_BROWSER_NEXT_URL_FILE\" ;;\n"
@@ -138,6 +161,8 @@ def _run_helper(
   canonical_target_url: str | None = None,
   screenshot_tiny_once: bool = False,
   wait_error: bool = False,
+  timeout_eval_mode: str = "",
+  bootstrap_intercept_once: bool = False,
   existing_output: bytes | None = None,
   profile_locked: bool = False,
   subprocess_timeout: float | None = None,
@@ -173,6 +198,7 @@ def _run_helper(
     "FAKE_LOADED_ASSET": loaded_asset or SHELL_ENTRY,
     "FAKE_BROWSER_LOG": str(browser_log),
     "FAKE_BROWSER_IDENTITY_LOG": str(tmp_path / "browser-identity.log"),
+    "FAKE_CAPTURE_LOCK_INHERITED": str(tmp_path / "capture-lock-inherited"),
     "FAKE_SCREENSHOT_MARKER": str(marker),
     "FAKE_VIEWPORT_FAIL_ONCE": "1" if viewport_fail_once else "0",
     "FAKE_VIEWPORT_MARKER": str(tmp_path / "viewport-ready"),
@@ -190,6 +216,10 @@ def _run_helper(
     "FAKE_CANONICAL_TARGET_URL": canonical_target_url or "",
     "FAKE_BROWSER_STDIN_LOG": str(tmp_path / "browser-stdin.log"),
     "FAKE_WAIT_ERROR": "1" if wait_error else "0",
+    "FAKE_TIMEOUT_EVAL_MODE": timeout_eval_mode,
+    "FAKE_TIMEOUT_EVAL_MARKER": str(tmp_path / "timeout-eval-once"),
+    "FAKE_BOOTSTRAP_INTERCEPT_ONCE": "1" if bootstrap_intercept_once else "0",
+    "FAKE_BOOTSTRAP_INTERCEPT_MARKER": str(tmp_path / "bootstrap-intercepted"),
   }
   args = ["bash", str(script)]
   if content_only:
@@ -355,9 +385,9 @@ def test_default_capture_detaches_pwa_state_and_verifies_current_shell(tmp_path:
   detach_indexes = [
     i for i, command in enumerate(commands) if command == "open about:blank"
   ]
-  assert len(detach_indexes) == 2
-  assert detach_indexes[0] < seed_index < detach_indexes[1]
-  assert detach_indexes[1] < target_index < build_index < screenshot_index
+  assert any(index < seed_index for index in detach_indexes)
+  assert any(seed_index < index < target_index for index in detach_indexes)
+  assert target_index < build_index < screenshot_index
 
 
 def test_default_capture_detaches_a_stale_controller_before_requiring_bootstrap(
@@ -380,6 +410,72 @@ def test_default_capture_detaches_a_stale_controller_before_requiring_bootstrap(
     if command == "open http://mobius.test/api/browser-bootstrap"
   )
   assert first_bootstrap < preflight_unregister < first_detach < second_bootstrap
+
+
+def test_stale_worker_bootstrap_interception_recovers_before_authentication(
+  tmp_path: Path,
+):
+  result, output, marker, browser_log = _run_helper(
+    tmp_path,
+    auth_ok=True,
+    bootstrap_intercept_once=True,
+  )
+
+  assert result.returncode == 0, result.stderr
+  assert output.exists()
+  assert marker.exists()
+  assert (tmp_path / "bootstrap-intercepted").exists()
+  commands = browser_log.read_text(encoding="utf-8").splitlines()
+  first_detach = commands.index("open about:blank")
+  authenticated_bootstrap = next(
+    i for i, command in enumerate(commands[first_detach + 1:], first_detach + 1)
+    if command == "open http://mobius.test/api/browser-bootstrap"
+  )
+  assert first_detach < authenticated_bootstrap
+
+
+def test_timeout_stops_queueing_commands_and_restarts_the_one_profile(
+  tmp_path: Path,
+):
+  result, output, marker, browser_log = _run_helper(
+    tmp_path,
+    auth_ok=True,
+    timeout_eval_mode="once",
+    subprocess_timeout=10,
+  )
+
+  assert result.returncode == 0, result.stderr
+  assert output.exists()
+  assert marker.exists()
+  assert "retained browser-state cleanup timed out" in result.stderr
+  assert "restarting this chat's isolated browser session once" in result.stderr
+  commands = browser_log.read_text(encoding="utf-8").splitlines()
+  timed_eval = next(
+    i for i, command in enumerate(commands)
+    if command.startswith("eval ") and "serviceWorker" in command
+  )
+  # No navigation/eval/close request is queued behind the poisoned daemon. The
+  # process-scoped reset is invisible to this command log; capture starts fresh.
+  assert commands[timed_eval + 1] == "open http://mobius.test/api/browser-bootstrap"
+
+
+def test_second_timeout_reports_the_failed_phase_without_an_infinite_restart(
+  tmp_path: Path,
+):
+  result, output, marker, browser_log = _run_helper(
+    tmp_path,
+    auth_ok=True,
+    timeout_eval_mode="always",
+    subprocess_timeout=10,
+  )
+
+  assert result.returncode != 0
+  assert "retained browser-state cleanup timed out again" in result.stderr
+  assert "after one isolated browser-session restart" in result.stderr
+  assert not output.exists()
+  assert not marker.exists()
+  commands = browser_log.read_text(encoding="utf-8").splitlines()
+  assert "close" not in commands
 
 
 def test_stale_shell_fails_instead_of_capturing_misleading_evidence(tmp_path: Path):
@@ -497,6 +593,15 @@ def test_browser_commands_keep_one_daemon_identity(tmp_path: Path):
   )
   assert identities
   assert set(identities) == {expected}
+
+
+def test_browser_daemon_does_not_inherit_the_capture_transaction_lock(
+  tmp_path: Path,
+):
+  result, _, _, _ = _run_helper(tmp_path, auth_ok=True)
+
+  assert result.returncode == 0, result.stderr
+  assert not (tmp_path / "capture-lock-inherited").exists()
 
 
 def test_browser_failure_includes_last_command_detail(tmp_path: Path):


### PR DESCRIPTION
## Summary

- stop queueing browser commands after an operation exceeds its bound
- reset only the exact per-chat automation profile, at most once, then restart capture
- report the precise phase that timed out instead of mislabeling cleanup failures as authentication errors
- prevent the persistent browser daemon from inheriting the capture transaction lock
- cover stale-worker interception, bounded recovery, process ownership, PID reuse, and repeat failure

## Why

Killing a timed-out CLI client does not cancel work already running in agent-browser's persistent daemon. Later retries can queue behind that work, making a valid authenticated shell look unavailable and leaving the capture session wedged. The helper now treats the profile as the ownership boundary and recovers the one affected session without touching other browser sessions.

## Testing

- 84 focused and adjacent backend tests passed on the current upstream base
- 60-test fast platform suite passed on the live source checkout
- live authenticated reproduction: left a page evaluation running after its CLI caller timed out, then verified that the helper reset the isolated session and captured the themed shell successfully
- full container suite not run because Docker is unavailable in the Möbius runtime