### PR TITLE
Recognize exact installed app source matches

### DIFF
--- a/backend/app/source_status.py
+++ b/backend/app/source_status.py
@@ -73,6 +73,13 @@ def _rev(repo: Path, ref: str) -> str | None:
   return value if proc.returncode == 0 and value else None
 
 
+def _trees_equal(repo: Path, left: str, right: str) -> bool:
+  """Return whether two refs name byte-identical source trees."""
+  left_tree = _rev(repo, f"{left}^{{tree}}")
+  right_tree = _rev(repo, f"{right}^{{tree}}")
+  return bool(left_tree and left_tree == right_tree)
+
+
 def _canonical_repo(url: str | None) -> str | None:
   """Turn common GitHub remote/manifest URLs into ``owner/repo``."""
   if not url:
@@ -469,6 +476,8 @@ def _project_status(
     "head_sha": None,
     "base_ref": "origin/main" if kind == "platform" else "upstream",
     "base_sha": None,
+    "comparison_ref": None,
+    "comparison_sha": None,
     "ahead": None,
     "behind": None,
     "tree": None,
@@ -496,6 +505,15 @@ def _project_status(
     compare_local=(kind == "platform"),
     classify_install=(kind == "app"),
   )
+  if kind == "app" and origin.get("ref"):
+    # Installer-owned ``upstream`` remains the update baseline, but a landed
+    # contribution can reach the last-fetched canonical branch before an app
+    # update advances that marker. Exact tree equality is a projection-safe
+    # witness: unlike an ordinary origin diff, it cannot turn omitted package
+    # files into apparent owner deletions.
+    origin["head_tree_matches_origin"] = _trees_equal(
+      repo, origin["ref"], "HEAD",
+    )
   response.update({"origin": origin, "forks": forks})
 
   response.update({
@@ -515,18 +533,26 @@ def _project_status(
     return response
 
   ahead, behind = _comparison_counts(repo, base_ref, "HEAD")
+  comparison_ref = (
+    origin["ref"]
+    if kind == "app" and origin.get("head_tree_matches_origin")
+    else base_ref
+  )
+  comparison_sha = _rev(repo, comparison_ref)
   tree, managed_paths = _diff_inventory(
-    repo, base_ref, "HEAD", classify_install=(kind == "app"),
+    repo, comparison_ref, "HEAD", classify_install=(kind == "app"),
   )
   reconciliation = _reconciliation_summary(
     repo,
     "HEAD",
-    base_ref,
+    comparison_ref,
     managed_paths=managed_paths,
   )
   response.update({
     "behind": behind,
     "ahead": ahead,
+    "comparison_ref": comparison_ref,
+    "comparison_sha": comparison_sha,
     "tree": tree,
     "reconciliation": reconciliation,
   })

--- a/backend/tests/test_source_status.py
+++ b/backend/tests/test_source_status.py
@@ -296,6 +296,83 @@ def test_endpoint_equal_sibling_histories_are_semantically_aligned():
   assert _git(repo, "merge-base", "main", "upstream") == base
 
 
+def test_exact_orphan_origin_tree_suppresses_a_stale_installer_baseline():
+  repo = _repo("origin-tree-witness")
+  base = _git(repo, "rev-parse", "HEAD")
+  _git(repo, "remote", "add", "origin", "https://github.com/example/demo.git")
+
+  (repo / "index.jsx").write_text("export default 2\n", encoding="utf-8")
+  _git(repo, "add", "index.jsx")
+  _commit(repo, "local projection")
+
+  _git(repo, "checkout", "-q", "--orphan", "shared")
+  _git(repo, "rm", "-q", "-r", "--cached", ".")
+  (repo / "index.jsx").write_text("export default 2\n", encoding="utf-8")
+  _git(repo, "add", "index.jsx")
+  shared = _commit(repo, "landed source")
+  _git(repo, "update-ref", "refs/remotes/origin/main", shared)
+  _git(repo, "checkout", "-q", "main")
+  _git(repo, "branch", "-D", "shared")
+
+  result = source_status.build_app_status(_app(repo))
+
+  assert result is not None
+  assert result["base_ref"] == "upstream"
+  assert result["base_sha"] == base
+  assert result["origin"]["head_tree_matches_origin"] is True
+  assert result["comparison_ref"] == "origin/main"
+  assert result["comparison_sha"] == shared
+  assert result["tree"]["files"] == 0
+  assert result["reconciliation"]["local_only_count"] == 0
+  assert result["reconciliation"]["new_upstream_count"] == 0
+  assert result["state"] == "aligned"
+  merge_base = subprocess.run(
+    ["git", "-C", str(repo), "merge-base", "main", "origin/main"],
+    capture_output=True,
+    check=False,
+  )
+  assert merge_base.returncode != 0
+
+
+def test_exact_origin_commit_never_hides_live_working_files():
+  repo = _repo("origin-tree-with-working")
+  head = _git(repo, "rev-parse", "HEAD")
+  _git(repo, "remote", "add", "origin", "https://github.com/example/demo.git")
+  _git(repo, "update-ref", "refs/remotes/origin/main", head)
+  (repo / "owner-draft.js").write_text("draft\n", encoding="utf-8")
+
+  result = source_status.build_app_status(_app(repo))
+
+  assert result is not None
+  assert result["origin"]["head_tree_matches_origin"] is True
+  assert result["comparison_ref"] == "origin/main"
+  assert result["state"] == "working"
+  assert result["working"]["untracked"] == 1
+
+
+def test_nonmatching_package_tree_keeps_installer_projection_comparison():
+  repo = _repo("origin-package-files")
+  base = _git(repo, "rev-parse", "HEAD")
+  _git(repo, "remote", "add", "origin", "https://github.com/example/demo.git")
+  _git(repo, "checkout", "-q", "-b", "full-source", base)
+  (repo / "package-only.md").write_text("not installed\n", encoding="utf-8")
+  _git(repo, "add", "package-only.md")
+  full_source = _commit(repo, "package source")
+  _git(repo, "update-ref", "refs/remotes/origin/main", full_source)
+  _git(repo, "checkout", "-q", "main")
+  (repo / "owner.js").write_text("owner\n", encoding="utf-8")
+  _git(repo, "add", "owner.js")
+  _commit(repo, "owner source")
+
+  result = source_status.build_app_status(_app(repo))
+
+  assert result is not None
+  assert result["origin"]["head_tree_matches_origin"] is False
+  assert result["comparison_ref"] == "upstream"
+  assert result["tree"]["paths"][0]["path"] == "owner.js"
+  assert "package-only.md" not in repr(result["tree"])
+
+
 def test_disjoint_same_file_edits_are_classified_as_compatible():
   repo = _repo("compatible-overlap")
   (repo / "index.jsx").write_text(


### PR DESCRIPTION
## Why
An installed app’s installer-owned update marker can lag behind the canonical branch after a contribution lands. Exact Git tree equality is a projection-safe proof that the committed source is already shared.

## What changed
- report exact committed-HEAD to canonical-tree equality for installed apps
- expose the effective comparison ref and commit separately from installer release provenance
- use canonical inventory/reconciliation only under exact equality; preserve `upstream` for every non-exact case
- cover orphan histories, dirty live work, and package-only canonical files

## Verification
- focused source-status suite: 19 passed
- pre-push backend/privacy gates