### PR TITLE
Restore the last workspace after relaunch

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1041,11 +1041,12 @@ the same reference for no-op transitions.
 
 `useWorkspaceSession.js` is the live state owner. It composes reducer transitions
 through a synchronous ref boundary, persists the sole versioned
-`mobius-workspace` session value, owns focused-pane presentation, and projects
-content geometry. A missing or invalid workspace value fails closed to a fresh
-empty workspace; retained active-destination keys can then restore the current
-chat or app through the normal navigation path. There is no parallel flat-tab
-persistence format.
+`mobius-workspace` local value, owns focused-pane presentation, and projects
+content geometry. The durable snapshot restores the focused tab, pane layout,
+and Standard/Builder world after a fully closed PWA is relaunched. A missing or
+invalid workspace value fails closed to a fresh empty workspace; retained
+active-destination keys can then restore the current chat or app through the
+normal navigation path. There is no parallel flat-tab persistence format.
 
 The render path walks the projected leaves. Each visible chat pane owns its own
 retained `ChatView` surface and scroll controller. App frames remain in the

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -171,7 +171,10 @@ export default function Shell() {
     projection,
     visiblePaneIds,
     persistWorkspaceSnapshot,
-  } = useWorkspaceSession({ storage: sessionStorage })
+  } = useWorkspaceSession({
+    storage: localStorage,
+    legacyStorage: sessionStorage,
+  })
 
   const {
     activeView,
@@ -708,13 +711,6 @@ export default function Shell() {
     if (openTabs.length >= 2) setTabStripEngaged(true)
     else if (openTabs.length === 0) setTabStripEngaged(false)
   }, [openTabs.length])
-  // Persist only the versioned workspace. The former flat-tab rollback mirror
-  // completed its release window and was removed so every boot has one owner.
-  useEffect(() => {
-    try {
-      sessionStorage.setItem(paneModel.STORAGE_KEY, paneModel.serializeWorkspace(workspace))
-    } catch { /* private mode / quota — workspace stays in memory only */ }
-  }, [workspace])
   // Pointer events inside an iframe do not bubble to its positioned shell
   // wrapper. The verified live frame sends a tiny focus signal so app panes have
   // the same click-to-focus semantics as native chat panes.

--- a/frontend/src/components/Shell/__tests__/paneModel.test.js
+++ b/frontend/src/components/Shell/__tests__/paneModel.test.js
@@ -5,7 +5,7 @@ import * as paneModel from '../paneModel.js'
 
 const { makeTab, tabKey } = tabModel
 
-// A Map-backed sessionStorage stub so the legacy dual-write round-trip is
+// A Map-backed browser-storage stub so persistence round-trips are
 // testable without jsdom, mirroring the tabModel tests.
 function fakeStorage(initial = null) {
   let value = initial
@@ -782,7 +782,7 @@ test('readWorkspaceRaw survives a throwing storage instead of crashing boot', ()
   const throwing = {
     getItem() { throw new DOMException('The operation is insecure.', 'SecurityError') },
   }
-  // Must not throw — sessionStorage.getItem can raise in a sandboxed frame, and
+  // Must not throw — browser storage getItem can raise in a sandboxed frame, and
   // the Shell reads it while building the reducer's initial state.
   assert.equal(paneModel.readWorkspaceRaw(throwing), null)
   // The null feeds parseWorkspace, which then seeds a safe empty workspace.

--- a/frontend/src/components/Shell/__tests__/useWorkspaceSession.hooktest.js
+++ b/frontend/src/components/Shell/__tests__/useWorkspaceSession.hooktest.js
@@ -76,3 +76,62 @@ test('reload snapshot persists the ref-current workspace, not a stale render clo
   )
   assert.deepEqual(paneModel.flatten(restored).map(tab => tab.id), ['durable'])
 })
