### PR TITLE
Make chat tail reservation respond to keyboard height

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -553,7 +553,7 @@ automatically armed by installing Möbius.
 
 ## Chat scroll + steer contract
 
-**Owner-authoritative contract — v1.16 (2026-08-02).** This section is the
+**Owner-authoritative contract — v1.17 (2026-08-03).** This section is the
 canonical source of truth for how a chat scrolls and steers. When implementation,
 comments, and this contract disagree, the implementation/comments are the bug:
 fix behavior to match this contract. If a real case is unspecified or the desired
@@ -571,19 +571,24 @@ and attaches their rule ids to new diagnostic chats. The Playwright lock-in spec
   (`PIN_USER_MSG` or `ANCHOR_AT`, staying at a pinned prompt or frozen reading
   position). Auto-scroll engages only through (a) the gesture-gated scroll handler
   after the user manually reaches or explicitly swipes toward the physical bottom,
-  or (b) the live-send pin handoff when the streaming reply has consumed its exact
-  reserved room. Only a send may create `PIN_USER_MSG`. Reservation does not create
+  or (b) the live-send pin handoff when its active reservation reaches zero. Only
+  a send may create `PIN_USER_MSG`. Reservation does not create
   a second kind of bottom: when `FOLLOW_BOTTOM` is active, it follows the physical
   tail including any remaining room. Real output first consumes that room without
   advancing the tail; after the room reaches zero, the same tail advances with the
   stream. A viewport/keyboard change, foreground return, mount, or chat restoration
-  must never create auto-scroll.
+  must never create follow intent; a resize may only complete an already-armed
+  live-send handoff when its responsive reservation reaches zero.
 - **R1 — Stable latest-turn reservation.** Dynamic bottom spacer derives from the
   latest user row and the real tail geometry, independent of whether that row has
   already entered the viewport. It reserves exactly enough room for that row to
-  reach the viewport top and shrinks as reply, tool, image, or other content fills
-  the deficit. The full range must exist before a downward gesture approaches the
-  final turn: crossing the latest-user viewport boundary must never extend
+  reach the active scroll viewport's top and shrinks as reply, tool, image, or
+  other content fills the deficit. When a mobile keyboard reduces the visible
+  scroll box, hidden blank room is removed from the spacer first; after it reaches
+  zero, only content that no longer fits moves upward. Closing the keyboard
+  restores the larger viewport's exact deficit. The full range for the visible
+  viewport must exist before a downward gesture approaches the final turn:
+  crossing the latest-user viewport boundary must never extend
   `scrollHeight` after momentum settles. The remaining room survives turn
   completion when the reply is short. Expanding content consumes it; collapsing
   the same content restores the exact deficit. Scroll mode does not own the
@@ -615,11 +620,13 @@ and attaches their rule ids to new diagnostic chats. The Playwright lock-in spec
   frames, and the prompt stays pinned; a one-frame terminal check cannot disarm
   just before final buffered text fills the reservation. Later idle layout changes
   cannot create follow. A non-pinning send preserves the exact reading anchor.
-  An armed or settled `PIN_USER_MSG` survives the complete mobile-keyboard
-  open/close cycle: viewport geometry cannot decide that a reply filled its
-  reservation or replace the pin with a different bottom alignment. A retired or
-  saved pin restores only as an ordinary `ANCHOR_AT`; pin ownership is never
-  reconstructed by layout, lifecycle restoration, or a reader gesture.
+  A settled `PIN_USER_MSG` survives the complete mobile-keyboard open/close
+  cycle. An armed live pin keeps the sent row fixed while responsive reservation
+  remains; if the smaller viewport reduces that reservation to zero, the existing
+  filled-reservation handoff enters `FOLLOW_BOTTOM` so covered live output stays
+  visible. A retired or saved pin restores only as an ordinary `ANCHOR_AT`; pin
+  ownership is never reconstructed by layout, lifecycle restoration, or a reader
+  gesture.
   Terminal promotion makes this decision against the committed settled DOM,
   before paint, so a final browser clamp cannot race the pin or its exact
   filled-reservation handoff.
@@ -711,14 +718,17 @@ and attaches their rule ids to new diagnostic chats. The Playwright lock-in spec
   through the scroll controller instead of calling `scrollIntoView`, because
   viewport intersection alone cannot detect that the absolutely-positioned
   composer is covering the target.
-- **R5b — One keyboard geometry signal; mode-preserving resize.** Shell alone
+- **R5b — One keyboard geometry signal; reservation-responsive resize.** Shell alone
   reconciles a browser's visual viewport into the visible shell frame. The chat
   does not race Shell with a second direct visual-viewport listener: its own
   scroll-box `ResizeObserver` is the sole downstream signal that keyboard layout
-  has actually landed. A resize never derives a new scroll mode from intermediate
-  geometry: it reapplies the mode that already owns the chat. `PIN_USER_MSG` keeps
-  the sent row at its pinned offset, `ANCHOR_AT` keeps the same row offset, and
-  `FOLLOW_BOTTOM` follows the resized physical tail. The R6 question-submission
+  has actually landed. A resize recalculates the latest-turn spacer from the
+  active scroll-box height, then reapplies the mode that already owns the chat.
+  `PIN_USER_MSG` keeps the sent row at its pinned offset while reservation remains,
+  `ANCHOR_AT` keeps the same row offset, and `FOLLOW_BOTTOM` follows the resized
+  physical tail without moving through blank room. The only ordinary mode change
+  is R3's existing armed-pin handoff when responsive reservation reaches zero. The
+  R6 question-submission
   release and focused native-caret rebase remain the two explicit editing rules,
   not a general keyboard heuristic. Open/close cycles therefore repeat the same
   idempotent operation every time. Browser clamps and controller writes may emit
