### PR TITLE
Clean every terminal contribution staging checkout

### DIFF
--- a/backend/app/github_contributions.py
+++ b/backend/app/github_contributions.py
@@ -326,7 +326,9 @@ def _settle_equivalence(record: dict, upstream_sha: str | None = None) -> str | 
 
 def _cleanup_terminal_staging_checkout(record: dict) -> bool:
   """Remove a terminal contribution checkout through its owning Git shape."""
-  if record.get("status") not in {"merged", "closed"}:
+  if record.get("status") not in {
+    "merged", "closed", "superseded", "commented", "abandoned",
+  }:
     return False
   plan = record.get("plan") if isinstance(record.get("plan"), dict) else {}
   repo = _safe_repo_path(plan.get("repo_path"))

--- a/backend/tests/test_github_routes.py
+++ b/backend/tests/test_github_routes.py
@@ -2089,9 +2089,17 @@ def test_cleanup_terminal_staging_checkout_only_removes_disposable_clone():
   }
   assert _cleanup_terminal_staging_checkout(record) is False
   assert disposable.exists()
-  record["status"] = "merged"
-  assert _cleanup_terminal_staging_checkout(record) is True
-  assert not disposable.exists()
+
+  for status in ("merged", "closed", "superseded", "commented", "abandoned"):
+    candidate = data_dir / "contrib" / f"terminal-cleanup-{status}" / "repo"
+    (candidate / ".git").mkdir(parents=True)
+    (candidate / "index.jsx").write_text("hello")
+    record = {
+      "status": status,
+      "plan": {"repo_path": str(candidate)},
+    }
+    assert _cleanup_terminal_staging_checkout(record) is True
+    assert not candidate.exists()
 
   live_repo = data_dir / "apps" / "terminal-cleanup-live"
   (live_repo / ".git").mkdir(parents=True)


### PR DESCRIPTION
## Summary
- make the existing guarded staging cleanup accept every terminal contribution status
- keep active records and live app/platform repositories untouched
- cover the complete terminal-state contract with focused tests

## Why
[#46](https://github.com/mobius-os/mobius/pull/46) introduced durable contribution checkouts and cleanup after merged or closed PRs. Later lifecycle states—superseded, commented, and abandoned—are also terminal, but were not eligible for the same cleanup primitive. That leaves their disposable checkouts behind indefinitely.

This follow-up extends the existing owner rather than adding another cleanup path. Path, Git-shape, and live-repository guards remain unchanged.

## Testing
- `scripts/wt-pytest.sh backend/tests/test_github_routes.py -q -k 'cleanup_terminal_staging_checkout'`