### PR TITLE
Reduce low-resource runtime overhead

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -538,6 +538,7 @@ async def lifespan(app):
   _reset_park_task = None
   _browser_profile_task = None
   _writer_supervisor_task = None
+  _tool_output_compression_task = None
   try:
     from app.chat import (
       sweep_idle_pending_chats,
@@ -622,6 +623,55 @@ async def lifespan(app):
         len(_restart_fallback_chats),
         len(_startup_continuations),
       )
+
+    async def _compress_legacy_tool_outputs():
+      """Fix old side-table rows forward without delaying readiness."""
+      from app.tool_output_storage import compress_legacy_tool_output_batch
+
+      total_rows = 0
+      raw_chars = 0
+      stored_chars = 0
+      after_chat_id = None
+      after_tool_use_id = None
+      try:
+        while True:
+          report = await _asyncio.to_thread(
+            compress_legacy_tool_output_batch,
+            _SweepSession,
+            batch_size=16,
+            after_chat_id=after_chat_id,
+            after_tool_use_id=after_tool_use_id,
+          )
+          if not int(report["scanned"]):
+            break
+          count = int(report["compressed"])
+          total_rows += count
+          raw_chars += int(report["raw_chars"])
+          stored_chars += int(report["stored_chars"])
+          after_chat_id = report["last_chat_id"]
+          after_tool_use_id = report["last_tool_use_id"]
+          await _asyncio.sleep(0.01)
+      except _asyncio.CancelledError:
+        raise
+      except Exception as _exc:
+        _log.error(
+          "legacy tool-output compression failed: %s", _exc, exc_info=True,
+        )
+        return
+      if total_rows:
+        _log.info(
+          "compressed %d legacy tool output(s): %d -> %d stored characters",
+          total_rows,
+          raw_chars,
+          stored_chars,
+        )
+
+    # Starts only after lifespan yields, so compression never delays the
+    # readiness transition. Exact-value compare-and-swap protects a tool row
+    # refreshed concurrently while short transactions yield between batches.
+    _tool_output_compression_task = _asyncio.create_task(
+      _compress_legacy_tool_outputs()
+    )
 
     async def _reset_park_loop():
       try:
@@ -715,6 +765,8 @@ async def lifespan(app):
       _browser_profile_task.cancel()
     if _writer_supervisor_task is not None:
       _writer_supervisor_task.cancel()
+    if _tool_output_compression_task is not None:
+      _tool_output_compression_task.cancel()
     # Drain + join the chat-writer actor so any in-flight persistence
     # completes before the process exits. Wrapped: a stop failure must
     # not mask the rest of shutdown.

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -25,6 +25,7 @@ from sqlalchemy.orm import column_property
 
 from app.database import Base
 from app.timeutil import now_naive_utc
+from app.tool_output_storage import CompressedToolOutputText
 
 
 CONTINUATION_RUN_STATUSES = ("parked", "resume_pending")
@@ -777,7 +778,7 @@ class Notification(Base):
 
 
 class ToolOutput(Base):
-  """Full text of a large tool result, stored out-of-band (contract rule 6).
+  """Full text of a large tool result, stored compactly out-of-band.
 
   The chat transcript blob (`Chat.messages`) and the live / catch-up event
   stream carry only a bounded head+tail excerpt of a big tool output; the full
@@ -790,9 +791,12 @@ class ToolOutput(Base):
   lifecycle for free — soft-delete keeps them (a recovered chat re-shows its
   outputs), the hard-purge sweep drops them with their chat. Written via the
   single-writer actor's `StashToolOutput` command as an insert/upsert on the
-  composite PK (race-immune; see chat_writer.py). `create_all` builds this table
-  on the next boot — a new table needs no ALTER migration (see run_migrations,
-  which only ALTERs existing tables)."""
+  composite PK (race-immune; see chat_writer.py). The TEXT payload is a
+  self-describing compressed frame; the read boundary also accepts legacy
+  plain text while a bounded background fix-forward updates old rows. Keeping
+  one column preserves SQLite/PostgreSQL portability without a schema migration.
+  `create_all` builds this table on the next boot — a new table needs no ALTER
+  migration (see run_migrations, which only ALTERs existing tables)."""
 
   __tablename__ = "tool_outputs"
 
@@ -802,7 +806,7 @@ class ToolOutput(Base):
   # The tool_use_id (Claude) / ThreadItem id (Codex) — stable emit→read and
   # unique within the chat, which is all the composite PK needs.
   tool_use_id = Column(String(128), primary_key=True)
