### PR TITLE
Separate provider lifecycle from event translation

### DIFF
--- a/backend/app/claude_events.py
+++ b/backend/app/claude_events.py
@@ -1,0 +1,518 @@
+"""Claude SDK messages translated into stable Möbius wire events.
+
+This module owns provider message interpretation only. Process acquisition, turn
+control, permission callbacks, and retry policy remain in ``claude_sdk_runner``.
+Keeping the translation matrix independent makes SDK shape changes testable
+without entering the long-lived runner lifecycle.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import Any
+
+from claude_agent_sdk.types import (
+  AssistantMessage,
+  RateLimitEvent,
+  ResultMessage,
+  ServerToolResultBlock,
+  ServerToolUseBlock,
+  StreamEvent,
+  SystemMessage,
+  TaskNotificationMessage,
+  TaskProgressMessage,
+  TaskStartedMessage,
+  TextBlock,
+  ThinkingBlock,
+  ToolResultBlock,
+  ToolUseBlock,
+  UserMessage,
+)
+
+try:
+  from claude_agent_sdk.types import TERMINAL_TASK_STATUSES, TaskUpdatedMessage
+except ImportError:
+  TERMINAL_TASK_STATUSES = frozenset()
+  TaskUpdatedMessage = None
+
+from app import activity
+from app.sdk_emit import emit_unknown_enabled, unknown_event
+from app.tool_summaries import summarize_tool_input
+from app.tool_sources import normalize_tool_sources, sources_from_websearch_text
+from app.usage_metrics import normalize_claude_usage
+
+log = logging.getLogger(__name__)
+
+# Bounds for the subagent task_* text fields. Unlike ordinary tool output these
+# never pass through the excerpt/stash reducer, so they are clipped at emission
+# to keep an oversized provider string off the wire, the in-memory event log,
+# and Chat.messages. A description/summary is a one-line label + short outcome; a
+# last_tool_name is a tool name — both are generous.
+_TASK_TEXT_CAP = 2000
+_TASK_LABEL_CAP = 200
+
+
+def _clip_task_text(value: object, cap: int) -> str | None:
+  """Coerce a task_* text field to a bounded string (or None).
+
+  None passes through as None (a genuinely absent field). Anything else is
+  str()-coerced — so SDK shape drift that hands us a non-string can't ride
+  through to a React child and crash the render — then truncated to ``cap``.
+  """
+  if value is None:
+    return None
+  text = value if isinstance(value, str) else str(value)
+  if len(text) > cap:
+    return text[: cap - 1] + "…"
+  return text
+
+
+def _thinking_event(content: str, segment_id: str | None = None) -> dict:
+  """Build a reasoning delta, preserving its content-block identity."""
+  event = {
+    "type": "thinking",
+    "content": content,
+    "ts": int(time.time() * 1000),
+  }
+  if segment_id:
+    event["segment_id"] = segment_id
+  return event
+
+
+def _skill_name_from_input(input_data: Any) -> str:
+  """Extracts the loaded skill's name from a Skill tool_use input.
+
+  The Skill tool's input is `{"skill": "<name>", "args": "..."}` — the
+  skill name lives under the `skill` key. Older / plugin-namespaced
+  forms can carry it as `command` (the slash-command name), so fall
+  back to that. Returns an empty string when neither is present so the
+  caller can decide not to emit an empty chip.
+  """
+  if not isinstance(input_data, dict):
+    return ""
+  name = input_data.get("skill") or input_data.get("command") or ""
+  return name.strip() if isinstance(name, str) else ""
+
+
+def _result_error_message(result: ResultMessage) -> str:
+  """Builds a user-facing error string from an SDK result."""
+  if isinstance(result.result, str) and result.result.strip():
+    return result.result.strip()
+  if result.errors:
+    # The bundled CLI attaches an internal `[ede_diagnostic] ...
+    # stop_reason=tool_use/null` entry whenever its end-of-turn
+    # validator trips — which it does on a Möbius-initiated interrupt
+    # (the message list ends on a synthetic user-interrupt entry), not
+    # only on real failures. Surfacing that raw string renders a scary
+    # red error block for what was a clean Stop, eroding trust. Filter
+    # ede entries out (mirroring the CLI's own diagnostic filter); if
+    # that leaves nothing, fall through to the friendly message below.
+    visible = [
+      err for err in result.errors
+      if err and not err.lstrip().startswith("[ede_diagnostic]")
+    ]
+    if visible:
+      return "\n".join(visible).strip()
+  if result.subtype == "error_during_execution":
+    return "Execution interrupted."
+  return "Claude SDK turn failed."
+
+
+def _format_tool_output(content: Any) -> str:
+  """Formats SDK tool-result content for Möbius tool_output events."""
+  if content is None:
+    return ""
+  if isinstance(content, str):
+    return content
+  if isinstance(content, list):
+    parts: list[str] = []
+    for item in content:
+      if isinstance(item, str):
+        parts.append(item)
+        continue
+      if isinstance(item, dict) and item.get("type") == "text":
+        text = item.get("text")
+        if isinstance(text, str):
+          parts.append(text)
+          continue
+      parts.append(json.dumps(item, ensure_ascii=True))
+    return "\n".join(part for part in parts if part).strip()
+  return json.dumps(content, ensure_ascii=True)
+
+
+def _server_web_search_input(inp: dict[str, Any]) -> str:
+  """Return the displayed query from Claude's server web_search input."""
+  if not isinstance(inp, dict):
+    return ""
+  query = inp.get("query")
+  if isinstance(query, str):
+    return query
+  queries = inp.get("queries")
+  if isinstance(queries, list):
+    return ", ".join(q for q in queries if isinstance(q, str))
+  return ""
+
+
+def _is_web_search_tool_result(content: Any) -> bool:
+  """True when Claude's opaque server result is a web-search result."""
+  if not isinstance(content, dict):
+    return False
+  return content.get("type") == "web_search_tool_result"
+
+
+def _emit_unknown(bc, kind: str, raw: Any) -> None:
+  """Logs an unknown SDK event and emits it on the wire when enabled.
+
+  The DEBUG log fires unconditionally so noisy sessions stay
+  inspectable in `chat.log` even when wire emission is turned off
+  via ``MOBIUS_EMIT_UNKNOWN=0``.
+  """
+  event = unknown_event(kind, raw)
+  if emit_unknown_enabled():
+    bc.publish(event)
+
+
+def _usage_event(usage: dict[str, Any]) -> dict:
+  """Builds the wire-shape `usage` event from an SDK usage dict.
+
+  The SDK's usage shape evolves — we extract the fields we know
+  about today and pass the full dict through under ``raw`` so a
+  later UI can pick up newly-added counters without a runner change.
+  """
+  return {
+    "type": "usage",
+    "input_tokens": usage.get("input_tokens"),
+    "output_tokens": usage.get("output_tokens"),
+    "cache_creation_input_tokens": usage.get("cache_creation_input_tokens"),
+    "cache_read_input_tokens": usage.get("cache_read_input_tokens"),
+    "raw": dict(usage),
+  }
+
+
+def dispatch_sdk_message(
+  sdk_msg: Any,
+  bc,
+  current_session_id: str | None,
+) -> tuple[str | None, dict | None]:
+  """Translates one SDK message into broadcast events.
+
+  Returns ``(new_session_id, terminal_result_or_None)``. When the
+  message is a ResultMessage, the caller receives the final result
+  dict and stops draining the SDK stream. For every other message
+  type the caller updates ``current_session_id`` from the first
+  return value and keeps reading.
+
+  Extracted from the runner loop so unit tests can exercise the
+  full dispatch matrix (named events, unknown fallthrough, usage
+  + stop_reason side channels) without spinning up a live SDK
+  subprocess.
+  """
+  if isinstance(sdk_msg, SystemMessage):
+    if isinstance(sdk_msg, TaskStartedMessage):
+      # tool_use_id ties this sub-task back to the parent turn's tool call that
+      # spawned it, so an observer can nest task events under their tool block.
+      # description/summary/last_tool_name are clipped at emission: unlike
+      # ordinary tool output they bypass the excerpt/stash reduction, so an
+      # oversized provider string would otherwise ride the wire, the in-memory
+      # event log, and Chat.messages verbatim. Clipping also coerces a
+      # non-string (SDK shape drift) to text so a downstream render can't crash.
+      public_event = {
+        "type": "task_start",
+        "task_id": sdk_msg.task_id,
+        "description": _clip_task_text(sdk_msg.description, _TASK_TEXT_CAP),
+        "task_type": sdk_msg.task_type,
+        "tool_use_id": sdk_msg.tool_use_id,
+      }
+      recorder = getattr(bc, "record_lifecycle", None)
+      if callable(recorder):
+        recorder({**public_event,
+          "provider_session_id": (
+            getattr(sdk_msg, "session_id", None) or current_session_id
+          ),
+          "source_event_id": getattr(sdk_msg, "uuid", None),
+        })
+      bc.publish(public_event)
+      return current_session_id, None
+    if isinstance(sdk_msg, TaskProgressMessage):
+      bc.publish({
+        "type": "task_progress",
+        "task_id": sdk_msg.task_id,
+        "usage": dict(sdk_msg.usage) if sdk_msg.usage else None,
+        "last_tool_name": _clip_task_text(sdk_msg.last_tool_name, _TASK_LABEL_CAP),
+        "tool_use_id": sdk_msg.tool_use_id,
+      })
+      return current_session_id, None
+    if isinstance(sdk_msg, TaskNotificationMessage):
+      public_event = {
+        "type": "task_done",
+        "task_id": sdk_msg.task_id,
+        "status": sdk_msg.status,
+        "summary": _clip_task_text(sdk_msg.summary, _TASK_TEXT_CAP),
+        "tool_use_id": sdk_msg.tool_use_id,
+      }
+      recorder = getattr(bc, "record_lifecycle", None)
+      if callable(recorder):
+        recorder({**public_event,
+          "provider_session_id": (
+            getattr(sdk_msg, "session_id", None) or current_session_id
+          ),
+          "source_event_id": getattr(sdk_msg, "uuid", None),
+        })
+      bc.publish(public_event)
+      return current_session_id, None
+    if TaskUpdatedMessage is not None and isinstance(sdk_msg, TaskUpdatedMessage):
+      # A background task's terminal state can arrive ONLY as a task_updated
+      # patch, with no accompanying TaskNotificationMessage — a task stopped via
+      # TaskStop reports status "killed" here and the matching notification is
+      # sometimes suppressed. Publish the same task_done shape on a terminal
+      # status so a consumer clears the task on a terminal signal from EITHER
+      # message. Non-terminal updates (pending/running/paused, or a patch with
+      # no status) carry no lifecycle-close a task_done would represent, so they
+      # are intentionally dropped rather than surfaced as noise. summary and
+      # tool_use_id are read via getattr — the SDK class omits them, so they
+      # resolve to None and the task_done shape stays uniform across both paths.
+      if sdk_msg.status in TERMINAL_TASK_STATUSES:
+        private_event = {
+          "type": "task_done",
+          "task_id": sdk_msg.task_id,
+          "status": sdk_msg.status,
+          "summary": getattr(sdk_msg, "summary", None),
+          "tool_use_id": getattr(sdk_msg, "tool_use_id", None),
+          "provider_session_id": (
+            getattr(sdk_msg, "session_id", None) or current_session_id
+          ),
+          "source_event_id": getattr(sdk_msg, "uuid", None),
+          "occurred_at": (getattr(sdk_msg, "patch", None) or {}).get(
+            "end_time"
+          ),
+        }
+        recorder = getattr(bc, "record_lifecycle", None)
+        if callable(recorder):
+          recorder(private_event)
+        bc.publish({key: private_event.get(key) for key in (
+          "type", "task_id", "status", "summary", "tool_use_id")})
+      return current_session_id, None
+    if sdk_msg.subtype == "init":
+      # Setup metadata only — no Möbius-side render.
+      return current_session_id, None
+    _emit_unknown(bc, f"system:{sdk_msg.subtype}", sdk_msg)
+    return current_session_id, None
+
+  if isinstance(sdk_msg, StreamEvent):
+    if sdk_msg.session_id:
+      current_session_id = sdk_msg.session_id
+    event = sdk_msg.event
+    event_type = event.get("type")
+    if event_type == "content_block_delta":
+      delta = event.get("delta", {})
+      delta_type = delta.get("type")
+      if delta_type == "text_delta":
+        text = delta.get("text")
+        if text:
+          bc.publish({"type": "text", "content": text})
+        return current_session_id, None
+      if delta_type == "thinking_delta":
+        thinking = delta.get("thinking") or delta.get("text") or ""
+        if thinking:
+          block_index = event.get("index")
+          segment_id = (
+            f"claude:content:{block_index}"
+            if block_index is not None else None
+          )
+          bc.publish(_thinking_event(thinking, segment_id))
+        return current_session_id, None
+      _emit_unknown(bc, f"stream:content_block_delta:{delta_type}", delta)
+      return current_session_id, None
+    if event_type == "content_block_start":
+      # A new assistant content block is starting. When it is a TEXT
+      # block, emit a provider boundary so the reducer (events.py) starts
+      # a fresh paragraph instead of concatenating into the prior text —
+      # the Claude analog of the Codex AgentMessageThreadItem boundary.
+      # The reducer self-guards (it only inserts a marker when the prior
+      # block is non-empty text), so emitting on every text block-start
+      # is safe: it only takes effect on the consecutive-text case, e.g.
+      # text resuming after an AskUserQuestion answer, which otherwise
+      # glued together as "answer1.answer2" with no separator.
+      cb = event.get("content_block") or {}
+      if isinstance(cb, dict) and cb.get("type") == "text":
+        bc.publish({"type": "text_boundary"})
+        return current_session_id, None
+    _emit_unknown(bc, f"stream:{event_type}", event)
+    return current_session_id, None
+
+  if isinstance(sdk_msg, AssistantMessage):
+    if sdk_msg.session_id:
+      current_session_id = sdk_msg.session_id
+    server_tools: dict[str, str] = {}
+    for block in sdk_msg.content:
+      if isinstance(block, ToolUseBlock):
+        # block.id is the canonical tool_use_id; the matching ToolResultBlock
+        # carries it as .tool_use_id. Thread it through so a large tool output
+        # can be reduced on the wire and fetched lazily by id (contract rule 6).
+        bc.publish({
+          "type": "tool_start",
+          "tool": block.name,
+          "input": "",
+          "tool_use_id": block.id,
+        })
+        summary = summarize_tool_input(block.name, block.input)
+        if summary:
+          bc.publish({
+            "type": "tool_input",
+            "tool": block.name,
+            "input": summary,
+            "tool_use_id": block.id,
+          })
+        # Skill observability: when the agent loads a skill, surface it
+        # as its own `skill_loaded` event (the frontend stamps a chip
+        # onto the Skill tool block) and append a record to the activity
+        # log so "most-used skills" can be aggregated. This fires
+        # whenever the Skill tool runs at all; whether skills are even
+        # OFFERED to the agent is the separate, gated `skills_enabled`
+        # decision below — observability is correct either way.
+        if block.name == "Skill":
+          skill = _skill_name_from_input(block.input)
+          if skill:
+            bc.publish({"type": "skill_loaded", "skill": skill})
+            activity.log_skill_load(getattr(bc, "chat_id", None), skill)
+        continue
+      if isinstance(block, ServerToolUseBlock):
+        server_tools[block.id] = block.name
+        if block.name == "web_search":
+          bc.publish({
+            "type": "tool_start",
+            "tool": "WebSearch",
+            "input": _server_web_search_input(block.input),
+            "tool_use_id": block.id,
+          })
+          continue
+        _emit_unknown(
+          bc, f"assistant_block:{type(block).__name__}", block,
+        )
+        continue
+      if isinstance(block, ServerToolResultBlock):
+        tool_name = server_tools.get(block.tool_use_id)
+        if (
+          tool_name == "web_search"
+          or _is_web_search_tool_result(block.content)
+        ):
+          sources = normalize_tool_sources(block.content)
+          if sources:
+            bc.publish({
+              "type": "tool_sources",
+              "sources": sources,
+              "tool_use_id": block.tool_use_id,
+            })
+          bc.publish({
+            "type": "tool_end",
+            "tool_use_id": block.tool_use_id,
+          })
+          continue
+        _emit_unknown(
+          bc, f"assistant_block:{type(block).__name__}", block,
+        )
+        continue
+      if isinstance(block, ThinkingBlock):
+        # Streamed via thinking_delta already — snapshot duplicate.
+        continue
+      if isinstance(block, TextBlock):
+        # The text already streamed live via text_delta events; this is the
+        # AUTHORITATIVE full text of the just-completed assistant item. Do NOT
+        # discard it — durable prose otherwise rides ONLY on the delta stream,
+        # so a single dropped/coalesced delta persists a permanently truncated
+        # message (the "I " bug). Emit it as a replace-semantics event; events.py
+        # overwrites the streamed text block with this complete text (a no-op
+        # when no delta was lost). Tool blocks are already sourced from this
+        # same message object and so were always durable — this closes the gap
+        # for text. Replace, never append: the reducer concatenates plain
+        # "text" events, so re-emitting as "text" would double the prose.
+        if block.text:
+          bc.publish({"type": "text_final", "content": block.text})
+        continue
+      _emit_unknown(
+        bc, f"assistant_block:{type(block).__name__}", block,
+      )
+    if sdk_msg.usage:
+      bc.publish(_usage_event(sdk_msg.usage))
+    if sdk_msg.stop_reason:
+      bc.publish({
+        "type": "stop_reason",
+        "reason": sdk_msg.stop_reason,
+      })
+    return current_session_id, None
+
+  if isinstance(sdk_msg, UserMessage):
+    content = sdk_msg.content if isinstance(sdk_msg.content, list) else []
+    for block in content:
+      if isinstance(block, ToolResultBlock):
+        output = _format_tool_output(block.content)
+        # Carry the tool_use_id (matches the ToolUseBlock's .id) so the sink can
+        # key a stash of the full output and the block can fetch it by id.
+        bc.publish({
+          "type": "tool_output",
+          "content": output,
+          "tool_use_id": block.tool_use_id,
+          "output_complete": True,
+        })
+        if output.startswith("Web search results for query"):
+          sources = sources_from_websearch_text(output)
+          if sources:
+            # Carry the same tool_use_id as the output it was parsed from. A
+            # turn can batch several WebSearch calls, and their results arrive
+            # together — without the id the consumer can only guess "the last
+            # WebSearch block", so every batch member lands on one block and
+            # overwrites the previous, keeping only the final search's sources.
+            bc.publish({
+              "type": "tool_sources",
+              "sources": sources,
+              "tool_use_id": block.tool_use_id,
+            })
+        bc.publish({"type": "tool_end", "tool_use_id": block.tool_use_id})
+        continue
+      _emit_unknown(bc, f"user_block:{type(block).__name__}", block)
+    return current_session_id, None
+
+  if isinstance(sdk_msg, RateLimitEvent):
+    info = sdk_msg.rate_limit_info
+    bc.publish({
+      "type": "rate_limit",
+      "status": info.status,
+      "resets_at": info.resets_at,
+      "rate_limit_type": info.rate_limit_type,
+      "utilization": info.utilization,
+    })
+    return current_session_id, None
+
+  if isinstance(sdk_msg, ResultMessage):
+    if sdk_msg.session_id:
+      current_session_id = sdk_msg.session_id
+    if sdk_msg.usage:
+      bc.publish(_usage_event(sdk_msg.usage))
+    if sdk_msg.stop_reason:
+      bc.publish({
+        "type": "stop_reason",
+        "reason": sdk_msg.stop_reason,
+      })
+    return current_session_id, {
+      "session_id": current_session_id,
+      "cost_usd": sdk_msg.total_cost_usd,
+      "usage": dict(sdk_msg.usage) if sdk_msg.usage else None,
+      "usage_metrics": normalize_claude_usage(
+        sdk_msg.usage, sdk_msg.model_usage,
+      ),
+      "model_usage": (
+        dict(sdk_msg.model_usage) if sdk_msg.model_usage else None
+      ),
+      "permission_denials": sdk_msg.permission_denials or None,
+      "api_error_status": sdk_msg.api_error_status,
+      "error": (
+        _result_error_message(sdk_msg)
+        if sdk_msg.is_error else None
+      ),
+    }
+
+  # Any SDK message class we didn't enumerate — never silently dropped.
+  _emit_unknown(bc, f"sdk_message:{type(sdk_msg).__name__}", sdk_msg)
+  return current_session_id, None

