### PR TITLE
Pace planned-restart recovery without stalling its backlog

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -904,11 +904,14 @@ presentation, never restart-cause evidence.
 Eligibility is rechecked under the per-chat transition lock immediately before
 promotion. Provider-limit retries are staggered one at a time; an authenticated
 planned restart restores the exact set that was already concurrent, so its
-eligible batch may start together. An app-initiated restart continuation carries
-the same app id into the next durable run unless a newer owner send is already
-queued and becomes the next run's actor; provider-limit retries remain
-owner-only, and app work queued after a park is never absorbed. The provider
-still receives a synthetic user `continue`, but the durable row is tagged
+eligible chats launch in small batches. While each pass makes progress, the
+supervisor promptly drains the durable remainder without waiting for launched
+turns to finish; a no-progress pass falls back to the ordinary retry cadence.
+An app-initiated restart continuation carries the same app id into the next
+durable run unless a newer owner send is already queued and becomes the next
+run's actor; provider-limit retries remain owner-only, and app work queued after
+a park is never absorbed. The provider still receives a synthetic user
+`continue`, but the durable row is tagged
 `kind="auto_continuation"` with reason `restart` or `usage_limit`; the UI, copy
 behavior, title selection, time context, compaction, provider-switch handoff,
 chat-note summarization, and redacted chat logs treat it as a product marker
@@ -916,10 +919,11 @@ rather than owner speech.
 
 The sweep is cheap: one indexed due-row query immediately at boot, on
 `chat_run_finished`, and on a 60-second fallback. Startup captures the boot
-authorization once and threads that exact value through reconciliation and the
-pre-yield sweep, so a second ledger read cannot make the two phases disagree;
-later sweeps perform one bounded local ledger read only when due restart rows
-exist. It does not create per-chat workers or poll at a short interval. Paid
+authorization once and threads that exact value through reconciliation and
+every supervisor sweep, so a later ledger read cannot disagree with the boot.
+When a successful pass leaves a restart remainder, the same supervisor follows
+up after two seconds; a no-progress pass returns to the event/60-second cadence.
+It creates neither per-chat workers nor a permanent short poll. Paid
 provider-limit continuation (`auto_resume_on_limit`) initially defaults off;
 planned-restart continuation (`auto_resume_on_restart`) initially defaults on.
 Each chat stores both choices independently, and changing either choice seeds

--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -1434,8 +1434,25 @@ CONTINUATION_SWEEP_BATCH_SIZE = 100
 # not delay an opted-in chat after its reset, but a bad/early reset timestamp
 # also must not launch a whole parked batch in one burst.
 LIMIT_AUTO_RESUME_STAGGER_SECS = 30.0
+# Planned restarts restore work that was already concurrent, but relaunching a
+# large set in one event-loop pass can starve readiness. Pace that exact set in
+# small batches; RuntimeSupervisors drains a successful remainder promptly.
+RESTART_AUTO_RESUME_BATCH_SIZE = 2
 _next_limit_auto_resume_at = 0.0
 _RESTART_AUTHORIZATION_UNSET = object()
+
+
+@dataclass(frozen=True)
+class ContinuationSweepResult:
+  """Durable outcomes from one continuation pass.
+
+  ``restart_deferred`` means an eligible planned-restart park remains due.
+  Callers may promptly run another pass only when this pass also made progress;
+  a no-progress result falls back to the ordinary retry cadence.
+  """
+
+  resolved: tuple[str, ...] = ()
+  restart_deferred: bool = False
 
 
 def _limit_auto_resume_now() -> float:
@@ -1710,7 +1727,7 @@ async def sweep_reset_parks(
   restart_authorization: str | None | object = (
     _RESTART_AUTHORIZATION_UNSET
   ),
-) -> list[str]:
+) -> ContinuationSweepResult:
   """Notify and optionally continue due durable recovery rows.
 
   A due park is a `chat_runs` row whose
@@ -1731,9 +1748,11 @@ async def sweep_reset_parks(
       at most one starts per sweep and launches are spaced even when unrelated
       chats are live. App-attributed provider-limit runs never auto-resume.
       Planned-restart continuations reclaim the exact set that was already live
-      before the restart, preserve each run's attribution, and may resume
-      independently. A staggered enabled chat stays pending for a later tick,
-      while notify-only chats in the same due batch still resolve normally.
+      before the restart and preserve each run's attribution. A pass launches a
+      small restart batch, then the supervisor promptly drains the durable
+      remainder without waiting for those turns to finish. A staggered enabled
+      chat stays pending while notify-only chats in the same due batch still
+      resolve normally.
       App-attributed messages newly queued behind either kind of park still
       require an ordinary app-owned handoff rather than being swept into the
       synthetic continuation.
@@ -1743,8 +1762,9 @@ async def sweep_reset_parks(
   """
   log = _get_logger()
   resolved: list[str] = []
