### PR TITLE
Keep shell interactions alive when the Navigation-store mirror throws

### DIFF
--- a/frontend/src/lib/__tests__/navHistory.test.js
+++ b/frontend/src/lib/__tests__/navHistory.test.js
@@ -198,6 +198,37 @@ test('pushNavEntry writes the tag to BOTH the History and Navigation stores', ()
   }
 })
 
+test('a Navigation store that throws cannot take down the primary History write', () => {
+  // WebKit regression (observed on an iOS standalone PWA, 2026-07-29): the
+  // Navigation API can wedge into a state where updateCurrentEntry throws
+  // InvalidStateError on every call until the page reloads. The throw used to escape AFTER
+  // history.pushState had run, killing openDrawer mid-flight on every tap.
+  // The mirror is best-effort: the classic write must land and the helper
+  // must return normally.
+  const { history } = installBrowserMocks()
+  globalThis.navigation.updateCurrentEntry = () => {
+    throw new DOMException('The object is in an invalid state.', 'InvalidStateError')
+  }
+  try {
+    const route = { view: 'chat', chatId: 'a', appId: null }
+    const pushed = pushNavEntry('drawer', route)
+    assert.equal(isMobiusNavState(pushed), true)
+    assert.equal(history.calls.length, 1)
+    assert.equal(history.calls[0].method, 'pushState')
+
+    const replaced = replaceNavEntry('base', '/shell/')
+    assert.equal(isMobiusNavState(replaced), true)
+    assert.equal(history.calls.length, 2)
+    assert.equal(history.calls[1].method, 'replaceState')
+
+    const updated = updateCurrentNavEntry(route)
+    assert.equal(isMobiusNavState(updated), true)
+    assert.equal(history.calls.length, 3)
+  } finally {
+    clearBrowserMocks()
+  }
+})
+
 test('replaceNavEntry writes the tag to BOTH stores and forwards the URL', () => {
   const { history, navigation } = installBrowserMocks()
   try {

--- a/frontend/src/lib/navHistory.js
+++ b/frontend/src/lib/navHistory.js
@@ -15,7 +15,10 @@
 //
 // The classic History store and Navigation API store are independent. Every
 // write below is mirrored to both or NavigationEvent.destination.getState()
-// would see shell entries as phantoms in modern Chromium.
+// would see shell entries as phantoms in modern Chromium. The mirror is
+// best-effort — see mirrorCurrentEntry.
+
+import { recordClientError } from './errorLog.js'
 
 let _entrySequence = 0
 
@@ -140,9 +143,29 @@ export function dropPopsForEntry(queue, entryId) {
   return next.length === queue.length ? queue : next
 }
 
+// The Navigation-store mirror is BEST-EFFORT. The classic History write that
+// precedes every call below is the authoritative store: all shell logic reads
+// history.state (navEntryIndex), and WebKit traversals resolve through the
+// popstate fallback. The mirror exists only so Chromium's
+// NavigationEvent.destination.getState() doesn't see shell entries as
+// phantoms.
+//
+// WebKit (iOS 18.4+ ships the Navigation API) can wedge that API into a state
+// where `updateCurrentEntry` throws InvalidStateError from native code on
+// EVERY call until the page reloads (observed in the field on an iOS
+// standalone-PWA install, 2026-07-29). Unguarded, that throw escaped AFTER
+// history.pushState had already run, killing openDrawer mid-flight on every
+// tap — the drawer opened once per fresh launch and never again, and every
+// other nav-writing tap died the same way. A failed mirror must never take
+// down the interaction that triggered it: swallow the throw and report it
+// through the debounced client-error channel so the broken engine state
+// stays diagnosable rather than silently absorbed.
 function mirrorCurrentEntry(state) {
-  if (typeof navigation !== 'undefined' && navigation.updateCurrentEntry) {
+  if (typeof navigation === 'undefined' || !navigation.updateCurrentEntry) return
+  try {
     navigation.updateCurrentEntry({ state })
+  } catch (error) {
+    recordClientError({ where: 'navHistory.mirrorCurrentEntry', error })
   }
 }
 


### PR DESCRIPTION
## Problem

WebKit (iOS 18.4+, which ships the Navigation API) can wedge `window.navigation` into a state where `navigation.updateCurrentEntry()` throws `InvalidStateError` from native code on every call until the page reloads. Observed in the field on an installed standalone PWA (iPhone, 2026-07-29), confirmed by the shell's client-error telemetry:

```
InvalidStateError: The object is in an invalid state.
updateCurrentEntry@[native code]
...
onClick@.../assets/Shell-*.js
```

`navHistory.mirrorCurrentEntry` called `updateCurrentEntry` unguarded, after the authoritative `history.pushState`/`replaceState` write. When the engine wedges, the throw escapes mid-interaction:

- `openDrawer()` dies between `pushShellEntry` and its state flip — the navigation drawer opens exactly once per fresh launch and then never again;
- every other nav-writing interaction (notifications, chat rows, opening apps) dies the same way, so the shell feels entirely frozen except for typing.

This is a fourth WebKit-only drawer defect after #248's three — invisible on Chromium, which never enters the wedged state.

## Fix

The classic History store is authoritative for all shell logic (`navEntryIndex` reads `history.state`; WebKit traversals resolve through the popstate fallback). The Navigation-store mirror exists only so Chromium's `NavigationEvent.destination.getState()` doesn't see shell entries as phantoms — best-effort by design intent. This PR makes it best-effort in fact: catch the throw and report it through the debounced client-error channel (`recordClientError`), so a wedged engine stays diagnosable in the activity log instead of fatal to every interaction.

## Verification

- New unit test: a Navigation store whose `updateCurrentEntry` throws must not take down the primary write, across push/replace/update. Frontend unit suite green except one pre-existing unrelated failure (`appModuleBroker.test.js`, present on the unmodified base).
- Live repro against the rendered shell with `navigation.updateCurrentEntry` stubbed to throw `InvalidStateError`: the drawer opens, closes, and reopens through every close path (toggle, scrim, chat select, Back, swipe) with the mirror failing on each call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)