### PR TITLE
Compact spacing between adjacent tool activity blocks

### DIFF
--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -777,9 +777,14 @@
 }
 
 .chat__text + .chat__tools,
-.chat__tools + .chat__text,
-.chat__tools + .chat__tools {
+.chat__tools + .chat__text {
   margin-top: var(--activity-block-gap, 8px);
+}
+
+/* Consecutive activity stretches share the compact internal row rhythm; prose
+   boundaries keep the wider block gap above. */
+.chat__tools + .chat__tools {
+  margin-top: var(--activity-row-gap, 4px);
 }
 .chat__text--assistant + .chat__text--assistant { margin-top: 0.75rem; }
 
@@ -1587,18 +1592,15 @@
   transform: rotate(-90deg);
 }
 
-/* Expanded child steps keep the same icon and label columns as their summary.
-   An earlier nested rail added 32px before every child, so a parent such as
-   "Browsing the web" and its "Searched the web" steps visibly jumped between
-   columns. The disclosure itself already supplies the hierarchy; alignment is
-   the stronger scanning cue for a chronological activity list. */
+/* A quiet rail makes the expanded parent/child hierarchy scannable. */
 .chat__activity-timeline {
   display: flex;
   flex-direction: column;
   gap: var(--activity-row-gap, 4px);
   margin-top: var(--activity-row-gap, 4px);
-  margin-inline-start: 0;
-  padding-inline-start: 0;
+  margin-inline-start: 20px;
+  padding-inline-start: 11px;
+  border-inline-start: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
 }
 
 /* Shared screen-reader status utility for transcript-local interactions such
@@ -1755,17 +1757,11 @@
   padding: var(--activity-row-gap, 4px) 0;
 }
 
-/* Top-level transcript actions keep a dependable touch target. Nested activity
-   rows deliberately stay at their compact 28px base height: the parent
-   disclosure already establishes one bounded inspection surface, so making
-   every child match top-level chat spacing turns an expanded run back into a
-   full transcript. The rows remain full-width buttons along the timeline. */
+/* Full-size touch targets belong to explicit actions. Full-width activity
+   disclosures retain their compact base height. */
 @media (pointer: coarse) {
   .chat__empty-action,
   .chat__quick-action-chip,
-  .chat__activity-header:not(.chat__activity-header--static),
-  .chat__activity-header--reserve-interactive,
-  .chat__tool--compact > .chat__tool-header:not(.chat__tool-header--static),
   .chat__tool-copy,
   .chat__lazy-retry {
     min-height: 44px;

--- a/frontend/src/components/ChatView/__tests__/activityLineStructure.test.js
+++ b/frontend/src/components/ChatView/__tests__/activityLineStructure.test.js
@@ -112,11 +112,11 @@ test('a delegating stretch keeps helper status and activity under one honest dis
     'helper rows remain honest noninteractive status')
 })
 
