### PR TITLE
Give visible chat sole reading-position ownership

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -645,7 +645,12 @@ and attaches their rule ids to new diagnostic chats. The Playwright lock-in spec
   relinquishes persistence authority; an initially hidden owner writes nothing.
   The incoming owner re-enters through `INITIAL` and consumes the shared saved
   coordinate before it can paint. Hidden owners register no page-lifecycle
-  persistence and cannot overwrite the active owner during reload.
+  persistence and cannot overwrite the active owner during reload. A settled
+  `ANCHOR_AT` transfers by its existing semantic address rather than being
+  re-measured after workspace geometry changes; only live follow/pin state is
+  frozen from physical geometry. Retained Builder owners keep their projected
+  pane rectangle while Standard paints, so even that required live-state freeze
+  reads the geometry the outgoing owner actually displayed.
 - **R5 — Reader owns gestures and layout-only sends.** From the first wheel/touch/key
   input until its scroll event lands, no layout path may write `scrollTop`: stream
   resize, spacer handoff, terminal promotion, catch-up, and viewport/keyboard resize

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -553,7 +553,7 @@ automatically armed by installing Möbius.
 
 ## Chat scroll + steer contract
 
-**Owner-authoritative contract — v1.13 (2026-08-01).** This section is the
+**Owner-authoritative contract — v1.14 (2026-08-02).** This section is the
 canonical source of truth for how a chat scrolls and steers. When implementation,
 comments, and this contract disagree, the implementation/comments are the bug:
 fix behavior to match this contract. If a real case is unspecified or the desired
@@ -638,6 +638,14 @@ and attaches their rule ids to new diagnostic chats. The Playwright lock-in spec
   Exactness is bounded by real content: if a viewport growth or content collapse
   makes the saved target unreachable, clamp it to the nearest real conversation
   position, then apply R1 only if that viewport shows the latest user row.
+  The durable reading coordinate belongs to the logical chat, not to every
+  retained DOM copy. When Standard and Builder retain separate physical
+  `ChatView`s for the same chat, only the surface participating in the active
+  handoff owns that coordinate. Its visible-to-hidden edge freezes once and
+  relinquishes persistence authority; an initially hidden owner writes nothing.
+  The incoming owner re-enters through `INITIAL` and consumes the shared saved
+  coordinate before it can paint. Hidden owners register no page-lifecycle
+  persistence and cannot overwrite the active owner during reload.
 - **R5 — Reader owns gestures and layout-only sends.** From the first wheel/touch/key
   input until its scroll event lands, no layout path may write `scrollTop`: stream
   resize, spacer handoff, terminal promotion, catch-up, and viewport/keyboard resize
@@ -764,6 +772,11 @@ Controller structure is part of the contract, not an implementation detail:
 - `ChatView` may read `modeRef` for a submit snapshot but must not assign it.
   It emits send, queue, pagination, and lifecycle events through the semantic
   methods returned by `useScrollMode`.
+- `ChatView` declares whether its physical surface owns the chat's durable
+  reading coordinate. `useScrollMode` alone transfers that authority, persists
+  the outgoing coordinate, and resets the incoming owner for restoration.
+  Hidden retained owners may keep DOM geometry but are never persistence
+  writers; do not reintroduce a second freeze call in `ChatView`.
 - Every live mode mutation goes through `transitionMode`, whose entry guard permits
   new pins only from send and new follow only from an unreserved-bottom gesture or
   an already-armed pin's filled-reservation handoff. Every mode-owned `scrollTop`

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -711,9 +711,6 @@ export default function ChatView({
     pendingMessagesLength: pendingQueue.pendingMessages.length,
     loadingOlderRef: loadingOlder,
     initialEntryPhase,
-    // Standard and Builder can retain separate physical ChatViews for the same
-    // logical chat. Only the surface participating in the active handoff may
-    // publish that chat's one durable reading coordinate.
     ownsReadingPosition: !hidden,
   })
 

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -690,7 +690,6 @@ export default function ChatView({
     anchorPagination,
     captureSendIntent,
     commitSendIntent,
-    freezeChatExit,
     freezeForegroundReturn,
     freezeQuestionSubmission,
     freezeQueuedSubmission,
@@ -712,6 +711,10 @@ export default function ChatView({
     pendingMessagesLength: pendingQueue.pendingMessages.length,
     loadingOlderRef: loadingOlder,
     initialEntryPhase,
+    // Standard and Builder can retain separate physical ChatViews for the same
+    // logical chat. Only the surface participating in the active handoff may
+    // publish that chat's one durable reading coordinate.
+    ownsReadingPosition: !hidden,
   })
 
   // Forward committed pane-geometry changes to the scroll controller. A new
@@ -730,19 +733,17 @@ export default function ChatView({
     if (paneContentHeight != null) paneResized(paneContentHeight)
   }, [paneContentHeight, paneResized])
 
-  // Settings used to unmount the active chat. Retained pane identity is useful
-  // for split/unsplit transitions, but hiding a pane must still perform the old
-  // leave/return lifecycle: freeze its reader position while geometry is live,
-  // then let the load effect below disconnect while hidden and refresh on show.
+  // A hidden retained owner is not an active runtime. The scroll controller
+  // owns the visible -> hidden reading-position handoff; this layer only arms
+  // freshness so the surface cannot paint stale history when it returns.
   useLayoutEffect(() => {
     if (!hidden) return
-    freezeChatExit()
     // Arm the freshness + restoration gate while this surface is still
     // physically hidden. A retained ChatView must not reappear with the
     // transcript from its previous visible lifetime for even one frame.
     setInitialEntryPhase('history')
     setLoading(true)
-  }, [hidden, freezeChatExit])
+  }, [hidden])
 
   function rememberSendIntent(cid, intent) {
     if (!cid || !intent) return

--- a/frontend/src/components/ChatView/__tests__/chatContract.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatContract.test.js
@@ -95,34 +95,6 @@ test('owner contract freezes question answers without locking keyboard movement'
   )
 })
 
