### PR TITLE
Align context menu behavior across shell surfaces

### DIFF
--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -1425,7 +1425,7 @@ const DrawerRow = memo(function DrawerRow({
     secondaryReleaseCleanupRef.current?.()
     const sourceBtn = event.currentTarget
     const pointerId = event.pointerId
-    const placement = itemMenuPlacement({ x: event.clientX, y: event.clientY })
+    const openingPoint = { x: event.clientX, y: event.clientY }
     let timer = null
     const cleanup = () => {
       window.removeEventListener('pointerup', onSecondaryPointerUp, true)
@@ -1440,7 +1440,7 @@ const DrawerRow = memo(function DrawerRow({
       if (upEvent.pointerId !== pointerId || upEvent.button !== 2) return
       upEvent.preventDefault()
       cleanup()
-      openItemMenuAt(placement, sourceBtn)
+      openItemMenuAt(openingPoint, sourceBtn)
     }
     window.addEventListener('pointerup', onSecondaryPointerUp, true)
     window.addEventListener('pointercancel', cleanup, true)

--- a/frontend/src/components/Drawer/DrawerItemActionMenu.jsx
+++ b/frontend/src/components/Drawer/DrawerItemActionMenu.jsx
@@ -1,7 +1,7 @@
 /* DrawerItemActionMenu gives app launcher cards and drawer rows one compact,
    pointer-accurate contextual menu across mouse, keyboard, and touch. */
 
-import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import {
   beginMenuPress,
@@ -11,6 +11,7 @@ import {
 } from './menuPointerOwnership.js'
 import { Pin, PinFilled } from '@openai/apps-sdk-ui/components/Icon'
 import { placeContextMenu } from '../../lib/contextMenuGeometry.js'
+import useContextMenuOutsideDismiss from '../../hooks/useContextMenuOutsideDismiss.js'
 
 function focusableMenuItems(menu) {
   return [...(menu?.querySelectorAll('[role="menuitem"]:not([disabled])') || [])]
@@ -44,6 +45,18 @@ export default function DrawerItemActionMenu({
     restoreOnCloseRef.current = restoreFocus
     onClose()
   }
+
+  const closeFromOutside = useCallback(() => {
+    pointerOwnerRef.current = { press: null, clickAction: null }
+    restoreOnCloseRef.current = false
+    onClose()
+  }, [onClose])
+
+  useContextMenuOutsideDismiss({
+    open,
+    menuRef,
+    onDismiss: closeFromOutside,
+  })
 
   useEffect(() => {
     if (open) {
@@ -160,14 +173,6 @@ export default function DrawerItemActionMenu({
 
   useEffect(() => {
     if (!open) return
-    function onOutsidePointerDown(event) {
-      if (menuRef.current?.contains(event.target)) return
-      pointerOwnerRef.current = { press: null, clickAction: null }
-      // The listener is capture-only: dismiss synchronously, then let the same
-      // pointer continue to its intended chat/app/settings/content target.
-      restoreOnCloseRef.current = false
-      onClose()
-    }
     function clearAbandonedPointer(event) {
       if (menuRef.current?.contains(event.target)) return
       pointerOwnerRef.current = cancelMenuPress(
@@ -175,11 +180,9 @@ export default function DrawerItemActionMenu({
         event.pointerId,
       )
     }
-    document.addEventListener('pointerdown', onOutsidePointerDown, true)
     document.addEventListener('pointerup', clearAbandonedPointer, true)
     document.addEventListener('pointercancel', clearAbandonedPointer, true)
     return () => {
-      document.removeEventListener('pointerdown', onOutsidePointerDown, true)
       document.removeEventListener('pointerup', clearAbandonedPointer, true)
       document.removeEventListener('pointercancel', clearAbandonedPointer, true)
     }

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -17,6 +17,7 @@ import {
 } from '../../api/client.js'
 import usePushSubscription from '../../hooks/usePushSubscription.js'
 import useNavigation, { deepLink } from '../../hooks/useNavigation.js'
+import useContextMenuOutsideDismiss from '../../hooks/useContextMenuOutsideDismiss.js'
 import { placeContextMenu } from '../../lib/contextMenuGeometry.js'
 import { parseNotificationTarget } from '../../lib/notificationTarget.js'
 import useSystemEventStream from '../../hooks/useSystemEventStream.js'
@@ -1096,17 +1097,15 @@ export default function Shell() {
     recoveredChatIdsRef.current.delete(chatId)
   }, [])
 
-  // Tabs expose a compact browser-style close menu without adding permanent
-  // chrome on desktop: right-click or the keyboard menu key. Phone tabs reserve
-  // press-and-hold for dragging and never open these bulk actions. The same state
-  // drives both the single strip and tiled pane strips.
+  // Tabs expose one compact browser-style close menu without adding permanent
+  // chrome: right-click or the keyboard menu key on desktop, and a stationary
+  // hold on touch. Movement after the touch hold still enters tab dragging. The
+  // same state drives both the single strip and tiled pane strips.
   const [tabMenu, setTabMenu] = useState(null)
   const tabMenuRef = useRef(null)
   const tabMenuReturnFocusRef = useRef(null)
-  const tabActionsAvailable = workspaceMode !== 'phone'
   const openTabMenu = useCallback((event, tab, paneId) => {
     event.preventDefault()
-    if (!tabActionsAvailable) return
     const owner = paneId || paneModel.paneOf(workspace, tabModel.tabKey(tab))?.id
     if (!owner) return
     const triggerRect = event.currentTarget.getBoundingClientRect()
@@ -1121,13 +1120,29 @@ export default function Shell() {
       tabKey: tabModel.tabKey(tab),
       paneId: owner,
     })
-  }, [tabActionsAvailable, workspace])
+  }, [workspace])
+  const openTabMenuAt = useCallback((x, y, tab, paneId) => {
+    if (!tab) return
+    const owner = paneId
+      || paneModel.paneOf(workspaceStateRef.current.ws, tabModel.tabKey(tab))?.id
+    if (!owner) return
+    tabMenuReturnFocusRef.current = null
+    setTabMenu({ x, y, tab, tabKey: tabModel.tabKey(tab), paneId: owner })
+  }, [])
   const closeTabMenu = useCallback((restoreFocus = true) => {
     setTabMenu(null)
     if (!restoreFocus) return
     const returnTarget = tabMenuReturnFocusRef.current
     queueMicrotask(() => returnTarget?.focus?.({ preventScroll: true }))
   }, [])
+  const closeTabMenuFromOutside = useCallback(() => {
+    closeTabMenu(false)
+  }, [closeTabMenu])
+  useContextMenuOutsideDismiss({
+    open: Boolean(tabMenu),
+    menuRef: tabMenuRef,
+    onDismiss: closeTabMenuFromOutside,
+  })
   useLayoutEffect(() => {
     if (!tabMenu || !tabMenuRef.current) return
     const menu = tabMenuRef.current
@@ -1158,23 +1173,12 @@ export default function Shell() {
   }, [])
   useEffect(() => {
     if (!tabMenu) return undefined
-    if (!tabActionsAvailable) {
-      closeTabMenu(false)
-      return undefined
-    }
-    const onDown = (event) => {
-      if (!event.target.closest?.('.workspace__menu')) closeTabMenu(false)
-    }
     const onKey = (event) => {
       if (event.key === 'Escape') closeTabMenu()
     }
-    document.addEventListener('pointerdown', onDown, true)
     document.addEventListener('keydown', onKey, true)
-    return () => {
-      document.removeEventListener('pointerdown', onDown, true)
-      document.removeEventListener('keydown', onKey, true)
-    }
-  }, [closeTabMenu, tabActionsAvailable, tabMenu])
+    return () => document.removeEventListener('keydown', onKey, true)
+  }, [closeTabMenu, tabMenu])
 
   // ── Workspace drag controller wiring (design §3, PR3) ─────────────────────
   // One shared controller owns the shipped workspace's document-level gesture.
@@ -1185,6 +1189,8 @@ export default function Shell() {
   sceneInputsRef.current = { projection, mode: workspaceMode, contentRect }
   const labelForTabRef = useRef(labelForTab)
   labelForTabRef.current = labelForTab
+  const openTabMenuAtRef = useRef(openTabMenuAt)
+  openTabMenuAtRef.current = openTabMenuAt
   const drawerRowGesturesRef = useRef(new Map())
   // A single-mode drag previews the builder world through the ONE descriptor
   // (INV 5): arm is phase 'drag-preview', and the id it mints is carried to the
@@ -1266,6 +1272,7 @@ export default function Shell() {
     drawerRowGesturesRef,
     closeDrawer,
     openDrawer,
+    openTabMenuAtRef,
     onPreviewBuilder: onModeDragPreview,
   })
 
@@ -3581,7 +3588,7 @@ export default function Shell() {
         action={toast?.action}
         onDismiss={dismissToast}
       />
-      {tabActionsAvailable && tabMenu && (() => {
+      {tabMenu && (() => {
         const menuPane = workspace.panes[tabMenu.paneId]
         const menuTabIndex = menuPane?.tabs.findIndex(
           tab => tabModel.tabKey(tab) === tabMenu.tabKey,

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -25,6 +25,10 @@ const drawerItemActionMenu = readFileSync(
   new URL('../../Drawer/DrawerItemActionMenu.jsx', import.meta.url),
   'utf8',
 )
+const contextMenuOutsideDismiss = readFileSync(
+  new URL('../../../hooks/useContextMenuOutsideDismiss.js', import.meta.url),
+  'utf8',
+)
 const paneModelSrc = readFileSync(new URL('../paneModel.js', import.meta.url), 'utf8')
 const chrome = readFileSync(new URL('../WorkspaceChrome.jsx', import.meta.url), 'utf8')
 const dragBinding = readFileSync(new URL('../useWorkspaceDrag.js', import.meta.url), 'utf8')
@@ -46,9 +50,9 @@ test('the workspace menu avoids an oversized border-and-shadow card', () => {
   assert.doesNotMatch(rule, /box-shadow:[^;]*(?:1[6-9]|[2-9]\d)px/)
 })
 
-test('the desktop workspace menu stays close-only, edge-clamped, and keyboard navigable', () => {
+test('the workspace tab menu stays close-only, edge-clamped, and keyboard navigable', () => {
   const menuMarkup = shell.slice(
-    shell.indexOf('{tabActionsAvailable && tabMenu &&'),
+    shell.indexOf('{tabMenu &&'),
     shell.indexOf('</HistoryDismissProvider>'),
   )
   assert.match(shell, /aria-label="Tab actions"/)
@@ -64,9 +68,11 @@ test('the desktop workspace menu stays close-only, edge-clamped, and keyboard na
   assert.match(shell, /querySelector\('\[role="menuitem"\]'\)\?\.focus\(\)/)
   assert.match(shell, /tabMenuReturnFocusRef\.current = event\.currentTarget/)
   assert.match(shell, /returnTarget\?\.focus\?\.\(\{ preventScroll: true \}\)/)
-  assert.match(shell, /const tabActionsAvailable = workspaceMode !== 'phone'/)
-  assert.match(shell, /event\.preventDefault\(\)\s*\n\s*if \(!tabActionsAvailable\) return/)
-  assert.match(shell, /\{tabActionsAvailable && tabMenu &&/)
+  assert.match(shell, /const openTabMenuAt = useCallback/)
+  assert.match(shell, /const openTabMenuAtRef = useRef\(openTabMenuAt\)/)
+  assert.match(shell, /\{tabMenu &&/)
+  assert.doesNotMatch(shell, /tabActionsAvailable/)
+  assert.match(shell, /useContextMenuOutsideDismiss\(\{[\s\S]*?open: Boolean\(tabMenu\)/)
   assert.doesNotMatch(shell, /workspace__menu-handle|workspace__menu-header|workspace__menu-close/)
   assert.doesNotMatch(css, /workspace__menu-handle|workspace__menu-header|workspace__menu-close|workspace-tab-sheet-in/)
 })
@@ -678,7 +684,8 @@ test('one held drawer-row gesture resolves menu, reorder, or workspace drag', ()
     'releasing a shorter stationary hold remains a normal tap')
   assert.match(drawerPointerUp, /if \(menuOpened\)[\s\S]*?cleanup\(\{ suppressClick: true \}\)/,
     'the menu-opening gesture restores selection only when its pointer ends')
-  assert.doesNotMatch(dragBinding, /openTabMenuAtRef/)
+  assert.match(dragBinding, /held && sourceKind === 'tab'[\s\S]*?openTabMenuAtRef\?\.current\?\./,
+    'a stationary tab hold opens the same actions on touch')
   assert.doesNotMatch(dragBinding, /addEventListener\('touchmove'/)
   assert.match(shell, /const drawerRowGesturesRef = useRef\(new Map\(\)\)/)
   assert.match(drawer, /const registry = drawerRowGesturesRef\.current[\s\S]*?registry\.set\(key, drawerGestureHandlerRef\)/)
@@ -939,12 +946,29 @@ test('drawer row actions have one opening path without a custom touch hold', () 
     'drawer rows rely on platform long-press feedback instead of adding a second vibration')
 })
 
+test('both context menus dismiss without stealing the destination press, including app frames', () => {
+  assert.match(shell, /useContextMenuOutsideDismiss\(\{[\s\S]*?open: Boolean\(tabMenu\)/)
+  assert.match(drawerItemActionMenu, /useContextMenuOutsideDismiss\(\{[\s\S]*?open,[\s\S]*?menuRef,[\s\S]*?onDismiss: closeFromOutside/)
+  assert.match(
+    drawerItemActionMenu,
+    /const closeFromOutside = useCallback\(\(\) => \{[\s\S]*?pointerOwnerRef\.current = \{ press: null, clickAction: null \}[\s\S]*?restoreOnCloseRef\.current = false[\s\S]*?onClose\(\)/,
+    'outside dismissal retires stale activation ownership and does not restore focus over the destination',
+  )
+  assert.match(contextMenuOutsideDismiss, /document\.addEventListener\('pointerdown', dismissFromOutsidePointer, true\)/)
+  assert.match(contextMenuOutsideDismiss, /menuRef\.current\?\.contains\(event\.target\)/)
+  assert.match(contextMenuOutsideDismiss, /window\.addEventListener\('blur', dismissFromFrameFocus, true\)/)
+  assert.match(contextMenuOutsideDismiss, /document\.activeElement\?\.tagName === 'IFRAME'/,
+    'focus transfer owns the cross-document seam because iframe pointer events cannot bubble to the shell')
+})
+
 test('a secondary-button release cannot immediately select a flipped drawer menu item', () => {
   assert.match(drawer, /event\.type === 'contextmenu' && secondaryReleaseCleanupRef\.current/)
   assert.match(drawer, /event\.pointerType !== 'mouse' \|\| event\.button !== 2/)
   assert.match(drawer, /window\.addEventListener\('pointerup', onSecondaryPointerUp, true\)/)
   assert.match(drawer, /upEvent\.pointerId !== pointerId \|\| upEvent\.button !== 2/)
-  assert.match(drawer, /cleanup\(\)[\s\S]*?openItemMenuAt\(placement, sourceBtn\)/)
+  assert.match(drawer, /const openingPoint = \{ x: event\.clientX, y: event\.clientY \}/)
+  assert.match(drawer, /cleanup\(\)[\s\S]*?openItemMenuAt\(openingPoint, sourceBtn\)/,
+    'the release path must not normalize the pointer point twice')
   assert.match(drawer, /timer = setTimeout\(cleanup, 1500\)/)
 })
 

--- a/frontend/src/components/Shell/dragController.js
+++ b/frontend/src/components/Shell/dragController.js
@@ -45,7 +45,7 @@ export const DRAWER_MENU_HOLD_MS = 400
 // Movement past this before a hold resolves yields to the source scroller.
 export const PRE_HOLD_MOVE_PX = 8
 // After a touch lift, a release that never moved past this is not a drop. Tabs
-// cancel cleanly because their hold gesture is reserved for dragging.
+// use that stationary outcome for actions; movement after the hold drags.
 export const RELEASE_IN_PLACE_PX = 5
 
 // ── Zone geometry (design §3.2 / §3.3) ───────────────────────────────────────

--- a/frontend/src/components/Shell/useWorkspaceDrag.js
+++ b/frontend/src/components/Shell/useWorkspaceDrag.js
@@ -80,6 +80,7 @@ export default function useWorkspaceDrag({
   drawerRowGesturesRef, // key -> ref({ openMenu, beginReorder }) registered by Drawer rows
   closeDrawer,
   openDrawer,
+  openTabMenuAtRef, // ref -> (clientX, clientY, tab, paneId) => void
   onPreviewBuilder, // (active, { committed }) => void — enter/leave the LIVE
   // builder preview a single-mode drag unfolds (point 15: dragging IS
   // building). Render-only: the reducer viewMode stays 'single' until the drop
@@ -310,8 +311,9 @@ export default function useWorkspaceDrag({
         }
       }
 
-      // Tabs and drawer rows share this ONE pointer owner. Tabs lift as soon as
-      // their hold resolves. Drawer rows become draggable after the brief first
+      // Tabs and drawer rows share this ONE pointer owner. A tab hold resolves
+      // intent without lifting immediately: movement then drags it, while a
+      // stationary release opens its actions. Drawer rows become draggable after the brief first
       // stage; if the pointer stays still through the second stage, actions open
       // immediately. Movement clears the same timer before handing off to reorder,
       // workspace drag, or scrolling, so no competing gesture lifecycle exists.
@@ -321,7 +323,6 @@ export default function useWorkspaceDrag({
           held = true
           if (navigator.vibrate) { try { navigator.vibrate(8) } catch { /* unsupported */ } }
           if (sourceKind !== 'drawer') {
-            arm()
             return
           }
           holdTimer = setTimeout(() => {
@@ -456,21 +457,29 @@ export default function useWorkspaceDrag({
             }
             if (!armed) return
           } else if (isTouch) {
-            const intent = touchTabMoveIntent(dx, dy)
-            if (intent === 'scroll') {
-              clearTimeout(holdTimer)
-              // The tab reserves one-finger panning so the browser cannot
-              // reclaim a post-hold horizontal move and cancel a live drag.
-              // Until the hold wins, mirror the strip's one-to-one pan here.
-              // Whitespace and close buttons remain native pan-x.
-              scrolling = true
-              scrollEl = srcEl.closest('.shell__tabstrip')
-              scrollAxis = 'x'
-              ev.preventDefault?.()
-              if (scrollEl) scrollEl.scrollLeft += start.x - ev.clientX
+            if (held && passedSlop(dx, dy)) arm()
+            if (armed) {
+              // Continue below so the move that first proves drag intent also
+              // positions the chip and preview; no second move is required.
+            } else if (held) {
               return
+            } else {
+              const intent = touchTabMoveIntent(dx, dy)
+              if (intent === 'scroll') {
+                clearTimeout(holdTimer)
+                // The tab reserves one-finger panning so the browser cannot
+                // reclaim a post-hold horizontal move and cancel a live drag.
+                // Until the hold wins, mirror the strip's one-to-one pan here.
+                // Whitespace and close buttons remain native pan-x.
+                scrolling = true
+                scrollEl = srcEl.closest('.shell__tabstrip')
+                scrollAxis = 'x'
+                ev.preventDefault?.()
+                if (scrollEl) scrollEl.scrollLeft += start.x - ev.clientX
+                return
+              }
+              if (!armed) return
             }
-            if (!armed) return
           } else {
             if (passedSlop(dx, dy)) arm()
             if (!armed) return
@@ -543,6 +552,18 @@ export default function useWorkspaceDrag({
         if (!armed) {
           if (scrolling) {
             cleanup({ suppressClick: true })
+          } else if (isTouch && held && sourceKind === 'tab') {
+            const dx = ev.clientX - start.x
+            const dy = ev.clientY - start.y
+            if (releasedInPlace(dx, dy)) {
+              openTabMenuAtRef?.current?.(
+                ev.clientX,
+                ev.clientY,
+                tabFromKey(key),
+                paneId,
+              )
+            }
+            cleanup({ suppressClick: true })
           } else cleanup()
           return
         }
@@ -559,8 +580,16 @@ export default function useWorkspaceDrag({
         const backOverDrawer = sourceKind === 'drawer' && drawerEdgeX != null
           && ev.clientX <= drawerEdgeX && !(isTouch && glided)
         if (isTouch && releasedInPlace(dx, dy)) {
-          // A lifted tab released in place cancels cleanly; its hold is reserved
-          // for drag.
+          // Pointer jitter can lift a held tab without becoming an intentional
+          // move. Keep the stationary-hold contract in that narrow case too.
+          if (sourceKind === 'tab') {
+            openTabMenuAtRef?.current?.(
+              ev.clientX,
+              ev.clientY,
+              tabFromKey(key),
+              paneId,
+            )
+          }
           cleanup({ suppressClick: true })
         } else if (backOverDrawer) {
           // Released back over the drawer = cancel; cleanup reopens it if glided.

--- a/frontend/src/hooks/useContextMenuOutsideDismiss.js
+++ b/frontend/src/hooks/useContextMenuOutsideDismiss.js
@@ -1,0 +1,39 @@
+import { useEffect } from 'react'
+
+/**
+ * Dismiss a pointer-transparent context menu without consuming the destination
+ * click. Parent-document pointer events cover shell and chat surfaces; focus
+ * transfer covers clicks entering an app iframe, whose pointer stream never
+ * bubbles into the shell document.
+ */
+export default function useContextMenuOutsideDismiss({
+  open,
+  menuRef,
+  onDismiss,
+}) {
+  useEffect(() => {
+    if (!open) return undefined
+    let active = true
+
+    function dismissFromOutsidePointer(event) {
+      if (!menuRef.current?.contains(event.target)) onDismiss()
+    }
+
+    function dismissFromFrameFocus() {
+      // Browsers disagree about whether activeElement changes before or just
+      // after the parent window's blur listener. Check at the microtask edge so
+      // the iframe owns focus in either ordering without delaying its click.
+      queueMicrotask(() => {
+        if (active && document.activeElement?.tagName === 'IFRAME') onDismiss()
+      })
+    }
+
+    document.addEventListener('pointerdown', dismissFromOutsidePointer, true)
+    window.addEventListener('blur', dismissFromFrameFocus, true)
+    return () => {
+      active = false
+      document.removeEventListener('pointerdown', dismissFromOutsidePointer, true)
+      window.removeEventListener('blur', dismissFromFrameFocus, true)
+    }
+  }, [menuRef, onDismiss, open])
+}

--- a/tests/workspace-panes.spec.mjs
+++ b/tests/workspace-panes.spec.mjs
@@ -131,8 +131,8 @@ async function mockApps(page, apps) {
     await page.route(new RegExp(`/api/apps/${a.id}/frame`), route => route.fulfill({
       status: 200, contentType: 'text/html',
       body: '<!doctype html><html><body style="margin:0">'
-        + '<div id="probe">app</div>'
-        + '<script>window.__fi = 0;'
+        + '<button id="probe" onclick="window.__clicks += 1">app</button>'
+        + '<script>window.__fi = 0; window.__clicks = 0;'
         + 'addEventListener("message", e => {'
         + ' if (e && e.data && e.data.type === "moebius:frame-init") window.__fi += 1;'
         + '});</script>'
@@ -634,6 +634,54 @@ test.describe('Workspace panes (PR2 gate)', () => {
     await page.getByRole('menuitem', { name: 'Close all other tabs' }).click()
     await expect.poll(async () => (await readWs(page)).panes.p1.tabs
       .map(tab => `${tab.kind}:${tab.id}`)).toEqual([keptKey])
+
+    const box = await activeTab.boundingBox()
+    const touchPoint = { x: box.x + box.width / 2, y: box.y + box.height / 2 }
+    await activeTab.dispatchEvent('pointerdown', {
+      pointerId: 41,
+      pointerType: 'touch',
+      isPrimary: true,
+      button: 0,
+      buttons: 1,
+      clientX: touchPoint.x,
+      clientY: touchPoint.y,
+    })
+    await page.waitForTimeout(450)
+    await activeTab.dispatchEvent('pointerup', {
+      pointerId: 41,
+      pointerType: 'touch',
+      isPrimary: true,
+      button: 0,
+      buttons: 0,
+      clientX: touchPoint.x,
+      clientY: touchPoint.y,
+    })
+    await expect(page.getByRole('menu', { name: 'Tab actions' })).toBeVisible()
+    await page.keyboard.press('Escape')
+  })
+
+  test('(d2) an app-frame click dismisses tab actions and still reaches the app', async ({ page }) => {
+    await boot(page, WIDE)
+    const chat = await createTaggedChat(page, 'wpFrameMenu')
+    const appId = 990102
+    await mockApps(page, [{ id: appId, name: 'Menu Target', chatId: chat.id }])
+    let ws = builderSeed([
+      { kind: 'chat', id: chat.id },
+      { kind: 'app', id: appId },
+    ])
+    ws = paneModel.moveTab(ws, `app:${appId}`, { root: true, edge: 'right' })
+    await seedWorkspace(page, ws)
+    await page.goto(`${BASE}/shell/?app=${appId}`, { waitUntil: 'domcontentloaded' })
+    await waitTiled(page)
+
+    const activeTab = page.locator(`.shell__tab-open[data-drag-key="app:${appId}"]`)
+    await activeTab.click({ button: 'right' })
+    await expect(page.getByRole('menu', { name: 'Tab actions' })).toBeVisible()
+
+    const frame = page.frameLocator(`iframe[data-app-id="${appId}"]`)
+    await frame.locator('#probe').click()
+    await expect(page.getByRole('menu', { name: 'Tab actions' })).toHaveCount(0)
+    await expect.poll(() => frame.locator('#probe').evaluate(() => window.__clicks)).toBe(1)
   })
 
   test('(e) a projection flip to phone preserves the persisted tree and pane focus', async ({ page }) => {


### PR DESCRIPTION
## Summary
- make stationary touch holds open the same close-only tab actions available from desktop right-click and keyboard
- preserve movement-after-hold as the existing tab drag gesture
- share outside-dismiss ownership across drawer and tab menus, including clicks inside isolated app frames
- keep destination presses live and retire stale drawer-menu activation provenance

## Verification
- `cd frontend && npm test`
- `cd frontend && npm run build`
- hosted Playwright adds an app-frame dismissal/activation regression

## Design review
The shared hook owns the actual cross-document boundary rather than adding per-surface iframe workarounds. Tab hold intent stays inside the existing workspace pointer session, so scrolling, dragging, native context-menu suppression, and click suppression retain one owner.

Prior-work search found no existing issue or PR for this combined behavior.