### PR TITLE
Bound contribution cleanup and provenance metadata

### DIFF
--- a/backend/app/app_apply.py
+++ b/backend/app/app_apply.py
@@ -199,6 +199,34 @@ def reconcile_manifest_icons(db: Session) -> tuple[list[int], list[str]]:
   return repaired, warnings
 
 
+def retire_integrated_app_provenance(db: Session) -> tuple[int, list[str]]:
+  """Bound app provenance metadata at the existing startup maintenance edge."""
+  retired = 0
+  warnings: list[str] = []
+  apps = (
+    db.query(models.App)
+    .filter(
+      models.App.deleted_at.is_(None),
+      models.App.source_dir.isnot(None),
+    )
+    .order_by(models.App.id)
+    .all()
+  )
+  for app in apps:
+    source = Path(app.source_dir)
+    try:
+      if (
+        not app_git.is_repo(source)
+        or not app_git.ref_exists(source, app_git.UPSTREAM_BRANCH)
+      ):
+        continue
+      upstream = app_git.head_sha(source, app_git.UPSTREAM_BRANCH)
+      retired += app_git.retire_landed_equivalent_changes(source, upstream)
+    except Exception as exc:
+      warnings.append(f"app {app.id}: {exc}")
+  return retired, warnings
+
+
 def _validate_local_identity(source_dir: Path, manifest: dict) -> None:
   if manifest["id"] != source_dir.name:
     raise AppApplyError(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -360,6 +360,26 @@ async def lifespan(app):
   except Exception as exc:
     _log.error("manifest-icon reconciliation failed: %s", exc, exc_info=True)
   record_memory_checkpoint("startup_icons_reconciled")
+  try:
+    from app.app_apply import retire_integrated_app_provenance
+    from app.database import SessionLocal as _ProvenanceSession
+    _provenance_db = _ProvenanceSession()
+    try:
+      _retired_refs, _provenance_warnings = (
+        retire_integrated_app_provenance(_provenance_db)
+      )
+      if _retired_refs or _provenance_warnings:
+        _log.info(
+          "app provenance retirement: retired=%d warnings=%d",
+          _retired_refs, len(_provenance_warnings),
+        )
+      for _warning in _provenance_warnings:
+        _log.warning("app provenance retirement: %s", _warning)
+    finally:
+      _provenance_db.close()
+  except Exception as exc:
+    _log.error("app provenance retirement failed: %s", exc, exc_info=True)
+  record_memory_checkpoint("startup_app_provenance_retired")
   # Start the single-writer chat-persistence actor AFTER db init and
   # crash reconciliation. Order is load-bearing: reconcile_startup_chats must
   # run BEFORE the actor exists — recovery has to work even when

--- a/backend/app/platform_update.py
+++ b/backend/app/platform_update.py
@@ -1243,6 +1243,13 @@ def reconcile_clone(
   # is fully in main, so a prior conflict/rollback for it is moot). The working
   # tree is untouched — any uncommitted local edits stay on disk.
   if _is_ancestor(repo, target, local):
+    try:
+      app_git.retire_landed_equivalent_changes(repo, target)
+    except Exception:
+      log.warning(
+        "platform: could not retire contribution provenance",
+        exc_info=True,
+      )
     _set_upstream(repo, target)
     CONFLICT_FLAG.unlink(missing_ok=True)
     ROLLED_BACK_FLAG.unlink(missing_ok=True)

--- a/backend/app/routes/github.py
+++ b/backend/app/routes/github.py
@@ -556,7 +556,7 @@ def _settle_equivalence(record: dict, upstream_sha: str | None = None) -> str | 
 
 
 def _cleanup_terminal_staging_checkout(record: dict) -> bool:
-  """Remove only disposable contribution clones for terminal records."""
+  """Remove a terminal contribution checkout through its owning Git shape."""
   if record.get("status") not in {"merged", "closed"}:
     return False
   plan = record.get("plan") if isinstance(record.get("plan"), dict) else {}
@@ -565,8 +565,73 @@ def _cleanup_terminal_staging_checkout(record: dict) -> bool:
   roots = (data_dir / "contrib", data_dir / "contributions")
   if not any(repo.is_relative_to(root) for root in roots):
     return False
-  if not (repo / ".git").exists():
+  marker = repo / ".git"
+  if not marker.exists() or marker.is_symlink():
     return False
+
+  # A linked worktree has a .git *file*. Deleting its directory directly
+  # strands the registration and branch lock in the source repository. Ask Git
+  # to remove it instead, using the common directory as the stable owner even
+  # while the checkout itself disappears.
+  if marker.is_file():
+    env = dict(os.environ)
+    for name in (
+      "GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE",
+      "GIT_OBJECT_DIRECTORY", "GIT_COMMON_DIR", "GIT_NAMESPACE",
+    ):
+      env.pop(name, None)
+    probe = subprocess.run(
+      [
+        "git", "-C", str(repo), "rev-parse", "--path-format=absolute",
+        "--git-dir", "--git-common-dir",
+      ],
+      cwd=str(repo.parent),
+      capture_output=True,
+      text=True,
+      check=False,
+      env=env,
+    )
+    paths = [Path(line).resolve() for line in probe.stdout.splitlines() if line]
+    if probe.returncode != 0 or len(paths) != 2:
+      return False
+    git_dir, common_dir = paths
+    if not common_dir.is_relative_to(data_dir):
+      return False
+
+    if git_dir != common_dir:
+      removed = subprocess.run(
+        [
+          "git", f"--git-dir={common_dir}",
+          "worktree", "remove", "--force", str(repo),
+        ],
+        cwd=str(data_dir),
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+      )
+      if removed.returncode != 0:
+        detail = (removed.stderr or removed.stdout or "git worktree remove failed").strip()
+        raise ContributionSubmitError(detail[:600])
+      subprocess.run(
+        ["git", f"--git-dir={common_dir}", "worktree", "prune"],
+        cwd=str(data_dir),
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+      )
+      return True
+
+    # Manifest-installed apps use `--separate-git-dir=<record-root>/git`.
+    # That is a main checkout rather than a linked worktree, so remove both
+    # halves only when the git directory is the documented sibling.
+    shutil.rmtree(repo)
+    if common_dir.name == "git" and common_dir.parent == repo.parent:
+      shutil.rmtree(common_dir, ignore_errors=True)
+    return True
+
+  # Ordinary standalone clones keep a real .git directory inside the checkout.
   shutil.rmtree(repo)
   return True
 

--- a/backend/tests/test_app_apply.py
+++ b/backend/tests/test_app_apply.py
@@ -114,6 +114,22 @@ def test_apply_updates_multifile_revision_once(client, auth, db):
   ]
 
 
+def test_startup_retires_integrated_app_provenance(client, auth, db):
+  source = _source()
+  created = _apply(client, auth, source)
+  assert created.status_code == 200, created.text
+  upstream = app_git.head_sha(source, app_git.UPSTREAM_BRANCH)
+
+  with patch.object(
+    app_git, "retire_landed_equivalent_changes", return_value=2,
+  ) as retire:
+    retired, warnings = app_apply.retire_integrated_app_provenance(db)
+
+  assert retired == 2
+  assert warnings == []
+  retire.assert_called_once_with(source, upstream)
+
+
 def test_local_manifest_icon_is_materialized_with_its_accepted_revision(
   client, auth, db,
 ):

--- a/backend/tests/test_github_routes.py
+++ b/backend/tests/test_github_routes.py
@@ -2276,6 +2276,65 @@ def test_standalone_app_review_persists_equivalence_in_installed_repo():
   assert app_git.ref_exists(live, landed)
 
 
+def test_cleanup_terminal_staging_checkout_unregisters_linked_worktree():
+  from app.routes.github import _cleanup_terminal_staging_checkout
+
+  data_dir = Path(get_settings().data_dir)
+  owner = data_dir / "contrib" / "terminal-cleanup-owner"
+  checkout = data_dir / "contrib" / "terminal-cleanup-linked" / "worktree"
+  owner.mkdir(parents=True)
+  subprocess.run(["git", "init", "-q", str(owner)], check=True)
+  subprocess.run(["git", "-C", str(owner), "config", "user.name", "Test"], check=True)
+  subprocess.run(
+    ["git", "-C", str(owner), "config", "user.email", "test@example.invalid"],
+    check=True,
+  )
+  (owner / "tracked.txt").write_text("base\n")
+  subprocess.run(["git", "-C", str(owner), "add", "tracked.txt"], check=True)
+  subprocess.run(["git", "-C", str(owner), "commit", "-qm", "base"], check=True)
+  checkout.parent.mkdir(parents=True)
+  subprocess.run(
+    ["git", "-C", str(owner), "worktree", "add", "-qb", "fix/cleanup-test", str(checkout)],
+    check=True,
+  )
+
+  record = {
+    "status": "merged",
+    "plan": {"repo_path": str(checkout)},
+  }
+  assert _cleanup_terminal_staging_checkout(record) is True
+  assert not checkout.exists()
+  listed = subprocess.run(
+    ["git", "-C", str(owner), "worktree", "list", "--porcelain"],
+    check=True,
+    capture_output=True,
+    text=True,
+  ).stdout
+  assert str(checkout) not in listed
+
+
+def test_cleanup_terminal_staging_checkout_removes_separate_git_dir():
+  from app.routes.github import _cleanup_terminal_staging_checkout
+
+  data_dir = Path(get_settings().data_dir)
+  root = data_dir / "contrib" / "terminal-cleanup-separated"
+  checkout = root / "worktree"
+  git_dir = root / "git"
+  root.mkdir(parents=True)
+  subprocess.run(
+    ["git", "init", "-q", f"--separate-git-dir={git_dir}", str(checkout)],
+    check=True,
+  )
+
+  record = {
+    "status": "closed",
+    "plan": {"repo_path": str(checkout)},
+  }
+  assert _cleanup_terminal_staging_checkout(record) is True
+  assert not checkout.exists()
+  assert not git_dir.exists()
+
+
 def test_ensure_owner_fork_remote_runs_in_repo_after_pinning_origin(
   tmp_path, monkeypatch,
 ):

--- a/backend/tests/test_platform_update.py
+++ b/backend/tests/test_platform_update.py
@@ -179,6 +179,22 @@ def test_clean_update_fast_forwards(clone_env):
   assert pu.reconcile_clone(platform, at_boot=True).status == "up_to_date"
 
 
+def test_up_to_date_retires_integrated_provenance(clone_env, monkeypatch):
+  _origin, platform = clone_env
+  target = _served_sha(platform)
+  calls = []
+  monkeypatch.setattr(
+    app_git,
+    "retire_landed_equivalent_changes",
+    lambda repo, upstream: calls.append((repo, upstream)) or 2,
+  )
+
+  result = pu.reconcile_clone(platform, at_boot=True)
+
+  assert result.status == "up_to_date"
+  assert calls == [(platform, target)]
+
+
 def test_clean_shallow_fast_forward_does_not_fetch_full_history(
   clone_env, monkeypatch,
 ):


### PR DESCRIPTION
## Summary
- remove terminal contribution checkouts through Git worktree ownership rather than treating linked worktrees as ordinary directories
- retain strict status and path boundaries before cleanup
- retire app provenance refs already represented by accepted upstream during startup
- retire platform provenance when an update confirms the local checkout is already current

## Verification
- 218 focused backend tests covering contribution routes, app apply, and platform updates
- Python import compilation and canonical diff checks

All provenance retirement remains strict: a ref is removed only when its reviewed content is already represented by the accepted upstream branch.