### PR TITLE
Make app-frame edge policy an update precondition

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -81,6 +81,17 @@ dependency manifest therefore carries a separate host action (and may require a
 particular ordering) even when the live clone merges cleanly. Never describe
 Apply + server restart alone as activating those files.
 
+The app-frame CSP is an explicit update precondition. Immediately before
+Settings sends Apply, the browser makes a cache-bypassing `HEAD` request to the
+public `/api/apps/0/frame` path and reports the effective enforced CSP. The
+backend rejects the update before touching source when that path is unverified
+or its effective script source list omits `blob:`. This checks the policy after
+the real public edge, not the weaker backend-only header. When the host edge must change, `scripts/reload-caddy.sh` validates and
+reloads the newly pulled `Caddyfile` **before** the owner retries Apply; a custom
+edge must perform the equivalent ordered reload. App code never falls back to a direct module URL:
+the exact-parent byte broker, version key, size bound, offline behavior, and
+token containment remain one execution path.
+
 **lodash is pinned to 4.18.1 via `overrides`.** `@openai/apps-sdk-ui` pulls lodash transitively — only through its `Slider` component, which the shell does not import. The 4.17.x line sat unfixed against several advisories for a long stretch; 4.18.x restored maintenance and patched them, so `frontend/package.json` `overrides` forces the transitive lodash to 4.18.1 (`npm audit` is clean). As defense-in-depth, `frontend/src/lib/__tests__/appsSdkLodash.test.js` also fails if the shell ever imports `Slider`, which keeps lodash tree-shaken out of the shipped bundle regardless of the pin.
 
 ## Self-update model — `upstream` / `main`, preserve local changes on update

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ If the instance cannot boot, start the latest isolated recovery worker without
 custom proxy configuration:
 
 ```bash
+
 scripts/mobiusctl recovery start
 # if the worker/browser restarts, rotate both credentials and print a new code:
 scripts/mobiusctl recovery reopen
@@ -175,13 +176,17 @@ Update a self-hosted instance inside Möbius: open Settings, find the Möbius
 section, and select **Check for updates**. Review the exact incoming commit,
 apply it, then select **Restart to finish**. The updater follows `origin/main`,
 preserves local platform changes, and keeps data under `/data`; normal updates
-do not require a host-side Git pull or image rebuild.
+do not require a host-side Git pull or image rebuild. If an update reports that
+the public app-frame policy is incompatible, update the host checkout first and
+run `scripts/reload-caddy.sh` before retrying Apply. A custom edge proxy needs
+the equivalent policy update and validated reload.
 
 The in-product agent has passwordless full root inside its Mobius container by
 default. To use the operator kill switch, set `MOBIUS_AGENT_SUDO=0` in `.env`
 and recreate the app with `docker compose up -d --force-recreate app`. The
 external recovery worker remains non-root and read-only, and recovery boot
 never installs the agent sudo rule.
+
 
 To connect a full web service such as Tandoor, point a sibling DNS name at the same server. For example, use `services.mobius.example.com`, then set it as `MOBIUS_SERVICE_GATEWAY_ORIGIN` in `.env`. Caddy serves integrations below `/services/<slug>`, so you do not need wildcard DNS or a new record for each service. See [.env.example](.env.example) for setup and [ARCHITECTURE.md](ARCHITECTURE.md#app-execution-tiers) for the trust boundaries.
 

--- a/backend/app/platform_edge.py
+++ b/backend/app/platform_edge.py
@@ -1,0 +1,53 @@
+"""Public-edge compatibility checks for owner-triggered platform updates.
+
+The bundled reverse proxy can replace the backend's app-frame CSP. The browser
+is therefore the only component that can observe the policy which will govern
+the next served frame. Settings reports that exact response header with Apply;
+this module validates the small, explicit contract before any source changes.
+"""
+
+from __future__ import annotations
+
+
+APP_FRAME_EDGE_PROBE_PATH = "/api/apps/0/frame"
+
+
+def csp_allows_blob_modules(value: str | None) -> bool:
+  """Whether every enforced policy permits a ``blob:`` module script.
+
+  A missing source-list directive imposes no script restriction, so a direct
+  or policy-free deployment remains valid. When a policy does constrain
+  scripts, ``script-src-elem`` takes precedence over ``script-src``, which in
+  turn falls back to ``default-src``. Multiple CSP headers are enforced as an
+  intersection; ASGI/browser header APIs expose them as a comma-joined value,
+  so every policy must allow the module.
+  """
+  if value is None or not value.strip():
+    return True
+
+  for policy in value.split(","):
+    directives: dict[str, tuple[str, ...]] = {}
+    for raw_directive in policy.split(";"):
+      parts = raw_directive.strip().lower().split()
+      if parts and parts[0] not in directives:
+        directives[parts[0]] = tuple(parts[1:])
+    sources = None
+    for name in ("script-src-elem", "script-src", "default-src"):
+      if name in directives:
+        sources = directives[name]
+        break
+    if sources is not None and "blob:" not in sources:
+      return False
+  return True
+
+
+def app_frame_edge_preflight_passes(
+  *,
+  path: str,
+  content_security_policy: str | None,
+) -> bool:
+  """Validate evidence from the one public path covered by the frame policy."""
+  return (
+    path == APP_FRAME_EDGE_PROBE_PATH
+    and csp_allows_blob_modules(content_security_policy)
+  )

--- a/backend/app/routes/platform.py
+++ b/backend/app/routes/platform.py
@@ -4,9 +4,9 @@ Small endpoints behind ``get_current_owner`` + ``reject_cross_site``:
 ``GET /status`` (cheap, read-only, fetch-free — drives the Settings "Updates"
 line), ``POST /check`` (owner-triggered ``git fetch`` + fresh status, the
 on-demand refresh for the "Check for updates" button), ``GET /update-preview``
-(an immutable exact-target plan), ``POST /apply`` (apply that reviewed target
-and merge it with local edits, or record a conflict),
-``GET /update-progress`` (the active Apply phase),
+(an immutable exact-target plan), ``POST /apply`` (verify the effective public
+app-frame policy, then apply that reviewed target and merge it with local edits,
+or record a conflict), ``GET /update-progress`` (the active Apply phase),
 ``POST /conflict-resolver-chat`` (owner-clicked resolver chat), and
 ``POST /restart`` (owner-confirmed self-restart, same SIGTERM pattern as the
 normal Settings restart). The status/check routes are wrapped so a transient git
@@ -25,7 +25,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 from starlette.background import BackgroundTask
 
-from app import models, platform_update
+from app import models, platform_edge, platform_update
 from app.database import get_db
 from app.deps import get_current_owner, reject_cross_site
 from app.platform_update import (
@@ -39,12 +39,20 @@ log = logging.getLogger("mobius.platform")
 router = APIRouter(prefix="/api/platform", tags=["platform"])
 
 
+class PlatformEdgePreflightIn(BaseModel):
+  """The effective app-frame policy observed through the public origin."""
+
+  path: str = Field(max_length=128)
+  content_security_policy: str | None = Field(default=None, max_length=16_384)
+
+
 class PlatformApplyIn(BaseModel):
   """The immutable update plan returned by ``GET /update-preview``."""
 
   plan_id: str = Field(min_length=64, max_length=64)
   current_sha: str = Field(min_length=40, max_length=64)
   target_sha: str = Field(min_length=40, max_length=64)
+  edge_preflight: PlatformEdgePreflightIn | None = None
 
 
 @router.get("/status")
@@ -120,6 +128,14 @@ async def apply_platform_update(
 ) -> PlatformApplyResult:
   """Apply exactly the release represented by the reviewed immutable plan."""
   try:
+    preflight = request.edge_preflight
+    if preflight is None:
+      raise HTTPException(status_code=409, detail="edge_csp_preflight_required")
+    if not platform_edge.app_frame_edge_preflight_passes(
+      path=preflight.path,
+      content_security_policy=preflight.content_security_policy,
+    ):
+      raise HTTPException(status_code=409, detail="edge_csp_blob_required")
     return await platform_update.apply_platform_update(
       db,
       plan_id=request.plan_id,

--- a/backend/tests/test_platform_edge.py
+++ b/backend/tests/test_platform_edge.py
@@ -1,0 +1,125 @@
+"""The updater's public app-frame policy migration contract."""
+
+import os
+import re
+import stat
+import subprocess
+from pathlib import Path
+
+from app.platform_edge import (
+  APP_FRAME_EDGE_PROBE_PATH,
+  app_frame_edge_preflight_passes,
+  csp_allows_blob_modules,
+)
+
+
+# Exact resource policy served to every frame by the bundled Caddyfile before
+# the brokered blob loader landed. The old matcher used this ordinary shell CSP
+# for `/api/apps/*/frame`, producing the real version-skew outage from #114.
+OLD_BUNDLED_APP_FRAME_CSP = (
+  "default-src 'self'; script-src 'self' 'unsafe-inline' https://esm.sh; "
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
+  "font-src 'self' https://fonts.gstatic.com https://cdn.openai.com; "
+  "connect-src 'self'; img-src 'self' data: blob:; frame-src 'self' "
+  "{$MOBIUS_SERVICE_GATEWAY_ORIGIN}; frame-ancestors 'self'"
+)
+
+
+def _current_bundled_app_frame_csp() -> str:
+  source = (Path(__file__).resolve().parents[2] / "Caddyfile").read_text()
+  line = next(
+    line.strip() for line in source.splitlines()
+    if line.strip().startswith(
+      "header @appFrame >Content-Security-Policy "
+    )
+  )
+  match = re.search(r'Content-Security-Policy "(.*)"$', line)
+  assert match is not None
+  return match.group(1)
+
+
+def test_real_old_bundled_policy_is_rejected_before_new_frame_activation():
+  assert csp_allows_blob_modules(OLD_BUNDLED_APP_FRAME_CSP) is False
+  assert csp_allows_blob_modules(_current_bundled_app_frame_csp()) is True
+
+
+def test_every_enforced_policy_must_allow_blob_modules():
+  assert csp_allows_blob_modules(None) is True
+  assert csp_allows_blob_modules("sandbox allow-scripts") is True
+  assert csp_allows_blob_modules(
+    "default-src 'self'; script-src 'self' blob:, sandbox allow-scripts"
+  ) is True
+  assert csp_allows_blob_modules(
+    "script-src 'self' blob:, default-src 'self'"
+  ) is False
+  assert csp_allows_blob_modules(
+    "script-src 'self' blob:; script-src-elem 'self'"
+  ) is False
+  assert csp_allows_blob_modules(
+    "script-src; default-src 'self' blob:"
+  ) is False
+
+
+def test_preflight_evidence_is_bound_to_the_frame_policy_path():
+  csp = "default-src 'self'; script-src 'self' blob:"
+  assert app_frame_edge_preflight_passes(
+    path=APP_FRAME_EDGE_PROBE_PATH,
+    content_security_policy=csp,
+  ) is True
+  assert app_frame_edge_preflight_passes(
+    path="/shell/",
+    content_security_policy=csp,
+  ) is False
+
+
+def test_self_hosted_update_validates_then_reloads_the_running_edge(tmp_path):
+  root = Path(__file__).resolve().parents[2]
+  script_path = root / "scripts" / "reload-caddy.sh"
+  readme = (root / "README.md").read_text()
+
+  binary_dir = tmp_path / "bin"
+  binary_dir.mkdir()
+  call_log = tmp_path / "docker-calls"
+  docker = binary_dir / "docker"
+  docker.write_text(
+    "#!/bin/sh\n"
+    "printf '%s\\n' \"$*\" >> \"$MOBIUS_DOCKER_CALL_LOG\"\n"
+    "if [ \"$*\" = 'compose ps --status running --services' ]; then\n"
+    "  printf '%s\\n' caddy\n"
+    "fi\n"
+  )
+  docker.chmod(0o755)
+  env = dict(os.environ)
+  env["PATH"] = f"{binary_dir}:{env['PATH']}"
+  env["MOBIUS_DOCKER_CALL_LOG"] = str(call_log)
+
+  result = subprocess.run(
+    [str(script_path)],
+    cwd=root,
+    env=env,
+    capture_output=True,
+    text=True,
+    check=False,
+  )
+
+  assert script_path.stat().st_mode & stat.S_IXUSR
+  assert result.returncode == 0, result.stderr
+  calls = call_log.read_text().splitlines()
+  assert calls == [
+    "compose version",
+    "compose ps --status running --services",
+    (
+      "compose exec -T caddy caddy validate "
+      "--config /etc/caddy/Caddyfile --adapter caddyfile"
+    ),
+    (
+      "compose exec -T caddy caddy reload "
+      "--config /etc/caddy/Caddyfile --adapter caddyfile"
+    ),
+  ]
+  assert result.stdout.strip() == "reload-caddy: active edge policy reloaded."
+  assert "scripts/reload-caddy.sh" in readme
+  update_section = readme.index("Update a self-hosted instance inside Möbius:")
+  reload_instruction = readme.index("scripts/reload-caddy.sh", update_section)
+  retry_instruction = readme.index("before retrying Apply", update_section)
+  assert reload_instruction < retry_instruction

--- a/backend/tests/test_platform_routes.py
+++ b/backend/tests/test_platform_routes.py
@@ -96,13 +96,64 @@ def test_apply_forwards_exact_reviewed_plan(client, auth, monkeypatch):
     "plan_id": "a" * 64,
     "current_sha": "1" * 40,
     "target_sha": "2" * 40,
+    "edge_preflight": {
+      "path": "/api/apps/0/frame",
+      "content_security_policy": (
+        "default-src 'self'; script-src 'self' blob:"
+      ),
+    },
   }
 
   res = client.post("/api/platform/apply", headers=auth, json=body)
 
   assert res.status_code == 200
-  assert captured == body
+  assert captured == {
+    "plan_id": body["plan_id"],
+    "current_sha": body["current_sha"],
+    "target_sha": body["target_sha"],
+  }
   assert res.json()["upstream_commit"] == body["target_sha"]
+
+
+def test_apply_rejects_missing_or_old_public_frame_policy(
+  client, auth, monkeypatch,
+):
+  called = False
+
+  async def fake_apply(*_args, **_kwargs):
+    nonlocal called
+    called = True
+
+  monkeypatch.setattr(
+    "app.routes.platform.platform_update.apply_platform_update",
+    fake_apply,
+  )
+  plan = {
+    "plan_id": "a" * 64,
+    "current_sha": "1" * 40,
+    "target_sha": "2" * 40,
+  }
+
+  missing = client.post("/api/platform/apply", headers=auth, json=plan)
+  assert missing.status_code == 409
+  assert missing.json()["detail"] == "edge_csp_preflight_required"
+
+  old = client.post(
+    "/api/platform/apply",
+    headers=auth,
+    json={
+      **plan,
+      "edge_preflight": {
+        "path": "/api/apps/0/frame",
+        "content_security_policy": (
+          "default-src 'self'; script-src 'self' 'unsafe-inline'"
+        ),
+      },
+    },
+  )
+  assert old.status_code == 409
+  assert old.json()["detail"] == "edge_csp_blob_required"
+  assert called is False
 
 
 def test_update_check_reports_fetch_failure(client, auth, monkeypatch):

--- a/frontend/src/components/SettingsView/SettingsView.jsx
+++ b/frontend/src/components/SettingsView/SettingsView.jsx
@@ -7,9 +7,14 @@ import { api, clearQueryCache, clearToken } from '../../api/client.js'
 import { authQueries, modelQueries, settingsQueries, themeQueries, versionQueries } from '../../hooks/queries.js'
 import { platformVersionIdentity } from '../../lib/platformVersionIdentity.js'
 import {
+  platformApplyErrorMessage,
   platformStatusFromApply,
   platformUpdateStatusLabel,
 } from '../../lib/platformUpdateState.js'
+import {
+  applyWithFreshEdgePolicy,
+  probeAppFrameEdgePolicy,
+} from '../../lib/platformEdgePreflight.js'
 import { settleBackgroundAgentSave } from '../../lib/backgroundAgentSave.js'
 import {
   PROVIDER_AVAILABILITY_PHASE,
@@ -1125,19 +1130,23 @@ export default function SettingsView({
     setPlatformProgress(null)
     setPlatformPhase('applying')
     try {
-      const res = await api.platform.apply(plan)
+      const { error: preflightError, response: res } = await applyWithFreshEdgePolicy(
+        plan,
+        {
+          probe: probeAppFrameEdgePolicy,
+          apply: payload => api.platform.apply(payload),
+        },
+      )
+      if (preflightError) {
+        setPlatformError(preflightError)
+        return { ok: false }
+      }
       let body = null
       try { body = await res.json() } catch {}
       if (!res.ok) {
         const detail = body?.detail || ''
         await refreshPlatform()
-        setPlatformError(
-          detail === 'update_plan_stale'
-            ? 'Möbius changed since this preview. Close it and review the refreshed update before applying.'
-            : detail
-              ? `Update stopped: ${detail}`
-              : 'Update stopped before completion. Check the current status before trying again.',
-        )
+        setPlatformError(platformApplyErrorMessage(detail))
         return { ok: false }
       }
       const state = typeof body?.state === 'string' ? body.state : ''

--- a/frontend/src/lib/__tests__/platformEdgePreflight.test.js
+++ b/frontend/src/lib/__tests__/platformEdgePreflight.test.js
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  APP_FRAME_EDGE_PROBE_PATH,
+  EDGE_POLICY_UNVERIFIED_MESSAGE,
+  applyWithFreshEdgePolicy,
+  probeAppFrameEdgePolicy,
+} from '../platformEdgePreflight.js'
+
+test('the edge probe bypasses app-code caches and reports the effective CSP', async () => {
+  const calls = []
+  const result = await probeAppFrameEdgePolicy(async (url, options) => {
+    calls.push({ url, options })
+    return {
+      status: 404,
+      headers: new Headers({
+        'Content-Security-Policy': "default-src 'self'; script-src 'self' blob:",
+      }),
+    }
+  }, () => 42)
+
+  assert.deepEqual(calls, [{
+    url: `${APP_FRAME_EDGE_PROBE_PATH}?mobius_edge_preflight=42`,
+    options: {
+      method: 'HEAD',
+      cache: 'no-store',
+      credentials: 'same-origin',
+    },
+  }])
+  assert.deepEqual(result, {
+    path: APP_FRAME_EDGE_PROBE_PATH,
+    content_security_policy: "default-src 'self'; script-src 'self' blob:",
+  })
+})
+
+test('a policy-free edge is represented explicitly rather than as a failed probe', async () => {
+  const result = await probeAppFrameEdgePolicy(async () => ({
+    status: 404,
+    headers: new Headers(),
+  }), () => 42)
+
+  assert.deepEqual(result, {
+    path: APP_FRAME_EDGE_PROBE_PATH,
+    content_security_policy: null,
+  })
+})
+
+test('apply carries the policy measured on this attempt, not a cached one', async () => {
+  const payloads = []
+  const probed = {
+    path: APP_FRAME_EDGE_PROBE_PATH,
+    content_security_policy: "script-src 'self' blob:",
+  }
+
+  const outcome = await applyWithFreshEdgePolicy(
+    { plan_id: 'p1', current_sha: 'aaa', target_sha: 'bbb' },
+    {
+      probe: async () => probed,
+      apply: async payload => {
+        payloads.push(payload)
+        return { ok: true }
+      },
+    },
+  )
+
+  assert.deepEqual(payloads, [{
+    plan_id: 'p1',
+    current_sha: 'aaa',
+    target_sha: 'bbb',
+    edge_preflight: probed,
+  }])
+  assert.deepEqual(outcome, { response: { ok: true } })
+})
+
+test('an unreadable edge stops the update before anything is applied', async () => {
+  let applied = 0
+
+  const outcome = await applyWithFreshEdgePolicy(
+    { plan_id: 'p1' },
+    {
+      probe: async () => { throw new Error('offline') },
+      apply: async () => { applied += 1 },
+    },
+  )
+
+  assert.equal(applied, 0)
+  assert.deepEqual(outcome, { error: EDGE_POLICY_UNVERIFIED_MESSAGE })
+})

--- a/frontend/src/lib/__tests__/platformUpdateState.test.js
+++ b/frontend/src/lib/__tests__/platformUpdateState.test.js
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import {
+  platformApplyErrorMessage,
   platformStatusFromApply,
   platformUpdateStatusLabel,
 } from '../platformUpdateState.js'
@@ -126,5 +127,20 @@ test('a legacy deployment flag does not hide an available in-app update', () => 
       updates_disabled: true,
     }),
     'New update available',
+  )
+})
+
+test('edge preflight failures explain the host-side recovery path', () => {
+  assert.match(
+    platformApplyErrorMessage('edge_csp_preflight_required'),
+    /Refresh this page/,
+  )
+  assert.match(
+    platformApplyErrorMessage('edge_csp_blob_required'),
+    /scripts\/reload-caddy\.sh/,
+  )
+  assert.equal(
+    platformApplyErrorMessage('update_plan_stale'),
+    'Möbius changed since this preview. Close it and review the refreshed update before applying.',
   )
 })

--- a/frontend/src/lib/platformEdgePreflight.js
+++ b/frontend/src/lib/platformEdgePreflight.js
@@ -1,0 +1,47 @@
+export const APP_FRAME_EDGE_PROBE_PATH = '/api/apps/0/frame'
+
+/** Read the policy that the public edge actually applies to app frames.
+ *
+ * HEAD is deliberately outside the service worker's GET-only app-code route,
+ * and app id 0 can never name an installed app. The response may be 404; only
+ * its edge-selected headers matter. A unique query plus `no-store` prevents a
+ * browser/CDN cache from turning an old policy into fresh evidence.
+ */
+export async function probeAppFrameEdgePolicy(
+  fetchImpl = globalThis.fetch,
+  now = Date.now,
+) {
+  const url = `${APP_FRAME_EDGE_PROBE_PATH}?mobius_edge_preflight=${now()}`
+  const response = await fetchImpl(url, {
+    method: 'HEAD',
+    cache: 'no-store',
+    credentials: 'same-origin',
+  })
+  return {
+    path: APP_FRAME_EDGE_PROBE_PATH,
+    content_security_policy: response.headers.get('content-security-policy'),
+  }
+}
+
+export const EDGE_POLICY_UNVERIFIED_MESSAGE =
+  'Couldn’t verify the public app-frame security policy, so nothing was changed. '
+  + 'Check the host proxy, then try again.'
+
+/** Apply a reviewed update only with a freshly measured edge policy attached.
+ *
+ * The ordering is the contract: the CSP the public edge serves decides whether
+ * mini-apps can still execute after the rebuild, so an unreadable edge must
+ * stop the update BEFORE any source changes rather than after. Binding the
+ * probe and the apply call into one unit keeps a future caller from issuing an
+ * apply that skips the probe, and makes the precondition testable without
+ * rendering Settings.
+ */
+export async function applyWithFreshEdgePolicy(plan, { probe, apply }) {
+  let edgePreflight
+  try {
+    edgePreflight = await probe()
+  } catch {
+    return { error: EDGE_POLICY_UNVERIFIED_MESSAGE }
+  }
+  return { response: await apply({ ...plan, edge_preflight: edgePreflight }) }
+}

