### PR TITLE
Classify semantic source reconciliation

### DIFF
--- a/backend/app/app_git.py
+++ b/backend/app/app_git.py
@@ -181,14 +181,18 @@ class ReconciliationReceipt:
   """Explain one update decision without exposing merge implementation details."""
 
   proven_present: tuple[str, ...] = ()
+  local_only_paths: tuple[str, ...] = ()
   new_upstream_paths: tuple[str, ...] = ()
+  compatible_paths: tuple[str, ...] = ()
   unresolved_conflict_paths: tuple[str, ...] = ()
   provenance_refs_used: tuple[str, ...] = ()
 
   def as_dict(self) -> dict[str, list[str]]:
     return {
       "proven_present": list(self.proven_present),
+      "local_only_paths": list(self.local_only_paths),
       "new_upstream_paths": list(self.new_upstream_paths),
+      "compatible_paths": list(self.compatible_paths),
       "unresolved_conflict_paths": list(self.unresolved_conflict_paths),
       "provenance_refs_used": list(self.provenance_refs_used),
     }
@@ -643,23 +647,30 @@ def describe_reconciliation(
   shared_base: str,
   upstream: str,
   *,
+  local: str | None = None,
   conflict_paths: Iterable[str] = (),
   proven_changes: Iterable[EquivalentChange] = (),
 ) -> ReconciliationReceipt:
   """Return the common platform/app receipt for one semantic merge base.
 
   ``shared_base`` already contains every reviewed change proven present on
-  both sides. Its diff to ``upstream`` is therefore the genuinely new upstream
-  path set, while ``conflict_paths`` is the residual owner decision. Callers do
-  not need to reconstruct either fact from warnings or Git topology.
+  both sides. Its diffs to ``local`` and ``upstream`` are therefore the
+  genuinely local and genuinely incoming path sets, while ``conflict_paths``
+  is the residual owner decision. Callers do not need to reconstruct any fact
+  from warnings or Git topology.
   """
   repo = Path(source_dir)
   proven = tuple(proven_changes)
-  new_paths = _diff_paths(repo, shared_base, upstream)
+  local_paths = (_diff_paths(repo, shared_base, local) if local else set()) or set()
+  new_paths = _diff_paths(repo, shared_base, upstream) or set()
+  conflicts = set(conflict_paths)
+  compatible = local_paths & new_paths - conflicts
   return ReconciliationReceipt(
     proven_present=tuple(change.contribution_id for change in proven),
-    new_upstream_paths=tuple(sorted(new_paths or ())),
-    unresolved_conflict_paths=tuple(sorted(set(conflict_paths))),
+    local_only_paths=tuple(sorted(local_paths - new_paths)),
+    new_upstream_paths=tuple(sorted(new_paths - local_paths)),
+    compatible_paths=tuple(sorted(compatible)),
+    unresolved_conflict_paths=tuple(sorted(conflicts)),
     provenance_refs_used=tuple(change.ref for change in proven),
   )
 
@@ -1185,10 +1196,44 @@ def merge_with_equivalent_changes(
     repo,
     shared_tree,
     upstream,
+    local=local,
     conflict_paths=merged.conflict_paths,
     proven_changes=applied,
   )
   return merged
+
+
+def preview_reconciliation(
+  source_dir: str | Path,
+  local: str,
+  upstream: str,
+) -> ReconciliationReceipt:
+  """Classify two refs with the same semantic proof used by real updates.
+
+  This is the read-only inventory seam for both platform and app source maps.
+  It never fetches, moves a ref, or touches the worktree. Proven contribution
+  anchors replace Git's historical base when available; otherwise the ordinary
+  merge base and conflict verdict remain authoritative.
+  """
+  repo = Path(source_dir)
+  equivalent = merge_with_equivalent_changes(repo, local, upstream)
+  if equivalent is not None:
+    return equivalent.reconciliation
+  base = _run(repo, "merge-base", local, upstream, check=False).stdout.strip()
+  if not base:
+    return ReconciliationReceipt()
+  try:
+    ordinary = merge_refs(repo, local, upstream)
+    conflicts = ordinary.conflict_paths
+  except (OSError, subprocess.SubprocessError, RuntimeError):
+    conflicts = ()
+  return describe_reconciliation(
+    repo,
+    base,
+    upstream,
+    local=local,
+    conflict_paths=conflicts,
+  )
 
 
 def retire_landed_equivalent_changes(
@@ -1880,6 +1925,7 @@ def merge_upstream(source_dir: str | Path) -> MergeResult:
       repo,
       ordinary_base,
       UPSTREAM_BRANCH,
+      local=LOCAL_BRANCH,
       conflict_paths=ordinary.conflict_paths,
     )
   if ordinary.status == "clean":

