### PR TITLE
Prefer live provider model labels

### DIFF
--- a/backend/app/codex_events.py
+++ b/backend/app/codex_events.py
@@ -16,7 +16,6 @@ from typing import Any
 
 from app.codex_appserver import _extract_bash_command
 from app.json_safety import json_safe
-from app.providers import MODEL_LABELS
 from app.tool_sources import normalize_tool_sources
 
 log = logging.getLogger("moebius.chat")
@@ -763,9 +762,8 @@ def _codex_user_error(error_text: str | None) -> str | None:
   if match is None:
     return error_text
   model_id = match.group("model")
-  model_name = MODEL_LABELS.get(model_id, model_id)
   return (
-    f"{model_name} isn’t available for this ChatGPT account. Codex is "
+    f"{model_id} isn’t available for this ChatGPT account. Codex is "
     "connected, but this account’s current plan or model rollout does not "
     "include it. Choose another Codex model from this chat’s Model menu, "
     "then try again."

--- a/backend/app/providers.py
+++ b/backend/app/providers.py
@@ -78,31 +78,6 @@ KNOWN_MODELS = {
 }
 
 
-# Human-readable label for model IDs we know how to polish. Live
-# registry calls return raw IDs without consistent UI metadata
-# (Anthropic's /v1/models returns `id` + a generic `display_name`;
-# Codex's models() returns slugs only), so labels come from this map
-# when present and fall back to the raw ID for newly released models.
-MODEL_LABELS: dict[str, str] = {
-  "claude-fable-5": "Fable 5",
-  "claude-sonnet-5": "Sonnet 5",
-  "claude-opus-4-8": "Opus 4.8",
-  "claude-opus-4-7": "Opus 4.7",
-  "claude-opus-4-6": "Opus 4.6",
-  "claude-opus-4-5-20251001": "Opus 4.5",
-  "claude-sonnet-4-6": "Sonnet 4.6",
-  "claude-sonnet-4-7-20251215": "Sonnet 4.7",
-  "claude-sonnet-4-5-20251001": "Sonnet 4.5",
-  "claude-haiku-4-5-20251001": "Haiku 4.5",
-  "gpt-5.6-sol": "GPT-5.6 Sol",
-  "gpt-5.6-terra": "GPT-5.6 Terra",
-  "gpt-5.6-luna": "GPT-5.6 Luna",
-  "gpt-5.5": "gpt-5.5",
-  "gpt-5.4": "gpt-5.4",
-  "gpt-5.4-mini": "gpt-5.4 mini",
-  "gpt-5.3-codex-spark": "GPT-5.3 Codex Spark",
-}
-
 # Optional model-specific effort capability overrides. Provider defaults remain
 # the fallback, so adding a new model normally needs no entry. Add a row only
 # when a model supports a narrower, reordered, or extended effort scale; the
@@ -869,12 +844,6 @@ _model_registry_locks: dict[str, asyncio.Lock] = {
 }
 
 
-def _label_for(model_id: str) -> str:
-  """Returns the human-readable label for `model_id`, falling back
-  to the raw ID when the model isn't in MODEL_LABELS."""
-  return MODEL_LABELS.get(model_id, model_id)
-
-
 def _fallback_models(provider_id: str) -> list[dict[str, Any]]:
   """Returns the KNOWN_MODELS list for `provider_id` as registry
   entries. Used when the upstream fetch fails. `available` is set
@@ -884,7 +853,7 @@ def _fallback_models(provider_id: str) -> list[dict[str, Any]]:
   return [
     {
       "id": mid,
-      "label": _label_for(mid),
+      "label": mid,
       "provider": provider_id,
       "available": True,
       **({"effort_levels": MODEL_EFFORT_LEVELS[mid]}
@@ -900,10 +869,11 @@ def _live_model_entries(
   """Wrap live provider models as registry entries.
 
   Static KNOWN_MODELS is only the failure fallback. When a live fetch
-  succeeds, the provider SDK/CLI is the source of truth; labels are a
-  cosmetic map with raw-ID fallback. Providers may return plain IDs or
-  lightweight ``{id, effort_levels}`` entries; the latter lets Codex carry its
-  live model-specific effort scale without teaching the frontend model names.
+  succeeds, the provider SDK/CLI is the source of truth. Providers may return
+  plain IDs or lightweight metadata dictionaries. Anthropic supplies a
+  human-readable label; Codex supplies each model's effort scale. Entries
+  without a provider label use their raw model ID rather than a second naming
+  catalog.
   """
   live_by_id: dict[str, dict[str, Any]] = {}
   for raw in live_models:
@@ -926,7 +896,14 @@ def _live_model_entries(
   return [
     {
       "id": mid,
-      "label": _label_for(mid),
+      "label": (
+        live_by_id[mid]["label"].strip()
+        if (
+          isinstance(live_by_id.get(mid, {}).get("label"), str)
+          and live_by_id[mid]["label"].strip()
+        )
+        else mid
+      ),
       "provider": provider_id,
       "available": True,
       **(
@@ -1152,7 +1129,7 @@ def codex_subscription_type(data_dir: str) -> str | None:
   return value if isinstance(value, str) and value.strip() else None
 
 
-async def _fetch_claude_models(data_dir: str) -> list[str]:
+async def _fetch_claude_models(data_dir: str) -> list[dict[str, str]]:
   """Calls Anthropic's /v1/models with the stored OAuth access token.
 
   Raises on any non-2xx or missing credentials so the caller can fall
@@ -1180,12 +1157,19 @@ async def _fetch_claude_models(data_dir: str) -> list[str]:
     )
     resp.raise_for_status()
     payload = resp.json()
