### PR TITLE
Fix mobile keyboard chat scrolling

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -553,7 +553,7 @@ automatically armed by installing Möbius.
 
 ## Chat scroll + steer contract
 
-**Owner-authoritative contract — v1.14 (2026-08-02).** This section is the
+**Owner-authoritative contract — v1.16 (2026-08-02).** This section is the
 canonical source of truth for how a chat scrolls and steers. When implementation,
 comments, and this contract disagree, the implementation/comments are the bug:
 fix behavior to match this contract. If a real case is unspecified or the desired
@@ -567,18 +567,17 @@ and attaches their rule ids to new diagnostic chats. The Playwright lock-in spec
 `backend/tests/test_chats_stream_steer`) encode this:
 
 - **R0 — Two modes; two explicit auto-scroll entrances.** A chat is either in **auto-scroll**
-  (`FOLLOW_BOTTOM`, following the real-content tail as the reply streams) or **hold**
+  (`FOLLOW_BOTTOM`, following the physical scroll tail as the reply streams) or **hold**
   (`PIN_USER_MSG` or `ANCHOR_AT`, staying at a pinned prompt or frozen reading
   position). Auto-scroll engages only through (a) the gesture-gated scroll handler
-  after the user manually reaches an ordinary bottom with no reservation remaining,
+  after the user manually reaches or explicitly swipes toward the physical bottom,
   or (b) the live-send pin handoff when the streaming reply has consumed its exact
-  reserved room. Only a send may create `PIN_USER_MSG`. The physical bottom while
-  reservation remains is an exact reader-owned `ANCHOR_AT` position—including a
-  negative row offset when the viewport is inside reserved reply room—not a pin or
-  the real-content tail. Reaching it must preserve that exact physical position and
-  must never manufacture the pin's spacer-exhaustion handoff. A viewport /
-  keyboard change, foreground return, mount, or chat restoration must never create
-  auto-scroll.
+  reserved room. Only a send may create `PIN_USER_MSG`. Reservation does not create
+  a second kind of bottom: when `FOLLOW_BOTTOM` is active, it follows the physical
+  tail including any remaining room. Real output first consumes that room without
+  advancing the tail; after the room reaches zero, the same tail advances with the
+  stream. A viewport/keyboard change, foreground return, mount, or chat restoration
+  must never create auto-scroll.
 - **R1 — Stable latest-turn reservation.** Dynamic bottom spacer derives from the
   latest user row and the real tail geometry, independent of whether that row has
   already entered the viewport. It reserves exactly enough room for that row to
@@ -615,14 +614,12 @@ and attaches their rule ids to new diagnostic chats. The Playwright lock-in spec
   is retired only after committed geometry is stable across consecutive layout
   frames, and the prompt stays pinned; a one-frame terminal check cannot disarm
   just before final buffered text fills the reservation. Later idle layout changes
-  cannot create follow. A non-pinning send preserves the exact reading anchor. `PIN_USER_MSG`
-  survives the complete
-  mobile-keyboard open/close cycle even though the full-height reservation makes its
-  scroll position temporarily look away from the physical bottom; viewport geometry
-  is not reader intent, so apart from the explicit filled-reservation handoff, only a
-  gesture-gated reader scroll may retire the pin. A retired or saved pin restores
-  only as an ordinary `ANCHOR_AT`; pin ownership is never reconstructed by layout,
-  lifecycle restoration, or a reader gesture.
+  cannot create follow. A non-pinning send preserves the exact reading anchor.
+  An armed or settled `PIN_USER_MSG` survives the complete mobile-keyboard
+  open/close cycle: viewport geometry cannot decide that a reply filled its
+  reservation or replace the pin with a different bottom alignment. A retired or
+  saved pin restores only as an ordinary `ANCHOR_AT`; pin ownership is never
+  reconstructed by layout, lifecycle restoration, or a reader gesture.
   Terminal promotion makes this decision against the committed settled DOM,
   before paint, so a final browser clamp cannot race the pin or its exact
   filled-reservation handoff.
@@ -670,10 +667,14 @@ and attaches their rule ids to new diagnostic chats. The Playwright lock-in spec
   input gets that early release only when its direction is exactly clamped at the
   matching scroll edge. An elapsed frame is not evidence that an in-range wheel was a
   no-op: renderer/compositor load can update geometry before the main-thread `scroll`
-  handler runs. After a real scroll lands, reader ownership remains active through a
-  short trailing-edge quiet window. The hot scroll handler records intent and current
-  tail proximity only; final anchor discovery, spacer sizing, mode transition, and
-  persistence run once when momentum settles. Exact physical-tail intent belongs to
+  handler runs. A meaningful touch swipe toward the end may enter `FOLLOW_BOTTOM`
+  once even when the browser is already clamped at the physical tail and therefore
+  emits no scroll event; coordinate comparison is the per-move hot path and physical
+  geometry is read at most once for that gesture. After a real scroll lands,
+  reader ownership remains active through a short trailing-edge quiet window. The
+  hot scroll handler records intent and physical-tail arrival only; final anchor
+  discovery, spacer sizing, mode transition, and persistence run once when momentum
+  settles. Exact physical-tail intent belongs to
   the scroll event's geometry: reply growth during the quiet window cannot erase that
   the reader reached bottom. Deferred layout work may resume only after that final
   semantic location is committed, so a stale follow/pin cannot write in the handoff
@@ -710,6 +711,19 @@ and attaches their rule ids to new diagnostic chats. The Playwright lock-in spec
   through the scroll controller instead of calling `scrollIntoView`, because
   viewport intersection alone cannot detect that the absolutely-positioned
   composer is covering the target.
+- **R5b — One keyboard geometry signal; mode-preserving resize.** Shell alone
+  reconciles a browser's visual viewport into the visible shell frame. The chat
+  does not race Shell with a second direct visual-viewport listener: its own
+  scroll-box `ResizeObserver` is the sole downstream signal that keyboard layout
+  has actually landed. A resize never derives a new scroll mode from intermediate
+  geometry: it reapplies the mode that already owns the chat. `PIN_USER_MSG` keeps
+  the sent row at its pinned offset, `ANCHOR_AT` keeps the same row offset, and
+  `FOLLOW_BOTTOM` follows the resized physical tail. The R6 question-submission
+  release and focused native-caret rebase remain the two explicit editing rules,
+  not a general keyboard heuristic. Open/close cycles therefore repeat the same
+  idempotent operation every time. Browser clamps and controller writes may emit
+  `scroll` while the box is changing, but only a gesture-owned scroll may change
+  the reader's semantic mode.
 - **R6 — One lossless active assistant row.** Live stream items, a persisted partial,
   and the settled transcript are alternate sources for one active assistant row, not
   separate answers. The answer response declares this ownership independently as
@@ -755,16 +769,16 @@ path means routing it through the same entries rather than inventing another rul
 | First direct/queued/steered user row becomes visible | any | `PIN_USER_MSG` | New row to top |
 | Later send submitted at real-content tail (mode may be one frame stale) | any | `PIN_USER_MSG` | New row to top |
 | Later send submitted anywhere else | hold or stale follow | `ANCHOR_AT`/existing hold | None |
-| Reader reaches physical bottom while latest-user reservation remains | any | exact `ANCHOR_AT` | User-owned; preserve the numeric physical position, including negative anchor offset |
-| Reader reaches bottom with no reservation remaining | any | `FOLLOW_BOTTOM` | User-owned |
+| Reader reaches or explicitly swipes toward physical bottom | any | `FOLLOW_BOTTOM` | User-owned; follow the one physical tail, including remaining reservation |
 | Reader scrolls manually away from bottom | any | `ANCHOR_AT` | User-owned |
 | Reply grows while an armed live pin still has reserved room | pin hold | same pin hold | Keep prompt fixed |
-| Streaming reply consumes the armed pin reservation | pin hold | `FOLLOW_BOTTOM` | Follow real-content tail |
+| Streaming reply consumes the armed pin reservation | pin hold | `FOLLOW_BOTTOM` | Follow physical tail |
 | Short reply settles before consuming the reservation | armed pin hold | settled pin hold | Keep prompt fixed; retire automatic handoff |
 | Other layout grows/collapses while latest user is visible | any hold | same hold | Consume/restore exact R1 deficit |
 | Latest user leaves the viewport | any | same reader mode | Collapse spacer to zero |
