### PR TITLE
Render Markdown escapes without backslashes

### DIFF
--- a/frontend/src/components/ChatView/__tests__/markdownEscapes.test.js
+++ b/frontend/src/components/ChatView/__tests__/markdownEscapes.test.js
@@ -1,0 +1,33 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { Marked } from 'marked'
+import { mathTokens } from '../markdown/mathTokens.js'
+
+const here = dirname(fileURLToPath(import.meta.url))
+
+test('escaped currency bypasses math and renders without its backslash', () => {
+  const md = new Marked()
+  md.use(mathTokens())
+
+  const [paragraph] = md.lexer('Revenue reached \\$100M while $x$ stays math.')
+  assert.deepEqual(
+    paragraph.tokens.map(token => [token.type, token.text]),
+    [
+      ['text', 'Revenue reached '],
+      ['escape', '$'],
+      ['text', '100M while '],
+      ['inlineKatex', 'x'],
+      ['text', ' stays math.'],
+    ],
+  )
+
+  const inlineSource = readFileSync(resolve(here, '../markdown/InlineContent.jsx'), 'utf8')
+  assert.match(
+    inlineSource,
+    /if \(token\.type === 'escape'\) \{\s*return token\.text\s*\}/,
+    'escape tokens must render their parsed text rather than raw Markdown',
+  )
+})

--- a/frontend/src/components/ChatView/markdown/InlineContent.jsx
+++ b/frontend/src/components/ChatView/markdown/InlineContent.jsx
@@ -37,6 +37,10 @@ function InlineToken({ token, onInternalNav, mediaDimensions }) {
     return token.text
   }
 
+  if (token.type === 'escape') {
+    return token.text
+  }
+
   // Math from marked-katex-extension.
   // displayMode:true means block-style math ($$...$$) that happened
   // to be on one line — render as block.  displayMode:false is inline.


### PR DESCRIPTION
## Summary
- render standard Markdown escape tokens from their parsed text so authoring backslashes do not appear in chat
- preserve inline math parsing and cover escaped currency alongside real math

## Testing
- `npm test`
- `npm run build`