-  output = Column(Text, nullable=False, default="")
+  output = Column(CompressedToolOutputText(), nullable=False, default="")
   created_at = Column(DateTime, default=lambda: datetime.now(UTC))
 
 

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -40,6 +40,11 @@ from app.resource_access import (
 )
 from app.schemas import ChatPatch, ChatProviderSwitch
 from app.timeutil import now_naive_utc, SOFT_DELETE_TTL
+from app.tool_output_storage import (
+  TOOL_OUTPUT_STORAGE_PREFIX,
+  decode_tool_output,
+  tool_output_length,
+)
 
 log = logging.getLogger(__name__)
 
@@ -63,11 +68,10 @@ app_chat_router = APIRouter(prefix="/api/app-chats", tags=["app-chats"])
 # browser's sessionStorage, which is the user's problem to preserve.
 EMPTY_CHAT_GRACE = timedelta(hours=24)
 
-# The expanded tool UI renders at most this much text. Slice in SQLite so a
-# multi-megabyte result is never materialized in the API process or browser just
-# to paint the preview. Read one extra sentinel character to detect truncation
-# without making SQLite scan the full value with ``length()``. The exact value
-# remains available through the same endpoint when the user explicitly copies.
+# The expanded tool UI renders at most this much text. Compressed rows inflate
+# only this bounded prefix for preview; legacy plain-text rows are sliced after
+# their normal database read. The exact value remains available through the
+# same endpoint when the user explicitly copies.
 TOOL_OUTPUT_PREVIEW_CHARS = 20_000
 THINKING_TRACE_PREVIEW_CHARS = 20_000
 
