### PR TITLE
Bound SQLite journals and agent scratch lifecycle

### DIFF
--- a/backend/app/agent_scratch.py
+++ b/backend/app/agent_scratch.py
@@ -1,0 +1,100 @@
+"""Scratch directories for agent subprocesses, on the bounded data volume.
+
+Agent CLIs write temporary files through TMPDIR. Left at the container's
+/tmp those land in the overlay upperdir: no quota, statvfs reporting host
+capacity, and — because /tmp is not a tmpfs in this image — never cleared,
+so scratch accumulates for the life of the container.
+
+Routing them to the data volume bounds that, but the volume also holds
+SQLite, so unbounded scratch there is worse than unbounded scratch on the
+host: it takes durable data down with it. This module owns the lifecycle
+that makes the move safe.
+
+Scratch is keyed per chat, matching the per-chat agent-browser profile it
+sits beside in the runner. A chat with no run in flight cannot be using its
+scratch, so that is the deletion rule.
+"""
+
+import logging
+import re
+import shutil
+import time
+from pathlib import Path
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app import models
+from app.config import agent_scratch_root
+
+log = logging.getLogger(__name__)
+
+# A run's row is created around the same moment its scratch is, and the two
+# are not ordered against each other. Without a grace period a sweep driven
+# by one starting run could delete the scratch of another that had not yet
+# registered. Comfortably longer than that gap, far shorter than a turn.
+_SWEEP_GRACE_SECONDS = 15 * 60
+
+
+def _dir_name(chat_id: str) -> str:
+  return re.sub(r"[^A-Za-z0-9_-]", "_", chat_id or "default")
+
+
+def scratch_for_chat(chat_id: str) -> Path:
+  """Create and return the scratch directory this chat's agents may use."""
+  path = agent_scratch_root() / _dir_name(chat_id)
+  path.mkdir(parents=True, exist_ok=True)
+  return path
+
+
+def sweep_idle_scratch(db: Session, *, now: float | None = None) -> dict:
+  """Delete scratch belonging to chats with no run still in flight.
+
+  Returns a summary so the runtime retention supervisor can report what it
+  reclaimed. Failure to remove one directory must not prevent the rest, so
+  errors are collected rather than aborting the sweep.
+  """
+  root = agent_scratch_root()
+  if not root.is_dir():
+    return {"removed": 0, "bytes": 0, "kept_live": 0, "kept_recent": 0}
+
+  live = {
+    _dir_name(chat_id)
+    for chat_id in db.scalars(
+      select(models.ChatRun.chat_id).where(
+        models.ChatRun.status.in_(models.NONTERMINAL_RUN_STATUSES)
+      )
+    ).all()
+  }
+  cutoff = (time.time() if now is None else now) - _SWEEP_GRACE_SECONDS
+  removed = reclaimed = kept_live = kept_recent = 0
+
+  for entry in root.iterdir():
+    if not entry.is_dir():
+      continue
+    if entry.name in live:
+      kept_live += 1
+      continue
+    try:
+      if entry.stat().st_mtime > cutoff:
+        kept_recent += 1
+        continue
+      size = sum(f.stat().st_size for f in entry.rglob("*") if f.is_file())
+      shutil.rmtree(entry)
+    except OSError as exc:
+      log.warning("agent scratch sweep skipped %s: %s", entry.name, exc)
+      continue
+    removed += 1
+    reclaimed += size
+
+  if removed:
+    log.info(
+      "agent scratch swept dirs=%d bytes=%d kept_live=%d kept_recent=%d",
+      removed, reclaimed, kept_live, kept_recent,
+    )
+  return {
+    "removed": removed,
+    "bytes": reclaimed,
+    "kept_live": kept_live,
+    "kept_recent": kept_recent,
+  }

--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -4157,6 +4157,12 @@ async def _run_chat_impl_with_db(
     "CHAT_ID": chat_id,
   })
   base_env.update(app_context_env)
