### PR TITLE
Activate live app previews on phones

### DIFF
--- a/backend/scripts/seed-skills/building-apps-quickstart.md
+++ b/backend/scripts/seed-skills/building-apps-quickstart.md
@@ -159,10 +159,14 @@ python "$SCRIPTS_DIR/apply_app.py" /data/apps/<slug>
 The helper validates the manifest and complete source tree, compiles and
 commits that exact revision, returns a compact receipt with `app_id`,
 `preview_path`, and `open_path`, and emits one live-preview action tied to this
-building chat. The preview may bloom into a separate visible pane when that
-adds space without hiding anything. When it would have to share a pane, it
-parks as an inactive tab instead of replacing what the partner is using. Reuse
-that numeric ID for preview, storage, notifications, and later actions; do not list apps again after a successful apply. Do not send a separate `open_item`.
+building chat. On a phone, that live-build action activates the app tab because
+there is only one visible Builder surface. On wider layouts it may bloom into a
+separate visible pane when that adds space without hiding anything; if it would
+have to share a web pane, it parks as an inactive tab instead of replacing what
+the partner is using.
+Reuse that numeric ID for preview, storage, notifications, and later actions;
+do not list apps again after a successful apply. Do not send a separate
+`open_item`.
 
 Afterward, edit source files normally and run the same command once the change
 is coherent enough to preview. Each successful apply live-swaps the already

--- a/frontend/src/components/Shell/__tests__/workspacePlacement.test.js
+++ b/frontend/src/components/Shell/__tests__/workspacePlacement.test.js
@@ -236,7 +236,7 @@ test('beside-source + foreground · phone: insert and activate', () => {
   assert.equal(out.panes.p0.activeTabKey, 'app:9', 'foreground activates the item')
 })
 
-test('live preview · phone: enters Builder without replacing its source chat', () => {
+test('live preview · phone: enters Builder and activates the app tab', () => {
   const ws = {
     ...paneModel.setViewMode(builderSeed([CHAT('a')]), 'single'),
     singleScreen: { kind: 'chat', id: 'a' },
@@ -248,8 +248,20 @@ test('live preview · phone: enters Builder without replacing its source chat', 
   )
   assert.equal(out.viewMode, 'panes', 'the live preview reveals the Builder world')
   assert.deepEqual(keysOf(out.panes.p0), ['chat:a', 'app:9'])
-  assert.equal(out.panes.p0.activeTabKey, 'chat:a',
-    'the preview is parked until the owner opens it')
+  assert.equal(out.panes.p0.activeTabKey, 'app:9',
+    'the one visible phone surface switches to the live app')
+  assert.equal(out.focusedPaneId, 'p0')
+})
+
+test('live preview · phone update: activates an app already parked beside its chat', () => {
+  const ws = builderSeed([CHAT('a'), APP(9)])
+  const out = resolveWorkspaceRequest(
+    ws,
+    builtAppWorkspaceRequest('a', 9),
+    env(ws, { mode: 'phone', rect: { w: 400, h: 800 } }),
+  )
+  assert.equal(out.panes.p0.activeTabKey, 'app:9',
+    'later coherent updates return the phone to the live app')
   assert.equal(out.focusedPaneId, 'p0')
 })
 

--- a/frontend/src/components/Shell/workspacePlacement.js
+++ b/frontend/src/components/Shell/workspacePlacement.js
@@ -11,10 +11,10 @@ export const PLACE_WITH_SOURCE = 'with-source'
 export const PLACE_WITH_FOCUS = 'with-focus'
 export const ACTIVATE_IN_BACKGROUND = 'background'
 export const ACTIVATE_FOREGROUND = 'foreground'
-// A live build preview is non-displacing: it may reveal the app in a new pane,
-// but it never replaces an already-visible tab. When no separate pane is
-// available it parks beside its source until the owner opens it. This is an
-// internal lifecycle intent, not an `open_item` wire value.
+// A live build preview is device-aware: wide layouts reveal it in a companion
+// pane without taking keyboard focus from chat, while phones activate the app
+// tab because there is only one visible surface. This is an internal lifecycle
+// intent, not an `open_item` wire value.
 export const ACTIVATE_LIVE_PREVIEW = 'live-preview'
 
 const PLACEMENTS = new Set([PLACE_BESIDE_SOURCE, PLACE_WITH_SOURCE, PLACE_WITH_FOCUS])
@@ -256,11 +256,13 @@ export function resolveWorkspaceRequest(ws, request, env = {}) {
   const preview = activation === ACTIVATE_LIVE_PREVIEW
   const foreground = activation === ACTIVATE_FOREGROUND
   const mode = env.mode || 'wide'
-  // Foreground is the ONLY permission to replace an active tab. A preview can
-  // still become visible by creating a new pane, whose sole tab is naturally
-  // active, but an existing pane keeps whatever the owner is using.
-  const activateItem = foreground
-  const focusItem = foreground
+  // Foreground is normally the only permission to replace an active tab. A
+  // phone live preview is the deliberate exception requested by the product:
+  // its one visible Builder surface switches to the app automatically. Wider
+  // layouts keep chat active and reveal the preview in a companion pane.
+  const phonePreview = preview && mode === 'phone'
+  const activateItem = foreground || phonePreview
+  const focusItem = foreground || phonePreview
 
   // Two-worlds (finding F4): in the SINGLE world the only visible surface is the
   // slot, so a FOREGROUND agent open must SET THE SLOT — mutating the hidden pane
@@ -369,8 +371,8 @@ export function resolveWorkspaceRequest(ws, request, env = {}) {
 
   // beside-source, the device-aware table.
   if (mode === 'phone') {
-    // Phone stack: previews and generic background placements remain parked;
-    // only an explicit foreground request changes the on-screen item.
+    // Phone stack: a live preview activates the app tab automatically; generic
+    // background placements remain parked and explicit foreground still wins.
     return insertBesideSource(working, item, sourcePane, source, {
       activate: activateItem,
       focus: focusItem,


### PR DESCRIPTION
## Summary
- activate an explicit live-build preview on phones as soon as a coherent app revision is ready
- keep generic background opens and wider workspace fallbacks non-displacing
- document the device-specific behavior and cover both first builds and later updates

## Why
[PR #336](https://github.com/mobius-os/mobius/pull/336) correctly prevented background previews from replacing content the owner was using, but it also left an explicit live-build preview inactive on phones. Because a phone has one visible Builder surface, a successful build added a tab while the screen appeared unchanged.

This narrows the exception to the dedicated `live-preview` intent in phone mode. Generic background opens remain parked, and wider layouts still preserve visible work while revealing a companion pane when space allows.

## Testing
- focused workspace-placement suite: 42 passed
- full frontend suite: 2,165 library/static and 66 hook tests passed
- production/PWA build passed
- rendered verification at wide and phone viewports