### PR TITLE
Honor planned restart continuation for app-started chats

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -803,22 +803,26 @@ presentation, never restart-cause evidence.
 | Event | Durable result | Boot/sweep result |
 |-------|----------------|-------------------|
 | Provider usage/rate limit | exact run `parked` until reset | notify; continue if the usage policy is on |
-| Accepted planned restart, exact park + boot nonce match | exact run `parked`, reason `restart`, nonce, due now | continue immediately if the restart policy is on |
+| Accepted planned restart, exact park + boot nonce match | exact run `parked`, reason `restart`, nonce, due now | continue immediately if the restart policy is on; preserve app attribution unless newer owner input takes over |
 | Accepted planned restart, stop/finalize did not settle | exact latest run remains `running` with the authenticated nonce | finalize partials, convert to due restart park, then continue in the same pre-yield pass |
 | Crash/OOM before supervisor acknowledgement | unacknowledged park or generic `running` evidence | resolve/reconcile to manual resumable interruption |
 | Repeated/unrelated boot before claim | acknowledgement is retired by boot-id mismatch | manual resumable interruption |
-| Policy off, unanswered question, app-owned run, or app-queued work | due park resolves without an automatic send | notify/manual owner action |
+| Policy off, unanswered question, or app work queued after the parked run | due park resolves without an automatic send | notify/manual owner action |
 | Owner sends, switches provider, deletes the chat, or a newer run wins | old park is superseded by the existing latest-run fence | no stale continuation |
 | Restart task creation fails after promotion | exact promoted rows roll back; restart park becomes `interrupted` | manual recovery; one-shot cause is not retried |
 
 Eligibility is rechecked under the per-chat transition lock immediately before
 promotion. Provider-limit retries are staggered one at a time; an authenticated
 planned restart restores the exact set that was already concurrent, so its
-eligible batch may start together. The provider still receives a synthetic user
-`continue`, but the durable row is tagged `kind="auto_continuation"` with reason
-`restart` or `usage_limit`; the UI, copy behavior, title selection, time
-context, compaction, provider-switch handoff, chat-note summarization, and
-redacted chat logs treat it as a product marker rather than owner speech.
+eligible batch may start together. An app-initiated restart continuation carries
+the same app id into the next durable run unless a newer owner send is already
+queued and becomes the next run's actor; provider-limit retries remain
+owner-only, and app work queued after a park is never absorbed. The provider
+still receives a synthetic user `continue`, but the durable row is tagged
+`kind="auto_continuation"` with reason `restart` or `usage_limit`; the UI, copy
+behavior, title selection, time context, compaction, provider-switch handoff,
+chat-note summarization, and redacted chat logs treat it as a product marker
+rather than owner speech.
 
 The sweep is cheap: one indexed due-row query immediately at boot, on
 `chat_run_finished`, and on a 60-second fallback. Startup captures the boot

--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -2768,8 +2768,11 @@ async def _auto_resume_chat(
               .first()
             )
             latest_id = latest[0] if latest is not None else None
+            restart_park = (
+              park is not None and park.park_reason == "restart"
+            )
             restart_authorized = True
-            if park is not None and park.park_reason == "restart":
+            if restart_park:
               if restart_authorization is _RESTART_AUTHORIZATION_UNSET:
                 from app.restart_ledger import authorized_restart_nonce
                 accepted_nonce = authorized_restart_nonce()
@@ -2796,7 +2799,13 @@ async def _auto_resume_chat(
               or _has_unanswered_question(chat)
               or park is None
               or park.status != "resume_pending"
-              or park.initiated_by_app_id is not None
+              # Provider-limit retries remain owner-only. A planned restart
+              # instead restores the exact authenticated turn and carries its
+              # app attribution into the synthetic continuation below.
+              or (
+                park.initiated_by_app_id is not None
+                and not restart_park
+              )
               or latest_id != park.id
               or any(
                 isinstance(msg, dict)
@@ -2807,7 +2816,10 @@ async def _auto_resume_chat(
               return False
             current_provider = chat.provider or "claude"
             resume_reason = (
-              "restart" if park.park_reason == "restart" else "usage_limit"
+              "restart" if restart_park else "usage_limit"
+            )
+            resume_app_id = (
+              park.initiated_by_app_id if restart_park else None
             )
           if not mark_starting(chat_id):
             return False
@@ -2830,6 +2842,7 @@ async def _auto_resume_chat(
                   else f"limit-resume-{park_token or chat_id}"
                 ),
               },
+              initiated_by_app_id=resume_app_id,
             )
           )
           await _await_ack(ack)
