### PR TITLE
Align expanded activity labels with summary columns

### DIFF
--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -1587,17 +1587,18 @@
   transform: rotate(-90deg);
 }
 
-/* Expanded, a quiet vertical hairline places the chronological child steps
-   beneath the parent label. The rail is neutral hierarchy, not a decorative
-   accent stripe. */
+/* Expanded child steps keep the same icon and label columns as their summary.
+   An earlier nested rail added 32px before every child, so a parent such as
+   "Browsing the web" and its "Searched the web" steps visibly jumped between
+   columns. The disclosure itself already supplies the hierarchy; alignment is
+   the stronger scanning cue for a chronological activity list. */
 .chat__activity-timeline {
   display: flex;
   flex-direction: column;
   gap: var(--activity-row-gap, 4px);
   margin-top: var(--activity-row-gap, 4px);
-  margin-inline-start: 20px;
-  padding-inline-start: 11px;
-  border-inline-start: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  margin-inline-start: 0;
+  padding-inline-start: 0;
 }
 
 /* Shared screen-reader status utility for transcript-local interactions such

--- a/frontend/src/components/ChatView/__tests__/activityLineStructure.test.js
+++ b/frontend/src/components/ChatView/__tests__/activityLineStructure.test.js
@@ -137,7 +137,7 @@ test('lazy tool details keep top-level touch targets and compact nested rows', (
     'nested thought rows should keep the compact timeline rhythm')
 })
 
-test('activity spacing derives from one block gap and one row gap', () => {
+test('activity spacing and aligned columns derive from one shared rhythm', () => {
   const message = cssRule('.chat__msg--assistant')
   const tools = cssRule('.chat__tools')
   const timeline = cssRule('.chat__activity-timeline')
@@ -147,11 +147,12 @@ test('activity spacing derives from one block gap and one row gap', () => {
   assert.match(tools, /gap:\s*var\(--activity-row-gap, 4px\)/)
   assert.match(timeline, /gap:\s*var\(--activity-row-gap, 4px\)/)
   assert.match(timeline, /margin-top:\s*var\(--activity-row-gap, 4px\)/)
-  assert.match(timeline, /margin-inline-start:\s*20px/,
-    'child steps indent beneath the parent icon lane')
-  assert.match(timeline, /padding-inline-start:\s*11px/)
-  assert.match(timeline, /border-inline-start:\s*1px/,
-    'a neutral one-pixel rail carries the child hierarchy')
+  assert.match(timeline, /margin-inline-start:\s*0/,
+    'child labels must stay in the same column as their summary label')
+  assert.match(timeline, /padding-inline-start:\s*0/,
+    'the timeline must not add a second indentation before child icons')
+  assert.doesNotMatch(timeline, /border-inline-start/,
+    'a nested rail must not occupy the shared activity label column')
   assert.doesNotMatch(chatCss, /\.chat__tools \+ \.chat__tools\s*\{\s*margin-top:\s*2px/,
     'adjacent activity blocks should not retain a one-off gap')
 })

--- a/tests/activity-lazy.spec.mjs
+++ b/tests/activity-lazy.spec.mjs
@@ -529,8 +529,9 @@ test('activity stays nested and lazy, aborts on close, and copies exact tool out
     await expect(activity.locator(`[id="${controlledId}"]`)).toBeHidden()
   }
 
-  // The rail and leading type icons communicate hierarchy; activity rows carry
-  // no trailing disclosure chevrons.
+  // Leading type icons communicate hierarchy while expanded rows keep the
+  // same icon column as their summary; no rail or trailing disclosure chevron
+  // should push the child labels sideways.
   await expect(activity.locator('.chat__chevron')).toHaveCount(0)
   expect(await activity.locator('svg').count()).toBeGreaterThanOrEqual(3)
   const [activityBox, timelineBox, toolBox] = await Promise.all([
@@ -539,8 +540,8 @@ test('activity stays nested and lazy, aborts on close, and copies exact tool out
     toolToggle.boundingBox(),
   ])
   expect(activityBox).not.toBeNull()
-  expect(timelineBox.x).toBeGreaterThan(activityBox.x + 12)
-  expect(toolBox.x).toBeGreaterThan(timelineBox.x + 8)
+  expect(Math.abs(timelineBox.x - activityBox.x)).toBeLessThanOrEqual(1)
+  expect(Math.abs(toolBox.x - timelineBox.x)).toBeLessThanOrEqual(1)
   const activityHeaderBox = await activityHeader.boundingBox()
   const thoughtToggleBox = await thoughtToggle.boundingBox()
   const toolToggleBox = await toolToggle.boundingBox()


### PR DESCRIPTION
## Summary
- align expanded activity steps with their summary icon and text columns
- remove the extra timeline indentation that made web-search status text jump sideways

## Testing
- `npm test`