--- a/frontend/src/lib/platformUpdateState.js
+++ b/frontend/src/lib/platformUpdateState.js
@@ -49,3 +49,18 @@ export function platformUpdateStatusLabel(platform) {
   if (available) return 'New update available'
   return 'Up to date'
 }
+
+export function platformApplyErrorMessage(detail) {
+  if (detail === 'update_plan_stale') {
+    return 'Möbius changed since this preview. Close it and review the refreshed update before applying.'
+  }
+  if (detail === 'edge_csp_preflight_required') {
+    return 'Refresh this page before applying. The current update flow must verify the public app-frame security policy first.'
+  }
+  if (detail === 'edge_csp_blob_required') {
+    return 'Nothing was changed because the host proxy still serves the older app-frame security policy. Reload its /api/apps/*/frame policy, or run scripts/reload-caddy.sh for bundled Caddy, then try again.'
+  }
+  return detail
+    ? `Update stopped: ${detail}`
+    : 'Update stopped before completion. Check the current status before trying again.'
+}

--- a/scripts/reload-caddy.sh
+++ b/scripts/reload-caddy.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -eu
+
+# Reload the bundled self-hosted edge from the host checkout's current
+# Caddyfile. Updating a bind-mounted file does not guarantee that the already
+# running Caddy process has loaded it, so validate and reload explicitly.
+REPO_ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+cd "$REPO_ROOT"
+
+if ! docker compose version >/dev/null 2>&1; then
+  echo "reload-caddy: Docker Compose is required." >&2
+  exit 1
+fi
+if ! docker compose ps --status running --services | grep -qx caddy; then
+  echo "reload-caddy: the bundled caddy service is not running." >&2
+  echo "Run 'docker compose up -d --build' first." >&2
+  exit 1
+fi
+
+docker compose exec -T caddy \
+  caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile
+docker compose exec -T caddy \
+  caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile
+
+echo "reload-caddy: active edge policy reloaded."