-test('lazy tool details keep top-level touch targets and compact nested rows', () => {
+test('lazy tool details and explicit actions keep accessible touch targets', () => {
   const toolBlock = readFileSync(new URL('../ToolBlock.jsx', import.meta.url), 'utf8')
   const coarse = [...chatCss.matchAll(/@media \(pointer: coarse\) \{[\s\S]*?\n\}/g)]
     .map(match => match[0])
-    .join('\n')
+    .find(rule => rule.includes('.chat__empty-action')) || ''
 
   assert.match(toolBlock, /aria-controls=\{detailId\}/)
   assert.match(toolBlock, /id=\{detailId\}[\s\S]*hidden=\{!open\}/,
@@ -129,30 +129,22 @@ test('lazy tool details keep top-level touch targets and compact nested rows', (
   assert.match(coarse, /\.chat__empty-action/)
   assert.match(coarse, /\.chat__quick-action-chip/)
   assert.match(coarse, /\.chat__lazy-retry/)
-  assert.match(coarse, /\.chat__tool--compact > \.chat__tool-header/)
   assert.match(coarse, /min-height:\s*44px/)
-  assert.doesNotMatch(coarse, /(?<!compact > )\.chat__tool-header:not/,
-    'nested tool rows should not inherit top-level transcript spacing')
-  assert.doesNotMatch(coarse, /\.chat__activity-think-toggle/,
-    'nested thought rows should keep the compact timeline rhythm')
 })
 
-test('activity spacing and aligned columns derive from one shared rhythm', () => {
+test('activity spacing and nested hierarchy derive from one shared rhythm', () => {
   const message = cssRule('.chat__msg--assistant')
   const tools = cssRule('.chat__tools')
+  const adjacentTools = cssRule('.chat__tools + .chat__tools')
   const timeline = cssRule('.chat__activity-timeline')
 
   assert.match(message, /--activity-block-gap:\s*8px/)
   assert.match(message, /--activity-row-gap:\s*4px/)
   assert.match(tools, /gap:\s*var\(--activity-row-gap, 4px\)/)
+  assert.match(adjacentTools, /margin-top:\s*var\(--activity-row-gap, 4px\)/,
+    'separate activity stretches should keep the same compact beat as grouped rows')
   assert.match(timeline, /gap:\s*var\(--activity-row-gap, 4px\)/)
   assert.match(timeline, /margin-top:\s*var\(--activity-row-gap, 4px\)/)
-  assert.match(timeline, /margin-inline-start:\s*0/,
-    'child labels must stay in the same column as their summary label')
-  assert.match(timeline, /padding-inline-start:\s*0/,
-    'the timeline must not add a second indentation before child icons')
-  assert.doesNotMatch(timeline, /border-inline-start/,
-    'a nested rail must not occupy the shared activity label column')
-  assert.doesNotMatch(chatCss, /\.chat__tools \+ \.chat__tools\s*\{\s*margin-top:\s*2px/,
-    'adjacent activity blocks should not retain a one-off gap')
+  assert.match(timeline, /border-inline-start:\s*1px/,
+    'a neutral one-pixel rail carries the child hierarchy')
 })

--- a/tests/activity-lazy.spec.mjs
+++ b/tests/activity-lazy.spec.mjs
@@ -529,9 +529,8 @@ test('activity stays nested and lazy, aborts on close, and copies exact tool out
     await expect(activity.locator(`[id="${controlledId}"]`)).toBeHidden()
   }
 
-  // Leading type icons communicate hierarchy while expanded rows keep the
-  // same icon column as their summary; no rail or trailing disclosure chevron
-  // should push the child labels sideways.
+  // The rail and leading type icons communicate hierarchy; activity rows carry
+  // no trailing disclosure chevrons.
   await expect(activity.locator('.chat__chevron')).toHaveCount(0)
   expect(await activity.locator('svg').count()).toBeGreaterThanOrEqual(3)
   const [activityBox, timelineBox, toolBox] = await Promise.all([
@@ -540,15 +539,14 @@ test('activity stays nested and lazy, aborts on close, and copies exact tool out
     toolToggle.boundingBox(),
   ])
   expect(activityBox).not.toBeNull()
-  expect(Math.abs(timelineBox.x - activityBox.x)).toBeLessThanOrEqual(1)
-  expect(Math.abs(toolBox.x - timelineBox.x)).toBeLessThanOrEqual(1)
-  const activityHeaderBox = await activityHeader.boundingBox()
+  expect(timelineBox.x).toBeGreaterThan(activityBox.x + 12)
+  expect(toolBox.x).toBeGreaterThan(timelineBox.x + 8)
   const thoughtToggleBox = await thoughtToggle.boundingBox()
   const toolToggleBox = await toolToggle.boundingBox()
-  expect(activityHeaderBox.height).toBeGreaterThanOrEqual(43)
+  expect(activityBox.height).toBe(32)
   for (const box of [thoughtToggleBox, toolToggleBox]) {
     expect(box.height).toBeGreaterThanOrEqual(27)
-    expect(box.height).toBeLessThan(43)
+    expect(box.height).toBeLessThan(33)
   }
 
   await thoughtToggle.click()


### PR DESCRIPTION
## Summary
- use the compact activity-row rhythm between adjacent tool activity blocks, including standalone image views
- keep quiet activity disclosures compact on touch screens instead of inflating every separate row to 44px
- keep the existing indented rail for expanded grouped activity

This takes a different direction from #521: it preserves the parent/child hierarchy and fixes both the oversized boundary between separate activity stretches and the touch-only row inflation that made those gaps persist on phones.

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- rendered phone-width verification with coarse-pointer emulation
