### PR TITLE
Keep drawer controls aligned across states

### DIFF
--- a/frontend/src/components/Drawer/Drawer.css
+++ b/frontend/src/components/Drawer/Drawer.css
@@ -170,28 +170,20 @@
 
 /* ── New chat ──────────────────────────────────────── */
 
-/* Outlined pill — visually distinct from the chat/app rows below
-   so a tap-friendly "start fresh" affordance reads as a primary
-   action, not just another list item. The hairline border sets it
-   apart; no horizontal margin so its left/right edges align with
-   the chat rows + Settings row (all at the drawer's 12px gutter).
-   Earlier the pill had `margin: 0 4px` which pushed its content
-   16px from the drawer edge while every other row was at 12px —
-   the misalignment read as a layout bug to the eye. New chat and Apps
-   are consecutive primary navigation actions, so they share the same
-   uninterrupted row rhythm. */
+/* Placement and weight distinguish the fixed primary action; keeping the base
+   row treatment makes New chat feel like part of the navigation rather than a
+   separate card. */
 .drawer__item--new {
   color: var(--text);
   font-weight: 500;
   margin: 0;
   padding: 11px 12px;
-  border: 1px solid var(--border);
+  min-height: 44px;
 }
 
 .drawer__item--new:hover {
   color: var(--text);
   background: var(--surface);
-  border-color: var(--border-light);
 }
 
 /* ── Navigation sections ──────────────────────────── */
@@ -781,8 +773,10 @@
    larger 15px labels preserve the rail's stronger visual weight when expanded.
    Mobile has no collapsed rail, so it keeps its existing compact drawer scale. */
 @media (min-width: 1024px) {
+  /* 58px drawer header + 8px body inset matches the collapsed rail's 66px
+     action start; the shared 40px row height keeps Apps aligned too. */
   .drawer__body {
-    padding: 12px 8px max(12px, env(safe-area-inset-bottom));
+    padding: 8px 8px max(12px, env(safe-area-inset-bottom));
   }
 
   .drawer__item,

--- a/frontend/src/components/Shell/Shell.css
+++ b/frontend/src/components/Shell/Shell.css
@@ -711,8 +711,8 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 8px;
-    margin-top: 58px;
+    gap: 0;
+    margin-top: 54px;
   }
 
   .shell__rail-action {
@@ -754,11 +754,24 @@
     display: none;
   }
 
+  /* Keep the panel within the drawer gutter while it is narrow, then move its
+     left edge so the capped panel continues to follow the resizable right edge. */
   .shell--drawer-docked .notifications {
+    --notifications-panel-max-width: 390px;
     top: 66px;
     right: auto;
-    left: 12px;
-    width: min(390px, calc(var(--desktop-sidebar-width) - 24px));
+    left: max(
+      12px,
+      calc(
+        var(--desktop-sidebar-width)
+        - var(--notifications-panel-max-width)
+        - 12px
+      )
+    );
+    width: min(
+      var(--notifications-panel-max-width),
+      calc(var(--desktop-sidebar-width) - 24px)
+    );
     max-height: calc(100dvh - 78px);
   }
 

--- a/frontend/src/components/Shell/__tests__/drawerAlignment.test.js
+++ b/frontend/src/components/Shell/__tests__/drawerAlignment.test.js
@@ -1,0 +1,43 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const drawerCss = readFileSync(new URL('../../Drawer/Drawer.css', import.meta.url), 'utf8')
+const shellCss = readFileSync(new URL('../Shell.css', import.meta.url), 'utf8')
+
+const ruleBody = (css, selector, occurrence = 0) => {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const matches = [...css.matchAll(new RegExp(`${escaped}\\s*\\{([^}]*)\\}`, 'g'))]
+  assert.ok(matches[occurrence], `Missing CSS rule: ${selector}`)
+  return matches[occurrence][1]
+}
+
+const px = (body, property) => {
+  const match = body.match(new RegExp(`${property}:\\s*(\\d+)px`))
+  assert.ok(match, `Missing pixel declaration: ${property}`)
+  return Number(match[1])
+}
+
+test('collapsed and expanded drawer actions share one vertical rhythm', () => {
+  const newChat = ruleBody(drawerCss, '.drawer__item--new')
+  const desktopDrawerBody = ruleBody(drawerCss, '.drawer__body', 1)
+  const desktopDrawerItem = ruleBody(drawerCss, '.drawer__item,\n  .drawer__item--new')
+  const desktopRail = ruleBody(shellCss, '.shell__rail-actions', 1)
+  const desktopRailAction = ruleBody(shellCss, '.shell__rail-action')
+
+  assert.equal(px(newChat, 'min-height'), 44)
+  assert.doesNotMatch(newChat, /(?:border|box-shadow)\s*:/)
+  assert.equal(58 + px(desktopDrawerBody, 'padding'), 12 + px(desktopRail, 'margin-top'))
+  assert.equal(px(desktopDrawerItem, 'min-height'), px(desktopRailAction, 'height'))
+  assert.match(
+    desktopRail,
+    /gap:\s*0;/,
+  )
+})
+
+test('the notifications panel follows the resizable drawer edge', () => {
+  assert.match(
+    shellCss,
+    /\.shell--drawer-docked \.notifications\s*\{[\s\S]*?--notifications-panel-max-width:\s*390px;[\s\S]*?left:\s*max\([\s\S]*?var\(--desktop-sidebar-width\)[\s\S]*?- var\(--notifications-panel-max-width\)[\s\S]*?width:\s*min\([\s\S]*?var\(--notifications-panel-max-width\)[\s\S]*?var\(--desktop-sidebar-width\)/,
+  )
+})


### PR DESCRIPTION
## Summary

- remove the card outline from New chat so the primary drawer actions share one visual treatment
- keep New chat and Apps on the same vertical rhythm when switching between the collapsed rail and expanded drawer
- keep notifications anchored to the resizable drawer edge
- add regression coverage for the shared geometry

This is a focused follow-up to [#359](https://github.com/mobius-os/mobius/pull/359), refining the navigation treatment after mixed Recents landed.

## Testing

- `npm test`
- `npm run build`