### PR TITLE
Expose a shared reconciliation receipt

### DIFF
--- a/backend/app/app_git.py
+++ b/backend/app/app_git.py
@@ -66,6 +66,7 @@ import subprocess
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
+from typing import Iterable
 
 log = logging.getLogger(__name__)
 
@@ -176,6 +177,24 @@ _DIFF_SHA256 = re.compile(r"^[0-9a-f]{64}$")
 
 
 @dataclass
+class ReconciliationReceipt:
+  """Explain one update decision without exposing merge implementation details."""
+
+  proven_present: tuple[str, ...] = ()
+  new_upstream_paths: tuple[str, ...] = ()
+  unresolved_conflict_paths: tuple[str, ...] = ()
+  provenance_refs_used: tuple[str, ...] = ()
+
+  def as_dict(self) -> dict[str, list[str]]:
+    return {
+      "proven_present": list(self.proven_present),
+      "new_upstream_paths": list(self.new_upstream_paths),
+      "unresolved_conflict_paths": list(self.unresolved_conflict_paths),
+      "provenance_refs_used": list(self.provenance_refs_used),
+    }
+
+
+@dataclass
 class MergeResult:
   """Verdict of merging `upstream` into the local `main` branch.
 
@@ -199,6 +218,9 @@ class MergeResult:
   merged_tree_oid: str | None = None
   merge_base_oid: str | None = None
   equivalent_change_refs: tuple[str, ...] = ()
+  reconciliation: ReconciliationReceipt = field(
+    default_factory=ReconciliationReceipt,
+  )
 
 
 @dataclass(frozen=True)
@@ -614,6 +636,32 @@ def _diff_paths(repo: Path, left: str, right: str) -> set[str] | None:
   if proc.returncode != 0:
     return None
   return {path for path in proc.stdout.split("\0") if path}
+
+
+def describe_reconciliation(
+  source_dir: str | Path,
+  shared_base: str,
+  upstream: str,
+  *,
+  conflict_paths: Iterable[str] = (),
+  proven_changes: Iterable[EquivalentChange] = (),
+) -> ReconciliationReceipt:
+  """Return the common platform/app receipt for one semantic merge base.
+
+  ``shared_base`` already contains every reviewed change proven present on
+  both sides. Its diff to ``upstream`` is therefore the genuinely new upstream
+  path set, while ``conflict_paths`` is the residual owner decision. Callers do
+  not need to reconstruct either fact from warnings or Git topology.
+  """
+  repo = Path(source_dir)
+  proven = tuple(proven_changes)
+  new_paths = _diff_paths(repo, shared_base, upstream)
+  return ReconciliationReceipt(
+    proven_present=tuple(change.contribution_id for change in proven),
+    new_upstream_paths=tuple(sorted(new_paths or ())),
+    unresolved_conflict_paths=tuple(sorted(set(conflict_paths))),
+    provenance_refs_used=tuple(change.ref for change in proven),
+  )
 
 
 def _source_is_resolved_projection(
@@ -1133,6 +1181,13 @@ def merge_with_equivalent_changes(
     return None
   merged.merge_base_oid = shared_tree
   merged.equivalent_change_refs = tuple(change.ref for change in applied)
+  merged.reconciliation = describe_reconciliation(
+    repo,
+    shared_tree,
+    upstream,
+    conflict_paths=merged.conflict_paths,
+    proven_changes=applied,
+  )
   return merged
 
 
@@ -1817,6 +1872,16 @@ def merge_upstream(source_dir: str | Path) -> MergeResult:
   ensure_repo(repo)
   _unshallow_if_no_merge_base(repo)
   ordinary = merge_refs(repo, LOCAL_BRANCH, UPSTREAM_BRANCH)
+  ordinary_base = _run(
+    repo, "merge-base", LOCAL_BRANCH, UPSTREAM_BRANCH, check=False,
+  ).stdout.strip()
+  if ordinary_base:
+    ordinary.reconciliation = describe_reconciliation(
+      repo,
+      ordinary_base,
+      UPSTREAM_BRANCH,
+      conflict_paths=ordinary.conflict_paths,
+    )
   if ordinary.status == "clean":
     return ordinary
   # A normal three-way merge can conflict when both sides carry the same

--- a/backend/app/bootstrap.py
+++ b/backend/app/bootstrap.py
@@ -193,7 +193,10 @@ async def ensure_bootstrap_apps_installed(db: Session) -> None:
       bootstrap_app.name, bootstrap_app.manifest_url,
     )
     try:
-      app, mode, warnings, _manifest, _conflicts, _divergence = (
+      (
+        app, mode, warnings, _manifest, _conflicts, _divergence,
+        _reconciliation,
+      ) = (
         await install_from_manifest(
           db,
           manifest_url=bootstrap_app.manifest_url,

--- a/backend/app/install.py
+++ b/backend/app/install.py
@@ -1845,8 +1845,11 @@ async def install_from_manifest(
   expected_app_id: int | None = None,
   expected_upstream_commit: str | None = None,
   expected_candidate_digest: str | None = None,
-) -> tuple[models.App, str, list[str], dict, list[str], str]:
-  """Returns `(app, mode, warnings, manifest, conflict_paths, divergence)`.
+) -> tuple[
+  models.App, str, list[str], dict, list[str], str,
+  app_git.ReconciliationReceipt,
+]:
+  """Returns app state plus a shared structured reconciliation receipt.
 
   The parsed manifest dict comes back so callers can read fields the
   App row doesn't store (notably `version`) without re-fetching.
@@ -2260,6 +2263,7 @@ async def install_from_manifest(
   warnings: list[str] = []
   conflict_paths: list[str] = []
   divergence: str = "none"
+  reconciliation = app_git.ReconciliationReceipt()
   # Set when upstream content is actually folded into the served `main`
   # branch (a clean merge, or a forced take-upstream). The post-write
   # commit then replays the result on the upstream tip as its sole parent
@@ -2697,9 +2701,22 @@ async def install_from_manifest(
             # fast-forward the served bundle — treat it as a conflict for the
             # agent to resolve, mirroring the clean-merge branch below, rather
             # than half-applying a tree with no entry.
+            if prev_upstream_commit:
+              reconciliation = await asyncio.to_thread(
+                app_git.describe_reconciliation,
+                git_source_dir,
+                prev_upstream_commit,
+                app_git.UPSTREAM_BRANCH,
+              )
             if entry_key not in source_tree:
               mode = "conflict"
               conflict_paths = [entry_key]
+              reconciliation = app_git.ReconciliationReceipt(
+                proven_present=reconciliation.proven_present,
+                new_upstream_paths=reconciliation.new_upstream_paths,
+                unresolved_conflict_paths=(entry_key,),
+                provenance_refs_used=reconciliation.provenance_refs_used,
+              )
             else:
               divergence = "fast_forward"
               merge_applied = True
@@ -2718,6 +2735,7 @@ async def install_from_manifest(
             merge = await asyncio.to_thread(
               app_git.merge_upstream, git_source_dir,
             )
+            reconciliation = merge.reconciliation
             if merge.status == "conflict":
               if force_core_store_update:
                 # Core App Store self-update: published upstream wins, keep the
@@ -2753,6 +2771,11 @@ async def install_from_manifest(
                   warnings.append(
                     "auto-resolved a version-only update conflict "
                     "(took the upstream version)"
+                  )
+                  reconciliation = app_git.ReconciliationReceipt(
+                    proven_present=reconciliation.proven_present,
+                    new_upstream_paths=reconciliation.new_upstream_paths,
+                    provenance_refs_used=reconciliation.provenance_refs_used,
                   )
                   # Exec bits come from the same merged tree the resolution was
                   # built on, mirroring the clean-merge branch above.
@@ -3092,7 +3115,10 @@ async def install_from_manifest(
       activity.log_event(
         "app_install", app_id=app.id, slug=app.slug, source=source,
       )
-      return app, mode, warnings, manifest, conflict_paths, divergence
+      return (
+        app, mode, warnings, manifest, conflict_paths, divergence,
+        reconciliation,
+      )
 
     # Storage seeds — fresh installs always seed; updates only fill in keys
     # that don't exist yet so user data isn't clobbered. Under the per-app lock
@@ -3334,7 +3360,10 @@ async def install_from_manifest(
       log.exception("install: initialization job failed to start")
       warnings.append(f"initialization failed to start — {exc!r}")
 
-  return app, mode, warnings, manifest, conflict_paths, divergence
+  return (
+    app, mode, warnings, manifest, conflict_paths, divergence,
+    reconciliation,
+  )
 
 
 def _cleanup(paths: list[Path]) -> None:

--- a/backend/app/platform_update.py
+++ b/backend/app/platform_update.py
@@ -240,6 +240,7 @@ class PlatformApplyResult(TypedDict):
   conflict_paths: list[str]
   chat_id: str | None
   phase: str
+  reconciliation: dict[str, list[str]]
 
 
 class PlatformRestartResponse(TypedDict):
@@ -324,6 +325,9 @@ class ReconcileResult:
   # still held. Hook refresh reads every allowlisted blob from this immutable
   # generation rather than trusting a locally merged HEAD or a moving ref.
   hook_source_sha: str | None = None
+  reconciliation: app_git.ReconciliationReceipt = field(
+    default_factory=app_git.ReconciliationReceipt,
+  )
 
 
 def platform_update_progress() -> PlatformUpdateProgress:
@@ -1254,6 +1258,8 @@ def reconcile_clone(
     _write_offline_flag("no_target_ref")
     return ReconcileResult("offline", pre, pre, None, error="no_target_ref")
 
+  reconciliation = app_git.ReconciliationReceipt()
+
   # Already integrated: local main contains origin/main. Nothing to apply. Sync
   # the upstream marker and clear any stale conflict/rollback flag (this target
   # is fully in main, so a prior conflict/rollback for it is moot). The working
@@ -1309,7 +1315,15 @@ def reconcile_clone(
       # an `upstream` marker that could drift and let `reset --hard` silently
       # discard committed local edits.
       _git("reset", "--hard", target, repo=repo)
+      reconciliation = app_git.describe_reconciliation(repo, pre, target)
     else:
+      ordinary_base = _git(
+        "merge-base", pre, target, repo=repo, check=False,
+      ).stdout.strip()
+      if ordinary_base:
+        reconciliation = app_git.describe_reconciliation(
+          repo, ordinary_base, target,
+        )
       # Main and target diverged: merge the reviewed upstream tree ONCE. This
       # preserves local commit identities and makes one resolver pass see every
       # net conflict instead of stopping once per historical local commit.
@@ -1342,6 +1356,8 @@ def reconcile_clone(
         # genuine later conflict) returns the reduced conflict set plus its
         # semantic base so the resolver preserves every proven elimination.
         equivalent = app_git.merge_with_equivalent_changes(repo, pre, target)
+        if equivalent is not None:
+          reconciliation = equivalent.reconciliation
         if equivalent is not None and equivalent.merged_tree_oid:
           _commit_equivalent_merge_tree(
             repo,
@@ -1374,7 +1390,18 @@ def reconcile_clone(
           ROLLED_BACK_FLAG.unlink(missing_ok=True)
           _clear_reconcile_pre()
           return ReconcileResult(
-            "conflict", pre, pre, target, conflict_paths=conflict_paths,
+            "conflict", pre, pre, target,
+            conflict_paths=conflict_paths,
+            reconciliation=(
+              equivalent.reconciliation
+              if equivalent is not None
+              else app_git.describe_reconciliation(
+                repo,
+                ordinary_base,
+                target,
+                conflict_paths=conflict_paths,
+              )
+            ),
           )
 
     # Post-reconcile import probe: a text-clean ff/merge can still produce a
@@ -1420,7 +1447,10 @@ def reconcile_clone(
   if at_boot:
     RESTART_NEEDED_FLAG.unlink(missing_ok=True)
   _clear_reconcile_pre()
-  return ReconcileResult("updated", pre, new_sha, target, error=None)
+  return ReconcileResult(
+    "updated", pre, new_sha, target, error=None,
+    reconciliation=reconciliation,
+  )
 
 
 def _reconcile_under_lock(
@@ -1886,6 +1916,7 @@ async def apply_platform_update(
         conflict_paths=res.conflict_paths,
         chat_id=chat_id,
         phase=final_phase.value,
+        reconciliation=res.reconciliation.as_dict(),
       )
     except Exception as exc:
       _set_update_progress(

--- a/backend/app/routes/apps.py
+++ b/backend/app/routes/apps.py
@@ -874,7 +874,10 @@ async def install_app(
   # overlap lets one delete what the other just wrote
   # (fs_locks.install_uninstall_lock has the full rationale).
   async with fs_locks.install_uninstall_lock():
-    app, mode, warnings, manifest, conflict_paths, divergence = (
+    (
+      app, mode, warnings, manifest, conflict_paths, divergence,
+      reconciliation,
+    ) = (
       await install_from_manifest(
         db,
         manifest_url=body.manifest_url,
@@ -939,6 +942,9 @@ async def install_app(
     warnings=warnings,
     conflict_paths=conflict_paths,
     divergence=divergence,
+    reconciliation=schemas.ReconciliationReceiptOut(
+      **reconciliation.as_dict(),
+    ),
   )
 
 
@@ -2056,7 +2062,7 @@ async def resolve_app_update(
     # icon, skills, seeds, and schedule. Re-enter it without holding the inner
     # app/source locks; it acquires those in the global order itself.
     try:
-      reapplied, mode, warnings, _, conflict_paths, _ = (
+      reapplied, mode, warnings, _, conflict_paths, _, reconciliation = (
         await install.install_from_manifest(
           db,
           manifest_url=None,
@@ -2095,6 +2101,9 @@ async def resolve_app_update(
     app=reapplied,
     warnings=warnings,
     conflict_paths=conflict_paths,
+    reconciliation=schemas.ReconciliationReceiptOut(
+      **reconciliation.as_dict(),
+    ),
   )
 
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -199,13 +199,6 @@ class AppApplyOut(BaseModel):
   app: AppOut
 
 
-class AppResolveUpdateOut(BaseModel):
-  mode: Literal["updated", "conflict"]
-  app: AppOut
-  warnings: list[str] = Field(default_factory=list)
-  conflict_paths: list[str] = Field(default_factory=list)
-
-
 class AppInstall(BaseModel):
   """Body for POST /api/apps/install — atomic install from a manifest.
 
