### PR TITLE
Remove remaining orchestration import cycles

### DIFF
--- a/backend/app/app_cron.py
+++ b/backend/app/app_cron.py
@@ -1,0 +1,124 @@
+"""Shared cron declaration and parsing primitives for installed apps."""
+
+import os
+import subprocess
+from pathlib import Path
+
+from fastapi import HTTPException
+
+from app.config import get_settings
+
+BAKED_CRON_SCAFFOLD = Path("/app/scripts/init-cron-scaffold.sh")
+_ALLOW_TEST_CRON_ENV = "MOBIUS_ALLOW_TEST_CRON"
+
+
+def cron_scaffold(override: Path | None = None) -> Path:
+  """Resolve a test override, the served scaffold, or the baked boot floor."""
+  if override is not None and override != BAKED_CRON_SCAFFOLD:
+    return override
+  live = (
+    Path(__file__).resolve().parent.parent
+    / "scripts"
+    / "init-cron-scaffold.sh"
+  )
+  return live if live.is_file() else BAKED_CRON_SCAFFOLD
+
+
+def cron_mutation_blocked_in_test_runtime() -> bool:
+  """Fail closed when an isolated test could otherwise edit host crontab."""
+  return (
+    os.environ.get("MOBIUS_TEST_RUNTIME") == "1"
+    and os.environ.get(_ALLOW_TEST_CRON_ENV) != "1"
+  )
+
+
+def register_cron(
+  slug: str,
+  schedule_expr: str,
+  job_path: Path,
+  app_id: int | None = None,
+  timezone: str | None = None,
+  zone_cron: str | None = None,
+  *,
+  scaffold: Path | None = None,
+) -> None:
+  """Install one durable, supervised app schedule through the scaffold.
+
+  The scaffold atomically records the complete durable declaration before it
+  installs the live crontab entry. A failed durable write therefore cannot
+  change live behavior, while a later live-write failure leaves a declaration
+  that startup reconciliation can retry safely.
+
+  ``app_id`` is passed to the common job runner as the target application.
+  ``timezone`` and ``zone_cron`` form one inseparable wall-clock identity: the
+  materialized crontab cadence is only a gate, and the runner decides whether
+  the source schedule is due in its named IANA zone.
+
+  Tests may inject ``scaffold`` explicitly. Production callers normally omit
+  it so the served checkout is preferred over the baked recovery floor.
+  """
+  if cron_mutation_blocked_in_test_runtime():
+    raise HTTPException(500, "Cron mutation is disabled in the test runtime.")
+  if (timezone is None) != (zone_cron is None):
+    raise HTTPException(
+      500, "Cron registration bug: timezone and zone_cron must be paired.",
+    )
+  if timezone is not None:
+    from app import cron_tz
+
+    if app_id is None:
+      raise HTTPException(500, "A timezone-owned schedule requires an app id.")
+    if not cron_tz.valid_timezone(timezone):
+      raise HTTPException(500, f"Unknown IANA timezone: {timezone!r}")
+    if cron_tz.parse_daily_cron(zone_cron) is None:
+      raise HTTPException(
+        500, f"Zone-owned schedule must be a plain daily cron: {zone_cron!r}",
+      )
+  active_scaffold = scaffold or cron_scaffold()
+  if not active_scaffold.exists():
+    raise HTTPException(500, "init-cron-scaffold.sh missing from image.")
+  command = [
+    str(active_scaffold), slug, schedule_expr, job_path.name,
+  ]
+  if app_id is not None:
+    command.append(str(app_id))
+  if timezone is not None:
+    command.extend([timezone, zone_cron])
+
+  from app.app_jobs import runner_script
+
+  env = dict(os.environ)
+  env["API_BASE_URL"] = get_settings().api_base_url
+  env["MOBIUS_APP_JOB_RUNNER"] = str(runner_script())
+  result = subprocess.run(
+    command, capture_output=True, text=True, timeout=30, env=env,
+  )
+  if result.returncode != 0:
+    raise HTTPException(
+      500,
+      f"Cron registration failed: {result.stderr.strip()[:400]}",
+    )
+
+
+def crontab_command_path(line: str) -> str:
+  """Return the app executable path from one cron line, or an empty string."""
+  stripped = line.strip()
+  if not stripped or stripped.startswith("#"):
+    return ""
+  first = stripped.split(None, 1)[0]
+  if first.startswith("@"):
+    command = (stripped.split(None, 1) + [""])[1]
+  elif "=" in first:
+    return ""
+  else:
+    parts = stripped.split(None, 5)
+    command = parts[5] if len(parts) == 6 else ""
+  tokens = command.split()
+  while tokens and "=" in tokens[0] and not tokens[0].startswith("/"):
+    tokens.pop(0)
+  if not tokens:
+    return ""
+  for index, token in enumerate(tokens):
+    if token.endswith("/app-job-runner.py") and len(tokens) > index + 2:
+      return tokens[-1]
+  return tokens[0]