@@ -776,9 +786,9 @@ path means routing it through the same entries rather than inventing another rul
 | Short reply settles before consuming the reservation | armed pin hold | settled pin hold | Keep prompt fixed; retire automatic handoff |
 | Other layout grows/collapses while latest user is visible | any hold | same hold | Consume/restore exact R1 deficit |
 | Latest user leaves the viewport | any | same reader mode | Collapse spacer to zero |
-| Viewport/keyboard changes | armed `PIN_USER_MSG` | same `PIN_USER_MSG` | Reapply pin after resize; never infer reservation fill from keyboard geometry |
+| Viewport/keyboard changes | armed `PIN_USER_MSG` | same pin while responsive room remains; `FOLLOW_BOTTOM` if it reaches zero | Shrink blank reservation first; reapply the pin or perform R3's filled-reservation handoff |
 | Viewport/keyboard changes | settled `PIN_USER_MSG` | same `PIN_USER_MSG` | Reapply the same pin; geometry never reclassifies it |
-| Viewport/keyboard changes | follow or anchor hold | same mode | Reapply follow to the physical tail or the exact anchor; never create or retire follow |
+| Viewport/keyboard changes | follow or anchor hold | same mode | Resize reservation to the visible scroll box, then reapply the physical tail or exact anchor; never create or retire follow |
 | Chat exits/backgrounds/returns | any | `ANCHOR_AT` | Restore exact saved anchor |
 | In-process question is answered | any | transient `ANCHOR_AT` over the prior mode; same active assistant row | Hold exact visible anchor through same-viewport card reflow and resumed output |
 | Viewport/keyboard changes after question submission | transient question anchor | pre-submit unanswered-card mode | Apply ordinary viewport behavior; answering adds no extra movement |
@@ -804,7 +814,7 @@ Controller structure is part of the contract, not an implementation detail:
 - `useScrollMode` is the sole writer of `.spacer-dynamic` height and the
   composer-clearance CSS geometry. Those indirect writes and every `writeMode`
   call share R5's reader-generation commit gate. Spacer height is
-  derived from the latest user row and exact tail deficit;
+  derived from the latest user row, active scroll-box height, and exact tail deficit;
   disclosure helpers and renderers may preserve an on-screen anchor but may never
   prime, enlarge, or unwind spacer themselves.
 - The gesture-gated `scroll` event reads physical-bottom geometry directly.

--- a/frontend/src/components/ChatView/__tests__/chatContract.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatContract.test.js
@@ -26,7 +26,7 @@ const userEl = offsetTop => ({ offsetTop })
 
 // A clean pinned frame: pin target 996, scrollTop sits there, and the spacer
 // reserved EXACTLY enough to reach it — no extra cushion (PIN_BOTTOM_ROOM 0).
-// fullViewH == clientHeight == 700, listHeight 1040, so spacer =
+// clientHeight == 700, listHeight 1040, so spacer =
 // max(0, 700 + 996 - 1040) = 656 and scrollHeight = 1040 + 656 = 1696.
 // maxScrollTop = 1696 - 700 = 996 == pinTarget: the pin rests flush at the
 // scroll ceiling, with no reservable blank below.
@@ -34,7 +34,6 @@ const pinnedEnv = {
   scrollEl: scrollEl({ scrollTop: 996, scrollHeight: 1696, clientHeight: 700 }),
   listEl: listEl(1040),
   lastUserMsgEl: userEl(1000),
-  fullViewH: 700,
 }
 
 test('pin registry summary matches owner-authoritative R2 geometry', () => {
@@ -72,7 +71,7 @@ test('owner contract freezes question answers without locking keyboard movement'
     new URL('../../../../../ARCHITECTURE.md', import.meta.url),
     'utf8',
   )
-  assert.match(architecture, /Owner-authoritative contract — v1\.16 \(2026-08-02\)/)
+  assert.match(architecture, /Owner-authoritative contract — v1\.17 \(2026-08-03\)/)
   assert.match(
     architecture,
     /In-process question is answered \| any \| transient `ANCHOR_AT` over the prior mode; same active assistant row/,
@@ -95,7 +94,7 @@ test('owner contract freezes question answers without locking keyboard movement'
   )
   assert.match(
     architecture,
-    /One keyboard geometry signal; mode-preserving resize/,
+    /One keyboard geometry signal; reservation-responsive resize/,
     'keyboard layout must flow from Shell into the actual chat scroll box once',
   )
 })
@@ -127,7 +126,6 @@ test('snapshotChatUX derives the geometry fields from a clean pinned frame', () 
   assert.equal(s.pinGap, 4) // lastUserTop - scrollTop == PIN_OFFSET
   assert.equal(s.distanceToBottom, 0) // pin rests flush at the scroll ceiling
   assert.equal(s.spacerReachable, true)
-  assert.equal(s.fullViewH, 700)
 })
 
 test('snapshotChatUX is null-tolerant: missing user message yields nulls, no throw', () => {
@@ -135,7 +133,6 @@ test('snapshotChatUX is null-tolerant: missing user message yields nulls, no thr
     scrollEl: scrollEl({ scrollTop: 100, scrollHeight: 1200, clientHeight: 700 }),
     listEl: listEl(1040),
     lastUserMsgEl: null,
-    fullViewH: 700,
   })
   assert.equal(s.lastUserTop, null)
   assert.equal(s.pinGap, null)
@@ -271,16 +268,14 @@ test('cushionPresent passes when the spacer reaches the pin (cushion 0)', () => 
   assert.equal(r.measured, PIN_BOTTOM_ROOM) // exactly 0: pin exactly reachable
 })
 