+  # Overrides any inherited TMPDIR from _safe_keys: agent scratch belongs on
+  # the bounded data volume, never the container's unbounded overlay. TMP and
+  # TEMP travel with it so a tool reading either does not escape back to /tmp.
+  from app.agent_scratch import scratch_for_chat
+  scratch = scratch_for_chat(chat_id)
+  base_env["TMPDIR"] = base_env["TMP"] = base_env["TEMP"] = str(scratch)
   # Partner viewport (sent by the React shell on each turn). The agent
   # uses these when taking screenshots so the framing matches what the
   # partner actually sees — preview_shell.sh reads them, mini-app

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,14 +1,10 @@
 """Application settings loaded from environment variables.
 
-FROZEN at runtime (chmod 444 root-owned per protected-files.txt).
-main.py imports this at module load; if I'm broken the server
-can't boot and /recover/chat is unreachable.
+Boot-critical: main.py imports this at module load, so a broken edit
+leaves only /recover reachable. `python3 -m py_compile` before a restart.
 
-To edit me, change the source on the host repo and rebuild the
-container image. The agent should not try to edit me in-place at
-runtime — the chmod will block it and the error looks like a bug.
-Use /data/shared/agent-settings.json for per-instance settings that
-don't need code changes.
+Use /data/shared/agent-settings.json for per-instance settings that don't
+need code changes.
 """
 
 import json
@@ -177,3 +173,19 @@ class Settings(BaseSettings):
 def get_settings() -> Settings:
   """Returns the cached application settings singleton."""
   return Settings()
+
+
+def agent_scratch_root() -> Path:
+  """Root under which each chat gets its own agent scratch directory.
+
+  On the data volume rather than the container's /tmp, because an overlay
+  upperdir has no size of its own: statvfs there reports host capacity, no
+  quota applies, and it is not a tmpfs so nothing clears it on restart.
+  data_dir is a fixed-size volume, so the same bytes land against a limit
+  the platform owns and can measure.
+
+  That ceiling is shared with the database, so per-chat directories and their
+  removal are what keep scratch from taking durable data down with it;
+  `agent_scratch` owns that lifecycle.
+  """
+  return Path(get_settings().data_dir) / "agent-scratch"

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,14 +1,9 @@
 """Database engine and session configuration.
 
-FROZEN at runtime (chmod 444 root-owned per protected-files.txt).
-main.py imports this at module load to set up the engine + run
-migrations; if I'm broken the server can't boot and /recover/chat
-is unreachable. (The recovery surface itself uses raw sqlite3
-and doesn't depend on me, but main.py still does.)
-
-To edit me, change the source on the host repo and rebuild the
-container image. For ad-hoc DB queries the agent should use raw
-`sqlite3` from stdlib — that path doesn't touch this file at all.
+Boot-critical: main.py imports this at module load to build the engine and
+run migrations, so a broken edit leaves only /recover reachable. `python3 -m
+py_compile` before a restart. (Recovery uses raw sqlite3 and does not depend
+on this module; main.py does.)
 """
 
 import json
@@ -25,6 +20,7 @@ from sqlalchemy import create_engine, event
 from sqlalchemy.orm import DeclarativeBase, sessionmaker
 from sqlalchemy.pool import NullPool
 
+from app import sqlite_policy
 from app.config import get_settings
 
 
@@ -111,31 +107,14 @@ def _make_engine():
         label,
       )
   if is_sqlite:
-    # SQLite under concurrent writes:
-    # - WAL lets readers run while a single writer writes (no
-    #   blanket lock the way the default DELETE journal does).
-    # - busy_timeout waits up to N ms for a lock instead of
-    #   immediately raising "database is locked" when two
-    #   coroutines try to commit in the same window.
-    # - synchronous=FULL fsyncs the WAL on every commit so an
-    #   OOM kill (which this host suffers periodically) or a
-    #   power loss can't leave the last N commits in the kernel
-    #   page cache but not on disk. NORMAL skips that fsync and
-    #   risks losing the last committed transaction on an abrupt
-    #   kill; FULL adds ~1 fsync per write transaction, acceptable
-    #   given write frequency on this platform.
+    # NullPool opens a fresh connection per session, so this runs constantly
+    # under load. The policy itself lives in sqlite_policy so the standalone
+    # scripts writing this same database apply it identically.
     @event.listens_for(eng, "connect")
     def _set_sqlite_pragmas(dbapi_conn, _record):
       cur = dbapi_conn.cursor()
