### PR TITLE
Keep app destinations covered until their intent is applied

### DIFF
--- a/frontend/public/app-frame.html
+++ b/frontend/public/app-frame.html
@@ -560,7 +560,10 @@
     //   7. parent posts {type:'moebius:frame-interactivity', interactive}
     //      whenever a shell modal (currently the navigation drawer) suspends or
     //      restores direct input without unpainting/reloading the app.
-    //   8. pointer input posts {type:'moebius:frame-focus'} so the shell can focus
+    //   8. parent may post {type:'moebius:app-intent', intent, nonce}; after
+    //      app message handlers and their resulting React commits can run, the
+    //      frame answers {type:'moebius:app-intent-applied', appId, nonce}.
+    //   9. pointer input posts {type:'moebius:frame-focus'} so the shell can focus
     //      this app's pane; iframe events do not bubble into the parent wrapper.
     //
     // Origin check: the opaque iframe still sees the parent shell's concrete
@@ -589,6 +592,31 @@
     // well as the document scroller, without walking every node when the drawer
     // opens. Nested third-party frames stay covered by the outer iframe guard.
     const gestureScrollers = new Set();
+
+    // App intent listeners live in app code, alongside this runtime listener.
+    // The parent keeps an opaque cover over the frame until we acknowledge.
+    // Two animation turns give a listener's state update and a follow-on effect
+    // (for example: resolve an id, then open its detail panel) time to commit.
+    // Background/hidden frames may pause rAF entirely, so the bounded timer is
+    // the equivalent task-turn fallback; the parent nonce-rejects stale acks.
+    function acknowledgeAppIntent(nonce) {
+      let sent = false;
+      const send = () => {
+        if (sent) return;
+        sent = true;
+        window.parent.postMessage(
+          { type: 'moebius:app-intent-applied', appId: _FRAME_APP_ID, nonce },
+          window.location.origin
+        );
+      };
+      const fallback = setTimeout(send, 120);
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          clearTimeout(fallback);
+          send();
+        });
+      });
+    }
 
     // A module request has two independent failure modes, and one deadline
     // cannot measure both. LIVENESS: the parent never takes the request at all
@@ -1164,6 +1192,12 @@
           window.mobius && window.mobius.storage &&
             window.mobius.storage._receiveDeadLetter(msg.payload);
         } catch (e) {}
+        return;
+      }
+      if (msg.type === 'moebius:app-intent') {
+        acknowledgeAppIntent(msg.nonce);
+        // Returning from this runtime listener does not stop the message event:
+        // the app's own listener still receives the same intent synchronously.
         return;
       }
       if (msg.type === 'moebius:frame-init') {

--- a/frontend/src/components/AppCanvas/AppCanvas.css
+++ b/frontend/src/components/AppCanvas/AppCanvas.css
@@ -42,6 +42,14 @@
   opacity: 1;
 }
 
