### PR TITLE
Add MCP connector registry with Settings UI and per-turn provider injection

### DIFF
--- a/backend/app/claude_sdk_runner.py
+++ b/backend/app/claude_sdk_runner.py
@@ -1531,6 +1531,19 @@ async def run_claude_sdk_turn(
     # Passed via --settings as inline JSON.
     _cli_settings = {"ultracode": True} if _ultracode else {"disableWorkflows": True}
     options_kwargs["extra_args"] = {"settings": json.dumps(_cli_settings)}
+    # Owner-registered connectors (Settings → Connectors) ride the SDK's
+    # native mcp_servers option. Read fresh each turn so registry edits
+    # apply without a restart; a registry failure must never break the
+    # turn — the agent just runs without connectors.
+    try:
+      from app.connectors import claude_mcp_servers
+      _connector_servers = claude_mcp_servers(db)
+    except Exception:
+      log.warning("connector injection skipped (registry read failed)",
+                  exc_info=True)
+      _connector_servers = {}
+    if _connector_servers:
+      options_kwargs["mcp_servers"] = _connector_servers
     options = ClaudeAgentOptions(**options_kwargs)
 
     client = ClaudeSDKClient(options)

--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -2452,6 +2452,18 @@ async def run_codex_sdk_turn(
   # and the MOEBIUS_CODEX_MULTI_AGENT kill switch, in _codex_config_overrides().
   codex_bin = shutil.which("codex")
   config_overrides = _codex_config_overrides()
+  # Owner-registered connectors (Settings → Connectors): config overrides
+  # declare the MCP servers; decrypted keys ride env vars (never argv).
+  # Read fresh each turn; a registry failure must never break the turn.
+  try:
+    from app.connectors import codex_config as _connectors_codex_config
+    _connector_overrides, _connector_env = _connectors_codex_config(db)
+  except Exception:
+    log.warning("connector injection skipped (registry read failed)",
+                exc_info=True)
+    _connector_overrides, _connector_env = [], {}
+  config_overrides = config_overrides + _connector_overrides
+  env.update(_connector_env)
   launch_args = _codex_app_server_launch_args(codex_bin, config_overrides)
   config_kwargs: dict[str, Any] = dict(
     codex_bin=codex_bin,

--- a/backend/app/connectors.py
+++ b/backend/app/connectors.py
@@ -1,0 +1,273 @@
+"""Connector registry core: MCP handshake, secret handling, per-turn provider config.
+
+A connector (models.Connector) is a remote streamable-HTTP MCP server the
+owner registered in Settings. This module owns everything the routes and
+the two runners need:
+
+- `handshake()` — add-time/refresh MCP probe (initialize → initialized →
+  tools/list over JSON-RPC), returning the server's advertised name, its
+  tool list, and a chars/4 token estimate of the full schema payload so
+  Settings can show real cost before the owner enables anything.
+- secret encrypt/decrypt — Fernet keyed off the instance secret (same
+  derivation pattern as app-scoped secrets in routes/secrets.py, distinct
+  salt). Plaintext keys never appear in API responses or logs.
+- `claude_mcp_servers()` / `codex_config()` — the per-turn injection
+  surfaces. Both read enabled connectors fresh each turn (registry edits
+  apply on the next turn, no restart). Claude gets the SDK's native
+  `mcp_servers` dict (deferred tool loading is the runtime's default, so
+  idle connectors cost stubs, not schemas). Codex gets `--config`
+  overrides plus env vars carrying the decrypted keys — the standard
+  `bearer_token_env_var` / `env_http_headers` indirection so secrets stay
+  out of argv.
+
+Injection MUST never break a turn: the runner call sites wrap these in
+try/except, and this module keeps per-connector failures local.
+"""
+
+import base64
+import hashlib
+import json
+import logging
+import re
+
+import httpx
+from cryptography.fernet import Fernet, InvalidToken
+
+from app import models
+from app.config import get_settings
+
+log = logging.getLogger(__name__)
+
+MCP_PROTOCOL_VERSION = "2025-06-18"
+_HANDSHAKE_TIMEOUT = 15.0
+_SLUG_RE = re.compile(r"[^a-z0-9_]+")
+
+
+class ConnectorError(Exception):
+  """Handshake or config failure with a partner-presentable message."""
+
+
+# ── Secrets ──────────────────────────────────────────────────────────────
+
+
+def _fernet() -> Fernet:
+  material = f"mobius-connector-secret-v1:{get_settings().secret_key}".encode()
+  key = base64.urlsafe_b64encode(hashlib.sha256(material).digest())
+  return Fernet(key)
+
+
+def encrypt_secret(value: str) -> str:
+  return _fernet().encrypt(value.encode()).decode()
+
+
+def decrypt_secret(token: str) -> str:
+  try:
+    return _fernet().decrypt(token.encode()).decode()
+  except InvalidToken as exc:
+    raise ConnectorError(
+      "Stored key can no longer be decrypted; remove and re-add the connector."
+    ) from exc
+
+
+# ── Naming / sizing (pure helpers, unit-tested) ──────────────────────────
+
+
+def slugify(name: str) -> str:
+  slug = _SLUG_RE.sub("_", name.strip().lower()).strip("_")
+  return slug[:48] or "connector"
+
+
+def estimate_tokens(tools: list) -> int:
+  """chars/4 estimate of what the full tool schemas cost per message."""
+  try:
+    return max(0, len(json.dumps(tools)) // 4)
+  except (TypeError, ValueError):
+    return 0
+
+
+def auth_headers(header_name: str | None, secret: str | None) -> dict[str, str]:
+  """The one pragmatic auth rule: Authorization gets a Bearer prefix
+  unless the pasted value already carries one; custom headers send the
+  value verbatim."""
+  if not header_name or not secret:
+    return {}
+  if header_name.lower() == "authorization" and not secret.startswith("Bearer "):
+    return {header_name: f"Bearer {secret}"}
+  return {header_name: secret}
+
+
+def bare_secret(header_name: str | None, secret: str) -> str:
+  """Codex's bearer_token_env_var adds its own `Bearer ` prefix, so the
+  env var must carry the bare key even if the owner pasted a full value."""
+  if header_name and header_name.lower() == "authorization":
+    return secret.removeprefix("Bearer ")
+  return secret
+
+
+# ── MCP handshake ────────────────────────────────────────────────────────
+
+
+def _parse_rpc_body(response: httpx.Response) -> dict:
+  """A streamable-HTTP server answers a POST with JSON or a short SSE
+  body; either way exactly one JSON-RPC response object is inside."""
+  content_type = response.headers.get("content-type", "")
+  if "text/event-stream" in content_type:
+    for line in response.text.splitlines():
+      if line.startswith("data:"):
+        payload = line[len("data:"):].strip()
+        if payload:
+          return json.loads(payload)
+    raise ConnectorError("Service sent an empty event stream.")
+  try:
+    return response.json()
+  except ValueError as exc:
+    raise ConnectorError("Service did not answer with valid JSON.") from exc
+
+
+async def _rpc(
+  client: httpx.AsyncClient,
+  url: str,
+  headers: dict[str, str],
+  method: str,
+  params: dict | None,
+  rpc_id: int | None,
+) -> dict | None:
+  body: dict = {"jsonrpc": "2.0", "method": method}
+  if params is not None:
+    body["params"] = params
+  if rpc_id is not None:
+    body["id"] = rpc_id
+  response = await client.post(url, json=body, headers=headers)
+  if rpc_id is None:
+    return None  # notification — servers answer 202/204/empty
+  if response.status_code in (401, 403):
+    raise ConnectorError(
+      "The service rejected the key (unauthorized). Check the API key and header."
+    )
+  if response.status_code >= 400:
+    raise ConnectorError(
+      f"The service answered HTTP {response.status_code} to {method}."
+    )
+  parsed = _parse_rpc_body(response)
+  if "error" in parsed:
+    message = str(parsed["error"].get("message", "unknown error"))
+    raise ConnectorError(f"The service reported an error: {message}")
+  return parsed.get("result") or {}
+
+
+async def handshake(
+  url: str, header_name: str | None = None, secret: str | None = None,
+) -> dict:
+  """Probes an MCP server; returns {name, tools, est_tokens}.
+
+  Raises ConnectorError with a partner-presentable message on any failure —
+  the caller decides whether to save anything.
+  """
+  base_headers = {
+    "Accept": "application/json, text/event-stream",
+    "MCP-Protocol-Version": MCP_PROTOCOL_VERSION,
+    **auth_headers(header_name, secret),
+  }
+  try:
+    async with httpx.AsyncClient(
+      timeout=_HANDSHAKE_TIMEOUT, follow_redirects=True,
+    ) as client:
+      init_body = {
+        "protocolVersion": MCP_PROTOCOL_VERSION,
+        "capabilities": {},
+        "clientInfo": {"name": "mobius", "version": "1.0"},
+      }
+      response = await client.post(
+        url,
+        json={"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": init_body},
+        headers=base_headers,
+      )
+      if response.status_code in (401, 403):
+        raise ConnectorError(
+          "The service requires sign-in Möbius can't do yet (or the key is wrong). "
+          "OAuth services arrive in the next phase; API-key services need the key here."
+        )
+      if response.status_code >= 400:
+        raise ConnectorError(
+          f"The service answered HTTP {response.status_code} — not a reachable "
+          "MCP endpoint, or the URL is wrong."
+        )
+      init = _parse_rpc_body(response)
+      if "error" in init:
+        raise ConnectorError(
+          f"The service refused the handshake: {init['error'].get('message', '')}"
+        )
+      session_headers = dict(base_headers)
+      session_id = response.headers.get("mcp-session-id")
+      if session_id:
+        session_headers["Mcp-Session-Id"] = session_id
+      server_info = (init.get("result") or {}).get("serverInfo") or {}
+
+      await _rpc(client, url, session_headers, "notifications/initialized", {}, None)
+      listed = await _rpc(client, url, session_headers, "tools/list", {}, 2)
+      tools = (listed or {}).get("tools") or []
+  except ConnectorError:
+    raise
+  except httpx.HTTPError as exc:
+    raise ConnectorError(f"Could not reach the service: {exc}") from exc
+
+  return {
+    "name": str(server_info.get("title") or server_info.get("name") or "").strip(),
+    "tools": tools,
+    "est_tokens": estimate_tokens(tools),
+  }
+
+
+# ── Per-turn provider config ─────────────────────────────────────────────
+
+
+def _enabled(db) -> list:
+  return (
+    db.query(models.Connector)
+    .filter(models.Connector.enabled.is_(True))
+    .order_by(models.Connector.id)
+    .all()
+  )
+
+
+def claude_mcp_servers(db) -> dict:
+  """The Claude SDK's native `mcp_servers` option: {slug: http config}."""
+  servers: dict[str, dict] = {}
+  for row in _enabled(db):
+    try:
+      config: dict = {"type": "http", "url": row.url}
+      if row.auth_header and row.auth_value_encrypted:
+        config["headers"] = auth_headers(
+          row.auth_header, decrypt_secret(row.auth_value_encrypted)
+        )
+      servers[row.slug] = config
+    except ConnectorError:
+      log.warning("connector %s skipped (secret undecryptable)", row.slug)
+  return servers
+
+
+def codex_config(db) -> tuple[list[str], dict[str, str]]:
+  """Codex `--config` overrides + env vars for enabled connectors.
+
+  Secrets ride env vars (never argv): Authorization keys use codex's
+  bearer_token_env_var; custom headers use env_http_headers, whose inline
+  TOML maps header name -> env var name.
+  """
+  overrides: list[str] = []
+  env: dict[str, str] = {}
+  for row in _enabled(db):
+    try:
+      overrides.append(f'mcp_servers.{row.slug}.url="{row.url}"')
+      if row.auth_header and row.auth_value_encrypted:
+        var = f"MOBIUS_CONNECTOR_{row.slug.upper()}"
+        secret = decrypt_secret(row.auth_value_encrypted)
+        env[var] = bare_secret(row.auth_header, secret)
+        if row.auth_header.lower() == "authorization":
+          overrides.append(f'mcp_servers.{row.slug}.bearer_token_env_var="{var}"')
+        else:
+          overrides.append(
+            f'mcp_servers.{row.slug}.env_http_headers={{"{row.auth_header}" = "{var}"}}'
+          )
+    except ConnectorError:
+      log.warning("connector %s skipped (secret undecryptable)", row.slug)
+  return overrides, env

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -56,6 +56,7 @@ from app import activity, models
 from app.routes import (
   admin_router, apps_router, auth_router,
   chat_embed_router, chat_logs_router, chat_router, chats_router, chats_stream_router,
+  connectors_router,
   debug_router, fs_router, github_router, media_router,
   local_services_router, notifications_router, notify_router, proxy_router, push_router,
   secrets_router, self_reminders_router, settings_router, skills_router,
@@ -1205,6 +1206,7 @@ app.include_router(chat_embed_router)
 app.include_router(chats_router)
 app.include_router(chats_stream_router)
 app.include_router(chat_logs_router)
+app.include_router(connectors_router)
 # App-attributed chat contract (design §1) — a SECOND router defined in
 # routes/chats.py under /api/app-chats, so it's imported directly rather
 # than via routes/__init__'s `_load` (which only returns `.router`).

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -923,3 +923,39 @@ class ContributionAutopilot(Base):
   rounds_json = Column(JSON, nullable=True, default=None)
   created_at = Column(DateTime, default=lambda: now_naive_utc())
   updated_at = Column(DateTime, default=lambda: now_naive_utc())
+
+
+class Connector(Base):
+  """A registered external MCP service injected into agent turns.
+
+  Phase-1 scope: remote streamable-HTTP MCP servers with no auth or a
+  static API key. The key is Fernet-encrypted at rest (same derivation
+  pattern as app secrets, distinct salt); the plaintext never appears in
+  API responses or logs — it is decrypted only when building per-turn
+  provider config. The cached tool list and token estimate come from the
+  add-time MCP handshake so Settings can show what a connector costs
+  before it is enabled.
+  """
+
+  __tablename__ = "connectors"
+
+  id = Column(Integer, primary_key=True)
+  # MCP server key for both providers (claude `mcp_servers` dict key,
+  # codex `mcp_servers.<slug>.*` config path) — lowercase [a-z0-9_].
+  slug = Column(String(64), nullable=False, unique=True)
+  name = Column(String(128), nullable=False)
+  url = Column(Text, nullable=False)
+  # HTTP header carrying the API key. NULL = no auth. "Authorization"
+  # gets a "Bearer " prefix at send time unless the stored value already
+  # carries one; any other header sends the stored value verbatim.
+  auth_header = Column(String(64), nullable=True)
+  auth_value_encrypted = Column(Text, nullable=True)
+  enabled = Column(Boolean, nullable=False, default=True)
+  # Cached tools/list result (list of {name, description}) + a chars/4
+  # token estimate of the full schema payload, refreshed on handshake.
+  tools_json = Column(JSON, nullable=False, default=list)
+  est_tokens = Column(Integer, nullable=False, default=0)
+  status = Column(String(16), nullable=False, default="ok")  # ok | error
+  status_detail = Column(Text, nullable=True)
+  created_at = Column(DateTime, default=lambda: now_naive_utc())
+  last_checked_at = Column(DateTime, nullable=True)

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -58,6 +58,7 @@ chat_embed_router = _load("chat_embed")
 chats_router = _load("chats")
 chats_stream_router = _load("chats_stream")
 chat_logs_router = _load("chat_logs")
+connectors_router = _load("connectors")
 proxy_router = _load("proxy")
 local_services_router = _load("local_services")
 notify_router = _load("notify")
@@ -91,6 +92,7 @@ __all__ = [
   "chats_router",
   "chats_stream_router",
   "chat_logs_router",
+  "connectors_router",
   "proxy_router",
   "local_services_router",
   "notify_router",

--- a/backend/app/routes/connectors.py
+++ b/backend/app/routes/connectors.py
@@ -1,0 +1,208 @@
+"""Connector registry routes: owner-gated CRUD over external MCP services.
+
+Add runs the MCP handshake BEFORE anything is saved — the owner sees the
+tool list and token estimate (or a concrete failure) at review time, and a
+service that can't be reached never becomes a row. Secrets are write-only:
+requests carry them, responses never do (INV mirrors github.py's token
+handling). Registry edits apply on the next agent turn — the runners read
+enabled connectors fresh each turn, so there is nothing to restart.
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from app import connectors as core
+from app import models
+from app.database import get_db
+from app.deps import get_current_owner, reject_cross_site
+from app.timeutil import now_naive_utc
+
+log = logging.getLogger(__name__)
+
+router = APIRouter(
+  prefix="/api/connectors",
+  tags=["connectors"],
+  dependencies=[Depends(reject_cross_site)],
+)
+
+_MAX_CONNECTORS = 32
+
+
+class ConnectorCreate(BaseModel):
+  url: str = Field(min_length=8, max_length=2048)
+  name: str = Field(default="", max_length=128)
+  auth_header: str = Field(default="", max_length=64)
+  auth_value: str = Field(default="", max_length=4096)
+
+
+class ConnectorPatch(BaseModel):
+  enabled: bool | None = None
+  name: str | None = Field(default=None, min_length=1, max_length=128)
+
+
+def _tool_preview(tools: list) -> list[dict]:
+  """Name + first-sentence description only — the full schemas stay
+  server-side; Settings needs the catalog, not the payload."""
+  preview = []
+  for tool in tools[:64]:
+    if isinstance(tool, dict):
+      description = str(tool.get("description") or "")
+      preview.append({
+        "name": str(tool.get("name") or ""),
+        "description": description.split(". ")[0][:160],
+      })
+  return preview
+
+
+def _public(row: models.Connector) -> dict:
+  tools = row.tools_json if isinstance(row.tools_json, list) else []
+  return {
+    "id": row.id,
+    "slug": row.slug,
+    "name": row.name,
+    "url": row.url,
+    "enabled": row.enabled,
+    "has_auth": bool(row.auth_header and row.auth_value_encrypted),
+    "auth_header": row.auth_header,
+    "tool_count": len(tools),
+    "tools": _tool_preview(tools),
+    "est_tokens": row.est_tokens,
+    "status": row.status,
+    "status_detail": row.status_detail,
+    "last_checked_at": (
+      row.last_checked_at.isoformat() if row.last_checked_at else None
+    ),
+  }
+
+
+def _unique_slug(db: Session, base: str) -> str:
+  slug = base
+  suffix = 2
+  while db.query(models.Connector).filter(models.Connector.slug == slug).first():
+    slug = f"{base}_{suffix}"
+    suffix += 1
+  return slug
+
+
+def _get_row(db: Session, connector_id: int) -> models.Connector:
+  row = db.query(models.Connector).filter(
+    models.Connector.id == connector_id
+  ).first()
+  if row is None:
+    raise HTTPException(status_code=404, detail="Connector not found.")
+  return row
+
+
+@router.get("")
+async def list_connectors(
+  owner: models.Owner = Depends(get_current_owner),
+  db: Session = Depends(get_db),
+):
+  rows = db.query(models.Connector).order_by(models.Connector.id).all()
+  return {"connectors": [_public(r) for r in rows]}
+
+
+@router.post("", status_code=201)
+async def add_connector(
+  body: ConnectorCreate,
+  owner: models.Owner = Depends(get_current_owner),
+  db: Session = Depends(get_db),
+):
+  if db.query(models.Connector).count() >= _MAX_CONNECTORS:
+    raise HTTPException(status_code=400, detail="Connector limit reached.")
+  url = body.url.strip()
+  if not url.startswith("https://") and not url.startswith("http://localhost"):
+    raise HTTPException(
+      status_code=400, detail="Connector URLs must use https."
+    )
+  auth_header = body.auth_header.strip() or (
+    "Authorization" if body.auth_value.strip() else ""
+  )
+  auth_value = body.auth_value.strip()
+
+  try:
+    probe = await core.handshake(url, auth_header or None, auth_value or None)
+  except core.ConnectorError as exc:
+    raise HTTPException(status_code=422, detail=str(exc))
+
+  name = body.name.strip() or probe["name"] or url.split("//", 1)[-1].split("/")[0]
+  row = models.Connector(
+    slug=_unique_slug(db, core.slugify(name)),
+    name=name[:128],
+    url=url,
+    auth_header=auth_header or None,
+    auth_value_encrypted=(
+      core.encrypt_secret(auth_value) if auth_header and auth_value else None
+    ),
+    enabled=True,
+    tools_json=probe["tools"],
+    est_tokens=probe["est_tokens"],
+    status="ok",
+    status_detail=None,
+    last_checked_at=now_naive_utc(),
+  )
+  db.add(row)
+  db.commit()
+  db.refresh(row)
+  log.info("connector added: %s (%d tools)", row.slug, len(probe["tools"]))
+  return _public(row)
+
+
+@router.patch("/{connector_id}")
+async def patch_connector(
+  connector_id: int,
+  body: ConnectorPatch,
+  owner: models.Owner = Depends(get_current_owner),
+  db: Session = Depends(get_db),
+):
+  row = _get_row(db, connector_id)
+  if body.enabled is not None:
+    row.enabled = body.enabled
+  if body.name is not None:
+    row.name = body.name.strip()[:128]
+  db.commit()
+  db.refresh(row)
+  return _public(row)
+
+
+@router.post("/{connector_id}/refresh")
+async def refresh_connector(
+  connector_id: int,
+  owner: models.Owner = Depends(get_current_owner),
+  db: Session = Depends(get_db),
+):
+  row = _get_row(db, connector_id)
+  secret = None
+  if row.auth_header and row.auth_value_encrypted:
+    try:
+      secret = core.decrypt_secret(row.auth_value_encrypted)
+    except core.ConnectorError as exc:
+      raise HTTPException(status_code=409, detail=str(exc))
+  try:
+    probe = await core.handshake(row.url, row.auth_header, secret)
+    row.tools_json = probe["tools"]
+    row.est_tokens = probe["est_tokens"]
+    row.status = "ok"
+    row.status_detail = None
+  except core.ConnectorError as exc:
+    row.status = "error"
+    row.status_detail = str(exc)
+  row.last_checked_at = now_naive_utc()
+  db.commit()
+  db.refresh(row)
+  return _public(row)
+
+
+@router.delete("/{connector_id}")
+async def delete_connector(
+  connector_id: int,
+  owner: models.Owner = Depends(get_current_owner),
+  db: Session = Depends(get_db),
+):
+  row = _get_row(db, connector_id)
+  db.delete(row)
+  db.commit()
+  return {"ok": True}

--- a/backend/tests/test_connectors.py
+++ b/backend/tests/test_connectors.py
@@ -1,0 +1,143 @@
+"""Tests for the connector registry core (app.connectors).
+
+Covers the pure/deterministic surfaces the runners and routes lean on:
+
+- the one auth rule (Authorization gets a Bearer prefix, custom headers
+  are verbatim, and codex env vars carry the BARE key because codex adds
+  its own prefix) — asymmetry here would break exactly one provider,
+  which is the worst failure mode to debug;
+- codex --config override formatting (secrets must ride env vars, never
+  argv, and the slug must be the same key claude uses);
+- the SSE-vs-JSON response body tolerance of the handshake parser;
+- secret encrypt/decrypt roundtrip and the friendly failure on garbage.
+"""
+
+import json
+
+import httpx
+import pytest
+
+from app import connectors as core
+from app import models
+
+
+def test_slugify_normalizes_and_bounds():
+  assert core.slugify("Context7 Docs!") == "context7_docs"
+  assert core.slugify("  --  ") == "connector"
+  assert len(core.slugify("x" * 200)) <= 48
+
+
+def test_estimate_tokens_chars_over_four():
+  tools = [{"name": "t", "description": "d" * 396}]
+  assert core.estimate_tokens(tools) == len(json.dumps(tools)) // 4
+  assert core.estimate_tokens([]) == len("[]") // 4
+
+
+def test_auth_headers_bearer_rule():
+  assert core.auth_headers("Authorization", "sk-123") == {
+    "Authorization": "Bearer sk-123"
+  }
+  # Already-prefixed values are not double-prefixed.
+  assert core.auth_headers("Authorization", "Bearer sk-123") == {
+    "Authorization": "Bearer sk-123"
+  }
+  # Custom headers send the pasted value verbatim.
+  assert core.auth_headers("X-Api-Key", "sk-123") == {"X-Api-Key": "sk-123"}
+  assert core.auth_headers(None, "sk-123") == {}
+  assert core.auth_headers("Authorization", None) == {}
+
+
+def test_bare_secret_strips_bearer_only_for_authorization():
+  # codex's bearer_token_env_var adds its own "Bearer " prefix.
+  assert core.bare_secret("Authorization", "Bearer sk-1") == "sk-1"
+  assert core.bare_secret("Authorization", "sk-1") == "sk-1"
+  assert core.bare_secret("X-Api-Key", "Bearer sk-1") == "Bearer sk-1"
+
+
+def test_parse_rpc_body_json_and_sse():
+  json_response = httpx.Response(
+    200, headers={"content-type": "application/json"},
+    text='{"jsonrpc":"2.0","id":1,"result":{}}',
+  )
+  assert core._parse_rpc_body(json_response)["id"] == 1
+
+  sse_response = httpx.Response(
+    200, headers={"content-type": "text/event-stream"},
+    text='event: message\ndata: {"jsonrpc":"2.0","id":2,"result":{}}\n\n',
+  )
+  assert core._parse_rpc_body(sse_response)["id"] == 2
+
+  empty_sse = httpx.Response(
+    200, headers={"content-type": "text/event-stream"}, text="\n\n",
+  )
+  with pytest.raises(core.ConnectorError):
+    core._parse_rpc_body(empty_sse)
+
+
+def test_secret_roundtrip_and_garbage(monkeypatch):
+  token = core.encrypt_secret("sk-value")
+  assert token != "sk-value"
+  assert core.decrypt_secret(token) == "sk-value"
+  with pytest.raises(core.ConnectorError):
+    core.decrypt_secret("not-a-fernet-token")
+
+
+class _FakeQuery:
+  def __init__(self, rows):
+    self._rows = rows
+
+  def filter(self, *args, **kwargs):
+    return self
+
+  def order_by(self, *args, **kwargs):
+    return self
+
+  def all(self):
+    return self._rows
+
+
+class _FakeDb:
+  def __init__(self, rows):
+    self._rows = rows
+
+  def query(self, model):
+    return _FakeQuery(self._rows)
+
+
+def _row(slug, url, auth_header=None, secret=None):
+  row = models.Connector(
+    slug=slug, name=slug, url=url, enabled=True,
+    auth_header=auth_header,
+    auth_value_encrypted=core.encrypt_secret(secret) if secret else None,
+    tools_json=[], est_tokens=0, status="ok",
+  )
+  return row
+
+
+def test_claude_mcp_servers_shapes_http_config():
+  db = _FakeDb([
+    _row("ctx", "https://mcp.example/mcp"),
+    _row("exa", "https://exa.example/mcp", "Authorization", "sk-9"),
+  ])
+  servers = core.claude_mcp_servers(db)
+  assert servers["ctx"] == {"type": "http", "url": "https://mcp.example/mcp"}
+  assert servers["exa"]["headers"] == {"Authorization": "Bearer sk-9"}
+
+
+def test_codex_config_env_indirection_keeps_secrets_out_of_argv():
+  db = _FakeDb([
+    _row("exa", "https://exa.example/mcp", "Authorization", "sk-9"),
+    _row("fire", "https://fire.example/mcp", "X-Api-Key", "fk-1"),
+  ])
+  overrides, env = core.codex_config(db)
+  assert 'mcp_servers.exa.url="https://exa.example/mcp"' in overrides
+  assert 'mcp_servers.exa.bearer_token_env_var="MOBIUS_CONNECTOR_EXA"' in overrides
+  assert env["MOBIUS_CONNECTOR_EXA"] == "sk-9"
+  assert (
+    'mcp_servers.fire.env_http_headers={"X-Api-Key" = "MOBIUS_CONNECTOR_FIRE"}'
+    in overrides
+  )
+  assert env["MOBIUS_CONNECTOR_FIRE"] == "fk-1"
+  # The secret itself must never appear in any override (argv is visible
+  # in process listings).
+  assert not any("sk-9" in o or "fk-1" in o for o in overrides)

--- a/frontend/src/components/SettingsView/ConnectorsSection.jsx
+++ b/frontend/src/components/SettingsView/ConnectorsSection.jsx
@@ -1,0 +1,316 @@
+/* ConnectorsSection — Settings surface for external MCP connectors.
+ *
+ * Owns its own data (list, add, toggle, refresh, remove) against
+ * /api/connectors so SettingsView stays a composer, not an owner. Add
+ * runs the server-side handshake before anything is saved: the owner
+ * sees the tool count and a per-message token estimate (or a concrete
+ * failure) at the moment of adding — cost-before-commit is the design's
+ * rule. A 404/503 from the API means the backend behind this feature
+ * hasn't been loaded yet (restart pending); render that as guidance,
+ * not an error.
+ */
+import { useCallback, useEffect, useState } from 'react'
+import { Alert } from '@openai/apps-sdk-ui/components/Alert'
+import { apiFetch, jsonOrThrow } from '../../api/client.js'
+import StatusDot from '../ui/StatusDot.jsx'
+
+function tokensLabel(estTokens) {
+  if (!estTokens) return null
+  if (estTokens >= 1000) return `~${(estTokens / 1000).toFixed(estTokens >= 10000 ? 0 : 1)}k tokens/msg`
+  return `~${estTokens} tokens/msg`
+}
+
+function connectorStatus(connector) {
+  if (connector.status === 'error') return { color: '--danger', label: 'Unreachable' }
+  if (!connector.enabled) return { color: '--border', label: 'Off' }
+  return { color: '--green', label: 'On' }
+}
+
+export default function ConnectorsSection() {
+  const [connectors, setConnectors] = useState(null) // null = loading
+  const [unavailable, setUnavailable] = useState(false)
+  const [listError, setListError] = useState('')
+
+  const [addOpen, setAddOpen] = useState(false)
+  const [url, setUrl] = useState('')
+  const [usesKey, setUsesKey] = useState(false)
+  const [authValue, setAuthValue] = useState('')
+  const [authHeader, setAuthHeader] = useState('Authorization')
+  const [addPhase, setAddPhase] = useState('idle') // idle | adding
+  const [addError, setAddError] = useState('')
+  const [justAdded, setJustAdded] = useState(null)
+
+  const [confirmRemove, setConfirmRemove] = useState(null)
+  const [busyId, setBusyId] = useState(null)
+
+  const load = useCallback(async () => {
+    setListError('')
+    try {
+      const res = await apiFetch('/api/connectors')
+      if (res.status === 404 || res.status === 503) {
+        setUnavailable(true)
+        setConnectors([])
+        return
+      }
+      const data = await jsonOrThrow(res, 'Could not load connectors')
+      setUnavailable(false)
+      setConnectors(data.connectors || [])
+    } catch (err) {
+      setListError(err.message || 'Could not load connectors')
+      setConnectors([])
+    }
+  }, [])
+
+  useEffect(() => { load() }, [load])
+
+  async function addConnector(event) {
+    event.preventDefault()
+    if (!url.trim() || addPhase === 'adding') return
+    setAddPhase('adding')
+    setAddError('')
+    try {
+      const res = await apiFetch('/api/connectors', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          url: url.trim(),
+          auth_header: usesKey ? authHeader.trim() : '',
+          auth_value: usesKey ? authValue.trim() : '',
+        }),
+      })
+      const row = await jsonOrThrow(res, 'Could not add connector')
+      setConnectors((current) => [...(current || []), row])
+      setJustAdded(row.id)
+      setUrl('')
+      setAuthValue('')
+      setUsesKey(false)
+      setAddOpen(false)
+    } catch (err) {
+      setAddError(err.message || 'Could not add connector')
+    } finally {
+      setAddPhase('idle')
+    }
+  }
+
+  async function patchConnector(connector, body) {
+    setBusyId(connector.id)
+    try {
+      const res = await apiFetch(`/api/connectors/${connector.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      const row = await jsonOrThrow(res, 'Could not update connector')
+      setConnectors((current) => current.map((c) => (c.id === row.id ? row : c)))
+    } catch (err) {
+      setListError(err.message || 'Could not update connector')
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  async function refreshConnector(connector) {
+    setBusyId(connector.id)
+    try {
+      const res = await apiFetch(`/api/connectors/${connector.id}/refresh`, {
+        method: 'POST',
+      })
+      const row = await jsonOrThrow(res, 'Could not re-check connector')
+      setConnectors((current) => current.map((c) => (c.id === row.id ? row : c)))
+    } catch (err) {
+      setListError(err.message || 'Could not re-check connector')
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  async function removeConnector(connector) {
+    setBusyId(connector.id)
+    setConfirmRemove(null)
+    try {
+      const res = await apiFetch(`/api/connectors/${connector.id}`, {
+        method: 'DELETE',
+      })
+      await jsonOrThrow(res, 'Could not remove connector')
+      setConnectors((current) => current.filter((c) => c.id !== connector.id))
+    } catch (err) {
+      setListError(err.message || 'Could not remove connector')
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  return (
+    <section className="settings__section" id="settings-connectors">
+      <h2 className="settings__section-title">Connectors</h2>
+      <p className="settings__subtext settings-connectors__intro">
+        Connected services give every chat extra abilities. Each connector
+        lists what it adds — and roughly what it costs per message — before
+        you enable it.
+      </p>
+
+      {unavailable && (
+        <div className="settings__notice" role="status">
+          Connectors finish setting up after the next server restart
+          (Server → Restart below).
+        </div>
+      )}
+
+      {connectors === null ? (
+        <div className="settings__notice" role="status">Loading connectors…</div>
+      ) : connectors.length === 0 && !unavailable ? (
+        <div className="settings__notice" role="status">
+          No connectors yet. Add a service by its connector address.
+        </div>
+      ) : (
+        <div className="settings-connectors__list">
+          {connectors.map((connector) => {
+            const status = connectorStatus(connector)
+            const tokens = tokensLabel(connector.est_tokens)
+            return (
+              <div className="settings-connectors__row" key={connector.id}>
+                <div className="settings-connectors__main">
+                  <StatusDot color={status.color}>{connector.name}</StatusDot>
+                  <span className="settings-connectors__meta">
+                    {connector.tool_count} tool{connector.tool_count === 1 ? '' : 's'}
+                    {tokens ? ` · ${tokens}` : ''}
+                    {connector.has_auth ? ' · uses a key' : ''}
+                  </span>
+                  {connector.status === 'error' && connector.status_detail && (
+                    <span className="settings-connectors__error">
+                      {connector.status_detail}
+                    </span>
+                  )}
+                  {justAdded === connector.id && connector.tools.length > 0 && (
+                    <span className="settings-connectors__meta">
+                      Adds: {connector.tools.slice(0, 6).map((t) => t.name).join(', ')}
+                      {connector.tool_count > 6 ? '…' : ''}
+                    </span>
+                  )}
+                </div>
+                <div className="settings-connectors__actions">
+                  <button
+                    type="button"
+                    className="settings__btn settings__btn--outline settings__btn--sm"
+                    disabled={busyId === connector.id}
+                    onClick={() => patchConnector(connector, { enabled: !connector.enabled })}
+                  >
+                    {connector.enabled ? 'Turn off' : 'Turn on'}
+                  </button>
+                  <button
+                    type="button"
+                    className="settings__btn settings__btn--outline settings__btn--sm"
+                    disabled={busyId === connector.id}
+                    onClick={() => refreshConnector(connector)}
+                  >
+                    Re-check
+                  </button>
+                  {confirmRemove === connector.id ? (
+                    <>
+                      <button
+                        type="button"
+                        className="settings__btn settings__btn--sm settings-connectors__danger"
+                        disabled={busyId === connector.id}
+                        onClick={() => removeConnector(connector)}
+                      >
+                        Really remove
+                      </button>
+                      <button
+                        type="button"
+                        className="settings__btn settings__btn--outline settings__btn--sm"
+                        onClick={() => setConfirmRemove(null)}
+                      >
+                        Keep
+                      </button>
+                    </>
+                  ) : (
+                    <button
+                      type="button"
+                      className="settings__btn settings__btn--outline settings__btn--sm"
+                      disabled={busyId === connector.id}
+                      onClick={() => setConfirmRemove(connector.id)}
+                    >
+                      Remove
+                    </button>
+                  )}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      {!unavailable && (addOpen ? (
+        <form className="settings-connectors__add" onSubmit={addConnector}>
+          <input
+            className="settings-connectors__input"
+            type="url"
+            placeholder="Connector address (https://…)"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            autoFocus
+          />
+          <label className="settings-connectors__key-toggle">
+            <input
+              type="checkbox"
+              checked={usesKey}
+              onChange={(e) => setUsesKey(e.target.checked)}
+            />
+            This service uses an API key
+          </label>
+          {usesKey && (
+            <div className="settings-connectors__key-fields">
+              <input
+                className="settings-connectors__input"
+                type="password"
+                placeholder="API key"
+                value={authValue}
+                onChange={(e) => setAuthValue(e.target.value)}
+              />
+              <input
+                className="settings-connectors__input settings-connectors__input--header"
+                type="text"
+                placeholder="Header (Authorization)"
+                value={authHeader}
+                onChange={(e) => setAuthHeader(e.target.value)}
+              />
+            </div>
+          )}
+          <div className="settings-connectors__actions">
+            <button
+              type="submit"
+              className="settings__btn settings__btn--sm"
+              disabled={addPhase === 'adding' || !url.trim()}
+            >
+              {addPhase === 'adding' ? 'Checking service…' : 'Add connector'}
+            </button>
+            <button
+              type="button"
+              className="settings__btn settings__btn--outline settings__btn--sm"
+              onClick={() => { setAddOpen(false); setAddError('') }}
+            >
+              Cancel
+            </button>
+          </div>
+          {addError && (
+            <Alert color="danger" variant="soft" description={addError} />
+          )}
+        </form>
+      ) : (
+        <div className="settings__row">
+          <button
+            type="button"
+            className="settings__btn settings__btn--outline settings__btn--sm"
+            onClick={() => setAddOpen(true)}
+          >
+            Add connector
+          </button>
+        </div>
+      ))}
+
+      {listError && (
+        <Alert color="danger" variant="soft" description={listError} />
+      )}
+    </section>
+  )
+}

--- a/frontend/src/components/SettingsView/SettingsView.css
+++ b/frontend/src/components/SettingsView/SettingsView.css
@@ -553,3 +553,85 @@
 .settings__section--server .settings__subtext--tight {
   margin: -10px 0 0;
 }
+
+/* ── Connectors section ─────────────────────────────────────────────
+   List rows + add form for external MCP connectors. Reuses the shared
+   settings button/notice vocabulary; only layout is new. */
+.settings-connectors__intro {
+  margin: -6px 0 12px;
+}
+.settings-connectors__list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+.settings-connectors__row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px 16px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border);
+}
+.settings-connectors__row:last-child {
+  border-bottom: none;
+}
+.settings-connectors__main {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+.settings-connectors__meta {
+  font-size: 12.5px;
+  color: var(--text-secondary, var(--text));
+  opacity: 0.75;
+}
+.settings-connectors__error {
+  font-size: 12.5px;
+  color: var(--danger);
+}
+.settings-connectors__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.settings-connectors__danger {
+  background: var(--danger);
+  border-color: var(--danger);
+}
+.settings-connectors__add {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 4px;
+}
+.settings-connectors__input {
+  width: 100%;
+  max-width: 480px;
+  padding: 9px 12px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--surface);
+  color: var(--text);
+  font: inherit;
+  font-size: 14px;
+}
+.settings-connectors__input--header {
+  max-width: 240px;
+}
+.settings-connectors__key-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13.5px;
+  color: var(--text);
+  cursor: pointer;
+}
+.settings-connectors__key-fields {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}

--- a/frontend/src/components/SettingsView/SettingsView.jsx
+++ b/frontend/src/components/SettingsView/SettingsView.jsx
@@ -30,6 +30,7 @@ import ModelSheet from '../ui/ModelSheet.jsx'
 import { modelEfforts, validEffort } from '../ui/modelEfforts.js'
 import ManageModelsModal from '../ChatView/ManageModelsModal.jsx'
 import UpdateReviewModal from './UpdateReviewModal.jsx'
+import ConnectorsSection from './ConnectorsSection.jsx'
 import { PROVIDER_INFO, PROVIDER_ORDER } from '../ChatView/ChatSettingsPanel.jsx'
 import '../ui/StatusDot.css'
 import '../ui/ModelSheet.css'
@@ -1510,6 +1511,8 @@ export default function SettingsView({
             </div>
           )}
         </section>
+
+        <ConnectorsSection />
 
         <section className="settings__section settings__section--compact settings__section--appearance">
           <div className="settings__appearance">


### PR DESCRIPTION
## What

A first-class **connector registry**: owners register remote MCP services (no-auth or API-key) in Settings, and every agent turn — Claude and Codex alike — can use them. This is Phase 1 of a connectors design (registry + injection + cost visibility); an OAuth lifecycle and a manifest/package tier build on this seam later.

## How it works

- **Registry** — a new `connectors` table plus owner-gated `/api/connectors` CRUD. The add path runs a real MCP handshake (`initialize` → `tools/list`, JSON and SSE response bodies both tolerated) **before** anything is saved: the owner reviews the advertised tool list and a chars/4 token estimate at add time, and an unreachable or key-rejecting service never becomes a row.
- **Secrets** — API keys are Fernet-encrypted at rest using the app-secrets derivation pattern with a distinct salt, are never returned by any endpoint, and never appear in argv or logs. One pragmatic auth rule: an `Authorization` header gets a `Bearer ` prefix unless the pasted value already carries one; custom headers send the value verbatim.
- **Injection** — per-turn and provider-native. The Claude runner passes the SDK's `mcp_servers` option (deferred tool loading is the runtime default, so idle connectors cost stubs, not schemas). The Codex runner appends `mcp_servers.*` config overrides, with keys riding env vars via `bearer_token_env_var` / `env_http_headers`. Both read the registry fresh each turn — edits apply on the next message, no restart — and any registry failure degrades to a connector-less turn rather than a broken one.
- **Settings UI** — a Connectors section (list with status dot, tool count, `~tokens/msg`, uses-a-key marker; add form with an API-key disclosure; enable/disable, re-check, remove with inline confirm). While the backend routes await the next boot, the section renders a restart-pending notice instead of an error.

## Why per-message cost is surfaced

Connector tool catalogs are prompt overhead on every message; owners on usage-based hosting should see that before enabling anything. The estimate comes from the same handshake that validates the service, so it costs nothing extra.

## Testing

- New `backend/tests/test_connectors.py`: the Authorization/Bearer asymmetry between providers (Claude headers vs Codex env-var indirection), secrets kept out of argv, SSE-vs-JSON handshake parsing, slug/token-estimate bounds, and the Fernet round-trip (8 tests).
- Existing runner suites (`test_codex_sdk_runner.py`, `test_runner_registry_integration.py`) pass against the edited runners (107 tests).
- Verified live on a running instance: section renders, pre-restart notice shows, watcher rebuild serves the UI without restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)