### PR TITLE
Keep more of the first message in chat titles

### DIFF
--- a/backend/app/chat_titles.py
+++ b/backend/app/chat_titles.py
@@ -1,0 +1,31 @@
+"""Chat naming policy for the immediate first-message fallback."""
+
+FIRST_MESSAGE_TITLE_MAX_CHARS = 80
+
+
+def first_message_title(content: object) -> str:
+  """Return the bounded plain-text title used before an agent name is ready."""
+  if isinstance(content, list):
+    content = " ".join(
+      part.get("text", "")
+      for part in content
+      if isinstance(part, dict)
+    )
+  if not isinstance(content, str):
+    return ""
+  return content.strip()[:FIRST_MESSAGE_TITLE_MAX_CHARS]
+
+
+def first_user_message_title(messages: list[object] | None) -> str:
+  """Derive the fallback title from the first ordinary owner message."""
+  for message in messages or []:
+    if (
+      not isinstance(message, dict)
+      or message.get("role") != "user"
+      or message.get("kind") == "auto_continuation"
+    ):
+      continue
+    title = first_message_title(message.get("content"))
+    if title:
+      return title
+  return ""

--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -52,6 +52,7 @@ from sqlalchemy import select, text, update
 from sqlalchemy.exc import SQLAlchemyError
 
 from app import models, schemas
+from app.chat_titles import first_message_title
 from app.json_safety import json_safe
 from app.events import (
   TOOL_OUTPUT_INLINE_THRESHOLD,
@@ -1958,7 +1959,7 @@ class ChatWriterActor:
       "ts": next_message_ts(existing + pending),
     }
     if len(existing) == 1:
-      chat.title = cmd.title_source[:40] or "New chat"
+      chat.title = first_message_title(cmd.title_source) or "New chat"
     chat.run_status = "running"
     chat.run_started_at = datetime.now(UTC)
     chat.updated_at = datetime.now(UTC)

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -24,6 +24,7 @@ from app.chat import (
 )
 from app.broadcast import get_system_broadcast
 from app.chat_retention import purge_expired_chat_tombstones
+from app.chat_titles import first_user_message_title
 from app.database import get_db
 from app.memory_observability import record_memory_checkpoint_once
 from app.deps import (
@@ -752,25 +753,6 @@ async def update_chat(
   return {"ok": True}
 
 
-def _first_message_title(chat) -> str:
-  """The 'first message' fallback name: the first user message's text trimmed
-  to a sane length (mirrors the StartTurn initial-title behavior)."""
-  for m in (chat.messages or []):
-    if (
-      not isinstance(m, dict)
-      or m.get("role") != "user"
-      or m.get("kind") == "auto_continuation"
-    ):
-      continue
-    c = m.get("content")
-    if isinstance(c, list):
-      c = " ".join(p.get("text", "") for p in c if isinstance(p, dict))
-    c = (c or "").strip()
-    if c:
-      return c[:80]
-  return ""
-
-
 @router.patch("/{chat_id}", dependencies=[Depends(reject_cross_site)])
 async def patch_chat(
   body: ChatPatch,
@@ -830,7 +812,7 @@ async def patch_chat(
     # it isn't locked, so it can never clobber a name the owner chose.
     previous_title = chat.title
     if body.clear_title:
-      chat.title = _first_message_title(chat) or "New chat"
+      chat.title = first_user_message_title(chat.messages) or "New chat"
       chat.title_locked = False
     elif body.title is not None:
       new_title = body.title.strip()

--- a/backend/tests/test_chat_writer_contention.py
+++ b/backend/tests/test_chat_writer_contention.py
@@ -592,6 +592,26 @@ def test_start_turn_is_atomic(actor):
   assert chat["run_started_at"] is not None
 
 
+def test_start_turn_keeps_a_useful_first_message_title_preview(actor):
+  """The drawer fallback keeps 80 characters while the agent name is pending."""
+  first_message = (
+    "Explain how the chat drawer derives a temporary title from the opening "
+    "message before a summary is available"
+  )
+  _seed_chat(messages=[])
+
+  _await(actor.submit(
+    StartTurn(
+      chat_id="c1",
+      run_token="rt-title-preview",
+      user_msg={"role": "user", "content": first_message, "ts": 5},
+      title_source=first_message,
+    )
+  ))
+
+  assert _load_chat()["title"] == first_message[:80]
+
+
 def test_start_turn_retry_after_completion_is_idempotent(actor):
   """A lost response retried after the run settled must not wake the agent."""
   original = {

--- a/backend/tests/test_chats.py
+++ b/backend/tests/test_chats.py
@@ -582,3 +582,34 @@ def test_committed_chat_rename_publishes_live_projection_event(
     "type": "chat_renamed",
     "chatId": str(chat.id),
   })
+
+
+def test_clearing_chat_title_uses_the_same_first_message_preview_limit(
+  client, auth, db, chat,
+):
+  """Resetting a name preserves the same 80-character drawer fallback."""
+  content = [
+    {"type": "text", "text": (
+      "Explain how the chat drawer derives a temporary title"
+    )},
+    {"type": "text", "text": (
+      "from the opening message before a summary is available"
+    )},
+  ]
+  first_message = " ".join(part["text"] for part in content)
+  chat.messages = [{"role": "user", "content": content}]
+  chat.title = "Drawer title behavior"
+  chat.title_locked = True
+  db.commit()
+
+  response = client.patch(
+    f"/api/chats/{chat.id}",
+    json={"clear_title": True},
+    headers=auth,
+  )
+
+  assert response.status_code == 200
+  db.expire_all()
+  current = db.query(models.Chat).filter_by(id=chat.id).first()
+  assert current.title == first_message[:80]
+  assert current.title_locked is False


### PR DESCRIPTION
## Summary
- keep up to 80 characters of the opening message while an automatic chat name is pending
- give first-message title selection and normalization one shared owner
- cover both plain and structured message content

## Testing
- focused chat-title tests (`4 passed`)
- `scripts/test.sh --fast` (`60 passed`)