### PR TITLE
Keep tab actions minimal and drawer rows clean

### DIFF
--- a/frontend/src/components/Drawer/Drawer.css
+++ b/frontend/src/components/Drawer/Drawer.css
@@ -428,47 +428,6 @@
   touch-action: pan-y pinch-zoom;
 }
 
-.drawer__more {
-  flex: 0 0 40px;
-  align-self: stretch;
-  display: grid;
-  place-items: center;
-  border: 0;
-  border-radius: 8px;
-  background: transparent;
-  color: var(--muted);
-  cursor: pointer;
-  opacity: 0;
-  transition: opacity 0.12s, color 0.12s, background 0.12s, transform 0.08s;
-  -webkit-tap-highlight-color: transparent;
-}
-
-.drawer__more:active {
-  color: var(--text);
-  background: var(--surface);
-  transform: scale(0.92);
-}
-
-.drawer__more[aria-expanded="true"] {
-  opacity: 1;
-  color: var(--accent);
-  background: var(--accent-dim);
-}
-
-.drawer__row:focus-within .drawer__more { opacity: 1; }
-
-@media (hover: hover) and (pointer: fine) {
-  .drawer__row:hover .drawer__more { opacity: 1; }
-  .drawer__more:hover {
-    color: var(--text);
-    background: var(--surface);
-  }
-}
-
-@media (hover: none) {
-  .drawer__more { opacity: 0.5; }
-}
-
 /* App cards and drawer rows share one action-menu placement path. Pointer
    coordinates are converted to root layout space so shell density never shifts
    a menu away from the click. */

--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -1,7 +1,7 @@
 import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useQueryClient } from '@tanstack/react-query'
-import { Chats, DotsVerticalMoreMenu, PinFilled } from '@openai/apps-sdk-ui/components/Icon'
+import { Chats, PinFilled } from '@openai/apps-sdk-ui/components/Icon'
 import { EmptyMessage } from '@openai/apps-sdk-ui/components/EmptyMessage'
 import { api } from '../../api/client.js'
 import { appQueries, chatQueries } from '../../hooks/queries.js'
@@ -1545,16 +1545,6 @@ const DrawerRow = memo(function DrawerRow({
           />
         ) : null}
         <span className="drawer__item-text">{label}</span>
-      </button>
-      <button
-        type="button"
-        className="drawer__more"
-        aria-label={`More actions for ${label}`}
-        aria-haspopup="menu"
-        aria-expanded={menuOpen}
-        onClick={openItemMenu}
-      >
-        <DotsVerticalMoreMenu width={16} height={16} aria-hidden="true" />
       </button>
       <DrawerItemMenu
         kind={kind}

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useState, useEffect, useLayoutEffect, useCallback, useMemo, useReducer, useRef } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
-import { CollapseSm } from '@openai/apps-sdk-ui/components/Icon'
+import { CollapseSm, X } from '@openai/apps-sdk-ui/components/Icon'
 import {
   AppsNavIcon,
   NewChatNavIcon,
@@ -23,6 +23,7 @@ import useNavigation, {
   deepLink,
 } from '../../hooks/useNavigation.js'
 import { replaceNavEntry } from '../../lib/navHistory.js'
+import { placeContextMenu } from '../../lib/contextMenuGeometry.js'
 import { parseNotificationTarget } from '../../lib/notificationTarget.js'
 import useSystemEventStream from '../../hooks/useSystemEventStream.js'
 import useTheme from '../../hooks/useTheme.js'
@@ -1575,26 +1576,33 @@ export default function Shell() {
     recoveredChatIdsRef.current.delete(chatId)
   }, [])
 
-  // The tab context menu is the ONLY split path in PR2. Split/Move items exist
-  // only when the workspace-splits flag is on (stage-A inert default); Close tab
-  // is always offered. The top strip attaches this handler only when the flag is
-  // on, so single-pane right-click keeps today's native menu (parity).
+  // Tabs expose a compact browser-style close menu without adding permanent
+  // chrome: right-click or the keyboard menu key on desktop, stationary hold on
+  // touch. The same state drives both the single strip and tiled pane strips.
   const [tabMenu, setTabMenu] = useState(null)
   const tabMenuRef = useRef(null)
   const tabMenuReturnFocusRef = useRef(null)
