### PR TITLE
Follow mobile keyboard from composer tail intent

### DIFF
--- a/frontend/src/components/ChatView/__tests__/scrollOwnership.test.js
+++ b/frontend/src/components/ChatView/__tests__/scrollOwnership.test.js
@@ -219,4 +219,17 @@ test('automatic geometry owners and newer semantic actions share reader authorit
     /const onPointerCancelInput = \(\) => \{[\s\S]*?disclosureInputOwnsGesture = false[\s\S]*?addEventListener\('pointercancel', onPointerCancelInput/,
     'a disclosure press promoted to a native pan must become reader-owned scroll',
   )
+
+  const composerStart = ownerSource.indexOf('const onComposerPointerDown =')
+  const composerEnd = ownerSource.indexOf('const noteScrollStart =', composerStart)
+  const composerPath = ownerSource.slice(composerStart, composerEnd)
+  assert.ok(composerStart >= 0 && composerEnd > composerStart,
+    'composer tail intent must remain inside the scroll owner')
+  assert.match(composerPath, /composerPointerRequestsFollow\(event, scrollEl\)/,
+    'composer focus may follow only after checking pre-keyboard tail geometry')
+  assert.ok(
+    composerPath.indexOf('supersedePendingReaderGesture()')
+      < composerPath.indexOf("transitionMode({ kind: 'FOLLOW_BOTTOM' }"),
+    'composer intent must retire an older gesture before keyboard follow begins',
+  )
 })

--- a/frontend/src/components/ChatView/__tests__/scrollRepairDirection.test.js
+++ b/frontend/src/components/ChatView/__tests__/scrollRepairDirection.test.js
@@ -143,7 +143,7 @@ test('question viewport release restores only its captured base authority', () =
   ), followOverlay, 'an equivalent-looking mode is not the overlay\'s authority')
 })
 
