### PR TITLE
Unify drawer hold, reorder, and workspace drag ownership

### DIFF
--- a/frontend/src/components/Drawer/Drawer.css
+++ b/frontend/src/components/Drawer/Drawer.css
@@ -348,14 +348,6 @@
   background-color: var(--surface);
 }
 
-/* The hold threshold has resolved, but the owner has not moved or released yet.
-   A quiet lift is the button-free affordance: release opens actions; vertical
-   movement of a pin becomes reorder. */
-.drawer__item[data-hold-ready="true"] {
-  background: var(--surface);
-  box-shadow: 0 3px 12px rgba(0, 0, 0, 0.20);
-}
-
 /* The lifted row while it is being dragged to a new spot. It reads as "picked
    up" — raised surface + shadow — rather than faded, so the movement is legible.
    The vertical follow/settle transform lives on the parent .drawer__row. */
@@ -441,13 +433,10 @@
 .drawer__row .drawer__item {
   flex: 1;
   min-width: 0;
-  /* iOS can cancel the pointer and show its callout before our release path.
-     This property affects touch callouts only; desktop context menus remain. */
-  -webkit-touch-callout: none;
 }
 
-/* Drawer rows scroll vertically before a hold. Once a hold resolves, the local
-   row gesture owns menu/reorder and the shared drawer swipe recognizer yields. */
+/* Row bodies keep native vertical scrolling until their deliberate hold wins.
+   The pinned reorder handle below owns its pointer stream independently. */
 .drawer__row .drawer__item[data-drag-key] {
   touch-action: pan-y pinch-zoom;
 }

--- a/frontend/src/components/Drawer/Drawer.css
+++ b/frontend/src/components/Drawer/Drawer.css
@@ -435,10 +435,17 @@
   min-width: 0;
 }
 
-/* Row bodies keep native vertical scrolling until their deliberate hold wins.
-   The pinned reorder handle below owns its pointer stream independently. */
+/* Ordinary rows retain native momentum scrolling. A pinned row must reserve its
+   one-finger pointer stream from pointerdown: touch-action cannot be changed
+   after a gesture starts, so allowing pan-y there lets the browser cancel the
+   pointer exactly when a held pin begins moving vertically. The shared row
+   controller mirrors pre-hold scrolling for pins; pinch zoom remains native. */
 .drawer__row .drawer__item[data-drag-key] {
   touch-action: pan-y pinch-zoom;
+}
+
+.drawer__row .drawer__item[data-pinned-key] {
+  touch-action: pinch-zoom;
 }
 
 /* App cards and drawer rows share one action-menu placement path. */

--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -28,7 +28,7 @@ import {
   clearDrawerGestureStyles,
 } from '../../lib/drawerLifecycle.js'
 import {
-  DRAWER_HOLD_MS,
+  DRAWER_MENU_HOLD_MS,
   PRE_HOLD_MOVE_PX,
 } from '../Shell/dragController.js'
 import InstallSheet from './InstallSheet.jsx'
@@ -1480,7 +1480,7 @@ const DrawerRow = memo(function DrawerRow({
         holdTimerRef.current = null
         suppressCardClickRef.current = true
         openItemMenuAt(holdOriginRef.current)
-      }, DRAWER_HOLD_MS)
+      }, DRAWER_MENU_HOLD_MS)
     }
     function cancelCardHold() {
       if (holdTimerRef.current) clearTimeout(holdTimerRef.current)

--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -89,6 +89,17 @@ function drawerGesturePoint(event, pointerId, touchEvents, ended = false) {
   )
 }
 