@@ -99,31 +103,44 @@ def _project_legacy_memory_recall_sidecars(
   if not tool_ids:
     return messages
 
-  # ``substr(text, start, length)`` and this CASE expression work on both
-  # SQLite and PostgreSQL. Avoid SQLite's convenient negative-start extension
-  # so the read contract stays portable.
-  output_length = func.length(models.ToolOutput.output)
-  tail_start = case(
+  # Keep legacy plain-text reads bounded in SQL. A compressed frame must be
+  # selected whole so the codec can inflate its tail, but it is already much
+  # smaller than the original note bodies.
+  stored_output = cast(models.ToolOutput.output, Text)
+  output_length = func.length(stored_output)
+  legacy_tail_start = case(
     (
       output_length > MAX_RECALL_RESULT_SCAN_CHARS,
       output_length - MAX_RECALL_RESULT_SCAN_CHARS + 1,
     ),
     else_=1,
   )
-  rows = db.query(
-    models.ToolOutput.tool_use_id,
-    func.substr(
-      models.ToolOutput.output,
-      tail_start,
+  stored_or_legacy_tail = case(
+    (
+      func.substr(
+        stored_output, 1, len(TOOL_OUTPUT_STORAGE_PREFIX),
+      ) == TOOL_OUTPUT_STORAGE_PREFIX,
+      stored_output,
+    ),
+    else_=func.substr(
+      stored_output,
+      legacy_tail_start,
       MAX_RECALL_RESULT_SCAN_CHARS,
     ),
+  )
+  rows = db.query(
+    models.ToolOutput.tool_use_id,
+    stored_or_legacy_tail,
   ).filter(
     models.ToolOutput.chat_id == chat_id,
     models.ToolOutput.tool_use_id.in_(tool_ids),
   ).all()
   return project_legacy_memory_recalls(
     messages,
-    output_tails={tool_use_id: tail for tool_use_id, tail in rows},
+    output_tails={
+      tool_use_id: decode_tool_output(stored)[-MAX_RECALL_RESULT_SCAN_CHARS:]
+      for tool_use_id, stored in rows
+    },
     live_message=live_message,
   )
 
@@ -1368,29 +1385,33 @@ def get_tool_output_by_id(
     models.ToolOutput.chat_id == chat_id,
     models.ToolOutput.tool_use_id == tool_use_id,
   )
-  if preview:
-    row = query.with_entities(
-      func.substr(models.ToolOutput.output, 1, TOOL_OUTPUT_PREVIEW_CHARS + 1),
-    ).first()
-  else:
-    row = query.first()
+  # Cast away the ORM compression type so preview decoding can inflate only
+  # the requested prefix rather than materializing the full original value.
+  row = query.with_entities(
+    cast(models.ToolOutput.output, Text),
+  ).first()
   if row is None:
     if is_chat_running(chat_id):
       return Response(status_code=202, headers={"Retry-After": "1"})
     raise HTTPException(status_code=404, detail="tool output not found")
 
   if preview:
-    output = (row[0] or "")
-    preview_complete = len(output) <= TOOL_OUTPUT_PREVIEW_CHARS
+    preview_complete = tool_output_length(
+      row[0]
+    ) <= TOOL_OUTPUT_PREVIEW_CHARS
+    output = decode_tool_output(
+      row[0],
+      max_chars=TOOL_OUTPUT_PREVIEW_CHARS,
+    )
     return PlainTextResponse(
-      output[:TOOL_OUTPUT_PREVIEW_CHARS],
+      output,
       headers={
         "Cache-Control": "private, no-store",
         "X-Tool-Output-Complete": "1" if preview_complete else "0",
       },
     )
   return PlainTextResponse(
-    row.output or "",
+    decode_tool_output(row[0]),
     headers={"Cache-Control": "private, no-store"},
   )
 

--- a/backend/app/routes/debug.py
+++ b/backend/app/routes/debug.py
@@ -52,7 +52,7 @@ _SECRET_KEY_CHANGED_FLAG = Path(
 
 def _runtime_memory_ownership(*, include_payloads: bool = True) -> dict:
   """Cheap cardinality/payload diagnostics from each long-lived owner."""
-  return {
+  report = {
     "runner_handles": {
       kind.value: len(registry.handles_by_kind(kind))
       for kind in RunnerKind
@@ -67,6 +67,18 @@ def _runtime_memory_ownership(*, include_payloads: bool = True) -> dict:
     "writer": writer_memory_diagnostics(),
     "questions": question_memory_diagnostics(),
   }
+  report["payload_sizing"] = {
+    "included": include_payloads,
+    **(
+      {}
+      if include_payloads
+      else {
+        "omitted": True,
+        "detail_url": "/api/debug/memory",
+      }
+    ),
+  }
+  return report
 
 
 @router.get("/status")
@@ -90,6 +102,11 @@ def debug_status(
 
   `media_migration_failed` follows the same absent-when-healthy contract. When
   present, old chat image paths may require recovery before they render.
+
+  Runtime payload sizing is deliberately omitted from this cheap endpoint.
+  The response says so under ``runtime_memory.payload_sizing`` and points to
+  ``/api/debug/memory``; query options do not turn the status probe into the
+  detailed report.
   """
   now_monotonic = time.monotonic()
   now_wall = datetime.now(UTC).replace(tzinfo=None)

--- a/backend/app/tool_output_storage.py
+++ b/backend/app/tool_output_storage.py
@@ -1,0 +1,200 @@
+"""Compact, self-describing storage for full tool outputs.
+
+Tool output is text at every product boundary, but large results live in the
+``tool_outputs`` side table for lazy expansion.  Keep the database column as
+portable TEXT (SQLite and PostgreSQL) while compressing its payload behind a
+versioned frame. Legacy plain-text rows remain readable while a bounded
+background fix-forward migrates them without a schema change.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import zlib
+
+from sqlalchemy import Text, text as sql_text
+from sqlalchemy.types import TypeDecorator
+
+
+TOOL_OUTPUT_STORAGE_PREFIX = "MOBIUS_TOOL_OUTPUT_ZLIB_V1:"
+_COMPRESSION_LEVEL = 3
+
+
+class ToolOutputDecodeError(ValueError):
+  """The stored frame is malformed or no longer round-trips exactly."""
+
+
+class CompressedToolOutputText(TypeDecorator):
+  """SQLAlchemy TEXT type that compresses only at the database boundary."""
+
+  impl = Text
+  cache_ok = True
+
+  def process_bind_param(self, value, _dialect):
+    return encode_tool_output(value)
+
+  def process_result_value(self, value, _dialect):
+    return decode_tool_output(value)
+
+
+def encode_tool_output(output: str | None) -> str:
+  """Return one versioned compressed TEXT value for ``output``."""
+  text = output or ""
+  if not text:
+    return ""
+  raw = text.encode("utf-8")
+  compressed = zlib.compress(raw, level=_COMPRESSION_LEVEL)
+  payload = base64.b64encode(compressed).decode("ascii")
+  return f"{TOOL_OUTPUT_STORAGE_PREFIX}{len(text)}:{payload}"
+
+
+def is_compressed_tool_output(stored: object) -> bool:
+  return isinstance(stored, str) and stored.startswith(
+    TOOL_OUTPUT_STORAGE_PREFIX
+  )
+
+
+def _parse_frame(stored: str) -> tuple[int, bytes]:
+  framed = stored[len(TOOL_OUTPUT_STORAGE_PREFIX):]
+  length_text, separator, payload = framed.partition(":")
+  if not separator or not length_text.isdigit():
+    raise ToolOutputDecodeError("invalid tool-output compression frame")
+  try:
+    compressed = base64.b64decode(payload, validate=True)
+  except (binascii.Error, ValueError) as exc:
+    raise ToolOutputDecodeError(
+      "invalid tool-output compression payload"
+    ) from exc
+  return int(length_text), compressed
+
+
+def tool_output_length(stored: str | None) -> int:
+  """Return the original character length without inflating a valid frame."""
+  value = stored or ""
+  if not is_compressed_tool_output(value):
+    return len(value)
+  length, _compressed = _parse_frame(value)
+  return length
+
+
+def decode_tool_output(
+  stored: str | None,
+  *,
+  max_chars: int | None = None,
+) -> str:
+  """Decode exact text, optionally inflating only a bounded character prefix."""
+  value = stored or ""
+  if not is_compressed_tool_output(value):
+    return value if max_chars is None else value[:max_chars]
+
+  expected_chars, compressed = _parse_frame(value)
+  try:
+    if max_chars is None:
+      raw = zlib.decompress(compressed)
+    else:
+      if max_chars < 0:
+        raise ValueError("max_chars must be non-negative")
+      # A Unicode code point occupies at most four UTF-8 bytes.  The small
+      # guard keeps a boundary code point whole while still bounding inflated
+      # memory by the requested preview rather than the full tool result.
+      raw = zlib.decompressobj().decompress(
+        compressed,
+        max_chars * 4 + 4,
+      )
+  except zlib.error as exc:
+    raise ToolOutputDecodeError(
+      "invalid tool-output compressed stream"
+    ) from exc
+
+  try:
+    text = raw.decode("utf-8")
+  except UnicodeDecodeError as exc:
+    raise ToolOutputDecodeError(
+      "invalid tool-output UTF-8 payload"
+    ) from exc
+
+  if max_chars is not None:
+    return text[:max_chars]
+  if len(text) != expected_chars:
+    raise ToolOutputDecodeError(
+      "tool-output compression length mismatch"
+    )
+  return text
+
+
+def compress_legacy_tool_output_batch(
+  session_factory,
+  *,
+  batch_size: int = 16,
+  after_chat_id: str | None = None,
+  after_tool_use_id: str | None = None,
+) -> dict[str, object]:
+  """Compress one old plain-text batch with an optimistic exact-value CAS.
+
+  New ORM writes already cross ``CompressedToolOutputText``. The comparison in
+  this one-time fix-forward prevents a concurrently refreshed tool result from
+  being overwritten by the older value selected for compression.
+  """
+  limit = max(1, min(int(batch_size), 128))
+  cursor_sql = ""
+  params: dict[str, object] = {
+    "prefix": TOOL_OUTPUT_STORAGE_PREFIX,
+    "prefix_length": len(TOOL_OUTPUT_STORAGE_PREFIX),
+    "limit": limit,
+  }
+  if after_chat_id is not None and after_tool_use_id is not None:
+    cursor_sql = (
+      "AND (chat_id > :after_chat_id OR "
+      "(chat_id = :after_chat_id AND tool_use_id > :after_tool_use_id)) "
+    )
+    params["after_chat_id"] = after_chat_id
+    params["after_tool_use_id"] = after_tool_use_id
+
+  with session_factory() as db:
+    rows = db.execute(sql_text(
+      "SELECT chat_id, tool_use_id, output FROM tool_outputs "
+      "WHERE output <> '' "
+      "AND substr(output, 1, :prefix_length) <> :prefix "
+      f"{cursor_sql}"
+      "ORDER BY chat_id ASC, tool_use_id ASC LIMIT :limit"
+    ), params).mappings().all()
+    if not rows:
+      return {
+        "scanned": 0,
+        "compressed": 0,
+        "raw_chars": 0,
+        "stored_chars": 0,
+        "last_chat_id": after_chat_id,
+        "last_tool_use_id": after_tool_use_id,
+      }
+
+    compressed_count = 0
+    raw_chars = 0
+    stored_chars = 0
+    for row in rows:
+      original = row["output"] or ""
+      stored = encode_tool_output(original)
+      result = db.execute(sql_text(
+        "UPDATE tool_outputs SET output = :stored "
+        "WHERE chat_id = :chat_id AND tool_use_id = :tool_use_id "
+        "AND output = :original"
+      ), {
+        "stored": stored,
+        "chat_id": row["chat_id"],
+        "tool_use_id": row["tool_use_id"],
+        "original": original,
+      })
+      if result.rowcount:
+        compressed_count += 1
+        raw_chars += len(original)
+        stored_chars += len(stored)
+    db.commit()
+    return {
+      "scanned": len(rows),
+      "compressed": compressed_count,
+      "raw_chars": raw_chars,
+      "stored_chars": stored_chars,
+      "last_chat_id": rows[-1]["chat_id"],
+      "last_tool_use_id": rows[-1]["tool_use_id"],
+    }

--- a/backend/app/tool_output_storage.py
+++ b/backend/app/tool_output_storage.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import base64
 import binascii
+import codecs
 import zlib
 
 from sqlalchemy import Text, text as sql_text
@@ -108,7 +109,13 @@ def decode_tool_output(
     ) from exc
 
   try:
-    text = raw.decode("utf-8")
+    if max_chars is None:
+      text = raw.decode("utf-8")
+    else:
+      # ``max_length`` may stop in the middle of a multibyte code point.
+      # Preview reads need only the complete prefix; an incremental decoder
+      # keeps that trailing fragment buffered rather than rejecting valid text.
+      text = codecs.getincrementaldecoder("utf-8")().decode(raw, final=False)
   except UnicodeDecodeError as exc:
     raise ToolOutputDecodeError(
       "invalid tool-output UTF-8 payload"

--- a/backend/scripts/package-static-app.mjs
+++ b/backend/scripts/package-static-app.mjs
@@ -307,7 +307,22 @@ export function packageStaticApp(opts) {
   fs.mkdirSync(path.dirname(entryPath), { recursive: true })
   fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
   fs.writeFileSync(entryPath, wrapperSource(opts.id, opts.name))
-  return { manifestPath, entryPath, assetCount: files.length, warnings: rewrite.warnings }
+  // Imported projects need node_modules to produce build/ or dist/, but the
+  // generated Möbius package serves only those static assets. Reclaim the
+  // dependency tree only after validation and both package files succeed, so a
+  // failed packaging attempt remains immediately rebuildable.
+  const nodeModulesPath = path.join(outDir, 'node_modules')
+  const removedNodeModules = fs.existsSync(nodeModulesPath)
+  if (removedNodeModules) {
+    fs.rmSync(nodeModulesPath, { recursive: true, force: true })
+  }
+  return {
+    manifestPath,
+    entryPath,
+    assetCount: files.length,
+    warnings: rewrite.warnings,
+    removedNodeModules,
+  }
 }
 
 function main() {
@@ -324,6 +339,9 @@ function main() {
     console.log(`package-static-app: wrote ${result.manifestPath}`)
     console.log(`package-static-app: wrote ${result.entryPath}`)
     console.log(`package-static-app: ${result.assetCount} static assets`)
+    if (result.removedNodeModules) {
+      console.log('package-static-app: removed imported node_modules')
+    }
   } catch (err) {
     console.error(`package-static-app: ${err.message}`)
     console.error(usage())

--- a/backend/scripts/seed-skills/building-apps.md
+++ b/backend/scripts/seed-skills/building-apps.md
@@ -65,7 +65,7 @@ node /app/scripts/package-static-app.mjs \
   --icon icon.png
 ```
 
-The packager writes `mobius.json` and an iframe `index.jsx`, enumerates every build file as `static_assets`, rewrites root-relative HTML/CSS asset references such as `/static/js/main.js` or `/fonts/foo.ttf` when the target exists inside the build, and fails on unresolved local CSS URLs. Re-run with `--force` after edits. Verify the generated package before installing:
+The packager writes `mobius.json` and an iframe `index.jsx`, enumerates every build file as `static_assets`, rewrites root-relative HTML/CSS asset references such as `/static/js/main.js` or `/fonts/foo.ttf` when the target exists inside the build, and fails on unresolved local CSS URLs. Once packaging succeeds it removes the imported repo's `node_modules`; failed packaging leaves dependencies in place so the build can be repaired and retried. Re-run with `npm install`, rebuild, and `--force` after later source edits. Verify the generated package before installing:
 
 ```bash
 node /app/scripts/package-static-app.mjs --help

--- a/backend/tests/test_debug_status.py
+++ b/backend/tests/test_debug_status.py
@@ -64,6 +64,11 @@ def test_debug_status_shape_matches_golden(client, auth):
   assert isinstance(runtime_memory["active_sinks"], list)
   assert "present" in runtime_memory["writer"]
   assert runtime_memory["questions"]["pending_count"] >= 0
+  assert runtime_memory["payload_sizing"] == {
+    "included": False,
+    "omitted": True,
+    "detail_url": "/api/debug/memory",
+  }
   golden_path = Path(__file__).with_name("golden_debug_status.json")
   expected = json.loads(golden_path.read_text(encoding="utf-8"))
   assert payload == expected
@@ -98,3 +103,20 @@ def test_debug_memory_report_is_authenticated_and_bounded(client, auth):
   assert "top_tracked_types" not in payload["gc"]
   assert "enabled" in payload["allocations"]
   assert "checkpoints" in payload
+  assert payload["runtime_memory"]["payload_sizing"] == {"included": True}
+
+
+def test_debug_status_does_not_silently_enable_guessed_payload_option(
+  client, auth,
+):
+  response = client.get(
+    "/api/debug/status?include_payloads=true",
+    headers=auth,
+  )
+
+  assert response.status_code == 200
+  assert response.json()["runtime_memory"]["payload_sizing"] == {
+    "included": False,
+    "omitted": True,
+    "detail_url": "/api/debug/memory",
+  }

--- a/backend/tests/test_tool_output_stash.py
+++ b/backend/tests/test_tool_output_stash.py
@@ -7,7 +7,7 @@ carrying tool identity + truncation metadata onto the persisted block."""
 import json
 import uuid
 
-from sqlalchemy import event as sqlalchemy_event
+from sqlalchemy import Text, cast, event as sqlalchemy_event, text as sql_text
 
 from app import models
 from app.chat_transcript import project_messages_for_detail
@@ -22,11 +22,27 @@ from app.events import (
     process_event,
 )
 from app.routes.chats import TOOL_OUTPUT_PREVIEW_CHARS
+from app.tool_output_storage import (
+    TOOL_OUTPUT_STORAGE_PREFIX,
+    compress_legacy_tool_output_batch,
+    decode_tool_output,
+)
 
 
 def _flush_writer():
     """Barrier proves the fire-and-forget stash already processed."""
     get_writer().submit(Barrier()).result(timeout=5)
+
+
+def _raw_tool_output(db, chat_id, tool_use_id):
+    return db.execute(
+        models.ToolOutput.__table__.select()
+        .with_only_columns(cast(models.ToolOutput.output, Text))
+        .where(
+            models.ToolOutput.chat_id == chat_id,
+            models.ToolOutput.tool_use_id == tool_use_id,
+        )
+    ).scalar_one()
 
 
 # -- actor round-trip -----------------------------------------------------
@@ -41,6 +57,9 @@ def test_stash_round_trip_insert_and_read_back(db):
     ).first()
     assert row is not None
     assert row.output == big
+    stored = _raw_tool_output(db, "c1", "tu_1")
+    assert stored.startswith(TOOL_OUTPUT_STORAGE_PREFIX)
+    assert decode_tool_output(stored) == big
 
 
 def test_stash_upsert_last_write_wins(db):
@@ -56,6 +75,32 @@ def test_stash_upsert_last_write_wins(db):
     ).all()
     assert len(rows) == 1
     assert rows[0].output == "second"
+
+
+def test_legacy_tool_output_backfill_is_bounded_and_idempotent(db):
+    big = "legacy\n" * 5000
+    db.execute(sql_text(
+        "INSERT INTO tool_outputs (chat_id, tool_use_id, output) "
+        "VALUES (:chat_id, :tool_use_id, :output)"
+    ), {"chat_id": "c1", "tool_use_id": "legacy", "output": big})
+    db.commit()
+
+    from app.database import SessionLocal
+    first = compress_legacy_tool_output_batch(
+        SessionLocal,
+        batch_size=1,
+    )
+    assert first["compressed"] == 1
+    db.expire_all()
+    stored = _raw_tool_output(db, "c1", "legacy")
+    assert stored.startswith(TOOL_OUTPUT_STORAGE_PREFIX)
+    assert decode_tool_output(stored) == big
+
+    second = compress_legacy_tool_output_batch(
+        SessionLocal,
+        batch_size=1,
+    )
+    assert second["compressed"] == 0
 
 
 def test_stash_ignores_empty_key(db):
@@ -80,7 +125,7 @@ def test_tool_output_by_id_endpoint_serves_full_text(client, auth, db):
     assert r.headers["cache-control"] == "private, no-store"
 
 
-def test_tool_output_preview_is_sliced_in_database(client, auth, db):
+def test_tool_output_preview_inflates_only_the_bounded_prefix(client, auth, db):
     chat_id = str(uuid.uuid4())
     db.add(models.Chat(id=chat_id, title="t", messages=[]))
     db.commit()
@@ -89,31 +134,19 @@ def test_tool_output_preview_is_sliced_in_database(client, auth, db):
         StashToolOutput(chat_id=chat_id, tool_use_id="tu_preview", output=big)
     ).result(timeout=5)
 
-    statements = []
-    engine = db.get_bind()
-
-    def capture_sql(_, __, statement, *args):
-        statements.append(statement.lower())
-
-    sqlalchemy_event.listen(engine, "before_cursor_execute", capture_sql)
-    try:
-        r = client.get(
-            f"/api/chats/{chat_id}/tool-output/tu_preview?preview=1",
-            headers=auth,
-        )
-    finally:
-        sqlalchemy_event.remove(engine, "before_cursor_execute", capture_sql)
+    r = client.get(
+        f"/api/chats/{chat_id}/tool-output/tu_preview?preview=1",
+        headers=auth,
+    )
 
     assert r.status_code == 200
     assert r.text == big[:TOOL_OUTPUT_PREVIEW_CHARS]
     assert r.headers["x-tool-output-complete"] == "0"
     assert r.headers["cache-control"] == "private, no-store"
-    preview_sql = next(
-        statement for statement in statements
-        if "from tool_outputs" in statement
-    )
-    assert "substr(" in preview_sql
-    assert "length(" not in preview_sql
+    db.expire_all()
+    stored = _raw_tool_output(db, chat_id, "tu_preview")
+    assert stored.startswith(TOOL_OUTPUT_STORAGE_PREFIX)
+    assert len(stored) < len(big)
 
 
 def test_tool_output_barrier_observes_latest_queued_stash(client, auth, db):

--- a/backend/tests/test_tool_output_storage.py
+++ b/backend/tests/test_tool_output_storage.py
@@ -1,0 +1,45 @@
+import pytest
+
+from app import tool_output_storage
+
+
+def test_compressed_tool_output_round_trips_unicode_exactly():
+    output = ("plain text αβγ🙂\n" * 2000) + "tail"
+
+    stored = tool_output_storage.encode_tool_output(output)
+
+    assert stored.startswith(tool_output_storage.TOOL_OUTPUT_STORAGE_PREFIX)
+    assert len(stored) < len(output.encode("utf-8"))
+    assert tool_output_storage.tool_output_length(stored) == len(output)
+    assert tool_output_storage.decode_tool_output(stored) == output
+
+
+def test_preview_decode_does_not_use_the_full_inflate_path(monkeypatch):
+    output = "0123456789" * 10_000
+    stored = tool_output_storage.encode_tool_output(output)
+
+    def reject_full_inflate(_payload):
+        raise AssertionError("preview used full zlib.decompress")
+
+    monkeypatch.setattr(
+        tool_output_storage.zlib,
+        "decompress",
+        reject_full_inflate,
+    )
+
+    assert tool_output_storage.decode_tool_output(
+        stored,
+        max_chars=123,
+    ) == output[:123]
+
+
+def test_plain_legacy_rows_remain_readable():
+    assert tool_output_storage.decode_tool_output("legacy", max_chars=3) == "leg"
+    assert tool_output_storage.tool_output_length("legacy") == 6
+
+
+def test_corrupt_compressed_frame_fails_loudly():
+    with pytest.raises(tool_output_storage.ToolOutputDecodeError):
+        tool_output_storage.decode_tool_output(
+            tool_output_storage.TOOL_OUTPUT_STORAGE_PREFIX + "12:not-base64",
+        )

--- a/backend/tests/test_tool_output_storage.py
+++ b/backend/tests/test_tool_output_storage.py
@@ -33,6 +33,16 @@ def test_preview_decode_does_not_use_the_full_inflate_path(monkeypatch):
     ) == output[:123]
 
 
+def test_preview_decode_keeps_complete_unicode_when_byte_limit_splits_a_codepoint():
+    output = "x" + ("🙂" * 10_000)
+    stored = tool_output_storage.encode_tool_output(output)
+
+    assert tool_output_storage.decode_tool_output(
+        stored,
+        max_chars=123,
+    ) == output[:123]
+
+
 def test_plain_legacy_rows_remain_readable():
     assert tool_output_storage.decode_tool_output("legacy", max_chars=3) == "leg"
     assert tool_output_storage.tool_output_length("legacy") == 6

--- a/scripts/package-static-app.test.mjs
+++ b/scripts/package-static-app.test.mjs
@@ -36,6 +36,7 @@ test('packages a built static app and rewrites root asset refs', () => {
   write(path.join(build, 'static/media/pixel.png'), 'png')
   write(path.join(build, 'fonts.css'), '@font-face{src:url("/fonts/commando.ttf")}')
   write(path.join(build, 'fonts/commando.ttf'), 'font')
+  write(path.join(repo, 'node_modules/demo/package.json'), '{"name":"demo"}')
 
   const result = packageStaticApp({
     id: '3d-demo',
@@ -64,6 +65,8 @@ test('packages a built static app and rewrites root asset refs', () => {
   assert.equal(manifest.static_assets['static/js/main.js'], 'build/static/js/main.js')
   assert.equal(manifest.static_assets['static/js/main.js.map'], undefined)
   assert.equal(manifest.permissions.cross_app_access, 'none')
+  assert.equal(result.removedNodeModules, true)
+  assert.equal(fs.existsSync(path.join(repo, 'node_modules')), false)
 
   const wrapper = fs.readFileSync(path.join(repo, 'index.jsx'), 'utf8')
   assert.match(wrapper, /function Mobius3dDemoApp/)
@@ -76,6 +79,7 @@ test('fails when CSS references an unresolved local asset', () => {
   const build = path.join(repo, 'dist')
   write(path.join(build, 'index.html'), '<link rel="stylesheet" href="./main.css">')
   write(path.join(build, 'main.css'), '.missing{background:url(/missing.png)}')
+  write(path.join(repo, 'node_modules/demo/package.json'), '{"name":"demo"}')
 
   assert.throws(
     () => packageStaticApp({
@@ -88,6 +92,7 @@ test('fails when CSS references an unresolved local asset', () => {
     }),
     /unresolved CSS url/,
   )
+  assert.equal(fs.existsSync(path.join(repo, 'node_modules')), true)
 })
 
 test('refuses to overwrite package files without force', () => {

--- a/scripts/wt-pytest.sh
+++ b/scripts/wt-pytest.sh
@@ -14,6 +14,7 @@
 # Usage (from anywhere inside a worktree or the main checkout):
 #   scripts/wt-pytest.sh                       # full suite
 #   scripts/wt-pytest.sh tests/test_foo.py -q  # a subset — args pass through
+#   scripts/wt-pytest.sh backend/tests/test_foo.py -q  # repo-relative also works
 #   scripts/wt-pytest.sh -k name -x            # any pytest args
 #
 # Bypass the deps resolution by exporting SECRET_KEY yourself; this script
@@ -85,6 +86,18 @@ else
 fi
 ESB_DIR="$NODE_MODULES/.bin"
 
+# The runner changes cwd to backend/ before invoking pytest. Accept both the
+# backend-relative paths documented by pytest and the natural repo-relative
+# paths callers get from search output, so a harmless path prefix does not
+# require a failed run and retry.
+PYTEST_ARGS=()
+for arg in "$@"; do
+  case "$arg" in
+    backend/tests/*) PYTEST_ARGS+=("${arg#backend/}") ;;
+    *) PYTEST_ARGS+=("$arg") ;;
+  esac
+done
+
 if [ -x "$VENV" ]; then
   PYTHON="$VENV"
 elif python3 -c 'import pytest' >/dev/null 2>&1; then
@@ -119,4 +132,4 @@ exec env \
   PATH="$ESB_DIR:${PATH:-}" \
   NODE_PATH="$NODE_MODULES${NODE_PATH:+:$NODE_PATH}" \
   SECRET_KEY="${SECRET_KEY:-$(python3 -c 'import secrets;print(secrets.token_hex(32))')}" \
-  "$PYTHON" -m pytest -p no:cacheprovider "$@"
+  "$PYTHON" -m pytest -p no:cacheprovider "${PYTEST_ARGS[@]}"

--- a/skill/core.md
+++ b/skill/core.md
@@ -194,10 +194,16 @@ Use the exact model string from the composer's `+` picker. Effort levels vary by
 
 ```bash
 curl -s -H "Authorization: Bearer $AGENT_TOKEN" "$API_BASE_URL/api/debug/status" | python3 -m json.tool
+curl -s -H "Authorization: Bearer $AGENT_TOKEN" "$API_BASE_URL/api/debug/memory?process_limit=20&allocation_limit=25" | python3 -m json.tool
 curl -s -H "Authorization: Bearer $AGENT_TOKEN" "$API_BASE_URL/api/debug/logs?lines=50&chat_id=$CHAT_ID" | python3 -m json.tool
 ```
 
-Use these when debugging instead of adding temporary endpoints.
+Use these when debugging instead of adding temporary endpoints. `status` is the
+cheap health view and intentionally omits variable-sized runtime payload totals;
+its `runtime_memory.payload_sizing` field points to the detailed `memory`
+report. Query flags on `status` do not enable payload sizing. Use `memory` for
+processes, maps, runtime-owner payload sizes, GC diagnostics, and optional
+allocation tracing; add `deep=true` only when a GC object-type walk is needed.
 
 ### The workspace
 


### PR DESCRIPTION
## Summary

- store large lazy tool results in a versioned compressed text frame while keeping legacy rows readable
- migrate existing tool results after readiness in small compare-and-swap batches and inflate only bounded previews
- remove imported `node_modules` only after static-app packaging succeeds, preserving dependencies when packaging fails
- make `/api/debug/status` explicitly point payload sizing to `/api/debug/memory` and document the detailed report
- accept both repository-relative and backend-relative pytest paths in the worktree helper

## Context

This builds on #30 and #34, which established lazy full tool-output storage and its migration, and #330, which established pull-based resource observability. This follow-up changes the retained representation and maintenance ergonomics without changing the transcript or live-stream contract.

## Validation

- `npm run test:packager` (3 passed)
- focused tool-output, migration, and debug tests (63 passed)
- `scripts/test.sh --fast` (60 passed)
- Python and Node syntax checks