### PR TITLE
Preserve keyboard chat position and disambiguate source titles

### DIFF
--- a/frontend/src/components/ChatView/MessageSources.jsx
+++ b/frontend/src/components/ChatView/MessageSources.jsx
@@ -1,5 +1,6 @@
 import {
   messageSources,
+  sourceDisplayLabels,
   sourceHost,
   sourceLabel,
 } from './messageSources.js'
@@ -15,12 +16,14 @@ function sourceMark(host) {
 export default function MessageSources({ blocks }) {
   const sources = messageSources(blocks)
   if (sources.length === 0) return null
+  const labels = sourceDisplayLabels(sources)
 
   return (
     <section className="chat__sources" aria-label="Sources for this answer">
       <ul className="chat__sources-list">
-        {sources.map(source => {
-          const label = sourceLabel(source)
+        {sources.map((source, index) => {
+          const label = labels[index]
+          const baseLabel = sourceLabel(source)
           const host = sourceHost(source.url)
           return (
             <li key={source.url} className="chat__source-item chat__source-item--web">
@@ -30,7 +33,7 @@ export default function MessageSources({ blocks }) {
                 target="_blank"
                 rel="noopener noreferrer"
                 title={source.snippet || source.title || source.url}
-                aria-label={`${label}${host && host !== label ? ` — ${host}` : ''} (opens in a new tab)`}
+                aria-label={`${label}${host && label === baseLabel && host !== label ? ` — ${host}` : ''} (opens in a new tab)`}
               >
                 {/* Keep reading passive: a local domain mark avoids contacting
                     every cited site merely because its card neared the viewport. */}

--- a/frontend/src/components/ChatView/__tests__/messageSources.test.js
+++ b/frontend/src/components/ChatView/__tests__/messageSources.test.js
@@ -7,6 +7,7 @@ import {
   boundedMessageSource,
   messageSources,
   safeSourceUrl,
+  sourceDisplayLabels,
   sourceHost,
   sourceLabel,
 } from '../messageSources.js'
@@ -150,6 +151,44 @@ test('a title equal to the URL is not treated as a real title', () => {
 test('a real title (Claude) wins over the host', () => {
   assert.equal(sourceLabel({ title: 'Node.js Releases', url: 'https://nodejs.org/x' }),
     'Node.js Releases')
+})
+
+test('colliding source titles stay distinct without dropping citations', () => {
+  const sources = [
+    {
+      title: 'Apple Accessibility Conformance Report',
+      url: 'https://support.apple.com/content/otherassets/vpat_macbookpro_2023.pdf',
+    },
+    {
+      title: 'Apple Accessibility Conformance Report',
+      url: 'https://support.apple.com/content/otherassets/vpat_macbookair_2024.pdf',
+    },
+  ]
+  assert.deepEqual(sourceDisplayLabels(sources), [
+    'vpat_macbookpro_2023.pdf · support.apple.com — Apple Accessibility Conformance Report',
+    'vpat_macbookair_2024.pdf · support.apple.com — Apple Accessibility Conformance Report',
+  ])
+  assert.equal(sources.length, 2, 'both distinct URLs remain available')
+})
+
+test('same-title locale variants use their path and exact repeats remain numbered', () => {
+  const title = 'Add a website shortcut to your home screen on iOS'
+  assert.deepEqual(sourceDisplayLabels([
+    { title, url: 'https://support.mozilla.org/en-US/kb/add-website-shortcut' },
+    { title, url: 'https://support.mozilla.org/eu/kb/add-website-shortcut' },
+    { title, url: 'https://support.mozilla.org/eu/kb/add-website-shortcut?variant=2' },
+  ]), [
+    `en-US/kb/add-website-shortcut · support.mozilla.org — ${title}`,
+    `eu/kb/add-website-shortcut · support.mozilla.org (1) — ${title}`,
+    `eu/kb/add-website-shortcut · support.mozilla.org (2) — ${title}`,
+  ])
+})
+
+test('unique source labels remain unchanged', () => {
+  assert.deepEqual(sourceDisplayLabels([
+    { title: 'Node.js Releases', url: 'https://nodejs.org/releases' },
+    { url: 'https://example.com/docs' },
+  ]), ['Node.js Releases', 'example.com'])
 })
 
 test('an unparseable URL still yields a usable label', () => {

--- a/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
+++ b/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
@@ -222,7 +222,7 @@ test('disclosure toggles follow only in FOLLOW_BOTTOM and otherwise hold the rea
   )
 })
 
-test('only provably clamped wheel input gets a next-frame no-scroll release', () => {
+test('only provably clamped wheel and keyboard input gets a next-frame release', () => {
   const middle = {
     scrollTop: 500,
     scrollHeight: 2000,
@@ -260,7 +260,25 @@ test('only provably clamped wheel input gets a next-frame no-scroll release', ()
     ...middle,
     deltaY: 0,
   }), true, 'a horizontal-only wheel cannot move this vertical controller')
-  assert.equal(readerInputNeedsFrameRelease('keydown'), true)
+  assert.equal(readerInputNeedsFrameRelease('keydown', middle, 'PageUp'), false,
+    'PageUp waits for the browser scroll before releasing reader ownership')
+  assert.equal(readerInputNeedsFrameRelease('keydown', {
+    ...middle,
+    scrollTop: 0,
+  }, 'PageUp'), true, 'PageUp at the top is already clamped')
+  assert.equal(readerInputNeedsFrameRelease('keydown', middle, 'PageDown'), false)
+  assert.equal(readerInputNeedsFrameRelease('keydown', {
+    ...middle,
+    scrollTop: 1200,
+  }, 'PageDown'), true, 'PageDown at the bottom is already clamped')
+  assert.equal(readerInputNeedsFrameRelease('keydown', middle, ' ', true), false,
+    'Shift+Space owns upward movement')
+  assert.equal(readerInputNeedsFrameRelease('keydown', {
+    ...middle,
+    scrollTop: 0,
+  }, ' ', true), true, 'Shift+Space fast-releases at the top')
+  assert.equal(readerInputNeedsFrameRelease('keydown', middle, 'Tab'), true,
+    'focus traversal has no stable scroll direction')
   assert.equal(readerInputNeedsFrameRelease('pointerdown'), false)
   assert.equal(readerInputNeedsFrameRelease('touchmove'), false)
 })
@@ -283,12 +301,15 @@ test('touch input never reads scroll geometry, so it cannot force a layout', () 
   readerInputNeedsFrameRelease('pointerdown', readGeometry)
   assert.equal(geometryReads, 0, 'touch and pointer input must not measure the scroller')
 
-  readerInputNeedsFrameRelease('keydown', readGeometry)
-  assert.equal(geometryReads, 0, 'keydown short-circuits before measuring')
+  // Scroll keys are rare and need the same exact-edge proof as wheel input.
+  readerInputNeedsFrameRelease('keydown', readGeometry, 'PageUp')
+  assert.equal(geometryReads, 1, 'keydown reads the scroller once')
+  readerInputNeedsFrameRelease('keydown', readGeometry, 'Tab')
+  assert.equal(geometryReads, 1, 'Tab fast-releases without measuring')
 
   // Wheel genuinely needs the values, so it must still read them - exactly once.
   readerInputNeedsFrameRelease('wheel', readGeometry)
-  assert.equal(geometryReads, 1, 'wheel reads the scroller once')
+  assert.equal(geometryReads, 2, 'wheel reads the scroller once')
 })
 
 test('scroll diagnostics expose behavior without message identity', () => {

--- a/frontend/src/components/ChatView/messageSources.js
+++ b/frontend/src/components/ChatView/messageSources.js
@@ -96,6 +96,82 @@ export function sourceLabel(source) {
   return sourceHost(source?.url) || source?.url || ''
 }
 
+function sourceUrlParts(source) {
+  try {
+    const parsed = new URL(safeSourceUrl(source?.url))
+    return {
+      host: parsed.host.replace(/^www\./i, ''),
+      parts: parsed.pathname
+        .split('/')
+        .filter(Boolean)
+        .map(part => {
+          try { return decodeURIComponent(part) } catch { return part }
+        }),
+    }
+  } catch {
+    return { host: '', parts: [], fallback: source?.url || '' }
+  }
+}
+
+function boundedSourceHint(value) {
+  if (value.length <= 96) return value
+  return `${value.slice(0, 47)}…${value.slice(-48)}`
+}
+
+function sourceUrlHint(parsed, expanded = false) {
+  const path = expanded
+    ? parsed.parts.join('/')
+    : parsed.parts.at(-1) || ''
+  if (path && parsed.host) return boundedSourceHint(`${path} · ${parsed.host}`)
+  return boundedSourceHint(path || parsed.host || parsed.fallback || '')
+}
+
+/** Keep every distinct citation while making repeated visible titles honest.
+ * Search results commonly reuse generic titles across different documents;
+ * URL-only dedupe correctly preserves those links, but identical chips make
+ * them look like duplicated UI. Only colliding labels gain a compact URL hint,
+ * placed first so the chip's ellipsis cannot hide the distinguishing part.
+ */
+export function sourceDisplayLabels(sources) {
+  if (!Array.isArray(sources)) return []
+  const baseLabels = sources.map(sourceLabel)
+  const indexesByLabel = new Map()
+  baseLabels.forEach((label, index) => {
+    const indexes = indexesByLabel.get(label) || []
+    indexes.push(index)
+    indexesByLabel.set(label, indexes)
+  })
+
+  const labels = [...baseLabels]
+  for (const [baseLabel, indexes] of indexesByLabel) {
+    if (indexes.length === 1) continue
+    const parsed = indexes.map(index => sourceUrlParts(sources[index]))
+    const compactHints = parsed.map(parts => sourceUrlHint(parts))
+    const compactCounts = new Map()
+    for (const hint of compactHints) {
+      compactCounts.set(hint, (compactCounts.get(hint) || 0) + 1)
+    }
+    const hints = compactHints.map((hint, index) => (
+      compactCounts.get(hint) > 1 ? sourceUrlHint(parsed[index], true) : hint
+    ))
+    const hintCounts = new Map()
+    for (const hint of hints) {
+      hintCounts.set(hint, (hintCounts.get(hint) || 0) + 1)
+    }
+    const occurrences = new Map()
+    hints.forEach((hint, groupIndex) => {
+      let distinctHint = hint
+      if (hintCounts.get(hint) > 1) {
+        const occurrence = (occurrences.get(hint) || 0) + 1
+        occurrences.set(hint, occurrence)
+        distinctHint = `${hint} (${occurrence})`
+      }
+      labels[indexes[groupIndex]] = `${distinctHint} — ${baseLabel}`
+    })
+  }
+  return labels
+}
+
 // First occurrence owns the position, so search order is kept. A later copy may
 // fill missing title/snippet metadata without moving or duplicating the card.
 export function messageSources(blocks) {

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -786,34 +786,47 @@ export function readerInputActivatesDisclosure(
 }
 
 
-/** Wheel and keyboard input have no pointer/touch release event. Keyboard
- * input keeps the next-frame no-scroll release. A wheel gets that fast release
- * only when its requested direction is exactly clamped at the corresponding
- * edge (or has no vertical delta). A proximity epsilon is not sufficient: a
- * wheel can still move through that final gap, and its compositor scroll can
- * arrive after rAF. For a wheel that can move, the actual scroll event owns the
- * release. */
-/**
- * `readGeometry` is a THUNK, not a value, because only the `wheel` branch below
- * ever reads it.
+/** Wheel and keyboard input have no pointer/touch release event. They get a
+ * next-frame no-scroll release only when their requested direction is exactly
+ * clamped at the corresponding edge (or cannot move this vertical scroller).
+ * A proximity epsilon is not sufficient: browser-owned wheel and keyboard
+ * scrolling can arrive after rAF. When movement is possible, the actual scroll
+ * event owns the release.
+ *
+ * `readGeometry` is a THUNK, not a value, because only wheel and scroll-key
+ * branches below ever read it.
  *
  * This function is called from the shared user-input handler, which is bound to
- * touchstart and touchmove as well as wheel. Passing an eagerly-built object
- * meant `scrollTop`/`scrollHeight`/`clientHeight` were read on every touch
- * event and then discarded at the `type !== 'wheel'` line - and reading
- * `scrollHeight` forces a synchronous layout of the whole (unvirtualized)
- * transcript. On desktop that cost is at least paid for something: wheel
- * genuinely needs the values, and fires roughly once per notch. Touch paid it
- * for nothing, at digitizer rate, starting with the first event of the gesture
- * - which is why the lag is felt as a scroll STARTS rather than during it.
+ * touchstart and touchmove as well as wheel/keydown. Passing an eagerly-built
+ * object meant `scrollTop`/`scrollHeight`/`clientHeight` were read on every
+ * touch event and then discarded - and reading `scrollHeight` forces a
+ * synchronous layout of the whole (unvirtualized) transcript. Wheel and the
+ * comparatively rare scroll keys genuinely need the values; touch does not.
  *
- * Deferring is deliberately done HERE rather than by guarding the call site on
- * `type === 'wheel'`. Which input types need geometry is this function's own
+ * Deferring is deliberately done HERE rather than by guarding the call site.
+ * Which input types need geometry is this function's own
  * rule; duplicating it at the caller would let the two drift apart silently.
  */
-export function readerInputNeedsFrameRelease(type, readGeometry) {
-  if (type === 'keydown') return true
-  if (type !== 'wheel') return false
+export function readerInputNeedsFrameRelease(
+  type,
+  readGeometry,
+  key = '',
+  shiftKey = false,
+) {
+  if (type !== 'wheel' && type !== 'keydown') return false
+
+  let towardStart = false
+  let towardEnd = false
+  if (type === 'keydown') {
+    towardStart = ['ArrowUp', 'PageUp', 'Home'].includes(key)
+      || (shiftKey && [' ', 'Spacebar'].includes(key))
+    towardEnd = ['ArrowDown', 'PageDown', 'End'].includes(key)
+      || (!shiftKey && [' ', 'Spacebar'].includes(key))
+    // Tab may reveal a newly-focused control, but has no stable direction to
+    // prove against this scroller. Keep its old fast no-scroll release; focus
+    // management owns any later reveal. It does not need a layout read.
+    if (!towardStart && !towardEnd) return true
+  }
 
   const {
     deltaY = 0,
@@ -822,9 +835,14 @@ export function readerInputNeedsFrameRelease(type, readGeometry) {
     clientHeight = 0,
   } = (typeof readGeometry === 'function' ? readGeometry() : readGeometry) || {}
 
+  const maxScrollTop = Math.max(0, scrollHeight - clientHeight)
+
+  if (type === 'keydown') {
+    return towardStart ? scrollTop <= 0 : scrollTop >= maxScrollTop
+  }
+
   if (!Number.isFinite(deltaY) || deltaY === 0) return true
 
-  const maxScrollTop = Math.max(0, scrollHeight - clientHeight)
   if (deltaY < 0) return scrollTop <= 0
   return scrollTop >= maxScrollTop
 }
@@ -2013,15 +2031,23 @@ export default function useScrollMode({
       pendingGestureTimerRef.current = setTimeout(() => {
         releasePendingGesture(sequence)
       }, PENDING_GESTURE_CAP_MS)
-      // Thunk, not an object literal: these three property reads force a
-      // synchronous layout, and only the wheel branch consumes them. See
+      // Thunk, not an object literal: these property reads force a synchronous
+      // layout, and only wheel/scroll-key branches consume them. See
       // readerInputNeedsFrameRelease.
-      if (readerInputNeedsFrameRelease(event?.type, () => ({
-        deltaY: event?.deltaY,
-        scrollTop: scrollEl.scrollTop,
-        scrollHeight: scrollEl.scrollHeight,
-        clientHeight: scrollEl.clientHeight,
-      }))) {
+      // Space/Enter on a disclosure button cannot natively scroll; preserve its
+      // existing one-frame release rather than waiting for the safety cap.
+      const keyboardDisclosure = activatesDisclosure && event?.type === 'keydown'
+      if (keyboardDisclosure || readerInputNeedsFrameRelease(
+          event?.type,
+          () => ({
+            deltaY: event?.deltaY,
+            scrollTop: scrollEl.scrollTop,
+            scrollHeight: scrollEl.scrollHeight,
+            clientHeight: scrollEl.clientHeight,
+          }),
+          event?.key,
+          event?.shiftKey,
+        )) {
         scheduleNoScrollRelease()
       }
     }

--- a/tests/frontend.spec.mjs
+++ b/tests/frontend.spec.mjs
@@ -624,24 +624,33 @@ test.describe('App canvas', () => {
 })
 
 test.describe('Scroll position', () => {
-  test('10. Scroll position saved on navigate, restored on return', async ({ page }) => {
+  test('10. PageUp position saved on navigate, restored on return', async ({ page }) => {
     await setup(page)
     await newChat(page)
 
     const chatId = await page.evaluate(() => localStorage.getItem('moebius_active_chat'))
     expect(chatId).toBeTruthy()
 
+    const textBlocks = Array.from({ length: 36 }, (_, i) => ({
+      type: 'text',
+      content: `Scroll restore paragraph ${i + 1}. ${'Persisted content. '.repeat(10)}`,
+    }))
     const messages = [
       { role: 'user', content: 'Scroll restore prompt', ts: 1700000000000 },
       {
         role: 'assistant',
-        content: Array.from({ length: 36 }, (_, i) =>
-          `Scroll restore paragraph ${i + 1}. ${'Persisted content. '.repeat(10)}`
-        ).join('\n\n'),
-        blocks: Array.from({ length: 36 }, (_, i) => ({
-          type: 'text',
-          content: `Scroll restore paragraph ${i + 1}. ${'Persisted content. '.repeat(10)}`,
-        })),
+        content: textBlocks.map(block => block.content).join('\n\n'),
+        blocks: [
+          ...textBlocks,
+          {
+            type: 'tool',
+            tool: 'Bash',
+            input: 'verify keyboard scrolling',
+            output: 'done',
+            status: 'done',
+            tool_use_id: 'keyboard-scroll-tool',
+          },
+        ],
       },
     ]
 
@@ -676,20 +685,22 @@ test.describe('Scroll position', () => {
       { timeout: 10000 }
     )
 
-    // Stamp an ANCHOR_AT mode with a real wheel gesture; the scroll state
-    // machine intentionally ignores non-gesture scroll events.
-    await page.evaluate(() => {
-      const el = document.querySelector('[data-chat-surface="painted"] .chat__scroll')
-      if (!el) return
-      el.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
-      el.scrollTop = Math.floor(el.scrollHeight / 3)
-    })
-    await page.waitForFunction(() => {
-      const el = document.querySelector('[data-chat-surface="painted"] .chat__scroll')
-      if (!el) return false
-      const gap = el.scrollHeight - el.scrollTop - el.clientHeight
-      return el.scrollTop > 0 && gap > 100
-    }, { timeout: 3000 })
+    // Use the same browser-owned delayed key scroll that exposed the bug. A
+    // synthetic scrollTop write would bypass the ownership race entirely.
+    const initialTop = await page.evaluate(
+      () => document.querySelector('[data-chat-surface="painted"] .chat__scroll')?.scrollTop ?? 0,
+    )
+    await page.locator(
+      '[data-chat-surface="painted"] .chat__activity-header',
+    ).last().focus()
+    await page.keyboard.press('PageUp')
+    await expect.poll(
+      () => page.evaluate(() => (
+        document.querySelector('[data-chat-surface="painted"] .chat__scroll')?.scrollTop ?? 0
+      )),
+      { timeout: 3000 },
+    ).toBeLessThan(initialTop - 100)
+    await waitForChatMode(page, chatId, 'ANCHOR_AT')
     const scrollBefore = await page.evaluate(() => {
       const el = document.querySelector('[data-chat-surface="painted"] .chat__scroll')
       return el ? el.scrollTop : null

--- a/tests/frontend.spec.mjs
+++ b/tests/frontend.spec.mjs
@@ -690,9 +690,10 @@ test.describe('Scroll position', () => {
     const initialTop = await page.evaluate(
       () => document.querySelector('[data-chat-surface="painted"] .chat__scroll')?.scrollTop ?? 0,
     )
-    await page.locator(
-      '[data-chat-surface="painted"] .chat__activity-header',
-    ).last().focus()
+    await page.getByRole('button', {
+      name: 'Ran verify keyboard scrolling',
+      exact: true,
+    }).focus()
     await page.keyboard.press('PageUp')
     await expect.poll(
       () => page.evaluate(() => (


### PR DESCRIPTION
## Problem

Two chat-reading paths still looked unreliable after the earlier steering fixes:

- Browser-owned PageUp/PageDown scrolling can arrive after the next animation frame. The controller released keyboard ownership at that frame, before Chrome delivered the real scroll event, so leaving and returning could restore the prior position instead of the one the reader chose.
- Distinct citations often reuse a generic page title. URL-only deduplication correctly kept every link, but the resulting source chips looked identical, and a trailing URL hint was hidden by the chip ellipsis.

## Fix

- Keep directional keyboard scrolling reader-owned until its first real scroll event, unless exact geometry proves that direction is already clamped. Tab, disclosure activation, and the bounded no-scroll fallback keep their fast release paths.
- Disambiguate only colliding source labels. Put the distinguishing filename or locale first so it remains visible under truncation, while preserving every unique URL and leaving ordinary source labels unchanged.
- Convert the existing return-position browser regression from a synthetic scrollTop write to a real PageUp keypress, avoiding a second overlapping scenario.

## Prior work

This builds on the reader-ownership contract in [#50](https://github.com/mobius-os/mobius/pull/50). The merged steering fixes [#322](https://github.com/mobius-os/mobius/pull/322) and [#331](https://github.com/mobius-os/mobius/pull/331) cover live-surface promotion and stale steer settlement; they do not cover delayed native keyboard scroll events or colliding citation titles.

## Verification

- Full frontend library/static suite: 2,147 passed.
- Full frontend hook suite: 66 passed.
- Production/PWA/offline build passed.
- Focused source and scroll-controller suites passed (100 checks on current upstream).
- Authenticated long-chat replay: PageUp, leave, and return restored the exact pixel and message-anchor offset; rendered source labels had no visible collisions.