### PR TITLE
Protect interactive responsiveness from background workers

### DIFF
--- a/backend/app/claude_sdk_runner.py
+++ b/backend/app/claude_sdk_runner.py
@@ -114,6 +114,7 @@ from app import activity
 from app.pending_questions import PendingQuestion
 from app.process_groups import (
   isolated_process_group_id,
+  lower_process_group_priority,
   terminate_process_group,
 )
 from app.runner_registry import RunnerKind, registry
@@ -1550,7 +1551,13 @@ async def run_claude_sdk_turn(
           "cost_usd": None,
           "error": "connect timeout",
         }
-      active_client.set_process_group_id(_claude_process_group_id(client))
+      process_group_id = _claude_process_group_id(client)
+      lower_process_group_priority(
+        process_group_id,
+        logger=log,
+        label="Claude CLI",
+      )
+      active_client.set_process_group_id(process_group_id)
       await client.query(turn_message)
 
       # At most one automatic re-query per turn (see the synthetic-resume

--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -72,6 +72,7 @@ from typing import Any, Callable
 
 from app.codex_appserver import _extract_bash_command
 from app.json_safety import json_safe
+from app.process_groups import lower_process_group_priority
 from app.providers import MODEL_LABELS, get_skill_path
 from app.runtime_types import RunnerResult
 from app.usage_metrics import codex_cost_usd, normalize_codex_usage
@@ -2549,6 +2550,11 @@ async def run_codex_sdk_turn(
         chat_id=chat_id,
       )
       process_group_id = _codex_process_group_id(codex)
+      lower_process_group_priority(
+        process_group_id,
+        logger=log,
+        label="Codex app-server",
+      )
       if process_group_capture_stop is not None:
         process_group_capture_stop.set()
       # Do NOT await the capture task here. Cancellation immediately after
@@ -3230,6 +3236,11 @@ async def run_codex_sdk_turn(
         captured_during_start = process_group_capture_task.result()
         if process_group_id is None:
           process_group_id = captured_during_start
+          lower_process_group_priority(
+            process_group_id,
+            logger=log,
+            label="Codex app-server",
+          )
       except asyncio.CancelledError:
         # A task owned only by this runner should not be cancelled, but a
         # proven PGID captured synchronously after __aenter__ still permits

--- a/backend/app/frontend_watcher.py
+++ b/backend/app/frontend_watcher.py
@@ -32,6 +32,11 @@ from pathlib import Path
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers.polling import PollingObserverVFS
 
+from app.process_groups import (
+  isolated_process_group_id,
+  lower_process_group_priority,
+)
+
 log = logging.getLogger(__name__)
 
 _DEBOUNCE_SECS = 1.75
@@ -1013,6 +1018,11 @@ class _FrontendHandler(FileSystemEventHandler):
         stderr=subprocess.STDOUT,
         text=True,
         start_new_session=True,
+      )
+      lower_process_group_priority(
+        isolated_process_group_id(proc.pid),
+        logger=log,
+        label="Frontend build",
       )
       with self._proc_lock:
         self._watch_proc = proc

--- a/backend/app/process_groups.py
+++ b/backend/app/process_groups.py
@@ -7,6 +7,8 @@ import os
 import signal
 import time
 
+BACKGROUND_PROCESS_NICE = 5
+
 
 def isolated_process_group_id(pid: object) -> int | None:
   """Return ``pid`` only when it provably leads a private process group."""
@@ -19,6 +21,38 @@ def isolated_process_group_id(pid: object) -> int | None:
   if pgid != pid or pgid == os.getpgrp():
     return None
   return pgid
