### PR TITLE
Simplify the recovery state model

### DIFF
--- a/frontend/src/components/ErrorBoundary/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary/ErrorBoundary.jsx
@@ -1,12 +1,11 @@
 import { Component } from 'react'
 import { api, BASE } from '../../api/client.js'
+import { redactDiagnosticText } from '../../lib/diagnosticRedaction.js'
 import { recordClientError } from '../../lib/errorLog.js'
 import {
   buildAgentRepairPrompt,
   errorRecoveryFingerprint,
   readErrorRecoveryAttempt,
-  redactDiagnosticText,
-  recoveryViewForAttempt,
   runAgentRepair,
   writeRefreshedRecoveryAttempt,
 } from '../../lib/errorRecovery.js'
@@ -37,9 +36,8 @@ import './ErrorBoundary.css'
 export default class ErrorBoundary extends Component {
   state = {
     error: null,
-    phase: 'resolving',
-    repairChatId: null,
-    attemptPhase: null,
+    attempt: null,
+    repairActive: false,
   }
 
   crashContext = null
@@ -73,19 +71,13 @@ export default class ErrorBoundary extends Component {
       attempt,
     }
     this.listenForPageShow()
-    this.setState(recoveryViewForAttempt(attempt, {
-      canAskAgent: this.props.canAskAgent !== false,
-    }))
-  }
-
-  componentDidUpdate(_prevProps, prevState) {
-    if (prevState.phase === 'resolving' && this.state.phase !== 'resolving') {
-      this.headingRef?.focus()
-    }
+    this.setState({ attempt, repairActive: false }, () => this.headingRef?.focus())
   }
 
   componentWillUnmount() {
-    this.repairController?.abort()
+    const controller = this.repairController
+    this.repairController = null
+    controller?.abort()
     if (this.pageShowListening) window.removeEventListener('pageshow', this.handlePageShow)
   }
 
