### PR TITLE
Fix notification menu responsiveness and clearing

### DIFF
--- a/frontend/src/components/NotificationBell/NotificationBell.css
+++ b/frontend/src/components/NotificationBell/NotificationBell.css
@@ -17,9 +17,14 @@
   cursor: pointer;
 }
 
-.notification-bell:hover,
 .notification-bell--active {
   background: var(--surface);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .notification-bell:hover {
+    background: var(--surface);
+  }
 }
 
 .notification-bell:focus-visible {

--- a/frontend/src/components/NotificationBell/NotificationCenter.jsx
+++ b/frontend/src/components/NotificationBell/NotificationCenter.jsx
@@ -1,0 +1,51 @@
+/* NotificationCenter owns the bell and preview so toggling this small overlay
+   never asks the workspace shell to render again. */
+import { forwardRef, useCallback, useImperativeHandle } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import NotificationsView from '../NotificationsView/NotificationsView.jsx'
+import NotificationBell from './NotificationBell.jsx'
+import useNotificationCenter from './useNotificationCenter.js'
+
+const NotificationCenter = forwardRef(function NotificationCenter(
+  { onOpenTarget },
+  eventActionsRef,
+) {
+  const queryClient = useQueryClient()
+  const {
+    state: { open, unreadCount },
+    actions: { toggle, close, clearAll, reconcile, onCreated },
+    meta: { rootRef, bellRef },
+  } = useNotificationCenter(queryClient)
+
+  // System events stay a narrow nudge from Shell while all interactive state
+  // remains local to this component.
+  useImperativeHandle(eventActionsRef, () => ({
+    reconcile,
+    onCreated,
+  }), [onCreated, reconcile])
+
+  const openTarget = useCallback((target) => {
+    close()
+    onOpenTarget?.(target)
+  }, [close, onOpenTarget])
+
+  return (
+    <div ref={rootRef} className="notification-center">
+      <NotificationBell
+        buttonRef={bellRef}
+        unreadCount={unreadCount}
+        active={open}
+        onClick={toggle}
+      />
+      {open && (
+        <NotificationsView
+          active
+          onOpenTarget={openTarget}
+          onClearAll={clearAll}
+        />
+      )}
+    </div>
+  )
+})
+
+export default NotificationCenter

--- a/frontend/src/components/NotificationsView/NotificationsView.css
+++ b/frontend/src/components/NotificationsView/NotificationsView.css
@@ -43,22 +43,10 @@
   cursor: pointer;
 }
 
