### PR TITLE
Give recoverable deleted chats an explicit read scope

### DIFF
--- a/backend/app/app_capabilities.py
+++ b/backend/app/app_capabilities.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from copy import deepcopy
 from typing import Any
 
 
@@ -149,9 +150,14 @@ def contract_from_manifest(manifest: dict[str, Any]) -> dict[str, Any]:
   perms = manifest.get("permissions") or {}
   schedule = manifest.get("schedule") or {}
   requested_logs = perms.get("chat_log_access", "none")
-  # The only chat-log route is structurally redacted.  A historical ``full``
-  # declaration therefore has summary effectiveness, never silent full access.
-  effective_logs = "summary" if requested_logs in ("summary", "full") else "none"
+  # Both readable tiers use structural redaction. The higher tier widens only
+  # the lifecycle scope to recoverable soft-deleted chats; there is no raw/full
+  # transcript capability.
+  effective_logs = (
+    requested_logs
+    if requested_logs in ("summary", "summary_with_deleted")
+    else "none"
+  )
   job = schedule.get("job")
   cron = schedule.get("default")
   system_prompt = manifest.get("system_prompt")
@@ -174,7 +180,7 @@ def contract_from_manifest(manifest: dict[str, Any]) -> dict[str, Any]:
       "chat_logs": {
         "requested": requested_logs,
         "effective": effective_logs,
-        "redaction": "structural" if effective_logs == "summary" else "none",
+        "redaction": "structural" if effective_logs != "none" else "none",
       },
       "filesystem_api": bool(perms.get("filesystem_access", False)),
       "shared_memory": perms.get("shared_memory", "none"),
@@ -263,6 +269,35 @@ def contract_from_app_state(
     "capabilities": capabilities,
   }
   return contract_from_manifest(manifest)
+
+
+def contract_with_chat_log_access(
+  contract: dict[str, Any] | None,
+  access: str,
+) -> dict[str, Any] | None:
+  """Update only the accepted chat-log scope in a reviewed contract.
+
+  Store contracts contain package-owned facts (skills, background work,
+  runtime limits, and more) that an owner permission change must preserve.
+  Rebuilding one from the App row would silently discard those facts.  This
+  narrow immutable projection keeps the complete reviewed contract intact
+  while recording the owner's explicit requested/effective scope choice.
+  """
+  if not isinstance(contract, dict):
+    return None
+  updated = deepcopy(contract)
+  data = updated.get("data")
+  if not isinstance(data, dict):
+    data = {}
+    updated["data"] = data
+  chat_logs = data.get("chat_logs")
+  if not isinstance(chat_logs, dict):
+    chat_logs = {}
+    data["chat_logs"] = chat_logs
+  chat_logs["requested"] = access
+  chat_logs["effective"] = access
+  chat_logs["redaction"] = "structural" if access != "none" else "none"
+  return updated
 
 
 def canonical_contract_json(contract: dict[str, Any]) -> str:

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -540,7 +540,7 @@ def run_migrations(eng) -> None:
     if null_nonce:
       conn.commit()
   if "chat_log_access" not in apps_cols:
-    # Chat-log read tier (none/summary/full) gating GET /api/chat-logs.
+    # Chat-log read tier gating GET /api/chat-logs.
     # Defaults to 'none'; an app gains read access by declaring
     # permissions.chat_log_access in its manifest (validated in
     # install.py) and the owner consenting at install. See models.App.
@@ -548,6 +548,16 @@ def run_migrations(eng) -> None:
       conn.execute(text(
         "ALTER TABLE apps ADD COLUMN chat_log_access VARCHAR(16) "
         "NOT NULL DEFAULT 'none'"
+      ))
+      conn.commit()
+  else:
+    # `full` was a legacy spelling for the same structurally redacted active
+    # chat view as `summary`; it never exposed raw transcripts. Move existing
+    # grants forward deliberately before the stricter schema/ladders load.
+    with eng.connect() as conn:
+      conn.execute(text(
+        "UPDATE apps SET chat_log_access = 'summary' "
+        "WHERE chat_log_access = 'full'"
       ))
       conn.commit()
   # Per-app git model (feature 084). Both columns are nullable with no

