### PR TITLE
Bound the large-history preview fixture

### DIFF
--- a/backend/tests/test_platform_update.py
+++ b/backend/tests/test_platform_update.py
@@ -1554,9 +1554,16 @@ def test_update_preview_caps_large_diff(clone_env):
   assert len(preview["diff"]) == pu.MAX_PREVIEW_DIFF_CHARS
 
 
-def test_update_preview_reports_exact_total_beyond_rendered_commit_cap(clone_env):
+def test_update_preview_reports_exact_total_beyond_rendered_commit_cap(
+  clone_env, monkeypatch,
+):
   origin, platform = clone_env
   work = origin.parent / "origin-work"
+  # The contract is that counting remains exact beyond the rendered cap, not
+  # that every full-suite worker must manufacture the production-sized history.
+  # Keeping this fixture small also avoids several parallel CI workers churning
+  # hundreds of temporary loose Git objects at once.
+  monkeypatch.setattr(pu, "_PREVIEW_COMMIT_LIMIT", 5)
   total = pu._PREVIEW_COMMIT_LIMIT + 7
   for index in range(total):
     (work / "release-counter.txt").write_text(f"{index}\n")


### PR DESCRIPTION
## Summary
- override the rendered commit cap inside the exact-total preview test
- keep the beyond-cap contract while creating 12 temporary commits instead of 107 per full-suite worker
- document why the production-sized fixture is harmful under parallel merge-queue execution

## Why
Parallel merge-queue runs repeatedly failed after 3,500+ passing tests because this one fixture made every worker create and push 107 loose commits at once; the temporary bare remote then intermittently reported a missing tree object. The behavior under test is exact counting beyond a cap, not the production cap’s literal value. A test-local cap preserves the contract while removing the filesystem stress that discarded otherwise-green queue batches.

## Verification
- 20 consecutive focused runs
- Ruff and diff checks