### PR TITLE
Persist setup errors before closing chat runs

### DIFF
--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -2737,6 +2737,8 @@ async def _terminal_setup_error_cleanup(
   chat_id: str,
   run_token: str = "",
   run_gen: int | None = None,
+  *,
+  error_message: str,
 ) -> chat_queue.TerminalDisposition:
   """Bounded terminal cleanup for a setup-time error before any runner ran.
 
@@ -2748,9 +2750,9 @@ async def _terminal_setup_error_cleanup(
   StartTurn's marker can't be erased and a wedged writer/lock can't hang
   teardown):
 
-    (0) ownership gate, (1) await ClearPending (strict),
-    (2) await FinishRun (strict), (3) discard_starting,
-    (4) forget (if-current), all inside
+    (0) ownership gate, (1) await Finalize with the error (strict),
+    (2) await ClearPending (strict), (3) await FinishRun (strict),
+    (4) discard_starting, (5) forget (if-current), all inside
     `asyncio.timeout(TERMINAL_LOCK_TIMEOUT_SECS)` around the queue lock.
 
   The ownership gate (step 0) mirrors `_complete_turn`'s `we_own_gen` check:
@@ -2783,6 +2785,14 @@ async def _terminal_setup_error_cleanup(
       async with chat_queue.get_lock(chat_id):
         if run_gen is not None and current_run_generation(chat_id) != run_gen:
           return chat_queue.TerminalDisposition.STALE_NO_ACTION
+        if run_token:
+          await _await_ack(get_writer().submit(Finalize(
+            chat_id=chat_id,
+            run_token=run_token,
+            snapshot=build_assistant_message([
+              {"type": "error", "message": error_message},
+            ]),
+          )))
         await _clear_pending_strict(chat_id)
         await _finish_run_strict(
           chat_id, run_token, terminal_status="failed",
@@ -4121,8 +4131,11 @@ async def _run_chat_impl_with_db(
 
   owner = db.query(models.Owner).first()
   if not owner:
-    bc.publish({"type": "error", "message": "No owner configured."})
-    disposition = await _terminal_setup_error_cleanup(chat_id, run_token or "", run_gen)
+    error_message = "No owner configured."
+    bc.publish({"type": "error", "message": error_message})
+    disposition = await _terminal_setup_error_cleanup(
+      chat_id, run_token or "", run_gen, error_message=error_message,
+    )
     bc.publish({"type": "done"})
     clear_active_broadcast_if(bc)  # identity-keyed: never clobber a successor
     bc.mark_completed()
@@ -4257,12 +4270,10 @@ async def _run_chat_impl_with_db(
   except Exception:
     log.exception("failed to snapshot system prompt chat_id=%s", chat_id)
     db.rollback()
-    bc.publish({
-      "type": "error",
-      "message": "Could not preserve this chat's system prompt snapshot.",
-    })
+    error_message = "Could not preserve this chat's system prompt snapshot."
+    bc.publish({"type": "error", "message": error_message})
     disposition = await _terminal_setup_error_cleanup(
-      chat_id, run_token or "", run_gen,
+      chat_id, run_token or "", run_gen, error_message=error_message,
     )
     bc.publish({"type": "done"})
     clear_active_broadcast_if(bc)
@@ -4344,7 +4355,9 @@ async def _run_chat_impl_with_db(
         provider_free=True,
       )
     bc.publish({"type": "error", "message": auth_error})
-    disposition = await _terminal_setup_error_cleanup(chat_id, run_token or "", run_gen)
+    disposition = await _terminal_setup_error_cleanup(
+      chat_id, run_token or "", run_gen, error_message=auth_error,
+    )
     bc.publish({"type": "done"})
     clear_active_broadcast_if(bc)  # identity-keyed: never clobber a successor
     bc.mark_completed()
@@ -4610,11 +4623,11 @@ async def _run_chat_impl_with_db(
     "unsupported provider chat_id=%s provider=%s — no SDK path",
     chat_id, provider.name,
   )
-  bc.publish({
-    "type": "error",
-    "message": f"Provider {provider.name!r} has no supported runtime.",
-  })
-  disposition = await _terminal_setup_error_cleanup(chat_id, run_token or "", run_gen)
+  error_message = f"Provider {provider.name!r} has no supported runtime."
+  bc.publish({"type": "error", "message": error_message})
+  disposition = await _terminal_setup_error_cleanup(
+    chat_id, run_token or "", run_gen, error_message=error_message,
+  )
   clear_active_broadcast_if(bc)  # identity-keyed: never clobber a successor
   bc.publish({"type": "done"})
   bc.mark_completed()

--- a/backend/tests/test_terminal_completion.py
+++ b/backend/tests/test_terminal_completion.py
@@ -842,6 +842,10 @@ def test_unsupported_provider_cleanup_clears_marker_and_pending(monkeypatch):
   state = _load("t7")
   assert state["running"] is False, "unsupported cleanup must clear marker"
   assert state["pending_messages"] == [], "pending must be cleared durably"
+  assert state["messages"][-1]["blocks"] == [{
+    "type": "error",
+    "message": "Provider 'Bogus' has no supported runtime.",
+  }]
   assert not chat_mod.registry.is_alive("t7"), "registry released"
 
 
@@ -1425,6 +1429,8 @@ def test_auth_error_cleanup_when_another_provider_is_connected(monkeypatch):
   state = _load("t12-auth-error")
   assert state["running"] is False
   assert state["pending_messages"] == []
+  assert state["messages"][-1]["blocks"]
+  assert state["messages"][-1]["blocks"][-1]["type"] == "error"
   assert _run_outcomes("t12-auth-error") == {"rt-12-auth": "failed"}
   assert not chat_mod.registry.is_alive("t12-auth-error")
 
@@ -1453,7 +1459,9 @@ def test_setup_error_cleanup_stale_gen_does_not_clobber_successor():
   chat_mod.registry.mark_starting("se-stale")    # successor holds the slot
 
   disposition = asyncio.run(
-    chat_mod._terminal_setup_error_cleanup("se-stale", "rt-stale", 1)
+    chat_mod._terminal_setup_error_cleanup(
+      "se-stale", "rt-stale", 1, error_message="stale error",
+    )
   )
   _drain_actor()
 
@@ -1463,6 +1471,9 @@ def test_setup_error_cleanup_stale_gen_does_not_clobber_successor():
   assert state["pending_messages"] == [
     {"role": "user", "content": "queued-behind-fresh", "ts": 2}
   ], "successor's queued send must survive"
+  assert state["messages"] == [
+    {"role": "user", "content": "fresh", "ts": 1}
+  ], "stale cleanup must not persist an error into the successor"
   assert chat_mod.registry.current_generation("se-stale") == 2, (
     "successor's generation must survive (not reset to reusable 0)"
   )
@@ -1484,7 +1495,9 @@ def test_setup_error_cleanup_owned_gen_clears_and_forgets():
   chat_mod.registry.mark_starting("se-own")
 
   disposition = asyncio.run(
-    chat_mod._terminal_setup_error_cleanup("se-own", "rt-own", gen)
+    chat_mod._terminal_setup_error_cleanup(
+      "se-own", "rt-own", gen, error_message="setup failed",
+    )
   )
   _drain_actor()
 
@@ -1492,6 +1505,9 @@ def test_setup_error_cleanup_owned_gen_clears_and_forgets():
   state = _load("se-own")
   assert state["running"] is False, "owned cleanup clears the marker"
   assert state["pending_messages"] == [], "owned cleanup clears pending"
+  assert state["messages"][-1]["blocks"] == [
+    {"type": "error", "message": "setup failed"}
+  ], "owned cleanup persists the setup error before clearing the marker"
   assert chat_mod.registry.current_generation("se-own") == 0, "forgotten"
   assert not chat_mod.registry.is_alive("se-own"), "starting slot released"
 


### PR DESCRIPTION
## Why

Failures that happen before a provider runner starts are broadcast live, but the setup cleanup immediately closes their durable run without persisting the error. After the in-memory event log expires—or after a restart—the transcript therefore shows a user message followed by no response.

## What changes

- persist the exact setup error through the existing strict terminal snapshot command before clearing pending work or closing the run;
- keep the generation ownership gate ahead of that write so a superseded run cannot write into its successor;
- cover unsupported-provider, credential, owned-generation, and stale-generation outcomes with focused terminal lifecycle tests.

This reuses the existing writer and terminal recovery semantics rather than adding a second persistence path.

## Verification

- 40 terminal-completion tests passed on the exact review branch;
- Python compilation, Ruff, and diff checks passed.