### PR TITLE
Isolate Codex protocol workers from shared serving executors

### DIFF
--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -60,6 +60,7 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures as _cf
+import functools
 import logging
 import os
 import signal
@@ -117,6 +118,24 @@ from app.runner_registry import RunnerKind, registry
 from app.memory_observability import record_memory_checkpoint_once
 
 log = logging.getLogger("moebius.chat")
+
+# The SDK implements every async protocol wait with ``asyncio.to_thread``.
+# A turn parked on request_user_input can hold that worker for hours; enough
+# parked chats therefore exhaust Python's small process-wide default executor
+# and prevent a new Codex client from even starting. Give each SDK client a
+# small owned pool: one worker may block on notifications while control/close
+# retain independent progress, and unrelated application work never queues
+# behind parked turns.
+_CODEX_CALL_EXECUTOR_WORKERS = 3
+_PROCESS_GROUP_CAPTURE_SPIN_SECONDS = 0.1
+_PROCESS_GROUP_CAPTURE_POLL_SECONDS = 0.01
+
+
+def _process_group_capture_delay(elapsed: float) -> float:
+  """Yield eagerly during normal startup, then back off a wedged poller."""
+  if elapsed < _PROCESS_GROUP_CAPTURE_SPIN_SECONDS:
+    return 0
+  return _PROCESS_GROUP_CAPTURE_POLL_SECONDS
 
 # Möbius supplies the complete behavioral constitution through the thread's
 # base_instructions. These overrides prevent user/project Codex configuration
