### PR TITLE
Guard app publishing to the canonical branch

### DIFF
--- a/backend/app/app_git.py
+++ b/backend/app/app_git.py
@@ -342,6 +342,24 @@ def _run_with_index(
   )
 
 
+def _require_local_branch(repo: Path) -> None:
+  """Fail before an accepted-source operation can touch the wrong index.
+
+  App history has one canonical writable branch. Updating ``main`` while a
+  deployment or review branch is checked out would move one ref and refresh a
+  different branch's index, making ignored runtime files appear staged. Keep
+  that invalid repository shape explicit instead of trying to reconcile two
+  source owners inside the publisher.
+  """
+  current = _run(
+    repo, "symbolic-ref", "--quiet", "--short", "HEAD", check=False,
+  )
+  if current.returncode != 0 or current.stdout.strip() != LOCAL_BRANCH:
+    raise SourceTreeChanged(
+      f"App source must be checked out on {LOCAL_BRANCH!r} before applying it."
+    )
+
+
 def _tracked_source(source_dir: Path) -> list[str]:
   """The source files to stage: everything in the dir minus what
   `.gitignore` excludes. We add by directory (`git add -A`) and let the
@@ -1439,6 +1457,7 @@ def snapshot_worktree(source_dir: str | Path) -> WorktreeTree:
   """
   repo = Path(source_dir)
   ensure_repo(repo)
+  _require_local_branch(repo)
   parent = head_sha(repo, LOCAL_BRANCH)
   with tempfile.TemporaryDirectory(prefix="mobius-app-index-") as tmp:
     index_file = Path(tmp) / "index"
