### PR TITLE
Prevent chat cache saves from stalling first scroll

### DIFF
--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -435,10 +435,11 @@ export default function ChatView({
   )
   const setActiveGoalState = useCallback((objective) => {
     setActiveGoalObjective(objective)
-    queryClient.setQueryData(chatMessagesQueryKey(chatId), existing => {
-      if (existing?.activeGoalObjective === objective) return existing
-      return { ...(existing || {}), activeGoalObjective: objective }
-    })
+    updateChatRuntimeCache(
+      queryClient,
+      chatMessagesQueryKey(chatId),
+      { activeGoalObjective: objective },
+    )
   }, [chatId, queryClient])
 
   useEffect(() => () => {

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -868,9 +868,9 @@ export default function ChatView({
         sendingRef.current = false
       }
       if (data.running || (!preserveLocalTurn && !staleSnapshot)) {
-        setServerRunningState(!!data.running)
+        setServerRunningLocalState(!!data.running)
       }
-      setActiveGoalState(data.running
+      setActiveGoalObjective(data.running
         ? (data.active_goal_objective || latestGoalObjective(msgs))
         : '')
       setLiveQuestionId(data.pending_question_id || null)
@@ -905,7 +905,6 @@ export default function ChatView({
     commitMessages,
     pendingQueue.hydrate,
     queryClient,
-    setActiveGoalState,
   ])
 
   // Active-turn runtime reconciliation. The SSE stream is authoritative for
@@ -945,8 +944,12 @@ export default function ChatView({
         setSending(false)
         sendingRef.current = false
       }
-      setServerRunningState(!!data.running)
-      setActiveGoalState(data.running ? (data.active_goal_objective || '') : '')
+      // Apply local UI state directly, then publish the complete runtime
+      // snapshot once. The side-effecting field setters are for independent
+      // optimistic transitions; using them here made one poll emit up to three
+      // persisted-cache updates for a single server response.
+      setServerRunningLocalState(!!data.running)
+      setActiveGoalObjective(data.running ? (data.active_goal_objective || '') : '')
       setLiveQuestionId(data.pending_question_id || null)
       updateChatRuntimeCache(queryClient, chatMessagesQueryKey(chatId), {
         running: !!data.running,
@@ -964,9 +967,7 @@ export default function ChatView({
   }, [
     chatId,
     pendingQueue.hydrate,
-    pendingQueue.pendingMessagesRef,
     queryClient,
-    setActiveGoalState,
   ])
 
   const handleCompactionStored = useCallback(
@@ -1646,7 +1647,7 @@ export default function ChatView({
     const settleRuntime = (runtime, visibleMessages) => {
       const running = !!runtime.running
       setServerRunningLocalState(running)
-      setActiveGoalState(running
+      setActiveGoalObjective(running
         ? (runtime.active_goal_objective || latestGoalObjective(visibleMessages))
         : '')
       hadMessagesRef.current = visibleMessages.length > 0

--- a/frontend/src/components/ChatView/__tests__/chatDetailCache.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatDetailCache.test.js
@@ -5,7 +5,6 @@ import {
   chatCacheCanPaint,
   chatDetailCacheValue,
   chatSnapshotMatchesRuntime,
-  mergeChatDetailCacheValue,
   mergeRecentMessagesIntoLoadedWindow,
   messageKey,
   messageMatchesKey,
@@ -167,43 +166,4 @@ test('a tail refresh retains every verified older row needed by a saved address'
   assert.equal(merged.messages.length, 40)
   assert.equal(merged.messages[0].content, 'Loaded 5')
   assert.equal(merged.messages[20].content, 'Fresh 25')
-})
-
-test('background detail publication keeps the full loaded window and new version', () => {
-  const current = {
-    updated_at: 'old',
-    offset: 0,
-    messages: Array.from({ length: 30 }, (_, id) => ({ id: String(id) })),
-  }
-  const recent = {
-    updated_at: 'new',
-    offset: 20,
-    messages: Array.from({ length: 11 }, (_, index) => ({
-      id: String(index + 20),
-      content: 'fresh',
-    })),
-  }
-  const merged = mergeChatDetailCacheValue(current, recent)
-  assert.equal(merged.updated_at, 'new')
-  assert.equal(merged.offset, 0)
-  assert.equal(merged.messages.length, 31)
-  assert.equal(merged.messages[0].id, '0')
-  assert.equal(merged.messages.at(-1).id, '30')
-})
-
-test('an unverifiable background tail never destroys the restoration window', () => {
-  const current = {
-    updated_at: 'old',
-    offset: 0,
-    messages: Array.from({ length: 20 }, (_, index) => ({ id: `old-${index}` })),
-  }
-  const recent = {
-    updated_at: 'new',
-    offset: 40,
-    messages: Array.from({ length: 20 }, (_, index) => ({ id: `new-${index}` })),
-  }
-  const merged = mergeChatDetailCacheValue(current, recent)
-  assert.equal(merged.updated_at, null, 'next activation must revalidate by saved anchor')
-  assert.equal(merged.offset, 0)
-  assert.equal(merged.messages, current.messages)
 })

--- a/frontend/src/components/ChatView/__tests__/chatRuntimeCache.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatRuntimeCache.test.js
@@ -47,6 +47,22 @@ test('unchanged runtime polls do not publish a persisted-cache update', () => {
   assert.equal(cache.value().messages, transcript)
 })
 
+test('an unchanged active goal does not publish a persisted-cache update', () => {
+  const cache = cacheHarness({
+    messages: [{ role: 'assistant', content: 'large durable history' }],
+    activeGoalObjective: 'Fix first-scroll jitter',
+  })
+
+  const changed = updateChatRuntimeCache(
+    cache.queryClient,
+    ['chat-messages', 'chat-1'],
+    { activeGoalObjective: 'Fix first-scroll jitter' },
+  )
+
+  assert.equal(changed, false)
+  assert.equal(cache.updates(), 0, 'an unchanged goal must skip setQueryData')
+})
+
 test('a runtime transition patches only runtime fields', () => {
   const transcript = [{ role: 'assistant', content: 'history' }]
   const cache = cacheHarness({

--- a/frontend/src/components/ChatView/__tests__/goalProgress.test.js
+++ b/frontend/src/components/ChatView/__tests__/goalProgress.test.js
@@ -125,6 +125,19 @@ test('the goal reuses the progress rail and stays as context for build phases', 
 })
 
 test('ChatView binds goal state to explicit run boundaries, not transport liveness', () => {
+  const runtimePoll = chatView.match(
+    /const reconcileRuntimeState = useCallback[\s\S]*?const handleCompactionStored/,
+  )?.[0] || ''
+  assert.doesNotMatch(
+    runtimePoll,
+    /setServerRunningState|setActiveGoalState/,
+    'one server snapshot must not publish through independent field setters',
+  )
+  assert.equal(
+    runtimePoll.match(/updateChatRuntimeCache\(/g)?.length,
+    1,
+    'one server snapshot should publish one complete runtime cache patch',
+  )
   const runStarts = chatView.split('setBuildPhases(railAtRunStart())').slice(1)
   assert.equal(runStarts.length, 4, 'every current run-start seam should be covered')
   for (const suffix of runStarts) {

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -2181,10 +2181,11 @@ export default function Shell() {
         // in the visible set, not equality with one global id, so a chat visible
         // in a background split gets no false dot (finding D-iii).
         if (!visibleChatIdsRef.current.has(String(chatId))) {
-          // Finish means the complete answer is durable now. Refresh the hidden
-          // chat immediately rather than making the owner's later return show
-          // an old snapshot and then wait for the final response to arrive.
-          void chatQueries.messages.refresh(queryClient, chatId).catch(() => {})
+          // Do not fetch or parse the hidden transcript here. Several agents can
+          // finish while the owner is reading another chat, and those unsolicited
+          // detail responses contend with the first native scroll frame. The
+          // retained ChatView consumes this run signal when it becomes visible;
+          // an unmounted chat uses the existing versioned activation read.
           setAttentionChatIds(prev => {
             if (prev.has(chatId)) return prev
             const next = new Set(prev)

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -797,8 +797,8 @@ test('chat drawer dots distinguish active work from unseen completion', () => {
   )
   assert.match(
     shell,
-    /ev\.type === 'chat_run_finished'[\s\S]*?!visibleChatIdsRef\.current\.has\(String\(chatId\)\)[\s\S]*?chatQueries\.messages\.refresh\(queryClient, chatId\)[\s\S]*?setAttentionChatIds/,
-    'a hidden finished chat must refresh before a later return and then raise attention',
+    /ev\.type === 'chat_run_finished'[\s\S]*?!visibleChatIdsRef\.current\.has\(String\(chatId\)\)(?:(?!chatQueries\.messages\.refresh)[\s\S])*?setAttentionChatIds/,
+    'a hidden finished chat must raise attention without parsing its transcript',
   )
   assert.match(
     shell,

--- a/frontend/src/hooks/queries.js
+++ b/frontend/src/hooks/queries.js
@@ -1,10 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { api } from '../api/client.js'
 import { appTokenRefreshInterval } from '../lib/appToken.js'
-import {
-  chatDetailCacheValue,
-  mergeChatDetailCacheValue,
-} from '../lib/chatDetailCache.js'
+import { chatDetailCacheValue } from '../lib/chatDetailCache.js'
 
 function jsonOrThrow(res, label) {
   if (!res.ok) throw new Error(`${label} ${res.status}`)
@@ -393,17 +390,6 @@ export const chatQueries = {
         queryFn: ({ signal }) => fetchChatMessages(chatId, { signal }),
         staleTime: Infinity,
       }).then(() => true)
-    },
-    // A terminal run event is durable evidence that the background chat has a
-    // newer settled tail. Publish it before the owner returns, while retaining
-    // every verified older row needed by that chat's saved reading address.
-    refresh: async (queryClient, chatId) => {
-      const key = ['chat-messages', chatId]
-      const recent = await fetchChatMessages(chatId)
-      queryClient.setQueryData(key, current => (
-        mergeChatDetailCacheValue(current, recent)
-      ))
-      return queryClient.getQueryData(key)
     },
     remove: (queryClient, chatId) => queryClient.removeQueries({ queryKey: ['chat-messages', chatId] }),
   },

--- a/frontend/src/lib/__tests__/queryPersistAllowlist.test.js
+++ b/frontend/src/lib/__tests__/queryPersistAllowlist.test.js
@@ -22,6 +22,7 @@ import {
   awaitCacheFlushBeforeReload,
   compactPersistedChatDetails,
   flushPersistedQueryCache,
+  restorePersistedClient,
   shouldPersistQueryKey,
 } from '../../queryClient.js'
 
@@ -92,8 +93,9 @@ test('explicit reload handoff preserves the complete loaded chat window', async 
     client.setQueryData(['models', 'registry'], { mustNotPersist: true })
 
     await flushPersistedQueryCache(client)
-    const raw = await get('mobius-query-cache')
-    const persisted = JSON.parse(raw)
+    const persisted = await get('mobius-query-cache')
+    assert.equal(typeof persisted, 'object',
+      'IndexedDB should receive a structured value, not a main-thread JSON string')
     const keys = persisted.clientState.queries.map(q => q.queryKey)
     assert.deepEqual(keys, [['chat-messages', 'chat-1']])
     const data = persisted.clientState.queries[0].state.data
@@ -103,6 +105,17 @@ test('explicit reload handoff preserves the complete loaded chat window', async 
   } finally {
     globalThis.indexedDB = previousIndexedDb
   }
+})
+
+test('persisted cache restore accepts both structured and legacy JSON values', () => {
+  const persisted = {
+    buster: 'v1',
+    timestamp: 123,
+    clientState: { queries: [] },
+  }
+
+  assert.equal(restorePersistedClient(persisted), persisted)
+  assert.deepEqual(restorePersistedClient(JSON.stringify(persisted)), persisted)
 })
 
 test('reload handoff cannot be stranded by a blocked cache write', async () => {

--- a/frontend/src/lib/chatDetailCache.js
+++ b/frontend/src/lib/chatDetailCache.js
@@ -208,29 +208,3 @@ export function mergeRecentMessagesIntoLoadedWindow({
     verified: true,
   }
 }
-
-/** Publish a recent detail response while retaining any verified older page. */
-export function mergeChatDetailCacheValue(current, recent) {
-  if (!current) return recent
-  const merged = mergeRecentMessagesIntoLoadedWindow({
-    loadedMessages: current.messages,
-    loadedOffset: current.offset,
-    recentMessages: recent?.messages,
-    recentOffset: recent?.offset,
-  })
-  if (!merged.verified) {
-    // Do not turn an unverifiable tail refresh into silent history loss. Keep
-    // the complete restoration window, but revoke its version proof so the
-    // next activation performs an anchor-addressed authoritative read.
-    return {
-      ...current,
-      updated_at: null,
-      running: !!recent?.running,
-      activeGoalObjective: recent?.activeGoalObjective || '',
-      pending_messages: recent?.pending_messages || [],
-      pending_question_id: recent?.pending_question_id || null,
-      chatInfo: recent?.chatInfo || current.chatInfo,
-    }
-  }
-  return { ...recent, messages: merged.messages, offset: merged.offset }
-}

--- a/frontend/src/queryClient.js
+++ b/frontend/src/queryClient.js
@@ -8,9 +8,9 @@
  * consumers, no per-component loading flash on mount.
  *
  * Persistence (`createAsyncStoragePersister` + `idb-keyval`) mirrors
- * the in-memory cache to IndexedDB. After a reload, queries hydrate
- * from disk before any network round-trip — chats and messages
- * appear instantly, then revalidate in background.
+ * the in-memory cache to IndexedDB using IndexedDB's native structured clone.
+ * After a reload, queries hydrate from disk before any network round-trip —
+ * chats and messages appear instantly, then revalidate in background.
  *
  * `defaultOptions` are tuned to "cached but not stale": staleTime 30s
  * means data is considered fresh for 30s (no refetch on remount in
@@ -68,13 +68,23 @@ export function compactPersistedChatDetails(persistedClient) {
   }
 }
 
+// Earlier releases stored this value as one large JSON string. Keep restore
+// compatible with that on-disk shape while writing the structured value
+// directly from now on. Avoiding JSON.stringify on the main thread matters on
+// large chat histories: the throttled save can otherwise land between touch
+// start and the browser's first native scroll frame.
+export function restorePersistedClient(storedClient) {
+  return typeof storedClient === 'string'
+    ? JSON.parse(storedClient)
+    : storedClient
+}
+
 export const queryPersister = createAsyncStoragePersister({
   storage: idbStorage,
   key: QUERY_CACHE_KEY,
   throttleTime: 1000,
-  serialize: persistedClient => JSON.stringify(
-    compactPersistedChatDetails(persistedClient),
-  ),
+  serialize: compactPersistedChatDetails,
+  deserialize: restorePersistedClient,
 })
 
 export const persistOptions = {
@@ -125,7 +135,7 @@ export async function flushPersistedQueryCache(client = queryClient) {
       shouldDehydrateQuery: (query) => shouldPersistQueryKey(query.queryKey),
     }),
   }
-  await idbStorage.setItem(QUERY_CACHE_KEY, JSON.stringify(persistedClient))
+  await idbStorage.setItem(QUERY_CACHE_KEY, persistedClient)
 }
 
 /** Wait briefly for the reload handoff, but never let a blocked IndexedDB


### PR DESCRIPTION
## Summary
- skip persisted-cache updates when a repeated runtime status check has not changed the active goal
- store the query cache as native IndexedDB data instead of encoding and decoding one large JSON string
- leave hidden completed chats unloaded until their existing visible-activation refresh
- apply each runtime status snapshot through one cache publication and remove the now-unused background merge path

## Why
This builds on #497's native-first scroll ownership by removing measured sources of main-thread contention around the first movement. Phone telemetry showed that the touch handler itself stayed under 2 ms while first movement could still be delayed during periodic cache work. An unchanged three-second runtime check was still publishing an update, which made the persister process the complete cache; real writes then encoded that cache as one large string.

A second trigger remained when replies finished outside the visible workspace: each completion downloaded and parsed a hidden transcript before raising its attention dot. That work is unnecessary for freshness because a retained chat consumes the completion signal when it becomes visible, while an unmounted chat already performs a versioned activation read.

The change keeps the existing persistence adapter and restoration behavior, but removes redundant publications and background transcript work instead of adding a parallel cache mechanism.

## Testing
- `npm test`
- `npm run lint -- --quiet`
- `npm run build`
- focused cache/runtime/workspace tests and an authenticated phone-sized render

## Verification note
The measured triggers, cache migration, clean-tree builds, automated checks, and rendered state are verified. Tactile scroll confirmation on the reporting Android device remains pending because its current session has not yet loaded this updated bundle.

Related: #497
