### PR TITLE
Use one durable migration ledger

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -4,6 +4,42 @@ Compatibility code is allowed when it protects owner data or a real external
 contract. Temporary rollout shims need an owner and an observable exit proof;
 “one release” is not a permanent architecture.
 
+## Upgrade floor
+
+Möbius is continuously deployed from git — there are no numbered releases — so
+the supported-upgrade window is a **rolling date**, not a version.
+
+> **A self-hosted owner may upgrade directly from any commit landed in the last
+> 90 days.** An install older than that must update through an intermediate
+> checkout rather than jumping to HEAD.
+
+This is the number that makes removals mechanical instead of a judgement call:
+
+- A compatibility path may be deleted once it has been **superseded for 90 days
+  AND** its exit proof in the table below holds. Both conditions, not either.
+- Before that date, deleting it is a regression for a supported upgrade, no
+  matter how empty the current database looks. Row counts on one instance are
+  evidence about *that* instance, never about the upgrade window.
+- After that date, keeping it needs a fresh justification recorded here.
+
+“One release” is explicitly NOT the floor. Retiring the `mobius-open-tabs`
+workspace fallback after a single release stranded owners who skipped a
+version and restored an empty workspace; the 90-day window exists so that
+cannot recur.
+
+### Earliest removal dates
+
+Every active migration below was introduced in July 2026, so **none is yet
+eligible** — the correct action today is to leave all of them in place.
+
+| Path | Superseded | Earliest removal |
+| --- | --- | --- |
+| legacy platform-app migration (`bootstrap.py`, `install.py`) | 2026-07-10 | 2026-10-08 |
+| transcript `cid` backfill (`chat_writer.py`) | 2026-07-13 | 2026-10-11 |
+| `appFrameStorage.js` per-app legacy scan | 2026-07-13 | 2026-10-11 |
+| raw-bcrypt owner hash (`auth.py`) | 2026-07-21 | 2026-10-19 |
+| notification target aliases (`push.py`) | 2026-07-28 | 2026-10-26 |
+
 The July 2026 maintenance baseline retired two expired mirrors and one
 status-derived fallback:
 
@@ -21,7 +57,7 @@ status-derived fallback:
 | `chat_writer.py` transcript migration | Historical chats without stable `cid` values or bounded thinking sidecars | The versioned migration ledger records the transcript migration and production diagnostics report no unmigrated rows | Remove only the read fallbacks in the next transcript-format change after that proof; keep the migrated `legacy-*` identifiers as data |
 | `auth.py` / `routes/auth.py` | Owner password hashes written in the earlier raw-bcrypt form | A versioned migration or bounded audit proves every owner hash uses the current wrapper format | Remove raw-bcrypt verification in the following release |
 | `install.py`, `routes/apps.py`, `compiler.py` | Installed apps created before source directories, immutable bundles, capability contracts, or publication records existed | Startup migrations and an app-table audit prove no installed row lacks the current source, bundle, contract, and publication identities | Remove each fallback with the migration that establishes its corresponding non-null invariant |
-| `appFrameStorage.js` | Preferences written by the former same-origin app frame, including the narrow CubeRun and Tandem allowlists | Each affected installation records a successful copy into its scoped storage prefix | Remove per-app legacy scans after the copy marker has shipped for one release |
+| `appFrameStorage.js` | Preferences written by the former same-origin app frame, including the narrow CubeRun and Tandem allowlists | **No code-level proof exists — the "copy marker" this row used to cite was never implemented, so the condition was unsatisfiable and the scan was permanent by accident.** The upgrade floor is the proof: past the date below, no supported install can still hold unmigrated same-origin keys | Remove the per-app legacy scans, and the `LEGACY_KEYS_BY_SLUG` allowlist naming individual apps with them, on 2026-10-11 |
 | provider event translators | Saved or replayed Claude/Codex events from older SDK payload shapes | The pinned provider SDK minimum and retained replay fixtures no longer emit or contain the old shape | Remove one fallback at a time with the SDK pin bump that makes it unreachable |
 | old notification targets (`/app/:id`, `/chat/:id`) | Previously delivered push/email links outside the current `/shell/` route shape | Product policy defines an expiry longer than every notification/link retention window and access logs show no use | Remove the parser aliases after that dated window |
 

