### PR TITLE
Prevent empty Builder workspaces

### DIFF
--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -1199,7 +1199,14 @@ export default function Shell() {
   const handleToggleViewMode = useCallback((cause) => {
     const ws = workspaceStateRef.current.ws
     const leavingBuilder = ws.viewMode !== 'single'
-    const to = leavingBuilder ? 'single' : 'panes'
+    const requestedTo = leavingBuilder ? 'single' : 'panes'
+    const to = paneModel.setViewMode(ws, requestedTo).viewMode
+    // Builder has no empty state. The model resolves an attempted entry with no
+    // tabs back to Standard; do not arm a browser scene or twist the mode logo for
+    // a destination the durable workspace correctly refused.
+    if (to === ws.viewMode) {
+      return { animated: false, totalMs: 0, transitionId: null, to, changed: false }
+    }
     const plan = deriveModeSnapshotPlan({ workspace: ws, projection, contentRect })
 
     // One browser-owned scene transaction commits BOTH durable authorities. The

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -1201,9 +1201,9 @@ export default function Shell() {
     const leavingBuilder = ws.viewMode !== 'single'
     const requestedTo = leavingBuilder ? 'single' : 'panes'
     const to = paneModel.setViewMode(ws, requestedTo).viewMode
-    // Builder has no empty state. The model resolves an attempted entry with no
-    // tabs back to Standard; do not arm a browser scene or twist the mode logo for
-    // a destination the durable workspace correctly refused.
+    // Builder has no empty state. The model seeds an empty tree from Standard's
+    // current screen; only the New Chat landing has no concrete tab to seed. Do
+    // not arm a browser scene or twist the logo for that honest no-op.
     if (to === ws.viewMode) {
       return { animated: false, totalMs: 0, transitionId: null, to, changed: false }
     }

--- a/frontend/src/components/Shell/__tests__/singleScreenSlot.test.js
+++ b/frontend/src/components/Shell/__tests__/singleScreenSlot.test.js
@@ -258,6 +258,11 @@ test('closing the LAST builder tab auto-returns to single', () => {
   const ws = builderSeed([makeTab('chat', '5')])
   const s = reduce(init(ws), { type: 'CLOSE_TAB', tabKey: 'chat:5' })
   assert.equal(s.ws.viewMode, 'single', 'empty builder auto-returns to single')
+  assert.deepEqual(
+    s.ws.singleScreen,
+    { kind: 'chat', id: '5' },
+    'a legacy workspace carries the departing visible tab into Standard',
+  )
   assert.equal(s.undo.restoreViewMode, true, 'the undo is flagged one-gesture')
 })
 
@@ -366,14 +371,15 @@ test('CLOSE_PANE that empties the builder auto-returns to single', () => {
   const ws = builderSeed([makeTab('chat', '5')])
   const s = reduce(init(ws), { type: 'CLOSE_PANE', paneId: ws.focusedPaneId })
   assert.equal(s.ws.viewMode, 'single')
+  assert.deepEqual(s.ws.singleScreen, { kind: 'chat', id: '5' })
   assert.equal(s.undo.restoreViewMode, true)
 })
 
-test('a refused empty-builder entry preserves the coupled close undo', () => {
+test('a genuinely empty New Chat entry preserves the coupled close undo', () => {
   // Auto-return arms a mode-coupled undo (restoreViewMode). Trying to enter an
   // empty Builder is not a new mode intent because that destination does not
   // exist, so it must not weaken the one-gesture restoration.
-  const ws = builderSeed([makeTab('chat', '5')])
+  const ws = { ...builderSeed([makeTab('chat', '5')]), singleScreen: null }
   let state = reduce(init(ws), { type: 'CLOSE_TAB', tabKey: 'chat:5' }) // → single, coupled undo
   assert.equal(state.undo.restoreViewMode, true)
   state = reduce(state, { type: 'SET_VIEW_MODE', mode: 'panes' }) // refused: tree is empty

--- a/frontend/src/components/Shell/__tests__/singleScreenSlot.test.js
+++ b/frontend/src/components/Shell/__tests__/singleScreenSlot.test.js
@@ -261,10 +261,25 @@ test('closing the LAST builder tab auto-returns to single', () => {
   assert.equal(s.undo.restoreViewMode, true, 'the undo is flagged one-gesture')
 })
 
-test('an empty workspace cannot enter or persist in builder mode', () => {
+test('an empty builder tree enters by seeding the current Standard chat or app', () => {
+  for (const singleScreen of [{ kind: 'chat', id: '5' }, { kind: 'app', id: '42' }]) {
+    const empty = {
+      ...paneModel.seedFromFlatTabs([]),
+      singleScreen,
+    }
+    const entered = reduce(init(empty), { type: 'SET_VIEW_MODE', mode: 'panes' })
+    assert.equal(entered.ws.viewMode, 'panes')
+    assert.ok(
+      paneModel.paneOf(entered.ws, `${singleScreen.kind}:${singleScreen.id}`),
+      'the Standard screen becomes the first Builder tab',
+    )
+    assert.deepEqual(entered.ws.singleScreen, singleScreen, 'Standard keeps its independent slot')
+  }
+
   const empty = paneModel.seedFromFlatTabs([])
-  const toggled = reduce(init(empty), { type: 'SET_VIEW_MODE', mode: 'panes' })
-  assert.equal(toggled.ws.viewMode, 'single', 'explicit entry remains Standard')
+  const home = empty
+  const refused = reduce(init(home), { type: 'SET_VIEW_MODE', mode: 'panes' })
+  assert.equal(refused.ws.viewMode, 'single', 'the New Chat landing has no concrete tab to seed')
 
   const stale = JSON.stringify({ ...empty, viewMode: 'panes' })
   assert.equal(
@@ -272,6 +287,48 @@ test('an empty workspace cannot enter or persist in builder mode', () => {
     'single',
     'a persisted empty Builder repairs to Standard at boot',
   )
+})
+
+test('closing the final Builder tab can re-enter from the preserved Standard screen', () => {
+  const ws = {
+    ...builderSeed([makeTab('chat', '5')]),
+    singleScreen: { kind: 'chat', id: '5' },
+  }
+  let state = reduce(init(ws), { type: 'CLOSE_TAB', tabKey: 'chat:5' })
+  assert.equal(state.ws.viewMode, 'single')
+  state = reduce(state, { type: 'SET_VIEW_MODE', mode: 'panes' })
+  assert.equal(state.ws.viewMode, 'panes')
+  assert.ok(paneModel.paneOf(state.ws, 'chat:5'))
+})
+
+test('a drawer drop into an empty Builder preserves a Standard chat or app as the first tab', () => {
+  for (const [singleScreen, dropped] of [
+    [{ kind: 'chat', id: '5' }, makeTab('app', '42')],
+    [{ kind: 'app', id: '42' }, makeTab('chat', '5')],
+  ]) {
+    const ws = {
+      ...paneModel.seedFromFlatTabs([]),
+      singleScreen,
+    }
+    const state = reduce(init(ws), {
+      type: 'OPEN_TAB_AT',
+      tab: dropped,
+      target: { paneId: ws.focusedPaneId },
+      flipViewMode: 'panes',
+    })
+    const pane = state.ws.panes[state.ws.focusedPaneId]
+    assert.equal(state.ws.viewMode, 'panes')
+    assert.deepEqual(pane.tabs.map(tabModel.tabKey), [
+      `${singleScreen.kind}:${singleScreen.id}`,
+      tabModel.tabKey(dropped),
+    ])
+    assert.equal(
+      pane.activeTabKey,
+      tabModel.tabKey(dropped),
+      'the dropped item activates without replacing Standard',
+    )
+    assert.deepEqual(state.ws.singleScreen, ws.singleScreen)
+  }
 })
 
 test('deleting the last builder resource also leaves no empty builder behind', () => {

--- a/frontend/src/components/Shell/__tests__/singleScreenSlot.test.js
+++ b/frontend/src/components/Shell/__tests__/singleScreenSlot.test.js
@@ -261,6 +261,28 @@ test('closing the LAST builder tab auto-returns to single', () => {
   assert.equal(s.undo.restoreViewMode, true, 'the undo is flagged one-gesture')
 })
 
+test('an empty workspace cannot enter or persist in builder mode', () => {
+  const empty = paneModel.seedFromFlatTabs([])
+  const toggled = reduce(init(empty), { type: 'SET_VIEW_MODE', mode: 'panes' })
+  assert.equal(toggled.ws.viewMode, 'single', 'explicit entry remains Standard')
+
+  const stale = JSON.stringify({ ...empty, viewMode: 'panes' })
+  assert.equal(
+    paneModel.parseWorkspace(stale).viewMode,
+    'single',
+    'a persisted empty Builder repairs to Standard at boot',
+  )
+})
+
+test('deleting the last builder resource also leaves no empty builder behind', () => {
+  const ws = builderSeed([makeTab('chat', '5')])
+  const state = reduce(init(ws), {
+    type: 'CLOSE_TAB', tabKey: 'chat:5', reason: 'deleted',
+  })
+  assert.equal(state.ws.viewMode, 'single')
+  assert.equal(state.undo, null, 'resource deletion remains non-undoable workspace state')
+})
+
 test('undo of the last-tab close restores the tab AND builder mode as one gesture', () => {
   const ws = builderSeed([makeTab('chat', '5')])
   let state = reduce(init(ws), { type: 'CLOSE_TAB', tabKey: 'chat:5' })
@@ -290,17 +312,39 @@ test('CLOSE_PANE that empties the builder auto-returns to single', () => {
   assert.equal(s.undo.restoreViewMode, true)
 })
 
-test('INV 8: an explicit later toggle rebases a coupled undo to tree-only', () => {
-  // Auto-return arms a mode-coupled undo (restoreViewMode). The owner then toggles
-  // the mode explicitly; undo must restore the TREE but not yank the mode back.
+test('a refused empty-builder entry preserves the coupled close undo', () => {
+  // Auto-return arms a mode-coupled undo (restoreViewMode). Trying to enter an
+  // empty Builder is not a new mode intent because that destination does not
+  // exist, so it must not weaken the one-gesture restoration.
   const ws = builderSeed([makeTab('chat', '5')])
   let state = reduce(init(ws), { type: 'CLOSE_TAB', tabKey: 'chat:5' }) // → single, coupled undo
   assert.equal(state.undo.restoreViewMode, true)
-  state = reduce(state, { type: 'SET_VIEW_MODE', mode: 'panes' }) // explicit later intent
-  assert.equal(state.undo.restoreViewMode, false, 'coupled undo rebased to tree-only')
+  state = reduce(state, { type: 'SET_VIEW_MODE', mode: 'panes' }) // refused: tree is empty
+  assert.equal(state.ws.viewMode, 'single')
+  assert.equal(state.undo.restoreViewMode, true, 'the refused entry does not rewrite undo semantics')
   state = reduce(state, { type: 'UNDO_LAST' })
   assert.ok(paneModel.paneOf(state.ws, 'chat:5'), 'tab restored')
-  assert.equal(state.ws.viewMode, 'panes', 'the owner\'s later mode choice is preserved')
+  assert.equal(state.ws.viewMode, 'panes', 'the closed Builder world is restored with its tab')
+})
+
+test('a real later mode choice still rebases a coupled undo to tree-only', () => {
+  let state = init({
+    ...paneModel.seedFromFlatTabs([makeTab('chat', '5')]),
+    viewMode: 'single',
+  })
+  state = reduce(state, {
+    type: 'OPEN_TAB_AT',
+    tab: makeTab('app', '42'),
+    target: { paneId: state.ws.focusedPaneId, edge: 'right' },
+    flipViewMode: 'panes',
+  })
+  assert.equal(state.undo.restoreViewMode, true)
+
+  state = reduce(state, { type: 'SET_VIEW_MODE', mode: 'single' })
+  assert.equal(state.undo.restoreViewMode, false, 'the accepted mode choice rebases the undo')
+  state = reduce(state, { type: 'UNDO_LAST' })
+  assert.equal(state.ws.viewMode, 'single', 'tree undo preserves the later Standard choice')
+  assert.equal(Object.keys(state.ws.panes).length, 1, 'the split itself is still undone')
 })
 
 test('singleScreenRoute: chat, installed app, Apps launcher, and empty/home', () => {

--- a/frontend/src/components/Shell/paneModel.js
+++ b/frontend/src/components/Shell/paneModel.js
@@ -595,14 +595,18 @@ export function isEmptyTree(ws) {
 // Auto-return an EMPTIED builder to single (owner semantic: closing the last tab
 // with no panes left in builder returns to single). Applied by the close reducer
 // cases when a close in 'panes' mode empties the tree. Flips viewMode to single
-// and seeds the slot if it was never initialized (an empty builder seeds an empty
-// single screen — focusedSlotSeed is null on an empty pane). The caller marks the
-// undo `restoreViewMode` so undo restores the closed tab AND builder mode as ONE
-// gesture. Returns { ws, autoReturned } so the caller knows whether to flag the undo.
+// and, for a legacy workspace whose slot was never initialized, carries the
+// departing visible item into Standard before the emptied tree loses it. The
+// caller marks the undo `restoreViewMode` so undo restores the closed tab AND
+// builder mode as ONE gesture. Returns { ws, autoReturned } so the caller knows
+// whether to flag the undo.
 function autoReturnIfEmptied(prevWs, nextWs) {
   if (prevWs.viewMode !== 'panes') return { ws: nextWs, autoReturned: false }
   if (isEmptyTree(prevWs) || !isEmptyTree(nextWs)) return { ws: nextWs, autoReturned: false }
-  return { ws: seedSingleScreenIfAbsent(setViewMode(nextWs, 'single')), autoReturned: true }
+  const withSlot = ('singleScreen' in nextWs)
+    ? nextWs
+    : setSingleScreen(nextWs, focusedSlotSeed(prevWs))
+  return { ws: setViewMode(withSlot, 'single'), autoReturned: true }
 }
 
 // Every live leaf pane id in in-order (left-to-right) sequence. The resolver

--- a/frontend/src/components/Shell/paneModel.js
+++ b/frontend/src/components/Shell/paneModel.js
@@ -478,18 +478,32 @@ function coerceViewMode(mode) {
   return mode === 'single' ? 'single' : 'panes'
 }
 
-// Set the view-mode. Pure; returns the SAME reference when it already holds the
-// resolved target mode (the workspace convention, so React can bail). Builder
-// cannot be entered with an empty tree: there is no pane content for that world
-// to present, so the honest resolved destination remains Standard.
-export function setViewMode(ws, mode) {
-  const requested = coerceViewMode(mode)
-  const next = requested === 'panes' && isEmptyTree(ws) ? 'single' : requested
-  if (ws.viewMode === next) return ws
-  return { ...ws, viewMode: next }
+function singleScreenTab(ws) {
+  const item = ('singleScreen' in ws)
+    ? sanitizeSingleScreen(ws.singleScreen)
+    : focusedSlotSeed(ws)
+  if (!item) return null
+  if (item.kind === 'apps') return tabModel.appsTab()
+  return tabModel.makeTab(item.kind, item.id)
 }
 
-// Flip single <-> panes. An empty Standard workspace remains Standard.
+// Set the view-mode. Pure; returns the SAME reference on a true no-op. Builder
+// has no empty state: entering it from an empty tree seeds the current Standard
+// screen as its first tab. If Standard is itself the empty New Chat landing,
+// there is no content to seed and the workspace honestly remains Standard.
+export function setViewMode(ws, mode) {
+  const requested = coerceViewMode(mode)
+  let nextWs = ws
+  if (requested === 'panes' && isEmptyTree(ws)) {
+    const tab = singleScreenTab(ws)
+    if (!tab) return ws
+    nextWs = doOpenTab(ws, tab)
+  }
+  if (nextWs.viewMode === requested) return nextWs
+  return { ...nextWs, viewMode: requested }
+}
+
+// Flip single <-> panes. An empty Standard workspace seeds its current screen.
 export function toggleViewMode(ws) {
   return setViewMode(ws, ws.viewMode === 'single' ? 'panes' : 'single')
 }
@@ -1731,8 +1745,13 @@ export function workspaceReducer(state, action) {
       // A drag drop from a drawer row (open the item AT the zone) or a strip tab
       // (degrades to a move). One commit, one undo slot — the drop is one tap
       // from repaired (design §3.5).
-      const next = openTabAt(ws, action.tab, action.target)
-      if (next === ws) return state
+      const cleanTab = sanitizeTab(action.tab)
+      if (!cleanTab) return state
+      // When a drawer drag enters Builder from an empty hidden tree, resolve the
+      // mode first: setViewMode seeds Standard's current screen as tab one. The
+      // dragged item then joins/splits that seeded pane instead of replacing it.
+      const working = action.flipViewMode ? setViewMode(ws, action.flipViewMode) : ws
+      const next = openTabAt(working, cleanTab, action.target)
       // A single-leaf splitting drop made in single view-mode flips to 'panes' as
       // part of the SAME gesture (the drop's intent is a second visible surface).
       // Folding the flip into THIS action — rather than a following SET_VIEW_MODE —
@@ -1741,6 +1760,7 @@ export function workspaceReducer(state, action) {
       // flipped mode over a reverted tree. action.flipViewMode is null for every
       // ordinary drop, so this is a no-op there.
       const flipped = action.flipViewMode ? setViewMode(next, action.flipViewMode) : next
+      if (flipped === ws) return state
       const dropLabel = action.label || 'Moved tab'
       return {
         ws: flipped,

--- a/frontend/src/components/Shell/paneModel.js
+++ b/frontend/src/components/Shell/paneModel.js
@@ -296,6 +296,10 @@ function nearestSurviving(orderedIds, survivors, targetId) {
   return null
 }
 
+function panesAreEmpty(panes) {
+  return Object.values(panes).every(pane => pane.tabs.length === 0)
+}
+
 // Enforce every workspace invariant, idempotently, and return the SAME reference
 // when the input already satisfies them (so normalize(normalize(ws)) is
 // reference-stable and callers can bail on an unchanged tree). Repairs — never
@@ -392,11 +396,15 @@ export function normalize(ws) {
   for (const id of splitIdsOf(layout)) maxId = Math.max(maxId, idSuffix(id))
   const storedNext = (Number.isInteger(ws.nextId) && ws.nextId > 0) ? ws.nextId : 0
   const nextId = Math.max(maxId + 1, storedNext)
-  // viewMode is a preserved field, coerced to a valid value (absent/corrupt ->
-  // 'panes', design: forgiving parse). It never affects the tree, so it rides
-  // through normalize untouched except for this coercion; deepEqual below still
-  // returns the SAME reference when the input already carried the same mode.
-  const viewMode = coerceViewMode(ws.viewMode)
+  // Builder is a presentation of actual pane content, never an empty world. A
+  // stale/corrupt persisted blob can still say `panes` after every tab is gone;
+  // repair that at the model boundary so boot cannot strand the owner in a blank
+  // Builder. Non-empty trees preserve their mode.
+  const requestedViewMode = coerceViewMode(ws.viewMode)
+  const viewMode = requestedViewMode === 'panes'
+    && panesAreEmpty(panes)
+    ? 'single'
+    : requestedViewMode
   const result = { v: 1, viewMode, layout, panes, focusedPaneId: focused, nextId }
   // The single-screen slot rides through normalize the same way viewMode does:
   // a preserved field, forgivingly sanitized, that never affects the tree. ABSENCE
@@ -471,16 +479,17 @@ function coerceViewMode(mode) {
 }
 
 // Set the view-mode. Pure; returns the SAME reference when it already holds the
-// target mode (the workspace convention, so React can bail on an unchanged tree).
-// It touches only viewMode — the layout/panes/focus/nextId are already normalized
-// and a mode flip never mutates them, so no re-normalize is needed.
+// resolved target mode (the workspace convention, so React can bail). Builder
+// cannot be entered with an empty tree: there is no pane content for that world
+// to present, so the honest resolved destination remains Standard.
 export function setViewMode(ws, mode) {
-  const next = coerceViewMode(mode)
+  const requested = coerceViewMode(mode)
+  const next = requested === 'panes' && isEmptyTree(ws) ? 'single' : requested
   if (ws.viewMode === next) return ws
   return { ...ws, viewMode: next }
 }
 
-// Flip single <-> panes. Absent/'panes' -> 'single'; 'single' -> 'panes'.
+// Flip single <-> panes. An empty Standard workspace remains Standard.
 export function toggleViewMode(ws) {
   return setViewMode(ws, ws.viewMode === 'single' ? 'panes' : 'single')
 }
@@ -566,7 +575,7 @@ export function seedSingleScreenIfAbsent(ws) {
 // this is the "last tab in builder just closed" signal (owner semantic: an empty
 // builder auto-returns to single).
 export function isEmptyTree(ws) {
-  return Object.values(ws.panes).every(pane => pane.tabs.length === 0)
+  return panesAreEmpty(ws.panes)
 }
 
 // Auto-return an EMPTIED builder to single (owner semantic: closing the last tab
@@ -1835,12 +1844,10 @@ export function workspaceReducer(state, action) {
     }
     case 'RESET_FLAT': {
       const seeded = seedFromFlatTabs(action.tabs)
-      // RESET_FLAT reseeds the BUILDER tree only (two-worlds design): it must not
-      // reset the world (viewMode) or the single-screen slot. seedFromFlatTabs
-      // returns a fresh 'panes' seed with no slot, so carry the current world state
-      // across. A boot with no valid blob starts from the initial seed anyway
-      // (current viewMode 'panes', slot absent), so this is a no-op there.
-      const next = { ...seeded, viewMode: ws.viewMode }
+      // RESET_FLAT reseeds the BUILDER tree only (two-worlds design): preserve the
+      // current world and single-screen slot unless the reset removed every tab,
+      // in which case the shared no-empty-Builder invariant resolves to Standard.
+      const next = setViewMode(seeded, ws.viewMode)
       if ('singleScreen' in ws) next.singleScreen = ws.singleScreen
       if (deepEqual(next, ws) && undo == null) return state
       return { ws: next, undo: null }

--- a/frontend/src/components/Shell/useLogoModeGesture.js
+++ b/frontend/src/components/Shell/useLogoModeGesture.js
@@ -141,6 +141,13 @@ export function useLogoModeGesture({
     // logo's scale in the SAME batched paint (endPress resets --hold-progress to 0,
     // but the is-beat-held animation's backwards fill holds .84 through the delay).
     const receipt = onToggleMode?.('hold')
+    // A completed hold can be a deliberate no-op (currently: Standard has no pane
+    // content, so there is no honest Builder destination). Release the gesture
+    // without playing entry feedback for a mode change that did not happen.
+    if (receipt?.changed === false) {
+      endPress({ suppressClick: true })
+      return
+    }
     const animated = !!(receipt && receipt.animated)
     if (animated) setHoldOwnsBeat(true)
     runHoldCompletion({

--- a/frontend/src/components/Shell/useLogoModeGesture.js
+++ b/frontend/src/components/Shell/useLogoModeGesture.js
@@ -141,9 +141,9 @@ export function useLogoModeGesture({
     // logo's scale in the SAME batched paint (endPress resets --hold-progress to 0,
     // but the is-beat-held animation's backwards fill holds .84 through the delay).
     const receipt = onToggleMode?.('hold')
-    // A completed hold can be a deliberate no-op (currently: Standard has no pane
-    // content, so there is no honest Builder destination). Release the gesture
-    // without playing entry feedback for a mode change that did not happen.
+    // A completed hold can be a deliberate no-op when Standard is the empty New
+    // Chat landing, with no concrete screen to seed into Builder. Release the
+    // gesture without playing feedback for a mode change that did not happen.
     if (receipt?.changed === false) {
       endPress({ suppressClick: true })
       return

--- a/tests/mode-transition.spec.mjs
+++ b/tests/mode-transition.spec.mjs
@@ -72,6 +72,17 @@ function twoPaneBuilder(slot) {
   return ws // viewMode stays 'panes' (builder)
 }
 
+// The user-visible empty-Builder seam: Standard has one concrete current item,
+// while the hidden Builder tree has no tabs yet. Entering Builder must seed this
+// chat as its only tab; the truly empty New Chat landing intentionally cannot
+// enter a content-less Builder world.
+function standardChatWithEmptyBuilder() {
+  return paneModel.setSingleScreen(
+    paneModel.seedFromFlatTabs([]),
+    { kind: 'chat', id: 'aaa' },
+  )
+}
+
 // An intentionally asymmetric three-pane tree. Its natural edge vectors differ
 // enough to expose same-duration entry as visibly different pane velocities.
 function unevenThreePaneBuilder(slot) {
@@ -186,20 +197,22 @@ for (const [name, viewport] of [
   ['wide', { width: 1280, height: 900 }],
 ]) {
   test(`[${name}] a single builder toggle flips the mode and settles clean`, async ({ page }) => {
-    await bootShell(page, viewport)
-    // A fresh workspace seeds viewMode:'panes' (builder), so do NOT hardcode the
-    // initial direction (finding 15) — read it and assert the toggle FLIPS it.
+    await bootSeededWorkspace(page, viewport, standardChatWithEmptyBuilder())
+    // The hidden Builder tree is empty, so this toggle also proves that entry
+    // seeds the current Standard chat rather than refusing or painting a blank.
     const before = await builderActive(page)
     await toggleMode(page)
     await expect.poll(() => builderActive(page)).toBe(!before)
+    const entered = await page.evaluate(key => JSON.parse(sessionStorage.getItem(key)), paneModel.STORAGE_KEY)
+    expect(entered.panes[entered.focusedPaneId].tabs.map(tabModel.tabKey)).toEqual(['chat:aaa'])
     // The beat settles: no transient class lingers.
     await expect.poll(() => transientClassCount(page), { timeout: 2000 }).toBe(0)
     await expect.poll(() => modePhase(page)).toBe('idle')
   })
 
   test(`[${name}] a cancelled single-mode drag UNTILES (BLOCKER 1: no permanent tile)`, async ({ page }) => {
-    await bootShell(page, viewport)
-    // Ensure SINGLE mode (a fresh workspace is builder).
+    await bootSeededWorkspace(page, viewport, standardChatWithEmptyBuilder())
+    // Ensure SINGLE mode.
     if (await builderActive(page)) {
       await toggleMode(page)
       await expect.poll(() => builderActive(page)).toBe(false)
@@ -230,7 +243,7 @@ for (const [name, viewport] of [
   })
 
   test(`[${name}] 20x rapid toggle never wedges and never doubles the beat class`, async ({ page }) => {
-    await bootShell(page, viewport)
+    await bootSeededWorkspace(page, viewport, standardChatWithEmptyBuilder())
     await armOneBeatObserver(page)
     const startBuilder = await builderActive(page)
     // Storm the toggle far faster than the beat can complete, so enter-during-exit

--- a/tests/tabs.spec.mjs
+++ b/tests/tabs.spec.mjs
@@ -295,18 +295,19 @@ test.describe('Tabs', () => {
     await expect(page.locator('.shell__tabstrip')).toHaveCount(1)
 
     // Close the last tab — the emptied builder auto-returns to SINGLE (owner
-    // semantic). The strip retires with the world flip, and the never-seeded single
-    // slot lands on the first-class New Chat landing (round 4 item 3) — never the
-    // freshest transcript.
+    // semantic). The strip retires with the world flip. A legacy workspace with
+    // no saved Standard slot carries the departing visible chat across rather
+    // than replacing it with a blank landing.
     await page.locator('.shell__tab-close').first().click()
     await expect(page.locator('.shell__tabstrip')).toHaveCount(0)
     await expect.poll(() => page.evaluate(
       key => JSON.parse(sessionStorage.getItem(key))?.viewMode,
       paneModel.STORAGE_KEY,
     ), { timeout: 3000 }).toBe('single')
-    // The New Chat empty surface (What's on your mind?) shows — the honest landing.
-    // Scope to the VISIBLE full-bleed surface (hidden panes can also carry the title).
-    await expect(page.locator('.shell__view--active .chat__empty-title')).toBeVisible({ timeout: 3000 })
+    await expect(page.locator('[data-chat-surface="painted"] .chat__scroll'))
+      .toBeVisible({ timeout: 3000 })
+    await expect(page.locator('[data-chat-surface="painted"] .chat__msg--user'))
+      .toContainText(prompt)
   })
 
   test('no toggle/strip surface when nothing is pinned (single-screen)', async ({ page }) => {

--- a/tests/workspace-panes.spec.mjs
+++ b/tests/workspace-panes.spec.mjs
@@ -1098,6 +1098,28 @@ test.describe('Workspace view-mode toggle', () => {
     await expect(page.getByRole('button', { name: /Use (panes|single screen)/ })).toHaveCount(0)
   })
 
+  test('closing the final legacy Builder tab returns to a visible Standard chat', async ({ page }) => {
+    await boot(page, WIDE)
+    const current = await createTaggedChat(page, 'vmFinalClose')
+    await mockApps(page, [])
+    await seedWorkspace(page, builderSeed([{ kind: 'chat', id: current.id }]))
+    await page.goto(`${BASE}/shell/?chat=${current.id}`, { waitUntil: 'domcontentloaded' })
+    await expect(page.locator('.shell__chat-view.shell__view--active')).toHaveCount(1, { timeout: 8000 })
+    expect('singleScreen' in await readWs(page), 'the fixture reproduces the legacy missing slot').toBe(false)
+
+    await page.getByRole('button', { name: /^Close .* tab$/ }).click()
+
+    await expect.poll(async () => (await readWs(page)).viewMode, {
+      timeout: 3000,
+      message: 'the final close returns to Standard',
+    }).toBe('single')
+    const after = await readWs(page)
+    expect(after.singleScreen).toEqual({ kind: 'chat', id: String(current.id) })
+    await expect(page.locator(
+      `[data-chat-surface="painted"][data-chat-id="${current.id}"].shell__view--active`,
+    )).toHaveCount(1)
+  })
+
   test('the logo gesture flips to single (geometry preserved, one pane) and back', async ({ page }) => {
     await boot(page, WIDE)
     const a = await createTaggedChat(page, 'vmA')

--- a/tests/workspace-panes.spec.mjs
+++ b/tests/workspace-panes.spec.mjs
@@ -1252,6 +1252,38 @@ test.describe('Workspace view-mode toggle', () => {
     expect(whichPaneHas(await readWs(page), `chat:${c.id}`), 'the drop is undone').toBe(null)
   })
 
+  test('single-mode drawer drop seeds an empty Builder without replacing Standard', async ({ page }) => {
+    await boot(page, WIDE)
+    const current = await createTaggedChat(page, 'vmEmptyCurrent')
+    const dropped = await createTaggedChat(page, 'vmEmptyDropped')
+    await mockApps(page, [])
+    await exposeChatsInDrawer(page, [current.id, dropped.id])
+    const ws = paneModel.setSingleScreen(
+      paneModel.seedFromFlatTabs([]),
+      { kind: 'chat', id: current.id },
+    )
+    await seedWorkspace(page, ws)
+    await page.goto(`${BASE}/shell/?chat=${current.id}`, { waitUntil: 'domcontentloaded' })
+    await expect(page.locator('.shell__chat-view.shell__view--active')).toHaveCount(1, { timeout: 8000 })
+
+    await ensureNavigationOpen(page)
+    const content = await page.locator('.shell__content').boundingBox()
+    const row = page.locator(`.drawer__item[data-drag-key="chat:${dropped.id}"]`)
+    await expect(row).toBeVisible()
+    await mouseDrag(page, row, content.x + content.width / 2, content.y + content.height / 2)
+
+    await expect.poll(async () => (await readWs(page)).viewMode, {
+      timeout: 3000,
+      message: 'the drop enters Builder',
+    }).toBe('panes')
+    const after = await readWs(page)
+    expect(after.panes[after.focusedPaneId].tabs.map(t => `${t.kind}:${t.id}`)).toEqual([
+      `chat:${current.id}`,
+      `chat:${dropped.id}`,
+    ])
+    expect(after.singleScreen).toEqual({ kind: 'chat', id: String(current.id) })
+  })
+
   test('single-mode drag → Escape cancels: back to single, no mutation, no residue', async ({ page }) => {
     await boot(page, WIDE)
     const a = await createTaggedChat(page, 'vmCancA')


### PR DESCRIPTION
## Summary
- Return to Standard and keep the departing chat or app visible whenever the final Builder tab or pane is closed.
- Seed an empty Builder from the current Standard chat or app when Builder is entered.
- Preserve that seeded tab when another chat or app is dragged in from the drawer.
- Keep the empty New Chat landing out of a content-less Builder world.

## Testing
- Shell unit suite (570 tests)
- Production frontend build
- Rendered phone-viewport final-tab close with a legacy missing Standard slot
- Added browser regressions for final-close fallback, empty-tree entry, and drawer-drop preservation
