### PR TITLE
Simplify chat runtime cache contract

### DIFF
--- a/frontend/src/components/ChatView/__tests__/chatRuntimeCache.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatRuntimeCache.test.js
@@ -26,15 +26,17 @@ test('unchanged runtime polls do not publish a persisted-cache update', () => {
   const cache = cacheHarness({
     messages: transcript,
     running: true,
+    activeGoalObjective: 'Fix first-scroll jitter',
     pending_messages: [{ id: 'queued-1', content: 'next' }],
     pending_question_id: null,
   })
 
-  const changed = updateChatRuntimeCache(
+  updateChatRuntimeCache(
     cache.queryClient,
     ['chat-messages', 'chat-1'],
     {
       running: true,
+      activeGoalObjective: 'Fix first-scroll jitter',
       // A network response creates new objects even when their JSON-domain
       // value is unchanged. That must still count as an unchanged poll.
       pending_messages: [{ id: 'queued-1', content: 'next' }],
@@ -42,25 +44,8 @@ test('unchanged runtime polls do not publish a persisted-cache update', () => {
     },
   )
 
-  assert.equal(changed, false)
   assert.equal(cache.updates(), 0, 'setQueryData itself must be skipped')
   assert.equal(cache.value().messages, transcript)
-})
-
-test('an unchanged active goal does not publish a persisted-cache update', () => {
-  const cache = cacheHarness({
-    messages: [{ role: 'assistant', content: 'large durable history' }],
-    activeGoalObjective: 'Fix first-scroll jitter',
-  })
-
-  const changed = updateChatRuntimeCache(
-    cache.queryClient,
-    ['chat-messages', 'chat-1'],
-    { activeGoalObjective: 'Fix first-scroll jitter' },
-  )
-
-  assert.equal(changed, false)
-  assert.equal(cache.updates(), 0, 'an unchanged goal must skip setQueryData')
 })
 
 test('a runtime transition patches only runtime fields', () => {
@@ -73,7 +58,7 @@ test('a runtime transition patches only runtime fields', () => {
     pending_question_id: null,
   })
 
-  const changed = updateChatRuntimeCache(
+  updateChatRuntimeCache(
     cache.queryClient,
     ['chat-messages', 'chat-1'],
     {
@@ -83,7 +68,6 @@ test('a runtime transition patches only runtime fields', () => {
     },
   )
 
-  assert.equal(changed, true)
   assert.equal(cache.updates(), 1)
   assert.equal(cache.value().messages, transcript)
   assert.equal(cache.value().offset, 12)
@@ -95,11 +79,11 @@ test('a runtime transition patches only runtime fields', () => {
 test('a missing chat cache accepts the first runtime snapshot', () => {
   const cache = cacheHarness(undefined)
 
-  assert.equal(updateChatRuntimeCache(
+  updateChatRuntimeCache(
     cache.queryClient,
     ['chat-messages', 'chat-1'],
     { running: true },
-  ), true)
+  )
   assert.equal(cache.updates(), 1)
   assert.deepEqual(cache.value(), { running: true })
 })

--- a/frontend/src/components/ChatView/chatRuntimeCache.js
+++ b/frontend/src/components/ChatView/chatRuntimeCache.js
@@ -32,12 +32,11 @@ export function updateChatRuntimeCache(queryClient, queryKey, patch) {
     current
     && fields.every(field => runtimeFieldMatches(current, field, patch[field]))
   ) {
-    return false
+    return
   }
 
   queryClient.setQueryData(queryKey, existing => ({
     ...(existing || {}),
     ...patch,
   }))
-  return true
 }


### PR DESCRIPTION
## Summary
- remove an unused changed/not-changed result from the chat runtime cache updater
- fold active-goal no-op coverage into the complete unchanged-snapshot case
- preserve the existing no-op publication behavior with less test and interface surface

## Why
#530 correctly stopped unchanged runtime snapshots from republishing the persisted chat cache. Production callers use this helper only as a command; none consume the boolean result it returned. Keeping that result made the helper's contract wider than its real responsibility and required a duplicate test case.

This follow-up narrows the interface and consolidates the coverage without changing cache behavior.

## Testing
- `npm run runtime:check`
- `npm run test:structure`
- focused chat runtime, goal, workspace, and persistence tests
- ESLint on the changed files

Follow-up to #530.