### PR TITLE
Remove redundant composer geometry signals

### DIFF
--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -12,8 +12,8 @@
    ║      opt back in through the allow-list beside the foot;   ║
    ║      transparent wrappers keep the gutter pass-through.    ║
    ║                                                            ║
-   ║   2. `--composer-h` is published by a ResizeObserver in    ║
-   ║      ChatView.jsx that watches `.chat__foot`. `.chat__list`║
+   ║   2. `--composer-h` is published by the scroll controller's║
+   ║      ResizeObserver on `.chat__foot`. `.chat__list`        ║
    ║      reserves --composer-h + the same full safe-area       ║
    ║      expression + 16px so the last message clears the      ║
    ║      pill and gesture area as it grows                     ║
@@ -156,12 +156,12 @@
   margin: 0 auto;
   /* Bottom padding clears the absolutely-positioned `.chat__foot`.
      Tracks the foot's measured height via the `--composer-h` CSS
-     var (written by ChatView's ResizeObserver), the full device safe-area
-     gap below the foot (the SAME env() expression as `.chat__foot`'s
-     `bottom` — keep them in sync), plus a small breathing-room
-     margin so chips/queue tray growing the foot keeps the last
-     message clear of the pill. Fallback 80px is for the first
-     paint before the RO fires. */
+     var (written by the scroll controller's ResizeObserver), the
+     full device safe-area gap below the foot (the SAME env()
+     expression as `.chat__foot`'s `bottom` — keep them in sync),
+     plus a small breathing-room margin so chips/queue tray growing
+     the foot keeps the last message clear of the pill. Fallback
+     80px is for the first paint before the RO fires. */
   padding: 8px 6px calc(var(--composer-h, 80px) + env(safe-area-inset-bottom, 0px) + 16px);
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -727,7 +727,6 @@ export default function ChatView({
     reapplyActiveMode,
     settleSendIntent,
     settleStreamingPin,
-    composerResized,
     composerEdited,
     paneResized,
   } = useScrollMode({
@@ -739,7 +738,6 @@ export default function ChatView({
     footRef,
     messages,
     messagesRef,
-    pendingMessagesLength: pendingQueue.pendingMessages.length,
     loadingOlderRef: loadingOlder,
     initialEntryPhase,
     onCachedCoordinateReady: acceptCachedReadingCoordinate,
@@ -1549,81 +1547,40 @@ export default function ChatView({
     if (el && !hidden) reconcileComposerTextarea(el, input)
   }, [chatId, hidden, input])
 
-  // Notify the scroll owner when `.chat__foot` geometry may have changed.
-  // The controller publishes the matching list clearance and spacer in one
-  // guarded layout pass so an observer cannot move the reader indirectly.
+  // Composer room depends on the pane and visual viewport, not footer
+  // geometry. The scroll controller observes the actual footer and scroll
+  // viewport so transcript clearance and anchoring share one owner.
   useEffect(() => {
-    const footEl = footRef.current
-    if (!footEl) return
-
-    let raf1 = 0
-    let raf2 = 0
-    // The room is published unconditionally; the foot measurement goes through
-    // the scroll controller, which may decline while the reader owns the
-    // scroll. Keeping them in one settle sequence means the cap and the list
-    // padding still land from the same events.
-    const applyNow = () => {
-      publishComposerRoom()
-      composerResized()
-    }
-    const applySoon = () => {
-      applyNow()
-      if (raf1) cancelAnimationFrame(raf1)
-      if (raf2) cancelAnimationFrame(raf2)
-      raf1 = requestAnimationFrame(() => {
-        applyNow()
-        raf2 = requestAnimationFrame(applyNow)
-      })
-    }
     const reconcileForegroundGeometry = () => {
       // Chromium can restore form/layout state independently when a document
       // returns from background or the back-forward cache. Reconcile the
-      // textarea first; measuring only the outer foot would preserve a stale
-      // multi-line height on an empty composer.
+      // textarea before publishing the restored room.
       reconcileComposerTextarea(inputRef.current, inputValueRef.current)
-      applySoon()
+      publishComposerRoom()
     }
     const onVisible = () => {
       if (document.visibilityState === 'visible') reconcileForegroundGeometry()
     }
 
-    applySoon()
-    const ro = typeof ResizeObserver !== 'undefined'
-      ? new ResizeObserver(applySoon)
-      : null
-    ro?.observe(footEl)
-    // The pane is the room's other input, and it can change without any window
-    // or viewport event at all — dragging a workspace split resizes this chat
-    // while the window stands still. Observe it directly rather than hoping a
-    // neighbouring event fires.
+    publishComposerRoom()
+    // A workspace split can resize this pane while the window stands still.
     const paneRo = typeof ResizeObserver !== 'undefined'
       ? new ResizeObserver(publishComposerRoom)
       : null
     if (chatRef.current) paneRo?.observe(chatRef.current)
-    window.addEventListener('resize', applySoon)
+    window.addEventListener('resize', publishComposerRoom)
     window.addEventListener('pageshow', reconcileForegroundGeometry)
-    window.visualViewport?.addEventListener('resize', applySoon)
-    window.visualViewport?.addEventListener('scroll', applySoon)
+    window.visualViewport?.addEventListener('resize', publishComposerRoom)
     document.addEventListener('visibilitychange', onVisible)
 
     return () => {
-      if (raf1) cancelAnimationFrame(raf1)
-      if (raf2) cancelAnimationFrame(raf2)
-      ro?.disconnect()
       paneRo?.disconnect()
-      window.removeEventListener('resize', applySoon)
+      window.removeEventListener('resize', publishComposerRoom)
       window.removeEventListener('pageshow', reconcileForegroundGeometry)
-      window.visualViewport?.removeEventListener('resize', applySoon)
-      window.visualViewport?.removeEventListener('scroll', applySoon)
+      window.visualViewport?.removeEventListener('resize', publishComposerRoom)
       document.removeEventListener('visibilitychange', onVisible)
     }
-  }, [composerResized, publishComposerRoom])
-
-  useEffect(() => {
-    composerResized()
-    const raf = requestAnimationFrame(composerResized)
-    return () => cancelAnimationFrame(raf)
-  }, [builtApps, sending, buildPhases, composerResized])
+  }, [publishComposerRoom])
 
   useEffect(() => {
     const latest = buildPhases[buildPhases.length - 1]

--- a/frontend/src/components/ChatView/__tests__/composerTextareaSizing.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerTextareaSizing.test.js
@@ -111,7 +111,7 @@ test('ChatView reconciles textarea geometry on value commits and foreground retu
   const inputBarSource = readFileSync(new URL('../ChatInputBar.jsx', import.meta.url), 'utf8')
   const voiceSource = readFileSync(new URL('../useVoiceInput.js', import.meta.url), 'utf8')
   assert.match(source, /useLayoutEffect\(\(\) => \{[\s\S]*reconcileComposerTextarea\(el, input\)[\s\S]*\}, \[chatId, hidden, input\]\)/)
-  assert.match(source, /const reconcileForegroundGeometry = \(\) => \{[\s\S]*reconcileComposerTextarea\(inputRef\.current, inputValueRef\.current\)[\s\S]*applySoon\(\)/)
+  assert.match(source, /const reconcileForegroundGeometry = \(\) => \{[\s\S]*reconcileComposerTextarea\(inputRef\.current, inputValueRef\.current\)[\s\S]*publishComposerRoom\(\)/)
   assert.match(source, /window\.addEventListener\('pageshow', reconcileForegroundGeometry\)/)
   assert.match(inputBarSource, /new ResizeObserver\(/)
   assert.match(inputBarSource, /syncComposerTallClass\(/)

--- a/frontend/src/components/ChatView/__tests__/sendLandingGeometry.test.js
+++ b/frontend/src/components/ChatView/__tests__/sendLandingGeometry.test.js
@@ -35,29 +35,13 @@ test('ChatView gives its composer elements to the scroll owner', () => {
     'ChatView must notify geometry changes without publishing scroll geometry')
 })
 
-test('footer resizes enter through the scroll owner instead of mutating geometry directly', () => {
-  const commentStart = chatView.indexOf('// Notify the scroll owner when `.chat__foot`')
-  const effectStart = chatView.indexOf('useEffect(() => {', commentStart)
-  const effectEnd = chatView.indexOf('\n  useEffect(() => {', effectStart + 20)
-  assert.ok(commentStart >= 0 && effectStart > commentStart && effectEnd > effectStart,
-    'footer resize effect exists')
-  const footerEffect = chatView.slice(effectStart, effectEnd)
-
-  assert.match(footerEffect, /new ResizeObserver\(applySoon\)/)
-  assert.match(footerEffect, /composerResized\(\)/)
-  assert.doesNotMatch(footerEffect, /style\.setProperty|measureComposerHeight/,
-    'the footer observer must not bypass reader-gesture ownership')
-
-  const bridgeStart = controller.indexOf('function runComposerResize()')
-  const bridgeEnd = controller.indexOf('\n    composerResizeRunRef.current', bridgeStart)
-  assert.ok(bridgeStart >= 0 && bridgeEnd > bridgeStart, 'composer resize bridge exists')
-  const bridge = controller.slice(bridgeStart, bridgeEnd)
-  assert.match(bridge, /deferLayoutUntilReaderYields\(authorityVersion\)/)
-  assert.match(
-    bridge,
-    /syncLayout\(\{[\s\S]*?forceApply:\s*modeRef\.current\.kind === 'FOLLOW_BOTTOM',[\s\S]*?authorityVersion,[\s\S]*?\}\)/,
-    'composer growth must reapply an established tail follow in the same owner pass',
-  )
+test('footer resizes are owned by the scroll controller observer', () => {
+  assert.match(controller, /ro\.observe\(scrollEl\)/)
+  assert.match(controller, /ro\.observe\(footRef\.current\)/)
+  assert.doesNotMatch(controller, /querySelector\(['"]\.queued['"]\)/,
+    'footer descendants must not add duplicate geometry observers')
+  assert.doesNotMatch(chatView, /new ResizeObserver\(applySoon\)|composerResized/,
+    'ChatView must not bridge footer geometry through a second observer')
 })
 
 test('gesture settlement replays deferred footer geometry and mode in one task', () => {

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -1207,9 +1207,6 @@ export function modeForQueuedSubmission(scrollEl, currentMode) {
  *   growth stays on its ResizeObserver so streaming cannot settle a gesture.
  * @param {React.MutableRefObject<Array<object>>} args.messagesRef
  *   Synchronous mirror for restore-time anchor validation.
- * @param {number} args.pendingMessagesLength
- *   Count of queued messages (drives effect re-runs when the tray
- *   shows/hides because the tray's margin shrinks the spacer math).
  * @param {React.MutableRefObject<boolean>} args.loadingOlderRef
  *   When true, scroll events from pagination shouldn't mutate mode.
  * @param {'history'|'cache-validating'|'cached'|'stream-catchup'|'preparing'|'ready'} args.initialEntryPhase
@@ -1234,7 +1231,6 @@ export default function useScrollMode({
   footRef,
   messages,
   messagesRef,
-  pendingMessagesLength,
   loadingOlderRef,
   initialEntryPhase,
   onCachedCoordinateReady,
@@ -1313,11 +1309,8 @@ export default function useScrollMode({
   // paneResized() forwards to it (null when no scroll DOM is mounted). Mirrors
   // the forceRevealRef / resumeLayoutAfterGestureRef effect-bridge pattern.
   const paneResizeRunRef = useRef(null)
-  // Footer height changes are scroll geometry: `.chat__list` consumes the
-  // published composer height and the dynamic spacer compensates that padding.
-  // The observer in ChatView notifies this runner rather than writing the CSS
-  // variable itself, so both mutations share the reader-gesture gate.
-  const composerResizeRunRef = useRef(null)
+  // Footer height changes are scroll geometry: the controller observes the
+  // footer and publishes its list clearance in the same guarded transaction.
   // Controlled composer edits must publish their draft before a PIN -> FOLLOW
   // transition can render. React's change handler invokes this effect-owned
   // bridge after accepting the new value.
@@ -2029,23 +2022,6 @@ export default function useScrollMode({
       settlePinnedMode(authorityVersion)
       return true
     }
-    function runComposerResize() {
-      const authorityVersion = currentAuthority()
-      if (!layoutOwnsScroll(authorityVersion)) {
-        deferLayoutUntilReaderYields(authorityVersion)
-        return
-      }
-      // Foot growth changes list padding without necessarily changing the
-      // list's observed content box. Reapply an established live follow here;
-      // otherwise only the first new line moves the viewport and later lines
-      // quietly leave the reader above the tail.
-      syncLayout({
-        forceApply: modeRef.current.kind === 'FOLLOW_BOTTOM',
-        authorityVersion,
-      })
-    }
-    composerResizeRunRef.current = runComposerResize
-
     syncLayout({ authorityVersion: currentAuthority() })
 
     // Shell supplies committed pane geometry separately from viewport resize.
@@ -2200,9 +2176,11 @@ export default function useScrollMode({
       requestRevealOnQuiet()  // each RO firing pushes the reveal back
     })
     ro.observe(listEl)
-    ro.observe(scrollEl)  // catches form-row growth (file chips, queue tray)
-    const queuedTrayEl = scrollEl.parentElement?.querySelector('.queued')
-    if (queuedTrayEl) ro.observe(queuedTrayEl)
+    ro.observe(scrollEl)  // catches real scroll-viewport size changes
+    // Composer height is list clearance, so it belongs to this same observer
+    // transaction. Queue rows, file chips, and other footer content are all
+    // descendants, so observing them separately would duplicate this signal.
+    if (footRef.current) ro.observe(footRef.current)
     // ResizeObserver alone is not a sufficient reveal gate. It reports that a
     // box ALREADY changed size, so it cannot hold the reveal for asynchronous
     // renderers that have not started yet: KaTeX is loaded on demand and then
@@ -2646,9 +2624,6 @@ export default function useScrollMode({
       scrollEl.removeEventListener('error', requestRevealOnQuiet, true)
       ro.disconnect()
       if (paneResizeRunRef.current === runPaneResize) paneResizeRunRef.current = null
-      if (composerResizeRunRef.current === runComposerResize) {
-        composerResizeRunRef.current = null
-      }
       scrollEl.removeEventListener('scroll', onScroll)
       scrollEl.removeEventListener('scrollend', settleReaderScroll)
       scrollEl.removeEventListener('pointerdown', onPointerDownInput)
@@ -2669,7 +2644,6 @@ export default function useScrollMode({
     }
   }, [
     messageCount,
-    pendingMessagesLength,
     chatId,
     initialEntryPhase,
     onCachedCoordinateReady,
@@ -2827,10 +2801,6 @@ export default function useScrollMode({
     if (run) run(projectedHeightPx)
   }, [])
 
-  const composerResized = useCallback(() => {
-    composerResizeRunRef.current?.()
-  }, [])
-
   const composerEdited = useCallback((event) => {
     composerEditRunRef.current?.(event)
   }, [])
@@ -2848,7 +2818,6 @@ export default function useScrollMode({
     reapplyActiveMode,
     settleSendIntent,
     settleStreamingPin,
-    composerResized,
     composerEdited,
     paneResized,
   }

--- a/tests/spacer.spec.mjs
+++ b/tests/spacer.spec.mjs
@@ -1490,5 +1490,26 @@ test.describe('Scroll edge cases', () => {
     expect(Math.abs(
       result.afterFormerGestureCap.top - result.settledFrames.at(-1).top
     )).toBeLessThanOrEqual(4)
+
+    // Keyboard-animation resize signals may update the composer room, but the
+    // footer/scroll ResizeObserver remains the only transcript geometry owner.
+    const signalOnly = await page.evaluate(async () => {
+      const scroll = document.querySelector('[data-chat-surface="painted"] .chat__scroll')
+      scroll.scrollTop = Math.max(0, scroll.scrollTop - 12)
+      await new Promise(resolve => requestAnimationFrame(resolve))
+      const beforeSignal = Math.round(scroll.scrollTop)
+      window.dispatchEvent(new Event('resize'))
+      window.visualViewport?.dispatchEvent(new Event('resize'))
+      await new Promise(resolve => requestAnimationFrame(() => {
+        requestAnimationFrame(() => requestAnimationFrame(resolve))
+      }))
+      return {
+        mode: scroll.dataset.scrollMode,
+        beforeSignal,
+        afterSignal: Math.round(scroll.scrollTop),
+      }
+    })
+    expect(signalOnly.mode).toBe('FOLLOW_BOTTOM')
+    expect(signalOnly.afterSignal).toBe(signalOnly.beforeSignal)
   })
 })


### PR DESCRIPTION
## Summary
- make the scroll controller’s ResizeObserver the sole owner of footer and scroll-viewport geometry
- remove queue-length effect churn and the duplicate queued-tray observer
- keep composer-room sizing separate from transcript movement and retain deterministic coverage for keyboard resize signals

## Verification
- `npm test`
- `npm run lint` (43 existing warnings, no errors)
- `npm run build`
- focused local Playwright was unavailable because Docker is not installed; the PR E2E check covers `tests/spacer.spec.mjs`