### PR TITLE
Keep composer edits anchored at chat tail

### DIFF
--- a/frontend/src/components/ChatView/ChatInputBar.jsx
+++ b/frontend/src/components/ChatView/ChatInputBar.jsx
@@ -421,6 +421,7 @@ function FileChips({ files, onRemove, chatId }) {
  * Props:
  *   input              — current textarea value
  *   onInputChange      — receives new string
+ *   onInputIntent      — runs after the controlled draft accepts an edit
  *   onSubmit           — called with FormEvent | MouseEvent | TouchEvent
  *   onSubmitSteer      — submits composed text and immediately steers
  *                        it when a live turn can accept steering
@@ -474,6 +475,7 @@ export default function ChatInputBar({
   chatId,
   input,
   onInputChange,
+  onInputIntent,
   onSubmit,
   onSubmitSteer,
   inputRef,
@@ -641,9 +643,11 @@ export default function ChatInputBar({
   }
 
   function handleTextareaChange(e) {
+    const value = e.target.value
     resetMessageHistory()
-    if (listeningRef?.current) onManualVoiceEdit?.(e.target.value)
-    onInputChange(e.target.value)
+    if (listeningRef?.current) onManualVoiceEdit?.(value)
+    onInputChange(value)
+    onInputIntent?.(e.nativeEvent)
   }
 
   function handlePaste(e) {

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -719,6 +719,7 @@ export default function ChatView({
     settleSendIntent,
     settleStreamingPin,
     composerResized,
+    composerEdited,
     paneResized,
   } = useScrollMode({
     chatId,
@@ -4224,6 +4225,7 @@ export default function ChatView({
           chatId={chatId}
           input={input}
           onInputChange={handleComposerInputChange}
+          onInputIntent={composerEdited}
           onSubmit={handleSubmit}
           onSubmitSteer={handleSubmitSteer}
           inputRef={inputRef}

--- a/frontend/src/components/ChatView/__tests__/composerVoiceEditing.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerVoiceEditing.test.js
@@ -18,10 +18,15 @@ test('manual textarea changes remain enabled while voice input is active', () =>
   assert.doesNotMatch(changeHandler, /listeningRef\?\.current\) return/,
     'listening must not discard owner edits')
   assert.match(changeHandler,
-    /if \(listeningRef\?\.current\) onManualVoiceEdit\?\.\(e\.target\.value\)/,
+    /if \(listeningRef\?\.current\) onManualVoiceEdit\?\.\(value\)/,
     'a live edit must rebase the recognition session before updating the draft')
-  assert.match(changeHandler, /onInputChange\(e\.target\.value\)/,
+  assert.match(changeHandler, /onInputChange\(value\)/,
     'the controlled composer must still receive the owner edit')
+  assert.ok(
+    changeHandler.indexOf('onInputChange(value)')
+      < changeHandler.indexOf('onInputIntent?.(e.nativeEvent)'),
+    'scroll ownership may change only after React accepts the controlled draft',
+  )
 })
 
 test('ChatView connects manual voice edits to the voice-input session', () => {

--- a/frontend/src/components/ChatView/__tests__/scrollOwnership.test.js
+++ b/frontend/src/components/ChatView/__tests__/scrollOwnership.test.js
@@ -220,13 +220,13 @@ test('automatic geometry owners and newer semantic actions share reader authorit
     'a disclosure press promoted to a native pan must become reader-owned scroll',
   )
 
-  const composerStart = ownerSource.indexOf('const onComposerPointerDown =')
+  const composerStart = ownerSource.indexOf('const onComposerTailIntent =')
   const composerEnd = ownerSource.indexOf('const noteScrollStart =', composerStart)
   const composerPath = ownerSource.slice(composerStart, composerEnd)
   assert.ok(composerStart >= 0 && composerEnd > composerStart,
     'composer tail intent must remain inside the scroll owner')
-  assert.match(composerPath, /composerPointerRequestsFollow\(event, scrollEl\)/,
-    'composer focus may follow only after checking pre-keyboard tail geometry')
+  assert.match(composerPath, /composerTailIntentRequestsFollow\(event, scrollEl\)/,
+    'composer focus/edit may follow only after checking pre-resize tail geometry')
   assert.ok(
     composerPath.indexOf('supersedePendingReaderGesture()')
       < composerPath.indexOf("transitionMode({ kind: 'FOLLOW_BOTTOM' }"),

--- a/frontend/src/components/ChatView/__tests__/scrollOwnership.test.js
+++ b/frontend/src/components/ChatView/__tests__/scrollOwnership.test.js
@@ -220,7 +220,7 @@ test('automatic geometry owners and newer semantic actions share reader authorit
     'a disclosure press promoted to a native pan must become reader-owned scroll',
   )
 
-  const composerStart = ownerSource.indexOf('const onComposerTailIntent =')
+  const composerStart = ownerSource.indexOf('const runComposerTailIntent =')
   const composerEnd = ownerSource.indexOf('const noteScrollStart =', composerStart)
   const composerPath = ownerSource.slice(composerStart, composerEnd)
   assert.ok(composerStart >= 0 && composerEnd > composerStart,

--- a/frontend/src/components/ChatView/__tests__/sendLandingGeometry.test.js
+++ b/frontend/src/components/ChatView/__tests__/sendLandingGeometry.test.js
@@ -53,7 +53,11 @@ test('footer resizes enter through the scroll owner instead of mutating geometry
   assert.ok(bridgeStart >= 0 && bridgeEnd > bridgeStart, 'composer resize bridge exists')
   const bridge = controller.slice(bridgeStart, bridgeEnd)
   assert.match(bridge, /deferLayoutUntilReaderYields\(authorityVersion\)/)
-  assert.match(bridge, /syncLayout\(\{ authorityVersion \}\)/)
+  assert.match(
+    bridge,
+    /syncLayout\(\{[\s\S]*?forceApply:\s*modeRef\.current\.kind === 'FOLLOW_BOTTOM',[\s\S]*?authorityVersion,[\s\S]*?\}\)/,
+    'composer growth must reapply an established tail follow in the same owner pass',
+  )
 })
 
 test('gesture settlement replays deferred footer geometry and mode in one task', () => {

--- a/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
+++ b/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
@@ -13,8 +13,8 @@ import {
   applyMode,
   anchorModeFromScroll,
   bottomAnchorModeFromScroll,
-  composerPointerRequestsFollow,
   contentHoldModeFromScroll,
+  composerTailIntentRequestsFollow,
   delayedSendWillPin,
   gestureLayoutRetryDelay,
   isNearContentBottom,
@@ -206,7 +206,7 @@ test('only scrolling keys claim reader ownership', () => {
   assert.equal(readerInputMayScroll('touchmove'), true)
 })
 
-test('a primary composer press requests follow only at the physical tail', () => {
+test('a composer press or direct edit requests follow only at the physical tail', () => {
   const composer = { matches: selector => selector === 'textarea.chat__input' }
   const otherControl = { matches: () => false }
   const atTail = makeScrollEl({
@@ -220,12 +220,26 @@ test('a primary composer press requests follow only at the physical tail', () =>
     clientHeight: 800,
   })
 
-  assert.equal(composerPointerRequestsFollow({ button: 0, target: composer }, atTail), true)
-  assert.equal(composerPointerRequestsFollow({ button: 0, target: composer }, aboveTail), false,
+  assert.equal(composerTailIntentRequestsFollow({
+    type: 'pointerdown', button: 0, target: composer,
+  }, atTail), true)
+  assert.equal(composerTailIntentRequestsFollow({
+    type: 'input', target: composer,
+  }, atTail), true, 'paste/typing can express tail intent without a new pointer event')
+  assert.equal(composerTailIntentRequestsFollow({
+    type: 'input', target: composer,
+  }, aboveTail), false,
     'composer focus must preserve an older reading position')
-  assert.equal(composerPointerRequestsFollow({ button: 1, target: composer }, atTail), false,
+  assert.equal(composerTailIntentRequestsFollow({
+    type: 'pointerdown', button: 1, target: composer,
+  }, atTail), false,
     'non-primary presses do not express writing intent')
-  assert.equal(composerPointerRequestsFollow({ button: 0, target: otherControl }, atTail), false)
+  assert.equal(composerTailIntentRequestsFollow({
+    type: 'input', target: otherControl,
+  }, atTail), false)
+  assert.equal(composerTailIntentRequestsFollow({
+    type: 'change', target: composer,
+  }, atTail), false, 'unrelated form events do not claim scroll ownership')
 })
 
 test('disclosure activation is recognized as an anchor-latching reading action', () => {

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -1317,6 +1317,10 @@ export default function useScrollMode({
   // The observer in ChatView notifies this runner rather than writing the CSS
   // variable itself, so both mutations share the reader-gesture gate.
   const composerResizeRunRef = useRef(null)
+  // Controlled composer edits must publish their draft before a PIN -> FOLLOW
+  // transition can render. React's change handler invokes this effect-owned
+  // bridge after accepting the new value.
+  const composerEditRunRef = useRef(null)
   // A custom Q&A field can grow while the phone browser is also moving its
   // visual viewport to keep the caret above the keyboard. Keep that native
   // editing lifecycle visible across focusout until the keyboard has returned
@@ -2508,7 +2512,7 @@ export default function useScrollMode({
       // Keep the gesture gate, but let that scroll become reader-owned.
       disclosureInputOwnsGesture = false
     }
-    const onComposerTailIntent = (event) => {
+    const runComposerTailIntent = (event) => {
       if (!composerTailIntentRequestsFollow(event, scrollEl)) return
       // Once FOLLOW already owns layout, later characters carry no new scroll
       // intent. Keep this a one-time handoff instead of persisting and tracing
@@ -2531,6 +2535,8 @@ export default function useScrollMode({
       persistMode()
       recordTrace('events', 'reader:composer-bottom', { scrollEl })
     }
+    const onComposerPointerDown = (event) => runComposerTailIntent(event)
+    composerEditRunRef.current = runComposerTailIntent
     const noteScrollStart = () => {
       if (!pendingGestureStart) return
       perfMark('scroll.startLatency', performance.now() - pendingGestureStart)
@@ -2547,8 +2553,7 @@ export default function useScrollMode({
     scrollEl.addEventListener('input', onQuestionEditMutation, { passive: true })
     scrollEl.addEventListener('pointerup', onPointerUpInput, { passive: true })
     scrollEl.addEventListener('pointercancel', onPointerCancelInput, { passive: true })
-    chatEl?.addEventListener('pointerdown', onComposerTailIntent, { passive: true })
-    chatEl?.addEventListener('input', onComposerTailIntent, { passive: true })
+    chatEl?.addEventListener('pointerdown', onComposerPointerDown, { passive: true })
 
     // Scroll handler — user-driven scrolls only mark intent here. The expensive
     // semantic location/mode work runs once in settleReaderScroll.
@@ -2655,8 +2660,10 @@ export default function useScrollMode({
       scrollEl.removeEventListener('input', onQuestionEditMutation)
       scrollEl.removeEventListener('pointerup', onPointerUpInput)
       scrollEl.removeEventListener('pointercancel', onPointerCancelInput)
-      chatEl?.removeEventListener('pointerdown', onComposerTailIntent)
-      chatEl?.removeEventListener('input', onComposerTailIntent)
+      chatEl?.removeEventListener('pointerdown', onComposerPointerDown)
+      if (composerEditRunRef.current === runComposerTailIntent) {
+        composerEditRunRef.current = null
+      }
       if (forceRevealRef.current === forceReveal) forceRevealRef.current = null
     }
   }, [
@@ -2823,6 +2830,10 @@ export default function useScrollMode({
     composerResizeRunRef.current?.()
   }, [])
 
+  const composerEdited = useCallback((event) => {
+    composerEditRunRef.current?.(event)
+  }, [])
+
   return {
     gestureWindowUntilRef,
     revealed,
@@ -2837,6 +2848,7 @@ export default function useScrollMode({
     settleSendIntent,
     settleStreamingPin,
     composerResized,
+    composerEdited,
     paneResized,
   }
 }

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -862,12 +862,16 @@ export function modeAfterReaderGesture({
 }
 
 
-/** A primary composer press at the physical tail is an explicit request to
- * keep the latest content visible while the software keyboard opens. Read the
- * geometry before focus changes the viewport; presses higher in the transcript
- * preserve their exact reading anchor. */
-export function composerPointerRequestsFollow(event, scrollEl) {
-  if (event?.button !== 0
+/** A primary composer press or direct edit at the physical tail is an explicit
+ * request to keep the latest content visible while the keyboard or composer
+ * changes the viewport. The edit case covers paste/typing while the textarea
+ * is already focused, so there may be no new pointer event to retire an older
+ * scroll gesture. Read the tail before the foot observer publishes the new
+ * composer height; edits higher in the transcript preserve their anchor. */
+export function composerTailIntentRequestsFollow(event, scrollEl) {
+  const primaryPress = event?.type === 'pointerdown' && event?.button === 0
+  const directEdit = event?.type === 'input'
+  if ((!primaryPress && !directEdit)
       || !event?.target?.matches?.('textarea.chat__input')
       || !scrollEl) return false
   return scrollEl.scrollHeight - scrollEl.scrollTop - scrollEl.clientHeight
@@ -2026,7 +2030,14 @@ export default function useScrollMode({
         deferLayoutUntilReaderYields(authorityVersion)
         return
       }
-      syncLayout({ authorityVersion })
+      // Foot growth changes list padding without necessarily changing the
+      // list's observed content box. Reapply an established live follow here;
+      // otherwise only the first new line moves the viewport and later lines
+      // quietly leave the reader above the tail.
+      syncLayout({
+        forceApply: modeRef.current.kind === 'FOLLOW_BOTTOM',
+        authorityVersion,
+      })
     }
     composerResizeRunRef.current = runComposerResize
 
@@ -2497,12 +2508,23 @@ export default function useScrollMode({
       // Keep the gesture gate, but let that scroll become reader-owned.
       disclosureInputOwnsGesture = false
     }
-    const onComposerPointerDown = (event) => {
-      if (!composerPointerRequestsFollow(event, scrollEl)) return
+    const onComposerTailIntent = (event) => {
+      if (!composerTailIntentRequestsFollow(event, scrollEl)) return
+      // Once FOLLOW already owns layout, later characters carry no new scroll
+      // intent. Keep this a one-time handoff instead of persisting and tracing
+      // the same state on every input event. An unfinished older gesture still
+      // comes through so writing can supersede it below.
+      if (modeRef.current?.kind === 'FOLLOW_BOTTOM'
+          && layoutMayOwnScroll(
+            gestureWindowUntilRef.current,
+            performance.now(),
+          )) return
       // Composer focus is a newer semantic action than any scroll still
-      // waiting on momentum/quiet settlement. Retire that gesture before the
-      // keyboard resize arrives so the viewport observer can apply FOLLOW in
-      // its first committed layout pass instead of waiting behind the old gate.
+      // waiting on momentum/quiet settlement. A direct edit is the same intent
+      // when the field was already focused and no new press occurred. Retire
+      // that gesture before the keyboard/composer resize arrives so the
+      // viewport observer can apply FOLLOW in its first committed layout pass
+      // instead of waiting behind the old gate.
       supersedePendingReaderGesture()
       readerLocationExplicitRef.current = true
       transitionMode({ kind: 'FOLLOW_BOTTOM' }, 'reader:composer-bottom')
@@ -2525,7 +2547,8 @@ export default function useScrollMode({
     scrollEl.addEventListener('input', onQuestionEditMutation, { passive: true })
     scrollEl.addEventListener('pointerup', onPointerUpInput, { passive: true })
     scrollEl.addEventListener('pointercancel', onPointerCancelInput, { passive: true })
-    chatEl?.addEventListener('pointerdown', onComposerPointerDown, { passive: true })
+    chatEl?.addEventListener('pointerdown', onComposerTailIntent, { passive: true })
+    chatEl?.addEventListener('input', onComposerTailIntent, { passive: true })
 
     // Scroll handler — user-driven scrolls only mark intent here. The expensive
     // semantic location/mode work runs once in settleReaderScroll.
@@ -2632,7 +2655,8 @@ export default function useScrollMode({
       scrollEl.removeEventListener('input', onQuestionEditMutation)
       scrollEl.removeEventListener('pointerup', onPointerUpInput)
       scrollEl.removeEventListener('pointercancel', onPointerCancelInput)
-      chatEl?.removeEventListener('pointerdown', onComposerPointerDown)
+      chatEl?.removeEventListener('pointerdown', onComposerTailIntent)
+      chatEl?.removeEventListener('input', onComposerTailIntent)
       if (forceRevealRef.current === forceReveal) forceRevealRef.current = null
     }
   }, [

--- a/tests/spacer.spec.mjs
+++ b/tests/spacer.spec.mjs
@@ -1348,4 +1348,138 @@ test.describe('Scroll edge cases', () => {
     const after = await measure(page)
     expect(Math.abs(after.scrollTop - before.scrollTop)).toBeLessThan(20)
   })
+
+  test('28. An already-focused paste follows the tail before the composer grows', async ({ page }) => {
+    const events = [
+      { type: 'catch_up_done' },
+      { type: 'text', content: 'Long response paragraph. '.repeat(120) },
+      { type: 'done' },
+    ]
+    await setupWithSSE(page, events, { width: 412, height: 615 })
+    await newChat(page)
+    await sendMessage(page, 'First message')
+    await page.waitForFunction(
+      () => !document.querySelector('[data-chat-surface="painted"] .chat__stop'),
+      { timeout: 10000 }
+    )
+
+    const overflow = await measure(page)
+    expect(overflow.scrollH).toBeGreaterThan(overflow.clientH + 100)
+
+    // Establish an ordinary reading anchor, then put that held viewport at the
+    // physical tail without manufacturing FOLLOW_BOTTOM. This is the restored
+    // / already-focused state that previously depended on a fresh composer tap.
+    await page.evaluate(() => {
+      const scroll = document.querySelector('[data-chat-surface="painted"] .chat__scroll')
+      scroll.dispatchEvent(new PointerEvent('pointerdown', {
+        bubbles: true,
+        button: 0,
+        pointerType: 'touch',
+      }))
+      scroll.scrollTop = Math.max(0, Math.floor(scroll.scrollHeight / 3))
+      scroll.dispatchEvent(new Event('scroll', { bubbles: true }))
+      scroll.dispatchEvent(new PointerEvent('pointerup', {
+        bubbles: true,
+        button: 0,
+        pointerType: 'touch',
+      }))
+    })
+    await page.evaluate(() => new Promise(resolve => setTimeout(resolve, 350)))
+    await expect(page.locator('[data-chat-surface="painted"] .chat__scroll'))
+      .toHaveAttribute('data-scroll-mode', 'ANCHOR_AT')
+    await page.evaluate(() => {
+      const surface = document.querySelector('[data-chat-surface="painted"]')
+      const scroll = surface.querySelector('.chat__scroll')
+      const input = surface.querySelector('.chat__input')
+      scroll.scrollTop = scroll.scrollHeight
+      input.focus({ preventScroll: true })
+    })
+    const atTail = await measure(page)
+    expect(atTail.scrollH - atTail.scrollTop - atTail.clientH).toBeLessThanOrEqual(4)
+    await expect(page.locator('[data-chat-surface="painted"] .chat__scroll'))
+      .toHaveAttribute('data-scroll-mode', 'ANCHOR_AT')
+
+    const result = await page.evaluate(async () => {
+      const surface = document.querySelector('[data-chat-surface="painted"]')
+      const scroll = surface.querySelector('.chat__scroll')
+      const input = surface.querySelector('.chat__input')
+      const foot = surface.querySelector('.chat__foot')
+      window.__mobiusChatScrollTrace = {
+        version: 1,
+        transitions: [],
+        writes: [],
+        events: [],
+      }
+      const sample = () => ({
+        mode: scroll.dataset.scrollMode,
+        top: Math.round(scroll.scrollTop),
+        height: scroll.scrollHeight,
+        viewport: scroll.clientHeight,
+        gap: Math.round(scroll.scrollHeight - scroll.scrollTop - scroll.clientHeight),
+        inputHeight: input.offsetHeight,
+        footHeight: foot.offsetHeight,
+      })
+
+      // A bottom-edge touch can still be waiting to prove whether a native
+      // scroll will arrive. Paste from the software keyboard then changes the
+      // already-focused textarea without another DOM pointer event.
+      scroll.dispatchEvent(new PointerEvent('pointerdown', {
+        bubbles: true,
+        button: 0,
+        pointerType: 'touch',
+      }))
+      const before = sample()
+      const lines = [
+        'First pasted line that wraps across the narrow composer width.',
+        'Second pasted line that also grows the composer.',
+        'Third pasted line.',
+        'Fourth pasted line.',
+      ]
+      const valueSetter = Object.getOwnPropertyDescriptor(
+        HTMLTextAreaElement.prototype,
+        'value',
+      ).set
+      valueSetter.call(input, lines[0])
+      input.dispatchEvent(new InputEvent('input', {
+        bubbles: true,
+        inputType: 'insertFromPaste',
+        data: lines[0],
+      }))
+      const immediate = sample()
+      const settledFrames = []
+      for (const line of lines.slice(1)) {
+        const next = `${input.value}\n${line}`
+        valueSetter.call(input, next)
+        input.dispatchEvent(new InputEvent('input', {
+          bubbles: true,
+          inputType: 'insertLineBreak',
+          data: line,
+        }))
+        await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))
+        settledFrames.push(sample())
+      }
+      await new Promise(resolve => setTimeout(resolve, 2100))
+      const afterFormerGestureCap = sample()
+      const composerEvents = window.__mobiusChatScrollTrace.events
+        .filter(event => event.event === 'reader:composer-bottom')
+      return {
+        before,
+        immediate,
+        settledFrames,
+        afterFormerGestureCap,
+        composerEvents,
+      }
+    })
+
+    expect(result.immediate.mode).toBe('FOLLOW_BOTTOM')
+    expect(result.composerEvents).toHaveLength(1)
+    expect(result.settledFrames.at(-1).footHeight).toBeGreaterThan(result.before.footHeight)
+    for (const frame of result.settledFrames) {
+      expect(frame.gap).toBeLessThanOrEqual(4)
+    }
+    expect(result.afterFormerGestureCap.gap).toBeLessThanOrEqual(4)
+    expect(Math.abs(
+      result.afterFormerGestureCap.top - result.settledFrames.at(-1).top
+    )).toBeLessThanOrEqual(4)
+  })
 })

--- a/tests/spacer.spec.mjs
+++ b/tests/spacer.spec.mjs
@@ -262,7 +262,16 @@ test.describe('Spacer mechanics', () => {
     await sendMessage(page, 'First message')
     const first = await measure(page)
     await stopAgent(page)
-    await sendMessage(page, 'Second message')
+    const scroll = page.locator('[data-chat-surface="painted"] .chat__scroll')
+    const composer = page.getByRole('textbox', { name: 'Message Möbius…' })
+    await expect(scroll).toHaveAttribute('data-scroll-mode', 'PIN_USER_MSG')
+    await composer.fill('Second message')
+    await expect(composer).toHaveValue('Second message')
+    await expect(scroll).toHaveAttribute('data-scroll-mode', 'FOLLOW_BOTTOM')
+    await composer.press('Enter')
+    await page.evaluate(() => new Promise(r =>
+      requestAnimationFrame(() => requestAnimationFrame(r))
+    ))
 
     const m = await measure(page)
     expect(m.msgCount).toBeGreaterThanOrEqual(2)


### PR DESCRIPTION
## Summary
- Treat direct edits in an already-focused composer at the physical chat tail as explicit follow intent, not only a fresh pointer press.
- Keep the existing bottom-follow active through each subsequent composer height change.
- Add unit and rendered regression coverage for delayed paste settlement without changing reading positions higher in the chat.

## Context
This follows #558, which fixed the delayed keyboard lift when a fresh composer press expressed tail intent. Paste or typing can change an already-focused composer without another pointer event. If an older scroll gesture still owned the viewport, footer geometry could wait for its safety release and then restore the stale anchor. After the first handoff, later composer height changes could also update clearance without reapplying bottom-follow.

This follow-up routes both cases through the existing scroll owner. It adds no timer, retry, or second scrolling mechanism.

## Verification
- Frontend unit and hook suites
- Structural test ratchet
- Production/PWA build
- Lint (0 errors; existing warnings only)
- Authenticated 426×510 rendered regression: every pasted line and the former delayed-settlement point remained at a 0 px tail gap