### PR TITLE
standalone: remove the Möbius return pill and streamline the install card

### DIFF
--- a/frontend/src/components/StandaloneApp/StandaloneApp.css
+++ b/frontend/src/components/StandaloneApp/StandaloneApp.css
@@ -6,39 +6,6 @@
   color: var(--text, #e8e8e8);
 }
 
-.standalone-app__mobius-link {
-  position: fixed;
-  right: max(14px, env(safe-area-inset-right));
-  bottom: max(14px, env(safe-area-inset-bottom));
-  z-index: 20;
-  display: flex;
-  align-items: center;
-  gap: 7px;
-  min-height: 42px;
-  padding: 0 13px;
-  border: 1px solid color-mix(in srgb, var(--text, #fff) 14%, transparent);
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--bg, #0d0d0d) 86%, transparent);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.22);
-  color: var(--text, #fff);
-  font: 600 12px/1 var(--font, system-ui, sans-serif);
-  text-decoration: none;
-  backdrop-filter: blur(14px);
-  opacity: 0.72;
-  transition: opacity 160ms ease, transform 160ms ease;
-}
-
-.standalone-app__mobius-link:hover,
-.standalone-app__mobius-link:focus-visible {
-  opacity: 1;
-  transform: translateY(-1px);
-}
-
-.standalone-app--immersive .standalone-app__mobius-link {
-  opacity: 0;
-  pointer-events: none;
-}
-
 .standalone-app__update {
   position: fixed;
   top: max(14px, env(safe-area-inset-top));
@@ -129,9 +96,9 @@
 
 .standalone-install {
   position: relative;
-  width: min(430px, 100%);
+  width: min(370px, 100%);
   max-height: calc(100dvh - 32px);
-  padding: 22px;
+  padding: 30px 26px 26px;
   overflow: auto;
   border: 1px solid var(--border, #333);
   border-radius: 20px;
@@ -142,11 +109,11 @@
 
 .standalone-install__identity {
   display: flex;
+  flex-direction: column;
   align-items: center;
   gap: 14px;
 }
 
-.standalone-install__identity p,
 .standalone-app--message p {
   margin: 5px 0 0;
   color: var(--muted, #aaa);
@@ -155,12 +122,19 @@
 }
 
 .standalone-install__icon {
-  flex: 0 0 64px;
-  width: 64px;
-  height: 64px;
+  width: 72px;
+  height: 72px;
   display: block;
-  border-radius: 15px;
+  border-radius: 21px;
   object-fit: cover;
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.38);
+}
+
+.standalone-install__identity h1 {
+  text-align: center;
+  font-size: 19px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
 }
 
 .standalone-install__instructions {
@@ -179,26 +153,19 @@
 
 .standalone-install__instructions strong { color: var(--text, #fff); }
 
-/* iOS Share steps. Sized as primary content, not as a footnote: on iPhone
-   this is the only instruction that matters, and the arrow below it points
-   down at the real Share button in Safari's toolbar. */
+/* The iOS instruction is the card's body, not an inset panel: on iPhone it is
+   the only thing the card has to say, so it gets the room rather than a border. */
 .standalone-install__steps {
-  margin-top: 14px;
-  padding: 14px 15px 12px;
-  border: 1px solid color-mix(in srgb, var(--accent, #a78bfa) 32%, var(--border, #333));
-  border-radius: 12px;
-  background: color-mix(in srgb, var(--accent, #a78bfa) 8%, transparent);
-}
-
-.standalone-install__steps p {
-  margin: 0;
-  color: var(--text, #fff);
-  font-size: 14px;
-  line-height: 1.5;
+  margin: 18px 0 0;
+  text-align: center;
+  text-wrap: balance;
+  color: var(--muted, #aaa);
+  font-size: 15px;
+  line-height: 1.55;
 }
 
 .standalone-install__steps strong {
-  color: var(--accent, #a78bfa);
+  color: var(--text, #fff);
   font-weight: 600;
 }
 
@@ -206,9 +173,9 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 32px;
-  height: 32px;
-  margin: 12px auto 0;
+  width: 34px;
+  height: 34px;
+  margin: 20px auto 2px;
   border-radius: 999px;
   border: 1px solid color-mix(in srgb, var(--accent, #a78bfa) 34%, var(--border, #333));
   background: color-mix(in srgb, var(--accent, #a78bfa) 10%, transparent);
@@ -273,7 +240,3 @@
 
 .standalone-install__success + h1 { text-align: center; }
 .standalone-install__success ~ .standalone-install__primary { display: block; margin: 18px auto 0; }
-
-@media (prefers-reduced-motion: reduce) {
-  .standalone-app__mobius-link { transition: none; }
-}

--- a/frontend/src/components/StandaloneApp/StandaloneApp.css
+++ b/frontend/src/components/StandaloneApp/StandaloneApp.css
@@ -193,7 +193,7 @@
   .standalone-install__arrow { animation: none; }
 }
 
-.standalone-install__actions { margin-top: 18px; }
+.standalone-install__actions { margin-top: 18px; justify-content: center; }
 
 /* Corner dismissal, replacing a worded "Maybe later" that competed with the
    one action worth taking. Larger touch target than the glyph it draws. */

--- a/frontend/src/components/StandaloneApp/StandaloneApp.jsx
+++ b/frontend/src/components/StandaloneApp/StandaloneApp.jsx
@@ -204,15 +204,6 @@ export default function StandaloneApp({ initialApp }) {
         onAppError={(_id, error, chatId) => setCrash({ error, chatId })}
       />
 
-      <a
-        className="standalone-app__mobius-link"
-        href={shellUrl({ app: app.id })}
-        aria-label={`Open ${app.name} in Möbius`}
-      >
-        <span aria-hidden="true">∞</span>
-        <span>Open in Möbius</span>
-      </a>
-
       {updateAvailable && (
         <button
           className="standalone-app__update"

--- a/frontend/src/components/StandaloneApp/StandaloneApp.jsx
+++ b/frontend/src/components/StandaloneApp/StandaloneApp.jsx
@@ -184,7 +184,7 @@ export default function StandaloneApp({ initialApp }) {
   }
 
   return (
-    <main className={`standalone-app${immersive ? ' standalone-app--immersive' : ''}`}>
+    <main className="standalone-app">
       <AppCanvas
         ref={canvasRef}
         appId={app.id}

--- a/frontend/src/components/StandaloneApp/StandaloneInstallCard.jsx
+++ b/frontend/src/components/StandaloneApp/StandaloneInstallCard.jsx
@@ -98,6 +98,13 @@ export default function StandaloneInstallCard({ app, forceOpen, onClose }) {
     if (result.outcome !== 'accepted') setShowInstructions(true)
   }
 
+  // The action button earns its place only when it can DO something: fire a
+  // native install prompt, or reveal guidance not yet on screen. On iPhone
+  // neither is ever true — there is no install API and the steps show on
+  // arrival — so the card ends at the sentence rather than at a button whose
+  // only effect is to close a dialog that already has a close.
+  const showAction = installState === 'ready' || !showInstructions
+
   if (!open) return null
 
   return (
@@ -111,6 +118,7 @@ export default function StandaloneInstallCard({ app, forceOpen, onClose }) {
         onClick={event => event.stopPropagation()}
       >
         <button
+          ref={showAction || installObserved ? null : primaryRef}
           className="standalone-install__close"
           type="button"
           aria-label="Close"
@@ -139,38 +147,39 @@ export default function StandaloneInstallCard({ app, forceOpen, onClose }) {
                 src={`/apps/${encodeURIComponent(app.slug)}/icon-192.png?v=${encodeURIComponent(app.updated_at || '0')}`}
                 alt=""
               />
-              <div>
-                <h1 id="standalone-install-title">Install {app.name}</h1>
-                <p>Keep it one tap away, without opening the Möbius workspace first.</p>
-              </div>
+              <h1 id="standalone-install-title">Install {app.name}</h1>
             </div>
             {showInstructions && (platform.ios ? (
-              // This document's manifest is the app's, so Add to Home Screen
-              // here produces the app — the whole reason the shell sends
-              // people to this page. The arrow points at Safari's toolbar.
-              <div className="standalone-install__steps" role="status">
-                <p>
-                  Tap the <strong>Share</strong> button below, then choose{' '}
-                  <strong>Add to Home Screen</strong>.
-                </p>
-                <span className="standalone-install__arrow" aria-hidden="true">↓</span>
-              </div>
+              // On iPhone the sentence IS the card, so it gets no box of its
+              // own — a bordered panel inside a bordered card is nesting that
+              // buys nothing. This document's manifest is the app's, so Add to
+              // Home Screen here produces the app, and the arrow points down
+              // at the real Share button in Safari's toolbar.
+              <p className="standalone-install__steps">
+                Tap the <strong>Share</strong> button below, then choose{' '}
+                <strong>Add to Home Screen</strong>.
+              </p>
             ) : (
               <div className="standalone-install__instructions" role="status">
                 <strong>{copy.summary}</strong>
                 <span>{copy.body}</span>
               </div>
             ))}
-            <div className="standalone-install__actions">
-              <button
-                ref={primaryRef}
-                className="standalone-install__primary"
-                type="button"
-                onClick={install}
-              >
-                {installState === 'ready' ? 'Install' : (showInstructions ? 'Got it' : copy.ctaLabel)}
-              </button>
-            </div>
+            {platform.ios && showInstructions && (
+              <span className="standalone-install__arrow" aria-hidden="true">↓</span>
+            )}
+            {showAction && (
+              <div className="standalone-install__actions">
+                <button
+                  ref={primaryRef}
+                  className="standalone-install__primary"
+                  type="button"
+                  onClick={install}
+                >
+                  {installState === 'ready' ? 'Install' : copy.ctaLabel}
+                </button>
+              </div>
+            )}
           </>
         )}
       </section>

--- a/frontend/src/components/StandaloneApp/StandaloneInstallCard.jsx
+++ b/frontend/src/components/StandaloneApp/StandaloneInstallCard.jsx
@@ -56,6 +56,7 @@ export default function StandaloneInstallCard({ app, forceOpen, onClose }) {
   )
   const dialogRef = useRef(null)
   const primaryRef = useRef(null)
+  const closeRef = useRef(null)
   const previousInstallStateRef = useRef(installState)
 
   useEffect(() => {
@@ -86,16 +87,24 @@ export default function StandaloneInstallCard({ app, forceOpen, onClose }) {
       close('installed')
       return
     }
+    // `showAction` gates this button out once instructions are on screen, so
+    // the only reachable case here is revealing them for the first time.
     if (installState !== 'ready') {
-      if (showInstructions) {
-        close('instructions-read')
-        return
-      }
-      setShowInstructions(true)
+      revealInstructions()
       return
     }
     const result = await requestInstall()
-    if (result.outcome !== 'accepted') setShowInstructions(true)
+    if (result.outcome !== 'accepted') revealInstructions()
+  }
+
+  // Revealing instructions unmounts the button that was just activated —
+  // `showAction` flips false. Focus would land on <body> while the dialog is
+  // open and its siblings are inert, stranding keyboard and screen-reader
+  // users outside a trap whose Tab handler matches neither edge. Hand focus to
+  // the control that survives.
+  function revealInstructions() {
+    setShowInstructions(true)
+    queueMicrotask(() => closeRef.current?.focus())
   }
 
   // The action button earns its place only when it can DO something: fire a
@@ -118,7 +127,7 @@ export default function StandaloneInstallCard({ app, forceOpen, onClose }) {
         onClick={event => event.stopPropagation()}
       >
         <button
-          ref={showAction || installObserved ? null : primaryRef}
+          ref={closeRef}
           className="standalone-install__close"
           type="button"
           aria-label="Close"


### PR DESCRIPTION
## Two changes, both about restraint

### The "Open in Möbius" pill

An installed app carried a floating "Open in Möbius" pill, fixed to the bottom-right corner, sitting **on top of the app's own content**. In a globe app it covered a row of the country list.

It offered a trip back to the workspace that the Home Screen icon and the browser already provide. An installed app should look like an app, not like a page with a way out.

I want to be straight that this one is a judgement call rather than a defect, and it is the last layer of the stack precisely so it can be declined without blocking anything before it. If the pill is load-bearing for navigation patterns I am not seeing, drop this commit and the rest of the stack is unaffected.

### The install card

The card now carries exactly what it needs: the icon, the app's name, the one sentence that does the work, and a way to close.

- **The tagline goes.** "Keep it one tap away" argued for a decision already made by everyone who reached that page.
- **The instruction loses its panel.** A bordered box inside a bordered card is nesting that buys nothing once the sentence *is* the card's body. It gets the room instead of the border, centred and balanced.
- **Identity stacks and centres**, icon at 72px with a soft drop, so the card reads top to bottom in one line of sight rather than as a header plus contents.
- **The action button appears only when it can do something** — fire a native install prompt, or reveal guidance not yet on screen. On iPhone neither is ever true, so the card ends at the sentence rather than at a button whose only effect was closing a dialog that already has a close. Focus follows to whichever control is actually rendered.

The card narrows to 370px with more vertical padding: less content wants less width, or the sentence stretches into a line too long to scan.

## Review shape

Fourth and last of the stack, and the most opinionated. Declining it costs nothing earlier in the chain.