-test('only real-bottom or an armed pin handoff can enter follow', () => {
+test('only explicit tail intent or an armed pin handoff can enter follow', () => {
   const hold = { kind: 'ANCHOR_AT', key: 'a-1', offset: 30 }
   const follow = { kind: 'FOLLOW_BOTTOM' }
   const armedPin = {
@@ -162,6 +162,10 @@ test('only real-bottom or an armed pin handoff can enter follow', () => {
   )
   assert.equal(
     modeForScrollTransition(hold, follow, 'reader:scroll-bottom'),
+    follow,
+  )
+  assert.equal(
+    modeForScrollTransition(hold, follow, 'reader:composer-bottom'),
     follow,
   )
 })

--- a/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
+++ b/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
@@ -13,6 +13,7 @@ import {
   applyMode,
   anchorModeFromScroll,
   bottomAnchorModeFromScroll,
+  composerPointerRequestsFollow,
   contentHoldModeFromScroll,
   delayedSendWillPin,
   gestureLayoutRetryDelay,
@@ -203,6 +204,28 @@ test('only scrolling keys claim reader ownership', () => {
   assert.equal(readerInputMayScroll('keydown', 'Tab'), true)
   assert.equal(readerInputMayScroll('wheel'), true)
   assert.equal(readerInputMayScroll('touchmove'), true)
+})
+
+test('a primary composer press requests follow only at the physical tail', () => {
+  const composer = { matches: selector => selector === 'textarea.chat__input' }
+  const otherControl = { matches: () => false }
+  const atTail = makeScrollEl({
+    scrollHeight: 2000,
+    scrollTop: 1200,
+    clientHeight: 800,
+  })
+  const aboveTail = makeScrollEl({
+    scrollHeight: 2000,
+    scrollTop: 1000,
+    clientHeight: 800,
+  })
+
+  assert.equal(composerPointerRequestsFollow({ button: 0, target: composer }, atTail), true)
+  assert.equal(composerPointerRequestsFollow({ button: 0, target: composer }, aboveTail), false,
+    'composer focus must preserve an older reading position')
+  assert.equal(composerPointerRequestsFollow({ button: 1, target: composer }, atTail), false,
+    'non-primary presses do not express writing intent')
+  assert.equal(composerPointerRequestsFollow({ button: 0, target: otherControl }, atTail), false)
 })
 
 test('disclosure activation is recognized as an anchor-latching reading action', () => {

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -5,7 +5,7 @@
  * single funnel that turns a mode into a concrete `scrollTop`.
  * Layout changes (RO, content mutation, spacer recompute, keyboard)
  * re-apply the mode but never mutate it. Only user gestures and
- * explicit lifecycle events (send, mount restore) mutate it.
+ * explicit semantic events (send, composer intent, mount restore) mutate it.
  *
  * Modes:
  *   { kind: 'INITIAL' }           — pre-restore default; no-op
@@ -849,8 +849,8 @@ export function modeAfterTerminalLayout(mode, spacerH, layoutStable) {
 }
 
 
-/** Resolve the quiet edge of a real reader gesture. The physical tail is the
- * single explicit entrance to following, whether or not reservation remains. */
+/** Resolve the quiet edge of a real reader gesture. The physical tail is an
+ * explicit entrance to following, whether or not reservation remains. */
 export function modeAfterReaderGesture({
   reachedBottom,
   holdMode,
@@ -860,19 +860,33 @@ export function modeAfterReaderGesture({
 }
 
 
+/** A primary composer press at the physical tail is an explicit request to
+ * keep the latest content visible while the software keyboard opens. Read the
+ * geometry before focus changes the viewport; presses higher in the transcript
+ * preserve their exact reading anchor. */
+export function composerPointerRequestsFollow(event, scrollEl) {
+  if (event?.button !== 0
+      || !event?.target?.matches?.('textarea.chat__input')
+      || !scrollEl) return false
+  return scrollEl.scrollHeight - scrollEl.scrollTop - scrollEl.clientHeight
+    < PHYSICAL_BOTTOM_EPSILON_PX
+}
+
+
 const FOLLOW_ENTRY_EVENTS = new Set([
   'reader:scroll-bottom',
+  'reader:composer-bottom',
   'layout:reservation-filled',
   'terminal:reservation-filled',
 ])
 
 /** Enforce the state machine's narrow entry authority.
  *
- * Only a send can create a pin. FOLLOW_BOTTOM can be entered only by the two
- * explicit product transitions: a real bottom gesture, or an
- * already-armed pin consuming its reservation. Other events may preserve the
- * current mode, demote it to an anchor/initial hold, or retire an armed pin,
- * but cannot manufacture automatic scroll ownership.
+ * Only a send can create a pin. FOLLOW_BOTTOM can be entered only by explicit
+ * tail intent (a real bottom gesture or a composer press already at the
+ * physical tail), or by an already-armed pin consuming its reservation. Other
+ * events may preserve the current mode, demote it to an anchor/initial hold,
+ * or retire an armed pin, but cannot manufacture automatic scroll ownership.
  */
 export function modeForScrollTransition(previousMode, proposedMode, event) {
   if (!proposedMode) return previousMode
@@ -896,7 +910,7 @@ export function modeForScrollTransition(previousMode, proposedMode, event) {
   if (proposedMode.kind === 'FOLLOW_BOTTOM'
       && previousMode?.kind !== 'FOLLOW_BOTTOM') {
     if (!FOLLOW_ENTRY_EVENTS.has(event)) return previousMode
-    if (event !== 'reader:scroll-bottom'
+    if (!event.startsWith('reader:')
         && !(previousMode?.kind === 'PIN_USER_MSG'
           && previousMode.followWhenFilled)) {
       return previousMode
@@ -1718,6 +1732,7 @@ export default function useScrollMode({
     const scrollEl = scrollRef.current
     const spacerEl = spacerRef.current
     if (!scrollEl || !spacerEl) return
+    const chatEl = chatRef.current
 
     if (observedScrollViewportRef.current.element !== scrollEl) {
       observedScrollViewportRef.current = {
@@ -2466,6 +2481,18 @@ export default function useScrollMode({
       // Keep the gesture gate, but let that scroll become reader-owned.
       disclosureInputOwnsGesture = false
     }
+    const onComposerPointerDown = (event) => {
+      if (!composerPointerRequestsFollow(event, scrollEl)) return
+      // Composer focus is a newer semantic action than any scroll still
+      // waiting on momentum/quiet settlement. Retire that gesture before the
+      // keyboard resize arrives so the viewport observer can apply FOLLOW in
+      // its first committed layout pass instead of waiting behind the old gate.
+      supersedePendingReaderGesture()
+      readerLocationExplicitRef.current = true
+      transitionMode({ kind: 'FOLLOW_BOTTOM' }, 'reader:composer-bottom')
+      persistMode()
+      recordTrace('events', 'reader:composer-bottom', { scrollEl })
+    }
     const noteScrollStart = () => {
       if (!pendingGestureStart) return
       perfMark('scroll.startLatency', performance.now() - pendingGestureStart)
@@ -2482,6 +2509,7 @@ export default function useScrollMode({
     scrollEl.addEventListener('input', onQuestionEditMutation, { passive: true })
     scrollEl.addEventListener('pointerup', onPointerUpInput, { passive: true })
     scrollEl.addEventListener('pointercancel', onPointerCancelInput, { passive: true })
+    chatEl?.addEventListener('pointerdown', onComposerPointerDown, { passive: true })
 
     // Scroll handler — user-driven scrolls only mark intent here. The expensive
     // semantic location/mode work runs once in settleReaderScroll.
@@ -2588,6 +2616,7 @@ export default function useScrollMode({
       scrollEl.removeEventListener('input', onQuestionEditMutation)
       scrollEl.removeEventListener('pointerup', onPointerUpInput)
       scrollEl.removeEventListener('pointercancel', onPointerCancelInput)
+      chatEl?.removeEventListener('pointerdown', onComposerPointerDown)
       if (forceRevealRef.current === forceReveal) forceRevealRef.current = null
     }
   }, [


### PR DESCRIPTION
## Summary

- Treat a primary composer press at the physical chat tail as explicit follow intent before focus changes the viewport.
- Finish any older scroll-gesture ownership before keyboard resize, allowing the first resized layout to follow immediately.
- Preserve exact reading anchors when the composer is pressed away from the physical tail.

## Context

PR #532 unified shell and chat keyboard-resize ownership and made viewport changes preserve the existing scroll mode. A restored or foregrounded chat can intentionally hold an exact anchor even when it is physically at the tail. Pressing the composer there would preserve that anchor; if a previous swipe was still settling, layout could also remain gated until settlement.

This follow-up makes the composer press an explicit tail-follow action without changing behavior higher in the transcript or adding timers, retries, or another keyboard listener.

## Verification

- Focused chat scroll-ownership tests
- `npm test`
- `npm run build`