### PR TITLE
Align Claude and Codex prompt and source policy

### DIFF
--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -118,6 +118,17 @@ from app.memory_observability import record_memory_checkpoint_once
 
 log = logging.getLogger("moebius.chat")
 
+# Möbius supplies the complete behavioral constitution through the thread's
+# base_instructions. These overrides prevent user/project Codex configuration
+# from silently adding a second instruction stack. Permission, tool, app, and
+# environment blocks remain Codex-owned because they describe the runtime
+# surface rather than agent behavior.
+_CODEX_PROMPT_CONTROL_OVERRIDES = [
+  'instructions=""',
+  'developer_instructions=""',
+  "project_doc_max_bytes=0",
+]
+
 
 def _env_flag_on(name: str, *, default: bool) -> bool:
   """Read a boolean env var: ``off``/``0``/``false``/``no``/empty disable it;
@@ -130,6 +141,10 @@ def _env_flag_on(name: str, *, default: bool) -> bool:
 
 def _codex_config_overrides() -> list[str]:
   """Assemble the Codex ``CodexConfig.config_overrides`` for a turn.
+
+  Prompt-control overrides are unconditional: per-chat ``base_instructions``
+  owns behavior, while config files and project instruction documents must not
+  grow a provider-specific second constitution.
 
   ``request_user_input`` (AskUserQuestion parity) is always on. Multi-agent
   (collab / spawn_agent — the Codex analog of Claude's Task fleet, whose
@@ -149,7 +164,8 @@ def _codex_config_overrides() -> list[str]:
   robust to a rollout change, not just to the binary we probed. Re-run the
   delegate probe after any @openai/codex bump.
   """
-  overrides = [
+  overrides = list(_CODEX_PROMPT_CONTROL_OVERRIDES)
+  overrides += [
     "features.default_mode_request_user_input=true",
     # Codex owns goal durability in its thread store.  Enabling the native
     # goal extension lets a new app-server resume the logical operation after
@@ -863,7 +879,7 @@ def _sdk_imports() -> dict[str, Any]:
     InvalidRequestError,
     TransportClosedError,
   )
-  from openai_codex.types import ReasoningEffort, ReasoningSummary
+  from openai_codex.types import Personality, ReasoningEffort, ReasoningSummary
   from openai_codex.generated.v2_all import (
     AgentMessageDeltaNotification,
     AgentMessageThreadItem,
@@ -972,6 +988,7 @@ def _sdk_imports() -> dict[str, Any]:
     "FileChangePatchUpdatedNotification": FileChangePatchUpdatedNotification,
     "FileChangeThreadItem": FileChangeThreadItem,
     "ImageViewThreadItem": ImageViewThreadItem,
+    "Personality": Personality,
     "ReasoningEffort": ReasoningEffort,
     "ReasoningSummary": ReasoningSummary,
     "Sandbox": Sandbox,
@@ -1434,9 +1451,8 @@ async def run_codex_sdk_turn(
   env = dict(base_env)
   env.setdefault("CODEX_HOME", "/data/cli-auth/codex")
 
-  # config_overrides carries the request_user_input (AskUserQuestion parity) and
-  # multi-agent enablement flags — assembled, with the #31864 tool_namespace pin
-  # and the MOEBIUS_CODEX_MULTI_AGENT kill switch, in _codex_config_overrides().
+  # config_overrides always isolates the prompt stack, then carries the
+  # request_user_input (AskUserQuestion parity), goal, and multi-agent flags.
   codex_bin = shutil.which("codex")
   config_overrides = _codex_config_overrides()
   launch_args = _codex_app_server_launch_args(codex_bin, config_overrides)
@@ -1650,8 +1666,10 @@ async def run_codex_sdk_turn(
           approval_mode=sdk["ApprovalMode"].auto_review,
           sandbox=_sandbox,
           base_instructions=base_instructions,
+          developer_instructions="",
           cwd=cwd,
           model=model,
+          personality=sdk["Personality"].none,
         )
       else:
         # Resume parses the thread's persisted history, which can include
@@ -1666,8 +1684,10 @@ async def run_codex_sdk_turn(
           approval_mode=sdk["ApprovalMode"].auto_review,
           sandbox=_sandbox,
           base_instructions=base_instructions,
+          developer_instructions="",
           cwd=cwd,
           model=model,
+          personality=sdk["Personality"].none,
         )
       record_memory_checkpoint_once(
         "codex_first_thread_ready",

--- a/backend/app/system_prompts.py
+++ b/backend/app/system_prompts.py
@@ -1,4 +1,9 @@
-"""Capture immutable per-chat prompts from installed-app fragments.
+"""Capture immutable, provider-neutral per-chat prompts.
+
+The resulting snapshot is the complete behavioral constitution supplied to
+both Claude and Codex. Provider runners may add only the permission, tool, and
+runtime metadata their transports require; they must not substitute a
+provider-authored personality or behavioral prompt.
 
 An app opts into this privileged surface by declaring a root-level
 ``system_prompt`` markdown file in its manifest.  The installer stores only the

--- a/backend/tests/test_chat_skills_context.py
+++ b/backend/tests/test_chat_skills_context.py
@@ -121,6 +121,18 @@ def test_core_prompt_has_no_static_skill_catalog():
   assert "<available_skills>" in core
 
 
+def test_core_prompt_owns_freshness_and_source_policy():
+  repo = Path(__file__).resolve().parents[2]
+  core = (repo / "skill" / "core.md").read_text(encoding="utf-8")
+
+  assert "## Freshness and sources" in core
+  assert "the partner asks you to search" in core
+  assert "could plausibly have changed" in core
+  assert "When in doubt, search" in core
+  assert "Prefer primary and official sources" in core
+  assert "Cite the supporting link close to the claim" in core
+
+
 def test_owned_app_skill_summaries_expose_complete_initial_read_sets():
   repo = Path(__file__).resolve().parents[2]
   seed_dir = repo / "backend" / "scripts" / "seed-skills"

--- a/backend/tests/test_claude_sdk_runner.py
+++ b/backend/tests/test_claude_sdk_runner.py
@@ -960,6 +960,7 @@ async def test_run_claude_sdk_turn_requests_summarized_thinking(monkeypatch):
 
   assert captured["options"].model == "claude-opus-4-8"
   assert captured["options"].effort == "high"
+  assert captured["options"].system_prompt == "system"
   assert captured["options"].max_buffer_size == 10 * 1024 * 1024
   assert captured["options"].thinking == {
     "type": "adaptive",

--- a/backend/tests/test_codex_sdk_runner.py
+++ b/backend/tests/test_codex_sdk_runner.py
@@ -304,6 +304,9 @@ def _fake_sdk(async_codex_cls):
       self.message = message
       self.data = data
 
+  class _FakePersonality:
+    none = "none"
+
   return {
     "AgentMessageDeltaNotification": _Dummy,
     "AgentMessageThreadItem": _Dummy,
@@ -322,6 +325,7 @@ def _fake_sdk(async_codex_cls):
     "ImageViewThreadItem": type("_FakeImageViewThreadItem", (), {}),
     "InvalidParamsError": _FakeInvalidParamsError,
     "InvalidRequestError": _FakeInvalidRequestError,
+    "Personality": _FakePersonality,
     "ReasoningEffort": _FakeReasoningEffort(),
     "ReasoningSummary": _FakeReasoningSummary(),
     "Sandbox": _FakeSandbox,
@@ -3162,6 +3166,9 @@ def test_codex_config_overrides_kill_switch(monkeypatch):
   monkeypatch.setenv("MOEBIUS_CODEX_MULTI_AGENT", "off")
   ov = runner._codex_config_overrides()
   assert ov == [
+    'instructions=""',
+    'developer_instructions=""',
+    "project_doc_max_bytes=0",
     "features.default_mode_request_user_input=true",
     "features.goals=true",
   ]
@@ -3727,12 +3734,12 @@ def test_run_codex_sdk_turn_fallback_does_not_start_capture_poller(
   assert result["error"] is None
 
 
-def test_run_codex_sdk_turn_resume_supplies_base_instructions(monkeypatch):
-  # On resume, the immutable per-chat constitution snapshot must be re-supplied
-  # as base_instructions — parity with the Claude runner re-sending its system
-  # prompt every turn — so a resumed Codex thread stays anchored to its prompt
-  # even after a server-side compaction, rather than trusting the thread's
-  # original instructions to survive.
+@pytest.mark.parametrize("session_id", [None, "resumed-thread"])
+def test_run_codex_sdk_turn_controls_prompt_layers(monkeypatch, session_id):
+  # Fresh and resumed threads receive the same immutable constitution as their
+  # base prompt, with provider-authored developer/personality layers disabled.
+  # Re-supplying the snapshot on resume also keeps a compacted thread anchored
+  # without trusting its original instructions to survive indefinitely.
   completed_turn = SimpleNamespace(id="turn-r", usage=None, error=None)
   notifications = [
     SimpleNamespace(
@@ -3755,11 +3762,13 @@ def test_run_codex_sdk_turn_resume_supplies_base_instructions(monkeypatch):
 
     async def thread_resume(self, session_id, **kwargs):
       captured["session_id"] = session_id
-      captured["base_instructions"] = kwargs.get("base_instructions")
+      captured["thread_options"] = kwargs
       return thread
 
-    async def thread_start(self, *_a, **_k):
-      raise AssertionError("a resume turn must not fall back to thread_start")
+    async def thread_start(self, **kwargs):
+      captured["session_id"] = None
+      captured["thread_options"] = kwargs
+      return thread
 
   monkeypatch.setattr(
     codex_sdk_runner, "_sdk_imports", lambda: _fake_sdk(FakeAsyncCodex),
@@ -3767,7 +3776,7 @@ def test_run_codex_sdk_turn_resume_supplies_base_instructions(monkeypatch):
 
   result = asyncio.run(codex_sdk_runner.run_codex_sdk_turn(
     user_message="continue",
-    session_id="resumed-thread",
+    session_id=session_id,
     base_env={},
     cwd="/tmp",
     chat_id="chat-resume",
@@ -3777,8 +3786,12 @@ def test_run_codex_sdk_turn_resume_supplies_base_instructions(monkeypatch):
     system_prompt="FROZEN CONSTITUTION SNAPSHOT",
   ))
 
-  assert captured["session_id"] == "resumed-thread"
-  assert captured["base_instructions"] == "FROZEN CONSTITUTION SNAPSHOT"
+  assert captured["session_id"] == session_id
+  assert captured["thread_options"]["base_instructions"] == (
+    "FROZEN CONSTITUTION SNAPSHOT"
+  )
+  assert captured["thread_options"]["developer_instructions"] == ""
+  assert captured["thread_options"]["personality"] == "none"
   assert result["session_id"] == "resumed-thread"
   assert result["error"] is None
 # --- Structured rate-limit reset extraction --------------------------------

--- a/backend/tests/test_runner_registry_integration.py
+++ b/backend/tests/test_runner_registry_integration.py
@@ -175,6 +175,7 @@ def test_codex_runner_registers_then_unregisters_handle(monkeypatch):
     ),
     "ItemStartedNotification": type("ItemStartedNotification", (), {}),
     "McpToolCallThreadItem": type("McpToolCallThreadItem", (), {}),
+    "Personality": type("Personality", (), {"none": "none"}),
     "ReasoningEffort": lambda value: value,
     "Sandbox": type(
       "Sandbox",

--- a/skill/core.md
+++ b/skill/core.md
@@ -10,6 +10,33 @@ Möbius is AI-maximalist: light up the good path with design, examples, and inst
 
 ---
 
+## Freshness and sources
+
+Search the web whenever it would materially improve factual accuracy. Search is
+required when:
+
+- the partner asks you to search, browse, verify, look something up, find the
+  latest information, or provide citations, quotations, or links;
+- a claim could plausibly have changed since your knowledge was learned, such
+  as news, prices, laws, regulations, schedules, standards, software, product
+  specifications, or public and company roles;
+- a recommendation could cost the partner substantial time or money;
+- the partner names a page, paper, dataset, PDF, or site whose contents were
+  not supplied;
+- medical, legal, or financial accuracy is important; or
+- the subject is niche, emerging, uncertain, or otherwise has a meaningful
+  chance of being recalled incorrectly.
+
+When in doubt, search. Do not claim that current information was checked unless
+you actually searched. Prefer primary and official sources; for technical work,
+use official documentation or original research. For news, distinguish the
+publication date from the date the event occurred and compare recent reporting
+when needed. Cite the supporting link close to the claim it supports. Do not
+search merely to re-check stable, self-contained facts or inspect local state
+that the available local tools can establish directly.
+
+---
+
 ## Write surface
 
 `/data/platform/` is the whole running Möbius repository and is editable in place. Before changing platform source or taking a public GitHub action, read the complete matching procedure from the available skills injected for this session.


### PR DESCRIPTION
## Problem

Möbius supplies a custom system prompt to both Claude and Codex, but the shared constitution did not define when current information must be searched and cited. Codex could also add configured instructions, project guidance, or a provider personality beside the Möbius prompt, allowing provider behavior to drift.

## Change

- Add one provider-neutral freshness and sourcing policy to the Möbius constitution, requiring search for explicit lookup requests, changeable facts, consequential recommendations, named sources, high-stakes guidance, and uncertain topics.
- Define the immutable per-chat prompt snapshot as the complete behavioral constitution for both providers.
- Keep Claude on its exact custom system prompt and protect that contract with a regression assertion.
- Make Codex use the same snapshot on fresh and resumed threads while clearing configured base/developer instructions, disabling project instruction discovery, and selecting no provider personality.
- Preserve provider-owned permission, tool, app, and environment descriptions because they document the runtime surface rather than agent behavior.

Existing chats retain their immutable prompt snapshots; newly started chats receive the aligned policy after restart.

## Prior work

This builds on [#261](https://github.com/mobius-os/mobius/pull/261), which re-supplied `base_instructions` on Codex resume, and complements the native skill parity in [#258](https://github.com/mobius-os/mobius/pull/258). Neither change defined a common sourcing policy or closed the remaining Codex configuration, project-guidance, and personality instruction layers.

## Verification

- Focused Claude, Codex, and prompt-context suites: 184 passed.
- Python import/compile checks passed.
- The installed Codex CLI accepted the prompt-isolation configuration through `debug prompt-input`.