### PR TITLE
Stabilize multiline question editing

### DIFF
--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -256,8 +256,8 @@ export default function ChatView({
   // Multi-pane workspace (design §2): when this chat renders inside a tiled
   // pane, Shell passes the pane's projected CONTENT height (pane rect minus the
   // strip). A change means a committed geometry event (divider commit,
-  // projection/mode flip, rotation, pane open/close) — forwarded to the scroll
-  // controller's paneResized() below. Null for a single-pane chat (today's
+  // projection/mode flip, rotation, pane open/close) — forwarded as a signal to
+  // the scroll controller's paneResized() below. Null for a single-pane chat (today's
   // behavior — the controller's own ResizeObserver owns resize there).
   paneContentHeight = null,
   // True when this mounted chat is hidden behind the full-workspace Settings
@@ -745,10 +745,10 @@ export default function ChatView({
   })
 
   // Forward committed pane-geometry changes to the scroll controller. A new
-  // projected height (divider commit, projection/mode flip, rotation) sets the
-  // layout-derived floor and re-applies the active mode under the reader gate
-  // (design §2). Skipped entirely for single-pane chats (paneContentHeight
-  // null) so today's resize behavior is untouched.
+  // projected height (divider commit, projection/mode flip, rotation) signals
+  // that the committed DOM geometry should re-apply the active mode under the
+  // reader gate (design §2). Skipped entirely for single-pane chats
+  // (paneContentHeight null) so today's resize behavior is untouched.
   //
   // Must be a layout effect: this is the only automatic scroll write in the
   // controller that would otherwise run after paint. Every other one is
@@ -757,7 +757,7 @@ export default function ChatView({
   // post-paint shows the reader a frame at the old scroll position before the
   // correction lands — visible as a jump when pane geometry changes.
   useLayoutEffect(() => {
-    if (paneContentHeight != null) paneResized(paneContentHeight)
+    if (paneContentHeight != null) paneResized()
   }, [paneContentHeight, paneResized])
 
   // A hidden retained owner is not an active runtime. The scroll controller

--- a/frontend/src/components/ChatView/QuestionCard.css
+++ b/frontend/src/components/ChatView/QuestionCard.css
@@ -227,7 +227,7 @@
 .qcard__input {
   display: block;
   width: 100%;
-  min-height: 38px;
+  height: 60px;
   margin-top: 10px;
   padding: 10px 11px;
   border-radius: 8px;
@@ -238,10 +238,8 @@
   font-family: inherit;
   line-height: 1.45;
   outline: none;
-  /* Unknown declarations are ignored, so older browsers fall through to the
-     measured QuestionCard.jsx path without a second CSS branch. */
-  field-sizing: content;
-  max-height: 180px;
+  /* Keep the card stable while writing. Longer answers scroll inside this
+     two-line surface instead of moving every control below it per newline. */
   overflow-y: auto;
   resize: none;
   box-sizing: border-box;
@@ -260,7 +258,8 @@
   border-color: var(--accent);
   box-shadow: 0 0 0 3px var(--accent-dim);
 }
-.qcard__input:disabled {
+.qcard__input:disabled,
+.qcard__input[readonly] {
   /* Keep the submitted custom answer readable but visibly settled. Safari
      otherwise preserves the active text color through -webkit-text-fill-color. */
   color: var(--muted);

--- a/frontend/src/components/ChatView/QuestionCard.jsx
+++ b/frontend/src/components/ChatView/QuestionCard.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import './QuestionCard.css'
 import {
   clearQuestionDraft,
@@ -6,7 +6,6 @@ import {
   readQuestionDraft,
   writeQuestionDraft,
 } from './questionDraft.js'
-import { textareaUsesNativeSizing } from './composerTextareaSizing.js'
 import {
   pointerSelectionChangedWithin,
   textSelectionSnapshot,
@@ -23,20 +22,6 @@ function resolveAnswer(answer, otherText) {
 }
 
 
-const CUSTOM_ANSWER_MAX_HEIGHT = 180
-
-
-function resizeCustomAnswer(textarea) {
-  if (!textarea || textareaUsesNativeSizing()) return
-  textarea.style.height = 'auto'
-  const contentHeight = textarea.scrollHeight
-  textarea.style.height = `${Math.min(contentHeight, CUSTOM_ANSWER_MAX_HEIGHT)}px`
-  textarea.style.overflowY = contentHeight > CUSTOM_ANSWER_MAX_HEIGHT
-    ? 'auto'
-    : 'hidden'
-}
-
-
 function CustomAnswerArea({
   active,
   answered,
@@ -46,48 +31,17 @@ function CustomAnswerArea({
   question,
   value,
 }) {
-  const textareaRef = useRef(null)
-
-  // The fallback re-measures both while writing and when a live answer becomes
-  // its confirmed transcript value. Native content sizing takes this no-op
-  // path and keeps the same natural height through the submission handoff.
-  useLayoutEffect(() => {
-    resizeCustomAnswer(textareaRef.current)
-  }, [value])
-
-  // Older browsers still need measured fallback sizing. scrollHeight depends
-  // on WIDTH, so re-measure when the field settles or later changes width. The
-  // guard makes our own height write a no-op resize instead of a loop.
-  useEffect(() => {
-    const textarea = textareaRef.current
-    if (
-      !textarea
-      || textareaUsesNativeSizing()
-      || typeof ResizeObserver === 'undefined'
-    ) return undefined
-    let lastWidth = -1
-    const observer = new ResizeObserver(() => {
-      const width = textarea.clientWidth
-      if (width === lastWidth) return
-      lastWidth = width
-      resizeCustomAnswer(textarea)
-    })
-    observer.observe(textarea)
-    return () => observer.disconnect()
-  }, [])
-
   return (
     <textarea
-      ref={textareaRef}
       className={`qcard__input${active ? ' qcard__input--active' : ''}`}
-      data-chat-scroll-edit-field
       aria-label={`Custom answer for: ${question}`}
       placeholder={answered ? 'No custom answer' : 'Or type your own answer…'}
       autoComplete="off"
-      rows={1}
+      rows={2}
       value={value}
       onChange={e => onChange(e.target.value)}
-      disabled={disabled}
+      readOnly={answered}
+      disabled={disabled && !answered}
       onKeyDown={e => {
         if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
           e.preventDefault()

--- a/frontend/src/components/ChatView/__tests__/framePipelineQuiescence.test.js
+++ b/frontend/src/components/ChatView/__tests__/framePipelineQuiescence.test.js
@@ -102,7 +102,7 @@ function enclosingEffectHook(source, needle) {
 
 test('pane resize correction runs before paint', () => {
   assert.equal(
-    enclosingEffectHook(chatView, 'paneResized(paneContentHeight)'),
+    enclosingEffectHook(chatView, 'if (paneContentHeight != null) paneResized()'),
     'useLayoutEffect',
     'a post-paint pane-resize correction shows one frame at the stale scroll position',
   )

--- a/frontend/src/components/ChatView/__tests__/questionCardState.test.js
+++ b/frontend/src/components/ChatView/__tests__/questionCardState.test.js
@@ -4,7 +4,6 @@ import assert from 'node:assert/strict'
 
 const component = readFileSync(new URL('../QuestionCard.jsx', import.meta.url), 'utf8')
 const chatView = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8')
-const scrollMode = readFileSync(new URL('../useScrollMode.js', import.meta.url), 'utf8')
 const css = readFileSync(new URL('../QuestionCard.css', import.meta.url), 'utf8')
 
 test('question option explanations remain selectable without choosing them', () => {
@@ -39,22 +38,12 @@ test('unanswered question cards do not have a stale gray state', () => {
     'a custom answer should be a direct writing surface, not an Other option')
   assert.match(component, /<CustomAnswerArea[\s\S]*?answered=\{answered\}[\s\S]*?value=\{answered[\s\S]*?unmatchedAnswers\.join\(', '\)/,
     'the custom answer should stay mounted and retain submitted custom text')
-  assert.match(component, /rows=\{1\}/,
-    'the custom answer should begin as a single line')
-  assert.match(component, /data-chat-scroll-edit-field/,
-    'the custom answer should publish its native caret-scroll ownership')
-  assert.doesNotMatch(component, /onInput=\{e => resizeCustomAnswer/,
-    'one post-commit measurement should own growth instead of resizing twice per edit')
-  assert.match(component, /if \(!textarea \|\| textareaUsesNativeSizing\(\)\) return/,
-    'current browsers should not run a per-character height measurement cycle')
-  assert.match(component, /textarea\.style\.height = 'auto'[\s\S]*?Math\.min\(contentHeight, CUSTOM_ANSWER_MAX_HEIGHT\)/,
-    'the older-browser fallback should grow with content up to the phone-safe cap')
-  assert.match(component, /useLayoutEffect\(\(\) => \{\s*resizeCustomAnswer\(textareaRef\.current\)\s*\}, \[value\]\)/,
-    'confirmed answer values should retain their natural content height')
-  assert.match(component, /textareaUsesNativeSizing\(\)[\s\S]*?new ResizeObserver\(\(\) => \{[\s\S]*?const width = textarea\.clientWidth[\s\S]*?if \(width === lastWidth\) return[\s\S]*?resizeCustomAnswer\(textarea\)/,
-    'only the measured fallback should observe width changes')
-  assert.match(component, /observer\.observe\(textarea\)[\s\S]*?return \(\) => observer\.disconnect\(\)/,
-    'the width observer should be released with the answered card')
+  assert.match(component, /rows=\{2\}/,
+    'the custom answer should provide two stable writing lines')
+  assert.match(component, /readOnly=\{answered\}[\s\S]*?disabled=\{disabled && !answered\}/,
+    'a submitted multiline answer should stay scrollable but not editable')
+  assert.doesNotMatch(component, /resizeCustomAnswer|textareaUsesNativeSizing|data-chat-scroll-edit-field/,
+    'the question editor should not grow the transcript or install a second scroll owner')
   assert.match(component, /e\.key === 'Enter' && \(e\.metaKey \|\| e\.ctrlKey\)/,
     'plain Enter should create a new line while the explicit shortcut submits')
   assert.match(component, /val\.replace\(\/\\n\/g, '\\n  '\)/,
@@ -82,10 +71,10 @@ test('question card css has no stale styling hook', () => {
     'stale question styling should not come back')
   assert.doesNotMatch(css, /\.qcard__status\s*\{[\s\S]*?\}/,
     'expiration status styling should not come back')
-  assert.match(css, /\.qcard__input:disabled\s*\{[\s\S]*?color:\s*var\(--muted\);[\s\S]*?-webkit-text-fill-color:\s*var\(--muted\);[\s\S]*?\}/,
+  assert.match(css, /\.qcard__input:disabled,\s*\.qcard__input\[readonly\]\s*\{[\s\S]*?color:\s*var\(--muted\);[\s\S]*?-webkit-text-fill-color:\s*var\(--muted\);[\s\S]*?\}/,
     'a submitted custom answer should visibly gray out in every browser')
-  assert.match(css, /\.qcard__input\s*\{[\s\S]*?width:\s*100%;[\s\S]*?min-height:\s*38px;[\s\S]*?field-sizing:\s*content;[\s\S]*?overflow-y:\s*auto;[\s\S]*?resize:\s*none;/,
-    'the custom answer should span the card and begin as a single growing line')
+  assert.match(css, /\.qcard__input\s*\{[\s\S]*?width:\s*100%;[\s\S]*?height:\s*60px;[\s\S]*?overflow-y:\s*auto;[\s\S]*?resize:\s*none;/,
+    'the custom answer should span the card and scroll internally at a stable height')
   assert.match(css, /\.qcard__submit-error\s*\{/,
     'a failed answer should keep its retry notice attached to the card')
 })
@@ -98,24 +87,6 @@ test('multiple questions read as one compact decision panel', () => {
   assert.match(css, /\.qcard\s*\{[\s\S]*?width:\s*min\(100%, 640px\);[\s\S]*?margin:\s*10px auto;/)
   assert.match(css, /\.qcard--grouped\s*\{[\s\S]*?overflow:\s*hidden;/)
   assert.match(css, /\.qcard--grouped \.qcard__q \+ \.qcard__q\s*\{[\s\S]*?margin-top:\s*0;/)
-})
-
-test('question editing lets native caret movement settle before layout reclaims scroll', () => {
-  assert.match(
-    scrollMode,
-    /addEventListener\('beforeinput', onQuestionEditMutation[\s\S]*?addEventListener\('input', onQuestionEditMutation/,
-    'all text mutation paths should enter the shared reader-ownership gate',
-  )
-  assert.match(
-    scrollMode,
-    /onQuestionEditMutation[\s\S]*?!isOrdinaryReadingHold\(modeRef\.current\)\) return[\s\S]*?onUserInput\(event\)/,
-    'tail-follow and other stronger modes must keep layout ownership while the field grows',
-  )
-  assert.match(
-    scrollMode,
-    /questionSubmissionWasActive[\s\S]*?editingAnchor = questionEditSessionRef\.current[\s\S]*?!questionSubmissionWasActive/,
-    'the editing rebase must never replace the established submission overlay',
-  )
 })
 
 test('a failed question submission does not append a transcript row', () => {

--- a/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
+++ b/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
@@ -23,7 +23,6 @@ import {
   modeForDisclosureToggle,
   modeForForegroundReturn,
   modeForQuestionSubmission,
-  modeForQuestionEditingViewportChange,
   modeForQueuedSubmission,
   modeAfterReaderGesture,
   modeAfterSpacerResize,
@@ -728,7 +727,7 @@ test('anchor reapply is inert for non-anchor modes and unresolved keys', () => {
 test('viewport resize reapplies the current mode without reclassifying it', () => {
   assert.match(
     scrollModeSource,
-    /const ordinaryViewportMode = modeRef\.current/,
+    /transitionMode\(\s*modeRef\.current,\s*'layout:viewport-change'/,
     'keyboard geometry keeps the existing pin, follow, or exact anchor',
   )
   assert.doesNotMatch(
@@ -740,46 +739,6 @@ test('viewport resize reapplies the current mode without reclassifying it', () =
     scrollModeSource,
     /visualViewport\.addEventListener/,
     'chat observes its actual resized box instead of racing Shell for the browser event',
-  )
-})
-
-test('question editing rebases only an ordinary held viewport to native caret movement', () => {
-  const staleHold = { kind: 'ANCHOR_AT', key: 'before-edit', offset: 20 }
-  const caretHold = { kind: 'ANCHOR_AT', key: 'question-row', offset: 84 }
-  assert.equal(
-    modeForQuestionEditingViewportChange(staleHold, caretHold),
-    caretHold,
-    'the visible caret-adjusted position becomes the new ordinary hold',
-  )
-
-  for (const strongerMode of [
-    { kind: 'PIN_USER_MSG', cid: 'c-1' },
-    { kind: 'HOLD_RESERVED_TAIL', cid: 'c-1' },
-    { kind: 'FOLLOW_BOTTOM' },
-    {
-      kind: 'ANCHOR_AT',
-      key: 'question-row',
-      offset: 84,
-      questionSubmitViewportH: 600,
-      questionSubmitBaseMode: { kind: 'FOLLOW_BOTTOM' },
-    },
-  ]) {
-    assert.equal(
-      modeForQuestionEditingViewportChange(strongerMode, caretHold),
-      strongerMode,
-      `${strongerMode.kind} must keep its existing ownership contract`,
-    )
-  }
-  assert.equal(
-    modeForQuestionEditingViewportChange(staleHold, null),
-    staleHold,
-    'an unresolved visible anchor never invents a new location',
-  )
-  const settledHold = { kind: 'ANCHOR_AT', key: 'question-row', offset: 84 }
-  assert.equal(
-    modeForQuestionEditingViewportChange(settledHold, { ...settledHold }),
-    settledHold,
-    'an unchanged caret hold does not manufacture a mode transition',
   )
 })
 

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -804,26 +804,6 @@ export function isNearContentBottom(scrollEl, threshold = NEAR_BOTTOM_PX) {
 }
 
 
-/** The plain reading-position hold, excluding the question-submission overlay
- * that uses the same ANCHOR_AT shape with a stronger transient contract. */
-export function isOrdinaryReadingHold(mode) {
-  return mode?.kind === 'ANCHOR_AT'
-    && !Number.isFinite(mode.questionSubmitViewportH)
-}
-
-/** A focused, content-growing question field gives the browser temporary
- * ownership of caret visibility. If that native adjustment moved an ordinary
- * held viewport, rebase the hold to what is visible now instead of restoring
- * the stale pre-edit anchor. Send pins, reserved-tail holds, live following,
- * and the submission overlay keep their stronger contracts. */
-export function modeForQuestionEditingViewportChange(mode, anchorMode = null) {
-  if (!isOrdinaryReadingHold(mode) || !anchorMode) return mode
-  if (mode.key === anchorMode.key
-      && Math.abs(mode.offset - anchorMode.offset) <= 0.5) return mode
-  return anchorMode
-}
-
-
 /** Advance an armed live pin to tail-follow exactly when its reserved reply
  * room is exhausted. Settled/restored pins omit `followWhenFilled`, so later
  * viewport or lazy-layout changes cannot manufacture follow intent. */
@@ -1278,10 +1258,6 @@ export default function useScrollMode({
   // once a newer gesture lands, older work can never regain ownership merely
   // because the gesture timing window later closes.
   const readerIntentVersionRef = useRef(0)
-  // Largest committed pane height for the current geometry. Spacer sizing is
-  // intentionally based on the active scroll box instead; this reference only
-  // tells a focused Q&A edit when the keyboard has fully closed again.
-  const fullPaneHRef = useRef(0)
   // The chat reacts to the size of its actual scroll viewport, after Shell has
   // reconciled any visual-viewport overlay. Keeping the last observed height
   // across effect re-runs makes ResizeObserver the one keyboard/layout signal
@@ -1302,9 +1278,6 @@ export default function useScrollMode({
   // last apply, so the post-reveal anchor clamp-repair only fires on a real
   // shift/clamp (design §2). Null when no anchor is active.
   const lastAnchorTopRef = useRef(null)
-  // A committed pane resize can lower the keyboard-closed height. Defer that
-  // value with the layout transaction when reader input currently owns scroll.
-  const pendingFullPaneHeightRef = useRef(null)
   // Set inside the layout effect to the live pane-resize runner; the returned
   // paneResized() forwards to it (null when no scroll DOM is mounted). Mirrors
   // the forceRevealRef / resumeLayoutAfterGestureRef effect-bridge pattern.
@@ -1315,12 +1288,6 @@ export default function useScrollMode({
   // transition can render. React's change handler invokes this effect-owned
   // bridge after accepting the new value.
   const composerEditRunRef = useRef(null)
-  // A custom Q&A field can grow while the phone browser is also moving its
-  // visual viewport to keep the caret above the keyboard. Keep that native
-  // editing lifecycle visible across focusout until the keyboard has returned
-  // to the full pane height; otherwise the controller can restore a stale
-  // anchor between viewport-animation frames and make the card oscillate.
-  const questionEditSessionRef = useRef(false)
   const initialEntryPhaseRef = useRef(initialEntryPhase)
   initialEntryPhaseRef.current = initialEntryPhase
   // A normal reveal ends entry stabilization. A forced safety-cap reveal keeps
@@ -1869,19 +1836,6 @@ export default function useScrollMode({
       if (chatRef.current && Number.isFinite(composerHeight)) {
         chatRef.current.style.setProperty('--composer-h', `${composerHeight}px`)
       }
-      // Keep the keyboard-closed pane reference current for the focused Q&A
-      // editing lifecycle. A committed pane resize may lower that reference;
-      // ordinary viewport changes only grow it, so a keyboard opening cannot
-      // masquerade as the new full pane. This value no longer sizes the spacer:
-      // reservation follows the active visible scroll box below.
-      if (pendingFullPaneHeightRef.current != null) {
-        const ph = pendingFullPaneHeightRef.current
-        if (Number.isFinite(ph) && ph > 0) fullPaneHRef.current = ph
-        pendingFullPaneHeightRef.current = null
-      }
-      if (scrollEl.clientHeight > fullPaneHRef.current) {
-        fullPaneHRef.current = scrollEl.clientHeight
-      }
       // A sent row remounts when its optimistic identity becomes canonical.
       // Read the mounted last-user row while its React ref reattaches so that
       // brief handoff cannot collapse the reservation to zero.
@@ -1956,9 +1910,6 @@ export default function useScrollMode({
       viewportChange = false,
       authorityVersion = currentAuthority(),
     } = {}) {
-      const questionSubmissionWasActive = viewportChange
-        && modeRef.current?.kind === 'ANCHOR_AT'
-        && Number.isFinite(modeRef.current.questionSubmitViewportH)
       // Question submission freezes the card-to-stream handoff, not the
       // keyboard. Restore the unanswered card's mode before sizing a changed
       // viewport so its ordinary reservation and clamp remain authoritative.
@@ -1981,26 +1932,12 @@ export default function useScrollMode({
       }
       sizeSpacer(authorityVersion)
       if (viewportChange) {
-        const editingAnchor = questionEditSessionRef.current
-          && !questionSubmissionWasActive
-          ? anchorModeFromScroll(scrollEl)
-          : null
         // A viewport resize is geometry, not reading intent. Reapply the mode
         // that already owns the chat instead of deriving a different mode from
-        // the browser's intermediate clamp. Only native Q&A caret movement may
-        // deliberately rebase an ordinary hold.
-        const ordinaryViewportMode = modeRef.current
-        const editingViewportMode = editingAnchor
-          ? modeForQuestionEditingViewportChange(ordinaryViewportMode, editingAnchor)
-          : ordinaryViewportMode
-        if (editingViewportMode !== ordinaryViewportMode) {
-          readerLocationExplicitRef.current = true
-        }
+        // the browser's intermediate clamp.
         transitionMode(
-          editingViewportMode,
-          editingViewportMode !== ordinaryViewportMode
-            ? 'layout:question-edit-viewport'
-            : 'layout:viewport-change',
+          modeRef.current,
+          'layout:viewport-change',
         )
         persistMode()
         applyLayoutMode('layout:viewport-change', authorityVersion)
@@ -2025,9 +1962,9 @@ export default function useScrollMode({
     syncLayout({ authorityVersion: currentAuthority() })
 
     // Shell supplies committed pane geometry separately from viewport resize.
-    // Its projected full height keeps Q&A keyboard-close detection honest even
-    // when the pane itself changes while the keyboard is open.
-    function runPaneResize(projectedHeightPx) {
+    // The signal distinguishes a deliberate workspace reflow from a transient
+    // visual-viewport change; the committed DOM is the geometry authority.
+    function runPaneResize() {
       const authorityVersion = currentAuthority()
       // This committed pane change has its own explicit owner. Adopt the DOM's
       // resulting scroll-box height now so the ResizeObserver delivery that
@@ -2036,12 +1973,8 @@ export default function useScrollMode({
         element: scrollEl,
         height: scrollEl.clientHeight,
       }
-      pendingFullPaneHeightRef.current =
-        (Number.isFinite(projectedHeightPx) && projectedHeightPx > 0)
-          ? projectedHeightPx
-          : pendingFullPaneHeightRef.current
       if (!layoutOwnsScroll(authorityVersion)) {
-        // Keep projected pane height, spacer, and mode in one replayable pass.
+        // Keep spacer and mode in one replayable pass.
         deferLayoutUntilReaderYields(authorityVersion)
         return
       }
@@ -2138,11 +2071,6 @@ export default function useScrollMode({
           viewportChange: true,
           authorityVersion,
         })
-        if (questionEditSessionRef.current
-            && !questionEditField(document.activeElement)
-            && scrollEl.clientHeight >= fullPaneHRef.current - 1) {
-          questionEditSessionRef.current = false
-        }
         requestRevealOnQuiet()
         return
       }
@@ -2295,24 +2223,6 @@ export default function useScrollMode({
         releasePendingGesture(sequence)
       })
     }
-    const scheduleQuestionEditNoScrollRelease = () => {
-      if (gestureWindowUntilRef.current !== Number.POSITIVE_INFINITY
-          || readerScrollDirty) return
-      // Q&A mutation changes DOM height after the input event. Hold ownership
-      // through one complete rendered frame so ResizeObserver and the browser's
-      // native caret reveal can settle before a no-scroll input gives layout
-      // writes back. This is a layout handshake, not a guessed delay.
-      const sequence = gestureSequenceRef.current
-      cancelAnimationFrame(pendingGestureReleaseRafRef.current)
-      pendingGestureReleaseRafRef.current = requestAnimationFrame(() => {
-        if (gestureSequenceRef.current !== sequence
-            || gestureWindowUntilRef.current !== Number.POSITIVE_INFINITY) return
-        pendingGestureReleaseRafRef.current = requestAnimationFrame(() => {
-          pendingGestureReleaseRafRef.current = 0
-          releasePendingGesture(sequence)
-        })
-      })
-    }
     const onUserInput = (event) => {
       const activatesDisclosure = readerInputActivatesDisclosure(
         event?.type,
@@ -2383,49 +2293,6 @@ export default function useScrollMode({
         )) {
         scheduleNoScrollRelease()
       }
-    }
-    const questionEditField = (target) => target?.matches?.(
-      'textarea[data-chat-scroll-edit-field]',
-    ) ? target : null
-    const onQuestionEditFocusIn = (event) => {
-      if (questionEditField(event.target)) {
-        questionEditSessionRef.current = true
-        return
-      }
-      // Moving directly into another writing surface usually keeps the same
-      // keyboard open. That new field owns any later caret/viewport movement;
-      // do not leave the Q&A session waiting for a full-height close that will
-      // not happen during this focus transfer.
-      if (questionEditSessionRef.current && event.target?.matches?.(
-        'textarea, input, [contenteditable="true"], [role="textbox"]',
-      )) {
-        questionEditSessionRef.current = false
-      }
-    }
-    const onQuestionEditFocusOut = (event) => {
-      if (!questionEditField(event.target)) return
-      if (questionEditField(event.relatedTarget)) {
-        questionEditSessionRef.current = true
-        return
-      }
-      if (scrollEl.clientHeight >= fullPaneHRef.current - 1) {
-        questionEditSessionRef.current = false
-      }
-    }
-    const onQuestionEditMutation = (event) => {
-      if (!questionEditField(event.target)) return
-      questionEditSessionRef.current = true
-      // Stronger modes already know where this resize belongs. In particular,
-      // FOLLOW_BOTTOM must absorb the new line in the same ResizeObserver pass
-      // instead of yielding for two painted frames and then snapping back.
-      if (!isOrdinaryReadingHold(modeRef.current)) return
-      if (layoutMayOwnScroll(
-        gestureWindowUntilRef.current,
-        performance.now(),
-      )) {
-        onUserInput(event)
-      }
-      scheduleQuestionEditNoScrollRelease()
     }
     // Reuse the exact input handler when the opt-in field probe is disabled;
     // the hot path then carries no timing closure or extra wrapper.
@@ -2526,10 +2393,6 @@ export default function useScrollMode({
     scrollEl.addEventListener('pointermove', onPointerMoveInput, { passive: true })
     scrollEl.addEventListener('wheel', onWheelInput, { passive: true })
     scrollEl.addEventListener('keydown', onUserInput, { passive: true })
-    scrollEl.addEventListener('focusin', onQuestionEditFocusIn, { passive: true })
-    scrollEl.addEventListener('focusout', onQuestionEditFocusOut, { passive: true })
-    scrollEl.addEventListener('beforeinput', onQuestionEditMutation, { passive: true })
-    scrollEl.addEventListener('input', onQuestionEditMutation, { passive: true })
     scrollEl.addEventListener('pointerup', onPointerUpInput, { passive: true })
     scrollEl.addEventListener('pointercancel', onPointerCancelInput, { passive: true })
     chatEl?.addEventListener('pointerdown', onComposerPointerDown, { passive: true })
@@ -2630,10 +2493,6 @@ export default function useScrollMode({
       scrollEl.removeEventListener('pointermove', onPointerMoveInput)
       scrollEl.removeEventListener('wheel', onWheelInput)
       scrollEl.removeEventListener('keydown', onUserInput)
-      scrollEl.removeEventListener('focusin', onQuestionEditFocusIn)
-      scrollEl.removeEventListener('focusout', onQuestionEditFocusOut)
-      scrollEl.removeEventListener('beforeinput', onQuestionEditMutation)
-      scrollEl.removeEventListener('input', onQuestionEditMutation)
       scrollEl.removeEventListener('pointerup', onPointerUpInput)
       scrollEl.removeEventListener('pointercancel', onPointerCancelInput)
       chatEl?.removeEventListener('pointerdown', onComposerPointerDown)
@@ -2796,9 +2655,9 @@ export default function useScrollMode({
   // (design §2). A stable identity is required — ChatView wires it to a
   // prop-change effect. Forwards to the live in-effect runner; no-op before the
   // scroll DOM mounts (single-pane chats never call it).
-  const paneResized = useCallback((projectedHeightPx) => {
+  const paneResized = useCallback(() => {
     const run = paneResizeRunRef.current
-    if (run) run(projectedHeightPx)
+    if (run) run()
   }, [])
 
   const composerEdited = useCallback((event) => {

--- a/tests/chat-redesign.spec.mjs
+++ b/tests/chat-redesign.spec.mjs
@@ -29,8 +29,12 @@ function fulfillStartedPost(route) {
 
 /** Helper: log in via the storageState set by auth.setup.mjs and
  *  install a default route mock that returns 204 for /stream. */
-async function setupWithStreamMock(page, streamBody) {
-  await page.setViewportSize({ width: 412, height: 915 })
+async function setupWithStreamMock(
+  page,
+  streamBody,
+  viewport = { width: 412, height: 915 },
+) {
+  await page.setViewportSize(viewport)
   await page.route(/\/api\/chats\/[0-9a-f-]+\/messages$/, route =>
     fulfillStartedPost(route)
   )
@@ -261,7 +265,8 @@ test.describe('Bug 1: AskUserQuestion', () => {
     await expect(page.getByRole('button', { name: 'Submitted' })).toBeDisabled()
     await expect(card.locator('.qcard__hint')).toHaveText('Choose one')
     await expect(card.locator('.qcard__opt')).toHaveCount(2)
-    await expect(customAnswer).toBeDisabled()
+    await expect(customAnswer).toHaveAttribute('readonly', '')
+    await expect(customAnswer).not.toBeEditable()
     await expect(customAnswer).toHaveValue('Take the quiet streets')
 
     const after = await geometry()
@@ -275,6 +280,73 @@ test.describe('Bug 1: AskUserQuestion', () => {
     expect(after.input.color).not.toBe(before.input.color)
     expect(after.input.textFillColor).toBe(after.input.color)
     expect(after.submitTop).toBeCloseTo(before.submitTop, 5)
+  })
+
+
+  test('multiline custom answers scroll inside a steady phone-sized card', async ({ page }) => {
+    const streamBody = [
+      `data: ${JSON.stringify({
+        type: 'question',
+        question_id: 'q-steady-multiline',
+        questions: [{
+          question: 'Describe the change',
+          header: 'Details',
+          multiSelect: false,
+          options: [
+            { label: 'Small', description: 'Keep the change focused' },
+            { label: 'Broad', description: 'Cover the surrounding behavior' },
+          ],
+        }],
+      })}\n\n`,
+      'data: {"type":"done"}\n\n',
+    ].join('')
+    await setupWithStreamMock(page, streamBody, { width: 426, height: 510 })
+    await newChat(page)
+    await sendMessage(page, 'Ask for multiline details')
+
+    const card = page.locator('[data-chat-surface="painted"] .qcard')
+    const customAnswer = card.getByRole('textbox', {
+      name: 'Custom answer for: Describe the change',
+    })
+    await expect(card).toBeVisible({ timeout: 5000 })
+    await customAnswer.focus()
+
+    const geometry = () => card.evaluate(el => {
+      const scroll = el.closest('.chat__scroll')
+      const input = el.querySelector('.qcard__input')
+      const option = el.querySelector('.qcard__opt')
+      const submit = el.querySelector('.qcard__submit')
+      const rect = node => node?.getBoundingClientRect()
+      return {
+        cardHeight: rect(el)?.height,
+        inputHeight: rect(input)?.height,
+        inputTop: rect(input)?.top,
+        inputScrollTop: input?.scrollTop,
+        optionTop: rect(option)?.top,
+        submitTop: rect(submit)?.top,
+        chatScrollTop: scroll?.scrollTop,
+      }
+    })
+
+    const before = await geometry()
+    await customAnswer.pressSequentially('First line')
+    await page.keyboard.press('Enter')
+    await customAnswer.pressSequentially('Second line')
+    await page.keyboard.press('Enter')
+    await customAnswer.pressSequentially('Third line')
+    await page.evaluate(() => new Promise(resolve => (
+      requestAnimationFrame(() => requestAnimationFrame(resolve))
+    )))
+    const after = await geometry()
+
+    await expect(customAnswer).toHaveValue('First line\nSecond line\nThird line')
+    expect(after.cardHeight).toBeCloseTo(before.cardHeight, 5)
+    expect(after.inputHeight).toBeCloseTo(before.inputHeight, 5)
+    expect(after.inputTop).toBeCloseTo(before.inputTop, 5)
+    expect(after.optionTop).toBeCloseTo(before.optionTop, 5)
+    expect(after.submitTop).toBeCloseTo(before.submitTop, 5)
+    expect(after.chatScrollTop).toBeCloseTo(before.chatScrollTop, 5)
+    expect(after.inputScrollTop).toBeGreaterThan(before.inputScrollTop)
   })
 
 


### PR DESCRIPTION
## Summary
- let multiline custom answers use a stable two-row native field instead of continuously rewriting its height
- keep confirmed answers readable and selectable without leaving them editable
- remove the question-specific viewport ownership path so the shared scroll controller remains the single geometry owner
- preserve the newer controlled-composer edit bridge while porting the live simplification

## Verification
- full frontend unit and hook suites
- frontend lint
- production frontend build
- expanded browser coverage for multiline editing, confirmation, keyboard submission, and scroll stability