### PR TITLE
Let the docked notifications panel cover the drawer

### DIFF
--- a/frontend/src/components/Shell/Shell.css
+++ b/frontend/src/components/Shell/Shell.css
@@ -751,24 +751,15 @@
     display: none;
   }
 
-  /* Keep the panel within the drawer gutter while it is narrow, then move its
-     left edge so the capped panel continues to follow the resizable right edge. */
+  /* The docked panel covers the drawer the way the phone panel covers the
+     screen: it fills the drawer's content column, inset by the same 8px gutter
+     Drawer.css gives its rows, so a resized drawer resizes the panel with it
+     and no row is left peeking out beside it. */
   .shell--drawer-docked .notifications {
-    --notifications-panel-max-width: 390px;
     top: 66px;
     right: auto;
-    left: max(
-      12px,
-      calc(
-        var(--desktop-sidebar-width)
-        - var(--notifications-panel-max-width)
-        - 12px
-      )
-    );
-    width: min(
-      var(--notifications-panel-max-width),
-      calc(var(--desktop-sidebar-width) - 24px)
-    );
+    left: 8px;
+    width: calc(var(--desktop-sidebar-width) - 16px);
     max-height: calc(100dvh - 78px);
   }
 

--- a/frontend/src/components/Shell/__tests__/drawerAlignment.test.js
+++ b/frontend/src/components/Shell/__tests__/drawerAlignment.test.js
@@ -35,9 +35,20 @@ test('collapsed and expanded drawer actions share one vertical rhythm', () => {
   )
 })
 
-test('the notifications panel follows the resizable drawer edge', () => {
+test('the docked notifications panel covers the drawer content column', () => {
+  const panel = ruleBody(shellCss, '.shell--drawer-docked .notifications')
+  const desktopDrawerBody = ruleBody(drawerCss, '.drawer__body', 1)
+  // Second shorthand value: the horizontal gutter drawer rows already sit in.
+  const gutterMatch = desktopDrawerBody.match(/padding:\s*\d+px\s+(\d+)px/)
+  assert.ok(gutterMatch, 'Missing desktop drawer body padding')
+  const gutter = Number(gutterMatch[1])
+
+  // Uncapped width tracks the resizable drawer, so widening it can never leave
+  // drawer rows visible beside the panel.
+  assert.equal(px(panel, 'left'), gutter)
   assert.match(
-    shellCss,
-    /\.shell--drawer-docked \.notifications\s*\{[\s\S]*?--notifications-panel-max-width:\s*390px;[\s\S]*?left:\s*max\([\s\S]*?var\(--desktop-sidebar-width\)[\s\S]*?- var\(--notifications-panel-max-width\)[\s\S]*?width:\s*min\([\s\S]*?var\(--notifications-panel-max-width\)[\s\S]*?var\(--desktop-sidebar-width\)/,
+    panel,
+    new RegExp(`width:\\s*calc\\(var\\(--desktop-sidebar-width\\) - ${gutter * 2}px\\)`),
   )
+  assert.doesNotMatch(panel, /max-width/)
 })


### PR DESCRIPTION
## Summary

The docked notifications panel was capped at a fixed 390px inside a drawer that the owner can resize up to 560px. Past that width the panel no longer covered the drawer: chat rows stayed visible on both sides of it, and the fixed cap needed `max()`/`min()` offset math purely to keep chasing the resizable right edge.

This drops the cap. The panel now fills the drawer's content column, inset by the same 8px gutter `Drawer.css` already gives its rows — the phone behaviour (fill the container, small gutter) applied to the drawer. Width follows `--desktop-sidebar-width` directly, so resizing the drawer resizes the panel with it, and the offset math goes away.

Follow-up to #366, which anchored the panel to the resizable drawer edge but kept the fixed cap.

## Changes

- `.shell--drawer-docked .notifications` fills the drawer content column instead of a capped 390px box
- removed the `--notifications-panel-max-width` variable and the `max()`/`min()` edge-chasing math
- the regression test now derives the expected gutter and width from `Drawer.css`'s own row padding, and asserts no width cap returns

## Testing

- `npm test`
- `node scripts/check-structural-test-budget.mjs` (88/88 files, 780/780 cases — unchanged; one case replaced by one case)
- verified in the rendered shell at both the minimum (240px) and a widened (480px) drawer: the panel spans the drawer's content column at both, with no rows peeking beside it