### PR TITLE
Redact an authorization value under any scheme, not just Bearer/Basic

### DIFF
--- a/frontend/src/lib/__tests__/errorRecovery.test.js
+++ b/frontend/src/lib/__tests__/errorRecovery.test.js
@@ -327,6 +327,10 @@ test('repair diagnostics redact common credentials before storage or agent use',
     'https://user:password@example.com/path?token=secret-token&code=secret-code',
     'postgres://db-user:db-password@database.internal/mobius',
     'Authorization: Bearer abc.def.ghi',
+    'Authorization: Token tok-scheme-secret',
+    'Authorization: ApiKey key-scheme-secret',
+    'authorization: Digest response="digest-scheme-secret"',
+    '{"authorization":"Token json-scheme-secret","keep":"visible-field"}',
     'Cookie: session=secret-cookie',
     'OPENAI_API_KEY=sk-secret',
     'AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE',
@@ -346,6 +350,10 @@ test('repair diagnostics redact common credentials before storage or agent use',
     'secret-token',
     'secret-code',
     'abc.def.ghi',
+    'tok-scheme-secret',
+    'key-scheme-secret',
+    'digest-scheme-secret',
+    'json-scheme-secret',
     'secret-cookie',
     'sk-secret',
     'AKIAIOSFODNN7EXAMPLE',
@@ -358,6 +366,9 @@ test('repair diagnostics redact common credentials before storage or agent use',
     'private-key-body',
   ]) assert.equal(redacted.includes(secret), false, `must redact ${secret}`)
   assert.match(redacted, /\[redacted\]/)
+  // A quoted authorization value ends at its closing quote, so redacting one
+  // JSON field must not swallow the rest of the object.
+  assert.match(redacted, /visible-field/)
   assert.match(redacted, /\[redacted-private-key\]/)
   assert.match(redacted, /\[redacted-provider-token\]/)
   assert.match(redacted, /\[redacted-high-entropy-value\]/)

--- a/frontend/src/lib/__tests__/errorRecovery.test.js
+++ b/frontend/src/lib/__tests__/errorRecovery.test.js
@@ -331,6 +331,7 @@ test('repair diagnostics redact common credentials before storage or agent use',
     'Authorization: ApiKey key-scheme-secret',
     'authorization: Digest response="digest-scheme-secret"',
     '{"authorization":"Token json-scheme-secret","keep":"visible-field"}',
+    '{"authorization":"Digest username=\\"Mufasa\\", response=\\"escaped-quote-secret\\"","keep":"second-visible-field"}',
     'Cookie: session=secret-cookie',
     'OPENAI_API_KEY=sk-secret',
     'AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE',
@@ -354,6 +355,7 @@ test('repair diagnostics redact common credentials before storage or agent use',
     'key-scheme-secret',
     'digest-scheme-secret',
     'json-scheme-secret',
+    'escaped-quote-secret',
     'secret-cookie',
     'sk-secret',
     'AKIAIOSFODNN7EXAMPLE',
@@ -369,6 +371,7 @@ test('repair diagnostics redact common credentials before storage or agent use',
   // A quoted authorization value ends at its closing quote, so redacting one
   // JSON field must not swallow the rest of the object.
   assert.match(redacted, /visible-field/)
+  assert.match(redacted, /second-visible-field/)
   assert.match(redacted, /\[redacted-private-key\]/)
   assert.match(redacted, /\[redacted-provider-token\]/)
   assert.match(redacted, /\[redacted-high-entropy-value\]/)

--- a/frontend/src/lib/diagnosticRedaction.js
+++ b/frontend/src/lib/diagnosticRedaction.js
@@ -5,7 +5,7 @@ const SECRET_QUERY_VALUE = /([?&](?:access_token|auth|authorization|code|key|pas
 // and embedded in the agent repair prompt. A quoted value (a JSON body) ends at
 // its closing quote so neighbouring fields survive; anything else runs to end of
 // line, exactly like COOKIE_VALUE below. The key itself may be quoted.
-const AUTHORIZATION_VALUE = /\b(authorization["']?\s*[:=]\s*)("[^"\r\n]*"|'[^'\r\n]*'|[^\r\n]+)/gi
+const AUTHORIZATION_VALUE = /\b(authorization["']?\s*[:=]\s*)("(?:\\.|[^"\\\r\n])*"|'(?:\\.|[^'\\\r\n])*'|[^\r\n]+)/gi
 const COOKIE_VALUE = /\b((?:set-)?cookie\s*[:=]\s*)[^\r\n]+/gi
 const SECRET_ASSIGNMENT = /(["']?)\b((?:[a-z0-9]+[_-])*(?:access[_-]?key[_-]?id|secret[_-]?access[_-]?key|api[_-]?key|client[_-]?secret|access[_-]?token|refresh[_-]?token|auth[_-]?token|private[_-]?key|token|password|passwd|pwd|secret))\1(\s*[:=]\s*)("[^"\r\n]*"|'[^'\r\n]*'|[^\s,;&#]+)/gi
 const JWT_VALUE = /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g

--- a/frontend/src/lib/diagnosticRedaction.js
+++ b/frontend/src/lib/diagnosticRedaction.js
@@ -1,5 +1,11 @@
 const SECRET_QUERY_VALUE = /([?&](?:access_token|auth|authorization|code|key|password|secret|token)=)[^&#\s"'<>]+/gi
-const AUTHORIZATION_VALUE = /\b(authorization\s*[:=]\s*)(?:bearer|basic)\s+[^\s,;]+/gi
+// Every scheme, not just Bearer/Basic: `Token`, `ApiKey` and `Digest` all carry
+// the credential, and an unrecognized scheme left the whole value in place --
+// including in the copy stored in session storage, POSTed to /api/client-errors,
+// and embedded in the agent repair prompt. A quoted value (a JSON body) ends at
+// its closing quote so neighbouring fields survive; anything else runs to end of
+// line, exactly like COOKIE_VALUE below. The key itself may be quoted.
+const AUTHORIZATION_VALUE = /\b(authorization["']?\s*[:=]\s*)("[^"\r\n]*"|'[^'\r\n]*'|[^\r\n]+)/gi
 const COOKIE_VALUE = /\b((?:set-)?cookie\s*[:=]\s*)[^\r\n]+/gi
 const SECRET_ASSIGNMENT = /(["']?)\b((?:[a-z0-9]+[_-])*(?:access[_-]?key[_-]?id|secret[_-]?access[_-]?key|api[_-]?key|client[_-]?secret|access[_-]?token|refresh[_-]?token|auth[_-]?token|private[_-]?key|token|password|passwd|pwd|secret))\1(\s*[:=]\s*)("[^"\r\n]*"|'[^'\r\n]*'|[^\s,;&#]+)/gi
 const JWT_VALUE = /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g


### PR DESCRIPTION
Follow-up to #474, which merged before this fix landed.

`AUTHORIZATION_VALUE` matched only `bearer|basic`, so every other scheme passed through untouched:

```
ok    "Authorization: Bearer abc.def.ghi"      -> "Authorization: [redacted]"
LEAK  "Authorization: Token secret-value-123"  -> unchanged
LEAK  "Authorization: ApiKey k-9f2b"           -> unchanged
LEAK  "authorization: Digest response=\"...\"" -> unchanged
```

`SECRET_ASSIGNMENT` does not catch these either — the scheme is followed by whitespace rather than `:` or `=` — and short credentials fall under `HIGH_ENTROPY_VALUE`'s 32-character floor. So nothing redacts them today.

That matters because the redacted text reaches three sinks: `recordClientError` stores it in session storage, it is POSTed to `/api/client-errors`, and it is embedded in the repair prompt sent to the agent.

**The fix** redacts the whole authorization value regardless of scheme, exactly as `COOKIE_VALUE` one line below already does. A quoted value ends at its closing quote so redacting one JSON field does not swallow its neighbours; anything else runs to end of line. The key may itself be quoted (`"authorization":`), which is why the pattern allows an optional quote before the separator.

Tests cover `Token`, `ApiKey`, `Digest`, the JSON form, and that a neighbouring field survives.