+
+test('a live session workspace is promoted once and restored after a cold relaunch', () => {
+  let visited = paneModel.seedFromFlatTabs([
+    { kind: 'chat', id: 'chat-a' },
+    { kind: 'app', id: 42 },
+  ])
+  visited = paneModel.setActiveTab(visited, visited.focusedPaneId, 'chat:chat-a')
+  const legacy = memoryStorage({
+    [paneModel.STORAGE_KEY]: paneModel.serializeWorkspace(visited),
+  })
+  const durable = memoryStorage()
+
+  const firstLaunch = renderHook(useWorkspaceSession, {
+    storage: durable,
+    legacyStorage: legacy,
+  })
+  assert.equal(
+    firstLaunch.result.current.workspace.panes.p0.activeTabKey,
+    'chat:chat-a',
+  )
+  assert.equal(legacy.getItem(paneModel.STORAGE_KEY), null)
+  assert.ok(durable.getItem(paneModel.STORAGE_KEY))
+
+  const coldRelaunch = renderHook(useWorkspaceSession, {
+    storage: durable,
+    legacyStorage: memoryStorage(),
+  })
+  assert.deepEqual(
+    paneModel.flatten(coldRelaunch.result.current.workspace).map(tab => tab.id),
+    ['chat-a', '42'],
+  )
+  assert.equal(
+    coldRelaunch.result.current.workspace.panes.p0.activeTabKey,
+    'chat:chat-a',
+  )
+})
+
+test('a failed durable copy keeps the session workspace available', () => {
+  const visited = paneModel.seedFromFlatTabs([{ kind: 'chat', id: 'still-here' }])
+  const legacy = memoryStorage({
+    [paneModel.STORAGE_KEY]: paneModel.serializeWorkspace(visited),
+  })
+  const unavailable = {
+    getItem() { return null },
+    setItem() { throw new DOMException('Quota exceeded', 'QuotaExceededError') },
+    removeItem() {},
+  }
+
+  const { result } = renderHook(useWorkspaceSession, {
+    storage: unavailable,
+    legacyStorage: legacy,
+  })
+
+  assert.deepEqual(
+    paneModel.flatten(result.current.workspace).map(tab => tab.id),
+    ['still-here'],
+  )
+  assert.ok(legacy.getItem(paneModel.STORAGE_KEY))
+})

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -91,21 +91,6 @@ test('an implicit home tab does not engage the single-pane tab strip', () => {
   assert.match(shell, /const closeTab = useCallback\(\(tab, \{ reason \} = \{\}\)/)
 })
 
-test('the canonical workspace snapshot survives a closed PWA relaunch', () => {
-  assert.match(
-    shell,
-    /useWorkspaceSession\(\{\s*storage: localStorage,\s*legacyStorage: sessionStorage,\s*\}\)/,
-  )
-  assert.doesNotMatch(
-    shell,
-    /sessionStorage\.setItem\(paneModel\.STORAGE_KEY/,
-  )
-  assert.match(
-    workspaceSession,
-    /storage\.setItem\(\s*paneModel\.STORAGE_KEY,\s*paneModel\.serializeWorkspace\(workspace\)/,
-  )
-})
-
 test('the drop preview reads as an 18% accent fill with a 2px border and morph', () => {
   const rule = css.match(/\.workspace__drop-preview\s*\{[\s\S]*?\}/)?.[0] || ''
   assert.match(rule, /border:\s*2px solid var\(--accent\)/)

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -91,6 +91,21 @@ test('an implicit home tab does not engage the single-pane tab strip', () => {
   assert.match(shell, /const closeTab = useCallback\(\(tab, \{ reason \} = \{\}\)/)
 })
 
+test('the canonical workspace snapshot survives a closed PWA relaunch', () => {
+  assert.match(
+    shell,
+    /useWorkspaceSession\(\{\s*storage: localStorage,\s*legacyStorage: sessionStorage,\s*\}\)/,
+  )
+  assert.doesNotMatch(
+    shell,
+    /sessionStorage\.setItem\(paneModel\.STORAGE_KEY/,
+  )
+  assert.match(
+    workspaceSession,
+    /storage\.setItem\(\s*paneModel\.STORAGE_KEY,\s*paneModel\.serializeWorkspace\(workspace\)/,
+  )
+})
+
 test('the drop preview reads as an 18% accent fill with a 2px border and morph', () => {
   const rule = css.match(/\.workspace__drop-preview\s*\{[\s\S]*?\}/)?.[0] || ''
   assert.match(rule, /border:\s*2px solid var\(--accent\)/)

--- a/frontend/src/components/Shell/paneModel.js
+++ b/frontend/src/components/Shell/paneModel.js
@@ -90,10 +90,11 @@ export const BUILDER_POWER_CHROME = (() => {
 export const MIN_PANE_W = 280
 export const MIN_PANE_H = 200
 
-// sessionStorage key for the sole serialized workspace state.
+// localStorage key for the sole serialized workspace state. The workspace must
+// survive a fully closed/relaunched PWA, not only an in-tab reload.
 export const STORAGE_KEY = 'mobius-workspace'
 
-// sessionStorage key for the maximized ("focus one pane full-screen") presentation.
+// localStorage key for the maximized ("focus one pane full-screen") presentation.
 // Deliberately SEPARATE from STORAGE_KEY: focusing a pane must never rewrite the
 // persisted split tree or ratios (design §2), so the maximize is a thin presentation
 // overlay stored beside the blob and re-seeded on mount. Without this, the reload
@@ -1566,7 +1567,7 @@ export function serializeWorkspace(ws) {
   return JSON.stringify(ws)
 }
 
-// The raw stored blob, or null if storage is unavailable. sessionStorage.getItem
+// The raw stored blob, or null if storage is unavailable. Browser storage getItem
 // can THROW (SecurityError in a sandboxed frame, disabled storage, a privacy
 // policy), and the caller reads it while evaluating parseWorkspace's argument —
 // outside parseWorkspace's own try/catch. Guarding the read here keeps broken

--- a/frontend/src/components/Shell/tabModel.js
+++ b/frontend/src/components/Shell/tabModel.js
@@ -33,7 +33,7 @@ export const APPS_TAB_KEY = 'apps:apps'
 export function appsTab() { return { kind: 'apps', id: APPS_ID } }
 export function isAppsTab(tab) { return !!tab && tab.kind === 'apps' }
 
-// Ids are stored as strings for stable React keys + sessionStorage. App ids
+// Ids are stored as strings for stable React keys + browser persistence. App ids
 // are re-coerced to Number in tabNavTarget — the ONLY correct nav shape (the
 // iframe LRU dedups on strict !==, so a string id would double-mount).
 export function makeTab(kind, id) {

--- a/frontend/src/components/Shell/useWorkspaceSession.js
+++ b/frontend/src/components/Shell/useWorkspaceSession.js
@@ -18,18 +18,27 @@ import { projectFocusedPane } from './workspaceView.js'
  * without moving those policies into the reducer. Every workspace mutation must
  * use dispatchWorkspace so same-batch transitions compose against workspaceStateRef.
  */
-export default function useWorkspaceSession({ storage }) {
+function bootWorkspaceSnapshot(storage, legacyStorage) {
+  const legacyRaw = paneModel.readWorkspaceRaw(legacyStorage)
+  if (paneModel.isValidWorkspaceBlob(legacyRaw)) {
+    return { raw: legacyRaw, source: legacyStorage }
+  }
+  return { raw: paneModel.readWorkspaceRaw(storage), source: storage }
+}
+
+export default function useWorkspaceSession({ storage, legacyStorage = null }) {
+  const [bootSnapshot] = useState(
+    () => bootWorkspaceSnapshot(storage, legacyStorage),
+  )
   const [workspaceState, dispatchWorkspaceRaw] = useReducer(
     paneModel.workspaceReducer,
     undefined,
     () => paneModel.initialWorkspaceState(
-      paneModel.parseWorkspace(paneModel.readWorkspaceRaw(storage)),
+      paneModel.parseWorkspace(bootSnapshot.raw),
     ),
   )
   const workspace = workspaceState.ws
-  const [blobValid] = useState(
-    () => paneModel.isValidWorkspaceBlob(paneModel.readWorkspaceRaw(storage)),
-  )
+  const blobValid = paneModel.isValidWorkspaceBlob(bootSnapshot.raw)
   const replaceImplicitBootTab = !blobValid
     && Object.keys(workspace.panes).length === 1
     && paneModel.flatten(workspace).length <= 1
@@ -42,7 +51,7 @@ export default function useWorkspaceSession({ storage }) {
 
   const [focusedPaneViewId, setFocusedPaneViewIdState] = useState(
     () => paneModel.resolveInitialFocusedPaneView(
-      workspace, paneModel.readFocusedPaneView(storage),
+      workspace, paneModel.readFocusedPaneView(bootSnapshot.source),
     ),
   )
   const focusedPaneViewIdRef = useRef(focusedPaneViewId)
@@ -134,6 +143,28 @@ export default function useWorkspaceSession({ storage }) {
   useEffect(() => {
     paneModel.writeFocusedPaneView(focusedPaneViewId, storage)
   }, [focusedPaneViewId, storage])
+
+  // The workspace is one durable browser-owned snapshot. `legacyStorage` is
+  // only the legacy session value: prefer it once during this live tab's
+  // upgrade, copy the normalized result durably, then remove it so it can never
+  // override a newer cross-launch snapshot on a later reload.
+  useEffect(() => {
+    try {
+      storage.setItem(
+        paneModel.STORAGE_KEY,
+        paneModel.serializeWorkspace(workspace),
+      )
+    } catch {
+      // Private mode/quota may reject writes; keep the session copy as the only
+      // available recovery source rather than deleting it after a failed copy.
+      return
+    }
+    if (!legacyStorage || legacyStorage === storage) return
+    try {
+      legacyStorage.removeItem(paneModel.STORAGE_KEY)
+      legacyStorage.removeItem(paneModel.FOCUSED_PANE_VIEW_KEY)
+    } catch { /* the durable copy already succeeded */ }
+  }, [legacyStorage, storage, workspace])
 
   const toggleFocusedPaneView = useCallback((paneId) => {
     const ws = workspaceStateRef.current.ws

--- a/tests/auth.setup.mjs
+++ b/tests/auth.setup.mjs
@@ -99,5 +99,10 @@ setup('authenticate', async ({ page, request }) => {
     )
   }
 
+  // The shared state is an authentication fixture, not a snapshot of whatever
+  // workspace the setup page happened to open. Once workspaces became durable,
+  // retaining this value made unrelated specs boot into the setup chat/app and
+  // override the explicit navigation state each test seeds.
+  await page.evaluate(() => localStorage.removeItem('mobius-workspace'))
   await page.context().storageState({ path: AUTH_FILE })
 })

--- a/tests/mode-transition.spec.mjs
+++ b/tests/mode-transition.spec.mjs
@@ -203,7 +203,7 @@ for (const [name, viewport] of [
     const before = await builderActive(page)
     await toggleMode(page)
     await expect.poll(() => builderActive(page)).toBe(!before)
-    const entered = await page.evaluate(key => JSON.parse(sessionStorage.getItem(key)), paneModel.STORAGE_KEY)
+    const entered = await page.evaluate(key => JSON.parse(localStorage.getItem(key)), paneModel.STORAGE_KEY)
     expect(entered.panes[entered.focusedPaneId].tabs.map(tabModel.tabKey)).toEqual(['chat:aaa'])
     // The beat settles: no transient class lingers.
     await expect.poll(() => transientClassCount(page), { timeout: 2000 }).toBe(0)
@@ -474,7 +474,7 @@ test('round4-3: a persisted NULL single slot stays New Chat even with historical
   await bootSeededWorkspace(page, WIDE, ws)
 
   await expect.poll(() => page.evaluate(
-    key => JSON.parse(sessionStorage.getItem(key))?.singleScreen?.id || null,
+    key => JSON.parse(localStorage.getItem(key))?.singleScreen?.id || null,
     paneModel.STORAGE_KEY,
   ), { timeout: 3000 }).toBe('freshboot')
   expect(createCount, 'boot materializes one new row instead of selecting chats[0]').toBe(1)
@@ -521,7 +521,7 @@ test('round4-3: a superseding NULL-slot request drains after the older POST with
   releaseFirstCreate()
 
   await expect.poll(() => page.evaluate(
-    key => JSON.parse(sessionStorage.getItem(key))?.singleScreen?.id || null,
+    key => JSON.parse(localStorage.getItem(key))?.singleScreen?.id || null,
     paneModel.STORAGE_KEY,
   ), { timeout: 4000 }).toBe('fresh-race-1')
   expect(createCount, 'the newer request reuses the already-created untouched row').toBe(1)
@@ -566,7 +566,7 @@ test('v2 auto-return flips the descriptor and the tree atomically (no lagging fr
   // The emptied builder auto-returned to single.
   await expect.poll(() => builderActive(page)).toBe(false)
   await expect.poll(() => page.evaluate(
-    key => JSON.parse(sessionStorage.getItem(key))?.viewMode, paneModel.STORAGE_KEY,
+    key => JSON.parse(localStorage.getItem(key))?.viewMode, paneModel.STORAGE_KEY,
   ), { timeout: 3000 }).toBe('single')
 })
 

--- a/tests/tabs.spec.mjs
+++ b/tests/tabs.spec.mjs
@@ -301,7 +301,7 @@ test.describe('Tabs', () => {
     await page.locator('.shell__tab-close').first().click()
     await expect(page.locator('.shell__tabstrip')).toHaveCount(0)
     await expect.poll(() => page.evaluate(
-      key => JSON.parse(sessionStorage.getItem(key))?.viewMode,
+      key => JSON.parse(localStorage.getItem(key))?.viewMode,
       paneModel.STORAGE_KEY,
     ), { timeout: 3000 }).toBe('single')
     await expect(page.locator('[data-chat-surface="painted"] .chat__scroll'))
@@ -321,7 +321,7 @@ test.describe('Tabs', () => {
     await page.goto(`${BASE}/shell/?chat=${chat.id}`, { waitUntil: 'domcontentloaded' })
     await expect.poll(() => appsMock.requests, { timeout: 5000 }).toBeGreaterThan(0)
     await expect.poll(() => page.evaluate(
-      key => JSON.parse(sessionStorage.getItem(key))?.viewMode,
+      key => JSON.parse(localStorage.getItem(key))?.viewMode,
       paneModel.STORAGE_KEY,
     )).toBe('single')
     await sendMessage(page, 'just a chat')
@@ -342,7 +342,7 @@ test.describe('Tabs', () => {
     await page.goto(`${BASE}/shell/?chat=${chat.id}`, { waitUntil: 'domcontentloaded' })
     await expect.poll(() => appsMock.requests, { timeout: 5000 }).toBeGreaterThan(0)
     await expect.poll(() => page.evaluate(
-      key => JSON.parse(sessionStorage.getItem(key))?.viewMode, paneModel.STORAGE_KEY,
+      key => JSON.parse(localStorage.getItem(key))?.viewMode, paneModel.STORAGE_KEY,
     )).toBe('single')
     await sendMessage(page, 'single with a parked tree')
     // NO strip in single, despite the engaged mirror + the parked 2-tab tree.

--- a/tests/workspace-panes.spec.mjs
+++ b/tests/workspace-panes.spec.mjs
@@ -13,7 +13,7 @@
  *   (e) a projection flip to phone preserves the persisted tree and pane focus;
  *
  * The flag is enabled per-test (localStorage 'mobius:workspace-splits' = '1')
- * and a 2-pane workspace blob is seeded in sessionStorage before the shell
+ * and a 2-pane workspace blob is seeded in localStorage before the shell
  * boots, exactly like tabs.spec seeds the flat workspace. Agent + apps routes
  * are intercepted so no agent tokens are consumed.
  *
@@ -158,7 +158,7 @@ async function seedWorkspace(page, ws) {
   await page.addInitScript(([flagKey, wsKey, wsBlob, legKey, leg]) => {
     try {
       localStorage.setItem(flagKey, '1')
-      sessionStorage.setItem(wsKey, wsBlob)
+      localStorage.setItem(wsKey, wsBlob)
       sessionStorage.setItem(legKey, leg)
     } catch { /* private mode */ }
   }, ['mobius:workspace-splits', paneModel.STORAGE_KEY, blob, 'mobius-open-tabs', legacy])
@@ -176,7 +176,7 @@ async function seedBuilderSingleLeaf(page, chatId) {
   await page.addInitScript(([flagKey, workspaceKey, workspaceBlob]) => {
     try {
       localStorage.setItem(flagKey, '1')
-      sessionStorage.setItem(workspaceKey, workspaceBlob)
+      localStorage.setItem(workspaceKey, workspaceBlob)
       sessionStorage.setItem('mobius-open-tabs', '[]') // empty legacy -> strip not engaged
     } catch { /* private mode */ }
   }, ['mobius:workspace-splits', paneModel.STORAGE_KEY, blob])
@@ -655,7 +655,7 @@ test.describe('Workspace panes (PR2 gate)', () => {
 
     // Baseline = the normalized blob the shell persisted after boot (a resize
     // must not rewrite it — geometry is projection, not persisted state).
-    const beforeBlob = await page.evaluate(k => sessionStorage.getItem(k), paneModel.STORAGE_KEY)
+    const beforeBlob = await page.evaluate(k => localStorage.getItem(k), paneModel.STORAGE_KEY)
     expect(beforeBlob, 'workspace blob persisted').toBeTruthy()
 
     // Flip the projection: wide → phone.
@@ -663,11 +663,11 @@ test.describe('Workspace panes (PR2 gate)', () => {
     await page.evaluate(() => new Promise(r =>
       requestAnimationFrame(() => requestAnimationFrame(() => setTimeout(r, 200)))))
 
-    const afterBlob = await page.evaluate(k => sessionStorage.getItem(k), paneModel.STORAGE_KEY)
+    const afterBlob = await page.evaluate(k => localStorage.getItem(k), paneModel.STORAGE_KEY)
     expect(afterBlob, 'the persisted tree is unchanged across the projection flip').toBe(beforeBlob)
     // The tree still parses to two panes (projection changed, tree did not).
     const leaves = await page.evaluate((k) => {
-      const ws = JSON.parse(sessionStorage.getItem(k))
+      const ws = JSON.parse(localStorage.getItem(k))
       return Object.keys(ws.panes).length
     }, paneModel.STORAGE_KEY)
     expect(leaves).toBe(2)
@@ -679,7 +679,7 @@ test.describe('Workspace panes (PR2 gate)', () => {
     await expect(otherStrip).toBeVisible({ timeout: 4000 })
     await otherStrip.click()
     await expect.poll(
-      () => page.evaluate((k) => JSON.parse(sessionStorage.getItem(k)).focusedPaneId,
+      () => page.evaluate((k) => JSON.parse(localStorage.getItem(k)).focusedPaneId,
         paneModel.STORAGE_KEY),
       { timeout: 3000, message: 'phone projection still commits pane focus' },
     ).toBe('p1')
@@ -729,7 +729,7 @@ function whichPaneHas(ws, tabKey) {
 }
 
 async function readWs(page) {
-  return page.evaluate(k => JSON.parse(sessionStorage.getItem(k)), paneModel.STORAGE_KEY)
+  return page.evaluate(k => JSON.parse(localStorage.getItem(k)), paneModel.STORAGE_KEY)
 }
 
 /** Press on a source element, arm past slop, glide to a target point, release —
@@ -1393,7 +1393,7 @@ test.describe('Workspace view-mode toggle', () => {
     await page.addInitScript((wsBlob) => {
       try {
         localStorage.setItem('mobius:workspace-splits', '0') // KILL SWITCH OFF
-        sessionStorage.setItem('mobius-workspace', wsBlob)
+        localStorage.setItem('mobius-workspace', wsBlob)
       } catch { /* private mode */ }
     }, blob)
     await page.goto(`${BASE}/shell/?chat=${a.id}`, { waitUntil: 'domcontentloaded' })


### PR DESCRIPTION
## Summary
- persist the canonical workspace across PWA lifetimes so the focused tab, pane layout, and Standard/Builder mode return after relaunch
- promote an existing session workspace once, without discarding it when durable browser storage is unavailable
- keep automatic persistence in the workspace owner and update the architecture and regression coverage

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- authenticated mobile-shell smoke test: clear session-only state, reload, and confirm the Apps directory is restored