### PR TITLE
Fix pinned-chat render loop and add recovery fallbacks

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -188,13 +188,25 @@
       if ('scrollRestoration' in history) {
         history.scrollRestoration = 'manual'
       }
-      // If the shell JS fails to load within 8s, surface a recovery link so the
-      // user can restore the UI without knowing the server address.
+      // If the shell JS fails to load within 8s, offer an ordinary reload first
+      // and keep the independent recovery service as the last resort.
       setTimeout(function() {
         if (!document.getElementById('root').hasChildNodes()) {
           var d = document.createElement('div')
-          d.style.cssText = 'position:fixed;bottom:24px;left:50%;transform:translateX(-50%);z-index:99999;background:#1e293b;border:1px solid #334155;border-radius:10px;padding:14px 20px;font-family:system-ui,sans-serif;font-size:13px;color:#94a3b8;text-align:center;white-space:nowrap'
-          d.innerHTML = 'Shell failed to load. <a href="/recover" style="color:#a78bfa;text-decoration:none;font-weight:500">Open recovery page \u2192</a>'
+          var retry = document.createElement('a')
+          var recovery = document.createElement('a')
+          d.setAttribute('role', 'alert')
+          d.style.cssText = 'position:fixed;bottom:24px;left:50%;transform:translateX(-50%);z-index:99999;width:max-content;max-width:calc(100vw - 48px);background:#1e293b;border:1px solid #334155;border-radius:10px;padding:14px 20px;font-family:system-ui,sans-serif;font-size:13px;line-height:1.5;color:#cbd5e1;text-align:center'
+          retry.href = window.location.href
+          retry.textContent = 'Try again'
+          retry.style.cssText = 'color:#c4b5fd;text-decoration:none;font-weight:600'
+          recovery.href = '/recover'
+          recovery.textContent = 'open recovery'
+          recovery.style.cssText = 'color:inherit;text-decoration:underline;text-underline-offset:2px'
+          d.append(
+            'Möbius failed to load. ', retry,
+            '. If it still won’t load, ', recovery, '.',
+          )
           document.body.appendChild(d)
         }
       }, 8000)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -200,7 +200,12 @@
           retry.href = window.location.href
           retry.textContent = 'Try again'
           retry.style.cssText = 'color:#c4b5fd;text-decoration:none;font-weight:600'
+          retry.addEventListener('click', function(event) {
+            event.preventDefault()
+            window.location.reload()
+          })
           recovery.href = '/recover'