--- a/backend/app/claude_sdk_runner.py
+++ b/backend/app/claude_sdk_runner.py
@@ -58,16 +58,13 @@ Design choices:
 from __future__ import annotations
 
 import asyncio
-import inspect
 import json
 import logging
 import os
 import signal
 import shutil
-import time
 from collections import deque
 from typing import Any
-from uuid import uuid4
 
 from claude_agent_sdk import (
   ClaudeAgentOptions,
@@ -81,48 +78,24 @@ from claude_agent_sdk.types import (
   PermissionResultDeny,
   RateLimitEvent,
   ResultMessage,
-  ServerToolResultBlock,
-  ServerToolUseBlock,
   StreamEvent,
-  SystemMessage,
-  TaskNotificationMessage,
-  TaskProgressMessage,
-  TaskStartedMessage,
-  TextBlock,
-  ThinkingBlock,
-  ToolResultBlock,
-  ToolUseBlock,
   UserMessage,
 )
 
-# The background-task terminal-state surface (TaskUpdatedMessage + the
-# TERMINAL_TASK_STATUSES set) is newer than our SDK FLOOR pin
-# (claude-agent-sdk>=0.2.87 in the Dockerfile). Import it defensively so a build
-# that resolves an in-range older SDK lacking these symbols still boots the
-# whole Claude runner — the task_updated branch below simply becomes a no-op
-# (its class is None, so the isinstance guard is never true), matching how the
-# Codex runner guards its own newer collab types. When the type is present the
-# branch handles killed/stopped background tasks whose terminal state arrives
-# ONLY as a task_updated patch.
-try:
-  from claude_agent_sdk.types import TERMINAL_TASK_STATUSES, TaskUpdatedMessage
-except ImportError:
-  TERMINAL_TASK_STATUSES = frozenset()
-  TaskUpdatedMessage = None
-
 from app import activity
-from app.pending_questions import PendingQuestion
+from app.claude_events import _clip_task_text, dispatch_sdk_message
 from app.process_groups import (
   isolated_process_group_id,
   lower_process_group_priority,
   terminate_process_group,
 )
+from app.question_bridge import (
+  QuestionOverlapError,
+  QuestionPersistenceError,
+  park_question,
+)
 from app.runner_registry import RunnerKind, registry
 from app.runtime_types import RunnerResult
-from app.sdk_emit import emit_unknown_enabled, unknown_event
-from app.tool_summaries import summarize_tool_input
-from app.tool_sources import normalize_tool_sources, sources_from_websearch_text
-from app.usage_metrics import normalize_claude_usage
 
 log = logging.getLogger(__name__)
 
@@ -190,42 +163,6 @@ def _terminate_claude_process_group(pgid: int | None) -> bool:
 _CLAUDE_SDK_MAX_BUFFER_SIZE = 10 * 1024 * 1024
 
 
-# Bounds for the subagent task_* text fields. Unlike ordinary tool output these
-# never pass through the excerpt/stash reducer, so they are clipped at emission
-# to keep an oversized provider string off the wire, the in-memory event log,
-# and Chat.messages. A description/summary is a one-line label + short outcome; a
-# last_tool_name is a tool name — both are generous.
-_TASK_TEXT_CAP = 2000
-_TASK_LABEL_CAP = 200
-
-
-def _clip_task_text(value: object, cap: int) -> str | None:
-  """Coerce a task_* text field to a bounded string (or None).
-
-  None passes through as None (a genuinely absent field). Anything else is
-  str()-coerced — so SDK shape drift that hands us a non-string can't ride
-  through to a React child and crash the render — then truncated to ``cap``.
-  """
-  if value is None:
-    return None
-  text = value if isinstance(value, str) else str(value)
-  if len(text) > cap:
-    return text[: cap - 1] + "…"
-  return text
-
-
-def _thinking_event(content: str, segment_id: str | None = None) -> dict:
-  """Build a reasoning delta, preserving its content-block identity."""
-  event = {
-    "type": "thinking",
-    "content": content,
-    "ts": int(time.time() * 1000),
-  }
-  if segment_id:
-    event["segment_id"] = segment_id
-  return event
-
-
 def _claude_thinking_config(model: str | None) -> dict[str, str] | None:
   """Request displayable thinking summaries on adaptive-thinking models."""
   mid = (model or "").lower()
@@ -246,6 +183,17 @@ def _claude_thinking_config(model: str | None) -> dict[str, str] | None:
   if mid.startswith(adaptive_prefixes):
     return {"type": "adaptive", "display": "summarized"}
   return None
+
+
+def _should_retry_without_model(error_text: str | None) -> bool:
+  """True when Claude rejected the explicit model selection."""
+  if not error_text:
+    return False
+  text = error_text.lower()
+  return (
+    "selected model" in text
+    and "may not exist or you may not have access" in text
+  )
 
 
 async def _persist_session_id(db, chat_id: str, session_id: str | None) -> None:
@@ -743,461 +691,6 @@ def observe_skill_file_read(
     log.debug("skill_loaded read observability failed", exc_info=True)
 
 
-def _skill_name_from_input(input_data: Any) -> str:
-  """Extracts the loaded skill's name from a Skill tool_use input.
-
-  The Skill tool's input is `{"skill": "<name>", "args": "..."}` — the
-  skill name lives under the `skill` key. Older / plugin-namespaced
-  forms can carry it as `command` (the slash-command name), so fall
-  back to that. Returns an empty string when neither is present so the
-  caller can decide not to emit an empty chip.
-  """
-  if not isinstance(input_data, dict):
-    return ""
-  name = input_data.get("skill") or input_data.get("command") or ""
-  return name.strip() if isinstance(name, str) else ""
-
-
-def _result_error_message(result: ResultMessage) -> str:
-  """Builds a user-facing error string from an SDK result."""
-  if isinstance(result.result, str) and result.result.strip():
-    return result.result.strip()
-  if result.errors:
-    # The bundled CLI attaches an internal `[ede_diagnostic] ...
-    # stop_reason=tool_use/null` entry whenever its end-of-turn
-    # validator trips — which it does on a Möbius-initiated interrupt
-    # (the message list ends on a synthetic user-interrupt entry), not
-    # only on real failures. Surfacing that raw string renders a scary
-    # red error block for what was a clean Stop, eroding trust. Filter
-    # ede entries out (mirroring the CLI's own diagnostic filter); if
-    # that leaves nothing, fall through to the friendly message below.
-    visible = [
-      err for err in result.errors
-      if err and not err.lstrip().startswith("[ede_diagnostic]")
-    ]
-    if visible:
-      return "\n".join(visible).strip()
-  if result.subtype == "error_during_execution":
-    return "Execution interrupted."
-  return "Claude SDK turn failed."
-
-
-def _should_retry_without_model(error_text: str | None) -> bool:
-  """True when Claude rejected the explicit model selection."""
-  if not error_text:
-    return False
-  text = error_text.lower()
-  return (
-    "selected model" in text
-    and "may not exist or you may not have access" in text
-  )
-
-
-def _format_tool_output(content: Any) -> str:
-  """Formats SDK tool-result content for Möbius tool_output events."""
-  if content is None:
-    return ""
-  if isinstance(content, str):
-    return content
-  if isinstance(content, list):
-    parts: list[str] = []
-    for item in content:
-      if isinstance(item, str):
-        parts.append(item)
-        continue
-      if isinstance(item, dict) and item.get("type") == "text":
-        text = item.get("text")
-        if isinstance(text, str):
-          parts.append(text)
-          continue
-      parts.append(json.dumps(item, ensure_ascii=True))
-    return "\n".join(part for part in parts if part).strip()
-  return json.dumps(content, ensure_ascii=True)
-
-
-def _server_web_search_input(inp: dict[str, Any]) -> str:
-  """Return the displayed query from Claude's server web_search input."""
-  if not isinstance(inp, dict):
-    return ""
-  query = inp.get("query")
-  if isinstance(query, str):
-    return query
-  queries = inp.get("queries")
-  if isinstance(queries, list):
-    return ", ".join(q for q in queries if isinstance(q, str))
-  return ""
-
-
-def _is_web_search_tool_result(content: Any) -> bool:
-  """True when Claude's opaque server result is a web-search result."""
-  if not isinstance(content, dict):
-    return False
-  return content.get("type") == "web_search_tool_result"
-
-
-async def _maybe_await(value: Any) -> Any:
-  """Awaits a value only when the callback returned an awaitable."""
-  if inspect.isawaitable(value):
-    return await value
-  return value
-
-
-def _emit_unknown(bc, kind: str, raw: Any) -> None:
-  """Logs an unknown SDK event and emits it on the wire when enabled.
-
-  The DEBUG log fires unconditionally so noisy sessions stay
-  inspectable in `chat.log` even when wire emission is turned off
-  via ``MOBIUS_EMIT_UNKNOWN=0``.
-  """
-  event = unknown_event(kind, raw)
-  if emit_unknown_enabled():
-    bc.publish(event)
-
-
-def _usage_event(usage: dict[str, Any]) -> dict:
-  """Builds the wire-shape `usage` event from an SDK usage dict.
-
-  The SDK's usage shape evolves — we extract the fields we know
-  about today and pass the full dict through under ``raw`` so a
-  later UI can pick up newly-added counters without a runner change.
-  """
-  return {
-    "type": "usage",
-    "input_tokens": usage.get("input_tokens"),
-    "output_tokens": usage.get("output_tokens"),
-    "cache_creation_input_tokens": usage.get("cache_creation_input_tokens"),
-    "cache_read_input_tokens": usage.get("cache_read_input_tokens"),
-    "raw": dict(usage),
-  }
-
-
-def dispatch_sdk_message(
-  sdk_msg: Any,
-  bc,
-  current_session_id: str | None,
-) -> tuple[str | None, dict | None]:
-  """Translates one SDK message into broadcast events.
-
-  Returns ``(new_session_id, terminal_result_or_None)``. When the
-  message is a ResultMessage, the caller receives the final result
-  dict and stops draining the SDK stream. For every other message
-  type the caller updates ``current_session_id`` from the first
-  return value and keeps reading.
-
-  Extracted from the runner loop so unit tests can exercise the
-  full dispatch matrix (named events, unknown fallthrough, usage
-  + stop_reason side channels) without spinning up a live SDK
-  subprocess.
-  """
-  if isinstance(sdk_msg, SystemMessage):
-    if isinstance(sdk_msg, TaskStartedMessage):
-      # tool_use_id ties this sub-task back to the parent turn's tool call that
-      # spawned it, so an observer can nest task events under their tool block.
-      # description/summary/last_tool_name are clipped at emission: unlike
-      # ordinary tool output they bypass the excerpt/stash reduction, so an
-      # oversized provider string would otherwise ride the wire, the in-memory
-      # event log, and Chat.messages verbatim. Clipping also coerces a
-      # non-string (SDK shape drift) to text so a downstream render can't crash.
-      public_event = {
-        "type": "task_start",
-        "task_id": sdk_msg.task_id,
-        "description": _clip_task_text(sdk_msg.description, _TASK_TEXT_CAP),
-        "task_type": sdk_msg.task_type,
-        "tool_use_id": sdk_msg.tool_use_id,
-      }
-      recorder = getattr(bc, "record_lifecycle", None)
-      if callable(recorder):
-        recorder({**public_event,
-          "provider_session_id": (
-            getattr(sdk_msg, "session_id", None) or current_session_id
-          ),
-          "source_event_id": getattr(sdk_msg, "uuid", None),
-        })
-      bc.publish(public_event)
-      return current_session_id, None
-    if isinstance(sdk_msg, TaskProgressMessage):
-      bc.publish({
-        "type": "task_progress",
-        "task_id": sdk_msg.task_id,
-        "usage": dict(sdk_msg.usage) if sdk_msg.usage else None,
-        "last_tool_name": _clip_task_text(sdk_msg.last_tool_name, _TASK_LABEL_CAP),
-        "tool_use_id": sdk_msg.tool_use_id,
-      })
-      return current_session_id, None
-    if isinstance(sdk_msg, TaskNotificationMessage):
-      public_event = {
-        "type": "task_done",
-        "task_id": sdk_msg.task_id,
-        "status": sdk_msg.status,
-        "summary": _clip_task_text(sdk_msg.summary, _TASK_TEXT_CAP),
-        "tool_use_id": sdk_msg.tool_use_id,
-      }
-      recorder = getattr(bc, "record_lifecycle", None)
-      if callable(recorder):
-        recorder({**public_event,
-          "provider_session_id": (
-            getattr(sdk_msg, "session_id", None) or current_session_id
-          ),
-          "source_event_id": getattr(sdk_msg, "uuid", None),
-        })
-      bc.publish(public_event)
-      return current_session_id, None
-    if TaskUpdatedMessage is not None and isinstance(sdk_msg, TaskUpdatedMessage):
-      # A background task's terminal state can arrive ONLY as a task_updated
-      # patch, with no accompanying TaskNotificationMessage — a task stopped via
-      # TaskStop reports status "killed" here and the matching notification is
-      # sometimes suppressed. Publish the same task_done shape on a terminal
-      # status so a consumer clears the task on a terminal signal from EITHER
-      # message. Non-terminal updates (pending/running/paused, or a patch with
-      # no status) carry no lifecycle-close a task_done would represent, so they
-      # are intentionally dropped rather than surfaced as noise. summary and
-      # tool_use_id are read via getattr — the SDK class omits them, so they
-      # resolve to None and the task_done shape stays uniform across both paths.
-      if sdk_msg.status in TERMINAL_TASK_STATUSES:
-        private_event = {
-          "type": "task_done",
-          "task_id": sdk_msg.task_id,
-          "status": sdk_msg.status,
-          "summary": getattr(sdk_msg, "summary", None),
-          "tool_use_id": getattr(sdk_msg, "tool_use_id", None),
-          "provider_session_id": (
-            getattr(sdk_msg, "session_id", None) or current_session_id
-          ),
-          "source_event_id": getattr(sdk_msg, "uuid", None),
-          "occurred_at": (getattr(sdk_msg, "patch", None) or {}).get(
-            "end_time"
-          ),
-        }
-        recorder = getattr(bc, "record_lifecycle", None)
-        if callable(recorder):
-          recorder(private_event)
-        bc.publish({key: private_event.get(key) for key in (
-          "type", "task_id", "status", "summary", "tool_use_id")})
-      return current_session_id, None
-    if sdk_msg.subtype == "init":
-      # Setup metadata only — no Möbius-side render.
-      return current_session_id, None
-    _emit_unknown(bc, f"system:{sdk_msg.subtype}", sdk_msg)
-    return current_session_id, None
-
-  if isinstance(sdk_msg, StreamEvent):
-    if sdk_msg.session_id:
-      current_session_id = sdk_msg.session_id
-    event = sdk_msg.event
-    event_type = event.get("type")
-    if event_type == "content_block_delta":
-      delta = event.get("delta", {})
-      delta_type = delta.get("type")
-      if delta_type == "text_delta":
-        text = delta.get("text")
-        if text:
-          bc.publish({"type": "text", "content": text})
-        return current_session_id, None
-      if delta_type == "thinking_delta":
-        thinking = delta.get("thinking") or delta.get("text") or ""
-        if thinking:
-          block_index = event.get("index")
-          segment_id = (
-            f"claude:content:{block_index}"
-            if block_index is not None else None
-          )
-          bc.publish(_thinking_event(thinking, segment_id))
-        return current_session_id, None
-      _emit_unknown(bc, f"stream:content_block_delta:{delta_type}", delta)
-      return current_session_id, None
-    if event_type == "content_block_start":
-      # A new assistant content block is starting. When it is a TEXT
-      # block, emit a provider boundary so the reducer (events.py) starts
-      # a fresh paragraph instead of concatenating into the prior text —
-      # the Claude analog of the Codex AgentMessageThreadItem boundary.
-      # The reducer self-guards (it only inserts a marker when the prior
-      # block is non-empty text), so emitting on every text block-start
-      # is safe: it only takes effect on the consecutive-text case, e.g.
-      # text resuming after an AskUserQuestion answer, which otherwise
-      # glued together as "answer1.answer2" with no separator.
-      cb = event.get("content_block") or {}
-      if isinstance(cb, dict) and cb.get("type") == "text":
-        bc.publish({"type": "text_boundary"})
-        return current_session_id, None
-    _emit_unknown(bc, f"stream:{event_type}", event)
-    return current_session_id, None
-
-  if isinstance(sdk_msg, AssistantMessage):
-    if sdk_msg.session_id:
-      current_session_id = sdk_msg.session_id
-    server_tools: dict[str, str] = {}
-    for block in sdk_msg.content:
-      if isinstance(block, ToolUseBlock):
-        # block.id is the canonical tool_use_id; the matching ToolResultBlock
-        # carries it as .tool_use_id. Thread it through so a large tool output
-        # can be reduced on the wire and fetched lazily by id (contract rule 6).
-        bc.publish({
-          "type": "tool_start",
-          "tool": block.name,
-          "input": "",
-          "tool_use_id": block.id,
-        })
-        summary = summarize_tool_input(block.name, block.input)
-        if summary:
-          bc.publish({
-            "type": "tool_input",
-            "tool": block.name,
-            "input": summary,
-            "tool_use_id": block.id,
-          })
-        # Skill observability: when the agent loads a skill, surface it
-        # as its own `skill_loaded` event (the frontend stamps a chip
-        # onto the Skill tool block) and append a record to the activity
-        # log so "most-used skills" can be aggregated. This fires
-        # whenever the Skill tool runs at all; whether skills are even
-        # OFFERED to the agent is the separate, gated `skills_enabled`
-        # decision below — observability is correct either way.
-        if block.name == "Skill":
-          skill = _skill_name_from_input(block.input)
-          if skill:
-            bc.publish({"type": "skill_loaded", "skill": skill})
-            activity.log_skill_load(getattr(bc, "chat_id", None), skill)
-        continue
-      if isinstance(block, ServerToolUseBlock):
-        server_tools[block.id] = block.name
-        if block.name == "web_search":
-          bc.publish({
-            "type": "tool_start",
-            "tool": "WebSearch",
-            "input": _server_web_search_input(block.input),
-            "tool_use_id": block.id,
-          })
-          continue
-        _emit_unknown(
-          bc, f"assistant_block:{type(block).__name__}", block,
-        )
-        continue
-      if isinstance(block, ServerToolResultBlock):
-        tool_name = server_tools.get(block.tool_use_id)
-        if (
-          tool_name == "web_search"
-          or _is_web_search_tool_result(block.content)
-        ):
-          sources = normalize_tool_sources(block.content)
-          if sources:
-            bc.publish({
-              "type": "tool_sources",
-              "sources": sources,
-              "tool_use_id": block.tool_use_id,
-            })
-          bc.publish({
-            "type": "tool_end",
-            "tool_use_id": block.tool_use_id,
-          })
-          continue
-        _emit_unknown(
-          bc, f"assistant_block:{type(block).__name__}", block,
-        )
-        continue
-      if isinstance(block, ThinkingBlock):
-        # Streamed via thinking_delta already — snapshot duplicate.
-        continue
-      if isinstance(block, TextBlock):
-        # The text already streamed live via text_delta events; this is the
-        # AUTHORITATIVE full text of the just-completed assistant item. Do NOT
-        # discard it — durable prose otherwise rides ONLY on the delta stream,
-        # so a single dropped/coalesced delta persists a permanently truncated
-        # message (the "I " bug). Emit it as a replace-semantics event; events.py
-        # overwrites the streamed text block with this complete text (a no-op
-        # when no delta was lost). Tool blocks are already sourced from this
-        # same message object and so were always durable — this closes the gap
-        # for text. Replace, never append: the reducer concatenates plain
-        # "text" events, so re-emitting as "text" would double the prose.
-        if block.text:
-          bc.publish({"type": "text_final", "content": block.text})
-        continue
-      _emit_unknown(
-        bc, f"assistant_block:{type(block).__name__}", block,
-      )
-    if sdk_msg.usage:
-      bc.publish(_usage_event(sdk_msg.usage))
-    if sdk_msg.stop_reason:
-      bc.publish({
-        "type": "stop_reason",
-        "reason": sdk_msg.stop_reason,
-      })
-    return current_session_id, None
-
-  if isinstance(sdk_msg, UserMessage):
-    content = sdk_msg.content if isinstance(sdk_msg.content, list) else []
-    for block in content:
-      if isinstance(block, ToolResultBlock):
-        output = _format_tool_output(block.content)
-        # Carry the tool_use_id (matches the ToolUseBlock's .id) so the sink can
-        # key a stash of the full output and the block can fetch it by id.
-        bc.publish({
-          "type": "tool_output",
-          "content": output,
-          "tool_use_id": block.tool_use_id,
-          "output_complete": True,
-        })
-        if output.startswith("Web search results for query"):
-          sources = sources_from_websearch_text(output)
-          if sources:
-            # Carry the same tool_use_id as the output it was parsed from. A
-            # turn can batch several WebSearch calls, and their results arrive
-            # together — without the id the consumer can only guess "the last
-            # WebSearch block", so every batch member lands on one block and
-            # overwrites the previous, keeping only the final search's sources.
-            bc.publish({
-              "type": "tool_sources",
-              "sources": sources,
-              "tool_use_id": block.tool_use_id,
-            })
-        bc.publish({"type": "tool_end", "tool_use_id": block.tool_use_id})
-        continue
-      _emit_unknown(bc, f"user_block:{type(block).__name__}", block)
-    return current_session_id, None
-
-  if isinstance(sdk_msg, RateLimitEvent):
-    info = sdk_msg.rate_limit_info
-    bc.publish({
-      "type": "rate_limit",
-      "status": info.status,
-      "resets_at": info.resets_at,
-      "rate_limit_type": info.rate_limit_type,
-      "utilization": info.utilization,
-    })
-    return current_session_id, None
-
-  if isinstance(sdk_msg, ResultMessage):
-    if sdk_msg.session_id:
-      current_session_id = sdk_msg.session_id
-    if sdk_msg.usage:
-      bc.publish(_usage_event(sdk_msg.usage))
-    if sdk_msg.stop_reason:
-      bc.publish({
-        "type": "stop_reason",
-        "reason": sdk_msg.stop_reason,
-      })
-    return current_session_id, {
-      "session_id": current_session_id,
-      "cost_usd": sdk_msg.total_cost_usd,
-      "usage": dict(sdk_msg.usage) if sdk_msg.usage else None,
-      "usage_metrics": normalize_claude_usage(
-        sdk_msg.usage, sdk_msg.model_usage,
-      ),
-      "model_usage": (
-        dict(sdk_msg.model_usage) if sdk_msg.model_usage else None
-      ),
-      "permission_denials": sdk_msg.permission_denials or None,
-      "api_error_status": sdk_msg.api_error_status,
-      "error": (
-        _result_error_message(sdk_msg)
-        if sdk_msg.is_error else None
-      ),
-    }
-
-  # Any SDK message class we didn't enumerate — never silently dropped.
-  _emit_unknown(bc, f"sdk_message:{type(sdk_msg).__name__}", sdk_msg)
-  return current_session_id, None
-
-
 # Injected when the owner picks the "ultracode" effort tier. Ultracode (xhigh
 # effort + standing dynamic-workflow orchestration) is armed the DOCUMENTED way
 # — the CLI's `ultracode` settings flag, passed below — NOT by putting the word
@@ -1326,52 +819,22 @@ async def run_claude_sdk_turn(
     if not isinstance(questions, list):
       questions = []
 
-    existing = pending_questions.get(chat_id)
-    if existing is not None and not existing.future.done():
-      return PermissionResultDeny(
-        message=f"AskUserQuestion already pending for chat {chat_id}"
-      )
-
-    future = asyncio.get_running_loop().create_future()
-    pending = PendingQuestion(
-      question_id=str(uuid4()),
-      questions=questions,
-      future=future,
-      # The turn's persistence run token (the sink carries it). The
-      # answer route submits AnswerQuestion keyed on this so the writer
-      # actor fences the right (chat_id, run_token) snapshot before
-      # merging the answer; None for a sink/broadcast without one
-      # (legacy/test) → the answer route broad-fences by chat.
-      run_token=getattr(bc, "run_token", None),
-    )
-    pending_questions[chat_id] = pending
-
-    # Save-before-broadcast (Candidate B): the card's question_id MUST be
-    # durably persisted before the SSE event shows it, or a fast Submit
-    # races the DB write and the answer is lost. `publish_question`
-    # submits a QuestionCommit, awaits its ack, then broadcasts — and
-    # RAISES if the commit didn't land. We register the pending entry
-    # first (so the finally below always pops it) but on a failed commit
-    # DENY the tool with a persistence-unavailable message rather than
-    # broadcasting an unpersisted card or writing the blob directly.
-    #
-    # Push notification on AskUserQuestion is AGENT-DRIVEN: the skill/seed
-    # tells the agent to `curl POST /api/notifications/send` itself, so it
-    # has direct visibility into push success/failure and decides whether
-    # a given question is worth a phone buzz.
     try:
-      await bc.publish_question({
-        "type": "question",
-        "question_id": pending.question_id,
-        "questions": questions,
-      })
-    except Exception as exc:
+      answers = await park_question(
+        chat_id=chat_id,
+        questions=questions,
+        bc=bc,
+        pending_questions=pending_questions,
+      )
+    except QuestionOverlapError as exc:
+      return PermissionResultDeny(
+        message=str(exc)
+      )
+    except QuestionPersistenceError as exc:
       log.error(
         "AskUserQuestion save-before-broadcast failed chat_id=%s: %s",
         chat_id, exc,
       )
-      if pending_questions.get(chat_id) is pending:
-        pending_questions.pop(chat_id, None)
       return PermissionResultDeny(
         message=(
           "Could not save the question (persistence unavailable); not "
@@ -1379,17 +842,10 @@ async def run_claude_sdk_turn(
         )
       )
 
-    try:
-      answers = await future
     except asyncio.CancelledError:
-      if pending_questions.get(chat_id) is pending:
-        pending_questions.pop(chat_id, None)
       return PermissionResultDeny(
         message="AskUserQuestion cancelled."
       )
-
-    if pending_questions.get(chat_id) is pending:
-      pending_questions.pop(chat_id, None)
 
     # Per docs: return updated_input with BOTH the original questions
     # array AND an answers dict {question_text: selected_label}.

--- a/backend/app/codex_events.py
+++ b/backend/app/codex_events.py
@@ -1,0 +1,959 @@
+"""Codex app-server notifications translated into stable Möbius events.
+
+The runner owns SDK acquisition, process/control lifecycle, and retry decisions.
+This module owns typed-notification interpretation and public/private event
+shapes so protocol churn can be reviewed and tested without the turn machinery.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import time
+from typing import Any
+
+from app.codex_appserver import _extract_bash_command
+from app.json_safety import json_safe
+from app.providers import MODEL_LABELS
+from app.tool_sources import normalize_tool_sources
+
+log = logging.getLogger("moebius.chat")
+
+def _thinking_event(content: str, segment_id: str | None = None) -> dict:
+  """Build a reasoning delta, preserving its provider semantic segment.
+
+  Deltas within one segment are token fragments and concatenate verbatim.
+  Distinct summary/content indices are separate thoughts and need a paragraph
+  boundary. Keeping that identity on the wire lets both live and durable
+  reducers make the distinction without guessing from Markdown text.
+  """
+  event = {
+    "type": "thinking",
+    "content": content,
+    "ts": int(time.time() * 1000),
+  }
+  if segment_id:
+    event["segment_id"] = segment_id
+  return event
+
+
+def _codex_thinking_segment_id(payload: Any) -> str | None:
+  item_id = getattr(payload, "item_id", None)
+  if not item_id:
+    return None
+  summary_index = getattr(payload, "summary_index", None)
+  if summary_index is not None:
+    return f"codex:{item_id}:summary:{summary_index}"
+  content_index = getattr(payload, "content_index", None)
+  if content_index is not None:
+    return f"codex:{item_id}:content:{content_index}"
+  return f"codex:{item_id}"
+
+
+def _extract_rate_limit_reset(snapshot) -> tuple[int | None, bool]:
+  """Pull a park-worthy reset epoch + reached flag from a RateLimitSnapshot.
+
+  The Codex analog of what the Claude runner reads off RateLimitEvent. Picks the
+  most-constrained window's ``resets_at`` (the binding limit is the one closest
+  to full, so its reset is the one worth waiting for) and reports whether any
+  window/credit pool actually hit its cap. ``rate_limit_reached_type`` has no
+  "ok" member, so a non-None value reliably means a real limit hit — a
+  structured signal trustworthy without string-matching the error text.
+
+  Returns ``(resets_at_epoch_or_None, reached_bool)``. Defensive against partial
+  or older SDK payloads: any missing field degrades to skip / (None, False).
+  """
+  if snapshot is None:
+    return None, False
+  reached = getattr(snapshot, "rate_limit_reached_type", None) is not None
+  best_reset: int | None = None
+  best_used = -1.0
+  for window in (
+    getattr(snapshot, "primary", None),
+    getattr(snapshot, "secondary", None),
+  ):
+    if window is None:
+      continue
+    resets_at = getattr(window, "resets_at", None)
+    if resets_at is None:
+      continue
+    try:
+      used = float(getattr(window, "used_percent", 0) or 0)
+    except (TypeError, ValueError):
+      used = 0.0
+    if used > best_used:
+      best_used = used
+      best_reset = resets_at
+  return best_reset, reached
+
+
+def _model_dump(value: Any) -> Any:
+  """Turns provider SDK objects into plain JSON-safe values."""
+  return json_safe(value)
+
+
+def _format_json(value: Any) -> str:
+  """Returns a stable user-facing string for tool inputs and outputs."""
+  dumped = _model_dump(value)
+  if dumped is None or dumped == "":
+    return ""
+  if isinstance(dumped, str):
+    return dumped
+  try:
+    return json.dumps(dumped, ensure_ascii=True, indent=2)
+  except (TypeError, ValueError):
+    return str(dumped)
+
+
+def _reasoning_summary_setting(sdk: dict[str, Any]) -> Any | None:
+  """Ask Codex for the richest public reasoning summary it supports."""
+  summary_cls = sdk.get("ReasoningSummary")
+  if summary_cls is None:
+    return None
+  try:
+    return summary_cls("auto")
+  except Exception:
+    try:
+      return summary_cls(root="auto")
+    except Exception:
+      log.warning("Codex: could not construct ReasoningSummary", exc_info=True)
+      return None
+
+
+def _web_search_sources(item: Any) -> list[dict[str, str]]:
+  """Extract source URLs exposed by a Codex web-search item, if any.
+
+  The pinned SDK's public item model carries the URL on ``openPage`` and
+  ``findInPage`` actions, but not on a plain search action. Keep the optional
+  result-field scan for forward compatibility with SDKs that expose the app
+  server's result metadata directly.
+  """
+  collected: list[dict[str, str]] = []
+  seen: set[str] = set()
+
+  def add(raw: Any) -> None:
+    for source in normalize_tool_sources(raw):
+      url = source.get("url")
+      if not url or url in seen:
+        continue
+      collected.append(source)
+      seen.add(url)
+
+  for attr in ("results", "sources", "content", "output"):
+    add(getattr(item, attr, None))
+
+  action = getattr(item, "action", None)
+  action_root = getattr(action, "root", action)
+  add(action_root)
+  return collected
+
+
+def _stamp_tool_use_id(event: dict[str, Any], item: Any) -> None:
+  """Stamp the ThreadItem's stable id onto a tool event as `tool_use_id`
+  (contract rule 6), so a large tool output can be reduced on the wire and
+  fetched lazily by id.
+
+  Verified stable: every Codex ThreadItem carries an `id`, the SAME id rides
+  the `ItemStarted` (tool_start) and `ItemCompleted` (tool_output/tool_end)
+  notifications for one tool call, and the streaming output-delta / file-change
+  notifications reference it as `itemId` — so it is stable emit->read and unique
+  within the chat, which is all the stash key needs. A test fake without an
+  `id` (or a null id) is left unstamped, so the event shape is unchanged."""
+  tid = getattr(item, "id", None)
+  if tid:
+    event["tool_use_id"] = tid
+
+
+def _stamp_notification_item_id(event: dict[str, Any], payload: Any) -> None:
+  """Stamp `tool_use_id` from a notification's `item_id` (the streaming
+  output-delta / file-change-patch notifications reference their ThreadItem by
+  `itemId`, the same id the completed item carries). getattr-guarded so SDK
+  shape drift or a test fake without the field degrades to an untagged event
+  (which the sink leaves inline) rather than raising."""
+  item_id = getattr(payload, "item_id", None) or getattr(payload, "itemId", None)
+  if item_id:
+    event["tool_use_id"] = item_id
+
+
+# A collab tool input is a short human label. VERIFIED on codex 0.144.5: a
+# delegation turn streams the collab tool ONLY as the `wait` op, which carries
+# no prompt, so the label is the partner-language "Working in the background"
+# rather than a wire op string. A future SDK that surfaces the spawn op WITH a
+# prompt would render "<op>: <prompt>". The summary joins the sub-agents'
+# last-known messages (dead at runtime — see _collab_summary); both are bounded
+# so an oversized prompt or a chatty fleet cannot bloat the wire event.
+_COLLAB_DESCRIPTION_MAX = 120
+_COLLAB_SUMMARY_MAX = 500
+
+
+def _collab_op(item: Any) -> str:
+  """The collab tool operation as its wire string (spawnAgent, sendInput, …).
+
+  ``item.tool`` is a ``CollabAgentTool`` enum on a real SDK item; a test fake may
+  pass the raw string. Read ``.value`` when present and fall back to ``str`` so
+  the caller never has to import the enum just to branch on the operation.
+  """
+  tool = getattr(item, "tool", None)
+  value = getattr(tool, "value", None)
+  if value:
+    return value
+  return str(tool) if tool is not None else "collab"
+
+
+def _collab_description(item: Any) -> str:
+  """Build the partner-language input for an ordinary collab tool activity.
+
+  VERIFIED on codex 0.144.5: the only collab item that streams on the parent
+  turn is the `wait` op, which carries no prompt. With no prompt there is
+  nothing task-specific to name, so return a generic owner-facing label rather
+  than leaking the wire op string ("wait:") into the activity. When a prompt IS
+  present (a future SDK that surfaces the spawn op, or a test fake) keep the
+  "<op>: <prompt>" form so the chip names the delegated work. Bounded either way.
+  """
+  prompt = (getattr(item, "prompt", None) or "").strip()
+  if not prompt:
+    return "Working in the background"
+  op = _collab_op(item)
+  return f"{op}: {prompt}"[:_COLLAB_DESCRIPTION_MAX]
+
+
+def _collab_summary(item: Any) -> str | None:
+  """Join the sub-agents' last-known status messages into one summary line.
+
+  DEAD AT RUNTIME on codex 0.144.5: the only collab item that reaches the parent
+  stream is the `wait` op, whose ``agents_states`` is always EMPTY, so this
+  returns None every time in production. Kept defensively for a future SDK that
+  populates ``agents_states`` on the parent stream. Today the named child and
+  its result are surfaced HISTORICALLY by the Workflows app parser (via the
+  child rollout's parent_thread_id), NOT by this summary — so nobody should read
+  the live Codex chip as carrying the child's answer.
+
+  ``agents_states`` maps a child thread id to a ``CollabAgentState`` whose
+  ``message`` is the agent's latest note (often None while running). Skip the
+  empties and return None when nothing is available, so a still-silent fleet
+  produces no summary rather than an empty string.
+  """
+  states = getattr(item, "agents_states", None) or {}
+  messages = []
+  for state in states.values():
+    message = (getattr(state, "message", None) or "").strip()
+    if message:
+      messages.append(message)
+  if not messages:
+    return None
+  return "; ".join(messages)[:_COLLAB_SUMMARY_MAX]
+
+
+def _subagent_lifecycle_event(
+  item: Any, sdk: dict[str, Any], *, provider_session_id: str | None,
+  occurred_at: Any = None, provider_activation_id: str | None = None,
+) -> dict[str, Any] | None:
+  """Normalize a Codex subAgentActivity marker without inventing completion.
+
+  The native marker currently exposes started/interacted/interrupted.  Started
+  opens a helper lane; interrupted closes it as stopped. Interacted is progress,
+  not a lifecycle boundary, and remains intentionally silent.
+  """
+  cls = sdk.get("SubAgentActivityThreadItem")
+  if cls is None or not isinstance(item, cls):
+    return None
+  kind = getattr(getattr(item, "kind", None), "value", None)
+  kind = kind or str(getattr(item, "kind", ""))
+  if kind == "started":
+    event_type, state = "agent_started", "running"
+  elif kind == "interrupted":
+    event_type, state = "agent_terminal", "stopped"
+  else:
+    return None
+  return {
+    "type": "agent_lifecycle",
+    "provider": "codex",
+    "provider_session_id": provider_session_id,
+    "provider_agent_id": getattr(item, "agent_thread_id", None),
+    "provider_activation_id": provider_activation_id,
+    "parent_kind": "unknown",
+    "event_type": event_type,
+    "state": state,
+    # agent_path is identity/role metadata, not an outcome summary. Keeping
+    # non-terminal Codex summaries empty gives the durable table a structural
+    # guarantee that delegated prompt/preview prose cannot enter through a
+    # start fact.
+    "agent_type": getattr(item, "agent_path", None),
+    "occurred_at": occurred_at,
+    "source": "runner",
+    "source_event_id": getattr(item, "id", None),
+  }
+
+
+def _thread_started_lifecycle_event(
+  payload: Any, *, root_thread_id: str | None,
+  parent_provider_activation_id: str | None = None,
+) -> dict[str, Any] | None:
+  """Build the exact spawn/parent fact carried by ThreadStartedNotification."""
+  thread = getattr(payload, "thread", None)
+  thread_id = getattr(thread, "id", None)
+  if not thread_id:
+    return None
+  parent_id = getattr(thread, "parent_thread_id", None)
+  # A top-level thread started notification is not a spawned helper.
+  if not parent_id or parent_id == thread_id:
+    return None
+  role = getattr(thread, "agent_role", None)
+  nickname = getattr(thread, "agent_nickname", None)
+  return {
+    "type": "agent_lifecycle",
+    "provider": "codex",
+    "provider_session_id": root_thread_id,
+    "provider_agent_id": thread_id,
+    "provider_activation_id": f"thread-started:{thread_id}",
+    "parent_provider_agent_id": parent_id,
+    "parent_provider_activation_id": (
+      parent_provider_activation_id or f"thread-started:{parent_id}"
+    ),
+    "parent_kind": "main" if parent_id == root_thread_id else "agent",
+    "event_type": "agent_spawned",
+    "state": "running",
+    # ``thread.preview`` derives from the delegated prompt. Role/nickname is
+    # sufficient lifecycle metadata; never copy the preview into persistence.
+    "agent_type": role or nickname,
+    "occurred_at": getattr(thread, "created_at", None),
+    "source": "runner",
+    "source_event_id": f"thread-started:{thread_id}",
+  }
+
+
+def _record_private_lifecycle(bc: Any, event: dict[str, Any] | None) -> None:
+  if event is None:
+    return
+  recorder = getattr(bc, "record_lifecycle", None)
+  if callable(recorder):
+    recorder(event)
+
+
+def _public_task_event(
+  lifecycle: dict[str, Any] | None,
+  *,
+  tool_use_id: str,
+) -> dict[str, Any] | None:
+  """Translate one provider-neutral lifecycle fact into the shared chip wire.
+
+  Durable Workflows attribution keeps the richer ``agent_lifecycle`` record.
+  The transcript needs only the same task_start/task_done contract Claude
+  already uses. An activation id, rather than a child thread id, is the public
+  task identity because Codex can resume one helper multiple times in a turn.
+  """
+  if not lifecycle:
+    return None
+  task_id = (
+    lifecycle.get("provider_activation_id")
+    or lifecycle.get("provider_agent_id")
+  )
+  if not task_id:
+    return None
+  event_type = lifecycle.get("event_type")
+  if event_type in ("agent_spawned", "agent_started"):
+    agent_type = str(lifecycle.get("agent_type") or "").strip()
+    return {
+      "type": "task_start",
+      "task_id": str(task_id),
+      "description": (
+        agent_type[:_COLLAB_DESCRIPTION_MAX] or "Background helper"
+      ),
+      "task_type": agent_type or None,
+      "tool_use_id": tool_use_id,
+    }
+  if event_type == "agent_terminal":
+    summary = lifecycle.get("summary")
+    return {
+      "type": "task_done",
+      "task_id": str(task_id),
+      "status": lifecycle.get("state") or "done",
+      "summary": (
+        str(summary)[:_COLLAB_SUMMARY_MAX] if summary is not None else None
+      ),
+      "tool_use_id": tool_use_id,
+    }
+  return None
+
+
+def _collab_reactivation_events(
+  item: Any, sdk: dict[str, Any], *, root_thread_id: str | None,
+  occurred_at: Any, active: dict[str, str], known: set[str],
+  activation_by_call_child: dict[tuple[str, str], str],
+  last_activation_by_child: dict[str, str],
+) -> list[dict[str, Any]]:
+  cls = sdk.get("CollabAgentToolCallThreadItem")
+  if cls is None or not isinstance(item, cls):
+    return []
+  operation = _collab_op(item)
+  receivers = [str(value) for value in (
+    getattr(item, "receiver_thread_ids", None) or []) if value]
+  sender = getattr(item, "sender_thread_id", None)
+  call_id = str(getattr(item, "id", None) or operation)
+  if operation == "spawnAgent":
+    known.update(receivers)
+    for child_id in receivers:
+      activation = active.setdefault(child_id, f"thread-started:{child_id}")
+      activation_by_call_child[(call_id, child_id)] = activation
+      last_activation_by_child[child_id] = activation
+    return []  # ThreadStarted carries the exact spawn + ancestry fact.
+  if operation not in ("sendInput", "resumeAgent"):
+    return []
+  events = []
+  for child_id in receivers:
+    known.add(child_id)
+    activation = active.get(child_id)
+    if activation is not None:
+      # Input sent to an already-running child is progress in the current
+      # activation, not proof of a new lane. Keep the call association so its
+      # exact completion can still enrich that activation later.
+      activation_by_call_child[(call_id, child_id)] = activation
+      continue
+    activation = f"{call_id}:{child_id}"
+    active[child_id] = activation
+    activation_by_call_child[(call_id, child_id)] = activation
+    last_activation_by_child[child_id] = activation
+    parent_kind = "main" if sender and sender == root_thread_id else (
+      "agent" if sender else "unknown")
+    events.append({
+      "type": "agent_lifecycle", "provider": "codex",
+      "provider_session_id": root_thread_id,
+      "provider_agent_id": child_id,
+      "provider_activation_id": activation,
+      "parent_provider_agent_id": sender,
+      "parent_provider_activation_id": active.get(str(sender)) if sender else None,
+      "parent_kind": parent_kind,
+      "event_type": "agent_started", "state": "running",
+      # ``item.prompt`` is the delegated prompt body, not a lifecycle summary.
+      # It must not enter the durable observability table; the terminal agent
+      # state may later contribute a provider-authored result summary.
+      "occurred_at": occurred_at,
+      "source": "runner", "source_event_id": f"{call_id}:{child_id}:started",
+    })
+  return events
+
+
+def _collab_completion_events(
+  item: Any, sdk: dict[str, Any], *, root_thread_id: str | None,
+  occurred_at: Any, active: dict[str, str], known: set[str],
+  activation_by_call_child: dict[tuple[str, str], str],
+  last_activation_by_child: dict[str, str],
+) -> list[dict[str, Any]]:
+  cls = sdk.get("CollabAgentToolCallThreadItem")
+  if cls is None or not isinstance(item, cls):
+    return []
+  terminal = {
+    "completed": "done", "errored": "failed", "interrupted": "stopped",
+    "shutdown": "stopped",
+  }
+  events = []
+  call_id = str(getattr(item, "id", None) or _collab_op(item))
+  for child_id, agent_state in (getattr(item, "agents_states", None) or {}).items():
+    child_id = str(child_id)
+    raw_status = getattr(agent_state, "status", None)
+    status = getattr(raw_status, "value", None) or str(raw_status or "")
+    state = terminal.get(status)
+    activation = activation_by_call_child.get((call_id, child_id))
+    if activation is None:
+      activation = active.get(child_id) or last_activation_by_child.get(child_id)
+    if state is None or activation is None:
+      continue
+    known.add(child_id)
+    events.append({
+      "type": "agent_lifecycle", "provider": "codex",
+      "provider_session_id": root_thread_id,
+      "provider_agent_id": child_id,
+      "provider_activation_id": activation,
+      "parent_kind": "unknown", "event_type": "agent_terminal",
+      "state": state, "summary": getattr(agent_state, "message", None),
+      "occurred_at": occurred_at, "source": "runner",
+      "source_event_id": f"{call_id}:{child_id}:{status}",
+    })
+    last_activation_by_child[child_id] = activation
+    if active.get(child_id) == activation:
+      active.pop(child_id, None)
+  return events
+
+
+def _thread_status_lifecycle_event(
+  payload: Any, *, root_thread_id: str | None, active: dict[str, str],
+  known: set[str], activation_counts: dict[str, int],
+  last_activation_by_child: dict[str, str],
+) -> dict[str, Any] | None:
+  thread_id = str(getattr(payload, "thread_id", None) or "")
+  if not thread_id or thread_id == root_thread_id or thread_id not in known:
+    return None
+  status_union = getattr(payload, "status", None)
+  status_root = getattr(status_union, "root", status_union)
+  status_type = str(getattr(status_root, "type", ""))
+  if status_type == "active":
+    if thread_id in active:
+      return None
+    activation_counts[thread_id] = activation_counts.get(thread_id, 0) + 1
+    activation = f"status:{thread_id}:{activation_counts[thread_id]}"
+    active[thread_id] = activation
+    last_activation_by_child[thread_id] = activation
+    event_type, state = "agent_started", "running"
+  elif status_type in ("idle", "systemError"):
+    activation = active.pop(thread_id, None)
+    if activation is None:
+      return None
+    last_activation_by_child[thread_id] = activation
+    event_type = "agent_terminal"
+    state = "done" if status_type == "idle" else "failed"
+  else:
+    return None
+  return {
+    "type": "agent_lifecycle", "provider": "codex",
+    "provider_session_id": root_thread_id,
+    "provider_agent_id": thread_id,
+    "provider_activation_id": activation,
+    "parent_kind": "unknown", "event_type": event_type, "state": state,
+    "source": "runner",
+    "source_event_id": f"thread-status:{thread_id}:{activation}:{status_type}",
+  }
+
+
+async def _record_collab_child_links(
+  item: Any, sdk: dict[str, Any], *, chat_id: str,
+) -> None:
+  """Attribute a spawned sub-agent's thread to this chat.
+
+  DEAD AT RUNTIME on codex 0.144.5: the only collab item that reaches the parent
+  stream is the `wait` op (never a `spawnAgent`), and its ``receiver_thread_ids``
+  is always EMPTY, so the spawn gate below never fires and no link is recorded
+  here in production. Kept defensively for a future SDK that surfaces the spawn
+  op with populated ``receiver_thread_ids`` on the parent stream. Today the named
+  child rollout is attributed to this chat by the Workflows app parser via the
+  child's parent_thread_id, NOT by this recorder — so the live Codex chip is not
+  a named child link.
+
+  A spawn's ``receiver_thread_ids`` are the freshly-spawned child thread ids;
+  recording each in the append-only session->chat map keeps the child's own
+  rollout resolvable back to this chat even though it streams on its own thread.
+  Gated on the spawn operation (that is when a NEW child id first appears; the
+  other ops reference children already recorded at their spawn). Idempotent, and
+  never raises: observability must not break the notification loop. The write
+  goes through ``record_session_link_async`` (own session, worker thread) so it
+  neither blocks the stream loop nor touches the runner's shared ``db``.
+  """
+  try:
+    collab_cls = sdk.get("CollabAgentToolCallThreadItem")
+    if collab_cls is None or not isinstance(item, collab_cls):
+      return
+    if _collab_op(item) != "spawnAgent":
+      return
+    from app.session_links import record_session_link_async
+    for child_id in getattr(item, "receiver_thread_ids", None) or []:
+      await record_session_link_async("codex", child_id, chat_id)
+  except Exception:
+    log.debug("codex collab child-link recording failed", exc_info=True)
+
+
+def _tool_start_event(item: Any, sdk: dict[str, Any]) -> dict[str, Any] | None:
+  """Builds one Möbius `tool_start` event from a typed item."""
+  image_view_cls = sdk.get("ImageViewThreadItem")
+  if image_view_cls is not None and isinstance(item, image_view_cls):
+    return {
+      "type": "tool_start",
+      "tool": "ViewImage",
+      "input": _format_json(getattr(item, "path", "")),
+    }
+  # Standalone dispatch keeps collab items as ordinary Task activity. The live
+  # loop now groups all such items under one per-turn host and enriches it with
+  # ThreadStarted/ThreadStatus task events, avoiding duplicate Task rows while
+  # retaining this safe fallback for isolated callers and older SDKs.
+  collab_cls = sdk.get("CollabAgentToolCallThreadItem")
+  if collab_cls is not None and isinstance(item, collab_cls):
+    return {
+      "type": "tool_start",
+      "tool": "Task",
+      "input": _collab_description(item),
+    }
+  sub_activity_cls = sdk.get("SubAgentActivityThreadItem")
+  if sub_activity_cls is not None and isinstance(item, sub_activity_cls):
+    # subAgentActivity is Codex's sub-agent LIFECYCLE marker (agentPath,
+    # agentThreadId, kind) in the parent thread's item stream/history. The
+    # invariant: the sub-agent's actual tool work is surfaced elsewhere — live,
+    # the parent streams the delegation as the CollabAgentToolCallThreadItem
+    # `Task` events above; on resume, the parent's replayed history is never
+    # re-rendered (the runner uses only thread.id + thread.turn()). So the
+    # marker itself carries nothing Möbius opens as its own tool block. This is
+    # a DELIBERATE no-op, classified explicitly rather than left to fall through
+    # silently — surfacing sub-agent lifecycle as its own UI is a future UX
+    # decision, not an accident of omission (see test_codex_sdk_contract).
+    log.debug("codex subAgentActivity marker (no-op): kind=%s",
+              getattr(item, "kind", None))
+    return None
+  if isinstance(item, sdk["CommandExecutionThreadItem"]):
+    return {
+      "type": "tool_start",
+      "tool": "Bash",
+      "input": _extract_bash_command(item.command),
+    }
+  if isinstance(item, sdk["FileChangeThreadItem"]):
+    first = item.changes[0] if item.changes else None
+    path = _model_dump(first).get("path", "") if first is not None else ""
+    return {
+      "type": "tool_start",
+      "tool": "Edit",
+      "input": path,
+    }
+  if isinstance(item, sdk["McpToolCallThreadItem"]):
+    tool_name = f"{item.server}:{item.tool}" if item.server else item.tool
+    return {
+      "type": "tool_start",
+      "tool": tool_name or "mcp",
+      "input": _format_json(item.arguments),
+    }
+  if isinstance(item, sdk["DynamicToolCallThreadItem"]):
+    tool_name = item.tool
+    if item.namespace:
+      tool_name = f"{item.namespace}:{tool_name}"
+    return {
+      "type": "tool_start",
+      "tool": tool_name or "tool",
+      "input": _format_json(item.arguments),
+    }
+  if isinstance(item, sdk["WebSearchThreadItem"]):
+    return {
+      "type": "tool_start",
+      "tool": "WebSearch",
+      "input": item.query,
+    }
+  return None
+
+
+def _tool_completed_events(item: Any, sdk: dict[str, Any]) -> list[dict[str, Any]]:
+  """Builds Möbius tool-end events from a completed typed item."""
+  image_view_cls = sdk.get("ImageViewThreadItem")
+  if image_view_cls is not None and isinstance(item, image_view_cls):
+    return [{"type": "tool_end"}]
+  # Standalone dispatch closes the ordinary Task activity above. The live loop
+  # owns its one per-turn host and bypasses this branch, publishing normalized
+  # task_done events from lifecycle notifications before closing that host.
+  collab_cls = sdk.get("CollabAgentToolCallThreadItem")
+  if collab_cls is not None and isinstance(item, collab_cls):
+    events: list[dict[str, Any]] = []
+    summary = _collab_summary(item)
+    if summary:
+      events.append({"type": "tool_output", "content": summary})
+    events.append({"type": "tool_end"})
+    return events
+
+  sub_activity_cls = sdk.get("SubAgentActivityThreadItem")
+  if sub_activity_cls is not None and isinstance(item, sub_activity_cls):
+    # Completion counterpart of the _tool_start_event no-op: the sub-agent
+    # lifecycle marker opens no Möbius tool block, so it closes none. The live
+    # delegation's open/close rides CollabAgentToolCallThreadItem (`Task`); this
+    # marker is classified explicitly to keep the invariant visible rather than
+    # silently returning [] by fall-through.
+    return []
+
+  if isinstance(item, sdk["CommandExecutionThreadItem"]):
+    output = (item.aggregated_output or "").strip()
+    exit_code = getattr(item, "exit_code", None)
+    events: list[dict[str, Any]] = [{
+      "type": "tool_output",
+      "content": output,
+      "output_complete": True,
+      **({"output_exit_code": exit_code} if isinstance(exit_code, int) else {}),
+    }]
+    events.append({"type": "tool_end"})
+    return events
+
+  if isinstance(item, sdk["FileChangeThreadItem"]):
+    lines: list[str] = []
+    for change in item.changes:
+      change_dict = _model_dump(change) or {}
+      kind = change_dict.get("kind", "?")
+      path = change_dict.get("path", "")
+      line = f"{kind} {path}".strip()
+      if line:
+        lines.append(line)
+    events: list[dict[str, Any]] = []
+    if lines:
+      events.append({"type": "tool_output", "content": "\n".join(lines)})
+    events.append({"type": "tool_end"})
+    return events
+
+  if isinstance(item, sdk["McpToolCallThreadItem"]):
+    events: list[dict[str, Any]] = []
+    result = _format_json(item.result)
+    if result:
+      events.append({"type": "tool_output", "content": result})
+    events.append({"type": "tool_end"})
+    return events
+
+  if isinstance(item, sdk["DynamicToolCallThreadItem"]):
+    events: list[dict[str, Any]] = []
+    result = _format_json(item.content_items)
+    if result:
+      events.append({"type": "tool_output", "content": result})
+    events.append({"type": "tool_end"})
+    return events
+
+  if isinstance(item, sdk["WebSearchThreadItem"]):
+    events: list[dict[str, Any]] = []
+    # The real query (or the opened page's URL) only lands on completion —
+    # ItemStarted carried an empty one, so the row showed a bare "WebSearch".
+    # Backfill it now; the caller stamps tool_use_id so it targets this exact
+    # search rather than the first input-less block.
+    query = getattr(item, "query", "")
+    if query:
+      events.append({"type": "tool_input", "input": query})
+    sources = _web_search_sources(item)
+    if sources:
+      events.append({"type": "tool_sources", "sources": sources})
+    events.append({"type": "tool_end"})
+    return events
+
+  if isinstance(item, sdk["AgentMessageThreadItem"]):
+    # Materialize the authoritative full text of the completed assistant
+    # message. Durable prose otherwise rides ONLY on the streamed
+    # AgentMessageDeltaNotification deltas (published as "text" above); if those
+    # were absent/dropped/coalesced (observed on oversized responses, e.g. a
+    # "very long numbered" request that persisted NOTHING) the reply vanishes
+    # silently. text_final REPLACES the accumulated text block, so it is
+    # idempotent when the deltas already delivered identical prose (events.py
+    # returns False), converts the lingering text_boundary into text when no
+    # delta arrived, and recovers a truncated prefix. Guarded on non-empty text
+    # so a genuinely-empty message stays silent.
+    text = item.text or ""
+    if text.strip():
+      event = {"type": "text_final", "content": text}
+      item_id = getattr(item, "id", None)
+      if item_id:
+        event["text_item_id"] = item_id
+      return [event]
+    return []
+
+  return []
+
+
+def _enum_wire_value(value: Any) -> str | None:
+  """Returns the wire value for a generated enum, tolerating test doubles."""
+  if value is None:
+    return None
+  raw = getattr(value, "value", value)
+  return raw if isinstance(raw, str) else str(raw)
+
+
+_CHATGPT_MODEL_UNAVAILABLE_RE = re.compile(
+  r"[\"'](?P<model>[^\"']+)[\"'] model is not supported when using Codex "
+  r"with a ChatGPT account",
+  re.IGNORECASE,
+)
+
+
+def _codex_user_error(error_text: str | None) -> str | None:
+  """Turns a known account/model rejection into a useful next action.
+
+  The live Codex catalog can advertise a model that the signed-in account's
+  plan or staged rollout cannot actually run. The upstream 400 is technically
+  precise but reads like a broken connection and offers no recovery path.
+  Preserve every unknown provider error verbatim; only this exact, observed
+  contract gets product wording.
+  """
+  if not error_text:
+    return error_text
+  match = _CHATGPT_MODEL_UNAVAILABLE_RE.search(error_text)
+  if match is None:
+    return error_text
+  model_id = match.group("model")
+  model_name = MODEL_LABELS.get(model_id, model_id)
+  return (
+    f"{model_name} isn’t available for this ChatGPT account. Codex is "
+    "connected, but this account’s current plan or model rollout does not "
+    "include it. Choose another Codex model from this chat’s Model menu, "
+    "then try again."
+  )
+
+
+def _agent_message_phase(item: Any, sdk: dict[str, Any]) -> str | None:
+  """Returns a completed agent message's native SDK phase."""
+  if not isinstance(item, sdk["AgentMessageThreadItem"]):
+    return None
+  return _enum_wire_value(getattr(item, "phase", None))
+
+
+def _turn_items(turn: Any) -> list[Any]:
+  """Unwraps the typed items included in a TurnCompleted payload."""
+  items = getattr(turn, "items", None) or []
+  return [
+    item.root if hasattr(item, "root") else item
+    for item in items
+  ]
+
+
+def _codex_terminal_error(
+  completed_turn: Any | None,
+  sdk: dict[str, Any],
+  *,
+  interrupt_requested: bool,
+  completed_message_phases: list[str | None],
+) -> tuple[str | None, str | None, str | None]:
+  """Validates the SDK's native turn-status and message-phase contract.
+
+  `turn/completed` is the terminal notification envelope, not proof that the
+  model completed the task. The nested TurnStatus carries that fact. Likewise,
+  an AgentMessageThreadItem marked `commentary` is an in-progress preamble,
+  while `final_answer` is the SDK's explicit completion signal.
+
+  Older SDK payloads can omit both status and message phase; that fully-legacy
+  shape retains historical success. Otherwise a completed turn needs an actual
+  agent message, and the LAST such message must be final: an earlier final
+  followed by commentary is not terminal completion. phase=None remains the
+  SDK helper's legacy final-response marker when a message is present.
+  """
+  if completed_turn is None:
+    return (
+      "Codex turn stream ended without a turn/completed notification.",
+      None,
+      None,
+    )
+
+  terminal_status = _enum_wire_value(getattr(completed_turn, "status", None))
+  failed_status = _enum_wire_value(sdk["TurnStatus"].failed)
+  interrupted_status = _enum_wire_value(sdk["TurnStatus"].interrupted)
+  completed_status = _enum_wire_value(sdk["TurnStatus"].completed)
+  error = getattr(completed_turn, "error", None)
+  error_message = getattr(error, "message", None) if error is not None else None
+
+  if terminal_status == failed_status:
+    return (
+      str(error_message or "Codex turn failed without an error message."),
+      terminal_status,
+      None,
+    )
+  if terminal_status == interrupted_status:
+    if not interrupt_requested:
+      return (
+        "Codex turn was interrupted unexpectedly.",
+        terminal_status,
+        None,
+      )
+    return None, terminal_status, None
+  if terminal_status not in (None, completed_status):
+    return (
+      f"Codex turn ended with unexpected status {terminal_status!r}.",
+      terminal_status,
+      None,
+    )
+  if error is not None:
+    return (
+      str(error_message or "Codex turn completed with an unknown error."),
+      terminal_status,
+      None,
+    )
+
+  # ItemCompleted normally carries phases first. When TurnCompleted includes
+  # agent items, that ordered snapshot is authoritative rather than additive:
+  # deduping/merging two streams can reorder messages and turn an earlier final
+  # into a false terminal success.
+  turn_phases = [
+    _agent_message_phase(item, sdk)
+    for item in _turn_items(completed_turn)
+    if isinstance(item, sdk["AgentMessageThreadItem"])
+  ]
+  phases = turn_phases if turn_phases else list(completed_message_phases)
+  commentary_phase = _enum_wire_value(sdk["MessagePhase"].commentary)
+  final_answer_phase = _enum_wire_value(sdk["MessagePhase"].final_answer)
+  if not phases:
+    if terminal_status is None:
+      return None, terminal_status, None
+    return (
+      "Codex turn completed without an agent final answer.",
+      terminal_status,
+      None,
+    )
+
+  final_message_phase = phases[-1]
+  if final_message_phase == commentary_phase:
+    return (
+      "Codex turn completed after commentary without a final answer.",
+      terminal_status,
+      final_message_phase,
+    )
+  if final_message_phase not in (None, final_answer_phase):
+    return (
+      f"Codex turn completed with unexpected final message phase "
+      f"{final_message_phase!r}.",
+      terminal_status,
+      final_message_phase,
+    )
+  return None, terminal_status, final_message_phase
+
+
+def _skill_names_in_command(command: str, data_dir: str) -> list[str]:
+  """Extracts Möbius skill names a shell command reads.
+
+  Codex has no Read tool and no `can_use_tool` hook — its closest
+  interception point is the command-execution item stream, where a
+  skill load looks like `cat /data/shared/skills/<name>.md` (flat) or
+  `cat /data/shared/skills/<id>/SKILL.md` (the directory shape installed
+  skills use), possibly via sed/head/grep over the same path. Any
+  reference to a skill file in a command counts as a load; that
+  over-counts an edit-in-place, which is acceptable for an aggregate
+  most-used signal. A directory skill is keyed by its DIRECTORY name —
+  the on-disk id — matching the Claude Read observer and the usage
+  aggregation; a deeper resource read inside the directory is not a
+  load. Returns deduped names in first-mention order.
+  """
+  if not command:
+    return []
+  from app.skills import GENERATED_INDEX_STEMS
+
+  prefix = re.escape(
+    os.path.normpath(os.path.join(data_dir, "shared", "skills"))
+  )
+  names: list[str] = []
+  # Either `<id>/SKILL.md` (directory skill, id = the dir name, SKILL.md
+  # case-insensitive) or a flat `<name>.md` directly under skills/. The two
+  # alternatives are disjoint (a flat match can't span a `/`), so one pass in
+  # command order preserves first-mention order without double counting.
+  pattern = prefix + r"/([A-Za-z0-9._-]+)(?:/(?i:SKILL\.md)|\.md)\b"
+  for match in re.finditer(pattern, command):
+    name = match.group(1)
+    # Reading a generated index is consulting a listing, not loading a skill.
+    if name not in names and name not in GENERATED_INDEX_STEMS:
+      names.append(name)
+  return names
+
+
+def _observe_skill_reads(
+  item: Any, sdk: dict[str, Any], *, bc: Any, chat_id: str,
+) -> None:
+  """Fire-and-forget `skill_loaded` events for skill-file shell reads.
+
+  Mirrors `observe_skill_file_read` in claude_sdk_runner: same wire
+  event (chip), same activity record (most-used-skills aggregation).
+  Never raises — observability must not break the notification loop.
+  """
+  try:
+    if not isinstance(item, sdk["CommandExecutionThreadItem"]):
+      return
+    from app import activity
+    from app.config import get_settings
+    command = _extract_bash_command(item.command or "")
+    skills = _skill_names_in_command(command, get_settings().data_dir)
+    for skill in skills:
+      bc.publish({"type": "skill_loaded", "skill": skill})
+      activity.log_skill_load(chat_id, skill)
+  except Exception:
+    log.debug("codex skill_loaded observability failed", exc_info=True)
+
+
+def _file_change_patch_summary(changes: list[Any]) -> str:
+  """Summarizes one file-change patch update as `kind path` lines."""
+  lines: list[str] = []
+  for change in changes:
+    change_dict = _model_dump(change) or {}
+    kind = change_dict.get("kind", "?")
+    path = change_dict.get("path", "")
+    line = f"{kind} {path}".strip()
+    if line:
+      lines.append(line)
+  return "\n".join(lines)

--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -60,58 +60,55 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures as _cf
-import json
 import logging
 import os
-import re
 import signal
 import shutil
 import time
 from dataclasses import dataclass
 from typing import Any, Callable
 
-from app.codex_appserver import _extract_bash_command
-from app.json_safety import json_safe
+from app.codex_events import (
+  _thinking_event,
+  _codex_thinking_segment_id,
+  _extract_rate_limit_reset,
+  _model_dump,
+  _reasoning_summary_setting,
+  _stamp_tool_use_id,
+  _stamp_notification_item_id,
+  _subagent_lifecycle_event,
+  _thread_started_lifecycle_event,
+  _record_private_lifecycle,
+  _public_task_event,
+  _collab_reactivation_events,
+  _collab_completion_events,
+  _thread_status_lifecycle_event,
+  _record_collab_child_links,
+  _tool_start_event,
+  _tool_completed_events,
+  _enum_wire_value,
+  _codex_user_error,
+  _agent_message_phase,
+  _codex_terminal_error,
+  # Compatibility import for existing internal callers; implementation lives
+  # beside the Codex event/observability code it supports.
+  _skill_names_in_command,
+  _observe_skill_reads,
+  _file_change_patch_summary,
+)
 from app.process_groups import lower_process_group_priority
-from app.providers import MODEL_LABELS, get_skill_path
+from app.providers import get_skill_path
+from app.question_bridge import (
+  QuestionOverlapError,
+  QuestionPersistenceError,
+  park_question,
+)
 from app.runtime_types import RunnerResult
 from app.usage_metrics import codex_cost_usd, normalize_codex_usage
 from app.runner_registry import RunnerKind, registry
-from app.tool_sources import normalize_tool_sources
 from app.memory_observability import record_memory_checkpoint_once
 
 log = logging.getLogger("moebius.chat")
-
-
-def _thinking_event(content: str, segment_id: str | None = None) -> dict:
-  """Build a reasoning delta, preserving its provider semantic segment.
-
-  Deltas within one segment are token fragments and concatenate verbatim.
-  Distinct summary/content indices are separate thoughts and need a paragraph
-  boundary. Keeping that identity on the wire lets both live and durable
-  reducers make the distinction without guessing from Markdown text.
-  """
-  event = {
-    "type": "thinking",
-    "content": content,
-    "ts": int(time.time() * 1000),
-  }
-  if segment_id:
-    event["segment_id"] = segment_id
-  return event
-
-
-def _codex_thinking_segment_id(payload: Any) -> str | None:
-  item_id = getattr(payload, "item_id", None)
-  if not item_id:
-    return None
-  summary_index = getattr(payload, "summary_index", None)
-  if summary_index is not None:
-    return f"codex:{item_id}:summary:{summary_index}"
-  content_index = getattr(payload, "content_index", None)
-  if content_index is not None:
-    return f"codex:{item_id}:content:{content_index}"
-  return f"codex:{item_id}"
 
 
 def _env_flag_on(name: str, *, default: bool) -> bool:
@@ -393,14 +390,6 @@ class _BridgeError(Exception):
 
   Module-level so test code and any future bridge paths can catch it by
   name without importing from inside a closure.
-  """
-
-
-class _OverlapError(_BridgeError):
-  """An AskUserQuestion was submitted while one was already pending.
-
-  The sync handler returns a JSON-RPC error so Codex fails the tool call
-  rather than continuing with empty answers (B2/B5 from round-5 review).
   """
 
 
@@ -1080,913 +1069,6 @@ def _enable_cache_write_usage_passthrough(
   notification_type.model_rebuild(force=True)
 
 
-def _extract_rate_limit_reset(snapshot) -> tuple[int | None, bool]:
-  """Pull a park-worthy reset epoch + reached flag from a RateLimitSnapshot.
-
-  The Codex analog of what the Claude runner reads off RateLimitEvent. Picks the
-  most-constrained window's ``resets_at`` (the binding limit is the one closest
-  to full, so its reset is the one worth waiting for) and reports whether any
-  window/credit pool actually hit its cap. ``rate_limit_reached_type`` has no
-  "ok" member, so a non-None value reliably means a real limit hit — a
-  structured signal trustworthy without string-matching the error text.
-
-  Returns ``(resets_at_epoch_or_None, reached_bool)``. Defensive against partial
-  or older SDK payloads: any missing field degrades to skip / (None, False).
-  """
-  if snapshot is None:
-    return None, False
-  reached = getattr(snapshot, "rate_limit_reached_type", None) is not None
-  best_reset: int | None = None
-  best_used = -1.0
-  for window in (
-    getattr(snapshot, "primary", None),
-    getattr(snapshot, "secondary", None),
-  ):
-    if window is None:
-      continue
-    resets_at = getattr(window, "resets_at", None)
-    if resets_at is None:
-      continue
-    try:
-      used = float(getattr(window, "used_percent", 0) or 0)
-    except (TypeError, ValueError):
-      used = 0.0
-    if used > best_used:
-      best_used = used
-      best_reset = resets_at
-  return best_reset, reached
-
-
-def _model_dump(value: Any) -> Any:
-  """Turns provider SDK objects into plain JSON-safe values."""
-  return json_safe(value)
-
-
-def _format_json(value: Any) -> str:
-  """Returns a stable user-facing string for tool inputs and outputs."""
-  dumped = _model_dump(value)
-  if dumped is None or dumped == "":
-    return ""
-  if isinstance(dumped, str):
-    return dumped
-  try:
-    return json.dumps(dumped, ensure_ascii=True, indent=2)
-  except (TypeError, ValueError):
-    return str(dumped)
-
-
-def _reasoning_summary_setting(sdk: dict[str, Any]) -> Any | None:
-  """Ask Codex for the richest public reasoning summary it supports."""
-  summary_cls = sdk.get("ReasoningSummary")
-  if summary_cls is None:
-    return None
-  try:
-    return summary_cls("auto")
-  except Exception:
-    try:
-      return summary_cls(root="auto")
-    except Exception:
-      log.warning("Codex: could not construct ReasoningSummary", exc_info=True)
-      return None
-
-
-def _web_search_sources(item: Any) -> list[dict[str, str]]:
-  """Extract source URLs exposed by a Codex web-search item, if any.
-
-  The pinned SDK's public item model carries the URL on ``openPage`` and
-  ``findInPage`` actions, but not on a plain search action. Keep the optional
-  result-field scan for forward compatibility with SDKs that expose the app
-  server's result metadata directly.
-  """
-  collected: list[dict[str, str]] = []
-  seen: set[str] = set()
-
-  def add(raw: Any) -> None:
-    for source in normalize_tool_sources(raw):
-      url = source.get("url")
-      if not url or url in seen:
-        continue
-      collected.append(source)
-      seen.add(url)
-
-  for attr in ("results", "sources", "content", "output"):
-    add(getattr(item, attr, None))
-
-  action = getattr(item, "action", None)
-  action_root = getattr(action, "root", action)
-  add(action_root)
-  return collected
-
-
-def _stamp_tool_use_id(event: dict[str, Any], item: Any) -> None:
-  """Stamp the ThreadItem's stable id onto a tool event as `tool_use_id`
-  (contract rule 6), so a large tool output can be reduced on the wire and
-  fetched lazily by id.
-
-  Verified stable: every Codex ThreadItem carries an `id`, the SAME id rides
-  the `ItemStarted` (tool_start) and `ItemCompleted` (tool_output/tool_end)
-  notifications for one tool call, and the streaming output-delta / file-change
-  notifications reference it as `itemId` — so it is stable emit->read and unique
-  within the chat, which is all the stash key needs. A test fake without an
-  `id` (or a null id) is left unstamped, so the event shape is unchanged."""
-  tid = getattr(item, "id", None)
-  if tid:
-    event["tool_use_id"] = tid
-
-
-def _stamp_notification_item_id(event: dict[str, Any], payload: Any) -> None:
-  """Stamp `tool_use_id` from a notification's `item_id` (the streaming
-  output-delta / file-change-patch notifications reference their ThreadItem by
-  `itemId`, the same id the completed item carries). getattr-guarded so SDK
-  shape drift or a test fake without the field degrades to an untagged event
-  (which the sink leaves inline) rather than raising."""
-  item_id = getattr(payload, "item_id", None) or getattr(payload, "itemId", None)
-  if item_id:
-    event["tool_use_id"] = item_id
-
-
-# A collab tool input is a short human label. VERIFIED on codex 0.144.5: a
-# delegation turn streams the collab tool ONLY as the `wait` op, which carries
-# no prompt, so the label is the partner-language "Working in the background"
-# rather than a wire op string. A future SDK that surfaces the spawn op WITH a
-# prompt would render "<op>: <prompt>". The summary joins the sub-agents'
-# last-known messages (dead at runtime — see _collab_summary); both are bounded
-# so an oversized prompt or a chatty fleet cannot bloat the wire event.
-_COLLAB_DESCRIPTION_MAX = 120
-_COLLAB_SUMMARY_MAX = 500
-
-
-def _collab_op(item: Any) -> str:
-  """The collab tool operation as its wire string (spawnAgent, sendInput, …).
-
-  ``item.tool`` is a ``CollabAgentTool`` enum on a real SDK item; a test fake may
-  pass the raw string. Read ``.value`` when present and fall back to ``str`` so
-  the caller never has to import the enum just to branch on the operation.
-  """
-  tool = getattr(item, "tool", None)
-  value = getattr(tool, "value", None)
-  if value:
-    return value
-  return str(tool) if tool is not None else "collab"
-
-
-def _collab_description(item: Any) -> str:
-  """Build the partner-language input for an ordinary collab tool activity.
-
-  VERIFIED on codex 0.144.5: the only collab item that streams on the parent
-  turn is the `wait` op, which carries no prompt. With no prompt there is
-  nothing task-specific to name, so return a generic owner-facing label rather
-  than leaking the wire op string ("wait:") into the activity. When a prompt IS
-  present (a future SDK that surfaces the spawn op, or a test fake) keep the
-  "<op>: <prompt>" form so the chip names the delegated work. Bounded either way.
-  """
-  prompt = (getattr(item, "prompt", None) or "").strip()
-  if not prompt:
-    return "Working in the background"
-  op = _collab_op(item)
-  return f"{op}: {prompt}"[:_COLLAB_DESCRIPTION_MAX]
-
-
-def _collab_summary(item: Any) -> str | None:
-  """Join the sub-agents' last-known status messages into one summary line.
-
-  DEAD AT RUNTIME on codex 0.144.5: the only collab item that reaches the parent
-  stream is the `wait` op, whose ``agents_states`` is always EMPTY, so this
-  returns None every time in production. Kept defensively for a future SDK that
-  populates ``agents_states`` on the parent stream. Today the named child and
-  its result are surfaced HISTORICALLY by the Workflows app parser (via the
-  child rollout's parent_thread_id), NOT by this summary — so nobody should read
-  the live Codex chip as carrying the child's answer.
-
-  ``agents_states`` maps a child thread id to a ``CollabAgentState`` whose
-  ``message`` is the agent's latest note (often None while running). Skip the
-  empties and return None when nothing is available, so a still-silent fleet
-  produces no summary rather than an empty string.
-  """
-  states = getattr(item, "agents_states", None) or {}
-  messages = []
-  for state in states.values():
-    message = (getattr(state, "message", None) or "").strip()
-    if message:
-      messages.append(message)
-  if not messages:
-    return None
-  return "; ".join(messages)[:_COLLAB_SUMMARY_MAX]
-
-
-def _subagent_lifecycle_event(
-  item: Any, sdk: dict[str, Any], *, provider_session_id: str | None,
-  occurred_at: Any = None, provider_activation_id: str | None = None,
-) -> dict[str, Any] | None:
-  """Normalize a Codex subAgentActivity marker without inventing completion.
-
-  The native marker currently exposes started/interacted/interrupted.  Started
-  opens a helper lane; interrupted closes it as stopped. Interacted is progress,
-  not a lifecycle boundary, and remains intentionally silent.
-  """
-  cls = sdk.get("SubAgentActivityThreadItem")
-  if cls is None or not isinstance(item, cls):
-    return None
-  kind = getattr(getattr(item, "kind", None), "value", None)
-  kind = kind or str(getattr(item, "kind", ""))
-  if kind == "started":
-    event_type, state = "agent_started", "running"
-  elif kind == "interrupted":
-    event_type, state = "agent_terminal", "stopped"
-  else:
-    return None
-  return {
-    "type": "agent_lifecycle",
-    "provider": "codex",
-    "provider_session_id": provider_session_id,
-    "provider_agent_id": getattr(item, "agent_thread_id", None),
-    "provider_activation_id": provider_activation_id,
-    "parent_kind": "unknown",
-    "event_type": event_type,
-    "state": state,
-    # agent_path is identity/role metadata, not an outcome summary. Keeping
-    # non-terminal Codex summaries empty gives the durable table a structural
-    # guarantee that delegated prompt/preview prose cannot enter through a
-    # start fact.
-    "agent_type": getattr(item, "agent_path", None),
-    "occurred_at": occurred_at,
-    "source": "runner",
-    "source_event_id": getattr(item, "id", None),
-  }
-
-
-def _thread_started_lifecycle_event(
-  payload: Any, *, root_thread_id: str | None,
-  parent_provider_activation_id: str | None = None,
-) -> dict[str, Any] | None:
-  """Build the exact spawn/parent fact carried by ThreadStartedNotification."""
-  thread = getattr(payload, "thread", None)
-  thread_id = getattr(thread, "id", None)
-  if not thread_id:
-    return None
-  parent_id = getattr(thread, "parent_thread_id", None)
-  # A top-level thread started notification is not a spawned helper.
-  if not parent_id or parent_id == thread_id:
-    return None
-  role = getattr(thread, "agent_role", None)
-  nickname = getattr(thread, "agent_nickname", None)
-  return {
-    "type": "agent_lifecycle",
-    "provider": "codex",
-    "provider_session_id": root_thread_id,
-    "provider_agent_id": thread_id,
-    "provider_activation_id": f"thread-started:{thread_id}",
-    "parent_provider_agent_id": parent_id,
-    "parent_provider_activation_id": (
-      parent_provider_activation_id or f"thread-started:{parent_id}"
-    ),
-    "parent_kind": "main" if parent_id == root_thread_id else "agent",
-    "event_type": "agent_spawned",
-    "state": "running",
-    # ``thread.preview`` derives from the delegated prompt. Role/nickname is
-    # sufficient lifecycle metadata; never copy the preview into persistence.
-    "agent_type": role or nickname,
-    "occurred_at": getattr(thread, "created_at", None),
-    "source": "runner",
-    "source_event_id": f"thread-started:{thread_id}",
-  }
-
-
-def _record_private_lifecycle(bc: Any, event: dict[str, Any] | None) -> None:
-  if event is None:
-    return
-  recorder = getattr(bc, "record_lifecycle", None)
-  if callable(recorder):
-    recorder(event)
-
-
-def _public_task_event(
-  lifecycle: dict[str, Any] | None,
-  *,
-  tool_use_id: str,
-) -> dict[str, Any] | None:
-  """Translate one provider-neutral lifecycle fact into the shared chip wire.
-
-  Durable Workflows attribution keeps the richer ``agent_lifecycle`` record.
-  The transcript needs only the same task_start/task_done contract Claude
-  already uses. An activation id, rather than a child thread id, is the public
-  task identity because Codex can resume one helper multiple times in a turn.
-  """
-  if not lifecycle:
-    return None
-  task_id = (
-    lifecycle.get("provider_activation_id")
-    or lifecycle.get("provider_agent_id")
-  )
-  if not task_id:
-    return None
-  event_type = lifecycle.get("event_type")
-  if event_type in ("agent_spawned", "agent_started"):
-    agent_type = str(lifecycle.get("agent_type") or "").strip()
-    return {
-      "type": "task_start",
-      "task_id": str(task_id),
-      "description": (
-        agent_type[:_COLLAB_DESCRIPTION_MAX] or "Background helper"
-      ),
-      "task_type": agent_type or None,
-      "tool_use_id": tool_use_id,
-    }
-  if event_type == "agent_terminal":
-    summary = lifecycle.get("summary")
-    return {
-      "type": "task_done",
-      "task_id": str(task_id),
-      "status": lifecycle.get("state") or "done",
-      "summary": (
-        str(summary)[:_COLLAB_SUMMARY_MAX] if summary is not None else None
-      ),
-      "tool_use_id": tool_use_id,
-    }
-  return None
-
-
-def _collab_reactivation_events(
-  item: Any, sdk: dict[str, Any], *, root_thread_id: str | None,
-  occurred_at: Any, active: dict[str, str], known: set[str],
-  activation_by_call_child: dict[tuple[str, str], str],
-  last_activation_by_child: dict[str, str],
-) -> list[dict[str, Any]]:
-  cls = sdk.get("CollabAgentToolCallThreadItem")
-  if cls is None or not isinstance(item, cls):
-    return []
-  operation = _collab_op(item)
-  receivers = [str(value) for value in (
-    getattr(item, "receiver_thread_ids", None) or []) if value]
-  sender = getattr(item, "sender_thread_id", None)
-  call_id = str(getattr(item, "id", None) or operation)
-  if operation == "spawnAgent":
-    known.update(receivers)
-    for child_id in receivers:
-      activation = active.setdefault(child_id, f"thread-started:{child_id}")
-      activation_by_call_child[(call_id, child_id)] = activation
-      last_activation_by_child[child_id] = activation
-    return []  # ThreadStarted carries the exact spawn + ancestry fact.
-  if operation not in ("sendInput", "resumeAgent"):
-    return []
-  events = []
-  for child_id in receivers:
-    known.add(child_id)
-    activation = active.get(child_id)
-    if activation is not None:
-      # Input sent to an already-running child is progress in the current
-      # activation, not proof of a new lane. Keep the call association so its
-      # exact completion can still enrich that activation later.
-      activation_by_call_child[(call_id, child_id)] = activation
-      continue
-    activation = f"{call_id}:{child_id}"
-    active[child_id] = activation
-    activation_by_call_child[(call_id, child_id)] = activation
-    last_activation_by_child[child_id] = activation
-    parent_kind = "main" if sender and sender == root_thread_id else (
-      "agent" if sender else "unknown")
-    events.append({
-      "type": "agent_lifecycle", "provider": "codex",
-      "provider_session_id": root_thread_id,
-      "provider_agent_id": child_id,
-      "provider_activation_id": activation,
-      "parent_provider_agent_id": sender,
-      "parent_provider_activation_id": active.get(str(sender)) if sender else None,
-      "parent_kind": parent_kind,
-      "event_type": "agent_started", "state": "running",
-      # ``item.prompt`` is the delegated prompt body, not a lifecycle summary.
-      # It must not enter the durable observability table; the terminal agent
-      # state may later contribute a provider-authored result summary.
-      "occurred_at": occurred_at,
-      "source": "runner", "source_event_id": f"{call_id}:{child_id}:started",
-    })
-  return events
-
-
-def _collab_completion_events(
-  item: Any, sdk: dict[str, Any], *, root_thread_id: str | None,
-  occurred_at: Any, active: dict[str, str], known: set[str],
-  activation_by_call_child: dict[tuple[str, str], str],
-  last_activation_by_child: dict[str, str],
-) -> list[dict[str, Any]]:
-  cls = sdk.get("CollabAgentToolCallThreadItem")
-  if cls is None or not isinstance(item, cls):
-    return []
-  terminal = {
-    "completed": "done", "errored": "failed", "interrupted": "stopped",
-    "shutdown": "stopped",
-  }
-  events = []
-  call_id = str(getattr(item, "id", None) or _collab_op(item))
-  for child_id, agent_state in (getattr(item, "agents_states", None) or {}).items():
-    child_id = str(child_id)
-    raw_status = getattr(agent_state, "status", None)
-    status = getattr(raw_status, "value", None) or str(raw_status or "")
-    state = terminal.get(status)
-    activation = activation_by_call_child.get((call_id, child_id))
-    if activation is None:
-      activation = active.get(child_id) or last_activation_by_child.get(child_id)
-    if state is None or activation is None:
-      continue
-    known.add(child_id)
-    events.append({
-      "type": "agent_lifecycle", "provider": "codex",
-      "provider_session_id": root_thread_id,
-      "provider_agent_id": child_id,
-      "provider_activation_id": activation,
-      "parent_kind": "unknown", "event_type": "agent_terminal",
-      "state": state, "summary": getattr(agent_state, "message", None),
-      "occurred_at": occurred_at, "source": "runner",
-      "source_event_id": f"{call_id}:{child_id}:{status}",
-    })
-    last_activation_by_child[child_id] = activation
-    if active.get(child_id) == activation:
-      active.pop(child_id, None)
-  return events
-
-
-def _thread_status_lifecycle_event(
-  payload: Any, *, root_thread_id: str | None, active: dict[str, str],
-  known: set[str], activation_counts: dict[str, int],
-  last_activation_by_child: dict[str, str],
-) -> dict[str, Any] | None:
-  thread_id = str(getattr(payload, "thread_id", None) or "")
-  if not thread_id or thread_id == root_thread_id or thread_id not in known:
-    return None
-  status_union = getattr(payload, "status", None)
-  status_root = getattr(status_union, "root", status_union)
-  status_type = str(getattr(status_root, "type", ""))
-  if status_type == "active":
-    if thread_id in active:
-      return None
-    activation_counts[thread_id] = activation_counts.get(thread_id, 0) + 1
-    activation = f"status:{thread_id}:{activation_counts[thread_id]}"
-    active[thread_id] = activation
-    last_activation_by_child[thread_id] = activation
-    event_type, state = "agent_started", "running"
-  elif status_type in ("idle", "systemError"):
-    activation = active.pop(thread_id, None)
-    if activation is None:
-      return None
-    last_activation_by_child[thread_id] = activation
-    event_type = "agent_terminal"
-    state = "done" if status_type == "idle" else "failed"
-  else:
-    return None
-  return {
-    "type": "agent_lifecycle", "provider": "codex",
-    "provider_session_id": root_thread_id,
-    "provider_agent_id": thread_id,
-    "provider_activation_id": activation,
-    "parent_kind": "unknown", "event_type": event_type, "state": state,
-    "source": "runner",
-    "source_event_id": f"thread-status:{thread_id}:{activation}:{status_type}",
-  }
-
-
-async def _record_collab_child_links(
-  item: Any, sdk: dict[str, Any], *, chat_id: str,
-) -> None:
-  """Attribute a spawned sub-agent's thread to this chat.
-
-  DEAD AT RUNTIME on codex 0.144.5: the only collab item that reaches the parent
-  stream is the `wait` op (never a `spawnAgent`), and its ``receiver_thread_ids``
-  is always EMPTY, so the spawn gate below never fires and no link is recorded
-  here in production. Kept defensively for a future SDK that surfaces the spawn
-  op with populated ``receiver_thread_ids`` on the parent stream. Today the named
-  child rollout is attributed to this chat by the Workflows app parser via the
-  child's parent_thread_id, NOT by this recorder — so the live Codex chip is not
-  a named child link.
-
-  A spawn's ``receiver_thread_ids`` are the freshly-spawned child thread ids;
-  recording each in the append-only session->chat map keeps the child's own
-  rollout resolvable back to this chat even though it streams on its own thread.
-  Gated on the spawn operation (that is when a NEW child id first appears; the
-  other ops reference children already recorded at their spawn). Idempotent, and
-  never raises: observability must not break the notification loop. The write
-  goes through ``record_session_link_async`` (own session, worker thread) so it
-  neither blocks the stream loop nor touches the runner's shared ``db``.
-  """
-  try:
-    collab_cls = sdk.get("CollabAgentToolCallThreadItem")
-    if collab_cls is None or not isinstance(item, collab_cls):
-      return
-    if _collab_op(item) != "spawnAgent":
-      return
-    from app.session_links import record_session_link_async
-    for child_id in getattr(item, "receiver_thread_ids", None) or []:
-      await record_session_link_async("codex", child_id, chat_id)
-  except Exception:
-    log.debug("codex collab child-link recording failed", exc_info=True)
-
-
-def _tool_start_event(item: Any, sdk: dict[str, Any]) -> dict[str, Any] | None:
-  """Builds one Möbius `tool_start` event from a typed item."""
-  image_view_cls = sdk.get("ImageViewThreadItem")
-  if image_view_cls is not None and isinstance(item, image_view_cls):
-    return {
-      "type": "tool_start",
-      "tool": "ViewImage",
-      "input": _format_json(getattr(item, "path", "")),
-    }
-  # Standalone dispatch keeps collab items as ordinary Task activity. The live
-  # loop now groups all such items under one per-turn host and enriches it with
-  # ThreadStarted/ThreadStatus task events, avoiding duplicate Task rows while
-  # retaining this safe fallback for isolated callers and older SDKs.
-  collab_cls = sdk.get("CollabAgentToolCallThreadItem")
-  if collab_cls is not None and isinstance(item, collab_cls):
-    return {
-      "type": "tool_start",
-      "tool": "Task",
-      "input": _collab_description(item),
-    }
-  sub_activity_cls = sdk.get("SubAgentActivityThreadItem")
-  if sub_activity_cls is not None and isinstance(item, sub_activity_cls):
-    # subAgentActivity is Codex's sub-agent LIFECYCLE marker (agentPath,
-    # agentThreadId, kind) in the parent thread's item stream/history. The
-    # invariant: the sub-agent's actual tool work is surfaced elsewhere — live,
-    # the parent streams the delegation as the CollabAgentToolCallThreadItem
-    # `Task` events above; on resume, the parent's replayed history is never
-    # re-rendered (the runner uses only thread.id + thread.turn()). So the
-    # marker itself carries nothing Möbius opens as its own tool block. This is
-    # a DELIBERATE no-op, classified explicitly rather than left to fall through
-    # silently — surfacing sub-agent lifecycle as its own UI is a future UX
-    # decision, not an accident of omission (see test_codex_sdk_contract).
-    log.debug("codex subAgentActivity marker (no-op): kind=%s",
-              getattr(item, "kind", None))
-    return None
-  if isinstance(item, sdk["CommandExecutionThreadItem"]):
-    return {
-      "type": "tool_start",
-      "tool": "Bash",
-      "input": _extract_bash_command(item.command),
-    }
-  if isinstance(item, sdk["FileChangeThreadItem"]):
-    first = item.changes[0] if item.changes else None
-    path = _model_dump(first).get("path", "") if first is not None else ""
-    return {
-      "type": "tool_start",
-      "tool": "Edit",
-      "input": path,
-    }
-  if isinstance(item, sdk["McpToolCallThreadItem"]):
-    tool_name = f"{item.server}:{item.tool}" if item.server else item.tool
-    return {
-      "type": "tool_start",
-      "tool": tool_name or "mcp",
-      "input": _format_json(item.arguments),
-    }
-  if isinstance(item, sdk["DynamicToolCallThreadItem"]):
-    tool_name = item.tool
-    if item.namespace:
-      tool_name = f"{item.namespace}:{tool_name}"
-    return {
-      "type": "tool_start",
-      "tool": tool_name or "tool",
-      "input": _format_json(item.arguments),
-    }
-  if isinstance(item, sdk["WebSearchThreadItem"]):
-    return {
-      "type": "tool_start",
-      "tool": "WebSearch",
-      "input": item.query,
-    }
-  return None
-
-
-def _tool_completed_events(item: Any, sdk: dict[str, Any]) -> list[dict[str, Any]]:
-  """Builds Möbius tool-end events from a completed typed item."""
-  image_view_cls = sdk.get("ImageViewThreadItem")
-  if image_view_cls is not None and isinstance(item, image_view_cls):
-    return [{"type": "tool_end"}]
-  # Standalone dispatch closes the ordinary Task activity above. The live loop
-  # owns its one per-turn host and bypasses this branch, publishing normalized
-  # task_done events from lifecycle notifications before closing that host.
-  collab_cls = sdk.get("CollabAgentToolCallThreadItem")
-  if collab_cls is not None and isinstance(item, collab_cls):
-    events: list[dict[str, Any]] = []
-    summary = _collab_summary(item)
-    if summary:
-      events.append({"type": "tool_output", "content": summary})
-    events.append({"type": "tool_end"})
-    return events
-
-  sub_activity_cls = sdk.get("SubAgentActivityThreadItem")
-  if sub_activity_cls is not None and isinstance(item, sub_activity_cls):
-    # Completion counterpart of the _tool_start_event no-op: the sub-agent
-    # lifecycle marker opens no Möbius tool block, so it closes none. The live
-    # delegation's open/close rides CollabAgentToolCallThreadItem (`Task`); this
-    # marker is classified explicitly to keep the invariant visible rather than
-    # silently returning [] by fall-through.
-    return []
-
-  if isinstance(item, sdk["CommandExecutionThreadItem"]):
-    output = (item.aggregated_output or "").strip()
-    exit_code = getattr(item, "exit_code", None)
-    events: list[dict[str, Any]] = [{
-      "type": "tool_output",
-      "content": output,
-      "output_complete": True,
-      **({"output_exit_code": exit_code} if isinstance(exit_code, int) else {}),
-    }]
-    events.append({"type": "tool_end"})
-    return events
-
-  if isinstance(item, sdk["FileChangeThreadItem"]):
-    lines: list[str] = []
-    for change in item.changes:
-      change_dict = _model_dump(change) or {}
-      kind = change_dict.get("kind", "?")
-      path = change_dict.get("path", "")
-      line = f"{kind} {path}".strip()
-      if line:
-        lines.append(line)
-    events: list[dict[str, Any]] = []
-    if lines:
-      events.append({"type": "tool_output", "content": "\n".join(lines)})
-    events.append({"type": "tool_end"})
-    return events
-
-  if isinstance(item, sdk["McpToolCallThreadItem"]):
-    events: list[dict[str, Any]] = []
-    result = _format_json(item.result)
-    if result:
-      events.append({"type": "tool_output", "content": result})
-    events.append({"type": "tool_end"})
-    return events
-
-  if isinstance(item, sdk["DynamicToolCallThreadItem"]):
-    events: list[dict[str, Any]] = []
-    result = _format_json(item.content_items)
-    if result:
-      events.append({"type": "tool_output", "content": result})
-    events.append({"type": "tool_end"})
-    return events
-
-  if isinstance(item, sdk["WebSearchThreadItem"]):
-    events: list[dict[str, Any]] = []
-    # The real query (or the opened page's URL) only lands on completion —
-    # ItemStarted carried an empty one, so the row showed a bare "WebSearch".
-    # Backfill it now; the caller stamps tool_use_id so it targets this exact
-    # search rather than the first input-less block.
-    query = getattr(item, "query", "")
-    if query:
-      events.append({"type": "tool_input", "input": query})
-    sources = _web_search_sources(item)
-    if sources:
-      events.append({"type": "tool_sources", "sources": sources})
-    events.append({"type": "tool_end"})
-    return events
-
-  if isinstance(item, sdk["AgentMessageThreadItem"]):
-    # Materialize the authoritative full text of the completed assistant
-    # message. Durable prose otherwise rides ONLY on the streamed
-    # AgentMessageDeltaNotification deltas (published as "text" above); if those
-    # were absent/dropped/coalesced (observed on oversized responses, e.g. a
-    # "very long numbered" request that persisted NOTHING) the reply vanishes
-    # silently. text_final REPLACES the accumulated text block, so it is
-    # idempotent when the deltas already delivered identical prose (events.py
-    # returns False), converts the lingering text_boundary into text when no
-    # delta arrived, and recovers a truncated prefix. Guarded on non-empty text
-    # so a genuinely-empty message stays silent.
-    text = item.text or ""
-    if text.strip():
-      event = {"type": "text_final", "content": text}
-      item_id = getattr(item, "id", None)
-      if item_id:
-        event["text_item_id"] = item_id
-      return [event]
-    return []
-
-  return []
-
-
-def _enum_wire_value(value: Any) -> str | None:
-  """Returns the wire value for a generated enum, tolerating test doubles."""
-  if value is None:
-    return None
-  raw = getattr(value, "value", value)
-  return raw if isinstance(raw, str) else str(raw)
-
-
-_CHATGPT_MODEL_UNAVAILABLE_RE = re.compile(
-  r"[\"'](?P<model>[^\"']+)[\"'] model is not supported when using Codex "
-  r"with a ChatGPT account",
-  re.IGNORECASE,
-)
-
-
-def _codex_user_error(error_text: str | None) -> str | None:
-  """Turns a known account/model rejection into a useful next action.
-
-  The live Codex catalog can advertise a model that the signed-in account's
-  plan or staged rollout cannot actually run. The upstream 400 is technically
-  precise but reads like a broken connection and offers no recovery path.
-  Preserve every unknown provider error verbatim; only this exact, observed
-  contract gets product wording.
-  """
-  if not error_text:
-    return error_text
-  match = _CHATGPT_MODEL_UNAVAILABLE_RE.search(error_text)
-  if match is None:
-    return error_text
-  model_id = match.group("model")
-  model_name = MODEL_LABELS.get(model_id, model_id)
-  return (
-    f"{model_name} isn’t available for this ChatGPT account. Codex is "
-    "connected, but this account’s current plan or model rollout does not "
-    "include it. Choose another Codex model from this chat’s Model menu, "
-    "then try again."
-  )
-
-
-def _agent_message_phase(item: Any, sdk: dict[str, Any]) -> str | None:
-  """Returns a completed agent message's native SDK phase."""
-  if not isinstance(item, sdk["AgentMessageThreadItem"]):
-    return None
-  return _enum_wire_value(getattr(item, "phase", None))
-
-
-def _turn_items(turn: Any) -> list[Any]:
-  """Unwraps the typed items included in a TurnCompleted payload."""
-  items = getattr(turn, "items", None) or []
-  return [
-    item.root if hasattr(item, "root") else item
-    for item in items
-  ]
-
-
-def _codex_terminal_error(
-  completed_turn: Any | None,
-  sdk: dict[str, Any],
-  *,
-  interrupt_requested: bool,
-  completed_message_phases: list[str | None],
-) -> tuple[str | None, str | None, str | None]:
-  """Validates the SDK's native turn-status and message-phase contract.
-
-  `turn/completed` is the terminal notification envelope, not proof that the
-  model completed the task. The nested TurnStatus carries that fact. Likewise,
-  an AgentMessageThreadItem marked `commentary` is an in-progress preamble,
-  while `final_answer` is the SDK's explicit completion signal.
-
-  Older SDK payloads can omit both status and message phase; that fully-legacy
-  shape retains historical success. Otherwise a completed turn needs an actual
-  agent message, and the LAST such message must be final: an earlier final
-  followed by commentary is not terminal completion. phase=None remains the
-  SDK helper's legacy final-response marker when a message is present.
-  """
-  if completed_turn is None:
-    return (
-      "Codex turn stream ended without a turn/completed notification.",
-      None,
-      None,
-    )
-
-  terminal_status = _enum_wire_value(getattr(completed_turn, "status", None))
-  failed_status = _enum_wire_value(sdk["TurnStatus"].failed)
-  interrupted_status = _enum_wire_value(sdk["TurnStatus"].interrupted)
-  completed_status = _enum_wire_value(sdk["TurnStatus"].completed)
-  error = getattr(completed_turn, "error", None)
-  error_message = getattr(error, "message", None) if error is not None else None
-
-  if terminal_status == failed_status:
-    return (
-      str(error_message or "Codex turn failed without an error message."),
-      terminal_status,
-      None,
-    )
-  if terminal_status == interrupted_status:
-    if not interrupt_requested:
-      return (
-        "Codex turn was interrupted unexpectedly.",
-        terminal_status,
-        None,
-      )
-    return None, terminal_status, None
-  if terminal_status not in (None, completed_status):
-    return (
-      f"Codex turn ended with unexpected status {terminal_status!r}.",
-      terminal_status,
-      None,
-    )
-  if error is not None:
-    return (
-      str(error_message or "Codex turn completed with an unknown error."),
-      terminal_status,
-      None,
-    )
-
-  # ItemCompleted normally carries phases first. When TurnCompleted includes
-  # agent items, that ordered snapshot is authoritative rather than additive:
-  # deduping/merging two streams can reorder messages and turn an earlier final
-  # into a false terminal success.
-  turn_phases = [
-    _agent_message_phase(item, sdk)
-    for item in _turn_items(completed_turn)
-    if isinstance(item, sdk["AgentMessageThreadItem"])
-  ]
-  phases = turn_phases if turn_phases else list(completed_message_phases)
-  commentary_phase = _enum_wire_value(sdk["MessagePhase"].commentary)
-  final_answer_phase = _enum_wire_value(sdk["MessagePhase"].final_answer)
-  if not phases:
-    if terminal_status is None:
-      return None, terminal_status, None
-    return (
-      "Codex turn completed without an agent final answer.",
-      terminal_status,
-      None,
-    )
-
-  final_message_phase = phases[-1]
-  if final_message_phase == commentary_phase:
-    return (
-      "Codex turn completed after commentary without a final answer.",
-      terminal_status,
-      final_message_phase,
-    )
-  if final_message_phase not in (None, final_answer_phase):
-    return (
-      f"Codex turn completed with unexpected final message phase "
-      f"{final_message_phase!r}.",
-      terminal_status,
-      final_message_phase,
-    )
-  return None, terminal_status, final_message_phase
-
-
-def _skill_names_in_command(command: str, data_dir: str) -> list[str]:
-  """Extracts Möbius skill names a shell command reads.
-
-  Codex has no Read tool and no `can_use_tool` hook — its closest
-  interception point is the command-execution item stream, where a
-  skill load looks like `cat /data/shared/skills/<name>.md` (flat) or
-  `cat /data/shared/skills/<id>/SKILL.md` (the directory shape installed
-  skills use), possibly via sed/head/grep over the same path. Any
-  reference to a skill file in a command counts as a load; that
-  over-counts an edit-in-place, which is acceptable for an aggregate
-  most-used signal. A directory skill is keyed by its DIRECTORY name —
-  the on-disk id — matching the Claude Read observer and the usage
-  aggregation; a deeper resource read inside the directory is not a
-  load. Returns deduped names in first-mention order.
-  """
-  if not command:
-    return []
-  from app.skills import GENERATED_INDEX_STEMS
-
-  prefix = re.escape(
-    os.path.normpath(os.path.join(data_dir, "shared", "skills"))
-  )
-  names: list[str] = []
-  # Either `<id>/SKILL.md` (directory skill, id = the dir name, SKILL.md
-  # case-insensitive) or a flat `<name>.md` directly under skills/. The two
-  # alternatives are disjoint (a flat match can't span a `/`), so one pass in
-  # command order preserves first-mention order without double counting.
-  pattern = prefix + r"/([A-Za-z0-9._-]+)(?:/(?i:SKILL\.md)|\.md)\b"
-  for match in re.finditer(pattern, command):
-    name = match.group(1)
-    # Reading a generated index is consulting a listing, not loading a skill.
-    if name not in names and name not in GENERATED_INDEX_STEMS:
-      names.append(name)
-  return names
-
-
-def _observe_skill_reads(
-  item: Any, sdk: dict[str, Any], *, bc: Any, chat_id: str,
-) -> None:
-  """Fire-and-forget `skill_loaded` events for skill-file shell reads.
-
-  Mirrors `observe_skill_file_read` in claude_sdk_runner: same wire
-  event (chip), same activity record (most-used-skills aggregation).
-  Never raises — observability must not break the notification loop.
-  """
-  try:
-    if not isinstance(item, sdk["CommandExecutionThreadItem"]):
-      return
-    from app import activity
-    from app.config import get_settings
-    command = _extract_bash_command(item.command or "")
-    skills = _skill_names_in_command(command, get_settings().data_dir)
-    for skill in skills:
-      bc.publish({"type": "skill_loaded", "skill": skill})
-      activity.log_skill_load(chat_id, skill)
-  except Exception:
-    log.debug("codex skill_loaded observability failed", exc_info=True)
-
-
-def _file_change_patch_summary(changes: list[Any]) -> str:
-  """Summarizes one file-change patch update as `kind path` lines."""
-  lines: list[str] = []
-  for change in changes:
-    change_dict = _model_dump(change) or {}
-    kind = change_dict.get("kind", "?")
-    path = change_dict.get("path", "")
-    line = f"{kind} {path}".strip()
-    if line:
-      lines.append(line)
-  return "\n".join(lines)
-
-
 def _is_transport_death(exc: BaseException) -> bool:
   """Returns True when the app-server connection itself died.
 
@@ -2082,21 +1164,8 @@ def _install_request_user_input_handler(
   default handler (auto-accept commandExecution / fileChange), which
   preserves the trust-the-agent posture documented in CLAUDE.md.
   """
-  from app.pending_questions import PendingQuestion
-  from uuid import uuid4
-
-  # _BridgeError / _OverlapError are module-level classes (see top of file).
-  # `park_question` raises them to signal the sync handler to return a
-  # JSON-RPC error to Codex rather than continuing with empty answers
-  # (B2/B5 from round-5 review).
-
-  async def park_question(questions_payload: list[dict]) -> dict:
-    """Asyncio side of the bridge — creates the future, publishes the
-    `question` event, waits for the answer, returns it keyed by
-    question id (Codex's native shape). Raises on overlap / cancel /
-    notify_cb failure so the sync handler can surface a real error
-    to Codex (B2, B4, B5 from round-5 review).
-    """
+  async def park_codex_question(questions_payload: list[dict]) -> dict:
+    """Run provider-specific admission around the shared question park."""
     # Admission is atomic on the runner loop: steer_into_active_turn marks the
     # ActiveCodexTurn before its first await, and this coroutine also runs on
     # that loop. If the user steer won, fail this not-yet-persisted tool call
@@ -2109,72 +1178,21 @@ def _install_request_user_input_handler(
         "Question superseded by steering input; continue with the new input."
       )
 
-    # Refuse to overlap with an existing pending question on the same
-    # chat. Returning empty here would silently swallow the second
-    # question — instead raise so the sync handler can fail the tool
-    # call with a real error response (Codex won't continue with bad
-    # data).
-    existing = pending_questions.get(chat_id)
-    if existing is not None and not existing.future.done():
-      raise _OverlapError(
-        f"AskUserQuestion already pending for chat {chat_id}"
-      )
-    future = asyncio.get_running_loop().create_future()
-    pending = PendingQuestion(
-      question_id=str(uuid4()),
-      questions=questions_payload,
-      future=future,
-      # The turn's persistence run token (the sink carries it). The
-      # answer route submits AnswerQuestion keyed on this so the writer
-      # actor fences the right (chat_id, run_token) snapshot before
-      # merging the answer; None for a sink/broadcast without one →
-      # broad-fence by chat.
-      run_token=getattr(bc, "run_token", None),
-    )
-    pending_questions[chat_id] = pending
-
     try:
-      # Save-before-broadcast (Candidate B): the card's question_id MUST
-      # persist before the SSE event shows it. `publish_question` submits
-      # a QuestionCommit, awaits its ack, then broadcasts — and RAISES if
-      # the commit didn't land. A failed commit is surfaced as a
-      # _BridgeError so the sync handler returns a real error to Codex
-      # (no unpersisted card on the wire, no fallback direct write).
-      #
-      # Push notification on AskUserQuestion is AGENT-DRIVEN: the
-      # skill/seed tells the agent to `curl POST /api/notifications/send`
-      # itself, so it sees push success/failure (bash output) and decides
-      # per-question whether to buzz the user. The cb arg is kept in the
-      # signature for compatibility but not invoked here.
-      try:
-        await bc.publish_question({
-          "type": "question",
-          "question_id": pending.question_id,
-          "questions": questions_payload,
-        })
-      except Exception as exc:
-        log.error(
-          "AskUserQuestion save-before-broadcast failed chat_id=%s: %s",
-          chat_id, exc,
-        )
-        raise _BridgeError("could not save the question")
-
-      try:
-        answers = await future
-      except (asyncio.CancelledError, _cf.CancelledError):
-        # Cancellation can arrive as either flavor depending on whether
-        # the cancel came from the asyncio loop side (asyncio) or from
-        # the SDK worker thread side via fut.cancel() (concurrent).
-        # Propagate so the sync handler returns the cancel error.
-        raise _BridgeError("cancelled")
-      return answers or {}
-    finally:
-      # B1/B4: always clean up the registry entry, no matter how the
-      # park exited (success, raise, cancel). Without this a failed
-      # park leaves the entry pinned and the next question on the
-      # same chat hits the overlap guard immediately.
-      if pending_questions.get(chat_id) is pending:
-        pending_questions.pop(chat_id, None)
+      return await park_question(
+        chat_id=chat_id,
+        questions=questions_payload,
+        bc=bc,
+        pending_questions=pending_questions,
+      )
+    except QuestionPersistenceError as exc:
+      log.error(
+        "AskUserQuestion save-before-broadcast failed chat_id=%s: %s",
+        chat_id, exc,
+      )
+      raise _BridgeError("could not save the question") from exc
+    except (asyncio.CancelledError, _cf.CancelledError) as exc:
+      raise _BridgeError("cancelled") from exc
 
   def handler(method: str, params: dict | None) -> dict:
     if method != _REQUEST_USER_INPUT_METHOD:
@@ -2248,7 +1266,7 @@ def _install_request_user_input_handler(
     # the tool call instead of continuing with empty answers (B2, B5).
     try:
       fut = asyncio.run_coroutine_threadsafe(
-        park_question(questions), loop,
+        park_codex_question(questions), loop,
       )
     except RuntimeError as exc:
       # Loop closed between handler install and invocation.
@@ -2265,7 +1283,7 @@ def _install_request_user_input_handler(
         "Codex bridge: question lost steer admission race chat_id=%s", chat_id,
       )
       return {"error": {"message": str(exc)}}
-    except _OverlapError as exc:
+    except QuestionOverlapError as exc:
       log.warning(
         "Codex bridge: overlap rejected chat_id=%s: %s", chat_id, exc,
       )

--- a/backend/app/question_bridge.py
+++ b/backend/app/question_bridge.py
@@ -1,0 +1,72 @@
+"""Provider-neutral parking for an interactive agent question.
+
+Claude and Codex expose different SDK callbacks and answer wire shapes, but the
+Möbius lifecycle in between is identical: reject an overlapping question,
+register a future, durably publish the card, wait without a timeout, and remove
+the exact registry entry on every exit path. Keeping that transaction here
+prevents the provider adapters from drifting on persistence or cleanup rules.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import MutableMapping, Sequence
+from typing import Any
+from uuid import uuid4
+
+from app.pending_questions import PendingQuestion
+
+
+class QuestionOverlapError(RuntimeError):
+  """Another unanswered question already owns this chat."""
+
+
+class QuestionPersistenceError(RuntimeError):
+  """The question card could not be durably committed before broadcast."""
+
+
+async def park_question(
+  *,
+  chat_id: str,
+  questions: Sequence[dict[str, Any]],
+  bc: Any,
+  pending_questions: MutableMapping[str, PendingQuestion],
+) -> dict[str, Any]:
+  """Publish and await one question using the shared Möbius lifecycle.
+
+  Provider adapters retain their admission checks, payload validation, answer
+  translation, and error presentation. Cancellation intentionally propagates
+  so each SDK callback can express it in its native result.
+  """
+  existing = pending_questions.get(chat_id)
+  if existing is not None and not existing.future.done():
+    raise QuestionOverlapError(
+      f"AskUserQuestion already pending for chat {chat_id}"
+    )
+
+  future = asyncio.get_running_loop().create_future()
+  payload = list(questions)
+  pending = PendingQuestion(
+    question_id=str(uuid4()),
+    questions=payload,
+    future=future,
+    run_token=getattr(bc, "run_token", None),
+  )
+  pending_questions[chat_id] = pending
+
+  try:
+    try:
+      await bc.publish_question({
+        "type": "question",
+        "question_id": pending.question_id,
+        "questions": payload,
+      })
+    except Exception as exc:
+      raise QuestionPersistenceError(
+        "could not save the question"
+      ) from exc
+    answers = await future
+    return answers or {}
+  finally:
+    if pending_questions.get(chat_id) is pending:
+      pending_questions.pop(chat_id, None)

--- a/backend/tests/test_claude_sdk_runner.py
+++ b/backend/tests/test_claude_sdk_runner.py
@@ -37,7 +37,7 @@ from claude_agent_sdk.types import (
   UserMessage,
 )
 
-from app import claude_sdk_runner, models
+from app import claude_events, claude_sdk_runner, models
 from app.claude_sdk_runner import (
   ActiveClaudeClient,
   dispatch_sdk_message,
@@ -879,7 +879,7 @@ def test_dispatch_text_delta_emits_text():
 
 
 def test_dispatch_thinking_delta_emits_thinking(monkeypatch):
-  monkeypatch.setattr(claude_sdk_runner.time, "time", lambda: 1.234)
+  monkeypatch.setattr(claude_events.time, "time", lambda: 1.234)
   bus = _Bus()
   msg = _stream_delta("thinking_delta", thinking="planning...")
   msg.event["index"] = 2
@@ -1325,9 +1325,9 @@ def test_dispatch_task_started_accepts_sdk_shape_without_identity_attrs(
     task_type = "explore"
     tool_use_id = None
 
-  monkeypatch.setattr(claude_sdk_runner, "SystemMessage", MinimalTaskStarted)
+  monkeypatch.setattr(claude_events, "SystemMessage", MinimalTaskStarted)
   monkeypatch.setattr(
-    claude_sdk_runner, "TaskStartedMessage", MinimalTaskStarted,
+    claude_events, "TaskStartedMessage", MinimalTaskStarted,
   )
   bus = _Bus()
   dispatch_sdk_message(MinimalTaskStarted(), bus, "known-session")

--- a/backend/tests/test_codex_sdk_contract.py
+++ b/backend/tests/test_codex_sdk_contract.py
@@ -287,7 +287,9 @@ def test_web_search_results_survive_generated_sdk_schema_lag():
     "title": "Structured search result",
     "url": "https://example.test/result",
   }]
-  assert codex_sdk_runner._web_search_sources(item) == [{
+  from app.codex_events import _web_search_sources
+
+  assert _web_search_sources(item) == [{
     "title": "Structured search result",
     "url": "https://example.test/result",
   }]

--- a/backend/tests/test_events.py
+++ b/backend/tests/test_events.py
@@ -1072,13 +1072,17 @@ def test_both_runners_emit_text_boundary():
   from pathlib import Path
 
   app_dir = Path(__file__).resolve().parents[1] / "app"
-  for runner in ("claude_sdk_runner.py", "codex_sdk_runner.py"):
-    src = (app_dir / runner).read_text()
+  for provider in ("claude", "codex"):
+    owners = (
+      f"{provider}_sdk_runner.py",
+      f"{provider}_events.py",
+    )
+    src = "\n".join((app_dir / owner).read_text() for owner in owners)
     assert '"text_boundary"' in src, (
-      f"{runner} never publishes a text_boundary event — consecutive "
+      f"{provider} never publishes a text_boundary event — consecutive "
       f"assistant message items will concatenate without a paragraph break "
       f"on this provider. Keep the streaming event vocabulary symmetric "
-      f"across runners (see events.process_event)."
+      f"across providers (see events.process_event)."
     )
 
 

--- a/backend/tests/test_question_bridge.py
+++ b/backend/tests/test_question_bridge.py
@@ -1,0 +1,108 @@
+"""Provider-neutral interactive-question lifecycle contracts."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from app.pending_questions import PendingQuestion
+from app.question_bridge import (
+  QuestionOverlapError,
+  QuestionPersistenceError,
+  park_question,
+)
+
+
+class _Bus:
+  run_token = "run-1"
+
+  def __init__(self, *, fail: bool = False):
+    self.fail = fail
+    self.events: list[dict] = []
+
+  async def publish_question(self, event: dict) -> None:
+    if self.fail:
+      raise RuntimeError("write unavailable")
+    self.events.append(event)
+
+
+def test_park_question_publishes_before_waiting_and_cleans_exact_entry():
+  async def exercise():
+    registry: dict[str, PendingQuestion] = {}
+    bus = _Bus()
+    task = asyncio.create_task(park_question(
+      chat_id="chat-1",
+      questions=[{"question": "Pick"}],
+      bc=bus,
+      pending_questions=registry,
+    ))
+    await asyncio.sleep(0)
+
+    pending = registry["chat-1"]
+    assert pending.run_token == "run-1"
+    assert bus.events == [{
+      "type": "question",
+      "question_id": pending.question_id,
+      "questions": [{"question": "Pick"}],
+    }]
+    pending.future.set_result({"Pick": "First"})
+    assert await task == {"Pick": "First"}
+    assert registry == {}
+
+  asyncio.run(exercise())
+
+
+def test_park_question_rejects_an_unanswered_overlap():
+  async def exercise():
+    loop = asyncio.get_running_loop()
+    existing = PendingQuestion("q-1", [], loop.create_future())
+    registry = {"chat-1": existing}
+    with pytest.raises(QuestionOverlapError):
+      await park_question(
+        chat_id="chat-1",
+        questions=[],
+        bc=_Bus(),
+        pending_questions=registry,
+      )
+    assert registry == {"chat-1": existing}
+
+  asyncio.run(exercise())
+
+
+def test_park_question_cleans_registry_when_persistence_fails():
+  async def exercise():
+    registry: dict[str, PendingQuestion] = {}
+    with pytest.raises(QuestionPersistenceError):
+      await park_question(
+        chat_id="chat-1",
+        questions=[],
+        bc=_Bus(fail=True),
+        pending_questions=registry,
+      )
+    assert registry == {}
+
+  asyncio.run(exercise())
+
+
+def test_park_question_does_not_remove_a_newer_replacement():
+  async def exercise():
+    registry: dict[str, PendingQuestion] = {}
+    task = asyncio.create_task(park_question(
+      chat_id="chat-1",
+      questions=[],
+      bc=_Bus(),
+      pending_questions=registry,
+    ))
+    await asyncio.sleep(0)
+    original = registry["chat-1"]
+    replacement = PendingQuestion(
+      "q-2", [], asyncio.get_running_loop().create_future(),
+    )
+    registry["chat-1"] = replacement
+    original.future.cancel()
+    with pytest.raises(asyncio.CancelledError):
+      await task
+    assert registry["chat-1"] is replacement
+
+  asyncio.run(exercise())

--- a/backend/tests/test_runner_registry_integration.py
+++ b/backend/tests/test_runner_registry_integration.py
@@ -19,7 +19,7 @@ class _FakeBroadcast:
 
 
 def test_claude_runner_registers_then_unregisters_handle():
-  from app import claude_sdk_runner as runner
+  from app import claude_events, claude_sdk_runner as runner
 
   class FakeStreamEvent:
     def __init__(self, session_id, event):
@@ -95,9 +95,10 @@ def test_claude_runner_registers_then_unregisters_handle():
   with patch.object(runner, "ClaudeSDKClient", FakeClaudeSDKClient), \
        patch.object(runner, "StreamEvent", FakeStreamEvent), \
        patch.object(runner, "ResultMessage", FakeResultMessage), \
-       patch.object(runner, "SystemMessage", type("FakeSystemMessage", (), {})), \
        patch.object(runner, "AssistantMessage", type("FakeAssistantMessage", (), {})), \
-       patch.object(runner, "UserMessage", type("FakeUserMessage", (), {})):
+       patch.object(runner, "UserMessage", type("FakeUserMessage", (), {})), \
+       patch.object(claude_events, "StreamEvent", FakeStreamEvent), \
+       patch.object(claude_events, "ResultMessage", FakeResultMessage):
     asyncio.run(_scenario())
 
 


### PR DESCRIPTION
## Summary
- move Claude and Codex event translation out of their process-lifecycle runners
- centralize the provider-neutral persist-before-broadcast question parking lifecycle
- retain provider-specific admission, validation, answer translation, and error presentation
- add focused question cleanup, overlap, and replacement-identity tests

## Verification
- focused Claude, Codex, question, and runner-registry suite: 229 passed
- canonical diff, whitespace, and privacy scans passed

The complete hosted backend and end-to-end checks must pass before merge.