### PR TITLE
Increase drawer row text size on phones

### DIFF
--- a/frontend/src/components/Drawer/Drawer.css
+++ b/frontend/src/components/Drawer/Drawer.css
@@ -289,7 +289,7 @@
   border: none;
   border-radius: 10px;
   color: var(--text);
-  font-size: 14px;
+  font-size: 15px;
   font-family: var(--font);
   font-weight: 400;
   text-align: left;
@@ -654,9 +654,9 @@
 }
 
 /* Desktop's collapsed rail and expanded drawer are two presentations of the
-   same three actions. Match their 20px glyphs and exact centers; the slightly
-   larger 15px labels preserve the rail's stronger visual weight when expanded.
-   Mobile has no collapsed rail, so it keeps its existing compact drawer scale. */
+   same three actions. Match their 20px glyphs and exact centers. Row labels use
+   the same readable 15px scale at every width; section labels retain their own
+   desktop treatment below. */
 @media (min-width: 1024px) {
   /* 58px drawer header + 8px body inset matches the collapsed rail's 66px
      action start; the shared 40px row height keeps Apps aligned too. */
@@ -668,7 +668,6 @@
   .drawer__item--new {
     min-height: 40px;
     padding: 0 11px;
-    font-size: 15px;
   }
 
   .drawer__label {

--- a/frontend/src/components/Shell/__tests__/drawerAlignment.test.js
+++ b/frontend/src/components/Shell/__tests__/drawerAlignment.test.js
@@ -35,6 +35,14 @@ test('collapsed and expanded drawer actions share one vertical rhythm', () => {
   )
 })
 
+test('phone drawer increases row type without changing the section-title scale', () => {
+  const drawerItem = ruleBody(drawerCss, '.drawer__item')
+  const drawerLabel = ruleBody(drawerCss, '.drawer__label')
+
+  assert.equal(px(drawerItem, 'font-size'), 15)
+  assert.equal(px(drawerLabel, 'font-size'), 14)
+})
+
 test('the docked notifications panel covers the drawer content column', () => {
   const panel = ruleBody(shellCss, '.shell--drawer-docked .notifications')
   const desktopDrawerBody = ruleBody(drawerCss, '.drawer__body', 1)

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -824,7 +824,7 @@ test('live preview reveal keeps the workspace controller distinct from device mo
   assert.doesNotMatch(shell, /const mode = paneModel\.modeForRect\(contentRect\)/)
 })
 
-test('large drawer lists memoize ordering and row actions without changing row ownership', () => {
+test('drawer rows preserve ordering, action identity, and app artwork', () => {
   assert.match(drawer, /useMemo\(\(\) => buildDrawerSections\(chats, apps\), \[chats, apps\]\)/)
   assert.match(drawer, /const filteredApps = useMemo\(/)
   assert.match(drawer, /const rowActions = useMemo\(/)
@@ -832,27 +832,8 @@ test('large drawer lists memoize ordering and row actions without changing row o
   assert.match(drawer, /visibleRecents\.map\(\(\{ kind, item \}\)[\s\S]*?item=\{item\}[\s\S]*?actions=\{rowActions\}/)
   assert.match(drawer, /item=\{app\}[\s\S]*?actions=\{rowActions\}/)
   assert.doesNotMatch(drawer, /onSelect=\{\(\) => on(?:Chat|App)/)
-})
-
-test('mixed recents reserve artwork for apps and separate sections without a second type scale', () => {
   assert.match(drawer, /kind === 'app'[\s\S]*?<AppIcon/)
   assert.doesNotMatch(drawer, /drawer__chat-icon|<Chat\b|<Clock\b|<PinFilled\b/)
-  assert.match(
-    drawerCss,
-    /\.drawer__label\s*\{[\s\S]*?font-size:\s*14px[\s\S]*?font-weight:\s*600[\s\S]*?color:\s*var\(--text\)[\s\S]*?padding:\s*6px 12px[\s\S]*?margin:\s*12px 0 4px/,
-  )
-  assert.match(
-    drawerCss,
-    /\.drawer__item\s*\{[\s\S]*?font-size:\s*14px/,
-  )
-  assert.match(
-    drawerCss,
-    /@media \(min-width: 1024px\)[\s\S]*?\.drawer__item,[\s\S]*?font-size:\s*15px[\s\S]*?\.drawer__label\s*\{[\s\S]*?font-size:\s*15px/,
-  )
-  assert.doesNotMatch(
-    drawerCss,
-    /\.drawer__row \.drawer__item\s*\{[^}]*font-size:/,
-  )
 })
 
 test('New chat and Apps share one compact navigation rhythm', () => {


### PR DESCRIPTION
## Summary
- increase drawer row text from 14px to 15px on phones without changing row height or padding
- keep Pinned and Recents section-title sizing unchanged
- remove the redundant desktop-only row-size override now that every width shares the same readable type scale

## Related work
- Companion to [#528](https://github.com/mobius-os/mobius/pull/528), which tightens drawer row geometry. This PR is independent: it changes type size only and does not alter row height or spacing.

## Testing
- focused `drawerAlignment.test.js`
- `npm run build`