### PR TITLE
Reserve phone tab holds for dragging

### DIFF
--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useState, useEffect, useLayoutEffect, useCallback, useMemo, useReducer, useRef } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
-import { CollapseSm, X } from '@openai/apps-sdk-ui/components/Icon'
+import { CollapseSm } from '@openai/apps-sdk-ui/components/Icon'
 import {
   AppsNavIcon,
   NewChatNavIcon,
@@ -1539,13 +1539,16 @@ export default function Shell() {
   }, [])
 
   // Tabs expose a compact browser-style close menu without adding permanent
-  // chrome: right-click or the keyboard menu key on desktop, stationary hold on
-  // touch. The same state drives both the single strip and tiled pane strips.
+  // chrome on desktop: right-click or the keyboard menu key. Phone tabs reserve
+  // press-and-hold for dragging and never open these bulk actions. The same state
+  // drives both the single strip and tiled pane strips.
   const [tabMenu, setTabMenu] = useState(null)
   const tabMenuRef = useRef(null)
   const tabMenuReturnFocusRef = useRef(null)
+  const tabActionsAvailable = workspaceMode !== 'phone'
   const openTabMenu = useCallback((event, tab, paneId) => {
     event.preventDefault()
+    if (!tabActionsAvailable) return
     const owner = paneId || paneModel.paneOf(workspace, tabModel.tabKey(tab))?.id
     if (!owner) return
     const triggerRect = event.currentTarget.getBoundingClientRect()
@@ -1560,15 +1563,7 @@ export default function Shell() {
       tabKey: tabModel.tabKey(tab),
       paneId: owner,
     })
-  }, [workspace])
-  const openTabMenuAt = useCallback((x, y, tab, paneId) => {
-    if (!tab) return
-    const owner = paneId
-      || paneModel.paneOf(workspaceStateRef.current.ws, tabModel.tabKey(tab))?.id
-    if (!owner) return
-    tabMenuReturnFocusRef.current = null
-    setTabMenu({ x, y, tab, tabKey: tabModel.tabKey(tab), paneId: owner })
-  }, [])
+  }, [tabActionsAvailable, workspace])
   const closeTabMenu = useCallback((restoreFocus = true) => {
     setTabMenu(null)
     if (!restoreFocus) return
@@ -1609,6 +1604,10 @@ export default function Shell() {
   }, [])
   useEffect(() => {
     if (!tabMenu) return undefined
+    if (!tabActionsAvailable) {
+      closeTabMenu(false)
+      return undefined
+    }
     const onDown = (event) => {
       if (!event.target.closest?.('.workspace__menu')) closeTabMenu(false)
     }
@@ -1621,7 +1620,7 @@ export default function Shell() {
       document.removeEventListener('pointerdown', onDown, true)
       document.removeEventListener('keydown', onKey, true)
     }
-  }, [closeTabMenu, tabMenu])
+  }, [closeTabMenu, tabActionsAvailable, tabMenu])
 
   // ── Workspace drag controller wiring (design §3, PR3) ─────────────────────
   // All of this is gated behind WORKSPACE_SPLITS_ENABLED — the hook installs no
@@ -1633,8 +1632,6 @@ export default function Shell() {
   sceneInputsRef.current = { projection, mode: workspaceMode, contentRect }
   const labelForTabRef = useRef(labelForTab)
   labelForTabRef.current = labelForTab
-  const openTabMenuAtRef = useRef(openTabMenuAt)
-  openTabMenuAtRef.current = openTabMenuAt
   // A single-mode drag previews the builder world through the ONE descriptor
   // (INV 5): arm is phase 'drag-preview', and the id it mints is carried to the
   // matching commit/cancel so a stale end-event from a superseded drag is
@@ -1711,7 +1708,6 @@ export default function Shell() {
     drawerOpenRef,
     closeDrawer,
     openDrawer,
-    openTabMenuAtRef,
     onPreviewBuilder: onModeDragPreview,
   })
 
