### PR TITLE
Fix mobile keyboard jitter when steering queued messages

### DIFF
--- a/frontend/src/components/ChatView/ChatInputBar.jsx
+++ b/frontend/src/components/ChatView/ChatInputBar.jsx
@@ -142,9 +142,9 @@ function PrimaryAction({
         key="primary"
         className="chat__action chat__steer"
         type="button"
-        // Keep focus stable through pointerdown, then let ChatView dismiss
-        // the keyboard deliberately as part of the steer action. Dispatching
-        // on touchend avoids waiting for Safari's synthesized click.
+        // Keep focus stable through pointerdown, then let ChatView dismiss the
+        // keyboard only after the authoritative steer row is positioned.
+        // Dispatching on touchend avoids waiting for Safari's synthesized click.
         onPointerDown={(e) => e.preventDefault()}
         onTouchEnd={(e) => { e.preventDefault(); onSteer() }}
         onClick={onSteer}

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -336,6 +336,13 @@ export default function ChatView({
   // Terminal live-to-settled commits bump this sequence. The corresponding
   // layout effect settles an armed prompt pin against the committed DOM.
   const [pinnedSettleSeq, setPinnedSettleSeq] = useState(0)
+  // A touch fast-forward dismisses the software keyboard only after the
+  // authoritative steer cut has rendered its user row. Closing it at request
+  // time resized the chat while that row did not exist yet, so the old tail
+  // re-anchored once and the steered row pinned in a second visible movement.
+  const steerKeyboardDismissRequestRef = useRef(null)
+  const [committedSteerKeyboardDismiss, setCommittedSteerKeyboardDismiss] =
+    useState(null)
   // Server-hydrated running marker. `sending` is the local UI flag and
   // `isStreaming` belongs to the SSE hook; both can briefly be false across
   // app/chat remounts or reconnect windows even though the backend still has
@@ -1178,6 +1185,16 @@ export default function ChatView({
         // Never infer a delayed pin from the reader's later position.
         fallbackWillPin: steeredIsFirstUser,
       })
+      const keyboardDismissRequest = steerKeyboardDismissRequestRef.current
+      if (keyboardDismissRequest
+          && keyboardDismissRequest.chatId === String(chatId)
+          && keyboardDismissRequest.cid === pinCid) {
+        steerKeyboardDismissRequestRef.current = null
+        // This state update batches with the transcript commit below. The
+        // layout effect waits for the exact row, after useScrollMode has
+        // applied its pin/hold, before allowing keyboard geometry to change.
+        setCommittedSteerKeyboardDismiss(keyboardDismissRequest)
+      }
       // Dedup by ts so a reconnect's catch-up replay of the same event
       // can't double-insert the steered user message. Insert by transcript ts
       // instead of blindly appending: if a fetch/replay already committed the
@@ -1200,6 +1217,9 @@ export default function ChatView({
       const cids = Array.isArray(consumePendingCids)
         ? consumePendingCids
         : []
+      if (cids.includes(steerKeyboardDismissRequestRef.current?.cid)) {
+        steerKeyboardDismissRequestRef.current = null
+      }
       pendingQueue.releaseSteerReservation(cids)
       forgetSendIntent({ cidList: cids })
       // A direct Cmd/Ctrl+Enter steer has no local tray row. The same
@@ -1208,6 +1228,35 @@ export default function ChatView({
       fetchMessages({ force: true })
     },
   })
+
+  // useScrollMode's layout effect is registered before this one. At a steer
+  // cut it therefore commits the new row's PIN_USER_MSG/ANCHOR_AT position
+  // first; only then may a still-focused, otherwise-unchanged touch composer
+  // close its keyboard. A draft edit or focus move during a deferred provider
+  // cut is newer owner intent and must not be interrupted by the old tap.
+  useLayoutEffect(() => {
+    const request = committedSteerKeyboardDismiss
+    if (!request) return
+    if (request.chatId !== String(chatId)) {
+      setCommittedSteerKeyboardDismiss(null)
+      return
+    }
+    const scrollEl = scrollRef.current
+    const escapedCid = typeof CSS !== 'undefined' && CSS.escape
+      ? CSS.escape(request.cid)
+      : request.cid
+    const committedRow = scrollEl?.querySelector(
+      `.chat__msg--user[data-cid="${escapedCid}"]`,
+    )
+    if (!committedRow) return
+
+    setCommittedSteerKeyboardDismiss(null)
+    const inputEl = inputRef.current
+    if (document.activeElement === inputEl
+        && inputValueRef.current === request.draft) {
+      inputEl.blur()
+    }
+  }, [chatId, committedSteerKeyboardDismiss, inputValueRef])
   // The composer clears before this boundary, so a slow picker save delays
   // transport without swallowing text entered after Send.
   const sendAfterSettingsSaved = useCallback(async (text, attachments, options) => {
@@ -3144,12 +3193,19 @@ export default function ChatView({
         isFirstUserMsg: steerIsFirstUser,
       })
       previousSendIntent = replaceSendIntent(steerCid, explicitSteerIntent)
-      // Queue-only sends deliberately retain mobile focus. Fast-forward is
-      // the explicit hand-off point, but snapshot reader position BEFORE
-      // blurring: keyboard dismissal resizes the viewport and can otherwise
-      // corrupt the pin decision. Both composer and per-row steer actions
-      // share this path.
-      if (_isTouchPrimary) inputRef.current?.blur()
+      // Queue-only sends deliberately retain mobile focus. Remember a touch
+      // fast-forward's focus/draft now, but do not blur yet: the authoritative
+      // cut must render and pin the steered row before keyboard geometry
+      // changes. Both composer and per-row steer actions share this path.
+      const inputEl = inputRef.current
+      steerKeyboardDismissRequestRef.current = null
+      if (_isTouchPrimary && document.activeElement === inputEl) {
+        steerKeyboardDismissRequestRef.current = {
+          chatId: String(chatId),
+          cid: steerCid,
+          draft: inputValueRef.current,
+        }
+      }
       // The queued tray is part of the footer height. Reserve these rows from
       // presentation before the request so the tray closes once, at the
       // deliberate steer action. The records remain in pendingQueue until the
@@ -3185,6 +3241,9 @@ export default function ChatView({
         onOwnerActivityRef.current?.()
       }
       if (result?.status !== 'steered') {
+        if (steerKeyboardDismissRequestRef.current?.cid === steerCid) {
+          steerKeyboardDismissRequestRef.current = null
+        }
         restoreReplacedSendIntent(
           steerCid,
           explicitSteerIntent,
@@ -3196,6 +3255,9 @@ export default function ChatView({
       // other status: release the unchanged queue back to the tray and let it
       // drain at turn-end.
     } catch {
+      if (steerKeyboardDismissRequestRef.current?.cid === steerCid) {
+        steerKeyboardDismissRequestRef.current = null
+      }
       restoreReplacedSendIntent(
         steerCid,
         explicitSteerIntent,

--- a/frontend/src/components/ChatView/__tests__/composerSteerTouch.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerSteerTouch.test.js
@@ -73,9 +73,28 @@ test('per-row fast-forward appears with the optimistic row and dispatches on tou
   )
 })
 
-test('the shared steer path snapshots scroll before dismissing the mobile composer', () => {
+test('touch steer dismisses the keyboard only after its committed row is positioned', () => {
   assert.match(
     chatView,
-    /async function steerRowsImpl\(steerRowsList\) \{[\s\S]*?explicitSteerIntent = captureSendIntent\(\{[\s\S]*?previousSendIntent = replaceSendIntent\(steerCid, explicitSteerIntent\)[\s\S]*?if \(_isTouchPrimary\) inputRef\.current\?\.blur\(\)[\s\S]*?pendingQueue\.reserveForSteer\(consumePendingCids\)/,
+    /async function steerRowsImpl\(steerRowsList\) \{[\s\S]*?explicitSteerIntent = captureSendIntent\(\{[\s\S]*?previousSendIntent = replaceSendIntent\(steerCid, explicitSteerIntent\)[\s\S]*?steerKeyboardDismissRequestRef\.current = \{[\s\S]*?pendingQueue\.reserveForSteer\(consumePendingCids\)/,
+    'the tap should retain focus while the provider is still settling the cut',
+  )
+  const requestToCut = chatView.match(
+    /async function steerRowsImpl\(steerRowsList\) \{[\s\S]*?\n  \/\/ STEER \(fast-forward\): inject/,
+  )?.[0] || ''
+  assert.doesNotMatch(
+    requestToCut,
+    /inputRef\.current\?\.blur\(\)|inputEl\.blur\(\)/,
+    'request-time keyboard dismissal recreates the pre-cut resize jitter',
+  )
+  assert.match(
+    chatView,
+    /onSteeredIntoTurn: \(\{[\s\S]*?landSentMessage\(pinCid,[\s\S]*?setCommittedSteerKeyboardDismiss\(keyboardDismissRequest\)[\s\S]*?commitMessages\(prev => insertMessageBatchByTs/,
+    'the authoritative cut should schedule dismissal in the same batch as the row',
+  )
+  assert.match(
+    chatView,
+    /useLayoutEffect\(\(\) => \{[\s\S]*?committedSteerKeyboardDismiss[\s\S]*?querySelector\([\s\S]*?chat__msg--user\[data-cid=[\s\S]*?document\.activeElement === inputEl[\s\S]*?inputValueRef\.current === request\.draft[\s\S]*?inputEl\.blur\(\)/,
+    'blur must wait for the committed row and preserve newer focus/draft intent',
   )
 })

--- a/tests/steer-queued.spec.mjs
+++ b/tests/steer-queued.spec.mjs
@@ -66,6 +66,12 @@ async function sendMessage(page, text) {
   await page.keyboard.press('Enter')
 }
 
+async function tapSend(page, text) {
+  const input = page.getByRole('textbox', { name: 'Message Möbius…' })
+  await input.fill(text)
+  await page.getByRole('button', { name: 'Send', exact: true }).click()
+}
+
 // The real service worker claims the page ~1s after load; from then on its
 // fetch() handler bypasses page.route, so the mocked /messages + /stream
 // contracts silently fall through to the real backend and the mock's steer
@@ -624,7 +630,10 @@ test.describe('Steer queued messages (fast-forward into the live turn)', () => {
     await setupChat(page)
     await newChat(page)
     await page.setViewportSize({ width: 1280, height: 900 })
-    await sendMessage(page, 'first message')
+    // This case deliberately advertises a touch-primary device. Plain Enter
+    // inserts a newline on that contract, so exercise the same Send control a
+    // phone user taps instead of borrowing the desktop helper above.
+    await tapSend(page, 'first message')
     await expect(page.locator('.chat__msg--user')).toBeVisible({ timeout: 5000 })
     await page.evaluate(() => {
       const mock = window.__immediateSteerMock
@@ -633,7 +642,7 @@ test.describe('Steer queued messages (fast-forward into the live turn)', () => {
       mock.emitInitial?.()
     })
     await expect(page.locator('.chat__stop')).toBeVisible({ timeout: 5000 })
-    await sendMessage(page, QUEUED_TEXT)
+    await tapSend(page, QUEUED_TEXT)
     const steerBtn = page.getByRole('button', { name: 'Send queued message now' })
     await expect(steerBtn).toBeVisible({ timeout: 5000 })
 

--- a/tests/steer-queued.spec.mjs
+++ b/tests/steer-queued.spec.mjs
@@ -488,6 +488,52 @@ test.describe('Steer queued messages (fast-forward into the live turn)', () => {
     const PRE_STEER = 'streaming room before fast-forward '.repeat(220)
     const messagePosts = []
 
+    // Exercise ChatView's touch-primary path and record the exact DOM state at
+    // every composer blur. A fresh send legitimately blurs before its row is
+    // committed; the later fast-forward blur must instead see the steered row
+    // already rendered and positioned by the scroll controller.
+    await page.addInitScript(() => {
+      const nativeMatchMedia = window.matchMedia.bind(window)
+      window.matchMedia = query => {
+        if (query !== '(hover: none) and (pointer: coarse)') {
+          return nativeMatchMedia(query)
+        }
+        return {
+          matches: true,
+          media: query,
+          onchange: null,
+          addListener() {},
+          removeListener() {},
+          addEventListener() {},
+          removeEventListener() {},
+          dispatchEvent() { return true },
+        }
+      }
+
+      window.__steerTouchBlurObservations = []
+      const nativeBlur = HTMLElement.prototype.blur
+      HTMLElement.prototype.blur = function (...args) {
+        if (this instanceof HTMLTextAreaElement
+            && this.getAttribute('aria-label') === 'Message Möbius…') {
+          const scroll = document.querySelector(
+            '[data-chat-surface="painted"] .chat__scroll',
+          )
+          const users = [...(document.querySelectorAll(
+            '[data-chat-surface="painted"] .chat__msg--user',
+          ))]
+          const row = users.at(-1)
+          const scrollRect = scroll?.getBoundingClientRect()
+          const rowRect = row?.getBoundingClientRect()
+          window.__steerTouchBlurObservations.push({
+            userCount: users.length,
+            mode: scroll?.dataset.scrollMode || null,
+            rowTop: scrollRect && rowRect ? rowRect.top - scrollRect.top : null,
+          })
+        }
+        return nativeBlur.apply(this, args)
+      }
+    })
+
     await page.route(/\/api\/chats\/[0-9a-f-]+\/messages$/, async (route) => {
       let body = {}
       try { body = JSON.parse(route.request().postData() || '{}') } catch { /* empty */ }
@@ -650,6 +696,15 @@ test.describe('Steer queued messages (fast-forward into the live turn)', () => {
       Math.max(...landedFrames) - Math.min(...landedFrames),
       JSON.stringify(result),
     ).toBeLessThanOrEqual(2)
+
+    const steerBlur = await page.evaluate(
+      () => window.__steerTouchBlurObservations?.at(-1) || null,
+    )
+    expect(steerBlur, JSON.stringify(steerBlur)).not.toBeNull()
+    expect(steerBlur.userCount, JSON.stringify(steerBlur)).toBe(2)
+    expect(steerBlur.mode, JSON.stringify(steerBlur)).toBe('PIN_USER_MSG')
+    expect(steerBlur.rowTop, JSON.stringify(steerBlur)).toBeGreaterThanOrEqual(-2)
+    expect(steerBlur.rowTop, JSON.stringify(steerBlur)).toBeLessThanOrEqual(12)
 
     const pinIndex = result.transitions.findIndex(
       row => row.event === 'send:pin-user-message',


### PR DESCRIPTION
## Summary
- Delay touch keyboard dismissal until the authoritative steered row has rendered and the scroll owner has positioned it.
- Preserve newer composer focus or draft changes while a provider is settling a deferred steer cut.
- Extend steering regression coverage to assert that the new row is pinned before blur.

## Testing
- `node --loader=./src/lib/__tests__/vite-env-loader.mjs --test src/components/ChatView/__tests__/composerSteerTouch.test.js`
- `node --check tests/steer-queued.spec.mjs`
- Phone-sized rendered check with a simulated software-keyboard resize; the steered row remained fixed through the resize.