### PR TITLE
Make cold Q&A chat entry responsive

### DIFF
--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -391,12 +391,25 @@ def _chat_detail_response(
 
   all_msgs = materialized_messages(chat)
   running = is_chat_running(chat.id) or has_running_run(db, chat.id)
+  pending_question = questions.get(chat.id)
   live_snapshot = chat.live_assistant
   live_message = (
     all_msgs[-1]
     if running
     and all_msgs
     and all_msgs[-1] is live_snapshot
+    else None
+  )
+  # A genuinely streaming assistant row must remain self-contained: the live
+  # surface may need every block before the next event arrives. A runner parked
+  # on an owner question is different. Nothing can extend that row until the
+  # question is answered, so its already-settled activity can use the same lazy
+  # compact projection as immutable history. The frontend deliberately does
+  # not attach to the replay stream during this pause; answering reconnects it
+  # before the provider can add more output.
+  compact_exempt_live_message = (
+    live_message
+    if not (compact and questions.is_waiting(chat.id))
     else None
   )
   total = len(all_msgs)
@@ -436,7 +449,7 @@ def _chat_detail_response(
     page = compact_messages_for_detail(
       page,
       message_offset=start,
-      live_message=live_message,
+      live_message=compact_exempt_live_message,
     )
   from app.chat_media_dimensions import project_message_image_dimensions
   page = project_message_image_dimensions(
@@ -446,7 +459,6 @@ def _chat_detail_response(
   )
 
   provider = chat.provider or "claude"
-  pending_question = questions.get(chat.id)
   settings_obj = _coerce_agent_settings(chat.agent_settings_json) or None
   active_goal_objective = (
     running_goal_objective(db, chat.id) if running else None

--- a/backend/tests/test_chat_transcript_compact.py
+++ b/backend/tests/test_chat_transcript_compact.py
@@ -1,6 +1,10 @@
 """Compact chat reads keep the transcript light without changing stored truth."""
 
+import asyncio
+
+from app import models, questions
 from app.chat_transcript import compact_messages_for_detail
+from app.pending_questions import PendingQuestion
 from sqlalchemy import event
 
 
@@ -178,6 +182,74 @@ def test_single_activity_and_live_message_remain_self_contained():
   assert compact is messages
   assert compact[0] is single
   assert compact[1] is live
+
+
+def test_compact_route_folds_settled_activity_while_live_turn_waits_for_answer(
+  client,
+  auth,
+  db,
+  monkeypatch,
+):
+  created = client.post(
+    "/api/chats",
+    headers=auth,
+    json={"title": "Parked question"},
+  )
+  assert created.status_code == 200
+  chat_id = created.json()["id"]
+  chat = db.get(models.Chat, chat_id)
+  chat.live_assistant = {
+    "role": "assistant",
+    "ts": 42,
+    "blocks": [
+      {"type": "thinking", "content": "settled reasoning"},
+      {"type": "tool", "tool": "Bash", "output": "settled output"},
+      {"type": "question", "question_id": "question-1", "questions": []},
+    ],
+  }
+  db.commit()
+  question_loop = asyncio.new_event_loop()
+  pending = PendingQuestion(
+    question_id="question-1",
+    questions=[],
+    future=question_loop.create_future(),
+  )
+  questions.register(chat_id, pending)
+  monkeypatch.setattr("app.routes.chats.is_chat_running", lambda _: True)
+
+  try:
+    response = client.get(
+      f"/api/chats/{chat_id}?limit=20&compact=1",
+      headers=auth,
+    )
+  finally:
+    questions.cancel(chat_id)
+    question_loop.close()
+
+  assert response.status_code == 200
+  payload = response.json()
+  assert payload["running"] is True
+  assert payload["pending_question_id"] == "question-1"
+  assert payload["messages"][0]["blocks"] == [
+    {
+      "type": "activity",
+      "activity_id": "0:0:2",
+      "message_index": 0,
+      "start": 0,
+      "end": 2,
+      "entries": [
+        {"item": {"type": "thinking"}, "idx": 0},
+        {
+          "item": {"type": "tool", "tool": "Bash", "status": "done"},
+          "idx": 1,
+        },
+      ],
+      "tool_count": 1,
+    },
+    {"type": "question", "question_id": "question-1", "questions": []},
+  ]
+  assert "settled reasoning" not in response.text
+  assert "settled output" not in response.text
 
 
 def test_image_reads_stay_distinctive_and_question_twins_are_not_rendered():

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -1,4 +1,5 @@
 import {
+  startTransition,
   useState,
   useRef,
   useEffect,
@@ -6,6 +7,7 @@ import {
   useCallback,
   useMemo,
 } from 'react'
+import { flushSync } from 'react-dom'
 import { useQueryClient } from '@tanstack/react-query'
 import Check from 'lucide-react/dist/esm/icons/check.mjs'
 import { apiFetch, getAuthHeaders, jsonOrThrow, BASE } from '../../api/client.js'
@@ -73,11 +75,13 @@ import {
   builtAppPulseDecision,
   canFastForwardQueue,
   cidOf,
+  coldTranscriptRenderFrames,
   continuationRowsFromPromotedMessage,
   isAutoContinuationMessage,
   isOwnerUserMessage,
   mergeRecentMessagesIntoLoadedWindow,
   openAppCtaViewModel,
+  shouldAttachRunningStream,
   shouldRetryStopAfterConfirm,
   stopConfirmedIdle,
   stopRequestSucceeded,
@@ -131,6 +135,14 @@ const MESSAGE_META_VISIBLE_MS = 5000
 
 function delay(ms) {
   return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function yieldToMainThread() {
+  // scheduler.yield() continuations retain enough priority for React to batch
+  // every prefix update into one final commit in Chromium. A fresh timer task
+  // gives React a real commit/paint/input boundary without imposing a whole
+  // animation-frame delay on every hidden slice.
+  return new Promise(resolve => setTimeout(resolve, 0))
 }
 
 function appendMessageBatch(prev, rows) {
@@ -828,6 +840,7 @@ export default function ChatView({
       }
       return {
         running: !!data.running,
+        pendingQuestionId: data.pending_question_id || null,
         pendingLimitResume: !!tailResumableBlock(msgs)?.pause?.resets_at,
       }
     } catch {
@@ -1211,7 +1224,10 @@ export default function ChatView({
           setEmbeddedRunActive(true)
         }
         if (
-          (running === true || (snapshot === null && delta.started))
+          shouldAttachRunningStream({
+            running: running === true || (snapshot === null && delta.started),
+            pendingQuestionId: snapshot?.pendingQuestionId,
+          })
           && !delta.finished
           && !isStreamingRef.current
         ) {
@@ -1237,7 +1253,10 @@ export default function ChatView({
   const ensureRuntimeStreamConnected = useCallback(() => {
     if (hiddenRef.current) return
     if (connectionError === 'disconnected') return
-    if (!serverRunningRef.current) return
+    if (!shouldAttachRunningStream({
+      running: serverRunningRef.current,
+      pendingQuestionId: liveQuestionId,
+    })) return
     if (isStreamingRef.current) return
     if (runtimeReconnectInFlightRef.current) return
 
@@ -1251,7 +1270,7 @@ export default function ChatView({
       .finally(() => {
         runtimeReconnectInFlightRef.current = false
       })
-  }, [connectToStream, connectionError, isStreamingRef])
+  }, [connectToStream, connectionError, isStreamingRef, liveQuestionId])
 
   const wasHiddenRef = useRef(hidden)
   useLayoutEffect(() => {
@@ -1577,7 +1596,12 @@ export default function ChatView({
       pendingQueue.hydrate(runtime.pending_messages || [])
       if (running) {
         setSending(true)
-        connectToStream(false)
+        if (shouldAttachRunningStream({
+          running,
+          pendingQuestionId: runtime.pending_question_id,
+        })) {
+          connectToStream(false)
+        }
       } else {
         setSending(false)
         sendingRef.current = false
@@ -1672,7 +1696,33 @@ export default function ChatView({
         messages: refreshed.messages,
         offset: refreshed.offset,
       })
-      applyMessagesToView(refreshed.messages, refreshed.offset)
+      const renderFrames = coldTranscriptRenderFrames(refreshed.messages)
+      if (renderFrames.length === 1) {
+        // An ordinary cold transcript stays one interruptible commit. Readiness
+        // remains in the SAME transition, so the shell cannot reveal a partial
+        // transcript; cached activations above remain immediate.
+        startTransition(() => {
+          applyMessagesToView(refreshed.messages, refreshed.offset)
+          settleRuntime(runtime, refreshed.messages)
+        })
+        return
+      }
+
+      // A single agentic turn can contain hundreds of interleaved worklog,
+      // activity, and report blocks. React cannot interrupt one DOM commit, so
+      // prepare that hidden destination in prefix-complete frame-sized slices.
+      // Each await yields a real paint opportunity to the outgoing chat and
+      // drawer. Only the final authoritative frame settles loading/readiness,
+      // preserving the existing hide-then-reveal scroll contract.
+      setInitialEntryPhase('preparing')
+      for (const frame of renderFrames) {
+        await yieldToMainThread()
+        if (cancelled || fetchGenRef.current !== gen) return
+        // React may batch state updates across async task yields and discard
+        // every intermediate prefix. Commit each hidden slice explicitly; the
+        // flush is scoped to this cold, off-screen preparation path only.
+        flushSync(() => applyMessagesToView(frame, refreshed.offset))
+      }
       settleRuntime(runtime, refreshed.messages)
     }
 

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -1717,7 +1717,18 @@ export default function ChatView({
       setInitialEntryPhase('preparing')
       for (const frame of renderFrames) {
         await yieldToMainThread()
-        if (cancelled || fetchGenRef.current !== gen) return
+        if (cancelled) return
+        if (fetchGenRef.current !== gen) {
+          // A newer generation owns the runtime now (a fresh send, or Stop
+          // clearing the queue), so this fetch must NOT apply its own runtime
+          // state — settleRuntime would re-hydrate the queue Stop just
+          // cleared. But 'preparing' is a hidden gate that only this path
+          // sets, and neither superseding path releases it: returning here
+          // without releasing it strands the chat blank until remount.
+          setInitialEntryPhase('ready')
+          setLoading(false)
+          return
+        }
         // React may batch state updates across async task yields and discard
         // every intermediate prefix. Commit each hidden slice explicitly; the
         // flush is scoped to this cold, off-screen preparation path only.

--- a/frontend/src/components/ChatView/MsgContent.jsx
+++ b/frontend/src/components/ChatView/MsgContent.jsx
@@ -183,6 +183,7 @@ function MsgContentInner({
                     />
                   : <StandardMarkdown
                       text={text}
+                      renderFraction={block._coldRenderFraction}
                       onInternalNav={onInternalNav}
                       mediaDimensions={msg.media_dimensions}
                     />)

--- a/frontend/src/components/ChatView/__tests__/chatRuntimeState.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatRuntimeState.test.js
@@ -8,6 +8,7 @@ import {
   canFastForwardQueue,
   shouldFreezeStreamingReturn,
   cidOf,
+  coldTranscriptRenderFrames,
   continuationRowsFromPromotedMessage,
   isAutoContinuationMessage,
   isOwnerUserMessage,
@@ -16,6 +17,7 @@ import {
   previewReadyAnnouncement,
   previewUpdatedAnnouncement,
   serverSnapshotBehindLocal,
+  shouldAttachRunningStream,
   shouldRetryStopAfterConfirm,
   shouldShowOpenAppCta,
   startedMessagesFromResponse,
@@ -97,6 +99,72 @@ test('only a recovered question answer starts a new hidden turn', () => {
 test('answer turn ownership requires the explicit semantic field', () => {
   assert.equal(answerTurnDisposition({ status: 'answer_delivered' }), 'unknown')
   assert.equal(answerTurnDisposition({ status: 'started' }), 'unknown')
+})
+
+test('a parked owner question uses compact history until its answer resumes the turn', () => {
+  assert.equal(shouldAttachRunningStream({
+    running: true,
+    pendingQuestionId: 'question-1',
+  }), false)
+  assert.equal(shouldAttachRunningStream({
+    running: true,
+    pendingQuestionId: null,
+  }), true)
+  assert.equal(shouldAttachRunningStream({
+    running: false,
+    pendingQuestionId: null,
+  }), false)
+})
+
+test('a pathological cold transcript is prepared as stable prefix frames', () => {
+  const large = {
+    role: 'assistant',
+    ts: 2,
+    blocks: Array.from({ length: 9 }, (_, index) => ({
+      type: 'text',
+      content: `report-${index}-${'x'.repeat(4000)}`,
+    })),
+  }
+  const messages = [{ role: 'user', ts: 1, content: 'audit' }, large]
+  const frames = coldTranscriptRenderFrames(messages, {
+    minCost: 1,
+    frameBudget: 4,
+  })
+
+  assert.equal(frames.length, 5)
+  assert.deepEqual(
+    frames.slice(0, -1).map(frame => frame.at(-1).blocks.length),
+    [2, 4, 6, 8],
+  )
+  assert.equal(frames.at(-1), messages,
+    'the reveal frame is the authoritative transcript array')
+  assert.equal(frames[0][0], messages[0],
+    'already-complete prefix messages retain identity across frames')
+})
+
+test('ordinary cold transcripts keep the one-commit path', () => {
+  const messages = [{
+    role: 'assistant',
+    blocks: [{ type: 'text', content: 'Short answer' }],
+  }]
+  assert.deepEqual(coldTranscriptRenderFrames(messages), [messages])
+})
+
+test('one long markdown block grows by token fractions instead of one giant frame', () => {
+  const block = { type: 'text', content: 'x'.repeat(48000) }
+  const messages = [{ role: 'assistant', ts: 1, blocks: [block] }]
+  const frames = coldTranscriptRenderFrames(messages, {
+    minCost: 1,
+    frameBudget: 4,
+  })
+
+  assert.deepEqual(
+    frames.slice(0, -1).map(frame => frame[0].blocks[0]._coldRenderFraction),
+    [4 / 12, 8 / 12],
+  )
+  assert.equal(frames.at(-1), messages)
+  assert.equal('_coldRenderFraction' in block, false,
+    'the read-side render plan never mutates transcript data')
 })
 
 test('an unknown explicit answer-turn value fails closed to a separate boundary', () => {

--- a/frontend/src/components/ChatView/chatRuntimeState.js
+++ b/frontend/src/components/ChatView/chatRuntimeState.js
@@ -180,6 +180,107 @@ export function answerKeepsCurrentTurn(response) {
   return answerTurnDisposition(response) === 'same'
 }
 
+/**
+ * A running turn normally owns a live replay stream. An unanswered owner
+ * question is a protocol barrier: no assistant output can arrive before the
+ * answer, while replaying the entire pre-question event log would only rebuild
+ * settled history beside the durable card. Keep that pause on the compact DB
+ * surface; the answer transport attaches before the runner continues.
+ */
+export function shouldAttachRunningStream({
+  running,
+  pendingQuestionId,
+} = {}) {
+  return !!running && !pendingQuestionId
+}
+
+function coldBlockRenderCost(block) {
+  if (block?.type !== 'text') return 1
+  // Markdown reports create work roughly in proportion to their source size,
+  // not merely their block count. Weight long prose so one helper report does
+  // not consume an entire supposedly-small frame by itself.
+  return Math.max(1, Math.ceil(String(block.content || '').length / 4000))
+}
+
+/**
+ * Build prefix-complete frames for a pathological cold transcript commit.
+ *
+ * The view stays hidden until the caller commits the final frame, so these are
+ * not partial product states. Each frame only appends blocks/messages; stable
+ * keys let React retain markdown and disclosure DOM already prepared by the
+ * prior frame. Ordinary chats return the original array as their sole frame.
+ */
+export function coldTranscriptRenderFrames(
+  messages,
+  { minCost = 80, frameBudget = 4 } = {},
+) {
+  if (!Array.isArray(messages) || messages.length === 0) return [messages || []]
+
+  const totalCost = messages.reduce((sum, message) => {
+    const blocks = Array.isArray(message?.blocks) ? message.blocks : []
+    return sum + (blocks.length > 0
+      ? blocks.reduce((blockSum, block) => blockSum + coldBlockRenderCost(block), 0)
+      : 1)
+  }, 0)
+  if (totalCost < minCost) return [messages]
+
+  const frames = []
+  const completeMessages = []
+  let frameCost = 0
+  for (const message of messages) {
+    const blocks = Array.isArray(message?.blocks) ? message.blocks : []
+    if (blocks.length === 0) {
+      completeMessages.push(message)
+      continue
+    }
+
+    const visibleBlocks = []
+    const publish = partialBlock => {
+      frames.push([
+        ...completeMessages,
+        {
+          ...message,
+          blocks: partialBlock
+            ? [...visibleBlocks, partialBlock]
+            : [...visibleBlocks],
+        },
+      ])
+    }
+
+    for (const block of blocks) {
+      const blockCost = coldBlockRenderCost(block)
+      let consumed = 0
+      while (consumed < blockCost) {
+        const take = Math.min(
+          frameBudget - frameCost,
+          blockCost - consumed,
+        )
+        consumed += take
+        frameCost += take
+        const complete = consumed === blockCost
+        const partialBlock = complete
+          ? null
+          : { ...block, _coldRenderFraction: consumed / blockCost }
+        if (complete) visibleBlocks.push(block)
+        if (frameCost === frameBudget) {
+          publish(partialBlock)
+          frameCost = 0
+        }
+      }
+    }
+    completeMessages.push(message)
+  }
+
+  if (frameCost > 0) frames.push([...completeMessages])
+
+  // The terminal commit must use the authoritative objects, not a last-message
+  // clone manufactured by the render plan. This keeps cache/view identity and
+  // the transcript state owner's equivalence checks aligned after reveal.
+  if (frames.length === 0) return [messages]
+  frames[frames.length - 1] = messages
+  return frames
+}
+
 export function shouldShowOpenAppCta(builtApp, turnActive = false) {
   if (!builtApp?.id) return false
   const seenCurrentBuild = Boolean(

--- a/frontend/src/components/ChatView/hooks/__tests__/useTranscriptState.test.js
+++ b/frontend/src/components/ChatView/hooks/__tests__/useTranscriptState.test.js
@@ -63,3 +63,26 @@ test('structurally identical commits still publish but avoid replacing view stat
   assert.equal(queryClient.writes, 1)
   assert.notEqual(queryClient.value.messages, first)
 })
+
+test('an accepted equivalent snapshot remains the synchronous owner across rerenders', () => {
+  const first = [{ role: 'user', content: 'same', ts: 1 }]
+  const equivalent = [{ ...first[0] }]
+  const queryClient = queryClientWith({ messages: first, offset: 0 })
+  const hookArgs = {
+    cacheKey: ['chat-messages', 7],
+    cached: queryClient.value,
+    queryClient,
+  }
+  const { result, rerender } = renderHook(useTranscriptState, hookArgs)
+
+  result.current.applyMessagesToView(equivalent, 0)
+  assert.equal(result.current.messages, first)
+  assert.equal(result.current.messagesRef.current, equivalent)
+
+  // Model an unrelated urgent render landing before an interruptible
+  // transcript transition. Rendered state is still the old equivalent array;
+  // the synchronous owner must not be rolled back to it.
+  rerender(hookArgs)
+  assert.equal(result.current.messages, first)
+  assert.equal(result.current.messagesRef.current, equivalent)
+})

--- a/frontend/src/components/ChatView/hooks/useTranscriptState.js
+++ b/frontend/src/components/ChatView/hooks/useTranscriptState.js
@@ -15,8 +15,12 @@ export default function useTranscriptState({ cacheKey, cached, queryClient }) {
   const [offset, setOffset] = useState(() => cached?.offset ?? 0)
   const messagesRef = useRef(messages)
   const offsetRef = useRef(offset)
-  messagesRef.current = messages
-  offsetRef.current = offset
+
+  // The mutation methods below advance these owners before scheduling React
+  // state. Do not copy rendered state back into them here: an interruptible
+  // cold-history render may be preceded by an urgent stream/runtime render of
+  // the older UI. That render must not roll the already-accepted transcript
+  // snapshot backward while the transition is still pending.
 
   const applyMessagesToView = useCallback((next, nextOffset, force = false) => {
     const prev = messagesRef.current

--- a/frontend/src/components/ChatView/markdown/BlockRenderer.jsx
+++ b/frontend/src/components/ChatView/markdown/BlockRenderer.jsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 import { Marked } from 'marked'
-import { MemoBlock, BlockToken, MathBlock } from './blocks.jsx'
+import { MemoBlock, MathBlock } from './blocks.jsx'
 import { mathTokens } from './mathTokens.js'
 import { groupMarkdownImages } from './imageGallery.js'
 import ImageGallery from './ImageGallery.jsx'
@@ -88,9 +88,17 @@ export function ProgressiveMarkdown({
 
 /**
  * StandardMarkdown — history mode.
- * One-shot render, no memoization overhead.
+ *
+ * Settled blocks normally render once. A pathological cold transcript can
+ * prepare one long block over several hidden frames; `renderFraction` reveals
+ * token prefixes while one memoized token tree keeps already-prepared DOM.
  */
-export function StandardMarkdown({ text, onInternalNav, mediaDimensions }) {
+export function StandardMarkdown({
+  text,
+  renderFraction,
+  onInternalNav,
+  mediaDimensions,
+}) {
   // The settled-transcript renderer, so this is the one that matters for "a
   // stopped chat still feels slow". `useMemo` only holds while the component
   // stays mounted; if anything remounts messages this re-tokenises every
@@ -100,10 +108,14 @@ export function StandardMarkdown({ text, onInternalNav, mediaDimensions }) {
     () => perfTime('markdown.tokenize.settled', () => groupMarkdownImages(tokenize(text))),
     [text],
   )
+  const fraction = Number(renderFraction)
+  const visibleTokens = Number.isFinite(fraction) && fraction > 0 && fraction < 1
+    ? tokens.slice(0, Math.max(1, Math.ceil(tokens.length * fraction)))
+    : tokens
 
   return (
     <div className="standard-markdown md-blocks">
-      {tokens.map((token, i) => {
+      {visibleTokens.map((token, i) => {
         const appCard = appLinkCardFromParagraph(token, window.location.href)
         if (appCard) {
           return <AppLinkCard key={i} card={appCard} onInternalNav={onInternalNav} />
@@ -121,7 +133,7 @@ export function StandardMarkdown({ text, onInternalNav, mediaDimensions }) {
           )
         }
         return (
-          <BlockToken
+          <MemoBlock
             key={i}
             token={token}
             onInternalNav={onInternalNav}

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -64,6 +64,7 @@ import { isPerfProbeEnabled, perfMark, perfTime } from '../../lib/perfProbe.js'
 // readiness: inline media owns a reserved frame and ResizeObserver keeps the
 // saved anchor stable as lazy previews arrive after reveal.
 const REVEAL_CAP_MS = 1500
+const PREPARING_REVEAL_CAP_MS = 5000
 
 // Reader quiet-settle window. Input and momentum retain Infinity ownership;
 // every real scroll restarts this timer. Only its trailing edge derives the
@@ -1037,7 +1038,7 @@ export function modeForQueuedSubmission(scrollEl, currentMode) {
  *   shows/hides because the tray's margin shrinks the spacer math).
  * @param {React.MutableRefObject<boolean>} args.loadingOlderRef
  *   When true, scroll events from pagination shouldn't mutate mode.
- * @param {'history'|'cached'|'ready'} args.initialEntryPhase
+ * @param {'history'|'cached'|'preparing'|'ready'} args.initialEntryPhase
  *   One entry-readiness state: history blocks reveal, cached permits an
  *   immediate first paint while layout stabilizes, and ready means the
  *   authoritative history read has settled.
@@ -1158,8 +1159,26 @@ export default function useScrollMode({
     revealedRef.current = false
     mountStabilizingRef.current = true
     setRevealed(false)
+    let preparationDeadline = 0
     const deadline = setTimeout(() => {
       if (revealedRef.current) return
+      // A pathological transcript can be deliberately preparing in bounded,
+      // committed slices. Revealing at the ordinary stalled-request cap would
+      // expose that incomplete prefix and let its later growth take over the
+      // reader's scroll mode. Give this explicit phase its own absolute escape
+      // hatch; a normal ready transition still reveals immediately through the
+      // quiet-layout path below.
+      if (initialEntryPhaseRef.current === 'preparing') {
+        preparationDeadline = setTimeout(() => {
+          if (revealedRef.current) return
+          if (forceRevealRef.current) forceRevealRef.current()
+          else {
+            revealedRef.current = true
+            setRevealed(true)
+          }
+        }, PREPARING_REVEAL_CAP_MS - REVEAL_CAP_MS)
+        return
+      }
       if (forceRevealRef.current) forceRevealRef.current()
       else {
         // Defensive fallback for a mount whose scroll DOM never materialized.
@@ -1167,7 +1186,10 @@ export default function useScrollMode({
         setRevealed(true)
       }
     }, REVEAL_CAP_MS)
-    return () => clearTimeout(deadline)
+    return () => {
+      clearTimeout(deadline)
+      clearTimeout(preparationDeadline)
+    }
   }, [chatId])
 
   // Geometry capture reads scrollHeight/offsetHeight, which forces a synchronous
@@ -1504,8 +1526,16 @@ export default function useScrollMode({
     const listEl = scrollEl.querySelector('.chat__list')
     if (!listEl) return
 
-    // Restore mode for this chat if persisted (mount-restore path).
-    if (modeRef.current.kind === 'INITIAL') {
+    // Restore mode for this chat if persisted (mount-restore path). A
+    // progressive cold render exposes only a prefix of one giant assistant
+    // row; validating a saved deep-in-row offset against that temporary short
+    // row would reject the real location as off-content and permanently fall
+    // back to the top. Wait for the authoritative frame, whose ready-phase
+    // render re-runs this effect with the complete row geometry.
+    if (
+      modeRef.current.kind === 'INITIAL'
+      && initialEntryPhaseRef.current !== 'preparing'
+    ) {
       const saved = _scrollModes[chatId]
       const restored = _validateSavedMode(saved, messagesRef.current, scrollEl)
       readerLocationExplicitRef.current = !!saved

--- a/frontend/src/components/ChatView/useStreamConnection.js
+++ b/frontend/src/components/ChatView/useStreamConnection.js
@@ -1451,7 +1451,17 @@ export default function useStreamConnection(chatId, {
       // streaming whatever the runner emits next. Returning here
       // prevents a redundant reconnect that would close the live
       // stream and replay the full catch-up burst.
-      if (data.status === 'answer_delivered') return data
+      if (data.status === 'answer_delivered') {
+        // A cold entry on a parked question intentionally skips replaying the
+        // settled pre-question event log. The answer releases that barrier, so
+        // attach now before the runner can publish its continuation. Existing
+        // live viewers retain their socket and avoid a redundant full replay.
+        if (!isStreamingRef.current) {
+          wantsReconnectRef.current = true
+          connectRef.current?.(true)
+        }
+        return data
+      }
       // A recovered AskUserQuestion answer (the process restarted after
       // persisting the question block) starts a fresh hidden continuation.
       // Its response declares `answer_turn: "new"` for ChatView's bridge


### PR DESCRIPTION
## Summary
- prepare oversized cold transcripts in bounded hidden slices, then reveal only the authoritative frame
- preserve saved reader position during preparation and keep ordinary cached entries on the existing path
- compact settled activity and defer replay while a running turn waits on an owner Q&A response

## Validation
- `scripts/wt-pytest.sh backend/tests/test_chat_transcript_compact.py --tb=short -q` (10 passed)
- frontend library tests (2,234 passed)
- frontend hook tests (77 passed)
- `npm run build`
- authenticated browser probe at 1512×861: worst reproduced main-thread gap reduced from 773 ms to 167 ms, with first reveal settled at the transcript bottom