### PR TITLE
Make drawer menu touch interactions predictable

### DIFF
--- a/frontend/src/components/Drawer/Drawer.css
+++ b/frontend/src/components/Drawer/Drawer.css
@@ -454,6 +454,7 @@
   inset: 0;
   z-index: 1000;
   background: transparent;
+  pointer-events: none;
 }
 
 .drawer__item-action-menu {
@@ -472,6 +473,7 @@
   color: var(--text);
   box-shadow: 0 14px 38px rgba(0, 0, 0, 0.38);
   scrollbar-width: none;
+  pointer-events: auto;
 }
 
 .drawer__item-action-menu[data-positioned="true"] {

--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -4,6 +4,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { EmptyMessage } from '@openai/apps-sdk-ui/components/EmptyMessage'
 import { api } from '../../api/client.js'
 import { appQueries, chatQueries } from '../../hooks/queries.js'
+import { useHistoryDismiss } from '../../hooks/useHistoryDismiss.jsx'
 import {
   AppsNavIcon,
   NewChatNavIcon,
@@ -286,6 +287,15 @@ export default function Drawer({
   // active id (rather than per-row state) lets a click on another row's
   // context action replace any open menu without a global listener per row.
   const [openMenu, setOpenMenu] = useState(null) // { kind, id, surface, placement } | null
+  const {
+    open: openItemMenuHistory,
+    close: closeItemMenu,
+  } = useHistoryDismiss(() => setOpenMenu(null))
+
+  function showItemMenu(kind, id, surface, placement) {
+    openItemMenuHistory()
+    setOpenMenu({ kind, id, surface, placement })
+  }
   // Belt-and-braces orphan cleanup: if the row whose menu was open
   // disappears from the list (delete, chat soft-delete, agent-side
   // removal), openMenu would still reference a dead id and the next
@@ -295,8 +305,8 @@ export default function Drawer({
     if (!openMenu) return
     const collection = openMenu.kind === 'chat' ? (chats || []) : (apps || [])
     const stillThere = collection.some(item => item.id === openMenu.id)
-    if (!stillThere) setOpenMenu(null)
-  }, [openMenu, chats, apps])
+    if (!stillThere) closeItemMenu()
+  }, [openMenu, chats, apps, closeItemMenu])
   const [renamingState, setRenamingState] = useState(null) // { kind, id } | null
   // Mirrors `renaming` synchronously (not via useEffect — that's one render
   // behind) so outside-tap cancellation sees the current edit immediately.
@@ -326,16 +336,16 @@ export default function Drawer({
 
   const resetAppsSurfaceUi = useCallback(({ restoreFocus = true } = {}) => {
     setAppQuery('')
-    setOpenMenu(null)
+    closeItemMenu()
     setRenaming(null)
     if (restoreFocus) {
       requestAnimationFrame(() => appsButtonRef.current?.focus())
     }
-  }, [setRenaming])
+  }, [closeItemMenu, setRenaming])
 
   function openApps() {
     setAppQuery('')
-    setOpenMenu(null)
+    closeItemMenu()
     setRenaming(null)
     onAppsOpen?.()
   }
@@ -368,12 +378,9 @@ export default function Drawer({
       else current.onApp(id)
     },
     toggleMenu(kind, id, next, surface = 'drawer', placement = null) {
-      rowActionInputsRef.current.setOpenMenu(next ? {
-        kind,
-        id,
-        surface,
-        placement,
-      } : null)
+      const current = rowActionInputsRef.current
+      if (next) current.showItemMenu(kind, id, surface, placement)
+      else current.closeItemMenu()
     },
     startRename(kind, id, surface = 'drawer') {
       rowActionInputsRef.current.setRenaming({ kind, id, surface })
@@ -912,7 +919,8 @@ export default function Drawer({
     onDeleteChat,
     onDeleteApp,
     onDeleteAppData,
-    setOpenMenu,
+    showItemMenu,
+    closeItemMenu,
     setRenaming,
     setInstallingApp,
     resetAppsSurfaceUi,

--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -1397,9 +1397,9 @@ const DrawerRow = memo(function DrawerRow({
   }
 
   function openItemMenu(event) {
-    // Touch menus open only from the shared gesture controller on release.
-    // Native long-press contextmenu would fire early and steal drag intent, so
-    // suppress it on both rows and cards; mouse and keyboard remain semantic.
+    // Touch menus open only from the shared gesture controller during its
+    // stationary hold. Native contextmenu would steal that timing and re-open
+    // actions on release, so suppress it; mouse and keyboard remain semantic.
     if (suppressTouchContextMenu(event)) return
     event.preventDefault()
     event.stopPropagation()
@@ -1767,8 +1767,8 @@ const DrawerRow = memo(function DrawerRow({
         className={`drawer__item ${active ? 'drawer__item--active' : ''}`}
         aria-current={active ? 'page' : undefined}
         // One shared controller resolves a held row only after intent is clear:
-        // release for actions, vertical movement to reorder a pin, outward
-        // movement to place it in the workspace.
+        // staying still opens actions, vertical movement reorders a pin, and
+        // outward movement places it in the workspace.
         data-drawer-key={`${kind}:${id}`}
         data-drag-key={`${kind}:${id}`}
         data-pinned-key={pinned ? `${kind}:${id}` : undefined}

--- a/frontend/src/components/Drawer/DrawerItemActionMenu.jsx
+++ b/frontend/src/components/Drawer/DrawerItemActionMenu.jsx
@@ -3,6 +3,12 @@
 
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
+import {
+  beginMenuPress,
+  cancelMenuPress,
+  consumeMenuClick,
+  finishMenuPress,
+} from './menuPointerOwnership.js'
 import { Pin, PinFilled } from '@openai/apps-sdk-ui/components/Icon'
 import { placeContextMenu } from '../../lib/contextMenuGeometry.js'
 
@@ -30,7 +36,7 @@ export default function DrawerItemActionMenu({
   const menuRef = useRef(null)
   const wasOpenRef = useRef(false)
   const restoreOnCloseRef = useRef(true)
-  const menuPressStartedRef = useRef(false)
+  const pointerOwnerRef = useRef({ press: null, clickAction: null })
   const [confirmation, setConfirmation] = useState(null)
   const [position, setPosition] = useState(null)
 
@@ -44,7 +50,7 @@ export default function DrawerItemActionMenu({
       wasOpenRef.current = true
       return
     }
-    menuPressStartedRef.current = false
+    pointerOwnerRef.current = { press: null, clickAction: null }
     setConfirmation(null)
     setPosition(null)
     if (!wasOpenRef.current) return
@@ -100,8 +106,6 @@ export default function DrawerItemActionMenu({
     return () => cancelAnimationFrame(frame)
   }, [open, position, confirmation])
 
-  if (!open) return null
-
   function run(action, { restoreFocus = true } = {}) {
     close({ restoreFocus })
     action()
@@ -133,28 +137,59 @@ export default function DrawerItemActionMenu({
 
   const recoveryLabel = itemKind === 'chat' ? 'chats' : 'apps'
 
+  function actionFor(target) {
+    return target?.closest?.('.drawer__item-action-item') || null
+  }
+
   function blockReleaseThroughClick(event) {
     // A touch menu can appear underneath the contact that opened it. Android
     // may retarget that contact's trailing click to the newly mounted action,
     // even though no pointerdown ever began inside the menu. Only a click with
     // menu-owned press provenance may run; detail=0 preserves keyboard and
     // assistive-technology activation.
-    const keyboardActivation = event.detail === 0
-    if (keyboardActivation || menuPressStartedRef.current) {
-      menuPressStartedRef.current = false
-      return
-    }
+    const outcome = consumeMenuClick(pointerOwnerRef.current, {
+      detail: event.detail,
+      action: actionFor(event.target),
+    })
+    pointerOwnerRef.current = outcome.owner
+    if (outcome.allowed) return
     event.preventDefault()
     event.stopPropagation()
     event.nativeEvent?.stopImmediatePropagation?.()
   }
 
+  useEffect(() => {
+    if (!open) return
+    function onOutsidePointerDown(event) {
+      if (menuRef.current?.contains(event.target)) return
+      pointerOwnerRef.current = { press: null, clickAction: null }
+      // The listener is capture-only: dismiss synchronously, then let the same
+      // pointer continue to its intended chat/app/settings/content target.
+      restoreOnCloseRef.current = false
+      onClose()
+    }
+    function clearAbandonedPointer(event) {
+      if (menuRef.current?.contains(event.target)) return
+      pointerOwnerRef.current = cancelMenuPress(
+        pointerOwnerRef.current,
+        event.pointerId,
+      )
+    }
+    document.addEventListener('pointerdown', onOutsidePointerDown, true)
+    document.addEventListener('pointerup', clearAbandonedPointer, true)
+    document.addEventListener('pointercancel', clearAbandonedPointer, true)
+    return () => {
+      document.removeEventListener('pointerdown', onOutsidePointerDown, true)
+      document.removeEventListener('pointerup', clearAbandonedPointer, true)
+      document.removeEventListener('pointercancel', clearAbandonedPointer, true)
+    }
+  }, [onClose, open])
+
+  if (!open) return null
+
   const layer = (
     <div
       className="drawer__item-action-layer"
-      onPointerDownCapture={() => {
-        menuPressStartedRef.current = false
-      }}
     >
       <div
         ref={menuRef}
@@ -167,11 +202,24 @@ export default function DrawerItemActionMenu({
           '--item-action-y': `${position?.y || 0}px`,
         }}
         onPointerDown={event => {
-          menuPressStartedRef.current = true
+          pointerOwnerRef.current = beginMenuPress(pointerOwnerRef.current, {
+            pointerId: event.pointerId,
+            action: actionFor(event.target),
+            isPrimary: event.isPrimary,
+          })
           event.stopPropagation()
         }}
-        onPointerCancel={() => {
-          menuPressStartedRef.current = false
+        onPointerUp={event => {
+          pointerOwnerRef.current = finishMenuPress(pointerOwnerRef.current, {
+            pointerId: event.pointerId,
+            action: actionFor(event.target),
+          })
+        }}
+        onPointerCancel={event => {
+          pointerOwnerRef.current = cancelMenuPress(
+            pointerOwnerRef.current,
+            event.pointerId,
+          )
         }}
         onClickCapture={blockReleaseThroughClick}
         onKeyDown={onMenuKeyDown}

--- a/frontend/src/components/Drawer/DrawerItemActionMenu.jsx
+++ b/frontend/src/components/Drawer/DrawerItemActionMenu.jsx
@@ -30,7 +30,7 @@ export default function DrawerItemActionMenu({
   const menuRef = useRef(null)
   const wasOpenRef = useRef(false)
   const restoreOnCloseRef = useRef(true)
-  const outsidePressStartedRef = useRef(false)
+  const menuPressStartedRef = useRef(false)
   const [confirmation, setConfirmation] = useState(null)
   const [position, setPosition] = useState(null)
 
@@ -44,7 +44,7 @@ export default function DrawerItemActionMenu({
       wasOpenRef.current = true
       return
     }
-    outsidePressStartedRef.current = false
+    menuPressStartedRef.current = false
     setConfirmation(null)
     setPosition(null)
     if (!wasOpenRef.current) return
@@ -133,40 +133,27 @@ export default function DrawerItemActionMenu({
 
   const recoveryLabel = itemKind === 'chat' ? 'chats' : 'apps'
 
-  function consumeOutsidePointer(event) {
-    if (event.target !== event.currentTarget) return false
+  function blockReleaseThroughClick(event) {
+    // A touch menu can appear underneath the contact that opened it. Android
+    // may retarget that contact's trailing click to the newly mounted action,
+    // even though no pointerdown ever began inside the menu. Only a click with
+    // menu-owned press provenance may run; detail=0 preserves keyboard and
+    // assistive-technology activation.
+    const keyboardActivation = event.detail === 0
+    if (keyboardActivation || menuPressStartedRef.current) {
+      menuPressStartedRef.current = false
+      return
+    }
     event.preventDefault()
     event.stopPropagation()
     event.nativeEvent?.stopImmediatePropagation?.()
-    return true
   }
 
   const layer = (
     <div
       className="drawer__item-action-layer"
-      onPointerDown={event => {
-        // Keep the layer mounted for the complete tap. Closing on pointerdown
-        // lets Android retarget the later release/click to the row underneath.
-        if (consumeOutsidePointer(event)) {
-          outsidePressStartedRef.current = true
-        }
-      }}
-      onPointerUp={event => {
-        consumeOutsidePointer(event)
-      }}
-      onPointerCancel={() => {
-        outsidePressStartedRef.current = false
-      }}
-      onClick={event => {
-        // The opener click can be retargeted to a layer that did not exist at
-        // pointerdown; only a new press that began on the layer may dismiss it.
-        if (!consumeOutsidePointer(event) || !outsidePressStartedRef.current) return
-        outsidePressStartedRef.current = false
-        close()
-      }}
-      onContextMenu={event => event.preventDefault()}
-      onWheel={event => {
-        if (event.target === event.currentTarget) close()
+      onPointerDownCapture={() => {
+        menuPressStartedRef.current = false
       }}
     >
       <div
@@ -179,7 +166,14 @@ export default function DrawerItemActionMenu({
           '--item-action-x': `${position?.x || 0}px`,
           '--item-action-y': `${position?.y || 0}px`,
         }}
-        onPointerDown={event => event.stopPropagation()}
+        onPointerDown={event => {
+          menuPressStartedRef.current = true
+          event.stopPropagation()
+        }}
+        onPointerCancel={() => {
+          menuPressStartedRef.current = false
+        }}
+        onClickCapture={blockReleaseThroughClick}
         onKeyDown={onMenuKeyDown}
       >
         {confirmation === 'delete-data' ? (

--- a/frontend/src/components/Drawer/menuPointerOwnership.js
+++ b/frontend/src/components/Drawer/menuPointerOwnership.js
@@ -1,0 +1,26 @@
+export function beginMenuPress(owner, { pointerId, action, isPrimary = true }) {
+  if (!isPrimary || action == null || owner.press != null) return owner
+  return { ...owner, press: { pointerId, action }, clickAction: null }
+}
+
+export function finishMenuPress(owner, { pointerId, action }) {
+  if (owner.press?.pointerId !== pointerId) return owner
+  const clickAction = owner.press.action === action ? action : null
+  return { press: null, clickAction }
+}
+
+export function cancelMenuPress(owner, pointerId) {
+  if (owner.press?.pointerId !== pointerId) return owner
+  return { press: null, clickAction: null }
+}
+
+export function consumeMenuClick(owner, { detail, action }) {
+  const keyboardActivation = detail === 0
+  const allowed = keyboardActivation || (
+    action != null && owner.clickAction === action
+  )
+  return {
+    allowed,
+    owner: { ...owner, clickAction: null },
+  }
+}

--- a/frontend/src/components/Shell/__tests__/dragController.test.js
+++ b/frontend/src/components/Shell/__tests__/dragController.test.js
@@ -89,7 +89,7 @@ test('releasedInPlace is true only within the release radius', () => {
 test('drawer rows expose drag before a stationary hold opens actions', () => {
   assert.equal(TAB_HOLD_MS, 350)
   assert.equal(DRAWER_DRAG_HOLD_MS, 180)
-  assert.equal(DRAWER_MENU_HOLD_MS, 550)
+  assert.equal(DRAWER_MENU_HOLD_MS, 400)
   assert.ok(DRAWER_DRAG_HOLD_MS < TAB_HOLD_MS)
   assert.ok(DRAWER_MENU_HOLD_MS > TAB_HOLD_MS)
 })

--- a/frontend/src/components/Shell/__tests__/menuPointerOwnership.test.js
+++ b/frontend/src/components/Shell/__tests__/menuPointerOwnership.test.js
@@ -1,0 +1,53 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  beginMenuPress,
+  cancelMenuPress,
+  consumeMenuClick,
+  finishMenuPress,
+} from '../../Drawer/menuPointerOwnership.js'
+
+const empty = () => ({ press: null, clickAction: null })
+const actionA = {}
+const actionB = {}
+
+test('the opener release has no menu-owned press and cannot activate an action', () => {
+  const outcome = consumeMenuClick(empty(), { detail: 1, action: actionA })
+  assert.equal(outcome.allowed, false)
+})
+
+test('one complete primary press authorizes exactly its own action click', () => {
+  let owner = beginMenuPress(empty(), {
+    pointerId: 7, action: actionA, isPrimary: true,
+  })
+  owner = finishMenuPress(owner, { pointerId: 7, action: actionA })
+  const first = consumeMenuClick(owner, { detail: 1, action: actionA })
+  assert.equal(first.allowed, true)
+  assert.equal(consumeMenuClick(first.owner, {
+    detail: 1, action: actionA,
+  }).allowed, false)
+})
+
+test('drag-out, cancellation, and a second pointer cannot authorize a click', () => {
+  let owner = beginMenuPress(empty(), {
+    pointerId: 7, action: actionA, isPrimary: true,
+  })
+  owner = beginMenuPress(owner, {
+    pointerId: 8, action: actionB, isPrimary: false,
+  })
+  owner = finishMenuPress(owner, { pointerId: 7, action: actionB })
+  assert.equal(consumeMenuClick(owner, { detail: 1, action: actionA }).allowed, false)
+
+  owner = beginMenuPress(empty(), {
+    pointerId: 9, action: actionA, isPrimary: true,
+  })
+  owner = cancelMenuPress(owner, 9)
+  assert.equal(consumeMenuClick(owner, { detail: 1, action: actionA }).allowed, false)
+})
+
+test('keyboard and assistive activation remain available without a pointer', () => {
+  assert.equal(consumeMenuClick(empty(), {
+    detail: 0, action: actionA,
+  }).allowed, true)
+})

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -669,11 +669,15 @@ test('one held drawer-row gesture resolves menu, reorder, or workspace drag', ()
     'the workspace outcome arms the shared drag implementation')
   assert.match(dragBinding, /intent === 'scroll'[\s\S]*?scrollAxis = 'y'[\s\S]*?scrollTop \+= start\.y - ev\.clientY/,
     'pre-hold row movement scrolls without surrendering the pointer to the browser')
-  assert.match(dragBinding, /const point = \{ \.\.\.lastPoint \}[\s\S]*?cleanup\(\{ suppressClick: true \}\)[\s\S]*?handler\?\.openMenu\?\.\(point\)/,
-    'a stationary long hold opens actions before release and suppresses its trailing click')
+  assert.match(dragBinding, /const point = \{ \.\.\.lastPoint \}[\s\S]*?menuOpened = true[\s\S]*?handler\.openMenu\(point\)/,
+    'a stationary long hold opens actions before release')
+  assert.doesNotMatch(dragBinding, /const point = \{ \.\.\.lastPoint \}[\s\S]{0,120}?cleanup\(/,
+    'selection suppression must stay active while the opening contact is still down')
   const drawerPointerUp = dragBinding.match(/const onUp = \(ev\) => \{[\s\S]*?\n      \}/)?.[0] || ''
   assert.doesNotMatch(drawerPointerUp, /openMenu/,
     'releasing a shorter stationary hold remains a normal tap')
+  assert.match(drawerPointerUp, /if \(menuOpened\)[\s\S]*?cleanup\(\{ suppressClick: true \}\)/,
+    'the menu-opening gesture restores selection only when its pointer ends')
   assert.doesNotMatch(dragBinding, /openTabMenuAtRef/)
   assert.doesNotMatch(dragBinding, /addEventListener\('touchmove'/)
   assert.match(shell, /const drawerRowGesturesRef = useRef\(new Map\(\)\)/)
@@ -911,12 +915,35 @@ test('chat deletion is immediate while app deletion still requires confirmation'
   )
 })
 
-test('one touch hold cannot dismiss its own drawer row menu', () => {
-  assert.match(drawerItemActionMenu, /const outsidePressStartedRef = useRef\(false\)/)
-  assert.match(drawerItemActionMenu, /if \(!consumeOutsidePointer\(event\) \|\| !outsidePressStartedRef\.current\) return/,
-    'a retargeted opener click has no layer-owned pointerdown and must be ignored')
-  assert.match(drawerItemActionMenu, /onPointerCancel=\{\(\) => \{[\s\S]*?outsidePressStartedRef\.current = false/,
-    'a cancelled outside press cannot authorize a later unrelated click')
+test('drawer row actions have one opening path without a custom touch hold', () => {
+  assert.match(drawer, /function openItemMenuAt\(point,[\s\S]*?actions\.toggleMenu\(kind, id, true, surface,/)
+  assert.equal((drawer.match(/onContextMenu=\{openItemMenu\}/g) || []).length, 2,
+    'app cards and drawer rows must share one semantic opening function')
+  assert.match(drawer, /if \(suppressTouchContextMenu\(event\)\) return/,
+    'native touch contextmenu must never pre-empt the shared held gesture')
+  assert.doesNotMatch(
+    dragBinding,
+    /srcEl\.closest\('\.drawer__row'\)\?\.querySelector\('\.drawer__more'\)\?\.click\(\)/,
+    'touch hold must not depend on a synthetic trigger click',
+  )
+  assert.doesNotMatch(drawer, /function beginTouchMenuHold/,
+    'drawer rows must not add a second touch lifecycle beside the shared controller')
+  assert.match(drawerCss, /\.drawer__item-action-layer\s*\{[\s\S]*?pointer-events:\s*none/)
+  assert.match(drawerCss, /\.drawer__item-action-menu\s*\{[\s\S]*?pointer-events:\s*auto/,
+    'the menu stays interactive while the next outside tap reaches its real destination')
+  assert.doesNotMatch(drawer, /navigator\.vibrate/,
+    'drawer rows rely on platform long-press feedback instead of adding a second vibration')
+})
+
+test('the background stays live while the opening press cannot activate an action', () => {
+  assert.doesNotMatch(drawerItemActionMenu, /outsidePressStartedRef|consumeOutsidePointer/)
+  assert.match(drawerItemActionMenu, /const menuPressStartedRef = useRef\(false\)/)
+  assert.match(drawerItemActionMenu, /function blockReleaseThroughClick\(event\)[\s\S]*?event\.detail === 0[\s\S]*?menuPressStartedRef\.current[\s\S]*?event\.preventDefault\(\)[\s\S]*?stopImmediatePropagation/,
+    'a release retargeted onto an action is blocked without breaking keyboard activation')
+  assert.match(drawerItemActionMenu, /onPointerDownCapture=\{\(\) => \{[\s\S]*?menuPressStartedRef\.current = false/)
+  assert.match(drawerItemActionMenu, /onPointerDown=\{event => \{[\s\S]*?menuPressStartedRef\.current = true[\s\S]*?event\.stopPropagation\(\)/,
+    'only a fresh pointer press begun inside the mounted menu authorizes its click')
+  assert.match(drawerItemActionMenu, /onClickCapture=\{blockReleaseThroughClick\}/)
 })
 
 test('a secondary-button release cannot immediately select a flipped drawer menu item', () => {
@@ -1049,7 +1076,7 @@ test('the builder preview cannot outlive its drag session past one visibility bo
   // guards keep it bounded:
   // (1) SOURCE — pagehide joins the per-session teardown, so a BFCache freeze that
   //     fires no pointercancel/blur/visibilitychange still cancels the drag.
-  assert.match(dragBinding, /const onPageHide = \(\) => cleanup\(\{ suppressClick: armed \|\| scrolling \}\)/)
+  assert.match(dragBinding, /const onPageHide = \(\) => cleanup\(\{ suppressClick: menuOpened \|\| armed \|\| scrolling \}\)/)
   assert.match(dragBinding, /window\.addEventListener\('pagehide', onPageHide\)/)
   assert.match(dragBinding, /window\.removeEventListener\('pagehide', onPageHide\)/)
   // (2) BACKSTOP — a persistent foreground reconcile force-cleans any session still

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -916,6 +916,10 @@ test('chat deletion is immediate while app deletion still requires confirmation'
 })
 
 test('drawer row actions have one opening path without a custom touch hold', () => {
+  assert.match(drawer, /import \{ useHistoryDismiss \} from '\.\.\/\.\.\/hooks\/useHistoryDismiss\.jsx'/)
+  assert.match(drawer, /open: openItemMenuHistory,[\s\S]*?close: closeItemMenu,[\s\S]*?useHistoryDismiss\(\(\) => setOpenMenu\(null\)\)/)
+  assert.match(drawer, /function showItemMenu\(kind, id, surface, placement\) \{[\s\S]*?openItemMenuHistory\(\)[\s\S]*?setOpenMenu/,
+    'Back ownership must be registered before the portaled menu paints')
   assert.match(drawer, /function openItemMenuAt\(point,[\s\S]*?actions\.toggleMenu\(kind, id, true, surface,/)
   assert.equal((drawer.match(/onContextMenu=\{openItemMenu\}/g) || []).length, 2,
     'app cards and drawer rows must share one semantic opening function')
@@ -933,17 +937,6 @@ test('drawer row actions have one opening path without a custom touch hold', () 
     'the menu stays interactive while the next outside tap reaches its real destination')
   assert.doesNotMatch(drawer, /navigator\.vibrate/,
     'drawer rows rely on platform long-press feedback instead of adding a second vibration')
-})
-
-test('the background stays live while the opening press cannot activate an action', () => {
-  assert.doesNotMatch(drawerItemActionMenu, /outsidePressStartedRef|consumeOutsidePointer/)
-  assert.match(drawerItemActionMenu, /const menuPressStartedRef = useRef\(false\)/)
-  assert.match(drawerItemActionMenu, /function blockReleaseThroughClick\(event\)[\s\S]*?event\.detail === 0[\s\S]*?menuPressStartedRef\.current[\s\S]*?event\.preventDefault\(\)[\s\S]*?stopImmediatePropagation/,
-    'a release retargeted onto an action is blocked without breaking keyboard activation')
-  assert.match(drawerItemActionMenu, /onPointerDownCapture=\{\(\) => \{[\s\S]*?menuPressStartedRef\.current = false/)
-  assert.match(drawerItemActionMenu, /onPointerDown=\{event => \{[\s\S]*?menuPressStartedRef\.current = true[\s\S]*?event\.stopPropagation\(\)/,
-    'only a fresh pointer press begun inside the mounted menu authorizes its click')
-  assert.match(drawerItemActionMenu, /onClickCapture=\{blockReleaseThroughClick\}/)
 })
 
 test('a secondary-button release cannot immediately select a flipped drawer menu item', () => {

--- a/frontend/src/components/Shell/dragController.js
+++ b/frontend/src/components/Shell/dragController.js
@@ -37,7 +37,11 @@ export const POINTER_SLOP = 5
 // owner and launcher cards from inventing their own thresholds.
 export const TAB_HOLD_MS = 350
 export const DRAWER_DRAG_HOLD_MS = 180
-export const DRAWER_MENU_HOLD_MS = 550
+// Stay ahead of the platform's own long-press takeover. Some touch browsers
+// cancel the pointer around their native context-menu threshold; opening first
+// keeps the menu on our single Pointer Events path instead of a release-time
+// native contextmenu fallback.
+export const DRAWER_MENU_HOLD_MS = 400
 // Movement past this before a hold resolves yields to the source scroller.
 export const PRE_HOLD_MOVE_PX = 8
 // After a touch lift, a release that never moved past this is not a drop. Tabs

--- a/frontend/src/components/Shell/useWorkspaceDrag.js
+++ b/frontend/src/components/Shell/useWorkspaceDrag.js
@@ -241,6 +241,7 @@ export default function useWorkspaceDrag({
       let armed = false
       let cancelled = false
       let cleaned = false
+      let menuOpened = false
       let holdTimer = null
       let held = false
       let scrolling = false
@@ -326,9 +327,17 @@ export default function useWorkspaceDrag({
           holdTimer = setTimeout(() => {
             if (cancelled || cleaned || armed || scrolling) return
             const handler = drawerGesture()
+            if (!handler?.openMenu) {
+              cleanup()
+              return
+            }
             const point = { ...lastPoint }
-            cleanup({ suppressClick: true })
-            handler?.openMenu?.(point)
+            // Keep this pointer session alive until the contact actually ends.
+            // Restoring body selection here leaves a small window in which the
+            // platform long-press can select whichever menu item appeared under
+            // the still-held finger (notably Android's text-selection handles).
+            menuOpened = true
+            handler.openMenu(point)
           }, DRAWER_MENU_HOLD_MS - DRAWER_DRAG_HOLD_MS)
         }, sourceKind === 'drawer' ? DRAWER_DRAG_HOLD_MS : TAB_HOLD_MS)
       }
@@ -401,6 +410,10 @@ export default function useWorkspaceDrag({
       }
       const onMove = (ev) => {
         if (ev.pointerId !== pointerId) return // ignore a second finger
+        if (menuOpened) {
+          ev.preventDefault?.()
+          return
+        }
         const previousPoint = lastPoint
         lastPoint = { x: ev.clientX, y: ev.clientY }
         const dx = ev.clientX - start.x
@@ -523,6 +536,10 @@ export default function useWorkspaceDrag({
 
       const onUp = (ev) => {
         if (ev.pointerId !== pointerId) return // ignore a second finger
+        if (menuOpened) {
+          cleanup({ suppressClick: true })
+          return
+        }
         if (!armed) {
           if (scrolling) {
             cleanup({ suppressClick: true })
@@ -562,7 +579,7 @@ export default function useWorkspaceDrag({
       // ARMED (§9): otherwise the compat click after an Escape / lost-capture /
       // blur / visibility cancel can still navigate to the source row.
       const onCancel = (ev) => {
-        if (ev.pointerId === pointerId) cleanup({ suppressClick: armed || scrolling })
+        if (ev.pointerId === pointerId) cleanup({ suppressClick: menuOpened || armed || scrolling })
       }
       const onKey = (ev) => { if (ev.key === 'Escape' && armed) { ev.preventDefault(); cleanup({ suppressClick: true }) } }
       // Touch pointers already have implicit capture, and Chromium may release and
@@ -572,16 +589,16 @@ export default function useWorkspaceDrag({
       const onLostCapture = (ev) => {
         if (ev.pointerId === pointerId && !isTouch) cleanup({ suppressClick: armed })
       }
-      const onWinBlur = () => cleanup({ suppressClick: armed || scrolling })
+      const onWinBlur = () => cleanup({ suppressClick: menuOpened || armed || scrolling })
       const onVisibility = () => {
-        if (document.visibilityState === 'hidden') cleanup({ suppressClick: armed || scrolling })
+        if (document.visibilityState === 'hidden') cleanup({ suppressClick: menuOpened || armed || scrolling })
       }
       // BFCache freeze / bfcache navigation can be the ONLY interruption event some
       // browsers fire — no pointercancel, no blur, and (on older Safari) no
       // visibilitychange-hidden first. Without this, a drag frozen mid-flight and
       // then restored would keep its render-only builder preview, wedging the
       // workspace tiled. pagehide cancels the drag as the page is frozen/unloaded.
-      const onPageHide = () => cleanup({ suppressClick: armed || scrolling })
+      const onPageHide = () => cleanup({ suppressClick: menuOpened || armed || scrolling })
 
       function cleanup({ suppressClick = false, committed = false } = {}) {
         if (cleaned) return


### PR DESCRIPTION
## Summary

- open a stationary touch menu before native long-press handling takes over
- keep gesture ownership through release so Android and iOS cannot select or activate an action beneath the opening finger
- let a tap outside the menu reach its intended chat, app, or settings destination directly
- preserve the earlier hold-and-move paths for pinned reordering and workspace drag

## Context

This is a focused follow-up to #565, which established one gesture owner for drawer menu, reorder, and drag intent. Open PR #573 retains the release-through guard but makes outside taps inert; this revision keeps that safety while allowing the tap to perform its normal destination action.

## Testing

- 130 focused drawer/workspace tests
- lint on the changed frontend files
- production frontend build
- trusted touch verification of menu timing, opener-release safety, and one-tap destination switching