### PR TITLE
Keep chat media valid through writer timeouts

### DIFF
--- a/backend/app/chat_media.py
+++ b/backend/app/chat_media.py
@@ -12,12 +12,14 @@ from app.chat_writer import RewriteChatMediaPaths, get_writer, wait_ack
 
 
 def fix_forward_chat_media(db: Session, data_dir: str) -> int:
-  """Moves old chat images into `media/` and rewrites stored message URLs.
+  """Copies old chat images into `media/` and rewrites stored message URLs.
 
-  The operation is idempotent. Files move before database references change,
-  so a crash can only leave a second run with fewer files to move. A conflicting
-  destination is accepted only when its bytes match; otherwise the migration
-  stops rather than silently overwriting either image.
+  The old copy remains until the writer confirms the URL rewrite. This matters
+  because a timed-out writer acknowledgement does not cancel a command already
+  running on the actor thread: either eventual database outcome therefore still
+  names a directory containing the bytes. A conflicting destination is accepted
+  only when its bytes match; otherwise the migration stops rather than silently
+  overwriting either image.
   """
   changed = 0
   chats_root = Path(data_dir) / "chats"
@@ -86,18 +88,12 @@ def fix_forward_chat_media(db: Session, data_dir: str) -> int:
           f"Conflicting chat media file for chat {chat_id}: {source.name}"
         )
 
-  # Load one transcript at a time. A real legacy fleet may contain many
-  # candidates, but the migration's peak memory stays bounded by its largest
-  # individual chat rather than the sum of every chat in the instance.
+  # The writer actor owns transcript loading and mutation. Keep the boot session
+  # on ids only so migration does not materialize the same JSON blob twice.
   for chat_id in sorted(candidate_ids):
-    chat = db.query(models.Chat).filter(models.Chat.id == chat_id).first()
-    if chat is None:
-      continue
-    chat_root = chats_root / chat.id
+    chat_root = chats_root / chat_id
     old_dir = chat_root / "generated"
     media_dir = chat_root / "media"
-    moved: list[tuple[Path, Path]] = []
-    duplicates: list[Path] = []
 
     try:
       if old_dir.is_dir():
@@ -106,19 +102,14 @@ def fix_forward_chat_media(db: Session, data_dir: str) -> int:
           if not source.is_file():
             continue
           destination = media_dir / source.name
-          if destination.exists():
-            # The global preflight proved this is an identical regular file.
-            # Keep the old copy until the URL rewrite commits successfully.
-            duplicates.append(source)
-          else:
-            source.replace(destination)
-            moved.append((source, destination))
+          if not destination.exists():
+            shutil.copy2(source, destination)
           changed += 1
 
-      old_prefix = f"/api/chats/{chat.id}/generated/"
-      new_prefix = f"/api/chats/{chat.id}/media/"
+      old_prefix = f"/api/chats/{chat_id}/generated/"
+      new_prefix = f"/api/chats/{chat_id}/media/"
       rewritten = wait_ack(get_writer().submit(RewriteChatMediaPaths(
-        chat_id=chat.id,
+        chat_id=chat_id,
         old_prefix=old_prefix,
         new_prefix=new_prefix,
       )))
@@ -126,15 +117,14 @@ def fix_forward_chat_media(db: Session, data_dir: str) -> int:
       db.expire_all()
     except BaseException:
       db.rollback()
-      # Restore files moved for this chat so a handled startup failure never
-      # leaves old URLs pointing at a directory the live API no longer serves.
-      for source, destination in reversed(moved):
-        if destination.exists() and not source.exists():
-          destination.replace(source)
+      # Keep both copies. The actor may still commit after a caller-side
+      # timeout, and either old or new URLs must remain readable in that case.
       raise
 
-    for source in duplicates:
-      source.unlink(missing_ok=True)
+    if old_dir.is_dir():
+      for source in old_dir.iterdir():
+        if source.is_file():
+          source.unlink()
     if old_dir.exists() and not any(old_dir.iterdir()):
       shutil.rmtree(old_dir)
 

--- a/backend/app/chat_media.py
+++ b/backend/app/chat_media.py
@@ -1,6 +1,7 @@
 """Fix-forward migration for the canonical per-chat media directory."""
 
 import filecmp
+import os
 import shutil
 from pathlib import Path
 
@@ -103,7 +104,18 @@ def fix_forward_chat_media(db: Session, data_dir: str) -> int:
             continue
           destination = media_dir / source.name
           if not destination.exists():
-            shutil.copy2(source, destination)
+            # Stage then rename. A bare copy2 to `destination` is not atomic:
+            # an interrupted copy leaves a short file there, the next pass
+            # skips it because it exists, and the intact legacy copy is deleted
+            # on the following successful pass -- so the truncation becomes
+            # permanent. os.replace() within one directory is atomic, so the
+            # destination is either absent or complete.
+            staged = destination.with_name(f".{source.name}.partial")
+            try:
+              shutil.copy2(source, staged)
+              os.replace(staged, destination)
+            finally:
+              staged.unlink(missing_ok=True)
           changed += 1
 
       old_prefix = f"/api/chats/{chat_id}/generated/"
@@ -117,8 +129,11 @@ def fix_forward_chat_media(db: Session, data_dir: str) -> int:
       db.expire_all()
     except BaseException:
       db.rollback()
-      # Keep both copies. The actor may still commit after a caller-side
-      # timeout, and either old or new URLs must remain readable in that case.
+      # Keep both copies so a later boot can finish the migration. Note what
+      # this does NOT buy: no route serves `/generated/` (routes/media.py only
+      # exposes `/{chat_id}/media/{filename}`), so if the rewrite never commits
+      # the affected messages stay broken until a later pass succeeds.
+      # Retaining the bytes is what makes that later pass possible.
       raise
 
     if old_dir.is_dir():

--- a/backend/tests/test_chat_media.py
+++ b/backend/tests/test_chat_media.py
@@ -93,7 +93,7 @@ def test_fix_forward_chat_media_preflights_conflicts(db, chat):
   assert (media_dir / "same.png").read_bytes() == b"different"
 
 
-def test_fix_forward_chat_media_restores_moved_file_when_commit_fails(
+def test_fix_forward_chat_media_keeps_both_copies_when_commit_fails(
   db, chat, monkeypatch,
 ):
   old_url = f"/api/chats/{chat.id}/generated/old.png"
@@ -111,6 +111,41 @@ def test_fix_forward_chat_media_restores_moved_file_when_commit_fails(
     fix_forward_chat_media(db, get_settings().data_dir)
 
   assert old_file.read_bytes() == b"old-image"
-  assert not (chat_root / "media" / "old.png").exists()
+  assert (chat_root / "media" / "old.png").read_bytes() == b"old-image"
   persisted = db.query(models.Chat).filter(models.Chat.id == chat.id).one()
   assert persisted.messages[0]["content"] == old_url
+
+
+def test_fix_forward_chat_media_timeout_stays_valid_after_late_commit(
+  db, chat, monkeypatch,
+):
+  old_url = f"/api/chats/{chat.id}/generated/old.png"
+  new_url = f"/api/chats/{chat.id}/media/old.png"
+  chat.messages = [{"role": "assistant", "content": old_url}]
+  db.commit()
+
+  chat_root = Path(get_settings().data_dir) / "chats" / chat.id
+  old_file = chat_root / "generated" / "old.png"
+  new_file = chat_root / "media" / "old.png"
+  old_file.parent.mkdir(parents=True)
+  old_file.write_bytes(b"old-image")
+
+  pending_ack = None
+
+  def timeout_without_cancelling(ack):
+    nonlocal pending_ack
+    pending_ack = ack
+    raise TimeoutError("writer acknowledgement timed out")
+
+  monkeypatch.setattr(chat_media, "wait_ack", timeout_without_cancelling)
+  with pytest.raises(TimeoutError, match="acknowledgement timed out"):
+    fix_forward_chat_media(db, get_settings().data_dir)
+
+  assert old_file.read_bytes() == b"old-image"
+  assert new_file.read_bytes() == b"old-image"
+  assert pending_ack is not None
+  assert pending_ack.result(timeout=5) == 1
+
+  db.expire_all()
+  persisted = db.query(models.Chat).filter(models.Chat.id == chat.id).one()
+  assert persisted.messages[0]["content"] == new_url

--- a/backend/tests/test_chat_media.py
+++ b/backend/tests/test_chat_media.py
@@ -1,3 +1,4 @@
+import shutil
 from pathlib import Path
 
 import pytest
@@ -149,3 +150,37 @@ def test_fix_forward_chat_media_timeout_stays_valid_after_late_commit(
   db.expire_all()
   persisted = db.query(models.Chat).filter(models.Chat.id == chat.id).one()
   assert persisted.messages[0]["content"] == new_url
+
+
+def test_interrupted_copy_leaves_no_truncated_destination(db, chat, monkeypatch):
+  """A crash mid-copy must not publish a short file at the destination.
+
+  Copying straight to `destination` is not atomic: an interrupted copy left a
+  truncated file there, the next boot skipped it because it existed, and the
+  intact legacy copy was deleted on the following successful pass -- making the
+  truncation permanent.
+  """
+  old_url = f"/api/chats/{chat.id}/generated/old.png"
+  chat.messages = [{"role": "assistant", "content": f"![image]({old_url})"}]
+  db.commit()
+
+  chat_root = Path(get_settings().data_dir) / "chats" / chat.id
+  old_dir = chat_root / "generated"
+  old_dir.mkdir(parents=True)
+  (old_dir / "old.png").write_bytes(b"complete-image-bytes")
+
+  real_copy = shutil.copy2
+
+  def truncated_copy(source, target, *args, **kwargs):
+    Path(target).write_bytes(b"short")
+    raise OSError("interrupted mid-copy")
+
+  monkeypatch.setattr(shutil, "copy2", truncated_copy)
+
+  with pytest.raises(OSError, match="interrupted mid-copy"):
+    fix_forward_chat_media(db, get_settings().data_dir)
+
+  monkeypatch.setattr(shutil, "copy2", real_copy)
+  assert not (chat_root / "media" / "old.png").exists()
+  assert (old_dir / "old.png").read_bytes() == b"complete-image-bytes"
+  assert not list((chat_root / "media").glob(".*.partial"))


### PR DESCRIPTION
## Summary

The chat-media migration waited for the chat writer before changing stored URLs, but a caller-side acknowledgement timeout does not cancel a command already running on the writer thread. Moving the only file copy before that acknowledgement left one bad race: a late database commit could point at `media/` after timeout recovery had moved the bytes back to `generated/`.

The migration now copies first, keeps both directories on any failure or timeout, and deletes the legacy copy only after the writer confirms the rewrite. Whichever database outcome wins, its URL still names a readable file.

## Changes

- copy legacy media into the canonical directory before submitting the rewrite
- keep both copies when the acknowledgement fails or times out
- delete the legacy copy only after confirmed writer completion
- let the writer actor remain the sole transcript loader instead of materializing the same JSON again in the boot session
- cover ordinary failure and a real late-commit-after-timeout race

This is a correctness follow-up to #449. That PR correctly restored one-way migration-to-writer ownership; this change closes the asynchronous acknowledgement lifetime that becomes visible at that boundary.

## Testing

- 7 focused migration tests passed after rebasing on current `main`
- 3,546 backend tests passed in the combined source review
- Ruff, Python compilation, privacy-path checks, and `git diff --check` passed