### PR TITLE
Extract shell and chat state owners

### DIFF
--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -14,12 +14,13 @@ import { chatMessagesQueryKey } from '../../hooks/queries.js'
 import useStreamConnection from './useStreamConnection.js'
 import useScrollMode from './useScrollMode.js'
 import useVoiceInput from './useVoiceInput.js'
-import useFileUpload from './useFileUpload.js'
 import useOnlineStatus from '../../hooks/useOnlineStatus.js'
 import { getOnlineSnapshot } from '../../lib/connectivityStore.js'
 import useSystemEventStream from '../../hooks/useSystemEventStream.js'
 import usePendingQueue from './hooks/usePendingQueue.js'
 import useBridgePartial from './hooks/useBridgePartial.js'
+import useTranscriptState from './hooks/useTranscriptState.js'
+import useComposerDraftState from './hooks/useComposerDraftState.js'
 import useOffscreenNudge, { useNudgeTargetRef } from './hooks/useOffscreenNudge.js'
 import ChatInputBar from './ChatInputBar.jsx'
 import { hasSendablePayload } from './composerSubmission.js'
@@ -58,7 +59,6 @@ import { clearChatQuestionDrafts } from './questionDraft.js'
 import { resolveStopResend } from './resolveStopResend.js'
 import { focusComposerElement, shouldApplyComposerFocusRequest } from './composerFocusPolicy.js'
 import { shouldDismissComposerKeyboardOnSubmit } from './composerKeyboardPolicy.js'