+// Android may end a long press without repeating the cancelled contact in
+// changedTouches. Once that contact is no longer live, its last known position
+// is the end point; otherwise the first hold remains stranded until another
+// touch happens to clean it up.
+function drawerGestureEndPoint(event, pointerId, touchEvents, fallback) {
+  const point = drawerGesturePoint(event, pointerId, touchEvents, true)
+  if (point) return point
+  if (touchEvents && !touchWithIdentifier(event.touches, pointerId)) return fallback
+  return null
+}
+
 function releaseDrawerRowClaim(source, pointerId, touchEvents, claimRef) {
   source.removeAttribute('data-hold-ready')
   deferDrawerGestureClaimRelease(claimRef, source)
@@ -1571,6 +1582,7 @@ const DrawerRow = memo(function DrawerRow({
       x: touchEvents ? initialTouch.clientX : event.clientX,
       y: touchEvents ? initialTouch.clientY : event.clientY,
     }
+    let lastPoint = start
     let held = false
     let cancelledAfterHold = false
     let cleaned = false
@@ -1603,6 +1615,7 @@ const DrawerRow = memo(function DrawerRow({
     function onMove(moveEvent) {
       const point = drawerGesturePoint(moveEvent, pointerId, touchEvents)
       if (!point) return
+      lastPoint = { x: point.clientX, y: point.clientY }
       const dx = point.clientX - start.x
       const dy = point.clientY - start.y
       if (!held) {
@@ -1614,7 +1627,7 @@ const DrawerRow = memo(function DrawerRow({
       moveEvent.preventDefault()
     }
     function onUp(upEvent) {
-      const point = drawerGesturePoint(upEvent, pointerId, touchEvents, true)
+      const point = drawerGestureEndPoint(upEvent, pointerId, touchEvents, lastPoint)
       if (!point) return
       const openMenu = held && !cancelledAfterHold
       // A touch hold mounts the transparent menu layer during this touchend.
@@ -1625,7 +1638,11 @@ const DrawerRow = memo(function DrawerRow({
       if (openMenu) openItemMenuAt({ x: point.clientX, y: point.clientY })
     }
     function onCancel(cancelEvent) {
-      if (drawerGesturePoint(cancelEvent, pointerId, touchEvents, true)) cleanup()
+      const point = drawerGestureEndPoint(cancelEvent, pointerId, touchEvents, lastPoint)
+      if (!point) return
+      const openMenu = touchEvents && held && !cancelledAfterHold
+      cleanup({ suppressClick: held })
+      if (openMenu) openItemMenuAt({ x: point.clientX, y: point.clientY })
     }
     function onInterrupted() { cleanup() }
     function onVisibility() {
@@ -1683,6 +1700,7 @@ const DrawerRow = memo(function DrawerRow({
       x: touchEvents ? initialTouch.clientX : event.clientX,
       y: touchEvents ? initialTouch.clientY : event.clientY,
     }
+    let lastPoint = start
     const sourceBtn = event.currentTarget
     let held = !isTouch
     let cancelledAfterHold = false
@@ -1810,6 +1828,7 @@ const DrawerRow = memo(function DrawerRow({
     function onMove(moveEvent) {
       const point = drawerGesturePoint(moveEvent, pointerId, touchEvents)
       if (!point) return
+      lastPoint = { x: point.clientX, y: point.clientY }
       const dx = point.clientX - start.x
       const dy = point.clientY - start.y
       if (isTouch && !held) {
@@ -1865,7 +1884,7 @@ const DrawerRow = memo(function DrawerRow({
     }
 
     function onUp(upEvent) {
-      const point = drawerGesturePoint(upEvent, pointerId, touchEvents, true)
+      const point = drawerGestureEndPoint(upEvent, pointerId, touchEvents, lastPoint)
       if (!point) return
       if (touchEvents && held) upEvent.preventDefault()
       removeListeners()
@@ -1884,11 +1903,18 @@ const DrawerRow = memo(function DrawerRow({
       settle(true)
     }
     function onCancel(cancelEvent) {
-      if (!drawerGesturePoint(cancelEvent, pointerId, touchEvents, true)) return
+      const point = drawerGestureEndPoint(cancelEvent, pointerId, touchEvents, lastPoint)
+      if (!point) return
+      const openMenu = touchEvents && held && !dragging && !cancelledAfterHold
       removeListeners()
       releaseTouchClaim()
-      if (dragging) settle(false)
-      else finalize(false)
+      if (held) suppressRowClickRef.current = true
+      if (dragging) {
+        settle(false)
+        return
+      }
+      finalize(false)
+      if (openMenu) openItemMenuAt({ x: point.clientX, y: point.clientY })
     }
 
     if (touchEvents) {

--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -1617,6 +1617,10 @@ const DrawerRow = memo(function DrawerRow({
       const point = drawerGesturePoint(upEvent, pointerId, touchEvents, true)
       if (!point) return
       const openMenu = held && !cancelledAfterHold
+      // A touch hold mounts the transparent menu layer during this touchend.
+      // Without consuming the native compatibility click here, Chrome retargets
+      // that trailing click to the new layer and immediately dismisses the menu.
+      if (touchEvents && held) upEvent.preventDefault()
       cleanup({ suppressClick: held })
       if (openMenu) openItemMenuAt({ x: point.clientX, y: point.clientY })
     }
@@ -1634,7 +1638,7 @@ const DrawerRow = memo(function DrawerRow({
       // promotes it to cancelable ownership before the first reorder/menu move.
       window.addEventListener('touchstart', onAdditionalTouch, true)
       window.addEventListener('touchmove', onMove, { capture: true, passive: true })
-      window.addEventListener('touchend', onUp, true)
+      window.addEventListener('touchend', onUp, { capture: true, passive: false })
       window.addEventListener('touchcancel', onCancel, true)
     } else {
       window.addEventListener('pointermove', onMove, { capture: true, passive: false })
@@ -1863,6 +1867,7 @@ const DrawerRow = memo(function DrawerRow({
     function onUp(upEvent) {
       const point = drawerGesturePoint(upEvent, pointerId, touchEvents, true)
       if (!point) return
+      if (touchEvents && held) upEvent.preventDefault()
       removeListeners()
       if (isTouch) {
         const openMenu = held && !dragging && !cancelledAfterHold
@@ -1893,7 +1898,7 @@ const DrawerRow = memo(function DrawerRow({
       // is promoted to cancelable ownership.
       window.addEventListener('touchstart', onAdditionalTouch, true)
       window.addEventListener('touchmove', onMove, { capture: true, passive: true })
-      window.addEventListener('touchend', onUp, true)
+      window.addEventListener('touchend', onUp, { capture: true, passive: false })
       window.addEventListener('touchcancel', onCancel, true)
     } else {
       window.addEventListener('pointermove', onMove, { capture: true, passive: false })

--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -12,7 +12,6 @@ import {
 import { appIconUrl } from '../appIcon.js'
 import {
   computePinnedDrag,
-  heldDrawerRowIntent,
   observePinnedOrderHandoff,
   pinnedEntriesMatchRanks,
   pinnedOrderHandoffStatus,
@@ -64,51 +63,6 @@ import './Drawer.css'
 const EMPTY_SET = new Set()
 const TOUCH_CONTEXT_MENU_PROVENANCE_MS = 1500
 
-// Pointerup can precede the matching touchend. Keep a held row's claim through
-// the current input task so Drawer's touchend recognizer also stands down. The
-// owner check prevents an old release from clearing a newer gesture.
-function deferDrawerGestureClaimRelease(claimRef, owner) {
-  if (claimRef?.current !== owner) return
-  setTimeout(() => {
-    if (claimRef.current === owner) claimRef.current = false
-  }, 0)
-}
-
-function touchWithIdentifier(list, identifier) {
-  for (const touch of list || []) {
-    if (touch.identifier === identifier) return touch
-  }
-  return null
-}
-
-function drawerGesturePoint(event, pointerId, touchEvents, ended = false) {
-  if (!touchEvents) return event.pointerId === pointerId ? event : null
-  return touchWithIdentifier(
-    ended ? event.changedTouches : event.touches,
-    pointerId,
-  )
-}
-
-// Android may end a long press without repeating the cancelled contact in
-// changedTouches. Once that contact is no longer live, its last known position
-// is the end point; otherwise the first hold remains stranded until another
-// touch happens to clean it up.
-function drawerGestureEndPoint(event, pointerId, touchEvents, fallback) {
-  const point = drawerGesturePoint(event, pointerId, touchEvents, true)
-  if (point) return point
-  if (touchEvents && !touchWithIdentifier(event.touches, pointerId)) return fallback
-  return null
-}
-
-function releaseDrawerRowClaim(source, pointerId, touchEvents, claimRef) {
-  source.removeAttribute('data-hold-ready')
-  deferDrawerGestureClaimRelease(claimRef, source)
-  if (touchEvents) return
-  try {
-    if (source.hasPointerCapture?.(pointerId)) source.releasePointerCapture(pointerId)
-  } catch { /* capture may already be gone at pointerup */ }
-}
-
 export default function Drawer({
   open,
   persistent = false,
@@ -154,11 +108,12 @@ export default function Drawer({
   // Truthy when local provider credentials are missing or their status could
   // not be checked. Drives a small warning dot on Settings.
   settingsWarning,
-  // Shared flag raised while any held row gesture owns the touch stream. The
-  // swipe-to-close handlers stand down so a menu/reorder gesture cannot also
-  // move the drawer. The workspace drag controller still uses the same flag for
-  // mouse drag-out. Null when gesture coordination is off.
+  // Shared flag raised while a row is being dragged into the workspace. The
+  // swipe-to-close handlers stand down for that same pointer stream.
   dragActiveRef,
+  // The workspace controller owns the row pointer until its held intent is
+  // clear, then calls the matching row for menu/reorder work.
+  drawerRowGesturesRef,
 }) {
   const streamingSet = streamingChatIds || EMPTY_SET
   const attentionSet = attentionChatIds || EMPTY_SET
@@ -1092,7 +1047,8 @@ export default function Drawer({
                         && renaming.kind === kind
                         && renaming.id === item.id)}
                       actions={rowActions}
-                      gestureClaimRef={dragActiveRef}
+                      dragActiveRef={dragActiveRef}
+                      drawerRowGesturesRef={drawerRowGesturesRef}
                     />
                   ))}
                 </section>
@@ -1145,7 +1101,8 @@ export default function Drawer({
                       && renaming.kind === kind
                       && renaming.id === item.id)}
                     actions={rowActions}
-                    gestureClaimRef={dragActiveRef}
+                    dragActiveRef={dragActiveRef}
+                    drawerRowGesturesRef={drawerRowGesturesRef}
                   />
                 )) : chatsStatus === 'loading' || appsStatus === 'loading' ? (
                   <p className="drawer__list-status" role="status">Loading recents…</p>
@@ -1287,7 +1244,8 @@ const DrawerRow = memo(function DrawerRow({
   menuPlacement,
   renaming,
   actions,
-  gestureClaimRef,
+  dragActiveRef,
+  drawerRowGesturesRef,
 }) {
   const id = item.id
   const label = kind === 'chat' ? item.title : item.name
@@ -1298,11 +1256,12 @@ const DrawerRow = memo(function DrawerRow({
   const holdTimerRef = useRef(null)
   const holdOriginRef = useRef(null)
   const itemButtonRef = useRef(null)
+  const menuRestoreFocusRef = useRef(null)
   const suppressCardClickRef = useRef(false)
   const suppressRowClickRef = useRef(false)
   const reorderCleanupRef = useRef(null)
-  const touchMenuCleanupRef = useRef(null)
   const secondaryReleaseCleanupRef = useRef(null)
+  const drawerGestureHandlerRef = useRef(null)
   // iOS may dispatch its long-press contextmenu AFTER pointercancel. Keep the
   // touch provenance independent of the live pointer session so that delayed
   // native event cannot open actions before a release. It expires, and keyboard
@@ -1351,9 +1310,24 @@ const DrawerRow = memo(function DrawerRow({
   useEffect(() => () => {
     if (holdTimerRef.current) clearTimeout(holdTimerRef.current)
     reorderCleanupRef.current?.()
-    touchMenuCleanupRef.current?.()
     secondaryReleaseCleanupRef.current?.()
   }, [])
+
+  drawerGestureHandlerRef.current = {
+    openMenu: point => openItemMenuAt(point, itemButtonRef.current),
+    beginReorder: session => beginPinnedReorder(session),
+  }
+  useLayoutEffect(() => {
+    if (variant === 'card' || !drawerRowGesturesRef?.current) return undefined
+    const key = `${kind}:${id}`
+    const registry = drawerRowGesturesRef.current
+    registry.set(key, drawerGestureHandlerRef)
+    return () => {
+      if (registry.get(key) === drawerGestureHandlerRef) {
+        registry.delete(key)
+      }
+    }
+  }, [drawerRowGesturesRef, id, kind, variant])
 
   // Autofocus + select-all on rename open so the user can either retype
   // from scratch or tap into the existing name to edit it.
@@ -1392,7 +1366,8 @@ const DrawerRow = memo(function DrawerRow({
     }
   }
 
-  function openItemMenuAt(point) {
+  function openItemMenuAt(point, trigger = itemButtonRef.current) {
+    menuRestoreFocusRef.current = trigger
     actions.toggleMenu(kind, id, true, surface, itemMenuPlacement(point))
   }
 
@@ -1414,8 +1389,9 @@ const DrawerRow = memo(function DrawerRow({
   }
 
   function openItemMenu(event) {
-    // Defense in depth for programmatic dispatch or a renderer that bypasses
-    // the capture prop. Ordinary touch events are stopped during capture.
+    // Touch menus open only from the shared gesture controller on release.
+    // Native long-press contextmenu would fire early and steal drag intent, so
+    // suppress it on both rows and cards; mouse and keyboard remain semantic.
     if (suppressTouchContextMenu(event)) return
     event.preventDefault()
     event.stopPropagation()
@@ -1426,7 +1402,7 @@ const DrawerRow = memo(function DrawerRow({
     openItemMenuAt({
       x: event.clientX,
       y: event.clientY,
-    })
+    }, event.currentTarget)
   }
 
   function recordItemMenuPointer(event) {
@@ -1439,6 +1415,7 @@ const DrawerRow = memo(function DrawerRow({
     if (event.pointerType !== 'mouse' || event.button !== 2) return false
     event.preventDefault()
     secondaryReleaseCleanupRef.current?.()
+    const sourceBtn = event.currentTarget
     const pointerId = event.pointerId
     const placement = itemMenuPlacement({ x: event.clientX, y: event.clientY })
     let timer = null
@@ -1455,7 +1432,7 @@ const DrawerRow = memo(function DrawerRow({
       if (upEvent.pointerId !== pointerId || upEvent.button !== 2) return
       upEvent.preventDefault()
       cleanup()
-      actions.toggleMenu(kind, id, true, surface, placement)
+      openItemMenuAt(placement, sourceBtn)
     }
     window.addEventListener('pointerup', onSecondaryPointerUp, true)
     window.addEventListener('pointercancel', cleanup, true)
@@ -1564,146 +1541,21 @@ const DrawerRow = memo(function DrawerRow({
           menuOpen={menuOpen}
           actions={actions}
           menuPlacement={menuPlacement}
-          restoreFocusRef={itemButtonRef}
+          restoreFocusRef={menuRestoreFocusRef}
         />
       </div>
     )
   }
 
-  function beginTouchMenuHold(event, { touchEvents = false } = {}) {
-    const initialTouch = touchEvents ? event.changedTouches?.[0] : null
-    if (touchEvents ? !initialTouch : (
-      event.pointerType === 'mouse' || event.button !== 0 || !event.isPrimary
-    )) return
-    touchMenuCleanupRef.current?.()
-    const pointerId = touchEvents ? initialTouch.identifier : event.pointerId
-    const sourceBtn = event.currentTarget
-    const start = {
-      x: touchEvents ? initialTouch.clientX : event.clientX,
-      y: touchEvents ? initialTouch.clientY : event.clientY,
-    }
-    let lastPoint = start
-    let held = false
-    let cancelledAfterHold = false
-    let cleaned = false
-
-    function cleanup({ suppressClick = false } = {}) {
-      if (cleaned) return
-      cleaned = true
-      if (holdTimerRef.current) clearTimeout(holdTimerRef.current)
-      holdTimerRef.current = null
-      if (touchEvents) {
-        window.removeEventListener('touchstart', onAdditionalTouch, true)
-        window.removeEventListener('touchmove', onMove, true)
-        window.removeEventListener('touchend', onUp, true)
-        window.removeEventListener('touchcancel', onCancel, true)
-      } else {
-        window.removeEventListener('pointermove', onMove, true)
-        window.removeEventListener('pointerup', onUp, true)
-        window.removeEventListener('pointercancel', onCancel, true)
-      }
-      window.removeEventListener('blur', onInterrupted, true)
-      window.removeEventListener('pagehide', onInterrupted, true)
-      document.removeEventListener('visibilitychange', onVisibility, true)
-      releaseDrawerRowClaim(sourceBtn, pointerId, touchEvents, gestureClaimRef)
-      if (suppressClick) suppressRowClickRef.current = true
-      if (touchMenuCleanupRef.current === cleanup) touchMenuCleanupRef.current = null
-    }
-    function onAdditionalTouch(touchEvent) {
-      if (touchEvent.touches.length > 1) cleanup()
-    }
-    function onMove(moveEvent) {
-      const point = drawerGesturePoint(moveEvent, pointerId, touchEvents)
-      if (!point) return
-      lastPoint = { x: point.clientX, y: point.clientY }
-      const dx = point.clientX - start.x
-      const dy = point.clientY - start.y
-      if (!held) {
-        if (Math.hypot(dx, dy) > PRE_HOLD_MOVE_PX) cleanup()
-        return
-      }
-      if (heldDrawerRowIntent(dx, dy, false) === 'pending') return
-      cancelledAfterHold = true
-      moveEvent.preventDefault()
-    }
-    function onUp(upEvent) {
-      const point = drawerGestureEndPoint(upEvent, pointerId, touchEvents, lastPoint)
-      if (!point) return
-      const openMenu = held && !cancelledAfterHold
-      // A touch hold mounts the transparent menu layer during this touchend.
-      // Without consuming the native compatibility click here, Chrome retargets
-      // that trailing click to the new layer and immediately dismisses the menu.
-      if (touchEvents && held) upEvent.preventDefault()
-      cleanup({ suppressClick: held })
-      if (openMenu) openItemMenuAt({ x: point.clientX, y: point.clientY })
-    }
-    function onCancel(cancelEvent) {
-      const point = drawerGestureEndPoint(cancelEvent, pointerId, touchEvents, lastPoint)
-      if (!point) return
-      const openMenu = touchEvents && held && !cancelledAfterHold
-      cleanup({ suppressClick: held })
-      if (openMenu) openItemMenuAt({ x: point.clientX, y: point.clientY })
-    }
-    function onInterrupted() { cleanup() }
-    function onVisibility() {
-      if (document.visibilityState === 'hidden') cleanup()
-    }
-
-    if (touchEvents) {
-      // Before the hold this listener is passive, so an ordinary row swipe stays
-      // on the browser's native scrolling path. A completed stationary hold
-      // promotes it to cancelable ownership before the first reorder/menu move.
-      window.addEventListener('touchstart', onAdditionalTouch, true)
-      window.addEventListener('touchmove', onMove, { capture: true, passive: true })
-      window.addEventListener('touchend', onUp, { capture: true, passive: false })
-      window.addEventListener('touchcancel', onCancel, true)
-    } else {
-      window.addEventListener('pointermove', onMove, { capture: true, passive: false })
-      window.addEventListener('pointerup', onUp, true)
-      window.addEventListener('pointercancel', onCancel, true)
-    }
-    window.addEventListener('blur', onInterrupted, true)
-    window.addEventListener('pagehide', onInterrupted, true)
-    document.addEventListener('visibilitychange', onVisibility, true)
-    holdTimerRef.current = setTimeout(() => {
-      if (cleaned) return
-      if (touchEvents) {
-        window.removeEventListener('touchmove', onMove, true)
-        window.addEventListener('touchmove', onMove, { capture: true, passive: false })
-      }
-      held = true
-      if (gestureClaimRef) gestureClaimRef.current = sourceBtn
-      sourceBtn.setAttribute('data-hold-ready', 'true')
-      if (!touchEvents) {
-        try { sourceBtn.setPointerCapture?.(pointerId) } catch { /* capture optional */ }
-      }
-    }, DRAWER_HOLD_MS)
-    touchMenuCleanupRef.current = cleanup
-  }
-
-  function beginPinnedReorder(event, { touchEvents = false } = {}) {
-    // Mouse starts reordering after clear vertical slop. Touch first survives a
-    // deliberate hold; release in place opens the contextual menu, while a
-    // following vertical drag reorders. These are one gesture owner, so touch
-    // can never also drag the row into the workspace or move the drawer.
-    const initialTouch = touchEvents ? event.changedTouches?.[0] : null
-    if (!pinned || (touchEvents ? !initialTouch : (
-      event.button !== 0 || !event.isPrimary
-    ))) return
-    const isTouch = touchEvents || event.pointerType !== 'mouse'
+  function beginPinnedReorder({ pointerId, start, moveEvent }) {
+    if (!pinned || !moveEvent) return false
     // Finish any still-settling previous drag before this gesture can measure;
     // lingering transforms from the old preview would poison the new geometry.
     reorderCleanupRef.current?.()
 
-    const pointerId = touchEvents ? initialTouch.identifier : event.pointerId
-    const start = {
-      x: touchEvents ? initialTouch.clientX : event.clientX,
-      y: touchEvents ? initialTouch.clientY : event.clientY,
-    }
-    let lastPoint = start
-    const sourceBtn = event.currentTarget
-    let held = !isTouch
-    let cancelledAfterHold = false
+    const sourceBtn = itemButtonRef.current
+    if (!sourceBtn) return false
+    const previousBodySelect = document.body.style.userSelect
     let dragging = false
     let listenersOff = false
     let cancelOrderHandoff = null
@@ -1712,12 +1564,15 @@ const DrawerRow = memo(function DrawerRow({
     let fromIndex = -1
     let src = null
     let pinnedSection = null
+    let ownsDragClaim = false
     let last = { slotDelta: 0, finalKeys: null, changed: false, shifts: new Map() }
 
-    function releaseTouchClaim() {
-      if (!isTouch) return
-      releaseDrawerRowClaim(sourceBtn, pointerId, touchEvents, gestureClaimRef)
+    function releaseDragClaim() {
+      if (!ownsDragClaim) return
+      ownsDragClaim = false
+      dragActiveRef.current = false
     }
+
     function clearStyles() {
       if (stylesCleared) return
       stylesCleared = true
@@ -1728,29 +1583,23 @@ const DrawerRow = memo(function DrawerRow({
         s.position = ''; s.willChange = ''
       }
       src?.btn.removeAttribute('data-reordering')
-      sourceBtn.removeAttribute('data-hold-ready')
-      releaseTouchClaim()
-      document.body.style.userSelect = ''
+      document.body.style.userSelect = previousBodySelect
+      releaseDragClaim()
+      try {
+        if (sourceBtn.hasPointerCapture?.(pointerId)) sourceBtn.releasePointerCapture(pointerId)
+      } catch { /* capture may already be gone at pointerup */ }
       if (reorderCleanupRef.current === forceFinish) reorderCleanupRef.current = null
     }
     function removeListeners() {
       if (listenersOff) return
       listenersOff = true
-      if (touchEvents) {
-        window.removeEventListener('touchstart', onAdditionalTouch, true)
-        window.removeEventListener('touchmove', onMove, true)
-        window.removeEventListener('touchend', onUp, true)
-        window.removeEventListener('touchcancel', onCancel, true)
-      } else {
-        window.removeEventListener('pointermove', onMove, true)
-        window.removeEventListener('pointerup', onUp, true)
-        window.removeEventListener('pointercancel', onCancel, true)
-      }
+      window.removeEventListener('pointermove', onMove, true)
+      window.removeEventListener('pointerup', onUp, true)
+      window.removeEventListener('pointercancel', onCancel, true)
       window.removeEventListener('blur', forceFinish, true)
       window.removeEventListener('pagehide', forceFinish, true)
+      window.removeEventListener('contextmenu', suppressNativeContextMenu, true)
       document.removeEventListener('visibilitychange', onVisibility, true)
-      if (holdTimerRef.current) clearTimeout(holdTimerRef.current)
-      holdTimerRef.current = null
     }
     // One-shot teardown for the whole session, guarded so a settle that resolves
     // AFTER a superseding drag has taken over cannot double-commit or wipe the
@@ -1784,14 +1633,16 @@ const DrawerRow = memo(function DrawerRow({
     function onVisibility() {
       if (document.visibilityState === 'hidden') forceFinish()
     }
+    function suppressNativeContextMenu(contextEvent) {
+      contextEvent.preventDefault()
+    }
     reorderCleanupRef.current = forceFinish
 
     function measureRows() {
       const drawerEl = sourceBtn.closest('#navigation-drawer')
       pinnedSection = sourceBtn.closest('.drawer__section')
       const wrapOf = (btn) => btn.closest('.drawer__row') || btn
-      // Measure once only after reorder intent wins. Ordinary touch scrolls do
-      // no layout work at pointerdown, keeping the first scroll frame crisp.
+      // Measure once only after the held row resolves to vertical reordering.
       rows = [...(drawerEl || document).querySelectorAll('[data-pinned-key]')]
         .map((btn) => {
           const wrap = wrapOf(btn)
@@ -1810,7 +1661,6 @@ const DrawerRow = memo(function DrawerRow({
       if (!measureRows()) return false
       dragging = true
       src.btn.setAttribute('data-reordering', 'true')
-      src.btn.removeAttribute('data-hold-ready')
       const s = src.wrap.style
       s.zIndex = '6'; s.position = 'relative'; s.transition = 'none'; s.willChange = 'transform'
       for (const r of rows) {
@@ -1822,37 +1672,9 @@ const DrawerRow = memo(function DrawerRow({
       return true
     }
 
-    function onAdditionalTouch(touchEvent) {
-      if (touchEvent.touches.length > 1) finalize(false)
-    }
     function onMove(moveEvent) {
-      const point = drawerGesturePoint(moveEvent, pointerId, touchEvents)
-      if (!point) return
-      lastPoint = { x: point.clientX, y: point.clientY }
-      const dx = point.clientX - start.x
-      const dy = point.clientY - start.y
-      if (isTouch && !held) {
-        if (Math.hypot(dx, dy) > PRE_HOLD_MOVE_PX) finalize(false)
-        return
-      }
-      if (isTouch && cancelledAfterHold) {
-        moveEvent.preventDefault()
-        return
-      }
-      if (!dragging) {
-        if (isTouch) {
-          const intent = heldDrawerRowIntent(dx, dy, true)
-          if (intent === 'pending') return
-          if (intent === 'cancel') {
-            cancelledAfterHold = true
-            moveEvent.preventDefault()
-            return
-          }
-        } else if (Math.abs(dx) > Math.abs(dy) || Math.abs(dy) < PRE_HOLD_MOVE_PX) {
-          return
-        }
-        if (!armDrag()) { finalize(false); return }
-      }
+      if (moveEvent.pointerId !== pointerId) return
+      const dy = moveEvent.clientY - start.y
       moveEvent.preventDefault()
       last = computePinnedDrag(rows, fromIndex, dy)
       src.wrap.style.transform = `translateY(${dy}px)`
@@ -1884,71 +1706,40 @@ const DrawerRow = memo(function DrawerRow({
     }
 
     function onUp(upEvent) {
-      const point = drawerGestureEndPoint(upEvent, pointerId, touchEvents, lastPoint)
-      if (!point) return
-      if (touchEvents && held) upEvent.preventDefault()
+      if (upEvent.pointerId !== pointerId) return
       removeListeners()
-      if (isTouch) {
-        const openMenu = held && !dragging && !cancelledAfterHold
-        releaseTouchClaim()
-        if (held) suppressRowClickRef.current = true
-        if (!dragging) {
-          finalize(false)
-          if (openMenu) openItemMenuAt({ x: point.clientX, y: point.clientY })
-          return
-        }
-      }
+      releaseDragClaim()
       if (!dragging) { finalize(false); return }
       suppressRowClickRef.current = true
       settle(true)
     }
     function onCancel(cancelEvent) {
-      const point = drawerGestureEndPoint(cancelEvent, pointerId, touchEvents, lastPoint)
-      if (!point) return
-      const openMenu = touchEvents && held && !dragging && !cancelledAfterHold
+      if (cancelEvent.pointerId !== pointerId) return
       removeListeners()
-      releaseTouchClaim()
-      if (held) suppressRowClickRef.current = true
+      releaseDragClaim()
       if (dragging) {
         settle(false)
         return
       }
       finalize(false)
-      if (openMenu) openItemMenuAt({ x: point.clientX, y: point.clientY })
     }
 
-    if (touchEvents) {
-      // Android may cancel the parallel Pointer Events stream as soon as it
-      // considers vertical panning. Keep the Touch Events session passive until
-      // a stationary hold resolves; only the deliberate reorder/menu gesture
-      // is promoted to cancelable ownership.
-      window.addEventListener('touchstart', onAdditionalTouch, true)
-      window.addEventListener('touchmove', onMove, { capture: true, passive: true })
-      window.addEventListener('touchend', onUp, { capture: true, passive: false })
-      window.addEventListener('touchcancel', onCancel, true)
-    } else {
-      window.addEventListener('pointermove', onMove, { capture: true, passive: false })
-      window.addEventListener('pointerup', onUp, true)
-      window.addEventListener('pointercancel', onCancel, true)
-    }
+    window.addEventListener('pointermove', onMove, { capture: true, passive: false })
+    window.addEventListener('pointerup', onUp, true)
+    window.addEventListener('pointercancel', onCancel, true)
     window.addEventListener('blur', forceFinish, true)
     window.addEventListener('pagehide', forceFinish, true)
+    window.addEventListener('contextmenu', suppressNativeContextMenu, true)
     document.addEventListener('visibilitychange', onVisibility, true)
-    if (isTouch) {
-      holdTimerRef.current = setTimeout(() => {
-        if (ended) return
-        if (touchEvents) {
-          window.removeEventListener('touchmove', onMove, true)
-          window.addEventListener('touchmove', onMove, { capture: true, passive: false })
-        }
-        held = true
-        if (gestureClaimRef) gestureClaimRef.current = sourceBtn
-        sourceBtn.setAttribute('data-hold-ready', 'true')
-        if (!touchEvents) {
-          try { sourceBtn.setPointerCapture?.(pointerId) } catch { /* capture optional */ }
-        }
-      }, DRAWER_HOLD_MS)
+    if (!armDrag()) {
+      finalize(false)
+      return false
     }
+    ownsDragClaim = true
+    dragActiveRef.current = true
+    try { sourceBtn.setPointerCapture?.(pointerId) } catch { /* capture optional */ }
+    onMove(moveEvent)
+    return true
   }
 
   function onRowPointerDown(event) {
@@ -1957,42 +1748,23 @@ const DrawerRow = memo(function DrawerRow({
     // and must retire the old one-shot guard rather than inherit it.
     suppressRowClickRef.current = false
     recordItemMenuPointer(event)
-    if (beginSecondaryMenuPress(event)) return
-    // Android can retire its Pointer Events stream when vertical panning is
-    // possible. Finger gestures are therefore owned by onRowTouchStart below;
-    // mouse and pen keep the pointer path.
-    if (event.pointerType === 'touch') return
-    if (event.pointerType !== 'mouse' && !pinned) {
-      beginTouchMenuHold(event)
-      return
-    }
-    beginPinnedReorder(event)
-  }
-
-  function onRowTouchStart(event) {
-    if (event.touches.length !== 1 || event.changedTouches.length !== 1) return
-    suppressRowClickRef.current = false
-    touchMenuPointerAtRef.current = performance.now()
-    if (pinned) beginPinnedReorder(event, { touchEvents: true })
-    else beginTouchMenuHold(event, { touchEvents: true })
+    beginSecondaryMenuPress(event)
   }
 
   return (
-    <div className="drawer__row" ref={wrapRef}>
+    <div className={`drawer__row${active ? ' drawer__row--active' : ''}`} ref={wrapRef}>
       <button
         ref={itemButtonRef}
         type="button"
         className={`drawer__item ${active ? 'drawer__item--active' : ''}`}
         aria-current={active ? 'page' : undefined}
-        // Mouse drag source for the workspace controller (design §3.1). Touch
-        // stays local through a Touch Events session: hold-release opens
-        // actions and held vertical movement reorders a pin, so Android cannot
-        // retire the gesture by cancelling its parallel pointer stream.
+        // One shared controller resolves a held row only after intent is clear:
+        // release for actions, vertical movement to reorder a pin, outward
+        // movement to place it in the workspace.
         data-drawer-key={`${kind}:${id}`}
         data-drag-key={`${kind}:${id}`}
         data-pinned-key={pinned ? `${kind}:${id}` : undefined}
         onPointerDown={onRowPointerDown}
-        onTouchStart={onRowTouchStart}
         onClick={() => {
           if (suppressRowClickRef.current) {
             suppressRowClickRef.current = false
@@ -2004,7 +1776,6 @@ const DrawerRow = memo(function DrawerRow({
           event.preventDefault()
           actions.startRename(kind, id, surface)
         }}
-        onContextMenuCapture={suppressTouchContextMenu}
         onContextMenu={openItemMenu}
         onKeyDown={event => {
           suppressRowClickRef.current = false
@@ -2051,7 +1822,7 @@ const DrawerRow = memo(function DrawerRow({
         menuOpen={menuOpen}
         actions={actions}
         menuPlacement={menuPlacement}
-        restoreFocusRef={itemButtonRef}
+        restoreFocusRef={menuRestoreFocusRef}
       />
     </div>
   )

--- a/frontend/src/components/Drawer/DrawerItemActionMenu.jsx
+++ b/frontend/src/components/Drawer/DrawerItemActionMenu.jsx
@@ -30,6 +30,7 @@ export default function DrawerItemActionMenu({
   const menuRef = useRef(null)
   const wasOpenRef = useRef(false)
   const restoreOnCloseRef = useRef(true)
+  const outsidePointerDownRef = useRef(null)
   const [confirmation, setConfirmation] = useState(null)
   const [position, setPosition] = useState(null)
 
@@ -37,6 +38,10 @@ export default function DrawerItemActionMenu({
     restoreOnCloseRef.current = restoreFocus
     onClose()
   }
+
+  useLayoutEffect(() => {
+    if (open) outsidePointerDownRef.current = null
+  }, [open])
 
   useEffect(() => {
     if (open) {
@@ -145,13 +150,25 @@ export default function DrawerItemActionMenu({
       onPointerDown={event => {
         // Keep the layer mounted for the complete tap. Closing on pointerdown
         // lets Android retarget the later release/click to the row underneath.
-        consumeOutsidePointer(event)
+        if (consumeOutsidePointer(event)) {
+          outsidePointerDownRef.current = event.pointerId
+        }
       }}
       onPointerUp={event => {
         consumeOutsidePointer(event)
       }}
+      onPointerCancel={event => {
+        if (consumeOutsidePointer(event)) outsidePointerDownRef.current = null
+      }}
       onClick={event => {
-        if (consumeOutsidePointer(event)) close()
+        if (!consumeOutsidePointer(event)) return
+        // A hold can mount this layer between the source pointerup and its
+        // browser-generated click. That click never began on the layer, so it
+        // must not dismiss the menu it just opened. A deliberate outside tap
+        // always contributes the layer-owned pointerdown recorded above.
+        if (outsidePointerDownRef.current == null) return
+        outsidePointerDownRef.current = null
+        close()
       }}
       onContextMenu={event => event.preventDefault()}
       onWheel={event => {

--- a/frontend/src/components/Drawer/DrawerItemActionMenu.jsx
+++ b/frontend/src/components/Drawer/DrawerItemActionMenu.jsx
@@ -30,7 +30,7 @@ export default function DrawerItemActionMenu({
   const menuRef = useRef(null)
   const wasOpenRef = useRef(false)
   const restoreOnCloseRef = useRef(true)
-  const outsidePointerDownRef = useRef(null)
+  const outsidePressStartedRef = useRef(false)
   const [confirmation, setConfirmation] = useState(null)
   const [position, setPosition] = useState(null)
 
@@ -39,15 +39,12 @@ export default function DrawerItemActionMenu({
     onClose()
   }
 
-  useLayoutEffect(() => {
-    if (open) outsidePointerDownRef.current = null
-  }, [open])
-
   useEffect(() => {
     if (open) {
       wasOpenRef.current = true
       return
     }
+    outsidePressStartedRef.current = false
     setConfirmation(null)
     setPosition(null)
     if (!wasOpenRef.current) return
@@ -151,23 +148,20 @@ export default function DrawerItemActionMenu({
         // Keep the layer mounted for the complete tap. Closing on pointerdown
         // lets Android retarget the later release/click to the row underneath.
         if (consumeOutsidePointer(event)) {
-          outsidePointerDownRef.current = event.pointerId
+          outsidePressStartedRef.current = true
         }
       }}
       onPointerUp={event => {
         consumeOutsidePointer(event)
       }}
-      onPointerCancel={event => {
-        if (consumeOutsidePointer(event)) outsidePointerDownRef.current = null
+      onPointerCancel={() => {
+        outsidePressStartedRef.current = false
       }}
       onClick={event => {
-        if (!consumeOutsidePointer(event)) return
-        // A hold can mount this layer between the source pointerup and its
-        // browser-generated click. That click never began on the layer, so it
-        // must not dismiss the menu it just opened. A deliberate outside tap
-        // always contributes the layer-owned pointerdown recorded above.
-        if (outsidePointerDownRef.current == null) return
-        outsidePointerDownRef.current = null
+        // The opener click can be retargeted to a layer that did not exist at
+        // pointerdown; only a new press that began on the layer may dismiss it.
+        if (!consumeOutsidePointer(event) || !outsidePressStartedRef.current) return
+        outsidePressStartedRef.current = false
         close()
       }}
       onContextMenu={event => event.preventDefault()}

--- a/frontend/src/components/Drawer/pinnedReorder.js
+++ b/frontend/src/components/Drawer/pinnedReorder.js
@@ -12,18 +12,6 @@
 // that identity is what lets the drop settle with no jump, regardless of whether
 // rows have different heights (app rows are taller than chat rows).
 
-import { PRE_HOLD_MOVE_PX } from '../Shell/dragController.js'
-
-// Once a touch hold has claimed a drawer row, only a clearly vertical movement
-// on a pinned item can become reordering. Every other movement cancels the row
-// action while remaining claimed until release, so the same finger cannot fall
-// through into drawer swipe-close or workspace drag-out.
-export function heldDrawerRowIntent(dx, dy, pinned, limit = PRE_HOLD_MOVE_PX) {
-  if (Math.hypot(dx, dy) <= limit) return 'pending'
-  if (pinned && Math.abs(dy) > Math.abs(dx)) return 'reorder'
-  return 'cancel'
-}
-
 export function computePinnedDrag(rows, fromIndex, deltaY) {
   const src = rows[fromIndex]
   const anchorTop = rows[0].top // top edge of the pinned region — a fixed anchor

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -1135,6 +1135,7 @@ export default function Shell() {
   sceneInputsRef.current = { projection, mode: workspaceMode, contentRect }
   const labelForTabRef = useRef(labelForTab)
   labelForTabRef.current = labelForTab
+  const drawerRowGesturesRef = useRef(new Map())
   // A single-mode drag previews the builder world through the ONE descriptor
   // (INV 5): arm is phase 'drag-preview', and the id it mints is carried to the
   // matching end so a stale event from a superseded drag is ignored.
@@ -1212,6 +1213,7 @@ export default function Shell() {
     labelForTabRef,
     dragActiveRef,
     drawerOpenRef,
+    drawerRowGesturesRef,
     closeDrawer,
     openDrawer,
     onPreviewBuilder: onModeDragPreview,
@@ -2997,6 +2999,7 @@ export default function Shell() {
         newAppIds={appAttentionSet}
         settingsWarning={providerAuth.needsAttention}
         dragActiveRef={dragActiveRef}
+        drawerRowGesturesRef={drawerRowGesturesRef}
       />
 
       {showWalkthrough && (

--- a/frontend/src/components/Shell/__tests__/dragController.test.js
+++ b/frontend/src/components/Shell/__tests__/dragController.test.js
@@ -5,7 +5,7 @@ import {
   HYSTERESIS_PX, ROOT_EDGE_PX, CARET_W, CARET_H, CENTER_INSET, DRAWER_EXIT_PX,
   CHIP_MOUSE_DX, CHIP_MOUSE_DY, CHIP_TOUCH_ABOVE,
   EDGE_BAND_MIN, EDGE_BAND_FRACTION,
-  passedSlop, touchTabMoveIntent, releasedInPlace, chipOffset,
+  passedSlop, touchTabMoveIntent, drawerRowMoveIntent, releasedInPlace, chipOffset,
   clientPointToLocal,
   crossedDrawerExit, edgeBands, edgePreviewRect, caretZone, edgeZone, centerZone,
   rootEdgeZone, hitTest, zoneTarget, releaseZone, zoneEq, buildScene,
@@ -60,6 +60,20 @@ test('touchTabMoveIntent reserves every pre-hold tab move for scrolling', () => 
   assert.equal(touchTabMoveIntent(0, 8.1), 'scroll', 'vertical jitter does not bypass the hold')
   assert.equal(touchTabMoveIntent(8.1, 0), 'scroll', 'horizontal pull scrolls over a tab body')
   assert.equal(PRE_HOLD_MOVE_PX, 8)
+})
+
+test('drawerRowMoveIntent resolves one gesture without competing owners', () => {
+  const touchPin = { isTouch: true, pinned: true }
+  assert.equal(drawerRowMoveIntent(4, 4, touchPin), 'pending')
+  assert.equal(drawerRowMoveIntent(0, 9, touchPin), 'yield',
+    'movement before the hold returns to native navigation')
+  assert.equal(drawerRowMoveIntent(0, 9, { ...touchPin, held: true }), 'reorder')
+  assert.equal(drawerRowMoveIntent(9, 0, { ...touchPin, held: true }), 'workspace')
+  assert.equal(drawerRowMoveIntent(-9, 0, { ...touchPin, held: true }), 'cancel')
+  assert.equal(drawerRowMoveIntent(0, 9, { isTouch: true, held: true }), 'cancel',
+    'an unpinned row cannot enter the reorder branch')
+  assert.equal(drawerRowMoveIntent(0, 6, { pinned: true }), 'reorder',
+    'mouse rows use ordinary drag slop without a hold')
 })
 
 test('releasedInPlace is true only within the release radius', () => {

--- a/frontend/src/components/Shell/__tests__/dragController.test.js
+++ b/frontend/src/components/Shell/__tests__/dragController.test.js
@@ -1,7 +1,8 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import {
-  POINTER_SLOP, TAB_HOLD_MS, DRAWER_HOLD_MS, PRE_HOLD_MOVE_PX, RELEASE_IN_PLACE_PX,
+  POINTER_SLOP, TAB_HOLD_MS, DRAWER_DRAG_HOLD_MS, DRAWER_MENU_HOLD_MS,
+  PRE_HOLD_MOVE_PX, RELEASE_IN_PLACE_PX,
   HYSTERESIS_PX, ROOT_EDGE_PX, CARET_W, CARET_H, CENTER_INSET, DRAWER_EXIT_PX,
   CHIP_MOUSE_DX, CHIP_MOUSE_DY, CHIP_TOUCH_ABOVE,
   EDGE_BAND_MIN, EDGE_BAND_FRACTION,
@@ -85,9 +86,12 @@ test('releasedInPlace is true only within the release radius', () => {
   assert.equal(releasedInPlace(RELEASE_IN_PLACE_PX + 0.1, 0), false)
 })
 
-test('drawer rows retain a more deliberate hold than tabs', () => {
+test('drawer rows expose drag before a stationary hold opens actions', () => {
   assert.equal(TAB_HOLD_MS, 350)
-  assert.equal(DRAWER_HOLD_MS, 450)
+  assert.equal(DRAWER_DRAG_HOLD_MS, 180)
+  assert.equal(DRAWER_MENU_HOLD_MS, 550)
+  assert.ok(DRAWER_DRAG_HOLD_MS < TAB_HOLD_MS)
+  assert.ok(DRAWER_MENU_HOLD_MS > TAB_HOLD_MS)
 })
 
 test('chipOffset floats above a touch point and trails a mouse', () => {

--- a/frontend/src/components/Shell/__tests__/dragController.test.js
+++ b/frontend/src/components/Shell/__tests__/dragController.test.js
@@ -65,8 +65,12 @@ test('touchTabMoveIntent reserves every pre-hold tab move for scrolling', () => 
 test('drawerRowMoveIntent resolves one gesture without competing owners', () => {
   const touchPin = { isTouch: true, pinned: true }
   assert.equal(drawerRowMoveIntent(4, 4, touchPin), 'pending')
-  assert.equal(drawerRowMoveIntent(0, 9, touchPin), 'yield',
-    'movement before the hold returns to native navigation')
+  assert.equal(drawerRowMoveIntent(0, 9, touchPin), 'scroll',
+    'vertical movement before the hold scrolls through the pointer owner')
+  assert.equal(drawerRowMoveIntent(9, 0, touchPin), 'yield',
+    'horizontal movement before the hold returns to drawer swipe')
+  assert.equal(drawerRowMoveIntent(0, 9, { isTouch: true }), 'yield',
+    'an unpinned row keeps native momentum scrolling')
   assert.equal(drawerRowMoveIntent(0, 9, { ...touchPin, held: true }), 'reorder')
   assert.equal(drawerRowMoveIntent(9, 0, { ...touchPin, held: true }), 'workspace')
   assert.equal(drawerRowMoveIntent(-9, 0, { ...touchPin, held: true }), 'cancel')

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -672,6 +672,14 @@ test('mobile tabs require a hold before dragging while the strip preserves pinch
   assert.equal((drawer.match(/window\.addEventListener\('touchend', onUp, \{ capture: true, passive: false \}\)/g) || []).length, 2,
     'held row releases must be allowed to suppress their compatibility click')
   assert.match(drawer, /onTouchStart=\{onRowTouchStart\}/)
+  assert.match(drawer, /function drawerGestureEndPoint\(event, pointerId, touchEvents, fallback\)[\s\S]*?!touchWithIdentifier\(event\.touches, pointerId\)[\s\S]*?return fallback/,
+    'a terminal Android touch with empty changedTouches must still settle the first hold')
+  assert.equal((drawer.match(/const point = drawerGestureEndPoint\(cancelEvent, pointerId, touchEvents, lastPoint\)/g) || []).length, 2,
+    'pinned and recent rows must both settle a cancelled touch hold')
+  assert.match(drawer, /const openMenu = touchEvents && held && !cancelledAfterHold/,
+    'a recognized stationary hold must open even when Android terminates it with touchcancel')
+  assert.match(drawer, /const openMenu = touchEvents && held && !dragging && !cancelledAfterHold/,
+    'a stationary pinned hold must open while a cancelled reorder still rolls back')
   assert.match(drawer, /const TOUCH_CONTEXT_MENU_PROVENANCE_MS = 1500/)
   assert.match(drawer, /function suppressTouchContextMenu\(event\)[\s\S]*?event\.nativeEvent\?\.pointerType[\s\S]*?contextPointerType === 'touch'[\s\S]*?freshTouchPointer[\s\S]*?event\.preventDefault\(\)[\s\S]*?event\.stopPropagation\(\)[\s\S]*?stopImmediatePropagation/)
   assert.equal((drawer.match(/onContextMenuCapture=\{suppressTouchContextMenu\}/g) || []).length, 2,

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -89,8 +89,7 @@ test('an implicit home tab does not engage the single-pane tab strip', () => {
 test('the canonical workspace snapshot survives a closed PWA relaunch', () => {
   assert.match(
     shell,
-    /useWorkspaceSession\(\{\s*storage: localStorage,\s*legacyStorage: sessionStorage,\s*\}\)/,
-    'the durable snapshot remains canonical while the one-time session migration stays available',
+    /useWorkspaceSession\(\{ storage: localStorage \}\)/,
   )
   assert.doesNotMatch(
     shell,
@@ -641,7 +640,7 @@ test('the logo keeps the stable "Toggle navigation" name; gesture rides aria-des
   assert.match(shellBrand, /builderModeActive \? 'Builder mode' : 'Single screen'/)
 })
 
-test('mobile tabs require a hold before dragging while the strip preserves pinch zoom', () => {
+test('one held drawer-row gesture resolves menu, reorder, or workspace drag', () => {
   assert.match(shellCss, /\.shell__tabstrip\s*\{[\s\S]*?touch-action:\s*pan-x pinch-zoom/)
   assert.match(shellCss, /\.shell__tab-open\[data-drag-key\]\s*\{[\s\S]*?touch-action:\s*pinch-zoom/)
   assert.doesNotMatch(shellCss, /data-touch-drag-handle/)
@@ -652,44 +651,42 @@ test('mobile tabs require a hold before dragging while the strip preserves pinch
   assert.match(drawerCss, /\.drawer__row \.drawer__item\[data-drag-key\]\s*\{[\s\S]*?touch-action:\s*pan-y pinch-zoom/)
   assert.match(dragBinding, /touchTabMoveIntent\(dx, dy\)/)
   assert.match(dragBinding, /scrollStripEl\.scrollLeft \+= previousPoint\.x - ev\.clientX/)
-  assert.match(
+  assert.doesNotMatch(
     dragBinding,
     /sourceKind === 'drawer' && e\.pointerType !== 'mouse'\) return/,
-    'touch drawer rows must not enter the workspace drag-out controller',
+    'touch drawer rows must remain available to the workspace drag controller',
   )
-  assert.match(drawer, /heldDrawerRowIntent\(dx, dy, true\)/)
-  assert.match(drawer, /openItemMenuAt\(\{ x: point\.clientX, y: point\.clientY \}\)/)
+  assert.match(dragBinding, /sourceKind === 'drawer' \? DRAWER_HOLD_MS : TAB_HOLD_MS/)
+  assert.match(dragBinding, /if \(sourceKind !== 'drawer'\) arm\(\)/,
+    'a drawer hold waits for intent rather than opening or dragging immediately')
+  assert.match(dragBinding, /drawerRowMoveIntent\(dx, dy, \{[\s\S]*?held,[\s\S]*?isTouch,[\s\S]*?data-pinned-key/,
+    'one pure decision boundary owns the held row directions')
+  assert.match(dragBinding, /intent === 'reorder'[\s\S]*?beginReorder/,
+    'the reorder outcome hands off to the row implementation')
+  assert.match(dragBinding, /intent === 'workspace'\) arm\(\)/,
+    'the workspace outcome arms the shared drag implementation')
+  assert.match(dragBinding, /sourceKind === 'drawer' && held[\s\S]*?cleanup\(\{ suppressClick: true \}\)[\s\S]*?handler\?\.openMenu\?\.\(point\)/,
+    'a stationary held release opens actions only after cleanup')
   assert.doesNotMatch(dragBinding, /openTabMenuAtRef/)
   assert.doesNotMatch(dragBinding, /addEventListener\('touchmove'/)
-  assert.match(drawer, /function beginTouchMenuHold\(event, \{ touchEvents = false \} = \{\}\)/)
-  assert.match(drawer, /function onRowTouchStart\(event\)[\s\S]*?beginPinnedReorder\(event, \{ touchEvents: true \}\)/)
-  assert.match(drawer, /if \(event\.pointerType === 'touch'\) return/)
-  assert.equal((drawer.match(/window\.addEventListener\('touchmove', onMove, \{ capture: true, passive: true \}\)/g) || []).length, 2,
-    'ordinary drawer-row scrolling must begin with passive touch listeners')
-  assert.equal((drawer.match(/holdTimerRef\.current = setTimeout\(\(\) => \{[\s\S]*?window\.addEventListener\('touchmove', onMove, \{ capture: true, passive: false \}\)/g) || []).length, 2,
-    'only a resolved hold may promote row gestures to cancelable ownership')
-  assert.doesNotMatch(drawer, /blockingTouchMove|function claimTouchMoves/)
-  assert.equal((drawer.match(/window\.addEventListener\('touchend', onUp, \{ capture: true, passive: false \}\)/g) || []).length, 2,
-    'held row releases must be allowed to suppress their compatibility click')
-  assert.match(drawer, /onTouchStart=\{onRowTouchStart\}/)
-  assert.match(drawer, /function drawerGestureEndPoint\(event, pointerId, touchEvents, fallback\)[\s\S]*?!touchWithIdentifier\(event\.touches, pointerId\)[\s\S]*?return fallback/,
-    'a terminal Android touch with empty changedTouches must still settle the first hold')
-  assert.equal((drawer.match(/const point = drawerGestureEndPoint\(cancelEvent, pointerId, touchEvents, lastPoint\)/g) || []).length, 2,
-    'pinned and recent rows must both settle a cancelled touch hold')
-  assert.match(drawer, /const openMenu = touchEvents && held && !cancelledAfterHold/,
-    'a recognized stationary hold must open even when Android terminates it with touchcancel')
-  assert.match(drawer, /const openMenu = touchEvents && held && !dragging && !cancelledAfterHold/,
-    'a stationary pinned hold must open while a cancelled reorder still rolls back')
+  assert.match(shell, /const drawerRowGesturesRef = useRef\(new Map\(\)\)/)
+  assert.match(drawer, /const registry = drawerRowGesturesRef\.current[\s\S]*?registry\.set\(key, drawerGestureHandlerRef\)/)
+  assert.doesNotMatch(drawer, /pinnedReorderIntent|heldDrawerRowIntent/,
+    'the row implementation must not classify the same gesture a second time')
+  assert.doesNotMatch(drawer, /onTouchStart|addEventListener\('touchmove'|addEventListener\('touchend'/,
+    'reordering has one Pointer Events lifecycle')
+  assert.doesNotMatch(drawer, /beginTouchMenuHold|touchMenuCleanupRef|drawerGestureEndPoint/,
+    'drawer menu access must not own a parallel custom touch lifecycle')
   assert.match(drawer, /const TOUCH_CONTEXT_MENU_PROVENANCE_MS = 1500/)
   assert.match(drawer, /function suppressTouchContextMenu\(event\)[\s\S]*?event\.nativeEvent\?\.pointerType[\s\S]*?contextPointerType === 'touch'[\s\S]*?freshTouchPointer[\s\S]*?event\.preventDefault\(\)[\s\S]*?event\.stopPropagation\(\)[\s\S]*?stopImmediatePropagation/)
-  assert.equal((drawer.match(/onContextMenuCapture=\{suppressTouchContextMenu\}/g) || []).length, 2,
-    'touch contextmenu must be stopped before the shared bubble-phase menu opener')
-  assert.match(drawerCss, /\.drawer__row \.drawer__item\s*\{[\s\S]*?-webkit-touch-callout:\s*none/)
-  assert.match(drawer, /sourceBtn\.setAttribute\('data-hold-ready', 'true'\)/)
-  assert.match(drawer, /const openMenu = held && !dragging && !cancelledAfterHold/)
-  assert.match(drawer, /if \(openMenu\) openItemMenuAt\(\{ x: point\.clientX, y: point\.clientY \}\)/)
-  assert.match(drawer, /if \(intent === 'cancel'\)[\s\S]*?cancelledAfterHold = true/)
-  assert.match(drawerCss, /\.drawer__item\[data-hold-ready="true"\]/)
+  assert.equal((drawer.match(/onContextMenuCapture=\{suppressTouchContextMenu\}/g) || []).length, 1,
+    'the card still suppresses native contextmenu during its own hold')
+  assert.doesNotMatch(drawerCss, /\.drawer__row \.drawer__item\s*\{[\s\S]*?-webkit-touch-callout:/,
+    'the shared controller owns callout suppression for its full hold window')
+  assert.doesNotMatch(drawer, /data-hold-ready/)
+  assert.match(drawer, /if \(dragging\) \{[\s\S]*?settle\(false\)/,
+    'a cancelled pinned reorder still rolls back')
+  assert.doesNotMatch(drawerCss, /data-hold-ready/)
 })
 
 test('drawer swipe-to-close leaves vertical scrolling on the native pointer path', () => {
@@ -833,7 +830,7 @@ test('live preview reveal keeps the workspace controller distinct from device mo
   assert.doesNotMatch(shell, /const mode = paneModel\.modeForRect\(contentRect\)/)
 })
 
-test('drawer rows preserve ordering, action identity, and app artwork', () => {
+test('large drawer lists memoize ordering and row actions without changing row ownership', () => {
   assert.match(drawer, /useMemo\(\(\) => buildDrawerSections\(chats, apps\), \[chats, apps\]\)/)
   assert.match(drawer, /const filteredApps = useMemo\(/)
   assert.match(drawer, /const rowActions = useMemo\(/)
@@ -841,6 +838,9 @@ test('drawer rows preserve ordering, action identity, and app artwork', () => {
   assert.match(drawer, /visibleRecents\.map\(\(\{ kind, item \}\)[\s\S]*?item=\{item\}[\s\S]*?actions=\{rowActions\}/)
   assert.match(drawer, /item=\{app\}[\s\S]*?actions=\{rowActions\}/)
   assert.doesNotMatch(drawer, /onSelect=\{\(\) => on(?:Chat|App)/)
+})
+
+test('mixed recents reserve artwork for apps without redundant chat icons', () => {
   assert.match(drawer, /kind === 'app'[\s\S]*?<AppIcon/)
   assert.doesNotMatch(drawer, /drawer__chat-icon|<Chat\b|<Clock\b|<PinFilled\b/)
 })
@@ -871,13 +871,13 @@ test('the Möbius header keeps its phone divider but flows into desktop navigati
   )
 })
 
-test('row-owned context menus need no permanent kebab or hidden anchor', () => {
+test('drawer rows keep action and reorder chrome out of the list', () => {
   assert.match(drawer, /<DrawerItemActionMenu[\s\S]*?itemKind=\{kind\}/)
   assert.doesNotMatch(
     drawer,
-    /triggerHidden|drawer__menu-anchor|drawer__more|DotsVerticalMoreMenu/,
+    /triggerHidden|drawer__menu-anchor|drawer__more|drawer__row-actions|drawer__reorder-handle|DotsHorizontalMoreMenu|DotsVerticalMoreMenu|GripVertical/,
   )
-  assert.doesNotMatch(drawerCss, /drawer__menu-anchor|drawer__more/)
+  assert.doesNotMatch(drawerCss, /drawer__menu-anchor|drawer__more|drawer__row-actions|drawer__reorder-handle/)
   assert.match(drawer, /onContextMenu=\{openItemMenu\}/)
   assert.match(
     drawer,
@@ -903,31 +903,32 @@ test('chat deletion is immediate while app deletion still requires confirmation'
   )
 })
 
-test('drawer row menus use one semantic context-menu path across pointer types', () => {
-  assert.match(drawer, /function openItemMenuAt\(point\)[\s\S]*?actions\.toggleMenu\(kind, id, true, surface,/)
+test('drawer row actions have one opening path without a custom touch hold', () => {
+  assert.match(drawer, /function openItemMenuAt\(point,[\s\S]*?actions\.toggleMenu\(kind, id, true, surface,/)
   assert.equal((drawer.match(/onContextMenu=\{openItemMenu\}/g) || []).length, 2,
-    'app cards, app rows, and chat rows must share one opening function')
-  assert.match(drawer, /if \(openMenu\) openItemMenuAt\(\{ x: point\.clientX, y: point\.clientY \}\)/)
+    'app cards and drawer rows must share one semantic opening function')
+  assert.match(drawer, /if \(suppressTouchContextMenu\(event\)\) return/,
+    'native touch contextmenu must never pre-empt the shared held gesture')
   assert.doesNotMatch(
     dragBinding,
     /srcEl\.closest\('\.drawer__row'\)\?\.querySelector\('\.drawer__more'\)\?\.click\(\)/,
     'touch hold must not depend on a synthetic trigger click',
   )
+  assert.doesNotMatch(drawer, /function beginTouchMenuHold/,
+    'drawer rows must not add a second touch lifecycle beside the shared controller')
   assert.match(drawerItemActionMenu, /function consumeOutsidePointer\(event\)[\s\S]*?event\.preventDefault\(\)[\s\S]*?event\.stopPropagation\(\)[\s\S]*?stopImmediatePropagation/)
-  assert.match(drawerItemActionMenu, /onPointerDown=\{event => \{[\s\S]*?consumeOutsidePointer\(event\)[\s\S]*?\}\}/)
-  assert.match(drawerItemActionMenu, /onClick=\{event => \{[\s\S]*?if \(consumeOutsidePointer\(event\)\) close\(\)/)
+  assert.match(drawerItemActionMenu, /onPointerDown=\{event => \{[\s\S]*?outsidePressStartedRef\.current = true[\s\S]*?\}\}/)
+  assert.match(drawerItemActionMenu, /onClick=\{event => \{[\s\S]*?!outsidePressStartedRef\.current\) return[\s\S]*?close\(\)/)
   assert.doesNotMatch(drawer, /navigator\.vibrate/,
     'drawer rows rely on platform long-press feedback instead of adding a second vibration')
 })
 
-test('one touch hold cannot dismiss its own drawer row menu', () => {
-  assert.equal((drawer.match(/if \(touchEvents && held\) upEvent\.preventDefault\(\)/g) || []).length, 2,
-    'both pinned and unpinned touch holds must consume the trailing compatibility click')
-  assert.match(
-    drawer,
-    /const openMenu = held && !cancelledAfterHold[\s\S]*?if \(touchEvents && held\) upEvent\.preventDefault\(\)[\s\S]*?cleanup\(\{ suppressClick: held \}\)[\s\S]*?if \(openMenu\) openItemMenuAt/,
-    'the release must be consumed before mounting the outside-dismiss layer',
-  )
+test('an opening press cannot dismiss its own action menu', () => {
+  assert.match(drawerItemActionMenu, /const outsidePressStartedRef = useRef\(false\)/)
+  assert.match(drawerItemActionMenu, /if \(!consumeOutsidePointer\(event\) \|\| !outsidePressStartedRef\.current\) return/,
+    'a retargeted opener click has no layer-owned pointerdown and must be ignored')
+  assert.match(drawerItemActionMenu, /onPointerCancel=\{\(\) => \{[\s\S]*?outsidePressStartedRef\.current = false/,
+    'a cancelled outside press cannot authorize a later unrelated click')
 })
 
 test('a secondary-button release cannot immediately select a flipped drawer menu item', () => {
@@ -935,11 +936,11 @@ test('a secondary-button release cannot immediately select a flipped drawer menu
   assert.match(drawer, /event\.pointerType !== 'mouse' \|\| event\.button !== 2/)
   assert.match(drawer, /window\.addEventListener\('pointerup', onSecondaryPointerUp, true\)/)
   assert.match(drawer, /upEvent\.pointerId !== pointerId \|\| upEvent\.button !== 2/)
-  assert.match(drawer, /cleanup\(\)[\s\S]*?actions\.toggleMenu\(kind, id, true, surface, placement\)/)
+  assert.match(drawer, /cleanup\(\)[\s\S]*?openItemMenuAt\(placement, sourceBtn\)/)
   assert.match(drawer, /timer = setTimeout\(cleanup, 1500\)/)
 })
 
-test('launcher cards and drawer rows share the same long-press threshold and movement slop', () => {
+test('launcher cards and drawer rows share one deliberate hold threshold', () => {
   const dragImports = drawer.match(
     /import \{([\s\S]*?)\} from '\.\.\/Shell\/dragController\.js'/,
   )?.[1] || ''
@@ -947,6 +948,12 @@ test('launcher cards and drawer rows share the same long-press threshold and mov
   assert.match(dragImports, /PRE_HOLD_MOVE_PX/)
   assert.match(drawer, /\}, DRAWER_HOLD_MS\)/)
   assert.match(drawer, /> PRE_HOLD_MOVE_PX/)
+  assert.match(dragBinding, /sourceKind === 'drawer' \? DRAWER_HOLD_MS : TAB_HOLD_MS/)
+  assert.doesNotMatch(
+    drawer.match(/function beginPinnedReorder\([\s\S]*?\n  function onRowPointerDown/)?.[0] || '',
+    /DRAWER_HOLD_MS/,
+    'the shared controller, not the reorder implementation, owns hold timing',
+  )
   assert.doesNotMatch(drawer, /520/)
 })
 

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -649,8 +649,9 @@ test('one held drawer-row gesture resolves menu, reorder, or workspace drag', ()
   assert.equal((paneStrip.match(/data-drag-key=\{dragKey\}/g) || []).length, 1,
     'the tab button is the one drag source')
   assert.match(drawerCss, /\.drawer__row \.drawer__item\[data-drag-key\]\s*\{[\s\S]*?touch-action:\s*pan-y pinch-zoom/)
+  assert.match(drawerCss, /\.drawer__row \.drawer__item\[data-pinned-key\]\s*\{[\s\S]*?touch-action:\s*pinch-zoom/)
   assert.match(dragBinding, /touchTabMoveIntent\(dx, dy\)/)
-  assert.match(dragBinding, /scrollStripEl\.scrollLeft \+= previousPoint\.x - ev\.clientX/)
+  assert.match(dragBinding, /scrollAxis === 'x'\)[\s\S]*?scrollEl\.scrollLeft \+= previousPoint\.x - ev\.clientX/)
   assert.doesNotMatch(
     dragBinding,
     /sourceKind === 'drawer' && e\.pointerType !== 'mouse'\) return/,
@@ -665,6 +666,8 @@ test('one held drawer-row gesture resolves menu, reorder, or workspace drag', ()
     'the reorder outcome hands off to the row implementation')
   assert.match(dragBinding, /intent === 'workspace'\) arm\(\)/,
     'the workspace outcome arms the shared drag implementation')
+  assert.match(dragBinding, /intent === 'scroll'[\s\S]*?scrollAxis = 'y'[\s\S]*?scrollTop \+= start\.y - ev\.clientY/,
+    'pre-hold row movement scrolls without surrendering the pointer to the browser')
   assert.match(dragBinding, /sourceKind === 'drawer' && held[\s\S]*?cleanup\(\{ suppressClick: true \}\)[\s\S]*?handler\?\.openMenu\?\.\(point\)/,
     'a stationary held release opens actions only after cleanup')
   assert.doesNotMatch(dragBinding, /openTabMenuAtRef/)
@@ -689,13 +692,14 @@ test('one held drawer-row gesture resolves menu, reorder, or workspace drag', ()
   assert.doesNotMatch(drawerCss, /data-hold-ready/)
 })
 
-test('drawer swipe-to-close leaves vertical scrolling on the native pointer path', () => {
+test('drawer whitespace stays native while pinned rows reserve the shared pointer path', () => {
   assert.match(drawerCss, /\.drawer\s*\{[\s\S]*?touch-action:\s*pan-y pinch-zoom/)
   assert.match(drawer, /onPointerDown=\{onDrawerPointerDown\}/)
   assert.match(drawer, /onPointerMove=\{onDrawerPointerMove\}/)
   assert.match(drawer, /onPointerCancel=\{onDrawerPointerCancel\}/)
   assert.doesNotMatch(drawer, /addEventListener\('touchmove', move/,
     'the panel must never install a scroll-blocking touch listener')
+  assert.match(dragBinding, /scrollAxis === 'y'[\s\S]*?scrollEl\.scrollTop \+= previousPoint\.y - ev\.clientY/)
   assert.match(drawer, /if \(dx < 0 && isHorizontalSwipe\) gesture\.panning = true/)
   assert.match(drawer, /setPointerCapture\?\.\(e\.pointerId\)/)
 })

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -912,12 +912,10 @@ test('chat deletion is immediate while app deletion still requires confirmation'
 })
 
 test('one touch hold cannot dismiss its own drawer row menu', () => {
-  assert.match(drawerItemActionMenu, /const outsidePointerDownRef = useRef\(null\)/)
-  assert.match(drawerItemActionMenu, /useLayoutEffect\(\(\) => \{[\s\S]*?if \(open\) outsidePointerDownRef\.current = null[\s\S]*?\}, \[open\]\)/,
-    'every newly opened menu starts without authorization from an older press')
-  assert.match(drawerItemActionMenu, /if \(outsidePointerDownRef\.current == null\) return/,
+  assert.match(drawerItemActionMenu, /const outsidePressStartedRef = useRef\(false\)/)
+  assert.match(drawerItemActionMenu, /if \(!consumeOutsidePointer\(event\) \|\| !outsidePressStartedRef\.current\) return/,
     'a retargeted opener click has no layer-owned pointerdown and must be ignored')
-  assert.match(drawerItemActionMenu, /onPointerCancel=\{event => \{[\s\S]*?outsidePointerDownRef\.current = null/,
+  assert.match(drawerItemActionMenu, /onPointerCancel=\{\(\) => \{[\s\S]*?outsidePressStartedRef\.current = false/,
     'a cancelled outside press cannot authorize a later unrelated click')
 })
 

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -911,6 +911,16 @@ test('chat deletion is immediate while app deletion still requires confirmation'
   )
 })
 
+test('one touch hold cannot dismiss its own drawer row menu', () => {
+  assert.match(drawerItemActionMenu, /const outsidePointerDownRef = useRef\(null\)/)
+  assert.match(drawerItemActionMenu, /useLayoutEffect\(\(\) => \{[\s\S]*?if \(open\) outsidePointerDownRef\.current = null[\s\S]*?\}, \[open\]\)/,
+    'every newly opened menu starts without authorization from an older press')
+  assert.match(drawerItemActionMenu, /if \(outsidePointerDownRef\.current == null\) return/,
+    'a retargeted opener click has no layer-owned pointerdown and must be ignored')
+  assert.match(drawerItemActionMenu, /onPointerCancel=\{event => \{[\s\S]*?outsidePointerDownRef\.current = null/,
+    'a cancelled outside press cannot authorize a later unrelated click')
+})
+
 test('a secondary-button release cannot immediately select a flipped drawer menu item', () => {
   assert.match(drawer, /event\.type === 'contextmenu' && secondaryReleaseCleanupRef\.current/)
   assert.match(drawer, /event\.pointerType !== 'mouse' \|\| event\.button !== 2/)

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -657,9 +657,9 @@ test('one held drawer-row gesture resolves menu, reorder, or workspace drag', ()
     /sourceKind === 'drawer' && e\.pointerType !== 'mouse'\) return/,
     'touch drawer rows must remain available to the workspace drag controller',
   )
-  assert.match(dragBinding, /sourceKind === 'drawer' \? DRAWER_HOLD_MS : TAB_HOLD_MS/)
-  assert.match(dragBinding, /if \(sourceKind !== 'drawer'\) arm\(\)/,
-    'a drawer hold waits for intent rather than opening or dragging immediately')
+  assert.match(dragBinding, /sourceKind === 'drawer' \? DRAWER_DRAG_HOLD_MS : TAB_HOLD_MS/)
+  assert.match(dragBinding, /DRAWER_MENU_HOLD_MS - DRAWER_DRAG_HOLD_MS/,
+    'one sequential timer owns both drawer hold stages')
   assert.match(dragBinding, /drawerRowMoveIntent\(dx, dy, \{[\s\S]*?held,[\s\S]*?isTouch,[\s\S]*?data-pinned-key/,
     'one pure decision boundary owns the held row directions')
   assert.match(dragBinding, /intent === 'reorder'[\s\S]*?beginReorder/,
@@ -668,8 +668,11 @@ test('one held drawer-row gesture resolves menu, reorder, or workspace drag', ()
     'the workspace outcome arms the shared drag implementation')
   assert.match(dragBinding, /intent === 'scroll'[\s\S]*?scrollAxis = 'y'[\s\S]*?scrollTop \+= start\.y - ev\.clientY/,
     'pre-hold row movement scrolls without surrendering the pointer to the browser')
-  assert.match(dragBinding, /sourceKind === 'drawer' && held[\s\S]*?cleanup\(\{ suppressClick: true \}\)[\s\S]*?handler\?\.openMenu\?\.\(point\)/,
-    'a stationary held release opens actions only after cleanup')
+  assert.match(dragBinding, /const point = \{ \.\.\.lastPoint \}[\s\S]*?cleanup\(\{ suppressClick: true \}\)[\s\S]*?handler\?\.openMenu\?\.\(point\)/,
+    'a stationary long hold opens actions before release and suppresses its trailing click')
+  const drawerPointerUp = dragBinding.match(/const onUp = \(ev\) => \{[\s\S]*?\n      \}/)?.[0] || ''
+  assert.doesNotMatch(drawerPointerUp, /openMenu/,
+    'releasing a shorter stationary hold remains a normal tap')
   assert.doesNotMatch(dragBinding, /openTabMenuAtRef/)
   assert.doesNotMatch(dragBinding, /addEventListener\('touchmove'/)
   assert.match(shell, /const drawerRowGesturesRef = useRef\(new Map\(\)\)/)
@@ -944,18 +947,18 @@ test('a secondary-button release cannot immediately select a flipped drawer menu
   assert.match(drawer, /timer = setTimeout\(cleanup, 1500\)/)
 })
 
-test('launcher cards and drawer rows share one deliberate hold threshold', () => {
+test('launcher cards and drawer rows share the stationary menu threshold', () => {
   const dragImports = drawer.match(
     /import \{([\s\S]*?)\} from '\.\.\/Shell\/dragController\.js'/,
   )?.[1] || ''
-  assert.match(dragImports, /DRAWER_HOLD_MS/)
+  assert.match(dragImports, /DRAWER_MENU_HOLD_MS/)
   assert.match(dragImports, /PRE_HOLD_MOVE_PX/)
-  assert.match(drawer, /\}, DRAWER_HOLD_MS\)/)
+  assert.match(drawer, /\}, DRAWER_MENU_HOLD_MS\)/)
   assert.match(drawer, /> PRE_HOLD_MOVE_PX/)
-  assert.match(dragBinding, /sourceKind === 'drawer' \? DRAWER_HOLD_MS : TAB_HOLD_MS/)
+  assert.match(dragBinding, /sourceKind === 'drawer' \? DRAWER_DRAG_HOLD_MS : TAB_HOLD_MS/)
   assert.doesNotMatch(
     drawer.match(/function beginPinnedReorder\([\s\S]*?\n  function onRowPointerDown/)?.[0] || '',
-    /DRAWER_HOLD_MS/,
+    /DRAWER_(?:DRAG|MENU)_HOLD_MS/,
     'the shared controller, not the reorder implementation, owns hold timing',
   )
   assert.doesNotMatch(drawer, /520/)

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -669,7 +669,8 @@ test('mobile tabs require a hold before dragging while the strip preserves pinch
   assert.equal((drawer.match(/holdTimerRef\.current = setTimeout\(\(\) => \{[\s\S]*?window\.addEventListener\('touchmove', onMove, \{ capture: true, passive: false \}\)/g) || []).length, 2,
     'only a resolved hold may promote row gestures to cancelable ownership')
   assert.doesNotMatch(drawer, /blockingTouchMove|function claimTouchMoves/)
-  assert.match(drawer, /window\.addEventListener\('touchend', onUp, true\)/)
+  assert.equal((drawer.match(/window\.addEventListener\('touchend', onUp, \{ capture: true, passive: false \}\)/g) || []).length, 2,
+    'held row releases must be allowed to suppress their compatibility click')
   assert.match(drawer, /onTouchStart=\{onRowTouchStart\}/)
   assert.match(drawer, /const TOUCH_CONTEXT_MENU_PROVENANCE_MS = 1500/)
   assert.match(drawer, /function suppressTouchContextMenu\(event\)[\s\S]*?event\.nativeEvent\?\.pointerType[\s\S]*?contextPointerType === 'touch'[\s\S]*?freshTouchPointer[\s\S]*?event\.preventDefault\(\)[\s\S]*?event\.stopPropagation\(\)[\s\S]*?stopImmediatePropagation/)
@@ -909,6 +910,16 @@ test('drawer row menus use one semantic context-menu path across pointer types',
   assert.match(drawerItemActionMenu, /onClick=\{event => \{[\s\S]*?if \(consumeOutsidePointer\(event\)\) close\(\)/)
   assert.doesNotMatch(drawer, /navigator\.vibrate/,
     'drawer rows rely on platform long-press feedback instead of adding a second vibration')
+})
+
+test('one touch hold cannot dismiss its own drawer row menu', () => {
+  assert.equal((drawer.match(/if \(touchEvents && held\) upEvent\.preventDefault\(\)/g) || []).length, 2,
+    'both pinned and unpinned touch holds must consume the trailing compatibility click')
+  assert.match(
+    drawer,
+    /const openMenu = held && !cancelledAfterHold[\s\S]*?if \(touchEvents && held\) upEvent\.preventDefault\(\)[\s\S]*?cleanup\(\{ suppressClick: held \}\)[\s\S]*?if \(openMenu\) openItemMenuAt/,
+    'the release must be consumed before mounting the outside-dismiss layer',
+  )
 })
 
 test('a secondary-button release cannot immediately select a flipped drawer menu item', () => {

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -89,7 +89,8 @@ test('an implicit home tab does not engage the single-pane tab strip', () => {
 test('the canonical workspace snapshot survives a closed PWA relaunch', () => {
   assert.match(
     shell,
-    /useWorkspaceSession\(\{ storage: localStorage \}\)/,
+    /useWorkspaceSession\(\{\s*storage: localStorage,\s*legacyStorage: sessionStorage,\s*\}\)/,
+    'the durable snapshot remains canonical while the one-time session migration stays available',
   )
   assert.doesNotMatch(
     shell,
@@ -908,34 +909,6 @@ test('chat deletion is immediate while app deletion still requires confirmation'
     /confirmation === 'delete-data'[\s\S]*?confirmation === 'delete'/,
     'app and app-data deletion must retain their confirmation paths',
   )
-})
-
-test('drawer row actions have one opening path without a custom touch hold', () => {
-  assert.match(drawer, /function openItemMenuAt\(point,[\s\S]*?actions\.toggleMenu\(kind, id, true, surface,/)
-  assert.equal((drawer.match(/onContextMenu=\{openItemMenu\}/g) || []).length, 2,
-    'app cards and drawer rows must share one semantic opening function')
-  assert.match(drawer, /if \(suppressTouchContextMenu\(event\)\) return/,
-    'native touch contextmenu must never pre-empt the shared held gesture')
-  assert.doesNotMatch(
-    dragBinding,
-    /srcEl\.closest\('\.drawer__row'\)\?\.querySelector\('\.drawer__more'\)\?\.click\(\)/,
-    'touch hold must not depend on a synthetic trigger click',
-  )
-  assert.doesNotMatch(drawer, /function beginTouchMenuHold/,
-    'drawer rows must not add a second touch lifecycle beside the shared controller')
-  assert.match(drawerItemActionMenu, /function consumeOutsidePointer\(event\)[\s\S]*?event\.preventDefault\(\)[\s\S]*?event\.stopPropagation\(\)[\s\S]*?stopImmediatePropagation/)
-  assert.match(drawerItemActionMenu, /onPointerDown=\{event => \{[\s\S]*?outsidePressStartedRef\.current = true[\s\S]*?\}\}/)
-  assert.match(drawerItemActionMenu, /onClick=\{event => \{[\s\S]*?!outsidePressStartedRef\.current\) return[\s\S]*?close\(\)/)
-  assert.doesNotMatch(drawer, /navigator\.vibrate/,
-    'drawer rows rely on platform long-press feedback instead of adding a second vibration')
-})
-
-test('an opening press cannot dismiss its own action menu', () => {
-  assert.match(drawerItemActionMenu, /const outsidePressStartedRef = useRef\(false\)/)
-  assert.match(drawerItemActionMenu, /if \(!consumeOutsidePointer\(event\) \|\| !outsidePressStartedRef\.current\) return/,
-    'a retargeted opener click has no layer-owned pointerdown and must be ignored')
-  assert.match(drawerItemActionMenu, /onPointerCancel=\{\(\) => \{[\s\S]*?outsidePressStartedRef\.current = false/,
-    'a cancelled outside press cannot authorize a later unrelated click')
 })
 
 test('a secondary-button release cannot immediately select a flipped drawer menu item', () => {

--- a/frontend/src/components/Shell/dragController.js
+++ b/frontend/src/components/Shell/dragController.js
@@ -102,12 +102,13 @@ export function touchTabMoveIntent(dx, dy, limit = PRE_HOLD_MOVE_PX) {
   return 'scroll'
 }
 
-// The drawer row's one held gesture has three outcomes. Before a touch hold,
-// movement yields to native scrolling/swiping. Afterwards (or immediately for
-// a mouse), vertical movement reorders a pin and outward movement lifts the row
-// into the workspace. Everything else cancels rather than starting a competing
-// interaction. Keeping this classification pure prevents the menu, reorder and
-// workspace branches from growing independent threshold logic again.
+// The drawer row's one held gesture has three outcomes. Before a pinned touch
+// hold, vertical movement scrolls the list through the same pointer owner while
+// a horizontal move yields to drawer swipe; unpinned rows keep native scrolling.
+// Afterwards (or immediately for a mouse), vertical movement reorders a pin and
+// outward movement lifts the row into the workspace. Keeping this classification
+// pure prevents the menu, reorder and workspace branches from growing separate
+// threshold logic.
 export function drawerRowMoveIntent(dx, dy, {
   held = false,
   isTouch = false,
@@ -115,7 +116,9 @@ export function drawerRowMoveIntent(dx, dy, {
 } = {}) {
   const limit = isTouch && !held ? PRE_HOLD_MOVE_PX : POINTER_SLOP
   if (hypot(dx, dy) <= limit) return 'pending'
-  if (isTouch && !held) return 'yield'
+  if (isTouch && !held) {
+    return pinned && Math.abs(dy) > Math.abs(dx) ? 'scroll' : 'yield'
+  }
   if (Math.abs(dy) > Math.abs(dx)) return pinned ? 'reorder' : 'cancel'
   return dx > 0 ? 'workspace' : 'cancel'
 }

--- a/frontend/src/components/Shell/dragController.js
+++ b/frontend/src/components/Shell/dragController.js
@@ -31,11 +31,13 @@ import { tabKey } from './tabModel.js'
 // A mouse drag arms once the pointer travels past this from the press point;
 // below it, the press is still a plain click (tab activate / row open).
 export const POINTER_SLOP = 5
-// Touch lift is a long-press. Tabs use the shorter threshold because they live
-// in a horizontal strip; drawer rows use the longer threshold in their own
-// gesture owner so an ordinary vertical scroll wins before any row action.
+// Touch lift is a long-press. Drawer rows have two deliberate stages: movement
+// can become a drag quickly, while a stationary press must continue longer
+// before opening actions. Keeping both timings here prevents the live pointer
+// owner and launcher cards from inventing their own thresholds.
 export const TAB_HOLD_MS = 350
-export const DRAWER_HOLD_MS = 450
+export const DRAWER_DRAG_HOLD_MS = 180
+export const DRAWER_MENU_HOLD_MS = 550
 // Movement past this before a hold resolves yields to the source scroller.
 export const PRE_HOLD_MOVE_PX = 8
 // After a touch lift, a release that never moved past this is not a drop. Tabs

--- a/frontend/src/components/Shell/dragController.js
+++ b/frontend/src/components/Shell/dragController.js
@@ -96,11 +96,28 @@ export function passedSlop(dx, dy, slop = POINTER_SLOP) {
 
 // Tabs do not infer drag intent from direction: every move before their hold
 // resolves belongs to scrolling, and the binding arms tab dragging only after
-// that deliberate hold. Drawer touch gestures are owned by Drawer itself so a
-// held row can open its menu or reorder a pin without also moving the workspace.
+// that deliberate hold.
 export function touchTabMoveIntent(dx, dy, limit = PRE_HOLD_MOVE_PX) {
   if (hypot(dx, dy) <= limit) return 'pending'
   return 'scroll'
+}
+
+// The drawer row's one held gesture has three outcomes. Before a touch hold,
+// movement yields to native scrolling/swiping. Afterwards (or immediately for
+// a mouse), vertical movement reorders a pin and outward movement lifts the row
+// into the workspace. Everything else cancels rather than starting a competing
+// interaction. Keeping this classification pure prevents the menu, reorder and
+// workspace branches from growing independent threshold logic again.
+export function drawerRowMoveIntent(dx, dy, {
+  held = false,
+  isTouch = false,
+  pinned = false,
+} = {}) {
+  const limit = isTouch && !held ? PRE_HOLD_MOVE_PX : POINTER_SLOP
+  if (hypot(dx, dy) <= limit) return 'pending'
+  if (isTouch && !held) return 'yield'
+  if (Math.abs(dy) > Math.abs(dx)) return pinned ? 'reorder' : 'cancel'
+  return dx > 0 ? 'workspace' : 'cancel'
 }
 
 // After a lift, a release still within this radius did not become a drag.

--- a/frontend/src/components/Shell/useWorkspaceDrag.js
+++ b/frontend/src/components/Shell/useWorkspaceDrag.js
@@ -244,7 +244,8 @@ export default function useWorkspaceDrag({
       let holdTimer = null
       let held = false
       let scrolling = false
-      let scrollStripEl = null
+      let scrollEl = null
+      let scrollAxis = null
       let curZone = null
       let scene = null
       let drawerEdgeX = null
@@ -396,7 +397,8 @@ export default function useWorkspaceDrag({
         const dy = ev.clientY - start.y
         if (scrolling) {
           ev.preventDefault?.()
-          if (scrollStripEl) scrollStripEl.scrollLeft += previousPoint.x - ev.clientX
+          if (scrollEl && scrollAxis === 'x') scrollEl.scrollLeft += previousPoint.x - ev.clientX
+          else if (scrollEl && scrollAxis === 'y') scrollEl.scrollTop += previousPoint.y - ev.clientY
           return
         }
         if (!armed) {
@@ -407,6 +409,15 @@ export default function useWorkspaceDrag({
               pinned: srcEl.hasAttribute('data-pinned-key'),
             })
             if (intent === 'pending') return
+            if (intent === 'scroll') {
+              clearTimeout(holdTimer)
+              scrolling = true
+              scrollEl = srcEl.closest('.drawer__scroll')
+              scrollAxis = 'y'
+              ev.preventDefault?.()
+              if (scrollEl) scrollEl.scrollTop += start.y - ev.clientY
+              return
+            }
             if (intent === 'reorder') {
               const handler = drawerGesture()
               ev.preventDefault?.()
@@ -430,9 +441,10 @@ export default function useWorkspaceDrag({
               // Until the hold wins, mirror the strip's one-to-one pan here.
               // Whitespace and close buttons remain native pan-x.
               scrolling = true
-              scrollStripEl = srcEl.closest('.shell__tabstrip')
+              scrollEl = srcEl.closest('.shell__tabstrip')
+              scrollAxis = 'x'
               ev.preventDefault?.()
-              if (scrollStripEl) scrollStripEl.scrollLeft += start.x - ev.clientX
+              if (scrollEl) scrollEl.scrollLeft += start.x - ev.clientX
               return
             }
             if (!armed) return

--- a/frontend/src/components/Shell/useWorkspaceDrag.js
+++ b/frontend/src/components/Shell/useWorkspaceDrag.js
@@ -3,7 +3,9 @@ import * as tabModel from './tabModel.js'
 import { STRIP_H } from './paneModel.js'
 import {
   buildScene, hitTest, zoneTarget, releaseZone, chipOffset, STRIP_CARET_PAD,
-  passedSlop, touchTabMoveIntent, releasedInPlace, TAB_HOLD_MS, crossedDrawerExit,
+  passedSlop, touchTabMoveIntent, drawerRowMoveIntent, releasedInPlace,
+  TAB_HOLD_MS, DRAWER_HOLD_MS,
+  crossedDrawerExit,
   rootEdgeAllowed, clientPointToLocal,
 } from './dragController.js'
 
@@ -75,6 +77,7 @@ export default function useWorkspaceDrag({
   labelForTabRef, // ref → (tab) => string
   dragActiveRef, // shared flag the Drawer's swipe-close handlers stand down on
   drawerOpenRef,
+  drawerRowGesturesRef, // key -> ref({ openMenu, beginReorder }) registered by Drawer rows
   closeDrawer,
   openDrawer,
   onPreviewBuilder, // (active, { committed }) => void — enter/leave the LIVE
@@ -261,6 +264,7 @@ export default function useWorkspaceDrag({
           ? (workspaceStateRef.current.ws.panes[paneId]?.tabs.length || 0)
           : 0,
       })
+      const drawerGesture = () => drawerRowGesturesRef?.current?.get(key)?.current
 
       // iOS callout/selection suppression begins NOW (pointerdown), scoped to the
       // source, for the WHOLE hold window — not at arm, when the magnifier has
@@ -304,18 +308,18 @@ export default function useWorkspaceDrag({
         }
       }
 
-      // Tabs use one unambiguous touch contract across their whole surface:
-      // movement before the hold belongs to strip scrolling; surviving the short
-      // hold lifts the tab so a following move drags it. Drawer touch rows never
-      // enter this controller: Drawer owns their menu/reorder gesture as one
-      // interaction, so a held finger cannot also glide navigation closed.
+      // Tabs and drawer rows share this ONE pointer owner. Tabs lift as soon as
+      // their hold resolves. A drawer hold stays undecided until the owner moves
+      // or releases: outward movement lifts into the workspace, vertical movement
+      // of a pin hands off to its reorder implementation, and release in place
+      // opens actions. Pre-hold movement returns to native scroll/swipe.
       if (isTouch) {
         holdTimer = setTimeout(() => {
           if (cancelled || cleaned) return
           held = true
           if (navigator.vibrate) { try { navigator.vibrate(8) } catch { /* unsupported */ } }
-          arm()
-        }, TAB_HOLD_MS)
+          if (sourceKind !== 'drawer') arm()
+        }, sourceKind === 'drawer' ? DRAWER_HOLD_MS : TAB_HOLD_MS)
       }
 
       function stopAutoScroll() {
@@ -396,7 +400,28 @@ export default function useWorkspaceDrag({
           return
         }
         if (!armed) {
-          if (isTouch) {
+          if (sourceKind === 'drawer') {
+            const intent = drawerRowMoveIntent(dx, dy, {
+              held,
+              isTouch,
+              pinned: srcEl.hasAttribute('data-pinned-key'),
+            })
+            if (intent === 'pending') return
+            if (intent === 'reorder') {
+              const handler = drawerGesture()
+              ev.preventDefault?.()
+              cancelled = true
+              cleanup()
+              handler?.beginReorder?.({ pointerId, start, moveEvent: ev })
+              return
+            }
+            if (intent === 'workspace') arm()
+            else {
+              cancelled = true
+              cleanup()
+            }
+            if (!armed) return
+          } else if (isTouch) {
             const intent = touchTabMoveIntent(dx, dy)
             if (intent === 'scroll') {
               clearTimeout(holdTimer)
@@ -412,19 +437,7 @@ export default function useWorkspaceDrag({
             }
             if (!armed) return
           } else {
-            if (sourceKind === 'drawer') {
-              // Drawer rows have two orthogonal mouse gestures: a deliberate
-              // rightward pull leaves navigation for the workspace, while a
-              // vertical drag belongs to pinned-item reordering. The previous
-              // any-axis arm contradicted that contract and stole vertical
-              // movement before the drawer could reorder it.
-              if (Math.abs(dy) > Math.abs(dx) && passedSlop(dx, dy)) {
-                cancelled = true
-                cleanup()
-                return
-              }
-              if (dx > 0 && Math.abs(dx) >= Math.abs(dy) && passedSlop(dx, dy)) arm()
-            } else if (passedSlop(dx, dy)) arm()
+            if (passedSlop(dx, dy)) arm()
             if (!armed) return
           }
         }
@@ -491,6 +504,11 @@ export default function useWorkspaceDrag({
         if (!armed) {
           if (scrolling) {
             cleanup({ suppressClick: true })
+          } else if (isTouch && sourceKind === 'drawer' && held) {
+            const handler = drawerGesture()
+            const point = { x: ev.clientX, y: ev.clientY }
+            cleanup({ suppressClick: true })
+            handler?.openMenu?.(point)
           } else cleanup()
           return
         }
@@ -676,10 +694,6 @@ export default function useWorkspaceDrag({
       const strip = srcEl.closest('[data-pane-strip]')
       const sourceKind = inDrawer ? 'drawer' : (strip ? 'tab' : null)
       if (!sourceKind) return
-      // Touch drawer rows have a different, local contract: stationary hold
-      // opens their contextual menu and held vertical movement reorders a pin.
-      // Never create a second workspace-drag session for that same pointer.
-      if (sourceKind === 'drawer' && e.pointerType !== 'mouse') return
       const paneId = strip ? strip.dataset.paneStrip : null
       startSession(e, srcEl, sourceKind, key, paneId)
     }

--- a/frontend/src/components/Shell/useWorkspaceDrag.js
+++ b/frontend/src/components/Shell/useWorkspaceDrag.js
@@ -4,7 +4,7 @@ import { STRIP_H } from './paneModel.js'
 import {
   buildScene, hitTest, zoneTarget, releaseZone, chipOffset, STRIP_CARET_PAD,
   passedSlop, touchTabMoveIntent, drawerRowMoveIntent, releasedInPlace,
-  TAB_HOLD_MS, DRAWER_HOLD_MS,
+  TAB_HOLD_MS, DRAWER_DRAG_HOLD_MS, DRAWER_MENU_HOLD_MS,
   crossedDrawerExit,
   rootEdgeAllowed, clientPointToLocal,
 } from './dragController.js'
@@ -310,17 +310,27 @@ export default function useWorkspaceDrag({
       }
 
       // Tabs and drawer rows share this ONE pointer owner. Tabs lift as soon as
-      // their hold resolves. A drawer hold stays undecided until the owner moves
-      // or releases: outward movement lifts into the workspace, vertical movement
-      // of a pin hands off to its reorder implementation, and release in place
-      // opens actions. Pre-hold movement returns to native scroll/swipe.
+      // their hold resolves. Drawer rows become draggable after the brief first
+      // stage; if the pointer stays still through the second stage, actions open
+      // immediately. Movement clears the same timer before handing off to reorder,
+      // workspace drag, or scrolling, so no competing gesture lifecycle exists.
       if (isTouch) {
         holdTimer = setTimeout(() => {
           if (cancelled || cleaned) return
           held = true
           if (navigator.vibrate) { try { navigator.vibrate(8) } catch { /* unsupported */ } }
-          if (sourceKind !== 'drawer') arm()
-        }, sourceKind === 'drawer' ? DRAWER_HOLD_MS : TAB_HOLD_MS)
+          if (sourceKind !== 'drawer') {
+            arm()
+            return
+          }
+          holdTimer = setTimeout(() => {
+            if (cancelled || cleaned || armed || scrolling) return
+            const handler = drawerGesture()
+            const point = { ...lastPoint }
+            cleanup({ suppressClick: true })
+            handler?.openMenu?.(point)
+          }, DRAWER_MENU_HOLD_MS - DRAWER_DRAG_HOLD_MS)
+        }, sourceKind === 'drawer' ? DRAWER_DRAG_HOLD_MS : TAB_HOLD_MS)
       }
 
       function stopAutoScroll() {
@@ -516,11 +526,6 @@ export default function useWorkspaceDrag({
         if (!armed) {
           if (scrolling) {
             cleanup({ suppressClick: true })
-          } else if (isTouch && sourceKind === 'drawer' && held) {
-            const handler = drawerGesture()
-            const point = { x: ev.clientX, y: ev.clientY }
-            cleanup({ suppressClick: true })
-            handler?.openMenu?.(point)
           } else cleanup()
           return
         }

--- a/frontend/src/lib/__tests__/appsDirectoryContract.test.js
+++ b/frontend/src/lib/__tests__/appsDirectoryContract.test.js
@@ -52,7 +52,7 @@ test('phone and web share one searchable launcher tab', () => {
   )?.[1] || ''
   assert.match(dragImports, /DRAWER_HOLD_MS/)
   assert.match(dragImports, /PRE_HOLD_MOVE_PX/)
-  assert.match(drawer, /setTimeout\(\(\) => \{[\s\S]*?toggleMenu[\s\S]*?DRAWER_HOLD_MS\)/)
+  assert.match(drawer, /setTimeout\(\(\) => \{[\s\S]*?openItemMenuAt[\s\S]*?DRAWER_HOLD_MS\)/)
   assert.doesNotMatch(drawer, /520/)
   assert.match(drawer, /menuPlacement=\{openMenu/)
   assert.match(itemActionMenu, /placeContextMenu/)

--- a/frontend/src/lib/__tests__/appsDirectoryContract.test.js
+++ b/frontend/src/lib/__tests__/appsDirectoryContract.test.js
@@ -50,9 +50,9 @@ test('phone and web share one searchable launcher tab', () => {
   const dragImports = drawer.match(
     /import \{([\s\S]*?)\} from '\.\.\/Shell\/dragController\.js'/,
   )?.[1] || ''
-  assert.match(dragImports, /DRAWER_HOLD_MS/)
+  assert.match(dragImports, /DRAWER_MENU_HOLD_MS/)
   assert.match(dragImports, /PRE_HOLD_MOVE_PX/)
-  assert.match(drawer, /setTimeout\(\(\) => \{[\s\S]*?openItemMenuAt[\s\S]*?DRAWER_HOLD_MS\)/)
+  assert.match(drawer, /setTimeout\(\(\) => \{[\s\S]*?openItemMenuAt[\s\S]*?DRAWER_MENU_HOLD_MS\)/)
   assert.doesNotMatch(drawer, /520/)
   assert.match(drawer, /menuPlacement=\{openMenu/)
   assert.match(itemActionMenu, /placeContextMenu/)

--- a/frontend/src/lib/__tests__/pinnedReorder.test.js
+++ b/frontend/src/lib/__tests__/pinnedReorder.test.js
@@ -3,20 +3,11 @@ import assert from 'node:assert/strict'
 
 import {
   computePinnedDrag,
-  heldDrawerRowIntent,
   observePinnedOrderHandoff,
   pinnedEntriesMatchRanks,
   pinnedOrderHandoffStatus,
   projectPinnedEntries,
 } from '../../components/Drawer/pinnedReorder.js'
-
-test('a held drawer row has one button-free menu or reorder contract', () => {
-  assert.equal(heldDrawerRowIntent(3, 4, true), 'pending', 'thumb jitter stays stationary')
-  assert.equal(heldDrawerRowIntent(0, 9, true), 'reorder', 'a held pin moves vertically')
-  assert.equal(heldDrawerRowIntent(9, 0, true), 'cancel', 'sideways drift never moves the drawer')
-  assert.equal(heldDrawerRowIntent(0, 9, false), 'cancel', 'an unpinned row cannot reorder')
-  assert.equal(heldDrawerRowIntent(9, 9, true), 'cancel', 'ambiguous diagonals cancel')
-})
 
 // Four uniform 40px rows stacked from top 0.
 function uniformRows() {


### PR DESCRIPTION
## Summary

- give each drawer-row pointer stream one gesture owner
- separate early drag readiness from the longer stationary menu hold
- settle Android pointer cancellation without requiring a second hold
- reserve pinned-row touch ownership while preserving native scrolling elsewhere
- remove duplicated row-level hold and reorder machinery

## Testing

- 135 focused drawer/workspace contracts
- fork pre-push frontend suite