### PR TITLE
Soften chat selection handoffs

### DIFF
--- a/frontend/src/components/Drawer/Drawer.css
+++ b/frontend/src/components/Drawer/Drawer.css
@@ -312,7 +312,11 @@
   font-weight: 400;
   text-align: left;
   cursor: pointer;
-  transition: color 0.12s, background 0.12s;
+  /* Selection feedback should never animate the glyphs themselves: tweening
+     the row color makes the title shimmer while a chat handoff is settling.
+     Keep only the quiet background wash; the selected title snaps to its
+     authoritative color in the same frame as the selection. */
+  transition: background-color 0.12s;
   -webkit-tap-highlight-color: transparent;
   /* Pairs with .drawer__scroll's scroll-padding-bottom so a row revealed via
      scroll-into-view never lands inside the bottom fade / against the divider. */
@@ -861,6 +865,7 @@
   .drawer,
   .drawer-overlay { transition: none; }
   .drawer__item-action-menu { animation: none; }
+  .drawer__item { transition: none; }
 }
 
 /* ── Settings warning dot ──────────────────────────── */

--- a/frontend/src/components/Shell/Shell.css
+++ b/frontend/src/components/Shell/Shell.css
@@ -290,6 +290,20 @@
   background: var(--bg);
 }
 
+/* The incoming transcript is already fully laid out below the opaque held
+   chat. Keep its content very slightly softened while staging, then let that
+   SAME mounted ChatView settle to full opacity when Shell atomically removes
+   the held cover. Because the wrapper background remains opaque and the held
+   layer is gone before this transition becomes visible, two text layers never
+   crossfade or ghost over one another. */
+.shell__chat-view > .chat {
+  transition: opacity 90ms ease-out;
+}
+
+.shell__chat-view--staging > .chat {
+  opacity: 0.94;
+}
+
 .shell__chat-view--staging {
   visibility: visible;
   pointer-events: none;
@@ -598,6 +612,7 @@
   .shell__logo { transition: none; }
   .shell__wordmark { transition: none; }
   .shell__tab-text-inner { animation: none !important; }
+  .shell__chat-view > .chat { transition: none; }
   /* No completion motion under reduced motion — the ignite/snap AND the hold's
      descriptor-owned release are both skipped (the toggle commits instantly, so
      is-beat-held is never even emitted; this is the belt-and-braces). The direct

--- a/frontend/src/components/Shell/__tests__/chatHandoff.test.js
+++ b/frontend/src/components/Shell/__tests__/chatHandoff.test.js
@@ -4,14 +4,15 @@ import assert from 'node:assert/strict'
 
 const shell = readFileSync(new URL('../Shell.jsx', import.meta.url), 'utf8')
 const shellCss = readFileSync(new URL('../Shell.css', import.meta.url), 'utf8')
+const drawerCss = readFileSync(new URL('../../Drawer/Drawer.css', import.meta.url), 'utf8')
 const chatSurfaceModel = readFileSync(new URL('../chatSurfaceModel.js', import.meta.url), 'utf8')
 const workspaceChrome = readFileSync(new URL('../WorkspaceChrome.jsx', import.meta.url), 'utf8')
 const chatView = readFileSync(new URL('../../ChatView/ChatView.jsx', import.meta.url), 'utf8')
 const apiClient = readFileSync(new URL('../../../api/client.js', import.meta.url), 'utf8')
 
-function ruleBody(selector) {
+function ruleBody(selector, source = shellCss) {
   const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  return shellCss.match(new RegExp(`${escaped}\\s*\\{([\\s\\S]*?)\\}`))?.[1] || ''
+  return source.match(new RegExp(`${escaped}\\s*\\{([\\s\\S]*?)\\}`))?.[1] || ''
 }
 
 test('chat display readiness preserves the authoritative transcript reveal gate', () => {
@@ -145,4 +146,25 @@ test('the held chat is an opaque layer above staging until the atomic swap', () 
   assert.match(ruleBody('.shell__chat-view--held'), /visibility:\s*visible/)
   assert.match(ruleBody('.shell__chat-view--held'), /z-index:\s*2/,
     'the last painted frame must stay above the staging mount')
+})
+
+test('chat selection settles without flashing or crossfading text layers', () => {
+  const drawerItem = ruleBody('.drawer__item', drawerCss)
+  assert.equal(
+    drawerItem.match(/transition:\s*([^;]+);/)?.[1],
+    'background-color 0.12s',
+    'the selected title color must snap instead of tweening its glyphs')
+
+  assert.match(ruleBody('.shell__chat-view > .chat'), /transition:\s*opacity 90ms ease-out/,
+    'the ready transcript should settle on its existing mounted surface')
+  assert.match(ruleBody('.shell__chat-view--staging > .chat'), /opacity:\s*0\.94/,
+    'only the incoming transcript should be softened while the opaque cover is held')
+  assert.doesNotMatch(ruleBody('.shell__chat-view--held'), /opacity:/,
+    'the outgoing transcript must stay opaque instead of ghosting over incoming text')
+  assert.match(shellCss,
+    /@media \(prefers-reduced-motion: reduce\)[\s\S]*?\.shell__chat-view > \.chat \{\s*transition:\s*none;/,
+    'the transcript settle should disappear under reduced motion')
+  assert.match(drawerCss,
+    /@media \(prefers-reduced-motion: reduce\)[\s\S]*?\.drawer__item \{\s*transition:\s*none;/,
+    'the drawer background wash should disappear under reduced motion')
 })


### PR DESCRIPTION
## Summary

- snap the selected chat title color instead of tweening the glyphs
- let the incoming transcript settle on its existing opaque surface after the outgoing chat is removed
- disable the handoff transitions for reduced-motion users

## Testing

- `npm test`
- `npm run build`
- rendered an uncached chat switch and verified the outgoing transcript stayed opaque, the selected title color changed immediately, and only the incoming transcript settled to full opacity