### PR TITLE
Make Codex sign-in sequential and model errors actionable

### DIFF
--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -71,7 +71,7 @@ from dataclasses import dataclass
 from typing import Any, Callable
 
 from app.codex_appserver import _extract_bash_command
-from app.providers import get_skill_path
+from app.providers import MODEL_LABELS, get_skill_path
 from app.runtime_types import RunnerResult
 from app.usage_metrics import codex_cost_usd, normalize_codex_usage
 from app.runner_registry import RunnerKind, registry
@@ -1771,6 +1771,37 @@ def _enum_wire_value(value: Any) -> str | None:
   return raw if isinstance(raw, str) else str(raw)
 
 
+_CHATGPT_MODEL_UNAVAILABLE_RE = re.compile(
+  r"[\"'](?P<model>[^\"']+)[\"'] model is not supported when using Codex "
+  r"with a ChatGPT account",
+  re.IGNORECASE,
+)
+
+
+def _codex_user_error(error_text: str | None) -> str | None:
+  """Turns a known account/model rejection into a useful next action.
+
+  The live Codex catalog can advertise a model that the signed-in account's
+  plan or staged rollout cannot actually run. The upstream 400 is technically
+  precise but reads like a broken connection and offers no recovery path.
+  Preserve every unknown provider error verbatim; only this exact, observed
+  contract gets product wording.
+  """
+  if not error_text:
+    return error_text
+  match = _CHATGPT_MODEL_UNAVAILABLE_RE.search(error_text)
+  if match is None:
+    return error_text
+  model_id = match.group("model")
+  model_name = MODEL_LABELS.get(model_id, model_id)
+  return (
+    f"{model_name} isn’t available for this ChatGPT account. Codex is "
+    "connected, but this account’s current plan or model rollout does not "
+    "include it. Choose another Codex model from this chat’s Model menu, "
+    "then try again."
+  )
+
+
 def _agent_message_phase(item: Any, sdk: dict[str, Any]) -> str | None:
   """Returns a completed agent message's native SDK phase."""
   if not isinstance(item, sdk["AgentMessageThreadItem"]):
