### PR TITLE
Restore mobile header divider

### DIFF
--- a/frontend/src/components/Shell/Shell.css
+++ b/frontend/src/components/Shell/Shell.css
@@ -75,7 +75,7 @@
   padding-left: 16px;
   padding-right: 16px;
   background: var(--bg); /* CONTRACT: opaque — bar floats above content, must hide whatever scrolls under it */
-  border-bottom: 0;
+  border-bottom: 1px solid var(--border-light); /* Phone header keeps a subtle edge; desktop removes it below. */
   position: relative;
   z-index: 100;
   -webkit-tap-highlight-color: transparent;

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -884,10 +884,14 @@ test('New chat and Apps share one compact navigation rhythm', () => {
   )
 })
 
-test('the Möbius header flows into navigation without a divider', () => {
+test('the Möbius header keeps its phone divider but flows into desktop navigation', () => {
   assert.match(
     shellCss,
-    /\.shell__bar\s*\{[\s\S]*?border-bottom:\s*0;/,
+    /\.shell__bar\s*\{[\s\S]*?border-bottom:\s*1px solid var\(--border-light\);/,
+  )
+  assert.match(
+    shellCss,
+    /@media \(min-width: 1024px\)[\s\S]*?\.shell__bar\s*\{[\s\S]*?border:\s*0;/,
   )
   assert.match(
     shellCss,


### PR DESCRIPTION
## Summary
- restore the subtle divider under the phone header
- keep desktop rail and docked sidebar headers borderless
- protect the responsive split with regression coverage

## Testing
- `node --test frontend/src/components/Shell/__tests__/workspaceUi.test.js`
- `npm run build`