-| Viewport/keyboard changes | `PIN_USER_MSG` | same `PIN_USER_MSG` | Reapply pin after resize; never infer intent from keyboard-open geometry |
-| Viewport/keyboard changes | follow or anchor hold | same follow if still at tail, otherwise hold anchor | Never creates follow |
+| Viewport/keyboard changes | armed `PIN_USER_MSG` | same `PIN_USER_MSG` | Reapply pin after resize; never infer reservation fill from keyboard geometry |
+| Viewport/keyboard changes | settled `PIN_USER_MSG` | same `PIN_USER_MSG` | Reapply the same pin; geometry never reclassifies it |
+| Viewport/keyboard changes | follow or anchor hold | same mode | Reapply follow to the physical tail or the exact anchor; never create or retire follow |
 | Chat exits/backgrounds/returns | any | `ANCHOR_AT` | Restore exact saved anchor |
 | In-process question is answered | any | transient `ANCHOR_AT` over the prior mode; same active assistant row | Hold exact visible anchor through same-viewport card reflow and resumed output |
 | Viewport/keyboard changes after question submission | transient question anchor | pre-submit unanswered-card mode | Apply ordinary viewport behavior; answering adds no extra movement |
@@ -783,7 +797,7 @@ Controller structure is part of the contract, not an implementation detail:
   Hidden retained owners may keep DOM geometry but are never persistence
   writers; do not reintroduce a second freeze call in `ChatView`.
 - Every live mode mutation goes through `transitionMode`, whose entry guard permits
-  new pins only from send and new follow only from an unreserved-bottom gesture or
+  new pins only from send and new follow only from a physical-bottom gesture or
   an already-armed pin's filled-reservation handoff. Every mode-owned `scrollTop`
   write goes through `writeMode`. The exported `applyMode` executor is for the
   controller and pure unit tests, not a second live writer.
@@ -797,6 +811,10 @@ Controller structure is part of the contract, not an implementation detail:
   Do not reintroduce a sentinel or asynchronous observer as a second bottom
   authority: its delayed state can contradict the viewport that caused the
   event.
+- Shell owns the browser visual-viewport subscription. The chat observes only
+  its resulting scroll-box size; do not add a second direct visual-viewport
+  listener to the scroll controller or keyboard ordering becomes registration-
+  dependent again.
 - `window.__mobiusChatScrollTrace` keeps bounded, content-free transition and
   actual-write history for diagnosis. It records mode kinds, armed state, and
   geometry only—never message text, keys, or cids.

--- a/frontend/src/components/ChatView/__tests__/chatContract.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatContract.test.js
@@ -72,7 +72,7 @@ test('owner contract freezes question answers without locking keyboard movement'
     new URL('../../../../../ARCHITECTURE.md', import.meta.url),
     'utf8',
   )
-  assert.match(architecture, /Owner-authoritative contract — v1\.14 \(2026-08-02\)/)
+  assert.match(architecture, /Owner-authoritative contract — v1\.16 \(2026-08-02\)/)
   assert.match(
     architecture,
     /In-process question is answered \| any \| transient `ANCHOR_AT` over the prior mode; same active assistant row/,
@@ -92,6 +92,11 @@ test('owner contract freezes question answers without locking keyboard movement'
     architecture,
     /Focused Q&A custom answer grows or its keyboard viewport changes \| ordinary hold \| current caret-visible `ANCHOR_AT`/,
     'editing may adopt native caret movement without weakening stronger scroll modes',
+  )
+  assert.match(
+    architecture,
+    /One keyboard geometry signal; mode-preserving resize/,
+    'keyboard layout must flow from Shell into the actual chat scroll box once',
   )
 })
 

--- a/frontend/src/components/ChatView/__tests__/scrollOwnership.test.js
+++ b/frontend/src/components/ChatView/__tests__/scrollOwnership.test.js
@@ -104,7 +104,9 @@ test('gesture scroll frames defer anchor, spacer, and persistence work until set
     'reader settlement path must remain discoverable')
   assert.match(settlePath, /anchorModeFromScroll/)
   assert.match(settlePath, /modeAfterReaderGesture/)
-  assert.match(settlePath, /hasReservedTail:\s*spacerH\s*>\s*1/)
+  assert.match(settlePath, /reachedBottom:\s*settledAtBottom/)
+  assert.doesNotMatch(settlePath, /spacerH|hasReservedTail/,
+    'physical-bottom intent must not branch on invisible reservation')
   assert.match(settlePath, /persistMode\(\)/)
   assert.match(settlePath, /sizeSpacer\(currentAuthority\(\)\)/)
   assert.doesNotMatch(settlePath, /PIN_USER_MSG|contentHoldModeFromScroll/,

--- a/frontend/src/components/ChatView/__tests__/scrollRepairDirection.test.js
+++ b/frontend/src/components/ChatView/__tests__/scrollRepairDirection.test.js
@@ -53,7 +53,7 @@ test('pin repair never moves backward over an unchanged reader position', () => 
   )
 })
 
