### PR TITLE
Settle running chat entry after stream catch-up

### DIFF
--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -319,7 +319,24 @@ export default function ChatView({
   // the reader's saved coordinate; an incomplete restoration window stays
   // hidden until the anchor-addressed read repairs or retires that coordinate.
   const initialSavedAnchorKey = savedReadingAnchorKey(chatId)
-  const initialCacheEntryState = chatCacheEntryState(
+  const [loading, setLoading] = useState(initialCacheEntryState === 'missing')
+  const [initialEntryPhase, setInitialEntryPhase] = useState(
+    initialCacheEntryState === 'paintable'
+      ? 'cached'
+      : initialCacheEntryState === 'validating'
+        ? 'cache-validating'
+        : initialCacheEntryState,
+  )
+  const acceptCachedReadingCoordinate = useCallback(() => {
+    setInitialEntryPhase(current => (
+      current === 'cache-validating' ? 'cached' : current
+    ))
+    setLoading(false)
+  }, [])
+  const acceptInitialStreamCatchUp = useCallback(() => {
+    setInitialEntryPhase(current => (
+      current === 'stream-catchup' ? 'ready' : current
+    ))
     cached,
     initialSavedAnchorKey,
     savedReadingAnchorHasNestedPart(chatId),
@@ -1037,6 +1054,7 @@ export default function ChatView({
     clearStreamItems,
     patchQuestionAnswers,
   } = useStreamConnection(chatId, {
+    onCatchUpSettled: acceptInitialStreamCatchUp,
     onConnectionLost: () => {
       // Browser transport ownership is uncertain here: the backend turn may
       // still be parked on a question or producing output. Preserve the
@@ -1684,7 +1702,17 @@ export default function ChatView({
     }
     const activationAnchorMatch = anchorMatchIn(activationCache)
     const cacheCoversSavedAnchor = !savedAnchorKey || !!activationAnchorMatch
-    const activationCacheEntryState = chatCacheEntryState(
+    setLoading(activationCacheEntryState === 'missing')
+    const activationEntryPhase = activationCacheEntryState === 'paintable'
+      ? 'cached'
+      : activationCacheEntryState === 'validating'
+        ? 'cache-validating'
+        : activationCacheEntryState
+    setInitialEntryPhase(current => (
+      activationEntryPhase === 'cache-validating' && current === 'cached'
+        ? current
+        : activationEntryPhase
+    ))
       activationCache,
       savedAnchorKey,
       savedReadingAnchorHasNestedPart(chatId),
@@ -1692,6 +1720,7 @@ export default function ChatView({
     remapAnchorMatch(activationAnchorMatch)
     chatIdStaleRef.current = false
     setLoadError(false)
+<<<<<<< HEAD
     setLoading(activationCacheEntryState === 'missing')
     const activationEntryPhase = activationCacheEntryState === 'paintable'
       ? 'cached'
@@ -1705,6 +1734,10 @@ export default function ChatView({
         ? current
         : activationEntryPhase
     ))
+=======
+    setLoading(activationEntryPhase === 'history')
+    setInitialEntryPhase(activationEntryPhase)
+>>>>>>> b7659c194 (Settle running chat entry after stream catch-up)
 
     const gen = fetchGenRef.current
     const requestJson = async (path, label) => {
@@ -1719,6 +1752,10 @@ export default function ChatView({
 
     const settleRuntime = (runtime, visibleMessages) => {
       const running = !!runtime.running
+      const attachesToStream = shouldAttachRunningStream({
+        running,
+        pendingQuestionId: runtime.pending_question_id,
+      })
       setServerRunningLocalState(running)
       setActiveGoalObjective(goalObjectiveFromRuntime(
         runtime, latestGoalObjective(visibleMessages),
@@ -1731,15 +1768,14 @@ export default function ChatView({
           ? visibleMessages[visibleMessages.length - 1]
           : null,
       })
-      setInitialEntryPhase('ready')
+      // Persisted rows are not the complete surface of a running turn. Keep
+      // the outgoing chat visible until the subscribe-time replay commits.
+      setInitialEntryPhase(attachesToStream ? 'stream-catchup' : 'ready')
       setLoading(false)
       pendingQueue.hydrate(runtime.pending_messages || [])
       if (running) {
         setSending(true)
-        if (shouldAttachRunningStream({
-          running,
-          pendingQuestionId: runtime.pending_question_id,
-        })) {
+        if (attachesToStream) {
           connectToStream(false)
         }
       } else {

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -319,24 +319,7 @@ export default function ChatView({
   // the reader's saved coordinate; an incomplete restoration window stays
   // hidden until the anchor-addressed read repairs or retires that coordinate.
   const initialSavedAnchorKey = savedReadingAnchorKey(chatId)
-  const [loading, setLoading] = useState(initialCacheEntryState === 'missing')
-  const [initialEntryPhase, setInitialEntryPhase] = useState(
-    initialCacheEntryState === 'paintable'
-      ? 'cached'
-      : initialCacheEntryState === 'validating'
-        ? 'cache-validating'
-        : initialCacheEntryState,
-  )
-  const acceptCachedReadingCoordinate = useCallback(() => {
-    setInitialEntryPhase(current => (
-      current === 'cache-validating' ? 'cached' : current
-    ))
-    setLoading(false)
-  }, [])
-  const acceptInitialStreamCatchUp = useCallback(() => {
-    setInitialEntryPhase(current => (
-      current === 'stream-catchup' ? 'ready' : current
-    ))
+  const initialCacheEntryState = chatCacheEntryState(
     cached,
     initialSavedAnchorKey,
     savedReadingAnchorHasNestedPart(chatId),
@@ -347,16 +330,19 @@ export default function ChatView({
       ? 'cached'
       : initialCacheEntryState === 'validating'
         ? 'cache-validating'
-        : 'history',
+        : initialCacheEntryState,
   )
   const acceptCachedReadingCoordinate = useCallback(() => {
-    // The scroll owner has proved the exact nested part against the committed
-    // cached DOM. Admit the same quiet-layout reveal path as an ordinary safe
-    // cache without waiting for the independent freshness handshake.
+    // The scroll owner has proved the exact nested part against committed DOM.
     setInitialEntryPhase(current => (
       current === 'cache-validating' ? 'cached' : current
     ))
     setLoading(false)
+  }, [])
+  const acceptInitialStreamCatchUp = useCallback(() => {
+    setInitialEntryPhase(current => (
+      current === 'stream-catchup' ? 'ready' : current
+    ))
   }, [])
   // On a failed initial /chats/{id} fetch, loadError flips in the catch so
   // the UI can render a retry message. Setting loading false alone would
@@ -1702,17 +1688,7 @@ export default function ChatView({
     }
     const activationAnchorMatch = anchorMatchIn(activationCache)
     const cacheCoversSavedAnchor = !savedAnchorKey || !!activationAnchorMatch
-    setLoading(activationCacheEntryState === 'missing')
-    const activationEntryPhase = activationCacheEntryState === 'paintable'
-      ? 'cached'
-      : activationCacheEntryState === 'validating'
-        ? 'cache-validating'
-        : activationCacheEntryState
-    setInitialEntryPhase(current => (
-      activationEntryPhase === 'cache-validating' && current === 'cached'
-        ? current
-        : activationEntryPhase
-    ))
+    const activationCacheEntryState = chatCacheEntryState(
       activationCache,
       savedAnchorKey,
       savedReadingAnchorHasNestedPart(chatId),
@@ -1720,13 +1696,12 @@ export default function ChatView({
     remapAnchorMatch(activationAnchorMatch)
     chatIdStaleRef.current = false
     setLoadError(false)
-<<<<<<< HEAD
     setLoading(activationCacheEntryState === 'missing')
     const activationEntryPhase = activationCacheEntryState === 'paintable'
       ? 'cached'
       : activationCacheEntryState === 'validating'
         ? 'cache-validating'
-        : 'history'
+        : activationCacheEntryState
     setInitialEntryPhase(current => (
       // Mount-time layout validation can finish before this passive activation
       // effect runs. Do not re-close a cache gate the scroll owner just proved.
@@ -1734,10 +1709,6 @@ export default function ChatView({
         ? current
         : activationEntryPhase
     ))
-=======
-    setLoading(activationEntryPhase === 'history')
-    setInitialEntryPhase(activationEntryPhase)
->>>>>>> b7659c194 (Settle running chat entry after stream catch-up)
 
     const gen = fetchGenRef.current
     const requestJson = async (path, label) => {

--- a/frontend/src/components/ChatView/__tests__/chatDetailCache.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatDetailCache.test.js
@@ -43,6 +43,22 @@ test('cache first paint requires the saved reading coordinate when one exists', 
     'an incomplete cache stays hidden until the anchor-addressed read settles')
 })
 
+
+test('a running cache waits for subscribe-time replay', () => {
+  const running = {
+    restorationWindowComplete: true,
+    running: true,
+    pending_question_id: null,
+    offset: 0,
+    messages: [{ id: 'owner-row', role: 'user', ts: 1 }],
+  }
+  assert.equal(chatCacheEntryState(running), 'stream-catchup')
+  assert.equal(chatCacheEntryState({ ...running, pending_question_id: 'question-1' }), 'paintable',
+    'a parked question has no possible stream output')
+  assert.equal(chatCacheEntryState(running, 'missing-row'), 'missing',
+    'missing saved history remains stronger than the stream gate')
+})
+
 test('message row addresses remain stable across authoritative replacements', () => {
   assert.equal(messageKey({ id: 'message-1', role: 'user', ts: 10 }, 4), 'message-1')
   assert.equal(messageKey({ id: 7 }, 4), '7')

--- a/frontend/src/components/ChatView/__tests__/goalProgress.test.js
+++ b/frontend/src/components/ChatView/__tests__/goalProgress.test.js
@@ -182,7 +182,7 @@ test('ChatView binds goal state to explicit run boundaries, not transport livene
   )
   assert.match(
     streamConnection,
-    /onConnectionLostRef\.current\?\.\(\)[\s\S]{0,100}onNeedsRefreshRef\.current/,
+    /onConnectionLostRef\.current\?\.\(\)[\s\S]{0,100}refreshThenSettleCatchUp\(\{ force: true \}\)/,
     'retry exhaustion must use the non-terminal handoff before reconciliation',
   )
   assert.match(

--- a/frontend/src/components/ChatView/__tests__/streamCatchUpOwner.test.js
+++ b/frontend/src/components/ChatView/__tests__/streamCatchUpOwner.test.js
@@ -1,0 +1,40 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { streamCatchUpOwnerMatches } from '../useStreamConnection.js'
+
+test('a catch-up owner matches only its chat and connection generation', () => {
+  const owner = { chatId: 'a', generation: 3 }
+  assert.equal(streamCatchUpOwnerMatches(owner, { chatId: 'a', generation: 3 }), true)
+  assert.equal(streamCatchUpOwnerMatches(owner, { chatId: 'b', generation: 3 }), false)
+  assert.equal(streamCatchUpOwnerMatches(owner, { chatId: 'a', generation: 4 }), false)
+})
+
+test('a delayed refresh from chat A cannot settle chat B', async () => {
+  const ownerA = { chatId: 'a', generation: 3 }
+  let current = ownerA
+  let releaseRefresh
+  const refresh = new Promise(resolve => { releaseRefresh = resolve })
+  let settled = 0
+
+  const completion = refresh.then(() => {
+    if (streamCatchUpOwnerMatches(ownerA, current)) settled += 1
+  })
+  current = { chatId: 'b', generation: 4 }
+  releaseRefresh()
+  await completion
+
+  assert.equal(settled, 0)
+})
+
+test('the current owner settles after either refresh outcome', async () => {
+  for (const refresh of [Promise.resolve(), Promise.reject(new Error('offline'))]) {
+    const owner = { chatId: 'a', generation: 5 }
+    let settled = 0
+    const settle = () => {
+      if (streamCatchUpOwnerMatches(owner, owner)) settled += 1
+    }
+    await refresh.then(settle, settle)
+    assert.equal(settled, 1)
+  }
+})

--- a/frontend/src/components/ChatView/__tests__/streamingRobustness.test.js
+++ b/frontend/src/components/ChatView/__tests__/streamingRobustness.test.js
@@ -45,6 +45,24 @@ test('active DB, live deltas, and reconnect snapshots share one assistant surfac
   )
 })
 
+test('initial running-chat entry settles from catch-up or its refreshed fallback', () => {
+  assert.match(
+    streamHookSource,
+    /setCatchUpCommitSeq\(s => s \+ 1\)[\s\S]*onCatchUpSettledRef\.current\?\.\(\)/,
+    'successful replay releases the same entry boundary it commits',
+  )
+  assert.match(
+    streamHookSource,
+    /const refreshThenSettleCatchUp = \(options\) => \{[\s\S]*Promise\.resolve\(refresh\)\.then\(settle, settle\)[\s\S]*terminal204: true/,
+    'terminal refresh outcomes share one non-stranding entry release',
+  )
+  assert.match(
+    streamHookSource,
+    /retryCount\.current >= 3[\s\S]*refreshThenSettleCatchUp\(\{ force: true \}\)/,
+    'retry exhaustion releases only after the best persisted fallback settles',
+  )
+})
+
 test('streaming deltas are flags on the shared active markdown tree', () => {
   assert.match(msgContentSource, /<ProgressiveMarkdown[\s\S]*isStreaming=\{isStreaming/,
     'active DB and live text must keep ProgressiveMarkdown mounted')

--- a/frontend/src/components/ChatView/__tests__/streamingRobustness.test.js
+++ b/frontend/src/components/ChatView/__tests__/streamingRobustness.test.js
@@ -45,24 +45,6 @@ test('active DB, live deltas, and reconnect snapshots share one assistant surfac
   )
 })
 
-test('initial running-chat entry settles from catch-up or its refreshed fallback', () => {
-  assert.match(
-    streamHookSource,
-    /setCatchUpCommitSeq\(s => s \+ 1\)[\s\S]*settleOwnedCatchUp\(\)/,
-    'successful replay releases the same entry boundary it commits',
-  )
-  assert.match(
-    streamHookSource,
-    /const refreshThenSettleCatchUp = \(options\) => \{[\s\S]*Promise\.resolve\(refresh\)\.then\(settleOwnedCatchUp, settleOwnedCatchUp\)[\s\S]*terminal204: true/,
-    'terminal refresh outcomes share one non-stranding entry release',
-  )
-  assert.match(
-    streamHookSource,
-    /retryCount\.current >= 3[\s\S]*refreshThenSettleCatchUp\(\{ force: true \}\)/,
-    'retry exhaustion releases only after the best persisted fallback settles',
-  )
-})
-
 test('streaming deltas are flags on the shared active markdown tree', () => {
   assert.match(msgContentSource, /<ProgressiveMarkdown[\s\S]*isStreaming=\{isStreaming/,
     'active DB and live text must keep ProgressiveMarkdown mounted')

--- a/frontend/src/components/ChatView/__tests__/streamingRobustness.test.js
+++ b/frontend/src/components/ChatView/__tests__/streamingRobustness.test.js
@@ -48,12 +48,12 @@ test('active DB, live deltas, and reconnect snapshots share one assistant surfac
 test('initial running-chat entry settles from catch-up or its refreshed fallback', () => {
   assert.match(
     streamHookSource,
-    /setCatchUpCommitSeq\(s => s \+ 1\)[\s\S]*onCatchUpSettledRef\.current\?\.\(\)/,
+    /setCatchUpCommitSeq\(s => s \+ 1\)[\s\S]*settleOwnedCatchUp\(\)/,
     'successful replay releases the same entry boundary it commits',
   )
   assert.match(
     streamHookSource,
-    /const refreshThenSettleCatchUp = \(options\) => \{[\s\S]*Promise\.resolve\(refresh\)\.then\(settle, settle\)[\s\S]*terminal204: true/,
+    /const refreshThenSettleCatchUp = \(options\) => \{[\s\S]*Promise\.resolve\(refresh\)\.then\(settleOwnedCatchUp, settleOwnedCatchUp\)[\s\S]*terminal204: true/,
     'terminal refresh outcomes share one non-stranding entry release',
   )
   assert.match(

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -1208,10 +1208,11 @@ export function modeForQueuedSubmission(scrollEl, currentMode) {
  *   shows/hides because the tray's margin shrinks the spacer math).
  * @param {React.MutableRefObject<boolean>} args.loadingOlderRef
  *   When true, scroll events from pagination shouldn't mutate mode.
- * @param {'history'|'cache-validating'|'cached'|'preparing'|'ready'} args.initialEntryPhase
+ * @param {'history'|'cache-validating'|'cached'|'stream-catchup'|'preparing'|'ready'} args.initialEntryPhase
  *   History blocks reveal, cached is a caller-validated restoration window,
  *   cache-validating mounts a complete cached window behind the gate so its
- *   exact nested coordinate can be checked, preparing is a hidden progressive
+ *   exact nested coordinate can be checked, stream-catchup holds a running
+ *   transcript until replay commits, preparing is a hidden progressive
  *   cold render, and ready means authoritative history has settled.
  * @param {() => void} [args.onCachedCoordinateReady]
  *   Promotes a hidden validation cache after its exact saved part resolves.

--- a/frontend/src/components/ChatView/useStreamConnection.js
+++ b/frontend/src/components/ChatView/useStreamConnection.js
@@ -46,6 +46,11 @@ import {
 // deployments / slower external DBs on the safe side of the same contract.
 export const SEND_POST_TIMEOUT_MS = 45000
 
+export function streamCatchUpOwnerMatches(owner, current) {
+  return owner?.generation === current?.generation
+    && String(owner?.chatId ?? '') === String(current?.chatId ?? '')
+}
+
 // Delay before the wake/online reattach surfaces as a visible
 // "Reconnecting…" note. Real mobile reattach can spend time waking the
 // radio, negotiating TLS, and replaying a long event log; quick
@@ -313,6 +318,7 @@ export default function useStreamConnection(chatId, {
   }
 
   const abortRef = useRef(null)
+  const connectionGenerationRef = useRef(0)
   const keptSocketDeadmanTimerRef = useRef(null)
   const retryCount = useRef(0)
   const chatIdRef = useRef(chatId)
@@ -514,6 +520,7 @@ export default function useStreamConnection(chatId, {
   }, [])
 
   const disconnect = useCallback(({ clearStreaming = false } = {}) => {
+    connectionGenerationRef.current += 1
     clearKeptSocketDeadman()
     // Salvage any text that's in the typewriter buffer but hasn't
     // been drained into streamItems yet. Without this, Stop loses
@@ -644,6 +651,10 @@ export default function useStreamConnection(chatId, {
   const connectToStream = useCallback(async (resetState = false) => {
     activeStreamChatIdRef.current = chatIdRef.current
     disconnect()
+    const catchUpOwner = {
+      generation: ++connectionGenerationRef.current,
+      chatId: chatIdRef.current,
+    }
 
     if (resetState) {
       // Keep the currently visible stream while a reconnect catch-up is in
@@ -662,12 +673,19 @@ export default function useStreamConnection(chatId, {
     abortRef.current = controller
     lastReadAtRef.current = 0
 
+    const settleOwnedCatchUp = () => {
+      if (!streamCatchUpOwnerMatches(catchUpOwner, {
+        generation: connectionGenerationRef.current,
+        chatId: chatIdRef.current,
+      })) return
+      onCatchUpSettledRef.current?.()
+    }
+
     const refreshThenSettleCatchUp = (options) => {
       const refresh = onNeedsRefreshRef.current?.(options)
-      const settle = () => onCatchUpSettledRef.current?.()
       // Refresh failures already render their own error. Either outcome must
       // release the outgoing chat rather than leave the handoff stranded.
-      Promise.resolve(refresh).then(settle, settle)
+      Promise.resolve(refresh).then(settleOwnedCatchUp, settleOwnedCatchUp)
     }
 
     try {
@@ -808,7 +826,7 @@ export default function useStreamConnection(chatId, {
         // commit after the reveal cap); a pre-reveal mount commit is covered by
         // hide-then-reveal and a kept socket produces no commit at all.
         setCatchUpCommitSeq(s => s + 1)
-        onCatchUpSettledRef.current?.()
+        settleOwnedCatchUp()
       }
 
       const patchCatchUpQuestionAnswers = (questionId, answers) => {

--- a/frontend/src/components/ChatView/useStreamConnection.js
+++ b/frontend/src/components/ChatView/useStreamConnection.js
@@ -167,9 +167,12 @@ const BROADCAST_REGISTRATION_WINDOW_MS = 1500
  *   but must not treat this as a terminal run boundary.
  * @param {(event: object) => void} [callbacks.onSystemEvent]
  *   Fired for non-chat SSE events (theme/app/shell). Not buffered.
- * @param {(opts?: {force?: boolean}) => void} [callbacks.onNeedsRefresh]
+ * @param {(opts?: {force?: boolean}) => void|Promise<void>} [callbacks.onNeedsRefresh]
  *   Fired when the stream returns 204 outside the post-send race
  *   window — caller should refetch persisted DB state.
+ * @param {() => void} [callbacks.onCatchUpSettled]
+ *   Fired after subscribe-time replay commits, or after its terminal /
+ *   disconnected fallback refresh settles.
  * @param {(info: {ts: number|null, message: object|null}) => void} [callbacks.onQueuedTurnStarting]
  *   Fired when the backend is about to promote queued follow-ups; `ts`
  *   identifies the first pending entry in the promoted group and `message`
@@ -221,6 +224,7 @@ export default function useStreamConnection(chatId, {
   onConnectionLost,
   onSystemEvent,
   onNeedsRefresh,
+  onCatchUpSettled,
   onQueuedTurnStarting,
   onSteeredIntoTurn,
   onSteerDeliveryFailed,
@@ -608,6 +612,8 @@ export default function useStreamConnection(chatId, {
   onSystemEventRef.current = onSystemEvent
   const onNeedsRefreshRef = useRef(onNeedsRefresh)
   onNeedsRefreshRef.current = onNeedsRefresh
+  const onCatchUpSettledRef = useRef(onCatchUpSettled)
+  onCatchUpSettledRef.current = onCatchUpSettled
   const onQueuedTurnStartingRef = useRef(onQueuedTurnStarting)
   onQueuedTurnStartingRef.current = onQueuedTurnStarting
   const onSteeredIntoTurnRef = useRef(onSteeredIntoTurn)
@@ -655,6 +661,14 @@ export default function useStreamConnection(chatId, {
     const controller = new AbortController()
     abortRef.current = controller
     lastReadAtRef.current = 0
+
+    const refreshThenSettleCatchUp = (options) => {
+      const refresh = onNeedsRefreshRef.current?.(options)
+      const settle = () => onCatchUpSettledRef.current?.()
+      // Refresh failures already render their own error. Either outcome must
+      // release the outgoing chat rather than leave the handoff stranded.
+      Promise.resolve(refresh).then(settle, settle)
+    }
 
     try {
       const res = await fetch(
@@ -727,7 +741,7 @@ export default function useStreamConnection(chatId, {
         // and ChatView clearing its running state.
         onStreamEndRef.current?.()
         setIsStreaming(false)
-        onNeedsRefreshRef.current?.({ force: true, terminal204: true })
+        refreshThenSettleCatchUp({ force: true, terminal204: true })
         return
       }
 
@@ -794,6 +808,7 @@ export default function useStreamConnection(chatId, {
         // commit after the reveal cap); a pre-reveal mount commit is covered by
         // hide-then-reveal and a kept socket produces no commit at all.
         setCatchUpCommitSeq(s => s + 1)
+        onCatchUpSettledRef.current?.()
       }
 
       const patchCatchUpQuestionAnswers = (questionId, answers) => {
@@ -1282,7 +1297,7 @@ export default function useStreamConnection(chatId, {
         // before the refresh restored `running` from the server.
         requestAnimationFrame(() => {
           onConnectionLostRef.current?.()
-          onNeedsRefreshRef.current?.({ force: true })
+          refreshThenSettleCatchUp({ force: true })
         })
       } else {
         setConnectionError('retrying')

--- a/frontend/src/components/Shell/__tests__/chatHandoff.test.js
+++ b/frontend/src/components/Shell/__tests__/chatHandoff.test.js
@@ -22,7 +22,7 @@ function ruleBody(selector, source = shellCss) {
 test('chat display readiness admits only coordinate-complete cached transcripts', () => {
   assert.match(
     detailCache,
-    /function chatCacheEntryState\([\s\S]*cached\?\.restorationWindowComplete !== true[\s\S]*messageKey\(message, baseOffset \+ index\)[\s\S]*savedAnchorHasNestedPart \? 'validating' : 'paintable'/,
+    /function chatCacheEntryState\([\s\S]*cached\?\.restorationWindowComplete !== true[\s\S]*messageKey\(message, baseOffset \+ index\)[\s\S]*if \(savedAnchorHasNestedPart\) return 'validating'[\s\S]*cached\.running[\s\S]*'stream-catchup' : 'paintable'/,
     'only canonical caches containing the durable row may paint or validate',
   )
   assert.match(chatView,
@@ -68,7 +68,7 @@ test('chat display readiness admits only coordinate-complete cached transcripts'
   )
 })
 
-test('activation reuses an unchanged retained transcript before stream catch-up', () => {
+test('activation holds an unchanged running transcript until stream catch-up', () => {
   const initialLoad = chatView.match(
     /const loadActivation = async \(\) => \{[\s\S]*?\n    loadActivation\(\)/,
   )?.[0] || ''
@@ -110,8 +110,8 @@ test('activation reuses an unchanged retained transcript before stream catch-up'
     'an activation error before ready must not erase the unconsumed saved coordinate')
   assert.match(
     chatView,
-    /setInitialEntryPhase\('ready'\)[\s\S]*if \(running\) \{[\s\S]*connectToStream\(false\)/,
-    'stream catch-up should continue after the persisted frame becomes paintable',
+    /setInitialEntryPhase\(attachesToStream \? 'stream-catchup' : 'ready'\)[\s\S]*if \(running\) \{[\s\S]*connectToStream\(false\)/,
+    'a running persisted frame remains gated until stream catch-up commits',
   )
   assert.match(
     initialLoad,

--- a/frontend/src/lib/chatDetailCache.js
+++ b/frontend/src/lib/chatDetailCache.js
@@ -37,7 +37,9 @@ export function messageMatchesKey(message, index, key) {
  * A saved row must be present in the cached window. Exact nested parts are a
  * DOM fact rather than a data fact: mount those caches behind the reveal gate
  * as `validating`, then let the scroll owner promote them only when the saved
- * part resolves in the committed cached DOM. */
+ * part resolves in the committed cached DOM. A running cache additionally
+ * waits for subscribe-time replay because persisted rows can lag the active
+ * assistant; parked owner questions have no possible stream output. */
 export function chatCacheEntryState(
   cached,
   savedAnchorKey = null,
@@ -46,26 +48,29 @@ export function chatCacheEntryState(
   if (cached?.restorationWindowComplete !== true || !Array.isArray(cached.messages)) {
     return 'missing'
   }
-  if (savedAnchorKey == null) return 'paintable'
-  const baseOffset = Number.isInteger(cached.offset) ? cached.offset : 0
-  const containsAnchor = cached.messages.some((message, index) => (
-    messageKey(message, baseOffset + index) === String(savedAnchorKey)
-    || (
-      message?.role === 'assistant'
-      && !message.hidden
-      && assistantAnchorKey(baseOffset + index) === String(savedAnchorKey)
-    )
-    || (
-      message?.role === 'user'
-      && !message.hidden
-      && message.kind !== 'continuation'
-      && message.kind !== 'auto_continuation'
-      && message.cid != null
-      && String(message.cid) === String(savedAnchorKey)
-    )
-  ))
+  let containsAnchor = savedAnchorKey == null
+  if (!containsAnchor) {
+    const baseOffset = Number.isInteger(cached.offset) ? cached.offset : 0
+    containsAnchor = cached.messages.some((message, index) => (
+      messageKey(message, baseOffset + index) === String(savedAnchorKey)
+      || (
+        message?.role === 'assistant'
+        && !message.hidden
+        && assistantAnchorKey(baseOffset + index) === String(savedAnchorKey)
+      )
+      || (
+        message?.role === 'user'
+        && !message.hidden
+        && message.kind !== 'continuation'
+        && message.kind !== 'auto_continuation'
+        && message.cid != null
+        && String(message.cid) === String(savedAnchorKey)
+      )
+    ))
+  }
   if (!containsAnchor) return 'missing'
-  return savedAnchorHasNestedPart ? 'validating' : 'paintable'
+  if (savedAnchorHasNestedPart) return 'validating'
+  return cached.running && !cached.pending_question_id ? 'stream-catchup' : 'paintable'
 }
 
 function settledToolBlocks(message) {

--- a/tests/frontend.spec.mjs
+++ b/tests/frontend.spec.mjs
@@ -967,7 +967,7 @@ test.describe('Scroll position', () => {
     expect(restored.scrollTop).toBeGreaterThan(0)
   })
 
-  test('10d. Previous-chat entry reveals authoritative history before catch-up and stays visually fixed', async ({ page }) => {
+  test('10d. Previous-chat entry holds outgoing chat until catch-up, then stays visually fixed', async ({ page }) => {
     await setup(page, { width: 900, height: 760 })
     await newChat(page)
 
@@ -1122,18 +1122,20 @@ test.describe('Scroll position', () => {
       history.back()
     })
 
+    // The returning chat is running, so its persisted rows are incomplete.
+    // Keep painting the outgoing empty chat until subscribe-time replay commits.
+    await expect.poll(() => catchUpServed, { timeout: 700 }).toBe(false)
+    await expect(page.locator('[data-chat-surface="painted"] .chat__empty-wrap')).toBeVisible()
+    await expect(page.locator('[data-chat-surface="painted"] [data-key="entry-anchor"]')).toHaveCount(0)
+
+    await expect.poll(() => catchUpServed, { timeout: 3000 }).toBe(true)
     await page.waitForFunction(() => {
       const el = document.querySelector('[data-chat-surface="painted"] .chat__scroll')
       const img = document.querySelector('[data-chat-surface="painted"] .md-image')
       return !!el && getComputedStyle(el).visibility !== 'hidden'
-        // The retained ChatView deliberately reveals its already-settled DOM
-        // immediately. Do not mistake the still-complete initial image for the
-        // delayed authoritative return image we are exercising here.
         && !!img?.src.includes('entry-image-return.png') && !!img.complete
         && !!document.querySelector('[data-key="entry-anchor"]')
     }, { timeout: 10000 })
-    expect(catchUpServed).toBe(false)
-    await expect.poll(() => catchUpServed, { timeout: 3000 }).toBe(true)
 
     const trajectory = await page.evaluate(() => window.__entryTrajectory || [])
     const visibleRows = trajectory.filter(row => row.visible)

--- a/tests/frontend.spec.mjs
+++ b/tests/frontend.spec.mjs
@@ -967,7 +967,7 @@ test.describe('Scroll position', () => {
     expect(restored.scrollTop).toBeGreaterThan(0)
   })
 
-  test('10d. Previous-chat entry holds outgoing chat until catch-up, then stays visually fixed', async ({ page }) => {
+  test('10d. Previous-chat entry gates authoritative rows until catch-up, then stays visually fixed', async ({ page }) => {
     await setup(page, { width: 900, height: 760 })
     await newChat(page)
 
@@ -1123,9 +1123,8 @@ test.describe('Scroll position', () => {
     })
 
     // The returning chat is running, so its persisted rows are incomplete.
-    // Once navigation targets it, the painted surface must still belong to the
-    // outgoing chat until subscribe-time replay commits. Assert chat ownership
-    // rather than empty-state markup, which the New Chat presentation may omit.
+    // Navigation may hand the painted surface to that chat immediately, but its
+    // authoritative transcript must remain gated until subscribe-time replay.
     await page.waitForFunction(
       id => localStorage.getItem('moebius_active_chat') === id,
       chatId,
@@ -1133,7 +1132,7 @@ test.describe('Scroll position', () => {
     )
     await expect.poll(() => catchUpServed, { timeout: 700 }).toBe(false)
     await expect(page.locator('[data-chat-surface="painted"]'))
-      .toHaveAttribute('data-chat-id', decoyChatId)
+      .toHaveAttribute('data-chat-id', chatId)
     await expect(page.locator('[data-chat-surface="painted"] [data-key="entry-anchor"]')).toHaveCount(0)
 
     await expect.poll(() => catchUpServed, { timeout: 3000 }).toBe(true)

--- a/tests/frontend.spec.mjs
+++ b/tests/frontend.spec.mjs
@@ -1126,7 +1126,11 @@ test.describe('Scroll position', () => {
     // Once navigation targets it, the painted surface must still belong to the
     // outgoing chat until subscribe-time replay commits. Assert chat ownership
     // rather than empty-state markup, which the New Chat presentation may omit.
-    await expect.poll(() => new URL(page.url()).searchParams.get('chat')).toBe(chatId)
+    await page.waitForFunction(
+      id => localStorage.getItem('moebius_active_chat') === id,
+      chatId,
+      { timeout: 3000 },
+    )
     await expect.poll(() => catchUpServed, { timeout: 700 }).toBe(false)
     await expect(page.locator('[data-chat-surface="painted"]'))
       .toHaveAttribute('data-chat-id', decoyChatId)

--- a/tests/frontend.spec.mjs
+++ b/tests/frontend.spec.mjs
@@ -977,6 +977,8 @@ test.describe('Scroll position', () => {
     let returning = false
     let streamCount = 0
     let catchUpServed = false
+    let releaseCatchUp
+    const catchUpGate = new Promise(resolve => { releaseCatchUp = resolve })
     let returnImageServed = false
     const squarePng = Buffer.from(
       'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wl2nWQAAAAASUVORK5CYII=',
@@ -1030,7 +1032,7 @@ test.describe('Scroll position', () => {
     await page.route(new RegExp(`/api/chats/${chatId}/stream$`), async route => {
       streamCount += 1
       if (streamCount > 1) return route.fulfill({ status: 204, body: '' })
-      await new Promise(resolve => setTimeout(resolve, 1200))
+      await catchUpGate
       catchUpServed = true
       return route.fulfill({
         status: 200,
@@ -1133,6 +1135,7 @@ test.describe('Scroll position', () => {
         && !!document.querySelector('[data-key="entry-anchor"]')
     }, { timeout: 10000 })
     expect(catchUpServed).toBe(false)
+    releaseCatchUp()
     await expect.poll(() => catchUpServed, { timeout: 3000 }).toBe(true)
 
     const trajectory = await page.evaluate(() => window.__entryTrajectory || [])

--- a/tests/frontend.spec.mjs
+++ b/tests/frontend.spec.mjs
@@ -1123,9 +1123,13 @@ test.describe('Scroll position', () => {
     })
 
     // The returning chat is running, so its persisted rows are incomplete.
-    // Keep painting the outgoing empty chat until subscribe-time replay commits.
+    // Once navigation targets it, the painted surface must still belong to the
+    // outgoing chat until subscribe-time replay commits. Assert chat ownership
+    // rather than empty-state markup, which the New Chat presentation may omit.
+    await expect.poll(() => new URL(page.url()).searchParams.get('chat')).toBe(chatId)
     await expect.poll(() => catchUpServed, { timeout: 700 }).toBe(false)
-    await expect(page.locator('[data-chat-surface="painted"] .chat__empty-wrap')).toBeVisible()
+    await expect(page.locator('[data-chat-surface="painted"]'))
+      .toHaveAttribute('data-chat-id', decoyChatId)
     await expect(page.locator('[data-chat-surface="painted"] [data-key="entry-anchor"]')).toHaveCount(0)
 
     await expect.poll(() => catchUpServed, { timeout: 3000 }).toBe(true)

--- a/tests/frontend.spec.mjs
+++ b/tests/frontend.spec.mjs
@@ -967,7 +967,7 @@ test.describe('Scroll position', () => {
     expect(restored.scrollTop).toBeGreaterThan(0)
   })
 
-  test('10d. Previous-chat entry gates authoritative rows until catch-up, then stays visually fixed', async ({ page }) => {
+  test('10d. Previous-chat entry reveals authoritative history before catch-up and stays visually fixed', async ({ page }) => {
     await setup(page, { width: 900, height: 760 })
     await newChat(page)
 
@@ -1122,27 +1122,18 @@ test.describe('Scroll position', () => {
       history.back()
     })
 
-    // The returning chat is running, so its persisted rows are incomplete.
-    // Navigation may hand the painted surface to that chat immediately, but its
-    // authoritative transcript must remain gated until subscribe-time replay.
-    await page.waitForFunction(
-      id => localStorage.getItem('moebius_active_chat') === id,
-      chatId,
-      { timeout: 3000 },
-    )
-    await expect.poll(() => catchUpServed, { timeout: 700 }).toBe(false)
-    await expect(page.locator('[data-chat-surface="painted"]'))
-      .toHaveAttribute('data-chat-id', chatId)
-    await expect(page.locator('[data-chat-surface="painted"] [data-key="entry-anchor"]')).toHaveCount(0)
-
-    await expect.poll(() => catchUpServed, { timeout: 3000 }).toBe(true)
     await page.waitForFunction(() => {
       const el = document.querySelector('[data-chat-surface="painted"] .chat__scroll')
       const img = document.querySelector('[data-chat-surface="painted"] .md-image')
       return !!el && getComputedStyle(el).visibility !== 'hidden'
+        // The retained ChatView deliberately reveals its already-settled DOM
+        // immediately. Do not mistake the still-complete initial image for the
+        // delayed authoritative return image we are exercising here.
         && !!img?.src.includes('entry-image-return.png') && !!img.complete
         && !!document.querySelector('[data-key="entry-anchor"]')
     }, { timeout: 10000 })
+    expect(catchUpServed).toBe(false)
+    await expect.poll(() => catchUpServed, { timeout: 3000 }).toBe(true)
 
     const trajectory = await page.evaluate(() => window.__entryTrajectory || [])
     const visibleRows = trajectory.filter(row => row.visible)

--- a/tests/frontend.spec.mjs
+++ b/tests/frontend.spec.mjs
@@ -967,7 +967,7 @@ test.describe('Scroll position', () => {
     expect(restored.scrollTop).toBeGreaterThan(0)
   })
 
-  test('10d. Previous-chat entry reveals authoritative history before catch-up and stays visually fixed', async ({ page }) => {
+  test('10d. Previous-chat entry stays held until catch-up, then settles without movement', async ({ page }) => {
     await setup(page, { width: 900, height: 760 })
     await newChat(page)
 
@@ -1124,19 +1124,23 @@ test.describe('Scroll position', () => {
       history.back()
     })
 
+    await page.waitForFunction(
+      id => localStorage.getItem('moebius_active_chat') === id,
+      chatId,
+      { timeout: 3000 },
+    )
+    await expect(page.locator('.shell__chat-view--held')).toHaveCount(1)
+    expect(catchUpServed).toBe(false)
+    releaseCatchUp()
+    await expect.poll(() => catchUpServed, { timeout: 3000 }).toBe(true)
+
     await page.waitForFunction(() => {
       const el = document.querySelector('[data-chat-surface="painted"] .chat__scroll')
       const img = document.querySelector('[data-chat-surface="painted"] .md-image')
       return !!el && getComputedStyle(el).visibility !== 'hidden'
-        // The retained ChatView deliberately reveals its already-settled DOM
-        // immediately. Do not mistake the still-complete initial image for the
-        // delayed authoritative return image we are exercising here.
         && !!img?.src.includes('entry-image-return.png') && !!img.complete
         && !!document.querySelector('[data-key="entry-anchor"]')
     }, { timeout: 10000 })
-    expect(catchUpServed).toBe(false)
-    releaseCatchUp()
-    await expect.poll(() => catchUpServed, { timeout: 3000 }).toBe(true)
 
     const trajectory = await page.evaluate(() => window.__entryTrajectory || [])
     const visibleRows = trajectory.filter(row => row.visible)


### PR DESCRIPTION
## Summary

- keep a running chat behind the existing handoff cover until its initial stream catch-up commits
- release the cover through one explicit stream outcome, including terminal refresh and exhausted-retry fallback paths
- leave idle cached chats and chats parked on an owner question unchanged

## Context

A running chat could report itself ready after persisted history loaded but before its subscribe-time stream catch-up committed. That allowed the transcript and its height to change immediately after the drawer handoff, producing a visible second render.

This is related to #563, which reduces catch-up payload size and improves cache-coordinate validation. This PR isolates the reveal-ordering invariant on current `main`; it does not include #563's backend snapshot or cold-transcript changes, so the behavior can be reviewed independently.

## Validation

- 54 focused frontend unit tests
- production frontend build
- phone-width frame trace: all transcript changes completed behind the handoff cover, with no content or height change after entry settled