### PR TITLE
Simplify composer popover focus ownership

### DIFF
--- a/frontend/src/components/ChatView/ChatSettingsPanel.css
+++ b/frontend/src/components/ChatView/ChatSettingsPanel.css
@@ -76,7 +76,6 @@
   color: var(--text);
   text-align: left;
   transition: background 0.12s ease, border-color 0.12s ease;
-  touch-action: pan-y;
 }
 
 @media (hover: hover) and (pointer: fine) {

--- a/frontend/src/components/ChatView/ChatSettingsPanel.jsx
+++ b/frontend/src/components/ChatView/ChatSettingsPanel.jsx
@@ -48,14 +48,11 @@
  * ║      sends. Rows stay interactive while routine saves settle.    ║
  * ║                                                                  ║
  * ║   4. KEYBOARD-STATE PRESERVATION                                 ║
- * ║      `refocusChatInput` gates on `wasInputFocusedRef?.current`   ║
- * ║      (captured in ComposerPopover at + tap-time). Picking a      ║
- * ║      model or effort with the keyboard DOWN does NOT pop it      ║
- * ║      up. Every interactive row in this panel has                 ║
- * ║      pointerdown focus guards — see ComposerPopover.jsx's        ║
- * ║      three-guard contract for the full story. The guard applies  ║
- * ║      to touch too; `touch-action: pan-y` still lets a row-origin  ║
- * ║      gesture scroll the long model list.                         ║
+ * ║      ComposerPopover owns one pointer handler on the popover.    ║
+ * ║      Bubbling covers every present and future control            ║
+ * ║      without leaking composer-specific focus props into shared   ║
+ * ║      controls. Its `touch-action: pan-y` keeps the long model    ║
+ * ║      list scrollable from any descendant.                        ║
  * ║                                                                  ║
  * ║   The shared <EffortStepper> renders a stepper track — NOT       ║
  * ║   pills, NOT a chip group. The slider was explicitly chosen      ║
@@ -99,10 +96,6 @@ import {
   resolveProviderAvailability,
   visibleProviderModels,
 } from '../../lib/providerAvailability.js'
-import {
-  focusComposerElement,
-  preserveComposerInputFocus,
-} from './composerFocusPolicy.js'
 import './ChatSettingsPanel.css'
 
 /** Claude product mark — four-petal flower / starburst silhouette,
@@ -249,12 +242,6 @@ export default function ChatSettingsPanel({
   onChange,
   // Shared promise tail for picker writes, handoffs, and message sends.
   settingsSaveTailRef,
-  // Tracks whether the chat textarea was focused when the popover
-  // opened. Used to decide whether to refocus after a picker
-  // action so the soft keyboard stays in its previous state
-  // (up if it was up, down if it was down).
-  wasInputFocusedRef,
-  composerInputRef,
   // Per-chat external state survives the popover and ChatView itself. This is
   // what keeps navigation away/back from unlocking a live handoff or losing
   // its retry id and error feedback.
@@ -453,18 +440,6 @@ export default function ChatSettingsPanel({
     }
   }, [chatId, pendingSwitch, provider, settingsSaveTailRef])
 
-  // Conditional refocus — only restores textarea focus if it was
-  // ALREADY focused when the popover opened. Without this guard,
-  // tapping + with the keyboard down and then picking a model
-  // would force-focus the textarea, popping the keyboard up.
-  // iOS Safari sometimes drops focus during the button click even
-  // with pointerdown preventDefault; this restores it in that case
-  // but only when the user was actually typing.
-  const refocusChatInput = useCallback(() => {
-    if (!wasInputFocusedRef?.current) return
-    focusComposerElement(composerInputRef?.current)
-  }, [composerInputRef, wasInputFocusedRef])
-
   const handleEffortChange = useCallback((value) => {
     // Remember this effort under the active provider so a later
     // provider-switch restores it; ship BOTH `effort` (active) and
@@ -476,8 +451,7 @@ export default function ChatSettingsPanel({
     patchChat({
       agent_settings_json: { effort: value, effort_by_provider: nextMap },
     })
-    refocusChatInput()
-  }, [draftProvider, draftEffortByProvider, patchChat, refocusChatInput])
+  }, [draftProvider, draftEffortByProvider, patchChat])
 
   const switchProviderModel = useCallback(async (
     value, providerValue, allowedEfforts, switchId = createProviderSwitchId(),
@@ -538,7 +512,6 @@ export default function ChatSettingsPanel({
   ])
 
   const handlePickModel = useCallback(async (value, providerValue, allowedEfforts) => {
-    refocusChatInput()
     if (providerValue !== draftProvider) {
       if (hasAssistantTurns) {
         if (providerSwitchInFlightRef.current) return
@@ -593,7 +566,6 @@ export default function ChatSettingsPanel({
     chatId,
     patchChat,
     provider,
-    refocusChatInput,
     switchProviderModel,
   ])
 
@@ -603,7 +575,6 @@ export default function ChatSettingsPanel({
       || compacting
       || providerSwitchInFlightRef.current
     ) return
-    refocusChatInput()
     const ok = await switchProviderModel(
       pendingSwitch.model,
       pendingSwitch.provider,
@@ -616,7 +587,6 @@ export default function ChatSettingsPanel({
   }, [
     pendingSwitch,
     compacting,
-    refocusChatInput,
     switchProviderModel,
   ])
 
@@ -629,8 +599,7 @@ export default function ChatSettingsPanel({
     }
     clearProviderSwitch(chatId)
     pendingSwitchPreviousRef.current = null
-    refocusChatInput()
-  }, [chatId, refocusChatInput])
+  }, [chatId])
 
   const isCodex = draftProvider === 'codex'
   const switchBusy = compacting
@@ -692,7 +661,6 @@ export default function ChatSettingsPanel({
               <span>Could not load models.</span>
               <button
                 type="button"
-                onPointerDown={preserveComposerInputFocus}
                 onClick={() => {
                   registryQuery.refetch()
                   prefsQuery.refetch()
@@ -724,7 +692,6 @@ export default function ChatSettingsPanel({
           <span>Could not verify providers. Showing the current model only.</span>
           <button
             type="button"
-            onPointerDown={preserveComposerInputFocus}
             onClick={() => providerStatusQuery.refetch()}
           >
             Retry
@@ -767,7 +734,6 @@ export default function ChatSettingsPanel({
               <button
                 type="button"
                 className={`csp-row${isSelected ? ' csp-row--selected' : ''}`}
-                onPointerDown={preserveComposerInputFocus}
                 onClick={() => {
                   if (!appCrossProvider) handlePickModel(m.id, pid, rowEfforts)
                 }}
@@ -790,9 +756,7 @@ export default function ChatSettingsPanel({
               </button>
               {isSelected && !isPendingRow && (
                 // Indent aligns the stepper under the row title (icon 30 +
-                // gap 12 + row pad 10 = 52). onStopPointerDown preserves the
-                // composer's soft-keyboard-focus contract — a stop tap must
-                // not blur the chat textarea (see preserveComposerInputFocus).
+                // gap 12 + row pad 10 = 52).
                 <div className="csp-effort-indent">
                   <EffortStepper
                     efforts={rowEfforts}
@@ -803,7 +767,6 @@ export default function ChatSettingsPanel({
                     // while a save settles. A live provider switch or
                     // disconnected provider remains genuinely unavailable.
                     disabled={switchBusy || !providerConfigured}
-                    onStopPointerDown={preserveComposerInputFocus}
                   />
                 </div>
               )}
@@ -816,7 +779,6 @@ export default function ChatSettingsPanel({
                     <button
                       type="button"
                       className="csp__confirm-btn csp__confirm-btn--primary"
-                      onPointerDown={preserveComposerInputFocus}
                       onClick={handleConfirmProviderSwitch}
                       disabled={switchBusy}
                     >
@@ -825,7 +787,6 @@ export default function ChatSettingsPanel({
                     <button
                       type="button"
                       className="csp__confirm-btn csp__confirm-btn--ghost"
-                      onPointerDown={preserveComposerInputFocus}
                       onClick={handleCancelProviderSwitch}
                       disabled={switchBusy}
                     >
@@ -845,7 +806,6 @@ export default function ChatSettingsPanel({
             <>
               <div
                 className="csp__automation-row"
-                onPointerDown={preserveComposerInputFocus}
               >
                 <label className="csp__automation-copy" htmlFor={autoResumeSwitchId}>
                   <span className="csp__automation-title">Automatically continue after usage limits</span>
@@ -869,7 +829,6 @@ export default function ChatSettingsPanel({
             <>
               <div
                 className="csp__automation-row"
-                onPointerDown={preserveComposerInputFocus}
               >
                 <label
                   className="csp__automation-copy"

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -2406,6 +2406,7 @@
   z-index: 50;
   /* Touch-scroll inside the popover should not bubble up and close
      the keyboard or scroll the chat behind it. */
+  touch-action: pan-y;
   overscroll-behavior: contain;
 }
 

