### PR TITLE
Require canonical app identities at the database boundary

### DIFF
--- a/backend/app/app_identity.py
+++ b/backend/app/app_identity.py
@@ -26,8 +26,6 @@ def slugify_for_source_dir(name: str) -> str:
   return slug
 
 
-
-
 def allocate_unique_slug(db: Session, name: str, exclude_id: int | None = None) -> str:
   """Returns a slug that isn't taken by any other App row.
 
@@ -54,23 +52,6 @@ def allocate_unique_slug(db: Session, name: str, exclude_id: int | None = None) 
       return candidate
     candidate = f"{base}-{suffix}"
     suffix += 1
-
-
-def ensure_slug(db: Session, app: models.App) -> str:
-  """Returns the app's slug, populating it on first call for legacy rows.
-
-  Apps created before the slug column existed have NULL slug. Lazy
-  backfill on first standalone-route access keeps the migration
-  pure-additive and avoids guessing slugs we might not be able to
-  validate at migration time (uniqueness needs a transaction).
-  """
-  if app.slug:
-    return app.slug
-  app.slug = allocate_unique_slug(db, app.name, exclude_id=app.id)
-  db.commit()
-  return app.slug
-
-
 
 
 def validate_source_dir(source_dir: str, data_dir: str) -> str:

--- a/backend/app/app_source_paths.py
+++ b/backend/app/app_source_paths.py
@@ -3,11 +3,6 @@
 from pathlib import Path
 
 
-def resolve_app_source_dir(app_source_dir) -> Path | None:
-  """Resolve the canonical stored source tree, or None when it is invalid."""
-  if not app_source_dir:
-    return None
-  try:
-    return Path(app_source_dir).resolve()
-  except OSError:
-    return None
+def resolve_app_source_dir(app_source_dir: str) -> Path:
+  """Resolve the canonical source tree stored on an app row."""
+  return Path(app_source_dir).resolve()

--- a/backend/app/chat_context.py
+++ b/backend/app/chat_context.py
@@ -151,11 +151,7 @@ def _build_app_context(
       return None, {}
     identities = []
     for linked_app in linked:
-      source_dir = (
-        Path(linked_app.source_dir)
-        if linked_app.source_dir
-        else data_root / "apps" / (linked_app.slug or str(linked_app.id))
-      )
+      source_dir = Path(linked_app.source_dir)
       identities.append({
         "app_id": linked_app.id,
         "name": linked_app.name,
@@ -191,9 +187,7 @@ def _build_app_context(
   if app is None:
     return None, {}
 
-  source_dir = Path(app.source_dir) if app.source_dir else (
-    data_root / "apps" / (app.slug or str(app.id))
-  )
+  source_dir = Path(app.source_dir)
   storage_dir = data_root / "apps" / str(app.id)
   # Per-project scoping (feature 135): when this chat carries a project_id in
   # agent_settings_json (the per-project-chat contract), the agent's workspace

--- a/backend/app/compiler.py
+++ b/backend/app/compiler.py
@@ -170,11 +170,8 @@ def purge_app_bundles(app_id: int) -> None:
     unlink_app_bundle(app_id, candidate)
 
 
-def _entry_source_path(app, *, source_root: Path | None = None) -> Path | None:
-  source_dir = source_root or getattr(app, "source_dir", None)
-  if not source_dir:
-    return None
-  source_root = Path(source_dir)
+def _entry_source_path(app, *, source_root: Path | None = None) -> Path:
+  source_root = source_root or Path(app.source_dir)
   entry = "index.jsx"
   manifest_path = source_root / "mobius.json"
   try:
@@ -405,8 +402,8 @@ async def recompile_app_bundle(db, app, jsx_source: str) -> None:
   compile_source_path = source_path
   snapshot = None
   source_commit = getattr(app, "source_commit", None)
-  source_dir = getattr(app, "source_dir", None)
-  if source_commit and source_dir:
+  if source_commit:
+    source_dir = Path(app.source_dir)
     # Bundle recovery is not a source publication authority. Compile the exact
     # Git revision selected by SQLite in a temporary tree so an unapplied draft
     # survives boot/recovery byte-for-byte. Static assets are installer-managed
@@ -418,18 +415,16 @@ async def recompile_app_bundle(db, app, jsx_source: str) -> None:
     try:
       await asyncio.to_thread(
         app_git.materialize_tree,
-        Path(source_dir),
+        source_dir,
         source_commit,
         snapshot_root,
       )
       await asyncio.to_thread(
-        _copy_managed_static_assets, Path(source_dir), snapshot_root,
+        _copy_managed_static_assets, source_dir, snapshot_root,
       )
       compile_source_path = _entry_source_path(
         app, source_root=snapshot_root,
       )
-      if compile_source_path is None:
-        raise RuntimeError("Accepted app source has no entry path.")
       accepted_source = compile_source_path.read_text(encoding="utf-8")
       if accepted_source != jsx_source:
         raise RuntimeError(
@@ -438,7 +433,7 @@ async def recompile_app_bundle(db, app, jsx_source: str) -> None:
     except Exception:
       snapshot.cleanup()
       raise
-  elif source_path is not None:
+  else:
     # Legacy rows have no durable source commit. Never repair them by writing
     # into the editable tree: that was a hidden source mutation and could
     # destroy an unapplied draft. Only a byte-identical entry is safe to use.
@@ -453,7 +448,7 @@ async def recompile_app_bundle(db, app, jsx_source: str) -> None:
       )
     from app import app_git
 
-    if await asyncio.to_thread(app_git.worktree_dirty, Path(source_dir)):
+    if await asyncio.to_thread(app_git.worktree_dirty, app.source_dir):
       raise RuntimeError(
         "Editable app source has an unapplied draft; apply it explicitly "
         "before rebuilding its bundle."
@@ -464,9 +459,7 @@ async def recompile_app_bundle(db, app, jsx_source: str) -> None:
       app.id,
       jsx_source,
       out_path=staged,
-      source_path=(
-        compile_source_path if compile_source_path is not None else None
-      ),
+      source_path=compile_source_path,
     )
   except Exception:
     if snapshot is not None:

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1002,10 +1002,123 @@ def _add_chat_run_root_identity(eng) -> None:
       ))
 
 
+def _require_app_identity(eng) -> None:
+  """Make every app row retain its canonical URL and source identities.
+
+  Fresh databases receive ordinary NOT NULL + CHECK constraints from the ORM
+  model. SQLite cannot add those constraints to an existing table without a
+  high-risk table rebuild, so upgraded databases enforce the identical write
+  boundary with small BEFORE triggers after proving every stored row is ready.
+  PostgreSQL can promote the columns directly.
+  """
+  from sqlalchemy import inspect as sa_inspect, text
+
+  if "apps" not in sa_inspect(eng).get_table_names():
+    return
+  with eng.begin() as conn:
+    from app.app_identity import slugify_for_source_dir
+
+    apps_root = Path(get_settings().data_dir) / "apps"
+    used_slugs = {
+      str(slug)
+      for (slug,) in conn.execute(text(
+        "SELECT slug FROM apps "
+        "WHERE slug IS NOT NULL AND length(trim(slug)) > 0"
+      ))
+    }
+    missing_slugs = conn.execute(text(
+      "SELECT id, name FROM apps "
+      "WHERE slug IS NULL OR length(trim(slug)) = 0 ORDER BY id"
+    )).all()
+    for app_id, name in missing_slugs:
+      base = slugify_for_source_dir(str(name or ""))
+      slug = base
+      suffix = 2
+      while slug in used_slugs:
+        slug = f"{base}-{suffix}"
+        suffix += 1
+      conn.execute(text(
+        "UPDATE apps SET slug = :slug WHERE id = :app_id"
+      ), {"slug": slug, "app_id": app_id})
+      used_slugs.add(slug)
+    missing_sources = conn.execute(text(
+      "SELECT id, slug FROM apps "
+      "WHERE source_dir IS NULL OR length(trim(source_dir)) = 0"
+    )).all()
+    for app_id, slug in missing_sources:
+      if not slug or not str(slug).strip():
+        raise RuntimeError(
+          f"cannot require app identity: app {app_id} has no slug"
+        )
+      conn.execute(text(
+        "UPDATE apps SET source_dir = :source_dir WHERE id = :app_id"
+      ), {
+        "source_dir": str(apps_root / str(slug)),
+        "app_id": app_id,
+      })
+    invalid = conn.execute(text(
+      "SELECT COUNT(*) FROM apps "
+      "WHERE slug IS NULL OR length(trim(slug)) = 0 "
+      "OR source_dir IS NULL OR length(trim(source_dir)) = 0"
+    )).scalar_one()
+    if invalid:
+      raise RuntimeError(
+        f"cannot require app identity: {invalid} app row(s) are incomplete"
+      )
+    duplicate_sources = conn.execute(text(
+      "SELECT source_dir FROM apps GROUP BY source_dir HAVING COUNT(*) > 1"
+    )).all()
+    if duplicate_sources:
+      raise RuntimeError(
+        "cannot require app identity: duplicate source_dir values exist"
+      )
+    conn.execute(text(
+      "CREATE UNIQUE INDEX IF NOT EXISTS ix_apps_source_dir "
+      "ON apps (source_dir)"
+    ))
+    if eng.dialect.name == "sqlite":
+      predicate = (
+        "NEW.slug IS NULL OR length(trim(NEW.slug)) = 0 "
+        "OR NEW.source_dir IS NULL OR length(trim(NEW.source_dir)) = 0"
+      )
+      conn.execute(text(
+        "CREATE TRIGGER IF NOT EXISTS apps_require_identity_insert "
+        f"BEFORE INSERT ON apps WHEN {predicate} BEGIN "
+        "SELECT RAISE(ABORT, 'apps require slug and source_dir'); END"
+      ))
+      conn.execute(text(
+        "CREATE TRIGGER IF NOT EXISTS apps_require_identity_update "
+        f"BEFORE UPDATE OF slug, source_dir ON apps WHEN {predicate} BEGIN "
+        "SELECT RAISE(ABORT, 'apps require slug and source_dir'); END"
+      ))
+    elif eng.dialect.name == "postgresql":
+      conn.execute(text(
+        "ALTER TABLE apps ALTER COLUMN slug SET NOT NULL"
+      ))
+      conn.execute(text(
+        "ALTER TABLE apps ALTER COLUMN source_dir SET NOT NULL"
+      ))
+      checks = {
+        item.get("name")
+        for item in sa_inspect(conn).get_check_constraints("apps")
+      }
+      if "ck_apps_slug_nonempty" not in checks:
+        conn.execute(text(
+          "ALTER TABLE apps ADD CONSTRAINT ck_apps_slug_nonempty "
+          "CHECK (length(trim(slug)) > 0)"
+        ))
+      if "ck_apps_source_dir_nonempty" not in checks:
+        conn.execute(text(
+          "ALTER TABLE apps ADD CONSTRAINT ck_apps_source_dir_nonempty "
+          "CHECK (length(trim(source_dir)) > 0)"
+        ))
+
+
 _SCHEMA_MIGRATIONS = (
   ("0001_legacy_schema_convergence", _converge_legacy_schema),
   ("0002_chat_run_goal_objective", _add_chat_run_goal_objective),
   ("0003_chat_run_root_identity", _add_chat_run_root_identity),
+  ("0004_app_identity_required", _require_app_identity),
 )
 
 

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1018,7 +1018,18 @@ def _require_app_identity(eng) -> None:
     return
   app_columns = {column["name"] for column in inspector.get_columns("apps")}
   with eng.begin() as conn:
-    from app.app_identity import slugify_for_source_dir
+    # Frozen migration copy. Historical identities must not change when the
+    # lifecycle helper evolves after this migration has shipped.
+    def slugify_for_source_dir(name: str) -> str:
+      slug = "".join(
+        ch if ch.isalnum() else "-" for ch in (name or "").lower()
+      ).strip("-")
+      while "--" in slug:
+        slug = slug.replace("--", "-")
+      slug = slug or "app"
+      if slug.isdigit():
+        slug = f"app-{slug}"
+      return slug
 
     apps_root = Path(get_settings().data_dir) / "apps"
     used_slugs = {
@@ -1045,13 +1056,43 @@ def _require_app_identity(eng) -> None:
       used_slugs.add(slug)
     source_projection = "jsx_source" if "jsx_source" in app_columns else "NULL"
     apps_root_resolved = apps_root.resolve()
-    reserved_sources = {
-      str(Path(source_dir).resolve())
-      for (source_dir,) in conn.execute(text(
-        "SELECT source_dir FROM apps "
-        "WHERE source_dir IS NOT NULL AND length(trim(source_dir)) > 0"
-      ))
-    }
+    existing_sources = conn.execute(text(
+      "SELECT id, source_dir FROM apps "
+      "WHERE source_dir IS NOT NULL AND length(trim(source_dir)) > 0 "
+      "ORDER BY id"
+    )).all()
+    canonical_sources: dict[str, int] = {}
+    canonical_updates: list[tuple[int, str]] = []
+    for app_id, stored_source in existing_sources:
+      try:
+        resolved_path = Path(stored_source).resolve()
+      except (OSError, RuntimeError) as exc:
+        raise RuntimeError(
+          f"cannot require app identity: app {app_id} has an invalid source_dir"
+        ) from exc
+      if (
+        resolved_path.parent != apps_root_resolved
+        or resolved_path.name.isdigit()
+      ):
+        raise RuntimeError(
+          "cannot require app identity: app "
+          f"{app_id} source_dir is outside the canonical apps root"
+        )
+      resolved = str(resolved_path)
+      prior_owner = canonical_sources.get(resolved)
+      if prior_owner is not None:
+        raise RuntimeError(
+          "cannot require app identity: apps "
+          f"{prior_owner} and {app_id} resolve to the same source_dir"
+        )
+      canonical_sources[resolved] = app_id
+      if str(stored_source) != resolved:
+        canonical_updates.append((app_id, resolved))
+    for app_id, resolved in canonical_updates:
+      conn.execute(text(
+        "UPDATE apps SET source_dir = :source_dir WHERE id = :app_id"
+      ), {"source_dir": resolved, "app_id": app_id})
+    reserved_sources = set(canonical_sources)
     missing_sources = conn.execute(text(
       f"SELECT id, slug, {source_projection} AS jsx_source FROM apps "
       "WHERE source_dir IS NULL OR length(trim(source_dir)) = 0"
@@ -1078,8 +1119,6 @@ def _require_app_identity(eng) -> None:
             )
           except (FileNotFoundError, OSError):
             migration_owned = False
-          if migration_owned:
-            return True
           try:
             names = {child.name for child in path.iterdir()}
           except (FileNotFoundError, OSError):
@@ -1090,6 +1129,7 @@ def _require_app_identity(eng) -> None:
           # source, so this app may safely resume the same deterministic path.
           if names <= {
             ".git",
+            ".gitignore",
             ".mobius-identity-migration",
             ".mobius-identity-migration.tmp",
           }:
@@ -1100,10 +1140,13 @@ def _require_app_identity(eng) -> None:
             ) == jsx_source
           except (FileNotFoundError, OSError):
             return False
-          return (
-            app_git.is_repo(path)
-            and not app_git.worktree_dirty(path)
-            and same_entry
+          if not same_entry:
+            return False
+          # A valid marker plus the stored source is exactly the partial state
+          # this migration itself can leave between write and commit. Without
+          # the marker, accept only an already-clean equivalent repository.
+          return migration_owned or (
+            app_git.is_repo(path) and not app_git.worktree_dirty(path)
           )
 
       # Allocate every missing identity, even when an extremely old schema has
@@ -1121,7 +1164,12 @@ def _require_app_identity(eng) -> None:
             f"{source_basename}-legacy-{app_id}-{candidate_number}"
           )
         candidate_number += 1
-        resolved_path = candidate.resolve()
+        try:
+          resolved_path = candidate.resolve()
+        except (OSError, RuntimeError):
+          # A pathological occupied basename (for example a symlink loop) does
+          # not get to brick boot; allocate the next deterministic sibling.
+          continue
         resolved = str(resolved_path)
         if (
           resolved_path.parent != apps_root_resolved

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1013,8 +1013,10 @@ def _require_app_identity(eng) -> None:
   """
   from sqlalchemy import inspect as sa_inspect, text
 
