### PR TITLE
Remove completed contribution cards from chat

### DIFF
--- a/frontend/src/components/ChatView/ContributionReviewCard.css
+++ b/frontend/src/components/ChatView/ContributionReviewCard.css
@@ -328,32 +328,6 @@
   overflow-wrap: anywhere;
 }
 
-/* The acknowledgement after this card's own Send. Same shape as every other card
-   — band, body, actions — so it inherits the swipe and the band's dismiss control
-   instead of being a special layout with no way out. */
-.contrib-card--sent {
-  border-left-color: var(--green, var(--accent));
-}
-
-.contrib-card--sent .contrib-card__badge {
-  background: color-mix(in srgb, var(--green, var(--accent)) 12%, transparent);
-  color: var(--green, var(--accent));
-}
-
-.contrib-card__link-btn {
-  flex: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 36px;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  font-size: 0.8125rem;
-  font-weight: 600;
-  color: var(--accent);
-  text-decoration: none;
-}
-
 @media (max-width: 560px) {
   .contrib-card-stack {
     width: 100%;

--- a/frontend/src/components/ChatView/ContributionReviewCard.jsx
+++ b/frontend/src/components/ChatView/ContributionReviewCard.jsx
@@ -50,19 +50,21 @@ export default function ContributionReviewCard({ chatId, turnActive, onOpenApp }
     wasActive.current = turnActive
   }, [turnActive, queryClient, queryKey])
 
-  const [sentRows, setSentRows] = useState([])
+  // The server remains authoritative, but a successful item leaves this
+  // composer surface immediately rather than waiting for its ledger refetch.
+  const [contributedItems, setContributedItems] = useState([])
   // Dismissals are persisted, so this only forces the re-render; the stored
   // decision is what actually filters the list.
   const [dismissRevision, setDismissRevision] = useState(0)
 
   const storage = typeof localStorage !== 'undefined' ? localStorage : null
-  const sentIds = new Set(sentRows.map(row => row.id))
   // Remove a successful single record locally before the ledger refetch
   // returns. Stack review items never send from chat and stay untouched.
   const pendingItems = visibleReviewItems(data, storage).filter(
-    item => item.kind !== 'record' || !sentIds.has(item.record.id),
+    item => item.kind !== 'record'
+      || !contributedItems.some(done => done.id === item.record.id),
   )
-  const panel = reviewPanelSummary(pendingItems.length, sentRows.length)
+  const panel = reviewPanelSummary(pendingItems.length)
   const grouped = panel.count > 1
   void dismissRevision
   if (!appId) return null
@@ -82,14 +84,7 @@ export default function ContributionReviewCard({ chatId, turnActive, onOpenApp }
             : 'Could not contribute this. Open Contribute for the details.',
         }
       }
-      return {
-        sent: {
-          id: record.id,
-          number: body?.number ?? body?.record?.number ?? null,
-          url: body?.url || body?.record?.url || null,
-          repo: record.repo,
-        },
-      }
+      return { contributed: true }
     } catch {
       return { error: 'Could not reach the server. Nothing was contributed.' }
     } finally {
@@ -97,11 +92,12 @@ export default function ContributionReviewCard({ chatId, turnActive, onOpenApp }
     }
   }
 