+  restart_deferred = False
   if draining:
-    return resolved
+    return ContinuationSweepResult()
   now = datetime.now(UTC).replace(tzinfo=None)
   try:
     due = (
@@ -1758,9 +1778,9 @@ async def sweep_reset_parks(
     )
   except Exception:
     log.exception("sweep_reset_parks: query failed")
-    return resolved
+    return ContinuationSweepResult()
   if not due:
-    return resolved
+    return ContinuationSweepResult()
   chat_ids = {run.chat_id for run in due}
   try:
     chats = {
@@ -1773,7 +1793,7 @@ async def sweep_reset_parks(
     }
   except Exception:
     log.exception("sweep_reset_parks: chat batch query failed")
-    return resolved
+    return ContinuationSweepResult()
   accepted_restart_nonce = restart_authorization
   if any(run.park_reason == "restart" for run in due):
     if restart_authorization is _RESTART_AUTHORIZATION_UNSET:
@@ -1832,6 +1852,7 @@ async def sweep_reset_parks(
     return auto_resume_rejection(chat, run) is None
 
   limit_resume_started = False
+  restart_resume_started = 0
   for run in due:
     chat_id = run.chat_id
     chat = chats.get(chat_id)
@@ -1847,6 +1868,12 @@ async def sweep_reset_parks(
       # One provider-limit continuation per sweep. Leave this park untouched,
       # but keep walking so a later notify-only chat is not held hostage by
       # another chat's auto-resume preference.
+      continue
+    if (
+      restart_auto_resume
+      and restart_resume_started >= RESTART_AUTO_RESUME_BATCH_SIZE
+    ):
+      restart_deferred = True
       continue
     if auto_resume:
       try:
@@ -1913,9 +1940,12 @@ async def sweep_reset_parks(
       )
       if resume_started:
         resolved.append(chat_id)
-        if not restart_auto_resume:
+        if restart_auto_resume:
+          restart_resume_started += 1
+        else:
           limit_resume_started = True
       elif restart_auto_resume:
+        restart_deferred = True
         log.warning(
           "restart continuation remained pending after scheduling attempt "
           "chat_id=%s run_token=%s; next event/fallback sweep will retry",
@@ -1987,7 +2017,7 @@ async def sweep_reset_parks(
       "continuation sweep resolved %d park(s): %s",
       len(resolved), ", ".join(resolved),
     )
-  return resolved
+  return ContinuationSweepResult(tuple(resolved), restart_deferred)
 
 
 async def _clear_pending(chat_id: str) -> list[str]:

--- a/backend/app/runtime_supervisors.py
+++ b/backend/app/runtime_supervisors.py
@@ -18,6 +18,9 @@ from typing import Protocol
 from app.database import SessionLocal
 
 
+RESTART_BACKLOG_DRAIN_INTERVAL_SECS = 2.0
+
+
 class RuntimeSettings(Protocol):
   data_dir: str
 
@@ -69,6 +72,7 @@ class RuntimeSupervisors:
   async def _start_chat_supervisors(self) -> None:
     from app.broadcast import get_system_broadcast
     from app.chat import (
+      ContinuationSweepResult,
       sweep_idle_pending_chats,
       sweep_reset_parks,
       sweep_wedged_runs,
@@ -86,44 +90,49 @@ class RuntimeSupervisors:
         except Exception as exc:
           self.log.error("wedged-marker sweep failed: %s", exc, exc_info=True)
 
-    async def sweep_reset_parks_once(*, startup: bool = False):
+    async def sweep_reset_parks_once():
       try:
         with SessionLocal() as db:
-          if startup:
-            return await sweep_reset_parks(
-              db, restart_authorization=self.restart_authorization,
-            )
-          return await sweep_reset_parks(db)
+          return await sweep_reset_parks(
+            db, restart_authorization=self.restart_authorization,
+          )
       except asyncio.CancelledError:
         raise
       except Exception as exc:
         self.log.error("reset-park sweep failed: %s", exc, exc_info=True)
-        return []
+        return ContinuationSweepResult()
 
-    startup_continuations = await sweep_reset_parks_once(startup=True)
+    startup_sweep = await sweep_reset_parks_once()
     if self.restart_authorization:
       self.log.info(
         "startup restart continuation pass authorized=%d fallback_recovered=%d "
         "started_or_resolved=%d",
         1,
         len(self.restart_fallback_chats),
-        len(startup_continuations),
+        len(startup_sweep.resolved),
       )
 
     async def reset_park_loop():
       system_broadcast = get_system_broadcast()
       events = system_broadcast.subscribe()
+      last_sweep = startup_sweep
       try:
         while True:
-          try:
-            async with asyncio.timeout(60):
-              while True:
-                event = await events.get()
-                if event and event.get("type") == "chat_run_finished":
-                  break
-          except asyncio.TimeoutError:
-            pass
-          await sweep_reset_parks_once()
+          fast_followup = bool(
+            last_sweep.restart_deferred and last_sweep.resolved
+          )
+          if fast_followup:
+            await asyncio.sleep(RESTART_BACKLOG_DRAIN_INTERVAL_SECS)
+          else:
+            try:
+              async with asyncio.timeout(60):
+                while True:
+                  event = await events.get()
+                  if event and event.get("type") == "chat_run_finished":
+                    break
+            except asyncio.TimeoutError:
+              pass
+          last_sweep = await sweep_reset_parks_once()
       finally:
         system_broadcast.unsubscribe(events)
 

--- a/backend/tests/test_drain_for_restart.py
+++ b/backend/tests/test_drain_for_restart.py
@@ -512,14 +512,15 @@ def test_five_chat_restart_recovers_timeouts_and_finalize_failure(
   monkeypatch.setattr(chat_mod, "_auto_resume_chat", _record_resume)
   db = SessionLocal()
   try:
-    resumed = asyncio.run(chat_mod.sweep_reset_parks(
+    sweep = asyncio.run(chat_mod.sweep_reset_parks(
       db, restart_authorization=nonce,
     ))
   finally:
     db.close()
 
-  assert set(resumed) == set(all_ids)
-  assert {item[0] for item in scheduled} == set(all_ids)
+  assert len(sweep.resolved) == chat_mod.RESTART_AUTO_RESUME_BATCH_SIZE
+  assert sweep.restart_deferred is True
+  assert {item[0] for item in scheduled} == set(sweep.resolved)
   assert all(item[2] == nonce for item in scheduled)
 
 

--- a/backend/tests/test_limit_park.py
+++ b/backend/tests/test_limit_park.py
@@ -16,9 +16,10 @@ Locks in the contracts of the limit-park feature:
       while draining, and resolves deleted chats silently.
   (e) Auto-resume is policy-controlled (off = notify only). Provider-limit
       retries ignore unrelated live work and launch with a short stagger,
-      while an accepted planned restart resumes the exact previously-live set
-      together. Each resumed turn combines its preserved queue + a "continue"
-      into one continuation.
+      while an accepted planned restart relaunches the exact previously-live
+      set in prompt batches that do not wait for earlier turns to finish. Each
+      resumed turn combines its preserved queue + a "continue" into one
+      continuation.
   (f) The parks are observable: /api/debug/status lists parked runs.
   (g) A planned restart reuses the same exact-run state with a due-now time;
       crashes, unanswered questions, and app-owned work stay manual.
@@ -568,12 +569,16 @@ def _due_park(
             initiated_by_app_id=initiated_by_app_id)
 
 
-def _run_sweep():
+def _run_sweep_result():
   db = SessionLocal()
   try:
     return asyncio.run(chat_mod.sweep_reset_parks(db))
   finally:
     db.close()
+
+
+def _run_sweep():
+  return list(_run_sweep_result().resolved)
 
 
 def test_sweep_notifies_once_and_resolves(owner_token, monkeypatch):
@@ -973,14 +978,14 @@ def test_startup_sweep_uses_one_captured_restart_authorization(
 
   db = SessionLocal()
   try:
-    resolved = asyncio.run(chat_mod.sweep_reset_parks(
+    result = asyncio.run(chat_mod.sweep_reset_parks(
       db, restart_authorization=nonce,
     ))
   finally:
     db.close()
 
   try:
-    assert resolved == [cid]
+    assert list(result.resolved) == [cid]
     assert len(scheduled) == 1
   finally:
     chat_mod.discard_starting(cid)
@@ -1419,10 +1424,10 @@ def test_sweep_starts_only_one_of_two_opted_chats(owner_token, monkeypatch):
       chat_mod.discard_starting(cid)
 
 
-def test_sweep_restarts_every_opted_chat_in_the_accepted_batch(
+def test_sweep_paces_restart_batch_without_waiting_for_live_turns(
   owner_token, monkeypatch,
 ):
-  """A restart restores the exact set that was already concurrent."""
+  """A durable remainder advances even while prior recoveries stay live."""
   del owner_token
   nonce = "restart-nonce-batch"
   monkeypatch.setattr(
@@ -1449,11 +1454,16 @@ def test_sweep_restarts_every_opted_chat_in_the_accepted_batch(
     )
 
   try:
-    assert set(_run_sweep()) == set(chat_ids)
+    first = _run_sweep_result()
+    assert len(first.resolved) == chat_mod.RESTART_AUTO_RESUME_BATCH_SIZE
+    assert first.restart_deferred is True
+
+    # Do not settle/discard either launched turn. The next pass is paced by
+    # launches, not by a global live-chat ceiling.
+    second = _run_sweep_result()
+    assert len(second.resolved) == 1
+    assert second.restart_deferred is False
     assert {item["chat_id"] for item in scheduled} == set(chat_ids)
-    assert [kind for kind, _ in events[:len(chat_ids)]] == [
-      "schedule", "schedule", "schedule",
-    ]
     assert {chat_id for kind, chat_id in events if kind == "notify"} == set(
       chat_ids
     )

--- a/backend/tests/test_runtime_supervisors.py
+++ b/backend/tests/test_runtime_supervisors.py
@@ -17,6 +17,14 @@ def _supervisors():
   )
 
 
+class _EmptySession:
+  def __enter__(self):
+    return object()
+
+  def __exit__(self, *_args):
+    return False
+
+
 @pytest.mark.asyncio
 async def test_stop_cancels_and_observes_every_named_task():
   supervisors = _supervisors()
@@ -72,18 +80,11 @@ async def test_reset_park_subscription_exists_only_while_its_task_runs(
 
   broadcast = SystemBroadcast()
 
-  class EmptySession:
-    def __enter__(self):
-      return object()
-
-    def __exit__(self, *_args):
-      return False
-
   async def no_chats(*_args, **_kwargs):
-    return []
+    return chat_module.ContinuationSweepResult()
 
   monkeypatch.setattr(broadcast_module, "get_system_broadcast", lambda: broadcast)
-  monkeypatch.setattr(supervisors_module, "SessionLocal", EmptySession)
+  monkeypatch.setattr(supervisors_module, "SessionLocal", _EmptySession)
   monkeypatch.setattr(chat_module, "sweep_reset_parks", no_chats)
 
   supervisors = _supervisors()
@@ -98,3 +99,40 @@ async def test_reset_park_subscription_exists_only_while_its_task_runs(
 
   await supervisors.stop()
   assert broadcast.subscribers == []
+
+
+@pytest.mark.asyncio
+async def test_restart_backlog_gets_prompt_followup_without_turn_completion(
+  monkeypatch,
+):
+  import app.broadcast as broadcast_module
+  import app.chat as chat_module
+  import app.runtime_supervisors as supervisors_module
+
+  broadcast = SystemBroadcast()
+
+  sweep_authorizations = []
+
+  async def paced_sweep(*_args, **_kwargs):
+    sweep_authorizations.append(_kwargs.get("restart_authorization"))
+    if len(sweep_authorizations) == 1:
+      return chat_module.ContinuationSweepResult(
+        ("first", "second"), restart_deferred=True,
+      )
+    return chat_module.ContinuationSweepResult(("third",))
+
+  monkeypatch.setattr(broadcast_module, "get_system_broadcast", lambda: broadcast)
+  monkeypatch.setattr(supervisors_module, "SessionLocal", _EmptySession)
+  monkeypatch.setattr(supervisors_module, "RESTART_BACKLOG_DRAIN_INTERVAL_SECS", 0)
+  monkeypatch.setattr(chat_module, "sweep_reset_parks", paced_sweep)
+
+  supervisors = _supervisors()
+  supervisors.restart_authorization = "accepted-restart"
+  await supervisors._start_chat_supervisors()
+  for _ in range(10):
+    if len(sweep_authorizations) >= 2:
+      break
+    await asyncio.sleep(0)
+
+  assert sweep_authorizations == ["accepted-restart", "accepted-restart"]
+  await supervisors.stop()


### PR DESCRIPTION
## Summary
- start authenticated planned-restart continuations in small per-sweep batches
- promptly drain the durable remainder while each pass makes progress
- return to the existing event/60-second cadence after a no-progress pass
- preserve the nonce, policy, latest-run, unanswered-question, and queued-app-work safeguards

## Why

[#540](https://github.com/mobius-os/mobius/pull/540) correctly removed the global two-live-chat admission gate that could leave eligible chats parked indefinitely. Starting every eligible continuation in one event-loop pass, however, can recreate the startup pressure that the gate was intended to prevent.

This follow-up paces launches rather than limiting live chats. Each pass starts two planned-restart continuations, then follows up after two seconds when it both made progress and found more eligible restart work. It never waits for those recovered turns to finish, so long-running chats cannot hold the remainder hostage.

## Design

The existing continuation sweep returns one explicit result to the existing runtime supervisor. There are no per-chat workers, new persisted scheduling flags, new settings, compatibility paths, or permanent short poll. Provider-limit recovery remains separately staggered, and every supervisor pass reuses the boot-captured restart authorization.

## Testing

- restart/recovery-focused backend suites: 100 passed
- hermetic fast backend gate: 69 passed
- complete backend suite: 3,583 passed, 1 skipped
- Python compilation and diff checks passed
- hosted CI remains authoritative for the protected merge gate