+
+
+def lower_process_group_priority(
+  pgid: int | None,
+  *,
+  logger: logging.Logger,
+  label: str,
+) -> bool:
+  """Give one proven-private process group a modest background priority.
+
+  Setting the group leader before it creates most descendants also makes the
+  inherited priority the default for later children. Failure is intentionally
+  non-fatal: isolation and cleanup remain useful even on a runtime without
+  ``setpriority`` support.
+  """
+  if not isinstance(pgid, int) or isolated_process_group_id(pgid) != pgid:
+    return False
+  try:
+    os.setpriority(
+      os.PRIO_PGRP,
+      pgid,
+      BACKGROUND_PROCESS_NICE,
+    )
+  except (AttributeError, OSError) as exc:
+    logger.warning(
+      "%s priority adjustment failed pgid=%s: %s",
+      label,
+      pgid,
+      exc,
+    )
+    return False
+  return True
 
 
 def terminate_process_group(

--- a/backend/tests/test_frontend_watcher_publish.py
+++ b/backend/tests/test_frontend_watcher_publish.py
@@ -592,6 +592,48 @@ def test_source_edit_during_vite_discards_staging_and_requests_rerun(
   assert publish_calls[0][0] == fw_dirs["staging"]
 
 
+def test_demand_build_lowers_vite_process_group_priority(
+  fw_dirs, monkeypatch,
+):
+  src = fw_dirs["frontend"] / "src"
+  src.mkdir()
+  source_file = src / "Shell.jsx"
+  source_file.write_text("export default 1\n", encoding="utf-8")
+  monkeypatch.setattr(fw, "_ensure_node_modules", lambda: None)
+  monkeypatch.setattr(
+    fw.subprocess,
+    "Popen",
+    lambda *args, **kwargs: _FakeViteProcess(
+      lambda: _write_build(fw_dirs["staging"], "priority"),
+    ),
+  )
+  monkeypatch.setattr(fw, "_publish_built_dir", lambda *_args: True)
+  monkeypatch.setattr(fw, "_publish_system_event", lambda _event: None)
+  monkeypatch.setattr(
+    fw,
+    "isolated_process_group_id",
+    lambda pid: pid,
+  )
+  priority_calls = []
+  monkeypatch.setattr(
+    fw,
+    "lower_process_group_priority",
+    lambda pgid, **kwargs: priority_calls.append((pgid, kwargs)) or True,
+  )
+  loop = asyncio.new_event_loop()
+  handler = fw._FrontendHandler(loop, start_threads=False)
+  try:
+    handler._run_demand_build(str(source_file))
+  finally:
+    handler.close()
+    loop.close()
+
+  assert priority_calls == [(
+    12345,
+    {"logger": fw.log, "label": "Frontend build"},
+  )]
+
+
 def test_idle_observer_requests_build_for_source_edit(fw_dirs, monkeypatch):
   src = fw_dirs["frontend"] / "src"
   src.mkdir()

--- a/backend/tests/test_process_groups.py
+++ b/backend/tests/test_process_groups.py
@@ -11,6 +11,81 @@ def test_isolated_process_group_id_refuses_shared_group(monkeypatch):
   assert process_groups.isolated_process_group_id(4321) is None
 
 
+def test_lower_process_group_priority_targets_proven_private_group(monkeypatch):
+  calls = []
+  monkeypatch.setattr(process_groups.os, "getpgid", lambda pid: pid)
+  monkeypatch.setattr(process_groups.os, "getpgrp", lambda: 9999)
+  monkeypatch.setattr(
+    process_groups.os,
+    "setpriority",
+    lambda which, who, priority: calls.append((which, who, priority)),
+  )
+
+  assert process_groups.lower_process_group_priority(
+    4321,
+    logger=logging.getLogger(__name__),
+    label="test",
+  ) is True
+  assert calls == [
+    (
+      process_groups.os.PRIO_PGRP,
+      4321,
+      process_groups.BACKGROUND_PROCESS_NICE,
+    ),
+  ]
+
+
+def test_lower_process_group_priority_refuses_unverified_group(monkeypatch):
+  monkeypatch.setattr(process_groups.os, "getpgid", lambda _pid: 4000)
+  monkeypatch.setattr(process_groups.os, "getpgrp", lambda: 9999)
+  monkeypatch.setattr(
+    process_groups.os,
+    "setpriority",
+    lambda *_args: (_ for _ in ()).throw(
+      AssertionError("unverified group must not be adjusted"),
+    ),
+  )
+
+  assert process_groups.lower_process_group_priority(
+    4321,
+    logger=logging.getLogger(__name__),
+    label="test",
+  ) is False
+
+
+def test_lower_process_group_priority_refuses_missing_group(monkeypatch):
+  monkeypatch.setattr(
+    process_groups.os,
+    "setpriority",
+    lambda *_args: (_ for _ in ()).throw(
+      AssertionError("missing group must not be adjusted"),
+    ),
+  )
+
+  assert process_groups.lower_process_group_priority(
+    None,
+    logger=logging.getLogger(__name__),
+    label="test",
+  ) is False
+
+
+def test_lower_process_group_priority_is_nonfatal(monkeypatch, caplog):
+  monkeypatch.setattr(process_groups.os, "getpgid", lambda pid: pid)
+  monkeypatch.setattr(process_groups.os, "getpgrp", lambda: 9999)
+  monkeypatch.setattr(
+    process_groups.os,
+    "setpriority",
+    lambda *_args: (_ for _ in ()).throw(PermissionError("denied")),
+  )
+
+  assert process_groups.lower_process_group_priority(
+    4321,
+    logger=logging.getLogger(__name__),
+    label="test",
+  ) is False
+  assert "test priority adjustment failed pgid=4321: denied" in caplog.text
+
+
 def test_terminate_process_group_has_sigkill_backstop(monkeypatch):
   calls = []
   monkeypatch.setattr(process_groups.os, "getpgrp", lambda: 9999)


### PR DESCRIPTION
## Summary

- give isolated Claude and Codex worker groups a modest background CPU priority
- apply the same policy to demand-driven frontend builds
- refuse unverified process groups and keep unsupported priority changes non-fatal

## Context

Agent descendants, tests, browsers, and frontend builds can compete with the interactive server inside one container. Möbius already owns these workloads through isolated process groups; this change makes them yield CPU without changing their execution or cleanup semantics.

This builds on #129's process-group isolation. It changes scheduling only after the group has been proven private.

## Testing

- focused process-group, frontend-watcher, Claude runner, and Codex runner suites: 200 passed
- `git diff --check`