### PR TITLE
Resume Codex goals through native SDK

### DIFF
--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -4818,6 +4818,84 @@ def _build_resumed_context(chat_row) -> str | None:
 CLI_SLASH_COMMANDS = frozenset({"/goal"})
 
 
+def _goal_argument(text: str) -> str | None:
+  match = re.match(r"^\s*/goal(?:\s+([\s\S]+))?\s*$", text or "")
+  if match is None:
+    return None
+  return (match.group(1) or "").strip() or None
+
+
+def _goal_clear_requested(text: str) -> bool:
+  argument = _goal_argument(text)
+  return bool(argument and argument.lower() == "clear")
+
+
+def _goal_objective(text: str) -> str | None:
+  """Return the clean objective from a leading ``/goal`` command."""
+  objective = _goal_argument(text)
+  if objective is None or objective.lower() == "clear":
+    return None
+  return objective
+
+
+def _chat_has_goal_intent(messages: list[schemas.ChatMessage]) -> bool:
+  """Whether this durable transcript has ever requested native goal mode."""
+  return any(
+    message.role == "user"
+    and re.match(r"^\s*/goal(?:\s|$)", message.content or "") is not None
+    for message in messages
+  )
+
+
+def _latest_goal_objective(
+  messages: list[schemas.ChatMessage],
+) -> str | None:
+  """Find the still-relevant legacy objective before a Resume message."""
+  for message in reversed(messages):
+    if message.role != "user":
+      continue
+    content = message.content or ""
+    if content.strip().lower() == "continue":
+      continue
+    if _goal_clear_requested(content):
+      return None
+    objective = _goal_objective(message.content)
+    if objective is not None:
+      return objective
+    # An intervening owner request changed the subject. Do not resurrect a
+    # historical pre-native goal merely because a later message says continue.
+    return None
+  return None
+
+
+def _goal_resume_requested(chat_row, text: str) -> bool:
+  """Whether this ``continue`` is a recovery action rather than ordinary prose."""
+  if (text or "").strip().lower() != "continue" or chat_row is None:
+    return False
+  durable = list(chat_row.messages or [])
+  if not durable:
+    return False
+  current = durable[-1] if isinstance(durable[-1], dict) else {}
+  if current.get("kind") == "auto_continuation":
+    return True
+  # The visible Resume button is rendered only for a resumable tail block and
+  # sends the same short text as an automatic continuation. The persisted tail
+  # is the durable intent signal; plain "continue" elsewhere must not revive an
+  # old goal that may already have finished before native goal storage existed.
+  for message in reversed(durable[:-1]):
+    if not isinstance(message, dict):
+      continue
+    if message.get("role") == "user":
+      return False
+    if message.get("role") != "assistant":
+      continue
+    return any(
+      isinstance(block, dict) and block.get("resumable") is True
+      for block in list(message.get("blocks") or [])
+    )
+  return False
+
+
 def _is_cli_slash_command(text: str) -> bool:
   """True when `text` starts with a supported Claude CLI slash command.
 
@@ -5297,7 +5375,12 @@ async def _run_chat_impl_with_db(
   """Run a turn with a session whose lifetime is owned by the wrapper."""
   log = _get_logger()
   settings = get_settings()
-  user_message = messages[-1].content
+  raw_user_message = messages[-1].content
+  user_message = raw_user_message
+  goal_objective = _goal_objective(raw_user_message)
+  goal_clear = _goal_clear_requested(raw_user_message)
+  goal_mode = _chat_has_goal_intent(messages)
+  goal_continue = (raw_user_message or "").strip().lower() == "continue"
   is_slash_command = _is_cli_slash_command(user_message)
   if is_slash_command:
     # The CLI dispatches a slash command only when it sits at position 0, so the
@@ -5330,6 +5413,23 @@ async def _run_chat_impl_with_db(
       log.exception(
         "failed to load per-chat agent_settings chat_id=%s", chat_id,
       )
+
+  # Chats created before native Codex goal handling have the /goal objective in
+  # their durable transcript but no provider-side ThreadGoal yet.  Either the
+  # automatic restart handoff or the visible one-tap Resume sends "continue";
+  # carrying the newest objective lets the runner adopt that old chat into the
+  # native goal store.  A native completed goal still wins authoritatively and
+  # is never restarted by this fallback.
+  fallback_goal_objective = (
+    _latest_goal_objective(messages)
+    if (
+      goal_continue
+      and goal_mode
+      and goal_objective is None
+      and _goal_resume_requested(chat_row, raw_user_message)
+    )
+    else None
+  )
 
   # Durable run marker: the turn's StartTurn (initial send) or
   # PromotePending (continuation / stale-pending drain) writer-actor
@@ -5748,6 +5848,11 @@ async def _run_chat_impl_with_db(
         system_prompt=system_prompt,
         resumed_context=resumed_context_fallback,
         should_abort=lambda: _run_generation_superseded(chat_id, run_gen),
+        goal_objective=goal_objective,
+        goal_clear=goal_clear,
+        goal_mode=goal_mode,
+        goal_continue=goal_continue,
+        fallback_goal_objective=fallback_goal_objective,
       )
       new_session_id = runner_result.get("session_id")
       err = runner_result.get("error")
@@ -5759,7 +5864,12 @@ async def _run_chat_impl_with_db(
         cost_usd=runner_result.get("cost_usd"),
         usage=usage_metrics,
       )
-      if not err and new_session_id and chat_id:
+      if (
+        not err
+        and new_session_id
+        and chat_id
+        and not _run_generation_superseded(chat_id, run_gen)
+      ):
         chat_obj = db.query(models.Chat).filter(
           models.Chat.id == chat_id
         ).first()
@@ -5893,7 +6003,12 @@ async def _run_chat_impl_with_db(
         cost_usd=runner_result.get("cost_usd"),
         usage=usage_metrics,
       )
-      if not err and new_session_id and chat_id:
+      if (
+        not err
+        and new_session_id
+        and chat_id
+        and not _run_generation_superseded(chat_id, run_gen)
+      ):
         chat_obj = db.query(models.Chat).filter(
           models.Chat.id == chat_id
         ).first()

--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -141,7 +141,13 @@ def _codex_config_overrides() -> list[str]:
   robust to a rollout change, not just to the binary we probed. Re-run the
   delegate probe after any @openai/codex bump.
   """