@@ -241,6 +234,23 @@ class AppPreviewOut(BaseModel):
   capability_diff: dict
 
 
+class ReconciliationReceiptOut(BaseModel):
+  proven_present: list[str] = Field(default_factory=list)
+  new_upstream_paths: list[str] = Field(default_factory=list)
+  unresolved_conflict_paths: list[str] = Field(default_factory=list)
+  provenance_refs_used: list[str] = Field(default_factory=list)
+
+
+class AppResolveUpdateOut(BaseModel):
+  mode: Literal["updated", "conflict"]
+  app: AppOut
+  warnings: list[str] = Field(default_factory=list)
+  conflict_paths: list[str] = Field(default_factory=list)
+  reconciliation: ReconciliationReceiptOut = Field(
+    default_factory=ReconciliationReceiptOut,
+  )
+
+
 class AppInstallOut(AppOut):
   """Install endpoint response — AppOut plus install-only fields."""
   # 'install' for a fresh row, 'update' if a same-manifest app already
@@ -269,6 +279,9 @@ class AppInstallOut(AppOut):
   # carried. Meaningful only when per-app git is enabled; conflicts are
   # carried by `mode == "conflict"`, not this field.
   divergence: Literal["none", "fast_forward", "clean_merge"] = "none"
+  reconciliation: ReconciliationReceiptOut = Field(
+    default_factory=ReconciliationReceiptOut,
+  )
 
 
 class AppScheduleUpdate(BaseModel):

