### PR TITLE
chat embed: report a frame that never boots instead of staying silently blank

### DIFF
--- a/frontend/public/mobius-runtime.js
+++ b/frontend/public/mobius-runtime.js
@@ -2475,6 +2475,19 @@ export function makeEmbedAuthorizationHandoff({
   }
 }
 
+// How long a freshly mounted embed frame may stay completely silent before
+// makeChat reports it dead. The child's very first message (BOOTSTRAP_READY)
+// normally arrives within a couple of seconds of the document load; 15s
+// tolerates a cold cache on a slow link while still bounding the
+// silent-black-panel failure — a frame whose document never executes posts
+// nothing, fires no 'error', and otherwise leaves apps staring at an
+// invisible (opacity:0) embed forever. Observed in the field when an edge
+// proxy stamped `frame-ancestors 'self'`/X-Frame-Options onto the embed
+// route: its ancestor app frame is intentionally opaque, so the browser
+// refused the document without any signal the parent could hear.
+// Overridable per mount via opts.bootstrapTimeoutMs (tests, unusual hosts).
+const EMBED_BOOTSTRAP_TIMEOUT_MS = 15000
+
 export function makeChat({ appId, getToken, storage }) {
   // Lazily create a chat the agent turn can be attributed to, via the
   // app-attributed backend contract (design §1.1: POST /api/app-chats).
@@ -2774,6 +2787,37 @@ export function makeChat({ appId, getToken, storage }) {
 
     let frameReveal = makeFrameRevealController(iframe)
 
+    // Watchdog for a frame that can never boot. Every failure PAST first
+    // contact has a reporter (authorization attempts emit 'error'; the child
+    // posts EMBED_ERROR for load/stream problems) — but a document that never
+    // executes at all posts nothing, and the panel stays silently blank.
+    // Report-only: the frame is left in place, so a genuinely slow boot that
+    // completes after the deadline still authorizes and fires 'ready'
+    // normally; 'error' is sticky, so a handler attached later still
+    // observes it.
+    const bootstrapTimeoutMs = (
+      Number.isFinite(opts.bootstrapTimeoutMs) && opts.bootstrapTimeoutMs > 0
+    ) ? opts.bootstrapTimeoutMs : EMBED_BOOTSTRAP_TIMEOUT_MS
+    let bootstrapTimer = null
+    function disarmBootstrapWatchdog() {
+      if (bootstrapTimer != null) {
+        clearTimeout(bootstrapTimer)
+        bootstrapTimer = null
+      }
+    }
+    function armBootstrapWatchdog() {
+      disarmBootstrapWatchdog()
+      const watchedFrame = iframe
+      bootstrapTimer = setTimeout(() => {
+        bootstrapTimer = null
+        if (watchedFrame !== iframe) return
+        emit('error', {
+          chatId,
+          error: 'embedded chat did not start (its frame was blocked or failed to load)',
+        })
+      }, bootstrapTimeoutMs)
+    }
+
     // Keep the older prompt-chip contract for apps that still use it. Newer
     // apps can provide one calm guidance line instead; guidance wins in the
     // renderer when both are present.
@@ -2965,6 +3009,7 @@ export function makeChat({ appId, getToken, storage }) {
       hasAuthorizedOnce = false
       authorizationHandoff = createAuthorizationHandoff()
       if (previous.parentNode) previous.parentNode.replaceChild(iframe, previous)
+      armBootstrapWatchdog()
     }
 
     function postGuidance() {
@@ -2984,6 +3029,9 @@ export function makeChat({ appId, getToken, storage }) {
       const msg = e.data
       if (!msg || typeof msg !== 'object') return
       if (typeof msg.type !== 'string' || !msg.type.startsWith(EMBED_NS)) return
+      // Any authentic embed message from the current frame (the source check
+      // above) proves its document booted — the watchdog's only question.
+      disarmBootstrapWatchdog()
       // A lazy route can finish document loading before its React effect has
       // installed the INIT listener. Mint the one-use grant only after the
       // exact child WindowProxy says that receiver is ready.
@@ -3054,6 +3102,7 @@ export function makeChat({ appId, getToken, storage }) {
     authorizationHandoff = createAuthorizationHandoff()
     window.addEventListener('message', onMessage)
     frameMount.appendChild(iframe)
+    armBootstrapWatchdog()
     if (controlsShell) {
       mount.appendChild(controlsShell)
       refreshChatOptions().catch(() => {})
@@ -3081,6 +3130,7 @@ export function makeChat({ appId, getToken, storage }) {
       },
       destroy() {
         window.removeEventListener('message', onMessage)
+        disarmBootstrapWatchdog()
         authorizationHandoff?.destroy()
         frameReveal?.destroy()
         revokeEmbed(chatId, instanceId)

--- a/frontend/src/lib/__tests__/mobiusRuntime.test.js
+++ b/frontend/src/lib/__tests__/mobiusRuntime.test.js
@@ -598,3 +598,114 @@ test('signal helper never queues an event above the server ASCII byte budget', a
     globalThis.clearTimeout = previousClearTimeout
   }
 })
+
+// ── makeChat embed bootstrap watchdog ────────────────────────────────────────
+//
+// A nested embed frame whose document never executes (an ancestor frame
+// policy blocking it, a failed asset) posts NOTHING: no BOOTSTRAP_READY, no
+// EMBED_ERROR — so without a watchdog the mount looks alive while the panel
+// stays blank forever. These tests pin the bounded-silence contract: silence
+// past the deadline emits the sticky 'error'; any authentic embed message
+// stands the watchdog down.
+
+function fakeEmbedDocument() {
+  const frames = []
+  const doc = {
+    createElement(tag) {
+      const el = {
+        tag,
+        style: {},
+        attributes: {},
+        setAttribute(name, value) { this.attributes[name] = value },
+        addEventListener() {},
+        removeEventListener() {},
+        contentWindow: {
+          messages: [],
+          postMessage(data) { this.messages.push(data) },
+        },
+        parentNode: null,
+      }
+      if (tag === 'iframe') frames.push(el)
+      return el
+    },
+  }
+  const mount = {
+    children: [],
+    appendChild(el) {
+      this.children.push(el)
+      el.parentNode = this
+    },
+    removeChild(el) {
+      this.children = this.children.filter((child) => child !== el)
+      el.parentNode = null
+    },
+  }
+  return { doc, mount, frames }
+}
+
+test('embedded chat mount reports a frame that never boots', async () => {
+  await withFakeWindow(async () => {
+    const { doc, mount } = fakeEmbedDocument()
+    const previousDocument = globalThis.document
+    globalThis.document = doc
+    try {
+      const chat = makeChat({
+        appId: 81,
+        getToken: async () => 'app-token',
+        storage: null,
+      })
+      const handle = await chat({
+        mount,
+        chatId: 'chat-silent',
+        bootstrapTimeoutMs: 20,
+      })
+      await new Promise((resolve) => setTimeout(resolve, 80))
+      // Attach AFTER the deadline: the sticky emitter must replay the error
+      // to a late listener, exactly like the mount-time READY contract.
+      const seen = []
+      handle.on('error', (detail) => seen.push(detail))
+      assert.equal(seen.length, 1)
+      assert.equal(seen[0].chatId, 'chat-silent')
+      assert.match(seen[0].error, /did not start/)
+      handle.destroy()
+    } finally {
+      globalThis.document = previousDocument
+    }
+  })
+})
+
+test('embedded chat watchdog stands down once the frame posts', async () => {
+  await withFakeWindow(async ({ window: fakeWindow }) => {
+    const { doc, mount, frames } = fakeEmbedDocument()
+    const previousDocument = globalThis.document
+    globalThis.document = doc
+    try {
+      const chat = makeChat({
+        appId: 82,
+        getToken: async () => 'app-token',
+        storage: null,
+      })
+      const handle = await chat({
+        mount,
+        chatId: 'chat-booted',
+        bootstrapTimeoutMs: 30,
+      })
+      const seen = []
+      handle.on('error', (detail) => seen.push(detail))
+      // The child's first authentic message (bootstrap-ready from the exact
+      // mounted frame) proves the document booted.
+      fakeWindow.emit(
+        { type: 'moebius:chat-embed:bootstrap-ready' },
+        { origin: 'null', source: frames[0].contentWindow },
+      )
+      await new Promise((resolve) => setTimeout(resolve, 90))
+      assert.equal(
+        seen.filter((detail) => /did not start/.test(detail.error)).length,
+        0,
+      )
+      handle.destroy()
+    } finally {
+      globalThis.document = previousDocument
+    }
+  })
+})


### PR DESCRIPTION
## Problem

A mounted embedded chat (`window.mobius.chat({mount, ...})`) whose nested frame document never executes fails **completely silently**. Every failure past first contact has a reporter — authorization attempts emit `'error'`, the child posts `EMBED_ERROR` for load/stream problems — but a document that never runs posts nothing at all. The handle resolves, the iframe sits at its pre-reveal `opacity:0`, and the app shows a dead blank panel forever, with no signal it can act on.

This is not hypothetical: observed in the field on a deployment whose edge proxy stamped `frame-ancestors 'self'` + `X-Frame-Options: SAMEORIGIN` onto `/shell/embed/chat`. The embed's ancestor app frame is intentionally opaque-origin, so the browser refused to display the document — HTTP 200, zero script execution, zero messages, and a user-facing black pane that took days to diagnose. (The bundled Caddyfile already carves out the embed route; a stale or third-party proxy can re-introduce the block at any time, and corporate/CDN policies can do the same.)

## Fix

Arm a bounded **bootstrap watchdog** per mounted embed frame:

- armed on mount and re-armed on frame replacement (`replaceEmbedFrame`);
- stood down by the first authentic embed message from the exact current frame (source-checked), normally `BOOTSTRAP_READY` within a couple of seconds;
- on silence past the deadline (default 15s, per-mount override `opts.bootstrapTimeoutMs`), emits the **sticky** `'error'` event with `{chatId, error}` so a handler attached after the fact still observes it — the same replay contract as the mount-time `READY`;
- report-only: the frame is left in place, so a genuinely slow boot that completes after the deadline still authorizes and fires `'ready'` normally;
- cleared on `destroy()`.

Apps can then surface their existing "chat isn't available here" states instead of a silent black panel. A companion PR to app-reflection adopts it.

## Tests

Two new `node:test` cases in `mobiusRuntime.test.js` pin the contract: a never-booting frame emits the sticky error (verified via a deliberately LATE listener), and a frame that posts `bootstrap-ready` never triggers the watchdog. Full `mobiusRuntime` suite (33) and the `chatEmbed*` suites (31) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)