### PR TITLE
Show provider plans and usage on demand

### DIFF
--- a/backend/app/provider_usage.py
+++ b/backend/app/provider_usage.py
@@ -1,0 +1,343 @@
+"""Read-only provider-plan usage snapshots for the Settings surface."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import shutil
+from contextlib import suppress
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from app import providers
+
+log = logging.getLogger(__name__)
+
+_CLAUDE_USAGE_URL = "https://api.anthropic.com/api/oauth/usage"
+_PROVIDER_TIMEOUT_SECONDS = 12.0
+
+_CLAUDE_WINDOW_LABELS = {
+  "five_hour": "5-hour",
+  "seven_day": "Weekly",
+  "seven_day_opus": "Opus weekly",
+  "seven_day_sonnet": "Sonnet weekly",
+  "seven_day_oauth_apps": "Connected apps weekly",
+  "seven_day_overage_included": "Extra usage weekly",
+  "monthly": "Monthly",
+  "monthly_agent_sdk": "Agent SDK monthly",
+  "agent_sdk_monthly": "Agent SDK monthly",
+}
+_CLAUDE_WINDOW_ORDER = tuple(_CLAUDE_WINDOW_LABELS)
+
+_PLAN_LABELS = {
+  "free": "Free plan",
+  "go": "Go plan",
+  "plus": "Plus plan",
+  "pro": "Pro plan",
+  "prolite": "Pro plan",
+  "max": "Max plan",
+  "team": "Team plan",
+  "business": "Business plan",
+  "self_serve_business_usage_based": "Business plan",
+  "enterprise": "Enterprise plan",
+  "enterprise_cbp_usage_based": "Enterprise plan",
+  "edu": "Education plan",
+  "api": "API billing",
+  "api_key": "API billing",
+}
+
+
+def plan_label(raw: Any) -> str | None:
+  if hasattr(raw, "value"):
+    raw = raw.value
+  if not isinstance(raw, str) or not raw.strip():
+    return None
+  value = raw.strip().lower().replace("-", "_").replace(" ", "_")
+  if value == "unknown":
+    return None
+  known = _PLAN_LABELS.get(value)
+  if known:
+    return known
+  return f"{value.replace('_', ' ').title()} plan"
+
+
+def _used_percent(raw: Any) -> float | int | None:
+  if isinstance(raw, bool):
+    return None
+  try:
+    value = float(raw)
+  except (TypeError, ValueError):
+    return None
+  if not 0 <= value <= 100:
+    return None
+  rounded = round(value, 1)
+  return int(rounded) if rounded.is_integer() else rounded
+
+
+def _reset_iso(raw: Any) -> str | None:
+  if raw is None or isinstance(raw, bool):
+    return None
+  if isinstance(raw, (int, float)):
+    seconds = float(raw)
+    if seconds > 10_000_000_000:
+      seconds /= 1000
+    try:
+      return datetime.fromtimestamp(seconds, tz=UTC).isoformat()
+    except (OSError, OverflowError, ValueError):
+      return None
+  if not isinstance(raw, str) or not raw.strip():
+    return None
+  value = raw.strip()
+  try:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+  except ValueError:
+    return None
+  if parsed.tzinfo is None:
+    parsed = parsed.replace(tzinfo=UTC)
+  return parsed.astimezone(UTC).isoformat()
+
+
+def _humanize_window_id(window_id: str) -> str:
+  return window_id.replace("_", " ").strip().title()
+
+
+def _window(
+  window_id: str,
+  label: str,
+  used_percent: Any,
+  resets_at: Any,
+) -> dict[str, Any] | None:
+  used = _used_percent(used_percent)
+  if used is None:
+    return None
+  return {
+    "id": window_id,
+    "label": label,
+    "used_percent": used,
+    "resets_at": _reset_iso(resets_at),
+  }
+
+
+def normalize_claude_usage(
+  payload: Any,
+  *,
+  subscription_type: Any = None,
+) -> dict[str, Any]:
+  """Normalize Claude's evolving usage document into stable display windows."""
+  source = payload if isinstance(payload, dict) else {}
+  ordered_ids = [
+    *[key for key in _CLAUDE_WINDOW_ORDER if key in source],
+    *[key for key in source if key not in _CLAUDE_WINDOW_LABELS],
+  ]
+  windows: list[dict[str, Any]] = []
+  for window_id in ordered_ids:
+    raw = source.get(window_id)
+    if not isinstance(raw, dict):
+      continue
+    normalized = _window(
+      window_id,
+      _CLAUDE_WINDOW_LABELS.get(window_id, _humanize_window_id(window_id)),
+      raw.get("utilization", raw.get("used_percentage")),
+      raw.get("resets_at", raw.get("resetsAt")),
+    )
+    if normalized is not None:
+      windows.append(normalized)
+  return {
+    "state": "ready" if windows else "unavailable",
+    "plan_label": plan_label(subscription_type),
+    "windows": windows,
+    "credit_balance": None,
+  }
+
+
+def _codex_window_label(raw: dict[str, Any], fallback: str) -> str:
+  duration = raw.get("window_duration_mins", raw.get("windowDurationMins"))
+  if duration == 300:
+    return "5-hour"
+  if duration == 10_080:
+    return "Weekly"
+  if isinstance(duration, (int, float)) and duration > 0:
+    hours = duration / 60
+    if hours.is_integer():
+      return f"{int(hours)}-hour"
+  return fallback
+
+
+def normalize_codex_usage(
+  payload: Any,
+  *,
+  plan_type: Any = None,
+) -> dict[str, Any]:
+  """Normalize Codex account/rate-limit protocol data for Settings."""
+  source = payload if isinstance(payload, dict) else {}
+  limits = source.get("rate_limits", source.get("rateLimits"))
+  limits = limits if isinstance(limits, dict) else {}
+  plan = plan_type or limits.get("plan_type", limits.get("planType"))
+  windows: list[dict[str, Any]] = []
+  for key, fallback in (("primary", "Current window"), ("secondary", "Weekly")):
+    raw = limits.get(key)
+    if not isinstance(raw, dict):
+      continue
+    normalized = _window(
+      key,
+      _codex_window_label(raw, fallback),
+      raw.get("used_percent", raw.get("usedPercent")),
+      raw.get("resets_at", raw.get("resetsAt")),
+    )
+    if normalized is not None:
+      windows.append(normalized)
+
+  credit_balance = None
+  credits = limits.get("credits")
+  if isinstance(credits, dict):
+    if credits.get("unlimited") is True:
+      credit_balance = "Unlimited credits"
+    elif credits.get("has_credits", credits.get("hasCredits")) is True:
+      balance = credits.get("balance")
+      if isinstance(balance, str) and balance.strip():
+        credit_balance = f"{balance.strip()} credits"
+
+  return {
+    "state": "ready" if windows else "unavailable",
+    "plan_label": plan_label(plan),
+    "windows": windows,
+    "credit_balance": credit_balance,
+  }
+
+
+async def _fetch_claude_usage(data_dir: str) -> dict[str, Any]:
+  subscription_type = providers.claude_subscription_type(data_dir)
+  token = await providers.claude_access_token(data_dir)
+  headers = {
+    "Authorization": f"Bearer {token}",
+    "anthropic-version": "2023-06-01",
+    "anthropic-beta": "oauth-2025-04-20",
+    "Content-Type": "application/json",
+  }
+  async with httpx.AsyncClient(timeout=5.0) as client:
+    response = await client.get(_CLAUDE_USAGE_URL, headers=headers)
+    response.raise_for_status()
+    return normalize_claude_usage(
+      response.json(),
+      subscription_type=subscription_type,
+    )
+
+
+def _codex_plan_type(account_response: Any) -> Any:
+  account = getattr(account_response, "account", None)
+  account = getattr(account, "root", account)
+  return getattr(account, "plan_type", None)
+
+
+def _read_started_codex_client(client: Any) -> tuple[Any, Any]:
+  """Run the blocking typed protocol calls after the app-server is started."""
+  from openai_codex.generated.v2_all import GetAccountRateLimitsResponse
+
+  client.initialize()
+  account = client.account_read()
+  limits = client.request(
+    "account/rateLimits/read",
+    None,
+    response_model=GetAccountRateLimitsResponse,
+  )
+  return account, limits
+
+
+async def _fetch_codex_usage(data_dir: str) -> dict[str, Any]:
+  """Read Codex plan limits with a bounded, explicitly reaped app-server."""
+  from openai_codex.client import CodexClient, CodexConfig
+
+  codex_bin = shutil.which("codex")
+  if not codex_bin:
+    raise RuntimeError("codex CLI not found")
+  env = dict(os.environ)
+  env["CODEX_HOME"] = str(Path(data_dir) / "cli-auth" / "codex")
+  client = CodexClient(CodexConfig(
+    codex_bin=codex_bin,
+    cwd=data_dir,
+    env=env,
+    client_name="mobius_settings",
+    client_title="Möbius Settings",
+  ))
+
+  # Popen itself is immediate and gives cleanup a concrete process to reap.
+  # The JSON-RPC calls run off-loop; if one wedges, close() terminates the
+  # app-server and unblocks its waiter before this endpoint returns.
+  client.start()
+  task = asyncio.create_task(asyncio.to_thread(_read_started_codex_client, client))
+  try:
+    account, limits = await asyncio.wait_for(
+      asyncio.shield(task),
+      timeout=_PROVIDER_TIMEOUT_SECONDS,
+    )
+  except TimeoutError:
+    await asyncio.to_thread(client.close)
+    with suppress(Exception):
+      await asyncio.wait_for(task, timeout=2.0)
+    raise RuntimeError("codex usage read timed out")
+  finally:
+    await asyncio.to_thread(client.close)
+
+  raw = limits.model_dump(mode="json", by_alias=False)
+  return normalize_codex_usage(raw, plan_type=_codex_plan_type(account))
+
+
+def _unavailable(plan_label: str | None = None) -> dict[str, Any]:
+  return {
+    "state": "unavailable",
+    "plan_label": plan_label,
+    "windows": [],
+    "credit_balance": None,
+  }
+
+
+async def _provider_snapshot(provider_id: str, data_dir: str) -> dict[str, Any]:
+  provider = providers.PROVIDERS[provider_id]
+  if provider.check_auth(data_dir) is not None:
+    return {
+      "state": "disconnected",
+      "plan_label": None,
+      "windows": [],
+      "credit_balance": None,
+    }
+  try:
+    if provider_id == "claude":
+      return await _fetch_claude_usage(data_dir)
+    if provider_id == "codex":
+      return await _fetch_codex_usage(data_dir)
+  except Exception as exc:  # best-effort read; Settings must still open
+    log.warning("%s plan usage unavailable: %s", provider_id, exc)
+    subscription = (
+      providers.claude_subscription_type(data_dir)
+      if provider_id == "claude"
+      else providers.codex_subscription_type(data_dir)
+    )
+    plan = plan_label(subscription)
+    return _unavailable(plan)
+  return _unavailable()
+
+
+def configured_plan_labels(data_dir: str) -> dict[str, str]:
+  """Read the locally stored plan labels without contacting either provider."""
+  return {
+    "claude": (
+      plan_label(providers.claude_subscription_type(data_dir))
+      or "Claude plan"
+    ),
+    "codex": (
+      plan_label(providers.codex_subscription_type(data_dir))
+      or "Codex plan"
+    ),
+  }
+
+
+async def read_provider_usage(
+  provider_id: str,
+  data_dir: str,
+) -> dict[str, Any]:
+  """Read one provider's plan usage only when its disclosure is opened."""
+  return await _provider_snapshot(provider_id, data_dir)

