### PR TITLE
Speed up cold chat entry and stream resume

### DIFF
--- a/backend/app/chat_event_sink.py
+++ b/backend/app/chat_event_sink.py
@@ -92,6 +92,22 @@ def get_active_sink(chat_id: str) -> "ChatEventSink | None":
   return _active_sinks.get(chat_id)
 
 
+def active_sink_stream_snapshot(chat_id: str, broadcast) -> list[dict] | None:
+  """Freeze the current assistant items for one snapshot-capable subscriber.
+
+  The sink is the reduction authority for a running turn: every content event
+  reaches ``assistant_blocks`` before it reaches the broadcast.  Pairing by
+  broadcast identity prevents a late sink from seeding a successor turn (or a
+  successor sink from seeding a completed broadcast during teardown). ``None``
+  means the caller must use ordinary event-log replay; an empty list is a valid
+  live snapshot before the assistant has produced its first item.
+  """
+  sink = get_active_sink(chat_id)
+  if sink is None or sink.bc is not broadcast:
+    return None
+  return copy.deepcopy(sink.assistant_blocks)
+
+
 def unregister_active_sink(chat_id: str, sink: "ChatEventSink") -> None:
   """Drop the live sink for `chat_id`, identity-keyed.
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -517,6 +517,7 @@ app.add_middleware(
     "Authorization",
     "Content-Type",
     "X-Mobius-Embed-Instance",
+    "X-Mobius-Stream-Snapshot",
     "X-Mobius-Version",
     "If-Match",
     "If-None-Match",

--- a/backend/app/routes/chats_stream.py
+++ b/backend/app/routes/chats_stream.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 
 from app import activity, models, questions, schemas
 from app.broadcast import create_broadcast, get_broadcast, get_system_broadcast
+from app.chat_event_sink import active_sink_stream_snapshot
 from app.chat import (
   _schedule_continuation,
   discard_starting,
@@ -55,6 +56,23 @@ log = logging.getLogger(__name__)
 
 # Keepalive interval for the SSE stream to prevent proxy timeouts.
 _KEEPALIVE_INTERVAL = 30  # seconds
+
+# A server-owned assistant snapshot already contains every content-bearing
+# event reduced by ChatEventSink. These few replay-safe control facts live
+# outside that block list and remain necessary when a reconnect skips the full
+# content log. They are replay-safe by contract: cumulative, idempotent by
+# identity, or a durable transcript boundary that tells the client to refresh.
+_SNAPSHOT_REPLAY_EVENT_TYPES = frozenset({
+  "answers_applied",
+  "app_updated",
+  "build_phase",
+  "chat_run_finished",
+  "chat_run_started",
+  "queued_turn_starting",
+  "steer_delivery_failed",
+  "steered_into_turn",
+  "theme_updated",
+})
 
 
 def _message_persist_unavailable(exc: Exception, *, chat_id: str) -> HTTPException:
@@ -1125,14 +1143,17 @@ async def cancel_pending_message(
 async def stream_chat(
   request: Request,
   chat_id: str,
+  snapshot: bool = False,
   principal: Principal = Depends(get_chat_view_principal),
   db: Session = Depends(get_db),
 ):
   """SSE endpoint: subscribes to the chat's broadcast and streams events.
 
-  Sends a catch-up burst of all prior events, then streams live events
-  until the broadcast is completed or the client disconnects.  Keepalive
-  comments are sent every 30 s to prevent proxy timeouts.
+  Snapshot-capable clients receive the live sink's current assistant items plus
+  the small set of replay-safe control facts that are not represented there;
+  older clients receive the full prior event log. Both then stream only new
+  events until completion or disconnect. Keepalive comments are sent every
+  30 s to prevent proxy timeouts.
 
   Same actor gate as send_message: owner streams any chat; an app token
   streams only a chat it created (403 otherwise). The ownership check
