### PR TITLE
Cover the remaining stale cron generations, and state the migration contract

### DIFF
--- a/backend/scripts/init_skills.py
+++ b/backend/scripts/init_skills.py
@@ -13,7 +13,16 @@ boot we add missing seed skills and apply only explicit, hash-gated migrations:
 an existing file is replaced when it is byte-for-byte a known baked predecessor,
 while every owner/agent-edited copy is preserved. A normal baked-seed edit does
 not propagate until its predecessor hash is deliberately registered below; this
-keeps urgent fix-forward migrations possible without blind overwrites. App-owned
+keeps urgent fix-forward migrations possible without blind overwrites.
+
+One narrow exception, and it is deliberate: a registered digest may name a
+known-bad OWNER-CURATED generation rather than a baked one, when that exact
+content is unsafe to leave in place (today: a `cron.md` copy that tells app
+jobs to read the owner service token). Such an entry is annotated with its
+provenance, because it cannot be reproduced from this repository's history and
+a reviewer would otherwise have no way to audit what is being overwritten. It
+remains an exact-hash match -- an owner edit that differs by one byte is still
+preserved. App-owned
 skills are not part of this seed tree; they arrive through manifests and their
 generic ownership sidecar.
 `.seed-version`/`SEED_VERSION` are kept as a
@@ -50,8 +59,18 @@ _UNMODIFIED_MIGRATIONS = {
   "cron.md": {
     "289336d78ad4268110360f12faac5512d5a53b66aa31c2a6ddd1a44f538f2559",
     "ed100cb496b887a7951adc967e92cda1449c4f8594f7859fbd32762221d24914",
+    # Every remaining baked generation that still shows the owner service token
+    # as the example an app job should read.  An instance sitting on one of
+    # these keeps the pre-app-token guidance until it is registered here, so
+    # the migration is only as complete as this set.
+    "76ab03fd128157715b388b16146239217f57bba62c5248b8192a39639d0200b1",
+    "e4539739815b80b4c52ca2c56f2a4055e7a4a12cd1843c0cb5077a149547acd1",
     # Locally curated pre-app-token copy. It tells scheduled app jobs to read
     # the owner service token, contradicting supervised $APP_TOKEN authority.
+    # Not a baked generation: it exists only on instances whose owner edited
+    # this skill before the app-token migration, which is why the digest
+    # cannot be reproduced from this repository's history.  Registered
+    # deliberately -- see the propagation policy note in the module docstring.
     "16055ea6ba6e4663636f87fde9868aa98d49ab39c5037ff90fa673d96c259cd9",
   },
   "recovery.md": {

--- a/backend/tests/test_memory_boot.py
+++ b/backend/tests/test_memory_boot.py
@@ -2,6 +2,7 @@
 
 import importlib.util
 import hashlib
+import re
 from pathlib import Path
 
 
@@ -107,6 +108,8 @@ def test_controlled_skills_have_fix_forward_migrations():
   assert module._UNMODIFIED_MIGRATIONS["cron.md"] == {
     "289336d78ad4268110360f12faac5512d5a53b66aa31c2a6ddd1a44f538f2559",
     "ed100cb496b887a7951adc967e92cda1449c4f8594f7859fbd32762221d24914",
+    "76ab03fd128157715b388b16146239217f57bba62c5248b8192a39639d0200b1",
+    "e4539739815b80b4c52ca2c56f2a4055e7a4a12cd1843c0cb5077a149547acd1",
     "16055ea6ba6e4663636f87fde9868aa98d49ab39c5037ff90fa673d96c259cd9",
   }
   assert module._UNMODIFIED_MIGRATIONS["images.md"] == {
@@ -144,6 +147,30 @@ def test_controlled_skills_have_fix_forward_migrations():
     "6e6e82e02287e8bb38195fb021ea25cee2dc4e27da1a6ce1e2a0143fb1d82d87"
     in module._UNMODIFIED_MIGRATIONS["recovery.md"]
   )
+
+
+def test_migration_digests_are_wellformed_and_never_the_current_seed():
+  """A registered digest must name a PREDECESSOR, never the shipping seed.
+
+  Registering the current seed's own digest is a silent no-op that reads like a
+  fix: the file is replaced with itself and the stale copy it was meant to
+  catch is never touched.  A mistyped digest is likewise invisible.  Neither
+  can be caught by asserting the literals back, so check the properties that
+  are checkable.
+  """
+  module = _load("init_skills")
+  seed_dir = SCRIPTS / "seed-skills"
+
+  for name, digests in module._UNMODIFIED_MIGRATIONS.items():
+    current = hashlib.sha256((seed_dir / name).read_bytes()).hexdigest()
+    for digest in digests:
+      assert re.fullmatch(r"[0-9a-f]{64}", digest), (
+        f"{name}: {digest!r} is not a sha256 hex digest"
+      )
+      assert digest != current, (
+        f"{name}: registers the digest of the seed it currently ships, which "
+        "would replace the file with itself instead of migrating a predecessor"
+      )
 
 
 def test_seeded_cron_jobs_use_only_app_scoped_credentials():


### PR DESCRIPTION
Follow-up to #465, which merged before this landed.

#465 registered one locally-curated digest. Enumerating every historical version of `backend/scripts/seed-skills/cron.md` and testing each with the predicate #465's own test uses (`SERVICE_TOKEN=$(cat /data/service-token.txt)` or `using bearer token $SERVICE_TOKEN`) gives:

| digest | shows the insecure example | registered |
|---|---|---|
| `289336d78ad4` | yes | yes |
| `76ab03fd1281` | **yes** | **no** |
| `e4539739815b` | **yes** | **no** |
| `ed100cb496b8` | no (has the prohibition) | yes |
| `4815ad9d8b6e` | no (has the prohibition) | no |
| `55a350281a94` | no — this is the shipping seed | no |
| `9a3f75688e14` | no (has the prohibition) | no |

So two baked generations that still show the owner service token as the example an app job should read are unregistered. An instance sitting on either keeps the pre-app-token guidance after #465 shipped. This registers both.

It also does two smaller things:

- **States the contract the list actually follows.** The module docstring says an existing file is replaced only when it is "byte-for-byte a known baked predecessor, while every owner/agent-edited copy is preserved". The digest #465 added is by its own comment a locally-curated copy, so it cannot be reproduced from this repository's history and a reviewer has no way to audit what is being overwritten. Rather than remove a deliberate entry, this records the exception and its provenance so the docstring and the list agree.
- **Guards a mistake this class invites.** `55a350281a94` above is the digest of the seed currently shipping. Registering a current-seed digest is a silent no-op — the file is replaced with itself while the stale copy it was meant to catch goes untouched — and it reads exactly like a fix. A mistyped digest is likewise invisible. The new test asserts every registered digest is well-formed and is never the shipping seed's own.
