### PR TITLE
Preserve queue-time scroll intent when steering

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -602,10 +602,13 @@ and attaches their rule ids to new diagnostic chats. The Playwright lock-in spec
   authoritative because `ScrollMode` can lag an input/layout frame; requiring both
   made identical bottom sends behave inconsistently. A real user scroll after
   submission invalidates an automatic delayed queue promotion (a tap without
-  scrolling does not). Explicit fast-forward is itself the visibility action, so it
-  captures fresh bottom geometry when pressed; a real scroll during its request
-  invalidates that snapshot. Missing delayed intent degrades to hold, never to an
-  inferred pin.
+  scrolling does not). Explicit fast-forward keeps that submit snapshot while
+  its reader generation remains current, so opening or closing the queue tray
+  cannot turn a bottom send into a hold (or manufacture a pin for somebody
+  reading above it). If the reader really moved after queueing, fast-forward
+  captures fresh bottom geometry instead; another real scroll during its request
+  invalidates that snapshot. Missing delayed intent degrades to hold, never to
+  an inferred pin.
 - **R3 — Pin holds until the reservation is filled.** A legitimate live pin
   transitions to `PIN_USER_MSG`, not immediately to `FOLLOW_BOTTOM`; the response
   first grows below the prompt without moving it. Exactly when the streaming reply
@@ -658,7 +661,8 @@ and attaches their rule ids to new diagnostic chats. The Playwright lock-in spec
   after submit opens fresh reader ownership and still wins. Queueing behind a live
   turn adds no transcript row, so it
   freezes the visible message before the queue tray/composer/keyboard reflow; the