@@ -4082,7 +4078,7 @@ export default function Shell() {
         action={toast?.action}
         onDismiss={dismissToast}
       />
-      {tabMenu && (() => {
+      {tabActionsAvailable && tabMenu && (() => {
         const menuPane = workspace.panes[tabMenu.paneId]
         const menuTabIndex = menuPane?.tabs.findIndex(
           tab => tabModel.tabKey(tab) === tabMenu.tabKey,
@@ -4104,21 +4100,6 @@ export default function Shell() {
               }}
               onKeyDown={handleTabMenuKeyDown}
             >
-              <div className="workspace__menu-handle" aria-hidden="true" />
-              <header className="workspace__menu-header">
-                <div>
-                  <span>Tab actions</span>
-                  <strong>{labelForTab(tabMenu.tab)}</strong>
-                </div>
-                <button
-                  type="button"
-                  className="workspace__menu-close"
-                  aria-label="Close tab actions"
-                  onClick={() => closeTabMenu()}
-                >
-                  <X width={18} height={18} aria-hidden="true" />
-                </button>
-              </header>
               <div className="workspace__menu-items">
                 <button
                   type="button"

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -38,9 +38,9 @@ test('the workspace menu avoids an oversized border-and-shadow card', () => {
   assert.doesNotMatch(rule, /box-shadow:[^;]*(?:1[6-9]|[2-9]\d)px/)
 })
 
-test('the workspace menu stays close-only, edge-clamped, and keyboard navigable', () => {
+test('the desktop workspace menu stays close-only, edge-clamped, and keyboard navigable', () => {
   const menuMarkup = shell.slice(
-    shell.indexOf('{tabMenu &&'),
+    shell.indexOf('{tabActionsAvailable && tabMenu &&'),
     shell.indexOf('</HistoryDismissProvider>'),
   )
   assert.match(shell, /aria-label="Tab actions"/)
@@ -56,7 +56,11 @@ test('the workspace menu stays close-only, edge-clamped, and keyboard navigable'
   assert.match(shell, /querySelector\('\[role="menuitem"\]'\)\?\.focus\(\)/)
   assert.match(shell, /tabMenuReturnFocusRef\.current = event\.currentTarget/)
   assert.match(shell, /returnTarget\?\.focus\?\.\(\{ preventScroll: true \}\)/)
-  assert.match(css, /@media \(max-width: 720px\)[\s\S]*?\.workspace__menu-header/)
+  assert.match(shell, /const tabActionsAvailable = workspaceMode !== 'phone'/)
+  assert.match(shell, /event\.preventDefault\(\)\s*\n\s*if \(!tabActionsAvailable\) return/)
+  assert.match(shell, /\{tabActionsAvailable && tabMenu &&/)
+  assert.doesNotMatch(shell, /workspace__menu-handle|workspace__menu-header|workspace__menu-close/)
+  assert.doesNotMatch(css, /workspace__menu-handle|workspace__menu-header|workspace__menu-close|workspace-tab-sheet-in/)
 })
 
 test('an implicit home tab does not engage the single-pane tab strip', () => {
@@ -637,6 +641,8 @@ test('mobile tabs require a hold before dragging while the strip preserves pinch
   assert.match(dragBinding, /if \(sourceKind === 'tab'\) arm\(\)/)
   assert.match(dragBinding, /touchMoveIntent\(dx, dy, sourceKind\)/)
   assert.match(dragBinding, /scrollStripEl\.scrollLeft \+= previousPoint\.x - ev\.clientX/)
+  assert.match(dragBinding, /if \(sourceKind === 'drawer'\) openDrawerTouchMenu\(\)/)
+  assert.doesNotMatch(dragBinding, /openTabMenuAtRef/)
   assert.doesNotMatch(dragBinding, /addEventListener\('touchmove'/)
 })
 

--- a/frontend/src/components/Shell/dragController.js
+++ b/frontend/src/components/Shell/dragController.js
@@ -45,8 +45,9 @@ export const PRE_HOLD_MOVE_PX = 8
 // jitter settle before a rightward drag-out takes ownership.
 export const DRAWER_DRAG_INTENT_PX = 18
 export const DRAWER_DRAG_DOMINANCE = 1.2
-// After a touch lift, a release that never moved past this opens the context
-// menu instead of dropping (lift → release-in-place = menu; lift → move = drag).
+// After a touch lift, a release that never moved past this is not a drop.
+// Drawer rows use that stationary release for their action menu; tabs cancel
+// cleanly because their hold gesture is reserved for dragging.
 export const RELEASE_IN_PLACE_PX = 5
 
 // ── Zone geometry (design §3.2 / §3.3) ───────────────────────────────────────
@@ -119,8 +120,7 @@ export function touchMoveIntent(dx, dy, sourceKind, limit = PRE_HOLD_MOVE_PX) {
   return 'scroll'
 }
 
-// After a lift, a release still within this radius opened no drag — it is the
-// escalation branch that opens the context menu.
+// After a lift, a release still within this radius did not become a drag.
 export function releasedInPlace(dx, dy, limit = RELEASE_IN_PLACE_PX) {
   return hypot(dx, dy) <= limit
 }

--- a/frontend/src/components/Shell/useWorkspaceDrag.js
+++ b/frontend/src/components/Shell/useWorkspaceDrag.js
@@ -80,7 +80,6 @@ export default function useWorkspaceDrag({
   drawerOpenRef,
   closeDrawer,
   openDrawer,
-  openTabMenuAtRef, // ref → (clientX, clientY, tab, paneId) => void
   onPreviewBuilder, // (active, { committed }) => void — enter/leave the LIVE
   // builder preview a single-mode drag unfolds (point 15: dragging IS
   // building). Render-only: the reducer viewMode stays 'single' until the drop
@@ -340,7 +339,9 @@ export default function useWorkspaceDrag({
 
       // Tabs use one unambiguous touch contract across their whole surface:
       // movement before the hold belongs to strip scrolling; surviving the short
-      // hold lifts the tab so a following move drags it. Drawer rows keep their
+      // hold lifts the tab so a following move drags it. Releasing that lifted tab
+      // in place simply puts it back — phone tabs do not overload the drag gesture
+      // with the desktop actions menu. Drawer rows keep their
       // directional drag-out shortcut because it does not compete with the
       // drawer's vertical scroll axis. A stationary drawer hold remains the
       // alternate path to its row menu.
@@ -532,30 +533,26 @@ export default function useWorkspaceDrag({
 
       const onUp = (ev) => {
         if (ev.pointerId !== pointerId) return // ignore a second finger
-        const openTouchMenu = () => {
-          if (sourceKind === 'tab' && openTabMenuAtRef.current) {
-            openTabMenuAtRef.current(ev.clientX, ev.clientY, tabFromKey(key), paneId)
-          } else if (sourceKind === 'drawer') {
-            // Re-enter the row's real context-menu boundary instead of
-            // programmatically clicking its menu trigger. `contextmenu` is the
-            // one semantic path shared with desktop right-click and keyboard
-            // access, so touch hold cannot drift when the trigger composition
-            // changes.
-            srcEl.dispatchEvent(new window.MouseEvent('contextmenu', {
-              bubbles: true,
-              cancelable: true,
-              view: window,
-              button: 2,
-              clientX: ev.clientX,
-              clientY: ev.clientY,
-            }))
-          }
+        const openDrawerTouchMenu = () => {
+          // Re-enter the row's real context-menu boundary instead of
+          // programmatically clicking its menu trigger. `contextmenu` is the
+          // one semantic path shared with desktop right-click and keyboard
+          // access, so touch hold cannot drift when the trigger composition
+          // changes.
+          srcEl.dispatchEvent(new window.MouseEvent('contextmenu', {
+            bubbles: true,
+            cancelable: true,
+            view: window,
+            button: 2,
+            clientX: ev.clientX,
+            clientY: ev.clientY,
+          }))
         }
         if (!armed) {
           if (scrolling) {
             cleanup({ suppressClick: true })
-          } else if (isTouch && held) {
-            openTouchMenu()
+          } else if (isTouch && held && sourceKind === 'drawer') {
+            openDrawerTouchMenu()
             cleanup({ suppressClick: true })
           } else cleanup()
           return
@@ -573,9 +570,9 @@ export default function useWorkspaceDrag({
         const backOverDrawer = sourceKind === 'drawer' && drawerEdgeX != null
           && ev.clientX <= drawerEdgeX && !(isTouch && glided)
         if (isTouch && releasedInPlace(dx, dy)) {
-          // Lift → release-in-place = context menu. A strip tab reuses the
-          // stage-A pane menu; a drawer row opens its own ⋮ menu (adjudicated).
-          openTouchMenu()
+          // A lifted tab released in place cancels cleanly; its hold is reserved
+          // for drag. Drawer rows retain their stationary-hold action menu.
+          if (sourceKind === 'drawer') openDrawerTouchMenu()
           cleanup({ suppressClick: true })
         } else if (backOverDrawer) {
           // Released back over the drawer = cancel; cleanup reopens it if glided.

--- a/frontend/src/components/Shell/workspace.css
+++ b/frontend/src/components/Shell/workspace.css
@@ -207,8 +207,8 @@ html[data-mode-view-transition]::view-transition-new(*) {
 }
 
 /* Tab actions stay off the permanent chrome. Desktop uses a pointer- or
-   keyboard-anchored menu; compact screens use the same actions as a named
-   bottom sheet. */
+   keyboard-anchored menu; phone tabs reserve their hold gesture for dragging
+   and never render it. */
 .workspace__menu-layer {
   position: fixed;
   inset: 0;
@@ -234,8 +234,6 @@ html[data-mode-view-transition]::view-transition-new(*) {
 }
 .workspace__menu[data-positioned="true"] { visibility: visible; }
 .workspace__menu::-webkit-scrollbar { width: 0; height: 0; }
-.workspace__menu-handle,
-.workspace__menu-header { display: none; }
 .workspace__menu-items { display: grid; gap: 1px; }
 .workspace__menu-item {
   display: block;
@@ -258,94 +256,6 @@ html[data-mode-view-transition]::view-transition-new(*) {
 .workspace__menu-item:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: -2px;
-}
-
-@media (max-width: 720px) {
-  .workspace__menu-layer {
-    background: rgba(0, 0, 0, 0.46);
-    backdrop-filter: blur(2px);
-    pointer-events: auto;
-  }
-
-  .workspace__menu,
-  .workspace__menu[data-positioned="true"] {
-    top: auto;
-    right: 12px;
-    bottom: max(12px, env(safe-area-inset-bottom));
-    left: 12px;
-    width: auto;
-    max-height: calc(100dvh - 24px - env(safe-area-inset-bottom));
-    visibility: visible;
-    padding: 7px;
-    border-radius: 20px;
-    background: var(--surface);
-    box-shadow: 0 22px 54px rgba(0, 0, 0, 0.46);
-    animation: workspace-tab-sheet-in 170ms cubic-bezier(0.2, 0.75, 0.2, 1);
-  }
-
-  .workspace__menu-handle {
-    width: 34px;
-    height: 4px;
-    display: block;
-    margin: 2px auto 7px;
-    border-radius: 999px;
-    background: var(--border);
-  }
-
-  .workspace__menu-header {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    padding: 4px 5px 10px;
-  }
-
-  .workspace__menu-header > div {
-    min-width: 0;
-    flex: 1;
-    display: grid;
-    gap: 2px;
-  }
-
-  .workspace__menu-header span {
-    color: var(--muted);
-    font-size: 11px;
-    font-weight: 650;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-  }
-
-  .workspace__menu-header strong {
-    overflow: hidden;
-    font-size: 16px;
-    font-weight: 650;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .workspace__menu-close {
-    width: 40px;
-    height: 40px;
-    flex: 0 0 40px;
-    display: grid;
-    place-items: center;
-    padding: 0;
-    border: 0;
-    border-radius: 999px;
-    background: color-mix(in srgb, var(--bg) 72%, transparent);
-    color: var(--muted);
-  }
-
-  .workspace__menu-item {
-    min-height: 48px;
-    padding: 11px 13px;
-    border-radius: 12px;
-    font-size: 15px;
-  }
-}
-
-@keyframes workspace-tab-sheet-in {
-  from { opacity: 0; transform: translateY(18px); }
-  to { opacity: 1; transform: translateY(0); }
 }
 
 /* ── Drag-to-organize overlays (design §3.3, PR3) ────────────────────────────


### PR DESCRIPTION
## Summary
- reserve phone tab holds for drag-and-drop instead of opening bulk close actions
- keep desktop right-click and keyboard tab actions unchanged
- remove the retired phone action sheet and its touch-menu bridge

## Why
On a phone, holding a tab is the direct-manipulation gesture for arranging it. Releasing a lifted tab in place should cancel cleanly, not turn that gesture into a close-actions sheet.

This follows up #354, which intentionally made the close menu available from stationary touch holds. Its desktop menu remains; this narrows only the phone interaction so a hold has one clear job.

## Validation
- staged branch: 88 focused workspace UI tests passed
- staged branch: 66 interaction hook tests passed
- production and offline/PWA build passed
- authenticated phone-sized touch path verified that a hold lifts the tab and a stationary release opens no menu
- desktop context menu remained available