### PR TITLE
Unify chats and apps in the Recents drawer

### DIFF
--- a/backend/app/app_recency.py
+++ b/backend/app/app_recency.py
@@ -1,0 +1,65 @@
+"""Durable per-app open recency without mutating executable bundle versions."""
+
+from datetime import datetime
+
+from sqlalchemy import update
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app import models
+from app.timeutil import now_naive_utc
+
+
+def _advance_existing(
+  db: Session, app_id: int, opened_at: datetime,
+) -> bool:
+  """Advance one row monotonically; report whether the singleton exists."""
+  advanced = db.execute(
+    update(models.AppRecencyState)
+    .where(
+      models.AppRecencyState.app_id == app_id,
+      models.AppRecencyState.last_opened_at < opened_at,
+    )
+    .values(last_opened_at=opened_at)
+  )
+  if advanced.rowcount:
+    return True
+  return db.get(models.AppRecencyState, app_id) is not None
+
+
+def mark_opened(db: Session, app_id: int) -> None:
+  """Record an app open inside the caller's transaction.
+
+  Update-first plus a savepoint-backed insert keeps simultaneous first opens
+  from two devices race-safe without committing the caller's session.
+  """
+  opened_at = now_naive_utc()
+  if _advance_existing(db, app_id, opened_at):
+    return
+  try:
+    with db.begin_nested():
+      db.add(models.AppRecencyState(
+        app_id=app_id,
+        last_opened_at=opened_at,
+      ))
+      db.flush()
+  except IntegrityError:
+    # Another first open inserted the singleton row after our UPDATE.
+    _advance_existing(db, app_id, opened_at)
+
+
+def annotate_apps(db: Session, apps: list[models.App]) -> list[models.App]:
+  """Attach the response-only ``last_opened_at`` field to app rows."""
+  ids = [app.id for app in apps]
+  opened_by_id = {}
+  if ids:
+    opened_by_id = {
+      row.app_id: row.last_opened_at
+      for row in db.query(
+        models.AppRecencyState.app_id,
+        models.AppRecencyState.last_opened_at,
+      ).filter(models.AppRecencyState.app_id.in_(ids)).all()
+    }
+  for app in apps:
+    app.last_opened_at = opened_by_id.get(app.id)
+  return apps

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -722,6 +722,21 @@ class AppActivityState(Base):
   unseen = Column(Boolean, nullable=False, default=True, server_default=true())
 
 
