### PR TITLE
Refine provider settings density

### DIFF
--- a/frontend/src/components/ProviderAuth/ProviderAuth.css
+++ b/frontend/src/components/ProviderAuth/ProviderAuth.css
@@ -314,7 +314,7 @@
 .settings__providers {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 7px;
 }
 
 .provider-row {
@@ -322,8 +322,8 @@
   grid-template-columns: 1fr auto;
   grid-template-rows: auto auto;
   align-items: center;
-  gap: 6px 10px;
-  padding: 10px 12px;
+  gap: 5px 10px;
+  padding: 9px 11px;
   background: var(--surface);
   border: 1px solid var(--border-light);
   border-radius: 8px;
@@ -399,6 +399,10 @@
   line-height: 1.3;
 }
 
+.provider-row__version-short {
+  display: none;
+}
+
 .provider-row__badge {
   font-size: 11px;
   font-weight: 500;
@@ -431,8 +435,8 @@
   display: inline-flex;
   align-items: center;
   gap: 3px;
-  margin: 0;
-  padding: 1px 0;
+  margin: -2px 0;
+  padding: 3px 0;
   border: 0;
   background: none;
   color: var(--green);
@@ -469,13 +473,21 @@
   border-radius: 3px;
 }
 
-/* Expanded usage is a terse metric strip rather than a stack of progress
-   bars. It appears only after the plan disclosure is opened. */
+/* Detail owns a full-width row beneath the provider header. Keeping it outside
+   the name/status stack gives compact usage lines enough room in narrow panes
+   without forcing the Reconnect action to wrap. */
+.provider-row__detail {
+  grid-column: 1 / -1;
+  min-width: 0;
+}
+
+/* Expanded usage is a tight line-per-window readout: the line carries the
+   at-a-glance shape, while the percentage and reset remain exact. */
 .provider-usage {
   display: grid;
-  gap: 6px;
-  width: min(100%, 460px);
-  margin-top: 3px;
+  gap: 5px;
+  width: 100%;
+  margin-top: 1px;
   padding-top: 7px;
   border-top: 1px solid var(--border-light);
 }
@@ -489,36 +501,55 @@
 
 .provider-usage__windows {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(92px, 1fr));
-  gap: 7px 16px;
+  gap: 5px;
 }
 
 .provider-usage__window {
   display: grid;
-  gap: 1px;
+  grid-template-columns: minmax(62px, auto) minmax(56px, 1fr) auto auto;
+  align-items: center;
+  gap: 8px;
   min-width: 0;
 }
 
 .provider-usage__label {
   color: var(--muted);
-  font-size: 10.5px;
-  line-height: 1.25;
+  font-size: 11px;
+  line-height: 1.3;
+  white-space: nowrap;
+}
+
+.provider-usage__track {
+  display: block;
+  width: 100%;
+  height: 3px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--muted) 18%, transparent);
+}
+
+.provider-usage__fill {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--accent);
+  transition: width 160ms ease;
 }
 
 .provider-usage__value {
   color: var(--text);
-  font-size: 15px;
+  min-width: 34px;
+  font-size: 11.5px;
   font-weight: 500;
-  line-height: 1.3;
+  line-height: 1;
+  text-align: right;
   font-variant-numeric: tabular-nums;
 }
 
 .provider-usage__reset {
-  overflow: hidden;
   color: var(--muted);
   font-size: 10.5px;
-  line-height: 1.25;
-  text-overflow: ellipsis;
+  line-height: 1.3;
   white-space: nowrap;
 }
 
@@ -541,7 +572,8 @@
   background: var(--surface2);
   border: 1px solid var(--border-light);
   color: var(--text);
-  padding: 7px 14px;
+  min-height: 32px;
+  padding: 6px 13px;
   border-radius: 999px;
   font-size: 13px;
   font-weight: 500;
