### PR TITLE
Keep permanent chat cleanup out of drawer reads

### DIFF
--- a/backend/app/chat_retention.py
+++ b/backend/app/chat_retention.py
@@ -1,0 +1,76 @@
+"""Permanent cleanup for chats whose owner-deletion window has expired.
+
+Only chats explicitly tombstoned through the delete lifecycle belong here.
+Ordinary reads must not infer abandonment from age or content, and notification
+history follows its own product lifecycle rather than piggybacking on chat
+listing.
+"""
+
+import shutil
+from pathlib import Path
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app import models, questions
+from app.chat import forget_chat
+from app.config import get_settings
+from app.timeutil import SOFT_DELETE_TTL, now_naive_utc
+
+
+def _purge_chat_storage(chat_id: str) -> None:
+  """Remove data derived from a chat after its recovery window has closed."""
+  data_dir = Path(get_settings().data_dir)
+  shutil.rmtree(data_dir / "chats" / chat_id, ignore_errors=True)
+  shutil.rmtree(
+    data_dir / "agent-browser-profiles" / f"chat-{chat_id}",
+    ignore_errors=True,
+  )
+  shutil.rmtree(
+    data_dir / "shared" / "memory" / "chats" / chat_id,
+    ignore_errors=True,
+  )
+
+
+def purge_expired_chat_tombstones(db: Session) -> list[str]:
+  """Permanently remove chats explicitly deleted more than seven days ago.
+
+  The candidate query selects IDs only, so this lifecycle sweep never decodes
+  transcript or pending-message JSON. Database deletion commits before
+  best-effort process/filesystem cleanup; a failed transaction therefore
+  cannot erase recoverable data outside the database.
+  """
+  cutoff = now_naive_utc() - SOFT_DELETE_TTL
+  expired_chat_ids = select(models.Chat.id).where(
+    models.Chat.deleted_at.isnot(None),
+    models.Chat.deleted_at < cutoff,
+  )
+  chat_ids = [
+    chat_id for chat_id in db.scalars(expired_chat_ids).all()
+  ]
+  if not chat_ids:
+    return []
+
+  dependent_models = (
+    models.AgentLifecycleEvent,
+    models.AgentLifecycleRunUpdate,
+    models.ChatRun,
+    models.ToolOutput,
+    models.ThinkingTrace,
+    models.ChatSessionLink,
+  )
+  for model in dependent_models:
+    db.query(model).filter(
+      model.chat_id.in_(expired_chat_ids),
+    ).delete(synchronize_session=False)
+  db.query(models.Chat).filter(
+    models.Chat.id.in_(expired_chat_ids),
+  ).delete(synchronize_session=False)
+  db.commit()
+
+  for chat_id in chat_ids:
+    questions.cancel(chat_id)
+    forget_chat(chat_id)
+    _purge_chat_storage(chat_id)
+
+  return chat_ids

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -192,6 +192,22 @@ async def lifespan(app):
     _log.error("legacy global auto-resume cleanup failed: %s", exc, exc_info=True)
   _init_db()
   record_memory_checkpoint("startup_database_initialized")
+  # Expired chat tombstones are permanent lifecycle cleanup, not a side effect
+  # of reading the drawer. Reclaim them once at boot and again on future chat
+  # deletes; both are existing lifecycle boundaries, so no polling task or
+  # resource ceiling is needed.
+  try:
+    from app.chat_retention import purge_expired_chat_tombstones
+    with SessionLocal() as _chat_retention_db:
+      _purged_chat_ids = purge_expired_chat_tombstones(_chat_retention_db)
+    if _purged_chat_ids:
+      _log.info(
+        "purged %s expired chat tombstone(s)", len(_purged_chat_ids),
+      )
+  except Exception as exc:
+    # Retention hygiene must not block recovery. A failed sweep retries on the
+    # next explicit chat delete or boot.
+    _log.error("expired chat tombstone cleanup failed: %s", exc, exc_info=True)
   # Upgrade hygiene for lifecycle observability. The append-only link table is
   # new, but older chats can already carry a current provider session pointer.
   # Seed those once after create_all has made the table; future sightings are

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -4,9 +4,7 @@ import hashlib
 import json
 import logging
 import re