-test('cushionPresent fails on the R5 bug: an undersized spacer leaves no keyboard-closed room', () => {
-  // The hook's stale-small fullViewH (400, the keyboard-open height) sized the
-  // spacer: max(0, 400 + 996 - 1040) = 356, so scrollHeight = 1396. The
-  // SNAPSHOT carries the true full view height (700 — clientHeight has grown
-  // back), so the cushion reads (1396 - 700) - 996 = -300: pin stranded.
+test('cushionPresent fails when a grown viewport still has the smaller spacer', () => {
+  // The keyboard-open spacer was 356px, then clientHeight grew to 700 without
+  // a recompute: scrollHeight 1396 leaves maxScrollTop 696, so the 996px pin
+  // target is unreachable.
   const buggy = {
     scrollEl: scrollEl({ scrollTop: 696, scrollHeight: 1396, clientHeight: 700 }),
     listEl: listEl(1040),
     lastUserMsgEl: userEl(1000),
-    fullViewH: 700,
   }
   const snap = snapshotChatUX(buggy)
   assert.equal(snap.spacerReachable, false) // pin target unreachable
@@ -289,21 +284,17 @@ test('cushionPresent fails on the R5 bug: an undersized spacer leaves no keyboar
   assert.ok(r.measured < PIN_BOTTOM_ROOM)
 })
 
-test('cushionPresent fails on a keyboard-open snapshot with an undersized spacer', () => {
-  // Keyboard open: clientHeight shrank to 400; the full viewport is 700 and
-  // the spacer only produced scrollHeight 1396. clientHeight-based math would
-  // read (1396 - 400) - 996 = 0 — a false green. Keyboard-closed terms
-  // (fullViewH) read (1396 - 700) - 996 = -300: no room once the keyboard
-  // closes.
+test('cushionPresent accepts the smaller exact spacer while the keyboard is open', () => {
+  // Keyboard open: clientHeight is 400 and the responsive spacer makes
+  // scrollHeight 1396. maxScrollTop remains exactly the 996px pin target.
   const snap = snapshotChatUX({
     scrollEl: scrollEl({ scrollTop: 696, scrollHeight: 1396, clientHeight: 400 }),
     listEl: listEl(1040),
     lastUserMsgEl: userEl(1000),
-    fullViewH: 700,
   })
   const r = cushionPresent(snap)
-  assert.equal(r.ok, false)
-  assert.equal(r.measured, -300)
+  assert.equal(r.ok, true)
+  assert.equal(r.measured, 0)
 })
 
 test('cushionPresent is indeterminate when geometry is missing', () => {

--- a/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
+++ b/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
@@ -1273,7 +1273,6 @@ test('spacer reservation belongs to the latest user row in any mode', () => {
       scrollEl,
       listEl,
       lastUserMsgEl,
-      600,
       { kind: 'PIN_USER_MSG', cid: 'c-1' },
     ),
     396,
@@ -1283,7 +1282,6 @@ test('spacer reservation belongs to the latest user row in any mode', () => {
       scrollEl,
       listEl,
       lastUserMsgEl,
-      600,
       { kind: 'ANCHOR_AT', key: 'a-1', offset: 0 },
     ),
     396,
@@ -1294,7 +1292,6 @@ test('spacer reservation belongs to the latest user row in any mode', () => {
       scrollEl,
       listEl,
       lastUserMsgEl,
-      600,
       { kind: 'PIN_USER_MSG', cid: 'different-row' },
     ),
     396,
@@ -1317,7 +1314,6 @@ test('off-screen latest user pre-reserves one stable downward scroll range', () 
       scrollEl,
       listEl,
       latestUserMsgEl,
-      600,
       { kind: 'ANCHOR_AT', key: 'older-user', offset: 0 },
     ),
     96,
@@ -1337,11 +1333,11 @@ test('crossing the latest-user viewport boundary cannot create a second-stage bo
 
   scrollEl.scrollTop = 0
   const beforeApproach = _computeSpacerH(
-    scrollEl, listEl, latestUserMsgEl, 600, mode,
+    scrollEl, listEl, latestUserMsgEl, mode,
   )
   scrollEl.scrollTop = 700
   const afterLatestUserAppears = _computeSpacerH(
-    scrollEl, listEl, latestUserMsgEl, 600, mode,
+    scrollEl, listEl, latestUserMsgEl, mode,
   )
 
   assert.equal(beforeApproach, 96)
@@ -1369,7 +1365,6 @@ test('an older applied anchor does not make tail scrollHeight grow later', () =>
       scrollEl,
       { offsetHeight: 1000 },
       latestUserMsgEl,
-      600,
       { kind: 'ANCHOR_AT', key: 'older-anchor', offset: 0 },
     ),
     296,
@@ -1397,7 +1392,6 @@ test('applied anchor may reserve before current geometry reaches its visible lat
       scrollEl,
       { offsetHeight: 900 },
       latestUserMsgEl,
-      600,
       { kind: 'ANCHOR_AT', key: 'latest-anchor', offset: 100 },
     ),
     396,
@@ -1405,24 +1399,56 @@ test('applied anchor may reserve before current geometry reaches its visible lat
   )
 })
 
-test('keyboard-closed height keeps permanent tail reservation stable', () => {
-  const scrollEl = makeSpacerScrollEl({ clientHeight: 400 })
+test('keyboard height shrinks blank reservation before moving followed content', () => {
+  const scrollEl = makeSpacerScrollEl({ clientHeight: 800 })
   const latestUserMsgEl = {
     offsetTop: 500,
     offsetHeight: 80,
     dataset: { cid: 'latest' },
   }
+  const listEl = { offsetHeight: 700 }
+  const mode = { kind: 'FOLLOW_BOTTOM' }
+  const closedSpacer = _computeSpacerH(
+    scrollEl, listEl, latestUserMsgEl, mode,
+  )
+  scrollEl.clientHeight = 500
+  const openSpacer = _computeSpacerH(
+    scrollEl, listEl, latestUserMsgEl, mode,
+  )
 
+  assert.equal(closedSpacer, 596)
+  assert.equal(openSpacer, 296)
   assert.equal(
-    _computeSpacerH(
-      scrollEl,
-      { offsetHeight: 700 },
-      latestUserMsgEl,
-      800,
-      { kind: 'INITIAL' },
-    ),
-    596,
-    'the full-height reservation exists before the hidden row is approached',
+    listEl.offsetHeight + closedSpacer - 800,
+    listEl.offsetHeight + openSpacer - 500,
+    'removing 300px of visible height first removes 300px of blank spacer',
+  )
+})
+
+test('keyboard overflow lifts only content that no longer fits', () => {
+  const scrollEl = makeSpacerScrollEl({ clientHeight: 800 })
+  const latestUserMsgEl = {
+    offsetTop: 500,
+    offsetHeight: 80,
+    dataset: { cid: 'latest' },
+  }
+  const listEl = { offsetHeight: 1050 }
+  const mode = { kind: 'FOLLOW_BOTTOM' }
+  const closedSpacer = _computeSpacerH(
+    scrollEl, listEl, latestUserMsgEl, mode,
+  )
+  scrollEl.clientHeight = 500
+  const openSpacer = _computeSpacerH(
+    scrollEl, listEl, latestUserMsgEl, mode,
+  )
+
+  assert.equal(closedSpacer, 246)
+  assert.equal(openSpacer, 0)
+  assert.equal(
+    (listEl.offsetHeight + openSpacer - 500)
+      - (listEl.offsetHeight + closedSpacer - 800),
+    54,
+    'after reservation reaches zero, only the remaining overflow moves the tail',
   )
 })
 
@@ -1436,13 +1462,13 @@ test('tool expansion consumes reservation and collapse restores the exact defici
   const mode = { kind: 'ANCHOR_AT', key: 'latest-user', offset: 4 }
 
   const collapsed = _computeSpacerH(
-    scrollEl, { offsetHeight: 500 }, lastUserMsgEl, 915, mode,
+    scrollEl, { offsetHeight: 500 }, lastUserMsgEl, mode,
   )
   const expanded = _computeSpacerH(
-    scrollEl, { offsetHeight: 1300 }, lastUserMsgEl, 915, mode,
+    scrollEl, { offsetHeight: 1300 }, lastUserMsgEl, mode,
   )
   const collapsedAgain = _computeSpacerH(
-    scrollEl, { offsetHeight: 500 }, lastUserMsgEl, 915, mode,
+    scrollEl, { offsetHeight: 500 }, lastUserMsgEl, mode,
   )
 
   assert.equal(collapsed, 611)
@@ -1454,7 +1480,7 @@ test('spacer reservation returns zero before there is a user message', () => {
   const scrollEl = makeSpacerScrollEl({ clientHeight: 600 })
   const listEl = { offsetHeight: 200 }
 
-  assert.equal(_computeSpacerH(scrollEl, listEl, null, 600), 0)
+  assert.equal(_computeSpacerH(scrollEl, listEl, null), 0)
 })
 
 test('ordinary question-answer anchor keeps the stable latest-turn tail range', () => {
@@ -1472,7 +1498,6 @@ test('ordinary question-answer anchor keeps the stable latest-turn tail range', 
       scrollEl,
       { offsetHeight: 1500 },
       { offsetTop: 1100, offsetHeight: 80, dataset: { cid: 'c-1' } },
-      960,
       mode,
     ),
     556,
@@ -1503,11 +1528,12 @@ test('question submission reserves the exact room that keeps its anchor reachabl
   }
 
   assert.equal(
-    _computeSpacerH(scrollEl, listEl, latestUser, 600, mode),
+    _computeSpacerH(scrollEl, listEl, latestUser, mode),
     340,
   )
+  scrollEl.clientHeight = 700
   assert.equal(
-    _computeSpacerH(scrollEl, listEl, latestUser, 700, mode),
+    _computeSpacerH(scrollEl, listEl, latestUser, mode),
     440,
     'the same-viewport overlay keeps the exact anchor until resize releases it',
   )
@@ -1537,16 +1563,16 @@ test('answered question uses the unanswered card spacer when the keyboard closes
   }
 
   assert.equal(
-    _computeSpacerH(scrollEl, listEl, latestUser, 700, heldMode),
+    _computeSpacerH(scrollEl, listEl, latestUser, heldMode),
     440,
     'without release the answered card would remain locked',
   )
   const released = releaseQuestionSubmissionForViewport(heldMode, 700)
   const answeredSpacer = _computeSpacerH(
-    scrollEl, listEl, latestUser, 700, released,
+    scrollEl, listEl, latestUser, released,
   )
   const unansweredSpacer = _computeSpacerH(
-    scrollEl, listEl, latestUser, 700, baseMode,
+    scrollEl, listEl, latestUser, baseMode,
   )
   assert.equal(answeredSpacer, unansweredSpacer)
   assert.equal(answeredSpacer, 396)
@@ -1574,7 +1600,6 @@ test('an off-content legacy anchor clamps to content then reserves for its visib
       scrollEl,
       { offsetHeight: 700 },
       { offsetTop: 100, offsetHeight: 80, dataset: { cid: 'c-1' } },
-      700,
       mode,
     ),
     96,
@@ -1601,24 +1626,15 @@ test('queued tray does not shorten spacer reservation', () => {
       scrollEl,
       listEl,
       lastUserMsgEl,
-      600,
       { kind: 'PIN_USER_MSG', cid: 'c-1' },
     ),
     396,
   )
 })
 
-// R5 regression contract: a send while at the bottom must pin the new user
-// message to the TOP, which requires the dynamic spacer to reserve enough
-// bottom room that the pin target is actually REACHABLE (maxScrollTop >=
-// pinTarget). By default it reserves EXACTLY that — no extra cushion — so
-// maxScrollTop == pinTarget and the row rests flush at the top. When
-// fullViewH is stale-SMALL (the keyboard-open height used after the keyboard
-// has already closed and grown clientHeight), the spacer is undersized, the
-// pin clamps short, and the message lands mid-viewport. The fix keeps
-// fullViewHRef >= clientHeight at every sizeSpacer() call (grow guard), so
-// this asserts the math the fix preserves.
-function pinReachable({ fullViewH, clientHeight, listH, lastUserTop }) {
+// R5 regression contract: spacer sizing reads the active scroll box directly,
+// so callers cannot preserve a stale keyboard-open height after it grows.
+function pinReachable({ clientHeight, listH, lastUserTop }) {
   const scrollEl = makeScrollEl({
     scrollHeight: 0, scrollTop: 0, clientHeight,
   })
@@ -1631,7 +1647,6 @@ function pinReachable({ fullViewH, clientHeight, listH, lastUserTop }) {
     scrollEl,
     listEl,
     lastUserMsgEl,
-    fullViewH,
     { kind: 'PIN_USER_MSG', cid: 'pin-row' },
   )
   const scrollHeight = listH + spacerH
@@ -1640,22 +1655,11 @@ function pinReachable({ fullViewH, clientHeight, listH, lastUserTop }) {
   return { spacerH, maxScrollTop, pinTarget, reachable: maxScrollTop >= pinTarget }
 }
 
-test('R5: spacer keeps the pin reachable when fullViewH tracks the (grown) clientHeight', () => {
-  // Keyboard just closed: clientHeight grew back to 700. With the grow guard,
-  // fullViewH is >= clientHeight, so the pin target is reachable → top pin.
-  const r = pinReachable({ fullViewH: 700, clientHeight: 700, listH: 1040, lastUserTop: 1000 })
-  assert.equal(r.reachable, true, 'message can reach the top when fullViewH >= clientHeight')
+test('R5: the active viewport keeps the pin exactly reachable', () => {
+  const r = pinReachable({ clientHeight: 700, listH: 1040, lastUserTop: 1000 })
+  assert.equal(r.reachable, true, 'message can reach the top after keyboard close')
   assert.equal(r.maxScrollTop, r.pinTarget, 'spacer reserves exactly enough to reach the pin — no extra cushion')
   assert.equal(r.maxScrollTop - r.pinTarget, 0, 'no reservable blank below the pinned message by default')
-})
-
-test('R5: a stale-small fullViewH undersizes the spacer and strands the pin mid-viewport (the bug)', () => {
-  // The pre-fix path: visualViewport fired sizeSpacer with the keyboard-open
-  // height (400) after clientHeight had already grown to 700.
-  const r = pinReachable({ fullViewH: 400, clientHeight: 700, listH: 1040, lastUserTop: 1000 })
-  assert.equal(r.reachable, false, 'stale-small fullViewH leaves the pin target unreachable')
-  assert.ok(r.pinTarget - r.maxScrollTop > 80,
-    'the message is still stranded far below the top — visually mid-viewport')
 })
 
 
@@ -1760,7 +1764,6 @@ test('F2: an idle-mounted short chat reserves for its visible latest user', () =
     scrollEl,
     listEl,
     lastUserMsgEl,
-    915,
     { kind: 'ANCHOR_AT', key: 'a-1', offset: 0 },
   )
   assert.equal(spacerH, 851)
@@ -1774,7 +1777,6 @@ test('F2: a saved pin restores as the same physical ordinary anchor', () => {
     { clientHeight },
     { offsetHeight: shortList },
     { offsetTop: lowUserTop, offsetHeight: 60, dataset: { cid: 'c-1' } },
-    clientHeight,
     { kind: 'PIN_USER_MSG', cid: 'c-1' },
   )
   const restored = makePinnableScrollEl({ listH: shortList, spacerH, clientHeight, userTop: lowUserTop, cid: 'c-1' })

--- a/frontend/src/components/ChatView/chatContract.js
+++ b/frontend/src/components/ChatView/chatContract.js
@@ -76,10 +76,10 @@ export const CHAT_CONTRACT = [
     id: 'spacer-reserves-room',
     title: 'Spacer reserves exactly enough to reach the pin',
     summary:
-      'The dynamic spacer, sized from fullViewH not clientHeight, reserves '
-      + 'exactly enough that the pin target is reachable (cushion >= 0), so the '
-      + 'message lands flush at the top instead of stranded mid-viewport — and '
-      + 'no extra blank the reader can scroll into below the last content.',
+      'The dynamic spacer uses the active scroll-box height and reserves exactly '
+      + 'enough that the pin target is reachable (cushion >= 0), so the message '
+      + 'lands flush at the top without scrollable blank room beyond that target. '
+      + 'A keyboard therefore removes hidden reservation before moving content.',
   },
   {
     id: 'reanchor-on-promote',
@@ -116,7 +116,7 @@ export const CHAT_CONTRACT = [
  * Timestamps are the caller's job — a snapshot is pure geometry.
  */
 export function snapshotChatUX(env, { pinOffset = PIN_OFFSET } = {}) {
-  const { scrollEl, listEl, lastUserMsgEl, fullViewH } = env || {}
+  const { scrollEl, listEl, lastUserMsgEl } = env || {}
   const scrollTop = scrollEl ? scrollEl.scrollTop : null
   const scrollHeight = scrollEl ? scrollEl.scrollHeight : null
   const clientHeight = scrollEl ? scrollEl.clientHeight : null
@@ -144,7 +144,6 @@ export function snapshotChatUX(env, { pinOffset = PIN_OFFSET } = {}) {
   return {
     scrollTop, scrollHeight, clientHeight, listHeight, lastUserTop,
     pinGap, distanceToBottom, spacerReachable,
-    fullViewH: fullViewH ?? null,
   }
 }
 
@@ -219,13 +218,8 @@ export function cushionPresent(snap, { min = PIN_BOTTOM_ROOM, pinOffset = PIN_OF
     return indeterminate(id, expected,
       'cannot derive cushion (missing scroll element or user message)')
   }
-  // Keyboard-closed terms: an open keyboard shrinks clientHeight, which would
-  // inflate (scrollHeight - clientHeight) and green-light an undersized
-  // spacer. fullViewH is the caller-known full viewport height; fall back to
-  // clientHeight only when the caller did not supply it.
-  const viewH = snap.fullViewH ?? snap.clientHeight
   const pinTarget = Math.max(0, snap.lastUserTop - pinOffset)
-  const cushion = (snap.scrollHeight - viewH) - pinTarget
+  const cushion = (snap.scrollHeight - snap.clientHeight) - pinTarget
   return { ok: cushion >= min, id, measured: cushion, expected }
 }
 

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -34,8 +34,10 @@
  * from tail geometry, not from whether a gesture has already scrolled that row
  * into view. That keeps scrollHeight stable while the reader approaches the
  * final turn: short replies keep the remaining room, while reply/tool
- * expansion consumes it and collapse restores it. The one explicit exception
- * is the transient
+ * expansion consumes it and collapse restores it. The reservation uses the
+ * active scroll-box height, so a keyboard first removes now-hidden blank room;
+ * only content that no longer fits makes FOLLOW_BOTTOM move. The one explicit
+ * exception is the transient
  * question-submit anchor: it reserves exactly enough tail room for a stable
  * same-viewport handoff. A keyboard resize restores the pre-submit mode before
  * sizing, so the answered card moves exactly as the unanswered card would.
@@ -723,11 +725,10 @@ export function _computeSpacerH(
   scrollEl,
   listEl,
   lastUserMsgEl,
-  fullViewH,
   mode = null,
 ) {
   if (!scrollEl || !listEl) return 0
-  const viewH = fullViewH || scrollEl.clientHeight
+  const viewH = scrollEl.clientHeight
   if (mode?.kind === 'ANCHOR_AT'
       && Number.isFinite(mode.questionSubmitViewportH)) {
     const anchorEl = _anchorEl(scrollEl, mode)
@@ -1235,7 +1236,9 @@ export default function useScrollMode({
   // once a newer gesture lands, older work can never regain ownership merely
   // because the gesture timing window later closes.
   const readerIntentVersionRef = useRef(0)
-  const fullViewHRef = useRef(0)
+  // Keyboard-closed pane height for the focused Q&A editing lifecycle.
+  // Spacer sizing reads the active scroll box directly.
+  const fullPaneHRef = useRef(0)
   // The chat reacts to the size of its actual scroll viewport, after Shell has
   // reconciled any visual-viewport overlay. Keeping the last observed height
   // across effect re-runs makes ResizeObserver the one keyboard/layout signal
@@ -1257,10 +1260,9 @@ export default function useScrollMode({
   // shift/clamp (design §2). Null when no anchor is active.
   const lastAnchorTopRef = useRef(null)
   // A pane-geometry resize (divider commit, projection/mode flip, rotation)
-  // hands its projected CONTENT height here; sizeSpacer consumes it under the
-  // reader-ownership gate so the (possibly LOWER) floor rides the same deferred
-  // pass as the spacer mutation. Null except in-flight.
-  const pendingPaneHeightRef = useRef(null)
+  // hands its projected content height here. sizeSpacer consumes it with the
+  // same deferred layout pass as spacer geometry. Null except in-flight.
+  const pendingFullPaneHeightRef = useRef(null)
   // Set inside the layout effect to the live pane-resize runner; the returned
   // paneResized() forwards to it (null when no scroll DOM is mounted). Mirrors
   // the forceRevealRef / resumeLayoutAfterGestureRef effect-bridge pattern.
@@ -1698,8 +1700,8 @@ export default function useScrollMode({
       }
     }
 
-    if (scrollEl.clientHeight > fullViewHRef.current) {
-      fullViewHRef.current = scrollEl.clientHeight
+    if (scrollEl.clientHeight > fullPaneHRef.current) {
+      fullPaneHRef.current = scrollEl.clientHeight
     }
 
     const listEl = scrollEl.querySelector('.chat__list')
@@ -1820,30 +1822,16 @@ export default function useScrollMode({
       if (chatRef.current && Number.isFinite(composerHeight)) {
         chatRef.current.style.setProperty('--composer-h', `${composerHeight}px`)
       }
-      // Keep fullViewHRef authoritative at EVERY spacer sizing, not just at
-      // the layout-effect entry and the RO callback start (the other two grow
-      // sites). On keyboard close, the viewport ResizeObserver reaches this
-      // pass with a newly grown clientHeight; without the guard the spacer
-      // would still use the stale keyboard-open height. That undersizes the
-      // spacer, clamps the pin below its target, and strands the message in the
-      // middle. Grow-only: a keyboard-open shrink is ignored, so opening and
-      // closing the keyboard never changes the permanent reply reservation.
-      //
-      // The ONE sanctioned lowering of the grow-only floor: a committed pane
-      // geometry change (divider/projection/rotation) delivers the layout-
-      // derived pane height through pendingPaneHeightRef, which may be SMALLER
-      // than the current floor (a narrower/shorter pane). Consume it here, under
-      // the same reader-ownership gate as every other write in this pass, before
-      // the grow-only clientHeight bump re-raises it if the real pane is taller.
-      // The viewport ResizeObserver never sets this ref, so keyboard changes
-      // keep the floor strictly grow-only (design §2).
-      if (pendingPaneHeightRef.current != null) {
-        const ph = pendingPaneHeightRef.current
-        if (Number.isFinite(ph) && ph > 0) fullViewHRef.current = ph
-        pendingPaneHeightRef.current = null
+      // Keep the keyboard-closed pane reference current for focused Q&A edits.
+      // A committed pane resize may lower it; keyboard viewport changes only
+      // grow it. This value does not size the spacer.
+      if (pendingFullPaneHeightRef.current != null) {
+        const ph = pendingFullPaneHeightRef.current
+        if (Number.isFinite(ph) && ph > 0) fullPaneHRef.current = ph
+        pendingFullPaneHeightRef.current = null
       }
-      if (scrollEl.clientHeight > fullViewHRef.current) {
-        fullViewHRef.current = scrollEl.clientHeight
+      if (scrollEl.clientHeight > fullPaneHRef.current) {
+        fullPaneHRef.current = scrollEl.clientHeight
       }
       // Fall back to the last user row in the DOM when the React ref is
       // transiently null. On a fresh send the just-sent row's optimistic node
@@ -1860,7 +1848,7 @@ export default function useScrollMode({
       // an older row or an unrelated reading location.
       const lastUserEl = _lastUserRowEl(scrollEl) || lastUserMsgRef.current
       const h = _computeSpacerH(
-        scrollEl, listEl, lastUserEl, fullViewHRef.current, modeRef.current,
+        scrollEl, listEl, lastUserEl, modeRef.current,
       )
       spacerEl.style.height = `${h}px`
       // A wheel/touch/key gesture begins before the browser emits its first
@@ -2038,19 +2026,9 @@ export default function useScrollMode({
 
     syncLayout({ authorityVersion: currentAuthority() })
 
-    // The scrollApi.paneResized(projectedHeightPx) contract (design §2,
-    // constraint 1). Shell calls this on COMMITTED pane-geometry changes for a
-    // MOUNTED chat — divider pointerup, projection/mode flip, pane open/close
-    // affecting this chat, rotation — with the pane's new projected CONTENT
-    // height (the LAYOUT-derived height, never scrollEl.clientHeight, so a
-    // keyboard-shrunk viewport can not stick the floor). It lowers the grow-only
-    // floor to that height and re-applies the active mode: FOLLOW_BOTTOM snaps
-    // the tail, PIN_USER_MSG re-pins, ANCHOR_AT re-anchors. The whole pass
-    // respects the reader-gesture ownership gate (R5): while a reader gesture
-    // owns scroll, it DEFERS everything (the floor lowering is applied by
-    // sizeSpacer only under the gate) and the reader-yield replay runs it. The
-    // The keyboard's viewport ResizeObserver path must never call this —
-    // divider/projection shrink and keyboard shrink stay structurally separate.
+    // Shell supplies committed pane geometry separately from viewport resize.
+    // Its projected full height keeps Q&A keyboard-close detection accurate
+    // even when the pane itself changes while the keyboard is open.
     function runPaneResize(projectedHeightPx) {
       const authorityVersion = currentAuthority()
       // This committed pane change has its own explicit owner. Adopt the DOM's
@@ -2060,14 +2038,12 @@ export default function useScrollMode({
         element: scrollEl,
         height: scrollEl.clientHeight,
       }
-      pendingPaneHeightRef.current =
+      pendingFullPaneHeightRef.current =
         (Number.isFinite(projectedHeightPx) && projectedHeightPx > 0)
           ? projectedHeightPx
-          : pendingPaneHeightRef.current
+          : pendingFullPaneHeightRef.current
       if (!layoutOwnsScroll(authorityVersion)) {
-        // Defer the floor lowering, spacer mutation, and mode re-apply as one
-        // replayable pass; the deferred syncLayout({forceApply}) consumes the
-        // pending height and re-applies the current mode when ownership yields.
+        // Keep projected pane height, spacer, and mode in one replayable pass.
         deferLayoutUntilReaderYields(authorityVersion)
         return
       }
@@ -2167,14 +2143,14 @@ export default function useScrollMode({
         })
         if (questionEditSessionRef.current
             && !questionEditField(document.activeElement)
-            && scrollEl.clientHeight >= fullViewHRef.current - 1) {
+            && scrollEl.clientHeight >= fullPaneHRef.current - 1) {
           questionEditSessionRef.current = false
         }
         requestRevealOnQuiet()
         return
       }
-      if (scrollEl.clientHeight > fullViewHRef.current) {
-        fullViewHRef.current = scrollEl.clientHeight
+      if (scrollEl.clientHeight > fullPaneHRef.current) {
+        fullPaneHRef.current = scrollEl.clientHeight
       }
       sizeSpacer(authorityVersion)
       const k = modeRef.current.kind
@@ -2474,7 +2450,7 @@ export default function useScrollMode({
         questionEditSessionRef.current = true
         return
       }
-      if (scrollEl.clientHeight >= fullViewHRef.current - 1) {
+      if (scrollEl.clientHeight >= fullPaneHRef.current - 1) {
         questionEditSessionRef.current = false
       }
     }
@@ -2776,7 +2752,7 @@ export default function useScrollMode({
       }
 
       const spacerH = _computeSpacerH(
-        scrollEl, listEl, lastUserEl, fullViewHRef.current, mode,
+        scrollEl, listEl, lastUserEl, mode,
       )
       const signature = [
         Math.round(listEl.offsetHeight),

--- a/frontend/src/components/ChatView/useStreamConnection.js
+++ b/frontend/src/components/ChatView/useStreamConnection.js
@@ -392,8 +392,8 @@ export default function useStreamConnection(chatId, {
   // screenshots match the partner's framing). interactive-widget=
   // resizes-content shrinks innerHeight when the keyboard opens — and
   // POST /messages typically fires WITH the keyboard open — so the raw
-  // value is keyboard-poisoned. Max-tracking mirrors the same defensive
-  // trick useScrollMode applies to the spacer (fullViewHRef).
+  // value is keyboard-poisoned. Max-tracking is specific to agent screenshot
+  // framing; the visible chat spacer intentionally responds to the keyboard.
   const maxInnerHeightRef = useRef(
     typeof window !== 'undefined' ? window.innerHeight : 0
   )

--- a/tests/pin-clamp-settle.spec.mjs
+++ b/tests/pin-clamp-settle.spec.mjs
@@ -302,9 +302,8 @@ test('Keyboard close cannot retire a pin before a short stream settles', async (
 
   // Match the real mobile order: the composer opens the keyboard (short
   // viewport), send pins there, then blur closes the keyboard while the reply
-  // is still streaming. The grow-only fullViewH reservation intentionally
-  // makes the pin look away from the PHYSICAL bottom while the keyboard is
-  // open; that temporary geometry must not be mistaken for reader intent.
+  // is still streaming. Each viewport gets an exact responsive reservation;
+  // the resize itself must not be mistaken for reader intent.
   await page.setViewportSize({ width: 426, height: 560 })
   // Chromium dispatches the resize after setViewportSize resolves. Wait for
   // FOLLOW_BOTTOM to apply the new geometry before Enter snapshots whether

--- a/tests/spacer.spec.mjs
+++ b/tests/spacer.spec.mjs
@@ -566,7 +566,7 @@ test.describe('Chat switching (the bug)', () => {
 })
 
 test.describe('Empty state transition', () => {
-  test('12. fullViewHRef captured on empty->chat transition', async ({ page }) => {
+  test('12. visible viewport reservation initializes on empty->chat transition', async ({ page }) => {
     await setup(page)
     await newChat(page)
 
@@ -580,7 +580,7 @@ test.describe('Empty state transition', () => {
     await sendMessage(page, 'First ever message')
     const m = await measure(page)
 
-    // Spacer should use the full viewport height, not 0.
+    // Spacer should use the newly mounted visible viewport height, not 0.
     expect(m.spacerH).toBeGreaterThan(0)
     assertSpacerReasonable(m)
     assertUserMsgAtTop(m)
@@ -1099,6 +1099,59 @@ test.describe('Scroll edge cases', () => {
     expect(after.toolCount).toBe(5)
     const afterGap = after.scrollH - after.scrollTop - after.clientH
     expect(afterGap).toBeLessThanOrEqual(10)
+  })
+
+  test('28. Keyboard-sized viewport consumes blank reservation before lifting output', async ({ page }) => {
+    await setup(page)
+    await newChat(page)
+    await sendMessage(page, 'Responsive keyboard spacer test')
+
+    // Enter follow through the reader-owned path.
+    await page.evaluate(() => {
+      const s = document.querySelector('[data-chat-surface="painted"] .chat__scroll')
+      if (!s) return
+      s.dispatchEvent(new PointerEvent('pointerdown', {
+        bubbles: true, pointerType: 'touch', clientY: 400,
+      }))
+      s.dispatchEvent(new PointerEvent('pointermove', {
+        bubbles: true, pointerType: 'touch', clientY: 360,
+      }))
+      s.dispatchEvent(new PointerEvent('pointerup', {
+        bubbles: true, pointerType: 'touch', clientY: 360,
+      }))
+    })
+    await page.waitForFunction(() => (
+      document.querySelector('[data-chat-surface="painted"] .chat__scroll')
+        ?.dataset.scrollMode === 'FOLLOW_BOTTOM'
+    ))
+
+    const closed = await measure(page)
+    expect(closed.spacerH).toBeGreaterThan(300)
+
+    await page.setViewportSize({ width: 412, height: 615 })
+    await page.waitForFunction(({ oldClientH, oldSpacerH }) => {
+      const s = document.querySelector('[data-chat-surface="painted"] .chat__scroll')
+      const spacer = document.querySelector('[data-chat-surface="painted"] .spacer-dynamic')
+      const spacerH = parseInt(spacer?.style.height) || 0
+      return s?.dataset.scrollMode === 'FOLLOW_BOTTOM'
+        && s.clientHeight < oldClientH
+        && spacerH < oldSpacerH
+    }, { oldClientH: closed.clientH, oldSpacerH: closed.spacerH })
+
+    const open = await measure(page)
+    expect(Math.abs(open.scrollTop - closed.scrollTop)).toBeLessThanOrEqual(8)
+    expect(Math.abs(open.userVisualTop - closed.userVisualTop)).toBeLessThanOrEqual(8)
+    expect(open.scrollH - open.scrollTop - open.clientH).toBeLessThanOrEqual(8)
+    expect(Math.abs(
+      (closed.spacerH - open.spacerH) - (closed.clientH - open.clientH),
+    )).toBeLessThanOrEqual(8)
+
+    await injectContent(page, 'Keyboard-visible streamed output. ', 120)
+    const overflow = await measure(page)
+    expect(overflow.spacerH).toBe(0)
+    expect(overflow.scrollTop).toBeGreaterThan(open.scrollTop + 20)
+    expect(overflow.scrollH - overflow.scrollTop - overflow.clientH)
+      .toBeLessThanOrEqual(10)
   })
 
   test('24. Auto-follow re-engages when user scrolls back to bottom', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Size the chat's reply reservation from the active visible scroll box, so a phone keyboard consumes blank room before moving conversation content.
- Preserve the single viewport owner and existing pin, reading-anchor, and tail-follow controller; only real overflow moves after the reservation reaches zero.
- Keep keyboard-closed pane height solely for focused Q&A editing, removing the spacer-specific height input and floor.

## Relation to prior work
[PR #532](https://github.com/mobius-os/mobius/pull/532) fixed visual-viewport ownership and mode-preserving keyboard resize. This follow-up keeps that architecture but changes the remaining reservation rule: the active scroll box now owns blank reply space, so keyboard-covered blank room disappears before real content moves. Once reservation reaches zero, the existing tail-follow behavior handles only true overflow.

## Testing
- `npm test`
- `npm run build`
- Focused ESLint (no errors)
- Unit coverage for blank-reservation shrink, overflow handoff, and exact pin reachability