### PR TITLE
Retire expired compatibility mirrors

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -66,7 +66,7 @@ The `/data` volume persists across `docker compose build && up -d`, so a new ima
 
 Möbius is meant to be self-hosted on a user-provisioned host — a managed platform (Railway/Render/Fly/PikaPods) or a raw VPS — so "apply a security update" splits into three tiers by who can even act:
 
-- **Image userspace** — the Python wheels, npm globals, apt packages, and vendored mini-app libs baked into the image. The agent owns these end-to-end: bump the pin (`Dockerfile` / `backend/requirements.txt` / `frontend/package.json`), rebuild, recreate. Never `apt upgrade` / `pip install -U` a *running* container — that mutation is ephemeral and drifts the live container away from the reproducible image. `deploy-prod.sh` is the apply path. One deliberate runtime exception: the `mobius` user (the in-product agent) has scoped NOPASSWD sudo for `apt-get`/`apt`/`dpkg` only (`/etc/sudoers.d/mobius-apt`, baked and visudo-validated in the `Dockerfile`), so it can install a genuinely needed OS package at runtime without full root — such installs stay ephemeral until pinned into the image, and the recovery floor deliberately depends on zero apt-installed packages, so a bad package can never take recovery down.
+- **Image userspace** — the Python wheels, npm globals, apt packages, and vendored mini-app libs baked into the image. The agent owns these end-to-end: change the declared constraint (`Dockerfile` / `backend/requirements.txt` / `frontend/package.json`), regenerate the hashed Python lock, rebuild, recreate. Never `apt upgrade` / `pip install -U` a *running* container — that mutation is ephemeral and drifts the live container away from the reproducible image. `deploy-prod.sh` is the apply path. One deliberate runtime exception: the `mobius` user (the in-product agent) has scoped NOPASSWD sudo for `apt-get`/`apt`/`dpkg` only (`/etc/sudoers.d/mobius-apt`, baked and visudo-validated in the `Dockerfile`), so it can install a genuinely needed OS package at runtime without full root — such installs stay ephemeral until pinned into the image, and the recovery floor deliberately depends on zero apt-installed packages, so a bad package can never take recovery down.
 - **Host OS userspace + the Docker engine** — outside every container; patched on the host (`unattended-upgrades` covers the OS packages; the engine is a separate host upgrade).
 - **Host kernel** — *not in the container*; it shares the host's and cannot be patched from inside. On a managed platform the operator patches+reboots the kernel underneath you (the safe default for non-devops owners); on a raw VPS it's the owner's job, via `unattended-upgrades` + livepatch + a scheduled reboot window.
 
@@ -967,101 +967,78 @@ export, and writer commands continue to use the full transcript.
 
 **GUARDRAIL — never write `Chat.messages` / `Chat.live_assistant` / `Chat.pending_messages` directly** from a request handler or SDK runner. SQLite WAL serializes commits but NOT the app-level JSON snapshot READ: two readers both see the pre-write snapshot and one silently overwrites the other (the lost-update race the actor closes). The only justified direct writer is `reconcile_interrupted_chats` (`chat.py`, runs at boot before the actor starts); `recovery_chat_runner.py` is actor-independent by design and appends to its own `/data/recovery/chats/<chat_id>.jsonl`, not the `Chat.messages` column.
 
-## Multi-pane workspace (design only)
+## Multi-pane workspace
 
-The shipped feature is a single tab strip that swaps one on-screen view. The
-target is a workspace where tabs can move between tiled panes: a build chat on
-the left and its app preview on the right, or several agent chats side by side.
-Phones degrade to swap-only tabs; tiling is a web/desktop capability.
+The shell ships a responsive tiled workspace. Wide layouts can show several
+chat and app surfaces at once; compact layouts project the focused pair; phones
+keep the same durable workspace but present one practical surface at a time.
+The shell decides geometry from the available content rectangle—callers express
+placement intent and never encode pane ids, split directions, or breakpoints.
 
-### Existing pane seams
+### State and ownership
 
-`frontend/src/components/Shell/tabModel.js` is the openable-item primitive. A
-tab is `{ kind: 'chat' | 'app', id: string }`; the module owns construction,
-identity (`tabKey`, `sameTab`), deduplication, capacity, persistence, navigation
-mapping, and current single-view active state. Construction, identity,
-deduplication, capacity, and `tabNavTarget` carry into panes unchanged. Today
-`isTabActive(tab, view)` maps the global `{ view, chatId, appId }` focus to a
-tab. A pane will instead store `activeTabKey` and compare it with `tabKey(tab)`.
+`frontend/src/components/Shell/paneModel.js` is the pure workspace model. A
+workspace contains a binary `layout` tree, a map of pane records, a focused pane,
+a presentation mode (`single` or `panes`), and the single-screen slot. Each pane
+owns its ordered tabs and `activeTabKey`; tab identity and navigation mapping
+remain in `tabModel.js`. The model normalizes persisted input, enforces unique
+tabs across panes, bounds pane count/depth, collapses empty splits, and returns
+the same reference for no-op transitions.
 
-`Shell.jsx` currently keeps one `openTabs` set, one active-view triple, and the
-hidden app-iframe LRU. This is the degenerate one-pane form of the target model.
+`useWorkspaceSession.js` is the live state owner. It composes reducer transitions
+through a synchronous ref boundary, persists the sole versioned
+`mobius-workspace` session value, owns focused-pane presentation, and projects
+content geometry. A missing or invalid workspace value fails closed to a fresh
+empty workspace; retained active-destination keys can then restore the current
+chat or app through the normal navigation path. There is no parallel flat-tab
+persistence format.
 
-`frontend/src/components/Shell/workspacePlacement.js` is the placement seam.
-Producers issue an `open-item` request with `placement: 'beside-source'`; they
-never name a tab strip, pane id, split direction, or breakpoint. Generic opens
-use `background` / `foreground`. A committed build uses the internal
-`live-preview` activation: it enters Builder, reveals the app in a companion
-pane while keeping the chat focused on wider screens, and activates the app tab
-on phones.
+The render path walks the projected leaves. Each visible chat pane owns its own
+retained `ChatView` surface and scroll controller. App frames remain in the
+global stable-id cache, so moving focus or resizing a pane does not reparent or
+reload an iframe. The global cache cap still applies across visible and retained
+apps.
 
-| Input | Confirmation | Current action |
-| --- | --- | --- |
-| `app_created {appId, chatId}` | Live row exists | Refresh lifecycle/list state |
-| `app_preview_ready {appId, chatId}` | Refetched row matches the app and requesting chat | Apply one `live-preview` `beside-source` request |
-| `app_preview_ready` missing/mismatched ids | No matching live row | Ignore the placement request |
-| Fresh app-list row with `chat_id` | App absent from the established session baseline | Apply the same live-preview request as reconnect fallback |
-| `app_updated` | Live row exists | Refresh CTA/code and live-swap the open frame |
-| Store install or app without `chat_id` | No source-chat relationship | Drawer arrival only |
-| Replayed/duplicate placement | Target app already open | Strict same-reference no-op |
+### Placement and interaction
 
-Every automatic built-preview path passes through
-`resolveWorkspaceRequests`. Direct drawer/user tab opens remain explicit
-foreground navigation and bypass automatic placement by design. Generic
-background work preserves every already-visible surface; a live preview is
-intentionally visible and may activate an existing companion tab without
-moving keyboard focus away from the building chat.
+`workspacePlacement.js` is the policy seam. Producers issue semantic requests
+such as `placement: 'beside-source'`, `activation: 'background'`, or the internal
+`live-preview` activation. `resolveWorkspaceRequests` combines those requests
+with the current model and device projection. App-build previews therefore use
+the same path whether they arrive live or are reconstructed after reconnect.
 
-### Target pane model
+Tab drag/drop, edge splitting, divider resizing, maximized-pane presentation,
+Builder/Standard mode changes, and undo all dispatch through the workspace
+owner. Feasibility is shared: at most four panes, depth at most two, and minimum
+projected dimensions of 280×200. Phone mode admits only top/bottom split intent
+and may project fewer leaves without discarding the underlying tree.
 
-- **Workspace** = a `layout` tree plus a set of `panes`.
-- **Pane** = `{ id, tabs: Tab[], activeTabKey }`, with its own open set and
-  focused tab. The current shell is `panes: [pane0]` with
-  `pane0.tabs = openTabs`.
-- **Layout** = a binary split tree: `{ dir: 'row' | 'col', a, b, ratio }`, with
-  pane leaves. A single pane is the trivial leaf.
-- **Focus** = the pane receiving keyboard input and serving as the current back
-  target.
+### Navigation and lifecycle constraints
 
-`paneModel.js`, beside `tabModel.js`, should own pure layout operations: split
-a pane, move a tab, close a pane, and resize a split. Rendering walks the tree
-and renders each leaf pane's active tab.
+1. **Do not remount ChatView to re-measure.** Each pane owns its scroll geometry;
+   resizing updates that owner while preserving follow-bottom and the current
+   reading anchor.
+2. **Do not reparent keyed app iframes.** Visible app panes count against the
+   global app cache. Stable render ownership avoids reloads and initialization
+   timeouts.
+3. **App ids remain numeric at the navigation boundary.** Every open flows
+   through `tabModel.tabNavTarget`; string/number divergence can double-mount an
+   app frame.
+4. **History entries carry pane ownership.** `useNavigation.js` tags shell
+   entries with the restorable route and pane hint, and repairs that hint when
+   focus or tab ownership changes. Back/Forward must not infer a pane from
+   visual order.
+5. **Single and Builder are two projections of one durable workspace.** Mode
+   transitions capture presentation state but never maintain a second layout
+   model. The single-screen slot is explicit, including an intentional null New
+   Chat destination.
+6. **Test behavior at the owner boundary.** Pure model tests cover invariants and
+   reference stability; hook tests cover same-batch transition composition;
+   browser tests cover resize, drag, navigation, and scroll continuity.
 
