### PR TITLE
Record the legacy platform app migration durably

### DIFF
--- a/backend/app/bootstrap.py
+++ b/backend/app/bootstrap.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass
 
 from sqlalchemy.orm import Session
 
-from app import legacy_platform_apps, models
+from app import database, legacy_platform_apps, models
 from app.config import get_settings
 from app.install import _is_historical_platform_app_source_dir, install_from_manifest
 
@@ -95,12 +95,27 @@ def _is_legacy_platform_row(app: models.App) -> bool:
   )
 
 
+_LEGACY_PLATFORM_APPS_MIGRATION = "data_0001_legacy_platform_apps"
+
+
 async def _migrate_legacy_platform_apps(db: Session) -> None:
   """Move old built-in rows forward by installing their trusted catalog entry.
 
   This only runs when an active row from an older image is already present and
   still points at the retired platform-core source tree.
+
+  ONE-SHOT, recorded durably. The row-shape predicate alone cannot tell an
+  un-migrated historical row from an app the OWNER creates later at the same
+  path with the same slug — `app_apply` writes exactly that shape (slug from the
+  manifest id, source_dir /data/apps/<slug>, no manifest_url). Without this
+  marker, an owner building a local app called `memory`, `reflection`, or
+  `beat-machine` would match on the next boot and have the catalog manifest
+  installed over their work. The ledger closes the window permanently once the
+  migration has had its chance.
   """
+  eng = db.get_bind()
+  if database.data_migration_done(eng, _LEGACY_PLATFORM_APPS_MIGRATION):
+    return
   rows = (
     db.query(models.App)
     .filter(
@@ -130,6 +145,10 @@ async def _migrate_legacy_platform_apps(db: Session) -> None:
         "bootstrap: legacy platform app migration failed for %s — %s",
         row.slug, exc,
       )
+      # Leave the marker unset so a transient catalog/network failure retries on
+      # the next boot rather than stranding a genuinely un-migrated row.
+      return
+  database.record_data_migration(eng, _LEGACY_PLATFORM_APPS_MIGRATION)
 
 
 async def ensure_bootstrap_apps_installed(db: Session) -> None:

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1016,6 +1016,57 @@ def schema_migration_history(eng) -> list[dict]:
   ]
 
 
