### PR TITLE
Keep active goal indicator across steered questions

### DIFF
--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -1963,11 +1963,16 @@ class ChatWriterActor:
     # so any still-running row is a prior run whose clear was dropped — mark it
     # interrupted before opening this one (at most one run is ever live).
     from app.models import ChatRun
+    from app.run_state import goal_objective_for_run_start
+    goal_objective = goal_objective_for_run_start(
+      db, cmd.chat_id, cmd.user_msg.get("content"),
+    )
     self._close_nonterminal_runs(db, cmd.chat_id, "interrupted")
     db.add(ChatRun(
       id=cmd.run_token, chat_id=cmd.chat_id, status="running",
       provider=chat.provider, started_at=started_at,
       initiated_by_app_id=cmd.initiated_by_app_id,
+      goal_objective=goal_objective,
     ))
     if not _commit_or_rollback(db):
       raise _PersistFailed("StartTurn did not persist")
@@ -2359,6 +2364,10 @@ class ChatWriterActor:
     # continuation. Close its run record and open the continuation's in the
     # SAME commit as the queue handoff.
     from app.models import ChatRun
+    from app.run_state import goal_objective_for_run_start
+    goal_objective = goal_objective_for_run_start(
+      db, cmd.chat_id, agent_pending.get("content"),
+    )
     self._close_nonterminal_runs(
       db, cmd.chat_id, cmd.ending_status, except_token=cmd.run_token
     )
@@ -2366,6 +2375,7 @@ class ChatWriterActor:
       id=cmd.run_token, chat_id=cmd.chat_id, status="running",
       provider=chat.provider, started_at=started_at,
       initiated_by_app_id=initiated_by_app_id,
+      goal_objective=goal_objective,
     ))
     if not _commit_or_rollback(db):
       raise _PersistFailed("PromotePending did not persist")

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -936,8 +936,74 @@ def _converge_legacy_schema(eng) -> None:
         conn.commit()
 
 
+def _add_chat_run_goal_objective(eng) -> None:
+  """Persist active goal identity on its owning durable run.
+
+  The bounded backfill covers a goal already running during this upgrade. User
+  timestamps are server-authored, and the run starts after its initiating row
+  is committed; later steered questions therefore fall strictly after the run
+  boundary and cannot replace the initiating ``/goal`` candidate.
+  """
+  import re
+  from sqlalchemy import inspect as sa_inspect, text
+
+  inspector = sa_inspect(eng)
+  tables = set(inspector.get_table_names())
+  if "chat_runs" not in tables:
+    return
+  columns = {column["name"] for column in inspector.get_columns("chat_runs")}
+  if "goal_objective" in columns:
+    return
+  with eng.begin() as conn:
+    conn.execute(text(
+      "ALTER TABLE chat_runs ADD COLUMN goal_objective TEXT NULL"
+    ))
+    rows = (
+      conn.execute(text(
+        "SELECT r.id, r.started_at, c.messages "
+        "FROM chat_runs r JOIN chats c ON c.id = r.chat_id "
+        "WHERE r.status IN ('running', 'parked', 'resume_pending')"
+      )).all()
+      if "chats" in tables
+      else []
+    )
+    for run_id, raw_started_at, raw_messages in rows:
+      try:
+        started_at = raw_started_at
+        if isinstance(started_at, str):
+          started_at = datetime.fromisoformat(started_at.replace("Z", "+00:00"))
+        if started_at.tzinfo is None:
+          started_at = started_at.replace(tzinfo=UTC)
+        started_ms = started_at.timestamp() * 1000
+        messages = (
+          json.loads(raw_messages)
+          if isinstance(raw_messages, str)
+          else list(raw_messages or [])
+        )
+      except (AttributeError, TypeError, ValueError, json.JSONDecodeError):
+        continue
+      initiating = None
+      for message in messages:
+        if not isinstance(message, dict) or message.get("role") != "user":
+          continue
+        timestamp = message.get("ts")
+        if isinstance(timestamp, (int, float)) and timestamp <= started_ms:
+          initiating = message
+      content = initiating.get("content", "") if initiating else ""
+      if not isinstance(content, str):
+        continue
+      match = re.match(r"^\s*/goal(?:\s+([\s\S]+))?\s*$", content)
+      objective = (match.group(1) or "").strip() if match else ""
+      if not objective or objective.lower() == "clear":
+        continue
+      conn.execute(text(
+        "UPDATE chat_runs SET goal_objective = :objective WHERE id = :run_id"
+      ), {"objective": objective, "run_id": run_id})
+
+
 _SCHEMA_MIGRATIONS = (
   ("0001_legacy_schema_convergence", _converge_legacy_schema),
+  ("0002_chat_run_goal_objective", _add_chat_run_goal_objective),
 )
 
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -217,6 +217,11 @@ class ChatRun(Base):
   # park_reason="restart"; an unplanned crash remains "interrupted".
   status = Column(String(16), nullable=False, default="running", index=True)
   provider = Column(String(32), nullable=True, default=None)