-import { sameMessageList } from './chatMessageList.js'
 import { updateChatRuntimeCache } from './chatRuntimeCache.js'
 import {
   chatDetailCacheValue,
@@ -94,23 +94,15 @@ import {
 } from './sendAttemptIdentity.js'
 import {
   clearFailedSendAttempt,
-  loadFailedSendAttempt,
-  saveFailedSendAttempt,
   sendAttemptIsDurable,
 } from './sendAttemptRecovery.js'
 import {
   clearComposerDraft,
-  composerDraftRevision,
   consumeComposerHandoff,
-  persistComposerDraft,
-  readComposerHandoff,
-  readComposerDraft,
-  readComposerDraftAsync,
 } from './composerDraft.js'
 import {
   reconcileComposerTextarea,
   resetComposerTextarea,
-  resizeComposerTextarea,
 } from './composerTextareaSizing.js'
 import {
   EMPTY_BUILD_PHASE_RAIL,
@@ -214,40 +206,6 @@ function tailResumableBlock(messages) {
   return null
 }
 
-function readInitialComposer(chatId, { acceptPending = true } = {}) {
-  try {
-    const failedAttempt = loadFailedSendAttempt(chatId)
-    // A retained hidden surface for the same chat must not claim a global
-    // navigation draft or its one-shot autosend. Only the currently painted
-    // world accepts that handoff; otherwise Standard + Builder duplicates could
-    // both start the same message when their shared chat id becomes visible.
-    const handoff = acceptPending
-      ? readComposerHandoff(chatId)
-      : { draft: null, autoSendDraft: null }
-    const pending = handoff.draft
-    if (pending && failedAttempt) clearFailedSendAttempt(chatId)
-    const saved = readComposerDraft(chatId)
-    const input = pending || failedAttempt?.text || saved.input
-    return {
-      input,
-      autoSend: !!input && handoff.autoSendDraft === input,
-      source: pending ? 'pending' : (failedAttempt ? 'failed' : 'saved'),
-      failedAttempt: pending ? null : failedAttempt,
-      attachments: pending
-        ? []
-        : (failedAttempt?.attachments || saved.attachments),
-    }
-  } catch {
-    return {
-      input: '',
-      autoSend: false,
-      source: 'empty',
-      failedAttempt: null,
-      attachments: [],
-    }
-  }
-}
-
 // Stable empty default so callers that pass no built apps (the embedded
 // composer) don't hand ChatView a fresh array each render and re-fire its
 // list-keyed effects.
@@ -294,6 +252,7 @@ export default function ChatView({
   const queryClient = useQueryClient()
   const hiddenRef = useRef(hidden)
   hiddenRef.current = hidden
+  const inputRef = useRef(null)
   const handleInternalNav = useCallback((url) => {
     onInternalNav?.(url)
   }, [onInternalNav])
@@ -316,14 +275,19 @@ export default function ChatView({
   // back through the versioned activation handoff, so any miss self-heals on
   // the first authoritative detail read.
   const cached = queryClient.getQueryData(chatMessagesQueryKey(chatId))
-  const [messages, setMessages] = useState(() => cached?.messages ?? [])
+  const transcriptCacheKey = useMemo(() => chatMessagesQueryKey(chatId), [chatId])
+  const {
+    messages,
+    messagesRef,
+    offset,
+    offsetRef,
+    applyMessagesToView,
+    commitMessages,
+  } = useTranscriptState({ cacheKey: transcriptCacheKey, cached, queryClient })
   const messageHistory = useMemo(
     () => composerHistoryFromMessages(messages),
     [messages],
   )
-  const [offset, setOffset] = useState(() => cached?.offset ?? 0)
-  const offsetRef = useRef(offset)
-  offsetRef.current = offset
   const [loading, setLoading] = useState(!cached)
   // Cached content is a real first paint even for a running chat. The initial
   // refresh remains authoritative and the stream catches up any active tail,
@@ -365,53 +329,28 @@ export default function ChatView({
       { running },
     )
   }
-  const initialComposerRef = useRef(null)
-  if (!initialComposerRef.current) {
-    initialComposerRef.current = readInitialComposer(chatId, { acceptPending: !hidden })
-  }
-  const draftAttachmentsRef = useRef(initialComposerRef.current.attachments)
-  const [input, setInputState] = useState(() => initialComposerRef.current.input)
-  const inputValueRef = useRef(input)
-  inputValueRef.current = input
-  function setComposerInput(nextInput) {
-    // Navigation can unmount this component before React flushes passive
-    // effects. Keep every composer transition durable at the state boundary,
-    // whether it came from typing, voice, restoration, or send cleanup.
-    inputValueRef.current = nextInput
-    persistComposerDraft(chatId, nextInput, draftAttachmentsRef.current)
-    setInputState(nextInput)
-  }
-  const [sendFailure, setSendFailure] = useState(() => (
-    initialComposerRef.current.failedAttempt
-      ? 'Möbius is checking whether your previous message reached the chat…'
-      : null
-  ))
-  const [pendingComposerSubmit, setPendingComposerSubmit] = useState(() => (
-    initialComposerRef.current.autoSend
-      ? {
-          token: `stored-handoff:${chatId}`,
-          text: initialComposerRef.current.input,
-          storedHandoff: true,
-        }
-      : null
-  ))
-  const submittedComposerRequestTokenRef = useRef(null)
-
-  useEffect(() => {
-    if (hidden) return
-    const initialComposer = initialComposerRef.current
-    const initial = initialComposer.input
-    if ((initialComposer.source === 'pending' || initialComposer.source === 'failed')
-        && (initial || initialComposer.attachments.length > 0)) {
-      // A global navigation handoff or failed-send recovery outranks any older
-      // per-chat draft. Adopt it into the live + durable draft owner before the
-      // one-shot handoff keys are removed.
-      persistComposerDraft(chatId, initial, initialComposer.attachments)
-    }
-    // The per-chat autosend marker remains until the actual send attempt. If
-    // this surface unmounts while loading, a remount can still finish safely.
-    consumeComposerHandoff(chatId, initial)
-  }, [hidden])
+  const {
+    input,
+    inputValueRef,
+    setComposerInput,
+    sendFailure,
+    setSendFailure,
+    pendingComposerSubmit,
+    setPendingComposerSubmit,
+    submittedComposerRequestTokenRef,
+    failedSendAttemptRef,
+    clearFailedAttempt,
+    rememberFailedAttempt,
+    pendingFiles,
+    clearFiles,
+    restoreFiles,
+    releaseFiles,
+    handleComposerInputChange,
+    handleComposerAddFiles,
+    handleComposerRemoveFile,
+    restoreComposerText,
+    restoreDurableDraft,
+  } = useComposerDraftState({ chatId, hidden, inputRef })
 
   // Per-chat agent runtime config (provider, agent_settings_json,
   // effective_agent_settings, has_assistant_turns). Resolved by the
@@ -600,14 +539,6 @@ export default function ChatView({
     }
   }, [chatId])
 
-  // Mirror `messages` in a ref so commitMessages can compute the next
-  // value without putting a side-effect (setQueryData) inside a
-  // setState updater. setState updaters must be pure; React may call
-  // them multiple times during concurrent rendering. Reading from a
-  // ref + calling setQueryData once outside the updater is correct.
-  const messagesRef = useRef(messages)
-  messagesRef.current = messages
-
   // Pending queue (the items shown in the queued-tray above the
   // composer) lives entirely inside usePendingQueue. Every mutation
   // goes through the hook's named ops; reads use pendingQueue.pendingMessages
@@ -624,66 +555,8 @@ export default function ChatView({
   const runtimeReconnectInFlightRef = useRef(false)
   const swReloadHoldTimerRef = useRef(null)
 
-  // Apply a resolved message snapshot to the mounted view without publishing
-  // it. Detail activation uses this after one complete cache publication;
-  // ordinary local/stream mutations go through commitMessages below.
-  const applyMessagesToView = useCallback((next, nextOffset, force = false) => {
-    const prev = messagesRef.current
-    // Advance messagesRef synchronously so back-to-back commits within the
-    // same React batch compose correctly.
-    messagesRef.current = next
-    if (nextOffset !== undefined) offsetRef.current = nextOffset
-    if (!force && sameMessageList(prev, next)) {
-      if (nextOffset !== undefined) {
-        setOffset(o => o === nextOffset ? o : nextOffset)
-      }
-      return
-    }
-    setMessages(next)
-    if (nextOffset !== undefined) {
-      setOffset(o => o === nextOffset ? o : nextOffset)
-    }
-  }, [])
-
-  // Single setter that updates local state AND the query cache.
-  //
-  // ALWAYS writes the query cache (so even empty chats have an entry,
-  // ensuring a cache hit on the next visit). By default, skips the
-  // React state update when messages are structurally identical
-  // (sameMessageList) — that's the path that was causing back-
-  // navigation jitter, because the background fetch would re-set the
-  // same array reference and trigger a redundant re-render of the
-  // spacer effect.
-  //
-  // The `force` option overrides that skip. Callers that originate
-  // state-machine transitions (e.g., promoteStreamToMessages doing a
-  // BRIDGE merge where catch-up content may match the DB partial
-  // byte-for-byte) MUST pass force=true. Without it, sameMessageList
-  // returns true on the structural match and setMessages is skipped
-  // — local state lags behind the cache, the UI keeps rendering the
-  // old version, and the only way to see the new one is to remount
-  // (which re-reads from the cache via useState initializer).
-  // Background-fetch callers leave force=false to keep the perf win.
-  const commitMessages = useCallback((updater, nextOffset, opts) => {
-    const force = opts?.force === true
-    const prev = messagesRef.current
-    const next = typeof updater === 'function' ? updater(prev) : updater
-    queryClient.setQueryData(chatMessagesQueryKey(chatId), (existing) => ({
-      ...(existing || {}),
-      // This composite is newer than the last complete detail read. Clearing
-      // its proof makes the next activation fail closed to one authoritative
-      // detail snapshot instead of treating local or streamed rows as a
-      // server-versioned response.
-      updated_at: null,
-      messages: next,
-      offset: nextOffset !== undefined ? nextOffset : (existing?.offset ?? 0),
-    }))
-    applyMessagesToView(next, nextOffset, force)
-  }, [applyMessagesToView, chatId, queryClient])
-
   // DOM refs
   const scrollRef = useRef(null)
-  const inputRef = useRef(null)
   const spacerRef = useRef(null)
   const lastUserMsgRef = useRef(null)
   // Stable callback ref attached to the last user message <div>. An
@@ -799,8 +672,6 @@ export default function ChatView({
   // If a POST's acknowledgement is lost, the composer is restored with the
   // same logical message identity. An unchanged retry reuses its cid so the
   // backend can acknowledge the durable row instead of starting a twin turn.
-  const failedSendAttemptRef = useRef(initialComposerRef.current.failedAttempt)
-
   // Ref mirrors of prop callbacks. doSend / doSendSilent are
   // memoized via useCallback; if these props were listed in the
   // deps array, every parent re-render that passed a fresh function
@@ -1472,47 +1343,6 @@ export default function ChatView({
       })
   }, [connectToStream, connectionError, isStreamingRef])
 
-  const {
-    files: pendingFiles,
-    addFiles,
-    removeFile,
-    clearFiles,
-    restoreFiles,
-    releaseFiles,
-  } = useFileUpload({
-    chatId,
-    initialFiles: initialComposerRef.current.attachments,
-    onFilesChange: nextFiles => {
-      draftAttachmentsRef.current = nextFiles
-      persistComposerDraft(chatId, inputValueRef.current, nextFiles)
-    },
-  })
-
-  useEffect(() => {
-    let cancelled = false
-    const revision = composerDraftRevision(chatId)
-    readComposerDraftAsync(chatId).then(saved => {
-      if (cancelled || composerDraftRevision(chatId) !== revision) return
-
-      const currentFiles = draftAttachmentsRef.current
-      const sameFiles = currentFiles.length === saved.attachments.length
-        && currentFiles.every((file, index) => {
-          const other = saved.attachments[index]
-          return file?.name === other?.name
-            && file?.size === other?.size
-            && file?.mime_type === other?.mime_type
-            && file?.status === other?.status
-        })
-      if (saved.input === inputValueRef.current && sameFiles) return
-
-      inputValueRef.current = saved.input
-      setInputState(saved.input)
-      draftAttachmentsRef.current = saved.attachments
-      restoreFiles(saved.attachments)
-    }).catch(() => {})
-    return () => { cancelled = true }
-  }, [chatId, restoreFiles])
-
   const wasHiddenRef = useRef(hidden)
   useLayoutEffect(() => {
     const becameVisible = wasHiddenRef.current && !hidden
@@ -1545,73 +1375,15 @@ export default function ChatView({
     // Composer drafts are chat-scoped across workspace worlds. A hidden retained
     // owner does not receive input events, so reconcile from the durable draft at
     // the visibility boundary before its first painted frame.
-    const saved = readComposerDraft(chatId)
-    if (saved.input !== inputValueRef.current) {
-      inputValueRef.current = saved.input
-      setInputState(saved.input)
-    }
-    restoreFiles(saved.attachments)
+    restoreDurableDraft()
   }, [
     chatId,
     commitMessages,
     hidden,
     pendingQueue.hydrate,
     queryClient,
-    restoreFiles,
+    restoreDurableDraft,
   ])
-
-  function clearFailedAttempt() {
-    if (!failedSendAttemptRef.current) return
-    failedSendAttemptRef.current = null
-    clearFailedSendAttempt(chatId)
-  }
-
-  function rememberFailedAttempt(attempt) {
-    failedSendAttemptRef.current = attempt
-    saveFailedSendAttempt(chatId, attempt)
-  }
-
-  // Reuse a failed attempt id only while the restored composer is genuinely
-  // untouched. Once the owner edits text or attachments—even if they later
-  // recreate the same visible draft—that is a new compose action and gets a
-  // new cid on send.
-  function handleComposerInputChange(nextInput) {
-    clearFailedAttempt()
-    setSendFailure(null)
-    setComposerInput(nextInput)
-  }
-
-  function handleComposerAddFiles(fileList) {
-    clearFailedAttempt()
-    setSendFailure(null)
-    return addFiles(fileList)
-  }
-
-  function handleComposerRemoveFile(fileId) {
-    clearFailedAttempt()
-    setSendFailure(null)
-    return removeFile(fileId)
-  }
-
-  function restoreComposerText(
-    text,
-    { focus = false, preserveFailedAttempt = false } = {},
-  ) {
-    if (preserveFailedAttempt) setComposerInput(text)
-    else handleComposerInputChange(text)
-    requestAnimationFrame(() => {
-      const el = inputRef.current
-      if (!el) return
-      resizeComposerTextarea(el, text)
-      if (focus) {
-        try { el.focus({ preventScroll: true }) }
-        catch { el.focus() }
-      }
-      const end = String(text).length
-      try { el.setSelectionRange(end, end) } catch {}
-      el.scrollTop = el.scrollHeight
-    })
-  }
 
   const {
     listening,

--- a/frontend/src/components/ChatView/__tests__/composerDraft.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerDraft.test.js
@@ -271,9 +271,12 @@ test('quota recovery sacrifices only transient cache and keeps every owner draft
 })
 
 test('the composer state boundary saves before scheduling React state', () => {
-  const source = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8')
-  const start = source.indexOf('function setComposerInput(nextInput)')
-  const end = source.indexOf('\n  }', start)
+  const source = readFileSync(
+    new URL('../hooks/useComposerDraftState.js', import.meta.url),
+    'utf8',
+  )
+  const start = source.indexOf('const setComposerInput = useCallback((nextInput) =>')
+  const end = source.indexOf('\n  }, [chatId])', start)
   const body = source.slice(start, end)
 
   const save = body.indexOf('persistComposerDraft(chatId, nextInput, draftAttachmentsRef.current)')

--- a/frontend/src/components/ChatView/__tests__/composerRenderIsolation.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerRenderIsolation.test.js
@@ -4,6 +4,10 @@ import { readFileSync } from 'node:fs'
 
 
 const chatView = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8')
+const composerOwner = readFileSync(
+  new URL('../hooks/useComposerDraftState.js', import.meta.url),
+  'utf8',
+)
 const activeSurface = readFileSync(
   new URL('../ActiveAssistantSurface.jsx', import.meta.url),
   'utf8',
@@ -22,13 +26,13 @@ test('composer edits cannot recreate the active assistant payload', () => {
 })
 
 test('draft persistence has one state-boundary owner', () => {
-  const setter = chatView.match(
-    /function setComposerInput\(nextInput\) \{[\s\S]*?\n  \}/,
+  const setter = composerOwner.match(
+    /const setComposerInput = useCallback\(\(nextInput\) => \{[\s\S]*?\n  \}, \[chatId\]\)/,
   )?.[0] || ''
   assert.match(setter, /persistComposerDraft\(/)
   assert.match(setter, /setInputState\(/)
   assert.doesNotMatch(
-    chatView,
+    composerOwner,
     /useEffect\(\(\) => \{\s*persistComposerDraft\(chatId, input,/,
   )
 })

--- a/frontend/src/components/ChatView/hooks/__tests__/react-hook-shim.mjs
+++ b/frontend/src/components/ChatView/hooks/__tests__/react-hook-shim.mjs
@@ -56,6 +56,23 @@ export function useState(initial) {
   return [slot.value, setter]
 }
 
+export function useReducer(reducer, initialArg, init) {
+  const i = _slotIndex++
+  if (_slots[i] === undefined) {
+    const slot = {
+      value: typeof init === 'function' ? init(initialArg) : initialArg,
+      dispatch: null,
+    }
+    slot.dispatch = (action) => {
+      slot.value = reducer(slot.value, action)
+      _rerender()
+    }
+    _slots[i] = slot
+  }
+  const slot = _slots[i]
+  return [slot.value, slot.dispatch]
+}
+
 export function useRef(initial) {
   const i = _slotIndex++
   if (_slots[i] === undefined) {
@@ -78,6 +95,22 @@ export function useCallback(fn, deps) {
     _slots[i].deps = deps
   }
   return _slots[i].fn
+}
+
+export function useMemo(factory, deps) {
+  const i = _slotIndex++
+  if (_slots[i] === undefined) {
+    _slots[i] = { value: factory(), deps }
+  } else if (
+    deps === undefined
+    || !Array.isArray(_slots[i].deps)
+    || deps.length !== _slots[i].deps.length
+    || deps.some((dep, idx) => !Object.is(dep, _slots[i].deps[idx]))
+  ) {
+    _slots[i].value = factory()
+    _slots[i].deps = deps
+  }
+  return _slots[i].value
 }
 
 function _scheduleEffect(fn, deps) {

--- a/frontend/src/components/ChatView/hooks/__tests__/useTranscriptState.test.js
+++ b/frontend/src/components/ChatView/hooks/__tests__/useTranscriptState.test.js
@@ -1,0 +1,65 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { renderHook } from './react-hook-shim.mjs'
+import useTranscriptState from '../useTranscriptState.js'
+
+function queryClientWith(initial) {
+  let value = initial
+  let writes = 0
+  return {
+    get value() { return value },
+    get writes() { return writes },
+    setQueryData(_key, updater) {
+      writes += 1
+      value = updater(value)
+    },
+  }
+}
+
+test('consecutive transcript commits compose through the synchronous owner ref', () => {
+  const queryClient = queryClientWith({ messages: [], offset: 0, updated_at: 'proof' })
+  const { result } = renderHook(useTranscriptState, {
+    cacheKey: ['chat-messages', 7],
+    cached: queryClient.value,
+    queryClient,
+  })
+
+  result.current.commitMessages(prev => [...prev, { ts: 1 }])
+  result.current.commitMessages(prev => [...prev, { ts: 2 }])
+
+  assert.deepEqual(result.current.messages, [{ ts: 1 }, { ts: 2 }])
+  assert.deepEqual(result.current.messagesRef.current, [{ ts: 1 }, { ts: 2 }])
+  assert.equal(queryClient.writes, 2)
+  assert.equal(queryClient.value.updated_at, null)
+})
+
+test('an authoritative view activation does not republish the query cache', () => {
+  const queryClient = queryClientWith({ messages: [{ ts: 1 }], offset: 0 })
+  const { result } = renderHook(useTranscriptState, {
+    cacheKey: ['chat-messages', 7],
+    cached: queryClient.value,
+    queryClient,
+  })
+
+  result.current.applyMessagesToView([{ ts: 1 }, { ts: 2 }], 12)
+
+  assert.deepEqual(result.current.messages, [{ ts: 1 }, { ts: 2 }])
+  assert.equal(result.current.offset, 12)
+  assert.equal(queryClient.writes, 0)
+})
+
+test('structurally identical commits still publish but avoid replacing view state', () => {
+  const first = [{ role: 'user', content: 'same', ts: 1 }]
+  const queryClient = queryClientWith({ messages: first, offset: 0 })
+  const { result } = renderHook(useTranscriptState, {
+    cacheKey: ['chat-messages', 7],
+    cached: queryClient.value,
+    queryClient,
+  })
+
+  result.current.commitMessages([{ ...first[0] }])
+
+  assert.equal(result.current.messages, first)
+  assert.equal(queryClient.writes, 1)
+  assert.notEqual(queryClient.value.messages, first)
+})

--- a/frontend/src/components/ChatView/hooks/useComposerDraftState.js
+++ b/frontend/src/components/ChatView/hooks/useComposerDraftState.js
@@ -1,0 +1,212 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  composerDraftRevision,
+  consumeComposerHandoff,
+  persistComposerDraft,
+  readComposerDraft,
+  readComposerDraftAsync,
+  readComposerHandoff,
+} from '../composerDraft.js'
+import {
+  clearFailedSendAttempt,
+  loadFailedSendAttempt,
+  saveFailedSendAttempt,
+} from '../sendAttemptRecovery.js'
+import { resizeComposerTextarea } from '../composerTextareaSizing.js'
+import useFileUpload from '../useFileUpload.js'
+
+function readInitialComposer(chatId, { acceptPending = true } = {}) {
+  try {
+    const failedAttempt = loadFailedSendAttempt(chatId)
+    const handoff = acceptPending
+      ? readComposerHandoff(chatId)
+      : { draft: null, autoSendDraft: null }
+    const pending = handoff.draft
+    if (pending && failedAttempt) clearFailedSendAttempt(chatId)
+    const saved = readComposerDraft(chatId)
+    const input = pending || failedAttempt?.text || saved.input
+    return {
+      input,
+      autoSend: !!input && handoff.autoSendDraft === input,
+      source: pending ? 'pending' : (failedAttempt ? 'failed' : 'saved'),
+      failedAttempt: pending ? null : failedAttempt,
+      attachments: pending ? [] : (failedAttempt?.attachments || saved.attachments),
+    }
+  } catch {
+    return {
+      input: '',
+      autoSend: false,
+      source: 'empty',
+      failedAttempt: null,
+      attachments: [],
+    }
+  }
+}
+
+/**
+ * Owns one chat's durable composer value, attachment draft, and ambiguous-send
+ * recovery identity. Every edit updates the ref and persistent draft before
+ * scheduling React state, so navigation cannot lose the latest value.
+ */
+export default function useComposerDraftState({ chatId, hidden, inputRef }) {
+  const initialRef = useRef(null)
+  if (!initialRef.current) {
+    initialRef.current = readInitialComposer(chatId, { acceptPending: !hidden })
+  }
+  const initial = initialRef.current
+  const draftAttachmentsRef = useRef(initial.attachments)
+  const [input, setInputState] = useState(() => initial.input)
+  const inputValueRef = useRef(input)
+  inputValueRef.current = input
+  const [sendFailure, setSendFailure] = useState(() => (
+    initial.failedAttempt
+      ? 'Möbius is checking whether your previous message reached the chat…'
+      : null
+  ))
+  const [pendingComposerSubmit, setPendingComposerSubmit] = useState(() => (
+    initial.autoSend
+      ? {
+          token: `stored-handoff:${chatId}`,
+          text: initial.input,
+          storedHandoff: true,
+        }
+      : null
+  ))
+  const submittedComposerRequestTokenRef = useRef(null)
+  const failedSendAttemptRef = useRef(initial.failedAttempt)
+
+  const setComposerInput = useCallback((nextInput) => {
+    inputValueRef.current = nextInput
+    persistComposerDraft(chatId, nextInput, draftAttachmentsRef.current)
+    setInputState(nextInput)
+  }, [chatId])
+
+  const {
+    files: pendingFiles,
+    addFiles,
+    removeFile,
+    clearFiles,
+    restoreFiles,
+    releaseFiles,
+  } = useFileUpload({
+    chatId,
+    initialFiles: initial.attachments,
+    onFilesChange: nextFiles => {
+      draftAttachmentsRef.current = nextFiles
+      persistComposerDraft(chatId, inputValueRef.current, nextFiles)
+    },
+  })
+
+  useEffect(() => {
+    if (hidden) return
+    if ((initial.source === 'pending' || initial.source === 'failed')
+        && (initial.input || initial.attachments.length > 0)) {
+      persistComposerDraft(chatId, initial.input, initial.attachments)
+    }
+    consumeComposerHandoff(chatId, initial.input)
+  }, [chatId, hidden, initial])
+
+  useEffect(() => {
+    let cancelled = false
+    const revision = composerDraftRevision(chatId)
+    readComposerDraftAsync(chatId).then(saved => {
+      if (cancelled || composerDraftRevision(chatId) !== revision) return
+      const currentFiles = draftAttachmentsRef.current
+      const sameFiles = currentFiles.length === saved.attachments.length
+        && currentFiles.every((file, index) => {
+          const other = saved.attachments[index]
+          return file?.name === other?.name
+            && file?.size === other?.size
+            && file?.mime_type === other?.mime_type
+            && file?.status === other?.status
+        })
+      if (saved.input === inputValueRef.current && sameFiles) return
+      inputValueRef.current = saved.input
+      setInputState(saved.input)
+      draftAttachmentsRef.current = saved.attachments
+      restoreFiles(saved.attachments)
+    }).catch(() => {})
+    return () => { cancelled = true }
+  }, [chatId, restoreFiles])
+
+  const clearFailedAttempt = useCallback(() => {
+    if (!failedSendAttemptRef.current) return
+    failedSendAttemptRef.current = null
+    clearFailedSendAttempt(chatId)
+  }, [chatId])
+
+  const rememberFailedAttempt = useCallback((attempt) => {
+    failedSendAttemptRef.current = attempt
+    saveFailedSendAttempt(chatId, attempt)
+  }, [chatId])
+
+  const handleComposerInputChange = useCallback((nextInput) => {
+    clearFailedAttempt()
+    setSendFailure(null)
+    setComposerInput(nextInput)
+  }, [clearFailedAttempt, setComposerInput])
+
+  const handleComposerAddFiles = useCallback((fileList) => {
+    clearFailedAttempt()
+    setSendFailure(null)
+    return addFiles(fileList)
+  }, [addFiles, clearFailedAttempt])
+
+  const handleComposerRemoveFile = useCallback((fileId) => {
+    clearFailedAttempt()
+    setSendFailure(null)
+    return removeFile(fileId)
+  }, [clearFailedAttempt, removeFile])
+
+  const restoreComposerText = useCallback((
+    text,
+    { focus = false, preserveFailedAttempt = false } = {},
+  ) => {
+    if (preserveFailedAttempt) setComposerInput(text)
+    else handleComposerInputChange(text)
+    requestAnimationFrame(() => {
+      const element = inputRef.current
+      if (!element) return
+      resizeComposerTextarea(element, text)
+      if (focus) {
+        try { element.focus({ preventScroll: true }) }
+        catch { element.focus() }
+      }
+      const end = String(text).length
+      try { element.setSelectionRange(end, end) } catch {}
+      element.scrollTop = element.scrollHeight
+    })
+  }, [handleComposerInputChange, inputRef, setComposerInput])
+
+  const restoreDurableDraft = useCallback(() => {
+    const saved = readComposerDraft(chatId)
+    if (saved.input !== inputValueRef.current) {
+      inputValueRef.current = saved.input
+      setInputState(saved.input)
+    }
+    restoreFiles(saved.attachments)
+  }, [chatId, restoreFiles])
+
+  return {
+    input,
+    inputValueRef,
+    setComposerInput,
+    sendFailure,
+    setSendFailure,
+    pendingComposerSubmit,
+    setPendingComposerSubmit,
+    submittedComposerRequestTokenRef,
+    failedSendAttemptRef,
+    clearFailedAttempt,
+    rememberFailedAttempt,
+    pendingFiles,
+    clearFiles,
+    restoreFiles,
+    releaseFiles,
+    handleComposerInputChange,
+    handleComposerAddFiles,
+    handleComposerRemoveFile,
+    restoreComposerText,
+    restoreDurableDraft,
+  }
+}

--- a/frontend/src/components/ChatView/hooks/useTranscriptState.js
+++ b/frontend/src/components/ChatView/hooks/useTranscriptState.js
@@ -1,0 +1,60 @@
+import { useCallback, useRef, useState } from 'react'
+import { sameMessageList } from '../chatMessageList.js'
+
+/**
+ * Owns the mounted transcript and its query-cache projection.
+ *
+ * The ref mirror is advanced synchronously before React state so consecutive
+ * mutations in one batch compose against the same authority. Cache publication
+ * happens exactly once per mutation and never from inside a React state updater.
+ * `applyMessagesToView` deliberately skips publication for an already-published
+ * authoritative activation snapshot.
+ */
+export default function useTranscriptState({ cacheKey, cached, queryClient }) {
+  const [messages, setMessages] = useState(() => cached?.messages ?? [])
+  const [offset, setOffset] = useState(() => cached?.offset ?? 0)
+  const messagesRef = useRef(messages)
+  const offsetRef = useRef(offset)
+  messagesRef.current = messages
+  offsetRef.current = offset
+
+  const applyMessagesToView = useCallback((next, nextOffset, force = false) => {
+    const prev = messagesRef.current
+    messagesRef.current = next
+    if (nextOffset !== undefined) offsetRef.current = nextOffset
+    if (!force && sameMessageList(prev, next)) {
+      if (nextOffset !== undefined) {
+        setOffset(current => current === nextOffset ? current : nextOffset)
+      }
+      return
+    }
+    setMessages(next)
+    if (nextOffset !== undefined) {
+      setOffset(current => current === nextOffset ? current : nextOffset)
+    }
+  }, [])
+
+  const commitMessages = useCallback((updater, nextOffset, opts) => {
+    const force = opts?.force === true
+    const prev = messagesRef.current
+    const next = typeof updater === 'function' ? updater(prev) : updater
+    queryClient.setQueryData(cacheKey, existing => ({
+      ...(existing || {}),
+      // Local and streamed composites are newer than the last complete detail
+      // read, so they cannot retain that response's authoritative version proof.
+      updated_at: null,
+      messages: next,
+      offset: nextOffset !== undefined ? nextOffset : (existing?.offset ?? 0),
+    }))
+    applyMessagesToView(next, nextOffset, force)
+  }, [applyMessagesToView, cacheKey, queryClient])
+
+  return {
+    messages,
+    messagesRef,
+    offset,
+    offsetRef,
+    applyMessagesToView,
+    commitMessages,
+  }
+}

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -20,7 +20,6 @@ import useNavigation, {
   coldRestoredCanvasAppId,
   deepLink,
 } from '../../hooks/useNavigation.js'
-import { replaceNavEntry } from '../../lib/navHistory.js'
 import { placeContextMenu } from '../../lib/contextMenuGeometry.js'
 import { parseNotificationTarget } from '../../lib/notificationTarget.js'
 import useSystemEventStream from '../../hooks/useSystemEventStream.js'
@@ -56,7 +55,6 @@ import {
   appUpdateStaleMessage,
   findAppStoreApp,
 } from '../../lib/appRecovery.js'
-import { BEFORE_SHELL_RELOAD_EVENT } from '../../lib/shellReloadEvents.js'
 import {
   acknowledgeAppActivity,
   appAttentionIds,
@@ -66,12 +64,10 @@ import {
   withAppsFlagged,
   withoutAppFlagged,
 } from './newAppAttention.js'
-import { shouldDeferShellReload } from './shellReloadPolicy.js'
 import {
   addCreatedChatToList,
   createdChatDetailCache,
   currentReusableEmptyChat,
-  enteredEmptySingleScreen,
   mergeChatListWithCreatedGuards,
   mostRecentConcreteChatId,
   reconcileCreatedChatGuard,
@@ -90,14 +86,9 @@ import {
   stageComposerHandoff,
 } from '../ChatView/composerDraft.js'
 import {
-  reloadWhenWorkerTakesOver,
   shouldRearmShellApply,
   watchForShellUpdateOnForeground,
 } from './swHandoff.js'
-import {
-  awaitCacheFlushBeforeReload,
-  flushPersistedQueryCache,
-} from '../../queryClient.js'
 import './Shell.css'
 import './workspace.css'
 import WorkspaceChrome from './WorkspaceChrome.jsx'
@@ -124,7 +115,7 @@ import {
 } from './builtAppState.js'
 import ErrorBoundary from '../ErrorBoundary/ErrorBoundary.jsx'
 import {
-  deriveContentVisibility, deriveModeSnapshotPlan, projectFocusedPane,
+  deriveContentVisibility, deriveModeSnapshotPlan,
   MODE_MOTION, EMPTY_SINGLE_SURFACE_KEY,
 } from './workspaceView.js'
 import NewChatLanding from './NewChatLanding.jsx'
@@ -136,10 +127,11 @@ import useAppIntentNavigation from './useAppIntentNavigation.js'
 import useDesktopSidebar, {
   desktopContentWidthAfterSidebarToggle,
 } from './useDesktopSidebar.js'
+import useWorkspaceSession from './useWorkspaceSession.js'
+import useShellReloadController from './useShellReloadController.js'
 import ShellBrand from './ShellBrand.jsx'
 import { HistoryDismissProvider } from '../../hooks/useHistoryDismiss.jsx'
 
-const SHELL_RELOAD_RECHECK_MS = 6000
 const APP_SETTINGS_SECTIONS = new Set([
   'ai-providers',
   'background-agents',
@@ -158,163 +150,31 @@ export default function Shell() {
     setWidth: setDesktopSidebarWidth,
   } = useDesktopSidebar()
 
-  // ── Workspace reducer — the single live authority for pane contents, per-pane
-  // active tabs, and focus (design §1). Declared ABOVE useNavigation so the
-  // adapter derives its legacy triple from it. Init: forgiving read of the
-  // versioned blob (readWorkspaceRaw guards the throwing sessionStorage.getItem
-  // before parseWorkspace's own try/catch), else the legacy flat seed.
-  // Capture the legacy projection once. Besides seeding a missing workspace, an
-  // empty value distinguishes the implicit home tab from a strip the user had
-  // actually engaged. The workspace still owns rendering either way.
-  const [legacyOpenTabs] = useState(() => tabModel.readOpenTabs())
-  const [workspaceState, dispatchWorkspaceRaw] = useReducer(
-    paneModel.workspaceReducer,
-    undefined,
-    () => paneModel.initialWorkspaceState(paneModel.parseWorkspace(
-      paneModel.readWorkspaceRaw(sessionStorage),
-      { fallbackTabs: legacyOpenTabs },
-    )),
-  )
-  const workspace = workspaceState.ws
-  // Whether a VALID persisted workspace blob booted this session (not a flat-tab
-  // fallback). The nav adapter uses it to make the blob authoritative over the
-  // legacy shell-reload triple, seeding from that triple only when absent/invalid
-  // (contract §5.3.10). Read once — sessionStorage is fixed for the mount.
-  const [blobValid] = useState(
-    () => paneModel.isValidWorkspaceBlob(paneModel.readWorkspaceRaw(sessionStorage)),
-  )
-  // A lone workspace tab with no legacy pinned projection is the shell's
-  // implicit home surface ONLY when there was no valid workspace blob. A valid
-  // single-screen workspace also deliberately dual-writes an empty legacy list;
-  // treating that durable state as implicit would RESET_FLAT on a cold deep link
-  // and silently flip its preserved viewMode back to the builder default.
-  const replaceImplicitBootTab = !blobValid
-    && legacyOpenTabs.length === 0
-    && Object.keys(workspace.panes).length === 1
-    && paneModel.flatten(workspace).length <= 1
-  // Ref-side reducer preview: this wrapper advances a ref copy of the reducer
-  // state SYNCHRONOUSLY before the raw React dispatch, so two navigation/
-  // placement events in one React 18 batch observe each other (design §1). Every
-  // caller uses this wrapper — no raw dispatch survives it.
-  const workspaceStateRef = useRef(workspaceState)
-  workspaceStateRef.current = workspaceState
-  // Shared "a workspace drag is live" flag. Declared ABOVE useNavigation so the
-  // drawer's OPEN path can stand down on it (useWorkspaceDrag sets it on arm and
-  // the Drawer's swipe-CLOSE handlers already read it).
-  const dragActiveRef = useRef(false)
-  // Set after useNavigation (needs navStackRef): reconciles in-memory restorable
-  // route hints against every workspace transition (design §5.1.3).
-  const onWorkspaceTransitionRef = useRef(null)
-  // Set once the New Chat policy has its chat/query dependencies. The synchronous
-  // workspace boundary can then own every edge into an empty single screen without
-  // making early navigation hooks depend on a callback declared later in the render.
-  const requestEmptySingleNewChatRef = useRef(null)
-  // Presentation state: which pane (if any) is maximized full-screen. It lives
-  // OUTSIDE the workspace blob so focusing a pane never rewrites the split tree or
-  // ratios — but it IS persisted to its own key and re-seeded here, so a maximize
-  // survives the apply-on-idle reload that fires while the tab is backgrounded
-  // (which otherwise dropped it, un-maximizing the pane on return). Seed the STATE
-  // and the REF together: dispatchWorkspace's reconcile reads the ref and short-
-  // circuits when it is null, so a state-only seed would fail to retarget/collapse
-  // the maximize on the first workspace mutation after boot.
-  const [focusedPaneViewId, setFocusedPaneViewIdState] = useState(
-    () => paneModel.resolveInitialFocusedPaneView(
-      workspace, paneModel.readFocusedPaneView(sessionStorage),
-    ),
-  )
-  const focusedPaneViewIdRef = useRef(focusedPaneViewId)
-  const setFocusedPaneViewId = useCallback((paneId) => {
-    focusedPaneViewIdRef.current = paneId
-    setFocusedPaneViewIdState(paneId)
-  }, [])
-  const dispatchWorkspace = useCallback((action) => {
-    const prev = workspaceStateRef.current
-    const next = paneModel.workspaceReducer(prev, action)
-    workspaceStateRef.current = next
-    // ANY tab-placement/pane transition can strand a route's paneId hint — a
-    // cross-pane move (even when the source pane survives) leaves the moved tab's
-    // routes pointing at the old pane, and a pane collapse leaves dead-pane hints.
-    // Reconcile them synchronously (using prev/next), before any restore reads
-    // them, so a hint always names the pane that now holds its item.
-    const enteredEmptySingle = next.ws !== prev.ws
-      && enteredEmptySingleScreen(
-        prev.ws, next.ws, paneModel.WORKSPACE_SPLITS_ENABLED,
-      )
-    if (next.ws !== prev.ws) {
-      onWorkspaceTransitionRef.current?.(prev.ws, next.ws)
-      const expanded = focusedPaneViewIdRef.current
-      if (expanded != null) {
-        const paneIds = Object.keys(next.ws.panes)
-        if (paneIds.length <= 1) {
-          setFocusedPaneViewId(null)
-        } else if (next.ws.focusedPaneId !== prev.ws.focusedPaneId
-            || !next.ws.panes[expanded]) {
-          setFocusedPaneViewId(next.ws.focusedPaneId)
-        }
-      }
-    }
-    dispatchWorkspaceRaw(action)
-    // Queue the reducer commit before policy state. React batches both, while the
-    // already-advanced ref still lets the request capture the pre-render chat target.
-    if (enteredEmptySingle) requestEmptySingleNewChatRef.current?.()
-  }, [setFocusedPaneViewId])
-
-  // ── Multi-pane projection (design §2/§4) — computed BEFORE useNavigation so
-  // the adapter learns the committed visible pane set. `contentRect` is the ONE
-  // geometry authority for projection. ResizeObserver keeps it aligned with
-  // external size changes; shell-owned desktop-sidebar toggles prime their target
-  // geometry before dispatch so CSS reservation + pane projection render once.
-  const contentElRef = useRef(null)
-  const [contentRect, setContentRect] = useState({ w: 0, h: 0 })
-  // A desktop-sidebar toggle can project the next rect before its CSS class
-  // commit. Hold that target across any already-queued ResizeObserver callback;
-  // the layout effect for the committed render settles it against real DOM.
-  const pendingContentRectRef = useRef(null)
-  // Read at placement-dispatch time (below) so the resolver derives the current
-  // device mode + pane rects without re-creating placeInWorkspace every resize.
-  const contentRectRef = useRef(contentRect)
-  contentRectRef.current = contentRect
-  const syncContentRect = useCallback(({ settlePending = false } = {}) => {
-    const el = contentElRef.current
-    if (!el) return
-    const w = Math.round(el.clientWidth)
-    const h = Math.round(el.clientHeight)
-    if (pendingContentRectRef.current && !settlePending) return
-    if (settlePending) pendingContentRectRef.current = null
-    setContentRect(prev => {
-      if (prev.w === w && prev.h === h) return prev
-      // Flag-off single-pane never tiles, so a content-size change would
-      // re-render Shell for a projection nothing reads. Skip it while the
-      // splits flag is off and the tree is a lone leaf (finding F).
-      if (!paneModel.WORKSPACE_SPLITS_ENABLED
-          && Object.keys(workspaceStateRef.current.ws.panes).length <= 1) return prev
-      return { w, h }
-    })
-  }, [])
-  useEffect(() => {
-    const el = contentElRef.current
-    if (!el || typeof ResizeObserver === 'undefined') return
-    // External layout changes (viewport, theme, browser chrome) still arrive
-    // through the observer. Shell-owned changes use the same commit helper in a
-    // layout effect, rather than waiting one painted frame for this callback.
-    const ro = new ResizeObserver(() => syncContentRect())
-    ro.observe(el)
-    return () => { ro.disconnect() }
-  }, [syncContentRect])
-  const workspaceMode = useMemo(() => paneModel.modeForRect(contentRect), [contentRect])
-  const baseProjection = useMemo(
-    () => paneModel.projectLayout(workspace, workspaceMode, contentRect),
-    [workspace, workspaceMode, contentRect],
-  )
-  const projection = useMemo(
-    () => projectFocusedPane(
-      baseProjection, workspace, focusedPaneViewId, contentRect,
-    ),
-    [baseProjection, workspace, focusedPaneViewId, contentRect],
-  )
-  // The committed visible pane set the nav adapter reads. Settings-open is
-  // applied separately inside isVisibleApp, so it is NOT excluded here.
-  const visiblePaneIds = useMemo(() => new Set(projection.visibleLeaves), [projection])
+  const {
+    legacyOpenTabs,
+    workspace,
+    workspaceStateRef,
+    dispatchWorkspace,
+    blobValid,
+    replaceImplicitBootTab,
+    dragActiveRef,
+    onWorkspaceTransitionRef,
+    requestEmptySingleNewChatRef,
+    focusedPaneViewId,
+    focusedPaneViewIdRef,
+    setFocusedPaneViewId,
+    toggleFocusedPaneView,
+    contentElRef,
+    contentRect,
+    contentRectRef,
+    primeContentRect,
+    syncContentRect,
+    workspaceMode,
+    baseProjection,
+    projection,
+    visiblePaneIds,
+    persistWorkspaceSnapshot,
+  } = useWorkspaceSession({ storage: sessionStorage })
 
   const {
     activeView,
@@ -360,9 +220,8 @@ export default function Shell() {
       sidebarWidth: desktopSidebarWidth,
     })
     const h = Math.round(el.clientHeight)
-    pendingContentRectRef.current = { w, h }
-    setContentRect(prev => (prev.w === w && prev.h === h ? prev : { w, h }))
-  }, [desktopSidebarReserved, desktopSidebarWidth])
+    primeContentRect({ w, h })
+  }, [desktopSidebarReserved, desktopSidebarWidth, primeContentRect])
   const closeDrawerRef = useRef(closeDrawer)
   closeDrawerRef.current = closeDrawer
   useEffect(() => {
@@ -418,28 +277,6 @@ export default function Shell() {
     }
   }, [workspace.viewMode, modeView.active, modeState.transition, setFocusedPaneViewId])
 
-  // Persist the maximized-pane presentation to its own key on every change so it
-  // survives the apply-on-idle reload (and a browser tab discard). Removing the
-  // key when nothing is maximized keeps a dismissed maximize from resurrecting on
-  // a later reload. Kept separate from the workspace-blob dual-write so focusing a
-  // pane never rewrites the tree/ratios.
-  useEffect(() => {
-    paneModel.writeFocusedPaneView(focusedPaneViewId, sessionStorage)
-  }, [focusedPaneViewId])
-
-  const toggleFocusedPaneView = useCallback((paneId) => {
-    const ws = workspaceStateRef.current.ws
-    if (!ws.panes[paneId] || Object.keys(ws.panes).length <= 1) {
-      setFocusedPaneViewId(null)
-      return
-    }
-    if (focusedPaneViewIdRef.current === paneId) {
-      setFocusedPaneViewId(null)
-      return
-    }
-    dispatchWorkspace({ type: 'FOCUS', paneId })
-    setFocusedPaneViewId(paneId)
-  }, [dispatchWorkspace, setFocusedPaneViewId])
   // Builder mode = the committed 'panes' world (logo twist + static brand cue + power
   // chrome), clamped off by the splits kill switch (INV 16). Flips synchronously
   // with the toggle, matching the gesture's own spring/snap.
@@ -769,12 +606,6 @@ export default function Shell() {
       return next
     })
   }, [])
-  const pendingShellReloadRef = useRef(false)
-  // False wins when several requests coalesce: an explicit shell_apply_now
-  // promotes an already-pending passive watcher rebuild to deliberate apply.
-  const pendingShellReloadPassiveRef = useRef(false)
-  const shellReloadTimerRef = useRef(null)
-  const lastShellInteractionAtRef = useRef(0)
   // Guards the once-per-mount deferred shell-update pickup effect below.
   const shellUpdatePickupRef = useRef(false)
   const shellUpdatePickupCheckStartedRef = useRef(false)
@@ -823,216 +654,6 @@ export default function Shell() {
     })
   }, [])
 
-  function shellReloadState() {
-    // Derive the compatibility triple from the freshest workspace at WRITE time,
-    // not the render-lagging active*Refs (§5.3.10): a workspace action previewed
-    // in the same React batch must not persist a fresh blob beside a stale triple.
-    // Settings is a global overlay tracked separately from pane content.
-    // CURRENT-WORLD projection (activeContentRoute): in single mode the reload
-    // triple must name the slot, not the hidden builder focus — the triple only
-    // seeds a boot with no valid workspace blob, and that boot lands in single
-    // mode showing the slot.
-    const content = paneModel.activeContentRoute(workspaceStateRef.current.ws)
-    return {
-      activeView: activeViewRef.current === 'settings' ? 'settings' : content.view,
-      activeAppId: content.appId,
-      activeChatId: content.chatId,
-      drawerOpen: drawerOpenRef.current,
-    }
-  }
-
-  async function performShellReload({ passive = false } = {}) {
-    let stalePrecache = false
-    try { stalePrecache = sessionStorage.getItem('sw-stale-precache-pending') === '1' } catch { /* ignore */ }
-    if (stalePrecache && navigator.onLine === false) {
-      // An offline reload is safe only while the existing precache remains
-      // intact; purging Workbox offline can strand an installed PWA on the
-      // fallback page, so stale recovery waits for an online idle boundary.
-      deferShellReload({ passive })
-      return
-    }
-    pendingShellReloadRef.current = false
-    pendingShellReloadPassiveRef.current = false
-    if (shellReloadTimerRef.current) {
-      clearTimeout(shellReloadTimerRef.current)
-      shellReloadTimerRef.current = null
-    }
-    // Capture view-owned transient state synchronously, before the async query
-    // flush or service-worker handoff can let layout/data change underneath it.
-    // ChatView uses this to persist the exact visible message anchor.
-    window.dispatchEvent(new Event(BEFORE_SHELL_RELOAD_EVENT))
-    // ChatView promotes terminal stream items into the in-memory query cache
-    // synchronously before it marks the shell idle. Normal IndexedDB writes
-    // are throttled, so a deferred rebuild can otherwise reload between those
-    // two phases and hydrate the previous partial. Flush the exact terminal
-    // cache as the reload handoff; the backend remains authoritative on the
-    // immediate background revalidation. This follows the synchronous event
-    // above so view-owned anchors are captured before the first await.
-    await awaitCacheFlushBeforeReload(flushPersistedQueryCache(queryClient))
-    // Workspace-first restore (§5.3.10): synchronously persist the latest
-    // workspace blob (tree/focus/active tabs are authoritative on boot) and the
-    // compatibility triple derived from its focused pane, so a valid blob wins
-    // over shellReload.active* and this handoff never destroys the just-persisted
-    // pane state.
-    try {
-      sessionStorage.setItem(
-        paneModel.STORAGE_KEY,
-        paneModel.serializeWorkspace(workspaceStateRef.current.ws),
-      )
-      // Capture the maximize from the REF (like the ws above): this runs after an
-      // await, so the render-closure focusedPaneViewId is stale. Keeping the (ws,
-      // maximize) pair from refs makes the persisted snapshot atomic.
-      paneModel.writeFocusedPaneView(focusedPaneViewIdRef.current, sessionStorage)
-    } catch { /* private mode / quota — the in-memory workspace still boots */ }
-    sessionStorage.setItem('shell-reload', JSON.stringify(shellReloadState()))
-    // Match the manifest scope so the post-reload page lands inside
-    // the installed PWA's declared scope — writing `/` here would
-    // briefly put the page out of scope and Chromium can refuse the
-    // next manifest update in-place.
-    replaceNavEntry('base', '/shell/')
-    // SW UPDATE LEASH (sw.js): the new service worker installed and is WAITING
-    // — it never skipWaiting()s on its own. THIS is the one moment we hand it
-    // control, so the SW generation flips exactly when the page generation does.
-    // Mark the reload page-initiated first so index.html's controllerchange
-    // handler treats any resulting controllerchange as OURS (an expected apply),
-    // not a spontaneous background SW flip to suppress.
-    try { sessionStorage.setItem('sw-skip-initiated', '1') } catch { /* ignore */ }
-
-    // Deferred stale-precache recovery (flagged by index.html at boot): a
-    // Chromium bug can keep serving the old precached index even after sw.js
-    // advertises a new bundle. Clearing Workbox's precache forces the reload to
-    // fall through to the network for index.html + the new hashed assets. Done
-    // HERE, at the same idle boundary as the reload, instead of index.html's old
-    // boot-time force-reload — so it can never blank a live turn.
-    if (stalePrecache) {
-      if (typeof caches !== 'undefined') {
-        try {
-          const keys = await caches.keys()
-          await Promise.all(
-            keys.filter(k => k.startsWith('workbox-precache-')).map(k => caches.delete(k)),
-          )
-        } catch { /* best-effort — the reload still self-heals via updateViaCache */ }
-      }
-      try { sessionStorage.removeItem('sw-stale-precache-pending') } catch { /* ignore */ }
-      // Loop-prevention: index.html's boot check reads this and skips
-      // re-flagging on the recovered load (then clears it).
-      try { sessionStorage.setItem('sw-stale-precache-recovering', '1') } catch { /* ignore */ }
-    }
-
-    // Hand control to the waiting worker (if any) and reload only once it has
-    // actually TAKEN OVER — the waiting worker reaching 'activated' (or a
-    // controllerchange), with a bounded fallback if the SW wedges. A blind
-    // ~220ms timer here used to reload before skipWaiting()->activate finished
-    // on a client's first update cycle, so the navigation was answered by the
-    // OUTGOING worker's precache and the page came back on the old generation
-    // and stuck (feature 207). No waiting worker (unchanged sw.js, e.g. a
-    // backend-only rebuild) → reload immediately: the reload alone re-fetches
-    // the current generation. The boot-time re-arm net (shouldRearmShellApply,
-    // mount effect below) still catches a stale landing if the fallback fires.
-    const doReload = () => window.location.reload()
-    if (navigator.serviceWorker?.getRegistration) {
-      navigator.serviceWorker.getRegistration()
-        .then(reg => reloadWhenWorkerTakesOver({
-          registration: reg,
-          serviceWorker: navigator.serviceWorker,
-          reload: doReload,
-        }))
-        .catch(doReload)
-    } else {
-      doReload()
-    }
-  }
-
-  function shellReloadWouldDisruptUser({ passive = false } = {}) {
-    return shouldDeferShellReload({
-      activeElement: document.activeElement,
-      activeView: activeViewRef.current,
-      activeChatId: activeChatIdRef.current,
-      multiPaneBuilderVisible: multiPaneBuilderVisibleRef.current,
-      streamingChatIds: streamingChatIdsRef.current,
-      passiveRebuild: passive,
-      voiceDictationActive: voiceDictationActiveRef.current,
-      lastUserInteractionAt: lastShellInteractionAtRef.current,
-      visibilityState: document.visibilityState,
-    })
-  }
-
-  function shellReloadHasStableVisibleHold(passive) {
-    if (document.visibilityState === 'hidden') return false
-    if (multiPaneBuilderVisibleRef.current) return true
-    return passive
-      && activeViewRef.current === 'chat'
-      && activeChatIdRef.current != null
-  }
-
-  function checkPendingShellReload() {
-    if (!pendingShellReloadRef.current) return
-    const passive = pendingShellReloadPassiveRef.current
-    if (shellReloadWouldDisruptUser({ passive })) {
-      // Stable visible holds (the whole Builder workspace, or a passive watcher
-      // while reading a chat) have no deadline. Wait for the view/mode/visibility
-      // effects below instead of waking the page every six seconds.
-      if (!shellReloadHasStableVisibleHold(passive)) scheduleShellReloadCheck()
-    } else {
-      performShellReload({ passive })
-    }
-  }
-
-  function scheduleShellReloadCheck() {
-    if (shellReloadTimerRef.current) clearTimeout(shellReloadTimerRef.current)
-    shellReloadTimerRef.current = setTimeout(() => {
-      shellReloadTimerRef.current = null
-      checkPendingShellReload()
-    }, SHELL_RELOAD_RECHECK_MS)
-  }
-
-  function deferShellReload({ passive = false } = {}) {
-    pendingShellReloadPassiveRef.current = pendingShellReloadRef.current
-      ? (pendingShellReloadPassiveRef.current && passive)
-      : passive
-    pendingShellReloadRef.current = true
-    if (!shellReloadHasStableVisibleHold(pendingShellReloadPassiveRef.current)) {
-      scheduleShellReloadCheck()
-    }
-  }
-
-  function requestShellReload({ passive = false } = {}) {
-    if (shellReloadWouldDisruptUser({ passive })) {
-      deferShellReload({ passive })
-    } else {
-      performShellReload({ passive })
-    }
-  }
-
-  useEffect(() => {
-    const record = () => { lastShellInteractionAtRef.current = Date.now() }
-    const releaseWhenHidden = () => {
-      if (document.visibilityState === 'hidden') checkPendingShellReload()
-    }
-    const opts = { capture: true, passive: true }
-    window.addEventListener('pointerdown', record, opts)
-    window.addEventListener('touchstart', record, opts)
-    window.addEventListener('keydown', record, opts)
-    window.addEventListener('input', record, opts)
-    window.addEventListener('focusin', record, opts)
-    document.addEventListener('visibilitychange', releaseWhenHidden)
-    return () => {
-      window.removeEventListener('pointerdown', record, opts)
-      window.removeEventListener('touchstart', record, opts)
-      window.removeEventListener('keydown', record, opts)
-      window.removeEventListener('input', record, opts)
-      window.removeEventListener('focusin', record, opts)
-      document.removeEventListener('visibilitychange', releaseWhenHidden)
-      if (shellReloadTimerRef.current) clearTimeout(shellReloadTimerRef.current)
-    }
-  }, [])
-
-  // Release a stable visible hold as soon as the owner leaves the chat surface
-  // or returns from Builder to Standard. Switching between chats remains
-  // protected for a passive generation.
-  useEffect(() => {
-    checkPendingShellReload()
-  }, [activeView, activeChatId, multiPaneBuilderVisible])
   // One shell-wide indicator owns the persistent offline explanation. Chat
   // still disables sends while unavailable, but does not repeat this status
   // beside the composer.
@@ -1830,6 +1451,26 @@ export default function Shell() {
   useEffect(() => {
     voiceDictationActiveRef.current = voiceDictationActive
   }, [voiceDictationActive])
+
+  const { requestShellReload } = useShellReloadController({
+    win: window,
+    doc: document,
+    nav: navigator,
+    storage: sessionStorage,
+    cacheStorage: typeof caches !== 'undefined' ? caches : null,
+    queryClient,
+    persistWorkspaceSnapshot,
+    workspaceStateRef,
+    activeViewRef,
+    activeChatIdRef,
+    drawerOpenRef,
+    multiPaneBuilderVisibleRef,
+    streamingChatIdsRef,
+    voiceDictationActiveRef,
+    activeView,
+    activeChatId,
+    multiPaneBuilderVisible,
+  })
 
   // Stable callbacks for ChatView — identity must not change across
   // renders or ChatView's onStreamEnd-handler memoization breaks. The

--- a/frontend/src/components/Shell/__tests__/modeReviewFixes.test.js
+++ b/frontend/src/components/Shell/__tests__/modeReviewFixes.test.js
@@ -13,6 +13,10 @@ import { modeReducer } from '../modeMachine.js'
 // tests/mode-transition.spec.mjs.
 
 const shell = readFileSync(new URL('../Shell.jsx', import.meta.url), 'utf8')
+const workspaceSession = readFileSync(
+  new URL('../useWorkspaceSession.js', import.meta.url),
+  'utf8',
+)
 const nav = readFileSync(new URL('../../../hooks/useNavigation.js', import.meta.url), 'utf8')
 const controller = readFileSync(new URL('../useModeController.js', import.meta.url), 'utf8')
 const scene = readFileSync(new URL('../useModeViewTransition.js', import.meta.url), 'utf8')
@@ -95,8 +99,8 @@ test('bypass hunt: concrete restores funnel; explicit-null restores use the empt
   // Tombstoned/semantic-home routes deliberately clear the slot directly. They are
   // safe because every workspace dispatch crosses the shared empty-single edge gate.
   assert.match(nav, /SET_SINGLE_SCREEN', item: null/)
-  assert.match(shell, /enteredEmptySingleScreen\(\s*prev\.ws, next\.ws/)
-  assert.match(shell, /requestEmptySingleNewChatRef\.current\?\.\(\)/)
+  assert.match(workspaceSession, /enteredEmptySingleScreen\(\s*prev\.ws, next\.ws/)
+  assert.match(workspaceSession, /requestEmptySingleNewChatRef\.current\?\.\(\)/)
 })
 
 // -- Finding F9 (expanding review): the chat repair/seed paths funnel too --------

--- a/frontend/src/components/Shell/__tests__/shellReloadController.test.js
+++ b/frontend/src/components/Shell/__tests__/shellReloadController.test.js
@@ -1,0 +1,39 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import * as paneModel from '../paneModel.js'
+import { deriveShellReloadState } from '../useShellReloadController.js'
+
+test('reload snapshot derives content from the current workspace authority', () => {
+  const workspace = paneModel.seedFromFlatTabs([
+    { kind: 'chat', id: 'older' },
+    { kind: 'app', id: 42 },
+  ])
+
+  assert.deepEqual(deriveShellReloadState({
+    workspace,
+    activeView: 'canvas',
+    drawerOpen: true,
+  }), {
+    activeView: 'canvas',
+    activeAppId: 42,
+    activeChatId: null,
+    drawerOpen: true,
+  })
+})
+
+test('settings takeover changes only the reload surface, not workspace content ids', () => {
+  const workspace = paneModel.seedFromFlatTabs([
+    { kind: 'chat', id: 'kept' },
+  ])
+
+  assert.deepEqual(deriveShellReloadState({
+    workspace,
+    activeView: 'settings',
+    drawerOpen: false,
+  }), {
+    activeView: 'settings',
+    activeAppId: null,
+    activeChatId: 'kept',
+    drawerOpen: false,
+  })
+})

--- a/frontend/src/components/Shell/__tests__/useWorkspaceSession.hooktest.js
+++ b/frontend/src/components/Shell/__tests__/useWorkspaceSession.hooktest.js
@@ -1,0 +1,78 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { renderHook } from '../../ChatView/hooks/__tests__/react-hook-shim.mjs'
+import useWorkspaceSession from '../useWorkspaceSession.js'
+import * as paneModel from '../paneModel.js'
+
+function memoryStorage(seed = {}) {
+  const values = new Map(Object.entries(seed))
+  return {
+    getItem(key) {
+      return values.has(key) ? values.get(key) : null
+    },
+    setItem(key, value) {
+      values.set(key, String(value))
+    },
+    removeItem(key) {
+      values.delete(key)
+    },
+  }
+}
+
+test('workspace owner composes transitions through one synchronous dispatch boundary', () => {
+  const storage = memoryStorage()
+  const { result } = renderHook(useWorkspaceSession, { storage })
+  const paneId = result.current.workspace.focusedPaneId
+
+  result.current.dispatchWorkspace({
+    type: 'OPEN_TAB',
+    paneId,
+    tab: { kind: 'chat', id: 'first' },
+  })
+  result.current.dispatchWorkspace({
+    type: 'OPEN_TAB',
+    paneId,
+    tab: { kind: 'chat', id: 'second' },
+  })
+
+  assert.deepEqual(
+    paneModel.flatten(result.current.workspace).map(tab => tab.id),
+    ['first', 'second'],
+  )
+  assert.equal(result.current.workspaceStateRef.current.ws, result.current.workspace)
+})
+
+test('workspace owner publishes transition policy hooks without owning their policy', () => {
+  const storage = memoryStorage()
+  const { result } = renderHook(useWorkspaceSession, { storage })
+  const transitions = []
+  result.current.onWorkspaceTransitionRef.current = (prev, next) => {
+    transitions.push([prev, next])
+  }
+
+  result.current.dispatchWorkspace({
+    type: 'OPEN_TAB',
+    paneId: result.current.workspace.focusedPaneId,
+    tab: { kind: 'app', id: 42 },
+  })
+
+  assert.equal(transitions.length, 1)
+  assert.notEqual(transitions[0][0], transitions[0][1])
+})
+
+test('reload snapshot persists the ref-current workspace, not a stale render closure', () => {
+  const storage = memoryStorage()
+  const { result } = renderHook(useWorkspaceSession, { storage })
+
+  result.current.dispatchWorkspace({
+    type: 'OPEN_TAB',
+    paneId: result.current.workspace.focusedPaneId,
+    tab: { kind: 'chat', id: 'durable' },
+  })
+  result.current.persistWorkspaceSnapshot()
+
+  const restored = paneModel.parseWorkspace(
+    storage.getItem(paneModel.STORAGE_KEY),
+  )
+  assert.deepEqual(paneModel.flatten(restored).map(tab => tab.id), ['durable'])
+})

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -7,6 +7,10 @@ const css = readFileSync(
   'utf8',
 )
 const shell = readFileSync(new URL('../Shell.jsx', import.meta.url), 'utf8')
+const workspaceSession = readFileSync(
+  new URL('../useWorkspaceSession.js', import.meta.url),
+  'utf8',
+)
 const shellBrand = readFileSync(new URL('../ShellBrand.jsx', import.meta.url), 'utf8')
 const newChatLanding = readFileSync(new URL('../NewChatLanding.jsx', import.meta.url), 'utf8')
 const workspaceViewSrc = readFileSync(new URL('../workspaceView.js', import.meta.url), 'utf8')
@@ -67,7 +71,7 @@ test('an implicit home tab does not engage the single-pane tab strip', () => {
   // Only a fallback workspace may be treated as implicit. A valid one-leaf
   // single-screen blob intentionally has an empty legacy mirror; resetting it
   // on a deep link would silently change its view mode back to builder.
-  assert.match(shell, /const replaceImplicitBootTab = !blobValid\s*\n?\s*&& legacyOpenTabs\.length === 0/)
+  assert.match(workspaceSession, /const replaceImplicitBootTab = !blobValid\s*\n?\s*&& legacyOpenTabs\.length === 0/)
   assert.match(shell, /const \[tabStripEngaged, setTabStripEngaged\] = useState\(legacyOpenTabs\.length > 0\)/)
   assert.match(shell, /if \(openTabs\.length >= 2\) setTabStripEngaged\(true\)/)
   assert.match(shell, /else if \(openTabs\.length === 0\) setTabStripEngaged\(false\)/)
@@ -1135,7 +1139,9 @@ test('round4-3: requestEmptySingleNewChat records a tokenized request and does N
 })
 
 test('round4-3: every reducer edge into an empty single screen uses one policy boundary', () => {
-  const dispatch = shell.match(/const dispatchWorkspace = useCallback\(\(action\) => \{[\s\S]*?\}, \[\]\)/)?.[0] || ''
+  const dispatch = workspaceSession.match(
+    /const dispatchWorkspace = useCallback\(\(action\) => \{[\s\S]*?\}, \[setFocusedPaneViewId\]\)/,
+  )?.[0] || ''
   assert.ok(dispatch.length > 0, 'found the workspace dispatch boundary')
   assert.match(dispatch, /workspaceReducer\(prev, action\)/)
   assert.match(dispatch, /enteredEmptySingleScreen\(\s*prev\.ws, next\.ws/)

--- a/frontend/src/components/Shell/useShellReloadController.js
+++ b/frontend/src/components/Shell/useShellReloadController.js
@@ -1,0 +1,211 @@
+import { useCallback, useEffect, useRef } from 'react'
+import { replaceNavEntry } from '../../lib/navHistory.js'
+import { BEFORE_SHELL_RELOAD_EVENT } from '../../lib/shellReloadEvents.js'
+import {
+  awaitCacheFlushBeforeReload,
+  flushPersistedQueryCache,
+} from '../../queryClient.js'
+import * as paneModel from './paneModel.js'
+import { shouldDeferShellReload } from './shellReloadPolicy.js'
+import { reloadWhenWorkerTakesOver } from './swHandoff.js'
+
+const RECHECK_MS = 6000
+
+export function deriveShellReloadState({
+  workspace,
+  activeView,
+  drawerOpen,
+}) {
+  const content = paneModel.activeContentRoute(workspace)
+  return {
+    activeView: activeView === 'settings' ? 'settings' : content.view,
+    activeAppId: content.appId,
+    activeChatId: content.chatId,
+    drawerOpen,
+  }
+}
+
+/**
+ * Owns the apply-on-idle shell-generation handoff.
+ *
+ * All delayed work reads `inputsRef`, so timers and service-worker callbacks
+ * cannot serialize a render-time workspace or liveness snapshot. Explicit
+ * apply requests promote coalesced passive watcher requests.
+ */
+export default function useShellReloadController(inputs) {
+  const inputsRef = useRef(inputs)
+  inputsRef.current = inputs
+  const pendingRef = useRef(false)
+  const passiveRef = useRef(false)
+  const timerRef = useRef(null)
+  const lastInteractionAtRef = useRef(0)
+
+  function hasStableVisibleHold(passive) {
+    const { doc, multiPaneBuilderVisibleRef, activeViewRef, activeChatIdRef } = inputsRef.current
+    if (doc.visibilityState === 'hidden') return false
+    if (multiPaneBuilderVisibleRef.current) return true
+    return passive
+      && activeViewRef.current === 'chat'
+      && activeChatIdRef.current != null
+  }
+
+  function wouldDisruptUser({ passive = false } = {}) {
+    const {
+      doc,
+      activeViewRef,
+      activeChatIdRef,
+      multiPaneBuilderVisibleRef,
+      streamingChatIdsRef,
+      voiceDictationActiveRef,
+    } = inputsRef.current
+    return shouldDeferShellReload({
+      activeElement: doc.activeElement,
+      activeView: activeViewRef.current,
+      activeChatId: activeChatIdRef.current,
+      multiPaneBuilderVisible: multiPaneBuilderVisibleRef.current,
+      streamingChatIds: streamingChatIdsRef.current,
+      passiveRebuild: passive,
+      voiceDictationActive: voiceDictationActiveRef.current,
+      lastUserInteractionAt: lastInteractionAtRef.current,
+      visibilityState: doc.visibilityState,
+    })
+  }
+
+  function scheduleCheck() {
+    const { win } = inputsRef.current
+    if (timerRef.current) win.clearTimeout(timerRef.current)
+    timerRef.current = win.setTimeout(() => {
+      timerRef.current = null
+      checkPendingImpl()
+    }, RECHECK_MS)
+  }
+
+  function deferReload({ passive = false } = {}) {
+    passiveRef.current = pendingRef.current
+      ? (passiveRef.current && passive)
+      : passive
+    pendingRef.current = true
+    if (!hasStableVisibleHold(passiveRef.current)) scheduleCheck()
+  }
+
+  async function performReload({ passive = false } = {}) {
+    const {
+      win,
+      nav,
+      storage,
+      cacheStorage,
+      queryClient,
+      persistWorkspaceSnapshot,
+      workspaceStateRef,
+      activeViewRef,
+      drawerOpenRef,
+    } = inputsRef.current
+    let stalePrecache = false
+    try { stalePrecache = storage.getItem('sw-stale-precache-pending') === '1' } catch { /* ignore */ }
+    if (stalePrecache && nav.onLine === false) {
+      deferReload({ passive })
+      return
+    }
+    pendingRef.current = false
+    passiveRef.current = false
+    if (timerRef.current) {
+      win.clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+
+    win.dispatchEvent(new win.Event(BEFORE_SHELL_RELOAD_EVENT))
+    await awaitCacheFlushBeforeReload(flushPersistedQueryCache(queryClient))
+    persistWorkspaceSnapshot()
+    storage.setItem('shell-reload', JSON.stringify(deriveShellReloadState({
+      workspace: workspaceStateRef.current.ws,
+      activeView: activeViewRef.current,
+      drawerOpen: drawerOpenRef.current,
+    })))
+    replaceNavEntry('base', '/shell/')
+    try { storage.setItem('sw-skip-initiated', '1') } catch { /* ignore */ }
+
+    if (stalePrecache) {
+      if (cacheStorage) {
+        try {
+          const keys = await cacheStorage.keys()
+          await Promise.all(
+            keys
+              .filter(key => key.startsWith('workbox-precache-'))
+              .map(key => cacheStorage.delete(key)),
+          )
+        } catch { /* best effort */ }
+      }
+      try { storage.removeItem('sw-stale-precache-pending') } catch { /* ignore */ }
+      try { storage.setItem('sw-stale-precache-recovering', '1') } catch { /* ignore */ }
+    }
+
+    const reload = () => win.location.reload()
+    if (nav.serviceWorker?.getRegistration) {
+      nav.serviceWorker.getRegistration()
+        .then(registration => reloadWhenWorkerTakesOver({
+          registration,
+          serviceWorker: nav.serviceWorker,
+          reload,
+        }))
+        .catch(reload)
+    } else {
+      reload()
+    }
+  }
+
+  function checkPendingImpl() {
+    if (!pendingRef.current) return
+    const passive = passiveRef.current
+    if (wouldDisruptUser({ passive })) {
+      if (!hasStableVisibleHold(passive)) scheduleCheck()
+      return
+    }
+    performReload({ passive })
+  }
+
+  const checkPendingShellReload = useCallback(() => {
+    checkPendingImpl()
+  }, [])
+
+  const requestShellReload = useCallback(({ passive = false } = {}) => {
+    if (wouldDisruptUser({ passive })) {
+      deferReload({ passive })
+    } else {
+      performReload({ passive })
+    }
+  }, [])
+
+  useEffect(() => {
+    const { win, doc } = inputsRef.current
+    const record = () => { lastInteractionAtRef.current = Date.now() }
+    const releaseWhenHidden = () => {
+      if (doc.visibilityState === 'hidden') checkPendingImpl()
+    }
+    const opts = { capture: true, passive: true }
+    win.addEventListener('pointerdown', record, opts)
+    win.addEventListener('touchstart', record, opts)
+    win.addEventListener('keydown', record, opts)
+    win.addEventListener('input', record, opts)
+    win.addEventListener('focusin', record, opts)
+    doc.addEventListener('visibilitychange', releaseWhenHidden)
+    return () => {
+      win.removeEventListener('pointerdown', record, opts)
+      win.removeEventListener('touchstart', record, opts)
+      win.removeEventListener('keydown', record, opts)
+      win.removeEventListener('input', record, opts)
+      win.removeEventListener('focusin', record, opts)
+      doc.removeEventListener('visibilitychange', releaseWhenHidden)
+      if (timerRef.current) win.clearTimeout(timerRef.current)
+    }
+  }, [])
+
+  useEffect(() => {
+    checkPendingImpl()
+  }, [
+    inputs.activeView,
+    inputs.activeChatId,
+    inputs.multiPaneBuilderVisible,
+  ])
+
+  return { requestShellReload, checkPendingShellReload }
+}

--- a/frontend/src/components/Shell/useWorkspaceSession.js
+++ b/frontend/src/components/Shell/useWorkspaceSession.js
@@ -1,0 +1,194 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+} from 'react'
+import * as tabModel from './tabModel.js'
+import * as paneModel from './paneModel.js'
+import { enteredEmptySingleScreen } from './newChatPolicy.js'
+import { projectFocusedPane } from './workspaceView.js'
+
+/**
+ * The live owner of workspace state, synchronous transition previews, persisted
+ * presentation state, and content-geometry projection.
+ *
+ * Callers may attach navigation and New Chat policies through the returned refs
+ * without moving those policies into the reducer. Every workspace mutation must
+ * use dispatchWorkspace so same-batch transitions compose against workspaceStateRef.
+ */
+export default function useWorkspaceSession({ storage }) {
+  const [legacyOpenTabs] = useState(() => tabModel.readOpenTabs(storage))
+  const [workspaceState, dispatchWorkspaceRaw] = useReducer(
+    paneModel.workspaceReducer,
+    undefined,
+    () => paneModel.initialWorkspaceState(paneModel.parseWorkspace(
+      paneModel.readWorkspaceRaw(storage),
+      { fallbackTabs: legacyOpenTabs },
+    )),
+  )
+  const workspace = workspaceState.ws
+  const [blobValid] = useState(
+    () => paneModel.isValidWorkspaceBlob(paneModel.readWorkspaceRaw(storage)),
+  )
+  const replaceImplicitBootTab = !blobValid
+    && legacyOpenTabs.length === 0
+    && Object.keys(workspace.panes).length === 1
+    && paneModel.flatten(workspace).length <= 1
+
+  const workspaceStateRef = useRef(workspaceState)
+  workspaceStateRef.current = workspaceState
+  const dragActiveRef = useRef(false)
+  const onWorkspaceTransitionRef = useRef(null)
+  const requestEmptySingleNewChatRef = useRef(null)
+
+  const [focusedPaneViewId, setFocusedPaneViewIdState] = useState(
+    () => paneModel.resolveInitialFocusedPaneView(
+      workspace, paneModel.readFocusedPaneView(storage),
+    ),
+  )
+  const focusedPaneViewIdRef = useRef(focusedPaneViewId)
+  const setFocusedPaneViewId = useCallback((paneId) => {
+    focusedPaneViewIdRef.current = paneId
+    setFocusedPaneViewIdState(paneId)
+  }, [])
+
+  const dispatchWorkspace = useCallback((action) => {
+    const prev = workspaceStateRef.current
+    const next = paneModel.workspaceReducer(prev, action)
+    workspaceStateRef.current = next
+    const enteredEmptySingle = next.ws !== prev.ws
+      && enteredEmptySingleScreen(
+        prev.ws, next.ws, paneModel.WORKSPACE_SPLITS_ENABLED,
+      )
+    if (next.ws !== prev.ws) {
+      onWorkspaceTransitionRef.current?.(prev.ws, next.ws)
+      const expanded = focusedPaneViewIdRef.current
+      if (expanded != null) {
+        const paneIds = Object.keys(next.ws.panes)
+        if (paneIds.length <= 1) {
+          setFocusedPaneViewId(null)
+        } else if (next.ws.focusedPaneId !== prev.ws.focusedPaneId
+            || !next.ws.panes[expanded]) {
+          setFocusedPaneViewId(next.ws.focusedPaneId)
+        }
+      }
+    }
+    dispatchWorkspaceRaw(action)
+    if (enteredEmptySingle) requestEmptySingleNewChatRef.current?.()
+  }, [setFocusedPaneViewId])
+
+  const contentElRef = useRef(null)
+  const [contentRect, setContentRect] = useState({ w: 0, h: 0 })
+  const pendingContentRectRef = useRef(null)
+  const contentRectRef = useRef(contentRect)
+  contentRectRef.current = contentRect
+
+  const syncContentRect = useCallback(({ settlePending = false } = {}) => {
+    const el = contentElRef.current
+    if (!el) return
+    const w = Math.round(el.clientWidth)
+    const h = Math.round(el.clientHeight)
+    if (pendingContentRectRef.current && !settlePending) return
+    if (settlePending) pendingContentRectRef.current = null
+    setContentRect(prev => {
+      if (prev.w === w && prev.h === h) return prev
+      if (!paneModel.WORKSPACE_SPLITS_ENABLED
+          && Object.keys(workspaceStateRef.current.ws.panes).length <= 1) return prev
+      return { w, h }
+    })
+  }, [])
+
+  const primeContentRect = useCallback((nextRect) => {
+    const w = Math.round(nextRect?.w || 0)
+    const h = Math.round(nextRect?.h || 0)
+    pendingContentRectRef.current = { w, h }
+    setContentRect(prev => (prev.w === w && prev.h === h ? prev : { w, h }))
+  }, [])
+
+  useEffect(() => {
+    const el = contentElRef.current
+    if (!el || typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver(() => syncContentRect())
+    observer.observe(el)
+    return () => { observer.disconnect() }
+  }, [syncContentRect])
+
+  const workspaceMode = useMemo(
+    () => paneModel.modeForRect(contentRect),
+    [contentRect],
+  )
+  const baseProjection = useMemo(
+    () => paneModel.projectLayout(workspace, workspaceMode, contentRect),
+    [workspace, workspaceMode, contentRect],
+  )
+  const projection = useMemo(
+    () => projectFocusedPane(
+      baseProjection, workspace, focusedPaneViewId, contentRect,
+    ),
+    [baseProjection, workspace, focusedPaneViewId, contentRect],
+  )
+  const visiblePaneIds = useMemo(
+    () => new Set(projection.visibleLeaves),
+    [projection],
+  )
+
+  useEffect(() => {
+    paneModel.writeFocusedPaneView(focusedPaneViewId, storage)
+  }, [focusedPaneViewId, storage])
+
+  const toggleFocusedPaneView = useCallback((paneId) => {
+    const ws = workspaceStateRef.current.ws
+    if (!ws.panes[paneId] || Object.keys(ws.panes).length <= 1) {
+      setFocusedPaneViewId(null)
+      return
+    }
+    if (focusedPaneViewIdRef.current === paneId) {
+      setFocusedPaneViewId(null)
+      return
+    }
+    dispatchWorkspace({ type: 'FOCUS', paneId })
+    setFocusedPaneViewId(paneId)
+  }, [dispatchWorkspace, setFocusedPaneViewId])
+
+  const persistWorkspaceSnapshot = useCallback(() => {
+    try {
+      storage.setItem(
+        paneModel.STORAGE_KEY,
+        paneModel.serializeWorkspace(workspaceStateRef.current.ws),
+      )
+      paneModel.writeFocusedPaneView(focusedPaneViewIdRef.current, storage)
+    } catch {
+      // Private mode/quota may reject writes; the mounted in-memory owner remains
+      // authoritative for this session.
+    }
+  }, [storage])
+
+  return {
+    legacyOpenTabs,
+    workspace,
+    workspaceStateRef,
+    dispatchWorkspace,
+    blobValid,
+    replaceImplicitBootTab,
+    dragActiveRef,
+    onWorkspaceTransitionRef,
+    requestEmptySingleNewChatRef,
+    focusedPaneViewId,
+    focusedPaneViewIdRef,
+    setFocusedPaneViewId,
+    toggleFocusedPaneView,
+    contentElRef,
+    contentRect,
+    contentRectRef,
+    primeContentRect,
+    syncContentRect,
+    workspaceMode,
+    baseProjection,
+    projection,
+    visiblePaneIds,
+    persistWorkspaceSnapshot,
+  }
+}

--- a/frontend/src/lib/__tests__/navigationWorkspaceContract.test.js
+++ b/frontend/src/lib/__tests__/navigationWorkspaceContract.test.js
@@ -9,6 +9,10 @@ const src = resolve(here, '../..')
 const navigation = readFileSync(resolve(src, 'hooks/useNavigation.js'), 'utf8')
 const canvas = readFileSync(resolve(src, 'components/AppCanvas/AppCanvas.jsx'), 'utf8')
 const shell = readFileSync(resolve(src, 'components/Shell/Shell.jsx'), 'utf8')
+const workspaceSession = readFileSync(
+  resolve(src, 'components/Shell/useWorkspaceSession.js'),
+  'utf8',
+)
 const frame = readFileSync(resolve(src, '../public/app-frame.html'), 'utf8')
 
 test('one open drawer owns at most one physical sentinel', () => {
@@ -138,7 +142,7 @@ test('pointer input inside an opaque app frame focuses its owning pane', () => {
 
 test('an explicit deep link replaces only a fallback implicit home tab', () => {
   assert.match(
-    shell,
+    workspaceSession,
     /const replaceImplicitBootTab = !blobValid[\s\S]*legacyOpenTabs\.length === 0[\s\S]*paneModel\.flatten\(workspace\)\.length <= 1/,
   )
   assert.match(


### PR DESCRIPTION
## Summary
- extract transcript and composer-draft ownership from the chat surface
- extract workspace-session and shell-reload ownership from the shell component
- preserve synchronous ref mirrors so same-batch transitions compose without stale render closures
- add focused owner-boundary tests while keeping navigation and reload policy at their existing layers

## Verification
- frontend unit suite: 2,206 passed
- frontend hook suite: 72 passed
- production frontend and offline service-worker build passed
- canonical diff, whitespace, and privacy scans passed

The complete hosted frontend, backend, and end-to-end checks must pass before merge.