### PR TITLE
Use ChatRun as the durable run authority

### DIFF
--- a/backend/app/browser_profiles.py
+++ b/backend/app/browser_profiles.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from sqlalchemy.orm import Session
 
 from app import models
+from app.run_state import running_chat_ids
 
 
 _CHAT_PROFILE = re.compile(r"^chat-([0-9a-fA-F-]{36})$")
@@ -215,13 +216,13 @@ def chat_activity_snapshot(db: Session) -> dict[str, dict]:
     models.Chat.activity_at,
     models.Chat.updated_at,
     models.Chat.deleted_at,
-    models.Chat.run_status,
   ).all()
+  running = running_chat_ids(db, (str(row.id) for row in rows))
   return {
     str(row.id): {
       "activity_at": row.activity_at or row.updated_at,
       "deleted_at": row.deleted_at,
-      "run_status": row.run_status,
+      "running": str(row.id) in running,
     }
     for row in rows
   }
@@ -288,7 +289,7 @@ def enforce_browser_profile_quota(
       active = (
         path.name in active_profile_names
         or (chat_id is not None and chat_id in active_chat_ids)
-        or (chat and chat.get("run_status") == "running")
+        or bool(chat and chat.get("running"))
       )
       if chat_id is None:
         # Named/legacy profiles are included in the byte budget and cache

--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -47,7 +47,7 @@ from app.chat_writer import (
   AppendSteeredUserMessage,
   Barrier,
   ClearPending,
-  ClearRunStatus,
+  FinishRun,
   Finalize,
   ParkRun,
   PrepareAutoResume,
@@ -1205,15 +1205,15 @@ def is_broadcast_stale(
 
 
 def _run_age_secs(
-  chat: models.Chat | None,
+  run: models.ChatRun | None,
   now: datetime | None = None,
 ) -> float | None:
-  """Age in seconds of the current durable run marker, when derivable."""
-  if chat is None or chat.run_started_at is None:
+  """Age in seconds of the current durable run, when derivable."""
+  if run is None or run.started_at is None:
     return None
   if now is None:
     now = datetime.now(UTC).replace(tzinfo=None)
-  started = chat.run_started_at
+  started = run.started_at
   if started.tzinfo is not None:
     started = started.astimezone(UTC).replace(tzinfo=None)
   return max(0.0, (now - started).total_seconds())
@@ -1335,7 +1335,8 @@ def live_run_health_fields(
   if now_wall is None:
     now_wall = datetime.now(UTC).replace(tzinfo=None)
   bc = get_broadcast(chat_id)
-  chat = db.query(models.Chat).filter(models.Chat.id == chat_id).first()
+  from app.run_state import running_run
+  run = running_run(db, chat_id)
   parked_until = _parked_until_for_chat(db, chat_id)
   stale = is_broadcast_stale(bc, now_monotonic)
   exemption = _stall_exemption(db, chat_id, now_wall)
@@ -1352,7 +1353,7 @@ def live_run_health_fields(
   return {
     "state": state,
     "last_event_age_secs": last_event_age_secs(bc, now_monotonic),
-    "run_age_secs": _run_age_secs(chat, now_wall),
+    "run_age_secs": _run_age_secs(run, now_wall),
     "subscriber_count": len(bc.subscribers) if bc is not None else 0,
     "stale": stale,
     "parked_until": (
@@ -1403,42 +1404,38 @@ def recover_chat_generation(chat_id: str) -> int:
   return registry.recover_generation(chat_id)
 
 
-# Durable run marker. The runner registry holds the live "is this chat
-# running" truth in memory; the row's run_status mirrors it so it
-# survives a process death. The pair (set on turn start, clear on turn
-# end) is what lets startup reconciliation distinguish a chat that
-# genuinely finished from one whose process was killed mid-turn.
+# Durable ChatRun lifecycle. The runner registry holds live process ownership;
+# ChatRun is the sole persisted state that survives a process death.
 #
 # C2: SET is folded into the turn's StartTurn / PromotePending
-# writer-actor command (atomic with the user-message write, no separate
-# _mark_run_started). Non-terminal CLEAR routes through the best-effort
-# helper below. Terminal turn-end CLEAR uses the strict helper so a failed
-# ack surfaces as FAILED_LEAVE_MARKER and leaves the marker set for
-# reconciliation instead of reporting a clean completion.
+# writer-actor command (atomic with the user-message write). Non-terminal
+# finish routes through the best-effort helper below. Terminal turn-end finish
+# uses the strict helper so a failed ack surfaces as FAILED_LEAVE_MARKER and
+# leaves the run open for reconciliation.
 
 
-async def _clear_run_status(
+async def _finish_run(
   chat_id: str,
   run_token: str = "",
   terminal_status: str = "completed",
 ) -> None:
-  """Clears the chat's durable run marker once the turn has ended.
+  """Close a chat's durable run once the turn has ended.
 
-  Routes through the actor's `ClearRunStatus` (the sole runtime mutator
-  of the row) and awaits the ack so a clear can't lose-update against an
+  Routes through the actor's `FinishRun` (the sole runtime mutator
+  of the row) and awaits the ack so a finish can't lose-update against an
   in-flight transcript snapshot for the same chat. Best-effort: a failed
-  ack is logged and swallowed — reconciliation resolves a marker left set
+  ack is logged and swallowed — reconciliation resolves a run left open
   by a dropped clear, so this never strands the turn or the caller.
 
-  `run_token` (when given) is the ending run's token: the actor clears
-  identity-keyed, only if that token still owns the marker, so a dying run
-  can't wipe a fresh turn's marker. Tokenless clears stay unconditional.
+  `run_token` (when given) is the ending run's identity, so a dying run cannot
+  finish a successor. Tokenless finishes intentionally retire all nonterminal
+  work for lifecycle cleanup.
   """
   if not chat_id:
     return
   try:
     ack = get_writer().submit(
-      ClearRunStatus(
+      FinishRun(
         chat_id=chat_id,
         run_token=run_token,
         terminal_status=terminal_status,
@@ -1447,8 +1444,8 @@ async def _clear_run_status(
     await _await_ack(ack)
   except Exception:
     _get_logger().warning(
-      "ClearRunStatus did not persist chat_id=%s (reconciliation will "
-      "repair)", chat_id, exc_info=True,
+      "FinishRun did not persist chat_id=%s (reconciliation will repair)",
+      chat_id, exc_info=True,
     )
 
 
@@ -1491,34 +1488,32 @@ async def _record_run_metrics(
     )
 
 
-async def _clear_run_status_strict(
+async def _finish_run_strict(
   chat_id: str,
   run_token: str = "",
   terminal_status: str = "completed",
 ) -> None:
-  """Strict terminal variant of `_clear_run_status`: surfaces a failed ack.
+  """Strict terminal variant of `_finish_run`: surfaces a failed ack.
 
-  The best-effort `_clear_run_status` above swallows a failed ack because a
-  marker left set by a dropped clear is self-correcting (reconciliation
+  The best-effort `_finish_run` above swallows a failed ack because a
+  run left open by a dropped finish is self-correcting (reconciliation
   resolves a turn that actually finished). But the empty-queue terminal
-  transition (`drain_and_release`) must distinguish "marker durably
-  cleared" (`EMPTY_TERMINAL_CLEARED`) from "clear didn't land"
-  (`FAILED_LEAVE_MARKER`) so it can LEAVE the marker set on failure rather
-  than reporting a clean completion that wiped the marker reconciliation
+  transition (`drain_and_release`) must distinguish "run durably
+  closed" (`EMPTY_TERMINAL_CLEARED`) from "finish didn't land"
+  (`FAILED_LEAVE_MARKER`) so it can LEAVE the run open on failure rather
+  than reporting a clean completion that removed the evidence reconciliation
   needs. So this re-raises on a failed ack (or a lock/ack timeout the
   bounded caller imposes).
 
-  No-op (no raise) when there's no chat_id — nothing to clear.
+  No-op (no raise) when there's no chat_id — nothing to finish.
 
-  `run_token` (when given) is the ending run's token: the actor clears the
-  marker only if that token still owns it (identity-keyed compare-and-clear),
-  so a dying run's clear can't wipe the marker a fresh turn just set (the
-  markerless-run race). Tokenless clears stay unconditional.
+  `run_token` (when given) is the ending run's identity. Tokenless finishes are
+  reserved for lifecycle cleanup.
   """
   if not chat_id:
     return
   ack = get_writer().submit(
-    ClearRunStatus(
+    FinishRun(
       chat_id=chat_id,
       run_token=run_token,
       terminal_status=terminal_status,
@@ -1554,14 +1549,12 @@ def reconcile_startup_chats(
   *,
   restart_authorization: str | None = None,
 ) -> StartupReconcileResult:
-  """Resolve chats stranded "running" by the previous process.
+  """Resolve ChatRuns stranded ``running`` by the previous process.
 
-  Called once from the FastAPI lifespan startup, BEFORE the server
-  accepts requests. The runner registry is in-memory, so at boot it is
-  always empty: every chat whose row still reads ``run_status ==
-  "running"`` is therefore a turn the previous process never finished
-  (a clean shutdown clears the marker in run_chat's finally; only a
-  crash — OOM / SIGKILL — leaves it set). For each such chat we:
+  Called once from FastAPI lifespan startup, before the server accepts
+  requests. The runner registry is empty at a cold boot, so every durable
+  ``ChatRun(status="running")`` is a turn the previous process never finished.
+  For each such chat we:
 
     - finalize the persisted transcript so a reopen renders a resolved
       turn rather than a forever-spinning tool block: any tool block
@@ -1575,22 +1568,21 @@ def reconcile_startup_chats(
       holds only the SUBSEQUENT sends the user queued while that turn ran,
       so preserving them does NOT re-run the interrupted turn — it just
       keeps the unsent queue. We deliberately do NOT auto-drain it here:
-      generic crashes clear only the run marker (below), leaving the chat in
-      the SAME markerless state (``run_status=None`` + non-empty queue) the
-      bottom of this function documents; that self-heals on the NEXT user POST
+      generic crashes close only the run (below), leaving the chat idle with a
+      non-empty queue; that self-heals on the NEXT user POST
       via the stale-pending drain in ``chats_stream.send_message``. The sole
       boot auto-promotion exception is an exact run whose restart nonce matches
       the root-owned authorization for this boot — that external proof removes
       the crash-loop ambiguity;
-    - clear the durable run marker.
+    - close the exact durable run row.
 
   No queue lock is taken: this runs single-threaded at startup before
   any POST /messages can land, so the serialization invariant that the
   per-chat queue lock documents has no concurrent writer to guard
   against here.
 
-  Mid-commit timeout contract (accept-and-document; see design §D). A
-  terminal `Finalize`/`PromotePending`/`ClearRunStatus` whose `await_ack`
+  Mid-commit timeout contract (accept-and-document; see design §D). A terminal
+  `Finalize`/`PromotePending`/`FinishRun` whose `await_ack`
   timed out mid-commit may STILL land on the actor thread after the caller
   gave up — there is no rollback (single-owner makes "leave the marker set"
   sufficient). This recovery covers BOTH outcomes of such a timeout:
@@ -1598,31 +1590,19 @@ def reconcile_startup_chats(
       `pending_messages`; it is PRESERVED here and drains on the next user
       POST (the stale-pending self-heal), so the queue survives the restart;
     - the commit DID land after the timeout (a PromotePending that moved
-      the head into `messages` + set the marker, but whose continuation was
+      the head into `messages` + opened the next ChatRun, but whose continuation was
       never scheduled because the caller had already returned
       FAILED_LEAVE_MARKER) → the promoted user message is now the LAST
       message, so the else-branch below appends a standalone interrupted-turn
-      assistant note rather than mutating it, and the marker is cleared.
+      assistant note rather than mutating it, and the run is closed.
   Either way the chat converges to a resolved, non-spinning state.
 
-  Known gap — late-promote live-recovery requires a restart (accept-and-
-  document, same class as the mid-commit-timeout edge above; live-marker-
-  gating is a deferred follow-up, NOT implemented here). This function is
-  STARTUP-ONLY (the lifespan calls it once, before the server accepts
-  requests). So if a PromotePending lands AFTER its await_ack timed out while
-  the process is STILL RUNNING — the promote moved the head into `messages`
-  and re-set the marker, but the caller already returned FAILED_LEAVE_MARKER
-  and scheduled no continuation — that promoted-but-unscheduled turn is NOT
-  recovered live: the marker stays set and reconciliation only sees it on the
-  next boot. Under the single-owner restart-recovery contract this is
-  acceptable: the turn is durable, the marker is the recovery handle, and a
-  restart resolves it. `_schedule_continuation`'s scheduling-failure path is the
-  same shape (marker left, recovered on restart). A future live-recovery would
-  gate the marker on an in-process watcher that reschedules a late promote
-  without a restart; deliberately deferred.
+  The runtime wedged-run sweep now closes the late-promote gap between boots:
+  an old running row with no registry or running broadcast is recovered by
+  exact run id after the terminal window settles.
 
   Intentional direct-write exception to the C2 single-writer rule: this
-  mutates `chat.messages` / `chat.pending_messages` / the run marker
+  mutates `chat.messages` / `chat.pending_messages` and ChatRun rows
   DIRECTLY on its own session rather than through the writer actor. That
   is deliberate — reconciliation runs in the FastAPI lifespan BEFORE
   `start_writer()` (recovery must work even when persistence is degraded,
@@ -1645,12 +1625,14 @@ def reconcile_startup_chats(
   manual: list[str] = []
   restart_parks: list[str] = []
   try:
+    from app.run_state import running_chat_ids
+    stale_ids = running_chat_ids(db)
     stale = (
       db.query(models.Chat)
-      .filter(models.Chat.run_status == "running")
+      .filter(models.Chat.id.in_(stale_ids))
       .filter(models.Chat.deleted_at.is_(None))
       .all()
-    )
+    ) if stale_ids else []
   except Exception:
     log.exception("reconcile_startup_chats: query failed")
     return StartupReconcileResult(manual=manual, restart_parks=restart_parks)
@@ -1828,20 +1810,13 @@ def reconcile_startup_chats(
         msgs.append(new_msg)
       chat.messages = msgs
       chat.live_assistant = None
-      # Preserve chat.pending_messages: clearing the run marker (below)
-      # drops the chat into the markerless-queue state that self-heals on
-      # the next user POST's stale-pending drain. We do NOT auto-drain at
+      # Preserve chat.pending_messages: closing the run leaves an idle queue
+      # that self-heals on the next user POST's stale-pending drain. We do NOT auto-drain at
       # boot — that is the crash-loop hazard. (Owner-reported bug: a
       # restart used to discard the queue here.)
-      chat.run_status = None
-      chat.run_started_at = None
-      # Close this chat's durable per-run record(s) in the SAME commit (077
-      # Step 3): a row still "running" at boot is the interrupted turn we just
-      # finalized. run_status stays the AUTHORITATIVE recovery trigger for the
-      # destructive transcript repair above; chat_runs is maintained alongside
-      # so the run record matches reality. (Flipping the destructive read onto
-      # chat_runs + retiring run_status is the Step-3b follow-up, once the
-      # record is proven in prod.)
+      # Close every still-running row for the chat in the SAME commit as the
+      # transcript repair. A healthy writer maintains one current row; closing
+      # all also repairs any historical duplicate left by an interrupted deploy.
       recovered_at = datetime.now(UTC)
       for run in running_runs:
         if restart_eligible and restart_run is not None and run.id == restart_run.id:
@@ -1879,21 +1854,10 @@ def reconcile_startup_chats(
       len(restart_parks), ", ".join(restart_parks),
     )
 
-  # Orphaned run records (077 Step 3): a chat_runs row left "running" whose
-  # chat is NOT alive and was NOT closed above (its run_status already cleared
-  # — a dropped close, or the chat soft-deleted mid-run). Non-destructive: mark
-  # the record interrupted so it doesn't linger as a false "running", but touch
-  # no transcript. Dual-write keeps the two signals in lockstep, so this
-  # normally finds nothing; it is belt-and-suspenders against a close that
-  # didn't land.
-  #
-  # Crucially it must NOT mask a destructive reconcile that FAILED above: that
-  # chat is left with run_status=="running" AND its record "running", and the
-  # next boot's destructive pass must retry it. So skip any record whose chat
-  # still authoritatively reads run_status=="running" and isn't deleted —
-  # flipping only its record would diverge the two signals (record says
-  # interrupted, the authoritative marker still says running). Only close a
-  # record whose chat is gone, soft-deleted, or already run_status-cleared.
+  # A running row whose chat is gone or soft-deleted cannot receive transcript
+  # recovery. Close it non-destructively. Active chats are skipped here: if
+  # their destructive pass failed above, the running row must remain as the
+  # recovery handle for the next boot.
   try:
     orphans = (
       db.query(models.ChatRun)
@@ -1907,13 +1871,7 @@ def reconcile_startup_chats(
       chat = (
         db.query(models.Chat).filter(models.Chat.id == run.chat_id).first()
       )
-      if (
-        chat is not None
-        and chat.deleted_at is None
-        and chat.run_status == "running"
-      ):
-        # The destructive pass owns this chat (and failed/rolled back, since it
-        # clears run_status on success). Leave the record running to match.
+      if chat is not None and chat.deleted_at is None:
         continue
       run.status = "interrupted"
       run.ended_at = datetime.now(UTC)
@@ -1926,23 +1884,23 @@ def reconcile_startup_chats(
     db.rollback()
     log.exception("reconcile_startup_chats: orphan run sweep failed")
 
-  # Boot never starts markerless work; the age-gated runtime sweep claims it.
+  # Boot never starts idle queued work; the age-gated runtime sweep claims it.
   try:
-    markerless = (
+    candidates = (
       db.query(models.Chat.id, models.Chat.pending_messages)
-      .filter(models.Chat.run_status.is_(None))
       .filter(models.Chat.deleted_at.is_(None))
       .all()
     )
-    for chat_id, pending_messages in markerless:
-      if pending_messages:
+    from app.run_state import has_nonterminal_run
+    for chat_id, pending_messages in candidates:
+      if pending_messages and not has_nonterminal_run(db, chat_id):
         log.warning(
-          "reconcile_startup_chats: markerless pending queue chat_id=%s "
+          "reconcile_startup_chats: idle pending queue chat_id=%s "
           "count=%d; left intact for the age-gated pending sweep",
           chat_id, len(pending_messages),
         )
   except Exception:
-    log.exception("reconcile_startup_chats: markerless-queue scan failed")
+    log.exception("reconcile_startup_chats: idle-queue scan failed")
 
   return StartupReconcileResult(
     manual=manual,
@@ -1988,21 +1946,20 @@ def notify_after_reconcile(db: Session, reconciled: list[str]) -> str | None:
 
 
 # Runtime liveness floor: a turn must be at least this old before the periodic
-# sweep treats a still-"running" marker as a candidate. Reaping is gated on the
+# sweep treats a still-running row as a candidate. Reaping is gated on the
 # broadcast + registry state below; the floor is only belt-and-suspenders
 # against a just-started turn whose registry/broadcast state hasn't settled.
 _WEDGED_RUN_MIN_AGE = timedelta(seconds=120)
 
 
-async def sweep_wedged_run_markers(db: Session) -> list[str]:
-  """Clear run markers orphaned by a completed-but-uncleared turn at runtime.
+async def sweep_wedged_runs(db: Session) -> list[str]:
+  """Recover durable runs orphaned by a completed-but-unclosed turn.
 
   `reconcile_interrupted_chats` only runs at boot, so a turn that reaches a
-  terminal WITHOUT clearing its marker and WITHOUT a process restart — a
+  terminal WITHOUT closing its run and WITHOUT a process restart — a
   FAILED_LEAVE_MARKER exit (finalize/promote ack raised or timed out) or the
-  documented late-promote gap — holds `run_status="running"` forever. The
-  frontend trusts that stale marker and the chat looks permanently busy ("whole
-  app busy"). This periodic sweep closes that gap between boots.
+  late-promote scheduling failure — leaves its ChatRun ``running`` forever.
+  This periodic sweep closes that gap between boots.
 
   Reaping requires THREE signals together, because none is safe alone:
 
@@ -2018,17 +1975,17 @@ async def sweep_wedged_run_markers(db: Session) -> list[str]:
       LIVE turn (a big build, or a workflow held open by
       `TaskOutput(block=True)`) whose broadcast is still running — we never reap
       a live turn, only a definitively-finished one whose marker stuck.
-    - `run_started_at` older than the floor — belt-and-suspenders.
+    - `ChatRun.started_at` older than the floor — belt-and-suspenders.
 
   Recovery is IDENTITY-KEYED on the wedged run's `ChatRun.id` (never
-  tokenless): if a fresh turn raced in and took the marker, the actor no-ops
-  rather than wiping the new run's transcript or marker. It runs under the
+  tokenless): if a fresh turn raced in, the actor no-ops rather than touching
+  the new run's transcript. It runs under the
   per-chat queue lock with an is_alive recheck, mirroring `stop_chat_for`'s
   clear discipline. The writer atomically materializes any saved live assistant,
-  appends a resumable interruption marker, closes the run, and clears the marker.
+  appends a resumable interruption note, and closes the run.
   `pending_messages` is preserved. This atomic domain command is required: a
-  separate `ReplaceTranscript` + `ClearRunStatus` pair could race a fresh send,
-  while clearing only the marker can permanently erase the recovery handle for
+  separate `ReplaceTranscript` + `FinishRun` pair could race a fresh send,
+  while closing first can permanently erase the recovery handle for
   a turn whose snapshots all failed to save.
   """
   log = _get_logger()
@@ -2041,38 +1998,28 @@ async def sweep_wedged_run_markers(db: Session) -> list[str]:
   try:
     cutoff = datetime.now(UTC).replace(tzinfo=None) - _WEDGED_RUN_MIN_AGE
     stale = (
-      # The watchdog needs only identity. A long-running chat can have a
+      # The watchdog needs only run identity. A long-running chat can have a
       # multi-megabyte transcript; hydrating it every minute while merely
       # checking registry/broadcast state repeats the same allocator problem
       # the idle-pending projection below avoids.
-      db.query(models.Chat.id)
-      .filter(models.Chat.run_status == "running")
+      db.query(models.ChatRun.id, models.ChatRun.chat_id)
+      .join(models.Chat, models.Chat.id == models.ChatRun.chat_id)
+      .filter(models.ChatRun.status == "running")
       .filter(models.Chat.deleted_at.is_(None))
-      .filter(models.Chat.run_started_at.isnot(None))
-      .filter(models.Chat.run_started_at < cutoff)
+      .filter(models.ChatRun.started_at.isnot(None))
+      .filter(models.ChatRun.started_at < cutoff)
       .all()
     )
   except Exception:
-    log.exception("sweep_wedged_run_markers: query failed")
+    log.exception("sweep_wedged_runs: query failed")
     return swept
-  for row in stale:
-    chat_id = row.id
+  for run in stale:
+    chat_id = run.chat_id
     if registry.is_alive(chat_id):
       continue
     bc = get_broadcast(chat_id)
     if bc is not None and bc.running:
       # Still streaming, in terminal cleanup, or a legitimately-long live turn.
-      continue
-    run = (
-      db.query(models.ChatRun)
-      .filter(models.ChatRun.chat_id == chat_id)
-      .filter(models.ChatRun.status == "running")
-      .order_by(models.ChatRun.started_at.desc())
-      .first()
-    )
-    if run is None:
-      # No run record to identity-key the clear on — leave it for boot reconcile
-      # rather than risk a tokenless clear wiping a racing fresh run's marker.
       continue
     try:
       async with asyncio.timeout(chat_queue.TERMINAL_LOCK_TIMEOUT_SECS):
@@ -2080,15 +2027,14 @@ async def sweep_wedged_run_markers(db: Session) -> list[str]:
           if registry.is_alive(chat_id):
             continue
           # Identity-keyed on the wedged run's token: a fresh turn that raced in
-          # owns a different token, so the actor no-ops instead of wiping it.
-          # Strict variant so a failed ack RAISES — a marker we couldn't clear
-          # must not be reported as swept (reconciliation repairs it on boot).
+          # owns a different token, so the actor no-ops.
+          # Strict variant so a failed ack RAISES and is retried later.
           await _recover_wedged_run_strict(chat_id, run.id)
       _finalize_broadcast_if_running(chat_id)
       swept.append(chat_id)
     except (Exception, asyncio.TimeoutError):
       log.warning(
-        "sweep_wedged_run_markers: recovery failed chat_id=%s "
+        "sweep_wedged_runs: recovery failed chat_id=%s "
         "(reconciliation will repair)", chat_id, exc_info=True,
       )
   if swept:
@@ -2129,7 +2075,6 @@ async def sweep_idle_pending_chats(db: Session) -> list[str]:
     # Chat only after its projected pending head proves old enough to recover.
     candidates = (
       db.query(models.Chat.id, models.Chat.pending_messages)
-      .filter(models.Chat.run_status.is_(None))
       .filter(models.Chat.deleted_at.is_(None))
       .all()
     )
@@ -2147,8 +2092,8 @@ async def sweep_idle_pending_chats(db: Session) -> list[str]:
     # pending precisely so it is not fired back into the exhausted limit
     # (chat_queue.TerminalDisposition), and resuming it belongs to
     # sweep_reset_parks (when the chat policy is enabled) or the user's own
-    # next send. The park row outlives run_status, so run_status IS NULL alone
-    # cannot distinguish "crashed drain" from "parked on purpose".
+    # next send. A terminal-looking queue alone cannot distinguish "crashed
+    # drain" from "parked on purpose".
     if _parked_until_for_chat(db, chat_id) is not None:
       continue
     if _restart_manual_hold_for_chat(db, chat_id):
@@ -2167,8 +2112,9 @@ async def sweep_idle_pending_chats(db: Session) -> list[str]:
             if chat is None:
               continue
             pending = list(chat.pending_messages or [])
+            from app.run_state import has_running_run
             if (
-              chat.run_status is not None
+              has_running_run(db, chat_id)
               or not _pending_head_is_stale(pending, now_ms)
               or _parked_until_for_chat(db, chat_id) is not None
               or _restart_manual_hold_for_chat(db, chat_id)
@@ -3406,16 +3352,16 @@ async def stop_chat_for(
     registry.discard_starting(chat_id)
     return all_stopped, cleared_pending_cids
   # With no active handle there is no runner-side final save left to
-  # await, so clear immediately (via the actor's ClearRunStatus). This is the
-  # path that resolves the orphaned-run-after-restart case (run_status stuck
-  # 'running' with an empty registry): Stop clears the stuck marker + the queue
+  # await, so clear immediately (via the actor's FinishRun). This is the
+  # path that resolves the orphaned-run-after-restart case (a ChatRun left
+  # 'running' with an empty registry): Stop closes the stuck run + the queue
   # and returns success. Active handles hand this clear back to run_chat's
   # finally block: SDK stop waiters resolve before chat.py's final sink save,
   # and a SQLite-blocked commit can exceed Stop's 2s timeout. If the process
   # dies first, the retained marker lets crash recovery reconcile the
   # interrupted turn.
   if not handles:
-    await _clear_run_status(chat_id, terminal_status="stopped")
+    await _finish_run(chat_id, terminal_status="stopped")
   _finalize_broadcast_if_running(chat_id)
   registry.discard_starting(chat_id)
   return all_stopped, cleared_pending_cids
@@ -3565,7 +3511,7 @@ async def _drain_and_release(
     db, chat_id, run_gen, run_token,
     discard_starting=discard_starting,
     forget_chat=forget_chat,
-    clear_run_status_strict=_clear_run_status_strict,
+    finish_run_strict=_finish_run_strict,
     current_generation=current_run_generation,
     ending_run_token=ending_run_token,
     ending_status=ending_status,
@@ -3734,7 +3680,7 @@ async def _terminal_setup_error_cleanup(
   teardown):
 
     (0) ownership gate, (1) await ClearPending (strict),
-    (2) await ClearRunStatus (strict), (3) discard_starting,
+    (2) await FinishRun (strict), (3) discard_starting,
     (4) forget (if-current), all inside
     `asyncio.timeout(TERMINAL_LOCK_TIMEOUT_SECS)` around the queue lock.
 
@@ -3769,7 +3715,7 @@ async def _terminal_setup_error_cleanup(
         if run_gen is not None and current_run_generation(chat_id) != run_gen:
           return chat_queue.TerminalDisposition.STALE_NO_ACTION
         await _clear_pending_strict(chat_id)
-        await _clear_run_status_strict(
+        await _finish_run_strict(
           chat_id, run_token, terminal_status="failed",
         )
         discard_starting(chat_id)
@@ -4016,7 +3962,7 @@ async def _park_run_strict(
 ) -> bool:
   """Park the run via the actor (commit-before-return); raises on failure.
 
-  The continuation sibling of `_clear_run_status_strict`: same await-the-ack
+  The continuation sibling of `_finish_run_strict`: same await-the-ack
   discipline, same identity-keyed ownership inside the actor. A tokenless
   caller (legacy/test paths with no per-run row) degrades to the plain
   marker clear — there is no row to park on, so the chat keeps today's
@@ -4026,7 +3972,7 @@ async def _park_run_strict(
   if not chat_id:
     return False
   if not run_token:
-    await _clear_run_status_strict(chat_id, "")
+    await _finish_run_strict(chat_id, "")
     return False
   ack = get_writer().submit(
     ParkRun(
@@ -4143,7 +4089,7 @@ async def _complete_turn(
        drain already cleared the marker + forgot the chat under the lock),
        or `STALE_NO_ACTION` (a newer gen owns the chat).
 
-  A drain that RAISES — the `PromotePending` / `ClearRunStatus` ack failed
+  A drain that RAISES — the `PromotePending` / `FinishRun` ack failed
   or timed out, OR the terminal lock acquisition exceeded
   `TERMINAL_LOCK_TIMEOUT_SECS` — is treated like a finalize failure: the
   queue is left intact, no continuation is scheduled, the marker is left
@@ -4367,7 +4313,7 @@ async def _complete_turn(
       )
     )
   except (Exception, asyncio.TimeoutError) as exc:
-    # The PromotePending / ClearRunStatus ack failed OR timed out, OR the
+    # The PromotePending / FinishRun ack failed OR timed out, OR the
     # terminal lock acquisition exceeded TERMINAL_LOCK_TIMEOUT_SECS. The
     # actor's await_ack is the single authority on whether a commit
     # happened; there is NO separate outer timer that could fire while the
@@ -5135,7 +5081,7 @@ async def run_chat(
                 # Identity-keyed on this dying run's token: if a fresh turn
                 # raced in and set a new marker (the is_alive window above),
                 # the actor no-ops this clear instead of wiping it.
-                await _clear_run_status_strict(
+                await _finish_run_strict(
                   chat_id, run_token or "", terminal_status=terminal_status,
                 )
                 disposition = (
@@ -5147,7 +5093,7 @@ async def run_chat(
                 disposition = chat_queue.TerminalDisposition.STALE_NO_ACTION
         except (Exception, asyncio.TimeoutError):
           _get_logger().warning(
-            "Stop-handoff ClearRunStatus did not persist chat_id=%s "
+            "Stop-handoff FinishRun did not persist chat_id=%s "
             "(reconciliation will repair)", chat_id, exc_info=True,
           )
           disposition = chat_queue.TerminalDisposition.FAILED_LEAVE_MARKER
@@ -5538,15 +5484,15 @@ async def _run_chat_impl_with_db(
     else None
   )
 
-  # Durable run marker: the turn's StartTurn (initial send) or
+  # Durable run identity: the turn's StartTurn (initial send) or
   # PromotePending (continuation / stale-pending drain) writer-actor
-  # command ALREADY set run_status="running" atomically with the
+  # command ALREADY inserted ChatRun(status="running") atomically with the
   # user-message write, keyed on this same run_token — so there is no
   # separate _mark_run_started here (it was a direct write the actor now
   # owns, eliminating the gap between the user-message commit and the
   # marker). The normal empty-queue clear happens inside the locked
   # terminal transition (_complete_turn -> _drain_and_release ->
-  # chat_queue.drain_and_release), using strict ClearRunStatus so a failed
+  # chat_queue.drain_and_release), using strict FinishRun so a failed
   # ack leaves the marker for reconciliation. run_chat's finally only owns
   # the separate Stop-handoff marker clear; continuation handoff keeps the
   # marker continuously set across the whole chain of turns.

--- a/backend/app/chat_queue.py
+++ b/backend/app/chat_queue.py
@@ -61,7 +61,7 @@ from app import schemas
 # Bound on EVERY terminal lock acquisition (the turn-end drain, the
 # no-owner / auth-error / unsupported-provider cleanup, and Stop's queue
 # cleanup). = 2·ACK_TIMEOUT_SECS + busy_timeout: a terminal transition may
-# await two sequential strict acks (PromotePending → ClearRunStatus) plus
+# await two sequential strict acks (PromotePending → FinishRun) plus
 # SQLite's 5s busy_timeout, so a healthy-but-contended terminal lock holder
 # completes well inside this bound. Exceeding it means the holder is wedged
 # — the timeout converts that hang into a FAILED_LEAVE_MARKER disposition
@@ -292,7 +292,7 @@ async def drain_and_release(
   *,
   discard_starting,
   forget_chat,
-  clear_run_status_strict,
+  finish_run_strict,
   current_generation,
   ending_run_token: str = "",
   ending_status: str = "completed",
@@ -308,7 +308,7 @@ async def drain_and_release(
       continuously set (PromotePending re-set it for the next turn) and
       ownership passes to the scheduled continuation; do NOT clear/forget.
     - If nothing to promote AND we_own_gen, clears the durable run marker
-      (strict `ClearRunStatus`, identity-keyed on `ending_run_token`), then
+      (strict `FinishRun`, identity-keyed on `ending_run_token`), then
       releases _starting, then forgets the chat — the clear-before-forget
       ordering, ALL inside this lock. The clear naming the finishing run's
       token means a fresh `StartTurn` that set a new marker mid-drain isn't
@@ -334,12 +334,12 @@ async def drain_and_release(
   Bounding: the lock acquisition is wrapped in
   `asyncio.timeout(TERMINAL_LOCK_TIMEOUT_SECS)`. A lock-acquisition timeout
   (another task holds the lock past the bound) OR a failed strict ack
-  (PromotePending / ClearRunStatus didn't land, timed out, or hit a
+  (PromotePending / FinishRun didn't land, timed out, or hit a
   malformed pending entry) raises out of this function; the caller maps that
   to `FAILED_LEAVE_MARKER`, leaving the marker set for reconciliation
   rather than scheduling a continuation / clearing on a lost write.
 
-  `discard_starting`, `forget_chat`, and `clear_run_status_strict` are
+  `discard_starting`, `forget_chat`, and `finish_run_strict` are
   injected so this module stays free of an import cycle back into chat.py /
   runner_registry. Caller (chat.py:_complete_turn) keeps responsibility for
   the post-lock `_schedule_continuation` call — this function does NOT
@@ -373,7 +373,7 @@ async def drain_and_release(
         # keyed on the finishing run's token, so even a StartTurn that lands
         # mid-drain (no generation bump → we_own_gen still true) keeps its
         # marker — the actor no-ops a clear that names the old owner.
-        await clear_run_status_strict(
+        await finish_run_strict(
           chat_id, ending_run_token, ending_status,
         )
         discard_starting(chat_id)

--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -310,11 +310,11 @@ class MigrateChat(_Command):
   live server's writer runs. The plain `_active_chat` re-read + commit the other
   commands use is NOT cross-process safe (the lost-update race the guardrail
   closes only holds WITHIN a single-actor process). So the write is an
-  optimistic compare-and-swap: `UPDATE ... WHERE run_status IS NULL AND
-  updated_at = <snapshot>`. Any concurrent live write (StartTurn sets
-  run_status; every row write bumps updated_at) makes the UPDATE match 0 rows,
-  so this command defers the chat instead of clobbering the turn. Idle-gating
-  keeps deferrals rare; the deferred chats are reported for a re-run.
+  optimistic compare-and-swap: `UPDATE ... WHERE no nonterminal ChatRun AND
+  updated_at = <snapshot>`. Any concurrent live write inserts a run row and
+  bumps updated_at, making the UPDATE match 0 rows, so this command defers the
+  chat instead of clobbering the turn. Idle-gating keeps deferrals rare; the
+  deferred chats are reported for a re-run.
 
   Idempotent + dry-run: an already-migrated row/block is a no-op (a cid is
   present, or a block already carries `output_truncated`); `dry_run` reports the
@@ -520,30 +520,24 @@ class ReplaceTranscript(_Command):
 
 
 @dataclass
-class ClearRunStatus(_Command):
-  """Clear the durable run marker once a turn has ended.
-
-  Replicates `_clear_run_status`: clears `run_status` / `run_started_at`
-  when either is set, commits.  Returns None.
-  """
+class FinishRun(_Command):
+  """Close one durable run once its turn has ended."""
 
   chat_id: str = ""
   run_token: str = ""
-  # Durable outcome for the run row.  Clearing Chat.run_status only means the
-  # chat is idle; it must not collapse a provider/setup failure into a
-  # successful "completed" run in the observability record.
+  # Preserve the real provider/setup/user-stop outcome in the run record.
   terminal_status: str = "completed"
 
 
 @dataclass
 class RecoverWedgedRun(_Command):
-  """Atomically materialize an interrupted turn and clear its stale marker.
+  """Atomically materialize an interrupted turn and close its durable run.
 
   Runtime recovery must never clear the only durable recovery handle while
   leaving a trailing user message unanswered.  This command folds the saved
   live assistant snapshot (when one exists) into history, appends the supplied
-  interruption block, closes the exact run row, and clears the marker in one
-  commit.  It preserves ``pending_messages`` unchanged.
+  interruption block, and closes the exact run row in one commit. It preserves
+  ``pending_messages`` unchanged.
   """
 
   chat_id: str = ""
@@ -555,18 +549,16 @@ class RecoverWedgedRun(_Command):
 class ParkRun(_Command):
   """Park a turn for a due continuation (design §2.4).
 
-  The identity-keyed sibling of `ClearRunStatus` for the limit exit: the
-  turn is over, so the per-chat marker (`Chat.run_status`) is cleared the
-  same way — but instead of closing the run's `chat_runs` row "completed",
-  the row moves to ``status="parked"`` carrying `parked_until` (the due time,
+  The identity-keyed sibling of `FinishRun` for the limit exit: instead of
+  closing the run's `chat_runs` row "completed", the row moves to
+  ``status="parked"`` carrying `parked_until` (the due time,
   naive UTC) and `park_reason`. Provider limits use their parsed reset time;
   a successfully drained planned restart uses ``park_reason="restart"`` and
   a due time of now. That parked row IS the durable continuation signal; no
   separate state enum exists. Same ownership discipline as
-  ClearRunStatus: a dying run whose marker was taken by a fresh turn still
-  closes its OWN row (as "completed", NOT parked — the owner already moved
-  on, so a stale park must not resurrect a notify) but leaves the fresh
-  marker and owner map untouched.
+  FinishRun: a dying run superseded by a fresh turn still closes its OWN row
+  (as "completed", NOT parked — the owner already moved on, so a stale park
+  must not resurrect a notify) but leaves the fresh owner untouched.
   """
 
   chat_id: str = ""
@@ -719,7 +711,7 @@ _FENCE_COMMANDS = (
   CancelPending,
   ClearPending,
   ReplaceTranscript,
-  ClearRunStatus,
+  FinishRun,
   RecoverWedgedRun,
   ParkRun,
   ResolvePark,
@@ -785,14 +777,10 @@ class ChatWriterActor:
     # `_session_factory()` hasn't returned yet (or hangs) must not report ready.
     # Stays clear if session-open fails (the thread goes fatal instead).
     self._session_ready = threading.Event()
-    # Per-chat owner of the durable run marker: the run_token whose StartTurn /
-    # PromotePending most recently set `run_status='running'`. `ClearRunStatus`
-    # is an identity-keyed compare-and-clear against this — a clear that names a
-    # run_token clears ONLY if that token still owns the marker, so a dying
-    # run's stale clear can't wipe the marker a fresh turn just set (the
-    # markerless-run race). Touched only on the consumer thread, so no lock; a
-    # tokenless clear (run_token="") stays unconditional for paths that already
-    # know they own the marker.
+    # Per-chat in-process owner of the latest durable ChatRun. Durable ownership
+    # is checked against ChatRun itself; this map is the faster same-process
+    # fence that keeps a dying run from touching a successor. Touched only on
+    # the consumer thread, so no lock.
     self._run_token_owner: dict[str, str] = {}
     # Serializes the check-and-set in `start()` so two concurrent callers
     # can't both pass the `_thread is None` check and each spawn a consumer
@@ -1438,8 +1426,8 @@ class ChatWriterActor:
       return self._clear_pending(db, cmd)
     if isinstance(cmd, ReplaceTranscript):
       return self._replace_transcript(db, cmd)
-    if isinstance(cmd, ClearRunStatus):
-      return self._clear_run_status(db, cmd)
+    if isinstance(cmd, FinishRun):
+      return self._finish_run(db, cmd)
     if isinstance(cmd, RecoverWedgedRun):
       return self._recover_wedged_run(db, cmd)
     if isinstance(cmd, ParkRun):
@@ -1720,23 +1708,24 @@ class ChatWriterActor:
     committing a block whose full text the side table can't reproduce — the
     actor's `except` rolls the transaction back and keeps serving other chats.
     """
-    from app.models import Chat, ToolOutput
+    from app.models import Chat, ChatRun, ToolOutput
 
     cid = cmd.chat_id
     row = db.execute(
       select(
-        Chat.messages, Chat.pending_messages, Chat.run_status, Chat.updated_at
+        Chat.messages, Chat.pending_messages, Chat.updated_at
       ).where(Chat.id == cid)
     ).first()
     if row is None:
       return {"chat_id": cid, "status": "missing"}
-    messages, pending, run_status, snap_updated_at = row
+    messages, pending, snap_updated_at = row
 
-    # Never touch a chat with a live turn in flight: the durable run marker is
-    # set atomically with the turn's first write, so a "running" row is one a
-    # live actor owns right now. Defer + re-check after (the script re-runs the
-    # skipped set once).
-    if run_status is not None:
+    # Never touch a chat with live or parked work. The ChatRun row is created
+    # atomically with the turn's first transcript write.
+    if db.query(ChatRun.id).filter(
+      ChatRun.chat_id == cid,
+      ChatRun.status.in_(models.NONTERMINAL_RUN_STATUSES),
+    ).first() is not None:
       return {"chat_id": cid, "status": "skipped_active"}
 
     plan = plan_chat_migration(messages or [], pending or [])
@@ -1800,14 +1789,18 @@ class ChatWriterActor:
       self._verify_thinking_round_trip(db, cid, plan.thinking_stashes)
 
       # Optimistic CAS: commit the rewritten blobs only while the chat is still
-      # idle AND unchanged since the snapshot. A concurrent live turn (another
-      # process's actor) sets run_status and/or bumps updated_at, matching 0 rows
-      # here — we roll back (dropping the flushed stashes too) and defer the chat.
+      # idle AND unchanged since the snapshot. A concurrent live turn inserts a
+      # nonterminal ChatRun and bumps updated_at, matching 0 rows here — we roll
+      # back (dropping the flushed stashes too) and defer the chat.
+      active_run_exists = select(ChatRun.id).where(
+        ChatRun.chat_id == cid,
+        ChatRun.status.in_(models.NONTERMINAL_RUN_STATUSES),
+      ).exists()
       result = db.execute(
         update(Chat)
         .where(
           Chat.id == cid,
-          Chat.run_status.is_(None),
+          ~active_run_exists,
           Chat.updated_at == snap_updated_at,
         )
         .values(messages=plan.new_messages, pending_messages=plan.new_pending)
@@ -1960,28 +1953,25 @@ class ChatWriterActor:
     }
     if len(existing) == 1:
       chat.title = first_message_title(cmd.title_source) or "New chat"
-    chat.run_status = "running"
-    chat.run_started_at = datetime.now(UTC)
+    started_at = datetime.now(UTC)
     chat.updated_at = datetime.now(UTC)
     # Owner-send: advance the drawer ordering key (see models.Chat.activity_at).
     chat.activity_at = datetime.now(UTC)
-    # Durable per-run record (077 Step 3), inserted in the SAME commit as the
-    # run_status marker so the two can never diverge. Keyed on this turn's
-    # run_token — the one identity the sink and ClearRunStatus also carry.
+    # The durable run row is inserted in the SAME commit as the user message.
+    # Its id is the one identity the sink and FinishRun also carry.
     # A fresh start claims an idle chat (mark_starting guarantees no live run),
     # so any still-running row is a prior run whose clear was dropped — mark it
     # interrupted before opening this one (at most one run is ever live).
     from app.models import ChatRun
-    self._close_running_runs(db, cmd.chat_id, "interrupted")
+    self._close_nonterminal_runs(db, cmd.chat_id, "interrupted")
     db.add(ChatRun(
       id=cmd.run_token, chat_id=cmd.chat_id, status="running",
-      provider=chat.provider, started_at=chat.run_started_at,
+      provider=chat.provider, started_at=started_at,
       initiated_by_app_id=cmd.initiated_by_app_id,
     ))
     if not _commit_or_rollback(db):
       raise _PersistFailed("StartTurn did not persist")
-    # This run_token now owns the marker — a later ClearRunStatus naming a
-    # different token (a dying run) must not clear it.
+    # This run_token now owns the in-process handoff fence.
     self._run_token_owner[cmd.chat_id] = cmd.run_token
     return {
       "history": history,
@@ -2143,6 +2133,8 @@ class ChatWriterActor:
     """Commit a provider handoff if its source chat is still idle/current."""
     from datetime import UTC, datetime
 
+    from app.models import ChatRun
+
     chat = _active_chat(db, cmd.chat_id)
     if chat is None:
       raise _PersistFailed(
@@ -2169,13 +2161,8 @@ class ChatWriterActor:
           "agent_settings_json": chat.agent_settings_json,
         }
 
-    from app.models import ChatRun
-
-    has_running_row = db.query(ChatRun).filter(
-      ChatRun.chat_id == cmd.chat_id,
-      ChatRun.status == "running",
-    ).first() is not None
-    if chat.run_status is not None or chat.pending_messages or has_running_row:
+    from app.run_state import has_running_run
+    if chat.pending_messages or has_running_run(db, cmd.chat_id):
       return {"status": "conflict", "reason": "busy"}
     if (chat.provider or "claude") != cmd.expected_provider:
       return {"status": "conflict", "reason": "provider_changed"}
@@ -2255,11 +2242,8 @@ class ChatWriterActor:
     if chat is None:
       raise _PersistFailed("PersistCompaction: chat not found or deleted")
     messages = list(chat.messages or [])
-    has_active_run = db.query(ChatRun).filter(
-      ChatRun.chat_id == cmd.chat_id,
-      ChatRun.status.in_(models.NONTERMINAL_RUN_STATUSES),
-    ).first() is not None
-    if chat.run_status is not None or chat.pending_messages or has_active_run:
+    from app.run_state import has_nonterminal_run
+    if chat.pending_messages or has_nonterminal_run(db, cmd.chat_id):
       return {"status": "conflict", "reason": "busy"}
     if (chat.provider or "claude") != cmd.expected_provider:
       return {"status": "conflict", "reason": "provider_changed"}
@@ -2369,26 +2353,23 @@ class ChatWriterActor:
         chat.messages + list(chat.pending_messages or [])
       ),
     }
-    chat.run_status = "running"
-    chat.run_started_at = datetime.now(UTC)
+    started_at = datetime.now(UTC)
     chat.updated_at = datetime.now(UTC)
     # The prior turn finished (the queue had more) and hands off to this
-    # continuation. Close its run record completed and open the continuation's,
-    # all in the SAME commit as the marker (077 Step 3). A continuation never
-    # gets a ClearRunStatus of its own — the marker stays set across the
-    # handoff — so this is where the prior run's record is closed.
+    # continuation. Close its run record and open the continuation's in the
+    # SAME commit as the queue handoff.
     from app.models import ChatRun
-    self._close_running_runs(
+    self._close_nonterminal_runs(
       db, cmd.chat_id, cmd.ending_status, except_token=cmd.run_token
     )
     db.add(ChatRun(
       id=cmd.run_token, chat_id=cmd.chat_id, status="running",
-      provider=chat.provider, started_at=chat.run_started_at,
+      provider=chat.provider, started_at=started_at,
       initiated_by_app_id=initiated_by_app_id,
     ))
     if not _commit_or_rollback(db):
       raise _PersistFailed("PromotePending did not persist")
-    # The promoted continuation now owns the marker under its run_token.
+    # The promoted continuation now owns the in-process handoff fence.
     self._run_token_owner[cmd.chat_id] = cmd.run_token
     return {
       "history": history,
@@ -2466,16 +2447,13 @@ class ChatWriterActor:
     return True
 
   @staticmethod
-  def _close_running_runs(db, chat_id, status, except_token=None):
-    """Mark every still-running `chat_runs` row for a chat terminal.
+  def _close_nonterminal_runs(db, chat_id, status, except_token=None):
+    """Mark every superseded nonterminal run for a chat terminal.
 
-    At most one run is ever live per chat (the run marker is per-chat and
-    single-owner), so when a new run takes over or the chat goes idle, any
-    OTHER row still ``status == "running"`` is by definition stale and is
-    moved to `status` ("completed" / "interrupted"). `except_token` keeps the
-    incoming run's own row untouched. Keyed off the per-chat single-run
-    invariant, so it needs no run-token side bookkeeping. Returns True when it
-    changed a row (the caller folds the commit in).
+    At most one run is current per chat. When a new run takes over or the chat
+    goes idle, any OTHER running/parked/resume-pending row is superseded.
+    `except_token` keeps the incoming run's own row untouched. Returns True
+    when it changed a row (the caller folds the commit in).
     """
     from datetime import UTC, datetime
 
@@ -2505,32 +2483,17 @@ class ChatWriterActor:
       changed = True
     return changed
 
-  def _clear_run_status(self, db, cmd: ClearRunStatus):
-    """Clear the durable run marker when set; commit.
+  def _finish_run(self, db, cmd: FinishRun):
+    """Close the exact durable run, or every nonterminal row tokenlessly.
 
-    Identity-keyed compare-and-clear: when `cmd.run_token` is set, clear ONLY
-    if that token still owns the marker (`_run_token_owner`). A dying run's
-    stale clear thus can't wipe the marker a fresh turn just set — the
-    fresh turn's StartTurn recorded itself as the owner, so the dying token
-    no longer matches and this is a no-op (the markerless-run race). A
-    tokenless clear (run_token="") is unconditional, for paths that already
-    know they own the marker (reconciliation, no-handoff cleanup).
-
-    The per-run `chat_runs` record (077 Step 3) is closed in the SAME commit:
-    a tokened clear marks its own run's row with `cmd.terminal_status` IF it is
-    still running. The default is the clean-success outcome "completed";
-    provider/setup errors, explicit Stop, and live interruption callers pass a
-    more specific terminal outcome.
-    A run superseded by a fresh StartTurn is already terminal ("interrupted",
-    set by that StartTurn's `_close_running_runs`), so its dying
-    no-op-on-the-marker clear correctly leaves the row terminal rather than
-    re-stamping it — either way the run's record is closed, never left
-    "running". A tokenless clear closes every still-running row for the chat
-    (the chat is going idle, so any lingering record is stale).
+    A tokened finish never mutates a successor: it can close only its own row,
+    and releases the in-process owner only when the same token still owns it.
+    Tokenless finish is reserved for lifecycle paths (such as deletion) that
+    intentionally retire all nonterminal work for the chat.
     """
     from datetime import UTC, datetime
 
-    from app.models import Chat, ChatRun
+    from app.models import ChatRun
 
     if cmd.terminal_status not in _TERMINAL_RUN_STATUSES:
       raise _PersistFailed(
@@ -2538,56 +2501,39 @@ class ChatWriterActor:
       )
 
     owner = self._run_token_owner.get(cmd.chat_id)
-    marker_is_ours = not (
-      cmd.run_token and owner is not None and owner != cmd.run_token
-    )
     changed = False
     if cmd.run_token:
-      run = (
-        db.query(ChatRun).filter(ChatRun.id == cmd.run_token).first()
-      )
+      run = db.query(ChatRun).filter(
+        ChatRun.id == cmd.run_token,
+        ChatRun.chat_id == cmd.chat_id,
+      ).first()
       if run is not None and run.status == "running":
         run.status = cmd.terminal_status
         run.ended_at = datetime.now(UTC)
         run.restart_nonce = None
         changed = True
-    elif marker_is_ours:
-      changed = self._close_running_runs(
+    else:
+      changed = self._close_nonterminal_runs(
         db, cmd.chat_id, cmd.terminal_status
       ) or changed
-    if not marker_is_ours:
-      # A dying run's stale clear: its own run record is closed above, but the
-      # per-chat marker belongs to the fresh turn — don't touch it or the
-      # owner map.
-      if changed and not _commit_or_rollback(db):
-        raise _PersistFailed("ClearRunStatus did not persist")
-      return None
-    chat = db.query(Chat).filter(Chat.id == cmd.chat_id).first()
-    if chat is not None and (
-      chat.run_status is not None or chat.run_started_at is not None
-    ):
-      chat.run_status = None
-      chat.run_started_at = None
-      changed = True
     if changed and not _commit_or_rollback(db):
-      raise _PersistFailed("ClearRunStatus did not persist")
-    self._run_token_owner.pop(cmd.chat_id, None)
+      raise _PersistFailed("FinishRun did not persist")
+    if not cmd.run_token or owner == cmd.run_token:
+      self._run_token_owner.pop(cmd.chat_id, None)
     return None
 
   def _recover_wedged_run(self, db, cmd: RecoverWedgedRun):
     """Recover a finished turn without creating a silent transcript gap.
 
-    The ownership check is the same identity fence as ``ClearRunStatus``.  A
-    stale recovery command may close its own old run row, but it cannot alter a
-    newer owner's transcript or marker.  When this run still owns the marker,
-    transcript recovery and marker/run closure land in the same transaction.
+    The exact run must still be latest and own the in-process fence before its
+    transcript can change. A stale command may close only its own old row.
     """
     from datetime import UTC, datetime
 
     from app.models import Chat, ChatRun
 
     owner = self._run_token_owner.get(cmd.chat_id)
-    marker_is_ours = not (
+    owner_is_ours = not (
       cmd.run_token and owner is not None and owner != cmd.run_token
     )
     changed = False
@@ -2595,13 +2541,19 @@ class ChatWriterActor:
       ChatRun.id == cmd.run_token,
       ChatRun.chat_id == cmd.chat_id,
     ).first()
+    run_is_current = bool(
+      run is not None
+      and run.status == "running"
+      and owner_is_ours
+      and self._run_is_latest(db, run)
+    )
     if run is not None and run.status == "running":
       run.status = "interrupted"
       run.ended_at = datetime.now(UTC)
       run.restart_nonce = None
       changed = True
 
-    if not marker_is_ours:
+    if not run_is_current:
       if changed and not _commit_or_rollback(db):
         raise _PersistFailed("RecoverWedgedRun did not persist stale close")
       return False
@@ -2659,37 +2611,27 @@ class ChatWriterActor:
 
       chat.messages = messages
       chat.live_assistant = None
-      if chat.run_status is not None or chat.run_started_at is not None:
-        chat.run_status = None
-        chat.run_started_at = None
       changed = True
 
     if changed and not _commit_or_rollback(db):
       raise _PersistFailed("RecoverWedgedRun did not persist")
-    self._run_token_owner.pop(cmd.chat_id, None)
+    if owner is None or owner == cmd.run_token:
+      self._run_token_owner.pop(cmd.chat_id, None)
     return True
 
   def _park_run(self, db, cmd: ParkRun):
-    """Park the run's row for continuation + clear the per-chat marker.
+    """Park the current durable run for continuation.
 
-    Mirrors `_clear_run_status`'s ownership discipline exactly — the same
-    identity-keyed compare against `_run_token_owner` — with one difference:
-    when this token still owns the marker, its `chat_runs` row becomes
-    ``status="parked"`` (carrying `parked_until` + `park_reason`) instead of
-    "completed". A dying run whose marker a fresh turn already took closes
-    its own row "completed" WITHOUT parking: the owner has moved on, and a
-    stale park would fire a spurious reset notify later. The per-chat marker
-    (`Chat.run_status`) is cleared either way the marker is ours — the turn
-    IS over, so the chat must not look busy, must not be reaped by the
-    wedged sweep, and must not get a spurious "server restarted" note from
-    boot reconcile.
+    The exact run must still be latest and own the in-process fence. A stale
+    dying run is completed instead, so it cannot resurrect a continuation
+    after a successor has taken over.
     """
     from datetime import UTC, datetime
 
-    from app.models import Chat, ChatRun
+    from app.models import ChatRun
 
     owner = self._run_token_owner.get(cmd.chat_id)
-    marker_is_ours = not (
+    owner_is_ours = not (
       cmd.run_token and owner is not None and owner != cmd.run_token
     )
     changed = False
@@ -2699,9 +2641,6 @@ class ChatWriterActor:
         db.query(ChatRun).filter(ChatRun.id == cmd.run_token).first()
       )
       # A tokened transition is useful only when the exact running row exists.
-      # Do not clear the generic chat marker on a missing/terminal row: leaving
-      # it set lets startup reconciliation recover manually instead of losing
-      # the only durable evidence that work was interrupted.
       if run is None or run.status != "running":
         return bool(
           run is not None
@@ -2712,7 +2651,8 @@ class ChatWriterActor:
             or run.restart_nonce == (cmd.restart_nonce or None)
           )
         )
-      if marker_is_ours:
+      run_is_current = owner_is_ours and self._run_is_latest(db, run)
+      if run_is_current:
         run.status = "parked"
         run.parked_until = cmd.parked_until
         run.park_reason = (cmd.park_reason or None)
@@ -2725,20 +2665,14 @@ class ChatWriterActor:
         run.restart_nonce = None
       run.ended_at = datetime.now(UTC)
       changed = True
-    if not marker_is_ours:
+    if not owner_is_ours or not parked:
       if changed and not _commit_or_rollback(db):
         raise _PersistFailed("ParkRun did not persist")
       return False
-    chat = db.query(Chat).filter(Chat.id == cmd.chat_id).first()
-    if chat is not None and (
-      chat.run_status is not None or chat.run_started_at is not None
-    ):
-      chat.run_status = None
-      chat.run_started_at = None
-      changed = True
     if changed and not _commit_or_rollback(db):
       raise _PersistFailed("ParkRun did not persist")
-    self._run_token_owner.pop(cmd.chat_id, None)
+    if owner is None or owner == cmd.run_token:
+      self._run_token_owner.pop(cmd.chat_id, None)
     return parked
 
   def _prepare_restart_intents(
@@ -2772,7 +2706,6 @@ class ChatWriterActor:
       chat = db.query(Chat).filter(
         Chat.id == chat_id,
         Chat.deleted_at.is_(None),
-        Chat.run_status == "running",
       ).first()
       if run is None or chat is None or not self._run_is_latest(db, run):
         continue
@@ -2846,17 +2779,8 @@ class ChatWriterActor:
 
   @staticmethod
   def _run_is_latest(db, run) -> bool:
-    """Whether ``run`` is the deterministic latest run for its chat."""
-    from app.models import ChatRun
-
-    latest = (
-      db.query(ChatRun.id)
-      .filter(ChatRun.chat_id == run.chat_id)
-      .order_by(ChatRun.started_at.desc(), ChatRun.id.desc())
-      .first()
-    )
-    latest_id = latest[0] if latest is not None else None
-    return latest_id == run.id
+    from app.run_state import run_is_latest
+    return run_is_latest(db, run)
 
   def _rollback_auto_resume(self, db, cmd: RollbackAutoResume) -> bool:
     """Reverse only the exact unscheduled PromotePending handoff."""
@@ -2877,7 +2801,6 @@ class ChatWriterActor:
       or promoted_run.status != "running"
       or not self._run_is_latest(db, promoted_run)
       or self._run_token_owner.get(cmd.chat_id) != cmd.promoted_run_token
-      or chat.run_status != "running"
     ):
       return False
 
@@ -2896,8 +2819,6 @@ class ChatWriterActor:
 
     chat.messages = messages[:-len(promoted_pending)]
     chat.pending_messages = promoted_pending + list(chat.pending_messages or [])
-    chat.run_status = None
-    chat.run_started_at = None
     db.delete(promoted_run)
     if cmd.retry_park:
       park.status = "resume_pending"

--- a/backend/app/contribution_autopilot.py
+++ b/backend/app/contribution_autopilot.py
@@ -800,13 +800,18 @@ async def spawn_round_turn(
     run_chat,
   )
   from app.chat_writer import StartTurn, alloc_run_token, await_ack, get_writer
+  from app.run_state import has_running_run
 
   chat = (
     db.query(models.Chat)
     .filter(models.Chat.id == chat_id, models.Chat.deleted_at.is_(None))
     .first()
   )
-  if chat is None or chat.run_status == "running" or is_chat_running(chat_id):
+  if (
+    chat is None
+    or has_running_run(db, chat_id)
+    or is_chat_running(chat_id)
+  ):
     return False
   if not mark_starting(chat_id):
     return False

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -16,6 +16,8 @@ import logging
 import os
 import threading
 import time
+import uuid
+from datetime import UTC, datetime
 from contextvars import ContextVar, Token
 from pathlib import Path
 
@@ -251,8 +253,9 @@ def run_migrations(eng) -> None:
 
   Uses SQLAlchemy's database-agnostic inspector so this works for both
   SQLite and PostgreSQL.  Safe to call on every boot — no-ops if already
-  up to date.  Skips entirely on fresh installs (no tables yet) since
-  create_all will build the correct schema from scratch.
+  up to date. Production creates missing tables before calling this function,
+  which lets migrations move legacy column data into newly introduced tables.
+  Direct callers with no application tables still no-op.
   """
   from sqlalchemy import JSON as SAJSON, bindparam, inspect as sa_inspect, text
   inspector = sa_inspect(eng)
@@ -277,6 +280,51 @@ def run_migrations(eng) -> None:
         conn.execute(text(
           "ALTER TABLE chats DROP COLUMN generated_images"
         ))
+        conn.commit()
+  # Retire the pre-ChatRun per-chat marker without losing an interrupted turn
+  # across the upgrade. ``main._init_db`` creates ``chat_runs`` first, then this
+  # migration copies every still-running legacy marker that lacks a durable run
+  # identity. Only after the recovery handle exists do we drop both old
+  # columns. Each insert is independently idempotent by the NOT EXISTS query,
+  # and each DROP is independently schema-gated for crash-safe retries.
+  if "chats" in tables and "chat_runs" in tables:
+    chats_cols = {c["name"] for c in inspector.get_columns("chats")}
+    if "run_status" in chats_cols:
+      provider_expr = "c.provider" if "provider" in chats_cols else "NULL"
+      started_expr = (
+        "c.run_started_at" if "run_started_at" in chats_cols else "NULL"
+      )
+      with eng.connect() as conn:
+        legacy = conn.execute(text(
+          f"SELECT c.id, {provider_expr}, {started_expr} "
+          "FROM chats c "
+          "WHERE c.run_status = 'running' "
+          "AND NOT EXISTS ("
+          "SELECT 1 FROM chat_runs r "
+          "WHERE r.chat_id = c.id AND r.status = 'running'"
+          ")"
+        )).all()
+        insert_run = text(
+          "INSERT INTO chat_runs "
+          "(id, chat_id, status, provider, started_at) "
+          "VALUES (:id, :chat_id, 'running', :provider, :started_at)"
+        )
+        now = datetime.now(UTC).replace(tzinfo=None)
+        for chat_id, provider, started_at in legacy:
+          conn.execute(insert_run, {
+            "id": str(uuid.uuid4()),
+            "chat_id": chat_id,
+            "provider": provider,
+            "started_at": started_at or now,
+          })
+        conn.commit()
+      with eng.connect() as conn:
+        conn.execute(text("ALTER TABLE chats DROP COLUMN run_status"))
+        conn.commit()
+      chats_cols.remove("run_status")
+    if "run_started_at" in chats_cols:
+      with eng.connect() as conn:
+        conn.execute(text("ALTER TABLE chats DROP COLUMN run_started_at"))
         conn.commit()
   apps_cols = {c["name"] for c in inspector.get_columns("apps")}
   if "chats" in tables:
@@ -701,15 +749,6 @@ def run_migrations(eng) -> None:
     if "pinned_at" not in chats_cols:
       # NOT NULL = pinned. Drawer sort key (see routes/chats.py).
       _add.append("ALTER TABLE chats ADD COLUMN pinned_at DATETIME NULL")
-    if "run_status" not in chats_cols:
-      # Crash-recovery run marker. "running" while a turn is in
-      # flight, NULL otherwise. Existing rows default to NULL (idle),
-      # which is correct: a row written before this column existed was
-      # not mid-turn at the moment we add the column. See
-      # models.Chat.run_status and chat.reconcile_interrupted_chats.
-      _add.append("ALTER TABLE chats ADD COLUMN run_status VARCHAR(16) NULL")
-    if "run_started_at" not in chats_cols:
-      _add.append("ALTER TABLE chats ADD COLUMN run_started_at DATETIME NULL")
     if "created_by_app_id" not in chats_cols:
       # App that opened this chat via the app-attributed chat contract
       # (design §1). NULL = an ordinary owner chat. No FK constraint in

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -85,11 +85,17 @@ def _install_pm_commit_launcher(source: Path, target: Path) -> bool:
 
 
 def _init_db():
-  """Run migrations and create tables, retrying on transient failures."""
+  """Create missing tables, then migrate existing ones, with retries.
+
+  Creating tables first lets a migration move legacy data into a newly
+  introduced table before retiring its old columns. ``create_all`` never
+  mutates existing tables, so column upgrades remain owned by
+  ``run_migrations``.
+  """
   for attempt in range(10):
     try:
-      run_migrations(engine)
       Base.metadata.create_all(bind=engine)
+      run_migrations(engine)
       return
     except OperationalError as e:
       if attempt < 9:
@@ -585,7 +591,7 @@ async def lifespan(app):
       sweep_idle_pending_chats,
       sweep_reset_parks,
       sweep_stalled_live_runs,
-      sweep_wedged_run_markers,
+      sweep_wedged_runs,
     )
     from app.database import SessionLocal as _SweepSession
 
@@ -595,7 +601,7 @@ async def lifespan(app):
         try:
           _sw_db = _SweepSession()
           try:
-            await sweep_wedged_run_markers(_sw_db)
+            await sweep_wedged_runs(_sw_db)
             await sweep_idle_pending_chats(_sw_db)
           finally:
             _sw_db.close()

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -160,27 +160,6 @@ class Chat(Base):
   # column DESC (newest pin at top of pinned group). PATCH
   # /api/chats/{id} accepts `pinned: bool` to toggle.
   pinned_at = Column(DateTime, nullable=True, default=None)
-  # Crash-recovery run marker. "running" while a turn is in flight,
-  # NULL otherwise. The runner registry holds the same truth in
-  # memory; this column is the DURABLE copy that survives an OOM /
-  # SIGKILL. On the next process start, lifespan reconciliation
-  # (chat.reconcile_interrupted_chats) finds any row still marked
-  # "running" — the in-memory registry is always empty at boot, so
-  # such a row is by definition a turn the dead process never
-  # finished — and resolves it (finalize the transcript, clear the
-  # marker, drop stranded pending_messages) instead of stranding the
-  # chat "running" forever in the user's view. Set at the top of
-  # chat._run_chat_impl, cleared in chat.run_chat's finally under the
-  # same generation-ownership guard that releases the _starting claim.
-  run_status = Column(String(16), nullable=True, default=None)
-  # When the in-flight turn started (UTC). Set alongside run_status;
-  # cleared to NULL when the turn ends. Not consulted by the startup
-  # reconciliation decision (run_status alone is sufficient — a boot
-  # with an empty registry makes every "running" row stale regardless
-  # of age) but kept for observability: the reconciliation log line
-  # reports how long the interrupted turn had been running, and a
-  # future liveness probe can read it without another migration.
-  run_started_at = Column(DateTime, nullable=True, default=None)
   # App that created this chat, when it was opened through the
   # app-attributed chat contract (design §1) rather than by the owner
   # in the shell. NULL = an ordinary owner chat. Set, this chat is
@@ -207,29 +186,20 @@ class Chat(Base):
 
 
 class ChatRun(Base):
-  """Durable per-turn run record (persistence redesign 077 Step 3).
+  """Durable per-turn run record and persisted run-state authority.
 
   One row per turn, keyed by the in-memory run_token (which IS this row's
   `id` — the same identity the actor commands and the sink already carry, not
-  a second one). This is the per-run successor to the single `Chat.run_status`
-  column: a row left ``status == "running"`` by a process that died is an
+  a second one). A row left ``status == "running"`` by a process that died is an
   interrupted turn that boot reconciliation resolves. It also carries the
   per-run attribution one shared column never could (provider, cost, the
   initiating app), which the app-attributed-chat contract (077 §1) and the
   redacted chat-log read API (Capability B) build on.
 
-  Transitional dual-write: `Chat.run_status` is still set/cleared in lockstep
-  with this row (in the same actor commit) for one deploy cycle, so a rollback
-  to pre-Step-3 code keeps recovering, and so reconciliation still catches a
-  turn that was in flight ACROSS the deploy (started under old code, with no
-  `chat_runs` row). Reconciliation reads the UNION of both signals during the
-  transition; retiring the `run_status` column is the Step-3b follow-up (along
-  with collapsing the in-memory generation onto this same run identity, which
-  is what finally closes 080 item 4's split source of truth).
-
-  `create_all` builds this table on the next boot (a new table, so no ALTER
-  migration is needed — see `run_migrations`, which only ALTERs existing
-  tables); existing rows are untouched.
+  The writer creates and transitions this row in the same transaction as the
+  transcript mutation that starts, parks, or completes a turn. Startup and
+  runtime recovery therefore consume the exact same identity the live sink
+  carries instead of maintaining a second per-chat status marker.
   """
 
   __tablename__ = "chat_runs"

--- a/backend/app/platform_update.py
+++ b/backend/app/platform_update.py
@@ -2060,18 +2060,25 @@ async def spawn_platform_conflict_chat(
   from app.chat_writer import StartTurn, alloc_run_token, await_ack, get_writer
   from app.config import get_settings
   from app.push import notify_owner
+  from app.run_state import running_chat_ids
 
   title = "Resolve platform update conflict"
-  running = (
-    db.query(models.Chat.id)
-    .filter(models.Chat.title == title)
-    .filter(models.Chat.run_status == "running")
-    .filter(models.Chat.deleted_at.is_(None))
-    .first()
+  candidate_ids = [
+    row.id for row in (
+      db.query(models.Chat.id)
+      .filter(models.Chat.title == title)
+      .filter(models.Chat.deleted_at.is_(None))
+      .all()
+    )
+  ]
+  running_ids = running_chat_ids(db, candidate_ids)
+  running_id = next(
+    (chat_id for chat_id in candidate_ids if chat_id in running_ids),
+    None,
   )
-  if running is not None:
+  if running_id is not None:
     return PlatformConflictResolverChatOut(
-      chat_id=running.id, created=False, started=False,
+      chat_id=running_id, created=False, started=False,
     )
 
   owner = db.query(models.Owner).first()

--- a/backend/app/routes/apps.py
+++ b/backend/app/routes/apps.py
@@ -1160,6 +1160,7 @@ async def _start_conflict_resolver_turn(
     run_chat,
   )
   from app.chat_writer import StartTurn, alloc_run_token, await_ack, get_writer
+  from app.run_state import has_running_run
 
   chat = (
     db.query(models.Chat)
@@ -1167,7 +1168,7 @@ async def _start_conflict_resolver_turn(
     .first()
   )
   if (
-    chat is None or chat.messages or chat.run_status == "running" or
+    chat is None or chat.messages or has_running_run(db, chat_id) or
     is_chat_running(chat_id)
   ):
     return False

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -15,7 +15,7 @@ from sqlalchemy.orm import Session
 from app import activity, auth, models, providers, questions
 from app.config import get_settings
 from app.chat import (
-  _clear_run_status,
+  _finish_run,
   bump_run_generation,
   is_chat_running,
   mark_chat_deleted,
@@ -36,6 +36,11 @@ from app.resource_access import (
   get_active_chat_for_principal,
   get_active_chat_or_404,
   require_active_chat_access,
+)
+from app.run_state import (
+  has_nonterminal_run,
+  has_running_run,
+  running_chat_ids,
 )
 from app.schemas import ChatPatch, ChatProviderSwitch
 from app.timeutil import now_naive_utc, SOFT_DELETE_TTL
@@ -288,7 +293,7 @@ def issue_media_token(
   return {"token": token, "expires_in": 900}
 
 
-def _owner_chat_summary(chat: models.Chat) -> dict:
+def _owner_chat_summary(chat: models.Chat, *, durable_running: bool = False) -> dict:
   """Canonical shape shared by create and the owner drawer list."""
   return {
     "id": chat.id,
@@ -298,12 +303,11 @@ def _owner_chat_summary(chat: models.Chat) -> dict:
     "pinned_at": chat.pinned_at.isoformat() if chat.pinned_at else None,
     "has_messages": bool(chat.messages and len(chat.messages) > 0),
     "created_by_app_id": chat.created_by_app_id,
-    "run_status": chat.run_status,
-    "running": chat.run_status == "running" or is_chat_running(chat.id),
+    "running": durable_running or is_chat_running(chat.id),
   }
 
 
-def _owner_chat_summary_projection(chat) -> dict:
+def _owner_chat_summary_projection(chat, *, durable_running: bool = False) -> dict:
   """Serialize the lightweight row projection used by the drawer list.
 
   ``GET /api/chats`` used to hydrate every complete ``Chat`` ORM object merely
@@ -320,8 +324,7 @@ def _owner_chat_summary_projection(chat) -> dict:
     "pinned_at": chat.pinned_at.isoformat() if chat.pinned_at else None,
     "has_messages": bool(chat.message_count),
     "created_by_app_id": chat.created_by_app_id,
-    "run_status": chat.run_status,
-    "running": chat.run_status == "running" or is_chat_running(chat.id),
+    "running": durable_running or is_chat_running(chat.id),
   }
 
 
@@ -355,7 +358,7 @@ def _chat_detail_response(
   from app.providers import effective_agent_settings
 
   all_msgs = materialized_messages(chat)
-  running = is_chat_running(chat.id)
+  running = is_chat_running(chat.id) or has_running_run(db, chat.id)
   live_snapshot = chat.live_assistant
   live_message = (
     all_msgs[-1]
@@ -482,7 +485,6 @@ def list_chats(
     # chats normally keep this NULL, so this remains a tiny projection rather
     # than pulling transcript/runtime JSON into the hot path.
     models.Chat.agent_settings_json,
-    models.Chat.run_status,
     case(
       (cast(models.Chat.messages, Text) != "[]", 1),
       else_=0,
@@ -501,11 +503,17 @@ def list_chats(
     # embedded app panels and stay hidden; an app can opt a spawned, first-class
     # owner conversation into the drawer by setting owner_visible at creation.
     chats = [c for c in chats if _visible_in_owner_drawer(c)]
+  durable_running = running_chat_ids(db, (chat.id for chat in chats))
   record_memory_checkpoint_once(
     "shell_chat_list_first_response",
     chat_count=len(chats),
   )
-  return [_owner_chat_summary_projection(c) for c in chats]
+  return [
+    _owner_chat_summary_projection(
+      chat, durable_running=chat.id in durable_running,
+    )
+    for chat in chats
+  ]
 
 
 @router.get("/session-links")
@@ -902,15 +910,10 @@ async def patch_chat(
       and latest_message.get("from_provider") == (chat.provider or "claude")
     )
     if provider_changing:
-      active_run = db.query(models.ChatRun).filter(
-        models.ChatRun.chat_id == chat_id,
-        models.ChatRun.status.in_(models.NONTERMINAL_RUN_STATUSES),
-      ).first()
       if (
         is_chat_running(chat_id)
-        or chat.run_status
         or chat.pending_messages
-        or active_run is not None
+        or has_nonterminal_run(db, chat_id)
       ):
         raise HTTPException(
           status_code=409,
@@ -1568,16 +1571,15 @@ async def delete_chat(
   questions.cancel(chat_id)
   mark_chat_deleted(chat_id)
   # Close the chat's durable run state as part of the delete. A delete with a
-  # LIVE handle stops the runner but does NOT clear the marker (that is handed
-  # to run_chat's finally), and the dying run then bows out STALE_NO_ACTION on
-  # the +inf generation — so without this the soft-deleted chat keeps a stale
-  # run_status=="running" AND a "running" chat_runs record until the next boot
-  # sweep. A tokenless ClearRunStatus closes every running run record + clears
-  # run_status + drops the actor's _run_token_owner entry; it is best-effort
+  # LIVE handle stops the runner but hands durable closure to run_chat's finally,
+  # and the dying run then bows out STALE_NO_ACTION on the +inf generation — so
+  # without this the soft-deleted chat keeps a running ChatRun until the next
+  # boot sweep. A tokenless FinishRun closes every nonterminal run record and
+  # drops the actor's _run_token_owner entry; it is best-effort
   # and safe on a soft-deleted row (clear commands don't resurrect), and
   # idempotent when the run state is already clean (the common idle delete).
   try:
-    await _clear_run_status(chat_id, terminal_status="stopped")
+    await _finish_run(chat_id, terminal_status="stopped")
   except Exception:
     # The tombstone is already committed and published. Returning a 500 now
     # would make the client treat an authoritative deletion as inconclusive,
@@ -1721,7 +1723,11 @@ async def _compact_chat_locked(
     raise HTTPException(
       status_code=409, detail="This chat already uses that provider."
     )
-  if is_chat_running(chat_id) or chat.run_status or chat.pending_messages:
+  if (
+    is_chat_running(chat_id)
+    or chat.pending_messages
+    or has_running_run(db, chat_id)
+  ):
     raise HTTPException(
       status_code=409,
       detail="Chat is busy — finish or stop the current turn before switching.",
@@ -1869,15 +1875,10 @@ async def compact_chat(
         status_code=409,
         detail="App chats cannot change provider after they are created.",
       )
-    active_run = db.query(models.ChatRun).filter(
-      models.ChatRun.chat_id == chat_id,
-      models.ChatRun.status.in_(models.NONTERMINAL_RUN_STATUSES),
-    ).first()
     if (
       is_chat_running(chat_id)
-      or chat.run_status
       or chat.pending_messages
-      or active_run is not None
+      or has_nonterminal_run(db, chat_id)
     ):
       raise HTTPException(
         status_code=409,
@@ -2266,17 +2267,12 @@ async def patch_app_chat(
   async with get_transition_lock(chat_id):
     chat = get_active_chat_for_principal(db, chat_id, principal)
     if body.system_prompt is not None:
-      active_run = db.query(models.ChatRun).filter(
-        models.ChatRun.chat_id == chat_id,
-        models.ChatRun.status.in_(models.NONTERMINAL_RUN_STATUSES),
-      ).first()
       if (
         chat.system_prompt_snapshot_id
-        or chat.run_status
         or chat.messages
         or chat.pending_messages
         or chat.session_id
-        or active_run is not None
+        or has_nonterminal_run(db, chat_id)
       ):
         raise HTTPException(
           status_code=409,
@@ -2300,17 +2296,12 @@ async def patch_app_chat(
           status_code=422, detail=f"unknown provider: {body.provider}"
         )
       if chat.provider != body.provider:
-        active_run = db.query(models.ChatRun).filter(
-          models.ChatRun.chat_id == chat_id,
-          models.ChatRun.status.in_(models.NONTERMINAL_RUN_STATUSES),
-        ).first()
         if (
           is_chat_running(chat_id)
-          or chat.run_status
           or chat.pending_messages
           or chat.messages
           or chat.session_id
-          or active_run is not None
+          or has_nonterminal_run(db, chat_id)
         ):
           raise HTTPException(
             status_code=409,

--- a/backend/app/run_state.py
+++ b/backend/app/run_state.py
@@ -1,0 +1,87 @@
+"""Canonical read-side queries for durable chat-run state.
+
+``ChatRun`` is the sole durable source of truth for whether work is running,
+parked, or awaiting continuation. Runtime ownership still lives in
+``runner_registry`` and the writer actor, but persisted state must never be
+reconstructed from a second per-chat marker.
+"""
+
+from collections.abc import Iterable
+
+from sqlalchemy.orm import Session
+
+from app import models
+
+
+def latest_run(db: Session, chat_id: str) -> models.ChatRun | None:
+  """Return the deterministic latest durable run for one chat."""
+  return (
+    db.query(models.ChatRun)
+    .filter(models.ChatRun.chat_id == chat_id)
+    .order_by(
+      models.ChatRun.started_at.desc(),
+      models.ChatRun.id.desc(),
+    )
+    .first()
+  )
+
+
+def run_is_latest(db: Session, run: models.ChatRun) -> bool:
+  """Whether ``run`` is the deterministic latest run for its chat."""
+  latest = latest_run(db, run.chat_id)
+  return latest is not None and latest.id == run.id
+
+
+def has_run_in(
+  db: Session,
+  chat_id: str,
+  statuses: Iterable[str],
+) -> bool:
+  """Whether a chat has any durable run in one of ``statuses``."""
+  wanted = tuple(statuses)
+  if not wanted:
+    return False
+  return db.query(models.ChatRun.id).filter(
+    models.ChatRun.chat_id == chat_id,
+    models.ChatRun.status.in_(wanted),
+  ).first() is not None
+
+
+def has_running_run(db: Session, chat_id: str) -> bool:
+  return has_run_in(db, chat_id, ("running",))
+
+
+def has_nonterminal_run(db: Session, chat_id: str) -> bool:
+  return has_run_in(db, chat_id, models.NONTERMINAL_RUN_STATUSES)
+
+
+def running_run(db: Session, chat_id: str) -> models.ChatRun | None:
+  """Return the latest currently-running row for one chat."""
+  return (
+    db.query(models.ChatRun)
+    .filter(
+      models.ChatRun.chat_id == chat_id,
+      models.ChatRun.status == "running",
+    )
+    .order_by(
+      models.ChatRun.started_at.desc(),
+      models.ChatRun.id.desc(),
+    )
+    .first()
+  )
+
+
+def running_chat_ids(
+  db: Session,
+  chat_ids: Iterable[str] | None = None,
+) -> set[str]:
+  """Return chat ids with a durable running row, optionally bounded."""
+  query = db.query(models.ChatRun.chat_id).filter(
+    models.ChatRun.status == "running",
+  )
+  if chat_ids is not None:
+    bounded = tuple(dict.fromkeys(chat_ids))
+    if not bounded:
+      return set()
+    query = query.filter(models.ChatRun.chat_id.in_(bounded))
+  return {str(row[0]) for row in query.distinct().all()}

--- a/backend/app/system_prompts.py
+++ b/backend/app/system_prompts.py
@@ -212,7 +212,6 @@ def backfill_started_chat_prompt_snapshots(
       chat.messages
       or chat.pending_messages
       or chat.session_id
-      or chat.run_status
       or chat.id in run_chat_ids
     )
     if not started:

--- a/backend/scripts/agent-browser-profile-cleanup.py
+++ b/backend/scripts/agent-browser-profile-cleanup.py
@@ -38,7 +38,7 @@ class ProfileRow:
   age_days: float
   chat_id: str | None = None
   chat_inactive_days: float | None = None
-  run_status: str | None = None
+  running: bool = False
   selected: bool = False
   reason: str = ""
 
@@ -68,7 +68,7 @@ class ChatDbUnavailable(Exception):
   Distinct from "the database is reachable and has zero chats". Selection must
   fail CLOSED on this: if we cannot tell which profiles belong to live chats,
   every chat profile would otherwise be misread as an orphan and reaped on age
-  alone, bypassing the run-status and inactivity guards. Reaping is the
+  alone, bypassing the active-run and inactivity guards. Reaping is the
   mutating side, so it forgives nothing here.
   """
 
@@ -82,22 +82,12 @@ def _load_chats(db_path: Path) -> dict[str, dict[str, Any]]:
     raise ChatDbUnavailable(f"cannot open {db_path}: {exc}") from exc
   conn.row_factory = sqlite3.Row
   try:
-    try:
-      rows = conn.execute(
-        "select id, deleted_at, updated_at, activity_at, run_status from chats"
-      ).fetchall()
-    except sqlite3.OperationalError as exc:
-      # `run_status` is slated for retirement (models.py: the Step-3b follow-up
-      # once ChatRun fully replaces it). Degrade gracefully rather than treating
-      # the column drop as an unreadable database: without run_status, the
-      # 14-day inactivity guard alone still protects any active chat, because an
-      # active chat has recent activity_at. Any OTHER operational error (locked,
-      # I/O, missing table) is a genuine read failure and must fail closed.
-      if "run_status" not in str(exc).lower():
-        raise ChatDbUnavailable(f"cannot read chats from {db_path}: {exc}") from exc
-      rows = conn.execute(
-        "select id, deleted_at, updated_at, activity_at from chats"
-      ).fetchall()
+    rows = conn.execute(
+      "select c.id, c.deleted_at, c.updated_at, c.activity_at, "
+      "exists(select 1 from chat_runs r "
+      "where r.chat_id=c.id and r.status='running') as running "
+      "from chats c"
+    ).fetchall()
   except sqlite3.Error as exc:
     raise ChatDbUnavailable(f"cannot read chats from {db_path}: {exc}") from exc
   finally:
@@ -105,7 +95,7 @@ def _load_chats(db_path: Path) -> dict[str, dict[str, Any]]:
   chats: dict[str, dict[str, Any]] = {}
   for row in rows:
     record = dict(row)
-    record.setdefault("run_status", None)
+    record["running"] = bool(record["running"])
     chats[str(row["id"])] = record
   return chats
 
@@ -199,7 +189,7 @@ def collect(args: argparse.Namespace) -> tuple[list[ProfileRow], dict[str, Any]]
       chat_id: str | None = None
       category = "non_chat_named"
       inactive_days: float | None = None
-      run_status: str | None = None
+      running = False
       match = CHAT_PROFILE_RE.fullmatch(name)
       if match:
         chat_id = match.group(1)
@@ -210,7 +200,7 @@ def collect(args: argparse.Namespace) -> tuple[list[ProfileRow], dict[str, Any]]
           category = "soft_deleted_chat"
         else:
           category = "existing_chat"
-          run_status = chat.get("run_status")
+          running = bool(chat.get("running"))
           activity_ts = (
             _parse_sqlite_datetime(chat.get("activity_at"))
             or _parse_sqlite_datetime(chat.get("updated_at"))
@@ -225,7 +215,7 @@ def collect(args: argparse.Namespace) -> tuple[list[ProfileRow], dict[str, Any]]
         age_days=age_days,
         chat_id=chat_id,
         chat_inactive_days=inactive_days,
-        run_status=run_status,
+        running=running,
       ))
 
   for row in rows:
@@ -245,7 +235,7 @@ def collect(args: argparse.Namespace) -> tuple[list[ProfileRow], dict[str, Any]]
       and args.include_existing_chats
       and old_enough
       and inactive_enough
-      and row.run_status != "running"
+      and not row.running
     ):
       row.selected = True
       row.reason = (

--- a/backend/scripts/chat_note.py
+++ b/backend/scripts/chat_note.py
@@ -171,7 +171,10 @@ def _read_chat_snapshot(chat_id: str) -> tuple[str, str] | None:
     con = sqlite3.connect(str(DB))
     row = con.execute(
       "select messages, updated_at from chats "
-      "where id=? and deleted_at is null and run_status is null",
+      "where id=? and deleted_at is null "
+      "and not exists (select 1 from chat_runs "
+      "where chat_runs.chat_id=chats.id "
+      "and status in ('running','parked','resume_pending'))",
       (chat_id,),
     ).fetchone()
     con.close()
@@ -432,7 +435,10 @@ def _publish_if_current(
     con.execute("begin immediate")
     row = con.execute(
       "select updated_at from chats "
-      "where id=? and deleted_at is null and run_status is null",
+      "where id=? and deleted_at is null "
+      "and not exists (select 1 from chat_runs "
+      "where chat_runs.chat_id=chats.id "
+      "and status in ('running','parked','resume_pending'))",
       (chat_id,),
     ).fetchone()
     if (
@@ -446,7 +452,10 @@ def _publish_if_current(
     published_at = datetime.now(UTC).replace(tzinfo=None).isoformat(sep=" ")
     changed = con.execute(
       "update chats set updated_at=? "
-      "where id=? and deleted_at is null and run_status is null "
+      "where id=? and deleted_at is null "
+      "and not exists (select 1 from chat_runs "
+      "where chat_runs.chat_id=chats.id "
+      "and status in ('running','parked','resume_pending')) "
       "and updated_at=?",
       (published_at, chat_id, expected_updated_at),
     ).rowcount

--- a/backend/scripts/migrate_chat_identity.py
+++ b/backend/scripts/migrate_chat_identity.py
@@ -19,8 +19,8 @@ Walks every chat's transcript once and does BOTH:
 
 Both mutations run through the single-writer `chat_writer` actor's `MigrateChat`
 command — the whole per-chat read-modify-write happens on the actor thread under
-an optimistic compare-and-swap (`WHERE run_status IS NULL AND updated_at =
-<snapshot>`), so a chat with a live turn in flight is DEFERRED, not clobbered,
+an optimistic compare-and-swap (`WHERE updated_at = <snapshot>` plus no
+nonterminal `ChatRun`), so a chat with a live turn in flight is DEFERRED, not clobbered,
 even though this script runs as a second writer process alongside the live
 server. Idle-gate the run to keep deferrals rare; deferred chats are reported
 for a re-run.

--- a/backend/scripts/seed-skills/manager-session-evidence.py
+++ b/backend/scripts/seed-skills/manager-session-evidence.py
@@ -613,8 +613,10 @@ def section_focus_chat(con, chat_id):
         return
     try:
         row = con.execute(
-            "select title, provider, created_at, updated_at, run_status, "
-            "coalesce(session_id,''), messages from chats where id=?",
+            "select c.title, c.provider, c.created_at, c.updated_at, "
+            "(select r.status from chat_runs r where r.chat_id=c.id "
+            "order by r.started_at desc, r.id desc limit 1), "
+            "coalesce(c.session_id,''), c.messages from chats c where c.id=?",
             (chat_id,),
         ).fetchone()
     except sqlite3.Error as exc:
@@ -623,13 +625,13 @@ def section_focus_chat(con, chat_id):
     if not row:
         print("  (no such chat)")
         return
-    title, provider, created, updated, run_status, session, messages = row
+    title, provider, created, updated, run_state, session, messages = row
     try:
         nmsg = len(json.loads(messages)) if messages else 0
     except (ValueError, TypeError):
         nmsg = "?"
     print(f"  title:    {title}")
-    print(f"  provider: {provider or 'claude'}   messages: {nmsg}   run_status: {run_status or '-'}")
+    print(f"  provider: {provider or 'claude'}   messages: {nmsg}   run: {run_state or '-'}")
     print(f"  created:  {created}   updated: {updated}")
     print(f"  session:  {session or '(none)'}")
 

--- a/backend/tests/test_agent_browser_profile_cleanup.py
+++ b/backend/tests/test_agent_browser_profile_cleanup.py
@@ -2,9 +2,8 @@
 
 The reaper runs `--delete` nightly on live prod. The one way it can destroy
 value is by misreading which profiles belong to live chats, so these tests pin
-the fail-closed contract: an unreadable chat database must delete nothing, and
-the planned retirement of the `run_status` column must degrade rather than
-flip selection to age-only.
+the fail-closed contract: an unreadable chat database must delete nothing and
+the canonical `chat_runs` table must protect active chats.
 """
 
 import importlib.util
@@ -34,15 +33,23 @@ def _load_module():
 cleanup = _load_module()
 
 
-def _chats_db(path, *, with_run_status=True, rows=()):
+def _chats_db(path, *, rows=(), running_chat_ids=()):
   cols = "id, deleted_at, updated_at, activity_at"
-  if with_run_status:
-    cols += ", run_status"
   conn = sqlite3.connect(str(path))
   conn.execute(f"create table chats({cols})")
+  conn.execute(
+    "create table chat_runs("
+    "id text primary key, chat_id text, status text, started_at text)"
+  )
   for row in rows:
     conn.execute(
       f"insert into chats({cols}) values ({','.join('?' * len(row))})", row
+    )
+  for index, chat_id in enumerate(running_chat_ids):
+    conn.execute(
+      "insert into chat_runs(id, chat_id, status, started_at) "
+      "values (?, ?, 'running', '2026-06-01 00:00:00')",
+      (f"run-{index}", chat_id),
     )
   conn.commit()
   conn.close()
@@ -67,28 +74,26 @@ def test_load_chats_raises_when_chats_table_absent(tmp_path):
     cleanup._load_chats(db)
 
 
-def test_load_chats_degrades_when_run_status_column_retired(tmp_path):
-  # Step-3b drops the run_status column. The reaper must keep working with the
-  # remaining columns, not read the drop as an unreadable database.
-  db = tmp_path / "no_runstatus.db"
+def test_load_chats_reads_idle_chat_from_canonical_run_table(tmp_path):
+  db = tmp_path / "idle.db"
   _chats_db(
     db,
-    with_run_status=False,
     rows=[("c1", None, "2026-06-01 00:00:00", "2026-06-01 00:00:00")],
   )
   chats = cleanup._load_chats(db)
   assert set(chats) == {"c1"}
-  assert chats["c1"]["run_status"] is None
+  assert chats["c1"]["running"] is False
 
 
-def test_load_chats_reads_a_healthy_db(tmp_path):
+def test_load_chats_reads_running_chat_from_canonical_run_table(tmp_path):
   db = tmp_path / "ok.db"
   _chats_db(
     db,
-    rows=[("c1", None, "2026-06-01 00:00:00", "2026-06-01 00:00:00", "idle")],
+    rows=[("c1", None, "2026-06-01 00:00:00", "2026-06-01 00:00:00")],
+    running_chat_ids=["c1"],
   )
   chats = cleanup._load_chats(db)
-  assert chats["c1"]["run_status"] == "idle"
+  assert chats["c1"]["running"] is True
 
 
 def test_delete_against_unreadable_db_deletes_nothing(tmp_path, capsys):

--- a/backend/tests/test_app_chat_contract.py
+++ b/backend/tests/test_app_chat_contract.py
@@ -336,7 +336,6 @@ def test_app_chat_patch_rejects_provider_switch_after_first_user_turn(
   chat_id = response.json()["id"]
   row = db.query(models.Chat).filter(models.Chat.id == chat_id).one()
   row.messages = [{"role": "user", "content": "first request"}]
-  row.run_status = "running"
   db.add(models.ChatRun(
     id="app-first-live-turn",
     chat_id=chat_id,

--- a/backend/tests/test_browser_profiles.py
+++ b/backend/tests/test_browser_profiles.py
@@ -318,7 +318,7 @@ def test_quota_prunes_regenerable_cache_before_profile(tmp_path):
   result = enforce_browser_profile_quota(
     tmp_path,
     {old: {"activity_at": now - timedelta(days=40),
-           "deleted_at": None, "run_status": None}},
+           "deleted_at": None, "running": False}},
     set(),
     now=now,
     max_bytes=90,
@@ -340,7 +340,7 @@ def test_quota_never_prunes_a_live_chat_profile(tmp_path):
   result = enforce_browser_profile_quota(
     tmp_path,
     {live: {"activity_at": now - timedelta(days=90),
-            "deleted_at": None, "run_status": "running"}},
+            "deleted_at": None, "running": True}},
     {live},
     now=now,
     max_bytes=1,
@@ -363,9 +363,9 @@ def test_quota_prunes_recent_closed_cache_before_old_durable_profile(tmp_path):
     tmp_path,
     {
       recent: {"activity_at": now - timedelta(days=1),
-               "deleted_at": None, "run_status": None},
+               "deleted_at": None, "running": False},
       old: {"activity_at": now - timedelta(days=90),
-            "deleted_at": None, "run_status": None},
+            "deleted_at": None, "running": False},
     },
     set(),
     now=now,
@@ -400,9 +400,9 @@ def test_quota_retires_oldest_recent_profile_when_grace_exceeds_budget(
     tmp_path,
     {
       older: {"activity_at": now - timedelta(days=2),
-              "deleted_at": None, "run_status": None},
+              "deleted_at": None, "running": False},
       newer: {"activity_at": now - timedelta(days=1),
-              "deleted_at": None, "run_status": None},
+              "deleted_at": None, "running": False},
     },
     set(),
     now=now,
@@ -435,9 +435,9 @@ def test_triggered_quota_finishes_at_low_water_after_partial_cache_reclaim(
     tmp_path,
     {
       older: {"activity_at": now - timedelta(days=2),
-              "deleted_at": None, "run_status": None},
+              "deleted_at": None, "running": False},
       newer: {"activity_at": now - timedelta(days=1),
-              "deleted_at": None, "run_status": None},
+              "deleted_at": None, "running": False},
     },
     set(),
     now=now,
@@ -464,7 +464,7 @@ def test_quota_reports_when_live_profiles_alone_exceed_the_budget(tmp_path):
   result = enforce_browser_profile_quota(
     tmp_path,
     {live: {"activity_at": now, "deleted_at": None,
-            "run_status": "running"}},
+            "running": True}},
     {live},
     now=now,
     max_bytes=50,

--- a/backend/tests/test_chat_agent_settings.py
+++ b/backend/tests/test_chat_agent_settings.py
@@ -392,7 +392,6 @@ def test_first_live_turn_cannot_switch_provider_via_patch(
   from app import models
 
   chat.messages = [{"role": "user", "content": "first request"}]
-  chat.run_status = "running"
   db.add(models.ChatRun(
     id="first-live-turn",
     chat_id=chat.id,

--- a/backend/tests/test_chat_compact.py
+++ b/backend/tests/test_chat_compact.py
@@ -363,7 +363,9 @@ def test_turn_start_during_synthesis_wins_without_partial_switch(
   db.expire_all()
   row = db.query(models.Chat).filter(models.Chat.id == chat_id).one()
   assert row.provider == "claude"
-  assert row.run_status == "running"
+  assert db.query(models.ChatRun).filter_by(
+    chat_id=chat_id, status="running",
+  ).count() == 1
   assert row.messages[-1]["content"] == "racing send"
   assert not any(m.get("kind") == "compaction" for m in row.messages)
 
@@ -507,8 +509,12 @@ def test_busy_chat_rejects_before_synthesis(client, auth, db, monkeypatch):
     {"role": "user", "content": "hi"},
     {"role": "assistant", "content": "hello"},
   ])
-  row = db.query(models.Chat).filter(models.Chat.id == chat_id).one()
-  row.run_status = "running"
+  db.add(models.ChatRun(
+    id="busy-provider-switch",
+    chat_id=chat_id,
+    status="running",
+    provider="claude",
+  ))
   db.commit()
   response = client.post(
     f"/api/chats/{chat_id}/provider-switch", headers=auth, json=_payload(),

--- a/backend/tests/test_chat_note.py
+++ b/backend/tests/test_chat_note.py
@@ -203,11 +203,15 @@ def test_read_transcript_excludes_derived_provider_handoffs(tmp_path):
   con = sqlite3.connect(database)
   con.execute(
     "create table chats (id text primary key, messages text, "
-    "updated_at text, run_status text, deleted_at text)"
+    "updated_at text, deleted_at text)"
   )
   con.execute(
-    "insert into chats (id, messages, updated_at, run_status, deleted_at) "
-    "values (?, ?, ?, null, null)",
+    "create table chat_runs ("
+    "id text primary key, chat_id text, status text, started_at text)"
+  )
+  con.execute(
+    "insert into chats (id, messages, updated_at, deleted_at) "
+    "values (?, ?, ?, null)",
     ("c1", json.dumps([
       {"role": "user", "content": "original request"},
       {
@@ -440,12 +444,16 @@ def _snapshot_db(cn, tmp_path):
   con.execute(
     "create table chats ("
     "id text primary key, messages text, updated_at text, "
-    "run_status text, deleted_at text)"
+    "deleted_at text)"
+  )
+  con.execute(
+    "create table chat_runs ("
+    "id text primary key, chat_id text, status text, started_at text)"
   )
   con.execute("create table owner (provider text)")
   con.execute("insert into owner values ('codex')")
   con.execute(
-    "insert into chats values (?, ?, ?, null, null)",
+    "insert into chats values (?, ?, ?, null)",
     (
       "c1",
       json.dumps([
@@ -494,7 +502,11 @@ def test_new_turn_or_delete_makes_summary_publication_stale(tmp_path):
   _existing, note_revision = cn._read_note_snapshot(note)
   con = sqlite3.connect(db_path)
   con.execute(
-    "update chats set run_status='running', updated_at=? where id='c1'",
+    "insert into chat_runs values "
+    "('run-c1', 'c1', 'running', '2026-07-13 10:00:01.000000')"
+  )
+  con.execute(
+    "update chats set updated_at=? where id='c1'",
     ("2026-07-13 10:00:01.000000",),
   )
   con.commit()
@@ -506,9 +518,9 @@ def test_new_turn_or_delete_makes_summary_publication_stale(tmp_path):
   assert not note.exists()
 
   con = sqlite3.connect(db_path)
+  con.execute("delete from chat_runs where chat_id='c1'")
   con.execute(
-    "update chats set run_status=null, deleted_at='2026-07-13', "
-    "updated_at=? where id='c1'",
+    "update chats set deleted_at='2026-07-13', updated_at=? where id='c1'",
     (revision,),
   )
   con.commit()

--- a/backend/tests/test_chat_queue_module.py
+++ b/backend/tests/test_chat_queue_module.py
@@ -22,7 +22,7 @@ from app import chat_queue, models
 
 
 def _record_clear(sink: list):
-  """Build an async `clear_run_status_strict` stub recording its chat_id.
+  """Build an async `finish_run_strict` stub recording its chat_id.
 
   drain_and_release awaits this strict clear INSIDE the lock for the
   empty-queue case (clear-before-forget) and never for a promoted
@@ -150,7 +150,7 @@ def test_drain_and_release_promotes_then_holds_starting(db):
       db, "cq-drain-with-head", run_gen=7, run_token="rt-cq",
       discard_starting=discarded.append,
       forget_chat=forgotten.append,
-      clear_run_status_strict=_record_clear(cleared),
+      finish_run_strict=_record_clear(cleared),
       current_generation=lambda _cid: 7,  # still ours → owns the turn
     )
 
@@ -188,7 +188,7 @@ def test_drain_and_release_releases_when_queue_empty(db):
       db, "cq-drain-empty", run_gen=7, run_token="rt-cq",
       discard_starting=discarded.append,
       forget_chat=forgotten.append,
-      clear_run_status_strict=_record_clear(cleared),
+      finish_run_strict=_record_clear(cleared),
       current_generation=lambda _cid: 7,  # still ours → owns the turn
     )
 
@@ -226,7 +226,7 @@ def test_drain_and_release_no_op_when_not_owning_generation(db):
       db, "cq-not-owner", run_gen=7, run_token="rt-cq",
       discard_starting=discarded.append,
       forget_chat=forgotten.append,
-      clear_run_status_strict=_record_clear(cleared),
+      finish_run_strict=_record_clear(cleared),
       current_generation=lambda _cid: 8,  # Stop bumped past run_gen → stale
     )
 
@@ -273,7 +273,7 @@ def test_drain_serializes_with_concurrent_lock_holder(db):
       db, "cq-serialize", run_gen=7, run_token="rt-cq",
       discard_starting=lambda _cid: None,
       forget_chat=lambda _cid: None,
-      clear_run_status_strict=_noop_clear,
+      finish_run_strict=_noop_clear,
       current_generation=lambda _cid: 7,  # still ours → owns the turn
     )
     observed_order.append("drain-finished")

--- a/backend/tests/test_chat_runs.py
+++ b/backend/tests/test_chat_runs.py
@@ -1,13 +1,12 @@
-"""Durable per-run record tests (persistence redesign 077 Step 3).
+"""Durable per-run state tests.
 
-`chat_runs` is the per-turn successor to the single `Chat.run_status` column:
-one row per turn keyed by run_token, dual-written with run_status (in the same
-actor commit) so the two never diverge, closed terminal on a clean turn end and
-marked interrupted by boot reconciliation when a process died mid-turn.
+`chat_runs` is the sole durable state: one row per turn keyed by run_token,
+closed terminal on a clean turn end and marked interrupted by boot
+reconciliation when a process died mid-turn.
 
 These drive the REAL `get_writer()` actor (the conftest `fresh_db` fixture
 starts one bound to the test DB) and the real `reconcile_interrupted_chats`, so
-they cover the wired dual-write + reconciliation maintenance, not a mock.
+they cover the wired lifecycle + reconciliation maintenance, not a mock.
 """
 
 import asyncio
@@ -16,15 +15,13 @@ from concurrent.futures import Future
 from app import chat as chat_mod
 from app import models
 from app.chat_writer import (
-  AppendPending, Barrier, ClearRunStatus, PromotePending, StartTurn,
+  AppendPending, Barrier, FinishRun, PromotePending, StartTurn,
   RecordRunMetrics, alloc_run_token, get_writer,
 )
 from app.database import SessionLocal
 
 
-def _seed_chat(chat_id, messages=None, pending=None, run_status=None):
-  from datetime import UTC, datetime
-
+def _seed_chat(chat_id, messages=None, pending=None):
   db = SessionLocal()
   try:
     chat = models.Chat(
@@ -33,9 +30,6 @@ def _seed_chat(chat_id, messages=None, pending=None, run_status=None):
       pending_messages=pending if pending is not None else [],
       session_id="sess", provider="claude",
     )
-    if run_status is not None:
-      chat.run_status = run_status
-      chat.run_started_at = datetime.now(UTC)
     db.add(chat)
     db.commit()
   finally:
@@ -71,11 +65,16 @@ def _runs(chat_id):
     db.close()
 
 
-def _run_status(chat_id):
+def _active_status(chat_id):
   db = SessionLocal()
   try:
-    chat = db.query(models.Chat).filter(models.Chat.id == chat_id).first()
-    return chat.run_status
+    from app.run_state import latest_run
+    run = latest_run(db, chat_id)
+    return (
+      run.status
+      if run is not None and run.status in models.NONTERMINAL_RUN_STATUSES
+      else None
+    )
   finally:
     db.close()
 
@@ -92,42 +91,41 @@ def _start(chat_id, run_token):
   )).result(timeout=5)
 
 
-# -- dual-write on start --------------------------------------------------
+# -- durable start --------------------------------------------------------
 def test_start_turn_opens_a_running_run_record():
   _seed_chat("r1")
   _start("r1", "rt-1")
   _drain()
   runs = _runs("r1")
   assert runs == {"rt-1": ("running", False)}
-  assert _run_status("r1") == "running"
+  assert _active_status("r1") == "running"
 
 
 # -- clean close ----------------------------------------------------------
-def test_clear_run_status_completes_the_run_record():
+def test_finish_run_completes_the_run_record():
   _seed_chat("r2")
   _start("r2", "rt-2")
   get_writer().submit(
-    ClearRunStatus(chat_id="r2", run_token="rt-2")
+    FinishRun(chat_id="r2", run_token="rt-2")
   ).result(timeout=5)
   _drain()
   runs = _runs("r2")
   assert runs["rt-2"] == ("completed", True)
-  assert _run_status("r2") is None
+  assert _active_status("r2") is None
 
 
-def test_clear_run_status_preserves_failed_outcome():
-  """An idle marker is not proof of success: a provider-error turn closes
-  durably as failed while clearing the same per-chat recovery marker."""
+def test_finish_run_preserves_failed_outcome():
+  """A provider-error turn closes durably as failed."""
   _seed_chat("r2-failed")
   _start("r2-failed", "rt-2-failed")
-  get_writer().submit(ClearRunStatus(
+  get_writer().submit(FinishRun(
     chat_id="r2-failed",
     run_token="rt-2-failed",
     terminal_status="failed",
   )).result(timeout=5)
   _drain()
   assert _runs("r2-failed")["rt-2-failed"] == ("failed", True)
-  assert _run_status("r2-failed") is None
+  assert _active_status("r2-failed") is None
 
 
 def test_record_run_metrics_updates_exact_run_without_touching_transcript():
@@ -225,8 +223,7 @@ def test_promote_closes_prior_run_and_opens_the_continuation():
   # The prior run is closed completed; the continuation is the live record.
   assert runs["rt-3a"] == ("completed", True)
   assert runs["rt-3b"] == ("running", False)
-  # The per-chat marker stays set across the handoff (the continuation runs).
-  assert _run_status("r3") == "running"
+  assert _active_status("r3") == "running"
 
 
 def test_error_handoff_marks_prior_run_failed_before_continuation():
@@ -247,27 +244,24 @@ def test_error_handoff_marks_prior_run_failed_before_continuation():
   runs = _runs("r3-failed")
   assert runs["rt-3-failed-a"] == ("failed", True)
   assert runs["rt-3-failed-b"] == ("running", False)
-  assert _run_status("r3-failed") == "running"
+  assert _active_status("r3-failed") == "running"
 
 
 # -- identity-keyed dying-run clear ---------------------------------------
-def test_dying_run_clear_closes_own_record_but_keeps_successor_marker():
-  """A fresh turn took the marker; the dying run's late tokened clear must
-  not wipe the successor's run_status, and must not touch the successor's
-  run record — only its own (which the fresh start already superseded)."""
+def test_dying_run_finish_closes_own_record_but_keeps_successor():
+  """A dying run's late finish must not touch its durable successor."""
   _seed_chat("r4")
-  _start("r4", "rt-4a")          # rt-4a owns the marker
+  _start("r4", "rt-4a")
   _start("r4", "rt-4b")          # fresh turn supersedes: rt-4a → interrupted
-  # The dying rt-4a now issues its late clear. owner is rt-4b, so the marker
-  # is the successor's — the clear must no-op on it.
+  # The dying rt-4a now issues its late finish.
   get_writer().submit(
-    ClearRunStatus(chat_id="r4", run_token="rt-4a")
+    FinishRun(chat_id="r4", run_token="rt-4a")
   ).result(timeout=5)
   _drain()
   runs = _runs("r4")
   assert runs["rt-4a"][0] == "interrupted"  # superseded by the fresh start
   assert runs["rt-4b"] == ("running", False)  # successor untouched
-  assert _run_status("r4") == "running", "successor's marker must survive"
+  assert _active_status("r4") == "running"
 
 
 # -- tokenless clear closes everything still running ----------------------
@@ -277,21 +271,18 @@ def test_tokenless_clear_closes_all_running_records():
   # A tokenless clear (Stop with no live handle / reconciliation handoff)
   # takes the chat idle and closes every still-running record.
   get_writer().submit(
-    ClearRunStatus(chat_id="r5", run_token="")
+    FinishRun(chat_id="r5", run_token="")
   ).result(timeout=5)
   _drain()
   assert _runs("r5")["rt-5"] == ("completed", True)
-  assert _run_status("r5") is None
+  assert _active_status("r5") is None
 
 
 # -- reconciliation maintains the record ----------------------------------
 def test_reconcile_marks_interrupted_run_record():
-  """An interrupted turn (run_status running + a running run record, no live
-  registry entry) is reconciled: transcript finalized, marker cleared, and the
-  run record moved to interrupted in the same pass."""
+  """A running durable row with no live registry entry is reconciled."""
   _seed_chat(
     "r6", messages=[{"role": "user", "content": "hi", "ts": 1}],
-    run_status="running",
   )
   _seed_run("rt-6", "r6", status="running")
   db = SessionLocal()
@@ -301,17 +292,13 @@ def test_reconcile_marks_interrupted_run_record():
     db.close()
   assert "r6" in reconciled
   assert _runs("r6")["rt-6"][0] == "interrupted"
-  assert _run_status("r6") is None
+  assert _active_status("r6") is None
 
 
-def test_reconcile_orphan_sweep_closes_record_without_run_status():
-  """A run record left running whose run_status was already cleared (a dropped
-  close, not an interruption) is closed by the non-destructive orphan sweep —
-  the record converges, but the transcript is NOT touched (run_status, the
-  authoritative trigger, said the chat was idle)."""
+def test_reconcile_uses_running_row_as_the_recovery_authority():
+  """A running ChatRun is sufficient durable evidence for transcript repair."""
   _seed_chat(
     "r7", messages=[{"role": "user", "content": "hi", "ts": 1}],
-    run_status=None,
   )
   _seed_run("rt-7", "r7", status="running")
   db = SessionLocal()
@@ -319,14 +306,14 @@ def test_reconcile_orphan_sweep_closes_record_without_run_status():
     reconciled = chat_mod.reconcile_interrupted_chats(db)
   finally:
     db.close()
-  assert "r7" not in reconciled, "no destructive recovery without run_status"
+  assert "r7" in reconciled
   assert _runs("r7")["rt-7"][0] == "interrupted"
-  # Transcript untouched: still the lone user message, no interruption note.
   db = SessionLocal()
   try:
     chat = db.query(models.Chat).filter(models.Chat.id == "r7").first()
-    assert len(chat.messages) == 1
-    assert chat.messages[0]["role"] == "user"
+    assert [message["role"] for message in chat.messages] == [
+      "user", "assistant",
+    ]
   finally:
     db.close()
 
@@ -361,16 +348,16 @@ def test_start_turn_coexists_with_surviving_terminal_run_records():
   _drain()
   runs = _runs("rr")
   assert runs[token] == ("running", False), "fresh turn opened, no PK collision"
-  assert _run_status("rr") == "running"
+  assert _active_status("rr") == "running"
 
 
 # -- orphan sweep must not touch a live chat ------------------------------
 def test_orphan_sweep_skips_a_live_chat():
   """The boot orphan sweep closes a dead chat's lingering running record but
   must NOT touch a chat the registry reports alive (the is_alive `continue`)."""
-  _seed_chat("dead", run_status=None)
+  _seed_chat("dead")
   _seed_run("rt-dead", "dead", status="running")
-  _seed_chat("live", run_status=None)
+  _seed_chat("live")
   _seed_run("rt-live", "live", status="running")
   chat_mod.registry.mark_starting("live")  # live chat is mid-spawn
   db = SessionLocal()

--- a/backend/tests/test_chat_runs_lifecycle.py
+++ b/backend/tests/test_chat_runs_lifecycle.py
@@ -15,16 +15,13 @@ from app.database import SessionLocal
 from app.timeutil import SOFT_DELETE_TTL
 
 
-def _seed_chat(chat_id, *, messages=None, run_status=None, deleted_at=None):
+def _seed_chat(chat_id, *, messages=None, deleted_at=None):
   db = SessionLocal()
   try:
     c = models.Chat(
       id=chat_id, title="t", messages=messages or [], pending_messages=[],
       session_id="sess", provider="claude",
     )
-    if run_status is not None:
-      c.run_status = run_status
-      c.run_started_at = datetime.now(UTC)
     if deleted_at is not None:
       c.deleted_at = deleted_at
     db.add(c)
@@ -61,8 +58,9 @@ def _chat_state(chat_id):
   db = SessionLocal()
   try:
     c = db.query(models.Chat).filter(models.Chat.id == chat_id).first()
+    from app.run_state import has_running_run
     return None if c is None else {
-      "run_status": c.run_status, "deleted_at": c.deleted_at,
+      "running": has_running_run(db, chat_id), "deleted_at": c.deleted_at,
     }
   finally:
     db.close()
@@ -73,19 +71,17 @@ def _drain():
 
 
 def test_soft_delete_closes_the_running_run_record(client, auth):
-  """Deleting a chat that carries a live run marker closes its durable run
-  record + clears run_status, instead of leaving a stale "running" record for
-  the next boot sweep to mop up."""
-  _seed_chat("del-live", run_status="running")
+  """Deleting a chat closes its durable run instead of leaving it for boot."""
+  _seed_chat("del-live")
   _seed_run("rt-del", "del-live", status="running")
   # Not in the registry, so is_chat_running is False — delete skips
-  # stop_chat_for and reaches the tokenless ClearRunStatus directly.
+  # stop_chat_for and reaches the tokenless FinishRun directly.
   r = client.delete("/api/chats/del-live", headers=auth)
   assert r.status_code == 204
   _drain()
   assert _runs("del-live")["rt-del"] != "running", "run record must be closed"
   state = _chat_state("del-live")
-  assert state["run_status"] is None, "run_status must be cleared on delete"
+  assert state["running"] is False
   assert state["deleted_at"] is not None, "chat is soft-deleted"
 
 
@@ -148,22 +144,18 @@ def test_hard_purge_deletes_session_links():
 
 
 def test_orphan_sweep_does_not_mask_a_failed_destructive_reconcile(monkeypatch):
-  """If a chat's destructive reconcile FAILS + rolls back (run_status stays
-  "running"), the non-destructive orphan sweep must NOT flip its run record to
-  "interrupted" — that would diverge the two signals and hide the failure from
-  the next boot's destructive retry."""
+  """A failed destructive reconcile must leave its run open for retry."""
   _seed_chat(
     "recon-fail",
     messages=[
       {"role": "user", "content": "hi", "ts": 1},
       {"role": "assistant", "blocks": [], "ts": 2},
     ],
-    run_status="running",
   )
   _seed_run("rt-rf", "recon-fail", status="running")
 
   # Force the destructive per-chat finalize to raise so its branch rolls back,
-  # leaving run_status=="running" (the failed-reconcile state).
+  # leaving the durable run open.
   def _boom(_blocks):
     raise RuntimeError("simulated finalize failure")
 
@@ -176,9 +168,7 @@ def test_orphan_sweep_does_not_mask_a_failed_destructive_reconcile(monkeypatch):
     db.close()
 
   assert "recon-fail" not in reconciled, "destructive reconcile failed"
-  assert _chat_state("recon-fail")["run_status"] == "running", (
-    "failed reconcile leaves run_status running for next boot"
-  )
+  assert _chat_state("recon-fail")["running"] is True
   assert _runs("recon-fail")["rt-rf"] == "running", (
     "orphan sweep must NOT flip a record whose chat is still authoritatively "
     "running — that would mask the failed reconcile"

--- a/backend/tests/test_chat_stop_delete_safety.py
+++ b/backend/tests/test_chat_stop_delete_safety.py
@@ -110,7 +110,7 @@ def test_stop_chat_for_never_escalates_replaced_handle(monkeypatch):
 
 
 def test_stop_on_orphaned_run_after_restart_succeeds(client, auth, db):
-  """Stop on an orphaned run — run_status stuck 'running' with an EMPTY
+  """Stop on an orphaned running row with an EMPTY
   registry (the exact shape a prior restart leaves: the in-memory registry
   is gone but the durable marker survives) — must succeed gracefully: clear
   the stuck marker + the queue, return success, NOT error or strand the chat.
@@ -126,8 +126,6 @@ def test_stop_on_orphaned_run_after_restart_succeeds(client, auth, db):
     id=chat_id, title="t",
     messages=[{"role": "user", "content": "hi", "ts": 1}],
     pending_messages=[{"role": "user", "content": "queued", "ts": 2}],
-    run_status="running",
-    run_started_at=datetime.now(UTC),
   )
   db.add(c)
   db.add(models.ChatRun(
@@ -146,9 +144,6 @@ def test_stop_on_orphaned_run_after_restart_succeeds(client, auth, db):
   assert r.json()["stopped"] is True, "Stop on an orphan must report success"
 
   db.expire_all()
-  row = db.query(models.Chat).filter(models.Chat.id == chat_id).first()
-  assert row.run_status is None, "the orphaned 'running' marker must be cleared"
-  assert row.run_started_at is None
   run = db.query(models.ChatRun).filter(
     models.ChatRun.id == "rt-orphan-after-restart",
   ).one()

--- a/backend/tests/test_chat_writer_activation.py
+++ b/backend/tests/test_chat_writer_activation.py
@@ -50,10 +50,13 @@ def _load(chat_id):
   db = SessionLocal()
   try:
     chat = db.query(models.Chat).filter(models.Chat.id == chat_id).first()
+    running = db.query(models.ChatRun.id).filter_by(
+      chat_id=chat_id, status="running",
+    ).first() is not None
     return None if chat is None else {
       "messages": list(chat.messages or []),
       "pending_messages": list(chat.pending_messages or []),
-      "run_status": chat.run_status,
+      "running": running,
     }
   finally:
     db.close()
@@ -325,15 +328,17 @@ def test_finalize_failure_via_run_chat_leaves_marker_for_reconciliation(
   # branch).
   db = SessionLocal()
   try:
-    from datetime import UTC, datetime
     from app import auth as auth_mod
     db.add(models.Owner(
       username="o", hashed_password=auth_mod.hash_password("x"),
       provider="claude",
     ))
-    c = db.query(models.Chat).filter(models.Chat.id == "c-fin").one()
-    c.run_status = "running"
-    c.run_started_at = datetime.now(UTC)
+    db.add(models.ChatRun(
+      id="rt-fin",
+      chat_id="c-fin",
+      status="running",
+      provider="claude",
+    ))
     db.commit()
   finally:
     db.close()
@@ -395,7 +400,7 @@ def test_finalize_failure_via_run_chat_leaves_marker_for_reconciliation(
   assert "done" in published
   assert "queued_turn_starting" not in published
   chat_state = _load("c-fin")
-  assert chat_state["run_status"] == "running"  # left for reconciliation
+  assert chat_state["running"] is True  # left for reconciliation
   assert len(chat_state["pending_messages"]) == 1  # not promoted/executed
 
 

--- a/backend/tests/test_chat_writer_contention.py
+++ b/backend/tests/test_chat_writer_contention.py
@@ -30,7 +30,7 @@ from app.chat_writer import (
   CancelPending,
   ChatWriterActor,
   ClearPending,
-  ClearRunStatus,
+  FinishRun,
   Finalize,
   PersistError,
   PersistSessionId,
@@ -93,6 +93,8 @@ def _load_chat(chat_id="c1"):
     chat = db.query(models.Chat).filter(models.Chat.id == chat_id).first()
     if chat is None:
       return None
+    from app.run_state import running_run
+    run = running_run(db, chat_id)
     # Detach plain copies so the caller can inspect after the session closes.
     return {
       "messages": list(chat.messages or []),
@@ -101,8 +103,8 @@ def _load_chat(chat_id="c1"):
       "session_id": chat.session_id,
       "provider": chat.provider,
       "title": chat.title,
-      "run_status": chat.run_status,
-      "run_started_at": chat.run_started_at,
+      "running_status": run.status if run is not None else None,
+      "running_started_at": run.started_at if run is not None else None,
     }
   finally:
     db.close()
@@ -588,8 +590,8 @@ def test_start_turn_is_atomic(actor):
   assert chat["messages"][-1]["cid"].startswith("server-")
   assert chat["title"] == "build me a todo app"
   assert chat["provider"] == "codex"
-  assert chat["run_status"] == "running"
-  assert chat["run_started_at"] is not None
+  assert chat["running_status"] == "running"
+  assert chat["running_started_at"] is not None
 
 
 def test_start_turn_keeps_a_useful_first_message_title_preview(actor):
@@ -637,8 +639,8 @@ def test_start_turn_retry_after_completion_is_idempotent(actor):
   assert result["message"] == original
   chat = _load_chat()
   assert chat["messages"] == [original]
-  assert chat["run_status"] is None
-  assert chat["run_started_at"] is None
+  assert chat["running_status"] is None
+  assert chat["running_started_at"] is None
   assert _load_run("retry-run") is None
 
 
@@ -655,7 +657,7 @@ def test_persist_session_id_updates_chat_without_touching_transcript(actor):
   chat = _load_chat()
   assert chat["session_id"] == "thread-early"
   assert chat["messages"] == [{"role": "user", "content": "hi", "ts": 1}]
-  assert chat["run_status"] is None
+  assert chat["running_status"] is None
 
 
 # -- 8. PromotePending collapses queued follow-ups ------------------------
@@ -675,7 +677,7 @@ def test_promote_pending_collapses_all_followups(actor):
   chat = _load_chat()
   assert [m["content"] for m in chat["messages"][-2:]] == ["first", "second"]
   assert chat["pending_messages"] == []
-  assert chat["run_status"] == "running"
+  assert chat["running_status"] == "running"
 
 
 def test_promote_pending_stops_collapse_at_hidden_boundary(actor):
@@ -1124,7 +1126,7 @@ def test_reconciliation_works_independent_of_actor():
 
   from app.chat import reconcile_interrupted_chats
 
-  # A chat stranded mid-turn: run_status='running', a partial assistant block.
+  # A chat stranded mid-turn with a partial assistant block.
   db = SessionLocal()
   try:
     chat = models.Chat(
@@ -1137,17 +1139,23 @@ def test_reconciliation_works_independent_of_actor():
         ),
       ],
       pending_messages=[{"role": "user", "content": "queued", "ts": 2}],
-      run_status="running",
-      run_started_at=datetime.now(UTC),
     )
     db.add(chat)
+    db.flush()
+    db.add(models.ChatRun(
+      id="rt-stranded",
+      chat_id="stranded",
+      status="running",
+      provider="claude",
+      started_at=datetime.now(UTC),
+    ))
     db.commit()
     reconciled = reconcile_interrupted_chats(db)
   finally:
     db.close()
   assert "stranded" in reconciled
   chat = _load_chat("stranded")
-  assert chat["run_status"] is None
+  assert chat["running_status"] is None
   # The queue is PRESERVED across the restart (bug #2): clearing the marker
   # leaves the markerless-queue state that self-heals on the next send.
   assert [m["content"] for m in chat["pending_messages"]] == ["queued"]
@@ -1196,25 +1204,28 @@ def test_clear_pending_empty_queue_is_noop(actor):
   assert chat["pending_messages"] == []
 
 
-def test_clear_run_status_clears_durable_marker(actor):
-  """ClearRunStatus clears run_status + run_started_at once a turn has ended."""
+def test_finish_run_closes_durable_run(actor):
   from datetime import UTC, datetime
 
   cid = _seed_chat(messages=[{"role": "user", "content": "hi", "ts": 1}])
-  # Mark the run via a throwaway session (the marker the command clears).
+  # Seed the run via a throwaway session.
   db = SessionLocal()
   try:
-    chat = db.query(models.Chat).filter(models.Chat.id == cid).first()
-    chat.run_status = "running"
-    chat.run_started_at = datetime.now(UTC)
+    db.add(models.ChatRun(
+      id="rt1",
+      chat_id=cid,
+      status="running",
+      provider="claude",
+      started_at=datetime.now(UTC),
+    ))
     db.commit()
   finally:
     db.close()
-  result = _await(actor.submit(ClearRunStatus(chat_id="c1", run_token="rt1")))
+  result = _await(actor.submit(FinishRun(chat_id="c1", run_token="rt1")))
   assert result is None
   chat = _load_chat()
-  assert chat["run_status"] is None
-  assert chat["run_started_at"] is None
+  assert chat["running_status"] is None
+  assert chat["running_started_at"] is None
 
 
 def test_stale_wedged_recovery_cannot_clobber_new_run(actor):
@@ -1243,7 +1254,7 @@ def test_stale_wedged_recovery_cannot_clobber_new_run(actor):
 
   assert result is False
   chat = _load_chat()
-  assert chat["run_status"] == "running"
+  assert chat["running_status"] == "running"
   assert [message["content"] for message in chat["messages"]] == ["old", "new"]
   assert _load_run("old-run")["status"] == "interrupted"
   assert _load_run("new-run")["status"] == "running"

--- a/backend/tests/test_chats.py
+++ b/backend/tests/test_chats.py
@@ -61,7 +61,7 @@ def test_delete_response_stays_authoritative_after_cleanup_failure(
   """Post-commit cleanup cannot turn a durable deletion into a false failure."""
   with (
     patch(
-      "app.routes.chats._clear_run_status",
+      "app.routes.chats._finish_run",
       new=AsyncMock(side_effect=RuntimeError("cleanup failed")),
     ),
     patch("app.routes.chats.get_system_broadcast") as mock_get_sb,
@@ -414,7 +414,6 @@ def test_retry_of_durable_message_is_acknowledged_without_new_turn(
   }
   db.refresh(chat)
   assert chat.messages == [stored]
-  assert chat.run_status is None
   assert calls == []
 
 

--- a/backend/tests/test_chats_stream_answer_race.py
+++ b/backend/tests/test_chats_stream_answer_race.py
@@ -265,7 +265,9 @@ def test_answer_recovers_durable_question_without_live_pending(
       assert [m["content"] for m in row.pending_messages] == [
         "queued-visible"
       ]
-      assert row.run_status == "running"
+      assert db.query(models.ChatRun).filter_by(
+        chat_id=chat.id, status="running",
+      ).count() == 1
     finally:
       db.close()
 

--- a/backend/tests/test_chats_stream_steer.py
+++ b/backend/tests/test_chats_stream_steer.py
@@ -1594,9 +1594,6 @@ def test_claude_reserved_row_survives_process_loss_and_sweep(
   _make_claude_chat(chat_id, steer_enabled=True)
   db = SessionLocal()
   try:
-    chat = db.get(models.Chat, chat_id)
-    chat.run_status = "running"
-    chat.run_started_at = datetime.now(UTC)
     db.add(models.ChatRun(
       id=f"run-{chat_id}",
       chat_id=chat_id,

--- a/backend/tests/test_crash_recovery.py
+++ b/backend/tests/test_crash_recovery.py
@@ -1,8 +1,8 @@
 """Startup reconciliation of chats stranded "running" by a crash.
 
 The runner registry that tracks "is this chat running" lives only in
-memory, so an OOM / SIGKILL mid-turn leaves the chat's durable
-``run_status`` column reading "running" with no live registry entry.
+memory, so an OOM / SIGKILL mid-turn leaves a durable ChatRun reading
+"running" with no live registry entry.
 ``chat.reconcile_interrupted_chats`` runs once at lifespan startup and
 resolves those rows so the user doesn't see a forever-spinning turn or
 strand queued messages. These tests pin that contract; they exercise
@@ -18,19 +18,30 @@ from app.runner_registry import RunnerKind, registry
 
 
 def _make_chat(db, chat_id, **kwargs):
+  running = kwargs.pop("running", False)
+  started_at = kwargs.pop("started_at", datetime.now(UTC))
   c = models.Chat(id=chat_id, title="t", messages=kwargs.pop("messages", []))
   for k, v in kwargs.items():
     setattr(c, k, v)
   db.add(c)
+  db.flush()
+  if running:
+    db.add(models.ChatRun(
+      id=f"rt-{chat_id}",
+      chat_id=chat_id,
+      status="running",
+      provider=c.provider,
+      started_at=started_at,
+    ))
   db.commit()
   db.refresh(c)
   return c
 
 
-def test_run_status_column_defaults_none(db, chat):
-  """A freshly created chat is not marked running."""
-  assert chat.run_status is None
-  assert chat.run_started_at is None
+def test_fresh_chat_has_no_durable_run(db, chat):
+  assert db.query(models.ChatRun).filter(
+    models.ChatRun.chat_id == chat.id,
+  ).first() is None
 
 
 def test_startup_reconciles_stale_running_chats(db):
@@ -40,8 +51,8 @@ def test_startup_reconciles_stale_running_chats(db):
   user's queued messages (owner-reported bug)."""
   _make_chat(
     db, "stale",
-    run_status="running",
-    run_started_at=datetime.now(UTC),
+    running=True,
+    started_at=datetime.now(UTC),
     messages=[{"role": "user", "content": "build me a thing"}],
     pending_messages=[{"role": "user", "content": "and another", "ts": 1}],
   )
@@ -51,8 +62,10 @@ def test_startup_reconciles_stale_running_chats(db):
   assert reconciled == ["stale"]
   db.expire_all()
   row = db.query(models.Chat).filter(models.Chat.id == "stale").first()
-  assert row.run_status is None, "stale running marker must be cleared"
-  assert row.run_started_at is None
+  assert db.query(models.ChatRun).filter(
+    models.ChatRun.chat_id == "stale",
+    models.ChatRun.status == "running",
+  ).first() is None
   # The queue is PRESERVED across the restart — clearing only the run
   # marker drops the chat into the markerless-queue state that self-heals
   # on the next user POST's stale-pending drain. It is NOT re-run as part
@@ -79,7 +92,7 @@ def test_reconcile_finalizes_running_tool_block(db):
   is appended to the same assistant message."""
   _make_chat(
     db, "midtool",
-    run_status="running",
+    running=True,
     messages=[
       {"role": "user", "content": "do it"},
       {
@@ -110,7 +123,7 @@ def test_reconcile_merges_bounded_live_snapshot_before_restart_note(db):
   _make_chat(
     db,
     "live-snapshot",
-    run_status="running",
+    running=True,
     messages=[{"role": "user", "content": "keep this", "ts": 1}],
     live_assistant={
       "role": "assistant",
@@ -135,7 +148,7 @@ def test_reconcile_appends_turn_when_no_assistant_message(db):
   the user's own message."""
   _make_chat(
     db, "early",
-    run_status="running",
+    running=True,
     messages=[{"role": "user", "content": "hi"}],
   )
 
@@ -154,7 +167,6 @@ def test_reconcile_leaves_idle_chats_untouched(db):
   mutation, no return entry."""
   _make_chat(
     db, "idle",
-    run_status=None,
     messages=[{"role": "user", "content": "done long ago"}],
     pending_messages=[],
   )
@@ -172,7 +184,7 @@ def test_reconcile_skips_soft_deleted_chats(db):
   out — don't resurrect it into the user's view."""
   _make_chat(
     db, "deleted",
-    run_status="running",
+    running=True,
     deleted_at=datetime.now(UTC),
     messages=[{"role": "user", "content": "x"}],
   )
@@ -196,7 +208,7 @@ def test_reconcile_skips_chat_with_live_registry_entry(db):
 
   _make_chat(
     db, "live",
-    run_status="running",
+    running=True,
     messages=[{"role": "user", "content": "still going"}],
   )
   registry.register(_Handle())
@@ -206,28 +218,35 @@ def test_reconcile_skips_chat_with_live_registry_entry(db):
   assert "live" not in reconciled
   db.expire_all()
   row = db.query(models.Chat).filter(models.Chat.id == "live").first()
-  assert row.run_status == "running", "a live turn's marker must survive"
+  assert db.query(models.ChatRun).filter(
+    models.ChatRun.chat_id == "live",
+    models.ChatRun.status == "running",
+  ).one()
   assert len(row.messages) == 1
 
 
-def test_clear_run_status_clears_the_durable_marker(db, chat):
+def test_finish_run_closes_the_durable_run(db, chat):
   """C2: the SET is folded into the turn's StartTurn / PromotePending
   writer-actor command (covered in the writer-contention suite); the
-  CLEAR routes through the actor's ClearRunStatus. Seed a running marker
+  CLEAR routes through the actor's FinishRun. Seed a running marker
   directly, then assert the actor-routed clear empties it."""
   import asyncio
   from datetime import UTC, datetime
 
-  chat.run_status = "running"
-  chat.run_started_at = datetime.now(UTC)
+  db.add(models.ChatRun(
+    id="rt-finish",
+    chat_id=chat.id,
+    status="running",
+    provider=chat.provider,
+    started_at=datetime.now(UTC),
+  ))
   db.commit()
 
-  asyncio.run(chat_mod._clear_run_status(chat.id))
+  asyncio.run(chat_mod._finish_run(chat.id, "rt-finish"))
 
   db.expire_all()
-  row = db.query(models.Chat).filter(models.Chat.id == chat.id).first()
-  assert row.run_status is None
-  assert row.run_started_at is None
+  run = db.get(models.ChatRun, "rt-finish")
+  assert run.status == "completed"
 
 
 def test_reconcile_assigns_ts_to_interrupted_messages(db):
@@ -236,7 +255,7 @@ def test_reconcile_assigns_ts_to_interrupted_messages(db):
   to preserve an existing ts or assign a fresh one."""
   _make_chat(
     db, "had-assistant",
-    run_status="running",
+    running=True,
     messages=[
       {"role": "user", "content": "hi", "ts": 1},
       {"role": "assistant",
@@ -245,7 +264,7 @@ def test_reconcile_assigns_ts_to_interrupted_messages(db):
   )
   _make_chat(
     db, "no-assistant",
-    run_status="running",
+    running=True,
     messages=[{"role": "user", "content": "hi", "ts": 5}],
   )
 
@@ -264,35 +283,37 @@ def test_reconcile_assigns_ts_to_interrupted_messages(db):
 
 def test_reconcile_warns_on_markerless_pending_queue_but_leaves_it(db, caplog):
   """A Stop's ClearPending committing just before a racing AppendPending leaves
-  a chat run_status=None with a non-empty pending queue. Reconciliation must
+  an idle chat with a non-empty pending queue. Reconciliation must
   NOT consume it — auto-promoting at startup would spawn a post-crash turn, and
   the next POST's stale-pending drain is the repair path — but it WARNS so a
   never-drained accumulating queue is visible rather than silent.
   """
   _make_chat(
     db, "markerless",
-    run_status=None,
     pending_messages=[{"role": "user", "content": "queued", "ts": 1}],
   )
 
   with caplog.at_level("WARNING"):
     reconciled = chat_mod.reconcile_interrupted_chats(db)
 
-  assert "markerless" not in reconciled, "a markerless queue must not be consumed"
+  assert "markerless" not in reconciled, "an idle queue must not be consumed"
   db.expire_all()
   row = db.query(models.Chat).filter(models.Chat.id == "markerless").first()
-  assert row.run_status is None
+  assert db.query(models.ChatRun).filter(
+    models.ChatRun.chat_id == "markerless",
+    models.ChatRun.status == "running",
+  ).first() is None
   assert len(row.pending_messages) == 1, (
     "the queue is left intact for the next-POST stale-pending drain"
   )
   assert any(
-    "markerless pending queue" in r.getMessage() for r in caplog.records
-  ), "an accumulating markerless queue must be surfaced as a warning"
+    "idle pending queue" in r.getMessage() for r in caplog.records
+  ), "an accumulating idle queue must be surfaced as a warning"
 
 
 def test_reconcile_preserved_queue_drains_on_next_post(db):
   """End-to-end of the owner-reported fix: a restart preserves the queue
-  (reconcile leaves pending_messages set + run_status=None), and the
+  (reconcile leaves pending_messages set with no running row), and the
   preserved queue then drains via the same promote path the next user
   POST's stale-pending self-heal runs. This proves the queue isn't just
   retained but is actually recoverable — the user's queued work survives
@@ -303,8 +324,8 @@ def test_reconcile_preserved_queue_drains_on_next_post(db):
 
   _make_chat(
     db, "restart-then-drain",
-    run_status="running",
-    run_started_at=datetime.now(UTC),
+    running=True,
+    started_at=datetime.now(UTC),
     session_id="sess-restart",
     messages=[{"role": "user", "content": "the interrupted turn", "ts": 1}],
     pending_messages=[
@@ -319,7 +340,10 @@ def test_reconcile_preserved_queue_drains_on_next_post(db):
   row = db.query(models.Chat).filter(
     models.Chat.id == "restart-then-drain"
   ).first()
-  assert row.run_status is None
+  assert db.query(models.ChatRun).filter(
+    models.ChatRun.chat_id == "restart-then-drain",
+    models.ChatRun.status == "running",
+  ).first() is None
   assert [m["content"] for m in row.pending_messages] == [
     "queued one", "queued two"
   ], "the queue must survive the restart"

--- a/backend/tests/test_db_migrations.py
+++ b/backend/tests/test_db_migrations.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import pytest
 from sqlalchemy import String, create_engine, inspect, text
 from sqlalchemy.exc import IntegrityError
@@ -172,6 +174,45 @@ def test_run_migrations_adds_park_columns_to_existing_chat_runs(tmp_path):
     "model_context_window",
     "usage_json",
   } <= cols
+
+
+def test_run_migrations_moves_legacy_running_marker_into_chat_runs(tmp_path):
+  """The authority cutover preserves an interrupted live turn before dropping
+  the two legacy Chat columns, and is safe to resume after a partial boot."""
+  eng = create_engine(f"sqlite:///{tmp_path / 'legacy-run-marker.db'}")
+  models.Base.metadata.create_all(eng)
+  started = datetime(2026, 7, 30, 23, 45, 12)
+  with Session(eng) as session:
+    session.add(models.Chat(
+      id="legacy-running",
+      title="Interrupted turn",
+      provider="codex",
+      messages=[{"role": "user", "content": "keep this turn"}],
+    ))
+    session.commit()
+  with eng.connect() as conn:
+    conn.execute(text("ALTER TABLE chats ADD COLUMN run_status VARCHAR(16)"))
+    conn.execute(text("ALTER TABLE chats ADD COLUMN run_started_at DATETIME"))
+    conn.execute(text(
+      "UPDATE chats SET run_status='running', "
+      "run_started_at=:started WHERE id='legacy-running'"
+    ), {"started": started})
+    conn.commit()
+
+  run_migrations(eng)
+  run_migrations(eng)
+
+  chat_columns = {c["name"] for c in inspect(eng).get_columns("chats")}
+  assert "run_status" not in chat_columns
+  assert "run_started_at" not in chat_columns
+  with Session(eng) as session:
+    runs = session.query(models.ChatRun).filter_by(
+      chat_id="legacy-running",
+    ).all()
+  assert len(runs) == 1
+  assert runs[0].status == "running"
+  assert runs[0].provider == "codex"
+  assert runs[0].started_at == started
 
 
 def test_agent_lifecycle_width_migration_is_postgres_only_and_idempotent():

--- a/backend/tests/test_drain_for_restart.py
+++ b/backend/tests/test_drain_for_restart.py
@@ -45,7 +45,7 @@ def _drain_writer():
   get_writer().submit(Barrier()).result(timeout=5)
 
 
-def _seed(chat_id: str, *, pending=None, messages=None, run_status="running"):
+def _seed(chat_id: str, *, pending=None, messages=None):
   db = SessionLocal()
   try:
     started = datetime.now(UTC).replace(tzinfo=None) - timedelta(seconds=30)
@@ -56,17 +56,14 @@ def _seed(chat_id: str, *, pending=None, messages=None, run_status="running"):
       pending_messages=pending or [],
       session_id="sess",
       provider="claude",
-      run_status=run_status,
-      run_started_at=started if run_status else None,
     ))
-    if run_status == "running":
-      db.add(models.ChatRun(
-        id=f"rt-{chat_id}",
-        chat_id=chat_id,
-        status="running",
-        provider="claude",
-        started_at=started,
-      ))
+    db.add(models.ChatRun(
+      id=f"rt-{chat_id}",
+      chat_id=chat_id,
+      status="running",
+      provider="claude",
+      started_at=started,
+    ))
     db.commit()
   finally:
     db.close()
@@ -76,10 +73,11 @@ def _chat(chat_id: str):
   db = SessionLocal()
   try:
     row = db.query(models.Chat).filter(models.Chat.id == chat_id).first()
+    from app.run_state import has_running_run
     return {
       "messages": materialized_messages(row),
       "pending": list(row.pending_messages or []),
-      "run_status": row.run_status,
+      "running_status": "running" if has_running_run(db, chat_id) else None,
     }
   finally:
     db.close()
@@ -212,7 +210,7 @@ def test_drain_finalizes_running_tool_before_clearing_reconcile_marker():
     if block.get("type") == "tool"
   )
   assert tool["status"] == "done"
-  assert state["run_status"] is None
+  assert state["running_status"] is None
 
 
 # -- (a) DrainForRestart preserves the queue; stop_chat_for clears it ---------
@@ -227,7 +225,7 @@ def test_drain_preserves_pending_while_stop_clears_it():
   _drain_writer()
   drained_state = _chat("drain-keep")
   assert drained_state["pending"] == queued
-  assert drained_state["run_status"] is None
+  assert drained_state["running_status"] is None
   assert _run("drain-keep")["status"] == "parked"
   assert _run("drain-keep")["park_reason"] == "restart"
 
@@ -284,7 +282,7 @@ def test_drain_park_failure_leaves_authenticated_marker_for_boot_recovery(
   }]
   _drain_writer()
 
-  assert _chat(cid)["run_status"] == "running"
+  assert _chat(cid)["running_status"] == "running"
   assert _run(cid)["status"] == "running"
   assert _run(cid)["restart_nonce"] == "restart-nonce-drain"
 
@@ -308,7 +306,7 @@ def test_drain_stop_timeout_keeps_authenticated_restart_intent():
   _drain_writer()
 
   assert handle.stop_calls == 1
-  assert _chat(cid)["run_status"] == "running"
+  assert _chat(cid)["running_status"] == "running"
   run = _run(cid)
   assert run["status"] == "running"
   assert run["restart_nonce"] == "restart-nonce-drain"
@@ -364,7 +362,7 @@ def test_drain_terminal_snapshot_failure_keeps_authenticated_restart_intent(
   }]
   _drain_writer()
 
-  assert _chat(cid)["run_status"] == "running"
+  assert _chat(cid)["running_status"] == "running"
   run = _run(cid)
   assert run["status"] == "running"
   assert run["restart_nonce"] == "restart-nonce-drain"
@@ -382,7 +380,7 @@ def test_drain_without_exact_run_token_stays_manual():
   assert _run_drain() == []
   _drain_writer()
 
-  assert _chat(cid)["run_status"] == "running"
+  assert _chat(cid)["running_status"] == "running"
   assert _run(cid)["status"] == "running"
 
 
@@ -411,7 +409,7 @@ def test_authenticated_restart_fallback_becomes_due_park():
 
   assert result.manual == []
   assert result.restart_parks == [cid]
-  assert _chat(cid)["run_status"] is None
+  assert _chat(cid)["running_status"] is None
   run = _run(cid)
   assert run["status"] == "parked"
   assert run["park_reason"] == "restart"
@@ -546,7 +544,7 @@ def test_reconcile_marks_paused_note_resumable_without_double_note():
 
   assert cid in reconciled
   state = _chat(cid)
-  assert state["run_status"] is None
+  assert state["running_status"] is None
   assert _run(cid)["status"] == "interrupted"
   blocks = state["messages"][-1]["blocks"]
   errors = [b for b in blocks if b.get("type") == "error"]
@@ -781,15 +779,15 @@ def test_stop_during_drain_preserves_pending():
 def test_wedged_sweep_stands_down_while_draining():
   """The wedged-marker sweep must not clear a marker the drain deliberately
   left set (design §2.3 — the sweeps stand down during a drain)."""
-  _seed("sweep-drain", run_status="running")
+  _seed("sweep-drain")
   chat_mod.draining = True
   try:
     db = SessionLocal()
     try:
-      swept = asyncio.run(chat_mod.sweep_wedged_run_markers(db))
+      swept = asyncio.run(chat_mod.sweep_wedged_runs(db))
     finally:
       db.close()
   finally:
     chat_mod.draining = False
   assert swept == []
-  assert _chat("sweep-drain")["run_status"] == "running"
+  assert _chat("sweep-drain")["running_status"] == "running"

--- a/backend/tests/test_idle_pending_sweep.py
+++ b/backend/tests/test_idle_pending_sweep.py
@@ -16,12 +16,12 @@ def _seed_pending(
   chat_id: str,
   *,
   age_secs: float,
-  run_status: str | None = None,
+  running: bool = False,
 ) -> None:
   now_ms = int(time.time() * 1000)
   db = SessionLocal()
   try:
-    db.add(models.Chat(
+    chat = models.Chat(
       id=chat_id,
       title="pending",
       provider="claude",
@@ -32,9 +32,17 @@ def _seed_pending(
         "ts": now_ms - int(age_secs * 1000),
         "cid": f"cid-{chat_id}",
       }],
-      run_status=run_status,
-      run_started_at=(datetime.now(UTC) if run_status else None),
-    ))
+    )
+    db.add(chat)
+    db.flush()
+    if running:
+      db.add(models.ChatRun(
+        id=f"rt-{chat_id}",
+        chat_id=chat_id,
+        status="running",
+        provider="claude",
+        started_at=datetime.now(UTC),
+      ))
     db.commit()
   finally:
     db.close()
@@ -60,8 +68,14 @@ def _read(chat_id: str):
   db = SessionLocal()
   try:
     chat = db.get(models.Chat, chat_id)
+    from app.run_state import latest_run
+    run = latest_run(db, chat_id)
     return (
-      chat.run_status,
+      (
+        run.status
+        if run is not None and run.status in models.NONTERMINAL_RUN_STATUSES
+        else None
+      ),
       list(chat.messages or []),
       list(chat.pending_messages or []),
     )
@@ -96,7 +110,7 @@ def test_idle_pending_sweep_claims_and_starts_old_queue(monkeypatch):
 
 def test_idle_pending_sweep_leaves_running_chat_untouched(monkeypatch):
   chat_id = "running-old-pending"
-  _seed_pending(chat_id, age_secs=180, run_status="running")
+  _seed_pending(chat_id, age_secs=180, running=True)
 
   swept, scheduled = _sweep(monkeypatch)
 
@@ -133,7 +147,6 @@ def test_idle_pending_sweep_candidate_query_does_not_load_transcripts(
       provider="codex",
       messages=[{"role": "assistant", "content": "x" * 1_000_000}],
       pending_messages=[],
-      run_status=None,
     ))
     db.commit()
   finally:
@@ -142,7 +155,7 @@ def test_idle_pending_sweep_candidate_query_does_not_load_transcripts(
   statements = []
 
   def capture(_conn, _cursor, statement, _parameters, _context, _many):
-    if "FROM chats" in statement and "chats.run_status IS NULL" in statement:
+    if "FROM chats" in statement and "chats.pending_messages" in statement:
       statements.append(statement)
 
   event.listen(engine, "before_cursor_execute", capture)
@@ -183,8 +196,7 @@ def _park_latest_run(chat_id: str, *, minutes_out: float) -> None:
 def test_idle_pending_sweep_leaves_limit_parked_queue_alone(monkeypatch):
   """LIMIT_PARKED preserves pending so it is NOT refired into the limit.
 
-  The park row outlives run_status (ParkRun clears the marker), so a
-  parked chat looks idle to the run_status filter. Draining it would
+  A parked chat has no running row. Draining it would
   consume the owner's queued work into a doomed turn and bypass the
   auto-resume opt-in that sweep_reset_parks enforces.
   """
@@ -196,8 +208,8 @@ def test_idle_pending_sweep_leaves_limit_parked_queue_alone(monkeypatch):
 
   assert swept == []
   assert scheduled == []
-  run_status, _messages, pending = _read(chat_id)
-  assert run_status is None
+  active_status, _messages, pending = _read(chat_id)
+  assert active_status == "parked"
   assert [m["content"] for m in pending] == ["recover me"]
 
 
@@ -215,7 +227,7 @@ def test_idle_pending_sweep_skips_past_park_until_user_or_optin(monkeypatch):
 
   assert swept == []
   assert scheduled == []
-  _run_status, _messages, pending = _read(chat_id)
+  _active_status, _messages, pending = _read(chat_id)
   assert [m["content"] for m in pending] == ["recover me"]
 
 
@@ -229,5 +241,5 @@ def test_idle_pending_sweep_stands_down_while_draining(monkeypatch):
 
   assert swept == []
   assert scheduled == []
-  _run_status, _messages, pending = _read(chat_id)
+  _active_status, _messages, pending = _read(chat_id)
   assert [m["content"] for m in pending] == ["recover me"]

--- a/backend/tests/test_limit_park.py
+++ b/backend/tests/test_limit_park.py
@@ -6,7 +6,7 @@ Locks in the six contracts of the limit-park feature:
       30-minute fallback, clamped, and it NEVER raises.
   (b) A limit kill PARKS the run row (parked_until + park_reason) and
       clears the per-chat marker; ownership is identity-keyed like
-      ClearRunStatus (a superseded run never parks onto a fresh marker).
+      FinishRun (a superseded run never parks onto a fresh marker).
   (c) Latest-run-wins: the park probe + stall exemption honor a park only
       while the chat's newest run row is the parked one, and a fresh
       StartTurn closes a stale park (no orphaned notify/auto-resume).
@@ -32,7 +32,7 @@ from app import chat as chat_mod
 from app import models
 from app.chat_writer import (
   Barrier,
-  ClearRunStatus,
+  FinishRun,
   ParkRun,
   PrepareAutoResume,
   PromotePending,
@@ -73,7 +73,7 @@ def _drain_writer():
 
 
 def _seed_chat(
-  chat_id: str, *, pending=None, run_status=None, deleted=False,
+  chat_id: str, *, pending=None, deleted=False,
   auto_resume=False, auto_restart=True, messages=None,
 ):
   db = SessionLocal()
@@ -91,10 +91,6 @@ def _seed_chat(
       provider="claude",
       auto_resume_on_limit=auto_resume,
       auto_resume_on_restart=auto_restart,
-      run_status=run_status,
-      run_started_at=(
-        datetime.now(UTC).replace(tzinfo=None) if run_status else None
-      ),
       deleted_at=(
         datetime.now(UTC).replace(tzinfo=None) if deleted else None
       ),
@@ -150,8 +146,9 @@ def _chat_row(chat_id: str):
   db = SessionLocal()
   try:
     row = db.query(models.Chat).filter(models.Chat.id == chat_id).first()
+    from app.run_state import has_running_run
     return {
-      "run_status": row.run_status,
+      "running_status": "running" if has_running_run(db, chat_id) else None,
       "messages": materialized_messages(row),
       "pending": list(row.pending_messages or []),
     }
@@ -280,7 +277,7 @@ def test_limit_exit_bare_429_synthesizes_the_card_block():
 
 def test_park_run_parks_row_and_clears_marker():
   cid = "park-basic"
-  _seed_chat(cid, run_status="running")
+  _seed_chat(cid)
   _seed_run(cid, "rt-park-basic")
   until = datetime(2026, 7, 11, 1, 40)
 
@@ -295,13 +292,13 @@ def test_park_run_parks_row_and_clears_marker():
   assert row["park_reason"] == "usage_limit"
   assert row["ended_at"] is not None
   # The per-chat marker is cleared: the turn is over, the chat is not busy.
-  assert _chat_row(cid)["run_status"] is None
+  assert _chat_row(cid)["running_status"] is None
 
 
 def test_restart_park_carries_one_shot_intent_nonce():
   cid = "park-restart-nonce"
   token = "rt-park-restart-nonce"
-  _seed_chat(cid, run_status="running")
+  _seed_chat(cid)
   _seed_run(cid, token)
 
   get_writer().submit(ParkRun(
@@ -350,10 +347,9 @@ def test_restart_park_idempotency_requires_the_same_nonce():
   assert _run_row(token)["restart_nonce"] == "nonce-first-1234"
 
 
-def test_park_run_missing_exact_row_keeps_generic_marker():
-  """Losing the exact identity must fail safe into manual crash recovery."""
+def test_park_run_missing_exact_row_is_a_noop():
   cid = "park-missing-exact-row"
-  _seed_chat(cid, run_status="running")
+  _seed_chat(cid)
 
   parked = get_writer().submit(ParkRun(
     chat_id=cid, run_token="rt-does-not-exist",
@@ -361,13 +357,13 @@ def test_park_run_missing_exact_row_keeps_generic_marker():
   )).result(timeout=5)
 
   assert parked is False
-  assert _chat_row(cid)["run_status"] == "running"
+  assert _chat_row(cid)["running_status"] is None
 
 
 def test_park_run_superseded_owner_completes_without_parking():
   """A dying run whose marker a fresh turn took must NOT park (a stale park
   would fire a spurious notify) — its own row closes 'completed' and the
-  fresh turn's marker survives, mirroring ClearRunStatus ownership."""
+  fresh turn's marker survives, mirroring FinishRun ownership."""
   cid = "park-superseded"
   _seed_chat(cid)
   # A fresh StartTurn claims the marker under rt-new (records ownership).
@@ -387,7 +383,7 @@ def test_park_run_superseded_owner_completes_without_parking():
   assert _run_row("rt-old")["status"] == "completed"
   assert _run_row("rt-old")["parked_until"] is None
   assert _run_row("rt-new")["status"] == "running"
-  assert _chat_row(cid)["run_status"] == "running"
+  assert _chat_row(cid)["running_status"] == "running"
 
 
 def test_resolve_park_is_idempotent():
@@ -482,10 +478,10 @@ def test_auto_resume_rollback_cannot_unwind_a_newer_successor():
   assert rolled_back is False
   assert _run_row(successor_token)["status"] == "running"
   state = _chat_row(cid)
-  assert state["run_status"] == "running"
+  assert state["running_status"] == "running"
   assert state["messages"][-1]["cid"] == "new-owner-turn"
 
-  get_writer().submit(ClearRunStatus(
+  get_writer().submit(FinishRun(
     chat_id=cid, run_token=successor_token,
   )).result(timeout=5)
 
@@ -547,16 +543,17 @@ def test_fresh_start_turn_closes_stale_park():
     db.close()
 
 
-def test_park_run_strict_tokenless_falls_back_to_marker_clear():
+def test_park_run_strict_tokenless_finishes_all_running_rows():
   cid = "park-tokenless"
-  _seed_chat(cid, run_status="running")
+  _seed_chat(cid)
+  _seed_run(cid, "rt-park-tokenless")
 
   asyncio.run(chat_mod._park_run_strict(
     cid, "", datetime(2026, 7, 11, 1, 40), "rate_limit",
   ))
   _drain_writer()
 
-  assert _chat_row(cid)["run_status"] is None
+  assert _chat_row(cid)["running_status"] is None
 
 
 # -- (d) the reset sweep -------------------------------------------------------
@@ -737,7 +734,7 @@ def test_sweep_auto_resume_on_starts_one_staggered_continue(
     assert promoted["_messages"][-1]["continuation_reason"] == "usage_limit"
     state = _chat_row("sweep-auto")
     assert state["pending"] == []
-    assert state["run_status"] == "running"  # PromotePending set the marker
+    assert state["running_status"] == "running"  # PromotePending set the marker
   finally:
     # _schedule_continuation was stubbed, so release the claim it would have
     # handed to the spawned turn.
@@ -1188,7 +1185,7 @@ def test_restart_spawn_failure_retires_one_shot_authorization(
   assert row["status"] == "interrupted"
   assert row["restart_nonce"] is None
   state = _chat_row(cid)
-  assert state["run_status"] is None
+  assert state["running_status"] is None
   assert state["pending"][-1]["cid"] == f"restart-resume-{token}"
   assert _run_sweep() == []
   db = SessionLocal()
@@ -1501,7 +1498,7 @@ def test_auto_resume_spawn_failure_rolls_back_and_retries_once(
   ]
   assert _run_row(park_token)["status"] == "resume_pending"
   state = _chat_row(cid)
-  assert state["run_status"] is None
+  assert state["running_status"] is None
   assert [m.get("cid") for m in state["pending"]] == [
     "queued-before-limit", f"limit-resume-{park_token}",
   ]
@@ -1557,7 +1554,7 @@ def test_post_promote_process_death_recovers_as_manual_resume_boundary():
   finally:
     db.close()
   state = _chat_row(cid)
-  assert state["run_status"] is None
+  assert state["running_status"] is None
   assert state["pending"] == []
   assert _run_row(park_token)["status"] == "completed"
   assert _run_row(promoted_token)["status"] == "interrupted"
@@ -1566,7 +1563,7 @@ def test_post_promote_process_death_recovers_as_manual_resume_boundary():
 
   # reconcile normally runs before the writer starts. This test drives it
   # against the fixture's live actor, so clear its in-memory owner bookkeeping.
-  get_writer().submit(ClearRunStatus(
+  get_writer().submit(FinishRun(
     chat_id=cid, run_token="",
   )).result(timeout=5)
 
@@ -1719,7 +1716,7 @@ def test_auto_resume_rechecks_app_work_inside_queue_handoff():
   ) is False
   state = _chat_row(cid)
   assert state["pending"] == [app_msg]
-  assert state["run_status"] is None
+  assert state["running_status"] is None
   assert not chat_mod.is_chat_running(cid)
 
 
@@ -1853,7 +1850,7 @@ def _limit_complete_turn(cid, *, parked_until, monkeypatch=None,
   """Drive _complete_turn's limit branch with a real bc + sink + seeded run."""
   from app.broadcast import create_broadcast
 
-  _seed_chat(cid, run_status="running")
+  _seed_chat(cid)
   _seed_run(cid, f"rt-{cid}")
   bc = create_broadcast(cid)
   sink = chat_mod._ChatEventSink(bc, cid, run_token=f"rt-{cid}")
@@ -1917,7 +1914,7 @@ def test_park_false_result_uses_same_manual_recovery_fallback(monkeypatch):
   )
 
   assert disposition.value == "failed_leave_marker"
-  assert _chat_row(cid)["run_status"] == "running"
+  assert _chat_row(cid)["running_status"] == "running"
   tail = _chat_row(cid)["messages"][-1]["blocks"][-1]
   assert "could not be scheduled" in tail["message"]
   assert not tail.get("pause")

--- a/backend/tests/test_liveness_watchdog.py
+++ b/backend/tests/test_liveness_watchdog.py
@@ -45,8 +45,6 @@ def _seed(chat_id: str, *, pending=None, age_secs=30):
       pending_messages=pending or [],
       session_id="sess",
       provider="claude",
-      run_status="running",
-      run_started_at=started,
     ))
     db.add(models.ChatRun(
       id=f"rt-{chat_id}",
@@ -75,7 +73,6 @@ def _chat(chat_id: str):
     return {
       "messages": materialized_messages(row),
       "pending": list(row.pending_messages or []),
-      "run_status": row.run_status,
     }
   finally:
     db.close()

--- a/backend/tests/test_migrate_chat_identity.py
+++ b/backend/tests/test_migrate_chat_identity.py
@@ -6,7 +6,7 @@ round-trip verification + rollback-on-failure contract, and the
 `scripts/migrate_chat_identity` orchestration.
 """
 import pytest
-from sqlalchemy import select, update
+from sqlalchemy import exists, select, update
 
 from app import models
 from app.chat_writer import (
@@ -36,13 +36,20 @@ def _fat_tool_msg(ts=100, full=None, **blk_extra) -> dict:
     return {"role": "assistant", "ts": ts, "content": "", "blocks": [blk]}
 
 
-def _make_chat(db, cid, messages, pending=None, run_status=None,
+def _make_chat(db, cid, messages, pending=None, running=False,
                deleted_at=None):
     chat = models.Chat(
         id=cid, title="t", messages=messages, pending_messages=pending or [],
-        run_status=run_status, deleted_at=deleted_at,
+        deleted_at=deleted_at,
     )
     db.add(chat)
+    if running:
+        db.add(models.ChatRun(
+            id=f"run-{cid}",
+            chat_id=cid,
+            status="running",
+            provider="claude",
+        ))
     db.commit()
     return chat
 
@@ -298,7 +305,7 @@ def test_migrate_skips_active_chat(db):
     _make_chat(db, "c5", [
         {"role": "user", "ts": 1},
         _fat_tool_msg(ts=2),
-    ], run_status="running")
+    ], running=True)
     res = _migrate("c5")
     assert res["status"] == "skipped_active"
     reread = _reread(db, "c5")
@@ -324,7 +331,7 @@ def test_migrate_includes_soft_deleted_chat(db):
 
 
 # -- optimistic CAS guard (the cross-process safety mechanism) ------------
-def test_cas_guard_run_status_and_updated_at(db):
+def test_cas_guard_nonterminal_run_and_updated_at(db):
     from datetime import timedelta
     _make_chat(db, "cx", [], [])
     snap = db.execute(
@@ -335,8 +342,16 @@ def test_cas_guard_run_status_and_updated_at(db):
     # exact snapshot + idle -> applies (rowcount 1)
     r1 = db.execute(
         update(models.Chat)
-        .where(models.Chat.id == "cx", models.Chat.run_status.is_(None),
-               models.Chat.updated_at == snap)
+        .where(
+            models.Chat.id == "cx",
+            models.Chat.updated_at == snap,
+            ~exists().where(
+                models.ChatRun.chat_id == models.Chat.id,
+                models.ChatRun.status.in_(
+                    ("running", "parked", "resume_pending")
+                ),
+            ),
+        )
         .values(messages=[{"a": 1}])
     )
     assert r1.rowcount == 1
@@ -352,17 +367,29 @@ def test_cas_guard_run_status_and_updated_at(db):
     assert r2.rowcount == 0
     db.rollback()
 
-    # run_status set (a live turn started) -> no-op even with fresh updated_at
-    db.execute(update(models.Chat).where(models.Chat.id == "cx")
-               .values(run_status="running"))
+    # A live run started -> no-op even with a fresh updated_at snapshot.
+    db.add(models.ChatRun(
+        id="run-cx",
+        chat_id="cx",
+        status="running",
+        provider="claude",
+    ))
     db.commit()
     snap2 = db.execute(
         select(models.Chat.updated_at).where(models.Chat.id == "cx")
     ).scalar_one()
     r3 = db.execute(
         update(models.Chat)
-        .where(models.Chat.id == "cx", models.Chat.run_status.is_(None),
-               models.Chat.updated_at == snap2)
+        .where(
+            models.Chat.id == "cx",
+            models.Chat.updated_at == snap2,
+            ~exists().where(
+                models.ChatRun.chat_id == models.Chat.id,
+                models.ChatRun.status.in_(
+                    ("running", "parked", "resume_pending")
+                ),
+            ),
+        )
         .values(messages=[{"c": 3}])
     )
     assert r3.rowcount == 0

--- a/backend/tests/test_terminal_completion.py
+++ b/backend/tests/test_terminal_completion.py
@@ -63,8 +63,8 @@ def _seed_owner_and_creds():
   }), encoding="utf-8")
 
 
-def _seed_chat(chat_id, messages=None, pending=None, run_status=None,
-               session_id="sess"):
+def _seed_chat(chat_id, messages=None, pending=None, running=None,
+               session_id="sess", run_token=None):
   from datetime import UTC, datetime
 
   db = SessionLocal()
@@ -75,10 +75,19 @@ def _seed_chat(chat_id, messages=None, pending=None, run_status=None,
       pending_messages=pending if pending is not None else [],
       session_id=session_id, provider="claude",
     )
-    if run_status is not None:
-      chat.run_status = run_status
-      chat.run_started_at = datetime.now(UTC)
     db.add(chat)
+    if running:
+      run_id = run_token or (
+        f"rt-{chat_id[1:]}" if chat_id.startswith("t")
+        else f"rt-{chat_id}"
+      )
+      db.add(models.ChatRun(
+        id=run_id,
+        chat_id=chat_id,
+        status="running",
+        provider="claude",
+        started_at=datetime.now(UTC),
+      ))
     db.commit()
   finally:
     db.close()
@@ -89,10 +98,14 @@ def _load(chat_id):
   db = SessionLocal()
   try:
     chat = db.query(models.Chat).filter(models.Chat.id == chat_id).first()
+    running = db.query(models.ChatRun.id).filter(
+      models.ChatRun.chat_id == chat_id,
+      models.ChatRun.status == "running",
+    ).first() is not None
     return None if chat is None else {
       "messages": list(chat.messages or []),
       "pending_messages": list(chat.pending_messages or []),
-      "run_status": chat.run_status,
+      "running": running,
     }
   finally:
     db.close()
@@ -103,13 +116,20 @@ def _seed_run(run_id, chat_id, *, provider="claude"):
 
   db = SessionLocal()
   try:
-    db.add(models.ChatRun(
-      id=run_id,
-      chat_id=chat_id,
-      status="running",
-      provider=provider,
-      started_at=datetime.now(UTC),
-    ))
+    run = db.query(models.ChatRun).filter(models.ChatRun.id == run_id).first()
+    if run is None:
+      db.query(models.ChatRun).filter(
+        models.ChatRun.chat_id == chat_id,
+        models.ChatRun.status == "running",
+      ).delete(synchronize_session=False)
+      run = models.ChatRun(
+        id=run_id,
+        chat_id=chat_id,
+        started_at=datetime.now(UTC),
+      )
+      db.add(run)
+    run.status = "running"
+    run.provider = provider
     db.commit()
   finally:
     db.close()
@@ -181,7 +201,7 @@ def test_empty_queue_terminal_clears_marker(monkeypatch):
   _seed_owner_and_creds()
   _seed_chat(
     "t1", messages=[{"role": "user", "content": "hi", "ts": 1}],
-    pending=[], run_status="running",
+    pending=[], running="running",
   )
   _patch_claude_runner(monkeypatch)
 
@@ -192,7 +212,7 @@ def test_empty_queue_terminal_clears_marker(monkeypatch):
   _drain_actor()
 
   state = _load("t1")
-  assert state["run_status"] is None, "empty-queue terminal must clear marker"
+  assert state["running"] is False, "empty-queue terminal must clear marker"
   assert "queued_turn_starting" not in published
   assert "done" in published
   # The chat was forgotten (generation dropped) after the clear.
@@ -210,7 +230,7 @@ def test_provider_error_clears_marker_but_records_failed_run(monkeypatch):
   _seed_owner_and_creds()
   _seed_chat(
     "t1-failed", messages=[{"role": "user", "content": "hi", "ts": 1}],
-    pending=[], run_status="running",
+    pending=[], running="running",
   )
   _seed_run("rt-1-failed", "t1-failed")
 
@@ -235,7 +255,7 @@ def test_provider_error_clears_marker_but_records_failed_run(monkeypatch):
   )
   _drain_actor()
 
-  assert _load("t1-failed")["run_status"] is None
+  assert _load("t1-failed")["running"] is False
   assert _run_outcomes("t1-failed") == {"rt-1-failed": "failed"}
   assert "error" in published
   assert "done" in published
@@ -249,7 +269,7 @@ def test_provider_error_handoff_keeps_failed_predecessor(monkeypatch):
     "t1-failed-queued",
     messages=[{"role": "user", "content": "hi", "ts": 1}],
     pending=[{"role": "user", "content": "next", "ts": 2}],
-    run_status="running",
+    running="running",
   )
   _seed_run("rt-1-failed-queued", "t1-failed-queued")
 
@@ -279,7 +299,7 @@ def test_provider_error_handoff_keeps_failed_predecessor(monkeypatch):
     "rt-1-failed-queued": "failed",
     successor_token: "running",
   }
-  assert _load("t1-failed-queued")["run_status"] == "running"
+  assert _load("t1-failed-queued")["running"] is True
 
 
 @pytest.mark.parametrize("queued", [False, True], ids=["settled", "handoff"])
@@ -296,7 +316,7 @@ def test_empty_provider_result_persists_retryable_failure(monkeypatch, queued):
     cid,
     messages=[{"role": "user", "content": "hi", "ts": 1}],
     pending=pending,
-    run_status="running",
+    running="running",
   )
   _seed_run(run_token, cid)
   _patch_claude_runner(monkeypatch, text=None)
@@ -332,11 +352,11 @@ def test_empty_provider_result_persists_retryable_failure(monkeypatch, queued):
   if queued:
     assert len(scheduled) == 1
     assert outcomes[scheduled[0]["run_token"]] == "running"
-    assert state["run_status"] == "running"
+    assert state["running"] is True
   else:
     assert scheduled == []
     assert outcomes == {run_token: "failed"}
-    assert state["run_status"] is None
+    assert state["running"] is False
 
 
 # -- 2. terminal write failure LEAVES the marker (+ reconcile repairs) ---
@@ -351,7 +371,7 @@ def test_terminal_finalize_failure_leaves_marker_then_reconcile_repairs(
   _seed_chat(
     "t2", messages=[{"role": "user", "content": "hi", "ts": 1}],
     pending=[{"role": "user", "content": "queued", "ts": 3}],
-    run_status="running",
+    running="running",
   )
   _patch_claude_runner(monkeypatch)
 
@@ -370,7 +390,7 @@ def test_terminal_finalize_failure_leaves_marker_then_reconcile_repairs(
   state = _load("t2")
   assert "error" in published
   assert "queued_turn_starting" not in published
-  assert state["run_status"] == "running", "failed terminal must LEAVE marker"
+  assert state["running"] is True, "failed terminal must LEAVE marker"
   assert len(state["pending_messages"]) == 1, "queue not consumed"
 
   # Reconcile-after-restart: the registry is empty (the run finished), so
@@ -383,7 +403,7 @@ def test_terminal_finalize_failure_leaves_marker_then_reconcile_repairs(
     db.close()
   assert "t2" in reconciled
   state = _load("t2")
-  assert state["run_status"] is None, "reconcile must clear the marker"
+  assert state["running"] is False, "reconcile must clear the marker"
   assert [m["content"] for m in state["pending_messages"]] == ["queued"], (
     "reconcile PRESERVES the queue (bug #2); it drains on the next send"
   )
@@ -406,7 +426,7 @@ def test_promote_ack_timeout_leaves_marker_then_reconcile_resolves(
     "t3",
     messages=[{"role": "user", "content": "hi", "ts": 1}],
     pending=[{"role": "user", "content": "queued", "ts": 3}],
-    run_status="running",
+    running="running",
   )
   # No streamed text → finalize() is a no-op, so the turn reaches the drain
   # (the promote) which is what we're latching.
@@ -451,7 +471,7 @@ def test_promote_ack_timeout_leaves_marker_then_reconcile_resolves(
   assert "queued_turn_starting" not in published
   assert "error" in published
   state = _load("t3")
-  assert state["run_status"] == "running", "timed-out promote must LEAVE marker"
+  assert state["running"] is True, "timed-out promote must LEAVE marker"
 
   # Reconcile-after-restart resolves whichever outcome the latched commit
   # produced (here it landed after the timeout: the head moved into messages
@@ -465,7 +485,7 @@ def test_promote_ack_timeout_leaves_marker_then_reconcile_resolves(
     db.close()
   assert "t3" in reconciled
   state = _load("t3")
-  assert state["run_status"] is None
+  assert state["running"] is False
   assert state["pending_messages"] == []
   assert state["messages"][-1]["role"] == "assistant"
   assert any(b["type"] == "error" for b in state["messages"][-1]["blocks"])
@@ -484,7 +504,7 @@ def test_drain_lock_bound_exceeded_leaves_marker_then_reconcile_clears(
     "t4",
     messages=[{"role": "user", "content": "hi", "ts": 1}],
     pending=[{"role": "user", "content": "queued", "ts": 3}],
-    run_status="running",
+    running="running",
   )
   _patch_claude_runner(monkeypatch, text=None)
   # Small terminal-lock bound so the held lock trips it deterministically.
@@ -525,7 +545,7 @@ def test_drain_lock_bound_exceeded_leaves_marker_then_reconcile_clears(
   assert "queued_turn_starting" not in published
   assert "error" in published
   state = _load("t4")
-  assert state["run_status"] == "running", "lock-bound timeout must LEAVE marker"
+  assert state["running"] is True, "lock-bound timeout must LEAVE marker"
   assert len(state["pending_messages"]) == 1, "queue not consumed on timeout"
 
   # Reconcile-after-restart clears it.
@@ -536,7 +556,7 @@ def test_drain_lock_bound_exceeded_leaves_marker_then_reconcile_clears(
   finally:
     db.close()
   assert "t4" in reconciled
-  assert _load("t4")["run_status"] is None
+  assert _load("t4")["running"] is False
 
 
 # -- 5a. appended scrub: orphan removed by identity, neighbours survive --
@@ -680,7 +700,7 @@ def test_stop_handoff_clears_only_immediate_successor_marker(monkeypatch):
   _seed_owner_and_creds()
   _seed_chat(
     "t6", messages=[{"role": "user", "content": "hi", "ts": 1}],
-    pending=[], run_status="running",
+    pending=[], running="running",
   )
   _seed_run("rt-6", "t6")
   _patch_claude_runner(monkeypatch)
@@ -705,13 +725,13 @@ def test_stop_handoff_clears_only_immediate_successor_marker(monkeypatch):
   # The dying run did NOT promote a queue / schedule a continuation, and the
   # Stop-handoff clear ran for the immediate successor generation.
   assert "queued_turn_starting" not in published
-  assert _load("t6")["run_status"] is None, (
+  assert _load("t6")["running"] is False, (
     "Stop handoff must clear the marker after terminal persistence"
   )
   assert _run_outcomes("t6") == {"rt-6": "stopped"}
 
   # A newer run's marker must NEVER be cleared by a stale Stop-bumped run.
-  _seed_chat("t6b", run_status="running")
+  _seed_chat("t6b", running="running")
   chat_mod._clear_after_terminal_generation["t6b"] = 0  # stopped gen 0
   chat_mod.bump_run_generation("t6b")  # successor gen 1 (the immediate one)
   chat_mod.bump_run_generation("t6b")  # a NEWER run claimed gen 2
@@ -729,7 +749,7 @@ def test_stop_handoff_clears_only_immediate_successor_marker(monkeypatch):
     )
   )
   _drain_actor()
-  assert _load("t6b")["run_status"] == "running", (
+  assert _load("t6b")["running"] is True, (
     "a stale Stop-bumped run must NOT clear a newer run's marker"
   )
 
@@ -743,7 +763,7 @@ def test_watchdog_handoff_records_interrupted_outcome(monkeypatch):
   _seed_owner_and_creds()
   _seed_chat(
     cid, messages=[{"role": "user", "content": "hi", "ts": 1}],
-    pending=[], run_status="running",
+    pending=[], running="running",
   )
   _seed_run(f"rt-{cid}", cid)
 
@@ -774,7 +794,7 @@ def test_watchdog_handoff_records_interrupted_outcome(monkeypatch):
   _run_real_chat(cid, run_token=f"rt-{cid}", run_gen=gen)
   _drain_actor()
 
-  assert _load(cid)["run_status"] is None
+  assert _load(cid)["running"] is False
   assert _run_outcomes(cid) == {f"rt-{cid}": "interrupted"}
 
 
@@ -787,7 +807,7 @@ def test_unsupported_provider_cleanup_clears_marker_and_pending(monkeypatch):
   _seed_chat(
     "t7", messages=[{"role": "user", "content": "hi", "ts": 1}],
     pending=[{"role": "user", "content": "queued", "ts": 3}],
-    run_status="running",
+    running="running",
   )
 
   # Force an unsupported provider: stub get_provider to return a provider
@@ -820,7 +840,7 @@ def test_unsupported_provider_cleanup_clears_marker_and_pending(monkeypatch):
   assert "queued_turn_starting" not in published
   assert scheduled == []
   state = _load("t7")
-  assert state["run_status"] is None, "unsupported cleanup must clear marker"
+  assert state["running"] is False, "unsupported cleanup must clear marker"
   assert state["pending_messages"] == [], "pending must be cleared durably"
   assert not chat_mod.registry.is_alive("t7"), "registry released"
 
@@ -835,7 +855,7 @@ def test_actor_fatal_leaves_marker_then_reconcile_repairs(monkeypatch):
   _seed_chat(
     "t8", messages=[{"role": "user", "content": "hi", "ts": 1}],
     pending=[{"role": "user", "content": "queued", "ts": 3}],
-    run_status="running",
+    running="running",
   )
   _patch_claude_runner(monkeypatch)
 
@@ -859,7 +879,7 @@ def test_actor_fatal_leaves_marker_then_reconcile_repairs(monkeypatch):
   assert "queued_turn_starting" not in published
   assert scheduled == []
   state = _load("t8")
-  assert state["run_status"] == "running", "actor-fatal terminal must LEAVE marker"
+  assert state["running"] is True, "actor-fatal terminal must LEAVE marker"
   assert len(state["pending_messages"]) == 1, "queue not consumed"
 
   # Reconcile-after-restart (the fatal actor is restarted by the fixture's
@@ -872,7 +892,7 @@ def test_actor_fatal_leaves_marker_then_reconcile_repairs(monkeypatch):
     db.close()
   assert "t8" in reconciled
   state = _load("t8")
-  assert state["run_status"] is None
+  assert state["running"] is False
   assert [m["content"] for m in state["pending_messages"]] == ["queued"], (
     "reconcile PRESERVES the queue (bug #2); it drains on the next send"
   )
@@ -892,7 +912,7 @@ def test_continuation_schedule_failure_after_promote_leaves_marker(monkeypatch):
     "t9",
     messages=[{"role": "user", "content": "hi", "ts": 1}],
     pending=[{"role": "user", "content": "queued", "ts": 3}],
-    run_status="running",
+    running="running",
   )
   _patch_claude_runner(monkeypatch)
 
@@ -920,7 +940,7 @@ def test_continuation_schedule_failure_after_promote_leaves_marker(monkeypatch):
   # continuation spawn), so the promote DID land before the failure.
   assert "queued_turn_starting" in published
   state = _load("t9")
-  assert state["run_status"] == "running", (
+  assert state["running"] is True, (
     "a promoted-but-unscheduled turn MUST leave the marker set"
   )
   # The promote moved the head into messages — the user message is now last.
@@ -937,7 +957,7 @@ def test_continuation_schedule_failure_after_promote_leaves_marker(monkeypatch):
     db.close()
   assert "t9" in reconciled
   state = _load("t9")
-  assert state["run_status"] is None, "reconcile must clear the marker"
+  assert state["running"] is False, "reconcile must clear the marker"
   assert state["messages"][-1]["role"] == "assistant"
   assert any(b["type"] == "error" for b in state["messages"][-1]["blocks"])
 
@@ -958,7 +978,7 @@ def test_stop_handoff_clear_does_not_erase_racing_fresh_start_turn_marker(
   marker. The new run's marker SURVIVES."""
   _seed_owner_and_creds()
   _seed_chat("t10", messages=[{"role": "user", "content": "hi", "ts": 1}],
-             pending=[], run_status="running")
+             pending=[], running="running")
   _patch_claude_runner(monkeypatch)
 
   # Set up the dying run as a Stop handoff: it owns `gen`; Stop bumped to the
@@ -990,7 +1010,7 @@ def test_stop_handoff_clear_does_not_erase_racing_fresh_start_turn_marker(
     await await_ack(ack)
 
   asyncio.run(_set_fresh_marker())
-  assert _load("t10")["run_status"] == "running", "fresh StartTurn set marker"
+  assert _load("t10")["running"] is True, "fresh StartTurn set marker"
 
   # Now the dying Stop-bumped run reaches its finally. Its gen-only check
   # (current == run_gen + 1) still passes, but the lock-gated is_chat_running
@@ -1000,7 +1020,7 @@ def test_stop_handoff_clear_does_not_erase_racing_fresh_start_turn_marker(
   _drain_actor()
 
   state = _load("t10")
-  assert state["run_status"] == "running", (
+  assert state["running"] is True, (
     "the dying Stop-bumped run must NOT clear the racing fresh run's marker"
   )
   # The fresh owner is still alive (its run never ran here — we only set its
@@ -1027,7 +1047,7 @@ def test_stale_dying_run_does_not_finalize_after_fresh_turn_claimed(monkeypatch)
   `registry.is_alive` re-check (the fresh `mark_starting`) is what does."""
   _seed_owner_and_creds()
   _seed_chat("t10c", messages=[{"role": "user", "content": "hi", "ts": 1}],
-             pending=[], run_status="running")
+             pending=[], running="running")
 
   chat_mod.mark_starting("t10c")
   gen = chat_mod.current_run_generation("t10c")
@@ -1117,7 +1137,7 @@ def test_stale_dying_run_does_not_finalize_after_fresh_turn_claimed(monkeypatch)
     m.get("role") == "assistant" for m in state["messages"][fresh_idx + 1:]
   ), "no assistant row may follow the fresh turn's user message"
   # The fresh turn's marker survives untouched.
-  assert state["run_status"] == "running", (
+  assert state["running"] is True, (
     "the fresh turn's run marker must survive the dying run's bow-out"
   )
   assert "done" in published
@@ -1139,7 +1159,7 @@ def test_no_owner_cleanup_clears_marker_before_registry_release(monkeypatch):
   _seed_chat(
     "t11", messages=[{"role": "user", "content": "hi", "ts": 1}],
     pending=[{"role": "user", "content": "queued", "ts": 3}],
-    run_status="running",
+    running="running",
   )
 
   scheduled = []
@@ -1159,7 +1179,7 @@ def test_no_owner_cleanup_clears_marker_before_registry_release(monkeypatch):
   assert "queued_turn_starting" not in published
   assert scheduled == []
   state = _load("t11")
-  assert state["run_status"] is None, "no-owner cleanup must clear the marker"
+  assert state["running"] is False, "no-owner cleanup must clear the marker"
   assert state["pending_messages"] == [], "pending must be cleared durably"
   assert not chat_mod.registry.is_alive("t11"), "registry released"
 
@@ -1197,7 +1217,7 @@ def test_no_connected_agent_streams_and_persists_guidance(
     dbx.close()
   _seed_chat(
     "t12", messages=[{"role": "user", "content": "hi", "ts": 1}],
-    run_status="running",
+    running="running",
   )
   _seed_run("rt-12", "t12")
 
@@ -1218,7 +1238,7 @@ def test_no_connected_agent_streams_and_persists_guidance(
   assert "error" not in published
   assert published[-1] == "done"
   state = _load("t12")
-  assert state["run_status"] is None
+  assert state["running"] is False
   assert state["messages"][-1]["role"] == "assistant"
   assert state["messages"][-1]["content"] == chat_mod.NO_AGENT_CONNECTED_MESSAGE
   assert state["messages"][-1]["blocks"] == [{
@@ -1262,7 +1282,7 @@ def test_no_connected_agent_promotes_queued_message(monkeypatch):
     "t12-queued",
     messages=[{"role": "user", "content": "hi", "ts": 1}],
     pending=[{"role": "user", "content": "queued", "ts": 3}],
-    run_status="running",
+    running="running",
   )
   _seed_run("rt-12-queued", "t12-queued")
   scheduled = []
@@ -1286,7 +1306,7 @@ def test_no_connected_agent_promotes_queued_message(monkeypatch):
   successor_token = scheduled[0]["run_token"]
   state = _load("t12-queued")
   assert state["pending_messages"] == []
-  assert state["run_status"] == "running"
+  assert state["running"] is True
   assert state["messages"][-2]["content"] == chat_mod.NO_AGENT_CONNECTED_MESSAGE
   assert state["messages"][-1]["content"] == "queued"
   assert _run_outcomes("t12-queued") == {
@@ -1326,7 +1346,7 @@ def test_no_connected_agent_stopped_during_metrics_preserves_successor_sink(
   _seed_chat(
     "t12-metrics-stop",
     messages=[{"role": "user", "content": "hi", "ts": 1}],
-    run_status="running",
+    running="running",
   )
   _seed_run("rt-12-metrics-stop", "t12-metrics-stop")
 
@@ -1383,7 +1403,7 @@ def test_auth_error_cleanup_when_another_provider_is_connected(monkeypatch):
     "t12-auth-error",
     messages=[{"role": "user", "content": "hi", "ts": 1}],
     pending=[{"role": "user", "content": "queued", "ts": 3}],
-    run_status="running",
+    running="running",
   )
   _seed_run("rt-12-auth", "t12-auth-error")
   monkeypatch.setattr(
@@ -1402,7 +1422,7 @@ def test_auth_error_cleanup_when_another_provider_is_connected(monkeypatch):
   assert "error" in published
   assert "text" not in published
   state = _load("t12-auth-error")
-  assert state["run_status"] is None
+  assert state["running"] is False
   assert state["pending_messages"] == []
   assert _run_outcomes("t12-auth-error") == {"rt-12-auth": "failed"}
   assert not chat_mod.registry.is_alive("t12-auth-error")
@@ -1425,7 +1445,7 @@ def test_setup_error_cleanup_stale_gen_does_not_clobber_successor():
     "se-stale",
     messages=[{"role": "user", "content": "fresh", "ts": 1}],
     pending=[{"role": "user", "content": "queued-behind-fresh", "ts": 2}],
-    run_status="running",
+    running="running",
   )
   chat_mod.registry.bump_generation("se-stale")  # → 1, the setup-erroring run
   chat_mod.registry.bump_generation("se-stale")  # → 2, a Stop bumped it
@@ -1438,7 +1458,7 @@ def test_setup_error_cleanup_stale_gen_does_not_clobber_successor():
 
   assert disposition is chat_queue.TerminalDisposition.STALE_NO_ACTION
   state = _load("se-stale")
-  assert state["run_status"] == "running", "successor's marker must survive"
+  assert state["running"] is True, "successor's marker must survive"
   assert state["pending_messages"] == [
     {"role": "user", "content": "queued-behind-fresh", "ts": 2}
   ], "successor's queued send must survive"
@@ -1456,7 +1476,8 @@ def test_setup_error_cleanup_owned_gen_clears_and_forgets():
     "se-own",
     messages=[{"role": "user", "content": "hi", "ts": 1}],
     pending=[{"role": "user", "content": "queued", "ts": 2}],
-    run_status="running",
+    running="running",
+    run_token="rt-own",
   )
   gen = chat_mod.registry.bump_generation("se-own")  # → 1, this run owns it
   chat_mod.registry.mark_starting("se-own")
@@ -1468,7 +1489,7 @@ def test_setup_error_cleanup_owned_gen_clears_and_forgets():
 
   assert disposition is chat_queue.TerminalDisposition.EMPTY_TERMINAL_CLEARED
   state = _load("se-own")
-  assert state["run_status"] is None, "owned cleanup clears the marker"
+  assert state["running"] is False, "owned cleanup clears the marker"
   assert state["pending_messages"] == [], "owned cleanup clears pending"
   assert chat_mod.registry.current_generation("se-own") == 0, "forgotten"
   assert not chat_mod.registry.is_alive("se-own"), "starting slot released"
@@ -1476,8 +1497,8 @@ def test_setup_error_cleanup_owned_gen_clears_and_forgets():
 
 # -- 13. strict marker-clear ACK timeout → FAILED_LEAVE_MARKER --------------
 def test_empty_queue_marker_clear_ack_timeout_leaves_marker(monkeypatch):
-  """The empty-queue terminal path issues a STRICT ClearRunStatus. Latch the
-  actor inside `_clear_run_status` AFTER dispatch so its commit blocks past a
+  """The empty-queue terminal path issues a STRICT FinishRun. Latch the
+  actor inside `_finish_run` AFTER dispatch so its commit blocks past a
   deterministically-small ACK_TIMEOUT_SECS. The strict clear's await_ack
   times out → drain_and_release raises → _complete_turn maps it to
   FAILED_LEAVE_MARKER: marker LEFT set (NOT cleared), no continuation,
@@ -1485,22 +1506,22 @@ def test_empty_queue_marker_clear_ack_timeout_leaves_marker(monkeypatch):
   _seed_owner_and_creds()
   _seed_chat(
     "t13", messages=[{"role": "user", "content": "hi", "ts": 1}],
-    pending=[], run_status="running",
+    pending=[], running="running",
   )
   # No streamed text → finalize() is a no-op, so the turn reaches the
-  # empty-queue drain (which issues the strict ClearRunStatus we latch).
+  # empty-queue drain (which issues the strict FinishRun we latch).
   _patch_claude_runner(monkeypatch, text=None)
   monkeypatch.setattr(chat_writer, "ACK_TIMEOUT_SECS", 0.2)
 
   writer = get_writer()
   release = threading.Event()
-  orig_clear = writer._clear_run_status
+  orig_clear = writer._finish_run
 
   def latched_clear(db, cmd):
     release.wait(timeout=10)  # block the actor inside the clear commit
     return orig_clear(db, cmd)
 
-  writer._clear_run_status = latched_clear
+  writer._finish_run = latched_clear
 
   scheduled = []
   orig_sched = chat_mod._schedule_continuation
@@ -1521,7 +1542,7 @@ def test_empty_queue_marker_clear_ack_timeout_leaves_marker(monkeypatch):
     )
     assert "queued_turn_starting" not in published
     assert "error" in published
-    assert _load("t13")["run_status"] == "running", (
+    assert _load("t13")["running"] is True, (
       "a timed-out strict marker clear must LEAVE the marker set"
     )
   finally:
@@ -1530,14 +1551,14 @@ def test_empty_queue_marker_clear_ack_timeout_leaves_marker(monkeypatch):
     # cleared, the same state a restart reconcile would reach).
     release.set()
     _drain_actor()
-    writer._clear_run_status = orig_clear
+    writer._finish_run = orig_clear
     chat_mod._schedule_continuation = orig_sched
 
   # Late-landing clear converged the marker (the documented accept-and-document
   # outcome). Had it NOT landed (commit dropped rather than delayed), the
   # marker would stay set and a restart reconcile would clear it — both
   # outcomes are covered by reconcile's mid-commit-timeout contract.
-  assert _load("t13")["run_status"] is None
+  assert _load("t13")["running"] is False
 
 
 # -- 14. malformed queue head LEAVES the marker -----------------------------------------------
@@ -1560,7 +1581,7 @@ def test_malformed_pending_head_leaves_marker_then_reconcile_repairs(monkeypatch
     # A truthy non-string content survives the `... or ""` guard and makes
     # schemas.ChatMessage(content=[...]) raise inside _promote_pending.
     pending=[{"role": "user", "content": ["malformed"], "ts": 3}],
-    run_status="running",
+    running="running",
   )
   # No streamed text → finalize() is a no-op, so the turn reaches the drain
   # (the promote) which is what raises on the malformed head.
@@ -1583,7 +1604,7 @@ def test_malformed_pending_head_leaves_marker_then_reconcile_repairs(monkeypatch
   assert "queued_turn_starting" not in published
   assert "error" in published
   state = _load("tb")
-  assert state["run_status"] == "running", (
+  assert state["running"] is True, (
     "a malformed queue head must LEAVE the marker set, not clear it"
   )
   assert len(state["pending_messages"]) == 1, "the malformed message stays queued"
@@ -1600,7 +1621,7 @@ def test_malformed_pending_head_leaves_marker_then_reconcile_repairs(monkeypatch
     db.close()
   assert "tb" in reconciled
   state = _load("tb")
-  assert state["run_status"] is None
+  assert state["running"] is False
   assert len(state["pending_messages"]) == 1, (
     "reconcile PRESERVES the queue (bug #2), even a malformed head"
   )
@@ -1627,7 +1648,7 @@ def test_reconcile_preserves_tail_unanswered_question_card():
          "questions": [{"id": "q-open", "question": "Color?"}]},
       ]},
     ],
-    run_status="running",
+    running="running",
   )
   db = SessionLocal()
   try:
@@ -1636,7 +1657,7 @@ def test_reconcile_preserves_tail_unanswered_question_card():
     db.close()
   assert "tq" in reconciled
   state = _load("tq")
-  assert state["run_status"] is None
+  assert state["running"] is False
   blocks = state["messages"][-1]["blocks"]
   qids = [b.get("question_id") for b in blocks if b.get("type") == "question"]
   assert "q-open" in qids, "the open question must remain answerable"
@@ -1750,7 +1771,7 @@ def test_stop_during_provider_setup_does_not_dispatch_runner(monkeypatch):
     cid,
     messages=[{"role": "user", "content": "hi", "ts": 1}],
     pending=[],
-    run_status="running",
+    running="running",
   )
   gen = chat_mod.registry.bump_generation(cid)
 
@@ -1779,7 +1800,7 @@ def test_stop_during_provider_setup_does_not_dispatch_runner(monkeypatch):
     "exists"
   )
   state = _load(cid)
-  assert state["run_status"] is None
+  assert state["running"] is False
 
 
 def test_normal_send_spawns_turn(monkeypatch):
@@ -1841,7 +1862,7 @@ def test_stop_during_finalize_makes_drain_bow_out_under_lock(monkeypatch):
     # A pending head so a drain that WRONGLY acted as owner would promote it
     # (queued_turn_starting + a continuation) — making the bug observable.
     pending=[{"role": "user", "content": "queued", "ts": 3}],
-    run_status="running",
+    running="running",
   )
   # Stream text so finalize() has blocks to commit and the Finalize command is
   # actually submitted + awaited (the bump must land inside that await).
@@ -1886,7 +1907,7 @@ def test_stop_during_finalize_makes_drain_bow_out_under_lock(monkeypatch):
   ], "the superseded turn must leave the queued message untouched"
   # The superseded run must NOT clear the marker — the newer owner still needs
   # it. The drain's STALE_NO_ACTION bow-out touches nothing durable.
-  assert _load("t17")["run_status"] == "running", (
+  assert _load("t17")["running"] is True, (
     "the superseded turn must NOT clear the marker the newer owner still holds"
   )
 
@@ -1930,7 +1951,7 @@ def test_stale_reclaim_bow_out_preserves_fresh_owners_broadcast_and_browser(
   _seed_owner_and_creds()
   _seed_chat(
     "t18a", messages=[{"role": "user", "content": "hi", "ts": 1}],
-    pending=[], run_status="running",
+    pending=[], running="running",
   )
   gen = _arrange_stale_reclaim("t18a")
 
@@ -1994,7 +2015,7 @@ def test_stale_reclaim_bow_out_clears_pointer_but_leaves_browser_when_no_success
   _seed_owner_and_creds()
   _seed_chat(
     "t18b", messages=[{"role": "user", "content": "hi", "ts": 1}],
-    pending=[], run_status="running",
+    pending=[], running="running",
   )
   gen = _arrange_stale_reclaim("t18b")
 
@@ -2037,17 +2058,17 @@ def test_stale_reclaim_bow_out_clears_pointer_but_leaves_browser_when_no_success
     bc_mod.set_active_broadcast(None)
 
 
-# -- 19. ClearRunStatus is identity-keyed: a stale token can't wipe a marker --
-def test_clear_run_status_is_identity_keyed_to_the_owning_run_token():
+# -- 19. FinishRun is identity-keyed: a stale token can't wipe a marker --
+def test_finish_run_is_identity_keyed_to_the_owning_run_token():
   """The markerless-run race. A fresh turn's StartTurn sets the marker and
   records itself (run_token) as the marker's owner. A dying run that races in
   during the window where the fresh turn has marked-starting but its handle
   isn't registered yet (so is_alive is briefly false) would otherwise clear
-  the marker by chat_id, leaving the fresh turn markerless. ClearRunStatus is
+  the marker by chat_id, leaving the fresh turn markerless. FinishRun is
   identity-keyed: a clear naming a DIFFERENT run_token is a no-op, so the fresh
   marker survives; the owning token still clears it.
   """
-  from app.chat_writer import ClearRunStatus, StartTurn, await_ack, get_writer
+  from app.chat_writer import FinishRun, StartTurn, await_ack, get_writer
 
   _seed_chat("t19", messages=[], pending=[])
 
@@ -2059,34 +2080,34 @@ def test_clear_run_status_is_identity_keyed_to_the_owning_run_token():
     await await_ack(a)
     # The dying run's clear names its OWN (older) token, not the fresh owner.
     a = get_writer().submit(
-      ClearRunStatus(chat_id="t19", run_token="rt-dying")
+      FinishRun(chat_id="t19", run_token="rt-dying")
     )
     await await_ack(a)
 
   asyncio.run(_fresh_then_stale_clear())
-  assert _load("t19")["run_status"] == "running", (
+  assert _load("t19")["running"] is True, (
     "a clear naming a non-owning run_token must NOT wipe the fresh marker"
   )
 
   async def _clear_matching():
     a = get_writer().submit(
-      ClearRunStatus(chat_id="t19", run_token="rt-fresh")
+      FinishRun(chat_id="t19", run_token="rt-fresh")
     )
     await await_ack(a)
 
   asyncio.run(_clear_matching())
-  assert _load("t19")["run_status"] is None, (
+  assert _load("t19")["running"] is False, (
     "the run_token that owns the marker still clears it"
   )
 
 
-# -- 20. a tokenless ClearRunStatus stays unconditional (reconcile/no-handoff)-
-def test_tokenless_clear_run_status_is_unconditional():
+# -- 20. a tokenless FinishRun stays unconditional (reconcile/no-handoff)-
+def test_tokenless_finish_run_is_unconditional():
   """A clear with run_token="" clears regardless of the recorded owner — the
   reconciliation and no-handoff paths that already know they own the marker
   must not be gated by the identity check.
   """
-  from app.chat_writer import ClearRunStatus, StartTurn, await_ack, get_writer
+  from app.chat_writer import FinishRun, StartTurn, await_ack, get_writer
 
   _seed_chat("t20", messages=[], pending=[])
 
@@ -2096,11 +2117,11 @@ def test_tokenless_clear_run_status_is_unconditional():
       user_msg={"role": "user", "content": "hi", "ts": 1},
     ))
     await await_ack(a)
-    a = get_writer().submit(ClearRunStatus(chat_id="t20", run_token=""))
+    a = get_writer().submit(FinishRun(chat_id="t20", run_token=""))
     await await_ack(a)
 
   asyncio.run(_start_then_tokenless_clear())
-  assert _load("t20")["run_status"] is None, (
+  assert _load("t20")["running"] is False, (
     "a tokenless clear clears unconditionally even with a recorded owner"
   )
 
@@ -2211,7 +2232,7 @@ def test_mutating_commands_do_not_resurrect_soft_deleted_chat():
     "t24",
     messages=[{"role": "user", "content": "hi", "ts": 1}],
     pending=[{"role": "user", "content": "queued", "ts": 2}],
-    run_status=None,
+    running=None,
   )
   # Soft-delete while it still holds a transcript + a queued message.
   db = SessionLocal()
@@ -2245,4 +2266,4 @@ def test_mutating_commands_do_not_resurrect_soft_deleted_chat():
     "no command may mutate the transcript of a soft-deleted chat"
   )
   assert len(state["pending_messages"]) == 1, "the queue must not be promoted"
-  assert state["run_status"] is None, "no run marker on a soft-deleted chat"
+  assert state["running"] is False, "no run marker on a soft-deleted chat"

--- a/backend/tests/test_wedged_marker_sweep.py
+++ b/backend/tests/test_wedged_marker_sweep.py
@@ -1,6 +1,6 @@
-"""Runtime liveness watchdog (`sweep_wedged_run_markers`) + limit classifier.
+"""Runtime liveness watchdog (`sweep_wedged_runs`) + limit classifier.
 
-The sweep clears run markers orphaned by a completed-but-uncleared turn WITHOUT
+The sweep closes runs orphaned by a completed-but-unclosed turn WITHOUT
 a process restart (a FAILED_LEAVE_MARKER terminal, or the late-promote gap),
 which boot reconciliation would otherwise only fix on the next restart. It must
 reap ONLY a definitively-finished turn — never a live turn, and never the
@@ -24,23 +24,20 @@ def _drain_writer():
   get_writer().submit(Barrier()).result(timeout=5)
 
 
-def _seed(chat_id, *, age_secs=200, run_status="running", pending=None,
+def _seed(chat_id, *, age_secs=200, pending=None,
           messages=None, live_assistant=None, with_run=True):
   db = SessionLocal()
   try:
-    started = None
-    if run_status is not None:
-      started = datetime.now(UTC).replace(tzinfo=None) - timedelta(
-        seconds=age_secs
-      )
+    started = datetime.now(UTC).replace(tzinfo=None) - timedelta(
+      seconds=age_secs
+    )
     c = models.Chat(
       id=chat_id, title="t", messages=messages or [],
       live_assistant=live_assistant, pending_messages=pending or [],
       session_id="sess", provider="claude",
-      run_status=run_status, run_started_at=started,
     )
     db.add(c)
-    if with_run and run_status is not None:
+    if with_run:
       db.add(models.ChatRun(
         id=f"rt-{chat_id}", chat_id=chat_id, status="running",
         provider="claude",
@@ -57,8 +54,18 @@ def _state(chat_id):
   db = SessionLocal()
   try:
     c = db.query(models.Chat).filter(models.Chat.id == chat_id).first()
+    run = db.query(models.ChatRun).filter(
+      models.ChatRun.chat_id == chat_id,
+    ).order_by(
+      models.ChatRun.started_at.desc(),
+      models.ChatRun.id.desc(),
+    ).first()
     return (
-      c.run_status,
+      (
+        run.status
+        if run is not None and run.status in models.NONTERMINAL_RUN_STATUSES
+        else None
+      ),
       list(c.pending_messages or []),
       list(c.messages or []),
       c.live_assistant,
@@ -81,7 +88,7 @@ def _run_outcome(chat_id):
 def _sweep():
   db = SessionLocal()
   try:
-    return asyncio.run(chat_mod.sweep_wedged_run_markers(db))
+    return asyncio.run(chat_mod.sweep_wedged_runs(db))
   finally:
     db.close()
 
@@ -97,7 +104,7 @@ def test_sweep_recovers_orphaned_turn_and_preserves_queue():
   _drain_writer()
   assert "wedged-1" in swept
   status, pending, messages, live = _state("wedged-1")
-  assert status is None, "orphaned marker should be cleared"
+  assert status is None
   assert _run_outcome("wedged-1") == "interrupted"
   assert live is None
   assert [message["role"] for message in messages] == ["user", "assistant"]
@@ -181,8 +188,8 @@ def test_wedged_candidate_query_does_not_load_transcripts():
 
   def capture(_conn, _cursor, statement, _parameters, _context, _many):
     if (
-      "FROM chats" in statement
-      and "chats.run_started_at <" in statement
+      "FROM chat_runs JOIN chats" in statement
+      and "chat_runs.started_at <" in statement
     ):
       statements.append(statement)
 
@@ -194,8 +201,8 @@ def test_wedged_candidate_query_does_not_load_transcripts():
   _drain_writer()
 
   assert len(statements) == 1
-  projection = statements[0].split("FROM chats", 1)[0]
-  assert "chats.id" in projection
+  projection = statements[0].split("FROM chat_runs", 1)[0]
+  assert "chat_runs.id" in projection
   assert "chats.messages" not in projection
 
 
@@ -238,13 +245,12 @@ def test_sweep_reaps_after_broadcast_completed():
 
 
 def test_sweep_skips_when_no_run_record():
-  # No ChatRun to identity-key the clear on — leave it for boot reconcile
-  # rather than risk a tokenless clear wiping a racing fresh run.
+  # No durable run means there is no recovery candidate.
   _seed("norun-1", age_secs=200, with_run=False)
   swept = _sweep()
   _drain_writer()
   assert "norun-1" not in swept
-  assert _state("norun-1")[0] == "running"
+  assert _state("norun-1")[0] is None
 
 
 def test_limit_error_text_classifier():

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -1817,7 +1817,7 @@ export default function Shell() {
   const streamingChatIds = useMemo(() => {
     const next = new Set(localStreamingChatIds)
     for (const chat of chats) {
-      if (chat.running || chat.run_status === 'running') next.add(chat.id)
+      if (chat.running) next.add(chat.id)
     }
     return next
   }, [localStreamingChatIds, chats])

--- a/frontend/src/components/Shell/__tests__/newChatPolicy.test.js
+++ b/frontend/src/components/Shell/__tests__/newChatPolicy.test.js
@@ -24,7 +24,6 @@ const empty = (id, extra = {}) => ({
   id,
   has_messages: false,
   running: false,
-  run_status: null,
   ...extra,
 })
 
@@ -101,7 +100,6 @@ test('the most recent concrete chat route can resume standard-mode composition',
 test('running, excluded, recovered, and populated active chats are rejected', () => {
   const options = { activeChatId: 'active' }
   assert.equal(currentReusableEmptyChat([empty('active', { running: true })], options), null)
-  assert.equal(currentReusableEmptyChat([empty('active', { run_status: 'running' })], options), null)
   assert.equal(currentReusableEmptyChat([empty('active', { has_messages: true })], options), null)
   assert.equal(currentReusableEmptyChat([empty('active')], {
     ...options, exclude: 'active',
@@ -221,7 +219,6 @@ test('a created chat enters the cache without displacing pinned chats', () => {
     pinned_at: null,
     has_messages: false,
     created_by_app_id: null,
-    run_status: null,
     running: false,
     messages: [],
     detail: untouchedDetail(),

--- a/frontend/src/components/Shell/newChatPolicy.js
+++ b/frontend/src/components/Shell/newChatPolicy.js
@@ -48,7 +48,7 @@ export function currentReusableEmptyChat(chats, {
   if (!chat || chat.has_messages) return null
   if (excludedId != null && activeId === excludedId) return null
   if (recoveredIds.has(activeId) || streamingIds.has(activeId)) return null
-  if (chat.running || chat.run_status === 'running') return null
+  if (chat.running) return null
   return chat
 }
 

--- a/tests/app-canvas.spec.mjs
+++ b/tests/app-canvas.spec.mjs
@@ -219,7 +219,6 @@ async function setupOpenAppRoutesWithStaleInitialList(
     updated_at: new Date().toISOString(),
     has_messages: true,
     running: false,
-    run_status: null,
   }
   const app = (id, name, slug) => ({
     id,
@@ -730,7 +729,6 @@ test.describe('AppCanvas: iframe-mount contract', () => {
             updated_at: new Date().toISOString(),
             has_messages: false,
             running: false,
-            run_status: null,
           }),
         })
       }
@@ -750,7 +748,6 @@ test.describe('AppCanvas: iframe-mount contract', () => {
           messages: [],
           has_messages: false,
           running: false,
-          run_status: null,
           provider: 'claude',
         }),
       })

--- a/tests/bootstrap.spec.mjs
+++ b/tests/bootstrap.spec.mjs
@@ -133,7 +133,6 @@ async function routeShell(page, {
         activity_at: null,
         pinned_at: null,
         created_by_app_id: null,
-        run_status: null,
         running: false,
         messages: [],
         detail,

--- a/tests/image-gallery.spec.mjs
+++ b/tests/image-gallery.spec.mjs
@@ -28,7 +28,6 @@ function chatListItem() {
     created_by_app_id: null,
     has_messages: true,
     running: false,
-    run_status: null,
   }
 }
 

--- a/tests/navigation.spec.mjs
+++ b/tests/navigation.spec.mjs
@@ -24,7 +24,6 @@ const NAV_CHATS = [
   created_by_app_id: null,
   has_messages: true,
   running: false,
-  run_status: null,
 }))
 
 function navChatDetail(id, assistantContent = 'Fixture response') {

--- a/tests/notifications.spec.mjs
+++ b/tests/notifications.spec.mjs
@@ -17,7 +17,6 @@ const CHATS = [{
   created_by_app_id: null,
   has_messages: true,
   running: false,
-  run_status: null,
 }]
 
 function notifRows(now = Date.now()) {

--- a/tests/shell-update-idle.spec.mjs
+++ b/tests/shell-update-idle.spec.mjs
@@ -445,7 +445,6 @@ test.describe('shell update — apply on idle, SW on a leash', () => {
         body: JSON.stringify([{
           ...idleChat,
           running: false,
-          run_status: 'idle',
         }]),
       })
     })

--- a/tests/steer-queued.spec.mjs
+++ b/tests/steer-queued.spec.mjs
@@ -820,7 +820,6 @@ test.describe('Steer queued messages (fast-forward into the live turn)', () => {
           pinned_at: null,
           has_messages: durableMessages.length > 0,
           created_by_app_id: null,
-          run_status: durableRunning ? 'running' : 'idle',
           running: durableRunning,
         }]),
       })

--- a/tests/viewed-image-layout.spec.mjs
+++ b/tests/viewed-image-layout.spec.mjs
@@ -19,7 +19,6 @@ function chatListItem() {
     created_by_app_id: null,
     has_messages: true,
     running: false,
-    run_status: null,
   }
 }
 


### PR DESCRIPTION
## Summary
- make `ChatRun` the single durable authority for running, parked, and resumable turns
- migrate legacy per-chat running markers without losing interrupted work
- route recovery, liveness, chat summaries, and maintenance scripts through the same run-state model
- remove duplicate legacy fields from the shell contract and clean mechanically duplicated fixtures

## Verification
- full backend suite: 3,492 passed, 1 skipped
- focused run lifecycle, migration, recovery, queue, and persistence suite: 383 passed
- frontend unit and hook suites: 2,270 passed
- production frontend and offline service-worker build passed
- canonical diff and privacy scan passed

The complete Docker-backed hosted checks must pass before merge.