### PR TITLE
Keep resumed goals visible

### DIFF
--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -112,7 +112,7 @@ import {
   railAtRunStart,
 } from './buildPhaseRail.js'
 import {
-  goalObjectiveFromText,
+  goalObjectiveAtRunStart,
   latestGoalObjective,
   progressRailViewModel,
 } from './goalProgress.js'
@@ -1228,7 +1228,10 @@ export default function ChatView({
       // position the live stream did (old-run phases, then reset) and the
       // rail always lands on the run being displayed.
       setBuildPhases(railAtRunStart())
-      setActiveGoalState(goalObjectiveFromText(message?.content))
+      setActiveGoalState(goalObjectiveAtRunStart(
+        message?.content,
+        messagesRef.current,
+      ))
       const consumedCids = message?._consumed_cids
       const serverRows = Array.isArray(message?._messages)
         ? message._messages.map(stripInternalUserMessageFields).filter(Boolean)
@@ -2292,7 +2295,10 @@ export default function ChatView({
             // the rail resets. A plain enqueue (started falsy) must NOT
             // touch the in-flight build's rail.
             setBuildPhases(railAtRunStart())
-            setActiveGoalState(goalObjectiveFromText(text))
+            setActiveGoalState(goalObjectiveAtRunStart(
+              text,
+              messagesRef.current,
+            ))
             setSending(true)
             setServerRunningState(true)
             // The queued send was promoted straight into the active turn, so
@@ -2367,7 +2373,10 @@ export default function ChatView({
           // Same run-start semantics as the branch above: this send became
           // the first message of a NEW run, so the rail resets here too.
           setBuildPhases(railAtRunStart())
-          setActiveGoalState(goalObjectiveFromText(text))
+          setActiveGoalState(goalObjectiveAtRunStart(
+            text,
+            messagesRef.current,
+          ))
           // Apply the shared send-intent rule before appending. A message that
           // raced into a started turn
           // is still a new send becoming the active turn, so it pins only
@@ -2443,7 +2452,7 @@ export default function ChatView({
     // above) wiped the in-flight build's rail, which the next catch-up
     // replay then silently repopulated (see buildPhaseRail.js).
     setBuildPhases(railAtRunStart())
-    setActiveGoalState(goalObjectiveFromText(text))
+    setActiveGoalState(goalObjectiveAtRunStart(text, messagesRef.current))
 
     // Direct sends use the same submit-time decision as queued/steered sends.
     // A legitimate pin changes FOLLOW_BOTTOM to PIN_USER_MSG, so reply growth

--- a/frontend/src/components/ChatView/__tests__/goalProgress.test.js
+++ b/frontend/src/components/ChatView/__tests__/goalProgress.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 
 import {
+  goalObjectiveAtRunStart,
   goalObjectiveFromText,
   latestGoalObjective,
   progressRailViewModel,
@@ -30,7 +31,7 @@ test('goalObjectiveFromText does not present clear or an empty command as active
   assert.equal(goalObjectiveFromText('/goal CLEAR'), '')
 })
 
-test('latestGoalObjective recovers only the latest visible owner turn', () => {
+test('latestGoalObjective recovers only the current visible owner turn', () => {
   assert.equal(latestGoalObjective([
     { role: 'user', content: '/goal old objective' },
     { role: 'assistant', content: 'Done' },
@@ -41,6 +42,54 @@ test('latestGoalObjective recovers only the latest visible owner turn', () => {
     { role: 'user', content: 'hidden answer', hidden: true },
     { role: 'assistant', content: 'Working', partial: true },
   ]), 'build the indicator')
+})
+
+test('a resumable continue keeps the same goal through live start and cold attach', () => {
+  const interruptedGoal = [
+    { role: 'user', content: '/goal finish the migration' },
+    {
+      role: 'assistant',
+      content: 'Partly done',
+      blocks: [{
+        type: 'error',
+        message: 'Interrupted',
+        resumable: true,
+      }],
+    },
+  ]
+  assert.equal(
+    goalObjectiveAtRunStart('continue', interruptedGoal),
+    'finish the migration',
+  )
+  assert.equal(
+    latestGoalObjective([
+      ...interruptedGoal,
+      { role: 'user', content: 'continue' },
+      { role: 'assistant', content: 'Working', partial: true },
+    ]),
+    'finish the migration',
+  )
+})
+
+test('continue does not revive a completed, cleared, or superseded goal', () => {
+  assert.equal(goalObjectiveAtRunStart('continue', [
+    { role: 'user', content: '/goal old objective' },
+    { role: 'assistant', content: 'Done' },
+  ]), '')
+  assert.equal(latestGoalObjective([
+    { role: 'user', content: '/goal old objective' },
+    { role: 'assistant', blocks: [{ type: 'error', resumable: true }] },
+    { role: 'user', content: '/goal clear' },
+    { role: 'assistant', blocks: [{ type: 'error', resumable: true }] },
+    { role: 'user', content: 'continue' },
+  ]), '')
+  assert.equal(latestGoalObjective([
+    { role: 'user', content: '/goal old objective' },
+    { role: 'assistant', blocks: [{ type: 'error', resumable: true }] },
+    { role: 'user', content: 'new subject' },
+    { role: 'assistant', blocks: [{ type: 'error', resumable: true }] },
+    { role: 'user', content: 'continue' },
+  ]), '')
 })
 
 test('the goal reuses the progress rail and stays as context for build phases', () => {
@@ -76,8 +125,8 @@ test('ChatView binds goal state to the existing run-start and turn-end lifecycle
   assert.equal(runStarts.length, 4, 'every current run-start seam should be covered')
   for (const suffix of runStarts) {
     assert.match(
-      suffix.slice(0, 260),
-      /setActiveGoalState\(goalObjectiveFromText\(/,
+      suffix.slice(0, 380),
+      /setActiveGoalState\(goalObjectiveAtRunStart\(/,
       'goal and build progress must reset together at each run boundary',
     )
   }

--- a/frontend/src/components/ChatView/goalProgress.js
+++ b/frontend/src/components/ChatView/goalProgress.js
@@ -18,21 +18,71 @@ export function goalObjectiveFromText(text) {
   return objective
 }
 
+function isContinue(text) {
+  return typeof text === 'string' && text.trim().toLowerCase() === 'continue'
+}
+
+function hasResumableTail(message) {
+  if (message?.role !== 'assistant' || !Array.isArray(message.blocks)) return false
+  const tail = message.blocks[message.blocks.length - 1]
+  return tail?.type === 'error' && tail.resumable === true
+}
+
+function previousVisibleMessageIndex(messages, beforeIndex) {
+  for (let i = beforeIndex - 1; i >= 0; i -= 1) {
+    if (!messages[i]?.hidden) return i
+  }
+  return -1
+}
+
+function priorGoalObjective(messages, beforeIndex) {
+  for (let i = beforeIndex - 1; i >= 0; i -= 1) {
+    const message = messages[i]
+    if (message?.role !== 'user' || message.hidden) continue
+    if (isContinue(message.content)) continue
+    return goalObjectiveFromText(message.content)
+  }
+  return ''
+}
+
 /**
  * Recover a goal when mounting into a turn that is already running.
  *
- * The latest visible owner message is the run-start message on an ordinary
- * attach. Live steers do not replace the in-memory goal state; this fallback is
- * only for a fresh mount/reconnect where that local state does not yet exist.
+ * An ordinary attach reads the objective from the latest visible owner
+ * message. A resumed goal instead starts with the synthetic owner message
+ * "continue"; accept that as goal continuity only when it directly follows
+ * the same resumable assistant tail that exposes the Resume action.
  */
 export function latestGoalObjective(messages) {
   if (!Array.isArray(messages)) return ''
   for (let i = messages.length - 1; i >= 0; i -= 1) {
     const message = messages[i]
     if (message?.role !== 'user' || message.hidden) continue
-    return goalObjectiveFromText(message.content)
+    const directObjective = goalObjectiveFromText(message.content)
+    if (directObjective) return directObjective
+    if (!isContinue(message.content)) return ''
+    const resumeTailIndex = previousVisibleMessageIndex(messages, i)
+    if (resumeTailIndex < 0 || !hasResumableTail(messages[resumeTailIndex])) return ''
+    return priorGoalObjective(messages, resumeTailIndex)
   }
   return ''
+}
+
+/**
+ * Resolve the goal at the synchronous run-start seam.
+ *
+ * Before a one-tap Resume is appended, the resumable assistant note is still
+ * the visible transcript tail. This mirrors latestGoalObjective's cold-attach
+ * rule so live starts and reconnects cannot disagree about the active goal.
+ */
+export function goalObjectiveAtRunStart(text, messages) {
+  const directObjective = goalObjectiveFromText(text)
+  if (directObjective || !isContinue(text) || !Array.isArray(messages)) {
+    return directObjective
+  }
+  const tailIndex = previousVisibleMessageIndex(messages, messages.length)
+  if (tailIndex < 0 || !hasResumableTail(messages[tailIndex])) return ''
+  return priorGoalObjective(messages, tailIndex)
 }
 
 /**


### PR DESCRIPTION
## Summary
- keep the original goal objective visible when a paused goal resumes with `continue`
- recover the same objective after remounting or reconnecting
- avoid reviving completed, cleared, or superseded goals

## Testing
- `node --loader=./src/lib/__tests__/vite-env-loader.mjs --test src/components/ChatView/__tests__/goalProgress.test.js`
- `npm run build`