### PR TITLE
Keep rapid model changes selectable and ordered

### DIFF
--- a/frontend/src/components/ChatView/ChatSettingsPanel.jsx
+++ b/frontend/src/components/ChatView/ChatSettingsPanel.jsx
@@ -41,14 +41,13 @@
  * ║      persisted flag isn't refreshed mid-turn, so the messages    ║
  * ║      check engages the lock the moment a reply lands.            ║
  * ║                                                                  ║
- * ║   3. STALE-PATCH GUARD                                           ║
- * ║      `latestReqId` is a MONOTONIC counter owned by the parent    ║
- * ║      (ComposerPopover) — NOT panel-local. A panel-local ref      ║
- * ║      would reset every time the popover closes and reopens,      ║
- * ║      defeating the guard. Rapid picks (model A → model B in      ║
- * ║      quick succession) only let the latest PATCH's response      ║
- * ║      update state; older responses return 'stale' and are        ║
- * ║      dropped.                                                    ║
+ * ║   3. SERIAL, LATEST-INTENT PICKER WRITES                         ║
+ * ║      `latestReqId` and `settingsSaveTailRef` are owned by the    ║
+ * ║      parent (ComposerPopover) — NOT panel-local. Routine model   ║
+ * ║      and effort picks remain interactive while saving, allocate  ║
+ * ║      their intent id immediately, and persist in tap order. An   ║
+ * ║      older response cannot repaint over a newer optimistic pick, ║
+ * ║      and closing/reopening + cannot reset either guard.          ║
  * ║                                                                  ║
  * ║   4. KEYBOARD-STATE PRESERVATION                                 ║
  * ║      `refocusChatInput` gates on `wasInputFocusedRef?.current`   ║