--- a/backend/app/providers.py
+++ b/backend/app/providers.py
@@ -22,6 +22,7 @@ it in PROVIDERS.
 """
 
 import asyncio
+import base64
 import json
 import logging
 import os
@@ -666,7 +667,7 @@ class ClaudeProvider(BaseProvider):
     than blocking every turn here.
     """
     try:
-      await _claude_access_token(data_dir)
+      await claude_access_token(data_dir)
     except Exception as exc:  # noqa: BLE001 - best-effort; never block a turn
       log.warning("claude pre-turn token refresh failed: %s", exc)
 
@@ -1056,7 +1057,7 @@ async def _refresh_claude_access_token(oauth: dict) -> dict:
   return refreshed
 
 
-async def _claude_access_token(data_dir: str) -> str:
+async def claude_access_token(data_dir: str) -> str:
   """Returns a non-expired Claude OAuth access token, refreshing it when the
   stored one has expired (or is within the refresh margin).
 
@@ -1103,6 +1104,51 @@ async def _claude_access_token(data_dir: str) -> str:
     return refreshed["accessToken"]
 
 
+def claude_subscription_type(data_dir: str) -> str | None:
+  """Return the non-secret Claude plan identifier stored with OAuth."""
+  try:
+    _, oauth = _read_claude_oauth(data_dir)
+  except (OSError, RuntimeError, ValueError):
+    return None
+  value = oauth.get("subscriptionType")
+  return value if isinstance(value, str) and value.strip() else None
+
+
+def codex_subscription_type(data_dir: str) -> str | None:
+  """Return the non-secret Codex plan identifier stored in its ID token.
+
+  This is display metadata only. Runtime authentication and live usage still
+  go through the Codex app-server, which remains authoritative.
+  """
+  path = Path(data_dir) / "cli-auth" / "codex" / "auth.json"
+  try:
+    auth = json.loads(path.read_text())
+    tokens = auth.get("tokens") if isinstance(auth, dict) else None
+    id_token = (
+      tokens.get("id_token")
+      if isinstance(tokens, dict)
+      else auth.get("id_token") if isinstance(auth, dict) else None
+    )
+    if not isinstance(id_token, str):
+      return None
+    parts = id_token.split(".")
+    if len(parts) != 3:
+      return None
+    encoded = parts[1] + "=" * (-len(parts[1]) % 4)
+    payload = json.loads(base64.urlsafe_b64decode(encoded))
+  except (OSError, ValueError, UnicodeError):
+    return None
+  if not isinstance(payload, dict):
+    return None
+  namespace = payload.get("https://api.openai.com/auth")
+  value = (
+    namespace.get("chatgpt_plan_type")
+    if isinstance(namespace, dict)
+    else payload.get("chatgpt_plan_type")
+  )
+  return value if isinstance(value, str) and value.strip() else None
+
+
 async def _fetch_claude_models(data_dir: str) -> list[str]:
   """Calls Anthropic's /v1/models with the stored OAuth access token.
 
