### PR TITLE
install: only announce an install the browser reported, and cut the cards to one action

### DIFF
--- a/frontend/src/components/Drawer/InstallSheet.css
+++ b/frontend/src/components/Drawer/InstallSheet.css
@@ -18,6 +18,7 @@
 @keyframes is-fade { from { opacity: 0; } to { opacity: 1; } }
 
 .is__card {
+  position: relative;
   width: 100%;
   max-width: 420px;
   background: var(--surface, #14181f);
@@ -226,10 +227,34 @@
   text-decoration: none;
 }
 
-/* The address is a fallback to read and retype by hand, so keep it
-   selectable and break it anywhere rather than overflowing the card. */
-.is__url {
+/* Corner dismissal. Sits in the card's padding, with a touch target larger
+   than the glyph so a thumb can hit it without crowding the title. */
+.is__close {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--muted, #9ca3af);
+  font: inherit;
+  font-size: 22px;
+  line-height: 1;
+  cursor: pointer;
+  transition: color 0.15s, background 0.15s;
+}
+
+.is__close:hover {
   color: var(--text, #d4d4d8);
-  overflow-wrap: anywhere;
-  user-select: all;
+  background: var(--hover, rgba(255, 255, 255, 0.06));
+}
+
+.is__close:focus-visible {
+  outline: 2px solid var(--accent, #a78bfa);
+  outline-offset: 2px;
 }

--- a/frontend/src/components/Drawer/InstallSheet.jsx
+++ b/frontend/src/components/Drawer/InstallSheet.jsx
@@ -145,22 +145,13 @@ export default function InstallSheet({ app, onClose }) {
     return new URL(`/apps/${appSlug}/?${query}`, window.location.origin).href
   }
 
-  // Shown for typing by hand. Deliberately WITHOUT the one-time pass: an
-  // address a human copies off a screen should not be a credential, and a
-  // pass-less arrival degrades to the ordinary login rather than failing.
-  const plainUrl = typeof window !== 'undefined'
-    ? new URL(`/apps/${appSlug}/?install=1`, window.location.origin).href
-    : `/apps/${appSlug}/?install=1`
-
   async function copyLink() {
     try {
       await navigator.clipboard.writeText(handoffUrl)
       setCopied(true)
     } catch {
-      // Clipboard access can be denied outright. The address is printed in
-      // the card either way, so this degrades to reading it off the screen.
       setCopied(false)
-      setError('Could not copy — the address is written below.')
+      setError('Could not copy — use the button above instead.')
     }
   }
 
@@ -223,6 +214,17 @@ export default function InstallSheet({ app, onClose }) {
       >
         {handoff ? (
           <>
+            {/* Nothing is left to confirm at this step — the work is done and
+                the card is now just instructions. A corner dismissal reads as
+                "I'm finished reading" without competing with the action. */}
+            <button
+              type="button"
+              className="is__close"
+              aria-label="Close"
+              onClick={() => onClose?.()}
+            >
+              ×
+            </button>
             <h2 className="is__title">Add {label} to your home screen</h2>
             <p className="is__hint is__hint--steps">
               Only Safari can put an app on your home screen, and you’re in
@@ -251,22 +253,6 @@ export default function InstallSheet({ app, onClose }) {
             </div>
 
             {error && <div className="is__error" role="alert">{error}</div>}
-
-            <p className="is__hint">
-              If it opens inside Möbius rather than Safari, tap the compass
-              icon to switch over. Or open Safari yourself and go to{' '}
-              <span className="is__url">{plainUrl}</span>
-            </p>
-
-            <div className="is__actions">
-              <button
-                type="button"
-                className="is__btn is__btn--secondary"
-                onClick={() => onClose?.()}
-              >
-                Done
-              </button>
-            </div>
           </>
         ) : (
         <>

--- a/frontend/src/components/StandaloneApp/StandaloneApp.css
+++ b/frontend/src/components/StandaloneApp/StandaloneApp.css
@@ -128,6 +128,7 @@
 }
 
 .standalone-install {
+  position: relative;
   width: min(430px, 100%);
   max-height: calc(100dvh - 32px);
   padding: 22px;
@@ -146,7 +147,6 @@
 }
 
 .standalone-install__identity p,
-.standalone-install__hint,
 .standalone-app--message p {
   margin: 5px 0 0;
   color: var(--muted, #aaa);
@@ -154,38 +154,14 @@
   line-height: 1.5;
 }
 
-.standalone-install__icon-button {
-  position: relative;
+.standalone-install__icon {
   flex: 0 0 64px;
   width: 64px;
   height: 64px;
-  padding: 0;
-  overflow: hidden;
-  border-radius: 15px;
-}
-
-.standalone-install__icon-button img {
-  width: 100%;
-  height: 100%;
   display: block;
+  border-radius: 15px;
   object-fit: cover;
 }
-
-.standalone-install__icon-button span {
-  position: absolute;
-  right: 3px;
-  bottom: 3px;
-  display: grid;
-  place-items: center;
-  width: 21px;
-  height: 21px;
-  border-radius: 50%;
-  background: var(--accent, #a78bfa);
-  color: var(--accent-fg, #111);
-  font-size: 11px;
-}
-
-.standalone-install__hint { margin-top: 14px; }
 
 .standalone-install__instructions {
   display: flex;
@@ -250,8 +226,32 @@
   .standalone-install__arrow { animation: none; }
 }
 
-.standalone-install__message { margin-top: 12px; color: var(--muted, #aaa); font-size: 12px; }
 .standalone-install__actions { margin-top: 18px; }
+
+/* Corner dismissal, replacing a worded "Maybe later" that competed with the
+   one action worth taking. Larger touch target than the glyph it draws. */
+.standalone-install .standalone-install__close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  border: none;
+  border-radius: 9px;
+  background: transparent;
+  color: var(--muted, #aaa);
+  font-size: 24px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.standalone-install .standalone-install__close:hover {
+  color: var(--text, #fff);
+  background: var(--hover, rgba(255, 255, 255, 0.06));
+}
 .standalone-install .standalone-install__primary {
   border-color: var(--accent, #a78bfa);
   background: var(--accent, #a78bfa);

--- a/frontend/src/components/StandaloneApp/StandaloneInstallCard.jsx
+++ b/frontend/src/components/StandaloneApp/StandaloneInstallCard.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, useSyncExternalStore } from 'react'
-import { apiFetch } from '../../api/client.js'
 import useDialogFocus from '../../hooks/useDialogFocus.js'
 import {
+  getInstallObservedSnapshot,
   getInstallPromptSnapshot,
   requestInstall,
   subscribeInstallPrompt,
@@ -15,32 +15,6 @@ import {
   standaloneInstallCompleted,
 } from '../../lib/standaloneBoot.js'
 
-async function fileToSquarePng(file, size = 512) {
-  const bmp = await createImageBitmap(file)
-  try {
-    const side = Math.min(bmp.width, bmp.height)
-    const canvas = document.createElement('canvas')
-    canvas.width = canvas.height = size
-    canvas.getContext('2d').drawImage(
-      bmp,
-      (bmp.width - side) / 2,
-      (bmp.height - side) / 2,
-      side,
-      side,
-      0,
-      0,
-      size,
-      size,
-    )
-    return await new Promise((resolve, reject) => canvas.toBlob(
-      blob => blob ? resolve(blob) : reject(new Error('encode failed')),
-      'image/png',
-    ))
-  } finally {
-    bmp.close?.()
-  }
-}
-
 function wasDismissed(slug) {
   try { return sessionStorage.getItem(`mobius:install-dismissed:${slug}`) === '1' }
   catch { return false }
@@ -51,31 +25,37 @@ function rememberDismissed(slug) {
   catch { /* session storage is optional */ }
 }
 
-export default function StandaloneInstallCard({ app, forceOpen, onClose, onIconUpdated }) {
+export default function StandaloneInstallCard({ app, forceOpen, onClose }) {
   const installState = useSyncExternalStore(
     subscribeInstallPrompt,
     getInstallPromptSnapshot,
     getInstallPromptSnapshot,
   )
+  // Only an install this page actually watched happen may be announced. iOS
+  // reports standalone display mode inside the in-app browser it opens from a
+  // PWA, so the boot-time guess said "installed" to someone who was mid-install.
+  const installObserved = useSyncExternalStore(
+    subscribeInstallPrompt,
+    getInstallObservedSnapshot,
+    getInstallObservedSnapshot,
+  )
   const platform = detectInstallPlatform()
-  const copy = installCopyForPlatform(platform, installState === 'installed', app.name)
+  const copy = installCopyForPlatform(platform, installObserved, app.name)
   const [open, setOpen] = useState(() => initiallyOpenStandaloneInstallCard({
     installState,
     forceOpen,
     dismissed: wasDismissed(app.slug),
   }))
   // iOS has no install API, so its steps are the whole answer rather than an
-  // extra detail — show them on arrival instead of behind a "Show me" tap.
-  // Other platforms keep the prompt primary and reveal steps only if it fails.
+  // extra detail — always show them on arrival. They stay correct whether or
+  // not the app is already on the home screen (adding twice is harmless),
+  // which is exactly why they are safe to show without knowing. Other
+  // platforms keep the native prompt primary and reveal steps only if it fails.
   const [showInstructions, setShowInstructions] = useState(
-    () => installState === 'manual' && (forceOpen || platform.ios),
+    () => platform.ios || (installState === 'manual' && forceOpen),
   )
-  const [uploading, setUploading] = useState(false)
-  const [message, setMessage] = useState('')
-  const [iconVersion, setIconVersion] = useState(app.updated_at || '0')
   const dialogRef = useRef(null)
   const primaryRef = useRef(null)
-  const fileRef = useRef(null)
   const previousInstallStateRef = useRef(installState)
 
   useEffect(() => {
@@ -101,33 +81,8 @@ export default function StandaloneInstallCard({ app, forceOpen, onClose, onIconU
     onClose?.()
   }
 
-  async function chooseIcon(event) {
-    const file = event.target.files?.[0]
-    event.target.value = ''
-    if (!file) return
-    setUploading(true)
-    setMessage('')
-    try {
-      const png = await fileToSquarePng(file)
-      const response = await apiFetch(`/apps/${app.id}/icon`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'image/png' },
-        body: png,
-      })
-      if (!response.ok) throw new Error(`icon upload ${response.status}`)
-      const version = String(Date.now())
-      setIconVersion(version)
-      setMessage('Icon updated')
-      onIconUpdated?.(version)
-    } catch {
-      setMessage("That image couldn't be saved. Try a PNG or JPEG.")
-    } finally {
-      setUploading(false)
-    }
-  }
-
   async function install() {
-    if (installState === 'installed') {
+    if (installObserved) {
       close('installed')
       return
     }
@@ -155,7 +110,15 @@ export default function StandaloneInstallCard({ app, forceOpen, onClose, onIconU
         aria-labelledby="standalone-install-title"
         onClick={event => event.stopPropagation()}
       >
-        {installState === 'installed' ? (
+        <button
+          className="standalone-install__close"
+          type="button"
+          aria-label="Close"
+          onClick={() => close('dismiss')}
+        >
+          ×
+        </button>
+        {installObserved ? (
           <>
             <div className="standalone-install__success" aria-hidden="true">✓</div>
             <h1 id="standalone-install-title">{app.name} is on your home screen</h1>
@@ -171,36 +134,24 @@ export default function StandaloneInstallCard({ app, forceOpen, onClose, onIconU
         ) : (
           <>
             <div className="standalone-install__identity">
-              <button
-                className="standalone-install__icon-button"
-                type="button"
-                aria-label="Change app icon"
-                disabled={uploading}
-                onClick={() => fileRef.current?.click()}
-              >
-                <img
-                  src={`/apps/${encodeURIComponent(app.slug)}/icon-192.png?v=${encodeURIComponent(iconVersion)}`}
-                  alt=""
-                />
-                <span aria-hidden="true">✎</span>
-              </button>
+              <img
+                className="standalone-install__icon"
+                src={`/apps/${encodeURIComponent(app.slug)}/icon-192.png?v=${encodeURIComponent(app.updated_at || '0')}`}
+                alt=""
+              />
               <div>
                 <h1 id="standalone-install-title">Install {app.name}</h1>
                 <p>Keep it one tap away, without opening the Möbius workspace first.</p>
               </div>
             </div>
-            <p className="standalone-install__hint">
-              Tap the icon to customise it, or keep the current one.
-            </p>
             {showInstructions && (platform.ios ? (
               // This document's manifest is the app's, so Add to Home Screen
               // here produces the app — the whole reason the shell sends
               // people to this page. The arrow points at Safari's toolbar.
               <div className="standalone-install__steps" role="status">
                 <p>
-                  Tap the <strong>Share</strong> button below{' '}
-                  <span aria-hidden="true">(the square with an up-arrow)</span>,
-                  then choose <strong>Add to Home Screen</strong>.
+                  Tap the <strong>Share</strong> button below, then choose{' '}
+                  <strong>Add to Home Screen</strong>.
                 </p>
                 <span className="standalone-install__arrow" aria-hidden="true">↓</span>
               </div>
@@ -210,9 +161,7 @@ export default function StandaloneInstallCard({ app, forceOpen, onClose, onIconU
                 <span>{copy.body}</span>
               </div>
             ))}
-            {message && <div className="standalone-install__message" role="status">{message}</div>}
             <div className="standalone-install__actions">
-              <button type="button" onClick={() => close('later')}>Maybe later</button>
               <button
                 ref={primaryRef}
                 className="standalone-install__primary"
@@ -222,13 +171,6 @@ export default function StandaloneInstallCard({ app, forceOpen, onClose, onIconU
                 {installState === 'ready' ? 'Install' : (showInstructions ? 'Got it' : copy.ctaLabel)}
               </button>
             </div>
-            <input
-              ref={fileRef}
-              type="file"
-              accept="image/png,image/jpeg,image/webp"
-              hidden
-              onChange={chooseIcon}
-            />
           </>
         )}
       </section>

--- a/frontend/src/lib/__tests__/installPrompt.test.js
+++ b/frontend/src/lib/__tests__/installPrompt.test.js
@@ -88,3 +88,38 @@ test('subscribers are notified when prompt availability changes', async () => {
 
   assert.equal(changes, 2)
 })
+
+// iOS reports standalone display mode inside the in-app browser it opens from
+// an installed PWA — a page that is plainly not the installed app. That guess
+// is fine for suppressing an install offer and catastrophic for announcing
+// success: it told someone mid-install that their app was already added.
+test('a standalone-looking launch suppresses the offer but claims nothing', async () => {
+  const installPrompt = await freshModule()
+  installPrompt.startInstallPromptCapture(makeTarget({ standalone: true }))
+
+  assert.equal(installPrompt.getInstallPromptSnapshot(), 'installed')
+  assert.equal(installPrompt.getInstallObservedSnapshot(), false)
+})
+
+test('only a witnessed appinstalled event may be announced', async () => {
+  const installPrompt = await freshModule()
+  const target = makeTarget()
+  installPrompt.startInstallPromptCapture(target)
+
+  assert.equal(installPrompt.getInstallObservedSnapshot(), false)
+  target.dispatch('appinstalled')
+  assert.equal(installPrompt.getInstallObservedSnapshot(), true)
+  assert.equal(installPrompt.getInstallPromptSnapshot(), 'installed')
+})
+
+test('subscribers are notified when an install is witnessed', async () => {
+  const installPrompt = await freshModule()
+  const target = makeTarget()
+  installPrompt.startInstallPromptCapture(target)
+  let notified = 0
+  installPrompt.subscribeInstallPrompt(() => { notified += 1 })
+
+  target.dispatch('appinstalled')
+  assert.equal(notified, 1)
+  assert.equal(installPrompt.getInstallObservedSnapshot(), true)
+})

--- a/frontend/src/lib/installPrompt.js
+++ b/frontend/src/lib/installPrompt.js
@@ -11,7 +11,21 @@ import { isStandaloneDisplay } from '../utils/installPlatform.js'
 
 let captureStarted = false
 let deferredPrompt = null
-let installed = false
+// Two different questions, deliberately kept apart.
+//
+// `launchedInstalled` — "does this document look like it is running AS an
+// installed app?" Inferred from display mode at boot. Good enough to stop the
+// product nagging someone to install what they are already using, and safe
+// when wrong in that direction.
+//
+// `observedInstall` — "did the browser TELL us an install just happened?"
+// Only `appinstalled` sets it. Nothing else may, because no browser on iOS
+// answers "is this app on the home screen"; the in-app browser view iOS opens
+// from a PWA even reports standalone display mode. Inferring installation
+// there made the card congratulate people mid-install. A claim that specific
+// needs evidence that specific.
+let launchedInstalled = false
+let observedInstall = false
 const listeners = new Set()
 
 function emitChange() {
@@ -23,10 +37,10 @@ export function startInstallPromptCapture(
 ) {
   if (!target || captureStarted) return
   captureStarted = true
-  installed = isStandaloneDisplay(target)
+  launchedInstalled = isStandaloneDisplay(target)
 
   target.addEventListener('beforeinstallprompt', (event) => {
-    if (installed) return
+    if (launchedInstalled) return
     event.preventDefault?.()
     deferredPrompt = event
     emitChange()
@@ -34,15 +48,25 @@ export function startInstallPromptCapture(
 
   target.addEventListener('appinstalled', () => {
     deferredPrompt = null
-    installed = true
+    observedInstall = true
     emitChange()
   })
 }
 
 export function getInstallPromptSnapshot() {
-  if (installed) return 'installed'
+  if (launchedInstalled || observedInstall) return 'installed'
   if (deferredPrompt) return 'ready'
   return 'manual'
+}
+
+/**
+ * True only when this page WATCHED an install complete. Use this — never the
+ * snapshot above — to tell someone their app is on the home screen. The
+ * snapshot answers "should we stop offering to install", which tolerates a
+ * guess; this answers "did it work", which does not.
+ */
+export function getInstallObservedSnapshot() {
+  return observedInstall
 }
 
 export function subscribeInstallPrompt(listener) {


### PR DESCRIPTION
## The problem

The install card told people their app was already on the Home Screen while they were still installing it.

There is no reliable way to ask iOS whether a given app is on the Home Screen — Apple exposes nothing, and `getInstalledRelatedApps` is Chromium-only. The card inferred it from display mode, which iOS *also* reports inside the in-app browser it opens from a PWA. So the guess was wrong precisely where someone was mid-install, and the card congratulated them instead of instructing them.

## The change

Stop asking a question that has no answer. Two questions that were conflated are now separate:

- **"Does this document look like an installed app?"** — a boot-time display-mode guess. Still used to stop offering an install to someone already using one, where being wrong is harmless.
- **"Did the browser tell us an install happened?"** — set only by `appinstalled`. The success message is the only thing allowed to read it.

iOS never fires `appinstalled`, so on iPhone that claim cannot appear at all. Its place is taken by the Share steps, which are correct whether or not the app is already installed — adding twice is harmless — which is exactly why they are safe to show without knowing the answer.

## Also: one action per card

Both cards had accumulated a worded dismissal competing with the one action worth taking.

- "Done" on the hand-off card and "Maybe later" on the standalone card become a corner ×.
- The Share step drops "(the square with an up-arrow)" — a gloss on a button everyone recognises, which pushed the actual instruction onto a third line.
- The standalone card's icon uploader is removed. Name and icon are chosen before that page is ever reached, so it was a second way to do an already-done job sitting in the middle of the one screen whose purpose is a single instruction. The icon remains as identity, not a control.

One CSS note worth flagging for review: `.standalone-install button` outranks a bare class, so the corner × matches that specificity or it inherits the 42px pill border it must not have.

## Testing

New unit tests pin the rule that a standalone-looking launch suppresses the install offer but claims nothing, and that only a witnessed `appinstalled` may be announced.

## Review shape

Third of a four-part stack.