### PR TITLE
Unify the pre-PR checks contract

### DIFF
--- a/backend/app/github_contribution_contract.py
+++ b/backend/app/github_contribution_contract.py
@@ -14,3 +14,6 @@ COAUTHOR_TRAILER = (
   "Co-authored-by: Möbius Agent <mobius-agent@users.noreply.github.com>"
 )
 SUBMIT_TIMEOUT_SECONDS = 90
+PRE_PR_CHECK_ACTIVE_STATES = frozenset({
+  "dispatching", "uncertain", "queued", "in_progress",
+})

--- a/backend/app/github_contributions.py
+++ b/backend/app/github_contributions.py
@@ -38,6 +38,7 @@ from app.github_contribution_contract import (
   GITHUB_LOGIN as _GITHUB_LOGIN,
   GITHUB_REPO as _GITHUB_REPO,
   GIT_SHA as _GIT_SHA,
+  PRE_PR_CHECK_ACTIVE_STATES as _PRE_PR_CHECK_ACTIVE_STATES,
   SUBMIT_TIMEOUT_SECONDS as _SUBMIT_TIMEOUT,
 )
 from app.contribution_records import (
@@ -424,12 +425,10 @@ def _claim_record(
       status_code=409,
       detail="This contribution is no longer waiting for approval.",
     )
-  early_checks = record.get("early_checks")
+  pre_pr_checks = record.get("pre_pr_checks")
   if (
-    isinstance(early_checks, dict)
-    and early_checks.get("state") in {
-      "dispatching", "uncertain", "queued", "in_progress",
-    }
+    isinstance(pre_pr_checks, dict)
+    and pre_pr_checks.get("state") in _PRE_PR_CHECK_ACTIVE_STATES
   ):
     raise HTTPException(
       status_code=409,

--- a/backend/app/github_pre_pr_checks.py
+++ b/backend/app/github_pre_pr_checks.py
@@ -17,7 +17,10 @@ from urllib.parse import quote
 
 from app import github_auth
 from app.contribution_errors import ContributionSubmitError
-from app.github_contribution_contract import GIT_SHA as _GIT_SHA
+from app.github_contribution_contract import (
+  GIT_SHA as _GIT_SHA,
+  PRE_PR_CHECK_ACTIVE_STATES as _ACTIVE_STATES,
+)
 from app import github_contribution_git as _git_ops
 from app import github_contributions as _contrib
 
@@ -26,13 +29,8 @@ _SUPPORTED_WORKFLOWS = {
   "mobius-os/mobius": "test.yml",
 }
 _API_VERSION = "2026-03-10"
-_ACTIVE_STATES = frozenset({
-  "dispatching", "uncertain", "queued", "in_progress",
-})
-
-
-def supports_prepared_checks(record: dict) -> bool:
-  """True when one prepared record may use the early-check action."""
+def supports_pre_pr_checks(record: dict) -> bool:
+  """True when one prepared record may use the pre-pr-check action."""
   plan = record.get("plan") if isinstance(record.get("plan"), dict) else {}
   repo = str(plan.get("repo") or record.get("repo") or "")
   return bool(
@@ -44,7 +42,7 @@ def supports_prepared_checks(record: dict) -> bool:
   )
 
 
-def check_is_active(check: object) -> bool:
+def pre_pr_checks_active(check: object) -> bool:
   return isinstance(check, dict) and check.get("state") in _ACTIVE_STATES
 
 
@@ -104,7 +102,7 @@ def _enable_workflow(repo: Path, fork_slug: str, workflow: str) -> None:
       "GitHub could not enable the Tests workflow on the personal fork. "
       "Enable Actions there or reconnect GitHub, then try Run checks again.",
       detail=detail[:600] or None,
-      code="early_checks_disabled",
+      code="pre_pr_checks_disabled",
     )
 
 
@@ -119,11 +117,11 @@ def _assert_upstream_workflow_dispatchable(
   )
   if source.returncode != 0 or "workflow_dispatch:" not in source.stdout:
     raise ContributionSubmitError(
-      "This is the one-time bootstrap for early checks: the manual Tests "
+      "This is the one-time bootstrap for pre-PR checks: the manual Tests "
       "trigger must reach upstream main before GitHub can run it from forks. "
       "Send this contribution normally; later platform contributions can run "
       "checks first.",
-      code="early_checks_unavailable",
+      code="pre_pr_checks_unavailable",
     )
 
 
@@ -148,7 +146,7 @@ def _dispatch_workflow(
       "The reviewed branch was pushed, but Contribute could not confirm "
       "whether GitHub started the checks. Reopen Contribute to reconcile the "
       "run before trying again.",
-      code="early_checks_uncertain",
+      code="pre_pr_checks_uncertain",
     ) from exc
   if result.returncode != 0:
     detail = (result.stderr or result.stdout or "").strip()
@@ -156,7 +154,7 @@ def _dispatch_workflow(
       "The reviewed branch was pushed, but GitHub could not start its Tests "
       "workflow.",
       detail=detail[:600] or None,
-      code="early_checks_dispatch_failed",
+      code="pre_pr_checks_dispatch_failed",
     )
   try:
     payload = _json_output(
@@ -167,7 +165,7 @@ def _dispatch_workflow(
     raise ContributionSubmitError(
       exc.message,
       detail=exc.detail,
-      code="early_checks_uncertain",
+      code="pre_pr_checks_uncertain",
     ) from exc
   try:
     run_id = int(payload.get("workflow_run_id"))
@@ -177,20 +175,18 @@ def _dispatch_workflow(
   if run_id <= 0 or not url.startswith("https://github.com/"):
     raise ContributionSubmitError(
       "GitHub started the checks but did not return their run details.",
-      code="early_checks_uncertain",
+      code="pre_pr_checks_uncertain",
     )
   return {"run_id": run_id, "url": url}
 
 
-def dispatch_prepared_checks(
+def dispatch_pre_pr_checks(
   record: dict,
   diff_path: Path,
-  *,
-  requested_at: str,
 ) -> tuple[dict, dict]:
   """Push the exact reviewed branch to the owner fork and start Tests.
 
-  Returns ``(early_checks, record_patch)``.  ``record_patch`` may contain a
+  Returns ``(pre_pr_checks, record_patch)``.  ``record_patch`` may contain a
   normalized reviewed head SHA and fork/push evidence; callers must persist it
   with the run atomically.
   """
@@ -208,14 +204,14 @@ def dispatch_prepared_checks(
     raise ContributionSubmitError(
       "Reconnect GitHub with full PR access before running checks on a fork.",
       status_code=409,
-      code="early_checks_scope",
+      code="pre_pr_checks_scope",
     )
-  if not supports_prepared_checks(record):
+  if not supports_pre_pr_checks(record):
     raise ContributionSubmitError(
-      "Early GitHub checks are currently available for standalone Möbius "
+      "Pre-PR GitHub checks are currently available for standalone Möbius "
       "platform contributions only.",
       status_code=409,
-      code="early_checks_unsupported",
+      code="pre_pr_checks_unsupported",
     )
 
   plan = record.get("plan") or {}
@@ -274,7 +270,7 @@ def dispatch_prepared_checks(
       raise ContributionSubmitError(
         f"This branch already has a {state_label} pull request: {url}. "
         "Use that pull request's checks instead of starting a private run.",
-        code="early_checks_existing_pr",
+        code="pre_pr_checks_existing_pr",
       )
 
     fork_slug = _contrib._ensure_owner_fork_remote(repo, upstream_repo, login)
@@ -318,7 +314,6 @@ def dispatch_prepared_checks(
       "branch": branch,
       "head_sha": pushed_sha,
       "workflow": workflow,
-      "requested_at": requested_at,
     }
     branch_url = f"https://github.com/{fork_slug}/tree/{quote(branch, safe='/')}"
     record_patch = _git_ops._record_patch_with(record_patch, {
@@ -329,6 +324,7 @@ def dispatch_prepared_checks(
     })
 
     _enable_workflow(repo, fork_slug, workflow)
+    pushed["requested_at"] = _now_iso()
     dispatched = _dispatch_workflow(
       repo,
       fork_slug=fork_slug,
@@ -346,8 +342,8 @@ def dispatch_prepared_checks(
     combined_patch = _git_ops._record_patch_with(
       record_patch, exc.record_patch,
     )
-    if pushed and not isinstance(combined_patch.get("early_checks"), dict):
-      check_state = "uncertain" if exc.code == "early_checks_uncertain" else "error"
+    if pushed and not isinstance(combined_patch.get("pre_pr_checks"), dict):
+      check_state = "uncertain" if exc.code == "pre_pr_checks_uncertain" else "error"
       patch = {
         **pushed,
         "state": check_state,
@@ -359,7 +355,7 @@ def dispatch_prepared_checks(
         exc.message,
         exc.status_code,
         detail=exc.detail,
-        record_patch={**combined_patch, "early_checks": patch},
+        record_patch={**combined_patch, "pre_pr_checks": patch},
         code=exc.code,
       ) from exc
     if combined_patch:
@@ -444,10 +440,10 @@ def _find_uncertain_run(repo: Path, check: dict) -> dict | None:
   return matches[0] if len(matches) == 1 else None
 
 
-def refresh_prepared_check(record: dict) -> dict | None:
-  """Return a fresh early-check snapshot, or None when no refresh is due."""
-  check = record.get("early_checks")
-  if not supports_prepared_checks(record) or not check_is_active(check):
+def refresh_pre_pr_check(record: dict) -> dict | None:
+  """Return a fresh pre-pr-check snapshot, or None when no refresh is due."""
+  check = record.get("pre_pr_checks")
+  if not supports_pre_pr_checks(record) or not pre_pr_checks_active(check):
     return None
   plan = record.get("plan") or {}
   repo = _contrib._safe_repo_path(plan.get("repo_path"))

--- a/backend/app/routes/github.py
+++ b/backend/app/routes/github.py
@@ -61,7 +61,7 @@ from app import (
   app_git,
   fs_locks,
   github_auth,
-  github_preflight_checks,
+  github_pre_pr_checks,
   models,
   source_status,
 )
@@ -823,7 +823,7 @@ async def contribution_review_status(
   }
 
 
-def _claim_prepared_checks(
+def _claim_pre_pr_checks(
   *, app_id: int, record_id: str, db: Session, expected_nonce: str | None,
 ) -> tuple[dict, Path, Path, str]:
   record_path, diff_path = _record_paths(app_id, record_id)
@@ -834,44 +834,43 @@ def _claim_prepared_checks(
       status_code=409,
       detail="This contribution is no longer waiting for approval.",
     )
-  if not github_preflight_checks.supports_prepared_checks(record):
+  if not github_pre_pr_checks.supports_pre_pr_checks(record):
     raise HTTPException(
       status_code=409,
       detail=(
-        "Early GitHub checks are currently available for standalone Möbius "
+        "Pre-PR GitHub checks are currently available for standalone Möbius "
         "platform contributions only."
       ),
     )
-  if github_preflight_checks.check_is_active(record.get("early_checks")):
+  if github_pre_pr_checks.pre_pr_checks_active(record.get("pre_pr_checks")):
     raise HTTPException(
       status_code=409,
       detail="GitHub checks are already starting or running for this review.",
     )
   request_id = secrets.token_hex(16)
-  requested_at = _now_iso()
+  claimed_at = _now_iso()
   claimed = {
     **record,
-    "early_checks": {
+    "pre_pr_checks": {
       "state": "dispatching",
       "request_id": request_id,
-      "requested_at": requested_at,
-      "observed_at": requested_at,
+      "observed_at": claimed_at,
     },
-    "updated_at": requested_at,
+    "updated_at": claimed_at,
   }
   _write_record(record_path, claimed)
   return claimed, record_path, diff_path, request_id
 
 
-def _settle_prepared_checks(
+def _settle_pre_pr_checks(
   *,
   record_path: Path,
   request_id: str,
   record_patch: dict,
-  early_checks: dict,
+  pre_pr_checks: dict,
 ) -> dict:
   current = _read_record(record_path)
-  live = current.get("early_checks")
+  live = current.get("pre_pr_checks")
   if (
     current.get("status") != "prepared"
     or not isinstance(live, dict)
@@ -885,8 +884,8 @@ def _settle_prepared_checks(
   updated = {
     **current,
     **record_patch,
-    "early_checks": {
-      **early_checks,
+    "pre_pr_checks": {
+      **pre_pr_checks,
       "request_id": request_id,
     },
     "updated_at": now,
@@ -896,11 +895,11 @@ def _settle_prepared_checks(
 
 
 @router.post(
-  "/contributions/{app_id}/{record_id}/run-checks",
+  "/contributions/{app_id}/{record_id}/pre-pr-checks",
   dependencies=[Depends(reject_cross_site)],
 )
 @_limiter.limit("10/minute")
-async def run_prepared_contribution_checks(
+async def run_pre_pr_checks(
   request: Request,
   app_id: int,
   record_id: str,
@@ -916,7 +915,7 @@ async def run_prepared_contribution_checks(
   expected_nonce = _validate_submit_app(app_id, principal, db)
   db.close()
   async with fs_locks.app_storage_lock(app_id):
-    claimed, record_path, diff_path, request_id = _claim_prepared_checks(
+    claimed, record_path, diff_path, request_id = _claim_pre_pr_checks(
       app_id=app_id,
       record_id=record_id,
       db=db,
@@ -930,20 +929,17 @@ async def run_prepared_contribution_checks(
     plan = claimed.get("plan") or {}
     repo_path = _safe_repo_path(plan.get("repo_path"))
     async with fs_locks.source_dir_lock(str(repo_path)):
-      early_checks, record_patch = await asyncio.to_thread(
-        github_preflight_checks.dispatch_prepared_checks,
+      pre_pr_checks, record_patch = await asyncio.to_thread(
+        github_pre_pr_checks.dispatch_pre_pr_checks,
         claimed,
         diff_path,
-        requested_at=str(
-          (claimed.get("early_checks") or {}).get("requested_at") or _now_iso()
-        ),
       )
   except ContributionSubmitError as exc:
     record_patch = dict(exc.record_patch)
-    early_checks = record_patch.pop("early_checks", None)
-    if not isinstance(early_checks, dict):
-      early_checks = {
-        **(claimed.get("early_checks") or {}),
+    pre_pr_checks = record_patch.pop("pre_pr_checks", None)
+    if not isinstance(pre_pr_checks, dict):
+      pre_pr_checks = {
+        **(claimed.get("pre_pr_checks") or {}),
         "state": "error",
         "message": exc.message,
         "observed_at": _now_iso(),
@@ -954,10 +950,10 @@ async def run_prepared_contribution_checks(
       "code": exc.code,
     })
   except Exception as exc:
-    log.exception("Prepared GitHub checks failed for %s/%s", app_id, record_id)
+    log.exception("Pre-PR GitHub checks failed for %s/%s", app_id, record_id)
     message = "Could not start GitHub checks for this contribution."
-    early_checks = {
-      **(claimed.get("early_checks") or {}),
+    pre_pr_checks = {
+      **(claimed.get("pre_pr_checks") or {}),
       "state": "error",
       "message": message,
       "observed_at": _now_iso(),
@@ -967,11 +963,11 @@ async def run_prepared_contribution_checks(
   async with fs_locks.app_storage_lock(app_id):
     _recheck_submit_app(db, app_id, expected_nonce)
     db.close()
-    record = _settle_prepared_checks(
+    record = _settle_pre_pr_checks(
       record_path=record_path,
       request_id=request_id,
       record_patch=record_patch,
-      early_checks=early_checks,
+      pre_pr_checks=pre_pr_checks,
     )
   if failure is not None:
     status_code, detail = failure
@@ -979,15 +975,15 @@ async def run_prepared_contribution_checks(
       status_code=status_code,
       detail={**detail, "record": record},
     )
-  return {"record": record, "checks": record["early_checks"]}
+  return {"record": record}
 
 
 @router.post(
-  "/contributions/{app_id}/prepared-checks/refresh",
+  "/contributions/{app_id}/pre-pr-checks/refresh",
   dependencies=[Depends(reject_cross_site)],
 )
 @_limiter.limit("30/minute")
-async def refresh_prepared_contribution_checks(
+async def refresh_pre_pr_checks(
   request: Request,
   app_id: int,
   db: Session = Depends(get_db),
@@ -1004,8 +1000,8 @@ async def refresh_prepared_contribution_checks(
         record = _read_record_tolerant(path)
         if (
           record is not None
-          and github_preflight_checks.check_is_active(
-            record.get("early_checks")
+          and github_pre_pr_checks.pre_pr_checks_active(
+            record.get("pre_pr_checks")
           )
         ):
           candidates.append((path, record))
@@ -1016,11 +1012,11 @@ async def refresh_prepared_contribution_checks(
   for path, record in candidates:
     try:
       checks = await asyncio.to_thread(
-        github_preflight_checks.refresh_prepared_check, record,
+        github_pre_pr_checks.refresh_pre_pr_check, record,
       )
     except ContributionSubmitError as exc:
       checks = {
-        **(record.get("early_checks") or {}),
+        **(record.get("pre_pr_checks") or {}),
         "state": "error",
         "message": exc.message,
         "observed_at": _now_iso(),
@@ -1034,8 +1030,8 @@ async def refresh_prepared_contribution_checks(
       current = _read_record_tolerant(path)
       if current is None or current.get("status") != "prepared":
         continue
-      current_checks = current.get("early_checks")
-      prior_checks = prior.get("early_checks")
+      current_checks = current.get("pre_pr_checks")
+      prior_checks = prior.get("pre_pr_checks")
       if (
         not isinstance(current_checks, dict)
         or not isinstance(prior_checks, dict)
@@ -1044,7 +1040,7 @@ async def refresh_prepared_contribution_checks(
         continue
       if checks == prior_checks:
         continue
-      updated = {**current, "early_checks": checks, "updated_at": _now_iso()}
+      updated = {**current, "pre_pr_checks": checks, "updated_at": _now_iso()}
       _write_record(path, updated)
       results.append(updated)
   return {"refreshed": results}

--- a/backend/tests/test_github_pre_pr_checks.py
+++ b/backend/tests/test_github_pre_pr_checks.py
@@ -6,7 +6,7 @@ import subprocess
 import pytest
 
 from app.contribution_errors import ContributionSubmitError
-from app import github_preflight_checks as checks
+from app import github_pre_pr_checks as checks
 
 
 def _record(*, repo="mobius-os/mobius", status="prepared"):
@@ -28,18 +28,18 @@ def _cp(payload, returncode=0):
 
 
 def test_support_is_narrow_and_active_states_are_explicit():
-  assert checks.supports_prepared_checks(_record())
-  assert not checks.supports_prepared_checks(_record(repo="mobius-os/app-demo"))
-  assert not checks.supports_prepared_checks(_record(status="open"))
+  assert checks.supports_pre_pr_checks(_record())
+  assert not checks.supports_pre_pr_checks(_record(repo="mobius-os/app-demo"))
+  assert not checks.supports_pre_pr_checks(_record(status="open"))
   stacked = _record()
   stacked["plan"]["stack"] = {"id": "stack-1"}
-  assert not checks.supports_prepared_checks(stacked)
+  assert not checks.supports_pre_pr_checks(stacked)
 
-  assert checks.check_is_active({"state": "dispatching"})
-  assert checks.check_is_active({"state": "uncertain"})
-  assert checks.check_is_active({"state": "queued"})
-  assert checks.check_is_active({"state": "in_progress"})
-  assert not checks.check_is_active({"state": "completed"})
+  assert checks.pre_pr_checks_active({"state": "dispatching"})
+  assert checks.pre_pr_checks_active({"state": "uncertain"})
+  assert checks.pre_pr_checks_active({"state": "queued"})
+  assert checks.pre_pr_checks_active({"state": "in_progress"})
+  assert not checks.pre_pr_checks_active({"state": "completed"})
 
 
 def test_bootstrap_requires_manual_trigger_on_upstream(monkeypatch, tmp_path):
@@ -54,7 +54,7 @@ def test_bootstrap_requires_manual_trigger_on_upstream(monkeypatch, tmp_path):
     checks._assert_upstream_workflow_dispatchable(
       tmp_path, upstream_sha="a" * 40, workflow="test.yml",
     )
-  assert failure.value.code == "early_checks_unavailable"
+  assert failure.value.code == "pre_pr_checks_unavailable"
   assert "one-time bootstrap" in failure.value.message
   assert calls[0][1] == (
     "show", f"{'a' * 40}:.github/workflows/test.yml",
@@ -74,7 +74,7 @@ def test_dispatch_response_without_run_identity_is_uncertain(
       workflow="test.yml",
       branch="fix/reviewed-change",
     )
-  assert failure.value.code == "early_checks_uncertain"
+  assert failure.value.code == "pre_pr_checks_uncertain"
 
 
 def test_exact_workflow_run_snapshot_rejects_the_wrong_head():

--- a/backend/tests/test_github_routes.py
+++ b/backend/tests/test_github_routes.py
@@ -27,7 +27,7 @@ import pytest
 from fastapi import HTTPException
 from fastapi.responses import Response
 
-from app import github_auth, github_preflight_checks, source_status
+from app import github_auth, github_pre_pr_checks, source_status
 from app.contribution_errors import ContributionSubmitError
 from app.config import get_settings
 from app.database import checked_out_connections
@@ -1276,19 +1276,21 @@ def _prepared_platform_review(app_id, record_id):
   return repo, record, diff_text
 
 
-def test_run_prepared_checks_persists_exact_run_and_blocks_duplicates(
+def test_run_pre_pr_checks_persists_exact_run_and_blocks_duplicates(
   client, owner_token, monkeypatch,
 ):
   _write_token(login="octocat", user_id=42, scopes=("public_repo", "workflow"))
   app_id, app_token = _app_token(client, owner_token, github_access=True)
   _repo, _record, _diff = _prepared_platform_review(
-    app_id, "early-check-success",
+    app_id, "pre-pr-check-success",
   )
 
-  def fake_dispatch(record, diff_path, *, requested_at):
-    assert record["early_checks"]["state"] == "dispatching"
-    assert diff_path.name == "early-check-success.diff"
-    assert requested_at == record["early_checks"]["requested_at"]
+  requested_at = "2026-08-02T14:00:00Z"
+
+  def fake_dispatch(record, diff_path):
+    assert record["pre_pr_checks"]["state"] == "dispatching"
+    assert diff_path.name == "pre-pr-check-success.diff"
+    assert "requested_at" not in record["pre_pr_checks"]
     return ({
       "state": "queued",
       "run_id": 734,
@@ -1302,46 +1304,48 @@ def test_run_prepared_checks_persists_exact_run_and_blocks_duplicates(
     }, {"last_submit_push_sha": record["plan"]["head_sha"]})
 
   monkeypatch.setattr(
-    github_preflight_checks, "dispatch_prepared_checks", fake_dispatch,
+    github_pre_pr_checks, "dispatch_pre_pr_checks", fake_dispatch,
   )
   headers = {"Authorization": f"Bearer {app_token}"}
   response = client.post(
-    f"/api/github/contributions/{app_id}/early-check-success/run-checks",
+    f"/api/github/contributions/{app_id}/pre-pr-check-success/pre-pr-checks",
     headers=headers,
   )
   assert response.status_code == 200, response.text
   record = response.json()["record"]
   assert record["status"] == "prepared"
-  assert record["early_checks"]["state"] == "queued"
-  assert record["early_checks"]["run_id"] == 734
-  assert record["early_checks"]["request_id"]
+  assert record["pre_pr_checks"]["state"] == "queued"
+  assert record["pre_pr_checks"]["run_id"] == 734
+  assert record["pre_pr_checks"]["request_id"]
   assert record["last_submit_push_sha"] == record["plan"]["head_sha"]
 
   duplicate = client.post(
-    f"/api/github/contributions/{app_id}/early-check-success/run-checks",
+    f"/api/github/contributions/{app_id}/pre-pr-check-success/pre-pr-checks",
     headers=headers,
   )
   assert duplicate.status_code == 409
   assert "already" in duplicate.json()["detail"].lower()
 
 
-def test_run_prepared_checks_keeps_recoverable_failure_on_the_record(
+def test_run_pre_pr_checks_keeps_recoverable_failure_on_the_record(
   client, owner_token, monkeypatch,
 ):
   _write_token(login="octocat", user_id=42, scopes=("public_repo", "workflow"))
   app_id, app_token = _app_token(client, owner_token, github_access=True)
   _repo, record, _diff = _prepared_platform_review(
-    app_id, "early-check-error",
+    app_id, "pre-pr-check-error",
   )
 
-  def fake_dispatch(_record, _diff_path, *, requested_at):
+  requested_at = "2026-08-02T14:00:00Z"
+
+  def fake_dispatch(_record, _diff_path):
     raise ContributionSubmitError(
       "GitHub could not start Tests.",
       status_code=409,
-      code="early_checks_dispatch_failed",
+      code="pre_pr_checks_dispatch_failed",
       record_patch={
         "last_submit_push_sha": record["plan"]["head_sha"],
-        "early_checks": {
+        "pre_pr_checks": {
           "state": "error",
           "message": "GitHub could not start Tests.",
           "requested_at": requested_at,
@@ -1351,51 +1355,51 @@ def test_run_prepared_checks_keeps_recoverable_failure_on_the_record(
     )
 
   monkeypatch.setattr(
-    github_preflight_checks, "dispatch_prepared_checks", fake_dispatch,
+    github_pre_pr_checks, "dispatch_pre_pr_checks", fake_dispatch,
   )
   response = client.post(
-    f"/api/github/contributions/{app_id}/early-check-error/run-checks",
+    f"/api/github/contributions/{app_id}/pre-pr-check-error/pre-pr-checks",
     headers={"Authorization": f"Bearer {app_token}"},
   )
   assert response.status_code == 409, response.text
   stored = response.json()["detail"]["record"]
   assert stored["status"] == "prepared"
-  assert stored["early_checks"]["state"] == "error"
-  assert stored["early_checks"]["request_id"]
+  assert stored["pre_pr_checks"]["state"] == "error"
+  assert stored["pre_pr_checks"]["request_id"]
   assert stored["last_submit_push_sha"] == record["plan"]["head_sha"]
 
 
-def test_run_prepared_checks_settles_an_invalid_checkout_claim(
+def test_run_pre_pr_checks_settles_an_invalid_checkout_claim(
   client, owner_token,
 ):
   _write_token(login="octocat", user_id=42, scopes=("public_repo", "workflow"))
   app_id, app_token = _app_token(client, owner_token, github_access=True)
   _repo, record, diff_text = _prepared_platform_review(
-    app_id, "early-check-invalid-path",
+    app_id, "pre-pr-check-invalid-path",
   )
   record["plan"]["repo_path"] = ""
-  _write_contribution(app_id, "early-check-invalid-path", record, diff_text)
+  _write_contribution(app_id, "pre-pr-check-invalid-path", record, diff_text)
 
   response = client.post(
-    f"/api/github/contributions/{app_id}/early-check-invalid-path/run-checks",
+    f"/api/github/contributions/{app_id}/pre-pr-check-invalid-path/pre-pr-checks",
     headers={"Authorization": f"Bearer {app_token}"},
   )
   assert response.status_code == 409, response.text
   stored = response.json()["detail"]["record"]
   assert stored["status"] == "prepared"
-  assert stored["early_checks"]["state"] == "error"
-  assert "durable repo_path" in stored["early_checks"]["message"]
+  assert stored["pre_pr_checks"]["state"] == "error"
+  assert "durable repo_path" in stored["pre_pr_checks"]["message"]
 
 
-def test_refresh_prepared_checks_persists_the_exact_terminal_run(
+def test_refresh_pre_pr_checks_persists_the_exact_terminal_run(
   client, owner_token, monkeypatch,
 ):
   _write_token(login="octocat", user_id=42, scopes=("public_repo", "workflow"))
   app_id, app_token = _app_token(client, owner_token, github_access=True)
   _repo, record, diff_text = _prepared_platform_review(
-    app_id, "early-check-refresh",
+    app_id, "pre-pr-check-refresh",
   )
-  record["early_checks"] = {
+  record["pre_pr_checks"] = {
     "state": "in_progress",
     "request_id": "request-1",
     "run_id": 735,
@@ -1404,24 +1408,24 @@ def test_refresh_prepared_checks_persists_the_exact_terminal_run(
     "branch": record["plan"]["branch"],
     "head_sha": record["plan"]["head_sha"],
   }
-  _write_contribution(app_id, "early-check-refresh", record, diff_text)
+  _write_contribution(app_id, "pre-pr-check-refresh", record, diff_text)
 
   def fake_refresh(_record):
     return {
-      **_record["early_checks"],
+      **_record["pre_pr_checks"],
       "state": "completed",
       "conclusion": "success",
       "completed_at": "2026-08-02T15:00:00Z",
     }
 
   monkeypatch.setattr(
-    github_preflight_checks, "refresh_prepared_check", fake_refresh,
+    github_pre_pr_checks, "refresh_pre_pr_check", fake_refresh,
   )
   headers = {"Authorization": f"Bearer {app_token}"}
-  url = f"/api/github/contributions/{app_id}/prepared-checks/refresh"
+  url = f"/api/github/contributions/{app_id}/pre-pr-checks/refresh"
   response = client.post(url, headers=headers)
   assert response.status_code == 200, response.text
-  assert response.json()["refreshed"][0]["early_checks"]["conclusion"] == (
+  assert response.json()["refreshed"][0]["pre_pr_checks"]["conclusion"] == (
     "success"
   )
 
@@ -1430,21 +1434,21 @@ def test_refresh_prepared_checks_persists_the_exact_terminal_run(
   assert repeat.json() == {"refreshed": []}
 
 
-def test_send_waits_while_prepared_checks_are_active(client, owner_token):
+def test_send_waits_while_pre_pr_checks_are_active(client, owner_token):
   _write_token(login="octocat", user_id=42, scopes=("public_repo", "workflow"))
   app_id, app_token = _app_token(client, owner_token, github_access=True)
   _repo, record, diff_text = _prepared_platform_review(
-    app_id, "early-check-send-lock",
+    app_id, "pre-pr-check-send-lock",
   )
-  record["early_checks"] = {
+  record["pre_pr_checks"] = {
     "state": "queued",
     "request_id": "request-2",
     "run_id": 736,
   }
-  _write_contribution(app_id, "early-check-send-lock", record, diff_text)
+  _write_contribution(app_id, "pre-pr-check-send-lock", record, diff_text)
 
   response = client.post(
-    f"/api/github/contributions/{app_id}/early-check-send-lock/submit",
+    f"/api/github/contributions/{app_id}/pre-pr-check-send-lock/submit",
     headers={"Authorization": f"Bearer {app_token}"},
   )
   assert response.status_code == 409
@@ -1452,10 +1456,10 @@ def test_send_waits_while_prepared_checks_are_active(client, owner_token):
 
   stored = json.loads(
     (Path(get_settings().data_dir) / "apps" / str(app_id) /
-     "contributions" / "early-check-send-lock.json").read_text()
+     "contributions" / "pre-pr-check-send-lock.json").read_text()
   )
   assert stored["status"] == "prepared"
-  assert stored["early_checks"]["state"] == "queued"
+  assert stored["pre_pr_checks"]["state"] == "queued"
 
 
 def test_review_status_catches_local_drift_before_send(


### PR DESCRIPTION
## Summary

- use one `pre_pr_checks` name from preparation through GitHub submission
- centralize the checks payload validation contract
- retire the overlapping preflight/early-check terminology

## Testing

- 146 focused backend tests