### PR TITLE
fix: boot persisted pre-PyJWT platforms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -217,11 +217,19 @@ COPY frontend/ ./shell-src/
 COPY scripts/test-image-fingerprint.sh /tmp/test-image-inputs/scripts/test-image-fingerprint.sh
 COPY Dockerfile /tmp/test-image-inputs/Dockerfile
 COPY backend/requirements.txt backend/requirements.lock /tmp/test-image-inputs/backend/
+COPY backend/legacy_runtime/ /tmp/test-image-inputs/backend/legacy_runtime/
 COPY frontend/package.json frontend/package-lock.json /tmp/test-image-inputs/frontend/
 RUN MOBIUS_TEST_IMAGE_INPUT_ROOT=/tmp/test-image-inputs \
       /tmp/test-image-inputs/scripts/test-image-fingerprint.sh \
       > /app/test-image-fingerprint \
     && rm -rf /tmp/test-image-inputs
+
+# /data/platform survives image replacement and can predate the PyJWT migration.
+# Install the narrow historical import surface on the standard interpreter path;
+# entrypoint intentionally clears PYTHONPATH before starting the platform.
+COPY backend/legacy_runtime/jose/ /usr/local/lib/python3.12/site-packages/jose/
+COPY backend/legacy_runtime/verify_jose.py /tmp/verify-legacy-jose.py
+RUN python /tmp/verify-legacy-jose.py && rm /tmp/verify-legacy-jose.py
 
 # Whole-repo platform seed. /data is a runtime volume, so bake the real clone
 # under /app and let entrypoint copy it into /data/platform on first boot. The

--- a/backend/legacy_runtime/jose/__init__.py
+++ b/backend/legacy_runtime/jose/__init__.py
@@ -1,0 +1,16 @@
+"""PyJWT-backed compatibility for persistent pre-migration checkouts.
+
+Some Railway volumes retain a platform checkout whose auth module imports
+``JWTError`` and ``jwt`` from python-jose. The current image uses PyJWT, whose
+HS256 API is compatible with that historical call site. Keep this facade
+limited to the two names that checkout imports instead of restoring the
+broader, vulnerable dependency tree.
+"""
+
+import jwt
+from jwt.exceptions import InvalidTokenError
+
+
+JWTError = InvalidTokenError
+
+__all__ = ["JWTError", "jwt"]

--- a/backend/legacy_runtime/verify_jose.py
+++ b/backend/legacy_runtime/verify_jose.py
@@ -1,0 +1,19 @@
+"""Build-time smoke test for the persistent-checkout jose facade."""
+
+from jose import JWTError, jwt
+
+
+key = "s" * 32
+token = jwt.encode(
+  {"scope": "mobius_sso_state"}, key, algorithm="HS256"
+)
+assert jwt.decode(token, key, algorithms=["HS256"])["scope"] == (
+  "mobius_sso_state"
+)
+
+try:
+  jwt.decode(token, "x" * 32, algorithms=["HS256"])
+except JWTError:
+  pass
+else:
+  raise AssertionError("JWTError did not catch an invalid signature")

--- a/backend/tests/test_verify_test_runtime.py
+++ b/backend/tests/test_verify_test_runtime.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 import shutil
 import subprocess
+import sys
 
 from scripts.verify_test_runtime import PLATFORM_ROOT, platform_head, validate_runtime
 
@@ -177,6 +178,53 @@ def test_image_deduplicates_agent_cli_payloads_without_breaking_sdk_contracts():
   assert "bundled_codex_path().samefile" in codex_layer
   assert "pip check" in codex_layer
   assert "declared cli-bin package is retained for SDK compatibility" in requirements
+
+
+def test_production_image_keeps_persistent_sso_checkouts_bootable():
+  dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+  fingerprint = (
+    ROOT / "scripts" / "test-image-fingerprint.sh"
+  ).read_text(encoding="utf-8")
+  requirements = (ROOT / "backend" / "requirements.txt").read_text(
+    encoding="utf-8"
+  )
+  requirements_lock = (ROOT / "backend" / "requirements.lock").read_text(
+    encoding="utf-8"
+  )
+  shim_root = ROOT / "backend" / "legacy_runtime"
+  probe_path = shim_root / "verify_jose.py"
+  probe = probe_path.read_text(encoding="utf-8")
+  subprocess.run(
+    [sys.executable, "-B", str(probe_path)],
+    check=True,
+    capture_output=True,
+    text=True,
+    env={**os.environ, "PYTHONPATH": str(shim_root)},
+  )
+
+  for unsafe_dependency in ("python-jose", "ecdsa"):
+    assert unsafe_dependency not in requirements.lower()
+    assert unsafe_dependency not in requirements_lock.lower()
+  assert (
+    "COPY backend/legacy_runtime/jose/ "
+    "/usr/local/lib/python3.12/site-packages/jose/"
+  ) in dockerfile
+  assert dockerfile.index("> /app/test-image-fingerprint") < dockerfile.index(
+    "COPY backend/legacy_runtime/jose/ "
+    "/usr/local/lib/python3.12/site-packages/jose/"
+  )
+  assert "from jose import JWTError, jwt" in probe
+  assert "jwt.encode" in probe
+  assert "jwt.decode" in probe
+  assert "except JWTError:" in probe
+  assert "backend/legacy_runtime/jose/__init__.py" in fingerprint
+  assert "backend/legacy_runtime/verify_jose.py" in fingerprint
+  assert "COPY backend/legacy_runtime/verify_jose.py" in dockerfile
+  assert (
+    "COPY backend/legacy_runtime/ "
+    "/tmp/test-image-inputs/backend/legacy_runtime/"
+  ) in dockerfile
+  assert "python /tmp/verify-legacy-jose.py" in dockerfile
 
 
 def test_pre_push_syntax_check_keeps_bytecode_out_of_checkout():

--- a/scripts/test-image-fingerprint.sh
+++ b/scripts/test-image-fingerprint.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 ROOT="${MOBIUS_TEST_IMAGE_INPUT_ROOT:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)}"
 files=(
   Dockerfile
+  backend/legacy_runtime/jose/__init__.py
+  backend/legacy_runtime/verify_jose.py
   backend/requirements.txt
   backend/requirements.lock
   frontend/package.json


### PR DESCRIPTION
## Summary

- keep pre-PyJWT platform checkouts on persistent Railway volumes bootable during image replacement
- provide only the historical `from jose import JWTError, jwt` surface, backed by the already-locked PyJWT runtime
- validate HS256 encode/decode and invalid-signature handling in the production image build
- include the compatibility source in the test-image fingerprint
- explicitly keep `python-jose` and its unfixed vulnerable `ecdsa` dependency out of the manifests and lock

## Production evidence

An existing Railway volume failed before reconcile with `ModuleNotFoundError: No module named jose` from its persisted `/data/platform/backend/app/auth.py`. Current source already uses PyJWT; the narrow bridge allows the old checkout to boot and reconcile without modifying user data.

## Validation

- runtime verification: 27 passed
- managed SSO tests: 4 passed
- Ruff passed
- standard-path container shim probe passed with PYTHONPATH scrubbed
- Dockerfile check, fingerprint, and `git diff --check` passed