--- a/backend/tests/test_app_git.py
+++ b/backend/tests/test_app_git.py
@@ -1115,6 +1115,12 @@ def test_partial_equivalence_materializes_only_residual_app_conflicts(tmp_path):
   assert result.conflict_paths == ["config.js"]
   assert result.merge_base_oid
   assert result.equivalent_change_refs == (landed,)
+  assert result.reconciliation.proven_present == ("partial-shared-change",)
+  assert result.reconciliation.provenance_refs_used == (landed,)
+  assert result.reconciliation.new_upstream_paths == (
+    "config.js", "upstream.js",
+  )
+  assert result.reconciliation.unresolved_conflict_paths == ("config.js",)
 
   conflicts = app_git.start_conflict_merge(
     repo, merge_base=result.merge_base_oid,

--- a/backend/tests/test_apps_install.py
+++ b/backend/tests/test_apps_install.py
@@ -2724,6 +2724,8 @@ def test_flag_on_clean_update_without_local_edits_is_fast_forward(
   payload = r2.json()
   assert payload["mode"] == "update"
   assert payload["divergence"] == "fast_forward"
+  assert "index.jsx" in payload["reconciliation"]["new_upstream_paths"]
+  assert payload["reconciliation"]["proven_present"] == []
   # With no local edits the served source must be the new upstream verbatim.
   # The latent bug let a failed in-memory merge leave the OLD bytes on disk
   # while still bumping the version, so assert the new content actually
@@ -2905,6 +2907,12 @@ def test_app_store_update_recognizes_squashed_local_contribution(
   assert body["mode"] == "update"
   assert body["divergence"] == "clean_merge"
   assert any("already present upstream" in item for item in body["warnings"])
+  assert body["reconciliation"] == {
+    "proven_present": ["app-store-reviewed-change"],
+    "new_upstream_paths": [],
+    "unresolved_conflict_paths": [],
+    "provenance_refs_used": [landed],
+  }
   assert "LOCAL FOLLOWUP" in entry.read_text()
   assert not app_git.ref_exists(source, landed)
 
@@ -2946,6 +2954,9 @@ def test_flag_on_conflicting_update_leaves_source_unchanged_until_resolve(
   assert payload["version"] == "1.0.0"
   assert payload["upstream_version"] == "2.0.0"
   assert "index.jsx" in payload["conflict_paths"]
+  assert payload["reconciliation"]["unresolved_conflict_paths"] == [
+    "index.jsx",
+  ]
 
   # The update attempt itself does not write conflict markers or leave a merge
   # in progress. The owner must click Resolve in chat before that happens.

--- a/backend/tests/test_platform_routes.py
+++ b/backend/tests/test_platform_routes.py
@@ -78,6 +78,12 @@ def test_apply_forwards_exact_reviewed_plan(client, auth, monkeypatch):
       "conflict_paths": [],
       "chat_id": None,
       "phase": "complete",
+      "reconciliation": {
+        "proven_present": [],
+        "new_upstream_paths": [],
+        "unresolved_conflict_paths": [],
+        "provenance_refs_used": [],
+      },
     }
 
   monkeypatch.setattr(

--- a/backend/tests/test_platform_update.py
+++ b/backend/tests/test_platform_update.py
@@ -410,6 +410,14 @@ def test_partial_provenance_persists_reduced_platform_conflict(clone_env):
 
   assert res.status == "conflict"
   assert res.conflict_paths == ["backend/app/foo.py"]
+  assert res.reconciliation.proven_present == ("partial-platform-change",)
+  assert res.reconciliation.provenance_refs_used == (landed,)
+  assert res.reconciliation.new_upstream_paths == (
+    "backend/app/foo.py", "backend/app/main.py",
+  )
+  assert res.reconciliation.unresolved_conflict_paths == (
+    "backend/app/foo.py",
+  )
   assert _served_sha(platform) == pre
   flag = pu._read_conflict_flag()
   assert flag["paths"] == ["backend/app/foo.py"]


### PR DESCRIPTION
## Summary
- expose one typed reconciliation receipt for both platform and app updates
- report reviewed changes proven present on both sides and the provenance refs used
- distinguish genuinely new upstream paths from only the residual paths that still conflict
- return the same structured explanation for clean, fast-forward, equivalent-change, and conflict outcomes

## Verification
- 316 focused backend tests covering app reconciliation, installation responses, platform routes, and platform updates
- Python import compilation and canonical diff checks

This is additive response metadata; the strict provenance and merge decisions remain owned by the existing shared reconciliation engine.