### PR TITLE
Normalize compact segmented control height

### DIFF
--- a/backend/scripts/seed-skills/app-component-shapes.md
+++ b/backend/scripts/seed-skills/app-component-shapes.md
@@ -431,11 +431,12 @@ A full-width form-submit adds `width: 100%` via a `.ma-btn-block` modifier.
 ```css
 /* mobius-ui:Segmented — app-owned; a future-library candidate (no sync owed). */
 .ma-seg {
-  display: inline-flex; gap: 2px; padding: 3px;
-  background: var(--surface2, var(--surface)); border: 1px solid var(--border); border-radius: 10px;
+  display: inline-flex; gap: 2px; height: 44px;
+  background: var(--surface2, var(--surface)); border: 0; border-radius: 10px;
+  box-shadow: inset 0 0 0 1px var(--border);
 }
 .ma-seg-btn {
-  min-height: 44px; padding: 6px 14px; border: 0; border-radius: 7px;
+  box-sizing: border-box; min-height: 44px; padding: 6px 14px; border: 0; border-radius: 7px;
   background: transparent; color: var(--muted); font-family: var(--font);
   font-size: 13px; font-weight: 650; cursor: pointer; transition: background 0.15s, color 0.15s;
 }

--- a/frontend/src/components/SettingsView/SettingsView.css
+++ b/frontend/src/components/SettingsView/SettingsView.css
@@ -175,9 +175,11 @@
 
 .settings__appearance-toggle {
   flex-shrink: 0;
+  box-sizing: border-box;
   display: inline-grid;
   grid-template-columns: repeat(2, 34px);
   align-items: center;
+  height: 44px;
   padding: 3px;
   border: 1px solid var(--border);
   border-radius: 8px;
@@ -196,7 +198,7 @@
   display: grid;
   place-items: center;
   width: 34px;
-  height: 30px;
+  height: 36px;
   border-radius: 5px;
   color: var(--muted);
   opacity: 0.68;


### PR DESCRIPTION
## Summary
- shell and future app segmented controls share one compact height without shrinking touch targets.
- keep the behavior at its existing owning interface without compatibility paths or unrelated refactors

## Verification
- focused settings checks, source-pattern review, and production build
- reviewed the full canonical diff against current `main`