-  overrides = ["features.default_mode_request_user_input=true"]
+  overrides = [
+    "features.default_mode_request_user_input=true",
+    # Codex owns goal durability in its thread store.  Enabling the native
+    # goal extension lets a new app-server resume the logical operation after
+    # Möbius deliberately tears the previous process down for a restart.
+    "features.goals=true",
+  ]
   if _env_flag_on("MOEBIUS_CODEX_MULTI_AGENT", default=True):
     overrides += [
       "features.multi_agent_v2.enabled=true",
@@ -553,6 +559,114 @@ class ActiveCodexTurn:
       self._finished.set_result(None)
 
 
+class _CodexGoalTurn:
+  """TurnHandle-shaped adapter for one SDK-native logical goal operation.
+
+  Codex may execute a goal as several physical turns.  The SDK's goal stream
+  coalesces those into one logical stream while the persisted thread goal is
+  active.  This adapter keeps the rest of Möbius on the ordinary TurnHandle
+  interface: Stop pauses then interrupts through the SDK, and steering targets
+  whichever physical turn the goal runtime currently owns.
+  """
+
+  def __init__(
+    self,
+    client: Any,
+    state: Any,
+    stream_type: Any,
+    invalid_request_type: type[Exception],
+  ):
+    self._client = client
+    self._state = state
+    self._invalid_request_type = invalid_request_type
+    self.id = state.logical_turn_id
+    if not self.id:
+      raise RuntimeError("Codex goal operation has no logical turn id")
+    self._stream = stream_type(
+      state,
+      lambda: client.next_goal_notification(state),
+      lambda: client.unregister_goal_operation(state),
+      lambda: client.cancel_goal_operation(state),
+    )
+
+  def stream(self):
+    return self._stream
+
+  async def interrupt(self) -> None:
+    # The SDK operation deliberately pauses the durable goal before signalling
+    # its current physical turn.  A later thread/resume can therefore restore
+    # the same objective and counters rather than starting a replacement chat.
+    await self._client.cancel_goal_operation(self._state)
+
+  async def steer(self, message: str) -> None:
+    physical_turn_id = await asyncio.to_thread(self._state.active_turn)
+    while physical_turn_id is not None:
+      try:
+        await self._client.turn_steer(
+          self._state.thread_id,
+          physical_turn_id,
+          message,
+        )
+        return
+      except self._invalid_request_type as exc:
+        error_message = str(getattr(exc, "message", exc))
+        if not (
+          error_message.startswith("expected active turn id")
+          or error_message.startswith("no active turn to steer")
+        ):
+          raise
+        # A logical goal can roll from one physical turn to the next between
+        # reading current_turn and the steer RPC. Rejection is side-effect-free;
+        # wait for the SDK route to observe the successor, then deliver the same
+        # owner message there exactly once. Stop/goal completion wakes this wait
+        # and returns None rather than spinning on a stale id.
+        physical_turn_id = await asyncio.to_thread(
+          self._state.active_turn,
+          after=physical_turn_id,
+        )
+    raise RuntimeError("Codex goal ended before the message could be delivered")
+
+
+async def _codex_thread_goal(client: Any, sdk: dict[str, Any], thread_id: str):
+  """Read a persisted goal before thread/resume can auto-start it."""
+  response = await client.request(
+    "thread/goal/get",
+    {"threadId": thread_id},
+    response_model=sdk["ThreadGoalGetResponse"],
+  )
+  return response.goal
+
+
+def _release_goal_route(client: Any, state: Any | None) -> None:
+  """Release a pre-resume goal route when no logical stream will own it."""
+  if state is None:
+    return
+  try:
+    state.finish()
+    state.wake_notification_reader()
+    client.unregister_goal_operation(state)
+  except Exception:
+    log.warning("Codex goal route cleanup failed", exc_info=True)
+
+
+def _wait_for_goal_snapshot(state: Any, timeout: float) -> Any | None:
+  """Wait until thread/resume's ordered goal snapshot reaches the SDK route."""
+  condition = getattr(state, "_condition", None)
+  if condition is None:
+    return getattr(state, "status", None)
+  deadline = time.monotonic() + timeout
+  with condition:
+    while getattr(state, "status", None) is None:
+      failure = getattr(state, "_failure", None)
+      if failure is not None:
+        raise failure
+      remaining = deadline - time.monotonic()
+      if remaining <= 0:
+        return None
+      condition.wait(remaining)
+    return state.status
+
+
 def _sdk_imports() -> dict[str, Any]:
   """Imports the SDK lazily so this module stays importable without it.
 
@@ -564,16 +678,18 @@ def _sdk_imports() -> dict[str, Any]:
   `openai_codex.generated.v2_all`, which is a private/generated path.
   The upstream stable surface does not yet expose these typed classes
   publicly. This is brittle: an SDK bump can rename or move them
-  freely. TG-NEW should add a contract test that imports these symbols
-  at test time so breakage is caught immediately.
+  freely, so the contract suite imports these symbols at test time and
+  catches breakage before an SDK update reaches the runner.
   """
   from openai_codex import ApprovalMode, AsyncCodex, Sandbox
   from openai_codex.client import CodexConfig
   from openai_codex.errors import (
     CodexRpcError,
+    InvalidRequestError,
     TransportClosedError,
   )
   from openai_codex.types import ReasoningEffort, ReasoningSummary
+  from openai_codex._goal import _AsyncGoalNotificationStream
   from openai_codex.generated.v2_all import (
     AgentMessageDeltaNotification,
     AgentMessageThreadItem,
@@ -594,6 +710,8 @@ def _sdk_imports() -> dict[str, Any]:
     ReasoningSummaryTextDeltaNotification,
     ReasoningTextDeltaNotification,
     ThreadTokenUsageUpdatedNotification,
+    ThreadGoalGetResponse,
+    ThreadGoalStatus,
     ThreadItem,
     ThreadTokenUsage,
     TokenUsageBreakdown,
@@ -666,8 +784,10 @@ def _sdk_imports() -> dict[str, Any]:
     "AgentMessageThreadItem": AgentMessageThreadItem,
     "ApprovalMode": ApprovalMode,
     "AsyncCodex": AsyncCodex,
+    "AsyncGoalNotificationStream": _AsyncGoalNotificationStream,
     "CodexConfig": CodexConfig,
     "CodexRpcError": CodexRpcError,
+    "InvalidRequestError": InvalidRequestError,
     "CommandExecutionOutputDeltaNotification": (
       CommandExecutionOutputDeltaNotification
     ),
@@ -698,6 +818,8 @@ def _sdk_imports() -> dict[str, Any]:
     "ThreadTokenUsageUpdatedNotification": (
       ThreadTokenUsageUpdatedNotification
     ),
+    "ThreadGoalGetResponse": ThreadGoalGetResponse,
+    "ThreadGoalStatus": ThreadGoalStatus,
     "TransportClosedError": TransportClosedError,
     "TurnCompletedNotification": TurnCompletedNotification,
     "TurnStatus": TurnStatus,
@@ -2002,6 +2124,11 @@ async def run_codex_sdk_turn(
   system_prompt: str | None = None,
   resumed_context: str | None = None,
   should_abort: Callable[[], bool] | None = None,
+  goal_objective: str | None = None,
+  goal_clear: bool = False,
+  goal_mode: bool = False,
+  goal_continue: bool = False,
+  fallback_goal_objective: str | None = None,
 ) -> RunnerResult:
   """Runs one Codex SDK turn and publishes Möbius-shaped events.
 
@@ -2119,6 +2246,9 @@ async def run_codex_sdk_turn(
 
   thread = None
   turn = None
+  goal_state = None
+  goal_cleared = False
+  goal_steer_message: str | None = None
   active_turn: ActiveCodexTurn | None = None
   current_session_id = session_id
   completed_turn: Any | None = None
@@ -2259,6 +2389,41 @@ async def run_codex_sdk_turn(
       # Möbius's design philosophy
       # ("trust the agent; container is the sandbox") is consistent.
       _sandbox = sdk["Sandbox"].full_access
+      persisted_goal = None
+      goal_store_available = True
+      if session_id is not None and goal_mode:
+        try:
+          persisted_goal = await _codex_thread_goal(
+            codex._client, sdk, session_id,
+          )
+        except sdk["InvalidRequestError"] as exc:
+          error_message = str(getattr(exc, "message", exc))
+          if not error_message.startswith("thread not found:"):
+            raise
+          # Preserve the existing lost-thread recovery path. Goal lookup must
+          # run before resume to register an active goal route in time, but a
+          # stale session id should still be allowed to resume as a new thread.
+          goal_store_available = False
+        if goal_clear:
+          if persisted_goal is not None:
+            cleared = await codex._client.thread_goal_clear(session_id)
+            goal_cleared = bool(getattr(cleared, "cleared", True))
+          persisted_goal = None
+        elif goal_objective is not None and persisted_goal is not None:
+          # An explicit new /goal replaces the stored operation.  Clear it
+          # before resume so app-server cannot auto-start the old objective in
+          # the small window between thread/resume and start_goal_operation.
+          await codex._client.thread_goal_clear(session_id)
+          persisted_goal = None
+        elif (
+          persisted_goal is not None
+          and persisted_goal.status != sdk["ThreadGoalStatus"].complete
+        ):
+          # Register before thread/resume: app-server emits the goal snapshot
+          # and may start the next physical turn immediately after its resume
+          # response.  Routing afterward loses those early notifications.
+          goal_state = codex._client.register_goal_operation(session_id)
+
       if session_id is None:
         thread = await codex.thread_start(
           approval_mode=sdk["ApprovalMode"].auto_review,
@@ -2291,9 +2456,17 @@ async def run_codex_sdk_turn(
 
       current_session_id = thread.id
       if abort_requested():
+        if goal_state is not None:
+          await codex._client.cancel_goal_operation(goal_state)
+          _release_goal_route(codex._client, goal_state)
+          goal_state = None
         log.info("Codex turn aborted before turn setup chat_id=%s", chat_id)
         return aborted_result()
       if session_id is not None and current_session_id != session_id:
+        if goal_state is not None:
+          _release_goal_route(codex._client, goal_state)
+        goal_state = None
+        persisted_goal = None
         # The requested Codex session is gone (rollout cleaned up, or a phantom
         # id) — Codex returned a fresh thread instead of resuming. Rather than
         # dead-end the chat, reseed like the Claude runner: continue on the fresh
@@ -2332,13 +2505,88 @@ async def run_codex_sdk_turn(
         "session_id": current_session_id,
       })
 
-      turn = await thread.turn(
-        user_message,
-        cwd=cwd,
-        model=model,
-        effort=effort,
-        summary=reasoning_summary,
+      if goal_clear:
+        await _persist_session_id(db, chat_id, current_session_id)
+        bc.publish({
+          "type": "text",
+          "content": (
+            "Goal cleared." if goal_cleared else "No active goal to clear."
+          ),
+        })
+        return {
+          "session_id": current_session_id,
+          "cost_usd": None,
+          "error": None,
+        }
+
+      native_goal_objective = (
+        (goal_objective or fallback_goal_objective)
+        if goal_store_available
+        else None
       )
+      if (
+        session_id is not None
+        and current_session_id != session_id
+      ):
+        # Lost-thread reseeding is an ordinary turn: the replacement needs the
+        # transcript block before a new durable goal can safely be created.
+        # The next explicit /goal can then start natively on that thread.
+        native_goal_objective = None
+
+      if native_goal_objective is not None and persisted_goal is None:
+        goal_state, _goal_turn_id = (
+          await codex._client.start_goal_operation(
+            thread.id, native_goal_objective,
+          )
+        )
+        turn = _CodexGoalTurn(
+          codex._client,
+          goal_state,
+          sdk["AsyncGoalNotificationStream"],
+          sdk["InvalidRequestError"],
+        )
+      elif goal_state is not None and persisted_goal is not None:
+        resumed_goal_status = await asyncio.to_thread(
+          _wait_for_goal_snapshot, goal_state, 30.0,
+        )
+        if resumed_goal_status is None:
+          raise RuntimeError(
+            "Timed out waiting for the persisted Codex goal snapshot"
+          )
+        if resumed_goal_status != sdk["ThreadGoalStatus"].active:
+          # Paused/blocked/limited goals stay idle across thread/resume.  A new
+          # Möbius turn is the owner's request to continue, so reactivate the
+          # SAME stored goal and wait for the runtime-created physical turn.
+          await codex._client.thread_goal_set(
+            thread.id,
+            status=sdk["ThreadGoalStatus"].active,
+          )
+        logical_turn_id = await asyncio.to_thread(
+          goal_state.wait_for_start, 30.0,
+        )
+        if logical_turn_id is None:
+          raise RuntimeError(
+            "Timed out waiting for the persisted Codex goal to resume"
+          )
+        turn = _CodexGoalTurn(
+          codex._client,
+          goal_state,
+          sdk["AsyncGoalNotificationStream"],
+          sdk["InvalidRequestError"],
+        )
+        if not goal_continue:
+          # thread/resume already started the goal's next physical turn.  A
+          # real owner message belongs inside it; the synthetic restart marker
+          # "continue" carries no extra content and is intentionally omitted.
+          goal_steer_message = user_message
+      else:
+        turn = await thread.turn(
+          user_message,
+          cwd=cwd,
+          model=model,
+          effort=effort,
+          summary=reasoning_summary,
+        )
       if abort_requested():
         try:
           await turn.interrupt()
@@ -2369,6 +2617,18 @@ async def run_codex_sdk_turn(
       # stale-resume check above so a rejected (mismatched) session is never
       # recorded.
       await _persist_session_id(db, chat_id, current_session_id)
+
+      if goal_steer_message is not None:
+        try:
+          await turn.steer(goal_steer_message)
+        except Exception:
+          if active_turn.interrupt_requested:
+            log.info(
+              "Codex goal steer ended during requested Stop chat_id=%s",
+              chat_id,
+            )
+          else:
+            raise
 
       known_child_ids: set[str] = set()
       active_activation_by_child: dict[str, str] = {}

--- a/backend/tests/test_agent_turn_releases_db_connection.py
+++ b/backend/tests/test_agent_turn_releases_db_connection.py
@@ -207,6 +207,70 @@ async def test_agent_turn_returns_connection_while_provider_is_running(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+  ("provider_id", "provider_name"),
+  (("codex", "Codex"), ("claude", "Claude Code")),
+)
+async def test_superseded_runner_cannot_overwrite_successor_session(
+  chat, db, monkeypatch, provider_id, provider_name,
+):
+  """A late terminal write belongs to its generation, not the next run."""
+  chat.provider = provider_id
+  chat.session_id = "successor-session"
+  chat.agent_settings_json = {"model": "gpt-5.4"}
+  db.commit()
+  run_gen = chat_mod.current_run_generation(chat.id)
+
+  async def stale_runner(**_kwargs):
+    chat_mod.bump_run_generation(chat.id)
+    return {
+      "session_id": "stale-run-session",
+      "cost_usd": 0.0,
+      "error": None,
+    }
+
+  async def fake_complete_turn(**kwargs):
+    kwargs["db"].close()
+    return chat_queue.TerminalDisposition.STALE_NO_ACTION
+
+  async def fake_record_run_metrics(**_kwargs):
+    return None
+
+  monkeypatch.setattr(
+    chat_mod, "get_provider", lambda _provider_id: _Provider(provider_name),
+  )
+  monkeypatch.setattr(chat_mod, "_complete_turn", fake_complete_turn)
+  monkeypatch.setattr(chat_mod, "_record_run_metrics", fake_record_run_metrics)
+  if provider_id == "codex":
+    from app import codex_sdk_runner
+    monkeypatch.setattr(codex_sdk_runner, "run_codex_sdk_turn", stale_runner)
+  else:
+    from app import claude_sdk_runner
+    monkeypatch.setattr(claude_sdk_runner, "run_claude_sdk_turn", stale_runner)
+    monkeypatch.setattr(claude_sdk_runner, "_resumable", lambda *_a, **_k: True)
+
+  create_broadcast(chat.id)
+  try:
+    result = await chat_mod._run_chat_impl(
+      messages=[schemas.ChatMessage(role="user", content="hello")],
+      chat_id=chat.id,
+      session_id="successor-session",
+      provider_id=provider_id,
+      run_gen=run_gen,
+    )
+  finally:
+    remove_broadcast(chat.id)
+
+  assert result is chat_queue.TerminalDisposition.STALE_NO_ACTION
+  verify = SessionLocal()
+  try:
+    stored = verify.query(models.Chat).filter(models.Chat.id == chat.id).one()
+    assert stored.session_id == "successor-session"
+  finally:
+    verify.close()
+
+
+@pytest.mark.asyncio
 async def test_agent_setup_exception_always_returns_connection(monkeypatch):
   """Unexpected setup failures are covered by the outer session owner."""
   _wait_for_writer_connection()

--- a/backend/tests/test_codex_sdk_contract.py
+++ b/backend/tests/test_codex_sdk_contract.py
@@ -35,6 +35,7 @@ See CLAUDE.md "Codex `_approval_handler` patch — known fragility" for
 the broader context.
 """
 
+import inspect
 import json
 
 import pytest
@@ -348,3 +349,54 @@ def test_transport_closed_error_is_still_exposed_by_the_sdk():
   # Not a RuntimeError: the runner relies on that to keep provider
   # ErrorNotifications (reraised as plain RuntimeErrors) out of this branch.
   assert not issubclass(TransportClosedError, RuntimeError)
+
+
+def test_native_goal_resume_sdk_contract_is_pinned():
+  """Fail at build time if Codex moves the goal lifecycle Möbius relies on."""
+  pytest.importorskip("openai_codex")
+  from openai_codex import AsyncCodex
+  from openai_codex._goal import (
+    _AsyncGoalNotificationStream,
+    _GoalOperationState,
+  )
+  from openai_codex.errors import InvalidRequestError
+  from openai_codex.generated.v2_all import (
+    ThreadGoalGetResponse,
+    ThreadGoalStatus,
+  )
+
+  client = AsyncCodex()._client
+  for method in (
+    "request",
+    "register_goal_operation",
+    "unregister_goal_operation",
+    "start_goal_operation",
+    "next_goal_notification",
+    "cancel_goal_operation",
+    "thread_goal_clear",
+    "thread_goal_set",
+    "turn_steer",
+  ):
+    assert callable(getattr(client, method, None)), (
+      f"openai_codex removed AsyncCodex._client.{method}; update the native "
+      "goal adapter before accepting this SDK bump"
+    )
+  assert _AsyncGoalNotificationStream is not None
+  assert issubclass(InvalidRequestError, Exception)
+  assert list(inspect.signature(_AsyncGoalNotificationStream).parameters)[:4] == [
+    "state", "next_notification", "unregister", "cancel_goal",
+  ]
+  state = _GoalOperationState(thread_id="contract-thread")
+  for method in (
+    "active_turn",
+    "wait_for_start",
+    "finish",
+    "wake_notification_reader",
+  ):
+    assert callable(getattr(state, method, None))
+  assert hasattr(state, "_condition")
+  assert hasattr(state, "_failure")
+  assert set(ThreadGoalGetResponse.model_fields) == {"goal"}
+  assert {status.value for status in ThreadGoalStatus} == {
+    "active", "paused", "blocked", "usageLimited", "budgetLimited", "complete",
+  }

--- a/backend/tests/test_codex_sdk_runner.py
+++ b/backend/tests/test_codex_sdk_runner.py
@@ -81,6 +81,128 @@ class _FakeTurnStatus(Enum):
   in_progress = "inProgress"
 
 
+class _FakeThreadGoalStatus(Enum):
+  active = "active"
+  paused = "paused"
+  blocked = "blocked"
+  usage_limited = "usageLimited"
+  budget_limited = "budgetLimited"
+  complete = "complete"
+
+
+class _FakeGoalState:
+  def __init__(self, thread_id: str, notifications=None, *, started=False):
+    self.thread_id = thread_id
+    self.logical_turn_id = "goal-turn" if started else None
+    self._current_turn_id = "physical-turn" if started else None
+    self.notifications = list(notifications or [])
+    self.finished = False
+    self.woken = False
+    self.status = None
+
+  def start(self):
+    self.logical_turn_id = "goal-turn"
+    self._current_turn_id = "physical-turn"
+
+  def wait_for_start(self, _timeout: float):
+    return self.logical_turn_id
+
+  def current_turn(self):
+    return self._current_turn_id
+
+  def active_turn(self, *, after=None):
+    if self.finished:
+      return None
+    if self._current_turn_id != after:
+      return self._current_turn_id
+    return None
+
+  def finish(self):
+    self.finished = True
+    self._current_turn_id = None
+
+  def wake_notification_reader(self):
+    self.woken = True
+
+
+class _FakeAsyncGoalNotificationStream:
+  def __init__(
+    self, state, _next_notification, unregister, _cancel_goal,
+  ):
+    self.state = state
+    self.unregister = unregister
+
+  async def __aiter__(self):
+    for notification in self.state.notifications:
+      yield notification
+    self.unregister()
+
+
+class _FakeGoalClient:
+  def __init__(self, goal=None):
+    self.goal = goal
+    self.state: _FakeGoalState | None = None
+    self.register_calls: list[str] = []
+    self.start_calls: list[tuple[str, str]] = []
+    self.set_calls: list[tuple[str, _FakeThreadGoalStatus]] = []
+    self.clear_calls: list[str] = []
+    self.steer_calls: list[tuple[str, str, str]] = []
+    self.cancel_calls: list[_FakeGoalState] = []
+    self.unregister_calls: list[_FakeGoalState] = []
+
+  async def request(self, method, params, *, response_model):
+    assert method == "thread/goal/get"
+    assert params == {"threadId": "thread-1"}
+    assert response_model is not None
+    return SimpleNamespace(goal=self.goal)
+
+  def register_goal_operation(self, thread_id):
+    self.register_calls.append(thread_id)
+    self.state = _FakeGoalState(thread_id)
+    self.state.status = self.goal.status
+    return self.state
+
+  async def start_goal_operation(self, thread_id, objective):
+    self.start_calls.append((thread_id, objective))
+    self.state = _FakeGoalState(
+      thread_id, _goal_completion_notifications(), started=True,
+    )
+    return self.state, self.state.logical_turn_id
+
+  async def thread_goal_set(self, thread_id, *, status=None, objective=None):
+    assert objective is None
+    self.set_calls.append((thread_id, status))
+    assert self.state is not None
+    self.state.start()
+    self.state.notifications = _goal_completion_notifications()
+    return SimpleNamespace()
+
+  async def thread_goal_clear(self, thread_id):
+    self.clear_calls.append(thread_id)
+    self.goal = None
+    return SimpleNamespace(cleared=True)
+
+  async def turn_steer(self, thread_id, expected_turn_id, message):
+    self.steer_calls.append((thread_id, expected_turn_id, message))
+
+  async def next_goal_notification(self, _state):
+    raise AssertionError("fake goal stream reads its state directly")
+
+  async def cancel_goal_operation(self, state):
+    self.cancel_calls.append(state)
+
+  def unregister_goal_operation(self, state):
+    self.unregister_calls.append(state)
+
+
+def _goal_completion_notifications():
+  completed = SimpleNamespace(id="goal-turn", usage=None, error=None)
+  return [SimpleNamespace(
+    method="turn/completed",
+    payload=_FakeTurnCompletedNotification(completed),
+  )]
+
+
 class _FakeTurnCompletedNotification:
   def __init__(self, turn):
     self.turn = turn
@@ -155,6 +277,13 @@ def _fake_sdk(async_codex_cls):
       self.message = message
       self.data = data
 
+  class _FakeInvalidRequestError(RuntimeError):
+    def __init__(self, code: int, message: str, data=None):
+      super().__init__(f"JSON-RPC error {code}: {message}")
+      self.code = code
+      self.message = message
+      self.data = data
+
   class _FakeCodexRpcError(RuntimeError):
     def __init__(self, code: int, message: str, data=None):
       super().__init__(f"JSON-RPC error {code}: {message}")
@@ -167,6 +296,7 @@ def _fake_sdk(async_codex_cls):
     "AgentMessageThreadItem": _Dummy,
     "ApprovalMode": _FakeApprovalMode,
     "AsyncCodex": async_codex_cls,
+    "AsyncGoalNotificationStream": _FakeAsyncGoalNotificationStream,
     "CodexConfig": _FakeCodexConfig,
     "CodexRpcError": _FakeCodexRpcError,
     "CommandExecutionOutputDeltaNotification": _Dummy,
@@ -178,6 +308,7 @@ def _fake_sdk(async_codex_cls):
     "FileChangeThreadItem": _Dummy,
     "ImageViewThreadItem": type("_FakeImageViewThreadItem", (), {}),
     "InvalidParamsError": _FakeInvalidParamsError,
+    "InvalidRequestError": _FakeInvalidRequestError,
     "ReasoningEffort": _FakeReasoningEffort(),
     "ReasoningSummary": _FakeReasoningSummary(),
     "Sandbox": _FakeSandbox,
@@ -190,6 +321,8 @@ def _fake_sdk(async_codex_cls):
     "ReasoningSummaryTextDeltaNotification": _Dummy,
     "ReasoningTextDeltaNotification": _Dummy,
     "ThreadTokenUsageUpdatedNotification": _Dummy,
+    "ThreadGoalGetResponse": type("ThreadGoalGetResponse", (), {}),
+    "ThreadGoalStatus": _FakeThreadGoalStatus,
     "TransportClosedError": _SdkTransportClosedError,
     "TurnCompletedNotification": _FakeTurnCompletedNotification,
     "TurnStatus": _FakeTurnStatus,
@@ -777,6 +910,301 @@ def test_run_codex_sdk_turn_resume_skips_skill_lookup(monkeypatch):
     "session_id": "requested-thread",
   }]
   assert registry.get_handle("chat-1", RunnerKind.CODEX_SDK) is None