@@ -1463,6 +1482,7 @@ def commit_worktree_tree(
   it as scratch state.
   """
   repo = Path(source_dir)
+  _require_local_branch(repo)
   current = head_sha(repo, LOCAL_BRANCH)
   if current != snapshot.parent_sha:
     raise SourceTreeChanged(
@@ -1728,6 +1748,7 @@ def commit_local(source_dir: str | Path, msg: str) -> str | None:
   """
   repo = Path(source_dir)
   ensure_repo(repo)
+  _require_local_branch(repo)
   git_dir = repo / ".git"
   merge_head_path = git_dir / "MERGE_HEAD"
   # Refuse to touch the index while a rebase/cherry-pick/am is in progress

--- a/backend/app/app_git.py
+++ b/backend/app/app_git.py
@@ -1748,7 +1748,12 @@ def commit_local(source_dir: str | Path, msg: str) -> str | None:
   """
   repo = Path(source_dir)
   ensure_repo(repo)
-  _require_local_branch(repo)
+  # NOT `_require_local_branch` here. This engine is shared: its only
+  # production caller is platform reconcile (platform_update.py), and a
+  # platform clone legitimately sits on a deploy/release branch. The canonical
+  # -branch invariant belongs to app accepted-source publication, so it is
+  # enforced at the two entry points that own it -- `snapshot_worktree` and
+  # `commit_worktree_tree` -- rather than inside the engine both share.
   git_dir = repo / ".git"
   merge_head_path = git_dir / "MERGE_HEAD"
   # Refuse to touch the index while a rebase/cherry-pick/am is in progress

--- a/backend/tests/test_app_git.py
+++ b/backend/tests/test_app_git.py
@@ -74,6 +74,21 @@ def test_worktree_snapshot_uses_git_inventory_without_mutating_real_index(
   assert (materialized / "link").read_text() == "/data/service-token.txt"
 
 
+def test_worktree_snapshot_rejects_a_noncanonical_checked_out_branch(tmp_path):
+  repo = tmp_path / "app"
+  repo.mkdir()
+  app_git.ensure_repo(repo)
+  app_git._run(repo, "checkout", "-q", "-b", "deploy/review")
+  _write(repo, "export default () => 'draft'\n")
+  index_before = app_git._run(repo, "write-tree").stdout.strip()
+
+  with pytest.raises(app_git.SourceTreeChanged, match="checked out on 'main'"):
+    app_git.snapshot_worktree(repo)
+
+  assert app_git._run(repo, "write-tree").stdout.strip() == index_before
+  assert "index.jsx" in app_git._run(repo, "status", "--porcelain").stdout
+
+
 def test_commit_worktree_tree_commits_candidate_and_leaves_later_edit_draft(
   tmp_path,
 ):
@@ -96,6 +111,24 @@ def test_commit_worktree_tree_commits_candidate_and_leaves_later_edit_draft(
   assert "index.jsx" in app_git._run(
     repo, "status", "--porcelain",
   ).stdout
+
+
+def test_commit_worktree_tree_rejects_a_branch_switch_without_touching_index(
+  tmp_path,
+):
+  repo = tmp_path / "app"
+  repo.mkdir()
+  app_git.ensure_repo(repo)
+  _write(repo, "export default () => 'accepted'\n")
+  snapshot = app_git.snapshot_worktree(repo)
+  app_git._run(repo, "checkout", "-q", "-b", "deploy/review")
+  index_before = app_git._run(repo, "write-tree").stdout.strip()
+
+  with pytest.raises(app_git.SourceTreeChanged, match="checked out on 'main'"):
+    app_git.commit_worktree_tree(repo, snapshot, "apply app")
+
+  assert app_git._run(repo, "write-tree").stdout.strip() == index_before
+  assert app_git.head_sha(repo, app_git.LOCAL_BRANCH) == snapshot.parent_sha
 
 
 def test_commit_worktree_tree_rejects_changed_parent(tmp_path):

--- a/backend/tests/test_app_git.py
+++ b/backend/tests/test_app_git.py
@@ -2668,3 +2668,34 @@ def test_adjacent_disjoint_source_edit_bails_safely(tmp_path):
   merge = app_git.merge_upstream(repo)
   assert merge.status == "conflict"
   assert app_git.resolve_version_only_conflict(repo, merge.conflict_paths) is None
+
+
+def test_commit_local_works_on_a_non_canonical_branch(tmp_path):
+  """The shared engine must not carry the app-only canonical-branch rule.
+
+  `commit_local`'s one production caller is platform reconcile, and a platform
+  clone legitimately sits on a deploy/release branch. Enforcing the app
+  invariant here broke that path while protecting nothing: app publication
+  goes through `snapshot_worktree`/`commit_worktree_tree`, which keep the guard.
+  """
+  repo = tmp_path / "platform"
+  repo.mkdir()
+  app_git.ensure_repo(repo)
+  (repo / "file.txt").write_text("one\n", encoding="utf-8")
+  app_git.commit_local(repo, "seed")
+  app_git._run(repo, "checkout", "-b", "deploy/aligned-20260801")
+
+  (repo / "file.txt").write_text("two\n", encoding="utf-8")
+  assert app_git.commit_local(repo, "platform: local edits before reconcile")
+
+
+def test_worktree_publication_still_refuses_a_non_canonical_branch(tmp_path):
+  repo = tmp_path / "app"
+  repo.mkdir()
+  app_git.ensure_repo(repo)
+  (repo / "file.txt").write_text("one\n", encoding="utf-8")
+  app_git.commit_local(repo, "seed")
+  app_git._run(repo, "checkout", "-b", "review/pr1")
+
+  with pytest.raises(app_git.SourceTreeChanged):
+    app_git.snapshot_worktree(repo)


### PR DESCRIPTION
## Summary

App source has one canonical writable branch: `main`. The publisher could previously update that ref while a deployment, review, or detached checkout owned the real index. That mixed one branch’s history with another branch’s staging area and could make ignored runtime paths appear staged.

This makes the ownership rule explicit at the three accepted-source boundaries. Snapshotting, publishing an accepted snapshot, and ordinary local commits now fail before touching the index or a ref unless `main` is checked out.

## Changes

- add one canonical-branch guard in the app Git owner
- apply it before snapshot, accepted-tree commit, and ordinary local commit operations
- prove a wrong-branch snapshot and a branch switch after snapshot leave the real index and `main` ref unchanged

This is a correctness follow-up to #177, which established that installed app source is an installer-owned projection rather than an ordinary origin checkout. It does not change contribution mapping; it prevents the publisher from operating in an invalid local checkout shape.

## Testing

- 82 focused app Git tests passed after rebasing on current `main`
- 3,546 backend tests passed in the combined source review
- Ruff, Python compilation, privacy-path checks, and `git diff --check` passed