--- a/backend/app/claude_sdk_runner.py
+++ b/backend/app/claude_sdk_runner.py
@@ -595,7 +595,7 @@ async def _seal_steer_split(bc, active_client, chat_id: str) -> None:
   # block can slip in front of it.
   if raw_bc is None:
     return
-  from app.chat import steered_into_turn_event
+  from app.chat_event_sink import steered_into_turn_event
 
   stored_messages = (
     stored_result.get("stored_messages") if isinstance(stored_result, dict)

--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -607,7 +607,7 @@ class ActiveCodexTurn:
     raw_bc = self._steer_broadcast()
     if raw_bc is None:
       return
-    from app.chat import steer_delivery_failed_event
+    from app.chat_event_sink import steer_delivery_failed_event
     raw_bc.publish(
       steer_delivery_failed_event(attempt.consume_pending_cids)
     )
@@ -616,7 +616,7 @@ class ActiveCodexTurn:
     self, attempt: _CodexSteerAttempt,
   ) -> None:
     """Persist + publish the accepted cut through the turn's owning sink."""
-    from app.chat import commit_steer_cut
+    from app.chat_event_sink import commit_steer_cut
     await commit_steer_cut(
       self.chat_id,
       attempt.user_msgs,

--- a/backend/app/install.py
+++ b/backend/app/install.py
@@ -53,6 +53,11 @@ from app import (
   models,
   source_dirs,
 )
+from app import app_cron
+from app.app_cron import (
+  crontab_command_path as _crontab_command_path,
+  cron_mutation_blocked_in_test_runtime as _cron_mutation_blocked_in_test_runtime,
+)
 from app.app_capabilities import contract_and_digest
 from app.app_source_check import check_app_source
 from app.compiler import (
@@ -236,43 +241,13 @@ _HTTP_TIMEOUT = 15.0
 # different host.
 _MAX_REDIRECTS = 5
 
-_BAKED_CRON_SCAFFOLD = Path("/app/scripts/init-cron-scaffold.sh")
+_BAKED_CRON_SCAFFOLD = app_cron.BAKED_CRON_SCAFFOLD
 # Tests override this module attribute to prevent production cron mutation.
 CRON_SCAFFOLD = _BAKED_CRON_SCAFFOLD
-_ALLOW_TEST_CRON_ENV = "MOBIUS_ALLOW_TEST_CRON"
 
 
 def _cron_scaffold() -> Path:
-  """Return an explicit test override or the active production scaffold.
-
-  Startup reconciliation must migrate persisted crontab entries immediately
-  after a platform update, before the next image rebuild refreshes /app. Prefer
-  the served checkout for that production default; retain the baked copy as
-  the degraded-boot floor.
-  """
-  if CRON_SCAFFOLD != _BAKED_CRON_SCAFFOLD:
-    return CRON_SCAFFOLD
-  live = (
-    Path(__file__).resolve().parent.parent
-    / "scripts"
-    / "init-cron-scaffold.sh"
-  )
-  return live if live.is_file() else _BAKED_CRON_SCAFFOLD
-
-
-def _cron_mutation_blocked_in_test_runtime() -> bool:
-  """Whether host crontab writes must fail closed in this process.
-
-  Pytest is occasionally run from inside the production container, where the
-  real scaffold and crontab binary are both available. Its database and
-  DATA_DIR are isolated, but a low-id test app must never escape that boundary
-  and replace a production schedule. Narrow unit tests can opt in only while
-  their crontab/scaffold subprocess is explicitly faked.
-  """
-  return (
-    os.environ.get("MOBIUS_TEST_RUNTIME") == "1"
-    and os.environ.get(_ALLOW_TEST_CRON_ENV) != "1"
-  )
+  return app_cron.cron_scaffold(CRON_SCAFFOLD)
 
 
 def _validate_manifest(m: dict) -> None:
@@ -1065,88 +1040,23 @@ def clear_pending_conflict_update(source_dir: str | Path) -> None:
   )
 
 
-def _register_cron(slug: str, schedule_expr: str, job_path: Path,
-                   app_id: int | None = None,
-                   timezone: str | None = None,
-                   zone_cron: str | None = None) -> None:
-  """Runs init-cron-scaffold.sh to install the crontab entry.
-
-  ``timezone``/``zone_cron`` (given together) declare the schedule's durable
-  zone-aware identity. The scaffold writes that identity into the complete
-  durable declaration atomically *before* installing the live entry. This
-  ordering means a persistence failure cannot change live behavior while
-  returning failure; a later live-write failure leaves a durable declaration
-  that boot reconciliation can safely retry.
-
-  The scaffold writes both the durable ``init-cron.sh`` declaration and the
-  live crontab entry. On restart, lifespan parses that declaration and rewrites
-  it through the supervised runner; app-owned shell is never executed merely
-  because the container booted. Calling the scaffold for an unchanged
-  ``(slug, schedule, job)`` is idempotent.
-
-  The job script itself is written earlier, in the transactional source
-  write (so a locally edited job survives an update via the per-app git
-  merge); the scaffold preserves an existing job file rather than stubbing
-  it, so it never clobbers what we wrote.
-
-  The job filename (e.g. fetch.sh, from the manifest's schedule.job) is
-  passed to the scaffold so the crontab entry points at the real job —
-  the scaffold defaults to job.sh otherwise, which would leave a
-  manifest that ships fetch.sh firing an empty stub.
-
-  `app_id`, when given, is passed as the scaffold's 4th arg so the
-  crontab command becomes `<job-path> <app_id>`. A reusable job that
-  reads its target app from "$1" (the same contract as the run-job
-  "Generate now" endpoint) then fires correctly from cron. Without it,
-  such a job runs with no id and exits early — which is exactly how a
-  freshly-installed news app's cron lands dead on arrival.
-  """
-  if _cron_mutation_blocked_in_test_runtime():
-    raise HTTPException(
-      500,
-      "Cron mutation is disabled in the test runtime.",
-    )
-  if (timezone is None) != (zone_cron is None):
-    raise HTTPException(
-      500, "Cron registration bug: timezone and zone_cron must be paired.",
-    )
-  if timezone is not None:
-    from app import cron_tz
-
-    if app_id is None:
-      raise HTTPException(
-        500, "A timezone-owned schedule requires an app id.",
-      )
-    if not cron_tz.valid_timezone(timezone):
-      raise HTTPException(500, f"Unknown IANA timezone: {timezone!r}")
-    if cron_tz.parse_daily_cron(zone_cron) is None:
-      raise HTTPException(
-        500, f"Zone-owned schedule must be a plain daily cron: {zone_cron!r}",
-      )
-  scaffold = _cron_scaffold()
-  if not scaffold.exists():
-    # In tests we mock this away; in containers it's always present.
-    raise HTTPException(500, "init-cron-scaffold.sh missing from image.")
-  cmd = [str(scaffold), slug, schedule_expr, job_path.name]
-  if app_id is not None:
-    cmd.append(str(app_id))
-  if timezone is not None:
-    cmd.extend([timezone, zone_cron])
-  # Cron has a deliberately minimal environment. Materialize the configured
-  # backend URL and the active supervisor path into its generated entry so
-  # scheduled jobs use the same live runner and server as Run now.
-  from app.app_jobs import runner_script
-  env = dict(os.environ)
-  env["API_BASE_URL"] = get_settings().api_base_url
-  env["MOBIUS_APP_JOB_RUNNER"] = str(runner_script())
-  result = subprocess.run(
-    cmd, capture_output=True, text=True, timeout=30, env=env,
+def _register_cron(
+  slug: str,
+  schedule_expr: str,
+  job_path: Path,
+  app_id: int | None = None,
+  timezone: str | None = None,
+  zone_cron: str | None = None,
+) -> None:
+  app_cron.register_cron(
+    slug,
+    schedule_expr,
+    job_path,
+    app_id,
+    timezone,
+    zone_cron,
+    scaffold=_cron_scaffold(),
   )
-  if result.returncode != 0:
-    raise HTTPException(
-      500,
-      f"Cron registration failed: {result.stderr.strip()[:400]}",
-    )
 
 
 def _reconcile_cron_after_install_rollback() -> None:
@@ -1172,41 +1082,6 @@ def _reconcile_cron_after_install_rollback() -> None:
     # Rollback is already a best-effort failure path. Log without masking the
     # original install exception that caused it.
     log.warning("install rollback cron reconciliation failed: %s", exc)
-
-
-def _crontab_command_path(line: str) -> str:
-  """The executable path a crontab job line runs, or "" for a line that
-  runs no job (blank, comment, or a `NAME=value` env/setting line).
-
-  The schedule is either a single `@shorthand` token (@daily/@reboot/…) or
-  five whitespace-separated fields; the rest is the command. cron also lets
-  the command be prefixed with inline `NAME=value` assignments, which we
-  skip to reach the real executable (the first non-assignment token).
-  """
-  s = line.strip()
-  if not s or s.startswith("#"):
-    return ""
-  first = s.split(None, 1)[0]
-  if first.startswith("@"):
-    cmd = (s.split(None, 1) + [""])[1]
-  elif "=" in first:
-    return ""  # NAME=value env/setting line — runs no command
-  else:
-    parts = s.split(None, 5)
-    cmd = parts[5] if len(parts) == 6 else ""
-  toks = cmd.split()
-  while toks and "=" in toks[0] and not toks[0].startswith("/"):
-    toks.pop(0)
-  if not toks:
-    return ""
-  for i, token in enumerate(toks):
-    if token.endswith("/app-job-runner.py") and len(toks) > i + 2:
-      # The supervised runner's job path is always its final argument. A
-      # wall-clock schedule inserts its timezone and source expression before
-      # the app id; using the final argument keeps uninstall parsing aligned
-      # with both ordinary and gated invocations.
-      return toks[-1]
-  return toks[0]
 
 
 def _crontab_without_app(current: str, source_dir: Path) -> str | None:
@@ -2829,18 +2704,10 @@ async def install_from_manifest(
   # that left local untouched).
 
   # Phase 3: materialize under one compensation journal.
-  # `created_paths`: files/dirs to delete on failure (and leave on
-  # success). `cleanup_actions`: callables run on the success path
-  # (commit) OR rollback path (revert) — used for backup-rename
-  # rollback on the update path's compiled bundle, so a failed
-  # recompile restores the previous good bundle on disk to match the
-  # DB row that rolled back.
+  # Every filesystem mutation registers its rollback/commit action on this
+  # journal before the durable row commit.
   journal = InstallJournal()
-  created_paths = journal.created_paths
-  rollback_actions = journal.rollback_actions
-  commit_actions = journal.commit_actions
   data_dir = Path(get_settings().data_dir)
-  perms = manifest.get("permissions") or {}
 
   try:
     app = await _prepare_app_row(
@@ -3286,7 +3153,7 @@ async def install_from_manifest(
         if mode == "update" and target.exists():
           continue
         atomic_write(target, content)
-        created_paths.append(target)
+        journal.created_paths.append(target)
 
     # A successfully resolved manifest declaration owns the package icon.
     # Omission clears it; a warned fetch/decode failure preserves the last

--- a/backend/app/providers.py
+++ b/backend/app/providers.py
@@ -31,12 +31,9 @@ import stat
 import threading
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any, Literal, Protocol
 
 from app.storage_io import atomic_write
-
-if TYPE_CHECKING:
-  from app.schemas import AgentSettingsOverride
 
 
 log = logging.getLogger(__name__)
@@ -170,6 +167,13 @@ _LEGACY_GLOBAL_AUTO_RESUME_KEY = "auto_resume_on_limit"
 _AGENT_SETTINGS_LOCK = threading.RLock()
 
 
+class _SettingsOverride(Protocol):
+  """Structural boundary for the Pydantic override accepted by this module."""
+
+  def model_dump(self) -> dict[str, Any]:
+    ...
+
+
 def remove_legacy_global_auto_resume_setting(data_dir: str) -> bool:
   """Delete the removed owner-global policy so rollback cannot revive it.
 
@@ -288,7 +292,7 @@ def update_agent_settings(data_dir: str, updater) -> bool:
 
 def effective_agent_settings(
   data_dir: str,
-  chat_overrides: "AgentSettingsOverride | dict[str, Any] | None" = None,
+  chat_overrides: _SettingsOverride | dict[str, Any] | None = None,
   provider: str | None = None,
 ) -> dict:
   """Merges per-chat overrides on top of the global defaults.

--- a/backend/app/routes/app_schedules.py
+++ b/backend/app/routes/app_schedules.py
@@ -105,7 +105,7 @@ def _manifest_schedule(source_dir: Path) -> tuple[str, str] | None:
 def _schedule_from_crontab_text(
   source_dir: Path, text: str,
 ) -> tuple[str, str] | None:
-  from app.install import _crontab_command_path
+  from app.app_cron import crontab_command_path as _crontab_command_path
 
   needle = f"{str(source_dir).rstrip('/')}/"
   for line in text.splitlines():
@@ -178,7 +178,7 @@ def reconcile_app_cron_supervision(db: Session) -> tuple[int, list[str]]:
   offset, decides the declared wall-clock occurrence at runtime.
   """
   from app import cron_tz
-  from app.install import _register_cron
+  from app.app_cron import register_cron as _register_cron
 
   settings = get_settings()
   apps_root = Path(settings.data_dir) / "apps"
@@ -444,7 +444,7 @@ def update_app_schedule(
       status_code=400, detail="App has no source_dir; cannot locate job.",
     )
   from app import cron_tz
-  from app.install import _register_cron
+  from app.app_cron import register_cron as _register_cron
   try:
     validate_cron_expr(body.cron)
   except ManifestContractError as exc:

--- a/backend/tests/test_app_uninstall_reversible.py
+++ b/backend/tests/test_app_uninstall_reversible.py
@@ -704,7 +704,7 @@ def test_recover_migrates_preserved_direct_cron_without_executing_it(
 
   assert client.delete(f"/api/apps/{app_id}", headers=auth).status_code == 204
 
-  with patch("app.install._register_cron") as register, \
+  with patch("app.app_cron.register_cron") as register, \
        patch("app.routes.app_schedules._read_live_crontab", return_value=""), \
        patch("app.routes.apps.subprocess.run") as direct_run:
     response = client.post(f"/api/apps/{app_id}/recover", headers=auth)

--- a/backend/tests/test_apps.py
+++ b/backend/tests/test_apps.py
@@ -348,7 +348,7 @@ def test_app_token_can_update_own_schedule_only(client, auth, monkeypatch):
   def fake_register(slug, schedule_expr, job_path, app_id=None):
     calls.append((slug, schedule_expr, job_path.name, app_id))
 
-  monkeypatch.setattr("app.install._register_cron", fake_register)
+  monkeypatch.setattr("app.app_cron.register_cron", fake_register)
   source_dir = Path(get_settings().data_dir) / "apps" / "news"
   source_dir.mkdir(parents=True, exist_ok=True)
   (source_dir / "fetch.sh").write_text("#!/bin/sh\n", encoding="utf-8")
@@ -390,7 +390,7 @@ def test_schedule_update_with_timezone_materializes_and_declares(
     calls.append((slug, schedule_expr, job_path.name, app_id,
                   timezone, zone_cron))
 
-  monkeypatch.setattr("app.install._register_cron", fake_register)
+  monkeypatch.setattr("app.app_cron.register_cron", fake_register)
   monkeypatch.setattr(
     "app.cron_tz.materialize_zone_cron",
     lambda zone_cron, tz_name: "* * * * *",
@@ -456,7 +456,7 @@ def test_reconcile_restores_zone_schedule_as_wall_clock_gate(client, auth, db):
                     timezone=None, zone_cron=None):
     calls.append((slug, schedule_expr, timezone, zone_cron))
 
-  with patch("app.install._register_cron", fake_register), \
+  with patch("app.app_cron.register_cron", fake_register), \
        patch("app.cron_tz.materialize_zone_cron",
              lambda zone_cron, tz_name: "* * * * *"):
     count, warnings = apps_module.reconcile_app_cron_supervision(db)
@@ -484,7 +484,7 @@ def test_reconcile_fails_closed_on_malformed_zone_declaration(
   )
 
   from app.routes import app_schedules as apps_module
-  with patch("app.install._register_cron") as register:
+  with patch("app.app_cron.register_cron") as register:
     count, warnings = apps_module.reconcile_app_cron_supervision(db)
 
   assert count == 0
@@ -663,7 +663,7 @@ def test_boot_reconciles_legacy_direct_cron_through_runner(client, db):
   from app.routes import app_schedules as apps_module
   direct = f"15 4 * * * {source_dir}/fetch.sh {app.id}"
   with patch.object(apps_module, "_read_live_crontab", return_value=direct), \
-       patch("app.install._register_cron") as register:
+       patch("app.app_cron.register_cron") as register:
     count, warnings = apps_module.reconcile_app_cron_supervision(db)
 
   assert count == 1


### PR DESCRIPTION
## Summary
- Give cron registration and crontab parsing a dedicated owner shared by installation and schedules.
- Make provider settings depend on a structural contract instead of the request-schema layer.
- Point provider steering at the event sink directly and remove every remaining backend import cycle.

## Validation
- Validated on the complete stack: 3,380 backend tests passed with 83.88% coverage; 111 independent recovery tests and 2,275 frontend tests passed; the production frontend build, runtime bundle check, static analysis, documentation links, privacy gates, and clean locked dependency install also passed.

## Stack
Layer 12 of 12 in **Platform maintainability foundations**. This layer is incremental against the preceding reviewed layer.