-  if "apps" not in sa_inspect(eng).get_table_names():
+  inspector = sa_inspect(eng)
+  if "apps" not in inspector.get_table_names():
     return
+  app_columns = {column["name"] for column in inspector.get_columns("apps")}
   with eng.begin() as conn:
     from app.app_identity import slugify_for_source_dir
 
@@ -1041,19 +1043,159 @@ def _require_app_identity(eng) -> None:
         "UPDATE apps SET slug = :slug WHERE id = :app_id"
       ), {"slug": slug, "app_id": app_id})
       used_slugs.add(slug)
+    source_projection = "jsx_source" if "jsx_source" in app_columns else "NULL"
+    apps_root_resolved = apps_root.resolve()
+    reserved_sources = {
+      str(Path(source_dir).resolve())
+      for (source_dir,) in conn.execute(text(
+        "SELECT source_dir FROM apps "
+        "WHERE source_dir IS NOT NULL AND length(trim(source_dir)) > 0"
+      ))
+    }
     missing_sources = conn.execute(text(
-      "SELECT id, slug FROM apps "
+      f"SELECT id, slug, {source_projection} AS jsx_source FROM apps "
       "WHERE source_dir IS NULL OR length(trim(source_dir)) = 0"
     )).all()
-    for app_id, slug in missing_sources:
+    for app_id, slug, jsx_source in missing_sources:
       if not slug or not str(slug).strip():
         raise RuntimeError(
           f"cannot require app identity: app {app_id} has no slug"
         )
