### PR TITLE
Keep chat and drawer momentum uninterrupted

### DIFF
--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -1198,7 +1198,8 @@ export function modeForQueuedSubmission(scrollEl, currentMode) {
  * @param {React.RefObject<HTMLElement>} args.footRef
  *   The overlaid composer element measured by the scroll owner.
  * @param {Array<object>} args.messages
- *   Persisted message list (drives effect re-runs).
+ *   Persisted message list. Row-count changes reinstall the DOM owner; content
+ *   growth stays on its ResizeObserver so streaming cannot settle a gesture.
  * @param {React.MutableRefObject<Array<object>>} args.messagesRef
  *   Synchronous mirror for restore-time anchor validation.
  * @param {number} args.pendingMessagesLength
@@ -1229,6 +1230,7 @@ export default function useScrollMode({
   initialEntryPhase,
   ownsReadingPosition,
 }) {
+  const messageCount = messages.length
   const [revealed, setRevealed] = useState(false)
   // A tiny React mirror reruns the layout effect when a semantic transition
   // enters/leaves PIN_USER_MSG before message props necessarily change.
@@ -1713,7 +1715,9 @@ export default function useScrollMode({
   // Single layout effect: spacer sizing, automatic scroll writes,
   // ResizeObserver layout updates (including the mobile keyboard after Shell
   // has resized), user-gesture detection, and geometry-based transitions.
-  // Re-runs on messages / pendingMessages / chatId changes.
+  // Re-runs when transcript structure, queue presence, or chat identity changes.
+  // Content-only streaming is already owned by ResizeObserver; reinstalling
+  // here would settle and recreate the active gesture on every streamed chunk.
   useLayoutEffect(() => {
     // Empty chats intentionally render no scroll node. Initialize the chat
     // identity before that early return so the first send can arm its pin
@@ -2621,7 +2625,7 @@ export default function useScrollMode({
       if (forceRevealRef.current === forceReveal) forceRevealRef.current = null
     }
   }, [
-    messages,
+    messageCount,
     pendingMessagesLength,
     chatId,
     initialEntryPhase,

--- a/frontend/src/components/Drawer/drawerRowWindow.js
+++ b/frontend/src/components/Drawer/drawerRowWindow.js
@@ -45,15 +45,23 @@ export function drawerRowWindow({
   if (count === 0) return { start: 0, end: 0 }
   const localTop = Math.max(0, (Number(scrollTop) || 0) - (Number(sectionTop) || 0))
   const visibleStart = Math.floor(localTop / DRAWER_ROW_HEIGHT)
-  const visibleEnd = Math.ceil(
-    (localTop + Math.max(DRAWER_ROW_HEIGHT, Number(viewportHeight) || 0))
-      / DRAWER_ROW_HEIGHT,
+  const viewportRows = Math.ceil(
+    Math.max(DRAWER_ROW_HEIGHT, Number(viewportHeight) || 0) / DRAWER_ROW_HEIGHT,
   )
+  // Move the React window in overscan-sized buckets instead of replacing one
+  // row at every 40px boundary. The bucket still retains a full overscan band
+  // around every viewport position it represents, but native momentum now gets
+  // several uninterrupted frames between DOM swaps.
+  const bucketStart = Math.floor(visibleStart / DRAWER_ROW_OVERSCAN)
+    * DRAWER_ROW_OVERSCAN
+  // The viewport may begin at the final row (and final fractional pixel) of the
+  // bucket, so reserve the complete bucket width before the lower overscan.
+  const bucketEnd = bucketStart + DRAWER_ROW_OVERSCAN + viewportRows
   return {
-    start: Math.max(0, visibleStart - DRAWER_ROW_OVERSCAN),
+    start: Math.max(0, bucketStart - DRAWER_ROW_OVERSCAN),
     end: Math.min(
       count,
-      Math.max(visibleStart + 1, visibleEnd + DRAWER_ROW_OVERSCAN),
+      bucketEnd + DRAWER_ROW_OVERSCAN,
     ),
   }
 }

--- a/frontend/src/lib/__tests__/drawerRowWindow.test.js
+++ b/frontend/src/lib/__tests__/drawerRowWindow.test.js
@@ -30,7 +30,7 @@ test('scrolling to the middle slides the window instead of accumulating rows', (
   })
   assert.ok(window.start >= 400 - DRAWER_ROW_OVERSCAN)
   assert.ok(
-    window.end <= 400 + Math.ceil(860 / DRAWER_ROW_HEIGHT) + DRAWER_ROW_OVERSCAN,
+    window.end <= 400 + Math.ceil(860 / DRAWER_ROW_HEIGHT) + 2 * DRAWER_ROW_OVERSCAN,
   )
   assert.ok(window.end - window.start < DRAWER_INITIAL_WINDOW_ROWS,
     'the mounted row count stays viewport-sized after an arbitrarily long scroll')
@@ -44,6 +44,39 @@ test('scrolling to the middle slides the window instead of accumulating rows', (
       + spacers.after,
     795 * DRAWER_ROW_HEIGHT,
     'windowing preserves the exact scroll extent',
+  )
+})
+
+test('small scroll steps reuse one mounted drawer window', () => {
+  const atBucketStart = drawerRowWindow({
+    total: 795,
+    scrollTop: 400 * DRAWER_ROW_HEIGHT,
+    viewportHeight: 860,
+    sectionTop: 0,
+  })
+
+  for (let row = 401; row < 400 + DRAWER_ROW_OVERSCAN; row += 1) {
+    assert.deepEqual(
+      drawerRowWindow({
+        total: 795,
+        scrollTop: row * DRAWER_ROW_HEIGHT,
+        viewportHeight: 860,
+        sectionTop: 0,
+      }),
+      atBucketStart,
+      'native momentum must not swap React rows at every 40px boundary',
+    )
+  }
+
+  assert.notDeepEqual(
+    drawerRowWindow({
+      total: 795,
+      scrollTop: (400 + DRAWER_ROW_OVERSCAN) * DRAWER_ROW_HEIGHT,
+      viewportHeight: 860,
+      sectionTop: 0,
+    }),
+    atBucketStart,
+    'the window still advances before the viewport can reach its overscan edge',
   )
 })
 

--- a/frontend/src/lib/__tests__/useScrollModeLifecycle.test.js
+++ b/frontend/src/lib/__tests__/useScrollModeLifecycle.test.js
@@ -1,0 +1,117 @@
+/* Behavioral coverage for the ChatView scroll controller's React lifecycle. */
+
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { renderHook } from '../../components/ChatView/hooks/__tests__/react-hook-shim.mjs'
+import useScrollMode from '../../components/ChatView/useScrollMode.js'
+
+function fakeElement(fields = {}) {
+  const listeners = new Map()
+  return {
+    clientHeight: 500,
+    scrollHeight: 900,
+    scrollTop: 400,
+    offsetHeight: 0,
+    offsetTop: 0,
+    dataset: {},
+    parentElement: null,
+    style: { setProperty() {} },
+    querySelector() { return null },
+    querySelectorAll() { return [] },
+    getBoundingClientRect() { return { top: 0, bottom: 0, height: 0 } },
+    addEventListener(type, handler) { listeners.set(type, handler) },
+    removeEventListener(type, handler) {
+      if (listeners.get(type) === handler) listeners.delete(type)
+    },
+    ...fields,
+  }
+}
+
+test('content-only streaming keeps the active reader gesture owner mounted', () => {
+  const previous = {
+    window: globalThis.window,
+    document: globalThis.document,
+    ResizeObserver: globalThis.ResizeObserver,
+    MutationObserver: globalThis.MutationObserver,
+    requestAnimationFrame: globalThis.requestAnimationFrame,
+    cancelAnimationFrame: globalThis.cancelAnimationFrame,
+  }
+  const observers = []
+  globalThis.window = {
+    addEventListener() {},
+    removeEventListener() {},
+    visualViewport: null,
+  }
+  globalThis.document = {
+    activeElement: null,
+    visibilityState: 'visible',
+    addEventListener() {},
+    removeEventListener() {},
+  }
+  globalThis.ResizeObserver = class {
+    constructor() {
+      this.disconnected = false
+      observers.push(this)
+    }
+    observe() {}
+    disconnect() { this.disconnected = true }
+  }
+  globalThis.MutationObserver = class {
+    observe() {}
+    disconnect() {}
+  }
+  globalThis.requestAnimationFrame = () => 1
+  globalThis.cancelAnimationFrame = () => {}
+
+  const lastUser = fakeElement({ offsetTop: 120, offsetHeight: 40 })
+  const list = fakeElement({ offsetHeight: 720 })
+  const scroll = fakeElement({
+    querySelector(selector) {
+      return selector === '.chat__list' ? list : null
+    },
+    querySelectorAll(selector) {
+      return selector === '.chat__msg--user[data-cid]' ? [lastUser] : []
+    },
+  })
+  scroll.parentElement = fakeElement()
+  const spacer = fakeElement()
+  const chat = fakeElement()
+  const foot = fakeElement({ offsetHeight: 80 })
+  const base = {
+    chatId: 'stream-lifecycle',
+    scrollRef: { current: scroll },
+    spacerRef: { current: spacer },
+    lastUserMsgRef: { current: lastUser },
+    chatRef: { current: chat },
+    footRef: { current: foot },
+    messagesRef: { current: [] },
+    pendingMessagesLength: 0,
+    loadingOlderRef: { current: false },
+    initialEntryPhase: 'history',
+    ownsReadingPosition: true,
+  }
+
+  try {
+    const messages = [{ role: 'user', cid: 'u1', content: 'Question' }]
+    base.messagesRef.current = messages
+    const hook = renderHook(useScrollMode, { ...base, messages })
+    assert.equal(observers.length, 1)
+
+    const streamed = [{ ...messages[0], content: 'Question, still streaming' }]
+    base.messagesRef.current = streamed
+    hook.rerender({ ...base, messages: streamed })
+    assert.equal(observers.length, 1,
+      'content changes stay on the existing ResizeObserver and gesture owner')
+    assert.equal(observers[0].disconnected, false)
+
+    const nextRow = [...streamed, { role: 'assistant', content: 'Answer' }]
+    base.messagesRef.current = nextRow
+    hook.rerender({ ...base, messages: nextRow })
+    assert.equal(observers.length, 2,
+      'adding a transcript row may reinstall the DOM lifecycle')
+    assert.equal(observers[0].disconnected, true)
+    hook.unmount()
+  } finally {
+    Object.assign(globalThis, previous)
+  }
+})

--- a/frontend/src/lib/__tests__/vite-env-loader.mjs
+++ b/frontend/src/lib/__tests__/vite-env-loader.mjs
@@ -26,6 +26,7 @@ const REACT_SHIM = new URL(
 const REACT_SHIMMED_MODULES = [
   '/components/Shell/useAppIntentNavigation.js',
   '/components/ChatView/useFileUpload.js',
+  '/components/ChatView/useScrollMode.js',
   '/hooks/useNavigation.js',
 ]
 


### PR DESCRIPTION
## Summary

- keep chat scroll ownership mounted across content-only streaming updates
- move the drawer's bounded row window in overscan-sized buckets rather than at every row boundary
- add behavioral coverage for both lifecycle contracts

## Context

This is a follow-up to #497 and #550. Those changes established native-first input and a single gesture-settlement path; a 426px rendered probe still exposed two remaining sources of churn: streamed content replaced the `messages` array and reinstalled the scroll controller, while long drawer scrolling replaced rows at every 40px boundary.

#558 changes composer-tail keyboard intent in the same controller but does not address content-only lifecycle churn; this patch is otherwise independent.

## Verification

- `npm test` (2,296 library tests and 79 hook tests)
- `npm run lint` (existing warnings only)
- `npm run build`
- 426px rendered probe: drawer row-window swaps fell from 22 to 4 across the same 1,200px scroll

Physical Android momentum remains a useful final confirmation.