### PR TITLE
Fix startup recovery fallback styling

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client
 import { QueryClientProvider, useIsRestoring } from '@tanstack/react-query'
 import ErrorBoundary from './components/ErrorBoundary/ErrorBoundary.jsx'
 import RecoveryLink from './components/ErrorBoundary/RecoveryLink.jsx'
+import './components/ErrorBoundary/RecoveryPanel.css'
 import { api, beginEphemeralAuth, getToken, setToken, BASE } from './api/client.js'
 import * as setupSession from './lib/setupSession.js'
 import { setupQueries } from './hooks/queries.js'
@@ -215,12 +216,16 @@ function AppRoot() {
   }
   if (status === 'sso') return <RouteLoading />
   if (status === 'sso-error') return (
-    <ManagedSignInError
+    <StartupError
+      title="Couldn’t sign in"
+      message="Your Möbius account could not be confirmed. Try again from this browser."
       onRetry={() => window.location.replace(api.auth.sso.startUrl('/shell/'))}
     />
   )
   if (status === 'setup-error') return (
-    <SetupStatusError
+    <StartupError
+      title="Couldn’t reach Möbius"
+      message="The server didn’t answer the startup check. Your account status is unknown, so sign-in is paused until the connection recovers."
       retrying={setupStatusQuery.isFetching}
       onRetry={() => setupStatusQuery.refetch()}
     />
@@ -261,18 +266,19 @@ function RouteLoading() {
   return <div className="app-route-loading" aria-hidden="true" />
 }
 
-function SetupStatusError({ retrying, onRetry }) {
+function StartupError({ title, message, retrying = false, onRetry }) {
   return (
     <div className="errbound" role="alert">
-      <div className="errbound__card">
-        <h1 className="errbound__title">Couldn’t reach Möbius</h1>
-        <p className="errbound__body">
-          The server didn’t answer the startup check. Your account status is unknown, so sign-in is paused until the connection recovers.
-        </p>
-        <div className="errbound__actions">
+      <section className="recovery-panel recovery-panel--boundary errbound__card">
+        <h1 className="recovery-panel__title">{title}</h1>
+        <p className="recovery-panel__body">{message}</p>
+        <div
+          className="recovery-panel__actions"
+          aria-busy={retrying ? true : undefined}
+        >
           <button
             type="button"
-            className="errbound__btn errbound__btn--primary"
+            className="recovery-panel__button recovery-panel__button--primary"
             onClick={onRetry}
             disabled={retrying}
           >
@@ -280,30 +286,7 @@ function SetupStatusError({ retrying, onRetry }) {
           </button>
         </div>
         <RecoveryLink />
-      </div>
-    </div>
-  )
-}
-
-function ManagedSignInError({ onRetry }) {
-  return (
-    <div className="errbound" role="alert">
-      <div className="errbound__card">
-        <h1 className="errbound__title">Couldn’t sign in</h1>
-        <p className="errbound__body">
-          Your Möbius account could not be confirmed. Try again from this browser.
-        </p>
-        <div className="errbound__actions">
-          <button
-            type="button"
-            className="errbound__btn errbound__btn--primary"
-            onClick={onRetry}
-          >
-            Try again
-          </button>
-        </div>
-        <RecoveryLink />
-      </div>
+      </section>
     </div>
   )
 }

--- a/frontend/src/lib/__tests__/routeSplitting.test.js
+++ b/frontend/src/lib/__tests__/routeSplitting.test.js
@@ -4,6 +4,10 @@ import { readFileSync } from 'node:fs'
 
 const SOURCE = readFileSync(new URL('../../App.jsx', import.meta.url), 'utf8')
 const INDEX_HTML = readFileSync(new URL('../../../index.html', import.meta.url), 'utf8')
+const RECOVERY_CSS = [
+  readFileSync(new URL('../../components/ErrorBoundary/ErrorBoundary.css', import.meta.url), 'utf8'),
+  readFileSync(new URL('../../components/ErrorBoundary/RecoveryPanel.css', import.meta.url), 'utf8'),
+].join('\n')
 
 test('mutually exclusive top-level flows remain lazy route boundaries', () => {
   for (const component of ['SetupWizard', 'LoginForm', 'Shell', 'ChatEmbed']) {
@@ -13,12 +17,36 @@ test('mutually exclusive top-level flows remain lazy route boundaries', () => {
       `${component} must not return to the shared startup bundle`,
     )
   }
+  const startupError = SOURCE.slice(
+    SOURCE.indexOf('function StartupError'),
+    SOURCE.indexOf('function removeSplash'),
+  )
+  const sharedClasses = [
+    'errbound__card',
+    'recovery-panel--boundary',
+    'recovery-panel__title',
+    'recovery-panel__body',
+    'recovery-panel__actions',
+    'recovery-panel__button',
+    'recovery-panel__button--primary',
+  ]
+
+  assert.ok((SOURCE.match(/<StartupError/g) || []).length >= 2)
+  assert.doesNotMatch(startupError, /errbound__(?:title|body|actions|btn)/)
+  for (const className of sharedClasses) {
+    assert.match(startupError, new RegExp(`className="[^"]*${className}`))
+    assert.match(
+      RECOVERY_CSS,
+      new RegExp(`\\.${className.replaceAll('-', '\\-')}(?:[\\s.:,{]|$)`),
+      `${className} must keep a stylesheet rule`,
+    )
+  }
 })
 
 test('route loading is blank without removing the launch mark', () => {
   const routeLoading = SOURCE.slice(
     SOURCE.indexOf('function RouteLoading'),
-    SOURCE.indexOf('function SetupStatusError'),
+    SOURCE.indexOf('function StartupError'),
   )
   const launchSplash = INDEX_HTML.slice(
     INDEX_HTML.indexOf('<div id="splash"'),


### PR DESCRIPTION
## Summary
- replace duplicated setup and managed sign-in failure markup with one StartupError component
- reuse the shared recovery-panel styles instead of deleted errbound child selectors
- keep the stylesheet dependency explicit and add a CSS contract regression check

## Verification
- full frontend test suite
- production frontend build
- ESLint (no errors; existing warnings only)
- structural-test ratchet at 88 files / 780 cases
- UI maintainability detector: no findings
- independent review: no blockers