### PR TITLE
Use Claude Agent SDK 0.2.128 as the single runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ FROM python:3.12-slim-trixie
 
 # Copy Node.js binary from the frontend stage instead of installing via
 # apt.  The debian nodejs/npm packages pull in ~200MB of system node
-# packages we don't need — only the claude CLI and npm globals need Node.
+# packages we don't need — the npm-installed agent tools still need Node.
 COPY --from=node-runtime /usr/local/bin/node /usr/local/bin/node
 COPY --from=node-runtime /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/npm
 RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
@@ -43,7 +43,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxfixes3 libxrandr2 libgbm1 libpango-1.0-0 libcairo2 libasound2t64 \
     fonts-liberation fonts-noto-color-emoji \
     && npm install -g esbuild@0.28.1 \
-    && npm install -g @anthropic-ai/claude-code@2.1.220 \
     && npm install -g @openai/codex@0.146.0 \
     && npm install -g agent-browser@0.31.1 \
     && agent-browser install \
@@ -105,8 +104,12 @@ WORKDIR /app
 
 COPY backend/requirements.txt backend/requirements.lock ./
 RUN pip install --no-cache-dir --require-hashes -r requirements.lock \
+    && _claude_cli="$(python -c \
+      'from pathlib import Path; import claude_agent_sdk; print(Path(claude_agent_sdk.__file__).parent / "_bundled" / "claude")')" \
+    && test -x "${_claude_cli}" \
+    && ln -s "${_claude_cli}" /usr/local/bin/claude \
     && python -c \
-      'from pathlib import Path; import claude_agent_sdk; p = Path(claude_agent_sdk.__file__).parent / "_bundled" / "claude"; p.unlink(missing_ok=True); assert not p.exists()'
+      'from pathlib import Path; import subprocess; import claude_agent_sdk; from claude_agent_sdk._cli_version import __cli_version__; bundled = Path(claude_agent_sdk.__file__).parent / "_bundled" / "claude"; global_cli = Path("/usr/local/bin/claude"); assert global_cli.samefile(bundled); assert subprocess.check_output([global_cli, "--version"], text=True).split()[0] == __cli_version__'
 
 # openai-codex Python SDK: its upstream pyproject pins a second, older
 # openai-codex-cli-bin payload. Keep that declared package so `pip check` and
@@ -146,16 +149,16 @@ RUN pip install --no-cache-dir --no-deps \
 
 # Capture each installed agent CLI's npm publish date into a small JSON the
 # Settings row reads (routes/settings._cli_release_dates), keyed by the
-# version actually installed above. Done at build time so a CLI pin bump
+# version reported by the executable. Done at build time so a CLI bump
 # refreshes the date automatically — no hand-maintained map, no test to
 # satisfy. Best effort: if the npm registry is unreachable the file is left
 # empty and the Settings row simply shows the bare version, never an error.
 RUN node -e "const cp=require('child_process'),fs=require('fs');\
-const want=['@anthropic-ai/claude-code','@openai/codex'];\
-let installed={};\
-try{installed=(JSON.parse(cp.execSync('npm ls -g --depth=0 --json',{stdio:['ignore','pipe','ignore']}).toString()).dependencies)||{};}catch(e){}\
+const want={'@anthropic-ai/claude-code':'claude','@openai/codex':'codex'};\
 const out={};\
-for(const name of want){const v=installed[name]&&installed[name].version;if(!v)continue;\
+for(const [name,command] of Object.entries(want)){let v;\
+try{const match=cp.execFileSync(command,['--version'],{stdio:['ignore','pipe','ignore']}).toString().match(/\\d+\\.\\d+\\.\\d+\\S*/);v=match&&match[0];}catch(e){}\
+if(!v)continue;\
 try{const t=JSON.parse(cp.execSync('npm view '+name+'@'+v+' time --json',{stdio:['ignore','pipe','ignore']}).toString());if(t&&t[v])out[v]=String(t[v]).slice(0,10);}catch(e){}}\
 fs.writeFileSync('/app/cli-release-dates.json',JSON.stringify(out));\
 console.log('cli-release-dates.json:',JSON.stringify(out));" \

--- a/backend/app/routes/settings.py
+++ b/backend/app/routes/settings.py
@@ -48,8 +48,8 @@ _VERSION_TIMEOUT = 2.0
 # Settings row can read "2.1.183 (2026-06-19)" instead of the raw CLI banner.
 #
 # Captured at image-build time by the Dockerfile (`npm view <pkg>@<v> time`,
-# right after the global installs) into the JSON file below — keyed by the
-# versions actually installed. A CLI pin bump therefore refreshes the date
+# after the agent runtimes are installed) into the JSON file below — keyed by
+# the versions their executables report. A CLI bump therefore refreshes the date
 # automatically, with no hand-maintained map to keep in lockstep and no test
 # to satisfy. Read once and cached; every failure mode (the file absent on a
 # dev checkout, or a build that couldn't reach the npm registry) degrades to

--- a/backend/requirements.lock
+++ b/backend/requirements.lock
@@ -427,13 +427,13 @@ charset-normalizer==3.4.9 \
     --hash=sha256:fa36ec09ef71d158186bc79e359ff5fdd6e7996fe8ab638f00d6b93139ba4fcf \
     --hash=sha256:fe2c7201c642b7c308f1675355ad7ff7b66acfe3541625efe5a3ad38f29d6115
     # via requests
