### PR TITLE
Add pre-PR GitHub checks for prepared contributions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: Tests
 
 on:
+  # Contribute can push an exact reviewed branch to the owner's fork and run
+  # this suite before opening a PR. Manual dispatch creates no PR thread or
+  # organization-wide notification; GitHub reports the run to its triggerer.
+  workflow_dispatch:
   pull_request:
     # True PR stacks target the upstream branch directly beneath them. Run the
     # same suite for every layer so the chain is reviewable in parallel; main's

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,10 +108,20 @@ returning always preserves the exact visible anchor and never restores
 auto-scroll to a newer tail. New send and lifecycle paths must use the shared
 state machine rather than deriving intent from geometry alone.
 
-**End-to-end (Playwright).** Comprehensive browser checks run in GitHub after a
-PR is opened. Do not point raw Playwright, an auth setup, or a preview proxy at
-a live Möbius backend. For a rare local reproduction, first commit the exact
-revision, then run the host-only disposable wrapper from a Docker-capable host:
+**End-to-end (Playwright).** Comprehensive browser checks run in GitHub for pull
+requests. A prepared platform contribution can run the same suite earlier from
+Contribute: **Run GitHub checks** pushes only the reviewed branch to the owner's
+fork and manually dispatches `.github/workflows/test.yml`; it does not open a
+pull request. From another checkout whose branch is already on GitHub, the
+equivalent manual command is:
+
+```bash
+gh workflow run test.yml -R <your-login>/mobius --ref <branch>
+```
+
+Do not point raw Playwright, an auth setup, or a preview proxy at a live Möbius
+backend. For a rare local reproduction, first commit the exact revision, then
+run the host-only disposable wrapper from a Docker-capable host:
 
 ```bash
 npm ci && npx playwright install --with-deps chrome

--- a/backend/app/github_contributions.py
+++ b/backend/app/github_contributions.py
@@ -424,6 +424,20 @@ def _claim_record(
       status_code=409,
       detail="This contribution is no longer waiting for approval.",
     )
+  early_checks = record.get("early_checks")
+  if (
+    isinstance(early_checks, dict)
+    and early_checks.get("state") in {
+      "dispatching", "uncertain", "queued", "in_progress",
+    }
+  ):
+    raise HTTPException(
+      status_code=409,
+      detail=(
+        "GitHub checks are still starting or running for this review. Wait "
+        "for them to finish before opening the pull request."
+      ),
+    )
   plan = record.get("plan")
   if not isinstance(plan, dict):
     raise HTTPException(

--- a/backend/app/github_preflight_checks.py
+++ b/backend/app/github_preflight_checks.py
@@ -1,0 +1,528 @@
+"""Run reviewed platform contributions through GitHub before opening a PR.
+
+Preparation stays private.  The explicit Contribute action handled here is a
+separate public boundary: it may create/update the owner's fork, push the exact
+reviewed branch, and dispatch the allowlisted test workflow, but it never opens
+or edits a pull request.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from urllib.parse import quote
+
+from app import github_auth
+from app.contribution_errors import ContributionSubmitError
+from app.github_contribution_contract import GIT_SHA as _GIT_SHA
+from app import github_contribution_git as _git_ops
+from app import github_contributions as _contrib
+
+
+_SUPPORTED_WORKFLOWS = {
+  "mobius-os/mobius": "test.yml",
+}
+_API_VERSION = "2026-03-10"
+_ACTIVE_STATES = frozenset({
+  "dispatching", "uncertain", "queued", "in_progress",
+})
+_SUCCESS_CONCLUSIONS = frozenset({"success", "neutral", "skipped"})
+
+
+def supports_prepared_checks(record: dict) -> bool:
+  """True when one prepared record may use the early-check action."""
+  plan = record.get("plan") if isinstance(record.get("plan"), dict) else {}
+  repo = str(plan.get("repo") or record.get("repo") or "")
+  return bool(
+    record.get("status") == "prepared"
+    and record.get("type") == "pr"
+    and plan.get("action") == "pr"
+    and not isinstance(plan.get("stack"), dict)
+    and repo in _SUPPORTED_WORKFLOWS
+  )
+
+
+def check_is_active(check: object) -> bool:
+  return isinstance(check, dict) and check.get("state") in _ACTIVE_STATES
+
+
+def check_failed(check: object) -> bool:
+  if not isinstance(check, dict):
+    return False
+  if check.get("state") == "error":
+    return True
+  return bool(
+    check.get("state") == "completed"
+    and str(check.get("conclusion") or "").lower()
+    not in _SUCCESS_CONCLUSIONS
+  )
+
+
+def _now() -> datetime:
+  return datetime.now(UTC)
+
+
+def _now_iso() -> str:
+  return _now().isoformat().replace("+00:00", "Z")
+
+
+def _parse_iso(value: object) -> datetime | None:
+  try:
+    parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+  except (TypeError, ValueError):
+    return None
+  if parsed.tzinfo is None:
+    parsed = parsed.replace(tzinfo=UTC)
+  return parsed.astimezone(UTC)
+
+
+def _json_output(proc: subprocess.CompletedProcess, message: str) -> dict:
+  try:
+    payload = json.loads(proc.stdout or "{}")
+  except ValueError:
+    payload = None
+  if not isinstance(payload, dict):
+    raise ContributionSubmitError(message)
+  return payload
+
+
+def _api(
+  repo: Path,
+  *args: str,
+  check: bool = True,
+) -> subprocess.CompletedProcess:
+  return _git_ops._gh(
+    repo,
+    "api",
+    "-H", "Accept: application/vnd.github+json",
+    "-H", f"X-GitHub-Api-Version: {_API_VERSION}",
+    *args,
+    check=check,
+  )
+
+
+def _workflow_state(repo: Path, fork_slug: str, workflow: str) -> str:
+  result = _api(
+    repo, f"repos/{fork_slug}/actions/workflows/{quote(workflow, safe='')}",
+    check=False,
+  )
+  if result.returncode != 0:
+    detail = (result.stderr or result.stdout or "").strip()
+    raise ContributionSubmitError(
+      "The manual Tests workflow is not available on the GitHub fork yet. "
+      "This bootstrap change must be sent normally once; later contributions "
+      "can run checks before a pull request is opened.",
+      detail=detail[:600] or None,
+      code="early_checks_unavailable",
+    )
+  payload = _json_output(result, "Could not inspect the GitHub test workflow.")
+  return str(payload.get("state") or "")
+
+
+def _enable_workflow(repo: Path, fork_slug: str, workflow: str) -> None:
+  state = _workflow_state(repo, fork_slug, workflow)
+  if state == "active":
+    return
+  enabled = _api(
+    repo,
+    "--method", "PUT",
+    f"repos/{fork_slug}/actions/workflows/{quote(workflow, safe='')}/enable",
+    check=False,
+  )
+  if enabled.returncode != 0:
+    detail = (enabled.stderr or enabled.stdout or "").strip()
+    raise ContributionSubmitError(
+      "GitHub Actions is disabled on the personal fork. Enable Actions there "
+      "or reconnect GitHub, then try Run checks again.",
+      detail=detail[:600] or None,
+      code="early_checks_disabled",
+    )
+
+
+def _assert_upstream_workflow_dispatchable(
+  repo: Path, *, upstream_sha: str, workflow: str,
+) -> None:
+  source = _git_ops._git(
+    repo,
+    "show",
+    f"{upstream_sha}:.github/workflows/{workflow}",
+    check=False,
+  )
+  if source.returncode != 0 or "workflow_dispatch:" not in source.stdout:
+    raise ContributionSubmitError(
+      "This is the one-time bootstrap for early checks: the manual Tests "
+      "trigger must reach upstream main before GitHub can run it from forks. "
+      "Send this contribution normally; later platform contributions can run "
+      "checks first.",
+      code="early_checks_unavailable",
+    )
+
+
+def _dispatch_workflow(
+  repo: Path,
+  *,
+  fork_slug: str,
+  workflow: str,
+  branch: str,
+) -> dict:
+  try:
+    result = _api(
+      repo,
+      "--method", "POST",
+      f"repos/{fork_slug}/actions/workflows/{quote(workflow, safe='')}/dispatches",
+      "-f", f"ref={branch}",
+      "-F", "return_run_details=true",
+      check=False,
+    )
+  except (OSError, subprocess.TimeoutExpired) as exc:
+    raise ContributionSubmitError(
+      "The reviewed branch was pushed, but Contribute could not confirm "
+      "whether GitHub started the checks. Reopen Contribute to reconcile the "
+      "run before trying again.",
+      code="early_checks_uncertain",
+    ) from exc
+  if result.returncode != 0:
+    detail = (result.stderr or result.stdout or "").strip()
+    raise ContributionSubmitError(
+      "The reviewed branch was pushed, but GitHub could not start its Tests "
+      "workflow.",
+      detail=detail[:600] or None,
+      code="early_checks_dispatch_failed",
+    )
+  try:
+    payload = _json_output(
+      result,
+      "GitHub started the checks but did not return their run details.",
+    )
+  except ContributionSubmitError as exc:
+    raise ContributionSubmitError(
+      exc.message,
+      detail=exc.detail,
+      code="early_checks_uncertain",
+    ) from exc
+  try:
+    run_id = int(payload.get("workflow_run_id"))
+  except (TypeError, ValueError):
+    run_id = 0
+  url = str(payload.get("html_url") or "")
+  if run_id <= 0 or not url.startswith("https://github.com/"):
+    raise ContributionSubmitError(
+      "GitHub started the checks but did not return their run details.",
+      code="early_checks_uncertain",
+    )
+  return {"run_id": run_id, "url": url}
+
+
+def dispatch_prepared_checks(
+  record: dict,
+  diff_path: Path,
+  *,
+  requested_at: str,
+) -> tuple[dict, dict]:
+  """Push the exact reviewed branch to the owner fork and start Tests.
+
+  Returns ``(early_checks, record_patch)``.  ``record_patch`` may contain a
+  normalized reviewed head SHA and fork/push evidence; callers must persist it
+  with the run atomically.
+  """
+  if not shutil.which("git") or not shutil.which("gh"):
+    raise ContributionSubmitError(
+      "This platform needs git and gh installed before it can run GitHub checks."
+    )
+  token = github_auth.get_token()
+  state = github_auth.read_state() or {}
+  login = str(state.get("login") or "")
+  scopes = set(state.get("scopes") or [])
+  if not token or not login:
+    raise ContributionSubmitError("Connect GitHub before running checks.", 401)
+  if "workflow" not in scopes:
+    raise ContributionSubmitError(
+      "Reconnect GitHub with full PR access before running checks on a fork.",
+      status_code=409,
+      code="early_checks_scope",
+    )
+  if not supports_prepared_checks(record):
+    raise ContributionSubmitError(
+      "Early GitHub checks are currently available for standalone Möbius "
+      "platform contributions only.",
+      status_code=409,
+      code="early_checks_unsupported",
+    )
+
+  plan = record.get("plan") or {}
+  upstream_repo = _git_ops._validate_repo_slug(
+    plan.get("repo") or record.get("repo")
+  )
+  workflow = _SUPPORTED_WORKFLOWS[upstream_repo]
+  branch = _git_ops._validate_branch(plan.get("branch") or record.get("branch"))
+  repo = _contrib._safe_repo_path(plan.get("repo_path"))
+  if not (repo / ".git").exists():
+    raise ContributionSubmitError("The staged repo is not a git checkout.")
+  author_name, author_email = _git_ops._connected_git_identity(state, login)
+
+  checkout_back = None
+  pushed: dict = {}
+  record_patch: dict = {}
+  try:
+    current_branch = _git_ops._git(
+      repo, "rev-parse", "--abbrev-ref", "HEAD",
+    ).stdout.strip()
+    checkout_back = (
+      _git_ops._git(repo, "rev-parse", "HEAD").stdout.strip()
+      if current_branch == "HEAD" else current_branch
+    )
+    _git_ops._git(repo, "check-ref-format", "--branch", branch)
+    _git_ops._assert_clean_worktree(repo)
+    _git_ops._git(repo, "checkout", "-q", branch)
+    expected_base, _, expected_diff = _git_ops._assert_fresh(
+      record, diff_path, repo, branch,
+    )
+    _git_ops._assert_coauthor_trailer(repo, branch)
+    record_patch = _git_ops._normalize_head_attribution(
+      repo,
+      branch,
+      author_name=author_name,
+      author_email=author_email,
+      base_sha=expected_base,
+      expected_diff=expected_diff,
+      record=record,
+    )
+    merge_patch = _git_ops._assert_merges_with_upstream(
+      repo, upstream_repo, branch,
+    )
+    record_patch = _git_ops._record_patch_with(record_patch, merge_patch)
+    _assert_upstream_workflow_dispatchable(
+      repo,
+      upstream_sha=str(merge_patch["last_submit_upstream_sha"]),
+      workflow=workflow,
+    )
+
+    conflict = _contrib._existing_branch_pr(
+      repo, upstream_repo, login, branch, same_repo=False,
+    )
+    if conflict is not None:
+      url, state_label = conflict
+      raise ContributionSubmitError(
+        f"This branch already has a {state_label} pull request: {url}. "
+        "Use that pull request's checks instead of starting a private run.",
+        code="early_checks_existing_pr",
+      )
+
+    fork_slug = _contrib._ensure_owner_fork_remote(repo, upstream_repo, login)
+    fork_patch = _contrib._inspect_owner_fork_default_branch(
+      repo,
+      fork_slug,
+      upstream_branch=str(merge_patch["last_submit_upstream_branch"]),
+      upstream_sha=str(merge_patch["last_submit_upstream_sha"]),
+    )
+    if (
+      fork_patch.get("last_submit_fork_sync") == "strictly-behind"
+      or fork_patch.get("last_submit_fork_carrier_branch")
+    ):
+      fork_patch = _contrib._sync_owner_fork_with_workflow_scope(
+        repo,
+        fork_slug,
+        upstream_branch=str(merge_patch["last_submit_upstream_branch"]),
+        upstream_sha=str(merge_patch["last_submit_upstream_sha"]),
+      )
+    record_patch = _git_ops._record_patch_with(record_patch, fork_patch)
+
+    push_source, record_patch = _contrib._push_reviewed_topic(
+      repo,
+      branch=branch,
+      fork_slug=fork_slug,
+      merge_patch=merge_patch,
+      record_patch=record_patch,
+      diff_path=diff_path,
+      expected_diff=expected_diff,
+      author_name=author_name,
+      author_email=author_email,
+      workflow_scope=True,
+    )
+    pushed_sha = _git_ops._git(repo, "rev-parse", push_source).stdout.strip()
+    if not _GIT_SHA.fullmatch(pushed_sha):
+      raise ContributionSubmitError(
+        "Could not verify the exact reviewed commit after pushing this branch."
+      )
+    branch_url = f"https://github.com/{fork_slug}/tree/{quote(branch, safe='/')}"
+    pushed = {
+      "fork_repo": fork_slug,
+      "branch": branch,
+      "head_sha": pushed_sha,
+      "branch_url": branch_url,
+      "workflow": workflow,
+      "requested_at": requested_at,
+    }
+    record_patch = _git_ops._record_patch_with(record_patch, {
+      "head_repository": fork_slug,
+      "last_pushed_branch": f"{login}:{branch}",
+      "last_pushed_branch_url": branch_url,
+      "last_submit_push_sha": pushed_sha,
+    })
+
+    _enable_workflow(repo, fork_slug, workflow)
+    dispatched = _dispatch_workflow(
+      repo,
+      fork_slug=fork_slug,
+      workflow=workflow,
+      branch=branch,
+    )
+    return ({
+      **pushed,
+      **dispatched,
+      "state": "queued",
+      "conclusion": None,
+      "observed_at": _now_iso(),
+    }, record_patch)
+  except ContributionSubmitError as exc:
+    combined_patch = _git_ops._record_patch_with(
+      record_patch, exc.record_patch,
+    )
+    if pushed and not isinstance(combined_patch.get("early_checks"), dict):
+      check_state = "uncertain" if exc.code == "early_checks_uncertain" else "error"
+      patch = {
+        **pushed,
+        "state": check_state,
+        "conclusion": None,
+        "message": exc.message,
+        "observed_at": _now_iso(),
+      }
+      raise ContributionSubmitError(
+        exc.message,
+        exc.status_code,
+        detail=exc.detail,
+        record_patch={**combined_patch, "early_checks": patch},
+        code=exc.code,
+      ) from exc
+    if combined_patch:
+      raise ContributionSubmitError(
+        exc.message,
+        exc.status_code,
+        detail=exc.detail,
+        record_patch=combined_patch,
+        code=exc.code,
+      ) from exc
+    raise
+  finally:
+    if checkout_back:
+      _git_ops._git(repo, "checkout", "-q", checkout_back, check=False)
+
+
+def _run_snapshot(payload: dict, check: dict) -> dict:
+  event = str(payload.get("event") or "")
+  head_sha = str(payload.get("head_sha") or "")
+  head_branch = str(payload.get("head_branch") or "")
+  html_url = str(payload.get("html_url") or "")
+  if (
+    event != "workflow_dispatch"
+    or head_sha != str(check.get("head_sha") or "")
+    or head_branch != str(check.get("branch") or "")
+    or not html_url.startswith("https://github.com/")
+  ):
+    raise ContributionSubmitError(
+      "GitHub returned a workflow run that does not match the reviewed branch."
+    )
+  status = str(payload.get("status") or "")
+  if status not in {"queued", "in_progress", "completed"}:
+    status = "in_progress"
+  next_check = {
+    **check,
+    "state": status,
+    "conclusion": payload.get("conclusion") if status == "completed" else None,
+    "url": html_url,
+    "observed_at": _now_iso(),
+  }
+  if payload.get("created_at"):
+    next_check["started_at"] = payload["created_at"]
+  if status == "completed" and payload.get("updated_at"):
+    next_check["completed_at"] = payload["updated_at"]
+  next_check.pop("message", None)
+  return next_check
+
+
+def _find_uncertain_run(repo: Path, check: dict) -> dict | None:
+  fork_slug = _git_ops._validate_repo_slug(check.get("fork_repo"))
+  branch = _git_ops._validate_branch(check.get("branch"))
+  head_sha = str(check.get("head_sha") or "")
+  if not _GIT_SHA.fullmatch(head_sha):
+    return None
+  path = (
+    f"repos/{fork_slug}/actions/workflows/"
+    f"{quote(str(check.get('workflow') or ''), safe='')}/runs"
+    f"?event=workflow_dispatch&branch={quote(branch, safe='')}"
+    f"&head_sha={quote(head_sha, safe='')}&per_page=10"
+  )
+  result = _api(repo, path, check=False)
+  if result.returncode != 0:
+    return None
+  payload = _json_output(result, "Could not reconcile the GitHub checks.")
+  runs = payload.get("workflow_runs")
+  requested = _parse_iso(check.get("requested_at"))
+  if not isinstance(runs, list) or requested is None:
+    return None
+  matches = []
+  for run in runs:
+    if not isinstance(run, dict):
+      continue
+    created = _parse_iso(run.get("created_at"))
+    if created is not None and created >= requested - timedelta(seconds=15):
+      matches.append(run)
+  return matches[0] if len(matches) == 1 else None
+
+
+def refresh_prepared_check(record: dict) -> dict | None:
+  """Return a fresh early-check snapshot, or None when no refresh is due."""
+  check = record.get("early_checks")
+  if not supports_prepared_checks(record) or not check_is_active(check):
+    return None
+  plan = record.get("plan") or {}
+  repo = _contrib._safe_repo_path(plan.get("repo_path"))
+  if not (repo / ".git").exists():
+    return {
+      **check,
+      "state": "error",
+      "message": "The prepared review checkout is no longer available.",
+      "observed_at": _now_iso(),
+    }
+
+  run_id = check.get("run_id")
+  if not run_id and check.get("state") == "uncertain":
+    matched = _find_uncertain_run(repo, check)
+    if matched is not None:
+      run_id = matched.get("id")
+      check = {
+        **check,
+        "run_id": run_id,
+        "url": matched.get("html_url") or check.get("url"),
+      }
+    elif (
+      (requested := _parse_iso(check.get("requested_at"))) is not None
+      and _now() - requested > timedelta(minutes=3)
+    ):
+      return {
+        **check,
+        "state": "error",
+        "message": (
+          "GitHub did not expose a matching workflow run. The reviewed branch "
+          "is still on the personal fork; Run checks can be tried again."
+        ),
+        "observed_at": _now_iso(),
+      }
+    else:
+      return check
+
+  try:
+    run_id = int(run_id)
+  except (TypeError, ValueError):
+    return check
+  fork_slug = _git_ops._validate_repo_slug(check.get("fork_repo"))
+  result = _api(
+    repo, f"repos/{fork_slug}/actions/runs/{run_id}", check=False,
+  )
+  if result.returncode != 0:
+    return check
+  payload = _json_output(result, "Could not inspect the GitHub checks.")
+  return _run_snapshot(payload, check)

--- a/backend/app/github_preflight_checks.py
+++ b/backend/app/github_preflight_checks.py
@@ -29,7 +29,6 @@ _API_VERSION = "2026-03-10"
 _ACTIVE_STATES = frozenset({
   "dispatching", "uncertain", "queued", "in_progress",
 })
-_SUCCESS_CONCLUSIONS = frozenset({"success", "neutral", "skipped"})
 
 
 def supports_prepared_checks(record: dict) -> bool:
@@ -47,18 +46,6 @@ def supports_prepared_checks(record: dict) -> bool:
 
 def check_is_active(check: object) -> bool:
   return isinstance(check, dict) and check.get("state") in _ACTIVE_STATES
-
-
-def check_failed(check: object) -> bool:
-  if not isinstance(check, dict):
-    return False
-  if check.get("state") == "error":
-    return True
-  return bool(
-    check.get("state") == "completed"
-    and str(check.get("conclusion") or "").lower()
-    not in _SUCCESS_CONCLUSIONS
-  )
 
 
 def _now() -> datetime:
@@ -104,28 +91,7 @@ def _api(
   )
 
 
-def _workflow_state(repo: Path, fork_slug: str, workflow: str) -> str:
-  result = _api(
-    repo, f"repos/{fork_slug}/actions/workflows/{quote(workflow, safe='')}",
-    check=False,
-  )
-  if result.returncode != 0:
-    detail = (result.stderr or result.stdout or "").strip()
-    raise ContributionSubmitError(
-      "The manual Tests workflow is not available on the GitHub fork yet. "
-      "This bootstrap change must be sent normally once; later contributions "
-      "can run checks before a pull request is opened.",
-      detail=detail[:600] or None,
-      code="early_checks_unavailable",
-    )
-  payload = _json_output(result, "Could not inspect the GitHub test workflow.")
-  return str(payload.get("state") or "")
-
-
 def _enable_workflow(repo: Path, fork_slug: str, workflow: str) -> None:
-  state = _workflow_state(repo, fork_slug, workflow)
-  if state == "active":
-    return
   enabled = _api(
     repo,
     "--method", "PUT",
@@ -135,8 +101,8 @@ def _enable_workflow(repo: Path, fork_slug: str, workflow: str) -> None:
   if enabled.returncode != 0:
     detail = (enabled.stderr or enabled.stdout or "").strip()
     raise ContributionSubmitError(
-      "GitHub Actions is disabled on the personal fork. Enable Actions there "
-      "or reconnect GitHub, then try Run checks again.",
+      "GitHub could not enable the Tests workflow on the personal fork. "
+      "Enable Actions there or reconnect GitHub, then try Run checks again.",
       detail=detail[:600] or None,
       code="early_checks_disabled",
     )
@@ -347,15 +313,14 @@ def dispatch_prepared_checks(
       raise ContributionSubmitError(
         "Could not verify the exact reviewed commit after pushing this branch."
       )
-    branch_url = f"https://github.com/{fork_slug}/tree/{quote(branch, safe='/')}"
     pushed = {
       "fork_repo": fork_slug,
       "branch": branch,
       "head_sha": pushed_sha,
-      "branch_url": branch_url,
       "workflow": workflow,
       "requested_at": requested_at,
     }
+    branch_url = f"https://github.com/{fork_slug}/tree/{quote(branch, safe='/')}"
     record_patch = _git_ops._record_patch_with(record_patch, {
       "head_repository": fork_slug,
       "last_pushed_branch": f"{login}:{branch}",
@@ -433,13 +398,19 @@ def _run_snapshot(payload: dict, check: dict) -> dict:
     "state": status,
     "conclusion": payload.get("conclusion") if status == "completed" else None,
     "url": html_url,
-    "observed_at": _now_iso(),
   }
   if payload.get("created_at"):
     next_check["started_at"] = payload["created_at"]
   if status == "completed" and payload.get("updated_at"):
     next_check["completed_at"] = payload["updated_at"]
   next_check.pop("message", None)
+  prior = {key: value for key, value in check.items() if key != "observed_at"}
+  current = {
+    key: value for key, value in next_check.items() if key != "observed_at"
+  }
+  if current == prior:
+    return check
+  next_check["observed_at"] = _now_iso()
   return next_check
 
 

--- a/backend/app/routes/github.py
+++ b/backend/app/routes/github.py
@@ -61,6 +61,7 @@ from app import (
   app_git,
   fs_locks,
   github_auth,
+  github_preflight_checks,
   models,
   source_status,
 )
@@ -820,6 +821,295 @@ async def contribution_review_status(
     "ready": sum(item["state"] == "ready" for item in results),
     "needs_refresh": sum(item["state"] == "needs_refresh" for item in results),
   }
+
+
+def _claim_prepared_checks(
+  *, app_id: int, record_id: str, db: Session, expected_nonce: str | None,
+) -> tuple[dict, Path, Path, str]:
+  record_path, diff_path = _record_paths(app_id, record_id)
+  _recheck_submit_app(db, app_id, expected_nonce)
+  record = _read_record(record_path)
+  if record.get("status") != "prepared":
+    raise HTTPException(
+      status_code=409,
+      detail="This contribution is no longer waiting for approval.",
+    )
+  if not github_preflight_checks.supports_prepared_checks(record):
+    raise HTTPException(
+      status_code=409,
+      detail=(
+        "Early GitHub checks are currently available for standalone Möbius "
+        "platform contributions only."
+      ),
+    )
+  if github_preflight_checks.check_is_active(record.get("early_checks")):
+    raise HTTPException(
+      status_code=409,
+      detail="GitHub checks are already starting or running for this review.",
+    )
+  request_id = secrets.token_hex(16)
+  requested_at = _now_iso()
+  claimed = {
+    **record,
+    "early_checks": {
+      "state": "dispatching",
+      "request_id": request_id,
+      "requested_at": requested_at,
+      "observed_at": requested_at,
+    },
+    "updated_at": requested_at,
+  }
+  _write_record(record_path, claimed)
+  return claimed, record_path, diff_path, request_id
+
+
+def _settle_prepared_checks(
+  *,
+  record_path: Path,
+  request_id: str,
+  record_patch: dict,
+  early_checks: dict,
+) -> dict:
+  current = _read_record(record_path)
+  live = current.get("early_checks")
+  if (
+    current.get("status") != "prepared"
+    or not isinstance(live, dict)
+    or live.get("request_id") != request_id
+  ):
+    raise HTTPException(
+      status_code=409,
+      detail="This contribution changed while GitHub checks were starting.",
+    )
+  now = _now_iso()
+  updated = {
+    **current,
+    **record_patch,
+    "early_checks": {
+      **early_checks,
+      "request_id": request_id,
+    },
+    "updated_at": now,
+  }
+  _write_record(record_path, updated)
+  return updated
+
+
+@router.post(
+  "/contributions/{app_id}/{record_id}/run-checks",
+  dependencies=[Depends(reject_cross_site)],
+)
+@_limiter.limit("10/minute")
+async def run_prepared_contribution_checks(
+  request: Request,
+  app_id: int,
+  record_id: str,
+  db: Session = Depends(get_db),
+  principal: Principal = Depends(get_principal),
+):
+  """Push one reviewed branch to the owner's fork and start Tests.
+
+  The owner confirms this action separately from Send. It never creates a pull
+  request, but it may create/update the personal fork, enable its allowlisted
+  Tests workflow, and push the exact reviewed branch before dispatching it.
+  """
+  expected_nonce = _validate_submit_app(app_id, principal, db)
+  db.close()
+  async with fs_locks.app_storage_lock(app_id):
+    claimed, record_path, diff_path, request_id = _claim_prepared_checks(
+      app_id=app_id,
+      record_id=record_id,
+      db=db,
+      expected_nonce=expected_nonce,
+    )
+  db.close()
+
+  plan = claimed.get("plan") or {}
+  repo_path = _safe_repo_path(plan.get("repo_path"))
+  try:
+    async with fs_locks.source_dir_lock(str(repo_path)):
+      early_checks, record_patch = await asyncio.to_thread(
+        github_preflight_checks.dispatch_prepared_checks,
+        claimed,
+        diff_path,
+        requested_at=str(
+          (claimed.get("early_checks") or {}).get("requested_at") or _now_iso()
+        ),
+      )
+  except ContributionSubmitError as exc:
+    patch = dict(exc.record_patch)
+    early_checks = patch.pop("early_checks", None)
+    if not isinstance(early_checks, dict):
+      early_checks = {
+        **(claimed.get("early_checks") or {}),
+        "state": "error",
+        "message": exc.message,
+        "observed_at": _now_iso(),
+      }
+    async with fs_locks.app_storage_lock(app_id):
+      _recheck_submit_app(db, app_id, expected_nonce)
+      db.close()
+      record = _settle_prepared_checks(
+        record_path=record_path,
+        request_id=request_id,
+        record_patch=patch,
+        early_checks=early_checks,
+      )
+    raise HTTPException(
+      status_code=exc.status_code,
+      detail={
+        "message": exc.message,
+        "detail": exc.detail,
+        "code": exc.code,
+        "record": record,
+      },
+    )
+  except Exception as exc:
+    log.exception("Prepared GitHub checks failed for %s/%s", app_id, record_id)
+    message = "Could not start GitHub checks for this contribution."
+    async with fs_locks.app_storage_lock(app_id):
+      _recheck_submit_app(db, app_id, expected_nonce)
+      db.close()
+      record = _settle_prepared_checks(
+        record_path=record_path,
+        request_id=request_id,
+        record_patch={},
+        early_checks={
+          **(claimed.get("early_checks") or {}),
+          "state": "error",
+          "message": message,
+          "observed_at": _now_iso(),
+        },
+      )
+    raise HTTPException(
+      status_code=500,
+      detail={"message": message, "record": record},
+    ) from exc
+
+  async with fs_locks.app_storage_lock(app_id):
+    _recheck_submit_app(db, app_id, expected_nonce)
+    db.close()
+    record = _settle_prepared_checks(
+      record_path=record_path,
+      request_id=request_id,
+      record_patch=record_patch,
+      early_checks=early_checks,
+    )
+  return {"record": record, "checks": record["early_checks"]}
+
+
+def _early_checks_notification(record: dict, checks: dict, app_id: int) -> dict:
+  title = str(record.get("title") or (record.get("plan") or {}).get("title")
+              or "A prepared contribution")
+  conclusion = str(checks.get("conclusion") or "").lower()
+  passed = conclusion in {"success", "neutral", "skipped"}
+  heading = "Early checks passed" if passed else "Early checks need attention"
+  run_url = str(checks.get("url") or "")
+  actions = [{
+    "action": "open-contribute",
+    "title": "Open Contribute",
+    "target": f"/shell/?app={app_id}",
+  }]
+  if run_url.startswith("https://github.com/"):
+    actions.append({
+      "action": "view-checks",
+      "title": "View GitHub run",
+      "target": run_url,
+    })
+  return {
+    "title": heading,
+    "body": title,
+    "target": f"/shell/?app={app_id}",
+    "actions": actions,
+  }
+
+
+@router.post(
+  "/contributions/{app_id}/prepared-checks/refresh",
+  dependencies=[Depends(reject_cross_site)],
+)
+@_limiter.limit("30/minute")
+async def refresh_prepared_contribution_checks(
+  request: Request,
+  app_id: int,
+  db: Session = Depends(get_db),
+  principal: Principal = Depends(get_principal),
+):
+  """Refresh active pre-PR workflow runs and notify once when each settles."""
+  _validate_submit_app(app_id, principal, db)
+  owner_id = principal.owner.id
+  db.close()
+  contribution_dir = _contributions_dir(app_id)
+  async with fs_locks.app_storage_lock(app_id):
+    candidates = []
+    if contribution_dir.exists():
+      for path in sorted(contribution_dir.glob("*.json"))[:500]:
+        record = _read_record_tolerant(path)
+        if (
+          record is not None
+          and github_preflight_checks.check_is_active(
+            record.get("early_checks")
+          )
+        ):
+          candidates.append((path, record))
+  if not candidates:
+    return {"refreshed": [], "notified": 0}
+
+  refreshed = []
+  for path, record in candidates:
+    try:
+      checks = await asyncio.to_thread(
+        github_preflight_checks.refresh_prepared_check, record,
+      )
+    except ContributionSubmitError as exc:
+      checks = {
+        **(record.get("early_checks") or {}),
+        "state": "error",
+        "message": exc.message,
+        "observed_at": _now_iso(),
+      }
+    if isinstance(checks, dict):
+      refreshed.append((path, record, checks))
+
+  results = []
+  notifications = []
+  async with fs_locks.app_storage_lock(app_id):
+    for path, prior, checks in refreshed:
+      current = _read_record_tolerant(path)
+      if current is None or current.get("status") != "prepared":
+        continue
+      current_checks = current.get("early_checks")
+      prior_checks = prior.get("early_checks")
+      if (
+        not isinstance(current_checks, dict)
+        or not isinstance(prior_checks, dict)
+        or current_checks.get("request_id") != prior_checks.get("request_id")
+      ):
+        continue
+      notify_key = ""
+      if checks.get("state") == "completed":
+        notify_key = f"completed:{checks.get('conclusion') or 'unknown'}"
+      elif checks.get("state") == "error":
+        notify_key = "error"
+      if notify_key and checks.get("notified") != notify_key:
+        checks = {**checks, "notified": notify_key}
+        notifications.append(_early_checks_notification(current, checks, app_id))
+      updated = {**current, "early_checks": checks, "updated_at": _now_iso()}
+      _write_record(path, updated)
+      results.append(updated)
+
+  for payload in notifications:
+    notify_owner(
+      db,
+      owner_id,
+      title=payload["title"],
+      body=payload["body"],
+      source_type="app",
+      source_id=str(app_id),
+      target=payload["target"],
+      actions=payload["actions"],
+    )
+  return {"refreshed": results, "notified": len(notifications)}
 
 
 # Paths touched by a stored diff, for the chat card's "what am I sending" list.

--- a/backend/app/routes/github.py
+++ b/backend/app/routes/github.py
@@ -924,9 +924,11 @@ async def run_prepared_contribution_checks(
     )
   db.close()
 
-  plan = claimed.get("plan") or {}
-  repo_path = _safe_repo_path(plan.get("repo_path"))
+  record_patch = {}
+  failure = None
   try:
+    plan = claimed.get("plan") or {}
+    repo_path = _safe_repo_path(plan.get("repo_path"))
     async with fs_locks.source_dir_lock(str(repo_path)):
       early_checks, record_patch = await asyncio.to_thread(
         github_preflight_checks.dispatch_prepared_checks,
@@ -937,8 +939,8 @@ async def run_prepared_contribution_checks(
         ),
       )
   except ContributionSubmitError as exc:
-    patch = dict(exc.record_patch)
-    early_checks = patch.pop("early_checks", None)
+    record_patch = dict(exc.record_patch)
+    early_checks = record_patch.pop("early_checks", None)
     if not isinstance(early_checks, dict):
       early_checks = {
         **(claimed.get("early_checks") or {}),
@@ -946,45 +948,21 @@ async def run_prepared_contribution_checks(
         "message": exc.message,
         "observed_at": _now_iso(),
       }
-    async with fs_locks.app_storage_lock(app_id):
-      _recheck_submit_app(db, app_id, expected_nonce)
-      db.close()
-      record = _settle_prepared_checks(
-        record_path=record_path,
-        request_id=request_id,
-        record_patch=patch,
-        early_checks=early_checks,
-      )
-    raise HTTPException(
-      status_code=exc.status_code,
-      detail={
-        "message": exc.message,
-        "detail": exc.detail,
-        "code": exc.code,
-        "record": record,
-      },
-    )
+    failure = (exc.status_code, {
+      "message": exc.message,
+      "detail": exc.detail,
+      "code": exc.code,
+    })
   except Exception as exc:
     log.exception("Prepared GitHub checks failed for %s/%s", app_id, record_id)
     message = "Could not start GitHub checks for this contribution."
-    async with fs_locks.app_storage_lock(app_id):
-      _recheck_submit_app(db, app_id, expected_nonce)
-      db.close()
-      record = _settle_prepared_checks(
-        record_path=record_path,
-        request_id=request_id,
-        record_patch={},
-        early_checks={
-          **(claimed.get("early_checks") or {}),
-          "state": "error",
-          "message": message,
-          "observed_at": _now_iso(),
-        },
-      )
-    raise HTTPException(
-      status_code=500,
-      detail={"message": message, "record": record},
-    ) from exc
+    early_checks = {
+      **(claimed.get("early_checks") or {}),
+      "state": "error",
+      "message": message,
+      "observed_at": _now_iso(),
+    }
+    failure = (500, {"message": message})
 
   async with fs_locks.app_storage_lock(app_id):
     _recheck_submit_app(db, app_id, expected_nonce)
@@ -995,33 +973,13 @@ async def run_prepared_contribution_checks(
       record_patch=record_patch,
       early_checks=early_checks,
     )
+  if failure is not None:
+    status_code, detail = failure
+    raise HTTPException(
+      status_code=status_code,
+      detail={**detail, "record": record},
+    )
   return {"record": record, "checks": record["early_checks"]}
-
-
-def _early_checks_notification(record: dict, checks: dict, app_id: int) -> dict:
-  title = str(record.get("title") or (record.get("plan") or {}).get("title")
-              or "A prepared contribution")
-  conclusion = str(checks.get("conclusion") or "").lower()
-  passed = conclusion in {"success", "neutral", "skipped"}
-  heading = "Early checks passed" if passed else "Early checks need attention"
-  run_url = str(checks.get("url") or "")
-  actions = [{
-    "action": "open-contribute",
-    "title": "Open Contribute",
-    "target": f"/shell/?app={app_id}",
-  }]
-  if run_url.startswith("https://github.com/"):
-    actions.append({
-      "action": "view-checks",
-      "title": "View GitHub run",
-      "target": run_url,
-    })
-  return {
-    "title": heading,
-    "body": title,
-    "target": f"/shell/?app={app_id}",
-    "actions": actions,
-  }
 
 
 @router.post(
@@ -1035,9 +993,8 @@ async def refresh_prepared_contribution_checks(
   db: Session = Depends(get_db),
   principal: Principal = Depends(get_principal),
 ):
-  """Refresh active pre-PR workflow runs and notify once when each settles."""
+  """Refresh active pre-PR workflow runs while Contribute is open."""
   _validate_submit_app(app_id, principal, db)
-  owner_id = principal.owner.id
   db.close()
   contribution_dir = _contributions_dir(app_id)
   async with fs_locks.app_storage_lock(app_id):
@@ -1053,7 +1010,7 @@ async def refresh_prepared_contribution_checks(
         ):
           candidates.append((path, record))
   if not candidates:
-    return {"refreshed": [], "notified": 0}
+    return {"refreshed": []}
 
   refreshed = []
   for path, record in candidates:
@@ -1072,7 +1029,6 @@ async def refresh_prepared_contribution_checks(
       refreshed.append((path, record, checks))
 
   results = []
-  notifications = []
   async with fs_locks.app_storage_lock(app_id):
     for path, prior, checks in refreshed:
       current = _read_record_tolerant(path)
@@ -1086,30 +1042,12 @@ async def refresh_prepared_contribution_checks(
         or current_checks.get("request_id") != prior_checks.get("request_id")
       ):
         continue
-      notify_key = ""
-      if checks.get("state") == "completed":
-        notify_key = f"completed:{checks.get('conclusion') or 'unknown'}"
-      elif checks.get("state") == "error":
-        notify_key = "error"
-      if notify_key and checks.get("notified") != notify_key:
-        checks = {**checks, "notified": notify_key}
-        notifications.append(_early_checks_notification(current, checks, app_id))
+      if checks == prior_checks:
+        continue
       updated = {**current, "early_checks": checks, "updated_at": _now_iso()}
       _write_record(path, updated)
       results.append(updated)
-
-  for payload in notifications:
-    notify_owner(
-      db,
-      owner_id,
-      title=payload["title"],
-      body=payload["body"],
-      source_type="app",
-      source_id=str(app_id),
-      target=payload["target"],
-      actions=payload["actions"],
-    )
-  return {"refreshed": results, "notified": len(notifications)}
+  return {"refreshed": results}
 
 
 # Paths touched by a stored diff, for the chat card's "what am I sending" list.

--- a/backend/tests/test_github_preflight_checks.py
+++ b/backend/tests/test_github_preflight_checks.py
@@ -1,0 +1,119 @@
+"""Focused contract tests for pre-PR GitHub workflow runs."""
+
+import json
+import subprocess
+
+import pytest
+
+from app.contribution_errors import ContributionSubmitError
+from app import github_preflight_checks as checks
+
+
+def _record(*, repo="mobius-os/mobius", status="prepared"):
+  return {
+    "type": "pr",
+    "status": status,
+    "repo": repo,
+    "plan": {
+      "action": "pr",
+      "repo": repo,
+      "branch": "fix/reviewed-change",
+    },
+  }
+
+
+def _cp(payload, returncode=0):
+  stdout = payload if isinstance(payload, str) else json.dumps(payload)
+  return subprocess.CompletedProcess([], returncode, stdout=stdout, stderr="")
+
+
+def test_support_is_narrow_and_active_states_are_explicit():
+  assert checks.supports_prepared_checks(_record())
+  assert not checks.supports_prepared_checks(_record(repo="mobius-os/app-demo"))
+  assert not checks.supports_prepared_checks(_record(status="open"))
+  stacked = _record()
+  stacked["plan"]["stack"] = {"id": "stack-1"}
+  assert not checks.supports_prepared_checks(stacked)
+
+  assert checks.check_is_active({"state": "dispatching"})
+  assert checks.check_is_active({"state": "uncertain"})
+  assert checks.check_is_active({"state": "queued"})
+  assert checks.check_is_active({"state": "in_progress"})
+  assert not checks.check_is_active({"state": "completed"})
+  assert checks.check_failed({"state": "completed", "conclusion": "failure"})
+  assert not checks.check_failed({"state": "completed", "conclusion": "success"})
+
+
+def test_bootstrap_requires_manual_trigger_on_upstream(monkeypatch, tmp_path):
+  calls = []
+
+  def fake_git(repo, *args, check=True):
+    calls.append((repo, args, check))
+    return _cp("on:\n  pull_request:\n")
+
+  monkeypatch.setattr(checks._git_ops, "_git", fake_git)
+  with pytest.raises(ContributionSubmitError) as failure:
+    checks._assert_upstream_workflow_dispatchable(
+      tmp_path, upstream_sha="a" * 40, workflow="test.yml",
+    )
+  assert failure.value.code == "early_checks_unavailable"
+  assert "one-time bootstrap" in failure.value.message
+  assert calls[0][1] == (
+    "show", f"{'a' * 40}:.github/workflows/test.yml",
+  )
+
+
+def test_dispatch_response_without_run_identity_is_uncertain(
+  monkeypatch, tmp_path,
+):
+  monkeypatch.setattr(
+    checks, "_api", lambda *args, **kwargs: _cp({"message": "Accepted"}),
+  )
+  with pytest.raises(ContributionSubmitError) as failure:
+    checks._dispatch_workflow(
+      tmp_path,
+      fork_slug="octocat/mobius",
+      workflow="test.yml",
+      branch="fix/reviewed-change",
+    )
+  assert failure.value.code == "early_checks_uncertain"
+
+
+def test_exact_workflow_run_snapshot_rejects_the_wrong_head():
+  check = {
+    "head_sha": "a" * 40,
+    "branch": "fix/reviewed-change",
+  }
+  payload = {
+    "event": "workflow_dispatch",
+    "head_sha": "b" * 40,
+    "head_branch": "fix/reviewed-change",
+    "html_url": "https://github.com/octocat/mobius/actions/runs/4",
+    "status": "completed",
+    "conclusion": "success",
+  }
+  with pytest.raises(ContributionSubmitError):
+    checks._run_snapshot(payload, check)
+
+
+def test_exact_workflow_run_snapshot_preserves_terminal_result():
+  check = {
+    "head_sha": "a" * 40,
+    "branch": "fix/reviewed-change",
+    "message": "old transport warning",
+  }
+  payload = {
+    "event": "workflow_dispatch",
+    "head_sha": "a" * 40,
+    "head_branch": "fix/reviewed-change",
+    "html_url": "https://github.com/octocat/mobius/actions/runs/4",
+    "status": "completed",
+    "conclusion": "failure",
+    "created_at": "2026-08-02T14:00:00Z",
+    "updated_at": "2026-08-02T14:03:00Z",
+  }
+  snapshot = checks._run_snapshot(payload, check)
+  assert snapshot["state"] == "completed"
+  assert snapshot["conclusion"] == "failure"
+  assert snapshot["completed_at"] == payload["updated_at"]
+  assert "message" not in snapshot

--- a/backend/tests/test_github_preflight_checks.py
+++ b/backend/tests/test_github_preflight_checks.py
@@ -40,8 +40,6 @@ def test_support_is_narrow_and_active_states_are_explicit():
   assert checks.check_is_active({"state": "queued"})
   assert checks.check_is_active({"state": "in_progress"})
   assert not checks.check_is_active({"state": "completed"})
-  assert checks.check_failed({"state": "completed", "conclusion": "failure"})
-  assert not checks.check_failed({"state": "completed", "conclusion": "success"})
 
 
 def test_bootstrap_requires_manual_trigger_on_upstream(monkeypatch, tmp_path):
@@ -117,3 +115,25 @@ def test_exact_workflow_run_snapshot_preserves_terminal_result():
   assert snapshot["conclusion"] == "failure"
   assert snapshot["completed_at"] == payload["updated_at"]
   assert "message" not in snapshot
+
+
+def test_unchanged_workflow_snapshot_reuses_the_stored_state():
+  check = {
+    "head_sha": "a" * 40,
+    "branch": "fix/reviewed-change",
+    "state": "in_progress",
+    "conclusion": None,
+    "url": "https://github.com/octocat/mobius/actions/runs/4",
+    "started_at": "2026-08-02T14:00:00Z",
+    "observed_at": "2026-08-02T14:01:00Z",
+  }
+  payload = {
+    "event": "workflow_dispatch",
+    "head_sha": check["head_sha"],
+    "head_branch": check["branch"],
+    "html_url": check["url"],
+    "status": "in_progress",
+    "conclusion": None,
+    "created_at": check["started_at"],
+  }
+  assert checks._run_snapshot(payload, check) is check

--- a/backend/tests/test_github_routes.py
+++ b/backend/tests/test_github_routes.py
@@ -27,7 +27,8 @@ import pytest
 from fastapi import HTTPException
 from fastapi.responses import Response
 
-from app import github_auth, source_status
+from app import github_auth, github_preflight_checks, source_status
+from app.contribution_errors import ContributionSubmitError
 from app.config import get_settings
 from app.database import checked_out_connections
 from app.storage_io import atomic_write
@@ -1261,6 +1262,186 @@ def _prepared_real_review(app_id, record_id):
   }
   _write_contribution(app_id, record_id, record, diff_text)
   return repo, record, diff_text
+
+
+def _prepared_platform_review(app_id, record_id):
+  """Build the supported standalone platform variant of a real review."""
+  repo, record, diff_text = _prepared_real_review(app_id, record_id)
+  record = {
+    **record,
+    "repo": "mobius-os/mobius",
+    "plan": {**record["plan"], "repo": "mobius-os/mobius"},
+  }
+  _write_contribution(app_id, record_id, record, diff_text)
+  return repo, record, diff_text
+
+
+def test_run_prepared_checks_persists_exact_run_and_blocks_duplicates(
+  client, owner_token, monkeypatch,
+):
+  _write_token(login="octocat", user_id=42, scopes=("public_repo", "workflow"))
+  app_id, app_token = _app_token(client, owner_token, github_access=True)
+  _repo, _record, _diff = _prepared_platform_review(
+    app_id, "early-check-success",
+  )
+
+  def fake_dispatch(record, diff_path, *, requested_at):
+    assert record["early_checks"]["state"] == "dispatching"
+    assert diff_path.name == "early-check-success.diff"
+    assert requested_at == record["early_checks"]["requested_at"]
+    return ({
+      "state": "queued",
+      "run_id": 734,
+      "url": "https://github.com/octocat/mobius/actions/runs/734",
+      "fork_repo": "octocat/mobius",
+      "branch": "fix/demo-review",
+      "head_sha": record["plan"]["head_sha"],
+      "workflow": "test.yml",
+      "requested_at": requested_at,
+      "observed_at": requested_at,
+    }, {"last_submit_push_sha": record["plan"]["head_sha"]})
+
+  monkeypatch.setattr(
+    github_preflight_checks, "dispatch_prepared_checks", fake_dispatch,
+  )
+  headers = {"Authorization": f"Bearer {app_token}"}
+  response = client.post(
+    f"/api/github/contributions/{app_id}/early-check-success/run-checks",
+    headers=headers,
+  )
+  assert response.status_code == 200, response.text
+  record = response.json()["record"]
+  assert record["status"] == "prepared"
+  assert record["early_checks"]["state"] == "queued"
+  assert record["early_checks"]["run_id"] == 734
+  assert record["early_checks"]["request_id"]
+  assert record["last_submit_push_sha"] == record["plan"]["head_sha"]
+
+  duplicate = client.post(
+    f"/api/github/contributions/{app_id}/early-check-success/run-checks",
+    headers=headers,
+  )
+  assert duplicate.status_code == 409
+  assert "already" in duplicate.json()["detail"].lower()
+
+
+def test_run_prepared_checks_keeps_recoverable_failure_on_the_record(
+  client, owner_token, monkeypatch,
+):
+  _write_token(login="octocat", user_id=42, scopes=("public_repo", "workflow"))
+  app_id, app_token = _app_token(client, owner_token, github_access=True)
+  _repo, record, _diff = _prepared_platform_review(
+    app_id, "early-check-error",
+  )
+
+  def fake_dispatch(_record, _diff_path, *, requested_at):
+    raise ContributionSubmitError(
+      "GitHub could not start Tests.",
+      status_code=409,
+      code="early_checks_dispatch_failed",
+      record_patch={
+        "last_submit_push_sha": record["plan"]["head_sha"],
+        "early_checks": {
+          "state": "error",
+          "message": "GitHub could not start Tests.",
+          "requested_at": requested_at,
+          "observed_at": requested_at,
+        },
+      },
+    )
+
+  monkeypatch.setattr(
+    github_preflight_checks, "dispatch_prepared_checks", fake_dispatch,
+  )
+  response = client.post(
+    f"/api/github/contributions/{app_id}/early-check-error/run-checks",
+    headers={"Authorization": f"Bearer {app_token}"},
+  )
+  assert response.status_code == 409, response.text
+  stored = response.json()["detail"]["record"]
+  assert stored["status"] == "prepared"
+  assert stored["early_checks"]["state"] == "error"
+  assert stored["early_checks"]["request_id"]
+  assert stored["last_submit_push_sha"] == record["plan"]["head_sha"]
+
+
+def test_refresh_prepared_checks_notifies_once_when_the_exact_run_settles(
+  client, owner_token, monkeypatch,
+):
+  _write_token(login="octocat", user_id=42, scopes=("public_repo", "workflow"))
+  app_id, app_token = _app_token(client, owner_token, github_access=True)
+  _repo, record, diff_text = _prepared_platform_review(
+    app_id, "early-check-refresh",
+  )
+  record["early_checks"] = {
+    "state": "in_progress",
+    "request_id": "request-1",
+    "run_id": 735,
+    "url": "https://github.com/octocat/mobius/actions/runs/735",
+    "fork_repo": "octocat/mobius",
+    "branch": record["plan"]["branch"],
+    "head_sha": record["plan"]["head_sha"],
+  }
+  _write_contribution(app_id, "early-check-refresh", record, diff_text)
+
+  def fake_refresh(_record):
+    return {
+      **_record["early_checks"],
+      "state": "completed",
+      "conclusion": "success",
+      "completed_at": "2026-08-02T15:00:00Z",
+    }
+
+  notifications = []
+  monkeypatch.setattr(
+    github_preflight_checks, "refresh_prepared_check", fake_refresh,
+  )
+  monkeypatch.setattr(
+    github_routes, "notify_owner",
+    lambda *args, **kwargs: notifications.append(kwargs),
+  )
+  headers = {"Authorization": f"Bearer {app_token}"}
+  url = f"/api/github/contributions/{app_id}/prepared-checks/refresh"
+  response = client.post(url, headers=headers)
+  assert response.status_code == 200, response.text
+  assert response.json()["notified"] == 1
+  assert response.json()["refreshed"][0]["early_checks"]["notified"] == (
+    "completed:success"
+  )
+  assert notifications[0]["title"] == "Early checks passed"
+
+  repeat = client.post(url, headers=headers)
+  assert repeat.status_code == 200
+  assert repeat.json() == {"refreshed": [], "notified": 0}
+  assert len(notifications) == 1
+
+
+def test_send_waits_while_prepared_checks_are_active(client, owner_token):
+  _write_token(login="octocat", user_id=42, scopes=("public_repo", "workflow"))
+  app_id, app_token = _app_token(client, owner_token, github_access=True)
+  _repo, record, diff_text = _prepared_platform_review(
+    app_id, "early-check-send-lock",
+  )
+  record["early_checks"] = {
+    "state": "queued",
+    "request_id": "request-2",
+    "run_id": 736,
+  }
+  _write_contribution(app_id, "early-check-send-lock", record, diff_text)
+
+  response = client.post(
+    f"/api/github/contributions/{app_id}/early-check-send-lock/submit",
+    headers={"Authorization": f"Bearer {app_token}"},
+  )
+  assert response.status_code == 409
+  assert "starting or running" in response.json()["detail"].lower()
+
+  stored = json.loads(
+    (Path(get_settings().data_dir) / "apps" / str(app_id) /
+     "contributions" / "early-check-send-lock.json").read_text()
+  )
+  assert stored["status"] == "prepared"
+  assert stored["early_checks"]["state"] == "queued"
 
 
 def test_review_status_catches_local_drift_before_send(

--- a/backend/tests/test_github_routes.py
+++ b/backend/tests/test_github_routes.py
@@ -1365,7 +1365,29 @@ def test_run_prepared_checks_keeps_recoverable_failure_on_the_record(
   assert stored["last_submit_push_sha"] == record["plan"]["head_sha"]
 
 
-def test_refresh_prepared_checks_notifies_once_when_the_exact_run_settles(
+def test_run_prepared_checks_settles_an_invalid_checkout_claim(
+  client, owner_token,
+):
+  _write_token(login="octocat", user_id=42, scopes=("public_repo", "workflow"))
+  app_id, app_token = _app_token(client, owner_token, github_access=True)
+  _repo, record, diff_text = _prepared_platform_review(
+    app_id, "early-check-invalid-path",
+  )
+  record["plan"]["repo_path"] = ""
+  _write_contribution(app_id, "early-check-invalid-path", record, diff_text)
+
+  response = client.post(
+    f"/api/github/contributions/{app_id}/early-check-invalid-path/run-checks",
+    headers={"Authorization": f"Bearer {app_token}"},
+  )
+  assert response.status_code == 409, response.text
+  stored = response.json()["detail"]["record"]
+  assert stored["status"] == "prepared"
+  assert stored["early_checks"]["state"] == "error"
+  assert "durable repo_path" in stored["early_checks"]["message"]
+
+
+def test_refresh_prepared_checks_persists_the_exact_terminal_run(
   client, owner_token, monkeypatch,
 ):
   _write_token(login="octocat", user_id=42, scopes=("public_repo", "workflow"))
@@ -1392,28 +1414,20 @@ def test_refresh_prepared_checks_notifies_once_when_the_exact_run_settles(
       "completed_at": "2026-08-02T15:00:00Z",
     }
 
-  notifications = []
   monkeypatch.setattr(
     github_preflight_checks, "refresh_prepared_check", fake_refresh,
-  )
-  monkeypatch.setattr(
-    github_routes, "notify_owner",
-    lambda *args, **kwargs: notifications.append(kwargs),
   )
   headers = {"Authorization": f"Bearer {app_token}"}
   url = f"/api/github/contributions/{app_id}/prepared-checks/refresh"
   response = client.post(url, headers=headers)
   assert response.status_code == 200, response.text
-  assert response.json()["notified"] == 1
-  assert response.json()["refreshed"][0]["early_checks"]["notified"] == (
-    "completed:success"
+  assert response.json()["refreshed"][0]["early_checks"]["conclusion"] == (
+    "success"
   )
-  assert notifications[0]["title"] == "Early checks passed"
 
   repeat = client.post(url, headers=headers)
   assert repeat.status_code == 200
-  assert repeat.json() == {"refreshed": [], "notified": 0}
-  assert len(notifications) == 1
+  assert repeat.json() == {"refreshed": []}
 
 
 def test_send_waits_while_prepared_checks_are_active(client, owner_token):

--- a/backend/tests/test_verify_test_runtime.py
+++ b/backend/tests/test_verify_test_runtime.py
@@ -545,7 +545,7 @@ def test_documented_browser_commands_use_disposable_runner():
   assert '/home/' not in test_script
 
 
-def test_pull_requests_run_required_suites_and_cutover_publishes_immutable_image():
+def test_manual_and_pull_request_runs_cover_suites_and_cutover_image():
   test_workflow = (ROOT / ".github" / "workflows" / "test.yml").read_text(
     encoding="utf-8"
   )
@@ -565,6 +565,7 @@ def test_pull_requests_run_required_suites_and_cutover_publishes_immutable_image
   e2e = test_workflow.split("\n  e2e:\n", 1)[1]
 
   assert "pull_request:\n" in test_triggers
+  assert "workflow_dispatch:\n" in test_triggers
   assert "push:\n" not in test_triggers
   assert "'feat/**'" not in test_triggers
   assert "'fix/**'" not in test_triggers


### PR DESCRIPTION
## Summary
- add a manual dispatch entry point to the complete Tests workflow
- let Contribute push the exact reviewed branch to a personal fork, start that workflow without opening a pull request, and track the exact run
- preserve ambiguous outcomes durably and refresh the active run while Contribute is open
- reuse unchanged run snapshots and rely on GitHub's personal completion notification instead of duplicate scheduled polling and pushes
- document the command-line equivalent and the one-time bootstrap condition

## Safety
- the action is separate from Send and never opens a pull request, comments, mentions a team, or emails the organization
- only standalone `mobius-os/mobius` reviews and the allowlisted Tests workflow are supported
- durable claims plus exact diff, branch, SHA, event, and run checks prevent duplicate or mismatched actions

## Bootstrap
This pull request adds the manual trigger itself, so it must use the ordinary pull-request path once. Pre-PR runs become available after `workflow_dispatch` reaches upstream `main`.

## Tests
- `scripts/wt-pytest.sh tests/test_github_preflight_checks.py tests/test_github_routes.py -q`
- `scripts/test.sh --fast`
