### PR TITLE
Normalize provider wrappers before JSON storage and add Clear all notifications

### DIFF
--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -52,6 +52,7 @@ from sqlalchemy import select, text, update
 from sqlalchemy.exc import SQLAlchemyError
 
 from app import models, schemas
+from app.json_safety import json_safe
 from app.events import (
   TOOL_OUTPUT_INLINE_THRESHOLD,
   build_assistant_message,
@@ -3548,6 +3549,9 @@ def _apply_last_assistant_message(db, chat_id: str, message: dict):
   """
   if not chat_id:
     return _WriteOutcome.NOOP
+  message = json_safe(copy.deepcopy(message))
+  if not isinstance(message, dict):
+    return _WriteOutcome.NOOP
   # `_active_chat` filters soft-deleted rows, so a finalize/snapshot enqueued
   # before a delete maps to NOOP here instead of resurrecting the dead row.
   chat = _active_chat(db, chat_id)
@@ -3644,7 +3648,9 @@ def update_live_assistant(
   if row is None:
     return None if require_row else True
   existing = row[0] if isinstance(row[0], dict) else None
-  snapshot = copy.deepcopy(message)
+  snapshot = json_safe(copy.deepcopy(message))
+  if not isinstance(snapshot, dict):
+    return True
   state = None
   answer_source = existing
   if existing is None:

--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -71,6 +71,7 @@ from dataclasses import dataclass
 from typing import Any, Callable
 
 from app.codex_appserver import _extract_bash_command
+from app.json_safety import json_safe
 from app.providers import MODEL_LABELS, get_skill_path
 from app.runtime_types import RunnerResult
 from app.usage_metrics import codex_cost_usd, normalize_codex_usage
@@ -1116,12 +1117,8 @@ def _extract_rate_limit_reset(snapshot) -> tuple[int | None, bool]:
 
 
 def _model_dump(value: Any) -> Any:
-  """Turns pydantic models into plain JSON-safe values."""
-  if value is None:
-    return None
-  if hasattr(value, "model_dump"):
-    return value.model_dump(by_alias=True, exclude_none=True, mode="json")
-  return value
+  """Turns provider SDK objects into plain JSON-safe values."""
+  return json_safe(value)
 
 
 def _format_json(value: Any) -> str:

--- a/backend/app/json_safety.py
+++ b/backend/app/json_safety.py
@@ -1,0 +1,36 @@
+"""Small helpers for values that must cross JSON persistence/wire boundaries."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from typing import Any
+
+
+def json_safe(value: Any) -> Any:
+  """Return a recursively JSON-serializable representation of ``value``.
+
+  Provider SDKs sometimes wrap simple scalars in Pydantic/root/path objects.
+  Those wrappers are useful inside the SDK, but JSON columns and JSON wire
+  payloads should only see plain Python scalars, lists, and dictionaries.
+  """
+  if value is None or isinstance(value, (str, int, float, bool)):
+    return value
+  if isinstance(value, os.PathLike):
+    return os.fspath(value)
+  if isinstance(value, Mapping):
+    return {str(json_safe(k)): json_safe(v) for k, v in value.items()}
+  if isinstance(value, (list, tuple, set, frozenset)):
+    return [json_safe(v) for v in value]
+  model_dump = getattr(value, "model_dump", None)
+  if callable(model_dump):
+    try:
+      return json_safe(model_dump(by_alias=True, exclude_none=True, mode="json"))
+    except TypeError:
+      try:
+        return json_safe(model_dump(mode="json"))
+      except TypeError:
+        return json_safe(model_dump())
+    except Exception:
+      pass
+  return str(value)

--- a/backend/app/routes/notifications.py
+++ b/backend/app/routes/notifications.py
@@ -104,6 +104,21 @@ def read_all(
   return {"updated": int(updated)}
 
 
+@router.delete("", dependencies=[Depends(reject_cross_site)])
+def clear_notifications(
+  owner: models.Owner = Depends(get_current_owner),
+  db: Session = Depends(get_db),
+):
+  """Delete all stored notifications for the owner. Idempotent."""
+  deleted = (
+    db.query(models.Notification)
+    .filter(models.Notification.owner_id == owner.id)
+    .delete(synchronize_session=False)
+  )
+  db.commit()
+  return {"deleted": int(deleted)}
+
+
 @router.get("")
 def list_notifications(
   # Owner-only: the notification history is the owner's. App tokens have no

--- a/backend/tests/test_chat_live_assistant.py
+++ b/backend/tests/test_chat_live_assistant.py
@@ -79,3 +79,34 @@ def test_materialized_snapshot_replaces_question_barrier_row():
   projected = materialized_messages(Row())
   assert len(projected) == 1
   assert projected[0] == Row.live_assistant
+
+
+def test_codex_path_wrappers_are_normalized_before_json_storage(db):
+  from openai_codex.generated.v2_all import LegacyAppPathString
+
+  chat, _history = _chat(db)
+
+  assert update_live_assistant(db, chat.id, {
+    "role": "assistant",
+    "blocks": [{
+      "type": "tool",
+      "name": "exec_command",
+      "cwd": LegacyAppPathString("/data"),
+      "paths": [LegacyAppPathString("/data/platform")],
+    }],
+  }) is True
+
+  db.refresh(chat)
+  block = chat.live_assistant["blocks"][0]
+  assert block["cwd"] == "/data"
+  assert block["paths"] == ["/data/platform"]
+
+  outcome = finalize_response_outcome(db, chat.id, [{
+    "type": "tool",
+    "name": "exec_command",
+    "cwd": LegacyAppPathString("/data"),
+  }])
+
+  db.refresh(chat)
+  assert outcome.value == "applied"
+  assert chat.messages[-1]["blocks"][0]["cwd"] == "/data"

--- a/backend/tests/test_chat_live_assistant.py
+++ b/backend/tests/test_chat_live_assistant.py
@@ -82,7 +82,14 @@ def test_materialized_snapshot_replaces_question_barrier_row():
 
 
 def test_codex_path_wrappers_are_normalized_before_json_storage(db):
-  from openai_codex.generated.v2_all import LegacyAppPathString
+  class ProviderPathWrapper:
+    """Minimal stand-in for the Codex SDK's Pydantic root path wrapper."""
+
+    def __init__(self, value):
+      self.value = value
+
+    def model_dump(self, **_kwargs):
+      return self.value
 
   chat, _history = _chat(db)
 
@@ -91,8 +98,8 @@ def test_codex_path_wrappers_are_normalized_before_json_storage(db):
     "blocks": [{
       "type": "tool",
       "name": "exec_command",
-      "cwd": LegacyAppPathString("/data"),
-      "paths": [LegacyAppPathString("/data/platform")],
+      "cwd": ProviderPathWrapper("/data"),
+      "paths": [ProviderPathWrapper("/data/platform")],
     }],
   }) is True
 
@@ -104,7 +111,7 @@ def test_codex_path_wrappers_are_normalized_before_json_storage(db):
   outcome = finalize_response_outcome(db, chat.id, [{
     "type": "tool",
     "name": "exec_command",
-    "cwd": LegacyAppPathString("/data"),
+    "cwd": ProviderPathWrapper("/data"),
   }])
 
   db.refresh(chat)

--- a/backend/tests/test_json_safety.py
+++ b/backend/tests/test_json_safety.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+from app.json_safety import json_safe
+
+
+def test_json_safe_normalizes_nested_provider_wrappers():
+  from openai_codex.generated.v2_all import LegacyAppPathString
+
+  assert json_safe({
+    "cwd": LegacyAppPathString("/data"),
+    "paths": [Path("/data/platform"), LegacyAppPathString("/tmp/app")],
+  }) == {
+    "cwd": "/data",
+    "paths": ["/data/platform", "/tmp/app"],
+  }

--- a/backend/tests/test_json_safety.py
+++ b/backend/tests/test_json_safety.py
@@ -3,12 +3,20 @@ from pathlib import Path
 from app.json_safety import json_safe
 
 
-def test_json_safe_normalizes_nested_provider_wrappers():
-  from openai_codex.generated.v2_all import LegacyAppPathString
+class ProviderPathWrapper:
+  """Minimal stand-in for the Codex SDK's Pydantic root path wrapper."""
 
+  def __init__(self, value):
+    self.value = value
+
+  def model_dump(self, **_kwargs):
+    return self.value
+
+
+def test_json_safe_normalizes_nested_provider_wrappers():
   assert json_safe({
-    "cwd": LegacyAppPathString("/data"),
-    "paths": [Path("/data/platform"), LegacyAppPathString("/tmp/app")],
+    "cwd": ProviderPathWrapper("/data"),
+    "paths": [Path("/data/platform"), ProviderPathWrapper("/tmp/app")],
   }) == {
     "cwd": "/data",
     "paths": ["/data/platform", "/tmp/app"],

--- a/backend/tests/test_notification_target.py
+++ b/backend/tests/test_notification_target.py
@@ -70,3 +70,26 @@ def test_notification_action_targets_round_trip(client, auth):
   actions = {a["action"]: a["target"] for a in (row["actions"] or [])}
   assert actions["open_app"] == "/shell/?app=7"
   assert actions["open_chat"] == "/shell/?chat=c-7"
+
+
+def test_clear_notifications_deletes_owner_history(client, auth):
+  for title in ["One", "Two"]:
+    r = client.post(
+      "/api/notifications/send",
+      headers=auth,
+      json={"title": title, "body": "Body"},
+    )
+    assert r.status_code == 200, r.text
+
+  assert len(client.get("/api/notifications", headers=auth).json()) == 2
+
+  cleared = client.delete("/api/notifications", headers=auth)
+  assert cleared.status_code == 200, cleared.text
+  assert cleared.json()["deleted"] == 2
+  assert client.get("/api/notifications", headers=auth).json() == []
+  assert client.get("/api/notifications/unread-count", headers=auth).json() == {"count": 0}
+
+  # Idempotent: a second clear is safe when the preview is already empty.
+  cleared_again = client.delete("/api/notifications", headers=auth)
+  assert cleared_again.status_code == 200, cleared_again.text
+  assert cleared_again.json()["deleted"] == 0

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -550,6 +550,8 @@ export const api = {
     unreadCount: () => apiFetch('/notifications/unread-count'),
     // Seen-on-open: idempotent bulk mark-read (clears the bell badge).
     readAll: () => apiFetch('/notifications/read-all', { method: 'POST' }),
+    // Owner action from the preview: remove all stored notifications.
+    clearAll: () => apiFetch('/notifications', { method: 'DELETE' }),
   },
   admin: {
     restart: () => apiFetch('/admin/restart', { method: 'POST' }),

--- a/frontend/src/components/NotificationBell/useNotificationCenter.js
+++ b/frontend/src/components/NotificationBell/useNotificationCenter.js
@@ -23,6 +23,12 @@ export default function useNotificationCenter(queryClient) {
       .catch(() => { /* Offline is safe: the unread count retries later. */ })
   ), [queryClient])
 
+  const clearAll = useCallback(async () => {
+    await api.notifications.clearAll()
+    queryClient.setQueryData(notificationQueries.list.key, [])
+    queryClient.setQueryData(notificationQueries.unreadCount.key, 0)
+  }, [queryClient])
+
   useEffect(() => {
     if (open) void markSeen()
   }, [open, markSeen])
@@ -59,7 +65,7 @@ export default function useNotificationCenter(queryClient) {
 
   return {
     state: { open, unreadCount },
-    actions: { toggle, close, reconcile, onCreated },
+    actions: { toggle, close, clearAll, reconcile, onCreated },
     meta: { rootRef, bellRef },
   }
 }

--- a/frontend/src/components/NotificationsView/NotificationsView.css
+++ b/frontend/src/components/NotificationsView/NotificationsView.css
@@ -43,6 +43,20 @@
   cursor: pointer;
 }
 
+.notifications__clear-actions {
+  display: flex;
+  align-items: center;
+  margin-left: auto;
+}
+
+.notifications__clear-actions .notifications__clear {
+  margin-left: 0;
+}
+
+.notifications__clear--confirm {
+  color: var(--danger);
+}
+
 .notifications__clear:hover:not(:disabled) {
   background: var(--surface);
 }

--- a/frontend/src/components/NotificationsView/NotificationsView.css
+++ b/frontend/src/components/NotificationsView/NotificationsView.css
@@ -30,13 +30,40 @@
   font-weight: 650;
 }
 
