### PR TITLE
Keep chat media migration dependency one-way

### DIFF
--- a/backend/app/chat_media.py
+++ b/backend/app/chat_media.py
@@ -11,20 +11,6 @@ from app import models
 from app.chat_writer import RewriteChatMediaPaths, get_writer, wait_ack
 
 
-def _replace_media_path(value, old_prefix: str, new_prefix: str):
-  """Recursively rewrites media URLs inside JSON-compatible chat data."""
-  if isinstance(value, str):
-    return value.replace(old_prefix, new_prefix)
-  if isinstance(value, list):
-    return [_replace_media_path(item, old_prefix, new_prefix) for item in value]
-  if isinstance(value, dict):
-    return {
-      key: _replace_media_path(item, old_prefix, new_prefix)
-      for key, item in value.items()
-    }
-  return value
-
-
 def fix_forward_chat_media(db: Session, data_dir: str) -> int:
   """Moves old chat images into `media/` and rewrites stored message URLs.
 

--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -125,6 +125,23 @@ def wait_ack(ack: Future, *, timeout: float | None = None):
   return ack.result(timeout=ACK_TIMEOUT_SECS if timeout is None else timeout)
 
 
+def _replace_chat_media_path(value, old_prefix: str, new_prefix: str):
+  """Recursively rewrite media URLs inside JSON-compatible chat data."""
+  if isinstance(value, str):
+    return value.replace(old_prefix, new_prefix)
+  if isinstance(value, list):
+    return [
+      _replace_chat_media_path(item, old_prefix, new_prefix)
+      for item in value
+    ]
+  if isinstance(value, dict):
+    return {
+      key: _replace_chat_media_path(item, old_prefix, new_prefix)
+      for key, item in value.items()
+    }
+  return value
+
+
 # -- Commands (domain-level; a later milestone swaps their dispatch) -----
 @dataclass
 class _Command:
@@ -1738,7 +1755,6 @@ class ChatWriterActor:
     self, db, cmd: "RewriteChatMediaPaths",
   ) -> int:
     """Rewrite both transcript blobs in one actor-owned transaction."""
-    from app.chat_media import _replace_media_path
     from app.models import Chat
 
     row = db.execute(select(
@@ -1747,10 +1763,10 @@ class ChatWriterActor:
     if row is None:
       return 0
     messages, pending = row
-    rewritten_messages = _replace_media_path(
+    rewritten_messages = _replace_chat_media_path(
       messages, cmd.old_prefix, cmd.new_prefix,
     )
-    rewritten_pending = _replace_media_path(
+    rewritten_pending = _replace_chat_media_path(
       pending, cmd.old_prefix, cmd.new_prefix,
     )
     values = {}

--- a/backend/tests/test_chat_media.py
+++ b/backend/tests/test_chat_media.py
@@ -50,10 +50,10 @@ def test_fix_forward_chat_media_skips_unrelated_transcripts(
   }]
   db.commit()
 
-  def unexpected_copy(*_args):
-    raise AssertionError("unrelated transcript was materialized for rewrite")
+  def unexpected_writer():
+    raise AssertionError("unrelated transcript was selected for rewrite")
 
-  monkeypatch.setattr(chat_media, "_replace_media_path", unexpected_copy)
+  monkeypatch.setattr(chat_media, "get_writer", unexpected_writer)
 
   assert fix_forward_chat_media(db, get_settings().data_dir) == 0
 


### PR DESCRIPTION
## Summary
- keep the recursive media-path transform inside the chat writer that owns transcript persistence
- make the media migration depend on the writer in one direction instead of importing the migration module back from the actor
- test that unrelated transcripts never enter the writer path rather than patching an implementation helper

This changes no runtime behavior or UI; it removes one function-local import workaround and restores an acyclic backend module graph.

## Why this follows #436
The broader reconciliation in #436 preserved the reviewed startup, provider-contract, frame-protocol, navigation, deployment, and behavior-test owners, but restored the earlier media helper placement. That reintroduced the `chat_media ↔ chat_writer` import cycle removed in the reviewed tree. This is the complete remaining three-file delta.

## Verification
- 40 focused media-migration and chat-writer tests passed
- changed Python modules compile cleanly
- backend import-graph audit reports zero cycles
- private-path and local privacy gates passed
- canonical diff re-reviewed and `git diff --check` passed