-  ids: list[str] = []
+  models: list[dict[str, str]] = []
   for entry in payload.get("data", []):
+    if not isinstance(entry, dict):
+      continue
     mid = entry.get("id")
-    if isinstance(mid, str):
-      ids.append(mid)
-  return ids
+    if not isinstance(mid, str):
+      continue
+    model = {"id": mid}
+    display_name = entry.get("display_name")
+    if isinstance(display_name, str) and display_name.strip():
+      model["label"] = display_name.strip()
+    models.append(model)
+  return models
 
 
 def _codex_model_slug(entry: Any) -> str | None:

--- a/backend/requirements.lock
+++ b/backend/requirements.lock
@@ -427,13 +427,13 @@ charset-normalizer==3.4.9 \
     --hash=sha256:fa36ec09ef71d158186bc79e359ff5fdd6e7996fe8ab638f00d6b93139ba4fcf \
     --hash=sha256:fe2c7201c642b7c308f1675355ad7ff7b66acfe3541625efe5a3ad38f29d6115
     # via requests
-claude-agent-sdk==0.2.126 \
-    --hash=sha256:201299609bb045e7ca8c7d3ff5e8d5900da2dcf3faad742990efe659e4c215ae \
-    --hash=sha256:239e6073486488ce78fe88681c05e819562f5c5e567f02574492c3be3d35684b \
-    --hash=sha256:79caa03c6612e268bee93e95170d6b9ffdfa4bb21373a2e9ba7a439d3fb2e8e8 \
-    --hash=sha256:8dd73c1a193afa133241d7346e89e5b60ebf45f6a8f2cc38c84c8aad794af61e \
-    --hash=sha256:b0077f8da92f402032ec91b27499eb896aa97a9d78150ccd4a7840d39e70b9de \
-    --hash=sha256:edac88522b6fca74f1a84aa0d0f29caad4adda8aed04c3f08b86836e06c6c271
+claude-agent-sdk==0.2.128 \
+    --hash=sha256:2ac7b2b3bc56ae9037fd284c8690d3dafab9493ecd28d8974bba79a418e1b800 \
+    --hash=sha256:2e47ee95be68cb07612fd5288a40f3307763da5a5adf66d6e03ea49dc0495c9c \
+    --hash=sha256:37b87c8e75daa2a6dc74da6d788e0981a2e5e3a6be80cfa4c287abce2bf70e0b \
+    --hash=sha256:55e8fa28918af5620f391692efe80527ad9f2294cec14dadeea93c5161dbefc4 \
+    --hash=sha256:6c10cc1c5403b2b0b3d8deb79ad5271a8e49b9db6460193599b91f49f16b4cf7 \
+    --hash=sha256:cc4a0f20337e227fe16f00edf7cbe109349707adb440fe51ca6c44f9f8d7d21a
     # via -r requirements.txt
 click==8.4.2 \
     --hash=sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6 \

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,7 +14,7 @@ pywebpush>=2.0.0
 pytest>=8.0
 pytest-asyncio>=0.23
 watchdog>=4.0.0
