### PR TITLE
Keep active goals visible through connection loss

### DIFF
--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -429,10 +429,8 @@ export default function ChatView({
     }, MESSAGE_META_VISIBLE_MS)
   }, [])
   useEffect(() => {
-    setActiveGoalObjective(
-      queryClient.getQueryData(chatMessagesQueryKey(chatId))
-        ?.activeGoalObjective ?? '',
-    )
+    const runtime = queryClient.getQueryData(chatMessagesQueryKey(chatId))
+    setActiveGoalObjective(runtime?.running ? (runtime.activeGoalObjective ?? '') : '')
   }, [chatId, queryClient])
 
   // Pending queue (the items shown in the queued-tray above the
@@ -953,6 +951,13 @@ export default function ChatView({
     patchQuestionAnswers,
     flushStreamSnapshot,
   } = useStreamConnection(chatId, {
+    onConnectionLost: () => {
+      // Browser transport ownership is uncertain here: the backend turn may
+      // still be parked on a question or producing output. Preserve the
+      // last-good assistant payload without retiring any run-owned state;
+      // onNeedsRefresh below is the authority for whether the run truly ended.
+      promoteStreamToMessages({ keepTurnOpen: true })
+    },
     onStreamEnd: ({ continues, promotedMessage } = {}) => {
       if (embedded && continues === false) setEmbeddedRunActive(false)
       promoteStreamToMessages()
@@ -1001,6 +1006,7 @@ export default function ChatView({
         setSending(false)
         sendingRef.current = false
         setServerRunningState(false)
+        setActiveGoalState('')
         // Stream ended without continuation. If we have local pending
         // entries, server may have cleared them (auth fail, error) —
         // refetch to reconcile. Skip when pending empty.
@@ -2814,6 +2820,7 @@ export default function ChatView({
       promoteStreamToMessages()
       setSending(false)
       setServerRunningState(false)
+      setActiveGoalState('')
       // Sync sendingRef to the just-committed state so the synchronous
       // doSend(resendText) call below reads the post-stop value.
       // setSending(false) queues a render — the next render will write
@@ -3082,10 +3089,7 @@ export default function ChatView({
   // (The fast-forward identity/readiness gates are computed separately below.)
   const turnActive = sending || isStreaming || serverRunning
   useEffect(() => {
-    if (!turnActive) {
-      if (activeGoalObjective) setActiveGoalState('')
-      return
-    }
+    if (!turnActive) return
     // Ordinary live turns set this synchronously at their run-start seam. This
     // branch is the cold remount/reconnect recovery path. The query cache
     // retains a known goal across keyed chat switches, including after a
@@ -3513,7 +3517,9 @@ export default function ChatView({
     .map(app => ({ app, vm: openAppCtaViewModel(app, turnActive) }))
     .filter(entry => entry.vm)
   const buildPhaseRail = buildPhaseRailViewModel(buildPhases)
-  const visibleGoalObjective = turnActive ? activeGoalObjective : ''
+  // Goal ownership comes from explicit run boundaries and authoritative
+  // runtime reconciliation, never a momentary browser transport signal.
+  const visibleGoalObjective = activeGoalObjective
   const progressRail = progressRailViewModel(
     visibleGoalObjective,
     buildPhaseRail,
@@ -3816,9 +3822,9 @@ export default function ChatView({
             attention actions → build-progress rail → connection/retry → queued
             messages → composer. The shell owns the one persistent offline
             explanation; the composer retains contextual send-failure copy. */}
-        {/* A LOST connection empties the stack: while the terminal
-            'disconnected' state is set, nudges, rail, and the queued tray
-            hide so the one thing on screen is the problem and its Retry
+        {/* A LOST connection hides transient actions: while the terminal
+            'disconnected' state is set, nudges hide so the one thing on screen
+            is the problem and its Retry
             (owner ask, 2026-07-17). ONLY 'disconnected' gates: 'retrying'
             is a transient bare-EOF auto-reconnect that clears itself in
             ~300ms — blanking and popping the whole stack on every mobile
@@ -3867,12 +3873,12 @@ export default function ChatView({
               </button>
             )}
           </div>
-          <ProgressRail
-            items={progressRail}
-            ariaLabel={visibleGoalObjective ? 'Goal progress' : 'Build progress'}
-          />
           </>
         )}
+        <ProgressRail
+          items={progressRail}
+          ariaLabel={visibleGoalObjective ? 'Goal progress' : 'Build progress'}
+        />
         {/* Contribution staged from THIS chat: approve it where the work
             happened. Renders nothing unless something is actually waiting.
             Owner-shell only: an app-embedded chat runs on a capability token

--- a/frontend/src/components/ChatView/__tests__/goalProgress.test.js
+++ b/frontend/src/components/ChatView/__tests__/goalProgress.test.js
@@ -10,6 +10,10 @@ import {
 } from '../goalProgress.js'
 
 const chatView = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8')
+const streamConnection = readFileSync(
+  new URL('../useStreamConnection.js', import.meta.url),
+  'utf8',
+)
 const progressRail = readFileSync(new URL('../ProgressRail.jsx', import.meta.url), 'utf8')
 const chatCss = readFileSync(new URL('../ChatView.css', import.meta.url), 'utf8')
 
@@ -120,7 +124,7 @@ test('the goal reuses the progress rail and stays as context for build phases', 
   )
 })
 
-test('ChatView binds goal state to the existing run-start and turn-end lifecycle', () => {
+test('ChatView binds goal state to explicit run boundaries, not transport liveness', () => {
   const runStarts = chatView.split('setBuildPhases(railAtRunStart())').slice(1)
   assert.equal(runStarts.length, 4, 'every current run-start seam should be covered')
   for (const suffix of runStarts) {
@@ -130,10 +134,35 @@ test('ChatView binds goal state to the existing run-start and turn-end lifecycle
       'goal and build progress must reset together at each run boundary',
     )
   }
+  assert.doesNotMatch(
+    chatView,
+    /if \(!turnActive\)[\s\S]{0,100}setActiveGoalState\(''\)/,
+    'a transient loss of browser liveness must not retire a durable goal',
+  )
   assert.match(
     chatView,
-    /if \(!turnActive\) \{\s*if \(activeGoalObjective\) setActiveGoalState\(''\)/,
-    'a completed or stopped turn must retire its goal indication',
+    /setServerRunningState\(false\)\s*setActiveGoalState\(''\)\s*\/\/ Stream ended without continuation/,
+    'a terminal stream boundary must retire its goal indication',
+  )
+  assert.match(
+    chatView,
+    /disconnect\(\{ clearStreaming: true \}\)\s*promoteStreamToMessages\(\)\s*setSending\(false\)\s*setServerRunningState\(false\)\s*setActiveGoalState\(''\)/,
+    'a confirmed Stop must retire its goal indication',
+  )
+  assert.match(
+    chatView,
+    /onConnectionLost: \(\) => \{[\s\S]{0,500}promoteStreamToMessages\(\{ keepTurnOpen: true \}\)/,
+    'connection loss may preserve partial output without ending the run',
+  )
+  assert.match(
+    streamConnection,
+    /onConnectionLostRef\.current\?\.\(\)[\s\S]{0,100}onNeedsRefreshRef\.current/,
+    'retry exhaustion must use the non-terminal handoff before reconciliation',
+  )
+  assert.match(
+    chatView,
+    /const visibleGoalObjective = activeGoalObjective/,
+    'goal visibility must follow goal ownership rather than a transport flag',
   )
   assert.match(
     chatView,

--- a/frontend/src/components/ChatView/useStreamConnection.js
+++ b/frontend/src/components/ChatView/useStreamConnection.js
@@ -161,6 +161,10 @@ const BROADCAST_REGISTRATION_WINDOW_MS = 1500
  * @param {(info?: {continues: boolean, promotedTs: number|null}) => void} [callbacks.onStreamEnd]
  *   Fired one rAF after the `done` event so React commits before the
  *   caller promotes streamItems to messages.
+ * @param {() => void} [callbacks.onConnectionLost]
+ *   Fired when this browser exhausts its reconnect attempts but the backend
+ *   turn may still be running. Callers may preserve the last-good payload,
+ *   but must not treat this as a terminal run boundary.
  * @param {(event: object) => void} [callbacks.onSystemEvent]
  *   Fired for non-chat SSE events (theme/app/shell). Not buffered.
  * @param {(opts?: {force?: boolean}) => void} [callbacks.onNeedsRefresh]
@@ -213,6 +217,7 @@ const BROADCAST_REGISTRATION_WINDOW_MS = 1500
  */
 export default function useStreamConnection(chatId, {
   onStreamEnd,
+  onConnectionLost,
   onSystemEvent,
   onNeedsRefresh,
   onQueuedTurnStarting,
@@ -606,6 +611,8 @@ export default function useStreamConnection(chatId, {
   const connectRef = useRef(null)
   const onStreamEndRef = useRef(onStreamEnd)
   onStreamEndRef.current = onStreamEnd
+  const onConnectionLostRef = useRef(onConnectionLost)
+  onConnectionLostRef.current = onConnectionLost
   const onSystemEventRef = useRef(onSystemEvent)
   onSystemEventRef.current = onSystemEvent
   const onNeedsRefreshRef = useRef(onNeedsRefresh)
@@ -1258,14 +1265,13 @@ export default function useStreamConnection(chatId, {
           _setStreamItems(saved)
         }
         // Retries are exhausted for THIS browser connection, not necessarily
-        // for the backend turn. Signal stream-end so any last-good partial can
-        // be promoted locally, then force a DB refresh; ChatView rehydrates
-        // `running` from the server and flips the composer back to active if
-        // the agent is still working. Without that refresh, a mobile sleep /
-        // network handoff could make the UI look idle while the server was
-        // still running.
+        // for the backend turn. Preserve any last-good partial through the
+        // explicitly non-terminal callback, then force an authoritative DB
+        // refresh. A connection failure must never masquerade as a run-end:
+        // doing so briefly retired run-owned UI (including the active goal)
+        // before the refresh restored `running` from the server.
         requestAnimationFrame(() => {
-          onStreamEndRef.current?.()
+          onConnectionLostRef.current?.()
           onNeedsRefreshRef.current?.({ force: true })
         })
       } else {

--- a/tests/stream-reconnect.spec.mjs
+++ b/tests/stream-reconnect.spec.mjs
@@ -976,8 +976,10 @@ test.describe('Stream reconnection', () => {
     const CHAT_ID = '11111111-1111-1111-1111-111111111111'
     const QUESTION_ID = 'q-frozen-1'
     const TURN_TS = 1700000000000
+    const GOAL = 'Keep this question stable'
 
     let answerPosted = null
+    let streamRequestCount = 0
 
     // Initial chat load: a running chat whose last assistant message is
     // frozen on an unanswered question. Crucially `pending_question_id`
@@ -989,7 +991,7 @@ test.describe('Stream reconnection', () => {
       title: 'frozen chat',
       updated_at: updatedAt,
       messages: [
-        { role: 'user', content: 'help me pick', ts: TURN_TS - 1000 },
+        { role: 'user', content: `/goal ${GOAL}`, ts: TURN_TS - 1000 },
         {
           role: 'assistant',
           ts: TURN_TS,
@@ -1012,6 +1014,7 @@ test.describe('Stream reconnection', () => {
       total: 2,
       offset: 0,
       running: true,
+      active_goal_objective: GOAL,
       pending_question_id: null,
       session_id: 'sess-1',
       provider: 'claude',
@@ -1031,6 +1034,7 @@ test.describe('Stream reconnection', () => {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           running: true,
+          active_goal_objective: GOAL,
           pending_messages: [],
           pending_question_id: null,
           updated_at: updatedAt,
@@ -1038,15 +1042,17 @@ test.describe('Stream reconnection', () => {
       })
     })
 
-    // The /stream catch-up is EMPTY (just catch_up_done) and the body
-    // holds open indefinitely — the turn is parked on the question
-    // future, so no `done` and no `question` event ever arrives.
+    // The first /stream catch-up is EMPTY (just catch_up_done), matching a
+    // turn parked on the question future: no `done` and no `question` event.
     // `streamItems` stays empty (no live card, no bridge suppression),
-    // `liveQuestionId` is never set by the stream, and `isStreaming`
-    // stays true. We use a never-resolving ReadableStream so the EOF
-    // reconnect loop doesn't churn — the connection just stays open the
-    // way a real parked turn's SSE does.
+    // and `liveQuestionId` is never set by the stream. Later reattachments
+    // fail so the same test reaches retry exhaustion after the answer handoff.
     await page.route(/\/api\/chats\/[0-9a-f-]+\/stream$/, async route => {
+      streamRequestCount++
+      if (streamRequestCount > 1) {
+        await route.fulfill({ status: 503, body: 'temporary stream failure' })
+        return
+      }
       const body = [
         'data: {"type":"catch_up_done"}\n\n',
       ].join('')
@@ -1055,12 +1061,8 @@ test.describe('Stream reconnection', () => {
         headers: {
           'Content-Type': 'text/event-stream',
           'Cache-Control': 'no-cache',
-          // A chunked SSE response that Playwright keeps open: fulfilling
-          // with a finite body still signals EOF, which would re-arm the
-          // reconnect. That's fine — every reconnect replays the same
-          // empty catch-up, isStreaming stays true throughout, and the
-          // persisted card stays answerable. We assert on that steady
-          // state.
+          // The finite body signals EOF and re-arms reconnect; subsequent
+          // requests deliberately fail above to exercise ambiguous loss.
         },
         body,
       })
@@ -1084,6 +1086,8 @@ test.describe('Stream reconnection', () => {
 
     // The persisted question card renders.
     await expect(page.locator('[data-chat-surface="painted"] .qcard')).toBeVisible({ timeout: 10000 })
+    const goalRail = page.getByRole('group', { name: 'Goal progress' })
+    await expect(goalRail).toContainText(`Goal · ${GOAL}`)
 
     // The option buttons must be ENABLED (the bug rendered them
     // disabled). Pick an answer + submit.
@@ -1094,6 +1098,13 @@ test.describe('Stream reconnection', () => {
     const submitBtn = page.getByRole('button', { name: 'Submit' })
     await expect(submitBtn).toBeEnabled()
     await submitBtn.click()
+
+    // The answer stays inside this same durable goal run. Even after this
+    // browser exhausts its reconnects, the connection warning must not retire
+    // the goal while the authoritative runtime still reports `running:true`.
+    await expect(goalRail).toContainText(`Goal · ${GOAL}`)
+    await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible({ timeout: 12000 })
+    await expect(goalRail).toContainText(`Goal · ${GOAL}`)
 
     // Answering MUST POST the answer payload (the turn unfreezes).
     await expect.poll(() => answerPosted, { timeout: 5000 }).not.toBeNull()


### PR DESCRIPTION
## Summary

- keep the active goal rail visible when browser reconnect attempts are exhausted but the server-side run remains active
- distinguish ambiguous connection loss from authoritative stream completion, preserving the last-good assistant content without retiring run-owned state
- clear the goal only on terminal completion, a confirmed Stop, or an authoritative idle refresh
- cover the active-goal, parked-question, answer, and Retry sequence in the mobile rendered regression

## Context

Follow-up to #429, which made active goal identity durable across steered questions. The shell still gated that durable goal on transient browser liveness and invoked its terminal callback after local retry exhaustion. A brief network handoff could therefore hide the goal, then restore it when runtime reconciliation reported that the same run was still active.

## Testing

- full frontend unit suite (2,257 passed)
- structural-test ratchet
- production/PWA build
- `git diff --check`

Co-authored-by: Möbius Agent <mobius-agent@users.noreply.github.com>