### PR TITLE
Show queued-message steer actions immediately

### DIFF
--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -3223,15 +3223,17 @@ export default function ChatView({
   // cancel-X sends exactly THAT queued message into the live turn, leaving
   // its siblings queued. Same core as the fast-forward button — one cid in
   // consume_pending_cids instead of all of them; the backend already selects
-  // pending rows by cid. Only the tapped row needs server confirmation (the
-  // all-confirmed gate above exists because handleSteer consumes the whole
-  // queue); an unconfirmed row gets one reconcile retry, then bails and
-  // stays queued.
+  // pending rows by cid. The arrow renders with the optimistic row. If it is
+  // tapped before persistence settles, wait for that row's exact queue write
+  // before reading it; the existing reconcile remains the recovery path for
+  // a stale mounted client whose local confirmation flag lagged the server.
   async function handleSteerOne(cid) {
     if (handlingSteerRef.current) return
     handlingSteerRef.current = true
     setSteerBusy(true)
     try {
+      const queueWrite = queuedSendRequestsRef.current.get(cid)
+      if (queueWrite) await Promise.allSettled([queueWrite])
       const findRow = () => (pendingQueue.pendingMessagesRef.current || [])
         .find(m => cidOf(m) === cid)
       let row = findRow()

--- a/frontend/src/components/ChatView/QueuedMessages.jsx
+++ b/frontend/src/components/ChatView/QueuedMessages.jsx
@@ -129,14 +129,14 @@ export default function QueuedMessages({
                     {isExpanded ? text : preview}
                   </span>
                 </button>
-                {steerActive && msg.serverTs === true && (
+                {steerActive && (
                   // Per-row fast-forward (owner ask, 2026-07-17): the same
                   // double-chevron as the composer's steer button, in the
                   // queue action's compact neutral well — send exactly THIS
                   // message into the running turn now.
-                  // Rendered only while a turn is live and the row is
-                  // server-confirmed (an optimistic row's cid selects nothing
-                  // on the backend).
+                  // Render it with the optimistic row so the action well and
+                  // cancel-X arrive together. An early tap waits for this
+                  // row's queue write in ChatView before force-steering it.
                   <button
                     type="button"
                     className="queued__action queued__steer"

--- a/frontend/src/components/ChatView/__tests__/composerSteerTouch.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerSteerTouch.test.js
@@ -49,13 +49,28 @@ test('Send, Steer, and Stop reuse one continuously visible primary action', () =
   assert.match(sendBlock, /key="primary"/)
 })
 
-test('per-row fast-forward dispatches on touchend too', () => {
+test('per-row fast-forward appears with the optimistic row and dispatches on touchend', () => {
+  assert.match(
+    queuedMessages,
+    /\{steerActive && \(/,
+    'the row action should render before serverTs confirmation, alongside cancel',
+  )
+  assert.doesNotMatch(
+    queuedMessages,
+    /steerActive && msg\.serverTs === true/,
+    'server confirmation must not delay the row action from appearing',
+  )
   const steerBlock = queuedMessages.match(
     /className="queued__action queued__steer"[\s\S]*?aria-label="Send this queued message now"/,
   )?.[0] || ''
   assert.match(steerBlock, /onPointerDown=\{\(e\) => e\.preventDefault\(\)\}/)
   assert.match(steerBlock, /onTouchEnd=\{\(e\) => \{/)
   assert.match(steerBlock, /e\.preventDefault\(\)[\s\S]*?onSteerOne\?\.\(cidOf\(msg\)\)/)
+  assert.match(
+    chatView,
+    /async function handleSteerOne\(cid\) \{[\s\S]*?const queueWrite = queuedSendRequestsRef\.current\.get\(cid\)[\s\S]*?if \(queueWrite\) await Promise\.allSettled\(\[queueWrite\]\)[\s\S]*?const findRow/,
+    'an early row tap should await that row\'s exact queue write before steering',
+  )
 })
 
 test('the shared steer path snapshots scroll before dismissing the mobile composer', () => {

--- a/frontend/src/components/ChatView/hooks/usePendingQueue.js
+++ b/frontend/src/components/ChatView/hooks/usePendingQueue.js
@@ -27,8 +27,8 @@ import { cidOf } from '../chatRuntimeState.js'
  *   - queued:      true (marker)
  *   - serverTs:    boolean — true once the server has confirmed the row
  *                  (a confirmQueued ack or a hydrate). An optimistic add
- *                  starts false. Read by ChatView's steer gate: only a
- *                  server-confirmed row can be force-steered.
+ *                  starts false. ChatView may show steer immediately, but it
+ *                  waits for confirmation before force-steering the row.
  *   - position?:   number (server-assigned)
  *   - attachments?: array
  *
@@ -206,7 +206,8 @@ export default function usePendingQueue(initialServerList = []) {
         position: msg.position ?? prev.length + 1,
         // serverTs marks an entry whose ts is the SERVER's, not an optimistic
         // Date.now(). An optimistic add starts unconfirmed; confirmQueued flips
-        // it once the POST acks. The steer gate reads this.
+        // it once the POST acks. The steer action reads this after awaiting
+        // an optimistic row's queue write.
         serverTs: msg.serverTs === true,
       },
     ])


### PR DESCRIPTION
## Summary
- show each queued row's steer action as soon as the optimistic queued row appears
- let an early tap wait for that row's enqueue to settle before force-steering
- keep the existing reconciliation fallback for stale confirmations

## Problem
Queued rows were rendered optimistically, but their steer action was gated on server confirmation. The cancel action therefore appeared first and the steer action shifted in after the persistence round-trip.

## Testing
- `npm test`
- focused queue and steer tests
- rendered an unconfirmed queued row and verified the steer and cancel actions were both present and enabled