### PR TITLE
Bind catalog updates to proven install identity

### DIFF
--- a/backend/app/app_git.py
+++ b/backend/app/app_git.py
@@ -1294,6 +1294,17 @@ def restore_upstream_ref(source_dir: str | Path, expected_sha: str | None) -> bo
   return True
 
 
+def origin_url(source_dir: str | Path) -> str | None:
+  """Return this app repo's configured ``origin`` URL, if available."""
+  if not is_repo(source_dir):
+    return None
+  proc = _run(
+    Path(source_dir), "remote", "get-url", "origin", check=False,
+  )
+  value = proc.stdout.strip()
+  return value if proc.returncode == 0 and value else None
+
+
 def has_origin(source_dir: str | Path) -> bool:
   """Whether this app repo has a real `origin` remote.
 
@@ -1301,12 +1312,7 @@ def has_origin(source_dir: str | Path) -> bool:
   `record_upstream` does not. Treat any git failure as false so callers can
   fall back to the synthetic path unchanged.
   """
-  if not is_repo(source_dir):
-    return False
-  proc = _run(
-    Path(source_dir), "remote", "get-url", "origin", check=False,
-  )
-  return proc.returncode == 0
+  return origin_url(source_dir) is not None
 
 
 def clone_upstream(

--- a/backend/app/bootstrap.py
+++ b/backend/app/bootstrap.py
@@ -99,37 +99,23 @@ async def ensure_bootstrap_apps_installed(db: Session) -> None:
     log.info("bootstrap: %s=1, skipping bootstrap app installs", _SKIP_ENV)
     return
 
-  # Manifest installs store the canonical identity key
-  # (`<base>#manifest-id=<id>`, with a trailing `/mobius.json` stripped from the
-  # base), not the bare URL.
-  from app.install import _canonical_base, _trusted_catalog_repo_base
+  # Bootstrap uses the same resolver as preview and install so all three paths
+  # agree on persisted identities, moved refs, and proven legacy origins.
+  from app.install import _find_install_identity_row
 
   for bootstrap_app in _BOOTSTRAP_APPS:
-    # A trusted mobius-os catalog app's identity is its REPO, not the pinned
-    # `<ref>`: match any revision so a pin bump (or the original branch install)
-    # resolves to the SAME row. Without this the presence check keys on the new
-    # commit's base, misses a row installed at an older ref, and either
-    # duplicates the app or — for a `reinstall_after_uninstall=False` app whose
-    # owner uninstalled it — misses the tombstone and silently reinstalls.
-    repo_base = _trusted_catalog_repo_base(bootstrap_app.manifest_url)
-    if repo_base is not None:
-      pattern = repo_base + "/%#manifest-id=%"
-    else:
-      pattern = _canonical_base(bootstrap_app.manifest_url) + "#manifest-id=%"
-    query = db.query(models.App).filter(models.App.manifest_url.like(pattern))
-    if bootstrap_app.reinstall_after_uninstall:
-      # The store is the recovery surface, so it must return after uninstall;
-      # owner uninstalls of the other bootstrap apps are respected (the query is
-      # otherwise tombstone-agnostic, so a tombstone counts as "present").
-      query = query.filter(models.App.deleted_at.is_(None))
-    # Re-verify in Python: SQL LIKE treats `_` as a wildcard, and a ref may
-    # contain one; the repo-base check rejects any incidental over-match.
-    existing = None
-    for row in query.all():
-      if repo_base is None or _trusted_catalog_repo_base(row.manifest_url) == repo_base:
-        existing = row
-        break
-    if existing is not None:
+    # Use the installer's identity resolver here too: bootstrap and an explicit
+    # Store action must agree across ref moves and legacy rows whose matching
+    # catalog origin predates persisted manifest identity.
+    existing = _find_install_identity_row(
+      db,
+      source_url=bootstrap_app.manifest_url,
+      manifest_id=bootstrap_app.name,
+    )
+    if existing is not None and (
+      existing.deleted_at is None
+      or not bootstrap_app.reinstall_after_uninstall
+    ):
       log.info(
         "bootstrap: %s already installed (app id=%s)",
         bootstrap_app.name, existing.id,

--- a/backend/app/install.py
+++ b/backend/app/install.py
@@ -398,6 +398,84 @@ def _find_ref_independent_catalog_row(
   return None
 
 
+def _find_trusted_origin_catalog_row(
+  db: Session,
+  canonical_manifest_url: str,
+  manifest_id: str,
+  manifest_url: str,
+) -> models.App | None:
+  """Adopt a legacy local row only when its Git origin proves identity.
+
+  Before catalog identity was persisted, an app could be built from the
+  canonical repository yet retain ``manifest_url=NULL``. Slug equality alone
+  is never enough to adopt owner data: a catalog package may legitimately use
+  the same id as an unrelated local app. For the narrow trusted root-catalog
+  shape, an exact canonical ``origin`` URL is the missing durable witness.
+  """
+  if _trusted_catalog_repo_base(canonical_manifest_url) is None:
+    return None
+  repo_ref = _derive_repo_ref(manifest_url)
+  if repo_ref is None:
+    return None
+  expected_origin, _ref = repo_ref
+  candidate = (
+    db.query(models.App)
+    .filter(
+      models.App.slug == manifest_id,
+      models.App.manifest_url.is_(None),
+    )
+    .first()
+  )
+  if candidate is None:
+    return None
+  actual_origin = app_git.origin_url(candidate.source_dir)
+  if actual_origin is None:
+    return None
+  return candidate if actual_origin.rstrip("/") == expected_origin.rstrip("/") else None
+
+
+def _find_install_identity_row(
+  db: Session,
+  *,
+  source_url: str,
+  manifest_id: str,
+) -> models.App | None:
+  """Resolve exact, moved-ref, and proven legacy catalog identities."""
+  canonical = _canonical_identity_key(source_url, manifest_id)
+  existing = (
+    db.query(models.App)
+    .filter(models.App.manifest_url == canonical)
+    .first()
+  )
+  if existing is None:
+    existing = _find_ref_independent_catalog_row(db, canonical, manifest_id)
+  if existing is None:
+    existing = _find_trusted_origin_catalog_row(
+      db, canonical, manifest_id, source_url,
+    )
+  return existing
+
+
+def _catalog_identity_matches(
+  existing_identity: str | None,
+  candidate_url: str,
+  manifest_id: str,
+) -> bool:
+  """Whether a reviewed candidate is the installed trusted catalog app."""
+  if not existing_identity:
+    return False
+  candidate_identity = _canonical_identity_key(candidate_url, manifest_id)
+  if candidate_identity == existing_identity:
+    return True
+  suffix = f"#manifest-id={manifest_id}"
+  existing_repo = _trusted_catalog_repo_base(existing_identity)
+  return bool(
+    existing_identity.endswith(suffix)
+    and existing_repo
+    and existing_repo == _trusted_catalog_repo_base(candidate_identity)
+  )
+
+
 def _canonical_identity_key(url_or_base: str, manifest_id: str) -> str:
   """Single canonical shape for the `manifest_url` column.
 
@@ -1601,6 +1679,7 @@ class InstallTarget:
   existing: models.App | None
   mode: str
   renaming: bool
+  adopting_trusted_origin: bool
   canonical_manifest_url: str
   force_core_store_update: bool
 
@@ -1865,16 +1944,9 @@ def _select_install_target(
   force_core_store_update = _should_force_core_store_update(
     source, manifest_id, canonical_manifest_url,
   )
-  existing = (
-    db.query(models.App)
-    .filter(models.App.manifest_url == canonical_manifest_url)
-    .first()
+  existing = _find_install_identity_row(
+    db, source_url=source_for_key, manifest_id=manifest_id,
   )
-  if existing is None:
-    # A catalog pin may move refs while retaining repo + manifest identity.
-    existing = _find_ref_independent_catalog_row(
-      db, canonical_manifest_url, manifest_id,
-    )
 
   renaming = False
   if existing is None:
@@ -1902,6 +1974,9 @@ def _select_install_target(
     existing=existing,
     mode="update" if existing else "install",
     renaming=renaming,
+    adopting_trusted_origin=bool(
+      existing is not None and existing.manifest_url is None
+    ),
     canonical_manifest_url=canonical_manifest_url,
     force_core_store_update=force_core_store_update,
   )
@@ -2537,7 +2612,7 @@ async def install_from_manifest(
         # the owner source we just committed to `main`. Force the three-way
         # merge instead, so those edits are folded in cleanly or surfaced as an
         # owner-gated conflict (identical on-disk == catalog resolves clean).
-        diverged = adopt_repoless_source or (
+        diverged = target.adopting_trusted_origin or adopt_repoless_source or (
           bool(prev_upstream_commit) and await asyncio.to_thread(
             app_git.local_diverged_from,
             git_source_dir, prev_upstream_commit,

--- a/backend/app/routes/apps.py
+++ b/backend/app/routes/apps.py
@@ -366,15 +366,11 @@ async def preview_app_install(
     )
   )
   source = body.manifest_url if body.manifest_url is not None else raw_base
-  canonical = install._canonical_identity_key(source, manifest["id"])
-  existing = (
-    db.query(models.App)
-    .filter(
-      models.App.manifest_url == canonical,
-      models.App.deleted_at.is_(None),
-    )
-    .first()
+  existing = install._find_install_identity_row(
+    db, source_url=source, manifest_id=manifest["id"],
   )
+  if existing is not None and existing.deleted_at is not None:
+    existing = None
   installed_contract = existing.capability_contract if existing else None
   return schemas.AppPreviewOut(
     manifest=manifest,
@@ -1060,6 +1056,7 @@ async def update_preview(
 )
 async def update_candidate_preview(
   app_id: int,
+  manifest_url: str | None = None,
   db: Session = Depends(get_db),
   principal: Principal = Depends(get_principal),
 ):
@@ -1091,10 +1088,10 @@ async def update_candidate_preview(
   from app import install
 
   app = live_app_or_404(db, app_id)
-  manifest_url = app.manifest_url
+  installed_manifest_url = app.manifest_url
   source_dir = app.source_dir
   upstream_commit = app.upstream_commit
-  if not manifest_url:
+  if not installed_manifest_url:
     raise HTTPException(400, "App has no update source.")
   repo = Path(source_dir)
   if not app_git.is_repo(repo) or not app_git.ref_exists(
@@ -1105,8 +1102,18 @@ async def update_candidate_preview(
   # Release the request session before upstream network I/O, matching the
   # update-check route's connection-pool discipline.
   db.close()
-  fetch_manifest_url = install._canonical_base(manifest_url) + "/mobius.json"
+  fetch_manifest_url = (
+    manifest_url
+    if manifest_url is not None
+    else install._canonical_base(installed_manifest_url) + "/mobius.json"
+  )
   fetched = await install.fetch_upstream_source(fetch_manifest_url)
+  if manifest_url is not None and not install._catalog_identity_matches(
+    installed_manifest_url, manifest_url, fetched.manifest["id"],
+  ):
+    raise HTTPException(
+      409, "Requested update source does not match the installed app.",
+    )
   candidate_tree = _fetched_source_tree(fetched)
   source_digest = install._source_review_digest(
     manifest=fetched.manifest,

--- a/backend/tests/test_apps_install.py
+++ b/backend/tests/test_apps_install.py
@@ -8,6 +8,7 @@ and force failure modes.
 """
 
 import asyncio
+from datetime import UTC, datetime
 import hashlib
 import io
 import json
@@ -1746,6 +1747,111 @@ def test_install_with_same_slug_different_manifest_keeps_both(
   assert preserved["manifest_url"] is None
 
 
+def test_trusted_catalog_adopts_legacy_row_only_with_matching_git_origin(
+  client, auth, db,
+):
+  """A pre-identity catalog app is adopted without weakening slug safety."""
+  from app import install
+
+  legacy = create_local_app(
+    client, auth, name="Codex", description="legacy Subagents", jsx_source=JSX,
+  )
+  repo = Path(legacy["source_dir"])
+  subprocess.run(
+    [
+      "git", "-C", str(repo), "remote", "add", "origin",
+      "https://github.com/mobius-os/app-subagents.git",
+    ],
+    check=True,
+  )
+  db.expire_all()
+
+  matched = install._find_install_identity_row(
+    db,
+    source_url=(
+      "https://raw.githubusercontent.com/mobius-os/"
+      "app-subagents/main/mobius.json"
+    ),
+    manifest_id="codex",
+  )
+  assert matched is not None
+  assert matched.id == legacy["id"]
+
+  unrelated = install._find_install_identity_row(
+    db,
+    source_url=(
+      "https://raw.githubusercontent.com/mobius-os/"
+      "app-something-else/main/mobius.json"
+    ),
+    manifest_id="codex",
+  )
+  assert unrelated is None
+
+  matched.deleted_at = datetime.now(UTC)
+  db.commit()
+  tombstone = install._find_install_identity_row(
+    db,
+    source_url=(
+      "https://raw.githubusercontent.com/mobius-os/"
+      "app-subagents/main/mobius.json"
+    ),
+    manifest_id="codex",
+  )
+  assert tombstone is not None
+  assert tombstone.id == legacy["id"]
+
+
+def test_trusted_origin_adoption_is_always_reconciled_as_local_source(
+  client, auth, db,
+):
+  """A proven legacy identity must still preserve its local source tree."""
+  from app import install
+
+  legacy = create_local_app(
+    client, auth, name="Codex", description="legacy Subagents", jsx_source=JSX,
+  )
+  repo = Path(legacy["source_dir"])
+  subprocess.run(
+    [
+      "git", "-C", str(repo), "remote", "add", "origin",
+      "https://github.com/mobius-os/app-subagents.git",
+    ],
+    check=True,
+  )
+  db.expire_all()
+  candidate = install.InstallCandidate(
+    manifest={**MANIFEST_NEWS, "id": "codex", "name": "Subagents"},
+    raw_base=(
+      "https://raw.githubusercontent.com/mobius-os/app-subagents/main/"
+    ),
+    entry_bytes=JSX.encode(),
+    icon_processed=None,
+    icon_warning=None,
+    bundled_job=None,
+    static_assets={},
+    source_files={},
+    seeds={},
+    capability_contract={},
+    capability_digest="a" * 64,
+    candidate_digest="b" * 64,
+    source_review_digest="c" * 64,
+  )
+  target = install._select_install_target(
+    db,
+    candidate=candidate,
+    manifest_url=(
+      "https://raw.githubusercontent.com/mobius-os/"
+      "app-subagents/main/mobius.json"
+    ),
+    source="store",
+    expected_app_id=None,
+  )
+  assert target.existing is not None
+  assert target.existing.id == legacy["id"]
+  assert target.mode == "update"
+  assert target.adopting_trusted_origin is True
+
+
 def test_install_same_manifest_twice_updates(
   client, auth, bypass_url_validation,
 ):
@@ -3277,6 +3383,98 @@ def test_update_candidate_preview_fetches_incoming_diff_without_mutation(
   listed = client.get("/api/apps/", headers=auth).json()
   row = next(app for app in listed if app["id"] == app_id)
   assert row["version"] == "1.0.0"
+
+
+def test_update_candidate_preview_uses_selected_trusted_catalog_ref(
+  client, auth, db, bypass_url_validation,
+):
+  """Review and Apply bind the same catalog ref, not an old stored pin."""
+  from app import models
+
+  base = "https://candidate-selected.test/repo/"
+  manifest = {**MANIFEST_NEWS, "id": "selected-candidate"}
+  installed = _install_v1(client, auth, base, manifest, JSX_MULTI)
+  assert installed.status_code == 201, installed.text
+  app_id = installed.json()["id"]
+
+  pinned_identity = (
+    "https://raw.githubusercontent.com/mobius-os/app-selected/"
+    "0123456789abcdef0123456789abcdef01234567"
+    "#manifest-id=selected-candidate"
+  )
+  row = db.query(models.App).filter(models.App.id == app_id).one()
+  row.manifest_url = pinned_identity
+  db.commit()
+
+  selected_url = (
+    "https://raw.githubusercontent.com/mobius-os/"
+    "app-selected/main/mobius.json"
+  )
+  next_manifest = {**manifest, "version": "2.0.0"}
+  incoming = JSX_MULTI.replace("ORIGINAL FOOTER", "SELECTED REF FOOTER")
+  responses = {
+    selected_url: (200, json.dumps(next_manifest).encode()),
+    selected_url.rsplit("/", 1)[0] + "/index.jsx": (200, incoming.encode()),
+    selected_url.rsplit("/", 1)[0] + "/icon.png": (200, _png_bytes()),
+    selected_url.rsplit("/", 1)[0] + "/prompt.md": (200, b"v2 prompt"),
+    selected_url.rsplit("/", 1)[0] + "/fetch.sh": (200, b""),
+  }
+  with patch(
+    "app.install.httpx.AsyncClient",
+    side_effect=_fake_async_client(responses),
+  ):
+    preview = client.get(
+      f"/api/apps/{app_id}/update-candidate-preview",
+      headers=auth,
+      params={"manifest_url": selected_url},
+    )
+
+  assert preview.status_code == 200, preview.text
+  payload = preview.json()
+  assert payload["upstream_version"] == "2.0.0"
+  assert "SELECTED REF FOOTER" in payload["upstream_diff"]
+  assert "ORIGINAL FOOTER" in payload["upstream_diff"]
+
+
+def test_update_candidate_preview_rejects_a_different_catalog_app(
+  client, auth, db, bypass_url_validation,
+):
+  """A manager cannot bind an installed row to another trusted package."""
+  from app import models
+
+  base = "https://candidate-mismatch.test/repo/"
+  manifest = {**MANIFEST_NEWS, "id": "candidate-mismatch"}
+  installed = _install_v1(client, auth, base, manifest, JSX)
+  assert installed.status_code == 201, installed.text
+  app_id = installed.json()["id"]
+  row = db.query(models.App).filter(models.App.id == app_id).one()
+  row.manifest_url = (
+    "https://raw.githubusercontent.com/mobius-os/app-one/main"
+    "#manifest-id=candidate-mismatch"
+  )
+  db.commit()
+
+  other_url = (
+    "https://raw.githubusercontent.com/mobius-os/app-two/main/mobius.json"
+  )
+  responses = {
+    other_url: (200, json.dumps(manifest).encode()),
+    other_url.rsplit("/", 1)[0] + "/index.jsx": (200, JSX.encode()),
+    other_url.rsplit("/", 1)[0] + "/icon.png": (200, _png_bytes()),
+    other_url.rsplit("/", 1)[0] + "/prompt.md": (200, PROMPT.encode()),
+    other_url.rsplit("/", 1)[0] + "/fetch.sh": (200, b""),
+  }
+  with patch(
+    "app.install.httpx.AsyncClient",
+    side_effect=_fake_async_client(responses),
+  ):
+    preview = client.get(
+      f"/api/apps/{app_id}/update-candidate-preview",
+      headers=auth,
+      params={"manifest_url": other_url},
+    )
+  assert preview.status_code == 409, preview.text
+  assert "does not match" in preview.json()["detail"]
 
 
 def test_deferred_replay_reports_changed_candidate_as_structured_recovery(

--- a/backend/tests/test_bootstrap.py
+++ b/backend/tests/test_bootstrap.py
@@ -307,3 +307,30 @@ async def test_bootstrap_honors_skills_tombstone_at_other_ref(db, monkeypatch):
 
   urls = [c.kwargs["manifest_url"] for c in install_mock.await_args_list]
   assert BOOTSTRAP_SKILLS_MANIFEST_URL not in urls  # tombstone respected
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_honors_legacy_trusted_origin_tombstone(
+  db, monkeypatch,
+):
+  """A pre-identity catalog row remains uninstalled after owner deletion."""
+  monkeypatch.delenv("MOEBIUS_SKIP_BOOTSTRAP", raising=False)
+  db.add(models.App(
+    source_dir="/tmp/mobius-tests/legacy-memory",
+    id=52,
+    name="Memory",
+    slug="memory",
+    manifest_url=None,
+    deleted_at=datetime.now(timezone.utc),
+  ))
+  db.commit()
+
+  install_mock = AsyncMock(return_value=_install_result())
+  with patch(
+    "app.app_git.origin_url",
+    return_value="https://github.com/mobius-os/app-memory.git",
+  ), patch("app.bootstrap.install_from_manifest", install_mock):
+    await ensure_bootstrap_apps_installed(db)
+
+  urls = [c.kwargs["manifest_url"] for c in install_mock.await_args_list]
+  assert BOOTSTRAP_MEMORY_MANIFEST_URL not in urls


### PR DESCRIPTION
## Summary
- resolve exact, moved-ref, and legacy trusted-origin catalog installs through one identity path
- preserve local source when a legacy app is adopted and keep uninstall tombstones respected during bootstrap
- let update reviews fetch the exact selected catalog manifest while rejecting a different package identity
- reuse the identity contract across capability preview, bootstrap, and install

## Testing
- `scripts/wt-pytest.sh backend/tests/test_apps_install.py backend/tests/test_bootstrap.py -q` (155 passed)
- `scripts/test.sh --fast` (72 passed)
- `python3 -m py_compile backend/app/app_git.py backend/app/bootstrap.py backend/app/install.py backend/app/routes/apps.py`

## Review note
The local changes originally arrived as two commits, but this PR intentionally combines them: recognizing a trusted legacy origin without forcing three-way reconciliation could otherwise replace owner-edited source. The combined contract never exposes that unsafe intermediate.