### PR TITLE
Harden progressive error recovery state

### DIFF
--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import PlainTextResponse, Response
 from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import Text, case, cast, func
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app import activity, auth, models, providers, questions
@@ -169,6 +170,22 @@ def _drain_writer_before_sidecar_read(
 class ChatUpdate(BaseModel):
   title: str | None = None
   messages: list[dict] | None = None
+
+
+class ChatCreate(ChatUpdate):
+  # Stable identity for a client retry whose first response may have been lost.
+  # It is owner-scoped by the route and derives an opaque UUID rather than being
+  # stored as user-visible chat metadata.
+  recovery_request_id: str | None = Field(default=None, min_length=1, max_length=128)
+
+
+def _chat_create_response(chat: models.Chat, db: Session) -> dict:
+  detail = _chat_detail_response(chat, db=db)
+  return {
+    **_owner_chat_summary(chat),
+    "messages": detail["messages"],
+    "detail": detail,
+  }
 
 
 class PinnedOrderItem(BaseModel):
@@ -675,7 +692,7 @@ def list_agent_lifecycle(
 
 @router.post("", dependencies=[Depends(reject_cross_site)])
 def create_chat(
-  body: ChatUpdate,
+  body: ChatCreate,
   _: models.Owner = Depends(get_current_owner),
   db: Session = Depends(get_db),
 ):
@@ -698,6 +715,18 @@ def create_chat(
   """
   import uuid
 
+  chat_id = str(uuid.uuid4())
+  if body.recovery_request_id:
+    chat_id = str(uuid.uuid5(
+      uuid.NAMESPACE_URL,
+      f"mobius:error-repair:{body.recovery_request_id}",
+    ))
+    existing = db.query(models.Chat).filter(models.Chat.id == chat_id).first()
+    if existing is not None:
+      if existing.deleted_at is not None:
+        raise HTTPException(status_code=409, detail="repair chat was deleted")
+      return _chat_create_response(existing, db)
+
   owner = db.query(models.Owner).first()
   data_dir = get_settings().data_dir
   provider = providers.resolve_default_provider(
@@ -705,7 +734,7 @@ def create_chat(
   )
 
   chat = models.Chat(
-    id=str(uuid.uuid4()),
+    id=chat_id,
     title=body.title or "New chat",
     messages=body.messages or [],
     provider=provider,
@@ -718,18 +747,22 @@ def create_chat(
     ),
   )
   db.add(chat)
-  db.commit()
+  try:
+    db.commit()
+  except IntegrityError:
+    db.rollback()
+    if not body.recovery_request_id:
+      raise
+    existing = db.query(models.Chat).filter(models.Chat.id == chat_id).first()
+    if existing is None or existing.deleted_at is not None:
+      raise
+    return _chat_create_response(existing, db)
   db.refresh(chat)
   activity.log_event("chat_created", chat_id=chat.id)
   _reclaim_expired_tombstones_after_chat_write(db)
   # Preserve the flat summary + messages fields existing callers consume while
   # carrying the exact detail contract under its own forward-compatible key.
-  detail = _chat_detail_response(chat, db=db)
-  return {
-    **_owner_chat_summary(chat),
-    "messages": detail["messages"],
-    "detail": detail,
-  }
+  return _chat_create_response(chat, db)
 
 
 @router.put("/pinned-order", dependencies=[Depends(reject_cross_site)])

--- a/backend/tests/test_chats.py
+++ b/backend/tests/test_chats.py
@@ -257,6 +257,25 @@ def test_create_chat_returns_canonical_owner_drawer_summary(client, auth):
   assert body["detail"] == detail_body
 
 
+def test_create_repair_chat_is_idempotent_across_ambiguous_retries(client, auth):
+  payload = {
+    "title": "Fix a Möbius error",
+    "recovery_request_id": "recovery-request-1",
+  }
+  first = client.post("/api/chats", json=payload, headers=auth)
+  retry = client.post("/api/chats", json=payload, headers=auth)
+
+  assert first.status_code == 200
+  assert retry.status_code == 200
+  assert retry.json()["id"] == first.json()["id"]
+  assert retry.json()["messages"] == []
+
+  listed = client.get("/api/chats", headers=auth)
+  assert listed.status_code == 200
+  matches = [row for row in listed.json() if row["id"] == first.json()["id"]]
+  assert len(matches) == 1
+
+
 def test_chat_list_projects_summaries_without_hydrating_transcripts(
   client, auth,
 ):

--- a/frontend/src/components/ErrorBoundary/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary/ErrorBoundary.jsx
@@ -3,14 +3,15 @@ import { api, BASE } from '../../api/client.js'
 import { recordClientError } from '../../lib/errorLog.js'
 import {
   buildAgentRepairPrompt,
-  clearErrorRecoveryAttempt,
-  ERROR_RECOVERY_STABLE_MS,
+  createRepairIdentity,
   errorRecoveryFingerprint,
   readErrorRecoveryAttempt,
+  recoveryActionPolicy,
   recoveryPhaseForAttempt,
   repairChatPath,
   startAgentRepair,
   writeErrorRecoveryAttempt,
+  writeRefreshedRecoveryAttempt,
 } from '../../lib/errorRecovery.js'
 import RecoveryLink from './RecoveryLink.jsx'
 import './ErrorBoundary.css'
@@ -42,18 +43,19 @@ export default class ErrorBoundary extends Component {
     phase: 'refresh',
     agentError: '',
     repairChatId: null,
+    attemptPhase: null,
   }
 
-  stableTimer = null
   crashContext = null
   agentStarting = false
+  repairController = null
+  pageShowListening = false
 
   static getDerivedStateFromError(error) {
     return { error }
   }
 
   componentDidCatch(error, info) {
-    clearTimeout(this.stableTimer)
     // Record through the shared client-error log (console + ring buffer the
     // recovery surface can read), same sink the global window handlers use.
     recordClientError({
@@ -64,14 +66,17 @@ export default class ErrorBoundary extends Component {
     })
     const message = String(error?.message || error)
     const surfaceKey = this.surfaceKey()
-    const fingerprint = errorRecoveryFingerprint(surfaceKey, message)
+    const componentStack = info?.componentStack || ''
+    const fingerprint = errorRecoveryFingerprint(surfaceKey, message, componentStack)
     const attempt = readErrorRecoveryAttempt({ surfaceKey, fingerprint })
     this.crashContext = {
       surfaceKey,
       fingerprint,
       message,
-      componentStack: info?.componentStack || '',
+      componentStack,
+      attempt,
     }
+    this.listenForPageShow()
     this.setState({
       phase: recoveryPhaseForAttempt(attempt, {
         canAskAgent: this.props.canAskAgent !== false,
@@ -80,33 +85,52 @@ export default class ErrorBoundary extends Component {
         ? 'Möbius couldn’t start the repair chat.'
         : '',
       repairChatId: attempt?.chatId || null,
+      attemptPhase: attempt?.phase || null,
     })
   }
 
-  componentDidMount() {
-    this.armStableClear()
-  }
-
   componentWillUnmount() {
-    clearTimeout(this.stableTimer)
+    this.repairController?.abort()
+    if (this.pageShowListening) window.removeEventListener('pageshow', this.handlePageShow)
   }
 
   surfaceKey = () => this.props.recoveryKey || this.props.label || 'app'
 
-  armStableClear = () => {
-    clearTimeout(this.stableTimer)
-    this.stableTimer = setTimeout(() => {
-      if (!this.state.error) clearErrorRecoveryAttempt(this.surfaceKey())
-    }, ERROR_RECOVERY_STABLE_MS)
+  listenForPageShow = () => {
+    if (this.pageShowListening) return
+    window.addEventListener('pageshow', this.handlePageShow)
+    this.pageShowListening = true
+  }
+
+  handlePageShow = (event) => {
+    const context = this.crashContext
+    if (!event.persisted || !context) return
+    this.agentStarting = false
+    this.repairController = null
+    const attempt = readErrorRecoveryAttempt({
+      surfaceKey: context.surfaceKey,
+      fingerprint: context.fingerprint,
+    })
+    context.attempt = attempt
+    this.setState({
+      phase: recoveryPhaseForAttempt(attempt, {
+        canAskAgent: this.props.canAskAgent !== false,
+      }),
+      attemptPhase: attempt?.phase || null,
+      repairChatId: attempt?.chatId || null,
+      agentError: attempt?.phase === 'agent-failed'
+        ? 'Möbius couldn’t start the repair chat.'
+        : '',
+    })
   }
 
   handleRefresh = () => {
+    if (this.agentStarting) return
     const context = this.crashContext
     if (context) {
-      writeErrorRecoveryAttempt({
+      writeRefreshedRecoveryAttempt({
         surfaceKey: context.surfaceKey,
         fingerprint: context.fingerprint,
-        phase: 'refreshed',
       })
     }
     this.props.onReset?.()
@@ -121,13 +145,44 @@ export default class ErrorBoundary extends Component {
 
   handleAgentRepair = async () => {
     const context = this.crashContext
-    if (!context || this.agentStarting) return
+    if (!context || this.agentStarting || this.props.canAskAgent === false) return
+    const identity = createRepairIdentity(context.attempt)
+    const startingAttempt = {
+      ...(context.attempt || {}),
+      phase: 'agent-starting',
+      repairRequestId: identity.repairRequestId,
+      messageCid: identity.messageCid,
+    }
+    context.attempt = startingAttempt
     this.agentStarting = true
-    this.setState({ phase: 'agent-starting', agentError: '' })
+    this.repairController = new AbortController()
+    writeErrorRecoveryAttempt({
+      surfaceKey: context.surfaceKey,
+      fingerprint: context.fingerprint,
+      ...startingAttempt,
+    })
+    this.setState({
+      phase: 'agent-starting',
+      attemptPhase: 'agent-starting',
+      agentError: '',
+    })
     try {
       const result = await startAgentRepair({
         client: api,
         base: BASE,
+        repairRequestId: identity.repairRequestId,
+        messageCid: identity.messageCid,
+        signal: this.repairController.signal,
+        onChatCreated: chatId => {
+          const attempt = { ...startingAttempt, chatId }
+          context.attempt = attempt
+          writeErrorRecoveryAttempt({
+            surfaceKey: context.surfaceKey,
+            fingerprint: context.fingerprint,
+            ...attempt,
+          })
+          this.setState({ repairChatId: chatId })
+        },
         prompt: buildAgentRepairPrompt({
           surface: context.surfaceKey,
           message: context.message,
@@ -140,17 +195,30 @@ export default class ErrorBoundary extends Component {
         fingerprint: context.fingerprint,
         phase: 'agent-directed',
         chatId: result.chatId,
+        repairRequestId: identity.repairRequestId,
+        messageCid: identity.messageCid,
       })
       window.location.assign(result.path)
-    } catch {
+    } catch (error) {
       this.agentStarting = false
+      this.repairController = null
+      if (error?.name === 'AbortError') return
+      const chatId = context.attempt?.chatId || null
+      context.attempt = {
+        phase: 'agent-failed',
+        chatId,
+        repairRequestId: identity.repairRequestId,
+        messageCid: identity.messageCid,
+      }
       writeErrorRecoveryAttempt({
         surfaceKey: context.surfaceKey,
         fingerprint: context.fingerprint,
-        phase: 'agent-failed',
+        ...context.attempt,
       })
       this.setState({
         phase: 'recovery',
+        attemptPhase: 'agent-failed',
+        repairChatId: chatId,
         agentError: 'Möbius couldn’t start the repair chat.',
       })
     }
@@ -166,9 +234,14 @@ export default class ErrorBoundary extends Component {
     if (!this.state.error) return this.props.children
     const message = String(this.state.error?.message || this.state.error)
     const cls = this.props.variant === 'inline' ? 'errbound errbound--inline' : 'errbound'
-    const { phase } = this.state
-    const afterRefresh = phase !== 'refresh'
-    const recovery = phase === 'recovery'
+    const { phase, attemptPhase, repairChatId } = this.state
+    const canAskAgent = this.props.canAskAgent !== false
+    const actions = recoveryActionPolicy({
+      phase,
+      attemptPhase,
+      canAskAgent,
+      repairChatId,
+    })
     return (
       <div className={cls} role="alert" aria-live="assertive">
         <div className="errbound__card">
@@ -180,11 +253,14 @@ export default class ErrorBoundary extends Component {
             {(phase === 'agent' || phase === 'agent-starting') && (
               <>Refreshing didn’t fix this screen. Möbius can send the error to a new repair chat for your agent to investigate.</>
             )}
-            {recovery && this.state.repairChatId && (
+            {actions.showRecovery && attemptPhase === 'agent-directed' && repairChatId && (
               <>The repair chat started, but this screen still can’t open. System recovery is the remaining fallback.</>
             )}
-            {recovery && !this.state.repairChatId && (
+            {actions.showRecovery && attemptPhase === 'agent-failed' && (
               <>The repair chat couldn’t start. You can try the agent again or use system recovery as a last resort.</>
+            )}
+            {actions.showRecovery && !canAskAgent && (
+              <>Refreshing didn’t fix this screen. Use system recovery to diagnose the problem without relying on this embedded chat.</>
             )}
           </p>
           <pre className="errbound__detail">{message}</pre>
@@ -192,17 +268,17 @@ export default class ErrorBoundary extends Component {
             <p className="errbound__status" role="status">{this.state.agentError}</p>
           )}
           <div className="errbound__actions">
-            {afterRefresh && (
+            {actions.showRefreshAgain && (
               <button type="button" className="errbound__btn" onClick={this.handleRefresh}>
                 Refresh again
               </button>
             )}
-            {recovery && this.state.repairChatId && (
+            {actions.showOpenRepairChat && (
               <button type="button" className="errbound__btn" onClick={this.openRepairChat}>
                 Open repair chat
               </button>
             )}
-            {!(recovery && this.state.repairChatId) && (
+            {(phase === 'refresh' || actions.showAskAgent || actions.showRetryAgent || phase === 'agent-starting') && (
               <button
                 type="button"
                 className="errbound__btn errbound__btn--primary"
@@ -210,13 +286,13 @@ export default class ErrorBoundary extends Component {
                 disabled={phase === 'agent-starting'}
               >
                 {phase === 'refresh' && 'Refresh screen'}
-                {phase === 'agent' && 'Ask agent to fix'}
+                {phase === 'agent' && (attemptPhase === 'agent-starting' ? 'Resume agent repair' : 'Ask agent to fix')}
                 {phase === 'agent-starting' && 'Starting repair chat…'}
-                {recovery && 'Try agent again'}
+                {actions.showRetryAgent && 'Try agent again'}
               </button>
             )}
           </div>
-          {recovery && (
+          {actions.showRecovery && (
             <RecoveryLink lead="If the repair chat can’t get you back in," />
           )}
         </div>

--- a/frontend/src/components/StandaloneApp/StandaloneApp.jsx
+++ b/frontend/src/components/StandaloneApp/StandaloneApp.jsx
@@ -8,14 +8,15 @@ import { stageComposerHandoff } from '../ChatView/composerDraft.js'
 import RecoveryLink from '../ErrorBoundary/RecoveryLink.jsx'
 import {
   buildAgentRepairPrompt,
-  clearErrorRecoveryAttempt,
-  ERROR_RECOVERY_STABLE_MS,
+  createRepairIdentity,
   errorRecoveryFingerprint,
   readErrorRecoveryAttempt,
+  recoveryActionPolicy,
   recoveryPhaseForAttempt,
   repairChatPath,
   startAgentRepair,
   writeErrorRecoveryAttempt,
+  writeRefreshedRecoveryAttempt,
 } from '../../lib/errorRecovery.js'
 import {
   isVisualContentOnly,
@@ -48,8 +49,10 @@ export default function StandaloneApp({ initialApp }) {
   const [removed, setRemoved] = useState(false)
   const [immersive, setImmersive] = useState(false)
   const [crash, setCrash] = useState(null)
+  const crashFingerprint = crash?.fingerprint || null
   const recoverySurfaceKey = `standalone-app:${initialApp.id}`
   const repairStartingRef = useRef(false)
+  const repairControllerRef = useRef(null)
   const [installOpen, setInstallOpen] = useState(() => {
     try { return new URLSearchParams(window.location.search).get('install') === '1' }
     catch { return false }
@@ -78,14 +81,6 @@ export default function StandaloneApp({ initialApp }) {
     return current
   }, [app, initialApp.id, queryClient])
 
-  useEffect(() => {
-    if (crash) return undefined
-    const timer = setTimeout(() => {
-      clearErrorRecoveryAttempt(recoverySurfaceKey)
-    }, ERROR_RECOVERY_STABLE_MS)
-    return () => clearTimeout(timer)
-  }, [crash, recoverySurfaceKey])
-
   const captureCrash = useCallback((_appId, error, chatId) => {
     const message = readableAppDiagnostic(error)
     const fingerprint = errorRecoveryFingerprint(recoverySurfaceKey, message)
@@ -98,12 +93,43 @@ export default function StandaloneApp({ initialApp }) {
       chatId,
       fingerprint,
       phase: recoveryPhaseForAttempt(attempt),
+      attemptPhase: attempt?.phase || null,
       repairChatId: attempt?.chatId || null,
+      repairRequestId: attempt?.repairRequestId || null,
+      messageCid: attempt?.messageCid || null,
       agentError: attempt?.phase === 'agent-failed'
         ? 'Möbius couldn’t start the repair chat.'
         : '',
     })
   }, [recoverySurfaceKey])
+
+  useEffect(() => () => repairControllerRef.current?.abort(), [])
+
+  useEffect(() => {
+    if (!crashFingerprint) return undefined
+    function onPageShow(event) {
+      if (!event.persisted) return
+      repairStartingRef.current = false
+      repairControllerRef.current = null
+      const attempt = readErrorRecoveryAttempt({
+        surfaceKey: recoverySurfaceKey,
+        fingerprint: crashFingerprint,
+      })
+      setCrash(current => current ? {
+        ...current,
+        phase: recoveryPhaseForAttempt(attempt),
+        attemptPhase: attempt?.phase || null,
+        repairChatId: attempt?.chatId || null,
+        repairRequestId: attempt?.repairRequestId || null,
+        messageCid: attempt?.messageCid || null,
+        agentError: attempt?.phase === 'agent-failed'
+          ? 'Möbius couldn’t start the repair chat.'
+          : '',
+      } : current)
+    }
+    window.addEventListener('pageshow', onPageShow)
+    return () => window.removeEventListener('pageshow', onPageShow)
+  }, [crashFingerprint, recoverySurfaceKey])
 
   useSystemEventStream(useCallback((event) => {
     if (String(event.appId || '') !== String(initialApp.id)) return
@@ -205,26 +231,55 @@ export default function StandaloneApp({ initialApp }) {
   }, [captureCrash, initialApp.id])
 
   const refreshCrash = useCallback(() => {
-    if (!crash) return
-    writeErrorRecoveryAttempt({
+    if (!crash || repairStartingRef.current) return
+    writeRefreshedRecoveryAttempt({
       surfaceKey: recoverySurfaceKey,
       fingerprint: crash.fingerprint,
-      phase: 'refreshed',
     })
     window.location.reload()
   }, [crash, recoverySurfaceKey])
 
   const reportCrash = useCallback(() => {
     if (!crash || repairStartingRef.current) return
+    const identity = createRepairIdentity(crash)
+    let createdChatId = crash.repairChatId || null
     repairStartingRef.current = true
+    repairControllerRef.current = new AbortController()
+    const startingAttempt = {
+      phase: 'agent-starting',
+      chatId: crash.repairChatId,
+      repairRequestId: identity.repairRequestId,
+      messageCid: identity.messageCid,
+    }
+    writeErrorRecoveryAttempt({
+      surfaceKey: recoverySurfaceKey,
+      fingerprint: crash.fingerprint,
+      ...startingAttempt,
+    })
     setCrash(current => current ? {
       ...current,
       phase: 'agent-starting',
+      attemptPhase: 'agent-starting',
+      repairRequestId: identity.repairRequestId,
+      messageCid: identity.messageCid,
       agentError: '',
     } : current)
     void startAgentRepair({
       client: api,
       base: BASE,
+      repairRequestId: identity.repairRequestId,
+      messageCid: identity.messageCid,
+      signal: repairControllerRef.current.signal,
+      onChatCreated: chatId => {
+        createdChatId = chatId
+        writeErrorRecoveryAttempt({
+          surfaceKey: recoverySurfaceKey,
+          fingerprint: crash.fingerprint,
+          ...startingAttempt,
+          chatId,
+        })
+        setCrash(current => current ? { ...current, repairChatId: chatId } : current)
+      },
       prompt: buildAgentRepairPrompt({
         surface: `standalone app ${app.name} (${app.id})`,
         message: readableAppDiagnostic(crash.error),
@@ -237,22 +292,37 @@ export default function StandaloneApp({ initialApp }) {
         fingerprint: crash.fingerprint,
         phase: 'agent-directed',
         chatId: result.chatId,
+        repairRequestId: identity.repairRequestId,
+        messageCid: identity.messageCid,
       })
       window.location.href = result.path
-    }).catch(() => {
+    }).catch(error => {
       repairStartingRef.current = false
+      repairControllerRef.current = null
+      if (error?.name === 'AbortError') return
       writeErrorRecoveryAttempt({
         surfaceKey: recoverySurfaceKey,
         fingerprint: crash.fingerprint,
         phase: 'agent-failed',
+        chatId: createdChatId,
+        repairRequestId: identity.repairRequestId,
+        messageCid: identity.messageCid,
       })
       setCrash(current => current ? {
         ...current,
         phase: 'recovery',
+        attemptPhase: 'agent-failed',
+        repairChatId: createdChatId,
         agentError: 'Möbius couldn’t start the repair chat.',
       } : current)
     })
   }, [app.id, app.name, crash, recoverySurfaceKey])
+
+  const crashActions = crash ? recoveryActionPolicy({
+    phase: crash.phase,
+    attemptPhase: crash.attemptPhase,
+    repairChatId: crash.repairChatId,
+  }) : null
 
   const openRepairChat = useCallback(() => {
     if (crash?.repairChatId) {
@@ -319,34 +389,34 @@ export default function StandaloneApp({ initialApp }) {
           <p>
             {crash.phase === 'refresh' && 'Refresh the app first. Your chats and data are safe.'}
             {(crash.phase === 'agent' || crash.phase === 'agent-starting') && 'Refreshing didn’t fix it. Möbius can send this error to a new repair chat for your agent to investigate.'}
-            {crash.phase === 'recovery' && crash.repairChatId && 'The repair chat started, but the app still can’t open. System recovery is the remaining fallback.'}
-            {crash.phase === 'recovery' && !crash.repairChatId && 'The repair chat couldn’t start. Try the agent again or use system recovery as a last resort.'}
+            {crash.phase === 'recovery' && crash.attemptPhase === 'agent-directed' && 'The repair chat started, but the app still can’t open. System recovery is the remaining fallback.'}
+            {crash.phase === 'recovery' && crash.attemptPhase === 'agent-failed' && 'The repair chat couldn’t start. Try the agent again or use system recovery as a last resort.'}
           </p>
           <pre>{readableAppDiagnostic(crash.error)}</pre>
           {crash.agentError && (
             <p className="standalone-app__crash-status" role="status">{crash.agentError}</p>
           )}
           <div>
-            {crash.phase !== 'refresh' && (
+            {crashActions.showRefreshAgain && (
               <button type="button" onClick={refreshCrash}>Refresh again</button>
             )}
-            {crash.phase === 'recovery' && crash.repairChatId && (
+            {crashActions.showOpenRepairChat && (
               <button type="button" onClick={openRepairChat}>Open repair chat</button>
             )}
-            {!crash.repairChatId && (
+            {(crash.phase === 'refresh' || crashActions.showAskAgent || crashActions.showRetryAgent || crash.phase === 'agent-starting') && (
               <button
                 type="button"
                 onClick={crash.phase === 'refresh' ? refreshCrash : reportCrash}
                 disabled={crash.phase === 'agent-starting'}
               >
                 {crash.phase === 'refresh' && 'Refresh app'}
-                {crash.phase === 'agent' && 'Ask agent to fix'}
+                {crash.phase === 'agent' && (crash.attemptPhase === 'agent-starting' ? 'Resume agent repair' : 'Ask agent to fix')}
                 {crash.phase === 'agent-starting' && 'Starting repair chat…'}
                 {crash.phase === 'recovery' && 'Try agent again'}
               </button>
             )}
           </div>
-          {crash.phase === 'recovery' && (
+          {crashActions.showRecovery && (
             <RecoveryLink
               className="standalone-app__recovery"
               lead="If the repair chat can’t get you back in,"

--- a/frontend/src/lib/__tests__/errorLog.test.js
+++ b/frontend/src/lib/__tests__/errorLog.test.js
@@ -130,6 +130,24 @@ test('still writes the sessionStorage ring (existing behavior preserved)', () =>
   assert.ok(ring.some((r) => r.message === 'ring me'), 'ring buffer still populated')
 })
 
+test('credentials are redacted before local storage and remote reporting', () => {
+  const secret = 'github_pat_0123456789abcdefghijklmnopqrstuvwxyz'
+  globalThis.location.href = `https://mobius.example/app?token=${secret}`
+  errorLog.recordClientError({
+    where: 'window.onerror',
+    message: `Authorization: Bearer ${secret}`,
+    stack: `OPENAI_API_KEY=${secret}`,
+    componentStack: `postgres://owner:${secret}@db.internal/mobius`,
+  })
+
+  const serializedRing = JSON.stringify(errorLog.getRecentErrors())
+  const serializedReport = fetchCalls[0].opts.body
+  assert.doesNotMatch(serializedRing, new RegExp(secret))
+  assert.doesNotMatch(serializedReport, new RegExp(secret))
+  assert.match(serializedRing, /\[redacted/)
+  assert.match(serializedReport, /\[redacted/)
+})
+
 function stubWindowEvents() {
   const handlers = {}
   globalThis.window = {

--- a/frontend/src/lib/__tests__/errorRecovery.test.js
+++ b/frontend/src/lib/__tests__/errorRecovery.test.js
@@ -4,13 +4,17 @@ import assert from 'node:assert/strict'
 import {
   AGENT_REPAIR_REQUEST_TIMEOUT_MS,
   buildAgentRepairPrompt,
+  createRepairIdentity,
   ERROR_RECOVERY_MAX_AGE_MS,
   errorRecoveryFingerprint,
   readErrorRecoveryAttempt,
+  recoveryActionPolicy,
   recoveryPhaseForAttempt,
+  redactDiagnosticText,
   repairChatPath,
   startAgentRepair,
   writeErrorRecoveryAttempt,
+  writeRefreshedRecoveryAttempt,
 } from '../errorRecovery.js'
 
 function memoryStorage() {
@@ -63,6 +67,70 @@ test('a matching refresh attempt advances the same surface to agent help', () =>
   })
   assert.equal(directed.chatId, 'repair-chat')
   assert.equal(recoveryPhaseForAttempt(directed), 'recovery')
+})
+
+test('refresh attempts never downgrade an agent repair or discard its identity', () => {
+  const storage = memoryStorage()
+  const surfaceKey = 'chat:monotonic'
+  const fingerprint = errorRecoveryFingerprint(surfaceKey, 'same failure')
+  writeErrorRecoveryAttempt({
+    storage,
+    surfaceKey,
+    fingerprint,
+    phase: 'agent-directed',
+    chatId: 'repair-chat',
+    repairRequestId: 'repair-request',
+    messageCid: 'repair-message',
+    now: 100,
+  })
+
+  assert.equal(writeRefreshedRecoveryAttempt({
+    storage,
+    surfaceKey,
+    fingerprint,
+    now: 200,
+  }), true)
+  assert.deepEqual(readErrorRecoveryAttempt({
+    storage,
+    surfaceKey,
+    fingerprint,
+    now: 300,
+  }), {
+    fingerprint,
+    phase: 'agent-directed',
+    at: 100,
+    chatId: 'repair-chat',
+    repairRequestId: 'repair-request',
+    messageCid: 'repair-message',
+  })
+})
+
+test('restricted recovery policy never exposes owner-agent actions', () => {
+  assert.deepEqual(recoveryActionPolicy({
+    phase: 'recovery',
+    attemptPhase: 'agent-failed',
+    canAskAgent: false,
+  }), {
+    showRefreshAgain: true,
+    showAskAgent: false,
+    showRetryAgent: false,
+    showOpenRepairChat: false,
+    showRecovery: true,
+  })
+})
+
+test('an interrupted repair resumes with the same request and message identities', () => {
+  let index = 0
+  const createId = () => ['request-id', 'message-cid'][index++]
+  const first = createRepairIdentity(null, createId)
+  const resumed = createRepairIdentity(first, () => 'must-not-be-used')
+
+  assert.deepEqual(first, {
+    repairRequestId: 'request-id',
+    messageCid: 'message-cid',
+  })
+  assert.deepEqual(resumed, first)
+  assert.equal(recoveryPhaseForAttempt({ phase: 'agent-starting' }), 'agent')
 })
 
 test('stale and different errors do not inherit an escalation', () => {
@@ -118,6 +186,28 @@ test('repair prompt bounds and indents untrusted diagnostics', () => {
   assert.match(prompt, /Preserve user data/)
 })
 
+test('repair diagnostics redact common credentials before storage or agent use', () => {
+  const input = [
+    'https://user:password@example.com/path?token=secret-token&code=secret-code',
+    'Authorization: Bearer abc.def.ghi',
+    'Cookie: session=secret-cookie',
+    'OPENAI_API_KEY=sk-secret',
+    'eyJheader.eyJpayload.signature',
+  ].join('\n')
+  const redacted = redactDiagnosticText(input)
+
+  for (const secret of [
+    'password',
+    'secret-token',
+    'secret-code',
+    'abc.def.ghi',
+    'secret-cookie',
+    'sk-secret',
+    'eyJpayload',
+  ]) assert.doesNotMatch(redacted, new RegExp(secret))
+  assert.match(redacted, /\[redacted\]/)
+})
+
 test('agent repair creates a fresh chat, sends the diagnostic, and returns its route', async () => {
   const calls = []
   const client = {
@@ -137,25 +227,28 @@ test('agent repair creates a fresh chat, sends the diagnostic, and returns its r
     prompt: 'diagnostic prompt',
     client,
     base: '/mobius',
-    createCid: () => 'repair-cid',
+    repairRequestId: 'repair-request',
+    messageCid: 'repair-cid',
   })
 
   assert.deepEqual(calls, [
     [
       'create',
-      { title: 'Fix a Möbius error' },
-      { timeoutMs: AGENT_REPAIR_REQUEST_TIMEOUT_MS },
+      { title: 'Fix a Möbius error', recovery_request_id: 'repair-request' },
+      { timeoutMs: AGENT_REPAIR_REQUEST_TIMEOUT_MS, signal: undefined },
     ],
     [
       'send',
       'repair/id',
       { content: 'diagnostic prompt', cid: 'repair-cid' },
-      { timeoutMs: AGENT_REPAIR_REQUEST_TIMEOUT_MS },
+      { timeoutMs: AGENT_REPAIR_REQUEST_TIMEOUT_MS, signal: undefined },
     ],
   ])
   assert.deepEqual(result, {
     chatId: 'repair/id',
     path: '/mobius/shell/?chat=repair%2Fid',
+    repairRequestId: 'repair-request',
+    messageCid: 'repair-cid',
   })
   assert.equal(repairChatPath('chat id'), '/shell/?chat=chat%20id')
 })
@@ -168,7 +261,12 @@ test('agent repair stops before navigation when the diagnostic send fails', asyn
     },
   }
   await assert.rejects(
-    startAgentRepair({ prompt: 'diagnostic', client }),
+    startAgentRepair({
+      prompt: 'diagnostic',
+      client,
+      repairRequestId: 'repair-request',
+      messageCid: 'repair-cid',
+    }),
     /repair chat send 503/,
   )
 })

--- a/frontend/src/lib/__tests__/errorRecovery.test.js
+++ b/frontend/src/lib/__tests__/errorRecovery.test.js
@@ -189,23 +189,49 @@ test('repair prompt bounds and indents untrusted diagnostics', () => {
 test('repair diagnostics redact common credentials before storage or agent use', () => {
   const input = [
     'https://user:password@example.com/path?token=secret-token&code=secret-code',
+    'postgres://db-user:db-password@database.internal/mobius',
     'Authorization: Bearer abc.def.ghi',
     'Cookie: session=secret-cookie',
     'OPENAI_API_KEY=sk-secret',
+    'AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE',
+    'AWS_SECRET_ACCESS_KEY="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"',
+    '{"AWS_SECRET_ACCESS_KEY":"json/secret+value-that-must-not-pass"}',
+    'NPM_TOKEN=npm_0123456789abcdefghijklmnopqrstuvwxyz',
+    'unlabeled github_pat_0123456789abcdefghijklmnopqrstuvwxyz',
+    'opaque c29tZS12ZXJ5LWxvbmctcHJpdmF0ZS12YWx1ZS0xMjM0NTY3ODkw',
     'eyJheader.eyJpayload.signature',
+    '-----BEGIN PRIVATE KEY-----\nprivate-key-body\n-----END PRIVATE KEY-----',
   ].join('\n')
   const redacted = redactDiagnosticText(input)
 
   for (const secret of [
     'password',
+    'db-password',
     'secret-token',
     'secret-code',
     'abc.def.ghi',
     'secret-cookie',
     'sk-secret',
+    'AKIAIOSFODNN7EXAMPLE',
+    'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+    'json/secret+value-that-must-not-pass',
+    'npm_0123456789abcdefghijklmnopqrstuvwxyz',
+    'github_pat_0123456789abcdefghijklmnopqrstuvwxyz',
+    'c29tZS12ZXJ5LWxvbmctcHJpdmF0ZS12YWx1ZS0xMjM0NTY3ODkw',
     'eyJpayload',
-  ]) assert.doesNotMatch(redacted, new RegExp(secret))
+    'private-key-body',
+  ]) assert.equal(redacted.includes(secret), false, `must redact ${secret}`)
   assert.match(redacted, /\[redacted\]/)
+  assert.match(redacted, /\[redacted-private-key\]/)
+  assert.match(redacted, /\[redacted-provider-token\]/)
+  assert.match(redacted, /\[redacted-high-entropy-value\]/)
+})
+
+test('diagnostic redaction preserves ordinary hashes, prose, and long symbols', () => {
+  const commit = '8fe8a7ae35dce88ee4af7585b9ff0b4c229df257'
+  const symbol = 'VeryLongRecoveryBoundaryComponentIdentifier'
+  const diagnostic = `Build ${commit} failed in ${symbol} while rendering the recovery screen.`
+  assert.equal(redactDiagnosticText(diagnostic), diagnostic)
 })
 
 test('agent repair creates a fresh chat, sends the diagnostic, and returns its route', async () => {

--- a/frontend/src/lib/appDiagnostic.js
+++ b/frontend/src/lib/appDiagnostic.js
@@ -1,8 +1,7 @@
-const TOKEN_IN_URL = /([?&]token=)[^&\s"'<>]+/gi
+import { redactDiagnosticText } from './errorRecovery.js'
 
 export function readableAppDiagnostic(error, limit = 6000) {
-  const raw = String(error?.message || error || 'Unknown app error')
-    .replace(TOKEN_IN_URL, '$1[redacted]')
+  const raw = redactDiagnosticText(error?.message || error || 'Unknown app error')
   return raw.length > limit
     ? `${raw.slice(0, limit)}\n[diagnostic truncated]`
     : raw

--- a/frontend/src/lib/errorLog.js
+++ b/frontend/src/lib/errorLog.js
@@ -10,6 +10,8 @@
 // or route through apiFetch's 401-reload path, and a failed report can never
 // itself throw.
 
+import { redactDiagnosticText } from './errorRecovery.js'
+
 const RING_KEY = 'mobius:error-log' // ring buffer of the last MAX errors
 const MAX = 10
 
@@ -58,7 +60,9 @@ function postClientError(record) {
         message: String(record.message).slice(0, 2000),
         where: record.where,
         stack: detail ? String(detail).slice(0, 8000) : undefined,
-        url: (typeof location !== 'undefined') ? location.href : undefined,
+        url: (typeof location !== 'undefined')
+          ? redactDiagnosticText(location.href).slice(0, 2000)
+          : undefined,
       }),
       keepalive: true,
     }).catch(() => {})
@@ -74,10 +78,12 @@ function postClientError(record) {
  */
 export function recordClientError({ where, message, error, stack, componentStack } = {}) {
   const record = {
-    where: where || 'unknown',
-    message: String(message ?? error?.message ?? error ?? 'Unknown error'),
-    stack: String(stack ?? error?.stack ?? '').slice(0, 2000),
-    componentStack: String(componentStack ?? '').slice(0, 2000),
+    where: redactDiagnosticText(where || 'unknown').slice(0, 200),
+    message: redactDiagnosticText(
+      message ?? error?.message ?? error ?? 'Unknown error',
+    ).slice(0, 2000),
+    stack: redactDiagnosticText(stack ?? error?.stack ?? '').slice(0, 2000),
+    componentStack: redactDiagnosticText(componentStack ?? '').slice(0, 2000),
     at: new Date().toISOString(),
   }
   console.error(`[mobius:error:${record.where}]`, record.message)

--- a/frontend/src/lib/errorRecovery.js
+++ b/frontend/src/lib/errorRecovery.js
@@ -12,18 +12,43 @@ const REPAIR_ACTIVE_PHASES = new Set(['agent-starting', 'agent-directed', 'agent
 const SECRET_QUERY_VALUE = /([?&](?:access_token|auth|authorization|code|key|password|secret|token)=)[^&#\s"'<>]+/gi
 const AUTHORIZATION_VALUE = /\b(authorization\s*[:=]\s*)(?:bearer|basic)\s+[^\s,;]+/gi
 const COOKIE_VALUE = /\b((?:set-)?cookie\s*[:=]\s*)[^\r\n]+/gi
-const SECRET_ASSIGNMENT = /\b((?:anthropic|openai|github|gitlab|slack|stripe)?_?(?:api_?)?(?:key|secret|token|password))\s*[:=]\s*([^\s,;&#]+)/gi
+const SECRET_ASSIGNMENT = /(["']?)\b((?:[a-z0-9]+[_-])*(?:access[_-]?key[_-]?id|secret[_-]?access[_-]?key|api[_-]?key|client[_-]?secret|access[_-]?token|refresh[_-]?token|auth[_-]?token|private[_-]?key|token|password|passwd|pwd|secret))\1(\s*[:=]\s*)("[^"\r\n]*"|'[^'\r\n]*'|[^\s,;&#]+)/gi
 const JWT_VALUE = /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g
-const URL_CREDENTIALS = /(https?:\/\/)[^\s/@:]+:[^\s/@]+@/gi
+const PRIVATE_KEY_BLOCK = /-----BEGIN [^-\r\n]*PRIVATE KEY-----[\s\S]*?-----END [^-\r\n]*PRIVATE KEY-----/g
+const PROVIDER_TOKEN = /\b(?:A(?:KIA|SIA)[0-9A-Z]{16}|github_pat_[A-Za-z0-9_]{20,}|gh[pousr]_[A-Za-z0-9]{20,}|glpat-[A-Za-z0-9_-]{20,}|npm_[A-Za-z0-9]{20,}|xox[baprs]-[A-Za-z0-9-]{10,}|(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{10,}|sk-[A-Za-z0-9_-]{20,}|AIza[A-Za-z0-9_-]{20,})\b/g
+const HIGH_ENTROPY_VALUE = /\b[A-Za-z0-9+_-]{32,}={0,2}\b/g
+const URL_CREDENTIALS = /([a-z][a-z0-9+.-]*:\/\/)[^\s/@:]+:[^\s/@]+@/gi
+
+function highEntropyReplacement(token) {
+  const value = token.replace(/=+$/, '')
+  const counts = new Map()
+  for (const character of value) {
+    counts.set(character, (counts.get(character) || 0) + 1)
+  }
+  let entropy = 0
+  for (const count of counts.values()) {
+    const probability = count / value.length
+    entropy -= probability * Math.log2(probability)
+  }
+  return entropy >= 4.5 ? '[redacted-high-entropy-value]' : token
+}
 
 export function redactDiagnosticText(value) {
   return String(value || '')
+    .replace(PRIVATE_KEY_BLOCK, '[redacted-private-key]')
     .replace(SECRET_QUERY_VALUE, '$1[redacted]')
     .replace(AUTHORIZATION_VALUE, '$1[redacted]')
     .replace(COOKIE_VALUE, '$1[redacted]')
-    .replace(SECRET_ASSIGNMENT, '$1=[redacted]')
+    .replace(SECRET_ASSIGNMENT, (_match, quote, key, separator, rawValue) => {
+      const valueQuote = rawValue.startsWith('"') || rawValue.startsWith("'")
+        ? rawValue[0]
+        : ''
+      return `${quote}${key}${quote}${separator}${valueQuote}[redacted]${valueQuote}`
+    })
     .replace(JWT_VALUE, '[redacted-jwt]')
     .replace(URL_CREDENTIALS, '$1[redacted]@')
+    .replace(PROVIDER_TOKEN, '[redacted-provider-token]')
+    .replace(HIGH_ENTROPY_VALUE, highEntropyReplacement)
 }
 
 function boundedText(value, limit) {

--- a/frontend/src/lib/errorRecovery.js
+++ b/frontend/src/lib/errorRecovery.js
@@ -1,12 +1,33 @@
 export const ERROR_RECOVERY_MAX_AGE_MS = 10 * 60 * 1000
-export const ERROR_RECOVERY_STABLE_MS = 15 * 1000
 export const AGENT_REPAIR_REQUEST_TIMEOUT_MS = 12 * 1000
 
-const STORAGE_PREFIX = 'mobius:error-recovery:'
-const ATTEMPT_PHASES = new Set(['refreshed', 'agent-directed', 'agent-failed'])
+const STORAGE_PREFIX = 'mobius:error-recovery:v2:'
+const ATTEMPT_PHASES = new Set([
+  'refreshed',
+  'agent-starting',
+  'agent-directed',
+  'agent-failed',
+])
+const REPAIR_ACTIVE_PHASES = new Set(['agent-starting', 'agent-directed', 'agent-failed'])
+const SECRET_QUERY_VALUE = /([?&](?:access_token|auth|authorization|code|key|password|secret|token)=)[^&#\s"'<>]+/gi
+const AUTHORIZATION_VALUE = /\b(authorization\s*[:=]\s*)(?:bearer|basic)\s+[^\s,;]+/gi
+const COOKIE_VALUE = /\b((?:set-)?cookie\s*[:=]\s*)[^\r\n]+/gi
+const SECRET_ASSIGNMENT = /\b((?:anthropic|openai|github|gitlab|slack|stripe)?_?(?:api_?)?(?:key|secret|token|password))\s*[:=]\s*([^\s,;&#]+)/gi
+const JWT_VALUE = /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g
+const URL_CREDENTIALS = /(https?:\/\/)[^\s/@:]+:[^\s/@]+@/gi
+
+export function redactDiagnosticText(value) {
+  return String(value || '')
+    .replace(SECRET_QUERY_VALUE, '$1[redacted]')
+    .replace(AUTHORIZATION_VALUE, '$1[redacted]')
+    .replace(COOKIE_VALUE, '$1[redacted]')
+    .replace(SECRET_ASSIGNMENT, '$1=[redacted]')
+    .replace(JWT_VALUE, '[redacted-jwt]')
+    .replace(URL_CREDENTIALS, '$1[redacted]@')
+}
 
 function boundedText(value, limit) {
-  return String(value || '')
+  return redactDiagnosticText(value)
     .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, ' ')
     .replace(/\r\n?/g, '\n')
     .replace(/[\u2028\u2029]/g, '\n')
@@ -27,8 +48,12 @@ function storageKey(surfaceKey) {
   return `${STORAGE_PREFIX}${stableHash(surfaceKey)}`
 }
 
-export function errorRecoveryFingerprint(surfaceKey, message) {
-  return stableHash(`${surfaceKey}\n${boundedText(message, 2000)}`)
+export function errorRecoveryFingerprint(surfaceKey, message, componentStack = '') {
+  return stableHash([
+    boundedText(surfaceKey, 180),
+    boundedText(message, 2000),
+    boundedText(componentStack, 2000),
+  ].join('\n'))
 }
 
 export function readErrorRecoveryAttempt({
@@ -63,6 +88,8 @@ export function writeErrorRecoveryAttempt({
   fingerprint,
   phase,
   chatId = null,
+  repairRequestId = null,
+  messageCid = null,
   now = Date.now(),
 }) {
   if (!ATTEMPT_PHASES.has(phase)) return false
@@ -72,6 +99,8 @@ export function writeErrorRecoveryAttempt({
       phase,
       at: now,
       chatId: chatId ? String(chatId) : null,
+      repairRequestId: repairRequestId ? String(repairRequestId) : null,
+      messageCid: messageCid ? String(messageCid) : null,
     }))
     return true
   } catch {
@@ -79,21 +108,57 @@ export function writeErrorRecoveryAttempt({
   }
 }
 
-export function clearErrorRecoveryAttempt(
-  surfaceKey,
+export function writeRefreshedRecoveryAttempt({
   storage = globalThis.sessionStorage,
-) {
-  try {
-    storage.removeItem(storageKey(surfaceKey))
-  } catch {
-    /* storage is best-effort */
-  }
+  surfaceKey,
+  fingerprint,
+  now = Date.now(),
+}) {
+  const current = readErrorRecoveryAttempt({ storage, surfaceKey, fingerprint, now })
+  if (current && REPAIR_ACTIVE_PHASES.has(current.phase)) return true
+  return writeErrorRecoveryAttempt({
+    storage,
+    surfaceKey,
+    fingerprint,
+    phase: 'refreshed',
+    now,
+  })
 }
 
 export function recoveryPhaseForAttempt(attempt, { canAskAgent = true } = {}) {
   if (!attempt) return 'refresh'
-  if (attempt.phase === 'refreshed' && canAskAgent) return 'agent'
+  if (
+    canAskAgent
+    && (attempt.phase === 'refreshed' || attempt.phase === 'agent-starting')
+  ) return 'agent'
   return 'recovery'
+}
+
+export function recoveryActionPolicy({
+  phase,
+  attemptPhase = null,
+  canAskAgent = true,
+  repairChatId = null,
+}) {
+  const starting = phase === 'agent-starting'
+  return {
+    showRefreshAgain: phase !== 'refresh' && !starting,
+    showAskAgent: canAskAgent && phase === 'agent',
+    showRetryAgent: canAskAgent && phase === 'recovery' && attemptPhase === 'agent-failed',
+    showOpenRepairChat: phase === 'recovery' && Boolean(repairChatId),
+    showRecovery: phase === 'recovery',
+  }
+}
+
+export function createRepairIdentity(
+  attempt,
+  createId = () => globalThis.crypto?.randomUUID?.()
+    || `repair-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+) {
+  return {
+    repairRequestId: attempt?.repairRequestId || createId(),
+    messageCid: attempt?.messageCid || createId(),
+  }
 }
 
 function diagnosticBlock(value, limit) {
@@ -136,25 +201,36 @@ export async function startAgentRepair({
   prompt,
   client,
   base = '',
-  createCid = () => globalThis.crypto?.randomUUID?.()
-    || `repair-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  repairRequestId,
+  messageCid,
+  signal,
+  onChatCreated,
 }) {
   if (!client?.chats?.create || !client?.chats?.send) {
     throw new Error('repair chat client is unavailable')
   }
-  const requestOptions = { timeoutMs: AGENT_REPAIR_REQUEST_TIMEOUT_MS }
+  if (!repairRequestId || !messageCid) {
+    throw new Error('repair request identity is unavailable')
+  }
+  const requestOptions = { timeoutMs: AGENT_REPAIR_REQUEST_TIMEOUT_MS, signal }
   const createResponse = await client.chats.create(
-    { title: 'Fix a Möbius error' },
+    { title: 'Fix a Möbius error', recovery_request_id: repairRequestId },
     requestOptions,
   )
   if (!createResponse.ok) throw new Error(`repair chat create ${createResponse.status}`)
   const chat = await createResponse.json()
   if (!chat?.id) throw new Error('repair chat create returned no chat id')
+  onChatCreated?.(String(chat.id))
 
   const sendResponse = await client.chats.send(chat.id, {
     content: prompt,
-    cid: createCid(),
+    cid: messageCid,
   }, requestOptions)
   if (!sendResponse.ok) throw new Error(`repair chat send ${sendResponse.status}`)
-  return { chatId: String(chat.id), path: repairChatPath(chat.id, base) }
+  return {
+    chatId: String(chat.id),
+    path: repairChatPath(chat.id, base),
+    repairRequestId,
+    messageCid,
+  }
 }


### PR DESCRIPTION
## Summary

- make the refresh → agent → recovery ladder monotonic across reloads and delayed reproductions
- give repair-chat creation a stable idempotency key and reuse the same message CID after ambiguous timeouts
- block owner-agent actions in restricted chat embeds and reconcile interrupted repairs after BFCache restoration
- version the recovery marker and redact common credentials before diagnostics enter storage or an agent turn

## Why

The initial progressive recovery implementation could lose its refresh marker after 15 seconds, move backward after a later refresh, and create duplicate or empty repair chats when a committed request timed out. Restricted embeds also rendered an owner-only action that their scoped credentials could never complete.

## Safety

- repair chat IDs are deterministically derived server-side from a random client request ID; concurrent duplicate POSTs converge on one chat
- the existing message-CID contract makes the diagnostic send idempotent as well
- lifecycle aborts release in-flight requests, while durable identities make response-loss retries safe
- diagnostic redaction covers credential-bearing query fields, authorization and cookie values, common secret assignments, JWTs, and URL userinfo
- recovery markers retain only the minimal incident identity and expire after ten minutes

## Verification

- `npm test` — 2,239 library tests and 76 hook tests pass
- `npm run build` — production and offline/PWA validation pass
- `scripts/wt-pytest.sh tests/test_chats.py -q` — 27 pass
- focused ESLint — 0 errors
- pre-push privacy, Python syntax, JSX parse, and frontend-unit gates pass

Follow-up: a stacked UI/accessibility PR will address focus, inert background surfaces, short-viewport scrolling, contrast, touch targets, live-region behavior, and diagnostic disclosure.