@@ -1112,13 +1158,13 @@ async def _fetch_claude_models(data_dir: str) -> list[str]:
   httpx (already a requirement) instead of pulling the `anthropic`
   SDK to keep dependency surface flat.
 
-  The access token is refreshed in `_claude_access_token` when expired —
+  The access token is refreshed in `claude_access_token` when expired —
   without that, an expired CLI token 401s here and the picker is stuck on
   the static KNOWN_MODELS fallback until the container restarts.
   """
   import httpx  # local import — only the registry path needs it
 
-  token = await _claude_access_token(data_dir)
+  token = await claude_access_token(data_dir)
   headers = {
     "Authorization": f"Bearer {token}",
     "anthropic-version": "2023-06-01",

--- a/backend/app/routes/settings.py
+++ b/backend/app/routes/settings.py
@@ -22,7 +22,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import Response
 from sqlalchemy.orm import Session
 
-from app import models, providers
+from app import models, provider_usage, providers
 from app.config import get_settings as get_app_settings
 from app.database import get_db
 from app.deps import (
@@ -279,7 +279,22 @@ def get_settings_view(
     "skills_enabled": providers.skills_enabled(data_dir),
     "claude_version": _format_cli_version(_cli_version("claude")),
     "codex_version": _format_cli_version(_cli_version("codex")),
+    "provider_plans": provider_usage.configured_plan_labels(data_dir),
   }
+
+
+@settings_router.get("/provider-usage/{provider_id}")
+async def get_provider_usage(
+  provider_id: str,
+  _: models.Owner = Depends(get_current_owner),
+) -> dict:
+  """Returns one connected provider's current plan allowance windows."""
+  if provider_id not in providers.PROVIDERS:
+    raise HTTPException(status_code=404, detail="Unknown provider.")
+  return await provider_usage.read_provider_usage(
+    provider_id,
+    get_app_settings().data_dir,
+  )
 
 
 @settings_router.post("", dependencies=[Depends(reject_cross_site)])

--- a/backend/tests/test_model_registry.py
+++ b/backend/tests/test_model_registry.py
@@ -191,7 +191,7 @@ async def test_access_token_returned_verbatim_when_fresh(tmp_path):
   """A token with comfortable life left is used as-is — no refresh call."""
   future = int(time.time() * 1000) + 60 * 60 * 1000  # +1h
   _write_creds(tmp_path, access="fresh-tok", refresh="r", expires_at=future)