+def data_migration_done(eng, name: str) -> bool:
+  """True when a one-shot DATA migration has already completed.
+
+  Shares the ``schema_migrations`` ledger with ``_SCHEMA_MIGRATIONS`` because
+  both answer the same question — "has this one-shot already run?" — but data
+  migrations record through these helpers instead of that tuple: they can be
+  async and perform network I/O (fetching a catalog manifest), which the
+  synchronous engine-only ``run_migrations`` loop cannot express.
+
+  Without a durable marker a "one-shot" data migration can only infer
+  completion from the shape of the rows it finds, which silently re-arms it for
+  any row created LATER that happens to match that shape.
+  """
+  from sqlalchemy import inspect as sa_inspect, text
+
+  if "schema_migrations" not in sa_inspect(eng).get_table_names():
+    return False
+  with eng.connect() as conn:
+    return conn.execute(text(
+      "SELECT 1 FROM schema_migrations WHERE version = :version"
+    ), {"version": name}).first() is not None
+
+
+def record_data_migration(eng, name: str) -> None:
+  """Mark a one-shot data migration complete so it never re-evaluates rows."""
+  from sqlalchemy import text
+  from sqlalchemy.exc import IntegrityError
+
+  with eng.begin() as conn:
+    conn.execute(text(
+      "CREATE TABLE IF NOT EXISTS schema_migrations ("
+      "version VARCHAR(128) PRIMARY KEY, "
+      "applied_at TIMESTAMP NOT NULL"
+      ")"
+    ))
+  # Plain INSERT + IntegrityError rather than a dialect-specific upsert: this
+  # ledger runs on both SQLite and PostgreSQL (Railway), and re-recording an
+  # already-complete migration is a no-op either way.
+  try:
+    with eng.begin() as conn:
+      conn.execute(text(
+        "INSERT INTO schema_migrations (version, applied_at) "
+        "VALUES (:version, :applied_at)"
+      ), {
+        "version": name,
+        "applied_at": datetime.now(UTC).replace(tzinfo=None),
+      })
+  except IntegrityError:
+    pass
+
+
 def run_migrations(eng) -> None:
   """Apply each unapplied, append-only schema migration exactly once.
 

--- a/backend/tests/test_bootstrap.py
+++ b/backend/tests/test_bootstrap.py
@@ -14,12 +14,28 @@ from fastapi import HTTPException
 
 from app import app_git, models
 from app.bootstrap import (
+  _LEGACY_PLATFORM_APPS_MIGRATION,
   BOOTSTRAP_SKILLS_MANIFEST_URL,
   BOOTSTRAP_STORE_MANIFEST_URL,
   LEGACY_PLATFORM_APP_MANIFEST_URLS,
   _migrate_legacy_platform_apps,
   ensure_bootstrap_apps_installed,
 )
+
+
+def _reset_legacy_platform_marker(db):
+  """Drop the durable one-shot marker so a case can act as a FIRST boot.
+
+  The marker is per-database and the suite reuses one, so without this every
+  case after the first would correctly short-circuit and assert nothing.
+  """
+  from sqlalchemy import text
+
+  db.execute(
+    text("DELETE FROM schema_migrations WHERE version = :v"),
+    {"v": _LEGACY_PLATFORM_APPS_MIGRATION},
+  )
+  db.commit()
 
 
 def _install_result(name="App", slug="app", app_id=1, mode="install"):
@@ -217,6 +233,7 @@ async def test_bootstrap_migrates_active_legacy_platform_rows(
   ))
   db.commit()
 
+  _reset_legacy_platform_marker(db)
   should_migrate = source_shape == "platform_core" or manifest_url_shape == "empty"
   install_mock = AsyncMock(
     return_value=_install_result("Memory", "memory", app_id=3, mode="update"),
@@ -233,6 +250,46 @@ async def test_bootstrap_migrates_active_legacy_platform_rows(
     assert install_mock.await_args.kwargs["source"] == "bootstrap"
   else:
     install_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_owner_app_reusing_a_historical_slug_is_never_overwritten(
+  db, monkeypatch,
+):
+  """An owner's own app named `memory` must survive the next boot.
+
+  `app_apply` writes exactly the shape the historical predicate matches — slug
+  from the manifest id, source_dir /data/apps/<slug>, no manifest_url — so
+  without a durable one-shot marker the migration would install the catalog
+  manifest OVER an app the owner built themselves.
+  """
+  monkeypatch.delenv("MOEBIUS_SKIP_BOOTSTRAP", raising=False)
+  from app.config import get_settings
+
+  data_dir = get_settings().data_dir
+  _reset_legacy_platform_marker(db)
+
+  # First boot: nothing legacy present, so the migration closes its window.
+  empty_mock = AsyncMock(return_value=_install_result())
+  with patch("app.bootstrap.install_from_manifest", empty_mock):
+    await _migrate_legacy_platform_apps(db)
+  empty_mock.assert_not_awaited()
+
+  # Later: the owner builds their own app and happens to call it "memory".
+  db.add(models.App(
+    name="Memory",
+    description="the owner's OWN app, not the catalog one",
+    jsx_source="export default function App() {}",
+    slug="memory",
+    source_dir=f"{data_dir}/apps/memory",
+    manifest_url=None,
+  ))
+  db.commit()
+
+  install_mock = AsyncMock(return_value=_install_result("Memory", "memory"))
+  with patch("app.bootstrap.install_from_manifest", install_mock):
+    await _migrate_legacy_platform_apps(db)
+  install_mock.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- record the legacy platform-app migration in the `schema_migrations` ledger
- add `data_migration_done()` / `record_data_migration()` for one-shot DATA migrations
- leave the marker unset when an install fails, so a transient error still retries

## Why
`_migrate_legacy_platform_apps` decides what to migrate purely from row shape:
an active row whose `source_dir` points at the retired platform-core tree, with
a slug from the manifest id and no `manifest_url`. That is also exactly the
shape `app_apply` writes for an app the OWNER creates later.

So an owner who builds a local app named `memory`, `reflection`, or
`beat-machine` matches the predicate on the next boot and has the trusted
catalog manifest installed over their work. The predicate cannot distinguish
the two cases, because by construction they are identical.

A durable marker closes the window permanently once the migration has had its
chance. The failure path deliberately returns without recording, so a transient
catalog or network failure retries on the next boot rather than stranding a
genuinely un-migrated row.

Data migrations record through these helpers rather than the `_SCHEMA_MIGRATIONS`
tuple because they can be async and perform network I/O (fetching a catalog
manifest), which the synchronous engine-only `run_migrations` loop cannot
express. They share the same ledger table because they answer the same question.

## Testing
- `pytest tests/test_bootstrap.py -q` (16 passed), including a new
  `test_owner_app_reusing_a_historical_slug_is_never_overwritten`