-  separately captured submit snapshot still controls the row when it is promoted.
+  separately captured submit snapshot still controls the row when it is promoted
+  or explicitly fast-forwarded, unless a newer real reader scroll replaced it.
   Never replace the input-to-first-scroll handoff with a fixed short window: under
   rendering load the browser may deliver that scroll later. Ownership begins only for
   inputs whose default action can scroll the transcript; ordinary typing, Enter, and

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -602,13 +602,10 @@ and attaches their rule ids to new diagnostic chats. The Playwright lock-in spec
   authoritative because `ScrollMode` can lag an input/layout frame; requiring both
   made identical bottom sends behave inconsistently. A real user scroll after
   submission invalidates an automatic delayed queue promotion (a tap without
-  scrolling does not). Explicit fast-forward keeps that submit snapshot while
-  its reader generation remains current, so opening or closing the queue tray
-  cannot turn a bottom send into a hold (or manufacture a pin for somebody
-  reading above it). If the reader really moved after queueing, fast-forward
-  captures fresh bottom geometry instead; another real scroll during its request
-  invalidates that snapshot. Missing delayed intent degrades to hold, never to
-  an inferred pin.
+  scrolling does not). Explicit fast-forward reuses that snapshot through tray
+  reflow while its reader generation remains current; after a real scroll it
+  captures current geometry instead. Another scroll during the request invalidates
+  that snapshot. Missing delayed intent degrades to hold, never to an inferred pin.
 - **R3 — Pin holds until the reservation is filled.** A legitimate live pin
   transitions to `PIN_USER_MSG`, not immediately to `FOLLOW_BOTTOM`; the response
   first grows below the prompt without moving it. Exactly when the streaming reply

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -769,11 +769,6 @@ export default function ChatView({
     return intent
   }
 
-  function peekSendIntent(cid) {
-    if (!cid) return null
-    return sendIntentByCidRef.current.get(cid) || null
-  }
-
   function restoreReplacedSendIntent(cid, replacement, previous) {
     if (!cid || sendIntentByCidRef.current.get(cid) !== replacement) return
     if (previous) sendIntentByCidRef.current.set(cid, previous)
@@ -3196,15 +3191,11 @@ export default function ChatView({
     let explicitSteerIntent = null
     let previousSendIntent = null
     try {
-      const steerIsFirstUser = isFirstVisibleUserMessage()
-      previousSendIntent = peekSendIntent(steerCid)
-      // Queue submission already captured the reader's position before the
-      // tray changed footer/viewport geometry. Preserve that decision when no
-      // real reader scroll followed; otherwise Fast-forward's current snapshot
-      // wins. The controller owns that generation check and also cancels any
-      // older quiet settlement, which previously overwrote a newer pin.
+      previousSendIntent = sendIntentByCidRef.current.get(steerCid) || null
+      // Preserve queue-time intent through tray reflow. The controller replaces
+      // it after real reader movement and retires any older gesture settlement.
       explicitSteerIntent = captureSendIntent({
-        isFirstUserMsg: steerIsFirstUser,
+        isFirstUserMsg: isFirstVisibleUserMessage(),
         previousIntent: previousSendIntent,
       })
       rememberSendIntent(steerCid, explicitSteerIntent)

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -769,11 +769,9 @@ export default function ChatView({
     return intent
   }
 
-  function replaceSendIntent(cid, intent) {
-    if (!cid || !intent) return null
-    const previous = sendIntentByCidRef.current.get(cid) || null
-    sendIntentByCidRef.current.set(cid, intent)
-    return previous
+  function peekSendIntent(cid) {
+    if (!cid) return null
+    return sendIntentByCidRef.current.get(cid) || null
   }
 
   function restoreReplacedSendIntent(cid, replacement, previous) {
@@ -1155,11 +1153,11 @@ export default function ChatView({
       // segment. That ordering is what makes promoting the live
       // stream here correct; it is not a guess about where the server cut.
       //
-      // It still follows the one visible-row scroll rule. Automatic queue
-      // promotion keeps the original submit snapshot; an explicit fast-forward
-      // captures a fresh snapshot when pressed, because that is the deliberate
-      // action making the row visible. Whether it pins or holds, the row gets
-      // the same permanent bottom reservation as a normal send.
+      // It still follows the one visible-row scroll rule. Queue promotion and
+      // explicit fast-forward keep the original submit snapshot until a real
+      // reader scroll replaces it; tray/footer reflow alone is not intent.
+      // Whether it pins or holds, the row gets the same permanent bottom
+      // reservation as a normal send.
       //
       // Current backends carry a non-empty `messages` array, each row with its
       // stable cid (card-221: every row carries one). During rolling deploys an
@@ -3199,16 +3197,17 @@ export default function ChatView({
     let previousSendIntent = null
     try {
       const steerIsFirstUser = isFirstVisibleUserMessage()
-      // Fast-forward is a deliberate visibility action, unlike automatic
-      // queue drain. Capture the reader's ACTUAL position now: bottom pins,
-      // reading elsewhere holds. A later real scroll during the POST still
-      // invalidates this opaque intent inside the scroll controller. Capturing
-      // also cancels any older quiet settlement, which is what previously
-      // overwrote the new pin and made the row bounce before settling.
+      previousSendIntent = peekSendIntent(steerCid)
+      // Queue submission already captured the reader's position before the
+      // tray changed footer/viewport geometry. Preserve that decision when no
+      // real reader scroll followed; otherwise Fast-forward's current snapshot
+      // wins. The controller owns that generation check and also cancels any
+      // older quiet settlement, which previously overwrote a newer pin.
       explicitSteerIntent = captureSendIntent({
         isFirstUserMsg: steerIsFirstUser,
+        previousIntent: previousSendIntent,
       })
-      previousSendIntent = replaceSendIntent(steerCid, explicitSteerIntent)
+      rememberSendIntent(steerCid, explicitSteerIntent)
       // Queue-only sends deliberately retain mobile focus. Remember a touch
       // fast-forward's focus/draft now, but do not blur yet: the authoritative
       // cut must render and pin the steered row before keyboard geometry

--- a/frontend/src/components/ChatView/__tests__/composerSteerTouch.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerSteerTouch.test.js
@@ -73,10 +73,20 @@ test('per-row fast-forward appears with the optimistic row and dispatches on tou
   )
 })
 
+test('fast-forward preserves queue-time scroll intent through layout reflow', () => {
+  const steerPath = chatView.match(
+    /async function steerRowsImpl\(steerRowsList\) \{[\s\S]*?\n  \/\/ STEER \(fast-forward\): inject/,
+  )?.[0] || ''
+  assert.match(
+    steerPath,
+    /previousSendIntent = sendIntentByCidRef\.current\.get\(steerCid\) \|\| null[\s\S]*?captureSendIntent\(\{[\s\S]*?previousIntent: previousSendIntent[\s\S]*?rememberSendIntent\(steerCid, explicitSteerIntent\)/,
+  )
+})
+
 test('touch steer dismisses the keyboard only after its committed row is positioned', () => {
   assert.match(
     chatView,
-    /async function steerRowsImpl\(steerRowsList\) \{[\s\S]*?previousSendIntent = peekSendIntent\(steerCid\)[\s\S]*?explicitSteerIntent = captureSendIntent\(\{[\s\S]*?previousIntent: previousSendIntent[\s\S]*?rememberSendIntent\(steerCid, explicitSteerIntent\)[\s\S]*?steerKeyboardDismissRequestRef\.current = \{[\s\S]*?pendingQueue\.reserveForSteer\(consumePendingCids\)/,
+    /async function steerRowsImpl\(steerRowsList\) \{[\s\S]*?explicitSteerIntent = captureSendIntent\(\{[\s\S]*?rememberSendIntent\(steerCid, explicitSteerIntent\)[\s\S]*?steerKeyboardDismissRequestRef\.current = \{[\s\S]*?pendingQueue\.reserveForSteer\(consumePendingCids\)/,
     'the tap should retain focus while the provider is still settling the cut',
   )
   const requestToCut = chatView.match(

--- a/frontend/src/components/ChatView/__tests__/composerSteerTouch.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerSteerTouch.test.js
@@ -76,7 +76,7 @@ test('per-row fast-forward appears with the optimistic row and dispatches on tou
 test('touch steer dismisses the keyboard only after its committed row is positioned', () => {
   assert.match(
     chatView,
-    /async function steerRowsImpl\(steerRowsList\) \{[\s\S]*?explicitSteerIntent = captureSendIntent\(\{[\s\S]*?previousSendIntent = replaceSendIntent\(steerCid, explicitSteerIntent\)[\s\S]*?steerKeyboardDismissRequestRef\.current = \{[\s\S]*?pendingQueue\.reserveForSteer\(consumePendingCids\)/,
+    /async function steerRowsImpl\(steerRowsList\) \{[\s\S]*?previousSendIntent = peekSendIntent\(steerCid\)[\s\S]*?explicitSteerIntent = captureSendIntent\(\{[\s\S]*?previousIntent: previousSendIntent[\s\S]*?rememberSendIntent\(steerCid, explicitSteerIntent\)[\s\S]*?steerKeyboardDismissRequestRef\.current = \{[\s\S]*?pendingQueue\.reserveForSteer\(consumePendingCids\)/,
     'the tap should retain focus while the provider is still settling the cut',
   )
   const requestToCut = chatView.match(

--- a/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
+++ b/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
@@ -14,6 +14,7 @@ import {
   anchorModeFromScroll,
   bottomAnchorModeFromScroll,
   contentHoldModeFromScroll,
+  delayedSendWillPin,
   gestureLayoutRetryDelay,
   isNearContentBottom,
   layoutMayOwnScroll,
@@ -148,6 +149,36 @@ test('shouldPinSend trusts bottom geometry even when mode is a stale hold', () =
     mode: { kind: 'PIN_USER_MSG', cid: 'c-123' },
     isFirstUserMsg: false,
   }), true)
+})
+
+test('delayed visibility preserves queue-time pin intent until the reader moves', () => {
+  const bottomAtQueueTime = {
+    willPin: true,
+    readerIntentVersion: 7,
+  }
+  assert.equal(delayedSendWillPin({
+    previousIntent: bottomAtQueueTime,
+    readerIntentVersion: 7,
+    // Opening the tray changed the viewport and made a later geometry snapshot
+    // look away from the tail, but the reader did not move.
+    willPinNow: false,
+  }), true)
+
+  assert.equal(delayedSendWillPin({
+    previousIntent: { willPin: false, readerIntentVersion: 7 },
+    readerIntentVersion: 7,
+    // Tray collapse can also make old content appear near the tail; layout
+    // alone must not manufacture a pin for somebody reading above it.
+    willPinNow: true,
+  }), false)
+
+  assert.equal(delayedSendWillPin({
+    previousIntent: bottomAtQueueTime,
+    // A real scroll advanced the generation, so Fast-forward-time geometry is
+    // now the newer intent and must win over the queued snapshot.
+    readerIntentVersion: 8,
+    willPinNow: false,
+  }), false)
 })
 
 test('layout writes yield from first input through gesture settlement', () => {

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -772,6 +772,22 @@ export function shouldPinSend({
 }
 
 
+/** Keep a queued send's submit-time pin decision until the reader actually
+ *  moves again. Opening/closing the queue tray and composer changes geometry,
+ *  but that layout work is not newer reading intent. An explicit fast-forward
+ *  therefore reuses the queued decision while its reader generation is still
+ *  current; after a real scroll, the fast-forward-time snapshot wins. */
+export function delayedSendWillPin({
+  previousIntent,
+  readerIntentVersion,
+  willPinNow,
+}) {
+  return previousIntent?.readerIntentVersion === readerIntentVersion
+    ? previousIntent.willPin
+    : willPinNow
+}
+
+
 /** Position-based bottom check that treats the dynamic pin spacer as phantom
  *  room, not real content. Send snapshots use the conversation tail because a
  *  new send should not require traversing reserved reply room first. */
@@ -1511,14 +1527,21 @@ export default function useScrollMode({
   const captureSendIntent = useCallback(({
     canPin = true,
     isFirstUserMsg = false,
+    previousIntent = null,
   } = {}) => {
+    const readerIntentVersion = readerIntentVersionRef.current
+    const willPinNow = canPin && shouldPinSend({
+      scrollEl: scrollRef.current,
+      mode: modeRef.current,
+      isFirstUserMsg,
+    })
     const intent = {
-      willPin: canPin && shouldPinSend({
-        scrollEl: scrollRef.current,
-        mode: modeRef.current,
-        isFirstUserMsg,
+      willPin: delayedSendWillPin({
+        previousIntent: canPin ? previousIntent : null,
+        readerIntentVersion,
+        willPinNow,
       }),
-      readerIntentVersion: readerIntentVersionRef.current,
+      readerIntentVersion,
     }
     supersedePendingReaderGesture()
     return intent

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -772,11 +772,9 @@ export function shouldPinSend({
 }
 
 
-/** Keep a queued send's submit-time pin decision until the reader actually
- *  moves again. Opening/closing the queue tray and composer changes geometry,
- *  but that layout work is not newer reading intent. An explicit fast-forward
- *  therefore reuses the queued decision while its reader generation is still
- *  current; after a real scroll, the fast-forward-time snapshot wins. */
+/** Layout may change bottom geometry without changing reader intent. Preserve
+ *  the queued decision within its generation; after real reader movement,
+ *  Fast-forward's current geometry wins. */
 export function delayedSendWillPin({
   previousIntent,
   readerIntentVersion,


### PR DESCRIPTION
## Summary

- Preserve a queued message's submit-time pin-or-hold decision through queue-tray and viewport reflow.
- Let a genuine reader scroll after queueing replace that decision when Fast-forward is pressed.
- Add regression coverage for both preserved pin and preserved hold behavior.

## Root cause

Queue submission captured the correct bottom state, then froze the visible conversation while the queued tray and composer changed the viewport. Fast-forward always sampled the resulting geometry again, even when the reader had not moved, so a message queued at the bottom could be misclassified as a held reading position.

The scroll controller now carries the queued decision forward only while its reader generation is still current. A real later scroll advances that generation and makes Fast-forward's current position authoritative instead.

## Relation to prior work

[PR #331](https://github.com/mobius-os/mobius/pull/331) centralized delayed send intent and invalidated it after real reader movement. [PR #525](https://github.com/mobius-os/mobius/pull/525) delayed mobile keyboard dismissal until the steered row was positioned. This follow-up closes the remaining gap between those boundaries: no-scroll queue and viewport reflow could still overwrite the valid submit-time decision. [PR #550](https://github.com/mobius-os/mobius/pull/550) hardens broader keyboard and gesture settlement, but does not change this queued-intent handoff.

## Verification

- `npm test`
- `npm run lint`
- `npm run build`
- Rendered phone-width mocked flow: after queue and height reflow left current geometry 421 px from the content tail, the steered row still landed 3.5 px from the top and remained stable across eight measured frames.