### PR TITLE
Keep drawer close interactions on their originating gesture

### DIFF
--- a/frontend/src/components/Drawer/Drawer.css
+++ b/frontend/src/components/Drawer/Drawer.css
@@ -26,23 +26,43 @@
   transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
 }
 
-/* `open` becomes false when the close transition STARTS, not when the panel
-   has left the viewport. Keep the fading scrim as the touch/pointer owner until
-   Drawer.jsx observes the panel's transform transitionend (or its fallback),
-   so the app behind never becomes interactive beneath visible drawer pixels. */
-.drawer-overlay--blocking {
+/* The full scrim owns outside taps only while the drawer is open. Once closing
+   starts, the geometry-matched shield below follows the remaining panel pixels
+   instead of leaving an invisible full-screen dead zone over the workspace. */
+.drawer-overlay--visible.drawer-overlay--blocking {
   pointer-events: auto;
 }
 
-/* ── Panel ─────────────────────────────────────────── */
-
+.drawer-close-shield,
 .drawer {
   position: fixed;
   top: calc(58px + env(safe-area-inset-top));
   left: 0;
   bottom: 0;
-  z-index: 95;
   width: min(360px, 90vw);
+}
+
+.drawer-close-shield {
+  z-index: 94;
+  pointer-events: none;
+  touch-action: none;
+  transform: translateX(-100%);
+}
+
+.drawer-close-shield--active {
+  pointer-events: auto;
+  animation: drawer-close-shield 100ms cubic-bezier(0.3, 0.6, 0.6, 1) both;
+}
+
+@keyframes drawer-close-shield {
+  from { transform: translateX(var(--drawer-close-start-x, 0px)); }
+  to { transform: translateX(-100%); }
+}
+
+/* ── Panel ─────────────────────────────────────────── */
+
+.drawer {
+  z-index: 95;
   background: var(--bg);
   border-right: 1px solid var(--border-light);
   display: flex;
@@ -737,6 +757,7 @@
 @media (prefers-reduced-motion: reduce) {
   .drawer,
   .drawer-overlay { transition: none; }
+  .drawer-close-shield { animation: none; }
   .drawer__item-action-menu { animation: none; }
   .drawer__item { transition: none; }
 }

--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -335,6 +335,12 @@ export default function Drawer({
   // behind) so outside-tap cancellation sees the current edit immediately.
   const renamingRef = useRef(null)
   const overlayCancelRef = useRef(false)
+  // Closing on pointerdown makes the drawer feel immediate, but WebKit may
+  // retarget the compatibility click from that same touch to content revealed
+  // beneath the scrim. Keep ownership of exactly that click. A new pointer or
+  // keyboard activation clears a stale claim first, so a touch sequence that
+  // produces no click cannot poison the owner's next action.
+  const outsideDismissClickRef = useRef(false)
   const renaming = renamingState
   const setRenaming = useCallback((next) => {
     renamingRef.current = next
@@ -459,9 +465,34 @@ export default function Drawer({
       renamingRef.current = null
       setRenaming(null)
     }
+    outsideDismissClickRef.current = true
     e.preventDefault()
+    e.stopPropagation()
     onClose?.()
   }
+
+  useEffect(() => {
+    function releaseStaleDismissClaim() {
+      outsideDismissClickRef.current = false
+    }
+    function consumeOutsideDismissClick(e) {
+      if (!outsideDismissClickRef.current) return
+      outsideDismissClickRef.current = false
+      e.preventDefault()
+      e.stopPropagation()
+    }
+    // Capture sees a new activation before the overlay's bubble handler can
+    // claim its own pointerdown. The click listener then catches both an
+    // ordinary scrim click and WebKit's retargeted compatibility click.
+    document.addEventListener('pointerdown', releaseStaleDismissClaim, true)
+    document.addEventListener('keydown', releaseStaleDismissClaim, true)
+    document.addEventListener('click', consumeOutsideDismissClick, true)
+    return () => {
+      document.removeEventListener('pointerdown', releaseStaleDismissClaim, true)
+      document.removeEventListener('keydown', releaseStaleDismissClaim, true)
+      document.removeEventListener('click', consumeOutsideDismissClick, true)
+    }
+  }, [])
 
   const queryClient = useQueryClient()
 
@@ -595,6 +626,7 @@ export default function Drawer({
   // drawer was dismissed (Escape, overlay tap, swipe).
   const previousFocusRef = useRef(null)
   const drawerRef = useRef(null)
+  const closeShieldRef = useRef(null)
   useEffect(() => {
     if (persistent) {
       previousFocusRef.current = null
@@ -688,14 +720,17 @@ export default function Drawer({
     drawerGestureRef.current = null
   }, [open, persistent])
 
-  // Keep the scrim hit-testable while the panel is sliding away. `open` flips
-  // false at the START of the 250ms close transition; dropping pointer-events
-  // in that same render exposes the chat/app while drawer pixels are still on
-  // screen. transitionend is the normal release, with a timeout fallback for
-  // reduced-motion or an interrupted compositor transition.
+  // Keep only the panel's still-visible footprint hit-testable while it slides
+  // away. The full-screen visual scrim stops owning input as soon as close is
+  // acknowledged; a geometry-matched shield follows the panel until its
+  // transition ends. This keeps uncovered controls live without allowing taps
+  // through visible drawer pixels.
   const [scrimBlocking, setScrimBlocking] = useState(open && !persistent)
   useLayoutEffect(() => {
-    if (open && !persistent) setScrimBlocking(true)
+    if (open && !persistent) {
+      closeShieldRef.current?.style.setProperty('--drawer-close-start-x', '0px')
+      setScrimBlocking(true)
+    }
     if (persistent) setScrimBlocking(false)
   }, [open, persistent])
   useLayoutEffect(() => {
@@ -717,6 +752,11 @@ export default function Drawer({
     const width = e.currentTarget.getBoundingClientRect().width
     const x = new DOMMatrixReadOnly(getComputedStyle(e.currentTarget).transform).m41
     if (x > -width + 1) return
+    setScrimBlocking(false)
+  }
+
+  function handleCloseShieldAnimationEnd(e) {
+    if (open || e.target !== e.currentTarget || e.animationName !== 'drawer-close-shield') return
     setScrimBlocking(false)
   }
 
@@ -763,7 +803,9 @@ export default function Drawer({
     el.classList.add('drawer--dragging')
     // Clamp to [-320, 0]: a finger that drifts back past the origin must not
     // drag an already-open panel further right than open.
-    el.style.transform = `translateX(${Math.min(0, Math.max(dx, -320))}px)`
+    const clampedX = Math.min(0, Math.max(dx, -320))
+    el.style.transform = `translateX(${clampedX}px)`
+    closeShieldRef.current?.style.setProperty('--drawer-close-start-x', `${clampedX}px`)
   }
   function onDrawerPointerUp(e) {
     // If the controller took over, it owns pointerup too — do nothing here.
@@ -793,6 +835,7 @@ export default function Drawer({
         // the .drawer--open class's translateX(0) take over with
         // the transition running from the drag position.
         el.style.transform = ''
+        closeShieldRef.current?.style.setProperty('--drawer-close-start-x', '0px')
       }
     }
     const suppressGeneratedClick = shouldSuppressDrawerSwipeClick({
@@ -815,6 +858,7 @@ export default function Drawer({
     const gesture = drawerGestureRef.current
     if (gesture && e.pointerId !== gesture.pointerId) return
     clearDrawerGestureStyles(drawerRef.current)
+    closeShieldRef.current?.style.setProperty('--drawer-close-start-x', '0px')
     drawerGestureRef.current = null
     // pointercancel means the browser owns the gesture (normally native pan-y).
     // It must never leave a click guard behind for a later destination tap.
@@ -906,10 +950,18 @@ export default function Drawer({
   return (
     <>
       {!persistent && (
-        <div
-          className={`drawer-overlay${open ? ' drawer-overlay--visible' : ''}${scrimBlocking ? ' drawer-overlay--blocking' : ''}`}
-          onPointerDown={handleOverlayPointerDown}
-        />
+        <>
+          <div
+            className={`drawer-overlay${open ? ' drawer-overlay--visible' : ''}${scrimBlocking ? ' drawer-overlay--blocking' : ''}`}
+            onPointerDown={handleOverlayPointerDown}
+          />
+          <div
+            ref={closeShieldRef}
+            className={`drawer-close-shield${!open && scrimBlocking ? ' drawer-close-shield--active' : ''}`}
+            aria-hidden="true"
+            onAnimationEnd={handleCloseShieldAnimationEnd}
+          />
+        </>
       )}
       {/* React 19 reflects the boolean `inert` prop to the boolean
           attribute (present when true, absent when false), so a closed

--- a/frontend/src/hooks/useNavigation.js
+++ b/frontend/src/hooks/useNavigation.js
@@ -280,6 +280,11 @@ export default function useNavigation({
   // pending flag must not brick the drawer forever: openDrawer reconciles from
   // the classic History store once the traversal is provably stale.
   const drawerClosePendingAtRef = useRef(0)
+  // A first open press while close bookkeeping still traverses history is
+  // intent, not noise. Keep it until the close settles; a bounded retry reuses
+  // stale-close recovery if WebKit loses the traversal completely.
+  const drawerOpenAfterCloseRef = useRef(false)
+  const drawerOpenAfterCloseTimerRef = useRef(0)
   // Per-(pane, app) pending nav-sentinel counts installed via the
   // moebius:nav-push postMessage protocol. Keyed by ownerKeyOf(paneId, appId).
   const appSentinelCountsRef = useRef(new Map())
@@ -549,6 +554,20 @@ export default function useNavigation({
     historyDismissalsRef.current.delete(entryId)
   }, [])
 
+  function clearDrawerOpenAfterClose() {
+    drawerOpenAfterCloseRef.current = false
+    if (drawerOpenAfterCloseTimerRef.current) {
+      clearTimeout(drawerOpenAfterCloseTimerRef.current)
+      drawerOpenAfterCloseTimerRef.current = 0
+    }
+  }
+
+  useEffect(() => () => {
+    if (drawerOpenAfterCloseTimerRef.current) {
+      clearTimeout(drawerOpenAfterCloseTimerRef.current)
+    }
+  }, [])
+
   function openDrawer() {
     // Stand down while a workspace drag is live — symmetric to the Drawer's
     // swipe-CLOSE handlers (both touch and pointer). A tab dragged toward the
@@ -570,9 +589,18 @@ export default function useNavigation({
     // push). Otherwise the traversal landed but its consumption never reached
     // handleBack — clear the stranded flags and open fresh.
     if (drawerClosePendingRef.current) {
-      if (Date.now() - drawerClosePendingAtRef.current < DRAWER_CLOSE_TRAVERSAL_GRACE_MS) {
+      const elapsed = Date.now() - drawerClosePendingAtRef.current
+      if (elapsed < DRAWER_CLOSE_TRAVERSAL_GRACE_MS) {
+        drawerOpenAfterCloseRef.current = true
+        if (!drawerOpenAfterCloseTimerRef.current) {
+          drawerOpenAfterCloseTimerRef.current = setTimeout(() => {
+            drawerOpenAfterCloseTimerRef.current = 0
+            if (drawerOpenAfterCloseRef.current) openDrawer()
+          }, DRAWER_CLOSE_TRAVERSAL_GRACE_MS - elapsed)
+        }
         return
       }
+      clearDrawerOpenAfterClose()
       drawerClosePendingRef.current = false
       if (drawerPushedRef.current
           && isMobiusNavState(history.state) && history.state.kind === 'drawer') {
@@ -593,6 +621,7 @@ export default function useNavigation({
       drawerOpenAfterLocalPopRef.current = true
       return
     }
+    clearDrawerOpenAfterClose()
     pushShellEntry('drawer', snapshotRoute())
     drawerPushedRef.current = true
     // Advance the ref synchronously so a same-batch open→close sees "open" and
@@ -607,6 +636,7 @@ export default function useNavigation({
     // skip past the drawer's sentinel before the first traversal settles.
     if (!drawerOpenRef.current || drawerClosePendingRef.current) return
     if (drawerPushedRef.current) {
+      clearDrawerOpenAfterClose()
       drawerClosePendingRef.current = true
       drawerClosePendingAtRef.current = Date.now()
       // A tap/swipe close should acknowledge immediately. Keep the logical ref
@@ -624,6 +654,7 @@ export default function useNavigation({
     } else {
       // Defensive: drawer open without a sentinel (shouldn't happen
       // in normal flow). Just close it directly.
+      clearDrawerOpenAfterClose()
       drawerOpenRef.current = false
       drawerClosePendingRef.current = false
       setDrawerVisible(false)
@@ -1190,6 +1221,7 @@ export default function useNavigation({
       // drawerOpenRef stuck true behind an already-hidden panel, which then refused
       // every subsequent open.
       if (drawerClosePendingRef.current) {
+        clearDrawerOpenAfterClose()
         drawerClosePendingRef.current = false
         drawerOpenRef.current = false
       }
@@ -1373,13 +1405,22 @@ export default function useNavigation({
     }
 
     function handleBack(destination, source) {
-      backFiredRef.current = true
-      setTimeout(() => { backFiredRef.current = false }, 400)
+      // Android can synthesize a delayed logo click after a PHYSICAL Back
+      // gesture. closeDrawer also traverses history, but that traversal is our
+      // own bookkeeping: arming the same guard there made a quick post-swipe
+      // iOS tap disappear when WebKit delivered click without pointerdown.
+      if (!drawerClosePendingRef.current) {
+        backFiredRef.current = true
+        setTimeout(() => { backFiredRef.current = false }, 400)
+      }
       const closeDrawerNextFrame = () => {
+        const closeIfStillClosed = () => {
+          if (!drawerOpenRef.current) setDrawerVisible(false)
+        }
         if (typeof requestAnimationFrame === 'function') {
-          requestAnimationFrame(() => setDrawerVisible(false))
+          requestAnimationFrame(closeIfStillClosed)
         } else {
-          setDrawerVisible(false)
+          closeIfStillClosed()
         }
       }
       // (1) A transient dismissible consumes Back before any shell route. The
@@ -1395,12 +1436,17 @@ export default function useNavigation({
       // the drawer only — never pops navStack. Catches real back-gestures on a
       // drawer-open view AND closeDrawer's history.back().
       if (drawerOpenRef.current && drawerPushedRef.current) {
+        const reopenAfterClose = drawerOpenAfterCloseRef.current
+        clearDrawerOpenAfterClose()
         drawerPushedRef.current = false
         drawerClosePendingRef.current = false
         drawerOpenRef.current = false
-        closeDrawerNextFrame()
+        if (!reopenAfterClose) closeDrawerNextFrame()
         appLocalPopInFlightRef.current = false
-        setTimeout(resumeLocalAppPops, 0)
+        setTimeout(() => {
+          if (reopenAfterClose) openDrawer()
+          resumeLocalAppPops()
+        }, 0)
         return
       }
       const sourceEntryId = source?.kind === 'app' ? navEntryId(source) : null
@@ -1510,6 +1556,7 @@ export default function useNavigation({
       // (5) Plain route: pop navStack and restore into the hinted (else focused)
       // pane. The route payload is the compatibility fallback for a tagged entry
       // whose in-memory stack was lost.
+      clearDrawerOpenAfterClose()
       drawerPushedRef.current = false
       drawerClosePendingRef.current = false
       drawerOpenRef.current = false

--- a/frontend/src/lib/__tests__/navigationWorkspaceContract.test.js
+++ b/frontend/src/lib/__tests__/navigationWorkspaceContract.test.js
@@ -42,10 +42,13 @@ test('a pending drawer close consumes its tagged source before direction fallbac
   assert.ok(pending >= 0 && guard > pending,
     'an unresolved traversal is resolved or blocks another open before the ordinary open guard')
   const pendingBlock = open.slice(pending, guard)
-  // Within the grace window the original serialization holds: the open returns
-  // while the close's history cursor may still legitimately be moving.
-  assert.match(pendingBlock, /DRAWER_CLOSE_TRAVERSAL_GRACE_MS[\s\S]{0,80}?return/,
-    'a fresh pending close still blocks the open')
+  // Within the grace window serialization still wins, but the activation is
+  // retained and replayed instead of being discarded.
+  assert.match(
+    pendingBlock,
+    /drawerOpenAfterCloseRef\.current = true[\s\S]*DRAWER_CLOSE_TRAVERSAL_GRACE_MS - elapsed[\s\S]*return/,
+    'a fresh pending close queues rather than discards the first open',
+  )
   // Re-adopting the sentinel after a LOST traversal requires classic-store
   // proof that the cursor never left it — never the boolean alone.
   assert.match(
@@ -68,7 +71,7 @@ test('a pending drawer close consumes its tagged source before direction fallbac
   // Whoever else resolves the drawer's history state clears the pending flag too,
   // so a later open cannot remain latched behind a hidden panel.
   assert.match(navigation, /drawerClosePendingRef\.current = false\s*\n\s*drawerOpenRef\.current = false\s*\n\s*setDrawerVisible\(false\)/)
-  assert.match(navigation, /function handleForward\([^)]*\) \{\s*\/\/[\s\S]*?if \(drawerClosePendingRef\.current\) \{\s*drawerClosePendingRef\.current = false\s*drawerOpenRef\.current = false/)
+  assert.match(navigation, /function handleForward\([^)]*\) \{\s*\/\/[\s\S]*?if \(drawerClosePendingRef\.current\) \{\s*clearDrawerOpenAfterClose\(\)\s*drawerClosePendingRef\.current = false\s*drawerOpenRef\.current = false/)
 })
 
 test('an explicit drawer close starts visually before consuming its history sentinel', () => {

--- a/tests/navigation.spec.mjs
+++ b/tests/navigation.spec.mjs
@@ -1129,20 +1129,53 @@ test.describe('Drawer close paths converge through handleBack', () => {
     expect(calls).toBe(1)
   })
 
-  test('22. Pointer-down on overlay closes drawer (does not navigate)', async ({ page }) => {
+  test('22. Outside press closes drawer without activating revealed content', async ({ page }) => {
     await setup(page)
     await openDrawer(page)
     await navigateToSettings(page)
     expect(await page.evaluate(() => !!document.querySelector('.settings'))).toBe(true)
+    await page.evaluate(() => {
+      const probe = document.createElement('button')
+      probe.id = 'drawer-underlay-probe'
+      probe.textContent = 'Underlying action'
+      probe.style.cssText = 'position:fixed;right:8px;top:280px;z-index:80'
+      probe.addEventListener('click', () => {
+        probe.dataset.clicks = String(Number(probe.dataset.clicks || 0) + 1)
+      })
+      document.body.appendChild(probe)
+    })
     await openDrawer(page)
     expect((await getNavState(page)).drawerOpen).toBe(true)
-    // Use a real pointer sequence rather than HTMLElement.click(). The drawer
-    // dismisses on pointerdown so a touch that moves enough for Chrome to
-    // suppress the later synthetic click still closes reliably.
-    await page.locator('.drawer-overlay').click({ position: { x: 400, y: 300 } })
-    await page.evaluate(() => new Promise(r => setTimeout(r, 400)))
+    await page.locator('.drawer-overlay').dispatchEvent('pointerdown', {
+      button: 0,
+      isPrimary: true,
+      pointerId: 4,
+      pointerType: 'touch',
+    })
     expect((await getNavState(page)).drawerOpen).toBe(false)
-    // Still on settings — overlay tap did not navigate.
+
+    // WebKit can retarget the compatibility click after the pointerdown has
+    // removed the scrim. That click still belongs to the drawer dismissal.
+    await page.locator('#drawer-underlay-probe').dispatchEvent('click', { detail: 1 })
+    await expect(page.locator('#drawer-underlay-probe')).not.toHaveAttribute('data-clicks')
+
+    // A genuinely new activation remains live. This also covers touch
+    // sequences that never synthesize the compatibility click: pointerdown
+    // releases any stale dismissal claim before the new click arrives.
+    await page.locator('#drawer-underlay-probe').click()
+    await expect(page.locator('#drawer-underlay-probe')).toHaveAttribute('data-clicks', '1')
+
+    await openDrawer(page)
+    await page.locator('.drawer-overlay').dispatchEvent('pointerdown', {
+      button: 0,
+      isPrimary: true,
+      pointerId: 5,
+      pointerType: 'touch',
+    })
+    await page.locator('#drawer-underlay-probe').click()
+    await expect(page.locator('#drawer-underlay-probe')).toHaveAttribute('data-clicks', '2')
+
+    // The close stays local to the drawer rather than navigating Settings.
     expect(await page.evaluate(() => !!document.querySelector('.settings'))).toBe(true)
   })
 
@@ -1290,9 +1323,13 @@ test.describe('Drawer close paths converge through handleBack', () => {
     )).toBeLessThanOrEqual(-359)
   })
 
-  test('22e. Closing scrim blocks the app until the panel is offscreen', async ({ page }) => {
+  test('22e. Closing input shield follows the panel instead of blocking the workspace', async ({ page }) => {
     await setup(page, { width: 426, height: 860 })
     await openDrawer(page)
+    await page.addStyleTag({ content: `
+      .drawer { transition-duration: 1s !important; }
+      .drawer-close-shield--active { animation-duration: 1s !important; }
+    ` })
     await page.locator('.drawer-overlay').dispatchEvent('pointerdown', {
       button: 0,
       isPrimary: true,
@@ -1304,16 +1341,28 @@ test.describe('Drawer close paths converge through handleBack', () => {
       .toHaveAttribute('aria-expanded', 'false')
     const closing = await page.locator('.drawer').evaluate((drawer) => {
       const x = new DOMMatrixReadOnly(getComputedStyle(drawer).transform).m41
+      const overlay = document.querySelector('.drawer-overlay')
+      const shield = document.querySelector('.drawer-close-shield')
       return {
         x,
-        blocking: getComputedStyle(document.querySelector('.drawer-overlay')).pointerEvents,
+        overlayPointerEvents: getComputedStyle(overlay).pointerEvents,
+        shieldPointerEvents: getComputedStyle(shield).pointerEvents,
+        shieldRect: shield.getBoundingClientRect().toJSON(),
+        uncoveredTarget: document.elementFromPoint(400, 300)?.className || null,
       }
     })
-    if (closing.x > -359) expect(closing.blocking).toBe('auto')
+    expect(closing.overlayPointerEvents).toBe('none')
+    if (closing.x > -359) {
+      expect(closing.shieldPointerEvents).toBe('auto')
+      expect(closing.shieldRect.right).toBeLessThanOrEqual(360)
+      expect(closing.uncoveredTarget).not.toContain('drawer-overlay')
+      expect(closing.uncoveredTarget).not.toContain('drawer-close-shield')
+    }
     await expect.poll(() => page.locator('.drawer').evaluate(
       (drawer) => new DOMMatrixReadOnly(getComputedStyle(drawer).transform).m41,
     )).toBeLessThanOrEqual(-359)
     await expect(page.locator('.drawer-overlay')).toHaveCSS('pointer-events', 'none')
+    await expect(page.locator('.drawer-close-shield')).toHaveCSS('pointer-events', 'none')
   })
 
   test('22f. Reduced motion releases the scrim in the committed close layout', async ({ page }) => {
@@ -1351,7 +1400,25 @@ test.describe('Drawer close paths converge through handleBack', () => {
     })
   })
 
-  test('22g. Desktop drawer resize follows pointer delta and settles lost capture', async ({ page }) => {
+  test('22g. Swipe close leaves a click-only next activation live', async ({ page }) => {
+    await setup(page, { width: 426, height: 860 })
+    await openDrawer(page)
+    const toggle = page.getByRole('button', { name: 'Toggle navigation' })
+
+    await dispatchDrawerPointerGesture(page, {
+      pointerId: 72,
+      points: [[260, 420], [100, 422]],
+    })
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false')
+
+    // WebKit can omit the next pointerdown after a moved touch stream while
+    // still delivering its click. The drawer's own history.back() is not an OS
+    // Back gesture, so that click must remain a first-try open.
+    await toggle.dispatchEvent('click', { detail: 1 })
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  test('22h. Desktop drawer resize follows pointer delta and settles lost capture', async ({ page }) => {
     await setup(page, { width: 1280, height: 800 })
     const drawer = page.locator('.drawer--persistent')
     const handle = page.getByRole('separator', { name: 'Resize navigation drawer' })


### PR DESCRIPTION
## Summary
- consume the complete outside-press activation so content beneath an open drawer never fires during dismissal
- preserve a drawer-open activation that arrives while swipe-close history bookkeeping settles
- keep the fading scrim visual separate from a geometry-matched closing input shield, so uncovered controls respond immediately
- prevent a late close frame from hiding a newer reopen

## Why
On phones, closing the drawer on pointerdown could expose the underlying workspace before WebKit delivered the compatibility click from that same touch. WebKit could then retarget that click to a tool disclosure or other control beneath the former scrim. Separately, internal history cleanup and an invisible full-screen closing scrim could make the next independent activation appear dead.

The drawer now owns the complete outside-dismiss activation, while a genuinely new pointer or keyboard activation remains live. This follows up on #497's native-first Pointer Events drawer work: it keeps that gesture ownership while correcting the post-close activation and shielding lifecycle.

## Testing
- npm test
- npm run build
- changed-file ESLint
- node --check tests/navigation.spec.mjs
- authenticated 426×860 shell probe covering retargeted outside-dismiss clicks, a dismissal with no synthesized click, uncovered hit testing, and a click-only first reopen