--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -580,7 +580,11 @@ def get_owner_app_or_chat_embed_for_models(
 # routes/storage.py (two-sided, not a single-principal gate) and are
 # deliberately NOT folded in here.
 _PERMISSION_LADDERS: dict[str, dict[str, int]] = {
-  "chat_log_access": {"none": 0, "summary": 1, "full": 2},
+  "chat_log_access": {
+    "none": 0,
+    "summary": 1,
+    "summary_with_deleted": 2,
+  },
 }
 
 
@@ -596,7 +600,8 @@ def require_app_permission(
   owner. For an app token, the granted level is read from the App row
   at request time (`getattr(app, key)`), so flipping the column revokes
   access on the very next call without rotating the 8h app JWT. This is
-  the common gate for ladder-style app permissions (none/summary/full);
+  the common gate for ladder-style app permissions
+  (none/summary/summary_with_deleted);
   the boolean grants below (manage_apps, github_access) use their own
   small owner-or-app gates instead.
 

--- a/backend/app/manifest_contract.py
+++ b/backend/app/manifest_contract.py
@@ -196,10 +196,12 @@ def validate_manifest_contract(manifest) -> None:
   for field in ("cross_app_access", "share_with_apps", "shared_memory"):
     if permissions.get(field, "none") not in ("none", "read", "write"):
       _fail(f"Manifest `permissions.{field}` must be one of none/read/write.")
-  if permissions.get("chat_log_access", "none") not in ("none", "summary", "full"):
+  if permissions.get("chat_log_access", "none") not in (
+    "none", "summary", "summary_with_deleted",
+  ):
     _fail(
       "Manifest `permissions.chat_log_access` must be one of "
-      "none/summary/full."
+      "none/summary/summary_with_deleted."
     )
   removed_job_permissions = {
     "background_agent", "job_authority",

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -653,14 +653,13 @@ class App(Base):
   #               stripped; surviving text secret-scrubbed). "Reduced
   #               exposure," not "safe" — regex can't catch pasted
   #               documents or encoded secrets.
-  #   'full'    — legacy declaration accepted for compatibility; the only
-  #               route still serves the same structurally redacted view as
-  #               'summary', and the reviewed contract says so explicitly.
+  #   'summary_with_deleted' — the same structural redaction widened only to
+  #               chats still inside the seven-day recovery window.
   # App frames receive only their scoped JWT and run in opaque-origin
   # sandboxes, so this live-row permission is an enforceable boundary in
   # addition to recording owner consent.
   chat_log_access = Column(
-    String(16), nullable=False, default="none"
+    String(24), nullable=False, default="none"
   )
   # Per-app git model: `upstream_commit` is the sha of the last
   # pristine-manifest commit on the app's `upstream` branch — the merge

--- a/backend/app/routes/apps.py
+++ b/backend/app/routes/apps.py
@@ -2212,7 +2212,7 @@ async def update_app(
   db: Session = Depends(get_db),
   _: models.Owner = Depends(get_current_owner),
 ):
-  """Update app metadata. Source and manifest authority live in app apply."""
+  """Update owner-controlled app metadata and narrow permission grants."""
   async with (
     fs_locks.install_uninstall_lock(),
     fs_locks.app_storage_lock(app_id),
@@ -2230,6 +2230,8 @@ async def update_app(
       app.share_with_apps = body.share_with_apps
     if body.cross_app_access is not None:
       app.cross_app_access = body.cross_app_access
+    if body.chat_log_access is not None:
+      app.chat_log_access = body.chat_log_access
     if body.share_manifest_url is not None:
       app.share_manifest_url = body.share_manifest_url or None
     if body.manage_skills is not None:
@@ -2245,12 +2247,27 @@ async def update_app(
           ),
         )
       app.manage_skills = body.manage_skills
-    # Keep a local app's owner-readable server-permission projection current.
-    # Runtime capabilities and offline declaration come only from mobius.json
-    # in the explicit source-apply transaction.
+    # Keep the owner-readable server-permission projection current. Runtime
+    # capabilities and offline declarations still come only from reviewed
+    # manifest/application flows. Store contracts must retain every other
+    # reviewed package fact when the owner changes this one live grant.
     if app.manifest_url is None:
       from app.app_capabilities import contract_from_app_state
       app.capability_contract = contract_from_app_state(app)
+    elif body.chat_log_access is not None:
+      from app.app_capabilities import (
+        contract_from_app_state,
+        contract_with_chat_log_access,
+      )
+      app.capability_contract = (
+        contract_with_chat_log_access(
+          app.capability_contract, body.chat_log_access,
+        )
+        # A legacy Store row may predate contracts entirely. There are no
+        # package facts to preserve in that case, so construct the smallest
+        # honest live-state projection instead of leaving review data absent.
+        or contract_from_app_state(app)
+      )
     db.commit()
     db.refresh(app)
     # A pin toggle is drawer-local ORDERING, not a change to the app itself, so
@@ -2263,7 +2280,8 @@ async def update_app(
       field is None
       for field in (
         body.name, body.description, body.chat_id, body.share_with_apps,
-        body.cross_app_access, body.share_manifest_url, body.manage_skills,
+        body.cross_app_access, body.chat_log_access, body.share_manifest_url,
+        body.manage_skills,
       )
     )
     if not pin_only:

--- a/backend/app/routes/chat_logs.py
+++ b/backend/app/routes/chat_logs.py
@@ -11,8 +11,9 @@ Gating (design §2):
   - App tokens need `App.chat_log_access >= 'summary'`, read from the
     App row at request time via `deps.require_app_permission` — flipping
     the column revokes on the next request, no JWT rotation.
-  - `full` passes this gate as at least `summary`, but grants nothing
-    extra because this route always serves the redacted summary view.
+  - Recoverable deleted chats require the explicit
+    `summary_with_deleted` tier and an `include_deleted=true` request.
+  - Every readable tier serves the same structurally redacted summary view.
 
 Read-only. No mutation endpoints. Every app-initiated read is written to
 the activity log (which app, which scope, when) so the owner can audit
@@ -20,9 +21,10 @@ who looked at what — closing the B↔C loop in the design.
 """
 
 import logging
+from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy import func
+from sqlalchemy import and_, func, or_
 from sqlalchemy.orm import Session
 
 from app import activity, chat_log_redaction as redact, models
@@ -30,6 +32,7 @@ from app.chat_transcript import materialized_messages
 from app.database import get_db
 from app.deps import Principal, get_principal, require_app_permission
 from app.resource_access import get_active_chat_or_404
+from app.timeutil import SOFT_DELETE_TTL, now_naive_utc
 
 log = logging.getLogger(__name__)
 
@@ -40,15 +43,18 @@ router = APIRouter(prefix="/api/chat-logs", tags=["chat-logs"])
 _MAX_LIMIT = 100
 
 
-def _gate_summary(principal: Principal, db: Session) -> None:
-  """Require chat_log_access>='summary' for app callers; owner passes.
-
-  `full` is deferred: an app that somehow carries chat_log_access='full'
-  is treated as having (at least) summary here — the route never serves
-  an un-redacted tier, so 'full' grants nothing extra today. We assert
-  the summary floor and stop.
-  """
+def _gate_summary(
+  principal: Principal,
+  db: Session,
+  *,
+  include_deleted: bool = False,
+) -> None:
+  """Require the live app permission for the requested lifecycle scope."""
   require_app_permission(principal, "chat_log_access", "summary", db)
+  if include_deleted:
+    require_app_permission(
+      principal, "chat_log_access", "summary_with_deleted", db,
+    )
 
 
 def _iso(dt) -> str | None:
@@ -61,18 +67,23 @@ def list_chat_logs(
   db: Session = Depends(get_db),
   limit: int = Query(default=20, ge=1, le=_MAX_LIMIT),
   cursor: int = Query(default=0, ge=0),
+  before_recency: datetime | None = Query(default=None),
+  before_id: str | None = Query(default=None),
+  include_deleted: bool = Query(default=False),
 ):
   """Paginated list of chats as redacted summaries.
 
   Each entry: id, scrubbed title, created_at, updated_at, message_count
   (post-redaction visible count), and a short redacted excerpt. Ordered
-  newest-updated first. `cursor` is a 0-based offset into that ordering;
-  the response returns `next_cursor` (or null when exhausted).
+  newest-activity first. Legacy callers may page with the 0-based `cursor`.
+  Durable consumers should instead pass the returned `next_before` pair as
+  `before_recency` + `before_id`; that keyset cannot skip a chat merely because
+  a newer chat arrived between requests.
 
-  Soft-deleted chats are excluded — an app browsing logs should see the
-  same active set the owner does, not deleted history.
+  Soft-deleted chats remain excluded by default. A caller with the explicit
+  higher tier may request chats still inside their seven-day recovery window.
   """
-  _gate_summary(principal, db)
+  _gate_summary(principal, db, include_deleted=include_deleted)
 
   # Recency means "last real activity", same as the owner's drawer
   # (routes/chats.py). updated_at also moves on non-activity writes —
@@ -82,15 +93,48 @@ def list_chat_logs(
   # id breaks timestamp ties so offset pagination is deterministic —
   # equal keys with unspecified order can duplicate or drop rows
   # across pages.
-  base = (
-    db.query(models.Chat)
-    .filter(models.Chat.deleted_at.is_(None))
-    .order_by(
-      func.coalesce(models.Chat.activity_at, models.Chat.updated_at).desc(),
-      models.Chat.id.desc(),
-    )
+  activity_recency = func.coalesce(
+    models.Chat.activity_at, models.Chat.updated_at,
   )
-  rows = base.offset(cursor).limit(limit + 1).all()
+  # Deletion is itself the lifecycle event a durable consumer must discover.
+  # Without it, deleting an old already-processed chat would leave it behind
+  # the caller's keyset marker forever.
+  recency = (
+    func.coalesce(models.Chat.deleted_at, activity_recency)
+    if include_deleted
+    else activity_recency
+  )
+  if (before_recency is None) != (before_id is None):
+    raise HTTPException(
+      status_code=422,
+      detail="before_recency and before_id must be supplied together",
+    )
+  if before_recency is not None and cursor:
+    raise HTTPException(
+      status_code=422,
+      detail="cursor cannot be combined with keyset pagination",
+    )
+  if before_recency is not None and before_recency.tzinfo is not None:
+    before_recency = before_recency.astimezone(UTC).replace(tzinfo=None)
+
+  base = db.query(models.Chat)
+  if include_deleted:
+    cutoff = now_naive_utc() - SOFT_DELETE_TTL
+    base = base.filter(or_(
+      models.Chat.deleted_at.is_(None),
+      models.Chat.deleted_at >= cutoff,
+    ))
+  else:
+    base = base.filter(models.Chat.deleted_at.is_(None))
+  if before_recency is not None and before_id is not None:
+    base = base.filter(or_(
+      recency < before_recency,
+      and_(recency == before_recency, models.Chat.id < before_id),
+    ))
+  base = base.order_by(recency.desc(), models.Chat.id.desc())
+  if before_recency is None:
+    base = base.offset(cursor)
+  rows = base.limit(limit + 1).all()
   has_more = len(rows) > limit
   rows = rows[:limit]
 
@@ -104,6 +148,11 @@ def list_chat_logs(
       "title": redact.scrub_secrets(c.title or ""),
       "created_at": _iso(c.created_at),
       "updated_at": _iso(c.updated_at),
+      "recency_at": _iso(
+        c.deleted_at if include_deleted and c.deleted_at
+        else c.activity_at or c.updated_at
+      ),
+      "deleted_at": _iso(c.deleted_at),
       "message_count": redact.count_visible_messages(msgs),
       "excerpt": redact.excerpt_for_chat(msgs),
     })
@@ -114,11 +163,31 @@ def list_chat_logs(
       app_id=principal.app_id,
       scope="list",
       count=len(items),
+      include_deleted=include_deleted,
       asserted=False,  # platform-authored audit event, not app-asserted
     )
 
-  next_cursor = cursor + limit if has_more else None
-  return {"items": items, "next_cursor": next_cursor}
+  next_cursor = (
+    cursor + limit if has_more and before_recency is None else None
+  )
+  next_before = None
+  if has_more and rows:
+    last = rows[-1]
+    next_before = {
+      # Must be the exact expression used by ORDER BY above. A deletion can
+      # make an old chat newest; returning its old activity timestamp here
+      # would jump the following request past every row between those dates.
+      "recency_at": _iso(
+        last.deleted_at if include_deleted and last.deleted_at
+        else last.activity_at or last.updated_at
+      ),
+      "id": last.id,
+    }
+  return {
+    "items": items,
+    "next_cursor": next_cursor,
+    "next_before": next_before,
+  }
 
 
 @router.get("/{chat_id}")
@@ -126,18 +195,32 @@ def get_chat_log(
   chat_id: str,
   principal: Principal = Depends(get_principal),
   db: Session = Depends(get_db),
+  include_deleted: bool = Query(default=False),
 ):
   """One chat as a redacted summary: whitelisted {role, text} messages.
 
   Newest-`MAX_MESSAGES_PER_CHAT` slice, each text truncated and
   secret-scrubbed (chat_log_redaction.redact_messages). Tool / thinking /
   question / error blocks, attachments, hidden + pending messages, and
-  the fs-path augmentation are all stripped server-side. 404 on a missing
-  or soft-deleted chat — same surface the owner sees.
+  the fs-path augmentation are all stripped server-side. Soft-deleted chats
+  require both the higher permission and an explicit request, and remain
+  readable only during their recovery window.
   """
-  _gate_summary(principal, db)
+  _gate_summary(principal, db, include_deleted=include_deleted)
 
-  chat = get_active_chat_or_404(db, chat_id)
+  if include_deleted:
+    cutoff = now_naive_utc() - SOFT_DELETE_TTL
+    chat = db.query(models.Chat).filter(
+      models.Chat.id == chat_id,
+      or_(
+        models.Chat.deleted_at.is_(None),
+        models.Chat.deleted_at >= cutoff,
+      ),
+    ).first()
+    if chat is None:
+      raise HTTPException(status_code=404, detail="Chat not found")
+  else:
+    chat = get_active_chat_or_404(db, chat_id)
   messages = redact.redact_messages(materialized_messages(chat))
 
   if principal.app_id is not None:
@@ -147,6 +230,7 @@ def get_chat_log(
       scope="chat",
       chat_id=chat_id,
       count=len(messages),
+      include_deleted=include_deleted,
       asserted=False,
     )
 
@@ -155,6 +239,7 @@ def get_chat_log(
     "title": redact.scrub_secrets(chat.title or ""),
     "created_at": _iso(chat.created_at),
     "updated_at": _iso(chat.updated_at),
+    "deleted_at": _iso(chat.deleted_at),
     "tier": "summary",
     "messages": messages,
   }

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -48,6 +48,7 @@ class TokenResponse(BaseModel):
 # Cross-app traffic passes only when BOTH sides permit. Defaults to
 # 'none' on both; the agent opts an app in when the partner asks.
 ShareLevel = Literal["none", "read", "write"]
+ChatLogAccess = Literal["none", "summary", "summary_with_deleted"]
 
 
 class AppApply(BaseModel):
@@ -77,6 +78,9 @@ class AppUpdate(BaseModel):
   pinned: bool | None = None
   cross_app_access: ShareLevel | None = None
   share_with_apps: ShareLevel | None = None
+  # Owner-approved requested/effective scope. Source apply never grants this
+  # implicitly, especially for Store apps; the owner accepts it explicitly.
+  chat_log_access: ChatLogAccess | None = None
   # Public install manifest attached after a local app is published. Empty
   # string clears it; None means omitted. This is deliberately separate from
   # App.manifest_url, which controls Store install/update identity.
@@ -177,7 +181,7 @@ class AppOut(BaseModel):
   # live. Informational so install UIs can surface the privileged declaration.
   system_prompt_file: str | None = None
   system_app: bool = False
-  chat_log_access: Literal["none", "summary", "full"] = "none"
+  chat_log_access: ChatLogAccess = "none"
   capability_contract: dict | None = None
   created_at: datetime
   updated_at: datetime

--- a/backend/scripts/seed-skills/building-apps.md
+++ b/backend/scripts/seed-skills/building-apps.md
@@ -40,6 +40,25 @@ required by the advanced feature below. An installable app starts as a
 root-level repository package and is installed from its raw `mobius.json` URL;
 an ordinary local app stays on the quickstart path.
 
+### Accepting a local chat-history scope for an installed app
+
+Editing and applying a Store-installed app's source never silently widens its
+chat-history grant. After the partner explicitly approves the precise scope,
+accept that one live permission separately:
+
+```bash
+curl -s -X PATCH "$API_BASE_URL/api/apps/<app-id>" \
+  -H "Authorization: Bearer $AGENT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"chat_log_access":"summary_with_deleted"}'
+```
+
+Allowed values are `none`, `summary`, and `summary_with_deleted`; there is no
+raw/`full` tier. The update preserves the rest of the Store-reviewed capability
+contract instead of rebuilding or replacing it. Keep the same scope declared
+in `mobius.json`, then verify the returned `chat_log_access`. This is an owner
+permission action, not a substitute for applying the source revision.
+
 ---
 
 ## Packaging / wrapping a pre-built or third-party web app

--- a/backend/scripts/seed-skills/reflection.md
+++ b/backend/scripts/seed-skills/reflection.md
@@ -126,7 +126,8 @@ brief is a weak channel signal, never a durable partner preference.
 
 On nights with user activity, this is the first phase and the one you may not skip. The agents that did today's work hold context you don't: what surprised them, what they'd warn future-you about, where a skill let them down. You recover it by **forking their session and asking them.**
 
-**Find every chat and subagent run with activity in the last 24h.**
+**Find every active chat and subagent run with activity in the last 24h, plus
+every recoverable deleted chat from the last 7 days.**
 
 User chats — query the DB directly (no auth needed; the container has no `sqlite3` CLI, use `python3`):
 
@@ -139,16 +140,27 @@ con = sqlite3.connect("/data/db/ultimate.db")
 # build the cutoff with Python utcnow().isoformat() — its 'T' separator sorts
 # AFTER the stored ' ', silently dropping rows whose timestamp lands on the
 # cutoff's date boundary.
-for cid, title, prov in con.execute(
-    "select id, title, coalesce(provider,'claude') from chats "
-    "where deleted_at is null and session_id is not null "
-    "and updated_at >= datetime('now','-24 hours') "
-    "order by updated_at desc"):
-  print(cid, "|", prov, "|", title)
+for cid, title, prov, deleted_at in con.execute(
+    "select id, title, coalesce(provider,'claude'), deleted_at from chats "
+    "where ((deleted_at is null and session_id is not null "
+    "and updated_at >= datetime('now','-24 hours')) "
+    "or deleted_at >= datetime('now','-7 days')) "
+    "order by coalesce(deleted_at, updated_at) desc"):
+  state = "deleted" if deleted_at else "active"
+  print(cid, "|", prov, "|", state, "|", title)
 PY
 ```
 
 This query intentionally includes app-attributed chats (`created_by_app_id` set): those are hidden from the owner's drawer but are real conversations an app's agent had, and they often hold the most interview-worthy context. Do not filter them out.
+
+Recoverable deleted chats remain evidence: deletion removes them from the
+partner's workspace, not from Reflection's ability to learn what worked, what
+failed, or what future agents should know. Treat a `deleted` row as read-only
+evidence. Read its platform-owned summary while it exists and fall back to its
+stored transcript directly; **never fork it, recover it, open it for the
+partner, or put its id/link in the brief, a Memory note, or another durable
+artifact.** Refer only to the lesson or outcome. Permanent purge after the
+seven-day recovery window ends access naturally.
 
 App subagent runs — cron jobs (news, gym, etc.) whose sessions are NOT chat rows. Find recently-modified session jsonls under the CLI projects dir:
 

--- a/backend/tests/test_apps.py
+++ b/backend/tests/test_apps.py
@@ -1,5 +1,6 @@
 """App registry lifecycle tests."""
 
+from copy import deepcopy
 from pathlib import Path
 from unittest.mock import call, patch
 
@@ -94,6 +95,80 @@ def test_update_app_rejects_non_public_share_url(client, auth):
     headers=auth,
   )
   assert response.status_code == 422
+
+
+def test_owner_can_accept_deleted_chat_scope_without_replacing_store_contract(
+  client, auth, db,
+):
+  app = create_local_app(
+    client, auth, name="Reflector", description="test",
+  )
+  row = db.query(models.App).filter(models.App.id == app["id"]).one()
+  reviewed = deepcopy(row.capability_contract)
+  reviewed["agent"]["skills"] = ["reflection.md"]
+  reviewed["background"] = {
+    "job": "fetch.sh", "mode": "scheduled", "cron": "0 6 * * *",
+    "user_configurable": True, "initialize_on_install": False,
+  }
+  row.manifest_url = "https://store.example/reflection/mobius.json"
+  row.capability_contract = reviewed
+  db.commit()
+
+  response = client.patch(
+    f"/api/apps/{app['id']}",
+    json={"chat_log_access": "summary_with_deleted"},
+    headers=auth,
+  )
+
+  assert response.status_code == 200, response.text
+  assert response.json()["chat_log_access"] == "summary_with_deleted"
+  row = db.query(models.App).populate_existing().filter_by(id=app["id"]).one()
+  assert row.chat_log_access == "summary_with_deleted"
+  assert row.capability_contract["agent"] == reviewed["agent"]
+  assert row.capability_contract["background"] == reviewed["background"]
+  assert row.capability_contract["data"]["chat_logs"] == {
+    "requested": "summary_with_deleted",
+    "effective": "summary_with_deleted",
+    "redaction": "structural",
+  }
+
+
+def test_owner_chat_log_scope_rejects_retired_full_value(client, auth):
+  app = create_local_app(client, auth, name="No raw logs", description="test")
+
+  response = client.patch(
+    f"/api/apps/{app['id']}",
+    json={"chat_log_access": "full"},
+    headers=auth,
+  )
+
+  assert response.status_code == 422
+
+
+def test_owner_chat_log_scope_backfills_a_legacy_store_contract(
+  client, auth, db,
+):
+  app = create_local_app(
+    client, auth, name="Legacy reflector", description="test",
+  )
+  row = db.query(models.App).filter(models.App.id == app["id"]).one()
+  row.manifest_url = "https://store.example/legacy/mobius.json"
+  row.capability_contract = None
+  db.commit()
+
+  response = client.patch(
+    f"/api/apps/{app['id']}",
+    json={"chat_log_access": "summary_with_deleted"},
+    headers=auth,
+  )
+
+  assert response.status_code == 200, response.text
+  chat_logs = response.json()["capability_contract"]["data"]["chat_logs"]
+  assert chat_logs == {
+    "requested": "summary_with_deleted",
+    "effective": "summary_with_deleted",
+    "redaction": "structural",
+  }
 
 
 def test_list_apps_does_not_hydrate_source_or_icon_payloads(client, auth, db):

--- a/backend/tests/test_chat_logs.py
+++ b/backend/tests/test_chat_logs.py
@@ -196,6 +196,43 @@ def test_revoking_grant_blocks_next_request_without_reissuing_token(
   assert revoked.status_code == 403
 
 
+def test_owner_approval_unblocks_deleted_scope_on_the_existing_app_token(
+  client, owner_token, db,
+):
+  """The explicit grant path and live-row request gate form one contract."""
+  from datetime import datetime
+
+  chat = _seed_chat(db, chat_id="approved-deleted")
+  chat.deleted_at = datetime.now()
+  app = _make_app(db, "approval-reader", chat_log_access="summary")
+  token = _app_token(client, owner_token, app.id)
+  headers = {"Authorization": f"Bearer {token}"}
+
+  denied = client.get(
+    "/api/chat-logs",
+    params={"include_deleted": True},
+    headers=headers,
+  )
+  assert denied.status_code == 403
+
+  approved = client.patch(
+    f"/api/apps/{app.id}",
+    json={"chat_log_access": "summary_with_deleted"},
+    headers={"Authorization": f"Bearer {owner_token}"},
+  )
+  assert approved.status_code == 200, approved.text
+
+  allowed = client.get(
+    "/api/chat-logs",
+    params={"include_deleted": True},
+    headers=headers,
+  )
+  assert allowed.status_code == 200, allowed.text
+  assert "approved-deleted" in {
+    item["id"] for item in allowed.json()["items"]
+  }
+
+
 def test_chat_logs_excludes_soft_deleted_chats(client, owner_token, db):
   from datetime import UTC, datetime
   chat = _seed_chat(db, chat_id="goner")
@@ -216,6 +253,136 @@ def test_chat_logs_excludes_soft_deleted_chats(client, owner_token, db):
   assert one.status_code == 404
 
 
+def test_recoverable_deleted_chats_need_explicit_higher_tier(
+  client, owner_token, db,
+):
+  from datetime import UTC, datetime, timedelta
+
+  active = _seed_chat(db, chat_id="active")
+  deleted = _seed_chat(db, chat_id="recoverable")
+  expired = _seed_chat(db, chat_id="expired")
+  active.activity_at = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=2)
+  deleted.deleted_at = datetime.now(UTC).replace(tzinfo=None)
+  expired.deleted_at = (
+    datetime.now(UTC).replace(tzinfo=None) - timedelta(days=8)
+  )
+  db.commit()
+
+  summary = _make_app(db, "active-only", chat_log_access="summary")
+  summary_headers = {
+    "Authorization": (
+      f"Bearer {_app_token(client, owner_token, summary.id)}"
+    ),
+  }
+  denied = client.get(
+    "/api/chat-logs",
+    params={"include_deleted": True},
+    headers=summary_headers,
+  )
+  assert denied.status_code == 403
+  denied_detail = client.get(
+    "/api/chat-logs/recoverable",
+    params={"include_deleted": True},
+    headers=summary_headers,
+  )
+  assert denied_detail.status_code == 403
+
+  reader = _make_app(
+    db, "lifecycle-reader", chat_log_access="summary_with_deleted",
+  )
+  headers = {
+    "Authorization": f"Bearer {_app_token(client, owner_token, reader.id)}",
+  }
+  default_list = client.get("/api/chat-logs", headers=headers)
+  assert default_list.status_code == 200
+  assert "recoverable" not in {
+    item["id"] for item in default_list.json()["items"]
+  }
+
+  lifecycle_list = client.get(
+    "/api/chat-logs",
+    params={"include_deleted": True},
+    headers=headers,
+  )
+  assert lifecycle_list.status_code == 200, lifecycle_list.text
+  items = {item["id"]: item for item in lifecycle_list.json()["items"]}
+  assert {"active", "recoverable"} <= set(items)
+  assert "expired" not in items
+  assert items["active"]["deleted_at"] is None
+  assert items["recoverable"]["deleted_at"] is not None
+  # The deletion itself is the durable-consumer recency signal.
+  assert items["recoverable"]["recency_at"] == items["recoverable"]["deleted_at"]
+
+  detail = client.get(
+    "/api/chat-logs/recoverable",
+    params={"include_deleted": True},
+    headers=headers,
+  )
+  assert detail.status_code == 200, detail.text
+  assert detail.json()["deleted_at"] is not None
+  assert detail.json()["tier"] == "summary"
+  assert detail.json()["messages"]
+
+  expired_detail = client.get(
+    "/api/chat-logs/expired",
+    params={"include_deleted": True},
+    headers=headers,
+  )
+  assert expired_detail.status_code == 404
+
+
+def test_deleted_chat_keyset_uses_deletion_recency_at_page_boundary(
+  client, owner_token, db,
+):
+  """A newly deleted old chat must not make the next page skip newer work."""
+  from datetime import datetime, timedelta
+
+  now = datetime.now()
+  deleted = _seed_chat(db, chat_id="deleted-boundary")
+  active_mid = _seed_chat(db, chat_id="active-mid")
+  active_old = _seed_chat(db, chat_id="active-old")
+  deleted.activity_at = now - timedelta(days=6)
+  deleted.deleted_at = now
+  active_mid.activity_at = now - timedelta(days=1)
+  active_old.activity_at = now - timedelta(days=2)
+  db.commit()
+
+  reader = _make_app(
+    db, "keyset-reader", chat_log_access="summary_with_deleted",
+  )
+  headers = {
+    "Authorization": f"Bearer {_app_token(client, owner_token, reader.id)}",
+  }
+  first = client.get(
+    "/api/chat-logs",
+    params={"include_deleted": True, "limit": 1},
+    headers=headers,
+  )
+
+  assert first.status_code == 200, first.text
+  first_body = first.json()
+  assert [item["id"] for item in first_body["items"]] == [
+    "deleted-boundary",
+  ]
+  assert first_body["next_before"]["recency_at"] == (
+    first_body["items"][0]["deleted_at"]
+  )
+
+  second = client.get(
+    "/api/chat-logs",
+    params={
+      "include_deleted": True,
+      "limit": 1,
+      "before_recency": first_body["next_before"]["recency_at"],
+      "before_id": first_body["next_before"]["id"],
+    },
+    headers=headers,
+  )
+
+  assert second.status_code == 200, second.text
+  assert [item["id"] for item in second.json()["items"]] == ["active-mid"]
+
+
 def test_chat_logs_install_validates_chat_log_access_value():
   """install.py rejects an out-of-range chat_log_access tier."""
   from fastapi import HTTPException
@@ -227,13 +394,21 @@ def test_chat_logs_install_validates_chat_log_access_value():
     "permissions": {"chat_log_access": "summary"},
   }
   _validate_manifest(good)  # no raise
+  _validate_manifest({
+    **good,
+    "permissions": {"chat_log_access": "summary_with_deleted"},
+  })
 
-  bad = dict(good, permissions={"chat_log_access": "everything"})
-  try:
-    _validate_manifest(bad)
-    assert False, "expected HTTPException for bad chat_log_access"
-  except HTTPException as exc:
-    assert exc.status_code == 400
+  for retired_or_invalid in ("full", "everything"):
+    bad = dict(
+      good,
+      permissions={"chat_log_access": retired_or_invalid},
+    )
+    try:
+      _validate_manifest(bad)
+      assert False, "expected HTTPException for bad chat_log_access"
+    except HTTPException as exc:
+      assert exc.status_code == 400
 
 
 def test_chat_logs_orders_by_activity_not_updated(client, owner_token, db):
@@ -263,3 +438,51 @@ def test_chat_logs_orders_by_activity_not_updated(client, owner_token, db):
   assert lst.status_code == 200
   ids = [i["id"] for i in lst.json()["items"]]
   assert ids.index("new-activity") < ids.index("old-activity")
+  entries = {item["id"]: item for item in lst.json()["items"]}
+  assert entries["new-activity"]["recency_at"].startswith("2026-06-01")
+
+
+def test_chat_logs_keyset_pages_without_offset_drift(
+  client, owner_token, db,
+):
+  from datetime import datetime
+
+  newest = _seed_chat(db, chat_id="newest")
+  middle = _seed_chat(db, chat_id="middle")
+  oldest = _seed_chat(db, chat_id="oldest")
+  newest.activity_at = datetime(2026, 6, 3)
+  middle.activity_at = datetime(2026, 6, 2)
+  oldest.activity_at = datetime(2026, 6, 1)
+  db.commit()
+  app = _make_app(db, "pager", chat_log_access="summary")
+  token = _app_token(client, owner_token, app.id)
+  headers = {"Authorization": f"Bearer {token}"}
+
+  first = client.get("/api/chat-logs?limit=2", headers=headers)
+  assert first.status_code == 200, first.text
+  assert [item["id"] for item in first.json()["items"]] == [
+    "newest", "middle",
+  ]
+  marker = first.json()["next_before"]
+  assert marker == {
+    "recency_at": first.json()["items"][-1]["recency_at"],
+    "id": "middle",
+  }
+
+  # A new head row would shift an offset page. The immutable key from the
+  # prior page still lands directly after `middle`, so `oldest` is not skipped.
+  inserted = _seed_chat(db, chat_id="inserted-later")
+  inserted.activity_at = datetime(2026, 6, 4)
+  db.commit()
+  second = client.get(
+    "/api/chat-logs",
+    params={
+      "limit": 2,
+      "before_recency": marker["recency_at"],
+      "before_id": marker["id"],
+    },
+    headers=headers,
+  )
+  assert second.status_code == 200, second.text
+  assert [item["id"] for item in second.json()["items"]] == ["oldest"]
+  assert second.json()["next_before"] is None

--- a/backend/tests/test_reflection_runner.py
+++ b/backend/tests/test_reflection_runner.py
@@ -1086,6 +1086,16 @@ def test_seed_skill_uses_chat_sent_without_false_activity_substitutes():
   assert "this schema has no `chat_sent`" not in seed
 
 
+def test_seed_skill_reads_deleted_chats_without_reopening_them():
+  seed = (
+    Path(dr.__file__).resolve().parent / "seed-skills" / "reflection.md"
+  ).read_text(encoding="utf-8")
+  assert "deleted_at >= datetime('now','-7 days')" in seed
+  assert "deleted_at is null and session_id is not null" in seed
+  assert "never fork it, recover it, open it" in seed
+  assert "put its id/link in the brief" in seed
+
+
 def test_seed_skill_aligns_question_engagement_and_owns_brief_style():
   seed = (
     Path(dr.__file__).resolve().parent / "seed-skills" / "reflection.md"


### PR DESCRIPTION
## Summary
- replace the unused `full` chat-log tier with explicit `summary_with_deleted` lifecycle access
- require both that owner-approved tier and `include_deleted=true` for chats still inside the seven-day recovery window
- add keyset pagination whose cursor uses the same deletion-aware recency expression as ordering
- preserve complete reviewed Store capability contracts when the owner changes this one live grant
- let Reflection learn from recoverable deleted chats without recovering, forking, linking, or retaining their identities

## Why
Deletion is a lifecycle event that durable readers can otherwise miss: offset pagination shifts under new activity, and ordering an old deleted chat by its old activity time can strand it behind a cursor forever. At the same time, deleted history is more sensitive than active summaries and should not be silently included in the ordinary read tier.

The new higher tier widens only lifecycle scope. Every response remains structurally redacted; there is no raw or `full` transcript capability. Legacy `full` values are migrated to ordinary `summary`, matching what they always actually received.

## Safety
The app permission is read from the live App row on every request, so revocation is immediate without token rotation. Deleted rows expire naturally after the recovery TTL. App reads remain activity-audited. Store source updates cannot grant this implicitly; the owner must accept the exact scope separately.

## Validation
- chat-log, app-permission, and Reflection suites: 93 passed
- coverage for live-token grant/revocation, recovery expiry, deletion-aware keyset boundaries, manifest validation, Store contract preservation, and Reflection privacy rules
- current-main integration and clean diff
- full CI before merge