### PR TITLE
Keep recovered goals stable during chat streaming

### DIFF
--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -2100,7 +2100,7 @@ class ChatWriterActor:
     from app.models import ChatRun
     from app.run_state import goal_objective_for_run_start
     goal_objective = goal_objective_for_run_start(
-      db, cmd.chat_id, cmd.user_msg.get("content"),
+      db, cmd.chat_id, cmd.user_msg,
     )
     self._close_nonterminal_runs(db, cmd.chat_id, "interrupted")
     db.add(ChatRun(
@@ -2503,7 +2503,7 @@ class ChatWriterActor:
     from app.continuations import is_continuation_message
     from app.run_state import goal_objective_for_run_start
     goal_objective = goal_objective_for_run_start(
-      db, cmd.chat_id, agent_pending.get("content"),
+      db, cmd.chat_id, agent_pending,
     )
     prior_run = (
       db.query(ChatRun)

--- a/backend/app/routes/chats_stream.py
+++ b/backend/app/routes/chats_stream.py
@@ -293,9 +293,14 @@ def _user_message_from_body(
   if body.cid:
     user_msg["cid"] = body.cid
   ensure_user_cid(user_msg)
-  if body.continuation == "manual":
+  # A recovered question answer resumes the interrupted logical turn even
+  # though its provider prompt contains the human-readable answer.
+  continuation_reason = (
+    "question_answer" if body.answers else body.continuation
+  )
+  if continuation_reason:
     user_msg["kind"] = "continuation"
-    user_msg["continuation_reason"] = "manual"
+    user_msg["continuation_reason"] = continuation_reason
   if body.hidden:
     user_msg["hidden"] = True
   if body.attachments:

--- a/backend/app/run_state.py
+++ b/backend/app/run_state.py
@@ -6,7 +6,8 @@ parked, or awaiting continuation. Runtime ownership still lives in
 reconstructed from a second per-chat marker.
 """
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
+from typing import Any
 
 from sqlalchemy.orm import Session
 
@@ -16,7 +17,7 @@ from app import models
 def goal_objective_for_run_start(
   db: Session,
   chat_id: str,
-  content: str | None,
+  message: Mapping[str, Any] | None,
 ) -> str | None:
   """Resolve the goal metadata for a newly opened durable run.
 
@@ -25,11 +26,13 @@ def goal_objective_for_run_start(
   ordinary turn after a completed goal therefore cannot revive stale UI state.
   """
   from app.chat_context import _goal_objective
+  from app.continuations import is_continuation_message
 
-  objective = _goal_objective(content or "")
+  content = message.get("content") if message is not None else ""
+  objective = _goal_objective(content if isinstance(content, str) else "")
   if objective is not None:
     return objective
-  if (content or "").strip().lower() != "continue":
+  if not is_continuation_message(message):
     return None
   previous = latest_run(db, chat_id)
   if previous is None or previous.status not in (

--- a/backend/tests/test_chat_runs.py
+++ b/backend/tests/test_chat_runs.py
@@ -111,7 +111,7 @@ def test_start_turn_opens_a_running_run_record():
   assert _active_status("r1") == "running"
 
 
-def test_goal_identity_lives_on_the_run_and_real_resume_inherits_it():
+def test_only_semantic_continuation_inherits_goal_identity():
   _seed_chat("r-goal")
   get_writer().submit(StartTurn(
     chat_id="r-goal", run_token="rt-goal",
@@ -129,10 +129,25 @@ def test_goal_identity_lives_on_the_run_and_real_resume_inherits_it():
   )).result(timeout=5)
   get_writer().submit(StartTurn(
     chat_id="r-goal", run_token="rt-resume",
-    user_msg={"role": "user", "content": "continue", "ts": 2},
+    user_msg={
+      "role": "user", "content": "continue", "ts": 2,
+      "kind": "continuation", "continuation_reason": "manual",
+    },
     title_source="continue", default_provider="codex",
   )).result(timeout=5)
   assert _goal_objective("r-goal") == "finish the migration"
+
+  get_writer().submit(FinishRun(
+    chat_id="r-goal",
+    run_token="rt-resume",
+    terminal_status="interrupted",
+  )).result(timeout=5)
+  get_writer().submit(StartTurn(
+    chat_id="r-goal", run_token="rt-plain-continue",
+    user_msg={"role": "user", "content": "continue", "ts": 3},
+    title_source="continue", default_provider="codex",
+  )).result(timeout=5)
+  assert _goal_objective("r-goal") is None
 
 
 def test_completed_goal_does_not_leak_into_an_ordinary_later_run():
@@ -151,6 +166,35 @@ def test_completed_goal_does_not_leak_into_an_ordinary_later_run():
     title_source="ordinary", default_provider="codex",
   )).result(timeout=5)
   assert _goal_objective("r-complete-goal") is None
+
+
+def test_stopped_goal_does_not_leak_into_a_later_question_answer():
+  _seed_chat("r-stopped-goal")
+  get_writer().submit(StartTurn(
+    chat_id="r-stopped-goal", run_token="rt-stopped-goal",
+    user_msg={
+      "role": "user", "content": "/goal old work", "ts": 1,
+    },
+    title_source="goal", default_provider="codex",
+  )).result(timeout=5)
+  get_writer().submit(FinishRun(
+    chat_id="r-stopped-goal",
+    run_token="rt-stopped-goal",
+    terminal_status="stopped",
+  )).result(timeout=5)
+  get_writer().submit(StartTurn(
+    chat_id="r-stopped-goal", run_token="rt-later-answer",
+    user_msg={
+      "role": "user",
+      "content": "- Pick one: b",
+      "kind": "continuation",
+      "continuation_reason": "question_answer",
+      "hidden": True,
+      "ts": 2,
+    },
+    title_source="answer", default_provider="codex",
+  )).result(timeout=5)
+  assert _goal_objective("r-stopped-goal") is None
 
 
 # -- clean close ----------------------------------------------------------

--- a/backend/tests/test_chats_stream_answer_race.py
+++ b/backend/tests/test_chats_stream_answer_race.py
@@ -50,7 +50,12 @@ def _make_pending(future: asyncio.Future) -> PendingQuestion:
   )
 
 
-def _seed_question_block(chat_id: str, question_id: str) -> None:
+def _seed_question_block(
+  chat_id: str,
+  question_id: str,
+  *,
+  user_content: str = "go",
+) -> None:
   """Persist an assistant message carrying the open question block.
 
   C2 routes the answer write through the actor's AnswerQuestion, which
@@ -64,7 +69,7 @@ def _seed_question_block(chat_id: str, question_id: str) -> None:
   try:
     chat = db.query(models.Chat).filter(models.Chat.id == chat_id).first()
     chat.messages = [
-      {"role": "user", "content": "go", "ts": 1},
+      {"role": "user", "content": user_content, "ts": 1},
       {
         "role": "assistant",
         "content": "",
@@ -224,7 +229,22 @@ def test_answer_recovers_durable_question_without_live_pending(
 
   async def go():
     qid = "q-recovered"
-    _seed_question_block(chat.id, qid)
+    _seed_question_block(
+      chat.id, qid, user_content="/goal finish the migration",
+    )
+    db = SessionLocal()
+    try:
+      db.add(models.ChatRun(
+        id="rt-interrupted-goal",
+        chat_id=chat.id,
+        status="interrupted",
+        provider="codex",
+        goal_objective="finish the migration",
+        started_at=datetime.now(UTC),
+      ))
+      db.commit()
+    finally:
+      db.close()
     _set_pending_messages(
       chat.id,
       [{"role": "user", "content": "queued-visible", "ts": 3}],
@@ -251,6 +271,11 @@ def test_answer_recovers_durable_question_without_live_pending(
     assert scheduled, "recovered answer should start a hidden continuation"
     assert scheduled[0]["next_user"]["hidden"] is True
     assert scheduled[0]["next_user"]["content"] == "- Pick one: b"
+    assert scheduled[0]["next_user"]["kind"] == "continuation"
+    assert (
+      scheduled[0]["next_user"]["continuation_reason"]
+      == "question_answer"
+    )
 
     db = SessionLocal()
     try:
@@ -265,9 +290,10 @@ def test_answer_recovers_durable_question_without_live_pending(
       assert [m["content"] for m in row.pending_messages] == [
         "queued-visible"
       ]
-      assert db.query(models.ChatRun).filter_by(
+      running = db.query(models.ChatRun).filter_by(
         chat_id=chat.id, status="running",
-      ).count() == 1
+      ).one()
+      assert running.goal_objective == "finish the migration"
     finally:
       db.close()
 

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -124,6 +124,7 @@ import {
 } from './buildPhaseRail.js'
 import {
   goalObjectiveAtRunStart,
+  goalObjectiveFromRuntime,
   latestGoalObjective,
   progressRailViewModel,
 } from './goalProgress.js'
@@ -869,13 +870,14 @@ export default function ChatView({
       if (data.running || (!preserveLocalTurn && !staleSnapshot)) {
         setServerRunningLocalState(!!data.running)
       }
-      setActiveGoalObjective(data.running
-        ? (data.active_goal_objective || latestGoalObjective(msgs))
-        : '')
+      const runtimeGoalObjective = goalObjectiveFromRuntime(
+        data, latestGoalObjective(msgs),
+      )
+      setActiveGoalObjective(runtimeGoalObjective)
       setLiveQuestionId(data.pending_question_id || null)
       updateChatRuntimeCache(queryClient, chatMessagesQueryKey(chatId), {
         running: !!data.running,
-        activeGoalObjective: data.active_goal_objective || '',
+        activeGoalObjective: runtimeGoalObjective,
         pending_messages: data.pending_messages || [],
         pending_question_id: data.pending_question_id || null,
       })
@@ -948,11 +950,17 @@ export default function ChatView({
       // optimistic transitions; using them here made one poll emit up to three
       // persisted-cache updates for a single server response.
       setServerRunningLocalState(!!data.running)
-      setActiveGoalObjective(data.running ? (data.active_goal_objective || '') : '')
+      const cachedGoalObjective = queryClient.getQueryData(
+        chatMessagesQueryKey(chatId),
+      )?.activeGoalObjective
+      const runtimeGoalObjective = goalObjectiveFromRuntime(
+        data, cachedGoalObjective,
+      )
+      setActiveGoalObjective(runtimeGoalObjective)
       setLiveQuestionId(data.pending_question_id || null)
       updateChatRuntimeCache(queryClient, chatMessagesQueryKey(chatId), {
         running: !!data.running,
-        activeGoalObjective: data.active_goal_objective || '',
+        activeGoalObjective: runtimeGoalObjective,
         pending_messages: serverPending,
         pending_question_id: data.pending_question_id || null,
       })
@@ -1688,9 +1696,9 @@ export default function ChatView({
     const settleRuntime = (runtime, visibleMessages) => {
       const running = !!runtime.running
       setServerRunningLocalState(running)
-      setActiveGoalObjective(running
-        ? (runtime.active_goal_objective || latestGoalObjective(visibleMessages))
-        : '')
+      setActiveGoalObjective(goalObjectiveFromRuntime(
+        runtime, latestGoalObjective(visibleMessages),
+      ))
       hadMessagesRef.current = visibleMessages.length > 0
       setLiveQuestionId(runtime.pending_question_id || null)
       setBridgeMountInputs({
@@ -1794,9 +1802,12 @@ export default function ChatView({
         // One narrow cache publication updates queue/liveness only. Reconcile
         // the mounted hidden owner from the newest version-matched cache object
         // before readiness so a concurrent terminal refresh wins this race.
+        const runtimeGoalObjective = goalObjectiveFromRuntime(
+          runtime, latestGoalObjective(msgs),
+        )
         updateChatRuntimeCache(queryClient, queryKey, {
           running: !!runtime.running,
-          activeGoalObjective: runtime.active_goal_objective || '',
+          activeGoalObjective: runtimeGoalObjective,
           pending_messages: runtime.pending_messages || [],
           pending_question_id: runtime.pending_question_id || null,
         })
@@ -1822,6 +1833,9 @@ export default function ChatView({
             // the latest cache/mounted owner for the optimistic handoff but
             // make the next activation take the authoritative detail path.
             updated_at: null,
+            activeGoalObjective: goalObjectiveFromRuntime(
+              runtime, latestGoalObjective(messagesRef.current),
+            ),
             ...handoffWindow,
           }
         })
@@ -1845,6 +1859,9 @@ export default function ChatView({
           })
       queryClient.setQueryData(queryKey, {
         ...detailCache,
+        activeGoalObjective: goalObjectiveFromRuntime(
+          runtime, latestGoalObjective(refreshed.messages),
+        ),
         messages: refreshed.messages,
         offset: refreshed.offset,
       })

--- a/frontend/src/components/ChatView/__tests__/goalProgress.test.js
+++ b/frontend/src/components/ChatView/__tests__/goalProgress.test.js
@@ -5,6 +5,7 @@ import { readFileSync } from 'node:fs'
 import {
   goalObjectiveAtRunStart,
   goalObjectiveFromText,
+  goalObjectiveFromRuntime,
   latestGoalObjective,
   progressRailViewModel,
 } from '../goalProgress.js'
@@ -75,7 +76,7 @@ test('a resumable continue keeps the same goal through live start and cold attac
   )
 })
 
-test('continue does not revive a completed, cleared, or superseded goal', () => {
+test('continuation recovery preserves only an active goal', () => {
   assert.equal(goalObjectiveAtRunStart('continue', [
     { role: 'user', content: '/goal old objective' },
     { role: 'assistant', content: 'Done' },
@@ -94,6 +95,18 @@ test('continue does not revive a completed, cleared, or superseded goal', () => 
     { role: 'assistant', blocks: [{ type: 'error', resumable: true }] },
     { role: 'user', content: 'continue' },
   ]), '')
+  assert.equal(goalObjectiveFromRuntime({
+    running: true,
+    active_goal_objective: null,
+  }, 'finish the migration'), 'finish the migration')
+  assert.equal(goalObjectiveFromRuntime({
+    running: true,
+    active_goal_objective: 'authoritative goal',
+  }, 'stale goal'), 'authoritative goal')
+  assert.equal(goalObjectiveFromRuntime({
+    running: false,
+    active_goal_objective: null,
+  }, 'finished goal'), '')
 })
 
 test('the goal reuses the progress rail and stays as context for build phases', () => {
@@ -184,7 +197,7 @@ test('ChatView binds goal state to explicit run boundaries, not transport livene
   )
   assert.match(
     chatView,
-    /runtime\.active_goal_objective \|\| latestGoalObjective\(visibleMessages\)/,
+    /goalObjectiveFromRuntime\(\s*runtime,\s*latestGoalObjective\(visibleMessages\)/,
     'a cold chat read should restore the objective from the durable active run',
   )
   assert.match(

--- a/frontend/src/components/ChatView/goalProgress.js
+++ b/frontend/src/components/ChatView/goalProgress.js
@@ -85,6 +85,12 @@ export function goalObjectiveAtRunStart(text, messages) {
   return priorGoalObjective(messages, tailIndex)
 }
 
+/** Keep a known goal through a rolling/recovered active runtime; idle ends it. */
+export function goalObjectiveFromRuntime(runtime, fallbackObjective = '') {
+  if (!runtime?.running) return ''
+  return runtime.active_goal_objective || fallbackObjective || ''
+}
+
 /**
  * Put the active goal and ordinary build phases on one existing progress rail.
  *


### PR DESCRIPTION
## Summary

- preserve active goal ownership when a durable question answer resumes an interrupted turn after restart
- keep an established goal visible when a live runtime refresh temporarily has no goal label
- synchronize the displayed and cached goal across chat refresh and activation paths
- cover interrupted, stopped, and recovered-question boundaries

## Context

Follow-up to #429 and #508. Those changes made goal identity durable through steered questions and transient connection loss, but a question answered after restart starts a recovered hidden continuation whose prompt is the answer rather than the literal `continue`. That continuation therefore opened a run without its prior goal. The runtime poll then cleared the rail from the empty durable label, while transcript recovery restored it on the next render, producing a repeated flash.

This change persists the recovered answer as an explicit continuation, inherits goal ownership only from unfinished or interrupted runs, and keeps the client’s established goal until an authoritative run end. Completed or stopped goals still do not leak into later turns.

## Testing

- `scripts/wt-pytest.sh backend/tests/test_chat_runs.py backend/tests/test_chats_stream_answer_race.py -q`
- `npm test`
- targeted ESLint
- authenticated rendered regression against a live recovered goal

Co-authored-by: Möbius Agent <mobius-agent@users.noreply.github.com>