+
+
+def test_new_goal_uses_sdk_logical_operation_not_ordinary_turn(monkeypatch):
+  ordinary_turn = _FakeTurnHandle(_goal_completion_notifications())
+  thread = _FakeThread("thread-1", ordinary_turn)
+
+  class FakeAsyncCodex:
+    last = None
+
+    def __init__(self, config=None):
+      self.config = config
+      self._client = _FakeGoalClient()
+      type(self).last = self
+
+    async def __aenter__(self):
+      return self
+
+    async def __aexit__(self, _exc_type, _exc, _tb):
+      return None
+
+    async def thread_start(self, **_kwargs):
+      return thread
+
+  monkeypatch.setattr(
+    codex_sdk_runner, "_sdk_imports", lambda: _fake_sdk(FakeAsyncCodex),
+  )
+
+  result = asyncio.run(codex_sdk_runner.run_codex_sdk_turn(
+    user_message="/goal Repair every failing test",
+    session_id=None,
+    base_env={},
+    cwd="/tmp",
+    chat_id="chat-goal",
+    bc=_FakeBroadcast(),
+    pending_questions={},
+    db=None,
+    goal_objective="Repair every failing test",
+    goal_mode=True,
+  ))
+
+  assert result["error"] is None
+  assert FakeAsyncCodex.last._client.start_calls == [
+    ("thread-1", "Repair every failing test"),
+  ]
+  assert thread.turn_args is None
+
+
+def test_active_goal_route_exists_before_resume_and_auto_continues(monkeypatch):
+  goal = SimpleNamespace(status=_FakeThreadGoalStatus.active)
+  ordinary_turn = _FakeTurnHandle(_goal_completion_notifications())
+  thread = _FakeThread("thread-1", ordinary_turn)
+
+  class FakeAsyncCodex:
+    last = None
+
+    def __init__(self, config=None):
+      self.config = config
+      self._client = _FakeGoalClient(goal)
+      type(self).last = self
+
+    async def __aenter__(self):
+      return self
+
+    async def __aexit__(self, _exc_type, _exc, _tb):
+      return None
+
+    async def thread_resume(self, thread_id, **_kwargs):
+      assert self._client.register_calls == [thread_id]
+      assert self._client.state is not None
+      self._client.state.start()
+      self._client.state.notifications = _goal_completion_notifications()
+      return thread
+
+  monkeypatch.setattr(
+    codex_sdk_runner, "_sdk_imports", lambda: _fake_sdk(FakeAsyncCodex),
+  )
+
+  result = asyncio.run(codex_sdk_runner.run_codex_sdk_turn(
+    user_message="continue",
+    session_id="thread-1",
+    base_env={},
+    cwd="/tmp",
+    chat_id="chat-goal",
+    bc=_FakeBroadcast(),
+    pending_questions={},
+    db=None,
+    goal_mode=True,
+    goal_continue=True,
+  ))
+
+  client = FakeAsyncCodex.last._client
+  assert result["error"] is None
+  assert client.register_calls == ["thread-1"]
+  assert client.set_calls == []
+  assert client.steer_calls == []
+  assert thread.turn_args is None
+
+
+def test_missing_goal_thread_keeps_existing_fresh_thread_recovery(monkeypatch):
+  ordinary_turn = _FakeTurnHandle(_goal_completion_notifications())
+  replacement_thread = _FakeThread("thread-2", ordinary_turn)
+  sdk_holder = {}
+
+  class MissingGoalThreadClient(_FakeGoalClient):
+    async def request(self, method, params, *, response_model):
+      assert method == "thread/goal/get"
+      raise sdk_holder["sdk"]["InvalidRequestError"](
+        -32600, "thread not found: thread-1",
+      )
+
+  class FakeAsyncCodex:
+    last = None
+
+    def __init__(self, config=None):
+      self.config = config
+      self._client = MissingGoalThreadClient()
+      type(self).last = self
+
+    async def __aenter__(self):
+      return self
+
+    async def __aexit__(self, _exc_type, _exc, _tb):
+      return None
+
+    async def thread_resume(self, _thread_id, **_kwargs):
+      return replacement_thread
+
+  sdk_holder["sdk"] = _fake_sdk(FakeAsyncCodex)
+  monkeypatch.setattr(
+    codex_sdk_runner, "_sdk_imports", lambda: sdk_holder["sdk"],
+  )
+
+  result = asyncio.run(codex_sdk_runner.run_codex_sdk_turn(
+    user_message="continue",
+    session_id="thread-1",
+    base_env={},
+    cwd="/tmp",
+    chat_id="chat-goal",
+    bc=_FakeBroadcast(),
+    pending_questions={},
+    db=None,
+    goal_mode=True,
+    goal_continue=True,
+    fallback_goal_objective="legacy objective",
+  ))
+
+  client = FakeAsyncCodex.last._client
+  assert result["error"] is None
+  assert result["session_id"] == "thread-2"
+  assert client.start_calls == []
+  assert replacement_thread.turn_args is not None
+
+
+def test_paused_goal_reactivates_and_steers_real_owner_message(monkeypatch):
+  goal = SimpleNamespace(status=_FakeThreadGoalStatus.paused)
+  ordinary_turn = _FakeTurnHandle(_goal_completion_notifications())
+  thread = _FakeThread("thread-1", ordinary_turn)
+
+  class FakeAsyncCodex:
+    last = None
+
+    def __init__(self, config=None):
+      self.config = config
+      self._client = _FakeGoalClient(goal)
+      type(self).last = self
+
+    async def __aenter__(self):
+      return self
+
+    async def __aexit__(self, _exc_type, _exc, _tb):
+      return None
+
+    async def thread_resume(self, thread_id, **_kwargs):
+      assert self._client.register_calls == [thread_id]
+      return thread
+
+  monkeypatch.setattr(
+    codex_sdk_runner, "_sdk_imports", lambda: _fake_sdk(FakeAsyncCodex),
+  )
+
+  result = asyncio.run(codex_sdk_runner.run_codex_sdk_turn(
+    user_message="Use the smaller durable design",
+    session_id="thread-1",
+    base_env={},
+    cwd="/tmp",
+    chat_id="chat-goal",
+    bc=_FakeBroadcast(),
+    pending_questions={},
+    db=None,
+    goal_mode=True,
+  ))
+
+  client = FakeAsyncCodex.last._client
+  assert result["error"] is None
+  assert client.set_calls == [
+    ("thread-1", _FakeThreadGoalStatus.active),
+  ]
+  assert client.steer_calls == [
+    ("thread-1", "physical-turn", "Use the smaller durable design"),
+  ]
+  assert thread.turn_args is None
+
+
+def test_goal_turn_interrupt_uses_sdk_pause_and_interrupt_operation():
+  async def scenario():
+    client = _FakeGoalClient()
+    state = _FakeGoalState("thread-1", started=True)
+    turn = codex_sdk_runner._CodexGoalTurn(
+      client,
+      state,
+      _FakeAsyncGoalNotificationStream,
+      RuntimeError,
+    )
+    await turn.interrupt()
+    assert client.cancel_calls == [state]
+
+  asyncio.run(scenario())
+
+
+def test_goal_turn_steer_follows_physical_turn_rollover():
+  async def scenario():
+    sdk = _fake_sdk(object)
+    state = _FakeGoalState("thread-1", started=True)
+
+    class RolloverClient(_FakeGoalClient):
+      async def turn_steer(self, thread_id, expected_turn_id, message):
+        self.steer_calls.append((thread_id, expected_turn_id, message))
+        if expected_turn_id == "physical-turn":
+          state._current_turn_id = "physical-turn-2"
+          raise sdk["InvalidRequestError"](
+            -32600,
+            "expected active turn id `physical-turn` but found "
+            "`physical-turn-2`",
+          )
+
+    client = RolloverClient()
+    turn = codex_sdk_runner._CodexGoalTurn(
+      client,
+      state,
+      _FakeAsyncGoalNotificationStream,
+      sdk["InvalidRequestError"],
+    )
+    await turn.steer("keep the owner message")
+    assert client.steer_calls == [
+      ("thread-1", "physical-turn", "keep the owner message"),
+      ("thread-1", "physical-turn-2", "keep the owner message"),
+    ]
+
+  asyncio.run(scenario())
+
+
+def test_goal_clear_uses_sdk_without_starting_an_ordinary_turn(monkeypatch):
+  goal = SimpleNamespace(status=_FakeThreadGoalStatus.active)
+  ordinary_turn = _FakeTurnHandle(_goal_completion_notifications())
+  thread = _FakeThread("thread-1", ordinary_turn)
+
+  class FakeAsyncCodex:
+    last = None
+
+    def __init__(self, config=None):
+      self.config = config
+      self._client = _FakeGoalClient(goal)
+      type(self).last = self
+
+    async def __aenter__(self):
+      return self
+
+    async def __aexit__(self, _exc_type, _exc, _tb):
+      return None
+
+    async def thread_resume(self, _thread_id, **_kwargs):
+      return thread
+
+  monkeypatch.setattr(
+    codex_sdk_runner, "_sdk_imports", lambda: _fake_sdk(FakeAsyncCodex),
+  )
+
+  bc = _FakeBroadcast()
+  result = asyncio.run(codex_sdk_runner.run_codex_sdk_turn(
+    user_message="/goal clear",
+    session_id="thread-1",
+    base_env={},
+    cwd="/tmp",
+    chat_id="chat-goal",
+    bc=bc,
+    pending_questions={},
+    db=None,
+    goal_clear=True,
+    goal_mode=True,
+  ))
+
+  assert result["error"] is None
+  assert FakeAsyncCodex.last._client.clear_calls == ["thread-1"]
+  assert thread.turn_args is None
+  assert {"type": "text", "content": "Goal cleared."} in bc.events
 
 
 def test_run_codex_sdk_turn_reports_all_model_calls_in_turn(monkeypatch):