@@ -3127,7 +3158,7 @@ async def run_codex_sdk_turn(
       result: RunnerResult = with_usage({
         "session_id": current_session_id,
         "cost_usd": None,
-        "error": error_text,
+        "error": _codex_user_error(error_text),
       })
       if terminal_status is not None:
         result["terminal_status"] = terminal_status
@@ -3166,7 +3197,7 @@ async def run_codex_sdk_turn(
     return with_usage({
       "session_id": current_session_id,
       "cost_usd": None,
-      "error": str(exc),
+      "error": _codex_user_error(str(exc)),
     })
   finally:
     if task_host_open and task_host_tool_use_id is not None:

--- a/backend/tests/test_codex_sdk_runner.py
+++ b/backend/tests/test_codex_sdk_runner.py
@@ -2685,6 +2685,27 @@ def test_codex_terminal_status_is_validated(
   )
 
 
+def test_chatgpt_model_rejection_explains_connection_and_recovery():
+  error = (
+    "{\"detail\":\"The 'gpt-5.6-sol' model is not supported when using "
+    "Codex with a ChatGPT account.\"}"
+  )
+
+  message = codex_sdk_runner._codex_user_error(error)
+
+  assert message == (
+    "GPT-5.6 Sol isn’t available for this ChatGPT account. Codex is "
+    "connected, but this account’s current plan or model rollout does not "
+    "include it. Choose another Codex model from this chat’s Model menu, "
+    "then try again."
+  )
+
+
+def test_unknown_codex_error_stays_verbatim():
+  error = "upstream returned 503"
+  assert codex_sdk_runner._codex_user_error(error) == error
+
+
 def test_codex_completed_turn_without_agent_message_is_not_success():
   sdk = _fake_sdk(object)
   turn = SimpleNamespace(

--- a/frontend/src/components/ProviderAuth/CodexAuth.jsx
+++ b/frontend/src/components/ProviderAuth/CodexAuth.jsx
@@ -24,7 +24,6 @@ export default function CodexAuth({ onConnected, showSetupHint = true }) {
   const [code, setCode] = useState('')
   const [copyState, setCopyState] = useState(null)
   const [error, setError] = useState('')
-  const [openedAuthWindow, setOpenedAuthWindow] = useState(true)
   const pollRef = useRef(null)
   const copyTimerRef = useRef(null)
   // Generation counter for in-flight poll fetches. setInterval gets
@@ -34,10 +33,11 @@ export default function CodexAuth({ onConnected, showSetupHint = true }) {
   // Each startLogin bumps the gen; each poll captures it and bails
   // if it no longer matches.
   const pollGenRef = useRef(0)
-  // The sign-in tab is reserved before the auth URL exists, so every path that
-  // ends without navigating it -- failed start, network error, a cancel or
-  // unmount mid-fetch -- has to close it, or the owner is left staring at a
-  // blank tab. Holding the handle here is what lets those later paths reach it.
+  // The sign-in tab is reserved by the Copy action, not by startLogin. That
+  // ordering keeps the one-time code visible before ChatGPT opens while still
+  // satisfying popup blockers' requirement that a tab originate in a user
+  // gesture. Holding the handle here lets unmount clean up the brief blank tab
+  // if the clipboard promise is still settling.
   const authWindowRef = useRef(null)
 
   // Three callers can be checking status at once: the interval poll, a pageshow
@@ -85,12 +85,18 @@ export default function CodexAuth({ onConnected, showSetupHint = true }) {
     if (copyTimerRef.current) clearTimeout(copyTimerRef.current)
   }, [stopPolling, releaseAuthWindow])
 
-  async function copyCodeToClipboard(value = code) {
+  async function copyCodeAndOpen(value = code) {
     if (!value) return
+    const authWindow = reserveAuthWindow('Opening ChatGPT sign-in…')
+    authWindowRef.current = authWindow
     try {
       await navigator.clipboard.writeText(value)
-      showCopyState('copied')
+      const opened = navigateAuthWindow(authWindow, url)
+      if (opened) authWindowRef.current = null
+      else releaseAuthWindow()
+      showCopyState(opened ? 'copied-opened' : 'copied')
     } catch {
+      releaseAuthWindow()
       showCopyState('failed')
     }
   }
@@ -133,12 +139,9 @@ export default function CodexAuth({ onConnected, showSetupHint = true }) {
   }
 
   async function startLogin() {
-    const authWindow = reserveAuthWindow('Opening Codex sign-in...')
-    authWindowRef.current = authWindow
     setError('')
     setStatus('connecting')
     setCopyState(null)
-    setOpenedAuthWindow(!!authWindow)
     // Capture the gen as of this call so a login that completes
     // after unmount/cancel doesn't transition the state machine.
     pollGenRef.current += 1
@@ -160,12 +163,6 @@ export default function CodexAuth({ onConnected, showSetupHint = true }) {
       setUrl(data.url)
       setCode(data.code)
       setStatus('pending')
-      const navigated = navigateAuthWindow(authWindow, data.url)
-      setOpenedAuthWindow(navigated)
-      // Once navigated the tab belongs to the owner's sign-in flow, so stop
-      // tracking it; if it never navigated it is a blank tab worth closing.
-      if (navigated) authWindowRef.current = null
-      else releaseAuthWindow()
 
       // Poll for completion. Bump the generation again for the poll
       // loop so cancel/unmount invalidates pending /status fetches.
@@ -233,42 +230,43 @@ export default function CodexAuth({ onConnected, showSetupHint = true }) {
     return (
       <div className="codex-auth">
         <p className="pa__muted">
-          Complete sign-in in your browser. {openedAuthWindow ? 'The page opened in a new tab;' : 'Open the page below;'}
-          {' '}if it asks for a code, copy this one.
+          Copy this one-time code. ChatGPT opens after it is safely on your
+          clipboard, ready for you to paste.
         </p>
         <div className="codex-auth__device">
           <div className="codex-auth__step">
-            <span className="codex-auth__step-num">1</span>
-            <span>
-              Open{' '}
-              <a href={url} target="_blank" rel="noopener noreferrer">
-                verification page
-              </a>
-            </span>
-          </div>
-          <div className="codex-auth__step">
-            <span className="codex-auth__step-num">2</span>
+            <span className="codex-auth__step-num">3</span>
             <span className="codex-auth__code-copy">
-              <span className="codex-auth__code-label">Enter code</span>
+              <span className="codex-auth__code-label">Copy your sign-in code</span>
               <code
                 className="codex-auth__code"
                 title="Click to copy"
-                onClick={() => copyCodeToClipboard()}
+                onClick={() => copyCodeAndOpen()}
               >
                 {code}
               </code>
               <button
                 type="button"
                 className="pa__btn pa__btn--sm codex-auth__copy-btn"
-                onClick={() => copyCodeToClipboard()}
+                onClick={() => copyCodeAndOpen()}
               >
-                {copyState === 'copied' ? 'Copied' : 'Copy code'}
+                {copyState?.startsWith('copied') ? 'Copied' : 'Copy code'}
               </button>
             </span>
           </div>
           {copyState === 'failed' && (
             <p className="pa__error codex-auth__copy-error" role="alert">
               Could not copy. Select the code above.
+            </p>
+          )}
+          {copyState === 'copied-opened' && (
+            <p className="pa__success codex-auth__copy-result" role="status">
+              Copied — ChatGPT opened in a new tab.
+            </p>
+          )}
+          {copyState === 'copied' && (
+            <p className="pa__muted codex-auth__copy-result" role="status">
+              Copied. If ChatGPT did not open, use Open page below.
             </p>
           )}
         </div>
@@ -310,9 +308,10 @@ export default function CodexAuth({ onConnected, showSetupHint = true }) {
           <div className="codex-auth__preflight-head">
             <span className="codex-auth__step-num" aria-hidden="true">1</span>
             <div>
-              <strong>Allow device access</strong>
+              <strong>Connect ChatGPT</strong>
               <p className="pa__muted codex-auth__hint">
-                In ChatGPT, open <strong>Settings → Security</strong> and turn on
+                Open <strong>Settings → Security</strong>, scroll to the very
+                bottom, and turn on
                 {' '}<strong>Enable device code authorization for Codex</strong>.
                 This is a one-time account setting.
               </p>
@@ -324,28 +323,34 @@ export default function CodexAuth({ onConnected, showSetupHint = true }) {
             target="_blank"
             rel="noopener noreferrer"
           >
-            Open ChatGPT security
+            Open ChatGPT settings
           </a>
-          <p className="pa__muted codex-auth__privacy">
-            Prefer not to have new conversations used to improve OpenAI’s
-            models? In ChatGPT, open <strong>Settings → Data Controls</strong>
-            {' '}and turn off <strong>Improve the model for everyone</strong>.
-            {' '}<a href={OPENAI_DATA_CONTROLS_URL} target="_blank" rel="noopener noreferrer">
-              OpenAI’s data-controls guide
-            </a>
-          </p>
+          <div className="codex-auth__privacy">
+            <span className="codex-auth__step-num" aria-hidden="true">2</span>
+            <div>
+              <strong>Optional: disable data sharing</strong>
+              <p className="pa__muted codex-auth__hint">
+                If you do not want new Codex conversations used to improve
+                OpenAI’s models, open <strong>Settings → Data Controls</strong>
+                {' '}and turn off <strong>Improve the model for everyone</strong>.
+                {' '}<a href={OPENAI_DATA_CONTROLS_URL} target="_blank" rel="noopener noreferrer">
+                  OpenAI’s data-controls guide
+                </a>
+              </p>
+            </div>
+          </div>
         </div>
       )}
       <div className="codex-auth__connect-step">
-        {showSetupHint && <span className="codex-auth__step-num" aria-hidden="true">2</span>}
+        {showSetupHint && <span className="codex-auth__step-num" aria-hidden="true">3</span>}
         <div>
-          {showSetupHint && <strong>Connect Codex</strong>}
+          {showSetupHint && <strong>Copy your sign-in code</strong>}
           <button
             className="pa__btn"
             onClick={startLogin}
             disabled={status === 'connecting'}
           >
-            {status === 'connecting' ? 'Starting…' : 'Continue with ChatGPT'}
+            {status === 'connecting' ? 'Getting code…' : 'Get sign-in code'}
           </button>
         </div>
       </div>

--- a/frontend/src/components/ProviderAuth/ProviderAuth.css
+++ b/frontend/src/components/ProviderAuth/ProviderAuth.css
@@ -156,6 +156,7 @@
 }
 
 .codex-auth__preflight-head,
+.codex-auth__privacy,
 .codex-auth__connect-step {
   display: flex;
   align-items: flex-start;
@@ -163,6 +164,7 @@
 }
 
 .codex-auth__preflight-head > div,
+.codex-auth__privacy > div,
 .codex-auth__connect-step > div {
   display: grid;
   gap: 8px;
@@ -171,6 +173,7 @@
 }
 
 .codex-auth__preflight-head strong,
+.codex-auth__privacy strong,
 .codex-auth__connect-step strong {
   color: var(--text);
   font-size: 14px;
@@ -184,7 +187,7 @@
 }
 
 .codex-auth__privacy {
-  margin: 2px 0 0 32px;
+  margin: 2px 0 0;
   padding-top: 11px;
   border-top: 1px solid var(--border-light);
   line-height: 1.5;
@@ -281,6 +284,11 @@
   margin: 2px 0 0 32px;
 }
 
+.codex-auth__copy-result {
+  margin: 2px 0 0 32px;
+  font-size: 13px;
+}
+
 .codex-auth__pending-actions {
   display: flex;
   align-items: center;
@@ -296,8 +304,7 @@
 }
 
 @media (max-width: 520px) {
-  .codex-auth__settings-link,
-  .codex-auth__privacy {
+  .codex-auth__settings-link {
     margin-left: 0;
   }
 }

--- a/tests/setup-provider-status.spec.mjs
+++ b/tests/setup-provider-status.spec.mjs
@@ -4,7 +4,7 @@ const BASE = process.env.MOBIUS_URL || 'http://localhost:8001'
 
 test.use({ serviceWorkers: 'block' })
 
-test('Codex connects from Settings and stays authoritative when status revalidation fails', async ({ page }) => {
+test('Codex shows the code before opening ChatGPT and stays authoritative', async ({ page }) => {
   await page.addInitScript(() => {
     // Older builds persisted this provider-wizard marker. It must never pull a
     // returning owner out of the shell now that agent setup is contextual.
@@ -73,13 +73,28 @@ test('Codex connects from Settings and stays authoritative when status revalidat
 
   const codexRow = page.locator('.provider-row').filter({ hasText: 'OpenAI Codex' })
   await codexRow.getByRole('button', { name: 'Connect OpenAI Codex' }).click()
-  await expect(codexRow.getByText('Allow device access', { exact: true })).toBeVisible()
-  await expect(codexRow.getByRole('link', { name: 'Open ChatGPT security' }))
+  await expect(codexRow.getByText('Connect ChatGPT', { exact: true })).toBeVisible()
+  await expect(codexRow.getByText(/scroll to the very bottom/)).toBeVisible()
+  await expect(codexRow.getByRole('link', { name: 'Open ChatGPT settings' }))
     .toHaveAttribute('href', 'https://chatgpt.com/#settings/Security')
+  await expect(codexRow.getByText('Optional: disable data sharing', { exact: true })).toBeVisible()
   await expect(codexRow.getByText(/Improve the model for everyone/)).toBeVisible()
 
-  await codexRow.getByRole('button', { name: 'Continue with ChatGPT' }).click()
-  await expect(page.getByText('Complete sign-in in your browser.')).toBeVisible()
+  let popupCount = 0
+  page.on('popup', () => { popupCount += 1 })
+  await codexRow.getByRole('button', { name: 'Get sign-in code' }).click()
+  await expect(codexRow.getByText('TEST-CODE', { exact: true })).toBeVisible()
+  expect(popupCount).toBe(0)
+
+  await page.context().grantPermissions(['clipboard-read', 'clipboard-write'], {
+    origin: BASE,
+  })
+  const popupPromise = page.waitForEvent('popup')
+  await codexRow.getByRole('button', { name: 'Copy code' }).click()
+  const signInPage = await popupPromise
+  await expect(signInPage).toHaveURL(`${BASE}/codex-test-login`)
+  await expect(codexRow.getByText('Copied — ChatGPT opened in a new tab.')).toBeVisible()
+
   await page.evaluate(() => window.dispatchEvent(new Event('pageshow')))
 
   await expect(codexRow.getByText('Connected', { exact: true })).toBeVisible()


### PR DESCRIPTION
## Summary
- show the ChatGPT account setup and optional data-control guidance before starting Codex device authentication
- keep the verification page closed until the one-time code has been copied, with a manual fallback when popups are blocked
- turn ChatGPT-account model rejections into an actionable explanation without changing unknown provider errors

## Testing
- `scripts/wt-pytest.sh backend/tests/test_codex_sdk_runner.py -q` (105 passed)
- `cd frontend && node --test src/components/ProviderAuth/__tests__/ProviderAuth.test.js` (6 passed)
- `cd frontend && npm run build`