-      # busy_timeout must come first: journal_mode=WAL takes locks and,
-      # with no busy handler yet installed, fails immediately instead of
-      # waiting when another connection holds them. NullPool opens a
-      # fresh connection per session, so this pragma sequence runs under
-      # load constantly. (True disk exhaustion still fails here — that
-      # cause is owned by the disk-headroom work, not this ordering.)
-      cur.execute("PRAGMA busy_timeout=5000")
-      cur.execute("PRAGMA journal_mode=WAL")
-      cur.execute("PRAGMA synchronous=FULL")
+      for pragma in sqlite_policy.connection_pragmas():
+        cur.execute(pragma)
       cur.close()
   return eng
 

--- a/backend/app/routes/fs.py
+++ b/backend/app/routes/fs.py
@@ -215,14 +215,13 @@ def _child_count(subdir: Path) -> int | None:
 
 @router.get("/disk")
 def fs_disk(_owner: models.Owner = Depends(get_owner_or_app_with_filesystem_access)):
-  """Disk usage of the HOST filesystem that backs the data dir, in bytes.
+  """Capacity of the filesystem containing the configured data dir, in bytes.
 
-  A single `statvfs` on the data-dir mount — no path parameter, no walk. This
-  reports the underlying HOST volume holding `/data` (total/used/free), NOT a
-  Möbius-imposed quota or the size of the viewable tree: everything else on
-  that mount (the OS, other containers, images) counts toward `used`. The
-  Editor surfaces it so the owner can see how much room the volume has
-  left."""
+  A single mount-level `statvfs` — not a recursive subtree size, and not a
+  Möbius-enforced quota. What else counts toward `used` depends on how the
+  deployment mounts `data_dir`: when it has its own volume this is Möbius's
+  own footprint, and when it shares a mount the mount's other tenants count
+  too."""
   data_dir = get_settings().data_dir
   usage = shutil.disk_usage(data_dir)
   return {"total": usage.total, "used": usage.used, "free": usage.free,

--- a/backend/app/runtime_supervisors.py
+++ b/backend/app/runtime_supervisors.py
@@ -225,11 +225,38 @@ class RuntimeSupervisors:
           )
         await asyncio.sleep(sweep_seconds)
 
+    async def agent_scratch_loop():
+      # Scratch cleanup is retention work, not part of starting a chat. Keeping
+      # it here avoids making every concurrent turn rescan the same directory.
+      await asyncio.sleep(300)
+      while True:
+        try:
+          from app.agent_scratch import sweep_idle_scratch
+
+          def sweep_once():
+            with SessionLocal() as db:
+              return sweep_idle_scratch(db)
+
+          result = await asyncio.to_thread(sweep_once)
+          if result["bytes"]:
+            self.log.info(
+              "agent scratch retention reclaimed %d bytes",
+              result["bytes"],
+            )
+        except asyncio.CancelledError:
+          raise
+        except Exception as exc:
+          self.log.error(
+            "agent scratch retention failed: %s", exc, exc_info=True,
+          )
+        await asyncio.sleep(60 * 60)
+
     self._spawn("wedged-marker-sweep", wedged_marker_loop())
     self._spawn("stalled-live-sweep", stalled_live_loop())
     self._spawn("reset-park-sweep", reset_park_loop())
     self._spawn("writer-supervisor", writer_supervisor_loop())
     self._spawn("browser-profile-quota", browser_profile_loop())
+    self._spawn("agent-scratch-retention", agent_scratch_loop())
     self._spawn("legacy-tool-output-compression", compress_legacy_tool_outputs())
 
   async def stop(self) -> None:

--- a/backend/app/sqlite_policy.py
+++ b/backend/app/sqlite_policy.py
@@ -1,0 +1,56 @@
+"""SQLite connection policy for the live runtime.
+
+One place that decides how this platform's SQLite connections behave, so the
+SQLAlchemy engine and the standalone scripts that open the same database
+cannot drift apart. Deliberately stdlib-only and import-light: `database`
+builds an engine at module load, so a script needing this policy must be able
+to reach it without paying for that.
+"""
+
+# Waits for a lock instead of raising "database is locked" the moment two
+# writers overlap. Must be installed before any pragma that can itself take a
+# lock — see connection_pragmas.
+BUSY_TIMEOUT_MS = 5000
+
+# Caps RETAINED journal size, not live growth. SQLite defaults this to -1
+# (never truncate), so a WAL only ratchets upward: a checkpoint returns pages
+# to the database but leaves the file at its high-water mark, and that
+# allocation is kept forever. With a limit set, a checkpoint that resets the
+# WAL also truncates the file back down.
+#
+# It is not a runtime ceiling. Truncation happens only on a reset, and a reset
+# needs a gap where no reader holds an older snapshot — so a single long-lived
+# read transaction is enough to let the file exceed this, regardless of how
+# many sessions are running. If it grows again, look for the transaction that
+# never ends rather than the session count.
+#
+# 64 MiB trades a little repeated growth work for a bound small against the
+# data volume. No formula: raise it if checkpoint churn shows up in write
+# latency, lower it if retained journal space becomes material.
+RETAINED_JOURNAL_LIMIT_BYTES = 64 * 1024 * 1024
+
+
+def connection_pragmas() -> tuple[str, ...]:
+  """The ordered PRAGMAs every live-runtime SQLite connection must run.
+
+  Returned as statements rather than applied to a connection because the
+  callers hold different objects — SQLAlchemy hands out a DBAPI cursor, the
+  standalone scripts a `sqlite3.Connection` — and the ordering is the part
+  that must not be duplicated.
+
+  Order is load-bearing: `busy_timeout` first, because `journal_mode=WAL`
+  takes locks and with no busy handler installed it fails immediately instead
+  of waiting when another connection holds them.
+
+  `synchronous=FULL` fsyncs the WAL on every commit, so an OOM kill (which
+  this host suffers periodically) or power loss cannot leave the last commits
+  in the page cache but not on disk. NORMAL skips that fsync and risks losing
+  the last committed transaction; FULL costs roughly one fsync per write
+  transaction, acceptable at this platform's write rate.
+  """
+  return (
+    f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}",
+    "PRAGMA journal_mode=WAL",
+    "PRAGMA synchronous=FULL",
+    f"PRAGMA journal_size_limit={RETAINED_JOURNAL_LIMIT_BYTES}",
+  )

--- a/backend/scripts/chat_note.py
+++ b/backend/scripts/chat_note.py
@@ -165,10 +165,34 @@ def _render_transcript(raw: str) -> str:
   return "\n\n".join(lines)
 
 
+def _apply_sqlite_policy(con: sqlite3.Connection) -> None:
+  """Apply the runtime's shared SQLite policy to a raw connection.
+
+  This script opens the same database the server does, so it must not drift
+  from the engine's settings — most visibly `journal_size_limit`, which is a
+  per-connection setting: a writer that skips it leaves the WAL's high-water
+  allocation in place no matter what the server's connections declare.
+
+  Imported lazily, and tolerant of failure, because publishing a chat note is
+  worth more than a pragma: the script also runs in contexts where the app
+  package is not importable.
+  """
+  backend_text = str(Path(__file__).resolve().parents[1])
+  if backend_text not in sys.path:
+    sys.path.insert(0, backend_text)
+  try:
+    from app.sqlite_policy import connection_pragmas
+  except ImportError:
+    return
+  for pragma in connection_pragmas():
+    con.execute(pragma)
+
+
 def _read_chat_snapshot(chat_id: str) -> tuple[str, str] | None:
   """Return complete transcript + durable revision for one idle live chat."""
   try:
     con = sqlite3.connect(str(DB))
