### PR TITLE
Add general clipboard paste to the chat composer

### DIFF
--- a/frontend/src/components/ChatView/ChatInputBar.jsx
+++ b/frontend/src/components/ChatView/ChatInputBar.jsx
@@ -101,7 +101,12 @@ import {
   slashCommandUnavailableReason,
   visibleSlashCommands,
 } from './slashCommands.js'
-import { filePasteNeedsDefaultPrevented, pastedFiles } from './pasteUpload.js'
+import {
+  filePasteNeedsDefaultPrevented,
+  insertClipboardText,
+  pastedFiles,
+  readClipboardContents,
+} from './pasteUpload.js'
 import { hasSendablePayload } from './composerSubmission.js'
 import {
   textareaUsesNativeSizing,
@@ -499,13 +504,17 @@ export default function ChatInputBar({
   leftButtons,
   rightButtons,
   attachTriggerRef,
+  clipboardTriggerRef,
   messageHistory = [],
   provider,
 }) {
   const fileInputRef = useRef(null)
   const historyIndexRef = useRef(null)
   const historyDraftRef = useRef('')
-  const historyCaretRef = useRef(null)
+  // One caret handoff serves every programmatic composer edit (sent-message
+  // history and explicit clipboard insertion). React first commits the
+  // controlled value; the layout effect below then restores its intended caret.
+  const pendingCaretRef = useRef(null)
   const historyProbeVersionRef = useRef(0)
   // Captures whether the textarea was focused at the moment the file
   // picker opened. Read by `handleFileSelect` to decide whether to
@@ -571,8 +580,47 @@ export default function ChatInputBar({
     historyProbeVersionRef.current += 1
     historyIndexRef.current = null
     historyDraftRef.current = ''
-    historyCaretRef.current = null
+    pendingCaretRef.current = null
   }
+
+  // Keep clipboard access behind the same narrow trigger boundary as Attach:
+  // ComposerPopover owns the visible action while the bar owns how clipboard
+  // text and files enter its controlled draft and attachment pipeline.
+  useLayoutEffect(() => {
+    if (!clipboardTriggerRef) return
+    clipboardTriggerRef.current = async () => {
+      const result = await readClipboardContents()
+      if (result.status !== 'ready') return result
+
+      if (result.files.length > 0) onAddFiles(result.files)
+      if (result.text) {
+        resetMessageHistory()
+        const textarea = inputRef?.current
+        const inserted = insertClipboardText(
+          input,
+          result.text,
+          textarea?.selectionStart,
+          textarea?.selectionEnd,
+        )
+        pendingCaretRef.current = inserted
+        if (listeningRef?.current) onManualVoiceEdit?.(inserted.value)
+        onInputChange(inserted.value)
+      }
+
+      return { ...result, status: 'pasted' }
+    }
+    return () => {
+      if (clipboardTriggerRef.current) clipboardTriggerRef.current = null
+    }
+  }, [
+    clipboardTriggerRef,
+    input,
+    inputRef,
+    listeningRef,
+    onAddFiles,
+    onInputChange,
+    onManualVoiceEdit,
+  ])
 
   // Never carry a traversal or its saved draft into another chat. History
   // list refreshes deliberately do not reset this: a queued message can move
@@ -585,11 +633,11 @@ export default function ChatInputBar({
   // History values arrive through the controlled composer boundary. Restore
   // the caret after React commits that value without changing focus or scroll.
   useLayoutEffect(() => {
-    const pending = historyCaretRef.current
+    const pending = pendingCaretRef.current
     const textarea = inputRef?.current
     if (!pending || pending.value !== input || !textarea) return
     try { textarea.setSelectionRange(pending.caret, pending.caret) } catch {}
-    historyCaretRef.current = null
+    pendingCaretRef.current = null
   }, [input, inputRef])
 
   // Modern browsers size the textarea from CSS (`field-sizing: content`).
@@ -688,7 +736,7 @@ export default function ChatInputBar({
     function applyHistoryMove(historyMove) {
       historyIndexRef.current = historyMove.index
       historyDraftRef.current = historyMove.draft
-      historyCaretRef.current = {
+      pendingCaretRef.current = {
         value: historyMove.value,
         caret: historyMove.value.length,
       }
@@ -705,7 +753,7 @@ export default function ChatInputBar({
             historyMove.value.length,
           )
         } catch {}
-        historyCaretRef.current = null
+        pendingCaretRef.current = null
       }
     }
 

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -2419,7 +2419,7 @@
   gap: 1px;
 }
 
-/* Hairline divider between Attach and the picker. The popover owns the one
+/* Hairline divider between content actions and the picker. The popover owns the one
    scroll surface; a nested model-list scroller hid the continuation control
    above summary rows on phones and made their visible order misleading. */
 .composer-popover__section--picker {
@@ -2434,7 +2434,7 @@
   border-top: 1px solid var(--border-light);
 }
 
-/* Generic popover row — used by the Attach files entry. Same
+/* Generic popover row — used by the clipboard and Attach entries. Same
    geometry as `.csp-row` in ChatSettingsPanel so the two sections
    align visually. */
 .composer-popover__row {
@@ -2453,7 +2453,8 @@
   transition: background 0.12s ease;
 }
 
-.composer-popover__row:hover { background: var(--surface2); /* CONTRACT: opaque hover/raised fill, slightly above --surface */ }
+.composer-popover__row:not(:disabled):hover { background: var(--surface2); /* CONTRACT: opaque hover/raised fill, slightly above --surface */ }
+.composer-popover__row:disabled { cursor: wait; opacity: 0.68; }
 
 .composer-popover__row-icon {
   width: 30px;
@@ -2489,6 +2490,8 @@
   color: var(--muted); /* CONTRACT: low-contrast text on opaque fill */
   line-height: 1.4;
 }
+
+.composer-popover__row-sub--error { color: var(--danger); }
 
 /* ── File chips: attach cards inside the pill ────────────────
    When the user attaches files the pill flips to a column layout

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -508,6 +508,10 @@ export default function ChatView({
   // current() to fire the bar's hidden picker. ChatInputBar's layout
   // effect installs the function.
   const attachTriggerRef = useRef(null)
+  // Clipboard reading also belongs to ChatInputBar because that component owns
+  // both destinations: controlled composer text and pending attachments. The
+  // popover calls this ref and renders only the browser outcome it returns.
+  const clipboardTriggerRef = useRef(null)
   // The model/effort picker can accept another choice before the prior save
   // settles. Keep its serialized write tail at ChatView scope so both a closed
   // + popover and an immediate Send still observe the same ordering boundary.
@@ -4214,6 +4218,7 @@ export default function ChatView({
           onAddFiles={handleComposerAddFiles}
           onRemoveFile={handleComposerRemoveFile}
           attachTriggerRef={attachTriggerRef}
+          clipboardTriggerRef={clipboardTriggerRef}
           messageHistory={messageHistory}
           provider={chatInfo?.provider}
           leftButtons={
@@ -4222,6 +4227,7 @@ export default function ChatView({
                 chatInfo={showPicker ? chatInfo : null}
                 chatId={chatId}
                 onAttachClick={() => attachTriggerRef.current?.()}
+                onPasteFromClipboard={() => clipboardTriggerRef.current?.()}
                 /* Derive live — `chatInfo.has_assistant_turns` is set
                    once on mount via the API and never refreshed when
                    the running turn finishes. Without this OR, sending

--- a/frontend/src/components/ChatView/ComposerPopover.jsx
+++ b/frontend/src/components/ChatView/ComposerPopover.jsx
@@ -2,8 +2,8 @@
  * ComposerPopover — the `+` button in the chat composer and the popover
  * it opens. Two sections in one popover:
  *
- *   1. Attach files  — calls `onAttachClick` (parent owns the hidden
- *      <input type="file"> so it can clear .value after each pick).
+ *   1. Add content — reads browser-exposed clipboard text/files or calls
+ *      `onAttachClick` (parent owns the hidden file input).
  *   2. Model / effort / summary / automation — renders
  *      <ChatSettingsPanel> when a chatInfo is available; omitted on a fresh
  *      empty chat where chatInfo hasn't loaded yet.
@@ -61,7 +61,7 @@
  */
 
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
-import { FileDocument, InfoCircle, Paperclip, Plus } from '@openai/apps-sdk-ui/components/Icon'
+import { Clipboard, FileDocument, InfoCircle, Paperclip, Plus } from '@openai/apps-sdk-ui/components/Icon'
 import ChatSettingsPanel from './ChatSettingsPanel.jsx'
 import { popoverMaxHeight, nearestClipTop } from './composerPopoverHeight.js'
 import { focusComposerElement } from './composerFocusPolicy.js'
@@ -70,6 +70,7 @@ export default function ComposerPopover({
   chatInfo,
   chatId,
   onAttachClick,
+  onPasteFromClipboard,
   onChangeChatInfo,
   // Live-derived in the parent: `chatInfo.has_assistant_turns` is
   // set once on mount and never refreshed when the running turn
@@ -95,6 +96,8 @@ export default function ComposerPopover({
   embedded = false,
 }) {
   const [open, setOpen] = useState(false)
+  const [pasteBusy, setPasteBusy] = useState(false)
+  const [pasteMessage, setPasteMessage] = useState('')
   const wrapRef = useRef(null)
   const triggerRef = useRef(null)
   // Tracks whether the chat textarea was focused at the moment the
@@ -191,6 +194,28 @@ export default function ComposerPopover({
     onAttachClick()
   }
 
+  async function handlePasteFromClipboard() {
+    if (pasteBusy) return
+    setPasteBusy(true)
+    setPasteMessage('')
+    try {
+      const result = await onPasteFromClipboard?.()
+      if (result?.status === 'pasted') {
+        setOpen(false)
+        return
+      }
+      const messages = {
+        denied: 'Clipboard access was blocked. Allow it in your browser settings, then retry.',
+        empty: 'No usable text or files were found on the clipboard.',
+        unsupported: 'Clipboard reading is unavailable here. Use Attach files instead.',
+        failed: 'Your browser could not read that clipboard item. Use Attach files instead.',
+      }
+      setPasteMessage(messages[result?.status] || messages.failed)
+    } finally {
+      setPasteBusy(false)
+    }
+  }
+
   function handleOpenInspector() {
     setOpen(false)
     onOpenInspector?.()
@@ -219,7 +244,10 @@ export default function ComposerPopover({
           // wasInputFocusedRef declaration above.
           const el = composerInputRef?.current
           const wasFocused = document.activeElement === el
-          if (!open) wasInputFocusedRef.current = wasFocused
+          if (!open) {
+            wasInputFocusedRef.current = wasFocused
+            setPasteMessage('')
+          }
           setOpen(o => !o)
           // Belt-and-suspenders against Android Chrome's focus
           // restoration: when the popover mounts as a sibling of
@@ -235,7 +263,7 @@ export default function ComposerPopover({
             })
           }
         }}
-        aria-label="Attach or change model"
+        aria-label="Chat options"
         aria-haspopup="dialog"
         aria-expanded={open}
       >
@@ -249,6 +277,24 @@ export default function ComposerPopover({
           style={maxHeight !== null ? { maxHeight: `${maxHeight}px` } : undefined}
         >
           <div className="composer-popover__section">
+            <button
+              type="button"
+              className="composer-popover__row"
+              onClick={handlePasteFromClipboard}
+              disabled={pasteBusy}
+            >
+              <span className="composer-popover__row-icon"><Clipboard width={20} height={20} /></span>
+              <span className="composer-popover__row-main">
+                <span className="composer-popover__row-title">Paste from clipboard</span>
+                <span
+                  className={`composer-popover__row-sub${pasteMessage ? ' composer-popover__row-sub--error' : ''}`}
+                  role={pasteMessage ? 'status' : undefined}
+                  aria-live={pasteMessage ? 'polite' : undefined}
+                >
+                  {pasteBusy ? 'Reading clipboard…' : pasteMessage || 'Text, images, and files'}
+                </span>
+              </span>
+            </button>
             <button
               type="button"
               className="composer-popover__row"

--- a/frontend/src/components/ChatView/__tests__/contextMenuOrder.test.js
+++ b/frontend/src/components/ChatView/__tests__/contextMenuOrder.test.js
@@ -35,6 +35,17 @@ test('chat context actions follow model selection and continuation policy', () =
 })
 
 
+test('composer offers general clipboard content before the file picker fallback', () => {
+  const clipboard = composerSource.indexOf('>Paste from clipboard</span>')
+  const attach = composerSource.indexOf('>Attach files</span>')
+
+  assert.ok(clipboard !== -1 && attach !== -1)
+  assert.ok(clipboard < attach)
+  assert.match(composerSource, /Text, images, and files/)
+  assert.match(composerSource, /onPasteFromClipboard/)
+})
+
+
 test('agent context inspector keeps continuity and active turn context visible', () => {
   assert.match(inspectorSource, /title: 'System prompt'/)
   assert.match(inspectorSource, /title: 'Recent chat summaries'/)

--- a/frontend/src/components/ChatView/__tests__/pasteUpload.test.js
+++ b/frontend/src/components/ChatView/__tests__/pasteUpload.test.js
@@ -3,7 +3,9 @@ import assert from 'node:assert/strict'
 
 import {
   filePasteNeedsDefaultPrevented,
+  insertClipboardText,
   pastedFiles,
+  readClipboardContents,
 } from '../pasteUpload.js'
 
 test('pastedFiles reads screenshots from clipboard files', () => {
@@ -27,4 +29,65 @@ test('file paste preserves accompanying text but suppresses file-only insertion'
   const files = [{ name: 'shot.png' }]
   assert.equal(filePasteNeedsDefaultPrevented({ getData: () => '' }, files), true)
   assert.equal(filePasteNeedsDefaultPrevented({ getData: () => 'caption' }, files), false)
+})
+
+function clipboardItem(types, values) {
+  return {
+    types,
+    getType: async (type) => new Blob([values[type]], { type }),
+  }
+}
+
+test('explicit clipboard read uses one semantic representation per item', async () => {
+  const clipboard = {
+    read: async () => [
+      clipboardItem(
+        ['text/plain', 'image/png'],
+        { 'text/plain': 'duplicate image label', 'image/png': 'png-bytes' },
+      ),
+      clipboardItem(['text/plain'], { 'text/plain': 'A caption' }),
+      clipboardItem(['application/pdf'], { 'application/pdf': 'pdf-bytes' }),
+    ],
+  }
+
+  const result = await readClipboardContents(clipboard)
+
+  assert.equal(result.status, 'ready')
+  assert.equal(result.text, 'A caption')
+  assert.deepEqual(
+    result.files.map(file => [file.name, file.type]),
+    [
+      ['clipboard-image.png', 'image/png'],
+      ['clipboard-file-2.pdf', 'application/pdf'],
+    ],
+  )
+})
+
+test('explicit clipboard read falls back to text-only browser support', async () => {
+  const result = await readClipboardContents({ readText: async () => 'plain text' })
+  assert.deepEqual(result, { status: 'ready', files: [], text: 'plain text' })
+})
+
+test('explicit clipboard read reports permission and empty outcomes', async () => {
+  const denied = new Error('blocked')
+  denied.name = 'NotAllowedError'
+  assert.deepEqual(
+    await readClipboardContents({ read: async () => { throw denied } }),
+    { status: 'denied', files: [], text: '' },
+  )
+  assert.deepEqual(
+    await readClipboardContents({ read: async () => [] }),
+    { status: 'empty', files: [], text: '' },
+  )
+})
+
+test('clipboard text replaces the current selection and returns its next caret', () => {
+  assert.deepEqual(
+    insertClipboardText('hello world', 'Möbius', 6, 11),
+    { value: 'hello Möbius', caret: 12 },
+  )
+  assert.deepEqual(
+    insertClipboardText('draft', '!', undefined, undefined),
+    { value: 'draft!', caret: 6 },
+  )
 })

--- a/frontend/src/components/ChatView/pasteUpload.js
+++ b/frontend/src/components/ChatView/pasteUpload.js
@@ -1,4 +1,156 @@
-// Clipboard-file extraction for chat paste uploads.
+// Normalize browser clipboard payloads into the composer's text + file model.
+
+const CLIPBOARD_MIME_EXTENSIONS = new Map([
+  ['application/json', 'json'],
+  ['application/pdf', 'pdf'],
+  ['application/zip', 'zip'],
+  ['audio/mpeg', 'mp3'],
+  ['audio/wav', 'wav'],
+  ['image/gif', 'gif'],
+  ['image/jpeg', 'jpg'],
+  ['image/png', 'png'],
+  ['image/svg+xml', 'svg'],
+  ['image/webp', 'webp'],
+  ['video/mp4', 'mp4'],
+  ['video/webm', 'webm'],
+])
+
+function normalizedMimeType(type) {
+  return String(type || '').split(';', 1)[0].trim().toLowerCase()
+}
+
+function isAttachableClipboardType(type) {
+  const mime = normalizedMimeType(type)
+  return mime.includes('/') && !mime.startsWith('text/') && !mime.startsWith('web ')
+}
+
+function clipboardFileName(type, index) {
+  const mime = normalizedMimeType(type)
+  const known = CLIPBOARD_MIME_EXTENSIONS.get(mime)
+  const subtype = mime.split('/')[1] || ''
+  const derived = subtype
+    .replace(/^x-/, '')
+    .split('+', 1)[0]
+    .replace(/[^a-z0-9]/g, '')
+    .slice(0, 12)
+  const extension = known || derived || 'bin'
+  const kind = mime.startsWith('image/') ? 'image' : 'file'
+  const suffix = index > 0 ? `-${index + 1}` : ''
+  return `clipboard-${kind}${suffix}.${extension}`
+}
+
+function clipboardBlobAsFile(blob, type, index, FileImpl = globalThis.File) {
+  if (typeof FileImpl !== 'function') return null
+  return new FileImpl(
+    [blob],
+    clipboardFileName(type || blob?.type, index),
+    { type: normalizedMimeType(type || blob?.type) || 'application/octet-stream' },
+  )
+}
+
+function htmlToPlainText(html, DOMParserImpl = globalThis.DOMParser) {
+  if (typeof DOMParserImpl !== 'function') return ''
+  const document = new DOMParserImpl().parseFromString(String(html || ''), 'text/html')
+  return document?.body?.textContent || ''
+}
+
+async function readClipboardItemText(item, types) {
+  const type = ['text/plain', 'text/uri-list', 'text/html']
+    .find(candidate => types.includes(candidate))
+  if (!type) return ''
+  const value = await (await item.getType(type)).text()
+  return type === 'text/html' ? htmlToPlainText(value) : value
+}
+
+function clipboardFailureStatus(error) {
+  return ['NotAllowedError', 'SecurityError'].includes(error?.name)
+    ? 'denied'
+    : 'failed'
+}
+
+/** Read every clipboard item the browser exposes, choosing one semantic
+ * representation per item: a binary format becomes an attachment; otherwise
+ * its plain-text (or text-equivalent) representation becomes composer text.
+ * Known browser limitations are explicit outcomes, not thrown control flow. */
+export async function readClipboardContents(
+  clipboard = globalThis.navigator?.clipboard,
+  FileImpl = globalThis.File,
+) {
+  if (!clipboard) return { status: 'unsupported', files: [], text: '' }
+
+  if (typeof clipboard.read !== 'function') {
+    if (typeof clipboard.readText !== 'function') {
+      return { status: 'unsupported', files: [], text: '' }
+    }
+    try {
+      const text = await clipboard.readText()
+      return text
+        ? { status: 'ready', files: [], text }
+        : { status: 'empty', files: [], text: '' }
+    } catch (error) {
+      return { status: clipboardFailureStatus(error), files: [], text: '' }
+    }
+  }
+
+  let items
+  try {
+    items = await clipboard.read()
+  } catch (error) {
+    return { status: clipboardFailureStatus(error), files: [], text: '' }
+  }
+
+  const files = []
+  const textParts = []
+  let itemReadFailed = false
+  for (const item of items || []) {
+    const types = Array.from(item?.types || []).map(normalizedMimeType)
+    const attachmentType = types.find(type => type.startsWith('image/'))
+      || types.find(isAttachableClipboardType)
+    try {
+      if (attachmentType) {
+        const blob = await item.getType(attachmentType)
+        const file = clipboardBlobAsFile(blob, attachmentType, files.length, FileImpl)
+        if (file) files.push(file)
+        continue
+      }
+      const text = await readClipboardItemText(item, types)
+      if (text) textParts.push(text)
+    } catch {
+      itemReadFailed = true
+    }
+  }
+
+  let text = textParts.join('\n')
+  // Some browsers implement rich reads but omit a usable type for otherwise
+  // ordinary text. Their narrower readText() path is still worth trying.
+  if (files.length === 0 && !text && typeof clipboard.readText === 'function') {
+    try { text = await clipboard.readText() } catch {}
+  }
+
+  if (files.length > 0 || text) return { status: 'ready', files, text }
+  return {
+    status: itemReadFailed ? 'failed' : 'empty',
+    files: [],
+    text: '',
+  }
+}
+
+/** Insert clipboard text into a controlled textarea without losing the
+ * selection that was active when the composer menu opened. */
+export function insertClipboardText(value, text, selectionStart, selectionEnd) {
+  const source = String(value || '')
+  const start = Number.isInteger(selectionStart)
+    ? Math.max(0, Math.min(selectionStart, source.length))
+    : source.length
+  const end = Number.isInteger(selectionEnd)
+    ? Math.max(start, Math.min(selectionEnd, source.length))
+    : start
+  const inserted = String(text || '')
+  return {
+    value: `${source.slice(0, start)}${inserted}${source.slice(end)}`,
+    caret: start + inserted.length,
+  }
+}
 
 /** Return every real File carried by a paste event's DataTransfer.
  * `clipboardData.files` is the reliable path for screenshots; the item


### PR DESCRIPTION
## Summary
- add a **Paste from clipboard** composer action for browser-exposed text, images, and files
- insert text at the current selection and route binary clipboard content through the existing attachment flow
- report denied, empty, unsupported, and unreadable clipboard states with an **Attach files** fallback

## Testing
- `npm run test:lib` (2,313 passed)
- focused clipboard and composer-menu tests (11 passed)
- authenticated phone-sized shell smoke test covering blocked permission and successful text insertion