+/* A shell deep link is a destination handoff, not a visit to the app's home
+   screen followed by a second navigation. Keep the old/home frame inert under
+   the opaque loading cover until the frame confirms its intent handlers have
+   committed the destination. */
+.canvas--intent-pending {
+  pointer-events: none;
+}
+
 /* One-shot shimmer confirming the preview refreshed in place. A faint accent
    veil that pulses and fades; opacity-only + pointer-events:none so it never
    blocks input or forces layout. Sits above the frames but below nothing that
@@ -96,6 +104,13 @@
   pointer-events: none;
   z-index: 1;
   animation: canvas-loading-in 80ms ease-out;
+}
+
+/* The ordinary first-load fade intentionally lets a fast app feel immediate.
+   A direct-intent cover has the opposite job: it must be opaque on its first
+   frame so the app's previous/home state cannot flash through. */
+.canvas-loading--intent-handoff {
+  animation: none;
 }
 
 @keyframes canvas-loading-in {

--- a/frontend/src/components/AppCanvas/AppCanvas.jsx
+++ b/frontend/src/components/AppCanvas/AppCanvas.jsx
@@ -124,10 +124,12 @@ function appFrameRequestUrl(appId, version, frameRev) {
 //      windowed app whose chrome already owns the inset padding can't
 //      double-pad. See lib/safeAreaInsets.js for the read contract.
 //
-//   6. {type: 'moebius:app-intent', intent}                parent → frame
-//      One-shot shell intent delivered after the app has mounted. Used by
-//      catalog surfaces that open an app directly into a setup/settings path
-//      without inventing app-specific deep links.
+//   6. {type: 'moebius:app-intent', intent, nonce}         parent → frame
+//      One-shot shell intent delivered after the app has mounted. The frame
+//      answers with {type:'moebius:app-intent-applied', nonce} after app message
+//      handlers and their resulting React commits have had a chance to run.
+//      AppCanvas keeps the destination covered until that acknowledgement, so
+//      a direct link never flashes the app's home screen first.
 //
 //   7. moebius:capability-*                                bidirectional
 //      One versioned session protocol for every host-mediated browser feature.
@@ -350,6 +352,12 @@ const AppCanvas = forwardRef(function AppCanvas({
   // VERSION — a Map, not a single ref, because two iframes are alive during the
   // swap window and each must be addressable independently.
   const framesRef = useRef(new Map())
+  // Message attribution lives in one intentionally stable listener below, so
+  // keep the current one-shot intent in a ref rather than re-registering that
+  // listener on every deep link. The nonce prevents a late acknowledgement for
+  // an older destination from uncovering a newer handoff.
+  const pendingIntentRef = useRef(pendingIntent)
+  pendingIntentRef.current = pendingIntent
   const storageHost = useMemo(() => createAppStorageHost({
     appId,
     getCurrentToken: () => hostTokenRef.current,
@@ -801,6 +809,13 @@ const AppCanvas = forwardRef(function AppCanvas({
       // directly — it is the verified sender window.
       if (srcVersion !== liveVersionRef.current) return
 
+      if (msg.type === 'moebius:app-intent-applied') {
+        const pending = pendingIntentRef.current
+        if (!pending || msg.nonce !== pending.nonce) return
+        onIntentDelivered?.(appId, pending)
+        return
+      }
+
       if (msg.type === 'moebius:frame-focus') {
         onAppFocus?.(appId)
         return
@@ -901,7 +916,8 @@ const AppCanvas = forwardRef(function AppCanvas({
     return () => window.removeEventListener('message', onMessage)
   }, [
     appId, appSlug, onNavPush, onNavPop, onNavForwardResult,
-    onAppFocus, onImmersive, onAppError, onHostRequest, queryClient,
+    onAppFocus, onImmersive, onIntentDelivered, onAppError, onHostRequest,
+    queryClient,
   ])
 
   // Capabilities belong to a visible workspace pane, not merely the focused
@@ -1035,7 +1051,9 @@ const AppCanvas = forwardRef(function AppCanvas({
 
   // One-shot shell intent, delivered to the VISIBLE frame once it has mounted.
   // Re-delivers to the promoted frame after a swap (dep on swap.liveVersion):
-  // the new module didn't receive the intent the old one did.
+  // the new module didn't receive the intent the old one did. The frame's
+  // applied acknowledgement clears the pending value; posting alone does not,
+  // because revealing now would briefly paint the app's previous/home state.
   useEffect(() => {
     if (!pendingIntent || !swap.liveLoaded) return
     if (!framesRef.current.get(swap.liveVersion)?.contentWindow) return
@@ -1044,8 +1062,7 @@ const AppCanvas = forwardRef(function AppCanvas({
       intent: pendingIntent.intent,
       nonce: pendingIntent.nonce,
     })
-    onIntentDelivered?.(appId, pendingIntent)
-  }, [appId, swap.liveLoaded, swap.liveVersion, pendingIntent, onIntentDelivered])
+  }, [swap.liveLoaded, swap.liveVersion, pendingIntent])
 
   // ── P1-A: probed-online forwarding ──────────────────────────────
   // Forward the shell's real reachability verdict (from useOnlineStatus, which
@@ -1343,6 +1360,7 @@ const AppCanvas = forwardRef(function AppCanvas({
   const frameVersions = [swap.liveVersion]
   if (swap.incomingVersion != null) frameVersions.push(swap.incomingVersion)
   frameVersions.sort(compareVersions)
+  const intentHandoffPending = pendingIntent != null
 
   // The iframe key OMITS `token` (a token refresh must not remount and drop
   // in-app state) — only appId+version identify a frame. During a swap the
@@ -1359,7 +1377,9 @@ const AppCanvas = forwardRef(function AppCanvas({
           <iframe
             ref={frameRefCb(v)}
             key={`${appId}-${v}`}
-            className={`canvas ${isLive ? 'canvas--live' : 'canvas--incoming'}`}
+            className={`canvas ${isLive ? 'canvas--live' : 'canvas--incoming'}${
+              isLive && intentHandoffPending ? ' canvas--intent-pending' : ''
+            }`}
             src={appFrameRequestUrl(appId, v, frameRev)}
             title={appName || 'Mini-app'}
             // data-app-id marks the app's VISIBLE browsing context. Exactly one
@@ -1384,8 +1404,12 @@ const AppCanvas = forwardRef(function AppCanvas({
       {swap.swaps > 0 && (
         <div className="canvas-swap-flash" key={`flash-${swap.swaps}`} aria-hidden="true" />
       )}
-      {!swap.liveLoaded && (
-        <div className="canvas-loading" aria-live="polite">
+      {(!swap.liveLoaded || intentHandoffPending) && (
+        <div
+          className={`canvas-loading${intentHandoffPending
+            ? ' canvas-loading--intent-handoff' : ''}`}
+          aria-live="polite"
+        >
           {!online && !offlineCapable ? (
             // A non-offline-capable app whose frame + module aren't cached
             // yet (never opened while online) can't load offline, so the

--- a/frontend/src/lib/__tests__/appIntentHandoff.test.js
+++ b/frontend/src/lib/__tests__/appIntentHandoff.test.js
@@ -1,0 +1,47 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const canvas = readFileSync(
+  new URL('../../components/AppCanvas/AppCanvas.jsx', import.meta.url),
+  'utf8',
+)
+const canvasCss = readFileSync(
+  new URL('../../components/AppCanvas/AppCanvas.css', import.meta.url),
+  'utf8',
+)
+const frame = readFileSync(
+  new URL('../../../public/app-frame.html', import.meta.url),
+  'utf8',
+)
+
+test('a direct app intent stays covered until the exact live frame applies it', () => {
+  assert.match(canvas, /const pendingIntentRef = useRef\(pendingIntent\)/)
+  assert.match(canvas, /if \(srcVersion !== liveVersionRef\.current\) return[\s\S]*msg\.type === 'moebius:app-intent-applied'/)
+  assert.match(canvas, /msg\.nonce !== pending\.nonce/)
+  assert.match(canvas, /onIntentDelivered\?\.\(appId, pending\)/)
+  assert.match(canvas, /\(!swap\.liveLoaded \|\| intentHandoffPending\)/)
+  assert.match(canvas, /canvas--intent-pending/)
+  assert.match(canvasCss, /\.canvas--intent-pending\s*\{[\s\S]*pointer-events:\s*none/)
+  assert.match(canvasCss, /\.canvas-loading--intent-handoff\s*\{[\s\S]*animation:\s*none/)
+})
+
+test('posting an intent no longer uncovers the app before its acknowledgement', () => {
+  const delivery = canvas.slice(
+    canvas.indexOf('// One-shot shell intent'),
+    canvas.indexOf('// ── P1-A:'),
+  )
+  assert.match(delivery, /postToFrame\(swap\.liveVersion/)
+  assert.doesNotMatch(delivery, /onIntentDelivered/)
+})
+
+test('the frame acknowledges after app handlers get two commit turns', () => {
+  const acknowledgement = frame.slice(
+    frame.indexOf('function acknowledgeAppIntent'),
+    frame.indexOf('function requestModuleBytes'),
+  )
+  assert.match(acknowledgement, /requestAnimationFrame\(\(\) => \{\s*requestAnimationFrame/)
+  assert.match(acknowledgement, /setTimeout\(send, 120\)/)
+  assert.match(acknowledgement, /type: 'moebius:app-intent-applied'/)
+  assert.match(frame, /msg\.type === 'moebius:app-intent'[\s\S]*acknowledgeAppIntent\(msg\.nonce\)/)
+})


### PR DESCRIPTION
## Summary
- keep direct app destinations behind an opaque cover until the live frame acknowledges the exact intent nonce
- acknowledge after app message handlers and their resulting React commits can paint
- reject stale acknowledgements from retired frames or older intents
- keep the covered frame inert until handoff completes

## Why
The shell previously cleared an app intent as soon as it posted the message. A frame could therefore reveal its home screen for a paint before its own destination state committed. This adds a small source-bound handoff: the exact live frame acknowledges the exact nonce, and only then does the shell remove the cover.

## Safety
The acknowledgement is accepted only from the current verified frame version and must match the current intent nonce. Hidden frames have a bounded task-turn fallback so they cannot remain covered forever when animation frames are paused.

## Validation
- current-main cherry-pick and clean diff
- focused contract coverage for nonce matching, cover ownership, and post-handler acknowledgement
- full CI before merge