--- a/frontend/src/components/ChatView/ComposerPopover.jsx
+++ b/frontend/src/components/ChatView/ComposerPopover.jsx
@@ -18,46 +18,15 @@
  * anchor — the form is only relative so other absolutely-positioned
  * children (none today) could anchor to it.
  *
- * ╔════════════════════════════════════════════════════════════════╗
- * ║                                                                ║
- * ║   SOFT-KEYBOARD CONTRACT — the rule that took the longest      ║
- * ║                                                                ║
- * ║   Tapping `+` MUST NEVER change the soft-keyboard state.       ║
- * ║   Up stays up. Down stays down. This holds regardless of       ║
- * ║   which affordance inside the popover the user then taps —     ║
- * ║   Attach files, a model row, an effort stop, or close          ║
- * ║   (Escape / outside-tap). The same contract holds for the      ║
- * ║   file-picker round-trip and the chip × button.                ║
- * ║                                                                ║
- * ║   THREE INDEPENDENT GUARDS make this work:                     ║
- * ║                                                                ║
- * ║   1. `pointerdown.preventDefault()` on EVERY interactive       ║
- * ║      element inside the composer (the +, every popover row,    ║
- * ║      every effort stop, every model row, the chip ×).          ║
- * ║      Spec-correct browsers honour this and don't shift         ║
- * ║      focus on tap.                                             ║
- * ║                                                                ║
- * ║   2. `wasInputFocusedRef` captured SYNCHRONOUSLY inside the    ║
- * ║      `+` button's onClick (not in a post-commit useEffect —    ║
- * ║      that misses iOS Safari's focus-shuffle window). Refocus   ║
- * ║      after every picker action is GATED on this ref. If it     ║
- * ║      was false, no refocus runs.                               ║
- * ║                                                                ║
- * ║   3. Defensive `requestAnimationFrame` blur on the `+` tap     ║
- * ║      if the textarea was NOT focused at tap-time. Catches      ║
- * ║      Android Chrome's occasional focus-restoration that        ║
- * ║      preventDefault doesn't always cover.                      ║
- * ║                                                                ║
- * ║   Violating any one of these can pop the keyboard or drop      ║
- * ║   focus inappropriately. They are NOT redundant; each one      ║
- * ║   plugs a different platform's behaviour. Don't simplify       ║
- * ║   without re-verifying on iOS Safari AND Android Chrome.       ║
- * ║                                                                ║
- * ║   `settingsSaveTailRef` comes from ChatView and outlives this  ║
- * ║   popover. Picker writes therefore keep their order when the   ║
- * ║   panel closes, and message sends can share the same boundary. ║
- * ║                                                                ║
- * ╚════════════════════════════════════════════════════════════════╝
+ * Soft-keyboard contract: opening or using this popover preserves whether the
+ * owning textarea was focused. The + trigger suppresses native button focus
+ * and records that state synchronously. The popover has one bubbling
+ * pointer boundary that suppresses descendant focus and restores the textarea
+ * on the next frame only when it was focused before opening. That next-frame
+ * repair covers mobile Safari dropping focus during the later click without
+ * stealing keyboard focus from keyboard-operated controls. ChatInputBar owns
+ * the separate native file-picker return. Opening with the keyboard down keeps
+ * the defensive next-frame blur for Android's occasional focus restoration.
  */
 
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
@@ -115,6 +84,12 @@ export default function ComposerPopover({
   // visible viewport. See composerPopoverHeight.js for why CSS viewport units
   // can't express either boundary.
   const [maxHeight, setMaxHeight] = useState(null)
+
+  function preservePickerInputFocus(event) {
+    event.preventDefault()
+    if (!wasInputFocusedRef.current) return
+    requestAnimationFrame(() => focusComposerElement(composerInputRef?.current))
+  }
 
   useLayoutEffect(() => {
     if (!open) return
@@ -246,15 +221,13 @@ export default function ComposerPopover({
           className="composer-popover"
           role="dialog"
           aria-label="Chat options"
+          onPointerDown={preservePickerInputFocus}
           style={maxHeight !== null ? { maxHeight: `${maxHeight}px` } : undefined}
         >
           <div className="composer-popover__section">
             <button
               type="button"
               className="composer-popover__row"
-              // Keep the textarea focused so the soft keyboard stays
-              // open while the user picks from the popover.
-              onPointerDown={(e) => e.preventDefault()}
               onClick={handleAttach}
             >
               <span className="composer-popover__row-icon"><Paperclip width={20} height={20} /></span>
@@ -285,8 +258,6 @@ export default function ComposerPopover({
                 onChange={onChangeChatInfo}
                 providerSwitchState={providerSwitchState}
                 settingsSaveTailRef={settingsSaveTailRef}
-                wasInputFocusedRef={wasInputFocusedRef}
-                composerInputRef={composerInputRef}
               />
             </div>
           )}
@@ -295,7 +266,6 @@ export default function ComposerPopover({
             <button
               type="button"
               className="composer-popover__row"
-              onPointerDown={(e) => e.preventDefault()}
               onClick={handleOpenSummary}
             >
               <span className="composer-popover__row-icon" aria-hidden="true">
@@ -311,7 +281,6 @@ export default function ComposerPopover({
             <button
               type="button"
               className="composer-popover__row"
-              onPointerDown={(e) => e.preventDefault()}
               onClick={handleOpenInspector}
             >
               <span className="composer-popover__row-icon" aria-hidden="true">

--- a/frontend/src/components/ChatView/__tests__/composerFocusPolicy.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerFocusPolicy.test.js
@@ -3,7 +3,6 @@ import assert from 'node:assert/strict'
 
 import {
   focusComposerElement,
-  preserveComposerInputFocus,
   shouldApplyComposerFocusRequest,
 } from '../composerFocusPolicy.js'
 
@@ -55,15 +54,4 @@ test('focusComposerElement falls back for older focus implementations', () => {
   }
   assert.equal(focusComposerElement(el), true)
   assert.deepEqual(calls, [[{ preventScroll: true }], []])
-})
-
-test('composer pointer actions preserve input focus for touch, mouse, and pen', () => {
-  for (const pointerType of ['touch', 'mouse', 'pen']) {
-    let prevented = 0
-    assert.equal(preserveComposerInputFocus({
-      pointerType,
-      preventDefault() { prevented += 1 },
-    }), true)
-    assert.equal(prevented, 1, pointerType)
-  }
 })

--- a/frontend/src/components/ChatView/composerFocusPolicy.js
+++ b/frontend/src/components/ChatView/composerFocusPolicy.js
@@ -18,16 +18,3 @@ export function focusComposerElement(el) {
   }
   return true
 }
-
-/**
- * Keep a pointer interaction inside the composer from moving focus away from
- * its textarea. This deliberately applies to touch as well as mouse/pen:
- * mobile browsers perform the focus default between pointerdown and click, so
- * attempting to refocus from the later click can be too late to stop the soft
- * keyboard collapsing.
- */
-export function preserveComposerInputFocus(event) {
-  if (!event || typeof event.preventDefault !== 'function') return false
-  event.preventDefault()
-  return true
-}

--- a/frontend/src/components/ui/EffortStepper.jsx
+++ b/frontend/src/components/ui/EffortStepper.jsx
@@ -12,10 +12,6 @@ import './EffortStepper.css'
  * an `onChange`. Stops at/below the selected one read as filled; the
  * selected one sits proud with an accent ring, like a slider thumb.
  *
- * `onStopPointerDown` is the composer's escape hatch: the `+` popover
- * must not let a stop-tap move focus off the chat textarea (it would
- * pop the soft keyboard), so it passes `preserveFocusUnlessTouch`.
- * Surfaces without that constraint (Settings) omit it.
  */
 export default function EffortStepper({
   efforts,
@@ -23,7 +19,6 @@ export default function EffortStepper({
   onChange,
   disabled = false,
   ariaLabel = 'Reasoning effort',
-  onStopPointerDown,
 }) {
   if (!efforts || efforts.length === 0) return null
   // Default to index 0 when the persisted value isn't in this
@@ -50,7 +45,6 @@ export default function EffortStepper({
               + (index === selectedIndex ? ' effort-stepper__stop--on' : '')
               + (index < selectedIndex ? ' effort-stepper__stop--filled' : '')
             }
-            onPointerDown={onStopPointerDown}
             onClick={() => onChange(effort.value)}
             onKeyDown={(event) => {
               let next


### PR DESCRIPTION
## Summary

- preserve the composer keyboard state through one bubbling pointer boundary on the options popover
- remove per-control pointer guards and click-time refocus calls
- remove composer-specific focus plumbing from the shared effort control and the no-longer-needed helper and test
- keep vertical touch scrolling and pointer-only next-frame focus repair

## Why

This is a follow-up to #523. That fix correctly prevented the soft keyboard from collapsing, but the policy was spread across every interactive control and leaked a composer-specific prop into a shared component. Owning the behavior at the existing popover boundary means current and future controls inherit it automatically. Pointer-only restoration also leaves keyboard-operated controls focused normally.

## Testing

- `npm test` (2,297 component/library tests and 79 hook tests)
- `npm run lint`
- `npm run build`
- rendered touch-pointer checks for attachments, model rows, effort stops, automation switches, context actions, and the popover surface
- rendered keyboard-down check confirming picker taps do not refocus the composer

Real-device iOS and Android soft-keyboard animation remains device-specific verification.