### PR TITLE
Align message copy with revealed timestamps

### DIFF
--- a/frontend/src/components/ChatView/ActiveAssistantSurface.jsx
+++ b/frontend/src/components/ChatView/ActiveAssistantSurface.jsx
@@ -35,6 +35,8 @@ function ActiveAssistantSurface({
   pendingQuestionRef,
   resumeCardRef,
   isStreaming,
+  messageMetaVisible,
+  onMessageMetaClick,
 }) {
   const msg = useMemo(() => {
     if (useDbActivePayload) return activeMirrorMsg
@@ -68,6 +70,8 @@ function ActiveAssistantSurface({
       pendingQuestionRef={pendingQuestionRef}
       resumeCardRef={resumeCardRef}
       isStreaming={isStreaming}
+      messageMetaVisible={messageMetaVisible}
+      onMessageMetaClick={onMessageMetaClick}
     />
   )
 }

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -365,40 +365,51 @@
   align-items: flex-start;
 }
 
-/* Tap-to-show timestamp below user messages. ChatView clears the visible state
+/* Tap-to-show message metadata. User timestamps and copy share one row, while
+   assistant rows show the copy action alone. ChatView clears the visible state
    automatically after a short glance, so the row never remains expanded. */
+.chat__msg-meta {
+  display: inline-flex;
+  align-items: center;
+  align-self: flex-end;
+  gap: 4px;
+  margin-top: 4px;
+  /* The row uses the existing inter-message gap without centering a real
+     button inside a zero-height box (which pulled the copy glyph upward into
+     the message bubble). Its negative bottom margin cancels only its own
+     layout height, so later rows keep the established transcript rhythm. */
+  height: 24px;
+  margin-bottom: -24px;
+  overflow: visible;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.15s ease, visibility 0s linear 0.15s;
+}
+.chat__msg-meta--visible {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition-delay: 0s;
+}
 .chat__ts {
   font-size: 11px;
   color: var(--muted); /* CONTRACT: low-contrast text on opaque fill */
-  margin-top: 4px;
-  opacity: 0;
-  pointer-events: none;
-  height: 0;
-  overflow: visible;
-  transition: opacity 0.15s ease;
+  white-space: nowrap;
 }
-.chat__ts--visible { opacity: 1; }
 
 /* ── One-tap message copy ──────────────────────────────
    The explicit mobile affordance: native long-press selection stays fully
    available (this is a plain tap target — never a press/hold interception,
-   see chatUiPolish.test), but a single tap now copies the whole message
-   with a visible "Copied" acknowledgement. Quiet ghost button, always
-   visible on touch devices, hover/focus-revealed on fine pointers. */
-.chat__msg-actions {
-  display: flex;
-  margin-top: 2px;
-}
-/* Every copy affordance lands in the same LOWER-RIGHT corner: code blocks
-   pin right:7px, user bubbles inherit their column's flex-end, and the
-   response row opts out of the assistant column's flex-start here. */
-.chat__msg--assistant .chat__msg-actions { align-self: flex-end; }
+   see chatUiPolish.test), but a single tap reveals a quiet ghost button
+   beside the timestamp when one is present. */
 .chat__msg-copy {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 5px;
-  min-height: 26px;
-  padding: 2px 7px;
+  min-height: 24px;
+  padding: 2px 5px;
   border: 0;
   border-radius: 7px;
   background: none;
@@ -417,10 +428,6 @@
   opacity: 1;
 }
 @media (hover: hover) and (pointer: fine) {
-  .chat__msg-copy { opacity: 0; }
-  .chat__msg:hover .chat__msg-copy,
-  .chat__msg-copy:focus-visible,
-  .chat__msg-copy--copied { opacity: 1; }
   .chat__msg-copy:hover {
     background: var(--surface2); /* CONTRACT: secondary opaque fill */
     color: var(--text);

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -32,7 +32,9 @@ import ActiveAssistantSurface from './ActiveAssistantSurface.jsx'
 import QueuedMessages from './QueuedMessages.jsx'
 import ContributionReviewCard from './ContributionReviewCard.jsx'
 import MsgContent from './MsgContent.jsx'
+import MessageMetaRow from './MessageMetaRow.jsx'
 import ActivityLineHeader from './ActivityLineHeader.jsx'
+import { messageCopyText } from './messageCopy.js'
 import { formatResetTime } from './resetTime.js'
 import {
   resetDeadlineDelay,
@@ -134,6 +136,7 @@ _touchMql?.addEventListener('change', (e) => { _isTouchPrimary = e.matches })
 
 const STOP_RETRY_DELAYS_MS = [0, 250, 700, 1200]
 const CHAT_FETCH_TIMEOUT_MS = 15000
+const MESSAGE_META_VISIBLE_MS = 5000
 
 function delay(ms) {
   return new Promise(resolve => setTimeout(resolve, ms))
@@ -469,8 +472,8 @@ export default function ChatView({
   // cards themselves use to publish the node being observed.
   const [showInspector, setShowInspector] = useState(false)
   const [showSummary, setShowSummary] = useState(false)
-  const [visibleTimestampKey, setVisibleTimestampKey] = useState(null)
-  const timestampTimerRef = useRef(null)
+  const [visibleMessageMetaKey, setVisibleMessageMetaKey] = useState(null)
+  const messageMetaTimerRef = useRef(null)
   const [previewReadyStatus, setPreviewReadyStatus] = useState('')
   // The app id whose CTA is mid recompile-pulse (label swapped to "Preview
   // updated ✓" for ~2s), or null.
@@ -505,17 +508,19 @@ export default function ChatView({
   }, [chatId, queryClient])
 
   useEffect(() => () => {
-    if (timestampTimerRef.current) clearTimeout(timestampTimerRef.current)
+    if (messageMetaTimerRef.current) clearTimeout(messageMetaTimerRef.current)
   }, [])
 
-  const showTimestamp = useCallback((event, key) => {
+  const showMessageMeta = useCallback((event, key) => {
+    if (event.defaultPrevented) return
+    if (event.target.closest?.('button, a, input, textarea, select, [role="button"]')) return
     if (window.getSelection?.()?.toString()) return
-    if (timestampTimerRef.current) clearTimeout(timestampTimerRef.current)
-    setVisibleTimestampKey(key)
-    timestampTimerRef.current = setTimeout(() => {
-      timestampTimerRef.current = null
-      setVisibleTimestampKey(current => current === key ? null : current)
-    }, 2200)
+    if (messageMetaTimerRef.current) clearTimeout(messageMetaTimerRef.current)
+    setVisibleMessageMetaKey(key)
+    messageMetaTimerRef.current = setTimeout(() => {
+      messageMetaTimerRef.current = null
+      setVisibleMessageMetaKey(current => current === key ? null : current)
+    }, MESSAGE_META_VISIBLE_MS)
   }, [])
   useEffect(() => {
     autoResumeRequestRef.current += 1
@@ -4007,9 +4012,11 @@ export default function ChatView({
             const dataKey = msg.id || `${msg.role}-${msg.ts ?? i}`
             // User rows key + pin on the stable cid so the optimistic→confirm
             // display-ts update never remounts the row (which would drop the
-            // pin target mid-swap). data-ts stays for the timestamp tooltip only.
+            // pin target mid-swap). data-ts stays for the revealed metadata row.
             const ownerUserMessage = isOwnerUserMessage(msg)
             const userCid = ownerUserMessage ? cidOf(msg) : null
+            const copyText = messageCopyText(msg)
+            const hasMessageMeta = Boolean(copyText || (ownerUserMessage && msg.ts))
             return (
             <li
               key={userCid || msg.id || msg.ts || `${msg.role}-${i}`}
@@ -4018,8 +4025,8 @@ export default function ChatView({
               data-key={dataKey}
               data-cid={userCid || undefined}
               data-ts={ownerUserMessage && msg.ts ? String(msg.ts) : undefined}
-              onClick={msg.ts && ownerUserMessage
-                ? (event) => showTimestamp(event, dataKey)
+              onClick={hasMessageMeta
+                ? (event) => showMessageMeta(event, dataKey)
                 : undefined}
             >
               <MsgContent
@@ -4051,14 +4058,11 @@ export default function ChatView({
                 pendingQuestionRef={pendingQuestionRef}
                 resumeCardRef={resumeCardRef}
               />
-              {msg.ts && ownerUserMessage && (
-                <time className={`chat__ts${visibleTimestampKey === dataKey ? ' chat__ts--visible' : ''}`}>
-                  {new Date(msg.ts).toLocaleString([], {
-                    month: 'short', day: 'numeric',
-                    hour: '2-digit', minute: '2-digit',
-                  })}
-                </time>
-              )}
+              <MessageMetaRow
+                timestamp={ownerUserMessage ? msg.ts : null}
+                copyText={copyText}
+                visible={visibleMessageMetaKey === dataKey}
+              />
             </li>
           )})}
 
@@ -4096,6 +4100,8 @@ export default function ChatView({
               // ", in progress" — instead of settling early. Source selection
               // still gates resume/question routing above (review 2026-07-17).
               isStreaming={activeAssistantIsStreaming || turnActive}
+              messageMetaVisible={visibleMessageMetaKey === streamingDataKey}
+              onMessageMetaClick={showMessageMeta}
             />
           )}
 

--- a/frontend/src/components/ChatView/MessageCopyButton.jsx
+++ b/frontend/src/components/ChatView/MessageCopyButton.jsx
@@ -1,11 +1,11 @@
-/* MessageCopyButton — one-tap "copy this message" under a settled chat row.
+/* MessageCopyButton — one-tap "copy this message" in a settled message's
+   revealable metadata row.
    Exists because native long-press selection is unreliable on phones. It is a
    plain tap target only: it never intercepts press/hold or the context menu,
    so native text selection and its action menu stay fully available (the
    chatUiPolish test locks that invariant). */
 import { useEffect, useRef, useState } from 'react'
-import Check from 'lucide-react/dist/esm/icons/check.mjs'
-import Copy from 'lucide-react/dist/esm/icons/copy.mjs'
+import { Check, Copy } from '@openai/apps-sdk-ui/components/Icon'
 import { copyPlainText } from './messageCopy.js'
 
 export default function MessageCopyButton({ text }) {
@@ -15,8 +15,8 @@ export default function MessageCopyButton({ text }) {
   useEffect(() => () => clearTimeout(timerRef.current), [])
 
   async function handleCopy(e) {
-    // A tap on a user row also toggles its timestamp via the row's onClick;
-    // copying must not double as that.
+    // The containing message row owns reveal timing; copying must not restart
+    // that timer or double as another message-row click.
     e.stopPropagation()
     if (!(await copyPlainText(text))) return
     setCopied(true)
@@ -33,9 +33,8 @@ export default function MessageCopyButton({ text }) {
       title="Copy message"
     >
       {copied
-        ? <Check size={14} strokeWidth={2.3} aria-hidden="true" />
-        : <Copy size={14} strokeWidth={2} aria-hidden="true" />}
-      {copied && <span className="chat__msg-copy-label">Copied</span>}
+        ? <Check width={14} height={14} aria-hidden="true" />
+        : <Copy width={14} height={14} aria-hidden="true" />}
     </button>
   )
 }

--- a/frontend/src/components/ChatView/MessageMetaRow.jsx
+++ b/frontend/src/components/ChatView/MessageMetaRow.jsx
@@ -1,0 +1,29 @@
+/* MessageMetaRow keeps a settled message's timestamp and copy action in one
+   revealable row. */
+import MessageCopyButton from './MessageCopyButton.jsx'
+
+
+export default function MessageMetaRow({
+  timestamp,
+  copyText,
+  visible,
+}) {
+  if (!timestamp && !copyText) return null
+
+  return (
+    <div
+      className={`chat__msg-meta${visible ? ' chat__msg-meta--visible' : ''}`}
+      aria-hidden={!visible}
+    >
+      {timestamp && (
+        <time className="chat__ts">
+          {new Date(timestamp).toLocaleString([], {
+            month: 'short', day: 'numeric',
+            hour: '2-digit', minute: '2-digit',
+          })}
+        </time>
+      )}
+      {copyText && <MessageCopyButton text={copyText} />}
+    </div>
+  )
+}

--- a/frontend/src/components/ChatView/MsgContent.jsx
+++ b/frontend/src/components/ChatView/MsgContent.jsx
@@ -14,8 +14,6 @@ import {
   suppressedQuestionToolIndices,
 } from './streamReducers.js'
 import { stripAugmentation } from './msgText.js'
-import { messageCopyText } from './messageCopy.js'
-import MessageCopyButton from './MessageCopyButton.jsx'
 import ErrorCard from './ErrorCard.jsx'
 import { assistantBlockKey } from './streamPromotion.js'
 
@@ -85,10 +83,6 @@ function MsgContentInner({
   // scalar props (no function prop needed from ChatView).
   const isQuestionAnswerable = (block) =>
     blockAnswerable(block, { msg, isLastMsg, liveQuestionId, onQuestionAnswer })
-  // One-tap copy for settled prose. A streaming answer is still changing
-  // under the reader, so the affordance appears when the turn settles —
-  // the same gate MessageSources uses.
-  const copyableText = isStreaming ? '' : messageCopyText(msg)
   if (msg.kind === 'compaction') {
     // Render the compaction as its own labeled card rather than the generic
     // ToolBlock — see CompactionCard. The stored `content` is untouched, so
@@ -365,11 +359,6 @@ function MsgContentInner({
             disclosureKey={`${messageKey}:references`}
           />
         )}
-        {copyableText && (
-          <div className="chat__msg-actions">
-            <MessageCopyButton text={copyableText} />
-          </div>
-        )}
       </>
     )
   }
@@ -401,11 +390,6 @@ function MsgContentInner({
             : text}
         </div>
       ) : null}
-      {copyableText && (
-        <div className="chat__msg-actions">
-          <MessageCopyButton text={copyableText} />
-        </div>
-      )}
     </>
   )
 }

--- a/frontend/src/components/ChatView/StreamingMessage.jsx
+++ b/frontend/src/components/ChatView/StreamingMessage.jsx
@@ -1,4 +1,6 @@
 import MsgContent from './MsgContent.jsx'
+import MessageMetaRow from './MessageMetaRow.jsx'
+import { messageCopyText } from './messageCopy.js'
 
 
 /**
@@ -25,12 +27,21 @@ export default function StreamingMessage({
   pendingQuestionRef,
   resumeCardRef,
   isStreaming,
+  messageMetaVisible,
+  onMessageMetaClick,
 }) {
+  // A live answer is still changing under the reader, so copy appears only
+  // after the turn settles.
+  const copyText = isStreaming ? '' : messageCopyText(msg)
+
   return (
     <li
       className="chat__msg chat__msg--assistant"
       data-key={dataKey}
       data-active-assistant="true"
+      onClick={copyText && onMessageMetaClick
+        ? (event) => onMessageMetaClick(event, dataKey)
+        : undefined}
     >
       <MsgContent
         msg={msg}
@@ -52,6 +63,10 @@ export default function StreamingMessage({
         isActiveAnswer
         isStreaming={isStreaming}
         suppressedQuestionKeys={null}
+      />
+      <MessageMetaRow
+        copyText={copyText}
+        visible={messageMetaVisible}
       />
     </li>
   )

--- a/frontend/src/components/ChatView/__tests__/messageCopyButton.test.js
+++ b/frontend/src/components/ChatView/__tests__/messageCopyButton.test.js
@@ -1,14 +1,17 @@
 /* One-tap message copy: messageCopyText owns what "copy this message" means,
  * MessageCopyButton is a plain tap target on the shared clipboard helper, and
- * MsgContent only offers copy on settled prose. Native long-press selection
- * must stay untouched (chatUiPolish.test locks the no-interception side). */
+ * MessageMetaRow keeps copy beside the timestamp behind the row's existing
+ * tap-to-reveal interaction. Native long-press selection must stay untouched
+ * (chatUiPolish.test locks the no-interception side). */
 import { readFileSync } from 'node:fs'
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import { messageCopyText } from '../messageCopy.js'
 
-const msgContent = readFileSync(new URL('../MsgContent.jsx', import.meta.url), 'utf8')
 const copyButton = readFileSync(new URL('../MessageCopyButton.jsx', import.meta.url), 'utf8')
+const metaRow = readFileSync(new URL('../MessageMetaRow.jsx', import.meta.url), 'utf8')
+const streamingMessage = readFileSync(new URL('../StreamingMessage.jsx', import.meta.url), 'utf8')
+const chatView = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8')
 
 test('messageCopyText joins prose blocks and skips activity chrome', () => {
   const msg = {
@@ -49,17 +52,31 @@ test('the copy button is a plain tap target on the shared clipboard helper', () 
 })
 
 test('only settled messages offer copy — a streaming answer is still changing', () => {
-  assert.match(msgContent, /isStreaming \? '' : messageCopyText\(msg\)/)
+  assert.match(streamingMessage, /isStreaming \? '' : messageCopyText\(msg\)/)
 })
 
-test('every copy affordance shares the lower-right corner', () => {
-  // Code blocks pin right (codeBlockCopy.test), user bubbles inherit their
-  // column's flex-end; the response row must opt out of the assistant
-  // column's flex-start or it strands the one copy button at the left.
-  const css = readFileSync(new URL('../ChatView.css', import.meta.url), 'utf8')
-  assert.match(
-    css,
-    /\.chat__msg--assistant \.chat__msg-actions \{ align-self: flex-end; \}/,
-    'response copy row aligns lower-right like code blocks and user bubbles',
+test('copy follows the timestamp inside one tap-revealed metadata row', () => {
+  assert.ok(
+    metaRow.indexOf('<time className="chat__ts">')
+      < metaRow.indexOf('<MessageCopyButton text={copyText} />'),
+    'copy must render immediately after the timestamp',
   )
+  assert.match(chatView, /visible=\{visibleMessageMetaKey === dataKey\}/)
+
+  const css = readFileSync(new URL('../ChatView.css', import.meta.url), 'utf8')
+  assert.match(css, /\.chat__msg-meta \{[\s\S]*visibility: hidden;/)
+  assert.match(css, /\.chat__msg-meta--visible \{[\s\S]*visibility: visible;/)
+  assert.match(css, /\.chat__msg-meta \{[\s\S]*height: 24px;[\s\S]*margin-bottom: -24px;/,
+    'the row must use the message gap instead of centering controls in zero height')
+})
+
+test('message metadata stays visible for five seconds', () => {
+  assert.match(chatView, /const MESSAGE_META_VISIBLE_MS = 5000/)
+  assert.match(chatView, /\}, MESSAGE_META_VISIBLE_MS\)/)
+})
+
+test('the revealed action uses the shared shell copy icon without visible text', () => {
+  assert.match(copyButton, /import \{ Check, Copy \} from '@openai\/apps-sdk-ui\/components\/Icon'/)
+  assert.match(copyButton, /<Copy width=\{14\} height=\{14\} aria-hidden="true" \/>/)
+  assert.doesNotMatch(copyButton, />Copy<\/span>/)
 })


### PR DESCRIPTION
## Summary
- message copy stays discreet, clearly aligned beside the timestamp, and visible long enough to use.
- keep the behavior at its existing owning interface without compatibility paths or unrelated refactors

## Verification
- `npm test -- --runInBand` focused message-copy checks and production build
- reviewed the full canonical diff against current `main`