-claude-agent-sdk==0.2.126
+claude-agent-sdk==0.2.128
 # openai-codex is installed --no-deps from a pinned Git SHA in Dockerfile.
 # Its declared cli-bin package is retained for SDK compatibility, but its
 # duplicate payload is replaced in-layer with a link to the pinned npm CLI.

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -546,7 +546,7 @@ def test_providers_models_returns_known_models_on_missing_creds(
   assert set(codex_ids) == DEFAULT_VISIBLE_MODELS["codex"]
   # Claude rows carry a tier derived from the id.
   by_id = {m["id"]: m for m in body["claude"]}
-  assert by_id["claude-opus-4-8"]["name"] == "Opus 4.8"
+  assert by_id["claude-opus-4-8"]["name"] == "claude-opus-4-8"
   assert by_id["claude-opus-4-8"]["tier"] == "opus"
   assert by_id["claude-sonnet-4-6"]["tier"] == "sonnet"
   # Codex rows intentionally omit `tier` — the field doesn't apply.

--- a/backend/tests/test_codex_sdk_runner.py
+++ b/backend/tests/test_codex_sdk_runner.py
@@ -2694,7 +2694,7 @@ def test_chatgpt_model_rejection_explains_connection_and_recovery():
   message = codex_sdk_runner._codex_user_error(error)
 
   assert message == (
-    "GPT-5.6 Sol isn’t available for this ChatGPT account. Codex is "
+    "gpt-5.6-sol isn’t available for this ChatGPT account. Codex is "
     "connected, but this account’s current plan or model rollout does not "
     "include it. Choose another Codex model from this chat’s Model menu, "
     "then try again."

--- a/backend/tests/test_model_registry.py
+++ b/backend/tests/test_model_registry.py
@@ -271,15 +271,20 @@ async def test_fetch_claude_models_uses_refreshed_token(tmp_path, monkeypatch):
     # /v1/models — must carry the refreshed token, else 401.
     assert request.headers["authorization"] == "Bearer live-tok"
     return httpx.Response(200, json={"data": [
-      {"id": "claude-opus-4-8"},
-      {"id": "claude-some-future-model"},
+      {"id": "claude-opus-4-8", "display_name": "Claude Opus 4.8"},
+      {
+        "id": "claude-some-future-model",
+        "display_name": "Claude Future Model",
+      },
     ]})
 
   _install_mock_transport(monkeypatch, handler)
 
-  ids = await providers._fetch_claude_models(str(tmp_path))
-  assert "claude-opus-4-8" in ids
-  assert "claude-some-future-model" in ids
+  live_models = await providers._fetch_claude_models(str(tmp_path))
+  assert live_models == [
+    {"id": "claude-opus-4-8", "label": "Claude Opus 4.8"},
+    {"id": "claude-some-future-model", "label": "Claude Future Model"},
+  ]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -735,9 +735,9 @@ def test_model_registry_returns_known_models_on_missing_creds(client, auth):
   assert claude_ids == KNOWN_MODELS["claude"]
   codex_ids = [m["id"] for m in body["providers"]["codex"]]
   assert codex_ids == KNOWN_MODELS["codex"]
-  # Labels carry through from MODEL_LABELS.
+  # Offline fallbacks use the exact model id; live catalogs own display names.
   by_id = {m["id"]: m for m in body["providers"]["claude"]}
-  assert by_id["claude-opus-4-8"]["label"] == "Opus 4.8"
+  assert by_id["claude-opus-4-8"]["label"] == "claude-opus-4-8"
   # The user-facing API contract is `available=true` on every fallback
   # entry, but the route layer relies on Pydantic's `ModelEntry`
   # default to fill that field. Verify the underlying helper directly
@@ -964,6 +964,21 @@ def test_live_model_entries_float_curated_defaults_in_requested_order():
     "claude-sonnet-4-6",
     "claude-future-model",
   ]
+
+
+def test_live_model_entries_prefer_provider_display_names():
+  from app import providers
+
+  entries = providers._live_model_entries(
+    "claude",
+    [
+      {"id": "claude-opus-4-8", "label": "Claude Opus 4.8"},
+      {"id": "claude-opus-5", "label": "Claude Opus 5"},
+    ],
+  )
+  by_id = {entry["id"]: entry for entry in entries}
+  assert by_id["claude-opus-4-8"]["label"] == "Claude Opus 4.8"
+  assert by_id["claude-opus-5"]["label"] == "Claude Opus 5"
 
 
 def test_live_model_entries_carry_provider_effort_metadata():

--- a/backend/tests/test_verify_test_runtime.py
+++ b/backend/tests/test_verify_test_runtime.py
@@ -158,8 +158,8 @@ def test_image_deduplicates_agent_cli_payloads_without_breaking_sdk_contracts():
     "pip install --no-cache-dir --require-hashes -r requirements.lock"
     in requirements_layer
   )
