### PR TITLE
Require a trusted build for incomplete recovery bootstrap

### DIFF
--- a/.github/workflows/compatibility-bootstrap.yml
+++ b/.github/workflows/compatibility-bootstrap.yml
@@ -168,6 +168,7 @@ jobs:
               --previous-sha "$COMPATIBILITY_PREVIOUS_SHA" \
               --previous-digest "$COMPATIBILITY_PREVIOUS_DIGEST" \
               --selected-digest "$IMAGE_DIGEST" \
+              --initial-main-digest "${{ steps.existing.outputs.initial_main_digest }}" \
               --tag "$tag"
             docker buildx imagetools create \
               --prefer-index=false \

--- a/backend/tests/test_compatibility_bootstrap.py
+++ b/backend/tests/test_compatibility_bootstrap.py
@@ -34,7 +34,7 @@ def classify(main, external=None, daily=None):
 
 def test_inventory_accepts_only_fresh_partial_and_complete_states():
   assert classify(PREVIOUS) == ("build", "")
-  assert classify(CURRENT) == ("reuse", CURRENT.digest)
+  assert classify(CURRENT) == ("build", "")
   assert classify(CURRENT, CURRENT) == ("reuse", CURRENT.digest)
 
 
@@ -53,6 +53,18 @@ def test_prewrite_rechecks_detect_tags_appearing_after_inventory():
   bootstrap.assert_prewrite_state(
     tag="main",
     main=PREVIOUS,
+    external=None,
+    daily=None,
+    current=CURRENT,
+    previous=PREVIOUS,
+  )
+  # A lone current-revision main is untrusted metadata from an incomplete
+  # attempt. The guarded build may replace it, but it may not carry forward to
+  # external-recovery until main owns the new selected digest.
+  untrusted = bootstrap.Identity("sha256:" + "d" * 64, CURRENT_SHA)
+  bootstrap.assert_prewrite_state(
+    tag="main",
+    main=untrusted,
     external=None,
     daily=None,
     current=CURRENT,

--- a/backend/tests/test_compatibility_bootstrap.py
+++ b/backend/tests/test_compatibility_bootstrap.py
@@ -57,6 +57,7 @@ def test_prewrite_rechecks_detect_tags_appearing_after_inventory():
     daily=None,
     current=CURRENT,
     previous=PREVIOUS,
+    initial_main=PREVIOUS,
   )
   # A lone current-revision main is untrusted metadata from an incomplete
   # attempt. The guarded build may replace it, but it may not carry forward to
@@ -69,7 +70,19 @@ def test_prewrite_rechecks_detect_tags_appearing_after_inventory():
     daily=None,
     current=CURRENT,
     previous=PREVIOUS,
+    initial_main=untrusted,
   )
+  swapped = bootstrap.Identity("sha256:" + "e" * 64, CURRENT_SHA)
+  with pytest.raises(bootstrap.StateError):
+    bootstrap.assert_prewrite_state(
+      tag="main",
+      main=swapped,
+      external=None,
+      daily=None,
+      current=CURRENT,
+      previous=PREVIOUS,
+      initial_main=untrusted,
+    )
   with pytest.raises(bootstrap.StateError):
     bootstrap.assert_prewrite_state(
       tag="main",
@@ -78,6 +91,7 @@ def test_prewrite_rechecks_detect_tags_appearing_after_inventory():
       daily=None,
       current=CURRENT,
       previous=PREVIOUS,
+      initial_main=PREVIOUS,
     )
   with pytest.raises(bootstrap.StateError):
     bootstrap.assert_prewrite_state(
@@ -87,6 +101,7 @@ def test_prewrite_rechecks_detect_tags_appearing_after_inventory():
       daily=None,
       current=CURRENT,
       previous=PREVIOUS,
+      initial_main=PREVIOUS,
     )
 
 

--- a/scripts/compatibility_bootstrap.py
+++ b/scripts/compatibility_bootstrap.py
@@ -94,7 +94,12 @@ def classify_inventory(
   current_sha: str,
   previous: Identity,
 ) -> tuple[str, str]:
-  """Accept exactly S0 (fresh), S1 (main moved), or S2 (complete)."""
+  """Build from incomplete state; reuse only two matching established tags.
+
+  A revision label is descriptive metadata, not provenance. In particular, a
+  current-revision :main without :external-recovery must be replaced by an
+  image built in this guarded workflow rather than trusted as a resume point.
+  """
 
   validate_identity(main)
   validate_identity(previous)