+      # URL slugs on very old/corrupt rows were never a filesystem trust
+      # boundary. Preserve the URL identity in SQLite, but derive the source
+      # basename through the same sanitizer used for newly allocated apps.
+      source_basename = slugify_for_source_dir(str(slug))
+      source_dir = apps_root / source_basename
+      app_git = None
+      if isinstance(jsx_source, str):
+        from app import app_git
+
+        def reusable_legacy_tree(path: Path) -> bool:
+          marker = path / ".mobius-identity-migration"
+          try:
+            migration_owned = marker.read_text(encoding="utf-8") == (
+              f"0004_app_identity_required:{app_id}\n"
+            )
+          except (FileNotFoundError, OSError):
+            migration_owned = False
+          if migration_owned:
+            return True
+          try:
+            names = {child.name for child in path.iterdir()}
+          except (FileNotFoundError, OSError):
+            names = set()
+          # A crash before the atomic marker publish can leave only the new
+          # directory (or its marker temp); a crash in the older implementation
+          # could leave only ensure_repo's clean seed. Neither contains owner
+          # source, so this app may safely resume the same deterministic path.
+          if names <= {
+            ".git",
+            ".mobius-identity-migration",
+            ".mobius-identity-migration.tmp",
+          }:
+            return True
+          try:
+            same_entry = (path / "index.jsx").read_text(
+              encoding="utf-8"
+            ) == jsx_source
+          except (FileNotFoundError, OSError):
+            return False
+          return (
+            app_git.is_repo(path)
+            and not app_git.worktree_dirty(path)
+            and same_entry
+          )
+
+      # Allocate every missing identity, even when an extremely old schema has
+      # no stored JSX. Reservations cover existing rows and earlier assignments
+      # in this transaction. Resolved containment rejects symlinks that escape
+      # apps_root before any mkdir, marker, or Git operation can touch them.
+      candidate_number = 0
+      while True:
+        if candidate_number == 0:
+          candidate = source_dir
+        elif candidate_number == 1:
+          candidate = apps_root / f"{source_basename}-legacy-{app_id}"
+        else:
+          candidate = apps_root / (
+            f"{source_basename}-legacy-{app_id}-{candidate_number}"
+          )
+        candidate_number += 1
+        resolved_path = candidate.resolve()
+        resolved = str(resolved_path)
+        if (
+          resolved_path.parent != apps_root_resolved
+          or resolved_path.name.isdigit()
+          or resolved in reserved_sources
+        ):
+          continue
+        if candidate.exists():
+          if app_git is None or not reusable_legacy_tree(candidate):
+            continue
+        source_dir = candidate
+        reserved_sources.add(resolved)
+        break
+
+      if isinstance(jsx_source, str):
+        source_dir.mkdir(parents=True, exist_ok=True)
+        marker = source_dir / ".mobius-identity-migration"
+        marker_temp = source_dir / ".mobius-identity-migration.tmp"
+        marker_temp.write_text(
+          f"0004_app_identity_required:{app_id}\n", encoding="utf-8"
+        )
+        os.replace(marker_temp, marker)
+        try:
+          app_git.ensure_repo(source_dir)
+          # Keep the durable ownership marker through the source commit without
+          # accepting it as app source. A crash at any earlier boundary can now
+          # retry the same directory deterministically.
+          exclude = source_dir / ".git" / "info" / "exclude"
+          exclude.parent.mkdir(parents=True, exist_ok=True)
+          existing_exclude = (
+            exclude.read_text(encoding="utf-8")
+            if exclude.exists()
+            else ""
+          )
+          if ".mobius-identity-migration" not in existing_exclude.splitlines():
+            exclude.write_text(
+              existing_exclude.rstrip("\n")
+              + ("\n" if existing_exclude else "")
+              + ".mobius-identity-migration\n",
+              encoding="utf-8",
+            )
+          entry = source_dir / "index.jsx"
+          # The marker proves this directory belongs to this migration, so a
+          # partial prior write is safe to replace with the stored revision.
+          entry.write_text(jsx_source, encoding="utf-8")
+          if entry.read_text(encoding="utf-8") != jsx_source:
+            raise RuntimeError(
+              f"cannot require app identity: legacy source for app {app_id} "
+              "does not match its stored revision"
+            )
+          app_git.commit_local(
+            source_dir, "Materialize legacy app source identity"
+          )
+          if app_git.worktree_dirty(source_dir):
+            raise RuntimeError(
+              "cannot require app identity: materialized source for app "
+              f"{app_id} "
+              "is not clean"
+            )
+          marker.unlink(missing_ok=True)
+        except Exception:
+          # Deliberately retain the marker: it is the crash/retry ownership
+          # proof and is excluded from app history once Git exists.
+          raise
+        if app_git.worktree_dirty(source_dir):
+          raise RuntimeError(
+            "cannot require app identity: materialized source for app "
+            f"{app_id} "
+            "is not clean"
+          )
       conn.execute(text(
         "UPDATE apps SET source_dir = :source_dir WHERE id = :app_id"
       ), {
-        "source_dir": str(apps_root / str(slug)),
+        "source_dir": str(source_dir),
         "app_id": app_id,
       })
     invalid = conn.execute(text(

--- a/backend/app/install.py
+++ b/backend/app/install.py
@@ -1075,8 +1075,6 @@ async def _sync_app_skills(
   silently take over another live app's skill file.
   """
   skills = list(dict.fromkeys(manifest.get("skills") or []))
-  if not app.source_dir:
-    raise RuntimeError(f"app {app.id} violates canonical source ownership")
   data_dir = Path(get_settings().data_dir)
   skills_dir = data_dir / "shared" / "skills"
   source_dir = Path(app.source_dir)
@@ -1928,15 +1926,11 @@ async def _run_post_commit_effects(
   job_name = schedule.get("job") if schedule else None
   cron_job_name = job_name or "job.sh"
   has_cron = bool(schedule and schedule.get("default"))
-  drop_prior_cron = mode == "update" and bool(app.source_dir)
+  drop_prior_cron = mode == "update"
   if candidate.bundled_job or has_cron or drop_prior_cron:
     slug = app.slug
     data_dir = Path(get_settings().data_dir)
-    app_data_dir = (
-      Path(app.source_dir)
-      if app.source_dir
-      else data_dir / "apps" / slug
-    )
+    app_data_dir = Path(app.source_dir)
     try:
       async with fs_locks.source_dir_lock(str(app_data_dir)):
         if not db.query(models.App.id).filter(models.App.id == app.id).first():
@@ -2198,8 +2192,6 @@ async def _activate_install_source(
     app.capability_contract = plan.capability_contract
 
   staged_bundle = data_dir / "compiled" / f"app-{app.id}.js.staging"
-  if not app.source_dir:
-    raise RuntimeError(f"app {app.id} violates canonical source ownership")
   source_dir = Path(app.source_dir)
 
   _reject_if_source_dir_taken(db, str(source_dir), exclude_id=app.id)
@@ -2453,8 +2445,8 @@ async def install_from_manifest(
     )
 
     # --- Per-app git: record upstream + (on update) merge into local ---
-    # Engaged whenever the app has a real source_dir. The merge decision AND the
-    # disk write below run under ONE held span of source_dir_lock — not two
+    # The merge decision AND the disk write below run under ONE held span of
+    # source_dir_lock — not two
     # separate critical sections — so explicit apply (which takes the same lock
     # before its own commit_local) cannot commit an agent edit in the gap and
     # have the write then clobber it (the edit would be lost from the live tree,
@@ -2464,8 +2456,6 @@ async def install_from_manifest(
     # conflict can short-circuit both. The lock is released before the seeds
     # block takes app_storage_lock, preserving the documented acquisition order
     # (install_uninstall -> app_storage -> source_dir).
-    if not app.source_dir:
-      raise RuntimeError(f"app {app.id} violates canonical source ownership")
     git_source_dir = Path(app.source_dir)
     source_lock = fs_locks.source_dir_lock(str(git_source_dir))
     await source_lock.acquire()
@@ -2896,7 +2886,7 @@ async def install_from_manifest(
     # install back.  Ref deletion is best-effort post-commit housekeeping: the
     # replay already parents `main` directly on this upstream target, so keeping
     # an obsolete ref is harmless while deleting it bounds metadata growth.
-    if app.source_dir and equivalence_target_to_retire:
+    if equivalence_target_to_retire:
       try:
         async with fs_locks.source_dir_lock(str(app.source_dir)):
           await asyncio.to_thread(
@@ -2924,8 +2914,7 @@ async def install_from_manifest(
     # Success: drop any .bak snapshots we made — the new bundle is
     # now the canonical one.
     journal.cleanup_superseded()
-    if app.source_dir:
-      clear_pending_conflict_update(app.source_dir)
+    clear_pending_conflict_update(app.source_dir)
 
   except CompileError as exc:
     app_name = str(

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -17,8 +17,8 @@ import secrets
 from datetime import UTC, datetime
 
 from sqlalchemy import (
-  Boolean, Column, DateTime, Float, ForeignKey, Integer, JSON, LargeBinary,
-  String, Text, UniqueConstraint, event, false, or_, true,
+  Boolean, CheckConstraint, Column, DateTime, Float, ForeignKey, Integer, JSON,
+  LargeBinary, String, Text, UniqueConstraint, event, false, or_, true,
 )
 
 from sqlalchemy.orm import column_property
@@ -523,6 +523,14 @@ class App(Base):
   """A mini-app created and managed by the agent."""
 
   __tablename__ = "apps"
+  __table_args__ = (
+    CheckConstraint(
+      "length(trim(slug)) > 0", name="ck_apps_slug_nonempty",
+    ),
+    CheckConstraint(
+      "length(trim(source_dir)) > 0", name="ck_apps_source_dir_nonempty",
+    ),
+  )
 
   id = Column(Integer, primary_key=True, index=True)
   name = Column(String(128), nullable=False)
@@ -537,7 +545,7 @@ class App(Base):
   # the slug pins the install identity (manifest `id`), and changing
   # it after a user has installed the standalone PWA would orphan
   # their home-screen icon.
-  slug = Column(String(128), nullable=True, unique=True, index=True)
+  slug = Column(String(128), nullable=False, unique=True, index=True)
   # Per-app secret stamped into every app-scoped token at mint and
   # verified on each request (deps._enforce_app_scope). It rotates with
   # the row: a freshly-created app gets a fresh random nonce, so a token
@@ -611,8 +619,7 @@ class App(Base):
   # Absolute directory holding this app's source files. Editable app source lives
   # under `/data/apps/<dirname>`. Stored explicitly so source apply can map a
   # directory back to its DB row without slugify-guessing the name.
-  # Null for apps created before this column existed.
-  source_dir = Column(String(512), nullable=True, default=None)
+  source_dir = Column(String(512), nullable=False, unique=True, index=True)
   # Chat that last created or modified this app.  Null for apps created
   # before this column was added.  Used to route app errors back to the
   # correct chat so the agent can fix them.

--- a/backend/app/routes/app_runtime.py
+++ b/backend/app/routes/app_runtime.py
@@ -13,7 +13,6 @@ from fastapi.responses import FileResponse, HTMLResponse, StreamingResponse
 from sqlalchemy.orm import Session
 
 from app import activity, models, theme
-from app.app_identity import ensure_slug
 from app.config import get_settings
 from app.database import get_db
 from app.deps import get_current_owner, resolve_owner_or_app
@@ -432,7 +431,7 @@ def get_frame(
   # (activity.log_event swallows its own OSError).
   if request.method != "HEAD":
     activity.log_event(
-      "app_open", app_id=app.id, slug=ensure_slug(db, app),
+      "app_open", app_id=app.id, slug=app.slug,
     )
   return HTMLResponse(html, headers=headers)
 

--- a/backend/app/routes/app_schedules.py
+++ b/backend/app/routes/app_schedules.py
@@ -9,7 +9,6 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from app import app_cron, app_jobs, models, schemas
-from app.app_identity import slugify_for_source_dir as _slugify_for_source_dir
 from app.config import get_settings
 from app.database import get_db
 from app.deps import (
@@ -127,8 +126,6 @@ def _schedule_from_crontab_text(
 
 
 def _app_schedule(app: models.App, live_crontab: str) -> tuple[str, str] | None:
-  if not app.source_dir:
-    return None
   source_dir = Path(app.source_dir)
   live = _schedule_from_crontab_text(source_dir, live_crontab)
   if live is not None:
@@ -150,8 +147,6 @@ def _app_zone_declaration(app: models.App) -> tuple[str, str] | None:
   """
   from app import cron_tz
 
-  if not app.source_dir:
-    return None
   source_dir = Path(app.source_dir)
   for replay_dir in _cron_replay_dirs_for_app(app, source_dir):
     declaration = cron_tz.parse_zone_declaration(
@@ -247,7 +242,7 @@ def reconcile_app_cron_supervision(db: Session) -> tuple[int, list[str]]:
   apps = db.query(models.App).filter(models.App.deleted_at.is_(None)).all()
   for app in apps:
     schedule = _app_schedule(app, live_crontab)
-    if schedule is None or not app.source_dir:
+    if schedule is None:
       continue
     source_dir = Path(app.source_dir)
     try:
@@ -408,10 +403,6 @@ def run_app_job(
       detail="App token can only run its own job.",
     )
   app = live_app_or_404(db, app_id)
-  if not app.source_dir:
-    raise HTTPException(
-      status_code=400, detail="App has no source_dir; cannot locate job.",
-    )
   source_dir = Path(app.source_dir)
   # The manifest's schedule.job wins. The legacy probe (fetch.sh
   # app-news convention, job.sh install-from-manifest default,
@@ -502,10 +493,6 @@ def update_app_schedule(
       detail="App token can only update its own schedule.",
     )
   app = live_app_or_404(db, app_id)
-  if not app.source_dir:
-    raise HTTPException(
-      status_code=400, detail="App has no source_dir; cannot locate job.",
-    )
   from app import cron_tz
   try:
     validate_cron_expr(body.cron)
@@ -533,7 +520,7 @@ def update_app_schedule(
   job_path = source_dir / job_name
   if not job_path.is_file():
     raise HTTPException(status_code=400, detail="Job script not found.")
-  slug = app.slug or _slugify_for_source_dir(app.name)
+  slug = app.slug
   if timezone is not None:
     materialized = cron_tz.materialize_zone_cron(body.cron, timezone)
     app_cron.register_cron(

--- a/backend/app/routes/apps.py
+++ b/backend/app/routes/apps.py
@@ -80,12 +80,14 @@ def _safe_to_rmtree_source(
   """Whether uninstall may recursively delete this resolved source dir.
 
   Only an IMMEDIATE, non-numeric child of /data/apps that NO OTHER app row
-  still resolves to. Refuses to delete:
+  still resolves to. The database requires unique canonical source strings;
+  the resolved-path comparison remains defense against an aliased legacy row.
+  Refuses to delete:
     - a nested descendant (parent != apps_root) — a legacy/invalid row whose
       source_dir points deep into /data/apps could otherwise rmtree a path
       inside another app's tree,
     - a /data/apps/<integer> per-app storage tree, and
-    - a directory a SIBLING app row shares — removing it when one app is
+    - a directory a SIBLING app row resolves to — removing it when one app is
       uninstalled would break the other.
   Ordinary app source dirs are a unique /data/apps/<slug>. Legacy rows that
   point outside that root are never removed by app uninstall/purge.
@@ -94,7 +96,7 @@ def _safe_to_rmtree_source(
     return False
   others = (
     db.query(models.App)
-    .filter(models.App.id != exclude_id, models.App.source_dir.isnot(None))
+    .filter(models.App.id != exclude_id)
     .all()
   )
   for other in others:
@@ -248,17 +250,16 @@ async def _hard_delete_app(db: Session, app: models.App) -> None:
       deleted_app_id,
     )
 
-  resolved_source = _resolve_app_source_dir(app_source_dir)
-  if resolved_source is not None:
-    try:
-      async with fs_locks.source_dir_lock(str(resolved_source)):
-        if _safe_to_rmtree_source(resolved_source, apps_root, db, deleted_app_id):
-          await asyncio.to_thread(_drop_cron_and_rmtree, resolved_source)
-    except Exception:
-      log.exception(
-        "Hard-deleted app %s but could not remove its retired source tree",
-        deleted_app_id,
-      )
+  try:
+    resolved_source = _resolve_app_source_dir(app_source_dir)
+    async with fs_locks.source_dir_lock(str(resolved_source)):
+      if _safe_to_rmtree_source(resolved_source, apps_root, db, deleted_app_id):
+        await asyncio.to_thread(_drop_cron_and_rmtree, resolved_source)
+  except Exception:
+    log.exception(
+      "Hard-deleted app %s but could not remove its retired source tree",
+      deleted_app_id,
+    )
 
 
 @router.get("/", response_model=list[schemas.AppOut])
@@ -883,7 +884,7 @@ async def update_check(
       checked_at=checked_at,
     )
 
-  if not manifest_url or not source_dir:
+  if not manifest_url:
     return _unknown()
 
   # Authentication and the target lookup have completed.  Release the request
@@ -1023,8 +1024,6 @@ async def update_preview(
         ),
       )
   app = live_app_or_404(db, app_id)
-  if not app.source_dir:
-    raise HTTPException(status_code=400, detail="App has no source_dir.")
   repo = Path(app.source_dir)
   if not app_git.is_repo(repo):
     raise HTTPException(status_code=400, detail="App is not a git repo.")
@@ -1095,7 +1094,7 @@ async def update_candidate_preview(
   manifest_url = app.manifest_url
   source_dir = app.source_dir
   upstream_commit = app.upstream_commit
-  if not manifest_url or not source_dir:
+  if not manifest_url:
     raise HTTPException(400, "App has no update source.")
   repo = Path(source_dir)
   if not app_git.is_repo(repo) or not app_git.ref_exists(
@@ -1245,8 +1244,6 @@ async def create_conflict_resolver_chat(
 ):
   """Create or return the owner-visible resolver chat for an app conflict."""
   app = live_app_or_404(db, app_id, populate=True)
-  if not app.source_dir:
-    raise HTTPException(status_code=400, detail="App has no source_dir.")
   repo = Path(app.source_dir)
   if not app_git.is_repo(repo):
     raise HTTPException(status_code=400, detail="App is not a git repo.")
@@ -2069,11 +2066,10 @@ async def delete_app(
     # job.sh stays in the preserved source tree so a reinstall/recover can
     # re-register the schedule. Drop cron under the per-source-dir lock, off the
     # loop (crontab shells out).
-    resolved_source = _resolve_app_source_dir(app_source_dir)
     try:
-      if resolved_source is not None:
-        async with fs_locks.source_dir_lock(str(resolved_source)):
-          await asyncio.to_thread(_drop_cron_only, resolved_source)
+      resolved_source = _resolve_app_source_dir(app_source_dir)
+      async with fs_locks.source_dir_lock(str(resolved_source)):
+        await asyncio.to_thread(_drop_cron_only, resolved_source)
     except Exception:
       log.exception(
         "App %s was deleted but its source cron could not be disabled",
@@ -2239,11 +2235,10 @@ async def recover_app(
     # preserved scripts here: an older one may run the job directly. Once all
     # replay locations are restored, the common reconciler below preserves the
     # cadence while rewriting/installing the supervised command.
-    resolved_source = _resolve_app_source_dir(app_source_dir)
     try:
-      if resolved_source is not None:
-        async with fs_locks.source_dir_lock(str(resolved_source)):
-          await asyncio.to_thread(_reenable_init_cron_replay, resolved_source)
+      resolved_source = _resolve_app_source_dir(app_source_dir)
+      async with fs_locks.source_dir_lock(str(resolved_source)):
+        await asyncio.to_thread(_reenable_init_cron_replay, resolved_source)
     except Exception:
       log.exception(
         "App %s was recovered but its cron declaration could not be restored",

--- a/backend/app/routes/standalone.py
+++ b/backend/app/routes/standalone.py
@@ -383,7 +383,7 @@ async def standalone_icon(
   app_id = app.id
   icon_png = app.effective_icon_png
   name = app.name
-  app_slug = app.slug or slug
+  app_slug = app.slug
   bg_inputs = (app.background_color, app.theme_color)
 
   def _compute() -> bytes:
@@ -480,8 +480,8 @@ def _standalone_index_html(app: models.App, install_pass: str = "") -> str:
       headers={"Retry-After": "1"},
     )
 
-  slug = quote(app.slug or "", safe="")
-  name = escape(app.name or app.slug or "App", quote=True)
+  slug = quote(app.slug, safe="")
+  name = escape(app.name or app.slug, quote=True)
   description = escape(app.description or "", quote=True)
   version = int(app.updated_at.timestamp() * 1_000_000) if app.updated_at else 0
   app_bg = _app_background_color(app)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -131,7 +131,7 @@ class AppOut(BaseModel):
   description: str
   compiled_path: str
   chat_id: str | None = None
-  source_dir: str | None = None
+  source_dir: str
   pinned_at: datetime | None = None
   # Owner navigation recency. Kept separate from updated_at so opening an app
   # never rotates its executable-bundle cache key.
@@ -161,11 +161,8 @@ class AppOut(BaseModel):
   github_connect: bool = False
   # Guarded owner-filesystem access — see models.App.filesystem_access.
   filesystem_access: bool = False
-  # URL slug for the standalone PWA install at /apps/<slug>/. Null
-  # only for legacy rows from before the slug column existed; lazy-
-  # backfilled on first access via standalone routes (see
-  # app_identity.ensure_slug).
-  slug: str | None = None
+  # Stable URL slug for the standalone PWA install at /apps/<slug>/.
+  slug: str
   # URL the app was installed from (manifest URL passed to
   # POST /api/apps/install). Null for user-built apps. The install
   # endpoint matches by this for update-vs-install discrimination.

--- a/backend/app/system_prompts.py
+++ b/backend/app/system_prompts.py
@@ -124,7 +124,7 @@ def compose_system_prompt(base: str, db: Session) -> str:
       continue
     source_label = str(Path(app.source_dir).resolve())
     fragments.append(
-      f"<!-- installed system app: {app.slug or app.id}; "
+      f"<!-- installed system app: {app.slug}; "
       f"source_dir: {source_label} -->\n{fragment}"
     )
   if not fragments:

--- a/backend/tests/test_activity.py
+++ b/backend/tests/test_activity.py
@@ -790,6 +790,7 @@ async def test_bootstrap_install_emits_with_source_bootstrap(db, monkeypatch):
 
     captured.append(source)
     fake = models.App(
+      source_dir="/tmp/mobius-tests/store",
       id=42, name="Store", slug="store",
       manifest_url=manifest_url,
     )

--- a/backend/tests/test_app_activity.py
+++ b/backend/tests/test_app_activity.py
@@ -6,6 +6,8 @@ from app.broadcast import get_system_broadcast
 
 def _app(db):
   app = models.App(
+    slug="test-app-activity-8",
+    source_dir="/tmp/mobius-tests/test-app-activity-8",
     name="News", description="", jsx_source="export default function App(){}",
     compiled_path="/tmp/app.js",
   )

--- a/backend/tests/test_app_chat_contract.py
+++ b/backend/tests/test_app_chat_contract.py
@@ -359,8 +359,12 @@ def test_app_cannot_touch_foreign_chat(client, owner_token, db):
   owner_chat = models.Chat(id="owner-chat", title="owner's", messages=[])
   db.add(owner_chat)
   # Another app's chat.
-  other = models.App(name="other", description="",
-                     jsx_source="export default () => null")
+  other = models.App(
+    slug="test-app-chat-contract-362",
+    source_dir="/tmp/mobius-tests/test-app-chat-contract-362",
+    name="other", description="",
+    jsx_source="export default () => null",
+  )
   db.add(other)
   db.commit()
   db.refresh(other)
@@ -417,8 +421,12 @@ def test_owner_can_still_send_to_app_owned_chat(client, owner_token, db):
   """The created_by_app_id tag attributes the chat to an app, but the
   owner can still drive it from the shell — it's an actor tag, not a
   fence against the owner."""
-  app = models.App(name="x", description="",
-                   jsx_source="export default () => null")
+  app = models.App(
+    slug="test-app-chat-contract-420",
+    source_dir="/tmp/mobius-tests/test-app-chat-contract-420",
+    name="x", description="",
+    jsx_source="export default () => null",
+  )
   db.add(app)
   db.commit()
   db.refresh(app)

--- a/backend/tests/test_app_jobs.py
+++ b/backend/tests/test_app_jobs.py
@@ -395,6 +395,8 @@ def test_wrapper_rejects_job_context_without_exact_app_identity(
 
 def _db_app(db, name):
   app = models.App(
+    slug=name,
+    source_dir=f"/tmp/mobius-tests/{name}",
     name=name, description="", jsx_source="export default () => null",
   )
   db.add(app)

--- a/backend/tests/test_app_preview.py
+++ b/backend/tests/test_app_preview.py
@@ -7,6 +7,8 @@ from app import models
 
 def _app(db):
   app = models.App(
+    slug="test-app-preview-9",
+    source_dir="/tmp/mobius-tests/test-app-preview-9",
     name="Atlas", description="", chat_id="chat-a",
     jsx_source="export default function App(){}",
     compiled_path="/tmp/app.js",

--- a/backend/tests/test_app_project_context.py
+++ b/backend/tests/test_app_project_context.py
@@ -18,6 +18,8 @@ _DATA_DIR = os.environ.get("DATA_DIR", "/tmp")
 
 def _app_chat(db, *, project_id=None):
   app = models.App(
+    slug="test-app-project-context-20",
+    source_dir="/tmp/mobius-tests/test-app-project-context-20",
     name="studio", description="t",
     jsx_source="export default () => null",
   )

--- a/backend/tests/test_app_recency.py
+++ b/backend/tests/test_app_recency.py
@@ -7,6 +7,8 @@ from app import models
 
 def _app(db):
   app = models.App(
+    slug="test-app-recency-9",
+    source_dir="/tmp/mobius-tests/test-app-recency-9",
     name="Atlas",
     description="",
     jsx_source="export default function App(){}",

--- a/backend/tests/test_app_report_context.py
+++ b/backend/tests/test_app_report_context.py
@@ -26,6 +26,8 @@ def _write_report(app_id, date_str, html):
 def _app_chat(db, *, report_date=None, app=None):
   if app is None:
     app = models.App(
+      slug="test-app-report-context-28",
+      source_dir="/tmp/mobius-tests/test-app-report-context-28",
       name="reporter", description="t",
       jsx_source="export default () => null",
     )
@@ -97,6 +99,8 @@ def test_no_block_when_report_file_missing(db):
 def test_malformed_report_date_rejected(db):
   # A traversal-shaped date must never become a path component.
   app = models.App(
+    slug="test-app-report-context-99",
+    source_dir="/tmp/mobius-tests/test-app-report-context-99",
     name="evil", description="t", jsx_source="export default () => null",
   )
   db.add(app)

--- a/backend/tests/test_app_secrets.py
+++ b/backend/tests/test_app_secrets.py
@@ -6,9 +6,11 @@ from app.config import get_settings
 
 
 def _create_app(db, name: str) -> models.App:
+  slug = name.lower().replace(" ", "-")
   app = models.App(
+    source_dir=f"/tmp/mobius-tests/{slug}",
     name=name,
-    slug=name.lower().replace(" ", "-"),
+    slug=slug,
     description="test",
     jsx_source="export default function App() { return null }",
     compiled_path=f"/tmp/{name}.js",

--- a/backend/tests/test_apps.py
+++ b/backend/tests/test_apps.py
@@ -173,6 +173,7 @@ def test_owner_chat_log_scope_backfills_a_legacy_store_contract(
 
 def test_list_apps_does_not_hydrate_source_or_icon_payloads(client, auth, db):
   app = models.App(
+    source_dir="/tmp/mobius-tests/heavy-metadata-test",
     name="Heavy metadata test",
     description="drawer row",
     jsx_source="x" * 1_000_000,

--- a/backend/tests/test_artifact_persistence_platform.py
+++ b/backend/tests/test_artifact_persistence_platform.py
@@ -39,6 +39,7 @@ def _create_app(client, auth, name="artifact-platform") -> int:
 
 def _seed_app_row(db, app_id: int, name: str) -> models.App:
   app = models.App(
+    source_dir="/tmp/mobius-tests/test-artifact-persistence-platform-41",
     id=app_id,
     name=name,
     description="test",

--- a/backend/tests/test_bootstrap.py
+++ b/backend/tests/test_bootstrap.py
@@ -26,7 +26,10 @@ from app.bootstrap import (
 def _install_result(name="App", slug="app", app_id=1, mode="install"):
   from app.install import InstallResult
 
-  app = models.App(id=app_id, name=name, slug=slug)
+  app = models.App(
+    source_dir="/tmp/mobius-tests/test-bootstrap-29",
+    id=app_id, name=name, slug=slug,
+  )
   return InstallResult(
     app=app,
     mode=mode,
@@ -83,6 +86,7 @@ async def test_bootstrap_applies_per_app_uninstall_policy(db, monkeypatch):
   deleted_at = datetime.now(timezone.utc)
   db.add_all([
     models.App(
+      source_dir="/tmp/mobius-tests/store",
       name="Store",
       description="owner uninstalled",
       jsx_source="export default function App() {}",
@@ -93,6 +97,7 @@ async def test_bootstrap_applies_per_app_uninstall_policy(db, monkeypatch):
       deleted_at=deleted_at,
     ),
     models.App(
+      source_dir="/tmp/mobius-tests/skills",
       name="Skills",
       description="owner uninstalled",
       jsx_source="export default function App() {}",
@@ -103,6 +108,7 @@ async def test_bootstrap_applies_per_app_uninstall_policy(db, monkeypatch):
       deleted_at=deleted_at,
     ),
     models.App(
+      source_dir="/tmp/mobius-tests/memory",
       name="Memory",
       description="owner uninstalled",
       jsx_source="export default function App() {}",
@@ -113,6 +119,7 @@ async def test_bootstrap_applies_per_app_uninstall_policy(db, monkeypatch):
       deleted_at=deleted_at,
     ),
     models.App(
+      source_dir="/tmp/mobius-tests/reflection",
       name="Reflection",
       description="already here",
       jsx_source="export default function App() {}",
@@ -144,6 +151,7 @@ async def test_bootstrap_skips_live_apps_by_canonical_manifest(db, monkeypatch):
 
   db.add_all([
     models.App(
+      source_dir="/tmp/mobius-tests/app-store",
       name="Store",
       description="already here",
       jsx_source="export default function App() {}",
@@ -151,6 +159,7 @@ async def test_bootstrap_skips_live_apps_by_canonical_manifest(db, monkeypatch):
       manifest_url=_canonical_identity_key(BOOTSTRAP_STORE_MANIFEST_URL, "store"),
     ),
     models.App(
+      source_dir="/tmp/mobius-tests/skills-custom",
       name="Skills",
       description="already here",
       jsx_source="export default function App() {}",
@@ -160,6 +169,7 @@ async def test_bootstrap_skips_live_apps_by_canonical_manifest(db, monkeypatch):
       ),
     ),
     models.App(
+      source_dir="/tmp/mobius-tests/memory-custom",
       name="Memory",
       description="already here",
       jsx_source="export default function App() {}",
@@ -169,6 +179,7 @@ async def test_bootstrap_skips_live_apps_by_canonical_manifest(db, monkeypatch):
       ),
     ),
     models.App(
+      source_dir="/tmp/mobius-tests/reflection-custom",
       name="Reflection",
       description="already here",
       jsx_source="export default function App() {}",
@@ -195,6 +206,7 @@ async def test_bootstrap_ignores_unrelated_store_slug(db, monkeypatch):
   """A user-built app named store does not satisfy canonical app identity."""
   monkeypatch.delenv("MOEBIUS_SKIP_BOOTSTRAP", raising=False)
   db.add(models.App(
+    source_dir="/tmp/mobius-tests/store",
     name="Store",
     description="user's own app, unrelated to the bootstrap manifest",
     jsx_source="export default function App() {}",
@@ -260,6 +272,7 @@ async def test_bootstrap_recognizes_skills_row_installed_at_other_ref(
     "https://raw.githubusercontent.com/mobius-os/app-skills"
   )
   db.add(models.App(
+    source_dir="/tmp/mobius-tests/skills",
     id=50, name="Skills", slug="skills",
     manifest_url=_canonical_identity_key(_SKILLS_MAIN_MANIFEST, "skills"),
   ))
@@ -281,6 +294,7 @@ async def test_bootstrap_honors_skills_tombstone_at_other_ref(db, monkeypatch):
   from app.install import _canonical_identity_key
 
   db.add(models.App(
+    source_dir="/tmp/mobius-tests/skills",
     id=51, name="Skills", slug="skills",
     manifest_url=_canonical_identity_key(_SKILLS_MAIN_MANIFEST, "skills"),
     deleted_at=datetime.now(timezone.utc),

--- a/backend/tests/test_catalog_index.py
+++ b/backend/tests/test_catalog_index.py
@@ -262,6 +262,7 @@ def test_refresh_route_calls_refresh_with_override(
   from app.routes import skills as rs
 
   app_row = models.App(
+    source_dir="/tmp/mobius-tests/skills",
     name="Skills", description="", jsx_source="x", compiled_path="", slug="skills",
   )
   db.add(app_row)
@@ -296,6 +297,7 @@ def test_sources_override_absent_or_malformed_is_none(db, monkeypatch):
   assert rs._catalog_sources_override(db) is None
 
   app_row = models.App(
+    source_dir="/tmp/mobius-tests/skills",
     name="Skills", description="", jsx_source="x", compiled_path="", slug="skills",
   )
   db.add(app_row)

--- a/backend/tests/test_chat_logs.py
+++ b/backend/tests/test_chat_logs.py
@@ -11,7 +11,10 @@ from app import models
 
 
 def _make_app(db, name, chat_log_access="none"):
+  slug = name.lower().replace(" ", "-")
   app = models.App(
+    slug=slug,
+    source_dir=f"/tmp/mobius-tests/{slug}",
     name=name,
     description="",
     jsx_source="export default () => null",

--- a/backend/tests/test_chat_writer_contention.py
+++ b/backend/tests/test_chat_writer_contention.py
@@ -68,6 +68,8 @@ def _seed_app(app_id=42):
   db = SessionLocal()
   try:
     app = models.App(
+      slug="test-chat-writer-contention-70",
+      source_dir="/tmp/mobius-tests/test-chat-writer-contention-70",
       id=app_id,
       name=f"App {app_id}",
       description="",

--- a/backend/tests/test_created_by_app_id.py
+++ b/backend/tests/test_created_by_app_id.py
@@ -38,6 +38,8 @@ def test_created_by_app_id_defaults_to_null(db):
 def test_created_by_app_id_persists_integer(db):
   """Setting created_by_app_id to an integer round-trips through the DB."""
   app = models.App(
+    slug="test-created-by-app-id-40",
+    source_dir="/tmp/mobius-tests/test-created-by-app-id-40",
     name="myapp", description="test", jsx_source="export default () => null",
   )
   db.add(app)
@@ -83,6 +85,8 @@ def _app_principal(db, app_id: int):
 def test_owner_principal_drives_any_chat(db):
   """An owner token may drive any chat regardless of created_by_app_id."""
   app = models.App(
+    slug="test-created-by-app-id-85",
+    source_dir="/tmp/mobius-tests/test-created-by-app-id-85",
     name="a1", description="", jsx_source="export default () => null",
   )
   db.add(app)
@@ -115,6 +119,8 @@ def test_owner_principal_drives_owner_created_chat(db):
 def test_app_principal_drives_own_chat(db):
   """An app token may drive a chat it created (matching created_by_app_id)."""
   app = models.App(
+    slug="test-created-by-app-id-117",
+    source_dir="/tmp/mobius-tests/test-created-by-app-id-117",
     name="a2", description="", jsx_source="export default () => null",
   )
   db.add(app)
@@ -136,6 +142,8 @@ def test_app_principal_drives_own_chat(db):
 def test_app_principal_blocked_from_owner_chat(db):
   """An app token receives 403 when targeting an owner-created chat (NULL)."""
   app = models.App(
+    slug="test-created-by-app-id-138",
+    source_dir="/tmp/mobius-tests/test-created-by-app-id-138",
     name="a3", description="", jsx_source="export default () => null",
   )
   db.add(app)
@@ -155,9 +163,13 @@ def test_app_principal_blocked_from_owner_chat(db):
 def test_app_principal_blocked_from_foreign_app_chat(db):
   """An app token receives 403 when targeting a chat owned by a different app."""
   app_a = models.App(
+    slug="test-created-by-app-id-157",
+    source_dir="/tmp/mobius-tests/test-created-by-app-id-157",
     name="a4", description="", jsx_source="export default () => null",
   )
   app_b = models.App(
+    slug="test-created-by-app-id-160",
+    source_dir="/tmp/mobius-tests/test-created-by-app-id-160",
     name="a5", description="", jsx_source="export default () => null",
   )
   db.add(app_a)

--- a/backend/tests/test_db_migrations.py
+++ b/backend/tests/test_db_migrations.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 
 from app import models
 import app.database as database
+from app.config import get_settings
 from app.database import (
   _agent_lifecycle_width_migrations,
   run_migrations,
@@ -46,6 +47,8 @@ def test_run_migrations_removes_retired_job_authority_receipts(tmp_path):
   with Session(eng) as session:
     memory = models.App(
       name="Memory",
+      slug="memory",
+      source_dir=str(tmp_path / "apps" / "memory"),
       description="",
       jsx_source="export default () => null",
       capability_contract={
@@ -116,6 +119,71 @@ def test_run_migrations_adds_manifest_url_to_existing_apps_table(tmp_path):
       "SELECT icon_ownership_split FROM apps WHERE id = 1"
     )).scalar_one()
   assert split in (False, 0)
+
+
+def test_app_identity_migration_backfills_source_and_enforces_future_writes(
+  tmp_path,
+):
+  eng = create_engine(f"sqlite:///{tmp_path / 'app-identity.db'}")
+  with eng.begin() as conn:
+    conn.execute(text(
+      "CREATE TABLE apps ("
+      "id INTEGER PRIMARY KEY, name VARCHAR(128) NOT NULL, "
+      "slug VARCHAR(128), source_dir VARCHAR(512))"
+    ))
+    conn.execute(text(
+      "INSERT INTO apps (id, name, slug, source_dir) "
+      "VALUES (1, 'Canonical app', 'canonical-app', NULL)"
+    ))
+    conn.execute(text(
+      "INSERT INTO apps (id, name, slug, source_dir) "
+      "VALUES (2, 'Canonical app', NULL, NULL)"
+    ))
+
+  run_migrations(eng)
+  run_migrations(eng)
+
+  with eng.connect() as conn:
+    identities = conn.execute(text(
+      "SELECT slug, source_dir FROM apps ORDER BY id"
+    )).all()
+    indexes = {item[1] for item in conn.execute(text("PRAGMA index_list(apps)"))}
+  apps_root = Path(get_settings().data_dir) / "apps"
+  assert identities == [
+    ("canonical-app", str(apps_root / "canonical-app")),
+    ("canonical-app-2", str(apps_root / "canonical-app-2")),
+  ]
+  assert "ix_apps_source_dir" in indexes
+
+  with pytest.raises(IntegrityError, match="apps require slug and source_dir"):
+    with eng.begin() as conn:
+      conn.execute(text(
+        "UPDATE apps SET source_dir = NULL WHERE id = 1"
+      ))
+  with pytest.raises(IntegrityError, match="apps require slug and source_dir"):
+    with eng.begin() as conn:
+      conn.execute(text(
+        "UPDATE apps SET slug = '' WHERE id = 1"
+      ))
+  with pytest.raises(IntegrityError):
+    with eng.begin() as conn:
+      conn.execute(text(
+        "UPDATE apps SET source_dir = :source_dir WHERE id = 2"
+      ), {"source_dir": str(apps_root / "canonical-app")})
+
+
+def test_fresh_app_schema_requires_nonempty_slug_and_source_dir(tmp_path):
+  eng = create_engine(f"sqlite:///{tmp_path / 'fresh-app-identity.db'}")
+  models.Base.metadata.create_all(eng)
+  columns = {column["name"]: column for column in inspect(eng).get_columns("apps")}
+  assert columns["slug"]["nullable"] is False
+  assert columns["source_dir"]["nullable"] is False
+  checks = {
+    item["name"] for item in inspect(eng).get_check_constraints("apps")
+  }
+  assert {"ck_apps_slug_nonempty", "ck_apps_source_dir_nonempty"} <= checks
+  indexes = {item["name"] for item in inspect(eng).get_indexes("apps")}
+  assert "ix_apps_source_dir" in indexes
 
 
 def test_run_migrations_adds_managed_sign_in_identity_to_existing_owner(tmp_path):
@@ -529,6 +597,7 @@ def test_run_migrations_records_an_inspectable_append_only_history(tmp_path):
     "0001_legacy_schema_convergence",
     "0002_chat_run_goal_objective",
     "0003_chat_run_root_identity",
+    "0004_app_identity_required",
   ]
   assert second == first
 
@@ -538,7 +607,9 @@ def test_chat_run_root_migration_backfills_existing_physical_runs(tmp_path):
   applied_at = datetime(2026, 8, 1)
   with eng.begin() as conn:
     conn.execute(text(
-      "CREATE TABLE apps (id INTEGER PRIMARY KEY, name VARCHAR(128))"
+      "CREATE TABLE apps ("
+      "id INTEGER PRIMARY KEY, name VARCHAR(128), "
+      "slug VARCHAR(128), source_dir VARCHAR(512))"
     ))
     conn.execute(text(
       "CREATE TABLE chat_runs ("

--- a/backend/tests/test_db_migrations.py
+++ b/backend/tests/test_db_migrations.py
@@ -1,7 +1,9 @@
 import ast
+import asyncio
 import hashlib
 from datetime import datetime
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from sqlalchemy import String, create_engine, inspect, text
@@ -122,8 +124,9 @@ def test_run_migrations_adds_manifest_url_to_existing_apps_table(tmp_path):
 
 
 def test_app_identity_migration_backfills_source_and_enforces_future_writes(
-  tmp_path,
+  tmp_path, monkeypatch,
 ):
+  monkeypatch.setattr(get_settings(), "data_dir", str(tmp_path))
   eng = create_engine(f"sqlite:///{tmp_path / 'app-identity.db'}")
   with eng.begin() as conn:
     conn.execute(text(
@@ -170,6 +173,285 @@ def test_app_identity_migration_backfills_source_and_enforces_future_writes(
       conn.execute(text(
         "UPDATE apps SET source_dir = :source_dir WHERE id = 2"
       ), {"source_dir": str(apps_root / "canonical-app")})
+
+
+def test_app_identity_migration_materializes_legacy_source_without_overwriting_draft(
+  tmp_path, monkeypatch,
+):
+  monkeypatch.setattr(get_settings(), "data_dir", str(tmp_path))
+  apps_root = tmp_path / "apps"
+  occupied = apps_root / "legacy-app"
+  occupied.mkdir(parents=True)
+  (occupied / "index.jsx").write_text("// owner's newer draft", encoding="utf-8")
+  stored = "export default function App() { return <main>Legacy</main> }"
+  eng = create_engine(f"sqlite:///{tmp_path / 'legacy-source.db'}")
+  with eng.begin() as conn:
+    conn.execute(text(
+      "CREATE TABLE apps ("
+      "id INTEGER PRIMARY KEY, name VARCHAR(128) NOT NULL, "
+      "slug VARCHAR(128), source_dir VARCHAR(512), jsx_source TEXT)"
+    ))
+    conn.execute(text(
+      "INSERT INTO apps (id, name, slug, source_dir, jsx_source) "
+      "VALUES (7, 'Legacy app', 'legacy-app', NULL, :source)"
+    ), {"source": stored})
+
+  run_migrations(eng)
+  with eng.connect() as conn:
+    source_dir = Path(conn.execute(text(
+      "SELECT source_dir FROM apps WHERE id = 7"
+    )).scalar_one())
+
+  assert source_dir == apps_root / "legacy-app-legacy-7"
+  assert (occupied / "index.jsx").read_text(encoding="utf-8") == "// owner's newer draft"
+  assert (source_dir / "index.jsx").read_text(encoding="utf-8") == stored
+  assert (source_dir / ".git").is_dir()
+  from app import app_git
+  assert app_git.worktree_dirty(source_dir) is False
+
+  from app import compiler
+
+  async def fake_compile(_app_id, source, *, out_path, source_path):
+    assert source == stored
+    assert Path(source_path) == source_dir / "index.jsx"
+    Path(out_path).parent.mkdir(parents=True, exist_ok=True)
+    Path(out_path).write_text("compiled legacy app", encoding="utf-8")
+
+  class FakeDB:
+    def commit(self):
+      return None
+
+    def rollback(self):
+      raise AssertionError("legacy rebuild must not roll back")
+
+  monkeypatch.setattr(compiler, "compile_jsx", fake_compile)
+  app = SimpleNamespace(
+    id=7,
+    source_dir=str(source_dir),
+    source_commit=None,
+    compiled_path=str(tmp_path / "missing-old-bundle.js"),
+    jsx_source=stored,
+    updated_at=None,
+  )
+  asyncio.run(compiler.recompile_app_bundle(FakeDB(), app, stored))
+  assert Path(app.compiled_path).read_text(encoding="utf-8") == "compiled legacy app"
+
+
+@pytest.mark.parametrize("occupied_nominal", [False, True])
+def test_app_identity_migration_retries_after_repo_initialization_crash(
+  tmp_path, monkeypatch, occupied_nominal,
+):
+  monkeypatch.setattr(get_settings(), "data_dir", str(tmp_path))
+  apps_root = tmp_path / "apps"
+  if occupied_nominal:
+    nominal = apps_root / "retry-app"
+    nominal.mkdir(parents=True)
+    (nominal / "index.jsx").write_text("// keep draft", encoding="utf-8")
+  stored = "export default () => <main>Retry</main>"
+  eng = create_engine(f"sqlite:///{tmp_path / 'retry-source.db'}")
+  with eng.begin() as conn:
+    conn.execute(text(
+      "CREATE TABLE apps (id INTEGER PRIMARY KEY, name VARCHAR(128) NOT NULL, "
+      "slug VARCHAR(128), source_dir VARCHAR(512), jsx_source TEXT)"
+    ))
+    conn.execute(text(
+      "INSERT INTO apps VALUES (9, 'Retry app', 'retry-app', NULL, :source)"
+    ), {"source": stored})
+
+  from app import app_git
+  real_ensure_repo = app_git.ensure_repo
+  failed = False
+
+  def crash_after_repo(path):
+    nonlocal failed
+    real_ensure_repo(path)
+    if not failed:
+      failed = True
+      raise OSError("simulated crash after repo initialization")
+
+  monkeypatch.setattr(app_git, "ensure_repo", crash_after_repo)
+  with pytest.raises(OSError, match="simulated crash"):
+    run_migrations(eng)
+  run_migrations(eng)
+
+  with eng.connect() as conn:
+    source_dir = Path(conn.execute(text(
+      "SELECT source_dir FROM apps WHERE id = 9"
+    )).scalar_one())
+  expected = apps_root / (
+    "retry-app-legacy-9" if occupied_nominal else "retry-app"
+  )
+  assert source_dir == expected
+  assert (source_dir / "index.jsx").read_text(encoding="utf-8") == stored
+  assert not (source_dir / ".mobius-identity-migration").exists()
+  assert app_git.worktree_dirty(source_dir) is False
+  if occupied_nominal:
+    assert (apps_root / "retry-app" / "index.jsx").read_text(
+      encoding="utf-8"
+    ) == "// keep draft"
+
+
+def test_app_identity_migration_retries_after_pre_marker_directory_crash(
+  tmp_path, monkeypatch,
+):
+  monkeypatch.setattr(get_settings(), "data_dir", str(tmp_path))
+  apps_root = tmp_path / "apps"
+  nominal = apps_root / "mkdir-retry"
+  nominal.mkdir(parents=True)
+  (nominal / "index.jsx").write_text("// occupied", encoding="utf-8")
+  eng = create_engine(f"sqlite:///{tmp_path / 'mkdir-retry.db'}")
+  with eng.begin() as conn:
+    conn.execute(text(
+      "CREATE TABLE apps (id INTEGER PRIMARY KEY, name VARCHAR(128) NOT NULL, "
+      "slug VARCHAR(128), source_dir VARCHAR(512), jsx_source TEXT)"
+    ))
+    conn.execute(text(
+      "INSERT INTO apps VALUES (13, 'Retry', 'mkdir-retry', NULL, "
+      "'export default () => 13')"
+    ))
+
+  target = apps_root / "mkdir-retry-legacy-13"
+  real_mkdir = Path.mkdir
+  failed = False
+
+  def crash_after_mkdir(path, *args, **kwargs):
+    nonlocal failed
+    result = real_mkdir(path, *args, **kwargs)
+    if Path(path) == target and not failed:
+      failed = True
+      raise OSError("simulated crash before marker publish")
+    return result
+
+  monkeypatch.setattr(Path, "mkdir", crash_after_mkdir)
+  with pytest.raises(OSError, match="before marker"):
+    run_migrations(eng)
+  run_migrations(eng)
+  with eng.connect() as conn:
+    assert Path(conn.execute(text(
+      "SELECT source_dir FROM apps WHERE id = 13"
+    )).scalar_one()) == target
+  assert (target / "index.jsx").read_text(encoding="utf-8") == "export default () => 13"
+
+
+def test_app_identity_migration_reserves_sanitized_source_names(
+  tmp_path, monkeypatch,
+):
+  monkeypatch.setattr(get_settings(), "data_dir", str(tmp_path))
+  apps_root = tmp_path / "apps"
+  claimed = apps_root / "a-b"
+  eng = create_engine(f"sqlite:///{tmp_path / 'identity-collisions.db'}")
+  with eng.begin() as conn:
+    conn.execute(text(
+      "CREATE TABLE apps (id INTEGER PRIMARY KEY, name VARCHAR(128) NOT NULL, "
+      "slug VARCHAR(128), source_dir VARCHAR(512), jsx_source TEXT)"
+    ))
+    conn.execute(text(
+      "INSERT INTO apps VALUES "
+      "(1, 'Existing', 'existing', :claimed, 'export default 1'), "
+      "(2, 'Slash', 'a/b', NULL, 'export default 2'), "
+      "(3, 'Dash', 'a-b', NULL, 'export default 2')"
+    ), {"claimed": str(claimed)})
+
+  run_migrations(eng)
+  with eng.connect() as conn:
+    rows = conn.execute(text(
+      "SELECT id, source_dir FROM apps ORDER BY id"
+    )).all()
+  assert rows == [
+    (1, str(claimed)),
+    (2, str(apps_root / "a-b-legacy-2")),
+    (3, str(apps_root / "a-b-legacy-3")),
+  ]
+  assert len({source for _, source in rows}) == 3
+
+
+def test_app_identity_migration_reserves_names_without_stored_jsx(
+  tmp_path, monkeypatch,
+):
+  monkeypatch.setattr(get_settings(), "data_dir", str(tmp_path))
+  apps_root = tmp_path / "apps"
+  claimed = apps_root / "same-name"
+  claimed.mkdir(parents=True)
+  (claimed / "draft.txt").write_text("preserve", encoding="utf-8")
+  eng = create_engine(f"sqlite:///{tmp_path / 'no-jsx-identities.db'}")
+  with eng.begin() as conn:
+    conn.execute(text(
+      "CREATE TABLE apps (id INTEGER PRIMARY KEY, name VARCHAR(128) NOT NULL, "
+      "slug VARCHAR(128), source_dir VARCHAR(512))"
+    ))
+    conn.execute(text(
+      "INSERT INTO apps VALUES "
+      "(1, 'Existing', 'existing', :claimed), "
+      "(2, 'Slash', 'same/name', NULL), "
+      "(3, 'Dash', 'same-name', NULL)"
+    ), {"claimed": str(claimed)})
+
+  run_migrations(eng)
+  with eng.connect() as conn:
+    rows = conn.execute(text(
+      "SELECT id, source_dir FROM apps ORDER BY id"
+    )).all()
+  assert rows == [
+    (1, str(claimed)),
+    (2, str(apps_root / "same-name-legacy-2")),
+    (3, str(apps_root / "same-name-legacy-3")),
+  ]
+  assert (claimed / "draft.txt").read_text(encoding="utf-8") == "preserve"
+
+
+def test_app_identity_migration_rejects_symlink_escape_before_writing(
+  tmp_path, monkeypatch,
+):
+  monkeypatch.setattr(get_settings(), "data_dir", str(tmp_path))
+  apps_root = tmp_path / "apps"
+  apps_root.mkdir()
+  outside = tmp_path / "outside"
+  outside.mkdir()
+  (apps_root / "escaped").symlink_to(outside, target_is_directory=True)
+  eng = create_engine(f"sqlite:///{tmp_path / 'symlink-identity.db'}")
+  with eng.begin() as conn:
+    conn.execute(text(
+      "CREATE TABLE apps (id INTEGER PRIMARY KEY, name VARCHAR(128) NOT NULL, "
+      "slug VARCHAR(128), source_dir VARCHAR(512), jsx_source TEXT)"
+    ))
+    conn.execute(text(
+      "INSERT INTO apps VALUES "
+      "(21, 'Escaped', 'escaped', NULL, 'export default 21')"
+    ))
+
+  run_migrations(eng)
+  with eng.connect() as conn:
+    source_dir = Path(conn.execute(text(
+      "SELECT source_dir FROM apps WHERE id = 21"
+    )).scalar_one())
+  assert source_dir == apps_root / "escaped-legacy-21"
+  assert list(outside.iterdir()) == []
+  assert (source_dir / "index.jsx").read_text(encoding="utf-8") == "export default 21"
+
+
+@pytest.mark.parametrize("unsafe_slug", ["../../outside-apps", "/tmp/outside-apps"])
+def test_app_identity_migration_never_treats_url_slug_as_a_source_path(
+  tmp_path, monkeypatch, unsafe_slug,
+):
+  monkeypatch.setattr(get_settings(), "data_dir", str(tmp_path))
+  eng = create_engine(f"sqlite:///{tmp_path / 'unsafe-slug.db'}")
+  with eng.begin() as conn:
+    conn.execute(text(
+      "CREATE TABLE apps (id INTEGER PRIMARY KEY, name VARCHAR(128) NOT NULL, "
+      "slug VARCHAR(128), source_dir VARCHAR(512), jsx_source TEXT)"
+    ))
+    conn.execute(text(
+      "INSERT INTO apps VALUES (11, 'Unsafe slug', :slug, NULL, 'export default 1')"
+    ), {"slug": unsafe_slug})
+
+  run_migrations(eng)
+  with eng.connect() as conn:
+    source_dir = Path(conn.execute(text(
+      "SELECT source_dir FROM apps WHERE id = 11"
+    )).scalar_one())
+  apps_root = (tmp_path / "apps").resolve()
+  assert source_dir.resolve().parent == apps_root
+  assert source_dir.name and source_dir.name not in {".", ".."}
 
 
 def test_fresh_app_schema_requires_nonempty_slug_and_source_dir(tmp_path):

--- a/backend/tests/test_db_migrations.py
+++ b/backend/tests/test_db_migrations.py
@@ -43,7 +43,10 @@ def test_run_migrations_drops_removed_image_generation_columns(tmp_path):
   assert "generated_images" not in chat_columns
 
 
-def test_run_migrations_removes_retired_job_authority_receipts(tmp_path):
+def test_run_migrations_removes_retired_job_authority_receipts(
+  tmp_path, monkeypatch,
+):
+  monkeypatch.setattr(get_settings(), "data_dir", str(tmp_path))
   eng = create_engine(f"sqlite:///{tmp_path / 'job-authority.db'}")
   models.Base.metadata.create_all(eng)
   with Session(eng) as session:
@@ -289,6 +292,130 @@ def test_app_identity_migration_retries_after_repo_initialization_crash(
     assert (apps_root / "retry-app" / "index.jsx").read_text(
       encoding="utf-8"
     ) == "// keep draft"
+
+
+def test_app_identity_migration_preserves_edit_after_partial_source_write(
+  tmp_path, monkeypatch,
+):
+  monkeypatch.setattr(get_settings(), "data_dir", str(tmp_path))
+  apps_root = tmp_path / "apps"
+  stored = "export default () => <main>Stored</main>"
+  eng = create_engine(f"sqlite:///{tmp_path / 'retry-owner-edit.db'}")
+  with eng.begin() as conn:
+    conn.execute(text(
+      "CREATE TABLE apps (id INTEGER PRIMARY KEY, name VARCHAR(128) NOT NULL, "
+      "slug VARCHAR(128), source_dir VARCHAR(512), jsx_source TEXT)"
+    ))
+    conn.execute(text(
+      "INSERT INTO apps VALUES (17, 'Retry edit', 'retry-edit', NULL, :source)"
+    ), {"source": stored})
+
+  from app import app_git
+  real_commit_local = app_git.commit_local
+  failed = False
+
+  def crash_before_commit(path, message):
+    nonlocal failed
+    if not failed:
+      failed = True
+      raise OSError("simulated crash after source write")
+    return real_commit_local(path, message)
+
+  monkeypatch.setattr(app_git, "commit_local", crash_before_commit)
+  with pytest.raises(OSError, match="after source write"):
+    run_migrations(eng)
+
+  original = apps_root / "retry-edit"
+  (original / "index.jsx").write_text("// owner's recovery edit", encoding="utf-8")
+  run_migrations(eng)
+
+  with eng.connect() as conn:
+    assigned = Path(conn.execute(text(
+      "SELECT source_dir FROM apps WHERE id = 17"
+    )).scalar_one())
+  assert assigned == apps_root / "retry-edit-legacy-17"
+  assert (original / "index.jsx").read_text(encoding="utf-8") == (
+    "// owner's recovery edit"
+  )
+  assert (assigned / "index.jsx").read_text(encoding="utf-8") == stored
+
+
+def test_app_identity_migration_rejects_existing_resolved_aliases(
+  tmp_path, monkeypatch,
+):
+  monkeypatch.setattr(get_settings(), "data_dir", str(tmp_path))
+  apps_root = tmp_path / "apps"
+  eng = create_engine(f"sqlite:///{tmp_path / 'resolved-aliases.db'}")
+  with eng.begin() as conn:
+    conn.execute(text(
+      "CREATE TABLE apps (id INTEGER PRIMARY KEY, name VARCHAR(128) NOT NULL, "
+      "slug VARCHAR(128), source_dir VARCHAR(512), jsx_source TEXT)"
+    ))
+    conn.execute(text(
+      "INSERT INTO apps VALUES "
+      "(1, 'One', 'one', :direct, NULL), "
+      "(2, 'Two', 'two', :alias, NULL)"
+    ), {
+      "direct": str(apps_root / "shared"),
+      "alias": str(apps_root / ".." / "apps" / "shared"),
+    })
+
+  with pytest.raises(RuntimeError, match="resolve to the same source_dir"):
+    run_migrations(eng)
+  assert "0004_app_identity_required" not in {
+    row["version"] for row in schema_migration_history(eng)
+  }
+
+
+def test_app_identity_migration_canonicalizes_one_existing_alias(
+  tmp_path, monkeypatch,
+):
+  monkeypatch.setattr(get_settings(), "data_dir", str(tmp_path))
+  apps_root = tmp_path / "apps"
+  eng = create_engine(f"sqlite:///{tmp_path / 'canonical-alias.db'}")
+  with eng.begin() as conn:
+    conn.execute(text(
+      "CREATE TABLE apps (id INTEGER PRIMARY KEY, name VARCHAR(128) NOT NULL, "
+      "slug VARCHAR(128), source_dir VARCHAR(512), jsx_source TEXT)"
+    ))
+    conn.execute(text(
+      "INSERT INTO apps VALUES (1, 'One', 'one', :alias, NULL)"
+    ), {"alias": str(apps_root / ".." / "apps" / "one")})
+
+  run_migrations(eng)
+  with eng.connect() as conn:
+    assert conn.execute(text(
+      "SELECT source_dir FROM apps WHERE id = 1"
+    )).scalar_one() == str((apps_root / "one").resolve())
+
+
+def test_app_identity_migration_skips_symlink_loop_candidate(
+  tmp_path, monkeypatch,
+):
+  monkeypatch.setattr(get_settings(), "data_dir", str(tmp_path))
+  apps_root = tmp_path / "apps"
+  apps_root.mkdir()
+  (apps_root / "loop-app").symlink_to("loop-app")
+  eng = create_engine(f"sqlite:///{tmp_path / 'symlink-loop.db'}")
+  with eng.begin() as conn:
+    conn.execute(text(
+      "CREATE TABLE apps (id INTEGER PRIMARY KEY, name VARCHAR(128) NOT NULL, "
+      "slug VARCHAR(128), source_dir VARCHAR(512), jsx_source TEXT)"
+    ))
+    conn.execute(text(
+      "INSERT INTO apps VALUES "
+      "(19, 'Loop app', 'loop-app', NULL, 'export default () => 19')"
+    ))
+
+  run_migrations(eng)
+  with eng.connect() as conn:
+    assigned = Path(conn.execute(text(
+      "SELECT source_dir FROM apps WHERE id = 19"
+    )).scalar_one())
+  assert assigned == apps_root / "loop-app-legacy-19"
+  assert (assigned / "index.jsx").read_text(encoding="utf-8") == (
+    "export default () => 19"
+  )
 
 
 def test_app_identity_migration_retries_after_pre_marker_directory_crash(

--- a/backend/tests/test_delegations.py
+++ b/backend/tests/test_delegations.py
@@ -113,7 +113,11 @@ def test_app_token_can_observe_own_work_but_cannot_submit_spend(
 
 
 def test_child_policy_is_integrity_checked_and_write_loss_needs_review(db):
-  app = models.App(name="Subagents", description="", jsx_source="")
+  app = models.App(
+    slug="test-delegations-116",
+    source_dir="/tmp/mobius-tests/test-delegations-116",
+    name="Subagents", description="", jsx_source="",
+  )
   db.add(app)
   db.flush()
   parent = models.Chat(id="parent", title="Parent", messages=[])

--- a/backend/tests/test_frame_etag.py
+++ b/backend/tests/test_frame_etag.py
@@ -24,7 +24,11 @@ def test_recompile_bumps_updated_at_so_etag_changes(monkeypatch, tmp_path):
   ETags (derived from it) never change and a warm browser 304s to the stale
   bundle even though the compiled file was rewritten."""
   monkeypatch.setattr(compiler, "_compiled_dir", lambda: tmp_path)
-  monkeypatch.setattr(compiler, "_entry_source_path", lambda app: None)
+  source_dir = tmp_path / "source"
+  source_dir.mkdir()
+  source_path = source_dir / "index.jsx"
+  jsx_source = "export default function A(){}"
+  source_path.write_text(jsx_source, encoding="utf-8")
 
   async def fake_compile(app_id, jsx, *, out_path=None, source_path=None):
     Path(out_path).write_text("// compiled")
@@ -41,8 +45,15 @@ def test_recompile_bumps_updated_at_so_etag_changes(monkeypatch, tmp_path):
       pass
 
   before = datetime.datetime(2020, 1, 1, 0, 0, 0)
-  app = SimpleNamespace(id=999, jsx_source="old", compiled_path=None, updated_at=before)
-  asyncio.run(compiler.recompile_app_bundle(FakeDB(), app, "export default function A(){}"))
+  app = SimpleNamespace(
+    id=999,
+    jsx_source="old",
+    compiled_path=None,
+    source_dir=str(source_dir),
+    source_commit=None,
+    updated_at=before,
+  )
+  asyncio.run(compiler.recompile_app_bundle(FakeDB(), app, jsx_source))
 
   assert app.updated_at > before, "recompile must advance updated_at for ETag freshness"
   assert commits["n"] == 1

--- a/backend/tests/test_fs.py
+++ b/backend/tests/test_fs.py
@@ -133,6 +133,7 @@ def test_owner_required(client, fsroot):
 def _app_auth(db, *, filesystem_access: bool) -> tuple[dict[str, str], models.App]:
   owner = db.query(models.Owner).filter(models.Owner.username == "test").one()
   app = models.App(
+    source_dir="/tmp/mobius-tests/filesystem-test-app",
     name="Filesystem test app",
     description="",
     jsx_source="export default function App() {}",

--- a/backend/tests/test_media_token.py
+++ b/backend/tests/test_media_token.py
@@ -189,6 +189,7 @@ def test_serve_upload_rejects_app_token_on_query_param(client, auth, chat, db):
   from app import models as _m
   app_row = _m.App(
     name="Test", description="test", slug="test-app-tok",
+    source_dir="/tmp/mobius-tests/test-app-tok",
     jsx_source="export default () => null",
     token_nonce="nonce1",
   )

--- a/backend/tests/test_notifications_unread.py
+++ b/backend/tests/test_notifications_unread.py
@@ -106,6 +106,8 @@ def test_notification_created_published_on_system_bus(client, auth):
 def test_app_attributed_send_publishes_activity_then_badge(client, auth, db):
   """App-sourced sends keep the drawer-dot event AND gain the badge nudge."""
   app = models.App(
+    slug="test-notifications-unread-108",
+    source_dir="/tmp/mobius-tests/test-notifications-unread-108",
     name="News", description="",
     jsx_source="export default function App(){}",
     compiled_path="/tmp/app.js",
@@ -136,6 +138,8 @@ def test_unread_endpoints_are_owner_only(client, auth, db):
   assert client.post("/api/notifications/read-all").status_code == 401
 
   app = models.App(
+    slug="test-notifications-unread-138",
+    source_dir="/tmp/mobius-tests/test-notifications-unread-138",
     name="Probe", description="",
     jsx_source="export default function App(){}",
     compiled_path="/tmp/probe.js",

--- a/backend/tests/test_pinned_order.py
+++ b/backend/tests/test_pinned_order.py
@@ -18,6 +18,7 @@ def _seed_pinned_rows(db):
   ]
   apps = [
     models.App(
+      source_dir=f"/tmp/mobius-tests/app-{index}",
       name=f"App {index}",
       description="",
       jsx_source="export default function App() {}",

--- a/backend/tests/test_resource_access.py
+++ b/backend/tests/test_resource_access.py
@@ -105,6 +105,8 @@ def test_access_only_gate_preserves_app_chat_ownership(db):
   """The minimal projection keeps the same app-vs-foreign authorization."""
   db.add_all([
     models.App(
+      slug="test-resource-access-107",
+      source_dir="/tmp/mobius-tests/test-resource-access-107",
       id=7,
       name="owner app",
       description="",

--- a/backend/tests/test_skills_platform.py
+++ b/backend/tests/test_skills_platform.py
@@ -46,7 +46,10 @@ def _app_token(db, *, manage_skills):
   from app import models
   from app.auth import create_access_token
 
+  suffix = "manage" if manage_skills else "read-only"
   app_row = models.App(
+    slug=f"skills-{suffix}",
+    source_dir=f"/tmp/mobius-tests/skills-{suffix}",
     name="Skills",
     description="skills app",
     jsx_source="export default () => null",

--- a/backend/tests/test_standalone_manifest.py
+++ b/backend/tests/test_standalone_manifest.py
@@ -282,6 +282,7 @@ def test_reserved_top_level_routes_do_not_alias_to_apps(client, owner_token):
   try:
     for slug in ("api", "apps", "assets", "recover", "shell", "vendor"):
       db.add(models.App(
+        source_dir=f"/tmp/mobius-tests/{slug}",
         name=slug,
         slug=slug,
         description="reserved route collision",

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -30,6 +30,17 @@ def _bundle_path(db, app_id: int) -> Path:
   return Path(row.compiled_path)
 
 
+def _set_legacy_source(row: models.App, jsx_source: str) -> None:
+  """Keep a pre-commit row reproducible without violating app identity."""
+  from app import app_git
+
+  source = Path(row.source_dir) / "index.jsx"
+  source.write_text(jsx_source, encoding="utf-8")
+  app_git.commit_local(row.source_dir, "test legacy source")
+  row.source_commit = None
+  row.jsx_source = jsx_source
+
+
 def test_put_json_inner_object(client, auth, owner_token):
   """PUT body is the inner object; server stringifies + writes."""
   app_id = _make_app(client, owner_token)
@@ -852,9 +863,8 @@ def test_uninstall_skips_numeric_source_dir(client, auth, owner_token, db):
   assert os.path.isfile(os.path.join(victim, "keep.json"))
 
 
-def test_uninstall_skips_nested_and_shared_source_dir(client, auth, owner_token, db):
-  """Uninstall won't rmtree a NESTED descendant of /data/apps (could be inside
-  another app's tree) or a dir SHARED by another app row (Codex review #4)."""
+def test_uninstall_skips_nested_source_dir(client, auth, owner_token, db):
+  """Uninstall won't remove a nested descendant of another app's tree."""
   import os
   import app.models as models
   data_dir = os.environ["DATA_DIR"]
@@ -868,18 +878,6 @@ def test_uninstall_skips_nested_and_shared_source_dir(client, auth, owner_token,
   db.commit()
   assert client.delete(f"/api/apps/{a1}", headers=auth).status_code == 204
   assert os.path.isdir(nested)
-
-  # An immediate-child dir referenced by TWO app rows must survive deleting one.
-  shared = os.path.join(data_dir, "apps", "shared-src")
-  os.makedirs(shared, exist_ok=True)
-  open(os.path.join(shared, "y.json"), "w").close()
-  a2 = _make_app(client, owner_token)
-  a3 = _make_app(client, owner_token)
-  for aid in (a2, a3):
-    db.query(models.App).filter(models.App.id == aid).first().source_dir = shared
-  db.commit()
-  assert client.delete(f"/api/apps/{a2}", headers=auth).status_code == 204
-  assert os.path.isdir(shared)  # a3 still references it
 
 
 # Transactional bundle recompile — compile out-of-place, publish an immutable
@@ -896,10 +894,9 @@ async def test_recompile_app_bundle_promotes_after_commit(client, owner_token, d
   app_id = _make_app(client, owner_token)
   data_dir = os.environ["DATA_DIR"]
   row = db.query(models.App).filter(models.App.id == app_id).first()
-  row.source_dir = None
-  row.source_commit = None
   previous = Path(row.compiled_path)
   new_jsx = "export default function App(){ return <div>PROMOTED</div> }"
+  _set_legacy_source(row, new_jsx)
   await recompile_app_bundle(db, row, new_jsx)
   current = Path(row.compiled_path)
   assert current != previous
@@ -921,9 +918,9 @@ async def test_recompile_publishes_before_commit_without_replacing_previous(
   import app.compiler as compiler
   app_id = _make_app(client, owner_token)
   row = db.query(models.App).filter(models.App.id == app_id).first()
-  row.source_dir = None
-  row.source_commit = None
   previous = Path(row.compiled_path)
+  new_jsx = "export default function App(){ return <div>BOUNDARY</div> }"
+  _set_legacy_source(row, new_jsx)
   observed = {}
   real_sync = compiler._sync_published_bundle
 
@@ -948,8 +945,7 @@ async def test_recompile_publishes_before_commit_without_replacing_previous(
       db.rollback()
 
   await compiler.recompile_app_bundle(
-    _InspectCommit(), row,
-    "export default function App(){ return <div>BOUNDARY</div> }",
+    _InspectCommit(), row, new_jsx,
   )
 
   assert observed["published"] != previous
@@ -971,8 +967,6 @@ async def test_recompile_app_bundle_commit_failure_keeps_live_bundle(
   app_id = _make_app(client, owner_token)
   data_dir = os.environ["DATA_DIR"]
   row = db.query(models.App).filter(models.App.id == app_id).first()
-  row.source_dir = None
-  row.source_commit = None
   live = Path(row.compiled_path)
   before = live.read_bytes()
 
@@ -984,6 +978,7 @@ async def test_recompile_app_bundle_commit_failure_keeps_live_bundle(
       db.rollback()
 
   new_jsx = "export default function App(){ return <div>CHANGED</div> }"
+  _set_legacy_source(row, new_jsx)
   with pytest.raises(RuntimeError):
     await recompile_app_bundle(_FailCommit(), row, new_jsx)
   assert Path(row.compiled_path) == live
@@ -1002,15 +997,15 @@ async def test_recompile_app_bundle_bad_jsx_keeps_live_bundle(
   from app.compiler import recompile_app_bundle
   app_id = _make_app(client, owner_token)
   row = db.query(models.App).filter(models.App.id == app_id).first()
-  row.source_dir = None
-  row.source_commit = None
   live = Path(row.compiled_path)
   before = live.read_bytes()
   # Has `export default` (passes the cheap guard) but the JSX is unclosed, so
   # esbuild itself fails.
+  bad_jsx = "export default function App(){ return <div> }"
+  _set_legacy_source(row, bad_jsx)
   with pytest.raises(RuntimeError):
     await recompile_app_bundle(
-      db, row, "export default function App(){ return <div> }",
+      db, row, bad_jsx,
     )
   assert Path(row.compiled_path) == live
   assert live.read_bytes() == before
@@ -1034,9 +1029,9 @@ async def test_reconcile_missing_bundles_recompiles_missing_file(
   live = _bundle_path(db, app_id)
   # Simulate a legacy interrupted row or incomplete compiled-volume restore.
   row = db.query(models.App).filter(models.App.id == app_id).first()
-  row.source_dir = None
-  row.source_commit = None
-  row.jsx_source = "export default function App(){ return <div>HEALED</div> }"
+  _set_legacy_source(
+    row, "export default function App(){ return <div>HEALED</div> }",
+  )
   db.commit()
   live.unlink()
   assert not live.exists()
@@ -1112,9 +1107,11 @@ async def test_reconcile_missing_bundles_isolates_one_apps_failure(
   broken = _bundle_path(db, broken_id)
   good = _bundle_path(db, good_id)
   broken_row = db.query(models.App).filter(models.App.id == broken_id).first()
-  broken_row.source_dir = None
-  broken_row.source_commit = None
-  broken_row.jsx_source = "export default function App(){ return <div> }"
+  _set_legacy_source(
+    broken_row, "export default function App(){ return <div> }",
+  )
+  good_row = db.query(models.App).filter(models.App.id == good_id).first()
+  _set_legacy_source(good_row, good_row.jsx_source)
   db.commit()
   broken.unlink()
   good.unlink()
@@ -1142,13 +1139,11 @@ async def test_reconcile_outdated_bundles_recompiles_legacy_bundle(
   from app.compiler import reconcile_outdated_bundles
   app_id = _make_app(client, owner_token)
   row = db.query(models.App).filter(models.App.id == app_id).first()
-  row.source_dir = None
-  row.source_commit = None
   Path(row.compiled_path).unlink()
   legacy = Path(os.environ["DATA_DIR"], "compiled", f"app-{app_id}.js")
   row.compiled_path = str(legacy)
-  row.jsx_source = (
-    "export default function App(){ return <div>ABI_MIGRATED</div> }"
+  _set_legacy_source(
+    row, "export default function App(){ return <div>ABI_MIGRATED</div> }",
   )
   db.commit()
   # Current ABI but mutable legacy name: this is the old same-ABI crash gap,
@@ -1179,8 +1174,6 @@ async def test_reconcile_outdated_bundles_recompiles_old_artifact_revision(
 
   app_id = _make_app(client, owner_token)
   row = db.query(models.App).filter(models.App.id == app_id).first()
-  row.source_dir = None
-  row.source_commit = None
   current = Path(row.compiled_path)
   current_bytes = current.read_bytes()
   current_banner = COMPILED_RUNTIME_BANNER.encode("ascii")
@@ -1192,8 +1185,9 @@ async def test_reconcile_outdated_bundles_recompiles_old_artifact_revision(
   current.unlink()
   old_bundle.write_bytes(old_bytes)
   row.compiled_path = str(old_bundle)
-  row.jsx_source = (
-    "export default function App(){ return <div>REVISION_MIGRATED</div> }"
+  _set_legacy_source(
+    row,
+    "export default function App(){ return <div>REVISION_MIGRATED</div> }",
   )
   db.commit()
 
@@ -1248,10 +1242,6 @@ async def test_reconcile_outdated_bundles_isolates_compile_failure(
   good_id = _make_app(client, owner_token)
   broken_row = db.query(models.App).filter(models.App.id == broken_id).first()
   good_row = db.query(models.App).filter(models.App.id == good_id).first()
-  broken_row.source_dir = None
-  broken_row.source_commit = None
-  good_row.source_dir = None
-  good_row.source_commit = None
   Path(broken_row.compiled_path).unlink()
   Path(good_row.compiled_path).unlink()
   compiled = Path(os.environ["DATA_DIR"], "compiled")
@@ -1259,9 +1249,11 @@ async def test_reconcile_outdated_bundles_isolates_compile_failure(
   good = compiled / f"app-{good_id}.js"
   broken_row.compiled_path = str(broken)
   good_row.compiled_path = str(good)
-  broken_row.jsx_source = "export default function App(){ return <div> }"
-  good_row.jsx_source = (
-    "export default function App(){ return <div>ABI_GOOD</div> }"
+  _set_legacy_source(
+    broken_row, "export default function App(){ return <div> }",
+  )
+  _set_legacy_source(
+    good_row, "export default function App(){ return <div>ABI_GOOD</div> }",
   )
   db.commit()
   for path in (broken, good):


### PR DESCRIPTION
## Summary

- enforce nonempty unique slug/source identities for every app row
- migrate historical rows without overwriting editable drafts
- materialize stored legacy JSX into a clean recoverable source tree
- make allocation path-confined, collision-safe, and retryable across crashes
- remove nullable identity fallbacks from runtime callers

## Testing

- 511 affected backend tests
- 103 migration and storage tests after the migration hardening
- copied live database migration audit