-test('reserved-bottom reader settlement replays the exact numeric position', () => {
+test('reserved-bottom reader settlement enters follow without moving backward', () => {
   const row = {
     offsetTop: 500,
     offsetHeight: 220,
@@ -81,32 +81,24 @@ test('reserved-bottom reader settlement replays the exact numeric position', () 
     offset: -700,
   })
   const settledMode = modeAfterReaderGesture({
-    reachedPhysicalBottom: true,
-    hasReservedTail: true,
+    reachedBottom: true,
     holdMode,
   })
-  assert.equal(settledMode, holdMode)
+  assert.deepEqual(settledMode, { kind: 'FOLLOW_BOTTOM' })
 
   applyMode(scrollEl, settledMode)
   assert.equal(scrollEl.scrollTop, 1200,
-    'settlement must not jump backward to the prompt or real-content tail')
+    'following the physical tail must not jump backward before reservation')
 })
 
-test('only an unreserved reader bottom creates follow', () => {
+test('physical reader bottom creates follow without a reservation branch', () => {
   const hold = { kind: 'ANCHOR_AT', key: 'a-1', offset: -300 }
-  assert.equal(modeAfterReaderGesture({
-    reachedPhysicalBottom: true,
-    hasReservedTail: true,
-    holdMode: hold,
-  }), hold)
   assert.deepEqual(modeAfterReaderGesture({
-    reachedPhysicalBottom: true,
-    hasReservedTail: false,
+    reachedBottom: true,
     holdMode: hold,
   }), { kind: 'FOLLOW_BOTTOM' })
   assert.equal(modeAfterReaderGesture({
-    reachedPhysicalBottom: false,
-    hasReservedTail: false,
+    reachedBottom: false,
     holdMode: hold,
   }), hold)
 })
@@ -169,7 +161,7 @@ test('only real-bottom or an armed pin handoff can enter follow', () => {
     follow,
   )
   assert.equal(
-    modeForScrollTransition(hold, follow, 'reader:real-content-bottom'),
+    modeForScrollTransition(hold, follow, 'reader:scroll-bottom'),
     follow,
   )
 })

--- a/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
+++ b/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
@@ -16,7 +16,6 @@ import {
   contentHoldModeFromScroll,
   gestureLayoutRetryDelay,
   isNearContentBottom,
-  isNearScrollBottom,
   layoutMayOwnScroll,
   modeForChatExit,
   modeForDisclosureToggle,
@@ -24,7 +23,6 @@ import {
   modeForQuestionSubmission,
   modeForQuestionEditingViewportChange,
   modeForQueuedSubmission,
-  modeForViewportChange,
   modeAfterReaderGesture,
   modeAfterSpacerResize,
   modeAfterTerminalLayout,
@@ -290,7 +288,7 @@ test('only provably clamped wheel and keyboard input gets a next-frame release',
   assert.equal(readerInputNeedsFrameRelease('touchmove'), false)
 })
 
-test('touch input never reads scroll geometry, so it cannot force a layout', () => {
+test('the no-scroll release classifier never reads touch geometry', () => {
   // The geometry thunk performs layout-forcing DOM reads (scrollHeight on an
   // unvirtualized transcript). Only the wheel branch consumes them, so any
   // input type that short-circuits before that branch must never invoke it.
@@ -334,6 +332,15 @@ test('reader-input tracing never measures the transcript at gesture start', () =
     scrollModeSource,
     /reader:scroll-start', \{ captureGeometry: false \}/,
     'the first compositor scroll frame must not force transcript layout',
+  )
+  const onScroll = scrollModeSource.slice(
+    scrollModeSource.indexOf('const onScroll = () =>'),
+    scrollModeSource.indexOf("scrollEl.addEventListener('scroll', onScroll"),
+  )
+  assert.ok(
+    onScroll.indexOf('if (!userDriven)')
+      < onScroll.indexOf('const distanceToBottom'),
+    'browser clamps must return before measuring reader-owned tail intent',
   )
 })
 
@@ -466,21 +473,10 @@ test('isNearContentBottom uses the same phantom-spacer bottom contract', () => {
     spacerHeight: 400,
   })
   assert.equal(isNearContentBottom(scrollEl), true)
-  assert.equal(isNearScrollBottom(scrollEl), false,
-    'middle of reserved spacer is not true scroll bottom')
-})
-
-test('physical-bottom geometry uses only a rounding epsilon', () => {
-  assert.equal(isNearScrollBottom(makeScrollEl({
-    scrollHeight: 2000,
-    scrollTop: 1497,
-    clientHeight: 500,
-  }), 4), true)
-  assert.equal(isNearScrollBottom(makeScrollEl({
-    scrollHeight: 2000,
-    scrollTop: 1495,
-    clientHeight: 500,
-  }), 4), false)
+  assert.ok(
+    scrollEl.scrollHeight - scrollEl.scrollTop - scrollEl.clientHeight > 50,
+    'the meaningful content tail does not require traversing reserved room',
+  )
 })
 
 test('pin reapply is needed when the first pin was clamped but spacer now makes the target reachable', () => {
@@ -641,11 +637,21 @@ test('anchor reapply is inert for non-anchor modes and unresolved keys', () => {
   )
 })
 
-test('viewport resize never turns a pin into auto-scroll without a gesture', () => {
-  const stalePin = { kind: 'PIN_USER_MSG', cid: 'c-123' }
-  assert.equal(
-    modeForViewportChange(stalePin, true),
-    stalePin,
+test('viewport resize reapplies the current mode without reclassifying it', () => {
+  assert.match(
+    scrollModeSource,
+    /const ordinaryViewportMode = modeRef\.current/,
+    'keyboard geometry keeps the existing pin, follow, or exact anchor',
+  )
+  assert.doesNotMatch(
+    scrollModeSource,
+    /modeForViewportChange/,
+    'viewport layout has no second semantic mode-derivation path',
+  )
+  assert.doesNotMatch(
+    scrollModeSource,
+    /visualViewport\.addEventListener/,
+    'chat observes its actual resized box instead of racing Shell for the browser event',
   )
 })
 
@@ -699,25 +705,28 @@ test('an armed live pin holds until its exact spacer is filled, then follows', (
   assert.deepEqual(modeAfterSpacerResize(livePin, 0), { kind: 'FOLLOW_BOTTOM' })
 })
 
-test('reader settlement preserves reserved room and follows only real content', () => {
+test('reader settlement follows the physical tail even while reservation remains', () => {
   const exactHold = {
     kind: 'ANCHOR_AT', key: 'user-c-123', offset: -320,
   }
-  assert.equal(modeAfterReaderGesture({
-    reachedPhysicalBottom: true,
-    hasReservedTail: true,
-    holdMode: exactHold,
-  }), exactHold, 'reserved room remains the reader\'s exact anchor')
   assert.deepEqual(modeAfterReaderGesture({
-    reachedPhysicalBottom: true,
-    hasReservedTail: false,
+    reachedBottom: true,
     holdMode: exactHold,
   }), { kind: 'FOLLOW_BOTTOM' })
   assert.equal(modeAfterReaderGesture({
-    reachedPhysicalBottom: false,
-    hasReservedTail: false,
+    reachedBottom: false,
     holdMode: exactHold,
   }), exactHold)
+
+  const scrollEl = makeScrollEl({
+    scrollHeight: 2000,
+    scrollTop: 1000,
+    clientHeight: 560,
+    spacerHeight: 400,
+  })
+  applyMode(scrollEl, { kind: 'FOLLOW_BOTTOM' })
+  assert.equal(scrollEl.scrollTop, 1440,
+    'follow owns the one physical tail instead of jumping back before reservation')
 })
 
 test('a short settled pin retires automatic follow but keeps its identity', () => {
@@ -748,27 +757,6 @@ test('terminal pin follows immediately when final committed geometry fills the s
   assert.deepEqual(
     modeAfterTerminalLayout(livePin, 0, false),
     { kind: 'FOLLOW_BOTTOM' },
-  )
-})
-
-test('keyboard close preserves pin identity even when keyboard-open geometry is away from the physical bottom', () => {
-  const pin = { kind: 'PIN_USER_MSG', cid: 'c-123' }
-  const temporaryAnchor = { kind: 'ANCHOR_AT', key: 'user-1', offset: 4 }
-
-  assert.equal(
-    modeForViewportChange(pin, false, temporaryAnchor),
-    pin,
-    'only a real reader scroll may retire PIN_USER_MSG',
-  )
-})
-
-test('viewport resize in reserved spacer anchors instead of snapping to bottom', () => {
-  const staleFollow = { kind: 'FOLLOW_BOTTOM' }
-  const anchor = { kind: 'ANCHOR_AT', key: 'user-1', offset: -240 }
-
-  assert.equal(
-    modeForViewportChange(staleFollow, false, anchor),
-    anchor,
   )
 })
 
@@ -1815,7 +1803,10 @@ test('F4: foreground return freezes as an anchor even at the tail', () => {
     scrollHeight: 1400, scrollTop: 685, clientHeight: 700,   // near the tail
     querySelectorAll(sel) { return sel === '.chat__msg[data-key]' ? [tailItem] : [] },
   }
-  assert.equal(isNearScrollBottom(scrollEl), true, 'precondition: at the tail')
+  assert.ok(
+    scrollEl.scrollHeight - scrollEl.scrollTop - scrollEl.clientHeight < 50,
+    'precondition: at the tail',
+  )
 
   const restored = modeForForegroundReturn(scrollEl)
   assert.equal(restored.kind, 'ANCHOR_AT',

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -47,8 +47,8 @@
  * reader ownership until the first scroll event actually arrives. Real scrolls
  * keep that ownership until the browser's native `scrollend` event (with a
  * 250ms quiet-settle fallback for older engines): the hot event path records
- * intent and current tail proximity only, then derives/persists the final anchor
- * and resizes reservation once after momentum stops. Wheel input
+ * intent and exact physical-tail arrival only, then derives/persists the final
+ * anchor and resizes reservation once after momentum stops. Wheel input
  * is released early only when its direction is exactly clamped at the matching
  * edge; elapsed frames cannot prove that an in-range gesture was a no-op under
  * renderer load. Outside that handoff/settle window, scrolls come from our
@@ -500,15 +500,13 @@ export function applyMode(scrollEl, mode) {
       return
     }
     case 'FOLLOW_BOTTOM':
-      // Mode never owns reservation. Follow the bottom of real content while
-      // excluding any latest-user room; visibility sizing remains independent.
-      {
-        const spacerH = scrollEl.querySelector('.spacer-dynamic')?.offsetHeight || 0
-        const realContentH = scrollEl.scrollHeight - spacerH
-        if (realContentH > scrollEl.clientHeight + 4) {
-          scrollEl.scrollTop = Math.max(0, realContentH - scrollEl.clientHeight)
-        }
-      }
+      // Follow the one physical tail. While reply reservation remains, real
+      // output consumes it without changing this target; once it is exhausted,
+      // the same target advances with the stream.
+      scrollEl.scrollTop = Math.max(
+        0,
+        scrollEl.scrollHeight - scrollEl.clientHeight,
+      )
       return
     case 'ANCHOR_AT': {
       const el = _anchorEl(scrollEl, mode)
@@ -774,48 +772,14 @@ export function shouldPinSend({
 }
 
 
-/** Position-based bottom check that treats the dynamic pin spacer as
- *  phantom room, not real content. Useful for reasoning about whether real
- *  message content is at the tail, but NOT for deciding whether to move the
- *  viewport: the reserved spacer is intentionally scrollable. */
+/** Position-based bottom check that treats the dynamic pin spacer as phantom
+ *  room, not real content. Send snapshots use the conversation tail because a
+ *  new send should not require traversing reserved reply room first. */
 export function isNearContentBottom(scrollEl, threshold = NEAR_BOTTOM_PX) {
   if (!scrollEl) return false
   const spacerH = scrollEl.querySelector('.spacer-dynamic')?.offsetHeight || 0
   const gap = scrollEl.scrollHeight - spacerH - scrollEl.scrollTop - scrollEl.clientHeight
   return gap < threshold
-}
-
-
-/** True scroll-bottom check: includes the dynamic spacer because the spacer is
- *  user-scrollable reserved room. Keyboard preservation and send pinning use
- *  this so "middle of the reserved space" remains a stable reading position
- *  instead of being treated as the bottom. */
-export function isNearScrollBottom(scrollEl, threshold = NEAR_BOTTOM_PX) {
-  if (!scrollEl) return false
-  const gap = scrollEl.scrollHeight - scrollEl.scrollTop - scrollEl.clientHeight
-  return gap < threshold
-}
-
-
-/** visualViewport resize/scroll is a browser viewport clamp, not a user
- *  reading gesture, so it must never CREATE FOLLOW_BOTTOM or retire a valid
- *  PIN_USER_MSG. Existing follow intent may survive while it remains at the
- *  tail; an ordinary hold freezes to the current anchor when possible.
- *
- *  PIN_USER_MSG must keep its identity through the whole keyboard cycle. The
- *  open keyboard deliberately leaves the permanent full-height reservation in
- *  place, so the pinned scrollTop is no longer at the physical bottom while
- *  the viewport is short. If keyboard-close used that temporary geometry to
- *  demote PIN_USER_MSG to ANCHOR_AT, a short reply's terminal live-to-settled
- *  height change could clamp scrollTop with no pin left to restore it. Only the
- *  gesture-gated scroll handler may retire a pin: a real reader scroll stamps
- *  FOLLOW_BOTTOM or ANCHOR_AT before any viewport event sees the mode. */
-export function modeForViewportChange(mode, wasNearScrollBottom, anchorMode = null) {
-  if (mode?.kind === 'PIN_USER_MSG') return mode
-  if (mode?.kind === 'FOLLOW_BOTTOM') {
-    return wasNearScrollBottom ? mode : (anchorMode || mode)
-  }
-  return mode
 }
 
 
@@ -866,26 +830,19 @@ export function modeAfterTerminalLayout(mode, spacerH, layoutStable) {
 }
 
 
-/** Resolve the quiet edge of a real reader gesture.
- *
- * FOLLOW_BOTTOM targets real content and excludes the dynamic reservation.
- * A physical position inside that reservation must therefore remain an exact
- * anchor; converting it to either FOLLOW_BOTTOM or PIN_USER_MSG moves backward.
- */
+/** Resolve the quiet edge of a real reader gesture. The physical tail is the
+ * single explicit entrance to following, whether or not reservation remains. */
 export function modeAfterReaderGesture({
-  reachedPhysicalBottom,
-  hasReservedTail,
+  reachedBottom,
   holdMode,
 }) {
-  if (reachedPhysicalBottom && !hasReservedTail) {
-    return { kind: 'FOLLOW_BOTTOM' }
-  }
+  if (reachedBottom) return { kind: 'FOLLOW_BOTTOM' }
   return holdMode || { kind: 'INITIAL' }
 }
 
 
 const FOLLOW_ENTRY_EVENTS = new Set([
-  'reader:real-content-bottom',
+  'reader:scroll-bottom',
   'layout:reservation-filled',
   'terminal:reservation-filled',
 ])
@@ -893,7 +850,7 @@ const FOLLOW_ENTRY_EVENTS = new Set([
 /** Enforce the state machine's narrow entry authority.
  *
  * Only a send can create a pin. FOLLOW_BOTTOM can be entered only by the two
- * explicit product transitions: a real unreserved-bottom gesture, or an
+ * explicit product transitions: a real bottom gesture, or an
  * already-armed pin consuming its reservation. Other events may preserve the
  * current mode, demote it to an anchor/initial hold, or retire an armed pin,
  * but cannot manufacture automatic scroll ownership.
@@ -920,7 +877,7 @@ export function modeForScrollTransition(previousMode, proposedMode, event) {
   if (proposedMode.kind === 'FOLLOW_BOTTOM'
       && previousMode?.kind !== 'FOLLOW_BOTTOM') {
     if (!FOLLOW_ENTRY_EVENTS.has(event)) return previousMode
-    if (event !== 'reader:real-content-bottom'
+    if (event !== 'reader:scroll-bottom'
         && !(previousMode?.kind === 'PIN_USER_MSG'
           && previousMode.followWhenFilled)) {
       return previousMode
@@ -1279,6 +1236,11 @@ export default function useScrollMode({
   // because the gesture timing window later closes.
   const readerIntentVersionRef = useRef(0)
   const fullViewHRef = useRef(0)
+  // The chat reacts to the size of its actual scroll viewport, after Shell has
+  // reconciled any visual-viewport overlay. Keeping the last observed height
+  // across effect re-runs makes ResizeObserver the one keyboard/layout signal
+  // and removes the old race between two direct visualViewport listeners.
+  const observedScrollViewportRef = useRef({ element: null, height: 0 })
   // Lives outside the layout effect so it survives StrictMode's
   // double-invoke in dev (and any future effect re-run). If this were
   // a local `let` inside the effect, the second invoke would reset it
@@ -1308,11 +1270,6 @@ export default function useScrollMode({
   // The observer in ChatView notifies this runner rather than writing the CSS
   // variable itself, so both mutations share the reader-gesture gate.
   const composerResizeRunRef = useRef(null)
-  // Tracks physical tail position independently from modeRef. A stale
-  // PIN_USER_MSG can survive after the reader manually returns to the bottom;
-  // when the keyboard opens, visualViewport fires AFTER the viewport has
-  // already changed, so we need the last known pre-change tail snapshot.
-  const nearScrollBottomRef = useRef(false)
   // A custom Q&A field can grow while the phone browser is also moving its
   // visual viewport to keep the caret above the keyboard. Keep that native
   // editing lifecycle visible across focusout until the keyboard has returned
@@ -1671,7 +1628,6 @@ export default function useScrollMode({
       authorityVersion,
     )
     lastAppliedModeRef.current = nextMode
-    nearScrollBottomRef.current = isNearScrollBottom(scrollEl)
     persistMode()
   }, [persistMode, scrollRef, transitionMode, writeMode])
 
@@ -1712,8 +1668,8 @@ export default function useScrollMode({
   }, [ownsReadingPosition, persistMode])
 
   // Single layout effect: spacer sizing, automatic scroll writes,
-  // ResizeObserver layout updates, user-gesture detection, geometry-based
-  // scroll transitions, and mobile keyboard tracking via visualViewport.
+  // ResizeObserver layout updates (including the mobile keyboard after Shell
+  // has resized), user-gesture detection, and geometry-based transitions.
   // Re-runs on messages / pendingMessages / chatId changes.
   useLayoutEffect(() => {
     // Empty chats intentionally render no scroll node. Initialize the chat
@@ -1734,6 +1690,13 @@ export default function useScrollMode({
     const scrollEl = scrollRef.current
     const spacerEl = spacerRef.current
     if (!scrollEl || !spacerEl) return
+
+    if (observedScrollViewportRef.current.element !== scrollEl) {
+      observedScrollViewportRef.current = {
+        element: scrollEl,
+        height: scrollEl.clientHeight,
+      }
+    }
 
     if (scrollEl.clientHeight > fullViewHRef.current) {
       fullViewHRef.current = scrollEl.clientHeight
@@ -1765,8 +1728,6 @@ export default function useScrollMode({
         'lifecycle:restore',
       )
     }
-    nearScrollBottomRef.current = isNearScrollBottom(scrollEl)
-
     // Identity check: apply the mode ONLY when transitionMode changed the
     // current object since the last apply. Semantic events always supply a
     // fresh object when they intend a transition, so === identity is the
@@ -1861,15 +1822,12 @@ export default function useScrollMode({
       }
       // Keep fullViewHRef authoritative at EVERY spacer sizing, not just at
       // the layout-effect entry and the RO callback start (the other two grow
-      // sites). The visualViewport keyboard handler reaches sizeSpacer via
-      // syncLayout BEFORE either of those grow steps runs on a keyboard-close,
-      // so without this the spacer would be sized from a stale-small fullViewH
-      // (the keyboard-open height) even though clientHeight has already grown
-      // back. That undersizes the spacer, the pin clamps below its target, and
-      // the message lands mid-viewport instead of at the top — the "sent
-      // while at the bottom, went to the middle not the top" bug. Grow-only: a
-      // keyboard-OPEN shrink is ignored, so Chat-UX constraint #4 (keyboard
-      // open/close must not resize the spacer) still holds.
+      // sites). On keyboard close, the viewport ResizeObserver reaches this
+      // pass with a newly grown clientHeight; without the guard the spacer
+      // would still use the stale keyboard-open height. That undersizes the
+      // spacer, clamps the pin below its target, and strands the message in the
+      // middle. Grow-only: a keyboard-open shrink is ignored, so opening and
+      // closing the keyboard never changes the permanent reply reservation.
       //
       // The ONE sanctioned lowering of the grow-only floor: a committed pane
       // geometry change (divider/projection/rotation) delivers the layout-
@@ -1877,8 +1835,8 @@ export default function useScrollMode({
       // than the current floor (a narrower/shorter pane). Consume it here, under
       // the same reader-ownership gate as every other write in this pass, before
       // the grow-only clientHeight bump re-raises it if the real pane is taller.
-      // The visualViewport keyboard path never sets this ref, so its floor stays
-      // strictly grow-only (design §2).
+      // The viewport ResizeObserver never sets this ref, so keyboard changes
+      // keep the floor strictly grow-only (design §2).
       if (pendingPaneHeightRef.current != null) {
         const ph = pendingPaneHeightRef.current
         if (Number.isFinite(ph) && ph > 0) fullViewHRef.current = ph
@@ -1954,7 +1912,6 @@ export default function useScrollMode({
       const el = _pinnedUserEl(scrollEl, modeRef.current.cid)
       lastPinTopRef.current = el ? el.offsetTop : null
       lastAppliedModeRef.current = modeRef.current
-      nearScrollBottomRef.current = isNearScrollBottom(scrollEl)
     }
 
     // The ANCHOR_AT twin of settlePinnedMode — the post-reveal clamp-repair.
@@ -1973,11 +1930,10 @@ export default function useScrollMode({
       const el = _anchorEl(scrollEl, modeRef.current)
       lastAnchorTopRef.current = el ? _scrollTopOf(scrollEl, el) : null
       lastAppliedModeRef.current = modeRef.current
-      nearScrollBottomRef.current = isNearScrollBottom(scrollEl)
     }
 
     // Full sync — size spacer and apply-if-changed. Used at mount, RO, reveal,
-    // and visualViewport keyboard changes. Each call sizes the spacer (always
+    // and actual scroll-viewport changes. Each call sizes the spacer (always
     // needed — the spacer math depends on changing content). Most callers only
     // touch scrollTop on a real mode transition; keyboard resize passes
     // forceApply so the current PIN/FOLLOW/ANCHOR survives the viewport clamp.
@@ -1986,7 +1942,6 @@ export default function useScrollMode({
       viewportChange = false,
       authorityVersion = currentAuthority(),
     } = {}) {
-      const preserveBottom = viewportChange && nearScrollBottomRef.current
       const questionSubmissionWasActive = viewportChange
         && modeRef.current?.kind === 'ANCHOR_AT'
         && Number.isFinite(modeRef.current.questionSubmitViewportH)
@@ -2008,19 +1963,19 @@ export default function useScrollMode({
       // restored mode after the reader yields.
       if (!layoutOwnsScroll(authorityVersion)) {
         deferLayoutUntilReaderYields(authorityVersion)
-        nearScrollBottomRef.current = isNearScrollBottom(scrollEl)
         return false
       }
       sizeSpacer(authorityVersion)
       if (viewportChange) {
-        const anchor = preserveBottom ? null : anchorModeFromScroll(scrollEl)
         const editingAnchor = questionEditSessionRef.current
           && !questionSubmissionWasActive
           ? anchorModeFromScroll(scrollEl)
           : null
-        const ordinaryViewportMode = modeForViewportChange(
-          modeRef.current, preserveBottom, anchor,
-        )
+        // A viewport resize is geometry, not reading intent. Reapply the mode
+        // that already owns the chat instead of deriving a different mode from
+        // the browser's intermediate clamp. Only native Q&A caret movement may
+        // deliberately rebase an ordinary hold.
+        const ordinaryViewportMode = modeRef.current
         const editingViewportMode = editingAnchor
           ? modeForQuestionEditingViewportChange(ordinaryViewportMode, editingAnchor)
           : ordinaryViewportMode
@@ -2069,7 +2024,6 @@ export default function useScrollMode({
       // clamped the first write, instead of waiting for a later RO event that
       // may never fire for the spacer-only height change.
       settlePinnedMode(authorityVersion)
-      nearScrollBottomRef.current = isNearScrollBottom(scrollEl)
       return true
     }
     function runComposerResize() {
@@ -2095,10 +2049,17 @@ export default function useScrollMode({
     // respects the reader-gesture ownership gate (R5): while a reader gesture
     // owns scroll, it DEFERS everything (the floor lowering is applied by
     // sizeSpacer only under the gate) and the reader-yield replay runs it. The
-    // visualViewport keyboard path must never call this — divider/projection
-    // shrink and keyboard shrink stay structurally separate.
+    // The keyboard's viewport ResizeObserver path must never call this —
+    // divider/projection shrink and keyboard shrink stay structurally separate.
     function runPaneResize(projectedHeightPx) {
       const authorityVersion = currentAuthority()
+      // This committed pane change has its own explicit owner. Adopt the DOM's
+      // resulting scroll-box height now so the ResizeObserver delivery that
+      // follows cannot process the same resize again as a keyboard change.
+      observedScrollViewportRef.current = {
+        element: scrollEl,
+        height: scrollEl.clientHeight,
+      }
       pendingPaneHeightRef.current =
         (Number.isFinite(projectedHeightPx) && projectedHeightPx > 0)
           ? projectedHeightPx
@@ -2119,7 +2080,6 @@ export default function useScrollMode({
           'pane:resize-follow',
           authorityVersion,
         )
-        nearScrollBottomRef.current = isNearScrollBottom(scrollEl)
       } else if (k === 'PIN_USER_MSG') {
         settlePinnedMode(authorityVersion)
       } else if (k === 'ANCHOR_AT') {
@@ -2191,6 +2151,28 @@ export default function useScrollMode({
         requestRevealOnQuiet()
         return
       }
+      const previousViewportH = observedScrollViewportRef.current.height
+      const currentViewportH = scrollEl.clientHeight
+      const viewportChanged = previousViewportH > 0
+        && Math.abs(currentViewportH - previousViewportH) >= 1
+      observedScrollViewportRef.current = {
+        element: scrollEl,
+        height: currentViewportH,
+      }
+      if (viewportChanged) {
+        syncLayout({
+          forceApply: true,
+          viewportChange: true,
+          authorityVersion,
+        })
+        if (questionEditSessionRef.current
+            && !questionEditField(document.activeElement)
+            && scrollEl.clientHeight >= fullViewHRef.current - 1) {
+          questionEditSessionRef.current = false
+        }
+        requestRevealOnQuiet()
+        return
+      }
       if (scrollEl.clientHeight > fullViewHRef.current) {
         fullViewHRef.current = scrollEl.clientHeight
       }
@@ -2258,7 +2240,6 @@ export default function useScrollMode({
         // jitter, no fight with the reader (whose first scroll flips the mode).
         settleAnchoredMode(authorityVersion)
       }
-      nearScrollBottomRef.current = isNearScrollBottom(scrollEl)
       requestRevealOnQuiet()  // each RO firing pushes the reveal back
     })
     ro.observe(listEl)
@@ -2325,22 +2306,18 @@ export default function useScrollMode({
       pendingGestureReleaseRafRef.current = 0
 
       if (!loadingOlderRef.current) {
-        // Snapshot the exact physical position, including negative anchor
-        // offsets while the viewport is inside reserved reply room. Lifecycle
-        // save/restore intentionally normalizes that room to readable content;
-        // a live gesture must not, because replaying the normalized target is
-        // the recurring jump back to the latest prompt.
+        // Snapshot the exact physical position for an ordinary hold. Reaching
+        // the physical tail instead enters FOLLOW_BOTTOM, including while
+        // latest-turn reservation remains.
         const holdMode = anchorModeFromScroll(scrollEl)
-        const spacerH = spacerEl.offsetHeight || 0
         const settledMode = modeAfterReaderGesture({
-          reachedPhysicalBottom: settledAtBottom,
-          hasReservedTail: spacerH > 1,
+          reachedBottom: settledAtBottom,
           holdMode,
         })
         transitionMode(
           settledMode,
           settledMode.kind === 'FOLLOW_BOTTOM'
-            ? 'reader:real-content-bottom'
+            ? 'reader:scroll-bottom'
             : 'reader:hold-exact',
         )
         persistMode()
@@ -2354,7 +2331,6 @@ export default function useScrollMode({
         }
       }
 
-      nearScrollBottomRef.current = isNearScrollBottom(scrollEl)
       recordTrace('events', 'reader:scroll-settled', { scrollEl })
       resumeLayoutAfterGestureRef.current?.()
       requestRevealOnQuiet()
@@ -2529,25 +2505,51 @@ export default function useScrollMode({
     // that actually moves. Stamped on pointerdown, consumed by that gesture's first
     // scroll event, so the recorded value is exactly the gap a reader feels.
     let pendingGestureStart = 0
+    let touchStartY = null
+    let touchEndChecked = false
     const onPointerDownInput = (event) => {
-      if (event.pointerType === 'touch' && isPerfProbeEnabled()) {
-        pendingGestureStart = performance.now()
-        perfTime('scroll.touchstart', () => onUserInput(event))
-        return
+      if (event.pointerType === 'touch') {
+        touchStartY = Number.isFinite(event.clientY) ? event.clientY : null
+        touchEndChecked = false
+        if (isPerfProbeEnabled()) {
+          pendingGestureStart = performance.now()
+          perfTime('scroll.touchstart', () => onUserInput(event))
+          return
+        }
       }
       onUserInput(event)
     }
-    // Pointerdown already owns an ordinary gesture. This branch does no work at
-    // digitizer frequency; it only re-arms the safety gate if a deliberately
-    // long (>2s) stationary touch outlived the no-scroll dead-man before moving.
+    // Pointerdown already owns an ordinary gesture. Client-coordinate math is
+    // the only per-move work. Once per touch, a meaningful swipe toward the end
+    // may claim FOLLOW_BOTTOM even when the browser is already clamped and can
+    // emit no scroll event; this is how a pinned reader explicitly asks to
+    // follow before the reserved reply room has been consumed.
     const onPointerMoveInput = (event) => {
-      if (event.pointerType !== 'touch'
-          || gestureWindowUntilRef.current === Number.POSITIVE_INFINITY
-          || readerScrollDirty) return
-      onUserInput(event)
+      if (event.pointerType !== 'touch') return
+      if (!touchEndChecked
+          && !readerScrollDirty
+          && touchStartY != null
+          && touchStartY - event.clientY >= 12) {
+        touchEndChecked = true
+        const distanceToBottom = scrollEl.scrollHeight
+          - scrollEl.scrollTop
+          - scrollEl.clientHeight
+        if (distanceToBottom < PHYSICAL_BOTTOM_EPSILON_PX) {
+          readerIntentVersionRef.current += 1
+          readerLocationExplicitRef.current = true
+          transitionMode({ kind: 'FOLLOW_BOTTOM' }, 'reader:scroll-bottom')
+          persistMode()
+        }
+      }
+      // Re-arm the safety gate if a deliberately long (>2s) stationary touch
+      // outlived the no-scroll dead-man before moving.
+      if (gestureWindowUntilRef.current !== Number.POSITIVE_INFINITY
+          && !readerScrollDirty) onUserInput(event)
     }
     const onPointerUpInput = () => {
       if (!readerScrollDirty) pendingGestureStart = 0
+      touchStartY = null
+      touchEndChecked = false
       scheduleNoScrollRelease()
     }
     const noteScrollStart = () => {
@@ -2578,14 +2580,13 @@ export default function useScrollMode({
       // measurement reflects when content actually moved, not whether this
       // controller classified the movement as reader-driven.
       noteScrollStart()
-      const distanceToBottom = scrollEl.scrollHeight
-        - scrollEl.scrollTop
-        - scrollEl.clientHeight
-      nearScrollBottomRef.current = distanceToBottom < NEAR_BOTTOM_PX
       const userDriven = performance.now() < gestureWindowUntilRef.current
       if (!userDriven) {
         return
       }
+      const distanceToBottom = scrollEl.scrollHeight
+        - scrollEl.scrollTop
+        - scrollEl.clientHeight
       // Disclosure expansion/collapse can produce a browser scroll while its
       // DOM changes. Its pre-toggle mode snapshot owns that movement; it is not
       // a fresh reader gesture and must not start a 250ms settlement that later
@@ -2633,25 +2634,6 @@ export default function useScrollMode({
       scrollEl.addEventListener('scrollend', settleReaderScroll, { passive: true })
     }
 
-    // Mobile keyboard via visualViewport.
-    let vvHandler = null
-    if (typeof window !== 'undefined' && window.visualViewport) {
-      vvHandler = () => {
-        syncLayout({
-          forceApply: true,
-          viewportChange: true,
-          authorityVersion: currentAuthority(),
-        })
-        if (questionEditSessionRef.current
-            && !questionEditField(document.activeElement)
-            && scrollEl.clientHeight >= fullViewHRef.current - 1) {
-          questionEditSessionRef.current = false
-        }
-      }
-      window.visualViewport.addEventListener('resize', vvHandler)
-      window.visualViewport.addEventListener('scroll', vvHandler)
-    }
-
     // Hide-then-reveal: kick off the quiet-debounce path immediately
     // (reveals ~50ms after the last RO firing, smoothing out
     // late-settling renderers like markdown/KaTeX/question cards).
@@ -2696,10 +2678,6 @@ export default function useScrollMode({
       scrollEl.removeEventListener('input', onQuestionEditMutation)
       scrollEl.removeEventListener('pointerup', onPointerUpInput)
       if (forceRevealRef.current === forceReveal) forceRevealRef.current = null
-      if (vvHandler && typeof window !== 'undefined' && window.visualViewport) {
-        window.visualViewport.removeEventListener('resize', vvHandler)
-        window.visualViewport.removeEventListener('scroll', vvHandler)
-      }
     }
   }, [
     messages,

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -130,6 +130,7 @@ import useDesktopSidebar, {
 import useWorkspaceSession from './useWorkspaceSession.js'
 import useShellReloadController from './useShellReloadController.js'
 import useAppFrameCache from './useAppFrameCache.js'
+import useShellVisualViewport from './useShellVisualViewport.js'
 import ShellBrand from './ShellBrand.jsx'
 import { HistoryDismissProvider } from '../../hooks/useHistoryDismiss.jsx'
 
@@ -262,6 +263,7 @@ export default function Shell() {
   // Standard ↔ Builder scene belongs independently to the browser transition.
   const SPLITS = paneModel.WORKSPACE_SPLITS_ENABLED
   const shellRootRef = useRef(null)
+  useShellVisualViewport(shellRootRef)
   const mode = useModeController({
     committedMode: workspace.viewMode,
     splitsEnabled: SPLITS,

--- a/frontend/src/components/Shell/__tests__/shellVisualViewport.test.js
+++ b/frontend/src/components/Shell/__tests__/shellVisualViewport.test.js
@@ -1,0 +1,54 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { fitShellToVisualViewport } from '../useShellVisualViewport.js'
+
+function fakeShell(layoutHeight) {
+  const properties = new Map()
+  return {
+    style: {
+      setProperty: (name, value) => properties.set(name, value),
+      removeProperty: name => properties.delete(name),
+    },
+    get clientHeight() {
+      const framed = Number.parseFloat(properties.get('height'))
+      return Number.isFinite(framed) ? framed : layoutHeight
+    },
+    property: name => properties.get(name),
+  }
+}
+
+test('a keyboard overlay fits the shell to the visible viewport', () => {
+  const root = fakeShell(860)
+  assert.equal(fitShellToVisualViewport(root, {
+    height: 492,
+    offsetTop: 44,
+  }), true)
+  assert.equal(root.property('top'), '44px')
+  assert.equal(root.property('bottom'), 'auto')
+  assert.equal(root.property('height'), '492px')
+})
+
+test('open, close, and open again always remeasure the unframed shell', () => {
+  const root = fakeShell(860)
+  const keyboardOpen = { height: 492, offsetTop: 0 }
+
+  assert.equal(fitShellToVisualViewport(root, keyboardOpen), true)
+  assert.equal(root.property('height'), '492px')
+
+  assert.equal(fitShellToVisualViewport(root, { height: 860, offsetTop: 0 }), false)
+  assert.equal(root.property('height'), undefined)
+
+  assert.equal(fitShellToVisualViewport(root, keyboardOpen), true)
+  assert.equal(root.property('height'), '492px')
+})
+
+test('ordinary layout resizing and small browser chrome keep the CSS frame', () => {
+  const resizedRoot = fakeShell(492)
+  assert.equal(fitShellToVisualViewport(resizedRoot, { height: 492 }), false)
+  assert.equal(resizedRoot.property('height'), undefined)
+
+  const chromeRoot = fakeShell(860)
+  assert.equal(fitShellToVisualViewport(chromeRoot, { height: 781 }), false)
+  assert.equal(chromeRoot.property('height'), undefined)
+})

--- a/frontend/src/components/Shell/useShellVisualViewport.js
+++ b/frontend/src/components/Shell/useShellVisualViewport.js
@@ -1,0 +1,68 @@
+/* Keep the full-screen shell inside the actually visible mobile viewport. */
+
+import { useLayoutEffect } from 'react'
+
+// Ignore small browser-bar changes; a software keyboard consumes much more.
+const MIN_KEYBOARD_INSET = 80
+
+function clearShellFrame(root) {
+  root.style.removeProperty('top')
+  root.style.removeProperty('bottom')
+  root.style.removeProperty('height')
+}
+
+/**
+ * Fit the shell to a keyboard-shrunken visual viewport. Removing the previous
+ * inline frame first makes the shell's own CSS layout the only baseline, so a
+ * browser cannot poison the next opening with a stale window-height reading.
+ */
+export function fitShellToVisualViewport(root, viewport) {
+  if (!root) return false
+  clearShellFrame(root)
+
+  const visibleHeight = Number(viewport?.height)
+  const layoutHeight = root.clientHeight
+  const coveredHeight = layoutHeight - visibleHeight
+  if (!(visibleHeight > 0) || coveredHeight < MIN_KEYBOARD_INSET) return false
+
+  const visibleTop = Math.min(
+    coveredHeight,
+    Math.max(0, Number(viewport.offsetTop) || 0),
+  )
+  root.style.setProperty('top', `${visibleTop}px`)
+  root.style.setProperty('bottom', 'auto')
+  root.style.setProperty('height', `${visibleHeight}px`)
+  return true
+}
+
+export default function useShellVisualViewport(rootRef) {
+  useLayoutEffect(() => {
+    const viewport = window.visualViewport
+    const root = rootRef.current
+    if (!viewport || !root) return undefined
+
+    let frameRequest = 0
+    const apply = () => {
+      frameRequest = 0
+      fitShellToVisualViewport(root, viewport)
+    }
+    const applySoon = () => {
+      if (!frameRequest) frameRequest = requestAnimationFrame(apply)
+    }
+
+    apply()
+    viewport.addEventListener('resize', applySoon)
+    viewport.addEventListener('scroll', applySoon)
+    window.addEventListener('resize', applySoon)
+    window.addEventListener('pageshow', applySoon)
+
+    return () => {
+      if (frameRequest) cancelAnimationFrame(frameRequest)
+      viewport.removeEventListener('resize', applySoon)
+      viewport.removeEventListener('scroll', applySoon)
+      window.removeEventListener('resize', applySoon)
+      window.removeEventListener('pageshow', applySoon)
+      clearShellFrame(root)
+    }
+  }, [rootRef])
+}

--- a/tests/send-rule.spec.mjs
+++ b/tests/send-rule.spec.mjs
@@ -244,7 +244,7 @@ test('Send while at the bottom hands off after a long response fills the reserva
   expect(m.scrollH - m.scrollTop - m.clientH).toBeLessThanOrEqual(8)
 })
 
-test('Immediate tail-to-send preserves a manual reserved-tail position as output fills it', async ({ page }) => {
+test('Immediate tail-to-send follows output after the reader returns to the physical tail', async ({ page }) => {
   await installChunkedStreams(page, [
     [
       [0, { type: 'catch_up_done' }],
@@ -281,10 +281,10 @@ test('Immediate tail-to-send preserves a manual reserved-tail position as output
   expect(held.lastUserVisualTop).toBeGreaterThanOrEqual(-2)
   expect(held.lastUserVisualTop).toBeLessThanOrEqual(10)
 
-  // Reproduce the owner's manual recovery exactly: move away, then reach the
-  // physical tail while reserved room still exists. The next streamed chunk
-  // must keep the prompt parked; it cannot turn that tail gesture into
-  // immediate real-content following.
+  // Move away, then deliberately return to the one physical tail while
+  // reserved room still exists. That reader gesture explicitly engages
+  // following; until output consumes the room, the prompt remains parked at
+  // the same physical tail.
   await page.evaluate(() => {
     const s = document.querySelector('[data-chat-surface="painted"] .chat__scroll')
     if (!s) return
@@ -295,10 +295,12 @@ test('Immediate tail-to-send preserves a manual reserved-tail position as output
   await page.waitForFunction(() =>
     [...document.querySelectorAll('[data-chat-surface="painted"] .chat__msg--assistant')]
       .some(el => el.textContent?.includes('HOLD_AFTER_MANUAL_TAIL')))
-  const manuallyHeld = await measure(page)
-  expect(manuallyHeld.spacerH).toBeGreaterThan(1)
-  expect(manuallyHeld.lastUserVisualTop).toBeGreaterThanOrEqual(-2)
-  expect(manuallyHeld.lastUserVisualTop).toBeLessThanOrEqual(10)
+  await expect(page.locator('[data-chat-surface="painted"] .chat__scroll'))
+    .toHaveAttribute('data-scroll-mode', 'FOLLOW_BOTTOM')
+  const followingReservedTail = await measure(page)
+  expect(followingReservedTail.spacerH).toBeGreaterThan(1)
+  expect(followingReservedTail.lastUserVisualTop).toBeGreaterThanOrEqual(-2)
+  expect(followingReservedTail.lastUserVisualTop).toBeLessThanOrEqual(10)
 
   await page.waitForFunction(() => {
     const text = [...document.querySelectorAll('[data-chat-surface="painted"] .chat__msg--assistant')]
@@ -313,8 +315,8 @@ test('Immediate tail-to-send preserves a manual reserved-tail position as output
 
   const filled = await measure(page)
   expect(filled.spacerH).toBeLessThanOrEqual(1)
-  expect(Math.abs(filled.scrollTop - manuallyHeld.scrollTop)).toBeLessThanOrEqual(8)
-  expect(filled.scrollH - filled.scrollTop - filled.clientH).toBeGreaterThan(50)
+  expect(filled.scrollTop - followingReservedTail.scrollTop).toBeGreaterThan(50)
+  expect(filled.scrollH - filled.scrollTop - filled.clientH).toBeLessThanOrEqual(8)
 })
 
 // ───────────────────────────────────────────────────────────────────

--- a/tests/spacer.spec.mjs
+++ b/tests/spacer.spec.mjs
@@ -1054,48 +1054,49 @@ test.describe('Scroll edge cases', () => {
     expect(gapFromBottom).toBeGreaterThan(50)
   })
 
-  test('25. Auto-follow stays glued tightly (regression on test 18 threshold)', async ({ page }) => {
-    // Test 18 asserts gap < 200 — wide enough to let the broken RO pass
-    // (5 small chunks drift ~150px without re-applying FOLLOW_BOTTOM).
-    // This is the SAME setup + content volume; the only difference is
-    // a TIGHT assertion (<= 5). Demonstrates the regression directly
-    // without invoking the 204-refresh path that heavier injection
-    // accidentally triggers.
+  test('25. Reserved-tail swipe follows tool output without jumping backward', async ({ page }) => {
     await setup(page)
     await newChat(page)
     await sendMessage(page, 'Autoscroll tight test')
 
-    await injectContent(page, 'Filling viewport with lots of text. ', 150)
     const before = await measure(page)
-    expect(before.listH).toBeGreaterThan(before.clientH)
+    expect(before.spacerH).toBeGreaterThan(0)
+    expect(before.userVisualTop).toBeGreaterThanOrEqual(0)
+    expect(before.userVisualTop).toBeLessThanOrEqual(10)
 
-    // Engage FOLLOW_BOTTOM via real gesture (test 18's exact pattern).
-    await page.evaluate(() => {
-      const s = document.querySelector('[data-chat-surface="painted"] .chat__scroll')
-      if (s) s.scrollTop = s.scrollHeight
-    })
-    await page.evaluate(() => new Promise(r => setTimeout(r, 150)))
+    // The fresh pin is already clamped at the physical bottom, so the browser
+    // cannot emit another scroll event. A deliberate swipe toward the end is
+    // nevertheless explicit follow intent.
     await page.evaluate(() => {
       const s = document.querySelector('[data-chat-surface="painted"] .chat__scroll')
       if (!s) return
-      s.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
-      s.scrollTop = Math.max(0, s.scrollTop - 1)
-      s.scrollTop = s.scrollHeight
+      s.dispatchEvent(new PointerEvent('pointerdown', {
+        bubbles: true, pointerType: 'touch', clientY: 400,
+      }))
+      s.dispatchEvent(new PointerEvent('pointermove', {
+        bubbles: true, pointerType: 'touch', clientY: 360,
+      }))
+      s.dispatchEvent(new PointerEvent('pointerup', {
+        bubbles: true, pointerType: 'touch', clientY: 360,
+      }))
     })
-    await page.evaluate(() => new Promise(r => setTimeout(r, 100)))
+    await page.waitForFunction(() => (
+      document.querySelector('[data-chat-surface="painted"] .chat__scroll')
+        ?.dataset.scrollMode === 'FOLLOW_BOTTOM'
+    ))
 
     const atBottom = await measure(page)
     expect(atBottom.scrollH - atBottom.scrollTop - atBottom.clientH)
       .toBeLessThanOrEqual(5)
 
-    // Five small chunks (test 18's exact volume) — auto-follow MUST
-    // keep us within a few px of the bottom, not 200px adrift.
+    // Tool calls consume reserved room first. Follow stays at the same physical
+    // tail rather than jumping backward to a second "real content" bottom.
     for (let i = 0; i < 5; i++) {
-      await injectContent(page, `Streaming chunk ${i + 1}. More text here. `, 5)
+      await injectToolBlock(page)
     }
 
     const after = await measure(page)
-    expect(after.error).toBeUndefined()
+    expect(after.toolCount).toBe(5)
     const afterGap = after.scrollH - after.scrollTop - after.clientH
     expect(afterGap).toBeLessThanOrEqual(10)
   })
@@ -1235,16 +1236,28 @@ test.describe('Scroll edge cases', () => {
     expect(after.spacerH).toBeGreaterThanOrEqual(0)
   })
 
-  test('27. Viewport resize cycles do not engage auto-follow on streaming chat', async ({ page }) => {
-    // Guards the prevListH gate in the ResizeObserver: the auto-follow
-    // branch must not snap to bottom when the list merely re-measures due
-    // to a viewport resize (content unchanged). This is a partial guard
-    // for the keyboard-cycle drift class of bugs — it does NOT simulate
-    // Chrome Android's first-focus overshoot, which is a browser-level
-    // animation quirk outside our code's control.
+  test('27. Viewport cycles preserve a sent-message pin and an older anchor', async ({ page }) => {
+    // The actual chat scroll box is the single keyboard/layout signal. Repeated
+    // resize cycles reapply whichever semantic mode already owns the chat;
+    // geometry must never replace a pin or exact anchor with another alignment.
     await setup(page)
     await newChat(page)
     await sendMessage(page, 'First')
+
+    const pinned = await measure(page)
+    expect(pinned.userVisualTop).toBeGreaterThanOrEqual(0)
+    expect(pinned.userVisualTop).toBeLessThanOrEqual(10)
+    for (let i = 0; i < 3; i++) {
+      for (const height of [615, 915]) {
+        await page.setViewportSize({ width: 412, height })
+        await page.evaluate(() => new Promise(r => setTimeout(r, 100)))
+        const duringCycle = await measure(page)
+        expect(Math.abs(duringCycle.userVisualTop - pinned.userVisualTop))
+          .toBeLessThanOrEqual(8)
+        await expect(page.locator('[data-chat-surface="painted"] .chat__scroll'))
+          .toHaveAttribute('data-scroll-mode', 'PIN_USER_MSG')
+      }
+    }
 
     // Grow the content so there's room to scroll up.
     await injectContent(page, 'Padding content line. ', 80)
@@ -1252,12 +1265,17 @@ test.describe('Scroll edge cases', () => {
       requestAnimationFrame(() => requestAnimationFrame(r))
     ))
 
-    // Scroll to the top (definitely not near the bottom).
+    // Scroll to the top through the reader-owned path (definitely not near the
+    // bottom). A bare scrollTop write is browser/programmatic layout, not
+    // reading intent, and deliberately cannot replace the keyboard snapshot.
     await page.evaluate(() => {
       const s = document.querySelector('[data-chat-surface="painted"] .chat__scroll')
-      if (s) s.scrollTop = 0
+      if (!s) return
+      s.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
+      s.scrollTop = 0
+      s.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }))
     })
-    await page.evaluate(() => new Promise(r => setTimeout(r, 50)))
+    await page.evaluate(() => new Promise(r => setTimeout(r, 350)))
 
     const before = await measure(page)
 


### PR DESCRIPTION
## Summary

- Fit the shell to the visual viewport only when a software keyboard overlays the layout viewport, remeasuring from the CSS frame on every cycle.
- Make chat scrolling react to its actual resized scroll box instead of racing the shell with a second visual-viewport listener.
- Preserve the active pin, follow, or reading anchor across keyboard resizing.
- Use one physical bottom for following, including reserved reply room, and recognize an end-directed touch swipe when the browser is already clamped.

## Root cause

The shell and chat independently interpreted the keyboard transition, so listener order could make the chat derive a new reading mode from intermediate geometry. The dynamic reply reservation also created two competing definitions of “bottom”: a reader could reach the physical end without enabling follow, and repeated keyboard cycles could replace a pinned message with a different bottom alignment.

The fix gives each layer one responsibility: the shell owns browser viewport reconciliation, the chat observes only its resulting box size, and keyboard geometry reapplies the existing semantic mode rather than changing it. Following then targets the single physical tail.

## Verification

- `npm test`
- `npm run build`
- Regression coverage for repeated open/close sizing, sent-message pin preservation, clamped touch follow, and tool-output growth while reply reservation remains.
- Manually verified through repeated soft-keyboard open/close cycles on a phone.