### PR TITLE
Keep the final-turn scroll range stable

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -517,7 +517,7 @@ automatically armed by installing Möbius.
 
 ## Chat scroll + steer contract
 
-**Owner-authoritative contract — v1.11 (2026-07-27).** This section is the
+**Owner-authoritative contract — v1.12 (2026-07-31).** This section is the
 canonical source of truth for how a chat scrolls and steers. When implementation,
 comments, and this contract disagree, the implementation/comments are the bug:
 fix behavior to match this contract. If a real case is unspecified or the desired
@@ -541,21 +541,24 @@ and attaches their rule ids to new diagnostic chats. The Playwright lock-in spec
   waits for the spacer-exhaustion handoff. A viewport /
   keyboard change, foreground return, mount, or chat restoration must never create
   auto-scroll.
-- **R1 — Visible latest-user reservation.** Dynamic bottom spacer belongs only to
-  the latest visible user row. It reserves exactly enough room for that row to reach
-  the viewport top and shrinks as reply, tool, image, or other content fills the
-  deficit. The remaining room survives turn completion when the reply is short.
-  Expanding content consumes it; collapsing the same content restores the exact
-  deficit. Mode does not own its ordinary lifetime: `PIN_USER_MSG` may reserve
-  before a fresh row is placed, while `ANCHOR_AT`, `FOLLOW_BOTTOM`, mount/return,
-  and disclosure settlement reserve only when their real viewport contains the
-  latest user row. If that row leaves the viewport, ordinary spacer is zero;
-  seeing an older user row never qualifies. An otherwise unreachable anchor clamps
-  to real conversation content before visibility is decided. R6's transient
-  question-submit hold is the sole exception: it may reserve only the exact tail
-  deficit required for a stable card handoff while the viewport size is unchanged.
-  It is never persisted and must release to the unanswered card's prior mode before
-  a keyboard or other viewport resize is laid out.
+- **R1 — Stable latest-turn reservation.** Dynamic bottom spacer derives from the
+  latest user row and the real tail geometry, independent of whether that row has
+  already entered the viewport. It reserves exactly enough room for that row to
+  reach the viewport top and shrinks as reply, tool, image, or other content fills
+  the deficit. The full range must exist before a downward gesture approaches the
+  final turn: crossing the latest-user viewport boundary must never extend
+  `scrollHeight` after momentum settles. The remaining room survives turn
+  completion when the reply is short. Expanding content consumes it; collapsing
+  the same content restores the exact deficit. Scroll mode does not own the
+  reservation; `PIN_USER_MSG`, `ANCHOR_AT`, `FOLLOW_BOTTOM`, mount/return, and
+  disclosure settlement all see the same tail range. Only the DOM's latest user row
+  participates—an older user row never gets a separate reservation. Durable anchor
+  validation still rejects locations wholly inside reserved blank space, so
+  restoring a chat lands on real conversation content. R6's transient
+  question-submit hold is the sole calculation exception: it may reserve only the
+  exact tail deficit required for a stable card handoff while the viewport size is
+  unchanged. It is never persisted and must release to the unanswered card's prior
+  mode before a keyboard or other viewport resize is laid out.
 - **R2 — One send rule everywhere.** The first visible user message always pins to
   the viewport top. Every subsequent direct, queued, promoted, or steered message
   pins when its submit-time DOM snapshot is at the real-content tail. Geometry is
@@ -718,7 +721,7 @@ Controller structure is part of the contract, not an implementation detail:
   `scrollTop` write goes through `writeMode`. The exported `applyMode` executor
   is for the controller and pure unit tests, not a second live writer.
 - `useScrollMode` is the sole writer of `.spacer-dynamic` height. The write is
-  derived from the latest user row's visibility and exact content deficit;
+  derived from the latest user row and exact tail deficit;
   disclosure helpers and renderers may preserve an on-screen anchor but may never
   prime, enlarge, or unwind spacer themselves.
 - The gesture-gated `scroll` event reads physical-bottom geometry directly.
@@ -744,9 +747,9 @@ but never backward. Do not derive a remounted timer solely from `Date.now()` or 
 client arrival time of replayed deltas: catch-up arrives as a burst and that makes a
 minutes-old turn visibly restart at one second.
 