-  token = await providers._claude_access_token(str(tmp_path))
+  token = await providers.claude_access_token(str(tmp_path))
   assert token == "fresh-tok"
 
 
@@ -218,7 +218,7 @@ async def test_expired_token_is_refreshed_and_persisted(tmp_path, monkeypatch):
 
   _install_mock_transport(monkeypatch, handler)
 
-  token = await providers._claude_access_token(str(tmp_path))
+  token = await providers.claude_access_token(str(tmp_path))
   assert token == "new-access-tok"
   # Correct refresh-grant shape sent upstream.
   assert captured["url"] == providers._CLAUDE_OAUTH_TOKEN_URL
@@ -264,7 +264,7 @@ async def test_refresh_preserves_sibling_credential_keys(tmp_path, monkeypatch):
 
   _install_mock_transport(monkeypatch, handler)
 
-  token = await providers._claude_access_token(str(tmp_path))
+  token = await providers.claude_access_token(str(tmp_path))
   assert token == "new-access-tok"
 
   saved = json.loads(creds_path.read_text())

--- a/backend/tests/test_provider_usage.py
+++ b/backend/tests/test_provider_usage.py
@@ -1,0 +1,172 @@
+"""Provider-plan usage normalization and Settings endpoint contracts."""
+
+import asyncio
+import base64
+import json
+
+
+def test_normalize_claude_usage_keeps_current_and_model_windows():
+  from app.provider_usage import normalize_claude_usage
+
+  snapshot = normalize_claude_usage(
+    {
+      "five_hour": {
+        "utilization": 34.2,
+        "resets_at": "2026-07-30T17:00:00Z",
+      },
+      "seven_day": {
+        "utilization": 61,
+        "resets_at": "2026-08-03T00:00:00+00:00",
+      },
+      "seven_day_opus": {
+        "utilization": 12,
+        "resets_at": "2026-08-03T00:00:00Z",
+      },
+      "extra_usage": {"is_enabled": False},
+    },
+    subscription_type="max",
+  )
+
+  assert snapshot["state"] == "ready"
+  assert snapshot["plan_label"] == "Max plan"
+  assert [window["label"] for window in snapshot["windows"]] == [
+    "5-hour", "Weekly", "Opus weekly",
+  ]
+  assert snapshot["windows"][0]["used_percent"] == 34.2
+  assert snapshot["windows"][0]["resets_at"] == "2026-07-30T17:00:00+00:00"
+
+
+def test_normalize_codex_usage_reads_primary_secondary_and_credits():
+  from app.provider_usage import normalize_codex_usage
+
+  snapshot = normalize_codex_usage(
+    {
+      "rate_limits": {
+        "primary": {
+          "used_percent": 21,
+          "window_duration_mins": 300,
+          "resets_at": 1785430800,
+        },
+        "secondary": {
+          "used_percent": 54,
+          "window_duration_mins": 10080,
+          "resets_at": 1785715200,
+        },
+        "credits": {
+          "has_credits": True,
+          "unlimited": False,
+          "balance": "18.50",
+        },
+      },
+    },
+    plan_type="plus",
+  )
+
+  assert snapshot["state"] == "ready"
+  assert snapshot["plan_label"] == "Plus plan"
+  assert [window["label"] for window in snapshot["windows"]] == [
+    "5-hour", "Weekly",
+  ]
+  assert snapshot["windows"][1]["used_percent"] == 54
+  assert snapshot["credit_balance"] == "18.50 credits"
+
+
+def test_normalizers_report_unavailable_without_inventing_limits():
+  from app.provider_usage import normalize_claude_usage, normalize_codex_usage
+
+  claude = normalize_claude_usage({}, subscription_type="pro")
+  codex = normalize_codex_usage({"rate_limits": {}}, plan_type="team")
+
+  assert claude == {
+    "state": "unavailable",
+    "plan_label": "Pro plan",
+    "windows": [],
+    "credit_balance": None,
+  }
+  assert codex == {
+    "state": "unavailable",
+    "plan_label": "Team plan",
+    "windows": [],
+    "credit_balance": None,
+  }
+
+
+def test_provider_usage_reads_only_requested_plan(monkeypatch):
+  from app import provider_usage
+
+  seen = []
+
+  async def fake_snapshot(provider_id, _data_dir):
+    await asyncio.sleep(0)
+    seen.append(provider_id)
+    return {"state": "ready", "windows": [{"id": "primary"}]}
+
+  monkeypatch.setattr(provider_usage, "_provider_snapshot", fake_snapshot)
+  body = asyncio.run(provider_usage.read_provider_usage("codex", "/data"))
+
+  assert body["state"] == "ready"
+  assert seen == ["codex"]
+
+
+def test_settings_provider_usage_endpoint(client, auth, monkeypatch):
+  from app import provider_usage
+
+  expected = {"state": "ready", "windows": []}
+  seen = []
+
+  async def fake_read(provider_id, _data_dir):
+    seen.append(provider_id)
+    return expected
+
+  monkeypatch.setattr(provider_usage, "read_provider_usage", fake_read)
+  response = client.get("/api/settings/provider-usage/codex", headers=auth)
+
+  assert response.status_code == 200
+  assert response.json() == expected
+  assert seen == ["codex"]
+
+
+def test_settings_provider_usage_rejects_unknown_provider(client, auth):
+  response = client.get("/api/settings/provider-usage/other", headers=auth)
+
+  assert response.status_code == 404
+
+
+def test_codex_subscription_type_reads_display_claim(tmp_path):
+  from app import providers
+
+  payload = {
+    "https://api.openai.com/auth": {
+      "chatgpt_plan_type": "plus",
+    },
+  }
+  encoded = base64.urlsafe_b64encode(
+    json.dumps(payload).encode(),
+  ).decode().rstrip("=")
+  auth_path = tmp_path / "cli-auth" / "codex" / "auth.json"
+  auth_path.parent.mkdir(parents=True)
+  auth_path.write_text(json.dumps({
+    "tokens": {"id_token": f"header.{encoded}.signature"},
+  }))
+
+  assert providers.codex_subscription_type(str(tmp_path)) == "plus"
+
+
+def test_configured_plan_labels_never_fetch_usage(monkeypatch):
+  from app import provider_usage, providers
+
+  monkeypatch.setattr(
+    providers,
+    "claude_subscription_type",
+    lambda _data_dir: "max",
+  )
+  monkeypatch.setattr(
+    providers,
+    "codex_subscription_type",
+    lambda _data_dir: "plus",
+  )
+
+  assert provider_usage.configured_plan_labels("/data") == {
+    "claude": "Max plan",
+    "codex": "Plus plan",
+  }

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -481,6 +481,9 @@ export const api = {
   },
   settings: {
     get: () => apiFetch('/settings'),
+    providerUsage: (provider) => apiFetch(
+      `/settings/provider-usage/${encodeURIComponent(provider)}`,
+    ),
     save: (payload) => apiFetch('/settings', {
       method: 'POST',
       body: JSON.stringify(payload),

--- a/frontend/src/components/ProviderAuth/ProviderAuth.css
+++ b/frontend/src/components/ProviderAuth/ProviderAuth.css
@@ -425,6 +425,109 @@
   line-height: 1.4;
 }
 
+/* A connected provider's plan name is the usage disclosure. Keeping it in the
+   status line makes the collapsed row no taller than "Connected" was. */
+.provider-plan-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  margin: 0;
+  padding: 1px 0;
+  border: 0;
+  background: none;
+  color: var(--green);
+  font: inherit;
+  font-size: 12.5px;
+  font-weight: 500;
+  line-height: 1.4;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.provider-plan-toggle__chevron {
+  flex: none;
+  transition: transform 140ms ease;
+}
+
+.provider-plan-toggle[aria-expanded="true"] {
+  color: var(--green);
+}
+
+.provider-plan-toggle[aria-expanded="true"] .provider-plan-toggle__chevron {
+  transform: rotate(180deg);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .provider-plan-toggle:hover {
+    color: color-mix(in srgb, var(--green) 82%, var(--text));
+  }
+}
+
+.provider-plan-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 3px;
+}
+
+/* Expanded usage is a terse metric strip rather than a stack of progress
+   bars. It appears only after the plan disclosure is opened. */
+.provider-usage {
+  display: grid;
+  gap: 6px;
+  width: min(100%, 460px);
+  margin-top: 3px;
+  padding-top: 7px;
+  border-top: 1px solid var(--border-light);
+}
+
+.provider-usage--message,
+.provider-usage__unavailable {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.provider-usage__windows {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(92px, 1fr));
+  gap: 7px 16px;
+}
+
+.provider-usage__window {
+  display: grid;
+  gap: 1px;
+  min-width: 0;
+}
+
+.provider-usage__label {
+  color: var(--muted);
+  font-size: 10.5px;
+  line-height: 1.25;
+}
+
+.provider-usage__value {
+  color: var(--text);
+  font-size: 15px;
+  font-weight: 500;
+  line-height: 1.3;
+  font-variant-numeric: tabular-nums;
+}
+
+.provider-usage__reset {
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 10.5px;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.provider-usage__credit {
+  color: var(--muted);
+  font-size: 11.5px;
+  line-height: 1.35;
+}
+
 /* Provider connected / disconnected indicator now renders via
    the shared <StatusDot> component
    (frontend/src/components/ui/StatusDot.jsx) — the bespoke

--- a/frontend/src/components/ProviderAuth/ProviderRow.jsx
+++ b/frontend/src/components/ProviderAuth/ProviderRow.jsx
@@ -26,6 +26,8 @@ import './ProviderAuth.css'
  *   statusNode      — optional node replacing the default Connected/Not
  *                     connected StatusDot (e.g. "Configured", or the
  *                     chat model's "Last model: Opus 4.8").
+ *   detailNode      — optional richer read-only detail below the status
+ *                     (e.g. current plan allowance windows in Settings).
  *   actionLabel     — optional override for the action button text
  *                     (e.g. "Reconfigure" / "Configure"); the default
  *                     is the Connect/Reconnect/Close verb below.
@@ -33,10 +35,10 @@ import './ProviderAuth.css'
  */
 export default function ProviderRow({
   name, connected, expanded, onToggleExpand, children,
-  badge, version, subtitle, statusNode, actionLabel, disabled = false,
+  badge, version, subtitle, statusNode, detailNode, actionLabel, disabled = false,
 }) {
-  // Name + installed CLI/SDK version + status are informational. The explicit
-  // action button is the only interactive target in the row.
+  // Name + installed CLI/SDK version are informational. The status slot can
+  // optionally carry a compact disclosure; auth remains a separate action.
   const info = (
     <span className="provider-row__info">
       <span className="provider-row__name-line">
@@ -60,6 +62,7 @@ export default function ProviderRow({
           {connected ? 'Connected' : 'Not connected'}
         </StatusDot>
       )}
+      {detailNode}
     </span>
   )
 

--- a/frontend/src/components/SettingsView/ProviderUsage.jsx
+++ b/frontend/src/components/SettingsView/ProviderUsage.jsx
@@ -1,0 +1,54 @@
+/* Compact plan and allowance detail rendered under a connected provider row. */
+
+import {
+  clampUsagePercent,
+  formatUsagePercent,
+  formatUsageReset,
+  visibleUsageWindows,
+} from './providerUsage.js'
+
+export default function ProviderUsage({
+  id,
+  snapshot,
+  loading = false,
+  failed = false,
+}) {
+  if (loading && !snapshot) {
+    return (
+      <span id={id} className="provider-usage provider-usage--message" role="status">
+        Checking plan usage…
+      </span>
+    )
+  }
+
+  if (!snapshot && !failed) return null
+  const windows = visibleUsageWindows(snapshot)
+  const ready = snapshot?.state === 'ready' && windows.length > 0
+
+  return (
+    <span id={id} className="provider-usage">
+      {ready ? (
+        <span className="provider-usage__windows">
+          {windows.map(window => {
+            const percent = clampUsagePercent(window.used_percent)
+            const reset = formatUsageReset(window.resets_at)
+            return (
+              <span className="provider-usage__window" key={window.id || window.label}>
+                <span className="provider-usage__label">{window.label}</span>
+                <span className="provider-usage__value">
+                  {formatUsagePercent(percent)}%
+                </span>
+                {reset && <span className="provider-usage__reset">{reset}</span>}
+              </span>
+            )
+          })}
+          {snapshot?.credit_balance && (
+            <span className="provider-usage__credit">{snapshot.credit_balance}</span>
+          )}
+        </span>
+      ) : (
+        <span className="provider-usage__unavailable">Usage unavailable</span>
+      )}
+    </span>
+  )
+}

--- a/frontend/src/components/SettingsView/SettingsView.jsx
+++ b/frontend/src/components/SettingsView/SettingsView.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { Alert } from '@openai/apps-sdk-ui/components/Alert'
-import { Moon, Sun } from '@openai/apps-sdk-ui/components/Icon'
+import { ChevronDown, Moon, Sun } from '@openai/apps-sdk-ui/components/Icon'
 import GripVertical from 'lucide-react/dist/esm/icons/grip-vertical.mjs'
 import { api, clearQueryCache, clearToken } from '../../api/client.js'
 import { authQueries, modelQueries, settingsQueries, themeQueries, versionQueries } from '../../hooks/queries.js'
@@ -30,6 +30,8 @@ import ModelSheet from '../ui/ModelSheet.jsx'
 import { modelEfforts, validEffort } from '../ui/modelEfforts.js'
 import ManageModelsModal from '../ChatView/ManageModelsModal.jsx'
 import UpdateReviewModal from './UpdateReviewModal.jsx'
+import ProviderUsage from './ProviderUsage.jsx'
+import { formatPlanStatus } from './providerUsage.js'
 import { PROVIDER_INFO, PROVIDER_ORDER } from '../ChatView/ChatSettingsPanel.jsx'
 import '../ui/StatusDot.css'
 import '../ui/ModelSheet.css'
@@ -81,6 +83,27 @@ function defaultBackgroundModel(provider) {
 
 function isKnownProvider(provider) {
   return PROVIDER_CHOICES.some(p => p.id === provider)
+}
+
+function PlanUsageToggle({ provider, label, expanded, onToggle }) {
+  return (
+    <button
+      type="button"
+      className="provider-plan-toggle"
+      onClick={onToggle}
+      aria-expanded={expanded}
+      aria-controls={`provider-usage-${provider}`}
+      aria-label={`${label}, ${expanded ? 'hide' : 'show'} usage`}
+    >
+      <span>{label}</span>
+      <ChevronDown
+        className="provider-plan-toggle__chevron"
+        width={13}
+        height={13}
+        aria-hidden="true"
+      />
+    </button>
+  )
 }
 
 function providerFromSettings(settings) {
@@ -335,6 +358,9 @@ export default function SettingsView({
   const [themeSwitching, setThemeSwitching] = useState(false)
   // Which provider has its inline auth panel expanded. null = none.
   const [expandedAuth, setExpandedAuth] = useState(null)
+  // Usage is deliberately on demand. Only the disclosed provider fetches,
+  // and keeping this separate from auth preserves the row's two clear actions.
+  const [expandedUsage, setExpandedUsage] = useState(null)
   // Surface failures from the dark-mode toggle: a failed theme
   // persist would otherwise bounce the knob without telling the user
   // why.
@@ -413,6 +439,18 @@ export default function SettingsView({
   //   LOADING — no data yet and no error: the initial in-flight fetch.
   const providerReady = settingsQuery.data !== undefined
     && providerAvailability.phase === PROVIDER_AVAILABILITY_PHASE.READY
+  const codexUsageQuery = settingsQueries.providerUsage.useQuery('codex', {
+    enabled: (
+      active && providerReady && codexAuthenticated
+      && expandedUsage === 'codex'
+    ),
+  })
+  const claudeUsageQuery = settingsQueries.providerUsage.useQuery('claude', {
+    enabled: (
+      active && providerReady && claudeAuthenticated
+      && expandedUsage === 'claude'
+    ),
+  })
   // Registry and provider/settings probes are independent. Starting them
   // together avoids an unnecessary request waterfall on a first open.
   const modelRegistryQuery = modelQueries.registry.useQuery()
@@ -740,23 +778,37 @@ export default function SettingsView({
   // render, which combined with the row's CSS transitions made the
   // panel feel jittery. With the updater form, deps are empty.
   const toggleClaudeAuth = useCallback(
-    () => setExpandedAuth(prev => {
-      if (prev !== 'claude') {
-        authProvidersAtStartRef.current = new Set(configuredProvidersRef.current)
-      }
-      return prev === 'claude' ? null : 'claude'
-    }),
+    () => {
+      setExpandedUsage(null)
+      setExpandedAuth(prev => {
+        if (prev !== 'claude') {
+          authProvidersAtStartRef.current = new Set(configuredProvidersRef.current)
+        }
+        return prev === 'claude' ? null : 'claude'
+      })
+    },
     [],
   )
   const toggleCodexAuth = useCallback(
-    () => setExpandedAuth(prev => {
-      if (prev !== 'codex') {
-        authProvidersAtStartRef.current = new Set(configuredProvidersRef.current)
-      }
-      return prev === 'codex' ? null : 'codex'
-    }),
+    () => {
+      setExpandedUsage(null)
+      setExpandedAuth(prev => {
+        if (prev !== 'codex') {
+          authProvidersAtStartRef.current = new Set(configuredProvidersRef.current)
+        }
+        return prev === 'codex' ? null : 'codex'
+      })
+    },
     [],
   )
+  const toggleClaudeUsage = useCallback(() => {
+    setExpandedAuth(null)
+    setExpandedUsage(prev => prev === 'claude' ? null : 'claude')
+  }, [])
+  const toggleCodexUsage = useCallback(() => {
+    setExpandedAuth(null)
+    setExpandedUsage(prev => prev === 'codex' ? null : 'codex')
+  }, [])
   const onProviderConnected = useCallback(async (provider) => {
     const providersBefore = authProvidersAtStartRef.current || configuredProviders
     const newlyConnected = !providersBefore.has(provider)
@@ -787,6 +839,7 @@ export default function SettingsView({
     }
     authProvidersAtStartRef.current = null
     settingsQueries.owner.invalidate(queryClient)
+    settingsQueries.providerUsage.invalidate(queryClient, provider)
     setExpandedAuth(null)
   }, [configuredProviders, persistBackgroundAgents, queryClient, settingsQuery.data])
   const onClaudeAuthDone = useCallback(() => {
@@ -1347,6 +1400,16 @@ export default function SettingsView({
     ? (modelsForProvider(defaultChatProvider).find(m => m.id === defaultChatModelId)?.label
         || defaultChatModelId)
     : ''
+  const codexPlanLabel = (
+    codexUsageQuery.data?.plan_label
+    || settingsQuery.data?.provider_plans?.codex
+    || ''
+  )
+  const claudePlanLabel = (
+    claudeUsageQuery.data?.plan_label
+    || settingsQuery.data?.provider_plans?.claude
+    || ''
+  )
 
   return (
     <div className="settings">
@@ -1368,6 +1431,22 @@ export default function SettingsView({
                   name="OpenAI Codex"
                   connected={codexAuthenticated}
                   version={codexVersion}
+                  statusNode={codexAuthenticated ? (
+                    <PlanUsageToggle
+                      provider="codex"
+                      label={formatPlanStatus(codexPlanLabel)}
+                      expanded={expandedUsage === 'codex'}
+                      onToggle={toggleCodexUsage}
+                    />
+                  ) : undefined}
+                  detailNode={codexAuthenticated && expandedUsage === 'codex' ? (
+                    <ProviderUsage
+                      id="provider-usage-codex"
+                      snapshot={codexUsageQuery.data}
+                      loading={codexUsageQuery.isPending}
+                      failed={codexUsageQuery.isError}
+                    />
+                  ) : null}
                   expanded={expandedAuth === 'codex'}
                   onToggleExpand={toggleCodexAuth}
                 >
@@ -1378,6 +1457,22 @@ export default function SettingsView({
                   name="Claude Code"
                   connected={claudeAuthenticated}
                   version={claudeVersion}
+                  statusNode={claudeAuthenticated ? (
+                    <PlanUsageToggle
+                      provider="claude"
+                      label={formatPlanStatus(claudePlanLabel)}
+                      expanded={expandedUsage === 'claude'}
+                      onToggle={toggleClaudeUsage}
+                    />
+                  ) : undefined}
+                  detailNode={claudeAuthenticated && expandedUsage === 'claude' ? (
+                    <ProviderUsage
+                      id="provider-usage-claude"
+                      snapshot={claudeUsageQuery.data}
+                      loading={claudeUsageQuery.isPending}
+                      failed={claudeUsageQuery.isError}
+                    />
+                  ) : null}
                   expanded={expandedAuth === 'claude'}
                   onToggleExpand={toggleClaudeAuth}
                 >

--- a/frontend/src/components/SettingsView/providerUsage.js
+++ b/frontend/src/components/SettingsView/providerUsage.js
@@ -1,0 +1,43 @@
+/* Pure display helpers for compact provider-plan usage snapshots. */
+
+export function formatPlanStatus(label) {
+  const value = typeof label === 'string' ? label.trim() : ''
+  const name = value.replace(/\s+plan$/i, '').trim()
+  return `Plan: ${name || 'Unknown'}`
+}
+
+export function clampUsagePercent(value) {
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric)) return 0
+  return Math.min(100, Math.max(0, numeric))
+}
+
+export function formatUsagePercent(value) {
+  const numeric = clampUsagePercent(value)
+  return Number.isInteger(numeric) ? String(numeric) : numeric.toFixed(1)
+}
+
+export function formatUsageReset(value, now = new Date()) {
+  if (!value) return ''
+  const reset = new Date(value)
+  if (Number.isNaN(reset.getTime())) return ''
+  const sameDay = (
+    reset.getFullYear() === now.getFullYear()
+    && reset.getMonth() === now.getMonth()
+    && reset.getDate() === now.getDate()
+  )
+  const time = new Intl.DateTimeFormat(undefined, {
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(reset)
+  if (sameDay) return `resets ${time}`
+  const day = new Intl.DateTimeFormat(undefined, { weekday: 'short' }).format(reset)
+  return `resets ${day} ${time}`
+}
+
+export function visibleUsageWindows(snapshot) {
+  if (!Array.isArray(snapshot?.windows)) return []
+  return snapshot.windows
+    .filter(window => window && typeof window.label === 'string')
+    .slice(0, 4)
+}

--- a/frontend/src/hooks/queries.js
+++ b/frontend/src/hooks/queries.js
@@ -16,6 +16,8 @@ const themeKey = ['theme']
 const themeModeKey = ['theme-mode']
 const setupStatusKey = ['auth', 'setup', 'status']
 const settingsKey = ['settings']
+const providerUsageRootKey = ['settings', 'provider-usage']
+const providerUsageKey = (provider) => [...providerUsageRootKey, provider]
 const appsKey = ['apps']
 const chatsKey = ['chats']
 const providersStatusKey = ['auth', 'providers', 'status']
@@ -68,6 +70,21 @@ function useSetupStatusQuery({ enabled = true } = {}) {
 async function fetchSettings() {
   const res = await api.settings.get()
   return jsonOrThrow(res, 'settings fetch failed:')
+}
+
+async function fetchProviderUsage(provider) {
+  const res = await api.settings.providerUsage(provider)
+  return jsonOrThrow(res, 'provider usage fetch failed:')
+}
+
+function useProviderUsageQuery(provider, { enabled = true } = {}) {
+  return useQuery({
+    queryKey: providerUsageKey(provider),
+    queryFn: () => fetchProviderUsage(provider),
+    enabled: enabled && Boolean(provider),
+    staleTime: 60_000,
+    retry: 0,
+  })
 }
 
 function useSettingsQuery() {
@@ -320,6 +337,15 @@ export const settingsQueries = {
     fetch: fetchSettings,
     useQuery: useSettingsQuery,
     invalidate: (queryClient) => queryClient.invalidateQueries({ queryKey: settingsKey }),
+  },
+  providerUsage: {
+    key: providerUsageRootKey,
+    keyFor: providerUsageKey,
+    fetch: fetchProviderUsage,
+    useQuery: useProviderUsageQuery,
+    invalidate: (queryClient, provider) => queryClient.invalidateQueries({
+      queryKey: provider ? providerUsageKey(provider) : providerUsageRootKey,
+    }),
   },
 }
 

--- a/frontend/src/lib/__tests__/providerUsage.test.js
+++ b/frontend/src/lib/__tests__/providerUsage.test.js
@@ -1,0 +1,50 @@
+/* Usage snapshots stay bounded and format reset times without JSX mounting. */
+
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  clampUsagePercent,
+  formatPlanStatus,
+  formatUsagePercent,
+  formatUsageReset,
+  visibleUsageWindows,
+} from '../../components/SettingsView/providerUsage.js'
+
+test('connected plan status uses the compact green-disclosure copy', () => {
+  assert.equal(formatPlanStatus('Max plan'), 'Plan: Max')
+  assert.equal(formatPlanStatus('Pro plan'), 'Plan: Pro')
+  assert.equal(formatPlanStatus('API billing'), 'Plan: API billing')
+  assert.equal(formatPlanStatus(''), 'Plan: Unknown')
+})
+
+test('usage percentages are bounded and retain useful precision', () => {
+  assert.equal(clampUsagePercent(-2), 0)
+  assert.equal(clampUsagePercent(140), 100)
+  assert.equal(formatUsagePercent(34.2), '34.2')
+  assert.equal(formatUsagePercent(54), '54')
+})
+
+test('reset formatting distinguishes today from another day', () => {
+  const now = new Date('2026-07-30T12:00:00Z')
+  const today = formatUsageReset('2026-07-30T17:00:00Z', now)
+  const later = formatUsageReset('2026-08-03T17:00:00Z', now)
+
+  assert.match(today, /^resets /)
+  assert.doesNotMatch(today, /Mon/)
+  assert.match(later, /^resets Mon /)
+})
+
+test('only four valid allowance windows are rendered', () => {
+  const windows = visibleUsageWindows({
+    windows: [
+      { id: 'a', label: 'A' },
+      null,
+      { id: 'b', label: 'B' },
+      { id: 'c', label: 'C' },
+      { id: 'd', label: 'D' },
+      { id: 'e', label: 'E' },
+    ],
+  })
+
+  assert.deepEqual(windows.map(window => window.id), ['a', 'b', 'c', 'd'])
+})

--- a/tests/setup-provider-status.spec.mjs
+++ b/tests/setup-provider-status.spec.mjs
@@ -97,6 +97,8 @@ test('Codex shows the code before opening ChatGPT and stays authoritative', asyn
 
   await page.evaluate(() => window.dispatchEvent(new Event('pageshow')))
 
-  await expect(codexRow.getByText('Connected', { exact: true })).toBeVisible()
+  await expect(codexRow.getByRole('button', {
+    name: /^Plan: .+, show usage$/,
+  })).toBeVisible()
   await expect.poll(() => settingsWrites).toBe(1)
 })


### PR DESCRIPTION
## Summary
- show a compact green plan disclosure for each connected Claude or Codex provider
- keep disconnected rows explicit without making any usage request
- fetch only the provider whose disclosure the owner opens
- normalize allowance windows, reset times, plan labels, and optional credits behind one bounded response
- explicitly start, time out, and reap the Codex app-server used for a usage read

## Why
Provider rows already knew whether a connection worked but not which plan it represented or how much allowance remained. Loading both providers eagerly would add avoidable network and process work whenever Settings opened. This keeps the default rows compact and makes detail opt-in.

## Safety
The route is owner-only and returns normalized display data, never credentials. Claude uses the existing refreshable OAuth token path; Codex uses its typed local app-server protocol with a 12-second deadline and explicit close. Failures degrade to a plan label or an unavailable message without blocking Settings.

## Validation
- provider usage and model registry tests: 20 passed
- focused frontend plan/percentage/reset/window tests: 4 passed
- hermetic backend contract suite: 60 passed
- current-main integration and clean diff
- full CI before merge