### PR TITLE
Preserve chat reading position across navigation

### DIFF
--- a/frontend/src/components/ChatView/__tests__/chatContract.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatContract.test.js
@@ -97,6 +97,10 @@ test('owner contract freezes question answers without locking keyboard movement'
 
 test('a retained chat crosses the old unmount lifecycle while hidden', () => {
   const chatView = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8')
+  const scrollController = readFileSync(
+    new URL('../useScrollMode.js', import.meta.url),
+    'utf8',
+  )
   assert.match(
     chatView,
     /useLayoutEffect\(\(\) => \{\s*if \(hidden\) freezeChatExit\(\)/,
@@ -106,6 +110,11 @@ test('a retained chat crosses the old unmount lifecycle while hidden', () => {
     chatView,
     /if \(hidden\) return[\s\S]*?\}, \[chatId, loadNonce, hidden\]\)/,
     'hidden chats must disconnect and refresh history when they become visible again',
+  )
+  assert.match(
+    scrollController,
+    /const freezeChatExit = useCallback\(\(\) => \{[\s\S]*?readerLocationExplicitRef\.current = true[\s\S]*?persistMode\(\{ freezeToCurrentPosition: true \}\)/,
+    'chat navigation must preserve an automatic tail hold through the later unmount cleanup',
   )
 })
 

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -1352,6 +1352,12 @@ export default function useScrollMode({
   // the transcript in the background. Keeping this as a controller event
   // avoids exposing persistMode/modeRef mutation to ChatView.
   const freezeChatExit = useCallback(() => {
+    // Leaving this chat is an explicit navigation action even when its initial
+    // location came from the automatic latest-content fallback. Promote the
+    // currently painted location before persisting it so the later unmount
+    // cleanup cannot delete the snapshot and reopen a growing turn at its new
+    // tail when the reader returns.
+    readerLocationExplicitRef.current = true
     persistMode({ freezeToCurrentPosition: true })
   }, [persistMode])
 


### PR DESCRIPTION
## Summary
- preserve the currently painted reading position whenever the owner leaves a chat, including chats that initially opened at the automatic tail
- keep that snapshot through the retained surface's later unmount cleanup so a growing transcript cannot reopen at a newer tail
- add contract coverage for the navigation-to-unmount handoff

## Testing
- full frontend unit and hook suites (2,292 passing)
- frontend production build
- live browser switch away from and back to a running chat retained the identical scroll position