### PR TITLE
Enforce reader ownership across chat scroll work

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -517,7 +517,7 @@ automatically armed by installing Möbius.
 
 ## Chat scroll + steer contract
 
-**Owner-authoritative contract — v1.12 (2026-07-31).** This section is the
+**Owner-authoritative contract — v1.13 (2026-08-01).** This section is the
 canonical source of truth for how a chat scrolls and steers. When implementation,
 comments, and this contract disagree, the implementation/comments are the bug:
 fix behavior to match this contract. If a real case is unspecified or the desired
@@ -536,9 +536,11 @@ and attaches their rule ids to new diagnostic chats. The Playwright lock-in spec
   position). Auto-scroll engages only through (a) the gesture-gated scroll handler
   after the user manually reaches an ordinary bottom with no reservation remaining,
   or (b) the live-send pin handoff when the streaming reply has consumed its exact
-  reserved room. The physical bottom while reservation remains is the prompt's pin
-  target, not the real-content tail: reaching it preserves (or repairs) pin hold and
-  waits for the spacer-exhaustion handoff. A viewport /
+  reserved room. Only a send may create `PIN_USER_MSG`. The physical bottom while
+  reservation remains is an exact reader-owned `ANCHOR_AT` position—including a
+  negative row offset when the viewport is inside reserved reply room—not a pin or
+  the real-content tail. Reaching it must preserve that exact physical position and
+  must never manufacture the pin's spacer-exhaustion handoff. A viewport /
   keyboard change, foreground return, mount, or chat restoration must never create
   auto-scroll.
 - **R1 — Stable latest-turn reservation.** Dynamic bottom spacer derives from the
@@ -582,7 +584,9 @@ and attaches their rule ids to new diagnostic chats. The Playwright lock-in spec
   mobile-keyboard open/close cycle even though the full-height reservation makes its
   scroll position temporarily look away from the physical bottom; viewport geometry
   is not reader intent, so apart from the explicit filled-reservation handoff, only a
-  gesture-gated reader scroll may retire the pin.
+  gesture-gated reader scroll may retire the pin. A retired or saved pin restores
+  only as an ordinary `ANCHOR_AT`; pin ownership is never reconstructed by layout,
+  lifecycle restoration, or a reader gesture.
   Terminal promotion makes this decision against the committed settled DOM,
   before paint, so a final browser clamp cannot race the pin or its exact
   filled-reservation handoff.
@@ -629,6 +633,14 @@ and attaches their rule ids to new diagnostic chats. The Playwright lock-in spec
   geometry, while a disclosure first settles any preceding gesture and then owns
   layout caused by its own expansion/collapse. A bounded dead-man remains the final
   escape hatch for any interrupted no-scroll gesture.
+  The first actual scroll event owned by each gesture also advances one monotonic
+  reader-intent generation. Every direct scroll write and every indirect geometry
+  write that can clamp scrolling (dynamic spacer height and composer clearance)
+  must commit through the scroll controller only when both its captured generation
+  is still current and the gesture gate is open. Deferred layout captured before a
+  newer gesture is rejected; once that gesture settles, the controller adopts the
+  current semantic location and performs one fresh geometry reconciliation. Waiting
+  for the timing gate to expire never gives stale work its authority back.
   A marked Q&A custom-answer field is the deliberate exception to "ordinary
   typing cannot scroll": changing its value can grow the field and cause the
   browser to move the transcript to keep the native caret visible. Only an
@@ -694,8 +706,7 @@ path means routing it through the same entries rather than inventing another rul
 | First direct/queued/steered user row becomes visible | any | `PIN_USER_MSG` | New row to top |
 | Later send submitted at real-content tail (mode may be one frame stale) | any | `PIN_USER_MSG` | New row to top |
 | Later send submitted anywhere else | hold or stale follow | `ANCHOR_AT`/existing hold | None |
-| Reader reaches physical bottom while latest-user reservation remains and turn is live | any | armed `PIN_USER_MSG` | User-owned; then keep prompt fixed |
-| Reader reaches physical bottom while latest-user reservation remains and turn is idle | any | settled `PIN_USER_MSG` | User-owned; keep prompt fixed |
+| Reader reaches physical bottom while latest-user reservation remains | any | exact `ANCHOR_AT` | User-owned; preserve the numeric physical position, including negative anchor offset |
 | Reader reaches bottom with no reservation remaining | any | `FOLLOW_BOTTOM` | User-owned |
 | Reader scrolls manually away from bottom | any | `ANCHOR_AT` | User-owned |
 | Reply grows while an armed live pin still has reserved room | pin hold | same pin hold | Keep prompt fixed |
@@ -717,10 +728,14 @@ Controller structure is part of the contract, not an implementation detail:
 - `ChatView` may read `modeRef` for a submit snapshot but must not assign it.
   It emits send, queue, pagination, and lifecycle events through the semantic
   methods returned by `useScrollMode`.