-  function rememberSent(sent) {
-    setSentRows(rows => [
-      ...rows.filter(row => row.id !== sent.id),
-      sent,
-    ])
+  function rememberContributed(recordId) {
+    setContributedItems(items => (
+      items.some(item => item.id === recordId)
+        ? items
+        : [...items, { id: recordId }]
+    ))
   }
 
   return (
@@ -123,15 +119,6 @@ export default function ContributionReviewCard({ chatId, turnActive, onOpenApp }
           <span className="contrib-card-stack__count">{panel.count}</span>
         </div>
       )}
-      {sentRows.map(sent => (
-        <SentRow
-          key={`sent:${sent.id}`}
-          sent={sent}
-          onDismiss={() => setSentRows(rows => (
-            rows.filter(row => row.id !== sent.id)
-          ))}
-        />
-      ))}
       {pendingItems.map(item => {
         const onOpenContribute = contributeApp && onOpenApp
           ? () => onOpenApp(contributeApp, { final: true })
@@ -158,7 +145,7 @@ export default function ContributionReviewCard({ chatId, turnActive, onOpenApp }
             autopilot={autopilotOnSend(data)}
             showPayoff={!grouped}
             onSubmit={submit}
-            onSent={rememberSent}
+            onContributed={rememberContributed}
             onOpenContribute={onOpenContribute}
             onDismiss={onDismiss}
           />
@@ -178,9 +165,8 @@ export default function ContributionReviewCard({ chatId, turnActive, onOpenApp }
  * (WebKit does not implement the pan-* keywords). Claiming is what stops the
  * surface underneath from taking the drag.
  *
- * It lives as a hook rather than inside one card because EVERY card here needs an
- * exit — the confirmation shipped without one, and an undismissable box above the
- * composer is worse than no confirmation at all.
+ * It lives as a hook rather than inside one card because every actionable card
+ * here needs the same exit.
  */
 function useSwipeToDismiss(onDismiss) {
   const cardRef = useRef(null)
@@ -260,53 +246,6 @@ function useSwipeToDismiss(onDismiss) {
 }
 
 
-/**
- * The acknowledgement after this card's own Send.
- *
- * It is an acknowledgement, NOT a permanent record — the Contribute app owns the
- * history and the chat reply carries the link. It gets every explicit exit the
- * other cards have (swipe and the band control), but no timed exit: the
- * acknowledgement and its GitHub link stay available until the owner dismisses
- * it or leaves the current chat surface.
- */
-function SentRow({ sent, onDismiss }) {
-  const cardRef = useSwipeToDismiss(onDismiss)
-
-  return (
-    <div ref={cardRef} className="contrib-card contrib-card--sent" role="status">
-      <div className="contrib-card__badge">
-        <span>Contributed</span>
-        <button
-          type="button"
-          className="contrib-card__dismiss"
-          aria-label="Dismiss"
-          onClick={() => onDismiss?.()}
-        >
-          <X width={14} height={14} aria-hidden="true" />
-        </button>
-      </div>
-      <p className="contrib-card__summary">
-        {sent.number
-          ? `Pull request #${sent.number} is with the maintainers.`
-          : 'It is with the maintainers now.'}
-      </p>
-      {sent.repo && <p className="contrib-card__meta">{sent.repo}</p>}
-      {sent.url && (
-        <div className="contrib-card__actions">
-          <a
-            className="contrib-card__link-btn"
-            href={sent.url}
-            target="_blank"
-            rel="noreferrer noopener"
-          >
-            View on GitHub
-          </a>
-        </div>
-      )}
-    </div>
-  )
-}
-
 function StackReviewRow({ item, onOpenContribute, onDismiss }) {
   const [open, setOpen] = useState(false)
   const cardRef = useSwipeToDismiss(onDismiss)
@@ -370,7 +309,7 @@ function StackReviewRow({ item, onOpenContribute, onDismiss }) {
 }
 
 function ReviewRow({
-  record, autopilot, showPayoff, onSubmit, onSent,
+  record, autopilot, showPayoff, onSubmit, onContributed,
   onOpenContribute, onDismiss,
 }) {
   const [open, setOpen] = useState(false)
@@ -397,8 +336,8 @@ function ReviewRow({
     }
     if (outcome?.error) {
       setError(outcome.error)
-    } else if (outcome?.sent) {
-      onSent(outcome.sent)
+    } else if (outcome?.contributed) {
+      onContributed(record.id)
     }
   }
 

--- a/frontend/src/components/ChatView/__tests__/contributionReviewModel.test.js
+++ b/frontend/src/components/ChatView/__tests__/contributionReviewModel.test.js
@@ -161,7 +161,7 @@ test('records that need attention stay in Contribute instead of blocking chat', 
 })
 
 test('multiple independent review items share one bounded review panel', () => {
-  assert.match(cardSrc, /const panel = reviewPanelSummary\(pendingItems\.length, sentRows\.length\)/)
+  assert.match(cardSrc, /const panel = reviewPanelSummary\(pendingItems\.length\)/)
   assert.match(cardSrc, /const grouped = panel\.count > 1/)
   assert.match(cardSrc, /contrib-card-stack--grouped/)
   assert.match(cardSrc, /\{panel\.title\}/)
@@ -230,26 +230,22 @@ test('the renderer gives a stack one review-together card, not one card per laye
   assert.match(cardSrc, /Review in Contribute/)
 })
 
-test('the grouped panel survives pending-to-contributed transitions', () => {
-  assert.deepEqual(reviewPanelSummary(3, 0), {
+test('the grouped panel describes only work that remains', () => {
+  assert.deepEqual(reviewPanelSummary(3), {
     count: 3,
     title: '3 reviews ready',
     copy: 'Each item keeps its own review and action.',
   })
-  assert.deepEqual(reviewPanelSummary(2, 1), {
-    count: 3,
-    title: '2 remaining · 1 contributed',
+  assert.deepEqual(reviewPanelSummary(1), {
+    count: 1,
+    title: '1 review ready',
     copy: 'Each item keeps its own review and action.',
   })
-  assert.deepEqual(reviewPanelSummary(0, 2), {
-    count: 2,
-    title: '2 items contributed',
-    copy: 'Each item was contributed separately.',
+  assert.deepEqual(reviewPanelSummary(0), {
+    count: 0,
+    title: '0 reviews ready',
+    copy: 'Each item keeps its own review and action.',
   })
-  assert.match(cardSrc, /const \[sentRows, setSentRows\] = useState\(\[\]\)/)
-  assert.match(cardSrc, /setSentRows\(rows => \[/)
-  assert.match(cardSrc, /\{sentRows\.map\(sent => \(/)
-  assert.match(cardSrc, /rows\.filter\(row => row\.id !== sent\.id\)/)
 })
 
 test('independent cards can submit in parallel without duplicating one record', () => {
@@ -260,7 +256,7 @@ test('independent cards can submit in parallel without duplicating one record', 
   assert.match(cardSrc, /const \[busy, setBusy\] = useState\(false\)/)
   assert.match(cardSrc, /disabled=\{busy \|\| submitting\}/)
   assert.doesNotMatch(cardSrc, /busyIds|errorsById/)
-  assert.match(cardSrc, /item => item\.kind !== 'record' \|\| !sentIds\.has\(item\.record\.id\)/)
+  assert.match(cardSrc, /!contributedItems\.some\(done => done\.id === item\.record\.id\)/)
 })
 
 test('a grouped panel does not repeat the same audience payoff on every card', () => {
@@ -429,7 +425,7 @@ test('the swipe has a visible, focusable equivalent', () => {
   assert.match(cardSrc, /import \{ X \} from '@openai\/apps-sdk-ui\/components\/Icon'/)
   assert.equal(
     (cardSrc.match(/<X width=\{14\} height=\{14\} aria-hidden="true" \/>/g) || []).length,
-    3,
+    2,
   )
   assert.doesNotMatch(cardSrc, /title="Dismiss/)
   assert.doesNotMatch(cardSrc, /✕|✖|❌/)
@@ -443,33 +439,18 @@ test('the dismissal gesture is claimed with a non-passive touchmove', () => {
   assert.doesNotMatch(cardSrc, /onTouchMove=\{/)
 })
 
-// The first version of the acknowledgement had NO exit: no swipe (its handlers
-// lived in the other card shape) and no control in a band it never rendered.
-// Every card shape must remain explicitly dismissible, while the acknowledgement
-// and its interactive GitHub link must never disappear on a timer.
-test('the post-send acknowledgement persists until an explicit user or navigation exit', () => {
-  const sentRow = cardSrc.slice(
-    cardSrc.indexOf('function SentRow('),
-    cardSrc.indexOf('function StackReviewRow('),
-  )
-  assert.ok(sentRow.length > 0, 'the acknowledgement is its own card shape')
-  // Same swipe binding as every other card, not a bespoke layout.
-  assert.match(sentRow, /useSwipeToDismiss\(onDismiss\)/)
-  // A band with a real dismiss control.
-  assert.match(sentRow, /className="contrib-card__badge"/)
-  assert.match(sentRow, /className="contrib-card__dismiss"/)
-  // Interactive content stays until one of those user exits or component
-  // navigation owns its lifecycle; elapsed time never removes it.
-  assert.doesNotMatch(sentRow, /setTimeout|setInterval/)
-  assert.doesNotMatch(cardSrc, /SENT_VISIBLE_MS/)
-  assert.match(sentRow, /View on GitHub/)
+test('a completed contribution leaves the composer with no acknowledgement card', () => {
+  assert.match(cardSrc, /const \[contributedItems, setContributedItems\] = useState/)
+  assert.match(cardSrc, /!contributedItems\.some\(done => done\.id === item\.record\.id\)/)
+  assert.match(cardSrc, /return \{ contributed: true \}/)
+  assert.match(cardSrc, /onContributed\(record\.id\)/)
+  assert.doesNotMatch(cardSrc, /function SentRow|contrib-card--sent/)
 })
 
-// One gesture implementation for every card shape here. Two copies is how the
-// acknowledgement ended up without one.
+// One gesture implementation for every actionable card shape here.
 test('every card shape shares one swipe implementation', () => {
   assert.equal((cardSrc.match(/function useSwipeToDismiss\(/g) || []).length, 1)
-  assert.equal((cardSrc.match(/= useSwipeToDismiss\(onDismiss\)/g) || []).length, 3)
+  assert.equal((cardSrc.match(/= useSwipeToDismiss\(onDismiss\)/g) || []).length, 2)
   assert.equal((cardSrc.match(/addEventListener\('touchmove'/g) || []).length, 1)
 })
 

--- a/frontend/src/components/ChatView/contributionReviewModel.js
+++ b/frontend/src/components/ChatView/contributionReviewModel.js
@@ -114,33 +114,12 @@ export function diffStatSummary(value) {
   return lines.at(-1) || ''
 }
 
-/**
- * Copy for the grouped panel across its whole transition, not just its pending
- * records. A sent acknowledgement is still a visible row, so it must count
- * toward the grouping decision until that acknowledgement leaves.
- */
-export function reviewPanelSummary(pendingCount, sentCount) {
-  const pending = Math.max(0, Number(pendingCount) || 0)
-  const sent = Math.max(0, Number(sentCount) || 0)
-  const count = pending + sent
-
-  if (sent === 0) {
-    return {
-      count,
-      title: `${pending} ${pending === 1 ? 'review' : 'reviews'} ready`,
-      copy: 'Each item keeps its own review and action.',
-    }
-  }
-  if (pending === 0) {
-    return {
-      count,
-      title: `${sent} item${sent === 1 ? '' : 's'} contributed`,
-      copy: 'Each item was contributed separately.',
-    }
-  }
+/** Copy for the grouped panel while it still has pending work. */
+export function reviewPanelSummary(pendingCount) {
+  const count = Math.max(0, Number(pendingCount) || 0)
   return {
     count,
-    title: `${pending} remaining · ${sent} contributed`,
+    title: `${count} ${count === 1 ? 'review' : 'reviews'} ready`,
     copy: 'Each item keeps its own review and action.',
   }
 }


### PR DESCRIPTION
## Summary
- remove completed contribution cards from the composer as soon as each submission succeeds
- keep remaining ready cards independently actionable when sending multiple items
- preserve per-card error messages when a submission fails

## Context
Related to #405, which keeps blocked contribution cards out of chat. This follow-up handles the successful end of the same lifecycle: completed work should leave the composer instead of becoming a persistent acknowledgement that needs another click.

## Verification
- `npm test` (2,199 frontend interface tests and 66 hook tests)
- focused contribution review model test (35 tests)
- `npm run build`