-### Localized migration path
-
-1. Introduce `paneModel.js` and a workspace reducer. Seed one pane from today's
-   `openTabs`; do not change the UI yet.
-2. Render the layout tree instead of one `<main>`. The single-pane output must
-   remain identical; this step unlocks two panes.
-3. Add drag-to-tile: dropping a tab on a pane edge splits it and moves the tab.
-   The strip's drag source already has `tabKey`.
-4. Add per-pane chat/app rendering. Today only the active ChatView mounts; a
-   workspace mounts one ChatView per visible chat pane and must obey the
-   constraints below.
-
-### Hard pane constraints
-
-1. **Never remount ChatView to re-measure.** Pane resizing must imperatively
-   reset its grow-only `fullViewHRef` in `useScrollMode` while preserving
-   `FOLLOW_BOTTOM`. Folding pane size into a React key freezes live follow
-   behavior. Each pane owns
-   its own height ref; keyboard resizing is pane-local.
-2. **Never reparent keyed app iframes, and keep the global cap.** Visible app
-   panes count against `APP_CACHE_MAX` (currently four). Preserve id-sorted
-   render order across the workspace; reparenting a sandboxed iframe reloads it
-   and can hit the ten-second loading timeout.
-3. **App ids remain numeric for navigation.** Route every pane open through
-   `tabModel.tabNavTarget`; string/number divergence double-mounts the iframe.
-4. **Design Back and pane focus together.** Multiple panes need per-pane
-   history or explicitly tagged tab/pane history entries dispatched by type.
-   A priority-list guess desynchronizes the Navigation API and sentinel model.
-5. **Test positive behavior.** Assert that a message stays pinned and a pane
-   continues following its stream across resize/toggle. A bound such as
-   `spacer <= client` is insufficient because a broken zero spacer passes it.
-
-`paneModel`, the layout reducer, multi-pane rendering, resizing, and drag/drop
-remain deferred until panes are the explicit task. The tab and placement seams
-above are useful in the shipped one-pane experience today.
+The central extension seam is semantic placement plus pure model operations.
+New workspace features should add an owned transition or projection rather than
+mutating pane-shaped state in `Shell.jsx`.
 
 ## Navigation back-stack + drawer model
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,0 +1,30 @@
+# Compatibility lifecycle
+
+Compatibility code is allowed when it protects owner data or a real external
+contract. Temporary rollout shims need an owner and an observable exit proof;
+“one release” is not a permanent architecture.
+
+The July 2026 maintenance baseline retired two expired mirrors and one
+status-derived fallback:
+
+- `mobius-open-tabs`, the flat workspace read/write path. `mobius-workspace` is
+  now the only workspace state.
+- `mobius-theme-bg`, the bare-colour theme read/write path. The structured
+  `mobius-theme` value is now the only cold-boot theme state.
+- status-derived AskUserQuestion row ownership. `answer_turn` is now required at
+  that semantic boundary.
+
+## Active migrations
+
+| Owner | Protected data or contract | Exit proof | Earliest removal |
+| --- | --- | --- | --- |
+| `chat_writer.py` transcript migration | Historical chats without stable `cid` values or bounded thinking sidecars | The versioned migration ledger records the transcript migration and production diagnostics report no unmigrated rows | Remove only the read fallbacks in the next transcript-format change after that proof; keep the migrated `legacy-*` identifiers as data |
+| `auth.py` / `routes/auth.py` | Owner password hashes written in the earlier raw-bcrypt form | A versioned migration or bounded audit proves every owner hash uses the current wrapper format | Remove raw-bcrypt verification in the following release |
+| `install.py`, `routes/apps.py`, `compiler.py` | Installed apps created before source directories, immutable bundles, capability contracts, or publication records existed | Startup migrations and an app-table audit prove no installed row lacks the current source, bundle, contract, and publication identities | Remove each fallback with the migration that establishes its corresponding non-null invariant |
+| `appFrameStorage.js` | Preferences written by the former same-origin app frame, including the narrow CubeRun and Tandem allowlists | Each affected installation records a successful copy into its scoped storage prefix | Remove per-app legacy scans after the copy marker has shipped for one release |
+| provider event translators | Saved or replayed Claude/Codex events from older SDK payload shapes | The pinned provider SDK minimum and retained replay fixtures no longer emit or contain the old shape | Remove one fallback at a time with the SDK pin bump that makes it unreachable |
+| old notification targets (`/app/:id`, `/chat/:id`) | Previously delivered push/email links outside the current `/shell/` route shape | Product policy defines an expiry longer than every notification/link retention window and access logs show no use | Remove the parser aliases after that dated window |
+
+Permanent interoperability—standard GitHub status contexts, documented
+third-party skill shapes, or public storage request formats—is not a temporary
+migration and does not belong in this removal ledger.

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -757,12 +757,6 @@ def _converge_legacy_schema(eng) -> None:
       # deleted app leaving a stale id behind just reads as "no live
       # owner app," which the route tolerates). See models.Chat.
       _add.append("ALTER TABLE chats ADD COLUMN created_by_app_id INTEGER NULL")
-    if "agent_id" not in chats_cols:
-      # Vestigial column from the removed named-agent feature. Kept
-      # nullable so the model and any pre-removal DBs agree on the
-      # schema without a table rebuild. Nothing reads or writes it.
-      # See models.Chat.agent_id.
-      _add.append("ALTER TABLE chats ADD COLUMN agent_id VARCHAR(64) NULL")
     if "activity_at" not in chats_cols:
       # Drawer ordering key that advances only on owner-send. Backfill
       # existing rows to updated_at so their current order is preserved

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -152,9 +152,6 @@ class Chat(Base):
   auto_resume_on_restart = Column(
     Boolean, nullable=False, default=True, server_default=true()
   )
-  # Vestigial: the named-agent feature was removed; column retained
-  # nullable to avoid a prod migration. Nothing reads or writes it.
-  agent_id = Column(String(64), nullable=True, default=None)
   # Drawer pinning: NOT NULL = pinned, NULL = unpinned. Sort key for
   # the chats list — pinned rows render first, ordered by this
   # column DESC (newest pin at top of pinned group). PATCH

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -109,12 +109,6 @@
         }
       } catch (e) {}
     }
-    if (!bg) {
-      try {
-        var legacy = localStorage.getItem('mobius-theme-bg');
-        if (legacy && HEX.test(legacy)) { bg = legacy; mode = mode || infer(legacy); }
-      } catch (e) {}
-    }
     if (!bg) bg = '#0d0d0d';
     if (!mode) mode = 'dark';
     if (css) {
@@ -165,7 +159,6 @@
     try {
       if (window.parent === window) {
         localStorage.setItem('mobius-theme', JSON.stringify({ bg: bg, mode: mode }));
-        localStorage.setItem('mobius-theme-bg', bg);
       }
     } catch (e) {}
   } catch (e) {}

--- a/frontend/public/app-frame.html
+++ b/frontend/public/app-frame.html
@@ -156,7 +156,7 @@
            src/lib/applyTheme.js). The frame reads its injected theme slot and
            may read the safe compatibility storage snapshot when available;
            when the server fills one. Resolves {css,bg,mode} (slot ->
-           mobius-theme -> mobius-theme-bg -> dark default) and paints --bg /
+           mobius-theme -> dark default) and paints --bg /
            data-theme / color-scheme before <style> parses, so a stale/
            uninjected frame follows the OWNER's persisted mode with no flash.
            applyTheme.prepaint.test.js pins this byte-identical to index.html. -->
@@ -194,12 +194,6 @@
           var p = JSON.parse(raw);
           if (p.bg && HEX.test(p.bg)) { bg = p.bg; mode = mode || p.mode || infer(p.bg); }
         }
-      } catch (e) {}
-    }
-    if (!bg) {
-      try {
-        var legacy = localStorage.getItem('mobius-theme-bg');
-        if (legacy && HEX.test(legacy)) { bg = legacy; mode = mode || infer(legacy); }
       } catch (e) {}
     }
     if (!bg) bg = '#0d0d0d';
@@ -252,7 +246,6 @@
     try {
       if (window.parent === window) {
         localStorage.setItem('mobius-theme', JSON.stringify({ bg: bg, mode: mode }));
-        localStorage.setItem('mobius-theme-bg', bg);
       }
     } catch (e) {}
   } catch (e) {}
