### PR TITLE
Survive a wedged Navigation store on the traversal read side

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "build": "node scripts/safe-build.mjs",
     "preview": "vite preview",
     "test": "npm run test:lib && npm run test:hooks",
-    "test:lib": "node --loader=./src/lib/__tests__/vite-env-loader.mjs --test $(find src/lib src/utils src/components/DiffView src/components/ProviderAuth src/components/NotificationsView src/components/ChatView/__tests__ src/components/Shell/__tests__ -name '*.test.js')",
+    "test:lib": "node --loader=./src/lib/__tests__/vite-env-loader.mjs --test $(find src/lib src/utils src/hooks src/components/DiffView src/components/ProviderAuth src/components/NotificationsView src/components/ChatView/__tests__ src/components/Shell/__tests__ -name '*.test.js')",
     "test:hooks": "node --loader=./src/components/ChatView/hooks/__tests__/react-loader.mjs --test $(find src/components/ChatView/hooks -name '*.test.js') $(find src/components/Shell/__tests__ -name '*.hooktest.js')"
   },
   "dependencies": {

--- a/frontend/src/hooks/__tests__/drawerCloseResilience.test.js
+++ b/frontend/src/hooks/__tests__/drawerCloseResilience.test.js
@@ -39,6 +39,25 @@ test('onNavigate consumes a pending drawer close BEFORE the phantom guard', () =
     'pending-close consumption must precede the canIntercept early-return')
 })
 