@@ -251,14 +270,66 @@ def _codex_process_group_id(
   return pgid
 
 
+class _CodexCallExecutor:
+  """Per-client worker pool for the SDK's blocking sync protocol surface."""
+
+  def __init__(self, chat_id: str) -> None:
+    self._executor = _cf.ThreadPoolExecutor(
+      max_workers=_CODEX_CALL_EXECUTOR_WORKERS,
+      thread_name_prefix=f"mobius-codex-{chat_id[:8]}",
+    )
+
+  async def call(self, fn, /, *args, **kwargs):
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(
+      self._executor,
+      functools.partial(fn, *args, **kwargs),
+    )
+
+  def close(self) -> None:
+    # AsyncCodex.__aexit__ has already closed the transport before this owner
+    # is released. ``wait=False`` keeps an unexpected SDK waiter from ever
+    # blocking the FastAPI event loop during terminal cleanup.
+    self._executor.shutdown(wait=False, cancel_futures=True)
+
+
+def _install_codex_call_executor(
+  codex_context: Any,
+  chat_id: str,
+) -> _CodexCallExecutor | None:
+  """Route one AsyncCodex client's sync bridge off the default executor.
+
+  Unit-test fakes intentionally omit the private ``_client._call_sync`` seam;
+  they have no blocking SDK protocol and need no executor. The production SDK
+  is pinned and this is the same wrapper-internal chain already guarded by the
+  approval-handler and process-identity contract helpers.
+  """
+  client = getattr(codex_context, "_client", None)
+  if client is None or not callable(getattr(client, "_call_sync", None)):
+    return None
+  owner = _CodexCallExecutor(chat_id)
+  try:
+    client._call_sync = owner.call
+  except (AttributeError, TypeError):
+    owner.close()
+    log.warning(
+      "Codex SDK async client does not allow an owned call executor; "
+      "falling back to its default executor chat_id=%s",
+      chat_id,
+      exc_info=True,
+    )
+    return None
+  return owner
+
+
 async def _enter_codex_context_owned(
   codex_context: Any,
 ) -> tuple[Any, asyncio.CancelledError | None]:
   """Enter AsyncCodex without abandoning its threaded startup on cancel.
 
-  The pinned SDK implements ``AsyncCodexClient.start()`` with
-  ``asyncio.to_thread(CodexClient.start)``. Cancelling ``__aenter__`` therefore
-  cancels only the awaiter; the worker can continue through ``Popen`` and
+  The pinned SDK implements ``AsyncCodexClient.start()`` as a blocking sync
+  call offloaded to a worker. Cancelling ``__aenter__`` therefore cancels only
+  the awaiter; the owned worker can continue through ``Popen`` and
   publish ``_proc`` after the cancelled runner has already returned. Keep the
   complete enter operation in a runner-owned task, shield it through every
   caller cancellation, and hand the cancellation back to the caller only once
@@ -296,11 +367,12 @@ async def _enter_codex_context_owned(
 class _EnteredCodexContext:
   """Own exit for an AsyncCodex context whose enter is already owned.
 
-  The pinned SDK delegates close to ``asyncio.to_thread``. An ordinary await
-  lets a second caller cancellation cancel that awaiter while its worker is
-  still queued or running, allowing process-group reap and runner return to
-  overtake the SDK's direct-child ``wait()``. Keep the complete exit in a
-  runner-owned task and defer every repeated cancellation until it finishes.
+  The pinned SDK delegates close to a blocking worker call (routed through the
+  per-client executor above). An ordinary await lets a second caller
+  cancellation cancel that awaiter while its worker is still queued or
+  running, allowing process-group reap and runner return to overtake the SDK's
+  direct-child ``wait()``. Keep the complete exit in a runner-owned task and
+  defer every repeated cancellation until it finishes.
   """
 
   def __init__(self, context: Any, entered: Any) -> None:
@@ -364,11 +436,19 @@ async def _capture_codex_process_group_during_start(
   identity helper therefore runs silently until ``setsid`` makes PID == PGID;
   it never returns or signals the shared group.
   """
+  started_at = time.monotonic()
   while not stop.is_set():
     pgid = _codex_process_group_id(codex, log_unisolated=False)
     if pgid is not None:
       return pgid
-    await asyncio.sleep(0)
+    # Preserve zero-delay polling during the narrow Popen→initialize window:
+    # an initialization failure can clear the only child PID after one loop
+    # turn. If startup remains unresolved beyond that normal window, back off
+    # so a wedged client cannot spin Uvicorn's event loop at 100% CPU.
+    delay = _process_group_capture_delay(
+      time.monotonic() - started_at,
+    )
+    await asyncio.sleep(delay)
   return _codex_process_group_id(codex, log_unisolated=False)
 
 
@@ -1504,6 +1584,7 @@ async def run_codex_sdk_turn(
   task_host_tool_use_id: str | None = None
   public_task_ids: set[str] = set()
   codex_context = sdk["AsyncCodex"](config=config)
+  codex_call_executor = _install_codex_call_executor(codex_context, chat_id)
   process_group_capture_stop: asyncio.Event | None = None
   process_group_capture_task: asyncio.Task[int | None] | None = None
   if launch_args is not None:
@@ -2327,6 +2408,8 @@ async def run_codex_sdk_turn(
           # until its bounded TERM/KILL sequence has completed.
           deferred_cancel = deferred_cancel or exc
       reap_task.result()
+    if codex_call_executor is not None:
+      codex_call_executor.close()
     if deferred_cancel is not None:
       raise deferred_cancel
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,7 +5,6 @@ static files.  API routes are registered first; the frontend SPA is
 mounted last as a catch-all so that client-side routing works.
 """
 
-import asyncio
 import logging
 import mimetypes
 import os
@@ -30,6 +29,7 @@ from fastapi.responses import FileResponse, HTMLResponse
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from sqlalchemy.exc import OperationalError
+from starlette.concurrency import run_in_threadpool
 
 from app.config import get_settings
 from app.database import (
@@ -1164,7 +1164,7 @@ async def app_owned_asset_by_id(app_id: int, asset_path: str, request: Request):
   the installed app's source_dir/static.
   """
   return _serve_app_static_asset(
-    await asyncio.to_thread(_app_source_dir_for_static_asset, app_id=app_id),
+    await run_in_threadpool(_app_source_dir_for_static_asset, app_id=app_id),
     asset_path,
     request,
   )
@@ -1186,7 +1186,7 @@ async def app_owned_opaque_embed_by_id(
   SAMEORIGIN and is never the document-navigation surface.
   """
   return _serve_app_static_asset(
-    await asyncio.to_thread(_app_source_dir_for_static_asset, app_id=app_id),
+    await run_in_threadpool(_app_source_dir_for_static_asset, app_id=app_id),
     asset_path,
     request,
   )
@@ -1202,7 +1202,7 @@ async def app_owned_asset(slug: str, asset_path: str, request: Request):
   if not slug or not all(ch.isalnum() or ch in "-_" for ch in slug):
     raise HTTPException(status_code=404, detail="Not found.")
   return _serve_app_static_asset(
-    await asyncio.to_thread(_app_source_dir_for_static_asset, slug=slug),
+    await run_in_threadpool(_app_source_dir_for_static_asset, slug=slug),
     asset_path,
     request,
   )
@@ -1228,7 +1228,7 @@ if _baked_dir.is_dir() or _live_dir.is_dir():
     "/assets/{asset_path:path}", methods=["GET", "HEAD"], include_in_schema=False
   )
   async def serve_asset(request: Request, asset_path: str):
-    target = await asyncio.to_thread(_resolve_asset_file, asset_path)
+    target = await run_in_threadpool(_resolve_asset_file, asset_path)
     if target is None:
       raise HTTPException(status_code=404, detail="Not found.")
     media_type = (
@@ -1255,7 +1255,7 @@ if _baked_dir.is_dir() or _live_dir.is_dir():
     # Resolve which build serves THIS request (live dist if complete, else the
     # baked floor) once, up front — per request, never a module-load snapshot.
     static_dir = _resolve_static_dir()
-    app_slug = await asyncio.to_thread(_top_level_app_slug_alias, path)
+    app_slug = await run_in_threadpool(_top_level_app_slug_alias, path)
     if app_slug:
       from fastapi.responses import RedirectResponse
       return RedirectResponse(

--- a/backend/app/provider_usage.py
+++ b/backend/app/provider_usage.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures as _cf
+import functools
 import logging
 import os
 import shutil
@@ -233,10 +235,11 @@ def _codex_plan_type(account_response: Any) -> Any:
   return getattr(account, "plan_type", None)
 
 
-def _read_started_codex_client(client: Any) -> tuple[Any, Any]:
-  """Run the blocking typed protocol calls after the app-server is started."""
+def _read_codex_client(client: Any) -> tuple[Any, Any]:
+  """Start and read one Codex client entirely on its owned worker."""
   from openai_codex.generated.v2_all import GetAccountRateLimitsResponse
 
+  client.start()
   client.initialize()
   account = client.account_read()
   limits = client.request(
@@ -264,23 +267,37 @@ async def _fetch_codex_usage(data_dir: str) -> dict[str, Any]:
     client_title="Möbius Settings",
   ))
 
-  # Popen itself is immediate and gives cleanup a concrete process to reap.
-  # The JSON-RPC calls run off-loop; if one wedges, close() terminates the
-  # app-server and unblocks its waiter before this endpoint returns.
-  client.start()
-  task = asyncio.create_task(asyncio.to_thread(_read_started_codex_client, client))
+  # Keep Settings' short-lived client off the process-wide default executor.
+  # Live Codex turns may each hold one default worker while waiting for a
+  # notification; queuing start/read/close behind them made this probe leak an
+  # app-server exactly when the system was busiest. Worker one owns the whole
+  # blocking read; worker two remains available to close the transport and
+  # unblock it on timeout.
+  executor = _cf.ThreadPoolExecutor(
+    max_workers=2,
+    thread_name_prefix="mobius-codex-usage",
+  )
+  loop = asyncio.get_running_loop()
+
+  def in_worker(fn, /, *args):
+    return loop.run_in_executor(executor, functools.partial(fn, *args))
+
+  task = in_worker(_read_codex_client, client)
   try:
     account, limits = await asyncio.wait_for(
       asyncio.shield(task),
       timeout=_PROVIDER_TIMEOUT_SECONDS,
     )
   except TimeoutError:
-    await asyncio.to_thread(client.close)
+    await in_worker(client.close)
     with suppress(Exception):
       await asyncio.wait_for(task, timeout=2.0)
     raise RuntimeError("codex usage read timed out")
   finally:
-    await asyncio.to_thread(client.close)
+    try:
+      await in_worker(client.close)
+    finally:
+      executor.shutdown(wait=False, cancel_futures=True)
 
   raw = limits.model_dump(mode="json", by_alias=False)
   return normalize_codex_usage(raw, plan_type=_codex_plan_type(account))

--- a/backend/tests/test_codex_sdk_contract.py
+++ b/backend/tests/test_codex_sdk_contract.py
@@ -54,6 +54,12 @@ def _make_sync_handle():
   return ac._client._sync
 
 
+def _make_async_handle():
+  """Return the live async-client instance whose call bridge we replace."""
+  openai_codex = pytest.importorskip("openai_codex")
+  return openai_codex.AsyncCodex()._client
+
+
 def test_codex_approval_handler_attribute_exists():
   """`_approval_handler` must exist on the live `_client._sync` object.
 
@@ -94,6 +100,25 @@ def test_codex_approval_handler_assignment_takes_effect():
     )
   finally:
     sync._approval_handler = original
+
+
+def test_codex_async_call_bridge_assignment_takes_effect():
+  """The per-chat executor must be installable on the pinned SDK instance."""
+  client = _make_async_handle()
+  original = client._call_sync
+
+  async def replacement(_fn, /, *_args, **_kwargs):
+    return "owned-executor"
+
+  try:
+    client._call_sync = replacement
+    assert client._call_sync is replacement, (
+      "Assignment to AsyncCodex()._client._call_sync did not take effect. "
+      "Parked notification waits would fall back to asyncio's shared default "
+      "executor and can take the shell and new chats offline."
+    )
+  finally:
+    client._call_sync = original
 
 
 def test_request_user_input_method_string_unchanged():

--- a/backend/tests/test_codex_sdk_runner.py
+++ b/backend/tests/test_codex_sdk_runner.py
@@ -1,6 +1,7 @@
 import asyncio
 import signal
 import threading
+from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
 from types import SimpleNamespace
 
@@ -3216,6 +3217,54 @@ def test_codex_process_group_id_refuses_shared_uvicorn_group(monkeypatch):
   monkeypatch.setattr(codex_sdk_runner.os, "getpgrp", lambda: 4000)
 
   assert codex_sdk_runner._codex_process_group_id(codex) is None
+
+
+def test_codex_call_executor_progresses_with_default_pool_saturated():
+  async def scenario():
+    loop = asyncio.get_running_loop()
+    release = threading.Event()
+    occupied = threading.Event()
+    saturated = ThreadPoolExecutor(max_workers=1)
+    replacement = ThreadPoolExecutor(max_workers=1)
+    loop.set_default_executor(saturated)
+
+    def occupy_default_worker():
+      occupied.set()
+      release.wait()
+
+    blocker = loop.run_in_executor(None, occupy_default_worker)
+    while not occupied.is_set():
+      await asyncio.sleep(0)
+
+    client = SimpleNamespace(_call_sync=lambda *_args, **_kwargs: None)
+    codex = SimpleNamespace(_client=client)
+    owner = codex_sdk_runner._install_codex_call_executor(
+      codex, "chat-owned-executor",
+    )
+    try:
+      assert owner is not None
+      worker_name = await asyncio.wait_for(
+        client._call_sync(lambda: threading.current_thread().name),
+        timeout=1,
+      )
+      assert worker_name.startswith("mobius-codex-chat-own")
+    finally:
+      owner.close()
+      release.set()
+      await blocker
+      loop.set_default_executor(replacement)
+      saturated.shutdown(wait=True)
+
+  asyncio.run(scenario())
+
+
+def test_process_group_capture_poll_backs_off_after_startup_window():
+  spin = codex_sdk_runner._PROCESS_GROUP_CAPTURE_SPIN_SECONDS
+  assert codex_sdk_runner._process_group_capture_delay(spin / 2) == 0
+  assert codex_sdk_runner._process_group_capture_delay(spin) == (
+    codex_sdk_runner._PROCESS_GROUP_CAPTURE_POLL_SECONDS
+  )
+  assert codex_sdk_runner._PROCESS_GROUP_CAPTURE_POLL_SECONDS > 0
 
 
 def test_terminate_codex_process_group_has_sigkill_backstop(monkeypatch):

--- a/backend/tests/test_generation_serving.py
+++ b/backend/tests/test_generation_serving.py
@@ -11,9 +11,13 @@ Three coupled guarantees:
   incomplete after boot is served (or floored to baked) with no restart.
 """
 
+import asyncio
 import shutil
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
+import httpx
 import pytest
 
 import app.main as main
@@ -208,6 +212,75 @@ def test_baked_floor_served_when_dist_incomplete(client, serving):
   assert r.status_code == 200
   assert "INCOMPLETE" not in r.text  # the broken dist index is never served
   assert "__mobius-theme__" in r.text  # the baked stub (theme slot) is
+
+
+@pytest.mark.asyncio
+async def test_static_delivery_ignores_saturated_asyncio_executor(
+  monkeypatch, serving, tmp_path,
+):
+  """Codex turns may occupy every asyncio-default worker without taking the
+  shell, service workers, or app assets offline.
+
+  Codex's SDK intentionally uses ``asyncio.to_thread`` for long-running
+  protocol calls. Static delivery must use Starlette/AnyIO's independent
+  worker pool, or enough concurrent turns make health checks pass while every
+  browser entry point waits forever behind the exhausted default executor.
+  """
+  _write_build(serving["live"], "executor")
+  vendor = serving["live"] / "vendor" / "fonts" / "executor.js"
+  vendor.parent.mkdir(parents=True)
+  vendor.write_text("export const ready = true;", encoding="utf-8")
+
+  app_source = tmp_path / "demo"
+  app_static = app_source / "static"
+  app_static.mkdir(parents=True)
+  (app_static / "index.html").write_text("app-static", encoding="utf-8")
+  monkeypatch.setattr(
+    main,
+    "_app_source_dir_for_static_asset",
+    lambda **_kwargs: str(app_source),
+  )
+  _reset_memo()
+
+  loop = asyncio.get_running_loop()
+  release = threading.Event()
+  occupied = threading.Event()
+  saturated = ThreadPoolExecutor(max_workers=1)
+  replacement = ThreadPoolExecutor(max_workers=1)
+  loop.set_default_executor(saturated)
+
+  def occupy_default_worker():
+    occupied.set()
+    release.wait()
+
+  blocker = loop.run_in_executor(None, occupy_default_worker)
+  while not occupied.is_set():
+    await asyncio.sleep(0)
+
+  paths = (
+    "/shell/",
+    "/sw.js",
+    "/vendor/fonts/executor.js",
+    "/assets/index-executor.js",
+    "/app-assets/demo/index.html",
+    "/app-assets/by-id/1/index.html",
+    "/app-embeds/by-id/1/index.html",
+  )
+  try:
+    transport = httpx.ASGITransport(app=main.app)
+    async with httpx.AsyncClient(
+      transport=transport, base_url="http://testserver",
+    ) as async_client:
+      responses = await asyncio.wait_for(
+        asyncio.gather(*(async_client.get(path) for path in paths)),
+        timeout=2,
+      )
+    assert [response.status_code for response in responses] == [200] * len(paths)
+  finally:
+    release.set()
+    await blocker
+    loop.set_default_executor(replacement)
+    saturated.shutdown(wait=True)
 
 
 # -- frontend_watcher: attic hardlink hook on the dist swap --------------

--- a/backend/tests/test_provider_usage.py
+++ b/backend/tests/test_provider_usage.py
@@ -3,9 +3,10 @@
 import asyncio
 import base64
 import json
+import sys
 import threading
 from concurrent.futures import ThreadPoolExecutor
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
@@ -182,7 +183,6 @@ async def test_codex_usage_ignores_saturated_default_executor(
   monkeypatch, tmp_path,
 ):
   from app import provider_usage
-  import openai_codex.client as codex_client
 
   calls = []
 
@@ -216,9 +216,20 @@ async def test_codex_usage_ignores_saturated_default_executor(
     def close(self):
       self._record("close")
 
+  codex_package = ModuleType("openai_codex")
+  codex_package.__path__ = []
+  codex_client = ModuleType("openai_codex.client")
+  codex_client.CodexClient = FakeClient
+  codex_client.CodexConfig = lambda **kwargs: kwargs
+  generated_package = ModuleType("openai_codex.generated")
+  generated_package.__path__ = []
+  generated_v2 = ModuleType("openai_codex.generated.v2_all")
+  generated_v2.GetAccountRateLimitsResponse = object
+  monkeypatch.setitem(sys.modules, "openai_codex", codex_package)
+  monkeypatch.setitem(sys.modules, "openai_codex.client", codex_client)
+  monkeypatch.setitem(sys.modules, "openai_codex.generated", generated_package)
+  monkeypatch.setitem(sys.modules, "openai_codex.generated.v2_all", generated_v2)
   monkeypatch.setattr(provider_usage.shutil, "which", lambda _name: "/codex")
-  monkeypatch.setattr(codex_client, "CodexClient", FakeClient)
-  monkeypatch.setattr(codex_client, "CodexConfig", lambda **kwargs: kwargs)
 
   loop = asyncio.get_running_loop()
   release = threading.Event()

--- a/backend/tests/test_provider_usage.py
+++ b/backend/tests/test_provider_usage.py
@@ -3,6 +3,11 @@
 import asyncio
 import base64
 import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+
+import pytest
 
 
 def test_normalize_claude_usage_keeps_current_and_model_windows():
@@ -170,3 +175,79 @@ def test_configured_plan_labels_never_fetch_usage(monkeypatch):
     "claude": "Max plan",
     "codex": "Plus plan",
   }
+
+
+@pytest.mark.asyncio
+async def test_codex_usage_ignores_saturated_default_executor(
+  monkeypatch, tmp_path,
+):
+  from app import provider_usage
+  import openai_codex.client as codex_client
+
+  calls = []
+
+  class FakeLimits:
+    def model_dump(self, **_kwargs):
+      return {"rate_limits": {}}
+
+  class FakeClient:
+    def __init__(self, _config):
+      pass
+
+    def _record(self, name):
+      calls.append((name, threading.current_thread().name))
+
+    def start(self):
+      self._record("start")
+
+    def initialize(self):
+      self._record("initialize")
+
+    def account_read(self):
+      self._record("account_read")
+      return SimpleNamespace(
+        account=SimpleNamespace(root=SimpleNamespace(plan_type="plus")),
+      )
+
+    def request(self, *_args, **_kwargs):
+      self._record("request")
+      return FakeLimits()
+
+    def close(self):
+      self._record("close")
+
+  monkeypatch.setattr(provider_usage.shutil, "which", lambda _name: "/codex")
+  monkeypatch.setattr(codex_client, "CodexClient", FakeClient)
+  monkeypatch.setattr(codex_client, "CodexConfig", lambda **kwargs: kwargs)
+
+  loop = asyncio.get_running_loop()
+  release = threading.Event()
+  occupied = threading.Event()
+  saturated = ThreadPoolExecutor(max_workers=1)
+  replacement = ThreadPoolExecutor(max_workers=1)
+  loop.set_default_executor(saturated)
+
+  def occupy_default_worker():
+    occupied.set()
+    release.wait()
+
+  blocker = loop.run_in_executor(None, occupy_default_worker)
+  while not occupied.is_set():
+    await asyncio.sleep(0)
+
+  try:
+    result = await asyncio.wait_for(
+      provider_usage._fetch_codex_usage(str(tmp_path)), timeout=1,
+    )
+    assert result["plan_label"] == "Plus plan"
+    assert {name for name, _thread in calls} >= {
+      "start", "initialize", "account_read", "request", "close",
+    }
+    assert all(
+      thread.startswith("mobius-codex-usage") for _name, thread in calls
+    )
+  finally:
+    release.set()
+    await blocker
+    loop.set_default_executor(replacement)
+    saturated.shutdown(wait=True)


### PR DESCRIPTION
## Summary

- keep static generation serving off the shared Codex executor
- give each Codex protocol session its own bounded worker lifecycle
- preserve provider usage accounting across isolated workers

## Testing

- 144 focused backend tests