### PR TITLE
Keep read-oriented control text selectable

### DIFF
--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -916,7 +916,10 @@
   min-height: 32px;
   padding: 5px 10px;
   cursor: pointer;
-  user-select: none;
+  /* This disclosure label is transcript content, not control chrome. */
+  user-select: text;
+  -webkit-user-select: text;
+  -webkit-touch-callout: default;
   background: none;
   border: 0;
   text-align: left;
@@ -2899,9 +2902,14 @@
   color: var(--text); /* CONTRACT: high-contrast text on opaque fill */
   cursor: pointer;
   min-width: 0;
+  /* Queued text is user-authored transcript content even though a long row is
+     also a disclosure control. Override the global button selection lock. */
+  user-select: text;
+  -webkit-user-select: text;
+  -webkit-touch-callout: default;
 }
 
-.queued__toggle:disabled {
+.queued__toggle--static {
   cursor: default;
 }
 

--- a/frontend/src/components/ChatView/QuestionCard.css
+++ b/frontend/src/components/ChatView/QuestionCard.css
@@ -119,6 +119,10 @@
   /* Press feedback on touch — a brief opacity dip on active is the
      low-cost equivalent of a scale transform without triggering layout. */
   -webkit-tap-highlight-color: transparent;
+  /* Choice labels and explanations are reading content as well as controls. */
+  user-select: text;
+  -webkit-user-select: text;
+  -webkit-touch-callout: default;
 }
 /* Option description — inline under the label (a title= tooltip is invisible
    on touch). Quiet by design: small, muted, left-aligned with the label. The
@@ -139,14 +143,14 @@
   color: var(--muted);
   line-height: 1.35;
 }
-.qcard__opt:active:not(:disabled) {
+.qcard__opt:active:not(.qcard__opt--static) {
   opacity: .75;
 }
 .qcard__opt:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
-.qcard__opt:hover:not(:disabled) {
+.qcard__opt:hover:not(.qcard__opt--static) {
   background: var(--surface2, rgba(128,128,128,.1));
 }
 .qcard__opt--on {
@@ -154,10 +158,10 @@
   color: var(--text);
   border-color: color-mix(in srgb, var(--accent) 42%, var(--border));
 }
-.qcard__opt--on:hover:not(:disabled) {
+.qcard__opt--on:hover:not(.qcard__opt--static) {
   background: color-mix(in srgb, var(--accent) 16%, var(--surface));
 }
-.qcard__opt:disabled {
+.qcard__opt--static {
   cursor: default;
   opacity: .6;
 }

--- a/frontend/src/components/ChatView/QuestionCard.jsx
+++ b/frontend/src/components/ChatView/QuestionCard.jsx
@@ -7,6 +7,10 @@ import {
   writeQuestionDraft,
 } from './questionDraft.js'
 import { textareaUsesNativeSizing } from './composerTextareaSizing.js'
+import {
+  pointerSelectionChangedWithin,
+  textSelectionSnapshot,
+} from '../../lib/selectableTextControl.js'
 
 
 function resolveAnswer(answer, otherText) {
@@ -121,6 +125,7 @@ export default function QuestionCard({
   const [submitting, setSubmitting] = useState(false)
   const [submitted, setSubmitted] = useState(false)
   const [submitError, setSubmitError] = useState('')
+  const pointerSelectionRef = useRef(null)
 
   const answered = submitted || !!answeredMap
   const displayAnswers = answeredMap || {}
@@ -309,15 +314,30 @@ export default function QuestionCard({
                     ? isChosen
                     : (isMulti ? selectedArr.includes(opt.label) : selected === opt.label)
                   const dimmed = answered && !isChosen
+                  const OptionSurface = inactive ? 'div' : 'button'
                   return (
-                    <button
+                    <OptionSurface
                       key={oi}
-                      type="button"
+                      type={inactive ? undefined : 'button'}
                       role={isMulti ? 'checkbox' : 'radio'}
                       aria-checked={isActive}
-                      className={`qcard__opt${isActive ? ' qcard__opt--on' : ''}${dimmed ? ' qcard__opt--dim' : ''}`}
-                      onClick={answered ? undefined : () => selectOption(q.question, opt.label)}
-                      disabled={inactive}
+                      aria-disabled={inactive || undefined}
+                      className={`qcard__opt${isActive ? ' qcard__opt--on' : ''}${dimmed ? ' qcard__opt--dim' : ''}${inactive ? ' qcard__opt--static' : ''}`}
+                      onPointerDown={inactive ? undefined : () => {
+                        pointerSelectionRef.current = textSelectionSnapshot()
+                      }}
+                      onClick={inactive ? undefined : (event) => {
+                        const selectionBeforePointer = pointerSelectionRef.current
+                        pointerSelectionRef.current = null
+                        if (
+                          event.detail !== 0
+                          && pointerSelectionChangedWithin(
+                            selectionBeforePointer,
+                            event.currentTarget,
+                          )
+                        ) return
+                        selectOption(q.question, opt.label)
+                      }}
                       title={opt.description || ''}
                     >
                       <span
@@ -335,7 +355,7 @@ export default function QuestionCard({
                       ) : (
                         opt.label
                       )}
-                    </button>
+                    </OptionSurface>
                   )
                 })
               })()}

--- a/frontend/src/components/ChatView/QueuedMessages.jsx
+++ b/frontend/src/components/ChatView/QueuedMessages.jsx
@@ -1,7 +1,11 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { ChevronDown, DoubleChevronRight, X } from '@openai/apps-sdk-ui/components/Icon'
 import { stripAugmentation } from './msgText.js'
 import { cidOf } from './chatRuntimeState.js'
+import {
+  pointerSelectionChangedWithin,
+  textSelectionSnapshot,
+} from '../../lib/selectableTextControl.js'
 
 const TRUNCATE_AT = 80
 
@@ -25,6 +29,7 @@ export default function QueuedMessages({
 }) {
   const [expanded, setExpanded] = useState(() => new Set())
   const [collapsed, setCollapsed] = useState(false)
+  const pointerSelectionRef = useRef(null)
 
   if (!items || items.length === 0) return null
 
@@ -101,6 +106,7 @@ export default function QueuedMessages({
             const preview = firstLine.length > TRUNCATE_AT
               ? firstLine.slice(0, TRUNCATE_AT) + '…'
               : firstLine + (text.includes('\n') ? ' …' : '')
+            const MessageSurface = needsTruncation ? 'button' : 'div'
 
             return (
               <div
@@ -108,14 +114,28 @@ export default function QueuedMessages({
                 className={`queued__row${isExpanded ? ' queued__row--expanded' : ''}`}
                 role="listitem"
               >
-                <button
-                  type="button"
-                  className="queued__toggle"
-                  onPointerDown={(e) => e.preventDefault()}
-                  onClick={() => needsTruncation && toggle(key)}
-                  aria-expanded={isExpanded}
-                  aria-label={isExpanded ? 'Collapse message' : 'Expand message'}
-                  disabled={!needsTruncation}
+                <MessageSurface
+                  type={needsTruncation ? 'button' : undefined}
+                  className={`queued__toggle${needsTruncation ? '' : ' queued__toggle--static'}`}
+                  onPointerDown={needsTruncation ? () => {
+                    pointerSelectionRef.current = textSelectionSnapshot()
+                  } : undefined}
+                  onClick={needsTruncation ? (event) => {
+                    const selectionBeforePointer = pointerSelectionRef.current
+                    pointerSelectionRef.current = null
+                    if (
+                      event.detail !== 0
+                      && pointerSelectionChangedWithin(
+                        selectionBeforePointer,
+                        event.currentTarget,
+                      )
+                    ) return
+                    toggle(key)
+                  } : undefined}
+                  aria-expanded={needsTruncation ? isExpanded : undefined}
+                  aria-label={needsTruncation
+                    ? (isExpanded ? 'Collapse message' : 'Expand message')
+                    : undefined}
                 >
                   {needsTruncation && (
                     <ChevronDown
@@ -128,7 +148,7 @@ export default function QueuedMessages({
                   <span className="queued__text">
                     {isExpanded ? text : preview}
                   </span>
-                </button>
+                </MessageSurface>
                 {steerActive && (
                   // Per-row fast-forward (owner ask, 2026-07-17): the same
                   // double-chevron as the composer's steer button, in the

--- a/frontend/src/components/ChatView/ToolBlock.jsx
+++ b/frontend/src/components/ChatView/ToolBlock.jsx
@@ -17,6 +17,10 @@ import {
   durableImageReference,
   toolImageReference,
 } from './toolImageResult.js'
+import {
+  pointerSelectionChangedWithin,
+  textSelectionSnapshot,
+} from '../../lib/selectableTextControl.js'
 
 // Render an already-formatted tool result (see toolResultFormat.js) so shell
 // output reads as a terminal (stdout / stderr / exit code) and a structured
@@ -105,6 +109,7 @@ function GenericToolBlock({ t, chatId, compact = false, disclosureKey }) {
   const [copyState, setCopyState] = useState('idle')
   const copyTimerRef = useRef(null)
   const copyControllerRef = useRef(null)
+  const pointerSelectionRef = useRef(null)
   const effectiveName = effectiveToolName(t)
   const isShell = effectiveName === 'Bash' || effectiveName === 'shell'
   const label = toolCallLabel(t)
@@ -368,7 +373,19 @@ function GenericToolBlock({ t, chatId, compact = false, disclosureKey }) {
           id={headerId}
           type="button"
           className="chat__tool-header"
-          onClick={() => {
+          onPointerDown={() => {
+            pointerSelectionRef.current = textSelectionSnapshot()
+          }}
+          onClick={(event) => {
+            const selectionBeforePointer = pointerSelectionRef.current
+            pointerSelectionRef.current = null
+            if (
+              event.detail !== 0
+              && pointerSelectionChangedWithin(
+                selectionBeforePointer,
+                headerRef.current,
+              )
+            ) return
             preserveTogglePosition(headerRef.current, detailRef.current)
             setOpen(o => !o)
           }}

--- a/frontend/src/components/ChatView/__tests__/chatUiPolish.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatUiPolish.test.js
@@ -215,3 +215,27 @@ test('queued row actions share full touch targets with compact visible wells', (
   assert.match(queuedMessages, /<DoubleChevronRight width=\{16\} height=\{16\}/)
   assert.match(queuedMessages, /<X width=\{16\} height=\{16\}/)
 })
+
+test('queued message content participates in native text selection', () => {
+  const css = stripComments(chatCss)
+  const toggleRule = css.match(/\.queued__toggle\s*\{[^}]*\}/)?.[0] || ''
+
+  assert.match(toggleRule, /user-select:\s*text/,
+    'desktop drag selection should include queued user text')
+  assert.match(toggleRule, /-webkit-user-select:\s*text/,
+    'WebKit should not inherit the global button selection lock')
+  assert.match(toggleRule, /-webkit-touch-callout:\s*default/,
+    'touch selection should keep the native action menu')
+  assert.match(queuedMessages, /const MessageSurface = needsTruncation \? 'button' : 'div'/,
+    'a non-disclosure queued message should be ordinary selectable content')
+  assert.match(
+    queuedMessages,
+    /event\.detail !== 0[\s\S]*pointerSelectionChangedWithin\([\s\S]*event\.currentTarget[\s\S]*\) return[\s\S]*toggle\(key\)/,
+    'selecting a long queued message must not also toggle its disclosure',
+  )
+  assert.doesNotMatch(
+    queuedMessages,
+    /className="queued__toggle"[\s\S]{0,160}onPointerDown=\{\(e\) => e\.preventDefault\(\)/,
+    'the queued message surface must not cancel selection at pointer-down',
+  )
+})

--- a/frontend/src/components/ChatView/__tests__/questionCardState.test.js
+++ b/frontend/src/components/ChatView/__tests__/questionCardState.test.js
@@ -7,6 +7,21 @@ const chatView = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8
 const scrollMode = readFileSync(new URL('../useScrollMode.js', import.meta.url), 'utf8')
 const css = readFileSync(new URL('../QuestionCard.css', import.meta.url), 'utf8')
 
+test('question option explanations remain selectable without choosing them', () => {
+  const optionRule = css.match(/\.qcard__opt\s*\{[^}]*\}/s)?.[0] || ''
+
+  assert.match(optionRule, /user-select:\s*text/)
+  assert.match(optionRule, /-webkit-user-select:\s*text/)
+  assert.match(optionRule, /-webkit-touch-callout:\s*default/)
+  assert.match(component, /const OptionSurface = inactive \? 'div' : 'button'/,
+    'answered or disabled options should become static selectable content')
+  assert.match(
+    component,
+    /event\.detail !== 0[\s\S]*pointerSelectionChangedWithin\([\s\S]*event\.currentTarget[\s\S]*\) return[\s\S]*selectOption/,
+    'a pointer selection should not also choose the live option',
+  )
+})
+
 test('unanswered question cards do not have a stale gray state', () => {
   assert.doesNotMatch(component, /const stale = disabled && !answered/,
     'QuestionCard should not model unanswered questions as stale')

--- a/frontend/src/components/ChatView/__tests__/toolBlockPresentation.test.js
+++ b/frontend/src/components/ChatView/__tests__/toolBlockPresentation.test.js
@@ -5,6 +5,7 @@ import assert from 'node:assert/strict'
 const toolBlock = readFileSync(new URL('../ToolBlock.jsx', import.meta.url), 'utf8')
 const activityHeader = readFileSync(new URL('../ActivityLineHeader.jsx', import.meta.url), 'utf8')
 const chatCss = readFileSync(new URL('../ChatView.css', import.meta.url), 'utf8')
+const indexCss = readFileSync(new URL('../../../index.css', import.meta.url), 'utf8')
 
 test('activity and child tool disclosures use icons without chevrons', () => {
   const activityIcon = activityHeader.indexOf('className="chat__activity-icon"')
@@ -19,6 +20,28 @@ test('activity and child tool disclosures use icons without chevrons', () => {
     'parent and tool rows should not render disclosure chevrons')
   assert.match(toolBlock, /aria-expanded=\{open\}/,
     'the real button communicates disclosure state')
+})
+
+test('tool call labels participate in native transcript text selection', () => {
+  const headerRule = chatCss.match(
+    /(?:^|\n)\.chat__tool-header\s*\{[^}]*\}/s,
+  )?.[0] || ''
+  assert.match(headerRule, /user-select:\s*text/,
+    'desktop drag selection should include the visible tool call')
+  assert.match(headerRule, /-webkit-user-select:\s*text/,
+    'WebKit should not inherit the global button selection lock')
+  assert.match(headerRule, /-webkit-touch-callout:\s*default/,
+    'touch selection keeps the native action menu')
+  assert.doesNotMatch(
+    indexCss,
+    /\.chat__tool-header\s*,\s*\.tool-block__header\s*\{[^}]*user-select:\s*none/s,
+    'the global chrome lock must not compete with the current disclosure owner',
+  )
+  assert.match(
+    toolBlock,
+    /onPointerDown=\{\(\) => \{[\s\S]*pointerSelectionRef\.current = textSelectionSnapshot\(\)[\s\S]*event\.detail !== 0[\s\S]*pointerSelectionChangedWithin\([\s\S]*headerRef\.current[\s\S]*\) return[\s\S]*preserveTogglePosition/,
+    'releasing a pointer selection must not also toggle the disclosure',
+  )
 })
 
 test('tool detail is a third nested level with labeled command and output', () => {

--- a/frontend/src/components/NotificationsView/NotificationsView.css
+++ b/frontend/src/components/NotificationsView/NotificationsView.css
@@ -119,6 +119,10 @@
 
 .notifications__row--link {
   cursor: pointer;
+  /* Notification title/body are reading content, not button chrome. */
+  user-select: text;
+  -webkit-user-select: text;
+  -webkit-touch-callout: default;
 }
 
 .notifications__row--link:hover {

--- a/frontend/src/components/NotificationsView/NotificationsView.jsx
+++ b/frontend/src/components/NotificationsView/NotificationsView.jsx
@@ -1,7 +1,11 @@
 import { Agent, Bell, Chat, Grid, SettingsSlider } from '@openai/apps-sdk-ui/components/Icon'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { notificationQueries } from '../../hooks/queries.js'
 import { parseNotificationTarget } from '../../lib/notificationTarget.js'
+import {
+  pointerSelectionChangedWithin,
+  textSelectionSnapshot,
+} from '../../lib/selectableTextControl.js'
 import { formatRelativeTime, iconKindForSource } from './notificationsModel.js'
 import './NotificationsView.css'
 
@@ -20,6 +24,7 @@ export default function NotificationsView({ active = false, onOpenTarget, onClea
   const { data, isLoading, isError } = notificationQueries.list.useQuery({ enabled: active })
   const rows = data ?? []
   const [now, setNow] = useState(() => Date.now())
+  const pointerSelectionRef = useRef(null)
   const [isClearing, setIsClearing] = useState(false)
   const [clearError, setClearError] = useState(false)
 
@@ -115,7 +120,21 @@ export default function NotificationsView({ active = false, onOpenTarget, onClea
                   <button
                     type="button"
                     className="notifications__row notifications__row--link"
-                    onClick={() => onOpenTarget?.(nav)}
+                    onPointerDown={() => {
+                      pointerSelectionRef.current = textSelectionSnapshot()
+                    }}
+                    onClick={(event) => {
+                      const selectionBeforePointer = pointerSelectionRef.current
+                      pointerSelectionRef.current = null
+                      if (
+                        event.detail !== 0
+                        && pointerSelectionChangedWithin(
+                          selectionBeforePointer,
+                          event.currentTarget,
+                        )
+                      ) return
+                      onOpenTarget?.(nav)
+                    }}
                   >
                     {body}
                   </button>

--- a/frontend/src/components/NotificationsView/__tests__/notificationsSelection.test.js
+++ b/frontend/src/components/NotificationsView/__tests__/notificationsSelection.test.js
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+
+const component = readFileSync(new URL('../NotificationsView.jsx', import.meta.url), 'utf8')
+const css = readFileSync(new URL('../NotificationsView.css', import.meta.url), 'utf8')
+
+test('linked notification content participates in native text selection', () => {
+  const rowRule = css.match(/\.notifications__row--link\s*\{[^}]*\}/s)?.[0] || ''
+
+  assert.match(rowRule, /user-select:\s*text/)
+  assert.match(rowRule, /-webkit-user-select:\s*text/)
+  assert.match(rowRule, /-webkit-touch-callout:\s*default/)
+  assert.match(
+    component,
+    /onPointerDown=\{\(\) => \{[\s\S]*textSelectionSnapshot\(\)[\s\S]*event\.detail !== 0[\s\S]*pointerSelectionChangedWithin\([\s\S]*event\.currentTarget[\s\S]*\) return[\s\S]*onOpenTarget/,
+    'releasing a pointer selection should not also open its notification target',
+  )
+})

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -515,9 +515,9 @@ textarea:focus-visible {
   -webkit-user-select: none;
 }
 
-/* Tool block header row (collapse toggle, status badge).  The block
-   body that shows code / tool output stays selectable. */
-.chat__tool-header,
+/* Legacy tool-block chrome stays non-selectable. Current chat tool
+   disclosures own their selection behavior in ChatView.css so the visible
+   call text can participate in an ordinary transcript selection. */
 .tool-block__header {
   user-select: none;
   -webkit-user-select: none;

--- a/frontend/src/lib/__tests__/selectableTextControl.test.js
+++ b/frontend/src/lib/__tests__/selectableTextControl.test.js
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import {
+  pointerSelectionChangedWithin,
+  textSelectionSnapshot,
+} from '../selectableTextControl.js'
+
+function selection({
+  anchorNode = {},
+  anchorOffset = 0,
+  focusNode = {},
+  focusOffset = 1,
+  intersects = true,
+  isCollapsed = false,
+  rangeCount = 1,
+} = {}) {
+  return {
+    anchorNode,
+    anchorOffset,
+    focusNode,
+    focusOffset,
+    isCollapsed,
+    rangeCount,
+    getRangeAt: () => ({ intersectsNode: () => intersects }),
+  }
+}
+
+test('textSelectionSnapshot ignores an absent or collapsed selection', () => {
+  assert.equal(textSelectionSnapshot(null), null)
+  assert.equal(textSelectionSnapshot(selection({ isCollapsed: true })), null)
+  assert.equal(textSelectionSnapshot(selection({ rangeCount: 0 })), null)
+})
+
+test('pointerSelectionChangedWithin detects a new selection in its control', () => {
+  const current = selection()
+
+  assert.equal(pointerSelectionChangedWithin(null, {}, current), true)
+  assert.equal(
+    pointerSelectionChangedWithin(textSelectionSnapshot(current), {}, current),
+    false,
+    'an unchanged selection must not suppress a later ordinary click',
+  )
+})
+
+test('pointerSelectionChangedWithin ignores selections outside the control', () => {
+  assert.equal(
+    pointerSelectionChangedWithin(null, {}, selection({ intersects: false })),
+    false,
+  )
+  assert.equal(pointerSelectionChangedWithin(null, null, selection()), false)
+})

--- a/frontend/src/lib/selectableTextControl.js
+++ b/frontend/src/lib/selectableTextControl.js
@@ -1,0 +1,46 @@
+/* Preserve native text selection inside controls without firing their action on pointer release. */
+
+export function textSelectionSnapshot(
+  selection = globalThis.getSelection?.(),
+) {
+  if (!selection || selection.isCollapsed || selection.rangeCount === 0) {
+    return null
+  }
+  return [
+    selection.anchorNode,
+    selection.anchorOffset,
+    selection.focusNode,
+    selection.focusOffset,
+  ]
+}
+
+function selectionSnapshotsMatch(left, right) {
+  return left === right || (
+    !!left
+    && !!right
+    && left.every((value, index) => value === right[index])
+  )
+}
+
+export function pointerSelectionChangedWithin(
+  selectionBeforePointer,
+  node,
+  selection = globalThis.getSelection?.(),
+) {
+  if (
+    !node
+    || !selection
+    || selection.isCollapsed
+    || selection.rangeCount === 0
+    || selectionSnapshotsMatch(
+      selectionBeforePointer,
+      textSelectionSnapshot(selection),
+    )
+  ) return false
+
+  try {
+    return selection.getRangeAt(0).intersectsNode(node)
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## Summary
- allow native text selection in queued messages, question choices, notification content, and tool call disclosures
- avoid triggering expand, choose, or navigation actions when a pointer drag creates a selection
- share one selection-change guard across these read-oriented controls
- remove a conflicting global selection rule so tool disclosures have one clear style owner

## Testing
- `npm test`
- `npm run build`
- manually drag-selected queued message text in the live shell without collapsing the row