### PR TITLE
Keep drawer row menus stable across outside taps

### DIFF
--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -4,6 +4,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { EmptyMessage } from '@openai/apps-sdk-ui/components/EmptyMessage'
 import { api } from '../../api/client.js'
 import { appQueries, chatQueries } from '../../hooks/queries.js'
+import { useHistoryDismiss } from '../../hooks/useHistoryDismiss.jsx'
 import {
   AppsNavIcon,
   NewChatNavIcon,
@@ -285,6 +286,15 @@ export default function Drawer({
   // active id (rather than per-row state) lets a click on another row's
   // context action replace any open menu without a global listener per row.
   const [openMenu, setOpenMenu] = useState(null) // { kind, id, surface, placement } | null
+  const {
+    open: openItemMenuHistory,
+    close: closeItemMenu,
+  } = useHistoryDismiss(() => setOpenMenu(null))
+
+  function showItemMenu(kind, id, surface, placement) {
+    openItemMenuHistory()
+    setOpenMenu({ kind, id, surface, placement })
+  }
   // Belt-and-braces orphan cleanup: if the row whose menu was open
   // disappears from the list (delete, chat soft-delete, agent-side
   // removal), openMenu would still reference a dead id and the next
@@ -294,8 +304,8 @@ export default function Drawer({
     if (!openMenu) return
     const collection = openMenu.kind === 'chat' ? (chats || []) : (apps || [])
     const stillThere = collection.some(item => item.id === openMenu.id)
-    if (!stillThere) setOpenMenu(null)
-  }, [openMenu, chats, apps])
+    if (!stillThere) closeItemMenu()
+  }, [openMenu, chats, apps, closeItemMenu])
   const [renamingState, setRenamingState] = useState(null) // { kind, id } | null
   // Mirrors `renaming` synchronously (not via useEffect — that's one render
   // behind) so outside-tap cancellation sees the current edit immediately.
@@ -325,16 +335,16 @@ export default function Drawer({
 
   const resetAppsSurfaceUi = useCallback(({ restoreFocus = true } = {}) => {
     setAppQuery('')
-    setOpenMenu(null)
+    closeItemMenu()
     setRenaming(null)
     if (restoreFocus) {
       requestAnimationFrame(() => appsButtonRef.current?.focus())
     }
-  }, [setRenaming])
+  }, [closeItemMenu, setRenaming])
 
   function openApps() {
     setAppQuery('')
-    setOpenMenu(null)
+    closeItemMenu()
     setRenaming(null)
     onAppsOpen?.()
   }
@@ -367,12 +377,9 @@ export default function Drawer({
       else current.onApp(id)
     },
     toggleMenu(kind, id, next, surface = 'drawer', placement = null) {
-      rowActionInputsRef.current.setOpenMenu(next ? {
-        kind,
-        id,
-        surface,
-        placement,
-      } : null)
+      const current = rowActionInputsRef.current
+      if (next) current.showItemMenu(kind, id, surface, placement)
+      else current.closeItemMenu()
     },
     startRename(kind, id, surface = 'drawer') {
       rowActionInputsRef.current.setRenaming({ kind, id, surface })
@@ -908,7 +915,8 @@ export default function Drawer({
     onDeleteChat,
     onDeleteApp,
     onDeleteAppData,
-    setOpenMenu,
+    showItemMenu,
+    closeItemMenu,
     setRenaming,
     setInstallingApp,
     resetAppsSurfaceUi,

--- a/frontend/src/components/Drawer/DrawerItemActionMenu.jsx
+++ b/frontend/src/components/Drawer/DrawerItemActionMenu.jsx
@@ -30,7 +30,7 @@ export default function DrawerItemActionMenu({
   const menuRef = useRef(null)
   const wasOpenRef = useRef(false)
   const restoreOnCloseRef = useRef(true)
-  const outsidePressStartedRef = useRef(false)
+  const menuPressStartedRef = useRef(false)
   const [confirmation, setConfirmation] = useState(null)
   const [position, setPosition] = useState(null)
 
@@ -44,7 +44,7 @@ export default function DrawerItemActionMenu({
       wasOpenRef.current = true
       return
     }
-    outsidePressStartedRef.current = false
+    menuPressStartedRef.current = false
     setConfirmation(null)
     setPosition(null)
     if (!wasOpenRef.current) return
@@ -141,29 +141,32 @@ export default function DrawerItemActionMenu({
     return true
   }
 
+  function blockReleaseThroughClick(event) {
+    // A touch menu can appear underneath the contact that opened it. Android
+    // may retarget that contact's trailing click to the newly mounted action,
+    // even though no pointerdown ever began inside the menu. Only a click with
+    // menu-owned press provenance may run; detail=0 preserves keyboard and
+    // assistive-technology activation.
+    const keyboardActivation = event.detail === 0
+    if (keyboardActivation || menuPressStartedRef.current) {
+      menuPressStartedRef.current = false
+      return
+    }
+    event.preventDefault()
+    event.stopPropagation()
+    event.nativeEvent?.stopImmediatePropagation?.()
+  }
+
   const layer = (
     <div
       className="drawer__item-action-layer"
-      onPointerDown={event => {
-        // Keep the layer mounted for the complete tap. Closing on pointerdown
-        // lets Android retarget the later release/click to the row underneath.
-        if (consumeOutsidePointer(event)) {
-          outsidePressStartedRef.current = true
-        }
+      onPointerDownCapture={() => {
+        menuPressStartedRef.current = false
       }}
-      onPointerUp={event => {
-        consumeOutsidePointer(event)
-      }}
-      onPointerCancel={() => {
-        outsidePressStartedRef.current = false
-      }}
-      onClick={event => {
-        // The opener click can be retargeted to a layer that did not exist at
-        // pointerdown; only a new press that began on the layer may dismiss it.
-        if (!consumeOutsidePointer(event) || !outsidePressStartedRef.current) return
-        outsidePressStartedRef.current = false
-        close()
-      }}
+      onPointerDown={consumeOutsidePointer}
+      onPointerUp={consumeOutsidePointer}
+      onPointerCancel={consumeOutsidePointer}
+      onClick={consumeOutsidePointer}
       onContextMenu={event => event.preventDefault()}
       onWheel={event => {
         if (event.target === event.currentTarget) close()
@@ -179,7 +182,14 @@ export default function DrawerItemActionMenu({
           '--item-action-x': `${position?.x || 0}px`,
           '--item-action-y': `${position?.y || 0}px`,
         }}
-        onPointerDown={event => event.stopPropagation()}
+        onPointerDown={event => {
+          menuPressStartedRef.current = true
+          event.stopPropagation()
+        }}
+        onPointerCancel={() => {
+          menuPressStartedRef.current = false
+        }}
+        onClickCapture={blockReleaseThroughClick}
         onKeyDown={onMenuKeyDown}
       >
         {confirmation === 'delete-data' ? (

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -911,12 +911,25 @@ test('chat deletion is immediate while app deletion still requires confirmation'
   )
 })
 
-test('one touch hold cannot dismiss its own drawer row menu', () => {
-  assert.match(drawerItemActionMenu, /const outsidePressStartedRef = useRef\(false\)/)
-  assert.match(drawerItemActionMenu, /if \(!consumeOutsidePointer\(event\) \|\| !outsidePressStartedRef\.current\) return/,
-    'a retargeted opener click has no layer-owned pointerdown and must be ignored')
-  assert.match(drawerItemActionMenu, /onPointerCancel=\{\(\) => \{[\s\S]*?outsidePressStartedRef\.current = false/,
-    'a cancelled outside press cannot authorize a later unrelated click')
+test('drawer row menus share one history-owned opening and close path', () => {
+  assert.match(drawer, /import \{ useHistoryDismiss \} from '\.\.\/\.\.\/hooks\/useHistoryDismiss\.jsx'/)
+  assert.match(drawer, /open: openItemMenuHistory,[\s\S]*?close: closeItemMenu,[\s\S]*?useHistoryDismiss\(\(\) => setOpenMenu\(null\)\)/)
+  assert.match(drawer, /function showItemMenu\(kind, id, surface, placement\) \{[\s\S]*?openItemMenuHistory\(\)[\s\S]*?setOpenMenu\(\{ kind, id, surface, placement \}\)/,
+    'history ownership must exist before the menu paints')
+  assert.match(drawer, /if \(next\) current\.showItemMenu\(kind, id, surface, placement\)[\s\S]*?else current\.closeItemMenu\(\)/,
+    'actions and Back/Escape must close through the same owner')
+})
+
+test('outside taps are inert and the opening press cannot activate an action', () => {
+  assert.doesNotMatch(drawerItemActionMenu, /outsidePressStartedRef/)
+  assert.match(drawerItemActionMenu, /const menuPressStartedRef = useRef\(false\)/)
+  assert.match(drawerItemActionMenu, /function blockReleaseThroughClick\(event\)[\s\S]*?event\.detail === 0[\s\S]*?menuPressStartedRef\.current[\s\S]*?event\.preventDefault\(\)[\s\S]*?stopImmediatePropagation/,
+    'a release retargeted onto an action is blocked without breaking keyboard activation')
+  assert.match(drawerItemActionMenu, /onPointerDown=\{consumeOutsidePointer\}[\s\S]*?onPointerUp=\{consumeOutsidePointer\}[\s\S]*?onClick=\{consumeOutsidePointer\}/,
+    'outside taps stay owned by the layer without dismissing the menu')
+  assert.match(drawerItemActionMenu, /onPointerDown=\{event => \{[\s\S]*?menuPressStartedRef\.current = true[\s\S]*?event\.stopPropagation\(\)/,
+    'only a fresh pointer press begun inside the mounted menu authorizes its click')
+  assert.match(drawerItemActionMenu, /onClickCapture=\{blockReleaseThroughClick\}/)
 })
 
 test('a secondary-button release cannot immediately select a flipped drawer menu item', () => {


### PR DESCRIPTION
## Summary

- keep outside taps owned by the open row-menu layer without dismissing or activating the row beneath
- reject release-through clicks unless a fresh pointer press began inside the mounted menu, while preserving keyboard activation
- route row-menu open and close through one history-owned dismissal boundary

## Why

On touch devices, the contact that opens a menu can finish after the menu mounts. Android may retarget that release to a newly painted action or underlying row. Outside taps also closed the menu even when the intended interaction model was an explicit Back/Escape/action dismissal.

## Verification

- 88 focused workspace UI tests
- frontend lint
- pre-push frontend unit gate