### PR TITLE
Restore delayed image-viewer close correlation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1097,7 +1097,13 @@ can deliver it untagged or not at all, which left the chat image viewer open
 with a permanently dead close button. A browser Back/swipe instead reaches the
 registered dismissal through `handleBack`; both navigation-event paths
 recognize a `dismissible` source BEFORE their phantom guard and before the
-Navigation API's `canIntercept` gate, and neither pops `navStackRef`. Forward traversal deliberately leaves a
+Navigation API's `canIntercept` gate, and neither pops `navStackRef`. Each
+registration captures the tagged shell cursor it was pushed from, so an
+untagged iframe landing restores that cursor rather than leaving it pointed at
+the consumed sentinel. Explicit-close traversals are also correlated with the
+entry that issued them: if delayed bookkeeping crosses a newer surface's
+sentinel, it never dismisses that surface and the navigation owner re-arms the
+same logical sentinel at the committed cursor. Forward traversal deliberately leaves a
 dismissed transient closed and treats its physical entry as a no-op sentinel;
 reopening it pushes a fresh entry and naturally truncates that stale Forward
 branch. Do not add component-local `popstate` listeners for these surfaces —

--- a/frontend/src/hooks/__tests__/navigationDismissible.test.js
+++ b/frontend/src/hooks/__tests__/navigationDismissible.test.js
@@ -158,6 +158,7 @@ function sessionHistory({ wedged = false, navigationApi = true } = {}) {
     },
     get pendingTraversals() { return queued },
     get currentKind() { return history.state?.kind ?? null },
+    get currentState() { return history.state },
     get depth() { return index },
   }
 }
@@ -233,6 +234,30 @@ test('closing stays available after a traversal the engine never delivers', asyn
     'a lost traversal must not leave the close affordance permanently dead')
 })
 
