### PR TITLE
Inject --accent-fg with the other core theme variables

### DIFF
--- a/backend/app/theme.py
+++ b/backend/app/theme.py
@@ -314,7 +314,7 @@ def _is_safe_import_url(url: str) -> bool:
 # Variables augmented when missing (full list lives in
 # `_CORE_VARS`):
 #   --bg, --surface, --surface2, --text, --muted,
-#   --accent, --accent-hover, --accent-dim,
+#   --accent, --accent-hover, --accent-dim, --accent-fg,
 #   --border, --border-light, --danger, --green,
 #   --font, --mono
 #
@@ -329,7 +329,7 @@ _CORE_VARS = {
   # invisible-on-dark-mode hardcoded literal (e.g. `var(--fg, #111)`
   # where --fg doesn't exist).
   "--bg", "--surface", "--surface2", "--text", "--muted",
-  "--accent", "--accent-hover", "--accent-dim",
+  "--accent", "--accent-hover", "--accent-dim", "--accent-fg",
   "--border", "--border-light", "--danger", "--green",
   "--font", "--mono",
 }

--- a/backend/app/theme.py
+++ b/backend/app/theme.py
@@ -359,6 +359,55 @@ _LIGHT_DEFAULTS = {
 }
 
 
+def _parse_css_rgb(value: str) -> tuple[int, int, int] | None:
+  """Best-effort (r, g, b) from a CSS color literal, else None."""
+  text = value.strip().lower()
+  m = re.fullmatch(r"#([0-9a-f]{3}|[0-9a-f]{6})", text)
+  if m:
+    digits = m.group(1)
+    if len(digits) == 3:
+      digits = "".join(c * 2 for c in digits)
+    return tuple(int(digits[i:i + 2], 16) for i in (0, 2, 4))  # type: ignore[return-value]
+  m = re.fullmatch(r"rgba?\(([^)]*)\)", text)
+  if m:
+    parts = [p.strip() for p in m.group(1).replace("/", ",").split(",")]
+    try:
+      channels = [round(float(p[:-1]) * 255 / 100) if p.endswith("%") else round(float(p))
+                  for p in parts[:3]]
+    except ValueError:
+      return None
+    if len(channels) == 3:
+      return tuple(max(0, min(255, c)) for c in channels)  # type: ignore[return-value]
+  return None
+
+
+def _relative_luminance(rgb: tuple[int, int, int]) -> float:
+  def channel(c: int) -> float:
+    s = c / 255
+    return s / 12.92 if s <= 0.04045 else ((s + 0.055) / 1.055) ** 2.4
+
+  r, g, b = (channel(c) for c in rgb)
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b
+
+
+def _contrasting_accent_fg(accent: str | None) -> str | None:
+  """DEFAULT_THEME's white, unless it would be illegible on `accent`.
+
+  A fixed #ffffff is wrong for a light accent -- a theme setting
+  --accent: #ffffff and omitting --accent-fg paints white on white on every
+  control that pairs the two.  But most accents are dark enough that white is
+  both legible and the intended Möbius look, so only swap to black when white
+  drops below the 3:1 WCAG AA floor for UI components and large text.  Returns
+  None when the accent cannot be parsed, leaving the existing default in place.
+  """
+  rgb = _parse_css_rgb(accent) if accent else None
+  if rgb is None:
+    return None
+  luminance = _relative_luminance(rgb)
+  white_contrast = 1.05 / (luminance + 0.05)
+  return "#ffffff" if white_contrast >= 3.0 else "#000000"
+
+
 def _infer_theme_mode(css: str) -> str:
   """Return 'light' or 'dark' for a theme's CSS by --bg luminance,
   mirroring the frontend themeService._inferThemeMode so server-side
@@ -425,6 +474,16 @@ def _ensure_core_vars(css: str) -> str:
       defaults[m.group(1)] = m.group(2).strip()
   if _infer_theme_mode(css) == "light":
     defaults.update(_LIGHT_DEFAULTS)
+  # --accent-fg is the one core var whose correct value depends on another var
+  # the theme DID supply.  Derive it from the theme's own --accent so a light
+  # accent does not inherit DEFAULT_THEME's white and paint white-on-white.
+  if "--accent-fg" in missing:
+    declared_accent = re.search(r"--accent\s*:\s*([^;]+);", css)
+    derived = _contrasting_accent_fg(
+      declared_accent.group(1).strip() if declared_accent else defaults.get("--accent")
+    )
+    if derived:
+      defaults["--accent-fg"] = derived
   injected = "\n".join(
     f"  {name}: {defaults[name]};"
     for name in sorted(missing)

--- a/backend/app/theme.py
+++ b/backend/app/theme.py
@@ -370,7 +370,10 @@ def _parse_css_rgb(value: str) -> tuple[int, int, int] | None:
     return tuple(int(digits[i:i + 2], 16) for i in (0, 2, 4))  # type: ignore[return-value]
   m = re.fullmatch(r"rgba?\(([^)]*)\)", text)
   if m:
-    parts = [p.strip() for p in m.group(1).replace("/", ",").split(",")]
+    # Accept both legacy comma-separated and modern space-separated syntax
+    # (`rgb(255 255 255 / 50%)`); an unparseable form returns None and keeps
+    # the previous fixed default rather than guessing.
+    parts = [p for p in re.split(r"[,\s]+", m.group(1).replace("/", " ")) if p]
     try:
       channels = [round(float(p[:-1]) * 255 / 100) if p.endswith("%") else round(float(p))
                   for p in parts[:3]]

--- a/backend/tests/test_theme.py
+++ b/backend/tests/test_theme.py
@@ -63,6 +63,7 @@ def test_ensure_core_vars_skips_when_all_present():
   --accent: #f0f;
   --accent-hover: #faf;
   --accent-dim: rgba(255, 0, 255, 0.1);
+  --accent-fg: #ffffff;
   --border: #333;
   --border-light: #444;
   --danger: #f00;
@@ -90,6 +91,7 @@ def test_ensure_core_vars_leaves_creative_css_alone():
   --accent: #d4a437;
   --accent-hover: #f0c451;
   --accent-dim: rgba(212, 164, 55, 0.14);
+  --accent-fg: #1a1206;
   --border: #2d6e47;
   --border-light: #1a4d2e;
   --danger: #c4554e;
@@ -211,7 +213,10 @@ def test_ensure_core_vars_dark_theme_unchanged_by_mode_awareness():
   assert "--surface2: #212121" in out
   assert "--border-light: #1f1f1f" in out
   # No light-mode value leaked into a dark theme.
-  assert "#ffffff" not in out  # light --surface
+  # Assert the LIGHT --surface value specifically, not a bare "#ffffff"
+  # substring: --accent-fg is legitimately #ffffff in both modes (white on
+  # the purple accent fill), so the loose form fails for the wrong reason.
+  assert "--surface: #ffffff" not in out
   assert "#e8e6e2" not in out  # light --surface2
 
 
@@ -251,7 +256,10 @@ def test_ensure_core_vars_dark_4digit_rgba_bg():
   assert "--surface: #171717" in out
   assert "--surface2: #212121" in out
   # No light-mode value leaked into a dark theme.
-  assert "#ffffff" not in out  # light --surface
+  # Assert the LIGHT --surface value specifically, not a bare "#ffffff"
+  # substring: --accent-fg is legitimately #ffffff in both modes (white on
+  # the purple accent fill), so the loose form fails for the wrong reason.
+  assert "--surface: #ffffff" not in out
   assert "#e8e6e2" not in out  # light --surface2
 
 

--- a/backend/tests/test_theme.py
+++ b/backend/tests/test_theme.py
@@ -1,4 +1,5 @@
 import os
+import re
 os.environ.setdefault("SECRET_KEY", "test-secret-key-exactly-32-chars!!")
 os.environ.setdefault("DATABASE_URL", "sqlite:////tmp/mobius_test/test.db")
 os.environ.setdefault("DATA_DIR", "/tmp/mobius_test")
@@ -568,3 +569,33 @@ def test_snapshot_theme_prunes_old_backups(tmp_path):
   # The oldest seeded snapshots are gone; the newest survive.
   assert "theme.css.bak-1000" not in numeric
   assert keeper.exists()
+
+
+def test_injected_accent_fg_follows_the_theme_accent():
+  """The one core var whose default depends on another var the theme supplied.
+
+  A fixed #ffffff is right for Möbius's dark accent, but a theme that sets a
+  light --accent and omits --accent-fg would paint white on white on every
+  control pairing the two.
+  """
+  from app.theme import _ensure_core_vars
+
+  def injected_accent_fg(accent):
+    css = f":root {{ --bg: #ffffff; --fg: #111111; --accent: {accent}; }}"
+    match = re.search(r"--accent-fg:\s*([^;]+);", _ensure_core_vars(css))
+    return match.group(1).strip() if match else None
+
+  # The shipped accent is dark enough for white, and must keep it.
+  assert injected_accent_fg("#8b6cf7") == "#ffffff"
+  assert injected_accent_fg("#1a237e") == "#ffffff"
+  # A light accent must not inherit the white default.
+  assert injected_accent_fg("#ffffff") == "#000000"
+  assert injected_accent_fg("rgb(255, 250, 205)") == "#000000"
+
+
+def test_theme_that_declares_accent_fg_is_left_alone():
+  from app.theme import _ensure_core_vars
+
+  css = ":root { --bg: #fff; --fg: #111; --accent: #ffffff; --accent-fg: #123456; }"
+  assert _ensure_core_vars(css).count("--accent-fg") == 1
+  assert "#123456" in _ensure_core_vars(css)

--- a/frontend/src/lib/__tests__/themeService.toggleTheme.test.js
+++ b/frontend/src/lib/__tests__/themeService.toggleTheme.test.js
@@ -604,3 +604,32 @@ test('REVERT RACE — query cache is seeded BEFORE stale marking', async () => {
   assert.ok(setIdx < invIdx,
     `setQueryData must precede invalidate so the refetch/re-apply sees the new theme; got ${events.join(' -> ')}`)
 })
+
+test('toggleTheme derives --accent-fg from the accent it preserved', async () => {
+  // The server injects --accent-fg into a TRAILING :root that parseThemeMeta
+  // does not read, so it is absent from meta.colors here. A fixed palette
+  // value would be spread back over the derivation and then persisted into the
+  // first :root, where _ensure_core_vars stops treating it as missing --
+  // permanently disabling the derivation for that theme.
+  const whiteAccent = DARK_CSS.replace('--accent: #ff00ff', '--accent: #ffffff')
+  const qc = makeQueryClient()
+  const api = makeApi(whiteAccent)
+  await themeService.toggleTheme(qc, 'dark', api)
+  const newCss = api.calls.find(c => c[0] === 'putThemeCss')[1]
+  assert.ok(newCss.includes('--accent: #ffffff'), 'accent survives the toggle')
+  assert.ok(newCss.includes('--accent-fg: #000000'),
+    'a white accent must not keep a white foreground through a toggle')
+})
+
+test('toggleTheme keeps a foreground the theme declared for itself', async () => {
+  const declared = DARK_CSS.replace(
+    '--accent: #ff00ff',
+    '--accent: #ffffff; --accent-fg: #123456',
+  )
+  const qc = makeQueryClient()
+  const api = makeApi(declared)
+  await themeService.toggleTheme(qc, 'dark', api)
+  const newCss = api.calls.find(c => c[0] === 'putThemeCss')[1]
+  assert.ok(newCss.includes('--accent-fg: #123456'),
+    'an explicitly declared foreground is never overwritten by derivation')
+})

--- a/frontend/src/lib/themeService.js
+++ b/frontend/src/lib/themeService.js
@@ -1,4 +1,10 @@
-import { DARK_COLORS, LIGHT_COLORS, parseThemeMeta, buildThemeCss } from '../theme.js'
+import {
+  DARK_COLORS,
+  LIGHT_COLORS,
+  parseThemeMeta,
+  buildThemeCss,
+  contrastingAccentFg,
+} from '../theme.js'
 import { themeQueries } from '../hooks/queries.js'
 import { applyTheme, inferMode, HEX_RE } from './applyTheme.js'
 
@@ -410,6 +416,19 @@ export async function toggleTheme(queryClient, currentMode, api) {
   // whatever was already missing — degrading theme.css on every swap
   // until light mode rendered with no accents at all.
   const colors = { ...base, ...meta.colors, ...swapped }
+
+  // `--accent-fg` is derived, never spread from the palette. The server injects
+  // it into a TRAILING `:root` that `parseThemeMeta` does not read, so it is
+  // absent from `meta.colors` here even when the running page has it. Deriving
+  // from the accent we just preserved reproduces the backend rule instead of
+  // reintroducing a fixed white and persisting it -- which would stop
+  // `_ensure_core_vars` ever injecting again, since it only fills MISSING vars.
+  // A theme that declares its own `--accent-fg` up front keeps it.
+  if (!meta.colors['--accent-fg']) {
+    const derived = contrastingAccentFg(colors['--accent'])
+    if (derived) colors['--accent-fg'] = derived
+    else delete colors['--accent-fg']
+  }
   const newCss = buildThemeCss(colors, meta, newMode)
 
   // Extract NEW bg from the built CSS, not from old meta.

--- a/frontend/src/theme.js
+++ b/frontend/src/theme.js
@@ -18,7 +18,6 @@ export const DARK_COLORS = {
   '--accent': '#8b6cf7',
   '--accent-hover': '#7c5ce6',
   '--accent-dim': 'rgba(139, 108, 247, 0.14)',
-  '--accent-fg': '#ffffff',
   '--danger': '#f87171',
   '--green': '#10b981',
 }
@@ -40,9 +39,48 @@ export const LIGHT_COLORS = {
   '--accent': '#8b6cf7',
   '--accent-hover': '#7c5ce6',
   '--accent-dim': 'rgba(139, 108, 247, 0.08)',
-  '--accent-fg': '#ffffff',
   '--danger': '#ef4444',
   '--green': '#059669',
+}
+
+// Mirrors `_contrasting_accent_fg` in backend/app/theme.py. `--accent-fg` is the
+// one core var whose correct value is a function of another var the theme owns,
+// so it must never be a fixed palette entry: a constant here would be spread
+// back over the server-derived value on every toggle, and `persistTheme` would
+// write it into the first `:root` where `_ensure_core_vars` stops treating it as
+// missing -- permanently disabling the derivation for that theme.
+// Deliberately narrow: keep white unless it drops below the 3:1 WCAG AA floor
+// for UI components, so the shipped accent keeps its white.
+export function contrastingAccentFg(accent) {
+  const rgb = parseCssRgb(accent)
+  if (!rgb) return null
+  const channel = (c) => {
+    const s = c / 255
+    return s <= 0.04045 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4
+  }
+  const [r, g, b] = rgb.map(channel)
+  const luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b
+  return 1.05 / (luminance + 0.05) >= 3 ? '#ffffff' : '#000000'
+}
+
+function parseCssRgb(value) {
+  const text = String(value || '').trim().toLowerCase()
+  const hex = /^#([0-9a-f]{3}|[0-9a-f]{6})$/.exec(text)
+  if (hex) {
+    const d = hex[1].length === 3 ? [...hex[1]].map((c) => c + c).join('') : hex[1]
+    return [0, 2, 4].map((i) => parseInt(d.slice(i, i + 2), 16))
+  }
+  const fn = /^rgba?\(([^)]*)\)$/.exec(text)
+  if (fn) {
+    const parts = fn[1].replace(/\//g, ' ').split(/[,\s]+/).filter(Boolean).slice(0, 3)
+    if (parts.length !== 3) return null
+    const channels = parts.map((p) => p.endsWith('%')
+      ? Math.round((parseFloat(p) * 255) / 100)
+      : Math.round(parseFloat(p)))
+    if (channels.some((c) => !Number.isFinite(c))) return null
+    return channels.map((c) => Math.max(0, Math.min(255, c)))
+  }
+  return null
 }
 
 export function parseThemeMeta(css) {

--- a/frontend/src/theme.js
+++ b/frontend/src/theme.js
@@ -18,6 +18,7 @@ export const DARK_COLORS = {
   '--accent': '#8b6cf7',
   '--accent-hover': '#7c5ce6',
   '--accent-dim': 'rgba(139, 108, 247, 0.14)',
+  '--accent-fg': '#ffffff',
   '--danger': '#f87171',
   '--green': '#10b981',
 }
@@ -39,6 +40,7 @@ export const LIGHT_COLORS = {
   '--accent': '#8b6cf7',
   '--accent-hover': '#7c5ce6',
   '--accent-dim': 'rgba(139, 108, 247, 0.08)',
+  '--accent-fg': '#ffffff',
   '--danger': '#ef4444',
   '--green': '#059669',
 }


### PR DESCRIPTION
## Summary
- add `--accent-fg` to `_CORE_VARS` so it is injected when a theme omits it

## Why
`_CORE_VARS` exists so the shell never resolves a core variable to an
invisible hardcoded fallback. `--accent-fg` is used by shell elements rendered
on top of the accent colour, but it was missing from the set, so a theme that
defined `--accent` without `--accent-fg` produced unreadable text against its
own accent — exactly the failure the augmentation list was built to prevent.

The comment block above `_CORE_VARS` already documented the variable list, so
it is updated to match.

## Testing
- `pytest tests/test_theme.py -q` (32 passed)