### PR TITLE
Migrate stale cron guidance to app-scoped credentials

### DIFF
--- a/backend/scripts/init_skills.py
+++ b/backend/scripts/init_skills.py
@@ -50,6 +50,9 @@ _UNMODIFIED_MIGRATIONS = {
   "cron.md": {
     "289336d78ad4268110360f12faac5512d5a53b66aa31c2a6ddd1a44f538f2559",
     "ed100cb496b887a7951adc967e92cda1449c4f8594f7859fbd32762221d24914",
+    # Locally curated pre-app-token copy. It tells scheduled app jobs to read
+    # the owner service token, contradicting supervised $APP_TOKEN authority.
+    "16055ea6ba6e4663636f87fde9868aa98d49ab39c5037ff90fa673d96c259cd9",
   },
   "recovery.md": {
     "ef62abb0d03d740f99add1b6f3938f780b34439cb0025616cb9dc5f74f779633",

--- a/backend/tests/test_memory_boot.py
+++ b/backend/tests/test_memory_boot.py
@@ -104,6 +104,11 @@ def test_controlled_skills_have_fix_forward_migrations():
   module = _load("init_skills")
 
   assert module.SEED_VERSION == "22"
+  assert module._UNMODIFIED_MIGRATIONS["cron.md"] == {
+    "289336d78ad4268110360f12faac5512d5a53b66aa31c2a6ddd1a44f538f2559",
+    "ed100cb496b887a7951adc967e92cda1449c4f8594f7859fbd32762221d24914",
+    "16055ea6ba6e4663636f87fde9868aa98d49ab39c5037ff90fa673d96c259cd9",
+  }
   assert module._UNMODIFIED_MIGRATIONS["images.md"] == {
     "248ea31e13d2d2d84a5acfca13526aa8ebfa3d90e9ee4bf55cfb72d47937f7d1",
     "29039a6fc5c9281794247eda5d0bbf66e969a1a260e9ed56c69ee6e1cd175f7c",
@@ -139,6 +144,15 @@ def test_controlled_skills_have_fix_forward_migrations():
     "6e6e82e02287e8bb38195fb021ea25cee2dc4e27da1a6ce1e2a0143fb1d82d87"
     in module._UNMODIFIED_MIGRATIONS["recovery.md"]
   )
+
+
+def test_seeded_cron_jobs_use_only_app_scoped_credentials():
+  text = (SCRIPTS / "seed-skills" / "cron.md").read_text(encoding="utf-8")
+
+  assert 'Authorization: Bearer $APP_TOKEN' in text
+  assert "Never read `/data/service-token.txt` from an app job" in text
+  assert "SERVICE_TOKEN=$(cat /data/service-token.txt)" not in text
+  assert "using bearer token $SERVICE_TOKEN" not in text
 
 
 def test_cron_starts_only_after_per_boot_supervision_proof():


### PR DESCRIPTION
## Why

#390 moved managed app jobs to short-lived app-scoped credentials and updated the current cron skill seed. One exact, locally curated predecessor was never registered in the hash-gated skill migration table, so installations carrying that untouched copy continued to tell app jobs to read the owner service token.

This follow-up closes that propagation gap without broad overwrites: only the byte-identical stale predecessor is eligible for migration, while every differently edited owner copy remains untouched.

## What changes

- register the known stale cron-skill digest in the existing hash-gated migration table;
- pin the complete accepted digest set in the boot contract;
- assert that the current seed uses `$APP_TOKEN` and does not contain the retired service-token example.

## Verification

- all 10 exact boot and skill-migration checks passed on the review branch;
- Python compilation and Ruff passed;
- the combined reviewed maintenance tree passed 3,440 backend checks with one skip and 111 isolated recovery checks.