+test('late close bookkeeping cannot dismiss the next surface', async () => {
+  const engine = sessionHistory({ wedged: true })
+  const { result } = await mountNavigation(engine)
+  const dismissals = []
+
+  const first = result.current.openHistoryDismiss(() => dismissals.push('first'))
+  result.current.closeHistoryDismiss(first)
+
+  // Open another viewer before the first close's asynchronous traversal lands.
+  // The engine will now physically traverse off this newer sentinel, but the
+  // request is still correlated with `first` and must not close `second`.
+  const second = result.current.openHistoryDismiss(() => dismissals.push('second'))
+  engine.settle()
+
+  assert.deepEqual(dismissals, ['first'])
+  assert.equal(engine.currentKind, 'dismissible',
+    'the still-open surface gets one live sentinel re-armed at the cursor')
+
+  result.current.closeHistoryDismiss(second)
+  engine.settle()
+  assert.deepEqual(dismissals, ['first', 'second'])
+  assert.equal(engine.currentKind, 'base', 'its own close consumes that sentinel once')
+})
+
 test('a back gesture dismisses the surface even when it lands on an untagged entry', async () => {
   // iOS Safari without the Navigation API, with a sandboxed iframe entry
   // sitting beneath the sentinel: the landing reads untagged, and the phantom
@@ -249,6 +274,11 @@ test('a back gesture dismisses the surface even when it lands on an untagged ent
 
   assert.deepEqual(dismissals, ['gesture'], 'Back closes the surface')
   assert.equal(engine.currentKind, null, 'and lands on the untagged entry beneath it')
+
+  const next = result.current.openHistoryDismiss(() => dismissals.push('next'))
+  assert.equal(engine.currentState.index, 1,
+    'the next sentinel derives from the tagged cursor beneath the phantom')
+  result.current.closeHistoryDismiss(next)
 })
 
 test('a back gesture on a healthy engine dismisses exactly once', async () => {

--- a/frontend/src/hooks/useNavigation.js
+++ b/frontend/src/hooks/useNavigation.js
@@ -310,6 +310,12 @@ export default function useNavigation({
   // sentinels but no route. The callback registry lets handleBack dismiss the
   // exact mounted surface without teaching it about that surface's React state.
   const historyDismissalsRef = useRef(new Map())
+  // Explicit closes dismiss synchronously, then ask History to consume their
+  // sentinel. The traversal can be delayed past the opening of another surface
+  // (or dropped entirely), so correlate each request with the exact entry it
+  // was issued for instead of treating the next dismissible traversal as the
+  // currently mounted surface's Back gesture.
+  const pendingHistoryDismissTraversalsRef = useRef([])
   // Legacy app-local levels are destructive: Back tells the iframe to close
   // them, and Forward cannot recreate them. Remember those physical entries so
   // revisiting one can safely degrade to the app base. Reversible entries use
@@ -488,6 +494,11 @@ export default function useNavigation({
 
   const openHistoryDismiss = useCallback((onDismiss) => {
     if (typeof onDismiss !== 'function') return null
+    // The classic store can land on an untagged iframe phantom beneath this
+    // sentinel. Capture the shell cursor BEFORE pushing so either history path
+    // can restore that authoritative model even when no browser store can name
+    // the committed shell entry.
+    const returnState = currentNavStateRef.current
     let state
     try {
       state = pushShellEntry('dismissible', snapshotRoute())
@@ -496,7 +507,7 @@ export default function useNavigation({
     }
     const entryId = navEntryId(state)
     if (!entryId) return null
-    historyDismissalsRef.current.set(entryId, { onDismiss })
+    historyDismissalsRef.current.set(entryId, { onDismiss, returnState })
     return entryId
   }, [pushShellEntry, snapshotRoute])
 
@@ -514,10 +525,23 @@ export default function useNavigation({
     if (!dismissal) return false
     historyDismissalsRef.current.delete(entryId)
     const current = currentNavStateRef.current
-    if (current?.kind === 'dismissible' && navEntryId(current) === entryId) {
-      try { history.back() } catch { /* history unavailable — the surface still closes */ }
-    }
+    // Close the surface before touching session history. A throwing or lost
+    // traversal must never strand the UI open again.
     dismissal.onDismiss()
+    if (current?.kind === 'dismissible' && navEntryId(current) === entryId) {
+      const pending = { entryId, returnState: dismissal.returnState }
+      pendingHistoryDismissTraversalsRef.current.push(pending)
+      try {
+        history.back()
+      } catch (error) {
+        // Do not swallow an unobserved History failure. Remove only the request
+        // that was never issued, then preserve the browser's error; dismissal
+        // itself has already completed synchronously above.
+        const index = pendingHistoryDismissTraversalsRef.current.indexOf(pending)
+        if (index >= 0) pendingHistoryDismissTraversalsRef.current.splice(index, 1)
+        throw error
+      }
+    }
     return true
   }, [])
 
@@ -1295,6 +1319,59 @@ export default function useNavigation({
       if (id) consumedAppEntryIdsRef.current.add(id)
     }
 
+    function settleDismissibleTraversal(destination, source) {
+      const sourceEntryId = navEntryId(source)
+      const registration = sourceEntryId
+        ? historyDismissalsRef.current.get(sourceEntryId)
+        : null
+      // History serializes traversal requests. If an explicit close is waiting,
+      // this event answers the oldest request even when the engine reports the
+      // newly-current sentinel as its source.
+      const pending = pendingHistoryDismissTraversalsRef.current.shift() || null
+      const returnState = registration?.returnState
+        || (pending?.entryId === sourceEntryId ? pending.returnState : null)
+      const committed = isMobiusNavState(destination)
+        ? destination
+        : (isMobiusNavState(history.state)
+            ? history.state
+            : (isMobiusNavState(returnState) ? returnState : null))
+
+      // A close for an older entry arrived after another surface opened. It is
+      // bookkeeping for `pending.entryId`, NOT a Back gesture for the live
+      // `sourceEntryId`: do not invoke that newer registration. The traversal
+      // has nevertheless crossed its physical sentinel, so re-arm the same
+      // logical surface at the committed cursor. When we landed on the older
+      // sentinel itself, repurpose that slot; when the engine jumped all the
+      // way to its return state, push a replacement above it. In both cases the
+      // mounted hook keeps the same entry id and its next close consumes one
+      // sentinel in one Back.
+      if (pending && pending.entryId !== sourceEntryId) {
+        if (registration && sourceEntryId) {
+          let rearmed
+          if (navEntryId(committed) === pending.entryId) {
+            rearmed = updateCurrentNavEntry(source.route, {
+              kind: 'dismissible',
+              entryId: sourceEntryId,
+            })
+          } else {
+            rearmed = pushNavEntry('dismissible', source.route, {
+              currentState: committed || registration.returnState,
+              entryId: sourceEntryId,
+            })
+          }
+          if (rearmed) {
+            currentNavStateRef.current = rearmed
+            return
+          }
+        }
+        if (committed) currentNavStateRef.current = committed
+        return
+      }
+
+      if (committed) currentNavStateRef.current = committed
+      handleBack(committed, source)
+    }
+
     function handleBack(destination, source) {
       backFiredRef.current = true
       setTimeout(() => { backFiredRef.current = false }, 400)
@@ -1519,11 +1596,7 @@ export default function useNavigation({
         // and the shell never keeps pointing at an entry it has already left.
         if (source?.kind === 'dismissible') {
           const consumeDismissible = () => {
-            const committed = isMobiusNavState(destination)
-              ? destination
-              : (isMobiusNavState(history.state) ? history.state : null)
-            if (committed) currentNavStateRef.current = committed
-            handleBack(committed, source)
+            settleDismissibleTraversal(destination, source)
           }
           if (e.canIntercept) e.intercept({ handler: consumeDismissible })
           else setTimeout(consumeDismissible, 0)
@@ -1607,8 +1680,7 @@ export default function useNavigation({
       // sits BENEATH the sentinel) must still consume it rather than fall into
       // the phantom guard below and strand the surface (mirrors onNavigate).
       if (source?.kind === 'dismissible') {
-        if (isMobiusNavState(destination)) currentNavStateRef.current = destination
-        handleBack(destination, source)
+        settleDismissibleTraversal(destination, source)
         return
       }
       // Phantom-entry guard: a pop landing on an UNTAGGED entry is a phantom

--- a/frontend/src/lib/navHistory.js
+++ b/frontend/src/lib/navHistory.js
@@ -172,12 +172,18 @@ function mirrorCurrentEntry(state) {
 export function pushNavEntry(kind, route = null, {
   currentState = history.state,
   appNav = null,
+  entryId = null,
 } = {}) {
   const current = navEntryIndex(currentState)
   const state = navState(kind, {
     index: current == null ? 0 : current + 1,
     route,
-    entryId: newEntryId(),
+    // A caller normally gets a fresh identity. The one deliberate override is
+    // useNavigation re-arming the SAME live dismissible after an older close's
+    // delayed bookkeeping traversal crossed it. The old physical copy is on
+    // the discarded Forward branch; preserving the logical id keeps the
+    // mounted surface's close handle correlated with its replacement sentinel.
+    entryId: typeof entryId === 'string' ? entryId : newEntryId(),
     appNav,
   })
   history.pushState(state, '')
@@ -215,6 +221,12 @@ export function updateCurrentNavEntry(route, options = {}) {
   if (Object.prototype.hasOwnProperty.call(options, 'appNav')) {
     if (options.appNav) state.appNav = options.appNav
     else delete state.appNav
+  }
+  // Re-keying is reserved for the same dismissible re-arm described above.
+  // Ordinary route refreshes never pass this option and preserve identity.
+  if (Object.prototype.hasOwnProperty.call(options, 'entryId')) {
+    if (typeof options.entryId === 'string') state.entryId = options.entryId
+    else delete state.entryId
   }
   history.replaceState(state, '')
   mirrorCurrentEntry(state)


### PR DESCRIPTION
## What happened

GitHub merged [#452](https://github.com/mobius-os/mobius/pull/452) from a stale merge-queue snapshot. Its squash commit message includes the reviewed round-two commit (`421a972a`), but the merged tree contains only the earlier snapshot: it includes the synchronous close and initial behavioural coverage while omitting delayed-traversal correlation, tagged-cursor recovery/re-arm, History failure cleanup, and the round-two assertions.

## The change

This follow-up reapplies only that already-reviewed round-two patch on current `main`:

- correlate explicit-close bookkeeping with the entry that issued it, so a late traversal cannot dismiss a newer viewer;
- recover the tagged shell cursor after an untagged iframe landing and re-arm the same logical dismissible sentinel when an older traversal crosses it;
- remove only the failed pending request and rethrow if `history.back()` itself fails;
- restore the late-close and cursor-recovery coverage plus the small architecture note.

No part of #452's already-merged synchronous-close behaviour is duplicated.

## Verification

- focused dismissible-navigation tests: 5/5
- generated runtime source check: passed
- structural-test ratchet: 88/88 files, 780/780 cases
- frontend library tests: 2269/2269
- frontend hook tests: 76/76
- production build: passed