### PR TITLE
Keep growing Q&A answers anchored inline

### DIFF
--- a/frontend/src/components/ChatView/QuestionCard.css
+++ b/frontend/src/components/ChatView/QuestionCard.css
@@ -227,7 +227,7 @@
 .qcard__input {
   display: block;
   width: 100%;
-  height: 60px;
+  min-height: 38px;
   margin-top: 10px;
   padding: 10px 11px;
   border-radius: 8px;
@@ -238,8 +238,10 @@
   font-family: inherit;
   line-height: 1.45;
   outline: none;
-  /* Keep the card stable while writing. Longer answers scroll inside this
-     two-line surface instead of moving every control below it per newline. */
+  /* Grow with the answer while the chat scroll owner keeps the surrounding
+     reading position anchored. Older browsers use the measured JSX fallback. */
+  field-sizing: content;
+  max-height: 180px;
   overflow-y: auto;
   resize: none;
   box-sizing: border-box;

--- a/frontend/src/components/ChatView/QuestionCard.jsx
+++ b/frontend/src/components/ChatView/QuestionCard.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import './QuestionCard.css'
 import {
   clearQuestionDraft,
@@ -6,6 +6,7 @@ import {
   readQuestionDraft,
   writeQuestionDraft,
 } from './questionDraft.js'
+import { textareaUsesNativeSizing } from './composerTextareaSizing.js'
 import {
   pointerSelectionChangedWithin,
   textSelectionSnapshot,
@@ -22,6 +23,20 @@ function resolveAnswer(answer, otherText) {
 }
 
 
+const CUSTOM_ANSWER_MAX_HEIGHT = 180
+
+
+function resizeCustomAnswer(textarea) {
+  if (!textarea || textareaUsesNativeSizing()) return
+  textarea.style.height = 'auto'
+  const contentHeight = textarea.scrollHeight
+  textarea.style.height = `${Math.min(contentHeight, CUSTOM_ANSWER_MAX_HEIGHT)}px`
+  textarea.style.overflowY = contentHeight > CUSTOM_ANSWER_MAX_HEIGHT
+    ? 'auto'
+    : 'hidden'
+}
+
+
 function CustomAnswerArea({
   active,
   answered,
@@ -31,13 +46,40 @@ function CustomAnswerArea({
   question,
   value,
 }) {
+  const textareaRef = useRef(null)
+
+  useLayoutEffect(() => {
+    resizeCustomAnswer(textareaRef.current)
+  }, [value])
+
+  // The measured fallback also reacts to width: wrapping can add lines without
+  // changing the answer value when a pane or device rotates.
+  useEffect(() => {
+    const textarea = textareaRef.current
+    if (
+      !textarea
+      || textareaUsesNativeSizing()
+      || typeof ResizeObserver === 'undefined'
+    ) return undefined
+    let lastWidth = -1
+    const observer = new ResizeObserver(() => {
+      const width = textarea.clientWidth
+      if (width === lastWidth) return
+      lastWidth = width
+      resizeCustomAnswer(textarea)
+    })
+    observer.observe(textarea)
+    return () => observer.disconnect()
+  }, [])
+
   return (
     <textarea
+      ref={textareaRef}
       className={`qcard__input${active ? ' qcard__input--active' : ''}`}
       aria-label={`Custom answer for: ${question}`}
       placeholder={answered ? 'No custom answer' : 'Or type your own answer…'}
       autoComplete="off"
-      rows={2}
+      rows={1}
       value={value}
       onChange={e => onChange(e.target.value)}
       readOnly={answered}

--- a/frontend/src/components/ChatView/__tests__/questionCardState.test.js
+++ b/frontend/src/components/ChatView/__tests__/questionCardState.test.js
@@ -38,12 +38,12 @@ test('unanswered question cards do not have a stale gray state', () => {
     'a custom answer should be a direct writing surface, not an Other option')
   assert.match(component, /<CustomAnswerArea[\s\S]*?answered=\{answered\}[\s\S]*?value=\{answered[\s\S]*?unmatchedAnswers\.join\(', '\)/,
     'the custom answer should stay mounted and retain submitted custom text')
-  assert.match(component, /rows=\{2\}/,
-    'the custom answer should provide two stable writing lines')
+  assert.match(component, /rows=\{1\}/,
+    'the custom answer should begin as one compact writing line')
   assert.match(component, /readOnly=\{answered\}[\s\S]*?disabled=\{disabled && !answered\}/,
     'a submitted multiline answer should stay scrollable but not editable')
-  assert.doesNotMatch(component, /resizeCustomAnswer|textareaUsesNativeSizing|data-chat-scroll-edit-field/,
-    'the question editor should not grow the transcript or install a second scroll owner')
+  assert.match(component, /resizeCustomAnswer|textareaUsesNativeSizing/,
+    'older browsers should measure the growing answer when native sizing is unavailable')
   assert.match(component, /e\.key === 'Enter' && \(e\.metaKey \|\| e\.ctrlKey\)/,
     'plain Enter should create a new line while the explicit shortcut submits')
   assert.match(component, /val\.replace\(\/\\n\/g, '\\n  '\)/,
@@ -73,8 +73,8 @@ test('question card css has no stale styling hook', () => {
     'expiration status styling should not come back')
   assert.match(css, /\.qcard__input:disabled,\s*\.qcard__input\[readonly\]\s*\{[\s\S]*?color:\s*var\(--muted\);[\s\S]*?-webkit-text-fill-color:\s*var\(--muted\);[\s\S]*?\}/,
     'a submitted custom answer should visibly gray out in every browser')
-  assert.match(css, /\.qcard__input\s*\{[\s\S]*?width:\s*100%;[\s\S]*?height:\s*60px;[\s\S]*?overflow-y:\s*auto;[\s\S]*?resize:\s*none;/,
-    'the custom answer should span the card and scroll internally at a stable height')
+  assert.match(css, /\.qcard__input\s*\{[\s\S]*?width:\s*100%;[\s\S]*?min-height:\s*38px;[\s\S]*?field-sizing:\s*content;[\s\S]*?max-height:\s*180px;[\s\S]*?overflow-y:\s*auto;[\s\S]*?resize:\s*none;/,
+    'the custom answer should expand inline to a bounded, internally scrollable height')
   assert.match(css, /\.qcard__submit-error\s*\{/,
     'a failed answer should keep its retry notice attached to the card')
 })

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -2383,6 +2383,57 @@ export default function useScrollMode({
     }
     const onComposerPointerDown = (event) => runComposerTailIntent(event)
     composerEditRunRef.current = runComposerTailIntent
+
+    let pendingInlineEditorAnchor = null
+    let inlineEditorRaf = 0
+    const isGrowingInlineEditor = target => target?.matches?.(
+      'textarea.qcard__input',
+    ) === true
+    const captureInlineEditorAnchor = (event) => {
+      if (!isGrowingInlineEditor(event.target)) return
+      // Capture before the browser changes the textarea/caret. Typing is a
+      // newer semantic action than a half-settled reader gesture, but it is not
+      // new scroll intent, so the exact current anchor becomes layout owner.
+      const readerGesturePending = !layoutMayOwnScroll(
+        gestureWindowUntilRef.current,
+        performance.now(),
+      )
+      const needsFreshAnchor = !readerLocationExplicitRef.current
+        || modeRef.current?.kind !== 'ANCHOR_AT'
+        || readerGesturePending
+      // Once typing has retired FOLLOW/PIN, the current anchor is already the
+      // exact contract to replay. Avoid measuring the transcript again on
+      // every character unless a newer reader gesture made it stale.
+      const nextMode = needsFreshAnchor
+        ? anchorModeFromScroll(scrollEl) || modeRef.current
+        : modeRef.current
+      supersedePendingReaderGesture()
+      if (needsFreshAnchor) {
+        readerLocationExplicitRef.current = true
+        transitionMode(nextMode, 'reader:inline-editor-growth')
+        persistMode()
+      }
+      pendingInlineEditorAnchor = {
+        mode: nextMode,
+        authorityVersion: currentAuthority(),
+      }
+    }
+    const restoreInlineEditorAnchor = (event) => {
+      if (!isGrowingInlineEditor(event.target)) return
+      const plan = pendingInlineEditorAnchor
+      pendingInlineEditorAnchor = null
+      if (!plan) return
+      cancelAnimationFrame(inlineEditorRaf)
+      inlineEditorRaf = requestAnimationFrame(() => {
+        inlineEditorRaf = 0
+        writeMode(
+          scrollEl,
+          plan.mode,
+          'layout:inline-editor-growth',
+          plan.authorityVersion,
+        )
+      })
+    }
     const noteScrollStart = () => {
       if (!pendingGestureStart) return
       perfMark('scroll.startLatency', performance.now() - pendingGestureStart)
@@ -2393,6 +2444,8 @@ export default function useScrollMode({
     scrollEl.addEventListener('pointermove', onPointerMoveInput, { passive: true })
     scrollEl.addEventListener('wheel', onWheelInput, { passive: true })
     scrollEl.addEventListener('keydown', onUserInput, { passive: true })
+    scrollEl.addEventListener('beforeinput', captureInlineEditorAnchor, { passive: true })
+    scrollEl.addEventListener('input', restoreInlineEditorAnchor, { passive: true })
     scrollEl.addEventListener('pointerup', onPointerUpInput, { passive: true })
     scrollEl.addEventListener('pointercancel', onPointerCancelInput, { passive: true })
     chatEl?.addEventListener('pointerdown', onComposerPointerDown, { passive: true })
@@ -2493,12 +2546,15 @@ export default function useScrollMode({
       scrollEl.removeEventListener('pointermove', onPointerMoveInput)
       scrollEl.removeEventListener('wheel', onWheelInput)
       scrollEl.removeEventListener('keydown', onUserInput)
+      scrollEl.removeEventListener('beforeinput', captureInlineEditorAnchor)
+      scrollEl.removeEventListener('input', restoreInlineEditorAnchor)
       scrollEl.removeEventListener('pointerup', onPointerUpInput)
       scrollEl.removeEventListener('pointercancel', onPointerCancelInput)
       chatEl?.removeEventListener('pointerdown', onComposerPointerDown)
       if (composerEditRunRef.current === runComposerTailIntent) {
         composerEditRunRef.current = null
       }
+      cancelAnimationFrame(inlineEditorRaf)
       if (forceRevealRef.current === forceReveal) forceRevealRef.current = null
     }
   }, [

--- a/frontend/src/lib/__tests__/useScrollModeLifecycle.test.js
+++ b/frontend/src/lib/__tests__/useScrollModeLifecycle.test.js
@@ -27,7 +27,7 @@ function fakeElement(fields = {}) {
   }
 }
 
-test('content-only streaming keeps the active reader gesture owner mounted', () => {
+function installBrowserEnvironment({ observers = [], frames = null } = {}) {
   const previous = {
     window: globalThis.window,
     document: globalThis.document,
@@ -36,7 +36,6 @@ test('content-only streaming keeps the active reader gesture owner mounted', () 
     requestAnimationFrame: globalThis.requestAnimationFrame,
     cancelAnimationFrame: globalThis.cancelAnimationFrame,
   }
-  const observers = []
   globalThis.window = {
     addEventListener() {},
     removeEventListener() {},
@@ -60,8 +59,20 @@ test('content-only streaming keeps the active reader gesture owner mounted', () 
     observe() {}
     disconnect() {}
   }
-  globalThis.requestAnimationFrame = () => 1
+  globalThis.requestAnimationFrame = frames
+    ? callback => {
+        frames.push(callback)
+        return frames.length
+      }
+    : () => 1
   globalThis.cancelAnimationFrame = () => {}
+  return () => Object.assign(globalThis, previous)
+}
+
+
+test('transcript changes keep one scroll owner after the first row mounts', () => {
+  const observers = []
+  const restoreBrowser = installBrowserEnvironment({ observers })
 
   const lastUser = fakeElement({ offsetTop: 120, offsetHeight: 40 })
   const list = fakeElement({ offsetHeight: 720 })
@@ -112,6 +123,105 @@ test('content-only streaming keeps the active reader gesture owner mounted', () 
     assert.equal(observers[0].disconnected, true)
     hook.unmount()
   } finally {
-    Object.assign(globalThis, previous)
+    restoreBrowser()
+  }
+})
+
+test('a growing inline editor restores its pre-input anchor but yields to a real scroll', () => {
+  const scrollListeners = new Map()
+  const frames = []
+  const restoreBrowser = installBrowserEnvironment({ frames })
+
+  let scroll
+  const row = fakeElement({
+    dataset: { key: 'assistant-question' },
+    offsetTop: 100,
+    offsetHeight: 300,
+    getBoundingClientRect() {
+      return { top: this.offsetTop - scroll.scrollTop, bottom: 400 - scroll.scrollTop }
+    },
+  })
+  const lastUser = fakeElement({
+    dataset: { cid: 'user-1', key: 'user-1' },
+    offsetTop: 0,
+    offsetHeight: 40,
+  })
+  const list = fakeElement({ offsetHeight: 400 })
+  scroll = fakeElement({
+    scrollTop: 40,
+    scrollHeight: 900,
+    clientHeight: 500,
+    getBoundingClientRect() { return { top: 0, bottom: 500, height: 500 } },
+    addEventListener(type, listener) { scrollListeners.set(type, listener) },
+    removeEventListener(type, listener) {
+      if (scrollListeners.get(type) === listener) scrollListeners.delete(type)
+    },
+    querySelector(selector) {
+      if (selector === '.chat__list') return list
+      if (selector.includes('data-key="assistant-question"')) return row
+      if (selector.includes('data-cid="user-1"')) return lastUser
+      return null
+    },
+    querySelectorAll(selector) {
+      if (selector === '.chat__msg[data-key]') return [row]
+      if (selector === '.chat__msg--user[data-cid]') return [lastUser]
+      return []
+    },
+  })
+  scroll.parentElement = fakeElement()
+  const scrollRef = { current: scroll }
+  const messages = [
+    { role: 'user', cid: 'user-1', content: 'Question' },
+    { role: 'assistant', cid: 'assistant-question', content: '' },
+  ]
+  const hookArgs = {
+    chatId: 'inline-growth-lifecycle',
+    scrollRef,
+    spacerRef: { current: fakeElement() },
+    lastUserMsgRef: { current: lastUser },
+    chatRef: { current: fakeElement() },
+    footRef: { current: fakeElement({ offsetHeight: 80 }) },
+    messages,
+    messagesRef: { current: messages },
+    loadingOlderRef: { current: false },
+    initialEntryPhase: 'ready',
+    hasTranscript: true,
+    ownsReadingPosition: true,
+  }
+  const editor = {
+    matches: selector => selector === 'textarea.qcard__input',
+    closest: () => null,
+  }
+
+  try {
+    const hook = renderHook(useScrollMode, hookArgs)
+    assert.equal(typeof scrollListeners.get('beforeinput'), 'function')
+    assert.equal(typeof scrollListeners.get('input'), 'function')
+
+    const beforeTyping = scroll.scrollTop
+    scrollListeners.get('beforeinput')({ target: editor })
+    scroll.scrollTop = 120 // Native caret reveal races the growing textarea.
+    scrollListeners.get('input')({ target: editor })
+    frames.at(-1)()
+    assert.equal(scroll.scrollTop, beforeTyping,
+      'typing restores the exact row position captured before the field grew')
+
+    scrollListeners.get('beforeinput')({ target: editor })
+    scrollListeners.get('input')({ target: editor })
+    const staleGrowthFrame = frames.at(-1)
+    scrollListeners.get('pointerdown')({
+      type: 'pointerdown', pointerType: 'mouse', button: 0, target: editor,
+    })
+    scroll.scrollTop = 90
+    scrollListeners.get('scroll')()
+    staleGrowthFrame()
+    assert.equal(scroll.scrollTop, 90,
+      'a newer reader gesture owns the viewport instead of the edit correction')
+
+    hook.unmount()
+    assert.equal(scrollListeners.has('beforeinput'), false)
+    assert.equal(scrollListeners.has('input'), false)
+  } finally {
+    restoreBrowser()
   }
 })

--- a/tests/chat-redesign.spec.mjs
+++ b/tests/chat-redesign.spec.mjs
@@ -283,7 +283,7 @@ test.describe('Bug 1: AskUserQuestion', () => {
   })
 
 
-  test('multiline custom answers scroll inside a steady phone-sized card', async ({ page }) => {
+  test('multiline custom answers grow inline without moving the conversation', async ({ page }) => {
     const streamBody = [
       `data: ${JSON.stringify({
         type: 'question',
@@ -309,21 +309,18 @@ test.describe('Bug 1: AskUserQuestion', () => {
       name: 'Custom answer for: Describe the change',
     })
     await expect(card).toBeVisible({ timeout: 5000 })
+    expect(await card.evaluate(el => !!el.closest('.chat__scroll'))).toBe(true)
+    expect(await card.evaluate(el => !!el.closest('.chat__question-dock'))).toBe(false)
     await customAnswer.focus()
 
     const geometry = () => card.evaluate(el => {
       const scroll = el.closest('.chat__scroll')
       const input = el.querySelector('.qcard__input')
-      const option = el.querySelector('.qcard__opt')
-      const submit = el.querySelector('.qcard__submit')
       const rect = node => node?.getBoundingClientRect()
       return {
+        cardTop: rect(el)?.top,
         cardHeight: rect(el)?.height,
         inputHeight: rect(input)?.height,
-        inputTop: rect(input)?.top,
-        inputScrollTop: input?.scrollTop,
-        optionTop: rect(option)?.top,
-        submitTop: rect(submit)?.top,
         chatScrollTop: scroll?.scrollTop,
       }
     })
@@ -340,13 +337,27 @@ test.describe('Bug 1: AskUserQuestion', () => {
     const after = await geometry()
 
     await expect(customAnswer).toHaveValue('First line\nSecond line\nThird line')
-    expect(after.cardHeight).toBeCloseTo(before.cardHeight, 5)
-    expect(after.inputHeight).toBeCloseTo(before.inputHeight, 5)
-    expect(after.inputTop).toBeCloseTo(before.inputTop, 5)
-    expect(after.optionTop).toBeCloseTo(before.optionTop, 5)
-    expect(after.submitTop).toBeCloseTo(before.submitTop, 5)
+    expect(after.cardHeight).toBeGreaterThan(before.cardHeight)
+    expect(after.inputHeight).toBeGreaterThan(before.inputHeight)
+    expect(after.cardTop).toBeCloseTo(before.cardTop, 5)
     expect(after.chatScrollTop).toBeCloseTo(before.chatScrollTop, 5)
-    expect(after.inputScrollTop).toBeGreaterThan(before.inputScrollTop)
+
+    // Past the growth cap, the writing field—not the transcript—owns overflow.
+    // Drive the real keyboard path so caret reveal, beforeinput, input, and the
+    // chat scroll owner race exactly as they do for an owner writing an answer.
+    for (let line = 4; line <= 14; line += 1) {
+      await page.keyboard.press('Enter')
+      await customAnswer.pressSequentially(`Line ${line}`)
+    }
+    await page.evaluate(() => new Promise(resolve => (
+      requestAnimationFrame(() => requestAnimationFrame(resolve))
+    )))
+    const capped = await geometry()
+    const inputScrollTop = await customAnswer.evaluate(el => el.scrollTop)
+    expect(capped.inputHeight).toBeLessThanOrEqual(181)
+    expect(inputScrollTop).toBeGreaterThan(0)
+    expect(capped.cardTop).toBeCloseTo(before.cardTop, 5)
+    expect(capped.chatScrollTop).toBeCloseTo(before.chatScrollTop, 5)
   })
 
 


### PR DESCRIPTION
## Summary
- let multiline Q&A answers expand inline with the conversation before using bounded internal overflow
- preserve the exact visible transcript anchor across keyboard, caret-reveal, and textarea growth without adding another scroll owner
- keep the scroll lifecycle stable during streaming and yield immediately to a newer reader gesture

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- browser regression covers inline growth, the height cap, internal overflow, and unchanged transcript geometry

## Review
The behavior remains owned by the existing chat scroll controller. Accessibility naming and plain-Enter / modified-Enter keyboard behavior are unchanged; submitted answers stay read-only and visible in transcript history.