### PR TITLE
Add a reviewed per-device asset cache for apps

### DIFF
--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -239,6 +239,7 @@ expose shell tokens, paths, browser internals, or another app's activity.
 Add primitives only after a real app needs them. Likely families are:
 
 - `media.microphone.capture`, `media.camera.capture`
+- `device.asset-cache`
 - `files.open`, `files.save`
 - `clipboard.read`, `clipboard.write`
 - `location.current`, `location.watch`
@@ -252,6 +253,37 @@ methods; wildcard access can remain possible through explicit owner approval.
 Moving credential possession into a generic host request transport would not
 change that authorization model. Likewise, app storage and cross-app access are
 durable server capabilities, not browser-session providers.
+
+### Large public assets stored on one device
+
+`device.asset-cache` lets an app install checksum-pinned public assets into
+the current browser without granting the opaque app frame ambient origin
+storage. It is intended for large, regenerable inputs such as an on-device ML
+model, not owner-authored data or a server-side application database.
+
+The app declares reviewed byte ceilings and supplies an exact package manifest
+for each operation: a package key, public HTTPS asset URLs, total sizes, and a
+SHA-256 for every bounded chunk. The shell:
+
+- partitions Cache Storage by installed app id;
+- asks for persistent browser storage only during an explicit install gesture;
+- downloads bounded byte ranges through an owner-only, SSRF-safe transient
+  relay when cross-origin range requests are unavailable;
+- verifies every chunk before retaining it and resumes only verified chunks;
+- leaves a previous complete package intact until its replacement is complete;
+- prunes abandoned partial versions and enforces the reviewed total app partition;
+- streams cached chunks back through transferable capability events; and
+- purges the app partition on explicit app-data removal and every Möbius cache
+  partition on logout.
+
+No asset is retained on the server. Browser persistence is best-effort: an app
+must state that installation is per device and browser profile, report whether
+the browser granted persistent storage, and tolerate user-initiated site-data
+removal. `status`, `install`, `read`, and `remove` use the ordinary capability
+session API; the app remains responsible for presentation, interpretation, and
+licensing of the bytes. A `read` consumer sends `control('next')` after taking
+ownership of every `chunk` event, so neither message port accumulates a whole
+large package in memory.
 
 ## Adding a capability
 

