### PR TITLE
Make platform updates deployment-aware

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -72,14 +72,27 @@ Möbius is meant to be self-hosted on a user-provisioned host — a managed plat
 
 Two invariants follow. (1) **Möbius never patches the kernel from inside the container** — it only *surfaces* "host reboot pending / kernel CVE outstanding" to the owner; the platform/OS applies it. (2) **The in-container agent cannot recreate its own container** (the swap would kill its own process), so the shape is *propose-in* (agent scans → bumps → tests → commits) / *dispose-out* (a host-driven `deploy-prod.sh`, or blue-green, does the rebuild+recreate). Detection is the agent's leverage on every tier: `pip-audit` + `npm audit` + an image scanner (Trivy / `docker scout`) over the built image → triage → bump → test → deploy (tier 1) or surface a reboot window (tiers 2/3).
 
-**The in-product platform updater does not update host deployment files.**
-Settings advances the served `/data/platform` clone inside the app volume; the
-bundled self-hosted Caddy service instead reads `./Caddyfile` from the host
-checkout, and image/dependency changes likewise need a host rebuild/recreate.
-An incoming change to `Caddyfile`, `docker-compose.yml`, `Dockerfile`, or a
-dependency manifest therefore carries a separate host action (and may require a
-particular ordering) even when the live clone merges cleanly. Never describe
-Apply + server restart alone as activating those files.
+**The in-product updater owns source reconciliation, not the deployment control
+plane.** `backend/app/platform_activation.py` is the single ordered contract
+used by update preview, Apply/status, and the image-dependency fingerprint:
+
+| Impact | Typical source | Activation |
+|---|---|---|
+| `live` | frontend source, tests, docs | frontend is rebuilt or source is read on demand |
+| `server_restart` | `backend/app/`, `skill/core.md` | restart the FastAPI process |
+| `proxy_reload` | `Caddyfile` | self-hosted host checkout + Caddy reload |
+| `container_recreate` | Compose topology or `railway.toml` | recreate services or trigger a managed deployment |
+| `image_rebuild` | Dockerfile, dependency locks, baked scripts/supervisors/recovery | rebuild the image and replace the app container |
+| `host_maintenance` | host-operated deployment/recovery tooling | update and act from the host |
+
+Rules can be deployment-scoped: Railway does not pretend to reload Caddy, and a
+self-hosted install does not pretend to apply `railway.toml`. Mixed updates keep
+every applicable reason and order by the highest action. Settings shows this
+impact before Apply and never offers **Restart to finish** for a higher level.
+The backend records external activation remainders but never invokes Docker,
+Caddy, Railway, or host package/kernel tools. In-container sudo cannot make
+those changes durable, and mounting a Docker socket would weaken the recovery
+boundary rather than solve the ownership problem.
 
 **lodash is pinned to 4.18.1 via `overrides`.** `@openai/apps-sdk-ui` pulls lodash transitively — only through its `Slider` component, which the shell does not import. The 4.17.x line sat unfixed against several advisories for a long stretch; 4.18.x restored maintenance and patched them, so `frontend/package.json` `overrides` forces the transitive lodash to 4.18.1 (`npm audit` is clean). As defense-in-depth, `frontend/src/lib/__tests__/appsSdkLodash.test.js` also fails if the shell ever imports `Slider`, which keeps lodash tree-shaken out of the shipped bundle regardless of the pin.
 
