### PR TITLE
Simplify pane mode transitions with captured scenes

### DIFF
--- a/frontend/src/components/Shell/NewChatLanding.jsx
+++ b/frontend/src/components/Shell/NewChatLanding.jsx
@@ -1,11 +1,11 @@
 /**
  * The first-class New Chat landing painted for a null single-screen slot
  * (round 4 item 3). A null slot is a DEFINITE New Chat destination now — never the
- * freshest transcript — so the honest beat destination is this cheap, always-available
+ * freshest transcript — so the destination is this cheap, always-available
  * surface. It shares ChatView's empty-treatment visuals (the same .chat__empty-wrap /
  * .chat__empty glyph + title) so the swap to a real empty ChatView, once the row
- * materializes, is visually seamless. It also doubles as the stationary world-reveal
- * underlay while the panes slide away.
+ * materializes, is visually seamless. The browser can capture it as the settled
+ * Standard scene while Builder panes slide away.
  *
  * It is deliberately NOT a live composer: drafts, attachments, provider state, and the
  * send pipeline are all chat-ID-bound, so the row is materialized AFTER the descriptor

--- a/frontend/src/components/Shell/PaneStrip.jsx
+++ b/frontend/src/components/Shell/PaneStrip.jsx
@@ -192,22 +192,23 @@ export function PaneFocusButton({ paneId, focused, onToggle }) {
 // before navTo snapshots the source route (see WorkspaceChrome.activateTab).
 export function PaneStrip({
   pane, paneRect, focused, labelForTab,
-  onActivate, onClose, onFocus, onTabContextMenu, motion = null,
+  onActivate, onClose, onFocus, onTabContextMenu,
+  viewTransitionStyle = null,
   canFocusPane = false, paneFocused = false, onTogglePaneFocus,
   revealKey = 0,
 }) {
-  // The strip deals WITH its pane during a mode beat (exit-design v2): the same
-  // compositor-only data-mode-motion + --mode-duration/--mode-delay the pane wrapper
-  // carries, merged into the strip's absolute-position style. A promote (survivor)
-  // strip clears upward; a deal-out/deal-in strip moves with its pane.
-  const style = motion
-    ? { left: paneRect.x, top: paneRect.y, width: paneRect.w, height: STRIP_H, ...motion.vars }
-    : { left: paneRect.x, top: paneRect.y, width: paneRect.w, height: STRIP_H }
+  const style = {
+    left: paneRect.x,
+    top: paneRect.y,
+    width: paneRect.w,
+    height: STRIP_H,
+    ...(viewTransitionStyle || {}),
+  }
   return (
     <div
       className={`workspace__strip shell__tabstrip${focused ? ' workspace__strip--focused' : ''}`}
       data-pane-strip={pane.id}
-      data-mode-motion={motion ? motion.motion : undefined}
+      data-mode-pane-vt={viewTransitionStyle ? pane.id : undefined}
       role="tablist"
       aria-label="Pane tabs"
       style={style}

--- a/frontend/src/components/Shell/Shell.css
+++ b/frontend/src/components/Shell/Shell.css
@@ -516,15 +516,15 @@
 }
 /* Same-beat timing (polish item 5 + round 4 item 1): the logo and wordmark
    settle on the SAME beat as the panes. The twist now rides --mode-total (the plan's
-   own totalMs, written on the shell root by Shell while the beat is live) so rotation
+   own totalMs, written on the small header subtree while the beat is live) so rotation
    reaches its rest exactly when the panes do. Entering keeps a tiny signature
    settle (the 1 control point); exiting is a quick, springless settle. */
-.shell--builder-entering .shell__logo {
+.shell__bar[data-mode-phase="entering"] .shell__logo {
   transition:
     rotate var(--mode-total, 260ms) cubic-bezier(0.2, 1, 0.32, 1),
     scale 160ms ease;
 }
-.shell--builder-exiting .shell__logo {
+.shell__bar[data-mode-phase="exiting"] .shell__logo {
   transition:
     rotate var(--mode-total, 220ms) cubic-bezier(0.25, 0.8, 0.25, 1),
     scale 160ms ease;
@@ -572,8 +572,8 @@
 /* The wordmark tint keeps pace with the one-shot mode beat. Its faint halo and
    the logo's matching drop-shadow are static settled-state cues, with no
    perpetual header animation. */
-.shell--builder-entering .shell__wordmark { transition-duration: 220ms; }
-.shell--builder-exiting .shell__wordmark { transition-duration: 140ms; }
+.shell__bar[data-mode-phase="entering"] .shell__wordmark { transition-duration: 220ms; }
+.shell__bar[data-mode-phase="exiting"] .shell__wordmark { transition-duration: 140ms; }
 @keyframes shell-logo-ignite {
   from { scale: 0.84; }
   to { scale: 1; }
@@ -659,8 +659,9 @@
     padding: 12px;
     flex-direction: column;
     align-items: center;
-    background: transparent;
+    background: var(--bg);
     border: 0;
+    border-right: 1px solid var(--border-light);
     pointer-events: none;
   }
 
@@ -694,6 +695,7 @@
     padding: 8px 12px;
     flex-direction: row;
     align-items: center;
+    border-right: 0;
     border-bottom: 0;
   }
 

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -102,6 +102,7 @@ import './workspace.css'
 import WorkspaceChrome from './WorkspaceChrome.jsx'
 import useWorkspaceDrag from './useWorkspaceDrag.js'
 import useModeController from './useModeController.js'
+import useModeViewTransition, { modeViewTransitionStyle } from './useModeViewTransition.js'
 import * as modeMachine from './modeMachine.js'
 import { undoKeyPressed, isEditableTarget } from './workspaceOnboarding.js'
 import PaneChatView from './PaneChatView.jsx'
@@ -122,8 +123,8 @@ import {
 } from './builtAppState.js'
 import ErrorBoundary from '../ErrorBoundary/ErrorBoundary.jsx'
 import {
-  deriveContentVisibility, deriveExitPlan, deriveEnterPlan, projectFocusedPane,
-  transitionSignature, MODE_MOTION, EMPTY_SINGLE_SURFACE_KEY,
+  deriveContentVisibility, deriveModeSnapshotPlan, projectFocusedPane,
+  MODE_MOTION, EMPTY_SINGLE_SURFACE_KEY,
 } from './workspaceView.js'
 import NewChatLanding from './NewChatLanding.jsx'
 import { recentChatsToPrefetch } from './chatPrefetch.js'
@@ -143,10 +144,8 @@ const APP_SETTINGS_SECTIONS = new Set([
   'background-agents',
   'models',
 ])
-// The builder mode beat durations live in workspaceView.js (MODE_MOTION); the
-// reconcile clock reads the latched plan's totalMs, and completion is keyed to the
-// beat's Web-Animations `finished` promises, not a bare timer — so no BUILDER_ENTER
-// / BUILDER_EXIT Shell constants exist (exit-design v2; INV 7/14).
+// Mode timing lives with the pure snapshot geometry in workspaceView.js; browser
+// transition completion owns its lifetime, so Shell has no animation timers.
 const SettingsView = lazy(() => import('../SettingsView/SettingsView.jsx'))
 
 export default function Shell() {
@@ -395,32 +394,28 @@ export default function Shell() {
   // Builder mode is the tiled 'panes' view-mode (only meaningful when splits can
   // exist). The logo itself is the persistent mode indicator and gesture surface;
   // there is deliberately no separate header control.
-  // ── Mode transition machine (modeMachine.js / useModeController) ───────────
-  // The ONE descriptor { committedMode, transition } that replaces the old
-  // dragPreviewBuilder / builderExiting / builderEntering booleans, their two
-  // bare timers, and the ad-hoc effectiveViewMode expression. workspace.viewMode
-  // stays the persisted authority; the controller mirrors it and owns only the
-  // transient beat, driving completion by epoch (INV 12/15) rather than a timer.
-  // Codex review §3: EVERY mode-dependent render fact below derives from
-  // mode.state (INV 4), so the reducer and the render can never disagree past one
-  // beat — the P0 wedge the review opened with.
+  // Durable mode and drag-preview stay in the small mode reducer. The visual
+  // Standard ↔ Builder scene belongs independently to the browser transition.
   const SPLITS = paneModel.WORKSPACE_SPLITS_ENABLED
   const shellRootRef = useRef(null)
   const mode = useModeController({
     committedMode: workspace.viewMode,
     splitsEnabled: SPLITS,
+  })
+  const modeView = useModeViewTransition({
     rootRef: shellRootRef,
+    durationMs: MODE_MOTION.slideMs,
   })
   const modeState = mode.state
-  // Keep the focused presentation through a Builder -> Standard exit so the
-  // latched beat animates exactly what the user saw. Once the descriptor idles,
+  // Keep the focused presentation through a Builder -> Standard scene so the
+  // captured old world is exactly what the user saw. Once the scene idles,
   // discard it; Standard mode has no pane-focus presentation to restore.
   useEffect(() => {
-    if (workspace.viewMode === 'single' && !modeState.transition
+    if (workspace.viewMode === 'single' && !modeView.active && !modeState.transition
         && focusedPaneViewIdRef.current != null) {
       setFocusedPaneViewId(null)
     }
-  }, [workspace.viewMode, modeState.transition, setFocusedPaneViewId])
+  }, [workspace.viewMode, modeView.active, modeState.transition, setFocusedPaneViewId])
 
   // Persist the maximized-pane presentation to its own key on every change so it
   // survives the apply-on-idle reload (and a browser tab discard). Removing the
@@ -448,74 +443,36 @@ export default function Shell() {
   // chrome), clamped off by the splits kill switch (INV 16). Flips synchronously
   // with the toggle, matching the gesture's own spring/snap.
   const builderModeActive = modeMachine.builderModeActive(modeState, { splitsEnabled: SPLITS })
-  // The mode the render paints: 'panes' while an exit beat OR a single-mode drag
-  // preview holds the tiled world; the committed mode otherwise. The single source
-  // (INV 4) — no scattered override.
+  // Drag-preview alone may project the tiled world before it is committed.
   const effectiveViewMode = modeMachine.effectiveViewMode(modeState, { splitsEnabled: SPLITS })
   const multiPaneBuilderVisible = effectiveViewMode === 'panes'
     && paneModel.paneIdsInOrder(workspace).length > 1
   const multiPaneBuilderVisibleRef = useRef(multiPaneBuilderVisible)
   multiPaneBuilderVisibleRef.current = multiPaneBuilderVisible
-  // The latched presentation plan for the live animated beat. Either direction may
-  // carry a stationary single-world underlay while panes scatter or assemble over it.
-  const beatPlan = modeMachine.transitionPresentation(modeState)
-  // A mode beat is live: moving surfaces are inert and app frames cannot intercept
-  // input while their compositor layer is in flight.
-  const modeBeatActive = !!beatPlan
-  const modeUnderlayKey = beatPlan ? beatPlan.underlayKey : null
-  // The logo spring-back window on the shell root while an animated beat is live
+  // The final React world is already committed during this window; only browser
+  // snapshots move. Shield that settled DOM until the scene transaction ends.
+  const modeBeatActive = !!modeView.active
+  // The logo spring-back window on ShellBrand while an animated beat is live
   // (round 4 item 1): the mark holds .84 through the beat and releases over the
   // terminal logoReleaseMs so its first full-size frame lands at completion. `both`
   // fill on the CSS keyframe holds .84 through the release DELAY. The twist rides
   // --mode-total so rotation, panes, and logo settle together. A short plan clamps
   // the release to the whole beat. Null (no vars) when idle.
-  const beatRootVars = useMemo(() => {
-    if (!beatPlan) return null
-    const total = beatPlan.totalMs
+  const brandBeatStyle = useMemo(() => {
+    const visualBeat = modeView.active
+    if (!visualBeat) return null
+    const total = visualBeat.totalMs
     const release = Math.min(MODE_MOTION.logoReleaseMs, total)
     return {
       '--mode-total': `${total}ms`,
       '--logo-release-ms': `${release}ms`,
       '--logo-release-delay': `${Math.max(0, total - MODE_MOTION.logoReleaseMs)}ms`,
     }
-  }, [beatPlan])
+  }, [modeView.active])
   const shellRootStyle = useMemo(() => ({
-    ...(beatRootVars || {}),
     '--desktop-sidebar-width': `${desktopSidebarWidth}px`,
     '--shell-tabstrip-height': `${paneModel.STRIP_H}px`,
-  }), [beatRootVars, desktopSidebarWidth])
-  // The key SINGLE mode paints beneath / within either directional beat. It drives
-  // destination AppCanvas insets before the first frame so neither direction jumps.
-  const beatTargetKey = beatPlan ? beatPlan.target : null
-  // key → latched participant, for the render's data-mode-motion + inline vars.
-  const beatParticipants = useMemo(() => {
-    const m = new Map()
-    if (beatPlan) for (const p of beatPlan.participants) m.set(p.key, p)
-    return m
-  }, [beatPlan])
-  // The inline compositor-motion attrs a wrapper (or its strip) carries THIS beat,
-  // or null. Only transform/opacity + FLIP variables — never a layout property.
-  const wrapperMotion = useCallback((key) => {
-    const p = beatParticipants.get(key)
-    if (!p) return null
-    const vars = { '--mode-duration': `${p.durationMs}ms`, '--mode-delay': `${p.delayMs}ms` }
-    if (p.motion === 'promote' && p.flip) {
-      vars['--flip-x'] = `${p.flip.x}px`
-      vars['--flip-y'] = `${p.flip.y}px`
-      vars['--flip-sx'] = p.flip.sx
-      vars['--flip-sy'] = p.flip.sy
-    }
-    if ((p.motion === 'deal-in' || p.motion === 'deal-out') && p.offset) {
-      vars['--mode-offset-x'] = `${p.offset.x}px`
-      vars['--mode-offset-y'] = `${p.offset.y}px`
-    }
-    return { motion: p.motion, vars }
-  }, [beatParticipants])
-  // The wrapper matching the stationary world underlay paints full-bleed beneath.
-  const isUnderlay = useCallback(
-    (key) => modeBeatActive && modeUnderlayKey != null && key === modeUnderlayKey,
-    [modeBeatActive, modeUnderlayKey],
-  )
+  }), [desktopSidebarWidth])
   // Immersive mode (moebius:immersive, .pm/128). The state is the id of the app
   // holding an immersive request (or null); it's APPLIED — bar hidden, canvas
   // full-viewport — only while that app is the active canvas of the FOCUSED
@@ -544,34 +501,6 @@ export default function Shell() {
     const drawer = document.getElementById('navigation-drawer')
     if (drawer?.contains(document.activeElement)) immersiveExitRef.current?.focus()
   }, [immersiveActive])
-  // HONEST EXIT DESTINATION (M2): the exit-plan classifier needs to know what the
-  // SINGLE world will actually paint on completion, not just the slot the tree
-  // seeds. A suspended single-world takeover (settingsOpenRaw) paints Settings over
-  // the slot; a retained immersive request (immersiveAppId) solos the holder over
-  // the viewport. Mirrored into refs so the toggle callback (stable identity, no
-  // dep churn) and the undo keydown handler (deps [dispatchWorkspace, mode]) both
-  // read the LIVE values without a stale closure or re-registering their listeners.
-  const settingsDestinationRef = useRef(settingsOpenRaw)
-  settingsDestinationRef.current = settingsOpenRaw
-  const immersiveHolderRef = useRef(immersiveAppId)
-  immersiveHolderRef.current = immersiveAppId
-
-  // INV 10 / H2: a topology, geometry, OR DESTINATION change DURING either animated
-  // beat makes its latched FLIP/edge transforms stale. Cancel rather than retarget a
-  // live transform: recompute the shared transition signature from the same projection
-  // authority and overlay classification both plan builders use. The live overlay state
-  // is in the deps, so a mid-beat Settings/immersive destination change also snaps.
-  useEffect(() => {
-    const t = modeState.transition
-    if (!t?.presentation) return
-    const live = transitionSignature({
-      workspace, projection, contentRect,
-      settingsDestination: settingsOpenRaw,
-      immersiveHolderId: immersiveAppId,
-    })
-    if (live !== t.presentation.snapshotSignature) mode.cancelBeat()
-  }, [workspace, projection, contentRect, settingsOpenRaw, immersiveAppId, modeState, mode])
-
   // The single derivation of what content the render paints and where (design
   // §2/§4/§5). Pure + memoized so the immersive-solo and Settings-overlay
   // branches are unit-tested in workspaceView.test.js, and so one commit flips
@@ -581,18 +510,15 @@ export default function Shell() {
       workspace, projection, settingsOverlayOpen: settingsActive,
       immersiveActive, immersiveAppId,
       viewMode: effectiveViewMode, // 'panes' during a single-mode drag preview
-      // World-reveal exit: paint the mounted destination beneath the deal (adds its
-      // app to visibleAppIds so the underlay is not a blank frame).
-      exitUnderlayKey: modeUnderlayKey,
       focusedPaneView: focusedPaneViewId != null,
     }),
     [workspace, projection, settingsActive, immersiveActive, immersiveAppId,
-      effectiveViewMode, modeUnderlayKey, focusedPaneViewId],
+      effectiveViewMode, focusedPaneViewId],
   )
   const { multiPane, single, focusedActiveKey, fullBleedKey, visibleAppIds } = contentVisibility
   // The EFFECTIVE-mode-gated Settings takeover flag (finding F3): true only when the
   // takeover actually PAINTS — false in builder AND during a single-mode drag
-  // preview / exit beat (effectiveViewMode 'panes'). Every PAINT gate below reads
+  // preview (effectiveViewMode 'panes'). Every PAINT gate below reads
   // THIS, not the committed-gated `settingsActive` (which is only the derivation
   // INPUT now), so those transient windows paint the tiled world with Settings
   // suspended exactly as the derived flags assume. MOUNT keys off `settingsOpenRaw`.