@@ -253,6 +252,10 @@ export default function ChatSettingsPanel({
   // Stale-PATCH guard: parent passes a ref that survives panel
   // mount/unmount. See ComposerPopover for the rationale.
   reqIdRef,
+  // Promise tail for routine picker writes. It shares the parent's lifetime
+  // with reqIdRef so closing/reopening the + popover cannot let a newer write
+  // overtake an older request that is still settling.
+  settingsSaveTailRef,
   // Tracks whether the chat textarea was focused when the popover
   // opened. Used to decide whether to refocus after a picker
   // action so the soft keyboard stays in its previous state
@@ -267,9 +270,11 @@ export default function ChatSettingsPanel({
   const [localError, setLocalError] = useState('')
   const fallbackReqId = useRef(0)
   const latestReqId = reqIdRef || fallbackReqId
+  const fallbackSettingsSaveTail = useRef(Promise.resolve())
+  const settingsSaveTail = settingsSaveTailRef || fallbackSettingsSaveTail
   const pendingSwitchPreviousRef = useRef(null)
-  // Synchronous double-click guard: disabled={compacting || saving}
-  // only takes effect after React re-renders.
+  // Synchronous guard for the paid atomic handoff. Routine picker writes use
+  // the serialized tail and deliberately remain available while saving.
   const providerSwitchInFlightRef = useRef(false)
   const pendingSwitch = restorableProviderSwitch(
     providerSwitchState?.request,
@@ -321,6 +326,11 @@ export default function ChatSettingsPanel({
   )
 
   useEffect(() => {
+    // Successful writes are published to the parent in serialized server
+    // order, but a newer optimistic choice may still be queued. Hold the
+    // visible draft until the whole tail settles; the final success or failure
+    // then reconciles from the last value the server actually accepted.
+    if (saving) return
     setDraftModel(effective?.model || '')
     setDraftEffort(effective?.effort || '')
     setDraftEffortByProvider(effective?.effort_by_provider || {})
@@ -329,9 +339,11 @@ export default function ChatSettingsPanel({
     effective?.effort,
     effective?.effort_by_provider,
     chatId,
+    saving,
   ])
 
   useEffect(() => {
+    if (saving) return
     const sourceProvider = provider || 'claude'
     setDraftProvider(sourceProvider)
     const restored = restorableProviderSwitch(
@@ -350,38 +362,51 @@ export default function ChatSettingsPanel({
     chatId,
     providerSwitchState?.request,
     providerSwitchState?.status,
+    saving,
   ])
 
-  const patchChat = useCallback(async (body) => {
-    if (!chatId) return 'fail'
+  const patchChat = useCallback((body) => {
+    if (!chatId) return Promise.resolve('fail')
+    // Allocate freshness at PICK time, not when this operation reaches the
+    // front of the save tail. Otherwise an older response can repaint its
+    // model during the interval where a newer choice is queued but not yet
+    // dispatched.
     const reqId = ++latestReqId.current
     setSaving(true)
     setLocalError('')
-    try {
-      const res = await apiFetch(`/chats/${chatId}`, {
-        method: 'PATCH',
-        body: JSON.stringify(body),
-      })
-      if (reqId !== latestReqId.current) return 'stale'
-      if (!res.ok) {
-        setLocalError('Could not save. Try again.')
+    const persist = async () => {
+      try {
+        const res = await apiFetch(`/chats/${chatId}`, {
+          method: 'PATCH',
+          body: JSON.stringify(body),
+        })
+        if (!res.ok) {
+          if (reqId !== latestReqId.current) return 'stale'
+          setLocalError('Could not save. Try again.')
+          return 'fail'
+        }
+        const data = await res.json()
+        // Writes are serialized, so every successful response is a real
+        // durable checkpoint. Publish it in order; the draft-sync effects
+        // above defer repaint while a newer optimistic intent remains queued.
+        onChange?.({
+          agent_settings_json: data.agent_settings_json,
+          provider: data.provider,
+          effective: data.effective,
+        })
+        return reqId === latestReqId.current ? 'ok' : 'stale'
+      } catch {
+        if (reqId !== latestReqId.current) return 'stale'
+        setLocalError('Network error.')
         return 'fail'
+      } finally {
+        if (reqId === latestReqId.current) setSaving(false)
       }
-      const data = await res.json()
-      onChange?.({
-        agent_settings_json: data.agent_settings_json,
-        provider: data.provider,
-        effective: data.effective,
-      })
-      return 'ok'
-    } catch {
-      if (reqId !== latestReqId.current) return 'stale'
-      setLocalError('Network error.')
-      return 'fail'
-    } finally {
-      if (reqId === latestReqId.current) setSaving(false)
     }
-  }, [chatId, onChange, latestReqId])
+    const operation = settingsSaveTail.current.then(persist)
+    settingsSaveTail.current = operation
+    return operation
+  }, [chatId, onChange, latestReqId, settingsSaveTail])
 
   const switchProviderWithHandoff = useCallback(async ({
     provider: nextProvider,
@@ -402,6 +427,10 @@ export default function ChatSettingsPanel({
     beginProviderSwitch(chatId, request)
     setLocalError('')
     try {
+      // A same-provider choice made just before this confirmation is part of
+      // the source chat state the handoff follows. Wait for that routine write
+      // even if + was closed/reopened while it settled.
+      await settingsSaveTail.current
       const res = await apiFetch(`/chats/${chatId}/provider-switch`, {
         method: 'POST',
         body: JSON.stringify(providerSwitchPayload({
@@ -444,7 +473,7 @@ export default function ChatSettingsPanel({
       )
       return false
     }
-  }, [chatId, pendingSwitch, provider])
+  }, [chatId, pendingSwitch, provider, settingsSaveTail])
 
   // Conditional refocus — only restores textarea focus if it was
   // ALREADY focused when the popover opened. Without this guard,
@@ -476,11 +505,12 @@ export default function ChatSettingsPanel({
   const switchProviderModel = useCallback(async (
     value, providerValue, allowedEfforts, switchId = createProviderSwitchId(),
   ) => {
-    if (
-      providerSwitchInFlightRef.current
-      || isProviderSwitchBlocking(chatId)
-    ) return false
-    providerSwitchInFlightRef.current = true
+    if (isProviderSwitchBlocking(chatId)) return false
+    // The atomic handoff cannot overlap itself. Empty-chat provider/model
+    // PATCHes use the serialized routine-write tail above, so they remain
+    // safely pickable while an earlier choice saves.
+    if (hasAssistantTurns && providerSwitchInFlightRef.current) return false
+    if (hasAssistantTurns) providerSwitchInFlightRef.current = true
     try {
       // Cross-provider switch: restore this provider's last-known
       // effort (or fall back to the value already on screen — which
@@ -523,7 +553,7 @@ export default function ChatSettingsPanel({
       setDraftEffortByProvider(nextEffortByProvider)
       return true
     } finally {
-      providerSwitchInFlightRef.current = false
+      if (hasAssistantTurns) providerSwitchInFlightRef.current = false
     }
   }, [
     draftEffort,
@@ -536,8 +566,8 @@ export default function ChatSettingsPanel({
   const handlePickModel = useCallback(async (value, providerValue, allowedEfforts) => {
     refocusChatInput()
     if (providerValue !== draftProvider) {
-      if (providerSwitchInFlightRef.current) return
       if (hasAssistantTurns) {
+        if (providerSwitchInFlightRef.current) return
         if (!pendingSwitchPreviousRef.current) {
           pendingSwitchPreviousRef.current = {
             provider: draftProvider,
@@ -565,9 +595,6 @@ export default function ChatSettingsPanel({
     // captured prior selection too, so a later Cancel reverts to THIS choice, not
     // a stale earlier one (#7 ensemble finding).
     pendingSwitchPreviousRef.current = null
-    const prevModel = draftModel
-    const prevEffort = draftEffort
-    const prevEffortByProvider = draftEffortByProvider
     const nextEffort = validEffort(allowedEfforts, draftEffort)
     const nextEffortByProvider = {
       ...draftEffortByProvider,
@@ -576,18 +603,13 @@ export default function ChatSettingsPanel({
     setDraftModel(value)
     setDraftEffort(nextEffort)
     setDraftEffortByProvider(nextEffortByProvider)
-    const outcome = await patchChat({
+    await patchChat({
       agent_settings_json: {
         model: value,
         effort: nextEffort,
         effort_by_provider: nextEffortByProvider,
       },
     })
-    if (outcome === 'fail') {
-      setDraftModel(prevModel)
-      setDraftEffort(prevEffort)
-      setDraftEffortByProvider(prevEffortByProvider)
-    }
   }, [
     draftProvider,
     draftModel,
@@ -770,7 +792,7 @@ export default function ChatSettingsPanel({
                 onClick={() => {
                   if (!appCrossProvider) handlePickModel(m.id, pid, rowEfforts)
                 }}
-                disabled={saving || switchBusy || appCrossProvider || !providerConfigured}
+                disabled={switchBusy || appCrossProvider || !providerConfigured}
                 aria-pressed={isSelected}
                 title={appCrossProvider
                   ? 'App chats keep their original provider. Create a new app chat to use this provider.'
@@ -797,10 +819,9 @@ export default function ChatSettingsPanel({
                     efforts={rowEfforts}
                     value={draftEffort}
                     onChange={handleEffortChange}
-                    // Effort writes are optimistic and latest-request-wins, so
+                    // Routine picker writes are optimistic and serialized, so
                     // keep the shared control visually stable and available
-                    // while a save settles. Provider/model changes still lock
-                    // the picker through `saving`; a live provider switch or
+                    // while a save settles. A live provider switch or
                     // disconnected provider remains genuinely unavailable.
                     disabled={switchBusy || !providerConfigured}
                     onStopPointerDown={preserveFocusUnlessTouch}

--- a/frontend/src/components/ChatView/ChatSettingsPanel.jsx
+++ b/frontend/src/components/ChatView/ChatSettingsPanel.jsx
@@ -41,13 +41,11 @@
  * ║      persisted flag isn't refreshed mid-turn, so the messages    ║
  * ║      check engages the lock the moment a reply lands.            ║
  * ║                                                                  ║
- * ║   3. SERIAL, LATEST-INTENT PICKER WRITES                         ║
- * ║      `latestReqId` and `settingsSaveTailRef` are owned by the    ║
- * ║      parent (ComposerPopover) — NOT panel-local. Routine model   ║
- * ║      and effort picks remain interactive while saving, allocate  ║
- * ║      their intent id immediately, and persist in tap order. An   ║
- * ║      older response cannot repaint over a newer optimistic pick, ║
- * ║      and closing/reopening + cannot reset either guard.          ║
+ * ║   3. ORDERED PICKER WRITES                                      ║
+ * ║      `settingsSaveTailRef` is owned by ChatView, so model and    ║
+ * ║      effort picks persist in tap order even if this popover is   ║
+ * ║      closed. The same tail gates provider handoffs and message   ║
+ * ║      sends. Rows stay interactive while routine saves settle.    ║
  * ║                                                                  ║
  * ║   4. KEYBOARD-STATE PRESERVATION                                 ║
  * ║      `refocusChatInput` gates on `wasInputFocusedRef?.current`   ║
@@ -249,12 +247,7 @@ export default function ChatSettingsPanel({
   restartResumeError = '',
   onRestartResumeChange,
   onChange,
-  // Stale-PATCH guard: parent passes a ref that survives panel
-  // mount/unmount. See ComposerPopover for the rationale.
-  reqIdRef,
-  // Promise tail for routine picker writes. It shares the parent's lifetime
-  // with reqIdRef so closing/reopening the + popover cannot let a newer write
-  // overtake an older request that is still settling.
+  // Shared promise tail for picker writes, handoffs, and message sends.
   settingsSaveTailRef,
   // Tracks whether the chat textarea was focused when the popover
   // opened. Used to decide whether to refocus after a picker
@@ -268,10 +261,6 @@ export default function ChatSettingsPanel({
 }) {
   const [saving, setSaving] = useState(false)
   const [localError, setLocalError] = useState('')
-  const fallbackReqId = useRef(0)
-  const latestReqId = reqIdRef || fallbackReqId
-  const fallbackSettingsSaveTail = useRef(Promise.resolve())
-  const settingsSaveTail = settingsSaveTailRef || fallbackSettingsSaveTail
   const pendingSwitchPreviousRef = useRef(null)
   // Synchronous guard for the paid atomic handoff. Routine picker writes use
   // the serialized tail and deliberately remain available while saving.
@@ -366,47 +355,35 @@ export default function ChatSettingsPanel({
   ])
 
   const patchChat = useCallback((body) => {
-    if (!chatId) return Promise.resolve('fail')
-    // Allocate freshness at PICK time, not when this operation reaches the
-    // front of the save tail. Otherwise an older response can repaint its
-    // model during the interval where a newer choice is queued but not yet
-    // dispatched.
-    const reqId = ++latestReqId.current
+    if (!chatId) return Promise.resolve()
     setSaving(true)
     setLocalError('')
-    const persist = async () => {
+    const operation = settingsSaveTailRef.current.then(async () => {
       try {
         const res = await apiFetch(`/chats/${chatId}`, {
           method: 'PATCH',
           body: JSON.stringify(body),
         })
-        if (!res.ok) {
-          if (reqId !== latestReqId.current) return 'stale'
-          setLocalError('Could not save. Try again.')
-          return 'fail'
-        }
+        if (!res.ok) return 'Could not save. Try again.'
         const data = await res.json()
-        // Writes are serialized, so every successful response is a real
-        // durable checkpoint. Publish it in order; the draft-sync effects
-        // above defer repaint while a newer optimistic intent remains queued.
         onChange?.({
           agent_settings_json: data.agent_settings_json,
           provider: data.provider,
           effective: data.effective,
         })
-        return reqId === latestReqId.current ? 'ok' : 'stale'
+        return ''
       } catch {
-        if (reqId !== latestReqId.current) return 'stale'
-        setLocalError('Network error.')
-        return 'fail'
-      } finally {
-        if (reqId === latestReqId.current) setSaving(false)
+        return 'Network error.'
       }
-    }
-    const operation = settingsSaveTail.current.then(persist)
-    settingsSaveTail.current = operation
+    })
+    settingsSaveTailRef.current = operation
+    operation.then(error => {
+      if (settingsSaveTailRef.current !== operation) return
+      setLocalError(error)
+      setSaving(false)
+    })
     return operation
-  }, [chatId, onChange, latestReqId, settingsSaveTail])
+  }, [chatId, onChange, settingsSaveTailRef])
 
   const switchProviderWithHandoff = useCallback(async ({
     provider: nextProvider,
@@ -430,7 +407,7 @@ export default function ChatSettingsPanel({
       // A same-provider choice made just before this confirmation is part of
       // the source chat state the handoff follows. Wait for that routine write
       // even if + was closed/reopened while it settled.
-      await settingsSaveTail.current
+      await settingsSaveTailRef.current
       const res = await apiFetch(`/chats/${chatId}/provider-switch`, {
         method: 'POST',
         body: JSON.stringify(providerSwitchPayload({
@@ -473,7 +450,7 @@ export default function ChatSettingsPanel({
       )
       return false
     }
-  }, [chatId, pendingSwitch, provider, settingsSaveTail])
+  }, [chatId, pendingSwitch, provider, settingsSaveTailRef])
 
   // Conditional refocus — only restores textarea focus if it was
   // ALREADY focused when the popover opened. Without this guard,
@@ -506,46 +483,43 @@ export default function ChatSettingsPanel({
     value, providerValue, allowedEfforts, switchId = createProviderSwitchId(),
   ) => {
     if (isProviderSwitchBlocking(chatId)) return false
-    // The atomic handoff cannot overlap itself. Empty-chat provider/model
-    // PATCHes use the serialized routine-write tail above, so they remain
-    // safely pickable while an earlier choice saves.
-    if (hasAssistantTurns && providerSwitchInFlightRef.current) return false
-    if (hasAssistantTurns) providerSwitchInFlightRef.current = true
-    try {
-      // Cross-provider switch: restore this provider's last-known
-      // effort (or fall back to the value already on screen — which
-      // becomes that provider's first memory once they accept it).
-      // The provider/model effort enums do not overlap perfectly. Normalize
-      // the remembered value against the selected model's declared scale so
-      // the UI and persisted runner value cannot drift apart.
-      const nextEffort = validEffort(
-        allowedEfforts,
-        draftEffortByProvider[providerValue] ?? draftEffort,
-      )
-      const nextEffortByProvider = {
-        ...draftEffortByProvider,
-        [providerValue]: nextEffort,
-      }
-      let ok
-      if (hasAssistantTurns) {
-        ok = await switchProviderWithHandoff({
-          provider: providerValue,
+    // Cross-provider switch: restore this provider's last-known effort and
+    // normalize it against the selected model's declared scale.
+    const nextEffort = validEffort(
+      allowedEfforts,
+      draftEffortByProvider[providerValue] ?? draftEffort,
+    )
+    const nextEffortByProvider = {
+      ...draftEffortByProvider,
+      [providerValue]: nextEffort,
+    }
+
+    if (!hasAssistantTurns) {
+      setDraftModel(value)
+      setDraftProvider(providerValue)
+      setDraftEffort(nextEffort)
+      setDraftEffortByProvider(nextEffortByProvider)
+      patchChat({
+        provider: providerValue,
+        agent_settings_json: {
           model: value,
           effort: nextEffort,
-          effortByProvider: nextEffortByProvider,
-          switchId,
-        })
-      } else {
-        const outcome = await patchChat({
-          provider: providerValue,
-          agent_settings_json: {
-            model: value,
-            effort: nextEffort,
-            effort_by_provider: nextEffortByProvider,
-          },
-        })
-        ok = outcome === 'ok'
-      }
+          effort_by_provider: nextEffortByProvider,
+        },
+      })
+      return true
+    }
+
+    if (providerSwitchInFlightRef.current) return false
+    providerSwitchInFlightRef.current = true
+    try {
+      const ok = await switchProviderWithHandoff({
+        provider: providerValue,
+        model: value,
+        effort: nextEffort,
+        effortByProvider: nextEffortByProvider,
+        switchId,
+      })
       if (!ok) return false
       setDraftModel(value)
       setDraftProvider(providerValue)
@@ -553,7 +527,7 @@ export default function ChatSettingsPanel({
       setDraftEffortByProvider(nextEffortByProvider)
       return true
     } finally {
-      if (hasAssistantTurns) providerSwitchInFlightRef.current = false
+      providerSwitchInFlightRef.current = false
     }
   }, [
     draftEffort,
@@ -839,7 +813,7 @@ export default function ChatSettingsPanel({
                       className="csp__confirm-btn csp__confirm-btn--primary"
                       onPointerDown={preserveFocusUnlessTouch}
                       onClick={handleConfirmProviderSwitch}
-                      disabled={saving || switchBusy}
+                      disabled={switchBusy}
                     >
                       Switch provider
                     </button>

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -473,6 +473,10 @@ export default function ChatView({
   // current() to fire the bar's hidden picker. ChatInputBar's layout
   // effect installs the function.
   const attachTriggerRef = useRef(null)
+  // The model/effort picker can accept another choice before the prior save
+  // settles. Keep its serialized write tail at ChatView scope so both a closed
+  // + popover and an immediate Send still observe the same ordering boundary.
+  const settingsSaveTailRef = useRef(Promise.resolve())
   // Refs for the absolutely-positioned foot. Its ResizeObserver notifies the
   // scroll controller, which owns publishing composer clearance together with
   // every other indirect scroll-geometry write.
@@ -1947,6 +1951,11 @@ export default function ChatView({
       }
       let queueRequest = null
       try {
+        // Keep the normal synchronous submit transition (snapshot + clear the
+        // composer), but do not put the message on the wire until the last
+        // model choice is durable. The tail never rejects; a failed final pick
+        // reconciles to the last successful checkpoint before this continues.
+        await settingsSaveTailRef.current
         queueRequest = streamSend(
           text,
           attachments.length > 0 ? attachments : undefined,
@@ -2239,6 +2248,10 @@ export default function ChatView({
     }
 
     try {
+      // The optimistic row and composer clear above happen at tap time. Only
+      // transport waits, so typing begun after Send cannot be swallowed by a
+      // delayed settings round-trip.
+      await settingsSaveTailRef.current
       const result = await streamSend(
         sendText,
         attachments.length > 0 ? attachments : undefined,
@@ -3961,6 +3974,7 @@ export default function ChatView({
                 }
                 onChangeChatInfo={mergeChatInfo}
                 providerSwitchState={providerSwitchState}
+                settingsSaveTailRef={settingsSaveTailRef}
                 onOpenInspector={() => setShowInspector(true)}
                 onOpenSummary={() => setShowSummary(true)}
                 embedded={embedded}

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -1142,6 +1142,13 @@ export default function ChatView({
       fetchMessages({ force: true })
     },
   })
+  // The composer clears before this boundary, so a slow picker save delays
+  // transport without swallowing text entered after Send.
+  const sendAfterSettingsSaved = useCallback(async (text, attachments, options) => {
+    await settingsSaveTailRef.current
+    return streamSend(text, attachments, options)
+  }, [streamSend])
+
   useEffect(() => {
     if (retiredAssistantItemsRef.current !== streamItems) {
       retiredAssistantItemsRef.current = null
@@ -1951,12 +1958,7 @@ export default function ChatView({
       }
       let queueRequest = null
       try {
-        // Keep the normal synchronous submit transition (snapshot + clear the
-        // composer), but do not put the message on the wire until the last
-        // model choice is durable. The tail never rejects; a failed final pick
-        // reconciles to the last successful checkpoint before this continues.
-        await settingsSaveTailRef.current
-        queueRequest = streamSend(
+        queueRequest = sendAfterSettingsSaved(
           text,
           attachments.length > 0 ? attachments : undefined,
           directSteer
@@ -2248,11 +2250,7 @@ export default function ChatView({
     }
 
     try {
-      // The optimistic row and composer clear above happen at tap time. Only
-      // transport waits, so typing begun after Send cannot be swallowed by a
-      // delayed settings round-trip.
-      await settingsSaveTailRef.current
-      const result = await streamSend(
+      const result = await sendAfterSettingsSaved(
         sendText,
         attachments.length > 0 ? attachments : undefined,
         // The minted cid rides the POST so the durable row carries the same
@@ -2376,7 +2374,7 @@ export default function ChatView({
     // stale-closure trap for callers like handleStop).
   }, [
     chatId,
-    streamSend,
+    sendAfterSettingsSaved,
     pendingFiles,
     commitMessages,
     fetchMessages,

--- a/frontend/src/components/ChatView/ComposerPopover.jsx
+++ b/frontend/src/components/ChatView/ComposerPopover.jsx
@@ -53,10 +53,9 @@
  * ║   plugs a different platform's behaviour. Don't simplify       ║
  * ║   without re-verifying on iOS Safari AND Android Chrome.       ║
  * ║                                                                ║
- * ║   `reqIdRef` lives here and `settingsSaveTailRef` comes from   ║
- * ║   ChatView. Both outlive ChatSettingsPanel, so the newest       ║
- * ║   picker intent and serialized write order survive panel       ║
- * ║   unmount. Panel-local refs would reset between popover opens.  ║
+ * ║   `settingsSaveTailRef` comes from ChatView and outlives this  ║
+ * ║   popover. Picker writes therefore keep their order when the   ║
+ * ║   panel closes, and message sends can share the same boundary. ║
  * ║                                                                ║
  * ╚════════════════════════════════════════════════════════════════╝
  */
@@ -96,17 +95,6 @@ export default function ComposerPopover({
   const [open, setOpen] = useState(false)
   const wrapRef = useRef(null)
   const triggerRef = useRef(null)
-  // Monotonic PATCH request counter. Lives here (not in ChatSettingsPanel)
-  // because the panel unmounts on popover close; a panel-local ref would
-  // reset between opens and break the stale-response guard. See
-  // ChatSettingsPanel's `reqIdRef` prop for the rationale.
-  const reqIdRef = useRef(0)
-  // Standalone/component-test fallback. The normal shell supplies ChatView's
-  // tail so an immediate Send also waits for the last picker choice.
-  const fallbackSettingsSaveTailRef = useRef(Promise.resolve())
-  const durableSettingsSaveTailRef = (
-    settingsSaveTailRef || fallbackSettingsSaveTailRef
-  )
   // Tracks whether the chat textarea was focused at the moment the
   // popover opened. If yes, refocus after a picker action so the
   // soft keyboard stays open. If no (user tapped + with keyboard
@@ -287,8 +275,7 @@ export default function ComposerPopover({
                 onRestartResumeChange={onRestartResumeChange}
                 onChange={onChangeChatInfo}
                 providerSwitchState={providerSwitchState}
-                reqIdRef={reqIdRef}
-                settingsSaveTailRef={durableSettingsSaveTailRef}
+                settingsSaveTailRef={settingsSaveTailRef}
                 wasInputFocusedRef={wasInputFocusedRef}
               />
             </div>

--- a/frontend/src/components/ChatView/ComposerPopover.jsx
+++ b/frontend/src/components/ChatView/ComposerPopover.jsx
@@ -53,9 +53,10 @@
  * ║   plugs a different platform's behaviour. Don't simplify       ║
  * ║   without re-verifying on iOS Safari AND Android Chrome.       ║
  * ║                                                                ║
- * ║   `reqIdRef` lives in THIS file (not ChatSettingsPanel) so     ║
- * ║   the stale-PATCH monotonic counter survives panel unmount.    ║
- * ║   A panel-local ref would reset between popover opens.         ║
+ * ║   `reqIdRef` lives here and `settingsSaveTailRef` comes from   ║
+ * ║   ChatView. Both outlive ChatSettingsPanel, so the newest       ║
+ * ║   picker intent and serialized write order survive panel       ║
+ * ║   unmount. Panel-local refs would reset between popover opens.  ║
  * ║                                                                ║
  * ╚════════════════════════════════════════════════════════════════╝
  */
@@ -87,6 +88,7 @@ export default function ComposerPopover({
   restartResumeError,
   onRestartResumeChange,
   providerSwitchState,
+  settingsSaveTailRef,
   onOpenInspector,
   onOpenSummary,
   embedded = false,
@@ -99,6 +101,12 @@ export default function ComposerPopover({
   // reset between opens and break the stale-response guard. See
   // ChatSettingsPanel's `reqIdRef` prop for the rationale.
   const reqIdRef = useRef(0)
+  // Standalone/component-test fallback. The normal shell supplies ChatView's
+  // tail so an immediate Send also waits for the last picker choice.
+  const fallbackSettingsSaveTailRef = useRef(Promise.resolve())
+  const durableSettingsSaveTailRef = (
+    settingsSaveTailRef || fallbackSettingsSaveTailRef
+  )
   // Tracks whether the chat textarea was focused at the moment the
   // popover opened. If yes, refocus after a picker action so the
   // soft keyboard stays open. If no (user tapped + with keyboard
@@ -280,6 +288,7 @@ export default function ComposerPopover({
                 onChange={onChangeChatInfo}
                 providerSwitchState={providerSwitchState}
                 reqIdRef={reqIdRef}
+                settingsSaveTailRef={durableSettingsSaveTailRef}
                 wasInputFocusedRef={wasInputFocusedRef}
               />
             </div>

--- a/frontend/src/components/ChatView/__tests__/chatUiPolish.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatUiPolish.test.js
@@ -7,10 +7,6 @@ const chatCss = readFileSync(new URL('../ChatView.css', import.meta.url), 'utf8'
 const chatInputBar = readFileSync(new URL('../ChatInputBar.jsx', import.meta.url), 'utf8')
 const chatView = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8')
 const queuedMessages = readFileSync(new URL('../QueuedMessages.jsx', import.meta.url), 'utf8')
-const chatSettingsPanel = readFileSync(
-  new URL('../ChatSettingsPanel.jsx', import.meta.url),
-  'utf8',
-)
 
 function stripComments(css) {
   return css.replace(/\/\*[\s\S]*?\*\//g, '')
@@ -32,28 +28,6 @@ test('theme transition does not animate every descendant or expensive shadows', 
     'theme toggles must not install a document-wide transition')
   assert.doesNotMatch(transitionRules, /box-shadow/,
     'theme toggles should not animate box-shadow across chat surfaces')
-})
-
-test('effort choice stays interactive and fully visible while its optimistic save settles', () => {
-  const effortStepper = chatSettingsPanel.match(
-    /<EffortStepper\s+efforts=\{rowEfforts\}[\s\S]*?onStopPointerDown=\{preserveFocusUnlessTouch\}[\s\S]*?\/>/,
-  )?.[0] || ''
-
-  assert.match(
-    effortStepper,
-    /disabled=\{switchBusy \|\| !providerConfigured\}/,
-    'only a provider switch or unavailable provider should disable effort',
-  )
-  assert.doesNotMatch(
-    effortStepper,
-    /disabled=\{[^}]*saving/,
-    'a routine save must not dim the effort control into a visible blackout',
-  )
-  assert.match(
-    chatSettingsPanel,
-    /if \(reqId !== latestReqId\.current\) return 'stale'/,
-    'rapid effort choices remain safe through the existing latest-request guard',
-  )
 })
 
 test('restored chat rows and tool blocks do not replay entrance animation', () => {

--- a/tests/provider-availability.spec.mjs
+++ b/tests/provider-availability.spec.mjs
@@ -69,3 +69,95 @@ test('picker exposes configured providers without leaking unavailable registry r
     await expect(unavailableRows).toContainText('Not connected')
   }
 })
+
+test('a second model choice stays selectable while the first choice saves', async ({ page }) => {
+  const modelIdsByProvider = {
+    claude: ['claude-test-one', 'claude-test-two', 'claude-test-three'],
+    codex: ['gpt-test-one', 'gpt-test-two', 'gpt-test-three'],
+  }
+  const modelsByProvider = Object.fromEntries(
+    Object.entries(modelIdsByProvider).map(([provider, ids]) => [
+      provider,
+      ids.map((id, index) => ({
+        id,
+        label: `Test model ${index + 1}`,
+        provider,
+        available: true,
+      })),
+    ]),
+  )
+
+  await page.route(/\/api\/auth\/providers\/status$/, route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      claude: { configured: true, authenticated: true },
+      codex: { configured: true, authenticated: true },
+    }),
+  }))
+  await page.route(/\/api\/models$/, route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      providers: modelsByProvider,
+    }),
+  }))
+  await page.route(/\/api\/owner\/model-prefs$/, route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ hidden_ids: [] }),
+  }))
+
+  await page.goto(BASE, { waitUntil: 'domcontentloaded' })
+  const chat = await createTaggedChat(page, 'rapid-model-choice')
+  expect(chat?.id).toBeTruthy()
+  const provider = chat.detail?.provider || chat.provider
+  expect(['claude', 'codex']).toContain(provider)
+  const providerLabel = provider === 'claude' ? 'Claude Code' : 'OpenAI Codex'
+  const modelIds = modelIdsByProvider[provider]
+
+  let releaseFirst
+  const firstHeld = new Promise(resolve => { releaseFirst = resolve })
+  const savedModels = []
+  await page.route(new RegExp(`/api/chats/${chat.id}$`), async route => {
+    if (route.request().method() !== 'PATCH') return route.continue()
+    const body = route.request().postDataJSON()
+    const model = body.agent_settings_json?.model
+    savedModels.push(model)
+    if (savedModels.length === 1) await firstHeld
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        ok: true,
+        provider,
+        agent_settings_json: body.agent_settings_json,
+        effective: body.agent_settings_json,
+      }),
+    })
+  })
+
+  await page.goto(`${BASE}/shell/?chat=${encodeURIComponent(chat.id)}`, {
+    waitUntil: 'domcontentloaded',
+  })
+  const paintedChat = page.locator('[data-chat-surface="painted"]')
+  await expect(paintedChat.locator('.chat__form')).toBeVisible()
+  await paintedChat.getByRole('button', { name: 'Attach or change model' }).click()
+
+  const rows = page.locator('button.csp-row').filter({ hasText: providerLabel })
+  await expect(rows).toHaveCount(3)
+  const first = rows.filter({ hasText: 'Test model 1' })
+  const second = rows.filter({ hasText: 'Test model 2' })
+  try {
+    await first.click()
+    await expect.poll(() => [...savedModels]).toEqual([modelIds[0]])
+    await expect(second).toBeEnabled({ timeout: 500 })
+    await second.click()
+    await expect(second).toHaveAttribute('aria-pressed', 'true')
+  } finally {
+    releaseFirst()
+  }
+
+  await expect.poll(() => [...savedModels]).toEqual(modelIds.slice(0, 2))
+  await expect(second).toHaveAttribute('aria-pressed', 'true')
+})

--- a/tests/provider-availability.spec.mjs
+++ b/tests/provider-availability.spec.mjs
@@ -148,6 +148,11 @@ test('model and effort choices stay interactive while saves remain ordered', asy
 
     const effortGroup = page.getByRole('radiogroup', { name: 'Reasoning effort' })
     alternateEffort = effortGroup.locator('[role="radio"][aria-checked="false"]').first()
+    const alternateEffortName = await alternateEffort.getAttribute('aria-label')
+    alternateEffort = effortGroup.getByRole('radio', {
+      name: alternateEffortName,
+      exact: true,
+    })
     await expect(alternateEffort).toBeEnabled()
     await alternateEffort.click()
     await expect(alternateEffort).toHaveAttribute('aria-checked', 'true')

--- a/tests/provider-availability.spec.mjs
+++ b/tests/provider-availability.spec.mjs
@@ -114,19 +114,21 @@ test('model and effort choices stay interactive while saves remain ordered', asy
   let releaseFirst
   const firstHeld = new Promise(resolve => { releaseFirst = resolve })
   const startedSettings = []
+  let persistedSettings = {}
   await page.route(new RegExp(`/api/chats/${chat.id}$`), async route => {
     if (route.request().method() !== 'PATCH') return route.continue()
     const body = route.request().postDataJSON()
     startedSettings.push(body.agent_settings_json)
     if (startedSettings.length === 1) await firstHeld
+    persistedSettings = { ...persistedSettings, ...body.agent_settings_json }
     return route.fulfill({
       status: 200,
       contentType: 'application/json',
       body: JSON.stringify({
         ok: true,
         provider,
-        agent_settings_json: body.agent_settings_json,
-        effective: body.agent_settings_json,
+        agent_settings_json: persistedSettings,
+        effective: persistedSettings,
       }),
     })
   })

--- a/tests/provider-availability.spec.mjs
+++ b/tests/provider-availability.spec.mjs
@@ -11,48 +11,56 @@ const BASE = process.env.MOBIUS_URL || 'http://localhost:8001'
 attachCleanup()
 test.use({ serviceWorkers: 'block' })
 
-test('picker exposes configured providers without leaking unavailable registry rows', async ({ page }) => {
+async function mockPickerData(page, { providerStatus, providers }) {
   await page.route(/\/api\/auth\/providers\/status$/, route => route.fulfill({
     status: 200,
     contentType: 'application/json',
-    body: JSON.stringify({
-      codex: { configured: true, authenticated: true },
-      claude: { configured: false, authenticated: false },
-    }),
+    body: JSON.stringify(providerStatus),
   }))
   await page.route(/\/api\/models$/, route => route.fulfill({
     status: 200,
     contentType: 'application/json',
-    body: JSON.stringify({
-      providers: {
-        codex: [
-          { id: 'codex-fast', label: 'Codex Fast', available: true },
-          { id: 'codex-deep', label: 'Codex Deep', available: true },
-        ],
-        claude: [
-          { id: 'claude-one', label: 'Claude One', available: true },
-          { id: 'claude-two', label: 'Claude Two', available: true },
-          { id: 'claude-three', label: 'Claude Three', available: true },
-        ],
-      },
-    }),
+    body: JSON.stringify({ providers }),
   }))
   await page.route(/\/api\/owner\/model-prefs$/, route => route.fulfill({
     status: 200,
     contentType: 'application/json',
     body: JSON.stringify({ hidden_ids: [] }),
   }))
+}
 
-  await page.goto(BASE, { waitUntil: 'domcontentloaded' })
-  const chat = await createTaggedChat(page, 'provider-availability')
-  expect(chat?.id).toBeTruthy()
-  await page.goto(`${BASE}/shell/?chat=${encodeURIComponent(chat.id)}`, {
+async function openPicker(page, chatId) {
+  await page.goto(`${BASE}/shell/?chat=${encodeURIComponent(chatId)}`, {
     waitUntil: 'domcontentloaded',
   })
   const paintedChat = page.locator('[data-chat-surface="painted"]')
   await expect(paintedChat.locator('.chat__form')).toBeVisible()
-
   await paintedChat.getByRole('button', { name: 'Attach or change model' }).click()
+}
+
+test('picker exposes configured providers without leaking unavailable registry rows', async ({ page }) => {
+  await mockPickerData(page, {
+    providerStatus: {
+      codex: { configured: true, authenticated: true },
+      claude: { configured: false, authenticated: false },
+    },
+    providers: {
+      codex: [
+        { id: 'codex-fast', label: 'Codex Fast', available: true },
+        { id: 'codex-deep', label: 'Codex Deep', available: true },
+      ],
+      claude: [
+        { id: 'claude-one', label: 'Claude One', available: true },
+        { id: 'claude-two', label: 'Claude Two', available: true },
+        { id: 'claude-three', label: 'Claude Three', available: true },
+      ],
+    },
+  })
+
+  await page.goto(BASE, { waitUntil: 'domcontentloaded' })
+  const chat = await createTaggedChat(page, 'provider-availability')
+  expect(chat?.id).toBeTruthy()
+  await openPicker(page, chat.id)
 
   const configuredRows = page.locator('button.csp-row:not([disabled])')
     .filter({ hasText: 'OpenAI Codex' })
@@ -70,7 +78,7 @@ test('picker exposes configured providers without leaking unavailable registry r
   }
 })
 
-test('a second model choice stays selectable while the first choice saves', async ({ page }) => {
+test('model and effort choices stay interactive while saves remain ordered', async ({ page }) => {
   const modelIdsByProvider = {
     claude: ['claude-test-one', 'claude-test-two', 'claude-test-three'],
     codex: ['gpt-test-one', 'gpt-test-two', 'gpt-test-three'],
@@ -87,26 +95,13 @@ test('a second model choice stays selectable while the first choice saves', asyn
     ]),
   )
 
-  await page.route(/\/api\/auth\/providers\/status$/, route => route.fulfill({
-    status: 200,
-    contentType: 'application/json',
-    body: JSON.stringify({
+  await mockPickerData(page, {
+    providerStatus: {
       claude: { configured: true, authenticated: true },
       codex: { configured: true, authenticated: true },
-    }),
-  }))
-  await page.route(/\/api\/models$/, route => route.fulfill({
-    status: 200,
-    contentType: 'application/json',
-    body: JSON.stringify({
-      providers: modelsByProvider,
-    }),
-  }))
-  await page.route(/\/api\/owner\/model-prefs$/, route => route.fulfill({
-    status: 200,
-    contentType: 'application/json',
-    body: JSON.stringify({ hidden_ids: [] }),
-  }))
+    },
+    providers: modelsByProvider,
+  })
 
   await page.goto(BASE, { waitUntil: 'domcontentloaded' })
   const chat = await createTaggedChat(page, 'rapid-model-choice')
@@ -118,13 +113,12 @@ test('a second model choice stays selectable while the first choice saves', asyn
 
   let releaseFirst
   const firstHeld = new Promise(resolve => { releaseFirst = resolve })
-  const savedModels = []
+  const startedSettings = []
   await page.route(new RegExp(`/api/chats/${chat.id}$`), async route => {
     if (route.request().method() !== 'PATCH') return route.continue()
     const body = route.request().postDataJSON()
-    const model = body.agent_settings_json?.model
-    savedModels.push(model)
-    if (savedModels.length === 1) await firstHeld
+    startedSettings.push(body.agent_settings_json)
+    if (startedSettings.length === 1) await firstHeld
     return route.fulfill({
       status: 200,
       contentType: 'application/json',
@@ -137,27 +131,38 @@ test('a second model choice stays selectable while the first choice saves', asyn
     })
   })
 
-  await page.goto(`${BASE}/shell/?chat=${encodeURIComponent(chat.id)}`, {
-    waitUntil: 'domcontentloaded',
-  })
-  const paintedChat = page.locator('[data-chat-surface="painted"]')
-  await expect(paintedChat.locator('.chat__form')).toBeVisible()
-  await paintedChat.getByRole('button', { name: 'Attach or change model' }).click()
+  await openPicker(page, chat.id)
 
   const rows = page.locator('button.csp-row').filter({ hasText: providerLabel })
   await expect(rows).toHaveCount(3)
   const first = rows.filter({ hasText: 'Test model 1' })
   const second = rows.filter({ hasText: 'Test model 2' })
+  let alternateEffort
   try {
     await first.click()
-    await expect.poll(() => [...savedModels]).toEqual([modelIds[0]])
+    await expect.poll(() => startedSettings.map(settings => settings.model))
+      .toEqual([modelIds[0]])
     await expect(second).toBeEnabled({ timeout: 500 })
     await second.click()
     await expect(second).toHaveAttribute('aria-pressed', 'true')
+
+    const effortGroup = page.getByRole('radiogroup', { name: 'Reasoning effort' })
+    alternateEffort = effortGroup.locator('[role="radio"][aria-checked="false"]').first()
+    await expect(alternateEffort).toBeEnabled()
+    await alternateEffort.click()
+    await expect(alternateEffort).toHaveAttribute('aria-checked', 'true')
+
+    await page.waitForTimeout(100)
+    expect(startedSettings.map(settings => settings.model)).toEqual([modelIds[0]])
   } finally {
     releaseFirst()
   }
 
-  await expect.poll(() => [...savedModels]).toEqual(modelIds.slice(0, 2))
+  await expect.poll(() => startedSettings.length).toBe(3)
+  expect(startedSettings.slice(0, 2).map(settings => settings.model))
+    .toEqual(modelIds.slice(0, 2))
+  expect(startedSettings[2].model).toBeUndefined()
+  expect(startedSettings[2].effort).toBeTruthy()
   await expect(second).toHaveAttribute('aria-pressed', 'true')
+  await expect(alternateEffort).toHaveAttribute('aria-checked', 'true')
 })


### PR DESCRIPTION
## Summary
- keep model and effort choices interactive while a previous picker save settles
- serialize picker writes so the newest choice remains both visible and durable
- wait for pending picker writes before sending a message, including after closing and reopening the menu

## Testing
- added a Playwright regression that holds the first model save while making a second choice
- `npm run test:lib`
- focused ESLint for the changed chat components
- `npm run build`