+.notifications__clear {
+  margin-left: auto;
+  padding: 8px 10px;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--accent);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.notifications__clear:hover:not(:disabled) {
+  background: var(--surface);
+}
+
+.notifications__clear:disabled {
+  cursor: default;
+  opacity: 0.62;
+}
+
+.notifications__clear:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 .notifications__close {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   width: 44px;
   height: 44px;
-  margin-left: auto;
+  margin-left: 2px;
   padding: 0;
   border: 0;
   border-radius: 10px;
@@ -66,6 +93,11 @@
   padding: 24px 16px;
   color: var(--muted);
   font-size: 14px;
+}
+
+.notifications__hint--error {
+  padding-block: 12px;
+  color: var(--danger);
 }
 
 .notifications__empty {

--- a/frontend/src/components/NotificationsView/NotificationsView.jsx
+++ b/frontend/src/components/NotificationsView/NotificationsView.jsx
@@ -16,10 +16,12 @@ const ICONS = {
 // A deliberately small shell preview, not a new navigation world. TRUST:
 // app-authored title/body stay plain text, app-authored icon URLs are ignored,
 // and targets pass through the fail-closed shared parser before navigation.
-export default function NotificationsView({ active = false, onClose, onOpenTarget }) {
+export default function NotificationsView({ active = false, onClose, onOpenTarget, onClearAll }) {
   const { data, isLoading, isError } = notificationQueries.list.useQuery({ enabled: active })
   const rows = data ?? []
   const [now, setNow] = useState(() => Date.now())
+  const [isClearing, setIsClearing] = useState(false)
+  const [clearError, setClearError] = useState(false)
 
   // Relative labels are live information, not a one-time formatting pass.
   // Refreshing once a minute keeps an open preview from saying "now" forever.
@@ -29,6 +31,19 @@ export default function NotificationsView({ active = false, onClose, onOpenTarge
     const timer = window.setInterval(() => setNow(Date.now()), 60_000)
     return () => window.clearInterval(timer)
   }, [active])
+
+  const handleClearAll = async () => {
+    if (!rows.length || isClearing) return
+    setIsClearing(true)
+    setClearError(false)
+    try {
+      await onClearAll?.()
+    } catch {
+      setClearError(true)
+    } finally {
+      setIsClearing(false)
+    }
+  }
 
   return (
     <section
@@ -40,6 +55,16 @@ export default function NotificationsView({ active = false, onClose, onOpenTarge
         <h2 id="notification-preview-title" className="notifications__title">
           Notifications
         </h2>
+        {rows.length > 0 && (
+          <button
+            type="button"
+            className="notifications__clear"
+            onClick={handleClearAll}
+            disabled={isClearing}
+          >
+            {isClearing ? 'Clearing…' : 'Clear all'}
+          </button>
+        )}
         <button
           type="button"
           className="notifications__close"
@@ -56,6 +81,11 @@ export default function NotificationsView({ active = false, onClose, onOpenTarge
         {isError && !rows.length && (
           <p className="notifications__hint" role="alert">
             Couldn’t load notifications. They’ll retry automatically.
+          </p>
+        )}
+        {clearError && (
+          <p className="notifications__hint notifications__hint--error" role="alert">
+            Couldn’t clear notifications. Try again when you’re online.
           </p>
         )}
         {!isLoading && !isError && rows.length === 0 && (

--- a/frontend/src/components/NotificationsView/NotificationsView.jsx
+++ b/frontend/src/components/NotificationsView/NotificationsView.jsx
@@ -22,6 +22,7 @@ export default function NotificationsView({ active = false, onClose, onOpenTarge
   const [now, setNow] = useState(() => Date.now())
   const [isClearing, setIsClearing] = useState(false)
   const [clearError, setClearError] = useState(false)
+  const [confirmClear, setConfirmClear] = useState(false)
 
   // Relative labels are live information, not a one-time formatting pass.
   // Refreshing once a minute keeps an open preview from saying "now" forever.
@@ -38,6 +39,7 @@ export default function NotificationsView({ active = false, onClose, onOpenTarge
     setClearError(false)
     try {
       await onClearAll?.()
+      setConfirmClear(false)
     } catch {
       setClearError(true)
     } finally {
@@ -56,14 +58,37 @@ export default function NotificationsView({ active = false, onClose, onOpenTarge
           Notifications
         </h2>
         {rows.length > 0 && (
-          <button
-            type="button"
-            className="notifications__clear"
-            onClick={handleClearAll}
-            disabled={isClearing}
-          >
-            {isClearing ? 'Clearing…' : 'Clear all'}
-          </button>
+          confirmClear ? (
+            <div className="notifications__clear-actions" role="group" aria-label="Confirm clearing notifications">
+              <button
+                type="button"
+                className="notifications__clear"
+                onClick={() => setConfirmClear(false)}
+                disabled={isClearing}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="notifications__clear notifications__clear--confirm"
+                onClick={handleClearAll}
+                disabled={isClearing}
+              >
+                {isClearing ? 'Clearing…' : 'Confirm clear'}
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              className="notifications__clear"
+              onClick={() => {
+                setClearError(false)
+                setConfirmClear(true)
+              }}
+            >
+              Clear all
+            </button>
+          )
         )}
         <button
           type="button"

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -663,6 +663,7 @@ export default function Shell() {
     actions: {
       toggle: toggleNotifications,
       close: closeNotifications,
+      clearAll: clearNotifications,
       reconcile: reconcileNotifications,
       onCreated: onNotificationCreated,
     },
@@ -3750,6 +3751,7 @@ export default function Shell() {
                 active
                 onClose={closeNotifications}
                 onOpenTarget={handleNotificationOpen}
+                onClearAll={clearNotifications}
               />
             )}
           </div>

--- a/tests/notifications.spec.mjs
+++ b/tests/notifications.spec.mjs
@@ -63,6 +63,14 @@ async function mockNotifications(page, { rows = notifRows(), unreadCount } = {})
     })
   })
   await page.route(/\/api\/notifications(?:\?.*)?$/, route => {
+    if (route.request().method() === 'DELETE') {
+      const deleted = state.rows.length
+      state.rows = []
+      state.unreadCount = 0
+      return route.fulfill({
+        status: 200, contentType: 'application/json', body: JSON.stringify({ deleted }),
+      })
+    }
     if (route.request().method() !== 'GET') return route.fallback()
     return route.fulfill({
       status: 200, contentType: 'application/json', body: JSON.stringify(state.rows.slice(0, 8)),
@@ -115,6 +123,18 @@ test('bell opens a bounded preview and seen-on-open clears its badge', async ({ 
   await page.locator('.notifications__close').click()
   await expect(page.locator('.notifications')).toBeHidden()
   await expect(bell).toHaveAttribute('aria-expanded', 'false')
+})
+
+test('clear all removes the preview rows and badge', async ({ page }) => {
+  await mockNotifications(page)
+  await setup(page)
+  await openPreview(page)
+
+  await expect(page.locator('.notifications__row')).toHaveCount(2)
+  await page.getByRole('button', { name: 'Clear all' }).click()
+  await expect(page.locator('.notifications__row')).toHaveCount(0)
+  await expect(page.locator('.notifications__empty')).toBeVisible()
+  await expect(page.locator('.notification-bell__badge')).toHaveCount(0)
 })
 
 test('bell toggles; Escape and outside click dismiss without navigation', async ({ page }) => {

--- a/tests/notifications.spec.mjs
+++ b/tests/notifications.spec.mjs
@@ -42,6 +42,7 @@ async function mockNotifications(page, { rows = notifRows(), unreadCount } = {})
     rows,
     unreadCount,
     readAllCalls: 0,
+    deleteCalls: 0,
     get unread() {
       return this.unreadCount ?? this.rows.filter(row => row.read_at == null).length
     },
@@ -64,6 +65,7 @@ async function mockNotifications(page, { rows = notifRows(), unreadCount } = {})
   })
   await page.route(/\/api\/notifications(?:\?.*)?$/, route => {
     if (route.request().method() === 'DELETE') {
+      state.deleteCalls += 1
       const deleted = state.rows.length
       state.rows = []
       state.unreadCount = 0
@@ -125,13 +127,18 @@ test('bell opens a bounded preview and seen-on-open clears its badge', async ({ 
   await expect(bell).toHaveAttribute('aria-expanded', 'false')
 })
 
-test('clear all removes the preview rows and badge', async ({ page }) => {
-  await mockNotifications(page)
+test('clear all requires confirmation, then removes the preview rows and badge', async ({ page }) => {
+  const state = await mockNotifications(page)
   await setup(page)
   await openPreview(page)
 
   await expect(page.locator('.notifications__row')).toHaveCount(2)
   await page.getByRole('button', { name: 'Clear all' }).click()
+  await expect(page.getByRole('button', { name: 'Confirm clear' })).toBeVisible()
+  expect(state.deleteCalls).toBe(0)
+  await expect(page.locator('.notifications__row')).toHaveCount(2)
+  await page.getByRole('button', { name: 'Confirm clear' }).click()
+  expect(state.deleteCalls).toBe(1)
   await expect(page.locator('.notifications__row')).toHaveCount(0)
   await expect(page.locator('.notifications__empty')).toBeVisible()
   await expect(page.locator('.notification-bell__badge')).toHaveCount(0)


### PR DESCRIPTION
## Summary

This bundles two independent improvements to Möbius.

### Fix: unsaved-response error from provider SDK wrappers
Provider SDKs occasionally wrap plain scalars — filesystem paths, model objects —
in Pydantic / `PathLike` wrappers. When one of those wrappers reached the chat
JSON columns it broke serialization and surfaced to the owner as an
"unsaved response" banner. A new `json_safe()` helper recursively coerces any
value into plain JSON-serializable scalars, lists, and dicts. It is applied at
the two chat-persistence seams (`update_live_assistant` and
`_apply_last_assistant_message`) and at the Codex `_model_dump` boundary, so the
wrappers are normalized before they ever reach a JSON column or wire payload.

### Feature: Clear all notifications
Adds an owner-only, idempotent `DELETE /api/notifications` route and a
"Clear all" control in the notification preview. It removes all stored
notifications and clears the bell badge, with an inline error hint if the
request fails while offline.

## Tests
- `backend/tests/test_json_safety.py` — nested wrapper normalization.
- `backend/tests/test_chat_live_assistant.py` — Codex path wrappers persist as plain strings through the live-assistant and finalize seams.
- `backend/tests/test_notification_target.py` — clear deletes the owner's history, resets the unread count, and is idempotent.
- `tests/notifications.spec.mjs` — Clear all empties the preview and removes the badge.