@@ -1180,6 +1201,14 @@ async def stream_chat(
     # the queue with no await in between), so the catch-up burst still
     # captures exactly the events present when this subscriber attaches.
     catch_up, queue = bc.subscribe()
+    snapshot_items = (
+      active_sink_stream_snapshot(chat_id, bc) if snapshot else None
+    )
+    if snapshot_items is not None:
+      catch_up = [
+        event for event in catch_up
+        if event.get("type") in _SNAPSHOT_REPLAY_EVENT_TYPES
+      ]
     last_embed_auth_check = 0.0
 
     def embed_session_active() -> bool:
@@ -1194,6 +1223,8 @@ async def stream_chat(
     try:
       if not embed_session_active():
         return
+      if snapshot_items is not None:
+        yield _sse({"type": "stream_snapshot", "items": snapshot_items})
       # Send all events buffered before this client connected.
       has_done = False
       for event in catch_up:

--- a/backend/app/routes/chats_stream.py
+++ b/backend/app/routes/chats_stream.py
@@ -6,7 +6,7 @@ import logging
 import time
 from pathlib import Path as FilePath
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, Header, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 from starlette.responses import Response
 from sqlalchemy.orm import Session
@@ -1143,7 +1143,7 @@ async def cancel_pending_message(
 async def stream_chat(
   request: Request,
   chat_id: str,
-  snapshot: bool = False,
+  snapshot: bool = Header(False, alias="X-Mobius-Stream-Snapshot"),
   principal: Principal = Depends(get_chat_view_principal),
   db: Session = Depends(get_db),
 ):

--- a/backend/tests/test_security_headers.py
+++ b/backend/tests/test_security_headers.py
@@ -373,6 +373,22 @@ def test_opaque_embed_preflight_allows_scoped_instance_header():
   assert "x-mobius-embed-instance" in allowed
 
 
+def test_opaque_embed_preflight_allows_stream_snapshot_header():
+  response = TestClient(app).options(
+    "/api/chats/exact-chat/stream",
+    headers={
+      "Origin": "null",
+      "Access-Control-Request-Method": "GET",
+      "Access-Control-Request-Headers": (
+        "authorization,x-mobius-embed-instance,x-mobius-stream-snapshot"
+      ),
+    },
+  )
+  assert response.status_code == 200
+  allowed = response.headers["access-control-allow-headers"].lower()
+  assert "x-mobius-stream-snapshot" in allowed
+
+
 def test_opaque_app_preflight_allows_versioned_storage_requests():
   """Sandboxed apps can perform the runtime's versioned read/write flow.
 

--- a/backend/tests/test_system_broadcast.py
+++ b/backend/tests/test_system_broadcast.py
@@ -39,6 +39,12 @@ from app.broadcast import (
 )
 from app.chat_writer import Barrier, get_writer
 from app.chat_transcript import materialized_messages
+from app.chat_event_sink import (
+  ChatEventSink,
+  active_sink_stream_snapshot,
+  register_active_sink,
+  unregister_active_sink,
+)
 from app.deps import Principal
 from app.routes.notify import NotifyBody
 from app.memory_recall import EMPTY_RECALL_BINDING
@@ -101,6 +107,29 @@ def test_chat_broadcast_fans_out_to_phone_and_web_subscribers():
   assert phone.get_nowait() == event
   assert web.get_nowait() == event
   assert len(bc.subscribers) == 2
+
+
+def test_active_sink_snapshot_is_frozen_and_broadcast_identity_keyed():
+  bc = ChatBroadcast("snapshot-chat")
+  sink = ChatEventSink(
+    bc,
+    bc.chat_id,
+    recall_binding=EMPTY_RECALL_BINDING,
+  )
+  sink.assistant_blocks = [{"type": "text", "content": "hello"}]
+  register_active_sink(bc.chat_id, sink)
+  try:
+    snapshot = active_sink_stream_snapshot(bc.chat_id, bc)
+    assert snapshot == sink.assistant_blocks
+    assert snapshot is not sink.assistant_blocks
+    snapshot[0]["content"] = "changed by subscriber"
+    assert sink.assistant_blocks[0]["content"] == "hello"
+    assert active_sink_stream_snapshot(
+      bc.chat_id,
+      ChatBroadcast(bc.chat_id),
+    ) is None
+  finally:
+    unregister_active_sink(bc.chat_id, sink)
 
 
 def test_task_progress_coalesces_by_task_id_in_log():
@@ -824,5 +853,63 @@ async def test_stream_generator_unsubscribes_after_finally_runs(db, chat):
     assert len(bc.subscribers) == baseline, (
       "the generator finished but its finally never unsubscribed — leak"
     )
+  finally:
+    bc_mod._broadcasts.pop(bc.chat_id, None)
+
+
+@pytest.mark.asyncio
+async def test_snapshot_stream_sends_reduced_items_plus_control_tail(
+  db, chat, monkeypatch,
+):
+  """A snapshot client must not replay the content event log it replaces.
+
+  The subscribe boundary still owns ordering: the frozen sink items arrive
+  first, replay-safe control facts follow, then ``catch_up_done`` separates
+  every event that was queued after subscribe.
+  """
+  from app.routes import chats_stream as stream_mod
+
+  bc = ChatBroadcast(chat.id)
+  bc.publish({"type": "text", "content": "old delta"})
+  bc.publish({"type": "tool_start", "tool": "Bash", "tool_use_id": "u1"})
+  bc.publish({"type": "build_phase", "phase": "rebuilding"})
+  bc.publish({"type": "answers_applied", "question_id": "q1", "answers": {}})
+  bc.publish({"type": "steered_into_turn", "ts": 4, "content": "follow up"})
+  bc.running = False
+  bc_mod._broadcasts[bc.chat_id] = bc
+  snapshot_items = [
+    {"type": "text", "content": "complete answer", "text_item_id": "t1"},
+    {"type": "tool", "tool": "Bash", "status": "running", "tool_use_id": "u1"},
+  ]
+  monkeypatch.setattr(
+    stream_mod,
+    "active_sink_stream_snapshot",
+    lambda chat_id, broadcast: snapshot_items
+      if chat_id == chat.id and broadcast is bc else None,
+  )
+  try:
+    resp = await stream_mod.stream_chat(
+      request=_NeverDisconnectedRequest(),
+      chat_id=bc.chat_id,
+      snapshot=True,
+      principal=Principal(owner=db.query(models.Owner).one(), app_id=None),
+      db=db,
+    )
+    chunks = [chunk async for chunk in resp.body_iterator]
+    payloads = [
+      json.loads(line.removeprefix("data: "))
+      for chunk in chunks
+      for line in chunk.splitlines()
+      if line.startswith("data: ")
+    ]
+
+    assert payloads[0] == {"type": "stream_snapshot", "items": snapshot_items}
+    replay_types = [event.get("type") for event in payloads]
+    assert "build_phase" in replay_types
+    assert "answers_applied" in replay_types
+    assert "steered_into_turn" in replay_types
+    assert "text" not in replay_types
+    assert "tool_start" not in replay_types
+    assert replay_types[-2:] == ["catch_up_done", "done"]
   finally:
     bc_mod._broadcasts.pop(bc.chat_id, None)

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -64,7 +64,7 @@ import { shouldDismissComposerKeyboardOnSubmit } from './composerKeyboardPolicy.
 import { updateChatRuntimeCache } from './chatRuntimeCache.js'
 import {
   assistantAnchorKey,
-  chatCacheCanPaint,
+  chatCacheEntryState,
   chatDetailCacheValue,
   chatSnapshotMatchesRuntime,
   mergeRecentMessagesIntoLoadedWindow,
@@ -319,15 +319,28 @@ export default function ChatView({
   // the reader's saved coordinate; an incomplete restoration window stays
   // hidden until the anchor-addressed read repairs or retires that coordinate.
   const initialSavedAnchorKey = savedReadingAnchorKey(chatId)
-  const initialCachePaintable = chatCacheCanPaint(
+  const initialCacheEntryState = chatCacheEntryState(
     cached,
     initialSavedAnchorKey,
     savedReadingAnchorHasNestedPart(chatId),
   )
-  const [loading, setLoading] = useState(!initialCachePaintable)
+  const [loading, setLoading] = useState(initialCacheEntryState === 'missing')
   const [initialEntryPhase, setInitialEntryPhase] = useState(
-    initialCachePaintable ? 'cached' : 'history',
+    initialCacheEntryState === 'paintable'
+      ? 'cached'
+      : initialCacheEntryState === 'validating'
+        ? 'cache-validating'
+        : 'history',
   )
+  const acceptCachedReadingCoordinate = useCallback(() => {
+    // The scroll owner has proved the exact nested part against the committed
+    // cached DOM. Admit the same quiet-layout reveal path as an ordinary safe
+    // cache without waiting for the independent freshness handshake.
+    setInitialEntryPhase(current => (
+      current === 'cache-validating' ? 'cached' : current
+    ))
+    setLoading(false)
+  }, [])
   // On a failed initial /chats/{id} fetch, loadError flips in the catch so
   // the UI can render a retry message. Setting loading false alone would
   // render the empty-state UI ("What's on your mind?") as if the chat had no
@@ -719,6 +732,7 @@ export default function ChatView({
     pendingMessagesLength: pendingQueue.pendingMessages.length,
     loadingOlderRef: loadingOlder,
     initialEntryPhase,
+    onCachedCoordinateReady: acceptCachedReadingCoordinate,
     ownsReadingPosition: !hidden,
   })
 
@@ -1670,7 +1684,7 @@ export default function ChatView({
     }
     const activationAnchorMatch = anchorMatchIn(activationCache)
     const cacheCoversSavedAnchor = !savedAnchorKey || !!activationAnchorMatch
-    const activationCachePaintable = chatCacheCanPaint(
+    const activationCacheEntryState = chatCacheEntryState(
       activationCache,
       savedAnchorKey,
       savedReadingAnchorHasNestedPart(chatId),
@@ -1678,8 +1692,19 @@ export default function ChatView({
     remapAnchorMatch(activationAnchorMatch)
     chatIdStaleRef.current = false
     setLoadError(false)
-    setLoading(!activationCachePaintable)
-    setInitialEntryPhase(activationCachePaintable ? 'cached' : 'history')
+    setLoading(activationCacheEntryState === 'missing')
+    const activationEntryPhase = activationCacheEntryState === 'paintable'
+      ? 'cached'
+      : activationCacheEntryState === 'validating'
+        ? 'cache-validating'
+        : 'history'
+    setInitialEntryPhase(current => (
+      // Mount-time layout validation can finish before this passive activation
+      // effect runs. Do not re-close a cache gate the scroll owner just proved.
+      activationEntryPhase === 'cache-validating' && current === 'cached'
+        ? current
+        : activationEntryPhase
+    ))
 
     const gen = fetchGenRef.current
     const requestJson = async (path, label) => {

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -83,7 +83,6 @@ import {
   answerKeepsCurrentTurn,
   builtAppPulseDecision,
   canFastForwardQueue,
-  cidOf,
   coldTranscriptRenderFrames,
   continuationRowsFromPromotedMessage,
   isContinuationMessage,
@@ -99,6 +98,7 @@ import {
   stripInternalUserMessageFields,
   systemEventForChat,
 } from './chatRuntimeState.js'
+import { cidOf } from './messageIdentity.js'
 import {
   cidForSendAttempt,
   sendDraftIdentity,

--- a/frontend/src/components/ChatView/QueuedMessages.jsx
+++ b/frontend/src/components/ChatView/QueuedMessages.jsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from 'react'
 import { ChevronDown, DoubleChevronRight, X } from '@openai/apps-sdk-ui/components/Icon'
 import { stripAugmentation } from './msgText.js'
-import { cidOf } from './chatRuntimeState.js'
+import { cidOf } from './messageIdentity.js'
 import {
   pointerSelectionChangedWithin,
   textSelectionSnapshot,

--- a/frontend/src/components/ChatView/__tests__/activityGrouping.test.js
+++ b/frontend/src/components/ChatView/__tests__/activityGrouping.test.js
@@ -1,0 +1,28 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { groupActivityRuns } from '../activityGrouping.js'
+
+const entry = (type, extra = {}) => ({ item: { type, ...extra } })
+
+test('activity grouping preserves interleave and isolates distinctive tools', () => {
+  const thought = entry('thinking')
+  const command = entry('tool', { name: 'exec_command' })
+  const prose = entry('text')
+  const image = entry('tool', { tool: 'Read', input: '/tmp/preview.png' })
+  const tail = entry('tool', { tool: 'Read', input: '/tmp/source.js' })
+
+  assert.deepEqual(groupActivityRuns([
+    thought, command, prose, image, tail,
+  ]), [
+    { group: [thought, command] },
+    { single: prose },
+    { group: [image] },
+    { group: [tail] },
+  ])
+})
+
+test('activity grouping handles empty and non-activity-only input', () => {
+  const question = entry('question')
+  assert.deepEqual(groupActivityRuns([]), [])
+  assert.deepEqual(groupActivityRuns([question]), [{ single: question }])
+})

--- a/frontend/src/components/ChatView/__tests__/chatDetailCache.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatDetailCache.test.js
@@ -2,7 +2,7 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 
 import {
-  chatCacheCanPaint,
+  chatCacheEntryState,
   chatDetailCacheValue,
   chatSnapshotMatchesRuntime,
   mergeRecentMessagesIntoLoadedWindow,
@@ -12,32 +12,34 @@ import {
 } from '../../../lib/chatDetailCache.js'
 
 test('cache first paint requires the saved reading coordinate when one exists', () => {
-  assert.equal(chatCacheCanPaint(null), false)
-  assert.equal(chatCacheCanPaint({ messages: [], offset: 0 }), false,
+  assert.equal(chatCacheEntryState(null), 'missing')
+  assert.equal(chatCacheEntryState({ messages: [], offset: 0 }), 'missing',
     'legacy or previously poisoned cache shapes fail closed')
-  assert.equal(chatCacheCanPaint({
+  assert.equal(chatCacheEntryState({
     restorationWindowComplete: true, messages: [], offset: 0,
-  }), true,
+  }), 'paintable',
     'a complete newly-created empty chat can paint before background refresh')
   const cached = {
     restorationWindowComplete: true,
     offset: 4,
     messages: [{ id: 'server-row', cid: 'client-row', role: 'user', ts: 10 }],
   }
-  assert.equal(chatCacheCanPaint(cached, 'server-row'), true)
-  assert.equal(chatCacheCanPaint(cached, 'client-row'), true,
+  assert.equal(chatCacheEntryState(cached, 'server-row'), 'paintable')
+  assert.equal(chatCacheEntryState(cached, 'client-row'), 'paintable',
     'optimistic-to-server aliases remain valid restoration coordinates')
-  assert.equal(chatCacheCanPaint(cached, 'user-10'), false,
+  assert.equal(chatCacheEntryState(cached, 'user-10'), 'missing',
     'a role/timestamp alias waits for passive canonical remapping')
-  assert.equal(chatCacheCanPaint({
+  assert.equal(chatCacheEntryState({
     restorationWindowComplete: true,
     offset: 4,
     messages: [{ id: 'persisted-answer', role: 'assistant', ts: 12 }],
-  }, 'assistant-4'), true,
+  }, 'assistant-4'), 'paintable',
   'a live-first positional alias survives the authoritative timestamp')
-  assert.equal(chatCacheCanPaint(cached, 'server-row', true), false,
-    'a nested part waits for committed DOM validation')
-  assert.equal(chatCacheCanPaint(cached, 'missing-row'), false,
+  assert.equal(chatCacheEntryState(cached, 'server-row', true), 'validating',
+    'a nested part mounts behind the gate for committed DOM validation')
+  assert.equal(chatCacheEntryState(cached, 'missing-row', true), 'missing',
+    'a nested part cannot validate when its row is absent')
+  assert.equal(chatCacheEntryState(cached, 'missing-row'), 'missing',
     'an incomplete cache stays hidden until the anchor-addressed read settles')
 })
 

--- a/frontend/src/components/ChatView/__tests__/chatRuntimeState.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatRuntimeState.test.js
@@ -151,6 +151,19 @@ test('ordinary cold transcripts keep the one-commit path', () => {
   assert.deepEqual(coldTranscriptRenderFrames(messages), [messages])
 })
 
+test('collapsed activity runs are prepared as the one row they present', () => {
+  const blocks = Array.from({ length: 360 }, (_, index) => ({
+    type: index % 2 === 0 ? 'thinking' : 'tool',
+    ...(index % 2 === 0
+      ? { content: `reasoning ${index}` }
+      : { tool: 'Bash', status: 'done', output: `step ${index}` }),
+  }))
+  const messages = [{ role: 'assistant', ts: 1, blocks }]
+
+  assert.deepEqual(coldTranscriptRenderFrames(messages), [messages],
+    'one collapsed ActivityStretch must not become ninety hidden prefix commits')
+})
+
 test('one long markdown block grows by token fractions instead of one giant frame', () => {
   const block = { type: 'text', content: 'x'.repeat(48000) }
   const messages = [{ role: 'assistant', ts: 1, blocks: [block] }]

--- a/frontend/src/components/ChatView/__tests__/chatRuntimeState.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatRuntimeState.test.js
@@ -7,7 +7,6 @@ import {
   builtAppPulseDecision,
   canFastForwardQueue,
   shouldFreezeStreamingReturn,
-  cidOf,
   coldTranscriptRenderFrames,
   continuationRowsFromPromotedMessage,
   isContinuationMessage,
@@ -269,17 +268,6 @@ test('a local turn refreshes completed history while preserving its optimistic s
     recent[1],
     loaded[2],
   ])
-})
-
-test('cidOf returns the row cid, else null (no read-time derivation)', () => {
-  // Post-card-221 every user row carries an explicit cid (client-minted, or a
-  // backfilled `legacy-<ts>`); cidOf returns it as-is and no longer derives one
-  // from `ts`. `ts` is display/ordering metadata only.
-  assert.equal(cidOf({ cid: 'abc', ts: 5 }), 'abc')
-  assert.equal(cidOf({ cid: 'legacy-5', ts: 5 }), 'legacy-5')
-  assert.equal(cidOf({ ts: 5 }), null)
-  assert.equal(cidOf({}), null)
-  assert.equal(cidOf(null), null)
 })
 
 test('stripInternalUserMessageFields KEEPS cid and drops the envelope fields', () => {

--- a/frontend/src/components/ChatView/__tests__/messageIdentity.test.js
+++ b/frontend/src/components/ChatView/__tests__/messageIdentity.test.js
@@ -1,0 +1,11 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { cidOf } from '../messageIdentity.js'
+
+test('cidOf returns the row cid, else null (no read-time derivation)', () => {
+  assert.equal(cidOf({ cid: 'abc', ts: 5 }), 'abc')
+  assert.equal(cidOf({ cid: 'legacy-5', ts: 5 }), 'legacy-5')
+  assert.equal(cidOf({ ts: 5 }), null)
+  assert.equal(cidOf({}), null)
+  assert.equal(cidOf(null), null)
+})

--- a/frontend/src/components/ChatView/__tests__/streamingRobustness.test.js
+++ b/frontend/src/components/ChatView/__tests__/streamingRobustness.test.js
@@ -22,7 +22,7 @@ const activeAssistantSource = readFileSync(
 )
 const blockRendererSource = readFileSync(new URL('../markdown/BlockRenderer.jsx', import.meta.url), 'utf8')
 
-test('active DB and live sources share one row shell and one block renderer', () => {
+test('active DB, live deltas, and reconnect snapshots share one assistant surface', () => {
   assert.match(streamingMessageSource, /<MsgContent[\s\S]*msg=\{msg\}/,
     'the stable active <li> must always delegate its selected payload to MsgContent')
   assert.doesNotMatch(streamingMessageSource, /ToolBlock|QuestionCard|ErrorCard|ProgressiveMarkdown/,
@@ -31,6 +31,18 @@ test('active DB and live sources share one row shell and one block renderer', ()
     'the live source must feed the same DB-shaped payload consumed by MsgContent')
   assert.match(chatViewSource, /key=\{streamingDataKey\}[\s\S]*dataKey=\{streamingDataKey\}/,
     'the active row key and scroll-anchor data-key must remain stable across source selection')
+  assert.match(streamHookSource, /\/stream\?snapshot=1/,
+    'new clients must opt into snapshot catch-up without changing old-client replay')
+  assert.match(
+    streamHookSource,
+    /event\.type === 'stream_snapshot'[\s\S]*catchUpItems = Array\.isArray\(event\.items\)[\s\S]*event\.items\.filter\(Boolean\)/,
+    'the trusted snapshot must seed the off-screen catch-up buffer before tail events reduce',
+  )
+  assert.match(
+    streamHookSource,
+    /seededByServerSnapshot[\s\S]*event\.type === 'steered_into_turn'[\s\S]*if \(!seededByServerSnapshot\) catchUpItems = \[\]/,
+    'a reconnect snapshot already sits after prior steer cuts and must retain its continuation',
+  )
 })
 
 test('streaming deltas are flags on the shared active markdown tree', () => {

--- a/frontend/src/components/ChatView/__tests__/streamingRobustness.test.js
+++ b/frontend/src/components/ChatView/__tests__/streamingRobustness.test.js
@@ -31,8 +31,8 @@ test('active DB, live deltas, and reconnect snapshots share one assistant surfac
     'the live source must feed the same DB-shaped payload consumed by MsgContent')
   assert.match(chatViewSource, /key=\{streamingDataKey\}[\s\S]*dataKey=\{streamingDataKey\}/,
     'the active row key and scroll-anchor data-key must remain stable across source selection')
-  assert.match(streamHookSource, /\/stream\?snapshot=1/,
-    'new clients must opt into snapshot catch-up without changing old-client replay')
+  assert.match(streamHookSource, /\/stream[\s\S]*?'X-Mobius-Stream-Snapshot': '1'/,
+    'new clients must opt into snapshot catch-up without changing the stable stream URL')
   assert.match(
     streamHookSource,
     /event\.type === 'stream_snapshot'[\s\S]*catchUpItems = Array\.isArray\(event\.items\)[\s\S]*event\.items\.filter\(Boolean\)/,

--- a/frontend/src/components/ChatView/activityGrouping.js
+++ b/frontend/src/components/ChatView/activityGrouping.js
@@ -1,0 +1,30 @@
+import { isDistinctiveActivityTool } from './toolActivityLabel.js'
+
+// Fold adjacent thinking/tool entries into the exact activity stretches shared
+// by rendering and cold-transcript preparation. Distinctive tools stand alone;
+// prose and other entries preserve their original interleave positions.
+// Pure: entry objects are carried through unchanged.
+export function groupActivityRuns(entries) {
+  const nodes = []
+  let run = []
+
+  const flush = () => {
+    if (run.length) nodes.push({ group: run })
+    run = []
+  }
+
+  for (const entry of entries) {
+    const type = entry?.item?.type
+    if (isDistinctiveActivityTool(entry?.item)) {
+      flush()
+      nodes.push({ group: [entry] })
+    } else if (type === 'tool' || type === 'thinking') {
+      run.push(entry)
+    } else {
+      flush()
+      nodes.push({ single: entry })
+    }
+  }
+  flush()
+  return nodes
+}

--- a/frontend/src/components/ChatView/chatRuntimeState.js
+++ b/frontend/src/components/ChatView/chatRuntimeState.js
@@ -3,7 +3,7 @@
  * focused tests because mobile timing regressions repeatedly happened here.
  */
 
-import { groupActivityRuns } from './groupBlocks.js'
+import { groupActivityRuns } from './activityGrouping.js'
 
 /**
  * The stable identity of a user message. `cid` is the canonical identity

--- a/frontend/src/components/ChatView/chatRuntimeState.js
+++ b/frontend/src/components/ChatView/chatRuntimeState.js
@@ -3,6 +3,8 @@
  * focused tests because mobile timing regressions repeatedly happened here.
  */
 
+import { groupActivityRuns } from './groupBlocks.js'
+
 /**
  * The stable identity of a user message. `cid` is the canonical identity
  * (React key, DOM pin target `data-cid`, queue cancel key, force-steer
@@ -136,6 +138,24 @@ function coldBlockRenderCost(block) {
   return Math.max(1, Math.ceil(String(block.content || '').length / 4000))
 }
 
+function coldPresentationChunks(blocks) {
+  const entries = blocks.map(item => ({ item }))
+  return groupActivityRuns(entries).map(node => {
+    if (node.group) {
+      return {
+        blocks: node.group.map(entry => entry.item),
+        // MsgContent presents one contiguous thinking/tool run as one collapsed
+        // ActivityStretch. Preparing every private entry as its own frame made
+        // the scheduler repeat the same growing group dozens of times before
+        // revealing a surface that contains only one row.
+        cost: 1,
+      }
+    }
+    const block = node.single.item
+    return { blocks: [block], cost: coldBlockRenderCost(block) }
+  })
+}
+
 /**
  * Build prefix-complete frames for a pathological cold transcript commit.
  *
@@ -153,7 +173,8 @@ export function coldTranscriptRenderFrames(
   const totalCost = messages.reduce((sum, message) => {
     const blocks = Array.isArray(message?.blocks) ? message.blocks : []
     return sum + (blocks.length > 0
-      ? blocks.reduce((blockSum, block) => blockSum + coldBlockRenderCost(block), 0)
+      ? coldPresentationChunks(blocks)
+        .reduce((chunkSum, chunk) => chunkSum + chunk.cost, 0)
       : 1)
   }, 0)
   if (totalCost < minCost) return [messages]
@@ -181,8 +202,8 @@ export function coldTranscriptRenderFrames(
       ])
     }
 
-    for (const block of blocks) {
-      const blockCost = coldBlockRenderCost(block)
+    for (const chunk of coldPresentationChunks(blocks)) {
+      const blockCost = chunk.cost
       let consumed = 0
       while (consumed < blockCost) {
         const take = Math.min(
@@ -192,10 +213,10 @@ export function coldTranscriptRenderFrames(
         consumed += take
         frameCost += take
         const complete = consumed === blockCost
-        const partialBlock = complete
+        const partialBlock = complete || chunk.blocks.length !== 1
           ? null
-          : { ...block, _coldRenderFraction: consumed / blockCost }
-        if (complete) visibleBlocks.push(block)
+          : { ...chunk.blocks[0], _coldRenderFraction: consumed / blockCost }
+        if (complete) visibleBlocks.push(...chunk.blocks)
         if (frameCost === frameBudget) {
           publish(partialBlock)
           frameCost = 0

--- a/frontend/src/components/ChatView/chatRuntimeState.js
+++ b/frontend/src/components/ChatView/chatRuntimeState.js
@@ -5,19 +5,6 @@
 
 import { groupActivityRuns } from './activityGrouping.js'
 
-/**
- * The stable identity of a user message. `cid` is the canonical identity
- * (React key, DOM pin target `data-cid`, queue cancel key, force-steer
- * selection). Current clients mint it; card-221 backfilled `cid=legacy-<ts>`
- * onto every legacy row, so post-migration every user row carries an explicit
- * cid and no read-time derivation is needed (chat_writer.cid_of matches). `ts`
- * is display/ordering metadata only. Returns null for a row with no cid.
- */
-export function cidOf(msg) {
-  if (!msg) return null
-  return msg.cid || null
-}
-
 export function isContinuationMessage(message) {
   return message?.kind === 'continuation'
     || message?.kind === 'auto_continuation'

--- a/frontend/src/components/ChatView/groupBlocks.js
+++ b/frontend/src/components/ChatView/groupBlocks.js
@@ -4,8 +4,8 @@ import {
   toolActivitySingular,
   toolActivityPastSingular,
   effectiveToolName,
-  isDistinctiveActivityTool,
 } from './toolActivityLabel.js'
+export { groupActivityRuns } from './activityGrouping.js'
 
 // Fold runs of adjacent ACTIVITY entries — thinking AND tool blocks — into one
 // activity node, including a lone entry. A build turn's pre-prose burst is one
@@ -35,33 +35,6 @@ import {
 //
 // Output: an array of nodes, each either `{ single: entry }` or
 // `{ group: [entry, entry, ...] }`. Pure — no React, no mutation of inputs.
-export function groupActivityRuns(entries) {
-  const nodes = []
-  let run = []
-
-  const flush = () => {
-    if (run.length >= 1) {
-      nodes.push({ group: run })
-    }
-    run = []
-  }
-
-  for (const entry of entries) {
-    const type = entry?.item?.type
-    if (isDistinctiveActivityTool(entry?.item)) {
-      flush()
-      nodes.push({ group: [entry] })
-    } else if (type === 'tool' || type === 'thinking') {
-      run.push(entry)
-    } else {
-      flush()
-      nodes.push({ single: entry })
-    }
-  }
-  flush()
-  return nodes
-}
-
 // Merge runs of ADJACENT thinking entries into one, so a persisted transcript
 // renders a continuous reasoning pass as a SINGLE "Thought for Ns" disclosure
 // instead of many tiny fragments. Fragments only exist in already-saved chats

--- a/frontend/src/components/ChatView/groupBlocks.js
+++ b/frontend/src/components/ChatView/groupBlocks.js
@@ -7,34 +7,6 @@ import {
 } from './toolActivityLabel.js'
 export { groupActivityRuns } from './activityGrouping.js'
 
-// Fold runs of adjacent ACTIVITY entries — thinking AND tool blocks — into one
-// activity node, including a lone entry. A build turn's pre-prose burst is one
-// contiguous stretch of reasoning + tool calls with nothing prose-like between
-// the pieces, so it honestly collapses to ONE quiet line (ActivityStretch)
-// instead of alternating "> Thought" lines and bordered tool cards. Giving
-// single- and multi-entry runs the same collapsed line also lets a lone tool (or
-// lone thinking) grow into a multi-entry stretch without swapping visual
-// primitives. MsgContent applies this to both DB-shaped history blocks and the
-// converted live payload, so source selection cannot reshuffle the active answer.
-//
-// Rules:
-//   - any run of entries whose item.type is 'tool' OR 'thinking' becomes a group
-//   - a DISTINCTIVE tool (isDistinctiveActivityTool — today an image view)
-//     breaks the run and stands as its OWN single-entry group, so notable beats
-//     punctuate the flow on their own line instead of folding into the combined
-//     "Edited files, read files, ran commands" summary (owner ref 2026-07-17).
-//     Consecutive distinctive tools each get their own line — they do not
-//     accumulate.
-//   - any non-activity entry (text, question, error) breaks the run and passes
-//     through, so interleave order is preserved exactly (interleave is sacred —
-//     these are the blocks a reader must not lose the position of)
-//
-// Input: an array of entries, each `{ item, ... }` where `item.type` decides
-// grouping. The rest of the entry (e.g. the caller's original index) is opaque
-// and carried through untouched, so the caller can still key/answer correctly.
-//
-// Output: an array of nodes, each either `{ single: entry }` or
-// `{ group: [entry, entry, ...] }`. Pure — no React, no mutation of inputs.
 // Merge runs of ADJACENT thinking entries into one, so a persisted transcript
 // renders a continuous reasoning pass as a SINGLE "Thought for Ns" disclosure
 // instead of many tiny fragments. Fragments only exist in already-saved chats

--- a/frontend/src/components/ChatView/hooks/usePendingQueue.js
+++ b/frontend/src/components/ChatView/hooks/usePendingQueue.js
@@ -1,5 +1,5 @@
 import { useState, useRef, useCallback } from 'react'
-import { cidOf } from '../chatRuntimeState.js'
+import { cidOf } from '../messageIdentity.js'
 
 /**
  * Hook that owns the per-chat pending-message queue (the items shown

--- a/frontend/src/components/ChatView/messageIdentity.js
+++ b/frontend/src/components/ChatView/messageIdentity.js
@@ -1,0 +1,12 @@
+/**
+ * The stable identity of a user message. `cid` is the canonical identity
+ * (React key, DOM pin target `data-cid`, queue cancel key, force-steer
+ * selection). Current clients mint it; card-221 backfilled `cid=legacy-<ts>`
+ * onto every legacy row, so post-migration every user row carries an explicit
+ * cid and no read-time derivation is needed (chat_writer.cid_of matches). `ts`
+ * is display/ordering metadata only. Returns null for a row with no cid.
+ */
+export function cidOf(msg) {
+  if (!msg) return null
+  return msg.cid || null
+}

--- a/frontend/src/components/ChatView/resolveStopResend.js
+++ b/frontend/src/components/ChatView/resolveStopResend.js
@@ -1,4 +1,4 @@
-import { cidOf } from './chatRuntimeState.js'
+import { cidOf } from './messageIdentity.js'
 
 /**
  * Decide what handleStop should re-send after a Stop, from the queued

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -1207,10 +1207,13 @@ export function modeForQueuedSubmission(scrollEl, currentMode) {
  *   shows/hides because the tray's margin shrinks the spacer math).
  * @param {React.MutableRefObject<boolean>} args.loadingOlderRef
  *   When true, scroll events from pagination shouldn't mutate mode.
- * @param {'history'|'cached'|'preparing'|'ready'} args.initialEntryPhase
+ * @param {'history'|'cache-validating'|'cached'|'preparing'|'ready'} args.initialEntryPhase
  *   History blocks reveal, cached is a caller-validated restoration window,
- *   preparing is a hidden progressive cold render, and ready means
- *   authoritative history has settled.
+ *   cache-validating mounts a complete cached window behind the gate so its
+ *   exact nested coordinate can be checked, preparing is a hidden progressive
+ *   cold render, and ready means authoritative history has settled.
+ * @param {() => void} [args.onCachedCoordinateReady]
+ *   Promotes a hidden validation cache after its exact saved part resolves.
  * @param {boolean} args.ownsReadingPosition
  *   True only for the physical ChatView participating in the active workspace
  *   handoff. Retained hidden owners may keep DOM geometry, but never consume
@@ -1228,6 +1231,7 @@ export default function useScrollMode({
   pendingMessagesLength,
   loadingOlderRef,
   initialEntryPhase,
+  onCachedCoordinateReady,
   ownsReadingPosition,
 }) {
   const messageCount = messages.length
@@ -1756,7 +1760,8 @@ export default function useScrollMode({
     if (
       modeRef.current.kind === 'INITIAL'
       && (
-        initialEntryPhaseRef.current === 'cached'
+        initialEntryPhaseRef.current === 'cache-validating'
+        || initialEntryPhaseRef.current === 'cached'
         || initialEntryPhaseRef.current === 'ready'
       )
     ) {
@@ -1767,10 +1772,15 @@ export default function useScrollMode({
         && !restored?.defaultTail
       readerLocationExplicitRef.current = resolved
       savedLocationUnresolvedRef.current = !!saved && !resolved
-      transitionMode(
-        restored,
-        'lifecycle:restore',
-      )
+      if (initialEntryPhaseRef.current !== 'cache-validating' || resolved) {
+        transitionMode(
+          restored,
+          'lifecycle:restore',
+        )
+        if (initialEntryPhaseRef.current === 'cache-validating') {
+          onCachedCoordinateReady?.()
+        }
+      }
     }
     // Semantic transitions use a fresh mode object. Identity therefore keeps
     // steady streaming from rewriting scrollTop, while the ref survives effect
@@ -2629,6 +2639,7 @@ export default function useScrollMode({
     pendingMessagesLength,
     chatId,
     initialEntryPhase,
+    onCachedCoordinateReady,
     ownsReadingPosition,
     pinModeActive,
     chatRef,

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -61,7 +61,8 @@
  */
 
 import { useState, useRef, useLayoutEffect, useCallback } from 'react'
-import { cidOf, isOwnerUserMessage } from './chatRuntimeState.js'
+import { cidOf } from './messageIdentity.js'
+import { isOwnerUserMessage } from './chatRuntimeState.js'
 import { BEFORE_SHELL_RELOAD_EVENT } from '../../lib/shellReloadEvents.js'
 import { isPerfProbeEnabled, perfMark, perfTime } from '../../lib/perfProbe.js'
 

--- a/frontend/src/components/ChatView/useStreamConnection.js
+++ b/frontend/src/components/ChatView/useStreamConnection.js
@@ -96,6 +96,9 @@ const BROADCAST_REGISTRATION_WINDOW_MS = 1500
  * each. Adding a new event type requires editing BOTH the backend
  * emitter AND the dispatch switch below in this file.
  *
+ *   stream_snapshot       Server-reduced assistant items at the exact
+ *                         subscription boundary { items }. Seeds reconnect
+ *                         catch-up so prior deltas need not be replayed.
  *   text                  Streamed assistant token chunk
  *                         { content }. Buffered + drained by rAF.
  *   text_boundary         Next text starts a fresh assistant block.
@@ -654,10 +657,13 @@ export default function useStreamConnection(chatId, {
     lastReadAtRef.current = 0
 
     try {
-      const res = await fetch(`${BASE}/api/chats/${chatIdRef.current}/stream`, {
-        headers: getAuthHeaders(),
-        signal: controller.signal,
-      })
+      const res = await fetch(
+        `${BASE}/api/chats/${chatIdRef.current}/stream?snapshot=1`,
+        {
+          headers: getAuthHeaders(),
+          signal: controller.signal,
+        },
+      )
 
       // Stale-connection guard. Between scheduling this fetch and its
       // resolution, the connection we belong to may have been torn down
@@ -742,6 +748,7 @@ export default function useStreamConnection(chatId, {
       // temporary blank/thinking state while a long catch-up replay is parsed.
       let isCatchUp = true
       let catchUpItems = []
+      let seededByServerSnapshot = false
 
       const applyStreamItems = (updater) => {
         if (!isCatchUp) {
@@ -842,7 +849,21 @@ export default function useStreamConnection(chatId, {
             continue
           }
 
-          if (event.type === 'text_boundary') {
+          if (event.type === 'stream_snapshot') {
+            // ChatEventSink reduced every content event before publishing it,
+            // so this is the complete assistant surface at subscribe time.
+            // Replace only the off-screen catch-up buffer; live deltas queued
+            // after that boundary are still handled by the normal reducers.
+            if (isCatchUp) {
+              catchUpItems = Array.isArray(event.items)
+                ? event.items.filter(Boolean)
+                : []
+              seededByServerSnapshot = true
+              textBufferRef.current = ''
+              textBufferItemIdRef.current = null
+              forceNewTextBlockRef.current = false
+            }
+          } else if (event.type === 'text_boundary') {
             flushBuffer()
             forceNewTextBlockRef.current = true
           } else if (event.type === 'text') {
@@ -1103,7 +1124,12 @@ export default function useStreamConnection(chatId, {
               // arrival instead, the A1 blocks that followed it survived here
               // and replayed as the head of A2 — the duplication, reproduced on
               // every reconnect.
-              catchUpItems = []
+              // Full-log replay has accumulated A1 before this cut and must
+              // drop it. A server snapshot is already reduced *after* every
+              // prior cut, so it contains only the current A2 surface; keep
+              // that payload while the authoritative DB refresh restores the
+              // sealed A1 + user rows this socket may have missed.
+              if (!seededByServerSnapshot) catchUpItems = []
               forceNewTextBlockRef.current = false
               // Dropping the replayed segment only reconstructs the transcript
               // if those DB rows are actually loaded, and this branch is exactly

--- a/frontend/src/components/ChatView/useStreamConnection.js
+++ b/frontend/src/components/ChatView/useStreamConnection.js
@@ -658,9 +658,12 @@ export default function useStreamConnection(chatId, {
 
     try {
       const res = await fetch(
-        `${BASE}/api/chats/${chatIdRef.current}/stream?snapshot=1`,
+        `${BASE}/api/chats/${chatIdRef.current}/stream`,
         {
-          headers: getAuthHeaders(),
+          headers: {
+            ...getAuthHeaders(),
+            'X-Mobius-Stream-Snapshot': '1',
+          },
           signal: controller.signal,
         },
       )

--- a/frontend/src/components/Shell/__tests__/chatHandoff.test.js
+++ b/frontend/src/components/Shell/__tests__/chatHandoff.test.js
@@ -22,14 +22,14 @@ function ruleBody(selector, source = shellCss) {
 test('chat display readiness admits only coordinate-complete cached transcripts', () => {
   assert.match(
     detailCache,
-    /function chatCacheCanPaint\([\s\S]*cached\?\.restorationWindowComplete !== true[\s\S]*savedAnchorHasNestedPart[\s\S]*messageKey\(message, baseOffset \+ index\)/,
-    'only canonical cache projections containing the durable coordinate may paint',
+    /function chatCacheEntryState\([\s\S]*cached\?\.restorationWindowComplete !== true[\s\S]*messageKey\(message, baseOffset \+ index\)[\s\S]*savedAnchorHasNestedPart \? 'validating' : 'paintable'/,
+    'only canonical caches containing the durable row may paint or validate',
   )
   assert.match(chatView,
-    /const initialSavedAnchorKey = savedReadingAnchorKey\(chatId\)[\s\S]*const initialCachePaintable = chatCacheCanPaint\([\s\S]*savedReadingAnchorHasNestedPart\(chatId\)[\s\S]*useState\(!initialCachePaintable\)[\s\S]*initialCachePaintable \? 'cached' : 'history'/,
-    'mount paints a safe cache immediately while incomplete caches remain gated')
+    /const initialSavedAnchorKey = savedReadingAnchorKey\(chatId\)[\s\S]*const initialCacheEntryState = chatCacheEntryState\([\s\S]*savedReadingAnchorHasNestedPart\(chatId\)[\s\S]*initialCacheEntryState === 'missing'[\s\S]*'cache-validating'/,
+    'mount paints a safe cache or mounts an exact-part cache behind validation')
   assert.match(chatView,
-    /const activationCachePaintable = chatCacheCanPaint\([\s\S]*setLoading\(!activationCachePaintable\)[\s\S]*activationCachePaintable \? 'cached' : 'history'/,
+    /const activationCacheEntryState = chatCacheEntryState\([\s\S]*setLoading\(activationCacheEntryState === 'missing'\)[\s\S]*activationCacheEntryState === 'validating'[\s\S]*'cache-validating'/,
     'a retained chat revalidates cache coverage on every visible activation')
   assert.match(scrollMode,
     /initialEntryPhaseRef\.current !== 'cached'[\s\S]*initialEntryPhaseRef\.current !== 'ready'[\s\S]*forceRevealRef/,
@@ -103,8 +103,8 @@ test('activation reuses an unchanged retained transcript before stream catch-up'
     /cacheIsSafeFallback[\s\S]*CHAT_READING_ANCHOR_NOT_FOUND[\s\S]*applyMessagesToView\(\[\], 0\)[\s\S]*setLoadError\(!cacheIsSafeFallback\)/,
     'an incomplete or contradictory cache must be cleared before the error surface paints')
   assert.match(scrollMode,
-    /modeRef\.current\.kind === 'INITIAL'[\s\S]*initialEntryPhaseRef\.current === 'cached'[\s\S]*initialEntryPhaseRef\.current === 'ready'[\s\S]*const saved = _scrollModes\[chatId\]/,
-    'the scroll controller consumes a coordinate only after cache coverage or activation proof')
+    /modeRef\.current\.kind === 'INITIAL'[\s\S]*initialEntryPhaseRef\.current === 'cache-validating'[\s\S]*const saved = _scrollModes\[chatId\][\s\S]*const resolved =[\s\S]*onCachedCoordinateReady\?\.\(\)/,
+    'the scroll controller admits a nested cache only after the exact DOM part resolves')
   assert.match(scrollMode,
     /savedLocationUnresolvedRef\.current[\s\S]*Object\.hasOwn\(_scrollModes, chatId\)/,
     'an activation error before ready must not erase the unconsumed saved coordinate')

--- a/frontend/src/lib/chatDetailCache.js
+++ b/frontend/src/lib/chatDetailCache.js
@@ -32,25 +32,23 @@ export function messageMatchesKey(message, index, key) {
   return `${role}-${index}` === target
 }
 
-/** Whether a canonical detail cache can be painted while its background
- * freshness check runs. A saved reading coordinate must be present in the
- * cached window; otherwise the transcript stays hidden until the
- * anchor-addressed authoritative read repairs or retires that coordinate. */
-export function chatCacheCanPaint(
+/** Classify the strongest safe entry a canonical detail cache can provide.
+ *
+ * A saved row must be present in the cached window. Exact nested parts are a
+ * DOM fact rather than a data fact: mount those caches behind the reveal gate
+ * as `validating`, then let the scroll owner promote them only when the saved
+ * part resolves in the committed cached DOM. */
+export function chatCacheEntryState(
   cached,
   savedAnchorKey = null,
   savedAnchorHasNestedPart = false,
 ) {
   if (cached?.restorationWindowComplete !== true || !Array.isArray(cached.messages)) {
-    return false
+    return 'missing'
   }
-  if (savedAnchorKey == null) return true
-  // A nested row-part address needs committed DOM validation. Keep it behind
-  // the authoritative phase so a compact/stale cache cannot consume the
-  // coordinate by falling back to the tail before that validation runs.
-  if (savedAnchorHasNestedPart) return false
+  if (savedAnchorKey == null) return 'paintable'
   const baseOffset = Number.isInteger(cached.offset) ? cached.offset : 0
-  return cached.messages.some((message, index) => (
+  const containsAnchor = cached.messages.some((message, index) => (
     messageKey(message, baseOffset + index) === String(savedAnchorKey)
     || (
       message?.role === 'assistant'
@@ -66,6 +64,8 @@ export function chatCacheCanPaint(
       && String(message.cid) === String(savedAnchorKey)
     )
   ))
+  if (!containsAnchor) return 'missing'
+  return savedAnchorHasNestedPart ? 'validating' : 'paintable'
 }
 
 function settledToolBlocks(message) {


### PR DESCRIPTION
## Summary

- prepare oversized cold transcripts by the collapsed activity groups people actually see, rather than every hidden thinking and tool event
- reconnect running chats from a server-reduced assistant snapshot plus the small control-event tail, instead of replaying the full turn log
- validate an exact saved reading position against complete cached DOM before waiting for the independent freshness read

## Context

This is a follow-up to #464. That PR introduced bounded cold preparation, and its review identified full event-log replay as the remaining major cost; this change removes that replay rather than moving it to a later interaction.

It is also related to #560, which preserves anchor identity through recovered question replies. The cache change here is distinct: when a complete cached window already contains a saved nested position, it validates that DOM position locally and reveals immediately, while unresolved positions still wait for the authoritative read.

## Validation

- 108 focused backend broadcast, steering, and terminal-completion tests
- complete frontend unit suites: 2,295 library tests and 79 hook tests
- frontend lint: 0 errors
- production frontend build
- rendered phone-width smoke check on a running chat with 495 raw blocks, presented as grouped activity rows