### PR TITLE
Reveal running chats before replay settles

### DIFF
--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -1888,7 +1888,11 @@ export default function ChatView({
           chatInfo: nextChatInfo,
         }))
         if (serverSnapshotBehindLocal(msgs, messagesRef.current)) {
-          setInitialEntryPhase(data.running ? 'catch-up' : 'ready')
+          // The successful detail read is the authoritative entry frame even
+          // when a live tail still needs to catch up. Keeping that already
+          // useful transcript hidden until stream settlement turns the replay
+          // safety deadline into chat-navigation latency.
+          setInitialEntryPhase('ready')
           setLoading(false)
           return
         }
@@ -1922,7 +1926,7 @@ export default function ChatView({
           runningAtMount: !!data.running,
           lastMsgAtMount: msgs.length > 0 ? msgs[msgs.length - 1] : null,
         })
-        setInitialEntryPhase(data.running ? 'catch-up' : 'ready')
+        setInitialEntryPhase('ready')
         setLoading(false)
 
         // Hydrate pending queue from backend so a reload mid-queue
@@ -3372,18 +3376,8 @@ export default function ChatView({
   // only a commit bumps it, so this skips the initial mount.
   useLayoutEffect(() => {
     if (catchUpCommitSeq === 0) return
-    setInitialEntryPhase(phase => phase === 'catch-up' ? 'ready' : phase)
     reapplyActiveMode()
   }, [catchUpCommitSeq, reapplyActiveMode])
-
-  // A stale `running` history snapshot can be followed by an authoritative
-  // terminal response without a catch-up commit. Release the bounded entry
-  // gate instead of waiting for its safety deadline.
-  useEffect(() => {
-    if (initialEntryPhase === 'catch-up' && !turnActive) {
-      setInitialEntryPhase('ready')
-    }
-  }, [initialEntryPhase, turnActive])
 
   // Promotion and this sequence update share one React batch, so the terminal
   // pin decision runs after the settled assistant DOM is committed and before

--- a/frontend/src/components/Shell/__tests__/chatHandoff.test.js
+++ b/frontend/src/components/Shell/__tests__/chatHandoff.test.js
@@ -30,6 +30,27 @@ test('chat display readiness preserves the authoritative transcript reveal gate'
     'the callback dependency is the owner-change signal; a parallel mutable ref would obscure it')
 })
 
+test('authoritative running history releases the held chat before stream catch-up', () => {
+  const initialLoad = chatView.match(
+    /apiFetch\(`\/chats\/\$\{chatId\}\?limit=20&compact=1`,[\s\S]*?\n  \}, \[chatId, loadNonce, hidden\]\)/,
+  )?.[0] || ''
+  assert.match(
+    initialLoad,
+    /if \(serverSnapshotBehindLocal[\s\S]*setInitialEntryPhase\('ready'\)/,
+    'a useful local frame must be revealed after the authoritative detail read',
+  )
+  assert.match(
+    initialLoad,
+    /setInitialEntryPhase\('ready'\)[\s\S]*if \(data\.running\) \{[\s\S]*connectToStream\(false\)/,
+    'stream catch-up should continue after the persisted frame becomes paintable',
+  )
+  assert.doesNotMatch(
+    initialLoad,
+    /setInitialEntryPhase\(data\.running \? 'catch-up' : 'ready'\)/,
+    'a running marker must not turn replay settlement into navigation latency',
+  )
+})
+
 test('a staging chat cannot leave the outgoing transcript held on a wedged request', () => {
   assert.match(chatView, /const CHAT_FETCH_TIMEOUT_MS = 15000/)
   assert.match(

--- a/tests/frontend.spec.mjs
+++ b/tests/frontend.spec.mjs
@@ -967,7 +967,7 @@ test.describe('Scroll position', () => {
     expect(restored.scrollTop).toBeGreaterThan(0)
   })
 
-  test('10d. Previous-chat entry stays visually fixed through delayed history, image decode, and first catch-up', async ({ page }) => {
+  test('10d. Previous-chat entry reveals authoritative history before catch-up and stays visually fixed', async ({ page }) => {
     await setup(page, { width: 900, height: 760 })
     await newChat(page)
 
@@ -976,6 +976,7 @@ test.describe('Scroll position', () => {
 
     let returning = false
     let streamCount = 0
+    let catchUpServed = false
     let returnImageServed = false
     const squarePng = Buffer.from(
       'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wl2nWQAAAAASUVORK5CYII=',
@@ -1029,7 +1030,8 @@ test.describe('Scroll position', () => {
     await page.route(new RegExp(`/api/chats/${chatId}/stream$`), async route => {
       streamCount += 1
       if (streamCount > 1) return route.fulfill({ status: 204, body: '' })
-      await new Promise(resolve => setTimeout(resolve, 500))
+      await new Promise(resolve => setTimeout(resolve, 1200))
+      catchUpServed = true
       return route.fulfill({
         status: 200,
         headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
@@ -1122,7 +1124,8 @@ test.describe('Scroll position', () => {
         && !!img?.src.includes('entry-image-return.png') && !!img.complete
         && !!document.querySelector('[data-key="entry-anchor"]')
     }, { timeout: 10000 })
-    await page.waitForTimeout(500)
+    expect(catchUpServed).toBe(false)
+    await expect.poll(() => catchUpServed, { timeout: 3000 }).toBe(true)
 
     const trajectory = await page.evaluate(() => window.__entryTrajectory || [])
     const visibleRows = trajectory.filter(row => row.visible)


### PR DESCRIPTION
## Summary

- reveal authoritative saved chat history as soon as the detail read completes, including while a turn is running
- continue stream catch-up and scroll reapplication without making replay settlement block the chat handoff
- require the existing previous-chat entry browser test to reveal before delayed catch-up while remaining visually fixed

## Context

Follow-up to #360. That change improved transition appearance, but the held outgoing surface could remain visible until a running chat's replay settled, making navigation wait for the 1.5-second reveal deadline.

## Testing

- `node --test frontend/src/components/Shell/__tests__/chatHandoff.test.js`
- `npm test`
- `npm run build`
- manually verified New chat → existing running chat in single-screen desktop and phone-width layouts
- updated Playwright coverage runs in PR CI