### PR TITLE
Make chat stop glyph more prominent

### DIFF
--- a/frontend/src/components/ChatView/ChatInputBar.jsx
+++ b/frontend/src/components/ChatView/ChatInputBar.jsx
@@ -44,7 +44,7 @@
  * ║                                                                  ║
  * ║   4. ICONS COME FROM THE APPS-SDK-UI PACKAGE                     ║
  * ║      Primary action: `ArrowUp` (22) for send, `Mic` (24), and    ║
- * ║      `Stop` (24). The package ships these — don't substitute     ║
+ * ║      `Stop` (28). The package ships these — don't substitute     ║
  * ║      hand-rolled paths.                                          ║
  * ║                                                                  ║
  * ║   5. ATTACH CARD CLASSIFIER (`classifyFile`) drives the badge    ║
@@ -171,7 +171,7 @@ function PrimaryAction({
         onClick={onStop}
         aria-label="Stop"
       >
-        <Stop width={24} height={24} aria-hidden="true" />
+        <Stop width={28} height={28} aria-hidden="true" />
       </button>
     )
   }

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -2139,7 +2139,11 @@
 }
 .chat__stop:focus-visible svg {
   outline: 2px solid var(--accent);
-  outline-offset: 3px;
+  /* Offset is measured from the SVG box, so it has to shrink as the glyph
+     grows: at 28px a 3px offset draws 28 + 2*(3 + 2) = 38px, exactly the
+     button's own 38px padding box, and the ring stops reading as a ring
+     around the glyph. 1px keeps the previous 34px visual. */
+  outline-offset: 1px;
   border-radius: 4px;
 }
 

--- a/frontend/src/components/ChatView/__tests__/chatUiPolish.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatUiPolish.test.js
@@ -85,8 +85,8 @@ test('stop action has no visible circular shell', () => {
 test('stop action keeps a legible glyph inside its full touch target', () => {
   assert.match(
     chatInputBar,
-    /<Stop width=\{24\} height=\{24\} aria-hidden="true" \/>/,
-    'the SDK Stop icon needs a 24px box because its square occupies only part of the viewBox',
+    /<Stop width=\{28\} height=\{28\} aria-hidden="true" \/>/,
+    'the SDK Stop icon needs a 28px box because its square occupies only part of the viewBox',
   )
 })
 


### PR DESCRIPTION
## Summary
- increase the chat composer Stop icon from 24px to 28px after real-use feedback that the merged glyph remains undersized
- keep the 40px tap target, transparent button shell, and composer layout unchanged
- update the nearby icon-size contract and regression check

Follow-up to #313, which raised the SDK icon from 16px to 24px. The SDK glyph occupies only part of its viewBox, so the visible square still reads smaller than the other primary composer actions.

## Verification
- `node --test src/components/ChatView/__tests__/chatUiPolish.test.js src/components/ChatView/__tests__/composerStopTouch.test.js`
- `git diff --check`