### PR TITLE
Keep the chat composer focused through picker taps

### DIFF
--- a/frontend/src/components/ChatView/ChatInputBar.jsx
+++ b/frontend/src/components/ChatView/ChatInputBar.jsx
@@ -36,6 +36,8 @@
  * ║      + tap, so the check is accurate. Refocus after pick is      ║
  * ║      GATED on this ref — unconditional refocus would pop the     ║
  * ║      keyboard up even when the user opened + with kb down.       ║
+ * ║      The same restoration runs when the native picker is         ║
+ * ║      cancelled, so returning empty-handed does not lose focus.   ║
  * ║                                                                  ║
  * ║   3. CHIP × BUTTON keeps the keyboard                            ║
  * ║      The remove-attachment × has `onPointerDown.preventDefault`  ║
@@ -105,6 +107,7 @@ import {
   textareaUsesNativeSizing,
   syncComposerTallClass,
 } from './composerTextareaSizing.js'
+import { focusComposerElement } from './composerFocusPolicy.js'
 
 
 // Detect touch-primary once (same heuristic ChatView uses).
@@ -609,19 +612,22 @@ export default function ChatInputBar({
   const hasInput = hasSendablePayload(input, pendingFiles)
   const hasUploading = pendingFiles?.some(c => c.status === 'uploading') ?? false
 
+  function restoreFocusAfterFilePicker() {
+    const shouldRestore = wasInputFocusedAtPickerOpenRef.current
+    wasInputFocusedAtPickerOpenRef.current = false
+    // The OS picker temporarily replaces the page. Restore the exact state the
+    // owner had before opening it, including when they cancel without choosing
+    // a file (modern browsers emit `cancel` instead of `change` in that case).
+    if (shouldRestore) {
+      setTimeout(() => focusComposerElement(inputRef?.current), 0)
+    }
+  }
+
   function handleFileSelect(e) {
     const fileList = Array.from(e.target.files || [])
-    if (!fileList.length) return
     e.target.value = ''
-    onAddFiles(fileList)
-    // Only refocus the textarea (reopening the soft keyboard) if it
-    // was focused BEFORE the OS file picker opened. Unconditional
-    // refocus would pop the keyboard up even when the user tapped
-    // `+` with the keyboard down — see the matching contract in
-    // ComposerPopover and ChatSettingsPanel.
-    if (wasInputFocusedAtPickerOpenRef.current) {
-      setTimeout(() => inputRef?.current?.focus({ preventScroll: true }), 0)
-    }
+    if (fileList.length) onAddFiles(fileList)
+    restoreFocusAfterFilePicker()
   }
 
   function handleTextareaChange(e) {
@@ -775,6 +781,7 @@ export default function ChatInputBar({
         multiple
         ref={fileInputRef}
         onChange={handleFileSelect}
+        onCancel={restoreFocusAfterFilePicker}
         style={{ display: 'none' }}
       />
       {sendFailure && (

--- a/frontend/src/components/ChatView/ChatSettingsPanel.jsx
+++ b/frontend/src/components/ChatView/ChatSettingsPanel.jsx
@@ -53,8 +53,9 @@
  * ║      model or effort with the keyboard DOWN does NOT pop it      ║
  * ║      up. Every interactive row in this panel has                 ║
  * ║      pointerdown focus guards — see ComposerPopover.jsx's        ║
- * ║      three-guard contract for the full story. Touch starts are   ║
- * ║      allowed to pan so long model lists can scroll.              ║
+ * ║      three-guard contract for the full story. The guard applies  ║
+ * ║      to touch too; `touch-action: pan-y` still lets a row-origin  ║
+ * ║      gesture scroll the long model list.                         ║
  * ║                                                                  ║
  * ║   The shared <EffortStepper> renders a stepper track — NOT       ║
  * ║   pills, NOT a chip group. The slider was explicitly chosen      ║
@@ -98,6 +99,10 @@ import {
   resolveProviderAvailability,
   visibleProviderModels,
 } from '../../lib/providerAvailability.js'
+import {
+  focusComposerElement,
+  preserveComposerInputFocus,
+} from './composerFocusPolicy.js'
 import './ChatSettingsPanel.css'
 
 /** Claude product mark — four-petal flower / starburst silhouette,
@@ -199,11 +204,6 @@ export const PROVIDER_INFO = {
 export const PROVIDER_ORDER = ['codex', 'claude']
 
 
-function preserveFocusUnlessTouch(ev) {
-  if (ev.pointerType !== 'touch') ev.preventDefault()
-}
-
-
 /** Resolves the displayed model list for `providerId` from the live
  *  registry + owner prefs.
  *
@@ -254,6 +254,7 @@ export default function ChatSettingsPanel({
   // action so the soft keyboard stays in its previous state
   // (up if it was up, down if it was down).
   wasInputFocusedRef,
+  composerInputRef,
   // Per-chat external state survives the popover and ChatView itself. This is
   // what keeps navigation away/back from unlocking a live handoff or losing
   // its retry id and error feedback.
@@ -461,9 +462,8 @@ export default function ChatSettingsPanel({
   // but only when the user was actually typing.
   const refocusChatInput = useCallback(() => {
     if (!wasInputFocusedRef?.current) return
-    const el = document.querySelector('.chat__input')
-    if (el) el.focus({ preventScroll: true })
-  }, [wasInputFocusedRef])
+    focusComposerElement(composerInputRef?.current)
+  }, [composerInputRef, wasInputFocusedRef])
 
   const handleEffortChange = useCallback((value) => {
     // Remember this effort under the active provider so a later
@@ -692,6 +692,7 @@ export default function ChatSettingsPanel({
               <span>Could not load models.</span>
               <button
                 type="button"
+                onPointerDown={preserveComposerInputFocus}
                 onClick={() => {
                   registryQuery.refetch()
                   prefsQuery.refetch()
@@ -721,7 +722,11 @@ export default function ChatSettingsPanel({
       {dataReady && availability.phase === PROVIDER_AVAILABILITY_PHASE.ERROR && (
         <div className="csp__availability-warning" role="alert">
           <span>Could not verify providers. Showing the current model only.</span>
-          <button type="button" onClick={() => providerStatusQuery.refetch()}>
+          <button
+            type="button"
+            onPointerDown={preserveComposerInputFocus}
+            onClick={() => providerStatusQuery.refetch()}
+          >
             Retry
           </button>
         </div>
@@ -762,7 +767,7 @@ export default function ChatSettingsPanel({
               <button
                 type="button"
                 className={`csp-row${isSelected ? ' csp-row--selected' : ''}`}
-                onPointerDown={preserveFocusUnlessTouch}
+                onPointerDown={preserveComposerInputFocus}
                 onClick={() => {
                   if (!appCrossProvider) handlePickModel(m.id, pid, rowEfforts)
                 }}
@@ -787,7 +792,7 @@ export default function ChatSettingsPanel({
                 // Indent aligns the stepper under the row title (icon 30 +
                 // gap 12 + row pad 10 = 52). onStopPointerDown preserves the
                 // composer's soft-keyboard-focus contract — a stop tap must
-                // not blur the chat textarea (see preserveFocusUnlessTouch).
+                // not blur the chat textarea (see preserveComposerInputFocus).
                 <div className="csp-effort-indent">
                   <EffortStepper
                     efforts={rowEfforts}
@@ -798,7 +803,7 @@ export default function ChatSettingsPanel({
                     // while a save settles. A live provider switch or
                     // disconnected provider remains genuinely unavailable.
                     disabled={switchBusy || !providerConfigured}
-                    onStopPointerDown={preserveFocusUnlessTouch}
+                    onStopPointerDown={preserveComposerInputFocus}
                   />
                 </div>
               )}
@@ -811,7 +816,7 @@ export default function ChatSettingsPanel({
                     <button
                       type="button"
                       className="csp__confirm-btn csp__confirm-btn--primary"
-                      onPointerDown={preserveFocusUnlessTouch}
+                      onPointerDown={preserveComposerInputFocus}
                       onClick={handleConfirmProviderSwitch}
                       disabled={switchBusy}
                     >
@@ -820,7 +825,7 @@ export default function ChatSettingsPanel({
                     <button
                       type="button"
                       className="csp__confirm-btn csp__confirm-btn--ghost"
-                      onPointerDown={preserveFocusUnlessTouch}
+                      onPointerDown={preserveComposerInputFocus}
                       onClick={handleCancelProviderSwitch}
                       disabled={switchBusy}
                     >
@@ -840,7 +845,7 @@ export default function ChatSettingsPanel({
             <>
               <div
                 className="csp__automation-row"
-                onPointerDown={preserveFocusUnlessTouch}
+                onPointerDown={preserveComposerInputFocus}
               >
                 <label className="csp__automation-copy" htmlFor={autoResumeSwitchId}>
                   <span className="csp__automation-title">Automatically continue after usage limits</span>
@@ -864,7 +869,7 @@ export default function ChatSettingsPanel({
             <>
               <div
                 className="csp__automation-row"
-                onPointerDown={preserveFocusUnlessTouch}
+                onPointerDown={preserveComposerInputFocus}
               >
                 <label
                   className="csp__automation-copy"

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -4177,6 +4177,7 @@ export default function ChatView({
                 onChangeChatInfo={mergeChatInfo}
                 providerSwitchState={providerSwitchState}
                 settingsSaveTailRef={settingsSaveTailRef}
+                composerInputRef={inputRef}
                 onOpenInspector={() => setShowInspector(true)}
                 onOpenSummary={() => setShowSummary(true)}
                 embedded={embedded}

--- a/frontend/src/components/ChatView/ComposerPopover.jsx
+++ b/frontend/src/components/ChatView/ComposerPopover.jsx
@@ -64,6 +64,7 @@ import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { FileDocument, InfoCircle, Paperclip, Plus } from '@openai/apps-sdk-ui/components/Icon'
 import ChatSettingsPanel from './ChatSettingsPanel.jsx'
 import { popoverMaxHeight, nearestClipTop } from './composerPopoverHeight.js'
+import { focusComposerElement } from './composerFocusPolicy.js'
 
 export default function ComposerPopover({
   chatInfo,
@@ -88,6 +89,7 @@ export default function ComposerPopover({
   onRestartResumeChange,
   providerSwitchState,
   settingsSaveTailRef,
+  composerInputRef,
   onOpenInspector,
   onOpenSummary,
   embedded = false,
@@ -184,8 +186,7 @@ export default function ComposerPopover({
     // up when the popover opened. Otherwise leave focus alone —
     // tapping + on a closed-keyboard chat shouldn't pop it open.
     if (wasInputFocusedRef.current) {
-      const el = document.querySelector('.chat__input')
-      if (el) el.focus({ preventScroll: true })
+      focusComposerElement(composerInputRef?.current)
     }
     onAttachClick()
   }
@@ -216,7 +217,7 @@ export default function ComposerPopover({
           // Capture focus state at the click moment — before React
           // commits and any iOS focus-shuffling completes. See
           // wasInputFocusedRef declaration above.
-          const el = document.querySelector('.chat__input')
+          const el = composerInputRef?.current
           const wasFocused = document.activeElement === el
           if (!open) wasInputFocusedRef.current = wasFocused
           setOpen(o => !o)
@@ -285,6 +286,7 @@ export default function ComposerPopover({
                 providerSwitchState={providerSwitchState}
                 settingsSaveTailRef={settingsSaveTailRef}
                 wasInputFocusedRef={wasInputFocusedRef}
+                composerInputRef={composerInputRef}
               />
             </div>
           )}

--- a/frontend/src/components/ChatView/__tests__/composerFocusPolicy.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerFocusPolicy.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 
 import {
   focusComposerElement,
+  preserveComposerInputFocus,
   shouldApplyComposerFocusRequest,
 } from '../composerFocusPolicy.js'
 
@@ -58,4 +59,15 @@ test('focusComposerElement falls back for older focus implementations', () => {
   }
   assert.equal(focusComposerElement(el), true)
   assert.deepEqual(calls, [[{ preventScroll: true }], []])
+})
+
+test('composer pointer actions preserve input focus for touch, mouse, and pen', () => {
+  for (const pointerType of ['touch', 'mouse', 'pen']) {
+    let prevented = 0
+    assert.equal(preserveComposerInputFocus({
+      pointerType,
+      preventDefault() { prevented += 1 },
+    }), true)
+    assert.equal(prevented, 1, pointerType)
+  }
 })

--- a/frontend/src/components/ChatView/composerFocusPolicy.js
+++ b/frontend/src/components/ChatView/composerFocusPolicy.js
@@ -20,3 +20,16 @@ export function focusComposerElement(el) {
   }
   return true
 }
+
+/**
+ * Keep a pointer interaction inside the composer from moving focus away from
+ * its textarea. This deliberately applies to touch as well as mouse/pen:
+ * mobile browsers perform the focus default between pointerdown and click, so
+ * attempting to refocus from the later click can be too late to stop the soft
+ * keyboard collapsing.
+ */
+export function preserveComposerInputFocus(event) {
+  if (!event || typeof event.preventDefault !== 'function') return false
+  event.preventDefault()
+  return true
+}


### PR DESCRIPTION
## Summary

- preserve the chat textarea focus while tapping model rows, effort levels, automation switches, retry actions, and attachment controls in the composer picker
- restore the same chat's textarea after choosing or cancelling the native file picker, without opening the keyboard when it was previously closed
- scope focus restoration to the owning chat so a retained hidden pane cannot receive focus instead

## Root cause

The model panel exempted touch pointers from its pointer-down focus guard, allowing mobile browsers to move focus off the textarea before the click handler ran. Later refocus attempts also used a document-wide textarea lookup, which could select a retained hidden chat, and cancelling the native file picker had no focus-restoration path.

## Testing

- `npm run build`
- `npm test` (2,296 component/library tests and 77 hook tests)
- rendered touch-pointer checks for model, effort, automation, and attachment controls; each prevented default focus movement and kept the owning textarea active

Real-device iOS and Android keyboard animation remains the final device-specific verification.

## Prior work

This complements #252 and #453. Those fixes keep the composer popover reachable and correctly sized while the soft keyboard is open; this change preserves the textarea's focus and keyboard state while interacting with that popover.