### PR TITLE
Add full-text chat search to the navigation drawer

### DIFF
--- a/backend/app/chat_search.py
+++ b/backend/app/chat_search.py
@@ -1,0 +1,330 @@
+"""Full-text search over chat transcripts (drawer search).
+
+Design: an SQLite FTS5 index over conversation prose — the owner's messages,
+the assistant's replies, and chat titles. Tool output, thinking traces, and
+`blocks` machinery are deliberately excluded: they live in their own tables,
+they are the bulk of the bytes, and they are noise for "where did we talk
+about X".
+
+The index is DERIVED data, reconciled lazily at query time:
+
+- `chat_search_docs` holds one plain-text row per indexed message (plus one
+  title row per chat, ``msg_idx = -1``). `chat_search_fts` is an
+  external-content FTS5 table over it, kept in sync by triggers on the docs
+  table itself (the canonical FTS5 external-content pattern — the triggers
+  watch OUR derived table, never `chats`).
+- `chat_search_state` remembers, per chat, how many messages are indexed and
+  the exact `chats.updated_at` text at index time. A search request first
+  reconciles: any live chat whose `updated_at` no longer equals the remembered
+  text gets its NEW messages appended (or a per-chat rebuild when history
+  shrank or the title changed); index rows for deleted/purged chats are
+  dropped. Chats whose timestamp moved without new content (run markers,
+  streaming) cost one state-row update, not a re-tokenize.
+
+Because reconciliation happens inside the search request there is no second
+code path that could forget to update the index, nothing hooks into the turn
+lifecycle, and a missing index (or this feature landing on an existing
+instance) simply rebuilds itself on first use. Memory: FTS5 reads b-tree
+pages from disk per query; nothing is cached in process memory. Only changed
+chats ever have their `messages` JSON hydrated — reconcile compares
+timestamps, not transcripts.
+
+Writes here touch only the three `chat_search_*` tables — never
+`Chat.messages` / `Chat.pending_messages` (those stay behind `chat_writer.py`).
+"""
+
+import re
+
+from sqlalchemy import text as sql
+from sqlalchemy.orm import Session
+
+from app import models
+
+# Private-use sentinels around FTS5 snippet matches. The API converts them to
+# a JSON-friendly form; they can never collide with real transcript text.
+_MARK_OPEN = "\ue000"
+_MARK_CLOSE = "\ue001"
+
+# Message roles whose `content` strings are conversation prose.
+_PROSE_ROLES = ("user", "assistant")
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS chat_search_docs (
+  id INTEGER PRIMARY KEY,
+  chat_id TEXT NOT NULL,
+  msg_idx INTEGER NOT NULL,
+  ts INTEGER,
+  role TEXT,
+  text TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS chat_search_docs_chat
+  ON chat_search_docs(chat_id);
+CREATE VIRTUAL TABLE IF NOT EXISTS chat_search_fts USING fts5(
+  text,
+  content='chat_search_docs',
+  content_rowid='id',
+  tokenize='unicode61 remove_diacritics 2'
+);
+CREATE TRIGGER IF NOT EXISTS chat_search_docs_ai
+  AFTER INSERT ON chat_search_docs BEGIN
+    INSERT INTO chat_search_fts(rowid, text) VALUES (new.id, new.text);
+  END;
+CREATE TRIGGER IF NOT EXISTS chat_search_docs_ad
+  AFTER DELETE ON chat_search_docs BEGIN
+    INSERT INTO chat_search_fts(chat_search_fts, rowid, text)
+      VALUES ('delete', old.id, old.text);
+  END;
+CREATE TABLE IF NOT EXISTS chat_search_state (
+  chat_id TEXT PRIMARY KEY,
+  indexed_count INTEGER NOT NULL,
+  indexed_title TEXT NOT NULL,
+  indexed_updated_at TEXT NOT NULL
+);
+"""
+
+_schema_ready = False
+
+
+def _ensure_schema(db: Session) -> None:
+  global _schema_ready
+  if _schema_ready:
+    return
+  # A pre-reveal index has a `chat_search_docs` without the `ts`/`role`
+  # columns. This is DERIVED data that rebuilds itself, so drop the stale
+  # search tables and recreate at the current schema rather than ALTER-dancing;
+  # the reconcile in the same search request repopulates from `chats`. Dropping
+  # the external-content FTS virtual table also removes its shadow tables, and
+  # dropping the docs table removes the sync triggers defined on it.
+  existing = db.execute(
+    sql(
+      "SELECT 1 FROM sqlite_master"
+      " WHERE type = 'table' AND name = 'chat_search_docs'"
+    )
+  ).fetchone()
+  if existing is not None:
+    columns = [row[1] for row in db.execute(sql("PRAGMA table_info(chat_search_docs)"))]
+    if "ts" not in columns:
+      for statement in (
+        "DROP TABLE IF EXISTS chat_search_fts",
+        "DROP TABLE IF EXISTS chat_search_docs",
+        "DROP TABLE IF EXISTS chat_search_state",
+      ):
+        db.execute(sql(statement))
+      db.commit()
+  for statement in _split_schema(_SCHEMA):
+    db.execute(sql(statement))
+  db.commit()
+  _schema_ready = True
+
+
+def _split_schema(schema: str) -> list[str]:
+  """Split the DDL on statement boundaries, keeping trigger bodies intact."""
+  statements, buf, in_trigger = [], [], False
+  for line in schema.splitlines():
+    stripped = line.strip()
+    if not stripped:
+      continue
+    buf.append(line)
+    if stripped.upper().startswith("CREATE TRIGGER"):
+      in_trigger = True
+    if stripped.endswith(";"):
+      if in_trigger and stripped.upper() != "END;":
+        continue
+      statements.append("\n".join(buf))
+      buf, in_trigger = [], False
+  return statements
+
+
+def _prose_docs(title: str, messages: list) -> list[tuple[int, object, object, str]]:
+  """(msg_idx, ts, role, text) rows: title at -1 (ts/role None), then prose.
+
+  `ts` and `role` are stored so a search result can point the drawer at the
+  exact transcript row to reveal — the chat UI keys each message row as
+  ``<role>-<ts>``. `ts` is unique within a chat, so it needs no message index.
+  """
+  docs: list[tuple[int, object, object, str]] = []
+  if title and title.strip():
+    docs.append((-1, None, None, title.strip()))
+  for idx, message in enumerate(messages):
+    if not isinstance(message, dict):
+      continue
+    role = message.get("role")
+    if role not in _PROSE_ROLES:
+      continue
+    content = message.get("content")
+    if isinstance(content, str) and content.strip():
+      ts = message.get("ts")
+      docs.append((idx, ts if isinstance(ts, int) else None, role, content))
+  return docs
+
+
+def _delete_chat_docs(db: Session, chat_id: str) -> None:
+  db.execute(
+    sql("DELETE FROM chat_search_docs WHERE chat_id = :cid"), {"cid": chat_id}
+  )
+  db.execute(
+    sql("DELETE FROM chat_search_state WHERE chat_id = :cid"), {"cid": chat_id}
+  )
+
+
+def _write_docs(db: Session, chat_id: str, docs: list[tuple[int, object, object, str]]) -> None:
+  for msg_idx, ts, role, doc_text in docs:
+    db.execute(
+      sql(
+        "INSERT INTO chat_search_docs (chat_id, msg_idx, ts, role, text)"
+        " VALUES (:cid, :idx, :ts, :role, :txt)"
+      ),
+      {"cid": chat_id, "idx": msg_idx, "ts": ts, "role": role, "txt": doc_text},
+    )
+
+
+def reconcile(db: Session) -> None:
+  """Bring the index in line with the chats table. Cheap when nothing changed."""
+  _ensure_schema(db)
+
+  # Index rows whose chat is gone or tombstoned. A restored chat re-enters
+  # through the stale scan below (restore bumps updated_at; no state row
+  # remains, so it reindexes from scratch).
+  orphans = db.execute(
+    sql(
+      "SELECT s.chat_id FROM chat_search_state s"
+      " WHERE NOT EXISTS (SELECT 1 FROM chats c"
+      "   WHERE c.id = s.chat_id AND c.deleted_at IS NULL)"
+    )
+  ).fetchall()
+  for (chat_id,) in orphans:
+    _delete_chat_docs(db, chat_id)
+
+  # Live chats whose row changed since we last indexed them. Compared as the
+  # exact stored text (equality, not ordering) so timestamp formatting can
+  # never produce a false "fresh".
+  stale = db.execute(
+    sql(
+      "SELECT c.id FROM chats c"
+      " LEFT JOIN chat_search_state s ON s.chat_id = c.id"
+      " WHERE c.deleted_at IS NULL"
+      "   AND (s.chat_id IS NULL"
+      "        OR s.indexed_updated_at IS NOT CAST(c.updated_at AS TEXT))"
+    )
+  ).fetchall()
+
+  for (chat_id,) in stale:
+    # Hydrates messages JSON for THIS chat only.
+    chat = db.get(models.Chat, chat_id)
+    if chat is None or chat.deleted_at is not None:
+      continue
+    row = db.execute(
+      sql("SELECT CAST(updated_at AS TEXT) FROM chats WHERE id = :cid"),
+      {"cid": chat_id},
+    ).fetchone()
+    updated_text = row[0] if row else ""
+    messages = chat.messages or []
+    title = chat.title or ""
+    state = db.execute(
+      sql(
+        "SELECT indexed_count, indexed_title FROM chat_search_state"
+        " WHERE chat_id = :cid"
+      ),
+      {"cid": chat_id},
+    ).fetchone()
+
+    if state is not None and state[1] == title and len(messages) >= state[0]:
+      # History is append-only, so only messages beyond the indexed count are
+      # new. A shrink (retention/repair rewrote history) or retitle falls
+      # through to the full per-chat rebuild below.
+      new_docs = [
+        doc for doc in _prose_docs("", messages) if doc[0] >= state[0]
+      ]
+      _write_docs(db, chat_id, new_docs)
+    else:
+      _delete_chat_docs(db, chat_id)
+      _write_docs(db, chat_id, _prose_docs(title, messages))
+
+    db.execute(
+      sql(
+        "INSERT INTO chat_search_state"
+        " (chat_id, indexed_count, indexed_title, indexed_updated_at)"
+        " VALUES (:cid, :count, :title, :updated)"
+        " ON CONFLICT(chat_id) DO UPDATE SET"
+        "  indexed_count = excluded.indexed_count,"
+        "  indexed_title = excluded.indexed_title,"
+        "  indexed_updated_at = excluded.indexed_updated_at"
+      ),
+      {
+        "cid": chat_id,
+        "count": len(messages),
+        "title": title,
+        "updated": updated_text,
+      },
+    )
+    # Release the hydrated transcript before the next stale chat.
+    db.expire(chat)
+
+  if orphans or stale:
+    db.commit()
+
+
+def _fts_query(raw: str) -> str:
+  """User text -> safe FTS5 query: quoted tokens, prefix on the last one."""
+  tokens = re.findall(r"[^\s\"'()*^]+", raw)
+  if not tokens:
+    return ""
+  quoted = [f'"{token}"' for token in tokens]
+  quoted[-1] = f"{quoted[-1]}*"
+  return " ".join(quoted)
+
+
+def search(db: Session, raw_query: str, limit: int = 20) -> list[dict]:
+  """Ranked chats matching the query, best doc per chat, with a snippet."""
+  match = _fts_query(raw_query)
+  if not match:
+    return []
+  reconcile(db)
+
+  rows = db.execute(
+    sql(
+      "SELECT d.chat_id, d.msg_idx, d.ts, d.role,"
+      "  snippet(chat_search_fts, 0, :mo, :mc, '…', 12) AS snip,"
+      "  bm25(chat_search_fts) AS rank,"
+      "  c.title, CAST(COALESCE(c.activity_at, c.updated_at) AS TEXT)"
+      " FROM chat_search_fts"
+      " JOIN chat_search_docs d ON d.id = chat_search_fts.rowid"
+      " JOIN chats c ON c.id = d.chat_id AND c.deleted_at IS NULL"
+      " WHERE chat_search_fts MATCH :q"
+      " ORDER BY rank LIMIT 200"
+    ),
+    {"q": match, "mo": _MARK_OPEN, "mc": _MARK_CLOSE},
+  ).fetchall()
+
+  # Best-ranked doc per chat wins; a title hit falls back to no snippet (the
+  # row already shows the title). bm25 is ascending-better in SQLite. The
+  # snippet's own prose doc supplies `ts`/`role` so the drawer can reveal that
+  # exact transcript row — a title-only hit has neither and simply opens the
+  # chat at its last position.
+  by_chat: dict[str, dict] = {}
+  for chat_id, msg_idx, ts, role, snip, rank, title, active_text in rows:
+    entry = by_chat.get(chat_id)
+    if entry is None:
+      entry = {
+        "id": chat_id,
+        "title": title,
+        "snippet": None,
+        "ts": None,
+        "role": None,
+        "rank": rank,
+        "last_active": active_text,
+        "match_count": 0,
+      }
+      by_chat[chat_id] = entry
+    entry["match_count"] += 1
+    if msg_idx >= 0 and entry["snippet"] is None:
+      entry["snippet"] = snip
+      entry["ts"] = ts
+      entry["role"] = role
+
+  results = sorted(
+    by_chat.values(), key=lambda e: (e["rank"], e["last_active"] or "")
+  )[:limit]
+  for entry in results:
+    entry.pop("rank", None)
+  return results

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import Text, case, cast, func
 from sqlalchemy.orm import Session
 
-from app import activity, auth, models, providers, questions
+from app import activity, auth, chat_search, models, providers, questions
 from app.config import get_settings
 from app.chat import (
   _finish_run,
@@ -519,6 +519,26 @@ def list_chats(
     )
     for chat in chats
   ]
+
+
+@router.get("/search")
+def search_chats(
+  q: str = Query("", max_length=256),
+  _: models.Owner = Depends(get_current_owner),
+  db: Session = Depends(get_db),
+):
+  """Full-text search over chat titles and conversation prose.
+
+  Registered before ``/{chat_id}`` so the literal path wins. The index is
+  derived data reconciled inside the request (see ``chat_search``); the first
+  query on an existing instance pays a one-time backfill, after which only
+  changed chats are touched. Snippets mark matches with private-use
+  sentinels U+E000/U+E001; the drawer converts them to highlight marks.
+  """
+  query = q.strip()
+  if not query:
+    return []
+  return chat_search.search(db, query)
 
 
 @router.get("/session-links")

--- a/backend/tests/test_chat_search.py
+++ b/backend/tests/test_chat_search.py
@@ -1,0 +1,142 @@
+"""Drawer chat search: FTS index reconciliation + /api/chats/search."""
+
+import uuid
+
+from app import chat_search, models
+from app.chat_search import sql
+
+
+def _make_chat(db, title, texts, role="user"):
+  # Distinct, increasing ts per message: ts is the drawer's reveal anchor and
+  # is unique within a chat in production data.
+  c = models.Chat(
+    id=str(uuid.uuid4()),
+    title=title,
+    messages=[
+      {"role": role, "content": t, "ts": 1000 + i} for i, t in enumerate(texts)
+    ],
+  )
+  db.add(c)
+  db.commit()
+  return c
+
+
+def _doc_count(db, chat_id):
+  return db.execute(
+    sql("SELECT count(*) FROM chat_search_docs WHERE chat_id = :c"),
+    {"c": chat_id},
+  ).fetchone()[0]
+
+
+def test_search_finds_message_text_with_snippet(db):
+  c = _make_chat(db, "Trip notes", ["let us plan the zanzibar itinerary"])
+  results = chat_search.search(db, "zanzibar")
+  hit = next(r for r in results if r["id"] == c.id)
+  assert hit["title"] == "Trip notes"
+  assert "zanzibar" in hit["snippet"]
+
+
+def test_result_carries_reveal_anchor_of_matching_message(db):
+  # The snippet's message, not the first one, supplies ts/role for the jump.
+  c = _make_chat(
+    db, "Notes", ["intro line", "the wombat migration route", "outro line"]
+  )
+  hit = next(r for r in chat_search.search(db, "wombat") if r["id"] == c.id)
+  assert hit["role"] == "user"
+  assert hit["ts"] == 1001
+
+
+def test_title_only_hit_has_no_reveal_anchor(db):
+  c = _make_chat(db, "Marimba tuning", ["unrelated body"])
+  hit = next(r for r in chat_search.search(db, "marimba") if r["id"] == c.id)
+  assert hit["ts"] is None and hit["role"] is None
+
+
+def test_prefix_match_on_last_token(db):
+  c = _make_chat(db, "Money", ["monthly budgeting spreadsheet"])
+  assert any(r["id"] == c.id for r in chat_search.search(db, "budg"))
+
+
+def test_title_match_has_no_snippet(db):
+  c = _make_chat(db, "Xylophone maintenance", ["unrelated body text"])
+  hit = next(
+    r for r in chat_search.search(db, "xylophone") if r["id"] == c.id
+  )
+  assert hit["snippet"] is None
+
+
+def test_new_messages_append_incrementally(db):
+  c = _make_chat(db, "Log", ["first entry"])
+  chat_search.search(db, "first")  # index it
+  before = _doc_count(db, c.id)
+  c.messages = c.messages + [
+    {"role": "assistant", "content": "quokka sighting confirmed", "ts": 2}
+  ]
+  db.commit()
+  assert any(r["id"] == c.id for r in chat_search.search(db, "quokka"))
+  assert _doc_count(db, c.id) == before + 1
+
+
+def test_rename_reindexes_title(db):
+  c = _make_chat(db, "Old name", ["body"])
+  chat_search.search(db, "body")
+  c.title = "Brand new marimba title"
+  db.commit()
+  assert any(r["id"] == c.id for r in chat_search.search(db, "marimba"))
+  assert not any(r["id"] == c.id for r in chat_search.search(db, "old name"))
+
+
+def test_deleted_chat_leaves_index_and_restore_returns(db):
+  from app.timeutil import now_naive_utc
+
+  c = _make_chat(db, "Doomed", ["ephemeral pangolin facts"])
+  chat_search.search(db, "pangolin")
+  c.deleted_at = now_naive_utc()
+  db.commit()
+  assert chat_search.search(db, "pangolin") == []
+  assert _doc_count(db, c.id) == 0
+  c.deleted_at = None
+  db.commit()
+  assert any(r["id"] == c.id for r in chat_search.search(db, "pangolin"))
+
+
+def test_shrunk_history_triggers_full_rebuild(db):
+  c = _make_chat(db, "Trimmed", ["alpha wombat", "beta wombat"])
+  chat_search.search(db, "wombat")
+  c.messages = [{"role": "user", "content": "gamma capybara", "ts": 3}]
+  db.commit()
+  assert chat_search.search(db, "wombat") == [] or not any(
+    r["id"] == c.id for r in chat_search.search(db, "wombat")
+  )
+  assert any(r["id"] == c.id for r in chat_search.search(db, "capybara"))
+
+
+def test_tool_noise_roles_are_not_indexed(db):
+  c = models.Chat(
+    id=str(uuid.uuid4()),
+    title="Noise",
+    messages=[
+      {"role": "tool", "content": "secret ocelot stacktrace"},
+      {"role": "user", "content": {"not": "a string"}},
+    ],
+  )
+  db.add(c)
+  db.commit()
+  assert not any(
+    r["id"] == c.id for r in chat_search.search(db, "ocelot")
+  )
+
+
+def test_operator_input_is_neutralized(db):
+  _make_chat(db, "Safe", ["plain text"])
+  for hostile in ['" OR 1=1 --', "NEAR(", "a*b^c", "   ", ""]:
+    chat_search.search(db, hostile)  # must not raise
+
+
+def test_search_endpoint_requires_owner_and_returns_hits(client, auth, db):
+  c = _make_chat(db, "Endpoint", ["searchable axolotl payload"])
+  assert client.get("/api/chats/search?q=axolotl").status_code == 401
+  r = client.get("/api/chats/search?q=axolotl", headers=auth)
+  assert r.status_code == 200
+  assert any(hit["id"] == c.id for hit in r.json())
+  assert client.get("/api/chats/search?q=", headers=auth).json() == []

--- a/frontend/scripts/check-built-globals.mjs
+++ b/frontend/scripts/check-built-globals.mjs
@@ -47,7 +47,12 @@ const ALLOWED_GLOBALS = new Set([
   'createImageBitmap', 'crypto', 'CSS', 'CustomEvent', 'document',
   'DOMMatrixReadOnly', 'DOMParser',
   'Element', 'Event', 'EventSource', 'fetch', 'File', 'FileReader', 'FormData',
-  'getComputedStyle', 'Headers', 'history', 'HTMLElement', 'HTMLInputElement',
+  'getComputedStyle', 'Headers',
+  // CSS Custom Highlight API: chat search paints matched words as non-destructive
+  // Ranges (searchTermHighlight.js). Guarded by `typeof Highlight` for browsers
+  // without it.
+  'Highlight',
+  'history', 'HTMLElement', 'HTMLInputElement',
   'indexedDB', 'IntersectionObserver', 'localStorage', 'location', 'matchMedia',
   'MessageChannel', 'MessageEvent', 'MutationObserver', 'navigation',
   'navigator', 'Node', 'NodeFilter', 'Notification', 'performance',

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -396,6 +396,13 @@ export const api = {
   },
   chats: {
     list: (options = {}) => apiFetch('/chats', options),
+    // Drawer full-text search. Time-boxed: a stuck request must not leave the
+    // drawer's results view spinning forever, and the caller aborts on every
+    // keystroke anyway.
+    search: (q, { signal } = {}) => apiFetch(
+      `/chats/search?q=${encodeURIComponent(q)}`,
+      { signal, timeoutMs: 10_000 },
+    ),
     create: (payload) => listAffectingMutation('chats', '/chats', {
       method: 'POST',
       body: JSON.stringify(payload),

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -359,6 +359,43 @@
 
 .chat__msg--user { align-items: flex-end; }
 .chat__msg--marker { align-items: stretch; }
+
+/* Drawer-search reveal: a soft, brief wash on the matched message so the eye
+   lands on it after the jump, then fade out. The precise cue is the word-level
+   highlight below; this is just gentle "here" context. A negative-margin padded
+   box keeps the wash around the bubble without shifting layout. Transient —
+   ChatView clears the class after the animation. */
+.chat__msg--search-hit {
+  border-radius: 14px;
+  margin-left: -8px;
+  margin-right: -8px;
+  padding-left: 8px;
+  padding-right: 8px;
+  animation: chat-search-hit 0.9s ease-out forwards;
+}
+
+@keyframes chat-search-hit {
+  0% { background: color-mix(in srgb, var(--accent) 12%, transparent); }
+  100% { background: transparent; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chat__msg--search-hit {
+    /* No pulse; the persistent word highlight below is the lasting cue. */
+    animation: none;
+    background: transparent;
+  }
+}
+
+/* The matched word(s) inside the revealed message. Painted by ChatView through
+   the CSS Custom Highlight API (non-destructive Ranges) and kept until the
+   reader leaves the chat. Only a few properties are stylable on ::highlight, so
+   a strong accent background + a contrasting text color carry the emphasis; the
+   accent-tinted text color keeps light words legible on the solid wash. */
+::highlight(chat-search-term) {
+  background-color: color-mix(in srgb, var(--accent) 62%, transparent);
+  color: var(--accent-fg, #fff);
+}
 .chat__msg--assistant {
   --activity-block-gap: 8px;
   --activity-row-gap: 4px;

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -13,6 +13,8 @@ import { apiFetch, getAuthHeaders, jsonOrThrow, BASE } from '../../api/client.js
 import { chatMessagesQueryKey } from '../../hooks/queries.js'
 import useStreamConnection from './useStreamConnection.js'
 import useScrollMode from './useScrollMode.js'
+import { peekSearchReveal, takeSearchReveal, subscribeSearchReveal } from './searchReveal.js'
+import { paintSearchTermHighlight, clearSearchTermHighlight } from './searchTermHighlight.js'
 import useVoiceInput from './useVoiceInput.js'
 import useOnlineStatus from '../../hooks/useOnlineStatus.js'
 import { getOnlineSnapshot } from '../../lib/connectivityStore.js'
@@ -210,6 +212,11 @@ function tailResumableBlock(messages) {
 // composer) don't hand ChatView a fresh array each render and re-fire its
 // list-keyed effects.
 const NO_BUILT_APPS = []
+
+// Where a search-reveal lands the matched word: pixels from the viewport top.
+// Mirrors useScrollMode's REVEAL_OFFSET (the row-top fallback when no word
+// range is measurable) so both paths feel the same.
+const SEARCH_REVEAL_MARGIN = 96
 
 export default function ChatView({
   chatId,
@@ -751,6 +758,7 @@ export default function ChatView({
     freezeQuestionSubmission,
     freezeQueuedSubmission,
     revealConversationTail,
+    revealAnchor,
     reapplyActiveMode,
     settleSendIntent,
     settleStreamingPin,
@@ -793,6 +801,124 @@ export default function ChatView({
   useLayoutEffect(() => {
     if (hidden) freezeChatExit()
   }, [hidden, freezeChatExit])
+
+  // Drawer search "jump to the match". Two lifetimes:
+  //   • the word-level highlight PERSISTS until the reader leaves the chat, and
+  //   • a brief row "landing" pulse fires once on arrival.
+  // `reveal` holds the active target for THIS chat; keeping it in state (not a
+  // one-shot consume) lets the apply effect retry as the transcript renders, so
+  // a fresh open no longer misses the highlight when the message paints a beat
+  // after the reveal fires (the "only a second click highlights it" bug).
+  const [reveal, setReveal] = useState(null) // { chatId, key, terms, scrolled }
+  const [searchHitKey, setSearchHitKey] = useState(null)
+  const [revealTick, setRevealTick] = useState(0)
+  const revealRetryRef = useRef(0)
+  const revealVisRetryRef = useRef(0)
+  const revealPulseTimerRef = useRef(0)
+  // Ownership token of the highlight THIS instance last painted, so its teardown
+  // only clears the global highlight when it still owns it — several ChatViews
+  // are mounted at once (the outgoing chat lingers as an inert cover during a
+  // tab switch), and an unscoped clear wiped the incoming chat's highlight.
+  const paintedTokenRef = useRef(0)
+  // Bumps when a reveal is requested for THIS chat while it is already mounted
+  // (re-tapping a result for the open chat), so the pickup effect re-runs.
+  const [searchRevealNonce, setSearchRevealNonce] = useState(0)
+  useEffect(() => subscribeSearchReveal((targetId) => {
+    if (String(targetId) === String(chatId)) setSearchRevealNonce(n => n + 1)
+  }), [chatId])
+
+  // Pick up a pending intent (fresh open: `revealed` flips true; re-tap while
+  // open: the nonce bumps) and promote it to the active reveal for this chat.
+  // PEEK (don't consume) the pending intent and promote it to this instance's
+  // active reveal. Consumption happens later, only from the VISIBLE instance's
+  // apply — several ChatViews can be mounted for the same chat (background tabs,
+  // Standard + Builder worlds), and a consume here would let a hidden copy
+  // swallow the intent and paint off-screen, leaving the visible copy blank.
+  useLayoutEffect(() => {
+    if (!revealed) return
+    const pending = peekSearchReveal(chatId)
+    if (!pending) return
+    setReveal(prev => {
+      if (prev && prev.chatId === chatId && prev.key === pending.key) return prev
+      revealRetryRef.current = 0
+      revealVisRetryRef.current = 0
+      return { chatId, key: pending.key, terms: pending.terms, scrolled: false }
+    })
+  }, [revealed, searchRevealNonce, chatId])
+
+  // Apply + keep the reveal: paint the matched words (idempotent, re-asserted as
+  // the transcript settles) and scroll to the match once. Retries across frames
+  // until the row and its rendered text exist, so async markdown can't leave a
+  // fresh open unhighlighted. The highlight then persists — cleared only when
+  // the reader leaves the chat (the cleanup below).
+  useLayoutEffect(() => {
+    if (!reveal || reveal.chatId !== chatId) return undefined
+    const scrollEl = scrollRef.current
+    // Apply ONLY from the visible instance. A hidden copy (background tab, other
+    // world) has `offsetParent === null`; it must not consume the intent or
+    // paint into its off-screen DOM. Re-runs when this copy becomes visible
+    // (focus/messages change) — with a bounded frame retry as a safety net.
+    if (!scrollEl || scrollEl.offsetParent === null) {
+      if (revealVisRetryRef.current < 45) {
+        revealVisRetryRef.current += 1
+        const raf = requestAnimationFrame(() => setRevealTick(t => t + 1))
+        return () => cancelAnimationFrame(raf)
+      }
+      return undefined
+    }
+    const esc = (typeof CSS !== 'undefined' && CSS.escape)
+      ? CSS.escape(reveal.key) : reveal.key
+    const row = scrollEl.querySelector(`[data-key="${esc}"]`)
+    if (!row) {
+      // The match can be OLDER than the initially-loaded window (open fetches
+      // only the latest 20 messages). Pull the rest of the history in once;
+      // this effect re-runs when `messages` grows and then anchors + paints.
+      if (offsetRef.current > 0) loadOlderThroughReveal()
+      return undefined
+    }
+    // The visible instance owns this reveal now — consume the shared intent so
+    // no other mounted copy (or a remount) grabs it. `reveal` state below keeps
+    // driving the paint/scroll; a later re-click re-arms a fresh intent.
+    takeSearchReveal(chatId)
+    const { firstRange, token } = paintSearchTermHighlight(row, reveal.terms)
+    if (token) paintedTokenRef.current = token
+    const retriesLeft = revealRetryRef.current < 12
+    // Scroll once. Prefer anchoring to the matched WORD (a deep match in a long
+    // message would otherwise sit below the fold); wait for it while retries
+    // remain, then fall back to the row top so the jump never stalls.
+    if (!reveal.scrolled && (firstRange || !retriesLeft)) {
+      const anchorOffset = firstRange
+        ? SEARCH_REVEAL_MARGIN
+          - (firstRange.getBoundingClientRect().top - row.getBoundingClientRect().top)
+        : undefined
+      if (revealAnchor(reveal.key, anchorOffset)) {
+        setReveal(r => (r && r.chatId === chatId ? { ...r, scrolled: true } : r))
+        setSearchHitKey(reveal.key)
+        clearTimeout(revealPulseTimerRef.current)
+        revealPulseTimerRef.current = setTimeout(() => setSearchHitKey(null), 900)
+      }
+    }
+    // Words not in the DOM yet (lazy markdown) — retry next frame, bounded, so a
+    // fresh open still highlights instead of needing a second click.
+    if (!firstRange && retriesLeft) {
+      revealRetryRef.current += 1
+      const raf = requestAnimationFrame(() => setRevealTick(t => t + 1))
+      return () => cancelAnimationFrame(raf)
+    }
+    return undefined
+  }, [reveal, messages, revealed, revealTick, chatId, revealAnchor, scrollRef])
+
+  // Leaving this chat (or unmounting) drops the persistent highlight and any
+  // active reveal, so a later return without a fresh search doesn't re-light it.
+  // Scope the clear to the token THIS instance painted: a co-mounted outgoing
+  // cover tearing down must not wipe the incoming chat's highlight.
+  useEffect(() => () => {
+    clearTimeout(revealPulseTimerRef.current)
+    clearSearchTermHighlight(paintedTokenRef.current)
+    paintedTokenRef.current = 0
+    setSearchHitKey(null)
+    setReveal(null)
+  }, [chatId])
 
   function rememberSendIntent(cid, intent) {
     if (!cid || !intent) return
@@ -1880,6 +2006,36 @@ export default function ChatView({
         })
       })
       .catch(() => { loadingOlder.current = false })
+  }
+
+  // Search reveal targeting a message older than the loaded window: pull ALL
+  // remaining older messages in ONE request (limit=before=offset → start 0), so
+  // the matched row exists and the reveal effect can anchor + highlight it. A
+  // deliberate jump, so loading the rest of the history is acceptable; unlike
+  // reader pagination it doesn't preserve position — the reveal scrolls next.
+  function loadOlderThroughReveal() {
+    const remaining = offsetRef.current
+    if (!scrollRef.current || loadingOlder.current || loading || remaining <= 0) return
+    loadingOlder.current = true
+    apiFetch(
+      `/chats/${chatId}?limit=${remaining}&before=${remaining}&compact=1`,
+      { timeoutMs: CHAT_FETCH_TIMEOUT_MS },
+    )
+      .then(r => jsonOrThrow(r, 'Earlier messages failed to load'))
+      .then(data => {
+        if (chatIdStaleRef.current) return
+        const older = data.messages || []
+        for (const msg of older) {
+          if (msg.blocks) {
+            for (const blk of msg.blocks) {
+              if (blk.type === 'tool' && blk.status === 'running') blk.status = 'done'
+            }
+          }
+        }
+        commitMessages(prev => [...older, ...prev], data.offset || 0)
+      })
+      .catch(() => {})
+      .finally(() => { loadingOlder.current = false })
   }
 
   function handleScroll() {
@@ -3814,7 +3970,9 @@ export default function ChatView({
             return (
             <li
               key={userCid || msg.id || msg.ts || `${msg.role}-${i}`}
-              className={`chat__msg chat__msg--${continuationMarker ? 'marker' : msg.role}`}
+              className={`chat__msg chat__msg--${continuationMarker ? 'marker' : msg.role}${
+                searchHitKey && dataKey === searchHitKey ? ' chat__msg--search-hit' : ''
+              }`}
               ref={i === lastUserIdx ? setLastUserMsgRef : null}
               data-key={dataKey}
               data-cid={userCid || undefined}

--- a/frontend/src/components/ChatView/__tests__/searchReveal.test.js
+++ b/frontend/src/components/ChatView/__tests__/searchReveal.test.js
@@ -1,0 +1,70 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  requestSearchReveal,
+  peekSearchReveal,
+  takeSearchReveal,
+  subscribeSearchReveal,
+} from '../searchReveal.js'
+import { applyMode } from '../useScrollMode.js'
+
+test('request → peek is non-destructive, take consumes once', () => {
+  requestSearchReveal('chat-A', 'user-1700000000000', ['budget'])
+  assert.deepEqual(peekSearchReveal('chat-A'), { key: 'user-1700000000000', terms: ['budget'] })
+  // Peek again: still there.
+  assert.deepEqual(peekSearchReveal('chat-A'), { key: 'user-1700000000000', terms: ['budget'] })
+  assert.deepEqual(takeSearchReveal('chat-A'), { key: 'user-1700000000000', terms: ['budget'] })
+  // Consumed.
+  assert.equal(peekSearchReveal('chat-A'), null)
+  assert.equal(takeSearchReveal('chat-A'), null)
+})
+
+test('intents are isolated per chat id, terms default to empty', () => {
+  requestSearchReveal('chat-B', 'assistant-22')
+  requestSearchReveal('chat-C', 'user-33')
+  assert.deepEqual(takeSearchReveal('chat-C'), { key: 'user-33', terms: [] })
+  // B untouched by C's consume.
+  assert.deepEqual(takeSearchReveal('chat-B'), { key: 'assistant-22', terms: [] })
+})
+
+test('a null/empty key is ignored (title-only hit)', () => {
+  requestSearchReveal('chat-D', null)
+  requestSearchReveal('chat-D', '')
+  assert.equal(peekSearchReveal('chat-D'), null)
+})
+
+test('subscribers fire with the target id for the already-open case', () => {
+  const seen = []
+  const unsub = subscribeSearchReveal((id) => seen.push(id))
+  requestSearchReveal('chat-E', 'user-5')
+  requestSearchReveal('chat-F', 'user-6')
+  unsub()
+  requestSearchReveal('chat-G', 'user-7') // after unsub: not observed
+  assert.deepEqual(seen, ['chat-E', 'chat-F'])
+  takeSearchReveal('chat-E'); takeSearchReveal('chat-F'); takeSearchReveal('chat-G')
+})
+
+test('a listener that throws does not drop the intent', () => {
+  const unsub = subscribeSearchReveal(() => { throw new Error('boom') })
+  requestSearchReveal('chat-H', 'user-8')
+  assert.deepEqual(peekSearchReveal('chat-H'), { key: 'user-8', terms: [] })
+  unsub()
+  takeSearchReveal('chat-H')
+})
+
+test('reveal ANCHOR_AT lands the matched row below the viewport top', () => {
+  // The mechanism revealAnchor drives: applyMode positions the data-key row so
+  // it sits `offset` px below the top (a little context above the match).
+  const row = { offsetTop: 1200 }
+  const scrollEl = {
+    scrollTop: 0,
+    scrollHeight: 5000,
+    clientHeight: 800,
+    querySelector(sel) {
+      return sel.includes('data-key') ? row : null
+    },
+  }
+  applyMode(scrollEl, { kind: 'ANCHOR_AT', key: 'user-42', offset: 96 })
+  assert.equal(scrollEl.scrollTop, 1200 - 96)
+})

--- a/frontend/src/components/ChatView/__tests__/searchTermHighlight.test.js
+++ b/frontend/src/components/ChatView/__tests__/searchTermHighlight.test.js
@@ -1,0 +1,23 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { termsFromSnippet } from '../searchTermHighlight.js'
+
+const O = ''
+const C = ''
+
+test('extracts each marked surface form from a snippet', () => {
+  const snip = `monthly ${O}budgeting${C} and ${O}budget${C} planning`
+  assert.deepEqual(termsFromSnippet(snip), ['budgeting', 'budget'])
+})
+
+test('dedupes repeats and trims whitespace', () => {
+  const snip = `${O}Atlas${C} vs ${O}Atlas${C} again`
+  assert.deepEqual(termsFromSnippet(snip), ['Atlas'])
+})
+
+test('returns empty for a title-only (unmarked) or missing snippet', () => {
+  assert.deepEqual(termsFromSnippet('no marks here'), [])
+  assert.deepEqual(termsFromSnippet(null), [])
+  assert.deepEqual(termsFromSnippet(''), [])
+})

--- a/frontend/src/components/ChatView/searchReveal.js
+++ b/frontend/src/components/ChatView/searchReveal.js
@@ -1,0 +1,49 @@
+/**
+ * One-shot "reveal this message" intents from drawer chat search.
+ *
+ * The drawer, on a search-result tap, records which transcript row the opened
+ * chat should jump to (keyed by chat id), then navigates normally. The mounted
+ * ChatView for that chat consumes the intent once its transcript is on screen:
+ * it scrolls the matched row into view (through the scroll controller, so the
+ * machine owns the position) and flashes a brief highlight.
+ *
+ * A plain module singleton — this is transient navigation glue, not persisted
+ * state. Nothing survives a reload (a reload lands on the reader's last saved
+ * scroll position, which is the sensible default). `key` is the row's
+ * `data-key` (`<role>-<ts>`); ts is unique within a chat.
+ */
+
+const _pending = new Map() // chatId -> { key, terms }
+const _listeners = new Set() // (chatId) => void
+
+/** Record a jump target and notify any already-mounted ChatView for that chat
+ *  (the re-selected-while-open case). Pass a null/empty key to no-op. `terms`
+ *  are the matched surface forms to highlight within the message (optional). */
+export function requestSearchReveal(chatId, key, terms = []) {
+  if (chatId == null || !key) return
+  const id = String(chatId)
+  _pending.set(id, { key, terms: Array.isArray(terms) ? terms : [] })
+  for (const fn of _listeners) {
+    try { fn(id) } catch { /* a listener error must not drop the intent */ }
+  }
+}
+
+/** Read the pending target for a chat without consuming it. */
+export function peekSearchReveal(chatId) {
+  return _pending.get(String(chatId)) || null
+}
+
+/** Read and clear the pending target for a chat. */
+export function takeSearchReveal(chatId) {
+  const id = String(chatId)
+  const value = _pending.get(id) || null
+  if (value) _pending.delete(id)
+  return value
+}
+
+/** Subscribe to reveal requests (fires with the target chat id). Returns an
+ *  unsubscribe function. */
+export function subscribeSearchReveal(listener) {
+  _listeners.add(listener)
+  return () => _listeners.delete(listener)
+}

--- a/frontend/src/components/ChatView/searchTermHighlight.js
+++ b/frontend/src/components/ChatView/searchTermHighlight.js
@@ -1,0 +1,116 @@
+/**
+ * Word-level highlighting for a revealed search match.
+ *
+ * The matched terms come straight from the result snippet, where the backend
+ * wrapped each matched surface form in the private-use sentinels U+E000/U+E001
+ * (already produced by SQLite FTS `snippet()`). Using those exact surface forms
+ * means the frontend re-does no tokenizing, prefixing, or diacritic folding —
+ * whatever FTS matched is what we light up.
+ *
+ * Painting uses the CSS Custom Highlight API: it highlights DOM Ranges without
+ * mutating the tree, so rendered markdown, KaTeX, code blocks, and links are
+ * left untouched. Where the API is unavailable it degrades to nothing (the
+ * message-level flash still fires), so it is purely additive.
+ */
+
+const HIGHLIGHT_NAME = 'chat-search-term'
+
+// U+E000 … U+E001 delimit each matched surface form in a snippet.
+const _SNIPPET_TERM_RE = /([\s\S]*?)/g
+
+/** Extract the distinct matched surface forms from a result snippet. */
+export function termsFromSnippet(snippet) {
+  if (!snippet || typeof snippet !== 'string') return []
+  const terms = new Set()
+  let match
+  _SNIPPET_TERM_RE.lastIndex = 0
+  while ((match = _SNIPPET_TERM_RE.exec(snippet)) !== null) {
+    const term = match[1].trim()
+    if (term) terms.add(term)
+  }
+  return [...terms]
+}
+
+function _supported() {
+  return (
+    typeof CSS !== 'undefined'
+    && !!CSS.highlights
+    && typeof Highlight !== 'undefined'
+    && typeof document !== 'undefined'
+  )
+}
+
+// The highlight is a single document-global named highlight, but several
+// ChatView instances coexist (the Shell keeps an outgoing chat mounted as an
+// inert cover during a tab switch). Ownership tracking stops a departing
+// instance's teardown from wiping the highlight a newer instance just painted:
+// each successful paint takes a fresh token, and a scoped clear only deletes
+// when it still owns it. That was the "1st chat highlights, 2nd/3rd don't"
+// clobber.
+let _ownerToken = 0
+let _nextToken = 1
+
+/**
+ * Clear the search-term highlight.
+ * - `token` omitted → force clear (any owner).
+ * - `token` given → clear only if it still owns the current highlight.
+ */
+export function clearSearchTermHighlight(token) {
+  if (token !== undefined && token !== _ownerToken) return
+  _ownerToken = 0
+  if (_supported()) {
+    try { CSS.highlights.delete(HIGHLIGHT_NAME) } catch { /* nothing to clear */ }
+  }
+}
+
+/**
+ * Highlight every occurrence of `terms` inside the message row `root`,
+ * case-insensitively, scoped to its rendered text (`.chat__text`).
+ *
+ * Returns `{ firstRange, token }` — the topmost matched Range (or null when
+ * nothing matched / unsupported) so the caller can scroll that exact word into
+ * view, and an ownership `token` (0 when nothing was painted) the caller passes
+ * to `clearSearchTermHighlight` so only the owning instance can clear it.
+ */
+export function paintSearchTermHighlight(root, terms) {
+  if (!_supported() || !root || !terms?.length) return { firstRange: null, token: 0 }
+  const needles = terms
+    .map(term => (typeof term === 'string' ? term.toLowerCase() : ''))
+    .filter(Boolean)
+  if (!needles.length) return { firstRange: null, token: 0 }
+
+  const textEls = root.querySelectorAll('.chat__text')
+  const scopes = textEls.length ? textEls : [root]
+  const ranges = []
+  for (const scope of scopes) {
+    const walker = document.createTreeWalker(scope, NodeFilter.SHOW_TEXT)
+    let node
+    while ((node = walker.nextNode())) {
+      const hay = node.nodeValue.toLowerCase()
+      for (const needle of needles) {
+        let from = 0
+        for (;;) {
+          const idx = hay.indexOf(needle, from)
+          if (idx === -1) break
+          const range = document.createRange()
+          range.setStart(node, idx)
+          range.setEnd(node, idx + needle.length)
+          ranges.push(range)
+          from = idx + needle.length
+        }
+      }
+    }
+  }
+  if (!ranges.length) return { firstRange: null, token: 0 }
+
+  try {
+    CSS.highlights.set(HIGHLIGHT_NAME, new Highlight(...ranges))
+  } catch {
+    return { firstRange: null, token: 0 }
+  }
+  _ownerToken = _nextToken++
+  // The tree walker visits text nodes in document order and matches within
+  // each node left-to-right, so ranges[0] is the topmost occurrence — the one
+  // to bring into view.
+  return { firstRange: ranges[0], token: _ownerToken }
+}

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -560,6 +560,11 @@ function _latestUserOwnsSpacer(scrollEl, listEl, lastUserMsgEl, mode, viewH) {
  */
 const PIN_OFFSET = 4
 const PIN_BOTTOM_ROOM = 0
+// Where a search-reveal jump lands the matched row: a comfortable margin below
+// the viewport top so a little prior context shows above it, rather than the
+// row flush to the very top. Kept well under any real viewport height so the
+// seeded ANCHOR_AT satisfies the content-intersection invariant.
+const REVEAL_OFFSET = 96
 export function _computeSpacerH(
   scrollEl,
   listEl,
@@ -1016,6 +1021,7 @@ export function modeForQueuedSubmission(scrollEl, currentMode) {
  *   freezeQuestionSubmission: () => void,
  *   freezeQueuedSubmission: () => void,
  *   revealConversationTail: () => void,
+ *   revealAnchor: (key: string) => boolean,
  *   settleSendIntent: (event?: object) => void,
  *   settleStreamingPin: () => void,
  *   composerResized: () => void,
@@ -1377,6 +1383,37 @@ export default function useScrollMode({
     lastAppliedModeRef.current = nextMode
     nearScrollBottomRef.current = isNearScrollBottom(scrollEl)
     persistMode()
+  }, [persistMode, scrollRef, transitionMode, writeMode])
+
+  // Jump to a specific transcript row (drawer search result). Like the
+  // attention nudge, this is an explicit reader location routed through the
+  // controller so modeRef, persistence, and later layout passes all agree on
+  // the anchor instead of a raw scrollIntoView the machine would overwrite.
+  // `offset` is the pixels from the viewport top to the row top after landing;
+  // the caller passes a value computed from the matched WORD's position so a
+  // deep match in a long message still lands the word (not just the row top) in
+  // view. Returns true when the row is in the loaded window and we anchored to
+  // it; false when it isn't present (an out-of-window match — caller no-ops).
+  const revealAnchor = useCallback((key, offset = REVEAL_OFFSET) => {
+    const scrollEl = scrollRef.current
+    if (!scrollEl || !key) return false
+    const esc = (typeof CSS !== 'undefined' && CSS.escape) ? CSS.escape(key) : key
+    const row = scrollEl.querySelector(`[data-key="${esc}"]`)
+    if (!row) return false
+    discardPendingReaderSettleRef.current?.()
+    gestureWindowUntilRef.current = 0
+    readerLocationExplicitRef.current = true
+    const nextMode = {
+      kind: 'ANCHOR_AT',
+      key,
+      offset: Number.isFinite(offset) ? offset : REVEAL_OFFSET,
+    }
+    transitionMode(nextMode, 'reader:search-reveal')
+    writeMode(scrollEl, nextMode, 'reader:search-reveal')
+    lastAppliedModeRef.current = nextMode
+    nearScrollBottomRef.current = isNearScrollBottom(scrollEl)
+    persistMode()
+    return true
   }, [persistMode, scrollRef, transitionMode, writeMode])
 
   useLayoutEffect(() => () => {
@@ -2449,6 +2486,7 @@ export default function useScrollMode({
     freezeQuestionSubmission,
     freezeQueuedSubmission,
     revealConversationTail,
+    revealAnchor,
     reapplyActiveMode,
     settleSendIntent,
     settleStreamingPin,

--- a/frontend/src/components/Drawer/Drawer.css
+++ b/frontend/src/components/Drawer/Drawer.css
@@ -186,6 +186,122 @@
   background: var(--surface);
 }
 
+/* ── Search ────────────────────────────────────────── */
+
+/* Same row treatment as New chat: search is navigation, not a widget. The
+   closed state is a plain row; the open state swaps the label for an input
+   inside the identical footprint so activation never shifts the layout. */
+.drawer__item--search {
+  color: var(--muted);
+  margin: 0;
+  padding: 11px 12px;
+  min-height: 44px;
+}
+
+.drawer__item--search:hover {
+  color: var(--text);
+  background: var(--surface);
+}
+
+.drawer__item--search-open {
+  color: var(--text);
+  cursor: default;
+  background: var(--surface);
+}
+
+/* The row is the focus surface: one quiet ring around the whole control
+   instead of the global 2px input ring boxing the text field alone. Applies
+   on :focus-within so keyboard users keep an explicit indicator. */
+.drawer__item--search-open:focus-within {
+  box-shadow: inset 0 0 0 1px var(--accent);
+}
+
+.drawer__search-input {
+  flex: 1;
+  min-width: 0;
+  border: none;
+  background: none;
+  padding: 0;
+  color: var(--text);
+  /* 16px baseline everywhere a finger can focus it: below that, iOS zooms
+     the whole page on focus (see the global input rule in index.css). Real
+     pointers get the drawer's 14px row scale back. */
+  font-size: 16px;
+  font-family: var(--font);
+  outline: none;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .drawer__search-input {
+    font-size: 14px;
+  }
+}
+
+.drawer__search-input:focus-visible {
+  outline: none;
+}
+
+.drawer__search-input::placeholder {
+  color: var(--muted);
+}
+
+.drawer__search-clear {
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  margin: -4px -6px -4px 0;
+  border: none;
+  border-radius: 8px;
+  background: none;
+  color: var(--muted);
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.drawer__search-clear:hover {
+  color: var(--text);
+  background: var(--surface);
+}
+
+/* Result rows are two-line: title in the row voice, matched excerpt under it
+   in the muted voice with the match itself lifted back to full contrast. */
+.drawer__item--result {
+  align-items: flex-start;
+}
+
+.drawer__item--result .drawer__item-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.drawer__result-title {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.drawer__result-snippet {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+  font-size: 12px;
+  line-height: 16px;
+  color: var(--muted);
+  overflow-wrap: anywhere;
+}
+
+.drawer__result-snippet mark {
+  background: none;
+  color: var(--text);
+  font-weight: 600;
+}
+
 /* ── Navigation sections ──────────────────────────── */
 
 .drawer__group {

--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -7,6 +7,7 @@ import { appQueries, chatQueries } from '../../hooks/queries.js'
 import {
   AppsNavIcon,
   NewChatNavIcon,
+  SearchNavIcon,
   SettingsNavIcon,
 } from '../navigationIcons.js'
 import { appIconUrl } from '../appIcon.js'
@@ -19,6 +20,8 @@ import {
   shouldSuppressDrawerSwipeClick,
   clearDrawerGestureStyles,
 } from '../../lib/drawerLifecycle.js'
+import { requestSearchReveal } from '../ChatView/searchReveal.js'
+import { termsFromSnippet } from '../ChatView/searchTermHighlight.js'
 import { WORKSPACE_SPLITS_ENABLED } from '../Shell/paneModel.js'
 import { DRAWER_HOLD_MS, PRE_HOLD_MOVE_PX } from '../Shell/dragController.js'
 import InstallSheet from './InstallSheet.jsx'
@@ -49,6 +52,30 @@ import './Drawer.css'
 // A fresh `new Set()` per call would break identity-based memoization
 // downstream.
 const EMPTY_SET = new Set()
+
+// Search snippets arrive with private-use sentinels (U+E000 / U+E001) around
+// each matched word — characters that cannot occur in real transcript text —
+// so highlighting needs no HTML from the server. This is the one place that
+// converts them, into <mark> elements.
+function SearchSnippet({ text }) {
+  if (!text) return null
+  const nodes = []
+  text.split('\ue000').forEach((chunk, i) => {
+    if (i === 0) {
+      if (chunk) nodes.push(chunk)
+      return
+    }
+    const end = chunk.indexOf('\ue001')
+    if (end === -1) {
+      nodes.push(chunk)
+      return
+    }
+    nodes.push(<mark key={i}>{chunk.slice(0, end)}</mark>)
+    const rest = chunk.slice(end + 1)
+    if (rest) nodes.push(rest)
+  })
+  return <span className="drawer__result-snippet">{nodes}</span>
+}
 
 export default function Drawer({
   open,
@@ -208,6 +235,61 @@ export default function Drawer({
     observer.observe(sentinel)
     return () => observer.disconnect()
   }, [allRecents.length, open, visibleRecentCount])
+
+  // Drawer-wide chat search. While a query is active the navigation scroll
+  // (Apps / Pinned / Recents) is swapped for ranked results; clearing the
+  // field restores it untouched. Keystrokes are debounced and the previous
+  // request aborted, so at most one search is ever in flight.
+  const [searchActive, setSearchActive] = useState(false)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [searchResults, setSearchResults] = useState([])
+  const [searchStatus, setSearchStatus] = useState('idle') // idle|loading|success|error
+  const searchInputRef = useRef(null)
+  const searchTerm = searchQuery.trim()
+
+  useEffect(() => {
+    if (!searchActive || !searchTerm) {
+      setSearchResults([])
+      setSearchStatus('idle')
+      return undefined
+    }
+    const ctrl = new AbortController()
+    setSearchStatus('loading')
+    const timer = setTimeout(async () => {
+      try {
+        const res = await api.chats.search(searchTerm, { signal: ctrl.signal })
+        if (!res.ok) throw new Error(`search failed: ${res.status}`)
+        const data = await res.json()
+        if (ctrl.signal.aborted) return
+        setSearchResults(Array.isArray(data) ? data : [])
+        setSearchStatus('success')
+      } catch {
+        if (ctrl.signal.aborted) return
+        setSearchStatus('error')
+      }
+    }, 200)
+    return () => {
+      clearTimeout(timer)
+      ctrl.abort()
+    }
+  }, [searchActive, searchTerm])
+
+  const closeSearch = useCallback(() => {
+    setSearchActive(false)
+    setSearchQuery('')
+  }, [])
+
+  // The input mounts on activation; focus it there so the phone keyboard
+  // rises with the same tap that opened search.
+  useEffect(() => {
+    if (searchActive) searchInputRef.current?.focus()
+  }, [searchActive])
+
+  // A dismissed modal drawer (phone) should reopen in its normal state, not
+  // mid-search. The persistent desktop sidebar keeps search across blurs.
+  useEffect(() => {
+    if (!open && !persistent) closeSearch()
+  }, [open, persistent, closeSearch])
 
   // One row at a time can be in rename or open-menu mode. Tracking the
   // active id (rather than per-row state) lets a click on another row's
@@ -922,6 +1004,121 @@ export default function Drawer({
               <span className="drawer__item-text">New chat</span>
             </button>
 
+            {searchActive ? (
+              <div className="drawer__item drawer__item--search drawer__item--search-open">
+                <span className="drawer__item-icon" aria-hidden="true">
+                  <SearchNavIcon />
+                </span>
+                <input
+                  ref={searchInputRef}
+                  className="drawer__search-input"
+                  type="text"
+                  inputMode="search"
+                  enterKeyHint="search"
+                  autoComplete="off"
+                  autoCorrect="off"
+                  spellCheck="false"
+                  value={searchQuery}
+                  placeholder="Search chats"
+                  aria-label="Search chats"
+                  onChange={event => setSearchQuery(event.target.value)}
+                  onKeyDown={event => {
+                    if (event.key === 'Escape') {
+                      // Owns Escape while search is up: first press clears the
+                      // drawer back to normal instead of dismissing the drawer.
+                      event.stopPropagation()
+                      closeSearch()
+                    }
+                  }}
+                />
+                <button
+                  type="button"
+                  className="drawer__search-clear"
+                  aria-label="Close search"
+                  onClick={closeSearch}
+                >
+                  <svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true">
+                    <path
+                      d="M4 4l8 8M12 4l-8 8"
+                      stroke="currentColor"
+                      strokeWidth="1.6"
+                      strokeLinecap="round"
+                      fill="none"
+                    />
+                  </svg>
+                </button>
+              </div>
+            ) : (
+              <button
+                type="button"
+                className="drawer__item drawer__item--search"
+                onClick={() => {
+                  resetAppsSurfaceUi({ restoreFocus: false })
+                  setSearchActive(true)
+                }}
+              >
+                <span className="drawer__item-icon" aria-hidden="true">
+                  <SearchNavIcon />
+                </span>
+                <span className="drawer__item-text">Search chats</span>
+              </button>
+            )}
+
+            {searchActive && searchTerm ? (
+              <div className="drawer__scroll drawer__scroll--navigation">
+                <section
+                  className="drawer__section"
+                  aria-labelledby="drawer-search-label"
+                  aria-live="polite"
+                >
+                  <h2 id="drawer-search-label" className="drawer__label">
+                    <span>Results</span>
+                  </h2>
+                  {searchResults.length > 0 ? searchResults.map(result => (
+                    <div className="drawer__row" key={result.id}>
+                      <button
+                        type="button"
+                        className={`drawer__item drawer__item--result${
+                          !appsActive && activeView === 'chat' && activeChatId === result.id
+                            ? ' drawer__item--active'
+                            : ''
+                        }`}
+                        onClick={() => {
+                          // Record the exact transcript row to reveal (when the
+                          // hit is a message, not just a title) BEFORE opening
+                          // the chat, so ChatView jumps there on first paint.
+                          if (result.ts != null && result.role) {
+                            requestSearchReveal(
+                              result.id,
+                              `${result.role}-${result.ts}`,
+                              termsFromSnippet(result.snippet),
+                            )
+                          }
+                          rowActions.select('chat', result.id)
+                        }}
+                      >
+                        <span className="drawer__item-text">
+                          <span className="drawer__result-title">{result.title}</span>
+                          <SearchSnippet text={result.snippet} />
+                        </span>
+                      </button>
+                    </div>
+                  )) : searchStatus === 'loading' ? (
+                    <p className="drawer__list-status" role="status">Searching…</p>
+                  ) : searchStatus === 'error' ? (
+                    <p className="drawer__list-status" role="alert">
+                      Search is unavailable right now.
+                    </p>
+                  ) : searchStatus === 'success' ? (
+                    <EmptyMessage className="drawer__empty" fill="static">
+                      <EmptyMessage.Description>
+                        No chats mention “{searchTerm}”
+                      </EmptyMessage.Description>
+                    </EmptyMessage>
+                  ) : null}
+                </section>
+              </div>
+            ) : (
             <div className="drawer__scroll drawer__scroll--navigation" ref={navigationScrollRef}>
               <button
                 ref={appsButtonRef}
@@ -1044,6 +1241,7 @@ export default function Drawer({
                 )}
               </section>
             </div>
+            )}
           </div>{/* /.drawer__scroll-wrap */}
 
           <div className="drawer__group drawer__group--bottom">

--- a/frontend/src/components/navigationIcons.js
+++ b/frontend/src/components/navigationIcons.js
@@ -5,5 +5,6 @@ export {
   Chat as ChatNavIcon,
   ComposeEditSquare as NewChatNavIcon,
   Grid as AppsNavIcon,
+  Search as SearchNavIcon,
   SettingsSlider as SettingsNavIcon,
 } from '@openai/apps-sdk-ui/components/Icon'


### PR DESCRIPTION
## Full-text chat search in the navigation drawer

Adds a **Search chats** row to the navigation drawer that runs full-text search over chat titles and conversation prose, and jumps to the matching message when you open a result.

### What it does
- A drawer row (magnifier + "Search chats") directly under **New chat** opens into a search field in place. Typing replaces the Recents list with ranked results — chat title, a snippet with the match highlighted, and last-active time. Clearing or `Esc` restores the drawer.
- Opening a result scrolls the chat to the matched message and highlights the matched word(s) in place; the highlight persists until you leave the chat.

### Design
- **Index:** an SQLite FTS5 table over conversation prose only — owner and assistant message text plus chat titles. Tool output and thinking traces are excluded (they live in their own tables and are noise for "where did we talk about X").
- **Derived, self-healing data:** the index lives in three `chat_search_*` tables and is reconciled lazily inside the search request — new messages append incrementally, retitles/rewrites rebuild per chat, deleted chats drop out, and a missing or old-schema index rebuilds itself on first use. No turn-lifecycle hooks, and nothing is cached in process memory (FTS reads b-tree pages from disk), so memory stays flat as history grows.
- **Endpoint:** `GET /api/chats/search`, registered before `/{chat_id}` so the literal path wins. Snippets mark matches with private-use sentinels (U+E000/U+E001) that the drawer converts to highlight marks — no HTML from the server.

### Jump-to-match
- The reveal is routed through the chat scroll controller (a new `revealAnchor`) rather than a raw `scrollIntoView`, so it cooperates with the existing scroll state machine.
- Word highlighting uses the CSS Custom Highlight API (non-destructive Ranges), so rendered markdown, KaTeX, code, and links are untouched; it degrades to nothing where the API is unavailable.
- Matches older than the initially-loaded window pull the rest of the history in with one request before anchoring.
- In the multi-tab/builder layout only the visible chat copy claims and paints the highlight, so a background copy cannot swallow the reveal.

### Mobile
The search row sits at the top of the drawer, clear of the software keyboard; the input keeps a 16px baseline on touch to avoid iOS zoom and returns to the 14px row scale on fine pointers.

### Tests
- Backend: FTS reconcile/lifecycle — snippet + reveal anchor, incremental append, retitle rebuild, delete/restore, shrunk-history rebuild, tool-noise exclusion, operator-input neutralization, and the `/api/chats/search` endpoint (owner-gated).
- Frontend: unit tests for the reveal intent store, snippet term extraction, and the anchor math.

### Notes
- Requires SQLite FTS5 (available in the platform image's SQLite build).
- Adds `Highlight` to the built-globals allowlist for the CSS Custom Highlight API.