-  const openTabMenu = useCallback((e, tab, paneId) => {
-    e.preventDefault()
+  const openTabMenu = useCallback((event, tab, paneId) => {
+    event.preventDefault()
     const owner = paneId || paneModel.paneOf(workspace, tabModel.tabKey(tab))?.id
     if (!owner) return
-    tabMenuReturnFocusRef.current = e.currentTarget
-    setTabMenu({ x: e.clientX, y: e.clientY, tab, tabKey: tabModel.tabKey(tab), paneId: owner })
+    const triggerRect = event.currentTarget.getBoundingClientRect()
+    const keyboardPlacement = event.clientX === 0 && event.clientY === 0
+    tabMenuReturnFocusRef.current = event.currentTarget
+    setTabMenu({
+      x: keyboardPlacement
+        ? triggerRect.left + Math.min(triggerRect.width / 2, 28)
+        : event.clientX,
+      y: keyboardPlacement ? triggerRect.bottom : event.clientY,
+      tab,
+      tabKey: tabModel.tabKey(tab),
+      paneId: owner,
+    })
   }, [workspace])
-  // Coordinate variant for the drag controller's touch lift→release-in-place
-  // path (design §3.1) — same menu, opened at a point with no trigger element to
-  // restore focus to. Reads the workspace from the ref so an async open (a
-  // settled drag) sees the current tree.
   const openTabMenuAt = useCallback((x, y, tab, paneId) => {
-    const owner = paneId || paneModel.paneOf(workspaceStateRef.current.ws, tabModel.tabKey(tab))?.id
+    if (!tab) return
+    const owner = paneId
+      || paneModel.paneOf(workspaceStateRef.current.ws, tabModel.tabKey(tab))?.id
     if (!owner) return
     tabMenuReturnFocusRef.current = null
     setTabMenu({ x, y, tab, tabKey: tabModel.tabKey(tab), paneId: owner })
@@ -1605,34 +1613,46 @@ export default function Shell() {
     const returnTarget = tabMenuReturnFocusRef.current
     queueMicrotask(() => returnTarget?.focus?.({ preventScroll: true }))
   }, [])
-  // A context menu must be keyboard-ready when it appears, and pointer
-  // coordinates near a viewport edge must not place actions off-screen.
   useLayoutEffect(() => {
     if (!tabMenu || !tabMenuRef.current) return
     const menu = tabMenuRef.current
-    const rect = menu.getBoundingClientRect()
-    const gutter = 8
-    menu.style.left = `${Math.max(gutter, Math.min(tabMenu.x, window.innerWidth - rect.width - gutter))}px`
-    menu.style.top = `${Math.max(gutter, Math.min(tabMenu.y, window.innerHeight - rect.height - gutter))}px`
+    const root = document.documentElement
+    const rootRect = root.getBoundingClientRect()
+    const position = placeContextMenu({
+      clientPoint: { x: tabMenu.x, y: tabMenu.y },
+      clientViewport: rootRect,
+      layoutViewport: {
+        width: root.offsetWidth || root.clientWidth || rootRect.width,
+        height: root.offsetHeight || root.clientHeight || rootRect.height,
+      },
+      menuSize: { width: menu.offsetWidth, height: menu.offsetHeight },
+    })
+    menu.style.setProperty('--workspace-menu-x', `${position.x}px`)
+    menu.style.setProperty('--workspace-menu-y', `${position.y}px`)
+    menu.dataset.positioned = 'true'
     menu.querySelector('[role="menuitem"]')?.focus()
   }, [tabMenu])
-  const handleTabMenuKeyDown = useCallback((e) => {
+  const handleTabMenuKeyDown = useCallback((event) => {
     const items = [...(tabMenuRef.current?.querySelectorAll('[role="menuitem"]') || [])]
     if (items.length === 0) return
     const current = Math.max(0, items.indexOf(document.activeElement))
     let next = null
-    if (e.key === 'ArrowDown') next = (current + 1) % items.length
-    else if (e.key === 'ArrowUp') next = (current - 1 + items.length) % items.length
-    else if (e.key === 'Home') next = 0
-    else if (e.key === 'End') next = items.length - 1
+    if (event.key === 'ArrowDown') next = (current + 1) % items.length
+    else if (event.key === 'ArrowUp') next = (current - 1 + items.length) % items.length
+    else if (event.key === 'Home') next = 0
+    else if (event.key === 'End') next = items.length - 1
     if (next == null) return
-    e.preventDefault()
+    event.preventDefault()
     items[next].focus()
   }, [])
   useEffect(() => {
-    if (!tabMenu) return
-    const onDown = (e) => { if (!e.target.closest?.('.workspace__menu')) closeTabMenu(false) }
-    const onKey = (e) => { if (e.key === 'Escape') closeTabMenu() }
+    if (!tabMenu) return undefined
+    const onDown = (event) => {
+      if (!event.target.closest?.('.workspace__menu')) closeTabMenu(false)
+    }
+    const onKey = (event) => {
+      if (event.key === 'Escape') closeTabMenu()
+    }
     document.addEventListener('pointerdown', onDown, true)
     document.addEventListener('keydown', onKey, true)
     return () => {
@@ -3814,9 +3834,7 @@ export default function Shell() {
                   if (tab.kind === 'chat') focusDesktopChatPaneComposer(tab.id)
                 }}
                 onClose={() => closeTab(tab)}
-                onContextMenu={paneModel.WORKSPACE_SPLITS_ENABLED
-                  ? (e) => openTabMenu(e, tab, null)
-                  : undefined}
+                onContextMenu={(event) => openTabMenu(event, tab, null)}
               />
             )
           })}
@@ -4222,105 +4240,89 @@ export default function Shell() {
         action={toast?.action}
         onDismiss={dismissToast}
       />
-      {/* Tab context menu — the ONLY split path in PR2. Fixed-position at the
-          pointer; dismisses on outside pointerdown/Escape (effect above). Split
-          and Move items exist only when the workspace-splits flag is on, so with
-          the flag off (stage-A default) the menu never even opens (the strip
-          handlers are omitted). */}
       {tabMenu && (() => {
         const menuPane = workspace.panes[tabMenu.paneId]
-        const otherPaneIds = Object.keys(workspace.panes).filter(pid => pid !== tabMenu.paneId)
-        const canOfferSplit = paneModel.WORKSPACE_SPLITS_ENABLED
-          && menuPane && menuPane.tabs.length >= 2
+        const menuTabIndex = menuPane?.tabs.findIndex(
+          tab => tabModel.tabKey(tab) === tabMenu.tabKey,
+        ) ?? -1
+        const hasSiblingTabs = Boolean(menuPane && menuPane.tabs.length > 1)
+        const hasTabsToRight = Boolean(
+          menuPane && menuTabIndex >= 0 && menuTabIndex < menuPane.tabs.length - 1,
+        )
         return (
-          <div
-            ref={tabMenuRef}
-            className="workspace__menu"
-            role="menu"
-            aria-label="Tab actions"
-            style={{ left: tabMenu.x, top: tabMenu.y }}
-            onKeyDown={handleTabMenuKeyDown}
-          >
-            {canOfferSplit && [
-              ['right', 'Split right'], ['left', 'Split left'],
-              ['top', 'Split up'], ['bottom', 'Split down'],
-            ]
-              .filter(([edge]) => paneModel.canSplit(workspace, tabMenu.paneId, edge, workspaceMode, contentRect))
-              .map(([edge, label]) => (
-                <button
-                  key={edge}
-                  type="button"
-                  role="menuitem"
-                  className="workspace__menu-item"
-                  onClick={() => {
-                    dispatchWorkspace({ type: 'MOVE_TAB', tabKey: tabMenu.tabKey, target: { paneId: tabMenu.paneId, edge } })
-                    closeTabMenu()
-                  }}
-                >
-                  {label}
-                </button>
-              ))}
-            {paneModel.WORKSPACE_SPLITS_ENABLED && otherPaneIds.length >= 1 && otherPaneIds.map(pid => {
-              const pane = workspace.panes[pid]
-              const active = pane?.tabs.find(t => tabModel.tabKey(t) === pane.activeTabKey)
-              return (
-                <button
-                  key={pid}
-                  type="button"
-                  role="menuitem"
-                  className="workspace__menu-item"
-                  onClick={() => {
-                    dispatchWorkspace({ type: 'MOVE_TAB', tabKey: tabMenu.tabKey, target: { paneId: pid } })
-                    closeTabMenu()
-                  }}
-                >
-                  Move to {active ? labelForTab(active) : 'pane'}
-                </button>
-              )
-            })}
-            <button
-              type="button"
-              role="menuitem"
-              className="workspace__menu-item"
-              onClick={() => {
-                closeTab(tabMenu.tab)
-                closeTabMenu()
+          <div className="workspace__menu-layer">
+            <div
+              ref={tabMenuRef}
+              className="workspace__menu"
+              role="menu"
+              aria-label="Tab actions"
+              style={{
+                '--workspace-menu-x': `${tabMenu.x}px`,
+                '--workspace-menu-y': `${tabMenu.y}px`,
               }}
+              onKeyDown={handleTabMenuKeyDown}
             >
-              Close tab
-            </button>
-            {/* Close all other tabs — keep only the right-clicked tab in its
-                pane. Only when a sibling exists (never a no-op menu item);
-                other panes are untouched — the menu stays pane-scoped. */}
-            {menuPane && menuPane.tabs.length >= 2 && (
-              <button
-                type="button"
-                role="menuitem"
-                className="workspace__menu-item"
-                onClick={() => {
-                  dispatchWorkspace({ type: 'CLOSE_OTHER_TABS', tabKey: tabMenu.tabKey })
-                  closeTabMenu()
-                }}
-              >
-                Close all other tabs
-              </button>
-            )}
-            {/* Close pane — a keyboard/menu affordance so a multi-tab pane need
-                not be dismissed one ✕ at a time (design §3.6). Only when there is
-                another pane to fall back to (never the single-pane strip). */}
-            {paneModel.WORKSPACE_SPLITS_ENABLED && tabMenu.paneId != null && otherPaneIds.length >= 1 && (
-              <button
-                type="button"
-                role="menuitem"
-                className="workspace__menu-item"
-                onClick={() => {
-                  dispatchWorkspace({ type: 'CLOSE_PANE', paneId: tabMenu.paneId })
-                  closeTabMenu()
-                }}
-              >
-                Close pane
-              </button>
-            )}
+              <div className="workspace__menu-handle" aria-hidden="true" />
+              <header className="workspace__menu-header">
+                <div>
+                  <span>Tab actions</span>
+                  <strong>{labelForTab(tabMenu.tab)}</strong>
+                </div>
+                <button
+                  type="button"
+                  className="workspace__menu-close"
+                  aria-label="Close tab actions"
+                  onClick={() => closeTabMenu()}
+                >
+                  <X width={18} height={18} aria-hidden="true" />
+                </button>
+              </header>
+              <div className="workspace__menu-items">
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="workspace__menu-item"
+                  onClick={() => {
+                    closeTab(tabMenu.tab)
+                    closeTabMenu()
+                  }}
+                >
+                  Close tab
+                </button>
+                {hasSiblingTabs && (
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className="workspace__menu-item"
+                    onClick={() => {
+                      dispatchWorkspace({
+                        type: 'CLOSE_OTHER_TABS',
+                        tabKey: tabMenu.tabKey,
+                      })
+                      closeTabMenu()
+                    }}
+                  >
+                    Close all other tabs
+                  </button>
+                )}
+                {hasTabsToRight && (
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className="workspace__menu-item"
+                    onClick={() => {
+                      dispatchWorkspace({
+                        type: 'CLOSE_TABS_TO_RIGHT',
+                        tabKey: tabMenu.tabKey,
+                      })
+                      closeTabMenu()
+                    }}
+                  >
+                    Close tabs to the right
+                  </button>
+                )}
+              </div>
+            </div>
           </div>
         )
       })()}

--- a/frontend/src/components/Shell/__tests__/paneModel.test.js
+++ b/frontend/src/components/Shell/__tests__/paneModel.test.js
@@ -1125,6 +1125,49 @@ test('CLOSE_OTHER_TABS is pane-scoped — a sibling pane keeps its tabs', () => 
   )
 })
 
+test('CLOSE_TABS_TO_RIGHT removes only later siblings and is undoable', () => {
+  const ws = paneModel.seedFromFlatTabs([
+    makeTab('chat', 'a'),
+    makeTab('app', 42),
+    makeTab('chat', 'c'),
+    makeTab('chat', 'd'),
+  ])
+  const paneId = ws.focusedPaneId
+  const start = paneModel.initialWorkspaceState(ws)
+  const closed = paneModel.workspaceReducer(start, {
+    type: 'CLOSE_TABS_TO_RIGHT',
+    tabKey: 'app:42',
+  })
+  assert.deepEqual(closed.ws.panes[paneId].tabs.map(tabKey), ['chat:a', 'app:42'])
+  assert.equal(closed.ws.panes[paneId].activeTabKey, 'app:42',
+    'the menu tab becomes active when the prior active tab was closed')
+  assert.equal(closed.undo.toast, 'Closed tabs to the right')
+  assert.equal(paneModel.workspaceReducer(closed, {
+    type: 'CLOSE_TABS_TO_RIGHT',
+    tabKey: 'app:42',
+  }), closed, 'the last tab has no right-side action')
+  assert.equal(paneModel.workspaceReducer(closed, { type: 'UNDO_LAST' }).ws, ws)
+})
+
+test('closeTabsToRight preserves a surviving active tab and other panes', () => {
+  let ws = paneModel.seedFromFlatTabs([
+    makeTab('chat', 'a'),
+    makeTab('chat', 'b'),
+    makeTab('chat', 'c'),
+  ])
+  const leftPane = ws.focusedPaneId
+  ws = paneModel.setActiveTab(ws, leftPane, 'chat:a')
+  ws = paneModel.splitPaneWithTab(ws, makeTab('app', 42), {
+    paneId: leftPane,
+    edge: 'right',
+  })
+  const closed = paneModel.closeTabsToRight(ws, 'chat:b')
+  assert.deepEqual(closed.panes[leftPane].tabs.map(tabKey), ['chat:a', 'chat:b'])
+  assert.equal(closed.panes[leftPane].activeTabKey, 'chat:a')
+  assert.ok(paneModel.flatten(closed).map(tabKey).includes('app:42'))
+  assert.equal(paneModel.closeTabsToRight(ws, 'chat:nope'), ws)
+})
+
 test('reducer APPLY_PLACEMENT composes batched dispatches instead of clobbering', () => {
   // The former bug: two placements resolved against the same stale render
   // snapshot, so the second REPLACED the first. A resolve function run against

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -36,13 +36,25 @@ test('the workspace menu avoids an oversized border-and-shadow card', () => {
   assert.doesNotMatch(rule, /box-shadow:[^;]*(?:1[6-9]|[2-9]\d)px/)
 })
 
-test('the workspace menu is labeled, edge-clamped, and arrow-key navigable', () => {
+test('the workspace menu stays close-only, edge-clamped, and keyboard navigable', () => {
+  const menuMarkup = shell.slice(
+    shell.indexOf('{tabMenu &&'),
+    shell.indexOf('</HistoryDismissProvider>'),
+  )
   assert.match(shell, /aria-label="Tab actions"/)
-  assert.match(shell, /window\.innerWidth - rect\.width - gutter/)
-  assert.match(shell, /e\.key === 'ArrowDown'/)
+  assert.match(menuMarkup, /Close tab/)
+  assert.match(menuMarkup, /Close all other tabs/)
+  assert.match(menuMarkup, /Close tabs to the right/)
+  assert.doesNotMatch(
+    menuMarkup,
+    /type: 'MOVE_TAB'|type: 'CLOSE_PANE'|Split |Move to |Close pane/,
+  )
+  assert.match(shell, /placeContextMenu\(\{/)
+  assert.match(shell, /event\.key === 'ArrowDown'/)
   assert.match(shell, /querySelector\('\[role="menuitem"\]'\)\?\.focus\(\)/)
-  assert.match(shell, /tabMenuReturnFocusRef\.current = e\.currentTarget/)
+  assert.match(shell, /tabMenuReturnFocusRef\.current = event\.currentTarget/)
   assert.match(shell, /returnTarget\?\.focus\?\.\(\{ preventScroll: true \}\)/)
+  assert.match(css, /@media \(max-width: 720px\)[\s\S]*?\.workspace__menu-header/)
 })
 
 test('an implicit home tab does not engage the single-pane tab strip', () => {
@@ -185,15 +197,13 @@ test('the divider drag tears down from the window, surviving a mid-drag unmount'
   assert.match(chrome, /document\.body\.style\.userSelect = prevUserSelect/)
 })
 
-test('the context menu offers Close pane when another pane can absorb the space', () => {
-  assert.match(shell, /type: 'CLOSE_PANE', paneId: tabMenu\.paneId/)
-  assert.match(shell, /Close pane/)
-})
-
-test('the context menu offers Close all other tabs only when a sibling tab exists', () => {
-  assert.match(shell, /menuPane && menuPane\.tabs\.length >= 2/)
-  assert.match(shell, /type: 'CLOSE_OTHER_TABS', tabKey: tabMenu\.tabKey/)
+test('the context menu offers pane-scoped bulk close actions only when useful', () => {
+  assert.match(shell, /const hasSiblingTabs = Boolean\(menuPane && menuPane\.tabs\.length > 1\)/)
+  assert.match(shell, /type: 'CLOSE_OTHER_TABS',[\s\S]*?tabKey: tabMenu\.tabKey/)
   assert.match(shell, /Close all other tabs/)
+  assert.match(shell, /const hasTabsToRight = Boolean\(/)
+  assert.match(shell, /type: 'CLOSE_TABS_TO_RIGHT',[\s\S]*?tabKey: tabMenu\.tabKey/)
+  assert.match(shell, /Close tabs to the right/)
 })
 
 test('tab labels resolve through memoized id Maps, not per-render linear scans', () => {
@@ -841,14 +851,18 @@ test('large drawer lists memoize ordering and row actions without changing row o
   assert.doesNotMatch(drawer, /onSelect=\{\(\) => on(?:Chat|App)/)
 })
 
-test('row-owned context menus keep a visible trigger without hidden anchors', () => {
+test('row-owned context menus need no permanent kebab or hidden anchor', () => {
   assert.match(drawer, /<DrawerItemActionMenu[\s\S]*?itemKind=\{kind\}/)
-  assert.doesNotMatch(drawer, /triggerHidden|drawer__menu-anchor/)
-  assert.match(drawer,
-    /className="drawer__more"[\s\S]*?aria-label=\{`More actions for \$\{label\}`\}/,
-    'drawer rows must retain an explicit keyboard and touch action trigger')
-  assert.match(drawerCss, /\.drawer__more\s*\{/)
-  assert.doesNotMatch(drawerCss, /drawer__menu-anchor/)
+  assert.doesNotMatch(
+    drawer,
+    /triggerHidden|drawer__menu-anchor|drawer__more|DotsVerticalMoreMenu/,
+  )
+  assert.doesNotMatch(drawerCss, /drawer__menu-anchor|drawer__more/)
+  assert.match(drawer, /onContextMenu=\{openItemMenu\}/)
+  assert.match(
+    drawer,
+    /event\.key === 'ContextMenu' \|\| \(event\.shiftKey && event\.key === 'F10'\)/,
+  )
   assert.match(drawer, /if \(openMenu\) return[\s\S]*?onClose\?\.\(\)/,
     'Escape must close a row menu before dismissing the mobile drawer beneath it')
 })

--- a/frontend/src/components/Shell/paneModel.js
+++ b/frontend/src/components/Shell/paneModel.js
@@ -911,6 +911,29 @@ export function closeOtherTabs(ws, tabKey) {
   })
 }
 
+// Close only the tabs after the named tab in its pane. If the active tab is
+// among those removed, the named tab becomes active; otherwise focus stays
+// where it was. Other panes are untouched and the operation is reversible.
+export function closeTabsToRight(ws, tabKey) {
+  const pane = paneOf(ws, tabKey)
+  if (!pane) return ws
+  const index = pane.tabs.findIndex(tab => tabModel.tabKey(tab) === tabKey)
+  if (index < 0 || index === pane.tabs.length - 1) return ws
+  const tabs = pane.tabs.slice(0, index + 1)
+  const activeSurvives = tabs.some(tab => tabModel.tabKey(tab) === pane.activeTabKey)
+  return commit(ws, {
+    ...ws,
+    panes: {
+      ...ws.panes,
+      [pane.id]: {
+        ...pane,
+        tabs,
+        activeTabKey: activeSurvives ? pane.activeTabKey : tabKey,
+      },
+    },
+  })
+}
+
 // Move a tab within/between panes. target is one of:
 //   { paneId, index? }  insert into an existing pane at index (append if absent)
 //   { paneId, edge }    split that pane on the edge, the tab alone in the new one
@@ -1713,6 +1736,12 @@ export function workspaceReducer(state, action) {
       const next = closeOtherTabs(ws, action.tabKey)
       if (next === ws) return state
       const label = action.label || 'Closed other tabs'
+      return { ws: next, undo: { ws, label, toast: label } }
+    }
+    case 'CLOSE_TABS_TO_RIGHT': {
+      const next = closeTabsToRight(ws, action.tabKey)
+      if (next === ws) return state
+      const label = action.label || 'Closed tabs to the right'
       return { ws: next, undo: { ws, label, toast: label } }
     }
     case 'MOVE_TAB': {

--- a/frontend/src/components/Shell/workspace.css
+++ b/frontend/src/components/Shell/workspace.css
@@ -307,34 +307,50 @@
   background: var(--accent);
 }
 
-/* Tab context menu — the split path. Fixed at the pointer. */
+/* Tab actions stay off the permanent chrome. Desktop uses a pointer- or
+   keyboard-anchored menu; compact screens use the same actions as a named
+   bottom sheet. */
+.workspace__menu-layer {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  pointer-events: none;
+}
+
 .workspace__menu {
   position: fixed;
-  z-index: 200;
-  min-width: 168px;
+  left: var(--workspace-menu-x);
+  top: var(--workspace-menu-y);
+  width: min(230px, calc(100vw - 24px));
   max-height: 70vh;
   overflow-y: auto;
+  visibility: hidden;
   padding: 6px;
-  border-radius: 10px;
   border: 1px solid var(--border-light);
+  border-radius: 10px;
   background: var(--bg);
   box-shadow: 0 4px 8px color-mix(in srgb, #000 28%, transparent);
-  /* No persistent scrollbar track on coarse pointers, matching the shell. */
+  pointer-events: auto;
   scrollbar-width: none;
 }
+.workspace__menu[data-positioned="true"] { visibility: visible; }
 .workspace__menu::-webkit-scrollbar { width: 0; height: 0; }
+.workspace__menu-handle,
+.workspace__menu-header { display: none; }
+.workspace__menu-items { display: grid; gap: 1px; }
 .workspace__menu-item {
   display: block;
   width: 100%;
   padding: 9px 12px;
-  border: none;
-  background: none;
+  border: 0;
   border-radius: 6px;
+  background: none;
   color: var(--text);
   font-size: 13px;
+  line-height: 1.35;
   text-align: left;
+  white-space: normal;
   cursor: pointer;
-  white-space: nowrap;
   -webkit-tap-highlight-color: transparent;
 }
 .workspace__menu-item:hover {
@@ -343,6 +359,94 @@
 .workspace__menu-item:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: -2px;
+}
+
+@media (max-width: 720px) {
+  .workspace__menu-layer {
+    background: rgba(0, 0, 0, 0.46);
+    backdrop-filter: blur(2px);
+    pointer-events: auto;
+  }
+
+  .workspace__menu,
+  .workspace__menu[data-positioned="true"] {
+    top: auto;
+    right: 12px;
+    bottom: max(12px, env(safe-area-inset-bottom));
+    left: 12px;
+    width: auto;
+    max-height: calc(100dvh - 24px - env(safe-area-inset-bottom));
+    visibility: visible;
+    padding: 7px;
+    border-radius: 20px;
+    background: var(--surface);
+    box-shadow: 0 22px 54px rgba(0, 0, 0, 0.46);
+    animation: workspace-tab-sheet-in 170ms cubic-bezier(0.2, 0.75, 0.2, 1);
+  }
+
+  .workspace__menu-handle {
+    width: 34px;
+    height: 4px;
+    display: block;
+    margin: 2px auto 7px;
+    border-radius: 999px;
+    background: var(--border);
+  }
+
+  .workspace__menu-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 4px 5px 10px;
+  }
+
+  .workspace__menu-header > div {
+    min-width: 0;
+    flex: 1;
+    display: grid;
+    gap: 2px;
+  }
+
+  .workspace__menu-header span {
+    color: var(--muted);
+    font-size: 11px;
+    font-weight: 650;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .workspace__menu-header strong {
+    overflow: hidden;
+    font-size: 16px;
+    font-weight: 650;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .workspace__menu-close {
+    width: 40px;
+    height: 40px;
+    flex: 0 0 40px;
+    display: grid;
+    place-items: center;
+    padding: 0;
+    border: 0;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--bg) 72%, transparent);
+    color: var(--muted);
+  }
+
+  .workspace__menu-item {
+    min-height: 48px;
+    padding: 11px 13px;
+    border-radius: 12px;
+    font-size: 15px;
+  }
+}
+
+@keyframes workspace-tab-sheet-in {
+  from { opacity: 0; transform: translateY(18px); }
+  to { opacity: 1; transform: translateY(0); }
 }
 
 /* ── Drag-to-organize overlays (design §3.3, PR3) ────────────────────────────
@@ -435,6 +539,7 @@
 .workspace__drag-chip[hidden] { display: none; }
 
 @media (prefers-reduced-motion: reduce) {
+  .workspace__menu { animation: none; }
   /* Instant swap — no draw-in flourish (design item 5, reduced-motion). */
   .workspace__divider-bar { transition: none; animation: none; }
   /* Reduced motion: instant geometry + color, no fade or morph (design §3.3). */

--- a/tests/navigation.spec.mjs
+++ b/tests/navigation.spec.mjs
@@ -998,7 +998,9 @@ test.describe('Delete response boundaries', () => {
     })
 
     await openDrawer(page)
-    await page.getByRole('button', { name: `More actions for ${target.title}` }).click()
+    await page.getByLabel('Primary navigation')
+      .getByRole('button', { name: target.title, exact: true })
+      .click({ button: 'right' })
     await page.getByRole('menuitem', { name: 'Delete' }).click()
 
     await expect.poll(() => deleteAttempts).toBe(1)

--- a/tests/tabs.spec.mjs
+++ b/tests/tabs.spec.mjs
@@ -242,6 +242,17 @@ async function seedSingleModeChat(page, chatId) {
   }, [paneModel.STORAGE_KEY, workspace])
 }
 
+async function mouseDrag(page, sourceLocator, toX, toY) {
+  const box = await sourceLocator.boundingBox()
+  const sx = box.x + box.width / 2
+  const sy = box.y + box.height / 2
+  await page.mouse.move(sx, sy)
+  await page.mouse.down()
+  await page.mouse.move(sx + 10, sy, { steps: 3 })
+  await page.mouse.move(toX, toY, { steps: 14 })
+  await page.mouse.up()
+}
+
 test.describe('Tabs', () => {
   test('strip shows pinned tabs, switches, closes, and the last close auto-returns to single', async ({ page }) => {
     const chat = await bootAndCreateChat(page, 'tabs')
@@ -389,8 +400,14 @@ test.describe('Tabs', () => {
     await expect.poll(() => appsMock.requests, { timeout: 5000 }).toBeGreaterThan(0)
 
     const appTab = page.locator('.shell__tab', { hasText: 'Demo App' }).locator('.shell__tab-open')
-    await appTab.click({ button: 'right' })
-    await page.getByRole('menuitem', { name: 'Split right' }).click()
+    const content = await page.locator('.shell__content').boundingBox()
+    expect(content, 'the workspace has a visible drop surface').not.toBeNull()
+    await mouseDrag(
+      page,
+      appTab,
+      content.x + content.width - 8,
+      content.y + content.height / 2,
+    )
 
     await expect(page.locator('.workspace__strip')).toHaveCount(2)
     await expect(page.locator('.shell__view--paned')).toHaveCount(2)

--- a/tests/workspace-panes.spec.mjs
+++ b/tests/workspace-panes.spec.mjs
@@ -9,7 +9,7 @@
  *   (b) a FOLLOW_BOTTOM chat keeps following AND does not remount across a
  *       divider resize and a cross-pane move (same root DOM object);
  *   (c) an app iframe survives a cross-pane move with no second frame-init;
- *   (d) split is absent from the context menu at caps;
+ *   (d) close-only tab actions remain available while model split caps hold;
  *   (e) a projection flip to phone preserves the persisted tree and pane focus;
  *
  * The flag is enabled per-test (localStorage 'mobius:workspace-splits' = '1')
@@ -297,15 +297,16 @@ async function gestureRememberedChatToBottom(page) {
   })
 }
 
-/** Open a one-tab pane's context menu and click "Move to <label>". */
-async function moveOnlyTabToOtherPane(page, paneId) {
-  await page.locator(`[data-pane-strip="${paneId}"] .shell__tab-open`)
-    .filter({ has: page.locator('.shell__tab-text') })
-    .first()
-    .click({ button: 'right' })
-  await expect(page.locator('.workspace__menu')).toBeVisible({ timeout: 3000 })
-  await page.locator('.workspace__menu-item', { hasText: /^Move to / }).first().click()
-  await expect(page.locator('.workspace__menu')).toHaveCount(0)
+/** Move the active tab to the other pane through the existing drag contract. */
+async function moveActiveTabToOtherPane(page, paneId) {
+  const source = page.locator(
+    `[data-pane-strip="${paneId}"] .shell__tab--active .shell__tab-open`,
+  )
+  const target = await page.locator(
+    `[data-pane-strip]:not([data-pane-strip="${paneId}"]) .shell__tab--active .shell__tab-open`,
+  ).first().boundingBox()
+  expect(target, 'the destination pane has an active tab').not.toBeNull()
+  await mouseDrag(page, source, target.x + target.width / 2, target.y + target.height / 2)
 }
 
 test.describe('Workspace panes (PR2 gate)', () => {
@@ -409,7 +410,7 @@ test.describe('Workspace panes (PR2 gate)', () => {
 
     // 2) Cross-pane move of chat A itself (p0 collapses to a single pane; the
     //    ChatView must not remount and FOLLOW must re-apply).
-    await moveOnlyTabToOtherPane(page, 'p0')
+    await moveActiveTabToOtherPane(page, 'p0')
     await page.evaluate(() => new Promise(r =>
       requestAnimationFrame(() => requestAnimationFrame(() => setTimeout(r, 150)))))
     await expect.poll(() => rememberedChatRootIsCurrent(page), {
@@ -581,12 +582,8 @@ test.describe('Workspace panes (PR2 gate)', () => {
     // Exactly one iframe wrapper for the app before the move.
     await expect(page.locator(`[data-tab-key="app:${APP_ID}"]`)).toHaveCount(1)
 
-    // Move the app tab from p0 to p1 via its pane-strip context menu.
-    await page.locator(`[data-pane-strip="p0"] .shell__tab--active .shell__tab-open`)
-      .click({ button: 'right' })
-    await expect(page.locator('.workspace__menu')).toBeVisible({ timeout: 3000 })
-    await page.locator('.workspace__menu-item', { hasText: /^Move to / }).first().click()
-    await expect(page.locator('.workspace__menu')).toHaveCount(0)
+    // Move the app tab from p0 to p1 through the existing drag contract.
+    await moveActiveTabToOtherPane(page, 'p0')
     await page.evaluate(() => new Promise(r =>
       requestAnimationFrame(() => requestAnimationFrame(() => setTimeout(r, 200)))))
 
@@ -599,7 +596,7 @@ test.describe('Workspace panes (PR2 gate)', () => {
     await expect(page.locator(`[data-tab-key="app:${APP_ID}"]`)).toHaveCount(1)
   })
 
-  test('(d) split is absent from the context menu at caps', async ({ page }) => {
+  test('(d) tab actions stay close-only while model split caps hold', async ({ page }) => {
     await boot(page, WIDE)
     const a = await createTaggedChat(page, 'wpCapA')
     const b = await createTaggedChat(page, 'wpCapB')
@@ -631,15 +628,19 @@ test.describe('Workspace panes (PR2 gate)', () => {
     await page.goto(`${BASE}/shell/?chat=${c.id}`, { waitUntil: 'domcontentloaded' })
     await waitTiled(page)
 
-    // Open the context menu on p1's active tab.
-    await page.locator(`[data-pane-strip="p1"] .shell__tab--active .shell__tab-open`)
-      .click({ button: 'right' })
-    await expect(page.locator('.workspace__menu')).toBeVisible({ timeout: 3000 })
-    // No "Split *" item — the caps gate removed every direction.
-    await expect(page.locator('.workspace__menu-item', { hasText: /^Split / })).toHaveCount(0)
-    // The menu is still functional (Move / Close remain).
-    await expect(page.locator('.workspace__menu-item', { hasText: /^Move to / }))
-      .not.toHaveCount(0)
+    const activeTab = page.locator(
+      `[data-pane-strip="p1"] .shell__tab--active .shell__tab-open`,
+    )
+    const keptKey = await activeTab.getAttribute('data-drag-key')
+    await activeTab.click({ button: 'right' })
+    await expect(page.getByRole('menu', { name: 'Tab actions' })).toBeVisible()
+    await expect(page.getByRole('menuitem', { name: 'Close tab', exact: true })).toBeVisible()
+    await expect(page.getByRole('menuitem', { name: 'Close all other tabs' })).toBeVisible()
+    await expect(page.getByRole('menuitem', { name: /^Split |^Move to |^Close pane$/ }))
+      .toHaveCount(0)
+    await page.getByRole('menuitem', { name: 'Close all other tabs' }).click()
+    await expect.poll(async () => (await readWs(page)).panes.p1.tabs
+      .map(tab => `${tab.kind}:${tab.id}`)).toEqual([keptKey])
   })
 
   test('(e) a projection flip to phone preserves the persisted tree and pane focus', async ({ page }) => {


### PR DESCRIPTION
## Summary
- keep the tab menu intentionally browser-like: **Close tab**, **Close all other tabs**, and **Close tabs to the right**
- expose tab actions by right-click, Menu/Shift+F10, and stationary touch hold instead of permanent tab chrome
- remove permanent drawer kebabs while preserving right-click, Menu/Shift+F10, and touch-hold row actions
- keep bulk tab closing pane-scoped and undoable

## Why
The earlier menu mixed basic cleanup with layout commands, while the drawer contribution restored a visible trigger the owner had intentionally removed. This keeps the high-value close actions, including Miljan's **Close all other tabs**, without the oversized layout menu or permanent drawer clutter.

## Context
[#341](https://github.com/mobius-os/mobius/pull/341) restored visible drawer-row triggers and [#87](https://github.com/mobius-os/mobius/pull/87) introduced the broad split/move tab menu. This revision narrows the tab menu to close actions and removes the permanent drawer trigger while retaining deliberate context access.

## Validation
- `npm test` — 2,169 library and 66 hook tests passed
- `npm run build` — production and offline/PWA build passed
- authenticated wide and phone renders verified the compact menu, bottom sheet, and clean drawer rows
- drawer right-click path verified
- required hosted browser E2E passed on the PR and final merge-queue revision