@@ -111,7 +116,7 @@ def classify_inventory(
   if main.revision != current_sha:
     raise StateError("the public :main compatibility floor changed unexpectedly")
   if external is None:
-    return "reuse", main.digest
+    return "build", ""
   if external != main:
     raise StateError("partial bootstrap channels disagree on their exact identity")
   return "reuse", main.digest
@@ -129,7 +134,11 @@ def assert_prewrite_state(
   if daily is not None:
     raise StateError(":daily appeared during compatibility publication")
   if tag == "main":
-    if main not in {previous, current}:
+    # An incomplete prior attempt may have moved :main to an image that merely
+    # claims the current revision. It is not trusted; this run replaces it with
+    # its freshly built digest. Complete state is reused during inventory and
+    # never reaches this prewrite branch.
+    if main not in {previous, current} and main.revision != current.revision:
       raise StateError(":main changed after the initial inventory")
     if external not in {None, current}:
       raise StateError(":external-recovery changed after the initial inventory")

--- a/scripts/compatibility_bootstrap.py
+++ b/scripts/compatibility_bootstrap.py
@@ -130,15 +130,17 @@ def assert_prewrite_state(
   daily: Identity | None,
   current: Identity,
   previous: Identity,
+  initial_main: Identity,
 ) -> None:
   if daily is not None:
     raise StateError(":daily appeared during compatibility publication")
   if tag == "main":
     # An incomplete prior attempt may have moved :main to an image that merely
-    # claims the current revision. It is not trusted; this run replaces it with
-    # its freshly built digest. Complete state is reused during inventory and
-    # never reaches this prewrite branch.
-    if main not in {previous, current} and main.revision != current.revision:
+    # claims the current revision. This run may replace only the exact digest
+    # it inventoried; accepting any same-revision image here would reopen a
+    # race with a concurrent registry writer. Complete state is reused during
+    # inventory and never reaches this prewrite branch.
+    if main not in {previous, current, initial_main}:
       raise StateError(":main changed after the initial inventory")
     if external not in {None, current}:
       raise StateError(":external-recovery changed after the initial inventory")
@@ -187,6 +189,7 @@ def build_parser() -> argparse.ArgumentParser:
   parser.add_argument("--previous-sha", required=True)
   parser.add_argument("--previous-digest", required=True)
   parser.add_argument("--selected-digest", default="")
+  parser.add_argument("--initial-main-digest", default="")
   parser.add_argument("--tag", choices=("main", "external-recovery"))
   parser.add_argument("--output")
   return parser
@@ -209,7 +212,11 @@ def main(argv: list[str] | None = None) -> int:
       current_sha=args.current_sha,
       previous=previous,
     )
-    _write_outputs(args.output, {"mode": mode, "digest": digest})
+    _write_outputs(args.output, {
+      "mode": mode,
+      "digest": digest,
+      "initial_main_digest": live_main.digest,
+    })
     return 0
 
   if not DIGEST_RE.fullmatch(args.selected_digest):
@@ -218,6 +225,9 @@ def main(argv: list[str] | None = None) -> int:
   if args.command == "prewrite":
     if not args.tag:
       raise StateError("prewrite tag is required")
+    if not DIGEST_RE.fullmatch(args.initial_main_digest):
+      raise StateError("invalid initial main digest")
+    initial_main = Identity(args.initial_main_digest, live_main.revision)
     assert_prewrite_state(
       tag=args.tag,
       main=live_main,
@@ -225,6 +235,7 @@ def main(argv: list[str] | None = None) -> int:
       daily=live_daily,
       current=current,
       previous=previous,
+      initial_main=initial_main,
     )
     return 0
 


### PR DESCRIPTION
## Summary
- rebuild the compatibility image whenever `:external-recovery` is still absent
- reuse an existing digest only after both controlled tags already agree exactly
- allow the guarded build to replace an untrusted lone `:main` image that merely claims the current revision

## Why
PR #485 treated `org.opencontainers.image.revision` on a lone `:main` image as sufficient crash-resume provenance. Registry metadata is self-declared, so a package writer could publish an arbitrary digest carrying the expected label and have the bootstrap promote it into the recovery channel. An incomplete state now always goes through this workflow's own build; only the already-complete, exact two-tag state is reusable.

## Verification
- `tests/test_compatibility_bootstrap.py`
- `tests/test_verify_test_runtime.py`
- Ruff and Python compile checks