@@ -1147,8 +1073,8 @@ export default function Shell() {
   const recoveredChatIdsRef = useRef(new Set())
   // ── Deferred New Chat materialization (round 4 item 3) ─────────────────────
   // A null single-screen slot renders the New Chat landing NOW; the reusable-empty
-  // validation + creation runs only AFTER the mode descriptor idles, so the slot write
-  // never drifts a live exit signature and cancels its own beat. The request is a
+  // validation + creation runs only AFTER the visual scene idles, so its settled
+  // pixels cannot be replaced beneath a captured transition. The request is a
   // monotonic token + a candidate captured from the pre-transition active chat; a
   // watcher effect materializes it once the descriptor is idle, stale-guarded on token
   // + still-single + still-null. offline/failed creation leaves the landing with a
@@ -1162,10 +1088,10 @@ export default function Shell() {
   // this is event-driven and only renders in that rare collision (no polling loop).
   const [materializeNewChatRevision, setMaterializeNewChatRevision] = useState(0)
   const [newChatLandingFailure, setNewChatLandingFailure] = useState(null)
-  // Live mirror of the mode descriptor so the async materialize can re-check for a
-  // beat that started during its await (writing the slot mid-beat would cancel it).
-  const modeTransitionRef = useRef(modeState.transition)
-  modeTransitionRef.current = modeState.transition
+  // Live mirror so async materialization cannot replace the captured New Chat
+  // landing while a browser scene transition is still displaying it.
+  const modeTransitionRef = useRef(modeView.active || modeState.transition)
+  modeTransitionRef.current = modeView.active || modeState.transition
   // Every mounted chat pane derives its OWN built-app CTA list per chatId inside
   // PaneChatView (builtAppState.js), so Shell no longer holds a global builtApps
   // bound to a single activeChatId.
@@ -1212,8 +1138,7 @@ export default function Shell() {
   // slot is a DEFINITE New Chat destination now — never the freshest chat — so this
   // leaves the slot null (the render paints the New Chat surface) and records a
   // tokenized pending request. The reusable-empty validation + creation runs only
-  // AFTER the mode descriptor idles (the materialize watcher below), so the slot write
-  // never drifts a live exit signature and cancels its own beat. The candidate is
+  // AFTER the visual scene idles (the materialize watcher below). The candidate is
   // captured from the PRE-transition active chat but NOT targeted synchronously — the
   // reuse policy (newChatPolicy) is deliberately provisional (has_messages can be
   // stale cross-client), so it must survive its detail validation before it becomes
@@ -1241,10 +1166,10 @@ export default function Shell() {
     const ws = workspaceStateRef.current.ws
     // R3 (auto-return through the descriptor): a user close that EMPTIES the builder
     // tree auto-returns to single (the reducer's autoReturnIfEmptied). Arm the SAME
-    // flip on the mode descriptor in the SAME batch (cause 'auto') so committedMode
+    // mirror the durable flip in the small mode controller in the SAME batch so
     // flips to single NOW — not a frame later via the passive sync-committed
     // reconcile, which left the logo twisted for one intermediate frame. An emptied
-    // tree has no pane to deal out, so the exit is instant (null presentation); the
+    // tree has no pane to animate, so the exit is instant; the
     // tree's coupled undo re-enters builder as one gesture. A sole Settings tab is
     // no exception — closing it empties the tree the same way. reason:'deleted' does
     // not auto-return (the reducer skips it), so it is excluded here too.
@@ -1315,8 +1240,8 @@ export default function Shell() {
   // EFFECTIVE builder world exactly — always present in builder (even at a
   // single leaf, where this single-pane .shell__tabstrip stands in for the
   // tiled WorkspaceChrome strips, giving phone users the drag source), riding
-  // an exit beat or a single-mode drag preview with the rest of the tiled
-  // presentation, and NEVER rendered in single mode OR over an immersive lease
+  // a single-mode drag preview with the rest of the tiled presentation, and NEVER
+  // rendered in single mode OR over an immersive lease
   // (the shell exit replaces every builder navigation surface). The legacy
   // tabStripEngaged latch is
   // the KILL-SWITCH world's rule only (engaged after 2+ tabs) — letting it
@@ -1383,12 +1308,6 @@ export default function Shell() {
     return map
   }, [projection, workspace])
 
-  // (v2: the exit-beat wrapper-rect substitution is DELETED. Panes hold their tiled
-  // content rect through the beat; a promote pane FLIPs via transform to cover the
-  // full box while departures deal out, so computed top/left/width/height never
-  // change until the descriptor clears and the destination snaps to full-bleed in
-  // one commit. visibleTabRects is now the sole tiled-geometry authority.)
-
   // ── The ONE Settings wrapper (design §4: overlay-or-pane geometry) ─────────
   // A single, stable SettingsView mount that is positioned like any chat/app
   // content when Settings is a visible builder tab, and full-bleed when the
@@ -1397,9 +1316,9 @@ export default function Shell() {
   // scroll position and transient Settings state survive the flip.
   const SETTINGS_KEY = tabModel.SETTINGS_TAB_KEY
   // Visible as a builder TAB: the takeover is not PAINTING AND some visible pane has
-  // the Settings tab active. Gated on the effective `settingsOverlay` (finding F3),
-  // so a single-mode drag preview / exit beat can paint a stray Settings tab as a
-  // pane. (Blind to a BACKGROUND Settings tab — not painted.)
+  // the Settings tab active. Gated on the effective `settingsOverlay` so a
+  // single-mode drag preview cannot paint a stray Settings tab as a pane. (Blind to
+  // a BACKGROUND Settings tab — not painted.)
   const settingsVisibleAsTab = !settingsOverlay
     && projection.visibleLeaves.some(id => workspace.panes[id]?.activeTabKey === SETTINGS_KEY)
   // MOUNT (finding F3): keyed off the RAW suspended overlay intent, NOT the
@@ -1509,7 +1428,7 @@ export default function Shell() {
   // actually painted. Publish one stable readiness contract for visual tools;
   // they must not learn private handoff classes or compositor attributes.
   const workspaceVisualState = deriveWorkspaceVisualState({
-    modeTransition: modeState.transition,
+    modeTransition: modeView.active || modeState.transition,
     chatPanesVisible,
     chatPaneLayers,
     paintedChatWorld: effectiveViewMode === 'single'
@@ -1738,40 +1657,24 @@ export default function Shell() {
   const handleToggleViewMode = useCallback((cause) => {
     const ws = workspaceStateRef.current.ws
     const leavingBuilder = ws.viewMode !== 'single'
-    // Build the latched presentation plan from the PROJECTION authority (exit-design
-    // v2). The plan owns ALL of the classification the old handler computed inline:
-    // promote a genuinely-shared pane vs reveal the single world underneath, the
-    // FLIP rects, shared short timing, and the completion contract. The machine treats
-    // it opaquely; the controller drops it under reduced motion (commit directly). A
-    // null plan (empty tree) is an instant flip. Settings needs no conversion — its
-    // tab SURVIVES the flip and single mode paints its own slot (never Settings).
-    // Durable flip FIRST. The synchronous dispatch boundary requests the New Chat
-    // landing if this enters a null slot (e.g. a Settings-focused builder never
-    // seeded one). The slot stays null through the beat, so exitTargetKey reveals
-    // home:new-chat and materialization waits for the descriptor to idle. THEN derive
-    // the plan from the already-advanced workspace (INV 2/3).
-    dispatchWorkspace({ type: 'SET_VIEW_MODE', mode: 'toggle' })
-    const settled = workspaceStateRef.current.ws
-    const presentation = leavingBuilder
-      ? deriveExitPlan({
-        // The tree is identical across the flip; only viewMode/slot advanced.
-        workspace: settled, projection, contentRect,
-        // M2: reveal to Settings / classify immersive instant, not the slot the
-        // takeover or immersive-solo covers at completion.
-        settingsDestination: settingsDestinationRef.current,
-        immersiveHolderId: immersiveHolderRef.current,
-      })
-      : deriveEnterPlan({
-        workspace: settled, projection, contentRect,
-        settingsDestination: settingsDestinationRef.current,
-        immersiveHolderId: immersiveHolderRef.current,
-      })
-    // The honest `cause` ('hold'|'swipe'|'keyboard') threads from the caller;
-    // an omitted cause falls back to 'toggle'. RETURN the
-    // toggle receipt so the logo gesture can tell an animated beat from an instant
-    // flip and hand its compression to the descriptor (round 4 item 1).
-    return mode.toggle({ cause, presentation })
-  }, [dispatchWorkspace, mode, projection, contentRect])
+    const to = leavingBuilder ? 'single' : 'panes'
+    const plan = deriveModeSnapshotPlan({ workspace: ws, projection, contentRect })
+
+    // One browser-owned scene transaction commits BOTH durable authorities. The
+    // old world is captured first; React then renders the final world once, and the
+    // browser animates settled snapshots. No temporary underlay, live FLIP, divider
+    // fade, or second projection commit exists for the panes to race against.
+    return modeView.run({
+      direction: leavingBuilder ? 'exit' : 'enter',
+      to,
+      cause,
+      plan,
+      update: () => {
+        dispatchWorkspace({ type: 'SET_VIEW_MODE', mode: to })
+        mode.toggle({ cause, to })
+      },
+    })
+  }, [dispatchWorkspace, mode, modeView, projection, contentRect])
   // The single-tap navigation toggle passed to ShellBrand (which owns the logo
   // gesture and static Builder cue). The HOLD / swipe / Shift+Enter mode toggle is
   // handleToggleViewMode above, passed to ShellBrand as onToggleMode.
@@ -1837,29 +1740,33 @@ export default function Shell() {
           ? undoSlot.ws.viewMode : wsState.ws.viewMode
         if (restoredMode !== wsState.ws.viewMode) {
           const scene = sceneInputsRef.current
-          const presentation = restoredMode === 'panes'
-            ? deriveEnterPlan({
-              workspace: undoSlot.ws,
-              projection: paneModel.projectLayout(undoSlot.ws, scene.mode, scene.contentRect),
-              contentRect: scene.contentRect,
-              settingsDestination: settingsDestinationRef.current,
-              immersiveHolderId: immersiveHolderRef.current,
-            })
-            : deriveExitPlan({
-              workspace: wsState.ws, projection: scene.projection, contentRect: scene.contentRect,
-              // M2: same honest-destination classification for an undo that exits
-              // builder — Settings/immersive still own the single world it lands in.
-              settingsDestination: settingsDestinationRef.current,
-              immersiveHolderId: immersiveHolderRef.current,
-            })
-          mode.undo({ restoredMode, presentation })
+          const paneWorld = restoredMode === 'panes' ? undoSlot.ws : wsState.ws
+          const paneProjection = restoredMode === 'panes'
+            ? paneModel.projectLayout(paneWorld, scene.mode, scene.contentRect)
+            : scene.projection
+          const plan = deriveModeSnapshotPlan({
+            workspace: paneWorld,
+            projection: paneProjection,
+            contentRect: scene.contentRect,
+          })
+          modeView.run({
+            direction: restoredMode === 'panes' ? 'enter' : 'exit',
+            to: restoredMode,
+            cause: 'undo',
+            plan,
+            update: () => {
+              mode.undo({ restoredMode })
+              dispatchWorkspace({ type: 'UNDO_LAST' })
+            },
+          })
+          return
         }
       }
       dispatchWorkspace({ type: 'UNDO_LAST' })
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [dispatchWorkspace, mode])
+  }, [dispatchWorkspace, mode, modeView])
 
   // No per-mutation undo toast: the reducer still mints a fresh undo slot on
   // every workspace mutation (its `toast` label included, for the reducer's own
@@ -3170,8 +3077,7 @@ export default function Shell() {
   }
 
   // Materialize the deferred New Chat landing into a real chat slot (round 4 item 3).
-  // Runs ONLY after the mode descriptor idles (the watcher below gates it), so the slot
-  // write never drifts a live exit signature and cancels its own beat. Stale-guarded
+  // Runs ONLY after the visual scene idles (the watcher below gates it). Stale-guarded
   // against a superseding request, a re-toggle back to builder, and a slot filled by
   // another path. On offline/failed creation it leaves the New Chat landing visible
   // with a retry affordance — never a blank <main>, never chats[0].
@@ -3337,12 +3243,10 @@ export default function Shell() {
 
   // ── Deferred New Chat materialization watcher (round 4 item 3) ─────────────
   // A pending New Chat request (recorded by requestEmptySingleNewChat) materializes
-  // only once the mode descriptor is IDLE and the slot is still an empty single — so
-  // the slot write can never drift a live exit signature and cancel its own beat. When
-  // the beat completes, modeState.transition flips to null and this re-runs.
+  // only once the visual scene is IDLE and the slot is still an empty single.
   useEffect(() => {
     if (!pendingNewChatToken) return
-    if (modeState.transition) return // wait for the descriptor to idle
+    if (modeView.active || modeState.transition) return
     const pending = pendingNewChatRef.current
     if (!pending || pending.token !== pendingNewChatToken) return
     const ws = workspaceStateRef.current.ws
@@ -3354,7 +3258,7 @@ export default function Shell() {
       return
     }
     materializeNewChatHomeRef.current?.(pending)
-  }, [pendingNewChatToken, materializeNewChatRevision, modeState.transition,
+  }, [pendingNewChatToken, materializeNewChatRevision, modeView.active, modeState.transition,
       workspace.viewMode, workspace.singleScreen, workspaceStateRef])
 
   function selectChat(id) {
@@ -3609,24 +3513,14 @@ export default function Shell() {
     >
     <div
       ref={shellRootRef}
-      // The logo-release timing vars for the live beat (round 4 item 1); absent when
-      // idle so the .shell__logo rotate/scale transitions fall back to their defaults.
+      // Stable shell geometry only. Beat-local custom properties live on the header
+      // or moving pane itself, never this ancestor of every retained transcript.
       style={shellRootStyle}
-      // The live transition phase + epoch, surfaced for observability + tests: the
-      // completion is epoch-keyed in the controller closure (INV 12/15), and this
-      // data-epoch documents which beat the DOM belongs to (a drag preview has no
-      // beat class, so this is the only external signal it is armed). idle otherwise.
-      data-mode-phase={modeState.transition ? modeState.transition.phase : 'idle'}
-      data-mode-epoch={modeState.transition ? modeState.transition.id : undefined}
+      data-mode-phase={modeView.active?.phase || modeState.transition?.phase || 'idle'}
+      data-mode-epoch={modeView.active?.id || modeState.transition?.id || undefined}
       data-workspace-visual-state={workspaceVisualState}
-      // The ONE transient beat class comes from the descriptor (INV 1/4): exactly
-      // one of entering/exiting is ever present, and the keyed animationend on
-      // this root completes the beat (the controller's listener). No separate
-      // entering/exiting booleans emit here anymore.
       className={`shell${immersiveActive ? ' shell--immersive' : ''}`
       + `${desktopSidebarReserved ? ' shell--drawer-docked' : ''}`
-      + `${modeMachine.transitionRootClass(modeState, { splitsEnabled: SPLITS })
-        ? ` ${modeMachine.transitionRootClass(modeState, { splitsEnabled: SPLITS })}` : ''}`
       + `${builderModeActive && paneModel.BUILDER_POWER_CHROME ? ' shell--builder-power' : ''}`}>
       <a
         className="shell__skip-link"
@@ -3642,7 +3536,11 @@ export default function Shell() {
           mobile drawer is modal. Keep the workspace inert below, but do not inert
           the header: doing so lets the scrim intercept the toggle and strands the
           drawer without the close path its label and aria-expanded state promise. */}
-      <header className="shell__bar">
+      <header
+        className="shell__bar"
+        style={brandBeatStyle || undefined}
+        data-mode-phase={modeView.active?.phase || undefined}
+      >
         <ShellBrand
           brandRef={brandButtonRef}
           splitsEnabled={paneModel.WORKSPACE_SPLITS_ENABLED}
@@ -3651,7 +3549,7 @@ export default function Shell() {
           // The live descriptor drives the logo's hold→completion spring (round 4
           // item 1): a hold-owned animated beat holds the mark compressed and releases
           // it as the beat completes, instead of an immediate ignite/snap.
-          transition={modeState.transition}
+          transition={modeView.active || modeState.transition}
           backFiredRef={backFiredRef}
           onToggleMode={handleToggleViewMode}
           onToggleNavigation={handleToggleNavigation}
@@ -3772,16 +3670,16 @@ export default function Shell() {
           reset the send-reservation and freeze stream-follow (the reason the
           bespoke split view was parked). */}
       {tabStripVisible && !workspaceChromeActive && (() => {
-        // Single-leaf beat: the sole strip deals in / out / clears WITH its pane
-        // (there is no WorkspaceChrome at one leaf). Its active key is the beat
-        // participant key.
-        const navMotion = wrapperMotion(focusedActiveKey)
+        const navPaneId = workspace.focusedPaneId
+        const navViewStyle = navPaneId
+          ? modeViewTransitionStyle('strip', navPaneId, 'single')
+          : null
         return (
         <nav
           className="shell__tabstrip"
           onWheel={scrollStripWheel}
           // INV 9 (inert beat): the single-pane strip clears WITH its pane during
-          // an exit beat, so it is pointer/keyboard inert throughout — not just under
+          // a mode scene, so it is pointer/keyboard inert throughout — not just under
           // the drawer (M4). It matches the WorkspaceChrome strips, which already go
           // inert for the full mode beat.
           inert={navigationSurfaceOpen || modeBeatActive}
@@ -3791,8 +3689,8 @@ export default function Shell() {
           // source pane exactly as it does for a WorkspaceChrome strip; dragging
           // a tab out with ≥2 tabs present splits the pane.
           data-pane-strip={paneModel.WORKSPACE_SPLITS_ENABLED ? workspace.focusedPaneId : undefined}
-          data-mode-motion={navMotion ? navMotion.motion : undefined}
-          style={navMotion ? navMotion.vars : undefined}
+          data-mode-pane-vt={navViewStyle ? navPaneId : undefined}
+          style={navViewStyle || undefined}
           onKeyDown={(e) => stripKeyDown(e, openTabs, (tab) => closeTab(tab))}
         >
           {openTabs.map(tab => {
@@ -3838,11 +3736,17 @@ export default function Shell() {
             reload). */}
         {renderedAppIds.map(id => {
           const tabKey = `app:${id}`
-          const underlay = isUnderlay(tabKey)
-          const paned = !underlay && workspaceChromeActive ? visibleTabRects.get(tabKey) : null
-          const fullBleed = !underlay && !paned && tabKey === fullBleedKey
-          const motion = wrapperMotion(tabKey)
-          const posStyle = paned ? { top: paned.y, left: paned.x, width: paned.w, height: paned.h } : null
+          const paned = workspaceChromeActive ? visibleTabRects.get(tabKey) : null
+          const fullBleed = !paned && tabKey === fullBleedKey
+          const surfaceVisible = !!(paned || fullBleed)
+          const appSurfaceInert = !surfaceVisible
+          const posStyle = paned ? {
+            top: paned.y,
+            left: paned.x,
+            width: paned.w,
+            height: paned.h,
+            ...modeViewTransitionStyle('pane', paned.paneId, tabKey),
+          } : null
           const app = apps.find(a => String(a.id) === String(id))
           return (
           <div
@@ -3850,27 +3754,18 @@ export default function Shell() {
             id={paned ? panePanelDomId(paned.paneId, tabKey) : undefined}
             role={paned ? 'tabpanel' : undefined}
             aria-labelledby={paned ? paneTabDomId(paned.paneId, tabKey) : undefined}
-            data-tab-key={(multiPane || focusedPaneViewId != null) && !underlay ? tabKey : undefined}
-            // COMPOSITOR-ONLY beat motion (v2): the wrapper HOLDS its tiled content
-            // rect and animates only transform/opacity via data-mode-motion + the
-            // latched --flip/--mode vars. A mid-beat focus change cannot retarget it
-            // (the plan is latched, INV 2/10). The world-reveal underlay paints
-            // full-bleed beneath the deal (INV 5).
-            data-mode-motion={motion ? motion.motion : undefined}
-            className={underlay
-              ? 'shell__view shell__app-view shell__view--exit-underlay'
-              : (paned
-                ? 'shell__view shell__app-view shell__view--paned'
-                : `shell__view shell__app-view ${fullBleed ? 'shell__view--active' : ''}`)}
-            style={motion ? { ...(posStyle || {}), ...motion.vars } : (posStyle || undefined)}
-            // INV 9 (inert beat): every moving surface — a participant pane OR the
-            // underlay — is pointer/keyboard inert so a tap on an in-flight / covered
-            // surface cannot dispatch FOCUS mid-animation.
-            inert={(modeBeatActive && (!!motion || underlay)) || undefined}
+            data-tab-key={(multiPane || focusedPaneViewId != null) ? tabKey : undefined}
+            data-mode-pane-vt={paned ? paned.paneId : undefined}
+            className={paned
+              ? 'shell__view shell__app-view shell__view--paned'
+              : `shell__view shell__app-view ${fullBleed ? 'shell__view--active' : ''}`}
+            style={posStyle || undefined}
+            inert={appSurfaceInert || undefined}
+            aria-hidden={appSurfaceInert ? 'true' : undefined}
             // Clicking a visible pane focuses it (chat panes are not opaque; app
             // iframes swallow interior clicks, so this catches wrapper padding —
             // interior app focus rides the runtime bridge later). Only in the
-            // tiled path (finding D-i), and never during the exit beat.
+            // tiled path (finding D-i), and never during a mode scene.
             onPointerDownCapture={paned && !modeBeatActive
               ? () => dispatchWorkspace({ type: 'FOCUS', paneId: paned.paneId }) : undefined}
           >
@@ -3878,17 +3773,15 @@ export default function Shell() {
             <AppCanvas
               appId={id}
               // Focused-pane-only: gates safe-area insets + the immersive holder
-              // (global last-writer-wins). During the exit beat the DESTINATION
-              // (beatTargetKey) is also driven active so its insets are correct
-              // before completion, not jumping only after (exit-design §Visibility).
-              active={tabKey === focusedActiveKey || (modeBeatActive && tabKey === beatTargetKey)}
+              // (global last-writer-wins).
+              active={tabKey === focusedActiveKey}
               // Visible in ANY pane: gates frame-visibility + nav-push (§5). A
               // background split's app keeps running and can install sentinels;
               // Settings/immersive-solo/hidden panes exclude it (visibleAppIds).
               visible={visibleAppIds.has(String(id))}
               // Every visible pane remains painted beneath the modal scrim, but
               // suspend its iframe interaction while the drawer is open OR during any
-              // exit beat (INV 9: cross-origin app interaction is inert throughout).
+              // mode scene (cross-origin app interaction is inert throughout).
               interactive={visibleAppIds.has(String(id)) && !navigationSurfaceOpen && !modeBeatActive}
               version={versionForApp(id)}
               appName={app?.name}
@@ -3920,26 +3813,16 @@ export default function Shell() {
           const tabKey = `chat:${chatId}`
           const standardOwner = world === STANDARD_CHAT_WORLD
           const paneActiveKey = paneModel.activeKeyForOwner(workspace, paneId) || tabKey
-          const isActiveLayer = role === 'active'
-          // The Standard owner alone may be the stationary world underlay. Every
-          // Builder chat — including one for the SAME chat id — is an independent
-          // moving participant, so the Standard DOM never changes geometry.
-          const underlay = standardOwner && isActiveLayer && isUnderlay(paneActiveKey)
           const builderRect = standardOwner ? null : builderChatTabRects.get(paneActiveKey)
           const builderPainted = !standardOwner
             && effectiveViewMode === 'panes'
             && chatPanesVisible
-          const paned = !underlay && builderPainted ? builderRect : null
-          const fullBleed = !underlay && paneActiveKey === fullBleedKey
+          const paned = builderPainted ? builderRect : null
+          const fullBleed = paneActiveKey === fullBleedKey
             && (standardOwner
               ? effectiveViewMode === 'single'
               : (builderPainted && !paned))
-          const surfaceVisible = !!(underlay || paned || fullBleed)
-          // A Standard surface never receives Builder motion. Its separate
-          // full-bleed owner sits still beneath the assembling/dealing panes.
-          const motion = !standardOwner && isActiveLayer
-            ? wrapperMotion(paneActiveKey)
-            : null
+          const surfaceVisible = !!(paned || fullBleed)
           const tabPanel = role !== 'held' && paned
           // A retained owner may belong to the hidden workspace world. Its
           // layers stay mounted for continuity, but only a surface painted by
@@ -3960,6 +3843,12 @@ export default function Shell() {
               bottom: 'auto',
             }
             : null
+          const chatViewStyle = paned
+            ? {
+              ...posStyle,
+              ...modeViewTransitionStyle('pane', paneId, surfaceKey),
+            }
+            : undefined
           return (
             <div
               key={surfaceKey}
@@ -3968,8 +3857,9 @@ export default function Shell() {
               aria-labelledby={tabPanel ? paneTabDomId(paneId, tabKey) : undefined}
               data-chat-world={world}
               data-chat-id={chatId}
+              data-mode-pane-vt={paned ? paneId : undefined}
               data-tab-key={!standardOwner && (multiPane || focusedPaneViewId != null)
-                && role !== 'held' && !underlay
+                && role !== 'held'
                 ? tabKey : undefined}
               // A ChatView can stay mounted in the parked workspace world so its
               // stream, draft, and scroll controller survive a world flip. Expose
@@ -3977,20 +3867,13 @@ export default function Shell() {
               // actually interactive; browser contracts must not accidentally
               // target a retained hidden world or an in-flight handoff layer.
               data-chat-surface={surfaceVisible && role === 'active' ? 'painted' : undefined}
-              // Compositor-only beat motion (v2): see the app wrapper. The world-
-              // reveal underlay chat paints full-bleed beneath the deal.
-              data-mode-motion={motion ? motion.motion : undefined}
-              className={underlay
-                ? `shell__view shell__view--exit-underlay shell__chat-view${handoffClass}`
-                : (paned
-                  ? `shell__view shell__view--paned shell__chat-view${handoffClass}`
-                  : `shell__view shell__chat-view ${fullBleed ? 'shell__view--active' : ''}${handoffClass}`)}
-              style={motion ? { ...(posStyle || {}), ...motion.vars } : (posStyle || undefined)}
+              className={paned
+                ? `shell__view shell__view--paned shell__chat-view${handoffClass}`
+                : `shell__view shell__chat-view ${fullBleed ? 'shell__view--active' : ''}${handoffClass}`}
+              style={chatViewStyle}
               // A retained owner that belongs to the other world is physically
-              // inert as well as visibility-hidden. Moving/underlay surfaces stay
-              // inert for the whole mode beat (INV 9).
-              inert={!surfaceVisible || settingsOverlay || role !== 'active'
-                || (modeBeatActive && (!!motion || underlay))}
+              // inert as well as visibility-hidden.
+              inert={!surfaceVisible || settingsOverlay || role !== 'active' || undefined}
               aria-hidden={!surfaceVisible || settingsOverlay || role !== 'active'
                 ? 'true' : undefined}
               onPointerDownCapture={paned && role === 'active' && !modeBeatActive
@@ -4050,12 +3933,18 @@ export default function Shell() {
             Drawer owns the launcher interactions and portals them into this
             stable host so app management remains one implementation. */}
         {(() => {
-          const appsUnderlay = isUnderlay(APPS_KEY)
-          const appsMotion = appsUnderlay ? null : wrapperMotion(APPS_KEY)
-          const appsPos = (!appsUnderlay && appsPaned)
-            ? { top: appsPaned.y, left: appsPaned.x, width: appsPaned.w, height: appsPaned.h }
+          const appsPos = appsPaned
+            ? {
+              top: appsPaned.y,
+              left: appsPaned.x,
+              width: appsPaned.w,
+              height: appsPaned.h,
+              ...modeViewTransitionStyle('pane', appsPaned.paneId, APPS_KEY),
+            }
             : null
-          const appsTabPanel = !appsUnderlay && appsPaned
+          const appsTabPanel = appsPaned
+          const appsSurfaceVisible = !!(appsPaned || appsFullBleed)
+          const appsSurfaceInert = !appsSurfaceVisible
           return (
             <div
               key="apps"
@@ -4063,17 +3952,14 @@ export default function Shell() {
               role={appsTabPanel ? 'tabpanel' : undefined}
               aria-labelledby={appsTabPanel ? paneTabDomId(appsPaned.paneId, APPS_KEY) : undefined}
               data-tab-key={appsTabPanel ? APPS_KEY : undefined}
-              data-mode-motion={appsMotion ? appsMotion.motion : undefined}
-              className={appsUnderlay
-                ? 'shell__view shell__view--exit-underlay shell__apps-view'
-                : (appsPaned
-                  ? 'shell__view shell__view--paned shell__apps-view'
-                  : `shell__view shell__apps-view ${appsFullBleed ? 'shell__view--active' : ''}`)}
-              style={appsMotion
-                ? { ...(appsPos || {}), ...appsMotion.vars }
-                : (appsPos || undefined)}
-              inert={(modeBeatActive && (!!appsMotion || appsUnderlay)) || undefined}
-              onPointerDownCapture={appsPaned && !appsUnderlay && !modeBeatActive
+              data-mode-pane-vt={appsPaned ? appsPaned.paneId : undefined}
+              className={appsPaned
+                ? 'shell__view shell__view--paned shell__apps-view'
+                : `shell__view shell__apps-view ${appsFullBleed ? 'shell__view--active' : ''}`}
+              style={appsPos || undefined}
+              inert={appsSurfaceInert || undefined}
+              aria-hidden={appsSurfaceInert ? 'true' : undefined}
+              onPointerDownCapture={appsPaned && !modeBeatActive
                 ? () => dispatchWorkspace({ type: 'FOCUS', paneId: appsPaned.paneId })
                 : undefined}
             >
@@ -4087,19 +3973,18 @@ export default function Shell() {
             regardless of the sibling app/chat arrays' lengths, preserving
             SettingsView identity across the tab<->overlay conversion. */}
         {settingsMounted && (() => {
-          // Settings plays TWO possible exit-beat roles. As a builder Settings TAB
-          // it is a DEAL-OUT participant (settingsMotion). As the honest destination
-          // of a suspended single-world takeover (M2) it is the world-reveal
-          // UNDERLAY: the mounted-hidden surface painted full-bleed BENEATH the
-          // dealing tree, so the takeover no longer snaps over a revealed slot at
-          // completion. The classifier excludes the settings leaf from participants
-          // when it is the underlay, so these two roles never coincide.
-          const settingsUnderlay = isUnderlay(SETTINGS_KEY)
-          const settingsMotion = settingsUnderlay ? null : wrapperMotion(SETTINGS_KEY)
-          const settingsPos = (!settingsUnderlay && settingsPaned)
-            ? { top: settingsPaned.y, left: settingsPaned.x, width: settingsPaned.w, height: settingsPaned.h }
+          const settingsPos = settingsPaned
+            ? {
+              top: settingsPaned.y,
+              left: settingsPaned.x,
+              width: settingsPaned.w,
+              height: settingsPaned.h,
+              ...modeViewTransitionStyle('pane', settingsPaned.paneId, SETTINGS_KEY),
+            }
             : null
-          const settingsTabPanel = !settingsUnderlay && settingsPaned
+          const settingsTabPanel = settingsPaned
+          const settingsSurfaceVisible = !!(settingsPaned || settingsFullBleed)
+          const settingsSurfaceInert = !settingsSurfaceVisible
           return (
           <div
             key="settings"
@@ -4110,18 +3995,15 @@ export default function Shell() {
             aria-labelledby={settingsTabPanel
               ? paneTabDomId(settingsPaned.paneId, SETTINGS_KEY)
               : undefined}
-            data-tab-key={(!settingsUnderlay && settingsPaned) ? SETTINGS_KEY : undefined}
-            data-mode-motion={settingsMotion ? settingsMotion.motion : undefined}
-            className={settingsUnderlay
-              ? 'shell__view shell__view--exit-underlay shell__settings-view'
-              : (settingsPaned
-                ? 'shell__view shell__view--paned shell__settings-view'
-                : `shell__view shell__settings-view ${settingsFullBleed ? 'shell__view--active' : ''}`)}
-            style={settingsMotion
-              ? { ...(settingsPos || {}), ...settingsMotion.vars }
-              : (settingsPos || undefined)}
-            inert={(modeBeatActive && (!!settingsMotion || settingsUnderlay)) || undefined}
-            onPointerDownCapture={settingsPaned && !settingsUnderlay && !modeBeatActive
+            data-tab-key={settingsPaned ? SETTINGS_KEY : undefined}
+            data-mode-pane-vt={settingsPaned ? settingsPaned.paneId : undefined}
+            className={settingsPaned
+              ? 'shell__view shell__view--paned shell__settings-view'
+              : `shell__view shell__settings-view ${settingsFullBleed ? 'shell__view--active' : ''}`}
+            style={settingsPos || undefined}
+            inert={settingsSurfaceInert || undefined}
+            aria-hidden={settingsSurfaceInert ? 'true' : undefined}
+            onPointerDownCapture={settingsPaned && !modeBeatActive
               ? () => dispatchWorkspace({ type: 'FOCUS', paneId: settingsPaned.paneId })
               : undefined}
           >
@@ -4134,7 +4016,7 @@ export default function Shell() {
                 onThemeChange={loadTheme}
                 onOpenChat={selectChat}
                 focusTarget={settingsFocusTarget}
-                active={!settingsUnderlay && (settingsFullBleed || !!settingsPaned)}
+                active={settingsFullBleed || !!settingsPaned}
                 refreshToken={settingsRefreshToken}
               />
             </Suspense>
@@ -4142,22 +4024,14 @@ export default function Shell() {
           )
         })()}
         {/* New Chat landing (round 4 item 3) — the first-class surface a null single
-            slot paints, and the stationary world-reveal underlay while an exit beat lands
-            on it. Rendered only when it is actually the surface (fullBleedKey) or the
-            reveal underlay, so it never sits mounted-hidden behind real content. The row
-            materializes into a real chat after the descriptor idles; until then this is
-            the honest destination (never chats[0], never a blank <main>). */}
+            slot paints (never chats[0], never a blank <main>). */}
         {(() => {
-          const newChatUnderlay = isUnderlay(EMPTY_SINGLE_SURFACE_KEY)
           const newChatSurface = fullBleedKey === EMPTY_SINGLE_SURFACE_KEY
-          if (!newChatUnderlay && !newChatSurface) return null
+          if (!newChatSurface) return null
           return (
             <div
               key="home-new-chat"
-              className={newChatUnderlay
-                ? 'shell__view shell__view--exit-underlay shell__chat-view'
-                : 'shell__view shell__view--active shell__chat-view'}
-              inert={(modeBeatActive && newChatUnderlay) || undefined}
+              className="shell__view shell__view--active shell__chat-view"
             >
               <NewChatLanding
                 // Retry state only on the resting surface — never mid-reveal.
@@ -4176,7 +4050,7 @@ export default function Shell() {
             // INV 9 / finding 10: during the exit deal the chrome is not just
             // pointer-transparent (CSS) but fully INERT — keyboard-unfocusable and
             // aria-hidden — so a tab/divider that already held focus can't process
-            // Enter/arrow input while invisibly dealing away.
+            // Enter/arrow input while its captured scene is moving.
             inert={navigationSurfaceOpen || modeBeatActive}
             workspace={workspace}
             projection={projection}
@@ -4187,15 +4061,13 @@ export default function Shell() {
             navTo={navTo}
             labelForTab={labelForTab}
             onTabContextMenu={openTabMenu}
-            // The ONE shared user-close action (INV 13) + the per-pane beat motion
-            // (each strip deals with its pane) — WorkspaceChrome owns no private
-            // close dispatcher and no motion knowledge of its own.
+            // The ONE shared user-close action — WorkspaceChrome owns no private
+            // close dispatcher or transition timing.
             onCloseTab={closeTab}
             focusedPaneViewId={focusedPaneViewId}
             onTogglePaneFocus={toggleFocusedPaneView}
             onChatPaneSelected={focusDesktopChatPaneComposer}
             revealKey={tabRevealRevision}
-            stripMotion={wrapperMotion}
           />
         )}
       </main>

--- a/frontend/src/components/Shell/WorkspaceChrome.jsx
+++ b/frontend/src/components/Shell/WorkspaceChrome.jsx
@@ -5,6 +5,7 @@ import {
 } from './paneModel.js'
 import { ARROW_STEP_RATIO } from '../../lib/splitHelper.js'
 import { PaneStrip } from './PaneStrip.jsx'
+import { modeViewTransitionStyle } from './useModeViewTransition.js'
 
 // The chrome layer for a tiled (≥2 visible leaves) workspace (design §2). It is
 // a sibling AFTER the flat content wrappers, absolute inset:0, pointer-events
@@ -94,9 +95,6 @@ export default function WorkspaceChrome({
   onTogglePaneFocus,
   onChatPaneSelected,
   revealKey = 0,
-  // key → { motion, vars } for the live mode beat, so each strip deals WITH its pane
-  // (Shell's wrapperMotion). Null/absent when no beat is live.
-  stripMotion = null,
 }) {
   const focusPane = useCallback((paneId) => {
     const newlyFocused = workspace.focusedPaneId !== paneId
@@ -268,8 +266,7 @@ export default function WorkspaceChrome({
             paneFocused={focusedPaneViewId === paneId}
             onTogglePaneFocus={onTogglePaneFocus}
             revealKey={revealKey}
-            // The strip deals WITH its pane this beat (motion keyed by its active tab).
-            motion={stripMotion ? stripMotion(pane.activeTabKey) : null}
+            viewTransitionStyle={modeViewTransitionStyle('strip', paneId, paneId)}
           />
         )
       })}

--- a/frontend/src/components/Shell/__tests__/chatHandoff.test.js
+++ b/frontend/src/components/Shell/__tests__/chatHandoff.test.js
@@ -97,7 +97,7 @@ test('only the painted workspace world can expose its handoff layers', () => {
   )
   assert.match(
     shell,
-    /const surfaceVisible = !!\(underlay \|\| paned \|\| fullBleed\)/,
+    /const surfaceVisible = !!\(paned \|\| fullBleed\)/,
     'a retained owner in the hidden world must remain mounted without becoming visible',
   )
   assert.match(

--- a/frontend/src/components/Shell/__tests__/modeMachine.test.js
+++ b/frontend/src/components/Shell/__tests__/modeMachine.test.js
@@ -1,392 +1,78 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import {
-  initialModeState, modeReducer, planArms,
-  effectiveViewMode, transitionRootClass, builderModeActive,
-  exitBeatActive, dragPreviewActive,
-  transitionPresentation, exitPresentation,
-  completionContract, reconcileVisibleEvent,
-  RECONCILE_SLACK_MS, MODE_MOTION,
+  initialModeState, modeReducer,
+  effectiveViewMode, builderModeActive, dragPreviewActive,
 } from '../modeMachine.js'
 
-// The exit-presentation v2 invariant lock (the "Single invariant list for tests").
-// Every transition latches ONE opaque presentation plan; the machine holds the
-// outgoing world, rejects stale epochs, and exposes the plan's completion contract.
-// It has NO role plumbing, no `animated` boolean, and no fixed per-phase animation
-// sets — a plan arms a beat iff it names a completion animation. INV numbers follow
-// modeMachine.js.
+function single() { return initialModeState('single') }
+function panes() { return initialModeState('panes') }
 
-// A minimal enter plan (one deal-in participant).
-function enterPlan({ totalMs = MODE_MOTION.enterItemMs } = {}) {
-  return {
-    kind: 'enter',
-    participants: [{ key: 'chat:1', paneId: 'p1', motion: 'deal-in', delayMs: 0, durationMs: totalMs }],
-    completionNames: ['shell-mode-deal-in'],
-    totalMs,
-  }
-}
-// A minimal exit plan (one deal-out participant, a chat underlay).
-function exitPlan({ underlayKey = 'chat:5', target = 'chat:5', sig = 'sigA', totalMs = MODE_MOTION.exitItemMs } = {}) {
-  return {
-    kind: 'exit',
-    target,
-    destinationRect: { x: 0, y: 0, w: 100, h: 200 },
-    participants: [{ key: 'chat:2', paneId: 'p2', motion: 'deal-out', delayMs: 0, durationMs: totalMs }],
-    underlayKey,
-    completionNames: ['shell-mode-deal-out'],
-    totalMs,
-    snapshotSignature: sig,
-  }
-}
-// A promote exit plan (physical continuity — no underlay).
-function promotePlan({ sig = 'sigP' } = {}) {
-  return {
-    kind: 'exit',
-    target: 'app:9',
-    destinationRect: { x: 0, y: 0, w: 100, h: 200 },
-    participants: [{ key: 'app:9', paneId: 'p1', motion: 'promote', delayMs: 0, durationMs: MODE_MOTION.promoteMs, flip: { x: 0, y: 0, sx: 1, sy: 1 } }],
-    underlayKey: null,
-    completionNames: ['shell-mode-promote'],
-    totalMs: MODE_MOTION.promoteMs,
-    snapshotSignature: sig,
-  }
-}
-
-function single() { return { ...initialModeState('single'), nextId: 1 } }
-function panes() { return { ...initialModeState('panes'), nextId: 1 } }
-
-function assertIdle(state, mode) {
-  assert.equal(state.transition, null, 'no live transition')
-  assert.equal(transitionRootClass(state), '', 'no transient root class')
-  assert.equal(exitBeatActive(state), false)
-  assert.equal(dragPreviewActive(state), false)
-  assert.equal(transitionPresentation(state), null)
-  assert.equal(exitPresentation(state), null)
-  assert.equal(completionContract(state), null)
-  assert.equal(effectiveViewMode(state), mode)
-  assert.equal(state.committedMode, mode)
-}
-
-// ── Baseline: the two stable modes ──────────────────────────────────────────
-
-test('stable single: idle, presents single, builder off', () => {
-  const s = single()
-  assertIdle(s, 'single')
-  assert.equal(builderModeActive(s), false)
+test('stable modes present their committed world', () => {
+  assert.equal(effectiveViewMode(single()), 'single')
+  assert.equal(builderModeActive(single()), false)
+  assert.equal(effectiveViewMode(panes()), 'panes')
+  assert.equal(builderModeActive(panes()), true)
 })
 
-test('stable panes: idle, presents panes, builder on', () => {
-  const s = panes()
-  assertIdle(s, 'panes')
-  assert.equal(builderModeActive(s), true)
+test('a toggle is an immediate durable state change with no visual descriptor', () => {
+  const entered = modeReducer(single(), { type: 'toggle', cause: 'hold' })
+  assert.equal(entered.committedMode, 'panes')
+  assert.equal(entered.transition, null)
+  const exited = modeReducer(entered, { type: 'toggle', cause: 'keyboard' })
+  assert.equal(exited.committedMode, 'single')
+  assert.equal(exited.transition, null)
 })
 
-// ── INV 2 (opaque latch) + Enter ────────────────────────────────────────────
-
-test('enter: committed flips to panes synchronously, entering class, one epoch, plan latched', () => {
-  const plan = enterPlan()
-  const s = modeReducer(single(), { type: 'toggle', cause: 'hold', presentation: plan, now: 100 })
-  assert.equal(s.committedMode, 'panes', 'durable mode flips at once (no deferred flip)')
-  assert.equal(s.transition.phase, 'entering')
-  assert.equal(s.transition.id, 1)
-  assert.equal(s.transition.presentation, plan, 'the EXACT plan reference is latched, opaquely')
-  assert.equal(effectiveViewMode(s), 'panes')
-  assert.equal(transitionRootClass(s), 'shell--builder-entering')
-  assert.equal(builderModeActive(s), true)
-  assert.equal(transitionPresentation(s), plan)
-  // Completion contract is taken STRAIGHT from the plan (INV 7): names + totalMs.
-  const c = completionContract(s)
-  assert.equal(c.maxMs, plan.totalMs)
-  assert.ok(c.animationNames.has('shell-mode-deal-in'))
+test('an explicit toggle to the resting mode is a no-op reference', () => {
+  const state = panes()
+  assert.equal(modeReducer(state, { type: 'toggle', to: 'panes' }), state)
 })
 
-test('enter then complete: settles to stable panes, no residue', () => {
-  let s = modeReducer(single(), { type: 'toggle', presentation: enterPlan(), now: 0 })
-  s = modeReducer(s, { type: 'complete', id: s.transition.id })
-  assertIdle(s, 'panes')
+test('undo restores mode directly; browser scene motion stays outside the reducer', () => {
+  const restored = modeReducer(single(), { type: 'undo', restoredMode: 'panes' })
+  assert.equal(restored.committedMode, 'panes')
+  assert.equal(restored.transition, null)
 })
 
-test('a null presentation is an instant flip — reduced motion / empty tree never arms (INV 11)', () => {
-  const s = modeReducer(single(), { type: 'toggle', presentation: null })
-  assert.equal(s.committedMode, 'panes')
-  assert.equal(s.transition, null)
+test('drag arm is the only transient projection and exposes Builder from Standard', () => {
+  const preview = modeReducer(single(), { type: 'drag-arm' })
+  assert.equal(preview.transition.phase, 'drag-preview')
+  assert.equal(preview.transition.id, 1)
+  assert.equal(preview.committedMode, 'single')
+  assert.equal(effectiveViewMode(preview), 'panes')
+  assert.equal(dragPreviewActive(preview), true)
 })
 
-test('a plan with NO completion names does not arm (INV 11)', () => {
-  const empty = { kind: 'exit', participants: [], completionNames: [], totalMs: 0, underlayKey: null, target: null, snapshotSignature: 's' }
-  const s = modeReducer(panes(), { type: 'toggle', presentation: empty })
-  assert.equal(s.transition, null, 'no participants → instant flip')
-  assert.equal(s.committedMode, 'single')
+test('only the matching drag epoch can cancel a preview', () => {
+  const preview = modeReducer(single(), { type: 'drag-arm' })
+  assert.equal(modeReducer(preview, { type: 'drag-cancel', id: 99 }), preview)
+  const cancelled = modeReducer(preview, { type: 'drag-cancel', id: 1 })
+  assert.equal(cancelled.transition, null)
+  assert.equal(cancelled.committedMode, 'single')
 })
 
-test('planArms is the ONE exported predicate (round 4 item 1: the toggle receipt reuses it)', () => {
-  // Exported so the controller can tell an animated beat from an instant flip when it
-  // builds the toggle receipt, rather than re-deriving the rule (which strands the
-  // is-beat-held handoff if the two ever drift).
-  assert.equal(planArms(enterPlan()), true, 'a plan that names a completion animation arms')
-  assert.equal(planArms(exitPlan()), true)
-  assert.equal(planArms(null), false, 'reduced motion / empty tree → instant flip')
-  assert.equal(planArms(undefined), false)
-  assert.equal(planArms({ completionNames: [] }), false, 'no completion names → no arm')
-  assert.equal(planArms({ completionNames: 'nope' }), false, 'non-array names never arm')
+test('a matching drag commit enters Builder and clears preview state', () => {
+  const preview = modeReducer(single(), { type: 'drag-arm' })
+  const committed = modeReducer(preview, { type: 'drag-commit', id: 1 })
+  assert.equal(committed.committedMode, 'panes')
+  assert.equal(committed.transition, null)
 })
 
-// ── Exit (panes → single): world reveal + promote ───────────────────────────
-
-test('exit reveal: committed flips to single, render holds panes, underlay + target exposed', () => {
-  const plan = exitPlan({ underlayKey: 'chat:5', target: 'chat:5' })
-  const s = modeReducer(panes(), { type: 'toggle', cause: 'hold', presentation: plan, now: 50 })
-  assert.equal(s.committedMode, 'single', 'durable mode is already single')
-  assert.equal(effectiveViewMode(s), 'panes', 'but the render holds the tiled world')
-  assert.equal(transitionRootClass(s), 'shell--builder-exiting')
-  assert.equal(exitBeatActive(s), true)
-  assert.equal(exitPresentation(s), plan)
-  assert.equal(exitPresentation(s).underlayKey, 'chat:5')
-  const c = completionContract(s)
-  assert.equal(c.maxMs, plan.totalMs)
-  assert.ok(c.animationNames.has('shell-mode-deal-out'))
+test('drag arm is inert from Builder and clears impossible stale preview state', () => {
+  const state = panes()
+  assert.equal(modeReducer(state, { type: 'drag-arm' }), state)
 })
 
-test('exit promote: physical continuity, no underlay, promote completion name', () => {
-  const plan = promotePlan()
-  const s = modeReducer(panes(), { type: 'toggle', presentation: plan, now: 0 })
-  assert.equal(exitPresentation(s).underlayKey, null)
-  assert.ok(completionContract(s).animationNames.has('shell-mode-promote'))
+test('external durable-mode synchronization clears transient projection', () => {
+  const preview = modeReducer(single(), { type: 'drag-arm' })
+  const synced = modeReducer(preview, { type: 'sync-committed', committedMode: 'single' })
+  assert.equal(synced.transition, null)
+  assert.equal(synced.committedMode, 'single')
 })
 
-test('exit then complete: settles to single, no residue', () => {
-  let s = modeReducer(panes(), { type: 'toggle', presentation: exitPlan(), now: 0 })
-  s = modeReducer(s, { type: 'complete', id: s.transition.id })
-  assertIdle(s, 'single')
-})
-
-// ── INV 3 (supersession) — rapid re-entry ───────────────────────────────────
-
-test('rapid exit→enter before completion: exit epoch fully superseded (INV 3/7)', () => {
-  let s = modeReducer(panes(), { type: 'toggle', presentation: exitPlan(), now: 0 })
-  const exitId = s.transition.id
-  s = modeReducer(s, { type: 'toggle', presentation: enterPlan(), now: 120 })
-  assert.equal(s.committedMode, 'panes')
-  assert.equal(s.transition.phase, 'entering', 'now an entry, not a stranded exit')
-  assert.notEqual(s.transition.id, exitId, 'new epoch')
-  assert.equal(exitBeatActive(s), false)
-  assert.equal(effectiveViewMode(s), 'panes')
-  assert.equal(transitionRootClass(s), 'shell--builder-entering')
-  // The stale exit completion can no longer clear the live entry (INV 7).
-  const after = modeReducer(s, { type: 'complete', id: exitId })
-  assert.equal(after.transition.phase, 'entering', 'stale completion ignored')
-})
-
-test('rapid enter→exit before completion: entry epoch fully superseded', () => {
-  let s = modeReducer(single(), { type: 'toggle', presentation: enterPlan(), now: 0 })
-  const enterId = s.transition.id
-  s = modeReducer(s, { type: 'toggle', presentation: exitPlan(), now: 100 })
-  assert.equal(s.committedMode, 'single')
-  assert.equal(s.transition.phase, 'exiting')
-  assert.notEqual(s.transition.id, enterId)
-  const after = modeReducer(s, { type: 'complete', id: enterId })
-  assert.equal(after.transition.phase, 'exiting', 'stale enter completion ignored')
-})
-
-test('enter→exit→enter: each accepted transition gets a new monotonic epoch', () => {
-  let s = single()
-  const ids = []
-  s = modeReducer(s, { type: 'toggle', presentation: enterPlan(), now: 0 }); ids.push(s.transition.id)
-  s = modeReducer(s, { type: 'toggle', presentation: exitPlan(), now: 10 }); ids.push(s.transition.id)
-  s = modeReducer(s, { type: 'toggle', presentation: enterPlan(), now: 20 }); ids.push(s.transition.id)
-  assert.deepEqual(ids, [1, 2, 3], 'monotonic epochs, one per accepted input')
-  assert.equal(s.committedMode, 'panes')
-  assert.equal(s.transition.phase, 'entering')
-})
-
-test('repeated enter request while entering: re-arms with a fresh epoch', () => {
-  let s = modeReducer(single(), { type: 'toggle', presentation: enterPlan(), now: 0 })
-  const first = s.transition.id
-  s = modeReducer(s, { type: 'toggle', to: 'panes', presentation: enterPlan(), now: 50 })
-  assert.equal(s.committedMode, 'panes')
-  assert.equal(s.transition.phase, 'entering')
-  assert.notEqual(s.transition.id, first, 'entry animation restarts under a new epoch')
-})
-
-test('cause threads through; omitting it falls back to the generic label', () => {
-  const p = enterPlan()
-  assert.equal(modeReducer(single(), { type: 'toggle', cause: 'hold', presentation: p, now: 0 }).transition.cause, 'hold')
-  assert.equal(modeReducer(single(), { type: 'toggle', cause: 'swipe', presentation: p, now: 0 }).transition.cause, 'swipe')
-  assert.equal(modeReducer(single(), { type: 'toggle', cause: 'keyboard', presentation: p, now: 0 }).transition.cause, 'keyboard')
-  assert.equal(modeReducer(panes(), { type: 'toggle', cause: 'auto', to: 'single', presentation: exitPlan(), now: 0 }).transition.cause, 'auto')
-  assert.equal(modeReducer(single(), { type: 'toggle', presentation: p, now: 0 }).transition.cause, 'toggle')
-})
-
-test('idempotent toggle to the committed mode with no beat is a no-op reference', () => {
-  const s = panes()
-  const after = modeReducer(s, { type: 'toggle', to: 'panes', presentation: null })
-  assert.equal(after, s, 'same reference — React can bail')
-})
-
-// ── INV 5: Drag-preview overlaps ────────────────────────────────────────────
-
-test('drag arm from single: drag-preview phase, committed stays single, no plan', () => {
-  const s = modeReducer(single(), { type: 'drag-arm', now: 0 })
-  assert.equal(s.committedMode, 'single')
-  assert.equal(s.transition.phase, 'drag-preview')
-  assert.equal(dragPreviewActive(s), true)
-  assert.equal(effectiveViewMode(s), 'panes', 'preview paints the tiled world')
-  assert.equal(transitionRootClass(s), '', 'a preview wears no enter/exit deal class')
-  assert.equal(transitionPresentation(s), null, 'a preview has no plan')
-  assert.equal(completionContract(s), null, 'a preview has no self-completing beat')
-})
-
-test('drag arm→cancel with matching id: back to idle single', () => {
-  let s = modeReducer(single(), { type: 'drag-arm', now: 0 })
-  s = modeReducer(s, { type: 'drag-cancel', id: s.transition.id })
-  assertIdle(s, 'single')
-})
-
-test('drag arm→cancel with STALE id: ignored (INV 5)', () => {
-  let s = modeReducer(single(), { type: 'drag-arm', now: 0 })
-  s = modeReducer(s, { type: 'drag-cancel', id: s.transition.id + 99 })
-  assert.equal(s.transition.phase, 'drag-preview')
-})
-
-test('drag arm→commit: mode flips to panes, preview cleared, one transaction', () => {
-  let s = modeReducer(single(), { type: 'drag-arm', now: 0 })
-  s = modeReducer(s, { type: 'drag-commit', id: s.transition.id })
-  assert.equal(s.committedMode, 'panes')
-  assert.equal(s.transition, null, 'no lingering preview or fabricated entry beat')
-  assertIdle(s, 'panes')
-})
-
-test('drag commit with STALE id: ignored — no fabricated mode change (P1 finding)', () => {
-  let s = modeReducer(single(), { type: 'drag-arm', now: 0 })
-  s = modeReducer(s, { type: 'drag-commit', id: s.transition.id + 5 })
-  assert.equal(s.committedMode, 'single')
-  assert.equal(s.transition.phase, 'drag-preview')
-})
-
-test('drag arm in BUILDER is not a preview (already tiled)', () => {
-  const s = modeReducer(panes(), { type: 'drag-arm', now: 0 })
-  assert.equal(s.transition, null)
-  assert.equal(s.committedMode, 'panes')
-})
-
-test('arm during exit: exit committed single, so the arm previews builder', () => {
-  let s = modeReducer(panes(), { type: 'toggle', presentation: exitPlan(), now: 0 })
-  const exitId = s.transition.id
-  s = modeReducer(s, { type: 'drag-arm', now: 30 })
-  assert.equal(s.committedMode, 'single')
-  assert.equal(s.transition.phase, 'drag-preview')
-  assert.notEqual(s.transition.id, exitId)
-  assert.equal(exitBeatActive(s), false, 'no stranded exit beat')
-})
-
-// ── Auto-return and Undo ────────────────────────────────────────────────────
-
-test('auto-return toggle (last-tab close) with no plan: instant flip to single', () => {
-  const s = modeReducer(panes(), { type: 'toggle', cause: 'auto', to: 'single', presentation: null })
-  assert.equal(s.committedMode, 'single')
-  assert.equal(s.transition, null, 'an emptied tree has no pane to deal — instant')
-})
-
-test('undo restoring panes from single: re-enters builder with the entry deal', () => {
-  const s = modeReducer(single(), { type: 'undo', restoredMode: 'panes', presentation: enterPlan(), now: 0 })
-  assert.equal(s.committedMode, 'panes')
-  assert.equal(s.transition.phase, 'entering')
-  assert.equal(s.transition.cause, 'undo')
-})
-
-test('ordinary tree undo (mode unchanged): no beat, same committed mode', () => {
-  const base = panes()
-  const s = modeReducer(base, { type: 'undo', restoredMode: 'panes', presentation: null })
-  assert.equal(s, base, 'no-op reference — undo carried the current mode forward')
-})
-
-test('undo restoring single from panes: exit deal', () => {
-  const s = modeReducer(panes(), { type: 'undo', restoredMode: 'single', presentation: exitPlan(), now: 0 })
-  assert.equal(s.committedMode, 'single')
-  assert.equal(s.transition.phase, 'exiting')
-})
-
-test('later explicit toggle supersedes a coupled undo/auto beat', () => {
-  let s = modeReducer(panes(), { type: 'toggle', cause: 'auto', to: 'single', presentation: exitPlan(), now: 0 })
-  s = modeReducer(s, { type: 'toggle', presentation: enterPlan(), now: 40 })
-  assert.equal(s.committedMode, 'panes')
-  assert.equal(s.transition.phase, 'entering')
-})
-
-// ── INV 10: invalidation snaps ──────────────────────────────────────────────
-
-test('cancel-beat clears the descriptor without touching committedMode (INV 10)', () => {
-  let s = modeReducer(panes(), { type: 'toggle', presentation: exitPlan(), now: 0 })
-  s = modeReducer(s, { type: 'cancel-beat' })
-  assert.equal(s.transition, null, 'beat cancelled, animation ownership not silently changed')
-  assert.equal(s.committedMode, 'single', 'durable mode is unaffected')
-  assertIdle(s, 'single')
-})
-
-// ── Page lifecycle ──────────────────────────────────────────────────────────
-
-test('sync-committed reconciles an external durable change with no beat (reload policy)', () => {
-  let s = modeReducer(single(), { type: 'toggle', presentation: enterPlan(), now: 0 })
-  s = modeReducer(s, { type: 'sync-committed', committedMode: 'single' })
-  assert.equal(s.committedMode, 'single')
-  assert.equal(s.transition, null, 'reload starts in the durable mode with no beat')
-})
-
-test('visibility reconcile force-completes a beat that outlived its plan totalMs (INV 14)', () => {
-  const plan = exitPlan({ totalMs: 180 })
-  const s = modeReducer(panes(), { type: 'toggle', presentation: plan, now: 1000 })
-  const late = 1000 + plan.totalMs + RECONCILE_SLACK_MS + 5
-  const ev = reconcileVisibleEvent(s, late)
-  assert.ok(ev, 'an overdue beat yields a completion event')
-  assert.equal(ev.type, 'complete')
-  assert.equal(ev.id, s.transition.id)
-  assertIdle(modeReducer(s, ev), 'single')
-})
-
-test('visibility reconcile leaves a still-fresh beat running', () => {
-  const s = modeReducer(panes(), { type: 'toggle', presentation: exitPlan(), now: 1000 })
-  assert.equal(reconcileVisibleEvent(s, 1000 + 10), null, 'a fresh beat is not force-completed')
-})
-
-// ── INV 7: completion + supersession ────────────────────────────────────────
-
-test('duplicate completion is harmless', () => {
-  let s = modeReducer(single(), { type: 'toggle', presentation: enterPlan(), now: 0 })
-  const id = s.transition.id
-  s = modeReducer(s, { type: 'complete', id })
-  assert.equal(modeReducer(s, { type: 'complete', id }), s, 'a second completion is a no-op reference')
-})
-
-test('completion from a superseded epoch never clears a newer transition (INV 7)', () => {
-  let s = modeReducer(single(), { type: 'toggle', presentation: enterPlan(), now: 0 })
-  const oldId = s.transition.id
-  s = modeReducer(s, { type: 'toggle', presentation: exitPlan(), now: 50 })
-  const newId = s.transition.id
-  const after = modeReducer(s, { type: 'complete', id: oldId })
-  assert.equal(after.transition.id, newId, 'live transition untouched by the old completion')
-})
-
-// ── INV 16: kill-switch clamp ───────────────────────────────────────────────
-
-test('kill switch clamps presentation to single before any derivation', () => {
-  const s = panes()
-  const opts = { splitsEnabled: false }
-  assert.equal(effectiveViewMode(s, opts), 'single', 'a persisted panes blob never reaches tiled render')
-  assert.equal(builderModeActive(s, opts), false)
-  assert.equal(transitionRootClass(s, opts), '')
-  assert.equal(exitBeatActive(s, opts), false)
-  assert.equal(dragPreviewActive(s, opts), false)
-})
-
-test('kill switch clamps even a live entering transition', () => {
-  const s = modeReducer(single(), { type: 'toggle', presentation: enterPlan(), now: 0 })
-  assert.equal(effectiveViewMode(s, { splitsEnabled: false }), 'single')
-  assert.equal(transitionRootClass(s, { splitsEnabled: false }), '')
-})
-
-// ── Unknown events are no-ops ────────────────────────────────────────────────
-
-test('an unknown event is a no-op reference', () => {
-  const s = panes()
-  assert.equal(modeReducer(s, { type: 'nonsense' }), s)
+test('the splits kill switch clamps every derivation to Standard', () => {
+  assert.equal(effectiveViewMode(panes(), { splitsEnabled: false }), 'single')
+  assert.equal(builderModeActive(panes(), { splitsEnabled: false }), false)
+  assert.equal(dragPreviewActive(modeReducer(single(), { type: 'drag-arm' }), { splitsEnabled: false }), false)
 })

--- a/frontend/src/components/Shell/__tests__/modeReviewFixes.test.js
+++ b/frontend/src/components/Shell/__tests__/modeReviewFixes.test.js
@@ -15,18 +15,10 @@ import { modeReducer } from '../modeMachine.js'
 const shell = readFileSync(new URL('../Shell.jsx', import.meta.url), 'utf8')
 const nav = readFileSync(new URL('../../../hooks/useNavigation.js', import.meta.url), 'utf8')
 const controller = readFileSync(new URL('../useModeController.js', import.meta.url), 'utf8')
+const scene = readFileSync(new URL('../useModeViewTransition.js', import.meta.url), 'utf8')
 const gesture = readFileSync(new URL('../useLogoModeGesture.js', import.meta.url), 'utf8')
 const brand = readFileSync(new URL('../ShellBrand.jsx', import.meta.url), 'utf8')
 const paneSrc = readFileSync(new URL('../paneModel.js', import.meta.url), 'utf8')
-
-// A minimal v2 exit plan for the reducer's behavioral cases (a plan arms a beat).
-function planFor(name = 'shell-mode-deal-out', totalMs = 180) {
-  return {
-    kind: name === 'shell-mode-deal-in' ? 'enter' : 'exit',
-    participants: [{ key: 'chat:2', paneId: 'p2', motion: name === 'shell-mode-deal-in' ? 'deal-in' : 'deal-out', delayMs: 0, durationMs: totalMs }],
-    completionNames: [name], totalMs, underlayKey: null, target: null, snapshotSignature: 'sig',
-  }
-}
 
 const { makeTab } = tabModel
 function reduce(state, action) { return paneModel.workspaceReducer(state, action) }
@@ -37,7 +29,7 @@ test('finding 1: dragArm returns the epoch it WILL assign, computed before dispa
   // Reading stateRef AFTER an async useReducer dispatch returns the stale
   // pre-dispatch epoch, so cancel/blur would carry the wrong id and never clear the
   // preview -- the wedge reincarnated. The id is read from nextId before dispatch.
-  assert.match(controller, /const id = s\.nextId\s*\n\s*dispatch\(\{ type: 'drag-arm'/)
+  assert.match(controller, /const id = current\.committedMode === 'single' \? current\.nextId : null\s*\n\s*dispatch\(\{ type: 'drag-arm'/)
   // The reducer really assigns nextId as the transition id, so that pre-computed id
   // is exactly what a later cancel/commit must carry.
   const armed = modeReducer({ committedMode: 'single', transition: null, nextId: 7 },
@@ -124,55 +116,35 @@ test('finding F9: historical-chat repair is builder-only; single mode requests N
   assert.doesNotMatch(shell, /type: 'OPEN_TAB', paneId: ws\.focusedPaneId,\s*\n\s*tab: tabModel\.makeTab\('chat', chats\[0\]\.id\)/)
 })
 
-// -- Finding 5: completion is epoch-keyed (captured epoch, not inferred) --------
-test('finding 5: completion captures the originating epoch, not the current transition id', () => {
-  assert.match(controller, /const epoch = contract\.id/)
-  assert.match(controller, /dispatch\(\{ type: 'complete', id: epoch \}\)/)
-  assert.match(controller, /Promise\.allSettled\(anims\.map\(a => a\.finished\)\)/)
-  assert.doesNotMatch(controller, /addEventListener\('animationend'/)
-  // The completion contract is computed from the COMMITTED render closure, not the
-  // render-written ref (W3): the collection effect reads completionContract(state).
-  assert.match(controller, /const contract = completionContract\(state\)/)
-  // One rAF collection (v2), not two chained frames.
-  assert.match(controller, /raf = requestAnimationFrame\(collect\)/)
-  // The reducer's id guard rejects a superseded epoch's completion (enter1 -> exit2
-  // -> enter3: a delayed complete{enter1} cannot clear enter3).
-  let s = { committedMode: 'single', transition: null, nextId: 1 }
-  s = modeReducer(s, { type: 'toggle', to: 'panes', presentation: planFor('shell-mode-deal-in'), now: 0 }) // enter, id 1
-  const e1 = s.transition.id
-  s = modeReducer(s, { type: 'toggle', to: 'single', presentation: planFor('shell-mode-deal-out'), now: 1 }) // exit, id 2
-  s = modeReducer(s, { type: 'toggle', to: 'panes', presentation: planFor('shell-mode-deal-in'), now: 2 }) // enter, id 3
-  const e3 = s.transition.id
-  assert.notEqual(e1, e3)
-  assert.equal(modeReducer(s, { type: 'complete', id: e1 }).transition.id, e3, 'stale epoch rejected')
+// -- Finding 5: scene completion is epoch-keyed -------------------------------
+test('finding 5: completion settles only the originating browser scene', () => {
+  assert.match(scene, /const id = nextIdRef\.current\+\+/)
+  assert.match(scene, /if \(liveRef\.current\?\.descriptor\.id !== id\) return/)
+  assert.match(scene, /transition\.finished\.then\([\s\S]*?settle\(id\)/)
+  assert.doesNotMatch(scene, /animationend|setTimeout/)
 })
 
-// -- Finding 6 / INV 10 / H2: cancelBeat is wired to either plan's signature drift --
-test('finding 6: topology/geometry/destination drift during either beat cancels it (INV 10 / H2)', () => {
-  assert.match(shell, /mode\.cancelBeat\(\)/)
-  // The watcher recomputes one signature for both enter and exit plans. There is no
-  // phase-only gate that would leave geometry-dependent entry transforms stale.
-  assert.match(shell, /if \(!t\?\.presentation\) return/)
-  assert.doesNotMatch(shell, /t\.phase !== 'exiting'/)
-  assert.match(shell, /const live = transitionSignature\(\{/)
-  assert.match(shell, /settingsDestination: settingsOpenRaw/)
-  assert.match(shell, /immersiveHolderId: immersiveAppId/)
-  assert.match(shell, /\}, \[workspace, projection, contentRect, settingsOpenRaw, immersiveAppId, modeState, mode\]\)/)
-  assert.match(shell, /if \(live !== t\.presentation\.snapshotSignature\) mode\.cancelBeat\(\)/)
-  // The reducer's cancel-beat clears the descriptor without touching committedMode.
-  let s = modeReducer({ committedMode: 'panes', transition: null, nextId: 1 },
-    { type: 'toggle', to: 'single', presentation: planFor('shell-mode-deal-out'), now: 0 })
-  s = modeReducer(s, { type: 'cancel-beat' })
-  assert.equal(s.transition, null)
-  assert.equal(s.committedMode, 'single')
+// -- Finding 6: scene geometry is captured once, never retargeted live ---------
+test('finding 6: participant snapshots are collected once at the world boundary', () => {
+  assert.match(scene, /let snapshots = direction === 'exit'\s*\n\s*\? participantSnapshots/)
+  assert.match(scene, /if \(direction === 'enter'\) snapshots = participantSnapshots/)
+  assert.doesNotMatch(shell, /transitionSignature|cancelBeat|snapshotSignature/)
+})
+
+test('finding 6: exit enables capture names before collecting departing panes', () => {
+  const enableAt = scene.indexOf('html.dataset.modeViewTransition = direction')
+  const collectAt = scene.indexOf("let snapshots = direction === 'exit'")
+  assert.ok(enableAt >= 0, 'root capture attribute should be enabled')
+  assert.ok(collectAt >= 0, 'departing pane snapshots should be collected')
+  assert.ok(enableAt < collectAt, 'capture names must exist before exit reads them')
 })
 
 // -- Finding 7: mode-restoring Undo routes through the controller --------------
 test('finding 7: undo routes the mode restoration through mode.undo before UNDO_LAST', () => {
-  assert.match(shell, /mode\.undo\(\{ restoredMode, presentation \}\)/)
+  assert.match(shell, /modeView\.run\(\{[\s\S]*?cause: 'undo'/)
+  assert.match(shell, /update: \(\) => \{\s*\n\s*mode\.undo\(\{ restoredMode \}\)\s*\n\s*dispatchWorkspace\(\{ type: 'UNDO_LAST' \}\)/)
   assert.match(shell, /const restoredMode = undoSlot\.restoreViewMode\s*\n\s*\? undoSlot\.ws\.viewMode : wsState\.ws\.viewMode/)
-  // The undo presentation is derived from the tree the beat animates (v2).
-  assert.match(shell, /const presentation = restoredMode === 'panes'\s*\n\s*\? deriveEnterPlan/)
+  assert.match(shell, /const plan = deriveModeSnapshotPlan\(\{/)
 })
 
 // -- Finding R3: the last-tab-close auto-return arms the descriptor same-batch ---
@@ -180,13 +152,13 @@ test('finding R3: an emptying close arms the auto-return flip in the SAME batch,
   // The auto-return no longer lags a frame: closeTab detects the close will empty
   // the builder tree and dispatches an INSTANT mode flip (cause 'auto') alongside
   // CLOSE_TAB, so committedMode flips to single WITH the tree — not a render later
-  // via the passive sync-committed reconcile. It is a normal planned exit, not a
+  // via the passive sync-committed reconcile. It is a normal mode change, not a
   // separate autoFlip event (that orphaned API was deleted).
   assert.match(shell, /paneModel\.isEmptyTree\(paneModel\.closeTab\(ws, key\)\)\) \{\s*\n\s*mode\.toggle\(\{ cause: 'auto', to: 'single' \}\)/)
   assert.doesNotMatch(controller, /autoFlip/)
-  // An emptied-tree flip carries no plan → the machine flips instantly (no beat).
+  // An emptied-tree flip is ordinary state with no visual scene to capture.
   const flipped = modeReducer({ committedMode: 'panes', transition: null, nextId: 1 },
-    { type: 'toggle', cause: 'auto', to: 'single', presentation: null })
+    { type: 'toggle', cause: 'auto', to: 'single' })
   assert.equal(flipped.committedMode, 'single')
   assert.equal(flipped.transition, null)
 })
@@ -210,18 +182,18 @@ test('finding R2: a foreground single-world placement dismisses the Settings tak
   assert.match(nav, /const dismissSettings = useCallback\(\(\) => \{\s*\n\s*if \(!settingsOpenRef\.current\) return/)
 })
 
-// -- Finding W1: an epoch-keyed completion watchdog bounds a stuck beat ---------
-test('finding W1: a bounded completion watchdog force-completes a stranded epoch (INV 7/14)', () => {
-  // A finished promise that never resolves while the page stays visible would strand
-  // the descriptor (the visibility reconcile only runs on visibilitychange). The
-  // watchdog is armed inside the same completion effect, bounded by the plan's
-  // totalMs + margin, dispatching complete{captured epoch}; the reducer's stale-epoch
-  // guard makes a late fire safe. It is the ONLY correctness timer.
-  assert.match(controller, /const watchdog = setTimeout\(settle, contract\.maxMs \+ RECONCILE_SLACK_MS\)/)
-  assert.match(controller, /clearTimeout\(watchdog\)/)
-  // No other bare setTimeout/setInterval correctness timer lives in the controller.
-  const timers = controller.match(/set(Timeout|Interval)\(/g) || []
-  assert.equal(timers.length, 1, 'exactly one timer — the watchdog')
+// -- Finding W1: browser completion replaces a guessed watchdog ----------------
+test('finding W1: transition.finished owns completion with no correctness timer', () => {
+  assert.match(scene, /transition\.finished\.then\([\s\S]*?settle\(id\)/)
+  assert.match(scene, /transition\.skipTransition\(\)/)
+  assert.doesNotMatch(scene, /setTimeout|setInterval/)
+  assert.doesNotMatch(controller, /setTimeout|setInterval|getAnimations/)
+})
+
+test('mode preparation is hidden behind the captured old scene', () => {
+  assert.match(scene, /html\.dataset\.modeViewTransition = direction[\s\S]*?let snapshots[\s\S]*?let transition/)
+  assert.match(scene, /document\.startViewTransition\(\(\) => \{[\s\S]*?flushSync/)
+  assert.match(scene, /transition\.ready\.then\(\(\) => \{/)
 })
 
 // -- Finding 8: slot-only app gets a synthetic history owner -------------------
@@ -277,20 +249,20 @@ test('finding 12: Shift+Enter ignores auto-repeat and clears its click-suppressi
 // -- Finding F13 (expanding review): the beat carries an HONEST cause -----------
 test('finding F13: cause threads from the gesture/keyboard, never a hardcoded hold', () => {
   // The controller forwards the caller's cause instead of hardcoding 'hold'.
-  assert.match(controller, /const toggle = useCallback\(\(\{ cause, to, presentation \} = \{\}\)/)
-  assert.match(controller, /type: 'toggle', cause, to: dest, from, presentation: plan/)
+  assert.match(controller, /const toggle = useCallback\(\(\{ cause, to \} = \{\}\)/)
+  assert.match(controller, /dispatch\(\{ type: 'toggle', cause, to: dest \}\)/)
   assert.doesNotMatch(controller, /type: 'toggle', cause: 'hold'/)
-  // Shell forwards the caller's cause into mode.toggle alongside the latched plan.
-  assert.match(shell, /mode\.toggle\(\{ cause, presentation \}\)/)
+  assert.match(shell, /cause,\s*\n\s*plan,\s*\n\s*update:/)
+  assert.match(shell, /mode\.toggle\(\{ cause, to \}\)/)
   // Each source layer names its own beat honestly.
   assert.match(gesture, /onToggleMode\?\.\('hold'\)/)
   assert.match(gesture, /onToggleMode\?\.\('swipe'\)/)
   assert.match(brand, /onToggleMode\('keyboard'\)/)
 })
 
-// -- Finding 13: reduced motion is reactive -----------------------------------
-test('finding 13: reduced-motion changes settle a live beat; the brand has no perpetual rAF', () => {
-  assert.match(controller, /matchMedia\('\(prefers-reduced-motion: reduce\)'\)/)
-  assert.match(controller, /if \(t && t\.phase !== 'drag-preview'\) dispatch\(\{ type: 'complete', id: t\.id \}\)/)
+// -- Finding 13: reduced motion takes the instant scene path ------------------
+test('finding 13: reduced motion bypasses capture; the brand has no perpetual rAF', () => {
+  assert.match(scene, /!prefersReducedMotion\(\)/)
+  assert.match(scene, /if \(!supported\) \{\s*\n\s*flushSync\(update\)/)
   assert.doesNotMatch(brand, /requestAnimationFrame|useLivingHalo|logo-halo/)
 })

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -10,6 +10,8 @@ const shell = readFileSync(new URL('../Shell.jsx', import.meta.url), 'utf8')
 const shellBrand = readFileSync(new URL('../ShellBrand.jsx', import.meta.url), 'utf8')
 const newChatLanding = readFileSync(new URL('../NewChatLanding.jsx', import.meta.url), 'utf8')
 const workspaceViewSrc = readFileSync(new URL('../workspaceView.js', import.meta.url), 'utf8')
+const modeViewTransitionSrc = readFileSync(new URL('../useModeViewTransition.js', import.meta.url), 'utf8')
+const modeControllerSrc = readFileSync(new URL('../useModeController.js', import.meta.url), 'utf8')
 const drawer = readFileSync(new URL('../../Drawer/Drawer.jsx', import.meta.url), 'utf8')
 const drawerItemActionMenu = readFileSync(
   new URL('../../Drawer/DrawerItemActionMenu.jsx', import.meta.url),
@@ -335,7 +337,7 @@ test('the docked sidebar offsets only direct shell layout rows', () => {
 })
 
 test('the header never grows a standalone pane-mode icon', () => {
-  assert.match(shell, /<header className="shell__bar"/)
+  assert.match(shell, /<header\s+[\s\S]*?className="shell__bar"/)
   // Owner contract: hold/swipe the top-left Möbius brand or drag from the drawer.
   // A second top-right affordance is redundant and must not quietly return.
   assert.doesNotMatch(shell, /PanelsTopLeft|shell__mode-toggle|Use panes|Use single screen/)
@@ -427,11 +429,12 @@ test('completion feedback (SINGLE PULSE): one completion haptic, NO mid-hold ram
 
 test('ShellBrand isolates gesture state and wires the brand ref + Shift+Enter', () => {
   const handler = shell.match(/const handleToggleViewMode = useCallback\(\(cause\) => \{[\s\S]*?\}, \[[^\]]*\]\)/)?.[0] || ''
-  // v2: the toggle builds the latched plan + flips the durable mode in one handler;
-  // there is no Settings conversion call anymore (the tab survives the flip).
+  // The toggle builds one captured-scene plan and commits the durable world in the
+  // transition callback; there is no Settings conversion call.
   assert.doesNotMatch(handler, /convertSettingsForModeTransition/)
-  assert.match(handler, /mode\.toggle\(\{ cause, presentation \}\)/)
-  assert.match(handler, /dispatchWorkspace\(\{ type: 'SET_VIEW_MODE', mode: 'toggle' \}\)/)
+  assert.match(handler, /return modeView\.run\(\{/)
+  assert.match(handler, /mode\.toggle\(\{ cause, to \}\)/)
+  assert.match(handler, /dispatchWorkspace\(\{ type: 'SET_VIEW_MODE', mode: to \}\)/)
   assert.doesNotMatch(handler, /openDrawer|closeDrawer/)
   // The gesture hook receives the toggle + the brand ref (for the ring var). The
   // ref is UNIFIED with the desktop-sidebar focus ref (one ref, both jobs) after
@@ -482,10 +485,11 @@ test('the logo mark IS the indicator (CHARGE): compress on hold + spring/snap + 
   // Item 5 + round 4 item 1: logo rotate rides --mode-total (the plan's own totalMs)
   // so the twist settles with the panes — for a world reveal, at the end of the
   // pane beat. The wordmark tint keeps pace.
-  assert.match(shellCss, /\.shell--builder-entering \.shell__logo\s*\{[\s\S]*?rotate var\(--mode-total, 260ms\) cubic-bezier\(0\.2, 1, 0\.32, 1\)/)
-  assert.match(shellCss, /\.shell--builder-exiting \.shell__logo\s*\{[\s\S]*?rotate var\(--mode-total, 220ms\) cubic-bezier\(0\.25, 0\.8, 0\.25, 1\)/)
-  assert.match(shellCss, /\.shell--builder-entering \.shell__wordmark \{ transition-duration: 220ms; \}/)
-  assert.match(shellCss, /\.shell--builder-exiting \.shell__wordmark \{ transition-duration: 140ms; \}/)
+  assert.match(shellCss, /\.shell__bar\[data-mode-phase="entering"\] \.shell__logo\s*\{[\s\S]*?rotate var\(--mode-total, 260ms\) cubic-bezier\(0\.2, 1, 0\.32, 1\)/)
+  assert.match(shellCss, /\.shell__bar\[data-mode-phase="exiting"\] \.shell__logo\s*\{[\s\S]*?rotate var\(--mode-total, 220ms\) cubic-bezier\(0\.25, 0\.8, 0\.25, 1\)/)
+  assert.match(shellCss, /\.shell__bar\[data-mode-phase="entering"\] \.shell__wordmark \{ transition-duration: 220ms; \}/)
+  assert.match(shellCss, /\.shell__bar\[data-mode-phase="exiting"\] \.shell__wordmark \{ transition-duration: 140ms; \}/)
+  assert.match(shell, /<header[\s\S]*?className="shell__bar"[\s\S]*?style=\{brandBeatStyle \|\| undefined\}[\s\S]*?data-mode-phase=\{modeView\.active\?\.phase \|\| undefined\}/)
   // Builder mode gets a faint static halo shared by the logo and wordmark.
   // Both shadows live on the existing leaves and have no animation/transition.
   const builderLogo = shellCss.match(/\.shell__brand--builder \.shell__logo\s*\{[\s\S]*?\}/)?.[0] || ''
@@ -554,123 +558,50 @@ test('the Builder brand indicator is static and has no perpetual frame loop', ()
   assert.match(shellCss, /\.shell__brand--builder \.shell__wordmark\s*\{[\s\S]*?text-shadow:/)
 })
 
-test('entry assembles over a stationary Standard surface, compositor-only, instant under reduced motion (v3)', () => {
-  // v3: entry is an opaque transform-only DEAL-IN keyed to the transient
-  // .shell--builder-entering class, applied per-wrapper via data-mode-motion
-  // (never the permanent .shell__view--paned). The Standard wrapper is the
-  // stationary underlay and carries no competing scale animation.
-  const panedBase = css.match(/\.shell__view--paned \{[\s\S]*?\n\}/)?.[0] || ''
-  assert.doesNotMatch(panedBase, /animation:/)
-  assert.doesNotMatch(panedBase, /transition:/)
-  assert.match(css, /\.shell--builder-entering\s*\n\.shell__view\[data-mode-motion="deal-in"\] \{[\s\S]*?animation:\s*\n?\s*shell-mode-deal-in/)
-  assert.match(css, /\.shell--builder-entering\s*\n\.shell__view\[data-mode-motion="deal-in"\] \{[\s\S]*?z-index:\s*2/,
-    'every moving pane must paint above the stationary underlay regardless of app/chat DOM order')
-  assert.doesNotMatch(css, /shell-mode-settle/)
-  // Deal-in is transform-only: an opaque pane physically covers the retained single
-  // screen as it arrives instead of exposing pane structure before fading content in.
-  const dealIn = css.match(/@keyframes shell-mode-deal-in\s*\{[\s\S]*?\n\}/)?.[0] || ''
-  assert.match(dealIn, /translate3d\(var\(--mode-offset-x\), var\(--mode-offset-y\), 0\)/)
-  assert.doesNotMatch(dealIn, /opacity:/)
-  assert.doesNotMatch(dealIn, /box-shadow|border-radius|filter|clip/)
-  assert.match(css, /--ease-mode-arrive:\s*cubic-bezier\(0\.33, 1, 0\.68, 1\)/,
-    'entry keeps readable cubic-out travel without braking into the shared seam')
-  assert.match(css, /--ease-mode-promote:\s*cubic-bezier\(0\.2, 0\.82, 0\.2, 1\)/,
-    'the accepted exit promotion curve stays unchanged')
-  // The old dead .workspace--resizing selector is gone entirely.
-  assert.doesNotMatch(css, /workspace--resizing/)
-  assert.doesNotMatch(css, /shell-pane-deal|shell-strip-deal-in|shell-pane-settle/)
-  // Reduced motion: any data-mode-motion element gets no beat (defensive parity —
-  // the controller never even arms one).
-  const reduced = css.match(/@media \(prefers-reduced-motion: reduce\)\s*\{[\s\S]*?\n\}/)?.[0] || ''
-  assert.match(reduced, /\.shell \[data-mode-motion\] \{ animation: none !important; \}/)
+test('mode changes animate captured scenes rather than live chat layout', () => {
+  assert.match(modeViewTransitionSrc, /document\.startViewTransition/)
+  assert.match(modeViewTransitionSrc, /flushSync\(\(\) => \{[\s\S]*?setActive\(descriptor\)[\s\S]*?update\(\)/)
+  assert.match(css, /html\[data-mode-view-transition\] \.shell__content \{\s*view-transition-name: mode-workspace;/)
+  assert.doesNotMatch(css, /@keyframes shell-mode-slide|data-mode-motion|shell__view--exit-underlay/)
+  assert.doesNotMatch(shell, /wrapperMotion|beatParticipants|modeUnderlayKey/)
 })
 
-test('builder single-leaf: the strip deals with its pane, entry through the ONE controller (item 3)', () => {
-  // The strip is the builder surface: visible in the effective builder world even
-  // at one leaf, and never in single mode or while immersive is covering the
-  // preserved builder world.
-  assert.match(shell, /const tabStripVisible = !immersiveActive\s*\n?\s*&& \(SPLITS \? effectiveViewMode === 'panes' : tabStripEngaged\)\s*\n?\s*&& openTabs\.length >= 1/)
+test('entry and exit share one linear document timeline', () => {
+  assert.match(modeViewTransitionSrc, /const startTime = document\.timeline\?\.currentTime/)
+  assert.match(modeViewTransitionSrc, /animation\.startTime = startTime/)
+  assert.match(modeViewTransitionSrc, /duration: durationMs, easing: 'linear', fill: 'both'/)
+  assert.match(modeViewTransitionSrc, /direction === 'enter'[\s\S]*?translate3d\(0, 0, 0\)/)
+  assert.match(modeViewTransitionSrc, /direction === 'enter'[\s\S]*?direction === 'enter'[\s\S]*?opacity: 1, transform: away/)
+  assert.doesNotMatch(modeViewTransitionSrc, /setTimeout|delay:/)
+})
+
+test('pane surfaces and strips are captured individually; dividers remain outside moving snapshots', () => {
+  assert.match(shell, /data-mode-pane-vt=\{paned \? paned\.paneId : undefined\}/)
+  assert.match(shell, /modeViewTransitionStyle\('pane', paned\.paneId, tabKey\)/)
+  assert.match(shell, /modeViewTransitionStyle\('strip', navPaneId, 'single'\)/)
+  assert.match(chrome, /modeViewTransitionStyle\('strip', paneId, paneId\)/)
+  assert.doesNotMatch(chrome, /modeViewTransitionStyle\('divider'/)
+  assert.match(css, /html\[data-mode-view-transition\]::view-transition-old\(\*\),[\s\S]*?opacity: 0;/)
+})
+
+test('navigation is a stationary foreground capture above travelling panes', () => {
+  assert.match(css, /html\[data-mode-view-transition\] \.shell__bar \{\s*view-transition-name: mode-navigation-bar;/)
+  assert.match(css, /html\[data-mode-view-transition\] \.drawer--open \{\s*view-transition-name: mode-navigation-drawer;/)
+  assert.match(css, /::view-transition-group\(mode-navigation-bar\) \{\s*z-index: 100;/)
+  assert.match(css, /::view-transition-group\(mode-navigation-drawer\) \{\s*z-index: 95;/)
+  assert.match(modeViewTransitionSrc, /const stationaryNames = stationarySnapshotNames\(shell\)/)
+  assert.match(modeViewTransitionSrc, /::view-transition-new\(\$\{name\}\)/)
+  assert.match(shellCss, /\.shell__bar \{[\s\S]*?background: var\(--bg\);[\s\S]*?border-right: 1px solid var\(--border-light\);/)
+})
+
+test('the mode handler commits one final world inside the scene transaction', () => {
   const handler = shell.match(/const handleToggleViewMode = useCallback\(\(cause\) => \{[\s\S]*?\}, \[[^\]]*\]\)/)?.[0] || ''
-  // v2: the handler builds the latched plan (deriveEnter/ExitPlan from the
-  // projection) and dispatches the controller beat + the durable flip in the SAME
-  // handler (INV 2/3). No Shell timer, no per-pane role plumbing.
-  // The plan derives from the SETTLED post-flip state (the synchronous reducer
-  // preview): the durable flip and the null-slot home resolution land first, so
-  // the beat animates toward the surface single mode will actually paint.
-  assert.match(handler, /deriveEnterPlan\(\{[\s\S]*?workspace: settled, projection, contentRect,/)
-  assert.match(handler, /mode\.toggle\(\{ cause, presentation \}\)/)
-  assert.match(handler, /dispatchWorkspace\(\{ type: 'SET_VIEW_MODE', mode: 'toggle' \}\)/)
-  assert.match(shell, /modeMachine\.transitionRootClass\(modeState/)
-  // The single-pane nav strip carries the beat motion so it deals WITH its pane.
-  assert.match(shell, /data-mode-motion=\{navMotion \? navMotion\.motion : undefined\}/)
-  // It is INERT throughout either direction (not just under the drawer), so a tap
-  // on an in-flight strip cannot re-target the transition.
-  assert.match(shell, /className="shell__tabstrip"[\s\S]*?inert=\{navigationSurfaceOpen \|\| modeBeatActive\}/)
-  // CSS: a strip deals in with its pane on enter (shared with the WorkspaceChrome
-  // strips via .shell__tabstrip[data-mode-motion]).
-  assert.match(css, /\.shell--builder-entering \.shell__tabstrip\[data-mode-motion="deal-in"\] \{[\s\S]*?shell-mode-deal-in/)
-  // Reduced motion drops any beat.
-  const reduced = css.match(/@media \(prefers-reduced-motion: reduce\)\s*\{[\s\S]*?\n\}/)?.[0] || ''
-  assert.match(reduced, /\.shell \[data-mode-motion\] \{ animation: none !important; \}/)
-})
-
-test('leaving builder plays the INVERSE deal: compositor-only promote/deal-out, decisive (item 1)', () => {
-  const handler = shell.match(/const handleToggleViewMode = useCallback\(\(cause\) => \{[\s\S]*?\}, \[[^\]]*\]\)/)?.[0] || ''
-  // v2: the latched plan owns classification (promote a genuinely-shared pane vs
-  // reveal the single world underneath), shared timing, and the FLIP rects — the
-  // handler no longer computes settlePaneId / leavingPaneIds / dealMultiPane itself.
-  assert.match(handler, /const leavingBuilder = ws\.viewMode !== 'single'/)
-  assert.match(handler, /deriveExitPlan\(\{[\s\S]*?workspace: settled, projection, contentRect,/)
-  // The durable flip goes through the workspace boundary BEFORE plan derivation. That
-  // boundary owns a null-slot New Chat request, so the destination remains
-  // home:new-chat through the beat without a toggle-specific policy patch.
-  assert.match(handler, /dispatchWorkspace\(\{ type: 'SET_VIEW_MODE', mode: 'toggle' \}\)[\s\S]*?const settled/)
-  assert.match(shell, /enteredEmptySingleScreen\(\s*prev\.ws, next\.ws/)
-  assert.match(shell, /requestEmptySingleNewChatRef\.current\?\.\(\)/)
-  assert.doesNotMatch(handler, /requestEmptySingleNewChat/)
-  // M2: the exit plan is fed the honest single-world destination state (a suspended
-  // Settings takeover / a retained immersive holder), so it reveals to Settings or
-  // classifies immersive instant instead of promoting/revealing the covered slot.
-  assert.match(handler, /settingsDestination: settingsDestinationRef\.current/)
-  assert.match(handler, /immersiveHolderId: immersiveHolderRef\.current/)
-  assert.doesNotMatch(handler, /settlePaneId|leavingPaneIds|dealMultiPane|multiPaneRef/)
-  // Held tiled while the beat runs — from the ONE descriptor (INV 4).
-  assert.match(shell, /const effectiveViewMode = modeMachine\.effectiveViewMode\(modeState/)
-  // The old data-pane-role + renderTabRects wrapper-widen are GONE: panes hold their
-  // tiled rect and animate transform (data-mode-motion + inline --flip/--mode vars).
-  assert.doesNotMatch(shell, /data-pane-role/)
-  assert.doesNotMatch(shell, /renderTabRects/)
-  assert.match(shell, /data-mode-motion=\{motion \? motion\.motion : undefined\}/)
-  // The world-reveal underlay paints full-bleed beneath the deal (INV 5).
-  assert.match(shell, /shell__view--exit-underlay/)
-  // M2: the Settings surface itself can be that underlay (a suspended takeover is the
-  // honest destination), painted full-bleed beneath the deal via its mounted-hidden
-  // wrapper rather than snapping over a revealed slot at completion.
-  assert.match(shell, /const settingsUnderlay = isUnderlay\(SETTINGS_KEY\)/)
-  // CSS v3: promote FLIPs to full-bleed; siblings scatter to projection-derived edges.
-  assert.match(css, /\.shell--builder-exiting\s*\n\.shell__view\[data-mode-motion="promote"\] \{[\s\S]*?shell-mode-promote/)
-  assert.match(css, /\.shell--builder-exiting\s*\n\.shell__view\[data-mode-motion="deal-out"\] \{[\s\S]*?shell-mode-deal-out/)
-  const dealOut = css.match(/@keyframes shell-mode-deal-out\s*\{[\s\S]*?\n\}/)?.[0] || ''
-  assert.match(dealOut, /translate3d\(var\(--mode-offset-x\), var\(--mode-offset-y\), 0\)/)
-  assert.match(dealOut, /opacity: 0/)
-  assert.doesNotMatch(dealOut, /box-shadow|border-radius|filter|clip/)
-  assert.match(css, /--ease-mode-leave:\s*cubic-bezier\(0\.4, 0, 0\.7, 0\.2\)/,
-    'scatter keeps the accepted inverse departure curve')
-  // The parent-chrome opacity fade is DELETED (strips deal with their panes now).
-  assert.doesNotMatch(css, /\.shell--builder-exiting \.workspace__chrome \{[\s\S]*?opacity: 0/)
-  // Reduced motion drops any beat.
-  const reduced = css.match(/@media \(prefers-reduced-motion: reduce\)\s*\{[\s\S]*?\n\}/)?.[0] || ''
-  assert.match(reduced, /\.shell \[data-mode-motion\] \{ animation: none !important; \}/)
-})
-
-test('world reveal keeps its destination stationary and ready beneath one short slide', () => {
-  const underlay = css.match(/\.shell__view--exit-underlay\s*\{[\s\S]*?\n\}/)?.[0] || ''
-  assert.match(underlay, /visibility:\s*visible/)
-  assert.doesNotMatch(underlay, /animation:|transition:|transform:|opacity:/)
-  assert.doesNotMatch(css, /shell-mode-destination-arrive|--mode-arrive/)
-  const workspaceView = readFileSync(new URL('../workspaceView.js', import.meta.url), 'utf8')
-  assert.doesNotMatch(workspaceView, /destinationMotion|DESTINATION_ARRIVE_NAME|exitArriveMs/)
-  assert.doesNotMatch(shell, /arriveVars|--mode-arrive/)
+  assert.match(handler, /deriveModeSnapshotPlan\(\{ workspace: ws, projection, contentRect \}\)/)
+  assert.match(handler, /return modeView\.run\(\{/)
+  assert.match(handler, /direction: leavingBuilder \? 'exit' : 'enter'/)
+  assert.match(handler, /update: \(\) => \{[\s\S]*?dispatchWorkspace\(\{ type: 'SET_VIEW_MODE', mode: to \}\)[\s\S]*?mode\.toggle\(\{ cause, to \}\)/)
+  assert.match(modeViewTransitionSrc, /!prefersReducedMotion\(\)/)
+  assert.match(modeViewTransitionSrc, /if \(!supported\) \{[\s\S]*?flushSync\(update\)/)
 })
 
 test('the PROPOSED builder power-chrome is behind a default-OFF flag + root class', () => {
@@ -988,7 +919,7 @@ test('a manual platform reconcile refreshes the persistent Settings surface', ()
     shell,
     /if \(ev\.type === 'shell_apply_now'\) \{\s*setSettingsRefreshToken\(token => token \+ 1\)/,
   )
-  assert.match(shell, /active=\{!settingsUnderlay && \(settingsFullBleed \|\| !!settingsPaned\)\}/)
+  assert.match(shell, /active=\{settingsFullBleed \|\| !!settingsPaned\}/)
   assert.match(shell, /refreshToken=\{settingsRefreshToken\}/)
   assert.match(settingsView, /active = true,\s*refreshToken = 0,/)
   assert.match(
@@ -1215,9 +1146,8 @@ test('round4-3: every reducer edge into an empty single screen uses one policy b
 test('round4-3: the materialize watcher gates on an IDLE descriptor', () => {
   const effect = shell.match(/Deferred New Chat materialization watcher[\s\S]*?workspaceStateRef\]\)/)?.[0] || ''
   assert.ok(effect.length > 0, 'found the materialize watcher')
-  // Deferred until the mode descriptor idles — a slot write mid-beat would drift the
-  // exit signature and cancel the latched plan.
-  assert.match(effect, /if \(modeState\.transition\) return/)
+  // Deferred until both the browser scene and drag-preview are idle.
+  assert.match(effect, /if \(modeView\.active \|\| modeState\.transition\) return/)
   assert.match(effect, /pending\.token !== pendingNewChatToken/)
   assert.match(effect, /if \(!single \|\| ws\.singleScreen != null\)/)
   assert.match(effect, /materializeNewChatHomeRef\.current\?\.\(pending\)/)
@@ -1257,10 +1187,9 @@ test('round4-3: resolveNewChatId is the shared reuse-and-create policy; newChat 
   assert.doesNotMatch(fn, /api\.chats\.create|apiFetch\(\s*['"`]\/chats/)
 })
 
-test('round4-3: the New Chat landing renders for a null slot / reveal underlay and reuses ChatView empty visuals', () => {
+test('round4-3: the New Chat landing renders for a null slot and reuses ChatView empty visuals', () => {
   // The presentation key + its wiring.
   assert.match(workspaceViewSrc, /export const EMPTY_SINGLE_SURFACE_KEY = 'home:new-chat'/)
-  assert.match(shell, /const newChatUnderlay = isUnderlay\(EMPTY_SINGLE_SURFACE_KEY\)/)
   assert.match(shell, /const newChatSurface = fullBleedKey === EMPTY_SINGLE_SURFACE_KEY/)
   assert.match(shell, /<NewChatLanding/)
   assert.match(shell, /onRetry=\{requestEmptySingleNewChat\}/)
@@ -1272,23 +1201,17 @@ test('round4-3: the New Chat landing renders for a null slot / reveal underlay a
   assert.match(newChatLanding, /Couldn’t start a new chat/)
 })
 
-// ── N1: retired v2 plumbing is gone ───────────────────────────────────────────
-test('N1: dead exit-presentation plumbing is removed', () => {
-  const controller = readFileSync(new URL('../useModeController.js', import.meta.url), 'utf8')
+// ── Retired live-layout mode plumbing is gone ───────────────────────────────
+test('mode transitions have one browser scene owner and no legacy CSS controller', () => {
+  const controller = modeControllerSrc
   // The ignored focusedPaneId drag-arm payload is gone (the reducer never read it).
   assert.doesNotMatch(controller, /dragArm = useCallback\(\(focusedPaneId\)/)
   assert.doesNotMatch(controller, /drag-arm', focusedPaneId/)
   assert.match(shell, /mode\.dragArm\(\)/)
-  // Polish item 2/3: --ease-mode-chrome + --ease-mode-promote are (re)introduced as
-  // USED tokens — the chrome fades + strip-clear ride the chrome curve, the promote
-  // FLIP rides the promote curve — so they are no longer the dead plumbing this
-  // originally removed.
-  assert.match(css, /--ease-mode-chrome: cubic-bezier/)
-  assert.match(css, /--ease-mode-promote: cubic-bezier/)
-  assert.match(css, /shell-mode-chrome-out 90ms var\(--ease-mode-chrome\)/)
-  assert.match(css, /shell-mode-chrome-in 70ms var\(--ease-mode-chrome\)[\s\S]*?calc\(var\(--mode-total, 240ms\) - 70ms\) both/)
-  assert.match(css, /shell-mode-strip-clear 100ms var\(--ease-mode-chrome\)/)
-  assert.match(css, /shell-mode-promote\s*\n?\s*var\(--mode-duration\)\s*\n?\s*var\(--ease-mode-promote\)/)
+  assert.doesNotMatch(controller, /getAnimations|animationName|setTimeout|presentation/)
+  assert.doesNotMatch(css, /shell-mode-(?:slide|promote|strip)|data-mode-motion/)
+  assert.doesNotMatch(workspaceViewSrc, /deriveExitPlan|deriveEnterPlan|transitionSignature/)
+  assert.match(modeViewTransitionSrc, /transition\.finished\.then\([\s\S]*?settle\(id\)/)
   // The unused excludeChatId param is gone; the helper is now the New Chat request
   // (round 4 item 3 — the old freshest-chat write is fully retired).
   assert.doesNotMatch(shell, /excludeChatId/)

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -560,7 +560,8 @@ test('the Builder brand indicator is static and has no perpetual frame loop', ()
 
 test('mode changes animate captured scenes rather than live chat layout', () => {
   assert.match(modeViewTransitionSrc, /document\.startViewTransition/)
-  assert.match(modeViewTransitionSrc, /flushSync\(\(\) => \{[\s\S]*?setActive\(descriptor\)[\s\S]*?update\(\)/)
+  assert.match(modeViewTransitionSrc, /flushSync\(\(\) => setActive\(descriptor\)\)[\s\S]*?document\.startViewTransition/)
+  assert.match(modeViewTransitionSrc, /document\.startViewTransition\(\(\) => \{[\s\S]*?flushSync\(\(\) => \{[\s\S]*?update\(\)/)
   assert.match(css, /html\[data-mode-view-transition\] \.shell__content \{\s*view-transition-name: mode-workspace;/)
   assert.doesNotMatch(css, /@keyframes shell-mode-slide|data-mode-motion|shell__view--exit-underlay/)
   assert.doesNotMatch(shell, /wrapperMotion|beatParticipants|modeUnderlayKey/)

--- a/frontend/src/components/Shell/__tests__/workspaceView.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceView.test.js
@@ -3,8 +3,8 @@ import assert from 'node:assert/strict'
 import * as paneModel from '../paneModel.js'
 import * as tabModel from '../tabModel.js'
 import {
-  deriveContentVisibility, deriveExitPlan, deriveEnterPlan, projectFocusedPane,
-  transitionSignature, MODE_MOTION,
+  deriveContentVisibility, deriveModeSnapshotPlan, projectFocusedPane,
+  MODE_MOTION,
   EMPTY_SINGLE_SURFACE_KEY,
 } from '../workspaceView.js'
 
@@ -25,6 +25,19 @@ function twoPaneChatAndApp() {
 
 function project(ws) {
   return paneModel.projectLayout(ws, paneModel.modeForRect(CONTENT), CONTENT)
+}
+
+function assertPaneSnapshotsClearViewport(plan, projection, bounds) {
+  assert.ok(Object.keys(plan.offsets).length > 0, 'the plan has moving panes')
+  const boundsX = Number.isFinite(bounds.x) ? bounds.x : 0
+  const boundsY = Number.isFinite(bounds.y) ? bounds.y : 0
+  for (const [paneId, { x, y }] of Object.entries(plan.offsets)) {
+    const rect = projection.rects[paneId]
+    if (x < 0) assert.ok(rect.x + rect.w + x < boundsX, 'left-moving pane clears the viewport')
+    if (x > 0) assert.ok(rect.x + x > boundsX + bounds.w, 'right-moving pane clears the viewport')
+    if (y < 0) assert.ok(rect.y + rect.h + y < boundsY, 'top-moving pane clears the viewport')
+    if (y > 0) assert.ok(rect.y + y > boundsY + bounds.h, 'bottom-moving pane clears the viewport')
+  }
 }
 
 test('single-pane app: no chrome, holder full-bleed, that app visible', () => {
@@ -443,19 +456,14 @@ test('round 4 item 3: a null slot renders home:new-chat while its ROUTE stays ch
   })
 })
 
-test('round 4 item 3: an INITIALIZED null slot targets home:new-chat; a legacy Settings-only absent slot stays null', () => {
-  // An initialized empty slot → New Chat landing target/underlay (world reveal).
+test('round 4 item 3: an INITIALIZED null slot is the New Chat landing without transition-only routing', () => {
   const nullSlot = { ...twoPaneChatAndApp(), singleScreen: null }
-  const nullPlan = deriveExitPlan({ workspace: nullSlot, projection: project(nullSlot), contentRect: CONTENT })
-  assert.equal(nullPlan.target, EMPTY_SINGLE_SURFACE_KEY)
-  assert.equal(nullPlan.underlayKey, EMPTY_SINGLE_SURFACE_KEY)
-  // A LEGACY absent-slot whose sole pane is Settings seeds NO concrete item, so the
-  // target stays null (the opaque-background reveal) — unchanged by item 3.
+  assert.equal(singleView(nullSlot).fullBleedKey, EMPTY_SINGLE_SURFACE_KEY)
+  // A legacy absent-slot still falls back through the ordinary durable route; no
+  // separate animation destination classifier is needed.
   const legacy = paneModel.seedFromFlatTabs([tabModel.settingsTab()])
   assert.equal('singleScreen' in legacy, false, 'absent slot (legacy)')
-  const legacyPlan = deriveExitPlan({ workspace: legacy, projection: project(legacy), contentRect: CONTENT })
-  assert.equal(legacyPlan.target, null, 'a legacy Settings-only absent slot is not the New Chat landing')
-  assert.equal(legacyPlan.underlayKey, null, 'opaque background reveal, no underlay wrapper')
+  assert.equal(singleView(legacy).fullBleedKey, tabModel.SETTINGS_TAB_KEY)
 })
 
 // ── Settings takeover is EFFECTIVE-mode gated (finding F3) ───────────────────
@@ -504,437 +512,41 @@ test('builder mode ignores the slot entirely (tree drives the render)', () => {
   assert.equal(v.visibleAppIds.has('42'), true, 'the tree app is what paints')
 })
 
-// ── Assemble/scatter v3: latched plans (deriveExitPlan / deriveEnterPlan) ─────
+// ── Native captured-scene motion ───────────────────────────────────────────
 
-test('deriveExitPlan: PROMOTE when the target is a visible pane active key (INV 3 honest destination)', () => {
-  // twoPaneChatAndApp: chat 5 left (unfocused), app 42 right (focused). Legacy
-  // absent-slot → target seeds from the focused item = app:42, which IS the active
-  // key of the right pane → promote it, deal the left sibling out, no underlay.
+test('mode snapshot plan gives every visible pane one linear off-screen vector', () => {
   const ws = twoPaneChatAndApp()
-  const plan = deriveExitPlan({ workspace: ws, projection: project(ws), contentRect: CONTENT })
-  assert.equal(plan.target, 'app:42')
-  assert.equal(plan.underlayKey, null, 'physical continuity — no world reveal')
-  const promote = plan.participants.find(p => p.motion === 'promote')
-  assert.equal(promote.key, 'app:42')
-  assert.equal(promote.delayMs, 0, 'the assembled world moves as one beat')
-  assert.ok(plan.completionNames.includes('shell-mode-promote'))
-  // The FLIP grows the promote pane's content rect to the full destination.
-  assert.equal(promote.flip.sx > 1, true, 'a half-width pane scales up to full width')
-  const dealOut = plan.participants.filter(p => p.motion === 'deal-out')
-  assert.equal(dealOut.length, 1)
-  assert.equal(dealOut[0].key, 'chat:5')
-  assert.ok(dealOut[0].offset.x < 0, 'left sibling scatters past the left edge')
-  assert.equal(dealOut[0].offset.y, 0)
-})
-
-test('deriveExitPlan: WORLD-REVEAL when the slot is tree-absent (underlay + all deal out)', () => {
-  const ws = { ...twoPaneChatAndApp(), singleScreen: { kind: 'chat', id: '99' } }
-  const plan = deriveExitPlan({ workspace: ws, projection: project(ws), contentRect: CONTENT })
-  assert.equal(plan.target, 'chat:99')
-  assert.equal(plan.underlayKey, 'chat:99', 'the mounted destination is revealed beneath')
-  assert.equal(plan.participants.every(p => p.motion === 'deal-out'), true, 'no false promotion')
-  assert.deepEqual(plan.completionNames, ['shell-mode-deal-out'])
-  assert.ok(plan.participants.every(p => p.delayMs === 0), 'all panes leave together')
-})
-
-test('deriveExitPlan: WORLD-REVEAL when the slot tab is INACTIVE in a pane (never promote it)', () => {
-  // app 42 active in the right pane; put chat 5 as the slot but make chat 5 an
-  // INACTIVE tab of the left pane (its active is chat 5 though — so instead use a
-  // genuinely inactive case): the slot points at an item that is not any pane's
-  // active key.
-  let ws = paneModel.seedFromFlatTabs([makeTab('chat', '5')])
-  ws = paneModel.openTab(ws, makeTab('chat', '7'), { paneId: ws.focusedPaneId, activate: false })
-  ws = paneModel.splitPaneWithTab(ws, makeTab('app', '42'), { paneId: ws.focusedPaneId, edge: 'right' })
-  ws = { ...ws, singleScreen: { kind: 'chat', id: '7' } } // 7 is an inactive tab
-  const plan = deriveExitPlan({ workspace: ws, projection: project(ws), contentRect: CONTENT })
-  assert.equal(plan.underlayKey, 'chat:7', 'an inactive-tab slot world-reveals, never promotes')
-  assert.equal(plan.participants.some(p => p.motion === 'promote'), false)
-})
-
-test('deriveExitPlan: NULL slot reveals the New Chat landing (round 4 item 3), empty tree is instant', () => {
-  const home = { ...twoPaneChatAndApp(), singleScreen: null }
-  const homePlan = deriveExitPlan({ workspace: home, projection: project(home), contentRect: CONTENT })
-  // A null slot is a definite New Chat destination now — a WORLD REVEAL to the
-  // home:new-chat underlay, never the freshest chat and never the opaque-only home.
-  assert.equal(homePlan.target, EMPTY_SINGLE_SURFACE_KEY)
-  assert.equal(homePlan.underlayKey, EMPTY_SINGLE_SURFACE_KEY, 'the New Chat landing is revealed beneath the deal')
-  assert.ok(homePlan.participants.every(p => p.motion === 'deal-out'), 'every painted leaf deals out')
-  assert.ok(homePlan.participants.length >= 1)
-  // Empty tree → no participants → null plan → an INSTANT flip (no descriptor).
-  const empty = paneModel.seedFromFlatTabs([])
-  assert.equal(deriveExitPlan({ workspace: empty, projection: project(empty), contentRect: CONTENT }), null)
-})
-
-test('deriveExitPlan: siblings deal out together in one short beat', () => {
-  const ws = { ...twoPaneChatAndApp(), singleScreen: { kind: 'chat', id: '99' } }
-  const plan = deriveExitPlan({ workspace: ws, projection: project(ws), contentRect: CONTENT })
-  const delays = plan.participants.map(p => p.delayMs).sort((a, b) => a - b)
-  assert.deepEqual(delays, [0, 0])
-  assert.equal(MODE_MOTION.staggerMs, undefined)
-  assert.ok(plan.participants.every(p => p.durationMs === MODE_MOTION.exitItemMs))
-  assert.equal(plan.totalMs, MODE_MOTION.exitItemMs)
-})
-
-test('deriveExitPlan: a world reveal has no delayed destination phase', () => {
-  const ws = { ...twoPaneChatAndApp(), singleScreen: { kind: 'chat', id: '99' } }
-  const plan = deriveExitPlan({ workspace: ws, projection: project(ws), contentRect: CONTENT })
-  assert.deepEqual(plan.completionNames, ['shell-mode-deal-out'])
-  assert.equal('destinationMotion' in plan, false)
-  assert.equal(plan.totalMs, MODE_MOTION.exitItemMs)
-})
-
-test('deriveExitPlan: a promote keeps its seamless continuity', () => {
-  // twoPaneChatAndApp legacy absent-slot → seeds app:42 (focused) → PROMOTE.
-  const ws = twoPaneChatAndApp()
-  const plan = deriveExitPlan({ workspace: ws, projection: project(ws), contentRect: CONTENT })
-  assert.ok(plan.participants.some(p => p.motion === 'promote'))
-  assert.equal('destinationMotion' in plan, false)
-  assert.equal(plan.completionNames.includes('shell-mode-destination-arrive'), false)
-})
-
-test('deriveExitPlan: four panes cost the same 180ms beat as one pane', () => {
-  // Build MAX_PANES visible leaves (a balanced 2×2 within MAX_DEPTH) and a tree-absent
-  // slot so all four deal out over a revealed underlay. Tied to MAX_PANES so a future
-  // pane-count change can't silently blow the beat budget.
-  let ws = paneModel.seedFromFlatTabs([makeTab('chat', '1')])
-  ws = paneModel.splitPaneWithTab(ws, makeTab('chat', '2'), { paneId: ws.focusedPaneId, edge: 'right' })
-  const leftId = paneModel.paneOf(ws, 'chat:1').id
-  const rightId = paneModel.paneOf(ws, 'chat:2').id
-  ws = paneModel.splitPaneWithTab(ws, makeTab('chat', '3'), { paneId: leftId, edge: 'bottom' })
-  ws = paneModel.splitPaneWithTab(ws, makeTab('chat', '4'), { paneId: rightId, edge: 'bottom' })
-  const proj = project(ws)
-  assert.equal(proj.visibleLeaves.length, paneModel.MAX_PANES, 'four visible leaves')
-  ws = { ...ws, singleScreen: { kind: 'chat', id: 'ghost' } } // tree-absent → world reveal
-  const plan = deriveExitPlan({ workspace: ws, projection: proj, contentRect: CONTENT })
-  assert.ok(plan.participants.every(p => p.motion === 'deal-out'), 'all four deal out')
-  assert.equal(plan.totalMs, MODE_MOTION.exitItemMs)
-  assert.equal(plan.totalMs, 180)
-})
-
-test('four-pane assemble/scatter preserves all four outer-edge vectors', () => {
-  let ws = paneModel.seedFromFlatTabs([makeTab('chat', '1')])
-  ws = paneModel.splitPaneWithTab(ws, makeTab('chat', '2'), { paneId: ws.focusedPaneId, edge: 'right' })
-  const leftId = paneModel.paneOf(ws, 'chat:1').id
-  const rightId = paneModel.paneOf(ws, 'chat:2').id
-  ws = paneModel.splitPaneWithTab(ws, makeTab('chat', '3'), { paneId: leftId, edge: 'bottom' })
-  ws = paneModel.splitPaneWithTab(ws, makeTab('chat', '4'), { paneId: rightId, edge: 'bottom' })
-  ws = { ...ws, singleScreen: { kind: 'chat', id: 'ghost' } }
   const projection = project(ws)
-
-  for (const [plan, duration] of [
-    [deriveExitPlan({ workspace: ws, projection, contentRect: CONTENT }), MODE_MOTION.exitItemMs],
-    [deriveEnterPlan({ workspace: ws, projection, contentRect: CONTENT }), MODE_MOTION.enterItemMs],
-  ]) {
-    const offsets = new Map(plan.participants.map(p => [p.key, p.offset]))
-    assert.ok(offsets.get('chat:1').x < 0 && offsets.get('chat:1').y < 0, 'top-left owns top+left')
-    assert.ok(offsets.get('chat:2').x > 0 && offsets.get('chat:2').y < 0, 'top-right owns top+right')
-    assert.ok(offsets.get('chat:3').x < 0 && offsets.get('chat:3').y > 0, 'bottom-left owns bottom+left')
-    assert.ok(offsets.get('chat:4').x > 0 && offsets.get('chat:4').y > 0, 'bottom-right owns bottom+right')
-    assert.ok(plan.participants.every(p => p.delayMs === 0),
-      'world-reveal edge panes move together; no pane-count stagger')
-    assert.equal(plan.totalMs, duration)
-  }
+  const plan = deriveModeSnapshotPlan({ workspace: ws, projection, contentRect: CONTENT })
+  assert.equal(plan.totalMs, MODE_MOTION.slideMs)
+  assert.deepEqual(Object.keys(plan.offsets).sort(), [...projection.visibleLeaves].sort())
+  assertPaneSnapshotsClearViewport(plan, projection, CONTENT)
 })
 
-test('uneven entry uses one coordinated progress clock for every edge', () => {
-  let ws = paneModel.seedFromFlatTabs([makeTab('chat', '1')])
-  ws = paneModel.splitPaneWithTab(ws, makeTab('chat', '2'), {
-    paneId: ws.focusedPaneId, edge: 'right',
-  })
-  const rightId = paneModel.paneOf(ws, 'chat:2').id
-  ws = paneModel.splitPaneWithTab(ws, makeTab('chat', '3'), {
-    paneId: rightId, edge: 'bottom',
-  })
-  ws = paneModel.setRatio(ws, ws.layout.id, 0.7)
-  ws = paneModel.setRatio(ws, ws.layout.b.id, 0.25)
-  ws = { ...ws, singleScreen: { kind: 'chat', id: 'ghost' } }
-
-  const plan = deriveEnterPlan({ workspace: ws, projection: project(ws), contentRect: CONTENT })
-  assert.equal(plan.totalMs, MODE_MOTION.enterItemMs)
-  assert.ok(plan.participants.every(p => p.delayMs === 0),
-    'every pane starts on the same frame')
-  assert.ok(plan.participants.every(
-    p => p.delayMs + p.durationMs === MODE_MOTION.enterItemMs,
-  ), 'every pane lands on the same terminal frame')
-})
-
-test('N1: MODE_MOTION drops the unused chromeMs constant', () => {
-  assert.equal(MODE_MOTION.chromeMs, undefined)
-  // The live timings the plan builders use are still present.
-  assert.equal(typeof MODE_MOTION.promoteMs, 'number')
-  assert.equal(typeof MODE_MOTION.exitItemMs, 'number')
-})
-
-// ── M4: the single-leaf promote FLIP must not overshoot ───────────────────────
-test('deriveExitPlan: M4 the single-leaf promote FLIPs identity (no STRIP_H overshoot)', () => {
-  // One visible leaf → its strip is a flex SIBLING outside .shell__content, so the
-  // sole wrapper already fills the content box. The promote FLIP must be identity,
-  // not inset by STRIP_H (which overshot y:-STRIP_H, sy>1 then snapped back).
-  const ws = { ...paneModel.seedFromFlatTabs([makeTab('app', '42')]), singleScreen: { kind: 'app', id: '42' } }
-  const plan = deriveExitPlan({ workspace: ws, projection: project(ws), contentRect: CONTENT })
-  const promote = plan.participants.find(p => p.motion === 'promote')
-  assert.ok(promote, 'the sole leaf promotes')
-  assert.equal(Math.abs(promote.flip.x), 0) // -from.x can be -0; compare magnitude
-  assert.equal(Math.abs(promote.flip.y), 0, 'no STRIP_H vertical inset')
-  assert.equal(promote.flip.sx, 1)
-  assert.equal(promote.flip.sy, 1, 'no vertical overshoot — the wrapper is already full-bleed')
-})
-
-test('deriveExitPlan: M4 a multi-pane promote KEEPS the STRIP_H inset (strip is inside the pane rect)', () => {
-  // >=2 leaves → WorkspaceChrome strips sit INSIDE each pane rect, so the wrapper is
-  // inset by STRIP_H and the FLIP legitimately scales up. The single-leaf fix must
-  // not touch this multi-pane case.
-  const ws = twoPaneChatAndApp() // legacy absent-slot → seeds app:42 (focused right pane)
-  const plan = deriveExitPlan({ workspace: ws, projection: project(ws), contentRect: CONTENT })
-  const promote = plan.participants.find(p => p.motion === 'promote')
-  assert.ok(promote && promote.key === 'app:42')
-  assert.ok(promote.flip.sy > 1, 'STRIP_H inset stays for a real multi-pane strip')
-})
-
-// ── M2: exit plans must describe takeover / immersive destinations ────────────
-test('deriveExitPlan: M2 a suspended Settings takeover reveals to the Settings underlay, not the slot', () => {
-  // The single world paints Settings OVER the slot on completion, so the exit must
-  // reveal to the mounted-hidden Settings surface — never promote/reveal the slot
-  // the takeover then covers (the M2 honest-destination break).
-  const ws = { ...twoPaneChatAndApp(), singleScreen: { kind: 'app', id: '42' } }
-  const plan = deriveExitPlan({
-    workspace: ws, projection: project(ws), contentRect: CONTENT,
-    settingsDestination: true,
-  })
-  assert.equal(plan.target, tabModel.SETTINGS_TAB_KEY)
-  assert.equal(plan.underlayKey, tabModel.SETTINGS_TAB_KEY, 'reveal to the Settings surface, not the slot')
-  assert.equal(plan.participants.some(p => p.motion === 'promote'), false, 'never a promote of the covered slot')
-  assert.ok(plan.participants.length >= 1 && plan.participants.every(p => p.motion === 'deal-out'))
-})
-
-test('deriveExitPlan: M2 an immersive-holder destination is an honest instant (null plan), not a false FLIP', () => {
-  // The single world will solo app 42 over the WHOLE viewport (header gone) — a
-  // rect the beat cannot honestly latch — so classify instant rather than FLIP to
-  // the content box and jump at completion.
-  const ws = { ...twoPaneChatAndApp(), singleScreen: { kind: 'app', id: '42' } }
-  const plan = deriveExitPlan({
-    workspace: ws, projection: project(ws), contentRect: CONTENT,
-    immersiveHolderId: 42,
-  })
-  assert.equal(plan, null)
-})
-
-test('deriveExitPlan: M2 an immersive holder that is NOT the exit slot animates normally', () => {
-  // app 42 holds an immersive REQUEST, but the exit lands on chat 5 (the slot), so
-  // immersive will not apply. The independent Standard chat is the underlay and
-  // every Builder pane deals out; it is not a false immersive instant.
-  const ws = { ...twoPaneChatAndApp(), singleScreen: { kind: 'chat', id: '5' } }
-  const plan = deriveExitPlan({
-    workspace: ws, projection: project(ws), contentRect: CONTENT,
-    immersiveHolderId: 42,
-  })
-  assert.ok(plan, 'a non-slot immersive request does not suppress the beat')
-  assert.equal(plan.target, 'chat:5')
-  assert.equal(plan.underlayKey, 'chat:5')
-  assert.ok(plan.participants.every(p => p.motion === 'deal-out'))
-  assert.ok(plan.participants.some(p => p.key === 'chat:5'))
-})
-
-test('deriveExitPlan: M2 Settings takes precedence over an immersive holder', () => {
-  // Both flags set: the takeover paints over everything (Settings wins), so classify
-  // as the Settings world reveal, NOT the immersive instant.
-  const ws = { ...twoPaneChatAndApp(), singleScreen: { kind: 'app', id: '42' } }
-  const plan = deriveExitPlan({
-    workspace: ws, projection: project(ws), contentRect: CONTENT,
-    settingsDestination: true, immersiveHolderId: 42,
-  })
-  assert.ok(plan, 'Settings destination still animates (it is representable as an underlay)')
-  assert.equal(plan.underlayKey, tabModel.SETTINGS_TAB_KEY)
-})
-
-test('deriveExitPlan: M2 a builder Settings tab that IS the destination does not also deal out', () => {
-  // A visible Settings pane equals the takeover destination — it is the stationary
-  // underlay, so it is excluded from the dealing-out participants (never two roles).
-  let ws = paneModel.seedFromFlatTabs([makeTab('chat', '5')])
-  ws = paneModel.splitPaneWithTab(ws, tabModel.settingsTab(), { paneId: ws.focusedPaneId, edge: 'right' })
-  const plan = deriveExitPlan({
-    workspace: ws, projection: project(ws), contentRect: CONTENT,
-    settingsDestination: true,
-  })
-  assert.equal(plan.underlayKey, tabModel.SETTINGS_TAB_KEY)
-  assert.equal(plan.participants.some(p => p.key === tabModel.SETTINGS_TAB_KEY), false, 'the underlay surface never deals out')
-  assert.ok(plan.participants.some(p => p.key === 'chat:5'), 'the sibling pane still deals out')
-})
-
-test('deriveEnterPlan: a shared Standard app stays still while siblings assemble', () => {
-  const two = twoPaneChatAndApp() // the app:42 pane is focused
-  const twoPlan = deriveEnterPlan({ workspace: two, projection: project(two), contentRect: CONTENT })
-  assert.deepEqual(twoPlan.completionNames, ['shell-mode-deal-in'])
-  assert.equal(twoPlan.underlayKey, 'app:42')
-  assert.equal(twoPlan.participants.length, 1)
-  assert.ok(twoPlan.participants.every(p => p.durationMs === MODE_MOTION.enterItemMs))
-  const gather = twoPlan.participants.find(p => p.motion === 'deal-in')
-  assert.equal(gather.key, 'chat:5')
-  assert.ok(gather.offset.x < 0, 'the left pane assembles from the left edge')
-  assert.ok(twoPlan.participants.every(p => p.delayMs === 0))
-  assert.equal(twoPlan.totalMs, MODE_MOTION.enterItemMs)
-
-  // There is no visible assembly when the Standard surface is the only leaf.
-  // Returning null makes the controller commit that world flip instantly.
-  const one = paneModel.seedFromFlatTabs([makeTab('app', '42')])
-  const onePlan = deriveEnterPlan({ workspace: one, projection: project(one), contentRect: CONTENT })
-  assert.equal(onePlan, null)
-})
-
-test('chat targets keep Standard stationary while every Builder pane assembles', () => {
-  const ws = { ...twoPaneChatAndApp(), singleScreen: { kind: 'chat', id: '5' } }
-  const input = { workspace: ws, projection: project(ws), contentRect: CONTENT }
-
-  const enter = deriveEnterPlan(input)
-  assert.equal(enter.underlayKey, 'chat:5')
-  assert.equal(enter.participants.length, 2)
-  assert.ok(enter.participants.every(participant => participant.motion === 'deal-in'))
-  assert.ok(enter.participants.some(participant => participant.key === 'chat:5'),
-    'the matching Builder chat is a separate pane surface, not the Standard DOM')
-
-  const exit = deriveExitPlan(input)
-  assert.equal(exit.underlayKey, 'chat:5')
-  assert.equal(exit.participants.length, 2)
-  assert.ok(exit.participants.every(participant => participant.motion === 'deal-out'))
-  assert.ok(exit.participants.some(participant => participant.key === 'chat:5'))
-})
-
-test('focused-pane mode keeps its original edge and its in-pane strip geometry', () => {
-  const ws = twoPaneChatAndApp() // chat:5 left, focused app:42 right
-  const base = project(ws)
-  const focused = projectFocusedPane(base, ws, ws.focusedPaneId, CONTENT)
-
-  // When Standard targets the focused app, the shared wrapper is not an identity
-  // FLIP: focused-pane chrome still occupies STRIP_H inside the full-size pane.
-  const shared = deriveExitPlan({ workspace: ws, projection: focused, contentRect: CONTENT })
-  const promote = shared.participants.find(p => p.motion === 'promote')
-  assert.ok(promote)
-  assert.equal(promote.flip.y, -paneModel.STRIP_H)
-  assert.ok(promote.flip.sy > 1)
-  assert.equal(promote.delayMs, 0)
-
-  // When Standard targets the left chat instead, the focused right pane scatters
-  // right. Its full-size painted rect must clear the viewport completely; it must
-  // never fall back to the centred-pane "top" direction.
-  const toLeft = { ...ws, singleScreen: { kind: 'chat', id: '5' } }
-  const exit = deriveExitPlan({ workspace: toLeft, projection: focused, contentRect: CONTENT })
-  const departing = exit.participants.find(p => p.key === 'app:42')
-  assert.equal(departing.motion, 'deal-out')
-  assert.ok(departing.offset.x > CONTENT.w)
-  assert.equal(departing.offset.y, 0)
-
-  const enter = deriveEnterPlan({ workspace: toLeft, projection: focused, contentRect: CONTENT })
-  const arriving = enter.participants.find(p => p.key === 'app:42')
-  assert.equal(arriving.motion, 'deal-in')
-  assert.equal(arriving.offset.x, departing.offset.x, 'entry is the directional inverse')
-  assert.equal(arriving.offset.y, 0)
-})
-
-test('deriveEnterPlan: a tree-absent single surface stays beneath the assembling panes', () => {
-  const ws = { ...twoPaneChatAndApp(), singleScreen: { kind: 'chat', id: '99' } }
-  const input = { workspace: ws, projection: project(ws), contentRect: CONTENT }
-  const plan = deriveEnterPlan(input)
-  assert.equal(plan.target, 'chat:99')
-  assert.equal(plan.underlayKey, 'chat:99')
-  assert.deepEqual(plan.completionNames, ['shell-mode-deal-in'])
-  assert.ok(plan.participants.every(p => p.motion === 'deal-in'))
-  const left = plan.participants.find(p => p.key === 'chat:5')
-  const right = plan.participants.find(p => p.key === 'app:42')
-  assert.ok(left.offset.x < 0)
-  assert.ok(right.offset.x > 0)
-  assert.equal(plan.snapshotSignature, transitionSignature(input), 'entry latches its input snapshot')
-  assert.notEqual(
-    plan.snapshotSignature,
-    transitionSignature({ ...input, contentRect: { ...CONTENT, w: CONTENT.w - 120 } }),
-    'a mid-entry content resize invalidates the latched edge offsets',
-  )
-})
-
-test('edge motions accept Shell\'s origin-free live content rect', () => {
-  const ws = { ...twoPaneChatAndApp(), singleScreen: { kind: 'chat', id: '99' } }
-  const contentRect = { w: CONTENT.w, h: CONTENT.h }
-  const projection = paneModel.projectLayout(ws, paneModel.modeForRect(contentRect), contentRect)
-  for (const plan of [
-    deriveExitPlan({ workspace: ws, projection, contentRect }),
-    deriveEnterPlan({ workspace: ws, projection, contentRect }),
-  ]) {
-    assert.ok(plan.participants.length > 0)
-    for (const participant of plan.participants) {
-      assert.ok(Number.isFinite(participant.offset.x), 'horizontal offset stays finite')
-      assert.ok(Number.isFinite(participant.offset.y), 'vertical offset stays finite')
-    }
-  }
-})
-
-test('transitionSignature is stable and drifts on topology/content-bound changes (INV 10)', () => {
-  const ws = { ...twoPaneChatAndApp(), singleScreen: { kind: 'chat', id: '99' } }
-  const base = transitionSignature({ workspace: ws, projection: project(ws), contentRect: CONTENT })
-  assert.equal(base, transitionSignature({ workspace: ws, projection: project(ws), contentRect: CONTENT }))
-  // A content-box resize drifts the signature → the beat cancels.
-  const resized = transitionSignature({ workspace: ws, projection: project(ws), contentRect: { x: 0, y: 0, w: 800, h: 600 } })
-  assert.notEqual(base, resized)
-  const movedBounds = transitionSignature({
-    workspace: ws, projection: project(ws), contentRect: { ...CONTENT, x: 12 },
-  })
-  assert.notEqual(base, movedBounds, 'edge offsets include the content origin when supplied')
-  // A divider ratio changes edge offsets without changing the content bounds, so
-  // per-pane rects are part of the invalidation signature too.
-  const resizedPane = paneModel.setRatio(ws, ws.layout.id, 0.62)
-  assert.notEqual(base, transitionSignature({ workspace: resizedPane, projection: project(resizedPane), contentRect: CONTENT }))
-  // Focused presentation geometry stays full-size across a divider change, but its
-  // durable source edge can move. That source rect must invalidate the live beat too.
-  const baseProjection = project(ws)
-  const focused = projectFocusedPane(baseProjection, ws, ws.focusedPaneId, CONTENT)
-  const focusedSig = transitionSignature({ workspace: ws, projection: focused, contentRect: CONTENT })
-  const sourceRect = focused.motionRects[ws.focusedPaneId]
-  const movedSource = {
-    ...focused,
-    motionRects: {
-      ...focused.motionRects,
-      [ws.focusedPaneId]: { ...sourceRect, x: sourceRect.x - 12 },
-    },
-  }
-  assert.notEqual(focusedSig,
-    transitionSignature({ workspace: ws, projection: movedSource, contentRect: CONTENT }))
-  // A different slot target drifts it too.
-  const retargeted = transitionSignature({ workspace: { ...ws, singleScreen: { kind: 'chat', id: '5' } }, projection: project(ws), contentRect: CONTENT })
-  assert.notEqual(base, retargeted)
-})
-
-test('transitionSignature folds the destination so a mid-beat destination change cancels (H2)', () => {
-  // The audit case: a live exit plan built toward the chat slot must cancel the moment
-  // a Settings takeover suspends over the slot mid-beat — the two signatures differ.
-  const ws = { ...twoPaneChatAndApp(), singleScreen: { kind: 'chat', id: '5' } }
-  const proj = project(ws)
-  const toChat = transitionSignature({ workspace: ws, projection: proj, contentRect: CONTENT })
-  const toSettings = transitionSignature({ workspace: ws, projection: proj, contentRect: CONTENT, settingsDestination: true })
-  assert.notEqual(toChat, toSettings, 'chat-target vs settings:settings destinations must differ')
-  // And the PLAN's stored snapshot equals a live recompute at the SAME destination, so
-  // the watcher never false-cancels while the destination holds (structural coupling:
-  // deriveExitPlan feeds its own input object to transitionSignature).
-  const settingsPlan = deriveExitPlan({ workspace: ws, projection: proj, contentRect: CONTENT, settingsDestination: true })
-  assert.equal(settingsPlan.snapshotSignature, toSettings)
-  const chatPlan = deriveExitPlan({ workspace: ws, projection: proj, contentRect: CONTENT })
-  assert.equal(chatPlan.snapshotSignature, toChat)
-  // An immersive holder that solos the exit slot is an INSTANT destination — its
-  // signature differs from the ordinary reveal, so a mid-beat immersive request cancels.
-  const app42 = { ...twoPaneChatAndApp(), singleScreen: { kind: 'app', id: '42' } }
-  const projApp = project(app42)
-  const reveal = transitionSignature({ workspace: app42, projection: projApp, contentRect: CONTENT })
-  const immersive = transitionSignature({ workspace: app42, projection: projApp, contentRect: CONTENT, immersiveHolderId: 42 })
-  assert.notEqual(reveal, immersive, 'an immersive-instant destination must drift the signature')
-})
-
-test('deriveContentVisibility augments visibleAppIds with an app underlay (exit reveal)', () => {
-  // During a world-reveal exit the effective mode is still 'panes'; the underlay app
-  // is not a visible tree pane, so it must be unioned in or it paints a blank frame.
+test('left and right panes preserve their own outward directions', () => {
   const ws = twoPaneChatAndApp()
-  const v = deriveContentVisibility({
-    workspace: ws, projection: project(ws),
-    settingsOverlayOpen: false, immersiveActive: false, immersiveAppId: null,
-    viewMode: 'panes', exitUnderlayKey: 'app:99',
-  })
-  assert.equal(v.exitUnderlayKey, 'app:99')
-  assert.equal(v.visibleAppIds.has('99'), true, 'the underlay app is painted beneath the deal')
-  assert.equal(v.visibleAppIds.has('42'), true, 'the tree apps still paint')
+  const projection = project(ws)
+  const plan = deriveModeSnapshotPlan({ workspace: ws, projection, contentRect: CONTENT })
+  const ordered = [...projection.visibleLeaves].sort(
+    (a, b) => projection.rects[a].x - projection.rects[b].x,
+  )
+  assert.ok(plan.offsets[ordered[0]].x < 0)
+  assert.ok(plan.offsets[ordered[1]].x > 0)
+})
+
+test('focused-pane presentation keeps the pane original edge for scene direction', () => {
+  const ws = twoPaneChatAndApp()
+  const base = project(ws)
+  const leftPane = [...base.visibleLeaves].sort(
+    (a, b) => base.rects[a].x - base.rects[b].x,
+  )[0]
+  const focused = projectFocusedPane(base, ws, leftPane, CONTENT)
+  const plan = deriveModeSnapshotPlan({ workspace: ws, projection: focused, contentRect: CONTENT })
+  assert.ok(plan.offsets[leftPane].x < 0, 'a full-size focused pane still exits toward its durable left edge')
+})
+
+test('an empty projection has no decorative mode transaction', () => {
+  const ws = paneModel.seedFromFlatTabs([])
+  const projection = project(ws)
+  assert.equal(deriveModeSnapshotPlan({ workspace: ws, projection, contentRect: CONTENT }), null)
 })

--- a/frontend/src/components/Shell/modeMachine.js
+++ b/frontend/src/components/Shell/modeMachine.js
@@ -1,137 +1,28 @@
-// The mode-transition machine — the ONE descriptor that replaces the old
-// three-boolean + two-timer + shared-render-override tangle (builderEntering,
-// builderExiting, dragPreviewBuilder, builderEnterTimerRef, builderExitTimerRef
-// and the effectiveViewMode expression scattered across Shell.jsx).
-//
-// Codex's adversarial review (codex-mode-machinery-review.md §3) found that the
-// old shape "cannot be made sequence-proof with local guards": rapid re-entry,
-// enter-during-exit, drag-arm-during-beat, undo-during-beat each stranded an
-// independent flag/timer/class. The prescribed replacement is a single exclusive
-// transition descriptor from which EVERYTHING derives, with completion keyed to the
-// transition epoch rather than a bare timer.
-//
-// EXIT-PRESENTATION v2 reshape: the descriptor no longer carries role plumbing
-// (focusedPaneId / leavingPaneIds / an `animated` boolean / fixed per-phase
-// animation-name sets). It latches ONE opaque `presentation` plan built by
-// workspaceView.deriveExit/EnterPlan. The machine treats the plan as data: it holds
-// the outgoing world, rejects stale epochs, and exposes the completion contract the
-// plan contains (its animation names + totalMs). It does NOT know what chat, app,
-// Settings, zoom, or a future surface means — a new destination surface needs only a
-// deriveExitPlan target adapter plus renderer support, never a new machine branch.
-//
-// State shape:
-//
-//   { committedMode: 'single' | 'panes',
-//     transition: null | {
-//       id,               // monotonic epoch — the completion key (INV 15)
-//       phase,            // 'entering' | 'exiting' | 'drag-preview'
-//       from, to,         // 'single' | 'panes'
-//       cause,            // 'hold'|'swipe'|'keyboard'|'drag'|'undo'|'auto'|'toggle'
-//       startedAt,        // ms — the reconcile clock (INV 14)
-//       presentation,     // opaque latched plan (null for a drag preview)
-//     } }
-//
-// The invariants are cited inline as `INV N` at their enforcement point so a
-// reviewer can grep any invariant number to its code. (Numbering follows the
-// exit-presentation v2 "Single invariant list for tests".)
-//
-//  1. One descriptor: at most one transition; no parallel booleans/timers.
-//  2. Opaque latch: the transition owns one immutable presentation snapshot. Live
-//     focus, topology, target, and geometry cannot retarget it.
-//  3. New input supersedes the prior epoch synchronously.
-//  4. effectiveViewMode, root class, logo/halo, aria, interactivity all derive from
-//     this one descriptor.
-//  5. Drag arm is phase 'drag-preview'; cancel and commit carry its id.
-//  7. One completion contract: the plan's names + totalMs end the beat; a stale
-//     epoch's completion cannot clear a newer one.
-// 10. Invalidation snaps: a topology/geometry change cancels the beat (cancel-beat);
-//     no transform is retargeted.
-// 11. Reduced motion / an empty plan never arms a descriptor (instant flip).
-// 14. visibilitychange / pageshow reconciles from startedAt; no bare timer.
-// 16. The splits kill switch clamps presentation to single before derivation.
-
-// The slack a visibility-return reconcile allows past the plan's nominal totalMs
-// before it force-completes a beat whose animationend never arrived (hidden tab,
-// throttled rAF). Not a correctness timer — nothing fires it on its own; it is a
-// pure comparison against startedAt at the reconcile boundary (INV 14). Sourced
-// from the presentation module so timing lives in one place.
-export { MODE_MOTION, RECONCILE_SLACK_MS } from './workspaceView.js'
-import { RECONCILE_SLACK_MS } from './workspaceView.js'
+// Durable workspace mode is ordinary state. The only transient React projection
+// left here is drag-preview: dragging a Standard tab temporarily reveals Builder
+// before a valid drop commits it. Visual Standard ↔ Builder motion belongs to the
+// browser's View Transition transaction (useModeViewTransition), not this reducer.
 
 export function initialModeState(committedMode = 'panes') {
   return {
     committedMode: committedMode === 'single' ? 'single' : 'panes',
     transition: null,
-    // Monotonic epoch source. Every transition takes `nextId` and increments it,
-    // so no two transitions in a session ever share an id — the guarantee INV 7
-    // (a stale completion from id=N cannot clear id=N+1) rests on.
     nextId: 1,
   }
 }
 
-// A presentation plan arms a beat iff it names at least one completion animation.
-// Reduced motion and structurally-instant flips (an empty tree) are represented as
-// a NULL presentation from the caller — there is no `animated` boolean to strand
-// (INV 11: retained transitions are animated by construction). A drag preview
-// passes no presentation and never self-completes. Exported so the controller can
-// tell an animated toggle from an instant flip when it builds the toggle RECEIPT —
-// the ONE predicate, never duplicated (logo-beat handoff, round 4 item 1).
-export function planArms(presentation) {
-  return !!presentation
-    && Array.isArray(presentation.completionNames)
-    && presentation.completionNames.length > 0
-}
-
-// Build a fresh transition descriptor for a committed direction change, taking
-// (and consuming) the monotonic epoch. Returns { transition, nextId }.
-function makeTransition(state, { from, to, cause, presentation, now }) {
-  const id = state.nextId
-  return {
-    nextId: id + 1,
-    transition: {
-      id,
-      phase: to === 'panes' ? 'entering' : 'exiting',
-      from,
-      to,
-      cause: cause || 'toggle',
-      startedAt: Number.isFinite(now) ? now : 0,
-      presentation, // the opaque latched plan (INV 2)
-    },
-  }
-}
-
-// The pure reducer. Every mode-changing path in the app funnels here (INV 2);
-// the controller (useModeController) is the only caller and pairs each
-// mode-committing event with its workspace dispatch so the pair is one
-// transaction. A toggle to the mode already committed with no live beat is a
-// genuine no-op reference so React can bail.
 export function modeReducer(state, event) {
   switch (event.type) {
-    // A user toggle (hold / swipe / keyboard), a drop-flip, or the last-tab-close
-    // auto-return (cause 'auto'). Direction is decided by the CURRENT committedMode
-    // unless `to` is given explicitly (undo passes it). committedMode flips
-    // SYNCHRONOUSLY here; the render holds the outgoing world during an exit beat
-    // via effectiveViewMode, never by deferring the durable flip. INV 2, INV 3.
     case 'toggle': {
-      const from = state.committedMode
-      const to = event.to || (from === 'single' ? 'panes' : 'single')
-      if (to === from && !state.transition) return state
-      if (!planArms(event.presentation)) {
-        // Instant flip — reduced motion, an empty tree, or a caller-declared
-        // no-beat direction change. Any prior transition is superseded (INV 3/11).
-        return { ...state, committedMode: to, transition: null }
-      }
-      const { transition, nextId } = makeTransition(state, {
-        from, to, cause: event.cause, presentation: event.presentation, now: event.now,
-      })
-      // INV 3: a new toggle REPLACES whatever transition was live with a new epoch,
-      // synchronously. The old epoch's pending completion is now stale (INV 7).
-      return { committedMode: to, transition, nextId }
+      const to = event.to || (state.committedMode === 'single' ? 'panes' : 'single')
+      if (to === state.committedMode && !state.transition) return state
+      return { ...state, committedMode: to, transition: null }
     }
-
-    // A single-mode drag previews the builder world without committing the durable
-    // mode (design: "dragging is building" — the preview, not the commit). INV 5.
-    // Only meaningful from single. Supersedes any live beat. INV 3.
+    case 'undo': {
+      const to = event.restoredMode === 'single' ? 'single' : 'panes'
+      if (to === state.committedMode && !state.transition) return state
+      return { ...state, committedMode: to, transition: null }
+    }
     case 'drag-arm': {
       if (state.committedMode !== 'single') {
         return state.transition ? { ...state, transition: null } : state
@@ -143,187 +34,47 @@ export function modeReducer(state, event) {
           id,
           phase: 'drag-preview',
           from: 'single',
-          to: 'single', // a preview commits nothing until drag-commit
+          to: 'single',
           cause: 'drag',
-          startedAt: Number.isFinite(event.now) ? event.now : 0,
-          presentation: null, // the preview has no self-completing plan
         },
         nextId: id + 1,
       }
     }
-
-    // Cancel/Escape/blur/lost-capture end of a drag preview. INV 5/7: only the
-    // matching live drag-preview epoch is cleared — a stale cancel is ignored.
     case 'drag-cancel': {
-      const t = state.transition
-      if (!t || t.phase !== 'drag-preview' || t.id !== event.id) return state
+      const live = state.transition
+      if (!live || live.phase !== 'drag-preview' || live.id !== event.id) return state
       return { ...state, transition: null }
     }
-
-    // A drop committed. The workspace reducer performs the placement + the 'panes'
-    // flip in the SAME batch; here we reflect committedMode='panes' and drop the
-    // preview. Only the matching live epoch commits (INV 5/7). A rejected/no-op drop
-    // never reaches here, so this never fabricates a mode change (P1 review finding).
     case 'drag-commit': {
-      const t = state.transition
-      if (!t || t.phase !== 'drag-preview' || t.id !== event.id) return state
+      const live = state.transition
+      if (!live || live.phase !== 'drag-preview' || live.id !== event.id) return state
       return { ...state, committedMode: 'panes', transition: null }
     }
-
-    // Undo restored the durable viewMode. Undo is a first-class controller event
-    // (INV 2) rather than a silent bypass. A restored mode that differs from the
-    // committed one is a real direction change and earns a beat when the caller
-    // supplies a plan (undoing a last-tab-close auto-return re-enters builder with
-    // the entry deal); an ordinary tree undo carries the current mode forward, so
-    // restoredMode === committedMode and this is a no-op.
-    case 'undo': {
-      const to = event.restoredMode === 'single' ? 'single' : 'panes'
-      const from = state.committedMode
-      if (to === from) {
-        return state.transition ? { ...state, transition: null } : state
-      }
-      if (!planArms(event.presentation)) {
-        return { ...state, committedMode: to, transition: null }
-      }
-      const { transition, nextId } = makeTransition(state, {
-        from, to, cause: 'undo', presentation: event.presentation, now: event.now,
-      })
-      return { committedMode: to, transition, nextId }
-    }
-
-    // Reconcile committedMode with an EXTERNAL durable-mode change — hydration on
-    // boot/reload, or any viewMode change that did not originate here. A reload
-    // starts directly in the durable mode with NO beat (the accepted reload
-    // policy), so this always clears any transition. Same reference when in sync.
     case 'sync-committed': {
       const to = event.committedMode === 'single' ? 'single' : 'panes'
       if (to === state.committedMode && !state.transition) return state
       return { ...state, committedMode: to, transition: null }
     }
-
-    // Topology / geometry mutation invalidated the latched plan (a participant pane
-    // closed, the active tab changed, the content box resized). INV 10: the
-    // descriptor CANCELS rather than silently retargeting a transform. The
-    // controller detects the snapshot drift and dispatches this; it does not touch
-    // committedMode (the durable mode already flipped).
-    case 'cancel-beat': {
-      return state.transition ? { ...state, transition: null } : state
-    }
-
-    // A keyed completion fired (finished promise / reduced-motion sync / visibility
-    // reconcile). INV 7: a completion for id=N is a no-op unless N is the LIVE
-    // transition, so a superseded epoch's late completion can never clear the
-    // current one.
-    case 'complete': {
-      const t = state.transition
-      if (!t || t.id !== event.id) return state
-      return { ...state, transition: null }
-    }
-
     default:
       return state
   }
 }
 
-// ── Pure derivations — the single source for every mode-dependent render fact
-// (INV 4). Shell.jsx reads THESE, never a scattered boolean. Each takes the
-// splits kill switch so the clamp (INV 16) is applied before anything else.
-
-// INV 16: with splits disabled the presentation is clamped to single BEFORE any
-// other derivation, so a persisted 'panes' blob can never reach the tiled render
-// and strand the owner in a control-less builder view.
 function clampMode(committedMode, splitsEnabled) {
   if (!splitsEnabled) return 'single'
   return committedMode
 }
 
-// The mode the render actually paints. During an exit or a drag preview the
-// outgoing tiled world is held ('panes'); everything else is the committed mode.
 export function effectiveViewMode(state, { splitsEnabled = true } = {}) {
   if (!splitsEnabled) return 'single'
-  const t = state.transition
-  if (t && (t.phase === 'exiting' || t.phase === 'drag-preview')) return 'panes'
+  if (state.transition?.phase === 'drag-preview') return 'panes'
   return clampMode(state.committedMode, splitsEnabled)
 }
 
-// The transient root class the shell wears for this beat. Exactly one, ever (INV
-// 1). Empty string when idle or during a drag preview (a preview shows the tiled
-// world but wears no enter/exit deal class).
-export function transitionRootClass(state, { splitsEnabled = true } = {}) {
-  if (!splitsEnabled) return ''
-  const t = state.transition
-  if (!t) return ''
-  if (t.phase === 'entering') return 'shell--builder-entering'
-  if (t.phase === 'exiting') return 'shell--builder-exiting'
-  return ''
-}
-
-// Builder mode is active (the logo's 180° twist + static brand cue + power chrome)
-// whenever the COMMITTED mode is panes — it flips synchronously with the toggle.
-// Clamped off by the kill switch. INV 4/16.
 export function builderModeActive(state, { splitsEnabled = true } = {}) {
   return clampMode(state.committedMode, splitsEnabled) === 'panes'
 }
 
-// True while an exit beat is live — the render uses this to (a) render the underlay,
-// (b) make outgoing panes + chrome + the underlay inert, and (c) pass every visible
-// AppCanvas interactive:false (INV 9 inert beat). Replaces the old
-// exitGeometryActive + leavingSurfacesInert pair.
-export function exitBeatActive(state, { splitsEnabled = true } = {}) {
-  if (!splitsEnabled) return false
-  const t = state.transition
-  return !!t && t.phase === 'exiting'
-}
-
-// A single-mode drag is previewing the builder world. INV 5.
 export function dragPreviewActive(state, { splitsEnabled = true } = {}) {
-  if (!splitsEnabled) return false
-  const t = state.transition
-  return !!t && t.phase === 'drag-preview'
-}
-
-// The latched presentation plan for the live ANIMATED beat (entering/exiting), or
-// null. Shell reads this to apply each participant's data-mode-motion + inline
-// FLIP/duration/delay variables. A drag preview has no plan.
-export function transitionPresentation(state) {
-  const t = state.transition
-  if (!t || t.phase === 'drag-preview') return null
-  return t.presentation || null
-}
-
-// The latched EXIT plan (target + participants + underlayKey), or null. Shell reads
-// underlayKey/target to paint the revealed destination beneath the deal.
-export function exitPresentation(state) {
-  const t = state.transition
-  if (!t || t.phase !== 'exiting') return null
-  return t.presentation || null
-}
-
-// The completion contract for the live transition (INV 7): which animation-names
-// end it, and the max duration the reconcile clock (INV 14) allows before it
-// force-completes. Taken straight from the latched plan. Null when nothing pends.
-export function completionContract(state) {
-  const p = transitionPresentation(state)
-  if (!p) return null
-  const t = state.transition
-  return {
-    id: t.id,
-    animationNames: new Set(p.completionNames),
-    maxMs: p.totalMs,
-  }
-}
-
-// INV 14: on visibilitychange→visible / pageshow, decide whether the live beat has
-// already outlived its nominal duration (its animationend was throttled away while
-// hidden) and should be force-completed. Returns a complete{id} event or null — a
-// pure comparison against startedAt, never a scheduled timer.
-export function reconcileVisibleEvent(state, now) {
-  const contract = completionContract(state)
-  if (!contract) return null
-  const t = state.transition
-  if (!Number.isFinite(now) || !Number.isFinite(t.startedAt)) return null
-  if (now - t.startedAt >= contract.maxMs + RECONCILE_SLACK_MS) {
-    return { type: 'complete', id: t.id }
-  }
-  return null
+  return !!splitsEnabled && state.transition?.phase === 'drag-preview'
 }

--- a/frontend/src/components/Shell/useLogoModeGesture.js
+++ b/frontend/src/components/Shell/useLogoModeGesture.js
@@ -43,9 +43,9 @@ export function prefersReducedMotion() {
 
 export function useLogoModeGesture({
   onToggleMode, brandRef, enabled = true, drawerOpen = false, builderModeActive = false,
-  // The live mode descriptor (modeMachine transition) or null. The hold hands its
-  // compression off to this descriptor: while an animated enter/exit beat owns the
-  // logo, the mark holds .84 and springs back at the beat's completion instead of
+  // The live captured-scene descriptor or null. The hold hands its compression off
+  // to this descriptor: while an animated mode change owns the logo, the mark holds
+  // .84 and springs back at the scene's completion instead of
   // flashing its own ignite/snap (round 4 item 1). The gesture only READS it — to
   // know when the animated beat has settled so the hold's ownership latch can clear.
   transition = null,
@@ -55,8 +55,8 @@ export function useLogoModeGesture({
   // one-shot completion animation class for an INSTANT flip (reduced motion, an empty
   // tree). An ANIMATED beat suppresses it: the descriptor owns the spring instead.
   const [flourish, setFlourish] = useState('')
-  // True once a completed HOLD started an animated beat, so the logo's compression is
-  // handed to the descriptor's release rather than an immediate ignite/snap. It
+  // True once a completed HOLD started an animated scene, so the logo's compression
+  // is handed to the descriptor's release rather than an immediate ignite/snap. It
   // persists across epoch SUPERSESSION (a keyboard/swipe retoggle during a hold-owned
   // beat inherits the compression against the newest epoch) and is cleared only when
   // no animated enter/exit descriptor remains — never merely because the epoch

--- a/frontend/src/components/Shell/useModeController.js
+++ b/frontend/src/components/Shell/useModeController.js
@@ -1,212 +1,55 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useReducer, useRef } from 'react'
-import {
-  initialModeState, modeReducer, completionContract, reconcileVisibleEvent,
-  planArms, RECONCILE_SLACK_MS,
-} from './modeMachine.js'
-import { prefersReducedMotion } from './useLogoModeGesture.js'
+import { initialModeState, modeReducer } from './modeMachine.js'
 
-// The React controller for the mode-transition descriptor (modeMachine.js). It
-// owns the ONE reducer, funnels every mode-changing intent through it (INV 2),
-// and drives completion by the transition EPOCH rather than a bare timer:
-//
-//   - a per-epoch layout effect captures the epoch in a closure and completes
-//     ONLY that epoch via the animations' `finished` promises (INV 7): a delayed
-//     animationend from a superseded epoch can never satisfy a newer one because
-//     the completion carries the CAPTURED originating epoch;
-//   - if no expected animation is running one frame after commit, it completes
-//     synchronously (no-valid-target recovery);
-//   - visibilitychange / pageshow reconciled from startedAt (INV 14): a beat whose
-//     animation was throttled away while hidden is force-completed on return, with
-//     NO scheduled correctness timer;
-//   - a reduced-motion media subscription settles a live beat if the preference
-//     flips mid-transition;
-//   - a committedMode reconcile so an EXTERNAL durable-mode change can never let
-//     the descriptor drift.
-//
-// The controller never persists anything and never touches the workspace tree —
-// Shell builds the presentation plan and pairs each mode-committing intent with the
-// matching workspace dispatch in the SAME handler so the pair batches as one
-// transaction (INV 2/3).
-export default function useModeController({
-  committedMode, splitsEnabled = true, rootRef,
-}) {
+// Synchronizes the durable workspace mode with the one transient state that still
+// belongs in React: drag-preview. Visual mode motion is a separate browser scene
+// transaction; this controller never watches CSS animations or schedules recovery.
+export default function useModeController({ committedMode, splitsEnabled = true }) {
   const [state, dispatch] = useReducer(
-    modeReducer, undefined, () => initialModeState(committedMode),
+    modeReducer,
+    undefined,
+    () => initialModeState(committedMode),
   )
-  // The listener effects (visibility reconcile, reduced-motion, drag arm) read the
-  // LIVE descriptor without re-subscribing every render. Updated in a LAYOUT effect
-  // (not at render time) so an abandoned concurrent render can never publish a
-  // descriptor the listeners then act on (W3).
   const stateRef = useRef(state)
   useLayoutEffect(() => { stateRef.current = state }, [state])
 
-  // ── Reconcile with the external durable authority ──────────────────────────
-  // workspace.viewMode is the persisted source of truth; the descriptor's
-  // committedMode mirrors it. A controller-driven toggle updates both in one batch,
-  // so they agree on the next render. Any OTHER path that moved viewMode (boot
-  // hydration, a reload) shows up as a drift and is synced with NO beat. INV 3.
   useEffect(() => {
     if (committedMode !== stateRef.current.committedMode) {
       dispatch({ type: 'sync-committed', committedMode })
     }
   }, [committedMode])
 
-  // ── Epoch-keyed completion (INV 7) ─────────────────────────────────────────
-  // For each ANIMATED transition epoch we CAPTURE the epoch + its completion
-  // contract from the COMMITTED render closure (this effect only runs for a
-  // committed render, so `state` is the durable descriptor — never a render-written
-  // ref that an abandoned render could have poisoned; W3). One frame after the beat
-  // class commits, collect the plan's animations via getAnimations and await their
-  // `finished` promises; when they settle — or if none are running (no valid
-  // target) — dispatch complete{capturedEpoch}. The reducer's id guard then rejects
-  // it unless it is still the live epoch, so a stale animation from epoch N can
-  // NEVER clear epoch N+1.
-  const transitionId = state.transition ? state.transition.id : null
   useEffect(() => {
-    const contract = completionContract(state)
-    if (!contract) return undefined
-    const epoch = contract.id
-    const names = contract.animationNames
-    let cancelled = false
-    let raf = 0
-    const settle = () => { if (!cancelled) dispatch({ type: 'complete', id: epoch }) }
-    const collect = () => {
-      if (cancelled) return
-      const root = rootRef?.current
-      let anims = []
-      if (root && typeof root.getAnimations === 'function') {
-        try {
-          anims = root.getAnimations({ subtree: true })
-            .filter(a => names.has(a.animationName) && a.playState !== 'finished')
-        } catch { anims = [] }
-      }
-      if (anims.length === 0) { settle(); return } // no valid target — recover
-      // INV 7: complete on the Web Animations `finished` promises. allSettled so a
-      // cancel (animationcancel → finished rejects) still settles this epoch.
-      Promise.allSettled(anims.map(a => a.finished)).then(settle)
-    }
-    // ONE rAF: the class applies on the React commit; the CSS animations register
-    // on the next style/layout, resolved before this frame's paint (exit-design v2).
-    raf = requestAnimationFrame(collect)
-    // W1: a bounded completion WATCHDOG (INV 7/14). The finished-promise path is the
-    // primary mechanism, and the visibility reconcile handles a beat throttled away
-    // while HIDDEN — but neither covers a beat whose `finished` promise never
-    // resolves while the page stays VISIBLE (a stuck/cancelled animation, a target
-    // that outlives its epoch). This timer force-completes the CAPTURED epoch at the
-    // plan's totalMs + margin; the reducer's stale-epoch guard makes a late fire a
-    // no-op if the beat already settled or was superseded. Armed only while an
-    // animated beat is live and cleared on cleanup, this is the ONE correctness timer
-    // in the mode system — nothing else schedules a bare timer.
-    const watchdog = setTimeout(settle, contract.maxMs + RECONCILE_SLACK_MS)
-    return () => {
-      cancelled = true
-      if (raf) cancelAnimationFrame(raf)
-      clearTimeout(watchdog)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [transitionId, rootRef])
+    if (splitsEnabled) return
+    dispatch({ type: 'sync-committed', committedMode: 'single' })
+  }, [splitsEnabled])
 
-  // ── Visibility / pageshow reconcile (INV 14) ───────────────────────────────
-  useEffect(() => {
-    const reconcile = () => {
-      if (typeof document !== 'undefined' && document.visibilityState === 'hidden') return
-      const ev = reconcileVisibleEvent(stateRef.current, now())
-      if (ev) dispatch(ev)
-    }
-    document.addEventListener('visibilitychange', reconcile)
-    window.addEventListener('pageshow', reconcile)
-    return () => {
-      document.removeEventListener('visibilitychange', reconcile)
-      window.removeEventListener('pageshow', reconcile)
-    }
+  const toggle = useCallback(({ cause, to } = {}) => {
+    const current = stateRef.current.committedMode
+    const dest = to || (current === 'single' ? 'panes' : 'single')
+    dispatch({ type: 'toggle', cause, to: dest })
+    return { to: dest, transitionId: null, animated: false, totalMs: 0 }
   }, [])
 
-  // ── Reduced-motion preference change mid-beat ──────────────────────────────
-  // Enabling reduce during a live beat settles the captured epoch at once rather
-  // than wait out an animation being removed underneath it.
-  useEffect(() => {
-    if (typeof window === 'undefined' || !window.matchMedia) return undefined
-    const mq = window.matchMedia('(prefers-reduced-motion: reduce)')
-    const onChange = () => {
-      if (!mq.matches) return
-      const t = stateRef.current.transition
-      if (t && t.phase !== 'drag-preview') dispatch({ type: 'complete', id: t.id })
-    }
-    mq.addEventListener?.('change', onChange)
-    return () => mq.removeEventListener?.('change', onChange)
+  const undo = useCallback(({ restoredMode } = {}) => {
+    dispatch({ type: 'undo', restoredMode })
   }, [])
 
-  // ── Intent dispatchers (Shell calls these alongside its workspace dispatch) ─
-  // Each is stable so it never churns the logo-gesture / drag-hook callbacks.
-
-  // A user toggle or the last-tab-close auto-return. Shell builds the presentation
-  // plan (deriveEnter/ExitPlan) and passes the HONEST cause ('hold'|'swipe'|
-  // 'keyboard'|'auto'); a null presentation means an instant flip (reduced motion or
-  // an empty tree — Shell passes none). `to` lets the auto-return pin the direction.
-  // Returns an authoritative RECEIPT (round 4 item 1) so the logo gesture can tell an
-  // animated beat (compression held until the descriptor completes) from an instant
-  // flip (immediate ignite/snap). `transitionId` is read from stateRef BEFORE the
-  // dispatch — makeTransition consumes exactly this `nextId`, so the receipt names the
-  // epoch the new beat WILL wear (the same atomic-before-dispatch trick dragArm uses).
-  const toggle = useCallback(({ cause, to, presentation } = {}) => {
-    const pre = stateRef.current
-    const from = pre.committedMode
-    const dest = to || (from === 'single' ? 'panes' : 'single')
-    // Reduced motion commits directly — never arm a descriptor (the plan is dropped
-    // so planArms is false and the reducer flips instantly). One place owns this.
-    const plan = prefersReducedMotion() ? null : presentation
-    // A toggle to the already-committed mode with no live beat is a reducer no-op, so
-    // it arms nothing even with a plan — reflect that in the receipt.
-    const noop = dest === from && !pre.transition
-    const animated = planArms(plan) && !noop
-    dispatch({ type: 'toggle', cause, to: dest, from, presentation: plan, now: now() })
-    return {
-      to: dest,
-      transitionId: animated ? pre.nextId : null,
-      animated,
-      totalMs: animated ? plan.totalMs : 0,
-    }
-  }, [])
-
-  // Undo restored the durable viewMode — routed here so the beat (re-entering
-  // builder on a last-tab-close undo) is coordinated, not a silent bypass. INV 2.
-  const undo = useCallback(({ restoredMode, presentation } = {}) => {
-    const plan = prefersReducedMotion() ? null : presentation
-    dispatch({ type: 'undo', restoredMode, presentation: plan, now: now() })
-  }, [])
-
-  // Drag arm / cancel / commit — the drag hook owns the id it passes back (INV 5).
-  // The id is computed BEFORE dispatch (the reducer assigns state.nextId), so the
-  // returned id is ATOMIC with the dispatch. Reading stateRef AFTER dispatch would
-  // return the pre-dispatch epoch and a later cancel/blur would carry the wrong id.
   const dragArm = useCallback(() => {
-    const s = stateRef.current
-    if (s.committedMode !== 'single') {
-      dispatch({ type: 'drag-arm', now: now() })
-      return null
-    }
-    const id = s.nextId
-    dispatch({ type: 'drag-arm', now: now() })
+    const current = stateRef.current
+    const id = current.committedMode === 'single' ? current.nextId : null
+    dispatch({ type: 'drag-arm' })
     return id
   }, [])
   const dragCancel = useCallback((id) => { dispatch({ type: 'drag-cancel', id }) }, [])
   const dragCommit = useCallback((id) => { dispatch({ type: 'drag-commit', id }) }, [])
 
-  // Topology / geometry mutation invalidated the latched plan — cancel the beat
-  // rather than let a transform retarget (INV 10). Wired to a workspace/geometry
-  // watcher in Shell that compares the live exit signature to the latched one.
-  const cancelBeat = useCallback(() => { dispatch({ type: 'cancel-beat' }) }, [])
-
-  // One memoized API object so consumers that depend on the whole controller do not
-  // churn every render; the callbacks above are already stable.
   return useMemo(() => ({
     state,
-    toggle, undo, dragArm, dragCancel, dragCommit, cancelBeat,
-  }), [state, toggle, undo, dragArm, dragCancel, dragCommit, cancelBeat])
-}
-
-function now() {
-  return (typeof performance !== 'undefined' && performance.now)
-    ? performance.now()
-    : Date.now()
+    toggle,
+    undo,
+    dragArm,
+    dragCancel,
+    dragCommit,
+  }), [state, toggle, undo, dragArm, dragCancel, dragCommit])
 }

--- a/frontend/src/components/Shell/useModeViewTransition.js
+++ b/frontend/src/components/Shell/useModeViewTransition.js
@@ -1,0 +1,198 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { flushSync } from 'react-dom'
+import { prefersReducedMotion } from './useLogoModeGesture.js'
+
+// Mode changes are scene changes, not live-layout animations. The browser captures
+// the settled Standard and Builder worlds, then this hook moves only the captured
+// pane pixels on one document timeline. Heavy retained chats can wake, measure, and
+// raster behind the old snapshot without consuming the visible motion clock.
+
+export const MODE_WORKSPACE_TRANSITION_NAME = 'mode-workspace'
+export const MODE_NAVIGATION_BAR_TRANSITION_NAME = 'mode-navigation-bar'
+export const MODE_NAVIGATION_DRAWER_TRANSITION_NAME = 'mode-navigation-drawer'
+
+function ident(value) {
+  const token = String(value ?? 'surface').replace(/[^a-zA-Z0-9_-]/g, '-')
+  return token || 'surface'
+}
+
+export function modeViewTransitionName(kind, ...parts) {
+  return `mode-${ident(kind)}-${parts.map(ident).join('-')}`
+}
+
+export function modeViewTransitionStyle(kind, paneId, identity = kind) {
+  // Keep view-transition-name itself off resting surfaces. It is enabled from
+  // this inert custom ident only while the root transaction attribute is present,
+  // so normal scrolling carries no extra capture/paint-containment contract.
+  return { '--mode-vt-name': modeViewTransitionName(kind, paneId, identity) }
+}
+
+function participantSnapshots(root, offsets) {
+  if (!root || !offsets) return []
+  const out = []
+  for (const element of root.querySelectorAll('[data-mode-pane-vt]')) {
+    const paneId = element.getAttribute('data-mode-pane-vt')
+    const offset = offsets[paneId]
+    if (!offset) continue
+    const name = getComputedStyle(element).viewTransitionName
+    if (!name || name === 'none') continue
+    out.push({ name, offset })
+  }
+  return out
+}
+
+function stationarySnapshotNames(root) {
+  if (!root) return []
+  const names = []
+  for (const element of root.querySelectorAll('.shell__bar, .drawer--open')) {
+    const name = getComputedStyle(element).viewTransitionName
+    if (name && name !== 'none') names.push(name)
+  }
+  return names
+}
+
+function animatePseudo(root, pseudoElement, keyframes, timing, startTime) {
+  const animation = root.animate(keyframes, { ...timing, pseudoElement })
+  // Animations created in the same microtask are already extremely close. Pinning
+  // them to one timeline instant removes even that construction-order difference.
+  if (Number.isFinite(startTime)) {
+    try { animation.startTime = startTime } catch { /* timeline pin unsupported */ }
+  }
+  return animation
+}
+
+export default function useModeViewTransition({ rootRef, durationMs }) {
+  const [active, setActive] = useState(null)
+  const liveRef = useRef(null)
+  const nextIdRef = useRef(1)
+
+  const settle = useCallback((id) => {
+    if (liveRef.current?.descriptor.id !== id) return
+    for (const animation of liveRef.current.animations) {
+      try { animation.cancel() } catch { /* pseudo already gone */ }
+    }
+    liveRef.current = null
+    delete document.documentElement.dataset.modeViewTransition
+    setActive(null)
+  }, [])
+
+  const run = useCallback(({ direction, to, cause = 'toggle', plan, update }) => {
+    const phase = direction === 'enter' ? 'entering' : 'exiting'
+    const id = nextIdRef.current++
+    const descriptor = {
+      id, phase, direction, to, cause,
+      totalMs: durationMs,
+    }
+    const supported = typeof document !== 'undefined'
+      && typeof document.startViewTransition === 'function'
+      && !prefersReducedMotion()
+      && plan?.offsets
+
+    if (!supported) {
+      flushSync(update)
+      return { animated: false, totalMs: 0, transitionId: null, to }
+    }
+
+    // Mode input is shielded while active, but a keyboard event can still reach the
+    // header. Finish the old visual transaction before accepting a new scene.
+    if (liveRef.current) {
+      for (const animation of liveRef.current.animations) {
+        try { animation.cancel() } catch { /* pseudo already gone */ }
+      }
+      try { liveRef.current.transition.skipTransition() } catch { /* already ending */ }
+    }
+
+    const html = document.documentElement
+    const shell = rootRef?.current
+    html.dataset.modeViewTransition = direction
+    // Capture names only exist while the root transaction attribute is present.
+    // Enable it before reading the departing scene; entry reads after the final
+    // Builder world has committed inside the update callback below.
+    let snapshots = direction === 'exit'
+      ? participantSnapshots(shell, plan.offsets)
+      : []
+    const stationaryNames = stationarySnapshotNames(shell)
+
+    let transition
+    try {
+      transition = document.startViewTransition(() => {
+        flushSync(() => {
+          setActive(descriptor)
+          update()
+        })
+        if (direction === 'enter') snapshots = participantSnapshots(shell, plan.offsets)
+      })
+    } catch {
+      delete html.dataset.modeViewTransition
+      flushSync(update)
+      return { animated: false, totalMs: 0, transitionId: null, to }
+    }
+
+    liveRef.current = { descriptor, transition, animations: [] }
+    transition.ready.then(() => {
+      if (liveRef.current?.descriptor.id !== id) return
+      if (snapshots.length === 0) {
+        transition.skipTransition()
+        return
+      }
+      const animations = liveRef.current.animations
+      const timing = { duration: durationMs, easing: 'linear', fill: 'both' }
+      const startTime = document.timeline?.currentTime
+      const workspaceSide = direction === 'enter' ? 'old' : 'new'
+      animations.push(animatePseudo(
+        html,
+        `::view-transition-${workspaceSide}(${MODE_WORKSPACE_TRANSITION_NAME})`,
+        [{ opacity: 1 }, { opacity: 1 }],
+        timing,
+        startTime,
+      ))
+      // Navigation remains a foreground layer in both worlds. Capturing its final
+      // pixels separately preserves the drawer/rail clipping boundary while panes
+      // travel beneath it, without involving live navigation DOM in the motion.
+      for (const name of stationaryNames) {
+        animations.push(animatePseudo(
+          html,
+          `::view-transition-new(${name})`,
+          [{ opacity: 1 }, { opacity: 1 }],
+          timing,
+          startTime,
+        ))
+      }
+      const paneSide = direction === 'enter' ? 'new' : 'old'
+      for (const { name, offset } of snapshots) {
+        const away = `translate3d(${offset.x}px, ${offset.y}px, 0)`
+        animations.push(animatePseudo(
+          html,
+          `::view-transition-${paneSide}(${name})`,
+          direction === 'enter'
+            ? [{ opacity: 1, transform: away }, { opacity: 1, transform: 'translate3d(0, 0, 0)' }]
+            : [{ opacity: 1, transform: 'translate3d(0, 0, 0)' }, { opacity: 1, transform: away }],
+          timing,
+          startTime,
+        ))
+      }
+    }).catch(() => {
+      try { transition.skipTransition() } catch { /* already skipped */ }
+    })
+    transition.finished.then(
+      () => settle(id),
+      () => settle(id),
+    )
+
+    return { animated: true, totalMs: durationMs, transitionId: id, to }
+  }, [durationMs, rootRef, settle])
+
+  useEffect(() => () => {
+    const live = liveRef.current
+    liveRef.current = null
+    if (typeof document !== 'undefined') {
+      delete document.documentElement.dataset.modeViewTransition
+    }
+    for (const animation of live?.animations || []) {
+      try { animation.cancel() } catch { /* pseudo already gone */ }
+    }
+    try { live?.transition.skipTransition() } catch { /* already finished */ }
+  }, [])
+
+  return useMemo(() => ({ active, run }), [active, run])
+}

--- a/frontend/src/components/Shell/useModeViewTransition.js
+++ b/frontend/src/components/Shell/useModeViewTransition.js
@@ -104,6 +104,12 @@ export default function useModeViewTransition({ rootRef, durationMs }) {
 
     const html = document.documentElement
     const shell = rootRef?.current
+    // Publish the descriptor before startViewTransition returns control to the
+    // caller. A completed logo hold uses the run receipt to hand its compression
+    // to this exact descriptor; waiting for the browser's asynchronous update
+    // callback left one render with no active beat, so the gesture correctly
+    // cleared its ownership latch before the scene had even begun.
+    flushSync(() => setActive(descriptor))
     html.dataset.modeViewTransition = direction
     // Capture names only exist while the root transaction attribute is present.
     // Enable it before reading the departing scene; entry reads after the final
@@ -117,14 +123,16 @@ export default function useModeViewTransition({ rootRef, durationMs }) {
     try {
       transition = document.startViewTransition(() => {
         flushSync(() => {
-          setActive(descriptor)
           update()
         })
         if (direction === 'enter') snapshots = participantSnapshots(shell, plan.offsets)
       })
     } catch {
       delete html.dataset.modeViewTransition
-      flushSync(update)
+      flushSync(() => {
+        setActive(null)
+        update()
+      })
       return { animated: false, totalMs: 0, transitionId: null, to }
     }
 

--- a/frontend/src/components/Shell/workspace.css
+++ b/frontend/src/components/Shell/workspace.css
@@ -3,165 +3,65 @@
    presentation — a single-pane workspace renders today's DOM verbatim (Shell's
    parity branch) and never touches any class here. */
 
-/* ── Mode-transition motion (assemble/scatter v3) ────────────────────────────
-   The mode beat is COMPOSITOR-ONLY: every keyframe touches transform + opacity
-   and NOTHING that forces layout on the live iframe/ChatView surfaces (no
-   box-shadow, border-radius, filter, clip, or animated top/left/width/height).
-   Panes hold their tiled content rect through the beat; exit promotion uses a
-   FLIP transform, while siblings travel to/from their corresponding outer edge.
-   clears in one commit that snaps the destination to ordinary full-bleed at
-   visually identical bounds. Timing constants + the per-beat plan live in
-   workspaceView.js (MODE_MOTION / deriveExit·EnterPlan). Shell writes each
-   participant's duration/delay and projection-derived transform variables inline. */
-.shell {
-  /* Cubic-out keeps long edge travel readable without the ballistic first frames
-     that made panes appear to brake into the shared seam. */
-  --ease-mode-arrive: cubic-bezier(0.33, 1, 0.68, 1);
-  --ease-mode-leave: cubic-bezier(0.4, 0, 0.7, 0.2);
-  /* Chrome (dividers + strips) leads the panes with a faster, front-loaded curve so
-     structure simplifies first (exit) / resolves after the focused card (entry). */
-  --ease-mode-chrome: cubic-bezier(0.2, 0.8, 0.2, 1);
-  /* The promote FLIP reads with more MASS than the light deal-out cards: a slower
-     middle and a clean, non-overshooting landing, so a half-pane grows to full-bleed
-     without racing ahead of its still-opaque siblings. */
-  --ease-mode-promote: cubic-bezier(0.2, 0.82, 0.2, 1);
+/* ── Native mode scene transition ───────────────────────────────────────────
+   Standard ↔ Builder is captured as two settled scenes. The old Standard scene
+   stays perfectly still while new pane snapshots assemble; the new Standard scene
+   is already settled beneath panes that disassemble. Snapshot preparation is
+   therefore invisible, live chats never animate their own layout, and every pane
+   uses the one document timeline started by useModeViewTransition.
+
+   All snapshots are opt-in from opacity:0. Pane/content snapshots, the stationary
+   workspace, and the foreground navigation are enabled by Web Animations. Divider
+   snapshots deliberately remain at zero, appearing only with the final resting
+   Builder DOM. */
+html[data-mode-view-transition] {
+  view-transition-name: none;
+}
+html[data-mode-view-transition] .shell__content {
+  view-transition-name: mode-workspace;
+}
+html[data-mode-view-transition] [data-mode-pane-vt] {
+  view-transition-name: var(--mode-vt-name);
+}
+html[data-mode-view-transition] .shell__bar {
+  view-transition-name: mode-navigation-bar;
+}
+html[data-mode-view-transition] .drawer--open {
+  view-transition-name: mode-navigation-drawer;
+}
+html[data-mode-view-transition]::view-transition-group(*) {
+  animation: none;
+}
+/* Captured panes cross the workspace edge, but navigation is the foreground
+   boundary exactly as it is at rest. These groups therefore sit above every
+   moving pane snapshot instead of letting left panes paint over the rail/drawer. */
+html[data-mode-view-transition]::view-transition-group(mode-navigation-bar) {
+  z-index: 100;
+}
+html[data-mode-view-transition]::view-transition-group(mode-navigation-drawer) {
+  z-index: 95;
+}
+html[data-mode-view-transition]::view-transition-image-pair(*) {
+  isolation: isolate;
+}
+html[data-mode-view-transition]::view-transition-old(*),
+html[data-mode-view-transition]::view-transition-new(*) {
+  animation: none;
+  mix-blend-mode: normal;
+  opacity: 0;
 }
 
 /* A content wrapper (app iframe or PaneChatView) that is the active tab of a
    VISIBLE pane. Shell writes its rect inline (top/left/width/height from the
    pane's content rect); this clears the base `.shell__view` inset:0 so the
    inline width/height win, and makes it visible + interactive. Everything else
-   keeps the full-bleed hidden pattern. NO geometry transition lives here (v2
-   deletes the 180ms bloom): a divider drag writes rects imperatively per frame
-   and mode beats animate transform only, so an interpolated layout property would
-   only race those and resize live iframes. Discrete layout commits snap. */
+   keeps the full-bleed hidden pattern. */
 .shell__view--paned {
   right: auto;
   bottom: auto;
   visibility: visible;
   pointer-events: auto;
 }
-
-/* The stationary single-world destination beneath an assemble or scatter beat.
-   The already-mounted target sits full-bleed from the first frame. */
-.shell__view--exit-underlay {
-  inset: 0;
-  visibility: visible;
-  pointer-events: none;
-  z-index: 0;
-}
-
-/* Promote: the survivor pane keeps its tiled content rect and FLIPs to cover the
-   full destination (transform-origin at its own top-left; Shell latches --flip-*
-   from the projection, never a DOM read). Its OWN curve (--ease-mode-promote) gives
-   it more mass than the deal-out cards — a slower middle, no overshoot — so it does
-   not consume the screen before the siblings have visibly departed. */
-.shell--builder-exiting
-.shell__view[data-mode-motion="promote"] {
-  z-index: 2;
-  transform-origin: 0 0;
-  animation:
-    shell-mode-promote
-    var(--mode-duration)
-    var(--ease-mode-promote)
-    both;
-}
-
-/* Deal-out: each pane scatters toward its corresponding outer edge in one short,
-   simultaneous beat. The offsets come from the pure projection — no DOM reads. */
-.shell--builder-exiting
-.shell__view[data-mode-motion="deal-out"] {
-  z-index: 4;
-  pointer-events: none;
-  animation:
-    shell-mode-deal-out
-    var(--mode-duration)
-    var(--ease-mode-leave)
-    var(--mode-delay, 0ms)
-    both;
-}
-
-/* Deal-in is the directional inverse, but deliberately NOT a crossfade: each pane
-   arrives fully painted from its edge and physically covers the stationary single
-   screen beneath it. Fading from zero exposed chrome before content and made the
-   two worlds look like separate transitions. */
-.shell--builder-entering
-.shell__view[data-mode-motion="deal-in"] {
-  z-index: 2;
-  animation:
-    shell-mode-deal-in
-    var(--mode-duration)
-    var(--ease-mode-arrive)
-    var(--mode-delay, 0ms)
-    both;
-}
-
-@keyframes shell-mode-promote {
-  from {
-    transform: translate3d(0, 0, 0) scale(1, 1);
-  }
-  to {
-    transform:
-      translate3d(var(--flip-x), var(--flip-y), 0)
-      scale(var(--flip-sx), var(--flip-sy));
-  }
-}
-
-@keyframes shell-mode-deal-out {
-  from { transform: translate3d(0, 0, 0); opacity: 1; }
-  to {
-    transform: translate3d(var(--mode-offset-x), var(--mode-offset-y), 0);
-    opacity: 0;
-  }
-}
-
-@keyframes shell-mode-deal-in {
-  from {
-    transform: translate3d(var(--mode-offset-x), var(--mode-offset-y), 0);
-  }
-  to { transform: translate3d(0, 0, 0); }
-}
-
-/* Strips move WITH their pane, replacing the deleted parent-chrome opacity fade.
-   A sibling (deal-out) strip uses the exact motion + delay of its pane; a survivor
-   (promote) strip clears upward over a fast 100ms chrome curve; an entering strip
-   shares its pane's deal-in. `.shell__tabstrip` matches BOTH the single-pane top nav
-   and the per-pane WorkspaceChrome strips — they never coexist, so the one selector
-   is correct for either surface. */
-.shell--builder-exiting .shell__tabstrip[data-mode-motion="deal-out"] {
-  animation:
-    shell-mode-deal-out var(--mode-duration) var(--ease-mode-leave)
-    var(--mode-delay, 0ms) both;
-}
-.shell--builder-exiting .shell__tabstrip[data-mode-motion="promote"] {
-  animation: shell-mode-strip-clear 100ms var(--ease-mode-chrome) both;
-}
-.shell--builder-entering .shell__tabstrip[data-mode-motion="deal-in"] {
-  animation:
-    shell-mode-deal-in var(--mode-duration) var(--ease-mode-arrive)
-    var(--mode-delay, 0ms) both;
-}
-@keyframes shell-mode-strip-clear {
-  from { transform: translate3d(0, 0, 0); opacity: 1; }
-  to { transform: translate3d(0, -6px, 0); opacity: 0; }
-}
-
-/* Dividers simplify first on exit, then resolve only over the LAST 70ms of
-   entry. The stationary underlay's strip follows the same rule:
-   structure cannot appear over the old screen before the panes themselves arrive.
-   Opacity-only; small elements. */
-.shell--builder-exiting .workspace__divider {
-  pointer-events: none;
-  animation: shell-mode-chrome-out 90ms var(--ease-mode-chrome) both;
-}
-.shell--builder-entering .shell__tabstrip:not([data-mode-motion]),
-.shell--builder-entering .workspace__divider {
-  animation:
-    shell-mode-chrome-in 70ms var(--ease-mode-chrome)
-    calc(var(--mode-total, 240ms) - 70ms) both;
-}
-@keyframes shell-mode-chrome-out { from { opacity: 1; } to { opacity: 0; } }
-@keyframes shell-mode-chrome-in { from { opacity: 0; } to { opacity: 1; } }
 
 /* The chrome layer — sibling after the content wrappers, over the whole content
    box, transparent to pointers except its own interactive children. */
@@ -180,9 +80,8 @@
   pointer-events: auto;
   padding-inline-end: 0;
   border-radius: 8px 8px 0 0;
-  /* No geometry transition (v2): a divider drag writes strip rects imperatively
-     per frame and a mode beat animates the strip's transform, so an interpolated
-     top/left would only race those. Discrete layout commits snap with the pane. */
+  /* Divider drag writes strip rectangles imperatively per frame; resting geometry
+     therefore stays discrete and never interpolates layout properties. */
   /* Strips sit ABOVE dividers (z:4): a horizontal divider's 44px hit target
      overlaps the top of the strip in the pane below it, and a divider above the
      strip stole the top half of those tabs. The divider's VISUAL bar lives in
@@ -545,10 +444,4 @@
   /* Reduced motion: instant geometry + color, no fade or morph (design §3.3). */
   .workspace__drop-preview { transition: none; }
   .workspace__drop-preglow { transition: none; }
-  /* Reduced motion never arms a mode descriptor (the controller commits directly),
-     so nothing carries data-mode-motion; this is defensive parity — any element
-     that somehow did gets no beat. Covers wrappers, strips, and dividers. */
-  .shell [data-mode-motion] { animation: none !important; }
-  .shell--builder-exiting .workspace__divider,
-  .shell--builder-entering .workspace__divider { animation: none; }
 }

--- a/frontend/src/components/Shell/workspaceView.js
+++ b/frontend/src/components/Shell/workspaceView.js
@@ -15,11 +15,10 @@
 // clearing it re-derives the ordinary multi-pane view with no remount.
 
 import * as paneModel from './paneModel.js'
-import * as tabModel from './tabModel.js'
 
 // The presentation key for a null single-screen slot (round 4 item 3). The persisted
 // slot stays `null` — adding a `{kind:'new-chat'}` variant would only invent migration
-// + sanitizer work — but for RENDERING and for the exit target/underlay, null now maps
+// + sanitizer work — but for RENDERING, null now maps
 // to this first-class New Chat landing rather than the freshest chat. `singleScreenRoute`
 // still reports {view:'chat', chatId:null}; only the render surface changes.
 export const EMPTY_SINGLE_SURFACE_KEY = 'home:new-chat'
@@ -49,64 +48,19 @@ export function projectFocusedPane(baseProjection, workspace, paneId, contentRec
   }
 }
 
-// ── Mode-transition motion (exit-presentation v2) ────────────────────────────
-// The presentation module owns the timing + the pure plan builders; the state
-// machine (modeMachine.js) treats a plan as OPAQUE data. A beat is described by a
-// latched plan of participants and their compositor-only motions — never a role
-// enum the machine has to grow a branch for. A future destination surface needs
-// only a target adapter here plus renderer support; the machine is unchanged.
-//
-// Timing (ms). Constants live here, NOT in the machine, so the reconcile clock
-// (INV 14) and the missing-target fallback (INV 13) reason about the plan's own
-// totalMs rather than a fixed per-phase maximum. Mode changes are intentionally one
-// short beat using only compositor transforms + opacity. Every participant in a
-// direction shares one progress clock: coordinated interface motion matters more
-// than equalizing raw pixels-per-millisecond across differently sized panes.
+// ── Mode scene motion ────────────────────────────────────────────────────────
+// Timing and geometry are the only mode-animation facts the React render needs.
+// The browser captures settled scenes and owns their lifetime; this module merely
+// says where each pane snapshot begins/ends.
 export const MODE_MOTION = Object.freeze({
-  enterItemMs: 240,
-  exitItemMs: 180,
-  promoteMs: 210,
+  slideMs: 320,
   logoReleaseMs: 90,
 })
 
-// The slack a visibility-return reconcile allows past the plan's totalMs before it
-// force-completes a beat whose animationend never arrived (hidden tab, throttled
-// rAF). Not a correctness timer — nothing fires it on its own; it is a pure
-// comparison against startedAt at the reconcile boundary (INV 14).
-export const RECONCILE_SLACK_MS = 250
-
-// The CSS animation-names each phase's completion listens for. Kept beside the
-// keyframes so a name typo is caught by one grep. Strip-clear + chrome fades are
-// deliberately ABSENT: they are shorter and must not gate completion.
-export const PROMOTE_NAME = 'shell-mode-promote'
-export const DEAL_OUT_NAME = 'shell-mode-deal-out'
-export const DEAL_IN_NAME = 'shell-mode-deal-in'
-
-// A pane's CONTENT rect is its pane rect minus the strip row on top — the same
-// geometry the tiled render positions the wrapper into (see visibleTabRects).
-function contentRectOfPane(rect) {
-  return { x: rect.x, y: rect.y + paneModel.STRIP_H, w: rect.w, h: Math.max(0, rect.h - paneModel.STRIP_H) }
-}
-
-// The FLIP the promote pane runs: it stays at its tiled content rect and
-// transforms to cover the full destination. Computed ONCE from the projection
-// authority (never DOM reads) and latched, so a mid-beat layout change cannot jerk
-// a live transform (INV 5/10) — a snapshot mismatch cancels instead.
-function flipTo(from, dest) {
-  return {
-    x: -from.x,
-    y: -from.y,
-    sx: from.w ? dest.w / from.w : 1,
-    sy: from.h ? dest.h / from.h : 1,
-  }
-}
-
-// Push a pane just beyond the nearest outer edges, following its vector away from
-// the workspace centre. A left/right split therefore travels horizontally, a
-// top/bottom split vertically, and a corner pane diagonally. The resulting motion
-// reads as one assembled surface rather than four unrelated card transitions.
-// Values are projection-derived and latched with the plan — no DOM measurement.
-function edgeOffset(rect, bounds, directionRect = rect) {
+// Point a pane completely beyond its nearest outer edges, following its vector
+// away from the workspace centre. This is the minimum off-screen vector for that
+// pane, used directly by the captured scene.
+function offscreenVector(rect, bounds, directionRect = rect) {
   // Shell's live contentRect is intentionally just {w, h}; projection rects are
   // already content-local. Tests and other pure callers may include an origin,
   // so accept both shapes without ever emitting an invalid `NaNpx` CSS variable.
@@ -130,33 +84,6 @@ function edgeOffset(rect, bounds, directionRect = rect) {
   return { x, y }
 }
 
-// A normal one-leaf builder uses the flow tab strip outside .shell__content, so
-// its wrapper already fills the content box. A focused pane is also a one-leaf
-// projection, but its WorkspaceChrome strip remains inside the pane. Projection
-// metadata makes that structural difference explicit instead of inferring it from
-// leaf count alone.
-function paintedContentRect(leaf, projection, leafCount) {
-  return (leafCount > 1 || projection.focusedPaneView)
-    ? contentRectOfPane(leaf.rect)
-    : leaf.rect
-}
-
-// The concrete surface key SINGLE mode will paint after this exit — the slot, the New
-// Chat landing (an explicit null slot, round 4 item 3), or (legacy absent-slot blob)
-// the value the SAME SET_VIEW_MODE transaction will seed from the focused item. A
-// Settings-focused legacy seed still resolves to null. The one classification input.
-function exitTargetKey(ws) {
-  // An INITIALIZED slot: a concrete chat/app key, or the New Chat landing when null.
-  // Null now means a definite New Chat destination — never the freshest chat.
-  if ('singleScreen' in ws) return paneModel.singleScreenKey(ws) || EMPTY_SINGLE_SURFACE_KEY
-  const seed = paneModel.focusedSlotSeed(ws)
-  if (!seed) return null
-  return seed.kind === 'app' ? `app:${seed.id}` : `chat:${seed.id}`
-}
-
-// The currently-painted visible leaves (paneId + active key + pane rect), in the
-// order the projection lists them. The membership + active keys are the topology
-// facts the snapshot signature latches; any change cancels the beat (INV 10).
 function visibleLeafDescriptors(workspace, projection) {
   const out = []
   for (const paneId of projection.visibleLeaves) {
@@ -176,209 +103,27 @@ function visibleLeafDescriptors(workspace, projection) {
   return out
 }
 
-// The effective destination single mode will ACTUALLY paint on completion, given the
-// tree's slot plus the two live overlay states (M2). A suspended Settings takeover
-// paints full-bleed OVER the slot (reveal to Settings); a retained immersive holder
-// that solos the exit slot is an INSTANT destination (full-viewport, header gone) the
-// beat cannot honestly latch. Both the exit PLAN and the exit SIGNATURE classify
-// through THIS one function from the SAME input, so an overlay input can never change
-// the plan's destination without also changing its invalidation key (INV 10 / H2).
-function classifyExitDestination({ workspace, settingsDestination = false, immersiveHolderId = null }) {
-  const slotTarget = exitTargetKey(workspace)
-  const immersiveInstant = !settingsDestination
-    && immersiveHolderId != null
-    && slotTarget === `app:${immersiveHolderId}`
-  const target = settingsDestination ? tabModel.SETTINGS_TAB_KEY : slotTarget
-  return { target, immersiveInstant }
-}
-
-// The immutable invalidation key for either directional beat. INVARIANT (INV 10 /
-// H2): it incorporates EVERY input deriveExitPlan / deriveEnterPlan uses — visible
-// pane keys and rects, content bounds, and the effective destination (including live
-// Settings/immersive state). The controller recomputes it and cancels on ANY drift;
-// otherwise a live layout commit could move wrappers underneath stale FLIP/edge
-// transforms. New destination inputs belong in classifyExitDestination, shared by
-// this signature and both plan builders, never in one alone.
-export function transitionSignature(input) {
-  const { workspace, projection, contentRect } = input
-  const { target, immersiveInstant } = classifyExitDestination(input)
-  const leaves = visibleLeafDescriptors(workspace, projection)
-    .map((l) => {
-      const painted = `${l.rect.x},${l.rect.y},${l.rect.w},${l.rect.h}`
-      if (l.motionRect === l.rect) return `${l.paneId}=${l.activeKey}@${painted}`
-      const motion = `${l.motionRect.x},${l.motionRect.y},${l.motionRect.w},${l.motionRect.h}`
-      return `${l.paneId}=${l.activeKey}@${painted}~${motion}`
-    })
-  const x = Number.isFinite(contentRect.x) ? contentRect.x : 0
-  const y = Number.isFinite(contentRect.y) ? contentRect.y : 0
-  return `${target || ''}|${immersiveInstant ? 'i' : ''}|${leaves.join(',')}`
-    + `|${x},${y},${contentRect.w}x${contentRect.h}`
-}
-
-// Sort by visual reading order (top, then left) of the pane rect.
-function byVisualOrder(a, b) {
-  if (a.rect.y !== b.rect.y) return a.rect.y - b.rect.y
-  return a.rect.x - b.rect.x
-}
-
-// deriveExitPlan(input) → the latched exit plan, or null when the beat is instant (an
-// empty tree — nothing painted to deal out — or an immersive-instant destination).
-// `input` is { workspace, projection, contentRect, settingsDestination?,
-// immersiveHolderId? }; the SAME object is fed to transitionSignature so the plan
-// and its invalidation key can never disagree about the destination (INV 10 / H2).
-//
-// Classification (exit-design v1 §exit-classification, honored by v2):
-//   - an APP target that is the active key of a VISIBLE leaf → promote that leaf
-//     (physical continuity), deal every sibling out, no underlay.
-//   - a CHAT target always has a separate Standard-world surface owner. Reveal
-//     that stationary full-bleed owner and deal out EVERY Builder chat pane,
-//     including the same underlying chat. Sharing one ChatView between the two
-//     geometries makes its composer/scroll controller resize at the mode boundary.
-//   - target is inactive-in-a-pane, tree-absent, the New Chat landing (an empty single
-//     slot, round 4 item 3), or null → WORLD REVEAL: deal every painted leaf out over
-//     the mounted destination (underlayKey = target; null = the opaque background only
-//     for a legacy Settings-focused absent-slot). Never promote the focused pane to
-//     manufacture a correspondence single mode will not paint.
-export function deriveExitPlan(input) {
-  const { workspace, projection, contentRect, settingsDestination = false } = input
-  const leaves = visibleLeafDescriptors(workspace, projection)
-  if (leaves.length === 0) return null // empty tree → instant flip, no descriptor
-  // HONEST DESTINATION (M2): what single mode will ACTUALLY paint on completion — the
-  // tree's slot re-classified by the live overlays — never the slot the tree seeds
-  // beneath a takeover/immersive-solo (else the takeover/immersive pops over the
-  // promoted-or-revealed slot at completion, breaking the "visually identical
-  // completion" contract). The exit signature reads the SAME classifier (H2).
-  //   - An immersive holder that solos the exit slot is a full-viewport INSTANT the
-  //     beat cannot honestly latch while the header is still painted and the mode is
-  //     still 'panes'. An honest instant beats a false animation that jumps at
-  //     completion, so classify it instant (return null).
-  const { target, immersiveInstant } = classifyExitDestination(input)
-  if (immersiveInstant) return null
-  //   - A suspended Settings takeover paints full-bleed OVER the slot → world reveal
-  //     to the mounted-hidden Settings surface (part-2 F3), never the slot the
-  //     takeover then covers (target = SETTINGS_TAB_KEY). modeMachine stays ignorant
-  //     of what Settings means; the underlayKey just names the destination wrapper.
-  const dest = { x: 0, y: 0, w: contentRect.w, h: contentRect.h }
-  const independentChatTarget = !!target?.startsWith('chat:')
-  // A Settings destination is always a world reveal (never a promote), even if a
-  // builder Settings tab happens to be a visible leaf.
-  const promoteLeaf = (target && !settingsDestination && !independentChatTarget)
-    ? leaves.find(l => l.activeKey === target)
+// The native mode transition moves settled pane snapshots, not live surfaces.
+// Every visible pane begins one small gap beyond its own outer edges and lands on
+// the same linear clock. Keeping the minimum pane-owned vector makes first contact
+// with the viewport consistent across unequal layouts.
+export function deriveModeSnapshotPlan({ workspace, projection, contentRect }) {
+  if (!workspace || !projection || !contentRect) return null
+  const offsets = {}
+  for (const leaf of visibleLeafDescriptors(workspace, projection)) {
+    offsets[leaf.paneId] = offscreenVector(
+      leaf.rect,
+      contentRect,
+      leaf.motionRect,
+    )
+  }
+  return Object.keys(offsets).length > 0
+    ? { offsets, totalMs: MODE_MOTION.slideMs }
     : null
-
-  const participants = []
-  const completionNames = new Set()
-  let underlayKey = null
-
-  if (promoteLeaf) {
-    // FLIP the promote pane from its ACTUAL wrapper geometry to the full box. At a
-    // single visible leaf the strip is a flex SIBLING outside .shell__content, so the
-    // sole wrapper already fills the content box — its rect IS the destination, an
-    // identity FLIP with no STRIP_H inset. At >=2 leaves the WorkspaceChrome strips
-    // sit INSIDE the pane rect, so the wrapper is inset by STRIP_H. Insetting the
-    // single-leaf case (contentRectOfPane) overshot the FLIP (y:-STRIP_H, sy>1) and
-    // snapped back when the strip unmounted (M4).
-    const siblings = leaves.filter(l => l !== promoteLeaf).sort(byVisualOrder)
-    const fromRect = paintedContentRect(promoteLeaf, projection, leaves.length)
-    participants.push({
-      key: promoteLeaf.activeKey,
-      paneId: promoteLeaf.paneId,
-      motion: 'promote',
-      delayMs: 0,
-      durationMs: MODE_MOTION.promoteMs,
-      flip: flipTo(fromRect, dest),
-    })
-    completionNames.add(PROMOTE_NAME)
-    // Siblings deal out in visual order beneath the promoting pane.
-    siblings.forEach((l) => {
-      participants.push({
-        key: l.activeKey, paneId: l.paneId, motion: 'deal-out',
-        delayMs: 0, durationMs: MODE_MOTION.exitItemMs,
-        offset: edgeOffset(l.rect, contentRect, l.motionRect),
-      })
-    })
-    if (siblings.length) completionNames.add(DEAL_OUT_NAME)
-  } else {
-    // World reveal: every painted leaf deals out together over the stationary target.
-    underlayKey = target // null = home reveal (opaque --bg background)
-    // The underlay is the stationary DESTINATION, so a visible leaf that IS the
-    // underlay (a builder Settings tab equal to the takeover destination) never
-    // also deals out. For an ordinary tree-absent chat/app slot this filters
-    // nothing — it was not a visible leaf, or the promote branch would have claimed
-    // it. If it leaves nothing to deal out (destination is the sole surface), the
-    // beat has no honest motion → instant flip.
-    const ordered = leaves
-      .filter(l => independentChatTarget || l.activeKey !== target)
-      .sort(byVisualOrder)
-    if (ordered.length === 0) return null
-    ordered.forEach((l) => {
-      participants.push({
-        key: l.activeKey, paneId: l.paneId, motion: 'deal-out',
-        delayMs: 0, durationMs: MODE_MOTION.exitItemMs,
-        offset: edgeOffset(l.rect, contentRect, l.motionRect),
-      })
-    })
-    completionNames.add(DEAL_OUT_NAME)
-  }
-
-  const totalMs = participants.reduce((m, p) => Math.max(m, p.delayMs + p.durationMs), 0)
-  return {
-    kind: 'exit',
-    target,
-    destinationRect: dest,
-    participants,
-    underlayKey,
-    completionNames: [...completionNames],
-    totalMs,
-    snapshotSignature: transitionSignature(input),
-  }
-}
-
-// deriveEnterPlan(input) → the latched entry plan, or null when there is nothing
-// to assemble. The single-screen surface remains the live, stationary full-bleed
-// underlay while visible panes gather from their nearest outer edge. Chat targets
-// have independent Standard/Builder surface owners, so EVERY Builder pane gathers
-// (including the matching chat) and fully covers the stationary Standard surface.
-// App/Settings targets still share one mounted surface and therefore exclude that
-// target leaf from the incoming set.
-//
-export function deriveEnterPlan(input) {
-  const { workspace, projection, contentRect } = input
-  const leaves = visibleLeafDescriptors(workspace, projection).sort(byVisualOrder)
-  if (leaves.length === 0) return null
-  const { target, immersiveInstant } = classifyExitDestination(input)
-  if (immersiveInstant) return null
-  const destinationRect = { x: 0, y: 0, w: contentRect.w, h: contentRect.h }
-  const participants = []
-  const completionNames = new Set()
-  const underlayKey = target
-  const independentChatTarget = !!target?.startsWith('chat:')
-  const incoming = leaves.filter(l => independentChatTarget || l.activeKey !== target)
-  if (incoming.length === 0) return null
-  for (const l of incoming) {
-    participants.push({
-      key: l.activeKey, paneId: l.paneId, motion: 'deal-in',
-      delayMs: 0,
-      durationMs: MODE_MOTION.enterItemMs,
-      offset: edgeOffset(l.rect, contentRect, l.motionRect),
-    })
-    completionNames.add(DEAL_IN_NAME)
-  }
-  const totalMs = participants.reduce((m, p) => Math.max(m, p.delayMs + p.durationMs), 0)
-  return {
-    kind: 'enter',
-    target,
-    destinationRect,
-    participants,
-    underlayKey,
-    completionNames: [...completionNames],
-    totalMs,
-    snapshotSignature: transitionSignature(input),
-  }
 }
 
 // deriveContentVisibility({ workspace, projection, settingsOverlayOpen,
-// immersiveActive, immersiveAppId, viewMode, exitUnderlayKey }) → the render flags.
+// immersiveActive, immersiveAppId, viewMode }) → the render flags.
 //
 // `settingsOverlayOpen` is ONLY the full-workspace Settings TAKEOVER overlay
 // (single mode / flag off) — NOT "the focused content is Settings". In builder
@@ -402,7 +147,7 @@ export function deriveEnterPlan(input) {
 // control silently inert whenever the owner happens to be in Builder mode.
 export function deriveContentVisibility({
   workspace, projection, settingsOverlayOpen, immersiveActive, immersiveAppId,
-  viewMode = 'panes', exitUnderlayKey = null, focusedPaneView = false,
+  viewMode = 'panes', focusedPaneView = false,
 }) {
   const multiPane = projection.visibleLeaves.length >= 2
   const builder = viewMode !== 'single'
@@ -477,15 +222,6 @@ export function deriveContentVisibility({
       visibleAppIds = paneModel.visibleAppIds(workspace, [workspace.focusedPaneId])
     }
   } else visibleAppIds = paneModel.visibleAppIds(workspace, projection.visibleLeaves)
-  // EXIT-BEAT UNDERLAY (exit-presentation v2): a WORLD-REVEAL exit paints the
-  // already-mounted destination full-bleed BENEATH the dealing-out tree while the
-  // effective mode is still 'panes'. Its app is not a visible tree pane, so union
-  // it in here — otherwise the underlay would show a blank frame. A chat/home
-  // underlay contributes no app id; Shell paints the chat wrapper directly.
-  if (exitUnderlayKey && exitUnderlayKey.startsWith('app:')) {
-    visibleAppIds = new Set(visibleAppIds)
-    visibleAppIds.add(exitUnderlayKey.slice('app:'.length))
-  }
   // Chat panes stay MOUNTED (no remount on overlay/view toggle) but hidden while a
   // takeover owns the box. In an ordinary builder world and single-mode they
   // paint; the renderer additionally gates each NON-focused single-mode chat pane
@@ -494,10 +230,10 @@ export function deriveContentVisibility({
   return {
     // `settingsOverlay` is the EFFECTIVE-mode-gated takeover flag (finding F3): it
     // is the one honest "is the Settings takeover painting NOW" signal — false in
-    // builder AND during a single-mode drag preview / exit beat (viewMode='panes').
+    // builder AND during a single-mode drag preview (viewMode='panes').
     // Shell's PAINT gates read THIS, not the committed-gated nav flag, so the tiled
     // world paints with the takeover suspended exactly as the flags above assume.
     multiPane, single, focusedActiveKey, chromeActive, fullBleedKey, visibleAppIds,
-    chatPanesVisible, settingsOverlay, exitUnderlayKey,
+    chatPanesVisible, settingsOverlay,
   }
 }

--- a/tests/mode-transition.spec.mjs
+++ b/tests/mode-transition.spec.mjs
@@ -89,138 +89,46 @@ function unevenThreePaneBuilder(slot) {
   return paneModel.setSingleScreen(ws, slot)
 }
 
-// Frame-sample the exit beat: on every animation frame while .shell--builder-exiting
-// is present, record each motion wrapper's LAYOUT box (offset*, transform-independent)
-// + its computed transform + a stable node marker. Start this BEFORE triggering the
-// toggle so the first exit frame is captured.
-async function sampleExitBeat(page) {
+// Capture the custom pseudo-element animations created for one native View
+// Transition. The live DOM commits immediately; the moving surfaces are browser
+// snapshots, so the durable contract lives on the document timeline rather than
+// transient wrapper classes or transforms.
+async function sampleSceneTransition(page) {
   return page.evaluate(async () => {
-    const root = document.querySelector('.shell')
-    const byKey = new Map() // data-tab-key → { boxes:Set, transforms:Set, node }
-    let started = false
-    let dualClass = false
-    let underlaySeen = false
-    await new Promise((resolve) => {
-      let frames = 0
-      const tick = () => {
-        const cls = root.className
-        if (cls.includes('shell--builder-entering') && cls.includes('shell--builder-exiting')) dualClass = true
-        const exiting = cls.includes('shell--builder-exiting')
-        if (exiting) {
-          started = true
-          if (document.querySelector('.shell__view--exit-underlay')) underlaySeen = true
-          for (const el of document.querySelectorAll('.shell__view[data-mode-motion]')) {
-            const key = el.getAttribute('data-tab-key') || el.dataset.modeMotion
-            let rec = byKey.get(key)
-            if (!rec) {
-              rec = {
-                boxes: new Set(), transforms: new Set(), node: el,
-                motion: el.dataset.modeMotion,
-                offsetX: parseFloat(el.style.getPropertyValue('--mode-offset-x')) || 0,
-                offsetY: parseFloat(el.style.getPropertyValue('--mode-offset-y')) || 0,
-              }
-              byKey.set(key, rec)
-            }
-            rec.boxes.add(`${el.offsetWidth}x${el.offsetHeight}@${el.offsetLeft},${el.offsetTop}`)
-            rec.transforms.add(getComputedStyle(el).transform)
-          }
-        }
-        frames += 1
-        if ((started && !exiting) || frames > 90) { resolve(); return }
-        requestAnimationFrame(tick)
-      }
-      requestAnimationFrame(tick)
-    })
-    const wrappers = [...byKey.entries()].map(([key, r]) => ({
-      key,
-      // Motion attributes and variables clear with the descriptor, so report the
-      // values latched on the first sampled frame rather than reading the idle DOM.
-      motion: r.motion,
-      offsetX: r.offsetX,
-      offsetY: r.offsetY,
-      distinctBoxes: r.boxes.size,
-      distinctTransforms: r.transforms.size,
-      transformsMatrix: [...r.transforms].every(t => t === 'none' || t.startsWith('matrix')),
-      survived: r.node.isConnected,
-    }))
-    return { started, dualClass, underlaySeen, wrappers }
-  })
-}
-
-// Capture the latched inline geometry on the first frame of either directional
-// beat. These are the pure projection outputs that tell each pane which edge owns it.
-async function captureBeatPlan(page, rootClass) {
-  return page.evaluate(async (wantedClass) => {
-    const root = document.querySelector('.shell')
-    for (let frames = 0; frames < 120; frames += 1) {
-      if (root.classList.contains(wantedClass)) {
-        const participants = [...document.querySelectorAll('.shell__view[data-mode-motion]')]
-          .map(el => ({
-            key: el.getAttribute('data-tab-key'),
-            motion: el.dataset.modeMotion,
-            x: parseFloat(el.style.getPropertyValue('--mode-offset-x')) || 0,
-            y: parseFloat(el.style.getPropertyValue('--mode-offset-y')) || 0,
-            duration: parseFloat(el.style.getPropertyValue('--mode-duration')) || 0,
-            delay: parseFloat(el.style.getPropertyValue('--mode-delay')) || 0,
-          }))
-        if (participants.length) {
-          return {
-            participants,
-            underlay: !!document.querySelector('.shell__view--exit-underlay'),
-          }
-        }
-      }
+    let direction = null
+    let records = []
+    for (let frames = 0; frames < 180; frames += 1) {
+      direction ||= document.documentElement.dataset.modeViewTransition || null
+      const animations = document.documentElement.getAnimations({ subtree: true })
+      records = animations.flatMap((animation) => {
+        const effect = animation.effect
+        const pseudo = effect?.pseudoElement || ''
+        if (!pseudo.startsWith('::view-transition-')) return []
+        const frames = effect.getKeyframes?.() || []
+        return [{
+          pseudo,
+          startTime: animation.startTime,
+          duration: effect.getTiming?.().duration,
+          frames: frames.map(frame => ({
+            opacity: frame.opacity ?? null,
+            transform: frame.transform ?? null,
+          })),
+        }]
+      })
+      if (direction && records.some(record => record.pseudo.includes('mode-pane-'))) break
       await new Promise(resolve => requestAnimationFrame(resolve))
     }
-    return { participants: [], underlay: false }
-  }, rootClass)
+    return { direction, records }
+  })
 }
 
-// Sample the actual entry paint order. Incoming panes must remain fully opaque so
-// they cover the retained single screen physically, while structure-only chrome
-// (dividers/chip) stays absent during the first half of the travel.
-async function sampleEnterPaint(page) {
-  return page.evaluate(async () => {
-    const root = document.querySelector('.shell')
-    let started = false
-    let minPaneOpacity = 1
-    let earlyChromeOpacity = 0
-    let paneFrames = 0
-    await new Promise((resolve) => {
-      let frames = 0
-      const tick = () => {
-        const entering = root.classList.contains('shell--builder-entering')
-        if (entering) {
-          started = true
-          const panes = [...document.querySelectorAll(
-            '.shell__view[data-mode-motion="deal-in"]',
-          )]
-          if (panes.length) {
-            paneFrames += 1
-            for (const pane of panes) {
-              minPaneOpacity = Math.min(minPaneOpacity, parseFloat(getComputedStyle(pane).opacity))
-            }
-            const progress = panes[0].getAnimations()[0]?.effect?.getComputedTiming?.().progress
-            if (progress != null && progress < 0.5) {
-              for (const chrome of document.querySelectorAll(
-                '.workspace__divider',
-              )) {
-                earlyChromeOpacity = Math.max(
-                  earlyChromeOpacity,
-                  parseFloat(getComputedStyle(chrome).opacity),
-                )
-              }
-            }
-          }
-        }
-        frames += 1
-        if ((started && !entering) || frames > 120) { resolve(); return }
-        requestAnimationFrame(tick)
-      }
-      requestAnimationFrame(tick)
-    })
-    return { started, minPaneOpacity, earlyChromeOpacity, paneFrames }
-  })
+function paneAnimations(scene, side) {
+  return scene.records.filter(record => record.pseudo.startsWith(`::view-transition-${side}(mode-pane-`))
+}
+
+function translation(frame) {
+  const match = /translate3d\((-?[\d.]+)px,\s*(-?[\d.]+)px/.exec(frame?.transform || '')
+  return match ? { x: Number(match[1]), y: Number(match[2]) } : { x: 0, y: 0 }
 }
 
 // Focus the brand toggle and flip the mode via the keyboard path.
@@ -236,13 +144,11 @@ async function builderActive(page) {
 // Start recording any frame where BOTH beat classes coexist (INV 1 violation).
 async function armOneBeatObserver(page) {
   await page.evaluate(() => {
-    const root = document.querySelector('.shell')
+    const root = document.documentElement
     window.__modeViolations = []
     window.__modeObs = new MutationObserver(() => {
-      const c = root.className
-      if (c.includes('shell--builder-entering') && c.includes('shell--builder-exiting')) {
-        window.__modeViolations.push(c)
-      }
+      const direction = root.dataset.modeViewTransition
+      if (direction && direction !== 'enter' && direction !== 'exit') window.__modeViolations.push(direction)
     })
     window.__modeObs.observe(root, { attributes: true, attributeFilter: ['class'] })
   })
@@ -269,8 +175,7 @@ async function openNavigation(page) {
 
 async function transientClassCount(page) {
   return page.evaluate(() => {
-    const c = document.querySelector('.shell').className
-    return ['shell--builder-entering', 'shell--builder-exiting'].filter(k => c.includes(k)).length
+    return document.documentElement.dataset.modeViewTransition ? 1 : 0
   })
 }
 
@@ -384,248 +289,93 @@ for (const [name, viewport] of [
 // stay constant while their transforms animate, and the same nodes must survive.
 const WIDE = { width: 1280, height: 900 }
 
-test('v3 scatter is compositor-only: layout boxes constant while transforms animate, nodes survive', async ({ page }) => {
-  // Standard and Builder now retain independent owners even for the same chat.
-  // The full-bleed Standard owner remains underneath while both Builder pane
-  // owners deal toward their durable edges.
+test('captured Builder panes scatter toward their durable edges on one timeline', async ({ page }) => {
   await bootSeededWorkspace(page, WIDE, twoPaneBuilder({ kind: 'chat', id: 'aaa' }))
-  await expect.poll(() => builderActive(page)).toBe(true)
-  await expect(page.locator('.workspace__strip')).toHaveCount(2)
-  const sampler = sampleExitBeat(page)
-  await page.waitForTimeout(30) // let the rAF sampler install before the toggle
+  const sampler = sampleSceneTransition(page)
+  await page.waitForTimeout(30)
   await toggleMode(page)
-  const r = await sampler
-  expect(r.started, 'an exit beat ran').toBe(true)
-  expect(r.dualClass, 'INV 1: never both beat classes at once').toBe(false)
-  expect(r.wrappers.length, 'the participant wrappers were sampled').toBeGreaterThanOrEqual(2)
-  // INV 5 (compositor-only): every participant's computed LAYOUT box (offset*,
-  // transform-independent) stayed constant across the whole beat.
-  for (const w of r.wrappers) expect(w.distinctBoxes, 'layout box constant during the beat').toBe(1)
-  // Only transform/opacity animated — every observed transform is a matrix (or none),
-  // and at least one participant's transform actually CHANGED across frames.
-  for (const w of r.wrappers) expect(w.transformsMatrix, 'only matrix transforms').toBe(true)
-  expect(r.wrappers.some(w => w.distinctTransforms > 1), 'a transform animated').toBe(true)
-  const departing = r.wrappers.filter(w => w.motion === 'deal-out')
-  expect(departing).toHaveLength(2)
-  expect(departing.some(w => w.offsetX < 0 && w.offsetY === 0),
-    'the left Builder owner scatters toward the left edge').toBe(true)
-  expect(departing.some(w => w.offsetX > 0 && w.offsetY === 0),
-    'the right Builder owner scatters toward the right edge').toBe(true)
-  // INV 4 (stable identity): the same DOM nodes survived completion.
-  for (const w of r.wrappers) expect(w.survived, 'same node survives completion').toBe(true)
-  // The beat settled clean.
+  const scene = await sampler
+  const panes = paneAnimations(scene, 'old')
+  expect(scene.direction).toBe('exit')
+  expect(panes).toHaveLength(2)
+  const destinations = panes.map(record => translation(record.frames.at(-1)))
+  expect(destinations.some(({ x, y }) => x < 0 && y === 0), 'left pane scatters left').toBe(true)
+  expect(destinations.some(({ x, y }) => x > 0 && y === 0), 'right pane scatters right').toBe(true)
+  expect(new Set(panes.map(record => record.startTime)).size, 'one shared start time').toBe(1)
+  expect(new Set(panes.map(record => record.duration)).size, 'one shared duration').toBe(1)
+  expect(panes.every(record => record.frames.every(frame => frame.opacity === 1 || frame.opacity === '1')),
+    'captured panes remain opaque').toBe(true)
   await expect.poll(() => modePhase(page), { timeout: 2000 }).toBe('idle')
   await expect.poll(() => builderActive(page)).toBe(false)
 })
 
-test('focused pane retains its durable edge during a mode exit', async ({ page }) => {
-  // Standard targets left chat aaa; focus the right builder pane bbb before exit.
-  // The focused presentation is centred/full-size, but its durable pane identity
-  // is still RIGHT, so it must leave right and fully clear the viewport—not fall
-  // back to the old arbitrary top exit.
+test('focused pane retains its durable right edge during a mode exit', async ({ page }) => {
   await bootSeededWorkspace(page, WIDE, twoPaneBuilder({ kind: 'chat', id: 'aaa' }))
-  await expect.poll(() => builderActive(page)).toBe(true)
-  await page.locator('[data-pane-strip="p1"]')
-    .getByRole('button', { name: 'Focus pane' }).click()
+  await page.locator('[data-pane-strip="p1"]').getByRole('button', { name: 'Focus pane' }).click()
   await expect(page.locator('[data-pane-strip]')).toHaveCount(1)
   const content = await page.locator('.shell__content').boundingBox()
-
-  const sampler = captureBeatPlan(page, 'shell--builder-exiting')
-  await page.waitForTimeout(30)
+  const sampler = sampleSceneTransition(page)
   await toggleMode(page)
-  const r = await sampler
-  expect(r.underlay, 'the left Standard chat is ready beneath the focused pane').toBe(true)
-  expect(r.participants).toHaveLength(1)
-  expect(r.participants[0].motion).toBe('deal-out')
-  expect(r.participants[0].x, 'a full-size focused pane clears beyond the right edge')
-    .toBeGreaterThan(content.width)
-  expect(r.participants[0].y).toBe(0)
-  await expect.poll(() => modePhase(page), { timeout: 2000 }).toBe('idle')
+  const scene = await sampler
+  const panes = paneAnimations(scene, 'old')
+  expect(panes).toHaveLength(1)
+  const destination = translation(panes[0].frames.at(-1))
+  expect(destination.x).toBeGreaterThan(content.width)
+  expect(destination.y).toBe(0)
 })
 
-test('v3 world-reveal scatter paints the mounted destination underlay beneath the panes', async ({ page }) => {
-  // slot === a tree-absent chat → WORLD REVEAL: every painted pane deals out over the
-  // mounted underlay (INV 3 honest destination), no false promotion.
+test('captured panes assemble from corresponding edges and land together', async ({ page }) => {
+  await bootSeededWorkspace(page, WIDE, unevenThreePaneBuilder({ kind: 'chat', id: 'ghost' }))
+  await toggleMode(page)
+  await expect.poll(() => modePhase(page)).toBe('idle')
+  const sampler = sampleSceneTransition(page)
+  await toggleMode(page)
+  const scene = await sampler
+  const panes = paneAnimations(scene, 'new')
+  expect(scene.direction).toBe('enter')
+  expect(panes).toHaveLength(3)
+  const origins = panes.map(record => translation(record.frames[0]))
+  expect(origins.some(({ x, y }) => x < 0 && y === 0), 'a pane enters from the left').toBe(true)
+  expect(origins.some(({ x }) => x > 0), 'a pane enters from the right').toBe(true)
+  expect(panes.every(record => translation(record.frames.at(-1)).x === 0
+    && translation(record.frames.at(-1)).y === 0), 'all panes land in place').toBe(true)
+  expect(new Set(panes.map(record => record.startTime)).size, 'every pane starts together').toBe(1)
+  expect(new Set(panes.map(record => record.duration)).size, 'every pane lands together').toBe(1)
+  await expect.poll(() => builderActive(page)).toBe(true)
+})
+
+test('world reveal keeps the ready Standard snapshot stationary beneath scattering panes', async ({ page }) => {
   await bootSeededWorkspace(page, WIDE, twoPaneBuilder({ kind: 'chat', id: 'ghost' }))
-  await expect.poll(() => builderActive(page)).toBe(true)
-  const sampler = sampleExitBeat(page)
-  await page.waitForTimeout(30)
+  const sampler = sampleSceneTransition(page)
   await toggleMode(page)
-  const r = await sampler
-  expect(r.started).toBe(true)
-  expect(r.underlaySeen, 'the reveal underlay was painted beneath the deal').toBe(true)
-  // Every participant deals out (a transform animates) with a constant layout box.
-  for (const w of r.wrappers) {
-    expect(w.distinctBoxes).toBe(1)
-    expect(w.transformsMatrix).toBe(true)
-  }
-  expect(r.wrappers.some(w => w.distinctTransforms > 1)).toBe(true)
-  await expect.poll(() => modePhase(page), { timeout: 2000 }).toBe('idle')
-})
-
-test('v3 panes assemble from their corresponding edges on one coordinated beat', async ({ page }) => {
-  await bootSeededWorkspace(page, WIDE, twoPaneBuilder({ kind: 'chat', id: 'ghost' }))
-  await toggleMode(page)
-  await expect.poll(() => modePhase(page), { timeout: 2000 }).toBe('idle')
+  const scene = await sampler
+  const panes = paneAnimations(scene, 'old')
+  const workspace = scene.records.find(record => record.pseudo === '::view-transition-new(mode-workspace)')
+  expect(panes).toHaveLength(2)
+  expect(workspace, 'the destination workspace has an explicit snapshot animation').toBeTruthy()
+  expect(workspace.frames.every(frame => frame.opacity === 1 || frame.opacity === '1')).toBe(true)
+  expect(workspace.frames.every(frame => !frame.transform || frame.transform === 'none'),
+    'the destination snapshot stays still').toBe(true)
+  expect(workspace.startTime, 'destination and panes share one clock').toBe(panes[0].startTime)
+  expect(workspace.duration).toBe(panes[0].duration)
   await expect.poll(() => builderActive(page)).toBe(false)
-
-  const sampler = captureBeatPlan(page, 'shell--builder-entering')
-  const paintSampler = sampleEnterPaint(page)
-  await page.waitForTimeout(30)
-  await toggleMode(page)
-  const r = await sampler
-  const paint = await paintSampler
-  expect(r.underlay, 'the current single screen remains beneath the assembly').toBe(true)
-  expect(r.participants).toHaveLength(2)
-  expect(r.participants.every(p => p.motion === 'deal-in')).toBe(true)
-  expect(r.participants.some(p => p.x < 0 && p.y === 0), 'left pane enters from left').toBe(true)
-  expect(r.participants.some(p => p.x > 0 && p.y === 0), 'right pane enters from right').toBe(true)
-  expect(paint.started).toBe(true)
-  expect(paint.paneFrames).toBeGreaterThan(2)
-  expect(paint.minPaneOpacity, 'pane content never fades in over visible structure').toBeGreaterThan(0.99)
-  expect(paint.earlyChromeOpacity, 'structure waits until pane content has arrived').toBeLessThan(0.05)
-  await expect.poll(() => modePhase(page), { timeout: 2000 }).toBe('idle')
-  await expect.poll(() => builderActive(page)).toBe(true)
 })
 
-test('uneven panes start and land together on one coordinated progress clock', async ({ page }) => {
-  await bootSeededWorkspace(
-    page,
-    WIDE,
-    unevenThreePaneBuilder({ kind: 'chat', id: 'ghost' }),
-  )
-  await toggleMode(page)
-  await expect.poll(() => modePhase(page), { timeout: 2000 }).toBe('idle')
-  await expect.poll(() => builderActive(page)).toBe(false)
-
-  const sampler = captureBeatPlan(page, 'shell--builder-entering')
-  await page.waitForTimeout(30)
-  await toggleMode(page)
-  const r = await sampler
-
-  expect(r.participants).toHaveLength(3)
-  expect(r.participants.every(p => p.delay === 0),
-    'every pane starts on the same frame').toBe(true)
-  const arrivals = r.participants.map(p => p.delay + p.duration)
-  expect(new Set(arrivals).size, 'all panes land on the same frame').toBe(1)
-  expect(new Set(r.participants.map(p => p.duration)).size,
-    'every pane shares one progress duration').toBe(1)
-  await expect.poll(() => modePhase(page), { timeout: 2000 }).toBe('idle')
-  await expect.poll(() => builderActive(page)).toBe(true)
-})
-
-test('shared Standard chat stays still while both Builder owners assemble above it', async ({ page }) => {
-  // slot === the focused LEFT pane's chat. Standard keeps a separate full-bleed
-  // owner, so neither Builder owner borrows or transforms that DOM: both pane
-  // owners assemble above it and Standard retires only after the beat.
+test('shared Standard chat stays stationary while both captured Builder owners assemble above it', async ({ page }) => {
   await bootSeededWorkspace(page, WIDE, twoPaneBuilder({ kind: 'chat', id: 'aaa' }))
   await toggleMode(page)
-  await expect.poll(() => modePhase(page), { timeout: 2000 }).toBe('idle')
-  await expect.poll(() => builderActive(page)).toBe(false)
-
-  const sampler = page.evaluate(async () => {
-    const root = document.querySelector('.shell')
-    let started = false
-    let minUnderlayOpacity = 1
-    const underlayTransforms = new Set()
-    const participants = []
-    await new Promise(resolve => {
-      let frames = 0
-      const tick = () => {
-        const entering = root.classList.contains('shell--builder-entering')
-        if (entering) {
-          started = true
-          const underlay = document.querySelector('.shell__view--exit-underlay')
-          if (underlay) {
-            const style = getComputedStyle(underlay)
-            minUnderlayOpacity = Math.min(minUnderlayOpacity, parseFloat(style.opacity))
-            underlayTransforms.add(style.transform)
-          }
-          if (participants.length === 0) {
-            for (const pane of document.querySelectorAll(
-              '.shell__view[data-mode-motion="deal-in"]',
-            )) {
-              participants.push({
-                x: parseFloat(pane.style.getPropertyValue('--mode-offset-x')) || 0,
-                y: parseFloat(pane.style.getPropertyValue('--mode-offset-y')) || 0,
-              })
-            }
-          }
-        }
-        frames += 1
-        if ((started && !entering) || frames > 120) { resolve(); return }
-        requestAnimationFrame(tick)
-      }
-      requestAnimationFrame(tick)
-    })
-    return {
-      started,
-      minUnderlayOpacity,
-      underlayTransforms: [...underlayTransforms],
-      participants,
-    }
-  })
-  await page.waitForTimeout(30)
+  await expect.poll(() => modePhase(page)).toBe('idle')
+  const sampler = sampleSceneTransition(page)
   await toggleMode(page)
-  const r = await sampler
-
-  expect(r.started).toBe(true)
-  expect(r.underlayTransforms, 'the Standard chat never scales or translates').toEqual(['none'])
-  expect(r.minUnderlayOpacity, 'the Standard chat never fades').toBeGreaterThanOrEqual(0.99)
-  expect(r.participants).toHaveLength(2)
-  expect(r.participants.some(p => p.x < 0 && p.y === 0),
-    'the left Builder owner enters from the left edge').toBe(true)
-  expect(r.participants.some(p => p.x > 0 && p.y === 0),
-    'the right Builder owner enters from the right edge').toBe(true)
-  await expect.poll(() => modePhase(page), { timeout: 2000 }).toBe('idle')
+  const scene = await sampler
+  const panes = paneAnimations(scene, 'new')
+  const workspace = scene.records.find(record => record.pseudo === '::view-transition-old(mode-workspace)')
+  expect(panes).toHaveLength(2)
+  expect(workspace).toBeTruthy()
+  expect(workspace.frames.every(frame => !frame.transform || frame.transform === 'none')).toBe(true)
+  expect(workspace.frames.every(frame => frame.opacity === 1 || frame.opacity === '1')).toBe(true)
+  expect(workspace.startTime).toBe(panes[0].startTime)
   await expect.poll(() => builderActive(page)).toBe(true)
-})
-
-// Frame-sample the destination across a world reveal. It is ready and stationary
-// beneath one short leftward departure; there is no delayed second phase.
-async function sampleStationaryUnderlay(page) {
-  return page.evaluate(async () => {
-    const root = document.querySelector('.shell')
-    let started = false
-    let cardsPresent = false
-    let minOpacity = 1
-    const transforms = new Set()
-    await new Promise((resolve) => {
-      let frames = 0
-      const tick = () => {
-        const exiting = root.className.includes('shell--builder-exiting')
-        const underlay = document.querySelector('.shell__view--exit-underlay')
-        if (exiting && underlay) {
-          started = true
-          const style = getComputedStyle(underlay)
-          minOpacity = Math.min(minOpacity, parseFloat(style.opacity))
-          transforms.add(style.transform)
-          const cards = [...document.querySelectorAll('.shell__view[data-mode-motion="deal-out"]')]
-          cardsPresent ||= cards.some(c => parseFloat(getComputedStyle(c).opacity) > 0.05)
-        }
-        frames += 1
-        if ((started && !exiting && frames > 4) || frames > 240) { resolve(); return }
-        requestAnimationFrame(tick)
-      }
-      requestAnimationFrame(tick)
-    })
-    return { started, cardsPresent, minOpacity, transforms: [...transforms] }
-  })
-}
-
-test('world reveal is one short scatter over a stationary, ready destination', async ({ page }) => {
-  await bootSeededWorkspace(page, WIDE, twoPaneBuilder({ kind: 'chat', id: 'ghost' }))
-  await expect.poll(() => builderActive(page)).toBe(true)
-  const sampler = sampleStationaryUnderlay(page)
-  await page.waitForTimeout(30)
-  await toggleMode(page)
-  const r = await sampler
-  expect(r.started, 'a world-reveal exit ran').toBe(true)
-  expect(r.cardsPresent, 'departing panes painted above the destination').toBe(true)
-  expect(r.minOpacity, 'the destination never waits behind a veil').toBeGreaterThanOrEqual(0.99)
-  expect(r.transforms, 'the destination itself stays still').toEqual(['none'])
-  await expect.poll(() => modePhase(page), { timeout: 2000 }).toBe('idle')
-  await expect.poll(() => builderActive(page)).toBe(false)
 })
 
 test('reduced motion has no intermediate exit phase (instant world flip)', async ({ page }) => {
@@ -639,8 +389,7 @@ test('reduced motion has no intermediate exit phase (instant world flip)', async
     await new Promise((resolve) => {
       let frames = 0
       const tick = () => {
-        if (root.className.includes('shell--builder-exiting')
-          || document.querySelector('.shell__view--exit-underlay')) sawExitPhase = true
+        if (document.documentElement.dataset.modeViewTransition) sawExitPhase = true
         frames += 1
         if (frames > 60) { resolve(); return }
         requestAnimationFrame(tick)
@@ -840,7 +589,7 @@ async function sampleLogoBeat(page) {
       let frames = 0
       const tick = () => {
         const cls = root.className
-        const beatClass = cls.includes('shell--builder-entering') || cls.includes('shell--builder-exiting')
+        const beatClass = !!document.documentElement.dataset.modeViewTransition
         if (beatClass) sawBeatClass = true
         if (brand.classList.contains('is-beat-held')) {
           beatHeldSeen = true
@@ -933,13 +682,10 @@ test('round4-1: reduced motion keeps direct hold feedback but releases without a
   await bootSeededWorkspace(page, WIDE, twoPaneBuilder({ kind: 'chat', id: 'aaa' }))
   await expect.poll(() => builderActive(page)).toBe(true)
   await page.evaluate(() => {
-    const root = document.querySelector('.shell')
+    const root = document.documentElement
     window.__reducedMotionBeatSeen = false
     window.__reducedMotionObserver = new MutationObserver(() => {
-      const cls = root.className
-      if (cls.includes('shell--builder-entering') || cls.includes('shell--builder-exiting')) {
-        window.__reducedMotionBeatSeen = true
-      }
+      if (root.dataset.modeViewTransition) window.__reducedMotionBeatSeen = true
     })
     window.__reducedMotionObserver.observe(root, { attributes: true, attributeFilter: ['class'] })
   })

--- a/tests/mode-transition.spec.mjs
+++ b/tests/mode-transition.spec.mjs
@@ -95,10 +95,12 @@ function unevenThreePaneBuilder(slot) {
 // transient wrapper classes or transforms.
 async function sampleSceneTransition(page) {
   return page.evaluate(async () => {
+    const initialDirection = document.documentElement.dataset.modeViewTransition || null
     let direction = null
     let records = []
     for (let frames = 0; frames < 180; frames += 1) {
-      direction ||= document.documentElement.dataset.modeViewTransition || null
+      const currentDirection = document.documentElement.dataset.modeViewTransition || null
+      if (currentDirection && currentDirection !== initialDirection) direction ||= currentDirection
       const animations = document.documentElement.getAnimations({ subtree: true })
       records = animations.flatMap((animation) => {
         const effect = animation.effect
@@ -579,8 +581,6 @@ async function pressHoldLogo(page, holdMs = 650) {
 async function sampleLogoBeat(page) {
   return page.evaluate(async () => {
     const root = document.querySelector('.shell')
-    const brand = document.querySelector('.shell__brand')
-    const logo = document.querySelector('.shell__logo')
     let beatHeldSeen = false
     let minScale = 1
     let epochMismatch = false
@@ -588,10 +588,11 @@ async function sampleLogoBeat(page) {
     await new Promise((resolve) => {
       let frames = 0
       const tick = () => {
-        const cls = root.className
         const beatClass = !!document.documentElement.dataset.modeViewTransition
         if (beatClass) sawBeatClass = true
-        if (brand.classList.contains('is-beat-held')) {
+        const brand = document.querySelector('.shell__brand')
+        const logo = document.querySelector('.shell__logo')
+        if (brand?.classList.contains('is-beat-held')) {
           beatHeldSeen = true
           const s = parseFloat(getComputedStyle(logo).scale)
           if (Number.isFinite(s)) minScale = Math.min(minScale, s)
@@ -605,7 +606,7 @@ async function sampleLogoBeat(page) {
       }
       requestAnimationFrame(tick)
     })
-    const settledScale = parseFloat(getComputedStyle(logo).scale)
+    const settledScale = parseFloat(getComputedStyle(document.querySelector('.shell__logo')).scale)
     return { beatHeldSeen, minScale, epochMismatch, sawBeatClass, settledScale }
   })
 }


### PR DESCRIPTION
## Summary

- capture Standard and Builder as settled browser scenes instead of resizing live chat and app layouts during motion
- move panes and tab strips on one 320ms linear timeline while leaving dividers outside the scene
- keep navigation in the foreground above travelling panes
- remove the transition planner, underlay roles, CSS animation controller, animation watchers, and recovery timer

## Prior work

This is a distinct follow-up to #164 and #199. Those changes improved coordination of the live wrapper choreography. This replaces that animation owner entirely: React commits the final workspace once, then the browser moves captured pane pixels without resizing retained chats during visible motion.

It also preserves the idle-work isolation from #231 by keeping beat-local values on the small header subtree rather than the shell ancestor.

## Validation

- frontend unit and hook suites
- production frontend and service-worker build