--- a/backend/app/install.py
+++ b/backend/app/install.py
@@ -2713,7 +2713,9 @@ async def install_from_manifest(
               conflict_paths = [entry_key]
               reconciliation = app_git.ReconciliationReceipt(
                 proven_present=reconciliation.proven_present,
+                local_only_paths=reconciliation.local_only_paths,
                 new_upstream_paths=reconciliation.new_upstream_paths,
+                compatible_paths=reconciliation.compatible_paths,
                 unresolved_conflict_paths=(entry_key,),
                 provenance_refs_used=reconciliation.provenance_refs_used,
               )
@@ -2774,7 +2776,9 @@ async def install_from_manifest(
                   )
                   reconciliation = app_git.ReconciliationReceipt(
                     proven_present=reconciliation.proven_present,
+                    local_only_paths=reconciliation.local_only_paths,
                     new_upstream_paths=reconciliation.new_upstream_paths,
+                    compatible_paths=reconciliation.compatible_paths,
                     provenance_refs_used=reconciliation.provenance_refs_used,
                   )
                   # Exec bits come from the same merged tree the resolution was

--- a/backend/app/platform_update.py
+++ b/backend/app/platform_update.py
@@ -1315,14 +1315,16 @@ def reconcile_clone(
       # an `upstream` marker that could drift and let `reset --hard` silently
       # discard committed local edits.
       _git("reset", "--hard", target, repo=repo)
-      reconciliation = app_git.describe_reconciliation(repo, pre, target)
+      reconciliation = app_git.describe_reconciliation(
+        repo, pre, target, local=pre,
+      )
     else:
       ordinary_base = _git(
         "merge-base", pre, target, repo=repo, check=False,
       ).stdout.strip()
       if ordinary_base:
         reconciliation = app_git.describe_reconciliation(
-          repo, ordinary_base, target,
+          repo, ordinary_base, target, local=pre,
         )
       # Main and target diverged: merge the reviewed upstream tree ONCE. This
       # preserves local commit identities and makes one resolver pass see every
@@ -1399,6 +1401,7 @@ def reconcile_clone(
                 repo,
                 ordinary_base,
                 target,
+                local=pre,
                 conflict_paths=conflict_paths,
               )
             ),

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -236,7 +236,9 @@ class AppPreviewOut(BaseModel):
 
 class ReconciliationReceiptOut(BaseModel):
   proven_present: list[str] = Field(default_factory=list)
+  local_only_paths: list[str] = Field(default_factory=list)
   new_upstream_paths: list[str] = Field(default_factory=list)
+  compatible_paths: list[str] = Field(default_factory=list)
   unresolved_conflict_paths: list[str] = Field(default_factory=list)
   provenance_refs_used: list[str] = Field(default_factory=list)
 

--- a/backend/app/source_status.py
+++ b/backend/app/source_status.py
@@ -23,6 +23,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from app import app_git
 from app.config import get_settings
 
 _GIT_TIMEOUT = 8
@@ -138,14 +139,14 @@ def _install_managed_paths(
   return managed
 
 
-def _diff_summary(
+def _diff_inventory(
   repo: Path,
   left: str,
   right: str,
   *,
   classify_install: bool = False,
-) -> dict[str, Any]:
-  """Count endpoint tree differences without returning source content."""
+) -> tuple[dict[str, Any], set[str]]:
+  """Count endpoint differences and retain their complete managed path set."""
   proc = _git(repo, "diff", "--numstat", "--no-renames", left, right, "--")
   if proc.returncode != 0:
     return {
@@ -154,7 +155,7 @@ def _diff_summary(
       "authored_insertions": 0, "authored_deletions": 0,
       "managed_insertions": 0, "managed_deletions": 0,
       "paths": [], "truncated": False,
-    }
+    }, set()
   files = insertions = deletions = binaries = 0
   authored_files = managed_files = 0
   authored_insertions = authored_deletions = 0
@@ -217,6 +218,92 @@ def _diff_summary(
     "managed_deletions": managed_deletions,
     "paths": paths,
     "truncated": files > len(paths),
+  }, managed_paths
+
+
+def _diff_summary(
+  repo: Path,
+  left: str,
+  right: str,
+  *,
+  classify_install: bool = False,
+) -> dict[str, Any]:
+  """Return the bounded, source-free endpoint comparison."""
+  summary, _managed_paths = _diff_inventory(
+    repo, left, right, classify_install=classify_install,
+  )
+  return summary
+
+
+def _endpoint_diff_paths(repo: Path, left: str, right: str) -> set[str] | None:
+  """Return path names whose endpoint bytes differ, independent of topology."""
+  proc = _git(repo, "diff", "--name-only", "--no-renames", "-z", left, right, "--")
+  if proc.returncode != 0:
+    return None
+  return {path for path in proc.stdout.split("\0") if path}
+
+
+def _reconciliation_summary(
+  repo: Path,
+  local: str,
+  upstream: str,
+  *,
+  managed_paths: set[str] | None = None,
+) -> dict[str, Any]:
+  """Bound the shared semantic receipt for Contribute's read-only source map."""
+  empty = {
+    "available": False,
+    "proven_present": [],
+    "proven_present_count": 0,
+    "local_only_paths": [],
+    "local_only_count": 0,
+    "new_upstream_paths": [],
+    "new_upstream_count": 0,
+    "compatible_paths": [],
+    "compatible_count": 0,
+    "unresolved_conflict_paths": [],
+    "unresolved_conflict_count": 0,
+    "truncated": False,
+  }
+  try:
+    receipt = app_git.preview_reconciliation(repo, local, upstream)
+    endpoint_paths = _endpoint_diff_paths(repo, upstream, local)
+  except (OSError, subprocess.SubprocessError, RuntimeError):
+    return empty
+  if endpoint_paths is None:
+    return empty
+
+  managed = managed_paths or set()
+
+  def source_paths(values: tuple[str, ...]) -> list[str]:
+    # A path that finished byte-identical on both endpoints is not remaining
+    # local or incoming work, even if both histories independently touched it.
+    return sorted(set(values) & endpoint_paths - managed)
+
+  proven = list(receipt.proven_present)
+  local_paths = source_paths(receipt.local_only_paths)
+  upstream_paths = source_paths(receipt.new_upstream_paths)
+  compatible_paths = source_paths(receipt.compatible_paths)
+  conflict_paths = source_paths(receipt.unresolved_conflict_paths)
+  truncated = any(
+    len(values) > _PATH_PREVIEW
+    for values in (
+      proven, local_paths, upstream_paths, compatible_paths, conflict_paths,
+    )
+  )
+  return {
+    "available": True,
+    "proven_present": proven[:_PATH_PREVIEW],
+    "proven_present_count": len(proven),
+    "local_only_paths": local_paths[:_PATH_PREVIEW],
+    "local_only_count": len(local_paths),
+    "new_upstream_paths": upstream_paths[:_PATH_PREVIEW],
+    "new_upstream_count": len(upstream_paths),
+    "compatible_paths": compatible_paths[:_PATH_PREVIEW],
+    "compatible_count": len(compatible_paths),
+    "unresolved_conflict_paths": conflict_paths[:_PATH_PREVIEW],
+    "unresolved_conflict_count": len(conflict_paths),
+    "truncated": truncated,
   }
 
 
@@ -385,6 +472,7 @@ def _project_status(
     "ahead": None,
     "behind": None,
     "tree": None,
+    "reconciliation": None,
     "working": None,
     "state": "unavailable",
   }
@@ -427,22 +515,56 @@ def _project_status(
     return response
 
   ahead, behind = _comparison_counts(repo, base_ref, "HEAD")
-  tree = _diff_summary(
+  tree, managed_paths = _diff_inventory(
     repo, base_ref, "HEAD", classify_install=(kind == "app"),
   )
-  response.update({"behind": behind, "ahead": ahead, "tree": tree})
+  reconciliation = _reconciliation_summary(
+    repo,
+    "HEAD",
+    base_ref,
+    managed_paths=managed_paths,
+  )
+  response.update({
+    "behind": behind,
+    "ahead": ahead,
+    "tree": tree,
+    "reconciliation": reconciliation,
+  })
 
   has_working = bool(working.get("files"))
-  has_conflict = bool(working.get("conflicts") or working.get("merge_active"))
-  has_local = bool(tree.get("authored_files", tree.get("files")))
+  semantic = reconciliation.get("available")
+  has_conflict = bool(
+    working.get("conflicts")
+    or working.get("merge_active")
+    or (
+      semantic
+      and reconciliation.get("unresolved_conflict_count")
+    )
+  )
+  has_local = bool(
+    (
+      reconciliation.get("local_only_count")
+      or reconciliation.get("compatible_count")
+      or reconciliation.get("unresolved_conflict_count")
+    )
+    if semantic else tree.get("authored_files", tree.get("files"))
+  )
+  has_incoming = bool(
+    (
+      reconciliation.get("new_upstream_count")
+      or reconciliation.get("compatible_count")
+      or reconciliation.get("unresolved_conflict_count")
+    )
+    if semantic else behind
+  )
   has_managed = bool(tree.get("managed_files"))
   if has_conflict:
     state = "conflict"
   elif has_working:
     state = "working"
-  elif behind and (ahead or has_local):
+  elif has_incoming and has_local:
     state = "diverged"
-  elif behind:
+  elif has_incoming:
     state = "incoming"
   elif has_local:
     state = "customized"

--- a/backend/tests/test_app_git.py
+++ b/backend/tests/test_app_git.py
@@ -1050,6 +1050,7 @@ def test_landed_equivalent_change_rebases_later_local_edit_without_agent(
 
   assert result.status == "clean"
   assert result.equivalent_change_refs == (landed,)
+  assert result.reconciliation.local_only_paths == ("index.jsx",)
   tree = app_git.read_merged_tree(repo, result.merged_tree_oid)
   assert tree["index.jsx"] == b'mode = "local followup"\n'
   assert tree["upstream.js"] == b"export const upstream = true\n"
@@ -1117,9 +1118,13 @@ def test_partial_equivalence_materializes_only_residual_app_conflicts(tmp_path):
   assert result.equivalent_change_refs == (landed,)
   assert result.reconciliation.proven_present == ("partial-shared-change",)
   assert result.reconciliation.provenance_refs_used == (landed,)
-  assert result.reconciliation.new_upstream_paths == (
-    "config.js", "upstream.js",
+  assert result.reconciliation.local_only_paths == (
+    "index.jsx",
   )
+  assert result.reconciliation.new_upstream_paths == (
+    "upstream.js",
+  )
+  assert result.reconciliation.compatible_paths == ()
   assert result.reconciliation.unresolved_conflict_paths == ("config.js",)
 
   conflicts = app_git.start_conflict_merge(

--- a/backend/tests/test_apps_install.py
+++ b/backend/tests/test_apps_install.py
@@ -2726,6 +2726,7 @@ def test_flag_on_clean_update_without_local_edits_is_fast_forward(
   assert payload["divergence"] == "fast_forward"
   assert "index.jsx" in payload["reconciliation"]["new_upstream_paths"]
   assert payload["reconciliation"]["proven_present"] == []
+  assert payload["reconciliation"]["local_only_paths"] == []
   # With no local edits the served source must be the new upstream verbatim.
   # The latent bug let a failed in-memory merge leave the OLD bytes on disk
   # while still bumping the version, so assert the new content actually
@@ -2909,7 +2910,9 @@ def test_app_store_update_recognizes_squashed_local_contribution(
   assert any("already present upstream" in item for item in body["warnings"])
   assert body["reconciliation"] == {
     "proven_present": ["app-store-reviewed-change"],
+    "local_only_paths": ["index.jsx"],
     "new_upstream_paths": [],
+    "compatible_paths": [],
     "unresolved_conflict_paths": [],
     "provenance_refs_used": [landed],
   }

--- a/backend/tests/test_platform_routes.py
+++ b/backend/tests/test_platform_routes.py
@@ -80,7 +80,9 @@ def test_apply_forwards_exact_reviewed_plan(client, auth, monkeypatch):
       "phase": "complete",
       "reconciliation": {
         "proven_present": [],
+        "local_only_paths": [],
         "new_upstream_paths": [],
+        "compatible_paths": [],
         "unresolved_conflict_paths": [],
         "provenance_refs_used": [],
       },

--- a/backend/tests/test_platform_update.py
+++ b/backend/tests/test_platform_update.py
@@ -412,9 +412,9 @@ def test_partial_provenance_persists_reduced_platform_conflict(clone_env):
   assert res.conflict_paths == ["backend/app/foo.py"]
   assert res.reconciliation.proven_present == ("partial-platform-change",)
   assert res.reconciliation.provenance_refs_used == (landed,)
-  assert res.reconciliation.new_upstream_paths == (
-    "backend/app/foo.py", "backend/app/main.py",
-  )
+  assert res.reconciliation.local_only_paths == ()
+  assert res.reconciliation.new_upstream_paths == ()
+  assert res.reconciliation.compatible_paths == ("backend/app/main.py",)
   assert res.reconciliation.unresolved_conflict_paths == (
     "backend/app/foo.py",
   )

--- a/backend/tests/test_source_status.py
+++ b/backend/tests/test_source_status.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import hashlib
 import subprocess
 from pathlib import Path
 
-from app import source_status
+import pytest
+
+from app import app_git, source_status
 from app.config import get_settings
 
 
@@ -67,6 +70,8 @@ def test_aligned_and_history_only_ahead_keep_tree_magnitude_zero():
   assert ahead["ahead"] == 1
   assert ahead["tree"]["files"] == 0
   assert ahead["state"] == "aligned"
+  assert ahead["reconciliation"]["local_only_count"] == 0
+  assert ahead["reconciliation"]["new_upstream_count"] == 0
 
 
 def test_committed_and_working_deltas_are_reported_separately():
@@ -235,10 +240,165 @@ def test_diverged_counts_and_sanitized_github_identity():
   assert result["state"] == "diverged"
   assert result["behind"] == 1
   assert result["ahead"] == 1
+  assert result["reconciliation"]["local_only_paths"] == ["local.js"]
+  assert result["reconciliation"]["new_upstream_paths"] == ["remote.js"]
+  assert result["reconciliation"]["unresolved_conflict_paths"] == []
   assert result["canonical_repo"] == "example/private-demo"
   payload = repr(result)
   assert str(repo) not in payload
   assert "git@github.com" not in payload
+
+
+def test_endpoint_equal_sibling_histories_are_semantically_aligned():
+  repo = _repo("same-endpoint")
+  base = _git(repo, "rev-parse", "HEAD")
+  (repo / "index.jsx").write_text("export default 2\n", encoding="utf-8")
+  _git(repo, "add", "index.jsx")
+  _commit(repo, "local spelling")
+
+  _git(repo, "checkout", "-q", "upstream")
+  (repo / "index.jsx").write_text("export default 2\n", encoding="utf-8")
+  _git(repo, "add", "index.jsx")
+  _commit(repo, "shared spelling")
+  _git(repo, "checkout", "-q", "main")
+
+  result = source_status.build_app_status(_app(repo))
+
+  assert result is not None
+  assert result["ahead"] == 1
+  assert result["behind"] == 1
+  assert result["tree"]["files"] == 0
+  assert result["reconciliation"]["local_only_count"] == 0
+  assert result["reconciliation"]["new_upstream_count"] == 0
+  assert result["state"] == "aligned"
+  assert _git(repo, "merge-base", "main", "upstream") == base
+
+
+def test_disjoint_same_file_edits_are_classified_as_compatible():
+  repo = _repo("compatible-overlap")
+  (repo / "index.jsx").write_text(
+    "first = 1\nkeep_a = 2\nkeep_b = 3\nlast = 4\n",
+    encoding="utf-8",
+  )
+  _git(repo, "add", "index.jsx")
+  _commit(repo, "shared multiline base")
+  _git(repo, "branch", "-f", "upstream", "HEAD")
+
+  (repo / "index.jsx").write_text(
+    "first = 10\nkeep_a = 2\nkeep_b = 3\nlast = 4\n",
+    encoding="utf-8",
+  )
+  _git(repo, "add", "index.jsx")
+  _commit(repo, "local first line")
+
+  _git(repo, "checkout", "-q", "upstream")
+  (repo / "index.jsx").write_text(
+    "first = 1\nkeep_a = 2\nkeep_b = 3\nlast = 40\n",
+    encoding="utf-8",
+  )
+  _git(repo, "add", "index.jsx")
+  _commit(repo, "upstream second line")
+  _git(repo, "checkout", "-q", "main")
+
+  result = source_status.build_app_status(_app(repo))
+
+  assert result is not None
+  receipt = result["reconciliation"]
+  assert receipt["local_only_paths"] == []
+  assert receipt["new_upstream_paths"] == []
+  assert receipt["compatible_paths"] == ["index.jsx"]
+  assert receipt["compatible_count"] == 1
+  assert receipt["unresolved_conflict_paths"] == []
+  assert result["state"] == "diverged"
+
+
+def test_managed_classification_does_not_depend_on_the_path_preview(monkeypatch):
+  repo = _repo("managed-beyond-preview")
+  (repo / "authored.js").write_text("owner\n", encoding="utf-8")
+  _git(repo, "add", "authored.js")
+  _commit(repo, "owner change")
+  (repo / "managed.js").write_text("installer\n", encoding="utf-8")
+  _git(repo, "add", "managed.js")
+  _commit(repo, "install: adapt package")
+  monkeypatch.setattr(source_status, "_PATH_PREVIEW", 1)
+
+  result = source_status.build_app_status(_app(repo))
+
+  assert result is not None
+  assert result["tree"]["truncated"] is True
+  assert result["tree"]["managed_files"] == 1
+  assert result["reconciliation"]["local_only_paths"] == ["authored.js"]
+  assert result["reconciliation"]["local_only_count"] == 1
+
+
+def test_reconciliation_degrades_only_for_expected_runtime_failures(
+  monkeypatch,
+):
+  repo = _repo("reconciliation-failures")
+
+  def expected_failure(*_args, **_kwargs):
+    raise RuntimeError("git comparison failed")
+
+  monkeypatch.setattr(app_git, "preview_reconciliation", expected_failure)
+  assert source_status._reconciliation_summary(
+    repo, "main", "upstream",
+  )["available"] is False
+
+  def programming_error(*_args, **_kwargs):
+    raise AssertionError("classifier invariant broke")
+
+  monkeypatch.setattr(app_git, "preview_reconciliation", programming_error)
+  with pytest.raises(AssertionError, match="classifier invariant broke"):
+    source_status._reconciliation_summary(repo, "main", "upstream")
+
+
+def test_reviewed_shared_change_is_removed_from_remaining_source_inventory():
+  repo = _repo("semantic-source-map")
+  base = _git(repo, "rev-parse", "upstream")
+
+  (repo / "index.jsx").write_text("export default 'shared'\n", encoding="utf-8")
+  _git(repo, "add", "index.jsx")
+  reviewed = _commit(repo, "reviewed contribution")
+  reviewed_diff = app_git._canonical_diff(repo, base, reviewed)
+  assert reviewed_diff is not None
+  digest = hashlib.sha256(reviewed_diff).hexdigest()
+  assert app_git.record_pending_equivalent_change(
+    repo,
+    base_sha=base,
+    head_sha=reviewed,
+    source_sha=reviewed,
+    diff_sha256=digest,
+    contribution_id="source-map-shared",
+  )
+
+  (repo / "index.jsx").write_text(
+    "export default 'local followup'\n", encoding="utf-8",
+  )
+  _git(repo, "add", "index.jsx")
+  _commit(repo, "later local work")
+
+  _git(repo, "checkout", "-q", "upstream")
+  (repo / "index.jsx").write_text("export default 'shared'\n", encoding="utf-8")
+  (repo / "incoming.js").write_text(
+    "export default 'incoming'\n", encoding="utf-8",
+  )
+  _git(repo, "add", ".")
+  upstream = _commit(repo, "squash plus independent upstream")
+  _git(repo, "checkout", "-q", "main")
+  landed = app_git.mark_equivalent_change_landed(
+    repo, digest, upstream_sha=upstream,
+  )
+  assert landed
+
+  result = source_status.build_app_status(_app(repo))
+
+  assert result is not None
+  receipt = result["reconciliation"]
+  assert receipt["proven_present"] == ["source-map-shared"]
+  assert receipt["local_only_paths"] == ["index.jsx"]
+  assert receipt["new_upstream_paths"] == ["incoming.js"]
+  assert receipt["unresolved_conflict_paths"] == []
+  assert result["state"] == "diverged"
 
 
 def test_local_only_and_invalid_source_paths_degrade_safely(tmp_path):


### PR DESCRIPTION
## Summary
- expose one read-only reconciliation preview using the same semantic proof as real app and platform updates
- classify paths as local-only, incoming-only, compatible overlap, or unresolved conflict
- remove byte-identical endpoint paths and install-managed adaptations from remaining owner-authored work
- keep exact counts independent from bounded path previews and fail open only for expected Git/runtime failures

## Why
Raw ahead/behind counts cannot tell whether a reviewed local change has already landed upstream under a squash commit. Existing source status could therefore report a repository as customized or diverged even when its endpoint tree was already aligned, and its managed-path classification depended on whichever paths fit in the UI preview.

This follows #57 and #61's safe aggregate source map and #177's installed-projection boundary. It reuses the update engine's existing equivalent-change proof rather than adding a second reconciliation mechanism.

## Validation
- hermetic backend contract suite: 65 passed
- focused coverage for equal sibling histories, compatible same-file edits, reviewed squash provenance, true conflicts, preview truncation, managed files, and expected failure degradation
- current-main cherry-pick and clean diff
- full CI before merge