### PR TITLE
Tighten drawer chat and app row spacing

### DIFF
--- a/frontend/src/components/Drawer/Drawer.css
+++ b/frontend/src/components/Drawer/Drawer.css
@@ -177,8 +177,8 @@
   color: var(--text);
   font-weight: 500;
   margin: 0;
-  padding: 11px 12px;
-  min-height: 44px;
+  padding: 8px 12px;
+  min-height: 40px;
 }
 
 .drawer__item--new:hover {
@@ -280,11 +280,11 @@
 
 .drawer__item {
   width: 100%;
-  min-height: 44px;
+  min-height: 40px;
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 10px 12px;
+  padding: 8px 12px;
   background: none;
   border: none;
   border-radius: 10px;
@@ -415,8 +415,8 @@
 .drawer__row {
   position: relative;
   display: flex;
-  flex: 0 0 44px;
-  height: 44px;
+  flex: 0 0 40px;
+  height: 40px;
   align-items: center;
   gap: 0;
 }

--- a/frontend/src/components/Drawer/Drawer.css
+++ b/frontend/src/components/Drawer/Drawer.css
@@ -177,8 +177,6 @@
   color: var(--text);
   font-weight: 500;
   margin: 0;
-  padding: 8px 12px;
-  min-height: 40px;
 }
 
 .drawer__item--new:hover {
@@ -415,7 +413,6 @@
 .drawer__row {
   position: relative;
   display: flex;
-  flex: 0 0 40px;
   height: 40px;
   align-items: center;
   gap: 0;

--- a/frontend/src/components/Drawer/drawerRowWindow.js
+++ b/frontend/src/components/Drawer/drawerRowWindow.js
@@ -40,20 +40,21 @@ export function drawerRowWindow({
   scrollTop,
   viewportHeight,
   sectionTop,
-  rowHeight = DRAWER_ROW_HEIGHT,
-  overscan = DRAWER_ROW_OVERSCAN,
 }) {
   const count = boundedTotal(total)
   if (count === 0) return { start: 0, end: 0 }
-  const height = Math.max(1, Number(rowHeight) || DRAWER_ROW_HEIGHT)
   const localTop = Math.max(0, (Number(scrollTop) || 0) - (Number(sectionTop) || 0))
-  const visibleStart = Math.floor(localTop / height)
+  const visibleStart = Math.floor(localTop / DRAWER_ROW_HEIGHT)
   const visibleEnd = Math.ceil(
-    (localTop + Math.max(height, Number(viewportHeight) || 0)) / height,
+    (localTop + Math.max(DRAWER_ROW_HEIGHT, Number(viewportHeight) || 0))
+      / DRAWER_ROW_HEIGHT,
   )
   return {
-    start: Math.max(0, visibleStart - overscan),
-    end: Math.min(count, Math.max(visibleStart + 1, visibleEnd + overscan)),
+    start: Math.max(0, visibleStart - DRAWER_ROW_OVERSCAN),
+    end: Math.min(
+      count,
+      Math.max(visibleStart + 1, visibleEnd + DRAWER_ROW_OVERSCAN),
+    ),
   }
 }
 
@@ -78,11 +79,11 @@ export function drawerRowWindowForIndex(current, total, rowIndex) {
   return drawerRowWindowContaining(count, rowIndex)
 }
 
-export function drawerRowSpacerHeights(window, total, rowHeight = DRAWER_ROW_HEIGHT) {
+export function drawerRowSpacerHeights(window, total) {
   const bounded = clampDrawerRowWindow(window, total)
   return {
-    before: bounded.start * rowHeight,
-    after: Math.max(0, boundedTotal(total) - bounded.end) * rowHeight,
+    before: bounded.start * DRAWER_ROW_HEIGHT,
+    after: Math.max(0, boundedTotal(total) - bounded.end) * DRAWER_ROW_HEIGHT,
   }
 }
 

--- a/frontend/src/components/Drawer/drawerRowWindow.js
+++ b/frontend/src/components/Drawer/drawerRowWindow.js
@@ -1,6 +1,6 @@
 /* Constant-size drawer windowing for the mixed Recent list. */
 
-export const DRAWER_ROW_HEIGHT = 44
+export const DRAWER_ROW_HEIGHT = 40
 export const DRAWER_ROW_OVERSCAN = 8
 export const DRAWER_INITIAL_WINDOW_ROWS = 48
 

--- a/frontend/src/components/Shell/__tests__/drawerAlignment.test.js
+++ b/frontend/src/components/Shell/__tests__/drawerAlignment.test.js
@@ -1,6 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
+import { DRAWER_ROW_HEIGHT } from '../../Drawer/drawerRowWindow.js'
 
 const drawerCss = readFileSync(new URL('../../Drawer/Drawer.css', import.meta.url), 'utf8')
 const shellCss = readFileSync(new URL('../Shell.css', import.meta.url), 'utf8')
@@ -20,12 +21,17 @@ const px = (body, property) => {
 
 test('collapsed and expanded drawer actions share one vertical rhythm', () => {
   const newChat = ruleBody(drawerCss, '.drawer__item--new')
+  const drawerItem = ruleBody(drawerCss, '.drawer__item')
+  const drawerRow = ruleBody(drawerCss, '.drawer__row')
   const desktopDrawerBody = ruleBody(drawerCss, '.drawer__body', 1)
   const desktopDrawerItem = ruleBody(drawerCss, '.drawer__item,\n  .drawer__item--new')
   const desktopRail = ruleBody(shellCss, '.shell__rail-actions', 1)
   const desktopRailAction = ruleBody(shellCss, '.shell__rail-action')
 
-  assert.equal(px(newChat, 'min-height'), 44)
+  assert.equal(px(newChat, 'min-height'), DRAWER_ROW_HEIGHT)
+  assert.equal(px(drawerItem, 'min-height'), DRAWER_ROW_HEIGHT)
+  assert.equal(px(drawerRow, 'height'), DRAWER_ROW_HEIGHT)
+  assert.match(drawerRow, new RegExp(`flex:\\s*0 0 ${DRAWER_ROW_HEIGHT}px;`))
   assert.doesNotMatch(newChat, /(?:border|box-shadow)\s*:/)
   assert.equal(58 + px(desktopDrawerBody, 'padding'), 12 + px(desktopRail, 'margin-top'))
   assert.equal(px(desktopDrawerItem, 'min-height'), px(desktopRailAction, 'height'))

--- a/frontend/src/components/Shell/__tests__/drawerAlignment.test.js
+++ b/frontend/src/components/Shell/__tests__/drawerAlignment.test.js
@@ -28,11 +28,9 @@ test('collapsed and expanded drawer actions share one vertical rhythm', () => {
   const desktopRail = ruleBody(shellCss, '.shell__rail-actions', 1)
   const desktopRailAction = ruleBody(shellCss, '.shell__rail-action')
 
-  assert.equal(px(newChat, 'min-height'), DRAWER_ROW_HEIGHT)
   assert.equal(px(drawerItem, 'min-height'), DRAWER_ROW_HEIGHT)
   assert.equal(px(drawerRow, 'height'), DRAWER_ROW_HEIGHT)
-  assert.match(drawerRow, new RegExp(`flex:\\s*0 0 ${DRAWER_ROW_HEIGHT}px;`))
-  assert.doesNotMatch(newChat, /(?:border|box-shadow)\s*:/)
+  assert.doesNotMatch(newChat, /(?:min-height|padding|border|box-shadow)\s*:/)
   assert.equal(58 + px(desktopDrawerBody, 'padding'), 12 + px(desktopRail, 'margin-top'))
   assert.equal(px(desktopDrawerItem, 'min-height'), px(desktopRailAction, 'height'))
   assert.match(

--- a/frontend/src/lib/__tests__/drawerRowWindow.test.js
+++ b/frontend/src/lib/__tests__/drawerRowWindow.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import {
   DRAWER_INITIAL_WINDOW_ROWS,
   DRAWER_ROW_HEIGHT,
+  DRAWER_ROW_OVERSCAN,
   clampDrawerRowWindow,
   drawerRowSpacerHeights,
   drawerRowWindow,
@@ -27,8 +28,10 @@ test('scrolling to the middle slides the window instead of accumulating rows', (
     viewportHeight: 860,
     sectionTop: 0,
   })
-  assert.ok(window.start > 380)
-  assert.ok(window.end < 430)
+  assert.ok(window.start >= 400 - DRAWER_ROW_OVERSCAN)
+  assert.ok(
+    window.end <= 400 + Math.ceil(860 / DRAWER_ROW_HEIGHT) + DRAWER_ROW_OVERSCAN,
+  )
   assert.ok(window.end - window.start < DRAWER_INITIAL_WINDOW_ROWS,
     'the mounted row count stays viewport-sized after an arbitrarily long scroll')
 


### PR DESCRIPTION
## Summary
- reduce navigation drawer rows from 44px to 40px without changing section-label spacing
- keep the virtualized Recents geometry in lockstep with the rendered row height
- cover the shared row-height contract with focused tests

## Testing
- `npm run test:lib`
- `npm run build`