-Only the latest visible user row makes R1's reservation current. Reservation
-lifetime follows that row's visibility and exact remaining deficit, not turn
-completion or a particular scroll mode.
+Only the latest user row makes R1's reservation current. Reservation lifetime
+follows the exact remaining tail deficit, not viewport visibility, turn completion,
+or a particular scroll mode.
 - **A restored send is one logical message.** The frontend scopes the draft
   identity to the chat and reuses its client-minted `cid` when an ambiguous
   failed POST restores an unchanged composer. The route checks that durable

--- a/frontend/src/components/ChatView/__tests__/anchorHeldThroughToggle.test.js
+++ b/frontend/src/components/ChatView/__tests__/anchorHeldThroughToggle.test.js
@@ -4,9 +4,9 @@ import assert from 'node:assert/strict'
 import { anchorHeldThroughToggle } from '../chatContract.js'
 
 // The disclosure seam (thinking/tool/activity collapse) is where the chat UI
-// regressed repeatedly: a bounce (anchor top moved across the toggle) or blank
-// room without the latest user row. This predicate is the machine-checkable
-// law for an ANCHOR_AT toggle.
+// regressed repeatedly: a bounce (anchor top moved across the toggle). Tail
+// reservation is stable and independent of viewport visibility; this predicate
+// is the machine-checkable law for an ANCHOR_AT toggle.
 
 test('a held anchor with no spacer growth passes', () => {
   const r = anchorHeldThroughToggle(
@@ -23,17 +23,10 @@ test('an anchor that bounced past tolerance fails', () => {
   assert.equal(r.measured.drift, 20)
 })
 
-test('an anchored disclosure cannot leave room without the latest user visible', () => {
+test('stable tail reservation may remain while an older anchor is held', () => {
   const reserved = anchorHeldThroughToggle(
     { anchorTop: 500, spacerH: 0 },
     { anchorTop: 500, spacerH: 48 })
-  assert.equal(reserved.ok, false)
-})
-
-test('collapse may restore reservation when the latest user remains visible', () => {
-  const reserved = anchorHeldThroughToggle(
-    { anchorTop: 500, spacerH: 0 },
-    { anchorTop: 500, spacerH: 48, latestUserVisible: true })
   assert.equal(reserved.ok, true)
 })
 
@@ -43,7 +36,7 @@ test('missing anchor data is indeterminate, never a false pass', () => {
   assert.match(r.reason, /anchorTop/)
 })
 
-test('a stale pre-toggle spacer passes only when the toggle leaves none behind', () => {
+test('a stable pre-toggle spacer does not affect the anchor contract', () => {
   const r = anchorHeldThroughToggle(
     { anchorTop: 300, spacerH: 250 },
     { anchorTop: 300, spacerH: 0 })

--- a/frontend/src/components/ChatView/__tests__/chatContract.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatContract.test.js
@@ -72,7 +72,7 @@ test('owner contract freezes question answers without locking keyboard movement'
     new URL('../../../../../ARCHITECTURE.md', import.meta.url),
     'utf8',
   )
-  assert.match(architecture, /Owner-authoritative contract — v1\.11 \(2026-07-27\)/)
+  assert.match(architecture, /Owner-authoritative contract — v1\.12 \(2026-07-31\)/)
   assert.match(
     architecture,
     /In-process question is answered \| any \| transient `ANCHOR_AT` over the prior mode; same active assistant row/,
@@ -80,7 +80,7 @@ test('owner contract freezes question answers without locking keyboard movement'
   )
   assert.match(
     architecture,
-    /question-submit hold is the sole exception: it may reserve only the exact tail\s+deficit required for a stable card handoff while the viewport size is unchanged/,
+    /question-submit hold is the sole calculation exception: it may reserve only the\s+exact tail deficit required for a stable card handoff while the viewport size is\s+unchanged/,
     'question submission may reserve only its same-viewport reachability deficit',
   )
   assert.match(

--- a/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
+++ b/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
@@ -1,5 +1,6 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
 
 import {
   _anchorModeIntersectsContent,
@@ -41,6 +42,11 @@ import {
   pinLanded,
   snapshotChatUX,
 } from '../chatContract.js'
+
+const scrollModeSource = readFileSync(
+  new URL('../useScrollMode.js', import.meta.url),
+  'utf8',
+)
 
 function makeScrollEl({ scrollHeight, scrollTop, clientHeight, spacerHeight = 0 }) {
   return {
@@ -310,6 +316,24 @@ test('touch input never reads scroll geometry, so it cannot force a layout', () 
   // Wheel genuinely needs the values, so it must still read them - exactly once.
   readerInputNeedsFrameRelease('wheel', readGeometry)
   assert.equal(geometryReads, 2, 'wheel reads the scroller once')
+})
+
+test('reader-input tracing never measures the transcript at gesture start', () => {
+  assert.match(
+    scrollModeSource,
+    /captureGeometry = true,[\s\S]*?geometry: captureGeometry \? _scrollGeometryForDiagnostics\(scrollEl\) : null/,
+    'low-frequency diagnostics retain geometry while hot paths can opt out',
+  )
+  assert.match(
+    scrollModeSource,
+    /reader:input-\$\{event\?\.type \|\| 'unknown'\}`,[\s\S]{0,120}?captureGeometry: false/,
+    'the first reader input must not force transcript layout',
+  )
+  assert.match(
+    scrollModeSource,
+    /reader:scroll-start', \{ captureGeometry: false \}/,
+    'the first compositor scroll frame must not force transcript layout',
+  )
 })
 
 test('scroll diagnostics expose behavior without message identity', () => {
@@ -1239,7 +1263,7 @@ function makeSpacerScrollEl({ clientHeight, queuedTray = null }) {
   }
 }
 
-test('spacer reservation belongs to the visible latest user row in any mode', () => {
+test('spacer reservation belongs to the latest user row in any mode', () => {
   const scrollEl = makeSpacerScrollEl({ clientHeight: 600 })
   scrollEl.scrollTop = 500
   const listEl = { offsetHeight: 900 }
@@ -1268,7 +1292,7 @@ test('spacer reservation belongs to the visible latest user row in any mode', ()
       { kind: 'ANCHOR_AT', key: 'a-1', offset: 0 },
     ),
     396,
-    'mode does not retire room while the latest user row is visible',
+    'mode does not retire the stable latest-turn room',
   )
   assert.equal(
     _computeSpacerH(
@@ -1279,11 +1303,11 @@ test('spacer reservation belongs to the visible latest user row in any mode', ()
       { kind: 'PIN_USER_MSG', cid: 'different-row' },
     ),
     396,
-    'visibility, not stale mode identity, owns the latest row reservation',
+    'stale mode identity cannot change the latest row reservation',
   )
 })
 
-test('spacer disappears when only an older user row is visible', () => {
+test('off-screen latest user pre-reserves one stable downward scroll range', () => {
   const scrollEl = makeSpacerScrollEl({ clientHeight: 600 })
   scrollEl.scrollTop = 0
   const listEl = { offsetHeight: 1400 }
@@ -1301,12 +1325,36 @@ test('spacer disappears when only an older user row is visible', () => {
       600,
       { kind: 'ANCHOR_AT', key: 'older-user', offset: 0 },
     ),
-    0,
-    'a visible older row cannot borrow reservation from the off-screen latest row',
+    96,
+    'tail room exists before the gesture reaches the latest row',
   )
 })
 
-test('applied anchor viewport outranks stale current visibility', () => {
+test('crossing the latest-user viewport boundary cannot create a second-stage bottom', () => {
+  const scrollEl = makeSpacerScrollEl({ clientHeight: 600 })
+  const listEl = { offsetHeight: 1400 }
+  const latestUserMsgEl = {
+    offsetTop: 900,
+    offsetHeight: 80,
+    dataset: { cid: 'latest' },
+  }
+  const mode = { kind: 'ANCHOR_AT', key: 'older-user', offset: 0 }
+
+  scrollEl.scrollTop = 0
+  const beforeApproach = _computeSpacerH(
+    scrollEl, listEl, latestUserMsgEl, 600, mode,
+  )
+  scrollEl.scrollTop = 700
+  const afterLatestUserAppears = _computeSpacerH(
+    scrollEl, listEl, latestUserMsgEl, 600, mode,
+  )
+
+  assert.equal(beforeApproach, 96)
+  assert.equal(afterLatestUserAppears, beforeApproach,
+    'scrolling the latest row into view must not extend scrollHeight')
+})
+
+test('an older applied anchor does not make tail scrollHeight grow later', () => {
   const anchor = { offsetTop: 100, offsetHeight: 80 }
   const scrollEl = {
     clientHeight: 600,
@@ -1329,8 +1377,8 @@ test('applied anchor viewport outranks stale current visibility', () => {
       600,
       { kind: 'ANCHOR_AT', key: 'older-anchor', offset: 0 },
     ),
-    0,
-    'a pending anchor that hides the latest row must not carry stale room into its applied viewport',
+    296,
+    'the final range is present even while an older anchor is visible',
   )
 })
 
@@ -1362,7 +1410,7 @@ test('applied anchor may reserve before current geometry reaches its visible lat
   )
 })
 
-test('keyboard-closed height cannot make an actually hidden row visible', () => {
+test('keyboard-closed height keeps permanent tail reservation stable', () => {
   const scrollEl = makeSpacerScrollEl({ clientHeight: 400 })
   const latestUserMsgEl = {
     offsetTop: 500,
@@ -1378,8 +1426,8 @@ test('keyboard-closed height cannot make an actually hidden row visible', () => 
       800,
       { kind: 'INITIAL' },
     ),
-    0,
-    'fullViewH sizes eligible room but actual clientHeight decides visibility',
+    596,
+    'the full-height reservation exists before the hidden row is approached',
   )
 })
 
@@ -1414,7 +1462,7 @@ test('spacer reservation returns zero before there is a user message', () => {
   assert.equal(_computeSpacerH(scrollEl, listEl, null, 600), 0)
 })
 
-test('question-answer anchor gets no room when the latest user row is off-screen', () => {
+test('ordinary question-answer anchor keeps the stable latest-turn tail range', () => {
   const anchor = { offsetTop: 60, offsetHeight: 220 }
   const scrollEl = {
     clientHeight: 960,
@@ -1432,8 +1480,8 @@ test('question-answer anchor gets no room when the latest user row is off-screen
       960,
       mode,
     ),
-    0,
-    'an unreachable anchor clamps to conversation content instead',
+    556,
+    'ordinary anchor visibility cannot create a second-stage bottom',
   )
 })
 

--- a/frontend/src/components/ChatView/chatContract.js
+++ b/frontend/src/components/ChatView/chatContract.js
@@ -104,7 +104,7 @@ export const CHAT_CONTRACT = [
     summary:
       'Collapsing or expanding thinking, tool, and activity disclosures keeps '
       + 'the reader anchor fixed. The helper never writes spacer; the sole '
-      + 'owner recomputes room only for the visible latest user row.',
+      + 'owner recomputes the stable latest-turn deficit.',
   },
 ]
 
@@ -232,22 +232,19 @@ export function cushionPresent(snap, { min = PIN_BOTTOM_ROOM, pinOffset = PIN_OF
 /** C7 anchor-held-through-toggle: collapsing/expanding a disclosure (a thinking
  *  block, tool card, or activity stretch) must not move the reader. The anchor's
  *  viewport-top stays put across the toggle (±tolerance). The disclosure helper
- *  never writes spacer; the scroll owner may independently consume/restore an
- *  exact deficit only when the latest user row remains visible. */
+ *  never writes spacer; the scroll owner may independently consume/restore the
+ *  stable latest-turn deficit. */
 export function anchorHeldThroughToggle(
   before, after, { tolerance = 2 } = {}) {
   const id = 'anchor-held-through-toggle'
-  const expected = `anchor top drift <= ${tolerance}; positive spacer requires visible latest user`
+  const expected = `anchor top drift <= ${tolerance}`
   if (!before || !after || before.anchorTop == null || after.anchorTop == null) {
     return indeterminate(id, expected,
       'no anchorTop in before/after (missing disclosure anchor)')
   }
   const drift = after.anchorTop - before.anchorTop
-  const spacerOk = after.spacerH == null
-    || after.spacerH <= tolerance
-    || after.latestUserVisible === true
   return {
-    ok: Math.abs(drift) <= tolerance && spacerOk,
+    ok: Math.abs(drift) <= tolerance,
     id, expected,
     measured: {
       drift,

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -26,12 +26,12 @@
  * A live pin leaves FOLLOW_BOTTOM while its dynamic spacer is being consumed,
  * then hands off to FOLLOW_BOTTOM exactly when that reservation reaches zero.
  * A short reply never reaches the handoff and remains pinned after settle.
- * Ordinary dynamic spacer room belongs exclusively to the latest visible
- * user row. It is independent of turn completion: short replies keep the
- * remaining room, while reply/tool expansion consumes it and collapse
- * restores it. PIN_USER_MSG may reserve before its row lands so a fresh send
- * can pin in one frame; every other ordinary mode reserves only while that
- * latest row is visible. The one explicit exception is the transient
+ * Ordinary dynamic spacer room belongs to the latest user row and is derived
+ * from tail geometry, not from whether a gesture has already scrolled that row
+ * into view. That keeps scrollHeight stable while the reader approaches the
+ * final turn: short replies keep the remaining room, while reply/tool
+ * expansion consumes it and collapse restores it. The one explicit exception
+ * is the transient
  * question-submit anchor: it reserves exactly enough tail room for a stable
  * same-viewport handoff. A keyboard resize restores the pre-submit mode before
  * sizing, so the answered card moves exactly as the unanswered card would.
@@ -479,64 +479,16 @@ export function _modeForPersistence(mode, messages, scrollEl) {
 }
 
 
-function _rowIntersectsViewport(rowEl, scrollTop, viewH) {
-  if (!rowEl || !Number.isFinite(scrollTop) || !(viewH > 0)) return false
-  const rowTop = rowEl.offsetTop
-  const rowHeight = rowEl.offsetHeight
-  if (!Number.isFinite(rowTop) || !Number.isFinite(rowHeight)) return false
-  return rowTop + rowHeight > scrollTop && rowTop < scrollTop + viewH
-}
-
-
-/** Whether the latest user row owns reservation in the viewport represented by
- *  current geometry/mode. A matching PIN_USER_MSG is allowed to reserve before
- *  the browser can place the fresh row. Other modes must actually show the
- *  latest user row — either now or at the real-content target they are about to
- *  apply. Older user rows never participate because the caller passes only the
- *  DOM tail user row.
- */
-function _latestUserOwnsSpacer(scrollEl, listEl, lastUserMsgEl, mode, viewH) {
-  const rowCid = lastUserMsgEl?.dataset?.cid
-  if (mode?.kind === 'PIN_USER_MSG'
-      && rowCid != null
-      && String(rowCid) === String(mode.cid)) {
-    return true
-  }
-
-  let targetScrollTop = null
-  if (mode?.kind === 'ANCHOR_AT') {
-    const anchorEl = _anchorEl(scrollEl, mode.key)
-    if (anchorEl) targetScrollTop = anchorEl.offsetTop - mode.offset
-  } else if (mode?.kind === 'FOLLOW_BOTTOM') {
-    targetScrollTop = listEl.offsetHeight - scrollEl.clientHeight
-  }
-  if (targetScrollTop == null) {
-    return _rowIntersectsViewport(lastUserMsgEl, scrollEl.scrollTop, viewH)
-  }
-
-  // Project against real content only. Spacer cannot make its own owner
-  // visible; it may only realize room for a row that the held viewport shows.
-  const maxRealScrollTop = Math.max(
-    0,
-    listEl.offsetHeight - scrollEl.clientHeight,
-  )
-  const clampedTarget = Math.min(
-    maxRealScrollTop,
-    Math.max(0, targetScrollTop),
-  )
-  return _rowIntersectsViewport(lastUserMsgEl, clampedTarget, viewH)
-}
-
-
-/** Spacer height needed so the latest visible user message can sit near the
+/** Spacer height needed so the latest user message can sit near the
  *  top of the viewport, with the PIN_OFFSET breathing room above it, or so a
  *  transient question-submit anchor remains reachable while the submit-time
  *  viewport size is unchanged.
  *
- *  Visibility is the defining invariant. The matching latest user pin may
- *  reserve before placement; every other mode gets room only while its real
- *  viewport contains that latest row. Turn completion does not retire room.
- *  Content growth consumes the exact deficit and content collapse restores it.
+ *  Tail geometry is the defining invariant. Reservation exists before a
+ *  downward gesture reaches the latest row, so scrollHeight cannot grow at the
+ *  old physical bottom after momentum settles. Turn completion does not retire
+ *  room. Content growth consumes the exact deficit and content collapse
+ *  restores it.
  *
  *  Formula:
  *    max(0, viewH + (lastUserMsgTop − PIN_OFFSET) − listH
@@ -552,11 +504,9 @@ function _latestUserOwnsSpacer(scrollEl, listEl, lastUserMsgEl, mode, viewH) {
  *  the pre-cushion behavior; a >0 value re-adds breathing room if the exact
  *  end-of-scroll rest ever feels cramped.)
  *
- *  Once the latest user row leaves the viewport, ordinary reservation
- *  collapses. An older visible user row never receives it. A question-submit
- *  anchor instead reserves only its exact reachability deficit for a
- *  same-viewport handoff. A keyboard resize restores the mode that owned the
- *  unanswered card before this function runs again.
+ *  A question-submit anchor instead reserves only its exact reachability
+ *  deficit for a same-viewport handoff. A keyboard resize restores the mode
+ *  that owned the unanswered card before this function runs again.
  */
 const PIN_OFFSET = 4
 const PIN_BOTTOM_ROOM = 0
@@ -577,13 +527,6 @@ export function _computeSpacerH(
     return Math.max(0, viewH + anchorTarget - listEl.offsetHeight)
   }
   if (!lastUserMsgEl) return 0
-  if (!_latestUserOwnsSpacer(
-    scrollEl,
-    listEl,
-    lastUserMsgEl,
-    mode,
-    scrollEl.clientHeight || viewH,
-  )) return 0
   const pinTarget = Math.max(0, lastUserMsgEl.offsetTop - PIN_OFFSET)
   return Math.max(
     0,
@@ -1139,10 +1082,17 @@ export default function useScrollMode({
     return () => clearTimeout(deadline)
   }, [chatId])
 
+  // Geometry capture reads scrollHeight/offsetHeight, which forces a synchronous
+  // reflow of the unvirtualized transcript. That is acceptable for low-frequency
+  // transition/write traces (they run right after a layout write anyway), but on
+  // the reader-input path it would reflow on every touchstart and first scroll
+  // frame — the exact gesture-start window that must stay cheap. Those call sites
+  // opt out; geometry stays on by default everywhere else.
   const recordTrace = useCallback((bucket, event, {
     from = null,
     to = null,
     scrollEl = scrollRef.current,
+    captureGeometry = true,
   } = {}) => {
     _appendScrollTrace(bucket, {
       at: Math.round(typeof performance !== 'undefined' ? performance.now() : 0),
@@ -1150,7 +1100,7 @@ export default function useScrollMode({
       event,
       ...(from ? { from: _scrollModeForDiagnostics(from) } : {}),
       ...(to ? { to: _scrollModeForDiagnostics(to) } : {}),
-      geometry: _scrollGeometryForDiagnostics(scrollEl),
+      geometry: captureGeometry ? _scrollGeometryForDiagnostics(scrollEl) : null,
     })
   }, [chatId, scrollRef])
 
@@ -1945,8 +1895,8 @@ export default function useScrollMode({
           if (anchor) transitionMode(anchor, 'reader:hold-anchor')
         }
         persistMode()
-        // Recompute once against the final viewport after momentum, never
-        // underneath the gesture itself.
+        // Tail geometry, not mode or viewport visibility, owns reservation.
+        // Recompute once after momentum, never underneath the gesture itself.
         // When a footer resize was deferred, replay geometry + the newly
         // settled semantic mode atomically; a bare sizeSpacer here would let
         // native scroll anchoring paint an intermediate displaced frame.
@@ -2030,7 +1980,7 @@ export default function useScrollMode({
       )
       if (!readerAlreadyOwns || activatesDisclosure) {
         recordTrace('events', `reader:input-${event?.type || 'unknown'}`, {
-          scrollEl,
+          captureGeometry: false,
         })
       }
       if (activatesDisclosure) {
@@ -2213,7 +2163,7 @@ export default function useScrollMode({
       }
       const firstOwnedScroll = !readerScrollDirty
       if (firstOwnedScroll) {
-        recordTrace('events', 'reader:scroll-start', { scrollEl })
+        recordTrace('events', 'reader:scroll-start', { captureGeometry: false })
         clearTimeout(pendingGestureTimerRef.current)
         pendingGestureTimerRef.current = 0
         cancelAnimationFrame(pendingGestureReleaseRafRef.current)


### PR DESCRIPTION
## Summary
- reserve the final-turn tail range before the latest user row enters the viewport, so reaching it cannot create a second-stage bottom
- keep the first touch and scroll tracing paths free of synchronous transcript layout reads
- update the owner scroll contract and focused regression coverage

## Context
This is a focused follow-up to #197, #220, and #342. Those changes established the latest-turn spacer and reader-settlement contracts; this closes a later regression where the reserved range depended on viewport visibility and gesture-start tracing measured the full transcript.

## Testing
- focused chat scroll contract tests (123 passing)
- frontend production build