### PR TITLE
Preserve mobile drawer scroll position on open

### DIFF
--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -18,6 +18,7 @@ import {
   isGeneratedTouchClick,
   isHorizontalDrawerSwipe,
   shouldSuppressDrawerSwipeClick,
+  shouldAutoRevealActiveChat,
   clearDrawerGestureStyles,
 } from '../../lib/drawerLifecycle.js'
 import { requestSearchReveal } from '../ChatView/searchReveal.js'
@@ -160,13 +161,14 @@ export default function Drawer({
     ))
   }, [allRecents.length])
 
-  // Selecting a chat from a workspace tab should reveal that same chat in the
-  // drawer. Older chats may sit outside the progressively mounted window, so
-  // first grow the window through the target row, then reveal it before paint.
-  // Remember the completed reveal so recency refreshes cannot fight a later
-  // manual scroll; leaving the chat or closing the drawer arms the next reveal.
+  // The always-visible desktop sidebar follows chat selections made elsewhere.
+  // The phone drawer instead preserves its last manual scroll position: opening
+  // navigation must not double as an automatic list scroll. Older desktop rows
+  // may sit outside the progressively mounted window, so first grow the window
+  // through the target row, then reveal it before paint. Remember the completed
+  // reveal so recency refreshes cannot fight a later manual scroll.
   useLayoutEffect(() => {
-    if (!open || activeView !== 'chat' || activeChatId == null) {
+    if (!shouldAutoRevealActiveChat({ open, persistent, activeView, activeChatId })) {
       revealedActiveChatRef.current = null
       return
     }
@@ -203,6 +205,7 @@ export default function Drawer({
     activeView,
     allRecents,
     open,
+    persistent,
     pinnedItems,
     visibleRecentCount,
   ])

--- a/frontend/src/lib/__tests__/drawerLifecycle.test.js
+++ b/frontend/src/lib/__tests__/drawerLifecycle.test.js
@@ -8,9 +8,26 @@ import {
   isGeneratedTouchClick,
   isHorizontalDrawerSwipe,
   shouldSuppressDrawerSwipeClick,
+  shouldAutoRevealActiveChat,
   clearDrawerGestureStyles,
   drawerOpenBlockedByDrag,
 } from '../drawerLifecycle.js'
+
+test('only the persistent sidebar follows active chat selections', () => {
+  const activeChat = {
+    open: true,
+    persistent: true,
+    activeView: 'chat',
+    activeChatId: 'chat-42',
+  }
+
+  assert.equal(shouldAutoRevealActiveChat(activeChat), true)
+  assert.equal(shouldAutoRevealActiveChat({ ...activeChat, persistent: false }), false,
+    'opening a modal drawer must preserve its manual scroll position')
+  assert.equal(shouldAutoRevealActiveChat({ ...activeChat, open: false }), false)
+  assert.equal(shouldAutoRevealActiveChat({ ...activeChat, activeView: 'canvas' }), false)
+  assert.equal(shouldAutoRevealActiveChat({ ...activeChat, activeChatId: null }), false)
+})
 
 test('the drawer open path stands down only while a drag is live', () => {
   // A live drag blocks the open (a left-edge tab drag must split, not open the

--- a/frontend/src/lib/drawerLifecycle.js
+++ b/frontend/src/lib/drawerLifecycle.js
@@ -9,6 +9,27 @@ export const DRAWER_CLOSE_WATCHDOG_BUFFER_MS = 80
 export const DRAWER_SWIPE_THRESHOLD_PX = 10
 export const DRAWER_SWIPE_DOMINANCE = 1.15
 
+/**
+ * Only the always-visible sidebar follows chat selections made elsewhere.
+ *
+ * A modal drawer is itself a destination the owner deliberately opens. Moving
+ * its list at that moment overrides the last manual scroll position and makes
+ * the opening gesture feel like it also scrolled the drawer. The persistent
+ * desktop sidebar has no such open gesture, so keeping its active row visible
+ * remains useful there.
+ */
+export function shouldAutoRevealActiveChat({
+  open,
+  persistent,
+  activeView,
+  activeChatId,
+}) {
+  return !!open
+    && !!persistent
+    && activeView === 'chat'
+    && activeChatId != null
+}
+
 function cssTimeMs(value) {
   const text = String(value || '').trim()
   const numeric = Number.parseFloat(text)


### PR DESCRIPTION
## Summary

- preserve the modal drawer's last manual scroll position when it opens
- continue revealing active chats in the persistent desktop sidebar
- cover the mobile/desktop reveal policy with a regression test

## Context

This follows #392. That change correctly kept externally selected chats visible, but applying the reveal while opening the mobile drawer made the list jump as navigation appeared. This narrows automatic reveal to the always-visible sidebar.

## Testing

- `npm test`
- `npm run build`