### PR TITLE
Centralize programmatic chat-turn startup

### DIFF
--- a/backend/app/chat_start.py
+++ b/backend/app/chat_start.py
@@ -1,0 +1,94 @@
+"""Programmatic chat-turn startup behind one lifecycle boundary.
+
+Interactive sends own request-specific validation and response shaping in the
+chat route.  App conflict resolution, platform conflict resolution, and
+Contribute Autopilot all start a prepared turn without that HTTP lifecycle.
+Those callers still own their distinct eligibility rules; this module owns the
+shared start protocol after eligibility is established.
+"""
+
+import asyncio
+import time
+
+from app.broadcast import (
+  create_broadcast,
+  get_system_broadcast,
+  remove_broadcast,
+)
+from app.chat import (
+  current_run_generation,
+  discard_starting,
+  mark_starting,
+  run_chat,
+)
+from app.chat_writer import (
+  StartTurn,
+  alloc_run_token,
+  await_ack,
+  get_writer,
+)
+
+
+async def start_programmatic_chat_turn(
+  *, chat_id: str, title: str, content: str, provider: str,
+) -> bool:
+  """Durably start one system-initiated turn if the chat can be claimed.
+
+  The caller decides whether the chat is eligible (empty-only conflict chats,
+  reusable Autopilot chats, or a newly created platform resolver).  This
+  boundary owns the claim, writer command, Stop-generation fence, broadcast,
+  task creation, and failure cleanup so those steps cannot drift by caller.
+
+  Returns ``False`` when the claim fails or a Stop wins while ``StartTurn`` is
+  committing.  Unexpected failures propagate after releasing the transient
+  claim; the durable run remains available to normal reconciliation.
+  """
+  if not mark_starting(chat_id):
+    return False
+
+  run_coro = None
+  broadcast_created = False
+  try:
+    start_gen = current_run_generation(chat_id)
+    run_token = alloc_run_token()
+    user_msg = {
+      "role": "user",
+      "content": content,
+      "ts": int(time.time() * 1000),
+    }
+    result = await await_ack(get_writer().submit(StartTurn(
+      chat_id=chat_id,
+      run_token=run_token,
+      user_msg=user_msg,
+      title_source=title,
+      default_provider=provider,
+    )))
+
+    if current_run_generation(chat_id) != start_gen:
+      discard_starting(chat_id)
+      return False
+
+    create_broadcast(chat_id)
+    broadcast_created = True
+    run_coro = run_chat(
+      result["history"],
+      chat_id=chat_id,
+      session_id=result["session_id"],
+      provider_id=result["provider"],
+      run_gen=start_gen,
+      run_token=run_token,
+    )
+    asyncio.create_task(run_coro)
+    run_coro = None
+    get_system_broadcast().publish({
+      "type": "chat_run_started",
+      "chatId": chat_id,
+    })
+    return True
+  except Exception:
+    if run_coro is not None:
+      run_coro.close()
+    if broadcast_created:
+      remove_broadcast(chat_id)
+    discard_starting(chat_id)
+    raise

--- a/backend/app/chat_start.py
+++ b/backend/app/chat_start.py
@@ -85,7 +85,14 @@ async def start_programmatic_chat_turn(
       "chatId": chat_id,
     })
     return True
-  except Exception:
+  except BaseException:
+    # BaseException, not Exception: ``asyncio.CancelledError`` derives from
+    # BaseException, and the only suspension point above is the ``await_ack``
+    # that a cancellation lands on -- after ``mark_starting`` has succeeded.
+    # Leaking the claim there wedges the chat as 'starting' until the process
+    # restarts (see ``discard_starting`` in app/chat.py), which is exactly the
+    # drift this boundary exists to own.  The re-raise below keeps cancellation
+    # propagating normally.
     if run_coro is not None:
       run_coro.close()
     if broadcast_created:

--- a/backend/app/chat_start.py
+++ b/backend/app/chat_start.py
@@ -46,8 +46,6 @@ async def start_programmatic_chat_turn(
   if not mark_starting(chat_id):
     return False
 
-  run_coro = None
-  broadcast_created = False
   try:
     start_gen = current_run_generation(chat_id)
     run_token = alloc_run_token()
@@ -69,33 +67,30 @@ async def start_programmatic_chat_turn(
       return False
 
     create_broadcast(chat_id)
-    broadcast_created = True
-    run_coro = run_chat(
-      result["history"],
-      chat_id=chat_id,
-      session_id=result["session_id"],
-      provider_id=result["provider"],
-      run_gen=start_gen,
-      run_token=run_token,
-    )
-    asyncio.create_task(run_coro)
     run_coro = None
-    get_system_broadcast().publish({
-      "type": "chat_run_started",
-      "chatId": chat_id,
-    })
-    return True
-  except BaseException:
-    # BaseException, not Exception: ``asyncio.CancelledError`` derives from
-    # BaseException, and the only suspension point above is the ``await_ack``
-    # that a cancellation lands on -- after ``mark_starting`` has succeeded.
-    # Leaking the claim there wedges the chat as 'starting' until the process
-    # restarts (see ``discard_starting`` in app/chat.py), which is exactly the
-    # drift this boundary exists to own.  The re-raise below keeps cancellation
-    # propagating normally.
-    if run_coro is not None:
-      run_coro.close()
-    if broadcast_created:
+    try:
+      run_coro = run_chat(
+        result["history"],
+        chat_id=chat_id,
+        session_id=result["session_id"],
+        provider_id=result["provider"],
+        run_gen=start_gen,
+        run_token=run_token,
+      )
+      asyncio.create_task(run_coro)
+    except BaseException:
+      if run_coro is not None:
+        run_coro.close()
       remove_broadcast(chat_id)
+      raise
+  except BaseException:
     discard_starting(chat_id)
     raise
+
+  # Once scheduled, the task owns the claim and broadcast. A system
+  # notification failure must not roll back a live run.
+  get_system_broadcast().publish({
+    "type": "chat_run_started",
+    "chatId": chat_id,
+  })
+  return True

--- a/backend/app/chat_start.py
+++ b/backend/app/chat_start.py
@@ -81,6 +81,8 @@ async def start_programmatic_chat_turn(
     except BaseException:
       if run_coro is not None:
         run_coro.close()
+      # No task or SSE subscriber owns this programmatic broadcast yet, so
+      # remove it instead of publishing the continuation path's terminal pair.
       remove_broadcast(chat_id)
       raise
   except BaseException:

--- a/backend/app/contribution_autopilot.py
+++ b/backend/app/contribution_autopilot.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import time
 import uuid
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -37,6 +36,7 @@ from sqlalchemy import and_, update
 from sqlalchemy.orm import Session
 
 from app import fs_locks, models
+from app.chat_start import start_programmatic_chat_turn
 from app.config import get_settings
 from app.contribution_records import (
   now_iso,
@@ -791,17 +791,12 @@ async def spawn_round_turn(
 ) -> bool:
   """Start a follow-up round turn in the dedicated chat.
 
-  Mirrors ``apps._start_conflict_resolver_turn`` but allows a non-empty IDLE
-  chat (rounds accumulate in one chat). Refuses only when the chat is missing or
-  a turn is already running — the caller then releases the claim and retries next
-  cron pass, so rounds never stack into the pending queue.
+  Unlike app conflict chats, Autopilot deliberately reuses a non-empty idle chat
+  so rounds accumulate in one place.  Eligibility stays here while the shared
+  programmatic-start boundary owns the turn lifecycle.  A busy chat is retried
+  on the next cron pass, so rounds never stack into the pending queue.
   """
-  from app.broadcast import create_broadcast, get_system_broadcast
-  from app.chat import (
-    current_run_generation, discard_starting, is_chat_running, mark_starting,
-    run_chat,
-  )
-  from app.chat_writer import StartTurn, alloc_run_token, await_ack, get_writer
+  from app.chat import is_chat_running
   from app.run_state import has_running_run
 
   chat = (
@@ -815,35 +810,9 @@ async def spawn_round_turn(
     or is_chat_running(chat_id)
   ):
     return False
-  if not mark_starting(chat_id):
-    return False
-
-  try:
-    start_gen = current_run_generation(chat_id)
-    run_token = alloc_run_token()
-    user_msg = {
-      "role": "user", "content": content, "ts": int(time.time() * 1000),
-    }
-    ack = get_writer().submit(StartTurn(
-      chat_id=chat_id,
-      run_token=run_token,
-      user_msg=user_msg,
-      title_source=title,
-      default_provider=provider,
-    ))
-    result = await await_ack(ack)
-    if current_run_generation(chat_id) != start_gen:
-      discard_starting(chat_id)
-      return False
-    create_broadcast(chat_id)
-    get_system_broadcast().publish(
-      {"type": "chat_run_started", "chatId": chat_id}
-    )
-    asyncio.create_task(run_chat(
-      result["history"], chat_id=chat_id, session_id=result["session_id"],
-      provider_id=result["provider"], run_gen=start_gen, run_token=run_token,
-    ))
-    return True
-  except Exception:
-    discard_starting(chat_id)
-    raise
+  return await start_programmatic_chat_turn(
+    chat_id=chat_id,
+    title=title,
+    content=content,
+    provider=provider,
+  )

--- a/backend/app/platform_update.py
+++ b/backend/app/platform_update.py
@@ -2049,15 +2049,10 @@ async def spawn_platform_conflict_chat(
   """Open a visible agent chat to reconcile the new platform version into
   the checked-out working branch — the platform analogue of a per-app
   update-conflict resolver chat. Dedupes on a running resolver."""
-  import time
   import uuid
 
   from app import models, providers
-  from app.broadcast import create_broadcast, get_system_broadcast
-  from app.chat import (
-    current_run_generation, discard_starting, mark_starting, run_chat,
-  )
-  from app.chat_writer import StartTurn, alloc_run_token, await_ack, get_writer
+  from app.chat_start import start_programmatic_chat_turn
   from app.config import get_settings
   from app.push import notify_owner
   from app.run_state import running_chat_ids
@@ -2100,36 +2095,14 @@ async def spawn_platform_conflict_chat(
   db.add(chat)
   db.commit()
 
-  if not mark_starting(chat_id):
-    return PlatformConflictResolverChatOut(
-      chat_id=chat_id, created=True, started=False,
-    )
-
   started = False
   try:
-    start_gen = current_run_generation(chat_id)
-    run_token = alloc_run_token()
-    user_msg = {"role": "user", "content": content, "ts": int(time.time() * 1000)}
-    ack = get_writer().submit(StartTurn(
-      chat_id=chat_id, run_token=run_token, user_msg=user_msg,
-      title_source=title, default_provider=provider,
-    ))
-    result = await await_ack(ack)
-    if current_run_generation(chat_id) == start_gen:
-      create_broadcast(chat_id)
-      get_system_broadcast().publish(
-        {"type": "chat_run_started", "chatId": chat_id}
-      )
-      asyncio.create_task(run_chat(
-        result["history"], chat_id=chat_id, session_id=result["session_id"],
-        provider_id=result["provider"], run_gen=start_gen, run_token=run_token,
-      ))
-      started = True
-    else:
-      discard_starting(chat_id)
-  except Exception:
-    discard_starting(chat_id)
-    raise
+    started = await start_programmatic_chat_turn(
+      chat_id=chat_id,
+      title=title,
+      content=content,
+      provider=provider,
+    )
   finally:
     try:
       notify_owner(

--- a/backend/app/platform_update.py
+++ b/backend/app/platform_update.py
@@ -2095,7 +2095,6 @@ async def spawn_platform_conflict_chat(
   db.add(chat)
   db.commit()
 
-  started = False
   try:
     started = await start_programmatic_chat_turn(
       chat_id=chat_id,

--- a/backend/app/routes/apps.py
+++ b/backend/app/routes/apps.py
@@ -10,7 +10,6 @@ import secrets
 import shutil
 import subprocess
 import tempfile
-import time
 import uuid
 from datetime import datetime, UTC
 from pathlib import Path
@@ -56,6 +55,7 @@ from app.compiler import (
   CompileError,
   recompile_app_bundle,
 )
+from app.chat_start import start_programmatic_chat_turn
 from app.config import get_settings
 from app.database import get_db
 from app.deps import (
@@ -696,12 +696,7 @@ async def _start_conflict_resolver_turn(
   db: Session, chat_id: str, title: str, content: str, provider: str,
 ) -> bool:
   """Start the resolver turn only while the chat is empty and idle."""
-  from app.broadcast import create_broadcast
-  from app.chat import (
-    current_run_generation, discard_starting, is_chat_running, mark_starting,
-    run_chat,
-  )
-  from app.chat_writer import StartTurn, alloc_run_token, await_ack, get_writer
+  from app.chat import is_chat_running
   from app.run_state import has_running_run
 
   chat = (
@@ -714,38 +709,12 @@ async def _start_conflict_resolver_turn(
     is_chat_running(chat_id)
   ):
     return False
-  if not mark_starting(chat_id):
-    return False
-
-  try:
-    start_gen = current_run_generation(chat_id)
-    run_token = alloc_run_token()
-    user_msg = {
-      "role": "user", "content": content, "ts": int(time.time() * 1000),
-    }
-    ack = get_writer().submit(StartTurn(
-      chat_id=chat_id,
-      run_token=run_token,
-      user_msg=user_msg,
-      title_source=title,
-      default_provider=provider,
-    ))
-    result = await await_ack(ack)
-    if current_run_generation(chat_id) != start_gen:
-      discard_starting(chat_id)
-      return False
-    create_broadcast(chat_id)
-    get_system_broadcast().publish(
-      {"type": "chat_run_started", "chatId": chat_id}
-    )
-    asyncio.create_task(run_chat(
-      result["history"], chat_id=chat_id, session_id=result["session_id"],
-      provider_id=result["provider"], run_gen=start_gen, run_token=run_token,
-    ))
-    return True
-  except Exception:
-    discard_starting(chat_id)
-    raise
+  return await start_programmatic_chat_turn(
+    chat_id=chat_id,
+    title=title,
+    content=content,
+    provider=provider,
+  )
 
 
 def _materialize_conflict_files(

--- a/backend/tests/test_chat_start.py
+++ b/backend/tests/test_chat_start.py
@@ -1,0 +1,168 @@
+"""Programmatic chat starts share one durable lifecycle protocol."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from app import chat_start
+from app.chat_writer import StartTurn
+
+
+class _Writer:
+  def __init__(self):
+    self.commands = []
+
+  def submit(self, command):
+    self.commands.append(command)
+    return "ack"
+
+
+def _install_start_fakes(monkeypatch, *, generations=(7, 7)):
+  writer = _Writer()
+  generation_values = iter(generations)
+  discarded = []
+  created_broadcasts = []
+  removed_broadcasts = []
+  system_events = []
+  scheduled = []
+
+  monkeypatch.setattr(chat_start, "mark_starting", lambda _chat_id: True)
+  monkeypatch.setattr(
+    chat_start,
+    "current_run_generation",
+    lambda _chat_id: next(generation_values),
+  )
+  monkeypatch.setattr(
+    chat_start, "discard_starting", lambda chat_id: discarded.append(chat_id),
+  )
+  monkeypatch.setattr(chat_start, "alloc_run_token", lambda: "run-1")
+  monkeypatch.setattr(chat_start, "get_writer", lambda: writer)
+
+  async def fake_await_ack(ack):
+    assert ack == "ack"
+    return {
+      "history": ["prepared-message"],
+      "session_id": "session-1",
+      "provider": "claude",
+    }
+
+  async def fake_run_chat(*_args, **_kwargs):
+    return None
+
+  def fake_create_task(coro):
+    scheduled.append(coro)
+    coro.close()
+    return SimpleNamespace()
+
+  monkeypatch.setattr(chat_start, "await_ack", fake_await_ack)
+  monkeypatch.setattr(chat_start, "run_chat", fake_run_chat)
+  monkeypatch.setattr(chat_start.asyncio, "create_task", fake_create_task)
+  monkeypatch.setattr(
+    chat_start,
+    "create_broadcast",
+    lambda chat_id: created_broadcasts.append(chat_id),
+  )
+  monkeypatch.setattr(
+    chat_start,
+    "remove_broadcast",
+    lambda chat_id: removed_broadcasts.append(chat_id),
+  )
+  monkeypatch.setattr(
+    chat_start,
+    "get_system_broadcast",
+    lambda: SimpleNamespace(publish=system_events.append),
+  )
+  return SimpleNamespace(
+    writer=writer,
+    discarded=discarded,
+    created_broadcasts=created_broadcasts,
+    removed_broadcasts=removed_broadcasts,
+    system_events=system_events,
+    scheduled=scheduled,
+  )
+
+
+@pytest.mark.asyncio
+async def test_programmatic_start_owns_writer_fence_broadcast_and_spawn(
+  monkeypatch,
+):
+  state = _install_start_fakes(monkeypatch)
+  monkeypatch.setattr(chat_start.time, "time", lambda: 123.456)
+
+  started = await chat_start.start_programmatic_chat_turn(
+    chat_id="chat-1",
+    title="Resolve conflict",
+    content="Fix the files",
+    provider="claude",
+  )
+
+  assert started is True
+  assert len(state.writer.commands) == 1
+  command = state.writer.commands[0]
+  assert isinstance(command, StartTurn)
+  assert command.chat_id == "chat-1"
+  assert command.run_token == "run-1"
+  assert command.title_source == "Resolve conflict"
+  assert command.default_provider == "claude"
+  assert command.user_msg == {
+    "role": "user", "content": "Fix the files", "ts": 123456,
+  }
+  assert state.created_broadcasts == ["chat-1"]
+  assert state.removed_broadcasts == []
+  assert len(state.scheduled) == 1
+  assert state.system_events == [
+    {"type": "chat_run_started", "chatId": "chat-1"}
+  ]
+  assert state.discarded == []
+
+
+@pytest.mark.asyncio
+async def test_programmatic_start_does_nothing_when_claim_is_busy(monkeypatch):
+  monkeypatch.setattr(chat_start, "mark_starting", lambda _chat_id: False)
+  monkeypatch.setattr(
+    chat_start,
+    "get_writer",
+    lambda: (_ for _ in ()).throw(AssertionError("writer must not run")),
+  )
+
+  assert await chat_start.start_programmatic_chat_turn(
+    chat_id="busy", title="t", content="c", provider="codex",
+  ) is False
+
+
+@pytest.mark.asyncio
+async def test_programmatic_start_yields_when_stop_wins_commit_race(monkeypatch):
+  state = _install_start_fakes(monkeypatch, generations=(4, 5))
+
+  started = await chat_start.start_programmatic_chat_turn(
+    chat_id="stopped", title="t", content="c", provider="codex",
+  )
+
+  assert started is False
+  assert len(state.writer.commands) == 1
+  assert state.created_broadcasts == []
+  assert state.scheduled == []
+  assert state.system_events == []
+  assert state.discarded == ["stopped"]
+
+
+@pytest.mark.asyncio
+async def test_programmatic_start_cleans_transient_owners_when_spawn_fails(
+  monkeypatch,
+):
+  state = _install_start_fakes(monkeypatch)
+
+  def fail_create_task(_coro):
+    raise RuntimeError("task scheduler unavailable")
+
+  monkeypatch.setattr(chat_start.asyncio, "create_task", fail_create_task)
+
+  with pytest.raises(RuntimeError, match="task scheduler unavailable"):
+    await chat_start.start_programmatic_chat_turn(
+      chat_id="chat-1", title="t", content="c", provider="codex",
+    )
+
+  assert state.created_broadcasts == ["chat-1"]
+  assert state.removed_broadcasts == ["chat-1"]
+  assert state.system_events == []
+  assert state.discarded == ["chat-1"]

--- a/backend/tests/test_chat_start.py
+++ b/backend/tests/test_chat_start.py
@@ -26,6 +26,7 @@ def _install_start_fakes(monkeypatch, *, generations=(7, 7)):
   removed_broadcasts = []
   system_events = []
   scheduled = []
+  run_calls = []
 
   monkeypatch.setattr(chat_start, "mark_starting", lambda _chat_id: True)
   monkeypatch.setattr(
@@ -47,8 +48,13 @@ def _install_start_fakes(monkeypatch, *, generations=(7, 7)):
       "provider": "claude",
     }
 
-  async def fake_run_chat(*_args, **_kwargs):
-    return None
+  def fake_run_chat(*args, **kwargs):
+    run_calls.append((args, kwargs))
+
+    async def finish():
+      return None
+
+    return finish()
 
   def fake_create_task(coro):
     scheduled.append(coro)
@@ -80,6 +86,7 @@ def _install_start_fakes(monkeypatch, *, generations=(7, 7)):
     removed_broadcasts=removed_broadcasts,
     system_events=system_events,
     scheduled=scheduled,
+    run_calls=run_calls,
   )
 
 
@@ -111,6 +118,15 @@ async def test_programmatic_start_owns_writer_fence_broadcast_and_spawn(
   assert state.created_broadcasts == ["chat-1"]
   assert state.removed_broadcasts == []
   assert len(state.scheduled) == 1
+  assert state.run_calls == [
+    ((["prepared-message"],), {
+      "chat_id": "chat-1",
+      "session_id": "session-1",
+      "provider_id": "claude",
+      "run_gen": 7,
+      "run_token": "run-1",
+    })
+  ]
   assert state.system_events == [
     {"type": "chat_run_started", "chatId": "chat-1"}
   ]
@@ -167,6 +183,32 @@ async def test_programmatic_start_cleans_transient_owners_when_spawn_fails(
   assert state.removed_broadcasts == ["chat-1"]
   assert state.system_events == []
   assert state.discarded == ["chat-1"]
+
+
+@pytest.mark.asyncio
+async def test_programmatic_start_does_not_reclaim_a_scheduled_run(
+  monkeypatch,
+):
+  state = _install_start_fakes(monkeypatch)
+
+  def fail_publish(_event):
+    raise RuntimeError("system broadcast unavailable")
+
+  monkeypatch.setattr(
+    chat_start,
+    "get_system_broadcast",
+    lambda: SimpleNamespace(publish=fail_publish),
+  )
+
+  with pytest.raises(RuntimeError, match="system broadcast unavailable"):
+    await chat_start.start_programmatic_chat_turn(
+      chat_id="chat-1", title="t", content="c", provider="codex",
+    )
+
+  assert len(state.scheduled) == 1
+  assert state.created_broadcasts == ["chat-1"]
+  assert state.removed_broadcasts == []
+  assert state.discarded == []
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_chat_start.py
+++ b/backend/tests/test_chat_start.py
@@ -1,5 +1,6 @@
 """Programmatic chat starts share one durable lifecycle protocol."""
 
+import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -166,3 +167,33 @@ async def test_programmatic_start_cleans_transient_owners_when_spawn_fails(
   assert state.removed_broadcasts == ["chat-1"]
   assert state.system_events == []
   assert state.discarded == ["chat-1"]
+
+
+@pytest.mark.asyncio
+async def test_programmatic_start_releases_the_claim_when_cancelled(monkeypatch):
+  """A cancellation at the ack must not wedge the chat as 'starting'.
+
+  ``asyncio.CancelledError`` derives from BaseException, so an ``except
+  Exception`` cleanup silently skips ``discard_starting`` -- and the registry
+  has no TTL, so every later start for that chat returns False until the
+  process restarts.  The only suspension point in the boundary is this await,
+  which is precisely where a cancelled caller lands.
+  """
+  state = _install_start_fakes(monkeypatch)
+
+  async def cancelled_await_ack(_ack):
+    raise asyncio.CancelledError()
+
+  monkeypatch.setattr(chat_start, "await_ack", cancelled_await_ack)
+
+  with pytest.raises(asyncio.CancelledError):
+    await chat_start.start_programmatic_chat_turn(
+      chat_id="chat-1", title="t", content="c", provider="claude",
+    )
+
+  # The claim is released, and nothing transient was left behind.
+  assert state.discarded == ["chat-1"]
+  assert state.created_broadcasts == []
+  assert state.removed_broadcasts == []
+  assert state.scheduled == []
+  assert state.system_events == []


### PR DESCRIPTION
## Why

App conflict resolution, platform conflict resolution, and Contribute Autopilot each reimplemented the same durable-start sequence: claim the chat, persist `StartTurn`, fence a racing Stop, create the broadcast, and schedule the provider turn. Changing that lifecycle required three coordinated edits and let cleanup behavior drift.

This is a focused follow-up to #410, which established `ChatRun` as the durable run authority. It completes the remaining caller-side ownership boundary without changing each caller's eligibility policy.

## What changes

- add one programmatic chat-turn start boundary for the shared claim, writer, generation, broadcast, and task lifecycle;
- keep empty-chat and reusable-chat eligibility rules with their existing callers;
- close an unscheduled coroutine and remove its transient broadcast when task creation fails, while leaving durable recovery state intact;
- cover success, busy claims, Stop races, and scheduling failure with intent-named tests.

## Verification

- 78 focused programmatic-start, platform-update, Autopilot, and app-conflict checks passed on the exact review branch;
- Python compilation and Ruff passed;
- the combined reviewed maintenance tree passed 3,440 backend checks with one skip and 111 isolated recovery checks.