--- a/backend/app/bootstrap.py
+++ b/backend/app/bootstrap.py
@@ -114,7 +114,7 @@ async def _migrate_legacy_platform_apps(db: Session) -> None:
   migration has had its chance.
   """
   eng = db.get_bind()
-  if database.data_migration_done(eng, _LEGACY_PLATFORM_APPS_MIGRATION):
+  if database.migration_applied(eng, _LEGACY_PLATFORM_APPS_MIGRATION):
     return
   rows = (
     db.query(models.App)
@@ -148,7 +148,7 @@ async def _migrate_legacy_platform_apps(db: Session) -> None:
       # Leave the marker unset so a transient catalog/network failure retries on
       # the next boot rather than stranding a genuinely un-migrated row.
       return
-  database.record_data_migration(eng, _LEGACY_PLATFORM_APPS_MIGRATION)
+  database.record_migration(eng, _LEGACY_PLATFORM_APPS_MIGRATION)
 
 
 async def ensure_bootstrap_apps_installed(db: Session) -> None:

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1016,33 +1016,9 @@ def schema_migration_history(eng) -> list[dict]:
   ]
 
 
-def data_migration_done(eng, name: str) -> bool:
-  """True when a one-shot DATA migration has already completed.
-
-  Shares the ``schema_migrations`` ledger with ``_SCHEMA_MIGRATIONS`` because
-  both answer the same question — "has this one-shot already run?" — but data
-  migrations record through these helpers instead of that tuple: they can be
-  async and perform network I/O (fetching a catalog manifest), which the
-  synchronous engine-only ``run_migrations`` loop cannot express.
-
-  Without a durable marker a "one-shot" data migration can only infer
-  completion from the shape of the rows it finds, which silently re-arms it for
-  any row created LATER that happens to match that shape.
-  """
-  from sqlalchemy import inspect as sa_inspect, text
-
-  if "schema_migrations" not in sa_inspect(eng).get_table_names():
-    return False
-  with eng.connect() as conn:
-    return conn.execute(text(
-      "SELECT 1 FROM schema_migrations WHERE version = :version"
-    ), {"version": name}).first() is not None
-
-
-def record_data_migration(eng, name: str) -> None:
-  """Mark a one-shot data migration complete so it never re-evaluates rows."""
+def ensure_migration_ledger(eng) -> None:
+  """Create the durable one-shot ledger if it does not exist yet."""
   from sqlalchemy import text
-  from sqlalchemy.exc import IntegrityError
 
   with eng.begin() as conn:
     conn.execute(text(
@@ -1051,6 +1027,38 @@ def record_data_migration(eng, name: str) -> None:
       "applied_at TIMESTAMP NOT NULL"
       ")"
     ))
+
+
+def migration_applied(eng, version: str) -> bool:
+  """True when ``version`` has already completed on this database.
+
+  One ledger answers "has this one-shot already run?" for every kind of
+  migration. ``run_migrations`` drives the synchronous schema entries in
+  ``_SCHEMA_MIGRATIONS`` through these same primitives; migrations that cannot
+  live in that tuple — async ones, or ones doing network I/O such as fetching a
+  catalog manifest — call them directly. Same table, same question, one
+  implementation, so the ledger can never disagree with itself.
+
+  Without a durable marker a "one-shot" migration can only infer completion
+  from the shape of the rows it finds, which silently re-arms it for any row
+  created LATER that happens to match that shape.
+  """
+  from sqlalchemy import inspect as sa_inspect, text
+
+  if "schema_migrations" not in sa_inspect(eng).get_table_names():
+    return False
+  with eng.connect() as conn:
+    return conn.execute(text(
+      "SELECT 1 FROM schema_migrations WHERE version = :version"
+    ), {"version": version}).first() is not None
+
+
+def record_migration(eng, version: str) -> None:
+  """Mark ``version`` complete so it never re-evaluates rows. Idempotent."""
+  from sqlalchemy import text
+  from sqlalchemy.exc import IntegrityError
+
+  ensure_migration_ledger(eng)
   # Plain INSERT + IntegrityError rather than a dialect-specific upsert: this
   # ledger runs on both SQLite and PostgreSQL (Railway), and re-recording an
   # already-complete migration is a no-op either way.
@@ -1060,7 +1068,7 @@ def record_data_migration(eng, name: str) -> None:
         "INSERT INTO schema_migrations (version, applied_at) "
         "VALUES (:version, :applied_at)"
       ), {
-        "version": name,
+        "version": version,
         "applied_at": datetime.now(UTC).replace(tzinfo=None),
       })
   except IntegrityError:
@@ -1078,34 +1086,21 @@ def run_migrations(eng) -> None:
   Each migration remains internally idempotent so a crash before its ledger
   insert safely retries it. The ledger row is committed only after the migration
   returns successfully.
+
+  Drives the shared ledger primitives (``migration_applied`` /
+  ``record_migration``) rather than its own SQL, so a one-shot recorded here and
+  one recorded by an async caller are the same fact in the same table.
   """
-  from sqlalchemy import inspect as sa_inspect, text
+  from sqlalchemy import inspect as sa_inspect
 
   if "apps" not in sa_inspect(eng).get_table_names():
     return
-  with eng.begin() as conn:
-    conn.execute(text(
-      "CREATE TABLE IF NOT EXISTS schema_migrations ("
-      "version VARCHAR(128) PRIMARY KEY, "
-      "applied_at TIMESTAMP NOT NULL"
-      ")"
-    ))
-  applied = {
-    row["version"] for row in schema_migration_history(eng)
-  }
+  ensure_migration_ledger(eng)
   for version, migration in _SCHEMA_MIGRATIONS:
-    if version in applied:
+    if migration_applied(eng, version):
       continue
     migration(eng)
-    with eng.begin() as conn:
-      conn.execute(text(
-        "INSERT INTO schema_migrations (version, applied_at) "
-        "VALUES (:version, :applied_at)"
-      ), {
-        "version": version,
-        "applied_at": datetime.now(UTC).replace(tzinfo=None),
-      })
-    applied.add(version)
+    record_migration(eng, version)
 
 
 def get_db():


### PR DESCRIPTION
## Summary
- route schema and async data migrations through one ledger API
- remove the duplicate schema-ledger implementation
- document a rolling 90-day direct-upgrade floor and concrete removal dates for active compatibility paths
- replace an impossible legacy-storage exit proof with the supported-upgrade window

## Why
Schema and data migrations used the same table but different primitives, which allowed their semantics to drift. Compatibility cleanup also lacked a mechanical support window, leaving temporary paths effectively permanent or vulnerable to premature removal. One ledger and one dated policy make both the upgrade path and the eventual deletion path explicit.

## Verification
- `tests/test_db_migrations.py`
- `tests/test_bootstrap.py`
- Ruff and Python compilation