### PR TITLE
Make Dependabot updates coherent

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,14 +4,38 @@ updates:
     directory: /backend
     schedule: { interval: weekly }
     open-pull-requests-limit: 5
+    versioning-strategy: lockfile-only
+    groups:
+      python-lockfile:
+        patterns: ["*"]
+
   - package-ecosystem: npm
     directory: /frontend
     schedule: { interval: weekly }
     open-pull-requests-limit: 5
-  - package-ecosystem: docker
-    directory: /
-    schedule: { interval: weekly }
-    open-pull-requests-limit: 5
+    versioning-strategy: increase-if-necessary
+    groups:
+      tanstack:
+        patterns: ["@tanstack/*"]
+        update-types: [minor, patch]
+      codemirror:
+        patterns:
+          - "@codemirror/*"
+          - "@lezer/*"
+          - codemirror
+        update-types: [minor, patch]
+      frontend-minor-patch:
+        patterns: ["*"]
+        exclude-patterns:
+          - "@tanstack/*"
+          - "@codemirror/*"
+          - "@lezer/*"
+          - codemirror
+        update-types: [minor, patch]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
   - package-ecosystem: github-actions
     directory: /
     schedule: { interval: weekly }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5075,12 +5075,13 @@
       }
     },
     "node_modules/@tanstack/query-async-storage-persister": {
-      "version": "5.101.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-async-storage-persister/-/query-async-storage-persister-5.101.2.tgz",
-      "integrity": "sha512-jf7zvVKZ5q2j/xuhbTIBUpw5xt6cw/ioOFQquxK7fRY0AmMQP8A0JVMOgYoeQLA4PKdeT7RxsuLAF0Lft9oJ8Q==",
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-async-storage-persister/-/query-async-storage-persister-5.101.4.tgz",
+      "integrity": "sha512-ROenNOVvxIZ1zKsBAiIvvslLo2xD8Me/vFz/tChdmuI7ciU+ET63yRrQ01W899Tx1ayQXdsGQJqYqjjVZk+OBQ==",
+      "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.101.2",
-        "@tanstack/query-persist-client-core": "5.101.2"
+        "@tanstack/query-core": "5.101.4",
+        "@tanstack/query-persist-client-core": "5.101.4"
       },
       "funding": {
         "type": "github",
@@ -5088,20 +5089,22 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.101.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.2.tgz",
-      "integrity": "sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==",
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.4.tgz",
+      "integrity": "sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tanstack/query-persist-client-core": {
-      "version": "5.101.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-persist-client-core/-/query-persist-client-core-5.101.2.tgz",
-      "integrity": "sha512-rgMsbvBVpSPDUsprC9FYxojdG0Q1LH6yq1i3DXz2aps4VEqv2l4Msj3YDqIifU3xkl/DrYe9YWntZAJLrM6xTg==",
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-persist-client-core/-/query-persist-client-core-5.101.4.tgz",
+      "integrity": "sha512-Bmu+RfWhwYEyYZEwSeKC0gX4+KTkiEB3yO8oz9BfAY/Jfe3ndz9EnYVhihIZPmWIr8NXayF7JuraNQcrXQQCCg==",
+      "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.101.2"
+        "@tanstack/query-core": "5.101.4"
       },
       "funding": {
         "type": "github",
@@ -5109,11 +5112,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.101.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.2.tgz",
-      "integrity": "sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg==",
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.4.tgz",
+      "integrity": "sha512-yRg2pfOCxIs4ZJW3XYYHU/WgtD04FHSnfHlpRT7h7pR77hwkdRG4wxbKe4aq6P0RvXUTBSQpQeadS1SUYUe+KA==",
+      "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.101.2"
+        "@tanstack/query-core": "5.101.4"
       },
       "funding": {
         "type": "github",
@@ -5124,18 +5128,19 @@
       }
     },
     "node_modules/@tanstack/react-query-persist-client": {
-      "version": "5.101.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query-persist-client/-/react-query-persist-client-5.101.2.tgz",
-      "integrity": "sha512-19UpaRtf0lvB2QAJ2MoixxtGf3osMOd508g99EsttUj4+3eLs+ulnNgYjB7AkQMHrRlcbVXqpVNqWkB4a7g8Zw==",
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-persist-client/-/react-query-persist-client-5.101.4.tgz",
+      "integrity": "sha512-CY5i7PPKS/5B8OR2zAs9nCbLpgqI4jN8eBhtAxKRMNHyGcQhmyOy4PkkJrAAXT+ecGj++fBJTgQw6OpyCt/2SQ==",
+      "license": "MIT",
       "dependencies": {
-        "@tanstack/query-persist-client-core": "5.101.2"
+        "@tanstack/query-persist-client-core": "5.101.4"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "@tanstack/react-query": "^5.101.2",
+        "@tanstack/react-query": "^5.101.4",
         "react": "^18 || ^19"
       }
     },


### PR DESCRIPTION
## Summary
- update Python lockfiles without raising already-compatible requirements
- group frontend minor and patch updates by compatibility while keeping major upgrades deliberate
- stop proposing Docker runtime-line changes that require coordinated platform migrations
- align the TanStack query packages on 5.101.4

This supersedes #447: the whole TanStack family moves together instead of leaving duplicate 5.101.2 and 5.101.4 cores in the lock.

## Testing
- `npm ci --ignore-scripts`
- `npm test` (2,304 tests)
- parsed `.github/dependabot.yml` and asserted the intended policies