### PR TITLE
Restore pointer input for goal suggestions

### DIFF
--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -8,9 +8,9 @@
    ║   1. `.chat__foot` is `position: absolute`, offset above   ║
    ║      env(safe-area-inset-bottom),                           ║
    ║      with `pointer-events: none` — chat content scrolls    ║
-   ║      *behind* the composer. Only the pill + + + queue +    ║
-   ║      attach-tray re-enable pointer-events. The gutter is   ║
-   ║      transparent.                                          ║
+   ║      *behind* the composer. Visible footer controls must   ║
+   ║      opt back in through the allow-list beside the foot;   ║
+   ║      transparent wrappers keep the gutter pass-through.    ║
    ║                                                            ║
    ║   2. `--composer-h` is published by a ResizeObserver in    ║
    ║      ChatView.jsx that watches `.chat__foot`. `.chat__list`║
@@ -1947,6 +1947,7 @@
 .chat__foot .chat__resume-nudge,
 .chat__foot .chat__open-app,
 .chat__foot .chat__progress-step--toggle,
+.chat__foot .slash-menu,
 .chat__foot .chat__pill,
 .chat__foot .composer-plus { pointer-events: auto; }
 

--- a/tests/slash-command-menu.spec.mjs
+++ b/tests/slash-command-menu.spec.mjs
@@ -31,4 +31,14 @@ test('the slash menu follows textarea focus without losing the draft', async ({ 
 
   await input.focus()
   await expect(page.getByRole('listbox', { name: 'Commands' })).toBeVisible()
+
+  // The footer deliberately lets empty-space taps pass through to the
+  // transcript. Its visible command surface must opt back into hit testing so
+  // an ordinary pointer click can complete the command without submitting it.
+  await input.fill('/go')
+  await page.getByRole('option', { name: /\/goal/ }).click()
+  await expect(input).toHaveValue('/goal ')
+  await expect(input).toBeFocused()
+  await expect(page.getByRole('listbox', { name: 'Commands' })).toBeHidden()
+  await expect(paintedChat.locator('.message--user')).toHaveCount(0)
 })

--- a/tests/slash-command-menu.spec.mjs
+++ b/tests/slash-command-menu.spec.mjs
@@ -35,10 +35,11 @@ test('the slash menu follows textarea focus without losing the draft', async ({ 
   // The footer deliberately lets empty-space taps pass through to the
   // transcript. Its visible command surface must opt back into hit testing so
   // an ordinary pointer click can complete the command without submitting it.
-  await input.fill('/go')
+  const reopenedInput = paintedChat.locator('textarea[aria-label="Message Möbius…"]')
+  await reopenedInput.fill('/go')
   await page.getByRole('option', { name: /\/goal/ }).click()
-  await expect(input).toHaveValue('/goal ')
-  await expect(input).toBeFocused()
+  await expect(reopenedInput).toHaveValue('/goal ')
+  await expect(reopenedInput).toBeFocused()
   await expect(page.getByRole('listbox', { name: 'Commands' })).toBeHidden()
   await expect(paintedChat.locator('.message--user')).toHaveCount(0)
 })


### PR DESCRIPTION
## Summary

- restore pointer input for the goal suggestion inside the transparent composer footer
- preserve click-through behavior around the composer and keep focus in the input
- cover pointer autocomplete without accidentally submitting a message

## Root cause

The footer intentionally ignores pointer input so its transparent gutter does not block the conversation. The slash-command menu was missing from the small allow-list of visible controls that opt back into hit testing, so its existing click handler never received taps.

## Verification

- `npm test`
- `npm run build`
- rendered phone-sized interaction: `/go` → click `/goal` → `/goal `, input focused, menu closed, no message submitted