+  # Objective shown by the shell while this exact run owns a native goal.
+  # This belongs to the run rather than the transcript tail: mid-turn owner
+  # questions are steered into the same run and must not make the goal vanish
+  # after a reload. NULL is an ordinary non-goal run.
+  goal_objective = Column(Text, nullable=True, default=None)
   # App that initiated this turn under the app-attributed-chat contract
   # (077 §1). NULL = an ordinary owner-driven turn. Reserved now so the
   # attribution lands on the run row, not retrofitted later.

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -41,6 +41,7 @@ from app.run_state import (
   has_nonterminal_run,
   has_running_run,
   running_chat_ids,
+  running_goal_objective,
 )
 from app.schemas import ChatPatch, ChatProviderSwitch
 from app.timeutil import now_naive_utc, SOFT_DELETE_TTL
@@ -416,6 +417,9 @@ def _chat_detail_response(
   provider = chat.provider or "claude"
   pending_question = questions.get(chat.id)
   settings_obj = _coerce_agent_settings(chat.agent_settings_json) or None
+  active_goal_objective = (
+    running_goal_objective(db, chat.id) if running else None
+  )
   return {
     "id": chat.id,
     "title": chat.title,
@@ -428,6 +432,7 @@ def _chat_detail_response(
     "total": total,
     "offset": start,
     "running": running,
+    "active_goal_objective": active_goal_objective,
     "pending_question_id": (
       pending_question.question_id if pending_question is not None else None
     ),
@@ -1107,6 +1112,7 @@ def get_chat_runtime(
   pending_question = questions.get(chat.id)
   return {
     "running": is_chat_running(chat.id),
+    "active_goal_objective": running_goal_objective(db, chat.id),
     "pending_messages": list(chat.pending_messages or []),
     "pending_question_id": (
       pending_question.question_id if pending_question is not None else None

--- a/backend/app/run_state.py
+++ b/backend/app/run_state.py
@@ -13,6 +13,33 @@ from sqlalchemy.orm import Session
 from app import models
 
 
+def goal_objective_for_run_start(
+  db: Session,
+  chat_id: str,
+  content: str | None,
+) -> str | None:
+  """Resolve the goal metadata for a newly opened durable run.
+
+  Explicit ``/goal`` commands start a new objective. A real continuation may
+  inherit only from the immediately preceding unfinished/interrupted run; an
+  ordinary turn after a completed goal therefore cannot revive stale UI state.
+  """
+  from app.chat import _goal_objective
+
+  objective = _goal_objective(content or "")
+  if objective is not None:
+    return objective
+  if (content or "").strip().lower() != "continue":
+    return None
+  previous = latest_run(db, chat_id)
+  if previous is None or previous.status not in (
+    *models.NONTERMINAL_RUN_STATUSES,
+    "interrupted",
+  ):
+    return None
+  return previous.goal_objective
+
+
 def latest_run(db: Session, chat_id: str) -> models.ChatRun | None:
   """Return the deterministic latest durable run for one chat."""
   return (
@@ -69,6 +96,23 @@ def running_run(db: Session, chat_id: str) -> models.ChatRun | None:
     )
     .first()
   )
+
+
+def running_goal_objective(db: Session, chat_id: str) -> str | None:
+  """Return only the active run's goal label for lightweight UI reads."""
+  row = (
+    db.query(models.ChatRun.goal_objective)
+    .filter(
+      models.ChatRun.chat_id == chat_id,
+      models.ChatRun.status == "running",
+    )
+    .order_by(
+      models.ChatRun.started_at.desc(),
+      models.ChatRun.id.desc(),
+    )
+    .first()
+  )
+  return row[0] if row is not None else None
 
 
 def running_chat_ids(

--- a/backend/tests/test_chat_runs.py
+++ b/backend/tests/test_chat_runs.py
@@ -79,6 +79,16 @@ def _active_status(chat_id):
     db.close()
 
 
+def _goal_objective(chat_id):
+  db = SessionLocal()
+  try:
+    from app.run_state import latest_run
+    run = latest_run(db, chat_id)
+    return run.goal_objective if run is not None else None
+  finally:
+    db.close()
+
+
 def _drain():
   get_writer().submit(Barrier()).result(timeout=5)
 
@@ -99,6 +109,48 @@ def test_start_turn_opens_a_running_run_record():
   runs = _runs("r1")
   assert runs == {"rt-1": ("running", False)}
   assert _active_status("r1") == "running"
+
+
+def test_goal_identity_lives_on_the_run_and_real_resume_inherits_it():
+  _seed_chat("r-goal")
+  get_writer().submit(StartTurn(
+    chat_id="r-goal", run_token="rt-goal",
+    user_msg={
+      "role": "user", "content": "/goal finish the migration", "ts": 1,
+    },
+    title_source="goal", default_provider="codex",
+  )).result(timeout=5)
+  assert _goal_objective("r-goal") == "finish the migration"
+
+  get_writer().submit(FinishRun(
+    chat_id="r-goal",
+    run_token="rt-goal",
+    terminal_status="interrupted",
+  )).result(timeout=5)
+  get_writer().submit(StartTurn(
+    chat_id="r-goal", run_token="rt-resume",
+    user_msg={"role": "user", "content": "continue", "ts": 2},
+    title_source="continue", default_provider="codex",
+  )).result(timeout=5)
+  assert _goal_objective("r-goal") == "finish the migration"
+
+
+def test_completed_goal_does_not_leak_into_an_ordinary_later_run():
+  _seed_chat("r-complete-goal")
+  get_writer().submit(StartTurn(
+    chat_id="r-complete-goal", run_token="rt-old-goal",
+    user_msg={"role": "user", "content": "/goal old work", "ts": 1},
+    title_source="goal", default_provider="codex",
+  )).result(timeout=5)
+  get_writer().submit(FinishRun(
+    chat_id="r-complete-goal", run_token="rt-old-goal",
+  )).result(timeout=5)
+  get_writer().submit(StartTurn(
+    chat_id="r-complete-goal", run_token="rt-ordinary",
+    user_msg={"role": "user", "content": "what happened?", "ts": 2},
+    title_source="ordinary", default_provider="codex",
+  )).result(timeout=5)
+  assert _goal_objective("r-complete-goal") is None
 
 
 # -- clean close ----------------------------------------------------------

--- a/backend/tests/test_chat_transcript_compact.py
+++ b/backend/tests/test_chat_transcript_compact.py
@@ -404,6 +404,7 @@ def test_runtime_route_does_not_select_transcript_json(
   assert runtime.status_code == 200
   assert runtime.json() == {
     "running": True,
+    "active_goal_objective": None,
     "pending_messages": [],
     "pending_question_id": None,
     "updated_at": created.json()["updated_at"],

--- a/backend/tests/test_chats.py
+++ b/backend/tests/test_chats.py
@@ -131,6 +131,45 @@ def test_agent_context_includes_evolving_chat_summary(
   assert payload["system_prompt_origin"] == "platform"
 
 
+def test_chat_reads_keep_goal_identity_after_a_mid_turn_question(
+  client, auth, chat, db,
+):
+  started_at = datetime.now(UTC)
+  started_ms = int(started_at.timestamp() * 1000)
+  chat.messages = [
+    {
+      "role": "user",
+      "content": "/goal finish the review",
+      "ts": started_ms - 5,
+      "cid": "goal-start",
+    },
+    {"role": "assistant", "content": "Working", "ts": started_ms + 5},
+    {
+      "role": "user",
+      "content": "A steered question",
+      "ts": started_ms + 10,
+      "cid": "goal-steer",
+    },
+  ]
+  db.add(models.ChatRun(
+    id="active-goal-run",
+    chat_id=chat.id,
+    status="running",
+    provider="codex",
+    goal_objective="finish the review",
+    started_at=started_at,
+  ))
+  db.commit()
+
+  detail = client.get(f"/api/chats/{chat.id}", headers=auth)
+  runtime = client.get(f"/api/chats/{chat.id}/runtime", headers=auth)
+
+  assert detail.status_code == 200
+  assert runtime.status_code == 200
+  assert detail.json()["active_goal_objective"] == "finish the review"
+  assert runtime.json()["active_goal_objective"] == "finish the review"
+
+
 def test_chat_usage_reports_totals_and_historic_coverage(
   client, auth, chat, db,
 ):

--- a/backend/tests/test_db_migrations.py
+++ b/backend/tests/test_db_migrations.py
@@ -524,8 +524,56 @@ def test_run_migrations_records_an_inspectable_append_only_history(tmp_path):
 
   assert [row["version"] for row in first] == [
     "0001_legacy_schema_convergence",
+    "0002_chat_run_goal_objective",
   ]
   assert second == first
+
+
+def test_goal_migration_backfills_only_the_running_turns_initiating_goal(
+  tmp_path,
+):
+  eng = create_engine(f"sqlite:///{tmp_path / 'goal-run.db'}")
+  models.Base.metadata.create_all(eng)
+  started_at = datetime(2026, 7, 31, 12, 0, 0)
+  started_ms = int(started_at.replace(tzinfo=database.UTC).timestamp() * 1000)
+  with Session(eng) as session:
+    session.add(models.Chat(
+      id="goal-chat",
+      title="Goal",
+      messages=[
+        {
+          "role": "user",
+          "content": "/goal finish the migration",
+          "ts": started_ms - 5,
+        },
+        {"role": "assistant", "content": "Working", "ts": started_ms + 5},
+        {
+          "role": "user",
+          "content": "A steered question",
+          "ts": started_ms + 10,
+        },
+      ],
+      pending_messages=[],
+    ))
+    session.add(models.ChatRun(
+      id="goal-run",
+      chat_id="goal-chat",
+      status="running",
+      provider="codex",
+      started_at=started_at,
+    ))
+    session.commit()
+  with eng.begin() as conn:
+    conn.execute(text("ALTER TABLE chat_runs DROP COLUMN goal_objective"))
+
+  run_migrations(eng)
+  run_migrations(eng)
+
+  with eng.connect() as conn:
+    objective = conn.execute(text(
+      "SELECT goal_objective FROM chat_runs WHERE id = 'goal-run'"
+    )).scalar_one()
+  assert objective == "finish the migration"
 
 
 def test_failed_migration_is_not_recorded_and_can_retry(tmp_path, monkeypatch):

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -2844,7 +2844,7 @@
    its height, so a height animation would fight the composer clearance. */
 .chat__progress-rail {
   max-width: 720px;
-  margin: 0 auto 8px;
+  margin: 0 auto 3px;
   display: flex;
   flex-wrap: wrap;
   align-items: center;

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -919,9 +919,13 @@ export default function ChatView({
       if (data.running || (!preserveLocalTurn && !staleSnapshot)) {
         setServerRunningState(!!data.running)
       }
+      setActiveGoalState(data.running
+        ? (data.active_goal_objective || latestGoalObjective(msgs))
+        : '')
       setLiveQuestionId(data.pending_question_id || null)
       updateChatRuntimeCache(queryClient, chatMessagesQueryKey(chatId), {
         running: !!data.running,
+        activeGoalObjective: data.active_goal_objective || '',
         pending_messages: data.pending_messages || [],
         pending_question_id: data.pending_question_id || null,
       })
@@ -944,7 +948,13 @@ export default function ChatView({
       // an authoritative idle verdict.
       return null
     }
-  }, [chatId, commitMessages, pendingQueue.hydrate, queryClient])
+  }, [
+    chatId,
+    commitMessages,
+    pendingQueue.hydrate,
+    queryClient,
+    setActiveGoalState,
+  ])
 
   // Active-turn runtime reconciliation. The SSE stream is authoritative for
   // assistant output, but queued-message affordances depend on the durable
@@ -984,9 +994,11 @@ export default function ChatView({
         sendingRef.current = false
       }
       setServerRunningState(!!data.running)
+      setActiveGoalState(data.running ? (data.active_goal_objective || '') : '')
       setLiveQuestionId(data.pending_question_id || null)
       updateChatRuntimeCache(queryClient, chatMessagesQueryKey(chatId), {
         running: !!data.running,
+        activeGoalObjective: data.active_goal_objective || '',
         pending_messages: serverPending,
         pending_question_id: data.pending_question_id || null,
       })
@@ -997,7 +1009,13 @@ export default function ChatView({
         pendingQueue.hydrate(serverPending)
       }
     } catch { /* background reconciliation is best-effort */ }
-  }, [chatId, pendingQueue.hydrate, pendingQueue.pendingMessagesRef, queryClient])
+  }, [
+    chatId,
+    pendingQueue.hydrate,
+    pendingQueue.pendingMessagesRef,
+    queryClient,
+    setActiveGoalState,
+  ])
 
   const handleCompactionStored = useCallback(
     () => fetchMessages({ force: true }),
@@ -1652,6 +1670,9 @@ export default function ChatView({
     const settleRuntime = (runtime, visibleMessages) => {
       const running = !!runtime.running
       setServerRunningLocalState(running)
+      setActiveGoalState(running
+        ? (runtime.active_goal_objective || latestGoalObjective(visibleMessages))
+        : '')
       hadMessagesRef.current = visibleMessages.length > 0
       setLiveQuestionId(runtime.pending_question_id || null)
       setBridgeMountInputs({
@@ -1720,6 +1741,7 @@ export default function ChatView({
         // changed. The retained messages and their DOM remain untouched.
         updateChatRuntimeCache(queryClient, queryKey, {
           running: !!runtime.running,
+          activeGoalObjective: runtime.active_goal_objective || '',
           pending_messages: runtime.pending_messages || [],
           pending_question_id: runtime.pending_question_id || null,
         })

--- a/frontend/src/components/ChatView/__tests__/chatDetailCache.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatDetailCache.test.js
@@ -22,6 +22,7 @@ test('prefetched chat detail matches the synchronous ChatView cache contract', (
     }],
     offset: 12,
     running: false,
+    active_goal_objective: 'Finish the migration',
     pending_messages: [{ id: 'queued' }],
     pending_question_id: 'question-1',
     provider: 'codex',
@@ -39,6 +40,7 @@ test('prefetched chat detail matches the synchronous ChatView cache contract', (
   assert.equal(cached.updated_at, source.updated_at)
   assert.equal(source.messages[0].blocks[0].status, 'running', 'projection does not mutate the response')
   assert.equal(cached.offset, 12)
+  assert.equal(cached.activeGoalObjective, 'Finish the migration')
   assert.equal(cached.pending_question_id, 'question-1')
   assert.deepEqual(cached.chatInfo, {
     provider: 'codex',

--- a/frontend/src/components/ChatView/__tests__/goalProgress.test.js
+++ b/frontend/src/components/ChatView/__tests__/goalProgress.test.js
@@ -142,6 +142,11 @@ test('ChatView binds goal state to the existing run-start and turn-end lifecycle
   )
   assert.match(
     chatView,
+    /runtime\.active_goal_objective \|\| latestGoalObjective\(visibleMessages\)/,
+    'a cold chat read should restore the objective from the durable active run',
+  )
+  assert.match(
+    chatView,
     /<ProgressRail\s+items=\{progressRail\}/,
     'the goal should render through the shared progress rail',
   )
@@ -153,6 +158,11 @@ test('ChatView binds goal state to the existing run-start and turn-end lifecycle
   assert.match(progressRail, /chat__progress-rail/)
   assert.match(progressRail, /aria-expanded=\{expanded\}/)
   assert.match(progressRail, /label\.scrollWidth > step\.clientWidth/)
+  assert.match(
+    chatCss,
+    /\.chat__progress-rail\s*\{[\s\S]*?margin:\s*0 auto 3px;/,
+    'the goal rail should sit close to the composer like other footer status UI',
+  )
   assert.match(
     chatCss,
     /\.chat__foot \.chat__progress-step--toggle[\s\S]*?\{ pointer-events: auto; \}/,

--- a/frontend/src/lib/chatDetailCache.js
+++ b/frontend/src/lib/chatDetailCache.js
@@ -44,6 +44,9 @@ export function chatDetailCacheValue(data = {}) {
       : [],
     offset: data.offset || 0,
     running: !!data.running,
+    activeGoalObjective: typeof data.active_goal_objective === 'string'
+      ? data.active_goal_objective
+      : '',
     pending_messages: Array.isArray(data.pending_messages)
       ? data.pending_messages
       : [],


### PR DESCRIPTION
## Summary

- persist the active `/goal` objective on its durable chat run so a later steered question cannot replace the indicator after reconnecting
- hydrate the objective through chat detail and runtime state, including a bounded migration for goals already running during upgrade
- carry objectives only through unfinished or interrupted resumes, so completed goals do not reappear on later turns
- move the compact progress rail closer to the composer

## Context

#295 added the active-goal rail and kept its identity in client state, but a cold reconnect still inferred the goal from the latest visible user message. Once that message was a mid-turn question rather than the original `/goal`, the label disappeared even though the goal was still running. This follow-up makes the durable run the identity owner.

## Testing

- full backend suite (3,508 passed)
- full frontend unit and hook suites
- production/PWA build
- `git diff --check`

Co-authored-by: Möbius Agent <mobius-agent@users.noreply.github.com>