@@ -100,15 +92,15 @@ export default class ErrorBoundary extends Component {
   handlePageShow = (event) => {
     const context = this.crashContext
     if (!event.persisted || !context) return
+    const controller = this.repairController
     this.repairController = null
+    controller?.abort()
     const attempt = readErrorRecoveryAttempt({
       surfaceKey: context.surfaceKey,
       fingerprint: context.fingerprint,
     })
     context.attempt = attempt
-    this.setState(recoveryViewForAttempt(attempt, {
-      canAskAgent: this.props.canAskAgent !== false,
-    }))
+    this.setState({ attempt, repairActive: false })
   }
 
   handleRefresh = () => {
@@ -135,6 +127,7 @@ export default class ErrorBoundary extends Component {
     if (!context || this.repairController || this.props.canAskAgent === false) return
     const controller = new AbortController()
     this.repairController = controller
+    this.setState({ repairActive: true })
     try {
       const result = await runAgentRepair({
         client: api,
@@ -143,12 +136,9 @@ export default class ErrorBoundary extends Component {
         fingerprint: context.fingerprint,
         previousAttempt: context.attempt,
         signal: controller.signal,
-        onAttempt: (attempt, { active }) => {
+        onAttempt: (attempt) => {
           context.attempt = attempt
-          this.setState(recoveryViewForAttempt(attempt, {
-            active,
-            canAskAgent: this.props.canAskAgent !== false,
-          }))
+          this.setState({ attempt })
         },
         prompt: buildAgentRepairPrompt({
           surface: context.surfaceKey,
@@ -161,7 +151,10 @@ export default class ErrorBoundary extends Component {
     } catch (error) {
       if (error?.name === 'AbortError') return
     } finally {
-      if (this.repairController === controller) this.repairController = null
+      if (this.repairController === controller) {
+        this.repairController = null
+        this.setState({ repairActive: false })
+      }
     }
   }
 
@@ -169,8 +162,6 @@ export default class ErrorBoundary extends Component {
     if (!this.state.error) return this.props.children
     const message = redactDiagnosticText(this.state.error?.message || this.state.error)
     const cls = this.props.variant === 'inline' ? 'errbound errbound--inline' : 'errbound'
-    const { phase, attemptPhase, repairChatId } = this.state
-    const canAskAgent = this.props.canAskAgent !== false
     return (
       <div className={cls}>
         <RecoveryPanel
@@ -180,10 +171,9 @@ export default class ErrorBoundary extends Component {
           title="Something broke"
           subject="screen"
           diagnostic={message}
-          phase={phase}
-          attemptPhase={attemptPhase}
-          repairChatId={repairChatId}
-          canAskAgent={canAskAgent}
+          attempt={this.state.attempt}
+          repairActive={this.state.repairActive}
+          canAskAgent={this.props.canAskAgent !== false}
           refreshLabel="Refresh screen"
           onRefresh={this.handleRefresh}
           onAgentRepair={this.handleAgentRepair}

--- a/frontend/src/components/ErrorBoundary/RecoveryPanel.jsx
+++ b/frontend/src/components/ErrorBoundary/RecoveryPanel.jsx
@@ -1,7 +1,7 @@
 import { useId } from 'react'
 import { BASE } from '../../api/client.js'
 import {
-  recoveryActionPolicy,
+  recoveryPhaseForAttempt,
   repairChatPath,
 } from '../../lib/errorRecovery.js'
 import RecoveryLink from './RecoveryLink.jsx'
@@ -12,7 +12,7 @@ function recoveryMessage({ phase, attemptPhase, canAskAgent, subject }) {
   if (phase === 'refresh') {
     return `This ${subject} hit an unexpected error. Refreshing won’t delete your chats.`
   }
-  if (phase === 'agent' || phase === 'agent-starting') {
+  if (phase === 'agent') {
     return `Refreshing didn’t fix ${currentSubject}. Möbius can start a new repair chat and share these technical details with your agent to investigate and fix it.`
   }
   if (!canAskAgent) {
@@ -25,54 +25,48 @@ function recoveryMessage({ phase, attemptPhase, canAskAgent, subject }) {
 }
 
 export default function RecoveryPanel({
+  attempt = null,
   canAskAgent = true,
   className = '',
   diagnostic,
-  headingId,
   headingRef,
   onAgentRepair,
   onRefresh,
-  phase,
+  repairActive = false,
   refreshLabel,
-  repairChatId,
   secondaryAction = null,
   subject,
   title,
-  attemptPhase,
   variant,
 }) {
-  const generatedHeadingId = useId()
-  const resolvedHeadingId = headingId || generatedHeadingId
-  const actions = recoveryActionPolicy({
-    phase,
-    attemptPhase,
-    canAskAgent,
-    repairChatId,
-  })
-  const starting = phase === 'agent-starting'
+  const headingId = useId()
+  const phase = recoveryPhaseForAttempt(attempt, { canAskAgent })
+  const attemptPhase = attempt?.phase || null
+  const repairChatId = attempt?.chatId || null
+  const starting = repairActive && attemptPhase === 'agent-starting'
   const agentFailed = attemptPhase === 'agent-failed'
-  const showPrimary = phase === 'refresh'
-    || actions.showAskAgent
-    || actions.showRetryAgent
-    || starting
-  const primaryLabel = phase === 'refresh'
-    ? refreshLabel
-    : starting
-      ? 'Starting repair chat…'
-      : phase === 'agent' && attemptPhase === 'agent-starting'
-        ? 'Resume repair chat'
-        : actions.showRetryAgent
-          ? 'Retry repair chat'
-          : 'Start repair chat'
+  let primaryAction = null
+  if (phase === 'refresh') {
+    primaryAction = { label: refreshLabel, onClick: onRefresh }
+  } else if (starting) {
+    primaryAction = { label: 'Starting repair chat…', onClick: onAgentRepair, disabled: true }
+  } else if (phase === 'agent') {
+    primaryAction = {
+      label: attemptPhase === 'agent-starting' ? 'Resume repair chat' : 'Start repair chat',
+      onClick: onAgentRepair,
+    }
+  } else if (canAskAgent && agentFailed) {
+    primaryAction = { label: 'Retry repair chat', onClick: onAgentRepair }
+  }
 
   return (
     <section
       className={`recovery-panel recovery-panel--${variant}${className ? ` ${className}` : ''}`}
-      aria-labelledby={resolvedHeadingId}
+      aria-labelledby={headingId}
     >
       <h1
         className="recovery-panel__title"
-        id={resolvedHeadingId}
+        id={headingId}
         ref={headingRef}
         tabIndex={-1}
       >
@@ -105,28 +99,28 @@ export default function RecoveryPanel({
             {secondaryAction.label}
           </a>
         )}
-        {actions.showRefreshAgain && (
+        {phase !== 'refresh' && !starting && (
           <button type="button" className="recovery-panel__button" onClick={onRefresh}>
             Refresh again
           </button>
         )}
-        {actions.showOpenRepairChat && (
+        {phase === 'recovery' && repairChatId && (
           <a className="recovery-panel__button" href={repairChatPath(repairChatId, BASE)}>
             Open repair chat
           </a>
         )}
-        {showPrimary && (
+        {primaryAction && (
           <button
             type="button"
             className="recovery-panel__button recovery-panel__button--primary"
-            onClick={phase === 'refresh' ? onRefresh : onAgentRepair}
-            disabled={starting}
+            onClick={primaryAction.onClick}
+            disabled={primaryAction.disabled}
           >
-            {primaryLabel}
+            {primaryAction.label}
           </button>
         )}
       </div>
-      {actions.showRecovery && (
+      {phase === 'recovery' && (
         <RecoveryLink
           className="recovery-panel__recovery"
           lead="If the repair chat can’t get you back in,"

--- a/frontend/src/components/StandaloneApp/StandaloneApp.jsx
+++ b/frontend/src/components/StandaloneApp/StandaloneApp.jsx
@@ -10,7 +10,6 @@ import {
   buildAgentRepairPrompt,
   errorRecoveryFingerprint,
   readErrorRecoveryAttempt,
-  recoveryViewForAttempt,
   runAgentRepair,
   writeRefreshedRecoveryAttempt,
 } from '../../lib/errorRecovery.js'
@@ -88,11 +87,15 @@ export default function StandaloneApp({ initialApp }) {
       error,
       fingerprint,
       attempt,
-      ...recoveryViewForAttempt(attempt),
+      repairActive: false,
     })
   }, [recoverySurfaceKey])
 
-  useEffect(() => () => repairControllerRef.current?.abort(), [])
+  useEffect(() => () => {
+    const controller = repairControllerRef.current
+    repairControllerRef.current = null
+    controller?.abort()
+  }, [])
 
   useEffect(() => {
     if (crashFingerprint) crashHeadingRef.current?.focus()
@@ -102,7 +105,9 @@ export default function StandaloneApp({ initialApp }) {
     if (!crashFingerprint) return undefined
     function onPageShow(event) {
       if (!event.persisted) return
+      const controller = repairControllerRef.current
       repairControllerRef.current = null
+      controller?.abort()
       const attempt = readErrorRecoveryAttempt({
         surfaceKey: recoverySurfaceKey,
         fingerprint: crashFingerprint,
@@ -110,7 +115,7 @@ export default function StandaloneApp({ initialApp }) {
       setCrash(current => current ? {
         ...current,
         attempt,
-        ...recoveryViewForAttempt(attempt),
+        repairActive: false,
       } : current)
     }
     window.addEventListener('pageshow', onPageShow)
@@ -229,6 +234,7 @@ export default function StandaloneApp({ initialApp }) {
     if (!crash || repairControllerRef.current) return
     const controller = new AbortController()
     repairControllerRef.current = controller
+    setCrash(current => current ? { ...current, repairActive: true } : current)
     void runAgentRepair({
       client: api,
       base: BASE,
@@ -236,11 +242,10 @@ export default function StandaloneApp({ initialApp }) {
       fingerprint: crash.fingerprint,
       previousAttempt: crash.attempt,
       signal: controller.signal,
-      onAttempt: (attempt, { active }) => {
+      onAttempt: (attempt) => {
         setCrash(current => current ? {
           ...current,
           attempt,
-          ...recoveryViewForAttempt(attempt, { active }),
         } : current)
       },
       prompt: buildAgentRepairPrompt({
@@ -254,7 +259,10 @@ export default function StandaloneApp({ initialApp }) {
     }).catch(error => {
       if (error?.name === 'AbortError') return
     }).finally(() => {
-      if (repairControllerRef.current === controller) repairControllerRef.current = null
+      if (repairControllerRef.current === controller) {
+        repairControllerRef.current = null
+        setCrash(current => current ? { ...current, repairActive: false } : current)
+      }
     })
   }, [app.id, app.name, crash, recoverySurfaceKey])
 
@@ -318,14 +326,12 @@ export default function StandaloneApp({ initialApp }) {
           <RecoveryPanel
             variant="standalone"
             className="standalone-app__crash"
-            headingId="standalone-crash-title"
             headingRef={crashHeadingRef}
             title={`${app.name} stopped unexpectedly`}
             subject="app"
             diagnostic={readableAppDiagnostic(crash.error)}
-            phase={crash.phase}
-            attemptPhase={crash.attemptPhase}
-            repairChatId={crash.repairChatId}
+            attempt={crash.attempt}
+            repairActive={crash.repairActive}
             refreshLabel="Refresh app"
             onRefresh={refreshCrash}
             onAgentRepair={reportCrash}

--- a/frontend/src/lib/__tests__/diagnosticRedaction.test.js
+++ b/frontend/src/lib/__tests__/diagnosticRedaction.test.js
@@ -1,0 +1,52 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { redactDiagnosticText } from '../diagnosticRedaction.js'
+
+test('diagnostic redaction removes common credentials', () => {
+  const input = [
+    'https://user:password@example.com/path?token=secret-token&code=secret-code',
+    'postgres://db-user:db-password@database.internal/mobius',
+    'Authorization: Bearer abc.def.ghi',
+    'Cookie: session=secret-cookie',
+    'OPENAI_API_KEY=sk-secret',
+    'AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE',
+    'AWS_SECRET_ACCESS_KEY="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"',
+    '{"AWS_SECRET_ACCESS_KEY":"json/secret+value-that-must-not-pass"}',
+    'NPM_TOKEN=npm_0123456789abcdefghijklmnopqrstuvwxyz',
+    'unlabeled github_pat_0123456789abcdefghijklmnopqrstuvwxyz',
+    'opaque c29tZS12ZXJ5LWxvbmctcHJpdmF0ZS12YWx1ZS0xMjM0NTY3ODkw',
+    'eyJheader.eyJpayload.signature',
+    '-----BEGIN PRIVATE KEY-----\nprivate-key-body\n-----END PRIVATE KEY-----',
+  ].join('\n')
+  const redacted = redactDiagnosticText(input)
+
+  for (const secret of [
+    'password',
+    'db-password',
+    'secret-token',
+    'secret-code',
+    'abc.def.ghi',
+    'secret-cookie',
+    'sk-secret',
+    'AKIAIOSFODNN7EXAMPLE',
+    'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+    'json/secret+value-that-must-not-pass',
+    'npm_0123456789abcdefghijklmnopqrstuvwxyz',
+    'github_pat_0123456789abcdefghijklmnopqrstuvwxyz',
+    'c29tZS12ZXJ5LWxvbmctcHJpdmF0ZS12YWx1ZS0xMjM0NTY3ODkw',
+    'eyJpayload',
+    'private-key-body',
+  ]) assert.equal(redacted.includes(secret), false, `must redact ${secret}`)
+  assert.match(redacted, /\[redacted\]/)
+  assert.match(redacted, /\[redacted-private-key\]/)
+  assert.match(redacted, /\[redacted-provider-token\]/)
+  assert.match(redacted, /\[redacted-high-entropy-value\]/)
+})
+
+test('diagnostic redaction preserves ordinary hashes, prose, and long symbols', () => {
+  const commit = '8fe8a7ae35dce88ee4af7585b9ff0b4c229df257'
+  const symbol = 'VeryLongRecoveryBoundaryComponentIdentifier'
+  const diagnostic = `Build ${commit} failed in ${symbol} while rendering the recovery screen.`
+  assert.equal(redactDiagnosticText(diagnostic), diagnostic)
+})

--- a/frontend/src/lib/__tests__/errorRecovery.test.js
+++ b/frontend/src/lib/__tests__/errorRecovery.test.js
@@ -4,17 +4,12 @@ import assert from 'node:assert/strict'
 import {
   AGENT_REPAIR_REQUEST_TIMEOUT_MS,
   buildAgentRepairPrompt,
-  createRepairIdentity,
   ERROR_RECOVERY_MAX_AGE_MS,
   errorRecoveryFingerprint,
   readErrorRecoveryAttempt,
-  recoveryActionPolicy,
   recoveryPhaseForAttempt,
-  recoveryViewForAttempt,
-  redactDiagnosticText,
   repairChatPath,
   runAgentRepair,
-  startAgentRepair,
   writeErrorRecoveryAttempt,
   writeRefreshedRecoveryAttempt,
 } from '../errorRecovery.js'
@@ -107,71 +102,29 @@ test('refresh attempts never downgrade an agent repair or discard its identity',
   })
 })
 
-test('restricted recovery policy never exposes owner-agent actions', () => {
-  assert.deepEqual(recoveryActionPolicy({
-    phase: 'recovery',
-    attemptPhase: 'agent-failed',
-    canAskAgent: false,
-  }), {
-    showRefreshAgain: true,
-    showAskAgent: false,
-    showRetryAgent: false,
-    showOpenRepairChat: false,
-    showRecovery: true,
-  })
-})
-
-test('an interrupted repair resumes with the same request and message identities', () => {
-  let index = 0
-  const createId = () => ['request-id', 'message-cid'][index++]
-  const first = createRepairIdentity(null, createId)
-  const resumed = createRepairIdentity(first, () => 'must-not-be-used')
-
-  assert.deepEqual(first, {
-    repairRequestId: 'request-id',
-    messageCid: 'message-cid',
-  })
-  assert.deepEqual(resumed, first)
-  assert.equal(recoveryPhaseForAttempt({ phase: 'agent-starting' }), 'agent')
-})
-
-test('recovery view state derives persisted identity and active progress', () => {
-  assert.deepEqual(recoveryViewForAttempt(null), {
-    phase: 'refresh',
-    attemptPhase: null,
-    repairChatId: null,
-  })
-
-  const attempt = {
-    phase: 'agent-starting',
-    chatId: 'repair-chat',
-    repairRequestId: 'repair-request',
-    messageCid: 'repair-message',
-  }
-  assert.deepEqual(recoveryViewForAttempt(attempt), {
-    phase: 'agent',
-    attemptPhase: 'agent-starting',
-    repairChatId: 'repair-chat',
-  })
-  assert.equal(recoveryViewForAttempt(attempt, { active: true }).phase, 'agent-starting')
-  assert.equal(recoveryViewForAttempt(attempt, { canAskAgent: false }).phase, 'recovery')
-})
-
-test('repair flow owns persisted transitions and reports active attempts', async () => {
+test('repair flow owns persisted transitions and reuses request identity', async () => {
   const storage = memoryStorage()
   const surfaceKey = 'chat:flow'
   const fingerprint = errorRecoveryFingerprint(surfaceKey, 'render failed')
   const snapshots = []
+  const calls = []
   const client = {
     chats: {
-      create: async () => ({ ok: true, json: async () => ({ id: 'repair-chat' }) }),
-      send: async () => ({ ok: true }),
+      create: async (payload, options) => {
+        calls.push(['create', payload, options])
+        return { ok: true, json: async () => ({ id: 'repair-chat' }) }
+      },
+      send: async (chatId, payload, options) => {
+        calls.push(['send', chatId, payload, options])
+        return { ok: true }
+      },
     },
   }
 
   const result = await runAgentRepair({
     prompt: 'diagnostic prompt',
     client,
+    base: '/mobius',
     surfaceKey,
     fingerprint,
     storage,
@@ -180,14 +133,30 @@ test('repair flow owns persisted transitions and reports active attempts', async
       repairRequestId: 'repair-request',
       messageCid: 'repair-message',
     },
-    onAttempt: (attempt, meta) => snapshots.push([attempt, meta]),
+    onAttempt: attempt => snapshots.push(attempt),
   })
 
-  assert.equal(result.chatId, 'repair-chat')
-  assert.deepEqual(snapshots.map(([attempt, meta]) => [attempt.phase, attempt.chatId, meta.active]), [
-    ['agent-starting', null, true],
-    ['agent-starting', 'repair-chat', true],
-    ['agent-directed', 'repair-chat', false],
+  assert.deepEqual(calls, [
+    [
+      'create',
+      { title: 'Fix a Möbius error', recovery_request_id: 'repair-request' },
+      { timeoutMs: AGENT_REPAIR_REQUEST_TIMEOUT_MS, signal: undefined },
+    ],
+    [
+      'send',
+      'repair-chat',
+      { content: 'diagnostic prompt', cid: 'repair-message' },
+      { timeoutMs: AGENT_REPAIR_REQUEST_TIMEOUT_MS, signal: undefined },
+    ],
+  ])
+  assert.deepEqual(result, {
+    chatId: 'repair-chat',
+    path: '/mobius/shell/?chat=repair-chat',
+  })
+  assert.deepEqual(snapshots.map(attempt => [attempt.phase, attempt.chatId]), [
+    ['agent-starting', null],
+    ['agent-starting', 'repair-chat'],
+    ['agent-directed', 'repair-chat'],
   ])
   const persisted = readErrorRecoveryAttempt({ storage, surfaceKey, fingerprint })
   assert.equal(Number.isFinite(persisted.at), true)
@@ -223,15 +192,15 @@ test('repair flow persists a failed send with the created chat identity', async 
       repairRequestId: 'repair-request',
       messageCid: 'repair-message',
     },
-    onAttempt: (attempt, meta) => snapshots.push([attempt, meta]),
+    onAttempt: attempt => snapshots.push(attempt),
   }), /repair chat send 503/)
 
-  assert.deepEqual(snapshots.at(-1), [{
+  assert.deepEqual(snapshots.at(-1), {
     phase: 'agent-failed',
     chatId: 'repair-chat',
     repairRequestId: 'repair-request',
     messageCid: 'repair-message',
-  }, { active: false }])
+  })
   assert.equal(
     readErrorRecoveryAttempt({ storage, surfaceKey, fingerprint }).phase,
     'agent-failed',
@@ -266,7 +235,7 @@ test('an aborted repair remains resumable instead of becoming a failure', async 
   const persisted = readErrorRecoveryAttempt({ storage, surfaceKey, fingerprint })
   assert.equal(persisted.phase, 'agent-starting')
   assert.equal(persisted.chatId, 'existing-chat')
-  assert.equal(recoveryViewForAttempt(persisted).phase, 'agent')
+  assert.equal(recoveryPhaseForAttempt(persisted), 'agent')
 })
 
 test('stale and different errors do not inherit an escalation', () => {
@@ -322,113 +291,6 @@ test('repair prompt bounds and indents untrusted diagnostics', () => {
   assert.match(prompt, /Preserve user data/)
 })
 
-test('repair diagnostics redact common credentials before storage or agent use', () => {
-  const input = [
-    'https://user:password@example.com/path?token=secret-token&code=secret-code',
-    'postgres://db-user:db-password@database.internal/mobius',
-    'Authorization: Bearer abc.def.ghi',
-    'Cookie: session=secret-cookie',
-    'OPENAI_API_KEY=sk-secret',
-    'AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE',
-    'AWS_SECRET_ACCESS_KEY="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"',
-    '{"AWS_SECRET_ACCESS_KEY":"json/secret+value-that-must-not-pass"}',
-    'NPM_TOKEN=npm_0123456789abcdefghijklmnopqrstuvwxyz',
-    'unlabeled github_pat_0123456789abcdefghijklmnopqrstuvwxyz',
-    'opaque c29tZS12ZXJ5LWxvbmctcHJpdmF0ZS12YWx1ZS0xMjM0NTY3ODkw',
-    'eyJheader.eyJpayload.signature',
-    '-----BEGIN PRIVATE KEY-----\nprivate-key-body\n-----END PRIVATE KEY-----',
-  ].join('\n')
-  const redacted = redactDiagnosticText(input)
-
-  for (const secret of [
-    'password',
-    'db-password',
-    'secret-token',
-    'secret-code',
-    'abc.def.ghi',
-    'secret-cookie',
-    'sk-secret',
-    'AKIAIOSFODNN7EXAMPLE',
-    'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
-    'json/secret+value-that-must-not-pass',
-    'npm_0123456789abcdefghijklmnopqrstuvwxyz',
-    'github_pat_0123456789abcdefghijklmnopqrstuvwxyz',
-    'c29tZS12ZXJ5LWxvbmctcHJpdmF0ZS12YWx1ZS0xMjM0NTY3ODkw',
-    'eyJpayload',
-    'private-key-body',
-  ]) assert.equal(redacted.includes(secret), false, `must redact ${secret}`)
-  assert.match(redacted, /\[redacted\]/)
-  assert.match(redacted, /\[redacted-private-key\]/)
-  assert.match(redacted, /\[redacted-provider-token\]/)
-  assert.match(redacted, /\[redacted-high-entropy-value\]/)
-})
-
-test('diagnostic redaction preserves ordinary hashes, prose, and long symbols', () => {
-  const commit = '8fe8a7ae35dce88ee4af7585b9ff0b4c229df257'
-  const symbol = 'VeryLongRecoveryBoundaryComponentIdentifier'
-  const diagnostic = `Build ${commit} failed in ${symbol} while rendering the recovery screen.`
-  assert.equal(redactDiagnosticText(diagnostic), diagnostic)
-})
-
-test('agent repair creates a fresh chat, sends the diagnostic, and returns its route', async () => {
-  const calls = []
-  const client = {
-    chats: {
-      create: async (payload, options) => {
-        calls.push(['create', payload, options])
-        return { ok: true, json: async () => ({ id: 'repair/id' }) }
-      },
-      send: async (chatId, payload, options) => {
-        calls.push(['send', chatId, payload, options])
-        return { ok: true }
-      },
-    },
-  }
-
-  const result = await startAgentRepair({
-    prompt: 'diagnostic prompt',
-    client,
-    base: '/mobius',
-    repairRequestId: 'repair-request',
-    messageCid: 'repair-cid',
-  })
-
-  assert.deepEqual(calls, [
-    [
-      'create',
-      { title: 'Fix a Möbius error', recovery_request_id: 'repair-request' },
-      { timeoutMs: AGENT_REPAIR_REQUEST_TIMEOUT_MS, signal: undefined },
-    ],
-    [
-      'send',
-      'repair/id',
-      { content: 'diagnostic prompt', cid: 'repair-cid' },
-      { timeoutMs: AGENT_REPAIR_REQUEST_TIMEOUT_MS, signal: undefined },
-    ],
-  ])
-  assert.deepEqual(result, {
-    chatId: 'repair/id',
-    path: '/mobius/shell/?chat=repair%2Fid',
-    repairRequestId: 'repair-request',
-    messageCid: 'repair-cid',
-  })
+test('repair chat paths encode chat identity', () => {
   assert.equal(repairChatPath('chat id'), '/shell/?chat=chat%20id')
-})
-
-test('agent repair stops before navigation when the diagnostic send fails', async () => {
-  const client = {
-    chats: {
-      create: async () => ({ ok: true, json: async () => ({ id: 'repair-chat' }) }),
-      send: async () => ({ ok: false, status: 503 }),
-    },
-  }
-  await assert.rejects(
-    startAgentRepair({
-      prompt: 'diagnostic',
-      client,
-      repairRequestId: 'repair-request',
-      messageCid: 'repair-cid',
-    }),
-    /repair chat send 503/,
-  )
 })

--- a/frontend/src/lib/__tests__/recoveryPanel.test.js
+++ b/frontend/src/lib/__tests__/recoveryPanel.test.js
@@ -1,0 +1,63 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import RecoveryPanel from '../../components/ErrorBoundary/RecoveryPanel.jsx'
+
+function renderPanel(overrides = {}) {
+  return renderToStaticMarkup(createElement(RecoveryPanel, {
+    title: 'Something broke',
+    subject: 'screen',
+    diagnostic: 'Maximum update depth exceeded',
+    refreshLabel: 'Refresh screen',
+    onRefresh: () => {},
+    onAgentRepair: () => {},
+    variant: 'boundary',
+    ...overrides,
+  }))
+}
+
+test('recovery panel advances from refresh to agent repair', () => {
+  const refresh = renderPanel()
+  assert.match(refresh, />Refresh screen</)
+  assert.doesNotMatch(refresh, /repair chat|isolated recovery workspace/i)
+
+  const agent = renderPanel({ attempt: { phase: 'refreshed' } })
+  assert.match(agent, />Refresh again</)
+  assert.match(agent, />Start repair chat</)
+  assert.doesNotMatch(agent, /isolated recovery workspace/i)
+})
+
+test('recovery panel distinguishes an active repair from an interrupted one', () => {
+  const attempt = {
+    phase: 'agent-starting',
+    repairRequestId: 'repair-request',
+    messageCid: 'repair-message',
+  }
+  const active = renderPanel({ attempt, repairActive: true })
+  assert.match(active, /aria-busy="true"/)
+  assert.match(active, /disabled=""[^>]*>Starting repair chat…</)
+  assert.doesNotMatch(active, />Refresh again</)
+
+  const interrupted = renderPanel({ attempt })
+  assert.match(interrupted, />Resume repair chat</)
+  assert.match(interrupted, />Refresh again</)
+})
+
+test('recovery panel exposes last resorts only after repair fails', () => {
+  const failed = renderPanel({
+    attempt: { phase: 'agent-failed', chatId: 'repair/chat' },
+  })
+  assert.match(failed, />Retry repair chat</)
+  assert.match(failed, />Open repair chat</)
+  assert.match(failed, /chat=repair%2Fchat/)
+  assert.match(failed, /isolated recovery workspace/i)
+
+  const restricted = renderPanel({
+    attempt: { phase: 'refreshed' },
+    canAskAgent: false,
+  })
+  assert.doesNotMatch(restricted, /Start repair chat|Retry repair chat/)
+  assert.match(restricted, /isolated recovery workspace/i)
+})

--- a/frontend/src/lib/__tests__/standaloneHostContract.test.js
+++ b/frontend/src/lib/__tests__/standaloneHostContract.test.js
@@ -33,12 +33,7 @@ test('standalone chat navigation delegates draft and autosend ownership', () => 
 test('generic and standalone crashes share one recovery panel contract', () => {
   const standalone = read('src/components/StandaloneApp/StandaloneApp.jsx')
   const boundary = read('src/components/ErrorBoundary/ErrorBoundary.jsx')
-  const panel = read('src/components/ErrorBoundary/RecoveryPanel.jsx')
 
   assert.match(standalone, /<RecoveryPanel/)
   assert.match(boundary, /<RecoveryPanel/)
-  assert.match(panel, /Refreshing didn’t fix/)
-  assert.match(panel, /Repair chat request failed/)
-  assert.doesNotMatch(standalone, /agentError|Repair chat request failed/)
-  assert.doesNotMatch(boundary, /agentError|Repair chat request failed/)
 })

--- a/frontend/src/lib/__tests__/vite-env-loader.mjs
+++ b/frontend/src/lib/__tests__/vite-env-loader.mjs
@@ -29,6 +29,9 @@ const REACT_SHIMMED_MODULES = [
 ]
 
 export async function resolve(specifier, context, nextResolve) {
+  if (specifier.endsWith('.css')) {
+    return { url: 'data:text/javascript,export default {}', shortCircuit: true }
+  }
   if (
     specifier === 'react'
     && REACT_SHIMMED_MODULES.some(m => context.parentURL?.endsWith(m))

--- a/frontend/src/lib/errorRecovery.js
+++ b/frontend/src/lib/errorRecovery.js
@@ -1,18 +1,16 @@
 import { redactDiagnosticText } from './diagnosticRedaction.js'
 
-export { redactDiagnosticText } from './diagnosticRedaction.js'
-
 export const ERROR_RECOVERY_MAX_AGE_MS = 10 * 60 * 1000
 export const AGENT_REPAIR_REQUEST_TIMEOUT_MS = 12 * 1000
 
 const STORAGE_PREFIX = 'mobius:error-recovery:v2:'
-const ATTEMPT_PHASES = new Set([
-  'refreshed',
+const AGENT_ATTEMPT_PHASES = new Set([
   'agent-starting',
   'agent-directed',
   'agent-failed',
 ])
-const REPAIR_ACTIVE_PHASES = new Set(['agent-starting', 'agent-directed', 'agent-failed'])
+const ATTEMPT_PHASES = new Set(['refreshed', ...AGENT_ATTEMPT_PHASES])
+
 function boundedText(value, limit) {
   return redactDiagnosticText(value)
     .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, ' ')
@@ -102,7 +100,7 @@ export function writeRefreshedRecoveryAttempt({
   now = Date.now(),
 }) {
   const current = readErrorRecoveryAttempt({ storage, surfaceKey, fingerprint, now })
-  if (current && REPAIR_ACTIVE_PHASES.has(current.phase)) return true
+  if (current && AGENT_ATTEMPT_PHASES.has(current.phase)) return true
   return writeErrorRecoveryAttempt({
     storage,
     surfaceKey,
@@ -121,41 +119,9 @@ export function recoveryPhaseForAttempt(attempt, { canAskAgent = true } = {}) {
   return 'recovery'
 }
 
-export function recoveryViewForAttempt(
-  attempt,
-  { canAskAgent = true, active = false } = {},
-) {
-  const attemptPhase = attempt?.phase || null
-  return {
-    phase: active && attemptPhase === 'agent-starting'
-      ? 'agent-starting'
-      : recoveryPhaseForAttempt(attempt, { canAskAgent }),
-    attemptPhase,
-    repairChatId: attempt?.chatId || null,
-  }
-}
-
-export function recoveryActionPolicy({
-  phase,
-  attemptPhase = null,
-  canAskAgent = true,
-  repairChatId = null,
-}) {
-  const starting = phase === 'agent-starting'
-  return {
-    showRefreshAgain: phase !== 'refresh' && !starting,
-    showAskAgent: canAskAgent && phase === 'agent',
-    showRetryAgent: canAskAgent && phase === 'recovery' && attemptPhase === 'agent-failed',
-    showOpenRepairChat: phase === 'recovery' && Boolean(repairChatId),
-    showRecovery: phase === 'recovery',
-  }
-}
-
-export function createRepairIdentity(
-  attempt,
-  createId = () => globalThis.crypto?.randomUUID?.()
-    || `repair-${Date.now()}-${Math.random().toString(36).slice(2)}`,
-) {
+function createRepairIdentity(attempt) {
+  const createId = () => globalThis.crypto?.randomUUID?.()
+    || `repair-${Date.now()}-${Math.random().toString(36).slice(2)}`
   return {
     repairRequestId: attempt?.repairRequestId || createId(),
     messageCid: attempt?.messageCid || createId(),
@@ -198,7 +164,7 @@ export function repairChatPath(chatId, base = '') {
   return `${base}/shell/?chat=${encodeURIComponent(chatId)}`
 }
 
-export async function startAgentRepair({
+async function startAgentRepair({
   prompt,
   client,
   base = '',
@@ -231,8 +197,6 @@ export async function startAgentRepair({
   return {
     chatId: String(chat.id),
     path: repairChatPath(chat.id, base),
-    repairRequestId,
-    messageCid,
   }
 }
 
@@ -254,7 +218,7 @@ export async function runAgentRepair({
     repairRequestId: identity.repairRequestId,
     messageCid: identity.messageCid,
   }
-  const persist = (nextAttempt, { active = false } = {}) => {
+  const persist = (nextAttempt) => {
     attempt = nextAttempt
     writeErrorRecoveryAttempt({
       storage,
@@ -262,10 +226,10 @@ export async function runAgentRepair({
       fingerprint,
       ...attempt,
     })
-    onAttempt?.(attempt, { active })
+    onAttempt?.(attempt)
   }
 
-  persist(attempt, { active: true })
+  persist(attempt)
   try {
     const result = await startAgentRepair({
       prompt,
@@ -275,7 +239,7 @@ export async function runAgentRepair({
       messageCid: identity.messageCid,
       signal,
       onChatCreated: chatId => {
-        persist({ ...attempt, chatId }, { active: true })
+        persist({ ...attempt, chatId })
       },
     })
     persist({


### PR DESCRIPTION
## Summary

- keep the persisted recovery attempt as the single source of truth instead of storing `phase`, `attemptPhase`, and `repairChatId` copies
- model only the live request as transient `repairActive` state, so aborted requests return to the resumable action instead of staying disabled
- remove internal-only recovery exports, callback metadata, and the diagnostic-redaction compatibility re-export
- replace copy-coupled source assertions with rendered RecoveryPanel behavior tests and colocate redaction tests with their module

This preserves the refresh → repair chat → isolated recovery escalation, fingerprint isolation, persisted repair identity, and credential redaction while removing 71 net lines.

## Verification

- focused ESLint on every changed source and test file
- 16 focused recovery, redaction, panel, and host-contract tests
- full frontend library and hook suites
- structural-test ratchet: 88/88 files, 780/780 cases
- production and offline PWA build
- browser matrix: desktop, mobile, short viewport, active repair, failed repair, and restricted surface
- contributor pre-push gate
