### PR TITLE
Reuse running chat caches across live snapshots

### DIFF
--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -3719,7 +3719,6 @@ def update_live_assistant(
   """Persist the current assistant snapshot without rewriting history."""
   if not chat_id:
     return True
-  from datetime import UTC, datetime
   from app.models import Chat
 
   row = db.execute(
@@ -3773,7 +3772,9 @@ def update_live_assistant(
   db.execute(
     update(Chat)
     .where(Chat.id == chat_id, Chat.deleted_at.is_(None))
-    .values(live_assistant=snapshot, updated_at=datetime.now(UTC))
+    # The stream is authoritative while this value changes. Bypass
+    # updated_at's onupdate default so retained history remains reusable.
+    .values(live_assistant=snapshot, updated_at=Chat.updated_at)
   )
   return _commit_or_rollback(db)
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -173,10 +173,10 @@ class Chat(Base):
   )
   # Advances ONLY when the OWNER sends a message into this chat (initial
   # send, a queued send, or a fast-forward/steer send). This is the drawer
-  # ordering key, deliberately decoupled from `updated_at` — which bumps on
-  # EVERY row write via onupdate (run markers, session id, streamed
-  # transcript, the agent's auto-retitle) and would otherwise re-sort the
-  # chat to the top on activity the owner did not initiate. No onupdate here.
+  # ordering key, deliberately decoupled from `updated_at` — which usually
+  # bumps on row writes (run markers, session id, the agent's auto-retitle)
+  # and would otherwise re-sort the chat to the top on activity the owner did
+  # not initiate. No onupdate here.
   activity_at = Column(
     DateTime, nullable=True, default=lambda: datetime.now(UTC)
   )

--- a/backend/tests/test_chat_live_assistant.py
+++ b/backend/tests/test_chat_live_assistant.py
@@ -28,6 +28,7 @@ def _chat(db, *, trailing_role="user"):
 
 def test_stream_snapshot_updates_only_live_value(db):
   chat, history = _chat(db)
+  history_version = chat.updated_at
 
   assert update_live_assistant(db, chat.id, {
     "role": "assistant",
@@ -38,11 +39,13 @@ def test_stream_snapshot_updates_only_live_value(db):
   assert chat.messages == history
   assert chat.live_assistant["ts"] == 4
   assert chat.live_assistant["blocks"][0]["text"] == "streaming"
+  assert chat.updated_at == history_version
   assert materialized_messages(chat)[-1] == chat.live_assistant
 
 
 def test_finalize_merges_live_turn_once_and_clears_snapshot(db):
   chat, history = _chat(db)
+  history_version = chat.updated_at
   update_live_assistant(db, chat.id, {
     "role": "assistant",
     "blocks": [{"type": "text", "text": "partial"}],
@@ -58,6 +61,7 @@ def test_finalize_merges_live_turn_once_and_clears_snapshot(db):
   assert len(chat.messages) == len(history) + 1
   assert chat.messages[-1]["ts"] == 4
   assert chat.messages[-1]["blocks"][0]["text"] == "complete"
+  assert chat.updated_at != history_version
 
 
 def test_materialized_snapshot_replaces_question_barrier_row():


### PR DESCRIPTION
## Summary

- keep the retained transcript cache stable across partial live-answer saves
- continue invalidating that cache at real transcript boundaries such as start, steer, question, and completion
- avoid fetching the same large in-progress answer through both chat detail and live catch-up when switching chats

## Context

This complements #563. That PR reduces the cost of live stream catch-up by replacing full event-log replay with a server-reduced snapshot. This follow-up removes a separate redundant detail read: partial live-answer saves currently advance the chat's general version, so every return to a running chat rejects its retained transcript and downloads the in-progress answer again before catch-up.

The change is independently correct with either replay or snapshot catch-up. Live catch-up remains authoritative for the changing assistant surface, while structural transcript changes still advance the version and force an authoritative detail read.

## Validation

- 89 focused chat writer, live assistant, compact transcript, and route tests
- 69 hermetic backend contract tests
- Python compile check