### PR TITLE
Make workspace behavior canonical

### DIFF
--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -28,7 +28,6 @@ import {
   shouldAutoRevealActiveChat,
   clearDrawerGestureStyles,
 } from '../../lib/drawerLifecycle.js'
-import { WORKSPACE_SPLITS_ENABLED } from '../Shell/paneModel.js'
 import {
   DRAWER_HOLD_MS,
   PRE_HOLD_MOVE_PX,
@@ -1959,7 +1958,7 @@ const DrawerRow = memo(function DrawerRow({
         // actions and held vertical movement reorders a pin, so Android cannot
         // retire the gesture by cancelling its parallel pointer stream.
         data-drawer-key={`${kind}:${id}`}
-        data-drag-key={WORKSPACE_SPLITS_ENABLED ? `${kind}:${id}` : undefined}
+        data-drag-key={`${kind}:${id}`}
         data-pinned-key={pinned ? `${kind}:${id}` : undefined}
         onPointerDown={onRowPointerDown}
         onTouchStart={onRowTouchStart}

--- a/frontend/src/components/Shell/PaneStrip.jsx
+++ b/frontend/src/components/Shell/PaneStrip.jsx
@@ -1,7 +1,7 @@
 import { useLayoutEffect, useRef } from 'react'
 import { CollapseSm, ExpandSm, X } from '@openai/apps-sdk-ui/components/Icon'
 import * as tabModel from './tabModel.js'
-import { STRIP_H, WORKSPACE_SPLITS_ENABLED } from './paneModel.js'
+import { STRIP_H } from './paneModel.js'
 
 // Each direction owns 40% of the one-shot cycle, so 1000/12 ms per clipped pixel
 // keeps travel at a readable 30px/s. The cycle runs once, returns to the beginning,
@@ -233,7 +233,7 @@ export function PaneStrip({
             tabId={paneTabDomId(pane.id, key)}
             controlsId={panePanelDomId(pane.id, key)}
             tabIndex={active ? 0 : -1}
-            dragKey={WORKSPACE_SPLITS_ENABLED ? key : undefined}
+            dragKey={key}
             onActivate={() => onActivate(pane.id, tab)}
             onClose={() => onClose(tab)}
             onContextMenu={(e) => onTabContextMenu(e, tab, pane.id)}

--- a/frontend/src/components/Shell/Shell.css
+++ b/frontend/src/components/Shell/Shell.css
@@ -578,7 +578,6 @@
   white-space: nowrap;
   border: 0;
 }
-
 /* A real text control is required to reserve the software keyboard during the
    async New-chat handoff. It stays mounted outside the modal drawer's inert
    subtree and never participates in layout or pointer hit-testing. */
@@ -598,14 +597,6 @@
   resize: none;
   font-size: 16px;
   caret-color: transparent;
-}
-/* PROPOSED "more power" builder chrome (design item 6, default OFF). Shell adds
-   .shell--builder-power only when the mobius:builder-power flag is on AND builder
-   mode is active. An accent power-rail under the top bar signals the build world;
-   the energized dividers live in workspace.css. Owner-toggleable preview — no
-   rebuild needed to try it. */
-.shell--builder-power .shell__bar {
-  box-shadow: inset 0 -2px 0 0 var(--accent);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -255,16 +255,14 @@ export default function Shell() {
   // The render never uses `activeView === 'settings'` for pane suppression (that
   // would hide every pane behind a builder Settings tab — the named risk).
   const settingsActive = settingsOverlayOpen
-  // Builder mode is the tiled 'panes' view-mode (only meaningful when splits can
-  // exist). The logo itself is the persistent mode indicator and gesture surface;
+  // Builder mode is the tiled 'panes' view-mode. The logo itself is the
+  // persistent mode indicator and gesture surface;
   // there is deliberately no separate header control.
   // Durable mode and drag-preview stay in the small mode reducer. The visual
   // Standard ↔ Builder scene belongs independently to the browser transition.
-  const SPLITS = paneModel.WORKSPACE_SPLITS_ENABLED
   const shellRootRef = useRef(null)
   const mode = useModeController({
     committedMode: workspace.viewMode,
-    splitsEnabled: SPLITS,
   })
   const modeView = useModeViewTransition({
     rootRef: shellRootRef,
@@ -281,12 +279,11 @@ export default function Shell() {
     }
   }, [workspace.viewMode, modeView.active, modeState.transition, setFocusedPaneViewId])
 
-  // Builder mode = the committed 'panes' world (logo twist + static brand cue + power
-  // chrome), clamped off by the splits kill switch (INV 16). Flips synchronously
-  // with the toggle, matching the gesture's own spring/snap.
-  const builderModeActive = modeMachine.builderModeActive(modeState, { splitsEnabled: SPLITS })
+  // Builder mode = the committed 'panes' world. It flips synchronously with the
+  // toggle, matching the gesture's own spring/snap.
+  const builderModeActive = modeMachine.builderModeActive(modeState)
   // Drag-preview alone may project the tiled world before it is committed.
-  const effectiveViewMode = modeMachine.effectiveViewMode(modeState, { splitsEnabled: SPLITS })
+  const effectiveViewMode = modeMachine.effectiveViewMode(modeState)
   const multiPaneBuilderVisible = effectiveViewMode === 'panes'
     && paneModel.paneIdsInOrder(workspace).length > 1
   const multiPaneBuilderVisibleRef = useRef(multiPaneBuilderVisible)
@@ -711,11 +708,6 @@ export default function Shell() {
   // A single implicit home tab on a fresh session stays visually identical to
   // the pre-workspace shell. State (rather than a render-time ref mutation) keeps
   // this safe under replayed or abandoned concurrent renders.
-  const [tabStripEngaged, setTabStripEngaged] = useState(openTabs.length >= 2)
-  useEffect(() => {
-    if (openTabs.length >= 2) setTabStripEngaged(true)
-    else if (openTabs.length === 0) setTabStripEngaged(false)
-  }, [openTabs.length])
   // Pointer events inside an iframe do not bubble to its positioned shell
   // wrapper. The verified live frame sends a tiny focus signal so app panes have
   // the same click-to-focus semantics as native chat panes.
@@ -740,7 +732,7 @@ export default function Shell() {
   // retired.
   const requestEmptySingleNewChat = useCallback(() => {
     const ws = workspaceStateRef.current.ws
-    const single = !paneModel.WORKSPACE_SPLITS_ENABLED || ws.viewMode === 'single'
+    const single = ws.viewMode === 'single'
     if (!single || ws.singleScreen != null) return
     const candidate = currentReusableEmptyChat(chatsRef.current, {
       activeChatId: activeChatIdRef.current,
@@ -782,7 +774,7 @@ export default function Shell() {
     // would unmount the mounted-hidden SettingsView). dismissSettings no-ops when no
     // takeover is open.
     const currentWs = workspaceStateRef.current.ws
-    const world = paneModel.WORKSPACE_SPLITS_ENABLED ? currentWs.viewMode : 'single'
+    const world = currentWs.viewMode
     if (world === 'single'
         && requests.some(r => r && r.item && r.activation === ACTIVATE_FOREGROUND)) {
       dismissSettings()
@@ -807,15 +799,10 @@ export default function Shell() {
   // single leaf, where this single-pane .shell__tabstrip stands in for the
   // tiled WorkspaceChrome strips, giving phone users the drag source), riding
   // a single-mode drag preview with the rest of the tiled presentation, and NEVER
-  // rendered in single mode OR over an immersive lease
-  // (the shell exit replaces every builder navigation surface). The legacy
-  // tabStripEngaged latch is
-  // the KILL-SWITCH world's rule only (engaged after 2+ tabs) — letting it
-  // leak into the flag-ON formula painted the parked builder tree's strip
-  // over single mode whenever the latch was set. An empty workspace (no tabs)
-  // shows nothing either way — the >= 1 gate stays.
+  // rendered in single mode OR over an immersive lease (the shell exit replaces
+  // every builder navigation surface). An empty workspace shows no strip.
   const tabStripVisible = !immersiveActive
-    && (SPLITS ? effectiveViewMode === 'panes' : tabStripEngaged)
+    && effectiveViewMode === 'panes'
     && openTabs.length >= 1
   const shellTabStripVisible = tabStripVisible && !workspaceChromeActive
 
@@ -1038,7 +1025,7 @@ export default function Shell() {
     // Only builder repair falls back to a historical chat. In single mode the
     // deleted-close edge already requested the explicit New Chat destination;
     // selecting chats[0] here would overwrite it with an unrelated transcript.
-    const single = !paneModel.WORKSPACE_SPLITS_ENABLED || ws.viewMode === 'single'
+    const single = ws.viewMode === 'single'
     const builderEmpty = !single
       && Object.keys(ws.panes).length === 1
       && !ws.panes[ws.focusedPaneId]?.activeTabKey
@@ -1136,8 +1123,7 @@ export default function Shell() {
   }, [closeTabMenu, tabActionsAvailable, tabMenu])
 
   // ── Workspace drag controller wiring (design §3, PR3) ─────────────────────
-  // All of this is gated behind WORKSPACE_SPLITS_ENABLED — the hook installs no
-  // listeners when the flag is off, so the default build is byte-unchanged.
+  // One shared controller owns the shipped workspace's document-level gesture.
   // Volatile inputs travel through refs so the hook installs its single
   // document-level pointerdown listener exactly once (never re-registers).
   // dragActiveRef is declared above useNavigation (the drawer OPEN path reads it).
@@ -1215,7 +1201,6 @@ export default function Shell() {
     openDrawer,
   ])
   useWorkspaceDrag({
-    enabled: paneModel.WORKSPACE_SPLITS_ENABLED,
     contentElRef,
     sceneInputsRef,
     workspaceStateRef,
@@ -1240,7 +1225,6 @@ export default function Shell() {
   // case click into the shell chrome (a strip tab or the divider) first, then
   // press the chord.
   useEffect(() => {
-    if (!paneModel.WORKSPACE_SPLITS_ENABLED) return undefined
     const onKey = (e) => {
       if (!undoKeyPressed(e) || isEditableTarget(document.activeElement)) return
       e.preventDefault()
@@ -1849,7 +1833,7 @@ export default function Shell() {
       // A zero-chat install waits for the live-confirmed bootstrap effect below so a
       // stale empty list cannot manufacture a server row.
       const ws = workspaceStateRef.current.ws
-      const single = !paneModel.WORKSPACE_SPLITS_ENABLED || ws.viewMode === 'single'
+      const single = ws.viewMode === 'single'
       const focusedPaneEmpty = !ws.panes[ws.focusedPaneId]?.activeTabKey
       if (single && ws.singleScreen == null && chats.length > 0
           && pendingNewChatRef.current == null) {
@@ -1902,7 +1886,7 @@ export default function Shell() {
           reason: 'deleted',
         })
         const ws = workspaceStateRef.current.ws
-        const single = !paneModel.WORKSPACE_SPLITS_ENABLED || ws.viewMode === 'single'
+        const single = ws.viewMode === 'single'
         const builderEmpty = !single && !ws.panes[ws.focusedPaneId]?.activeTabKey
         const fallback = chats.find(c => c.id !== probedChatId)
         if (builderEmpty && fallback) {
@@ -2455,7 +2439,7 @@ export default function Shell() {
       // watcher will retry after that beat without issuing another detail/POST call.
       if (chatId != null) pending.resolvedChatId = chatId
       const ws = workspaceStateRef.current.ws
-      const single = !paneModel.WORKSPACE_SPLITS_ENABLED || ws.viewMode === 'single'
+      const single = ws.viewMode === 'single'
       if (!single || ws.singleScreen != null) {
         if (pendingNewChatRef.current && pendingNewChatRef.current.token === pending.token) {
           pendingNewChatRef.current = null
@@ -2525,7 +2509,7 @@ export default function Shell() {
     )
     const ws = workspaceStateRef.current.ws
     const resumeId = (
-      (!SPLITS || ws.viewMode === 'single')
+      (ws.viewMode === 'single')
       && activeChatIdRef.current == null
       && !draft
       && !forceNew
@@ -2605,7 +2589,7 @@ export default function Shell() {
     const pending = pendingNewChatRef.current
     if (!pending || pending.token !== pendingNewChatToken) return
     const ws = workspaceStateRef.current.ws
-    const single = !paneModel.WORKSPACE_SPLITS_ENABLED || ws.viewMode === 'single'
+    const single = ws.viewMode === 'single'
     if (!single || ws.singleScreen != null) {
       // No longer an empty single slot (re-toggled to builder, or a slot was set by
       // another path) — drop the request.
@@ -2679,7 +2663,7 @@ export default function Shell() {
       reason: 'deleted',
     })
     const wsAfterClose = workspaceStateRef.current.ws
-    const single = !paneModel.WORKSPACE_SPLITS_ENABLED || wsAfterClose.viewMode === 'single'
+    const single = wsAfterClose.viewMode === 'single'
     const focusedAfterClose = wsAfterClose.panes[wsAfterClose.focusedPaneId]
     if (!single && !focusedAfterClose?.activeTabKey) {
       // Exclude the just-deleted id: it's still in `chats` until the
@@ -2854,7 +2838,7 @@ export default function Shell() {
     // the starter chat then.
     if (chats.length === 0 && activeChatId === null && activeView === 'chat') {
       const ws = workspaceStateRef.current.ws
-      const single = !paneModel.WORKSPACE_SPLITS_ENABLED || ws.viewMode === 'single'
+      const single = ws.viewMode === 'single'
       if (single && ws.singleScreen == null) requestEmptySingleNewChat()
       else newChat()
     }
@@ -2875,9 +2859,7 @@ export default function Shell() {
       data-mode-phase={modeView.active?.phase || modeState.transition?.phase || 'idle'}
       data-mode-epoch={modeView.active?.id || modeState.transition?.id || undefined}
       data-workspace-visual-state={workspaceVisualState}
-      className={`shell${immersiveActive ? ' shell--immersive' : ''}`
-      + `${desktopSidebarReserved ? ' shell--drawer-docked' : ''}`
-      + `${builderModeActive && paneModel.BUILDER_POWER_CHROME ? ' shell--builder-power' : ''}`}>
+      className={`shell${immersiveActive ? ' shell--immersive' : ''}${desktopSidebarReserved ? ' shell--drawer-docked' : ''}`}>
       <a
         className="shell__skip-link"
         href="#main-content"
@@ -2907,7 +2889,6 @@ export default function Shell() {
       >
         <ShellBrand
           brandRef={brandButtonRef}
-          splitsEnabled={paneModel.WORKSPACE_SPLITS_ENABLED}
           navigationOpen={navigationOpen}
           builderModeActive={builderModeActive}
           // The live descriptor drives the logo's hold→completion spring (round 4
@@ -3052,7 +3033,7 @@ export default function Shell() {
           // Tag it with the sole pane's id so the drag controller resolves a
           // source pane exactly as it does for a WorkspaceChrome strip; dragging
           // a tab out with ≥2 tabs present splits the pane.
-          data-pane-strip={paneModel.WORKSPACE_SPLITS_ENABLED ? workspace.focusedPaneId : undefined}
+          data-pane-strip={workspace.focusedPaneId}
           data-mode-pane-vt={navViewStyle ? navPaneId : undefined}
           style={navViewStyle || undefined}
           onKeyDown={(e) => stripKeyDown(e, openTabs, (tab) => closeTab(tab))}
@@ -3072,7 +3053,7 @@ export default function Shell() {
                 active={active}
                 revealKey={tabRevealRevision}
                 tabIndex={active ? 0 : -1}
-                dragKey={paneModel.WORKSPACE_SPLITS_ENABLED ? key : undefined}
+                dragKey={key}
                 onActivate={() => {
                   const { view, opts } = tabModel.tabNavTarget(tab)
                   navTo(view, opts)

--- a/frontend/src/components/Shell/ShellBrand.jsx
+++ b/frontend/src/components/Shell/ShellBrand.jsx
@@ -8,7 +8,6 @@ import { useLogoModeGesture } from './useLogoModeGesture.js'
  */
 const ShellBrand = memo(function ShellBrand({
   brandRef,
-  splitsEnabled,
   navigationOpen,
   builderModeActive,
   // The live mode descriptor (modeMachine transition) or null. The logo's hold hands
@@ -24,7 +23,7 @@ const ShellBrand = memo(function ShellBrand({
   const logoGesture = useLogoModeGesture({
     onToggleMode,
     brandRef,
-    enabled: splitsEnabled,
+    enabled: true,
     // Cancel a live hold if navigation opens by any other path.
     drawerOpen: navigationOpen,
     builderModeActive,
@@ -36,7 +35,7 @@ const ShellBrand = memo(function ShellBrand({
   // the delay against the newest beat when a retoggle supersedes, with no remount.
   const animatedBeat = !!transition
     && (transition.phase === 'entering' || transition.phase === 'exiting')
-  const beatHeld = splitsEnabled && logoGesture.holdOwnsBeat && animatedBeat
+  const beatHeld = logoGesture.holdOwnsBeat && animatedBeat
   const beatParity = beatHeld ? (transition.id % 2 === 0 ? 'b' : 'a') : ''
 
   return (
@@ -54,31 +53,29 @@ const ShellBrand = memo(function ShellBrand({
         // Navigation remains the primary, stable accessible name. The builder
         // gesture is supplementary and its state is announced below.
         aria-label="Toggle navigation"
-        aria-description={splitsEnabled
-          ? 'Hold or press Shift+Enter for builder mode'
-          : undefined}
+        aria-description="Hold or press Shift+Enter for builder mode"
         aria-controls="navigation-drawer"
         aria-expanded={navigationOpen}
         onPointerDown={(e) => {
           // A deliberate interaction immediately clears Android's compatibility-
           // click guard left by an OS Back gesture.
           backFiredRef.current = false
-          if (splitsEnabled) logoGesture.onPointerDown(e)
+          logoGesture.onPointerDown(e)
         }}
-        onPointerMove={splitsEnabled ? logoGesture.onPointerMove : undefined}
-        onPointerUp={splitsEnabled ? logoGesture.onPointerUp : undefined}
-        onPointerCancel={splitsEnabled ? logoGesture.onPointerCancel : undefined}
-        onContextMenu={splitsEnabled ? logoGesture.onContextMenu : undefined}
-        onLostPointerCapture={splitsEnabled ? logoGesture.onLostPointerCapture : undefined}
+        onPointerMove={logoGesture.onPointerMove}
+        onPointerUp={logoGesture.onPointerUp}
+        onPointerCancel={logoGesture.onPointerCancel}
+        onContextMenu={logoGesture.onContextMenu}
+        onLostPointerCapture={logoGesture.onLostPointerCapture}
         onKeyDown={(e) => {
           backFiredRef.current = false
           // A keyboard interaction clears pointer provenance so a keyboard-invoked
           // contextmenu on the focused brand reaches the native menu instead of
           // inheriting a stale touch/pen suppression.
-          if (splitsEnabled) logoGesture.onKeyDown()
+          logoGesture.onKeyDown()
           // e.repeat guard: holding Shift+Enter must fire ONE toggle, not a storm
           // of them at the keyboard repeat rate (INV 3).
-          if (splitsEnabled && e.shiftKey && e.key === 'Enter' && !e.repeat) {
+          if (e.shiftKey && e.key === 'Enter' && !e.repeat) {
             e.preventDefault()
             keyboardModeClickRef.current = true
             // Honest cause (finding F13): Shift+Enter is the 'keyboard' beat.
@@ -121,11 +118,9 @@ const ShellBrand = memo(function ShellBrand({
         </span>
         <span className="shell__wordmark">Möbius</span>
       </button>
-      {splitsEnabled && (
-        <span className="shell__sr-only" role="status" aria-live="polite">
-          {builderModeActive ? 'Builder mode' : 'Single screen'}
-        </span>
-      )}
+      <span className="shell__sr-only" role="status" aria-live="polite">
+        {builderModeActive ? 'Builder mode' : 'Single screen'}
+      </span>
     </>
   )
 })

--- a/frontend/src/components/Shell/__tests__/modeMachine.test.js
+++ b/frontend/src/components/Shell/__tests__/modeMachine.test.js
@@ -66,9 +66,3 @@ test('external durable-mode synchronization clears transient projection', () => 
   assert.equal(synced.transition, null)
   assert.equal(synced.committedMode, 'single')
 })
-
-test('the splits kill switch clamps every derivation to Standard', () => {
-  assert.equal(effectiveViewMode(panes(), { splitsEnabled: false }), 'single')
-  assert.equal(builderModeActive(panes(), { splitsEnabled: false }), false)
-  assert.equal(dragPreviewActive(modeReducer(single(), { type: 'drag-arm' }), { splitsEnabled: false }), false)
-})

--- a/frontend/src/components/Shell/__tests__/modeReviewFixes.test.js
+++ b/frontend/src/components/Shell/__tests__/modeReviewFixes.test.js
@@ -88,8 +88,8 @@ test('finding 4: non-history newChat routes through applyModeDestination (not a 
   assert.doesNotMatch(shell, /type: 'OPEN_TAB', paneId: ws\.focusedPaneId,\s*\n\s*tab: tabModel\.makeTab\('chat', chatId\)/)
 })
 
-test('finding 9: applyModeDestination clamps the kill switch BEFORE the world branch', () => {
-  assert.match(nav, /const mode = paneModel\.WORKSPACE_SPLITS_ENABLED \? ws\.viewMode : 'single'/)
+test('finding 9: applyModeDestination branches on the canonical workspace world', () => {
+  assert.match(nav, /const mode = ws\.viewMode/)
   assert.match(nav, /if \(mode === 'single'\) \{[\s\S]*?SET_SINGLE_SCREEN/)
 })
 
@@ -111,7 +111,7 @@ test('finding F9: historical-chat repair is builder-only; single mode requests N
   // the explicit New Chat landing instead.
   assert.match(shell, /applyModeDestination\(\{ view: 'chat', chatId: fallback\.id, appId: null, paneId: ws\.focusedPaneId \}, \{ preserveSettings: true \}\)/)
   assert.match(shell, /applyModeDestination\(\{ view: 'chat', chatId: chats\[0\]\.id, appId: null, paneId: ws\.focusedPaneId \}, \{ preserveSettings: true \}\)/)
-  assert.match(shell, /const single = !paneModel\.WORKSPACE_SPLITS_ENABLED \|\| ws\.viewMode === 'single'/)
+  assert.match(shell, /const single = ws\.viewMode === 'single'/)
   assert.match(shell, /if \(single && ws\.singleScreen == null && chats\.length > 0\s*&& pendingNewChatRef\.current == null\) \{\s*requestEmptySingleNewChat\(\)/)
   assert.match(shell, /else if \(!single && focusedPaneEmpty && chats\[0\]\)/)
   assert.match(shell, /const builderEmpty = !single/)
@@ -240,7 +240,7 @@ test('finding 11: the hold cancels on the page-lifecycle interruptions', () => {
   assert.match(gesture, /window\.addEventListener\('pagehide', cancel\)/)
   assert.match(gesture, /document\.addEventListener\('visibilitychange', onHidden\)/)
   assert.match(gesture, /const onLostPointerCapture = useCallback/)
-  assert.match(brand, /onLostPointerCapture=\{splitsEnabled \? logoGesture\.onLostPointerCapture : undefined\}/)
+  assert.match(brand, /onLostPointerCapture=\{logoGesture\.onLostPointerCapture\}/)
 })
 
 // -- Finding 12: Shift+Enter e.repeat guard + keyboardModeClickRef cleanup -----

--- a/frontend/src/components/Shell/__tests__/newChatPolicy.test.js
+++ b/frontend/src/components/Shell/__tests__/newChatPolicy.test.js
@@ -47,19 +47,6 @@ test('empty-single policy fires only on the transition edge', () => {
   ), false)
 })
 
-test('empty-single policy respects the splits kill switch', () => {
-  assert.equal(enteredEmptySingleScreen(
-    { viewMode: 'panes', singleScreen: { kind: 'app', id: 4 } },
-    { viewMode: 'panes', singleScreen: null },
-    false,
-  ), true)
-  assert.equal(enteredEmptySingleScreen(
-    { viewMode: 'panes', singleScreen: null },
-    { viewMode: 'single', singleScreen: null },
-    false,
-  ), false)
-})
-
 test('only the active empty chat is eligible for client-side reuse', () => {
   const offscreen = empty('offscreen')
   const active = empty('active')

--- a/frontend/src/components/Shell/__tests__/settingsTab.test.js
+++ b/frontend/src/components/Shell/__tests__/settingsTab.test.js
@@ -103,54 +103,6 @@ test('an older/unknown tab kind is scrubbed on parse (forgiving read)', () => {
     'the unknown kind is dropped, the chat survives')
 })
 
-test('flag OFF scrubs a persisted Settings tab before first render (rollback safety)', async () => {
-  // A blob a builder (flag-on) shell wrote, carrying a Settings tab.
-  const onWs = paneModel.openTab(onePane('9'), settingsTab(), { paneId: 'p0', activate: true })
-  const blob = paneModel.serializeWorkspace(onWs)
-  assert.ok(paneModel.flatten(onWs).some(tabModel.isSettingsTab), 'flag-on keeps it')
-
-  // Re-evaluate paneModel with the kill switch OFF (a fresh module instance via a
-  // cache-busting query, evaluated while localStorage returns '0' for the key).
-  const prevLS = globalThis.localStorage
-  globalThis.localStorage = { getItem: (k) => (k === 'mobius:builder-settings' ? '0' : null) }
-  try {
-    const pmOff = await import('../paneModel.js?builder-settings-off')
-    assert.equal(pmOff.BUILDER_SETTINGS_ENABLED, false, 'flag read as off')
-    const parsed = pmOff.parseWorkspace(blob)
-    assert.ok(!pmOff.flatten(parsed).some(t => t.kind === 'settings'),
-      'the Settings tab is scrubbed like any unknown kind')
-    assert.ok(pmOff.flatten(parsed).some(t => t.kind === 'chat' && t.id === '9'),
-      'the chat survives the scrub')
-  } finally {
-    if (prevLS === undefined) delete globalThis.localStorage
-    else globalThis.localStorage = prevLS
-  }
-})
-
-test('workspace-splits OFF also disables the Settings tab and scrubs it (review §3)', async () => {
-  // The Settings tab only makes sense where builder mode can exist. With splits off
-  // there is no builder mode, so BUILDER_SETTINGS_ENABLED must be false even though
-  // the builder-settings key is unset — a persisted settings:settings is scrubbed
-  // and can never leak into the legacy single-pane strip.
-  const onWs = paneModel.openTab(onePane('9'), settingsTab(), { paneId: 'p0', activate: true })
-  const blob = paneModel.serializeWorkspace(onWs)
-
-  const prevLS = globalThis.localStorage
-  // splits off; the builder-settings key is UNSET (its own default would be "on").
-  globalThis.localStorage = { getItem: (k) => (k === 'mobius:workspace-splits' ? '0' : null) }
-  try {
-    const pmOff = await import('../paneModel.js?workspace-splits-off')
-    assert.equal(pmOff.WORKSPACE_SPLITS_ENABLED, false)
-    assert.equal(pmOff.BUILDER_SETTINGS_ENABLED, false, 'gated on splits, not just its own key')
-    const parsed = pmOff.parseWorkspace(blob)
-    assert.ok(!pmOff.flatten(parsed).some(t => t.kind === 'settings'), 'settings scrubbed')
-    assert.ok(pmOff.flatten(parsed).some(t => t.kind === 'chat' && t.id === '9'), 'chat kept')
-  } finally {
-    if (prevLS === undefined) delete globalThis.localStorage
-    else globalThis.localStorage = prevLS
-  }
-})
-
 test('a mode flip (SET_VIEW_MODE) PRESERVES a builder Settings tab AND a pending undo', () => {
   // v2 deleted the 'mode-convert' close: a builder Settings tab SURVIVES entering
   // single (single paints its own slot, never Settings), and the pure SET_VIEW_MODE

--- a/frontend/src/components/Shell/__tests__/viewMode.test.js
+++ b/frontend/src/components/Shell/__tests__/viewMode.test.js
@@ -177,35 +177,7 @@ test('UNDO_LAST restores the captured tree but KEEPS the current view-mode', () 
   assert.equal(undone.ws.viewMode, 'single', 'the view-mode flip is NOT reverted')
 })
 
-// ── M3: the fresh/fallback seed has one standard world in every flag state ────
-// parseWorkspace returns seedFromFlatTabs directly on the fresh/fallback/invalid
-// paths (no re-normalize), so the seed itself must carry the mode both rendering
-// and activeContentRoute read. The splits kill switch still clamps every other
-// candidate to that same single-screen world.
-test('M3: with splits OFF a fresh/fallback seed is single and activeContentRoute reads the slot', async () => {
-  const prevLS = globalThis.localStorage
-  globalThis.localStorage = { getItem: (k) => (k === 'mobius:workspace-splits' ? '0' : null) }
-  try {
-    const pmOff = await import('../paneModel.js?m3-splits-off')
-    assert.equal(pmOff.WORKSPACE_SPLITS_ENABLED, false)
-    // The fresh fallback seed (empty raw → seedFromFlatTabs) is clamped to single.
-    const fresh = pmOff.parseWorkspace('')
-    assert.equal(fresh.viewMode, 'single', 'the seed itself is single when splits are off')
-    // Reproduce the review simulation: focused builder tab A, single-world slot B.
-    let ws = pmOff.seedFromFlatTabs([makeTab('chat', 'A')])
-    assert.equal(ws.viewMode, 'single', 'seedFromFlatTabs clamps at the parse layer')
-    ws = pmOff.setSingleScreen(ws, { kind: 'chat', id: 'B' })
-    const route = pmOff.activeContentRoute(ws)
-    assert.equal(route.view, 'chat')
-    assert.equal(route.chatId, 'B', 'reads the single-world SLOT, not the hidden builder focus A')
-  } finally {
-    if (prevLS === undefined) delete globalThis.localStorage
-    else globalThis.localStorage = prevLS
-  }
-})
-
-test('M3: with splits ON a fresh seed still starts in standard mode', () => {
-  assert.equal(paneModel.WORKSPACE_SPLITS_ENABLED, true)
+test('M3: a fresh seed starts in standard mode and activeContentRoute reads the slot', () => {
   let ws = paneModel.seedFromFlatTabs([makeTab('chat', 'A')])
   assert.equal(ws.viewMode, 'single')
   ws = paneModel.setSingleScreen(ws, { kind: 'chat', id: 'B' })

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -76,19 +76,29 @@ test('an implicit home tab does not engage the single-pane tab strip', () => {
   // single-screen blob intentionally has an empty legacy mirror; resetting it
   // on a deep link would silently change its view mode back to builder.
   assert.match(workspaceSession, /const replaceImplicitBootTab = !blobValid\s*\n?\s*&& Object\.keys\(workspace\.panes\)\.length === 1/)
-  assert.match(shell, /const \[tabStripEngaged, setTabStripEngaged\] = useState\(openTabs\.length >= 2\)/)
-  assert.match(shell, /if \(openTabs\.length >= 2\) setTabStripEngaged\(true\)/)
-  assert.match(shell, /else if \(openTabs\.length === 0\) setTabStripEngaged\(false\)/)
-  // With splits ON the strip follows the EFFECTIVE builder world only (never
-  // single mode or an immersive takeover); the engaged latch is the kill-switch
-  // world's legacy rule.
-  assert.match(shell, /const tabStripVisible = !immersiveActive\s*\n?\s*&& \(SPLITS \? effectiveViewMode === 'panes' : tabStripEngaged\)\s*\n?\s*&& openTabs\.length >= 1/)
+  assert.doesNotMatch(shell, /tabStripEngaged/)
+  assert.match(shell, /const tabStripVisible = !immersiveActive\s*\n?\s*&& effectiveViewMode === 'panes'\s*\n?\s*&& openTabs\.length >= 1/)
   assert.doesNotMatch(shell, /mobius-open-tabs|flattenRollbackPriority|writeOpenTabs/)
   // v2 DELETED the legacy sole-tab "unpin" shortcut (deletion list): the sole-tab
   // close is always a real CLOSE_TAB now, so an emptied builder auto-returns to
   // single. The ONE unified close takes a tab object + opts (INV 13).
   assert.doesNotMatch(shell, /openTabs\.length === 1 && kind !== 'settings'/)
   assert.match(shell, /const closeTab = useCallback\(\(tab, \{ reason \} = \{\}\)/)
+})
+
+test('the canonical workspace snapshot survives a closed PWA relaunch', () => {
+  assert.match(
+    shell,
+    /useWorkspaceSession\(\{ storage: localStorage \}\)/,
+  )
+  assert.doesNotMatch(
+    shell,
+    /sessionStorage\.setItem\(paneModel\.STORAGE_KEY/,
+  )
+  assert.match(
+    workspaceSession,
+    /storage\.setItem\(\s*paneModel\.STORAGE_KEY,\s*paneModel\.serializeWorkspace\(workspace\)/,
+  )
 })
 
 test('the drop preview reads as an 18% accent fill with a 2px border and morph', () => {
@@ -147,8 +157,7 @@ test('post-drag click suppression is source-scoped and expires on fresh input', 
   assert.match(dragBinding, /suppressNextSourceClick\(srcEl\)/)
 })
 
-test('the undo chord is flag-gated and defers to focused inputs', () => {
-  assert.match(shell, /if \(!paneModel\.WORKSPACE_SPLITS_ENABLED\) return undefined[\s\S]*?undoKeyPressed\(e\)/)
+test('the undo chord defers to focused inputs', () => {
   assert.match(shell, /isEditableTarget\(document\.activeElement\)/)
   assert.match(shell, /dispatchWorkspace\(\{ type: 'UNDO_LAST' \}\)/)
 })
@@ -562,7 +571,7 @@ test('logo pointer provenance EXPIRES so a keyboard context menu reaches the nat
   // as keyboard-invoked; Shell wires it into the brand's onKeyDown.
   assert.match(logoGestureSrc, /const onKeyDown = useCallback\(\(\) => \{\s*\n?\s*lastPointerTypeRef\.current = ''\s*\n?\s*lastPointerTypeAtRef\.current = 0/)
   assert.match(logoGestureSrc, /onKeyDown, onLostPointerCapture,\s*\n?\s*consumeSuppressedClick/)
-  assert.match(shellBrand, /if \(splitsEnabled\) logoGesture\.onKeyDown\(\)/)
+  assert.match(shellBrand, /logoGesture\.onKeyDown\(\)/)
 })
 
 test('the Builder brand indicator is static and has no perpetual frame loop', () => {
@@ -621,22 +630,12 @@ test('the mode handler commits one final world inside the scene transaction', ()
   assert.match(modeViewTransitionSrc, /if \(!supported\) \{[\s\S]*?flushSync\(update\)/)
 })
 
-test('the PROPOSED builder power-chrome is behind a default-OFF flag + root class', () => {
-  // The flag only enables on the literal '1' (default off), read once at load.
-  assert.match(paneModelSrc, /export const BUILDER_POWER_CHROME = \(\(\) => \{[\s\S]*?localStorage\.getItem\('mobius:builder-power'\) === '1'/)
-  // Shell adds the root class only when the flag is on AND builder mode is active.
-  assert.match(shell, /builderModeActive && paneModel\.BUILDER_POWER_CHROME \? ' shell--builder-power' : ''/)
-  // The gated chrome: a power-rail under the bar + energized dividers.
-  assert.match(shellCss, /\.shell--builder-power \.shell__bar\s*\{[\s\S]*?box-shadow/)
-  assert.match(css, /\.shell--builder-power \.workspace__divider-bar/)
-})
-
 test('the logo keeps the stable "Toggle navigation" name; gesture rides aria-description + live region', () => {
   // The accessible NAME stays stable (drawer semantics + e2e selectors depend on
   // it); the hold/keyboard path is a supplementary aria-description, and mode state
   // rides a polite live region (not a conflicting aria-pressed).
   assert.match(shellBrand, /aria-label="Toggle navigation"/)
-  assert.match(shellBrand, /aria-description=\{splitsEnabled\s*\n?\s*\? 'Hold or press Shift\+Enter for builder mode'/)
+  assert.match(shellBrand, /aria-description="Hold or press Shift\+Enter for builder mode"/)
   assert.match(shellBrand, /role="status" aria-live="polite"/)
   assert.match(shellBrand, /builderModeActive \? 'Builder mode' : 'Single screen'/)
 })
@@ -1064,17 +1063,6 @@ test('the builder preview cannot outlive its drag session past one visibility bo
   assert.match(dragBinding, /may outlive its session by at most ONE visibility\/foreground boundary,\s*\n?\s*\/\/ or at most one subsequent user interaction/)
 })
 
-test('the splits kill-switch forces the single-pane fallback so a rolled-back panes blob is not un-exitable', () => {
-  // The tiled render (chromeActive) is flag-INDEPENDENT, but both exit controls
-  // (the logo gesture + Shift+Enter) are flag-GATED. So a rolled-back client that
-  // persisted a 'panes' blob and then had WORKSPACE_SPLITS disabled would restore
-  // TILED with no way to reach single ("cannot reach single mode", survives reload).
-  // coerceViewMode — run by normalize() on every parse/restore — forces 'single'
-  // when splits are off, delivering the kill-switch's documented single-pane fallback
-  // (the tree is preserved; re-enabling splits restores the panes).
-  assert.match(paneModelSrc, /function coerceViewMode\(mode\) \{\s*\n\s*if \(!WORKSPACE_SPLITS_ENABLED\) return 'single'/)
-})
-
 test('workspace focus, drag label, and cancel visuals remain coherent', () => {
   // V4: the FOCUSED pane's active pill softens the base full-accent border so the 2px
   // underline is what carries focus (the border used to mask it).
@@ -1176,7 +1164,6 @@ test('round4-3: every reducer edge into an empty single screen uses one policy b
   assert.ok(dispatch.length > 0, 'found the workspace dispatch boundary')
   assert.match(dispatch, /workspaceReducer\(prev, action\)/)
   assert.match(dispatch, /enteredEmptySingleScreen\(\s*prev\.ws, next\.ws/)
-  assert.match(dispatch, /prev\.ws, next\.ws, paneModel\.WORKSPACE_SPLITS_ENABLED/)
   assert.match(dispatch, /requestEmptySingleNewChatRef\.current\?\.\(\)/)
   // Explicit calls remain only for boot states that do not cross a reducer edge:
   // populated-history null restore and live-confirmed zero-chat bootstrap.

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -89,7 +89,8 @@ test('an implicit home tab does not engage the single-pane tab strip', () => {
 test('the canonical workspace snapshot survives a closed PWA relaunch', () => {
   assert.match(
     shell,
-    /useWorkspaceSession\(\{ storage: localStorage \}\)/,
+    /useWorkspaceSession\(\{\s*storage: localStorage,\s*legacyStorage: sessionStorage,\s*\}\)/,
+    'the durable snapshot remains canonical while the one-time session migration stays available',
   )
   assert.doesNotMatch(
     shell,

--- a/frontend/src/components/Shell/modeMachine.js
+++ b/frontend/src/components/Shell/modeMachine.js
@@ -45,21 +45,15 @@ export function modeReducer(state, event) {
   }
 }
 
-function clampMode(committedMode, splitsEnabled) {
-  if (!splitsEnabled) return 'single'
-  return committedMode
-}
-
-export function effectiveViewMode(state, { splitsEnabled = true } = {}) {
-  if (!splitsEnabled) return 'single'
+export function effectiveViewMode(state) {
   if (state.transition?.phase === 'drag-preview') return 'panes'
-  return clampMode(state.committedMode, splitsEnabled)
+  return state.committedMode
 }
 
-export function builderModeActive(state, { splitsEnabled = true } = {}) {
-  return clampMode(state.committedMode, splitsEnabled) === 'panes'
+export function builderModeActive(state) {
+  return state.committedMode === 'panes'
 }
 
-export function dragPreviewActive(state, { splitsEnabled = true } = {}) {
-  return !!splitsEnabled && state.transition?.phase === 'drag-preview'
+export function dragPreviewActive(state) {
+  return state.transition?.phase === 'drag-preview'
 }

--- a/frontend/src/components/Shell/newChatPolicy.js
+++ b/frontend/src/components/Shell/newChatPolicy.js
@@ -11,9 +11,9 @@ function normalizedId(value) {
  * edge check is important: actions while the landing is already visible must
  * not manufacture new request tokens.
  */
-export function enteredEmptySingleScreen(previous, next, splitsEnabled = true) {
-  const previousSingle = !splitsEnabled || previous?.viewMode === 'single'
-  const nextSingle = !splitsEnabled || next?.viewMode === 'single'
+export function enteredEmptySingleScreen(previous, next) {
+  const previousSingle = previous?.viewMode === 'single'
+  const nextSingle = next?.viewMode === 'single'
   return nextSingle
     && next?.singleScreen == null
     && (!previousSingle || previous?.singleScreen != null)

--- a/frontend/src/components/Shell/paneModel.js
+++ b/frontend/src/components/Shell/paneModel.js
@@ -47,42 +47,6 @@ export const PANE_GAP = 7
 // and positioned renderers cannot drift.
 export const STRIP_H = 34
 
-// Multi-pane exposure waits for the pane-aware back/sentinel work (stage B).
-// Until then every user ENTRY POINT into splits — the context-menu split/move
-// items and the phone pane chip/sheet — is ON by default now that the PR2
-// gates (unit + positive-behavior e2e) are green; 'mobius:workspace-splits'
-// = '0' is the kill switch that restores the single-pane fallback. Read once
-// at module load; absent-localStorage runtimes get the default (enabled).
-export const WORKSPACE_SPLITS_ENABLED = (() => {
-  try { return localStorage.getItem('mobius:workspace-splits') !== '0' } catch { return true }
-})()
-
-// Kill switch for the builder-mode Settings tab. When enabled (the default),
-// sanitizeTab accepts the canonical `settings:settings` tab so Settings can live
-// in a pane; the nav adapter opens it as a tab in builder mode and as the
-// takeover overlay in single mode. When DISABLED, sanitizeTab drops a Settings
-// tab exactly like an unknown kind — so a rolled-back client (feature shipped,
-// then flag turned off) SCRUBS any persisted Settings tab before first render
-// and reverts to today's overlay everywhere (design: flag-off sanitization).
-//
-// It is GATED on WORKSPACE_SPLITS_ENABLED (review §3): the Settings tab only makes
-// sense where builder mode (panes) can exist. With splits off there is no builder
-// mode, so a persisted `settings:settings` is scrubbed on parse AND new Settings
-// navigation routes to the takeover overlay — the tab can never leak into the
-// legacy single-pane strip. Read once at module load; '0' also disables.
-export const BUILDER_SETTINGS_ENABLED = WORKSPACE_SPLITS_ENABLED && (() => {
-  try { return localStorage.getItem('mobius:builder-settings') !== '0' } catch { return true }
-})()
-
-// PROPOSED "more power" builder chrome — NOT yet owner-approved (design item 6).
-// An accent power-rail under the top bar + accent-energized dividers while in
-// builder mode. Default OFF: it ships behind this flag so the owner can preview it
-// by flipping 'mobius:builder-power' to '1' (one class toggle, no rebuild). Read
-// once at load, mirroring the other kill switches; only the literal '1' enables it.
-export const BUILDER_POWER_CHROME = (() => {
-  try { return localStorage.getItem('mobius:builder-power') === '1' } catch { return false }
-})()
-
 // The smallest a pane may be. canSplit refuses a split whose either resulting
 // child would fall below this within the pane's current projected rect — the
 // shared feasibility predicate drag/menu/resolver all consult (design §3.2,
@@ -176,7 +140,7 @@ function sanitizeTab(raw) {
     return String(raw.id) === tabModel.APPS_ID ? tabModel.appsTab() : null
   }
   if (raw.kind === 'settings') {
-    return (BUILDER_SETTINGS_ENABLED && String(raw.id) === tabModel.SETTINGS_ID)
+    return String(raw.id) === tabModel.SETTINGS_ID
       ? tabModel.settingsTab()
       : null
   }
@@ -466,16 +430,7 @@ export function seedFromFlatTabs(tabs) {
 // full-bleed (the workspaceView derivation reads viewMode; the tree is untouched
 // so toggling back re-projects it exactly). Any other/absent value is 'panes'.
 //
-// The splits KILL SWITCH forces 'single' here — its documented job is to "restore
-// the single-pane fallback", and normalize() runs on every parse/restore. Without
-// this, a rolled-back client (splits shipped, blob persisted 'panes', then the flag
-// turned OFF) restores viewMode 'panes' and RENDERS TILED (the tiled derivation is
-// flag-independent) while BOTH exit controls — the logo gesture and Shift+Enter —
-// are flag-gated OFF: an un-exitable multi-pane workspace that survives reload
-// ("cannot reach single mode"). Forcing 'single' collapses to the focused tab and
-// preserves the tree, so re-enabling splits restores the panes.
 function coerceViewMode(mode) {
-  if (!WORKSPACE_SPLITS_ENABLED) return 'single'
   return mode === 'single' ? 'single' : 'panes'
 }
 
@@ -1609,7 +1564,7 @@ export function writeFocusedPaneView(paneId, storage) {
 //   - and it IS the focused pane (the lockstep invariant toggle/reconcile keep).
 // Any miss returns null → the workspace boots in its normal tiled view.
 export function resolveInitialFocusedPaneView(ws, rawId) {
-  if (!WORKSPACE_SPLITS_ENABLED || rawId == null || !ws || !ws.panes) return null
+  if (rawId == null || !ws || !ws.panes) return null
   if (ws.viewMode === 'single') return null
   if (Object.keys(ws.panes).length <= 1) return null
   if (!ws.panes[rawId]) return null

--- a/frontend/src/components/Shell/useModeController.js
+++ b/frontend/src/components/Shell/useModeController.js
@@ -4,7 +4,7 @@ import { initialModeState, modeReducer } from './modeMachine.js'
 // Synchronizes the durable workspace mode with the one transient state that still
 // belongs in React: drag-preview. Visual mode motion is a separate browser scene
 // transaction; this controller never watches CSS animations or schedules recovery.
-export default function useModeController({ committedMode, splitsEnabled = true }) {
+export default function useModeController({ committedMode }) {
   const [state, dispatch] = useReducer(
     modeReducer,
     undefined,
@@ -25,11 +25,6 @@ export default function useModeController({ committedMode, splitsEnabled = true 
   useEffect(() => {
     syncCommitted(committedMode)
   }, [committedMode, syncCommitted])
-
-  useEffect(() => {
-    if (splitsEnabled) return
-    syncCommitted('single')
-  }, [splitsEnabled, syncCommitted])
 
   const dragArm = useCallback(() => {
     const current = stateRef.current

--- a/frontend/src/components/Shell/useWorkspaceDrag.js
+++ b/frontend/src/components/Shell/useWorkspaceDrag.js
@@ -18,9 +18,7 @@ import {
 // document identifies a drag source by its `data-drag-key` (strip tabs in the
 // chrome AND the single-pane top strip, rows in the drawer) and geometrically
 // hit-tests against projectLayout rects — never DOM-event bubbling, because
-// iframes swallow events and the drawer is inert. Everything is gated behind
-// `enabled` (WORKSPACE_SPLITS_ENABLED); with the flag off the listener never
-// installs and the shell is unchanged.
+// iframes swallow events and the drawer is inert.
 
 const STRIP_ZONE_H = STRIP_H + STRIP_CARET_PAD
 const AUTO_SCROLL_EDGE = 32 // px from a strip's scroll edge that arms auto-scroll
@@ -70,7 +68,6 @@ function suppressNextSourceClick(sourceEl) {
 }
 
 export default function useWorkspaceDrag({
-  enabled,
   contentElRef,
   sceneInputsRef, // ref → { projection, mode, contentRect }
   workspaceStateRef, // ref → { ws, undo } (advanced synchronously by Shell's dispatch)
@@ -90,8 +87,6 @@ export default function useWorkspaceDrag({
   // single mode paints its own slot, never a forced takeover.)
 }) {
   useEffect(() => {
-    if (!enabled) return undefined
-
     // ── Reusable overlay DOM (created lazily on the first arm) ────────────────
     let shieldEl = null
     let chipEl = null
@@ -728,8 +723,7 @@ export default function useWorkspaceDrag({
       clearPendingSourceClick?.()
       removeOverlays()
     }
-    // enabled is a module-load constant and every volatile input arrives through
-    // a ref, so the listener installs exactly once.
+    // Every volatile input arrives through a ref, so the listener installs once.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [enabled])
+  }, [])
 }

--- a/frontend/src/components/Shell/useWorkspaceSession.js
+++ b/frontend/src/components/Shell/useWorkspaceSession.js
@@ -65,9 +65,7 @@ export default function useWorkspaceSession({ storage, legacyStorage = null }) {
     const next = paneModel.workspaceReducer(prev, action)
     workspaceStateRef.current = next
     const enteredEmptySingle = next.ws !== prev.ws
-      && enteredEmptySingleScreen(
-        prev.ws, next.ws, paneModel.WORKSPACE_SPLITS_ENABLED,
-      )
+      && enteredEmptySingleScreen(prev.ws, next.ws)
     if (next.ws !== prev.ws) {
       onWorkspaceTransitionRef.current?.(prev.ws, next.ws)
       const expanded = focusedPaneViewIdRef.current
@@ -100,8 +98,6 @@ export default function useWorkspaceSession({ storage, legacyStorage = null }) {
     if (settlePending) pendingContentRectRef.current = null
     setContentRect(prev => {
       if (prev.w === w && prev.h === h) return prev
-      if (!paneModel.WORKSPACE_SPLITS_ENABLED
-          && Object.keys(workspaceStateRef.current.ws.panes).length <= 1) return prev
       return { w, h }
     })
   }, [])

--- a/frontend/src/components/Shell/workspace.css
+++ b/frontend/src/components/Shell/workspace.css
@@ -191,12 +191,6 @@ html[data-mode-view-transition]::view-transition-new(*) {
   transform: scaleY(1);
 }
 
-/* PROPOSED builder power-chrome (design item 6, default OFF — gated by
-   .shell--builder-power on the shell root). Accent-energized resting dividers. */
-.shell--builder-power .workspace__divider-bar {
-  background: color-mix(in srgb, var(--accent) 55%, var(--border-light));
-}
-
 .workspace__divider--v:hover .workspace__divider-bar,
 .workspace__divider--v:focus-visible .workspace__divider-bar { transform: scaleX(3); }
 .workspace__divider--h:hover .workspace__divider-bar,

--- a/frontend/src/components/Shell/workspacePlacement.js
+++ b/frontend/src/components/Shell/workspacePlacement.js
@@ -271,8 +271,7 @@ export function resolveWorkspaceRequest(ws, request, env = {}) {
   // point for USER nav; the agent path funnels here) and honors the invariant that
   // single-mode opens never touch the pane tree. BACKGROUND work still parks in the
   // builder tree plus its attention dot — the builder world is the workshop. The
-  // world is clamped to single when the splits kill switch is off (INV 16).
-  const world = paneModel.WORKSPACE_SPLITS_ENABLED ? ws.viewMode : 'single'
+  const world = ws.viewMode
   if (foreground && world === 'single') {
     return paneModel.setSingleScreen(ws, { kind: item.kind, id: String(item.id) })
   }
@@ -291,7 +290,6 @@ export function resolveWorkspaceRequest(ws, request, env = {}) {
   // and park the preview in the hidden Builder tree for an explicit later open.
   let working = (
     preview
-    && paneModel.WORKSPACE_SPLITS_ENABLED
     && (world === 'panes' || singleShowsSource)
   )
     ? paneModel.setViewMode(ws, 'panes')

--- a/frontend/src/hooks/useNavigation.js
+++ b/frontend/src/hooks/useNavigation.js
@@ -174,7 +174,7 @@ export default function useNavigation({
   // the boot effect re-opens it, so the overlay must start closed.
   const [settingsOpen, setSettingsOpen] = useState(
     initialNav.view === 'settings'
-    && !(paneModel.BUILDER_SETTINGS_ENABLED && workspace.viewMode === 'panes'),
+    && workspace.viewMode !== 'panes',
   )
   // Visual visibility is intentionally separate from history ownership.
   // An explicit tap/swipe close can start the panel transition immediately
@@ -196,7 +196,7 @@ export default function useNavigation({
   // tab, each shown only in its own world, NEVER destructively converted between
   // them (INV 6/7).
   const overlayShowing = settingsOpen
-    && (workspace.viewMode === 'single' || !paneModel.BUILDER_SETTINGS_ENABLED)
+    && workspace.viewMode === 'single'
   const activeView = overlayShowing ? 'settings' : contentRoute.view
   const activeChatId = contentRoute.chatId
   const activeAppId = contentRoute.appId
@@ -251,7 +251,7 @@ export default function useNavigation({
   // user was really looking at (finding M1).
   const overlayShowingForWs = useCallback(
     (ws) => settingsOpenRef.current
-      && (ws.viewMode === 'single' || !paneModel.BUILDER_SETTINGS_ENABLED),
+      && ws.viewMode === 'single',
     [],
   )
   // The committed set of visible pane ids (excludes phone-deck-hidden panes).
@@ -356,7 +356,7 @@ export default function useNavigation({
     // + visiblePaneIds) names HIDDEN tree panes that do not paint, so consulting it
     // there would classify an unpainted app as visible and let Back FOCUS + nav-back
     // into an invisible iframe. Only the BUILDER world reads the tree/visible set.
-    const mode = paneModel.WORKSPACE_SPLITS_ENABLED ? ws.viewMode : 'single'
+    const mode = ws.viewMode
     if (mode === 'single') {
       if ('singleScreen' in ws) {
         const slot = ws.singleScreen
@@ -877,7 +877,7 @@ export default function useNavigation({
   // React batch snapshots the correct overlay flag (mirrors navTo's own pattern).
   const applySettingsDestination = useCallback((paneId) => {
     const ws = workspaceStateRef.current.ws
-    if (paneModel.BUILDER_SETTINGS_ENABLED && ws.viewMode === 'panes') {
+    if (ws.viewMode === 'panes') {
       const targetPaneId = (typeof paneId === 'string' && ws.panes[paneId])
         ? paneId
         : ws.focusedPaneId
@@ -913,7 +913,7 @@ export default function useNavigation({
     // Kill-switch clamp BEFORE the world branch (finding 9; INV 16): with splits
     // disabled the presentation is single, so a chat/app nav must set the SLOT,
     // never OPEN_TAB into the hidden pane tree.
-    const mode = paneModel.WORKSPACE_SPLITS_ENABLED ? ws.viewMode : 'single'
+    const mode = ws.viewMode
     // A USER-initiated chat/app open leaves any Settings takeover (they chose to go
     // elsewhere). A BACKGROUND repair/seed passes preserveSettings (R1): it writes
     // the destination BENEATH an open takeover without dismissing it, so a boot-seed
@@ -1142,8 +1142,7 @@ export default function useNavigation({
       // RESET_FLAT deliberately preserves a slot, so omitting the second write
       // would leave the implicit starter chat mounted behind the requested chat.
       const bootDeepLink = (route, tab) => {
-        const mode = paneModel.WORKSPACE_SPLITS_ENABLED
-          ? workspaceStateRef.current.ws.viewMode : 'single'
+        const mode = workspaceStateRef.current.ws.viewMode
         if (mode === 'single') {
           if (!blobValid) openBootTab(tab)
           applyModeDestination(route)
@@ -1171,7 +1170,6 @@ export default function useNavigation({
         openBootTab(tabModel.makeTab('chat', initialNav.chatId))
       } else if (
         initialNav.view === 'settings'
-        && paneModel.BUILDER_SETTINGS_ENABLED
         && workspaceStateRef.current.ws.viewMode === 'panes'
       ) {
         // Reload/return-to-settings in builder mode: make the Settings tab the

--- a/frontend/src/lib/__tests__/navigationWorkspaceContract.test.js
+++ b/frontend/src/lib/__tests__/navigationWorkspaceContract.test.js
@@ -175,11 +175,11 @@ test('the legacy active destination wins every blob-invalid flat-tab boot', () =
 // nav-bookkeeping consumers that decide "what is visible / what did Back see" must
 // read the PAINTED overlay (world-gated), never the raw settingsOpen flag.
 test('M1: overlayShowingForWs is the world-gated PAINTED takeover, not the raw flag', () => {
-  // Mirrors the render-time overlayShowing derivation: single world OR builder-
-  // Settings flag off. This is the one predicate both consumers below share.
+  // Mirrors the render-time overlayShowing derivation. This is the one predicate
+  // both consumers below share.
   assert.match(
     navigation,
-    /const overlayShowingForWs = useCallback\(\s*\(ws\) => settingsOpenRef\.current\s*&& \(ws\.viewMode === 'single' \|\| !paneModel\.BUILDER_SETTINGS_ENABLED\)/,
+    /const overlayShowingForWs = useCallback\(\s*\(ws\) => settingsOpenRef\.current\s*&& ws\.viewMode === 'single'/,
   )
 })
 

--- a/tests/mode-transition.spec.mjs
+++ b/tests/mode-transition.spec.mjs
@@ -39,7 +39,7 @@ async function bootShell(page, viewport) {
 }
 
 // Mock a chat GET so a seeded chat pane mounts a ChatView without a network error,
-// then seed a persisted workspace blob into sessionStorage before boot.
+// then seed a persisted workspace blob into durable browser storage before boot.
 async function bootSeededWorkspace(page, viewport, ws) {
   await page.setViewportSize(viewport)
   await page.route(/\/api\/chats\/[0-9a-f-]+\/messages$/, r => r.fulfill({ status: 202, body: '{}' }))
@@ -51,7 +51,7 @@ async function bootSeededWorkspace(page, viewport, ws) {
   })
   const blob = paneModel.serializeWorkspace(ws)
   await page.addInitScript(([key, raw]) => {
-    try { sessionStorage.setItem(key, raw); sessionStorage.setItem('mobius-open-tabs', '[]') } catch { /* private mode */ }
+    try { localStorage.setItem(key, raw) } catch { /* private mode */ }
   }, [paneModel.STORAGE_KEY, blob])
   await page.goto(BASE, { waitUntil: 'domcontentloaded' })
   await page.waitForSelector('.shell', { timeout: 10000 })

--- a/tests/navigation.spec.mjs
+++ b/tests/navigation.spec.mjs
@@ -557,12 +557,8 @@ test.describe('Drawer touch lifecycle', () => {
   test.use({ hasTouch: true })
 
   test('an interrupted workspace drag cannot consume the next real drawer-row tap', async ({ page }) => {
-    // Enable workspace gestures before the shell module evaluates. Touch drawer
-    // rows intentionally own menu/reorder locally; a hybrid device's mouse or
+    // Touch drawer rows own menu/reorder locally; a hybrid device's mouse or
     // trackpad still uses the row-to-workspace drag contract tested below.
-    await page.addInitScript(() => {
-      localStorage.setItem('mobius:workspace-splits', '1')
-    })
     await setup(page, { width: 412, height: 915 })
     await openDrawer(page)
 
@@ -1605,16 +1601,15 @@ async function bootTwoAppPanes(page) {
     contentType: 'application/json',
     body: JSON.stringify({ token: 'mock-app-token' }),
   }))
-  // Land on the origin, then seed the flag + workspace blob and re-navigate so
-  // the shell boots the two-pane tree with the splits flag on.
+  // Land on the origin, then seed the canonical workspace and re-navigate so
+  // the shell boots the two-pane tree.
   await page.goto(BASE, { waitUntil: 'domcontentloaded' })
   const blob = paneModel.serializeWorkspace(twoAppPanes())
-  await page.addInitScript(([flagKey, wsKey, wsBlob]) => {
+  await page.addInitScript(([wsKey, wsBlob]) => {
     try {
-      localStorage.setItem(flagKey, '1')
-      sessionStorage.setItem(wsKey, wsBlob)
+      localStorage.setItem(wsKey, wsBlob)
     } catch { /* private mode */ }
-  }, ['mobius:workspace-splits', paneModel.STORAGE_KEY, blob])
+  }, [paneModel.STORAGE_KEY, blob])
   await page.goto(`${BASE}/shell/?app=${PANE_APP_A}`, { waitUntil: 'domcontentloaded' })
   await expect(page.locator('.workspace__chrome')).toHaveCount(1, { timeout: 8000 })
   await page.evaluate(() => new Promise(r =>

--- a/tests/shell-update-idle.spec.mjs
+++ b/tests/shell-update-idle.spec.mjs
@@ -156,13 +156,9 @@ async function seedTwoPaneBuilder(page, firstChatId, secondChatId) {
   })
   workspace = paneModel.focusPane(workspace, 'p0')
   const blob = paneModel.serializeWorkspace(workspace)
-  const legacy = JSON.stringify(paneModel.flatten(workspace)
-    .map(tab => ({ kind: tab.kind, id: tab.id })))
-  await page.addInitScript(([workspaceKey, workspaceBlob, openTabs]) => {
-    localStorage.setItem('mobius:workspace-splits', '1')
-    sessionStorage.setItem(workspaceKey, workspaceBlob)
-    sessionStorage.setItem('mobius-open-tabs', openTabs)
-  }, [paneModel.STORAGE_KEY, blob, legacy])
+  await page.addInitScript(([workspaceKey, workspaceBlob]) => {
+    localStorage.setItem(workspaceKey, workspaceBlob)
+  }, [paneModel.STORAGE_KEY, blob])
 }
 
 async function sendMessage(page, text) {

--- a/tests/tabs.spec.mjs
+++ b/tests/tabs.spec.mjs
@@ -215,29 +215,23 @@ async function seedTabs(page, tabs, { viewMode = 'panes' } = {}) {
   let ws = paneModel.seedFromFlatTabs(tabs)
   ws = paneModel.setViewMode(ws, viewMode)
   const workspace = paneModel.serializeWorkspace(ws)
-  await page.addInitScript(([workspaceKey, workspaceRaw, legacyKey, t]) => {
+  await page.addInitScript(([workspaceKey, workspaceRaw]) => {
     try {
-      // Match the shell's dual-write persistence contract. The versioned
-      // workspace is authoritative; the flat key only supports one-release
-      // rollback and may already contain an older projection.
-      sessionStorage.setItem(workspaceKey, workspaceRaw)
-      sessionStorage.setItem(legacyKey, JSON.stringify(t))
+      localStorage.setItem(workspaceKey, workspaceRaw)
     } catch { /* private mode */ }
-  }, [paneModel.STORAGE_KEY, workspace, 'mobius-open-tabs', tabs])
+  }, [paneModel.STORAGE_KEY, workspace])
 }
 
-// Single-SCREEN workspace holding just `chatId`, with an EMPTY legacy mirror so
-// the strip is unengaged. A valid blob remains authoritative through a cold
-// ?chat= deep-link; the target opens into that workspace without RESET_FLAT
-// replacing its preserved view mode.
+// Single-SCREEN workspace holding just `chatId`. A valid blob remains
+// authoritative through a cold ?chat= deep-link; the target opens into that
+// workspace without RESET_FLAT replacing its preserved view mode.
 async function seedSingleModeChat(page, chatId) {
   const ws = paneModel.setViewMode(
     paneModel.seedFromFlatTabs([{ kind: 'chat', id: chatId }]), 'single')
   const workspace = paneModel.serializeWorkspace(ws)
   await page.addInitScript(([workspaceKey, workspaceRaw]) => {
     try {
-      sessionStorage.setItem(workspaceKey, workspaceRaw)
-      sessionStorage.setItem('mobius-open-tabs', '[]')
+      localStorage.setItem(workspaceKey, workspaceRaw)
     } catch { /* private mode */ }
   }, [paneModel.STORAGE_KEY, workspace])
 }
@@ -395,7 +389,6 @@ test.describe('Tabs', () => {
     const chat = await bootAndCreateChat(page, 'split', { width: 1200, height: 800 })
     const appsMock = await mockOwnedApp(page, chat.id)
     await seedTabs(page, [{ kind: 'chat', id: chat.id }, { kind: 'app', id: APP_ID }])
-    await page.addInitScript(() => localStorage.setItem('mobius:workspace-splits', '1'))
 
     await page.goto(`${BASE}/shell/?chat=${chat.id}`, { waitUntil: 'domcontentloaded' })
     await expect.poll(() => appsMock.requests, { timeout: 5000 }).toBeGreaterThan(0)

--- a/tests/workspace-panes.spec.mjs
+++ b/tests/workspace-panes.spec.mjs
@@ -12,10 +12,9 @@
  *   (d) close-only tab actions remain available while model split caps hold;
  *   (e) a projection flip to phone preserves the persisted tree and pane focus;
  *
- * The flag is enabled per-test (localStorage 'mobius:workspace-splits' = '1')
- * and a 2-pane workspace blob is seeded in localStorage before the shell
- * boots, exactly like tabs.spec seeds the flat workspace. Agent + apps routes
- * are intercepted so no agent tokens are consumed.
+ * A 2-pane workspace blob is seeded in localStorage before the shell boots,
+ * exactly like tabs.spec seeds the canonical workspace. Agent + apps routes are
+ * intercepted so no agent tokens are consumed.
  *
  * Run: scripts/playwright-local.sh --allow-local-e2e tests/workspace-panes.spec.mjs --project=tests
  */
@@ -150,36 +149,29 @@ async function mockApps(page, apps) {
   return state
 }
 
-/** Seed a workspace blob (authoritative) + the legacy flat mirror + the splits
- *  flag, all before the shell bundle evaluates on the next navigation. */
+/** Seed the canonical workspace before the shell bundle evaluates. */
 async function seedWorkspace(page, ws) {
   const blob = paneModel.serializeWorkspace(ws)
-  const legacy = JSON.stringify(paneModel.flatten(ws).map(t => ({ kind: t.kind, id: t.id })))
-  await page.addInitScript(([flagKey, wsKey, wsBlob, legKey, leg]) => {
+  await page.addInitScript(([wsKey, wsBlob]) => {
     try {
-      localStorage.setItem(flagKey, '1')
       localStorage.setItem(wsKey, wsBlob)
-      sessionStorage.setItem(legKey, leg)
     } catch { /* private mode */ }
-  }, ['mobius:workspace-splits', paneModel.STORAGE_KEY, blob, 'mobius-open-tabs', legacy])
+  }, [paneModel.STORAGE_KEY, blob])
 }
 
-/** Seed one explicit Builder leaf while keeping the legacy strip mirror empty.
- *  Fresh workspaces now intentionally start in Standard; this fixture owns the
- *  older "one chat, strip never engaged" Builder state directly. */
+/** Seed one explicit Builder leaf. Fresh workspaces intentionally start in
+ *  Standard, so this fixture owns the Builder state directly. */
 async function seedBuilderSingleLeaf(page, chatId) {
   const ws = paneModel.setViewMode(
     paneModel.seedFromFlatTabs([{ kind: 'chat', id: chatId }]),
     'panes',
   )
   const blob = paneModel.serializeWorkspace(ws)
-  await page.addInitScript(([flagKey, workspaceKey, workspaceBlob]) => {
+  await page.addInitScript(([workspaceKey, workspaceBlob]) => {
     try {
-      localStorage.setItem(flagKey, '1')
       localStorage.setItem(workspaceKey, workspaceBlob)
-      sessionStorage.setItem('mobius-open-tabs', '[]') // empty legacy -> strip not engaged
     } catch { /* private mode */ }
-  }, ['mobius:workspace-splits', paneModel.STORAGE_KEY, blob])
+  }, [paneModel.STORAGE_KEY, blob])
 }
 
 /** Two chat panes side by side: p0 = chatA (focused), p1 = chatB. */
@@ -1492,11 +1484,7 @@ test.describe('Workspace view-mode toggle', () => {
     await page.mouse.up()
   })
 
-  // Regression (item 0): the splits KILL SWITCH must collapse a persisted 'panes'
-  // blob to single on restore. The tiled render is flag-independent but both exit
-  // controls are flag-gated, so a rolled-back client (splits off, panes blob) would
-  // otherwise restore TILED with no way to reach single — un-exitable, across reload.
-  test('(item 0) splits kill-switch collapses a persisted panes blob to single, never un-exitable tiled', async ({ page }) => {
+  test('a persisted Builder workspace restores canonically and remains exit-able', async ({ page }) => {
     await boot(page, WIDE)
     const a = await createTaggedChat(page, 'killA')
     const b = await createTaggedChat(page, 'killB')
@@ -1504,18 +1492,19 @@ test.describe('Workspace view-mode toggle', () => {
     const blob = paneModel.serializeWorkspace(twoChatPanes(a.id, b.id)) // viewMode 'panes'
     await page.addInitScript((wsBlob) => {
       try {
-        localStorage.setItem('mobius:workspace-splits', '0') // KILL SWITCH OFF
         localStorage.setItem('mobius-workspace', wsBlob)
       } catch { /* private mode */ }
     }, blob)
     await page.goto(`${BASE}/shell/?chat=${a.id}`, { waitUntil: 'domcontentloaded' })
-    await expect(page.locator('.shell__chat-view.shell__view--active')).toHaveCount(1, { timeout: 8000 })
-    // Restored SINGLE despite the persisted 'panes' viewMode: no tiled chrome/panes.
+    await expect(page.locator('.workspace__chrome')).toHaveCount(1, { timeout: 8000 })
+    expect((await readWs(page)).viewMode).toBe('panes')
+    const brand = page.getByRole('button', { name: 'Toggle navigation' })
+    await expect(brand).toHaveClass(/shell__brand--builder/)
+
+    await brand.focus()
+    await page.keyboard.press('Shift+Enter')
+    await expect.poll(() => readWs(page).then(ws => ws.viewMode)).toBe('single')
     await expect(page.locator('.workspace__chrome')).toHaveCount(0)
-    await expect(page.locator('.shell__view--paned')).toHaveCount(0)
-    expect((await readWs(page)).viewMode).toBe('single')
-    // The logo carries no builder state either (there is no builder mode with splits off).
-    await expect(page.getByRole('button', { name: 'Toggle navigation' })).not.toHaveClass(/shell__brand--builder/)
   })
 
   // single-mode + ONE leaf: dragging stays enabled; the drop's shape decides


### PR DESCRIPTION
## Summary
- persist one canonical workspace across full app relaunches
- remove completed rollout switches and dormant Builder chrome/settings branches
- route mode changes, dragging, placement, and navigation through the canonical workspace owner

This includes the durable restoration work from #526 and extends it by removing the rollout scaffolding that would otherwise leave two behavioral paths to maintain.

## Testing
- `npm test`