### PR TITLE
Reuse unchanged chat snapshots during activation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -937,9 +937,14 @@ count. Only an explicit disclosure resolves that exact range through
 `GET /api/chats/{id}/activity-detail`; the live assistant stays self-contained.
 Mounted runtime reconciliation uses `GET /api/chats/{id}/runtime`, whose ORM
 projection raiseloads every unrequested field so polling can never silently
-decode `Chat.messages`. These are read projections, never a second persistence
-format: provider context, recovery, export, and writer commands continue to
-use the full transcript.
+decode `Chat.messages`. Both projections carry the row's `updated_at` as the
+detail-snapshot version. On activation, a retained ChatView reads the runtime
+projection first and reuses its painted transcript only when those explicit
+versions match; a missing or changed version fails closed to the compact detail
+read. Any local, streamed, or paginated message-cache mutation clears the
+cached version until a complete detail response proves it again. These are read
+projections, never a second persistence format: provider context, recovery,
+export, and writer commands continue to use the full transcript.
 
 - **Commit-before-ack (strict paths):** the caller's `await` on `QuestionCommit`/`Finalize`/`AnswerQuestion`/`Barrier`/`DrainAndStop` doesn't unblock until the commit succeeds; `PersistTranscript` and `PersistError` are fire-and-forget (submitted without awaiting the ack).
 - **Questions commit-before-broadcast:** a question row is durable before its SSE push fires, so a reconnect's catch-up burst always finds it.

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -415,6 +415,7 @@ def _chat_detail_response(
   return {
     "id": chat.id,
     "title": chat.title,
+    "updated_at": chat.updated_at.isoformat() if chat.updated_at else None,
     # Settled large-output excerpts are omitted here because the disclosure
     # already fetches them from their durable sidecar on demand. Live turns
     # retain excerpts so the in-progress surface remains self-contained.
@@ -1113,7 +1114,10 @@ def get_chat_runtime(
     db,
     chat_id,
     principal,
-    load_fields=(models.Chat.pending_messages,),
+    load_fields=(
+      models.Chat.pending_messages,
+      models.Chat.updated_at,
+    ),
   )
   pending_question = questions.get(chat.id)
   return {
@@ -1122,6 +1126,7 @@ def get_chat_runtime(
     "pending_question_id": (
       pending_question.question_id if pending_question is not None else None
     ),
+    "updated_at": chat.updated_at.isoformat() if chat.updated_at else None,
   }
 
 

--- a/backend/tests/test_chat_transcript_compact.py
+++ b/backend/tests/test_chat_transcript_compact.py
@@ -332,6 +332,7 @@ def test_runtime_route_does_not_select_transcript_json(
     "running": True,
     "pending_messages": [],
     "pending_question_id": None,
+    "updated_at": created.json()["updated_at"],
   }
   chat_select = next(
     statement
@@ -339,4 +340,5 @@ def test_runtime_route_does_not_select_transcript_json(
     if "from chats" in statement and "chats.pending_messages" in statement
   )
   assert "chats.pending_messages" in chat_select
+  assert "chats.updated_at" in chat_select
   assert "chats.messages as" not in chat_select

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -57,8 +57,12 @@ import { resolveStopResend } from './resolveStopResend.js'
 import { focusComposerElement, shouldApplyComposerFocusRequest } from './composerFocusPolicy.js'
 import { shouldDismissComposerKeyboardOnSubmit } from './composerKeyboardPolicy.js'
 import { sameMessageList } from './chatMessageList.js'
-import { chatDetailCacheValue, chatEntryPhase } from '../../lib/chatDetailCache.js'
 import { updateChatRuntimeCache } from './chatRuntimeCache.js'
+import {
+  chatDetailCacheValue,
+  chatEntryPhase,
+  chatSnapshotMatchesRuntime,
+} from '../../lib/chatDetailCache.js'
 import { composerHistoryFromMessages } from './composerHistory.js'
 import { sendFailureMessage } from './sendFailure.js'
 import { assistantStreamCoversMessage, chooseActiveAssistantDataKey, findTrailingAssistantPartialIndex, promoteAssistantStream, streamItemsHaveRenderableContent } from './streamPromotion.js'
@@ -309,7 +313,8 @@ export default function ChatView({
   // for already-warm in-memory caches (same session) this is exact;
   // for IndexedDB-restored caches it's best-effort. The initial fetch
   // useEffect below always fires regardless and writes the fresh data
-  // back via `commitMessages`, so any miss self-heals on next remount.
+  // back through the versioned activation handoff, so any miss self-heals on
+  // the first authoritative detail read.
   const cached = queryClient.getQueryData(chatMessagesQueryKey(chatId))
   const [messages, setMessages] = useState(() => cached?.messages ?? [])
   const messageHistory = useMemo(
@@ -346,10 +351,14 @@ export default function ChatView({
   // does not fall back to Mic while a turn is still running with queued work.
   const [serverRunning, setServerRunning] = useState(() => !!cached?.running)
   const serverRunningRef = useRef(!!cached?.running)
-  function setServerRunningState(v) {
+  function setServerRunningLocalState(v) {
     const running = !!v
     serverRunningRef.current = running
     setServerRunning(running)
+  }
+  function setServerRunningState(v) {
+    const running = !!v
+    setServerRunningLocalState(running)
     updateChatRuntimeCache(
       queryClient,
       chatMessagesQueryKey(chatId),
@@ -612,6 +621,27 @@ export default function ChatView({
   const runtimeReconnectInFlightRef = useRef(false)
   const swReloadHoldTimerRef = useRef(null)
 
+  // Apply a resolved message snapshot to the mounted view without publishing
+  // it. Detail activation uses this after one complete cache publication;
+  // ordinary local/stream mutations go through commitMessages below.
+  const applyMessagesToView = useCallback((next, nextOffset, force = false) => {
+    const prev = messagesRef.current
+    // Advance messagesRef synchronously so back-to-back commits within the
+    // same React batch compose correctly.
+    messagesRef.current = next
+    if (nextOffset !== undefined) offsetRef.current = nextOffset
+    if (!force && sameMessageList(prev, next)) {
+      if (nextOffset !== undefined) {
+        setOffset(o => o === nextOffset ? o : nextOffset)
+      }
+      return
+    }
+    setMessages(next)
+    if (nextOffset !== undefined) {
+      setOffset(o => o === nextOffset ? o : nextOffset)
+    }
+  }, [])
+
   // Single setter that updates local state AND the query cache.
   //
   // ALWAYS writes the query cache (so even empty chats have an entry,
@@ -635,30 +665,18 @@ export default function ChatView({
     const force = opts?.force === true
     const prev = messagesRef.current
     const next = typeof updater === 'function' ? updater(prev) : updater
-    // Advance messagesRef synchronously so back-to-back commitMessages
-    // calls within the same React batch (e.g. handleStop's promote +
-    // doSend's user-msg append) compose correctly. Without this, the
-    // second call's updater reads the pre-batch prev and overwrites
-    // the first call's result on setMessages.
-    messagesRef.current = next
-    if (nextOffset !== undefined) offsetRef.current = nextOffset
     queryClient.setQueryData(chatMessagesQueryKey(chatId), (existing) => ({
       ...(existing || {}),
+      // This composite is newer than the last complete detail read. Clearing
+      // its proof makes the next activation fail closed to one authoritative
+      // detail snapshot instead of treating local or streamed rows as a
+      // server-versioned response.
+      updated_at: null,
       messages: next,
       offset: nextOffset !== undefined ? nextOffset : (existing?.offset ?? 0),
     }))
-    if (!force && sameMessageList(prev, next)) {
-      // Offset may still have changed (older-messages pagination).
-      if (nextOffset !== undefined) {
-        setOffset(o => o === nextOffset ? o : nextOffset)
-      }
-      return
-    }
-    setMessages(next)
-    if (nextOffset !== undefined) {
-      setOffset(o => o === nextOffset ? o : nextOffset)
-    }
-  }, [chatId, queryClient])
+    applyMessagesToView(next, nextOffset, force)
+  }, [applyMessagesToView, chatId, queryClient])
 
   // DOM refs
   const scrollRef = useRef(null)
@@ -1834,116 +1852,143 @@ export default function ChatView({
   // Fetch messages and connect to an in-progress stream if the agent is running.
   useEffect(() => {
     // A hidden retained pane is not an active runtime. Returning to visibility
-    // changes this dependency and re-runs the authoritative history + stream
-    // handshake, matching the former unmount/remount behavior without losing
-    // the pane's DOM identity.
+    // changes this dependency and re-runs the version + stream handshake
+    // without losing the pane's DOM identity.
     if (hidden) return
     let cancelled = false
     const initialLoadController = new AbortController()
+    const queryKey = chatMessagesQueryKey(chatId)
+    const activationCache = queryClient.getQueryData(queryKey)
     chatIdStaleRef.current = false
     setLoadError(false)
-    setInitialEntryPhase(cachedEntryPhase)
+    setInitialEntryPhase(chatEntryPhase(activationCache))
 
     const gen = fetchGenRef.current
-    apiFetch(`/chats/${chatId}?limit=20&compact=1`, {
-      timeoutMs: CHAT_FETCH_TIMEOUT_MS,
-      signal: initialLoadController.signal,
-    })
-      .then(r => {
-        if (r.status === 404) throw new Error('CHAT_NOT_FOUND')
-        if (!r.ok) throw new Error(`CHAT_LOAD_FAILED_${r.status}`)
-        return r.json()
+    const requestJson = async (path, label) => {
+      const response = await apiFetch(path, {
+        timeoutMs: CHAT_FETCH_TIMEOUT_MS,
+        signal: initialLoadController.signal,
       })
-      .then(data => {
-        if (cancelled) return
-        if (fetchGenRef.current !== gen) return
-        const detailCache = chatDetailCacheValue(data)
-        const msgs = detailCache.messages
-        const failedAttempt = failedSendAttemptRef.current
-        if (failedAttempt) {
-          if (sendAttemptIsDurable(failedAttempt, msgs, data.pending_messages)) {
-            clearFailedAttempt()
-            setComposerInput('')
-            clearFiles()
-            setSendFailure(null)
-          } else {
-            setSendFailure(
-              'That message didn’t reach the chat. It’s ready in the composer—try again.',
-            )
-          }
+      if (response.status === 404) throw new Error('CHAT_NOT_FOUND')
+      if (!response.ok) throw new Error(`${label}_${response.status}`)
+      return response.json()
+    }
+
+    const settleRuntime = (runtime, visibleMessages) => {
+      const running = !!runtime.running
+      setServerRunningLocalState(running)
+      hadMessagesRef.current = visibleMessages.length > 0
+      setLiveQuestionId(runtime.pending_question_id || null)
+      setBridgeMountInputs({
+        runningAtMount: running,
+        lastMsgAtMount: visibleMessages.length > 0
+          ? visibleMessages[visibleMessages.length - 1]
+          : null,
+      })
+      setInitialEntryPhase('ready')
+      setLoading(false)
+      pendingQueue.hydrate(runtime.pending_messages || [])
+      if (running) {
+        setSending(true)
+        connectToStream(false)
+      } else {
+        setSending(false)
+        sendingRef.current = false
+      }
+    }
+
+    const loadActivation = async () => {
+      let runtime = null
+      let detailCache = null
+      let reused = false
+
+      if (typeof activationCache?.updated_at === 'string') {
+        runtime = await requestJson(
+          `/chats/${chatId}/runtime`,
+          'CHAT_RUNTIME_FAILED',
+        )
+        if (chatSnapshotMatchesRuntime(activationCache, runtime)) {
+          detailCache = activationCache
+          reused = true
         }
-        // Snapshot the per-chat runtime config (provider/model/effort) BEFORE
-        // the behind-local guard below. This is independent of the messages
-        // snapshot, and the guard's early-return used to skip it — so after any
-        // interaction (local optimistic state ahead of the server snapshot) the
-        // `+` popover's model picker silently vanished, leaving only Attach +
-        // "What the agent knows". Setting it here keeps the picker present
-        // regardless of the messages fast-path.
-        const nextChatInfo = detailCache.chatInfo
-        setChatInfo(nextChatInfo)
-        queryClient.setQueryData(chatMessagesQueryKey(chatId), (existing) => ({
-          ...(existing || {}),
-          running: detailCache.running,
-          pending_messages: detailCache.pending_messages,
-          pending_question_id: detailCache.pending_question_id,
-          chatInfo: nextChatInfo,
-        }))
-        if (serverSnapshotBehindLocal(msgs, messagesRef.current)) {
-          // The successful detail read is the authoritative entry frame even
-          // when a live tail still needs to catch up. Keeping that already
-          // useful transcript hidden until stream settlement turns the replay
-          // safety deadline into chat-navigation latency.
-          setInitialEntryPhase('ready')
-          setLoading(false)
-          return
-        }
+      }
+      if (!reused) {
+        runtime = await requestJson(
+          `/chats/${chatId}?limit=20&compact=1`,
+          'CHAT_LOAD_FAILED',
+        )
+        detailCache = chatDetailCacheValue(runtime)
+      }
 
-        // Keep the DB partial when the agent is still running. The user sees
-        // the most recent persisted state immediately; SSE catch-up makes the
-        // same active MsgContent swap to the live payload. On done,
-        // promoteStreamToMessages replaces this partial with the final version.
-        // Previously we stripped this and waited for SSE — caused the "message
-        // disappears on choppy return" bug.
-
-        const refreshed = mergeRecentMessagesIntoLoadedWindow({
-          loadedMessages: messagesRef.current,
-          loadedOffset: offsetRef.current,
-          recentMessages: msgs,
-          recentOffset: data.offset || 0,
-        })
-        commitMessages(refreshed.messages, refreshed.offset)
-        setServerRunningState(!!data.running)
-        hadMessagesRef.current = refreshed.messages.length > 0
-        setLiveQuestionId(data.pending_question_id || null)
-        // (chatInfo — the model/effort picker config — is snapshotted above,
-        // before the behind-local guard, so the picker survives interactions.)
-        // Feed the bridge gate with the data.running + last-msg
-        // snapshot. useBridgePartial captures the kept-partial ts
-        // on first valid input and stays sticky from there — only
-        // the very first turn after mount is a "bridge"; subsequent
-        // turns always APPEND (markBridged retires the gate on the
-        // first promote).
-        setBridgeMountInputs({
-          runningAtMount: !!data.running,
-          lastMsgAtMount: msgs.length > 0 ? msgs[msgs.length - 1] : null,
-        })
-        setInitialEntryPhase('ready')
-        setLoading(false)
-
-        // Hydrate pending queue from backend so a reload mid-queue
-        // doesn't drop the visible "queued" tray. The server list is
-        // authoritative for confirmed rows; hydrate() still preserves
-        // optimistic in-flight rows if a queue POST is racing this fetch.
-        pendingQueue.hydrate(data.pending_messages || [])
-
-        if (data.running) {
-          setSending(true)
-          connectToStream(false)
+      if (cancelled || fetchGenRef.current !== gen) return
+      const msgs = detailCache.messages
+      const failedAttempt = failedSendAttemptRef.current
+      if (failedAttempt) {
+        if (sendAttemptIsDurable(
+          failedAttempt,
+          msgs,
+          runtime.pending_messages,
+        )) {
+          clearFailedAttempt()
+          setComposerInput('')
+          clearFiles()
+          setSendFailure(null)
         } else {
-          setSending(false)
-          sendingRef.current = false
+          setSendFailure(
+            'That message didn’t reach the chat. It’s ready in the composer—try again.',
+          )
         }
+      }
+
+      if (reused) {
+        // One narrow publication updates queue/liveness only when those fields
+        // changed. The retained messages and their DOM remain untouched.
+        updateChatRuntimeCache(queryClient, queryKey, {
+          running: !!runtime.running,
+          pending_messages: runtime.pending_messages || [],
+          pending_question_id: runtime.pending_question_id || null,
+        })
+        settleRuntime(runtime, msgs)
+        return
+      }
+
+      // Snapshot provider/model settings before checking for optimistic local
+      // rows. Runtime config belongs to this server response even when the
+      // mounted transcript is temporarily ahead of it.
+      setChatInfo(detailCache.chatInfo)
+      if (serverSnapshotBehindLocal(msgs, messagesRef.current)) {
+        queryClient.setQueryData(queryKey, existing => ({
+          ...detailCache,
+          // The local suffix is not proven by this server version. Preserve it
+          // for the visible optimistic handoff but make the next activation
+          // take the authoritative detail path.
+          updated_at: null,
+          messages: existing?.messages || messagesRef.current,
+          offset: existing?.offset ?? offsetRef.current,
+        }))
+        settleRuntime(runtime, messagesRef.current)
+        return
+      }
+
+      // Keep an already-loaded older prefix while replacing its overlapping
+      // recent page. Publish the complete detail snapshot once, then update the
+      // mounted view without a second query-cache notification.
+      const refreshed = mergeRecentMessagesIntoLoadedWindow({
+        loadedMessages: messagesRef.current,
+        loadedOffset: offsetRef.current,
+        recentMessages: msgs,
+        recentOffset: runtime.offset || 0,
       })
+      queryClient.setQueryData(queryKey, {
+        ...detailCache,
+        messages: refreshed.messages,
+        offset: refreshed.offset,
+      })
+      applyMessagesToView(refreshed.messages, refreshed.offset)
+      settleRuntime(runtime, refreshed.messages)
+    }
+
+    loadActivation()
       .catch((err) => {
         if (cancelled) return
         setInitialEntryPhase('ready')

--- a/frontend/src/components/ChatView/__tests__/chatDetailCache.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatDetailCache.test.js
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict'
 import {
   chatDetailCacheValue,
   chatEntryPhase,
+  chatSnapshotMatchesRuntime,
 } from '../../../lib/chatDetailCache.js'
 
 test('a cached running chat paints immediately while catch-up runs', () => {
@@ -14,6 +15,7 @@ test('a cached running chat paints immediately while catch-up runs', () => {
 
 test('prefetched chat detail matches the synchronous ChatView cache contract', () => {
   const source = {
+    updated_at: '2026-07-30T12:00:00Z',
     messages: [{
       role: 'assistant',
       blocks: [{ type: 'tool', status: 'running' }, { type: 'text', text: 'done' }],
@@ -34,6 +36,7 @@ test('prefetched chat detail matches the synchronous ChatView cache contract', (
   const cached = chatDetailCacheValue(source)
 
   assert.equal(cached.messages[0].blocks[0].status, 'done')
+  assert.equal(cached.updated_at, source.updated_at)
   assert.equal(source.messages[0].blocks[0].status, 'running', 'projection does not mutate the response')
   assert.equal(cached.offset, 12)
   assert.equal(cached.pending_question_id, 'question-1')
@@ -46,4 +49,18 @@ test('prefetched chat detail matches the synchronous ChatView cache contract', (
     auto_resume_on_limit: true,
     auto_resume_on_restart: false,
   })
+})
+
+test('a retained snapshot is reusable only at the same explicit row version', () => {
+  const cached = { updated_at: '2026-07-30T12:00:00Z' }
+  assert.equal(chatSnapshotMatchesRuntime(cached, {
+    updated_at: '2026-07-30T12:00:00Z',
+  }), true)
+  assert.equal(chatSnapshotMatchesRuntime(cached, {
+    updated_at: '2026-07-30T12:00:01Z',
+  }), false)
+  assert.equal(chatSnapshotMatchesRuntime(cached, {}), false)
+  assert.equal(chatSnapshotMatchesRuntime({}, {
+    updated_at: '2026-07-30T12:00:00Z',
+  }), false)
 })

--- a/frontend/src/components/Shell/__tests__/chatHandoff.test.js
+++ b/frontend/src/components/Shell/__tests__/chatHandoff.test.js
@@ -31,24 +31,29 @@ test('chat display readiness preserves the authoritative transcript reveal gate'
     'the callback dependency is the owner-change signal; a parallel mutable ref would obscure it')
 })
 
-test('authoritative running history releases the held chat before stream catch-up', () => {
+test('activation reuses an unchanged retained transcript before stream catch-up', () => {
   const initialLoad = chatView.match(
-    /apiFetch\(`\/chats\/\$\{chatId\}\?limit=20&compact=1`,[\s\S]*?\n  \}, \[chatId, loadNonce, hidden\]\)/,
+    /const loadActivation = async \(\) => \{[\s\S]*?\n    loadActivation\(\)/,
   )?.[0] || ''
   assert.match(
     initialLoad,
-    /if \(serverSnapshotBehindLocal[\s\S]*setInitialEntryPhase\('ready'\)/,
-    'a useful local frame must be revealed after the authoritative detail read',
+    /\/runtime`[\s\S]*chatSnapshotMatchesRuntime\(activationCache, runtime\)[\s\S]*reused = true/,
+    'an unchanged row version must reuse the retained transcript',
   )
   assert.match(
     initialLoad,
-    /setInitialEntryPhase\('ready'\)[\s\S]*if \(data\.running\) \{[\s\S]*connectToStream\(false\)/,
-    'stream catch-up should continue after the persisted frame becomes paintable',
+    /if \(!reused\) \{[\s\S]*\/chats\/\$\{chatId\}\?limit=20&compact=1/,
+    'missing or changed versions must fail closed to the full detail route',
   )
-  assert.doesNotMatch(
+  assert.match(
     initialLoad,
-    /setInitialEntryPhase\(data\.running \? 'catch-up' : 'ready'\)/,
-    'a running marker must not turn replay settlement into navigation latency',
+    /if \(reused\) \{[\s\S]*updateChatRuntimeCache[\s\S]*settleRuntime\(runtime, msgs\)[\s\S]*return/,
+    'the fast path may update liveness but must not republish messages',
+  )
+  assert.match(
+    chatView,
+    /setInitialEntryPhase\('ready'\)[\s\S]*if \(running\) \{[\s\S]*connectToStream\(false\)/,
+    'stream catch-up should continue after the persisted frame becomes paintable',
   )
 })
 
@@ -56,8 +61,8 @@ test('a staging chat cannot leave the outgoing transcript held on a wedged reque
   assert.match(chatView, /const CHAT_FETCH_TIMEOUT_MS = 15000/)
   assert.match(
     chatView,
-    /apiFetch\(`\/chats\/\$\{chatId\}\?limit=20&compact=1`, \{\s*timeoutMs: CHAT_FETCH_TIMEOUT_MS,\s*signal: initialLoadController\.signal,\s*\}\)/,
-    'the initial load must share the bounded message-fetch deadline',
+    /const requestJson = async \(path, label\) => \{[\s\S]*apiFetch\(path, \{\s*timeoutMs: CHAT_FETCH_TIMEOUT_MS,\s*signal: initialLoadController\.signal,\s*\}\)/,
+    'both version and detail reads must share the bounded activation deadline',
   )
   assert.match(chatView, /initialLoadController\.abort\(\)/,
     'hiding or unmounting a staging chat must release its request immediately')

--- a/frontend/src/components/Shell/__tests__/newChatPolicy.test.js
+++ b/frontend/src/components/Shell/__tests__/newChatPolicy.test.js
@@ -180,10 +180,12 @@ test('a canonical create response becomes an authoritative empty detail cache', 
       auto_resume_on_limit: false,
       auto_resume_on_restart: true,
       offset: 0,
+      updated_at: '2026-07-30T12:00:00Z',
     }),
   })
 
   assert.deepEqual(cache, {
+    updated_at: '2026-07-30T12:00:00Z',
     messages: [],
     pending_messages: [],
     pending_question_id: null,

--- a/frontend/src/components/Shell/newChatPolicy.js
+++ b/frontend/src/components/Shell/newChatPolicy.js
@@ -118,6 +118,9 @@ export function createdChatDetailCache(created) {
   if (typeof detail.has_assistant_turns !== 'boolean') return null
 
   return {
+    updated_at: typeof detail.updated_at === 'string'
+      ? detail.updated_at
+      : null,
     messages: detail.messages,
     pending_messages: detail.pending_messages,
     pending_question_id: detail.pending_question_id,

--- a/frontend/src/lib/chatDetailCache.js
+++ b/frontend/src/lib/chatDetailCache.js
@@ -25,8 +25,20 @@ export function chatEntryPhase(cached) {
   return cached ? 'cached' : 'history'
 }
 
+// A detail cache carries the Chat row version it was built from. Runtime reads
+// expose the same version without hydrating transcript JSON, so a retained
+// chat can prove that its already-painted messages are still current.
+// Missing versions fail closed during rolling updates and use the full detail
+// path once to seed the contract.
+export function chatSnapshotMatchesRuntime(cached, runtime) {
+  return typeof cached?.updated_at === 'string'
+    && typeof runtime?.updated_at === 'string'
+    && cached.updated_at === runtime.updated_at
+}
+
 export function chatDetailCacheValue(data = {}) {
   return {
+    updated_at: typeof data.updated_at === 'string' ? data.updated_at : null,
     messages: Array.isArray(data.messages)
       ? data.messages.map(settledToolBlocks)
       : [],

--- a/tests/stream-reconnect.spec.mjs
+++ b/tests/stream-reconnect.spec.mjs
@@ -983,41 +983,57 @@ test.describe('Stream reconnection', () => {
     // frozen on an unanswered question. Crucially `pending_question_id`
     // is null (the live in-process registry hint is absent — the path
     // that used to wedge), forcing the durable fallback.
-    await page.route(/\/api\/chats\/[0-9a-f-]+\?limit=20&compact=1$/, route => {
+    const updatedAt = '2026-07-30T18:00:00'
+    const detail = {
+      id: CHAT_ID,
+      title: 'frozen chat',
+      updated_at: updatedAt,
+      messages: [
+        { role: 'user', content: 'help me pick', ts: TURN_TS - 1000 },
+        {
+          role: 'assistant',
+          ts: TURN_TS,
+          blocks: [
+            { type: 'text', content: 'A couple of choices:' },
+            {
+              type: 'question',
+              question_id: QUESTION_ID,
+              questions: [
+                {
+                  question: 'Which color?',
+                  options: [{ label: 'Red' }, { label: 'Blue' }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      pending_messages: [],
+      total: 2,
+      offset: 0,
+      running: true,
+      pending_question_id: null,
+      session_id: 'sess-1',
+      provider: 'claude',
+    }
+    await page.route(/\/api\/chats\/[0-9a-f-]+\?limit=(?:1|20&compact=1)$/, route => {
+      if (route.request().method() !== 'GET') { route.continue(); return }
+      route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(detail),
+      })
+    })
+    await page.route(/\/api\/chats\/[0-9a-f-]+\/runtime$/, route => {
       if (route.request().method() !== 'GET') { route.continue(); return }
       route.fulfill({
         status: 200,
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          id: CHAT_ID,
-          title: 'frozen chat',
-          messages: [
-            { role: 'user', content: 'help me pick', ts: TURN_TS - 1000 },
-            {
-              role: 'assistant',
-              ts: TURN_TS,
-              blocks: [
-                { type: 'text', content: 'A couple of choices:' },
-                {
-                  type: 'question',
-                  question_id: QUESTION_ID,
-                  questions: [
-                    {
-                      question: 'Which color?',
-                      options: [{ label: 'Red' }, { label: 'Blue' }],
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-          pending_messages: [],
-          total: 2,
-          offset: 0,
           running: true,
+          pending_messages: [],
           pending_question_id: null,
-          session_id: 'sess-1',
-          provider: 'claude',
+          updated_at: updatedAt,
         }),
       })
     })


### PR DESCRIPTION
## Summary

- version compact chat-detail and lightweight runtime projections with the row update time
- reuse a retained transcript only when its version exactly matches current runtime state
- clear version proof after local, streamed, or paginated message changes and fail closed to a full detail read
- publish a refreshed detail snapshot once instead of notifying the cache twice

## Context

Opening an unchanged retained chat still fetched and reconciled its full transcript while the outgoing chat remained visible. This keeps the already-painted transcript when a lightweight runtime check proves it is current, while preserving the authoritative detail path for every ambiguous or changed state.

This builds on #382's single chat-entry phase. It reduces activation I/O without reintroducing parallel readiness states.

## Testing

- compact transcript backend tests: 8 passed
- focused activation and handoff frontend tests: 32 passed
- complete frontend unit suite: 2,279 passed
- production frontend build
- `git diff --check`