### PR TITLE
Center agent context inspector within chat pane

### DIFF
--- a/frontend/src/components/ChatView/AgentContextInspector.jsx
+++ b/frontend/src/components/ChatView/AgentContextInspector.jsx
@@ -7,7 +7,7 @@ import { StandardMarkdown } from './markdown/BlockRenderer.jsx'
 
 const CSS = `
 .aci__overlay {
-  position: fixed;
+  position: absolute;
   inset: 0;
   z-index: 1000;
   display: grid;
@@ -23,8 +23,7 @@ const CSS = `
 
 .aci {
   width: min(680px, 100%);
-  max-height: calc(100vh - 36px);
-  max-height: calc(100dvh - 36px);
+  max-height: calc(100% - 36px);
   overflow: hidden;
   display: flex;
   flex-direction: column;
@@ -243,7 +242,7 @@ const CSS = `
   }
 
   .aci {
-    max-height: calc(100dvh - 20px);
+    max-height: calc(100% - 20px);
     border-radius: 18px;
   }
 

--- a/frontend/src/components/ChatView/__tests__/contextMenuOrder.test.js
+++ b/frontend/src/components/ChatView/__tests__/contextMenuOrder.test.js
@@ -15,6 +15,10 @@ const inspectorSource = readFileSync(
   new URL('../AgentContextInspector.jsx', import.meta.url),
   'utf8',
 )
+const chatViewCss = readFileSync(
+  new URL('../ChatView.css', import.meta.url),
+  'utf8',
+)
 
 
 test('chat context actions follow model selection and continuation policy', () => {
@@ -38,4 +42,14 @@ test('agent context inspector keeps continuity and active turn context visible',
   assert.match(inspectorSource, /title: 'Current app context'/)
   assert.match(inspectorSource, /title: 'App report'/)
   assert.match(inspectorSource, /title: 'Compaction handoff'/)
+})
+
+
+test('agent context inspector is centered inside its owning chat', () => {
+  const overlayCss = inspectorSource.match(/\.aci__overlay\s*\{([^}]+)\}/)?.[1] || ''
+  const chatCss = chatViewCss.match(/\.chat\s*\{([^}]+)\}/)?.[1] || ''
+
+  assert.match(overlayCss, /position:\s*absolute/)
+  assert.doesNotMatch(overlayCss, /position:\s*fixed/)
+  assert.match(chatCss, /position:\s*relative/)
 })


### PR DESCRIPTION
## Summary
- center the agent context inspector within its owning chat pane
- constrain the dialog height to the chat pane rather than the browser viewport
- add regression coverage for chat-relative positioning

## Testing
- `npm test` (2,234 tests passed)
- `npm run build`
- visually verified with the navigation drawer open; the dialog and chat pane share the same horizontal center
