### PR TITLE
Persist Codex ultra effort selections

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -444,7 +444,8 @@ class AgentSettingsOverride(BaseModel):
   # Acceptable per the platform's "reversibility over prevention"
   # philosophy.
   effort: Literal[
-    "none", "minimal", "low", "medium", "high", "xhigh", "max", "ultracode"
+    "none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra",
+    "ultracode",
   ] | None = None
   # Per-provider memory of the last-picked effort. The enums are
   # NOT comparable across providers — Codex `medium` is roughly

--- a/backend/tests/test_chat_agent_settings.py
+++ b/backend/tests/test_chat_agent_settings.py
@@ -438,6 +438,21 @@ def test_agent_settings_override_rejects_unknown_keys():
   raise AssertionError("Expected ValidationError for unknown key")
 
 
+def test_agent_settings_override_accepts_codex_catalog_ultra_effort():
+  """Sol/Terra advertise `ultra`; the picker payload must round-trip."""
+  settings = AgentSettingsOverride(
+    model="gpt-5.6-sol",
+    effort="ultra",
+    effort_by_provider={"codex": "ultra"},
+  )
+
+  assert settings.model_dump(exclude_unset=True) == {
+    "model": "gpt-5.6-sol",
+    "effort": "ultra",
+    "effort_by_provider": {"codex": "ultra"},
+  }
+
+
 def test_patch_chat_provider_and_model_in_same_request(
   client, auth, chat, monkeypatch,
 ):


### PR DESCRIPTION
## Summary
- accept `ultra` in per-chat agent settings so supported Codex picker selections survive saving and reopening
- add a regression test covering the model, active effort, and provider-specific effort memory payload

## Testing
- `scripts/wt-pytest.sh backend/tests/test_chat_agent_settings.py -q` (27 passed)