@@ -308,7 +301,7 @@
     }
     /* Mode-aware fallback (defense in depth). Gated on data-theme="light" via :where() (zero added specificity, so a server-injected :root or a live theme-swap still wins by source order),
        set by the pre-paint <head> script (shared IIFE) from the owner's persisted
-       localStorage['mobius-theme-bg'] — NOT on OS prefers-color-scheme. A
+       localStorage['mobius-theme'] — NOT on OS prefers-color-scheme. A
        dark-shell owner on a light-OS device therefore keeps the dark :root
        default; light only appears from a positive owner signal (this attribute)
        or from the server-filled __mobius-theme__ slot. No signal => dark

--- a/frontend/public/offline.html
+++ b/frontend/public/offline.html
@@ -37,17 +37,14 @@
   <button onclick="location.reload()">Try again</button>
   <script>
     // Match the owner's theme background if the shell persisted it on a
-    // previous online visit (applyTheme writes both keys). Prefer the
-    // newer mobius-theme ({bg,mode}); fall back to the legacy
-    // mobius-theme-bg bare hex. Best-effort; the inline default above
-    // stays if neither is present.
+    // previous online visit. Best-effort; the inline default above stays if
+    // the current structured theme is absent.
     try {
       var bg = null;
       try {
         var raw = localStorage.getItem('mobius-theme');
         if (raw) { var p = JSON.parse(raw); if (p && p.bg) bg = p.bg; }
       } catch (e) {}
-      if (!bg) bg = localStorage.getItem('mobius-theme-bg');
       if (bg && /^#[0-9a-fA-F]{3,8}$/.test(bg)) {
         document.documentElement.style.setProperty('--bg', bg);
       }

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -176,7 +176,6 @@ function delDatabase(name, label) {
       const req = indexedDB.deleteDatabase(name)
       req.onsuccess = req.onerror = () => resolve()
       req.onblocked = () => {
-        // eslint-disable-next-line no-console
         console.warn(`mobius: ${label} DB delete blocked by an open connection on logout`)
         resolve()
       }

--- a/frontend/src/components/AppCanvas/AppCanvas.jsx
+++ b/frontend/src/components/AppCanvas/AppCanvas.jsx
@@ -978,7 +978,6 @@ const AppCanvas = forwardRef(function AppCanvas({
     }
     window.addEventListener('mobius:shared-storage', onSharedStorage)
     return () => window.removeEventListener('mobius:shared-storage', onSharedStorage)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   // Clear this app's pending nav-sentinels when the VISIBLE frame stops

--- a/frontend/src/components/ChatView/__tests__/chatRuntimeState.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatRuntimeState.test.js
@@ -94,9 +94,9 @@ test('only a recovered question answer starts a new hidden turn', () => {
   assert.equal(answerKeepsCurrentTurn(null), false)
 })
 
-test('answer turn ownership stays compatible with older backends', () => {
-  assert.equal(answerTurnDisposition({ status: 'answer_delivered' }), 'same')
-  assert.equal(answerTurnDisposition({ status: 'started' }), 'new')
+test('answer turn ownership requires the explicit semantic field', () => {
+  assert.equal(answerTurnDisposition({ status: 'answer_delivered' }), 'unknown')
+  assert.equal(answerTurnDisposition({ status: 'started' }), 'unknown')
 })
 
 test('an unknown explicit answer-turn value fails closed to a separate boundary', () => {

--- a/frontend/src/components/ChatView/chatRuntimeState.js
+++ b/frontend/src/components/ChatView/chatRuntimeState.js
@@ -173,13 +173,6 @@ export function shouldFreezeStreamingReturn({
 export function answerTurnDisposition(response) {
   if (response?.answer_turn === 'same') return 'same'
   if (response?.answer_turn === 'new') return 'new'
-  if (response?.answer_turn != null) return 'unknown'
-
-  // Rolling-update compatibility: older backends shipped the same semantic
-  // distinction only through `status`. Once both sides carry answer_turn,
-  // future status names cannot silently change row ownership.
-  if (response?.status === 'answer_delivered') return 'same'
-  if (response?.status === 'started') return 'new'
   return 'unknown'
 }
 

--- a/frontend/src/components/ChatView/useStreamConnection.js
+++ b/frontend/src/components/ChatView/useStreamConnection.js
@@ -1455,7 +1455,7 @@ export default function useStreamConnection(chatId, {
       // A recovered AskUserQuestion answer (the process restarted after
       // persisting the question block) starts a fresh hidden continuation.
       // Its response declares `answer_turn: "new"` for ChatView's bridge
-      // decision; status remains the rolling-update compatibility signal.
+      // decision; status still owns the transport reconnect below.
       // That is a NEW stream, unlike the in-process answer_delivered path
       // above, so initialize the same reconnect state a visible fresh send
       // would use.

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -151,7 +151,6 @@ export default function Shell() {
   } = useDesktopSidebar()
 
   const {
-    legacyOpenTabs,
     workspace,
     workspaceStateRef,
     dispatchWorkspace,
@@ -730,25 +729,18 @@ export default function Shell() {
   // A single implicit home tab on a fresh session stays visually identical to
   // the pre-workspace shell. State (rather than a render-time ref mutation) keeps
   // this safe under replayed or abandoned concurrent renders.
-  const [tabStripEngaged, setTabStripEngaged] = useState(legacyOpenTabs.length > 0)
+  const [tabStripEngaged, setTabStripEngaged] = useState(openTabs.length >= 2)
   useEffect(() => {
     if (openTabs.length >= 2) setTabStripEngaged(true)
     else if (openTabs.length === 0) setTabStripEngaged(false)
   }, [openTabs.length])
-  // Dual-write on every workspace commit: the versioned blob is authoritative on
-  // boot, and the legacy flat key is mirrored for one release so a rolled-back
-  // client still finds its tabs. The rollback ordering keeps the focused pane
-  // together and its active tab last for older clients.
+  // Persist only the versioned workspace. The former flat-tab rollback mirror
+  // completed its release window and was removed so every boot has one owner.
   useEffect(() => {
     try {
       sessionStorage.setItem(paneModel.STORAGE_KEY, paneModel.serializeWorkspace(workspace))
     } catch { /* private mode / quota — workspace stays in memory only */ }
-    tabModel.writeOpenTabs(
-      tabStripEngaged
-        ? paneModel.flattenRollbackPriority(workspace)
-        : [],
-    )
-  }, [tabStripEngaged, workspace])
+  }, [workspace])
   // Pointer events inside an iframe do not bubble to its positioned shell
   // wrapper. The verified live frame sends a tiny focus signal so app panes have
   // the same click-to-focus semantics as native chat panes.

--- a/frontend/src/components/Shell/__tests__/paneModel.test.js
+++ b/frontend/src/components/Shell/__tests__/paneModel.test.js
@@ -91,7 +91,7 @@ test('seedFromFlatTabs makes a single focused pane with the last tab active', ()
   assertInvariants(ws)
 })
 
