### PR TITLE
Hide blocked contribution cards from chat

### DIFF
--- a/frontend/src/components/ChatView/ContributionReviewCard.css
+++ b/frontend/src/components/ChatView/ContributionReviewCard.css
@@ -106,18 +106,10 @@
   border-top: 1px solid var(--border-light);
 }
 
-.contrib-card-stack--grouped .contrib-card--blocked {
-  border-left-color: var(--muted);
-}
-
 .contrib-card-stack--grouped .contrib-card__badge {
   margin: 0;
   padding: 0;
   border-bottom: 0;
-  background: transparent;
-}
-
-.contrib-card-stack--grouped .contrib-card--blocked .contrib-card__badge {
   background: transparent;
 }
 
@@ -129,10 +121,6 @@
 
 .contrib-card--dragging {
   transition: none;
-}
-
-.contrib-card--blocked {
-  border-left-color: var(--muted);
 }
 
 .contrib-card--stack {
@@ -157,11 +145,6 @@
   letter-spacing: 0.04em;
   text-transform: uppercase;
   color: var(--accent);
-}
-
-.contrib-card--blocked .contrib-card__badge {
-  background: color-mix(in srgb, var(--muted) 12%, transparent);
-  color: var(--muted);
 }
 
 /* The swipe's visible equivalent. This follows the shell's quiet Lucide close
@@ -200,13 +183,13 @@
 }
 
 .contrib-card__meta,
-.contrib-card__blocker {
+.contrib-card__error {
   font-size: 0.75rem;
   line-height: 1.35;
   color: var(--muted);
 }
 
-.contrib-card__blocker {
+.contrib-card__error {
   color: var(--danger);
 }
 

--- a/frontend/src/components/ChatView/ContributionReviewCard.jsx
+++ b/frontend/src/components/ChatView/ContributionReviewCard.jsx
@@ -14,7 +14,6 @@ import {
   payoffLine,
   rememberReviewItemDismissed,
   reviewPanelSummary,
-  sendBlocker,
   statusLabel,
   visibleReviewItems,
 } from './contributionReviewModel.js'
@@ -156,7 +155,6 @@ export default function ContributionReviewCard({ chatId, turnActive, onOpenApp }
           <ReviewRow
             key={item.id}
             record={record}
-            connected={data?.connected !== false}
             autopilot={autopilotOnSend(data)}
             showPayoff={!grouped}
             onSubmit={submit}
@@ -372,7 +370,7 @@ function StackReviewRow({ item, onOpenContribute, onDismiss }) {
 }
 
 function ReviewRow({
-  record, connected, autopilot, showPayoff, onSubmit, onSent,
+  record, autopilot, showPayoff, onSubmit, onSent,
   onOpenContribute, onDismiss,
 }) {
   const [open, setOpen] = useState(false)
@@ -381,7 +379,6 @@ function ReviewRow({
   // Each row owns its own in-flight guard. That keeps sibling rows independent
   // while closing the same-frame double-click window for this record.
   const activeSendRef = useRef(false)
-  const blocker = sendBlocker(record, { connected })
   const diffStat = diffStatSummary(record.diff_stat)
   const submitting = record.status === 'submitting'
   const cardRef = useSwipeToDismiss(onDismiss)
@@ -406,15 +403,12 @@ function ReviewRow({
   }
 
   return (
-    <div
-      ref={cardRef}
-      className={`contrib-card${blocker ? ' contrib-card--blocked' : ''}`}
-    >
+    <div ref={cardRef} className="contrib-card">
       {/* Header band, then what it is, then the actions. The band also carries
           dismissal, so the swipe has a visible, pointer- and keyboard-reachable
           equivalent rather than being a touch-only secret. */}
       <div className="contrib-card__badge">
-        <span>{statusLabel(record, !!blocker)}</span>
+        <span>{statusLabel(record)}</span>
         <button
           type="button"
           className="contrib-card__dismiss"
