### PR TITLE
Restore summary-owned chat naming

### DIFF
--- a/backend/scripts/chat_note.py
+++ b/backend/scripts/chat_note.py
@@ -59,10 +59,15 @@ The note is the chat's durable memory. Its exact shape:
 ---
 type: chat
 description: <the chat's concise one-line NAME in the partner's own words,
-capitalized and normally at most 10 words, e.g. "Dialing in sour espresso", not
-"chat 12". Keep the existing name through ordinary follow-up turns. Rename it
-only when the RECENT conversation has substantially moved to a different main
-topic, then name that current topic rather than the chat's opening topic.>
+normally at most 10 words. Use sentence case: capitalize the first word plus
+real proper nouns and product names, e.g. "Dialing in sour espresso" or "Adding
+search to GitHub". On the first publication, replace the raw opening-message
+fallback with this useful name. On later publications, give recent work more
+weight but keep the existing name through ordinary follow-up turns. Rename it
+only when the recent conversation has substantially moved to a different main
+topic, then name that current topic rather than the chat's opening topic. Bring
+an existing generated name into sentence case once when needed; that formatting
+correction is not topic churn.>
 ---
 ## Digest
 <ONE short paragraph: what the chat is about, what it produced, and its current
@@ -607,10 +612,7 @@ def run() -> int:
     return 0
 
   m = re.search(r"^description:\s*(.+)$", out, re.MULTILINE)
-  # StartTurn already names a fresh chat from its first message.  Keep that
-  # synchronous name on the first summary publication; later publications
-  # may sync the title from the durable note.
-  if m and existing.strip():
+  if m:
     _patch_title(chat_id, m.group(1).strip())
   return 0
 

--- a/backend/tests/test_chat_note.py
+++ b/backend/tests/test_chat_note.py
@@ -161,13 +161,24 @@ def test_build_prompt_includes_existing_note_to_grow():
   assert "old" in p
 
 
-def test_summary_name_is_stable_until_a_substantial_recent_topic_shift():
+def test_summary_name_policy_balances_first_turn_recency_and_stability():
   cn = _load_chat_note()
   prompt = " ".join(cn.SYSTEM_PROMPT.lower().split())
+  assert (
+    "on the first publication, replace the raw opening-message fallback"
+    in prompt
+  )
+  assert "use sentence case" in prompt
+  assert "title case" not in prompt
+  assert (
+    "capitalize the first word plus real proper nouns and product names"
+    in prompt
+  )
+  assert "that formatting correction is not topic churn" in prompt
+  assert "give recent work more weight" in prompt
   assert "keep the existing name through ordinary follow-up turns" in prompt
   assert "substantially moved to a different main topic" in prompt
   assert "current topic rather than the chat's opening topic" in prompt
-  assert "capitalized" in prompt
 
 
 def test_generated_chat_name_capitalizes_without_damaging_product_casing():
@@ -476,6 +487,30 @@ def _valid_note(description="ours", summary="current"):
     f"## Digest\n{summary}\n\n## Summary\n{summary}\n\n"
     "## Facts & intent\n- intent: test"
   )
+
+
+def test_first_summary_publication_replaces_the_opening_message_title(
+  tmp_path, monkeypatch,
+):
+  """The raw first-message title is only a fallback until a note is ready."""
+  cn = _load_chat_note()
+  monkeypatch.setattr(cn, "MEMORY_DIR", tmp_path / "memory")
+  monkeypatch.setattr(
+    cn, "_read_chat_snapshot", lambda _cid: ("transcript", "r1"),
+  )
+  monkeypatch.setattr(cn, "_read_note_snapshot", lambda _note: ("", "missing"))
+  monkeypatch.setattr(
+    cn, "_summarize", lambda _transcript, _existing: _valid_note("Current work"),
+  )
+  monkeypatch.setattr(cn, "_publish_if_current", lambda *args: True)
+  patched = []
+  monkeypatch.setattr(
+    cn, "_patch_title", lambda cid, name: patched.append((cid, name)),
+  )
+  monkeypatch.setattr(cn.sys, "argv", ["chat_note.py", "c1"])
+
+  assert cn.run() == 0
+  assert patched == [("c1", "Current work")]
 
 
 def test_two_backstops_publish_only_one_revision(tmp_path):


### PR DESCRIPTION
## Summary
- replace the opening-message fallback with the summary-generated name after the first settled turn
- use sentence case while preserving proper nouns and product names
- keep generated names stable through ordinary follow-ups, with updates for substantial topic changes
- preserve manual-name precedence

## Context
This follows the smaller summary-owned direction described in #274 and corrects the first-publication exception introduced by #507 without adding a second naming path. The immediate first-message preview from #389 remains the fallback while the first turn is running.

## Testing
- `scripts/wt-pytest.sh backend/tests/test_chat_note.py backend/tests/test_chats.py -q`
- `scripts/test.sh --fast`