### PR TITLE
Own broadcast subscriptions inside supervisor tasks

### DIFF
--- a/backend/app/runtime_supervisors.py
+++ b/backend/app/runtime_supervisors.py
@@ -104,8 +104,6 @@ class RuntimeSupervisors:
         except Exception as exc:
           self.log.error("stalled-live sweep failed: %s", exc, exc_info=True)
 
-    events = get_system_broadcast().subscribe()
-
     async def sweep_reset_parks_once(*, startup: bool = False):
       try:
         with SessionLocal() as db:
@@ -131,6 +129,8 @@ class RuntimeSupervisors:
       )
 
     async def reset_park_loop():
+      system_broadcast = get_system_broadcast()
+      events = system_broadcast.subscribe()
       try:
         while True:
           try:
@@ -143,7 +143,7 @@ class RuntimeSupervisors:
             pass
           await sweep_reset_parks_once()
       finally:
-        get_system_broadcast().unsubscribe(events)
+        system_broadcast.unsubscribe(events)
 
     async def compress_legacy_tool_outputs():
       from app.tool_output_storage import compress_legacy_tool_output_batch

--- a/backend/tests/test_runtime_supervisors.py
+++ b/backend/tests/test_runtime_supervisors.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from app.broadcast import SystemBroadcast
 from app.runtime_supervisors import RuntimeSupervisors
 
 
@@ -63,3 +64,41 @@ async def test_start_fails_open_when_chat_supervisor_wiring_breaks(monkeypatch):
 
   assert frontend_started is True
   assert supervisors._tasks == {}
+
+
+@pytest.mark.asyncio
+async def test_reset_park_subscription_exists_only_while_its_task_runs(
+  monkeypatch,
+):
+  import app.broadcast as broadcast_module
+  import app.chat as chat_module
+  import app.runtime_supervisors as supervisors_module
+
+  broadcast = SystemBroadcast()
+
+  class EmptySession:
+    def __enter__(self):
+      return object()
+
+    def __exit__(self, *_args):
+      return False
+
+  async def no_chats(*_args, **_kwargs):
+    return []
+
+  monkeypatch.setattr(broadcast_module, "get_system_broadcast", lambda: broadcast)
+  monkeypatch.setattr(supervisors_module, "SessionLocal", EmptySession)
+  monkeypatch.setattr(chat_module, "sweep_reset_parks", no_chats)
+
+  supervisors = _supervisors()
+  await supervisors._start_chat_supervisors()
+
+  # Task creation alone must not allocate a process-lifetime subscriber. An
+  # immediate shutdown can cancel a coroutine before its first instruction.
+  assert broadcast.subscribers == []
+
+  await asyncio.sleep(0)
+  assert len(broadcast.subscribers) == 1
+
+  await supervisors.stop()
+  assert broadcast.subscribers == []


### PR DESCRIPTION
## Summary

The reset-park supervisor subscribed to the system broadcast before its task coroutine started. An immediate shutdown could cancel that coroutine before its first instruction, so its `finally` block never ran and the process kept an orphan subscriber.

The coroutine now acquires and releases its own subscription. Task creation allocates nothing, running owns exactly one subscriber, and cancellation tears it down through the same lifetime boundary.

## Changes

- move subscription creation inside the reset-park task
- unsubscribe through the exact broadcast instance that created the queue
- test the task-created, running, and stopped subscriber states

## Testing

- 3 focused runtime-supervisor tests passed after rebasing on current `main`
- 3,546 backend tests passed in the combined source review
- Ruff, Python compilation, privacy-path checks, and `git diff --check` passed