-.notifications__clear-actions {
-  display: flex;
-  align-items: center;
-  margin-left: auto;
-}
-
-.notifications__clear-actions .notifications__clear {
-  margin-left: 0;
-}
-
-.notifications__clear--confirm {
-  color: var(--danger);
-}
-
-.notifications__clear:hover:not(:disabled) {
-  background: var(--surface);
+@media (hover: hover) and (pointer: fine) {
+  .notifications__clear:hover:not(:disabled) {
+    background: var(--surface);
+  }
 }
 
 .notifications__clear:disabled {
@@ -69,31 +57,6 @@
 .notifications__clear:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
-}
-
-.notifications__close {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 44px;
-  height: 44px;
-  margin-left: 2px;
-  padding: 0;
-  border: 0;
-  border-radius: 10px;
-  background: transparent;
-  color: var(--muted);
-  cursor: pointer;
-}
-
-.notifications__close:hover {
-  background: var(--surface);
-  color: var(--text);
-}
-
-.notifications__close:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: -2px;
 }
 
 .notifications__content {

--- a/frontend/src/components/NotificationsView/NotificationsView.jsx
+++ b/frontend/src/components/NotificationsView/NotificationsView.jsx
@@ -1,4 +1,4 @@
-import { Agent, Bell, Chat, Grid, SettingsSlider, X } from '@openai/apps-sdk-ui/components/Icon'
+import { Agent, Bell, Chat, Grid, SettingsSlider } from '@openai/apps-sdk-ui/components/Icon'
 import { useEffect, useState } from 'react'
 import { notificationQueries } from '../../hooks/queries.js'
 import { parseNotificationTarget } from '../../lib/notificationTarget.js'
@@ -16,13 +16,12 @@ const ICONS = {
 // A deliberately small shell preview, not a new navigation world. TRUST:
 // app-authored title/body stay plain text, app-authored icon URLs are ignored,
 // and targets pass through the fail-closed shared parser before navigation.
-export default function NotificationsView({ active = false, onClose, onOpenTarget, onClearAll }) {
+export default function NotificationsView({ active = false, onOpenTarget, onClearAll }) {
   const { data, isLoading, isError } = notificationQueries.list.useQuery({ enabled: active })
   const rows = data ?? []
   const [now, setNow] = useState(() => Date.now())
   const [isClearing, setIsClearing] = useState(false)
   const [clearError, setClearError] = useState(false)
-  const [confirmClear, setConfirmClear] = useState(false)
 
   // Relative labels are live information, not a one-time formatting pass.
   // Refreshing once a minute keeps an open preview from saying "now" forever.
@@ -38,8 +37,7 @@ export default function NotificationsView({ active = false, onClose, onOpenTarge
     setIsClearing(true)
     setClearError(false)
     try {
-      await onClearAll?.()
-      setConfirmClear(false)
+      await onClearAll()
     } catch {
       setClearError(true)
     } finally {
@@ -58,46 +56,15 @@ export default function NotificationsView({ active = false, onClose, onOpenTarge
           Notifications
         </h2>
         {rows.length > 0 && (
-          confirmClear ? (
-            <div className="notifications__clear-actions" role="group" aria-label="Confirm clearing notifications">
-              <button
-                type="button"
-                className="notifications__clear"
-                onClick={() => setConfirmClear(false)}
-                disabled={isClearing}
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                className="notifications__clear notifications__clear--confirm"
-                onClick={handleClearAll}
-                disabled={isClearing}
-              >
-                {isClearing ? 'Clearing…' : 'Confirm clear'}
-              </button>
-            </div>
-          ) : (
-            <button
-              type="button"
-              className="notifications__clear"
-              onClick={() => {
-                setClearError(false)
-                setConfirmClear(true)
-              }}
-            >
-              Clear all
-            </button>
-          )
+          <button
+            type="button"
+            className="notifications__clear"
+            onClick={handleClearAll}
+            disabled={isClearing}
+          >
+            {isClearing ? 'Clearing…' : 'Clear all'}
+          </button>
         )}
-        <button
-          type="button"
-          className="notifications__close"
-          aria-label="Close notifications"
-          onClick={onClose}
-        >
-          <X width={18} height={18} aria-hidden="true" />
-        </button>
       </div>
       <div className="notifications__content">
         {isLoading && (

--- a/frontend/src/components/NotificationsView/__tests__/notificationsActions.test.js
+++ b/frontend/src/components/NotificationsView/__tests__/notificationsActions.test.js
@@ -1,0 +1,19 @@
+/* Notification actions stay lightweight: one-step clear and no redundant close control. */
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const component = readFileSync(new URL('../NotificationsView.jsx', import.meta.url), 'utf8')
+const css = readFileSync(new URL('../NotificationsView.css', import.meta.url), 'utf8')
+
+test('notification header clears immediately and closes through the bell boundary', () => {
+  assert.match(component, /onClick=\{handleClearAll\}/)
+  assert.match(component, /await onClearAll\(\)/)
+  assert.match(component, /isClearing \? 'Clearing…' : 'Clear all'/)
+  assert.doesNotMatch(component, /confirmClear|Confirm clear|Close notifications/)
+  assert.doesNotMatch(css, /notifications__clear-actions|notifications__close/)
+  assert.match(
+    css,
+    /@media \(hover: hover\) and \(pointer: fine\)[\s\S]*?\.notifications__clear:hover/,
+  )
+})

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -10,9 +10,7 @@ import Drawer from '../Drawer/Drawer.jsx'
 import Toast from '../ui/Toast.jsx'
 import AppCanvas from '../AppCanvas/AppCanvas.jsx'
 import WalkthroughOverlay from '../Walkthrough/WalkthroughOverlay.jsx'
-import NotificationBell from '../NotificationBell/NotificationBell.jsx'
-import useNotificationCenter from '../NotificationBell/useNotificationCenter.js'
-import NotificationsView from '../NotificationsView/NotificationsView.jsx'
+import NotificationCenter from '../NotificationBell/NotificationCenter.jsx'
 import {
   api, apiFetch, jsonOrThrow, probeDeletion, BASE, clearAppRuntimeData,
   invalidateShellListCache,
@@ -658,17 +656,13 @@ export default function Shell() {
       // this session; the next live list fetch restores server truth.
       .catch(() => {})
   }, [activeAppId, activeView, queryClient])
-  const {
-    state: { open: notificationsOpen, unreadCount: notificationUnreadCount },
-    actions: {
-      toggle: toggleNotifications,
-      close: closeNotifications,
-      clearAll: clearNotifications,
-      reconcile: reconcileNotifications,
-      onCreated: onNotificationCreated,
-    },
-    meta: { rootRef: notificationCenterRef, bellRef: notificationBellRef },
-  } = useNotificationCenter(queryClient)
+  const notificationCenterActionsRef = useRef(null)
+  const reconcileNotifications = useCallback(() => {
+    notificationCenterActionsRef.current?.reconcile()
+  }, [])
+  const onNotificationCreated = useCallback(() => {
+    notificationCenterActionsRef.current?.onCreated()
+  }, [])
   // Confirmed writes outrank offline-capable list reads. These session-scoped
   // tombstones filter every query completion (including an in-flight,
   // pre-delete NetworkFirst fallback) until a recovery succeeds.
@@ -2399,13 +2393,12 @@ export default function Shell() {
   })
 
   const handleNotificationOpen = useCallback((target) => {
-    closeNotifications()
     if (target?.view === 'canvas') {
       void openAppWithIntent(target.app, target.intent)
     } else if (target?.view === 'chat') {
       navToRef.current('chat', { chatId: target.chatId })
     }
-  }, [closeNotifications, openAppWithIntent])
+  }, [openAppWithIntent])
 
   const coldDeepLinkHandledRef = useRef(false)
   useEffect(() => {
@@ -3739,22 +3732,10 @@ export default function Shell() {
               Offline
             </span>
           )}
-          <div ref={notificationCenterRef} className="notification-center">
-            <NotificationBell
-              buttonRef={notificationBellRef}
-              unreadCount={notificationUnreadCount}
-              active={notificationsOpen}
-              onClick={toggleNotifications}
-            />
-            {notificationsOpen && (
-              <NotificationsView
-                active
-                onClose={closeNotifications}
-                onOpenTarget={handleNotificationOpen}
-                onClearAll={clearNotifications}
-              />
-            )}
-          </div>
+          <NotificationCenter
+            ref={notificationCenterActionsRef}
+            onOpenTarget={handleNotificationOpen}
+          />
         </div>
       </header>
 

--- a/frontend/src/components/Shell/__tests__/notificationCenterOwnership.test.js
+++ b/frontend/src/components/Shell/__tests__/notificationCenterOwnership.test.js
@@ -1,0 +1,38 @@
+/* Notification-center interaction stays below Shell's workspace render boundary. */
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const shell = readFileSync(new URL('../Shell.jsx', import.meta.url), 'utf8')
+const center = readFileSync(
+  new URL('../../NotificationBell/NotificationCenter.jsx', import.meta.url),
+  'utf8',
+)
+const bellCss = readFileSync(
+  new URL('../../NotificationBell/NotificationBell.css', import.meta.url),
+  'utf8',
+)
+
+test('notification toggles are owned below the workspace shell', () => {
+  assert.doesNotMatch(shell, /useNotificationCenter/)
+  assert.match(
+    shell,
+    /<NotificationCenter\s+ref=\{notificationCenterActionsRef\}/,
+  )
+  assert.match(center, /useNotificationCenter\(queryClient\)/)
+  assert.match(center, /useImperativeHandle\(eventActionsRef/)
+})
+
+test('closed bell hover styling only applies to precise pointing devices', () => {
+  const baseActiveRule = bellCss.match(/\.notification-bell--active\s*\{[^}]*\}/s)?.[0] || ''
+  const preciseHoverRule = bellCss.match(
+    /@media \(hover: hover\) and \(pointer: fine\)\s*\{[\s\S]*?\.notification-bell:hover\s*\{[^}]*\}[\s\S]*?\}/,
+  )?.[0] || ''
+
+  assert.match(baseActiveRule, /background:\s*var\(--surface\)/)
+  assert.match(preciseHoverRule, /background:\s*var\(--surface\)/)
+  assert.doesNotMatch(
+    bellCss.slice(0, bellCss.indexOf('@media (hover: hover)')),
+    /\.notification-bell:hover/,
+  )
+})

--- a/tests/notifications.spec.mjs
+++ b/tests/notifications.spec.mjs
@@ -122,23 +122,20 @@ test('bell opens a bounded preview and seen-on-open clears its badge', async ({ 
   await expect(page.locator('.notification-bell__badge')).toHaveCount(0)
   await expect(bell).toHaveAttribute('aria-expanded', 'true')
 
-  await page.locator('.notifications__close').click()
+  await expect(page.locator('.notifications__close')).toHaveCount(0)
+  await page.locator('.notification-bell').click()
   await expect(page.locator('.notifications')).toBeHidden()
   await expect(bell).toHaveAttribute('aria-expanded', 'false')
 })
 
-test('clear all requires confirmation, then removes the preview rows and badge', async ({ page }) => {
+test('clear all immediately removes the preview rows and badge', async ({ page }) => {
   const state = await mockNotifications(page)
   await setup(page)
   await openPreview(page)
 
   await expect(page.locator('.notifications__row')).toHaveCount(2)
   await page.getByRole('button', { name: 'Clear all' }).click()
-  await expect(page.getByRole('button', { name: 'Confirm clear' })).toBeVisible()
-  expect(state.deleteCalls).toBe(0)
-  await expect(page.locator('.notifications__row')).toHaveCount(2)
-  await page.getByRole('button', { name: 'Confirm clear' }).click()
-  expect(state.deleteCalls).toBe(1)
+  await expect.poll(() => state.deleteCalls).toBe(1)
   await expect(page.locator('.notifications__row')).toHaveCount(0)
   await expect(page.locator('.notifications__empty')).toBeVisible()
   await expect(page.locator('.notification-bell__badge')).toHaveCount(0)


### PR DESCRIPTION
## Summary

- Keep notification menu interaction state below the workspace shell so opening and closing the preview does not re-render the full workspace.
- Limit bell and clear-action hover feedback to precise pointers, preventing touch taps from leaving controls highlighted.
- Remove the redundant close icon and make **Clear all** immediate while preserving bell, outside-click, and Escape dismissal plus inline failure feedback.

## Context

Follow-up to #362, which introduced **Clear all**. This refines that interaction without changing the notification API or persistence behavior.

## Tests

- `npm test` — 2,254 passing
- `npm run build`
- Authenticated browser smoke check with mocked notification reads and deletion