@@ -567,8 +599,34 @@
 
 .provider-row__auth {
   grid-column: 1 / -1;
-  grid-row: 2;
   padding-top: 8px;
   border-top: 1px solid var(--border-light);
   margin-top: 4px;
+}
+
+@container settings (max-width: 400px) {
+  .provider-row__version-full {
+    display: none;
+  }
+
+  .provider-row__version-short {
+    display: inline;
+  }
+
+  .provider-usage__window {
+    grid-template-columns: minmax(62px, auto) minmax(48px, 1fr) auto;
+    gap: 6px;
+  }
+
+  .provider-usage__reset {
+    grid-column: 2 / -1;
+    margin-top: -3px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .provider-plan-toggle__chevron,
+  .provider-usage__fill {
+    transition: none;
+  }
 }

--- a/frontend/src/components/ProviderAuth/ProviderRow.jsx
+++ b/frontend/src/components/ProviderAuth/ProviderRow.jsx
@@ -44,8 +44,14 @@ export default function ProviderRow({
       <span className="provider-row__name-line">
         <span className="provider-row__name">{name}</span>
         {connected && version && (
-          <span className="provider-row__version" title="Installed CLI version">
-            {version}
+          <span
+            className="provider-row__version"
+            title={`Installed CLI version ${version}`}
+          >
+            <span className="provider-row__version-full">{version}</span>
+            <span className="provider-row__version-short">
+              {version.split(/\s+/)[0]}
+            </span>
           </span>
         )}
       </span>
@@ -62,7 +68,6 @@ export default function ProviderRow({
           {connected ? 'Connected' : 'Not connected'}
         </StatusDot>
       )}
-      {detailNode}
     </span>
   )
 
@@ -86,6 +91,11 @@ export default function ProviderRow({
           ? 'Close'
           : (actionLabel || (connected ? 'Reconnect' : 'Connect'))}
       </button>
+      {detailNode && (
+        <div className="provider-row__detail">
+          {detailNode}
+        </div>
+      )}
       {expanded && (
         <div className="provider-row__auth">
           {children}

--- a/frontend/src/components/SettingsView/ProviderUsage.jsx
+++ b/frontend/src/components/SettingsView/ProviderUsage.jsx
@@ -35,6 +35,19 @@ export default function ProviderUsage({
             return (
               <span className="provider-usage__window" key={window.id || window.label}>
                 <span className="provider-usage__label">{window.label}</span>
+                <span
+                  className="provider-usage__track"
+                  role="progressbar"
+                  aria-label={`${window.label} usage`}
+                  aria-valuemin="0"
+                  aria-valuemax="100"
+                  aria-valuenow={percent}
+                >
+                  <span
+                    className="provider-usage__fill"
+                    style={{ width: `${percent}%` }}
+                  />
+                </span>
                 <span className="provider-usage__value">
                   {formatUsagePercent(percent)}%
                 </span>

--- a/frontend/src/components/SettingsView/SettingsView.css
+++ b/frontend/src/components/SettingsView/SettingsView.css
@@ -1,32 +1,35 @@
 .settings {
   height: 100%;
   overflow-y: auto;
-  padding: 32px 24px 24px;
+  padding: 28px 22px 20px;
+  scrollbar-gutter: stable;
 }
 
 .settings__content {
-  max-width: 640px;
+  width: 100%;
+  max-width: 660px;
+  min-width: 0;
   margin: 0 auto;
 }
 
 .settings__title {
-  font-size: 26px;
+  font-size: 25px;
   font-weight: 600;
   letter-spacing: 0;
-  margin-bottom: 24px;
+  margin-bottom: 18px;
 }
 
 .settings__section {
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 8px;
-  padding: 20px;
-  margin-bottom: 14px;
+  padding: 17px;
+  margin-bottom: 10px;
   scroll-margin-top: 24px;
 }
 
 .settings__section--compact {
-  padding: 14px 20px;
+  padding: 13px 17px;
 }
 
 /* Light mode: cards in light mode lose almost all visible
@@ -49,7 +52,7 @@
   color: var(--muted);
   text-transform: none;
   letter-spacing: 0;
-  margin-bottom: 14px;
+  margin-bottom: 12px;
 }
 
 .settings__label {
@@ -127,6 +130,7 @@
 .settings__btn--sm {
   padding: 5px 12px;
   font-size: 13px;
+  min-height: 32px;
   /* Uniform width + centered label so short row actions ("Open", "Update",
      "Restart", "Retry") render at the same size — a button and an anchor with
      different label lengths otherwise read as mismatched controls. line-height
@@ -156,6 +160,8 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 14px;
+  min-width: 0;
 }
 
 /* Top-align a row whose label spans two lines (label + subtext), so the
@@ -234,12 +240,12 @@
    between SettingsView and SetupWizard. */
 
 .settings-agent-group {
-  margin-top: 16px;
-  padding-top: 16px;
+  margin-top: 14px;
+  padding-top: 14px;
   border-top: 1px solid var(--border);
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 10px;
   scroll-margin-top: 24px;
 }
 
@@ -324,7 +330,7 @@
   display: grid;
   grid-template-columns: minmax(0, 1fr);
   align-items: center;
-  min-height: 54px;
+  min-height: 50px;
   padding: 0;
   border: 0;
   border-radius: 9px;
@@ -493,7 +499,11 @@
    overflow. Tested against the 280px pane floor. */
 @container settings (max-width: 400px) {
   .settings {
-    padding: 20px 14px 16px;
+    padding: 18px 14px 16px;
+  }
+
+  .settings__title {
+    margin-bottom: 16px;
   }
 
   .settings__section {
@@ -534,7 +544,7 @@
 .settings__section--server {
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: 12px;
 }
 
 .settings__section--server .settings__section-title,

--- a/frontend/src/components/SettingsView/SettingsView.jsx
+++ b/frontend/src/components/SettingsView/SettingsView.jsx
@@ -360,7 +360,10 @@ export default function SettingsView({
   const [expandedAuth, setExpandedAuth] = useState(null)
   // Usage is deliberately on demand. Only the disclosed provider fetches,
   // and keeping this separate from auth preserves the row's two clear actions.
-  const [expandedUsage, setExpandedUsage] = useState(null)
+  const [expandedUsage, setExpandedUsage] = useState({
+    codex: false,
+    claude: false,
+  })
   // Surface failures from the dark-mode toggle: a failed theme
   // persist would otherwise bounce the knob without telling the user
   // why.
@@ -442,13 +445,13 @@ export default function SettingsView({
   const codexUsageQuery = settingsQueries.providerUsage.useQuery('codex', {
     enabled: (
       active && providerReady && codexAuthenticated
-      && expandedUsage === 'codex'
+      && expandedUsage.codex
     ),
   })
   const claudeUsageQuery = settingsQueries.providerUsage.useQuery('claude', {
     enabled: (
       active && providerReady && claudeAuthenticated
-      && expandedUsage === 'claude'
+      && expandedUsage.claude
     ),
   })
   // Registry and provider/settings probes are independent. Starting them
@@ -779,7 +782,9 @@ export default function SettingsView({
   // panel feel jittery. With the updater form, deps are empty.
   const toggleClaudeAuth = useCallback(
     () => {
-      setExpandedUsage(null)
+      setExpandedUsage(prev => (
+        prev.claude ? { ...prev, claude: false } : prev
+      ))
       setExpandedAuth(prev => {
         if (prev !== 'claude') {
           authProvidersAtStartRef.current = new Set(configuredProvidersRef.current)
@@ -791,7 +796,9 @@ export default function SettingsView({
   )
   const toggleCodexAuth = useCallback(
     () => {
-      setExpandedUsage(null)
+      setExpandedUsage(prev => (
+        prev.codex ? { ...prev, codex: false } : prev
+      ))
       setExpandedAuth(prev => {
         if (prev !== 'codex') {
           authProvidersAtStartRef.current = new Set(configuredProvidersRef.current)
@@ -802,12 +809,12 @@ export default function SettingsView({
     [],
   )
   const toggleClaudeUsage = useCallback(() => {
-    setExpandedAuth(null)
-    setExpandedUsage(prev => prev === 'claude' ? null : 'claude')
+    setExpandedAuth(prev => prev === 'claude' ? null : prev)
+    setExpandedUsage(prev => ({ ...prev, claude: !prev.claude }))
   }, [])
   const toggleCodexUsage = useCallback(() => {
-    setExpandedAuth(null)
-    setExpandedUsage(prev => prev === 'codex' ? null : 'codex')
+    setExpandedAuth(prev => prev === 'codex' ? null : prev)
+    setExpandedUsage(prev => ({ ...prev, codex: !prev.codex }))
   }, [])
   const onProviderConnected = useCallback(async (provider) => {
     const providersBefore = authProvidersAtStartRef.current || configuredProviders
@@ -1435,11 +1442,11 @@ export default function SettingsView({
                     <PlanUsageToggle
                       provider="codex"
                       label={formatPlanStatus(codexPlanLabel)}
-                      expanded={expandedUsage === 'codex'}
+                      expanded={expandedUsage.codex}
                       onToggle={toggleCodexUsage}
                     />
                   ) : undefined}
-                  detailNode={codexAuthenticated && expandedUsage === 'codex' ? (
+                  detailNode={codexAuthenticated && expandedUsage.codex ? (
                     <ProviderUsage
                       id="provider-usage-codex"
                       snapshot={codexUsageQuery.data}
@@ -1461,11 +1468,11 @@ export default function SettingsView({
                     <PlanUsageToggle
                       provider="claude"
                       label={formatPlanStatus(claudePlanLabel)}
-                      expanded={expandedUsage === 'claude'}
+                      expanded={expandedUsage.claude}
                       onToggle={toggleClaudeUsage}
                     />
                   ) : undefined}
-                  detailNode={claudeAuthenticated && expandedUsage === 'claude' ? (
+                  detailNode={claudeAuthenticated && expandedUsage.claude ? (
                     <ProviderUsage
                       id="provider-usage-claude"
                       snapshot={claudeUsageQuery.data}

--- a/frontend/src/lib/__tests__/providerUsage.test.js
+++ b/frontend/src/lib/__tests__/providerUsage.test.js
@@ -2,6 +2,7 @@
 
 import test from 'node:test'
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
 import {
   clampUsagePercent,
   formatPlanStatus,
@@ -9,6 +10,19 @@ import {
   formatUsageReset,
   visibleUsageWindows,
 } from '../../components/SettingsView/providerUsage.js'
+
+const usageView = readFileSync(
+  new URL('../../components/SettingsView/ProviderUsage.jsx', import.meta.url),
+  'utf8',
+)
+const settingsView = readFileSync(
+  new URL('../../components/SettingsView/SettingsView.jsx', import.meta.url),
+  'utf8',
+)
+const providerCss = readFileSync(
+  new URL('../../components/ProviderAuth/ProviderAuth.css', import.meta.url),
+  'utf8',
+)
 
 test('connected plan status uses the compact green-disclosure copy', () => {
   assert.equal(formatPlanStatus('Max plan'), 'Plan: Max')
@@ -47,4 +61,32 @@ test('only four valid allowance windows are rendered', () => {
   })
 
   assert.deepEqual(windows.map(window => window.id), ['a', 'b', 'c', 'd'])
+})
+
+test('Claude and Codex usage disclosures stay independently expandable', () => {
+  assert.match(settingsView, /expandedUsage\.codex/)
+  assert.match(settingsView, /expandedUsage\.claude/)
+  assert.match(
+    settingsView,
+    /setExpandedUsage\(prev => \(\{ \.\.\.prev, codex: !prev\.codex \}\)\)/,
+  )
+  assert.match(
+    settingsView,
+    /setExpandedUsage\(prev => \(\{ \.\.\.prev, claude: !prev\.claude \}\)\)/,
+  )
+  assert.doesNotMatch(settingsView, /expandedUsage === '(?:codex|claude)'/)
+})
+
+test('expanded usage restores thin accessible lines without tall cards', () => {
+  assert.match(usageView, /className="provider-usage__track"/)
+  assert.match(usageView, /role="progressbar"/)
+  assert.match(usageView, /className="provider-usage__fill"/)
+  assert.match(
+    providerCss,
+    /\.provider-usage__track\s*\{[^}]*height:\s*3px;/s,
+  )
+  assert.match(
+    providerCss,
+    /\.provider-usage__window\s*\{[^}]*grid-template-columns:/s,
+  )
 })


### PR DESCRIPTION
## Summary
- provider settings use space more clearly while keeping versions and usage details accessible.
- keep the behavior at its existing owning interface without compatibility paths or unrelated refactors

## Verification
- focused provider usage and settings tests plus production build
- reviewed the full canonical diff against current `main`