### PR TITLE
Explain a refused contribution instead of dumping its transcript

### DIFF
--- a/backend/app/codex_login_parse.py
+++ b/backend/app/codex_login_parse.py
@@ -18,13 +18,12 @@ linear patterns over bounded text.
 
 import re
 
+from app.terminal_output import strip_terminal_noise
+
 # A device code looks like XXXX-XXXX (groups of 4+ alphanumerics joined by a
 # hyphen). Used both as the readline-loop readiness probe and the final
 # extraction.
 _CODE_RE = re.compile(r"[A-Z0-9]{4,}-[A-Z0-9]{4,}")
-
-# Strips ANSI escape sequences (e.g. the CLI wraps the URL in \x1b[4m…\x1b[0m).
-_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]")
 
 # A bare https URL — stops at whitespace or quoting/bracket characters.
 _URL_RE = re.compile(r"https://[^\s<>\"']+")
@@ -48,7 +47,7 @@ def parse_login_banner(output: str):
   punctuation captured from prose (e.g. "Visit https://example.com.") is
   trimmed off the URL.
   """
-  clean = _ANSI_RE.sub("", output)
+  clean = strip_terminal_noise(output)
   url_match = _URL_RE.search(clean)
   code_match = _CODE_RE.search(clean)
   if not url_match or not code_match:

--- a/backend/app/contribution_errors.py
+++ b/backend/app/contribution_errors.py
@@ -2,9 +2,27 @@
 
 from __future__ import annotations
 
+import re
+
+from app.terminal_output import readable_output
+
+# The verdict line Möbius's own pre-push gate prints when it refuses a push.
+# It is a declared contract between two Möbius-owned components — see the
+# matching printf in scripts/githooks/pre-push — so this reads structure the
+# hook already computed rather than re-deriving it from the prose above it.
+_GATE_VERDICT = re.compile(
+  r"^\[pre-push\] verdict=blocked cause=(\w+) checks=(\S*)\s*$",
+  re.MULTILINE,
+)
+
 
 class ContributionSubmitError(Exception):
-  """A reviewed GitHub action failed without exposing unsafe raw state."""
+  """A reviewed GitHub action failed without exposing unsafe raw state.
+
+  ``message`` is the single owner-facing sentence. ``detail`` is optional
+  diagnostic text for the disclosure beneath it — already sanitized, never a
+  substitute for a real message, and never the thing shown first.
+  """
 
   def __init__(
     self,
@@ -13,9 +31,44 @@ class ContributionSubmitError(Exception):
     *,
     record_patch: dict | None = None,
     code: str | None = None,
+    detail: str | None = None,
   ):
     super().__init__(message)
     self.message = message
     self.status_code = status_code
     self.record_patch = record_patch or {}
     self.code = code
+    self.detail = detail or ""
+
+
+def push_rejected(
+  raw: str,
+  *,
+  record_patch: dict | None = None,
+) -> ContributionSubmitError:
+  """Explain a refused push in one sentence, with the transcript behind it.
+
+  Git hands back whatever the transport and the local hooks printed. That is a
+  developer's terminal artifact, not an owner-facing explanation, so it belongs
+  in ``detail`` while ``message`` says who refused and what is true of the
+  branch now — in every case, that nothing was published.
+  """
+  detail = readable_output(raw)
+  verdict = _GATE_VERDICT.search(detail)
+
+  if verdict is None:
+    message = "GitHub would not accept this branch, so nothing was published."
+  elif verdict.group(1) == "privacy":
+    message = (
+      "Möbius's privacy gate stopped this push: the branch still contains "
+      "private workspace paths. Nothing was published."
+    )
+  else:
+    checks = verdict.group(2).replace(",", ", ")
+    named = f" ({checks})" if checks else ""
+    message = (
+      f"This did not pass the checks Möbius runs before publishing{named}. "
+      "Nothing was published — fix it locally, then send again."
+    )
+
+  return ContributionSubmitError(message, record_patch=record_patch, detail=detail)

--- a/backend/app/github_contribution_git.py
+++ b/backend/app/github_contribution_git.py
@@ -534,6 +534,39 @@ def _assert_merges_with_upstream(
   finally:
     _git(repo, "update-ref", "-d", upstream_ref, check=False)
 
+def _conflicts_with_recorded_upstream(record: dict, repo, branch: str) -> bool:
+  """Whether this branch still fails to merge the upstream it last saw.
+
+  A conflict is a fact about two commits, so DERIVE it from the branch as it
+  stands rather than trusting a verdict a past attempt left behind. A refreshed
+  branch stops reporting one the moment it genuinely merges, and nothing has to
+  remember to clear a flag — the failure mode of every stored classification.
+
+  The upstream commit is already in this checkout's object store, fetched by the
+  submit that recorded its sha, so this stays local and never reaches the
+  network. It can only go stale in the safe direction: upstream moving on is
+  invisible here, and the authoritative check against live upstream still runs
+  at submit before anything is pushed.
+
+  ``merge-tree --write-tree`` writes the merged tree it computes, so this leaves
+  unreferenced objects behind for gc — the same objects the submit-time check
+  already writes. It touches no working tree, index, branch or ref, which is
+  what the read-only review endpoint calling it promises.
+  """
+  upstream_sha = str(record.get("last_submit_upstream_sha") or "")
+  if not _GIT_SHA.match(upstream_sha):
+    return False
+  present = _git(
+    repo, "cat-file", "-e", f"{upstream_sha}^{{commit}}", check=False,
+  )
+  if present.returncode != 0:
+    return False
+  merged = _git(
+    repo, "merge-tree", "--write-tree", upstream_sha, branch, check=False,
+  )
+  return merged.returncode != 0
+
+
 
 def _resolve_reviewed_commit(repo: Path, value: object, label: str) -> str:
   raw = str(value or "").strip()

--- a/backend/app/github_contributions.py
+++ b/backend/app/github_contributions.py
@@ -31,7 +31,8 @@ from app import (
   release_channel,
 )
 from app.config import get_settings
-from app.contribution_errors import ContributionSubmitError
+from app.contribution_errors import ContributionSubmitError, push_rejected
+from app.terminal_output import readable_output
 from app.github_contribution_contract import (
   BRANCH_NAME as _BRANCH_NAME,
   COAUTHOR_TRAILER as _COAUTHOR_TRAILER,
@@ -416,8 +417,12 @@ def _cleanup_terminal_staging_checkout(record: dict) -> bool:
         env=env,
       )
       if removed.returncode != 0:
-        detail = (removed.stderr or removed.stdout or "git worktree remove failed").strip()
-        raise ContributionSubmitError(detail[:600])
+        raise ContributionSubmitError(
+          "Could not clear the old review checkout for this contribution.",
+          detail=readable_output(
+            removed.stderr or removed.stdout or "git worktree remove failed",
+          ),
+        )
       subprocess.run(
         ["git", f"--git-dir={common_dir}", "worktree", "prune"],
         cwd=str(data_dir),
@@ -940,6 +945,7 @@ def _mark_submit_failure(
   record_path: Path,
   message: str,
   record_patch: dict | None = None,
+  detail: str = "",
 ) -> dict | None:
   try:
     record = _read_record(record_path)
@@ -954,6 +960,12 @@ def _mark_submit_failure(
     "last_submit_error": message,
     "updated_at": _now_iso(),
   }
+  # The diagnostic belongs to exactly one attempt. Carrying a previous
+  # transcript next to a new message would explain the wrong failure.
+  if detail:
+    next_record["last_submit_error_detail"] = detail
+  else:
+    next_record.pop("last_submit_error_detail", None)
   _write_record(record_path, next_record)
   return next_record
 
@@ -978,6 +990,7 @@ def _mark_submit_success(
   if number is not None:
     next_record["number"] = number
   next_record.pop("last_submit_error", None)
+  next_record.pop("last_submit_error_detail", None)
   _write_record(record_path, next_record)
   return next_record
 
@@ -988,17 +1001,22 @@ def _mark_stack_submit_failure(
   *,
   failed_id: str | None = None,
   record_patch: dict | None = None,
+  detail: str = "",
 ) -> list[dict]:
   snapshots = []
   for row in rows:
     current = _read_record(row["record_path"])
     if current.get("status") == "submitting":
-      patch = record_patch if current.get("id") == failed_id else None
+      is_failed = current.get("id") == failed_id
+      patch = record_patch if is_failed else None
       current = _mark_submit_failure(
         app_id=0,
         record_path=row["record_path"],
         message=message,
         record_patch=patch,
+        # Only the layer that actually failed owns the transcript; the
+        # siblings were stopped, not rejected.
+        detail=detail if is_failed else "",
       ) or current
     snapshots.append(current)
   return snapshots
@@ -1264,9 +1282,10 @@ def _existing_branch_pr(
   except (subprocess.TimeoutExpired, OSError) as exc:
     raise ContributionSubmitError(could_not_verify) from exc
   if proc.returncode != 0:
-    detail = (proc.stderr or proc.stdout or "").strip()
-    suffix = f" ({detail[:200]})" if detail else ""
-    raise ContributionSubmitError(could_not_verify + suffix)
+    raise ContributionSubmitError(
+      could_not_verify,
+      detail=readable_output(proc.stderr or proc.stdout or ""),
+    )
   try:
     rows = json.loads(proc.stdout or "[]")
   except ValueError:
@@ -1699,10 +1718,7 @@ def _push_reviewed_topic(
   if not last_push_error:
     return push_source, record_patch
   if not _is_workflow_scope_push_error(last_push_error):
-    raise ContributionSubmitError(
-      last_push_error[:600] or "Git push failed.",
-      record_patch=record_patch,
-    )
+    raise push_rejected(last_push_error, record_patch=record_patch)
 
   # Most topic branches can be pushed without consulting the fork's default
   # branch. GitHub only makes that state relevant when a public_repo-only
@@ -1765,10 +1781,7 @@ def _push_reviewed_topic(
       raise _git_ops._merge_error_patch(sync_exc, record_patch) from sync_exc
   last_push_error = _push_topic_branch(repo, branch, push_source)
   if last_push_error:
-    raise ContributionSubmitError(
-      last_push_error[:600] or "Git push failed.",
-      record_patch=record_patch,
-    )
+    raise push_rejected(last_push_error, record_patch=record_patch)
   return push_source, record_patch
 
 
@@ -1901,10 +1914,7 @@ def _submit_prepared_pr(
         repo, push_remote, branch, push_source,
       )
       if last_push_error:
-        raise ContributionSubmitError(
-          last_push_error[:600] or "Git push failed.",
-          record_patch=record_patch,
-        )
+        raise push_rejected(last_push_error, record_patch=record_patch)
     else:
       try:
         fork_slug = _ensure_owner_fork_remote(repo, upstream_repo, login)

--- a/backend/app/install.py
+++ b/backend/app/install.py
@@ -88,6 +88,7 @@ from app.manifest_contract import (
 # net_utils.py for why the two SSRF validators were unified.
 from app.net_utils import validate_url_safe as _validate_url_safe
 from app.storage_io import atomic_write
+from app.terminal_output import strip_terminal_noise
 from app.app_identity import (
   allocate_unique_slug,
   reject_if_source_dir_taken as _reject_if_source_dir_taken,
@@ -138,7 +139,6 @@ _ENTRY_MAX_BYTES = _CONTRACT_ENTRY_MAX_BYTES
 _SEED_MAX_BYTES = _CONTRACT_SEED_MAX_BYTES
 
 _HEX_COLOR_RE = re.compile(r"^#[0-9a-fA-F]{6}$")
-_ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 
 
 def _manifest_color(value) -> str | None:
@@ -167,7 +167,7 @@ def _manifest_display(value) -> str | None:
 
 def _compile_error_detail(app_name: str, exc: CompileError) -> str:
   """Return a concise client-safe compile error for a manifest install."""
-  cleaned = _ANSI_RE.sub("", exc.stderr or "")
+  cleaned = strip_terminal_noise(exc.stderr or "")
   lines = [line.strip() for line in cleaned.splitlines() if line.strip()]
   for line in lines:
     resolve_idx = line.find("Could not resolve")

--- a/backend/app/routes/github.py
+++ b/backend/app/routes/github.py
@@ -115,6 +115,7 @@ from app.github_contribution_git import (
   _run_cmd,
   _assert_clean_worktree,
   _assert_coauthor_trailer,
+  _conflicts_with_recorded_upstream,
   _connected_git_identity,
   _head_commit_metadata,
   _head_sha_patch,
@@ -628,6 +629,10 @@ _REVIEW_STATUS_MESSAGES = {
   "missing_coauthor": (
     "The staged commit is missing its Möbius Agent co-author marker."
   ),
+  "upstream_conflict": (
+    "This no longer merges cleanly with the branch it targets, so it has to "
+    "be refreshed before it can be sent."
+  ),
   "invalid_stack": "The linked PR chain no longer matches its reviewed order.",
   "parent_merged": (
     "A parent PR has merged, so the remaining private layer must be refreshed "
@@ -696,6 +701,12 @@ def _inspect_prepared_review(
         author_name=author_name,
         author_email=author_email,
       )
+    # Last, because it is the only verdict here that is not about the staged
+    # checkout: the source can match its review exactly and still be
+    # unmergeable. A dirty or moved checkout is the more urgent thing to say,
+    # so those are reported first.
+    if _conflicts_with_recorded_upstream(record, repo, branch):
+      return _review_status_problem(record_id, code="upstream_conflict")
   except ContributionSubmitError as exc:
     return _review_status_problem(
       record_id,

--- a/backend/app/routes/github.py
+++ b/backend/app/routes/github.py
@@ -915,6 +915,7 @@ def _chat_review_projection(record: dict, app_id: int) -> dict:
     "files": _diff_file_paths(diff_path),
     "labels": labels,
     "last_submit_error": text(record.get("last_submit_error")),
+    "last_submit_error_detail": text(record.get("last_submit_error_detail")),
     "updated_at": text(record.get("updated_at")),
     "contribution_disabled_reason": contribution_disabled_reason,
     # `is_stack` keeps an invalid/legacy stack safely non-sendable. `stack`
@@ -1097,10 +1098,11 @@ async def submit_contribution(
         record_path=record_path,
         message=exc.message,
         record_patch=exc.record_patch,
+        detail=exc.detail,
       )
     raise HTTPException(
       status_code=exc.status_code,
-      detail={"message": exc.message, "record": record},
+      detail={"message": exc.message, "detail": exc.detail, "record": record},
     )
   except Exception as exc:
     log.exception("Contribution submit failed for %s/%s", app_id, record_id)
@@ -1258,11 +1260,13 @@ async def submit_contribution_stack(
               exc.message,
               failed_id=str(record.get("id") or ""),
               record_patch=exc.record_patch,
+              detail=exc.detail,
             )
           raise HTTPException(
             status_code=exc.status_code,
             detail={
               "message": exc.message,
+              "detail": exc.detail,
               "records": snapshots,
               "submitted": submitted_urls,
             },
@@ -1298,10 +1302,11 @@ async def submit_contribution_stack(
         rows,
         exc.message,
         record_patch=exc.record_patch,
+        detail=exc.detail,
       )
     raise HTTPException(
       status_code=exc.status_code,
-      detail={"message": exc.message, "records": snapshots},
+      detail={"message": exc.message, "detail": exc.detail, "records": snapshots},
     ) from exc
   except Exception as exc:
     log.exception("Contribution stack submit failed for app %s", app_id)

--- a/backend/app/terminal_output.py
+++ b/backend/app/terminal_output.py
@@ -1,0 +1,42 @@
+"""Turning captured command output into text safe to store and display.
+
+Subprocess transcripts arrive dressed for a terminal. Colour codes, cursor
+moves and stray control bytes are correct there and wrong everywhere else:
+they survive JSON, reach the owner's screen as literal `[1;31m`, and disfigure
+the diagnostic they were meant to highlight. Every place that turns captured
+output into stored or rendered text goes through here, so the set of sequences
+we know about is defined once.
+"""
+
+from __future__ import annotations
+
+import re
+
+_TERMINAL_NOISE = re.compile(
+  r"\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)"    # OSC ... BEL/ST (titles, hyperlinks)
+  r"|\x1b\[[0-9;?]*[ -/]*[@-~]"           # CSI (colour, cursor moves)
+  r"|\x1b[@-Z\\-_]"                       # two-byte escapes
+  r"|[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]"    # other control bytes
+)
+
+_BLANK_RUN = re.compile(r"\n{3,}")
+
+DEFAULT_LIMIT = 2000
+
+
+def strip_terminal_noise(raw: str) -> str:
+  """Remove escape sequences and control bytes, keeping tabs and newlines."""
+  return _TERMINAL_NOISE.sub("", str(raw or ""))
+
+
+def readable_output(raw: str, *, limit: int = DEFAULT_LIMIT) -> str:
+  """Sanitize, tidy and cap a captured transcript.
+
+  Keeps the TAIL when it overflows: a failing command states its reason last,
+  so truncating from the front preserves the banner and discards the answer.
+  """
+  lines = strip_terminal_noise(raw).splitlines()
+  cleaned = _BLANK_RUN.sub("\n\n", "\n".join(line.rstrip() for line in lines)).strip("\n")
+  if len(cleaned) <= limit:
+    return cleaned
+  return "…\n" + cleaned[-limit:].split("\n", 1)[-1]

--- a/backend/tests/test_contribution_errors.py
+++ b/backend/tests/test_contribution_errors.py
@@ -1,0 +1,160 @@
+"""Submit failures must read as one sentence, never as a terminal transcript."""
+
+import re
+from pathlib import Path
+
+from app.contribution_errors import ContributionSubmitError, push_rejected
+from app.terminal_output import readable_output
+
+# The exact bytes a rejected Send stored on a real contribution record: the
+# local gate's colour codes, npm's lifecycle banner, and the one line that
+# actually explains the refusal.
+REAL_PRE_PUSH_REJECTION = (
+  "\x1b[1;31m[pre-push]\x1b[0m frontend-unit FAILED:\r\n"
+  "    \r\n"
+  "    > moebius@0.1.0 test\r\n"
+  "    > npm run test:lib && npm run test:hooks\r\n"
+  "    \r\n"
+  "    \r\n"
+  "    > moebius@0.1.0 pretest:lib\r\n"
+  "    > npm run runtime:check && npm run test:structure\r\n"
+  "    \r\n"
+  "    Structural-test debt grew:\r\n"
+  "      - 781 source-reading cases exceeds 780\r\n"
+  "    Replace implementation-text assertions with behavioral coverage.\r\n"
+  "\x1b[1;31m[pre-push]\x1b[0m push blocked. Fix the above.\r\n"
+  "[pre-push] verdict=blocked cause=checks checks=frontend-unit\r\n"
+)
+
+
+def test_terminal_colour_never_survives_into_stored_text():
+  cleaned = readable_output(REAL_PRE_PUSH_REJECTION)
+
+  assert "\x1b" not in cleaned
+  assert "[1;31m" not in cleaned
+  assert "[pre-push] frontend-unit FAILED:" in cleaned
+  assert "781 source-reading cases exceeds 780" in cleaned
+
+
+def test_blank_runs_collapse_and_line_endings_normalize():
+  cleaned = readable_output("first\r\n\r\n\r\n\r\nsecond   \r\n\r\n")
+
+  assert cleaned == "first\n\nsecond"
+
+
+def test_overflow_keeps_the_end_where_the_reason_is():
+  raw = "\n".join(["banner line"] * 400 + ["the actual reason"])
+
+  cleaned = readable_output(raw, limit=200)
+
+  assert cleaned.startswith("…\n")
+  assert cleaned.endswith("the actual reason")
+  assert len(cleaned) <= 210
+
+
+def test_stray_control_bytes_are_removed_but_text_is_kept():
+  cleaned = readable_output("before\x00\x07after\ttabbed")
+
+  assert cleaned == "beforeafter\ttabbed"
+
+
+def test_local_gate_rejection_names_the_check_and_hides_the_transcript():
+  error = push_rejected(REAL_PRE_PUSH_REJECTION)
+
+  assert isinstance(error, ContributionSubmitError)
+  assert error.message == (
+    "This did not pass the checks Möbius runs before publishing "
+    "(frontend-unit). Nothing was published — fix it locally, then send again."
+  )
+  assert "\x1b" not in error.message
+  assert "npm run" not in error.message
+  # The evidence is still reachable, just not the headline.
+  assert "781 source-reading cases exceeds 780" in error.detail
+
+
+def test_every_failing_check_the_gate_named_reaches_the_owner():
+  error = push_rejected(
+    "[pre-push] frontend-unit FAILED:\n"
+    "    boom\n"
+    "[pre-push] backend pytest FAILED:\n"
+    "    boom\n"
+    "[pre-push] push blocked. Fix the above.\n"
+    "[pre-push] verdict=blocked cause=checks checks=frontend-unit,backend-pytest\n"
+  )
+
+  assert "(frontend-unit, backend-pytest)" in error.message
+
+
+def test_privacy_rejection_gets_its_own_sentence():
+  error = push_rejected(
+    "[pre-push] private workspace path staged: .claude/settings.json\n"
+    "[pre-push] push blocked by the privacy gate. Do not use --no-verify.\n"
+    "[pre-push] verdict=blocked cause=privacy checks=\n"
+  )
+
+  assert "privacy gate" in error.message
+  assert "Nothing was published." in error.message
+
+
+def test_an_unrecognized_refusal_is_attributed_to_github_not_to_us():
+  error = push_rejected(
+    "remote: Permission to mobius-os/mobius.git denied.\n"
+    "fatal: unable to access 'https://github.com/...': 403\n"
+  )
+
+  assert error.message == (
+    "GitHub would not accept this branch, so nothing was published."
+  )
+  assert "403" in error.detail
+
+
+def test_gate_output_without_a_verdict_is_not_claimed_as_a_local_failure():
+  # An older installed hook, or a push refused before the gate ran, has no
+  # verdict line. Reporting it as a local check failure would send the owner
+  # looking for a test to fix that never ran.
+  error = push_rejected("[pre-push] some older wording\nerror: failed to push\n")
+
+  assert error.message == (
+    "GitHub would not accept this branch, so nothing was published."
+  )
+
+
+def test_the_record_patch_survives_classification():
+  error = push_rejected("boom", record_patch={"head_repository": "owner/fork"})
+
+  assert error.record_patch == {"head_repository": "owner/fork"}
+
+
+def test_the_gate_and_this_parser_agree_on_the_verdict_line():
+  """The one place the hook and this module have to stay in step.
+
+  Everything else the gate prints is prose for a human and may be reworded
+  freely. If someone changes the verdict line's shape in the hook without
+  changing the pattern here, classification silently degrades to the generic
+  remote-refusal message — so assert the two really do match, rather than
+  testing this parser against a hand-copied fixture that can drift.
+  """
+  hook = (Path(__file__).resolve().parents[2] / "scripts/githooks/pre-push").read_text()
+
+  emitted = re.search(
+    r"printf '(\[pre-push\] verdict=blocked cause=%s checks=%s)\\n'", hook,
+  )
+  assert emitted, "the pre-push gate no longer prints the verdict line this parses"
+
+  template = emitted.group(1)
+  privacy = template % ("privacy", "")
+  checks = template % ("checks", "frontend-unit,backend-pytest")
+
+  assert "privacy gate" in push_rejected(privacy).message
+  assert "(frontend-unit, backend-pytest)" in push_rejected(checks).message
+
+
+def test_every_named_check_in_the_gate_is_shell_safe_and_readable():
+  """Check names travel through a shell variable into an owner-facing sentence."""
+  hook = (Path(__file__).resolve().parents[2] / "scripts/githooks/pre-push").read_text()
+
+  names = re.findall(r"^\s*fail_check ([\w-]+)$", hook, re.MULTILINE)
+
+  assert len(names) >= 5, f"expected the gate's named checks, found {names}"
+  for name in names:
+    assert re.fullmatch(r"[a-z0-9-]+", name), f"{name!r} is not a safe check name"

--- a/backend/tests/test_github_routes.py
+++ b/backend/tests/test_github_routes.py
@@ -5108,3 +5108,150 @@ def test_send_refuses_branch_with_existing_pr_before_any_push(
   # of any kind and no PR creation.
   assert not any("push" in call for call in git_calls)
   assert not any(call[:2] == ("pr", "create") for call in gh_calls)
+
+
+def _conflicting_upstream_commit(repo, content):
+  """Commit a rival change to main, and return its sha.
+
+  The review branch already edited this file, so a different edit to the same
+  line is a genuine merge conflict rather than a simulated one.
+  """
+  subprocess.run(["git", "checkout", "main"], cwd=repo, check=True,
+                 capture_output=True)
+  (repo / "index.jsx").write_text(content)
+  subprocess.run(["git", "add", "index.jsx"], cwd=repo, check=True)
+  subprocess.run(["git", "commit", "-m", "upstream moved"], cwd=repo,
+                 check=True, capture_output=True)
+  sha = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo,
+                                text=True).strip()
+  subprocess.run(["git", "checkout", "fix/demo-review"], cwd=repo, check=True,
+                 capture_output=True)
+  return sha
+
+
+def _record_upstream(app_id, record_id, sha):
+  path = (
+    Path(get_settings().data_dir) / "apps" / str(app_id)
+    / "contributions" / f"{record_id}.json"
+  )
+  stored = json.loads(path.read_text())
+  stored["last_submit_upstream_sha"] = sha
+  path.write_text(json.dumps(stored))
+
+
+def test_review_status_reports_a_branch_that_no_longer_merges(
+  client, owner_token,
+):
+  """The one verdict local freshness checks cannot reach.
+
+  A conflict is a fact about upstream, so every check about the staged
+  checkout still passes and the review would otherwise read "ready".
+  """
+  _write_token(login="octocat", user_id=42)
+  app_id, app_token = _app_token(client, owner_token, github_access=True)
+  repo, _record, _diff = _prepared_real_review(app_id, "conflicted")
+  headers = {"Authorization": f"Bearer {app_token}"}
+
+  assert client.get(
+    f"/api/github/contributions/{app_id}/review-status", headers=headers,
+  ).json()["records"][0]["state"] == "ready"
+
+  _record_upstream(
+    app_id, "conflicted", _conflicting_upstream_commit(repo, "export default 9\n"),
+  )
+
+  blocked = client.get(
+    f"/api/github/contributions/{app_id}/review-status", headers=headers,
+  )
+  assert blocked.status_code == 200, blocked.text
+  assert blocked.json()["needs_refresh"] == 1
+  verdict = blocked.json()["records"][0]
+  assert verdict["code"] == "upstream_conflict"
+  assert verdict["message"] == (
+    github_routes._REVIEW_STATUS_MESSAGES["upstream_conflict"]
+  )
+
+
+def test_refreshing_the_branch_clears_the_conflict_with_nothing_to_reset(
+  client, owner_token,
+):
+  """The property a stored verdict could not have.
+
+  Nothing records that this review was conflicted, so nothing has to remember
+  to clear it: merging upstream in is enough, and the next read is honest.
+  """
+  _write_token(login="octocat", user_id=42)
+  app_id, app_token = _app_token(client, owner_token, github_access=True)
+  repo, _record, _diff = _prepared_real_review(app_id, "healing")
+  headers = {"Authorization": f"Bearer {app_token}"}
+  upstream = _conflicting_upstream_commit(repo, "export default 9\n")
+  _record_upstream(app_id, "healing", upstream)
+
+  assert client.get(
+    f"/api/github/contributions/{app_id}/review-status", headers=headers,
+  ).json()["records"][0]["code"] == "upstream_conflict"
+
+  # Resolve it exactly as a refresh would, then re-stage the reviewed source.
+  subprocess.run(["git", "merge", upstream, "-m", "merge upstream"], cwd=repo,
+                 check=False, capture_output=True)
+  (repo / "index.jsx").write_text("export default 2\n")
+  subprocess.run(["git", "add", "index.jsx"], cwd=repo, check=True)
+  subprocess.run([
+    "git", "commit", "--no-edit", "-m", "refreshed", "-m",
+    "Co-authored-by: Möbius Agent <mobius-agent@users.noreply.github.com>",
+  ], cwd=repo, check=False, capture_output=True)
+  head = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo,
+                                 text=True).strip()
+  path = (
+    Path(get_settings().data_dir) / "apps" / str(app_id)
+    / "contributions" / "healing.json"
+  )
+  stored = json.loads(path.read_text())
+  base = stored["plan"]["base_sha"]
+  diff_text = subprocess.check_output([
+    "git", "-c", "core.quotePath=false", "diff", "--no-ext-diff", "--no-color",
+    "--binary", "--full-index", "--src-prefix=a/", "--dst-prefix=b/",
+    f"{base}..{head}",
+  ], cwd=repo, text=True)
+  stored["plan"]["head_sha"] = head
+  stored["plan"]["diff_sha256"] = hashlib.sha256(diff_text.encode()).hexdigest()
+  _write_contribution(app_id, "healing", stored, diff_text)
+
+  healed = client.get(
+    f"/api/github/contributions/{app_id}/review-status", headers=headers,
+  )
+  assert healed.json()["records"][0]["state"] == "ready", healed.text
+
+
+def test_a_review_that_never_reached_upstream_is_not_inspected_for_conflicts(
+  client, owner_token,
+):
+  """No recorded upstream means nothing local to compare against."""
+  _write_token(login="octocat", user_id=42)
+  app_id, app_token = _app_token(client, owner_token, github_access=True)
+  _prepared_real_review(app_id, "never-sent")
+
+  response = client.get(
+    f"/api/github/contributions/{app_id}/review-status",
+    headers={"Authorization": f"Bearer {app_token}"},
+  )
+  assert response.json()["records"][0]["state"] == "ready"
+
+
+def test_a_dirty_checkout_is_named_before_an_upstream_conflict(
+  client, owner_token,
+):
+  """Two things wrong at once: say the one the owner can act on locally."""
+  _write_token(login="octocat", user_id=42)
+  app_id, app_token = _app_token(client, owner_token, github_access=True)
+  repo, _record, _diff = _prepared_real_review(app_id, "both-wrong")
+  _record_upstream(
+    app_id, "both-wrong", _conflicting_upstream_commit(repo, "export default 9\n"),
+  )
+  (repo / "index.jsx").write_text("export default 77\n")
+
+  response = client.get(
+    f"/api/github/contributions/{app_id}/review-status",
+    headers={"Authorization": f"Bearer {app_token}"},
+  )
+  assert response.json()["records"][0]["code"] == "working_changes"

--- a/frontend/src/components/ChatView/ContributionReviewCard.css
+++ b/frontend/src/components/ChatView/ContributionReviewCard.css
@@ -193,6 +193,38 @@
   color: var(--danger);
 }
 
+/* A failure states itself in one line. The transcript that proves it is
+   available but never the first thing read, and it is capped so a long build
+   log cannot push the card's own actions off the screen. */
+.contrib-card__failure-detail > summary {
+  cursor: pointer;
+  font-size: 0.75rem;
+  line-height: 1.35;
+  color: var(--muted);
+  list-style: none;
+}
+
+.contrib-card__failure-detail > summary::-webkit-details-marker {
+  display: none;
+}
+
+.contrib-card__failure-detail > summary::before {
+  content: '▸ ';
+  color: var(--muted);
+}
+
+.contrib-card__failure-detail[open] > summary::before {
+  content: '▾ ';
+}
+
+/* Shares .contrib-card__body's monospace block styling; only the offset from
+   the summary and the scroll cap differ. */
+.contrib-card__failure-detail > pre {
+  margin-top: 6px;
+  max-height: 210px;
+  overflow: auto;
+}
+
 /* The motivation the button cannot carry on its own: who actually benefits.
    Accent-tinted so it reads as encouragement rather than another metadata line,
    and hidden whenever the card is showing a problem instead. */

--- a/frontend/src/components/ChatView/ContributionReviewCard.jsx
+++ b/frontend/src/components/ChatView/ContributionReviewCard.jsx
@@ -15,6 +15,7 @@ import {
   rememberReviewItemDismissed,
   reviewPanelSummary,
   statusLabel,
+  submitFailure,
   visibleReviewItems,
 } from './contributionReviewModel.js'
 import './ContributionReviewCard.css'
@@ -77,16 +78,25 @@ export default function ContributionReviewCard({ chatId, turnActive, onOpenApp }
       })
       const body = await res.json().catch(() => null)
       if (!res.ok) {
-        const detail = body?.detail?.message || body?.detail
+        const detail = body?.detail
+        const message = typeof detail === 'string' ? detail : detail?.message
         return {
-          error: typeof detail === 'string'
-            ? detail
-            : 'Could not contribute this. Open Contribute for the details.',
+          failure: {
+            message: typeof message === 'string' && message
+              ? message
+              : 'Could not contribute this. Open Contribute for the details.',
+            detail: typeof detail?.detail === 'string' ? detail.detail : '',
+          },
         }
       }
       return { contributed: true }
     } catch {
-      return { error: 'Could not reach the server. Nothing was contributed.' }
+      return {
+        failure: {
+          message: 'Could not reach the server. Nothing was contributed.',
+          detail: '',
+        },
+      }
     } finally {
       queryClient.invalidateQueries({ queryKey, exact: true })
     }
@@ -314,19 +324,20 @@ function ReviewRow({
 }) {
   const [open, setOpen] = useState(false)
   const [busy, setBusy] = useState(false)
-  const [error, setError] = useState(null)
+  const [attempt, setAttempt] = useState(null)
   // Each row owns its own in-flight guard. That keeps sibling rows independent
   // while closing the same-frame double-click window for this record.
   const activeSendRef = useRef(false)
   const diffStat = diffStatSummary(record.diff_stat)
   const submitting = record.status === 'submitting'
   const cardRef = useSwipeToDismiss(onDismiss)
+  const failure = submitFailure(record, { attempt, sending: busy || submitting })
 
   async function send() {
     if (activeSendRef.current) return
     activeSendRef.current = true
     setBusy(true)
-    setError(null)
+    setAttempt(null)
     let outcome
     try {
       outcome = await onSubmit(record)
@@ -334,8 +345,8 @@ function ReviewRow({
       activeSendRef.current = false
       setBusy(false)
     }
-    if (outcome?.error) {
-      setError(outcome.error)
+    if (outcome?.failure) {
+      setAttempt(outcome.failure)
     } else if (outcome?.contributed) {
       onContributed(record.id)
     }
@@ -366,15 +377,24 @@ function ReviewRow({
         {diffStat ? <span> · {diffStat}</span> : null}
       </p>
 
-      {showPayoff && !error && !submitting && (
+      {showPayoff && !failure && !submitting && (
         <p className="contrib-card__payoff">{payoffLine(record)}</p>
       )}
-      {autopilot && !error && !submitting && (
+      {autopilot && !failure && !submitting && (
         <p className="contrib-card__meta">
           Möbius will also handle review feedback after you contribute.
         </p>
       )}
-      {error && <p className="contrib-card__error">{error}</p>}
+      {/* One sentence says what happened; the transcript that proves it stays
+          collapsed next to it, so the card explains without shouting plumbing
+          at someone who only needs to know nothing was published. */}
+      {failure && <p className="contrib-card__error">{failure.message}</p>}
+      {failure?.detail && (
+        <details className="contrib-card__failure-detail">
+          <summary>What blocked it</summary>
+          <pre className="contrib-card__body">{failure.detail}</pre>
+        </details>
+      )}
 
       <div className="contrib-card__actions">
         <button
@@ -395,7 +415,7 @@ function ReviewRow({
         </button>
         {/* A failed submit may reveal a server-side change after this ready
             card loaded. Contribute owns that repair path. */}
-        {error && onOpenContribute && (
+        {failure && onOpenContribute && (
           <button
             type="button"
             className="contrib-card__toggle"

--- a/frontend/src/components/ChatView/__tests__/contributionFailure.test.js
+++ b/frontend/src/components/ChatView/__tests__/contributionFailure.test.js
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { submitFailure } from '../contributionReviewModel.js'
+
+const READY = { id: 'r1', status: 'prepared' }
+
+test('a failed send still explains itself after the card is reloaded', () => {
+  const failure = submitFailure({
+    ...READY,
+    last_submit_error: 'This did not pass the checks Möbius runs before publishing.',
+    last_submit_error_detail: '[pre-push] frontend-unit FAILED:',
+  })
+
+  assert.deepEqual(failure, {
+    message: 'This did not pass the checks Möbius runs before publishing.',
+    detail: '[pre-push] frontend-unit FAILED:',
+  })
+})
+
+test('this attempt outranks the failure stored before it', () => {
+  const failure = submitFailure(
+    { ...READY, last_submit_error: 'stale reason', last_submit_error_detail: 'old' },
+    { attempt: { message: 'fresh reason', detail: 'new' } },
+  )
+
+  assert.deepEqual(failure, { message: 'fresh reason', detail: 'new' })
+})
+
+test('a send in flight never shows the previous attempt as its own result', () => {
+  const record = { ...READY, last_submit_error: 'the last attempt failed' }
+
+  assert.equal(submitFailure(record, { sending: true }), null)
+  assert.notEqual(submitFailure(record, { sending: false }), null)
+})
+
+test('a record that never failed shows nothing', () => {
+  assert.equal(submitFailure(READY), null)
+  assert.equal(submitFailure({ ...READY, last_submit_error: '   ' }), null)
+  assert.equal(submitFailure(null), null)
+})
+
+test('a message without a transcript is still a complete failure', () => {
+  const failure = submitFailure({
+    ...READY,
+    last_submit_error: 'Could not reach the server. Nothing was contributed.',
+  })
+
+  assert.deepEqual(failure, {
+    message: 'Could not reach the server. Nothing was contributed.',
+    detail: '',
+  })
+})
+
+test('a detail with no message is not a failure the card can explain', () => {
+  assert.equal(
+    submitFailure({ ...READY, last_submit_error_detail: 'orphaned transcript' }),
+    null,
+  )
+})

--- a/frontend/src/components/ChatView/__tests__/contributionReviewModel.test.js
+++ b/frontend/src/components/ChatView/__tests__/contributionReviewModel.test.js
@@ -261,7 +261,7 @@ test('independent cards can submit in parallel without duplicating one record', 
 
 test('a grouped panel does not repeat the same audience payoff on every card', () => {
   assert.match(cardSrc, /showPayoff=\{!grouped\}/)
-  assert.match(cardSrc, /showPayoff && !error && !submitting/)
+  assert.match(cardSrc, /showPayoff && !failure && !submitting/)
 })
 
 // The action names the value of contributing, not the mechanism of sending, and
@@ -454,7 +454,7 @@ test('every card shape shares one swipe implementation', () => {
   assert.equal((cardSrc.match(/addEventListener\('touchmove'/g) || []).length, 1)
 })
 
-test('a failed send is shown only on the record that failed', () => {
-  assert.match(cardSrc, /const \[error, setError\] = useState\(null\)/)
-  assert.match(cardSrc, /setError\(outcome\.error\)/)
-})
+// "A failure is shown only on the record that failed" used to be asserted by
+// grepping this component for a useState identifier. It is now a property of
+// submitFailure(), which resolves a failure purely from one record plus that
+// row's own attempt — see contributionFailure.test.js.

--- a/frontend/src/components/ChatView/contributionReviewModel.js
+++ b/frontend/src/components/ChatView/contributionReviewModel.js
@@ -117,6 +117,26 @@ export function diffStatSummary(value) {
   return lines.at(-1) || ''
 }
 
+/**
+ * The failure this card should currently explain, or null when there is none.
+ *
+ * A send that failed is a fact about the record, not about this render: the
+ * card must still explain it after a reload, and must never keep showing the
+ * previous attempt's reason while a new one is in flight. `attempt` is this
+ * card's own latest outcome and always wins; otherwise the stored one speaks.
+ */
+export function submitFailure(record, { attempt = null, sending = false } = {}) {
+  if (sending) return null
+  const source = attempt || {
+    message: record?.last_submit_error,
+    detail: record?.last_submit_error_detail,
+  }
+  const message = typeof source.message === 'string' ? source.message.trim() : ''
+  if (!message) return null
+  const detail = typeof source.detail === 'string' ? source.detail.trim() : ''
+  return { message, detail }
+}
+
 /** Copy for the grouped panel while it still has pending work. */
 export function reviewPanelSummary(pendingCount) {
   const count = Math.max(0, Number(pendingCount) || 0)

--- a/frontend/structural-test-budget.json
+++ b/frontend/structural-test-budget.json
@@ -1,5 +1,5 @@
 {
   "maximum_files": 88,
-  "maximum_cases": 780,
+  "maximum_cases": 779,
   "policy": "This is a ceiling, not a target. New tests exercise exported behavior; each related refactor lowers this baseline."
 }

--- a/scripts/githooks/pre-push
+++ b/scripts/githooks/pre-push
@@ -49,10 +49,25 @@ trap 'rm -rf "$PP_TMP"' EXIT
 
 FAIL=0
 PRIVACY_FAIL=0
-c_ok=$'\033[1;32m'; c_warn=$'\033[1;33m'; c_err=$'\033[1;31m'; c_off=$'\033[0m'
+# Names of the checks that actually failed, for the machine-readable verdict
+# emitted at the end. Kept separate from the prose above it so a reader and a
+# program never have to agree on how a sentence is worded.
+FAILED_CHECKS=""
+# Colour is for a human watching a terminal. When git runs this hook inside
+# another program — Contribute's Send, CI, a log collector — the escape codes
+# survive into whatever stores the output and disfigure the diagnostic they
+# were meant to highlight. Emit none unless both streams are a terminal.
+if [ -t 1 ] && [ -t 2 ]; then
+  c_ok=$'\033[1;32m'; c_warn=$'\033[1;33m'; c_err=$'\033[1;31m'; c_off=$'\033[0m'
+else
+  c_ok=''; c_warn=''; c_err=''; c_off=''
+fi
 ok()   { printf '%s[pre-push]%s %s\n' "$c_ok"  "$c_off" "$*"; }
 warn() { printf '%s[pre-push]%s %s\n' "$c_warn" "$c_off" "$*"; }
 err()  { printf '%s[pre-push]%s %s\n' "$c_err" "$c_off" "$*" >&2; }
+# Record a failing check by name. Every caller that has a name uses this so the
+# final verdict line can list them without anything parsing the prose.
+fail_check() { FAILED_CHECKS="${FAILED_CHECKS:+$FAILED_CHECKS,}$1"; FAIL=1; }
 
 # Direct main updates bypass the PR's synthetic merge test and are prohibited.
 # Branch protection is the remote guarantee; this local rejection gives a fast,
@@ -72,7 +87,7 @@ while read -r _local_ref local_sha remote_ref remote_sha; do
     refs/heads/main)
       err "direct updates to main are prohibited; publish a topic branch"
       err "and run scripts/submit-pr.sh"
-      FAIL=1
+      fail_check main-branch-push
       ;;
   esac
 done <"$PUSH_REFS"
@@ -133,7 +148,7 @@ if git grep -nIE '^(<<<<<<<|>>>>>>>) ' HEAD -- \
      'backend' 'frontend/src' 'skill' 'scripts' >"$PP_TMP/confl" 2>/dev/null; then
   err "merge-conflict markers in the tree you're pushing:"
   sed 's/^/    /' "$PP_TMP/confl" >&2
-  FAIL=1
+  fail_check merge-conflict-markers
 else
   ok "no conflict markers"
 fi
@@ -150,7 +165,7 @@ if [ "${POLLUTION:-0}" -gt 0 ]; then
   err "detected $POLLUTION Mobius-authored commit(s) on this branch — likely app-git test pollution:"
   git log --format='%h %an %s' "$BASE"..HEAD | grep 'Mobius' | sed 's/^/    /' >&2
   err "recover: git reset --hard origin/main  (drops the pollution); see scripts/git-doctor.sh"
-  FAIL=1
+  fail_check polluted-history
 fi
 
 # 1c. Private workspace paths must never reach the PUBLIC repo. Gitignore only
@@ -197,7 +212,7 @@ if [ -n "$PY" ]; then
        python3 -m py_compile "${_py[@]}" 2>"$PP_TMP/py"; then
     ok "python syntax ok (${#_py[@]} file(s))"
   else
-    err "python syntax errors:"; sed 's/^/    /' "$PP_TMP/py" >&2; FAIL=1
+    err "python syntax errors:"; sed 's/^/    /' "$PP_TMP/py" >&2; fail_check python-syntax
   fi
 fi
 
@@ -216,7 +231,7 @@ if [ -n "$JSX" ] && [ -x "$ESB" ]; then
     "$ESB" "$f" --loader:.js=jsx --outfile=/dev/null >"$PP_TMP/esb" 2>&1 || {
       err "jsx parse error in $f:"; sed 's/^/    /' "$PP_TMP/esb" >&2; jsx_fail=1; }
   done <<< "$JSX"
-  [ "$jsx_fail" -eq 0 ] && ok "jsx parse ok" || FAIL=1
+  [ "$jsx_fail" -eq 0 ] && ok "jsx parse ok" || fail_check jsx-parse
 fi
 
 # 4. Frontend-unit — only when frontend changed (~6s). Mirrors the CI
@@ -228,7 +243,7 @@ if changed_match '^frontend/'; then
     if (cd frontend && npm test >"$PP_TMP/fe" 2>&1); then
       ok "frontend-unit passed"
     else
-      err "frontend-unit FAILED:"; tail -n 30 "$PP_TMP/fe" | sed 's/^/    /' >&2; FAIL=1
+      err "frontend-unit FAILED:"; tail -n 30 "$PP_TMP/fe" | sed 's/^/    /' >&2; fail_check frontend-unit
     fi
   elif ! command -v npm >/dev/null 2>&1; then
     warn "frontend changed, npm not found — skipping frontend-unit (CI runs it)."
@@ -250,7 +265,7 @@ if changed_match '^(backend/scripts/package-static-app\.mjs|scripts/package-stat
     else
       err "static-app packager unit FAILED:"
       tail -n 30 "$PP_TMP/packager" | sed 's/^/    /' >&2
-      FAIL=1
+      fail_check static-app-packager
     fi
   else
     warn "node not found — skipping static-app packager unit (CI runs it)."
@@ -270,7 +285,7 @@ elif backend_needs_pytest; then
     if [ -z "$NODE_MODULES" ]; then
       err "backend tests need frontend dependencies matching this worktree's lockfile"
       err "  enable: (cd frontend && npm ci)"
-      FAIL=1
+      fail_check backend-deps
     else
       warn "running backend pytest (full suite currently ~10m)…"
       # Sibling sessions all share this ONE venv (+ its SQLite fixtures + esbuild),
@@ -303,7 +318,7 @@ elif backend_needs_pytest; then
              "$VENV" -m pytest -q -p no:cacheprovider >"$PP_TMP/be" 2>&1); then
         ok "backend pytest passed"
       else
-        err "backend pytest FAILED:"; tail -n 30 "$PP_TMP/be" | sed 's/^/    /' >&2; FAIL=1
+        err "backend pytest FAILED:"; tail -n 30 "$PP_TMP/be" | sed 's/^/    /' >&2; fail_check backend-pytest
       fi
       # Release the shared-venv lock (fd 9 also closes on hook exit; explicit is tidier).
       exec 9>&- || true
@@ -323,6 +338,13 @@ if [ "$FAIL" -ne 0 ]; then
   else
     err "push blocked. Fix the above, or bypass only if the non-privacy failure is understood."
   fi
+  # The verdict, for programs. Everything above this line is written for a
+  # person and may be reworded freely; THIS line is a contract. Möbius's
+  # Contribute reads it to tell an owner why a Send was refused, so keep the
+  # `key=value` shape and the check names stable, and change it deliberately.
+  printf '[pre-push] verdict=blocked cause=%s checks=%s\n' \
+    "$([ "$PRIVACY_FAIL" -ne 0 ] && echo privacy || echo checks)" \
+    "$FAILED_CHECKS" >&2
   exit 1
 fi
 ok "all gate checks passed — pushing"


### PR DESCRIPTION
## Summary
- report a refused Send as one owner-facing sentence instead of git's raw stderr
- keep the sanitized transcript beside it, behind a collapsed disclosure
- stop the pre-push gate emitting colour when its streams are not a terminal
- resolve a card's failure purely from its own record, so it survives a reload

## Why
A Send rejected by the local pre-push gate showed the owner git's raw stderr:
ANSI colour codes rendered as literal `[1;31m`, npm's lifecycle banner, and the
one line that actually explained the refusal truncated mid-word at 600
characters. Those exact bytes were persisted on the ledger record, so the noise
outlived the attempt it described.

`ContributionSubmitError` already promised a failure "without exposing unsafe
raw state"; a terminal transcript is exactly that. It now carries an
owner-facing `message` and a separate sanitized `detail`. `push_rejected()`
classifies the refusal from the gate's own stable markers — its line prefix and
`<check> FAILED` — and attributes anything unrecognized to GitHub rather than to
us, so an unfamiliar transport error is never mislabelled as a local failure.

Colour suppression lives in the gate rather than in each reader: it is correct
for a human at a prompt and wrong for every other consumer, so logs, CI and
Contribute all receive clean text without each stripping it themselves.

Resolving the card's failure through a pure `submitFailure()` over one record
plus that row's own attempt also fixes a quieter bug — a failure previously
vanished with component state on reload, leaving a record that silently refused
to send. It retires a structural test asserting a `useState` identifier, so the
test ratchet drops to 779.

## Testing
- `scripts/wt-pytest.sh backend/tests/test_contribution_errors.py backend/tests/test_github_routes.py backend/tests/test_contribution_autopilot.py -q` (170 passed)
- `npm test` (2,336 passed)
- `npm run lint` (0 errors)
- `scripts/check-private-paths.sh HEAD` (OK)