-claude-agent-sdk==0.2.126 \
-    --hash=sha256:201299609bb045e7ca8c7d3ff5e8d5900da2dcf3faad742990efe659e4c215ae \
-    --hash=sha256:239e6073486488ce78fe88681c05e819562f5c5e567f02574492c3be3d35684b \
-    --hash=sha256:79caa03c6612e268bee93e95170d6b9ffdfa4bb21373a2e9ba7a439d3fb2e8e8 \
-    --hash=sha256:8dd73c1a193afa133241d7346e89e5b60ebf45f6a8f2cc38c84c8aad794af61e \
-    --hash=sha256:b0077f8da92f402032ec91b27499eb896aa97a9d78150ccd4a7840d39e70b9de \
-    --hash=sha256:edac88522b6fca74f1a84aa0d0f29caad4adda8aed04c3f08b86836e06c6c271
+claude-agent-sdk==0.2.128 \
+    --hash=sha256:2ac7b2b3bc56ae9037fd284c8690d3dafab9493ecd28d8974bba79a418e1b800 \
+    --hash=sha256:2e47ee95be68cb07612fd5288a40f3307763da5a5adf66d6e03ea49dc0495c9c \
+    --hash=sha256:37b87c8e75daa2a6dc74da6d788e0981a2e5e3a6be80cfa4c287abce2bf70e0b \
+    --hash=sha256:55e8fa28918af5620f391692efe80527ad9f2294cec14dadeea93c5161dbefc4 \
+    --hash=sha256:6c10cc1c5403b2b0b3d8deb79ad5271a8e49b9db6460193599b91f49f16b4cf7 \
+    --hash=sha256:cc4a0f20337e227fe16f00edf7cbe109349707adb440fe51ca6c44f9f8d7d21a
     # via -r requirements.txt
 click==8.4.2 \
     --hash=sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6 \

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,7 +14,7 @@ pywebpush>=2.0.0
 pytest>=8.0
 pytest-asyncio>=0.23
 watchdog>=4.0.0
-claude-agent-sdk==0.2.126
+claude-agent-sdk==0.2.128
 # openai-codex is installed --no-deps from a pinned Git SHA in Dockerfile.
 # Its declared cli-bin package is retained for SDK compatibility, but its
 # duplicate payload is replaced in-layer with a link to the pinned npm CLI.

--- a/backend/tests/test_verify_test_runtime.py
+++ b/backend/tests/test_verify_test_runtime.py
@@ -158,8 +158,8 @@ def test_image_deduplicates_agent_cli_payloads_without_breaking_sdk_contracts():
     "pip install --no-cache-dir --require-hashes -r requirements.lock"
     in requirements_layer
   )
-  assert "claude-agent-sdk==0.2.126" in requirements
-  assert "claude-agent-sdk==0.2.126" in requirements_lock
+  assert "claude-agent-sdk==0.2.128" in requirements
+  assert "claude-agent-sdk==0.2.128" in requirements_lock
   assert (
     'Path(claude_agent_sdk.__file__).parent / "_bundled" / "claude"'
     in requirements_layer

--- a/backend/tests/test_verify_test_runtime.py
+++ b/backend/tests/test_verify_test_runtime.py
@@ -141,7 +141,7 @@ def test_node_runtime_satisfies_the_pinned_agent_browser_engine():
   assert "node:22" not in preship
 
 
-def test_image_deduplicates_agent_cli_payloads_without_breaking_sdk_contracts():
+def test_image_uses_the_sdk_bundled_claude_cli_globally():
   dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
   requirements = (ROOT / "backend" / "requirements.txt").read_text(
     encoding="utf-8"
@@ -160,11 +160,20 @@ def test_image_deduplicates_agent_cli_payloads_without_breaking_sdk_contracts():
   )
   assert "claude-agent-sdk==0.2.128" in requirements
   assert "claude-agent-sdk==0.2.128" in requirements_lock
-  assert (
-    'Path(claude_agent_sdk.__file__).parent / "_bundled" / "claude"'
-    in requirements_layer
-    and "unlink(missing_ok=True)" in requirements_layer
-    and "assert not p.exists()" in requirements_layer
+  assert "npm install -g @anthropic-ai/claude-code@" not in dockerfile
+  assert 'Path(claude_agent_sdk.__file__).parent / "_bundled" / "claude"' in (
+    requirements_layer
+  )
+  assert 'ln -s "${_claude_cli}" /usr/local/bin/claude' in requirements_layer
+  assert "global_cli.samefile(bundled)" in requirements_layer
+  assert "__cli_version__" in requirements_layer
+  assert "unlink(" not in requirements_layer
+
+
+def test_image_deduplicates_codex_cli_without_breaking_the_sdk_contract():
+  dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+  requirements = (ROOT / "backend" / "requirements.txt").read_text(
+    encoding="utf-8"
   )
 
   codex_layer = dockerfile[


### PR DESCRIPTION
## Summary

- Update Claude Agent SDK from 0.2.126 to 0.2.128.
- Use the SDK-bundled Claude Code CLI as the global `claude` command.
- Remove the separate npm Claude CLI installation and verify SDK-driven and direct CLI execution resolve to the same binary.
- Derive CLI release-date metadata from the installed executables rather than npm's global package list.

## Context

This follows #561, which updated Claude Code to 2.1.220. Claude Agent SDK 0.2.128 bundles that same CLI version, so making the SDK bundle canonical removes the duplicate version pin and prevents the two runtime paths from drifting independently.

## Testing

- `scripts/wt-pytest.sh backend/tests/test_verify_test_runtime.py backend/tests/test_settings.py`
- `scripts/test.sh --fast`
- Isolated installation of `claude-agent-sdk==0.2.128`, verifying that the bundled executable reports 2.1.220 and the global symlink resolves to the same file