+          recovery.target = '_top'
           recovery.textContent = 'open recovery'
           recovery.style.cssText = 'color:inherit;text-decoration:underline;text-underline-offset:2px'
           d.append(

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,7 @@ import { lazy, Suspense, useState, useEffect } from 'react'
 import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client'
 import { QueryClientProvider, useIsRestoring } from '@tanstack/react-query'
 import ErrorBoundary from './components/ErrorBoundary/ErrorBoundary.jsx'
+import RecoveryLink from './components/ErrorBoundary/RecoveryLink.jsx'
 import { api, beginEphemeralAuth, getToken, setToken, BASE } from './api/client.js'
 import * as setupSession from './lib/setupSession.js'
 import { setupQueries } from './hooks/queries.js'
@@ -274,6 +275,7 @@ function SetupStatusError({ retrying, onRetry }) {
             {retrying ? 'Trying again…' : 'Try again'}
           </button>
         </div>
+        <RecoveryLink />
       </div>
     </div>
   )
@@ -296,6 +298,7 @@ function ManagedSignInError({ onRetry }) {
             Try again
           </button>
         </div>
+        <RecoveryLink />
       </div>
     </div>
   )

--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -47,7 +47,7 @@ import {
   clampDrawerRowWindow,
   drawerRowSpacerHeights,
   drawerRowWindow,
-  drawerRowWindowContaining,
+  drawerRowWindowForIndex,
   initialDrawerRowWindow,
   sameDrawerRowWindow,
 } from './drawerRowWindow.js'
@@ -272,11 +272,13 @@ export default function Drawer({
     ))
     if (!isPinned && recentIndex < 0) return
 
-    if (recentIndex < recentWindow.start || recentIndex >= recentWindow.end) {
-      setRecentWindow(drawerRowWindowContaining(
-        allRecents.length,
-        recentIndex,
-      ))
+    const revealWindow = drawerRowWindowForIndex(
+      recentWindow,
+      allRecents.length,
+      recentIndex,
+    )
+    if (revealWindow !== recentWindow) {
+      setRecentWindow(revealWindow)
       return
     }
 

--- a/frontend/src/components/Drawer/drawerRowWindow.js
+++ b/frontend/src/components/Drawer/drawerRowWindow.js
@@ -68,6 +68,16 @@ export function drawerRowWindowContaining(total, rowIndex, windowRows = DRAWER_I
   return { start, end: Math.min(count, start + width) }
 }
 
+/** Return the existing window when the row is already mounted or is not part
+ * of Recents. Pinned rows deliberately have a Recent index of -1: preserving
+ * object identity there prevents a layout effect from scheduling forever. */
+export function drawerRowWindowForIndex(current, total, rowIndex) {
+  const count = boundedTotal(total)
+  if (!Number.isInteger(rowIndex) || rowIndex < 0 || rowIndex >= count) return current
+  if (rowIndex >= current?.start && rowIndex < current?.end) return current
+  return drawerRowWindowContaining(count, rowIndex)
+}
+
 export function drawerRowSpacerHeights(window, total, rowHeight = DRAWER_ROW_HEIGHT) {
   const bounded = clampDrawerRowWindow(window, total)
   return {

--- a/frontend/src/components/ErrorBoundary/ErrorBoundary.css
+++ b/frontend/src/components/ErrorBoundary/ErrorBoundary.css
@@ -61,11 +61,15 @@
 
 .errbound__actions {
   display: flex;
+  flex-wrap: wrap;
   gap: 10px;
   justify-content: flex-end;
 }
 
 .errbound__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   font: inherit;
   font-size: 14px;
   font-weight: 500;
@@ -75,6 +79,7 @@
   background: transparent;
   color: var(--text, #ececec);
   cursor: pointer;
+  text-decoration: none;
   transition: opacity 0.15s var(--ease-out-soft, ease);
 }
 
@@ -88,4 +93,24 @@
   background: var(--accent, #8b6cf7);
   border-color: var(--accent, #8b6cf7);
   color: var(--accent-fg, #ffffff);
+}
+
+.errbound__recovery {
+  margin: 14px 0 0;
+  color: var(--muted, #a3a3a3);
+  font-size: 13px;
+  line-height: 1.5;
+  text-align: end;
+}
+
+.errbound__recovery a {
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .errbound__recovery a:hover {
+    color: var(--text, #ececec);
+  }
 }

--- a/frontend/src/components/ErrorBoundary/ErrorBoundary.css
+++ b/frontend/src/components/ErrorBoundary/ErrorBoundary.css
@@ -61,15 +61,11 @@
 
 .errbound__actions {
   display: flex;
-  flex-wrap: wrap;
   gap: 10px;
   justify-content: flex-end;
 }
 
 .errbound__btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
   font: inherit;
   font-size: 14px;
   font-weight: 500;
@@ -79,7 +75,6 @@
   background: transparent;
   color: var(--text, #ececec);
   cursor: pointer;
-  text-decoration: none;
   transition: opacity 0.15s var(--ease-out-soft, ease);
 }
 

--- a/frontend/src/components/ErrorBoundary/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary/ErrorBoundary.jsx
@@ -1,5 +1,6 @@
 import { Component } from 'react'
 import { recordClientError } from '../../lib/errorLog.js'
+import RecoveryLink from './RecoveryLink.jsx'
 import './ErrorBoundary.css'
 
 /**
@@ -78,6 +79,7 @@ export default class ErrorBoundary extends Component {
               Reload app
             </button>
           </div>
+          <RecoveryLink />
         </div>
       </div>
     )

--- a/frontend/src/components/ErrorBoundary/RecoveryLink.jsx
+++ b/frontend/src/components/ErrorBoundary/RecoveryLink.jsx
@@ -1,12 +1,13 @@
 export const RECOVERY_PATH = '/recover'
 
+/** Recovery denies framing, so nested chat errors must navigate the top-level page. */
 export default function RecoveryLink({
   className = 'errbound__recovery',
   lead = 'If the problem continues after trying again,',
 }) {
   return (
     <p className={className}>
-      {lead} <a href={RECOVERY_PATH}>open recovery</a>.
+      {lead} <a href={RECOVERY_PATH} target="_top">open recovery</a>.
     </p>
   )
 }

--- a/frontend/src/components/ErrorBoundary/RecoveryLink.jsx
+++ b/frontend/src/components/ErrorBoundary/RecoveryLink.jsx
@@ -1,0 +1,12 @@
+export const RECOVERY_PATH = '/recover'
+
+export default function RecoveryLink({
+  className = 'errbound__recovery',
+  lead = 'If the problem continues after trying again,',
+}) {
+  return (
+    <p className={className}>
+      {lead} <a href={RECOVERY_PATH}>open recovery</a>.
+    </p>
+  )
+}

--- a/frontend/src/components/StandaloneApp/StandaloneApp.css
+++ b/frontend/src/components/StandaloneApp/StandaloneApp.css
@@ -116,6 +116,20 @@
   cursor: pointer;
 }
 
+.standalone-app__recovery {
+  margin: 14px 0 0;
+  color: var(--muted, #a3a3a3);
+  font-size: 13px;
+  line-height: 1.5;
+  text-align: end;
+}
+
+.standalone-app__recovery a {
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
 .standalone-install__backdrop {
   position: fixed;
   inset: 0;

--- a/frontend/src/components/StandaloneApp/StandaloneApp.jsx
+++ b/frontend/src/components/StandaloneApp/StandaloneApp.jsx
@@ -5,6 +5,7 @@ import { api } from '../../api/client.js'
 import { appQueries } from '../../hooks/queries.js'
 import useSystemEventStream from '../../hooks/useSystemEventStream.js'
 import { stageComposerHandoff } from '../ChatView/composerDraft.js'
+import RecoveryLink from '../ErrorBoundary/RecoveryLink.jsx'
 import {
   isVisualContentOnly,
   standaloneAppVersion,
@@ -232,6 +233,10 @@ export default function StandaloneApp({ initialApp }) {
             <button type="button" onClick={() => window.location.reload()}>Try again</button>
             {app.chat_id && <button type="button" onClick={reportCrash}>Report to agent</button>}
           </div>
+          <RecoveryLink
+            className="standalone-app__recovery"
+            lead="If the app still won’t open,"
+          />
         </section>
       )}
 

--- a/frontend/src/lib/__tests__/drawerRowWindow.test.js
+++ b/frontend/src/lib/__tests__/drawerRowWindow.test.js
@@ -57,7 +57,7 @@ test('desktop active-chat reveal mounts a far row in one bounded window', () => 
   assert.equal(window.end - window.start, DRAWER_INITIAL_WINDOW_ROWS)
 })
 
-test('desktop active-chat reveal leaves the Recent window alone for a pinned row', () => {
+test('desktop active-chat reveal moves the window only for an unmounted Recent row', () => {
   const current = { start: 120, end: 168 }
 
   assert.equal(
@@ -65,4 +65,14 @@ test('desktop active-chat reveal leaves the Recent window alone for a pinned row
     current,
     'a pinned chat is absent from Recents and must not schedule a state update',
   )
+  assert.equal(
+    drawerRowWindowForIndex(current, 795, 140),
+    current,
+    'an already-mounted row must preserve object identity',
+  )
+
+  const moved = drawerRowWindowForIndex(current, 795, 620)
+  assert.notEqual(moved, current)
+  assert.ok(moved.start <= 620 && moved.end > 620)
+  assert.equal(moved.end - moved.start, DRAWER_INITIAL_WINDOW_ROWS)
 })

--- a/frontend/src/lib/__tests__/drawerRowWindow.test.js
+++ b/frontend/src/lib/__tests__/drawerRowWindow.test.js
@@ -7,6 +7,7 @@ import {
   drawerRowSpacerHeights,
   drawerRowWindow,
   drawerRowWindowContaining,
+  drawerRowWindowForIndex,
   initialDrawerRowWindow,
 } from '../../components/Drawer/drawerRowWindow.js'
 
@@ -54,4 +55,14 @@ test('desktop active-chat reveal mounts a far row in one bounded window', () => 
   const window = drawerRowWindowContaining(795, 620)
   assert.ok(window.start <= 620 && window.end > 620)
   assert.equal(window.end - window.start, DRAWER_INITIAL_WINDOW_ROWS)
+})
+
+test('desktop active-chat reveal leaves the Recent window alone for a pinned row', () => {
+  const current = { start: 120, end: 168 }
+
+  assert.equal(
+    drawerRowWindowForIndex(current, 795, -1),
+    current,
+    'a pinned chat is absent from Recents and must not schedule a state update',
+  )
 })

--- a/frontend/src/lib/__tests__/recoveryLink.test.js
+++ b/frontend/src/lib/__tests__/recoveryLink.test.js
@@ -1,0 +1,23 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import RecoveryLink, {
+  RECOVERY_PATH,
+} from '../../components/ErrorBoundary/RecoveryLink.jsx'
+
+test('recovery stays a plain last-resort link with adaptable context', () => {
+  const defaultHtml = renderToStaticMarkup(createElement(RecoveryLink))
+  assert.match(defaultHtml, /class="errbound__recovery"/)
+  assert.match(defaultHtml, /If the problem continues after trying again/)
+  assert.match(defaultHtml, new RegExp(`href="${RECOVERY_PATH}"`))
+
+  const standaloneHtml = renderToStaticMarkup(createElement(RecoveryLink, {
+    className: 'standalone-app__recovery',
+    lead: 'If the app still won’t open,',
+  }))
+  assert.match(standaloneHtml, /class="standalone-app__recovery"/)
+  assert.match(standaloneHtml, /If the app still won’t open/)
+  assert.match(standaloneHtml, />open recovery<\/a>/)
+})

--- a/frontend/src/lib/__tests__/recoveryLink.test.js
+++ b/frontend/src/lib/__tests__/recoveryLink.test.js
@@ -12,6 +12,7 @@ test('recovery stays a plain last-resort link with adaptable context', () => {
   assert.match(defaultHtml, /class="errbound__recovery"/)
   assert.match(defaultHtml, /If the problem continues after trying again/)
   assert.match(defaultHtml, new RegExp(`href="${RECOVERY_PATH}"`))
+  assert.match(defaultHtml, /target="_top"/)
 
   const standaloneHtml = renderToStaticMarkup(createElement(RecoveryLink, {
     className: 'standalone-app__recovery',


### PR DESCRIPTION
## Summary

- preserve the existing Recent row window when the active chat is pinned or already mounted, preventing the drawer layout effect from scheduling a fresh state object on every commit
- add a shared, plain-anchor recovery fallback to fatal React, startup, sign-in, and standalone-app failure surfaces
- keep Retry, Reload, and Report as the primary actions; recovery appears only as quiet last-resort guidance
- make recovery escape nested chat-embed frames to the top-level page, because the recovery service denies framing
- make the pre-React bootstrap watchdog retry the exact current URL before offering recovery

## Root cause

A pinned chat is intentionally absent from the Recent list, so its row index is -1. The active-chat reveal effect passed that index to the window constructor, which returned a new initial-window object. Setting that fresh object from the layout effect on every commit caused React maximum-update-depth error 185.

## Review follow-up

The maintainer pass also covered every recent-window writer and every fatal-error entry point. It strengthened the row-window regression to prove both no-op and far-row transitions, removed styling left over from an earlier recovery-button treatment, and made recovery links target the top-level window so they remain usable from the sandboxed chat embed.

## Verification

- npm test — 2,230 library tests and 76 hook tests pass
- structural-test ratchet remains at 88/88 files and 780/780 cases
- npm run build — production and offline validation pass
- npm run lint — 0 errors, existing warning baseline remains within the repository limit
- Impeccable detector — clean
- pre-push frontend-unit gate passes