-- Every live mode mutation goes through `transitionMode`; every mode-owned
-  `scrollTop` write goes through `writeMode`. The exported `applyMode` executor
-  is for the controller and pure unit tests, not a second live writer.
-- `useScrollMode` is the sole writer of `.spacer-dynamic` height. The write is
+- Every live mode mutation goes through `transitionMode`, whose entry guard permits
+  new pins only from send and new follow only from an unreserved-bottom gesture or
+  an already-armed pin's filled-reservation handoff. Every mode-owned `scrollTop`
+  write goes through `writeMode`. The exported `applyMode` executor is for the
+  controller and pure unit tests, not a second live writer.
+- `useScrollMode` is the sole writer of `.spacer-dynamic` height and the
+  composer-clearance CSS geometry. Those indirect writes and every `writeMode`
+  call share R5's reader-generation commit gate. Spacer height is
   derived from the latest user row and exact tail deficit;
   disclosure helpers and renderers may preserve an on-screen anchor but may never
   prime, enlarge, or unwind spacer themselves.

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -473,19 +473,11 @@ export default function ChatView({
   // current() to fire the bar's hidden picker. ChatInputBar's layout
   // effect installs the function.
   const attachTriggerRef = useRef(null)
-  // Refs for the absolutely-positioned foot. A ResizeObserver
-  // measures `.chat__foot` and publishes its height as `--composer-h`
-  // on `.chat`, which `.chat__list` reads for its bottom padding so
-  // chips/queue/multi-line growth keep the last message visible
-  // above the pill.
+  // Refs for the absolutely-positioned foot. Its ResizeObserver notifies the
+  // scroll controller, which owns publishing composer clearance together with
+  // every other indirect scroll-geometry write.
   const chatRef = useRef(null)
   const footRef = useRef(null)
-  const measureComposerHeight = useCallback(() => {
-    const chatEl = chatRef.current
-    const footEl = footRef.current
-    if (!chatEl || !footEl) return
-    chatEl.style.setProperty('--composer-h', `${footEl.offsetHeight}px`)
-  }, [])
 
   // One explicit Shell-to-composer handoff owns both New-chat focus and drafts
   // supplied by app navigation. Storage restores unmounted chats; applying the
@@ -657,12 +649,12 @@ export default function ChatView({
     scrollRef,
     spacerRef,
     lastUserMsgRef,
-    syncComposerGeometry: measureComposerHeight,
+    chatRef,
+    footRef,
     messages,
     messagesRef,
     pendingMessagesLength: pendingQueue.pendingMessages.length,
     loadingOlderRef: loadingOlder,
-    turnRunning: sending || serverRunning,
     initialEntryPhase,
   })
 
@@ -1443,11 +1435,9 @@ export default function ChatView({
     if (el && !hidden) reconcileComposerTextarea(el, input)
   }, [chatId, hidden, input])
 
-  // Publish `.chat__foot`'s rendered height as `--composer-h` on
-  // `.chat`. `.chat__list` reads this var for its bottom padding so
-  // the last message always clears the absolutely-positioned pill
-  // — chips, queue tray, multi-line growth all push the clearance
-  // in lockstep.
+  // Notify the scroll owner when `.chat__foot` geometry may have changed.
+  // The controller publishes the matching list clearance and spacer in one
+  // guarded layout pass so an observer cannot move the reader indirectly.
   useEffect(() => {
     const footEl = footRef.current
     if (!footEl) return

--- a/frontend/src/components/ChatView/__tests__/chatContract.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatContract.test.js
@@ -72,7 +72,7 @@ test('owner contract freezes question answers without locking keyboard movement'
     new URL('../../../../../ARCHITECTURE.md', import.meta.url),
     'utf8',
   )
-  assert.match(architecture, /Owner-authoritative contract — v1\.12 \(2026-07-31\)/)
+  assert.match(architecture, /Owner-authoritative contract — v1\.13 \(2026-08-01\)/)
   assert.match(
     architecture,
     /In-process question is answered \| any \| transient `ANCHOR_AT` over the prior mode; same active assistant row/,

--- a/frontend/src/components/ChatView/__tests__/scrollOwnership.test.js
+++ b/frontend/src/components/ChatView/__tests__/scrollOwnership.test.js
@@ -57,6 +57,16 @@ test('the sole spacer owner still exists (guard is not vacuous)', () => {
   assert.deepEqual(writers, [OWNER])
 })
 
+test('only the scroll owner publishes composer clearance geometry', () => {
+  const write = /style\.setProperty\(\s*['"]--composer-h['"]/
+  const writers = sourceFiles(chatViewDir).filter(({ full }) => (
+    write.test(readFileSync(full, 'utf8'))
+  )).map(f => f.name).sort()
+  assert.deepEqual(writers, [OWNER],
+    'composer clearance can clamp scrollTop indirectly, so route it through '
+    + 'the same reader-authority gate as spacer and direct scroll writes')
+})
+
 test('gesture scroll frames defer anchor, spacer, and persistence work until settle', () => {
   const start = ownerSource.indexOf('const onScroll = () => {')
   const end = ownerSource.indexOf(
@@ -86,15 +96,65 @@ test('gesture scroll frames defer anchor, spacer, and persistence work until set
   const settlePath = ownerSource.slice(settleStart, settleEnd)
   assert.ok(settleStart >= 0 && settleEnd > settleStart,
     'reader settlement path must remain discoverable')
-  assert.match(settlePath, /contentHoldModeFromScroll/)
-  assert.match(settlePath, /if \(settledAtBottom\)/)
+  assert.match(settlePath, /anchorModeFromScroll/)
+  assert.match(settlePath, /modeAfterReaderGesture/)
+  assert.match(settlePath, /hasReservedTail:\s*spacerH\s*>\s*1/)
   assert.match(settlePath, /persistMode\(\)/)
-  assert.match(settlePath, /sizeSpacer\(\)/)
+  assert.match(settlePath, /sizeSpacer\(currentAuthority\(\)\)/)
+  assert.doesNotMatch(settlePath, /PIN_USER_MSG|contentHoldModeFromScroll/,
+    'a reader gesture may hold or follow but must never recreate pin authority')
   assert.doesNotMatch(
     settlePath,
     /scrollEl\.scrollHeight\s*>\s*scrollEl\.clientHeight/,
     'a live spacer collapse must not leave the pre-gesture pin armed',
   )
+})
+
+test('every automatic geometry owner shares the reader-generation gate', () => {
+  const writeStart = ownerSource.indexOf('const writeMode = useCallback(')
+  const writeEnd = ownerSource.indexOf('const persistMode =', writeStart)
+  const writePath = ownerSource.slice(writeStart, writeEnd)
+  assert.match(writePath, /scrollAuthorityAllowsCommit/,
+    'direct scroll writes must reject stale generations')
+
+  const spacerStart = ownerSource.indexOf('function sizeSpacer(')
+  const spacerEnd = ownerSource.indexOf('function maybeApplyMode(', spacerStart)
+  const spacerPath = ownerSource.slice(spacerStart, spacerEnd)
+  assert.match(spacerPath, /layoutOwnsScroll\(authorityVersion\)/)
+  assert.ok(
+    spacerPath.indexOf('layoutOwnsScroll(authorityVersion)')
+      < spacerPath.indexOf("style.setProperty('--composer-h'"),
+    'composer clearance must be gated before it mutates layout',
+  )
+  assert.ok(
+    spacerPath.indexOf('layoutOwnsScroll(authorityVersion)')
+      < spacerPath.indexOf('spacerEl.style.height ='),
+    'spacer height must be gated before it mutates layout',
+  )
+
+  const terminalStart = ownerSource.indexOf('const settleStreamingPin =')
+  const terminalEnd = ownerSource.indexOf('const paneResized =', terminalStart)
+  const terminalPath = ownerSource.slice(terminalStart, terminalEnd)
+  assert.match(terminalPath, /terminalAuthorityVersion/)
+  assert.match(terminalPath, /scrollAuthorityAllowsCommit/,
+    'terminal rAF work must reject a later reader generation')
+
+  const hotStart = ownerSource.indexOf('const onScroll = () => {')
+  const hotEnd = ownerSource.indexOf(
+    "scrollEl.addEventListener('scroll', onScroll",
+    hotStart,
+  )
+  const hotPath = ownerSource.slice(hotStart, hotEnd)
+  assert.match(
+    hotPath,
+    /readerIntentAfterScroll\(\{/,
+    'actual scrolls must claim generations by input sequence, not quiet batch',
+  )
+
+  assert.match(terminalPath, /authority === 'wait'/)
+  assert.match(terminalPath, /requestAnimationFrame\(inspectCommittedLayout\)/,
+    'terminal settlement must wait through a no-scroll tap instead of retiring pin')
+  assert.doesNotMatch(terminalPath, /terminal:reader-owns/)
 })
 
 test('newer semantic actions cannot be overwritten by an older quiet settlement', () => {

--- a/frontend/src/components/ChatView/__tests__/scrollRepairDirection.test.js
+++ b/frontend/src/components/ChatView/__tests__/scrollRepairDirection.test.js
@@ -3,6 +3,13 @@ import assert from 'node:assert/strict'
 import {
   _anchorReapplyNeeded,
   _pinReapplyNeeded,
+  anchorModeFromScroll,
+  applyMode,
+  modeAfterReaderGesture,
+  modeForScrollTransition,
+  readerIntentAfterScroll,
+  scrollAuthorityAllowsCommit,
+  terminalLayoutAuthority,
 } from '../useScrollMode.js'
 
 test('anchor repair never moves backward over an unchanged reader position', () => {
@@ -44,4 +51,194 @@ test('pin repair never moves backward over an unchanged reader position', () => 
     ),
     false,
   )
+})
+
+test('reserved-bottom reader settlement replays the exact numeric position', () => {
+  const row = {
+    offsetTop: 500,
+    offsetHeight: 220,
+    dataset: { key: 'assistant-tail' },
+  }
+  const spacer = { offsetHeight: 1200 }
+  const scrollEl = {
+    scrollHeight: 1900,
+    scrollTop: 1200,
+    clientHeight: 700,
+    querySelector(selector) {
+      if (selector === '.spacer-dynamic') return spacer
+      if (selector === '[data-key="assistant-tail"]') return row
+      return null
+    },
+    querySelectorAll(selector) {
+      return selector === '.chat__msg[data-key]' ? [row] : []
+    },
+  }
+
+  const holdMode = anchorModeFromScroll(scrollEl)
+  assert.deepEqual(holdMode, {
+    kind: 'ANCHOR_AT',
+    key: 'assistant-tail',
+    offset: -700,
+  })
+  const settledMode = modeAfterReaderGesture({
+    reachedPhysicalBottom: true,
+    hasReservedTail: true,
+    holdMode,
+  })
+  assert.equal(settledMode, holdMode)
+
+  applyMode(scrollEl, settledMode)
+  assert.equal(scrollEl.scrollTop, 1200,
+    'settlement must not jump backward to the prompt or real-content tail')
+})
+
+test('only an unreserved reader bottom creates follow', () => {
+  const hold = { kind: 'ANCHOR_AT', key: 'a-1', offset: -300 }
+  assert.equal(modeAfterReaderGesture({
+    reachedPhysicalBottom: true,
+    hasReservedTail: true,
+    holdMode: hold,
+  }), hold)
+  assert.deepEqual(modeAfterReaderGesture({
+    reachedPhysicalBottom: true,
+    hasReservedTail: false,
+    holdMode: hold,
+  }), { kind: 'FOLLOW_BOTTOM' })
+  assert.equal(modeAfterReaderGesture({
+    reachedPhysicalBottom: false,
+    hasReservedTail: false,
+    holdMode: hold,
+  }), hold)
+})
+
+test('transition entry authority prevents layout and reader paths creating pins', () => {
+  const hold = { kind: 'ANCHOR_AT', key: 'a-1', offset: 30 }
+  const pin = { kind: 'PIN_USER_MSG', cid: 'c-2', followWhenFilled: true }
+  assert.equal(modeForScrollTransition(hold, pin, 'reader:hold-exact'), hold)
+  assert.equal(modeForScrollTransition(hold, pin, 'layout:mode-transition'), hold)
+  assert.equal(modeForScrollTransition(hold, pin, 'send:pin-user-message'), pin)
+})
+
+test('question viewport release restores only its captured base authority', () => {
+  const follow = { kind: 'FOLLOW_BOTTOM' }
+  const pin = { kind: 'PIN_USER_MSG', cid: 'c-2', followWhenFilled: true }
+  const followOverlay = {
+    kind: 'ANCHOR_AT',
+    key: 'q-1',
+    offset: 40,
+    questionSubmitViewportH: 720,
+    questionSubmitBaseMode: follow,
+  }
+  const pinOverlay = {
+    ...followOverlay,
+    questionSubmitBaseMode: pin,
+  }
+
+  assert.equal(modeForScrollTransition(
+    followOverlay,
+    follow,
+    'layout:question-viewport-release',
+  ), follow)
+  assert.equal(modeForScrollTransition(
+    pinOverlay,
+    pin,
+    'layout:question-viewport-release',
+  ), pin)
+  assert.equal(modeForScrollTransition(
+    followOverlay,
+    { kind: 'FOLLOW_BOTTOM' },
+    'layout:question-viewport-release',
+  ), followOverlay, 'an equivalent-looking mode is not the overlay\'s authority')
+})
+
+test('only real-bottom or an armed pin handoff can enter follow', () => {
+  const hold = { kind: 'ANCHOR_AT', key: 'a-1', offset: 30 }
+  const follow = { kind: 'FOLLOW_BOTTOM' }
+  const armedPin = {
+    kind: 'PIN_USER_MSG', cid: 'c-2', followWhenFilled: true,
+  }
+  const settledPin = { kind: 'PIN_USER_MSG', cid: 'c-2' }
+
+  assert.equal(modeForScrollTransition(hold, follow, 'layout:mode-transition'), hold)
+  assert.equal(
+    modeForScrollTransition(settledPin, follow, 'layout:reservation-filled'),
+    settledPin,
+  )
+  assert.equal(
+    modeForScrollTransition(armedPin, follow, 'layout:reservation-filled'),
+    follow,
+  )
+  assert.equal(
+    modeForScrollTransition(hold, follow, 'reader:real-content-bottom'),
+    follow,
+  )
+})
+
+test('a newer reader generation permanently rejects stale layout work', () => {
+  assert.equal(scrollAuthorityAllowsCommit({
+    capturedVersion: 4,
+    currentVersion: 5,
+    gestureWindowUntil: 0,
+    now: 100,
+  }), false, 'an expired timing gate cannot revive generation 4')
+  assert.equal(scrollAuthorityAllowsCommit({
+    capturedVersion: 5,
+    currentVersion: 5,
+    gestureWindowUntil: 120,
+    now: 100,
+  }), false, 'the current generation still yields during an active gesture')
+  assert.equal(scrollAuthorityAllowsCommit({
+    capturedVersion: 5,
+    currentVersion: 5,
+    gestureWindowUntil: 0,
+    now: 100,
+  }), true)
+})
+
+test('two gestures inside one quiet settlement advance two generations', () => {
+  const firstGesture = readerIntentAfterScroll({
+    gestureSequence: 11,
+    claimedSequence: null,
+    version: 4,
+  })
+  assert.deepEqual(firstGesture, {
+    claimedSequence: 11, version: 5,
+  })
+  assert.deepEqual(readerIntentAfterScroll({
+    gestureSequence: 11,
+    claimedSequence: firstGesture.claimedSequence,
+    version: firstGesture.version,
+  }), {
+    claimedSequence: 11, version: 5,
+  }, 'more scroll frames from the same input sequence share its generation')
+
+  const secondGesture = readerIntentAfterScroll({
+    gestureSequence: 12,
+    claimedSequence: firstGesture.claimedSequence,
+    version: firstGesture.version,
+  })
+  assert.deepEqual(secondGesture, {
+    claimedSequence: 12, version: 6,
+  }, 'a newer input sequence advances even before the shared quiet edge')
+})
+
+test('terminal settlement waits through taps but dies after actual reader movement', () => {
+  assert.equal(terminalLayoutAuthority({
+    capturedVersion: 7,
+    currentVersion: 7,
+    gestureWindowUntil: Number.POSITIVE_INFINITY,
+    now: 100,
+  }), 'wait', 'a tap/input gate alone cannot retire the armed pin')
+  assert.equal(terminalLayoutAuthority({
+    capturedVersion: 7,
+    currentVersion: 7,
+    gestureWindowUntil: 0,
+    now: 101,
+  }), 'commit', 'a no-scroll release resumes terminal layout settlement')
+  assert.equal(terminalLayoutAuthority({
+    capturedVersion: 7,
+    currentVersion: 8,
+    gestureWindowUntil: 0,
+    now: 102,
+  }), 'stale', 'actual reader movement permanently retires the older plan')
 })

--- a/frontend/src/components/ChatView/__tests__/sendLandingGeometry.test.js
+++ b/frontend/src/components/ChatView/__tests__/sendLandingGeometry.test.js
@@ -11,28 +11,32 @@ const controller = readFileSync(new URL('../useScrollMode.js', import.meta.url),
 const chatView = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8')
 
 test('send landing synchronizes composer geometry before reservation math', () => {
-  const sizeStart = controller.indexOf('function sizeSpacer()')
-  const sizeEnd = controller.indexOf('\n    function maybeApplyMode()', sizeStart)
+  const sizeStart = controller.indexOf('function sizeSpacer(')
+  const sizeEnd = controller.indexOf('\n    function maybeApplyMode(', sizeStart)
   assert.ok(sizeStart >= 0 && sizeEnd > sizeStart, 'sizeSpacer block exists')
 
   const sizeSpacer = controller.slice(sizeStart, sizeEnd)
-  const sync = sizeSpacer.indexOf('syncComposerGeometry?.()')
+  const gate = sizeSpacer.indexOf('layoutOwnsScroll(authorityVersion)')
+  const sync = sizeSpacer.indexOf("style.setProperty('--composer-h'")
   const measure = sizeSpacer.indexOf('_computeSpacerH(')
-  assert.ok(sync >= 0, 'sizeSpacer synchronizes the committed composer height')
+  assert.ok(gate >= 0 && sync > gate,
+    'sizeSpacer owns composer clearance behind reader authority')
   assert.ok(measure > sync,
     'composer height must be published before list/spacer geometry is measured')
 })
 
-test('ChatView gives its existing composer measurement to the scroll owner', () => {
+test('ChatView gives its composer elements to the scroll owner', () => {
   const callStart = chatView.indexOf('} = useScrollMode({')
   const callEnd = chatView.indexOf('\n  })', callStart)
   assert.ok(callStart >= 0 && callEnd > callStart, 'useScrollMode call exists')
   const args = chatView.slice(callStart, callEnd)
-  assert.match(args, /syncComposerGeometry:\s*measureComposerHeight/)
+  assert.match(args, /\bchatRef,\s*\n\s*footRef,/)
+  assert.doesNotMatch(chatView, /style\.setProperty\(\s*['"]--composer-h['"]/,
+    'ChatView must notify geometry changes without publishing scroll geometry')
 })
 
 test('footer resizes enter through the scroll owner instead of mutating geometry directly', () => {
-  const commentStart = chatView.indexOf("// Publish `.chat__foot`'s rendered height")
+  const commentStart = chatView.indexOf('// Notify the scroll owner when `.chat__foot`')
   const effectStart = chatView.indexOf('useEffect(() => {', commentStart)
   const effectEnd = chatView.indexOf('\n  useEffect(() => {', effectStart + 20)
   assert.ok(commentStart >= 0 && effectStart > commentStart && effectEnd > effectStart,
@@ -41,15 +45,15 @@ test('footer resizes enter through the scroll owner instead of mutating geometry
 
   assert.match(footerEffect, /new ResizeObserver\(applySoon\)/)
   assert.match(footerEffect, /composerResized\(\)/)
-  assert.doesNotMatch(footerEffect, /measureComposerHeight\(\)/,
+  assert.doesNotMatch(footerEffect, /style\.setProperty|measureComposerHeight/,
     'the footer observer must not bypass reader-gesture ownership')
 
   const bridgeStart = controller.indexOf('function runComposerResize()')
   const bridgeEnd = controller.indexOf('\n    composerResizeRunRef.current', bridgeStart)
   assert.ok(bridgeStart >= 0 && bridgeEnd > bridgeStart, 'composer resize bridge exists')
   const bridge = controller.slice(bridgeStart, bridgeEnd)
-  assert.match(bridge, /deferLayoutUntilReaderYields\(\)/)
-  assert.match(bridge, /syncLayout\(\)/)
+  assert.match(bridge, /deferLayoutUntilReaderYields\(authorityVersion\)/)
+  assert.match(bridge, /syncLayout\(\{ authorityVersion \}\)/)
 })
 
 test('gesture settlement replays deferred footer geometry and mode in one task', () => {
@@ -57,12 +61,12 @@ test('gesture settlement replays deferred footer geometry and mode in one task',
   const replayEnd = controller.indexOf('\n    const resumeLayoutAfterGesture', replayStart)
   assert.ok(replayStart >= 0 && replayEnd > replayStart, 'atomic replay exists')
   const replay = controller.slice(replayStart, replayEnd)
-  assert.match(replay, /syncLayout\(\{ forceApply: true \}\)/)
+  assert.match(replay, /syncLayout\(\{ forceApply: true, authorityVersion \}\)/)
 
   const settleStart = controller.indexOf('const settleReaderScroll = () => {')
   const settleEnd = controller.indexOf('\n    const scheduleReaderSettle', settleStart)
   assert.ok(settleStart >= 0 && settleEnd > settleStart, 'reader settlement exists')
   const settle = controller.slice(settleStart, settleEnd)
-  assert.match(settle, /if \(!replayDeferredLayoutNow\(\)\) sizeSpacer\(\)/,
+  assert.match(settle, /if \(!replayDeferredLayoutNow\(\)\)\s*\{\s*sizeSpacer\(currentAuthority\(\)\)/,
     'settlement must not publish footer geometry before its compensating mode write')
 })

--- a/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
+++ b/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
@@ -24,7 +24,7 @@ import {
   modeForQuestionEditingViewportChange,
   modeForQueuedSubmission,
   modeForViewportChange,
-  modeAfterReaderReachesBottom,
+  modeAfterReaderGesture,
   modeAfterSpacerResize,
   modeAfterTerminalLayout,
   physicalBottomAnchorModeFromScroll,
@@ -698,45 +698,25 @@ test('an armed live pin holds until its exact spacer is filled, then follows', (
   assert.deepEqual(modeAfterSpacerResize(livePin, 0), { kind: 'FOLLOW_BOTTOM' })
 })
 
-test('reader reaching the reserved physical bottom keeps the live pin armed', () => {
-  const livePin = {
-    kind: 'PIN_USER_MSG', cid: 'c-123', followWhenFilled: true,
+test('reader settlement preserves reserved room and follows only real content', () => {
+  const exactHold = {
+    kind: 'ANCHOR_AT', key: 'user-c-123', offset: -320,
   }
-  assert.equal(modeAfterReaderReachesBottom({
-    mode: livePin,
-    spacerH: 320,
-    turnRunning: true,
-    lastUserCid: 'c-123',
-  }), livePin, 'the existing pin identity stays intact')
-})
-
-test('reader reaching visible latest-user reservation creates a live pin', () => {
-  assert.deepEqual(modeAfterReaderReachesBottom({
-    mode: { kind: 'FOLLOW_BOTTOM' },
-    spacerH: 320,
-    turnRunning: true,
-    lastUserCid: 'c-123',
-  }), {
-    kind: 'PIN_USER_MSG', cid: 'c-123', followWhenFilled: true,
-  })
-})
-
-test('reader reaches ordinary bottom only after reservation is exhausted', () => {
-  assert.deepEqual(modeAfterReaderReachesBottom({
-    mode: { kind: 'PIN_USER_MSG', cid: 'c-123', followWhenFilled: true },
-    spacerH: 0,
-    turnRunning: true,
-    lastUserCid: 'c-123',
+  assert.equal(modeAfterReaderGesture({
+    reachedPhysicalBottom: true,
+    hasReservedTail: true,
+    holdMode: exactHold,
+  }), exactHold, 'reserved room remains the reader\'s exact anchor')
+  assert.deepEqual(modeAfterReaderGesture({
+    reachedPhysicalBottom: true,
+    hasReservedTail: false,
+    holdMode: exactHold,
   }), { kind: 'FOLLOW_BOTTOM' })
-})
-
-test('reader reaching visible latest-user reservation creates a settled pin', () => {
-  assert.deepEqual(modeAfterReaderReachesBottom({
-    mode: { kind: 'ANCHOR_AT', key: 'user-c-123', offset: 4 },
-    spacerH: 320,
-    turnRunning: false,
-    lastUserCid: 'c-123',
-  }), { kind: 'PIN_USER_MSG', cid: 'c-123' })
+  assert.equal(modeAfterReaderGesture({
+    reachedPhysicalBottom: false,
+    hasReservedTail: false,
+    holdMode: exactHold,
+  }), exactHold)
 })
 
 test('a short settled pin retires automatic follow but keeps its identity', () => {
@@ -957,21 +937,33 @@ test('a product continuation marker cannot take ownership of a saved user pin', 
       kind: 'auto_continuation',
     },
   ]
+  const ownerRow = {
+    offsetTop: 420,
+    dataset: { key: 'owner-user-row' },
+  }
+  const scrollEl = {
+    querySelector(selector) {
+      return selector === '.chat__msg--user[data-cid="owner-cid"]'
+        ? ownerRow
+        : null
+    },
+    querySelectorAll() { return [] },
+  }
 
   assert.deepEqual(
     _validateSavedMode(
       { kind: 'PIN_USER_MSG', cid: 'owner-cid', followWhenFilled: true },
       messages,
-      null,
+      scrollEl,
     ),
-    { kind: 'PIN_USER_MSG', cid: 'owner-cid' },
-    'the preceding owner row remains the latest real user message',
+    { kind: 'ANCHOR_AT', key: 'owner-user-row', offset: PIN_OFFSET },
+    'the preceding owner row restores physically without recreating pin authority',
   )
   assert.deepEqual(
     _validateSavedMode(
       { kind: 'PIN_USER_MSG', cid: 'restart-resume-token' },
       messages,
-      null,
+      scrollEl,
     ),
     { kind: 'INITIAL' },
     'the provider-facing marker is never restored as an owner-authored pin',
@@ -1771,7 +1763,7 @@ test('F2: an idle-mounted short chat reserves for its visible latest user', () =
   assert.equal(spacerH, 851)
 })
 
-test('F2: a deliberately restored pin owns exact room and keeps its user row visible', () => {
+test('F2: a saved pin restores as the same physical ordinary anchor', () => {
   const shortList = 260
   const clientHeight = 915
   const lowUserTop = 200
@@ -1783,10 +1775,17 @@ test('F2: a deliberately restored pin owns exact room and keeps its user row vis
     { kind: 'PIN_USER_MSG', cid: 'c-1' },
   )
   const restored = makePinnableScrollEl({ listH: shortList, spacerH, clientHeight, userTop: lowUserTop, cid: 'c-1' })
-  applyMode(restored, { kind: 'PIN_USER_MSG', cid: 'c-1' })
+  restored.querySelector = (selector) => {
+    if (selector === '.spacer-dynamic') return { offsetHeight: spacerH }
+    if (selector === '[data-key="user-c-1"]') return { offsetTop: lowUserTop }
+    return null
+  }
+  applyMode(restored, {
+    kind: 'ANCHOR_AT', key: 'user-c-1', offset: PIN_OFFSET,
+  })
   assert.equal(restored.scrollTop, lowUserTop - PIN_OFFSET)
   assert.equal(restored.scrollHeight - restored.clientHeight, restored.scrollTop,
-    'the reservation ends exactly at the visible pin target')
+    'the reservation ends at the same visible location without live pin state')
 })
 
 

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -447,11 +447,13 @@ export function _validateSavedMode(saved, messages, scrollEl) {
     if (saved.cid == null) return holdBottom()
     const lastUserMsg = [...messages].reverse()
       .find(isOwnerUserMessage)
-    // Automatic pin→follow is live-turn state, never restoration state. Strip
-    // the armed flag even if a pagehide captured it mid-stream; mount/return
-    // must not manufacture tail-follow from saved geometry.
-    return cidOf(lastUserMsg) === saved.cid
-      ? settledPinMode(saved)
+    if (cidOf(lastUserMsg) !== saved.cid) return holdBottom()
+    // PIN_USER_MSG is a live send action, not a durable reading location.
+    // Restore its physical result as an ordinary anchor so mount/return cannot
+    // recreate pin authority or its later pin→follow layout handoff.
+    const row = _pinnedUserEl(scrollEl, saved.cid)
+    return row?.dataset?.key
+      ? { kind: 'ANCHOR_AT', key: row.dataset.key, offset: PIN_OFFSET }
       : holdBottom()
   }
   if (saved.kind === 'ANCHOR_AT') {
@@ -658,29 +660,119 @@ export function modeAfterTerminalLayout(mode, spacerH, layoutStable) {
 }
 
 
-/** Resolve a reader-owned scroll that reaches the physical bottom.
+/** Resolve the quiet edge of a real reader gesture.
  *
- * Positive spacer means the latest user row is visible (or already pinned).
- * Reaching its reserved bottom makes that visible row the explicit pin;
- * an ordinary bottom with no reservation enters FOLLOW_BOTTOM.
+ * FOLLOW_BOTTOM targets real content and excludes the dynamic reservation.
+ * A physical position inside that reservation must therefore remain an exact
+ * anchor; converting it to either FOLLOW_BOTTOM or PIN_USER_MSG moves backward.
  */
-export function modeAfterReaderReachesBottom({
-  mode,
-  spacerH,
-  turnRunning,
-  lastUserCid,
+export function modeAfterReaderGesture({
+  reachedPhysicalBottom,
+  hasReservedTail,
+  holdMode,
 }) {
-  if (spacerH > 1 && lastUserCid != null) {
-    if (mode?.kind === 'PIN_USER_MSG' && mode.cid === lastUserCid) {
-      return mode
-    }
-    return {
-      kind: 'PIN_USER_MSG',
-      cid: lastUserCid,
-      ...(turnRunning ? { followWhenFilled: true } : {}),
+  if (reachedPhysicalBottom && !hasReservedTail) {
+    return { kind: 'FOLLOW_BOTTOM' }
+  }
+  return holdMode || { kind: 'INITIAL' }
+}
+
+
+const FOLLOW_ENTRY_EVENTS = new Set([
+  'reader:real-content-bottom',
+  'layout:reservation-filled',
+  'terminal:reservation-filled',
+])
+
+/** Enforce the state machine's narrow entry authority.
+ *
+ * Only a send can create a pin. FOLLOW_BOTTOM can be entered only by the two
+ * explicit product transitions: a real unreserved-bottom gesture, or an
+ * already-armed pin consuming its reservation. Other events may preserve the
+ * current mode, demote it to an anchor/initial hold, or retire an armed pin,
+ * but cannot manufacture automatic scroll ownership.
+ */
+export function modeForScrollTransition(previousMode, proposedMode, event) {
+  if (!proposedMode) return previousMode
+  const restoresQuestionSubmissionBase =
+    event === 'layout:question-viewport-release'
+    && previousMode?.kind === 'ANCHOR_AT'
+    && Number.isFinite(previousMode.questionSubmitViewportH)
+    && previousMode.questionSubmitBaseMode === proposedMode
+  if (restoresQuestionSubmissionBase) return proposedMode
+
+  const samePin = previousMode?.kind === 'PIN_USER_MSG'
+    && proposedMode.kind === 'PIN_USER_MSG'
+    && previousMode.cid === proposedMode.cid
+
+  if (proposedMode.kind === 'PIN_USER_MSG'
+      && !samePin
+      && event !== 'send:pin-user-message') {
+    return previousMode
+  }
+
+  if (proposedMode.kind === 'FOLLOW_BOTTOM'
+      && previousMode?.kind !== 'FOLLOW_BOTTOM') {
+    if (!FOLLOW_ENTRY_EVENTS.has(event)) return previousMode
+    if (event !== 'reader:real-content-bottom'
+        && !(previousMode?.kind === 'PIN_USER_MSG'
+          && previousMode.followWhenFilled)) {
+      return previousMode
     }
   }
-  return { kind: 'FOLLOW_BOTTOM' }
+
+  return proposedMode
+}
+
+
+/** A layout plan may commit only while it owns both time and generation.
+ * Gesture timing blocks work during the active handoff; the monotonic reader
+ * generation prevents work captured before a later gesture from regaining
+ * authority when that timing gate eventually opens.
+ */
+export function scrollAuthorityAllowsCommit({
+  capturedVersion,
+  currentVersion,
+  gestureWindowUntil,
+  now,
+}) {
+  return capturedVersion === currentVersion
+    && layoutMayOwnScroll(gestureWindowUntil, now)
+}
+
+
+/** Claim one monotonic intent generation for the current input sequence.
+ * Reader settlement may intentionally batch several nearby gestures into one
+ * quiet-edge layout pass, but each newer sequence must still invalidate work
+ * captured after the preceding gesture.
+ */
+export function readerIntentAfterScroll({
+  gestureSequence,
+  claimedSequence,
+  version,
+}) {
+  if (gestureSequence === claimedSequence) {
+    return { claimedSequence, version }
+  }
+  return {
+    claimedSequence: gestureSequence,
+    version: version + 1,
+  }
+}
+
+
+/** Terminal rAF work distinguishes a no-scroll input from actual reader
+ * movement. A closed gesture gate with the same generation means wait; only a
+ * newer actual-scroll generation makes the old terminal plan permanently stale.
+ */
+export function terminalLayoutAuthority({
+  capturedVersion,
+  currentVersion,
+  gestureWindowUntil,
+  now,
+}) {
+  if (capturedVersion !== currentVersion) return 'stale'
+  return layoutMayOwnScroll(gestureWindowUntil, now) ? 'commit' : 'wait'
 }
 
 
@@ -932,10 +1024,10 @@ export function modeForQueuedSubmission(scrollEl, currentMode) {
  *   The dynamic spacer at the bottom of `.chat__list`.
  * @param {React.RefObject<HTMLElement>} args.lastUserMsgRef
  *   The most recent visible user message element.
- * @param {() => void} args.syncComposerGeometry
- *   Publishes the current overlaid composer height before the controller reads
- *   list/spacer geometry. Keeping this in the same pre-paint layout pass stops
- *   a later composer measurement from briefly clamping a newly pinned send.
+ * @param {React.RefObject<HTMLElement>} args.chatRef
+ *   The `.chat` root whose composer-clearance CSS variable is scroll geometry.
+ * @param {React.RefObject<HTMLElement>} args.footRef
+ *   The overlaid composer element measured by the scroll owner.
  * @param {Array<object>} args.messages
  *   Persisted message list (drives effect re-runs).
  * @param {React.MutableRefObject<Array<object>>} args.messagesRef
@@ -945,9 +1037,6 @@ export function modeForQueuedSubmission(scrollEl, currentMode) {
  *   shows/hides because the tray's margin shrinks the spacer math).
  * @param {React.MutableRefObject<boolean>} args.loadingOlderRef
  *   When true, scroll events from pagination shouldn't mutate mode.
- * @param {boolean} args.turnRunning
- *   Whether a reader-owned move to the latest user's reserved bottom should
- *   arm the ordinary spacer-exhaustion handoff while output is still live.
  * @param {'history'|'cached'|'ready'} args.initialEntryPhase
  *   One entry-readiness state: history blocks reveal, cached permits an
  *   immediate first paint while layout stabilizes, and ready means the
@@ -974,12 +1063,12 @@ export default function useScrollMode({
   scrollRef,
   spacerRef,
   lastUserMsgRef,
-  syncComposerGeometry,
+  chatRef,
+  footRef,
   messages,
   messagesRef,
   pendingMessagesLength,
   loadingOlderRef,
-  turnRunning,
   initialEntryPhase,
 }) {
   const [revealed, setRevealed] = useState(false)
@@ -1007,13 +1096,11 @@ export default function useScrollMode({
   // settlement still waiting on the quiet edge. The effect publishes its
   // local cancel closure here so those actions cannot be overwritten later.
   const discardPendingReaderSettleRef = useRef(null)
-  // Monotonic counter for actual user scroll intent. Send/steer code captures
-  // this at submit time and honors a delayed pin only if the user did not
-  // scroll after submitting. Programmatic applyMode scrolls must not increment
-  // it. Input only opens the pre-scroll ownership gate; the counter is bumped
-  // by an actual gesture-driven scroll event, so tapping a disclosure cannot
-  // accidentally cancel a queued/steered send's pin intent.
-  const userScrollIntentVersionRef = useRef(0)
+  // Monotonic generation for actual reader scroll intent. Send/steer snapshots
+  // and every deferred/automatic geometry commit use this same authority:
+  // once a newer gesture lands, older work can never regain ownership merely
+  // because the gesture timing window later closes.
+  const readerIntentVersionRef = useRef(0)
   const fullViewHRef = useRef(0)
   // Lives outside the layout effect so it survives StrictMode's
   // double-invoke in dev (and any future effect re-run). If this were
@@ -1055,10 +1142,6 @@ export default function useScrollMode({
   // to the full pane height; otherwise the controller can restore a stale
   // anchor between viewport-animation frames and make the card oscillate.
   const questionEditSessionRef = useRef(false)
-  // Keep reader events wired to the latest run state without rebuilding every
-  // observer/listener whenever the boolean changes.
-  const turnRunningRef = useRef(!!turnRunning)
-  turnRunningRef.current = !!turnRunning
   const initialEntryPhaseRef = useRef(initialEntryPhase)
   initialEntryPhaseRef.current = initialEntryPhase
   // A normal reveal ends entry stabilization. A forced safety-cap reveal keeps
@@ -1113,9 +1196,10 @@ export default function useScrollMode({
   // through the methods returned by this hook; layout and reader paths below
   // use the same transition function, so mode ownership cannot drift across
   // a collection of direct `modeRef.current = ...` writes.
-  const transitionMode = useCallback((nextMode, event) => {
-    if (!nextMode) return modeRef.current
+  const transitionMode = useCallback((proposedMode, event) => {
     const previousMode = modeRef.current
+    const nextMode = modeForScrollTransition(previousMode, proposedMode, event)
+    if (!nextMode) return previousMode
     if (nextMode === previousMode) return previousMode
     modeRef.current = nextMode
     const pinOwnedBefore = previousMode?.kind === 'PIN_USER_MSG'
@@ -1136,8 +1220,19 @@ export default function useScrollMode({
   // remains exported as a pure executor for unit tests, but live code routes
   // every mode-owned write through here and records only writes that actually
   // moved the viewport.
-  const writeMode = useCallback((scrollEl, mode, event) => {
-    if (!scrollEl || !mode) return
+  const writeMode = useCallback((
+    scrollEl,
+    mode,
+    event,
+    authorityVersion = readerIntentVersionRef.current,
+  ) => {
+    if (!scrollEl || !mode) return false
+    if (!scrollAuthorityAllowsCommit({
+      capturedVersion: authorityVersion,
+      currentVersion: readerIntentVersionRef.current,
+      gestureWindowUntil: gestureWindowUntilRef.current,
+      now: performance.now(),
+    })) return false
     const before = scrollEl.scrollTop
     applyMode(scrollEl, mode)
     if (Math.abs(scrollEl.scrollTop - before) > 0.5) {
@@ -1147,6 +1242,7 @@ export default function useScrollMode({
         scrollEl,
       })
     }
+    return true
   }, [recordTrace])
 
   const persistMode = useCallback(({ freezeToCurrentPosition = false } = {}) => {
@@ -1218,7 +1314,7 @@ export default function useScrollMode({
         mode: modeRef.current,
         isFirstUserMsg,
       }),
-      userScrollIntentVersion: userScrollIntentVersionRef.current,
+      readerIntentVersion: readerIntentVersionRef.current,
     }
     supersedePendingReaderGesture()
     return intent
@@ -1226,7 +1322,7 @@ export default function useScrollMode({
 
   const sendIntentIsCurrent = useCallback(intent => (
     !!intent
-    && intent.userScrollIntentVersion === userScrollIntentVersionRef.current
+    && intent.readerIntentVersion === readerIntentVersionRef.current
   ), [])
 
   const commitSendIntent = useCallback(({
@@ -1332,9 +1428,16 @@ export default function useScrollMode({
     if (!scrollEl || !nextMode) return
     discardPendingReaderSettleRef.current?.()
     gestureWindowUntilRef.current = 0
+    readerIntentVersionRef.current += 1
+    const authorityVersion = readerIntentVersionRef.current
     readerLocationExplicitRef.current = true
     transitionMode(nextMode, 'reader:attention-nudge-tail')
-    writeMode(scrollEl, nextMode, 'reader:attention-nudge-tail')
+    writeMode(
+      scrollEl,
+      nextMode,
+      'reader:attention-nudge-tail',
+      authorityVersion,
+    )
     lastAppliedModeRef.current = nextMode
     nearScrollBottomRef.current = isNearScrollBottom(scrollEl)
     persistMode()
@@ -1386,6 +1489,7 @@ export default function useScrollMode({
     // without the newly mounted transcript being mistaken for a chat change.
     if (modeChatIdRef.current !== chatId) {
       modeChatIdRef.current = chatId
+      readerIntentVersionRef.current += 1
       transitionMode({ kind: 'INITIAL' }, 'lifecycle:chat-change')
     }
 
@@ -1426,13 +1530,20 @@ export default function useScrollMode({
     // above) so it survives the layout effect re-running, including
     // React 19 StrictMode's dev-time double-invoke.
 
-    const layoutOwnsScroll = () => layoutMayOwnScroll(
-      gestureWindowUntilRef.current,
-      performance.now(),
+    const currentAuthority = () => readerIntentVersionRef.current
+    const layoutOwnsScroll = (authorityVersion = currentAuthority()) => (
+      scrollAuthorityAllowsCommit({
+        capturedVersion: authorityVersion,
+        currentVersion: readerIntentVersionRef.current,
+        gestureWindowUntil: gestureWindowUntilRef.current,
+        now: performance.now(),
+      })
     )
     let deferredGestureLayoutTimer = 0
     let deferredGestureLayoutPending = false
-    const deferLayoutUntilReaderYields = () => {
+    const deferLayoutUntilReaderYields = (
+      authorityVersion = currentAuthority(),
+    ) => {
       clearTimeout(deferredGestureLayoutTimer)
       deferredGestureLayoutPending = true
       const ownershipUntil = gestureWindowUntilRef.current
@@ -1441,7 +1552,10 @@ export default function useScrollMode({
       // no-scroll release, or the next effect instance resumes this pass.
       const delay = gestureLayoutRetryDelay(ownershipUntil, performance.now())
       if (delay == null) return
+      const scheduledAuthority = authorityVersion
       deferredGestureLayoutTimer = setTimeout(() => {
+        deferredGestureLayoutTimer = 0
+        if (!layoutOwnsScroll(scheduledAuthority)) return
         deferredGestureLayoutPending = false
         // The observer pass that noticed the geometry change deliberately
         // yielded to reader input. Once ownership returns, replay that missed
@@ -1449,11 +1563,18 @@ export default function useScrollMode({
         // common case for FOLLOW_BOTTOM while new content arrives). Calling
         // the ordinary identity-gated path here would resize the spacer but
         // leave the viewport behind the live tail forever.
-        if (scrollRef.current === scrollEl) syncLayout({ forceApply: true })
+        if (scrollRef.current === scrollEl) {
+          syncLayout({
+            forceApply: true,
+            authorityVersion: scheduledAuthority,
+          })
+        }
       }, delay)
     }
     const replayDeferredLayoutNow = () => {
-      if (!deferredGestureLayoutPending || !layoutOwnsScroll()) return false
+      const authorityVersion = currentAuthority()
+      if (!deferredGestureLayoutPending
+          || !layoutOwnsScroll(authorityVersion)) return false
       clearTimeout(deferredGestureLayoutTimer)
       deferredGestureLayoutTimer = 0
       deferredGestureLayoutPending = false
@@ -1461,16 +1582,16 @@ export default function useScrollMode({
       // must commit in ONE task. If CSS padding + spacer land first and the
       // HOLD/ANCHOR write waits for the next timer, browser scroll anchoring
       // can paint one frame 36px away before the controller corrects it.
-      syncLayout({ forceApply: true })
+      syncLayout({ forceApply: true, authorityVersion })
       return true
     }
     const resumeLayoutAfterGesture = () => {
       if (!deferredGestureLayoutPending) return
-      deferLayoutUntilReaderYields()
+      deferLayoutUntilReaderYields(currentAuthority())
     }
     resumeLayoutAfterGestureRef.current = resumeLayoutAfterGesture
 
-    function sizeSpacer() {
+    function sizeSpacer(authorityVersion = currentAuthority()) {
       // The list's bottom padding is derived from the absolutely-positioned
       // composer height. React commits the emptied composer / new turn footer
       // in the same render as a sent row, but the foot's ResizeObserver runs
@@ -1481,7 +1602,14 @@ export default function useScrollMode({
       // before ANY list/spacer reads, so reservation + scrollTop land from one
       // geometry snapshot. Respect reader ownership: the CSS-variable write is
       // scroll geometry too and must wait with the spacer during a gesture.
-      if (layoutOwnsScroll()) syncComposerGeometry?.()
+      if (!layoutOwnsScroll(authorityVersion)) {
+        deferLayoutUntilReaderYields(authorityVersion)
+        return spacerEl.offsetHeight || 0
+      }
+      const composerHeight = footRef.current?.offsetHeight
+      if (chatRef.current && Number.isFinite(composerHeight)) {
+        chatRef.current.style.setProperty('--composer-h', `${composerHeight}px`)
+      }
       // Keep fullViewHRef authoritative at EVERY spacer sizing, not just at
       // the layout-effect entry and the RO callback start (the other two grow
       // sites). The visualViewport keyboard handler reaches sizeSpacer via
@@ -1502,7 +1630,7 @@ export default function useScrollMode({
       // the grow-only clientHeight bump re-raises it if the real pane is taller.
       // The visualViewport keyboard path never sets this ref, so its floor stays
       // strictly grow-only (design §2).
-      if (pendingPaneHeightRef.current != null && layoutOwnsScroll()) {
+      if (pendingPaneHeightRef.current != null) {
         const ph = pendingPaneHeightRef.current
         if (Number.isFinite(ph) && ph > 0) fullViewHRef.current = ph
         pendingPaneHeightRef.current = null
@@ -1527,14 +1655,6 @@ export default function useScrollMode({
       const h = _computeSpacerH(
         scrollEl, listEl, lastUserEl, fullViewHRef.current, modeRef.current,
       )
-      if (!layoutOwnsScroll()) {
-        // Spacer height is itself scroll geometry: shrinking it can make the
-        // browser clamp scrollTop even though we never assign scrollTop. Hold
-        // both direct and indirect scroll writes for the whole gesture, then
-        // run one deterministic layout pass when ownership returns.
-        deferLayoutUntilReaderYields()
-        return spacerEl.offsetHeight || 0
-      }
       spacerEl.style.height = `${h}px`
       // A wheel/touch/key gesture begins before the browser emits its first
       // scroll event. Do not let spacer geometry perform pin→follow in that
@@ -1546,9 +1666,14 @@ export default function useScrollMode({
       }
     }
 
-    function maybeApplyMode() {
+    function maybeApplyMode(authorityVersion) {
       if (modeRef.current !== lastAppliedModeRef.current) {
-        writeMode(scrollEl, modeRef.current, 'layout:mode-transition')
+        if (!writeMode(
+          scrollEl,
+          modeRef.current,
+          'layout:mode-transition',
+          authorityVersion,
+        )) return
         lastAppliedModeRef.current = modeRef.current
         // Record the pin/anchor baseline (or clear both) so the RO's
         // re-apply-on-shift checks below have a reference offsetTop.
@@ -1567,11 +1692,16 @@ export default function useScrollMode({
       }
     }
 
-    function settlePinnedMode() {
+    function settlePinnedMode(authorityVersion) {
       if (!_pinReapplyNeeded(scrollEl, modeRef.current, lastPinTopRef.current)) {
         return
       }
-      writeMode(scrollEl, modeRef.current, 'layout:repair-pin')
+      if (!writeMode(
+        scrollEl,
+        modeRef.current,
+        'layout:repair-pin',
+        authorityVersion,
+      )) return
       const el = _pinnedUserEl(scrollEl, modeRef.current.cid)
       lastPinTopRef.current = el ? el.offsetTop : null
       lastAppliedModeRef.current = modeRef.current
@@ -1581,11 +1711,16 @@ export default function useScrollMode({
     // The ANCHOR_AT twin of settlePinnedMode — the post-reveal clamp-repair.
     // Re-applies only when _anchorReapplyNeeded says the anchor shifted or was
     // clamped (never every firing), so it does not fight the reader or jitter.
-    function settleAnchoredMode() {
+    function settleAnchoredMode(authorityVersion) {
       if (!_anchorReapplyNeeded(scrollEl, modeRef.current, lastAnchorTopRef.current)) {
         return
       }
-      writeMode(scrollEl, modeRef.current, 'layout:repair-anchor')
+      if (!writeMode(
+        scrollEl,
+        modeRef.current,
+        'layout:repair-anchor',
+        authorityVersion,
+      )) return
       const el = _anchorEl(scrollEl, modeRef.current.key)
       lastAnchorTopRef.current = el ? el.offsetTop : null
       lastAppliedModeRef.current = modeRef.current
@@ -1597,7 +1732,11 @@ export default function useScrollMode({
     // needed — the spacer math depends on changing content). Most callers only
     // touch scrollTop on a real mode transition; keyboard resize passes
     // forceApply so the current PIN/FOLLOW/ANCHOR survives the viewport clamp.
-    function syncLayout({ forceApply = false, viewportChange = false } = {}) {
+    function syncLayout({
+      forceApply = false,
+      viewportChange = false,
+      authorityVersion = currentAuthority(),
+    } = {}) {
       const preserveBottom = viewportChange && nearScrollBottomRef.current
       const questionSubmissionWasActive = viewportChange
         && modeRef.current?.kind === 'ANCHOR_AT'
@@ -1614,14 +1753,16 @@ export default function useScrollMode({
           transitionMode(released, 'layout:question-viewport-release')
         }
       }
-      sizeSpacer()
-      // Input precedes the browser's first `scroll` event. Every layout entry
-      // point shares this gate so streaming, footer reflow, keyboard resize,
-      // and catch-up cannot race the reader and throw the viewport elsewhere.
-      if (!layoutOwnsScroll()) {
+      // Releasing the submitted-question overlay is a semantic state change,
+      // not a scroll write. It must happen even while the input gate retains
+      // viewport ownership; the deferred layout pass below then applies the
+      // restored mode after the reader yields.
+      if (!layoutOwnsScroll(authorityVersion)) {
+        deferLayoutUntilReaderYields(authorityVersion)
         nearScrollBottomRef.current = isNearScrollBottom(scrollEl)
-        return
+        return false
       }
+      sizeSpacer(authorityVersion)
       if (viewportChange) {
         const anchor = preserveBottom ? null : anchorModeFromScroll(scrollEl)
         const editingAnchor = questionEditSessionRef.current
@@ -1644,7 +1785,12 @@ export default function useScrollMode({
             : 'layout:viewport-change',
         )
         persistMode()
-        writeMode(scrollEl, modeRef.current, 'layout:viewport-change')
+        writeMode(
+          scrollEl,
+          modeRef.current,
+          'layout:viewport-change',
+          authorityVersion,
+        )
         lastAppliedModeRef.current = modeRef.current
         if (modeRef.current.kind === 'PIN_USER_MSG') {
           const el = _pinnedUserEl(scrollEl, modeRef.current.cid)
@@ -1659,28 +1805,35 @@ export default function useScrollMode({
           lastAnchorTopRef.current = null
         }
       } else if (forceApply) {
-        writeMode(scrollEl, modeRef.current, 'layout:forced-reapply')
+        writeMode(
+          scrollEl,
+          modeRef.current,
+          'layout:forced-reapply',
+          authorityVersion,
+        )
       } else {
-        maybeApplyMode()
+        maybeApplyMode(authorityVersion)
       }
       // A send can set PIN_USER_MSG while the dynamic spacer is still at its
       // old height. `sizeSpacer()` above makes the target reachable; this
       // immediate settle pass applies the same pin again if the browser had
       // clamped the first write, instead of waiting for a later RO event that
       // may never fire for the spacer-only height change.
-      settlePinnedMode()
+      settlePinnedMode(authorityVersion)
       nearScrollBottomRef.current = isNearScrollBottom(scrollEl)
+      return true
     }
     function runComposerResize() {
-      if (!layoutOwnsScroll()) {
-        deferLayoutUntilReaderYields()
+      const authorityVersion = currentAuthority()
+      if (!layoutOwnsScroll(authorityVersion)) {
+        deferLayoutUntilReaderYields(authorityVersion)
         return
       }
-      syncLayout()
+      syncLayout({ authorityVersion })
     }
     composerResizeRunRef.current = runComposerResize
 
-    syncLayout()
+    syncLayout({ authorityVersion: currentAuthority() })
 
     // The scrollApi.paneResized(projectedHeightPx) contract (design §2,
     // constraint 1). Shell calls this on COMMITTED pane-geometry changes for a
@@ -1696,26 +1849,32 @@ export default function useScrollMode({
     // visualViewport keyboard path must never call this — divider/projection
     // shrink and keyboard shrink stay structurally separate.
     function runPaneResize(projectedHeightPx) {
+      const authorityVersion = currentAuthority()
       pendingPaneHeightRef.current =
         (Number.isFinite(projectedHeightPx) && projectedHeightPx > 0)
           ? projectedHeightPx
           : pendingPaneHeightRef.current
-      if (!layoutOwnsScroll()) {
+      if (!layoutOwnsScroll(authorityVersion)) {
         // Defer the floor lowering, spacer mutation, and mode re-apply as one
         // replayable pass; the deferred syncLayout({forceApply}) consumes the
         // pending height and re-applies the current mode when ownership yields.
-        deferLayoutUntilReaderYields()
+        deferLayoutUntilReaderYields(authorityVersion)
         return
       }
-      sizeSpacer()
+      sizeSpacer(authorityVersion)
       const k = modeRef.current.kind
       if (k === 'FOLLOW_BOTTOM') {
-        writeMode(scrollEl, modeRef.current, 'pane:resize-follow')
+        writeMode(
+          scrollEl,
+          modeRef.current,
+          'pane:resize-follow',
+          authorityVersion,
+        )
         nearScrollBottomRef.current = isNearScrollBottom(scrollEl)
       } else if (k === 'PIN_USER_MSG') {
-        settlePinnedMode()
+        settlePinnedMode(authorityVersion)
       } else if (k === 'ANCHOR_AT') {
-        settleAnchoredMode()
+        settleAnchoredMode(authorityVersion)
       }
     }
     paneResizeRunRef.current = runPaneResize
@@ -1732,9 +1891,10 @@ export default function useScrollMode({
       clearTimeout(revealTimer)
       if (revealedRef.current && !mountStabilizingRef.current) return
       if (!entryReady()) return
+      const authorityVersion = currentAuthority()
       revealTimer = setTimeout(() => {
         if (scrollRef.current !== scrollEl || !entryReady()) return
-        syncLayout()
+        if (!syncLayout({ authorityVersion })) return
         revealedRef.current = true
         mountStabilizingRef.current = initialEntryPhaseRef.current !== 'ready'
         setRevealed(true)
@@ -1742,7 +1902,7 @@ export default function useScrollMode({
     }
     const forceReveal = () => {
       if (revealedRef.current || scrollRef.current !== scrollEl) return
-      syncLayout()
+      syncLayout({ authorityVersion: currentAuthority() })
       mountStabilizingRef.current = true
       revealedRef.current = true
       setRevealed(true)
@@ -1767,20 +1927,26 @@ export default function useScrollMode({
     //                   never re-applied unconditionally (jitter risk).
     //
     const ro = new ResizeObserver(() => {
+      const authorityVersion = currentAuthority()
       if (scrollEl.clientHeight > fullViewHRef.current) {
         fullViewHRef.current = scrollEl.clientHeight
       }
-      sizeSpacer()
+      sizeSpacer(authorityVersion)
       const k = modeRef.current.kind
-      const mayWriteScroll = layoutOwnsScroll()
+      const mayWriteScroll = layoutOwnsScroll(authorityVersion)
       if (mayWriteScroll && (
         k === 'FOLLOW_BOTTOM'
         || (k === 'ANCHOR_AT'
           && (!revealedRef.current || mountStabilizingRef.current))
       )) {
-        writeMode(scrollEl, modeRef.current, k === 'FOLLOW_BOTTOM'
-          ? 'layout:follow-live-tail'
-          : 'layout:restore-anchor')
+        writeMode(
+          scrollEl,
+          modeRef.current,
+          k === 'FOLLOW_BOTTOM'
+            ? 'layout:follow-live-tail'
+            : 'layout:restore-anchor',
+          authorityVersion,
+        )
         nearScrollBottomRef.current = isNearScrollBottom(scrollEl)
       } else if (k === 'PIN_USER_MSG' && mayWriteScroll) {
         // Re-pin in two cases, both of which leave the message off its
@@ -1817,7 +1983,7 @@ export default function useScrollMode({
         // higher — reintroducing the May-2026 stutter. Gating on the
         // target means we re-pin exactly once, when the settled layout
         // can actually hold the message at the top.
-        settlePinnedMode()
+        settlePinnedMode(authorityVersion)
       } else if (k === 'ANCHOR_AT' && mayWriteScroll) {
         // POST-REVEAL ANCHOR_AT repair (the pre-reveal case is handled by the
         // first branch above). Background panes resize routinely once panes
@@ -1827,7 +1993,7 @@ export default function useScrollMode({
         // again. _anchorReapplyNeeded gates it exactly like the pin, so
         // steady-state streaming below the anchor stays a no-op — no May-2026
         // jitter, no fight with the reader (whose first scroll flips the mode).
-        settleAnchoredMode()
+        settleAnchoredMode(authorityVersion)
       }
       nearScrollBottomRef.current = isNearScrollBottom(scrollEl)
       requestRevealOnQuiet()  // each RO firing pushes the reveal back
@@ -1848,6 +2014,7 @@ export default function useScrollMode({
     // run once at the trailing edge instead of on every compositor frame.
     let readerScrollDirty = false
     let readerScrollAtBottom = false
+    let readerScrollSequence = null
     let readerSettleTimer = 0
     let disclosureInputOwnsGesture = false
 
@@ -1879,43 +2046,39 @@ export default function useScrollMode({
       pendingGestureReleaseRafRef.current = 0
 
       if (!loadingOlderRef.current) {
-        if (settledAtBottom) {
-          const spacerH = spacerEl.offsetHeight || 0
-          const lastUserEl = _lastUserRowEl(scrollEl) || lastUserMsgRef.current
-          const lastUserCid = lastUserEl?.dataset?.cid ?? null
-          transitionMode(
-            modeAfterReaderReachesBottom({
-              mode: modeRef.current,
-              spacerH,
-              turnRunning: turnRunningRef.current,
-              lastUserCid,
-            }),
-            'reader:physical-bottom',
-          )
-        } else {
-          // Moving away from the physical bottom always retires live follow.
-          // Do this even if live spacer/content changes collapsed the scroll
-          // range during the 250ms quiet window: the earlier gesture-owned
-          // scroll event is authoritative intent, and leaving the old PIN mode
-          // armed would let a later resize throw the reader back to the prompt.
-          // If the viewport is wholly inside reserved spacer there is no exact
-          // row anchor, so settle on the real-content tail instead of leaving a
-          // stale FOLLOW_BOTTOM armed for the next content resize.
-          const anchor = contentHoldModeFromScroll(scrollEl)
-          if (anchor) transitionMode(anchor, 'reader:hold-anchor')
-        }
+        // Snapshot the exact physical position, including negative anchor
+        // offsets while the viewport is inside reserved reply room. Lifecycle
+        // save/restore intentionally normalizes that room to readable content;
+        // a live gesture must not, because replaying the normalized target is
+        // the recurring jump back to the latest prompt.
+        const holdMode = anchorModeFromScroll(scrollEl)
+        const spacerH = spacerEl.offsetHeight || 0
+        const settledMode = modeAfterReaderGesture({
+          reachedPhysicalBottom: settledAtBottom,
+          hasReservedTail: spacerH > 1,
+          holdMode,
+        })
+        transitionMode(
+          settledMode,
+          settledMode.kind === 'FOLLOW_BOTTOM'
+            ? 'reader:real-content-bottom'
+            : 'reader:hold-exact',
+        )
         persistMode()
         // Tail geometry, not mode or viewport visibility, owns reservation.
         // Recompute once after momentum, never underneath the gesture itself.
         // When a footer resize was deferred, replay geometry + the newly
         // settled semantic mode atomically; a bare sizeSpacer here would let
         // native scroll anchoring paint an intermediate displaced frame.
-        if (!replayDeferredLayoutNow()) sizeSpacer()
+        if (!replayDeferredLayoutNow()) {
+          sizeSpacer(currentAuthority())
+        }
       }
 
       nearScrollBottomRef.current = isNearScrollBottom(scrollEl)
       recordTrace('events', 'reader:scroll-settled', { scrollEl })
       resumeLayoutAfterGestureRef.current?.()
+      requestRevealOnQuiet()
     }
 
     const scheduleReaderSettle = () => {
@@ -2184,7 +2347,13 @@ export default function useScrollMode({
       // quiet window; re-reading bottom later would erase the reader's explicit
       // "I reached the tail" intent and incorrectly settle as ANCHOR_AT.
       readerScrollAtBottom = distanceToBottom < PHYSICAL_BOTTOM_EPSILON_PX
-      userScrollIntentVersionRef.current += 1
+      const intent = readerIntentAfterScroll({
+        gestureSequence: gestureSequenceRef.current,
+        claimedSequence: readerScrollSequence,
+        version: readerIntentVersionRef.current,
+      })
+      readerScrollSequence = intent.claimedSequence
+      readerIntentVersionRef.current = intent.version
       readerLocationExplicitRef.current = true
       scheduleReaderSettle()
     }
@@ -2194,7 +2363,11 @@ export default function useScrollMode({
     let vvHandler = null
     if (typeof window !== 'undefined' && window.visualViewport) {
       vvHandler = () => {
-        syncLayout({ forceApply: true, viewportChange: true })
+        syncLayout({
+          forceApply: true,
+          viewportChange: true,
+          authorityVersion: currentAuthority(),
+        })
         if (questionEditSessionRef.current
             && !questionEditField(document.activeElement)
             && scrollEl.clientHeight >= fullViewHRef.current - 1) {
@@ -2260,7 +2433,8 @@ export default function useScrollMode({
     chatId,
     initialEntryPhase,
     pinModeActive,
-    syncComposerGeometry,
+    chatRef,
+    footRef,
   ])
 
   // Re-hold the reading position after an atomic catch-up commit lands
@@ -2275,13 +2449,21 @@ export default function useScrollMode({
     if (!revealedRef.current) return
     const scrollEl = scrollRef.current
     if (!scrollEl) return
-    if (!layoutMayOwnScroll(
-      gestureWindowUntilRef.current,
-      performance.now(),
-    )) return
+    const authorityVersion = readerIntentVersionRef.current
+    if (!scrollAuthorityAllowsCommit({
+      capturedVersion: authorityVersion,
+      currentVersion: readerIntentVersionRef.current,
+      gestureWindowUntil: gestureWindowUntilRef.current,
+      now: performance.now(),
+    })) return
     const k = modeRef.current.kind
     if (k === 'FOLLOW_BOTTOM' || k === 'ANCHOR_AT') {
-      writeMode(scrollEl, modeRef.current, 'lifecycle:catch-up-reapply')
+      writeMode(
+        scrollEl,
+        modeRef.current,
+        'lifecycle:catch-up-reapply',
+        authorityVersion,
+      )
     }
   }, [scrollRef, writeMode])
 
@@ -2301,6 +2483,7 @@ export default function useScrollMode({
       return
     }
     const terminalCid = terminalMode.cid
+    const terminalAuthorityVersion = readerIntentVersionRef.current
     let previousSignature = null
     let stableFrames = 0
 
@@ -2314,19 +2497,19 @@ export default function useScrollMode({
           || mode.cid !== terminalCid) {
         return
       }
-      const mayWriteScroll = layoutMayOwnScroll(
-        gestureWindowUntilRef.current,
-        performance.now(),
-      )
-      if (!mayWriteScroll) {
-        // Terminal promotion can land between input and the first scroll
-        // event. The reader wins that race: freeze what is visible and retire
-        // the live handoff without issuing a final scroll write.
-        transitionMode(
-          anchorModeFromScroll(scrollEl) || settledPinMode(mode),
-          'terminal:reader-owns',
-        )
-        persistMode()
+      const authority = terminalLayoutAuthority({
+        capturedVersion: terminalAuthorityVersion,
+        currentVersion: readerIntentVersionRef.current,
+        gestureWindowUntil: gestureWindowUntilRef.current,
+        now: performance.now(),
+      })
+      if (authority === 'stale') return
+      if (authority === 'wait') {
+        // Input alone is not reader movement. Keep the pin armed while a tap
+        // or the input-to-first-scroll handoff owns the viewport. A real scroll
+        // advances the generation and makes this plan stale; a no-scroll input
+        // releases the gate and lets the ordinary committed-layout decision run.
+        requestAnimationFrame(inspectCommittedLayout)
         return
       }
 
@@ -2363,11 +2546,22 @@ export default function useScrollMode({
 
       // Keep styled geometry and the decision in the same frame. The main RO
       // normally wrote this value already; assigning the same value is a no-op.
+      if (!scrollAuthorityAllowsCommit({
+        capturedVersion: terminalAuthorityVersion,
+        currentVersion: readerIntentVersionRef.current,
+        gestureWindowUntil: gestureWindowUntilRef.current,
+        now: performance.now(),
+      })) return
       spacerEl.style.height = `${spacerH}px`
       transitionMode(nextMode, spacerH <= 1
         ? 'terminal:reservation-filled'
         : 'terminal:short-reply-settle')
-      writeMode(scrollEl, modeRef.current, 'terminal:settle-layout')
+      writeMode(
+        scrollEl,
+        modeRef.current,
+        'terminal:settle-layout',
+        terminalAuthorityVersion,
+      )
       persistMode()
     }
 

--- a/tests/send-rule.spec.mjs
+++ b/tests/send-rule.spec.mjs
@@ -244,7 +244,7 @@ test('Send while at the bottom hands off after a long response fills the reserva
   expect(m.scrollH - m.scrollTop - m.clientH).toBeLessThanOrEqual(8)
 })
 
-test('Immediate tail-to-send holds through reserved streaming room, then follows', async ({ page }) => {
+test('Immediate tail-to-send preserves a manual reserved-tail position as output fills it', async ({ page }) => {
   await installChunkedStreams(page, [
     [
       [0, { type: 'catch_up_done' }],
@@ -308,13 +308,13 @@ test('Immediate tail-to-send holds through reserved streaming room, then follows
   await page.waitForFunction(() => {
     const scroll = document.querySelector('[data-chat-surface="painted"] .chat__scroll')
     const spacer = document.querySelector('[data-chat-surface="painted"] .spacer-dynamic')
-    if (!scroll || !spacer || spacer.offsetHeight > 1) return false
-    return scroll.scrollHeight - scroll.scrollTop - scroll.clientHeight <= 8
+    return !!scroll && !!spacer && spacer.offsetHeight <= 1
   })
 
-  const following = await measure(page)
-  expect(following.spacerH).toBeLessThanOrEqual(1)
-  expect(following.scrollH - following.scrollTop - following.clientH).toBeLessThanOrEqual(8)
+  const filled = await measure(page)
+  expect(filled.spacerH).toBeLessThanOrEqual(1)
+  expect(Math.abs(filled.scrollTop - manuallyHeld.scrollTop)).toBeLessThanOrEqual(8)
+  expect(filled.scrollH - filled.scrollTop - filled.clientH).toBeGreaterThan(50)
 })
 
 // ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- make send, reader, and layout transitions obey one explicit scroll-state entry policy
- preserve the exact physical reader position when a gesture ends inside reserved reply room
- reject direct and indirect layout work captured before a newer reader gesture
- keep composer clearance, spacer sizing, terminal settlement, and scroll writes behind the same ownership boundary

## Why
This is a focused follow-up to #220, #342, and #430, which established quiet reader settlement, atomic footer geometry, and a stable final-turn range. The residual alignment in #436 preserved those foundations, but it also retained an inherited transition that converted a reader reaching the physical bottom while reservation remained into `PIN_USER_MSG`.

That transition recreated automatic layout authority from reader movement and could snap the viewport back toward the latest prompt. A timing gate alone also allowed delayed work captured before a later gesture to become eligible again once the gate expired.

This change narrows the state-machine entrances: only Send creates a pin, and only an unreserved real-content-bottom gesture or an already-armed pin consuming its reservation enters follow. A monotonic reader generation permanently rejects stale direct and indirect geometry work.

## Testing
- 134 focused chat scroll and controller contract tests
- structural test-budget check
- production frontend and PWA build
- rendered 426×860 reserved-tail settlement preserved the identical numeric scroll position