### PR TITLE
Add isolated recovery target and opt-in agent sudo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,6 @@ SECRET_KEY=
 # local-services.json. Every enabled service uses /services/<slug> below this
 # one origin, so later services need no additional DNS record.
 # MOBIUS_SERVICE_GATEWAY_ORIGIN=https://services.mobius.example.com
+# Optional full-root capability for the in-product agent. Keep disabled until
+# the owner has explicitly confirmed; changing it requires recreating the app.
+MOBIUS_AGENT_SUDO=0

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ venv/
 
 # Environment — never commit secrets
 .env
+.mobius-recovery.env
 
 # Node
 node_modules/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -183,9 +183,13 @@ FastAPI app. `main.py` is the factory (CORS, rate limiting, routers, static serv
 | `theme.py` | Theme CSS management and HTML injection |
 | `push.py` | VAPID key management and Web Push delivery |
 
-### Recovery (the frozen island)
+### Recovery boundaries during external cutover
 
-Recovery is a SEPARATE always-up container, `recoveryd`, not a module inside `backend/app/`. Its code is a distinct package, `backend/recovery/` (baked root-owned to `/app/recovery/`, outside `backend/app/`), deliberately isolated from the SDK/chat stack — stdlib `http.server`, zero `app.*` imports — so a broken platform install cannot take recovery down. The only recovery-adjacent module left in `backend/app/` is `recovery_seed.py` (it mirrors the owner row into a DB-independent seed for a wiped-DB login; see the self-heal section).
+The legacy `recoveryd` container remains available only during the staged
+external-recovery cutover. Its code is a distinct package,
+`backend/recovery/` (baked root-owned to `/app/recovery/`, outside
+`backend/app/`) and deliberately isolated from the SDK/chat stack. The only
+recovery-adjacent module in `backend/app/` is `recovery_seed.py`.
 
 | File | Role |
 |------|------|
@@ -194,6 +198,25 @@ Recovery is a SEPARATE always-up container, `recoveryd`, not a module inside `ba
 | `recovery_chat_pages.py` | HTML + page surface for the recovery chat |
 | `recovery_chat_runner.py` | Minimal CLI runner for the recovery chat; shares no code with `chat`/`providers`/SDK (runs the standalone `claude` binary as its own subprocess) and appends to its own per-chat jsonl under `/data`, never the `Chat.messages` column |
 | `recovery_restore.sh` | Baked git-reset restore tool (`backend/scripts/recovery_restore.sh` → `/app/scripts/`) — what the "Restore platform" button drives |
+
+The replacement boundary is `backend/recovery_target/targetd.py`. In
+`MOBIUS_BOOT_MODE=recovery`, the baked entrypoint starts this stdlib daemon as
+root before initializing or importing anything from `/data`. It listens only
+on the private target port, authenticates every request with a high-entropy
+one-time bearer, and exposes bounded execution and filesystem operations to a
+separate non-root recovery worker. Normal mode never starts the listener.
+
+The entrypoint removes the target bearer from the exec environment and passes
+it once through an unlinked descriptor; targetd must be container PID 1,
+consumes and closes that descriptor, marks itself non-dumpable, and removes
+packet-capture, ptrace, and mount capabilities from every capability set
+(including bounding) before listening. The raw bearer is immediately wiped;
+only a domain-separated SHA-256 verifier remains at rest. Convenience file
+operations are kernel-confined with `openat2` to `/data`, `/app`, and `/tmp`
+(writes omit `/app`) without symlink, magic-link, `..`, or nested-mount
+escapes. Thus a root repair child can neither inspect target memory or file
+descriptors nor enlist target PID1 to read its own `/proc` memory. Target health
+reports the immutable image-baked Git revision, never a runtime identity env.
 
 `recovery_auth.py` (HMAC-cookie auth) and `recovery_db.py` (raw-`sqlite3` owner-row read, no ORM, with a DB-independent `/data/.recovery-owner.json` fallback for a wiped DB) round out the package. See the self-heal section below for the container itself.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -293,7 +293,10 @@ COPY protected-files.txt ./protected-files.txt
 # Frozen recovery floor (recoveryd) — the Tier-1 recovery system that runs in
 # its own container. It imports no app.* code and remains root-owned/read-only.
 COPY backend/recovery ./recovery/
-RUN chmod -R a-w /app/recovery /app/recovery-target
+# Stamp target identity from the actual baked checkout, never a runtime-
+# overridable environment value.
+RUN cp /app/platform-baked/.baked-sha /app/recovery-target/BUILD_REVISION \
+    && chmod -R a-w /app/recovery /app/recovery-target
 RUN chmod +x ./scripts/entrypoint.sh
 
 # Build identity — passed at `docker compose build` time (deploy-prod.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -282,28 +282,18 @@ RUN useradd -m -s /bin/bash mobius \
     && ln -s /opt/agent-browser /home/mobius/.agent-browser \
     && chown -R mobius:mobius /opt/agent-browser
 
-# apt scoped-sudo (owner spec): mobius (the in-product agent) may install/remove
-# OS packages but NOT have full root, so it can't break the recovery floor or
-# core system files. Scoped to apt/dpkg only; validated by visudo. NOT a hard
-# sandbox (apt maintainer scripts run as root) — the real safety is that the
-# recovery runtime depends on ZERO apt-installed packages, so a bad package can
-# never compromise it.
-RUN printf 'mobius ALL=(root) NOPASSWD: /usr/bin/apt-get, /usr/bin/apt, /usr/bin/dpkg\n' \
-      > /etc/sudoers.d/mobius-apt \
-    && chmod 440 /etc/sudoers.d/mobius-apt \
-    && visudo -cf /etc/sudoers.d/mobius-apt
-
 # Runtime source belongs at the tail of the image so normal code changes reuse
 # the browser, CLI, Python, vendor, and platform-seed layers above.
 COPY backend/app ./app/
 COPY backend/scripts ./scripts/
+COPY backend/recovery_target ./recovery-target/
 COPY skill/ ./skill/
 COPY protected-files.txt ./protected-files.txt
 
 # Frozen recovery floor (recoveryd) — the Tier-1 recovery system that runs in
 # its own container. It imports no app.* code and remains root-owned/read-only.
 COPY backend/recovery ./recovery/
-RUN chmod -R a-w /app/recovery
+RUN chmod -R a-w /app/recovery /app/recovery-target
 RUN chmod +x ./scripts/entrypoint.sh
 
 # Build identity — passed at `docker compose build` time (deploy-prod.sh

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -79,6 +79,18 @@ editable platform is broken. This is appropriate because:
 3. Recovery is isolated from the editable production process and provides the
    rollback boundary.
 
+Full agent root is an explicit instance capability, disabled by default.
+`MOBIUS_AGENT_SUDO=1` is accepted only by the root-owned baked entrypoint and
+creates an unrestricted sudo rule after owner confirmation; reverting it
+requires recreating the container. The recovery worker never shares that
+container: it is non-root/read-only and reaches a separate root target through
+a one-time authenticated, bounded protocol. The target removes the bearer from
+its exec environment, wipes it after deriving a one-way verifier, blocks child
+access to its memory and descriptors, drops packet-capture/ptrace/mount
+capabilities, and confines its own file helpers to explicit roots with Linux
+`openat2`. Repair commands retain root over the stopped `/data` instance but
+cannot inspect target PID1 or modify the recovery worker itself.
+
 ## Opaque embedded-chat contract
 
 `window.mobius.chat` creates three documents. The outer sandbox restriction

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -91,6 +91,13 @@ capabilities, and confines its own file helpers to explicit roots with Linux
 `openat2`. Repair commands retain root over the stopped `/data` instance but
 cannot inspect target PID1 or modify the recovery worker itself.
 
+Self-hosted recovery containers never restart automatically. A worker restart
+would reconstruct its tmpfs-backed one-time-code state from unchanged
+environment credentials, while a target restart would retain the same bearer.
+If either exits, use `scripts/mobiusctl recovery reopen`; it removes both
+containers, rotates both credentials, pulls the latest worker, and recreates a
+clean pair while keeping the ordinary app stopped.
+
 ## Opaque embedded-chat contract
 
 `window.mobius.chat` creates three documents. The outer sandbox restriction

--- a/backend/recovery_target/targetd.py
+++ b/backend/recovery_target/targetd.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import base64
 import binascii
+import ctypes
 import errno
 import hmac
 import json
@@ -31,6 +32,15 @@ from typing import Any
 
 PROTOCOL = "mobius-recovery-target/v1"
 DEFAULT_PORT = 18002
+BUILD_REVISION_PATH = Path("/app/recovery-target/BUILD_REVISION")
+CAP_NET_ADMIN = 12
+CAP_NET_RAW = 13
+_CAPABILITY_VERSION_3 = 0x20080522
+_PR_CAPBSET_READ = 23
+_PR_CAPBSET_DROP = 24
+_PR_CAP_AMBIENT = 47
+_PR_CAP_AMBIENT_IS_SET = 1
+_PR_CAP_AMBIENT_CLEAR_ALL = 4
 # An 8 MiB decoded payload expands to about 10.67 MiB as base64 before the JSON
 # envelope is counted. Keep the wire budget large enough for the advertised
 # file/stdin boundary while still rejecting unbounded request bodies.
@@ -45,6 +55,23 @@ MAX_ENV_ITEMS = 128
 MAX_ENV_BYTES = 256 * 1024
 MAX_CONCURRENT_EXEC = 2
 _EXEC_SLOTS = threading.BoundedSemaphore(MAX_CONCURRENT_EXEC)
+_STARTUP_TOKEN: bytes | None = None
+_BUILD_REVISION = "unknown"
+
+
+class _CapabilityHeader(ctypes.Structure):
+  _fields_ = [
+    ("version", ctypes.c_uint32),
+    ("pid", ctypes.c_int),
+  ]
+
+
+class _CapabilityData(ctypes.Structure):
+  _fields_ = [
+    ("effective", ctypes.c_uint32),
+    ("permitted", ctypes.c_uint32),
+    ("inheritable", ctypes.c_uint32),
+  ]
 
 
 class RequestError(Exception):
@@ -60,13 +87,185 @@ class RequestError(Exception):
     self.status = status
 
 
-def _token() -> str:
-  value = os.environ.get("MOBIUS_RECOVERY_TARGET_TOKEN", "")
-  if len(value) < 32 or len(value.encode("utf-8")) > 512:
+def _validate_token(value: bytes) -> bytes:
+  if len(value) < 32 or len(value) > 512:
     raise RuntimeError(
       "MOBIUS_RECOVERY_TARGET_TOKEN must contain 32-512 UTF-8 bytes"
     )
+  try:
+    value.decode("utf-8")
+  except UnicodeDecodeError as exc:
+    raise RuntimeError(
+      "MOBIUS_RECOVERY_TARGET_TOKEN must contain 32-512 UTF-8 bytes"
+    ) from exc
+  if b"\x00" in value or b"\r" in value or b"\n" in value:
+    raise RuntimeError(
+      "MOBIUS_RECOVERY_TARGET_TOKEN must not contain NUL or newlines"
+    )
   return value
+
+
+def _capability_state(
+  libc: ctypes.CDLL,
+) -> tuple[_CapabilityHeader, Any]:
+  header = _CapabilityHeader(version=_CAPABILITY_VERSION_3, pid=0)
+  data = (_CapabilityData * 2)()
+  if libc.capget(ctypes.byref(header), ctypes.byref(data)) != 0:
+    error = ctypes.get_errno()
+    raise RuntimeError(f"could not inspect process capabilities: errno {error}")
+  return header, data
+
+
+def _drop_packet_capture_capabilities() -> None:
+  """Permanently deny packet capture/manipulation to target exec children."""
+  libc = ctypes.CDLL(None, use_errno=True)
+  capget = getattr(libc, "capget", None)
+  capset = getattr(libc, "capset", None)
+  prctl = getattr(libc, "prctl", None)
+  if capget is None or capset is None or prctl is None:
+    raise RuntimeError("recovery target requires Linux capability controls")
+
+  # A root repair command otherwise inherits Docker's CAP_NET_RAW and can use
+  # AF_PACKET to capture a later worker Authorization header on the private
+  # plain-HTTP interface. Remove both packet capabilities from every mutable
+  # set and the bounding set before the server starts listening.
+  header, data = _capability_state(libc)
+  for capability in (CAP_NET_ADMIN, CAP_NET_RAW):
+    word = capability // 32
+    mask = 1 << (capability % 32)
+    data[word].effective &= ~mask
+    data[word].permitted &= ~mask
+    data[word].inheritable &= ~mask
+
+    bounded = prctl(_PR_CAPBSET_READ, capability, 0, 0, 0)
+    if bounded < 0:
+      error = ctypes.get_errno()
+      raise RuntimeError(
+        f"could not inspect capability bounding set: errno {error}"
+      )
+    if bounded and prctl(_PR_CAPBSET_DROP, capability, 0, 0, 0) != 0:
+      error = ctypes.get_errno()
+      raise RuntimeError(
+        f"could not drop capability {capability} from bounding set: errno {error}"
+      )
+
+  if capset(ctypes.byref(header), ctypes.byref(data)) != 0:
+    error = ctypes.get_errno()
+    raise RuntimeError(f"could not restrict process capabilities: errno {error}")
+  if prctl(_PR_CAP_AMBIENT, _PR_CAP_AMBIENT_CLEAR_ALL, 0, 0, 0) != 0:
+    error = ctypes.get_errno()
+    raise RuntimeError(f"could not clear ambient capabilities: errno {error}")
+
+  # Fail closed if the kernel ignored any operation. The bounding-set check is
+  # essential because uid 0 regains capabilities from that set across exec.
+  _, restricted = _capability_state(libc)
+  for capability in (CAP_NET_ADMIN, CAP_NET_RAW):
+    word = capability // 32
+    mask = 1 << (capability % 32)
+    if (
+      restricted[word].effective & mask
+      or restricted[word].permitted & mask
+      or restricted[word].inheritable & mask
+    ):
+      raise RuntimeError(f"capability {capability} remains in process sets")
+    if prctl(_PR_CAPBSET_READ, capability, 0, 0, 0) != 0:
+      raise RuntimeError(f"capability {capability} remains in bounding set")
+    if prctl(
+      _PR_CAP_AMBIENT, _PR_CAP_AMBIENT_IS_SET, capability, 0, 0
+    ) != 0:
+      raise RuntimeError(f"capability {capability} remains in ambient set")
+
+
+def _set_process_nondumpable() -> None:
+  """Blocks sibling/child ptrace and /proc memory access to the bearer."""
+  libc = ctypes.CDLL(None, use_errno=True)
+  prctl = getattr(libc, "prctl", None)
+  if prctl is None:
+    raise RuntimeError("recovery target requires Linux prctl")
+  # PR_SET_DUMPABLE = 4. Failure must stop recovery rather than expose the
+  # in-memory capability to an arbitrary root command launched by this target.
+  if prctl(4, 0, 0, 0, 0) != 0:
+    error = ctypes.get_errno()
+    raise RuntimeError(f"could not disable process dumpability: errno {error}")
+
+
+def _assert_clean_initial_environment() -> None:
+  """Proves the exec environment itself never received the bearer."""
+  if "MOBIUS_RECOVERY_TARGET_TOKEN" in os.environ:
+    raise RuntimeError(
+      "MOBIUS_RECOVERY_TARGET_TOKEN must not reach the target environment"
+    )
+  try:
+    initial_environment = Path("/proc/self/environ").read_bytes()
+  except OSError as exc:
+    raise RuntimeError("could not inspect recovery target environment") from exc
+  if b"MOBIUS_RECOVERY_TARGET_TOKEN=" in initial_environment:
+    raise RuntimeError("recovery target bearer is exposed through /proc")
+
+
+def _read_startup_token() -> bytes:
+  """Consumes the one-shot inherited descriptor; never reads a secret env."""
+  if "MOBIUS_RECOVERY_TARGET_TOKEN" in os.environ:
+    raise RuntimeError(
+      "MOBIUS_RECOVERY_TARGET_TOKEN must not reach the target environment"
+    )
+  raw_fd = os.environ.pop("MOBIUS_RECOVERY_TARGET_TOKEN_FD", "")
+  if not raw_fd.isdecimal():
+    raise RuntimeError("MOBIUS_RECOVERY_TARGET_TOKEN_FD is required")
+  fd = int(raw_fd)
+  if fd < 3:
+    raise RuntimeError("MOBIUS_RECOVERY_TARGET_TOKEN_FD is invalid")
+  value = bytearray()
+  try:
+    while len(value) <= 512:
+      chunk = os.read(fd, 513 - len(value))
+      if not chunk:
+        break
+      value.extend(chunk)
+  except OSError as exc:
+    raise RuntimeError("could not consume recovery target bearer") from exc
+  finally:
+    try:
+      os.close(fd)
+    except OSError:
+      pass
+  try:
+    return _validate_token(bytes(value))
+  finally:
+    for index in range(len(value)):
+      value[index] = 0
+
+
+def _load_baked_build_revision() -> str:
+  try:
+    value = BUILD_REVISION_PATH.read_text(encoding="ascii").strip().lower()
+  except OSError as exc:
+    raise RuntimeError("baked recovery target identity is missing") from exc
+  if len(value) != 40 or any(char not in "0123456789abcdef" for char in value):
+    raise RuntimeError("baked recovery target identity is invalid")
+  return value
+
+
+def _initialize_startup_security(*, require_pid_one: bool = True) -> None:
+  """Loads immutable identity + bearer before any request can be accepted."""
+  global _BUILD_REVISION, _STARTUP_TOKEN
+  if require_pid_one and os.getpid() != 1:
+    raise RuntimeError(
+      "recovery target must be container pid 1 so no parent retains its bearer"
+    )
+  if _STARTUP_TOKEN is not None:
+    raise RuntimeError("recovery target startup security was already initialized")
+  _assert_clean_initial_environment()
+  _drop_packet_capture_capabilities()
+  _set_process_nondumpable()
+  _STARTUP_TOKEN = _read_startup_token()
+  _BUILD_REVISION = _load_baked_build_revision()
+
+
+def _startup_token() -> bytes:
+  if _STARTUP_TOKEN is None:
+    raise RuntimeError("recovery target bearer is not initialized")
+  return _STARTUP_TOKEN
 
 
 def _absolute_path(value: Any, field: str = "path") -> Path:
@@ -467,9 +666,9 @@ class _Handler(BaseHTTPRequestHandler):
     )
 
   def _authorized(self) -> bool:
-    expected = f"Bearer {_token()}"
-    supplied = self.headers.get("Authorization", "")
-    if not hmac.compare_digest(supplied.encode(), expected.encode()):
+    expected = b"Bearer " + _startup_token()
+    supplied = self.headers.get("Authorization", "").encode("utf-8")
+    if not hmac.compare_digest(supplied, expected):
       self._send(
         HTTPStatus.UNAUTHORIZED,
         {"error": {"code": "unauthorized", "message": "invalid bearer token"}},
@@ -513,7 +712,7 @@ class _Handler(BaseHTTPRequestHandler):
       "protocol": PROTOCOL,
       "target": "mobius",
       "mode": "recovery",
-      "build_sha": os.environ.get("BUILD_SHA", "unknown"),
+      "build_sha": _BUILD_REVISION,
     })
 
   def do_POST(self) -> None:  # noqa: N802
@@ -581,8 +780,10 @@ def main() -> None:
     raise SystemExit("recovery target refuses to run outside recovery boot mode")
   if os.geteuid() != 0:
     raise SystemExit("recovery target must run as root")
-  token = _token()
-  del token
+  try:
+    _initialize_startup_security()
+  except RuntimeError as exc:
+    raise SystemExit(f"recovery target security initialization failed: {exc}") from exc
   raw_port = os.environ.get("MOBIUS_RECOVERY_TARGET_PORT", str(DEFAULT_PORT))
   try:
     port = int(raw_port)

--- a/backend/recovery_target/targetd.py
+++ b/backend/recovery_target/targetd.py
@@ -1,0 +1,555 @@
+#!/usr/bin/env python3
+"""Immutable root repair target used only by an external recovery worker.
+
+This module is deliberately stdlib-only and is launched by the baked entrypoint
+before any path below /data is imported.  It is not a recovery user interface or
+an agent runner: it is a small, bearer-authenticated capability endpoint for the
+separate recovery service.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hmac
+import json
+import os
+import selectors
+import signal
+import socket
+import stat
+import subprocess
+import tempfile
+import threading
+import time
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+
+PROTOCOL = "mobius-recovery-target/v1"
+DEFAULT_PORT = 18002
+MAX_REQUEST_BYTES = 8 * 1024 * 1024
+MAX_FILE_BYTES = 8 * 1024 * 1024
+MAX_OUTPUT_BYTES = 4 * 1024 * 1024
+MAX_LIST_ENTRIES = 10_000
+DEFAULT_TIMEOUT_SECONDS = 120.0
+MAX_TIMEOUT_SECONDS = 900.0
+MAX_ENV_ITEMS = 128
+MAX_CONCURRENT_EXEC = 2
+_EXEC_SLOTS = threading.BoundedSemaphore(MAX_CONCURRENT_EXEC)
+
+
+class RequestError(Exception):
+  def __init__(
+    self,
+    code: str,
+    message: str,
+    status: HTTPStatus = HTTPStatus.BAD_REQUEST,
+  ) -> None:
+    super().__init__(message)
+    self.code = code
+    self.message = message
+    self.status = status
+
+
+def _token() -> str:
+  value = os.environ.get("MOBIUS_RECOVERY_TARGET_TOKEN", "")
+  if len(value) < 32 or len(value.encode("utf-8")) > 512:
+    raise RuntimeError(
+      "MOBIUS_RECOVERY_TARGET_TOKEN must contain 32-512 UTF-8 bytes"
+    )
+  return value
+
+
+def _absolute_path(value: Any, field: str = "path") -> Path:
+  if not isinstance(value, str) or not value or "\x00" in value:
+    raise RequestError("invalid_path", f"{field} must be a non-empty path")
+  path = Path(value)
+  if not path.is_absolute():
+    raise RequestError("invalid_path", f"{field} must be absolute")
+  return path
+
+
+def _bounded_int(
+  value: Any,
+  *,
+  field: str,
+  default: int,
+  minimum: int,
+  maximum: int,
+) -> int:
+  if value is None:
+    return default
+  if isinstance(value, bool) or not isinstance(value, int):
+    raise RequestError("invalid_request", f"{field} must be an integer")
+  if value < minimum or value > maximum:
+    raise RequestError(
+      "invalid_request", f"{field} must be between {minimum} and {maximum}"
+    )
+  return value
+
+
+def _decode_base64(value: Any, field: str) -> bytes:
+  if not isinstance(value, str):
+    raise RequestError("invalid_request", f"{field} must be base64 text")
+  try:
+    decoded = base64.b64decode(value, validate=True)
+  except (binascii.Error, ValueError) as exc:
+    raise RequestError("invalid_request", f"{field} is not valid base64") from exc
+  if len(decoded) > MAX_FILE_BYTES:
+    raise RequestError(
+      "payload_too_large",
+      f"decoded {field} exceeds {MAX_FILE_BYTES} bytes",
+      HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+    )
+  return decoded
+
+
+def _kill_process_group(process: subprocess.Popen[bytes]) -> None:
+  if process.poll() is not None:
+    return
+  try:
+    os.killpg(process.pid, signal.SIGKILL)
+  except ProcessLookupError:
+    pass
+
+
+def _run_exec(body: dict[str, Any]) -> dict[str, Any]:
+  argv = body.get("argv")
+  if (
+    not isinstance(argv, list)
+    or not argv
+    or len(argv) > 256
+    or any(not isinstance(item, str) or not item or "\x00" in item for item in argv)
+  ):
+    raise RequestError(
+      "invalid_request", "argv must be a non-empty list of non-empty strings"
+    )
+  cwd_value = body.get("cwd", "/data")
+  cwd = _absolute_path(cwd_value, "cwd")
+  if not cwd.is_dir():
+    raise RequestError("invalid_cwd", "cwd must name an existing directory")
+
+  timeout_raw = body.get("timeout_seconds", DEFAULT_TIMEOUT_SECONDS)
+  if isinstance(timeout_raw, bool) or not isinstance(timeout_raw, (int, float)):
+    raise RequestError("invalid_request", "timeout_seconds must be a number")
+  timeout = float(timeout_raw)
+  if not 0.1 <= timeout <= MAX_TIMEOUT_SECONDS:
+    raise RequestError(
+      "invalid_request",
+      f"timeout_seconds must be between 0.1 and {MAX_TIMEOUT_SECONDS:g}",
+    )
+
+  requested_env = body.get("env", {})
+  if not isinstance(requested_env, dict) or len(requested_env) > MAX_ENV_ITEMS:
+    raise RequestError(
+      "invalid_request", f"env must contain at most {MAX_ENV_ITEMS} entries"
+    )
+  env = {
+    "HOME": "/root",
+    "LANG": os.environ.get("LANG", "C.UTF-8"),
+    "PATH": os.environ.get(
+      "PATH", "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+    ),
+    "DATA_DIR": os.environ.get("DATA_DIR", "/data"),
+  }
+  for key, value in requested_env.items():
+    if (
+      not isinstance(key, str)
+      or not key
+      or "=" in key
+      or "\x00" in key
+      or not isinstance(value, str)
+      or "\x00" in value
+    ):
+      raise RequestError("invalid_request", "env keys and values must be strings")
+    if len(key) > 256 or len(value.encode("utf-8")) > 64 * 1024:
+      raise RequestError("invalid_request", "env key or value is too large")
+    env[key] = value
+
+  if "stdin" in body and "stdin_base64" in body:
+    raise RequestError(
+      "invalid_request", "stdin and stdin_base64 are mutually exclusive"
+    )
+  if "stdin_base64" in body:
+    stdin = _decode_base64(body["stdin_base64"], "stdin_base64")
+  else:
+    stdin_value = body.get("stdin", "")
+    if not isinstance(stdin_value, str):
+      raise RequestError("invalid_request", "stdin must be a string")
+    stdin = stdin_value.encode("utf-8")
+    if len(stdin) > MAX_FILE_BYTES:
+      raise RequestError(
+        "payload_too_large",
+        f"stdin exceeds {MAX_FILE_BYTES} bytes",
+        HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+      )
+
+  if not _EXEC_SLOTS.acquire(blocking=False):
+    raise RequestError(
+      "exec_busy",
+      "the recovery target is already running the maximum number of commands",
+      HTTPStatus.SERVICE_UNAVAILABLE,
+    )
+  started = time.monotonic()
+  process: subprocess.Popen[bytes] | None = None
+  try:
+    try:
+      process = subprocess.Popen(
+        argv,
+        cwd=str(cwd),
+        env=env,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        start_new_session=True,
+      )
+    except OSError as exc:
+      raise RequestError(
+        "exec_failed", str(exc), HTTPStatus.UNPROCESSABLE_ENTITY
+      ) from exc
+    assert process.stdin and process.stdout and process.stderr
+    for stream in (process.stdin, process.stdout, process.stderr):
+      os.set_blocking(stream.fileno(), False)
+
+    selector = selectors.DefaultSelector()
+    selector.register(process.stdout, selectors.EVENT_READ, "stdout")
+    selector.register(process.stderr, selectors.EVENT_READ, "stderr")
+    stdin_view = memoryview(stdin)
+    stdin_offset = 0
+    if stdin:
+      selector.register(process.stdin, selectors.EVENT_WRITE, "stdin")
+    else:
+      process.stdin.close()
+
+    output = {"stdout": bytearray(), "stderr": bytearray()}
+    truncated = False
+    timed_out = False
+    while selector.get_map():
+      remaining = timeout - (time.monotonic() - started)
+      if remaining <= 0:
+        timed_out = True
+        _kill_process_group(process)
+        remaining = 0.1
+      events = selector.select(min(max(remaining, 0.01), 0.25))
+      for key, _mask in events:
+        stream = key.fileobj
+        kind = key.data
+        if kind == "stdin":
+          try:
+            written = os.write(stream.fileno(), stdin_view[stdin_offset:])
+            stdin_offset += written
+          except BrokenPipeError:
+            stdin_offset = len(stdin_view)
+          if stdin_offset >= len(stdin_view):
+            selector.unregister(stream)
+            stream.close()
+          continue
+        try:
+          chunk = os.read(stream.fileno(), 64 * 1024)
+        except BlockingIOError:
+          continue
+        if not chunk:
+          selector.unregister(stream)
+          stream.close()
+          continue
+        target = output[kind]
+        room = MAX_OUTPUT_BYTES - len(target)
+        if room > 0:
+          target.extend(chunk[:room])
+        if len(chunk) > room:
+          truncated = True
+          _kill_process_group(process)
+
+      if process.poll() is not None:
+        # Pipes may still contain a final kernel-buffered chunk. Keep draining
+        # them, but an unwritten stdin pipe can now be retired.
+        if process.stdin in [item.fileobj for item in selector.get_map().values()]:
+          selector.unregister(process.stdin)
+          process.stdin.close()
+    exit_code = process.wait(timeout=2)
+    elapsed_ms = round((time.monotonic() - started) * 1000)
+    return {
+      "exit_code": exit_code,
+      "stdout": bytes(output["stdout"]).decode("utf-8", "replace"),
+      "stderr": bytes(output["stderr"]).decode("utf-8", "replace"),
+      "stdout_base64": base64.b64encode(output["stdout"]).decode("ascii"),
+      "stderr_base64": base64.b64encode(output["stderr"]).decode("ascii"),
+      "truncated": truncated,
+      "timed_out": timed_out,
+      "duration_ms": elapsed_ms,
+    }
+  finally:
+    if process is not None and process.poll() is None:
+      _kill_process_group(process)
+      try:
+        process.wait(timeout=2)
+      except subprocess.TimeoutExpired:
+        pass
+    _EXEC_SLOTS.release()
+
+
+def _read_file(body: dict[str, Any]) -> dict[str, Any]:
+  path = _absolute_path(body.get("path"))
+  offset = _bounded_int(
+    body.get("offset"), field="offset", default=0, minimum=0, maximum=2**63 - 1
+  )
+  limit = _bounded_int(
+    body.get("limit"),
+    field="limit",
+    default=MAX_FILE_BYTES,
+    minimum=1,
+    maximum=MAX_FILE_BYTES,
+  )
+  try:
+    st = path.stat()
+    if not stat.S_ISREG(st.st_mode):
+      raise RequestError("not_a_file", "path is not a regular file")
+    with path.open("rb") as handle:
+      handle.seek(offset)
+      data = handle.read(limit)
+    return {
+      "path": str(path),
+      "offset": offset,
+      "data_base64": base64.b64encode(data).decode("ascii"),
+      "eof": offset + len(data) >= st.st_size,
+      "size": st.st_size,
+      "mode": stat.S_IMODE(st.st_mode),
+      "uid": st.st_uid,
+      "gid": st.st_gid,
+    }
+  except RequestError:
+    raise
+  except OSError as exc:
+    raise RequestError(
+      "fs_read_failed", str(exc), HTTPStatus.UNPROCESSABLE_ENTITY
+    ) from exc
+
+
+def _write_file(body: dict[str, Any]) -> dict[str, Any]:
+  path = _absolute_path(body.get("path"))
+  data = _decode_base64(body.get("data_base64"), "data_base64")
+  mode = _bounded_int(
+    body.get("mode"), field="mode", default=0o600, minimum=0, maximum=0o7777
+  )
+  atomic = body.get("atomic", True)
+  if not isinstance(atomic, bool):
+    raise RequestError("invalid_request", "atomic must be a boolean")
+  if not path.parent.is_dir():
+    raise RequestError("missing_parent", "the destination parent does not exist")
+
+  temp_path: Path | None = None
+  try:
+    if atomic:
+      fd, raw_temp = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+      temp_path = Path(raw_temp)
+      try:
+        os.fchmod(fd, mode)
+        offset = 0
+        while offset < len(data):
+          offset += os.write(fd, data[offset:])
+        os.fsync(fd)
+      finally:
+        os.close(fd)
+      os.replace(temp_path, path)
+      temp_path = None
+    else:
+      flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+      flags |= getattr(os, "O_NOFOLLOW", 0)
+      fd = os.open(path, flags, mode)
+      try:
+        os.fchmod(fd, mode)
+        offset = 0
+        while offset < len(data):
+          offset += os.write(fd, data[offset:])
+        os.fsync(fd)
+      finally:
+        os.close(fd)
+    return {"path": str(path), "bytes_written": len(data), "mode": mode}
+  except OSError as exc:
+    raise RequestError(
+      "fs_write_failed", str(exc), HTTPStatus.UNPROCESSABLE_ENTITY
+    ) from exc
+  finally:
+    if temp_path is not None:
+      temp_path.unlink(missing_ok=True)
+
+
+def _list_directory(body: dict[str, Any]) -> dict[str, Any]:
+  path = _absolute_path(body.get("path"))
+  try:
+    entries: list[dict[str, Any]] = []
+    with os.scandir(path) as iterator:
+      for entry in iterator:
+        if len(entries) >= MAX_LIST_ENTRIES:
+          raise RequestError(
+            "too_many_entries",
+            f"directory contains more than {MAX_LIST_ENTRIES} entries",
+            HTTPStatus.UNPROCESSABLE_ENTITY,
+          )
+        info = entry.stat(follow_symlinks=False)
+        kind = (
+          "symlink" if stat.S_ISLNK(info.st_mode)
+          else "directory" if stat.S_ISDIR(info.st_mode)
+          else "file" if stat.S_ISREG(info.st_mode)
+          else "other"
+        )
+        item: dict[str, Any] = {
+          "name": entry.name,
+          "type": kind,
+          "size": info.st_size,
+          "mode": stat.S_IMODE(info.st_mode),
+          "uid": info.st_uid,
+          "gid": info.st_gid,
+          "mtime_ns": info.st_mtime_ns,
+        }
+        if kind == "symlink":
+          item["target"] = os.readlink(entry.path)
+        entries.append(item)
+    entries.sort(key=lambda item: item["name"])
+    return {"path": str(path), "entries": entries}
+  except RequestError:
+    raise
+  except OSError as exc:
+    raise RequestError(
+      "fs_list_failed", str(exc), HTTPStatus.UNPROCESSABLE_ENTITY
+    ) from exc
+
+
+class _Handler(BaseHTTPRequestHandler):
+  protocol_version = "HTTP/1.1"
+  server_version = "MobiusRecoveryTarget/1"
+
+  def log_message(self, fmt: str, *args: object) -> None:
+    print(f"recovery-target: {self.address_string()} {fmt % args}", flush=True)
+
+  def _send(self, status: HTTPStatus, payload: dict[str, Any]) -> None:
+    raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    self.send_response(status.value)
+    self.send_header("Content-Type", "application/json")
+    self.send_header("Content-Length", str(len(raw)))
+    self.send_header("Cache-Control", "no-store")
+    self.send_header("X-Content-Type-Options", "nosniff")
+    self.send_header("Connection", "close")
+    self.end_headers()
+    self.wfile.write(raw)
+    self.close_connection = True
+
+  def _error(self, error: RequestError) -> None:
+    self._send(
+      error.status,
+      {"error": {"code": error.code, "message": error.message}},
+    )
+
+  def _authorized(self) -> bool:
+    expected = f"Bearer {_token()}"
+    supplied = self.headers.get("Authorization", "")
+    if not hmac.compare_digest(supplied.encode(), expected.encode()):
+      self._send(
+        HTTPStatus.UNAUTHORIZED,
+        {"error": {"code": "unauthorized", "message": "invalid bearer token"}},
+      )
+      return False
+    return True
+
+  def _body(self) -> dict[str, Any]:
+    if self.headers.get("Transfer-Encoding"):
+      raise RequestError(
+        "invalid_framing", "Transfer-Encoding is not supported"
+      )
+    raw_length = self.headers.get("Content-Length")
+    if raw_length is None or not raw_length.isdecimal():
+      raise RequestError("invalid_framing", "a valid Content-Length is required")
+    length = int(raw_length)
+    if length > MAX_REQUEST_BYTES:
+      raise RequestError(
+        "payload_too_large",
+        f"request exceeds {MAX_REQUEST_BYTES} bytes",
+        HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+      )
+    raw = self.rfile.read(length)
+    if len(raw) != length:
+      raise RequestError("invalid_framing", "request body ended early")
+    try:
+      value = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+      raise RequestError("invalid_json", "request body must be a JSON object") from exc
+    if not isinstance(value, dict):
+      raise RequestError("invalid_json", "request body must be a JSON object")
+    return value
+
+  def do_GET(self) -> None:  # noqa: N802
+    if not self._authorized():
+      return
+    if self.path != "/v1/health":
+      self._error(RequestError("not_found", "endpoint not found", HTTPStatus.NOT_FOUND))
+      return
+    self._send(HTTPStatus.OK, {
+      "protocol": PROTOCOL,
+      "target": "mobius",
+      "mode": "recovery",
+      "build_sha": os.environ.get("BUILD_SHA", "unknown"),
+    })
+
+  def do_POST(self) -> None:  # noqa: N802
+    if not self._authorized():
+      return
+    handlers = {
+      "/v1/exec": _run_exec,
+      "/v1/fs/read": _read_file,
+      "/v1/fs/write": _write_file,
+      "/v1/fs/list": _list_directory,
+    }
+    operation = handlers.get(self.path)
+    if operation is None:
+      self._error(RequestError("not_found", "endpoint not found", HTTPStatus.NOT_FOUND))
+      return
+    try:
+      result = operation(self._body())
+    except RequestError as exc:
+      self._error(exc)
+      return
+    except Exception:
+      self._error(RequestError(
+        "internal_error", "recovery target operation failed", HTTPStatus.INTERNAL_SERVER_ERROR
+      ))
+      return
+    self._send(HTTPStatus.OK, result)
+
+
+class _DualStackServer(ThreadingHTTPServer):
+  address_family = socket.AF_INET6
+  daemon_threads = True
+  allow_reuse_address = True
+
+  def server_bind(self) -> None:
+    self.socket.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+    super().server_bind()
+
+
+def main() -> None:
+  if os.environ.get("MOBIUS_BOOT_MODE") != "recovery":
+    raise SystemExit("recovery target refuses to run outside recovery boot mode")
+  if os.geteuid() != 0:
+    raise SystemExit("recovery target must run as root")
+  token = _token()
+  del token
+  raw_port = os.environ.get("MOBIUS_RECOVERY_TARGET_PORT", str(DEFAULT_PORT))
+  try:
+    port = int(raw_port)
+  except ValueError as exc:
+    raise SystemExit("MOBIUS_RECOVERY_TARGET_PORT must be an integer") from exc
+  if not 1 <= port <= 65535:
+    raise SystemExit("MOBIUS_RECOVERY_TARGET_PORT must be between 1 and 65535")
+  server = _DualStackServer(("::", port), _Handler)
+  print(
+    f"Mobius recovery target {PROTOCOL} listening privately on [::]:{port}",
+    flush=True,
+  )
+  server.serve_forever(poll_interval=0.25)
+
+
+if __name__ == "__main__":
+  main()

--- a/backend/recovery_target/targetd.py
+++ b/backend/recovery_target/targetd.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import base64
 import binascii
+import errno
 import hmac
 import json
 import os
@@ -529,6 +530,30 @@ class _DualStackServer(ThreadingHTTPServer):
     super().server_bind()
 
 
+class _IPv4Server(ThreadingHTTPServer):
+  daemon_threads = True
+  allow_reuse_address = True
+
+
+def _create_server(port: int) -> ThreadingHTTPServer:
+  """Prefer one dual-stack socket, but keep recovery usable without IPv6."""
+  try:
+    return _DualStackServer(("::", port), _Handler)
+  except OSError as exc:
+    if exc.errno not in {
+      errno.EAFNOSUPPORT,
+      errno.EADDRNOTAVAIL,
+      errno.ENOPROTOOPT,
+      errno.EPROTONOSUPPORT,
+    }:
+      raise
+    print(
+      f"recovery-target: IPv6 unavailable ({exc}); falling back to IPv4",
+      flush=True,
+    )
+    return _IPv4Server(("0.0.0.0", port), _Handler)
+
+
 def main() -> None:
   if os.environ.get("MOBIUS_BOOT_MODE") != "recovery":
     raise SystemExit("recovery target refuses to run outside recovery boot mode")
@@ -543,7 +568,10 @@ def main() -> None:
     raise SystemExit("MOBIUS_RECOVERY_TARGET_PORT must be an integer") from exc
   if not 1 <= port <= 65535:
     raise SystemExit("MOBIUS_RECOVERY_TARGET_PORT must be between 1 and 65535")
-  server = _DualStackServer(("::", port), _Handler)
+  # Every endpoint, including health, requires the bearer token. Managed
+  # launchers therefore clear provider-level unauthenticated health checks and
+  # probe /v1/health themselves before handing the worker to the owner.
+  server = _create_server(port)
   print(
     f"Mobius recovery target {PROTOCOL} listening privately on [::]:{port}",
     flush=True,

--- a/backend/recovery_target/targetd.py
+++ b/backend/recovery_target/targetd.py
@@ -13,15 +13,16 @@ import base64
 import binascii
 import ctypes
 import errno
+import hashlib
 import hmac
 import json
 import os
+import secrets
 import selectors
 import signal
 import socket
 import stat
 import subprocess
-import tempfile
 import threading
 import time
 from http import HTTPStatus
@@ -35,12 +36,22 @@ DEFAULT_PORT = 18002
 BUILD_REVISION_PATH = Path("/app/recovery-target/BUILD_REVISION")
 CAP_NET_ADMIN = 12
 CAP_NET_RAW = 13
+CAP_SYS_PTRACE = 19
+CAP_SYS_ADMIN = 21
+_BLOCKED_CAPABILITIES = (
+  CAP_NET_ADMIN, CAP_NET_RAW, CAP_SYS_PTRACE, CAP_SYS_ADMIN,
+)
 _CAPABILITY_VERSION_3 = 0x20080522
 _PR_CAPBSET_READ = 23
 _PR_CAPBSET_DROP = 24
 _PR_CAP_AMBIENT = 47
 _PR_CAP_AMBIENT_IS_SET = 1
 _PR_CAP_AMBIENT_CLEAR_ALL = 4
+_SYS_OPENAT2 = 437
+_RESOLVE_NO_XDEV = 0x01
+_RESOLVE_NO_MAGICLINKS = 0x02
+_RESOLVE_BENEATH = 0x08
+_TOKEN_DIGEST_DOMAIN = b"mobius-recovery-target/v1 bearer\x00"
 # An 8 MiB decoded payload expands to about 10.67 MiB as base64 before the JSON
 # envelope is counted. Keep the wire budget large enough for the advertised
 # file/stdin boundary while still rejecting unbounded request bodies.
@@ -55,8 +66,16 @@ MAX_ENV_ITEMS = 128
 MAX_ENV_BYTES = 256 * 1024
 MAX_CONCURRENT_EXEC = 2
 _EXEC_SLOTS = threading.BoundedSemaphore(MAX_CONCURRENT_EXEC)
-_STARTUP_TOKEN: bytes | None = None
+_STARTUP_TOKEN_DIGEST: bytes | None = None
 _BUILD_REVISION = "unknown"
+_DATA_ROOT = Path(os.environ.get("DATA_DIR", "/data"))
+# Convenience file operations are deliberately narrower than root exec. They
+# run inside target PID1 and therefore must never act as a confused deputy for
+# /proc memory. Recovery data, baked app sources, and scratch paths are
+# sufficient for inspection; only stopped-instance data and scratch are
+# writable. openat2 enforces these roots against symlink and mount races.
+_FS_READ_ROOTS = (_DATA_ROOT, Path("/app"), Path("/tmp"))
+_FS_WRITE_ROOTS = (_DATA_ROOT, Path("/tmp"))
 
 
 class _CapabilityHeader(ctypes.Structure):
@@ -74,6 +93,14 @@ class _CapabilityData(ctypes.Structure):
   ]
 
 
+class _OpenHow(ctypes.Structure):
+  _fields_ = [
+    ("flags", ctypes.c_uint64),
+    ("mode", ctypes.c_uint64),
+    ("resolve", ctypes.c_uint64),
+  ]
+
+
 class RequestError(Exception):
   def __init__(
     self,
@@ -87,22 +114,22 @@ class RequestError(Exception):
     self.status = status
 
 
-def _validate_token(value: bytes) -> bytes:
+def _validate_token(value: bytes | bytearray | memoryview) -> None:
   if len(value) < 32 or len(value) > 512:
     raise RuntimeError(
-      "MOBIUS_RECOVERY_TARGET_TOKEN must contain 32-512 UTF-8 bytes"
+      "MOBIUS_RECOVERY_TARGET_TOKEN must contain 32-512 printable ASCII bytes"
     )
-  try:
-    value.decode("utf-8")
-  except UnicodeDecodeError as exc:
+  if any(byte < 0x21 or byte > 0x7E for byte in value):
     raise RuntimeError(
-      "MOBIUS_RECOVERY_TARGET_TOKEN must contain 32-512 UTF-8 bytes"
-    ) from exc
-  if b"\x00" in value or b"\r" in value or b"\n" in value:
-    raise RuntimeError(
-      "MOBIUS_RECOVERY_TARGET_TOKEN must not contain NUL or newlines"
+      "MOBIUS_RECOVERY_TARGET_TOKEN must contain 32-512 printable ASCII bytes"
     )
-  return value
+
+
+def _token_digest(value: bytes | bytearray | memoryview) -> bytes:
+  verifier = hashlib.sha256()
+  verifier.update(_TOKEN_DIGEST_DOMAIN)
+  verifier.update(value)
+  return verifier.digest()
 
 
 def _capability_state(
@@ -116,8 +143,8 @@ def _capability_state(
   return header, data
 
 
-def _drop_packet_capture_capabilities() -> None:
-  """Permanently deny packet capture/manipulation to target exec children."""
+def _drop_recovery_escape_capabilities() -> None:
+  """Deny packet capture, ptrace, and mounts to target exec children."""
   libc = ctypes.CDLL(None, use_errno=True)
   capget = getattr(libc, "capget", None)
   capset = getattr(libc, "capset", None)
@@ -125,12 +152,12 @@ def _drop_packet_capture_capabilities() -> None:
   if capget is None or capset is None or prctl is None:
     raise RuntimeError("recovery target requires Linux capability controls")
 
-  # A root repair command otherwise inherits Docker's CAP_NET_RAW and can use
-  # AF_PACKET to capture a later worker Authorization header on the private
-  # plain-HTTP interface. Remove both packet capabilities from every mutable
-  # set and the bounding set before the server starts listening.
+  # A root repair command must not capture a later Authorization header,
+  # ptrace target PID1, or create a nested mount that bypasses filesystem-root
+  # policy. None of these powers are needed to repair the stopped /data tree.
+  # Remove them from every mutable set and the bounding set before listening.
   header, data = _capability_state(libc)
-  for capability in (CAP_NET_ADMIN, CAP_NET_RAW):
+  for capability in _BLOCKED_CAPABILITIES:
     word = capability // 32
     mask = 1 << (capability % 32)
     data[word].effective &= ~mask
@@ -159,7 +186,7 @@ def _drop_packet_capture_capabilities() -> None:
   # Fail closed if the kernel ignored any operation. The bounding-set check is
   # essential because uid 0 regains capabilities from that set across exec.
   _, restricted = _capability_state(libc)
-  for capability in (CAP_NET_ADMIN, CAP_NET_RAW):
+  for capability in _BLOCKED_CAPABILITIES:
     word = capability // 32
     mask = 1 << (capability % 32)
     if (
@@ -203,8 +230,8 @@ def _assert_clean_initial_environment() -> None:
     raise RuntimeError("recovery target bearer is exposed through /proc")
 
 
-def _read_startup_token() -> bytes:
-  """Consumes the one-shot inherited descriptor; never reads a secret env."""
+def _read_startup_token_digest() -> bytes:
+  """Consumes and wipes the bearer, retaining only a one-way verifier."""
   if "MOBIUS_RECOVERY_TARGET_TOKEN" in os.environ:
     raise RuntimeError(
       "MOBIUS_RECOVERY_TARGET_TOKEN must not reach the target environment"
@@ -215,13 +242,16 @@ def _read_startup_token() -> bytes:
   fd = int(raw_fd)
   if fd < 3:
     raise RuntimeError("MOBIUS_RECOVERY_TARGET_TOKEN_FD is invalid")
-  value = bytearray()
+  value = bytearray(513)
+  view = memoryview(value)
+  token: memoryview | None = None
+  length = 0
   try:
-    while len(value) <= 512:
-      chunk = os.read(fd, 513 - len(value))
-      if not chunk:
+    while length < len(value):
+      read = os.readv(fd, [view[length:]])
+      if not read:
         break
-      value.extend(chunk)
+      length += read
   except OSError as exc:
     raise RuntimeError("could not consume recovery target bearer") from exc
   finally:
@@ -230,8 +260,13 @@ def _read_startup_token() -> bytes:
     except OSError:
       pass
   try:
-    return _validate_token(bytes(value))
+    token = view[:length]
+    _validate_token(token)
+    return _token_digest(token)
   finally:
+    if token is not None:
+      token.release()
+    view.release()
     for index in range(len(value)):
       value[index] = 0
 
@@ -248,24 +283,25 @@ def _load_baked_build_revision() -> str:
 
 def _initialize_startup_security(*, require_pid_one: bool = True) -> None:
   """Loads immutable identity + bearer before any request can be accepted."""
-  global _BUILD_REVISION, _STARTUP_TOKEN
+  global _BUILD_REVISION, _STARTUP_TOKEN_DIGEST
   if require_pid_one and os.getpid() != 1:
     raise RuntimeError(
       "recovery target must be container pid 1 so no parent retains its bearer"
     )
-  if _STARTUP_TOKEN is not None:
+  if _STARTUP_TOKEN_DIGEST is not None:
     raise RuntimeError("recovery target startup security was already initialized")
   _assert_clean_initial_environment()
-  _drop_packet_capture_capabilities()
+  _assert_fs_policy_supported()
+  _drop_recovery_escape_capabilities()
   _set_process_nondumpable()
-  _STARTUP_TOKEN = _read_startup_token()
+  _STARTUP_TOKEN_DIGEST = _read_startup_token_digest()
   _BUILD_REVISION = _load_baked_build_revision()
 
 
-def _startup_token() -> bytes:
-  if _STARTUP_TOKEN is None:
+def _startup_token_digest() -> bytes:
+  if _STARTUP_TOKEN_DIGEST is None:
     raise RuntimeError("recovery target bearer is not initialized")
-  return _STARTUP_TOKEN
+  return _STARTUP_TOKEN_DIGEST
 
 
 def _absolute_path(value: Any, field: str = "path") -> Path:
@@ -275,6 +311,121 @@ def _absolute_path(value: Any, field: str = "path") -> Path:
   if not path.is_absolute():
     raise RequestError("invalid_path", f"{field} must be absolute")
   return path
+
+
+def _openat2(dir_fd: int, relative: Path, flags: int, mode: int = 0) -> int:
+  """Open one path beneath dir_fd without symlink or mount escapes."""
+  if relative.is_absolute():
+    raise ValueError("openat2 path must be relative")
+  raw_path = os.fsencode(str(relative) or ".")
+  if b"\x00" in raw_path:
+    raise OSError(errno.EINVAL, "path contains NUL")
+  how = _OpenHow(
+    flags=flags,
+    mode=mode,
+    resolve=_RESOLVE_BENEATH | _RESOLVE_NO_MAGICLINKS | _RESOLVE_NO_XDEV,
+  )
+  libc = ctypes.CDLL(None, use_errno=True)
+  result = libc.syscall(
+    ctypes.c_long(_SYS_OPENAT2),
+    ctypes.c_int(dir_fd),
+    ctypes.c_char_p(raw_path),
+    ctypes.byref(how),
+    ctypes.c_size_t(ctypes.sizeof(how)),
+  )
+  if result < 0:
+    error = ctypes.get_errno()
+    raise OSError(error, os.strerror(error), os.fsdecode(raw_path))
+  return int(result)
+
+
+def _select_fs_root(path: Path, roots: tuple[Path, ...]) -> tuple[Path, Path]:
+  for root in sorted(set(roots), key=lambda item: len(item.parts), reverse=True):
+    if not root.is_absolute():
+      continue
+    try:
+      relative = path.relative_to(root)
+    except ValueError:
+      continue
+    return root, relative if relative.parts else Path(".")
+  raise RequestError(
+    "path_forbidden",
+    "path is outside the recovery filesystem roots",
+    HTTPStatus.FORBIDDEN,
+  )
+
+
+def _translate_policy_open_error(exc: OSError) -> None:
+  if exc.errno in {errno.EXDEV, errno.ELOOP}:
+    raise RequestError(
+      "path_forbidden",
+      "path escapes its recovery filesystem root",
+      HTTPStatus.FORBIDDEN,
+    ) from exc
+  if exc.errno in {errno.ENOSYS, errno.EOPNOTSUPP}:
+    raise RequestError(
+      "path_policy_unavailable",
+      "kernel-enforced recovery path policy is unavailable",
+      HTTPStatus.INTERNAL_SERVER_ERROR,
+    ) from exc
+  raise exc
+
+
+def _open_relative(root: Path, relative: Path, flags: int, mode: int = 0) -> int:
+  root_flags = (
+    getattr(os, "O_PATH", os.O_RDONLY)
+    | os.O_DIRECTORY
+    | os.O_CLOEXEC
+    | getattr(os, "O_NOFOLLOW", 0)
+  )
+  root_fd = os.open(root, root_flags)
+  try:
+    try:
+      return _openat2(root_fd, relative, flags | os.O_CLOEXEC, mode)
+    except OSError as exc:
+      _translate_policy_open_error(exc)
+      raise AssertionError("unreachable")
+  finally:
+    os.close(root_fd)
+
+
+def _open_fs_path(
+  path: Path,
+  roots: tuple[Path, ...],
+  flags: int,
+  mode: int = 0,
+) -> int:
+  root, relative = _select_fs_root(path, roots)
+  return _open_relative(root, relative, flags, mode)
+
+
+def _open_fs_parent(
+  path: Path, roots: tuple[Path, ...],
+) -> tuple[int, str]:
+  root, relative = _select_fs_root(path, roots)
+  name = relative.name
+  if relative == Path(".") or name in {"", ".", ".."} or "/" in name:
+    raise RequestError(
+      "invalid_path", "path must name an entry below a recovery filesystem root"
+    )
+  parent_fd = _open_relative(
+    root, relative.parent, os.O_RDONLY | os.O_DIRECTORY,
+  )
+  return parent_fd, name
+
+
+def _assert_fs_policy_supported() -> None:
+  """Fail target startup unless the kernel can enforce race-free roots."""
+  if any(not root.is_absolute() for root in (*_FS_READ_ROOTS, *_FS_WRITE_ROOTS)):
+    raise RuntimeError("recovery filesystem roots must be absolute")
+  try:
+    fd = _open_relative(Path("/tmp"), Path("."), os.O_RDONLY | os.O_DIRECTORY)
+  except (OSError, RequestError) as exc:
+    raise RuntimeError(
+      "kernel-enforced recovery filesystem policy is unavailable"
+    ) from exc
+  else:
+    os.close(fd)
 
 
 def _bounded_int(
@@ -515,13 +666,22 @@ def _read_file(body: dict[str, Any]) -> dict[str, Any]:
     minimum=1,
     maximum=MAX_FILE_BYTES,
   )
+  fd: int | None = None
   try:
-    st = path.stat()
+    fd = _open_fs_path(path, _FS_READ_ROOTS, os.O_RDONLY)
+    st = os.fstat(fd)
     if not stat.S_ISREG(st.st_mode):
       raise RequestError("not_a_file", "path is not a regular file")
-    with path.open("rb") as handle:
-      handle.seek(offset)
-      data = handle.read(limit)
+    os.lseek(fd, offset, os.SEEK_SET)
+    chunks: list[bytes] = []
+    remaining = limit
+    while remaining:
+      chunk = os.read(fd, remaining)
+      if not chunk:
+        break
+      chunks.append(chunk)
+      remaining -= len(chunk)
+    data = b"".join(chunks)
     return {
       "path": str(path),
       "offset": offset,
@@ -538,6 +698,9 @@ def _read_file(body: dict[str, Any]) -> dict[str, Any]:
     raise RequestError(
       "fs_read_failed", str(exc), HTTPStatus.UNPROCESSABLE_ENTITY
     ) from exc
+  finally:
+    if fd is not None:
+      os.close(fd)
 
 
 def _write_file(body: dict[str, Any]) -> dict[str, Any]:
@@ -549,14 +712,26 @@ def _write_file(body: dict[str, Any]) -> dict[str, Any]:
   atomic = body.get("atomic", True)
   if not isinstance(atomic, bool):
     raise RequestError("invalid_request", "atomic must be a boolean")
-  if not path.parent.is_dir():
-    raise RequestError("missing_parent", "the destination parent does not exist")
-
-  temp_path: Path | None = None
+  parent_fd: int | None = None
+  temp_name: str | None = None
   try:
+    parent_fd, name = _open_fs_parent(path, _FS_WRITE_ROOTS)
     if atomic:
-      fd, raw_temp = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
-      temp_path = Path(raw_temp)
+      for _attempt in range(10):
+        candidate = f".{name}.{secrets.token_hex(8)}.tmp"
+        try:
+          fd = os.open(
+            candidate,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC,
+            mode,
+            dir_fd=parent_fd,
+          )
+        except FileExistsError:
+          continue
+        temp_name = candidate
+        break
+      else:
+        raise OSError(errno.EEXIST, "could not allocate atomic write path")
       try:
         os.fchmod(fd, mode)
         offset = 0
@@ -565,12 +740,15 @@ def _write_file(body: dict[str, Any]) -> dict[str, Any]:
         os.fsync(fd)
       finally:
         os.close(fd)
-      os.replace(temp_path, path)
-      temp_path = None
+      os.replace(
+        temp_name, name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd,
+      )
+      temp_name = None
+      os.fsync(parent_fd)
     else:
       flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
       flags |= getattr(os, "O_NOFOLLOW", 0)
-      fd = os.open(path, flags, mode)
+      fd = os.open(name, flags | os.O_CLOEXEC, mode, dir_fd=parent_fd)
       try:
         os.fchmod(fd, mode)
         offset = 0
@@ -585,16 +763,25 @@ def _write_file(body: dict[str, Any]) -> dict[str, Any]:
       "fs_write_failed", str(exc), HTTPStatus.UNPROCESSABLE_ENTITY
     ) from exc
   finally:
-    if temp_path is not None:
-      temp_path.unlink(missing_ok=True)
+    if temp_name is not None and parent_fd is not None:
+      try:
+        os.unlink(temp_name, dir_fd=parent_fd)
+      except FileNotFoundError:
+        pass
+    if parent_fd is not None:
+      os.close(parent_fd)
 
 
 def _list_directory(body: dict[str, Any]) -> dict[str, Any]:
   path = _absolute_path(body.get("path"))
+  directory_fd: int | None = None
   try:
+    directory_fd = _open_fs_path(
+      path, _FS_READ_ROOTS, os.O_RDONLY | os.O_DIRECTORY,
+    )
     entries: list[dict[str, Any]] = []
     encoded_bytes = len(str(path).encode("utf-8")) + 64
-    with os.scandir(path) as iterator:
+    with os.scandir(directory_fd) as iterator:
       for entry in iterator:
         if len(entries) >= MAX_LIST_ENTRIES:
           raise RequestError(
@@ -619,7 +806,7 @@ def _list_directory(body: dict[str, Any]) -> dict[str, Any]:
           "mtime_ns": info.st_mtime_ns,
         }
         if kind == "symlink":
-          item["target"] = os.readlink(entry.path)
+          item["target"] = os.readlink(entry.name, dir_fd=directory_fd)
         encoded_bytes += len(
           json.dumps(item, separators=(",", ":")).encode("utf-8")
         ) + 1
@@ -638,6 +825,9 @@ def _list_directory(body: dict[str, Any]) -> dict[str, Any]:
     raise RequestError(
       "fs_list_failed", str(exc), HTTPStatus.UNPROCESSABLE_ENTITY
     ) from exc
+  finally:
+    if directory_fd is not None:
+      os.close(directory_fd)
 
 
 class _Handler(BaseHTTPRequestHandler):
@@ -666,9 +856,26 @@ class _Handler(BaseHTTPRequestHandler):
     )
 
   def _authorized(self) -> bool:
-    expected = b"Bearer " + _startup_token()
-    supplied = self.headers.get("Authorization", "").encode("utf-8")
-    if not hmac.compare_digest(supplied, expected):
+    values = self.headers.get_all("Authorization", failobj=[]) or []
+    supplied_buffer: bytearray | None = None
+    authorized = False
+    if len(values) == 1 and values[0].startswith("Bearer "):
+      try:
+        supplied_buffer = bytearray(values[0][7:], "ascii")
+        _validate_token(supplied_buffer)
+      except (UnicodeEncodeError, RuntimeError):
+        pass
+      else:
+        supplied_digest = _token_digest(supplied_buffer)
+        authorized = hmac.compare_digest(
+          supplied_digest, _startup_token_digest()
+        )
+      finally:
+        if supplied_buffer is not None:
+          for index in range(len(supplied_buffer)):
+            supplied_buffer[index] = 0
+    values.clear()
+    if not authorized:
       self._send(
         HTTPStatus.UNAUTHORIZED,
         {"error": {"code": "unauthorized", "message": "invalid bearer token"}},

--- a/backend/recovery_target/targetd.py
+++ b/backend/recovery_target/targetd.py
@@ -31,7 +31,10 @@ from typing import Any
 
 PROTOCOL = "mobius-recovery-target/v1"
 DEFAULT_PORT = 18002
-MAX_REQUEST_BYTES = 8 * 1024 * 1024
+# An 8 MiB decoded payload expands to about 10.67 MiB as base64 before the JSON
+# envelope is counted. Keep the wire budget large enough for the advertised
+# file/stdin boundary while still rejecting unbounded request bodies.
+MAX_REQUEST_BYTES = 12 * 1024 * 1024
 MAX_FILE_BYTES = 8 * 1024 * 1024
 MAX_OUTPUT_BYTES = 4 * 1024 * 1024
 MAX_LIST_ENTRIES = 10_000
@@ -39,6 +42,7 @@ MAX_LIST_RESPONSE_BYTES = 8 * 1024 * 1024
 DEFAULT_TIMEOUT_SECONDS = 120.0
 MAX_TIMEOUT_SECONDS = 900.0
 MAX_ENV_ITEMS = 128
+MAX_ENV_BYTES = 256 * 1024
 MAX_CONCURRENT_EXEC = 2
 _EXEC_SLOTS = threading.BoundedSemaphore(MAX_CONCURRENT_EXEC)
 
@@ -157,6 +161,7 @@ def _run_exec(body: dict[str, Any]) -> dict[str, Any]:
     ),
     "DATA_DIR": os.environ.get("DATA_DIR", "/data"),
   }
+  requested_env_bytes = 0
   for key, value in requested_env.items():
     if (
       not isinstance(key, str)
@@ -167,8 +172,16 @@ def _run_exec(body: dict[str, Any]) -> dict[str, Any]:
       or "\x00" in value
     ):
       raise RequestError("invalid_request", "env keys and values must be strings")
-    if len(key) > 256 or len(value.encode("utf-8")) > 64 * 1024:
+    key_bytes = len(key.encode("utf-8"))
+    value_bytes = len(value.encode("utf-8"))
+    if key_bytes > 256 or value_bytes > 64 * 1024:
       raise RequestError("invalid_request", "env key or value is too large")
+    requested_env_bytes += key_bytes + value_bytes
+    if requested_env_bytes > MAX_ENV_BYTES:
+      raise RequestError(
+        "invalid_request",
+        f"env exceeds {MAX_ENV_BYTES} aggregate UTF-8 bytes",
+      )
     env[key] = value
 
   if "stdin" in body and "stdin_base64" in body:

--- a/backend/recovery_target/targetd.py
+++ b/backend/recovery_target/targetd.py
@@ -35,6 +35,7 @@ MAX_REQUEST_BYTES = 8 * 1024 * 1024
 MAX_FILE_BYTES = 8 * 1024 * 1024
 MAX_OUTPUT_BYTES = 4 * 1024 * 1024
 MAX_LIST_ENTRIES = 10_000
+MAX_LIST_RESPONSE_BYTES = 8 * 1024 * 1024
 DEFAULT_TIMEOUT_SECONDS = 120.0
 MAX_TIMEOUT_SECONDS = 900.0
 MAX_ENV_ITEMS = 128
@@ -274,8 +275,6 @@ def _run_exec(body: dict[str, Any]) -> dict[str, Any]:
     elapsed_ms = round((time.monotonic() - started) * 1000)
     return {
       "exit_code": exit_code,
-      "stdout": bytes(output["stdout"]).decode("utf-8", "replace"),
-      "stderr": bytes(output["stderr"]).decode("utf-8", "replace"),
       "stdout_base64": base64.b64encode(output["stdout"]).decode("ascii"),
       "stderr_base64": base64.b64encode(output["stderr"]).decode("ascii"),
       "truncated": truncated,
@@ -382,6 +381,7 @@ def _list_directory(body: dict[str, Any]) -> dict[str, Any]:
   path = _absolute_path(body.get("path"))
   try:
     entries: list[dict[str, Any]] = []
+    encoded_bytes = len(str(path).encode("utf-8")) + 64
     with os.scandir(path) as iterator:
       for entry in iterator:
         if len(entries) >= MAX_LIST_ENTRIES:
@@ -408,6 +408,15 @@ def _list_directory(body: dict[str, Any]) -> dict[str, Any]:
         }
         if kind == "symlink":
           item["target"] = os.readlink(entry.path)
+        encoded_bytes += len(
+          json.dumps(item, separators=(",", ":")).encode("utf-8")
+        ) + 1
+        if encoded_bytes > MAX_LIST_RESPONSE_BYTES:
+          raise RequestError(
+            "response_too_large",
+            f"directory metadata exceeds {MAX_LIST_RESPONSE_BYTES} bytes",
+            HTTPStatus.UNPROCESSABLE_ENTITY,
+          )
         entries.append(item)
     entries.sort(key=lambda item: item["name"])
     return {"path": str(path), "entries": entries}

--- a/backend/recovery_target/targetd.py
+++ b/backend/recovery_target/targetd.py
@@ -23,6 +23,7 @@ import signal
 import socket
 import stat
 import subprocess
+import sys
 import threading
 import time
 from http import HTTPStatus
@@ -47,6 +48,8 @@ _PR_CAPBSET_DROP = 24
 _PR_CAP_AMBIENT = 47
 _PR_CAP_AMBIENT_IS_SET = 1
 _PR_CAP_AMBIENT_CLEAR_ALL = 4
+_PR_SET_CHILD_SUBREAPER = 36
+_PR_GET_CHILD_SUBREAPER = 37
 _SYS_OPENAT2 = 437
 _RESOLVE_NO_XDEV = 0x01
 _RESOLVE_NO_MAGICLINKS = 0x02
@@ -65,8 +68,15 @@ MAX_TIMEOUT_SECONDS = 900.0
 MAX_ENV_ITEMS = 128
 MAX_ENV_BYTES = 256 * 1024
 MAX_CONCURRENT_EXEC = 2
+MAX_TARGET_LIFETIME_SECONDS = 24 * 60 * 60
 _EXEC_SLOTS = threading.BoundedSemaphore(MAX_CONCURRENT_EXEC)
+_ACTIVE_SUPERVISORS: set[int] = set()
+_ACTIVE_SUPERVISORS_LOCK = threading.Lock()
 _STARTUP_TOKEN_DIGEST: bytes | None = None
+_TARGET_EXPIRES_AT: int | None = None
+_TARGET_EXPIRED = threading.Event()
+_TARGET_REVOCATION_LOCK = threading.Lock()
+_TARGET_SHUTDOWN_STARTED = False
 _BUILD_REVISION = "unknown"
 _DATA_ROOT = Path(os.environ.get("DATA_DIR", "/data"))
 # Convenience file operations are deliberately narrower than root exec. They
@@ -216,6 +226,30 @@ def _set_process_nondumpable() -> None:
     raise RuntimeError(f"could not disable process dumpability: errno {error}")
 
 
+def _set_child_subreaper() -> None:
+  """Keep every orphaned repair process below this immutable PID1.
+
+  PID 1 is already the final reparenting point in a container PID namespace,
+  but setting and verifying the Linux subreaper bit makes that dependency
+  explicit and gives the per-exec supervisor the same fail-closed primitive.
+  """
+  libc = ctypes.CDLL(None, use_errno=True)
+  prctl = getattr(libc, "prctl", None)
+  if prctl is None:
+    raise RuntimeError("recovery target requires Linux prctl")
+  if prctl(_PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0) != 0:
+    error = ctypes.get_errno()
+    raise RuntimeError(f"could not become a child subreaper: errno {error}")
+  enabled = ctypes.c_int(0)
+  if prctl(
+    _PR_GET_CHILD_SUBREAPER, ctypes.byref(enabled), 0, 0, 0,
+  ) != 0:
+    error = ctypes.get_errno()
+    raise RuntimeError(f"could not verify child subreaper state: errno {error}")
+  if enabled.value != 1:
+    raise RuntimeError("kernel ignored child subreaper configuration")
+
+
 def _assert_clean_initial_environment() -> None:
   """Proves the exec environment itself never received the bearer."""
   if "MOBIUS_RECOVERY_TARGET_TOKEN" in os.environ:
@@ -271,6 +305,43 @@ def _read_startup_token_digest() -> bytes:
       value[index] = 0
 
 
+def _read_target_expiry() -> int:
+  """Consume a bounded absolute deadline for the root capability."""
+  raw = os.environ.pop("MOBIUS_RECOVERY_TARGET_EXPIRES_AT", "")
+  if not raw.isascii() or not raw.isdecimal() or len(raw) > 10:
+    raise RuntimeError(
+      "MOBIUS_RECOVERY_TARGET_EXPIRES_AT must be an epoch integer"
+    )
+  expires_at = int(raw)
+  now = int(time.time())
+  if expires_at <= now:
+    raise RuntimeError("recovery target expiry must be in the future")
+  if expires_at > now + MAX_TARGET_LIFETIME_SECONDS:
+    raise RuntimeError(
+      "recovery target expiry exceeds the maximum 24-hour lifetime"
+    )
+  return expires_at
+
+
+def _target_is_expired() -> bool:
+  expires_at = _TARGET_EXPIRES_AT
+  if _TARGET_EXPIRED.is_set() or expires_at is None:
+    return True
+  if time.time() >= expires_at:
+    _TARGET_EXPIRED.set()
+    return True
+  return False
+
+
+def _require_active_target() -> None:
+  if _target_is_expired():
+    raise RequestError(
+      "auth_expired",
+      "recovery target capability has expired",
+      HTTPStatus.UNAUTHORIZED,
+    )
+
+
 def _load_baked_build_revision() -> str:
   try:
     value = BUILD_REVISION_PATH.read_text(encoding="ascii").strip().lower()
@@ -283,7 +354,7 @@ def _load_baked_build_revision() -> str:
 
 def _initialize_startup_security(*, require_pid_one: bool = True) -> None:
   """Loads immutable identity + bearer before any request can be accepted."""
-  global _BUILD_REVISION, _STARTUP_TOKEN_DIGEST
+  global _BUILD_REVISION, _STARTUP_TOKEN_DIGEST, _TARGET_EXPIRES_AT
   if require_pid_one and os.getpid() != 1:
     raise RuntimeError(
       "recovery target must be container pid 1 so no parent retains its bearer"
@@ -294,6 +365,8 @@ def _initialize_startup_security(*, require_pid_one: bool = True) -> None:
   _assert_fs_policy_supported()
   _drop_recovery_escape_capabilities()
   _set_process_nondumpable()
+  _set_child_subreaper()
+  _TARGET_EXPIRES_AT = _read_target_expiry()
   _STARTUP_TOKEN_DIGEST = _read_startup_token_digest()
   _BUILD_REVISION = _load_baked_build_revision()
 
@@ -463,16 +536,268 @@ def _decode_base64(value: Any, field: str) -> bytes:
   return decoded
 
 
-def _kill_process_group(process: subprocess.Popen[bytes]) -> None:
-  if process.poll() is not None:
+def _process_record(pid: int) -> tuple[int, int] | None:
+  """Return ``(ppid, starttime)`` from proc without trusting process names."""
+  try:
+    raw = Path(f"/proc/{pid}/stat").read_text(encoding="ascii")
+    tail = raw[raw.rindex(")") + 2:].split()
+    return int(tail[1]), int(tail[19])
+  except (OSError, ValueError, IndexError):
+    return None
+
+
+def _process_snapshot() -> dict[int, tuple[int, int]]:
+  snapshot: dict[int, tuple[int, int]] = {}
+  try:
+    entries = os.scandir("/proc")
+  except OSError:
+    return snapshot
+  with entries:
+    for entry in entries:
+      if not entry.name.isdecimal():
+        continue
+      pid = int(entry.name)
+      record = _process_record(pid)
+      if record is not None:
+        snapshot[pid] = record
+  return snapshot
+
+
+def _descendant_snapshot(
+  root_pid: int,
+) -> dict[int, tuple[int, int, int]]:
+  """Return descendants as ``pid -> (ppid, starttime, depth)``."""
+  processes = _process_snapshot()
+  descendants: dict[int, tuple[int, int, int]] = {}
+  frontier = {root_pid}
+  depth = 1
+  while frontier:
+    found = {
+      pid for pid, (ppid, _starttime) in processes.items()
+      if ppid in frontier and pid != root_pid and pid not in descendants
+    }
+    for pid in found:
+      ppid, starttime = processes[pid]
+      descendants[pid] = (ppid, starttime, depth)
+    frontier = found
+    depth += 1
+  return descendants
+
+
+def _signal_recorded_process(pid: int, starttime: int, signum: int) -> None:
+  current = _process_record(pid)
+  if current is None or current[1] != starttime:
     return
   try:
-    os.killpg(process.pid, signal.SIGKILL)
+    os.kill(pid, signum)
   except ProcessLookupError:
     pass
 
 
+def _stop_and_kill_descendants(root_pid: int) -> None:
+  """Freeze then kill a whole process tree, including new sessions.
+
+  The exec supervisor is a child subreaper, so double-forked and ``setsid``
+  processes remain descendants of this one stable root. Freezing ancestors
+  before the final scan closes the fork-while-cleaning race.
+  """
+  descendants = _descendant_snapshot(root_pid)
+  for pid, (_ppid, starttime, depth) in sorted(
+    descendants.items(), key=lambda item: item[1][2],
+  ):
+    _signal_recorded_process(pid, starttime, signal.SIGSTOP)
+  # A child could fork between the first snapshot and SIGSTOP delivery.
+  descendants.update(_descendant_snapshot(root_pid))
+  for pid, (_ppid, starttime, depth) in sorted(
+    descendants.items(), key=lambda item: item[1][2], reverse=True,
+  ):
+    _signal_recorded_process(pid, starttime, signal.SIGKILL)
+
+
+def _reap_all_children(deadline: float) -> None:
+  while time.monotonic() < deadline:
+    reaped = False
+    while True:
+      try:
+        pid, _status = os.waitpid(-1, os.WNOHANG)
+      except ChildProcessError:
+        return
+      if pid == 0:
+        break
+      reaped = True
+    if not reaped:
+      time.sleep(0.01)
+
+
+def _retire_untracked_target_children() -> None:
+  """Kill/reap only children not owned by another concurrent exec."""
+  with _ACTIVE_SUPERVISORS_LOCK:
+    active = set(_ACTIVE_SUPERVISORS)
+    snapshot = _process_snapshot()
+    roots = {
+      pid: starttime
+      for pid, (ppid, starttime) in snapshot.items()
+      if ppid == os.getpid() and pid not in active
+    }
+    for pid in roots:
+      _stop_and_kill_descendants(pid)
+    for pid, starttime in roots.items():
+      _signal_recorded_process(pid, starttime, signal.SIGKILL)
+    deadline = time.monotonic() + 1.0
+    for pid in roots:
+      while time.monotonic() < deadline:
+        try:
+          waited, _status = os.waitpid(pid, os.WNOHANG)
+        except ChildProcessError:
+          break
+        if waited == pid:
+          break
+        time.sleep(0.01)
+
+
+def _request_supervisor_termination(process: subprocess.Popen[bytes]) -> None:
+  if process.poll() is not None:
+    return
+  try:
+    os.kill(process.pid, signal.SIGTERM)
+  except ProcessLookupError:
+    pass
+
+
+def _force_kill_supervisor(process: subprocess.Popen[bytes]) -> None:
+  if process.poll() is not None:
+    return
+  _stop_and_kill_descendants(process.pid)
+  try:
+    os.kill(process.pid, signal.SIGKILL)
+  except ProcessLookupError:
+    pass
+
+
+def _retire_active_supervisors(*, force: bool) -> None:
+  """Stop every in-flight root command when the capability expires."""
+  with _ACTIVE_SUPERVISORS_LOCK:
+    active = list(_ACTIVE_SUPERVISORS)
+  for pid in active:
+    record = _process_record(pid)
+    if record is None:
+      continue
+    _ppid, starttime = record
+    if force:
+      _stop_and_kill_descendants(pid)
+      _signal_recorded_process(pid, starttime, signal.SIGKILL)
+    else:
+      _signal_recorded_process(pid, starttime, signal.SIGTERM)
+
+
+def _revoke_target(server: Any) -> None:
+  """Revoke once, close the listener, and leave PID1 parked without restart."""
+  global _STARTUP_TOKEN_DIGEST, _TARGET_SHUTDOWN_STARTED
+  with _TARGET_REVOCATION_LOCK:
+    _TARGET_EXPIRED.set()
+    # Only a one-way digest survives startup, but discard even that verifier
+    # at expiry. Every request checks the sticky expiry event before auth.
+    _STARTUP_TOKEN_DIGEST = None
+    if _TARGET_SHUTDOWN_STARTED:
+      return
+    _TARGET_SHUTDOWN_STARTED = True
+
+  _retire_active_supervisors(force=False)
+  try:
+    # Called by a timer or request thread, never the serve_forever thread.
+    server.shutdown()
+  finally:
+    # Graceful supervisor termination owns normal tree cleanup. This forced
+    # pass closes the small race where a hostile child delays that cleanup.
+    _retire_active_supervisors(force=True)
+
+
+def _read_supervisor_config(fd: int) -> dict[str, Any]:
+  payload = bytearray()
+  try:
+    while len(payload) <= MAX_REQUEST_BYTES:
+      chunk = os.read(fd, min(64 * 1024, MAX_REQUEST_BYTES + 1 - len(payload)))
+      if not chunk:
+        break
+      payload.extend(chunk)
+  finally:
+    os.close(fd)
+  if len(payload) > MAX_REQUEST_BYTES:
+    raise RuntimeError("exec supervisor configuration is too large")
+  try:
+    value = json.loads(payload.decode("utf-8"))
+  except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+    raise RuntimeError("exec supervisor configuration is invalid") from exc
+  if not isinstance(value, dict):
+    raise RuntimeError("exec supervisor configuration is invalid")
+  return value
+
+
+def _supervisor_exit_code(returncode: int) -> int:
+  if returncode < 0:
+    return min(255, 128 - returncode)
+  return min(255, returncode)
+
+
+def _exec_supervisor_main(raw_fd: str) -> int:
+  """Own one repair process tree until every descendant has been reaped."""
+  if not raw_fd.isdecimal() or int(raw_fd) < 3:
+    print("recovery exec supervisor received an invalid descriptor", file=sys.stderr)
+    return 125
+  try:
+    _set_child_subreaper()
+    config = _read_supervisor_config(int(raw_fd))
+    argv = config["argv"]
+    cwd = config["cwd"]
+    env = config["env"]
+    if not isinstance(argv, list) or not argv or not isinstance(cwd, str):
+      raise RuntimeError("exec supervisor configuration is invalid")
+    if not isinstance(env, dict):
+      raise RuntimeError("exec supervisor configuration is invalid")
+  except (KeyError, OSError, RuntimeError) as exc:
+    print(f"recovery exec supervisor failed to initialize: {exc}", file=sys.stderr)
+    return 125
+
+  termination_signal: list[int | None] = [None]
+
+  def terminate(signum: int, _frame: object) -> None:
+    termination_signal[0] = signum
+
+  for signum in (signal.SIGHUP, signal.SIGINT, signal.SIGTERM):
+    signal.signal(signum, terminate)
+
+  child: subprocess.Popen[bytes] | None = None
+  returncode = 125
+  try:
+    child = subprocess.Popen(argv, cwd=cwd, env=env)
+    while True:
+      if termination_signal[0] is not None:
+        returncode = 128 + int(termination_signal[0])
+        break
+      polled = child.poll()
+      if polled is not None:
+        returncode = _supervisor_exit_code(polled)
+        break
+      time.sleep(0.01)
+  except OSError as exc:
+    print(f"recovery exec supervisor could not start command: {exc}", file=sys.stderr)
+  finally:
+    # This is intentionally unconditional after the direct command exits.
+    # Background/setsid/double-fork children are never durable recovery state.
+    deadline = time.monotonic() + 2.0
+    while time.monotonic() < deadline:
+      descendants = _descendant_snapshot(os.getpid())
+      if not descendants:
+        break
+      _stop_and_kill_descendants(os.getpid())
+      _reap_all_children(min(deadline, time.monotonic() + 0.25))
+    _stop_and_kill_descendants(os.getpid())
+    _reap_all_children(deadline)
+  return returncode
+
+
 def _run_exec(body: dict[str, Any]) -> dict[str, Any]:
+  _require_active_target()
   argv = body.get("argv")
   if (
     not isinstance(argv, list)
@@ -560,17 +885,48 @@ def _run_exec(body: dict[str, Any]) -> dict[str, Any]:
     )
   started = time.monotonic()
   process: subprocess.Popen[bytes] | None = None
+  config_read_fd: int | None = None
+  config_write_fd: int | None = None
   try:
     try:
-      process = subprocess.Popen(
-        argv,
-        cwd=str(cwd),
-        env=env,
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        start_new_session=True,
-      )
+      config_read_fd, config_write_fd = os.pipe()
+      supervisor_env = {
+        "HOME": "/root",
+        "LANG": os.environ.get("LANG", "C.UTF-8"),
+        "PATH": os.environ.get(
+          "PATH", "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        ),
+        "DATA_DIR": os.environ.get("DATA_DIR", "/data"),
+      }
+      with _ACTIVE_SUPERVISORS_LOCK:
+        process = subprocess.Popen(
+          [
+            sys.executable, "-I", str(Path(__file__).resolve()),
+            "--exec-supervisor", str(config_read_fd),
+          ],
+          cwd="/",
+          env=supervisor_env,
+          stdin=subprocess.PIPE,
+          stdout=subprocess.PIPE,
+          stderr=subprocess.PIPE,
+          start_new_session=True,
+          pass_fds=(config_read_fd,),
+        )
+        _ACTIVE_SUPERVISORS.add(process.pid)
+      os.close(config_read_fd)
+      config_read_fd = None
+      config_payload = json.dumps({
+        "argv": argv,
+        "cwd": str(cwd),
+        "env": env,
+      }, separators=(",", ":")).encode("utf-8")
+      config_offset = 0
+      while config_offset < len(config_payload):
+        config_offset += os.write(
+          config_write_fd, config_payload[config_offset:],
+        )
+      os.close(config_write_fd)
+      config_write_fd = None
     except OSError as exc:
       raise RequestError(
         "exec_failed", str(exc), HTTPStatus.UNPROCESSABLE_ENTITY
@@ -592,11 +948,18 @@ def _run_exec(body: dict[str, Any]) -> dict[str, Any]:
     output = {"stdout": bytearray(), "stderr": bytearray()}
     truncated = False
     timed_out = False
+    termination_requested_at: float | None = None
+    process_exited_at: float | None = None
     while selector.get_map():
+      if _target_is_expired() and termination_requested_at is None:
+        termination_requested_at = time.monotonic()
+        _request_supervisor_termination(process)
       remaining = timeout - (time.monotonic() - started)
       if remaining <= 0:
         timed_out = True
-        _kill_process_group(process)
+        if termination_requested_at is None:
+          termination_requested_at = time.monotonic()
+          _request_supervisor_termination(process)
         remaining = 0.1
       events = selector.select(min(max(remaining, 0.01), 0.25))
       for key, _mask in events:
@@ -626,15 +989,45 @@ def _run_exec(body: dict[str, Any]) -> dict[str, Any]:
           target.extend(chunk[:room])
         if len(chunk) > room:
           truncated = True
-          _kill_process_group(process)
+          if termination_requested_at is None:
+            termination_requested_at = time.monotonic()
+            _request_supervisor_termination(process)
 
       if process.poll() is not None:
+        if process_exited_at is None:
+          process_exited_at = time.monotonic()
         # Pipes may still contain a final kernel-buffered chunk. Keep draining
-        # them, but an unwritten stdin pipe can now be retired.
+        # briefly, but never let an escaped descriptor holder defeat the API's
+        # timeout after its per-exec supervisor has exited.
         if process.stdin in [item.fileobj for item in selector.get_map().values()]:
           selector.unregister(process.stdin)
           process.stdin.close()
-    exit_code = process.wait(timeout=2)
+        if time.monotonic() - process_exited_at >= 0.5:
+          for item in list(selector.get_map().values()):
+            stream = item.fileobj
+            selector.unregister(stream)
+            stream.close()
+          break
+      elif (
+        termination_requested_at is not None
+        and time.monotonic() - termination_requested_at >= 3.0
+      ):
+        _force_kill_supervisor(process)
+    try:
+      exit_code = process.wait(timeout=2)
+    except subprocess.TimeoutExpired:
+      # A supervisor that has closed its pipes but has not exited is not a
+      # completed repair command. Kill it before reporting a target failure so
+      # callers can never mistake an uncontained process for a clean result.
+      _force_kill_supervisor(process)
+      try:
+        exit_code = process.wait(timeout=1)
+      except subprocess.TimeoutExpired as final_exc:
+        raise RequestError(
+          "exec_cleanup_failed",
+          "repair process supervisor could not be retired",
+          HTTPStatus.INTERNAL_SERVER_ERROR,
+        ) from final_exc
     elapsed_ms = round((time.monotonic() - started) * 1000)
     return {
       "exit_code": exit_code,
@@ -645,16 +1038,31 @@ def _run_exec(body: dict[str, Any]) -> dict[str, Any]:
       "duration_ms": elapsed_ms,
     }
   finally:
+    for fd in (config_read_fd, config_write_fd):
+      if fd is not None:
+        try:
+          os.close(fd)
+        except OSError:
+          pass
     if process is not None and process.poll() is None:
-      _kill_process_group(process)
+      _request_supervisor_termination(process)
       try:
         process.wait(timeout=2)
       except subprocess.TimeoutExpired:
-        pass
+        _force_kill_supervisor(process)
+        try:
+          process.wait(timeout=1)
+        except subprocess.TimeoutExpired:
+          pass
+    if process is not None:
+      with _ACTIVE_SUPERVISORS_LOCK:
+        _ACTIVE_SUPERVISORS.discard(process.pid)
+    _retire_untracked_target_children()
     _EXEC_SLOTS.release()
 
 
 def _read_file(body: dict[str, Any]) -> dict[str, Any]:
+  _require_active_target()
   path = _absolute_path(body.get("path"))
   offset = _bounded_int(
     body.get("offset"), field="offset", default=0, minimum=0, maximum=2**63 - 1
@@ -704,6 +1112,7 @@ def _read_file(body: dict[str, Any]) -> dict[str, Any]:
 
 
 def _write_file(body: dict[str, Any]) -> dict[str, Any]:
+  _require_active_target()
   path = _absolute_path(body.get("path"))
   data = _decode_base64(body.get("data_base64"), "data_base64")
   mode = _bounded_int(
@@ -773,6 +1182,7 @@ def _write_file(body: dict[str, Any]) -> dict[str, Any]:
 
 
 def _list_directory(body: dict[str, Any]) -> dict[str, Any]:
+  _require_active_target()
   path = _absolute_path(body.get("path"))
   directory_fd: int | None = None
   try:
@@ -856,6 +1266,18 @@ class _Handler(BaseHTTPRequestHandler):
     )
 
   def _authorized(self) -> bool:
+    if _target_is_expired():
+      _revoke_target(self.server)
+      self._send(
+        HTTPStatus.UNAUTHORIZED,
+        {
+          "error": {
+            "code": "auth_expired",
+            "message": "recovery target capability has expired",
+          }
+        },
+      )
+      return False
     values = self.headers.get_all("Authorization", failobj=[]) or []
     supplied_buffer: bytearray | None = None
     authorized = False
@@ -867,14 +1289,30 @@ class _Handler(BaseHTTPRequestHandler):
         pass
       else:
         supplied_digest = _token_digest(supplied_buffer)
-        authorized = hmac.compare_digest(
-          supplied_digest, _startup_token_digest()
-        )
+        try:
+          expected_digest = _startup_token_digest()
+        except RuntimeError:
+          expected_digest = b""
+        authorized = hmac.compare_digest(supplied_digest, expected_digest)
       finally:
         if supplied_buffer is not None:
           for index in range(len(supplied_buffer)):
             supplied_buffer[index] = 0
     values.clear()
+    # Close the compare-vs-deadline race: expiry is sticky, so even a wall-clock
+    # adjustment cannot make a revoked capability valid again.
+    if _target_is_expired():
+      _revoke_target(self.server)
+      self._send(
+        HTTPStatus.UNAUTHORIZED,
+        {
+          "error": {
+            "code": "auth_expired",
+            "message": "recovery target capability has expired",
+          }
+        },
+      )
+      return False
     if not authorized:
       self._send(
         HTTPStatus.UNAUTHORIZED,
@@ -920,6 +1358,7 @@ class _Handler(BaseHTTPRequestHandler):
       "target": "mobius",
       "mode": "recovery",
       "build_sha": _BUILD_REVISION,
+      "expires_at": _TARGET_EXPIRES_AT,
     })
 
   def do_POST(self) -> None:  # noqa: N802
@@ -982,6 +1421,30 @@ def _create_server(port: int) -> ThreadingHTTPServer:
     return _IPv4Server(("0.0.0.0", port), _Handler)
 
 
+def _schedule_target_expiry(server: ThreadingHTTPServer) -> threading.Timer:
+  expires_at = _TARGET_EXPIRES_AT
+  if expires_at is None:
+    raise RuntimeError("recovery target expiry is not initialized")
+  delay = max(0.0, expires_at - time.time())
+  timer = threading.Timer(delay, _revoke_target, args=(server,))
+  timer.daemon = True
+  timer.start()
+  return timer
+
+
+def _park_expired_target() -> None:
+  """Keep an expired PID1 quiescent so restart policies cannot hot-loop."""
+  stopped = threading.Event()
+
+  def stop(_signum: int, _frame: object) -> None:
+    stopped.set()
+
+  for signum in (signal.SIGHUP, signal.SIGINT, signal.SIGTERM):
+    signal.signal(signum, stop)
+  while not stopped.wait(3600):
+    pass
+
+
 def main() -> None:
   if os.environ.get("MOBIUS_BOOT_MODE") != "recovery":
     raise SystemExit("recovery target refuses to run outside recovery boot mode")
@@ -1006,8 +1469,21 @@ def main() -> None:
     f"Mobius recovery target {PROTOCOL} listening privately on [::]:{port}",
     flush=True,
   )
-  server.serve_forever(poll_interval=0.25)
+  expiry_timer = _schedule_target_expiry(server)
+  try:
+    server.serve_forever(poll_interval=0.25)
+  finally:
+    expiry_timer.cancel()
+    server.server_close()
+  if _TARGET_EXPIRED.is_set():
+    print(
+      "recovery-target: capability expired; listener closed and PID1 parked",
+      flush=True,
+    )
+    _park_expired_target()
 
 
 if __name__ == "__main__":
+  if len(sys.argv) == 3 and sys.argv[1] == "--exec-supervisor":
+    raise SystemExit(_exec_supervisor_main(sys.argv[2]))
   main()

--- a/backend/scripts/agent_sudo.sh
+++ b/backend/scripts/agent_sudo.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Configure the externally-owned root capability before the entrypoint drops
+# privileges. This file is baked root-owned; the live platform never sources it.
+
+configure_agent_sudo() {
+  _sudo_mode="${1:-0}"
+  _sudo_dir="${2:-/etc/sudoers.d}"
+  _visudo="${3:-/usr/sbin/visudo}"
+  rm -f "$_sudo_dir/mobius-apt" "$_sudo_dir/mobius-agent"
+  case "$_sudo_mode" in
+    0)
+      return 0
+      ;;
+    1)
+      printf 'mobius ALL=(root) NOPASSWD: ALL\n' > "$_sudo_dir/mobius-agent" || return 1
+      chmod 440 "$_sudo_dir/mobius-agent" || return 1
+      "$_visudo" -cf "$_sudo_dir/mobius-agent" >/dev/null || {
+        rm -f "$_sudo_dir/mobius-agent"
+        return 1
+      }
+      return 0
+      ;;
+    *)
+      echo "FATAL: MOBIUS_AGENT_SUDO must be 0 or 1." >&2
+      return 64
+      ;;
+  esac
+}

--- a/backend/scripts/entrypoint.sh
+++ b/backend/scripts/entrypoint.sh
@@ -9,6 +9,28 @@
 case "${MOBIUS_BOOT_MODE:-normal}" in
   normal) ;;
   recovery)
+    # Never exec the target with its bearer in the process environment. Linux
+    # exposes the original exec environment through /proc even after unsetenv,
+    # so move the secret through an unlinked, inherited descriptor and build a
+    # fresh Python environment without it. The target closes fd 3 before it
+    # starts listening and refuses to run unless it is container pid 1.
+    _recovery_target_token=${MOBIUS_RECOVERY_TARGET_TOKEN:-}
+    unset MOBIUS_RECOVERY_TARGET_TOKEN
+    umask 077
+    _recovery_token_file=$(mktemp /tmp/mobius-recovery-target-token.XXXXXX) || {
+      echo "FATAL: could not allocate recovery target secret descriptor." >&2
+      exit 70
+    }
+    if ! printf '%s' "$_recovery_target_token" > "$_recovery_token_file"; then
+      rm -f "$_recovery_token_file"
+      echo "FATAL: could not stage recovery target secret." >&2
+      exit 70
+    fi
+    exec 3< "$_recovery_token_file"
+    rm -f "$_recovery_token_file"
+    unset _recovery_target_token _recovery_token_file
+    MOBIUS_RECOVERY_TARGET_TOKEN_FD=3
+    export MOBIUS_RECOVERY_TARGET_TOKEN_FD
     exec python3 -I /app/recovery-target/targetd.py
     ;;
   *)

--- a/backend/scripts/entrypoint.sh
+++ b/backend/scripts/entrypoint.sh
@@ -5,7 +5,8 @@
 
 # Recovery target mode is an immutable, early boot path. It must run before
 # touching /data or importing any agent-editable platform code. The separate
-# recovery worker reaches this private listener with a one-time bearer token.
+# recovery worker reaches this private listener with a one-time bearer token
+# whose canonical base-10 epoch deadline is enforced by targetd itself.
 case "${MOBIUS_BOOT_MODE:-normal}" in
   normal) ;;
   recovery)

--- a/backend/scripts/entrypoint.sh
+++ b/backend/scripts/entrypoint.sh
@@ -3,6 +3,27 @@
 # the 'mobius' user for the actual server.  The non-root user allows
 # --dangerously-skip-permissions in the Claude CLI.
 
+# Recovery target mode is an immutable, early boot path. It must run before
+# touching /data or importing any agent-editable platform code. The separate
+# recovery worker reaches this private listener with a one-time bearer token.
+case "${MOBIUS_BOOT_MODE:-normal}" in
+  normal) ;;
+  recovery)
+    exec python3 -I /app/recovery-target/targetd.py
+    ;;
+  *)
+    echo "FATAL: MOBIUS_BOOT_MODE must be normal or recovery." >&2
+    exit 64
+    ;;
+esac
+
+# Root is an externally-controlled instance capability. There is deliberately
+# no partial apt/dpkg rule: package maintainer scripts already make that rule
+# equivalent to arbitrary root. Enabling this setting is therefore explicit
+# and honest; disabling it leaves the agent with no sudo path at all.
+. /app/scripts/agent_sudo.sh
+configure_agent_sudo "${MOBIUS_AGENT_SUDO:-0}" || exit $?
+
 # Stop cron on container shutdown so it doesn't orphan processes.
 cleanup() { kill "$(cat /var/run/crond.pid 2>/dev/null)" 2>/dev/null; }
 trap cleanup TERM INT

--- a/backend/tests/test_agent_sudo.py
+++ b/backend/tests/test_agent_sudo.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "agent_sudo.sh"
+
+
+def _configure(tmp_path: Path, mode: str) -> subprocess.CompletedProcess[str]:
+  return subprocess.run(
+    [
+      "/bin/sh", "-c",
+      '. "$1"; configure_agent_sudo "$2" "$3" /bin/true',
+      "test-agent-sudo", str(_SCRIPT), mode, str(tmp_path),
+    ],
+    text=True,
+    capture_output=True,
+    check=False,
+  )
+
+
+def test_sudo_disabled_removes_every_agent_rule(tmp_path):
+  (tmp_path / "mobius-apt").write_text("legacy")
+  (tmp_path / "mobius-agent").write_text("enabled")
+  result = _configure(tmp_path, "0")
+  assert result.returncode == 0
+  assert list(tmp_path.iterdir()) == []
+
+
+def test_sudo_enabled_is_full_root_and_not_misleading_apt_scope(tmp_path):
+  result = _configure(tmp_path, "1")
+  assert result.returncode == 0
+  rule = tmp_path / "mobius-agent"
+  assert rule.read_text() == "mobius ALL=(root) NOPASSWD: ALL\n"
+  assert os.stat(rule).st_mode & 0o777 == 0o440
+  assert not (tmp_path / "mobius-apt").exists()
+
+
+def test_sudo_mode_fails_closed_on_unknown_value(tmp_path):
+  result = _configure(tmp_path, "yes")
+  assert result.returncode == 64
+  assert "must be 0 or 1" in result.stderr
+  assert list(tmp_path.iterdir()) == []
+
+
+def test_recovery_mode_precedes_data_initialization_and_sudo_configuration():
+  entrypoint = (
+    Path(__file__).resolve().parents[1] / "scripts" / "entrypoint.sh"
+  ).read_text()
+  recovery_exec = entrypoint.index("exec python3 -I /app/recovery-target/targetd.py")
+  sudo_config = entrypoint.index("configure_agent_sudo")
+  data_init = entrypoint.index("mkdir -p /data/db")
+  assert recovery_exec < sudo_config < data_init

--- a/backend/tests/test_recovery_target.py
+++ b/backend/tests/test_recovery_target.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import errno
 import importlib.util
 import json
 import threading
@@ -70,6 +71,20 @@ def test_dual_stack_health_is_authenticated(target):
       "mode": "recovery",
       "build_sha": "unknown",
     }
+
+
+def test_listener_falls_back_to_ipv4_when_ipv6_is_unavailable(target, monkeypatch):
+  class NoIPv6:
+    def __init__(self, *_args, **_kwargs):
+      raise OSError(errno.EAFNOSUPPORT, "IPv6 disabled")
+
+  monkeypatch.setattr(target, "_DualStackServer", NoIPv6)
+  server = target._create_server(0)
+  try:
+    assert server.address_family == target.socket.AF_INET
+    assert server.server_address[0] == "0.0.0.0"
+  finally:
+    server.server_close()
 
 
 def test_exec_uses_argv_without_shell_and_does_not_inherit_target_token(

--- a/backend/tests/test_recovery_target.py
+++ b/backend/tests/test_recovery_target.py
@@ -29,7 +29,7 @@ def target(monkeypatch):
   assert spec and spec.loader
   module = importlib.util.module_from_spec(spec)
   spec.loader.exec_module(module)
-  module._STARTUP_TOKEN = b"t" * 43
+  module._STARTUP_TOKEN_DIGEST = module._token_digest(b"t" * 43)
   return module
 
 
@@ -167,6 +167,85 @@ def test_file_endpoints_work_over_http(target, tmp_path):
     assert base64.b64decode(read["data_base64"]) == b"network"
 
 
+@pytest.mark.parametrize("path", [
+  "/proc/1/maps",
+  "/proc/1/mem",
+  "/proc/1/environ",
+  "/sys/kernel",
+  "/dev/null",
+  "/etc/passwd",
+])
+def test_file_api_rejects_paths_outside_explicit_recovery_roots(target, path):
+  operations = (
+    (target._read_file, {"path": path}),
+    (target._list_directory, {"path": path}),
+    (target._write_file, {
+      "path": path,
+      "data_base64": base64.b64encode(b"blocked").decode("ascii"),
+    }),
+  )
+  for operation, body in operations:
+    with pytest.raises(target.RequestError) as denied:
+      operation(body)
+    assert denied.value.code == "path_forbidden"
+    assert denied.value.status == target.HTTPStatus.FORBIDDEN
+
+
+def test_file_api_rejects_dotdot_and_symlink_escapes(target, tmp_path):
+  proc_link = tmp_path / "proc-link"
+  proc_link.symlink_to("/proc", target_is_directory=True)
+  attempts = (
+    (target._read_file, {"path": "/tmp/../proc/1/maps"}),
+    (target._read_file, {"path": str(proc_link / "1" / "maps")}),
+    (target._list_directory, {"path": str(proc_link / "1")}),
+    (target._write_file, {
+      "path": str(proc_link / "forbidden"),
+      "data_base64": base64.b64encode(b"blocked").decode("ascii"),
+    }),
+  )
+  for operation, body in attempts:
+    with pytest.raises(target.RequestError) as denied:
+      operation(body)
+    assert denied.value.code == "path_forbidden"
+
+
+def test_file_api_preserves_relative_symlinks_within_one_allowed_mount(
+  target, tmp_path,
+):
+  real = tmp_path / "real"
+  real.mkdir()
+  (real / "existing").write_bytes(b"safe")
+  link = tmp_path / "internal-link"
+  link.symlink_to("real", target_is_directory=True)
+
+  read = target._read_file({"path": str(link / "existing")})
+  assert base64.b64decode(read["data_base64"]) == b"safe"
+  target._write_file({
+    "path": str(link / "created"),
+    "data_base64": base64.b64encode(b"written").decode("ascii"),
+  })
+  assert (real / "created").read_bytes() == b"written"
+
+
+def test_openat2_rejects_cross_mount_resolution(target):
+  root_fd = os.open("/", os.O_PATH | os.O_DIRECTORY)
+  try:
+    with pytest.raises(OSError) as denied:
+      target._openat2(root_fd, Path("proc/1/maps"), os.O_RDONLY)
+  finally:
+    os.close(root_fd)
+  assert denied.value.errno == errno.EXDEV
+
+
+def test_target_startup_fails_closed_without_openat2(target, monkeypatch):
+  def unavailable(*_args, **_kwargs):
+    raise OSError(errno.ENOSYS, "openat2 unavailable")
+
+  monkeypatch.setattr(target, "_openat2", unavailable)
+  with pytest.raises(RuntimeError, match="filesystem policy is unavailable"):
+    target._assert_fs_policy_supported()
+
+
 def test_exact_eight_mib_file_write_fits_wire_budget(target, tmp_path):
   payload = b"w" * target.MAX_FILE_BYTES
   path = tmp_path / "boundary.bin"
@@ -242,7 +321,15 @@ def test_target_token_fails_closed(target, value):
 def test_direct_secret_environment_is_rejected(target, monkeypatch):
   monkeypatch.setenv("MOBIUS_RECOVERY_TARGET_TOKEN", "s" * 43)
   with pytest.raises(RuntimeError, match="must not reach"):
-    target._read_startup_token()
+    target._read_startup_token_digest()
+
+
+def test_target_retains_only_a_one_way_bearer_verifier(target):
+  raw = b"t" * 43
+  assert not hasattr(target, "_STARTUP_TOKEN")
+  assert target._STARTUP_TOKEN_DIGEST == target._token_digest(raw)
+  assert len(target._STARTUP_TOKEN_DIGEST) == 32
+  assert target._STARTUP_TOKEN_DIGEST != raw
 
 
 def test_fd_secret_is_absent_from_target_and_root_exec_proc_environments(
@@ -273,7 +360,7 @@ spec = importlib.util.spec_from_file_location("subprocess_targetd", sys.argv[1])
 module = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(module)
 module.BUILD_REVISION_PATH = Path(sys.argv[2])
-module._drop_packet_capture_capabilities = lambda: None
+module._drop_recovery_escape_capabilities = lambda: None
 module._initialize_startup_security(require_pid_one=False)
 dumpable = ctypes.CDLL(None, use_errno=True).prctl(3, 0, 0, 0, 0)
 try:
@@ -331,10 +418,10 @@ print(json.dumps({
   assert payload["exec"]["exit_code"] != 0
 
 
-def test_packet_capabilities_are_removed_from_all_sets_and_bounding(
+def test_escape_capabilities_are_removed_from_all_sets_and_bounding(
   target, monkeypatch,
 ):
-  blocked = {target.CAP_NET_ADMIN, target.CAP_NET_RAW}
+  blocked = set(target._BLOCKED_CAPABILITIES)
   data = (target._CapabilityData * 2)()
   for capability in blocked:
     mask = 1 << (capability % 32)
@@ -376,7 +463,7 @@ def test_packet_capabilities_are_removed_from_all_sets_and_bounding(
     lambda _libc: (target._CapabilityHeader(), data),
   )
 
-  target._drop_packet_capture_capabilities()
+  target._drop_recovery_escape_capabilities()
 
   assert bounding == set()
   assert ambient == set()

--- a/backend/tests/test_recovery_target.py
+++ b/backend/tests/test_recovery_target.py
@@ -12,6 +12,7 @@ import threading
 import time
 import urllib.error
 import urllib.request
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -30,6 +31,7 @@ def target(monkeypatch):
   module = importlib.util.module_from_spec(spec)
   spec.loader.exec_module(module)
   module._STARTUP_TOKEN_DIGEST = module._token_digest(b"t" * 43)
+  module._TARGET_EXPIRES_AT = int(time.time()) + 3600
   return module
 
 
@@ -74,7 +76,52 @@ def test_dual_stack_health_is_authenticated(target):
       "target": "mobius",
       "mode": "recovery",
       "build_sha": "unknown",
+      "expires_at": target._TARGET_EXPIRES_AT,
     }
+
+
+def test_expired_target_rejects_a_valid_bearer_and_closes_listener(
+  target, monkeypatch,
+):
+  target._TARGET_EXPIRES_AT = 1_800_000_000
+  monkeypatch.setattr(target.time, "time", lambda: 1_800_000_000)
+  with _server(target) as url:
+    with pytest.raises(urllib.error.HTTPError) as expired:
+      _request(url, "/v1/health")
+    assert expired.value.code == 401
+    payload = json.load(expired.value)
+  assert payload["error"] == {
+    "code": "auth_expired",
+    "message": "recovery target capability has expired",
+  }
+  assert target._TARGET_EXPIRED.is_set()
+  assert target._STARTUP_TOKEN_DIGEST is None
+
+
+@pytest.mark.parametrize("raw", [
+  "",
+  "1800000000.5",
+  "-1800000000",
+  "1799999999",
+  "1800086401",
+  "99999999999",
+])
+def test_target_expiry_must_be_a_future_epoch_within_24_hours(
+  target, monkeypatch, raw,
+):
+  monkeypatch.setattr(target.time, "time", lambda: 1_800_000_000)
+  monkeypatch.setenv("MOBIUS_RECOVERY_TARGET_EXPIRES_AT", raw)
+  with pytest.raises(RuntimeError):
+    target._read_target_expiry()
+
+
+def test_target_expiry_accepts_the_24_hour_boundary(target, monkeypatch):
+  monkeypatch.setattr(target.time, "time", lambda: 1_800_000_000)
+  monkeypatch.setenv(
+    "MOBIUS_RECOVERY_TARGET_EXPIRES_AT",
+    str(1_800_000_000 + target.MAX_TARGET_LIFETIME_SECONDS),
+  )
+  assert target._read_target_expiry() == 1_800_086_400
 
 
 def test_listener_falls_back_to_ipv4_when_ipv6_is_unavailable(target, monkeypatch):
@@ -120,6 +167,105 @@ def test_exec_timeout_kills_the_process_group(target, tmp_path):
   assert result["timed_out"] is True
   assert result["exit_code"] != 0
   assert time.monotonic() - started < 3
+
+
+def test_exec_supervisor_kills_and_reaps_setsid_double_fork(
+  target, tmp_path,
+):
+  marker = tmp_path / "escaped.pid"
+  program = f'''
+import os
+import time
+
+pid = os.fork()
+if pid:
+  os._exit(0)
+os.setsid()
+pid = os.fork()
+if pid:
+  os._exit(0)
+with open({str(marker)!r}, "w", encoding="ascii") as target:
+  target.write(str(os.getpid()))
+time.sleep(30)
+'''
+  started = time.monotonic()
+  result = target._run_exec({
+    "argv": [sys.executable, "-c", program],
+    "cwd": str(tmp_path),
+    "timeout_seconds": 5,
+  })
+
+  assert result["exit_code"] == 0
+  assert result["timed_out"] is False
+  assert time.monotonic() - started < 3
+  escaped_pid = int(marker.read_text())
+  assert not Path(f"/proc/{escaped_pid}").exists()
+
+
+def test_exec_supervisor_kills_detached_child_that_closes_output_pipes(
+  target, tmp_path,
+):
+  marker = tmp_path / "detached.pid"
+  program = f'''
+import os
+import time
+
+pid = os.fork()
+if pid:
+  os._exit(0)
+os.setsid()
+for fd in (0, 1, 2):
+  try:
+    os.close(fd)
+  except OSError:
+    pass
+with open({str(marker)!r}, "w", encoding="ascii") as target:
+  target.write(str(os.getpid()))
+time.sleep(30)
+'''
+  result = target._run_exec({
+    "argv": [sys.executable, "-c", program],
+    "cwd": str(tmp_path),
+    "timeout_seconds": 5,
+  })
+
+  assert result["exit_code"] == 0
+  escaped_pid = int(marker.read_text())
+  assert not Path(f"/proc/{escaped_pid}").exists()
+
+
+def test_concurrent_exec_cleanup_does_not_kill_an_active_supervisor(
+  target, tmp_path,
+):
+  ready = tmp_path / "long-command.ready"
+  long_program = f'''
+import pathlib
+import time
+
+pathlib.Path({str(ready)!r}).touch()
+time.sleep(0.5)
+print("survived")
+'''
+  with ThreadPoolExecutor(max_workers=2) as executor:
+    long_result = executor.submit(target._run_exec, {
+      "argv": [sys.executable, "-c", long_program],
+      "cwd": str(tmp_path),
+      "timeout_seconds": 5,
+    })
+    deadline = time.monotonic() + 3
+    while not ready.exists() and time.monotonic() < deadline:
+      time.sleep(0.01)
+    assert ready.exists(), "long-running supervisor never became active"
+    short_result = executor.submit(target._run_exec, {
+      "argv": ["/bin/true"],
+      "cwd": str(tmp_path),
+      "timeout_seconds": 5,
+    })
+
+  assert short_result.result()["exit_code"] == 0
+  completed = long_result.result()
+  assert completed["exit_code"] == 0
+  assert base64.b64decode(completed["stdout_base64"]) == b"survived\n"
 
 
 def test_exec_output_is_bounded_and_process_is_killed(target, tmp_path, monkeypatch):
@@ -347,6 +493,7 @@ def test_fd_secret_is_absent_from_target_and_root_exec_proc_environments(
   env = os.environ.copy()
   env.pop("MOBIUS_RECOVERY_TARGET_TOKEN", None)
   env["MOBIUS_RECOVERY_TARGET_TOKEN_FD"] = str(read_fd)
+  env["MOBIUS_RECOVERY_TARGET_EXPIRES_AT"] = str(int(time.time()) + 3600)
   program = r'''
 import base64
 import ctypes
@@ -409,6 +556,7 @@ print(json.dumps({
   assert b"MOBIUS_RECOVERY_TARGET_TOKEN=" not in own_environment
   assert token not in command_stdout
   assert b"MOBIUS_RECOVERY_TARGET_TOKEN=" not in command_stdout
+  assert b"MOBIUS_RECOVERY_TARGET_EXPIRES_AT=" not in command_stdout
   # Root can read its own /proc/self/environ on some kernels even after
   # PR_SET_DUMPABLE=0. The security boundary is that the target is provably
   # non-dumpable and its root exec child cannot inspect the parent; the real

--- a/backend/tests/test_recovery_target.py
+++ b/backend/tests/test_recovery_target.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import base64
 import errno
 import importlib.util
+import io
 import json
 import threading
 import time
@@ -42,7 +43,7 @@ def _server(target):
     thread.join(timeout=2)
 
 
-def _request(url, path, *, token="t" * 43, body=None):
+def _request(url, path, *, token="t" * 43, body=None, timeout=15):
   headers = {"Authorization": f"Bearer {token}"}
   data = None
   method = "GET"
@@ -53,7 +54,7 @@ def _request(url, path, *, token="t" * 43, body=None):
   request = urllib.request.Request(
     url + path, data=data, headers=headers, method=method
   )
-  with urllib.request.urlopen(request, timeout=5) as response:
+  with urllib.request.urlopen(request, timeout=timeout) as response:
     return response.status, json.load(response)
 
 
@@ -161,6 +162,62 @@ def test_file_endpoints_work_over_http(target, tmp_path):
     assert write["bytes_written"] == 7
     _, read = _request(url, "/v1/fs/read", body={"path": str(path)})
     assert base64.b64decode(read["data_base64"]) == b"network"
+
+
+def test_exact_eight_mib_file_write_fits_wire_budget(target, tmp_path):
+  payload = b"w" * target.MAX_FILE_BYTES
+  path = tmp_path / "boundary.bin"
+  with _server(target) as url:
+    status, write = _request(url, "/v1/fs/write", body={
+      "path": str(path),
+      "data_base64": base64.b64encode(payload).decode("ascii"),
+    })
+  assert status == 200
+  assert write["bytes_written"] == 8 * 1024 * 1024
+  assert path.stat().st_size == 8 * 1024 * 1024
+
+
+def test_exact_eight_mib_exec_stdin_fits_wire_budget(target, tmp_path):
+  payload = b"s" * target.MAX_FILE_BYTES
+  with _server(target) as url:
+    status, result = _request(url, "/v1/exec", body={
+      "argv": ["/bin/sh", "-c", "wc -c"],
+      "cwd": str(tmp_path),
+      "stdin_base64": base64.b64encode(payload).decode("ascii"),
+    })
+  assert status == 200
+  assert result["exit_code"] == 0
+  assert int(base64.b64decode(result["stdout_base64"]).strip()) == 8 * 1024 * 1024
+
+
+def test_request_wire_budget_rejects_more_than_twelve_mib(target):
+  assert target.MAX_REQUEST_BYTES == 12 * 1024 * 1024
+  handler = object.__new__(target._Handler)
+  handler.headers = {
+    "Content-Length": str(target.MAX_REQUEST_BYTES + 1),
+  }
+  handler.rfile = io.BytesIO(b"")
+  with pytest.raises(target.RequestError) as too_large:
+    handler._body()
+  assert too_large.value.code == "payload_too_large"
+  assert too_large.value.status == target.HTTPStatus.REQUEST_ENTITY_TOO_LARGE
+
+
+def test_exec_environment_has_an_aggregate_byte_budget(target, tmp_path):
+  assert target.MAX_ENV_BYTES == 256 * 1024
+  with pytest.raises(target.RequestError) as too_large:
+    target._run_exec({
+      "argv": ["/bin/true"],
+      "cwd": str(tmp_path),
+      "env": {
+        "A": "a" * (64 * 1024),
+        "B": "b" * (64 * 1024),
+        "C": "c" * (64 * 1024),
+        "D": "d" * (64 * 1024),
+      },
+    })
+  assert too_large.value.code == "invalid_request"
+  assert "aggregate" in too_large.value.message
 
 
 def test_directory_listing_has_an_aggregate_response_budget(

--- a/backend/tests/test_recovery_target.py
+++ b/backend/tests/test_recovery_target.py
@@ -99,7 +99,8 @@ def test_exec_uses_argv_without_shell_and_does_not_inherit_target_token(
     "env": {"GREETING": "hello"},
   })
   assert result["exit_code"] == 0
-  assert result["stdout"] == "hello"
+  assert "stdout" not in result
+  assert "stderr" not in result
   assert base64.b64decode(result["stdout_base64"]) == b"hello"
   assert result["timed_out"] is False
   assert result["truncated"] is False
@@ -160,6 +161,16 @@ def test_file_endpoints_work_over_http(target, tmp_path):
     assert write["bytes_written"] == 7
     _, read = _request(url, "/v1/fs/read", body={"path": str(path)})
     assert base64.b64decode(read["data_base64"]) == b"network"
+
+
+def test_directory_listing_has_an_aggregate_response_budget(
+  target, tmp_path, monkeypatch,
+):
+  (tmp_path / "long-link").symlink_to("x" * 512)
+  monkeypatch.setattr(target, "MAX_LIST_RESPONSE_BYTES", 128)
+  with pytest.raises(target.RequestError) as too_large:
+    target._list_directory({"path": str(tmp_path)})
+  assert too_large.value.code == "response_too_large"
 
 
 @pytest.mark.parametrize("value", ["", "short", "x" * 513])

--- a/backend/tests/test_recovery_target.py
+++ b/backend/tests/test_recovery_target.py
@@ -5,6 +5,9 @@ import errno
 import importlib.util
 import io
 import json
+import os
+import subprocess
+import sys
 import threading
 import time
 import urllib.error
@@ -26,7 +29,7 @@ def target(monkeypatch):
   assert spec and spec.loader
   module = importlib.util.module_from_spec(spec)
   spec.loader.exec_module(module)
-  monkeypatch.setenv("MOBIUS_RECOVERY_TARGET_TOKEN", "t" * 43)
+  module._STARTUP_TOKEN = b"t" * 43
   return module
 
 
@@ -231,10 +234,161 @@ def test_directory_listing_has_an_aggregate_response_budget(
 
 
 @pytest.mark.parametrize("value", ["", "short", "x" * 513])
-def test_target_token_fails_closed(target, monkeypatch, value):
-  monkeypatch.setenv("MOBIUS_RECOVERY_TARGET_TOKEN", value)
+def test_target_token_fails_closed(target, value):
   with pytest.raises(RuntimeError, match="32-512"):
-    target._token()
+    target._validate_token(value.encode("utf-8"))
+
+
+def test_direct_secret_environment_is_rejected(target, monkeypatch):
+  monkeypatch.setenv("MOBIUS_RECOVERY_TARGET_TOKEN", "s" * 43)
+  with pytest.raises(RuntimeError, match="must not reach"):
+    target._read_startup_token()
+
+
+def test_fd_secret_is_absent_from_target_and_root_exec_proc_environments(
+  tmp_path,
+):
+  """Exercise the real fd handoff, prctl, /proc, and exec boundary."""
+  token = b"subprocess-only-secret-" + b"z" * 43
+  revision = tmp_path / "BUILD_REVISION"
+  revision.write_text("a" * 40 + "\n")
+  read_fd, write_fd = os.pipe()
+  try:
+    os.write(write_fd, token)
+  finally:
+    os.close(write_fd)
+  env = os.environ.copy()
+  env.pop("MOBIUS_RECOVERY_TARGET_TOKEN", None)
+  env["MOBIUS_RECOVERY_TARGET_TOKEN_FD"] = str(read_fd)
+  program = r'''
+import base64
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location("subprocess_targetd", sys.argv[1])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+module.BUILD_REVISION_PATH = Path(sys.argv[2])
+module._drop_packet_capture_capabilities = lambda: None
+module._initialize_startup_security(require_pid_one=False)
+try:
+  self_environment = Path("/proc/self/environ").read_bytes()
+  self_environment_blocked = False
+except PermissionError:
+  self_environment = b""
+  self_environment_blocked = True
+parent_pid = os.getpid()
+result = module._run_exec({
+  "argv": [
+    "/bin/sh", "-c",
+    f"cat /proc/self/environ; cat /proc/{parent_pid}/environ",
+  ],
+  "cwd": "/tmp",
+})
+print(json.dumps({
+  "self_environment": base64.b64encode(self_environment).decode("ascii"),
+  "self_environment_blocked": self_environment_blocked,
+  "fd_closed": not Path(f"/proc/self/fd/{sys.argv[3]}").exists(),
+  "exec": result,
+}))
+'''
+  try:
+    completed = subprocess.run(
+      [
+        sys.executable, "-c", program, str(_TARGET_PATH), str(revision),
+        str(read_fd),
+      ],
+      env=env,
+      pass_fds=(read_fd,),
+      text=True,
+      capture_output=True,
+      timeout=15,
+    )
+  finally:
+    os.close(read_fd)
+  assert completed.returncode == 0, completed.stderr
+  assert token.decode("ascii") not in completed.stdout
+  assert token.decode("ascii") not in completed.stderr
+  payload = json.loads(completed.stdout)
+  own_environment = base64.b64decode(payload["self_environment"])
+  command_stdout = base64.b64decode(payload["exec"]["stdout_base64"])
+  assert token not in own_environment
+  assert b"MOBIUS_RECOVERY_TARGET_TOKEN=" not in own_environment
+  assert token not in command_stdout
+  assert b"MOBIUS_RECOVERY_TARGET_TOKEN=" not in command_stdout
+  assert payload["self_environment_blocked"] is True
+  assert payload["fd_closed"] is True
+  assert payload["exec"]["exit_code"] != 0
+
+
+def test_packet_capabilities_are_removed_from_all_sets_and_bounding(
+  target, monkeypatch,
+):
+  blocked = {target.CAP_NET_ADMIN, target.CAP_NET_RAW}
+  data = (target._CapabilityData * 2)()
+  for capability in blocked:
+    mask = 1 << (capability % 32)
+    data[capability // 32].effective |= mask
+    data[capability // 32].permitted |= mask
+    data[capability // 32].inheritable |= mask
+  bounding = set(blocked)
+  ambient = set(blocked)
+
+  class FakeLibc:
+    def capget(self, _header, _data):
+      return 0
+
+    def capset(self, _header, _data):
+      return 0
+
+    def prctl(self, operation, argument, *_unused):
+      if operation == target._PR_CAPBSET_READ:
+        return int(argument in bounding)
+      if operation == target._PR_CAPBSET_DROP:
+        bounding.discard(argument)
+        return 0
+      if (
+        operation == target._PR_CAP_AMBIENT
+        and argument == target._PR_CAP_AMBIENT_CLEAR_ALL
+      ):
+        ambient.clear()
+        return 0
+      if operation == target._PR_CAP_AMBIENT:
+        capability = _unused[0]
+        return int(capability in ambient)
+      raise AssertionError((operation, argument, _unused))
+
+  fake_libc = FakeLibc()
+  monkeypatch.setattr(target.ctypes, "CDLL", lambda *_args, **_kwargs: fake_libc)
+  monkeypatch.setattr(
+    target,
+    "_capability_state",
+    lambda _libc: (target._CapabilityHeader(), data),
+  )
+
+  target._drop_packet_capture_capabilities()
+
+  assert bounding == set()
+  assert ambient == set()
+  for capability in blocked:
+    mask = 1 << (capability % 32)
+    word = data[capability // 32]
+    assert not word.effective & mask
+    assert not word.permitted & mask
+    assert not word.inheritable & mask
+
+
+def test_health_identity_is_baked_not_runtime_environment(
+  target, monkeypatch,
+):
+  monkeypatch.setenv("BUILD_SHA", "runtime-spoof")
+  target._BUILD_REVISION = "b" * 40
+  with _server(target) as url:
+    _, body = _request(url, "/v1/health")
+  assert body["build_sha"] == "b" * 40
 
 
 def test_paths_must_be_absolute(target):

--- a/backend/tests/test_recovery_target.py
+++ b/backend/tests/test_recovery_target.py
@@ -262,6 +262,7 @@ def test_fd_secret_is_absent_from_target_and_root_exec_proc_environments(
   env["MOBIUS_RECOVERY_TARGET_TOKEN_FD"] = str(read_fd)
   program = r'''
 import base64
+import ctypes
 import importlib.util
 import json
 import os
@@ -274,6 +275,7 @@ spec.loader.exec_module(module)
 module.BUILD_REVISION_PATH = Path(sys.argv[2])
 module._drop_packet_capture_capabilities = lambda: None
 module._initialize_startup_security(require_pid_one=False)
+dumpable = ctypes.CDLL(None, use_errno=True).prctl(3, 0, 0, 0, 0)
 try:
   self_environment = Path("/proc/self/environ").read_bytes()
   self_environment_blocked = False
@@ -291,6 +293,7 @@ result = module._run_exec({
 print(json.dumps({
   "self_environment": base64.b64encode(self_environment).decode("ascii"),
   "self_environment_blocked": self_environment_blocked,
+  "dumpable": dumpable,
   "fd_closed": not Path(f"/proc/self/fd/{sys.argv[3]}").exists(),
   "exec": result,
 }))
@@ -319,7 +322,11 @@ print(json.dumps({
   assert b"MOBIUS_RECOVERY_TARGET_TOKEN=" not in own_environment
   assert token not in command_stdout
   assert b"MOBIUS_RECOVERY_TARGET_TOKEN=" not in command_stdout
-  assert payload["self_environment_blocked"] is True
+  # Root can read its own /proc/self/environ on some kernels even after
+  # PR_SET_DUMPABLE=0. The security boundary is that the target is provably
+  # non-dumpable and its root exec child cannot inspect the parent; the real
+  # container drill below proves the same invariant across pid 1.
+  assert payload["dumpable"] == 0
   assert payload["fd_closed"] is True
   assert payload["exec"]["exit_code"] != 0
 

--- a/backend/tests/test_recovery_target.py
+++ b/backend/tests/test_recovery_target.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import base64
+import importlib.util
+import json
+import threading
+import time
+import urllib.error
+import urllib.request
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+
+_TARGET_PATH = (
+  Path(__file__).resolve().parents[1] / "recovery_target" / "targetd.py"
+)
+
+
+@pytest.fixture()
+def target(monkeypatch):
+  spec = importlib.util.spec_from_file_location("test_recovery_targetd", _TARGET_PATH)
+  assert spec and spec.loader
+  module = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(module)
+  monkeypatch.setenv("MOBIUS_RECOVERY_TARGET_TOKEN", "t" * 43)
+  return module
+
+
+@contextmanager
+def _server(target):
+  server = target._DualStackServer(("::", 0), target._Handler)
+  thread = threading.Thread(target=server.serve_forever, daemon=True)
+  thread.start()
+  try:
+    yield f"http://127.0.0.1:{server.server_port}"
+  finally:
+    server.shutdown()
+    server.server_close()
+    thread.join(timeout=2)
+
+
+def _request(url, path, *, token="t" * 43, body=None):
+  headers = {"Authorization": f"Bearer {token}"}
+  data = None
+  method = "GET"
+  if body is not None:
+    headers["Content-Type"] = "application/json"
+    data = json.dumps(body).encode()
+    method = "POST"
+  request = urllib.request.Request(
+    url + path, data=data, headers=headers, method=method
+  )
+  with urllib.request.urlopen(request, timeout=5) as response:
+    return response.status, json.load(response)
+
+
+def test_dual_stack_health_is_authenticated(target):
+  with _server(target) as url:
+    with pytest.raises(urllib.error.HTTPError) as denied:
+      _request(url, "/v1/health", token="wrong")
+    assert denied.value.code == 401
+
+    status, body = _request(url, "/v1/health")
+    assert status == 200
+    assert body == {
+      "protocol": "mobius-recovery-target/v1",
+      "target": "mobius",
+      "mode": "recovery",
+      "build_sha": "unknown",
+    }
+
+
+def test_exec_uses_argv_without_shell_and_does_not_inherit_target_token(
+  target, tmp_path,
+):
+  result = target._run_exec({
+    "argv": [
+      "/bin/sh", "-c",
+      "printf '%s' \"$GREETING\"; test -z \"$MOBIUS_RECOVERY_TARGET_TOKEN\"",
+    ],
+    "cwd": str(tmp_path),
+    "env": {"GREETING": "hello"},
+  })
+  assert result["exit_code"] == 0
+  assert result["stdout"] == "hello"
+  assert base64.b64decode(result["stdout_base64"]) == b"hello"
+  assert result["timed_out"] is False
+  assert result["truncated"] is False
+
+
+def test_exec_timeout_kills_the_process_group(target, tmp_path):
+  started = time.monotonic()
+  result = target._run_exec({
+    "argv": ["/bin/sh", "-c", "sleep 30 & wait"],
+    "cwd": str(tmp_path),
+    "timeout_seconds": 0.1,
+  })
+  assert result["timed_out"] is True
+  assert result["exit_code"] != 0
+  assert time.monotonic() - started < 3
+
+
+def test_exec_output_is_bounded_and_process_is_killed(target, tmp_path, monkeypatch):
+  monkeypatch.setattr(target, "MAX_OUTPUT_BYTES", 1024)
+  result = target._run_exec({
+    "argv": ["/bin/sh", "-c", "yes x"],
+    "cwd": str(tmp_path),
+    "timeout_seconds": 5,
+  })
+  assert result["truncated"] is True
+  assert len(base64.b64decode(result["stdout_base64"])) == 1024
+  assert result["exit_code"] != 0
+
+
+def test_file_read_write_and_list_protocol(target, tmp_path):
+  path = tmp_path / "payload.bin"
+  status = target._write_file({
+    "path": str(path),
+    "data_base64": base64.b64encode(b"abcdef").decode(),
+    "mode": 0o640,
+  })
+  assert status["bytes_written"] == 6
+  assert path.read_bytes() == b"abcdef"
+  assert path.stat().st_mode & 0o777 == 0o640
+
+  first = target._read_file({"path": str(path), "offset": 1, "limit": 3})
+  assert base64.b64decode(first["data_base64"]) == b"bcd"
+  assert first["eof"] is False
+  listing = target._list_directory({"path": str(tmp_path)})
+  assert [(item["name"], item["type"]) for item in listing["entries"]] == [
+    ("payload.bin", "file")
+  ]
+
+
+def test_file_endpoints_work_over_http(target, tmp_path):
+  path = tmp_path / "network.txt"
+  with _server(target) as url:
+    status, write = _request(url, "/v1/fs/write", body={
+      "path": str(path),
+      "data_base64": base64.b64encode(b"network").decode(),
+    })
+    assert status == 200
+    assert write["bytes_written"] == 7
+    _, read = _request(url, "/v1/fs/read", body={"path": str(path)})
+    assert base64.b64decode(read["data_base64"]) == b"network"
+
+
+@pytest.mark.parametrize("value", ["", "short", "x" * 513])
+def test_target_token_fails_closed(target, monkeypatch, value):
+  monkeypatch.setenv("MOBIUS_RECOVERY_TARGET_TOKEN", value)
+  with pytest.raises(RuntimeError, match="32-512"):
+    target._token()
+
+
+def test_paths_must_be_absolute(target):
+  with pytest.raises(target.RequestError, match="absolute"):
+    target._read_file({"path": "relative"})
+
+
+def test_request_body_and_file_bounds_are_explicit(target, monkeypatch, tmp_path):
+  monkeypatch.setattr(target, "MAX_FILE_BYTES", 4)
+  with pytest.raises(target.RequestError) as too_large:
+    target._write_file({
+      "path": str(tmp_path / "large"),
+      "data_base64": base64.b64encode(b"12345").decode(),
+    })
+  assert too_large.value.code == "payload_too_large"

--- a/backend/tests/test_self_hosted_recovery.py
+++ b/backend/tests/test_self_hosted_recovery.py
@@ -17,6 +17,10 @@ def _compose():
 def test_external_recovery_worker_is_unprivileged_and_has_no_host_control():
   worker = _compose()["services"]["recovery"]
   assert worker["profiles"] == ["recovery"]
+  # The hardened worker must be its own PID 1 so it can reject wrappers that
+  # retain bootstrap authority; Compose's `init` shim would make it PID 2.
+  assert worker.get("init") is None
+  assert worker["restart"] == "unless-stopped"
   assert worker["read_only"] is True
   assert worker["cap_drop"] == ["ALL"]
   assert "no-new-privileges:true" in worker["security_opt"]

--- a/backend/tests/test_self_hosted_recovery.py
+++ b/backend/tests/test_self_hosted_recovery.py
@@ -1,3 +1,5 @@
+import os
+import subprocess
 from pathlib import Path
 
 import yaml
@@ -21,6 +23,8 @@ def test_external_recovery_worker_is_unprivileged_and_has_no_host_control():
   assert worker["ports"] == [
     "127.0.0.1:${MOBIUS_RECOVERY_PORT:-18003}:8000"
   ]
+  assert "/state:uid=10001,gid=10001,mode=0700" in worker["tmpfs"]
+  assert "HOME=/state" in worker["environment"]
   assert "MOBIUS_RECOVERY_SECURE_COOKIE=0" in worker["environment"]
 
 
@@ -56,3 +60,83 @@ def test_lifecycle_pulls_latest_before_stopping_app_and_restores_on_finish():
 def test_app_sudo_is_explicit_and_defaults_off():
   app_env = _compose()["services"]["app"]["environment"]
   assert "MOBIUS_AGENT_SUDO=${MOBIUS_AGENT_SUDO:-0}" in app_env
+
+
+def _mobiusctl(tmp_path, action, *, state=None, extra_env=None):
+  state_path = state or tmp_path / "recovery.env"
+  env = os.environ.copy()
+  env["MOBIUS_RECOVERY_STATE_FILE"] = str(state_path)
+  env.update(extra_env or {})
+  result = subprocess.run(
+    [str(ROOT / "scripts" / "mobiusctl"), "recovery", action],
+    cwd=ROOT,
+    env=env,
+    text=True,
+    capture_output=True,
+    timeout=10,
+  )
+  return result, state_path
+
+
+def test_lifecycle_rejects_user_image_shell_injection_before_writing_state(
+  tmp_path,
+):
+  marker = tmp_path / "injected"
+  malicious = f"ghcr.io/mobius/recovery:stable\n$(touch {marker})"
+  result, state = _mobiusctl(
+    tmp_path,
+    "start",
+    extra_env={"MOBIUS_RECOVERY_IMAGE": malicious},
+  )
+  assert result.returncode != 0
+  assert "unsafe characters" in result.stderr
+  assert not marker.exists()
+  assert not state.exists()
+
+
+def test_lifecycle_never_sources_injected_state(tmp_path):
+  marker = tmp_path / "injected"
+  state = tmp_path / "recovery.env"
+  state.write_text(
+    "MOBIUS_RECOVERY_TARGET_TOKEN=" + "t" * 43 + "\n"
+    "MOBIUS_RECOVERY_LOCAL_TOKEN=" + "l" * 43 + "\n"
+    "MOBIUS_RECOVERY_PORT=18003\n"
+    "MOBIUS_RECOVERY_IMAGE=ghcr.io/mobius/recovery:stable\n"
+    f"$(touch {marker})\n"
+  )
+  state.chmod(0o600)
+  result, _ = _mobiusctl(tmp_path, "status", state=state)
+  assert result.returncode != 0
+  assert "unexpected or malformed line" in result.stderr
+  assert not marker.exists()
+
+
+def test_lifecycle_rejects_unsafe_state_files(tmp_path):
+  content = (
+    "MOBIUS_RECOVERY_TARGET_TOKEN=" + "t" * 43 + "\n"
+    "MOBIUS_RECOVERY_LOCAL_TOKEN=" + "l" * 43 + "\n"
+    "MOBIUS_RECOVERY_PORT=18003\n"
+    "MOBIUS_RECOVERY_IMAGE=ghcr.io/mobius/recovery:stable\n"
+  )
+
+  permissive = tmp_path / "permissive.env"
+  permissive.write_text(content)
+  permissive.chmod(0o644)
+  result, _ = _mobiusctl(tmp_path, "status", state=permissive)
+  assert result.returncode != 0
+  assert "permissions must be" in result.stderr
+
+  original = tmp_path / "original.env"
+  original.write_text(content)
+  original.chmod(0o600)
+  hardlink = tmp_path / "hardlink.env"
+  os.link(original, hardlink)
+  result, _ = _mobiusctl(tmp_path, "status", state=hardlink)
+  assert result.returncode != 0
+  assert "exactly one hard link" in result.stderr
+
+  symlink = tmp_path / "symlink.env"
+  symlink.symlink_to(original)
+  result, _ = _mobiusctl(tmp_path, "status", state=symlink)
+  assert result.returncode != 0
+  assert "must not be a symlink" in result.stderr

--- a/backend/tests/test_self_hosted_recovery.py
+++ b/backend/tests/test_self_hosted_recovery.py
@@ -35,7 +35,9 @@ def test_only_root_target_mounts_the_stopped_app_data():
   assert target["profiles"] == ["recovery"]
   assert target.get("init") is None
   assert target["read_only"] is True
-  assert set(target["cap_drop"]) == {"NET_ADMIN", "NET_RAW"}
+  assert set(target["cap_drop"]) == {
+    "NET_ADMIN", "NET_RAW", "SYS_ADMIN", "SYS_PTRACE",
+  }
   assert target["tmpfs"] == ["/tmp", "/run"]
   assert target["volumes"] == ["app_data:/data"]
   assert any(

--- a/backend/tests/test_self_hosted_recovery.py
+++ b/backend/tests/test_self_hosted_recovery.py
@@ -39,6 +39,8 @@ def test_only_root_target_mounts_the_stopped_app_data():
 
 def test_lifecycle_pulls_latest_before_stopping_app_and_restores_on_finish():
   script = (ROOT / "scripts" / "mobiusctl").read_text()
+  assert "/?token=" not in script
+  assert "Paste this one-time code into the Recovery sign-in form" in script
   start = script.index("compose pull recovery")
   stop = script.index("compose stop app", start)
   launch = script.index("compose up -d --force-recreate recovery-target recovery")

--- a/backend/tests/test_self_hosted_recovery.py
+++ b/backend/tests/test_self_hosted_recovery.py
@@ -1,7 +1,9 @@
 import os
 import subprocess
+import time
 from pathlib import Path
 
+import pytest
 import yaml
 
 
@@ -43,6 +45,10 @@ def test_only_root_target_mounts_the_stopped_app_data():
   assert any(
     item == "MOBIUS_BOOT_MODE=recovery" for item in target["environment"]
   )
+  assert (
+    "MOBIUS_RECOVERY_TARGET_EXPIRES_AT="
+    "${MOBIUS_RECOVERY_TARGET_EXPIRES_AT:-0}"
+  ) in target["environment"]
   assert target["healthcheck"] == {"disable": True}
   assert worker.get("volumes") is None
   assert worker["depends_on"]["recovery-target"]["condition"] == "service_started"
@@ -58,9 +64,9 @@ def test_lifecycle_pulls_latest_before_stopping_app_and_restores_on_finish():
   assert start < stop < launch
 
   finish = script.index("finish_recovery()")
-  down = script.index("recovery_down", finish)
-  app_up = script.index("docker compose up -d app", finish)
-  health = script.index("Waiting for Mobius health", finish)
+  down = script.index("recovery_down_strict", finish)
+  app_up = script.index("normal_compose up -d --force-recreate app", finish)
+  health = script.index("wait_for_normal_app", app_up)
   assert down < app_up < health
 
 
@@ -73,6 +79,7 @@ def _mobiusctl(tmp_path, action, *, state=None, extra_env=None):
   state_path = state or tmp_path / "recovery.env"
   env = os.environ.copy()
   env["MOBIUS_RECOVERY_STATE_FILE"] = str(state_path)
+  env["MOBIUS_RECOVERY_LOCK_DIR"] = str(tmp_path)
   env.update(extra_env or {})
   result = subprocess.run(
     [str(ROOT / "scripts" / "mobiusctl"), "recovery", action],
@@ -83,6 +90,128 @@ def _mobiusctl(tmp_path, action, *, state=None, extra_env=None):
     timeout=10,
   )
   return result, state_path
+
+
+def _write_recovery_state(
+  path, target="t" * 43, local="l" * 43, expires_at=None,
+):
+  expires_at = expires_at or int(time.time()) + 3600
+  path.write_text(
+    f"MOBIUS_RECOVERY_TARGET_TOKEN={target}\n"
+    f"MOBIUS_RECOVERY_TARGET_EXPIRES_AT={expires_at}\n"
+    f"MOBIUS_RECOVERY_LOCAL_TOKEN={local}\n"
+    "MOBIUS_RECOVERY_PORT=18003\n"
+    "MOBIUS_RECOVERY_IMAGE=ghcr.io/mobius/recovery:stable\n"
+  )
+  path.chmod(0o600)
+
+
+def _read_recovery_state(path):
+  return dict(
+    line.split("=", 1)
+    for line in path.read_text().splitlines()
+  )
+
+
+def _fake_docker(tmp_path):
+  bin_dir = tmp_path / "bin"
+  bin_dir.mkdir()
+  docker = bin_dir / "docker"
+  docker.write_text(
+    "#!/bin/sh\n"
+    "printf '%s\\n' \"$*\" >>\"$DOCKER_LOG\"\n"
+    "case \"$*\" in\n"
+    "  *\"${DOCKER_FAIL_MATCH:-__never__}\"*) exit 42 ;;\n"
+    "  *\"${DOCKER_BLOCK_MATCH:-__never__}\"*)\n"
+    "    : >\"$DOCKER_BLOCK_READY\"\n"
+    "    while [ ! -e \"$DOCKER_BLOCK_RELEASE\" ]; do sleep 0.05; done ;;\n"
+    "esac\n"
+    "case \"$*\" in\n"
+    "  *\"${DOCKER_REMAINING_MATCH:-__never__}\"*) printf 'remaining-container\\n' ;;\n"
+    "  *'ps -q app'*) printf 'fake-app\\n' ;;\n"
+    "  inspect*fake-app*) printf '%s\\n' \"${DOCKER_APP_HEALTH:-healthy}\" ;;\n"
+    "esac\n"
+    "exit 0\n"
+  )
+  docker.chmod(0o755)
+  log = tmp_path / "docker.log"
+  return {
+    "PATH": f"{bin_dir}:{os.environ['PATH']}",
+    "DOCKER_LOG": str(log),
+  }, log
+
+
+def test_reopen_rotates_both_tokens_without_starting_normal_app(tmp_path):
+  state = tmp_path / "recovery.env"
+  old_target = "t" * 43
+  old_local = "l" * 43
+  _write_recovery_state(state, old_target, old_local)
+  fake_env, log = _fake_docker(tmp_path)
+
+  result, _ = _mobiusctl(
+    tmp_path, "reopen", state=state, extra_env=fake_env,
+  )
+
+  assert result.returncode == 0, result.stderr
+  rotated = _read_recovery_state(state)
+  assert rotated["MOBIUS_RECOVERY_TARGET_TOKEN"] != old_target
+  assert rotated["MOBIUS_RECOVERY_LOCAL_TOKEN"] != old_local
+  assert int(rotated["MOBIUS_RECOVERY_TARGET_EXPIRES_AT"]) > int(time.time())
+  assert rotated["MOBIUS_RECOVERY_LOCAL_TOKEN"] in result.stdout
+  assert old_local not in result.stdout
+  assert (state.stat().st_mode & 0o777) == 0o600
+  commands = log.read_text().splitlines()
+  app_stop = next(
+    i for i, line in enumerate(commands) if "stop app" in line
+  )
+  pull = next(i for i, line in enumerate(commands) if "pull recovery" in line)
+  stop = next(
+    i for i, line in enumerate(commands)
+    if "stop recovery recovery-target" in line
+  )
+  remove = next(
+    i for i, line in enumerate(commands)
+    if "rm -f recovery recovery-target" in line
+  )
+  launch = next(
+    i for i, line in enumerate(commands)
+    if "up -d --force-recreate recovery-target recovery" in line
+  )
+  assert app_stop < pull < stop < remove < launch
+  assert all("up -d app" not in line for line in commands)
+
+
+def test_failed_reopen_keeps_app_stopped_and_new_tokens_retryable(tmp_path):
+  state = tmp_path / "recovery.env"
+  old_target = "t" * 43
+  old_local = "l" * 43
+  _write_recovery_state(state, old_target, old_local)
+  fake_env, log = _fake_docker(tmp_path)
+  fake_env["DOCKER_FAIL_MATCH"] = (
+    "up -d --force-recreate recovery-target recovery"
+  )
+
+  result, _ = _mobiusctl(
+    tmp_path, "reopen", state=state, extra_env=fake_env,
+  )
+
+  assert result.returncode == 42
+  assert "ordinary Mobius app remains stopped" in result.stderr
+  rotated = _read_recovery_state(state)
+  assert rotated["MOBIUS_RECOVERY_TARGET_TOKEN"] != old_target
+  assert rotated["MOBIUS_RECOVERY_LOCAL_TOKEN"] != old_local
+  assert all("up -d app" not in line for line in log.read_text().splitlines())
+
+
+def test_reopen_requires_an_active_valid_state(tmp_path):
+  fake_env, log = _fake_docker(tmp_path)
+  result, state = _mobiusctl(
+    tmp_path, "reopen", extra_env=fake_env,
+  )
+  assert result.returncode != 0
+  assert "recovery start" in result.stderr
+  assert not state.exists()
+  assert not log.exists()
 
 
 def test_lifecycle_rejects_user_image_shell_injection_before_writing_state(
@@ -101,11 +230,39 @@ def test_lifecycle_rejects_user_image_shell_injection_before_writing_state(
   assert not state.exists()
 
 
+def test_start_mints_a_bounded_target_expiry(tmp_path):
+  fake_env, _log = _fake_docker(tmp_path)
+  before = int(time.time())
+
+  result, state = _mobiusctl(
+    tmp_path,
+    "start",
+    extra_env={**fake_env, "MOBIUS_RECOVERY_TTL_SECONDS": "300"},
+  )
+
+  assert result.returncode == 0, result.stderr
+  expiry = int(_read_recovery_state(state)["MOBIUS_RECOVERY_TARGET_EXPIRES_AT"])
+  assert before + 300 <= expiry <= int(time.time()) + 300
+
+
+@pytest.mark.parametrize("ttl", ["299", "86401", "0300", "1.5"])
+def test_start_rejects_unbounded_or_noncanonical_target_ttl(tmp_path, ttl):
+  result, state = _mobiusctl(
+    tmp_path,
+    "start",
+    extra_env={"MOBIUS_RECOVERY_TTL_SECONDS": ttl},
+  )
+  assert result.returncode != 0
+  assert "300 to 86400" in result.stderr
+  assert not state.exists()
+
+
 def test_lifecycle_never_sources_injected_state(tmp_path):
   marker = tmp_path / "injected"
   state = tmp_path / "recovery.env"
   state.write_text(
     "MOBIUS_RECOVERY_TARGET_TOKEN=" + "t" * 43 + "\n"
+    "MOBIUS_RECOVERY_TARGET_EXPIRES_AT=1800000000\n"
     "MOBIUS_RECOVERY_LOCAL_TOKEN=" + "l" * 43 + "\n"
     "MOBIUS_RECOVERY_PORT=18003\n"
     "MOBIUS_RECOVERY_IMAGE=ghcr.io/mobius/recovery:stable\n"
@@ -121,6 +278,7 @@ def test_lifecycle_never_sources_injected_state(tmp_path):
 def test_lifecycle_rejects_unsafe_state_files(tmp_path):
   content = (
     "MOBIUS_RECOVERY_TARGET_TOKEN=" + "t" * 43 + "\n"
+    f"MOBIUS_RECOVERY_TARGET_EXPIRES_AT={int(time.time()) + 3600}\n"
     "MOBIUS_RECOVERY_LOCAL_TOKEN=" + "l" * 43 + "\n"
     "MOBIUS_RECOVERY_PORT=18003\n"
     "MOBIUS_RECOVERY_IMAGE=ghcr.io/mobius/recovery:stable\n"
@@ -147,3 +305,117 @@ def test_lifecycle_rejects_unsafe_state_files(tmp_path):
   result, _ = _mobiusctl(tmp_path, "status", state=symlink)
   assert result.returncode != 0
   assert "must not be a symlink" in result.stderr
+
+
+def test_finish_refuses_to_start_app_when_recovery_stop_fails(tmp_path):
+  state = tmp_path / "recovery.env"
+  _write_recovery_state(state)
+  fake_env, log = _fake_docker(tmp_path)
+  fake_env["DOCKER_FAIL_MATCH"] = "stop recovery recovery-target"
+
+  result, _ = _mobiusctl(
+    tmp_path, "finish", state=state, extra_env=fake_env,
+  )
+
+  assert result.returncode == 42
+  assert state.exists(), "credentials must survive an unverified teardown"
+  commands = log.read_text().splitlines()
+  assert all("up -d --force-recreate app" not in line for line in commands)
+
+
+def test_finish_refuses_to_start_app_when_removed_services_still_exist(tmp_path):
+  state = tmp_path / "recovery.env"
+  _write_recovery_state(state)
+  fake_env, log = _fake_docker(tmp_path)
+  fake_env["DOCKER_REMAINING_MATCH"] = (
+    "ps -aq recovery recovery-target"
+  )
+
+  result, _ = _mobiusctl(
+    tmp_path, "finish", state=state, extra_env=fake_env,
+  )
+
+  assert result.returncode != 0
+  assert "app stays stopped" in result.stderr
+  assert state.exists()
+  assert all(
+    "up -d --force-recreate app" not in line
+    for line in log.read_text().splitlines()
+  )
+
+
+def test_finish_recreates_app_only_after_verified_teardown(tmp_path):
+  state = tmp_path / "recovery.env"
+  _write_recovery_state(state)
+  fake_env, log = _fake_docker(tmp_path)
+
+  result, _ = _mobiusctl(
+    tmp_path, "finish", state=state, extra_env=fake_env,
+  )
+
+  assert result.returncode == 0, result.stderr
+  assert not state.exists()
+  commands = log.read_text().splitlines()
+  stop = next(
+    i for i, line in enumerate(commands)
+    if "stop recovery recovery-target" in line
+  )
+  remove = next(
+    i for i, line in enumerate(commands)
+    if "rm -f recovery recovery-target" in line
+  )
+  absent = next(
+    i for i, line in enumerate(commands)
+    if "ps -aq recovery recovery-target" in line
+  )
+  recreate = next(
+    i for i, line in enumerate(commands)
+    if "up -d --force-recreate app" in line
+  )
+  assert stop < remove < absent < recreate
+
+
+def test_lifecycle_lock_rejects_concurrent_finish_or_reopen(tmp_path):
+  state = tmp_path / "recovery.env"
+  _write_recovery_state(state)
+  fake_env, log = _fake_docker(tmp_path)
+  ready = tmp_path / "block.ready"
+  release = tmp_path / "block.release"
+  fake_env.update({
+    "MOBIUS_RECOVERY_STATE_FILE": str(state),
+    "MOBIUS_RECOVERY_LOCK_DIR": str(tmp_path),
+    "DOCKER_BLOCK_MATCH": "ps recovery-target recovery",
+    "DOCKER_BLOCK_READY": str(ready),
+    "DOCKER_BLOCK_RELEASE": str(release),
+  })
+  first = subprocess.Popen(
+    [str(ROOT / "scripts" / "mobiusctl"), "recovery", "status"],
+    cwd=ROOT,
+    env={**os.environ, **fake_env},
+    text=True,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+  )
+  try:
+    for _attempt in range(100):
+      if ready.exists():
+        break
+      time.sleep(0.02)
+    assert ready.exists(), "first lifecycle never reached the fake Docker gate"
+
+    second, _ = _mobiusctl(
+      tmp_path,
+      "finish",
+      state=state,
+      extra_env={**fake_env, "MOBIUS_RECOVERY_LOCK_WAIT_SECONDS": "0"},
+    )
+    assert second.returncode == 75
+    assert "Another Mobius recovery/update lifecycle is active" in second.stderr
+  finally:
+    release.touch()
+    first_stdout, first_stderr = first.communicate(timeout=5)
+  assert first.returncode == 0, (first_stdout, first_stderr)
+  assert sum(
+    "ps recovery-target recovery" in line
+    for line in log.read_text().splitlines()
+  ) == 1

--- a/backend/tests/test_self_hosted_recovery.py
+++ b/backend/tests/test_self_hosted_recovery.py
@@ -21,6 +21,7 @@ def test_external_recovery_worker_is_unprivileged_and_has_no_host_control():
   assert worker["ports"] == [
     "127.0.0.1:${MOBIUS_RECOVERY_PORT:-18003}:8000"
   ]
+  assert "MOBIUS_RECOVERY_SECURE_COOKIE=0" in worker["environment"]
 
 
 def test_only_root_target_mounts_the_stopped_app_data():

--- a/backend/tests/test_self_hosted_recovery.py
+++ b/backend/tests/test_self_hosted_recovery.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _compose():
+  return yaml.safe_load((ROOT / "docker-compose.yml").read_text())
+
+
+def test_external_recovery_worker_is_unprivileged_and_has_no_host_control():
+  worker = _compose()["services"]["recovery"]
+  assert worker["profiles"] == ["recovery"]
+  assert worker["read_only"] is True
+  assert worker["cap_drop"] == ["ALL"]
+  assert "no-new-privileges:true" in worker["security_opt"]
+  assert worker.get("volumes", []) == []
+  assert all("docker.sock" not in item for item in worker.get("volumes", []))
+  assert worker["ports"] == [
+    "127.0.0.1:${MOBIUS_RECOVERY_PORT:-18003}:8000"
+  ]
+
+
+def test_only_root_target_mounts_the_stopped_app_data():
+  services = _compose()["services"]
+  target = services["recovery-target"]
+  worker = services["recovery"]
+  assert target["profiles"] == ["recovery"]
+  assert target["volumes"] == ["app_data:/data"]
+  assert any(
+    item == "MOBIUS_BOOT_MODE=recovery" for item in target["environment"]
+  )
+  assert worker.get("volumes") is None
+  assert worker["depends_on"]["recovery-target"]["condition"] == "service_healthy"
+
+
+def test_lifecycle_pulls_latest_before_stopping_app_and_restores_on_finish():
+  script = (ROOT / "scripts" / "mobiusctl").read_text()
+  start = script.index("compose pull recovery")
+  stop = script.index("compose stop app", start)
+  launch = script.index("compose up -d --force-recreate recovery-target recovery")
+  assert start < stop < launch
+
+  finish = script.index("finish_recovery()")
+  down = script.index("recovery_down", finish)
+  app_up = script.index("docker compose up -d app", finish)
+  health = script.index("Waiting for Mobius health", finish)
+  assert down < app_up < health
+
+
+def test_app_sudo_is_explicit_and_defaults_off():
+  app_env = _compose()["services"]["app"]["environment"]
+  assert "MOBIUS_AGENT_SUDO=${MOBIUS_AGENT_SUDO:-0}" in app_env

--- a/backend/tests/test_self_hosted_recovery.py
+++ b/backend/tests/test_self_hosted_recovery.py
@@ -20,7 +20,10 @@ def test_external_recovery_worker_is_unprivileged_and_has_no_host_control():
   # The hardened worker must be its own PID 1 so it can reject wrappers that
   # retain bootstrap authority; Compose's `init` shim would make it PID 2.
   assert worker.get("init") is None
-  assert worker["restart"] == "unless-stopped"
+  # The tmpfs-backed one-time-code ledger is not durable. An automatic restart
+  # would reconstruct it from the unchanged Compose environment and replay a
+  # consumed code, so only mobiusctl `reopen` may recreate this container.
+  assert worker["restart"] == "no"
   assert worker["read_only"] is True
   assert worker["cap_drop"] == ["ALL"]
   assert "no-new-privileges:true" in worker["security_opt"]
@@ -40,6 +43,9 @@ def test_only_root_target_mounts_the_stopped_app_data():
   worker = services["recovery"]
   assert target["profiles"] == ["recovery"]
   assert target.get("init") is None
+  # A restarted target would accept the same still-live bearer. It must remain
+  # exited until `reopen` removes both services and rotates both credentials.
+  assert target["restart"] == "no"
   assert target["read_only"] is True
   assert set(target["cap_drop"]) == {
     "NET_ADMIN", "NET_RAW", "SYS_ADMIN", "SYS_PTRACE",
@@ -72,6 +78,14 @@ def test_lifecycle_pulls_latest_before_stopping_app_and_restores_on_finish():
   app_up = script.index("normal_compose up -d --force-recreate app", finish)
   health = script.index("wait_for_normal_app", app_up)
   assert down < app_up < health
+
+
+def test_lifecycle_directs_crashed_services_through_credential_rotation():
+  script = (ROOT / "scripts" / "mobiusctl").read_text()
+  assert "required after either isolated service exits" in script
+  assert "If either recovery service exits, do not restart it" in script
+  assert "If either service exited, do not restart it" in script
+  assert script.count("scripts/mobiusctl recovery reopen") >= 3
 
 
 def test_app_sudo_is_explicit_and_defaults_off():

--- a/backend/tests/test_self_hosted_recovery.py
+++ b/backend/tests/test_self_hosted_recovery.py
@@ -33,12 +33,17 @@ def test_only_root_target_mounts_the_stopped_app_data():
   target = services["recovery-target"]
   worker = services["recovery"]
   assert target["profiles"] == ["recovery"]
+  assert target.get("init") is None
+  assert target["read_only"] is True
+  assert set(target["cap_drop"]) == {"NET_ADMIN", "NET_RAW"}
+  assert target["tmpfs"] == ["/tmp", "/run"]
   assert target["volumes"] == ["app_data:/data"]
   assert any(
     item == "MOBIUS_BOOT_MODE=recovery" for item in target["environment"]
   )
+  assert target["healthcheck"] == {"disable": True}
   assert worker.get("volumes") is None
-  assert worker["depends_on"]["recovery-target"]["condition"] == "service_healthy"
+  assert worker["depends_on"]["recovery-target"]["condition"] == "service_started"
 
 
 def test_lifecycle_pulls_latest_before_stopping_app_and_restores_on_finish():

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,24 +78,29 @@ services:
     profiles: ["recovery"]
     image: ${MOBIUS_IMAGE:-mobius}
     container_name: ${MOBIUS_RECOVERY_TARGET_CONTAINER:-mobius-recovery-target}
-    init: true
     restart: unless-stopped
+    read_only: true
+    cap_drop:
+      - NET_ADMIN
+      - NET_RAW
+    tmpfs:
+      - /tmp
+      - /run
     environment:
       - MOBIUS_BOOT_MODE=recovery
       - MOBIUS_RECOVERY_TARGET_PORT=18002
       - MOBIUS_RECOVERY_TARGET_TOKEN=${MOBIUS_RECOVERY_TARGET_TOKEN:-not-configured}
-      - BUILD_SHA=${BUILD_SHA:-unknown}
       - DATA_DIR=/data
     volumes:
       - app_data:/data
     expose:
       - "18002"
+    # The image's ordinary unauthenticated /api/health probe must not run in
+    # target mode, and an authenticated Docker health command would expose the
+    # bearer in a second process. The worker performs the authenticated protocol
+    # readiness check; target startup itself is synchronous and fail-closed.
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS -H 'Authorization: Bearer $${MOBIUS_RECOVERY_TARGET_TOKEN}' http://127.0.0.1:18002/v1/health >/dev/null || exit 1"]
-      interval: 5s
-      timeout: 3s
-      retries: 12
-      start_period: 3s
+      disable: true
 
   recovery:
     profiles: ["recovery"]
@@ -125,7 +130,7 @@ services:
       - "127.0.0.1:${MOBIUS_RECOVERY_PORT:-18003}:8000"
     depends_on:
       recovery-target:
-        condition: service_healthy
+        condition: service_started
 
   # Frozen recovery floor (recoveryd) — its OWN container so a broken or
   # crash-looping platform cannot take recovery down (different cgroup,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,9 @@ services:
       - GITHUB_OAUTH_CLIENT_ID=${GITHUB_OAUTH_CLIENT_ID:-Ov23liMpOLS6qp5YV8Vk}
       - DATABASE_URL=sqlite:////data/db/ultimate.db
       - DATA_DIR=/data
+      # Full root is opt-in because it persists for the lifetime of this
+      # container. Set MOBIUS_AGENT_SUDO=1 only after the owner confirms.
+      - MOBIUS_AGENT_SUDO=${MOBIUS_AGENT_SUDO:-0}
     volumes:
       - app_data:/data
     expose:
@@ -66,6 +69,59 @@ services:
     # (Codex HIGH; plan _148 1.6). Env-overridable for bigger/smaller hosts.
     mem_limit: ${MOBIUS_APP_MEM_LIMIT:-6g}
     oom_score_adj: 200
+
+  # On-demand self-hosted recovery. `scripts/mobiusctl recovery start` stops
+  # the ordinary app before starting these two profile-scoped services.
+  # recovery-target is the only root process; the external worker receives no
+  # Docker socket and cannot write its own read-only filesystem.
+  recovery-target:
+    profiles: ["recovery"]
+    image: ${MOBIUS_IMAGE:-mobius}
+    container_name: ${MOBIUS_RECOVERY_TARGET_CONTAINER:-mobius-recovery-target}
+    init: true
+    restart: unless-stopped
+    environment:
+      - MOBIUS_BOOT_MODE=recovery
+      - MOBIUS_RECOVERY_TARGET_PORT=18002
+      - MOBIUS_RECOVERY_TARGET_TOKEN=${MOBIUS_RECOVERY_TARGET_TOKEN:-not-configured}
+      - BUILD_SHA=${BUILD_SHA:-unknown}
+      - DATA_DIR=/data
+    volumes:
+      - app_data:/data
+    expose:
+      - "18002"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS -H 'Authorization: Bearer $${MOBIUS_RECOVERY_TARGET_TOKEN}' http://127.0.0.1:18002/v1/health >/dev/null || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 3s
+
+  recovery:
+    profiles: ["recovery"]
+    image: ${MOBIUS_RECOVERY_IMAGE:-ghcr.io/mobius-os/mobius-recovery:stable}
+    container_name: ${MOBIUS_RECOVERY_CONTAINER:-mobius-recovery}
+    init: true
+    restart: unless-stopped
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+      - /tmp
+      - /run
+    environment:
+      - PORT=8000
+      - HOME=/tmp
+      - MOBIUS_RECOVERY_TARGET_URL=http://recovery-target:18002
+      - MOBIUS_RECOVERY_TARGET_TOKEN=${MOBIUS_RECOVERY_TARGET_TOKEN:-not-configured}
+      - MOBIUS_RECOVERY_LOCAL_TOKEN=${MOBIUS_RECOVERY_LOCAL_TOKEN:-not-configured}
+    ports:
+      - "127.0.0.1:${MOBIUS_RECOVERY_PORT:-18003}:8000"
+    depends_on:
+      recovery-target:
+        condition: service_healthy
 
   # Frozen recovery floor (recoveryd) — its OWN container so a broken or
   # crash-looping platform cannot take recovery down (different cgroup,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,6 +117,9 @@ services:
       - MOBIUS_RECOVERY_TARGET_URL=http://recovery-target:18002
       - MOBIUS_RECOVERY_TARGET_TOKEN=${MOBIUS_RECOVERY_TARGET_TOKEN:-not-configured}
       - MOBIUS_RECOVERY_LOCAL_TOKEN=${MOBIUS_RECOVERY_LOCAL_TOKEN:-not-configured}
+      # The self-host helper publishes plain HTTP on loopback. Managed HTTPS
+      # deployments retain the worker's secure-cookie default instead.
+      - MOBIUS_RECOVERY_SECURE_COOKIE=0
     ports:
       - "127.0.0.1:${MOBIUS_RECOVERY_PORT:-18003}:8000"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,6 +92,7 @@ services:
       - MOBIUS_BOOT_MODE=recovery
       - MOBIUS_RECOVERY_TARGET_PORT=18002
       - MOBIUS_RECOVERY_TARGET_TOKEN=${MOBIUS_RECOVERY_TARGET_TOKEN:-not-configured}
+      - MOBIUS_RECOVERY_TARGET_EXPIRES_AT=${MOBIUS_RECOVERY_TARGET_EXPIRES_AT:-0}
       - DATA_DIR=/data
     volumes:
       - app_data:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,6 @@ services:
     profiles: ["recovery"]
     image: ${MOBIUS_RECOVERY_IMAGE:-ghcr.io/mobius-os/mobius-recovery:stable}
     container_name: ${MOBIUS_RECOVERY_CONTAINER:-mobius-recovery}
-    init: true
     restart: unless-stopped
     read_only: true
     cap_drop:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,9 +111,10 @@ services:
     tmpfs:
       - /tmp
       - /run
+      - /state:uid=10001,gid=10001,mode=0700
     environment:
       - PORT=8000
-      - HOME=/tmp
+      - HOME=/state
       - MOBIUS_RECOVERY_TARGET_URL=http://recovery-target:18002
       - MOBIUS_RECOVERY_TARGET_TOKEN=${MOBIUS_RECOVERY_TARGET_TOKEN:-not-configured}
       - MOBIUS_RECOVERY_LOCAL_TOKEN=${MOBIUS_RECOVERY_LOCAL_TOKEN:-not-configured}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,6 +83,8 @@ services:
     cap_drop:
       - NET_ADMIN
       - NET_RAW
+      - SYS_ADMIN
+      - SYS_PTRACE
     tmpfs:
       - /tmp
       - /run

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,12 +73,16 @@ services:
   # On-demand self-hosted recovery. `scripts/mobiusctl recovery start` stops
   # the ordinary app before starting these two profile-scoped services.
   # recovery-target is the only root process; the external worker receives no
-  # Docker socket and cannot write its own read-only filesystem.
+  # Docker socket and cannot write its own read-only filesystem. Both services
+  # are deliberately one-shot: restarting either container would replay the
+  # credentials injected at creation. After either process exits, use
+  # `scripts/mobiusctl recovery reopen` to remove both containers and rotate
+  # both credentials before recreating them.
   recovery-target:
     profiles: ["recovery"]
     image: ${MOBIUS_IMAGE:-mobius}
     container_name: ${MOBIUS_RECOVERY_TARGET_CONTAINER:-mobius-recovery-target}
-    restart: unless-stopped
+    restart: "no"
     read_only: true
     cap_drop:
       - NET_ADMIN
@@ -109,7 +113,7 @@ services:
     profiles: ["recovery"]
     image: ${MOBIUS_RECOVERY_IMAGE:-ghcr.io/mobius-os/mobius-recovery:stable}
     container_name: ${MOBIUS_RECOVERY_CONTAINER:-mobius-recovery}
-    restart: unless-stopped
+    restart: "no"
     read_only: true
     cap_drop:
       - ALL

--- a/scripts/mobiusctl
+++ b/scripts/mobiusctl
@@ -1,0 +1,173 @@
+#!/bin/sh
+set -eu
+
+# Host-side lifecycle for the external self-hosted recovery worker. The worker
+# has no Docker socket: this small operator command owns every container state
+# transition, while the root target owns only the stopped instance's /data.
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+PROJECT_DIR=$(dirname "$SCRIPT_DIR")
+STATE_FILE=${MOBIUS_RECOVERY_STATE_FILE:-"$PROJECT_DIR/.mobius-recovery.env"}
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: scripts/mobiusctl recovery start|status|finish
+
+  start   stop Mobius, pull the latest approved recovery image, and expose the
+          recovery UI on loopback (default http://127.0.0.1:18003)
+  status  show the isolated recovery services
+  finish  remove recovery services, restart Mobius, and verify app health
+EOF
+  exit 64
+}
+
+[ "${1:-}" = "recovery" ] || usage
+action=${2:-}
+[ "$#" -eq 2 ] || usage
+
+compose() {
+  (
+    cd "$PROJECT_DIR"
+    if [ -f .env ]; then
+      docker compose --profile recovery \
+        --env-file .env --env-file "$STATE_FILE" "$@"
+    else
+      docker compose --profile recovery --env-file "$STATE_FILE" "$@"
+    fi
+  )
+}
+
+new_token() {
+  if command -v openssl >/dev/null 2>&1; then
+    openssl rand -base64 48 | tr '+/' '-_' | tr -d '=\n'
+  else
+    python3 -c 'import secrets; print(secrets.token_urlsafe(48))'
+  fi
+}
+
+write_state() {
+  if [ -L "$STATE_FILE" ]; then
+    echo "Refusing symlink recovery state: $STATE_FILE" >&2
+    exit 1
+  fi
+  umask 077
+  {
+    printf 'MOBIUS_RECOVERY_TARGET_TOKEN=%s\n' "$(new_token)"
+    printf 'MOBIUS_RECOVERY_LOCAL_TOKEN=%s\n' "$(new_token)"
+    printf 'MOBIUS_RECOVERY_PORT=%s\n' "${MOBIUS_RECOVERY_PORT:-18003}"
+    printf 'MOBIUS_RECOVERY_IMAGE=%s\n' \
+      "${MOBIUS_RECOVERY_IMAGE:-ghcr.io/mobius-os/mobius-recovery:stable}"
+  } > "$STATE_FILE"
+}
+
+load_state() {
+  [ -f "$STATE_FILE" ] || return 1
+  # Generated values contain only URL-safe token/image/number characters.
+  # shellcheck disable=SC1090
+  . "$STATE_FILE"
+  export MOBIUS_RECOVERY_TARGET_TOKEN MOBIUS_RECOVERY_LOCAL_TOKEN
+  export MOBIUS_RECOVERY_PORT MOBIUS_RECOVERY_IMAGE
+}
+
+recovery_down() {
+  compose stop recovery recovery-target >/dev/null 2>&1 || true
+  compose rm -f recovery recovery-target >/dev/null 2>&1 || true
+}
+
+start_recovery() {
+  if [ -f "$STATE_FILE" ]; then
+    echo "Recovery state already exists. Run 'scripts/mobiusctl recovery status' or finish it first." >&2
+    exit 1
+  fi
+  write_state
+  load_state
+
+  app_was_stopped=0
+  cleanup_failed_start() {
+    status=$?
+    if [ "$status" -ne 0 ]; then
+      echo "Recovery start failed; restoring the ordinary Mobius app." >&2
+      recovery_down
+      compose up -d app >/dev/null 2>&1 || true
+      rm -f "$STATE_FILE"
+    fi
+    exit "$status"
+  }
+  trap cleanup_failed_start EXIT HUP INT TERM
+
+  echo "Pulling the latest approved recovery worker..."
+  compose pull recovery
+  echo "Stopping the ordinary Mobius app..."
+  compose stop app
+  app_was_stopped=1
+  compose up -d --force-recreate recovery-target recovery
+
+  trap - EXIT HUP INT TERM
+  echo "Recovery is isolated from the stopped app and available only on loopback:"
+  printf '  http://127.0.0.1:%s/?token=%s\n' \
+    "$MOBIUS_RECOVERY_PORT" "$MOBIUS_RECOVERY_LOCAL_TOKEN"
+  echo "When repair is complete: scripts/mobiusctl recovery finish"
+  : "$app_was_stopped"
+}
+
+status_recovery() {
+  if ! load_state; then
+    echo "Recovery is not active."
+    exit 0
+  fi
+  compose ps recovery-target recovery
+  printf 'Loopback URL: http://127.0.0.1:%s/\n' "$MOBIUS_RECOVERY_PORT"
+}
+
+finish_recovery() {
+  if ! load_state; then
+    echo "No recovery state found; ensuring the ordinary app is running."
+    # Compose still needs an env file for profile interpolation.
+    write_state
+    load_state
+  fi
+  echo "Stopping and removing the isolated recovery services..."
+  recovery_down
+  rm -f "$STATE_FILE"
+
+  # Use the ordinary .env/default interpolation after the recovery secret is
+  # gone; the app never receives either recovery token.
+  (
+    cd "$PROJECT_DIR"
+    docker compose up -d app
+  )
+  container_id=$(
+    cd "$PROJECT_DIR"
+    docker compose ps -q app
+  )
+  [ -n "$container_id" ] || {
+    echo "Mobius app container was not created." >&2
+    exit 1
+  }
+  echo "Waiting for Mobius health..."
+  attempt=0
+  while [ "$attempt" -lt 120 ]; do
+    health=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$container_id" 2>/dev/null || true)
+    case "$health" in
+      healthy|running)
+        echo "Mobius is back and healthy."
+        exit 0
+        ;;
+      unhealthy|exited|dead)
+        echo "Mobius did not recover cleanly (state: $health)." >&2
+        exit 1
+        ;;
+    esac
+    attempt=$((attempt + 1))
+    sleep 1
+  done
+  echo "Timed out waiting for Mobius health." >&2
+  exit 1
+}
+
+case "$action" in
+  start) start_recovery ;;
+  status) status_recovery ;;
+  finish) finish_recovery ;;
+  *) usage ;;
+esac

--- a/scripts/mobiusctl
+++ b/scripts/mobiusctl
@@ -19,7 +19,8 @@ Usage: scripts/mobiusctl recovery start|reopen|status|finish
   start   stop Mobius, pull the latest approved recovery image, and expose the
           recovery UI on loopback (default http://127.0.0.1:18003)
   reopen  keep Mobius stopped, rotate both credentials, and recreate a clean
-          recovery target + latest worker with a new one-time sign-in code
+          recovery target + latest worker with a new one-time sign-in code;
+          required after either isolated service exits
   status  show the isolated recovery services
   finish  remove recovery services, restart Mobius, and verify app health
 EOF
@@ -374,6 +375,8 @@ show_recovery_access() {
   printf '  %s\n' "$MOBIUS_RECOVERY_LOCAL_TOKEN"
   printf 'Root repair authority expires at Unix epoch %s.\n' \
     "$MOBIUS_RECOVERY_TARGET_EXPIRES_AT"
+  echo "If either recovery service exits, do not restart it; rotate both credentials with:"
+  echo "  scripts/mobiusctl recovery reopen"
   echo "When repair is complete: scripts/mobiusctl recovery finish"
 }
 
@@ -461,7 +464,8 @@ status_recovery() {
   printf 'Loopback URL: http://127.0.0.1:%s/\n' "$MOBIUS_RECOVERY_PORT"
   printf 'Root target expiry (Unix epoch): %s\n' \
     "$MOBIUS_RECOVERY_TARGET_EXPIRES_AT"
-  echo "For a new one-time code: scripts/mobiusctl recovery reopen"
+  echo "If either service exited, do not restart it; rotate both credentials with:"
+  echo "  scripts/mobiusctl recovery reopen"
 }
 
 finish_recovery() {

--- a/scripts/mobiusctl
+++ b/scripts/mobiusctl
@@ -8,6 +8,9 @@ set -eu
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 PROJECT_DIR=$(dirname "$SCRIPT_DIR")
 STATE_FILE=${MOBIUS_RECOVERY_STATE_FILE:-"$PROJECT_DIR/.mobius-recovery.env"}
+RECOVERY_TARGET_MIN_TTL_SECONDS=300
+RECOVERY_TARGET_MAX_TTL_SECONDS=86400
+RECOVERY_TARGET_DEFAULT_TTL_SECONDS=3600
 
 usage() {
   cat >&2 <<'EOF'
@@ -25,14 +28,65 @@ EOF
 action=${2:-}
 [ "$#" -eq 2 ] || usage
 
+# Serialize every host-side state transition. In particular, `finish` and
+# `reopen` must never interleave into a state where the ordinary app and root
+# target both mount /data. Lock the installation directory itself (no
+# attacker-replaceable lock file), and bound contention so automation fails
+# loudly instead of hanging forever.
+LOCK_DIR=${MOBIUS_RECOVERY_LOCK_DIR:-$PROJECT_DIR}
+LOCK_WAIT=${MOBIUS_RECOVERY_LOCK_WAIT_SECONDS:-30}
+[ -d "$LOCK_DIR" ] && [ ! -L "$LOCK_DIR" ] || {
+  echo "Invalid recovery lock directory: $LOCK_DIR" >&2
+  exit 1
+}
+case "$LOCK_WAIT" in
+  ""|*[!0-9]*)
+    echo "MOBIUS_RECOVERY_LOCK_WAIT_SECONDS must be an integer from 0 to 300" >&2
+    exit 64
+    ;;
+esac
+[ "$LOCK_WAIT" -le 300 ] || {
+  echo "MOBIUS_RECOVERY_LOCK_WAIT_SECONDS must be an integer from 0 to 300" >&2
+  exit 64
+}
+command -v flock >/dev/null 2>&1 || {
+  echo "The host 'flock' command is required for safe recovery lifecycle changes." >&2
+  exit 69
+}
+exec 9< "$LOCK_DIR" || {
+  echo "Could not open the recovery lifecycle lock for $LOCK_DIR" >&2
+  exit 1
+}
+if ! flock -w "$LOCK_WAIT" 9; then
+  echo "Another Mobius recovery/update lifecycle is active; try again shortly." >&2
+  exit 75
+fi
+
+normal_compose() {
+  (
+    cd "$PROJECT_DIR"
+    if [ -f .env ]; then
+      docker compose --env-file .env "$@"
+    else
+      docker compose "$@"
+    fi
+  )
+}
+
 compose() {
   (
     cd "$PROJECT_DIR"
     if [ -f .env ]; then
-      docker compose --profile recovery \
-        --env-file .env --env-file "$STATE_FILE" "$@"
-    else
+      if [ -f "$STATE_FILE" ]; then
+        docker compose --profile recovery \
+          --env-file .env --env-file "$STATE_FILE" "$@"
+      else
+        docker compose --profile recovery --env-file .env "$@"
+      fi
+    elif [ -f "$STATE_FILE" ]; then
       docker compose --profile recovery --env-file "$STATE_FILE" "$@"
+    else
+      docker compose --profile recovery "$@"
     fi
   )
 }
@@ -56,6 +110,35 @@ validate_port() {
   esac
   [ "$1" -ge 1 ] && [ "$1" -le 65535 ] ||
     die_state "port must be an integer from 1 to 65535"
+}
+
+validate_ttl() {
+  case "$1" in
+    ""|*[!0-9]*)
+      die_state "MOBIUS_RECOVERY_TTL_SECONDS must be an integer from 300 to 86400"
+      ;;
+  esac
+  case "$1" in
+    0*)
+      die_state "MOBIUS_RECOVERY_TTL_SECONDS must be an integer from 300 to 86400"
+      ;;
+  esac
+  [ "$1" -ge "$RECOVERY_TARGET_MIN_TTL_SECONDS" ] &&
+    [ "$1" -le "$RECOVERY_TARGET_MAX_TTL_SECONDS" ] ||
+    die_state "MOBIUS_RECOVERY_TTL_SECONDS must be an integer from 300 to 86400"
+}
+
+validate_target_expiry() {
+  case "$1" in
+    ""|*[!0-9]*) die_state "target expiry must be an epoch integer" ;;
+  esac
+  case "$1" in
+    0*) die_state "target expiry must be an epoch integer" ;;
+  esac
+  [ "${#1}" -le 10 ] && [ "$1" -gt 0 ] ||
+    die_state "target expiry must be an epoch integer"
+  [ "$1" -le "$(( $2 + RECOVERY_TARGET_MAX_TTL_SECONDS ))" ] ||
+    die_state "target expiry exceeds the maximum 24-hour lifetime"
 }
 
 validate_image() {
@@ -87,10 +170,32 @@ write_state() {
   recovery_local_token=$(new_token)
   recovery_port=${MOBIUS_RECOVERY_PORT:-18003}
   recovery_image=${MOBIUS_RECOVERY_IMAGE:-ghcr.io/mobius-os/mobius-recovery:stable}
+  recovery_ttl=${MOBIUS_RECOVERY_TTL_SECONDS:-$RECOVERY_TARGET_DEFAULT_TTL_SECONDS}
+  validate_ttl "$recovery_ttl"
+  recovery_now=$(date -u +%s 2>/dev/null) ||
+    die_state "could not read the current epoch time"
+  case "$recovery_now" in
+    ""|*[!0-9]*) die_state "could not read the current epoch time" ;;
+  esac
+  recovery_target_expires_at=$((recovery_now + recovery_ttl))
   validate_token "$recovery_target_token"
   validate_token "$recovery_local_token"
   validate_port "$recovery_port"
   validate_image "$recovery_image"
+  validate_target_expiry "$recovery_target_expires_at" "$recovery_now"
+  unset recovery_now recovery_ttl
+}
+
+emit_state() {
+  printf 'MOBIUS_RECOVERY_TARGET_TOKEN=%s\n' "$recovery_target_token"
+  printf 'MOBIUS_RECOVERY_TARGET_EXPIRES_AT=%s\n' "$recovery_target_expires_at"
+  printf 'MOBIUS_RECOVERY_LOCAL_TOKEN=%s\n' "$recovery_local_token"
+  printf 'MOBIUS_RECOVERY_PORT=%s\n' "$recovery_port"
+  printf 'MOBIUS_RECOVERY_IMAGE=%s\n' "$recovery_image"
+}
+
+write_state() {
+  generate_state
 
   # Noclobber closes the symlink/existing-file race around state creation.
   # A later load independently verifies type, ownership, link count, and mode.
@@ -127,10 +232,12 @@ load_state() {
     die_state "$STATE_FILE must be owned by the current user"
 
   recovery_target_token=
+  recovery_target_expires_at=
   recovery_local_token=
   recovery_port=
   recovery_image=
   seen_target=0
+  seen_expiry=0
   seen_local=0
   seen_port=0
   seen_image=0
@@ -140,6 +247,11 @@ load_state() {
         [ "$seen_target" -eq 0 ] || die_state "duplicate target token"
         recovery_target_token=${state_line#MOBIUS_RECOVERY_TARGET_TOKEN=}
         seen_target=1
+        ;;
+      MOBIUS_RECOVERY_TARGET_EXPIRES_AT=*)
+        [ "$seen_expiry" -eq 0 ] || die_state "duplicate target expiry"
+        recovery_target_expires_at=${state_line#MOBIUS_RECOVERY_TARGET_EXPIRES_AT=}
+        seen_expiry=1
         ;;
       MOBIUS_RECOVERY_LOCAL_TOKEN=*)
         [ "$seen_local" -eq 0 ] || die_state "duplicate local token"
@@ -159,24 +271,81 @@ load_state() {
       *) die_state "unexpected or malformed line" ;;
     esac
   done < "$STATE_FILE"
-  [ "$seen_target$seen_local$seen_port$seen_image" = "1111" ] ||
+  [ "$seen_target$seen_expiry$seen_local$seen_port$seen_image" = "11111" ] ||
     die_state "required values are missing"
   validate_token "$recovery_target_token"
   validate_token "$recovery_local_token"
   validate_port "$recovery_port"
   validate_image "$recovery_image"
+  recovery_now=$(date -u +%s 2>/dev/null) ||
+    die_state "could not read the current epoch time"
+  case "$recovery_now" in
+    ""|*[!0-9]*) die_state "could not read the current epoch time" ;;
+  esac
+  validate_target_expiry "$recovery_target_expires_at" "$recovery_now"
+  unset recovery_now
 
   MOBIUS_RECOVERY_TARGET_TOKEN=$recovery_target_token
+  MOBIUS_RECOVERY_TARGET_EXPIRES_AT=$recovery_target_expires_at
   MOBIUS_RECOVERY_LOCAL_TOKEN=$recovery_local_token
   MOBIUS_RECOVERY_PORT=$recovery_port
   MOBIUS_RECOVERY_IMAGE=$recovery_image
-  export MOBIUS_RECOVERY_TARGET_TOKEN MOBIUS_RECOVERY_LOCAL_TOKEN
+  export MOBIUS_RECOVERY_TARGET_TOKEN MOBIUS_RECOVERY_TARGET_EXPIRES_AT
+  export MOBIUS_RECOVERY_LOCAL_TOKEN
   export MOBIUS_RECOVERY_PORT MOBIUS_RECOVERY_IMAGE
 }
 
 recovery_down() {
   compose stop recovery recovery-target >/dev/null 2>&1 || true
   compose rm -f recovery recovery-target >/dev/null 2>&1 || true
+}
+
+recovery_down_strict() {
+  compose stop recovery recovery-target || return $?
+  compose rm -f recovery recovery-target || return $?
+  remaining=$(compose ps -aq recovery recovery-target) || return $?
+  if [ -n "$remaining" ]; then
+    echo "Recovery services are still present after removal; the app stays stopped." >&2
+    return 1
+  fi
+  return 0
+}
+
+wait_for_normal_app() {
+  container_id=$(normal_compose ps -q app)
+  [ -n "$container_id" ] || {
+    echo "Mobius app container was not created." >&2
+    return 1
+  }
+  echo "Waiting for Mobius health..."
+  attempt=0
+  while [ "$attempt" -lt 120 ]; do
+    health=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$container_id" 2>/dev/null || true)
+    case "$health" in
+      healthy|running)
+        echo "Mobius is back and healthy."
+        return 0
+        ;;
+      unhealthy|exited|dead)
+        echo "Mobius did not recover cleanly (state: $health)." >&2
+        return 1
+        ;;
+    esac
+    attempt=$((attempt + 1))
+    sleep 1
+  done
+  echo "Timed out waiting for Mobius health." >&2
+  return 1
+}
+
+show_recovery_access() {
+  echo "Recovery is isolated from the stopped app and available only on loopback:"
+  printf '  http://127.0.0.1:%s/\n' "$MOBIUS_RECOVERY_PORT"
+  echo "Paste this one-time code into the Recovery sign-in form:"
+  printf '  %s\n' "$MOBIUS_RECOVERY_LOCAL_TOKEN"
+  printf 'Root repair authority expires at Unix epoch %s.\n' \
+    "$MOBIUS_RECOVERY_TARGET_EXPIRES_AT"
+  echo "When repair is complete: scripts/mobiusctl recovery finish"
 }
 
 start_recovery() {
@@ -191,10 +360,17 @@ start_recovery() {
   cleanup_failed_start() {
     status=$?
     if [ "$status" -ne 0 ]; then
-      echo "Recovery start failed; restoring the ordinary Mobius app." >&2
-      recovery_down
-      compose up -d app >/dev/null 2>&1 || true
-      rm -f "$STATE_FILE"
+      echo "Recovery start failed; retiring partial recovery services." >&2
+      if recovery_down_strict; then
+        if [ "$app_was_stopped" -eq 0 ] || normal_compose up -d app; then
+          rm -f -- "$STATE_FILE"
+          echo "The ordinary Mobius app is restored." >&2
+        else
+          echo "The ordinary Mobius app could not be restored; recovery state was retained." >&2
+        fi
+      else
+        echo "Partial recovery services could not be removed; the app remains stopped and recovery state was retained." >&2
+      fi
     fi
     exit "$status"
   }
@@ -223,52 +399,30 @@ status_recovery() {
   fi
   compose ps recovery-target recovery
   printf 'Loopback URL: http://127.0.0.1:%s/\n' "$MOBIUS_RECOVERY_PORT"
+  printf 'Root target expiry (Unix epoch): %s\n' \
+    "$MOBIUS_RECOVERY_TARGET_EXPIRES_AT"
+  echo "For a new one-time code: scripts/mobiusctl recovery reopen"
 }
 
 finish_recovery() {
   if ! load_state; then
-    echo "No recovery state found; ensuring the ordinary app is running."
-    # Compose still needs an env file for profile interpolation.
-    write_state
-    load_state
+    echo "No recovery state found; verifying isolated services are absent."
   fi
   echo "Stopping and removing the isolated recovery services..."
-  recovery_down
-  rm -f "$STATE_FILE"
+  # This is the mutual-exclusion gate: never discard the credentials or start
+  # the ordinary app unless Compose proves both isolated services are gone.
+  recovery_down_strict
+  if [ -e "$STATE_FILE" ] || [ -L "$STATE_FILE" ]; then
+    rm -f -- "$STATE_FILE"
+  fi
+  [ ! -e "$STATE_FILE" ] && [ ! -L "$STATE_FILE" ] ||
+    die_state "could not remove recovery state after service teardown"
 
-  # Use the ordinary .env/default interpolation after the recovery secret is
-  # gone; the app never receives either recovery token.
-  (
-    cd "$PROJECT_DIR"
-    docker compose up -d app
-  )
-  container_id=$(
-    cd "$PROJECT_DIR"
-    docker compose ps -q app
-  )
-  [ -n "$container_id" ] || {
-    echo "Mobius app container was not created." >&2
-    exit 1
-  }
-  echo "Waiting for Mobius health..."
-  attempt=0
-  while [ "$attempt" -lt 120 ]; do
-    health=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$container_id" 2>/dev/null || true)
-    case "$health" in
-      healthy|running)
-        echo "Mobius is back and healthy."
-        exit 0
-        ;;
-      unhealthy|exited|dead)
-        echo "Mobius did not recover cleanly (state: $health)." >&2
-        exit 1
-        ;;
-    esac
-    attempt=$((attempt + 1))
-    sleep 1
-  done
-  echo "Timed out waiting for Mobius health." >&2
-  exit 1
+  # Recreate rather than restart the stopped container. Full sudo can mutate
+  # its writable overlay; only a new container from the configured image makes
+  # the external recovery boundary meaningful after repair or sudo revocation.
+  normal_compose up -d --force-recreate app
+  wait_for_normal_app
 }
 
 case "$action" in

--- a/scripts/mobiusctl
+++ b/scripts/mobiusctl
@@ -45,26 +45,131 @@ new_token() {
   fi
 }
 
+die_state() {
+  echo "Invalid recovery state: $*" >&2
+  exit 1
+}
+
+validate_port() {
+  case "$1" in
+    ""|*[!0-9]*) die_state "port must be an integer from 1 to 65535" ;;
+  esac
+  [ "$1" -ge 1 ] && [ "$1" -le 65535 ] ||
+    die_state "port must be an integer from 1 to 65535"
+}
+
+validate_image() {
+  # Deliberately narrower than the full OCI grammar. Every accepted character
+  # is inert in both an env file and a shell assignment, while ordinary
+  # registry/repository/tag/digest references remain supported.
+  [ "${#1}" -le 512 ] || die_state "recovery image reference is too long"
+  case "$1" in
+    [A-Za-z0-9]*) ;;
+    *) die_state "recovery image must start with a letter or number" ;;
+  esac
+  case "$1" in
+    *[!A-Za-z0-9._/@:+-]*)
+      die_state "recovery image contains unsafe characters"
+      ;;
+  esac
+}
+
+validate_token() {
+  [ "${#1}" -ge 32 ] && [ "${#1}" -le 512 ] ||
+    die_state "recovery token length is invalid"
+  case "$1" in
+    *[!A-Za-z0-9_-]*) die_state "recovery token contains unsafe characters" ;;
+  esac
+}
+
 write_state() {
-  if [ -L "$STATE_FILE" ]; then
-    echo "Refusing symlink recovery state: $STATE_FILE" >&2
-    exit 1
+  recovery_target_token=$(new_token)
+  recovery_local_token=$(new_token)
+  recovery_port=${MOBIUS_RECOVERY_PORT:-18003}
+  recovery_image=${MOBIUS_RECOVERY_IMAGE:-ghcr.io/mobius-os/mobius-recovery:stable}
+  validate_token "$recovery_target_token"
+  validate_token "$recovery_local_token"
+  validate_port "$recovery_port"
+  validate_image "$recovery_image"
+
+  # Noclobber closes the symlink/existing-file race around state creation.
+  # A later load independently verifies type, ownership, link count, and mode.
+  if ! (
+    umask 077
+    set -C
+    {
+      printf 'MOBIUS_RECOVERY_TARGET_TOKEN=%s\n' "$recovery_target_token"
+      printf 'MOBIUS_RECOVERY_LOCAL_TOKEN=%s\n' "$recovery_local_token"
+      printf 'MOBIUS_RECOVERY_PORT=%s\n' "$recovery_port"
+      printf 'MOBIUS_RECOVERY_IMAGE=%s\n' "$recovery_image"
+    } > "$STATE_FILE"
+  ); then
+    die_state "could not create $STATE_FILE exclusively"
   fi
-  umask 077
-  {
-    printf 'MOBIUS_RECOVERY_TARGET_TOKEN=%s\n' "$(new_token)"
-    printf 'MOBIUS_RECOVERY_LOCAL_TOKEN=%s\n' "$(new_token)"
-    printf 'MOBIUS_RECOVERY_PORT=%s\n' "${MOBIUS_RECOVERY_PORT:-18003}"
-    printf 'MOBIUS_RECOVERY_IMAGE=%s\n' \
-      "${MOBIUS_RECOVERY_IMAGE:-ghcr.io/mobius-os/mobius-recovery:stable}"
-  } > "$STATE_FILE"
 }
 
 load_state() {
-  [ -f "$STATE_FILE" ] || return 1
-  # Generated values contain only URL-safe token/image/number characters.
-  # shellcheck disable=SC1090
-  . "$STATE_FILE"
+  if [ ! -e "$STATE_FILE" ] && [ ! -L "$STATE_FILE" ]; then
+    return 1
+  fi
+  [ ! -L "$STATE_FILE" ] || die_state "$STATE_FILE must not be a symlink"
+  [ -f "$STATE_FILE" ] || die_state "$STATE_FILE must be a regular file"
+  state_metadata=$(stat -c '%h %a %u' -- "$STATE_FILE" 2>/dev/null) ||
+    die_state "could not inspect $STATE_FILE"
+  set -- $state_metadata
+  [ "$#" -eq 3 ] || die_state "could not inspect $STATE_FILE"
+  [ "$1" -eq 1 ] || die_state "$STATE_FILE must have exactly one hard link"
+  case "$2" in
+    400|600) ;;
+    *) die_state "$STATE_FILE permissions must be 0600 or 0400" ;;
+  esac
+  [ "$3" -eq "$(id -u)" ] ||
+    die_state "$STATE_FILE must be owned by the current user"
+
+  recovery_target_token=
+  recovery_local_token=
+  recovery_port=
+  recovery_image=
+  seen_target=0
+  seen_local=0
+  seen_port=0
+  seen_image=0
+  while IFS= read -r state_line || [ -n "$state_line" ]; do
+    case "$state_line" in
+      MOBIUS_RECOVERY_TARGET_TOKEN=*)
+        [ "$seen_target" -eq 0 ] || die_state "duplicate target token"
+        recovery_target_token=${state_line#MOBIUS_RECOVERY_TARGET_TOKEN=}
+        seen_target=1
+        ;;
+      MOBIUS_RECOVERY_LOCAL_TOKEN=*)
+        [ "$seen_local" -eq 0 ] || die_state "duplicate local token"
+        recovery_local_token=${state_line#MOBIUS_RECOVERY_LOCAL_TOKEN=}
+        seen_local=1
+        ;;
+      MOBIUS_RECOVERY_PORT=*)
+        [ "$seen_port" -eq 0 ] || die_state "duplicate port"
+        recovery_port=${state_line#MOBIUS_RECOVERY_PORT=}
+        seen_port=1
+        ;;
+      MOBIUS_RECOVERY_IMAGE=*)
+        [ "$seen_image" -eq 0 ] || die_state "duplicate image"
+        recovery_image=${state_line#MOBIUS_RECOVERY_IMAGE=}
+        seen_image=1
+        ;;
+      *) die_state "unexpected or malformed line" ;;
+    esac
+  done < "$STATE_FILE"
+  [ "$seen_target$seen_local$seen_port$seen_image" = "1111" ] ||
+    die_state "required values are missing"
+  validate_token "$recovery_target_token"
+  validate_token "$recovery_local_token"
+  validate_port "$recovery_port"
+  validate_image "$recovery_image"
+
+  MOBIUS_RECOVERY_TARGET_TOKEN=$recovery_target_token
+  MOBIUS_RECOVERY_LOCAL_TOKEN=$recovery_local_token
+  MOBIUS_RECOVERY_PORT=$recovery_port
+  MOBIUS_RECOVERY_IMAGE=$recovery_image
   export MOBIUS_RECOVERY_TARGET_TOKEN MOBIUS_RECOVERY_LOCAL_TOKEN
   export MOBIUS_RECOVERY_PORT MOBIUS_RECOVERY_IMAGE
 }

--- a/scripts/mobiusctl
+++ b/scripts/mobiusctl
@@ -14,10 +14,12 @@ RECOVERY_TARGET_DEFAULT_TTL_SECONDS=3600
 
 usage() {
   cat >&2 <<'EOF'
-Usage: scripts/mobiusctl recovery start|status|finish
+Usage: scripts/mobiusctl recovery start|reopen|status|finish
 
   start   stop Mobius, pull the latest approved recovery image, and expose the
           recovery UI on loopback (default http://127.0.0.1:18003)
+  reopen  keep Mobius stopped, rotate both credentials, and recreate a clean
+          recovery target + latest worker with a new one-time sign-in code
   status  show the isolated recovery services
   finish  remove recovery services, restart Mobius, and verify app health
 EOF
@@ -165,7 +167,7 @@ validate_token() {
   esac
 }
 
-write_state() {
+generate_state() {
   recovery_target_token=$(new_token)
   recovery_local_token=$(new_token)
   recovery_port=${MOBIUS_RECOVERY_PORT:-18003}
@@ -202,15 +204,42 @@ write_state() {
   if ! (
     umask 077
     set -C
-    {
-      printf 'MOBIUS_RECOVERY_TARGET_TOKEN=%s\n' "$recovery_target_token"
-      printf 'MOBIUS_RECOVERY_LOCAL_TOKEN=%s\n' "$recovery_local_token"
-      printf 'MOBIUS_RECOVERY_PORT=%s\n' "$recovery_port"
-      printf 'MOBIUS_RECOVERY_IMAGE=%s\n' "$recovery_image"
-    } > "$STATE_FILE"
+    emit_state > "$STATE_FILE"
   ); then
     die_state "could not create $STATE_FILE exclusively"
   fi
+}
+
+rotate_state() {
+  old_target_token=$recovery_target_token
+  old_local_token=$recovery_local_token
+  rotation_attempt=0
+  while [ "$rotation_attempt" -lt 3 ]; do
+    generate_state
+    if [ "$recovery_target_token" != "$old_target_token" ] &&
+       [ "$recovery_local_token" != "$old_local_token" ]; then
+      break
+    fi
+    rotation_attempt=$((rotation_attempt + 1))
+  done
+  [ "$recovery_target_token" != "$old_target_token" ] &&
+    [ "$recovery_local_token" != "$old_local_token" ] ||
+    die_state "could not rotate recovery credentials"
+
+  # Replace the already-validated single-link state atomically. A crash before
+  # rename leaves the old valid state; a crash after rename leaves the new one,
+  # so `reopen` is always safely retryable while the ordinary app stays down.
+  state_tmp=$(mktemp "${STATE_FILE}.tmp.XXXXXX") ||
+    die_state "could not create temporary recovery state"
+  chmod 600 "$state_tmp" || {
+    rm -f -- "$state_tmp"
+    die_state "could not secure temporary recovery state"
+  }
+  if ! emit_state > "$state_tmp" || ! mv -f -- "$state_tmp" "$STATE_FILE"; then
+    rm -f -- "$state_tmp"
+    die_state "could not atomically rotate recovery state"
+  fi
+  unset state_tmp old_target_token old_local_token rotation_attempt
 }
 
 load_state() {
@@ -350,7 +379,7 @@ show_recovery_access() {
 
 start_recovery() {
   if [ -f "$STATE_FILE" ]; then
-    echo "Recovery state already exists. Run 'scripts/mobiusctl recovery status' or finish it first." >&2
+    echo "Recovery state already exists. Run 'scripts/mobiusctl recovery reopen' for a new code, or finish it first." >&2
     exit 1
   fi
   write_state
@@ -384,12 +413,43 @@ start_recovery() {
   compose up -d --force-recreate recovery-target recovery
 
   trap - EXIT HUP INT TERM
-  echo "Recovery is isolated from the stopped app and available only on loopback:"
-  printf '  http://127.0.0.1:%s/\n' "$MOBIUS_RECOVERY_PORT"
-  echo "Paste this one-time code into the Recovery sign-in form:"
-  printf '  %s\n' "$MOBIUS_RECOVERY_LOCAL_TOKEN"
-  echo "When repair is complete: scripts/mobiusctl recovery finish"
+  show_recovery_access
   : "$app_was_stopped"
+}
+
+reopen_recovery() {
+  if ! load_state; then
+    echo "Recovery is not active; run 'scripts/mobiusctl recovery start' first." >&2
+    exit 1
+  fi
+
+  services_stopped=0
+  cleanup_failed_reopen() {
+    status=$?
+    if [ "$status" -ne 0 ]; then
+      echo "Recovery reopen failed; the ordinary Mobius app remains stopped." >&2
+      if [ "$services_stopped" -eq 1 ]; then
+        recovery_down
+      fi
+    fi
+    exit "$status"
+  }
+  trap cleanup_failed_reopen EXIT HUP INT TERM
+
+  echo "Ensuring the ordinary Mobius app stays stopped..."
+  compose stop app
+  echo "Pulling the latest approved recovery worker..."
+  compose pull recovery
+  echo "Removing the previous isolated recovery services..."
+  recovery_down_strict
+  services_stopped=1
+  rotate_state
+  load_state
+  compose up -d --force-recreate recovery-target recovery
+
+  trap - EXIT HUP INT TERM
+  echo "Previous recovery credentials were revoked."
+  show_recovery_access
 }
 
 status_recovery() {
@@ -427,6 +487,7 @@ finish_recovery() {
 
 case "$action" in
   start) start_recovery ;;
+  reopen) reopen_recovery ;;
   status) status_recovery ;;
   finish) finish_recovery ;;
   *) usage ;;

--- a/scripts/mobiusctl
+++ b/scripts/mobiusctl
@@ -104,8 +104,9 @@ start_recovery() {
 
   trap - EXIT HUP INT TERM
   echo "Recovery is isolated from the stopped app and available only on loopback:"
-  printf '  http://127.0.0.1:%s/?token=%s\n' \
-    "$MOBIUS_RECOVERY_PORT" "$MOBIUS_RECOVERY_LOCAL_TOKEN"
+  printf '  http://127.0.0.1:%s/\n' "$MOBIUS_RECOVERY_PORT"
+  echo "Paste this one-time code into the Recovery sign-in form:"
+  printf '  %s\n' "$MOBIUS_RECOVERY_LOCAL_TOKEN"
   echo "When repair is complete: scripts/mobiusctl recovery finish"
   : "$app_was_stopped"
 }

--- a/scripts/verify-recovery-target-container.sh
+++ b/scripts/verify-recovery-target-container.sh
@@ -27,16 +27,19 @@ printf '%s\n' \
   'BUILD_SHA=runtime-spoof-must-not-win' \
   "MOBIUS_RECOVERY_TARGET_TOKEN=$TOKEN" >"$ENV_FILE"
 
-# Add both dangerous capabilities deliberately. targetd must remove them itself
-# so this proves the invariant independently of Compose or platform defaults.
+# Add dangerous capabilities deliberately. targetd must remove them itself so
+# this proves the invariant independently of Compose or platform defaults.
 docker run -d \
   --name "$CONTAINER" \
   --read-only \
   --tmpfs /tmp \
   --tmpfs /run \
   --tmpfs /data \
+  --tmpfs /data/mounted:rw,noexec,nosuid,size=1m \
   --cap-add NET_ADMIN \
   --cap-add NET_RAW \
+  --cap-add SYS_ADMIN \
+  --cap-add SYS_PTRACE \
   --no-healthcheck \
   --env-file "$ENV_FILE" \
   -p 127.0.0.1::18002 \
@@ -62,6 +65,7 @@ headers = {
   "Authorization": f"Bearer {token}",
   "Content-Type": "application/json",
 }
+rejected_fs_checks = []
 
 
 def request(path, payload=None):
@@ -72,6 +76,19 @@ def request(path, payload=None):
   )
   with urllib.request.urlopen(req, timeout=5) as response:
     return json.load(response)
+
+
+def rejected(path, payload):
+  try:
+    request(path, payload)
+  except urllib.error.HTTPError as exc:
+    body = json.load(exc)
+    assert exc.code == 403, (path, payload, exc.code, body)
+    assert body["error"]["code"] == "path_forbidden", body
+    assert token not in json.dumps(body), body
+    rejected_fs_checks.append((path, payload.get("path")))
+  else:
+    raise AssertionError((path, payload, "request unexpectedly succeeded"))
 
 
 deadline = time.monotonic() + 30
@@ -87,6 +104,43 @@ while True:
 revision = health["build_sha"]
 assert len(revision) == 40 and all(c in "0123456789abcdef" for c in revision)
 assert revision != "runtime-spoof-must-not-win"
+
+# Target PID1 handles convenience filesystem calls itself, so nondumpability
+# alone cannot protect its memory from a confused-deputy /proc read. Prove the
+# authenticated API rejects virtual filesystems, lexical/symlink escapes, and a
+# real nested tmpfs mount while ordinary /data IO remains available.
+safe_payload = base64.b64encode(b"safe recovery data").decode("ascii")
+written = request("/v1/fs/write", {
+  "path": "/data/http-positive",
+  "data_base64": safe_payload,
+})
+assert written["bytes_written"] == len(b"safe recovery data")
+safe_read = request("/v1/fs/read", {"path": "/data/http-positive"})
+assert base64.b64decode(safe_read["data_base64"]) == b"safe recovery data"
+
+for proc_path in ("/proc/1/maps", "/proc/1/mem", "/proc/1/environ"):
+  rejected("/v1/fs/read", {"path": proc_path})
+rejected("/v1/fs/list", {"path": "/proc/1"})
+rejected("/v1/fs/read", {"path": "/sys/kernel/uevent_seqnum"})
+rejected("/v1/fs/write", {
+  "path": "/dev/null",
+  "data_base64": base64.b64encode(b"blocked").decode("ascii"),
+})
+rejected("/v1/fs/read", {"path": "/data/../proc/1/maps"})
+rejected("/v1/fs/list", {"path": "/data/mounted"})
+
+link_setup = request("/v1/exec", {
+  "argv": ["/bin/ln", "-s", "/proc", "/data/proc-link"],
+  "cwd": "/data",
+})
+assert link_setup["exit_code"] == 0, link_setup
+rejected("/v1/fs/read", {"path": "/data/proc-link/1/maps"})
+rejected("/v1/fs/list", {"path": "/data/proc-link/1"})
+rejected("/v1/fs/write", {
+  "path": "/data/proc-link/forbidden",
+  "data_base64": base64.b64encode(b"blocked").decode("ascii"),
+})
+assert len(rejected_fs_checks) == 11, rejected_fs_checks
 
 child_program = r'''
 import json
@@ -191,12 +245,13 @@ else:
 assert token not in child["proc"]["environ"]["data"]
 assert "MOBIUS_RECOVERY_TARGET_TOKEN=" not in child["proc"]["environ"]["data"]
 
-blocked_mask = (1 << 12) | (1 << 13)
+blocked_mask = (1 << 12) | (1 << 13) | (1 << 19) | (1 << 21)
 assert set(child["caps"]) == {"CapInh", "CapPrm", "CapEff", "CapBnd", "CapAmb"}
 for name, raw_value in child["caps"].items():
   assert int(raw_value, 16) & blocked_mask == 0, (name, raw_value)
 
 print(json.dumps({
+  "blocked_fs_checks": len(rejected_fs_checks),
   "build_sha": revision,
   "packet_errno": child["packet"]["errno"],
   "capabilities": child["caps"],

--- a/scripts/verify-recovery-target-container.sh
+++ b/scripts/verify-recovery-target-container.sh
@@ -5,8 +5,10 @@ set -euo pipefail
 
 IMAGE=${MOBIUS_IMAGE:-mobius}
 CONTAINER="mobius-recovery-target-security-$$"
+EXPIRED_CONTAINER="${CONTAINER}-expired"
 ENV_FILE=$(mktemp /tmp/mobius-recovery-target-security.XXXXXX)
 TOKEN=$(python3 -c 'import secrets; print(secrets.token_urlsafe(48))')
+EXPIRES_AT=$(($(date -u +%s) + 600))
 
 cleanup() {
   status=$?
@@ -14,6 +16,7 @@ cleanup() {
     docker logs "$CONTAINER" 2>/dev/null || true
   fi
   docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+  docker rm -f "$EXPIRED_CONTAINER" >/dev/null 2>&1 || true
   rm -f "$ENV_FILE"
   exit "$status"
 }
@@ -25,6 +28,7 @@ printf '%s\n' \
   'MOBIUS_RECOVERY_TARGET_PORT=18002' \
   'DATA_DIR=/data' \
   'BUILD_SHA=runtime-spoof-must-not-win' \
+  "MOBIUS_RECOVERY_TARGET_EXPIRES_AT=$EXPIRES_AT" \
   "MOBIUS_RECOVERY_TARGET_TOKEN=$TOKEN" >"$ENV_FILE"
 
 # Add dangerous capabilities deliberately. targetd must remove them itself so
@@ -50,6 +54,7 @@ BINDING=$(docker port "$CONTAINER" 18002/tcp)
 PORT=${BINDING##*:}
 MOBIUS_TEST_URL="http://127.0.0.1:$PORT" \
 MOBIUS_TEST_TOKEN="$TOKEN" \
+MOBIUS_TEST_EXPIRES_AT="$EXPIRES_AT" \
 python3 - <<'PY'
 import base64
 import errno
@@ -61,6 +66,7 @@ import urllib.request
 
 url = os.environ["MOBIUS_TEST_URL"]
 token = os.environ["MOBIUS_TEST_TOKEN"]
+expires_at = int(os.environ["MOBIUS_TEST_EXPIRES_AT"])
 headers = {
   "Authorization": f"Bearer {token}",
   "Content-Type": "application/json",
@@ -104,6 +110,7 @@ while True:
 revision = health["build_sha"]
 assert len(revision) == 40 and all(c in "0123456789abcdef" for c in revision)
 assert revision != "runtime-spoof-must-not-win"
+assert health["expires_at"] == expires_at, health
 
 # Target PID1 handles convenience filesystem calls itself, so nondumpability
 # alone cannot protect its memory from a confused-deputy /proc read. Prove the
@@ -141,6 +148,46 @@ rejected("/v1/fs/write", {
   "data_base64": base64.b64encode(b"blocked").decode("ascii"),
 })
 assert len(rejected_fs_checks) == 11, rejected_fs_checks
+
+# A process group is not a containment boundary: a repair command can call
+# setsid and double-fork while retaining the HTTP response pipes. The baked
+# per-exec subreaper must kill/reap that descendant before returning.
+escaped_program = r'''
+import os
+import time
+
+pid = os.fork()
+if pid:
+  os._exit(0)
+os.setsid()
+pid = os.fork()
+if pid:
+  os._exit(0)
+with open("/tmp/recovery-escaped.pid", "w", encoding="ascii") as target:
+  target.write(str(os.getpid()))
+time.sleep(30)
+'''
+escaped_started = time.monotonic()
+escaped_result = request("/v1/exec", {
+  "argv": ["/usr/local/bin/python3", "-c", escaped_program],
+  "cwd": "/tmp",
+  "timeout_seconds": 5,
+})
+assert escaped_result["exit_code"] == 0, escaped_result
+assert not escaped_result["timed_out"], escaped_result
+assert time.monotonic() - escaped_started < 3, escaped_result
+escaped_marker = request(
+  "/v1/fs/read", {"path": "/tmp/recovery-escaped.pid"},
+)
+escaped_pid = int(base64.b64decode(escaped_marker["data_base64"]))
+escaped_probe = request("/v1/exec", {
+  "argv": [
+    "/usr/local/bin/python3", "-c",
+    f"import os,sys; sys.exit(1 if os.path.exists('/proc/{escaped_pid}') else 0)",
+  ],
+  "cwd": "/tmp",
+})
+assert escaped_probe["exit_code"] == 0, (escaped_pid, escaped_probe)
 
 child_program = r'''
 import json
@@ -253,8 +300,86 @@ for name, raw_value in child["caps"].items():
 print(json.dumps({
   "blocked_fs_checks": len(rejected_fs_checks),
   "build_sha": revision,
+  "escaped_pid_reaped": escaped_pid,
   "packet_errno": child["packet"]["errno"],
   "capabilities": child["caps"],
   "pid_one": child["pid_one"],
 }, sort_keys=True))
 PY
+
+# A retained bearer must become inert at the target's own absolute deadline,
+# independently of worker/session state. The target closes its listener and
+# parks PID1 instead of exiting into an `unless-stopped` restart loop.
+TOKEN=$(python3 -c 'import secrets; print(secrets.token_urlsafe(48))')
+EXPIRES_AT=$(($(date -u +%s) + 8))
+ENV_FILE=$(mktemp /tmp/mobius-recovery-target-expiry.XXXXXX)
+chmod 600 "$ENV_FILE"
+printf '%s\n' \
+  'MOBIUS_BOOT_MODE=recovery' \
+  'MOBIUS_RECOVERY_TARGET_PORT=18002' \
+  'DATA_DIR=/data' \
+  "MOBIUS_RECOVERY_TARGET_EXPIRES_AT=$EXPIRES_AT" \
+  "MOBIUS_RECOVERY_TARGET_TOKEN=$TOKEN" >"$ENV_FILE"
+docker run -d \
+  --name "$EXPIRED_CONTAINER" \
+  --read-only \
+  --tmpfs /tmp \
+  --tmpfs /run \
+  --tmpfs /data \
+  --no-healthcheck \
+  --env-file "$ENV_FILE" \
+  -p 127.0.0.1::18002 \
+  "$IMAGE" >/dev/null
+rm -f "$ENV_FILE"
+
+BINDING=$(docker port "$EXPIRED_CONTAINER" 18002/tcp)
+PORT=${BINDING##*:}
+MOBIUS_TEST_URL="http://127.0.0.1:$PORT" \
+MOBIUS_TEST_TOKEN="$TOKEN" \
+MOBIUS_TEST_EXPIRES_AT="$EXPIRES_AT" \
+python3 - <<'PY'
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+
+url = os.environ["MOBIUS_TEST_URL"]
+token = os.environ["MOBIUS_TEST_TOKEN"]
+expires_at = int(os.environ["MOBIUS_TEST_EXPIRES_AT"])
+request = urllib.request.Request(
+  url + "/v1/health",
+  headers={"Authorization": f"Bearer {token}"},
+)
+while True:
+  try:
+    with urllib.request.urlopen(request, timeout=1) as response:
+      health = json.load(response)
+    break
+  except (OSError, urllib.error.URLError):
+    if time.time() >= expires_at - 1:
+      raise
+    time.sleep(0.1)
+assert health["expires_at"] == expires_at, health
+
+time.sleep(max(0, expires_at - time.time()) + 0.25)
+try:
+  urllib.request.urlopen(request, timeout=1)
+except urllib.error.HTTPError as exc:
+  body = json.load(exc)
+  assert exc.code == 401, (exc.code, body)
+  assert body["error"]["code"] == "auth_expired", body
+  result = "auth_expired"
+except (ConnectionError, urllib.error.URLError, TimeoutError, OSError):
+  result = "listener_closed"
+else:
+  raise AssertionError("expired recovery bearer was still accepted")
+print(json.dumps({"expired_bearer": result}, sort_keys=True))
+PY
+
+expired_state=$(docker inspect \
+  -f '{{.State.Running}} {{.RestartCount}}' "$EXPIRED_CONTAINER")
+[ "$expired_state" = "true 0" ] || {
+  echo "expired recovery target did not remain quiescent: $expired_state" >&2
+  exit 1
+}

--- a/scripts/verify-recovery-target-container.sh
+++ b/scripts/verify-recovery-target-container.sh
@@ -110,17 +110,49 @@ else:
   packet = {"opened": True, "errno": None}
   packet_socket.close()
 
-try:
-  with open("/proc/1/environ", "rb") as environ:
-    parent_environment = environ.read()
-except OSError as exc:
-  proc = {"readable": False, "errno": exc.errno, "data": ""}
-else:
-  proc = {
+def probe_file(path):
+  try:
+    with open(path, "rb", buffering=0) as source:
+      data = source.read(4096)
+  except OSError as exc:
+    return {"readable": False, "errno": exc.errno, "data": ""}
+  return {
     "readable": True,
     "errno": None,
-    "data": parent_environment.decode("latin1"),
+    "data": data.decode("latin1"),
   }
+
+
+def probe_fds(path):
+  try:
+    entries = os.listdir(path)
+  except OSError as exc:
+    return {"listed": False, "errno": exc.errno, "entries": {}}
+  probes = {}
+  for entry in entries:
+    fd_path = f"{path}/{entry}"
+    try:
+      target = os.readlink(fd_path)
+    except OSError as exc:
+      link = {"readable": False, "errno": exc.errno, "target": ""}
+    else:
+      link = {"readable": True, "errno": None, "target": target}
+    try:
+      opened = os.open(fd_path, os.O_RDONLY | os.O_NONBLOCK)
+    except OSError as exc:
+      descriptor = {"openable": False, "errno": exc.errno}
+    else:
+      os.close(opened)
+      descriptor = {"openable": True, "errno": None}
+    probes[entry] = {"link": link, "descriptor": descriptor}
+  return {"listed": True, "errno": None, "entries": probes}
+
+
+proc = {
+  "environ": probe_file("/proc/1/environ"),
+  "mem": probe_file("/proc/1/mem"),
+  "fds": probe_fds("/proc/1/fd"),
+}
 
 print(json.dumps({
   "uid": os.geteuid(),
@@ -140,8 +172,24 @@ assert child["uid"] == 0
 assert "targetd.py" in child["pid_one"]
 assert child["packet"]["opened"] is False
 assert child["packet"]["errno"] in {errno.EPERM, errno.EACCES}
-assert token not in child["proc"]["data"]
-assert "MOBIUS_RECOVERY_TARGET_TOKEN=" not in child["proc"]["data"]
+for name in ("environ", "mem"):
+  probe = child["proc"][name]
+  assert probe["readable"] is False, (name, probe)
+  assert probe["errno"] in {errno.EPERM, errno.EACCES}, (name, probe)
+fds = child["proc"]["fds"]
+if not fds["listed"]:
+  assert fds["errno"] in {errno.EPERM, errno.EACCES}, fds
+else:
+  assert fds["entries"], fds
+  for fd, probe in fds["entries"].items():
+    assert probe["link"]["readable"] is False, (fd, probe)
+    assert probe["link"]["errno"] in {errno.EPERM, errno.EACCES}, (fd, probe)
+    assert probe["descriptor"]["openable"] is False, (fd, probe)
+    assert probe["descriptor"]["errno"] in {
+      errno.EPERM, errno.EACCES,
+    }, (fd, probe)
+assert token not in child["proc"]["environ"]["data"]
+assert "MOBIUS_RECOVERY_TARGET_TOKEN=" not in child["proc"]["environ"]["data"]
 
 blocked_mask = (1 << 12) | (1 << 13)
 assert set(child["caps"]) == {"CapInh", "CapPrm", "CapEff", "CapBnd", "CapAmb"}

--- a/scripts/verify-recovery-target-container.sh
+++ b/scripts/verify-recovery-target-container.sh
@@ -35,6 +35,7 @@ printf '%s\n' \
 # this proves the invariant independently of Compose or platform defaults.
 docker run -d \
   --name "$CONTAINER" \
+  --restart=no \
   --read-only \
   --tmpfs /tmp \
   --tmpfs /run \
@@ -307,9 +308,30 @@ print(json.dumps({
 }, sort_keys=True))
 PY
 
+# A crash must leave the root target exited. Reconstructing it automatically
+# from the container config would replay the same still-live bearer; the host
+# lifecycle must instead remove both services and rotate both credentials via
+# `mobiusctl recovery reopen`.
+restart_policy=$(docker inspect \
+  -f '{{.HostConfig.RestartPolicy.Name}}' "$CONTAINER")
+[ "$restart_policy" = "no" ] || {
+  echo "recovery target has replay-prone restart policy: $restart_policy" >&2
+  exit 1
+}
+docker kill "$CONTAINER" >/dev/null
+docker wait "$CONTAINER" >/dev/null
+sleep 2
+crashed_state=$(docker inspect \
+  -f '{{.State.Status}} {{.RestartCount}}' "$CONTAINER")
+[ "$crashed_state" = "exited 0" ] || {
+  echo "crashed recovery target restarted with retained authority: $crashed_state" >&2
+  exit 1
+}
+
 # A retained bearer must become inert at the target's own absolute deadline,
 # independently of worker/session state. The target closes its listener and
-# parks PID1 instead of exiting into an `unless-stopped` restart loop.
+# parks PID1; expiry therefore remains final even if an operator inspects the
+# still-running container before using `mobiusctl recovery reopen`.
 TOKEN=$(python3 -c 'import secrets; print(secrets.token_urlsafe(48))')
 EXPIRES_AT=$(($(date -u +%s) + 8))
 ENV_FILE=$(mktemp /tmp/mobius-recovery-target-expiry.XXXXXX)
@@ -322,6 +344,7 @@ printf '%s\n' \
   "MOBIUS_RECOVERY_TARGET_TOKEN=$TOKEN" >"$ENV_FILE"
 docker run -d \
   --name "$EXPIRED_CONTAINER" \
+  --restart=no \
   --read-only \
   --tmpfs /tmp \
   --tmpfs /run \

--- a/scripts/verify-recovery-target-container.sh
+++ b/scripts/verify-recovery-target-container.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Proves the root recovery target cannot reveal its bearer or sniff worker HTTP.
+
+set -euo pipefail
+
+IMAGE=${MOBIUS_IMAGE:-mobius}
+CONTAINER="mobius-recovery-target-security-$$"
+ENV_FILE=$(mktemp /tmp/mobius-recovery-target-security.XXXXXX)
+TOKEN=$(python3 -c 'import secrets; print(secrets.token_urlsafe(48))')
+
+cleanup() {
+  status=$?
+  if [ "$status" -ne 0 ]; then
+    docker logs "$CONTAINER" 2>/dev/null || true
+  fi
+  docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+  rm -f "$ENV_FILE"
+  exit "$status"
+}
+trap cleanup EXIT INT TERM
+
+chmod 600 "$ENV_FILE"
+printf '%s\n' \
+  'MOBIUS_BOOT_MODE=recovery' \
+  'MOBIUS_RECOVERY_TARGET_PORT=18002' \
+  'DATA_DIR=/data' \
+  'BUILD_SHA=runtime-spoof-must-not-win' \
+  "MOBIUS_RECOVERY_TARGET_TOKEN=$TOKEN" >"$ENV_FILE"
+
+# Add both dangerous capabilities deliberately. targetd must remove them itself
+# so this proves the invariant independently of Compose or platform defaults.
+docker run -d \
+  --name "$CONTAINER" \
+  --read-only \
+  --tmpfs /tmp \
+  --tmpfs /run \
+  --tmpfs /data \
+  --cap-add NET_ADMIN \
+  --cap-add NET_RAW \
+  --no-healthcheck \
+  --env-file "$ENV_FILE" \
+  -p 127.0.0.1::18002 \
+  "$IMAGE" >/dev/null
+rm -f "$ENV_FILE"
+
+BINDING=$(docker port "$CONTAINER" 18002/tcp)
+PORT=${BINDING##*:}
+MOBIUS_TEST_URL="http://127.0.0.1:$PORT" \
+MOBIUS_TEST_TOKEN="$TOKEN" \
+python3 - <<'PY'
+import base64
+import errno
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+
+url = os.environ["MOBIUS_TEST_URL"]
+token = os.environ["MOBIUS_TEST_TOKEN"]
+headers = {
+  "Authorization": f"Bearer {token}",
+  "Content-Type": "application/json",
+}
+
+
+def request(path, payload=None):
+  body = None if payload is None else json.dumps(payload).encode()
+  method = "GET" if body is None else "POST"
+  req = urllib.request.Request(
+    url + path, data=body, headers=headers, method=method,
+  )
+  with urllib.request.urlopen(req, timeout=5) as response:
+    return json.load(response)
+
+
+deadline = time.monotonic() + 30
+while True:
+  try:
+    health = request("/v1/health")
+    break
+  except (OSError, urllib.error.URLError):
+    if time.monotonic() >= deadline:
+      raise
+    time.sleep(0.25)
+
+revision = health["build_sha"]
+assert len(revision) == 40 and all(c in "0123456789abcdef" for c in revision)
+assert revision != "runtime-spoof-must-not-win"
+
+child_program = r'''
+import json
+import os
+import socket
+
+caps = {}
+with open("/proc/self/status", encoding="ascii") as status:
+  for line in status:
+    name, _, value = line.partition(":")
+    if name in {"CapInh", "CapPrm", "CapEff", "CapBnd", "CapAmb"}:
+      caps[name] = value.strip()
+
+try:
+  packet_socket = socket.socket(
+    socket.AF_PACKET, socket.SOCK_RAW, socket.htons(3),
+  )
+except OSError as exc:
+  packet = {"opened": False, "errno": exc.errno}
+else:
+  packet = {"opened": True, "errno": None}
+  packet_socket.close()
+
+try:
+  with open("/proc/1/environ", "rb") as environ:
+    parent_environment = environ.read()
+except OSError as exc:
+  proc = {"readable": False, "errno": exc.errno, "data": ""}
+else:
+  proc = {
+    "readable": True,
+    "errno": None,
+    "data": parent_environment.decode("latin1"),
+  }
+
+print(json.dumps({
+  "uid": os.geteuid(),
+  "pid_one": open("/proc/1/cmdline", "rb").read().decode("latin1"),
+  "caps": caps,
+  "packet": packet,
+  "proc": proc,
+}))
+'''
+result = request("/v1/exec", {
+  "argv": ["/usr/local/bin/python3", "-c", child_program],
+  "cwd": "/tmp",
+})
+assert result["exit_code"] == 0, result
+child = json.loads(base64.b64decode(result["stdout_base64"]))
+assert child["uid"] == 0
+assert "targetd.py" in child["pid_one"]
+assert child["packet"]["opened"] is False
+assert child["packet"]["errno"] in {errno.EPERM, errno.EACCES}
+assert token not in child["proc"]["data"]
+assert "MOBIUS_RECOVERY_TARGET_TOKEN=" not in child["proc"]["data"]
+
+blocked_mask = (1 << 12) | (1 << 13)
+assert set(child["caps"]) == {"CapInh", "CapPrm", "CapEff", "CapBnd", "CapAmb"}
+for name, raw_value in child["caps"].items():
+  assert int(raw_value, 16) & blocked_mask == 0, (name, raw_value)
+
+print(json.dumps({
+  "build_sha": revision,
+  "packet_errno": child["packet"]["errno"],
+  "capabilities": child["caps"],
+  "pid_one": child["pid_one"],
+}, sort_keys=True))
+PY


### PR DESCRIPTION
This is the non-destructive prerequisite for moving recovery out of the Mobius container.

It adds:
- an early-boot, root-capable recovery target with a bounded authenticated protocol and expiry
- explicit MOBIUS_AGENT_SUDO opt-in, default off
- self-hosted mobiusctl recovery start/status/finish/reopen orchestration
- a non-root external recovery worker profile pinned away from the target volume
- restart=no and credential rotation after either recovery process exits

Embedded recovery remains present in this PR. Its removal will follow only after mobius.you, the immutable worker release, and Railway readiness audits are live.

Validation:
- 67 focused sudo/target/self-host tests
- real recovery-target containment, expiry, PID 1, escaped-descendant, filesystem-escape, and crash/no-restart drills
- privacy gate and diff checks