### PR TITLE
Preserve proven changes through update conflicts

### DIFF
--- a/backend/app/app_git.py
+++ b/backend/app/app_git.py
@@ -185,6 +185,10 @@ class MergeResult:
   back. `status` is 'conflict' when at least one tracked file conflicted;
   `conflict_paths` names them and `merged_tree_oid` is None — the caller must NOT
   write anything, leaving the local edits intact for an agent to resolve.
+  `merge_base_oid` is normally None. When reviewed contribution provenance
+  proves a newer semantic base but a later genuine conflict remains, it names
+  that synthetic base tree so the owner-gated resolver can materialize only the
+  residual conflicts instead of repeating Git's older historical conflict set.
 
   There is one path for one and many files: a single-file app is just a tree
   with one source key (`index.jsx`), so the caller always reads the merged tree
@@ -193,6 +197,7 @@ class MergeResult:
   status: str
   conflict_paths: list[str] = field(default_factory=list)
   merged_tree_oid: str | None = None
+  merge_base_oid: str | None = None
   equivalent_change_refs: tuple[str, ...] = ()
 
 
@@ -1065,13 +1070,15 @@ def merge_with_equivalent_changes(
   ``upstream`` *and still contains the exact reviewed delta* (or strict
   tree-subsumption proves the latter directly against the target when GitHub
   could not provide a merge oid). A final off-tree merge with that semantic
-  base is accepted only when Git itself produces a clean tree. No ref or
-  working tree moves here; callers keep their existing rollback transaction.
+  base returns either a clean tree or the strictly reduced residual conflict
+  set plus the semantic base needed to materialize it. No ref or working tree
+  moves here; callers keep their existing rollback transaction.
 
   Anchors are applied in deterministic passes.  A dependent anchor that cannot
   merge onto the current shared tree is deferred until another anchor supplies
   its prerequisite.  Any anchor still unprovable is simply omitted; the final
-  merge then remains conflicted and the existing agent fallback owns it.
+  merge then remains conflicted and the owner-gated agent fallback owns only
+  those residual paths.
   """
   repo = Path(source_dir)
   real_base = _run(repo, "merge-base", local, upstream, check=False)
@@ -1120,8 +1127,11 @@ def merge_with_equivalent_changes(
     merged = merge_refs(repo, local, upstream, merge_base=shared_tree)
   except (OSError, subprocess.SubprocessError, RuntimeError):
     return None
-  if merged.status != "clean" or not merged.merged_tree_oid:
+  if merged.status not in {"clean", "conflict"}:
     return None
+  if merged.status == "clean" and not merged.merged_tree_oid:
+    return None
+  merged.merge_base_oid = shared_tree
   merged.equivalent_change_refs = tuple(change.ref for change in applied)
   return merged
 
@@ -1939,7 +1949,13 @@ def read_tree_exec_paths(
   return frozenset(out)
 
 
-def start_conflict_merge(source_dir: str | Path) -> list[str]:
+def start_conflict_merge(
+  source_dir: str | Path,
+  *,
+  merge_base: str | None = None,
+  local_branch: str = LOCAL_BRANCH,
+  upstream_branch: str = UPSTREAM_BRANCH,
+) -> list[str]:
   """Starts a REAL merge of `upstream` into the working tree on `main`.
 
   Unlike `merge_upstream` (an in-memory verdict that never touches the tree),
@@ -1955,17 +1971,99 @@ def start_conflict_merge(source_dir: str | Path) -> list[str]:
   pre-merge (committed local) state. Call only after `merge_upstream` verdicted
   a conflict, and under `source_dir_lock`.
 
+  When ``merge_base`` is supplied, it is the proven semantic base returned by
+  :func:`merge_with_equivalent_changes`. Git's ordinary merge command cannot
+  accept an explicit base, so this path performs the same three-tree merge in
+  the real index with ``read-tree -m -u``, writes conflict markers, and records
+  the normal MERGE_HEAD/ORIG_HEAD state. Abort/finalize therefore remain the
+  same as an ordinary merge while already-landed contribution conflicts stay
+  eliminated for both platform and app resolvers.
+
   Returns the conflicting repo-relative paths. In the pathological case where
-  the real merge resolves clean (it shares ort machinery with `merge_upstream`,
-  so they agree in practice), the in-progress merge is aborted and an empty list
-  is returned so the caller never strands a half-merge.
+  the materialized merge resolves clean, it resets to the committed local state
+  and returns an empty list so the caller never strands a half-merge.
   """
   repo = Path(source_dir)
   ensure_repo(repo)
-  _unshallow_if_no_merge_base(repo)
-  merged = _run(
-    repo, "merge", "--no-commit", "--no-ff", UPSTREAM_BRANCH, check=False,
-  )
+  _unshallow_if_no_merge_base(repo, local_branch, upstream_branch)
+  local_sha = head_sha(repo, local_branch)
+  upstream_sha = head_sha(repo, upstream_branch)
+  if _run(repo, "status", "--porcelain").stdout.strip():
+    raise RuntimeError("cannot start conflict merge with local source edits")
+  if merge_base is None:
+    merged = _run(
+      repo, "merge", "--no-commit", "--no-ff", upstream_branch, check=False,
+    )
+  else:
+    verdict = merge_refs(
+      repo, local_branch, upstream_branch, merge_base=merge_base,
+    )
+    if verdict.status != "conflict" or not verdict.conflict_paths:
+      return []
+    try:
+      # read-tree resolves every clean path directly and leaves only residual
+      # conflicts as staged 1/2/3 entries. The follow-up checkout writes the
+      # familiar markers without collapsing the unmerged index, so binary
+      # conflicts remain gated by has_unresolved_binary_conflicts.
+      _run(
+        repo, "read-tree", "-m", "-u",
+        merge_base, local_branch, upstream_branch,
+      )
+      # read-tree prepares the exact three-stage index but deliberately does
+      # only trivial whole-blob resolution. Run Git's standard content driver
+      # so disjoint hunks inside one file merge cleanly; a nonzero result is
+      # expected while any genuine conflict remains and is classified below.
+      _run(
+        repo, "merge-index", "-o", "git-merge-one-file", "-a", check=False,
+      )
+      stages_by_path: dict[str, set[int]] = {}
+      for row in _run(repo, "ls-files", "-u", "-z").stdout.split("\0"):
+        if "\t" not in row:
+          continue
+        meta, path = row.split("\t", 1)
+        try:
+          stage = int(meta.rsplit(" ", 1)[1])
+        except (IndexError, ValueError):
+          continue
+        stages_by_path.setdefault(path, set()).add(stage)
+      # git-merge-one-file predates Git's modern merge engine and leaves a
+      # stage-1-only entry when both sides deleted the same path (it can even
+      # misdescribe this as a delete/mode conflict). The off-tree verdict
+      # correctly treats that as clean, so finish that unambiguous deletion
+      # before exposing the real residual set.
+      for path, stages in stages_by_path.items():
+        if stages == {1}:
+          _run(repo, "update-index", "--force-remove", "--", path)
+      unresolved = sorted(
+        path for path, stages in stages_by_path.items() if stages != {1}
+      )
+      if unresolved:
+        # Limit marker checkout to paths that remain unmerged. A blanket "."
+        # also consults Git's resolve-undo cache and can resurrect conflicts
+        # that merge-index just resolved cleanly inside the same file. Render
+        # each path independently because delete/modify and binary conflicts
+        # legitimately have no pair of text blobs from which Git can write
+        # markers. Their nonzero checkout is expected: the three-stage index
+        # remains the authoritative unresolved state while other text paths
+        # still receive familiar markers for the resolver.
+        for path in unresolved:
+          _run(
+            repo, "checkout", "--conflict=merge", "--", path, check=False,
+          )
+      _run(repo, "update-ref", "ORIG_HEAD", local_sha)
+      git_dir = repo / ".git"
+      (git_dir / "MERGE_HEAD").write_text(upstream_sha + "\n")
+      (git_dir / "MERGE_MSG").write_text(
+        f"Merge {upstream_branch} with reviewed contribution base\n"
+      )
+      merged = subprocess.CompletedProcess(
+        args=("git", "read-tree"), returncode=1, stdout="", stderr="",
+      )
+    except Exception:
+      _run(repo, "reset", "--hard", local_sha, check=False)
+      for name in ("MERGE_HEAD", "MERGE_MSG", "MERGE_MODE"):
+        (repo / ".git" / name).unlink(missing_ok=True)
+      raise
   # Unmerged paths show in `git status --porcelain` with a U in either status
   # column (UU/AU/UA/UD/DU) or the AA/DD both-added/both-deleted codes.
   status = _run(repo, "status", "--porcelain").stdout
@@ -1978,9 +2076,11 @@ def start_conflict_merge(source_dir: str | Path) -> list[str]:
     detail = merged.stderr.strip() or merged.stdout.strip()
     raise RuntimeError(f"git merge failed (rc={merged.returncode}): {detail}")
   if not conflict_paths and (repo / ".git" / "MERGE_HEAD").exists():
-    # Real merge resolved clean (vs the conflict verdict). Don't strand a
-    # dangling --no-commit merge; abort back to the committed local state.
-    _run(repo, "merge", "--abort", check=False)
+    # Real/explicit-base materialization resolved clean despite the earlier
+    # verdict. Don't strand a dangling merge; restore the committed local state.
+    _run(repo, "reset", "--hard", local_sha, check=False)
+    for name in ("MERGE_HEAD", "MERGE_MSG", "MERGE_MODE"):
+      (repo / ".git" / name).unlink(missing_ok=True)
   return conflict_paths
 
 

--- a/backend/app/platform_update.py
+++ b/backend/app/platform_update.py
@@ -113,6 +113,9 @@ LOCAL_BRANCH = "main"
 # The canonical release ref a reconcile targets. A configured release channel
 # could override this later; for now it is the remote-tracking ``origin/main``.
 DEFAULT_TARGET_REF = "origin/main"
+# Keeps an off-tree semantic merge-base tree reachable while an owner may leave
+# a platform conflict unresolved across Git maintenance or server restarts.
+_CONFLICT_MERGE_BASE_REF = "refs/mobius/platform-conflict-base"
 
 # The platform tree is larger than an app but still small; a git op slower than
 # this is wedged, not busy. Fetch gets its own (network-bound) budget.
@@ -756,24 +759,29 @@ def _atomic_write_text(path: Path, content: str) -> None:
 
 
 def _write_conflict_flag(
-  target: str | None, paths: list[str], chat_id: str | None = None
+  target: str | None,
+  paths: list[str],
+  chat_id: str | None = None,
+  merge_base: str | None = None,
 ) -> None:
   """Persist a conflict so Settings keeps surfacing it across reloads.
 
-  Line 0 is the target (``origin/main``) sha; an optional ``chat:<id>`` line
-  records the resolver chat; the remaining lines are the conflicting paths. The
-  ``chat:`` prefix keeps the format backward compatible — a flag written before
-  the chat id is recorded simply lacks that line and reads back as no chat id.
+  Line 0 is the target (``origin/main``) sha; optional ``chat:<id>`` and
+  ``base:<tree>`` lines record the resolver chat and a proven semantic merge
+  base; the remaining lines are conflicting paths. Prefixes keep the format
+  backward compatible with conflict flags written before either field existed.
   """
   body = [target or ""]
   if chat_id:
     body.append(f"chat:{chat_id}")
+  if merge_base:
+    body.append(f"base:{merge_base}")
   body.extend(paths)
   _atomic_write_text(CONFLICT_FLAG, "\n".join(body))
 
 
 def _read_conflict_flag() -> dict | None:
-  """Parse :data:`CONFLICT_FLAG` into ``{upstream, chat_id, paths}`` or None.
+  """Parse the conflict target, chat, semantic base, and paths, or return None.
 
   ``upstream`` is the target sha (named for backward compatibility with the
   status field, not the ``upstream`` branch)."""
@@ -782,6 +790,7 @@ def _read_conflict_flag() -> dict | None:
   lines = CONFLICT_FLAG.read_text().splitlines()
   target = lines[0].strip() if lines else ""
   chat_id: str | None = None
+  merge_base: str | None = None
   paths: list[str] = []
   for line in lines[1:]:
     stripped = line.strip()
@@ -789,9 +798,16 @@ def _read_conflict_flag() -> dict | None:
       continue
     if stripped.startswith("chat:"):
       chat_id = stripped[len("chat:"):] or None
+    elif stripped.startswith("base:"):
+      merge_base = stripped[len("base:"):] or None
     else:
       paths.append(stripped)
-  return {"upstream": target or None, "chat_id": chat_id, "paths": paths}
+  return {
+    "upstream": target or None,
+    "chat_id": chat_id,
+    "merge_base": merge_base,
+    "paths": paths,
+  }
 
 
 def _write_offline_flag(error: str) -> None:
@@ -1316,7 +1332,8 @@ def reconcile_clone(
         # squash/batch case: ordinary Git sees two edits to the same lines, while
         # the causal record says one side is the already-contributed predecessor
         # of the other.  The engine is off-tree and fail-closed; no proof (or a
-        # genuine later conflict) returns None and preserves the resolver path.
+        # genuine later conflict) returns the reduced conflict set plus its
+        # semantic base so the resolver preserves every proven elimination.
         equivalent = app_git.merge_with_equivalent_changes(repo, pre, target)
         if equivalent is not None and equivalent.merged_tree_oid:
           _commit_equivalent_merge_tree(
@@ -1328,12 +1345,29 @@ def reconcile_clone(
           )
         else:
           # Genuine/unproven content conflict: record it, clear any stale
-          # rollback flag, and let the caller open a resolver chat.
-          _write_conflict_flag(target, paths)
+          # rollback flag, and let the caller open a resolver chat. A partially
+          # proven semantic base narrows both the path list and the real merge
+          # the resolver will materialize; no proof keeps the ordinary result.
+          conflict_paths = (
+            equivalent.conflict_paths
+            if equivalent is not None and equivalent.conflict_paths
+            else paths
+          )
+          merge_base = (
+            equivalent.merge_base_oid if equivalent is not None else None
+          )
+          if merge_base:
+            _git(
+              "update-ref", _CONFLICT_MERGE_BASE_REF, merge_base,
+              repo=repo,
+            )
+          _write_conflict_flag(
+            target, conflict_paths, merge_base=merge_base,
+          )
           ROLLED_BACK_FLAG.unlink(missing_ok=True)
           _clear_reconcile_pre()
           return ReconcileResult(
-            "conflict", pre, pre, target, conflict_paths=paths,
+            "conflict", pre, pre, target, conflict_paths=conflict_paths,
           )
 
     # Post-reconcile import probe: a text-clean ff/merge can still produce a
@@ -1883,9 +1917,12 @@ async def create_platform_conflict_resolver_chat(
 
   conflict_paths = flag.get("paths") or _unmerged_paths(repo)
   target_sha = flag.get("upstream") or _rev(repo, DEFAULT_TARGET_REF)
+  merge_base = flag.get("merge_base")
   if not target_sha:
     raise PlatformUpdateError("Platform conflict target is unavailable.")
-  result = await spawn_platform_conflict_chat(db, conflict_paths, target_sha)
+  result = await spawn_platform_conflict_chat(
+    db, conflict_paths, target_sha, merge_base,
+  )
   if result is None:
     raise PlatformUpdateError("Could not open resolver chat.")
 
@@ -1893,16 +1930,54 @@ async def create_platform_conflict_resolver_chat(
     target_sha,
     conflict_paths,
     result["chat_id"],
+    merge_base,
   )
   return result
+
+
+def materialize_platform_conflict(
+  target_sha: str,
+  merge_base: str,
+  repo: Path = PLATFORM_REPO,
+) -> list[str]:
+  """Start the owner-approved platform conflict from its proven semantic base."""
+  target = _rev(repo, target_sha)
+  base = _git(
+    "rev-parse", "--verify", "--quiet", f"{merge_base}^{{tree}}",
+    repo=repo, check=False,
+  ).stdout.strip()
+  if target != target_sha or not base:
+    raise PlatformUpdateError("Platform conflict merge proof is unavailable.")
+  return app_git.start_conflict_merge(
+    repo,
+    merge_base=base,
+    local_branch=_local_branch(repo),
+    upstream_branch=target,
+  )
 
 
 def _platform_conflict_resolver_message(
   target_sha: str,
   conflict_paths: list[str],
+  merge_base: str | None = None,
 ) -> str:
   """Instructions bound to the exact release the owner reviewed and applied."""
   files = ", ".join(conflict_paths) if conflict_paths else "some files"
+  if merge_base:
+    start_merge = (
+      "Start the prepared merge from its proven reviewed-change base: "
+      "`cd /data/platform/backend && python3 -c \"from "
+      "app.platform_update import materialize_platform_conflict as m; "
+      f"print('\\\\n'.join(m('{target_sha}', '{merge_base}')))\"`. "
+      "This preserves the updater's already-landed-change analysis and writes "
+      "markers only for the residual conflicts."
+    )
+  else:
+    start_merge = (
+      "Resolve it with ordinary git: `git -C /data/platform merge --no-ff "
+      f"{target_sha}` compares the complete local and reviewed upstream trees "
+      "once and stops with every conflicting file marked."
+    )
   return (
     "A platform update is ready but conflicts with local edits — the new "
     "version and the local changes both touched the same lines, so they can't "
@@ -1911,10 +1986,8 @@ def _platform_conflict_resolver_message(
     f"The exact reviewed version is commit `{target_sha}`; local edits are on "
     "the checked-out working branch. "
     f"Reconcile these conflicting files by hand: {files}.\n\n"
-    "Resolve it with ordinary git: `git -C /data/platform merge --no-ff "
-    f"{target_sha}` compares the complete local and reviewed upstream trees "
-    "once and stops with every conflicting file marked; combine the intent of "
-    "the local version and upstream's, save each file, then `git add` it and "
+    f"{start_merge} Combine the intent of the local version and upstream's, "
+    "save each file, then `git add` it and "
     "`git commit --no-edit` (this finishes the merge non-interactively from the "
     "prepared merge message). When the merge finishes, the working branch "
     "carries both histories.\n\n"
@@ -1927,7 +2000,10 @@ def _platform_conflict_resolver_message(
 
 
 async def spawn_platform_conflict_chat(
-  db: Session, conflict_paths: list[str], target_sha: str,
+  db: Session,
+  conflict_paths: list[str],
+  target_sha: str,
+  merge_base: str | None = None,
 ) -> PlatformConflictResolverChatOut | None:
   """Open a visible agent chat to reconcile the new platform version into
   the checked-out working branch — the platform analogue of a per-app
@@ -1964,7 +2040,9 @@ async def spawn_platform_conflict_chat(
     get_settings().data_dir, owner.provider,
   )
 
-  content = _platform_conflict_resolver_message(target_sha, conflict_paths)
+  content = _platform_conflict_resolver_message(
+    target_sha, conflict_paths, merge_base,
+  )
 
   chat_id = str(uuid.uuid4())
   chat = models.Chat(

--- a/backend/app/routes/apps.py
+++ b/backend/app/routes/apps.py
@@ -1754,7 +1754,9 @@ async def create_conflict_resolver_chat(
 
     if materialize_on_new_chat:
       conflict_paths = await asyncio.to_thread(
-        app_git.start_conflict_merge, repo,
+        app_git.start_conflict_merge,
+        repo,
+        merge_base=merge.merge_base_oid,
       ) or conflict_paths
       if not conflict_paths:
         raise HTTPException(

--- a/backend/app/routes/github.py
+++ b/backend/app/routes/github.py
@@ -439,6 +439,19 @@ def _record_pending_equivalence(record: dict) -> str | None:
   if repos is None:
     return None
   source_repo, review_repo = repos
+  plan_base_sha = str(plan.get("base_sha") or "")
+  plan_head_sha = str(plan.get("head_sha") or "")
+  # Older cleanup could remove a linked review worktree before the merged-state
+  # poll created its durable witness. The reviewed commits remain in the live
+  # repository, but only reuse it when both immutable commits still resolve.
+  if (
+    not app_git.ref_exists(review_repo, f"{plan_base_sha}^{{commit}}")
+    or not app_git.ref_exists(review_repo, f"{plan_head_sha}^{{commit}}")
+  ) and (
+    app_git.ref_exists(source_repo, f"{plan_base_sha}^{{commit}}")
+    and app_git.ref_exists(source_repo, f"{plan_head_sha}^{{commit}}")
+  ):
+    review_repo = source_repo
   source_sha = str(plan.get("source_sha") or "").strip()
   current_source = app_git.head_sha(source_repo, "HEAD")
   if not source_sha:
@@ -455,8 +468,8 @@ def _record_pending_equivalence(record: dict) -> str | None:
   if not source_sha:
     return None
   kwargs = {
-    "base_sha": str(plan.get("base_sha") or ""),
-    "head_sha": str(plan.get("head_sha") or ""),
+    "base_sha": plan_base_sha,
+    "head_sha": plan_head_sha,
     "diff_sha256": str(plan.get("diff_sha256") or ""),
     "contribution_id": str(record.get("id") or ""),
     "review_source_dir": review_repo,
@@ -547,9 +560,14 @@ def _settle_equivalence(record: dict, upstream_sha: str | None = None) -> str | 
   repo, _review_repo = repos
   digest = str(plan.get("diff_sha256") or "")
   if record.get("status") == "merged":
-    return app_git.mark_equivalent_change_landed(
+    equivalent = app_git.mark_equivalent_change_landed(
       repo, digest, upstream_sha=upstream_sha,
     )
+    if equivalent is None and _record_pending_equivalence(record) is not None:
+      equivalent = app_git.mark_equivalent_change_landed(
+        repo, digest, upstream_sha=upstream_sha,
+      )
+    return equivalent
   if record.get("status") == "closed":
     app_git.discard_pending_equivalent_change(repo, digest)
   return None

--- a/backend/tests/test_app_git.py
+++ b/backend/tests/test_app_git.py
@@ -1058,6 +1058,125 @@ def test_landed_equivalent_change_rebases_later_local_edit_without_agent(
   assert (repo / "index.jsx").read_text() == 'mode = "local followup"\n'
 
 
+def test_partial_equivalence_materializes_only_residual_app_conflicts(tmp_path):
+  """Proven shared work stays out of a later owner-gated conflict merge."""
+  repo = tmp_path / "app"
+  app_git.ensure_repo(repo)
+  app_git.record_upstream(
+    repo,
+    {
+      "index.jsx": b'mode = "base"\n',
+      "config.js": b'choice = "base"\n',
+    },
+    "https://x/mobius.json",
+    "1.0.0",
+  )
+  app_git.align_local_to_upstream(repo)
+  base = app_git.head_sha(repo, app_git.UPSTREAM_BRANCH)
+
+  _write(repo, 'mode = "shared contribution"\n')
+  reviewed = app_git.commit_local(repo, "reviewed contribution")
+  assert reviewed
+  digest = _review_digest(repo, base, reviewed)
+  assert app_git.record_pending_equivalent_change(
+    repo,
+    base_sha=base,
+    head_sha=reviewed,
+    source_sha=reviewed,
+    diff_sha256=digest,
+    contribution_id="partial-shared-change",
+  )
+
+  _write(repo, 'mode = "local followup"\n')
+  (repo / "config.js").write_text('choice = "local"\n')
+  local = app_git.commit_local(repo, "later local edits")
+  assert local
+  upstream = app_git.record_upstream(
+    repo,
+    {
+      "index.jsx": b'mode = "shared contribution"\n',
+      "config.js": b'choice = "upstream"\n',
+      "upstream.js": b"export const added = true\n",
+    },
+    "https://x/mobius.json",
+    "2.0.0",
+  )
+  landed = app_git.mark_equivalent_change_landed(
+    repo, digest, upstream_sha=upstream,
+  )
+  assert landed
+
+  ordinary = app_git.merge_refs(
+    repo, app_git.LOCAL_BRANCH, app_git.UPSTREAM_BRANCH,
+  )
+  assert set(ordinary.conflict_paths) == {"index.jsx", "config.js"}
+  result = app_git.merge_upstream(repo)
+  assert result.status == "conflict"
+  assert result.conflict_paths == ["config.js"]
+  assert result.merge_base_oid
+  assert result.equivalent_change_refs == (landed,)
+
+  conflicts = app_git.start_conflict_merge(
+    repo, merge_base=result.merge_base_oid,
+  )
+  assert conflicts == ["config.js"]
+  assert (repo / "index.jsx").read_text() == 'mode = "local followup"\n'
+  assert "export const added = true" in (repo / "upstream.js").read_text()
+  config = (repo / "config.js").read_text()
+  assert "<<<<<<< ours" in config
+  assert 'choice = "local"' in config
+  assert 'choice = "upstream"' in config
+
+  assert app_git.abort_in_progress_merge(repo) is True
+  assert app_git.head_sha(repo, app_git.LOCAL_BRANCH) == local
+  assert (repo / "config.js").read_text() == 'choice = "local"\n'
+  assert not (repo / "upstream.js").exists()
+
+
+def test_explicit_base_materializes_delete_modify_conflict(tmp_path):
+  """Marker rendering must not abort a valid non-text-shaped conflict."""
+  repo = tmp_path / "app"
+  app_git.ensure_repo(repo)
+  app_git.record_upstream(
+    repo,
+    {
+      "index.jsx": b"export default true\n",
+      "obsolete.svg": b"<svg />\n",
+      "retired.js": b"export const value = 'base'\n",
+    },
+    "https://x/mobius.json",
+    "1.0.0",
+  )
+  app_git.align_local_to_upstream(repo)
+  base = app_git.head_sha(repo, app_git.UPSTREAM_BRANCH)
+
+  (repo / "retired.js").unlink()
+  (repo / "obsolete.svg").unlink()
+  local = app_git.commit_local(repo, "remove retired module")
+  assert local
+  app_git.record_upstream(
+    repo,
+    {
+      "index.jsx": b"export default true\n",
+      "retired.js": b"export const value = 'upstream'\n",
+    },
+    "https://x/mobius.json",
+    "2.0.0",
+  )
+
+  conflicts = app_git.start_conflict_merge(
+    repo, merge_base=app_git._tree_oid(repo, base),
+  )
+
+  assert conflicts == ["retired.js"]
+  assert app_git.has_unresolved_conflicts(repo) is True
+  assert (repo / ".git" / "MERGE_HEAD").exists()
+  assert not (repo / "obsolete.svg").exists()
+  assert app_git.abort_in_progress_merge(repo) is True
+  assert app_git.head_sha(repo, app_git.LOCAL_BRANCH) == local
+  assert not (repo / "retired.js").exists()
+
+
 def test_agent_resolved_local_projection_becomes_a_durable_shared_base(
   tmp_path,
 ):

--- a/backend/tests/test_github_routes.py
+++ b/backend/tests/test_github_routes.py
@@ -2172,6 +2172,78 @@ def test_contribution_lifecycle_persists_equivalence_in_live_linked_repo():
   assert app_git.ref_exists(live, landed)
 
 
+def test_merged_legacy_record_reconstructs_witness_after_worktree_cleanup():
+  """A pre-witness linked review remains attributable after its worktree left."""
+  from app import app_git
+  from app.routes.github import _settle_equivalence
+
+  data_dir = Path(get_settings().data_dir)
+  live = data_dir / "apps" / "equivalence-legacy-live"
+  review = data_dir / "contrib" / "equivalence-legacy-review" / "worktree"
+  live.mkdir(parents=True)
+  subprocess.run(["git", "init", "-qb", "main", str(live)], check=True)
+  subprocess.run(["git", "-C", str(live), "config", "user.name", "Test"], check=True)
+  subprocess.run(
+    ["git", "-C", str(live), "config", "user.email", "test@example.invalid"],
+    check=True,
+  )
+  (live / "index.jsx").write_text("base\n")
+  subprocess.run(["git", "-C", str(live), "add", "index.jsx"], check=True)
+  subprocess.run(["git", "-C", str(live), "commit", "-qm", "base"], check=True)
+  base = subprocess.check_output(
+    ["git", "-C", str(live), "rev-parse", "HEAD"], text=True,
+  ).strip()
+  (live / "index.jsx").write_text("reviewed\n")
+  subprocess.run(["git", "-C", str(live), "commit", "-qam", "reviewed"], check=True)
+  source = subprocess.check_output(
+    ["git", "-C", str(live), "rev-parse", "HEAD"], text=True,
+  ).strip()
+  review.parent.mkdir(parents=True)
+  subprocess.run(
+    ["git", "-C", str(live), "worktree", "add", "-qb", "fix/legacy",
+     str(review), source],
+    check=True,
+  )
+  diff = app_git._canonical_diff(review, base, source)
+  assert diff is not None
+  digest = hashlib.sha256(diff).hexdigest()
+  tree = subprocess.check_output(
+    ["git", "-C", str(live), "rev-parse", f"{source}^{{tree}}"], text=True,
+  ).strip()
+  upstream = subprocess.check_output(
+    [
+      "git", "-c", "user.name=Test", "-c", "user.email=test@example.invalid",
+      "-C", str(live), "commit-tree", tree, "-p", base, "-m", "squash",
+    ],
+    text=True,
+  ).strip()
+  subprocess.run(
+    ["git", "-C", str(live), "worktree", "remove", "--force", str(review)],
+    check=True,
+  )
+  assert not review.exists()
+
+  record = {
+    "id": "equivalence-legacy-review",
+    "status": "merged",
+    "plan": {
+      "repo_path": str(review),
+      "source_repo_path": str(live),
+      "source_sha": source,
+      "base_sha": base,
+      "head_sha": source,
+      "diff_sha256": digest,
+    },
+  }
+  landed = _settle_equivalence(record, upstream)
+
+  assert landed and app_git.ref_exists(live, landed)
+  witness = app_git._read_equivalent_change(live, landed)
+  assert witness is not None
+  assert witness.source_sha == source
+  assert witness.upstream_sha == upstream
+
+
 def test_standalone_app_review_persists_equivalence_in_installed_repo():
   """A no-origin app's disposable review clone cannot own the only witness."""
   from app import app_git

--- a/backend/tests/test_platform_update.py
+++ b/backend/tests/test_platform_update.py
@@ -341,6 +341,79 @@ def test_contributed_squash_uses_provenance_for_both_histories(clone_env):
   assert not app_git.ref_exists(platform, landed)
 
 
+def test_partial_provenance_persists_reduced_platform_conflict(clone_env):
+  """A genuine later conflict keeps the proven contribution out of resolution."""
+  origin, platform = clone_env
+  base = _served_sha(platform)
+  shared = _MAIN_PY.replace("LINE_A = 1", "LINE_A = 'SHARED REVIEW'")
+  reviewed = _local_commit(
+    platform,
+    edits={"backend/app/main.py": shared},
+    msg="reviewed contribution",
+  )
+  diff = app_git._canonical_diff(platform, base, reviewed)
+  assert diff is not None
+  digest = hashlib.sha256(diff).hexdigest()
+  assert app_git.record_pending_equivalent_change(
+    platform,
+    base_sha=base,
+    head_sha=reviewed,
+    source_sha=reviewed,
+    diff_sha256=digest,
+    contribution_id="partial-platform-change",
+  )
+
+  followup = shared.replace("SHARED REVIEW", "LOCAL FOLLOWUP")
+  pre = _local_commit(
+    platform,
+    edits={
+      "backend/app/main.py": followup,
+      "backend/app/foo.py": "VALUE = 'LOCAL'\n",
+    },
+    msg="later local edits",
+  )
+  target = _advance_origin(
+    origin,
+    edits={
+      "backend/app/main.py": shared.replace("LINE_C = 3", "LINE_C = 9001"),
+      "backend/app/foo.py": "VALUE = 'UPSTREAM'\n",
+    },
+    msg="squash plus genuine conflict",
+  )
+  landed = app_git.mark_equivalent_change_landed(
+    platform, digest, upstream_sha=target,
+  )
+  assert landed
+
+  _git(platform, "fetch", "-q", "origin")
+  ordinary = app_git.merge_refs(platform, pre, target)
+  assert set(ordinary.conflict_paths) == {
+    "backend/app/main.py", "backend/app/foo.py",
+  }
+  res = pu.reconcile_clone(platform, at_boot=True)
+
+  assert res.status == "conflict"
+  assert res.conflict_paths == ["backend/app/foo.py"]
+  assert _served_sha(platform) == pre
+  flag = pu._read_conflict_flag()
+  assert flag["paths"] == ["backend/app/foo.py"]
+  assert flag["merge_base"]
+
+  conflicts = pu.materialize_platform_conflict(
+    target, flag["merge_base"], platform,
+  )
+  assert conflicts == ["backend/app/foo.py"]
+  assert "LINE_A = 'LOCAL FOLLOWUP'" in (
+    platform / "backend/app/main.py"
+  ).read_text()
+  assert "LINE_C = 9001" in (platform / "backend/app/main.py").read_text()
+  assert "<<<<<<< ours" in (platform / "backend/app/foo.py").read_text()
+
+  _git(platform, "merge", "--abort")
+  assert _served_sha(platform) == pre
+  assert (platform / "backend/app/foo.py").read_text() == "VALUE = 'LOCAL'\n"
+
+
 def test_diverged_update_surfaces_all_net_conflicts_together(clone_env):
   origin, platform = clone_env
   _local_commit(platform, edits={"backend/app/main.py":
@@ -1016,8 +1089,8 @@ async def test_platform_conflict_resolver_chat_is_click_gated(
   pu._write_conflict_flag(target, ["backend/app/main.py"])
   calls = []
 
-  async def fake_spawn(db, paths, target_sha):
-    calls.append((db, paths, target_sha))
+  async def fake_spawn(db, paths, target_sha, merge_base):
+    calls.append((db, paths, target_sha, merge_base))
     return {
       "chat_id": "resolver-chat",
       "created": True,
@@ -1034,11 +1107,12 @@ async def test_platform_conflict_resolver_chat_is_click_gated(
     "created": True,
     "started": True,
   }
-  assert calls == [(db, ["backend/app/main.py"], target)]
+  assert calls == [(db, ["backend/app/main.py"], target, None)]
   flag = pu._read_conflict_flag()
   assert flag["upstream"] == target
   assert flag["paths"] == ["backend/app/main.py"]
   assert flag["chat_id"] == "resolver-chat"
+  assert flag["merge_base"] is None
 
 
 def test_platform_conflict_resolver_message_pins_reviewed_target():
@@ -1056,6 +1130,20 @@ def test_platform_conflict_resolver_message_pins_reviewed_target():
   # editor and hangs/errors; it must finish non-interactively instead.
   assert "commit --no-edit" in content
   assert "merge --continue" not in content
+
+
+def test_platform_conflict_resolver_message_preserves_semantic_base():
+  target = "a" * 40
+  merge_base = "b" * 40
+
+  content = pu._platform_conflict_resolver_message(
+    target, ["backend/app/main.py"], merge_base,
+  )
+
+  assert "materialize_platform_conflict" in content
+  assert target in content
+  assert merge_base in content
+  assert f"merge --no-ff {target}" not in content
 
 
 def test_status_restart_needed_when_disk_head_changed_after_boot(clone_env):
@@ -1274,14 +1362,21 @@ def test_offline_boot_clears_stale_restart_flag(clone_env):
 # --- conflict flag format round-trips (chat id, legacy) ---------------------
 
 def test_conflict_flag_roundtrips_chat_id_and_reads_legacy(clone_env):
-  pu._write_conflict_flag("tgt-sha", ["backend/app/a.py", "backend/app/b.py"], "chat-42")
+  pu._write_conflict_flag(
+    "tgt-sha",
+    ["backend/app/a.py", "backend/app/b.py"],
+    "chat-42",
+    "base-tree",
+  )
   assert pu._read_conflict_flag() == {
     "upstream": "tgt-sha", "chat_id": "chat-42",
+    "merge_base": "base-tree",
     "paths": ["backend/app/a.py", "backend/app/b.py"],
   }
   pu.CONFLICT_FLAG.write_text("tgt-sha\nbackend/app/a.py")
   legacy = pu._read_conflict_flag()
   assert legacy["chat_id"] is None
+  assert legacy["merge_base"] is None
   assert legacy["paths"] == ["backend/app/a.py"]
 
 


### PR DESCRIPTION
## Summary
- preserve strictly proven reviewed changes when a later upstream update has genuine residual conflicts
- materialize only the reduced conflict set for both platform and app resolvers
- reconstruct legacy provenance before terminal review-worktree cleanup when immutable Git objects still prove it
- handle delete/modify, both-deleted, binary, and line-level residual merges without weakening equivalence checks

## Verification
- 278 focused backend tests covering app reconciliation, platform reconciliation, and contribution provenance
- Python import compilation and staged diff checks

No patch-similarity or title-based equivalence is introduced; every eliminated conflict still requires exact contribution provenance and tree/diff proof.