+    _apply_sqlite_policy(con)
     row = con.execute(
       "select messages, updated_at from chats "
       "where id=? and deleted_at is null "
@@ -295,6 +319,7 @@ def _configured_provider() -> str:
     return override
   try:
     con = sqlite3.connect(str(DB))
+    _apply_sqlite_policy(con)
     row = con.execute("select provider from owner limit 1").fetchone()
     con.close()
   except sqlite3.Error:
@@ -432,6 +457,7 @@ def _publish_if_current(
   """Atomically publish only while both durable snapshots are still current."""
   con = sqlite3.connect(str(DB), timeout=10, isolation_level=None)
   try:
+    _apply_sqlite_policy(con)
     con.execute("begin immediate")
     row = con.execute(
       "select updated_at from chats "

--- a/backend/tests/test_agent_scratch.py
+++ b/backend/tests/test_agent_scratch.py
@@ -1,0 +1,110 @@
+"""Agent scratch stays on the bounded data volume and does not outlive its run.
+
+The container's /tmp is an overlay upperdir: no quota, statvfs reporting host
+capacity, and not a tmpfs, so nothing ever clears it. Moving scratch to the
+data volume bounds it — but that volume also holds SQLite, so scratch without
+a lifecycle would take durable data down with it. These cover both halves.
+"""
+
+import time
+
+from app import agent_scratch, config, models
+
+
+def _pin_data_dir(monkeypatch, tmp_path):
+  monkeypatch.setattr(
+    config, "get_settings", lambda: type("S", (), {"data_dir": str(tmp_path)})()
+  )
+  return tmp_path
+
+
+def test_scratch_root_follows_the_configured_volume(monkeypatch, tmp_path):
+  """A hardcoded path would satisfy a single-volume assertion, so move the
+  volume and require the root to move with it."""
+  _pin_data_dir(monkeypatch, tmp_path / "volume-a")
+  first = config.agent_scratch_root()
+  _pin_data_dir(monkeypatch, tmp_path / "volume-b")
+  second = config.agent_scratch_root()
+
+  assert first != second
+  assert (tmp_path / "volume-a") in first.parents
+  assert (tmp_path / "volume-b") in second.parents
+
+
+def test_scratch_for_chat_is_usable_before_the_subprocess_starts(
+  monkeypatch, tmp_path
+):
+  """The path is exported straight into a subprocess environment, so it has to
+  exist by then rather than on first write."""
+  _pin_data_dir(monkeypatch, tmp_path)
+
+  assert agent_scratch.scratch_for_chat("chat-1").is_dir()
+
+
+def test_scratch_is_isolated_per_chat(monkeypatch, tmp_path):
+  """Sweeping is per chat, so two chats must not share one directory."""
+  _pin_data_dir(monkeypatch, tmp_path)
+
+  assert agent_scratch.scratch_for_chat("a") != agent_scratch.scratch_for_chat("b")
+
+
+def test_sweep_reclaims_scratch_for_a_chat_with_no_run_in_flight(
+  monkeypatch, tmp_path, db
+):
+  _pin_data_dir(monkeypatch, tmp_path)
+  idle = agent_scratch.scratch_for_chat("idle-chat")
+  (idle / "leftover.bin").write_bytes(b"x" * 2048)
+
+  result = agent_scratch.sweep_idle_scratch(
+    db, now=time.time() + agent_scratch._SWEEP_GRACE_SECONDS + 1
+  )
+
+  assert not idle.exists()
+  assert result["removed"] == 1
+  assert result["bytes"] >= 2048
+
+
+def test_sweep_never_deletes_scratch_of_a_run_still_in_flight(
+  monkeypatch, tmp_path, db, chat
+):
+  """Deleting a live run's scratch would corrupt a turn already in progress."""
+  _pin_data_dir(monkeypatch, tmp_path)
+  chat_id = getattr(chat, "id", chat)
+  db.add(
+    models.ChatRun(
+      id="run-live", chat_id=chat_id, status="running"
+    )
+  )
+  db.commit()
+  live = agent_scratch.scratch_for_chat(chat_id)
+
+  result = agent_scratch.sweep_idle_scratch(
+    db, now=time.time() + agent_scratch._SWEEP_GRACE_SECONDS + 1
+  )
+
+  assert live.is_dir()
+  assert result["kept_live"] == 1
+  assert result["removed"] == 0
+
+
+def test_sweep_spares_scratch_created_before_its_run_row_exists(
+  monkeypatch, tmp_path, db
+):
+  """Scratch and the ChatRun row are created around the same moment and are not
+  ordered against each other, so a run starting now must not delete the scratch
+  of one that has not registered yet."""
+  _pin_data_dir(monkeypatch, tmp_path)
+  starting = agent_scratch.scratch_for_chat("just-started")
+
+  result = agent_scratch.sweep_idle_scratch(db)
+
+  assert starting.is_dir()
+  assert result["kept_recent"] == 1
+  assert result["removed"] == 0
+
+
+def test_sweep_reports_zero_before_any_scratch_exists(monkeypatch, tmp_path, db):
+  """First run on a fresh volume: absence is an ordinary result, not an error."""
+  _pin_data_dir(monkeypatch, tmp_path / "never-written")
+
+  assert agent_scratch.sweep_idle_scratch(db)["removed"] == 0

--- a/backend/tests/test_database_pragmas.py
+++ b/backend/tests/test_database_pragmas.py
@@ -1,11 +1,16 @@
 """SQLite connections install their lock handler before lock-taking pragmas."""
 
+import importlib.util
+import sqlite3
+from pathlib import Path
 from types import SimpleNamespace
 
-from app import database
+from app import database, sqlite_policy
 
 
-def test_sqlite_connection_pragma_order(monkeypatch, tmp_path):
+def _capture_connect_pragmas(monkeypatch, tmp_path):
+  """Run _make_engine with a fake engine and return the pragmas a new
+  connection executes."""
   listeners = {}
 
   def _listens_for(_engine, event_name):
@@ -45,9 +50,62 @@ def test_sqlite_connection_pragma_order(monkeypatch, tmp_path):
   database._make_engine()
   connection = _Connection()
   listeners["connect"](connection, object())
+  return connection.connection_cursor.statements
 
-  assert connection.connection_cursor.statements == [
+
+def test_sqlite_connection_pragma_order(monkeypatch, tmp_path):
+  """busy_timeout must precede journal_mode=WAL: WAL takes locks, and with no
+  busy handler installed it fails immediately instead of waiting."""
+  assert _capture_connect_pragmas(monkeypatch, tmp_path) == [
     "PRAGMA busy_timeout=5000",
     "PRAGMA journal_mode=WAL",
     "PRAGMA synchronous=FULL",
+    f"PRAGMA journal_size_limit={sqlite_policy.RETAINED_JOURNAL_LIMIT_BYTES}",
   ]
+
+
+def test_sqlite_journal_limit_reaches_a_real_connection(tmp_path):
+  """The list above only proves what we emit. SQLite silently ignores a
+  malformed or out-of-range pragma, so read the value back off a live
+  connection: without a limit the default is -1 and the WAL is never
+  truncated, retaining its high-water allocation forever."""
+  con = sqlite3.connect(tmp_path / "pragma.db")
+  try:
+    con.execute("PRAGMA journal_mode=WAL")
+    con.execute(
+      f"PRAGMA journal_size_limit={sqlite_policy.RETAINED_JOURNAL_LIMIT_BYTES}"
+    )
+
+    assert con.execute("PRAGMA journal_size_limit").fetchone()[0] == (
+      sqlite_policy.RETAINED_JOURNAL_LIMIT_BYTES
+    )
+  finally:
+    con.close()
+
+
+def test_standalone_writer_applies_the_same_policy_as_the_engine(tmp_path):
+  """chat_note.py opens this database directly, outside SQLAlchemy. Because
+  journal_size_limit is per-connection, a writer that skips it leaves the WAL's
+  retained allocation in place no matter what the engine's connections declare.
+  Exercise its configurator rather than reading its source, so the test tracks
+  the behaviour and not the wiring."""
+  spec = importlib.util.spec_from_file_location(
+    "chat_note_under_test",
+    Path(__file__).resolve().parents[1] / "scripts" / "chat_note.py",
+  )
+  chat_note = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(chat_note)
+
+  con = sqlite3.connect(tmp_path / "note.db")
+  try:
+    con.execute("PRAGMA journal_mode=WAL")
+    chat_note._apply_sqlite_policy(con)
+
+    assert con.execute("PRAGMA journal_size_limit").fetchone()[0] == (
+      sqlite_policy.RETAINED_JOURNAL_LIMIT_BYTES
+    )
+    assert con.execute("PRAGMA busy_timeout").fetchone()[0] == (
+      sqlite_policy.BUSY_TIMEOUT_MS
+    )
+  finally:
+    con.close()


### PR DESCRIPTION
## Summary

- apply one ordered SQLite connection policy to the server and the standalone chat-summary writer
- cap retained WAL allocation while preserving the existing durability and lock-wait settings
- keep agent scratch on the measured data volume in isolated per-chat directories
- reclaim scratch only after a grace period and only when no durable run is active, from the existing runtime supervisor rather than the chat-start hot path
- correct the data-volume description so it remains accurate for both dedicated and shared mounts

## Verification

- 67 focused backend tests passed, covering scratch lifecycle, SQLite policy, runtime supervisors, and settings
- Python compilation, Ruff, diff, and privacy checks passed

## Design review

The final review removed an accidentally carried delegation migration and moved retention out of every turn start. The result has one SQLite policy, one scratch owner, and no new scheduler.