-test('a retained chat has exactly one durable reading-position owner', () => {
-  const chatView = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8')
-  const scrollController = readFileSync(
-    new URL('../useScrollMode.js', import.meta.url),
-    'utf8',
-  )
-  assert.match(
-    chatView,
-    /ownsReadingPosition: !hidden/,
-    'ChatView must declare whether this physical surface owns the logical chat coordinate',
-  )
-  assert.doesNotMatch(
-    chatView,
-    /freezeChatExit/,
-    'ChatView must not duplicate the scroll controller\'s ownership transition',
-  )
-  assert.match(
-    scrollController,
-    /if \(!readingPositionOwnerRef\.current\) return[\s\S]*const wasOwner = readingPositionOwnerRef\.current[\s\S]*freezeToCurrentPosition: modeRef\.current\.kind !== 'ANCHOR_AT'[\s\S]*readingPositionOwnerRef\.current = false[\s\S]*readingPositionOwnerRef\.current = true[\s\S]*transitionMode\(\{ kind: 'INITIAL' \}, 'lifecycle:position-owner-enter'\)/,
-    'the outgoing owner must preserve a settled semantic anchor, freeze live modes, relinquish writes, and make the incoming owner restore shared state',
-  )
-  assert.match(
-    chatView,
-    /if \(hidden\) return[\s\S]*?\}, \[chatId, loadNonce, hidden\]\)/,
-    'hidden chats must disconnect and refresh history when they become visible again',
-  )
-})
-
 test('an empty chat initializes scroll identity before its first transcript mounts', () => {
   const scrollController = readFileSync(new URL('../useScrollMode.js', import.meta.url), 'utf8')
   const layoutOwner = scrollController.indexOf('// Single layout effect:')

--- a/frontend/src/components/ChatView/__tests__/chatContract.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatContract.test.js
@@ -113,8 +113,8 @@ test('a retained chat has exactly one durable reading-position owner', () => {
   )
   assert.match(
     scrollController,
-    /if \(!readingPositionOwnerRef\.current\) return[\s\S]*const wasOwner = readingPositionOwnerRef\.current[\s\S]*persistMode\(\{ freezeToCurrentPosition: true \}\)[\s\S]*readingPositionOwnerRef\.current = false[\s\S]*readingPositionOwnerRef\.current = true[\s\S]*transitionMode\(\{ kind: 'INITIAL' \}, 'lifecycle:position-owner-enter'\)/,
-    'the outgoing owner must freeze once, relinquish writes, and make the incoming owner restore shared state',
+    /if \(!readingPositionOwnerRef\.current\) return[\s\S]*const wasOwner = readingPositionOwnerRef\.current[\s\S]*freezeToCurrentPosition: modeRef\.current\.kind !== 'ANCHOR_AT'[\s\S]*readingPositionOwnerRef\.current = false[\s\S]*readingPositionOwnerRef\.current = true[\s\S]*transitionMode\(\{ kind: 'INITIAL' \}, 'lifecycle:position-owner-enter'\)/,
+    'the outgoing owner must preserve a settled semantic anchor, freeze live modes, relinquish writes, and make the incoming owner restore shared state',
   )
   assert.match(
     chatView,

--- a/frontend/src/components/ChatView/__tests__/chatContract.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatContract.test.js
@@ -72,7 +72,7 @@ test('owner contract freezes question answers without locking keyboard movement'
     new URL('../../../../../ARCHITECTURE.md', import.meta.url),
     'utf8',
   )
-  assert.match(architecture, /Owner-authoritative contract — v1\.13 \(2026-08-01\)/)
+  assert.match(architecture, /Owner-authoritative contract — v1\.14 \(2026-08-02\)/)
   assert.match(
     architecture,
     /In-process question is answered \| any \| transient `ANCHOR_AT` over the prior mode; same active assistant row/,
@@ -95,7 +95,7 @@ test('owner contract freezes question answers without locking keyboard movement'
   )
 })
 
-test('a retained chat crosses the old unmount lifecycle while hidden', () => {
+test('a retained chat has exactly one durable reading-position owner', () => {
   const chatView = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8')
   const scrollController = readFileSync(
     new URL('../useScrollMode.js', import.meta.url),
@@ -103,18 +103,23 @@ test('a retained chat crosses the old unmount lifecycle while hidden', () => {
   )
   assert.match(
     chatView,
-    /useLayoutEffect\(\(\) => \{\s*if \(!hidden\) return\s*freezeChatExit\(\)[\s\S]*setInitialEntryPhase\('history'\)[\s\S]*setLoading\(true\)/,
-    'hiding a retained chat must freeze its position and arm freshness before it can paint again',
+    /ownsReadingPosition: !hidden/,
+    'ChatView must declare whether this physical surface owns the logical chat coordinate',
+  )
+  assert.doesNotMatch(
+    chatView,
+    /freezeChatExit/,
+    'ChatView must not duplicate the scroll controller\'s ownership transition',
+  )
+  assert.match(
+    scrollController,
+    /if \(!readingPositionOwnerRef\.current\) return[\s\S]*const wasOwner = readingPositionOwnerRef\.current[\s\S]*persistMode\(\{ freezeToCurrentPosition: true \}\)[\s\S]*readingPositionOwnerRef\.current = false[\s\S]*readingPositionOwnerRef\.current = true[\s\S]*transitionMode\(\{ kind: 'INITIAL' \}, 'lifecycle:position-owner-enter'\)/,
+    'the outgoing owner must freeze once, relinquish writes, and make the incoming owner restore shared state',
   )
   assert.match(
     chatView,
     /if \(hidden\) return[\s\S]*?\}, \[chatId, loadNonce, hidden\]\)/,
     'hidden chats must disconnect and refresh history when they become visible again',
-  )
-  assert.match(
-    scrollController,
-    /const freezeChatExit = useCallback\(\(\) => \{[\s\S]*?readerLocationExplicitRef\.current = true[\s\S]*?persistMode\(\{ freezeToCurrentPosition: true \}\)/,
-    'chat navigation must preserve an automatic tail hold through the later unmount cleanup',
   )
 })
 

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -1212,6 +1212,10 @@ export function modeForQueuedSubmission(scrollEl, currentMode) {
  *   History blocks reveal, cached is a caller-validated restoration window,
  *   preparing is a hidden progressive cold render, and ready means
  *   authoritative history has settled.
+ * @param {boolean} args.ownsReadingPosition
+ *   True only for the physical ChatView participating in the active workspace
+ *   handoff. Retained hidden owners may keep DOM geometry, but never consume
+ *   or write the logical chat's one durable reading coordinate.
  */
 export default function useScrollMode({
   chatId,
@@ -1225,6 +1229,7 @@ export default function useScrollMode({
   pendingMessagesLength,
   loadingOlderRef,
   initialEntryPhase,
+  ownsReadingPosition,
 }) {
   const [revealed, setRevealed] = useState(false)
   // A tiny React mirror reruns the layout effect when a semantic transition
@@ -1238,6 +1243,10 @@ export default function useScrollMode({
   const revealedRef = useRef(false)
   const modeRef = useRef({ kind: 'INITIAL' })
   const modeChatIdRef = useRef(null)
+  // Standard and Builder may retain separate physical ChatViews for one chat.
+  // This is the sole durable-position authority: only the active surface may
+  // persist, and a hidden surface must re-enter through INITIAL before restore.
+  const readingPositionOwnerRef = useRef(ownsReadingPosition)
   // False only when mount had no deliberate reader location and therefore
   // used the automatic latest-message fallback. Passive lifecycle/viewport
   // changes must not promote that fallback into a saved reading position.
@@ -1437,6 +1446,7 @@ export default function useScrollMode({
 
   const persistMode = useCallback(({ freezeToCurrentPosition = false } = {}) => {
     try {
+      if (!readingPositionOwnerRef.current) return
       if (!readerLocationExplicitRef.current) {
         // Keep a stored location this visit merely failed to resolve. Only an
         // absent location — never a retrieval failure — may be cleared here.
@@ -1475,6 +1485,33 @@ export default function useScrollMode({
       _persistScrollModes()
     } catch {}
   }, [chatId, messagesRef, scrollRef, transitionMode])
+
+  // Transfer the logical chat's one durable reading coordinate at the same
+  // boundary that transfers physical visibility. The outgoing owner freezes
+  // once, then loses all persistence authority. The incoming owner starts from
+  // INITIAL so the ordinary restore path consumes the newest shared coordinate
+  // instead of reviving stale geometry from the last time this workspace world
+  // was visible. An initially hidden retained owner is neither transition.
+  useLayoutEffect(() => {
+    const wasOwner = readingPositionOwnerRef.current
+    if (wasOwner === ownsReadingPosition) return
+
+    if (wasOwner) {
+      if (modeRef.current.kind !== 'INITIAL'
+          && !(savedLocationUnresolvedRef.current
+            && !readerLocationExplicitRef.current)) {
+        readerLocationExplicitRef.current = true
+        persistMode({ freezeToCurrentPosition: true })
+      }
+      readingPositionOwnerRef.current = false
+      return
+    }
+
+    readingPositionOwnerRef.current = true
+    readerLocationExplicitRef.current = false
+    savedLocationUnresolvedRef.current = false
+    transitionMode({ kind: 'INITIAL' }, 'lifecycle:position-owner-enter')
+  }, [ownsReadingPosition, persistMode, transitionMode])
 
   const settleNonPin = useCallback(({
     retireFollow = false,
@@ -1599,29 +1636,6 @@ export default function useScrollMode({
       : modeRef.current
   }, [scrollRef, transitionMode])
 
-  // A retained pane becoming hidden must cross the same scroll lifecycle
-  // boundary as the old unmounting ChatView. Freeze and persist the exact
-  // visible row before Settings (or another full-workspace overlay) can grow
-  // the transcript in the background. Keeping this as a controller event
-  // avoids exposing persistMode/modeRef mutation to ChatView.
-  const freezeChatExit = useCallback(() => {
-    // Leaving this chat is an explicit navigation action even when its initial
-    // location came from the automatic latest-content fallback. Promote the
-    // currently painted location before persisting it so the later unmount
-    // cleanup cannot delete the snapshot and reopen a growing turn at its new
-    // tail when the reader returns.
-    //
-    // The one exception is a visit that never resolved the stored location and
-    // in which the reader never moved: promoting there would overwrite a good
-    // saved position with the fallback tail this visit happened to show, which
-    // is how a single unresolvable return turned into "coming back again
-    // fails" forever after.
-    if (savedLocationUnresolvedRef.current
-        && !readerLocationExplicitRef.current) return
-    readerLocationExplicitRef.current = true
-    persistMode({ freezeToCurrentPosition: true })
-  }, [persistMode])
-
   // A sticky attention nudge (question or paused turn) is an explicit reader
   // request, but not a scroll gesture inside `.chat__scroll`. Route it through
   // the controller anyway:
@@ -1670,7 +1684,7 @@ export default function useScrollMode({
   // browser lifecycle events too, so reload returns to the last reading
   // position rather than an older mode saved during the last message change.
   useLayoutEffect(() => {
-    if (typeof window === 'undefined') return
+    if (!ownsReadingPosition || typeof window === 'undefined') return
     const onPageLeaving = () => persistMode({ freezeToCurrentPosition: true })
     const onVisibilityChange = () => {
       if (typeof document !== 'undefined' && document.visibilityState === 'hidden') {
@@ -1687,7 +1701,7 @@ export default function useScrollMode({
       window.removeEventListener(BEFORE_SHELL_RELOAD_EVENT, onPageLeaving)
       document.removeEventListener('visibilitychange', onVisibilityChange)
     }
-  }, [chatId])
+  }, [chatId, ownsReadingPosition])
 
   // Single layout effect: spacer sizing, automatic scroll writes,
   // ResizeObserver layout updates, user-gesture detection, geometry-based
@@ -1702,6 +1716,12 @@ export default function useScrollMode({
       readerIntentVersionRef.current += 1
       transitionMode({ kind: 'INITIAL' }, 'lifecycle:chat-change')
     }
+
+    // Retained hidden workspace worlds keep their DOM but own no scroll
+    // lifecycle, observers, or durable reading-position writes. Becoming the
+    // active owner above re-enters through INITIAL and this effect then installs
+    // the one live controller against fresh geometry.
+    if (!readingPositionOwnerRef.current) return
 
     const scrollEl = scrollRef.current
     const spacerEl = spacerRef.current
@@ -2678,6 +2698,7 @@ export default function useScrollMode({
     pendingMessagesLength,
     chatId,
     initialEntryPhase,
+    ownsReadingPosition,
     pinModeActive,
     chatRef,
     footRef,
@@ -2841,7 +2862,6 @@ export default function useScrollMode({
     anchorPagination,
     captureSendIntent,
     commitSendIntent,
-    freezeChatExit,
     freezeForegroundReturn,
     freezeQuestionSubmission,
     freezeQueuedSubmission,

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -153,6 +153,10 @@ const _scrollModes = (() => {
   }
   catch { return {} }
 })()
+// `clearReadingPositions` is a terminal owner-session boundary. React and the
+// browser may still deliver cleanup/pagehide work before the ensuing reload;
+// those late callbacks must not recreate storage the session just removed.
+let _readingPositionWritesEnabled = true
 
 /** The durable message row an activation must contain before reveal.
  * ChatView uses only the row identity; this module keeps ownership of the
@@ -203,11 +207,13 @@ export function retireSavedReadingPosition(chatId) {
  *  still-mounted ChatView's pagehide write would put the in-memory map
  *  straight back over the cleared key. */
 export function clearReadingPositions() {
+  _readingPositionWritesEnabled = false
   for (const key of Object.keys(_scrollModes)) delete _scrollModes[key]
   try { localStorage.removeItem(READING_POSITION_KEY) } catch {}
 }
 
 function _persistScrollModes() {
+  if (!_readingPositionWritesEnabled) return
   try {
     const entries = Object.entries(_scrollModes)
     if (entries.length > READING_POSITION_LIMIT) {
@@ -1501,7 +1507,15 @@ export default function useScrollMode({
           && !(savedLocationUnresolvedRef.current
             && !readerLocationExplicitRef.current)) {
         readerLocationExplicitRef.current = true
-        persistMode({ freezeToCurrentPosition: true })
+        // The outgoing main-effect cleanup has already settled any pending
+        // reader gesture into ANCHOR_AT. Keep that semantic address intact:
+        // re-measuring it after the shell changed worlds can discard a nested
+        // part path and make the reverse handoff return somewhere else inside
+        // a long turn. Live FOLLOW/PIN modes still need one physical freeze so
+        // content arriving while inactive cannot redefine their tail.
+        persistMode({
+          freezeToCurrentPosition: modeRef.current.kind !== 'ANCHOR_AT',
+        })
       }
       readingPositionOwnerRef.current = false
       return

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -1492,12 +1492,9 @@ export default function useScrollMode({
     } catch {}
   }, [chatId, messagesRef, scrollRef, transitionMode])
 
-  // Transfer the logical chat's one durable reading coordinate at the same
-  // boundary that transfers physical visibility. The outgoing owner freezes
-  // once, then loses all persistence authority. The incoming owner starts from
-  // INITIAL so the ordinary restore path consumes the newest shared coordinate
-  // instead of reviving stale geometry from the last time this workspace world
-  // was visible. An initially hidden retained owner is neither transition.
+  // Transfer the logical chat's one durable coordinate with visibility. The
+  // outgoing owner persists before relinquishing authority; the incoming owner
+  // restores through INITIAL. A retained surface that begins hidden does neither.
   useLayoutEffect(() => {
     const wasOwner = readingPositionOwnerRef.current
     if (wasOwner === ownsReadingPosition) return
@@ -1507,12 +1504,9 @@ export default function useScrollMode({
           && !(savedLocationUnresolvedRef.current
             && !readerLocationExplicitRef.current)) {
         readerLocationExplicitRef.current = true
-        // The outgoing main-effect cleanup has already settled any pending
-        // reader gesture into ANCHOR_AT. Keep that semantic address intact:
-        // re-measuring it after the shell changed worlds can discard a nested
-        // part path and make the reverse handoff return somewhere else inside
-        // a long turn. Live FOLLOW/PIN modes still need one physical freeze so
-        // content arriving while inactive cannot redefine their tail.
+        // Main-effect cleanup has already settled pending input to ANCHOR_AT.
+        // Preserve that address: re-measuring after a world reflow can lose its
+        // nested part. Live FOLLOW/PIN modes still need one physical freeze.
         persistMode({
           freezeToCurrentPosition: modeRef.current.kind !== 'ANCHOR_AT',
         })
@@ -1691,7 +1685,7 @@ export default function useScrollMode({
   // on every messages change; cleanup is only fired on chatId change.)
   useLayoutEffect(() => {
     return () => persistMode({ freezeToCurrentPosition: true })
-  }, [chatId])
+  }, [persistMode])
 
   // A hard shell refresh/page background does not reliably run React's
   // cleanup after the human manually scrolls. Persist the current mode on the
@@ -1715,7 +1709,7 @@ export default function useScrollMode({
       window.removeEventListener(BEFORE_SHELL_RELOAD_EVENT, onPageLeaving)
       document.removeEventListener('visibilitychange', onVisibilityChange)
     }
-  }, [chatId, ownsReadingPosition])
+  }, [ownsReadingPosition, persistMode])
 
   // Single layout effect: spacer sizing, automatic scroll writes,
   // ResizeObserver layout updates, user-gesture detection, geometry-based

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -3182,10 +3182,10 @@ export default function Shell() {
               bottom: 'auto',
             }
             : null
-          const chatViewStyle = paned
+          const chatViewStyle = builderRect
             ? {
               ...posStyle,
-              ...modeViewTransitionStyle('pane', paneId, surfaceKey),
+              ...(paned ? modeViewTransitionStyle('pane', paneId, surfaceKey) : {}),
             }
             : undefined
           return (

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -1024,11 +1024,6 @@ test('Shell threads the (drag-preview) viewMode into the content derivation and 
   assert.match(shell, /const standardOwner = world === STANDARD_CHAT_WORLD/)
   assert.match(shell, /const builderPainted = !standardOwner[\s\S]*effectiveViewMode === 'panes'/)
   assert.match(shell, /visible=\{surfaceVisible && chatPanesVisible && role !== 'held'\}/)
-  assert.match(
-    shell,
-    /const chatViewStyle = builderRect[\s\S]*\.\.\.posStyle[\s\S]*\.\.\.\(paned \? modeViewTransitionStyle[\s\S]*: \{\}\)/,
-    'a parked Builder owner must keep its pane rectangle instead of borrowing Standard geometry',
-  )
 })
 
 test('DRAG IS BUILDING: arming in single mode unfolds a builder preview; any drop commits panes', () => {

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -1024,6 +1024,11 @@ test('Shell threads the (drag-preview) viewMode into the content derivation and 
   assert.match(shell, /const standardOwner = world === STANDARD_CHAT_WORLD/)
   assert.match(shell, /const builderPainted = !standardOwner[\s\S]*effectiveViewMode === 'panes'/)
   assert.match(shell, /visible=\{surfaceVisible && chatPanesVisible && role !== 'held'\}/)
+  assert.match(
+    shell,
+    /const chatViewStyle = builderRect[\s\S]*\.\.\.posStyle[\s\S]*\.\.\.\(paned \? modeViewTransitionStyle[\s\S]*: \{\}\)/,
+    'a parked Builder owner must keep its pane rectangle instead of borrowing Standard geometry',
+  )
 })
 
 test('DRAG IS BUILDING: arming in single mode unfolds a builder preview; any drop commits panes', () => {

--- a/tests/bootstrap.spec.mjs
+++ b/tests/bootstrap.spec.mjs
@@ -512,9 +512,22 @@ test.describe('Logout cache wipe', () => {
 
     await page.evaluate(async () => {
       sessionStorage.setItem('draft:sign-out-test', 'private draft')
+      localStorage.setItem('chat-reading-position', JSON.stringify({
+        'sign-out-test': {
+          kind: 'ANCHOR_AT',
+          key: 'private-reading-position',
+          offset: 12,
+          at: Date.now(),
+        },
+      }))
       await caches.open('mobius-sign-out-test')
       await caches.open('unrelated-cache-keep-me')
     })
+    // Reload once so the scroll module owns the seeded map in memory. Without
+    // the terminal write gate, the mounted chat's pagehide cleanup recreates
+    // the just-cleared key (often as an empty object) during sign-out reload.
+    await page.reload({ waitUntil: 'domcontentloaded' })
+    await waitForShell(page)
 
     const nav = page.getByRole('button', { name: 'Toggle navigation' })
     if (await nav.getAttribute('aria-expanded') !== 'true') await nav.click()
@@ -528,6 +541,7 @@ test.describe('Logout cache wipe', () => {
     await expect(page.locator('.login')).toBeVisible({ timeout: 10000 })
     await expect(page.getByText(/session expired/i)).toHaveCount(0)
     expect(await page.evaluate(() => localStorage.getItem('token'))).toBeNull()
+    expect(await page.evaluate(() => localStorage.getItem('chat-reading-position'))).toBeNull()
     expect(await page.evaluate(() => sessionStorage.getItem('draft:sign-out-test'))).toBeNull()
     const cachesAfter = await page.evaluate(() => caches.keys())
     expect(cachesAfter).not.toContain('mobius-sign-out-test')

--- a/tests/spacer.spec.mjs
+++ b/tests/spacer.spec.mjs
@@ -530,7 +530,7 @@ test.describe('Chat switching (the bug)', () => {
         && scroll.scrollTop > scroll.clientHeight
     }, chatId)
 
-    const beforeReturn = await page.evaluate((id) => {
+    const readPosition = () => page.evaluate((id) => {
       const scroll = document.querySelector('[data-chat-surface="painted"] .chat__scroll')
       const saved = JSON.parse(localStorage.getItem('chat-reading-position') || '{}')[id]
       const anchor = scroll.querySelector(`[data-key="${CSS.escape(saved.key)}"]`)
@@ -540,6 +540,7 @@ test.describe('Chat switching (the bug)', () => {
         anchorTop: anchor.getBoundingClientRect().top - scroll.getBoundingClientRect().top,
       }
     }, chatId)
+    const beforeReturn = await readPosition()
 
     // A cold shell mount may retain physical ChatView owners for both workspace
     // worlds. An initially hidden owner has never painted and must not replace
@@ -553,16 +554,7 @@ test.describe('Chat switching (the bug)', () => {
         ?.dataset.scrollMode === 'ANCHOR_AT'
     ), chatId)
 
-    const afterReturn = await page.evaluate((id) => {
-      const scroll = document.querySelector('[data-chat-surface="painted"] .chat__scroll')
-      const saved = JSON.parse(localStorage.getItem('chat-reading-position') || '{}')[id]
-      const anchor = scroll.querySelector(`[data-key="${CSS.escape(saved.key)}"]`)
-      return {
-        key: saved.key,
-        offset: saved.offset,
-        anchorTop: anchor.getBoundingClientRect().top - scroll.getBoundingClientRect().top,
-      }
-    }, chatId)
+    const afterReturn = await readPosition()
 
     expect(afterReturn.key).toBe(beforeReturn.key)
     expect(Math.abs(afterReturn.offset - beforeReturn.offset)).toBeLessThanOrEqual(1)

--- a/tests/spacer.spec.mjs
+++ b/tests/spacer.spec.mjs
@@ -478,50 +478,85 @@ test.describe('Short responses', () => {
 })
 
 test.describe('Chat switching (the bug)', () => {
-  test('11. Return to chat — RO active, spacer tracks injected content', async ({ page }) => {
+  test('11. Cold return preserves the visible owner\'s exact reading position', async ({ page }) => {
     await setup(page)
     await newChat(page)
-    await sendMessage(page, 'Test switch')
+    const chatId = await page.evaluate(() => localStorage.getItem('moebius_active_chat'))
+    expect(chatId).toBeTruthy()
 
-    const beforeSwitch = await measure(page)
-    expect(beforeSwitch.spacerH).toBeGreaterThan(0)
+    // Persist enough stable transcript rows to make a middle reading position
+    // meaningfully different from both the first row and the recent tail.
+    await page.evaluate(async ({ id }) => {
+      const token = localStorage.getItem('token')
+      const now = Date.now()
+      const messages = Array.from({ length: 36 }, (_, index) => ({
+        role: index % 2 === 0 ? 'user' : 'assistant',
+        content: `Return position row ${index}. ${'Stable browser contract text. '.repeat(12)}`,
+        ts: now + index,
+        cid: index % 2 === 0 ? `return-position-${index}` : undefined,
+        blocks: [],
+      }))
+      const response = await fetch(`/api/chats/${id}`, {
+        method: 'PUT',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ messages }),
+      })
+      if (!response.ok) throw new Error(`seed PUT failed: ${response.status}`)
+    }, { id: chatId })
 
-    // Simulate switching away: save state to sessionStorage.
+    await page.goto(`${BASE}/shell/?chat=${encodeURIComponent(chatId)}`, {
+      waitUntil: 'domcontentloaded',
+    })
+    await expect(page.locator('[data-chat-surface="painted"] .chat__scroll'))
+      .toBeVisible({ timeout: 15000 })
+
+    // Exercise the reader-owned path rather than assigning scrollTop as test
+    // setup. The pointer edge opens the controller's gesture window; the
+    // resulting ANCHOR_AT write is the product state that must survive return.
     await page.evaluate(() => {
       const scroll = document.querySelector('[data-chat-surface="painted"] .chat__scroll')
-      const spacer = document.querySelector('[data-chat-surface="painted"] .spacer-dynamic')
-      if (scroll && spacer) {
-        const positions = JSON.parse(sessionStorage.getItem('chat-scroll') || '{}')
-        const spacers = JSON.parse(sessionStorage.getItem('chat-spacer') || '{}')
-        positions['test-chat'] = scroll.scrollHeight - scroll.scrollTop
-        spacers['test-chat'] = spacer.style.height
-        sessionStorage.setItem('chat-scroll', JSON.stringify(positions))
-        sessionStorage.setItem('chat-spacer', JSON.stringify(spacers))
-      }
+      if (!scroll) throw new Error('scroll surface missing')
+      scroll.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
+      scroll.scrollTop = Math.floor(scroll.scrollHeight / 3)
     })
+    await page.waitForFunction((id) => {
+      const scroll = document.querySelector('[data-chat-surface="painted"] .chat__scroll')
+      const saved = JSON.parse(localStorage.getItem('chat-reading-position') || '{}')[id]
+      return scroll?.dataset.scrollMode === 'ANCHOR_AT'
+        && saved?.kind === 'ANCHOR_AT'
+        && scroll.scrollTop > scroll.clientHeight
+    }, chatId)
 
-    // Reload to simulate returning.
-    await page.goto(BASE)
-    await expect(page.locator('[data-chat-surface="painted"] :is(.chat__scroll, .chat__empty-wrap)').first()).toBeVisible({ timeout: 8000 })
-    await page.evaluate(() => new Promise(r => setTimeout(r, 500)))
+    const beforeReturn = await page.evaluate((id) => {
+      const scroll = document.querySelector('[data-chat-surface="painted"] .chat__scroll')
+      const saved = JSON.parse(localStorage.getItem('chat-reading-position') || '{}')[id]
+      return { top: scroll.scrollTop, key: saved.key, offset: saved.offset }
+    }, chatId)
 
-    const hasScroll = await page.evaluate(() => !!document.querySelector('[data-chat-surface="painted"] .chat__scroll'))
-    if (!hasScroll) {
-      // App loaded a different (empty) chat — skip this assertion.
-      return
-    }
+    // A cold shell mount may retain physical ChatView owners for both workspace
+    // worlds. An initially hidden owner has never painted and must not replace
+    // the visible owner's durable coordinate while mounting or unloading.
+    await page.goto(BASE, { waitUntil: 'domcontentloaded' })
+    await expect(page.locator('[data-chat-surface="painted"] .chat__scroll'))
+      .toBeVisible({ timeout: 15000 })
+    await page.waitForFunction((id) => (
+      document.querySelector('[data-chat-surface="painted"]')?.dataset.chatId === id
+      && document.querySelector('[data-chat-surface="painted"] .chat__scroll')
+        ?.dataset.scrollMode === 'ANCHOR_AT'
+    ), chatId)
 
-    // Inject content simulating agent still streaming.
-    await injectContent(page, 'Streaming content. ', 50)
-    const afterContent = await measure(page)
-    if (afterContent.error) return // scroll element disappeared
+    const afterReturn = await page.evaluate((id) => {
+      const scroll = document.querySelector('[data-chat-surface="painted"] .chat__scroll')
+      const saved = JSON.parse(localStorage.getItem('chat-reading-position') || '{}')[id]
+      return { top: scroll.scrollTop, key: saved.key, offset: saved.offset }
+    }, chatId)
 
-    // Key assertion: spacer should have shrunk (RO is active).
-    if (afterContent.listH > afterContent.clientH) {
-      expect(afterContent.spacerH).toBe(0)
-    } else {
-      assertSpacerReasonable(afterContent)
-    }
+    expect(afterReturn.key).toBe(beforeReturn.key)
+    expect(Math.abs(afterReturn.offset - beforeReturn.offset)).toBeLessThanOrEqual(1)
+    expect(Math.abs(afterReturn.top - beforeReturn.top)).toBeLessThanOrEqual(8)
   })
 })
 

--- a/tests/spacer.spec.mjs
+++ b/tests/spacer.spec.mjs
@@ -533,7 +533,12 @@ test.describe('Chat switching (the bug)', () => {
     const beforeReturn = await page.evaluate((id) => {
       const scroll = document.querySelector('[data-chat-surface="painted"] .chat__scroll')
       const saved = JSON.parse(localStorage.getItem('chat-reading-position') || '{}')[id]
-      return { top: scroll.scrollTop, key: saved.key, offset: saved.offset }
+      const anchor = scroll.querySelector(`[data-key="${CSS.escape(saved.key)}"]`)
+      return {
+        key: saved.key,
+        offset: saved.offset,
+        anchorTop: anchor.getBoundingClientRect().top - scroll.getBoundingClientRect().top,
+      }
     }, chatId)
 
     // A cold shell mount may retain physical ChatView owners for both workspace
@@ -551,12 +556,20 @@ test.describe('Chat switching (the bug)', () => {
     const afterReturn = await page.evaluate((id) => {
       const scroll = document.querySelector('[data-chat-surface="painted"] .chat__scroll')
       const saved = JSON.parse(localStorage.getItem('chat-reading-position') || '{}')[id]
-      return { top: scroll.scrollTop, key: saved.key, offset: saved.offset }
+      const anchor = scroll.querySelector(`[data-key="${CSS.escape(saved.key)}"]`)
+      return {
+        key: saved.key,
+        offset: saved.offset,
+        anchorTop: anchor.getBoundingClientRect().top - scroll.getBoundingClientRect().top,
+      }
     }, chatId)
 
     expect(afterReturn.key).toBe(beforeReturn.key)
     expect(Math.abs(afterReturn.offset - beforeReturn.offset)).toBeLessThanOrEqual(1)
-    expect(Math.abs(afterReturn.top - beforeReturn.top)).toBeLessThanOrEqual(8)
+    // A cold fetch may contain fewer paginated rows above the anchor, so raw
+    // scrollTop is deliberately not stable. The semantic coordinate must put
+    // the same anchor at the same visible viewport position.
+    expect(Math.abs(afterReturn.anchorTop - beforeReturn.anchorTop)).toBeLessThanOrEqual(8)
   })
 })
 

--- a/tests/workspace-panes.spec.mjs
+++ b/tests/workspace-panes.spec.mjs
@@ -1226,17 +1226,11 @@ test.describe('Workspace view-mode toggle', () => {
     // The parked Builder owner must keep the rect it will paint. Expanding it
     // to Standard's box before its ownership cleanup changes wrapping and makes
     // a lifecycle capture describe content the reader was not looking at.
-    const [parkedBuilderBox, standardBox] = await Promise.all([
-      builderSurface.evaluate((element) => {
-        const { width, height } = element.getBoundingClientRect()
-        return { width, height }
-      }),
-      standardSurface.evaluate((element) => {
-        const { width, height } = element.getBoundingClientRect()
-        return { width, height }
-      }),
+    const [parkedBuilderWidth, standardWidth] = await Promise.all([
+      builderSurface.evaluate(element => element.getBoundingClientRect().width),
+      standardSurface.evaluate(element => element.getBoundingClientRect().width),
     ])
-    expect(parkedBuilderBox.width).toBeLessThan(standardBox.width - 100)
+    expect(parkedBuilderWidth).toBeLessThan(standardWidth - 100)
 
     const brand = page.getByRole('button', { name: 'Toggle navigation' })
     await brand.focus()
@@ -1264,7 +1258,7 @@ test.describe('Workspace view-mode toggle', () => {
       (JSON.parse(localStorage.getItem('chat-reading-position') || '{}')[id]?.at || 0) > after
     ), { id: String(a.id), after: previousWriteAt })
 
-    const before = await page.evaluate((id) => {
+    const readBuilderState = () => page.evaluate((id) => {
       const scroll = document.querySelector(
         `[data-chat-world="builder"][data-chat-id="${id}"] .chat__scroll`,
       )
@@ -1277,6 +1271,7 @@ test.describe('Workspace view-mode toggle', () => {
         width: wrapper.getBoundingClientRect().width,
       }
     }, String(a.id))
+    const before = await readBuilderState()
 
     await brand.focus()
     await page.keyboard.press('Shift+Enter')
@@ -1284,14 +1279,7 @@ test.describe('Workspace view-mode toggle', () => {
       .toHaveAttribute('data-scroll-mode', 'ANCHOR_AT', { timeout: 15000 })
     await expect(page.locator('.workspace__chrome')).toHaveCount(0)
 
-    const afterExit = await page.evaluate((id) => {
-      const { at: _at, ...saved } =
-        JSON.parse(localStorage.getItem('chat-reading-position') || '{}')[id]
-      const wrapper = document.querySelector(
-        `[data-chat-world="builder"][data-chat-id="${id}"]`,
-      )
-      return { saved, width: wrapper.getBoundingClientRect().width }
-    }, String(a.id))
+    const afterExit = await readBuilderState()
     expect(afterExit.saved).toEqual(before.saved)
     expect(Math.abs(afterExit.width - before.width)).toBeLessThanOrEqual(1)
 

--- a/tests/workspace-panes.spec.mjs
+++ b/tests/workspace-panes.spec.mjs
@@ -1181,6 +1181,130 @@ test.describe('Workspace view-mode toggle', () => {
     })
   })
 
+  test('a Standard round trip preserves Builder reading ownership and geometry', async ({ page }) => {
+    await boot(page, WIDE)
+    const a = await createTaggedChat(page, 'vmReadingA')
+    const b = await createTaggedChat(page, 'vmReadingB')
+    await mockApps(page, [])
+
+    const token = await page.evaluate(() => localStorage.getItem('token'))
+    const now = Date.now()
+    const messages = Array.from({ length: 36 }, (_, index) => ({
+      role: index % 2 === 0 ? 'user' : 'assistant',
+      content: `Workspace reading row ${index}. ${'Stable width-sensitive text. '.repeat(20)}`,
+      ts: now + index,
+      cid: index % 2 === 0 ? `workspace-reading-${index}` : undefined,
+      blocks: index % 2 === 0
+        ? []
+        : [{
+            type: 'text',
+            content: `Workspace reading row ${index}. ${'Stable width-sensitive text. '.repeat(20)}`,
+          }],
+    }))
+    const seeded = await page.request.put(`${BASE}/api/chats/${a.id}`, {
+      headers: { Authorization: `Bearer ${token}` },
+      data: { messages },
+      failOnStatusCode: false,
+    })
+    expect(seeded.ok()).toBe(true)
+
+    const builder = twoChatPanes(a.id, b.id)
+    await seedWorkspace(page, {
+      ...builder,
+      viewMode: 'single',
+      singleScreen: { kind: 'chat', id: String(a.id) },
+    })
+    await page.goto(`${BASE}/shell/?chat=${a.id}`, { waitUntil: 'domcontentloaded' })
+    const standardSurface = page.locator(
+      `[data-chat-world="standard"][data-chat-id="${a.id}"]`,
+    )
+    const builderSurface = page.locator(
+      `[data-chat-world="builder"][data-chat-id="${a.id}"]`,
+    )
+    await expect(standardSurface.locator('.chat__scroll')).toBeVisible({ timeout: 15000 })
+
+    // The parked Builder owner must keep the rect it will paint. Expanding it
+    // to Standard's box before its ownership cleanup changes wrapping and makes
+    // a lifecycle capture describe content the reader was not looking at.
+    const [parkedBuilderBox, standardBox] = await Promise.all([
+      builderSurface.evaluate((element) => {
+        const { width, height } = element.getBoundingClientRect()
+        return { width, height }
+      }),
+      standardSurface.evaluate((element) => {
+        const { width, height } = element.getBoundingClientRect()
+        return { width, height }
+      }),
+    ])
+    expect(parkedBuilderBox.width).toBeLessThan(standardBox.width - 100)
+
+    const brand = page.getByRole('button', { name: 'Toggle navigation' })
+    await brand.focus()
+    await page.keyboard.press('Shift+Enter')
+    await waitTiled(page)
+    const builderScroll = builderSurface.locator('.chat__scroll')
+    await expect(builderScroll).toBeVisible({ timeout: 15000 })
+
+    const previousWriteAt = await page.evaluate(
+      id => JSON.parse(localStorage.getItem('chat-reading-position') || '{}')[id]?.at || 0,
+      String(a.id),
+    )
+    await builderScroll.evaluate((scroll) => {
+      scroll.dispatchEvent(new PointerEvent('pointerdown', {
+        bubbles: true,
+        pointerType: 'mouse',
+      }))
+      scroll.scrollTop = Math.floor(scroll.scrollHeight / 3)
+      scroll.dispatchEvent(new PointerEvent('pointerup', {
+        bubbles: true,
+        pointerType: 'mouse',
+      }))
+    })
+    await page.waitForFunction(({ id, after }) => (
+      (JSON.parse(localStorage.getItem('chat-reading-position') || '{}')[id]?.at || 0) > after
+    ), { id: String(a.id), after: previousWriteAt })
+
+    const before = await page.evaluate((id) => {
+      const scroll = document.querySelector(
+        `[data-chat-world="builder"][data-chat-id="${id}"] .chat__scroll`,
+      )
+      const { at: _at, ...saved } =
+        JSON.parse(localStorage.getItem('chat-reading-position') || '{}')[id]
+      const wrapper = scroll.closest('[data-chat-world="builder"]')
+      return {
+        top: scroll.scrollTop,
+        saved,
+        width: wrapper.getBoundingClientRect().width,
+      }
+    }, String(a.id))
+
+    await brand.focus()
+    await page.keyboard.press('Shift+Enter')
+    await expect(standardSurface.locator('.chat__scroll'))
+      .toHaveAttribute('data-scroll-mode', 'ANCHOR_AT', { timeout: 15000 })
+    await expect(page.locator('.workspace__chrome')).toHaveCount(0)
+
+    const afterExit = await page.evaluate((id) => {
+      const { at: _at, ...saved } =
+        JSON.parse(localStorage.getItem('chat-reading-position') || '{}')[id]
+      const wrapper = document.querySelector(
+        `[data-chat-world="builder"][data-chat-id="${id}"]`,
+      )
+      return { saved, width: wrapper.getBoundingClientRect().width }
+    }, String(a.id))
+    expect(afterExit.saved).toEqual(before.saved)
+    expect(Math.abs(afterExit.width - before.width)).toBeLessThanOrEqual(1)
+
+    await brand.focus()
+    await page.keyboard.press('Shift+Enter')
+    await waitTiled(page)
+    await expect(builderScroll).toHaveAttribute('data-scroll-mode', 'ANCHOR_AT', {
+      timeout: 15000,
+    })
+    expect(Math.abs((await builderScroll.evaluate(scroll => scroll.scrollTop)) - before.top))
+      .toBeLessThanOrEqual(8)
+  })
+
   // Regression (item 0): a genuine MULTI-PANE exit via the real POINTER-HOLD
   // completion path — the path the single-leaf keyboard verification missed — must
   // collapse the tiled workspace and STAY collapsed, and a rapid re-enter within


### PR DESCRIPTION
## Summary
- give the active chat surface sole ownership of the logical chat's durable reading position
- preserve semantic anchors and parked pane geometry across Standard/Builder round trips
- prevent sign-out cleanup from recreating owner-scoped reading positions
- replace the obsolete return-position check with real cold-return and workspace-round-trip regressions

## Why
Standard and Builder may retain separate physical `ChatView` surfaces for the same logical chat. Hidden copies could persist stale or never-painted geometry over the visible chat's saved coordinate, so reloads and returns reopened at the wrong place.

The durable coordinate now has one writer. The active surface transfers ownership inside the scroll controller; settled semantic anchors move unchanged, live follow/pin state freezes once, and hidden surfaces do no scroll or persistence work. Parked Builder surfaces also keep their pane geometry, so a world transition cannot reflow the outgoing reader position before handoff.

This is a focused follow-up to #458 and #382: #458 centralized semantic scroll authority inside the controller, while #382 made chat entry readiness a single phase. Neither assigned the one durable coordinate between retained Standard and Builder surfaces. This change closes that remaining ownership gap without adding another lifecycle path.

## Testing
- `npm --prefix frontend test`
- `npm --prefix frontend run lint` (0 errors; 45 existing warnings)
- `npm --prefix frontend run build`
- syntax checks for the changed Playwright specs
- authenticated rendered verification: a Builder → Standard → Builder round trip preserved the nested semantic anchor, pane geometry, and exact reading position; before/after frames were pixel-identical
