### PR TITLE
Ask GitHub before first publication of a branch

### DIFF
--- a/backend/app/routes/github.py
+++ b/backend/app/routes/github.py
@@ -1959,6 +1959,77 @@ def _find_existing_pr(
   return None
 
 
+def _existing_branch_pr(
+  repo: Path,
+  upstream_repo: str,
+  login: str,
+  branch: str,
+  *,
+  same_repo: bool = False,
+) -> tuple[str, str] | None:
+  """Truth check before first publication: this branch's existing OPEN or
+  MERGED pull request in the upstream repo, as ``(url, state)``, else None.
+
+  The submit preflights above prove WHAT would be sent (the exact reviewed
+  diff); only the agent-writable ledger row claims the record was never sent
+  before — and that row can lie (field incident 2026-07-29: a freshly-merged
+  PR's record was rewritten back to ``prepared`` by a stale re-stage, so one
+  more Send would have force-pushed the merged branch and opened a duplicate
+  PR). GitHub is the one store that cannot drift from the public truth, so
+  ask it directly. Fail CLOSED: a lookup that cannot complete raises instead
+  of letting the send proceed blind — the send needs GitHub reachable anyway.
+  A PR closed WITHOUT merging is not returned: rework-and-resend of a
+  rejected branch stays legitimate. An open PR outranks a merged one in the
+  report so the message names the row that would collide first.
+  """
+  could_not_verify = (
+    "Could not verify whether this branch already has a pull request. "
+    "Nothing was pushed; try again once GitHub is reachable."
+  )
+  expected_owner = upstream_repo.split("/", 1)[0] if same_repo else login
+  try:
+    proc = _gh(
+      repo,
+      "pr", "list",
+      "-R", upstream_repo,
+      "--head", branch,
+      "--state", "all",
+      "--json", "url,state,headRefName,headRepositoryOwner",
+      "--limit", "20",
+      check=False,
+    )
+  except (subprocess.TimeoutExpired, OSError) as exc:
+    raise ContributionSubmitError(could_not_verify) from exc
+  if proc.returncode != 0:
+    detail = (proc.stderr or proc.stdout or "").strip()
+    suffix = f" ({detail[:200]})" if detail else ""
+    raise ContributionSubmitError(could_not_verify + suffix)
+  try:
+    rows = json.loads(proc.stdout or "[]")
+  except ValueError:
+    raise ContributionSubmitError(could_not_verify) from None
+  merged: tuple[str, str] | None = None
+  if isinstance(rows, list):
+    for row in rows:
+      if not isinstance(row, dict):
+        continue
+      owner = row.get("headRepositoryOwner")
+      owner_login = owner.get("login") if isinstance(owner, dict) else ""
+      if str(owner_login or "").casefold() != expected_owner.casefold():
+        continue
+      if str(row.get("headRefName") or "") != branch:
+        continue
+      url = row.get("url")
+      if not (isinstance(url, str) and url.startswith("https://github.com/")):
+        continue
+      state_label = str(row.get("state") or "").upper()
+      if state_label == "OPEN":
+        return (url, "open")
+      if state_label == "MERGED" and merged is None:
+        merged = (url, "merged")
+  return merged
+
+
 def _is_workflow_scope_push_error(message: str) -> bool:
   """Recognize GitHub's stable OAuth workflow-scope rejection."""
   detail = str(message or "").lower()
@@ -2521,6 +2592,33 @@ def _submit_prepared_pr(
     submit_base = direct_base or _validate_branch(
       str(merge_patch.get("last_submit_upstream_branch") or "")
     )
+
+    # Pre-publication truth check: everything above proves WHAT would be sent;
+    # only the ledger row says WHETHER it was already sent, and that row is
+    # agent-writable state that can regress (see _existing_branch_pr). Ask
+    # GitHub before touching anything public — an OPEN or MERGED pull request
+    # from this exact branch means this send can only be a duplicate, and
+    # today's flow would push FIRST (silently rewriting that PR's public
+    # branch) before GitHub refused the create. The resume path
+    # (expected_existing_pr_number) legitimately expects its open PR and
+    # keeps its own stricter exact-commit verification below.
+    if expected_existing_pr_number is None:
+      conflict = _existing_branch_pr(
+        repo,
+        upstream_repo,
+        login,
+        branch,
+        same_repo=bool(direct_base),
+      )
+      if conflict is not None:
+        conflict_url, conflict_state = conflict
+        raise ContributionSubmitError(
+          f"This branch already has a {conflict_state} pull request: "
+          f"{conflict_url}. Nothing was pushed. Reconcile this card with "
+          "that pull request — or re-stage the work on a fresh branch — "
+          "instead of sending it again.",
+          record_patch=record_patch,
+        )
 
     push_source = "HEAD"
     if direct_base:

--- a/backend/tests/test_github_routes.py
+++ b/backend/tests/test_github_routes.py
@@ -2470,7 +2470,14 @@ def test_submit_contribution_keeps_accepted_pr_open_on_label_transport_failure(
   assert create_call[-2:] == ("--base", "main")
   assert ("push", "fork", "HEAD:refs/heads/fix/demo-polish") in git_calls
   assert sum(call[:1] == ("fetch",) for call in git_calls) == 1
-  assert not any(call[:2] == ("pr", "list") for call in gh_calls)
+  # Exactly one pre-publication truth check (`--state all`), and no
+  # ambiguous-create recovery probe on this clean-create path.
+  assert sum(
+    call[:2] == ("pr", "list") and "all" in call for call in gh_calls
+  ) == 1
+  assert not any(
+    call[:2] == ("pr", "list") and "all" not in call for call in gh_calls
+  )
   assert ("checkout", "-q", "develop") in git_calls
   assert upstream_pool_counts
   assert set(upstream_pool_counts) == {baseline_checked_out}
@@ -2609,8 +2616,18 @@ def test_submit_contribution_recovers_ambiguous_create_by_exact_pushed_head(
   )
 
   creates = [call for call in gh_calls if call[:2] == ("pr", "create")]
-  probes = [call for call in gh_calls if call[:2] == ("pr", "list")]
+  # The pre-publication truth check is a separate `--state all` lookup; the
+  # ambiguous-create RECOVERY probe queries open PRs only. Count them apart.
+  preflights = [
+    call for call in gh_calls
+    if call[:2] == ("pr", "list") and "all" in call
+  ]
+  probes = [
+    call for call in gh_calls
+    if call[:2] == ("pr", "list") and "all" not in call
+  ]
   assert len(creates) == 1, "an ambiguous response must never trigger a second create"
+  assert len(preflights) == 1
   assert len(probes) == 1
   assert creates[0][-2:] == ("--base", "main")
   assert "url,headRefName,headRefOid,headRepositoryOwner" in probes[0]
@@ -4716,3 +4733,184 @@ def test_submit_records_where_the_owner_pressed_send(
   assert submitted.status_code == 200, submitted.text
   record_path, _ = github_routes._record_paths(app_id, "provenance")
   assert json.loads(record_path.read_text())["submitter"] == "chat-review-card"
+
+
+# ── Pre-publication branch truth check ──────────────────────────────────────
+# The reviewed-diff preflights prove WHAT would be sent; _existing_branch_pr
+# proves WHETHER it was already sent, from GitHub itself, because the
+# agent-writable ledger row can regress (2026-07-29: a merged PR's record was
+# rewritten back to `prepared`; one more Send would have force-pushed the
+# merged branch and opened a duplicate PR).
+
+
+def _branch_pr_row(url, state, branch, owner):
+  return {
+    "url": url,
+    "state": state,
+    "headRefName": branch,
+    "headRepositoryOwner": {"login": owner},
+  }
+
+
+def test_existing_branch_pr_classifies_states(tmp_path, monkeypatch):
+  from app.routes.github import _existing_branch_pr
+
+  rows = []
+
+  def fake_gh(repo_path, *args, check=True):
+    assert args[:2] == ("pr", "list") and "all" in args
+    return _cp(json.dumps(rows))
+
+  monkeypatch.setattr("app.routes.github._gh", fake_gh)
+  call = lambda: _existing_branch_pr(
+    tmp_path, "mobius-os/app-demo", "octocat", "fix/x",
+  )
+
+  # Closed-without-merging stays sendable: rework-and-resend is legitimate.
+  rows = [_branch_pr_row("https://github.com/mobius-os/app-demo/pull/1",
+                         "CLOSED", "fix/x", "octocat")]
+  assert call() is None
+
+  # A different owner's or branch's PR never blocks this send.
+  rows = [
+    _branch_pr_row("https://github.com/mobius-os/app-demo/pull/2",
+                   "OPEN", "fix/x", "someone-else"),
+    _branch_pr_row("https://github.com/mobius-os/app-demo/pull/3",
+                   "OPEN", "fix/other", "octocat"),
+  ]
+  assert call() is None
+
+  rows = [_branch_pr_row("https://github.com/mobius-os/app-demo/pull/4",
+                         "MERGED", "fix/x", "octocat")]
+  assert call() == ("https://github.com/mobius-os/app-demo/pull/4", "merged")
+
+  # An open PR outranks a merged one: the message should name the row the
+  # send would collide with first.
+  rows = [
+    _branch_pr_row("https://github.com/mobius-os/app-demo/pull/4",
+                   "MERGED", "fix/x", "octocat"),
+    _branch_pr_row("https://github.com/mobius-os/app-demo/pull/5",
+                   "OPEN", "fix/x", "octocat"),
+  ]
+  assert call() == ("https://github.com/mobius-os/app-demo/pull/5", "open")
+
+
+def test_existing_branch_pr_fails_closed_when_lookup_fails(
+  tmp_path, monkeypatch,
+):
+  from app.routes.github import ContributionSubmitError, _existing_branch_pr
+
+  # The lookup failing must STOP the send, not let it proceed blind: the
+  # whole point is refusing to trust local state about public reality.
+  monkeypatch.setattr(
+    "app.routes.github._gh",
+    lambda repo_path, *args, check=True: _cp("boom", returncode=1),
+  )
+  with pytest.raises(ContributionSubmitError) as err:
+    _existing_branch_pr(tmp_path, "mobius-os/app-demo", "octocat", "fix/x")
+  assert "Nothing was pushed" in err.value.message
+
+  monkeypatch.setattr(
+    "app.routes.github._gh",
+    lambda repo_path, *args, check=True: _cp("not-json"),
+  )
+  with pytest.raises(ContributionSubmitError):
+    _existing_branch_pr(tmp_path, "mobius-os/app-demo", "octocat", "fix/x")
+
+
+def test_send_refuses_branch_with_existing_pr_before_any_push(
+  tmp_path, monkeypatch,
+):
+  from app.routes.github import ContributionSubmitError, _submit_prepared_pr
+
+  _write_token(login="octocat")
+  record_id = "already-sent-guard"
+  repo = Path(get_settings().data_dir) / "contributions" / record_id / "repo"
+  (repo / ".git").mkdir(parents=True)
+  branch = "stack/demo-flow/01-model"
+  base = "b" * 40
+  head = "a" * 40
+  diff_text = "diff --git a/model.py b/model.py\n+reviewed\n"
+  diff_path = tmp_path / "layer.diff"
+  diff_path.write_text(diff_text)
+  record = {
+    "id": record_id,
+    "type": "pr",
+    "repo": "mobius-os/app-demo",
+    "status": "submitting",
+    "title": "Model layer",
+    "branch": branch,
+    "plan": {
+      "action": "pr",
+      "repo": "mobius-os/app-demo",
+      "title": "Model layer",
+      "body_draft": "Reviewed model layer.",
+      "branch": branch,
+      "repo_path": str(repo),
+      "base_sha": base,
+      "head_sha": head,
+      "diff_sha256": hashlib.sha256(diff_text.encode()).hexdigest(),
+    },
+  }
+  monkeypatch.setattr("app.routes.github.shutil.which", lambda name: f"/bin/{name}")
+  git_calls = []
+
+  def fake_git(repo_path, *args, check=True):
+    git_calls.append(args)
+    if (preflight := _submit_preflight_response(args)) is not None:
+      return preflight
+    if args == ("rev-parse", "--abbrev-ref", "HEAD"):
+      return _cp(branch + "\n")
+    if args == ("status", "--porcelain"):
+      return _cp("")
+    if args == ("rev-parse", branch) or args == ("rev-parse", "HEAD"):
+      return _cp(head + "\n")
+    if args == ("rev-parse", "--verify", f"{base}^{{commit}}"):
+      return _cp(base + "\n")
+    if args == ("rev-parse", "--verify", f"{head}^{{commit}}"):
+      return _cp(head + "\n")
+    if args[-1:] == (f"{base}..{head}",) and "diff" in args:
+      return _cp(diff_text)
+    if args == ("log", "-1", "--format=%B", branch):
+      return _cp(
+        "Model layer\n\n"
+        "Co-authored-by: Möbius Agent <mobius-agent@users.noreply.github.com>\n"
+      )
+    if args[:3] == (
+      "show", "-s", "--format=%H%x00%T%x00%an%x00%ae%x00%cn%x00%ce%x00%aI",
+    ):
+      return _commit_metadata(head)
+    return _cp("")
+
+  gh_calls = []
+
+  def fake_gh(repo_path, *args, check=True):
+    gh_calls.append(args)
+    if args[:2] == ("repo", "view"):
+      return _cp("main\n")
+    if args[:2] == ("pr", "list") and "all" in args:
+      # GitHub's truth: this exact branch was already sent and merged.
+      return _cp(json.dumps([_branch_pr_row(
+        "https://github.com/mobius-os/app-demo/pull/61",
+        "MERGED", branch, "mobius-os",
+      )]))
+    if args[:2] == ("pr", "list"):
+      return _cp("[]")
+    if args[:2] == ("pr", "create"):
+      raise AssertionError("a duplicate send must never reach pr create")
+    return _cp("")
+
+  monkeypatch.setattr("app.routes.github._git", fake_git)
+  monkeypatch.setattr("app.routes.github._gh", fake_gh)
+
+  with pytest.raises(ContributionSubmitError) as err:
+    _submit_prepared_pr(record, diff_path, direct_base_branch="main")
+
+  # The refusal names the public truth…
+  assert "pull/61" in err.value.message
+  assert "merged" in err.value.message
+  assert "Nothing was pushed" in err.value.message
+  # …and, unlike the pre-guard flow, nothing public was touched: no git push
+  # of any kind and no PR creation.
+  assert not any("push" in call for call in git_calls)
+  assert not any(call[:2] == ("pr", "create") for call in gh_calls)


### PR DESCRIPTION
## Problem

Every submit preflight in the contribution send flow proves **what** would be sent — the exact reviewed diff, branch, base, and commit identity. Only the agent-writable ledger record says **whether** it was already sent, and that record can regress: in a field incident (2026-07-29), a freshly-merged PR's record was rewritten back to `prepared` by a stale re-stage moments after the owner pressed Send. One more Send would have produced a duplicate public PR of already-merged work — and the current flow pushes the branch **first**, only learning at `pr create` that it is a duplicate, silently rewriting the existing PR's public branch on the way.

## Fix

A pre-push truth check in `_submit_prepared_pr`: before touching anything public, ask GitHub whether this exact branch (same head owner, same name) already has a pull request in the target repo.

- **Open or merged** → refuse before the push, naming the existing PR so the card can be reconciled (or the work re-staged on a fresh branch).
- **Closed without merging** → proceed: rework-and-resend of a rejected branch stays legitimate.
- **Lookup cannot complete** → fail closed with a retryable message; the send needs GitHub reachable anyway, so this adds no new failure mode.
- The resume path (`expected_existing_pr_number`) is exempt — it legitimately expects its open PR and keeps its stricter exact-commit verification.

GitHub is the one store that cannot drift from the public truth, so the last gate before publication consults it rather than trusting local bookkeeping.

## Verification

New tests cover state classification (open / merged / closed / foreign owner / foreign branch), open-outranking-merged in the refusal message, fail-closed lookup failures, and a full submit that must refuse **before any push**. Existing probe-count assertions were updated to distinguish the new `--state all` preflight from the ambiguous-create recovery probe. `tests/test_github_routes.py`: 128 pass; hermetic fast contract suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)