-test('seedFromFlatTabs sanitizes and dedups readOpenTabs-shaped input', () => {
+test('seedFromFlatTabs sanitizes and dedups untrusted input', () => {
   const seeded = paneModel.seedFromFlatTabs([
     { kind: 'chat', id: 'a' },
     { kind: 'app', id: 42 },        // numeric id normalizes to a string
@@ -100,10 +100,6 @@ test('seedFromFlatTabs sanitizes and dedups readOpenTabs-shaped input', () => {
     { kind: 'chat', id: 'a' },       // duplicate dropped
   ])
   assert.deepEqual(paneModel.flatten(seeded), [makeTab('chat', 'a'), makeTab('app', 42)])
-  // Round-trips through today's flat projection unchanged.
-  assert.deepEqual(paneModel.flatten(seeded), tabModel.readOpenTabs(
-    fakeStorage(JSON.stringify(paneModel.flatten(seeded))),
-  ))
   assertInvariants(seeded)
 })
 
@@ -782,39 +778,6 @@ test('canSplit: minimum pane size within the current projected rect', () => {
     'an unknown pane can not split')
 })
 
-test('flattenRollbackPriority round-trips every tab with the focused active tab last', () => {
-  // Two panes, eight tabs, focus on pB whose active tab is chat:f6.
-  const ws = paneModel.normalize({
-    v: 1,
-    layout: { id: 's0', dir: 'row', a: 'pA', b: 'pB', ratio: 0.5 },
-    panes: {
-      pA: {
-        id: 'pA',
-        tabs: [makeTab('chat', 'f0'), makeTab('chat', 'f1'), makeTab('chat', 'f2'), makeTab('chat', 'f3')],
-        activeTabKey: 'chat:f1',
-      },
-      pB: {
-        id: 'pB',
-        tabs: [makeTab('chat', 'f4'), makeTab('chat', 'f5'), makeTab('chat', 'f6'), makeTab('chat', 'f7')],
-        activeTabKey: 'chat:f6',
-      },
-    },
-    focusedPaneId: 'pB',
-    nextId: 2,
-  })
-
-  const rollback = paneModel.flattenRollbackPriority(ws)
-  // Background pane first, then focused pane's other tabs, then its active last.
-  assert.equal(tabKey(rollback.at(-1)), 'chat:f6', 'the focused active tab is dead last')
-
-  const store = fakeStorage()
-  tabModel.writeOpenTabs(rollback, store)
-  const survivors = tabModel.readOpenTabs(store).map(tabKey)
-  assert.equal(survivors.length, 8)
-  for (let i = 0; i < 8; i += 1) assert.ok(survivors.includes(`chat:f${i}`))
-  assert.equal(survivors.at(-1), 'chat:f6', 'and its active tab is the last kept')
-})
-
 test('readWorkspaceRaw survives a throwing storage instead of crashing boot', () => {
   const throwing = {
     getItem() { throw new DOMException('The operation is insecure.', 'SecurityError') },
@@ -822,11 +785,9 @@ test('readWorkspaceRaw survives a throwing storage instead of crashing boot', ()
   // Must not throw — sessionStorage.getItem can raise in a sandboxed frame, and
   // the Shell reads it while building the reducer's initial state.
   assert.equal(paneModel.readWorkspaceRaw(throwing), null)
-  // The null feeds parseWorkspace, which then seeds from the flat fallback.
-  const ws = paneModel.parseWorkspace(paneModel.readWorkspaceRaw(throwing), {
-    fallbackTabs: [makeTab('chat', 'a')],
-  })
-  assert.deepEqual(ws, paneModel.seedFromFlatTabs([makeTab('chat', 'a')]))
+  // The null feeds parseWorkspace, which then seeds a safe empty workspace.
+  const ws = paneModel.parseWorkspace(paneModel.readWorkspaceRaw(throwing))
+  assert.deepEqual(ws, paneModel.seedFromFlatTabs([]))
 
   const working = fakeStorage(JSON.stringify(paneModel.seedFromFlatTabs([makeTab('chat', 'z')])))
   assert.ok(typeof paneModel.readWorkspaceRaw(working) === 'string', 'a healthy storage reads through')
@@ -837,19 +798,18 @@ test('serialize/parse round-trips a valid workspace', () => {
     paneModel.seedFromFlatTabs([makeTab('chat', 'a'), makeTab('app', 7)]),
     'app:7', { paneId: 'p0', edge: 'bottom' },
   )
-  const back = paneModel.parseWorkspace(paneModel.serializeWorkspace(ws), { fallbackTabs: [] })
+  const back = paneModel.parseWorkspace(paneModel.serializeWorkspace(ws))
   assert.deepEqual(back, ws)
 })
 
 test('parseWorkspace falls back on garbage, wrong version, and too-deep trees', () => {
-  const fallbackTabs = [makeTab('chat', 'seed')]
-  const seed = paneModel.seedFromFlatTabs(fallbackTabs)
+  const seed = paneModel.seedFromFlatTabs([])
 
-  assert.deepEqual(paneModel.parseWorkspace('not json {{{', { fallbackTabs }), seed)
-  assert.deepEqual(paneModel.parseWorkspace(null, { fallbackTabs }), seed)
-  assert.deepEqual(paneModel.parseWorkspace('', { fallbackTabs }), seed)
+  assert.deepEqual(paneModel.parseWorkspace('not json {{{'), seed)
+  assert.deepEqual(paneModel.parseWorkspace(null), seed)
+  assert.deepEqual(paneModel.parseWorkspace(''), seed)
   assert.deepEqual(
-    paneModel.parseWorkspace(JSON.stringify({ v: 2, layout: 'p0', panes: {} }), { fallbackTabs }),
+    paneModel.parseWorkspace(JSON.stringify({ v: 2, layout: 'p0', panes: {} })),
     seed,
   )
 
@@ -870,7 +830,7 @@ test('parseWorkspace falls back on garbage, wrong version, and too-deep trees', 
     focusedPaneId: 'p1',
     nextId: 5,
   })
-  assert.deepEqual(paneModel.parseWorkspace(tooDeep, { fallbackTabs }), seed)
+  assert.deepEqual(paneModel.parseWorkspace(tooDeep), seed)
 })
 
 test('parseWorkspace repairs a recoverable blob instead of falling back', () => {
@@ -896,7 +856,7 @@ test('parseWorkspace repairs a recoverable blob instead of falling back', () => 
     focusedPaneId: 'ghost',
     nextId: 3,
   })
-  const ws = paneModel.parseWorkspace(raw, { fallbackTabs: [makeTab('chat', 'seed')] })
+  const ws = paneModel.parseWorkspace(raw)
   assert.equal(ws.v, 1)
   assert.deepEqual(paneModel.flatten(ws), [makeTab('chat', 'a'), makeTab('app', 7)])
   assert.equal(ws.focusedPaneId, paneIdsOf(ws.layout)[0])
@@ -904,8 +864,7 @@ test('parseWorkspace repairs a recoverable blob instead of falling back', () => 
 })
 
 test('parseWorkspace falls back on a malformed split node', () => {
-  const fallbackTabs = [makeTab('chat', 'seed')]
-  const seed = paneModel.seedFromFlatTabs(fallbackTabs)
+  const seed = paneModel.seedFromFlatTabs([])
   const bad = JSON.stringify({
     v: 1,
     layout: { id: null, dir: 'diagonal', ratio: 0.5, a: 'pA', b: 'pB' },
@@ -918,7 +877,7 @@ test('parseWorkspace falls back on a malformed split node', () => {
   })
   // normalize keeps the split's shape verbatim, so isValidWorkspace is what
   // catches id:null / dir:'diagonal' and forces the fallback.
-  assert.deepEqual(paneModel.parseWorkspace(bad, { fallbackTabs }), seed)
+  assert.deepEqual(paneModel.parseWorkspace(bad), seed)
 })
 
 test('parseWorkspace accepts a persisted pane with more than six tabs', () => {
@@ -930,7 +889,7 @@ test('parseWorkspace accepts a persisted pane with more than six tabs', () => {
     focusedPaneId: 'p0',
     nextId: 1,
   })
-  const parsed = paneModel.parseWorkspace(raw, { fallbackTabs: [makeTab('chat', 'seed')] })
+  const parsed = paneModel.parseWorkspace(raw)
   assert.deepEqual(parsed.panes.p0.tabs, many)
   assert.equal(parsed.panes.p0.activeTabKey, 'chat:c0')
   assertInvariants(parsed)
@@ -949,7 +908,7 @@ test('normalize recomputes nextId so a stale generator cannot lose a tab', () =>
     },
     focusedPaneId: 'p0',
     nextId: 1,
-  }), { fallbackTabs: [] })
+  }))
   assert.ok(persisted.nextId > 5, 'nextId is recomputed past every live suffix')
 
   const before = new Set(paneModel.flatten(persisted).map(tabKey))

--- a/frontend/src/components/Shell/__tests__/settingsTab.test.js
+++ b/frontend/src/components/Shell/__tests__/settingsTab.test.js
@@ -64,18 +64,6 @@ test('focusedContentRoute ignores a BACKGROUND settings tab', () => {
   assert.equal(route.chatId, '5')
 })
 
-// ── Legacy rollback projection stays chat/app-only ───────────────────────────
-
-test('flattenRollbackPriority excludes the Settings tab', () => {
-  let ws = onePane()
-  ws = paneModel.openTab(ws, makeTab('app', 42), { paneId: ws.focusedPaneId, activate: true })
-  ws = paneModel.openTab(ws, settingsTab(), { paneId: ws.focusedPaneId, activate: true })
-  const rollback = paneModel.flattenRollbackPriority(ws)
-  assert.ok(!rollback.some(tabModel.isSettingsTab), 'settings never mirrored to the legacy key')
-  // flatten() (the strip projection) DOES keep it — it is a real, tappable tab.
-  assert.ok(paneModel.flatten(ws).some(tabModel.isSettingsTab), 'flatten keeps the settings tab')
-})
-
 // ── Compatibility suite (design §7) ─────────────────────────────────────────
 
 // Two panes: p0 = chat 'c' (focused), p1 = app 42.

--- a/frontend/src/components/Shell/__tests__/tabModel.test.js
+++ b/frontend/src/components/Shell/__tests__/tabModel.test.js
@@ -2,16 +2,6 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import * as tabModel from '../tabModel.js'
 
-// A Map-backed sessionStorage stub so read/write are testable without jsdom.
-function fakeStorage(initial = null) {
-  let value = initial
-  return {
-    getItem: () => value,
-    setItem: (_k, v) => { value = v },
-    _raw: () => value,
-  }
-}
-
 test('makeTab normalizes the id to a string', () => {
   assert.deepEqual(tabModel.makeTab('app', 42), { kind: 'app', id: '42' })
   assert.deepEqual(tabModel.makeTab('chat', 'abc'), { kind: 'chat', id: 'abc' })
@@ -36,67 +26,6 @@ test('tabNavTarget gives apps a numeric appId and chats a string chatId', () => 
   assert.deepEqual(chatTarget, { view: 'chat', opts: { chatId: 'abc' } })
 })
 
-test('readOpenTabs restores valid tabs and drops malformed entries', () => {
-  const store = fakeStorage(JSON.stringify([
-    { kind: 'chat', id: 'a' },
-    { kind: 'app', id: 42 },      // numeric id in the store -> normalized
-    { kind: 'bogus', id: 'x' },   // unknown kind -> dropped
-    { id: 'no-kind' },            // missing kind -> dropped
-    { kind: 'app' },              // missing id -> dropped
-    'garbage',                    // non-object -> dropped
-  ]))
-  assert.deepEqual(tabModel.readOpenTabs(store), [
-    { kind: 'chat', id: 'a' },
-    { kind: 'app', id: '42' },
-  ])
-})
-
-// A corrupt/hand-edited store must not produce a NaN app id (which navTo would
-// turn into /api/apps/NaN and the numeric iframe LRU would accumulate).
-test('readOpenTabs drops app tabs whose id is not a finite number', () => {
-  const store = fakeStorage(JSON.stringify([
-    { kind: 'app', id: 'abc' },   // non-numeric app id -> dropped
-    { kind: 'app', id: '7' },     // kept
-    { kind: 'chat', id: 'abc' },  // chat ids are free-form -> kept
-  ]))
-  assert.deepEqual(tabModel.readOpenTabs(store), [
-    { kind: 'app', id: '7' },
-    { kind: 'chat', id: 'abc' },
-  ])
-})
-
-// Two id forms of the same tab in a corrupt store would render duplicate keys.
-test('readOpenTabs dedups the same tab across id forms', () => {
-  const store = fakeStorage(JSON.stringify([
-    { kind: 'app', id: 42 },
-    { kind: 'app', id: '42' },    // same tab, string form -> deduped
-    { kind: 'chat', id: 'a' },
-  ]))
-  assert.deepEqual(tabModel.readOpenTabs(store), [
-    { kind: 'app', id: '42' },
-    { kind: 'chat', id: 'a' },
-  ])
-})
-
-test('readOpenTabs returns [] for absent, non-array, or corrupt storage', () => {
-  assert.deepEqual(tabModel.readOpenTabs(fakeStorage(null)), [])
-  assert.deepEqual(tabModel.readOpenTabs(fakeStorage('{"not":"an array"}')), [])
-  assert.deepEqual(tabModel.readOpenTabs(fakeStorage('not json')), [])
-})
-
-test('writeOpenTabs round-trips through readOpenTabs', () => {
-  const store = fakeStorage()
-  const tabs = [tabModel.makeTab('chat', 'a'), tabModel.makeTab('app', 42)]
-  tabModel.writeOpenTabs(tabs, store)
-  assert.deepEqual(tabModel.readOpenTabs(store), tabs)
-})
-
-test('readOpenTabs preserves every explicitly open tab beyond six', () => {
-  const tabs = Array.from({ length: 10 }, (_, i) => tabModel.makeTab('chat', `c${i}`))
-  const store = fakeStorage(JSON.stringify(tabs))
-  assert.deepEqual(tabModel.readOpenTabs(store), tabs)
-})
-
 // ── Settings tab (builder mode) ─────────────────────────────────────────────
 
 test('settingsTab is the one canonical single-instance tab', () => {
@@ -109,19 +38,6 @@ test('settingsTab is the one canonical single-instance tab', () => {
 
 test('tabNavTarget maps the Settings tab to the settings view with no opts', () => {
   assert.deepEqual(tabModel.tabNavTarget(tabModel.settingsTab()), { view: 'settings' })
-})
-
-test('readOpenTabs keeps the legacy projection chat/app-only (drops Settings)', () => {
-  const store = fakeStorage(JSON.stringify([
-    { kind: 'chat', id: 'a' },
-    { kind: 'settings', id: 'settings' },
-    { kind: 'apps', id: 'apps' },
-    { kind: 'app', id: 7 },
-  ]))
-  assert.deepEqual(tabModel.readOpenTabs(store), [
-    { kind: 'chat', id: 'a' },
-    { kind: 'app', id: '7' },
-  ])
 })
 
 // ── Apps launcher tab ───────────────────────────────────────────────────────

--- a/frontend/src/components/Shell/__tests__/viewMode.test.js
+++ b/frontend/src/components/Shell/__tests__/viewMode.test.js
@@ -23,14 +23,12 @@ function twoPanes() {
 
 // ── viewMode field + persistence (design: view-mode toggle, forgiving parse) ──
 
-test('first boot and fallback workspaces default to standard single-screen mode', () => {
+test('first boot workspaces default to an empty standard single-screen mode', () => {
   assert.equal(freshWorkspace().viewMode, 'single')
   assert.equal(paneModel.activeContentRoute(freshWorkspace()).chatId, '5')
-  const firstBoot = paneModel.parseWorkspace(null, {
-    fallbackTabs: [makeTab('chat', '5')],
-  })
+  const firstBoot = paneModel.parseWorkspace(null)
   assert.equal(firstBoot.viewMode, 'single')
-  assert.equal(paneModel.activeContentRoute(firstBoot).chatId, '5')
+  assert.equal(paneModel.activeContentRoute(firstBoot).chatId, null)
 })
 
 test('setViewMode sets the mode and is same-reference on a no-op', () => {
@@ -78,12 +76,12 @@ test('normalize stays reference-stable when viewMode already matches', () => {
 
 test('viewMode round-trips the blob', () => {
   const single = paneModel.setViewMode(twoPanes(), 'single')
-  const back = paneModel.parseWorkspace(paneModel.serializeWorkspace(single), { fallbackTabs: [] })
+  const back = paneModel.parseWorkspace(paneModel.serializeWorkspace(single))
   assert.equal(back.viewMode, 'single')
   // And a panes blob round-trips as panes.
   const panes = twoPanes()
   assert.equal(
-    paneModel.parseWorkspace(paneModel.serializeWorkspace(panes), { fallbackTabs: [] }).viewMode,
+    paneModel.parseWorkspace(paneModel.serializeWorkspace(panes)).viewMode,
     'panes',
   )
 })
@@ -92,14 +90,14 @@ test('parseWorkspace defaults an absent viewMode to panes', () => {
   const noField = { ...twoPanes() }
   delete noField.viewMode
   const blob = JSON.stringify(noField)
-  assert.equal(paneModel.parseWorkspace(blob, { fallbackTabs: [] }).viewMode, 'panes')
+  assert.equal(paneModel.parseWorkspace(blob).viewMode, 'panes')
   // The blob is still valid (viewMode never gates validity).
   assert.equal(paneModel.isValidWorkspaceBlob(blob), true)
 })
 
 test('parseWorkspace degrades a corrupted viewMode to panes without falling back', () => {
   const corrupt = JSON.stringify({ ...twoPanes(), viewMode: 42 })
-  const ws = paneModel.parseWorkspace(corrupt, { fallbackTabs: [] })
+  const ws = paneModel.parseWorkspace(corrupt)
   assert.equal(ws.viewMode, 'panes')
   // The rest of the tree survived (this was NOT a fresh-seed fallback).
   assert.equal(Object.keys(ws.panes).length, 2, 'the two panes are preserved')

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -71,15 +71,15 @@ test('an implicit home tab does not engage the single-pane tab strip', () => {
   // Only a fallback workspace may be treated as implicit. A valid one-leaf
   // single-screen blob intentionally has an empty legacy mirror; resetting it
   // on a deep link would silently change its view mode back to builder.
-  assert.match(workspaceSession, /const replaceImplicitBootTab = !blobValid\s*\n?\s*&& legacyOpenTabs\.length === 0/)
-  assert.match(shell, /const \[tabStripEngaged, setTabStripEngaged\] = useState\(legacyOpenTabs\.length > 0\)/)
+  assert.match(workspaceSession, /const replaceImplicitBootTab = !blobValid\s*\n?\s*&& Object\.keys\(workspace\.panes\)\.length === 1/)
+  assert.match(shell, /const \[tabStripEngaged, setTabStripEngaged\] = useState\(openTabs\.length >= 2\)/)
   assert.match(shell, /if \(openTabs\.length >= 2\) setTabStripEngaged\(true\)/)
   assert.match(shell, /else if \(openTabs\.length === 0\) setTabStripEngaged\(false\)/)
   // With splits ON the strip follows the EFFECTIVE builder world only (never
   // single mode or an immersive takeover); the engaged latch is the kill-switch
   // world's legacy rule.
   assert.match(shell, /const tabStripVisible = !immersiveActive\s*\n?\s*&& \(SPLITS \? effectiveViewMode === 'panes' : tabStripEngaged\)\s*\n?\s*&& openTabs\.length >= 1/)
-  assert.match(shell, /tabStripEngaged[\s\S]*?paneModel\.flattenRollbackPriority\(workspace\)[\s\S]*?: \[\]/)
+  assert.doesNotMatch(shell, /mobius-open-tabs|flattenRollbackPriority|writeOpenTabs/)
   // v2 DELETED the legacy sole-tab "unpin" shortcut (deletion list): the sole-tab
   // close is always a real CLOSE_TAB now, so an emptied builder auto-returns to
   // single. The ONE unified close takes a tab object + opts (INV 13).

--- a/frontend/src/components/Shell/paneModel.js
+++ b/frontend/src/components/Shell/paneModel.js
@@ -1,14 +1,11 @@
-// Pane model — the tiled-workspace successor of the flat tab strip.
+// Pane model — the tiled workspace behind the shell.
 //
 // tabModel.js owns a single flat open set and computes active-ness against one
 // global nav focus. This module generalizes that to a binary split tree of
 // panes: each pane holds its own set of tabModel tabs plus its own active tab,
 // and the workspace tracks which pane has focus. A single pane is the trivial
-// leaf, so today's shell is the degenerate one-pane form of this model — see
-// ARCHITECTURE.md's "Multi-pane workspace" section for the seams and the
-// scroll/nav constraints migration must honor, and
-// docs/design/split-pane-workspace.md for the full v1 design (§1 is this file's
-// spec: the state shape, the normalize() invariants, and the reducer contract).
+// leaf. The state shape, normalize() invariants, reducer contract, and rendering
+// constraints are documented in ARCHITECTURE.md.
 //
 // Everything here is pure and dependency-free except tabModel.js. Tab identity,
 // construction, the numeric-app-id posture, and nav mapping all stay in
@@ -93,9 +90,7 @@ export const BUILDER_POWER_CHROME = (() => {
 export const MIN_PANE_W = 280
 export const MIN_PANE_H = 200
 
-// sessionStorage key for the serialized workspace; the legacy flat key
-// (tabModel's 'mobius-open-tabs') is dual-written for one release so a rollback
-// still finds its tabs.
+// sessionStorage key for the sole serialized workspace state.
 export const STORAGE_KEY = 'mobius-workspace'
 
 // sessionStorage key for the maximized ("focus one pane full-screen") presentation.
@@ -164,8 +159,8 @@ function clampRatio(ratio) {
 }
 
 // Coerce one raw tab to a canonical tabModel tab, or null if it can't be a live
-// tab: this is tabModel.readOpenTabs's posture — drop unknown kinds, missing
-// ids, and app ids that aren't finite numbers (they would become NaN in
+// tab: drop unknown kinds, missing ids, and app ids that aren't finite numbers
+// (they would become NaN in
 // tabNavTarget and never resolve). The Settings tab is the one non-chat/app kind
 // accepted, and only under two conditions that make single-instance and rollback
 // safety structural rather than guarded-around:
@@ -1168,8 +1163,8 @@ export function prune(ws, { liveChatIds, liveAppIds } = {}) {
   return commit(ws, candidate)
 }
 
-// In-order walk of every tab across every pane — the flat projection today's
-// strip renders and the legacy dual-write's ordering baseline.
+// In-order walk of every tab across every pane — the flat projection the
+// drawer, app-frame cache, and workspace strip consume.
 export function flatten(ws) {
   const out = []
   for (const id of leafIds(ws.layout)) {
@@ -1177,33 +1172,6 @@ export function flatten(ws) {
     if (pane) out.push(...pane.tabs)
   }
   return out
-}
-
-// Rollback ordering for the legacy 'mobius-open-tabs' dual-write. Background
-// panes come first, then the focused pane's other tabs, then its active tab,
-// preserving the old key's focus-oriented ordering for older clients.
-// The Settings tab is filtered out: this projection feeds a chat/app-only
-// rollback mirror (readOpenTabs drops it on read anyway), so it never belongs
-// in the legacy key — dropping it here also keeps a chat/app active-last even
-// when Settings is the focused active tab.
-export function flattenRollbackPriority(ws) {
-  const out = []
-  const focusedId = ws.focusedPaneId
-  for (const id of leafIds(ws.layout)) {
-    if (id === focusedId) continue
-    const pane = ws.panes[id]
-    if (pane) out.push(...pane.tabs)
-  }
-  const focused = ws.panes[focusedId]
-  if (focused) {
-    const active = focused.activeTabKey
-    for (const tab of focused.tabs) {
-      if (tabModel.tabKey(tab) !== active) out.push(tab)
-    }
-    const activeTab = focused.tabs.find(tab => tabModel.tabKey(tab) === active)
-    if (activeTab) out.push(activeTab)
-  }
-  return out.filter(tab => !tabModel.isSettingsTab(tab))
 }
 
 // ── Projection: the tree → renderable geometry (design §4) ──────────────────
@@ -1574,8 +1542,8 @@ export function serializeWorkspace(ws) {
 // The raw stored blob, or null if storage is unavailable. sessionStorage.getItem
 // can THROW (SecurityError in a sandboxed frame, disabled storage, a privacy
 // policy), and the caller reads it while evaluating parseWorkspace's argument —
-// outside parseWorkspace's own try/catch. Guarding the read here (the
-// tabModel.readOpenTabs posture) keeps a broken storage from taking down boot.
+// outside parseWorkspace's own try/catch. Guarding the read here keeps broken
+// browser storage from taking down boot.
 export function readWorkspaceRaw(storage) {
   try {
     return storage.getItem(STORAGE_KEY)
@@ -1623,17 +1591,17 @@ export function resolveInitialFocusedPaneView(ws, rawId) {
 
 // Forgiving read: any structural failure — bad JSON, wrong version, or an
 // invariant that survives normalize (a too-deep/too-wide corrupt blob) — falls
-// back to a fresh flat seed. Never throws.
-export function parseWorkspace(raw, { fallbackTabs = [] } = {}) {
+// back to a fresh workspace. Never throws.
+export function parseWorkspace(raw) {
   try {
-    if (typeof raw !== 'string' || raw.length === 0) return seedFromFlatTabs(fallbackTabs)
+    if (typeof raw !== 'string' || raw.length === 0) return seedFromFlatTabs([])
     const parsed = JSON.parse(raw)
-    if (!parsed || parsed.v !== 1) return seedFromFlatTabs(fallbackTabs)
+    if (!parsed || parsed.v !== 1) return seedFromFlatTabs([])
     const normalized = normalize(parsed)
-    if (!isValidWorkspace(normalized)) return seedFromFlatTabs(fallbackTabs)
+    if (!isValidWorkspace(normalized)) return seedFromFlatTabs([])
     return normalized
   } catch {
-    return seedFromFlatTabs(fallbackTabs)
+    return seedFromFlatTabs([])
   }
 }
 

--- a/frontend/src/components/Shell/tabModel.js
+++ b/frontend/src/components/Shell/tabModel.js
@@ -3,17 +3,11 @@
 // A tab is a pinned reference to a chat or app the owner can swap to:
 // `{ kind: 'chat' | 'app', id: string }`, plus the canonical shell-owned
 // Apps and Settings tabs (see below). This module
-// owns the whole tab contract — construction, identity, open-set deduplication,
-// persistence, how a tab maps to navigation, and whether it is
-// the one on screen — so no call site has to re-derive them.
+// owns the whole tab contract — construction, identity, navigation mapping,
+// and active-state comparison — so no call site has to re-derive them.
 //
-// It is deliberately dependency-free and pane-agnostic. Today the shell keeps
-// ONE open set (a flat strip) and one on-screen view. The planned multi-pane
-// workspace (build several apps / chat with several agents in tiled panes)
-// holds a set of these tabs PER pane and computes active-ness against that
-// pane's own view — the same primitives, fed pane state instead of global
-// nav. See ARCHITECTURE.md's "Multi-pane workspace" section for the target
-// model and the scroll/nav constraints that migration must honor.
+// It is deliberately dependency-free and pane-agnostic. The workspace holds
+// these tabs per pane and computes active-ness against pane state.
 
 // The Settings tab — a single-instance builder surface, not a chat/app.
 //
@@ -25,9 +19,6 @@
 // string — unlike chat/app ids there is no per-instance identity — which is why
 // `settingsTab()` takes no argument and `SETTINGS_TAB_KEY` is a constant.
 //
-// Deliberately kept OUT of the legacy `mobius-open-tabs` projection (readOpenTabs
-// below drops any non-chat/app kind): that flat key is a one-release rollback
-// mirror for shells that predate the Settings tab, so it must stay chat/app-only.
 export const SETTINGS_ID = 'settings'
 export const SETTINGS_TAB_KEY = 'settings:settings'
 export function settingsTab() { return { kind: 'settings', id: SETTINGS_ID } }
@@ -71,42 +62,4 @@ export function tabNavTarget(tab) {
   return tab.kind === 'app'
     ? { view: 'canvas', opts: { appId: Number(tab.id) } }
     : { view: 'chat', opts: { chatId: tab.id } }
-}
-
-const STORAGE_KEY = 'mobius-open-tabs'
-
-// Restore the open set from owner-written storage. Forgiving by design (a
-// hand-edited or corrupt store must never crash the shell): drop malformed
-// entries, drop app tabs whose id isn't a finite number (they would become
-// NaN in tabNavTarget and never resolve), and dedup after normalizing so two
-// id forms of the same tab can't render duplicate React keys. The kind filter
-// keeps this legacy projection chat/app-only — a Settings tab is never mirrored
-// here (it lives only in the versioned workspace blob).
-export function readOpenTabs(storage = sessionStorage) {
-  try {
-    const parsed = JSON.parse(storage.getItem(STORAGE_KEY) || '[]')
-    if (!Array.isArray(parsed)) return []
-    const seen = new Set()
-    const tabs = []
-    for (const raw of parsed) {
-      if (!raw || (raw.kind !== 'chat' && raw.kind !== 'app') || raw.id == null) continue
-      if (raw.kind === 'app' && !Number.isFinite(Number(raw.id))) continue
-      const tab = makeTab(raw.kind, raw.id)
-      const key = tabKey(tab)
-      if (seen.has(key)) continue
-      seen.add(key)
-      tabs.push(tab)
-    }
-    return tabs
-  } catch {
-    return []
-  }
-}
-
-export function writeOpenTabs(tabs, storage = sessionStorage) {
-  try {
-    storage.setItem(STORAGE_KEY, JSON.stringify(tabs))
-  } catch {
-    /* private mode / quota — tabs stay in memory only */
-  }
 }

--- a/frontend/src/components/Shell/useWorkspaceSession.js
+++ b/frontend/src/components/Shell/useWorkspaceSession.js
@@ -6,7 +6,6 @@ import {
   useRef,
   useState,
 } from 'react'
-import * as tabModel from './tabModel.js'
 import * as paneModel from './paneModel.js'
 import { enteredEmptySingleScreen } from './newChatPolicy.js'
 import { projectFocusedPane } from './workspaceView.js'
@@ -20,21 +19,18 @@ import { projectFocusedPane } from './workspaceView.js'
  * use dispatchWorkspace so same-batch transitions compose against workspaceStateRef.
  */
 export default function useWorkspaceSession({ storage }) {
-  const [legacyOpenTabs] = useState(() => tabModel.readOpenTabs(storage))
   const [workspaceState, dispatchWorkspaceRaw] = useReducer(
     paneModel.workspaceReducer,
     undefined,
-    () => paneModel.initialWorkspaceState(paneModel.parseWorkspace(
-      paneModel.readWorkspaceRaw(storage),
-      { fallbackTabs: legacyOpenTabs },
-    )),
+    () => paneModel.initialWorkspaceState(
+      paneModel.parseWorkspace(paneModel.readWorkspaceRaw(storage)),
+    ),
   )
   const workspace = workspaceState.ws
   const [blobValid] = useState(
     () => paneModel.isValidWorkspaceBlob(paneModel.readWorkspaceRaw(storage)),
   )
   const replaceImplicitBootTab = !blobValid
-    && legacyOpenTabs.length === 0
     && Object.keys(workspace.panes).length === 1
     && paneModel.flatten(workspace).length <= 1
 
@@ -167,7 +163,6 @@ export default function useWorkspaceSession({ storage }) {
   }, [storage])
 
   return {
-    legacyOpenTabs,
     workspace,
     workspaceStateRef,
     dispatchWorkspace,

--- a/frontend/src/hooks/useNavigation.js
+++ b/frontend/src/hooks/useNavigation.js
@@ -1147,12 +1147,9 @@ export default function useNavigation({
           tabModel.makeTab('chat', deepLink.chatId),
         )
       } else if (!blobValid && initialNav.view === 'canvas' && initialNav.appId != null) {
-        // No valid blob: the flat-tab seed is only the tab STRIP; the legacy
-        // triple (moebius_active_view/_app/_chat) names the ACTIVE tab and must
-        // win as active — NOT gated on `bootPaneEmpty`, because a prior session's
-        // persisted mobius-open-tabs makes the seeded pane non-empty and would
-        // otherwise strand the restore on the wrong (stale) tab. openBootTab dedups
-        // an already-open tab and replaces a lone implicit-home tab.
+        // No valid blob: the retained active-destination keys name the item to
+        // restore. openBootTab replaces the lone implicit-home fallback and
+        // normalizes the destination into the current workspace shape.
         openBootTab(tabModel.makeTab('app', initialNav.appId))
       } else if (!blobValid && initialNav.chatId != null) {
         openBootTab(tabModel.makeTab('chat', initialNav.chatId))

--- a/frontend/src/hooks/useTheme.js
+++ b/frontend/src/hooks/useTheme.js
@@ -65,10 +65,6 @@ export default function useTheme() {
   useEffect(() => {
     if (!data || !data.css) return
     applyThemeToDom(data.css, data.bg, data.mode)
-    // Persist the background so the cold-offline shell boot and the
-    // branded offline.html can match the owner's theme before any JS
-    // or network is available (read in index.html + offline.html).
-    try { if (data.bg) localStorage.setItem('mobius-theme-bg', data.bg) } catch {}
   }, [data])
 
   // Stable identity, for the same reason the panes get a ref-backed navTo:

--- a/frontend/src/lib/__tests__/applyTheme.test.js
+++ b/frontend/src/lib/__tests__/applyTheme.test.js
@@ -236,7 +236,6 @@ test('applyTheme ignores a non-hex bg (no DOM / no persist mutation)', () => {
   assert.equal(dom.document.body.style.background, '#init')
   assert.equal(dom.meta.content, '#init')
   assert.equal(store.getItem('mobius-theme'), null)
-  assert.equal(store.getItem('mobius-theme-bg'), null)
 })
 
 test('applyTheme sets data-theme + color-scheme + status bar from mode', () => {
@@ -270,10 +269,9 @@ test('applyTheme infers mode from --bg in CSS when no bg arg', () => {
   assert.equal(dom.documentElement.getAttribute('data-theme'), 'light')
 })
 
-test('applyTheme persists both mobius-theme and mobius-theme-bg', () => {
+test('applyTheme persists the structured mobius-theme value', () => {
   applyTheme({ css: ':root{--bg:#f0eeeb;}', bg: '#f0eeeb' }, ctx())
   assert.deepEqual(JSON.parse(store.getItem('mobius-theme')), { bg: '#f0eeeb', mode: 'light' })
-  assert.equal(store.getItem('mobius-theme-bg'), '#f0eeeb')
 })
 
 test('applyTheme does NOT persist inside an iframe (window.parent !== window) â€” the drawer-bleed fix', () => {
@@ -286,11 +284,14 @@ test('applyTheme does NOT persist inside an iframe (window.parent !== window) â€
     globalThis.window = { parent: {} }              // iframe: parent is the shell, not self
     applyTheme({ css: ':root{--bg:#0d0d0d;}', bg: '#0d0d0d', mode: 'dark' }, ctx())
     assert.equal(store.getItem('mobius-theme'), null, 'iframe must NOT write the shared theme key')
-    assert.equal(store.getItem('mobius-theme-bg'), null)
     const top = {}; top.parent = top               // top-level shell: parent === self
     globalThis.window = top
     applyTheme({ css: ':root{--bg:#f0eeeb;}', bg: '#f0eeeb', mode: 'light' }, ctx())
-    assert.equal(store.getItem('mobius-theme-bg'), '#f0eeeb', 'top-level shell persists')
+    assert.deepEqual(
+      JSON.parse(store.getItem('mobius-theme')),
+      { bg: '#f0eeeb', mode: 'light' },
+      'top-level shell persists',
+    )
   } finally {
     if (saved) Object.defineProperty(globalThis, 'window', saved); else delete globalThis.window
   }
@@ -309,21 +310,13 @@ test('resolveTheme: 1) JSON slot wins', () => {
 
 test('resolveTheme: 2) mobius-theme when no slot', () => {
   store.setItem('mobius-theme', JSON.stringify({ bg: '#f0eeeb', mode: 'light' }))
-  store.setItem('mobius-theme-bg', '#0d0d0d')
   const t = resolveTheme(ctx())
   assert.equal(t.bg, '#f0eeeb')
   assert.equal(t.mode, 'light')
   assert.equal(t.css, undefined)
 })
 
-test('resolveTheme: 3) legacy mobius-theme-bg when no slot/new key', () => {
-  store.setItem('mobius-theme-bg', '#f0eeeb')
-  const t = resolveTheme(ctx())
-  assert.equal(t.bg, '#f0eeeb')
-  assert.equal(t.mode, 'light')  // inferred from the bg
-})
-
-test('resolveTheme: 4) dark default when nothing present', () => {
+test('resolveTheme: 3) dark default when nothing present', () => {
   const t = resolveTheme(ctx())
   assert.deepEqual(t, { bg: '#0d0d0d', mode: 'dark' })
 })

--- a/frontend/src/lib/__tests__/navigationWorkspaceContract.test.js
+++ b/frontend/src/lib/__tests__/navigationWorkspaceContract.test.js
@@ -143,7 +143,7 @@ test('pointer input inside an opaque app frame focuses its owning pane', () => {
 test('an explicit deep link replaces only a fallback implicit home tab', () => {
   assert.match(
     workspaceSession,
-    /const replaceImplicitBootTab = !blobValid[\s\S]*legacyOpenTabs\.length === 0[\s\S]*paneModel\.flatten\(workspace\)\.length <= 1/,
+    /const replaceImplicitBootTab = !blobValid[\s\S]*Object\.keys\(workspace\.panes\)\.length === 1[\s\S]*paneModel\.flatten\(workspace\)\.length <= 1/,
   )
   assert.match(
     navigation,

--- a/frontend/src/lib/__tests__/themeService.test.js
+++ b/frontend/src/lib/__tests__/themeService.test.js
@@ -113,9 +113,8 @@ function makeDomStub() {
 let dom
 let themeService
 
-// Minimal localStorage stub — applyThemeToDom now persists the active
-// bg to localStorage['mobius-theme-bg'] so the next cold-boot splash
-// reads the current theme's bg (BUG 2). Captures the writes for assertion.
+// Minimal localStorage stub — captures the structured theme writes for
+// cold-boot assertions.
 function makeLocalStorageStub() {
   const map = new Map()
   return {
@@ -354,12 +353,10 @@ test('getEffectiveTheme returns null when no theme has been applied', () => {
 })
 
 
-// --- BUG 2: applyThemeToDom syncs the inline --bg + localStorage ---
-// The splash script in index.html sets an INLINE --bg on <html> from
-// localStorage['mobius-theme-bg'] before first paint. An inline style on
-// documentElement beats `:root{}`, so applyThemeToDom must overwrite it
-// (and the localStorage key) with the theme it actually paints — otherwise
-// a stale splash value pins the wrong background after a toggle/reload.
+// --- applyThemeToDom syncs the inline --bg + structured persistence ---
+// The splash script sets an INLINE --bg on <html> before first paint. An inline
+// style beats `:root{}`, so applyThemeToDom must overwrite it with the theme it
+// actually paints.
 
 test('applyThemeToDom syncs the inline --bg on <html> to the active bg', () => {
   // Seed a STALE inline value the splash would have written (dark).
@@ -369,21 +366,22 @@ test('applyThemeToDom syncs the inline --bg on <html> to the active bg', () => {
     'inline --bg on <html> must track the painted theme, not the stale splash value')
 })
 
-test('applyThemeToDom writes localStorage[mobius-theme-bg] to the active bg', () => {
-  localStorage.setItem('mobius-theme-bg', '#0d0d0d')  // stale dark from a prior splash
+test('applyThemeToDom writes the structured theme for the next boot', () => {
   themeService.applyThemeToDom(':root { --bg: #f0eeeb; }', '#f0eeeb')
-  assert.equal(localStorage.getItem('mobius-theme-bg'), '#f0eeeb',
-    'next cold-boot splash must read the CURRENT bg, not the previous one')
+  assert.deepEqual(
+    JSON.parse(localStorage.getItem('mobius-theme')),
+    { bg: '#f0eeeb', mode: 'light' },
+  )
 })
 
 test('applyThemeToDom does NOT touch inline --bg or localStorage for a non-hex bg', () => {
   // Defensive: a malformed bg must not corrupt the inline var or the
-  // persisted splash key (same gate as body/meta).
+  // persisted structured theme (same gate as body/meta).
   dom.documentElement.style.setProperty('--bg', '#initial')
-  localStorage.setItem('mobius-theme-bg', '#initial')
+  localStorage.setItem('mobius-theme', JSON.stringify({ bg: '#initial', mode: 'dark' }))
   themeService.applyThemeToDom(':root {}', 'expression(alert(1))')
   assert.equal(dom.documentElement.style.getPropertyValue('--bg'), '#initial')
-  assert.equal(localStorage.getItem('mobius-theme-bg'), '#initial')
+  assert.equal(localStorage.getItem('mobius-theme'), JSON.stringify({ bg: '#initial', mode: 'dark' }))
 })
 
 test('applyThemeToDom dark→light then light→dark leaves a consistent inline --bg', () => {
@@ -395,23 +393,21 @@ test('applyThemeToDom dark→light then light→dark leaves a consistent inline 
   assert.equal(dom.documentElement.style.getPropertyValue('--bg'), '#0d0d0d')
   themeService.applyThemeToDom(':root { --bg: #f0eeeb; }', '#f0eeeb')  // back to light
   assert.equal(dom.documentElement.style.getPropertyValue('--bg'), '#f0eeeb')
-  assert.equal(localStorage.getItem('mobius-theme-bg'), '#f0eeeb')
+  assert.equal(JSON.parse(localStorage.getItem('mobius-theme')).bg, '#f0eeeb')
 })
 
 
 // --- DELEGATION: applyThemeToDom now delegates to the shared library ---
 // (src/lib/applyTheme.js). These assert the contract that moved with the
-// delegation: BOTH localStorage keys are written, and color-scheme is set.
+// delegation: the structured localStorage key is written and color-scheme is set.
 
-test('applyThemeToDom (delegated) writes BOTH mobius-theme and mobius-theme-bg', () => {
+test('applyThemeToDom (delegated) writes mobius-theme', () => {
   themeService.applyThemeToDom(':root { --bg: #f0eeeb; }', '#f0eeeb')
   assert.deepEqual(
     JSON.parse(localStorage.getItem('mobius-theme')),
     { bg: '#f0eeeb', mode: 'light' },
     'the new {bg,mode} key the pre-paint IIFE + resolveTheme read',
   )
-  assert.equal(localStorage.getItem('mobius-theme-bg'), '#f0eeeb',
-    'the legacy bare-hex key (one-cycle compat with the old splash script)')
 })
 
 test('applyThemeToDom (delegated) sets documentElement.style.colorScheme', () => {

--- a/frontend/src/lib/__tests__/themeService.toggleTheme.test.js
+++ b/frontend/src/lib/__tests__/themeService.toggleTheme.test.js
@@ -161,8 +161,8 @@ function makeApi(initialCss = DARK_CSS) {
 let dom
 let themeService
 
-// applyThemeToDom (called inside toggleTheme) now writes
-// localStorage['mobius-theme-bg'] (BUG 2). Stub it so the calls don't throw.
+// applyThemeToDom (called inside toggleTheme) writes the structured theme.
+// Stub localStorage so those calls are testable.
 function makeLocalStorageStub() {
   const map = new Map()
   return {
@@ -535,9 +535,7 @@ test('BUG 2 — toggleTheme keeps the inline --bg in lockstep with the painted t
   await themeService.toggleTheme(qc, 'dark', api)
   assert.equal(dom.documentElement.style.getPropertyValue('--bg'), '#f0eeeb',
     'inline --bg must track the toggled-to light bg, not the stale splash value')
-  // Delegation: applyThemeToDom (now via the shared library) persists BOTH
-  // the legacy bare-hex key AND the new {bg,mode} key the pre-paint IIFE reads.
-  assert.equal(localStorage.getItem('mobius-theme-bg'), '#f0eeeb')
+  // Delegation: applyThemeToDom persists the {bg,mode} key the pre-paint IIFE reads.
   assert.deepEqual(
     JSON.parse(localStorage.getItem('mobius-theme')),
     { bg: '#f0eeeb', mode: 'light' },

--- a/frontend/src/lib/appFrameStorage.js
+++ b/frontend/src/lib/appFrameStorage.js
@@ -6,7 +6,7 @@ const SHARED_KEYS = new Set([
   'mobius:setup-complete:v1',
   'mobius:system-setup-ready:v1',
 ])
-const THEME_KEYS = new Set(['mobius-theme', 'mobius-theme-bg'])
+const THEME_KEYS = new Set(['mobius-theme'])
 const LEGACY_KEYS_BY_SLUG = {
   cuberun: new Set([
     'highscores', 'musicEnabled',

--- a/frontend/src/lib/applyTheme.js
+++ b/frontend/src/lib/applyTheme.js
@@ -39,7 +39,6 @@ const STYLE_ID = 'mobius-theme'
 const FONT_LINK_ATTR = 'data-theme-font'
 const SLOT_ID = '__mobius-theme__'
 const STORE_KEY = 'mobius-theme'
-const STORE_BG_KEY = 'mobius-theme-bg'
 const DEFAULT_BG = '#0d0d0d'
 const DEFAULT_MODE = 'dark'
 
@@ -89,9 +88,7 @@ export function inferMode(bg) {
  *   2. `localStorage['mobius-theme']` — `{ bg, mode }` persisted by
  *      `applyTheme` on every paint. Carries a warm reload + cold-offline
  *      reopen (served from the SW's cached, slot-EMPTY index.html).
- *   3. `localStorage['mobius-theme-bg']` — a bare hex, the legacy key
- *      kept for one more cycle so a pre-upgrade install still themes.
- *   4. The dark default.
+ *   3. The dark default.
  *
  * `css` is only ever present from the slot (offline reloads paint from
  * the SW-cached <style id="mobius-theme"> that a prior online paint left
@@ -118,12 +115,7 @@ export function resolveTheme({ doc = globalThis.document, store = defaultStore()
       return { bg, mode: d.mode || inferMode(bg) || DEFAULT_MODE }
     }
   } catch {}
-  // 3. Legacy bare-hex key.
-  try {
-    const bg = store && store.getItem(STORE_BG_KEY)
-    if (bg && HEX_RE.test(bg)) return { bg, mode: inferMode(bg) || DEFAULT_MODE }
-  } catch {}
-  // 4. Default.
+  // 3. Default.
   return { bg: DEFAULT_BG, mode: DEFAULT_MODE }
 }
 
@@ -138,9 +130,8 @@ export function resolveTheme({ doc = globalThis.document, store = defaultStore()
  *     inline `--bg` on <html> (beats `:root{}`, keeps the pre-paint var
  *     in lockstep), and `color-scheme`/`data-theme`/iOS status bar from
  *     the mode.
- *   - Persist BOTH `mobius-theme` ({bg,mode}, the new key resolveTheme +
- *     the pre-paint IIFE read) AND `mobius-theme-bg` (bare hex, the
- *     legacy key one-cycle-compatible with the old splash script).
+ *   - Persist `mobius-theme` ({bg,mode}), the sole key shared by
+ *     resolveTheme and the pre-paint IIFE.
  *
  * `doc`/`store` are injectable for tests; default to globals.
  */
@@ -230,14 +221,13 @@ export function applyTheme(theme, { doc = globalThis.document, store = defaultSt
     doc.head.appendChild(themeStyleEl)
   }
 
-  // Persist for the next boot: the new {bg,mode} key the pre-paint IIFE +
-  // resolveTheme read, and the legacy bare-hex key for one-cycle compat.
+  // Persist for the next boot: the {bg,mode} key shared by the pre-paint IIFE
+  // and resolveTheme.
   // Persist only from the top-level shell — opaque app frames intentionally do not share
   // this store and must not clobber the shell-owned theme key.
   if (bg && HEX_RE.test(bg) && (typeof window === 'undefined' || window.parent === window)) {
     try {
       store.setItem(STORE_KEY, JSON.stringify({ bg, mode: mode || DEFAULT_MODE }))
-      store.setItem(STORE_BG_KEY, bg)
     } catch {}
   }
 }
@@ -250,7 +240,7 @@ export function applyTheme(theme, { doc = globalThis.document, store = defaultSt
  *
  * It does the minimum needed to avoid a wrong-mode/wrong-bg flash:
  * resolve {css?, bg, mode} by the SAME precedence as resolveTheme
- * (slot -> mobius-theme -> mobius-theme-bg -> dark default), inject the
+ * (slot -> mobius-theme -> dark default), inject the
  * slot css into <style id="mobius-theme"> when present, and set --bg /
  * data-theme / color-scheme on <html>. The full applyTheme (fonts, meta
  * tags, status bar, persistence) runs once the module loads.
@@ -292,12 +282,6 @@ export const PREPAINT_SRC = `(function () {
           var p = JSON.parse(raw);
           if (p.bg && HEX.test(p.bg)) { bg = p.bg; mode = mode || p.mode || infer(p.bg); }
         }
-      } catch (e) {}
-    }
-    if (!bg) {
-      try {
-        var legacy = localStorage.getItem('mobius-theme-bg');
-        if (legacy && HEX.test(legacy)) { bg = legacy; mode = mode || infer(legacy); }
       } catch (e) {}
     }
     if (!bg) bg = '#0d0d0d';
@@ -350,7 +334,6 @@ export const PREPAINT_SRC = `(function () {
     try {
       if (window.parent === window) {
         localStorage.setItem('mobius-theme', JSON.stringify({ bg: bg, mode: mode }));
-        localStorage.setItem('mobius-theme-bg', bg);
       }
     } catch (e) {}
   } catch (e) {}

--- a/frontend/src/lib/themeService.js
+++ b/frontend/src/lib/themeService.js
@@ -200,8 +200,8 @@ function runThemeTransition(mutateDom, options = {}) {
  * which is the single source of truth for the DOM mutations (strip+link
  * @import fonts, inject <style id="mobius-theme"> last in <head>, mirror bg
  * onto body / meta theme-color / inline --bg, set data-theme + color-scheme +
- * iOS status bar from the mode) AND for persisting {bg,mode} + the legacy
- * mobius-theme-bg key. The same library code paints the app-frame's pre-paint
+ * iOS status bar from the mode) AND for persisting the sole {bg,mode} key.
+ * The same library code paints the app-frame's pre-paint
  * IIFE, so the shell and the iframe can never drift.
  *
  * Kept as a named export so existing callers (useTheme's apply effect,

--- a/tests/offline-fallback.spec.mjs
+++ b/tests/offline-fallback.spec.mjs
@@ -15,15 +15,25 @@ async function swReady(page) {
   )
 }
 
-test('shell persists theme bg for the offline page', async ({ page }) => {
+test('offline page consumes the structured theme persisted by the shell', async ({ page }) => {
   await page.goto(`${BASE}/shell/`)
-  // useTheme writes this on a successful theme load.
+  // The shell and offline fallback share one structured cold-boot contract.
   await page.waitForFunction(
-    () => !!localStorage.getItem('mobius-theme-bg'),
+    () => {
+      try {
+        return !!JSON.parse(localStorage.getItem('mobius-theme'))?.bg
+      } catch {
+        return false
+      }
+    },
     { timeout: 15000 },
   )
-  const bg = await page.evaluate(() => localStorage.getItem('mobius-theme-bg'))
-  expect(bg).toBeTruthy()
+  const bg = await page.evaluate(() => JSON.parse(localStorage.getItem('mobius-theme')).bg)
+
+  await page.goto(`${BASE}/offline.html`)
+  await expect.poll(() => page.evaluate(() => (
+    getComputedStyle(document.documentElement).getPropertyValue('--bg').trim()
+  ))).toBe(bg)
 })
 
 test('shell loads offline from the SW cache (no native error page)', async ({ page, context }) => {


### PR DESCRIPTION
## Summary
- Remove completed run-state, workspace, theme, navigation, and frame-storage transition mirrors.
- Document the remaining compatibility contracts with their protected data and earliest safe removal.
- Bring architecture documentation back in line with the implemented workspace and standalone model.

## Validation
- Validated on the complete stack: 3,380 backend tests passed with 83.88% coverage; 111 independent recovery tests and 2,275 frontend tests passed; the production frontend build, runtime bundle check, static analysis, documentation links, privacy gates, and clean locked dependency install also passed.

## Stack
Layer 3 of 12 in **Platform maintainability foundations**. This layer is incremental against the preceding reviewed layer.