### PR TITLE
Extract chat runtime policy ownership

### DIFF
--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -5,7 +5,6 @@ import {
   useLayoutEffect,
   useCallback,
   useMemo,
-  useSyncExternalStore,
 } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import Check from 'lucide-react/dist/esm/icons/check.mjs'
@@ -21,6 +20,7 @@ import usePendingQueue from './hooks/usePendingQueue.js'
 import useBridgePartial from './hooks/useBridgePartial.js'
 import useTranscriptState from './hooks/useTranscriptState.js'
 import useComposerDraftState from './hooks/useComposerDraftState.js'
+import useChatRuntimePolicy from './hooks/useChatRuntimePolicy.js'
 import useOffscreenNudge, { useNudgeTargetRef } from './hooks/useOffscreenNudge.js'
 import ChatInputBar from './ChatInputBar.jsx'
 import { hasSendablePayload } from './composerSubmission.js'
@@ -40,8 +40,6 @@ import { formatResetTime } from './resetTime.js'
 import {
   resetDeadlineDelay,
   resetDeadlineState,
-  saveAutoResumePolicy,
-  saveRestartResumePolicy,
 } from './autoResumePolicy.js'
 import {
   EMPTY_CHAT_RUN_SIGNAL,
@@ -49,10 +47,7 @@ import {
   chatRunSignalDelta,
 } from '../../lib/chatRunSignal.js'
 import {
-  clearProviderSwitch,
-  getProviderSwitchState,
   isProviderSwitchBlocking,
-  subscribeProviderSwitch,
 } from './providerSwitch.js'
 import { questionKey } from './questionKey.js'
 import { clearChatQuestionDrafts } from './questionDraft.js'
@@ -352,18 +347,6 @@ export default function ChatView({
     restoreDurableDraft,
   } = useComposerDraftState({ chatId, hidden, inputRef })
 
-  // Per-chat agent runtime config (provider, agent_settings_json,
-  // effective_agent_settings, has_assistant_turns). Resolved by the
-  // initial /chats/{id} fetch and used to drive ChatSettingsPanel
-  // (the model + effort picker inside the `+` popover). A canonical create or
-  // earlier detail cache can provide it immediately; otherwise the picker
-  // stays hidden until the fetch lands.
-  const [chatInfo, setChatInfo] = useState(() => cached?.chatInfo ?? null)
-  const [autoResumeSaving, setAutoResumeSaving] = useState(false)
-  const [autoResumeError, setAutoResumeError] = useState('')
-  const [autoResumeErrorSource, setAutoResumeErrorSource] = useState('')
-  const [restartResumeSaving, setRestartResumeSaving] = useState(false)
-  const [restartResumeError, setRestartResumeError] = useState('')
   const [embeddedRunSignal, setEmbeddedRunSignal] = useState(
     EMPTY_CHAT_RUN_SIGNAL,
   )
@@ -372,28 +355,7 @@ export default function ChatView({
   // from the current card's reset timestamp below, so a newly loaded card can
   // never render using the previous card's boolean state.
   const [, setLimitResetClockTick] = useState(0)
-  const autoResumeSavingRef = useRef(false)
-  const autoResumeRequestRef = useRef(0)
-  const restartResumeSavingRef = useRef(false)
-  const restartResumeRequestRef = useRef(0)
   const armedEmbeddedResetRef = useRef(null)
-  // This external per-chat state survives ChatView's keyed unmount/remount.
-  // Send handlers also read the store directly, closing the same-frame gap
-  // before React paints disabled controls.
-  const subscribeToProviderSwitch = useCallback(
-    listener => subscribeProviderSwitch(chatId, listener),
-    [chatId],
-  )
-  const readProviderSwitch = useCallback(
-    () => getProviderSwitchState(chatId),
-    [chatId],
-  )
-  const providerSwitchState = useSyncExternalStore(
-    subscribeToProviderSwitch,
-    readProviderSwitch,
-    readProviderSwitch,
-  )
-  const providerSwitching = providerSwitchState.status === 'switching'
   // The question_id of the AskUserQuestion the runner is currently parked
   // on, set from the live SSE `question` event (onLiveQuestion). It is a
   // FAST-PATH HINT only, never the sole gate: the backend does not persist
@@ -462,82 +424,11 @@ export default function ChatView({
     }, MESSAGE_META_VISIBLE_MS)
   }, [])
   useEffect(() => {
-    autoResumeRequestRef.current += 1
-    autoResumeSavingRef.current = false
-    setAutoResumeSaving(false)
-    setAutoResumeError('')
-    setAutoResumeErrorSource('')
-    restartResumeRequestRef.current += 1
-    restartResumeSavingRef.current = false
-    setRestartResumeSaving(false)
-    setRestartResumeError('')
     setActiveGoalObjective(
       queryClient.getQueryData(chatMessagesQueryKey(chatId))
         ?.activeGoalObjective ?? '',
     )
   }, [chatId, queryClient])
-
-  const handleAutoResumeChange = useCallback(async (next, source = 'card') => {
-    if (autoResumeSavingRef.current) return
-    autoResumeSavingRef.current = true
-    const requestId = ++autoResumeRequestRef.current
-    setAutoResumeSaving(true)
-    setAutoResumeError('')
-    setAutoResumeErrorSource(source)
-    try {
-      const result = await saveAutoResumePolicy({
-        chatId,
-        next,
-        request: apiFetch,
-      })
-      if (requestId !== autoResumeRequestRef.current) return
-      if (result.value !== null) {
-        setChatInfo(prev => prev ? ({
-          ...prev,
-          auto_resume_on_limit: result.value,
-        }) : prev)
-      }
-      setAutoResumeError(result.error)
-    } finally {
-      if (requestId === autoResumeRequestRef.current) {
-        autoResumeSavingRef.current = false
-        setAutoResumeSaving(false)
-      }
-    }
-  }, [chatId])
-
-  const handleAutoResumeSettingsChange = useCallback(
-    next => handleAutoResumeChange(next, 'settings'),
-    [handleAutoResumeChange],
-  )
-
-  const handleRestartResumeChange = useCallback(async next => {
-    if (restartResumeSavingRef.current) return
-    restartResumeSavingRef.current = true
-    const requestId = ++restartResumeRequestRef.current
-    setRestartResumeSaving(true)
-    setRestartResumeError('')
-    try {
-      const result = await saveRestartResumePolicy({
-        chatId,
-        next,
-        request: apiFetch,
-      })
-      if (requestId !== restartResumeRequestRef.current) return
-      if (result.value !== null) {
-        setChatInfo(prev => prev ? ({
-          ...prev,
-          auto_resume_on_restart: result.value,
-        }) : prev)
-      }
-      setRestartResumeError(result.error)
-    } finally {
-      if (requestId === restartResumeRequestRef.current) {
-        restartResumeSavingRef.current = false
-        setRestartResumeSaving(false)
-      }
-    }
-  }, [chatId])
 
   // Pending queue (the items shown in the queued-tray above the
   // composer) lives entirely inside usePendingQueue. Every mutation
@@ -1004,28 +895,32 @@ export default function ChatView({
     [fetchMessages],
   )
 
-  useEffect(() => {
-    if (hidden) return
-    if (
-      providerSwitchState.status !== 'success'
-      || !providerSwitchState.result
-    ) return
-    const data = providerSwitchState.result
-    setChatInfo(prev => prev ? ({
-      ...prev,
-      agent_settings_json: data.agent_settings_json,
-      provider: data.provider || prev.provider,
-      effective: data.effective || prev.effective,
-    }) : prev)
-    handleCompactionStored()
-    clearProviderSwitch(chatId)
-  }, [
+  // Provider selection and automatic-resume persistence form one per-chat
+  // policy owner. Transcript refresh remains an injected settled outcome.
+  const {
+    autoResumeEnabled,
+    autoResumeError,
+    autoResumeErrorSource,
+    autoResumeSaving,
+    chatInfo,
+    clearAutoResumeError,
+    handleAutoResumeChange,
+    handleAutoResumeSettingsChange,
+    handleRestartResumeChange,
+    mergeChatInfo,
+    providerSwitchState,
+    providerSwitching,
+    restartResumeEnabled,
+    restartResumeError,
+    restartResumeSaving,
+    setChatInfo,
+  } = useChatRuntimePolicy({
     chatId,
-    handleCompactionStored,
+    cached,
     hidden,
-    providerSwitchState.result,
-    providerSwitchState.status,
-  ])
+    onProviderSwitchSettled: handleCompactionStored,
+    request: apiFetch,
+  })
 
   const {
     streamItems,
@@ -3435,8 +3330,6 @@ export default function ChatView({
   const pendingResumeBlock = tailResumableBlock(messages)
   const hasPendingResume = !!pendingResumeBlock
   const pendingLimitResetAt = pendingResumeBlock?.pause?.resets_at || null
-  const autoResumeEnabled = !!chatInfo?.auto_resume_on_limit
-  const restartResumeEnabled = !!chatInfo?.auto_resume_on_restart
   useEffect(() => {
     if (!embedded || !autoResumeEnabled || !pendingLimitResetAt) {
       if (!pendingLimitResetAt) armedEmbeddedResetRef.current = null
@@ -3488,8 +3381,7 @@ export default function ChatView({
   )
 
   useEffect(() => {
-    setAutoResumeError('')
-    setAutoResumeErrorSource('')
+    clearAutoResumeError()
     let timer = null
     let cancelled = false
     const schedule = () => {
@@ -3508,7 +3400,7 @@ export default function ChatView({
       cancelled = true
       if (timer !== null) clearTimeout(timer)
     }
-  }, [pendingLimitResetAt])
+  }, [clearAutoResumeError, pendingLimitResetAt])
 
   // Visibility of either card is a pure viewport question — an
   // IntersectionObserver rooted at the scroll container is the signal, no
@@ -4049,20 +3941,7 @@ export default function ChatView({
                 onRestartResumeChange={
                   embedded ? undefined : handleRestartResumeChange
                 }
-                onChangeChatInfo={({ agent_settings_json, provider, effective }) => {
-                  // Merge into chatInfo so the next render reflects the
-                  // PATCH without a roundtrip. effective is authoritative
-                  // (backend re-merged on top of the current global file).
-                  // `provider` only changes when the user picked a new one —
-                  // preserve the existing value otherwise so an unrelated
-                  // PATCH doesn't wipe it.
-                  setChatInfo(prev => prev ? ({
-                    ...prev,
-                    agent_settings_json: agent_settings_json,
-                    provider: provider || prev.provider,
-                    effective: effective || prev.effective,
-                  }) : prev)
-                }}
+                onChangeChatInfo={mergeChatInfo}
                 providerSwitchState={providerSwitchState}
                 onOpenInspector={() => setShowInspector(true)}
                 onOpenSummary={() => setShowSummary(true)}

--- a/frontend/src/components/ChatView/hooks/__tests__/react-hook-shim.mjs
+++ b/frontend/src/components/ChatView/hooks/__tests__/react-hook-shim.mjs
@@ -113,6 +113,18 @@ export function useMemo(factory, deps) {
   return _slots[i].value
 }
 
+export function useSyncExternalStore(subscribe, getSnapshot) {
+  const snapshotRef = useRef(getSnapshot())
+  snapshotRef.current = getSnapshot()
+  useEffect(() => subscribe(() => {
+    const next = getSnapshot()
+    if (Object.is(next, snapshotRef.current)) return
+    snapshotRef.current = next
+    _rerender()
+  }), [getSnapshot, subscribe])
+  return snapshotRef.current
+}
+
 function _scheduleEffect(fn, deps) {
   const i = _slotIndex++
   if (_slots[i] === undefined) {

--- a/frontend/src/components/ChatView/hooks/__tests__/useChatRuntimePolicy.test.js
+++ b/frontend/src/components/ChatView/hooks/__tests__/useChatRuntimePolicy.test.js
@@ -1,0 +1,127 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  completeProviderSwitch,
+  getProviderSwitchState,
+  resetProviderSwitchMemoryForTests,
+} from '../../providerSwitch.js'
+import useChatRuntimePolicy from '../useChatRuntimePolicy.js'
+import { renderHook } from './react-hook-shim.mjs'
+
+const unusedRequest = async () => {
+  throw new Error('unexpected request')
+}
+
+test('runtime policy derives resumability from the cached chat contract', () => {
+  resetProviderSwitchMemoryForTests()
+  const { result } = renderHook(useChatRuntimePolicy, {
+    chatId: 'policy-cached',
+    cached: {
+      chatInfo: {
+        provider: 'codex',
+        auto_resume_on_limit: true,
+        auto_resume_on_restart: false,
+      },
+    },
+    hidden: false,
+    onProviderSwitchSettled() {},
+    request: unusedRequest,
+  })
+
+  assert.equal(result.current.chatInfo.provider, 'codex')
+  assert.equal(result.current.autoResumeEnabled, true)
+  assert.equal(result.current.restartResumeEnabled, false)
+})
+
+test('a completed provider switch settles through one owner and clears its store', () => {
+  resetProviderSwitchMemoryForTests()
+  const chatId = 'policy-switch'
+  let settled = 0
+  completeProviderSwitch(chatId, { switch_id: 'switch-1' }, {
+    provider: 'claude',
+    agent_settings_json: { model: 'sonnet' },
+    effective: { model: 'sonnet' },
+  })
+
+  const { result } = renderHook(useChatRuntimePolicy, {
+    chatId,
+    cached: {
+      chatInfo: {
+        provider: 'codex',
+        agent_settings_json: {},
+        effective: {},
+      },
+    },
+    hidden: false,
+    onProviderSwitchSettled() { settled += 1 },
+    request: unusedRequest,
+  })
+
+  assert.equal(settled, 1)
+  assert.equal(result.current.chatInfo.provider, 'claude')
+  assert.deepEqual(result.current.chatInfo.effective, { model: 'sonnet' })
+  assert.equal(getProviderSwitchState(chatId).status, 'idle')
+})
+
+test('chat-info patches preserve the provider when the response omits it', () => {
+  resetProviderSwitchMemoryForTests()
+  const { result } = renderHook(useChatRuntimePolicy, {
+    chatId: 'policy-merge',
+    cached: {
+      chatInfo: {
+        provider: 'codex',
+        agent_settings_json: {},
+        effective: {},
+      },
+    },
+    hidden: false,
+    onProviderSwitchSettled() {},
+    request: unusedRequest,
+  })
+
+  result.current.mergeChatInfo({
+    agent_settings_json: { effort: 'high' },
+    effective: { effort: 'high' },
+  })
+
+  assert.equal(result.current.chatInfo.provider, 'codex')
+  assert.deepEqual(result.current.chatInfo.effective, { effort: 'high' })
+})
+
+test('policy actions persist both resume settings and update one chat owner', async () => {
+  resetProviderSwitchMemoryForTests()
+  const calls = []
+  const request = async (url, options) => {
+    calls.push([url, options])
+    const body = JSON.parse(options.body)
+    return {
+      ok: true,
+      async json() { return body },
+    }
+  }
+  const { result } = renderHook(useChatRuntimePolicy, {
+    chatId: 'policy-save',
+    cached: {
+      chatInfo: {
+        provider: 'codex',
+        auto_resume_on_limit: false,
+        auto_resume_on_restart: false,
+      },
+    },
+    hidden: false,
+    onProviderSwitchSettled() {},
+    request,
+  })
+
+  await result.current.handleAutoResumeSettingsChange(true)
+  await result.current.handleRestartResumeChange(true)
+
+  assert.equal(calls.length, 2)
+  assert.equal(result.current.autoResumeEnabled, true)
+  assert.equal(result.current.restartResumeEnabled, true)
+  assert.equal(result.current.autoResumeSaving, false)
+  assert.equal(result.current.restartResumeSaving, false)
+  result.current.clearAutoResumeError()
+  assert.equal(result.current.autoResumeError, '')
+})

--- a/frontend/src/components/ChatView/hooks/useChatRuntimePolicy.js
+++ b/frontend/src/components/ChatView/hooks/useChatRuntimePolicy.js
@@ -1,0 +1,187 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react'
+
+import {
+  saveAutoResumePolicy,
+  saveRestartResumePolicy,
+} from '../autoResumePolicy.js'
+import {
+  clearProviderSwitch,
+  getProviderSwitchState,
+  subscribeProviderSwitch,
+} from '../providerSwitch.js'
+
+/** Own per-chat provider selection and automatic-resume policy state. */
+export default function useChatRuntimePolicy({
+  chatId,
+  cached,
+  hidden,
+  onProviderSwitchSettled,
+  request,
+}) {
+  const [chatInfo, setChatInfo] = useState(() => cached?.chatInfo ?? null)
+  const [autoResumeSaving, setAutoResumeSaving] = useState(false)
+  const [autoResumeError, setAutoResumeError] = useState('')
+  const [autoResumeErrorSource, setAutoResumeErrorSource] = useState('')
+  const [restartResumeSaving, setRestartResumeSaving] = useState(false)
+  const [restartResumeError, setRestartResumeError] = useState('')
+  const autoResumeSavingRef = useRef(false)
+  const autoResumeRequestRef = useRef(0)
+  const restartResumeSavingRef = useRef(false)
+  const restartResumeRequestRef = useRef(0)
+
+  const subscribeToProviderSwitch = useCallback(
+    listener => subscribeProviderSwitch(chatId, listener),
+    [chatId],
+  )
+  const readProviderSwitch = useCallback(
+    () => getProviderSwitchState(chatId),
+    [chatId],
+  )
+  const providerSwitchState = useSyncExternalStore(
+    subscribeToProviderSwitch,
+    readProviderSwitch,
+    readProviderSwitch,
+  )
+  const providerSwitching = providerSwitchState.status === 'switching'
+
+  const clearAutoResumeError = useCallback(() => {
+    setAutoResumeError('')
+    setAutoResumeErrorSource('')
+  }, [])
+
+  const mergeChatInfo = useCallback(({
+    agent_settings_json,
+    provider,
+    effective,
+  }) => {
+    setChatInfo(previous => previous ? ({
+      ...previous,
+      agent_settings_json,
+      provider: provider || previous.provider,
+      effective: effective || previous.effective,
+    }) : previous)
+  }, [])
+
+  useEffect(() => {
+    autoResumeRequestRef.current += 1
+    autoResumeSavingRef.current = false
+    setAutoResumeSaving(false)
+    setAutoResumeError('')
+    setAutoResumeErrorSource('')
+    restartResumeRequestRef.current += 1
+    restartResumeSavingRef.current = false
+    setRestartResumeSaving(false)
+    setRestartResumeError('')
+  }, [chatId])
+
+  const handleAutoResumeChange = useCallback(async (
+    next,
+    source = 'card',
+  ) => {
+    if (autoResumeSavingRef.current) return
+    autoResumeSavingRef.current = true
+    const requestId = ++autoResumeRequestRef.current
+    setAutoResumeSaving(true)
+    setAutoResumeError('')
+    setAutoResumeErrorSource(source)
+    try {
+      const result = await saveAutoResumePolicy({
+        chatId,
+        next,
+        request,
+      })
+      if (requestId !== autoResumeRequestRef.current) return
+      if (result.value !== null) {
+        setChatInfo(previous => previous ? ({
+          ...previous,
+          auto_resume_on_limit: result.value,
+        }) : previous)
+      }
+      setAutoResumeError(result.error)
+    } finally {
+      if (requestId === autoResumeRequestRef.current) {
+        autoResumeSavingRef.current = false
+        setAutoResumeSaving(false)
+      }
+    }
+  }, [chatId, request])
+
+  const handleAutoResumeSettingsChange = useCallback(
+    next => handleAutoResumeChange(next, 'settings'),
+    [handleAutoResumeChange],
+  )
+
+  const handleRestartResumeChange = useCallback(async next => {
+    if (restartResumeSavingRef.current) return
+    restartResumeSavingRef.current = true
+    const requestId = ++restartResumeRequestRef.current
+    setRestartResumeSaving(true)
+    setRestartResumeError('')
+    try {
+      const result = await saveRestartResumePolicy({
+        chatId,
+        next,
+        request,
+      })
+      if (requestId !== restartResumeRequestRef.current) return
+      if (result.value !== null) {
+        setChatInfo(previous => previous ? ({
+          ...previous,
+          auto_resume_on_restart: result.value,
+        }) : previous)
+      }
+      setRestartResumeError(result.error)
+    } finally {
+      if (requestId === restartResumeRequestRef.current) {
+        restartResumeSavingRef.current = false
+        setRestartResumeSaving(false)
+      }
+    }
+  }, [chatId, request])
+
+  useEffect(() => {
+    if (hidden) return
+    if (
+      providerSwitchState.status !== 'success'
+      || !providerSwitchState.result
+    ) return
+    mergeChatInfo(providerSwitchState.result)
+    onProviderSwitchSettled()
+    clearProviderSwitch(chatId)
+  }, [
+    chatId,
+    hidden,
+    mergeChatInfo,
+    onProviderSwitchSettled,
+    providerSwitchState.result,
+    providerSwitchState.status,
+  ])
+
+  const autoResumeEnabled = !!chatInfo?.auto_resume_on_limit
+  const restartResumeEnabled = !!chatInfo?.auto_resume_on_restart
+
+  return {
+    autoResumeEnabled,
+    autoResumeError,
+    autoResumeErrorSource,
+    autoResumeSaving,
+    chatInfo,
+    clearAutoResumeError,
+    handleAutoResumeChange,
+    handleAutoResumeSettingsChange,
+    handleRestartResumeChange,
+    mergeChatInfo,
+    providerSwitchState,
+    providerSwitching,
+    restartResumeEnabled,
+    restartResumeError,
+    restartResumeSaving,
+    setChatInfo,
+  }
+}


### PR DESCRIPTION
## Summary
- Move per-chat continuation policy state and persistence actions into one hook.
- Reduce ChatView local state and effect coordination without changing its visible behavior.
- Add direct action-level coverage for policy persistence and reset paths.

## Validation
- Validated on the complete stack: 3,380 backend tests passed with 83.88% coverage; 111 independent recovery tests and 2,275 frontend tests passed; the production frontend build, runtime bundle check, static analysis, documentation links, privacy gates, and clean locked dependency install also passed.

## Stack
Layer 10 of 12 in **Platform maintainability foundations**. This layer is incremental against the preceding reviewed layer.