@@ -2911,11 +2924,14 @@ async def sweep_reset_parks(
     - A park whose chat was deleted resolves silently.
     - Auto-resume is controlled per chat. Provider-limit retries are staggered:
       at most one starts per sweep and launches are spaced even when unrelated
-      chats are live. Planned-restart continuations reclaim the exact set that
-      was already live before the restart, so every eligible chat in the batch
-      may resume independently. A staggered enabled chat stays pending for a
-      later tick, while notify-only chats in the same due batch still resolve
-      normally. App-attributed runs and queues never auto-resume.
+      chats are live. App-attributed provider-limit runs never auto-resume.
+      Planned-restart continuations reclaim the exact set that was already live
+      before the restart, preserve each run's attribution, and may resume
+      independently. A staggered enabled chat stays pending for a later tick,
+      while notify-only chats in the same due batch still resolve normally.
+      App-attributed messages newly queued behind either kind of park still
+      require an ordinary app-owned handoff rather than being swept into the
+      synthetic continuation.
 
   Stands down while draining — a restart is in progress, and the fresh
   process's immediate sweep picks everything up. Never raises.
@@ -3005,11 +3021,13 @@ async def sweep_reset_parks(
     )
     if chat is None or chat.deleted_at is not None:
       return "chat unavailable"
-    if run.initiated_by_app_id is not None or app_work_queued:
+    restart_park = run.park_reason == "restart"
+    if app_work_queued:
+      return "app-attributed work"
+    if run.initiated_by_app_id is not None and not restart_park:
       return "app-attributed work"
     if _has_unanswered_question(chat):
       return "waiting for an answer"
-    restart_park = run.park_reason == "restart"
     policy_enabled = bool(
       chat.auto_resume_on_restart
       if restart_park else chat.auto_resume_on_limit

--- a/backend/tests/test_limit_park.py
+++ b/backend/tests/test_limit_park.py
@@ -140,6 +140,7 @@ def _run_row(token: str):
       "park_reason": run.park_reason,
       "restart_nonce": run.restart_nonce,
       "ended_at": run.ended_at,
+      "initiated_by_app_id": run.initiated_by_app_id,
     }
   finally:
     db.close()
@@ -563,6 +564,7 @@ def test_park_run_strict_tokenless_falls_back_to_marker_clear():
 def _due_park(
   cid: str, token: str, *, pending=None, deleted=False, auto_resume=False,
   auto_restart=True, park_reason=None, messages=None, restart_nonce=None,
+  initiated_by_app_id=None,
 ):
   _seed_chat(
     cid, pending=pending, deleted=deleted, auto_resume=auto_resume,
@@ -571,7 +573,8 @@ def _due_park(
   _seed_run(cid, token, status="parked",
             parked_until=datetime.now(UTC).replace(tzinfo=None)
             - timedelta(minutes=1), park_reason=park_reason,
-            restart_nonce=restart_nonce)
+            restart_nonce=restart_nonce,
+            initiated_by_app_id=initiated_by_app_id)
 
 
 def _run_sweep():
@@ -821,6 +824,133 @@ def test_restart_park_auto_continues_with_product_marker(
     assert marker["cid"] == f"restart-resume-{token}"
     assert notifications[0]["title"] == "Möbius restarted"
     assert "limit" not in notifications[0]["body"].lower()
+  finally:
+    chat_mod.discard_starting(cid)
+
+
+def test_app_initiated_restart_preserves_attribution_and_continues(
+  owner_token, monkeypatch,
+):
+  """The restart policy applies to app chats without losing ownership."""
+  del owner_token
+  monkeypatch.setattr(
+    "app.push.notify_owner", lambda *args, **kwargs: "notif-id",
+  )
+  scheduled = []
+  monkeypatch.setattr(
+    chat_mod, "_schedule_continuation",
+    lambda **kwargs: scheduled.append(kwargs),
+  )
+  cid = "restart-app-attributed"
+  token = f"rt-{cid}"
+  nonce = "restart-nonce-app-attributed"
+  app_id = 42
+  monkeypatch.setattr(
+    "app.restart_ledger.authorized_restart_nonce", lambda: nonce,
+  )
+  _due_park(
+    cid,
+    token,
+    auto_restart=True,
+    park_reason="restart",
+    restart_nonce=nonce,
+    initiated_by_app_id=app_id,
+  )
+
+  try:
+    assert _run_sweep() == [cid]
+    assert len(scheduled) == 1
+    resumed_run = _run_row(scheduled[0]["run_token"])
+    assert resumed_run["initiated_by_app_id"] == app_id
+    marker = scheduled[0]["next_user"]["_messages"][-1]
+    assert marker["kind"] == "auto_continuation"
+    assert marker["continuation_reason"] == "restart"
+  finally:
+    chat_mod.discard_starting(cid)
+
+
+def test_restart_does_not_absorb_newly_queued_app_work(
+  owner_token, monkeypatch,
+):
+  """A restart restores its exact run, not later unattended app messages."""
+  del owner_token
+  notifications = []
+  monkeypatch.setattr(
+    "app.push.notify_owner",
+    lambda *args, **kwargs: notifications.append(kwargs) or "notif-id",
+  )
+  resumes = []
+
+  async def _fake_resume(*args, **kwargs):
+    resumes.append((args, kwargs))
+    return True
+
+  monkeypatch.setattr(chat_mod, "_auto_resume_chat", _fake_resume)
+  cid = "restart-app-work-queued"
+  token = f"rt-{cid}"
+  nonce = "restart-nonce-app-work-queued"
+  monkeypatch.setattr(
+    "app.restart_ledger.authorized_restart_nonce", lambda: nonce,
+  )
+  _due_park(
+    cid,
+    token,
+    auto_restart=True,
+    park_reason="restart",
+    restart_nonce=nonce,
+    pending=[{
+      "role": "user",
+      "content": "new app work",
+      "ts": 3,
+      "_initiated_by_app_id": 42,
+    }],
+  )
+
+  assert _run_sweep() == [cid]
+  assert resumes == []
+  assert _run_row(token)["status"] == "interrupted"
+  assert notifications[0]["title"] == "Möbius restarted"
+
+
+def test_owner_message_queued_after_app_restart_takes_over_attribution(
+  owner_token, monkeypatch,
+):
+  """New owner input outranks the parked app when forming the next run."""
+  del owner_token
+  monkeypatch.setattr(
+    "app.push.notify_owner", lambda *args, **kwargs: "notif-id",
+  )
+  scheduled = []
+  monkeypatch.setattr(
+    chat_mod, "_schedule_continuation",
+    lambda **kwargs: scheduled.append(kwargs),
+  )
+  cid = "restart-app-owner-takeover"
+  token = f"rt-{cid}"
+  nonce = "restart-nonce-app-owner-takeover"
+  monkeypatch.setattr(
+    "app.restart_ledger.authorized_restart_nonce", lambda: nonce,
+  )
+  _due_park(
+    cid,
+    token,
+    auto_restart=True,
+    park_reason="restart",
+    restart_nonce=nonce,
+    initiated_by_app_id=42,
+    pending=[{
+      "role": "user",
+      "content": "owner follow-up",
+      "ts": 3,
+    }],
+  )
+
+  try:
+    assert _run_sweep() == [cid]
+    assert len(scheduled) == 1
+    resumed_run = _run_row(scheduled[0]["run_token"])
+    assert resumed_run["initiated_by_app_id"] is None
+    assert "owner follow-up" in scheduled[0]["next_user"]["content"]
   finally:
     chat_mod.discard_starting(cid)
 


### PR DESCRIPTION
## Summary
- honor **Continue after planned restarts** for app-started chats
- preserve the initiating app on the resumed run unless newer owner input has taken control
- keep provider-limit retries and newly queued app work on their existing manual path

## Why
This follows the authenticated planned-restart boundary introduced in #157, the independent default-on restart policy from #168, and the exact handoff recovery expanded in #304. Those changes retained an older app-attribution exclusion, so an app-started chat could show restart continuation as enabled yet still stop after a planned restart.

This follow-up removes only that stale exception. It does not turn provider-limit retries into background app work or absorb app messages queued after the parked run.

## Safety
Automatic continuation still requires the latest exact restart park, the current boot's supervisor-authenticated nonce, the per-chat restart policy, and no unanswered question. The resumed turn uses the existing pending-message attribution path. A newer owner message becomes the next run's actor; later app work stays manual.

## Testing
- complete backend suite before the final upstream refresh: 3,469 passed, 1 skipped
- focused restart, app-chat, writer, transcript, and proxy suites after the final rebase: 202 passed
- Python compilation and diff checks passed