### PR TITLE
ci: publish the main Railway image tag

### DIFF
--- a/.github/workflows/main-image.yml
+++ b/.github/workflows/main-image.yml
@@ -1,4 +1,4 @@
-name: Main image
+name: Publish main image
 
 on:
   push:
@@ -45,8 +45,7 @@ jobs:
         with:
           context: .
           push: true
-          # Existing Railway services follow this legacy tag.
-          tags: ghcr.io/mobius-os/mobius:daily
+          tags: ghcr.io/mobius-os/mobius:main
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
@@ -63,11 +62,11 @@ jobs:
         run: |
           docker logout ghcr.io
           for attempt in 1 2 3 4 5 6; do
-            if docker buildx imagetools inspect ghcr.io/mobius-os/mobius:daily; then
+            if docker buildx imagetools inspect ghcr.io/mobius-os/mobius:main; then
               exit 0
             fi
             if [ "$attempt" = 6 ]; then
-              echo "ghcr.io/mobius-os/mobius:daily is not public" >&2
+              echo "ghcr.io/mobius-os/mobius:main is not public" >&2
               echo "Set the package visibility once at:" >&2
               echo "https://github.com/orgs/mobius-os/packages/container/mobius/settings" >&2
               exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,8 +25,9 @@ any non-trivial change.
 ## Tests
 
 Required PR CI is `.github/workflows/test.yml`; the commands below mirror it.
-After protected merges, `.github/workflows/image-cache.yml` refreshes the
-shared Docker cache without repeating the test suite.
+After protected merges, `.github/workflows/main-image.yml` publishes the
+prebuilt `ghcr.io/mobius-os/mobius:main` Railway image without repeating the
+test suite.
 
 ## Submitting a session branch
 

--- a/backend/tests/test_verify_test_runtime.py
+++ b/backend/tests/test_verify_test_runtime.py
@@ -475,11 +475,11 @@ def test_pull_requests_run_required_suites_and_main_publishes_image():
   test_workflow = (ROOT / ".github" / "workflows" / "test.yml").read_text(
     encoding="utf-8"
   )
-  cache_workflow = (ROOT / ".github" / "workflows" / "image-cache.yml").read_text(
+  image_workflow = (ROOT / ".github" / "workflows" / "main-image.yml").read_text(
     encoding="utf-8"
   )
   test_triggers = test_workflow.split("\npermissions:\n", 1)[0]
-  cache_triggers = cache_workflow.split("\npermissions:\n", 1)[0]
+  image_triggers = image_workflow.split("\npermissions:\n", 1)[0]
   backend = test_workflow.split("\n  backend:\n", 1)[1].split(
     "\n  frontend-unit:\n", 1,
   )[0]
@@ -497,19 +497,20 @@ def test_pull_requests_run_required_suites_and_main_publishes_image():
   assert "cache-from: type=gha" in e2e
   assert "cache-to:" not in e2e
 
-  assert "push:\n" in cache_triggers
-  assert "    branches: [main]\n" in cache_triggers
-  assert "schedule:\n" not in cache_triggers
-  assert "workflow_dispatch:\n" in cache_triggers
-  assert "pull_request:\n" not in cache_triggers
-  assert "packages: write" in cache_workflow
-  assert "push: true" in cache_workflow
-  assert "tags: ghcr.io/mobius-os/mobius:daily" in cache_workflow
-  assert "docker buildx imagetools inspect ghcr.io/mobius-os/mobius:daily" in cache_workflow
-  assert "cache-to: type=gha,mode=max,ignore-error=true" in cache_workflow
-  assert "load: true" not in cache_workflow
+  assert "push:\n" in image_triggers
+  assert "    branches: [main]\n" in image_triggers
+  assert "schedule:\n" not in image_triggers
+  assert "workflow_dispatch:\n" in image_triggers
+  assert "pull_request:\n" not in image_triggers
+  assert "packages: write" in image_workflow
+  assert "push: true" in image_workflow
+  assert "tags: ghcr.io/mobius-os/mobius:main" in image_workflow
+  assert "docker buildx imagetools inspect ghcr.io/mobius-os/mobius:main" in image_workflow
+  assert "ghcr.io/mobius-os/mobius:daily" not in image_workflow
+  assert "cache-to: type=gha,mode=max,ignore-error=true" in image_workflow
+  assert "load: true" not in image_workflow
 
-  workflows = test_workflow + cache_workflow
+  workflows = test_workflow + image_workflow
   assert workflows.count("DOCKER_BUILD_RECORD_UPLOAD: 'false'") == 2
   assert "actions/checkout@v5" not in workflows
   assert "actions/setup-node@v5" not in workflows


### PR DESCRIPTION
## Summary

- publish one GHCR image channel, `ghcr.io/mobius-os/mobius:main`, after every push to `main`
- remove the retired scheduled/daily publishing path and rename the workflow accordingly
- update runtime verification tests and contributor documentation

## Validation

- focused runtime verification suite: 26 passed
- pull-request checks: frontend, backend, privacy, and browser end-to-end all passed
- merge-queue validation is in progress