@@ -433,24 +427,21 @@ function ReviewRow({
         {diffStat ? <span> · {diffStat}</span> : null}
       </p>
 
-      {/* The payoff, but never next to a problem: a blocked review needs the
-          reason, not encouragement. */}
-      {showPayoff && !blocker && !error && !submitting && (
+      {showPayoff && !error && !submitting && (
         <p className="contrib-card__payoff">{payoffLine(record)}</p>
       )}
-      {autopilot && !blocker && !error && !submitting && (
+      {autopilot && !error && !submitting && (
         <p className="contrib-card__meta">
           Möbius will also handle review feedback after you contribute.
         </p>
       )}
-      {blocker && <p className="contrib-card__blocker">{blocker}</p>}
-      {error && <p className="contrib-card__blocker">{error}</p>}
+      {error && <p className="contrib-card__error">{error}</p>}
 
       <div className="contrib-card__actions">
         <button
           type="button"
           className="contrib-card__send"
-          disabled={busy || submitting || !!blocker}
+          disabled={busy || submitting}
           onClick={send}
         >
           {submitting || busy ? 'Contributing…' : contributeLabel(record)}
@@ -463,9 +454,9 @@ function ReviewRow({
         >
           {open ? 'Hide details' : 'Details'}
         </button>
-        {/* Only when something needs sorting out — the happy path stays two
-            buttons, and Contribute owns every state this card cannot fix. */}
-        {(blocker || error) && onOpenContribute && (
+        {/* A failed submit may reveal a server-side change after this ready
+            card loaded. Contribute owns that repair path. */}
+        {error && onOpenContribute && (
           <button
             type="button"
             className="contrib-card__toggle"

--- a/frontend/src/components/ChatView/__tests__/contributionReviewModel.test.js
+++ b/frontend/src/components/ChatView/__tests__/contributionReviewModel.test.js
@@ -125,14 +125,39 @@ test('autopilot on send mirrors the owner default and the backend capability', (
   assert.equal(autopilotOnSend(null), false)
 })
 
-test('the status word distinguishes waiting, blocked, and in-flight', () => {
-  assert.equal(statusLabel({ status: 'prepared' }, false), 'Ready to contribute')
-  assert.equal(statusLabel({ status: 'prepared' }, true), 'Needs attention')
+test('the status word distinguishes waiting and in-flight', () => {
+  assert.equal(statusLabel({ status: 'prepared' }), 'Ready to contribute')
   assert.equal(
-    statusLabel({ status: 'prepared', stack: { id: 'demo' } }, true),
+    statusLabel({ status: 'prepared', stack: { id: 'demo' } }),
     'Review together',
   )
-  assert.equal(statusLabel({ status: 'submitting' }, false), 'Publishing')
+  assert.equal(statusLabel({ status: 'submitting' }), 'Publishing')
+})
+
+test('records that need attention stay in Contribute instead of blocking chat', () => {
+  const payload = {
+    connected: true,
+    records: [
+      { id: 'ready', status: 'prepared', review: { state: 'ready' } },
+      { id: 'drifted', status: 'prepared', review: { state: 'needs_refresh' } },
+      { id: 'unreviewed', status: 'prepared' },
+      { id: 'publishing', status: 'submitting' },
+    ],
+  }
+  assert.deepEqual(
+    visibleReviewItems(payload, fakeStorage()).map(item => item.id),
+    ['ready', 'publishing'],
+  )
+  assert.deepEqual(
+    visibleReviewItems({ ...payload, connected: false }, fakeStorage())
+      .map(item => item.id),
+    ['publishing'],
+  )
+  // Filtering is presentation-only: the durable ledger still owns every item.
+  assert.deepEqual(
+    actionableRecords(payload).map(record => record.id),
+    ['ready', 'drifted', 'unreviewed', 'publishing'],
+  )
 })
 
 test('multiple independent review items share one bounded review panel', () => {
@@ -233,14 +258,14 @@ test('independent cards can submit in parallel without duplicating one record', 
   assert.match(cardSrc, /if \(activeSendRef\.current\) return/)
   assert.match(cardSrc, /activeSendRef\.current = true/)
   assert.match(cardSrc, /const \[busy, setBusy\] = useState\(false\)/)
-  assert.match(cardSrc, /disabled=\{busy \|\| submitting \|\| !!blocker\}/)
+  assert.match(cardSrc, /disabled=\{busy \|\| submitting\}/)
   assert.doesNotMatch(cardSrc, /busyIds|errorsById/)
   assert.match(cardSrc, /item => item\.kind !== 'record' \|\| !sentIds\.has\(item\.record\.id\)/)
 })
 
 test('a grouped panel does not repeat the same audience payoff on every card', () => {
   assert.match(cardSrc, /showPayoff=\{!grouped\}/)
-  assert.match(cardSrc, /showPayoff && !blocker && !error && !submitting/)
+  assert.match(cardSrc, /showPayoff && !error && !submitting/)
 })
 
 // The action names the value of contributing, not the mechanism of sending, and

--- a/frontend/src/components/ChatView/contributionReviewModel.js
+++ b/frontend/src/components/ChatView/contributionReviewModel.js
@@ -70,11 +70,10 @@ export function autopilotOnSend(payload) {
 // an app's repository reaches that app's users instead.
 export const PLATFORM_REPO = 'mobius-os/mobius'
 
-/** The one-line status word shown on the card. */
-export function statusLabel(record, blocked) {
+/** The one-line status word shown on a card the chat can act on. */
+export function statusLabel(record) {
   if (record?.status === 'submitting') return 'Publishing'
   if (record?.stack || record?.is_stack) return 'Review together'
-  if (blocked) return 'Needs attention'
   return 'Ready to contribute'
 }
 
@@ -297,7 +296,19 @@ function reviewItemDismissIdentity(item) {
 
 export function visibleReviewItems(payload, storage) {
   return reviewItems(payload).filter(
-    item => !isDismissed(reviewItemDismissIdentity(item), storage),
+    item => {
+      if (isDismissed(reviewItemDismissIdentity(item), storage)) return false
+      // Chat is the quick happy path. If a single contribution needs repair,
+      // Contribute remains its durable home; rendering a disabled attention
+      // card above the composer only creates a dead end. Stacks are different:
+      // their one useful chat action is to open the ordered review in Contribute.
+      if (item.kind === 'record') {
+        return !sendBlocker(item.record, {
+          connected: payload?.connected !== false,
+        })
+      }
+      return true
+    },
   )
 }
 


### PR DESCRIPTION
## Summary
- keep chat contribution prompts focused on reviews that are ready to act on
- leave blocked or stale reviews in Contribute instead of showing disabled attention cards above the composer
- preserve stacked-review handoffs and recovery when a ready submission fails

## Verification
- `npm test` (2,204 frontend interface tests and 66 hook tests)
- focused contribution review model test (36 tests)
- rendered a ready card in the authenticated shell and expanded its details