### PR TITLE
Align provider usage bars and use 24-hour reset times

### DIFF
--- a/frontend/src/components/ProviderAuth/ProviderAuth.css
+++ b/frontend/src/components/ProviderAuth/ProviderAuth.css
@@ -501,18 +501,17 @@
 
 .provider-usage__windows {
   display: grid;
-  gap: 5px;
+  grid-template-columns: minmax(62px, auto) minmax(56px, 1fr) auto auto;
+  gap: 5px 8px;
 }
 
 .provider-usage__window {
-  display: grid;
-  grid-template-columns: minmax(62px, auto) minmax(56px, 1fr) auto auto;
-  align-items: center;
-  gap: 8px;
-  min-width: 0;
+  display: contents;
 }
 
 .provider-usage__label {
+  grid-column: 1;
+  align-self: center;
   color: var(--muted);
   font-size: 11px;
   line-height: 1.3;
@@ -520,6 +519,8 @@
 }
 
 .provider-usage__track {
+  grid-column: 2;
+  align-self: center;
   display: block;
   width: 100%;
   height: 3px;
@@ -537,6 +538,8 @@
 }
 
 .provider-usage__value {
+  grid-column: 3;
+  align-self: center;
   color: var(--text);
   min-width: 34px;
   font-size: 11.5px;
@@ -547,6 +550,8 @@
 }
 
 .provider-usage__reset {
+  grid-column: 4;
+  align-self: center;
   color: var(--muted);
   font-size: 10.5px;
   line-height: 1.3;
@@ -554,6 +559,7 @@
 }
 
 .provider-usage__credit {
+  grid-column: 1 / -1;
   color: var(--muted);
   font-size: 11.5px;
   line-height: 1.35;
@@ -613,9 +619,18 @@
     display: inline;
   }
 
+  .provider-usage__windows {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+  }
+
   .provider-usage__window {
+    display: grid;
     grid-template-columns: minmax(62px, auto) minmax(48px, 1fr) auto;
+    align-items: center;
     gap: 6px;
+    min-width: 0;
   }
 
   .provider-usage__reset {

--- a/frontend/src/components/SettingsView/providerUsage.js
+++ b/frontend/src/components/SettingsView/providerUsage.js
@@ -31,9 +31,9 @@ export function formatUsageReset(value, now = new Date()) {
     minute: '2-digit',
     hourCycle: 'h23',
   }).format(reset)
-  if (sameDay) return `resets ${time}`
+  if (sameDay) return `Resets ${time}`
   const day = new Intl.DateTimeFormat(undefined, { weekday: 'short' }).format(reset)
-  return `resets ${day} ${time}`
+  return `Resets ${day} ${time}`
 }
 
 export function visibleUsageWindows(snapshot) {

--- a/frontend/src/components/SettingsView/providerUsage.js
+++ b/frontend/src/components/SettingsView/providerUsage.js
@@ -27,8 +27,9 @@ export function formatUsageReset(value, now = new Date()) {
     && reset.getDate() === now.getDate()
   )
   const time = new Intl.DateTimeFormat(undefined, {
-    hour: 'numeric',
+    hour: '2-digit',
     minute: '2-digit',
+    hourCycle: 'h23',
   }).format(reset)
   if (sameDay) return `resets ${time}`
   const day = new Intl.DateTimeFormat(undefined, { weekday: 'short' }).format(reset)

--- a/frontend/src/lib/__tests__/providerUsage.test.js
+++ b/frontend/src/lib/__tests__/providerUsage.test.js
@@ -39,13 +39,12 @@ test('usage percentages are bounded and retain useful precision', () => {
 })
 
 test('reset formatting distinguishes today from another day', () => {
-  const now = new Date('2026-07-30T12:00:00Z')
-  const today = formatUsageReset('2026-07-30T17:00:00Z', now)
-  const later = formatUsageReset('2026-08-03T17:00:00Z', now)
+  const now = new Date(2026, 6, 30, 12, 0)
+  const today = formatUsageReset(new Date(2026, 6, 30, 17, 5), now)
+  const later = formatUsageReset(new Date(2026, 7, 3, 7, 0), now)
 
-  assert.match(today, /^resets /)
-  assert.doesNotMatch(today, /Mon/)
-  assert.match(later, /^resets Mon /)
+  assert.equal(today, 'resets 17:05')
+  assert.equal(later, 'resets Mon 07:00')
 })
 
 test('only four valid allowance windows are rendered', () => {
@@ -77,7 +76,7 @@ test('Claude and Codex usage disclosures stay independently expandable', () => {
   assert.doesNotMatch(settingsView, /expandedUsage === '(?:codex|claude)'/)
 })
 
-test('expanded usage restores thin accessible lines without tall cards', () => {
+test('expanded usage shares aligned columns without tall cards', () => {
   assert.match(usageView, /className="provider-usage__track"/)
   assert.match(usageView, /role="progressbar"/)
   assert.match(usageView, /className="provider-usage__fill"/)
@@ -87,6 +86,10 @@ test('expanded usage restores thin accessible lines without tall cards', () => {
   )
   assert.match(
     providerCss,
-    /\.provider-usage__window\s*\{[^}]*grid-template-columns:/s,
+    /\.provider-usage__windows\s*\{[^}]*grid-template-columns:/s,
+  )
+  assert.match(
+    providerCss,
+    /\.provider-usage__window\s*\{[^}]*display:\s*contents;/s,
   )
 })

--- a/frontend/src/lib/__tests__/providerUsage.test.js
+++ b/frontend/src/lib/__tests__/providerUsage.test.js
@@ -43,8 +43,8 @@ test('reset formatting distinguishes today from another day', () => {
   const today = formatUsageReset(new Date(2026, 6, 30, 17, 5), now)
   const later = formatUsageReset(new Date(2026, 7, 3, 7, 0), now)
 
-  assert.equal(today, 'resets 17:05')
-  assert.equal(later, 'resets Mon 07:00')
+  assert.equal(today, 'Resets 17:05')
+  assert.equal(later, 'Resets Mon 07:00')
 })
 
 test('only four valid allowance windows are rendered', () => {


### PR DESCRIPTION
## Summary
- align provider usage rows so progress tracks, percentages, and reset labels share consistent columns
- preserve the compact stacked layout in narrow settings panes
- format reset labels with a 00–23 hour cycle

## Tests
- `node --test frontend/src/lib/__tests__/providerUsage.test.js`
- `npm run build`