--- a/backend/app/app_capabilities.py
+++ b/backend/app/app_capabilities.py
@@ -26,6 +26,26 @@ CONTRACT_SCHEMA = 4
 # its own integer version, so adding (say) camera v2 never forces every storage
 # or microphone consumer onto a new global runtime version.
 RUNTIME_CAPABILITY_DEFINITIONS: dict[str, dict[str, Any]] = {
+  "device.asset-cache": {
+    "version": 1,
+    "kind": "session",
+    "title": "Store large files on this device",
+    "description": (
+      "Download verified app assets into this browser's private storage."
+    ),
+    "risk": "storage",
+    "lifecycle": "active_frame",
+    "default_limits": {
+      "max_bytes": 256 * 1024 * 1024,
+      "max_asset_bytes": 256 * 1024 * 1024,
+      "max_chunk_bytes": 8 * 1024 * 1024,
+    },
+    "hard_limits": {
+      "max_bytes": (1 * 1024 * 1024, 2 * 1024 * 1024 * 1024),
+      "max_asset_bytes": (1 * 1024 * 1024, 1 * 1024 * 1024 * 1024),
+      "max_chunk_bytes": (256 * 1024, 16 * 1024 * 1024),
+    },
+  },
   "media.microphone.capture": {
     "version": 1,
     "kind": "session",

--- a/backend/app/routes/app_runtime.py
+++ b/backend/app/routes/app_runtime.py
@@ -5,9 +5,11 @@ import hashlib
 import json
 import re
 from pathlib import Path
+from urllib.parse import urljoin, urlparse
 
-from fastapi import APIRouter, Depends, HTTPException, Request, Response
-from fastapi.responses import FileResponse, HTMLResponse
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
+from fastapi.responses import FileResponse, HTMLResponse, StreamingResponse
 from sqlalchemy.orm import Session
 
 from app import activity, models, theme
@@ -16,10 +18,183 @@ from app.config import get_settings
 from app.database import get_db
 from app.deps import get_current_owner, resolve_owner_or_app
 from app.http_caching import strip_range
+from app.net_utils import validate_url_safe
 from app.resource_access import live_app, live_app_or_404
 
 
 router = APIRouter()
+
+_DEVICE_ASSET_CAPABILITY = "device.asset-cache"
+_DEVICE_ASSET_MAX_REDIRECTS = 5
+_DEVICE_ASSET_USER_AGENT = "Mobius/1.0 (device asset relay)"
+
+
+def _device_asset_declaration(app: models.App) -> dict:
+  contract = app.capability_contract
+  runtime = contract.get("runtime") if isinstance(contract, dict) else None
+  declaration = (
+    runtime.get(_DEVICE_ASSET_CAPABILITY)
+    if isinstance(runtime, dict)
+    else None
+  )
+  if not isinstance(declaration, dict) or declaration.get("version") != 1:
+    raise HTTPException(
+      status_code=403,
+      detail="This app has not declared device asset storage.",
+    )
+  return declaration
+
+
+def _parse_content_range(value: str | None) -> tuple[int, int, int | None] | None:
+  match = re.fullmatch(r"bytes (\d+)-(\d+)/(\d+|\*)", value or "")
+  if not match:
+    return None
+  total = None if match.group(3) == "*" else int(match.group(3))
+  return int(match.group(1)), int(match.group(2)), total
+
+
+async def _open_device_asset_range(
+  url: str,
+  offset: int,
+  length: int,
+) -> tuple[httpx.AsyncClient, httpx.Response, int | None]:
+  """Open one exact public byte range without retaining it on the server."""
+  current_url = url
+  client = httpx.AsyncClient(
+    follow_redirects=False,
+    timeout=httpx.Timeout(60.0, connect=20.0),
+  )
+  expected_end = offset + length - 1
+  try:
+    for hop in range(_DEVICE_ASSET_MAX_REDIRECTS + 1):
+      pinned_url, host_header, sni_host = validate_url_safe(current_url)
+      request = client.build_request(
+        "GET",
+        pinned_url,
+        headers={
+          "Accept": "application/octet-stream,*/*;q=0.1",
+          "Accept-Encoding": "identity",
+          "Range": f"bytes={offset}-{expected_end}",
+          "User-Agent": _DEVICE_ASSET_USER_AGENT,
+        },
+      )
+      request.headers["host"] = host_header
+      request.extensions["sni_hostname"] = sni_host
+      try:
+        upstream = await client.send(request, stream=True)
+      except httpx.TimeoutException as exc:
+        raise HTTPException(504, "Timed out downloading the device asset.") from exc
+      except httpx.RequestError as exc:
+        raise HTTPException(502, "Could not reach the device asset source.") from exc
+
+      if upstream.status_code in (301, 302, 303, 307, 308):
+        location = upstream.headers.get("location")
+        await upstream.aclose()
+        if not location:
+          raise HTTPException(502, "Device asset redirect had no destination.")
+        if hop >= _DEVICE_ASSET_MAX_REDIRECTS:
+          raise HTTPException(502, "Too many device asset redirects.")
+        current_url = urljoin(current_url, location)
+        continue
+
+      content_encoding = upstream.headers.get("content-encoding", "identity")
+      if content_encoding not in ("", "identity"):
+        await upstream.aclose()
+        raise HTTPException(502, "Device asset source changed the requested bytes.")
+
+      declared_length = upstream.headers.get("content-length")
+      try:
+        actual_length = int(declared_length) if declared_length is not None else None
+      except ValueError:
+        actual_length = None
+      total_bytes = None
+      if upstream.status_code == 206:
+        content_range = _parse_content_range(upstream.headers.get("content-range"))
+        if not content_range or content_range[:2] != (offset, expected_end):
+          await upstream.aclose()
+          raise HTTPException(502, "Device asset source returned the wrong byte range.")
+        total_bytes = content_range[2]
+      elif not (
+        upstream.status_code == 200
+        and offset == 0
+        and actual_length == length
+      ):
+        status = upstream.status_code
+        await upstream.aclose()
+        raise HTTPException(
+          502,
+          f"Device asset source did not honor the requested range ({status}).",
+        )
+      if actual_length is not None and actual_length != length:
+        await upstream.aclose()
+        raise HTTPException(502, "Device asset source returned an unexpected size.")
+      return client, upstream, total_bytes
+    raise HTTPException(502, "Too many device asset redirects.")
+  except BaseException:
+    await client.aclose()
+    raise
+
+
+@router.get("/{app_id}/device-assets/relay")
+async def relay_device_asset_range(
+  app_id: int,
+  url: str = Query(min_length=1, max_length=4096),
+  offset: int = Query(ge=0),
+  length: int = Query(gt=0),
+  db: Session = Depends(get_db),
+  _: models.Owner = Depends(get_current_owner),
+):
+  """Stream one reviewed, bounded public range into the shell's device cache.
+
+  The trusted shell owns this request; an opaque app frame cannot call it with
+  its scoped bearer. Bytes pass through the server only for CORS/SSRF safety
+  and are never written to disk. The shell verifies the app-supplied SHA-256
+  before retaining each chunk in browser Cache Storage.
+  """
+  app = live_app_or_404(db, app_id)
+  declaration = _device_asset_declaration(app)
+  limits = declaration.get("limits") or {}
+  max_asset_bytes = int(limits.get("max_asset_bytes") or 0)
+  max_chunk_bytes = int(limits.get("max_chunk_bytes") or 0)
+  if length > max_chunk_bytes or offset + length > max_asset_bytes:
+    raise HTTPException(413, "Requested device asset range exceeds its reviewed limit.")
+  parsed = urlparse(url)
+  if parsed.scheme != "https" or not parsed.hostname or parsed.username or parsed.password:
+    raise HTTPException(400, "Device assets require a public HTTPS URL.")
+  db.close()
+
+  client, upstream, total_bytes = await _open_device_asset_range(url, offset, length)
+  if total_bytes is not None and total_bytes > max_asset_bytes:
+    await upstream.aclose()
+    await client.aclose()
+    raise HTTPException(413, "Device asset exceeds its reviewed size limit.")
+
+  async def stream():
+    transferred = 0
+    try:
+      async for chunk in upstream.aiter_raw():
+        transferred += len(chunk)
+        if transferred > length:
+          raise RuntimeError("Device asset source exceeded its declared range.")
+        yield chunk
+      if transferred != length:
+        raise RuntimeError("Device asset source ended before the range was complete.")
+    finally:
+      await upstream.aclose()
+      await client.aclose()
+
+  headers = {
+    "Cache-Control": "no-store",
+    "Content-Length": str(length),
+    "X-Content-Type-Options": "nosniff",
+  }
+  if total_bytes is not None:
+    headers["X-Mobius-Asset-Total"] = str(total_bytes)
+  return StreamingResponse(
+    stream(),
+    media_type="application/octet-stream",
+    headers=headers,
+  )
 
 
 def _etag_for_app(app: models.App) -> str | None:

--- a/backend/app/routes/app_runtime.py
+++ b/backend/app/routes/app_runtime.py
@@ -50,7 +50,21 @@ def _parse_content_range(value: str | None) -> tuple[int, int, int | None] | Non
   if not match:
     return None
   total = None if match.group(3) == "*" else int(match.group(3))
-  return int(match.group(1)), int(match.group(2)), total
+  start = int(match.group(1))
+  end = int(match.group(2))
+  if start > end or (total is not None and end >= total):
+    return None
+  return start, end, total
+
+
+def _is_https_device_asset_url(url: str) -> bool:
+  parsed = urlparse(url)
+  return bool(
+    parsed.scheme == "https"
+    and parsed.hostname
+    and not parsed.username
+    and not parsed.password
+  )
 
 
 async def _open_device_asset_range(
@@ -95,6 +109,8 @@ async def _open_device_asset_range(
         if hop >= _DEVICE_ASSET_MAX_REDIRECTS:
           raise HTTPException(502, "Too many device asset redirects.")
         current_url = urljoin(current_url, location)
+        if not _is_https_device_asset_url(current_url):
+          raise HTTPException(502, "Device asset redirect requires a public HTTPS URL.")
         continue
 
       content_encoding = upstream.headers.get("content-encoding", "identity")
@@ -158,8 +174,7 @@ async def relay_device_asset_range(
   max_chunk_bytes = int(limits.get("max_chunk_bytes") or 0)
   if length > max_chunk_bytes or offset + length > max_asset_bytes:
     raise HTTPException(413, "Requested device asset range exceeds its reviewed limit.")
-  parsed = urlparse(url)
-  if parsed.scheme != "https" or not parsed.hostname or parsed.username or parsed.password:
+  if not _is_https_device_asset_url(url):
     raise HTTPException(400, "Device assets require a public HTTPS URL.")
   db.close()
 

--- a/backend/tests/test_app_capabilities.py
+++ b/backend/tests/test_app_capabilities.py
@@ -105,6 +105,28 @@ def test_runtime_capability_is_independently_versioned_and_bounded():
   }
 
 
+def test_device_asset_cache_is_client_only_and_reviewed_by_size():
+  runtime = normalize_runtime_capabilities(_manifest(capabilities={
+    "device.asset-cache": {
+      "version": 1,
+      "reason": "Keep an on-device speech model in this browser.",
+      "limits": {
+        "max_bytes": 256 * 1024 * 1024,
+        "max_asset_bytes": 256 * 1024 * 1024,
+        "max_chunk_bytes": 8 * 1024 * 1024,
+      },
+    },
+  }))
+
+  device_cache = runtime["device.asset-cache"]
+  assert device_cache["risk"] == "storage"
+  assert device_cache["lifecycle"] == "active_frame"
+  assert device_cache["description"] == (
+    "Download verified app assets into this browser's private storage."
+  )
+  assert device_cache["limits"]["max_bytes"] == 256 * 1024 * 1024
+
+
 def test_runtime_capability_rejects_unknown_name_version_and_limits():
   for capabilities, message in (
     ({"device.telepathy": {"version": 1}}, "Unknown capability"),

--- a/backend/tests/test_device_asset_relay.py
+++ b/backend/tests/test_device_asset_relay.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from test_app_fixtures import create_local_app
 
-from app.routes.app_runtime import _parse_content_range
+from app.routes.app_runtime import _is_https_device_asset_url, _parse_content_range
 
 
 def _create_device_asset_app(client, auth):
@@ -49,6 +49,14 @@ def test_content_range_parser_requires_an_exact_byte_form():
   assert _parse_content_range("bytes 0-0/*") == (0, 0, None)
   assert _parse_content_range("items 8-15/100") is None
   assert _parse_content_range("bytes */100") is None
+  assert _parse_content_range("bytes 15-8/100") is None
+  assert _parse_content_range("bytes 8-15/15") is None
+
+
+def test_device_asset_urls_cannot_downgrade_or_embed_credentials():
+  assert _is_https_device_asset_url("https://assets.example/model.bin") is True
+  assert _is_https_device_asset_url("http://assets.example/model.bin") is False
+  assert _is_https_device_asset_url("https://owner:secret@assets.example/model.bin") is False
 
 
 def test_device_asset_relay_requires_a_reviewed_capability(client, auth):

--- a/backend/tests/test_device_asset_relay.py
+++ b/backend/tests/test_device_asset_relay.py
@@ -1,0 +1,167 @@
+"""The device-asset relay is bounded, owner-only, and never retains bytes."""
+
+from unittest.mock import patch
+
+from test_app_fixtures import create_local_app
+
+from app.routes.app_runtime import _parse_content_range
+
+
+def _create_device_asset_app(client, auth):
+  return create_local_app(
+    client,
+    auth,
+    name="Device Assets",
+    capabilities={
+      "device.asset-cache": {
+        "version": 1,
+        "reason": "Keep a public model in this browser.",
+        "limits": {
+          "max_bytes": 256 * 1024 * 1024,
+          "max_asset_bytes": 256 * 1024 * 1024,
+          "max_chunk_bytes": 8 * 1024 * 1024,
+        },
+      },
+    },
+  )
+
+
+class _FakeCloser:
+  def __init__(self):
+    self.closed = False
+
+  async def aclose(self):
+    self.closed = True
+
+
+class _FakeUpstream(_FakeCloser):
+  def __init__(self, body: bytes):
+    super().__init__()
+    self.body = body
+
+  async def aiter_raw(self):
+    yield self.body[:2]
+    yield self.body[2:]
+
+
+def test_content_range_parser_requires_an_exact_byte_form():
+  assert _parse_content_range("bytes 8-15/100") == (8, 15, 100)
+  assert _parse_content_range("bytes 0-0/*") == (0, 0, None)
+  assert _parse_content_range("items 8-15/100") is None
+  assert _parse_content_range("bytes */100") is None
+
+
+def test_device_asset_relay_requires_a_reviewed_capability(client, auth):
+  app = create_local_app(client, auth, name="No Device Storage")
+
+  response = client.get(
+    f"/api/apps/{app['id']}/device-assets/relay",
+    headers=auth,
+    params={"url": "https://assets.example/model.bin", "offset": 0, "length": 5},
+  )
+
+  assert response.status_code == 403
+
+
+def test_device_asset_relay_is_shell_owned_not_app_token_callable(client, auth):
+  app = _create_device_asset_app(client, auth)
+  token_response = client.post(
+    "/api/auth/app-token",
+    headers=auth,
+    json={"app_id": app["id"]},
+  )
+  assert token_response.status_code == 200
+
+  response = client.get(
+    f"/api/apps/{app['id']}/device-assets/relay",
+    headers={
+      "Authorization": f"Bearer {token_response.json()['token']}",
+      "Origin": "null",
+      "Sec-Fetch-Site": "cross-site",
+    },
+    params={"url": "https://assets.example/model.bin", "offset": 0, "length": 5},
+  )
+
+  assert response.status_code == 403
+
+
+def test_device_asset_relay_rejects_non_https_and_oversize_ranges(client, auth):
+  app = _create_device_asset_app(client, auth)
+  endpoint = f"/api/apps/{app['id']}/device-assets/relay"
+
+  insecure = client.get(
+    endpoint,
+    headers=auth,
+    params={"url": "http://assets.example/model.bin", "offset": 0, "length": 5},
+  )
+  assert insecure.status_code == 400
+
+  oversize = client.get(
+    endpoint,
+    headers=auth,
+    params={
+      "url": "https://assets.example/model.bin",
+      "offset": 0,
+      "length": 8 * 1024 * 1024 + 1,
+    },
+  )
+  assert oversize.status_code == 413
+
+
+def test_device_asset_relay_streams_one_exact_range_without_caching(client, auth):
+  app = _create_device_asset_app(client, auth)
+  upstream = _FakeUpstream(b"hello")
+  http_client = _FakeCloser()
+
+  async def fake_open(url, offset, length):
+    assert url == "https://assets.example/model.bin"
+    assert (offset, length) == (5, 5)
+    return http_client, upstream, 100
+
+  with patch(
+    "app.routes.app_runtime._open_device_asset_range",
+    side_effect=fake_open,
+  ):
+    response = client.get(
+      f"/api/apps/{app['id']}/device-assets/relay",
+      headers=auth,
+      params={
+        "url": "https://assets.example/model.bin",
+        "offset": 5,
+        "length": 5,
+      },
+    )
+
+  assert response.status_code == 200, response.text
+  assert response.content == b"hello"
+  assert response.headers["cache-control"] == "no-store"
+  assert response.headers["x-mobius-asset-total"] == "100"
+  assert upstream.closed is True
+  assert http_client.closed is True
+
+
+def test_device_asset_relay_rejects_an_upstream_beyond_reviewed_size(client, auth):
+  app = _create_device_asset_app(client, auth)
+  upstream = _FakeUpstream(b"hello")
+  http_client = _FakeCloser()
+
+  async def fake_open(*_args):
+    return http_client, upstream, 256 * 1024 * 1024 + 1
+
+  with patch(
+    "app.routes.app_runtime._open_device_asset_range",
+    side_effect=fake_open,
+  ):
+    response = client.get(
+      f"/api/apps/{app['id']}/device-assets/relay",
+      headers=auth,
+      params={
+        "url": "https://assets.example/model.bin",
+        "offset": 0,
+        "length": 5,
+      },
+    )
+
+  assert response.status_code == 413
+  assert upstream.closed is True
+  assert http_client.closed is True

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -153,14 +153,22 @@ export function clearQueryCache() {
 // offline work. The runtime owns the IndexedDB schemas, so keep the record
 // traversal there rather than duplicating it in bundled code.
 export async function clearAppRuntimeData(appId) {
+  const cleanups = []
   try {
     const runtimeUrl = `${BASE}/mobius-runtime.js`
     const runtime = await import(/* @vite-ignore */ runtimeUrl)
-    await runtime.purgeAppRuntimeData?.(appId)
+    cleanups.push(runtime.purgeAppRuntimeData?.(appId))
   } catch {
     // The server-side wipe already succeeded. Local cleanup is best-effort and
     // the rotated installation nonce still prevents stale record reuse.
   }
+  try {
+    const deviceAssets = await import('../lib/deviceAssetCache.js')
+    cleanups.push(deviceAssets.purgeDeviceAssetCache?.(appId))
+  } catch {
+    // Browser support and module loading are best-effort during data removal.
+  }
+  await Promise.allSettled(cleanups)
 }
 
 // The offline outbox and signal queue (mobius-runtime.js) are their OWN

--- a/frontend/src/components/AppCanvas/AppCanvas.jsx
+++ b/frontend/src/components/AppCanvas/AppCanvas.jsx
@@ -459,7 +459,7 @@ const AppCanvas = forwardRef(function AppCanvas({
   const capabilityHostRef = useRef(null)
   if (!capabilityHostRef.current) {
     capabilityHostRef.current = createCapabilityHost({
-      providers: builtInCapabilityProviders(),
+      providers: builtInCapabilityProviders({ deviceAssets: { appId } }),
       getDeclaration(capability) {
         return capabilityContractRef.current?.runtime?.[capability] || null
       },

--- a/frontend/src/lib/__tests__/capabilityHost.test.js
+++ b/frontend/src/lib/__tests__/capabilityHost.test.js
@@ -74,6 +74,18 @@ test('host binds a declared capability session to its exact source', async () =>
   assert.equal(harness.host.activeCount(), 0)
 })
 
+test('provider events can transfer large buffers without cloning them', async () => {
+  const harness = setup()
+  harness.host.handle(harness.source, openMessage())
+  await new Promise((resolve) => setImmediate(resolve))
+  const bytes = new ArrayBuffer(8)
+
+  harness.channel.event('chunk', { bytes }, [bytes])
+
+  assert.deepEqual(harness.sent.at(-1).transfer, [bytes])
+  assert.equal(harness.sent.at(-1).message.value.bytes, bytes)
+})
+
 test('host refuses undeclared, inactive, and mismatched-version requests', () => {
   const undeclared = setup({ declared: false })
   undeclared.host.handle(undeclared.source, openMessage())

--- a/frontend/src/lib/__tests__/deviceAssetCache.test.js
+++ b/frontend/src/lib/__tests__/deviceAssetCache.test.js
@@ -1,0 +1,282 @@
+import { createHash, webcrypto } from 'node:crypto'
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  createDeviceAssetCacheProvider,
+  normalizeDeviceAssetPackage,
+  purgeDeviceAssetCache,
+} from '../deviceAssetCache.js'
+
+const DECLARATION = {
+  limits: {
+    max_bytes: 1024,
+    max_asset_bytes: 1024,
+    max_chunk_bytes: 512,
+  },
+}
+
+function digest(bytes) {
+  return createHash('sha256').update(bytes).digest('hex')
+}
+
+function packageInput(chunks = [Buffer.from('hello'), Buffer.from(' world')]) {
+  return {
+    operation: 'install',
+    package: {
+      key: 'voice-v1',
+      assets: [{
+        id: 'model',
+        url: 'https://assets.example/model.bin',
+        bytes: chunks.reduce((total, chunk) => total + chunk.byteLength, 0),
+        chunks: chunks.map((chunk) => ({ bytes: chunk.byteLength, sha256: digest(chunk) })),
+      }],
+    },
+  }
+}
+
+class MemoryCache {
+  constructor() { this.values = new Map() }
+  async match(key) {
+    const response = this.values.get(typeof key === 'string' ? key : key.url)
+    return response?.clone()
+  }
+  async put(key, response) {
+    this.values.set(typeof key === 'string' ? key : key.url, response.clone())
+  }
+  async delete(key) {
+    return this.values.delete(typeof key === 'string' ? key : key.url)
+  }
+  async keys() {
+    return [...this.values.keys()].map((url) => new Request(url))
+  }
+}
+
+class MemoryCacheStorage {
+  constructor() { this.values = new Map() }
+  async open(name) {
+    if (!this.values.has(name)) this.values.set(name, new MemoryCache())
+    return this.values.get(name)
+  }
+  async keys() { return [...this.values.keys()] }
+  async delete(name) { return this.values.delete(name) }
+}
+
+function runProvider(provider, input, { events = [], ready = [] } = {}) {
+  return new Promise((resolve, reject) => {
+    let control
+    control = provider.open({
+      input,
+      declaration: DECLARATION,
+      channel: {
+        ready(value) { ready.push(value) },
+        event(name, value, transfer) {
+          events.push({ name, value, transfer })
+          if (name === 'chunk') queueMicrotask(() => control.control('next'))
+        },
+        result: resolve,
+        error: reject,
+      },
+    })
+  })
+}
+
+async function waitFor(predicate) {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    if (predicate()) return
+    await new Promise((resolve) => setTimeout(resolve, 1))
+  }
+  throw new Error('Timed out waiting for device asset test state.')
+}
+
+test('device package validation applies reviewed package and chunk limits', () => {
+  const normalized = normalizeDeviceAssetPackage(packageInput(), DECLARATION)
+  assert.equal(normalized.bytes, 11)
+  assert.deepEqual(normalized.assets[0].chunks.map((chunk) => chunk.offset), [0, 5])
+
+  const tooLarge = packageInput([Buffer.alloc(513)])
+  assert.throws(
+    () => normalizeDeviceAssetPackage(tooLarge, DECLARATION),
+    (error) => error.code === 'invalid_request' && /chunk/.test(error.message),
+  )
+})
+
+test('status does not create browser storage before an explicit install', async () => {
+  const cacheStorage = new MemoryCacheStorage()
+  const provider = createDeviceAssetCacheProvider({
+    appId: '61',
+    cacheStorage,
+    cryptoImpl: webcrypto,
+    origin: 'https://mobius.test',
+    storageManager: {},
+  })
+  const result = await runProvider(
+    provider,
+    { ...packageInput(), operation: 'status' },
+  )
+
+  assert.equal(result.state, 'missing')
+  assert.equal(cacheStorage.values.size, 0)
+})
+
+test('install verifies and resumes chunks, then read transfers them in order', async () => {
+  const cacheStorage = new MemoryCacheStorage()
+  const chunks = [Buffer.from('hello'), Buffer.from(' world')]
+  const calls = []
+  const provider = createDeviceAssetCacheProvider({
+    appId: 61,
+    cacheStorage,
+    cryptoImpl: webcrypto,
+    origin: 'https://mobius.test',
+    storageManager: {
+      async persisted() { return false },
+      async persist() { return true },
+      async estimate() { return { usage: 0, quota: 1_000_000 } },
+    },
+    async fetchRange({ offset }) {
+      calls.push(offset)
+      return new Response(chunks[offset === 0 ? 0 : 1])
+    },
+  })
+  const input = packageInput(chunks)
+  const events = []
+  const installed = await runProvider(provider, input, { events })
+  assert.equal(installed.state, 'ready')
+  assert.equal(installed.persistence, 'persistent')
+  assert.deepEqual(calls, [0, 5])
+  assert.deepEqual(events.map(({ value }) => value.downloadedBytes), [5, 11])
+
+  await runProvider(provider, input)
+  assert.deepEqual(calls, [0, 5], 'verified chunks are reused on a repeated install')
+
+  const readEvents = []
+  const readResult = await runProvider(
+    provider,
+    { ...input, operation: 'read' },
+    { events: readEvents },
+  )
+  assert.equal(readResult.state, 'ready')
+  assert.deepEqual(
+    readEvents.map(({ value }) => Buffer.from(value.bytes).toString()),
+    ['hello', ' world'],
+  )
+  assert.equal(readEvents.every(({ value, transfer }) => transfer[0] === value.bytes), true)
+})
+
+test('read waits for each consumer acknowledgement before transferring the next chunk', async () => {
+  const cacheStorage = new MemoryCacheStorage()
+  const chunks = [Buffer.from('first'), Buffer.from('second')]
+  const provider = createDeviceAssetCacheProvider({
+    appId: 61,
+    cacheStorage,
+    cryptoImpl: webcrypto,
+    origin: 'https://mobius.test',
+    storageManager: {},
+    async fetchRange({ offset }) {
+      return new Response(chunks[offset === 0 ? 0 : 1])
+    },
+  })
+  const input = packageInput(chunks)
+  await runProvider(provider, input)
+
+  const events = []
+  let control
+  const result = new Promise((resolve, reject) => {
+    control = provider.open({
+      input: { ...input, operation: 'read' },
+      declaration: DECLARATION,
+      channel: {
+        ready() {},
+        event(name, value) { if (name === 'chunk') events.push(value) },
+        result: resolve,
+        error: reject,
+      },
+    })
+  })
+  await waitFor(() => events.length === 1)
+  assert.equal(events.length, 1)
+
+  control.control('next')
+  await waitFor(() => events.length === 2)
+  assert.equal(events.length, 2)
+  control.control('next')
+  await result
+})
+
+test('an invalid download is rejected without replacing a complete package', async () => {
+  const cacheStorage = new MemoryCacheStorage()
+  const original = [Buffer.from('safe')]
+  const provider = createDeviceAssetCacheProvider({
+    appId: 61,
+    cacheStorage,
+    cryptoImpl: webcrypto,
+    origin: 'https://mobius.test',
+    storageManager: {},
+    async fetchRange() { return new Response(original[0]) },
+  })
+  const first = packageInput(original)
+  await runProvider(provider, first)
+
+  const replacement = packageInput([Buffer.from('new!')])
+  replacement.package.assets[0].url = 'https://assets.example/model-v2.bin'
+  const brokenProvider = createDeviceAssetCacheProvider({
+    appId: 61,
+    cacheStorage,
+    cryptoImpl: webcrypto,
+    origin: 'https://mobius.test',
+    storageManager: {},
+    async fetchRange() { return new Response(Buffer.from('bad!')) },
+  })
+  await assert.rejects(
+    runProvider(brokenProvider, replacement),
+    (error) => error.code === 'integrity_failed',
+  )
+
+  const readEvents = []
+  await runProvider(provider, { ...first, operation: 'read' }, { events: readEvents })
+  assert.equal(Buffer.from(readEvents[0].value.bytes).toString(), 'safe')
+})
+
+test('separate complete packages cannot exceed the reviewed app partition', async () => {
+  const cacheStorage = new MemoryCacheStorage()
+  const declaration = {
+    limits: { max_bytes: 10, max_asset_bytes: 10, max_chunk_bytes: 10 },
+  }
+  let body = Buffer.from('123456')
+  const provider = createDeviceAssetCacheProvider({
+    appId: 61,
+    cacheStorage,
+    cryptoImpl: webcrypto,
+    origin: 'https://mobius.test',
+    storageManager: {},
+    async fetchRange() { return new Response(body) },
+  })
+  const first = packageInput([body])
+  await new Promise((resolve, reject) => provider.open({
+    input: first,
+    declaration,
+    channel: { ready() {}, event() {}, result: resolve, error: reject },
+  }))
+
+  body = Buffer.from('abcdef')
+  const second = packageInput([body])
+  second.package.key = 'another-package'
+  await assert.rejects(
+    new Promise((resolve, reject) => provider.open({
+      input: second,
+      declaration,
+      channel: { ready() {}, event() {}, result: resolve, error: reject },
+    })),
+    (error) => error.code === 'quota_exceeded',
+  )
+})
+
+test('explicit app-data purge removes only that app device partition', async () => {
+  const cacheStorage = new MemoryCacheStorage()
+  await cacheStorage.open('mobius-device-assets-v1-app-61')
+  await cacheStorage.open('mobius-device-assets-v1-app-62')
+
+  assert.equal(await purgeDeviceAssetCache(61, cacheStorage), true)
+  assert.equal(cacheStorage.values.has('mobius-device-assets-v1-app-61'), false)
+  assert.equal(cacheStorage.values.has('mobius-device-assets-v1-app-62'), true)
+})

--- a/frontend/src/lib/__tests__/deviceAssetCache.test.js
+++ b/frontend/src/lib/__tests__/deviceAssetCache.test.js
@@ -237,6 +237,27 @@ test('an invalid download is rejected without replacing a complete package', asy
   assert.equal(Buffer.from(readEvents[0].value.bytes).toString(), 'safe')
 })
 
+test('install rejects an upstream asset whose total differs from the reviewed size', async () => {
+  const chunks = [Buffer.from('hello'), Buffer.from(' world')]
+  const provider = createDeviceAssetCacheProvider({
+    appId: 61,
+    cacheStorage: new MemoryCacheStorage(),
+    cryptoImpl: webcrypto,
+    origin: 'https://mobius.test',
+    storageManager: {},
+    async fetchRange({ offset }) {
+      return new Response(chunks[offset === 0 ? 0 : 1], {
+        headers: { 'X-Mobius-Asset-Total': '12' },
+      })
+    },
+  })
+
+  await assert.rejects(
+    runProvider(provider, packageInput(chunks)),
+    (error) => error.code === 'download_failed' && /reviewed asset size/.test(error.message),
+  )
+})
+
 test('separate complete packages cannot exceed the reviewed app partition', async () => {
   const cacheStorage = new MemoryCacheStorage()
   const declaration = {

--- a/frontend/src/lib/capabilityHost.js
+++ b/frontend/src/lib/capabilityHost.js
@@ -144,9 +144,9 @@ export function createCapabilityHost({
           post(shellSession, 'moebius:capability-ready', { value })
         }
       },
-      event(event, value) {
+      event(event, value, transfer = []) {
         if (current(shellSession) && typeof event === 'string') {
-          post(shellSession, 'moebius:capability-event', { event, value })
+          post(shellSession, 'moebius:capability-event', { event, value }, transfer)
         }
       },
       result(value, transfer = []) {

--- a/frontend/src/lib/capabilityProviders.js
+++ b/frontend/src/lib/capabilityProviders.js
@@ -1,4 +1,8 @@
 import { startMicrophoneCapture } from './microphoneCapture.js'
+import {
+  createDeviceAssetCacheProvider,
+  DEVICE_ASSET_CACHE,
+} from './deviceAssetCache.js'
 
 export const MICROPHONE_CAPTURE = 'media.microphone.capture'
 
@@ -41,6 +45,7 @@ export function createMicrophoneProvider({ startCapture = startMicrophoneCapture
 
 export function builtInCapabilityProviders(options = {}) {
   return {
+    [DEVICE_ASSET_CACHE]: createDeviceAssetCacheProvider(options.deviceAssets),
     [MICROPHONE_CAPTURE]: createMicrophoneProvider(options.microphone),
   }
 }

--- a/frontend/src/lib/deviceAssetCache.js
+++ b/frontend/src/lib/deviceAssetCache.js
@@ -1,0 +1,549 @@
+import { apiFetch } from '../api/client.js'
+
+export const DEVICE_ASSET_CACHE = 'device.asset-cache'
+
+const CACHE_PREFIX = 'mobius-device-assets-v1'
+const MIN_FREE_BYTES = 16 * 1024 * 1024
+const KEY_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,79}$/
+const SHA256_PATTERN = /^[a-f0-9]{64}$/
+
+function capabilityError(code, message, name = 'CapabilityError') {
+  const error = new Error(message)
+  error.code = code
+  error.name = name
+  return error
+}
+
+function assertKey(value, label) {
+  if (typeof value !== 'string' || !KEY_PATTERN.test(value)) {
+    throw capabilityError(
+      'invalid_request',
+      `${label} must contain only letters, numbers, dots, dashes, and underscores.`,
+      'TypeError',
+    )
+  }
+  return value
+}
+
+function assertInteger(value, label, { min = 0, max = Number.MAX_SAFE_INTEGER } = {}) {
+  if (!Number.isSafeInteger(value) || value < min || value > max) {
+    throw capabilityError(
+      'invalid_request',
+      `${label} must be an integer between ${min} and ${max}.`,
+      'TypeError',
+    )
+  }
+  return value
+}
+
+function reviewedLimits(declaration) {
+  const limits = declaration?.limits || {}
+  return {
+    maxBytes: assertInteger(limits.max_bytes, 'max_bytes', { min: 1 }),
+    maxAssetBytes: assertInteger(limits.max_asset_bytes, 'max_asset_bytes', { min: 1 }),
+    maxChunkBytes: assertInteger(limits.max_chunk_bytes, 'max_chunk_bytes', { min: 1 }),
+  }
+}
+
+export function normalizeDeviceAssetPackage(input, declaration) {
+  if (!input?.package || typeof input.package !== 'object'
+    || Array.isArray(input.package)) {
+    throw capabilityError('invalid_request', 'A device asset package is required.', 'TypeError')
+  }
+  const limits = reviewedLimits(declaration)
+  const rawPackage = input.package
+  const key = assertKey(rawPackage.key, 'Package key')
+  if (!Array.isArray(rawPackage.assets) || rawPackage.assets.length < 1
+    || rawPackage.assets.length > 64) {
+    throw capabilityError(
+      'invalid_request',
+      'A package must contain between 1 and 64 assets.',
+      'TypeError',
+    )
+  }
+
+  const seen = new Set()
+  let packageBytes = 0
+  const assets = rawPackage.assets.map((asset, assetIndex) => {
+    if (!asset || typeof asset !== 'object' || Array.isArray(asset)) {
+      throw capabilityError('invalid_request', `Asset ${assetIndex + 1} is invalid.`, 'TypeError')
+    }
+    const id = assertKey(asset.id, `Asset ${assetIndex + 1} id`)
+    if (seen.has(id)) {
+      throw capabilityError('invalid_request', `Asset id \`${id}\` is duplicated.`, 'TypeError')
+    }
+    seen.add(id)
+    let source
+    try { source = new URL(asset.url) } catch {
+      throw capabilityError('invalid_request', `Asset \`${id}\` has an invalid URL.`, 'TypeError')
+    }
+    if (source.protocol !== 'https:' || source.username || source.password) {
+      throw capabilityError(
+        'invalid_request',
+        `Asset \`${id}\` must use a public HTTPS URL without credentials.`,
+        'TypeError',
+      )
+    }
+    const bytes = assertInteger(asset.bytes, `Asset \`${id}\` size`, {
+      min: 1,
+      max: limits.maxAssetBytes,
+    })
+    if (!Array.isArray(asset.chunks) || asset.chunks.length < 1
+      || asset.chunks.length > 16_384) {
+      throw capabilityError(
+        'invalid_request',
+        `Asset \`${id}\` must contain a bounded chunk manifest.`,
+        'TypeError',
+      )
+    }
+    let chunkBytes = 0
+    const chunks = asset.chunks.map((chunk, chunkIndex) => {
+      if (!chunk || typeof chunk !== 'object' || Array.isArray(chunk)) {
+        throw capabilityError(
+          'invalid_request',
+          `Asset \`${id}\` chunk ${chunkIndex + 1} is invalid.`,
+          'TypeError',
+        )
+      }
+      const size = assertInteger(
+        chunk.bytes,
+        `Asset \`${id}\` chunk ${chunkIndex + 1} size`,
+        { min: 1, max: limits.maxChunkBytes },
+      )
+      const sha256 = typeof chunk.sha256 === 'string'
+        ? chunk.sha256.toLowerCase()
+        : ''
+      if (!SHA256_PATTERN.test(sha256)) {
+        throw capabilityError(
+          'invalid_request',
+          `Asset \`${id}\` chunk ${chunkIndex + 1} needs a SHA-256 digest.`,
+          'TypeError',
+        )
+      }
+      const normalized = { index: chunkIndex, offset: chunkBytes, bytes: size, sha256 }
+      chunkBytes += size
+      return normalized
+    })
+    if (chunkBytes !== bytes) {
+      throw capabilityError(
+        'invalid_request',
+        `Asset \`${id}\` chunks do not add up to its declared size.`,
+        'TypeError',
+      )
+    }
+    packageBytes += bytes
+    return { id, url: source.href, bytes, chunks }
+  })
+  if (packageBytes > limits.maxBytes) {
+    throw capabilityError(
+      'invalid_request',
+      'The device asset package exceeds its reviewed storage limit.',
+      'TypeError',
+    )
+  }
+  return { key, bytes: packageBytes, assets }
+}
+
+function utf8(value) {
+  return new TextEncoder().encode(value)
+}
+
+async function sha256Hex(value, cryptoImpl = globalThis.crypto) {
+  if (!cryptoImpl?.subtle) {
+    throw capabilityError('unavailable', 'This browser cannot verify downloaded files.')
+  }
+  const digest = await cryptoImpl.subtle.digest('SHA-256', value)
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+async function packageFingerprint(pkg, cryptoImpl) {
+  const canonical = JSON.stringify({
+    key: pkg.key,
+    assets: pkg.assets.map((asset) => ({
+      id: asset.id,
+      url: asset.url,
+      bytes: asset.bytes,
+      chunks: asset.chunks.map(({ bytes, sha256 }) => ({ bytes, sha256 })),
+    })),
+  })
+  return sha256Hex(utf8(canonical), cryptoImpl)
+}
+
+function cacheName(appId) {
+  return `${CACHE_PREFIX}-app-${appId}`
+}
+
+function pathSegment(value) {
+  return encodeURIComponent(value)
+}
+
+function packagePrefix(origin, appId, pkg) {
+  return `${origin}/.mobius/device-assets/${appId}/${pathSegment(pkg.key)}/`
+}
+
+function chunkUrl(origin, appId, pkg, fingerprint, asset, chunk) {
+  return `${packagePrefix(origin, appId, pkg)}${fingerprint}/${pathSegment(asset.id)}/${chunk.index}`
+}
+
+function versionPrefix(origin, appId, pkg, fingerprint) {
+  return `${packagePrefix(origin, appId, pkg)}${fingerprint}/`
+}
+
+function completeUrl(origin, appId, pkg, fingerprint) {
+  return `${versionPrefix(origin, appId, pkg, fingerprint)}.complete`
+}
+
+async function chunkIsCached(cache, url, chunk) {
+  const response = await cache.match(url)
+  if (!response) return false
+  const bytes = Number(response.headers.get('content-length'))
+  const sha256 = response.headers.get('x-mobius-sha256')
+  if (bytes === chunk.bytes && sha256 === chunk.sha256) return true
+  await cache.delete(url)
+  return false
+}
+
+async function packageState(cache, origin, appId, pkg, fingerprint) {
+  let cachedBytes = 0
+  let cachedChunks = 0
+  let totalChunks = 0
+  for (const asset of pkg.assets) {
+    for (const chunk of asset.chunks) {
+      totalChunks += 1
+      if (await chunkIsCached(
+        cache,
+        chunkUrl(origin, appId, pkg, fingerprint, asset, chunk),
+        chunk,
+      )) {
+        cachedBytes += chunk.bytes
+        cachedChunks += 1
+      }
+    }
+  }
+  return {
+    state: cachedChunks === totalChunks ? 'ready' : (cachedChunks ? 'partial' : 'missing'),
+    cachedBytes,
+    totalBytes: pkg.bytes,
+    cachedChunks,
+    totalChunks,
+  }
+}
+
+async function persistence(storageManager, request) {
+  if (!storageManager?.persisted) return 'best-effort'
+  try {
+    if (await storageManager.persisted()) return 'persistent'
+    if (request && storageManager.persist && await storageManager.persist()) {
+      return 'persistent'
+    }
+  } catch {}
+  return 'best-effort'
+}
+
+async function assertSpace(storageManager, missingBytes) {
+  if (!storageManager?.estimate || missingBytes <= 0) return
+  let estimate
+  try { estimate = await storageManager.estimate() } catch { return }
+  const quota = Number(estimate?.quota)
+  const usage = Number(estimate?.usage)
+  if (Number.isFinite(quota) && Number.isFinite(usage)
+    && quota - usage < missingBytes + Math.min(MIN_FREE_BYTES, missingBytes)) {
+    throw capabilityError(
+      'quota_exceeded',
+      'This device does not have enough browser storage for the download.',
+      'QuotaExceededError',
+    )
+  }
+}
+
+function entryVersionPrefix(url, origin, appId) {
+  const root = `${origin}/.mobius/device-assets/${appId}/`
+  if (!url.startsWith(root)) return null
+  const path = url.slice(root.length).split('/')
+  return path.length >= 3 ? `${root}${path[0]}/${path[1]}/` : null
+}
+
+async function pruneStalePartials(cache, origin, appId, pkg, fingerprint) {
+  const current = versionPrefix(origin, appId, pkg, fingerprint)
+  const keys = await cache.keys()
+  const urls = keys.map((request) => (
+    typeof request === 'string' ? request : request.url
+  ))
+  const complete = new Set(urls
+    .filter((url) => url.endsWith('/.complete'))
+    .map((url) => url.slice(0, -'.complete'.length)))
+  await Promise.all(keys.map((request, index) => {
+    const prefix = entryVersionPrefix(urls[index], origin, appId)
+    return prefix && prefix !== current && !complete.has(prefix)
+      ? cache.delete(request)
+      : false
+  }))
+}
+
+async function cacheByteUsage(cache) {
+  let bytes = 0
+  for (const request of await cache.keys()) {
+    const response = await cache.match(request)
+    const size = Number(response?.headers?.get('content-length'))
+    if (Number.isSafeInteger(size) && size > 0) bytes += size
+  }
+  return bytes
+}
+
+async function assertPartitionBudget(cache, maxBytes, missingBytes) {
+  if (await cacheByteUsage(cache) + missingBytes > maxBytes) {
+    throw capabilityError(
+      'quota_exceeded',
+      'This app\'s reviewed device-storage allowance is not large enough for the download.',
+      'QuotaExceededError',
+    )
+  }
+}
+
+async function pruneOldPackageVersions(cache, origin, appId, pkg, fingerprint) {
+  const keepPrefix = versionPrefix(origin, appId, pkg, fingerprint)
+  const prefix = packagePrefix(origin, appId, pkg)
+  const keys = await cache.keys()
+  await Promise.all(keys.map((request) => {
+    const url = typeof request === 'string' ? request : request.url
+    return url.startsWith(prefix) && !url.startsWith(keepPrefix)
+      ? cache.delete(request)
+      : false
+  }))
+}
+
+async function removePackage(cache, origin, appId, pkg) {
+  const prefix = packagePrefix(origin, appId, pkg)
+  const keys = await cache.keys()
+  const matches = keys.filter((request) => {
+    const url = typeof request === 'string' ? request : request.url
+    return url.startsWith(prefix)
+  })
+  await Promise.all(matches.map((request) => cache.delete(request)))
+  return matches.length
+}
+
+function progressValue(state, persistenceMode) {
+  return { ...state, persistence: persistenceMode }
+}
+
+export function createDeviceAssetCacheProvider({
+  appId,
+  cacheStorage = globalThis.caches,
+  storageManager = globalThis.navigator?.storage,
+  cryptoImpl = globalThis.crypto,
+  origin = globalThis.location?.origin,
+  fetchRange = async ({ appId: targetAppId, url, offset, length, signal }) => {
+    const query = new URLSearchParams({
+      url,
+      offset: String(offset),
+      length: String(length),
+    })
+    return apiFetch(`/apps/${targetAppId}/device-assets/relay?${query}`, {
+      method: 'GET',
+      signal,
+      headers: { Accept: 'application/octet-stream' },
+    })
+  },
+} = {}) {
+  // Navigation state may carry the numeric app id as a canonical decimal
+  // string. Normalize that host-owned identity once at this boundary so
+  // browser-backed storage does not become unavailable for route-derived ids.
+  const ownerAppId = Number(appId)
+  return {
+    version: 1,
+    exclusive: true,
+    onDeactivate: 'cancel',
+    open({ input, declaration, channel }) {
+      const controller = new AbortController()
+      let settled = false
+      let releaseRead = null
+
+      const waitForReadConsumer = () => new Promise((resolve, reject) => {
+        releaseRead = { resolve, reject }
+      }).finally(() => { releaseRead = null })
+
+      Promise.resolve().then(async () => {
+        if (!Number.isSafeInteger(ownerAppId) || ownerAppId < 1 || !origin
+          || !cacheStorage?.open) {
+          throw capabilityError(
+            'unavailable',
+            'Device asset storage is unavailable in this browser.',
+          )
+        }
+        const operation = input.operation
+        if (!['status', 'install', 'read', 'remove'].includes(operation)) {
+          throw capabilityError('invalid_request', 'Unknown device asset operation.', 'TypeError')
+        }
+        const pkg = normalizeDeviceAssetPackage(input, declaration)
+        const fingerprint = await packageFingerprint(pkg, cryptoImpl)
+        const name = cacheName(ownerAppId)
+        const existingNames = cacheStorage.keys ? await cacheStorage.keys() : null
+        const hasPartition = existingNames === null || existingNames.includes(name)
+        if (operation !== 'install' && !hasPartition) {
+          const empty = {
+            state: 'missing',
+            cachedBytes: 0,
+            totalBytes: pkg.bytes,
+            cachedChunks: 0,
+            totalChunks: pkg.assets.reduce(
+              (total, asset) => total + asset.chunks.length,
+              0,
+            ),
+          }
+          const value = progressValue(empty, 'best-effort')
+          channel.ready(value)
+          if (operation === 'read') {
+            throw capabilityError(
+              'not_installed',
+              'This device needs to download the requested files first.',
+              'NotFoundError',
+            )
+          }
+          return value
+        }
+        const cache = await cacheStorage.open(name)
+        const persistenceMode = await persistence(storageManager, operation === 'install')
+        let state = await packageState(cache, origin, ownerAppId, pkg, fingerprint)
+        channel.ready(progressValue(state, persistenceMode))
+
+        if (operation === 'status') return progressValue(state, persistenceMode)
+        if (operation === 'remove') {
+          await removePackage(cache, origin, ownerAppId, pkg)
+          state = await packageState(cache, origin, ownerAppId, pkg, fingerprint)
+          return progressValue(state, persistenceMode)
+        }
+        if (operation === 'read') {
+          if (state.state !== 'ready') {
+            throw capabilityError(
+              'not_installed',
+              'This device needs to download the requested files first.',
+              'NotFoundError',
+            )
+          }
+          for (const asset of pkg.assets) {
+            for (const chunk of asset.chunks) {
+              if (controller.signal.aborted) throw controller.signal.reason
+              const url = chunkUrl(origin, ownerAppId, pkg, fingerprint, asset, chunk)
+              const response = await cache.match(url)
+              if (!response) {
+                throw capabilityError(
+                  'not_installed',
+                  'A cached file is incomplete; download it again on this device.',
+                  'NotFoundError',
+                )
+              }
+              const buffer = await response.arrayBuffer()
+              // Do not enqueue an entire large package into the app/worker
+              // message ports at once. The consumer acknowledges each
+              // transferred chunk after taking ownership, keeping the shell's
+              // peak memory bounded to one reviewed chunk.
+              const consumed = waitForReadConsumer()
+              channel.event('chunk', {
+                assetId: asset.id,
+                index: chunk.index,
+                offset: chunk.offset,
+                totalBytes: asset.bytes,
+                bytes: buffer,
+              }, [buffer])
+              await consumed
+            }
+          }
+          return progressValue(state, persistenceMode)
+        }
+
+        const missingBytes = pkg.bytes - state.cachedBytes
+        await pruneStalePartials(cache, origin, ownerAppId, pkg, fingerprint)
+        await assertPartitionBudget(cache, reviewedLimits(declaration).maxBytes, missingBytes)
+        await assertSpace(storageManager, missingBytes)
+        let downloadedBytes = state.cachedBytes
+        for (const asset of pkg.assets) {
+          for (const chunk of asset.chunks) {
+            if (controller.signal.aborted) throw controller.signal.reason
+            const url = chunkUrl(origin, ownerAppId, pkg, fingerprint, asset, chunk)
+            if (await chunkIsCached(cache, url, chunk)) continue
+            const response = await fetchRange({
+              appId: ownerAppId,
+              url: asset.url,
+              offset: chunk.offset,
+              length: chunk.bytes,
+              signal: controller.signal,
+            })
+            if (!response?.ok) {
+              throw capabilityError(
+                'download_failed',
+                `The device asset source returned ${response?.status || 'an error'}.`,
+              )
+            }
+            const buffer = await response.arrayBuffer()
+            if (buffer.byteLength !== chunk.bytes) {
+              throw capabilityError('download_failed', 'A downloaded chunk had the wrong size.')
+            }
+            if (await sha256Hex(buffer, cryptoImpl) !== chunk.sha256) {
+              throw capabilityError(
+                'integrity_failed',
+                'A downloaded chunk failed its integrity check and was not stored.',
+              )
+            }
+            await cache.put(url, new Response(buffer, {
+              headers: {
+                'Content-Length': String(chunk.bytes),
+                'Content-Type': 'application/octet-stream',
+                'X-Mobius-SHA256': chunk.sha256,
+              },
+            }))
+            downloadedBytes += chunk.bytes
+            channel.event('progress', {
+              downloadedBytes,
+              totalBytes: pkg.bytes,
+              assetId: asset.id,
+            })
+          }
+        }
+        state = await packageState(cache, origin, ownerAppId, pkg, fingerprint)
+        if (state.state !== 'ready') {
+          throw capabilityError('integrity_failed', 'The device asset package is incomplete.')
+        }
+        await cache.put(completeUrl(origin, ownerAppId, pkg, fingerprint), new Response('', {
+          headers: {
+            'Content-Length': '0',
+            'X-Mobius-Package-Complete': '1',
+          },
+        }))
+        await pruneOldPackageVersions(cache, origin, ownerAppId, pkg, fingerprint)
+        return progressValue(state, persistenceMode)
+      }).then((result) => {
+        settled = true
+        channel.result(result)
+      }).catch((error) => {
+        settled = true
+        channel.error(error)
+      })
+
+      return {
+        control(action) {
+          if (action === 'cancel' && !settled && !controller.signal.aborted) {
+            const error = capabilityError(
+              'aborted',
+              'Device asset operation cancelled.',
+              'AbortError',
+            )
+            controller.abort(error)
+            releaseRead?.reject(error)
+          } else if (action === 'next') {
+            releaseRead?.resolve()
+          }
+        },
+      }
+    },
+  }
+}
+
+export async function purgeDeviceAssetCache(appId, cacheStorage = globalThis.caches) {
+  if (!Number.isSafeInteger(Number(appId)) || Number(appId) < 1 || !cacheStorage?.delete) {
+    return false
+  }
+  return cacheStorage.delete(cacheName(Number(appId)))
+}

--- a/frontend/src/lib/deviceAssetCache.js
+++ b/frontend/src/lib/deviceAssetCache.js
@@ -477,6 +477,13 @@ export function createDeviceAssetCacheProvider({
                 `The device asset source returned ${response?.status || 'an error'}.`,
               )
             }
+            const upstreamTotal = response.headers.get('X-Mobius-Asset-Total')
+            if (upstreamTotal !== null && upstreamTotal !== String(asset.bytes)) {
+              throw capabilityError(
+                'download_failed',
+                'The device asset source did not match the reviewed asset size.',
+              )
+            }
             const buffer = await response.arrayBuffer()
             if (buffer.byteLength !== chunk.bytes) {
               throw capabilityError('download_failed', 'A downloaded chunk had the wrong size.')


### PR DESCRIPTION
## Summary
- add a reviewed `device.asset-cache` capability for large, regenerable public assets
- partition browser Cache Storage by app and request persistence only during explicit install
- verify bounded SHA-256 chunks, resume verified partials, preserve the prior complete package until replacement succeeds, and stream reads with backpressure
- relay exact HTTPS byte ranges through an owner-only, SSRF-safe, no-store route without retaining bytes on the server
- purge an app’s device partition when its data is explicitly cleared

## Why
Opaque app frames intentionally cannot use origin-bound browser stores. Apps that need large on-device inputs should not gain same-origin access or implement feature-specific platform bridges. This adds one general, reviewed storage primitive while leaving download UX, licensing, and interpretation inside each app.

## Verification
- focused frontend capability and cache tests (16 passed)
- focused backend capability and relay tests (16 passed)
- verified in the News app that route-derived string app IDs resolve correctly and expose the explicit per-device download state