@@ -2592,8 +3020,16 @@ def test_codex_config_overrides_kill_switch(monkeypatch):
   from app import codex_sdk_runner as runner
   monkeypatch.setenv("MOEBIUS_CODEX_MULTI_AGENT", "off")
   ov = runner._codex_config_overrides()
-  assert ov == ["features.default_mode_request_user_input=true"]
+  assert ov == [
+    "features.default_mode_request_user_input=true",
+    "features.goals=true",
+  ]
   assert not any("multi_agent_v2" in o for o in ov)
+
+
+def test_codex_config_overrides_enable_native_goal_runtime(monkeypatch):
+  monkeypatch.delenv("MOEBIUS_CODEX_MULTI_AGENT", raising=False)
+  assert "features.goals=true" in codex_sdk_runner._codex_config_overrides()
 
 
 def test_codex_app_server_launch_args_preserve_overrides_under_setsid(

--- a/backend/tests/test_time_context.py
+++ b/backend/tests/test_time_context.py
@@ -8,13 +8,19 @@ import re
 import time
 import uuid
 from pathlib import Path
+from types import SimpleNamespace
 
-from app import models
+from app import models, schemas
 from app.chat import (
   CLI_SLASH_COMMANDS,
   _build_time_context,
+  _chat_has_goal_intent,
+  _goal_clear_requested,
+  _goal_objective,
+  _goal_resume_requested,
   _human_elapsed,
   _is_cli_slash_command,
+  _latest_goal_objective,
   _last_user_message_elapsed,
 )
 from app.database import SessionLocal
@@ -115,6 +121,64 @@ def test_goal_slash_command_is_detected_without_matching_paths():
   assert not _is_cli_slash_command("/")
   assert not _is_cli_slash_command("/data/apps/x is broken")
   assert not _is_cli_slash_command("please run /goal later")
+
+
+def test_goal_objective_is_extracted_from_clean_persisted_message():
+  assert _goal_objective("/goal repair every failing test") == (
+    "repair every failing test"
+  )
+  assert _goal_objective("\n/goal\n  inspect first\nthen fix  ") == (
+    "inspect first\nthen fix"
+  )
+  assert _goal_objective("/goal") is None
+  assert _goal_objective("/goal clear") is None
+  assert _goal_objective("/goal CLEAR") is None
+  assert _goal_clear_requested("/goal clear")
+  assert not _goal_clear_requested("/goal clear the backlog")
+  assert _goal_objective("please /goal later") is None
+
+
+def test_goal_intent_and_latest_objective_scan_durable_history():
+  messages = [
+    schemas.ChatMessage(role="user", content="hello"),
+    schemas.ChatMessage(role="assistant", content="hi"),
+    schemas.ChatMessage(role="user", content="/goal first objective"),
+    schemas.ChatMessage(role="user", content="continue"),
+  ]
+  assert _chat_has_goal_intent(messages)
+  assert _latest_goal_objective(messages) == "first objective"
+
+  cleared = messages + [
+    schemas.ChatMessage(role="user", content="/goal clear"),
+    schemas.ChatMessage(role="user", content="continue"),
+  ]
+  assert _latest_goal_objective(cleared) is None
+
+  changed_subject = messages[:-1] + [
+    schemas.ChatMessage(role="user", content="different request"),
+    schemas.ChatMessage(role="user", content="continue"),
+  ]
+  assert _latest_goal_objective(changed_subject) is None
+
+
+def test_legacy_goal_migration_requires_a_durable_resume_intent():
+  assert _goal_resume_requested(SimpleNamespace(messages=[
+    {"role": "assistant", "blocks": [{"type": "error", "resumable": True}]},
+    {"role": "user", "content": "continue"},
+  ]), "continue")
+  assert _goal_resume_requested(SimpleNamespace(messages=[
+    {"role": "user", "content": "continue", "kind": "auto_continuation"},
+  ]), "continue")
+  assert not _goal_resume_requested(SimpleNamespace(messages=[
+    {"role": "assistant", "content": "ordinary reply"},
+    {"role": "user", "content": "continue"},
+  ]), "continue")
+
+
+def test_textless_send_is_not_a_slash_command():
+  """An attachment-only send has no text; this used to raise IndexError."""
+  for textless in ("", "   ", "\n\n", None):
+    assert not _is_cli_slash_command(textless)
 
 
 def test_slash_command_registry_parity():


### PR DESCRIPTION
## Summary
- persist long-running `/goal` work in Codex's native thread-goal lifecycle so a server restart can resume the same logical operation
- preserve Stop, steering, `/goal clear`, explicit legacy Resume migration, and stale-thread recovery across physical turn changes
- pin the private SDK surface currently required for logical goal streams so future SDK changes fail visibly

## Testing
- `scripts/wt-pytest.sh tests/test_codex_sdk_runner.py tests/test_codex_sdk_contract.py tests/test_time_context.py tests/test_agent_turn_releases_db_connection.py -q` (138 passed)
- broader restart, queue, steering, completion, and Claude regression set (222 passed)
- `scripts/test.sh --fast` (58 passed)
- `node --test frontend/src/components/ChatView/__tests__/goalProgress.test.js` (5 passed)
- Python compilation and canonical diff checks

## Notes
The current Python SDK does not expose the resumable logical-goal stream as a public interface. This keeps the private dependency isolated behind one adapter and a contract test rather than recreating provider lifecycle state inside Möbius.