-import shutil
-from datetime import UTC, datetime, timedelta
-from pathlib import Path
+from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import PlainTextResponse, Response
@@ -19,13 +17,13 @@ from app.config import get_settings
 from app.chat import (
   _clear_run_status,
   bump_run_generation,
-  forget_chat,
   is_chat_running,
   mark_chat_deleted,
   recover_chat_generation,
   stop_chat_for,
 )
 from app.broadcast import get_system_broadcast
+from app.chat_retention import purge_expired_chat_tombstones
 from app.database import get_db
 from app.memory_observability import record_memory_checkpoint_once
 from app.deps import (
@@ -59,19 +57,11 @@ app_chat_router = APIRouter(prefix="/api/app-chats", tags=["app-chats"])
 # SOFT_DELETE_TTL is imported from app.timeutil — one shared window for chat +
 # app soft-delete so the two recovery periods can't drift.
 
-# How long an untouched empty chat (no session, no messages, no pending
-# queue) survives before the list_chats sweeper hard-deletes it. Long
-# enough that a user who opened a chat, started a draft in the browser,
-# and walked away for the afternoon doesn't lose it; short enough that
-# abandoned empties don't pile up across weeks. Hard-delete (not soft)
-# because there's nothing to recover — content lived only in the
-# browser's sessionStorage, which is the user's problem to preserve.
-EMPTY_CHAT_GRACE = timedelta(hours=24)
-
-# The expanded tool UI renders at most this much text. Compressed rows inflate
-# only this bounded prefix for preview; legacy plain-text rows are sliced after
-# their normal database read. The exact value remains available through the
-# same endpoint when the user explicitly copies.
+# The expanded tool UI renders at most this much text. Slice in SQLite so a
+# multi-megabyte result is never materialized in the API process or browser just
+# to paint the preview. Read one extra sentinel character to detect truncation
+# without making SQLite scan the full value with ``length()``. The exact value
+# remains available through the same endpoint when the user explicitly copies.
 TOOL_OUTPUT_PREVIEW_CHARS = 20_000
 THINKING_TRACE_PREVIEW_CHARS = 20_000
 
@@ -166,42 +156,6 @@ def _drain_writer_before_sidecar_read(
   # this request-scoped session. End that read-only snapshot after the barrier
   # so the query can see the writer's just-committed stash.
   db.rollback()
-
-
-def _purge_chat_dir(chat_id: str) -> None:
-  """Removes per-chat dirs left on disk after a chat is gone.
-
-  Three locations get cleaned: the chat's data dir
-  (`/data/chats/{chat_id}/` — uploads, media, scratch),
-  its agent-browser Chromium profile
-  (`/data/agent-browser-profiles/chat-{chat_id}/` — IndexedDB,
-  cache, cookies; typically 50-200 MB per profile that's seen any
-  use), and its memory note dir
-  (`/data/shared/memory/chats/{chat_id}/`). Without the second
-  rmtree, profiles accumulated across every chat that ever invoked
-  agent-browser and were never reclaimed by chat-delete or the
-  7-day soft-delete purge — a slow disk leak proportional to chat
-  count, not time. The note is DERIVED from the chat, so the
-  owner's delete intent covers it; by hard-purge time the 7-day
-  soft-delete window plus nightly reflection have had time to
-  promote durable facts into topic notes, and an orphan note would
-  otherwise linger as a memory entry pointing at a chat that no
-  longer exists.
-
-  All rmtrees use `ignore_errors=True` so chats that never wrote
-  to a given location don't raise.
-  """
-  data_dir = Path(get_settings().data_dir)
-  shutil.rmtree(data_dir / "chats" / chat_id, ignore_errors=True)
-  shutil.rmtree(
-    data_dir / "agent-browser-profiles" / f"chat-{chat_id}",
-    ignore_errors=True,
-  )
-  shutil.rmtree(
-    data_dir / "shared" / "memory" / "chats" / chat_id,
-    ignore_errors=True,
-  )
-
 
 
 class ChatUpdate(BaseModel):
@@ -370,6 +324,17 @@ def _owner_chat_summary_projection(chat) -> dict:
   }
 
 
+def _reclaim_expired_tombstones_after_chat_write(db: Session) -> None:
+  """Run unrelated retention cleanup without changing the write's outcome."""
+  try:
+    purge_expired_chat_tombstones(db)
+  except Exception:
+    db.rollback()
+    # The requested create/delete is already committed. Retention retries at
+    # the next chat lifecycle write or boot rather than falsifying its result.
+    log.exception("Expired chat tombstone cleanup failed after chat write")
+
+
 def _chat_detail_response(
   chat: models.Chat,
   *,
@@ -486,110 +451,6 @@ def list_chats(
 ):
   """Returns all active chats ordered by most recently updated."""
   record_memory_checkpoint_once("shell_chat_list_first_request")
-  # Purge chats soft-deleted more than TTL ago.
-  # Use naive datetime to match SQLite's naive UTC storage — comparing an
-  # aware datetime against a naive DB value throws TypeError in Python 3.11+.
-  cutoff = now_naive_utc() - SOFT_DELETE_TTL
-  stale = db.query(models.Chat).filter(
-    models.Chat.deleted_at.isnot(None),
-    models.Chat.deleted_at < cutoff,
-  ).all()
-  for c in stale:
-    questions.cancel(c.id)
-    forget_chat(c.id)
-    _purge_chat_dir(c.id)
-    # Drop the chat's durable run records (077 Step 3) with it. chat_runs has
-    # no ON DELETE CASCADE and SQLite leaves FK enforcement off, so a hard
-    # chat delete would otherwise orphan its run rows and grow the table
-    # unbounded over the instance's life.
-    # Lifecycle rows can reference both the chat and one of its runs, so delete
-    # them before either parent for FK-correctness on stricter databases.
-    db.query(models.AgentLifecycleEvent).filter(
-      models.AgentLifecycleEvent.chat_id == c.id
-    ).delete(synchronize_session=False)
-    db.query(models.AgentLifecycleRunUpdate).filter(
-      models.AgentLifecycleRunUpdate.chat_id == c.id
-    ).delete(synchronize_session=False)
-    db.query(models.ChatRun).filter(
-      models.ChatRun.chat_id == c.id
-    ).delete(synchronize_session=False)
-    # Drop the chat's stashed large tool outputs (contract rule 6) with it —
-    # same lifecycle, same no-FK-cascade reasoning as chat_runs above. The
-    # rows rode the soft-delete window (a recovered chat re-showed its
-    # outputs); at hard-purge time the chat is gone for good, so are they.
-    db.query(models.ToolOutput).filter(
-      models.ToolOutput.chat_id == c.id
-    ).delete(synchronize_session=False)
-    db.query(models.ThinkingTrace).filter(
-      models.ThinkingTrace.chat_id == c.id
-    ).delete(synchronize_session=False)
-    # Drop the chat's session->chat link rows (subagent observability) with it —
-    # same no-FK-cascade lifecycle as chat_runs. A link records every provider
-    # session this chat was ever seen under; once the chat is gone for good the
-    # links resolve to nothing, so purge them here rather than leak dead rows.
-    db.query(models.ChatSessionLink).filter(
-      models.ChatSessionLink.chat_id == c.id
-    ).delete(synchronize_session=False)
-    db.delete(c)
-  # Hard-delete abandoned empties — chats that were created, never had
-  # a message sent (no session_id, no messages, no pending queue), and
-  # have been sitting that way for over EMPTY_GRACE. The soft-delete
-  # TTL above is for chats the user EXPLICITLY deleted — those have
-  # content worth a 7-day recovery window. An untouched empty has
-  # nothing to recover; the soft-delete dance just defers reclaim.
-  # The grace protects a chat opened minutes ago with a draft in the
-  # browser's sessionStorage from being nuked out from under the user
-  # between draft autosaves. JSON-column emptiness is checked in Python
-  # rather than SQL because cross-dialect `JSON = '[]'` is fragile;
-  # the SQL prefilter (NULL session, NULL deleted_at, older than the
-  # grace) keeps the candidate set small.
-  empty_cutoff = now_naive_utc() - EMPTY_CHAT_GRACE
-  candidates = db.query(models.Chat).filter(
-    models.Chat.deleted_at.is_(None),
-    models.Chat.session_id.is_(None),
-    models.Chat.created_at < empty_cutoff,
-  ).all()
-  for c in candidates:
-    if c.messages or c.pending_messages:
-      continue
-    # An app-attributed chat is a mini-app's durable anchor: the app persists
-    # its id (window.mobius.chat persist -> chat_id.json) and resumes it across
-    # mounts, so an empty app-chat is not abandoned scratch the way an owner's
-    # new-chat-then-leave is. Hard-deleting it left the app's persisted id
-    # pointing at a dead row, so the next mount's resume PATCH 404'd. Leave
-    # app-chats for the app + the soft-delete TTL to manage.
-    if c.created_by_app_id is not None:
-      continue
-    questions.cancel(c.id)
-    forget_chat(c.id)
-    _purge_chat_dir(c.id)
-    # Drop the chat's run records with it (see the stale-purge note above —
-    # no FK cascade on SQLite, so these would orphan otherwise).
-    db.query(models.AgentLifecycleEvent).filter(
-      models.AgentLifecycleEvent.chat_id == c.id
-    ).delete(synchronize_session=False)
-    db.query(models.AgentLifecycleRunUpdate).filter(
-      models.AgentLifecycleRunUpdate.chat_id == c.id
-    ).delete(synchronize_session=False)
-    db.query(models.ChatRun).filter(
-      models.ChatRun.chat_id == c.id
-    ).delete(synchronize_session=False)
-    db.query(models.ChatSessionLink).filter(
-      models.ChatSessionLink.chat_id == c.id
-    ).delete(synchronize_session=False)
-    db.delete(c)
-  # Notification TTL: rows are written by agent-driven push calls
-  # (POST /api/notifications/send), and nothing else deletes them. Keep
-  # the table from growing unbounded by dropping anything older than
-  # 90 days alongside the chat purge above — same cadence, same
-  # transaction. Naive UTC matches `Notification.sent_at`'s storage
-  # format (see the chat cutoff above for the same TypeError-avoidance
-  # rationale).
-  notification_cutoff = now_naive_utc() - timedelta(days=90)
-  db.query(models.Notification).filter(
-    models.Notification.sent_at < notification_cutoff,
-  ).delete(synchronize_session=False)
-  db.commit()
 
   # Pinned chats sort first (newest pin at top of the pinned group),
   # then unpinned by owner-send recency. `activity_at` is the drawer
@@ -831,6 +692,7 @@ def create_chat(
   db.commit()
   db.refresh(chat)
   activity.log_event("chat_created", chat_id=chat.id)
+  _reclaim_expired_tombstones_after_chat_write(db)
   # Preserve the flat summary + messages fields existing callers consume while
   # carrying the exact detail contract under its own forward-compatible key.
   detail = _chat_detail_response(chat, db=db)
@@ -1712,6 +1574,9 @@ async def delete_chat(
       "Chat %s was deleted but its durable run marker could not be cleared",
       chat_id,
     )
+  # The current chat has just entered its recovery window and therefore cannot
+  # be selected when this existing lifecycle boundary reclaims older tombstones.
+  _reclaim_expired_tombstones_after_chat_write(db)
 
 
 @router.post("/{chat_id}/recover", dependencies=[Depends(reject_cross_site)])

--- a/backend/tests/test_agent_lifecycle.py
+++ b/backend/tests/test_agent_lifecycle.py
@@ -385,7 +385,9 @@ def test_owner_endpoint_rejects_app_token(client, owner_token):
   assert response.status_code == 403
 
 
-def test_stale_chat_hard_purge_removes_lifecycle_before_run(client, auth, db):
+def test_stale_chat_hard_purge_removes_lifecycle_before_run(db):
+  from app.chat_retention import purge_expired_chat_tombstones
+
   _chat_run(db, "chat-stale", "run-stale", deleted=True)
   values = normalize_chat_event(
     chat_id="chat-stale",
@@ -399,8 +401,7 @@ def test_stale_chat_hard_purge_removes_lifecycle_before_run(client, auth, db):
   )
   assert record_event(db, values) is True
 
-  response = client.get("/api/chats", headers=auth)
-  assert response.status_code == 200, response.text
+  purge_expired_chat_tombstones(db)
   db.expire_all()
   assert db.query(models.AgentLifecycleEvent).filter_by(
     event_key=values["event_key"]

--- a/backend/tests/test_chat_runs_lifecycle.py
+++ b/backend/tests/test_chat_runs_lifecycle.py
@@ -9,9 +9,10 @@ from datetime import UTC, datetime
 
 from app import chat as chat_mod
 from app import models
+from app.chat_retention import purge_expired_chat_tombstones
 from app.chat_writer import Barrier, get_writer
 from app.database import SessionLocal
-from app.routes.chats import SOFT_DELETE_TTL
+from app.timeutil import SOFT_DELETE_TTL
 
 
 def _seed_chat(chat_id, *, messages=None, run_status=None, deleted_at=None):
@@ -88,8 +89,8 @@ def test_soft_delete_closes_the_running_run_record(client, auth):
   assert state["deleted_at"] is not None, "chat is soft-deleted"
 
 
-def test_hard_purge_deletes_orphaned_run_records(client, auth):
-  """The list_chats TTL purge hard-deletes the Chat row; its run records must
+def test_hard_purge_deletes_orphaned_run_records():
+  """The tombstone lifecycle purge hard-deletes the Chat row; its run records must
   go with it (no FK cascade on SQLite) rather than orphaning + growing the
   table unbounded."""
   old = datetime.now(UTC).replace(tzinfo=None) - SOFT_DELETE_TTL - (
@@ -98,9 +99,11 @@ def test_hard_purge_deletes_orphaned_run_records(client, auth):
   _seed_chat("purge-me", deleted_at=old)
   _seed_run("rt-p1", "purge-me", status="completed")
   _seed_run("rt-p2", "purge-me", status="interrupted")
-  # Listing chats runs the purge sweep.
-  r = client.get("/api/chats", headers=auth)
-  assert r.status_code == 200
+  db = SessionLocal()
+  try:
+    purge_expired_chat_tombstones(db)
+  finally:
+    db.close()
   assert _chat_state("purge-me") is None, "chat row hard-deleted"
   assert _runs("purge-me") == {}, "run records purged with the chat, not orphaned"
 
@@ -127,7 +130,7 @@ def _session_links(chat_id):
     db.close()
 
 
-def test_hard_purge_deletes_session_links(client, auth):
+def test_hard_purge_deletes_session_links():
   """A chat's append-only session->chat link rows (subagent observability) must
   be purged with the chat — same no-FK-cascade lifecycle as chat_runs, else the
   table grows unbounded and the endpoint returns links to a dead chat."""
@@ -135,9 +138,11 @@ def test_hard_purge_deletes_session_links(client, auth):
   _seed_chat("purge-links", deleted_at=old)
   _seed_session_link("claude", "sess-purge-1", "purge-links")
   _seed_session_link("codex", "sess-purge-2", "purge-links")
-  # Listing chats runs the purge sweep.
-  r = client.get("/api/chats", headers=auth)
-  assert r.status_code == 200
+  db = SessionLocal()
+  try:
+    purge_expired_chat_tombstones(db)
+  finally:
+    db.close()
   assert _chat_state("purge-links") is None, "chat row hard-deleted"
   assert _session_links("purge-links") == [], "session links purged with the chat"
 

--- a/backend/tests/test_lifecycle.py
+++ b/backend/tests/test_lifecycle.py
@@ -1,16 +1,20 @@
 # backend/tests/test_lifecycle.py
 from datetime import datetime, timedelta
 from pathlib import Path
+import uuid
+
 from app import models
+from app.chat_retention import purge_expired_chat_tombstones
+from sqlalchemy import event
 
 
-def test_ttl_is_seven_days(client, db, auth, chat):
+def test_ttl_is_seven_days(db, chat):
   """Chats deleted fewer than 7 days ago must not be purged."""
   chat_id = chat.id  # capture before any purge
   chat.deleted_at = datetime.utcnow() - timedelta(days=6)
   db.commit()
 
-  client.get("/api/chats", headers=auth)
+  purge_expired_chat_tombstones(db)
 
   still_there = db.query(models.Chat).filter(
     models.Chat.id == chat_id
@@ -18,13 +22,13 @@ def test_ttl_is_seven_days(client, db, auth, chat):
   assert still_there is not None, "Chat deleted 6 days ago must survive"
 
 
-def test_purge_after_seven_days(client, db, auth, chat):
+def test_purge_after_seven_days(db, chat):
   """Chats deleted more than 7 days ago must be hard-deleted."""
   chat_id = chat.id  # capture before purge deletes the row
   chat.deleted_at = datetime.utcnow() - timedelta(days=8)
   db.commit()
 
-  client.get("/api/chats", headers=auth)
+  purge_expired_chat_tombstones(db)
 
   gone = db.query(models.Chat).filter(
     models.Chat.id == chat_id
@@ -32,7 +36,88 @@ def test_purge_after_seven_days(client, db, auth, chat):
   assert gone is None, "Chat deleted 8 days ago must be purged"
 
 
-def test_purge_removes_data_dir(client, db, auth, chat):
+def test_expired_tombstone_purge_does_not_hydrate_transcript_json(
+  db, chat,
+):
+  """The retention sweep selects tombstone ids, not complete Chat entities."""
+  chat_id = chat.id
+  chat.messages = [{"role": "user", "content": "large transcript sentinel"}]
+  chat.deleted_at = datetime.utcnow() - timedelta(days=8)
+  db.commit()
+  # Remove the fixture entity from this session so an accidental
+  # ``query(Chat).all()`` must instantiate it and fire the load event below.
+  db.expunge_all()
+
+  hydrated_chat_ids = []
+
+  def on_load(loaded_chat, _context):
+    hydrated_chat_ids.append(loaded_chat.id)
+
+  event.listen(models.Chat, "load", on_load)
+  try:
+    purge_expired_chat_tombstones(db)
+  finally:
+    event.remove(models.Chat, "load", on_load)
+
+  assert chat_id not in hydrated_chat_ids
+
+
+def test_expired_tombstone_survives_drawer_reads(client, db, auth, chat):
+  """GET /api/chats is projection-only and never performs permanent cleanup."""
+  chat_id = chat.id
+  chat.deleted_at = datetime.utcnow() - timedelta(days=8)
+  db.commit()
+
+  response = client.get("/api/chats", headers=auth)
+
+  assert response.status_code == 200
+  db.expire_all()
+  assert db.get(models.Chat, chat_id) is not None
+
+
+def test_new_delete_reclaims_older_expired_tombstones(
+  client, db, auth, chat,
+):
+  """An explicit delete is the runtime lifecycle boundary for old tombstones."""
+  expired_id = str(uuid.uuid4())
+  db.add(models.Chat(
+    id=expired_id,
+    title="Expired tombstone",
+    messages=[],
+    deleted_at=datetime.utcnow() - timedelta(days=8),
+  ))
+  db.commit()
+
+  response = client.delete(f"/api/chats/{chat.id}", headers=auth)
+
+  assert response.status_code == 204
+  db.expire_all()
+  assert db.get(models.Chat, expired_id) is None
+  assert db.get(models.Chat, chat.id).deleted_at is not None
+
+
+def test_old_empty_chat_survives_drawer_reads(client, db, auth):
+  """Age and empty content do not imply owner intent to delete a chat."""
+  chat_id = str(uuid.uuid4())
+  db.add(models.Chat(
+    id=chat_id,
+    title="Old empty chat",
+    messages=[],
+    pending_messages=[],
+    session_id=None,
+    created_at=datetime.utcnow() - timedelta(days=365),
+  ))
+  db.commit()
+
+  response = client.get("/api/chats", headers=auth)
+
+  assert response.status_code == 200
+  assert chat_id in {row["id"] for row in response.json()}
+  db.expire_all()
+  assert db.get(models.Chat, chat_id) is not None
+
+
+def test_purge_removes_data_dir(db, chat):
   """Hard delete must remove /data/chats/{id}/ directory."""
   import os
   chat_id = chat.id  # capture before purge
@@ -45,12 +130,12 @@ def test_purge_removes_data_dir(client, db, auth, chat):
   (chat_dir / "uploads").mkdir()
   (chat_dir / "uploads" / "file.txt").write_text("hello")
 
-  client.get("/api/chats", headers=auth)
+  purge_expired_chat_tombstones(db)
 
   assert not chat_dir.exists(), "Chat directory must be deleted with chat"
 
 
-def test_purge_removes_agent_browser_profile(client, db, auth, chat):
+def test_purge_removes_agent_browser_profile(db, chat):
   """Hard delete must also remove the agent-browser Chromium profile.
 
   Profiles accumulate at /data/agent-browser-profiles/chat-{id}/
@@ -69,14 +154,14 @@ def test_purge_removes_agent_browser_profile(client, db, auth, chat):
   (profile_dir / "Cache").mkdir()
   (profile_dir / "Cache" / "blob.bin").write_text("fake-cache")
 
-  client.get("/api/chats", headers=auth)
+  purge_expired_chat_tombstones(db)
 
   assert not profile_dir.exists(), (
     "agent-browser profile dir must be deleted with chat"
   )
 
 
-def test_purge_removes_memory_note_dir(client, db, auth, chat):
+def test_purge_removes_memory_note_dir(db, chat):
   """Hard delete must also remove the chat's memory note dir.
 
   The note (`shared/memory/chats/<id>/index.md`) is derived from the
@@ -94,22 +179,15 @@ def test_purge_removes_memory_note_dir(client, db, auth, chat):
   note_dir.mkdir(parents=True, exist_ok=True)
   (note_dir / "index.md").write_text("---\ntype: chat\n---\n## Summary\nx")
 
-  client.get("/api/chats", headers=auth)
+  purge_expired_chat_tombstones(db)
 
   assert not note_dir.exists(), (
     "memory note dir must be deleted with chat"
   )
 
 
-def test_notifications_older_than_90_days_purged(client, db, auth):
-  """Notifications older than 90 days must be deleted by list_chats.
-
-  The notification table had no TTL — rows accumulated indefinitely
-  from agent-driven push notifications (POST /api/notifications/send).
-  Ticket 052 caps growth by deleting >90-day rows alongside the
-  existing soft-deleted-chat purge.
-  """
-  import uuid
+def test_old_notifications_survive_chat_drawer_reads(client, db, auth):
+  """Listing chats does not silently impose retention on notification history."""
   notif_source = str(uuid.uuid4())  # doesn't need to match a real chat
   owner = db.query(models.Owner).first()
   old = models.Notification(
@@ -139,7 +217,7 @@ def test_notifications_older_than_90_days_purged(client, db, auth):
 
   assert db.query(models.Notification).filter(
     models.Notification.id == "old-notif"
-  ).first() is None, "Notification older than 90 days must be purged"
+  ).first() is not None, "Chat listing must preserve old notification history"
   assert db.query(models.Notification).filter(
     models.Notification.id == "recent-notif"
   ).first() is not None, "Notification newer than 90 days must survive"


### PR DESCRIPTION
## Summary
- make chat listing a projection-only read with no permanent deletion side effects
- purge only chats the owner explicitly deleted after their seven-day recovery window
- run bounded tombstone cleanup at startup and explicit chat lifecycle writes
- preserve old empty chats and notification history unless their owning lifecycle explicitly removes them

## Verification
- 57 focused backend tests covering retention, chat runs, lifecycle events, and chat routes
- canonical diff check after rebasing onto current upstream main