--- a/tests/platform-update-modal.spec.mjs
+++ b/tests/platform-update-modal.spec.mjs
@@ -137,6 +137,10 @@ test('a clean apply closes the review and exposes the restart step', async ({ pa
     plan_id: preview.plan_id,
     current_sha: preview.current_sha,
     target_sha: preview.target_sha,
+    edge_preflight: {
+      path: '/api/apps/0/frame',
+      content_security_policy: expect.stringContaining('blob:'),
+    },
   })
   const restart = page.getByRole('button', { name: 'Restart to finish' })
   await expect(restart).toBeVisible()


### PR DESCRIPTION
## Summary
- probe the effective public app-frame CSP immediately before Settings applies an update
- stop before any source change when the edge cannot execute brokered blob modules
- provide a validated Caddy reload helper for host-edge migrations
- keep app execution on the exact-parent byte broker without a direct module-URL fallback

## Why
Closes #114.

[#109](https://github.com/mobius-os/mobius/pull/109) reproduced the all-app outage, but its direct-import fallback could execute app code twice, bypass broker size/version/offline invariants, and expose the app bearer in a module URL. This fixes the migration at the update boundary instead.

The in-product path now checks the policy observed after the real public edge and rejects Apply without touching the platform tree. When the host edge needs to change, the helper validates and reloads the pulled Caddy policy before the owner retries Apply. Custom proxies need the equivalent ordered reload.

## Testing
- focused platform edge/update/routes tests: 87 passed
- full frontend unit suite: 2,296 lib tests + 77 hook tests
- production frontend build
- `git diff --check`
