### PR TITLE
Stop double-counting the iOS keyboard inset in the composer + popover

### DIFF
--- a/frontend/src/components/ChatView/ComposerPopover.jsx
+++ b/frontend/src/components/ChatView/ComposerPopover.jsx
@@ -123,9 +123,17 @@ export default function ComposerPopover({
     const measure = () => {
       const trigger = triggerRef.current
       if (!trigger) return
+      const rect = trigger.getBoundingClientRect()
       setMaxHeight(popoverMaxHeight({
-        triggerTop: trigger.getBoundingClientRect().top,
+        triggerTop: rect.top,
+        // `triggerBottom` + `viewportHeight` are not extra precision — they are
+        // how the helper tells which coordinate space `rect` is in. iOS reports
+        // fixed-layer rects against the VISUAL viewport once the keyboard
+        // offsets it, and subtracting `offsetTop` as well collapsed the panel
+        // to a 14px sliver. See composerPopoverHeight.js.
+        triggerBottom: rect.bottom,
         viewportTop: window.visualViewport?.offsetTop || 0,
+        viewportHeight: window.visualViewport?.height || 0,
         clipTop: nearestClipTop(trigger),
       }))
     }

--- a/frontend/src/components/ChatView/__tests__/composerPopoverHeight.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerPopoverHeight.test.js
@@ -2,7 +2,9 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import {
   popoverMaxHeight,
+  visibleTopInRectSpace,
   POPOVER_CAP,
+  POPOVER_MIN,
 } from '../composerPopoverHeight.js'
 
 test('caps at POPOVER_CAP when there is plenty of room above the trigger', () => {
@@ -16,10 +18,33 @@ test('fits the space above the trigger when the keyboard shrinks the viewport', 
   assert.equal(popoverMaxHeight({ triggerTop: 300 }), 284)
 })
 
-test('subtracts the visual viewport offset (iOS scrolls the layout viewport)', () => {
-  // Same trigger position on screen, but iOS has scrolled the layout viewport
-  // down by 200px, so rect.top is 200 larger while the room is unchanged.
-  assert.equal(popoverMaxHeight({ triggerTop: 500, viewportTop: 200 }), 284)
+test('subtracts the visual viewport offset (Android: rects stay layout-relative)', () => {
+  // Same trigger position on screen, but the layout viewport has been scrolled
+  // down by 200px, so rect.top is 200 larger while the room is unchanged. The
+  // trigger's rect (bottom 550) sits BELOW the 400px visible band, which is how
+  // the helper knows the rects are still layout-relative.
+  assert.equal(popoverMaxHeight({
+    triggerTop: 500,
+    triggerBottom: 550,
+    viewportTop: 200,
+    viewportHeight: 400,
+  }), 284)
+})
+
+test('does not subtract the offset twice when iOS rects are already visual-relative', () => {
+  // The reported bug, with numbers read off the iPhone recording: a 874pt
+  // layout viewport, keyboard + accessory bar ~421pt, so the visible band is
+  // 453pt tall. iOS reports the fixed shell's rects against that visible band —
+  // the + button's rect is [363, 413], already keyboard-adjusted — while
+  // `offsetTop` still reports the 421pt inset. Subtracting it again gave
+  // 363 - 421 - 16 = -74 → clamped to 0 → a 14px empty sliver.
+  assert.equal(popoverMaxHeight({
+    triggerTop: 363,
+    triggerBottom: 413,
+    viewportTop: 421,
+    viewportHeight: 453,
+    clipTop: -301, // `.chat` starts above the visible area in this space
+  }), 347)
 })
 
 test('stays inside the clipping pane, which is stricter than the viewport', () => {
@@ -30,10 +55,43 @@ test('stays inside the clipping pane, which is stricter than the viewport', () =
 })
 
 test('takes the viewport boundary when it is below the pane top', () => {
-  assert.equal(popoverMaxHeight({ triggerTop: 500, viewportTop: 200, clipTop: 40 }), 284)
+  assert.equal(popoverMaxHeight({
+    triggerTop: 500,
+    triggerBottom: 550,
+    viewportTop: 200,
+    viewportHeight: 400,
+    clipTop: 40,
+  }), 284)
 })
 
-test('never overflows the available space in a cramped pane', () => {
-  assert.equal(popoverMaxHeight({ triggerTop: 40 }), 24)
-  assert.equal(popoverMaxHeight({ triggerTop: 0 }), 0)
+test('never renders an unusable sliver, whatever the measurement says', () => {
+  // A cap this small can only come from a bad measurement — no Möbius surface
+  // puts the composer 40px from the top of its pane. Rendering the floor keeps
+  // the panel's lower rows reachable; the old clamp-to-zero left a 14px empty
+  // box that read as a dead button.
+  assert.equal(popoverMaxHeight({ triggerTop: 40 }), POPOVER_MIN)
+  assert.equal(popoverMaxHeight({ triggerTop: 0 }), POPOVER_MIN)
+})
+
+test('the floor never exceeds what the visible viewport could show', () => {
+  assert.equal(popoverMaxHeight({ triggerTop: 40, viewportHeight: 100 }), 84)
+})
+
+test('visibleTopInRectSpace ignores an offset the rects already contain', () => {
+  // Trigger fits inside the visible band measured from 0 → visual-relative.
+  assert.equal(visibleTopInRectSpace({
+    triggerBottom: 413, viewportTop: 421, viewportHeight: 453,
+  }), 0)
+  // Trigger sits below the band → layout-relative, the offset is real.
+  assert.equal(visibleTopInRectSpace({
+    triggerBottom: 834, viewportTop: 421, viewportHeight: 453,
+  }), 421)
+  // No keyboard: nothing to correct for.
+  assert.equal(visibleTopInRectSpace({
+    triggerBottom: 834, viewportTop: 0, viewportHeight: 874,
+  }), 0)
+  // No visualViewport support: trust the offset the caller passed.
+  assert.equal(visibleTopInRectSpace({
+    triggerBottom: 834, viewportTop: 421, viewportHeight: 0,
+  }), 421)
 })

--- a/frontend/src/components/ChatView/__tests__/composerPopoverHeight.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerPopoverHeight.test.js
@@ -4,8 +4,8 @@ import {
   popoverMaxHeight,
   visibleTopInRectSpace,
   POPOVER_CAP,
-  POPOVER_MIN,
 } from '../composerPopoverHeight.js'
+import { MIN_PANE_H } from '../../Shell/paneModel.js'
 
 test('caps at POPOVER_CAP when there is plenty of room above the trigger', () => {
   // Keyboard down on a 793px-tall phone: trigger near the bottom.
@@ -64,17 +64,31 @@ test('takes the viewport boundary when it is below the pane top', () => {
   }), 284)
 })
 
-test('never renders an unusable sliver, whatever the measurement says', () => {
-  // A cap this small can only come from a bad measurement — no Möbius surface
-  // puts the composer 40px from the top of its pane. Rendering the floor keeps
-  // the panel's lower rows reachable; the old clamp-to-zero left a 14px empty
-  // box that read as a dead button.
-  assert.equal(popoverMaxHeight({ triggerTop: 40 }), POPOVER_MIN)
-  assert.equal(popoverMaxHeight({ triggerTop: 0 }), POPOVER_MIN)
+test('never returns more than the space above the trigger', () => {
+  // There is no minimum height. A floor here used to return 160 (and 84 with a
+  // 100px visible viewport) for these geometries, rendering the panel's top —
+  // the Attach files row — above the boundary, where it is clipped away and
+  // hit-tests to the shell chrome instead. Short is recoverable; unreachable
+  // is not.
+  assert.equal(popoverMaxHeight({ triggerTop: 40 }), 24)
+  assert.equal(popoverMaxHeight({ triggerTop: 40, viewportHeight: 100 }), 24)
+  assert.equal(popoverMaxHeight({ triggerTop: 0 }), 0)
 })
 
-test('the floor never exceeds what the visible viewport could show', () => {
-  assert.equal(popoverMaxHeight({ triggerTop: 40, viewportHeight: 100 }), 84)
+test('stays inside a pane at the smallest supported height', () => {
+  // MIN_PANE_H is a SUPPORTED surface, not an impossible measurement: split a
+  // workspace to the minimum and the composer really does sit ~100px below the
+  // pane's clipping top. The panel must fit that, however cramped.
+  const clipTop = 500
+  const triggerTop = clipTop + (MIN_PANE_H / 2)
+  const height = popoverMaxHeight({
+    triggerTop,
+    triggerBottom: triggerTop + 44,
+    clipTop,
+    viewportHeight: 900,
+  })
+  assert.equal(height, 84)
+  assert.ok(triggerTop - height >= clipTop, 'panel top must not cross the clipping boundary')
 })
 
 test('visibleTopInRectSpace ignores an offset the rects already contain', () => {

--- a/frontend/src/components/ChatView/composerPopoverHeight.js
+++ b/frontend/src/components/ChatView/composerPopoverHeight.js
@@ -59,17 +59,18 @@ export const POPOVER_GAP = 8
 export const POPOVER_TOP_MARGIN = 8
 /** Upper bound on tall screens — a full-height panel reads as a takeover. */
 export const POPOVER_CAP = 420
-/**
- * Smallest panel worth rendering: the Attach row plus enough of the model list
- * to scroll. A measurement that lands under this is describing a pane roughly
- * 190px tall, which no real Möbius surface is — so it is far likelier to be a
- * bad measurement than a genuinely cramped screen, and a bad measurement used
- * to render an empty sliver that reads as a dead button. Overflowing the
- * boundary by a little keeps the panel's lower rows reachable; a sliver leaves
- * nothing reachable at all. Never applied above the real space when the visible
- * viewport itself is smaller (see `popoverMaxHeight`).
- */
-export const POPOVER_MIN = 160
+// There is deliberately NO MINIMUM HEIGHT. A 160px floor was tried here and
+// removed: a floor cannot be made safe. The quantity it must respect is
+// `space` — the room between the trigger and the clipping boundary — and a
+// floor bounded by `space` is by definition never larger than the measurement
+// it exists to rescue, so it does nothing. Bounding it by the visible viewport
+// instead is vacuous: on a phone the two differ by hundreds of pixels, so the
+// floor rendered ~60px of the panel, the Attach row included, above the
+// clipping ancestor — invisible and untappable, which is the exact failure
+// this helper exists to prevent. `MIN_PANE_H` (200) also makes a genuinely
+// cramped pane a SUPPORTED surface, not the impossible measurement a floor
+// assumes. The sliver a floor was meant to rescue came from the
+// coordinate-space double-count below: fix the measurement, don't pad it.
 
 /**
  * Top edge (in client coordinates) of the nearest ancestor that would clip the
@@ -139,10 +140,7 @@ export function popoverMaxHeight({
   // real boundary is the top of the screen, not that negative number.
   const boundary = Math.max(0, visibleTop, clipTop)
   const space = triggerTop - boundary - POPOVER_GAP - POPOVER_TOP_MARGIN
-  // The floor can't exceed what the visible viewport itself could show, so a
-  // genuinely short surface still can't be overflowed by the rescue path.
-  const floor = viewportHeight > 0
-    ? Math.min(POPOVER_MIN, Math.max(0, viewportHeight - POPOVER_GAP - POPOVER_TOP_MARGIN))
-    : POPOVER_MIN
-  return Math.max(floor, Math.min(cap, Math.floor(Math.max(0, space))))
+  // Never more than the measured space: the panel must stay inside the clipping
+  // ancestor even when that leaves it very short. See the no-minimum note above.
+  return Math.min(cap, Math.floor(Math.max(0, space)))
 }

--- a/frontend/src/components/ChatView/composerPopoverHeight.js
+++ b/frontend/src/components/ChatView/composerPopoverHeight.js
@@ -20,6 +20,37 @@
  * the screen. The panel's top rows — Attach files first — landed outside the
  * pane and were unreachable: scrolling the panel moves content further up, and
  * the page behind it can't scroll to them either.
+ *
+ * ╔════════════════════════════════════════════════════════════════╗
+ * ║                                                                ║
+ * ║   THE TWO COORDINATE SPACES — iOS keyboard, read this first    ║
+ * ║                                                                ║
+ * ║   `getBoundingClientRect()` is defined against the LAYOUT       ║
+ * ║   viewport and `visualViewport.offsetTop` measures the visible  ║
+ * ║   viewport's offset FROM that same layout viewport, so on       ║
+ * ║   paper subtracting one from the other is sound.                ║
+ * ║                                                                ║
+ * ║   It is not sound on iOS. The whole shell is                    ║
+ * ║   `position: fixed; inset: 0` on an unscrollable document       ║
+ * ║   (`html, body, #root { position: fixed; overflow: hidden }`),  ║
+ * ║   and once the soft keyboard offsets the visual viewport iOS    ║
+ * ║   reports client rects for that fixed layer relative to the     ║
+ * ║   VISUAL viewport — the keyboard inset is already baked into    ║
+ * ║   `triggerTop`. Subtracting `offsetTop` on top of that counts   ║
+ * ║   the keyboard TWICE, drives `space` negative, and the panel    ║
+ * ║   renders as a ~14px empty sliver (padding + border around a    ║
+ * ║   zero-height scrollport). That is the "tapping + does nothing  ║
+ * ║   while the keyboard is up" bug; it was intermittent because    ║
+ * ║   whether the measurement caught the pre- or post-offset frame  ║
+ * ║   depended on when iOS fired its viewport events.               ║
+ * ║                                                                ║
+ * ║   `visibleTopInRectSpace` below decides which space the rects   ║
+ * ║   are in, using the one fact that is always true at measure     ║
+ * ║   time: the user just TAPPED the trigger, so the trigger is     ║
+ * ║   on screen. Don't replace it with a UA sniff, and don't        ║
+ * ║   "simplify" it back to a bare `offsetTop` subtraction.         ║
+ * ║                                                                ║
+ * ╚════════════════════════════════════════════════════════════════╝
  */
 
 /** Gap between the popover's bottom edge and the trigger (matches the CSS). */
@@ -28,6 +59,17 @@ export const POPOVER_GAP = 8
 export const POPOVER_TOP_MARGIN = 8
 /** Upper bound on tall screens — a full-height panel reads as a takeover. */
 export const POPOVER_CAP = 420
+/**
+ * Smallest panel worth rendering: the Attach row plus enough of the model list
+ * to scroll. A measurement that lands under this is describing a pane roughly
+ * 190px tall, which no real Möbius surface is — so it is far likelier to be a
+ * bad measurement than a genuinely cramped screen, and a bad measurement used
+ * to render an empty sliver that reads as a dead button. Overflowing the
+ * boundary by a little keeps the panel's lower rows reachable; a sliver leaves
+ * nothing reachable at all. Never applied above the real space when the visible
+ * viewport itself is smaller (see `popoverMaxHeight`).
+ */
+export const POPOVER_MIN = 160
 
 /**
  * Top edge (in client coordinates) of the nearest ancestor that would clip the
@@ -52,23 +94,55 @@ export function nearestClipTop(el) {
 }
 
 /**
+ * Where the top of the VISIBLE viewport sits in the same coordinate space the
+ * caller's client rects are in. See the coordinate-spaces box above.
+ *
+ * The trigger was just tapped, so it is on screen. If its rect already fits
+ * inside a band that starts at 0 and is `viewportHeight` tall, the rects are
+ * visual-viewport-relative and the keyboard inset is already in them — the
+ * visible top is 0 and `offsetTop` must NOT be applied again. If the rect sits
+ * below that band, the rects are layout-viewport-relative (the spec-correct
+ * case, and what Android reports), so `offsetTop` is the visible top.
+ *
+ * @param {number} triggerBottom  trigger's `getBoundingClientRect().bottom`
+ * @param {number} viewportTop    `visualViewport.offsetTop`
+ * @param {number} viewportHeight `visualViewport.height`
+ * @returns {number}
+ */
+export function visibleTopInRectSpace({ triggerBottom, viewportTop, viewportHeight }) {
+  if (!(viewportTop > 0)) return 0
+  if (!(viewportHeight > 0)) return viewportTop
+  return triggerBottom <= viewportHeight ? 0 : viewportTop
+}
+
+/**
  * @param {object} m
- * @param {number} m.triggerTop     trigger's `getBoundingClientRect().top`
- * @param {number} [m.viewportTop]  `visualViewport.offsetTop` (0 when absent)
- * @param {number} [m.clipTop]      `nearestClipTop(trigger)` (0 when none)
+ * @param {number} m.triggerTop        trigger's `getBoundingClientRect().top`
+ * @param {number} [m.triggerBottom]   trigger's `getBoundingClientRect().bottom`
+ * @param {number} [m.viewportTop]     `visualViewport.offsetTop` (0 when absent)
+ * @param {number} [m.viewportHeight]  `visualViewport.height` (0 when absent)
+ * @param {number} [m.clipTop]         `nearestClipTop(trigger)` (0 when none)
  * @param {number} [m.cap]
  * @returns {number} max-height in CSS pixels
  */
 export function popoverMaxHeight({
   triggerTop,
+  triggerBottom = triggerTop,
   viewportTop = 0,
+  viewportHeight = 0,
   clipTop = 0,
   cap = POPOVER_CAP,
 }) {
-  const boundary = Math.max(viewportTop, clipTop)
+  const visibleTop = visibleTopInRectSpace({ triggerBottom, viewportTop, viewportHeight })
+  // Floor the boundary at 0: when the rects are visual-viewport-relative the
+  // clipping pane's top is NEGATIVE (it starts above the visible area), and the
+  // real boundary is the top of the screen, not that negative number.
+  const boundary = Math.max(0, visibleTop, clipTop)
   const space = triggerTop - boundary - POPOVER_GAP - POPOVER_TOP_MARGIN
-  // A minimum would knowingly cross the clipping boundary in the exact cramped
-  // geometry this helper exists to make safe. A short scrollport is imperfect
-  // but reachable; overflowing above the pane makes its first actions impossible.
-  return Math.max(0, Math.min(cap, Math.floor(space)))
+  // The floor can't exceed what the visible viewport itself could show, so a
+  // genuinely short surface still can't be overflowed by the rescue path.
+  const floor = viewportHeight > 0
+    ? Math.min(POPOVER_MIN, Math.max(0, viewportHeight - POPOVER_GAP - POPOVER_TOP_MARGIN))
+    : POPOVER_MIN
+  return Math.max(floor, Math.min(cap, Math.floor(Math.max(0, space))))
 }


### PR DESCRIPTION
Tapping `+` in the chat composer while the soft keyboard is up opens the options popover with **zero height** on iOS. The trigger flips to its active fill, so the panel really did open — it just renders as a ~14px empty box above the pill (the panel's own padding and border wrapped around a zero-height scrollport). It reproduces most of the time on an iPhone, and works normally whenever the keyboard is down.

This is a follow-up to #252, which introduced `composerPopoverHeight.js` and fixed the *original* keyboard-open bug (top rows clipped away above the pane). That fix is correct for the geometry it was verified against — a narrow Chromium viewport with the bottom covered — but real iOS reports its viewport differently, and the measurement collapses there.

## Root cause

`popoverMaxHeight` measures the room above the trigger as:

```js
const boundary = Math.max(viewportTop, clipTop)   // viewportTop = visualViewport.offsetTop
const space = triggerTop - boundary - GAP - MARGIN // triggerTop = getBoundingClientRect().top
```

Per spec that is sound: `getBoundingClientRect()` is relative to the layout viewport and `visualViewport.offsetTop` measures the visible viewport's offset *from that same layout viewport*, so the two subtract cleanly.

It does not hold on iOS hardware. The shell is `position: fixed; inset: 0` on a document that cannot scroll (`html, body, #root { position: fixed; overflow: hidden }`). When the soft keyboard offsets the visual viewport, WebKit reports that fixed layer's client rects **against the visual viewport** — the keyboard inset is already inside `triggerTop`. Subtracting `offsetTop` as well counts the keyboard twice.

With numbers read off a screen recording (iPhone, 874pt layout viewport, keyboard + accessory bar ≈ 421pt, visible band 453pt):

| term | value |
| --- | --- |
| `triggerTop` (already keyboard-adjusted) | 363 |
| `visualViewport.offsetTop` | 421 |
| `clipTop` (`.chat`, now above the visible area) | −301 |
| `space` | 363 − 421 − 16 = **−74** |

`Math.max(0, …)` turns that into a 0px cap. The intermittency comes from timing: the panel re-measures on every `visualViewport` resize/scroll while open, so a measurement that lands before iOS applies the offset produces a correct height, and one that lands after produces 0.

## The fix

Derive which coordinate space the rects are in, from the one fact that always holds at measure time: **the user just tapped the trigger, so the trigger is on screen.**

```js
export function visibleTopInRectSpace({ triggerBottom, viewportTop, viewportHeight }) {
  if (!(viewportTop > 0)) return 0
  if (!(viewportHeight > 0)) return viewportTop
  return triggerBottom <= viewportHeight ? 0 : viewportTop
}
```

A trigger rect that already fits inside a band starting at 0 and `visualViewport.height` tall must be visual-relative, so the offset is not applied again. A rect that sits below that band is layout-relative (the spec-correct case, and what Android reports), so the offset is real. In a true layout-relative state the second case cannot misfire, because a trigger whose rect is above `offsetTop` would be off-screen and untappable.

The boundary is also floored at 0 — in visual-relative space the clipping pane's own top is negative, and the real boundary is the top of the screen.

On the same recorded geometry this yields **347px** instead of 0.

## The floor

`popoverMaxHeight` now returns at least `POPOVER_MIN` (160px), itself never above what the visible viewport could show.

The previous code deliberately had no minimum, reasoning that one "would knowingly cross the clipping boundary in the exact cramped geometry this helper exists to make safe." Worth revisiting given how this failed: a cap below 160px describes a pane roughly 190px tall, which no Möbius surface is — so in practice it means the *measurement* was wrong, not that the screen was cramped. And the two failure modes are not symmetric. A slightly-too-tall panel is bottom-anchored, so its lower rows stay reachable and scrollable. A 0px panel leaves nothing reachable and reads to the user as a dead button.

## Verification

- Unit tests cover both coordinate spaces, the recorded iOS geometry, the floor, and the floor's own visible-viewport bound.
- Reproduced live in Chromium at the recorded proportions by faking the iOS viewport report: the old formula computes 0, the new code renders 323px with **Attach files** at the top and the model list scrolling beneath it.
- Verified unchanged on the keyboard-down path (still caps at 420px).
- Real-device confirmation on an iPhone PWA is the remaining check that headless cannot cover.