### PR TITLE
Keep drawer scroll position stable when chats reorder

### DIFF
--- a/frontend/src/components/Drawer/Drawer.css
+++ b/frontend/src/components/Drawer/Drawer.css
@@ -251,6 +251,12 @@
   display: flex;
   flex-direction: column;
   overflow-y: auto;
+  /* Chat recency changes deliberately reorder keyed rows. Native scroll
+     anchoring treats that move as inserted/removed content and adjusts
+     scrollTop, so sending in the current chat nudges the navigation scrollbar.
+     The drawer owns a stable list position instead: keep its numeric scroll
+     offset while the row moves to its new recency slot. */
+  overflow-anchor: none;
   overscroll-behavior: contain;
   scrollbar-width: var(--shell-scrollbar-width, none);
   /* Bottom room keeps the final chat clear of the Settings divider.

--- a/frontend/src/lib/__tests__/drawerScrollCssInvariants.test.js
+++ b/frontend/src/lib/__tests__/drawerScrollCssInvariants.test.js
@@ -1,0 +1,19 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+const css = readFileSync(
+  fileURLToPath(new URL('../../components/Drawer/Drawer.css', import.meta.url)),
+  'utf8',
+)
+
+test('chat recency reorders do not move the drawer scroll position', () => {
+  const scrollRule = css.match(/\.drawer__scroll\s*\{([^}]*)\}/)?.[1] || ''
+
+  assert.match(
+    scrollRule,
+    /overflow-anchor:\s*none/,
+    'native anchoring must not change scrollTop when a chat row moves to the top',
+  )
+})


### PR DESCRIPTION
## Summary
- keep the drawer's scroll position unchanged when recency updates reorder chat rows
- opt the drawer out of native browser scroll anchoring, which interprets keyed row moves as inserted or removed content
- add a regression invariant for the drawer scroll container

## Why
Sending a message can move the current conversation to the top of the chat list. Native scroll anchoring then adjusts the drawer's scroll offset, nudging the user away from the position they chose.

This is a focused follow-up to #210: that change progressively renders large chat histories and preserves the revealed row window, while this patch prevents the browser from moving the scroll offset when those rendered rows reorder.

## Testing
- `npm test` — 2,145 frontend library/component tests and 66 hook tests pass
- `npm run build`
- authenticated browser replay: moving the active chat row to the top kept the drawer at the same scroll offset