+test('a pending close landing on a classic-store phantom keeps seeking, not finishing', () => {
+  // The wedged-mirror recovery must not swallow the HEALTHY-engine phantom
+  // seek: when the committed entry is untagged in the authoritative classic
+  // store too, the landing is a genuine iframe phantom beneath the sentinel —
+  // the close's tagged home is deeper. Finishing there would clear the pending
+  // flags and strand the shell on the untagged entry (caught by e2e
+  // navigation 31, "seeks through phantom history").
+  const consume = onNavigate.slice(
+    onNavigate.indexOf('const consume = () =>'),
+    onNavigate.indexOf('if (e.canIntercept)'),
+  )
+  assert.match(consume,
+    /if \(!committed && drawerClosePendingRef\.current\) \{\s*\n\s*continueDrawerCloseAfterPhantom\(\)\s*\n\s*return/,
+    'an untagged classic-store landing during a pending close continues the seek')
+  // And the finish path still runs only after that guard.
+  assert.ok(consume.indexOf('continueDrawerCloseAfterPhantom()') < consume.indexOf('handleBack(committed, source)'),
+    'the phantom-seek continuation is decided before the close is finished')
+})
+
 test('every Navigation-store read in onNavigate is defensive', () => {
   // The wedged engine throws from its entry accessors just as it does from
   // updateCurrentEntry. Each mirror read must be try/catch-wrapped so a

--- a/frontend/src/hooks/__tests__/drawerCloseResilience.test.js
+++ b/frontend/src/hooks/__tests__/drawerCloseResilience.test.js
@@ -62,7 +62,13 @@ test('every Navigation-store read in onNavigate is defensive', () => {
   // The wedged engine throws from its entry accessors just as it does from
   // updateCurrentEntry. Each mirror read must be try/catch-wrapped so a
   // throwing accessor cannot kill traversal handling.
-  for (const read of ['e.destination.getState()', 'navigation.currentEntry', 'sourceEntry?.getState?.()']) {
+  for (const read of [
+    'e.destination.getState()',
+    'navigation.currentEntry',
+    'sourceEntry?.getState?.()',
+    'sourceEntry?.index',
+    'e.destination?.index',
+  ]) {
     const at = onNavigate.indexOf(read)
     assert.ok(at > -1, `${read} is read in onNavigate`)
     const before = onNavigate.slice(Math.max(0, at - 120), at)

--- a/frontend/src/hooks/__tests__/drawerCloseResilience.test.js
+++ b/frontend/src/hooks/__tests__/drawerCloseResilience.test.js
@@ -1,0 +1,68 @@
+/* Drawer-close resilience against a wedged WebKit Navigation API (source
+ * contract, matching the house pattern for useNavigation.js coverage).
+ *
+ * The Navigation store is a best-effort MIRROR of the classic History store
+ * (navHistory.mirrorCurrentEntry). On a wedged WebKit engine (iOS 18.4+) the
+ * mirror is unreadable AND unwritable: updateCurrentEntry throws
+ * InvalidStateError, and getState() returns undefined for entries whose
+ * mirror write failed. Observed in the field 2026-07-29 (standalone iOS PWA):
+ * the drawer opened once per launch, a scrim-close walked the session history
+ * backwards out of the shell via the phantom guard, and every later open was
+ * silently refused until relaunch.
+ *
+ * These are deliberate SOURCE contracts: useNavigation is a hook with live
+ * history/navigation side effects that has no mountable unit harness, and the
+ * wedged-engine behavior was verified against the rendered shell with the
+ * Navigation API stubbed to throw/return-undefined. The contracts lock the
+ * three load-bearing shapes of that fix. */
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+const src = readFileSync(new URL('../useNavigation.js', import.meta.url), 'utf8')
+const onNavigate = src.slice(src.indexOf('function onNavigate'), src.indexOf("navigation.addEventListener('navigate'"))
+
+test('onNavigate consumes a pending drawer close BEFORE the phantom guard', () => {
+  const pendingClose = onNavigate.indexOf('drawerClosePendingRef.current && source?.kind === \'drawer\'')
+  const phantomGuard = onNavigate.indexOf('!isMobiusNavState(destination)')
+  assert.ok(pendingClose > -1, 'pending-close consumption exists in onNavigate')
+  assert.ok(phantomGuard > -1, 'phantom guard exists in onNavigate')
+  // A wedged mirror store makes the destination read untagged; if the phantom
+  // guard ran first it would misread our own close as an iframe phantom,
+  // re-issue history.back() per traversal, and never clear the pending flag.
+  assert.ok(pendingClose < phantomGuard,
+    'pending drawer close must be consumed before the phantom guard can misread it')
+  // And it must not depend on interception being available: canIntercept may
+  // be false for traversals on some engines; the close still consumes.
+  const canInterceptReturn = onNavigate.indexOf('if (!e.canIntercept) return')
+  assert.ok(canInterceptReturn > pendingClose,
+    'pending-close consumption must precede the canIntercept early-return')
+})
+
+test('every Navigation-store read in onNavigate is defensive', () => {
+  // The wedged engine throws from its entry accessors just as it does from
+  // updateCurrentEntry. Each mirror read must be try/catch-wrapped so a
+  // throwing accessor cannot kill traversal handling.
+  for (const read of ['e.destination.getState()', 'navigation.currentEntry', 'sourceEntry?.getState?.()']) {
+    const at = onNavigate.indexOf(read)
+    assert.ok(at > -1, `${read} is read in onNavigate`)
+    const before = onNavigate.slice(Math.max(0, at - 120), at)
+    assert.ok(/try\s*{[^}]*$/.test(before), `${read} is wrapped in try/catch`)
+  }
+})
+
+test('openDrawer reconciles a provably-stale pending close from the classic store', () => {
+  const openDrawer = src.slice(src.indexOf('function openDrawer'), src.indexOf('function closeDrawer'))
+  // Bounded: within the grace window the original serialization guarantee
+  // holds (never re-adopt while the traversal may still land).
+  assert.ok(openDrawer.includes('DRAWER_CLOSE_TRAVERSAL_GRACE_MS'),
+    'stale-close recovery is gated on the traversal grace window')
+  // Re-adopt only on classic-store evidence that the back() never committed:
+  // the sentinel is still the CURRENT entry.
+  assert.ok(/isMobiusNavState\(history\.state\) && history\.state\.kind === 'drawer'/.test(openDrawer),
+    're-adoption requires the classic store to still show the drawer sentinel')
+  // closeDrawer stamps the clock the recovery reads.
+  const closeDrawer = src.slice(src.indexOf('function closeDrawer'), src.indexOf('const appNavPush'))
+  assert.ok(closeDrawer.includes('drawerClosePendingAtRef.current = Date.now()'),
+    'closeDrawer stamps the pending-close start time')
+})

--- a/frontend/src/hooks/useNavigation.js
+++ b/frontend/src/hooks/useNavigation.js
@@ -1529,6 +1529,17 @@ export default function useNavigation({
               ? destination
               : (isMobiusNavState(history.state) ? history.state : null)
             if (committed) currentNavStateRef.current = committed
+            // Untagged in the CLASSIC store too? Then this is not a wedged
+            // mirror read but a GENUINE phantom beneath the sentinel (a
+            // sandboxed iframe pushed it before the drawer opened): the
+            // close's tagged home is still deeper. Keep the close pending and
+            // keep seeking — the same behavior the phantom guard gives a
+            // healthy engine — instead of finishing here, which would clear
+            // the pending flags and strand the shell on an untagged entry.
+            if (!committed && drawerClosePendingRef.current) {
+              continueDrawerCloseAfterPhantom()
+              return
+            }
             handleBack(committed, source)
           }
           // Intercept when the engine allows it (suppresses the traversal

--- a/frontend/src/hooks/useNavigation.js
+++ b/frontend/src/hooks/useNavigation.js
@@ -1502,6 +1502,10 @@ export default function useNavigation({
         try { sourceEntry = navigation.currentEntry } catch { /* wedged engine */ }
         let sourceEntryState
         try { sourceEntryState = sourceEntry?.getState?.() } catch { sourceEntryState = undefined }
+        let currentEntryIndex
+        try { currentEntryIndex = sourceEntry?.index } catch { currentEntryIndex = undefined }
+        let destinationEntryIndex
+        try { destinationEntryIndex = e.destination?.index } catch { destinationEntryIndex = undefined }
         const source = sourceEntryState || currentNavStateRef.current
         // A drawer-sentinel consumption is recognized FIRST — before the
         // phantom guard, and even when the destination's mirror state is
@@ -1552,8 +1556,8 @@ export default function useNavigation({
         }
         if (!e.canIntercept) return
         const direction = navTraversalDirection(source, destination, {
-          currentEntryIndex: sourceEntry?.index,
-          destinationEntryIndex: e.destination?.index,
+          currentEntryIndex,
+          destinationEntryIndex,
         })
         const sourceRoute = snapshotRoute()
         // Phantom-entry guard: ignore a traversal landing on an UNTAGGED entry —

--- a/frontend/src/hooks/useNavigation.js
+++ b/frontend/src/hooks/useNavigation.js
@@ -24,6 +24,14 @@ const RETURN_VIEW_KEY = 'mobius:return-view'
 
 const MAX_APP_SENTINELS = 20
 
+// How long a drawer close may wait for its history traversal before openDrawer
+// treats the traversal as LOST and reconciles from the classic store (see
+// openDrawer). Real same-document commits land within tens of milliseconds;
+// this is deliberately far above that so a merely-slow traversal is never
+// raced, while a wedged-engine loss (WebKit Navigation API) stays recoverable
+// by the user's next tap instead of requiring a full relaunch.
+const DRAWER_CLOSE_TRAVERSAL_GRACE_MS = 1500
+
 // Returns true if ANY (paneId, appId) owner in the per-owner sentinel map has
 // pending back-targets. Used by the popstate / onNavigate early-return guards:
 // even when the currently-visible app has zero sentinels (e.g. you just switched
@@ -311,6 +319,12 @@ export default function useNavigation({
   // reaches the tagged entry beneath the drawer sentinel. Keep that traversal
   // serialized so the modal stays inert until the sentinel is truly consumed.
   const drawerClosePendingRef = useRef(false)
+  // When that close began (ms epoch). A wedged WebKit Navigation API can LOSE
+  // the close's traversal outright (never fired, dropped mid-flight, or
+  // misrouted while the mirror store is unreadable — see onNavigate). The
+  // pending flag must not brick the drawer forever: openDrawer reconciles from
+  // the classic History store once the traversal is provably stale.
+  const drawerClosePendingAtRef = useRef(0)
   // Per-(pane, app) pending nav-sentinel counts installed via the
   // moebius:nav-push postMessage protocol. Keyed by ownerKeyOf(paneId, appId).
   const appSentinelCountsRef = useRef(new Map())
@@ -560,7 +574,30 @@ export default function useNavigation({
     // sentinel while that traversal is unresolved: the cursor may already have
     // left it even though popstate has not run, and treating the boolean flag as
     // proof that it is still current makes the next close over-pop a real route.
-    if (drawerClosePendingRef.current) return
+    //
+    // …unless the traversal is provably LOST. A wedged WebKit Navigation API
+    // can drop the close's traversal outright, and a permanently-pending close
+    // used to refuse every later open until a full relaunch. Real commits land
+    // in tens of milliseconds; once the close is far staler than that, the
+    // user's open must win. Reconcile from the authoritative classic store:
+    // the sentinel still being the CURRENT entry means the back() never
+    // committed — re-adopt it (logically open again, one sentinel, no second
+    // push). Otherwise the traversal landed but its consumption never reached
+    // handleBack — clear the stranded flags and open fresh.
+    if (drawerClosePendingRef.current) {
+      if (Date.now() - drawerClosePendingAtRef.current < DRAWER_CLOSE_TRAVERSAL_GRACE_MS) {
+        return
+      }
+      drawerClosePendingRef.current = false
+      if (drawerPushedRef.current
+          && isMobiusNavState(history.state) && history.state.kind === 'drawer') {
+        drawerOpenRef.current = true
+        setDrawerVisible(true)
+        return
+      }
+      drawerOpenRef.current = false
+      drawerPushedRef.current = false
+    }
     // Synchronous guard for a rapid double activation before React has rendered
     // `drawerOpen=true`. One drawer owns exactly one physical sentinel.
     if (drawerOpenRef.current) return
@@ -586,6 +623,7 @@ export default function useNavigation({
     if (!drawerOpenRef.current || drawerClosePendingRef.current) return
     if (drawerPushedRef.current) {
       drawerClosePendingRef.current = true
+      drawerClosePendingAtRef.current = Date.now()
       // A tap/swipe close should acknowledge immediately. Keep the logical ref
       // true until Back consumes the drawer sentinel (so handleBack still owns
       // navigation correctness), but begin the visual close before that async
@@ -1452,11 +1490,56 @@ export default function useNavigation({
     if (typeof navigation !== 'undefined' && navigation.addEventListener) {
       function onNavigate(e) {
         if (e.navigationType !== 'traverse') return
+        // The Navigation store is a best-effort MIRROR of the authoritative
+        // classic History store (see navHistory.mirrorCurrentEntry) — on the
+        // READ side too. A wedged WebKit Navigation API (iOS 18.4+) throws
+        // from its own entry accessors just as it does from
+        // updateCurrentEntry, and returns undefined for entries whose mirror
+        // write failed. Treat every mirror read as optional.
+        let destination
+        try { destination = e.destination.getState() } catch { destination = undefined }
+        let sourceEntry = null
+        try { sourceEntry = navigation.currentEntry } catch { /* wedged engine */ }
+        let sourceEntryState
+        try { sourceEntryState = sourceEntry?.getState?.() } catch { sourceEntryState = undefined }
+        const source = sourceEntryState || currentNavStateRef.current
+        // A drawer-sentinel consumption is recognized FIRST — before the
+        // phantom guard, and even when the destination's mirror state is
+        // unreadable. On a wedged engine the sentinel's mirror write failed, so
+        // destination.getState() comes back untagged and the phantom guard
+        // below misreads our own close as an iframe phantom: it re-issues
+        // history.back() per traversal (walking the session history all the
+        // way out of the shell) and drawerClosePendingRef never clears, so
+        // every later open is silently refused until a full relaunch
+        // (observed in the field 2026-07-29, standalone iOS PWA, alongside
+        // the mirrorCurrentEntry InvalidStateError reports). Our own state —
+        // the close intent with a drawer-tagged source, or an open drawer
+        // whose live sentinel a Back gesture is consuming — is stronger
+        // evidence than a missing mirror tag. (An iframe-owned traversal
+        // never raises the TOP window's navigate event, so a top-level
+        // traverse with the sentinel live is ours.)
+        const pendingDrawerClose = drawerClosePendingRef.current && source?.kind === 'drawer'
+        const unreadableSentinelConsumption = !isMobiusNavState(destination)
+          && drawerOpenRef.current && drawerPushedRef.current
+        if (pendingDrawerClose || unreadableSentinelConsumption) {
+          const consume = () => {
+            // Post-commit the CLASSIC store is authoritative for where we
+            // landed; fall back to it when the mirror state is untagged.
+            const committed = isMobiusNavState(destination)
+              ? destination
+              : (isMobiusNavState(history.state) ? history.state : null)
+            if (committed) currentNavStateRef.current = committed
+            handleBack(committed, source)
+          }
+          // Intercept when the engine allows it (suppresses the traversal
+          // slide); otherwise let the traversal commit and consume right
+          // after — the drawer branch of handleBack keys on our own refs,
+          // not on the destination.
+          if (e.canIntercept) e.intercept({ handler: consume })
+          else setTimeout(consume, 0)
+          return
+        }
         if (!e.canIntercept) return
-        const destination = e.destination.getState()
-        const sourceEntry = navigation.currentEntry
-        const source = sourceEntry?.getState?.()
-          || currentNavStateRef.current
         const direction = navTraversalDirection(source, destination, {
           currentEntryIndex: sourceEntry?.index,
           destinationEntryIndex: e.destination?.index,
@@ -1488,17 +1571,6 @@ export default function useNavigation({
             appLocalPopInFlightRef.current = false
             appLocalPopInFlightEntryRef.current = null
             setTimeout(resumeLocalAppPops, 0)
-          } })
-          return
-        }
-        // The pending-close intent is stronger evidence than direction here.
-        // Navigation API indices normally classify this as Back, but a browser
-        // may omit or duplicate shell indices. The source tag still proves that
-        // this traversal is consuming the drawer's own physical sentinel.
-        if (drawerClosePendingRef.current && source?.kind === 'drawer') {
-          e.intercept({ handler() {
-            currentNavStateRef.current = destination
-            handleBack(destination, source)
           } })
           return
         }

--- a/frontend/src/lib/__tests__/navigationWorkspaceContract.test.js
+++ b/frontend/src/lib/__tests__/navigationWorkspaceContract.test.js
@@ -21,28 +21,46 @@ test('one open drawer owns at most one physical sentinel', () => {
 // closeDrawer hides the panel immediately but keeps drawerOpenRef true until Back
 // consumes the sentinel. Safari can classify that popstate as same/unknown when
 // shell indices are missing. Resolve the pending close at the event boundary;
-// never infer from drawerPushedRef that the sentinel is still current while a
-// traversal is in flight, because the next close could then over-pop a real route.
+// never infer from drawerPushedRef ALONE that the sentinel is still current
+// while a traversal is in flight, because the next close could then over-pop a
+// real route. A wedged WebKit Navigation API can also LOSE the traversal
+// outright (2026-07-29): after a bounded grace window openDrawer reconciles
+// from the CLASSIC store — which, unlike the boolean, can prove whether the
+// history cursor still sits on the sentinel — so a lost close can never refuse
+// every later open until relaunch.
 test('a pending drawer close consumes its tagged source before direction fallback', () => {
   const open = navigation.slice(
     navigation.indexOf('function openDrawer()'),
     navigation.indexOf('function closeDrawer('),
   )
   const guard = open.indexOf('if (drawerOpenRef.current) return')
-  const pending = open.indexOf('if (drawerClosePendingRef.current) return')
+  const pending = open.indexOf('if (drawerClosePendingRef.current) {')
   assert.ok(pending >= 0 && guard > pending,
-    'an unresolved traversal blocks another open before the ordinary open guard')
+    'an unresolved traversal is resolved or blocks another open before the ordinary open guard')
+  const pendingBlock = open.slice(pending, guard)
+  // Within the grace window the original serialization holds: the open returns
+  // while the close's history cursor may still legitimately be moving.
+  assert.match(pendingBlock, /DRAWER_CLOSE_TRAVERSAL_GRACE_MS[\s\S]{0,80}?return/,
+    'a fresh pending close still blocks the open')
+  // Re-adopting the sentinel after a LOST traversal requires classic-store
+  // proof that the cursor never left it — never the boolean alone.
+  assert.match(
+    pendingBlock,
+    /drawerPushedRef\.current\s*&&\s*isMobiusNavState\(history\.state\) && history\.state\.kind === 'drawer'/,
+    're-adoption is gated on the classic store still showing the drawer sentinel',
+  )
   assert.doesNotMatch(open, /if \(drawerPushedRef\.current\) \{\s*drawerOpenRef\.current = true/,
     'a boolean cannot prove that an async history cursor still sits on the sentinel')
-  assert.equal(
-    (navigation.match(
-      /if \(drawerClosePendingRef\.current && source\?\.kind === 'drawer'\) \{/g,
-    ) || []).length,
-    2,
-    'both Navigation API and popstate paths consume a pending tagged drawer source',
-  )
+  // Both traversal paths consume a pending tagged drawer source. The popstate
+  // path reads the classic store directly; the Navigation API path recognizes
+  // the consumption through its own refs BEFORE the phantom guard, because a
+  // wedged mirror store returns untagged reads for our own entries.
   assert.match(navigation,
-    /if \(drawerClosePendingRef\.current && source\?\.kind === 'drawer'\) \{[\s\S]{0,180}?handleBack\(destination, source\)/)
+    /const pendingDrawerClose = drawerClosePendingRef\.current && source\?\.kind === 'drawer'/)
+  assert.match(navigation,
+    /if \(pendingDrawerClose \|\| unreadableSentinelConsumption\) \{/)
+  assert.match(navigation,
+    /if \(drawerClosePendingRef\.current && source\?\.kind === 'drawer'\) \{\s*\n\s*handleBack\(destination, source\)/)
   // Whoever else resolves the drawer's history state clears the pending flag too,
   // so a later open cannot remain latched behind a hidden panel.
   assert.match(navigation, /drawerClosePendingRef\.current = false\s*\n\s*drawerOpenRef\.current = false\s*\n\s*setDrawerVisible\(false\)/)


### PR DESCRIPTION
## Problem

Follow-up to #361, which guarded the WRITE side of the wedged-WebKit Navigation API failure. The same wedged engine (iOS 18.4+) is broken on the READ side too: `getState()` returns undefined for entries whose best-effort mirror write failed, and entry accessors can throw.

The navigate-path phantom guard treated those unreadable reads as authoritative, so with #361 in place the drawer still died: the sentinel entry has no Navigation-store state, the close traversal's `e.destination.getState()` comes back untagged, and the shell misreads its own drawer close as an iframe phantom — `continueDrawerCloseAfterPhantom` re-issues `history.back()` per traversal (reproduced walking the session history out of the shell to `about:blank`) and `drawerClosePendingRef` never clears, so every later open is silently refused until relaunch. Field-reported on a standalone iOS PWA (2026-07-29) with the #361 guard active; same WebKit-only defect family #248 fought.

## Fix

Same doctrine as #361, applied to the read side: the classic History store is authoritative; mirror reads are optional.

- Every Navigation-store read in `onNavigate` is defensive (try/catch).
- A drawer-sentinel consumption is recognized before the phantom guard, from the shell's own state — a pending close with a drawer-tagged source, or an open drawer whose live sentinel a Back gesture is consuming — with or without interception; post-commit the destination falls back to `history.state`. (An iframe-owned traversal never raises the top window's navigate event, so a top-level traverse with the sentinel live is ours.)
- `openDrawer` reconciles a provably-stale pending close (lost traversal) from the classic store: re-adopt the sentinel when it is still the current entry, else clear the stranded flags — the user's next tap always wins, bounded by `DRAWER_CLOSE_TRAVERSAL_GRACE_MS`.

## Verification

- Source contracts for the traversal fixes (`drawerCloseResilience.test.js`); the drawer-close contract in `navigationWorkspaceContract.test.js` updated to the evolved invariant (a lost close reconciles from the classic store instead of refusing every later open).
- Live against the rendered shell with the Navigation store stubbed to throw/return-undefined: scrim-, toggle-, Back-, and chat-select-close all reopen; the app never leaves the shell. Healthy-engine behavior unchanged (123 navigation contract tests; full frontend suite parity except two pre-existing environmental failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)