### PR TITLE
Preserve reading position through recovered QA replies

### DIFF
--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -63,6 +63,7 @@ import { focusComposerElement, shouldApplyComposerFocusRequest } from './compose
 import { shouldDismissComposerKeyboardOnSubmit } from './composerKeyboardPolicy.js'
 import { updateChatRuntimeCache } from './chatRuntimeCache.js'
 import {
+  assistantAnchorKey,
   chatCacheCanPaint,
   chatDetailCacheValue,
   chatSnapshotMatchesRuntime,
@@ -2752,6 +2753,10 @@ export default function ChatView({
       // The 202 means the answer write committed. Settle the durable and live
       // card sources only now; an optimistic pre-request answer made transient
       // failures look final and erased the retryable per-tab question draft.
+      const keepsCurrentTurn = answerKeepsCurrentTurn(response)
+      const recoveredRows = keepsCurrentTurn
+        ? []
+        : (startedMessagesFromResponse(response) || [])
       if (resolvedAnswers) {
         commitMessages(prev => {
           const updated = [...prev]
@@ -2765,7 +2770,10 @@ export default function ChatView({
             })
             updated[lastIdx] = msg
           }
-          return updated
+          // Recovery commits a hidden continuation before its reply starts.
+          // Mirror the backend's canonical rows so the live reply mounts at
+          // the same transcript position its durable row will occupy.
+          return appendMessageBatch(updated, recoveredRows)
         })
         // A mid-turn question may still live in streamItems rather than the
         // durable message list. Keep both render sources in agreement.
@@ -2780,7 +2788,7 @@ export default function ChatView({
       // Unknown future modes also retire the bridge: preserving the completed
       // question row and appending is safer than overwriting it with output
       // from a turn whose ownership semantics this client does not know.
-      if (!answerKeepsCurrentTurn(response)) {
+      if (!keepsCurrentTurn) {
         bridgeHook.markBridged()
         activeAssistantDataKeyRef.current = null
       }
@@ -3730,21 +3738,21 @@ export default function ChatView({
   // The ONE active <li> carries this data-key for both DB and live payloads.
   // ANCHOR_AT resolves `[data-key]`, so source selection must never change it.
   // The first committed source owns the key: a DB-first bridge seeds the
-  // partial's durable key, while a live-first answer keeps its synthetic key
-  // even if a related DB partial arrives later.
+  // partial's durable key, while a live-first answer keeps its absolute
+  // transcript-position alias even if a related DB partial arrives later.
   //
   // Fast-forward can insert a user row AFTER the mounted partial while the
   // stream remains live. Therefore bridge identity is ts-based across the
   // full message list, not "last message only." For multi-turn flow (no
   // bridge), the previous assistant is rendered alongside the streaming
-  // <li> (different turns), so the streaming <li> gets its own synthetic key
-  // rather than reusing a previous assistant row's key.
+  // <li> (different turns). The live row therefore uses the absolute index its
+  // eventual durable row will occupy, not the previous assistant's key.
   const streamingDataKey = chooseActiveAssistantDataKey({
     latched: activeAssistantDataKeyRef.current,
     mirroredMsg: activeMirrorMsg,
     mirrorIndex: activeMirrorMsgIdx,
     hasLivePayload: hasLiveAssistantPayload,
-    chatId,
+    appendIndex: offset + messages.length,
   })
   useLayoutEffect(() => {
     if (!turnActive) {
@@ -3975,6 +3983,9 @@ export default function ChatView({
             // ANCHOR_AT mode. msg.id (server-assigned UUID) is ideal;
             // fall back to role+ts which is also stable across renders.
             const dataKey = messageKey(msg, offset + i)
+            const anchorKey = msg.role === 'assistant'
+              ? assistantAnchorKey(offset + i)
+              : null
             // User rows key + pin on the stable cid so the optimistic→confirm
             // display-ts update never remounts the row (which would drop the
             // pin target mid-swap). data-ts stays for the revealed metadata row.
@@ -3988,6 +3999,7 @@ export default function ChatView({
               className={`chat__msg chat__msg--${continuationMarker ? 'marker' : msg.role}`}
               ref={i === lastUserIdx ? setLastUserMsgRef : null}
               data-key={dataKey}
+              data-anchor-key={anchorKey === dataKey ? undefined : anchorKey}
               data-cid={userCid || undefined}
               data-ts={ownerUserMessage && msg.ts ? String(msg.ts) : undefined}
               onClick={hasMessageMeta

--- a/frontend/src/components/ChatView/__tests__/chatDetailCache.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatDetailCache.test.js
@@ -29,6 +29,12 @@ test('cache first paint requires the saved reading coordinate when one exists', 
     'optimistic-to-server aliases remain valid restoration coordinates')
   assert.equal(chatCacheCanPaint(cached, 'user-10'), false,
     'a role/timestamp alias waits for passive canonical remapping')
+  assert.equal(chatCacheCanPaint({
+    restorationWindowComplete: true,
+    offset: 4,
+    messages: [{ id: 'persisted-answer', role: 'assistant', ts: 12 }],
+  }, 'assistant-4'), true,
+  'a live-first positional alias survives the authoritative timestamp')
   assert.equal(chatCacheCanPaint(cached, 'server-row', true), false,
     'a nested part waits for committed DOM validation')
   assert.equal(chatCacheCanPaint(cached, 'missing-row'), false,

--- a/frontend/src/components/ChatView/__tests__/streamPromotion.test.js
+++ b/frontend/src/components/ChatView/__tests__/streamPromotion.test.js
@@ -3,6 +3,7 @@
  */
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
+import { assistantAnchorKey, messageKey } from '../../../lib/chatDetailCache.js'
 
 import {
   streamItemsToAssistantPayload,
@@ -419,28 +420,28 @@ test('a later visible user row retires a stale mount bridge before new stream ou
 })
 
 test('active row data-key is latched for both live-first and DB-first source switches', () => {
-  const synthetic = chooseActiveAssistantDataKey({
+  const appendAlias = chooseActiveAssistantDataKey({
     latched: null,
     mirroredMsg: null,
     mirrorIndex: -1,
     hasLivePayload: true,
-    chatId: 'chat-1',
+    appendIndex: 12,
   })
-  assert.equal(synthetic, 'streaming-chat-1')
+  assert.equal(appendAlias, 'assistant-12')
   assert.equal(chooseActiveAssistantDataKey({
-    latched: { key: synthetic, mirrorKey: null },
+    latched: { key: appendAlias, mirrorKey: null },
     mirroredMsg: { role: 'assistant', ts: 9 },
     mirrorIndex: 2,
     hasLivePayload: true,
-    chatId: 'chat-1',
-  }), synthetic, 'live-first DB adoption must keep the mounted synthetic anchor')
+    appendIndex: 12,
+  }), appendAlias, 'live-first DB adoption must keep the mounted append-position anchor')
 
   const dbFirst = chooseActiveAssistantDataKey({
     latched: null,
     mirroredMsg: { role: 'assistant', ts: 9 },
     mirrorIndex: 2,
     hasLivePayload: false,
-    chatId: 'chat-1',
+    appendIndex: 12,
   })
   assert.equal(dbFirst, 'assistant-9')
   assert.equal(chooseActiveAssistantDataKey({
@@ -448,7 +449,7 @@ test('active row data-key is latched for both live-first and DB-first source swi
     mirroredMsg: { role: 'assistant', ts: 9 },
     mirrorIndex: 2,
     hasLivePayload: true,
-    chatId: 'chat-1',
+    appendIndex: 12,
   }), dbFirst, 'DB-first bridge must keep its durable anchor when live data wins')
 
   const released = chooseActiveAssistantDataKey({
@@ -456,11 +457,36 @@ test('active row data-key is latched for both live-first and DB-first source swi
     mirroredMsg: null,
     mirrorIndex: -1,
     hasLivePayload: true,
-    chatId: 'chat-1',
+    appendIndex: 12,
   })
-  assert.equal(released, synthetic)
+  assert.equal(released, appendAlias)
   assert.notEqual(released, dbFirst,
     'an unrelated live answer must not duplicate the restored history row data-key')
+})
+
+test('recovered QA keeps one anchor from live row through authoritative persistence', () => {
+  const transcript = [
+    { role: 'assistant', ts: 10, blocks: [{ type: 'question' }] },
+    { role: 'user', ts: 11, cid: 'hidden-answer', hidden: true },
+  ]
+  const liveKey = chooseActiveAssistantDataKey({
+    latched: null,
+    mirroredMsg: null,
+    mirrorIndex: -1,
+    hasLivePayload: true,
+    appendIndex: 12,
+  })
+  const promoted = promoteAssistantStream(transcript, {
+    items: [{ type: 'text', content: 'Recovered answer' }],
+  })
+  assert.equal(messageKey(promoted.at(-1), 12), liveKey,
+    'the optimistic durable row takes over the live positional key')
+
+  const authoritative = { ...promoted.at(-1), ts: 99 }
+  assert.notEqual(messageKey(authoritative, 12), liveKey,
+    'the server timestamp becomes the primary durable identity')
+  assert.equal(assistantAnchorKey(12), liveKey,
+    'the DOM alias still resolves the reader anchor after persistence')
 })
 
 test('text prefix does not hide a persisted tool block when stream lacks it', () => {

--- a/frontend/src/components/ChatView/__tests__/streamingRobustness.test.js
+++ b/frontend/src/components/ChatView/__tests__/streamingRobustness.test.js
@@ -46,10 +46,14 @@ test('R6: answering in-process keeps the active bridge through settlement', () =
   const end = chatViewSource.indexOf('\n  function handleSubmit', start)
   const answerPath = chatViewSource.slice(start, end)
   const sendIndex = answerPath.indexOf('const response = await streamSend')
-  const retireIndex = answerPath.indexOf('if (!answerKeepsCurrentTurn(response))')
+  const ownershipIndex = answerPath.indexOf(
+    'const keepsCurrentTurn = answerKeepsCurrentTurn(response)',
+  )
+  const retireIndex = answerPath.indexOf('if (!keepsCurrentTurn)', ownershipIndex)
   const markIndex = answerPath.indexOf('bridgeHook.markBridged()', retireIndex)
 
-  assert.ok(sendIndex >= 0 && retireIndex > sendIndex && markIndex > retireIndex,
+  assert.ok(sendIndex >= 0 && ownershipIndex > sendIndex
+    && retireIndex > ownershipIndex && markIndex > retireIndex,
     'the bridge may retire only after the backend says recovery started a new turn')
   assert.doesNotMatch(answerPath.slice(0, sendIndex), /bridgeHook\.markBridged\(\)/,
     'an in-process answer must not retire the same-turn bridge before its POST result')

--- a/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
+++ b/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
@@ -614,6 +614,26 @@ test('anchor reapply fires when the anchor row shifted since the last apply', ()
   )
 })
 
+test('a promoted assistant still resolves its live transcript-position alias', () => {
+  const row = { offsetTop: 1000 }
+  const scrollEl = {
+    scrollHeight: 2000,
+    scrollTop: 500,
+    clientHeight: 700,
+    querySelector(selector) {
+      return selector === '[data-anchor-key="assistant-12"]' ? row : null
+    },
+  }
+
+  assert.equal(_anchorReapplyNeeded(
+    scrollEl,
+    { kind: 'ANCHOR_AT', key: 'assistant-12', offset: 40 },
+    1000,
+  ), true, 'terminal layout can repair the held viewport through the alias')
+  applyMode(scrollEl, { kind: 'ANCHOR_AT', key: 'assistant-12', offset: 40 })
+  assert.equal(scrollEl.scrollTop, 960)
+})
+
 test('anchor reapply fires when scrollTop was clamped short but the target is now reachable', () => {
   // target = 1000 - 40 = 960; maxScrollTop = 2000 - 700 = 1300 ≥ 960 reachable;
   // scrollTop 500 < 960 → clamped short.

--- a/frontend/src/components/ChatView/streamPromotion.js
+++ b/frontend/src/components/ChatView/streamPromotion.js
@@ -4,6 +4,7 @@
  * stream becomes blocks/content and how an in-flight DB partial is replaced.
  */
 
+import { assistantAnchorKey } from '../../lib/chatDetailCache.js'
 import { questionKey } from './questionKey.js'
 
 export function streamItemToBlock(item, { finalize = true } = {}) {
@@ -319,31 +320,34 @@ export function chooseActiveAssistantMirrorIndex({
 
 
 // The first mounted active row owns the scroll-anchor key for its lifetime.
-// DB-first bridge answers seed from the durable row; live-first answers seed a
-// synthetic turn key and must not adopt a later DB partial's key, because both
-// React reconciliation and ANCHOR_AT resolve through this identity.
+// DB-first bridge answers seed from the durable row; live-first answers seed
+// from the absolute transcript position their durable row will occupy. That
+// positional alias remains available after persistence gives the row a server
+// timestamp, so ANCHOR_AT survives terminal promotion instead of losing its
+// target at exactly the moment final layout settles.
 export function chooseActiveAssistantDataKey({
   latched,
   mirroredMsg,
   mirrorIndex,
   hasLivePayload,
-  chatId,
+  appendIndex,
 }) {
   const mirroredKey = mirroredMsg?.role === 'assistant' && !mirroredMsg.hidden
     ? (mirroredMsg.id || `${mirroredMsg.role}-${mirroredMsg.ts ?? mirrorIndex}`)
     : null
+  const appendedKey = assistantAnchorKey(appendIndex)
   if (latched?.key) {
     // A DB-seeded key is valid only while that row still mirrors the active
     // answer. If surface selection releases it as unrelated, the restored
     // history row owns the durable key and the live answer needs a distinct
-    // synthetic anchor. A live-first latch is intentionally retained when it
-    // later adopts a related DB mirror.
+    // append-position anchor. A live-first latch is intentionally retained
+    // when it later adopts a related DB mirror.
     if (latched.mirrorKey && latched.mirrorKey !== mirroredKey) {
-      return mirroredKey || (hasLivePayload ? `streaming-${chatId}` : latched.key)
+      return mirroredKey || (hasLivePayload ? appendedKey : latched.key)
     }
     return latched.key
   }
-  return mirroredKey || `streaming-${chatId}`
+  return mirroredKey || appendedKey
 }
 
 export function findTrailingAssistantPartialIndex(messages) {

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -543,6 +543,7 @@ function _anchorRow(scrollEl, key) {
   if (!scrollEl || key == null) return null
   const esc = (typeof CSS !== 'undefined' && CSS.escape) ? CSS.escape(key) : key
   return scrollEl.querySelector(`[data-key="${esc}"]`)
+    || scrollEl.querySelector(`[data-anchor-key="${esc}"]`)
     || scrollEl.querySelector(`[data-cid="${esc}"]`)
 }
 

--- a/frontend/src/lib/chatDetailCache.js
+++ b/frontend/src/lib/chatDetailCache.js
@@ -14,6 +14,11 @@ export function messageKey(message, index = 0) {
   return `${message.role}-${message.ts ?? index}`
 }
 
+/** The one pre-persistence address shared by a live assistant and its row. */
+export function assistantAnchorKey(index) {
+  return `assistant-${index}`
+}
+
 /** True when a durable address names this row through any identity the row
  * has carried. The primary DOM key stays id-first for existing positions;
  * cid and role/timestamp aliases bridge optimistic and legacy lifetimes. */
@@ -47,6 +52,11 @@ export function chatCacheCanPaint(
   const baseOffset = Number.isInteger(cached.offset) ? cached.offset : 0
   return cached.messages.some((message, index) => (
     messageKey(message, baseOffset + index) === String(savedAnchorKey)
+    || (
+      message?.role === 'assistant'
+      && !message.hidden
+      && assistantAnchorKey(baseOffset + index) === String(savedAnchorKey)
+    )
     || (
       message?.role === 'user'
       && !message.hidden


### PR DESCRIPTION
## Summary

- keep recovered question answers in transcript order before the resumed reply streams
- give live-first assistant rows a stable positional anchor that survives persistence
- restore saved reading positions through that anchor after final layout settles

## Testing

- focused ChatView tests (125 passed)
- production frontend build