### PR TITLE
Polish progressive recovery accessibility

### DIFF
--- a/frontend/src/components/ErrorBoundary/ErrorBoundary.css
+++ b/frontend/src/components/ErrorBoundary/ErrorBoundary.css
@@ -8,9 +8,14 @@
   inset: 0;
   z-index: 9999;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
-  padding: max(24px, env(safe-area-inset-top)) 24px max(24px, env(safe-area-inset-bottom));
+  overflow: auto;
+  padding:
+    max(24px, env(safe-area-inset-top))
+    max(24px, env(safe-area-inset-right))
+    max(24px, env(safe-area-inset-bottom))
+    max(24px, env(safe-area-inset-left));
   background: var(--bg, #0d0d0d);
   color: var(--text, #ececec);
 }
@@ -25,6 +30,7 @@
 .errbound__card {
   width: 100%;
   max-width: 28rem;
+  margin: auto;
   padding: 24px;
   background: var(--surface, #171717);
   border: 1px solid var(--border, rgba(255, 255, 255, 0.08));
@@ -38,6 +44,10 @@
   font-weight: 600;
 }
 
+.errbound__title:focus {
+  outline: none;
+}
+
 .errbound__body {
   margin: 0 0 16px;
   font-size: 14px;
@@ -45,8 +55,26 @@
   opacity: 0.8;
 }
 
-.errbound__detail {
+.errbound__details {
   margin: 0 0 20px;
+  color: var(--muted, #a8a8a8);
+  font-size: 13px;
+}
+
+.errbound__details summary {
+  width: max-content;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.errbound__details summary:focus-visible {
+  outline: 2px solid var(--accent, #8b6cf7);
+  outline-offset: 3px;
+}
+
+.errbound__detail {
+  margin: 10px 0 0;
   padding: 10px 12px;
   max-height: 8rem;
   overflow: auto;
@@ -54,7 +82,7 @@
   font-size: 12px;
   white-space: pre-wrap;
   word-break: break-word;
-  color: var(--danger, #f87171);
+  color: color-mix(in srgb, var(--danger, #f87171) 78%, var(--text, #ececec));
   background: color-mix(in srgb, var(--danger, #f87171) 12%, transparent);
   border-radius: 8px;
 }
@@ -67,6 +95,10 @@
 }
 
 .errbound__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
   font: inherit;
   font-size: 14px;
   font-weight: 500;
@@ -76,7 +108,8 @@
   background: transparent;
   color: var(--text, #ececec);
   cursor: pointer;
-  transition: opacity 0.15s var(--ease-out-soft, ease);
+  text-decoration: none;
+  transition: background-color 0.15s var(--ease-out-soft, ease), border-color 0.15s var(--ease-out-soft, ease);
 }
 
 .errbound__btn:disabled {
@@ -92,21 +125,41 @@
 
 @media (hover: hover) and (pointer: fine) {
   .errbound__btn:hover {
-    opacity: 0.85;
+    border-color: color-mix(in srgb, var(--text, #ececec) 42%, transparent);
+    background: color-mix(in srgb, var(--text, #ececec) 8%, transparent);
   }
 }
 
 .errbound__btn--primary {
-  background: var(--accent, #8b6cf7);
-  border-color: var(--accent, #8b6cf7);
+  background: color-mix(in srgb, var(--accent, #8b6cf7) 82%, #000);
+  border-color: color-mix(in srgb, var(--accent, #8b6cf7) 82%, #000);
   color: var(--accent-fg, #ffffff);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .errbound__btn--primary:hover {
+    border-color: color-mix(in srgb, var(--accent, #8b6cf7) 74%, #000);
+    background: color-mix(in srgb, var(--accent, #8b6cf7) 74%, #000);
+  }
 }
 
 .errbound__status {
   margin: -8px 0 16px;
-  color: var(--danger, #f87171);
+  color: color-mix(in srgb, var(--danger, #f87171) 78%, var(--text, #ececec));
   font-size: 13px;
   line-height: 1.5;
+}
+
+.errbound__status--sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .errbound__recovery {
@@ -126,5 +179,15 @@
 @media (hover: hover) and (pointer: fine) {
   .errbound__recovery a:hover {
     color: var(--text, #ececec);
+  }
+}
+
+@media (max-width: 30rem) {
+  .errbound__actions {
+    flex-direction: column;
+  }
+
+  .errbound__btn {
+    width: 100%;
   }
 }

--- a/frontend/src/components/ErrorBoundary/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary/ErrorBoundary.jsx
@@ -6,6 +6,7 @@ import {
   createRepairIdentity,
   errorRecoveryFingerprint,
   readErrorRecoveryAttempt,
+  redactDiagnosticText,
   recoveryActionPolicy,
   recoveryPhaseForAttempt,
   repairChatPath,
@@ -40,7 +41,7 @@ import './ErrorBoundary.css'
 export default class ErrorBoundary extends Component {
   state = {
     error: null,
-    phase: 'refresh',
+    phase: 'resolving',
     agentError: '',
     repairChatId: null,
     attemptPhase: null,
@@ -50,6 +51,7 @@ export default class ErrorBoundary extends Component {
   agentStarting = false
   repairController = null
   pageShowListening = false
+  headingRef = null
 
   static getDerivedStateFromError(error) {
     return { error }
@@ -82,11 +84,17 @@ export default class ErrorBoundary extends Component {
         canAskAgent: this.props.canAskAgent !== false,
       }),
       agentError: attempt?.phase === 'agent-failed'
-        ? 'Möbius couldn’t start the repair chat.'
+        ? 'Repair chat request failed.'
         : '',
       repairChatId: attempt?.chatId || null,
       attemptPhase: attempt?.phase || null,
     })
+  }
+
+  componentDidUpdate(_prevProps, prevState) {
+    if (prevState.phase === 'resolving' && this.state.phase !== 'resolving') {
+      this.headingRef?.focus()
+    }
   }
 
   componentWillUnmount() {
@@ -119,7 +127,7 @@ export default class ErrorBoundary extends Component {
       attemptPhase: attempt?.phase || null,
       repairChatId: attempt?.chatId || null,
       agentError: attempt?.phase === 'agent-failed'
-        ? 'Möbius couldn’t start the repair chat.'
+        ? 'Repair chat request failed.'
         : '',
     })
   }
@@ -219,20 +227,14 @@ export default class ErrorBoundary extends Component {
         phase: 'recovery',
         attemptPhase: 'agent-failed',
         repairChatId: chatId,
-        agentError: 'Möbius couldn’t start the repair chat.',
+        agentError: 'Repair chat request failed.',
       })
-    }
-  }
-
-  openRepairChat = () => {
-    if (this.state.repairChatId) {
-      window.location.assign(repairChatPath(this.state.repairChatId, BASE))
     }
   }
 
   render() {
     if (!this.state.error) return this.props.children
-    const message = String(this.state.error?.message || this.state.error)
+    const message = redactDiagnosticText(this.state.error?.message || this.state.error)
     const cls = this.props.variant === 'inline' ? 'errbound errbound--inline' : 'errbound'
     const { phase, attemptPhase, repairChatId } = this.state
     const canAskAgent = this.props.canAskAgent !== false
@@ -243,40 +245,58 @@ export default class ErrorBoundary extends Component {
       repairChatId,
     })
     return (
-      <div className={cls} role="alert" aria-live="assertive">
+      <div className={cls}>
         <div className="errbound__card">
-          <h1 className="errbound__title">Something broke</h1>
+          <h1
+            className="errbound__title"
+            ref={node => { this.headingRef = node }}
+            tabIndex={-1}
+          >
+            Something broke
+          </h1>
           <p className="errbound__body">
             {phase === 'refresh' && (
-              <>This screen hit an unexpected error. Your chats and data are safe. Refresh the screen to try it again.</>
+              <>This screen hit an unexpected error. Refreshing won’t delete your chats.</>
             )}
             {(phase === 'agent' || phase === 'agent-starting') && (
-              <>Refreshing didn’t fix this screen. Möbius can send the error to a new repair chat for your agent to investigate.</>
+              <>Refreshing didn’t fix this screen. Möbius can start a new repair chat and share these technical details with your agent to investigate and fix it.</>
             )}
             {actions.showRecovery && attemptPhase === 'agent-directed' && repairChatId && (
               <>The repair chat started, but this screen still can’t open. System recovery is the remaining fallback.</>
             )}
             {actions.showRecovery && attemptPhase === 'agent-failed' && (
-              <>The repair chat couldn’t start. You can try the agent again or use system recovery as a last resort.</>
+              <>The repair chat couldn’t start. You can retry it or use system recovery as a last resort.</>
             )}
             {actions.showRecovery && !canAskAgent && (
               <>Refreshing didn’t fix this screen. Use system recovery to diagnose the problem without relying on this embedded chat.</>
             )}
           </p>
-          <pre className="errbound__detail">{message}</pre>
-          {this.state.agentError && (
-            <p className="errbound__status" role="status">{this.state.agentError}</p>
+          <details className="errbound__details">
+            <summary>Technical details</summary>
+            <pre className="errbound__detail">{message}</pre>
+          </details>
+          {(phase === 'agent-starting' || this.state.agentError) && (
+            <p
+              className={`errbound__status${this.state.agentError ? ' errbound__status--sr-only' : ''}`}
+              role="status"
+              aria-live="polite"
+            >
+              {phase === 'agent-starting' ? 'Starting the repair chat. This may take a moment.' : this.state.agentError}
+            </p>
           )}
-          <div className="errbound__actions">
+          <div
+            className="errbound__actions"
+            aria-busy={phase === 'agent-starting' ? true : undefined}
+          >
             {actions.showRefreshAgain && (
               <button type="button" className="errbound__btn" onClick={this.handleRefresh}>
                 Refresh again
               </button>
             )}
             {actions.showOpenRepairChat && (
-              <button type="button" className="errbound__btn" onClick={this.openRepairChat}>
+              <a className="errbound__btn" href={repairChatPath(repairChatId, BASE)}>
                 Open repair chat
-              </button>
+              </a>
             )}
             {(phase === 'refresh' || actions.showAskAgent || actions.showRetryAgent || phase === 'agent-starting') && (
               <button
@@ -286,9 +306,9 @@ export default class ErrorBoundary extends Component {
                 disabled={phase === 'agent-starting'}
               >
                 {phase === 'refresh' && 'Refresh screen'}
-                {phase === 'agent' && (attemptPhase === 'agent-starting' ? 'Resume agent repair' : 'Ask agent to fix')}
+                {phase === 'agent' && (attemptPhase === 'agent-starting' ? 'Resume repair chat' : 'Start repair chat')}
                 {phase === 'agent-starting' && 'Starting repair chat…'}
-                {actions.showRetryAgent && 'Try agent again'}
+                {actions.showRetryAgent && 'Retry repair chat'}
               </button>
             )}
           </div>

--- a/frontend/src/components/ErrorBoundary/RecoveryLink.jsx
+++ b/frontend/src/components/ErrorBoundary/RecoveryLink.jsx
@@ -7,7 +7,7 @@ export default function RecoveryLink({
 }) {
   return (
     <p className={className}>
-      {lead} <a href={RECOVERY_PATH} target="_top">open recovery</a>.
+      {lead} <a href={RECOVERY_PATH} target="_top">open the isolated recovery workspace</a>.
     </p>
   )
 }

--- a/frontend/src/components/StandaloneApp/StandaloneApp.css
+++ b/frontend/src/components/StandaloneApp/StandaloneApp.css
@@ -58,11 +58,36 @@
   font: 600 12px/1 var(--font, system-ui, sans-serif);
 }
 
-.standalone-app__crash,
+.standalone-app__crash-layer {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  overflow: auto;
+  padding:
+    max(24px, env(safe-area-inset-top))
+    max(16px, env(safe-area-inset-right))
+    max(24px, env(safe-area-inset-bottom))
+    max(16px, env(safe-area-inset-left));
+  background: var(--bg, #0d0d0d);
+}
+
+.standalone-app__crash {
+  width: min(520px, 100%);
+  margin: auto;
+  padding: 22px;
+  border: 1px solid var(--border, #333);
+  border-radius: 18px;
+  background: var(--surface, #171717);
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.5);
+  font-family: var(--font, system-ui, sans-serif);
+}
+
 .standalone-app--message > section {
   position: fixed;
   inset: 50% auto auto 50%;
-  z-index: 40;
   transform: translate(-50%, -50%);
   width: min(520px, calc(100vw - 32px));
   padding: 22px;
@@ -73,7 +98,13 @@
   font-family: var(--font, system-ui, sans-serif);
 }
 
-.standalone-app__crash h1,
+.standalone-app__crash h1 {
+  margin: 0;
+  color: var(--text, #fff);
+  font-size: 20px;
+  line-height: 1.3;
+}
+
 .standalone-app--message h1,
 .standalone-install h1 {
   margin: 0;
@@ -82,14 +113,36 @@
   line-height: 1.3;
 }
 
-.standalone-app__crash pre {
-  max-height: 180px;
+.standalone-app__crash h1:focus {
+  outline: none;
+}
+
+.standalone-app__details {
   margin: 14px 0;
+  color: var(--muted, #aaa);
+  font-size: 13px;
+}
+
+.standalone-app__details summary {
+  width: max-content;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.standalone-app__details summary:focus-visible {
+  outline: 2px solid var(--accent, #a78bfa);
+  outline-offset: 3px;
+}
+
+.standalone-app__details pre {
+  max-height: 180px;
+  margin: 10px 0 0;
   padding: 12px;
   overflow: auto;
   border-radius: 10px;
   background: color-mix(in srgb, var(--bg, #000) 82%, transparent);
-  color: var(--danger, #f87171);
+  color: color-mix(in srgb, var(--danger, #f87171) 78%, var(--text, #ececec));
   font: 12px/1.5 ui-monospace, monospace;
   white-space: pre-wrap;
   user-select: text;
@@ -103,21 +156,38 @@
 }
 
 .standalone-app__crash .standalone-app__crash-status {
-  margin: -6px 0 14px;
-  color: var(--danger, #f87171);
+  margin: 0 0 14px;
+  color: color-mix(in srgb, var(--danger, #f87171) 78%, var(--text, #ececec));
 }
 
-.standalone-app__crash > div,
+.standalone-app__crash-status--sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.standalone-app__crash-actions,
 .standalone-install__actions {
   display: flex;
+  flex-wrap: wrap;
   justify-content: flex-end;
   gap: 10px;
 }
 
 .standalone-app__crash button,
+.standalone-app__crash-actions a,
 .standalone-install button,
 .standalone-app--message a {
-  min-height: 42px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
   padding: 0 15px;
   border: 1px solid var(--border, #333);
   border-radius: 11px;
@@ -134,9 +204,29 @@
 }
 
 .standalone-app__crash button:focus-visible,
+.standalone-app__crash-actions a:focus-visible,
 .standalone-app__recovery a:focus-visible {
   outline: 2px solid var(--accent, #a78bfa);
   outline-offset: 3px;
+}
+
+.standalone-app__crash .standalone-app__crash-primary {
+  border-color: color-mix(in srgb, var(--accent, #8b6cf7) 82%, #000);
+  background: color-mix(in srgb, var(--accent, #8b6cf7) 82%, #000);
+  color: var(--accent-fg, #fff);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .standalone-app__crash button:hover,
+  .standalone-app__crash-actions a:hover {
+    border-color: color-mix(in srgb, var(--text, #ececec) 42%, transparent);
+    background: color-mix(in srgb, var(--text, #ececec) 8%, transparent);
+  }
+
+  .standalone-app__crash .standalone-app__crash-primary:hover {
+    border-color: color-mix(in srgb, var(--accent, #8b6cf7) 74%, #000);
+    background: color-mix(in srgb, var(--accent, #8b6cf7) 74%, #000);
+  }
 }
 
 .standalone-app__recovery {
@@ -265,4 +355,15 @@
 
 @media (prefers-reduced-motion: reduce) {
   .standalone-app__mobius-link { transition: none; }
+}
+
+@media (max-width: 30rem) {
+  .standalone-app__crash-actions {
+    flex-direction: column;
+  }
+
+  .standalone-app__crash button,
+  .standalone-app__crash-actions a {
+    width: 100%;
+  }
 }

--- a/frontend/src/components/StandaloneApp/StandaloneApp.jsx
+++ b/frontend/src/components/StandaloneApp/StandaloneApp.jsx
@@ -43,6 +43,7 @@ function shellUrl(params = {}) {
 export default function StandaloneApp({ initialApp }) {
   const queryClient = useQueryClient()
   const canvasRef = useRef(null)
+  const crashHeadingRef = useRef(null)
   const visualContentOnly = isVisualContentOnly()
   const [app, setApp] = useState(initialApp)
   const [updateAvailable, setUpdateAvailable] = useState(false)
@@ -98,12 +99,16 @@ export default function StandaloneApp({ initialApp }) {
       repairRequestId: attempt?.repairRequestId || null,
       messageCid: attempt?.messageCid || null,
       agentError: attempt?.phase === 'agent-failed'
-        ? 'Möbius couldn’t start the repair chat.'
+        ? 'Repair chat request failed.'
         : '',
     })
   }, [recoverySurfaceKey])
 
   useEffect(() => () => repairControllerRef.current?.abort(), [])
+
+  useEffect(() => {
+    if (crashFingerprint) crashHeadingRef.current?.focus()
+  }, [crashFingerprint])
 
   useEffect(() => {
     if (!crashFingerprint) return undefined
@@ -123,7 +128,7 @@ export default function StandaloneApp({ initialApp }) {
         repairRequestId: attempt?.repairRequestId || null,
         messageCid: attempt?.messageCid || null,
         agentError: attempt?.phase === 'agent-failed'
-          ? 'Möbius couldn’t start the repair chat.'
+          ? 'Repair chat request failed.'
           : '',
       } : current)
     }
@@ -313,7 +318,7 @@ export default function StandaloneApp({ initialApp }) {
         phase: 'recovery',
         attemptPhase: 'agent-failed',
         repairChatId: createdChatId,
-        agentError: 'Möbius couldn’t start the repair chat.',
+        agentError: 'Repair chat request failed.',
       } : current)
     })
   }, [app.id, app.name, crash, recoverySurfaceKey])
@@ -323,12 +328,6 @@ export default function StandaloneApp({ initialApp }) {
     attemptPhase: crash.attemptPhase,
     repairChatId: crash.repairChatId,
   }) : null
-
-  const openRepairChat = useCallback(() => {
-    if (crash?.repairChatId) {
-      window.location.href = repairChatPath(crash.repairChatId, BASE)
-    }
-  }, [crash?.repairChatId])
 
   if (removed) {
     return (
@@ -343,7 +342,7 @@ export default function StandaloneApp({ initialApp }) {
   }
 
   return (
-    <main className={`standalone-app${immersive ? ' standalone-app--immersive' : ''}`}>
+    <main className={`standalone-app${immersive ? ' standalone-app--immersive' : ''}${crash ? ' standalone-app--crashed' : ''}`}>
       <AppCanvas
         ref={canvasRef}
         appId={app.id}
@@ -354,7 +353,7 @@ export default function StandaloneApp({ initialApp }) {
         capabilityContract={app.capability_contract || null}
         active
         visible
-        interactive
+        interactive={!crash}
         immersive={immersive}
         onImmersive={(_id, value) => setImmersive(value)}
         onNavPush={onNavPush}
@@ -363,16 +362,18 @@ export default function StandaloneApp({ initialApp }) {
         onAppError={captureCrash}
       />
 
-      <a
-        className="standalone-app__mobius-link"
-        href={shellUrl({ app: app.id })}
-        aria-label={`Open ${app.name} in Möbius`}
-      >
-        <span aria-hidden="true">∞</span>
-        <span>Open in Möbius</span>
-      </a>
+      {!crash && (
+        <a
+          className="standalone-app__mobius-link"
+          href={shellUrl({ app: app.id })}
+          aria-label={`Open ${app.name} in Möbius`}
+        >
+          <span aria-hidden="true">∞</span>
+          <span>Open in Möbius</span>
+        </a>
+      )}
 
-      {updateAvailable && (
+      {updateAvailable && !crash && (
         <button
           className="standalone-app__update"
           type="button"
@@ -384,48 +385,69 @@ export default function StandaloneApp({ initialApp }) {
       )}
 
       {crash && (
-        <section className="standalone-app__crash" role="alert">
-          <h1>{app.name} stopped unexpectedly</h1>
-          <p>
-            {crash.phase === 'refresh' && 'Refresh the app first. Your chats and data are safe.'}
-            {(crash.phase === 'agent' || crash.phase === 'agent-starting') && 'Refreshing didn’t fix it. Möbius can send this error to a new repair chat for your agent to investigate.'}
-            {crash.phase === 'recovery' && crash.attemptPhase === 'agent-directed' && 'The repair chat started, but the app still can’t open. System recovery is the remaining fallback.'}
-            {crash.phase === 'recovery' && crash.attemptPhase === 'agent-failed' && 'The repair chat couldn’t start. Try the agent again or use system recovery as a last resort.'}
-          </p>
-          <pre>{readableAppDiagnostic(crash.error)}</pre>
-          {crash.agentError && (
-            <p className="standalone-app__crash-status" role="status">{crash.agentError}</p>
-          )}
-          <div>
-            {crashActions.showRefreshAgain && (
-              <button type="button" onClick={refreshCrash}>Refresh again</button>
-            )}
-            {crashActions.showOpenRepairChat && (
-              <button type="button" onClick={openRepairChat}>Open repair chat</button>
-            )}
-            {(crash.phase === 'refresh' || crashActions.showAskAgent || crashActions.showRetryAgent || crash.phase === 'agent-starting') && (
-              <button
-                type="button"
-                onClick={crash.phase === 'refresh' ? refreshCrash : reportCrash}
-                disabled={crash.phase === 'agent-starting'}
+        <div className="standalone-app__crash-layer">
+          <section
+            className="standalone-app__crash"
+            aria-labelledby="standalone-crash-title"
+          >
+            <h1 id="standalone-crash-title" ref={crashHeadingRef} tabIndex={-1}>
+              {app.name} stopped unexpectedly
+            </h1>
+            <p>
+              {crash.phase === 'refresh' && 'This app hit an unexpected error. Refreshing won’t delete your chats.'}
+              {(crash.phase === 'agent' || crash.phase === 'agent-starting') && 'Refreshing didn’t fix the app. Möbius can start a new repair chat and share these technical details with your agent to investigate and fix it.'}
+              {crash.phase === 'recovery' && crash.attemptPhase === 'agent-directed' && 'The repair chat started, but the app still can’t open. System recovery is the remaining fallback.'}
+              {crash.phase === 'recovery' && crash.attemptPhase === 'agent-failed' && 'The repair chat couldn’t start. You can retry it or use system recovery as a last resort.'}
+            </p>
+            <details className="standalone-app__details">
+              <summary>Technical details</summary>
+              <pre>{readableAppDiagnostic(crash.error)}</pre>
+            </details>
+            {(crash.phase === 'agent-starting' || crash.agentError) && (
+              <p
+                className={`standalone-app__crash-status${crash.agentError ? ' standalone-app__crash-status--sr-only' : ''}`}
+                role="status"
+                aria-live="polite"
               >
-                {crash.phase === 'refresh' && 'Refresh app'}
-                {crash.phase === 'agent' && (crash.attemptPhase === 'agent-starting' ? 'Resume agent repair' : 'Ask agent to fix')}
-                {crash.phase === 'agent-starting' && 'Starting repair chat…'}
-                {crash.phase === 'recovery' && 'Try agent again'}
-              </button>
+                {crash.phase === 'agent-starting' ? 'Starting the repair chat. This may take a moment.' : crash.agentError}
+              </p>
             )}
-          </div>
-          {crashActions.showRecovery && (
-            <RecoveryLink
-              className="standalone-app__recovery"
-              lead="If the repair chat can’t get you back in,"
-            />
-          )}
-        </section>
+            <div
+              className="standalone-app__crash-actions"
+              aria-busy={crash.phase === 'agent-starting' ? true : undefined}
+            >
+              <a href={shellUrl({ app: app.id })}>Open in Möbius</a>
+              {crashActions.showRefreshAgain && (
+                <button type="button" onClick={refreshCrash}>Refresh again</button>
+              )}
+              {crashActions.showOpenRepairChat && (
+                <a href={repairChatPath(crash.repairChatId, BASE)}>Open repair chat</a>
+              )}
+              {(crash.phase === 'refresh' || crashActions.showAskAgent || crashActions.showRetryAgent || crash.phase === 'agent-starting') && (
+                <button
+                  type="button"
+                  className="standalone-app__crash-primary"
+                  onClick={crash.phase === 'refresh' ? refreshCrash : reportCrash}
+                  disabled={crash.phase === 'agent-starting'}
+                >
+                  {crash.phase === 'refresh' && 'Refresh app'}
+                  {crash.phase === 'agent' && (crash.attemptPhase === 'agent-starting' ? 'Resume repair chat' : 'Start repair chat')}
+                  {crash.phase === 'agent-starting' && 'Starting repair chat…'}
+                  {crash.phase === 'recovery' && 'Retry repair chat'}
+                </button>
+              )}
+            </div>
+            {crashActions.showRecovery && (
+              <RecoveryLink
+                className="standalone-app__recovery"
+                lead="If the repair chat can’t get you back in,"
+              />
+            )}
+          </section>
+        </div>
       )}
 
-      {!visualContentOnly && (
+      {!crash && !visualContentOnly && (
         <StandaloneInstallCard
           app={app}
           forceOpen={installOpen}

--- a/frontend/src/lib/__tests__/recoveryLink.test.js
+++ b/frontend/src/lib/__tests__/recoveryLink.test.js
@@ -20,5 +20,5 @@ test('recovery stays a plain last-resort link with adaptable context', () => {
   }))
   assert.match(standaloneHtml, /class="standalone-app__recovery"/)
   assert.match(standaloneHtml, /If the app still won’t open/)
-  assert.match(standaloneHtml, />open recovery<\/a>/)
+  assert.match(standaloneHtml, />open the isolated recovery workspace<\/a>/)
 })


### PR DESCRIPTION
## Summary

- move focus into the recovery surface after a crash and use a dedicated polite status for repair progress
- collapse raw diagnostics behind a native `details` disclosure and redact the generic boundary’s displayed message
- make repair-chat navigation native links, clarify the authority/data-sharing copy, and describe recovery as an isolated workspace
- isolate a failed standalone app by disabling canvas interactivity and suppressing competing install/update controls
- make both recovery surfaces safe-area-aware, vertically scrollable at short/zoomed viewports, and free of horizontal clipping
- raise action targets to 44px, restore contrast-increasing hover states, and use AA-compliant recovery action/error colors

Depends on #474. GitHub will show the stacked correctness commits in this PR until #474 lands; the UI-specific delta is one commit on top.

## Verification

- `npm test` — 2,241 library tests and 76 hook tests passed
- `npm run build` — production, service-worker, and offline builds passed
- focused ESLint passed with zero warnings/errors
- browser-checked the real generic boundary and a faithful standalone recovery surface at 1280×720, 390×844, 320×320, and 320×280
  - recovery heading receives focus
  - technical details expand/collapse
  - all recovery actions measure at least 44px high
  - short surfaces scroll to every action
  - no horizontal viewport overflow

## Review notes

- The existing shell-wide viewport zoom policy is intentionally unchanged; it predates this work and is covered by workspace geometry tests. The recovery surfaces now remain reachable under short/zoom-equivalent layouts independently of that policy.