+class AppRecencyState(Base):
+  """Durable last-opened timestamp for one installed app.
+
+  This stays outside ``apps`` so opening an app does not advance
+  ``App.updated_at``, which is the executable-bundle cache key.
+  """
+
+  __tablename__ = "app_recency_state"
+
+  app_id = Column(Integer, ForeignKey("apps.id"), primary_key=True)
+  last_opened_at = Column(
+    DateTime, nullable=False, default=lambda: now_naive_utc()
+  )
+
+
 class AppPreviewState(Base):
   """Durable acknowledgement of the exact app build opened from its chat CTA.
 

--- a/backend/app/routes/apps.py
+++ b/backend/app/routes/apps.py
@@ -23,8 +23,8 @@ from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session, defer
 
 from app import (
-  activity, app_activity, app_apply, app_git, app_jobs, app_preview, fs_locks,
-  icon_cache, icon_ownership,
+  activity, app_activity, app_apply, app_git, app_jobs, app_preview,
+  app_recency, fs_locks, icon_cache, icon_ownership,
   legacy_platform_apps,
   models, providers, schemas,
   source_dirs, theme,
@@ -415,6 +415,9 @@ async def _hard_delete_app(db: Session, app: models.App) -> None:
   db.query(models.AppActivityState).filter(
     models.AppActivityState.app_id == deleted_app_id,
   ).delete(synchronize_session=False)
+  db.query(models.AppRecencyState).filter(
+    models.AppRecencyState.app_id == deleted_app_id,
+  ).delete(synchronize_session=False)
   db.query(models.AppPreviewState).filter(
     models.AppPreviewState.app_id == deleted_app_id,
   ).delete(synchronize_session=False)
@@ -748,8 +751,10 @@ async def list_apps(
     )
     .all()
   )
-  return app_preview.annotate_apps(
-    db, app_activity.annotate_apps(db, apps)
+  return app_recency.annotate_apps(
+    db, app_preview.annotate_apps(
+      db, app_activity.annotate_apps(db, apps)
+    )
   )
 
 
@@ -2099,9 +2104,28 @@ def get_app(
 ):
   """Returns a single mini-app by ID (404 for a tombstoned one)."""
   app = live_app_or_404(db, app_id)
-  return app_preview.annotate_apps(
-    db, app_activity.annotate_apps(db, [app])
+  return app_recency.annotate_apps(
+    db, app_preview.annotate_apps(
+      db, app_activity.annotate_apps(db, [app])
+    )
   )[0]
+
+
+@router.post(
+  "/{app_id}/opened",
+  status_code=204,
+  dependencies=[Depends(reject_cross_site)],
+)
+def mark_app_opened(
+  app_id: int,
+  db: Session = Depends(get_db),
+  _: models.Owner = Depends(get_current_owner),
+):
+  """Record owner navigation recency without changing the app bundle version."""
+  live_app_or_404(db, app_id)
+  app_recency.mark_opened(db, app_id)
+  db.commit()
+  return Response(status_code=204)
 
 
 class AppActivitySeenRequest(BaseModel):

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -114,6 +114,9 @@ class AppOut(BaseModel):
   chat_id: str | None = None
   source_dir: str | None = None
   pinned_at: datetime | None = None
+  # Owner navigation recency. Kept separate from updated_at so opening an app
+  # never rotates its executable-bundle cache key.
+  last_opened_at: datetime | None = None
   # A durable app-attributed notification landed since this app was last
   # opened. The shell renders the same quiet activity dot used for chats.
   has_unseen_activity: bool = False

--- a/backend/tests/test_app_recency.py
+++ b/backend/tests/test_app_recency.py
@@ -1,0 +1,87 @@
+"""Owner app opens drive durable mixed-drawer recency."""
+
+from datetime import timedelta
+
+from app import models
+
+
+def _app(db):
+  app = models.App(
+    name="Atlas",
+    description="",
+    jsx_source="export default function App(){}",
+    compiled_path="/tmp/app.js",
+  )
+  db.add(app)
+  db.commit()
+  db.refresh(app)
+  return app
+
+
+def _listed(client, auth, app_id):
+  response = client.get("/api/apps/", headers=auth)
+  assert response.status_code == 200, response.text
+  return next(row for row in response.json() if row["id"] == app_id)
+
+
+def test_open_records_durable_recency_without_rotating_bundle_version(
+  client, auth, db,
+):
+  app = _app(db)
+  original_updated_at = app.updated_at
+  assert _listed(client, auth, app.id)["last_opened_at"] is None
+
+  opened = client.post(f"/api/apps/{app.id}/opened", headers=auth)
+  assert opened.status_code == 204, opened.text
+
+  row = _listed(client, auth, app.id)
+  assert row["last_opened_at"] is not None
+  db.refresh(app)
+  assert app.updated_at == original_updated_at
+
+
+def test_reopening_advances_the_existing_recency_row(client, auth, db):
+  app = _app(db)
+  assert client.post(f"/api/apps/{app.id}/opened", headers=auth).status_code == 204
+  state = db.get(models.AppRecencyState, app.id)
+  first = state.last_opened_at
+
+  state.last_opened_at = first.replace(year=first.year - 1)
+  db.commit()
+  assert client.post(f"/api/apps/{app.id}/opened", headers=auth).status_code == 204
+  db.refresh(state)
+  assert state.last_opened_at > first
+  assert db.query(models.AppRecencyState).count() == 1
+
+
+def test_delayed_open_never_moves_a_newer_recency_marker_backward(
+  client, auth, db,
+):
+  app = _app(db)
+  future = app.updated_at + timedelta(days=1)
+  db.add(models.AppRecencyState(
+    app_id=app.id,
+    last_opened_at=future,
+  ))
+  db.commit()
+
+  assert client.post(f"/api/apps/{app.id}/opened", headers=auth).status_code == 204
+  state = db.get(models.AppRecencyState, app.id)
+  assert state.last_opened_at == future
+
+
+def test_open_requires_owner_and_rejects_cross_site(client, auth, db):
+  app = _app(db)
+  assert client.post(f"/api/apps/{app.id}/opened").status_code == 401
+  cross_site = client.post(
+    f"/api/apps/{app.id}/opened",
+    headers={**auth, "Sec-Fetch-Site": "cross-site"},
+  )
+  assert cross_site.status_code == 403
+  assert db.get(models.AppRecencyState, app.id) is None
+
+
+def test_open_rejects_unknown_app(client, auth, db):
+  response = client.post("/api/apps/999999/opened", headers=auth)
+  assert response.status_code == 404
+  assert db.query(models.AppRecencyState).count() == 0

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -432,6 +432,9 @@ export const api = {
   },
   apps: {
     list: () => apiFetch('/apps/'),
+    markOpened: (appId) => apiFetch(`/apps/${appId}/opened`, {
+      method: 'POST',
+    }),
     markActivitySeen: (appId, activityVersion) => apiFetch(`/apps/${appId}/activity/seen`, {
       method: 'POST',
       body: JSON.stringify({ activity_version: activityVersion }),

--- a/frontend/src/components/Drawer/Drawer.css
+++ b/frontend/src/components/Drawer/Drawer.css
@@ -159,7 +159,7 @@
 }
 
 /* New chat is the fixed primary action. Everything navigational beneath it
-   shares one natural scroll: Apps, Pinned, then the complete chat history. */
+   shares one natural scroll: Apps, Pinned, then the complete mixed recents. */
 .drawer__scroll-wrap {
   flex: 1;
   min-height: 0;
@@ -177,13 +177,13 @@
    the chat rows + Settings row (all at the drawer's 12px gutter).
    Earlier the pill had `margin: 0 4px` which pushed its content
    16px from the drawer edge while every other row was at 12px —
-   the misalignment read as a layout bug to the eye. Margin-bottom
-   tightened 12 → 4 so the "Chats" header sits close to the pill
-   (the header's own padding provides the visual gap). */
+   the misalignment read as a layout bug to the eye. New chat and Apps
+   are consecutive primary navigation actions, so they share the same
+   uninterrupted row rhythm. */
 .drawer__item--new {
   color: var(--text);
   font-weight: 500;
-  margin: 0 0 4px;
+  margin: 0;
   padding: 11px 12px;
   border: 1px solid var(--border);
 }
@@ -210,31 +210,21 @@
 }
 
 
-/* Section labels are navigation landmarks, not secondary metadata. Match the
-   type weight and contrast of New chat / Apps so Pinned and Chats remain easy
-   to scan; their non-button structure and lack of hover treatment still make
-   the action-vs-heading distinction clear.
-
-   These stay as <h2>s so screen-reader users can jump between sections via
-   rotor / heading navigation. */
+/* Pinned and Recents use the same type scale as every navigation row, but
+   whitespace and weight make them clear section boundaries. */
 .drawer__label {
   display: flex;
   align-items: center;
-  gap: 8px;
   font-size: 14px;
-  font-weight: 500;
+  line-height: 20px;
+  font-weight: 600;
   letter-spacing: 0;
   text-transform: none;
-  color: var(--muted);
-  /* Top padding tightened from 18 → 8 so the gap between
-     "New chat" and the "Chats" section header reads as a
-     subtle separation, not a vertical chasm. The 6px bottom
-     keeps the label visually attached to the rows below. */
-  padding: 8px 12px 6px;
-  margin: 0;
+  color: var(--text);
+  padding: 6px 12px;
+  margin: 12px 0 4px;
 }
-.drawer__label svg { flex-shrink: 0; opacity: 1; color: currentColor; }
-.drawer__label span { line-height: 1; }
+.drawer__label span { line-height: inherit; }
 
 .drawer__label .drawer__label-count {
   margin-left: auto;
@@ -266,8 +256,8 @@
 }
 
 .drawer__scroll--navigation {
-  margin-top: 2px;
-  padding-top: 2px;
+  margin-top: 0;
+  padding-top: 0;
 }
 
 .drawer__item--apps {
@@ -795,6 +785,10 @@
   .drawer__item--new {
     min-height: 40px;
     padding: 0 11px;
+    font-size: 15px;
+  }
+
+  .drawer__label {
     font-size: 15px;
   }
 

--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -1,7 +1,6 @@
 import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useQueryClient } from '@tanstack/react-query'
-import { Chats, PinFilled } from '@openai/apps-sdk-ui/components/Icon'
 import { EmptyMessage } from '@openai/apps-sdk-ui/components/EmptyMessage'
 import { api } from '../../api/client.js'
 import { appQueries, chatQueries } from '../../hooks/queries.js'
@@ -33,9 +32,9 @@ import {
 import ShareAppSheet from './ShareAppSheet.jsx'
 import { isDrawerAppShareEligible } from './appShareState.js'
 import {
-  clampDrawerChatCount,
-  initialDrawerChatCount,
-  nextDrawerChatCount,
+  clampDrawerRowCount,
+  initialDrawerRowCount,
+  nextDrawerRowCount,
 } from './drawerProgressiveRows.js'
 import {
   clampDesktopSidebarWidth,
@@ -90,8 +89,7 @@ export default function Drawer({
   // Set of app ids that first appeared in the fetched list this session
   // (freshly built or App-Store-installed). Rendered as the same green
   // dot as chat attention, cleared by Shell when the app is opened —
-  // an arrival cue for an app that otherwise lands silently at the bottom
-  // of the oldest-first list.
+  // an arrival cue before normal open recency takes over.
   newAppIds,
   // Truthy when local provider credentials are missing or their status could
   // not be checked. Drives a small warning dot on Settings.
@@ -109,17 +107,17 @@ export default function Drawer({
   const resizeRef = useRef(null)
   const {
     pinned: pinnedItems,
-    chats: allChats,
+    recents: allRecents,
     apps: sortedApps,
   } = useMemo(() => buildDrawerSections(chats, apps), [chats, apps])
-  const [visibleChatCount, setVisibleChatCount] = useState(
-    () => initialDrawerChatCount(allChats.length),
+  const [visibleRecentCount, setVisibleRecentCount] = useState(
+    () => initialDrawerRowCount(allRecents.length),
   )
-  const chatScrollRef = useRef(null)
-  const chatSentinelRef = useRef(null)
-  const visibleChats = useMemo(
-    () => allChats.slice(0, visibleChatCount),
-    [allChats, visibleChatCount],
+  const navigationScrollRef = useRef(null)
+  const recentSentinelRef = useRef(null)
+  const visibleRecents = useMemo(
+    () => allRecents.slice(0, visibleRecentCount),
+    [allRecents, visibleRecentCount],
   )
 
   // Preserve the revealed window across recency reorders. Only clamp when
@@ -127,31 +125,31 @@ export default function Drawer({
   // batch available. Resetting to one batch on every query-cache refresh would
   // make rows disappear beneath someone who was already scrolling.
   useEffect(() => {
-    setVisibleChatCount(current => clampDrawerChatCount(
+    setVisibleRecentCount(current => clampDrawerRowCount(
       current,
-      allChats.length,
+      allRecents.length,
     ))
-  }, [allChats.length])
+  }, [allRecents.length])
 
   // One continuous list, progressively materialized as its sentinel nears the
-  // viewport. The chat summaries are already the shell's small navigation
-  // projection; this boundary avoids mounting hundreds of interactive menu
+  // viewport. Chat summaries and app metadata are already small navigation
+  // projections; this boundary avoids mounting hundreds of interactive menu
   // trees before they can be seen. Browsers without IntersectionObserver keep
-  // the old fully-rendered behavior rather than making history unreachable.
+  // the fully-rendered behavior rather than making history unreachable.
   useEffect(() => {
-    if (!open || visibleChatCount >= allChats.length) return undefined
-    const root = chatScrollRef.current
-    const sentinel = chatSentinelRef.current
+    if (!open || visibleRecentCount >= allRecents.length) return undefined
+    const root = navigationScrollRef.current
+    const sentinel = recentSentinelRef.current
     if (!root || !sentinel) return undefined
     if (typeof IntersectionObserver === 'undefined') {
-      setVisibleChatCount(allChats.length)
+      setVisibleRecentCount(allRecents.length)
       return undefined
     }
     const observer = new IntersectionObserver(entries => {
       if (!entries.some(entry => entry.isIntersecting)) return
-      setVisibleChatCount(current => nextDrawerChatCount(
+      setVisibleRecentCount(current => nextDrawerRowCount(
         current,
-        allChats.length,
+        allRecents.length,
       ))
     }, {
       root,
@@ -160,7 +158,7 @@ export default function Drawer({
     })
     observer.observe(sentinel)
     return () => observer.disconnect()
-  }, [allChats.length, open, visibleChatCount])
+  }, [allRecents.length, open, visibleRecentCount])
 
   // One row at a time can be in rename or open-menu mode. Tracking the
   // active id (rather than per-row state) lets a click on another row's
@@ -875,7 +873,7 @@ export default function Drawer({
               <span className="drawer__item-text">New chat</span>
             </button>
 
-            <div className="drawer__scroll drawer__scroll--navigation" ref={chatScrollRef}>
+            <div className="drawer__scroll drawer__scroll--navigation" ref={navigationScrollRef}>
               <button
                 ref={appsButtonRef}
                 type="button"
@@ -892,7 +890,6 @@ export default function Drawer({
               {pinnedItems.length > 0 && (
                 <section className="drawer__section" aria-labelledby="drawer-pinned-label">
                   <h2 id="drawer-pinned-label" className="drawer__label">
-                    <PinFilled width={15} height={15} aria-hidden="true" />
                     <span>Pinned</span>
                   </h2>
                   {pinnedItems.map(({ kind, item }) => (
@@ -931,62 +928,72 @@ export default function Drawer({
                 </section>
               )}
 
-              {chatsStatus === 'loading' && (
-                <p className="drawer__list-status" role="status">Loading chats…</p>
-              )}
-              {chatsStatus === 'error' && (
-                <div className="drawer__list-status" role="alert">
-                  <span>Chats unavailable.</span>
-                  <button type="button" onClick={onRetryChats}>Retry</button>
-                </div>
-              )}
-              {chatsStatus === 'success' && (
-                <section className="drawer__section" aria-labelledby="drawer-chats-label">
-                  <h2 id="drawer-chats-label" className="drawer__label drawer__label--chats">
-                    <Chats width={16} height={16} aria-hidden="true" />
-                    <span>Chats</span>
-                  </h2>
-                  {allChats.length > 0 ? visibleChats.map(chat => (
-                    <DrawerRow
-                      key={chat.id}
-                      kind="chat"
-                      item={chat}
-                      surface="drawer"
-                      streaming={streamingSet.has(chat.id)}
-                      attention={attentionSet.has(chat.id)}
-                      active={!appsActive && activeView === 'chat' && activeChatId === chat.id}
-                      menuOpen={!!(openMenu
-                        && openMenu.surface === 'drawer'
-                        && openMenu.kind === 'chat'
-                        && openMenu.id === chat.id)}
-                      menuPlacement={openMenu
-                        && openMenu.surface === 'drawer'
-                        && openMenu.kind === 'chat'
-                        && openMenu.id === chat.id
-                        ? openMenu.placement
-                        : null}
-                      renaming={!!(renaming
-                        && renaming.surface === 'drawer'
-                        && renaming.kind === 'chat'
-                        && renaming.id === chat.id)}
-                      actions={rowActions}
-                    />
-                  )) : (
-                    <EmptyMessage className="drawer__empty" fill="static">
-                      <EmptyMessage.Description>
-                        No conversations yet
-                      </EmptyMessage.Description>
-                    </EmptyMessage>
-                  )}
-                  {visibleChatCount < allChats.length && (
-                    <div
-                      ref={chatSentinelRef}
-                      className="drawer__progressive-sentinel"
-                      aria-hidden="true"
-                    />
-                  )}
-                </section>
-              )}
+              <section className="drawer__section" aria-labelledby="drawer-recents-label">
+                <h2 id="drawer-recents-label" className="drawer__label drawer__label--recents">
+                  <span>Recents</span>
+                </h2>
+                {allRecents.length > 0 ? visibleRecents.map(({ kind, item }) => (
+                  <DrawerRow
+                    key={`${kind}:${item.id}`}
+                    kind={kind}
+                    item={item}
+                    surface="drawer"
+                    streaming={kind === 'chat' && streamingSet.has(item.id)}
+                    building={kind === 'app' && !!(item.chat_id && streamingSet.has(item.chat_id))}
+                    attention={kind === 'chat'
+                      ? attentionSet.has(item.id)
+                      : newAppSet.has(Number(item.id))}
+                    active={!appsActive && (
+                      kind === 'chat'
+                        ? activeView === 'chat' && activeChatId === item.id
+                        : activeView === 'canvas' && Number(activeAppId) === Number(item.id)
+                    )}
+                    menuOpen={!!(openMenu
+                      && openMenu.surface === 'drawer'
+                      && openMenu.kind === kind
+                      && openMenu.id === item.id)}
+                    menuPlacement={openMenu
+                      && openMenu.surface === 'drawer'
+                      && openMenu.kind === kind
+                      && openMenu.id === item.id
+                      ? openMenu.placement
+                      : null}
+                    renaming={!!(renaming
+                      && renaming.surface === 'drawer'
+                      && renaming.kind === kind
+                      && renaming.id === item.id)}
+                    actions={rowActions}
+                  />
+                )) : chatsStatus === 'loading' || appsStatus === 'loading' ? (
+                  <p className="drawer__list-status" role="status">Loading recents…</p>
+                ) : chatsStatus === 'error' || appsStatus === 'error' ? (
+                  <div className="drawer__list-status" role="alert">
+                    <span>Recents unavailable.</span>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        onRetryChats?.()
+                        onRetryApps?.()
+                      }}
+                    >
+                      Retry
+                    </button>
+                  </div>
+                ) : (
+                  <EmptyMessage className="drawer__empty" fill="static">
+                    <EmptyMessage.Description>
+                      Nothing recent yet
+                    </EmptyMessage.Description>
+                  </EmptyMessage>
+                )}
+                {visibleRecentCount < allRecents.length && (
+                  <div
+                    ref={recentSentinelRef}
+                    className="drawer__progressive-sentinel"
+                    aria-hidden="true"
+                  />
+                )}
+              </section>
             </div>
           </div>{/* /.drawer__scroll-wrap */}
 

--- a/frontend/src/components/Drawer/drawerInformationArchitecture.js
+++ b/frontend/src/components/Drawer/drawerInformationArchitecture.js
@@ -14,13 +14,26 @@ function oldestPinnedFirst(a, b) {
   return pinnedAt(a.item).localeCompare(pinnedAt(b.item))
 }
 
+function recentAt({ kind, item }) {
+  if (kind === 'chat') {
+    return item?.activity_at || item?.updated_at || item?.created_at || ''
+  }
+  return item?.last_opened_at || item?.updated_at || item?.created_at || ''
+}
+
+function newestRecentFirst(a, b) {
+  return recentAt(b).localeCompare(recentAt(a))
+}
+
 /**
  * Build the drawer's navigation projection without mutating query-cache arrays.
  *
  * Pinned chats and apps share one stable section ordered oldest-pin-first, so a
- * new pin appends at the bottom and manual drag-to-reorder owns the rest. The
- * ordinary chat history stays recency ordered; the apps grid keeps its
- * pinned-first ordering (also oldest-pin-first) then stable creation order.
+ * new pin appends at the bottom and manual drag-to-reorder owns the rest.
+ * Unpinned chats and apps share one newest-first Recents section. Chat activity
+ * follows owner conversation activity; app activity follows explicit opens,
+ * falling back to the bundle update/creation time until the first open. The
+ * searchable apps grid keeps its pinned-first then stable creation ordering.
  */
 export function buildDrawerSections(chats = [], apps = []) {
   const chatRows = chats
@@ -51,9 +64,18 @@ export function buildDrawerSections(chats = [], apps = []) {
       .map(item => ({ kind: 'app', item })),
   ].sort(oldestPinnedFirst)
 
+  const recents = [
+    ...chatRows
+      .filter(chat => !chat.pinned_at)
+      .map(item => ({ kind: 'chat', item })),
+    ...appRows
+      .filter(app => !app.pinned_at)
+      .map(item => ({ kind: 'app', item })),
+  ].sort(newestRecentFirst)
+
   return {
     pinned,
-    chats: chatRows.filter(chat => !chat.pinned_at),
+    recents,
     apps: appRows,
   }
 }

--- a/frontend/src/components/Drawer/drawerProgressiveRows.js
+++ b/frontend/src/components/Drawer/drawerProgressiveRows.js
@@ -1,22 +1,22 @@
 /* Progressive drawer-row sizing keeps one continuous list without mounting it all. */
 
-export const DRAWER_CHAT_BATCH_SIZE = 48
+export const DRAWER_ROW_BATCH_SIZE = 48
 
-export function initialDrawerChatCount(total) {
-  return Math.min(Math.max(0, total), DRAWER_CHAT_BATCH_SIZE)
+export function initialDrawerRowCount(total) {
+  return Math.min(Math.max(0, total), DRAWER_ROW_BATCH_SIZE)
 }
 
-export function nextDrawerChatCount(current, total) {
+export function nextDrawerRowCount(current, total) {
   const boundedTotal = Math.max(0, total)
   return Math.min(
     boundedTotal,
-    Math.max(0, current) + DRAWER_CHAT_BATCH_SIZE,
+    Math.max(0, current) + DRAWER_ROW_BATCH_SIZE,
   )
 }
 
-export function clampDrawerChatCount(current, total) {
+export function clampDrawerRowCount(current, total) {
   return Math.min(
-    Math.max(initialDrawerChatCount(total), current),
+    Math.max(initialDrawerRowCount(total), current),
     Math.max(0, total),
   )
 }

--- a/frontend/src/components/Shell/Shell.css
+++ b/frontend/src/components/Shell/Shell.css
@@ -75,7 +75,7 @@
   padding-left: 16px;
   padding-right: 16px;
   background: var(--bg); /* CONTRACT: opaque — bar floats above content, must hide whatever scrolls under it */
-  border-bottom: 1px solid var(--border-light); /* CONTRACT: subtle 1px hairline; pairs with --bg above */
+  border-bottom: 0;
   position: relative;
   z-index: 100;
   -webkit-tap-highlight-color: transparent;
@@ -679,7 +679,7 @@
     padding: 8px 12px;
     flex-direction: row;
     align-items: center;
-    border-bottom: 1px solid var(--border-light);
+    border-bottom: 0;
   }
 
   .shell--drawer-docked .shell__bar-actions {

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -622,6 +622,42 @@ export default function Shell() {
 
   const { loadTheme } = useTheme()
   const queryClient = useQueryClient()
+  const recencyMarkedAppRef = useRef(null)
+  useEffect(() => {
+    if (activeView !== 'canvas' || activeAppId == null) {
+      recencyMarkedAppRef.current = null
+      return
+    }
+    const appId = Number(activeAppId)
+    if (!Number.isSafeInteger(appId) || appId <= 0) return
+    const key = String(appId)
+    if (recencyMarkedAppRef.current === key) return
+    recencyMarkedAppRef.current = key
+
+    // The navigation is already authoritative locally, so move the app in
+    // Recents immediately while the durable cross-session marker catches up.
+    const lastOpenedAt = new Date().toISOString()
+    const promoteCachedApp = () => {
+      queryClient.setQueryData(appQueries.keys.all, rows => (
+        Array.isArray(rows)
+          ? rows.map(app => (
+            Number(app.id) === appId
+              ? { ...app, last_opened_at: lastOpenedAt }
+              : app
+          ))
+          : rows
+      ))
+    }
+    promoteCachedApp()
+    void api.apps.markOpened(appId)
+      .then(response => {
+        if (response.ok) promoteCachedApp()
+        else appQueries.list.invalidate(queryClient)
+      })
+      // Offline navigation remains useful and keeps the optimistic order for
+      // this session; the next live list fetch restores server truth.
+      .catch(() => {})
+  }, [activeAppId, activeView, queryClient])
   const {
     state: { open: notificationsOpen, unreadCount: notificationUnreadCount },
     actions: {

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -178,10 +178,11 @@ test('the authenticated shell offers a keyboard skip link', () => {
 test('drawer lists distinguish loading, error, and confirmed empty data', () => {
   assert.match(shell, /appsStatus=\{appsStatus\}/)
   assert.match(shell, /chatsStatus=\{chatsStatus\}/)
-  assert.match(drawer, /chatsStatus === 'loading'/)
-  assert.match(drawer, /chatsStatus === 'error'/)
-  assert.match(drawer, /chatsStatus === 'success'/)
-  assert.match(drawer, /No conversations yet/)
+  assert.match(drawer, /chatsStatus === 'loading' \|\| appsStatus === 'loading'/)
+  assert.match(drawer, /chatsStatus === 'error' \|\| appsStatus === 'error'/)
+  assert.match(drawer, /Loading recents…/)
+  assert.match(drawer, /Recents unavailable\./)
+  assert.match(drawer, /Nothing recent yet/)
 })
 
 test('a crashed app pane is isolated by a per-pane ErrorBoundary', () => {
@@ -846,9 +847,52 @@ test('large drawer lists memoize ordering and row actions without changing row o
   assert.match(drawer, /const filteredApps = useMemo\(/)
   assert.match(drawer, /const rowActions = useMemo\(/)
   assert.match(drawer, /const DrawerRow = memo\(function DrawerRow/)
-  assert.match(drawer, /item=\{chat\}[\s\S]*?actions=\{rowActions\}/)
+  assert.match(drawer, /visibleRecents\.map\(\(\{ kind, item \}\)[\s\S]*?item=\{item\}[\s\S]*?actions=\{rowActions\}/)
   assert.match(drawer, /item=\{app\}[\s\S]*?actions=\{rowActions\}/)
   assert.doesNotMatch(drawer, /onSelect=\{\(\) => on(?:Chat|App)/)
+})
+
+test('mixed recents reserve artwork for apps and separate sections without a second type scale', () => {
+  assert.match(drawer, /kind === 'app'[\s\S]*?<AppIcon/)
+  assert.doesNotMatch(drawer, /drawer__chat-icon|<Chat\b|<Clock\b|<PinFilled\b/)
+  assert.match(
+    drawerCss,
+    /\.drawer__label\s*\{[\s\S]*?font-size:\s*14px[\s\S]*?font-weight:\s*600[\s\S]*?color:\s*var\(--text\)[\s\S]*?padding:\s*6px 12px[\s\S]*?margin:\s*12px 0 4px/,
+  )
+  assert.match(
+    drawerCss,
+    /\.drawer__item\s*\{[\s\S]*?font-size:\s*14px/,
+  )
+  assert.match(
+    drawerCss,
+    /@media \(min-width: 1024px\)[\s\S]*?\.drawer__item,[\s\S]*?font-size:\s*15px[\s\S]*?\.drawer__label\s*\{[\s\S]*?font-size:\s*15px/,
+  )
+  assert.doesNotMatch(
+    drawerCss,
+    /\.drawer__row \.drawer__item\s*\{[^}]*font-size:/,
+  )
+})
+
+test('New chat and Apps share one compact navigation rhythm', () => {
+  assert.match(
+    drawerCss,
+    /\.drawer__item--new\s*\{[\s\S]*?margin:\s*0;/,
+  )
+  assert.match(
+    drawerCss,
+    /\.drawer__scroll--navigation\s*\{[\s\S]*?margin-top:\s*0;[\s\S]*?padding-top:\s*0;/,
+  )
+})
+
+test('the Möbius header flows into navigation without a divider', () => {
+  assert.match(
+    shellCss,
+    /\.shell__bar\s*\{[\s\S]*?border-bottom:\s*0;/,
+  )
+  assert.match(
+    shellCss,
+    /\.shell--drawer-docked \.shell__bar\s*\{[\s\S]*?border-bottom:\s*0;/,
+  )
 })
 
 test('row-owned context menus need no permanent kebab or hidden anchor', () => {

--- a/frontend/src/lib/__tests__/drawerInformationArchitecture.test.js
+++ b/frontend/src/lib/__tests__/drawerInformationArchitecture.test.js
@@ -7,14 +7,14 @@ import {
   filterInstalledApps,
 } from '../../components/Drawer/drawerInformationArchitecture.js'
 
-test('drawer separates pinned chats and apps from ordinary chat history', () => {
+test('drawer separates mixed pins from mixed recents ordered by activity', () => {
   const sections = buildDrawerSections([
     { id: 'empty', has_messages: false, updated_at: '2026-07-30' },
     { id: 'old-chat', has_messages: true, updated_at: '2026-07-20' },
     { id: 'new-chat', has_messages: true, activity_at: '2026-07-29' },
     { id: 'pinned-chat', has_messages: true, pinned_at: '2026-07-25', updated_at: '2026-07-01' },
   ], [
-    { id: 1, created_at: '2026-07-01' },
+    { id: 1, created_at: '2026-07-01', last_opened_at: '2026-07-27' },
     { id: 2, created_at: '2026-07-02', pinned_at: '2026-07-26' },
   ])
 
@@ -23,7 +23,11 @@ test('drawer separates pinned chats and apps from ordinary chat history', () => 
     ['chat', 'pinned-chat'],
     ['app', 2],
   ])
-  assert.deepEqual(sections.chats.map(chat => chat.id), ['new-chat', 'old-chat'])
+  assert.deepEqual(sections.recents.map(entry => [entry.kind, entry.item.id]), [
+    ['chat', 'new-chat'],
+    ['app', 1],
+    ['chat', 'old-chat'],
+  ])
   assert.deepEqual(sections.apps.map(app => app.id), [2, 1])
 })
 
@@ -44,9 +48,28 @@ test('ordinary chat order follows owner activity rather than generic row updates
   ], [])
 
   assert.deepEqual(
-    sections.chats.map(chat => chat.id),
+    sections.recents.map(entry => entry.item.id),
     ['owner-steered', 'agent-finished'],
   )
+})
+
+test('app opens outrank bundle updates without changing catalogue order', () => {
+  const sections = buildDrawerSections([], [
+    {
+      id: 1,
+      created_at: '2026-07-01',
+      updated_at: '2026-07-29T12:00:00Z',
+      last_opened_at: '2026-07-29T13:00:00Z',
+    },
+    {
+      id: 2,
+      created_at: '2026-07-02',
+      updated_at: '2026-07-29T12:30:00Z',
+    },
+  ])
+
+  assert.deepEqual(sections.recents.map(entry => entry.item.id), [1, 2])
+  assert.deepEqual(sections.apps.map(app => app.id), [1, 2])
 })
 
 test('pinned order is stable across mixed timestamp formats (Z vs naive UTC)', () => {

--- a/frontend/src/lib/__tests__/drawerProgressiveRows.test.js
+++ b/frontend/src/lib/__tests__/drawerProgressiveRows.test.js
@@ -1,26 +1,26 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import {
-  DRAWER_CHAT_BATCH_SIZE,
-  clampDrawerChatCount,
-  initialDrawerChatCount,
-  nextDrawerChatCount,
+  DRAWER_ROW_BATCH_SIZE,
+  clampDrawerRowCount,
+  initialDrawerRowCount,
+  nextDrawerRowCount,
 } from '../../components/Drawer/drawerProgressiveRows.js'
 
 
 test('drawer starts with one bounded batch and grows continuously', () => {
-  assert.equal(initialDrawerChatCount(0), 0)
-  assert.equal(initialDrawerChatCount(12), 12)
-  assert.equal(initialDrawerChatCount(426), DRAWER_CHAT_BATCH_SIZE)
+  assert.equal(initialDrawerRowCount(0), 0)
+  assert.equal(initialDrawerRowCount(12), 12)
+  assert.equal(initialDrawerRowCount(426), DRAWER_ROW_BATCH_SIZE)
   assert.equal(
-    nextDrawerChatCount(DRAWER_CHAT_BATCH_SIZE, 426),
-    DRAWER_CHAT_BATCH_SIZE * 2,
+    nextDrawerRowCount(DRAWER_ROW_BATCH_SIZE, 426),
+    DRAWER_ROW_BATCH_SIZE * 2,
   )
-  assert.equal(nextDrawerChatCount(400, 426), 426)
+  assert.equal(nextDrawerRowCount(400, 426), 426)
 })
 
 test('drawer count survives reorder and clamps only when the list shrinks', () => {
-  assert.equal(clampDrawerChatCount(144, 426), 144)
-  assert.equal(clampDrawerChatCount(144, 80), 80)
-  assert.equal(clampDrawerChatCount(12, 426), DRAWER_CHAT_BATCH_SIZE)
+  assert.equal(clampDrawerRowCount(144, 426), 144)
+  assert.equal(clampDrawerRowCount(144, 80), 80)
+  assert.equal(clampDrawerRowCount(12, 426), DRAWER_ROW_BATCH_SIZE)
 })

--- a/tests/app-canvas.spec.mjs
+++ b/tests/app-canvas.spec.mjs
@@ -83,6 +83,10 @@ async function setupShellBasics(page) {
       body: '{}',
     })
   })
+  await page.route(/\/api\/apps\/\d+\/opened$/, route => {
+    if (route.request().method() !== 'POST') return route.fallback()
+    route.fulfill({ status: 204, body: '' })
+  })
   await page.route(/\/api\/health$/, route =>
     route.fulfill({
       status: 200,


### PR DESCRIPTION
## Summary

- replace the chat-only drawer history with mixed Recents ordered by conversation activity and app opens
- keep pinned chats and apps together while preserving app artwork and text-only chat rows
- persist app-open recency separately from app bundle timestamps
- refine the drawer hierarchy, spacing, and header treatment

## Testing

- `scripts/wt-pytest.sh tests/test_app_recency.py -q`
- focused drawer and shell unit tests (96 passed)
- `npm run build`