### PR TITLE
fix(push): route Android notification taps to the installed PWA, not the browser

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -888,6 +888,19 @@ def _resolve_asset_file(asset_path: str) -> Path | None:
   return None
 
 
+# Root-served worker scripts: `sw.js` caches the shell, `sw-push.js` owns Web
+# Push (see frontend/public/sw-push.js). Same delivery contract at every use
+# site below.
+_SERVICE_WORKER_SCRIPTS = frozenset({"sw.js", "sw-push.js"})
+
+# The push worker's scope. It exists only to name a URL prefix inside the
+# shell's PWA scope, and must never resolve to a document — a page here would
+# be controlled by a worker with no fetch handler, so it would boot the shell
+# with no precache and no offline fallback. Mirrored in the frontend's
+# swNavigationPolicy denylist for the offline path.
+_PUSH_WORKER_SCOPE = "shell/push"
+
+
 def _is_static_asset_path(path: str) -> bool:
   """True for paths that must 404 on a miss rather than fall through to
   the SPA HTML.
@@ -913,7 +926,7 @@ def _is_static_asset_path(path: str) -> bool:
     # First path segment — catches both `vendor` and `vendor/<file>`
     # without over-matching a route like `vendorfoo`.
     path.split("/", 1)[0] in {"vendor", "assets"}
-    or path == "sw.js"
+    or path in _SERVICE_WORKER_SCRIPTS
     or path.rsplit(".", 1)[-1] in {
       "js", "mjs", "css", "html", "map", "wasm", "json",
     }
@@ -929,8 +942,8 @@ _RESERVED_TOP_LEVEL_APP_ALIASES = {
   "chat",
   "recover",
   "shell",
-  "sw.js",
   "vendor",
+  *_SERVICE_WORKER_SCRIPTS,
 }
 
 
@@ -1215,6 +1228,8 @@ if _baked_dir.is_dir() or _live_dir.is_dir():
   @app.get("/{path:path}")
   async def spa_fallback(request: Request, path: str):
     """Serves the SPA index.html for any non-API, non-asset path."""
+    if path == _PUSH_WORKER_SCOPE or path.startswith(f"{_PUSH_WORKER_SCOPE}/"):
+      raise HTTPException(status_code=404, detail="Not found.")
     # Resolve which build serves THIS request (live dist if complete, else the
     # baked floor) once, up front — per request, never a module-load snapshot.
     static_dir = _resolve_static_dir()
@@ -1277,10 +1292,9 @@ if _baked_dir.is_dir() or _live_dir.is_dir():
       # If-None-Match on every request, so a 304 keeps the
       # download cheap when nothing changed.
       headers = _public_static_headers(path)
-      if path == "sw.js":
+      if path in _SERVICE_WORKER_SCRIPTS:
         headers["Cache-Control"] = "no-cache, must-revalidate"
-      if path == "sw.js":
-        # sw.js is a REVALIDATING response (no-cache + the mtime ETag
+        # A worker script is a REVALIDATING response (no-cache + the mtime ETag
         # FileResponse sets), so it must never answer a 206. A
         # `Range: bytes=0-0` probe would otherwise let Chromium store the
         # 1-byte slice and later serve it as a status-200 full body — a

--- a/backend/tests/test_generation_serving.py
+++ b/backend/tests/test_generation_serving.py
@@ -129,6 +129,29 @@ def test_unknown_asset_returns_404_not_html(client, serving):
   assert "text/html" not in head.headers.get("content-type", "")
 
 
+def test_push_worker_scope_never_resolves_to_a_document(client, serving):
+  """The push worker's scope must hold no documents.
+
+  `/shell/push/` exists only to name a URL prefix inside the shell's PWA scope
+  so Android routes notifications to the installed app (see
+  frontend/public/sw-push.js). A page served there would be controlled by that
+  worker, which has no fetch handler, so it would boot the shell with no
+  precache and no offline fallback. The SPA fallback happily answers any
+  extensionless path with index.html, so this has to be refused explicitly.
+  """
+  _write_build(serving["live"], "gen2")
+  _reset_memo()
+  if not _spa_active(client):
+    pytest.skip("SPA fallback not registered (no static dir in this env)")
+  for path in ("/shell/push", "/shell/push/", "/shell/push/anything"):
+    r = client.get(path)
+    assert r.status_code == 404, path
+    assert "text/html" not in r.headers.get("content-type", ""), path
+  # The sibling shell routes must keep working — this is a narrow carve-out.
+  assert client.get("/shell/").status_code == 200
+  assert client.get("/shell/pushy").status_code == 200
+
+
 def test_traversal_attempts_rejected(serving):
   live = serving["live"]
   _write_build(live, "gen2")

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -29,7 +29,17 @@ export default [
     ],
   },
   {
-    files: ['src/**/*.{js,jsx}', 'scripts/**/*.mjs', 'vite.config.js'],
+    files: [
+      'src/**/*.{js,jsx}',
+      'scripts/**/*.mjs',
+      'vite.config.js',
+      // Served verbatim from public/ rather than bundled, but still hand-
+      // written source that deserves the same rules and worker globals. A
+      // pattern, not a filename: the generated files here are already in
+      // `ignores` above, so the next hand-written one is linted by default
+      // instead of shipping unchecked.
+      'public/**/*.js',
+    ],
     languageOptions: {
       ecmaVersion: 'latest',
       sourceType: 'module',

--- a/frontend/public/sw-push.js
+++ b/frontend/public/sw-push.js
@@ -1,0 +1,165 @@
+/**
+ * Möbius push worker — registered at scope `/shell/push/`.
+ *
+ * WHY THIS IS A SEPARATE WORKER FROM `sw.js`
+ * ------------------------------------------
+ * On Android, Chrome decides WHICH INSTALLED APP receives a web push by
+ * resolving the *service worker's scope URL* against the intent filters of
+ * installed WebAPKs — `NotificationPlatformBridge.getWebApkPackage(scopeUrl)`
+ * → `WebApkValidator.queryFirstWebApkPackage(context, scopeUrl)`. A WebAPK's
+ * intent filter carries its manifest `scope` as an Android `pathPrefix`. When
+ * a WebAPK matches, Chrome hands the notification to it (`WebApkServiceClient`)
+ * and bakes the package name into the click PendingIntent, so tapping launches
+ * that app. When nothing matches, Chrome displays and owns the notification
+ * itself, and a tap opens Chrome.
+ *
+ * Möbius's shell is installed with `scope: "/shell/"`, but the caching worker
+ * (`sw.js`) is deliberately registered at `/` — it also has to serve the
+ * standalone mini-app pages under `/apps/<slug>/`, which are separate PWAs on
+ * the same origin. `/` is NOT inside `/shell/`, so no WebAPK ever matched:
+ * every notification was a plain Chrome site notification and every tap landed
+ * in Chrome instead of Möbius.
+ *
+ * This worker exists solely to own the push subscription from a scope that is
+ * inside the shell WebAPK's scope. `/shell/push/` holds no documents — the
+ * backend 404s it and `swNavigationPolicy` keeps the shell off it — so this
+ * registration controls ZERO pages, which is the point. A worker registered at
+ * `/shell/` itself would be a narrower match than `sw.js` for the shell's own
+ * pages, take control of them, and silently disable the shell's precache and
+ * offline behaviour.
+ *
+ * Served verbatim from `public/` (no bundler), so it must stay dependency-free
+ * and valid as a classic worker script.
+ */
+
+self.addEventListener('install', () => self.skipWaiting())
+self.addEventListener('activate', (e) => e.waitUntil(self.clients.claim()))
+
+self.addEventListener('push', (e) => {
+  if (!e.data) return
+  const data = e.data.json()
+  const options = {
+    body: data.body || '',
+    icon: data.icon || '/icons/icon-192.png',
+    badge: '/icons/icon-192.png',
+    data: { target: data.target || '/', actions: data.actions },
+    actions: (data.actions || []).slice(0, 2).map(a => ({
+      action: a.action,
+      title: a.title,
+    })),
+  }
+  e.waitUntil(self.registration.showNotification(data.title, options))
+})
+
+// Whitelist notification targets to same-origin chat/app paths so a
+// malicious payload (server compromise, MITM of an unencrypted push)
+// can't steer openWindow() or postMessage to an arbitrary URL.
+//
+// COLD-START SCOPE: the canonical target is `/shell/?app=<id>` (and
+// `/shell/?chat=<id>`), which is INSIDE the PWA manifest scope (`/shell/`).
+// A cold tap (app closed/backgrounded) does `clients.openWindow(target)`;
+// only a target inside scope reopens the installed standalone PWA — an
+// out-of-scope form opens a plain browser tab instead. The retired
+// `/app/<id>` and `/chat/<id>` legacy forms are no longer accepted (the last
+// one on prod predates this by weeks); they now fall through to root. We
+// preserve the query string so the page-side parser (Shell onSwMessage,
+// useNavigation deepLink) can read `?app=`/`?chat=`.
+function _safeTarget(raw) {
+  if (typeof raw !== 'string' || !raw) return '/'
+  let path = raw
+  let search = ''
+  try {
+    if (/^https?:\/\//i.test(raw)) {
+      const u = new URL(raw)
+      if (u.origin !== self.location.origin) return '/'
+      path = u.pathname
+      search = u.search
+    } else {
+      const q = raw.indexOf('?')
+      if (q !== -1) {
+        path = raw.slice(0, q)
+        search = raw.slice(q)
+      }
+    }
+  } catch { return '/' }
+  // In-scope shell deep-link: /shell/ or /shell with an ?app=/?chat= query.
+  if (/^\/shell\/?$/.test(path)) {
+    try {
+      const params = new URLSearchParams(search)
+      const app = params.get('app')
+      const chat = params.get('chat')
+      // An app deep-link may carry a one-shot intent naming WHICH item to
+      // open (e.g. `artifact:tip-calculator-7f3a`). Dropping it here landed
+      // the tap on the app's index instead of the item the notification was
+      // about. Same conservative charset as the ids, plus the ':' and '.'
+      // that namespace an intent's target.
+      const intent = params.get('intent')
+      if (app && /^[A-Za-z0-9_-]+$/.test(app)) {
+        return (intent && /^[A-Za-z0-9_.:-]{1,128}$/.test(intent))
+          ? `/shell/?app=${app}&intent=${encodeURIComponent(intent)}`
+          : `/shell/?app=${app}`
+      }
+      if (chat && /^[A-Za-z0-9_-]+$/.test(chat)) return `/shell/?chat=${chat}`
+    } catch { /* fall through */ }
+    return '/shell/'
+  }
+  // Root is the only remaining out-of-scope target we accept; every other
+  // form (including the retired /app/<id> and /chat/<id> notification
+  // targets) falls through to root.
+  if (path === '/') return path
+  return '/'
+}
+
+self.addEventListener('notificationclick', (e) => {
+  e.notification.close()
+  const data = e.notification.data || {}
+  let target = data.target || '/'
+
+  if (e.action && data.actions) {
+    const match = data.actions.find(a => a.action === e.action)
+    if (match && match.target) target = match.target
+  }
+  target = _safeTarget(target)
+
+  e.waitUntil((async () => {
+    // `includeUncontrolled` is load-bearing here: this worker deliberately
+    // controls no documents, so every shell window is an uncontrolled client
+    // of it. matchAll is origin-scoped, not path-scoped, so the shell's own
+    // windows are still visible to us.
+    const windowClients = await self.clients.matchAll({
+      type: 'window',
+      includeUncontrolled: true,
+    })
+    const focusable = windowClients.filter(c => 'focus' in c)
+    // Prefer a client the user is currently looking at — focusing a
+    // hidden/background tab would steer the message away from the
+    // window they're actually using. Fall back to the first match
+    // if nothing is visible.
+    const visible = focusable.find(c => c.visibilityState === 'visible')
+    const target_client = visible || focusable[0]
+    if (target_client) {
+      // For shell deep-links, navigate the existing client instead of only
+      // postMessaging it. The message path is fast when the current Shell
+      // listener is alive, but installed PWAs can have a stale/booting page
+      // after a service-worker update; navigation gives the browser a durable
+      // URL to load so a "Open <app>" action does not focus Mobius and then
+      // appear to do nothing.
+      if (/^\/shell\/?\?/.test(target) && 'navigate' in target_client) {
+        try {
+          const navigated = await target_client.navigate(target)
+          await (navigated || target_client).focus()
+          return
+        } catch {
+          // Fall back to focus + postMessage below.
+        }
+      }
+      // Focus BEFORE postMessage so the message lands on the window
+      // the user will end up on. If focus moves the active document
+      // mid-handler, postMessage on the un-focused one can race.
+      await target_client.focus()
+      target_client.postMessage({ type: 'notification-click', target })
+      return
+    }
+    if (self.clients.openWindow) return self.clients.openWindow(target)
+  })())
+})

--- a/frontend/scripts/check-offline-build.mjs
+++ b/frontend/scripts/check-offline-build.mjs
@@ -7,7 +7,7 @@
 // network error and the browser-chrome leak we're killing comes back;
 // if mobius-runtime.js isn't precached, offline-capable apps can't load
 // window.mobius offline.
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import path from 'node:path'
 
 const buildDir = path.resolve(process.argv[2] || 'dist')
@@ -19,4 +19,36 @@ for (const f of required) {
   }
   if (!sw.includes(f)) throw new Error(`${f} not precached in dist/sw.js`)
 }
+
+// Push-worker gate. Android hands a web push to the installed shell only when
+// the push worker's SCOPE sits inside the PWA manifest's scope, so those two
+// values are a cross-file contract with no import to hold them together —
+// break it and every notification silently becomes a Chrome notification whose
+// tap leaves the app. Invisible on desktop, in headless runs, and in CI, so
+// this is the only place it can be caught. Derive the expected scope from the
+// real manifest and prove the shipped bundle registers exactly that.
+const pushWorker = 'sw-push.js'
+if (!existsSync(path.join(buildDir, pushWorker))) {
+  throw new Error(`missing ${path.join(buildDir, pushWorker)} — push is dead`)
+}
+// A precached worker script can never be updated afterwards.
+if (sw.includes(pushWorker)) {
+  throw new Error(`${pushWorker} must NOT be precached in dist/sw.js`)
+}
+const manifest = JSON.parse(
+  readFileSync(path.join(buildDir, 'manifest.webmanifest'), 'utf8'),
+)
+const pushScope = `${manifest.scope}push/`
+const assets = path.join(buildDir, 'assets')
+const registersPushScope = readdirSync(assets)
+  .filter(f => f.endsWith('.js'))
+  .some(f => readFileSync(path.join(assets, f), 'utf8').includes(pushScope))
+if (!registersPushScope) {
+  throw new Error(
+    `no bundle registers the push worker at ${pushScope} — the manifest scope `
+    + `(${manifest.scope}) and PUSH_SW_SCOPE have drifted`,
+  )
+}
+
 console.log('offline build OK:', required.join(', '), 'present + precached')
+console.log(`push worker OK: ${pushWorker} shipped, unprecached, scoped ${pushScope}`)

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -594,5 +594,9 @@ export const api = {
       method: 'POST',
       body: JSON.stringify(payload),
     }),
+    unsubscribe: (payload) => apiFetch('/push/subscribe', {
+      method: 'DELETE',
+      body: JSON.stringify(payload),
+    }),
   },
 }

--- a/frontend/src/hooks/usePushSubscription.js
+++ b/frontend/src/hooks/usePushSubscription.js
@@ -1,47 +1,23 @@
 import { useEffect } from 'react'
-import { api } from '../api/client.js'
+import { subscribeToPush } from '../lib/pushSubscription.js'
 
 /**
  * Subscribes the browser to Web Push notifications after login.
  * Runs once per session — re-subscribes each time (subscriptions can
  * rotate), but only prompts for permission once.
+ *
+ * Push lives on its own service worker — see `lib/pushSubscription.js`.
  */
 export default function usePushSubscription() {
   useEffect(() => {
     if (!('serviceWorker' in navigator) || !('PushManager' in window)) return
-
-    async function subscribe() {
-      try {
-        const reg = await navigator.serviceWorker.ready
-
-        // Fetch the VAPID public key from the server.
-        const res = await api.push.vapidKey()
-        if (!res.ok) return
-        const { publicKey } = await res.json()
-
-        // Convert base64url to Uint8Array for subscribe().
-        const padding = '='.repeat((4 - publicKey.length % 4) % 4)
-        const raw = atob(publicKey.replace(/-/g, '+').replace(/_/g, '/') + padding)
-        const key = new Uint8Array(raw.length)
-        for (let i = 0; i < raw.length; i++) key[i] = raw.charCodeAt(i)
-
-        // Subscribe (prompts for permission if needed).
-        const sub = await reg.pushManager.subscribe({
-          userVisibleOnly: true,
-          applicationServerKey: key,
-        })
-
-        // Send subscription to backend.
-        const subJson = sub.toJSON()
-        await api.push.subscribe({
-          endpoint: subJson.endpoint,
-          keys: subJson.keys,
-        })
-      } catch {
-        // Permission denied or push not supported — silently ignore.
-      }
-    }
-
-    subscribe()
+    // A denied permission can never be re-raised from here, so the whole
+    // pipeline (worker install, key fetch, subscribe) would be wasted. Only
+    // 'denied' short-circuits: 'default' is what raises the prompt.
+    // `globalThis.` matters: a bare `Notification` is a ReferenceError, not
+    // undefined, anywhere the API is absent.
+    if (globalThis.Notification?.permission === 'denied') return
+    // Push unsupported or the prompt refused — nothing to surface.
+    subscribeToPush().catch(() => {})
   }, [])
 }

--- a/frontend/src/lib/__tests__/pushSubscription.test.js
+++ b/frontend/src/lib/__tests__/pushSubscription.test.js
@@ -1,0 +1,201 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { PUSH_SW_SCOPE, subscribeToPush } from '../pushSubscription.js'
+
+// Mirrors the shell PWA's manifest scope (frontend/public/manifest.webmanifest).
+// Android hands a push to the installed Möbius app only when the service
+// worker's scope resolves to that WebAPK, so a push scope outside this makes
+// every notification a plain Chrome notification whose tap opens Chrome. That
+// failure is invisible on desktop and in headless runs. The build-time gate in
+// scripts/check-offline-build.mjs checks the real manifest; this pins the
+// relationship for the unit suite.
+const SHELL_MANIFEST_SCOPE = '/shell/'
+
+const ORIGIN = 'https://mobius.test'
+const PUSH_ENDPOINT = `${ORIGIN}/endpoint/push`
+const LEGACY_ENDPOINT = `${ORIGIN}/endpoint/legacy`
+
+function fakeSubscription(endpoint) {
+  return {
+    endpoint,
+    unsubscribed: false,
+    toJSON: () => ({ endpoint, keys: { p256dh: 'p', auth: 'a' } }),
+    async unsubscribe() { this.unsubscribed = true },
+  }
+}
+
+/**
+ * @param legacy - what `getRegistration('/')` resolves to: a subscription to
+ *   retire, `null` for a caching worker that never held one, `'throws'` for a
+ *   registration whose pushManager is unusable, or `'missing'` for none at all.
+ */
+function fakeContainer({ legacy = null, installing = false } = {}) {
+  const registered = []
+  const pushWorker = {
+    scope: `${ORIGIN}${PUSH_SW_SCOPE}`,
+    active: installing ? null : {},
+    installing: installing ? fakeInstallingWorker() : null,
+    pushManager: {
+      subscribe: async (options) => {
+        // The browser rejects with InvalidStateError when the registration has
+        // no active worker; the fake has to model that or the wait for
+        // activation looks unnecessary.
+        if (!pushWorker.active) throw new Error('InvalidStateError')
+        pushWorker.subscribeOptions = options
+        return fakeSubscription(PUSH_ENDPOINT)
+      },
+    },
+  }
+  return {
+    registered,
+    pushWorker,
+    register: async (url, options) => {
+      registered.push({ url, ...options })
+      return pushWorker
+    },
+    getRegistration: async (scope) => {
+      if (scope !== '/' || legacy === 'missing') return undefined
+      return {
+        scope: `${ORIGIN}/`,
+        pushManager: {
+          getSubscription: async () => {
+            if (legacy === 'throws') throw new Error('permission revoked')
+            return legacy
+          },
+        },
+      }
+    },
+  }
+}
+
+function fakeInstallingWorker() {
+  const worker = { state: 'installing', listeners: [] }
+  worker.addEventListener = (_, fn) => worker.listeners.push(fn)
+  worker.removeEventListener = (_, fn) => {
+    worker.listeners = worker.listeners.filter(l => l !== fn)
+  }
+  worker.settle = (state) => {
+    worker.state = state
+    for (const fn of [...worker.listeners]) fn()
+  }
+  return worker
+}
+
+function fakePush() {
+  const push = {
+    sent: [],
+    removed: [],
+    vapidKey: async () => ({ ok: true, json: async () => ({ publicKey: 'QUJD' }) }),
+    subscribe: async (payload) => { push.sent.push(payload) },
+    unsubscribe: async (payload) => { push.removed.push(payload) },
+  }
+  return push
+}
+
+test('the push worker is registered inside the shell PWA scope', async () => {
+  const container = fakeContainer()
+  await subscribeToPush({ container, push: fakePush() })
+
+  // The URL is a three-way contract with vite.config.js globIgnores and the
+  // backend's worker delivery contract, so pin the literals, not the constants.
+  assert.deepEqual(container.registered, [
+    { url: '/sw-push.js', scope: '/shell/push/' },
+  ])
+  assert.ok(
+    PUSH_SW_SCOPE.startsWith(SHELL_MANIFEST_SCOPE),
+    `${PUSH_SW_SCOPE} must sit inside the shell scope ${SHELL_MANIFEST_SCOPE}`,
+  )
+  // A worker registered AT the manifest scope would out-match the `/`-scoped
+  // caching worker for the shell's own pages, take control of them, and
+  // disable the shell precache. The extra segment is what prevents that.
+  assert.notEqual(PUSH_SW_SCOPE, SHELL_MANIFEST_SCOPE)
+})
+
+test('the subscription is created on the push worker and sent to the server',
+  async () => {
+    const container = fakeContainer()
+    const push = fakePush()
+
+    await subscribeToPush({ container, push })
+
+    assert.equal(container.pushWorker.subscribeOptions.userVisibleOnly, true)
+    assert.deepEqual(push.sent, [{
+      endpoint: PUSH_ENDPOINT,
+      keys: { p256dh: 'p', auth: 'a' },
+    }])
+  })
+
+test('subscribing waits for a freshly installed worker to activate',
+  async () => {
+    // register() resolves while the worker is still installing, and
+    // pushManager.subscribe() needs an active one.
+    const container = fakeContainer({ installing: true })
+    const worker = container.pushWorker.installing
+    const push = fakePush()
+
+    const done = subscribeToPush({ container, push })
+    await Promise.resolve()
+    assert.deepEqual(push.sent, [], 'does not subscribe while installing')
+
+    container.pushWorker.active = {}
+    worker.settle('activated')
+    await done
+
+    assert.equal(push.sent.length, 1)
+    assert.deepEqual(worker.listeners, [], 'the statechange listener is released')
+  })
+
+test('a failed install settles instead of hanging forever', async () => {
+  const container = fakeContainer({ installing: true })
+  const worker = container.pushWorker.installing
+
+  const done = subscribeToPush({ container, push: fakePush() })
+  await Promise.resolve()
+  worker.settle('redundant')
+
+  // No active worker, so subscribe() rejects — the caller's catch surfaces it.
+  // The point is that this resolves at all rather than stranding the promise.
+  await assert.rejects(done)
+})
+
+test('a subscription left on the caching worker is retired', async () => {
+  // sw.js no longer handles `push`, so a send to its endpoint would trip the
+  // browser's userVisibleOnly fallback ("site updated in the background").
+  const stale = fakeSubscription(LEGACY_ENDPOINT)
+  const container = fakeContainer({ legacy: stale })
+  const push = fakePush()
+
+  await subscribeToPush({ container, push })
+
+  assert.deepEqual(push.removed, [{ endpoint: LEGACY_ENDPOINT }])
+  assert.equal(stale.unsubscribed, true)
+})
+
+test('only the enumerated legacy scopes are retired', async () => {
+  // Retirement is an allowlist: a future standalone mini-app push worker must
+  // not be unsubscribed just because it is not the shell's.
+  const container = fakeContainer({ legacy: 'missing' })
+  const push = fakePush()
+  const seen = []
+  const getRegistration = container.getRegistration
+  container.getRegistration = async (scope) => {
+    seen.push(scope)
+    return getRegistration(scope)
+  }
+
+  await subscribeToPush({ container, push })
+
+  assert.deepEqual(seen, ['/'])
+  assert.deepEqual(push.removed, [])
+})
+
+test('an unusable legacy pushManager is skipped, not fatal', async () => {
+  const container = fakeContainer({ legacy: 'throws' })
+  const push = fakePush()
+
+  await subscribeToPush({ container, push })
+
+  assert.deepEqual(push.removed, [])
+  assert.equal(push.sent.length, 1, 'the new subscription still lands')
+})

--- a/frontend/src/lib/__tests__/swNotificationTarget.test.js
+++ b/frontend/src/lib/__tests__/swNotificationTarget.test.js
@@ -3,17 +3,19 @@ import { readFileSync } from 'node:fs'
 import { test } from 'node:test'
 
 const SOURCE = readFileSync(
-  new URL('../../sw.js', import.meta.url),
+  new URL('../../../public/sw-push.js', import.meta.url),
   'utf8',
 )
 
 // _safeTarget is the notification-click allowlist: it normalizes whatever a
 // notification carried in `data.target` down to a shell route we are willing
-// to open. Extract it from source (same approach as the denylist test) rather
-// than importing sw.js, which needs a ServiceWorkerGlobalScope.
+// to open. It lives in the push worker (public/sw-push.js), which owns push
+// and notificationclick. Extract it from source (same approach as the denylist
+// test) rather than importing the worker, which needs a
+// ServiceWorkerGlobalScope.
 function loadSafeTarget() {
   const start = SOURCE.indexOf('function _safeTarget(raw) {')
-  assert.ok(start !== -1, '_safeTarget exists in sw.js')
+  assert.ok(start !== -1, '_safeTarget exists in sw-push.js')
   let depth = 0
   let end = -1
   for (let i = SOURCE.indexOf('{', start); i < SOURCE.length; i += 1) {

--- a/frontend/src/lib/notificationTarget.js
+++ b/frontend/src/lib/notificationTarget.js
@@ -4,10 +4,11 @@
 // (POST /api/notifications/send), and the backend does not validate `target`,
 // so every consumer must treat it as hostile input. This parser is consumed by
 // BOTH the NotificationsView row click and Shell's warm-tap notification-click
-// handler, so the two can never drift; sw.js keeps its own `_safeTarget` copy
-// (separate bundle) with the same posture. Never navigate a raw target.
+// handler, so the two can never drift; the push worker keeps its own
+// `_safeTarget` copy (public/sw-push.js is served unbundled and cannot import
+// this) with the same posture. Never navigate a raw target.
 //
-// Posture mirrors sw.js::_safeTarget: same-origin only for absolute URLs,
+// Posture mirrors sw-push.js::_safeTarget: same-origin only for absolute URLs,
 // known in-scope forms only, conservative id charsets, and FAIL CLOSED — any
 // unrecognized or malformed target parses to null (a no-op for the caller),
 // never to a best-effort navigation.

--- a/frontend/src/lib/pushSubscription.js
+++ b/frontend/src/lib/pushSubscription.js
@@ -1,0 +1,104 @@
+import { api } from '../api/client.js'
+
+/**
+ * Web Push subscription lifecycle, kept out of React so it can be exercised
+ * directly. `public/sw-push.js` explains why push has its own worker and why
+ * its scope has to look the way it does.
+ */
+export const PUSH_SW_SCOPE = '/shell/push/'
+const PUSH_SW_URL = '/sw-push.js'
+
+// Scopes an earlier release subscribed on. This is an ALLOWLIST on purpose:
+// "retire every registration that isn't ours" would silently unsubscribe a
+// standalone mini-app's own push worker the moment those exist, and the loss
+// is invisible until a notification fails to arrive on someone's phone.
+// Removable once no install can still be running the pre-/shell/push/ shell.
+const LEGACY_PUSH_SCOPES = ['/']
+
+/** Register the push worker and resolve once it has an active worker. */
+async function activatePushWorker(container) {
+  const registration = await container.register(
+    PUSH_SW_URL, { scope: PUSH_SW_SCOPE },
+  )
+  if (registration.active) return registration
+  const worker = registration.installing
+  if (!worker) return registration
+  // register() resolves while the worker is still installing, and
+  // pushManager.subscribe() needs an active one. `redundant` resolves too, so
+  // a failed install surfaces as a subscribe error instead of hanging here
+  // forever on a promise nobody can settle.
+  await new Promise((resolve) => {
+    const onChange = () => {
+      if (worker.state === 'activated' || worker.state === 'redundant') {
+        worker.removeEventListener('statechange', onChange)
+        resolve()
+      }
+    }
+    worker.addEventListener('statechange', onChange)
+  })
+  return registration
+}
+
+/**
+ * Retire a subscription an older release left on the caching worker.
+ *
+ * That worker no longer handles `push`, so a send to its endpoint would trip
+ * the browser's userVisibleOnly fallback and show a generic "site updated in
+ * the background" notification. Drop it server-side first, then locally, so a
+ * failure can't strand an endpoint in the database still receiving sends. The
+ * registration itself is left alone — it is the shell's cache.
+ */
+async function retireLegacySubscriptions(container, push) {
+  for (const scope of LEGACY_PUSH_SCOPES) {
+    const registration = await container.getRegistration(scope)
+    if (!registration) continue
+    let stale
+    try {
+      stale = await registration.pushManager.getSubscription()
+    } catch {
+      continue // No push support here, or the permission was revoked.
+    }
+    if (!stale) continue
+    await push.unsubscribe({ endpoint: stale.endpoint })
+    await stale.unsubscribe()
+  }
+}
+
+/** base64url VAPID key → the Uint8Array `subscribe()` wants. */
+function applicationServerKey(publicKey) {
+  const padding = '='.repeat((4 - publicKey.length % 4) % 4)
+  const raw = atob(publicKey.replace(/-/g, '+').replace(/_/g, '/') + padding)
+  const key = new Uint8Array(raw.length)
+  for (let i = 0; i < raw.length; i++) key[i] = raw.charCodeAt(i)
+  return key
+}
+
+/**
+ * Subscribe this browser to Web Push and hand the subscription to the server.
+ * Safe to call on every session — subscriptions rotate, and the browser only
+ * prompts for permission once.
+ */
+export async function subscribeToPush({
+  container = navigator.serviceWorker,
+  push = api.push,
+} = {}) {
+  // Independent: the worker's first install is a real fetch, and holding the
+  // key request behind it costs a round trip on every fresh install.
+  const [registration, res] = await Promise.all([
+    activatePushWorker(container),
+    push.vapidKey(),
+  ])
+  if (!res.ok) return
+
+  const { publicKey } = await res.json()
+  const subscription = await registration.pushManager.subscribe({
+    userVisibleOnly: true,
+    applicationServerKey: applicationServerKey(publicKey),
+  })
+
+  const { endpoint, keys } = subscription.toJSON()
+  await push.subscribe({ endpoint, keys })
+
+  // Only once the replacement is registered server-side.
+  await retireLegacySubscriptions(container, push)
+}

--- a/frontend/src/lib/swNavigationPolicy.js
+++ b/frontend/src/lib/swNavigationPolicy.js
@@ -9,6 +9,11 @@ const SHELL_NAVIGATION_DENYLIST = [
   /^\/apps\//,
   /^\/recover(\/|$)/,
   /^\/shell\/embed(\/|$)/,
+  // The push worker's scope (public/sw-push.js). It names a URL prefix inside
+  // the shell's PWA scope and must never resolve to a document: a page there
+  // would be controlled by that worker, which has no fetch handler, so it
+  // would boot the shell with no precache and no offline fallback.
+  /^\/shell\/push(\/|$)/,
   /^\/sites(\/|$)/,
   /^\/services(\/|$)/,
   ...PROXIED_APP_SUBTREES,

--- a/frontend/src/sw.js
+++ b/frontend/src/sw.js
@@ -11,8 +11,6 @@
  *     (immutable bundled libs), `esm.sh/*` (versioned remote
  *     deps), and `/api/proxy?url=*.{img|font|...}` (cacheable
  *     static assets via the CORS-bypass proxy).
- *   - Web Push handlers (push, notificationclick). These are
- *     domain-specific behavior that doesn't fit a Workbox recipe.
  *
  * Caching model for `/api/apps/{id}/{frame,module}` (ALL installed apps):
  *   - These ARE cached, by `appCodeHandler`, for EVERY installed app — loading
@@ -778,134 +776,7 @@ self.addEventListener('message', (event) => {
   if (event && typeof event.waitUntil === 'function') event.waitUntil(work)
 })
 
-// ── Web Push ────────────────────────────────────────────────────
-//
-// Pure-domain behavior — Workbox has no stock recipe for these,
-// so we own them verbatim. Keep complete; an earlier truncation
-// of this file failed `node --check` and silently disabled the
-// SW for installed PWAs (no push, no offline cache).
-
-self.addEventListener('push', (e) => {
-  if (!e.data) return
-  const data = e.data.json()
-  const options = {
-    body: data.body || '',
-    icon: data.icon || '/icons/icon-192.png',
-    badge: '/icons/icon-192.png',
-    data: { target: data.target || '/', actions: data.actions },
-    actions: (data.actions || []).slice(0, 2).map(a => ({
-      action: a.action,
-      title: a.title,
-    })),
-  }
-  e.waitUntil(self.registration.showNotification(data.title, options))
-})
-
-// Whitelist notification targets to same-origin chat/app paths so a
-// malicious payload (server compromise, MITM of an unencrypted push)
-// can't steer openWindow() or postMessage to an arbitrary URL.
-//
-// COLD-START SCOPE: the canonical target is `/shell/?app=<id>` (and
-// `/shell/?chat=<id>`), which is INSIDE the PWA manifest scope (`/shell/`).
-// A cold tap (app closed/backgrounded) does `clients.openWindow(target)`;
-// only a target inside scope reopens the installed standalone PWA — an
-// out-of-scope form opens a plain browser tab instead. The retired
-// `/app/<id>` and `/chat/<id>` legacy forms are no longer accepted (the last
-// one on prod predates this by weeks); they now fall through to root. We
-// preserve the query string so the page-side parser (Shell onSwMessage,
-// useNavigation deepLink) can read `?app=`/`?chat=`.
-function _safeTarget(raw) {
-  if (typeof raw !== 'string' || !raw) return '/'
-  let path = raw
-  let search = ''
-  try {
-    if (/^https?:\/\//i.test(raw)) {
-      const u = new URL(raw)
-      if (u.origin !== self.location.origin) return '/'
-      path = u.pathname
-      search = u.search
-    } else {
-      const q = raw.indexOf('?')
-      if (q !== -1) {
-        path = raw.slice(0, q)
-        search = raw.slice(q)
-      }
-    }
-  } catch { return '/' }
-  // In-scope shell deep-link: /shell/ or /shell with an ?app=/?chat= query.
-  if (/^\/shell\/?$/.test(path)) {
-    try {
-      const params = new URLSearchParams(search)
-      const app = params.get('app')
-      const chat = params.get('chat')
-      // An app deep-link may carry a one-shot intent naming WHICH item to
-      // open (e.g. `artifact:tip-calculator-7f3a`). Dropping it here landed
-      // the tap on the app's index instead of the item the notification was
-      // about. Same conservative charset as the ids, plus the ':' and '.'
-      // that namespace an intent's target.
-      const intent = params.get('intent')
-      if (app && /^[A-Za-z0-9_-]+$/.test(app)) {
-        return (intent && /^[A-Za-z0-9_.:-]{1,128}$/.test(intent))
-          ? `/shell/?app=${app}&intent=${encodeURIComponent(intent)}`
-          : `/shell/?app=${app}`
-      }
-      if (chat && /^[A-Za-z0-9_-]+$/.test(chat)) return `/shell/?chat=${chat}`
-    } catch { /* fall through */ }
-    return '/shell/'
-  }
-  // Root is the only remaining out-of-scope target we accept; every other
-  // form (including the retired /app/<id> and /chat/<id> notification
-  // targets) falls through to root.
-  if (path === '/') return path
-  return '/'
-}
-
-self.addEventListener('notificationclick', (e) => {
-  e.notification.close()
-  const data = e.notification.data || {}
-  let target = data.target || '/'
-
-  if (e.action && data.actions) {
-    const match = data.actions.find(a => a.action === e.action)
-    if (match && match.target) target = match.target
-  }
-  target = _safeTarget(target)
-
-  e.waitUntil((async () => {
-    const windowClients = await clients.matchAll({
-      type: 'window',
-      includeUncontrolled: true,
-    })
-    const focusable = windowClients.filter(c => 'focus' in c)
-    // Prefer a client the user is currently looking at — focusing a
-    // hidden/background tab would steer the message away from the
-    // window they're actually using. Fall back to the first match
-    // if nothing is visible.
-    const visible = focusable.find(c => c.visibilityState === 'visible')
-    const target_client = visible || focusable[0]
-    if (target_client) {
-      // For shell deep-links, navigate the existing client instead of only
-      // postMessaging it. The message path is fast when the current Shell
-      // listener is alive, but installed PWAs can have a stale/booting page
-      // after a service-worker update; navigation gives the browser a durable
-      // URL to load so actions like "Open Klix" don't focus Mobius and then
-      // appear to do nothing.
-      if (/^\/shell\/?\?/.test(target) && 'navigate' in target_client) {
-        try {
-          const navigated = await target_client.navigate(target)
-          await (navigated || target_client).focus()
-          return
-        } catch {
-          // Fall back to focus + postMessage below.
-        }
-      }
-      // Focus BEFORE postMessage so the message lands on the window
-      // the user will end up on. If focus moves the active document
-      // mid-handler, postMessage on the un-focused one can race.
-      await target_client.focus()
-      target_client.postMessage({ type: 'notification-click', target })
-      return
-    }
-    if (clients.openWindow) return clients.openWindow(target)
-  })())
-})
+// Web Push is handled by `public/sw-push.js`, registered at `/shell/push/` so
+// Android routes notifications to the installed shell. Do not add a `push` or
+// `notificationclick` listener here — this worker's `/` scope is outside the
+// shell's PWA scope, which is the bug that moved them out.

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -61,9 +61,9 @@ function stampFrameRev() {
 }
 
 // Service-worker integration uses `injectManifest` rather than the
-// `generateSW` shortcut: the SW source at `src/sw.js` still has
-// hand-written push + notification-click handlers that don't fit
-// Workbox's stock recipes, so we keep ownership of the SW and let
+// `generateSW` shortcut: the SW source at `src/sw.js` has hand-written
+// routing and offline behaviour that doesn't fit Workbox's stock
+// recipes, so we keep ownership of the SW and let
 // the plugin only INJECT the precache manifest (`self.__WB_MANIFEST`)
 // into it. That replaces the previous hand-edited `VERSION = 'vN'`
 // constant with build-content-hashed cache names — every Vite
@@ -103,7 +103,13 @@ export default defineConfig({
         // rewritten to the active --bg, so precaching it would freeze gesture/
         // system-UI color hints to whatever theme existed at build time.
         globPatterns: ['**/*.{js,css,html,svg,png,ico,webmanifest}'],
-        globIgnores: ['vendor/**', 'app-frame.html', 'manifest.webmanifest'],
+        // `sw-push.js` is itself a service worker (see public/sw-push.js).
+        // Precaching a worker script would let the shell SW serve a cached
+        // copy back to the browser's update check, freezing push behaviour at
+        // whatever shipped first.
+        globIgnores: [
+          'vendor/**', 'app-frame.html', 'manifest.webmanifest', 'sw-push.js',
+        ],
         // ROOT FIX for stale installed PWAs: give EVERY precache
         // entry a real content-hash revision.
         //

--- a/tests/sw-pwa.spec.mjs
+++ b/tests/sw-pwa.spec.mjs
@@ -7,7 +7,8 @@
  *     content-hashed shell assets (no manual VERSION bump).
  *   - Workbox routing rules cover `/vendor/*`, `esm.sh/*`, and
  *     `/api/proxy?url=*.{img/font}` (SWR).
- *   - Push + notificationclick handlers are present in the built SW.
+ *   - Push + notificationclick handlers are present in the built push
+ *     worker, and its scope stays inside the PWA manifest scope.
  *
  * What this test guards against: any future refactor that
  * accidentally drops precache injection or runtime caching, or
@@ -40,11 +41,45 @@ test.describe('Service worker — vite-plugin-pwa contract', () => {
     // SW. Without precacheAndRoute, the migration is incomplete.
     expect(body).toContain('precache')
     expect(body).toMatch(/mobius-vendor|mobius-esm|mobius-proxy/)
-    expect(body).toContain('notificationclick')
-    expect(body).toContain('notification-click')
-    expect(body).toContain('postMessage')
-    expect(body).toMatch(/\.navigate\(/)
+    // Push deliberately does NOT live here — see the push-worker test below.
+    expect(body).not.toContain('notificationclick')
   })
+
+  test('the push worker owns notification handling, inside the PWA scope',
+    async ({ page }) => {
+      // Android hands a push to the installed shell only when the SERVICE
+      // WORKER'S SCOPE resolves to that WebAPK, and a WebAPK's intent filter
+      // carries the manifest `scope` as its pathPrefix. The caching worker is
+      // registered at `/` so it can also serve the standalone mini-app pages,
+      // which puts it outside `/shell/` — so push lives on its own worker.
+      // Get this wrong and every notification becomes a Chrome notification
+      // whose tap leaves the app, which nothing else in CI can see.
+      const res = await page.request.get(`${BASE}/sw-push.js`)
+      expect(res.status()).toBe(200)
+      const body = await res.text()
+      expect(body).toContain('notificationclick')
+      expect(body).toContain('notification-click')
+      expect(body).toContain('postMessage')
+      expect(body).toMatch(/\.navigate\(/)
+
+      const manifest = JSON.parse(
+        await (await page.request.get(`${BASE}/manifest.webmanifest`)).text(),
+      )
+      await page.goto(BASE, { waitUntil: 'domcontentloaded' })
+      const scope = await page.evaluate(async () => {
+        const reg = await navigator.serviceWorker.register(
+          '/sw-push.js', { scope: '/shell/push/' },
+        )
+        return reg.scope
+      })
+      expect(new URL(scope).pathname.startsWith(manifest.scope)).toBe(true)
+
+      // The scope must hold no documents: a page there would be controlled by
+      // this worker, which has no fetch handler, so it would boot the shell
+      // with no precache and no offline fallback.
+      const doc = await page.request.get(`${BASE}/shell/push/`)
+      expect(doc.status()).toBe(404)
+    })
 
   test('manifest is reachable', async ({ page }) => {
     const res = await page.request.get(`${BASE}/manifest.webmanifest`)


### PR DESCRIPTION
## The bug

On Android, tapping any Möbius push notification opens **Chrome**, not the
installed Möbius app — even though the notification target is a perfectly valid
in-scope `/shell/?app=<id>` deep link.

## Why

Chrome decides which installed app receives a web push by resolving the
**service worker's scope URL** against the intent filters of installed WebAPKs:

- `NotificationPlatformBridge.getWebApkPackage(scopeUrl)` →
  `WebApkValidator.queryFirstWebApkPackage(context, scopeUrl)`
- a WebAPK's intent filter carries its manifest `scope` as an Android
  `pathPrefix`
- on a match, Chrome hands display to the WebAPK (`WebApkServiceClient`) and
  bakes the package into the click `PendingIntent`, so a tap launches that app
- on no match, Chrome displays and owns the notification, and a tap opens Chrome

Möbius's shell is installed with `scope: "/shell/"`, but `sw.js` is registered
at `/` — it also has to serve the standalone mini-app pages under
`/apps/<slug>/`, which are separate PWAs on the same origin. `/` is not inside
`/shell/`, so **no WebAPK ever matched** and every notification was a plain
Chrome site notification.

The mismatch dates from the move of the shell to `/shell/` (which narrowed the
manifest scope so sub-app install prompts could fire) — the worker registration
was deliberately left untouched in that change, and the notification
consequence was not visible at the time.

Nothing about this reproduces on desktop or in a headless run: it needs an
installed WebAPK on a real device.

## The fix

Move `push` and `notificationclick` to a dedicated worker registered at
`/shell/push/`.

- **inside** the shell's manifest scope, so Chrome matches the WebAPK
- **holds no documents**, so it controls zero pages

The second property is load-bearing. Registering at `/shell/` itself would be a
narrower match than the `/` registration for the shell's own pages, take control
of them, and silently disable the shell precache and offline behaviour. The
extra path segment keeps the caching worker in charge of everything it serves
today.

Alternatives considered and rejected:

- **Widen the shell manifest scope back to `/`.** Fixes routing, but Chromium
  suppresses the install prompt for any URL inside an installed PWA's scope, so
  every `/apps/<slug>/` page would lose its own install prompt — exactly what
  the `/shell/` narrowing existed to enable.
- **Re-scope `sw.js` to `/shell/` and give standalone app pages their own
  worker.** Architecturally tidier, but it rewrites the caching topology (new
  precache cache name, one-time full re-download, per-app registrations) for a
  bug that does not require touching caching at all. Left as possible follow-up
  — the same `/apps/<slug>/push/` pattern would fix notifications for standalone
  mini-app PWAs when those grow their own push.

## Also in this change

- Subscription lifecycle moves out of the React hook into
  `lib/pushSubscription.js` so it can be exercised directly; the hook is now
  just the React adapter.
- A subscription left on the caching worker by an earlier release is retired
  (server-side first, then locally). That worker no longer handles `push`, so a
  send to its endpoint would otherwise trip the browser's `userVisibleOnly`
  fallback and show a generic "site updated in the background" notification.
- `sw-push.js` is excluded from the Workbox precache — a precached worker script
  can never be updated.
- `main.py` gives both worker scripts one delivery contract (reserved top-level
  name, 404 rather than SPA HTML on a miss, revalidating full-body response),
  replacing two adjacent `if path == "sw.js"` branches.
- ESLint now covers `public/sw-push.js`; it is hand-written source that happens
  to ship unbundled.

## Testing

- New behavioural coverage for the subscription flow: registration scope sits
  inside the shell PWA scope, the subscription is created on the push worker and
  never on the caching worker, a legacy subscription is retired, the fresh one
  is not, and a registration without push support is skipped rather than fatal.
- `swNotificationTarget.test.js` follows `_safeTarget` to its new home; the
  allowlist itself is unchanged.
- Verified in a real browser that both workers register and activate at `/` and
  `/shell/push/`, that the shell page is still controlled by `sw.js`, and that
  the precache cache name is unchanged (no re-download).
- Frontend unit tests, lint, and build pass; backend static-serving, push, and
  notification suites pass on this base.

The Android tap itself is device-only and cannot be exercised in CI.