-  assert "claude-agent-sdk==0.2.126" in requirements
-  assert "claude-agent-sdk==0.2.126" in requirements_lock
+  assert "claude-agent-sdk==0.2.128" in requirements
+  assert "claude-agent-sdk==0.2.128" in requirements_lock
   assert (
     'Path(claude_agent_sdk.__file__).parent / "_bundled" / "claude"'
     in requirements_layer

--- a/frontend/src/components/ChatView/__tests__/providerModelFallbacks.test.js
+++ b/frontend/src/components/ChatView/__tests__/providerModelFallbacks.test.js
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  CLAUDE_MODELS,
+  CODEX_MODELS,
+} from '../../ProviderModelPicker/ProviderModelPicker.jsx'
+
+test('provider model fallbacks do not maintain a second display-name catalog', () => {
+  for (const model of [...CLAUDE_MODELS, ...CODEX_MODELS]) {
+    assert.equal(model.label, model.value)
+  }
+})

--- a/frontend/src/components/ProviderModelPicker/ProviderModelPicker.jsx
+++ b/frontend/src/components/ProviderModelPicker/ProviderModelPicker.jsx
@@ -8,35 +8,38 @@
  * The component code is gone; only fallback rows remain.
  */
 
-/** Fallback models per provider. Add here when a new default fallback lands; the value
- *  is what gets passed to ClaudeAgentOptions(model=...) / Codex thread.start.
+/** Fallback model IDs used only before `/api/models` resolves or when live
+ *  discovery is unavailable. Providers own display names; raw IDs are the
+ *  honest fallback instead of a second hand-maintained naming catalog.
  *
  *  Anthropic switched to dateless pinned IDs starting with the 4.6 generation —
  *  `claude-opus-4-8` IS the pinned snapshot, no date suffix exists. Dated entries
  *  for older generations stay listed so existing chats that persisted them in
  *  agent_settings_json keep resolving (the API treats them as aliases). */
-export const CLAUDE_MODELS = [
-  { value: 'claude-fable-5', label: 'Fable 5' },
-  { value: 'claude-sonnet-5', label: 'Sonnet 5' },
-  { value: 'claude-opus-4-8', label: 'Opus 4.8' },
-  { value: 'claude-opus-4-7', label: 'Opus 4.7' },
-  { value: 'claude-opus-4-6', label: 'Opus 4.6' },
-  { value: 'claude-opus-4-5-20251001', label: 'Opus 4.5' },
-  { value: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
-  { value: 'claude-sonnet-4-7-20251215', label: 'Sonnet 4.7' },
-  { value: 'claude-sonnet-4-5-20251001', label: 'Sonnet 4.5' },
-  { value: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5' },
-]
+const rawFallbackModels = (ids) => ids.map((value) => ({ value, label: value }))
 
-export const CODEX_MODELS = [
+export const CLAUDE_MODELS = rawFallbackModels([
+  'claude-fable-5',
+  'claude-sonnet-5',
+  'claude-opus-4-8',
+  'claude-opus-4-7',
+  'claude-opus-4-6',
+  'claude-opus-4-5-20251001',
+  'claude-sonnet-4-6',
+  'claude-sonnet-4-7-20251215',
+  'claude-sonnet-4-5-20251001',
+  'claude-haiku-4-5-20251001',
+])
+
+export const CODEX_MODELS = rawFallbackModels([
   // The live `/api/models` registry is the source of truth. These
   // fallback rows mirror the current Codex CLI catalog for first paint
   // and registry-failure cases.
-  { value: 'gpt-5.6-sol', label: 'GPT-5.6 Sol' },
-  { value: 'gpt-5.6-terra', label: 'GPT-5.6 Terra' },
-  { value: 'gpt-5.6-luna', label: 'GPT-5.6 Luna' },
-  { value: 'gpt-5.5', label: 'gpt-5.5' },
-  { value: 'gpt-5.4', label: 'gpt-5.4' },
-  { value: 'gpt-5.4-mini', label: 'gpt-5.4 mini' },
-  { value: 'gpt-5.3-codex-spark', label: 'GPT-5.3 Codex Spark' },
-]
+  'gpt-5.6-sol',
+  'gpt-5.6-terra',
+  'gpt-5.6-luna',
+  'gpt-5.5',
+  'gpt-5.4',
+  'gpt-5.4-mini',
+  'gpt-5.3-codex-spark',
+])


### PR DESCRIPTION
## Summary

- preserve provider-supplied human-readable model labels when available
- keep static labels as offline and compatibility fallbacks
- update the Claude Agent SDK lock to 0.2.128

## Testing

- 96 focused backend tests