@@ -138,7 +151,8 @@ FastAPI app. `main.py` is the factory (CORS, rate limiting, routers, static serv
 
 | File | Role |
 |------|------|
-| `main.py` | App factory: CORS, rate limiting, security headers (`_SecurityHeadersMiddleware` — authoritative on every response, strips-and-replaces same-named route headers; deliberately no CSP, see SECURITY.md), router mounting, static file serving; resolves `_static_dir` at load (`main.py:1000`); serves `GET /api/version` (image + served-platform identity) |
+| `main.py` | App factory: CORS, rate limiting, origin-owned standard headers and document CSP selection (`_SecurityHeadersMiddleware`), router mounting, static file serving, and `GET /api/version` identity |
+| `response_policy.py` | Validated origin sources plus the shell, embedded-chat, opaque app-frame, packaged-document, and published-site policies shared by direct and proxied deployments |
 | `frontend_watcher.py` | Polling watcher that auto-rebuilds the served frontend clone (`/data/platform/frontend`) on edit — debounced `vite build`, atomic `.dist-next`→`dist` swap |
 | `config.py` | `Settings` via pydantic-settings; reads `.env` |
 | `database.py` | SQLAlchemy engine, `SessionLocal`, `Base`, `get_db`, and `run_migrations()` (idempotent boot-time additive `ALTER TABLE`s) |

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,99 +1,9 @@
 {$FRONTEND_ORIGIN} {
+    # Application response policy is owned by FastAPI and passed through
+    # unchanged so direct Railway and self-hosted proxy paths stay identical.
+    # Caddy retains only topology concerns: public host routing, TLS and
+    # compression.
     encode gzip
-
-    # The embedded-chat bootstrap document is intentionally nested below an
-    # opaque app frame. That ancestor can satisfy neither X-Frame-Options:
-    # SAMEORIGIN nor CSP frame-ancestors 'self'. Keep the exception exact and
-    # retain the rest of the resource/security policy while the blank document
-    # establishes its server-verified one-use capability.
-    @chatEmbed path /shell/embed/chat
-    @staticEmbed path /app-embeds/by-id/*
-    # App frames execute compiled code transferred by their exact parent as a
-    # short-lived blob module. Keep blob: scoped to this already-opaque frame;
-    # the ordinary shell never needs blob-backed scripts.
-    @appFrame path /api/apps/*/frame
-    # Published sites (/sites/<token>/) are public snapshots of the owner's own
-    # agent-authored artifacts + Web Studio builds. They must run at an opaque
-    # origin (CSP `sandbox`, no allow-same-origin) so their JS cannot read the
-    # shell origin's localStorage/JWT. Like /app-embeds, /sites is
-    # EXCLUDED from @notFrameableEmbed and given its own X-Frame-Options + CSP
-    # block below — Caddy does not guarantee that a later `header >Set` on the
-    # same field wins over an earlier one, so overlapping matchers on the same
-    # header are unreliable; a disjoint matcher is the only deterministic form.
-    # Mirrors the app middleware (_PUBLISHED_SITE_CSP), which likewise keeps
-    # X-Frame-Options SAMEORIGIN while replacing the CSP, so the boundary holds
-    # identically at both the proxy and the origin.
-    @publishedSite path /sites/*
-    @notFrameableEmbed not path /shell/embed/chat /app-embeds/by-id/* /api/apps/*/frame /sites/*
-
-    header {
-        # Defer replacements until after reverse_proxy copies the backend
-        # response. Without `>`, the mirrored backend values are appended and
-        # browsers receive comma-joined duplicates such as
-        # `X-Content-Type-Options: nosniff, nosniff`.
-        >X-Content-Type-Options "nosniff"
-        >Permissions-Policy "camera=(), geolocation=()"
-        >Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
-        # script-src notes:
-        #   'unsafe-inline' — cannot be removed: index.html, app-frame.html,
-        #   standalone.py contain inline <script> blocks (error handlers,
-        #   postMessage init, BIP capture). Replacing them with nonce/hash-based
-        #   CSP requires server-side rendering changes across these surfaces.
-        #   https://esm.sh — remains for apps that deliberately use an absolute
-        #   dynamic import while online. Supported bare imports are bundled by
-        #   the app compiler and do not depend on this origin.
-    }
-    # img-src includes blob: — the shell creates object URLs for upload
-    # previews (useFileUpload), the image lightbox, and install-sheet icon
-    # previews; without blob: those render as broken images under an
-    # enforced policy.
-    header >Referrer-Policy "strict-origin-when-cross-origin"
-    header @notFrameableEmbed >X-Frame-Options "SAMEORIGIN"
-    header @notFrameableEmbed >Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://esm.sh; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com https://cdn.openai.com; connect-src 'self'; img-src 'self' data: blob:; frame-src 'self' {$MOBIUS_SERVICE_GATEWAY_ORIGIN}; frame-ancestors 'self'"
-    header @appFrame >X-Frame-Options "SAMEORIGIN"
-    # A user-opened external tab must not inherit the app frame's opaque
-    # origin. The app remains sandboxed; only its new popup/tab escapes.
-    #
-    # Every fetch directive NAMES THIS ORIGIN WITH ITS SCHEME, and needs all
-    # three parts:
-    # the sandbox deliberately omits allow-same-origin, so the frame's origin is
-    # opaque. `'self'` matches NOTHING for an opaque origin, and a bare host
-    # (`example.com`) matches nothing either — a scheme-less host source is
-    # compared against the DOCUMENT's scheme, and an opaque origin has none to
-    # compare. Only a fully-qualified `scheme://host` matches on the request URL
-    # alone. Chromium resolves all three leniently; WebKit obeys the spec, so on
-    # iOS every network call an app made was blocked before it left the device —
-    # no status, no server-side trace, indistinguishable from the network being
-    # down. Verified from the device: with the bare host present, WebKit still
-    # reported `refused by: connect-src` for a URL on exactly that host.
-    #
-    # Use {$FRONTEND_ORIGIN} — the one variable that already carries the scheme,
-    # and the same origin @notFrameableEmbed/frame-ancestors is written against.
-    # Do NOT rebuild it as `https://{$DOMAIN}`: DOMAIN is a bare host in
-    # production but a full URL under docker-compose.test.yml, so the prefix
-    # yields `https://http://localhost:8001` — an invalid source the browser
-    # drops, leaving the directive with no usable origin at all.
-    #
-    # This restores the reach the frame was always meant to have without
-    # weakening the sandbox: one origin, and the app still holds nothing but its
-    # own scoped token. FRONTEND_ORIGIN also owns this site's address above, so
-    # leaving it unset makes Caddy reject the configuration at startup instead
-    # of silently reducing these directives to the original broken policy.
-    header @appFrame >Content-Security-Policy "sandbox allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox allow-top-navigation-by-user-activation; default-src {$FRONTEND_ORIGIN}; script-src {$FRONTEND_ORIGIN} 'unsafe-inline' blob: https://esm.sh; style-src {$FRONTEND_ORIGIN} 'unsafe-inline' https://fonts.googleapis.com; font-src {$FRONTEND_ORIGIN} https://fonts.gstatic.com https://cdn.openai.com; connect-src {$FRONTEND_ORIGIN}; img-src {$FRONTEND_ORIGIN} data: blob:; frame-src {$FRONTEND_ORIGIN} {$MOBIUS_SERVICE_GATEWAY_ORIGIN}; frame-ancestors 'self'"
-    # The embedded chat mounts the full ChatView (upload previews, image
-    # lightbox), so its img-src needs blob: for the same object URLs as the
-    # shell policy above.
-    header @chatEmbed >Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://esm.sh; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com https://cdn.openai.com; connect-src 'self'; img-src 'self' data: blob:; frame-src 'self'"
-    header @staticEmbed >Content-Security-Policy "sandbox allow-scripts allow-forms allow-pointer-lock; default-src {$FRONTEND_ORIGIN}; script-src {$FRONTEND_ORIGIN} 'unsafe-inline'; style-src {$FRONTEND_ORIGIN} 'unsafe-inline'; font-src {$FRONTEND_ORIGIN} data:; connect-src {$FRONTEND_ORIGIN}; img-src {$FRONTEND_ORIGIN} data: blob:; media-src {$FRONTEND_ORIGIN} blob:; worker-src {$FRONTEND_ORIGIN} blob:"
-    # /sites/ headers (disjoint matcher — see the @publishedSite note above).
-    # X-Frame-Options SAMEORIGIN keeps the page top-level-only; the CSP is
-    # sandbox-only: the opaque origin is the credential boundary, and resource
-    # loading is left unrestricted because /sites/ also serves multi-file Web
-    # Studio sites that pull external assets. Keep in sync with
-    # _PUBLISHED_SITE_CSP in main.py.
-    header @publishedSite >X-Frame-Options "SAMEORIGIN"
-    header @publishedSite >Content-Security-Policy "sandbox allow-scripts allow-forms allow-popups; object-src 'none'; base-uri 'none'; frame-ancestors 'self'"
-
     reverse_proxy app:8000
 }
 
@@ -108,9 +18,8 @@
     handle @serviceSurface {
         encode gzip
         header {
-            >X-Content-Type-Options "nosniff"
-            >Referrer-Policy "strict-origin-when-cross-origin"
-            >Permissions-Policy "camera=(), geolocation=()"
+            # The backend owns standard headers. The gateway keeps only its
+            # host-specific frame exception and a fail-closed CSP fallback.
             ?Content-Security-Policy "frame-ancestors 'self' {$FRONTEND_ORIGIN}"
             -X-Frame-Options
         }

--- a/Dockerfile
+++ b/Dockerfile
@@ -216,6 +216,7 @@ COPY frontend/ ./shell-src/
 # failing the build if any declared input was not copied into the image.
 COPY scripts/test-image-fingerprint.sh /tmp/test-image-inputs/scripts/test-image-fingerprint.sh
 COPY Dockerfile /tmp/test-image-inputs/Dockerfile
+COPY backend/app/platform_activation.py /tmp/test-image-inputs/backend/app/platform_activation.py
 COPY backend/requirements.txt backend/requirements.lock /tmp/test-image-inputs/backend/
 COPY backend/legacy_runtime/ /tmp/test-image-inputs/backend/legacy_runtime/
 COPY frontend/package.json frontend/package-lock.json /tmp/test-image-inputs/frontend/

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,19 +12,19 @@ being external attackers reaching the public HTTPS endpoint.
   No client-side token exposure.
 - **Encryption at rest:** API keys stored with Fernet (AES-128 + HMAC),
   derived from SECRET_KEY.
-- **TLS and response headers:** Caddy auto-provisions HTTPS certificates. The
-  backend sets HSTS (1 year, preload), X-Frame-Options,
-  X-Content-Type-Options, Referrer-Policy, and Permissions-Policy so those
-  protections do not depend on the front proxy. The bundled Caddy deployment
-  also sets a resource CSP and mirrors the frame policy; other operators may
-  supply a different resource CSP at their proxy.
-- **CSP is deployment policy, not the app authorization boundary:** the
-  backend does not impose a shell-wide resource CSP. The bundled Caddyfile does
-  apply one, including `frame-ancestors 'self'` on ordinary routes. The exact
-  inert chat bootstrap, response-sandboxed `/app-embeds/` namespace, and
-  host/path-scoped service adapter have narrowly different frame policies.
-  Scoped server-verified principals and response sandboxing remain the actual
-  authorization boundaries.
+- **TLS and response headers:** Caddy auto-provisions HTTPS certificates, while
+  the backend owns standard response headers and scoped document CSPs so direct
+  Railway and self-hosted proxy paths cannot drift. The primary Caddy host
+  passes policy through unchanged. Only the distinct service-gateway host keeps
+  its topology-specific frame exception and fail-closed routing behavior.
+- **CSP is origin policy, not the app authorization boundary:** ordinary shell
+  documents, the inert chat bootstrap, opaque app frames, packaged embeds, and
+  published sites each receive their policy from the backend. App-frame
+  `script-src` includes narrow `'wasm-unsafe-eval'`, never JavaScript
+  `'unsafe-eval'`. No global COOP/COEP isolation is enabled; SharedArrayBuffer or
+  threaded Wasm needs a dedicated design because cross-origin assets and popups
+  can break under those headers. Scoped principals and opaque response
+  sandboxing remain the authorization boundaries.
 - **Mini-app isolation and tokens:** `AppCanvas`-mounted app frames omit
   `allow-same-origin`, giving them an opaque origin. They cannot read shell
   localStorage or the owner JWT. Each receives a refreshable app JWT bound to

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -47,6 +47,13 @@ from app.frontend_assets import (
   resolve_frontend_dir,
 )
 from app.memory_observability import record_memory_checkpoint
+from app.response_policy import (
+  CHAT_EMBED_CSP,
+  PUBLISHED_SITE_CSP,
+  app_frame_csp,
+  shell_csp,
+  static_embed_csp,
+)
 from app.storage_io import atomic_write
 from app import activity, models
 # providers and push are on the agent's write surface; deferred into
@@ -262,24 +269,15 @@ class _BodySizeLimitMiddleware:
     })
 
 
-# Standard security headers. The bundled Caddy sets these, but production is
-# fronted by an external Caddy whose vhost has no header block (and managed
-# deployments often proxy the app directly), so prod serves NONE of them today.
-# Setting them here means they hold regardless of what fronts the app. These are
-# resource-load-agnostic — they protect against clickjacking, MIME-sniffing, TLS
-# downgrade, and referrer leakage WITHOUT restricting what apps may load, so web
-# images / external embeds keep working. There is deliberately no global
-# Content-Security-Policy here yet: mini-apps intentionally support user-chosen
-# external resources and a strict shell-wide policy would break that contract.
-# App isolation instead comes from opaque-origin sandboxed frames plus scoped
-# tokens. Clickjacking is covered by X-Frame-Options without a CSP. Narrow
-# exceptions are the inert embedded-chat bootstrap, response-sandboxed packaged
-# documents, and an explicitly configured shared service-gateway surface.
+# Standard security headers are origin-owned so Railway and the bundled Caddy
+# expose one contract. Camera/location remain unavailable to opaque app frames,
+# while ``self`` leaves room for a future shell-owned capability provider after
+# the owner grants browser permission.
 _SECURITY_HEADERS = [
   (b"x-content-type-options", b"nosniff"),
   (b"x-frame-options", b"SAMEORIGIN"),
   (b"referrer-policy", b"strict-origin-when-cross-origin"),
-  (b"permissions-policy", b"camera=(), geolocation=()"),
+  (b"permissions-policy", b"camera=(self), geolocation=(self)"),
   (b"strict-transport-security",
    b"max-age=31536000; includeSubDomains; preload"),
 ]
@@ -288,6 +286,7 @@ _X_FRAME_OPTIONS = b"x-frame-options"
 _CONTENT_SECURITY_POLICY = b"content-security-policy"
 _OPAQUE_STATIC_EMBED_PREFIX = "/app-embeds/by-id/"
 _PUBLISHED_SITE_PREFIX = "/sites/"
+_APP_FRAME_PATH = re.compile(r"^/api/apps/[^/]+/frame$")
 
 # This isolation boundary must always be enforced, never Report-Only: browsers
 # ignore the CSP sandbox directive in a Report-Only policy. The sandbox omits
@@ -296,17 +295,11 @@ _PUBLISHED_SITE_PREFIX = "/sites/"
 # absolute origin explicitly in every fetch directive. This does not weaken the
 # credential boundary: packaged code already executes in the opaque document,
 # and it still cannot reach the shell's localStorage, cookies, or owner token.
-_STATIC_EMBED_ORIGIN = settings.frontend_origin.rstrip("/")
-_STATIC_EMBED_CSP = (
-  "sandbox allow-scripts allow-forms allow-pointer-lock; "
-  f"default-src {_STATIC_EMBED_ORIGIN}; "
-  f"script-src {_STATIC_EMBED_ORIGIN} 'unsafe-inline'; "
-  f"style-src {_STATIC_EMBED_ORIGIN} 'unsafe-inline'; "
-  f"font-src {_STATIC_EMBED_ORIGIN} data:; "
-  f"connect-src {_STATIC_EMBED_ORIGIN}; "
-  f"img-src {_STATIC_EMBED_ORIGIN} data: blob:; "
-  f"media-src {_STATIC_EMBED_ORIGIN} blob:; "
-  f"worker-src {_STATIC_EMBED_ORIGIN} blob:"
+_STATIC_EMBED_CSP = static_embed_csp(settings.frontend_origin)
+_SHELL_CSP = shell_csp(os.environ.get("MOBIUS_SERVICE_GATEWAY_ORIGIN", ""))
+_APP_FRAME_CSP = app_frame_csp(
+  settings.frontend_origin,
+  os.environ.get("MOBIUS_SERVICE_GATEWAY_ORIGIN", ""),
 )
 
 # Published sites (`/sites/<token>/`) are public snapshots of the owner's own
@@ -324,10 +317,7 @@ _STATIC_EMBED_CSP = (
 # share token + public artifact data, but never the shell origin or the owner
 # JWT. Must be enforcing, never Report-Only. X-Frame-Options SAMEORIGIN is
 # KEPT (published pages open top-level; no cross-site framing need).
-_PUBLISHED_SITE_CSP = (
-  "sandbox allow-scripts allow-forms allow-popups; "
-  "object-src 'none'; base-uri 'none'; frame-ancestors 'self'"
-)
+_PUBLISHED_SITE_CSP = PUBLISHED_SITE_CSP
 
 
 def _frame_policy_exception(scope) -> bool:
@@ -348,10 +338,9 @@ class _SecurityHeadersMiddleware:
   """Authoritatively sets the platform security headers on every response. Pure
   ASGI so it never buffers a streaming body. It strips any same-named header a
   route may have set first and replaces it with the platform value, so no route
-  can weaken the HSTS/MIME/etc. wall. Opaque static embeds get their enforced
-  response sandbox here alongside their frame-policy exception. Other frame
-  exceptions are exact routes whose inert response or gateway-origin adapter
-  provides the replacement boundary; ordinary routes retain SAMEORIGIN."""
+  can weaken the HSTS/MIME/etc. wall. Document policies are selected by exact
+  origin-owned namespaces. The shared service gateway is the sole exception:
+  its host adapter supplies a topology-specific frame policy."""
 
   def __init__(self, app):
     self.app = app
@@ -365,22 +354,27 @@ class _SecurityHeadersMiddleware:
     path = scope.get("path") or ""
     opaque_static_embed = path.startswith(_OPAQUE_STATIC_EMBED_PREFIX)
     published_site = path.startswith(_PUBLISHED_SITE_PREFIX)
-    # Both namespaces need an ENFORCED response CSP and the same protection on
-    # the generic-500 path; only the embed also drops X-Frame-Options.
-    response_sandboxed = opaque_static_embed or published_site
-    response_headers = _SECURITY_HEADERS
+    chat_embed = path == "/shell/embed/chat"
+    app_frame = bool(_APP_FRAME_PATH.fullmatch(path))
+    service_surface = path.startswith("/services/") and _frame_policy_exception(scope)
+    response_headers = list(_SECURITY_HEADERS)
     replaced_header_names = _SECURITY_HEADER_NAMES
     if opaque_static_embed or _frame_policy_exception(scope):
       response_headers = [
         (name, value) for name, value in _SECURITY_HEADERS
         if name != _X_FRAME_OPTIONS
       ]
-    if response_sandboxed:
-      csp = _STATIC_EMBED_CSP if opaque_static_embed else _PUBLISHED_SITE_CSP
-      # Copy before appending so we never mutate the _SECURITY_HEADERS module
-      # constant (the published-site branch leaves X-Frame-Options in place, so
-      # response_headers is still that shared list here).
-      response_headers = list(response_headers)
+    if not service_surface:
+      if opaque_static_embed:
+        csp = _STATIC_EMBED_CSP
+      elif published_site:
+        csp = _PUBLISHED_SITE_CSP
+      elif chat_embed:
+        csp = CHAT_EMBED_CSP
+      elif app_frame:
+        csp = _APP_FRAME_CSP
+      else:
+        csp = _SHELL_CSP
       response_headers.append((
         _CONTENT_SECURITY_POLICY,
         csp.encode("ascii"),
@@ -407,9 +401,9 @@ class _SecurityHeadersMiddleware:
       return await self.app(scope, receive, _send)
     except Exception:
       # Starlette's unhandled-error response is outside user middleware. Send
-      # this namespace's generic 500 through our wrapper before re-raising so
-      # the outer layer still logs it without bypassing the sandbox boundary.
-      if response_sandboxed and not response_started:
+      # one through this wrapper before re-raising so direct and proxied generic
+      # errors cannot diverge on the response policy.
+      if not response_started:
         response = Response(
           "Internal Server Error",
           status_code=500,

--- a/backend/app/platform_activation.py
+++ b/backend/app/platform_activation.py
@@ -1,0 +1,325 @@
+"""Classify platform source changes by the deployment action they require.
+
+This module is intentionally dependency-free.  The running updater imports it,
+and ``scripts/test-image-fingerprint.sh`` executes its small CLI so image inputs
+and owner-facing update semantics cannot grow separate path tables.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Iterable, Literal, TypedDict
+
+
+class ActivationLevel(str, Enum):
+  """Ordered activation boundary for a changed platform path."""
+
+  LIVE = "live"
+  SERVER_RESTART = "server_restart"
+  PROXY_RELOAD = "proxy_reload"
+  CONTAINER_RECREATE = "container_recreate"
+  IMAGE_REBUILD = "image_rebuild"
+  HOST_MAINTENANCE = "host_maintenance"
+
+
+LEVEL_ORDER = {
+  level: index for index, level in enumerate(ActivationLevel)
+}
+DeploymentKind = Literal["railway", "self_hosted"]
+DeploymentScope = Literal["all", "railway", "self_hosted"]
+
+
+class ActivationReason(TypedDict):
+  """One independently actionable reason within a platform update."""
+
+  code: str
+  level: str
+  summary: str
+  paths: list[str]
+  applies: bool
+
+
+class PlatformActivationImpact(TypedDict):
+  """Owner-readable and machine-ordered activation result."""
+
+  level: str
+  source_level: str
+  deployment: DeploymentKind
+  actions: list[str]
+  reasons: list[ActivationReason]
+  guidance: list[str]
+  requires_operator: bool
+
+
+@dataclass(frozen=True)
+class _Rule:
+  code: str
+  level: ActivationLevel
+  summary: str
+  exact: tuple[str, ...] = ()
+  prefixes: tuple[str, ...] = ()
+  deployment: DeploymentScope = "all"
+  dependency_fingerprint: bool = False
+
+  def matches(self, path: str) -> bool:
+    return path in self.exact or any(path.startswith(prefix) for prefix in self.prefixes)
+
+
+def _normalize_path(path: str) -> str:
+  normalized = path.strip()
+  return normalized[2:] if normalized.startswith("./") else normalized
+
+
+# Ordered first-match rules.  Narrow baked/deployment inputs precede the broad
+# backend runtime rule.  A path may require only one owning activation boundary;
+# mixed updates still report every distinct rule they touch.
+_RULES = (
+  _Rule(
+    "host_operator_tooling",
+    ActivationLevel.HOST_MAINTENANCE,
+    "Host-operated deployment or recovery tooling changed.",
+    exact=("scripts/mobiusctl", "scripts/deploy-prod.sh"),
+    deployment="self_hosted",
+  ),
+  _Rule(
+    "container_image_definition",
+    ActivationLevel.IMAGE_REBUILD,
+    "The container image definition changed.",
+    exact=("Dockerfile",),
+    dependency_fingerprint=True,
+  ),
+  _Rule(
+    "container_build_context",
+    ActivationLevel.IMAGE_REBUILD,
+    "The container build context changed.",
+    exact=(".dockerignore",),
+  ),
+  _Rule(
+    "python_dependencies",
+    ActivationLevel.IMAGE_REBUILD,
+    "Python dependencies changed and must be installed into a new image.",
+    exact=("backend/requirements.txt", "backend/requirements.lock"),
+    dependency_fingerprint=True,
+  ),
+  _Rule(
+    "frontend_dependencies",
+    ActivationLevel.IMAGE_REBUILD,
+    "Frontend or app-compiler dependencies changed and need a new image.",
+    exact=("frontend/package.json", "frontend/package-lock.json"),
+    dependency_fingerprint=True,
+  ),
+  _Rule(
+    "legacy_python_runtime",
+    ActivationLevel.IMAGE_REBUILD,
+    "The image-installed compatibility runtime changed.",
+    prefixes=("backend/legacy_runtime/",),
+    dependency_fingerprint=True,
+  ),
+  _Rule(
+    "baked_runtime",
+    ActivationLevel.IMAGE_REBUILD,
+    "Baked scripts, supervisors, recovery code, or protected-file rules changed.",
+    exact=("protected-files.txt",),
+    prefixes=(
+      "backend/scripts/",
+      "backend/runtime/",
+      "backend/recovery_target/",
+      "backend/static/",
+    ),
+  ),
+  _Rule(
+    "self_hosted_topology",
+    ActivationLevel.CONTAINER_RECREATE,
+    "Self-hosted container topology or runtime configuration changed.",
+    exact=("docker-compose.yml", "docker-compose.prod.yml"),
+    deployment="self_hosted",
+  ),
+  _Rule(
+    "railway_topology",
+    ActivationLevel.CONTAINER_RECREATE,
+    "Railway build or deployment configuration changed.",
+    exact=("railway.toml",),
+    deployment="railway",
+  ),
+  _Rule(
+    "self_hosted_proxy",
+    ActivationLevel.PROXY_RELOAD,
+    "The self-hosted Caddy routing or TLS policy changed.",
+    exact=("Caddyfile",),
+    deployment="self_hosted",
+  ),
+  _Rule(
+    "backend_development_source",
+    ActivationLevel.LIVE,
+    "Backend tests and evaluation tooling do not alter the running server.",
+    exact=(
+      "backend/pyproject.toml",
+      "backend/requirements-static.txt",
+      "backend/test_app_fixtures.py",
+    ),
+    prefixes=("backend/tests/", "backend/memeval/"),
+  ),
+  _Rule(
+    "server_runtime",
+    ActivationLevel.SERVER_RESTART,
+    "Server runtime code or the cached agent constitution changed.",
+    exact=("backend", "backend/app", "skill/core.md"),
+    prefixes=("backend/",),
+  ),
+)
+
+
+def deployment_kind(environ: dict[str, str] | None = None) -> DeploymentKind:
+  """Detect Railway without inventing a generic provider-control contract."""
+  env = os.environ if environ is None else environ
+  railway_markers = (
+    "RAILWAY_PROJECT_ID",
+    "RAILWAY_SERVICE_ID",
+    "RAILWAY_ENVIRONMENT_ID",
+    "RAILWAY_DEPLOYMENT_ID",
+    "RAILWAY_PUBLIC_DOMAIN",
+  )
+  return "railway" if any((env.get(key) or "").strip() for key in railway_markers) else "self_hosted"
+
+
+def _rule_for_path(path: str) -> _Rule | None:
+  normalized = _normalize_path(path)
+  return next((rule for rule in _RULES if rule.matches(normalized)), None)
+
+
+def backend_import_probe_required(paths: Iterable[str]) -> bool:
+  """Whether changed source can alter imports in a fresh FastAPI process."""
+  for path in paths:
+    normalized = _normalize_path(path)
+    rule = _rule_for_path(normalized)
+    if rule and rule.code == "server_runtime" and normalized != "skill/core.md":
+      return True
+  return False
+
+
+def _applies(rule: _Rule, deployment: DeploymentKind) -> bool:
+  return rule.deployment == "all" or rule.deployment == deployment
+
+
+def _guidance(level: ActivationLevel, deployment: DeploymentKind) -> str:
+  if level is ActivationLevel.LIVE:
+    return "No deployment action is required; live source is rebuilt or read on demand."
+  if level is ActivationLevel.SERVER_RESTART:
+    return "Restart Möbius after Apply so the running server loads the new source."
+  if deployment == "railway":
+    if level is ActivationLevel.CONTAINER_RECREATE:
+      return "Trigger a Railway deployment; an in-product restart cannot apply deployment configuration."
+    if level is ActivationLevel.IMAGE_REBUILD:
+      return "Trigger a Railway image rebuild and deployment; Restart cannot install dependencies or baked tools."
+  else:
+    if level is ActivationLevel.PROXY_RELOAD:
+      return "Refresh the host checkout, then reload Caddy; restarting Möbius does not reload the proxy."
+    if level is ActivationLevel.CONTAINER_RECREATE:
+      return "Refresh the host checkout, then recreate the affected Docker Compose services."
+    if level is ActivationLevel.IMAGE_REBUILD:
+      return "Refresh the host checkout, rebuild the image, then recreate the app container."
+    if level is ActivationLevel.HOST_MAINTENANCE:
+      return "Update the host-operated tooling and complete its maintenance outside the container."
+  return "Complete this deployment action outside Möbius; an in-product restart is insufficient."
+
+
+def classify_activation(
+  paths: Iterable[str], *, deployment: DeploymentKind | None = None,
+) -> PlatformActivationImpact:
+  """Classify changed paths once, preserving both universal and local impact."""
+  active_deployment = deployment or deployment_kind()
+  grouped: dict[str, tuple[_Rule | None, list[str]]] = {}
+  for raw_path in paths:
+    path = _normalize_path(raw_path)
+    if not path:
+      continue
+    rule = _rule_for_path(path)
+    key = rule.code if rule else "live_source"
+    if key not in grouped:
+      grouped[key] = (rule, [])
+    grouped[key][1].append(path)
+
+  reasons: list[ActivationReason] = []
+  source_levels: list[ActivationLevel] = [ActivationLevel.LIVE]
+  effective_levels: list[ActivationLevel] = [ActivationLevel.LIVE]
+  for code, (rule, grouped_paths) in grouped.items():
+    level = rule.level if rule else ActivationLevel.LIVE
+    applies = True if rule is None else _applies(rule, active_deployment)
+    source_levels.append(level)
+    if applies:
+      effective_levels.append(level)
+    reasons.append(ActivationReason(
+      code=code,
+      level=level.value,
+      summary=(
+        rule.summary
+        if rule
+        else "These files are rebuilt, read on demand, or do not affect the running installation."
+      ),
+      paths=sorted(set(grouped_paths)),
+      applies=applies,
+    ))
+
+  source_level = max(source_levels, key=LEVEL_ORDER.get)
+  required_level = max(effective_levels, key=LEVEL_ORDER.get)
+  action_levels = sorted(
+    {
+      ActivationLevel(reason["level"])
+      for reason in reasons
+      if reason["applies"] and reason["level"] != ActivationLevel.LIVE.value
+    },
+    key=LEVEL_ORDER.get,
+  )
+  guidance = [_guidance(level, active_deployment) for level in action_levels]
+  if not guidance:
+    guidance = [_guidance(ActivationLevel.LIVE, active_deployment)]
+
+  return PlatformActivationImpact(
+    level=required_level.value,
+    source_level=source_level.value,
+    deployment=active_deployment,
+    actions=[level.value for level in action_levels],
+    reasons=reasons,
+    guidance=guidance,
+    requires_operator=LEVEL_ORDER[required_level] > LEVEL_ORDER[ActivationLevel.SERVER_RESTART],
+  )
+
+
+def dependency_fingerprint_paths(root: Path) -> list[str]:
+  """Enumerate the image dependency inputs declared by the classifier."""
+  paths: set[str] = set()
+  for rule in _RULES:
+    if not rule.dependency_fingerprint:
+      continue
+    paths.update(rule.exact)
+    for prefix in rule.prefixes:
+      base = root / prefix
+      if base.is_file():
+        paths.add(prefix.rstrip("/"))
+      elif base.is_dir():
+        paths.update(
+          str(path.relative_to(root))
+          for path in base.rglob("*")
+          if path.is_file()
+        )
+  return sorted(paths)
+
+
+def _main() -> int:
+  parser = argparse.ArgumentParser()
+  subparsers = parser.add_subparsers(dest="command", required=True)
+  fingerprint = subparsers.add_parser("dependency-fingerprint-paths")
+  fingerprint.add_argument("root", type=Path)
+  args = parser.parse_args()
+  if args.command == "dependency-fingerprint-paths":
+    for path in dependency_fingerprint_paths(args.root.resolve()):
+      print(path)
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(_main())

--- a/backend/app/platform_update.py
+++ b/backend/app/platform_update.py
@@ -64,7 +64,8 @@ from typing import Callable, Literal, TypedDict
 
 from sqlalchemy.orm import Session
 
-from app import app_git, release_channel
+from app import app_git, platform_activation, release_channel
+from app.platform_activation import PlatformActivationImpact
 
 
 log = logging.getLogger(__name__)
@@ -77,6 +78,10 @@ PLATFORM_BACKEND = PLATFORM_REPO / "backend"
 # Runtime marker files. Each is a transient signal, never user data (they are
 # gitignored out of the outer ``/data`` repo in entrypoint.sh).
 UPGRADE_FLAG = Path("/data/.platform-upgrade-available")
+# Durable activation remainder.  The historical filename is retained so old
+# images keep ignoring it and a rolling upgrade never invents another marker.
+# Legacy content was a bare restart SHA; current content is a JSON target+paths
+# record that can survive a server restart when host/image work is still due.
 RESTART_NEEDED_FLAG = Path("/data/.platform-restart-needed")
 # Written by entrypoint.sh before uvicorn starts. These identify the backend
 # tree the current Python process actually imported, which can differ from the
@@ -218,6 +223,7 @@ class PlatformUpdateState(str, Enum):
   AVAILABLE = "available"
   CONFLICT = "conflict"
   RESTART_NEEDED = "restart_needed"
+  ACTIVATION_NEEDED = "activation_needed"
   # A text-clean merge failed the import probe and was rolled back to the
   # previous served commit; the update needs a repair pass before it can land.
   ROLLED_BACK = "rolled_back"
@@ -229,6 +235,7 @@ class PlatformStatus(TypedDict):
   state: str
   available: bool
   needs_restart: bool
+  activation: PlatformActivationImpact
   current_build_sha: str | None
   recorded_upstream_sha: str | None
   # Latest fetched origin/main commit that is already contained in local main.
@@ -248,6 +255,7 @@ class PlatformApplyResult(TypedDict):
 
   state: str
   needs_restart: bool
+  activation: PlatformActivationImpact
   upstream_commit: str | None
   merge_commit: str | None
   conflict_paths: list[str]
@@ -303,6 +311,7 @@ class PlatformUpdatePreview(TypedDict):
   # and rejects a changed local tip or substituted target instead of silently
   # installing bytes other than the ones represented by this preview.
   plan_id: str | None
+  activation: PlatformActivationImpact
   total_commits: int
   commits_truncated: bool
   commits: list[PlatformCommitSummary]
@@ -877,10 +886,52 @@ def recorded_upstream_sha(repo: Path = PLATFORM_REPO) -> str | None:
   return _rev(repo, UPSTREAM_BRANCH) or None
 
 
+def _read_activation_marker() -> dict[str, object] | None:
+  """Read the current target+paths marker, including the legacy bare SHA."""
+  try:
+    raw = RESTART_NEEDED_FLAG.read_text(encoding="utf-8").strip()
+  except (FileNotFoundError, OSError):
+    return None
+  if not raw:
+    return None
+  try:
+    parsed = json.loads(raw)
+  except json.JSONDecodeError:
+    # Before activation impacts existed this file held only a target SHA.  Its
+    # only meaning was a backend restart, so preserve exactly that remainder.
+    return {"target_sha": raw, "paths": ["backend/app"]}
+  if not isinstance(parsed, dict):
+    return None
+  target = str(parsed.get("target_sha") or "").strip()
+  paths = parsed.get("paths")
+  if not isinstance(paths, list):
+    return None
+  clean_paths = sorted({str(path).strip() for path in paths if str(path).strip()})
+  return {"target_sha": target, "paths": clean_paths}
+
+
+def _write_activation_marker(target_sha: str, paths: list[str]) -> None:
+  clean_paths = sorted({path.strip() for path in paths if path.strip()})
+  if not clean_paths:
+    RESTART_NEEDED_FLAG.unlink(missing_ok=True)
+    return
+  _atomic_write_text(RESTART_NEEDED_FLAG, json.dumps({
+    "target_sha": target_sha or "",
+    "paths": clean_paths,
+  }, separators=(",", ":")))
+
+
+def mark_activation_needed(target_sha: str, paths: list[str]) -> None:
+  """Persist activation work, preserving any earlier host/image remainder."""
+  existing = _read_activation_marker() or {}
+  existing_paths = existing.get("paths")
+  carried = existing_paths if isinstance(existing_paths, list) else []
+  _write_activation_marker(target_sha, [*carried, *paths])
+
+
 def mark_restart_needed(target_sha: str) -> None:
-  """Record that a restart is needed to load an owner-applied update, stamping
-  the reconciled commit the running uvicorn does NOT yet import."""
-  _atomic_write_text(RESTART_NEEDED_FLAG, target_sha or "")
+  """Compatibility helper for callers that know only a server restart is due."""
+  mark_activation_needed(target_sha, ["backend/app"])
 
 
 def _served_platform_sha() -> str | None:
@@ -899,39 +950,13 @@ def _served_platform_sha() -> str | None:
   return sha or None
 
 
-# The served uvicorn runs with cwd ``backend/`` and imports the platform backend.
-# Any backend RUNTIME source (anything under ``backend/`` EXCEPT the
-# never-imported subtrees below) can alter the running server. The tracked
-# constitution is also loaded and cached by that process. Both need a restart.
-# Everything else takes effect without one: frontend/** rebuilds into dist,
-# top-level tests/ and docs never run in the server, backend/tests/** never
-# imports, backend/scripts/** are subprocess-invoked fresh each call,
-# backend/recovery_target/** and backend/runtime/** are baked infrastructure,
-# and backend/memeval/** is eval tooling. Broad on backend runtime so a
-# root-level module or symlinked source cannot silently slip past — fail toward
-# restarting.
-_NON_RUNTIME_BACKEND_SUBDIRS = (
-  "backend/tests/", "backend/scripts/", "backend/recovery_target/",
-  "backend/runtime/", "backend/memeval/",
-)
-
-
-def _paths_need_restart(paths: list[str]) -> bool:
-  """True iff changed files are cached or imported by the served process."""
-  for p in paths:
-    if p == "skill/core.md":
-      return True
-    if p != "backend" and not p.startswith("backend/"):
-      continue  # not backend (frontend/tests/docs/…) — no server restart
-    if any(p.startswith(sub) for sub in _NON_RUNTIME_BACKEND_SUBDIRS):
-      continue  # backend, but a subtree the served process never imports
-    return True
-  return False
-
-
 def _paths_need_import_probe(paths: list[str]) -> bool:
   """True iff changed files can affect backend imports in a fresh process."""
-  return _paths_need_restart([p for p in paths if p != "skill/core.md"])
+  return platform_activation.backend_import_probe_required(paths)
+
+
+def _activation_for_paths(paths: list[str]) -> PlatformActivationImpact:
+  return platform_activation.classify_activation(paths)
 
 
 def _tree_change_needs_import_probe(
@@ -948,39 +973,79 @@ def _tree_change_needs_import_probe(
   return _paths_need_import_probe(paths)
 
 
-def _tree_change_needs_restart(
-  repo: Path, before: str | None, after: str | None
-) -> bool:
-  """Does the ``before``→``after`` change require restarting the served uvicorn?
-
-  True iff it touched served backend runtime code or the process-cached
-  constitution. Fail SAFE toward restarting: a missing sha or an uncomputable
-  diff returns True, so a restart is never skipped on an ambiguous change. Same
-  commit → False; a genuinely empty diff (an ``--allow-empty`` commit) → False.
-  """
+def _tree_change_activation(
+  repo: Path, before: str | None, after: str | None,
+) -> PlatformActivationImpact:
+  """Activation contract for a tree delta, failing closed to a server restart."""
   if before == after:
-    return False  # same sha (or both missing) — nothing changed
+    return _activation_for_paths([])
   if not before or not after:
-    return True  # one side unknown — can't prove no backend change, fail closed
+    return _activation_for_paths(["backend/app"])
   paths = _changed_paths(repo, before, after)
   if paths is None:
-    return True  # diff failed — fail closed
-  return _paths_need_restart(paths)  # empty list → genuine no-change → False
+    return _activation_for_paths(["backend/app"])
+  return _activation_for_paths(paths)
 
 
-def _platform_tree_needs_restart(repo: Path = PLATFORM_REPO) -> bool:
+def _pending_activation_paths(repo: Path = PLATFORM_REPO) -> list[str]:
+  marker = _read_activation_marker() or {}
+  marker_paths = marker.get("paths")
+  paths = list(marker_paths) if isinstance(marker_paths, list) else []
   served = _served_platform_sha()
-  if not served:
-    return False
-  try:
-    local = _local_branch(repo)
-    head = _rev(repo, local)
-  except Exception:
-    return False
-  # The tree advanced past what's served, but a restart is only needed if the
-  # served backend package or process-cached constitution changed; a
-  # frontend/tests/docs/scripts advance is already live or irrelevant.
-  return _tree_change_needs_restart(repo, served, head)
+  if served:
+    try:
+      head = _rev(repo, _local_branch(repo))
+    except Exception:
+      head = None
+    changed = _changed_paths(repo, served, head) if head else None
+    if changed:
+      paths.extend(changed)
+  return sorted({str(path) for path in paths if str(path)})
+
+
+def _platform_activation_impact(
+  repo: Path = PLATFORM_REPO,
+) -> PlatformActivationImpact:
+  return _activation_for_paths(_pending_activation_paths(repo))
+
+
+def _complete_boot_activation(repo: Path) -> None:
+  """Retire activation work this boot can prove complete.
+
+  A fresh server always satisfies ``server_restart``.  A new image identity
+  that contains the applied target also proves image/recreate work complete.
+  Proxy reload and host maintenance remain explicit because the container
+  cannot observe or control those external planes.
+  """
+  marker = _read_activation_marker()
+  if not marker:
+    RESTART_NEEDED_FLAG.unlink(missing_ok=True)
+    return
+  paths = marker.get("paths")
+  if not isinstance(paths, list):
+    return
+  target = str(marker.get("target_sha") or "")
+  build = current_build_sha()
+  build_contains_target = bool(
+    target and build and (_rev(repo, build) or "")
+    and _is_ancestor(repo, target, build)
+  )
+  completed_by_image = {
+    platform_activation.ActivationLevel.CONTAINER_RECREATE.value,
+    platform_activation.ActivationLevel.IMAGE_REBUILD.value,
+  }
+  remaining: list[str] = []
+  for path in paths:
+    level = _activation_for_paths([str(path)])["level"]
+    if level in {
+      platform_activation.ActivationLevel.LIVE.value,
+      platform_activation.ActivationLevel.SERVER_RESTART.value,
+    }:
+      continue
+    if build_contains_target and level in completed_by_image:
+      continue
+    remaining.append(str(path))
+  _write_activation_marker(target, remaining)
 
 
 def _changed_paths(
@@ -1262,12 +1327,10 @@ def reconcile_clone(
   _abort_interrupted(repo)
   pre = _rev(repo, local)
 
-  # A boot IS the restart the RESTART_NEEDED flag asks for — the fresh uvicorn
-  # imports whatever is on disk moments from now — so clear it unconditionally at
-  # boot, not only on the success branches, else an owner Apply followed by an
-  # offline reboot (fetch fails, early return) sticks a permanent restart prompt.
+  # A boot satisfies source-restart work, but must not erase image/proxy/host
+  # requirements the process cannot perform or even observe.
   if at_boot:
-    RESTART_NEEDED_FLAG.unlink(missing_ok=True)
+    _complete_boot_activation(repo)
 
   if not _has_origin(repo):
     return ReconcileResult("skipped", pre, pre, None, error="no_origin")
@@ -1339,8 +1402,6 @@ def reconcile_clone(
     _set_upstream(repo, target)
     CONFLICT_FLAG.unlink(missing_ok=True)
     ROLLED_BACK_FLAG.unlink(missing_ok=True)
-    if at_boot:
-      RESTART_NEEDED_FLAG.unlink(missing_ok=True)
     return ReconcileResult("up_to_date", pre, pre, target, error=None)
 
   if progress:
@@ -1514,8 +1575,6 @@ def reconcile_clone(
   _set_upstream(repo, target)
   CONFLICT_FLAG.unlink(missing_ok=True)
   ROLLED_BACK_FLAG.unlink(missing_ok=True)
-  if at_boot:
-    RESTART_NEEDED_FLAG.unlink(missing_ok=True)
   _clear_reconcile_pre()
   return ReconcileResult(
     "updated", pre, new_sha, target, error=None,
@@ -1690,7 +1749,11 @@ def platform_status(repo: Path = PLATFORM_REPO) -> PlatformStatus:
   upstream_sha = recorded_upstream_sha(repo)
   conflict = CONFLICT_FLAG.exists() or _reconcile_in_progress(repo)
   rolled_back = ROLLED_BACK_FLAG.exists()
-  restart_needed = RESTART_NEEDED_FLAG.exists() or _platform_tree_needs_restart(repo)
+  activation = _platform_activation_impact(repo)
+  restart_needed = (
+    activation["level"]
+    == platform_activation.ActivationLevel.SERVER_RESTART.value
+  )
   local = _local_branch(repo)
   target = _rev(repo, DEFAULT_TARGET_REF)
   target_contained = bool(target) and _is_ancestor(repo, target, local)
@@ -1701,7 +1764,8 @@ def platform_status(repo: Path = PLATFORM_REPO) -> PlatformStatus:
     paths = flag.get("paths") or _unmerged_paths(repo)
     return PlatformStatus(
       state=PlatformUpdateState.CONFLICT.value, available=False,
-      needs_restart=restart_needed, current_build_sha=image_sha,
+      needs_restart=restart_needed, activation=activation,
+      current_build_sha=image_sha,
       recorded_upstream_sha=upstream_sha,
       contained_upstream_sha=contained_upstream_sha,
       seed_required=False,
@@ -1716,6 +1780,8 @@ def platform_status(repo: Path = PLATFORM_REPO) -> PlatformStatus:
     available = True
   elif restart_needed:
     state = PlatformUpdateState.RESTART_NEEDED
+  elif activation["level"] != platform_activation.ActivationLevel.LIVE.value:
+    state = PlatformUpdateState.ACTIVATION_NEEDED
   elif available:
     state = PlatformUpdateState.AVAILABLE
   else:
@@ -1723,6 +1789,7 @@ def platform_status(repo: Path = PLATFORM_REPO) -> PlatformStatus:
 
   return PlatformStatus(
     state=state.value, available=available, needs_restart=restart_needed,
+    activation=activation,
     current_build_sha=image_sha, recorded_upstream_sha=upstream_sha,
     contained_upstream_sha=contained_upstream_sha,
     seed_required=False, conflict_paths=[], conflict_chat_id=None,
@@ -1768,6 +1835,7 @@ def empty_platform_update_preview(
   return PlatformUpdatePreview(
     state=PlatformUpdateState.UP_TO_DATE.value, available=False,
     current_sha=current_sha, target_sha=target_sha, plan_id=None,
+    activation=_activation_for_paths([]),
     total_commits=0, commits_truncated=False,
     commits=[], files=[], diff=None, diff_truncated=False, conflict_paths=[],
   )
@@ -1904,6 +1972,7 @@ def _platform_update_preview_unlocked(repo: Path) -> PlatformUpdatePreview:
       state=PlatformUpdateState.AVAILABLE.value, available=True,
       current_sha=local_sha, target_sha=target,
       plan_id=_update_plan_id(local_sha, target) if local_sha else None,
+      activation=_activation_for_paths(["backend/app"]),
       total_commits=0, commits_truncated=False, commits=[], files=[],
       diff=None, diff_truncated=False, conflict_paths=[],
     )
@@ -1911,10 +1980,14 @@ def _platform_update_preview_unlocked(repo: Path) -> PlatformUpdatePreview:
   commits = _preview_commits(repo, base, target)
   total_commits = _preview_commit_count(repo, base, target)
   conflict = _read_conflict_flag() or {}
+  activation_paths = _changed_paths(repo, base, target)
+  if activation_paths is None:
+    activation_paths = ["backend/app"]
   return PlatformUpdatePreview(
     state=PlatformUpdateState.AVAILABLE.value, available=True,
     current_sha=local_sha, target_sha=target,
     plan_id=_update_plan_id(local_sha, target) if local_sha else None,
+    activation=_activation_for_paths(activation_paths),
     total_commits=total_commits,
     commits_truncated=total_commits > len(commits),
     commits=commits,
@@ -1932,11 +2005,13 @@ async def apply_platform_update(
   target_sha: str,
   repo: Path = PLATFORM_REPO,
 ) -> PlatformApplyResult:
-  """Owner-triggered reconcile. Clean/updated -> ``restart_needed`` (the running
-  uvicorn must restart to load the new code). Conflict -> the conflict is
-  recorded and Settings offers an owner-clicked resolver chat. Rolled back ->
-  the tree stayed on the old code and the state says so. Offline/skipped -> a
-  ``409`` via :class:`PlatformUpdateError`. Never restarts on its own."""
+  """Owner-triggered reconcile with an explicit activation remainder.
+
+  Clean source can be live, restartable, or require an external deployment
+  action.  Conflict/rollback leave the previous runtime and its remainder
+  untouched.  The backend never invokes Docker, Caddy, or a provider control
+  plane.
+  """
   async with _APPLY_LOCK:
     _set_update_progress(
       PlatformUpdatePhase.PREPARING,
@@ -1967,6 +2042,30 @@ async def apply_platform_update(
       )
       chat_id: str | None = None
 
+      def record_current_activation(head: str | None) -> PlatformActivationImpact:
+        served = _served_platform_sha()
+        if served == head:
+          changed_paths: list[str] = []
+        elif not served or not head:
+          changed_paths = ["backend/app"]
+        else:
+          maybe_paths = _changed_paths(repo, served, head)
+          changed_paths = ["backend/app"] if maybe_paths is None else maybe_paths
+        incoming_impact = _tree_change_activation(repo, served, head)
+        if (
+          incoming_impact["source_level"]
+          != platform_activation.ActivationLevel.LIVE.value
+        ):
+          mark_activation_needed(head or "", changed_paths)
+        return _platform_activation_impact(repo)
+
+      def clean_state(impact: PlatformActivationImpact) -> PlatformUpdateState:
+        if impact["level"] == platform_activation.ActivationLevel.SERVER_RESTART.value:
+          return PlatformUpdateState.RESTART_NEEDED
+        if impact["level"] != platform_activation.ActivationLevel.LIVE.value:
+          return PlatformUpdateState.ACTIVATION_NEEDED
+        return PlatformUpdateState.UP_TO_DATE
+
       if res.status == "updated":
         publish_progress(PlatformUpdatePhase.FINALIZING)
         hook_refresh = await asyncio.to_thread(
@@ -1974,15 +2073,11 @@ async def apply_platform_update(
         )
         if hook_refresh:
           log.warning("git hook refresh failed after platform update: %s", hook_refresh)
-        # Compare the SERVED sha (what the running uvicorn imported) to the new
-        # head, not just this reconcile's delta: a backend edit committed locally
-        # while the server ran would otherwise be missed if the incoming update
-        # only touched the frontend, leaving apply and status disagreeing.
-        if _tree_change_needs_restart(repo, _served_platform_sha(), res.new_sha):
-          mark_restart_needed(res.new_sha or "")
-          state = PlatformUpdateState.RESTART_NEEDED
-        else:
-          state = PlatformUpdateState.UP_TO_DATE
+        # Compare what this process imported to the new head, not only the
+        # incoming target: local commits made while uvicorn ran are part of the
+        # same activation remainder.
+        activation = record_current_activation(res.new_sha)
+        state = clean_state(activation)
       elif res.status == "conflict":
         # Keep the resolver gated behind the owner's next click. A conflict pass
         # rewrites the flag with target + paths, so preserve a previously opened
@@ -2003,13 +2098,14 @@ async def apply_platform_update(
       elif res.status == "rolled_back":
         state = PlatformUpdateState.ROLLED_BACK
       elif res.status == "up_to_date":
-        if _platform_tree_needs_restart(repo):
-          mark_restart_needed(_rev(repo, _local_branch(repo)) or res.pre_sha or "")
-          state = PlatformUpdateState.RESTART_NEEDED
-        else:
-          state = PlatformUpdateState.UP_TO_DATE
+        head = _rev(repo, _local_branch(repo)) or res.pre_sha
+        activation = record_current_activation(head)
+        state = clean_state(activation)
       else:  # offline / skipped — nothing changed; tell the UI plainly.
         raise PlatformUpdateError(res.error or res.status)
+
+      if res.status in {"conflict", "rolled_back"}:
+        activation = _platform_activation_impact(repo)
 
       final_phase = (
         PlatformUpdatePhase.BLOCKED
@@ -2025,7 +2121,11 @@ async def apply_platform_update(
       )
       return PlatformApplyResult(
         state=state.value,
-        needs_restart=(state is PlatformUpdateState.RESTART_NEEDED),
+        needs_restart=(
+          activation["level"]
+          == platform_activation.ActivationLevel.SERVER_RESTART.value
+        ),
+        activation=activation,
         upstream_commit=res.target_sha,
         merge_commit=res.new_sha if res.status == "updated" else None,
         conflict_paths=res.conflict_paths,

--- a/backend/app/response_policy.py
+++ b/backend/app/response_policy.py
@@ -1,0 +1,120 @@
+"""Origin-owned browser response policies shared by every deployment path."""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+from urllib.parse import urlparse
+
+
+def absolute_csp_origin(value: str) -> str | None:
+  """Return one origin-only HTTP(S) CSP source or fail closed."""
+  try:
+    parsed = urlparse(value.strip())
+    port = parsed.port
+  except (AttributeError, TypeError, ValueError):
+    return None
+  if (
+    parsed.scheme not in {"http", "https"}
+    or not parsed.hostname
+    or parsed.username is not None
+    or parsed.password is not None
+    or parsed.path not in ("", "/")
+    or parsed.params
+    or parsed.query
+    or parsed.fragment
+  ):
+    return None
+  hostname = parsed.hostname
+  if ":" in hostname:
+    try:
+      ipaddress.IPv6Address(hostname)
+    except ValueError:
+      return None
+    host = f"[{hostname}]"
+  else:
+    if not re.fullmatch(r"[A-Za-z0-9.-]+", hostname):
+      return None
+    host = hostname
+  authority = f"{host}:{port}" if port is not None else host
+  return f"{parsed.scheme}://{authority}"
+
+
+def _validated_frontend_origin(frontend_origin: str) -> str:
+  origin = absolute_csp_origin(frontend_origin)
+  if origin is None:
+    raise RuntimeError("FRONTEND_ORIGIN must be one absolute HTTP(S) origin")
+  return origin
+
+
+def app_frame_csp(frontend_origin: str, gateway_origin: str = "") -> str:
+  """Complete policy for the opaque mini-app document."""
+  origin = _validated_frontend_origin(frontend_origin)
+  frame_sources = [origin]
+  gateway = absolute_csp_origin(gateway_origin)
+  if gateway is not None and gateway != origin:
+    frame_sources.append(gateway)
+  return (
+    "sandbox allow-scripts allow-forms allow-popups "
+    "allow-popups-to-escape-sandbox "
+    "allow-top-navigation-by-user-activation; "
+    f"default-src {origin}; "
+    f"script-src {origin} 'unsafe-inline' 'wasm-unsafe-eval' "
+    "blob: https://esm.sh; "
+    f"style-src {origin} 'unsafe-inline' https://fonts.googleapis.com; "
+    f"font-src {origin} https://fonts.gstatic.com https://cdn.openai.com; "
+    f"connect-src {origin}; "
+    f"img-src {origin} data: blob:; "
+    f"frame-src {' '.join(frame_sources)}; "
+    "frame-ancestors 'self'"
+  )
+
+
+def shell_csp(gateway_origin: str = "") -> str:
+  """Policy for ordinary shell/API documents, independent of proxy syntax."""
+  frame_sources = ["'self'"]
+  gateway = absolute_csp_origin(gateway_origin)
+  if gateway is not None:
+    frame_sources.append(gateway)
+  return (
+    "default-src 'self'; "
+    "script-src 'self' 'unsafe-inline' https://esm.sh; "
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
+    "font-src 'self' https://fonts.gstatic.com https://cdn.openai.com; "
+    "connect-src 'self'; "
+    "img-src 'self' data: blob:; "
+    f"frame-src {' '.join(frame_sources)}; "
+    "frame-ancestors 'self'"
+  )
+
+
+CHAT_EMBED_CSP = (
+  "default-src 'self'; "
+  "script-src 'self' 'unsafe-inline' https://esm.sh; "
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
+  "font-src 'self' https://fonts.gstatic.com https://cdn.openai.com; "
+  "connect-src 'self'; "
+  "img-src 'self' data: blob:; "
+  "frame-src 'self'"
+)
+
+
+def static_embed_csp(frontend_origin: str) -> str:
+  origin = _validated_frontend_origin(frontend_origin)
+  return (
+    "sandbox allow-scripts allow-forms allow-pointer-lock; "
+    f"default-src {origin}; "
+    f"script-src {origin} 'unsafe-inline'; "
+    f"style-src {origin} 'unsafe-inline'; "
+    f"font-src {origin} data:; "
+    f"connect-src {origin}; "
+    f"img-src {origin} data: blob:; "
+    f"media-src {origin} blob:; "
+    f"worker-src {origin} blob:"
+  )
+
+
+PUBLISHED_SITE_CSP = (
+  "sandbox allow-scripts allow-forms allow-popups; "
+  "object-src 'none'; base-uri 'none'; frame-ancestors 'self'"
+)

--- a/backend/app/routes/app_runtime.py
+++ b/backend/app/routes/app_runtime.py
@@ -3,6 +3,7 @@
 import asyncio
 import hashlib
 import json
+import os
 import re
 from pathlib import Path
 from urllib.parse import urljoin, urlparse
@@ -19,6 +20,7 @@ from app.deps import get_current_owner, resolve_owner_or_app
 from app.http_caching import strip_range
 from app.net_utils import validate_url_safe
 from app.resource_access import live_app, live_app_or_404
+from app.response_policy import absolute_csp_origin, app_frame_csp
 
 
 router = APIRouter()
@@ -247,11 +249,22 @@ def _not_modified_if_match(
   return None
 
 
-_APP_FRAME_CSP = (
-  "sandbox allow-scripts allow-forms allow-popups "
-  "allow-popups-to-escape-sandbox "
-  "allow-top-navigation-by-user-activation"
-)
+_absolute_csp_origin = absolute_csp_origin
+
+
+def _app_frame_csp() -> str:
+  """Complete mini-app document policy for every deployment topology.
+
+  The origin response owns this policy so managed platforms and self-hosted
+  reverse proxies cannot drift. Caddy deliberately passes it through rather
+  than maintaining a second copy. ``'wasm-unsafe-eval'`` is the narrow browser
+  permission for WebAssembly compilation; it does not allow JavaScript
+  ``eval()`` or ``new Function()``.
+  """
+  return app_frame_csp(
+    get_settings().frontend_origin,
+    os.environ.get("MOBIUS_SERVICE_GATEWAY_ORIGIN", ""),
+  )
 
 
 def _frame_etag(
@@ -371,7 +384,6 @@ def get_frame(
   etag = _frame_etag(app, frame_path, frame_rev=frame_rev)
   frame_cache_headers = {
     "Cache-Control": "no-cache",
-    "Content-Security-Policy": _APP_FRAME_CSP,
   }
   if etag:
     not_modified = _not_modified_if_match(
@@ -404,14 +416,14 @@ def get_frame(
   # bytes are theme-independent (so the ETag no longer folds the theme).
 
   # The element remains unsandboxed until navigation so the shell service
-  # worker can intercept and serve a cached frame offline. Apply the equivalent
-  # sandbox on the RESPONSE: the loaded app still receives an opaque origin,
-  # including when this backend is reached without the edge proxy. Caddy adds
-  # the full resource policy while preserving this sandbox contract. Popups
+  # worker can intercept and serve a cached frame offline. The origin security
+  # middleware applies the response sandbox on both 200 and 304. Popups
   # opened by an explicit app link must escape the opaque-origin sandbox:
   # otherwise the destination inherits Origin: null and sites such as GitHub
   # load their document but fail same-origin API/storage requests. This does
-  # not relax the app frame itself or let it navigate the owner shell.
+  # not relax the app frame itself or let it navigate the owner shell. The
+  # complete resource policy lives at the origin; reverse proxies pass it
+  # through so Railway and self-hosted installs enforce one contract.
   headers = dict(frame_cache_headers)
   if etag:
     headers["ETag"] = etag

--- a/backend/app/routes/platform.py
+++ b/backend/app/routes/platform.py
@@ -25,7 +25,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 from starlette.background import BackgroundTask
 
-from app import models, platform_update
+from app import models, platform_activation, platform_update
 from app.database import get_db
 from app.deps import get_current_owner, reject_cross_site
 from app.platform_update import (
@@ -64,7 +64,9 @@ async def get_platform_status(
     log.warning("platform status failed: %r", exc)
     return PlatformStatus(
       state=platform_update.PlatformUpdateState.UP_TO_DATE.value,
-      available=False, needs_restart=False, current_build_sha=None,
+      available=False, needs_restart=False,
+      activation=platform_activation.classify_activation([]),
+      current_build_sha=None,
       recorded_upstream_sha=None, contained_upstream_sha=None,
       seed_required=False, conflict_paths=[],
       conflict_chat_id=None,

--- a/backend/tests/test_frame.py
+++ b/backend/tests/test_frame.py
@@ -75,13 +75,20 @@ def test_frame_returns_etag_and_cache_control(client, owner_token):
   assert r.status_code == 200
   assert r.headers.get("etag", "").startswith('W/"')
   assert "no-cache" in r.headers.get("cache-control", "")
-  sandbox = r.headers.get("content-security-policy", "")
-  assert "sandbox allow-scripts" in sandbox
+  policy = r.headers.get("content-security-policy", "")
+  assert "sandbox allow-scripts" in policy
   # A target=_blank link must open as a normal destination page rather than
   # inheriting this frame's opaque origin (which breaks same-origin fetches and
   # signed-in storage on sites such as GitHub).
-  assert "allow-popups-to-escape-sandbox" in sandbox
-  assert "allow-same-origin" not in sandbox
+  assert "allow-popups-to-escape-sandbox" in policy
+  assert "allow-same-origin" not in policy
+  # The origin response—not a deployment-specific proxy—owns the complete
+  # resource policy, so Railway and self-hosted installs both admit reviewed
+  # browser WebAssembly without enabling JavaScript eval.
+  assert "script-src " in policy
+  assert "'wasm-unsafe-eval'" in policy
+  assert " 'unsafe-eval'" not in policy
+  assert "blob:" in policy
 
 
 def test_frame_304_on_matching_if_none_match(client, owner_token):

--- a/backend/tests/test_platform_activation.py
+++ b/backend/tests/test_platform_activation.py
@@ -1,0 +1,67 @@
+"""Activation classification is one ordered contract across deployments."""
+
+from pathlib import Path
+
+from app import platform_activation as activation
+
+
+def test_ordered_levels_choose_the_highest_effective_action():
+  impact = activation.classify_activation(
+    ["frontend/src/App.jsx", "backend/app/main.py", "Dockerfile"],
+    deployment="self_hosted",
+  )
+
+  assert impact["level"] == "image_rebuild"
+  assert impact["actions"] == ["server_restart", "image_rebuild"]
+  assert impact["requires_operator"] is True
+
+
+def test_deployment_specific_inputs_share_contract_without_fake_commands():
+  caddy_on_railway = activation.classify_activation(
+    ["Caddyfile"], deployment="railway",
+  )
+  railway_on_self_hosted = activation.classify_activation(
+    ["railway.toml"], deployment="self_hosted",
+  )
+
+  assert caddy_on_railway["source_level"] == "proxy_reload"
+  assert caddy_on_railway["level"] == "live"
+  assert caddy_on_railway["reasons"][0]["applies"] is False
+  assert railway_on_self_hosted["source_level"] == "container_recreate"
+  assert railway_on_self_hosted["level"] == "live"
+
+
+def test_baked_runtime_and_dependencies_never_degrade_to_restart_only():
+  for path in (
+    "backend/requirements.txt",
+    "frontend/package-lock.json",
+    "backend/scripts/entrypoint.sh",
+    "backend/runtime/restart_ledger.py",
+    "backend/recovery_target/targetd.py",
+    "protected-files.txt",
+  ):
+    impact = activation.classify_activation([path], deployment="self_hosted")
+    assert impact["level"] == "image_rebuild", path
+    assert impact["requires_operator"] is True
+
+
+def test_dependency_fingerprint_comes_from_the_image_rules():
+  root = Path(__file__).resolve().parents[2]
+  paths = activation.dependency_fingerprint_paths(root)
+
+  assert paths == sorted({
+    "Dockerfile",
+    "backend/legacy_runtime/jose/__init__.py",
+    "backend/legacy_runtime/verify_jose.py",
+    "backend/requirements.lock",
+    "backend/requirements.txt",
+    "frontend/package-lock.json",
+    "frontend/package.json",
+  })
+
+
+def test_no_global_cross_origin_isolation_is_hidden_in_activation_policy():
+  source = Path(__file__).resolve().parents[1] / "app" / "response_policy.py"
+  text = source.read_text(encoding="utf-8")
+  assert "Cross-Origin-Opener-Policy" not in text
+  assert "Cross-Origin-Embedder-Policy" not in text

--- a/backend/tests/test_platform_update.py
+++ b/backend/tests/test_platform_update.py
@@ -1077,6 +1077,7 @@ async def test_apply_restarts_and_rebuilds_when_update_touches_backend(
   # A backend change (mixed with frontend) still restarts AND rebuilds.
   assert res["state"] == pu.PlatformUpdateState.RESTART_NEEDED.value
   assert res["needs_restart"] is True
+  assert res["activation"]["level"] == "server_restart"
   assert calls == [(platform, new)]
 
 
@@ -1240,34 +1241,29 @@ async def test_apply_marks_restart_when_disk_already_ahead_of_running_backend(
 
   assert res["state"] == pu.PlatformUpdateState.RESTART_NEEDED.value
   assert res["needs_restart"] is True
-  assert pu.RESTART_NEEDED_FLAG.read_text() == head
+  assert pu._read_activation_marker() == {
+    "target_sha": head,
+    "paths": ["backend/app/main.py"],
+  }
 
 
-# --- path-aware restart classifier (backend/app change → restart; else not) --
+# --- path-aware activation classifier ---------------------------------------
 
-def test_paths_need_restart_classifier():
-  assert pu._paths_need_restart(["backend/app/main.py"]) is True
-  assert pu._paths_need_restart(["backend/app/routes/apps.py", "docs/x.md"]) is True
-  # a backend RUNTIME file outside backend/app/ (root module, deps) also restarts
-  assert pu._paths_need_restart(["backend/config_helper.py"]) is True
-  assert pu._paths_need_restart(["backend/requirements.txt"]) is True
-  assert pu._paths_need_restart(["backend/requirements.lock"]) is True
-  # the platform constitution is process-cached even though it is not Python
-  assert pu._paths_need_restart(["skill/core.md"]) is True
-  # a rename OUT of backend/app (with --no-renames the delete side shows) restarts
-  assert pu._paths_need_restart(
-    ["docs/admin.py", "backend/app/routes/admin.py"]) is True
-  # non-backend-runtime paths never force a restart of the served uvicorn
-  assert pu._paths_need_restart([
-    "frontend/src/App.jsx", "tests/foo.spec.mjs", "backend/tests/test_x.py",
-    "backend/scripts/memory_search.py", "backend/recovery_target/targetd.py",
-    "backend/runtime/restart_ledger.py",
-    "backend/memeval/systems.py", "docs/y.md", "README.md",
-  ]) is False
-  assert pu._paths_need_restart([]) is False
-  # a path merely CONTAINING backend/app/ but not under it is not runtime code
-  assert pu._paths_need_restart(["docs/backend/app/notes.md"]) is False
-  assert pu._paths_need_restart(["skill/building-apps.md"]) is False
+def test_platform_update_uses_explicit_activation_levels():
+  assert pu._activation_for_paths(["backend/app/main.py"])["level"] == \
+    "server_restart"
+  assert pu._activation_for_paths(["backend/config_helper.py"])["level"] == \
+    "server_restart"
+  assert pu._activation_for_paths(["skill/core.md"])["level"] == \
+    "server_restart"
+  assert pu._activation_for_paths(["backend/requirements.txt"])["level"] == \
+    "image_rebuild"
+  assert pu._activation_for_paths(["backend/scripts/entrypoint.sh"])["level"] == \
+    "image_rebuild"
+  assert pu._activation_for_paths(["Caddyfile"])["level"] == "proxy_reload"
+  assert pu._activation_for_paths(["frontend/src/App.jsx"])["level"] == "live"
+  assert pu._activation_for_paths(["backend/tests/test_x.py"])["level"] == "live"
+  assert pu._activation_for_paths(["docs/backend/app/notes.md"])["level"] == "live"
 
 
 def test_import_probe_classifier_excludes_constitution_only_change():
@@ -1305,7 +1301,8 @@ def test_changed_paths_no_renames_surfaces_deleted_backend(clone_env):
 
   paths = pu._changed_paths(platform, before, after)
   assert "backend/app/main.py" in paths  # delete side present
-  assert pu._tree_change_needs_restart(platform, before, after) is True
+  assert pu._tree_change_activation(platform, before, after)["level"] == \
+    "server_restart"
 
 
 def test_empty_commit_does_not_force_restart(clone_env):
@@ -1316,18 +1313,20 @@ def test_empty_commit_does_not_force_restart(clone_env):
 
   assert before != after
   assert pu._changed_paths(platform, before, after) == []  # genuine empty diff
-  assert pu._tree_change_needs_restart(platform, before, after) is False
+  assert pu._tree_change_activation(platform, before, after)["level"] == "live"
 
 
-def test_tree_change_needs_restart_fails_closed_on_missing_sha(clone_env):
+def test_tree_change_activation_fails_closed_on_missing_sha(clone_env):
   origin, platform = clone_env
   served = _served_sha(platform)
   # one side unknown → can't prove no backend change → restart (fail closed)
-  assert pu._tree_change_needs_restart(platform, served, None) is True
-  assert pu._tree_change_needs_restart(platform, None, served) is True
+  assert pu._tree_change_activation(platform, served, None)["level"] == \
+    "server_restart"
+  assert pu._tree_change_activation(platform, None, served)["level"] == \
+    "server_restart"
   # both missing / equal → nothing changed
-  assert pu._tree_change_needs_restart(platform, None, None) is False
-  assert pu._tree_change_needs_restart(platform, served, served) is False
+  assert pu._tree_change_activation(platform, None, None)["level"] == "live"
+  assert pu._tree_change_activation(platform, served, served)["level"] == "live"
 
 
 def test_status_no_restart_when_only_frontend_changed(clone_env):
@@ -1358,6 +1357,40 @@ def test_status_no_restart_when_only_tests_changed(clone_env):
 
   assert status["needs_restart"] is False
   assert status["state"] == pu.PlatformUpdateState.UP_TO_DATE.value
+
+
+def test_status_requires_image_instead_of_offering_restart_for_dependencies(
+  clone_env,
+):
+  _, platform = clone_env
+  served = _served_sha(platform)
+  pu.SERVING_SOURCE_FILE.write_text("platform\n")
+  pu.SERVING_SHA_FILE.write_text(served + "\n")
+  _local_commit(platform, edits={"backend/requirements.txt": "new-package==1\n"})
+
+  status = pu.platform_status(platform)
+
+  assert status["state"] == pu.PlatformUpdateState.ACTIVATION_NEEDED.value
+  assert status["needs_restart"] is False
+  assert status["activation"]["level"] == "image_rebuild"
+  assert status["activation"]["requires_operator"] is True
+
+
+def test_boot_clears_restart_but_preserves_unverified_image_work(clone_env):
+  _, platform = clone_env
+  target = _served_sha(platform)
+  pu.mark_activation_needed(
+    target,
+    ["backend/app/main.py", "backend/requirements.lock"],
+  )
+
+  res = pu.reconcile_clone(platform, at_boot=True)
+
+  assert res.status == "up_to_date"
+  assert pu._read_activation_marker() == {
+    "target_sha": target,
+    "paths": ["backend/requirements.lock"],
+  }
 
 
 # --- restart flag lifecycle -------------------------------------------------
@@ -1526,6 +1559,24 @@ def test_update_preview_clean_fast_forward(clone_env):
   assert "backend/app/main.py" in changed
   assert "LINE_C = 300" in preview["diff"]
   assert preview["diff_truncated"] is False
+  assert preview["activation"]["level"] == "server_restart"
+
+
+def test_update_preview_warns_before_dependency_update_is_applied(clone_env):
+  origin, platform = clone_env
+  _advance_origin(
+    origin,
+    edits={"backend/requirements.lock": "locked dependency bytes\n"},
+    msg="change image dependency",
+  )
+  pu._fetch(platform)
+
+  preview = pu.platform_update_preview(platform)
+
+  assert preview["activation"]["level"] == "image_rebuild"
+  assert preview["activation"]["actions"] == ["image_rebuild"]
+  assert "Restart cannot" not in " ".join(preview["activation"]["guidance"])
+  assert "rebuild the image" in " ".join(preview["activation"]["guidance"])
 
 
 def test_update_preview_excludes_local_edits(clone_env):
@@ -1725,7 +1776,10 @@ async def test_frontend_build_failure_rolls_back_source_and_is_not_success(
 
   assert result["state"] == pu.PlatformUpdateState.ROLLED_BACK.value
   assert result["phase"] == pu.PlatformUpdatePhase.BLOCKED.value
-  assert result["needs_restart"] is False
+  # The failed newer release does not erase activation already pending before
+  # this Apply attempt.
+  assert result["needs_restart"] is True
+  assert result["activation"]["level"] == "server_restart"
   assert result["upstream_commit"] == target
   assert result["merge_commit"] is None
   assert _served_sha(platform) == before

--- a/backend/tests/test_security_headers.py
+++ b/backend/tests/test_security_headers.py
@@ -1,20 +1,16 @@
-"""The security-header middleware stamps the standard headers on every response.
+"""The origin owns response policy; Caddy passes it through unchanged."""
 
-These are resource-load-agnostic (clickjacking / MIME-sniff / TLS / referrer).
-The backend deliberately has no global resource CSP; exact opaque/static/service
-documents supply their own policies while the bundled proxy owns shell CSP.
-"""
-
-import re
 from pathlib import Path
-from urllib.parse import urlparse
 
-import yaml
 from fastapi import Response
 from fastapi.testclient import TestClient
 
 from app import main
-from app.main import _PUBLISHED_SITE_CSP, _STATIC_EMBED_CSP, app
+from app.main import (
+  _PUBLISHED_SITE_CSP, _SHELL_CSP, _STATIC_EMBED_CSP, app,
+)
+from app.response_policy import CHAT_EMBED_CSP
+from app.routes.app_runtime import _app_frame_csp
 
 
 def _headers(path="/api/health"):
@@ -63,32 +59,14 @@ def test_published_site_sandbox_survives_a_404_and_a_500(monkeypatch):
   assert r500.headers.get("content-security-policy") == _PUBLISHED_SITE_CSP
 
 
-def test_bundled_caddy_mirrors_published_site_sandbox():
+def test_bundled_caddy_does_not_override_published_site_sandbox():
   caddyfile = Path(__file__).resolve().parents[2] / "Caddyfile"
-  lines = [line.strip() for line in caddyfile.read_text(encoding="utf-8").splitlines()]
-  # /sites/ is a DISJOINT matcher, excluded from @notFrameableEmbed, with its
-  # own X-Frame-Options + CSP — Caddy does not guarantee a later `header >Set`
-  # wins over an earlier one on the same field, so two overlapping matchers on
-  # Content-Security-Policy are unreliable. It mirrors how /app-embeds are
-  # excluded and self-header their own policy.
-  assert "@publishedSite path /sites/*" in lines
-  assert (
-    "@notFrameableEmbed not path /shell/embed/chat /app-embeds/by-id/* "
-    "/api/apps/*/frame /sites/*" in lines
-  ), "published sites must be excluded from the shell CSP matcher"
-  # Its own frame boundary, set directly on the disjoint matcher.
-  assert 'header @publishedSite >X-Frame-Options "SAMEORIGIN"' in lines
-  pub_csp = next(
-    line for line in lines
-    if line.startswith("header @publishedSite >Content-Security-Policy ")
-  )
-  # Assert EQUALITY with the origin policy, not just substrings: the whole
-  # point of this pair is that the proxy and the origin send the same thing,
-  # and a substring check would pass while they silently diverged.
-  assert pub_csp == (
-    'header @publishedSite >Content-Security-Policy "'
-    f'{_PUBLISHED_SITE_CSP}"'
-  )
+  primary = caddyfile.read_text(encoding="utf-8").split(
+    "# Full backend web services", 1,
+  )[0]
+  assert "reverse_proxy app:8000" in primary
+  assert "Content-Security-Policy" not in primary
+  assert "X-Frame-Options" not in primary
   assert "sandbox allow-scripts" in _PUBLISHED_SITE_CSP
   assert "allow-same-origin" not in _PUBLISHED_SITE_CSP
   # external-asset sites must keep loading
@@ -100,14 +78,17 @@ def test_standard_security_headers_present():
   assert h.get("x-content-type-options") == "nosniff"
   assert h.get("x-frame-options") == "SAMEORIGIN"
   assert h.get("referrer-policy") == "strict-origin-when-cross-origin"
-  assert h.get("permissions-policy") == "camera=(), geolocation=()"
+  assert h.get("permissions-policy") == "camera=(self), geolocation=(self)"
   assert "strict-transport-security" in h
 
 
-def test_no_csp_so_apps_keep_loading_web_resources():
-  # Deliberately no global Content-Security-Policy — ordinary app resource
-  # freedom is separate from the exact document policies tested below.
-  assert "content-security-policy" not in _headers()
+def test_direct_shell_response_receives_the_origin_owned_policy():
+  policy = _headers().get("content-security-policy")
+  assert policy == _SHELL_CSP
+  assert "https://esm.sh" in policy
+  assert "img-src 'self' data: blob:" in policy
+  assert "'wasm-unsafe-eval'" not in policy
+  assert "Cross-Origin-Opener-Policy" not in _headers()
 
 
 def test_embedded_chat_allows_opaque_origin_app_ancestor():
@@ -117,6 +98,7 @@ def test_embedded_chat_allows_opaque_origin_app_ancestor():
   # The route itself is inert: no chat id or credential is accepted in its URL.
   h = _headers("/shell/embed/chat")
   assert "x-frame-options" not in h
+  assert h.get("content-security-policy") == CHAT_EMBED_CSP
   assert h.get("x-content-type-options") == "nosniff"
   assert h.get("strict-transport-security")
 
@@ -161,185 +143,68 @@ def test_static_embed_policy_survives_unhandled_route_exception(monkeypatch):
   assert "x-frame-options" not in response.headers
 
 
-def test_bundled_caddy_mirrors_exact_embed_frame_exception():
-  """The compose proxy must not silently re-add either frame blocker."""
+def test_bundled_caddy_keeps_only_gateway_specific_response_policy():
+  """The primary proxy is pass-through; gateway host behavior stays exact."""
   caddyfile = Path(__file__).resolve().parents[2] / "Caddyfile"
-  lines = [line.strip() for line in caddyfile.read_text(encoding="utf-8").splitlines()]
-  assert "@chatEmbed path /shell/embed/chat" in lines
-  assert "@staticEmbed path /app-embeds/by-id/*" in lines
-  assert "@appFrame path /api/apps/*/frame" in lines
-  assert (
-    "@notFrameableEmbed not path /shell/embed/chat /app-embeds/by-id/* "
-    "/api/apps/*/frame /sites/*" in lines
+  text = caddyfile.read_text(encoding="utf-8")
+  primary, gateway = text.split("# Full backend web services", 1)
+  assert "header" not in primary
+  assert "reverse_proxy app:8000" in primary
+  assert "@serviceSurface path /services/*" in gateway
+  assert "?Content-Security-Policy" in gateway
+  assert "frame-ancestors 'self' {$FRONTEND_ORIGIN}" in gateway
+  assert "-X-Frame-Options" in gateway
+  assert 'respond "Not found" 404' in gateway
+  assert ">X-Content-Type-Options" not in gateway
+  assert ">Permissions-Policy" not in gateway
+  # Direct origin policies retain the exact scoped differences Caddy used to
+  # mirror by hand.
+  assert "frame-ancestors 'self'" in _SHELL_CSP
+  assert "frame-ancestors" not in CHAT_EMBED_CSP
+  assert "sandbox allow-scripts" in _STATIC_EMBED_CSP
+  assert "allow-same-origin" not in _STATIC_EMBED_CSP
+  service_csp = next(
+    line for line in (line.strip() for line in gateway.splitlines())
+    if line.startswith("?Content-Security-Policy ")
   )
-  assert 'header @notFrameableEmbed >X-Frame-Options "SAMEORIGIN"' in lines
-  assert not any(
-    line.startswith("X-Frame-Options ") for line in lines
-  ), "X-Frame-Options must remain on the exact non-embed matcher"
-  ordinary_csp = next(
-    line for line in lines
-    if line.startswith("header @notFrameableEmbed >Content-Security-Policy ")
-  )
-  embed_csp = next(
-    line for line in lines
-    if line.startswith("header @chatEmbed >Content-Security-Policy ")
-  )
-  assert "frame-ancestors 'self'" in ordinary_csp
-  assert "frame-src 'self' {$MOBIUS_SERVICE_GATEWAY_ORIGIN}" in ordinary_csp
-  assert "frame-src *" not in ordinary_csp
-  assert "frame-ancestors" not in embed_csp
-  assert "frame-src 'self'" in embed_csp
-  assert "MOBIUS_SERVICE_GATEWAY_ORIGIN" not in embed_csp
-  # Both the shell and the embedded chat render upload previews and the image
-  # lightbox via URL.createObjectURL; a policy without blob: breaks those.
-  assert "img-src 'self' data: blob:" in ordinary_csp
-  assert "img-src 'self' data: blob:" in embed_csp
-  assert "https://cdn.openai.com" in ordinary_csp
-  assert "https://cdn.openai.com" in embed_csp
-  app_frame_csp = next(
-    line for line in lines
-    if line.startswith("header @appFrame >Content-Security-Policy ")
-  )
-  assert "sandbox allow-scripts" in app_frame_csp
-  assert "allow-popups-to-escape-sandbox" in app_frame_csp
-  assert "allow-same-origin" not in app_frame_csp
-  assert (
-    "script-src {$FRONTEND_ORIGIN} 'unsafe-inline' blob: https://esm.sh"
-    in app_frame_csp
-  )
-  assert "blob:" not in ordinary_csp.split("style-src", 1)[0]
-  assert 'header @appFrame >X-Frame-Options "SAMEORIGIN"' in lines
-  # The frame's origin is opaque, so 'self' matches nothing in EVERY fetch
-  # directive. The response's absolute origin must be named wherever the frame
-  # intentionally loads its own resources, not only for API connections.
+  assert "frame-ancestors 'self' {$FRONTEND_ORIGIN}" in service_csp
+  assert "{$MOBIUS_SERVICE_GATEWAY_ORIGIN} {" in gateway
+
+
+def test_backend_owns_complete_app_frame_policy(monkeypatch):
+  """Direct managed and proxied installs receive one exact frame policy."""
+  gateway = "https://services.example.test"
+  monkeypatch.setenv("MOBIUS_SERVICE_GATEWAY_ORIGIN", gateway)
+  policy = _app_frame_csp()
+  origin = main.settings.frontend_origin.rstrip("/")
+
+  assert "sandbox allow-scripts" in policy
+  assert "allow-popups-to-escape-sandbox" in policy
+  assert "allow-same-origin" not in policy
+  assert "'wasm-unsafe-eval'" in policy
+  assert " 'unsafe-eval'" not in policy
+  assert f"frame-src {origin} {gateway}" in policy
+
+  # The frame's origin is opaque, so 'self' matches nothing in fetch
+  # directives. Every intentional same-site resource source must name the
+  # origin explicitly, independent of the deployment's reverse proxy.
   for directive in (
     "default-src", "script-src", "style-src", "font-src", "connect-src",
     "img-src", "frame-src",
   ):
-    sources = app_frame_csp.split(f"{directive} ", 1)[1].split(";", 1)[0]
-    assert "{$FRONTEND_ORIGIN}" in sources
+    sources = policy.split(f"{directive} ", 1)[1].split(";", 1)[0]
+    assert origin in sources
     assert "'self'" not in sources
-  static_csp = next(
-    line for line in lines
-    if line.startswith("header @staticEmbed >Content-Security-Policy ")
+
+
+def test_app_frame_policy_drops_malformed_gateway_origin(monkeypatch):
+  monkeypatch.setenv(
+    "MOBIUS_SERVICE_GATEWAY_ORIGIN",
+    "https://services.example.test; script-src *",
   )
-  assert "sandbox allow-scripts" in static_csp
-  assert "allow-same-origin" not in static_csp
-  assert "frame-ancestors" not in static_csp
-  assert "MOBIUS_SERVICE_GATEWAY_ORIGIN" not in static_csp
-  # Caddy and the backend must enforce the same packaged-document boundary.
-  # Resolve the sole Caddy env placeholder to the configured backend origin,
-  # then compare the complete policy rather than sampling one directive.
-  assert (
-    static_csp.split('Content-Security-Policy "', 1)[1].rsplit('"', 1)[0]
-    .replace("{$FRONTEND_ORIGIN}", main.settings.frontend_origin.rstrip("/"))
-    == _STATIC_EMBED_CSP
-  )
-  service_csp = next(
-    line for line in lines
-    if line.startswith("?Content-Security-Policy ")
-  )
-  assert "frame-ancestors 'self' {$FRONTEND_ORIGIN}" in service_csp
-  assert "{$MOBIUS_SERVICE_GATEWAY_ORIGIN} {" in lines
-  assert "@serviceSurface path /services/*" in lines
-  assert "respond \"Not found\" 404" in lines
-  assert "-X-Frame-Options" in lines
-  for name in (
-    "X-Content-Type-Options", "Referrer-Policy", "Permissions-Policy",
-    "Strict-Transport-Security",
-  ):
-    assert any(line.startswith(f">{name} ") for line in lines), (
-      f"{name} must replace, not duplicate, the backend value after proxying"
-    )
-
-
-def test_app_frame_sources_stay_absolute_in_every_environment():
-  """Every variable-backed CSP source resolves to one absolute origin.
-
-  The app frame is sandboxed without allow-same-origin, so its origin is opaque:
-  'self' matches nothing and a scheme-less host matches nothing, which leaves a
-  real `scheme://host` as the only source that can match. Writing that as
-  `https://{$DOMAIN}` looks right because DOMAIN is a bare host in production —
-  but it is a full URL under docker-compose.test.yml, so the prefix yielded
-  `https://http://localhost:8001`. Browsers drop an invalid source silently,
-  so the directive was left with no usable origin and the frame could not reach
-  the API at all. Resolve the placeholder against every value the compose files
-  actually assign, so the next such rewrite fails here rather than in e2e.
-
-  Resolution is scoped to the service that mounts the Caddyfile: that container
-  is what expands `{$VAR}`, so a variable defined only on some other service
-  would leave the directive empty at runtime while still looking assigned.
-  """
-  root = Path(__file__).resolve().parents[2]
-  caddy_lines = (root / "Caddyfile").read_text(encoding="utf-8").splitlines()
-  # FRONTEND_ORIGIN is deliberately also the site address. Caddy cannot parse
-  # an empty site label, so an omitted variable now fails startup instead of
-  # quietly deleting the only source that opaque frames can match.
-  assert caddy_lines[0].strip() == "{$FRONTEND_ORIGIN} {"
-  app_frame_csp = next(
-    line.strip()
-    for line in caddy_lines
-    if line.strip().startswith("header @appFrame >Content-Security-Policy ")
-  )
-  policy = app_frame_csp.split(
-    'Content-Security-Policy "', 1
-  )[1].rsplit('"', 1)[0]
-  variable_directives = {
-    fields[0]: " ".join(fields[1:])
-    for raw in policy.split(";")
-    if (fields := raw.strip().split()) and "{$" in raw
-  }
-  assert variable_directives, "the app frame must name its absolute origins"
-
-  # Compose's own merge tags (`!override`, `!reset`) are not YAML-standard, so
-  # a plain safe_load raises on docker-compose.test.yml. Keep the node's value
-  # and drop the tag; nothing here inspects a tagged field.
-  class _ComposeLoader(yaml.SafeLoader):
-    pass
-
-  _ComposeLoader.add_multi_constructor(
-    "", lambda loader, suffix, node: loader.construct_sequence(node)
-    if isinstance(node, yaml.SequenceNode) else loader.construct_scalar(node)
-  )
-
-  for name in ("docker-compose.yml", "docker-compose.test.yml"):
-    services = yaml.load(
-      (root / name).read_text(encoding="utf-8"), Loader=_ComposeLoader
-    )["services"]
-    proxies = {
-      svc: spec for svc, spec in services.items()
-      if any("Caddyfile" in str(v) for v in (spec or {}).get("volumes") or [])
-    }
-    assert proxies, f"{name} must mount the Caddyfile on some service"
-    for svc, spec in proxies.items():
-      env = dict(
-        entry.split("=", 1)
-        for entry in (spec.get("environment") or [])
-        if "=" in entry
-      )
-      for directive, sources in variable_directives.items():
-        referenced = set(re.findall(r"\{\$(\w+)\}", sources))
-        for var in referenced:
-          assert var in env, (
-            f"{name}: service {svc!r} mounts the Caddyfile but never sets "
-            f"{var}, so app-frame {directive} would resolve to nothing"
-          )
-        # Substitute ALL variables before parsing. Replacing and validating
-        # one at a time leaves the other {$VAR} token behind in frame-src,
-        # making the guard reject a valid two-origin policy spuriously.
-        resolved = sources
-        for var in referenced:
-          resolved = resolved.replace(f"{{${var}}}", env[var])
-        resolved = re.sub(r"\$\{\w+:-([^}]*)\}", r"\1", resolved)
-        resolved = re.sub(r"\$\{\w+\}", "mobius.example.test", resolved)
-        for source in resolved.split():
-          if source.startswith("'") or source in ("data:", "blob:"):
-            continue
-          parsed = urlparse(source)
-          assert source.count("://") == 1 and parsed.scheme and parsed.netloc, (
-            f"{name}: {directive} resolves to {source!r}, which is not a "
-            "single absolute origin and would be ignored by the browser"
-          )
+  policy = _app_frame_csp()
+  assert "services.example.test" not in policy
+  assert "script-src *" not in policy
 
 
 def test_compose_keeps_optional_service_gateway_inert_by_default():

--- a/frontend/src/components/SettingsView/SettingsView.css
+++ b/frontend/src/components/SettingsView/SettingsView.css
@@ -91,6 +91,12 @@
   line-height: 1.45;
 }
 
+.settings__notice--stacked {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
 .settings__subtext a {
   color: var(--accent);
   text-decoration: underline;

--- a/frontend/src/components/SettingsView/SettingsView.jsx
+++ b/frontend/src/components/SettingsView/SettingsView.jsx
@@ -52,7 +52,7 @@ const UPDATE_CHECKED_RESET_MS = 2200
 const RETURN_VIEW_KEY = 'mobius:return-view'
 const RESTART_SHELL_READY_PATH = '/shell/'
 const PLATFORM_APPLY_STATES = new Set([
-  'restart_needed', 'up_to_date', 'conflict', 'rolled_back',
+  'restart_needed', 'activation_needed', 'up_to_date', 'conflict', 'rolled_back',
 ])
 const PROVIDER_CHOICES = [
   { id: 'claude', label: 'Claude Code' },
@@ -1138,7 +1138,7 @@ export default function SettingsView({
         setPlatform(current => platformStatusFromApply(current, body))
       }
       await refreshPlatform()
-      if (state === 'restart_needed' || state === 'up_to_date') {
+      if (state === 'restart_needed' || state === 'activation_needed' || state === 'up_to_date') {
         return { ok: true, state }
       }
       if (state === 'conflict' || state === 'rolled_back') {
@@ -1336,7 +1336,13 @@ export default function SettingsView({
   // apply needs a repair pass, so the row says so distinctly rather than reading
   // as a plain "New update available".
   const platformRolledBack = platform?.state === 'rolled_back'
-  const platformRestart = !!platform?.needs_restart
+  const platformActivationLevel = platform?.activation?.level || (
+    platform?.needs_restart ? 'server_restart' : 'live'
+  )
+  const platformRestart = platformActivationLevel === 'server_restart'
+  const platformExternalActivation = !['live', 'server_restart'].includes(
+    platformActivationLevel,
+  )
   const updateAvailable = !!platform?.available
   const mobiusUpdating =
     platformPhase === 'applying' || updatePhase === 'checking'
@@ -1600,7 +1606,7 @@ export default function SettingsView({
           ) : (
             // Loading: no cached data yet and no error — the initial
             // in-flight fetch. Show a neutral notice instead of nothing.
-            <div className="settings__notice" role="status">
+            <div className="settings__notice settings__notice--stacked" role="status">
               Loading providers…
             </div>
           )}
@@ -1653,7 +1659,7 @@ export default function SettingsView({
           <div className="settings__row settings__row--top">
             <div className="settings__update">
               <StatusDot
-                color={platformConflict || platformRolledBack || platformRestart || updateAvailable ? '--accent' : '--green'}
+                color={platformConflict || platformRolledBack || platformRestart || platformExternalActivation || updateAvailable ? '--accent' : '--green'}
               >
                 {platformUpdateStatusLabel(platform)}
               </StatusDot>
@@ -1681,6 +1687,28 @@ export default function SettingsView({
                       : 'Resolve in chat'}
                 </button>
               ) : null
+            ) : platformExternalActivation ? (
+              updateAvailable ? (
+                <button
+                  ref={platformActionRef}
+                  className="settings__btn settings__btn--sm settings__btn--nowrap"
+                  type="button"
+                  onClick={openUpdateReview}
+                  disabled={mobiusUpdating || platformPhase !== 'idle'}
+                >
+                  {mobiusUpdating ? 'Updating…' : 'Review update'}
+                </button>
+              ) : (
+                <button
+                  ref={platformActionRef}
+                  className="settings__btn settings__btn--outline settings__btn--sm settings__btn--nowrap"
+                  type="button"
+                  onClick={checkForUpdates}
+                  disabled={updatePhase === 'checking' || platformPhase !== 'idle'}
+                >
+                  {updatePhase === 'idle' ? 'Check for more' : checkUpdatesLabel}
+                </button>
+              )
             ) : platformRestart ? (
               <div
                 className="settings__update-actions"
@@ -1752,6 +1780,14 @@ export default function SettingsView({
               {platformRestartSlow
                 ? 'This is taking longer than usual. Möbius is still checking.'
                 : 'Restart signal sent. The page will reload shortly.'}
+            </div>
+          )}
+          {platformExternalActivation && (
+            <div className="settings__notice" role="status">
+              {(platform?.activation?.guidance || []).map((line) => (
+                <span key={line}>{line}</span>
+              ))}
+              <span>A server restart alone will not complete this update.</span>
             </div>
           )}
           {platformError && (

--- a/frontend/src/components/SettingsView/UpdateReviewModal.css
+++ b/frontend/src/components/SettingsView/UpdateReviewModal.css
@@ -142,6 +142,56 @@
   font-size: 16px;
 }
 
+.urm__activation {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  padding: 12px 14px;
+  border: 1px solid color-mix(in srgb, var(--accent) 52%, var(--border));
+  border-radius: 11px;
+  background: color-mix(in srgb, var(--accent) 7%, var(--surface));
+}
+
+.urm__activation--live {
+  border-color: var(--border);
+  background: var(--surface2);
+}
+
+.urm__activation-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.urm__activation-title {
+  margin: 0;
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.urm__activation-deployment {
+  color: var(--muted);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.urm__activation-guidance {
+  margin: 0;
+  color: var(--text);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.urm__activation-reasons {
+  margin: 1px 0 0;
+  padding-left: 18px;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
 .urm__section {
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/SettingsView/UpdateReviewModal.jsx
+++ b/frontend/src/components/SettingsView/UpdateReviewModal.jsx
@@ -30,6 +30,7 @@ import {
   summarizePreview,
   isTrivialUpdate,
 } from '../../lib/platformUpdatePreview.js'
+import { platformActivationLabel } from '../../lib/platformUpdateState.js'
 import FileDiffList from '../DiffView/FileDiffList.jsx'
 import './UpdateReviewModal.css'
 
@@ -111,7 +112,11 @@ export default function UpdateReviewModal({
     }
     if (
       result?.ok
-      && (result.state === 'restart_needed' || result.state === 'up_to_date')
+      && (
+        result.state === 'restart_needed'
+        || result.state === 'activation_needed'
+        || result.state === 'up_to_date'
+      )
     ) onClose()
   }, [onApply, onClose, preview])
 
@@ -127,6 +132,13 @@ export default function UpdateReviewModal({
   const target = shortSha(preview?.target_sha)
   const commits = Array.isArray(preview?.commits) ? preview.commits : []
   const files = Array.isArray(preview?.files) ? preview.files : []
+  const activation = preview?.activation
+  const activationGuidance = Array.isArray(activation?.guidance)
+    ? activation.guidance
+    : []
+  const activationReasons = Array.isArray(activation?.reasons)
+    ? activation.reasons.filter((reason) => reason?.applies)
+    : []
   const parsedFiles = useMemo(
     () => parseUnifiedDiff(preview?.diff),
     [preview?.diff],
@@ -220,6 +232,32 @@ export default function UpdateReviewModal({
             <div className="urm__notice" role="status">
               {progressLabel}
             </div>
+          )}
+
+          {!hasResult && !loading && !loadError && !notAvailable && activation && (
+            <section
+              className={`urm__activation urm__activation--${activation.level || 'live'}`}
+              aria-labelledby="urm-activation-title"
+            >
+              <div className="urm__activation-head">
+                <h3 id="urm-activation-title" className="urm__activation-title">
+                  {platformActivationLabel(activation)}
+                </h3>
+                <span className="urm__activation-deployment">
+                  {activation.deployment === 'railway' ? 'Railway' : 'Self-hosted'}
+                </span>
+              </div>
+              {activationGuidance.map((line) => (
+                <p key={line} className="urm__activation-guidance">{line}</p>
+              ))}
+              {activationReasons.length > 0 && (
+                <ul className="urm__activation-reasons">
+                  {activationReasons.map((reason) => (
+                    <li key={reason.code}>{reason.summary}</li>
+                  ))}
+                </ul>
+              )}
+            </section>
           )}
 
           {!hasResult && !loading && !loadError && notAvailable && (

--- a/frontend/src/lib/__tests__/appModuleBroker.test.js
+++ b/frontend/src/lib/__tests__/appModuleBroker.test.js
@@ -170,17 +170,10 @@ test('bundled app packages are not duplicated in the shell install precache', ()
   assert.match(worker, /RETAINED_RUNTIME_ASSETS/)
 })
 
-test('only app-frame responses admit brokered blob modules at the edge', () => {
-  assert.match(caddy, /@appFrame path \/api\/apps\/\*\/frame/)
-  const frameCsp = caddy.split('\n').find(
-    line => line.includes('header @appFrame >Content-Security-Policy'),
-  ) || ''
-  const ordinaryCsp = caddy.split('\n').find(
-    line => line.includes('header @notFrameableEmbed >Content-Security-Policy'),
-  ) || ''
-  assert.match(frameCsp, /sandbox allow-scripts/)
-  assert.match(frameCsp, /allow-popups-to-escape-sandbox/)
-  assert.doesNotMatch(frameCsp, /allow-same-origin/)
-  assert.match(frameCsp, /script-src[^;]*\bblob:/)
-  assert.doesNotMatch(ordinaryCsp, /script-src[^;]*\bblob:/)
+test('the primary edge passes through application response policy', () => {
+  const primaryHost = caddy.split('# Full backend web services', 1)[0]
+  assert.match(primaryHost, /reverse_proxy app:8000/)
+  assert.doesNotMatch(primaryHost, /\bheader\b/)
+  assert.doesNotMatch(primaryHost, /Content-Security-Policy/)
+  assert.match(caddy, /backend owns standard headers/)
 })

--- a/frontend/src/lib/__tests__/platformUpdateState.test.js
+++ b/frontend/src/lib/__tests__/platformUpdateState.test.js
@@ -26,6 +26,27 @@ test('a clean apply consumes the reviewed target but preserves restart readiness
   assert.equal(projected.contained_upstream_sha, 'applied')
 })
 
+test('an image-required apply projects the external activation contract', () => {
+  const activation = {
+    level: 'image_rebuild',
+    guidance: ['Rebuild and deploy.'],
+  }
+  const projected = platformStatusFromApply(
+    { state: 'available', available: true, needs_restart: false },
+    {
+      state: 'activation_needed',
+      needs_restart: false,
+      activation,
+      upstream_commit: 'applied',
+    },
+  )
+
+  assert.equal(projected.available, false)
+  assert.equal(projected.needs_restart, false)
+  assert.equal(projected.activation, activation)
+  assert.equal(platformUpdateStatusLabel(projected), 'Image rebuild required')
+})
+
 test('a failed newer release does not forget an earlier staged update', () => {
   const projected = platformStatusFromApply(
     {
@@ -96,6 +117,14 @@ test('update-row copy represents restart and availability independently', () => 
       available: true,
     }),
     'New update available',
+  )
+  assert.equal(
+    platformUpdateStatusLabel({
+      state: 'activation_needed',
+      activation: { level: 'proxy_reload' },
+      available: false,
+    }),
+    'Proxy reload required',
   )
 })
 

--- a/frontend/src/lib/__tests__/updateReviewModal.test.js
+++ b/frontend/src/lib/__tests__/updateReviewModal.test.js
@@ -29,13 +29,23 @@ test('the combined raw-diff toggle is gone and truncation is explained per file'
 })
 
 test('apply outcomes close only for explicit clean states and preserve actionable results', () => {
-  assert.match(settingsView, /state === 'restart_needed' \|\| state === 'up_to_date'/)
+  assert.match(settingsView, /state === 'restart_needed' \|\| state === 'activation_needed' \|\| state === 'up_to_date'/)
   assert.match(settingsView, /state === 'conflict' \|\| state === 'rolled_back'/)
   assert.match(settingsView, /The update returned an unexpected result/)
   assert.match(modal, /result\?\.state === 'conflict' \|\| result\?\.state === 'rolled_back'/)
-  assert.match(modal, /result\.state === 'restart_needed' \|\| result\.state === 'up_to_date'/)
+  assert.match(modal, /result\.state === 'activation_needed'/)
+  assert.match(modal, /result\.state === 'up_to_date'/)
   assert.doesNotMatch(modal, /if \(result\?\.ok\) onClose\(\)/)
   assert.match(modal, /applyProgress\?\.plan_id === preview\?\.plan_id/)
+})
+
+test('activation impact is visible before Apply and external work never becomes Restart to finish', () => {
+  assert.match(modal, /platformActivationLabel\(activation\)/)
+  assert.match(modal, /activationGuidance\.map/)
+  assert.match(modal, /activationReasons\.map/)
+  assert.match(settingsView, /platformExternalActivation/)
+  assert.match(settingsView, /A server restart alone will not complete this update\./)
+  assert.match(settingsView, /platformExternalActivation \? \(/)
 })
 
 test('the apply response is a truthful fallback when status refresh fails', () => {

--- a/frontend/src/lib/platformUpdateState.js
+++ b/frontend/src/lib/platformUpdateState.js
@@ -8,7 +8,11 @@
 export function platformStatusFromApply(previous, result) {
   const state = result.state
   const upstream = result.upstream_commit || previous?.recorded_upstream_sha || null
-  const clean = state === 'restart_needed' || state === 'up_to_date'
+  const clean = (
+    state === 'restart_needed'
+    || state === 'activation_needed'
+    || state === 'up_to_date'
+  )
   const failedOntoStagedUpdate = (
     (state === 'rolled_back' || state === 'conflict')
     && !!previous?.needs_restart
@@ -20,6 +24,7 @@ export function platformStatusFromApply(previous, result) {
     // the OLD `available:true` through the render before the status refresh:
     // the batched-update UI would otherwise offer the update that just applied.
     available: state === 'rolled_back',
+    activation: result.activation || previous?.activation || null,
     needs_restart:
       state === 'restart_needed'
       || !!result.needs_restart
@@ -41,11 +46,30 @@ export function platformUpdateStatusLabel(platform) {
   const state = platform?.state
   const needsRestart = !!platform?.needs_restart
   const available = !!platform?.available
+  const activationLevel = platform?.activation?.level || (
+    needsRestart ? 'server_restart' : 'live'
+  )
 
   if (state === 'conflict') return 'Update blocked'
   if (state === 'rolled_back') return 'Update needs repair'
-  if (needsRestart && available) return 'More updates available'
-  if (needsRestart) return 'Ready to restart'
+  if (activationLevel !== 'live' && available) return 'More updates available'
+  if (activationLevel === 'server_restart') return 'Ready to restart'
+  if (activationLevel === 'proxy_reload') return 'Proxy reload required'
+  if (activationLevel === 'container_recreate') return 'Deployment required'
+  if (activationLevel === 'image_rebuild') return 'Image rebuild required'
+  if (activationLevel === 'host_maintenance') return 'Host maintenance required'
   if (available) return 'New update available'
   return 'Up to date'
+}
+
+export function platformActivationLabel(activation) {
+  const labels = {
+    live: 'Live refresh',
+    server_restart: 'Server restart',
+    proxy_reload: 'Proxy reload',
+    container_recreate: 'Container recreation',
+    image_rebuild: 'Image rebuild',
+    host_maintenance: 'Host maintenance',
+  }
+  return labels[activation?.level] || 'Activation details'
 }

--- a/scripts/test-image-fingerprint.sh
+++ b/scripts/test-image-fingerprint.sh
@@ -4,15 +4,15 @@
 set -euo pipefail
 
 ROOT="${MOBIUS_TEST_IMAGE_INPUT_ROOT:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)}"
-files=(
-  Dockerfile
-  backend/legacy_runtime/jose/__init__.py
-  backend/legacy_runtime/verify_jose.py
-  backend/requirements.txt
-  backend/requirements.lock
-  frontend/package.json
-  frontend/package-lock.json
+CLASSIFIER="$ROOT/backend/app/platform_activation.py"
+mapfile -t files < <(
+  python3 "$CLASSIFIER" dependency-fingerprint-paths "$ROOT"
 )
+
+[ "${#files[@]}" -gt 0 ] || {
+  echo "No image dependency inputs were classified." >&2
+  exit 1
+}
 
 for file in "${files[@]}"; do
   sha256sum "$ROOT/$file" | cut -d' ' -f1


### PR DESCRIPTION
## Summary
- classify platform changes by the action that can actually activate them, from live refresh through host maintenance
- show deployment-specific impact and reasons before Apply so image or proxy work is never presented as a server restart
- move application response policy to FastAPI and keep Caddy focused on TLS, routing, compression, and the service-gateway host

This advances #114 by eliminating duplicated application response policy and surfacing external activation work before an owner applies an update. Caddy continues to own the topology-specific gateway boundary rather than pretending direct managed deployments use the same operator commands.

## Testing
- 109 focused backend update, security, and frame tests
- 30 focused frontend frame and update tests
- targeted frontend lint
- production and PWA build
- image dependency fingerprint, Python compile, and shell syntax checks