### PR TITLE
Keep drawer labels steady on press

### DIFF
--- a/frontend/src/components/Drawer/Drawer.css
+++ b/frontend/src/components/Drawer/Drawer.css
@@ -322,6 +322,14 @@
   background: var(--accent-dim);
 }
 
+/* Press feedback stays on the row surface rather than scaling the button.
+   Scaling a drawer row rasterizes its text at a transient smaller size, which
+   makes chat names visibly shrink and grow during otherwise unrelated chat
+   handoffs. The selected row already has its own steady accent wash. */
+.drawer__item:not(.drawer__item--active):active {
+  background-color: var(--surface);
+}
+
 /* The lifted row while it is being dragged to a new spot. It reads as "picked
    up" — raised surface + shadow — rather than faded, so the movement is legible.
    The vertical follow/settle transform lives on the parent .drawer__row. */

--- a/frontend/src/components/Shell/__tests__/chatHandoff.test.js
+++ b/frontend/src/components/Shell/__tests__/chatHandoff.test.js
@@ -5,6 +5,7 @@ import assert from 'node:assert/strict'
 const shell = readFileSync(new URL('../Shell.jsx', import.meta.url), 'utf8')
 const shellCss = readFileSync(new URL('../Shell.css', import.meta.url), 'utf8')
 const drawerCss = readFileSync(new URL('../../Drawer/Drawer.css', import.meta.url), 'utf8')
+const indexCss = readFileSync(new URL('../../../index.css', import.meta.url), 'utf8')
 const chatSurfaceModel = readFileSync(new URL('../chatSurfaceModel.js', import.meta.url), 'utf8')
 const workspaceChrome = readFileSync(new URL('../WorkspaceChrome.jsx', import.meta.url), 'utf8')
 const chatView = readFileSync(new URL('../../ChatView/ChatView.jsx', import.meta.url), 'utf8')
@@ -150,10 +151,17 @@ test('the held chat is an opaque layer above staging until the atomic swap', () 
 
 test('chat selection settles without flashing or crossfading text layers', () => {
   const drawerItem = ruleBody('.drawer__item', drawerCss)
+  const drawerPress = ruleBody('.drawer__item:not(.drawer__item--active):active', drawerCss)
   assert.equal(
     drawerItem.match(/transition:\s*([^;]+);/)?.[1],
     'background-color 0.12s',
     'the selected title color must snap instead of tweening its glyphs')
+  assert.doesNotMatch(indexCss, /\.drawer__item:active\b/,
+    'drawer press feedback must stay out of the global scale contract')
+  assert.match(drawerPress, /background-color:\s*var\(--surface\)/,
+    'an unselected row should retain quiet press feedback')
+  assert.doesNotMatch(drawerPress, /transform:/,
+    'drawer press feedback must keep the row geometry fixed')
 
   assert.match(ruleBody('.shell__chat-view > .chat'), /transition:\s*opacity 90ms ease-out/,
     'the ready transcript should settle on its existing mounted surface')

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -404,11 +404,11 @@ textarea:focus-visible {
    transcript stays visually still while the scroll state machine works. */
 
 /* Tap feedback on shell-bar buttons. Component-specific transitions
-   for .chat__send, .chat__mic, .chat__stop, .drawer__item live in
-   their own CSS files — `transition` is a shorthand that REPLACES,
-   not extends, so listing them here would clobber the component
-   contracts. The :active scale below still applies via the per-class
-   selectors. */
+   for .chat__send, .chat__mic, and .chat__stop live in their own CSS
+   files — `transition` is a shorthand that REPLACES, not extends, so
+   listing them here would clobber the component contracts. Drawer rows
+   deliberately keep their glyph geometry fixed and use a background wash
+   for press feedback instead (Drawer.css). */
 .shell__bar button {
   transition: transform 100ms ease, background 180ms ease,
               color 180ms ease, border-color 180ms ease,
@@ -416,7 +416,6 @@ textarea:focus-visible {
 }
 .chat__send:active,
 .chat__mic:active,
-.drawer__item:active,
 .shell__bar button:active {
   transform: scale(0.96);
 }


### PR DESCRIPTION
## Summary

- keep drawer rows and labels at a stable scale while pressed
- preserve press feedback with a quiet background wash
- add regression coverage that keeps drawer press styling out of the global scale rule

## Testing

- `npm test`
- `npm run build`