### PR TITLE
Simplify platform activation ownership

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -320,18 +320,16 @@ _APP_FRAME_CSP = app_frame_csp(
 _PUBLISHED_SITE_CSP = PUBLISHED_SITE_CSP
 
 
-def _frame_policy_exception(scope) -> bool:
-  """Exact routes whose own isolation permits a non-SAMEORIGIN ancestor."""
+def _is_public_service_surface(scope) -> bool:
+  """Whether the gateway host may frame this registered service route."""
   path = scope.get("path") or ""
-  if path == "/shell/embed/chat":
-    return True
-  if path.startswith("/services/"):
-    try:
-      from app.routes.local_services import is_public_service_surface_request
-      return is_public_service_surface_request(scope)
-    except Exception:
-      return False
-  return False
+  if not path.startswith("/services/"):
+    return False
+  try:
+    from app.routes.local_services import is_public_service_surface_request
+    return is_public_service_surface_request(scope)
+  except Exception:
+    return False
 
 
 class _SecurityHeadersMiddleware:
@@ -356,10 +354,10 @@ class _SecurityHeadersMiddleware:
     published_site = path.startswith(_PUBLISHED_SITE_PREFIX)
     chat_embed = path == "/shell/embed/chat"
     app_frame = bool(_APP_FRAME_PATH.fullmatch(path))
-    service_surface = path.startswith("/services/") and _frame_policy_exception(scope)
+    service_surface = _is_public_service_surface(scope)
     response_headers = list(_SECURITY_HEADERS)
     replaced_header_names = _SECURITY_HEADER_NAMES
-    if opaque_static_embed or _frame_policy_exception(scope):
+    if opaque_static_embed or chat_embed or service_surface:
       response_headers = [
         (name, value) for name, value in _SECURITY_HEADERS
         if name != _X_FRAME_OPTIONS

--- a/backend/app/platform_activation.py
+++ b/backend/app/platform_activation.py
@@ -37,22 +37,17 @@ class ActivationReason(TypedDict):
   """One independently actionable reason within a platform update."""
 
   code: str
-  level: str
   summary: str
   paths: list[str]
-  applies: bool
 
 
 class PlatformActivationImpact(TypedDict):
   """Owner-readable and machine-ordered activation result."""
 
   level: str
-  source_level: str
   deployment: DeploymentKind
-  actions: list[str]
   reasons: list[ActivationReason]
   guidance: list[str]
-  requires_operator: bool
 
 
 @dataclass(frozen=True)
@@ -183,7 +178,8 @@ def deployment_kind(environ: dict[str, str] | None = None) -> DeploymentKind:
     "RAILWAY_DEPLOYMENT_ID",
     "RAILWAY_PUBLIC_DOMAIN",
   )
-  return "railway" if any((env.get(key) or "").strip() for key in railway_markers) else "self_hosted"
+  on_railway = any((env.get(key) or "").strip() for key in railway_markers)
+  return "railway" if on_railway else "self_hosted"
 
 
 def _rule_for_path(path: str) -> _Rule | None:
@@ -196,7 +192,11 @@ def backend_import_probe_required(paths: Iterable[str]) -> bool:
   for path in paths:
     normalized = _normalize_path(path)
     rule = _rule_for_path(normalized)
-    if rule and rule.code == "server_runtime" and normalized != "skill/core.md":
+    if (
+      rule
+      and rule.level is ActivationLevel.SERVER_RESTART
+      and normalized != "skill/core.md"
+    ):
       return True
   return False
 
@@ -212,12 +212,21 @@ def _guidance(level: ActivationLevel, deployment: DeploymentKind) -> str:
     return "Restart Möbius after Apply so the running server loads the new source."
   if deployment == "railway":
     if level is ActivationLevel.CONTAINER_RECREATE:
-      return "Trigger a Railway deployment; an in-product restart cannot apply deployment configuration."
+      return (
+        "Trigger a Railway deployment; an in-product restart cannot apply "
+        "deployment configuration."
+      )
     if level is ActivationLevel.IMAGE_REBUILD:
-      return "Trigger a Railway image rebuild and deployment; Restart cannot install dependencies or baked tools."
+      return (
+        "Trigger a Railway image rebuild and deployment; Restart cannot "
+        "install dependencies or baked tools."
+      )
   else:
     if level is ActivationLevel.PROXY_RELOAD:
-      return "Refresh the host checkout, then reload Caddy; restarting Möbius does not reload the proxy."
+      return (
+        "Refresh the host checkout, then reload Caddy; restarting Möbius "
+        "does not reload the proxy."
+      )
     if level is ActivationLevel.CONTAINER_RECREATE:
       return "Refresh the host checkout, then recreate the affected Docker Compose services."
     if level is ActivationLevel.IMAGE_REBUILD:
@@ -230,7 +239,7 @@ def _guidance(level: ActivationLevel, deployment: DeploymentKind) -> str:
 def classify_activation(
   paths: Iterable[str], *, deployment: DeploymentKind | None = None,
 ) -> PlatformActivationImpact:
-  """Classify changed paths once, preserving both universal and local impact."""
+  """Classify the actions that apply to this installation."""
   active_deployment = deployment or deployment_kind()
   grouped: dict[str, tuple[_Rule | None, list[str]]] = {}
   for raw_path in paths:
@@ -244,48 +253,38 @@ def classify_activation(
     grouped[key][1].append(path)
 
   reasons: list[ActivationReason] = []
-  source_levels: list[ActivationLevel] = [ActivationLevel.LIVE]
-  effective_levels: list[ActivationLevel] = [ActivationLevel.LIVE]
+  action_levels: set[ActivationLevel] = set()
   for code, (rule, grouped_paths) in grouped.items():
     level = rule.level if rule else ActivationLevel.LIVE
-    applies = True if rule is None else _applies(rule, active_deployment)
-    source_levels.append(level)
-    if applies:
-      effective_levels.append(level)
+    if rule is not None and not _applies(rule, active_deployment):
+      continue
+    if level is not ActivationLevel.LIVE:
+      action_levels.add(level)
     reasons.append(ActivationReason(
       code=code,
-      level=level.value,
       summary=(
         rule.summary
         if rule
         else "These files are rebuilt, read on demand, or do not affect the running installation."
       ),
       paths=sorted(set(grouped_paths)),
-      applies=applies,
     ))
 
-  source_level = max(source_levels, key=LEVEL_ORDER.get)
-  required_level = max(effective_levels, key=LEVEL_ORDER.get)
-  action_levels = sorted(
-    {
-      ActivationLevel(reason["level"])
-      for reason in reasons
-      if reason["applies"] and reason["level"] != ActivationLevel.LIVE.value
-    },
+  required_level = max(
+    action_levels,
+    default=ActivationLevel.LIVE,
     key=LEVEL_ORDER.get,
   )
-  guidance = [_guidance(level, active_deployment) for level in action_levels]
+  ordered_actions = sorted(action_levels, key=LEVEL_ORDER.get)
+  guidance = [_guidance(level, active_deployment) for level in ordered_actions]
   if not guidance:
     guidance = [_guidance(ActivationLevel.LIVE, active_deployment)]
 
   return PlatformActivationImpact(
     level=required_level.value,
-    source_level=source_level.value,
     deployment=active_deployment,
-    actions=[level.value for level in action_levels],
     reasons=reasons,
     guidance=guidance,
-    requires_operator=LEVEL_ORDER[required_level] > LEVEL_ORDER[ActivationLevel.SERVER_RESTART],
   )
 
 
@@ -311,13 +310,10 @@ def dependency_fingerprint_paths(root: Path) -> list[str]:
 
 def _main() -> int:
   parser = argparse.ArgumentParser()
-  subparsers = parser.add_subparsers(dest="command", required=True)
-  fingerprint = subparsers.add_parser("dependency-fingerprint-paths")
-  fingerprint.add_argument("root", type=Path)
+  parser.add_argument("root", type=Path)
   args = parser.parse_args()
-  if args.command == "dependency-fingerprint-paths":
-    for path in dependency_fingerprint_paths(args.root.resolve()):
-      print(path)
+  for path in dependency_fingerprint_paths(args.root.resolve()):
+    print(path)
   return 0
 
 

--- a/backend/app/platform_update.py
+++ b/backend/app/platform_update.py
@@ -264,6 +264,13 @@ class PlatformApplyResult(TypedDict):
   reconciliation: dict[str, list[str]]
 
 
+class _ActivationMarker(TypedDict):
+  """Validated durable activation remainder."""
+
+  target_sha: str
+  paths: list[str]
+
+
 class PlatformRestartResponse(TypedDict):
   """Response shape for ``POST /api/platform/restart``."""
 
@@ -886,7 +893,7 @@ def recorded_upstream_sha(repo: Path = PLATFORM_REPO) -> str | None:
   return _rev(repo, UPSTREAM_BRANCH) or None
 
 
-def _read_activation_marker() -> dict[str, object] | None:
+def _read_activation_marker() -> _ActivationMarker | None:
   """Read the current target+paths marker, including the legacy bare SHA."""
   try:
     raw = RESTART_NEEDED_FLAG.read_text(encoding="utf-8").strip()
@@ -923,15 +930,9 @@ def _write_activation_marker(target_sha: str, paths: list[str]) -> None:
 
 def mark_activation_needed(target_sha: str, paths: list[str]) -> None:
   """Persist activation work, preserving any earlier host/image remainder."""
-  existing = _read_activation_marker() or {}
-  existing_paths = existing.get("paths")
-  carried = existing_paths if isinstance(existing_paths, list) else []
+  existing = _read_activation_marker()
+  carried = existing["paths"] if existing else []
   _write_activation_marker(target_sha, [*carried, *paths])
-
-
-def mark_restart_needed(target_sha: str) -> None:
-  """Compatibility helper for callers that know only a server restart is due."""
-  mark_activation_needed(target_sha, ["backend/app"])
 
 
 def _served_platform_sha() -> str | None:
@@ -950,63 +951,44 @@ def _served_platform_sha() -> str | None:
   return sha or None
 
 
-def _paths_need_import_probe(paths: list[str]) -> bool:
-  """True iff changed files can affect backend imports in a fresh process."""
-  return platform_activation.backend_import_probe_required(paths)
-
-
-def _activation_for_paths(paths: list[str]) -> PlatformActivationImpact:
-  return platform_activation.classify_activation(paths)
+def _activation_paths_between(
+  repo: Path, before: str | None, after: str | None,
+) -> list[str]:
+  """Changed paths, failing closed to backend runtime when unreadable."""
+  if before == after:
+    return []
+  if not before or not after:
+    return ["backend/app"]
+  paths = _changed_paths(repo, before, after)
+  return ["backend/app"] if paths is None else paths
 
 
 def _tree_change_needs_import_probe(
   repo: Path, before: str | None, after: str | None
 ) -> bool:
   """Whether a reconciled tree needs the defensive throwaway backend boot."""
-  if before == after:
-    return False
-  if not before or not after:
-    return True
-  paths = _changed_paths(repo, before, after)
-  if paths is None:
-    return True
-  return _paths_need_import_probe(paths)
-
-
-def _tree_change_activation(
-  repo: Path, before: str | None, after: str | None,
-) -> PlatformActivationImpact:
-  """Activation contract for a tree delta, failing closed to a server restart."""
-  if before == after:
-    return _activation_for_paths([])
-  if not before or not after:
-    return _activation_for_paths(["backend/app"])
-  paths = _changed_paths(repo, before, after)
-  if paths is None:
-    return _activation_for_paths(["backend/app"])
-  return _activation_for_paths(paths)
+  return platform_activation.backend_import_probe_required(
+    _activation_paths_between(repo, before, after)
+  )
 
 
 def _pending_activation_paths(repo: Path = PLATFORM_REPO) -> list[str]:
-  marker = _read_activation_marker() or {}
-  marker_paths = marker.get("paths")
-  paths = list(marker_paths) if isinstance(marker_paths, list) else []
+  marker = _read_activation_marker()
+  paths = list(marker["paths"]) if marker else []
   served = _served_platform_sha()
   if served:
     try:
       head = _rev(repo, _local_branch(repo))
     except Exception:
       head = None
-    changed = _changed_paths(repo, served, head) if head else None
-    if changed:
-      paths.extend(changed)
+    paths.extend(_activation_paths_between(repo, served, head))
   return sorted({str(path) for path in paths if str(path)})
 
 
 def _platform_activation_impact(
   repo: Path = PLATFORM_REPO,
 ) -> PlatformActivationImpact:
-  return _activation_for_paths(_pending_activation_paths(repo))
+  return platform_activation.classify_activation(_pending_activation_paths(repo))
 
 
 def _complete_boot_activation(repo: Path) -> None:
@@ -1021,10 +1003,8 @@ def _complete_boot_activation(repo: Path) -> None:
   if not marker:
     RESTART_NEEDED_FLAG.unlink(missing_ok=True)
     return
-  paths = marker.get("paths")
-  if not isinstance(paths, list):
-    return
-  target = str(marker.get("target_sha") or "")
+  paths = marker["paths"]
+  target = marker["target_sha"]
   build = current_build_sha()
   build_contains_target = bool(
     target and build and (_rev(repo, build) or "")
@@ -1036,7 +1016,7 @@ def _complete_boot_activation(repo: Path) -> None:
   }
   remaining: list[str] = []
   for path in paths:
-    level = _activation_for_paths([str(path)])["level"]
+    level = platform_activation.classify_activation([path])["level"]
     if level in {
       platform_activation.ActivationLevel.LIVE.value,
       platform_activation.ActivationLevel.SERVER_RESTART.value,
@@ -1726,6 +1706,17 @@ def managed_release_ready_sync() -> str:
   )
 
 
+def _state_for_activation(
+  impact: PlatformActivationImpact,
+) -> PlatformUpdateState:
+  level = impact["level"]
+  if level == platform_activation.ActivationLevel.SERVER_RESTART.value:
+    return PlatformUpdateState.RESTART_NEEDED
+  if level == platform_activation.ActivationLevel.LIVE.value:
+    return PlatformUpdateState.UP_TO_DATE
+  return PlatformUpdateState.ACTIVATION_NEEDED
+
+
 def boot_guard_sync() -> str:
   """Shell entry point run after reconcile and before uvicorn.
 
@@ -1750,6 +1741,7 @@ def platform_status(repo: Path = PLATFORM_REPO) -> PlatformStatus:
   conflict = CONFLICT_FLAG.exists() or _reconcile_in_progress(repo)
   rolled_back = ROLLED_BACK_FLAG.exists()
   activation = _platform_activation_impact(repo)
+  activation_state = _state_for_activation(activation)
   restart_needed = (
     activation["level"]
     == platform_activation.ActivationLevel.SERVER_RESTART.value
@@ -1778,10 +1770,8 @@ def platform_status(repo: Path = PLATFORM_REPO) -> PlatformStatus:
     # An update is available but its last apply failed the import probe.
     state = PlatformUpdateState.ROLLED_BACK
     available = True
-  elif restart_needed:
-    state = PlatformUpdateState.RESTART_NEEDED
-  elif activation["level"] != platform_activation.ActivationLevel.LIVE.value:
-    state = PlatformUpdateState.ACTIVATION_NEEDED
+  elif activation_state is not PlatformUpdateState.UP_TO_DATE:
+    state = activation_state
   elif available:
     state = PlatformUpdateState.AVAILABLE
   else:
@@ -1835,7 +1825,7 @@ def empty_platform_update_preview(
   return PlatformUpdatePreview(
     state=PlatformUpdateState.UP_TO_DATE.value, available=False,
     current_sha=current_sha, target_sha=target_sha, plan_id=None,
-    activation=_activation_for_paths([]),
+    activation=platform_activation.classify_activation([]),
     total_commits=0, commits_truncated=False,
     commits=[], files=[], diff=None, diff_truncated=False, conflict_paths=[],
   )
@@ -1972,7 +1962,7 @@ def _platform_update_preview_unlocked(repo: Path) -> PlatformUpdatePreview:
       state=PlatformUpdateState.AVAILABLE.value, available=True,
       current_sha=local_sha, target_sha=target,
       plan_id=_update_plan_id(local_sha, target) if local_sha else None,
-      activation=_activation_for_paths(["backend/app"]),
+      activation=platform_activation.classify_activation(["backend/app"]),
       total_commits=0, commits_truncated=False, commits=[], files=[],
       diff=None, diff_truncated=False, conflict_paths=[],
     )
@@ -1980,14 +1970,12 @@ def _platform_update_preview_unlocked(repo: Path) -> PlatformUpdatePreview:
   commits = _preview_commits(repo, base, target)
   total_commits = _preview_commit_count(repo, base, target)
   conflict = _read_conflict_flag() or {}
-  activation_paths = _changed_paths(repo, base, target)
-  if activation_paths is None:
-    activation_paths = ["backend/app"]
+  activation_paths = _activation_paths_between(repo, base, target)
   return PlatformUpdatePreview(
     state=PlatformUpdateState.AVAILABLE.value, available=True,
     current_sha=local_sha, target_sha=target,
     plan_id=_update_plan_id(local_sha, target) if local_sha else None,
-    activation=_activation_for_paths(activation_paths),
+    activation=platform_activation.classify_activation(activation_paths),
     total_commits=total_commits,
     commits_truncated=total_commits > len(commits),
     commits=commits,
@@ -2044,27 +2032,11 @@ async def apply_platform_update(
 
       def record_current_activation(head: str | None) -> PlatformActivationImpact:
         served = _served_platform_sha()
-        if served == head:
-          changed_paths: list[str] = []
-        elif not served or not head:
-          changed_paths = ["backend/app"]
-        else:
-          maybe_paths = _changed_paths(repo, served, head)
-          changed_paths = ["backend/app"] if maybe_paths is None else maybe_paths
-        incoming_impact = _tree_change_activation(repo, served, head)
-        if (
-          incoming_impact["source_level"]
-          != platform_activation.ActivationLevel.LIVE.value
-        ):
+        changed_paths = _activation_paths_between(repo, served, head)
+        incoming_impact = platform_activation.classify_activation(changed_paths)
+        if incoming_impact["level"] != platform_activation.ActivationLevel.LIVE.value:
           mark_activation_needed(head or "", changed_paths)
         return _platform_activation_impact(repo)
-
-      def clean_state(impact: PlatformActivationImpact) -> PlatformUpdateState:
-        if impact["level"] == platform_activation.ActivationLevel.SERVER_RESTART.value:
-          return PlatformUpdateState.RESTART_NEEDED
-        if impact["level"] != platform_activation.ActivationLevel.LIVE.value:
-          return PlatformUpdateState.ACTIVATION_NEEDED
-        return PlatformUpdateState.UP_TO_DATE
 
       if res.status == "updated":
         publish_progress(PlatformUpdatePhase.FINALIZING)
@@ -2077,7 +2049,7 @@ async def apply_platform_update(
         # incoming target: local commits made while uvicorn ran are part of the
         # same activation remainder.
         activation = record_current_activation(res.new_sha)
-        state = clean_state(activation)
+        state = _state_for_activation(activation)
       elif res.status == "conflict":
         # Keep the resolver gated behind the owner's next click. A conflict pass
         # rewrites the flag with target + paths, so preserve a previously opened
@@ -2100,7 +2072,7 @@ async def apply_platform_update(
       elif res.status == "up_to_date":
         head = _rev(repo, _local_branch(repo)) or res.pre_sha
         activation = record_current_activation(head)
-        state = clean_state(activation)
+        state = _state_for_activation(activation)
       else:  # offline / skipped — nothing changed; tell the UI plainly.
         raise PlatformUpdateError(res.error or res.status)
 

--- a/backend/app/routes/app_runtime.py
+++ b/backend/app/routes/app_runtime.py
@@ -3,7 +3,6 @@
 import asyncio
 import hashlib
 import json
-import os
 import re
 from pathlib import Path
 from urllib.parse import urljoin, urlparse
@@ -20,7 +19,6 @@ from app.deps import get_current_owner, resolve_owner_or_app
 from app.http_caching import strip_range
 from app.net_utils import validate_url_safe
 from app.resource_access import live_app, live_app_or_404
-from app.response_policy import absolute_csp_origin, app_frame_csp
 
 
 router = APIRouter()
@@ -247,17 +245,6 @@ def _not_modified_if_match(
       headers["X-Mobius-Offline"] = "1"
     return Response(status_code=304, headers=headers)
   return None
-
-
-_absolute_csp_origin = absolute_csp_origin
-
-
-def _app_frame_csp() -> str:
-  """Complete mini-app policy shared by every deployment topology."""
-  return app_frame_csp(
-    get_settings().frontend_origin,
-    os.environ.get("MOBIUS_SERVICE_GATEWAY_ORIGIN", ""),
-  )
 
 
 def _frame_etag(

--- a/backend/tests/test_deploy_edge_topology.py
+++ b/backend/tests/test_deploy_edge_topology.py
@@ -43,8 +43,3 @@ def test_stopped_shared_edge_never_falls_back_to_bundled_caddy():
   assert "{{.State.Status}}" in text
   assert "refusing to fall back to bundled Caddy" in text
   assert "Restore the shared edge proxy" in text
-
-
-def test_unknown_csp_mode_fails_instead_of_silently_enforcing():
-  text = SCRIPT.read_text(encoding="utf-8")
-  assert "EDGE_CSP_MODE must be 'enforce' or 'report-only'." in text

--- a/backend/tests/test_platform_activation.py
+++ b/backend/tests/test_platform_activation.py
@@ -12,8 +12,9 @@ def test_ordered_levels_choose_the_highest_effective_action():
   )
 
   assert impact["level"] == "image_rebuild"
-  assert impact["actions"] == ["server_restart", "image_rebuild"]
-  assert impact["requires_operator"] is True
+  assert {reason["code"] for reason in impact["reasons"]} == {
+    "live_source", "server_runtime", "container_image_definition",
+  }
 
 
 def test_deployment_specific_inputs_share_contract_without_fake_commands():
@@ -24,11 +25,10 @@ def test_deployment_specific_inputs_share_contract_without_fake_commands():
     ["railway.toml"], deployment="self_hosted",
   )
 
-  assert caddy_on_railway["source_level"] == "proxy_reload"
   assert caddy_on_railway["level"] == "live"
-  assert caddy_on_railway["reasons"][0]["applies"] is False
-  assert railway_on_self_hosted["source_level"] == "container_recreate"
+  assert caddy_on_railway["reasons"] == []
   assert railway_on_self_hosted["level"] == "live"
+  assert railway_on_self_hosted["reasons"] == []
 
 
 def test_baked_runtime_and_dependencies_never_degrade_to_restart_only():
@@ -42,7 +42,6 @@ def test_baked_runtime_and_dependencies_never_degrade_to_restart_only():
   ):
     impact = activation.classify_activation([path], deployment="self_hosted")
     assert impact["level"] == "image_rebuild", path
-    assert impact["requires_operator"] is True
 
 
 def test_dependency_fingerprint_comes_from_the_image_rules():
@@ -58,10 +57,3 @@ def test_dependency_fingerprint_comes_from_the_image_rules():
     "frontend/package-lock.json",
     "frontend/package.json",
   })
-
-
-def test_no_global_cross_origin_isolation_is_hidden_in_activation_policy():
-  source = Path(__file__).resolve().parents[1] / "app" / "response_policy.py"
-  text = source.read_text(encoding="utf-8")
-  assert "Cross-Origin-Opener-Policy" not in text
-  assert "Cross-Origin-Embedder-Policy" not in text

--- a/backend/tests/test_platform_routes.py
+++ b/backend/tests/test_platform_routes.py
@@ -7,6 +7,8 @@ case injects a failure at the route seam, so the test remains hermetic even when
 its runner lives inside a real Möbius installation.
 """
 
+from app.platform_activation import classify_activation
+
 
 def test_update_preview_requires_owner(client):
   assert client.get("/api/platform/update-preview").status_code == 401
@@ -73,15 +75,9 @@ def test_apply_forwards_exact_reviewed_plan(client, auth, monkeypatch):
     return {
       "state": "restart_needed",
       "needs_restart": True,
-      "activation": {
-        "level": "server_restart",
-        "source_level": "server_restart",
-        "deployment": "self_hosted",
-        "actions": ["server_restart"],
-        "reasons": [],
-        "guidance": ["Restart Möbius."],
-        "requires_operator": False,
-      },
+      "activation": classify_activation(
+        ["backend/app/main.py"], deployment="self_hosted"
+      ),
       "upstream_commit": plan["target_sha"],
       "merge_commit": "3" * 40,
       "conflict_paths": [],

--- a/backend/tests/test_platform_update.py
+++ b/backend/tests/test_platform_update.py
@@ -28,7 +28,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from app import app_git
+from app import app_git, platform_activation
 from app import platform_update as pu
 from app import release_channel
 
@@ -1250,25 +1250,28 @@ async def test_apply_marks_restart_when_disk_already_ahead_of_running_backend(
 # --- path-aware activation classifier ---------------------------------------
 
 def test_platform_update_uses_explicit_activation_levels():
-  assert pu._activation_for_paths(["backend/app/main.py"])["level"] == \
+  classify = platform_activation.classify_activation
+  assert classify(["backend/app/main.py"])["level"] == \
     "server_restart"
-  assert pu._activation_for_paths(["backend/config_helper.py"])["level"] == \
+  assert classify(["backend/config_helper.py"])["level"] == \
     "server_restart"
-  assert pu._activation_for_paths(["skill/core.md"])["level"] == \
+  assert classify(["skill/core.md"])["level"] == \
     "server_restart"
-  assert pu._activation_for_paths(["backend/requirements.txt"])["level"] == \
+  assert classify(["backend/requirements.txt"])["level"] == \
     "image_rebuild"
-  assert pu._activation_for_paths(["backend/scripts/entrypoint.sh"])["level"] == \
+  assert classify(["backend/scripts/entrypoint.sh"])["level"] == \
     "image_rebuild"
-  assert pu._activation_for_paths(["Caddyfile"])["level"] == "proxy_reload"
-  assert pu._activation_for_paths(["frontend/src/App.jsx"])["level"] == "live"
-  assert pu._activation_for_paths(["backend/tests/test_x.py"])["level"] == "live"
-  assert pu._activation_for_paths(["docs/backend/app/notes.md"])["level"] == "live"
+  assert classify(["Caddyfile"])["level"] == "proxy_reload"
+  assert classify(["frontend/src/App.jsx"])["level"] == "live"
+  assert classify(["backend/tests/test_x.py"])["level"] == "live"
+  assert classify(["docs/backend/app/notes.md"])["level"] == "live"
 
 
 def test_import_probe_classifier_excludes_constitution_only_change():
-  assert pu._paths_need_import_probe(["skill/core.md"]) is False
-  assert pu._paths_need_import_probe([
+  assert platform_activation.backend_import_probe_required(
+    ["skill/core.md"]
+  ) is False
+  assert platform_activation.backend_import_probe_required([
     "skill/core.md", "backend/app/chat.py",
   ]) is True
 
@@ -1301,8 +1304,7 @@ def test_changed_paths_no_renames_surfaces_deleted_backend(clone_env):
 
   paths = pu._changed_paths(platform, before, after)
   assert "backend/app/main.py" in paths  # delete side present
-  assert pu._tree_change_activation(platform, before, after)["level"] == \
-    "server_restart"
+  assert platform_activation.classify_activation(paths)["level"] == "server_restart"
 
 
 def test_empty_commit_does_not_force_restart(clone_env):
@@ -1313,20 +1315,18 @@ def test_empty_commit_does_not_force_restart(clone_env):
 
   assert before != after
   assert pu._changed_paths(platform, before, after) == []  # genuine empty diff
-  assert pu._tree_change_activation(platform, before, after)["level"] == "live"
+  assert pu._activation_paths_between(platform, before, after) == []
 
 
-def test_tree_change_activation_fails_closed_on_missing_sha(clone_env):
+def test_activation_paths_fail_closed_on_missing_sha(clone_env):
   origin, platform = clone_env
   served = _served_sha(platform)
   # one side unknown → can't prove no backend change → restart (fail closed)
-  assert pu._tree_change_activation(platform, served, None)["level"] == \
-    "server_restart"
-  assert pu._tree_change_activation(platform, None, served)["level"] == \
-    "server_restart"
+  assert pu._activation_paths_between(platform, served, None) == ["backend/app"]
+  assert pu._activation_paths_between(platform, None, served) == ["backend/app"]
   # both missing / equal → nothing changed
-  assert pu._tree_change_activation(platform, None, None)["level"] == "live"
-  assert pu._tree_change_activation(platform, served, served)["level"] == "live"
+  assert pu._activation_paths_between(platform, None, None) == []
+  assert pu._activation_paths_between(platform, served, served) == []
 
 
 def test_status_no_restart_when_only_frontend_changed(clone_env):
@@ -1373,7 +1373,6 @@ def test_status_requires_image_instead_of_offering_restart_for_dependencies(
   assert status["state"] == pu.PlatformUpdateState.ACTIVATION_NEEDED.value
   assert status["needs_restart"] is False
   assert status["activation"]["level"] == "image_rebuild"
-  assert status["activation"]["requires_operator"] is True
 
 
 def test_boot_clears_restart_but_preserves_unverified_image_work(clone_env):
@@ -1397,7 +1396,7 @@ def test_boot_clears_restart_but_preserves_unverified_image_work(clone_env):
 
 def test_boot_reconcile_clears_restart_flag(clone_env):
   origin, platform = clone_env
-  pu.mark_restart_needed("some-sha")
+  pu.mark_activation_needed("some-sha", ["backend/app"])
   assert pu.RESTART_NEEDED_FLAG.exists()
   # A boot with no new deploy is up_to_date; a boot IS the restart the flag asks
   # for, so it clears (the fresh process serves the on-disk code).
@@ -1408,7 +1407,7 @@ def test_boot_reconcile_clears_restart_flag(clone_env):
 
 def test_non_boot_reconcile_keeps_restart_flag(clone_env):
   origin, platform = clone_env
-  pu.mark_restart_needed("some-sha")
+  pu.mark_activation_needed("some-sha", ["backend/app"])
   # An owner-apply reconcile (at_boot=False) must NOT clear the flag on an
   # up-to-date pass — the running process is unchanged.
   res = pu.reconcile_clone(platform, at_boot=False)
@@ -1424,7 +1423,7 @@ def test_non_boot_reconcile_keeps_restart_flag(clone_env):
 
 def test_offline_boot_clears_stale_restart_flag(clone_env):
   origin, platform = clone_env
-  pu.mark_restart_needed("some-sha")
+  pu.mark_activation_needed("some-sha", ["backend/app"])
   assert pu.RESTART_NEEDED_FLAG.exists()
   # Force the fetch to fail so the reconcile returns 'offline' BEFORE reaching any
   # success/up-to-date branch — the flag must still clear (the boot IS the restart
@@ -1574,7 +1573,6 @@ def test_update_preview_warns_before_dependency_update_is_applied(clone_env):
   preview = pu.platform_update_preview(platform)
 
   assert preview["activation"]["level"] == "image_rebuild"
-  assert preview["activation"]["actions"] == ["image_rebuild"]
   assert "Restart cannot" not in " ".join(preview["activation"]["guidance"])
   assert "rebuild the image" in " ".join(preview["activation"]["guidance"])
 

--- a/backend/tests/test_security_headers.py
+++ b/backend/tests/test_security_headers.py
@@ -9,8 +9,7 @@ from app import main
 from app.main import (
   _PUBLISHED_SITE_CSP, _SHELL_CSP, _STATIC_EMBED_CSP, app,
 )
-from app.response_policy import CHAT_EMBED_CSP
-from app.routes.app_runtime import _app_frame_csp
+from app.response_policy import CHAT_EMBED_CSP, app_frame_csp
 
 
 def _headers(path="/api/health"):
@@ -88,7 +87,8 @@ def test_direct_shell_response_receives_the_origin_owned_policy():
   assert "https://esm.sh" in policy
   assert "img-src 'self' data: blob:" in policy
   assert "'wasm-unsafe-eval'" not in policy
-  assert "Cross-Origin-Opener-Policy" not in _headers()
+  assert "cross-origin-opener-policy" not in _headers()
+  assert "cross-origin-embedder-policy" not in _headers()
 
 
 def test_embedded_chat_allows_opaque_origin_app_ancestor():
@@ -171,12 +171,11 @@ def test_bundled_caddy_keeps_only_gateway_specific_response_policy():
   assert "{$MOBIUS_SERVICE_GATEWAY_ORIGIN} {" in gateway
 
 
-def test_backend_owns_complete_app_frame_policy(monkeypatch):
+def test_backend_owns_complete_app_frame_policy():
   """Direct managed and proxied installs receive one exact frame policy."""
   gateway = "https://services.example.test"
-  monkeypatch.setenv("MOBIUS_SERVICE_GATEWAY_ORIGIN", gateway)
-  policy = _app_frame_csp()
   origin = main.settings.frontend_origin.rstrip("/")
+  policy = app_frame_csp(origin, gateway)
 
   assert "sandbox allow-scripts" in policy
   assert "allow-popups-to-escape-sandbox" in policy
@@ -197,12 +196,11 @@ def test_backend_owns_complete_app_frame_policy(monkeypatch):
     assert "'self'" not in sources
 
 
-def test_app_frame_policy_drops_malformed_gateway_origin(monkeypatch):
-  monkeypatch.setenv(
-    "MOBIUS_SERVICE_GATEWAY_ORIGIN",
+def test_app_frame_policy_drops_malformed_gateway_origin():
+  policy = app_frame_csp(
+    main.settings.frontend_origin,
     "https://services.example.test; script-src *",
   )
-  policy = _app_frame_csp()
   assert "services.example.test" not in policy
   assert "script-src *" not in policy
 

--- a/backend/tests/test_verify_test_runtime.py
+++ b/backend/tests/test_verify_test_runtime.py
@@ -5,8 +5,8 @@ import shutil
 import subprocess
 import sys
 
-from scripts.verify_test_runtime import PLATFORM_ROOT, platform_head, validate_runtime
 from app.platform_activation import dependency_fingerprint_paths
+from scripts.verify_test_runtime import PLATFORM_ROOT, platform_head, validate_runtime
 
 
 SHA = "a" * 40
@@ -183,6 +183,7 @@ def test_image_deduplicates_agent_cli_payloads_without_breaking_sdk_contracts():
 
 def test_production_image_keeps_persistent_sso_checkouts_bootable():
   dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+  fingerprint_paths = dependency_fingerprint_paths(ROOT)
   requirements = (ROOT / "backend" / "requirements.txt").read_text(
     encoding="utf-8"
   )

--- a/frontend/src/components/SettingsView/SettingsView.jsx
+++ b/frontend/src/components/SettingsView/SettingsView.jsx
@@ -1606,7 +1606,7 @@ export default function SettingsView({
           ) : (
             // Loading: no cached data yet and no error — the initial
             // in-flight fetch. Show a neutral notice instead of nothing.
-            <div className="settings__notice settings__notice--stacked" role="status">
+            <div className="settings__notice" role="status">
               Loading providers…
             </div>
           )}
@@ -1783,7 +1783,7 @@ export default function SettingsView({
             </div>
           )}
           {platformExternalActivation && (
-            <div className="settings__notice" role="status">
+            <div className="settings__notice settings__notice--stacked" role="status">
               {(platform?.activation?.guidance || []).map((line) => (
                 <span key={line}>{line}</span>
               ))}

--- a/frontend/src/components/SettingsView/UpdateReviewModal.jsx
+++ b/frontend/src/components/SettingsView/UpdateReviewModal.jsx
@@ -137,7 +137,7 @@ export default function UpdateReviewModal({
     ? activation.guidance
     : []
   const activationReasons = Array.isArray(activation?.reasons)
-    ? activation.reasons.filter((reason) => reason?.applies)
+    ? activation.reasons
     : []
   const parsedFiles = useMemo(
     () => parseUnifiedDiff(preview?.diff),

--- a/frontend/src/lib/__tests__/platformUpdateState.test.js
+++ b/frontend/src/lib/__tests__/platformUpdateState.test.js
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import {
+  platformActivationLabel,
   platformStatusFromApply,
   platformUpdateStatusLabel,
 } from '../platformUpdateState.js'
@@ -44,6 +45,7 @@ test('an image-required apply projects the external activation contract', () => 
   assert.equal(projected.available, false)
   assert.equal(projected.needs_restart, false)
   assert.equal(projected.activation, activation)
+  assert.equal(platformActivationLabel(projected.activation), 'Image rebuild')
   assert.equal(platformUpdateStatusLabel(projected), 'Image rebuild required')
 })
 

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -508,10 +508,6 @@ valid_gateway_origin() {
 # rather than mounting keeps prod at permanent parity with the file CI
 # validates — the pre-edge setup drifted for months because the external proxy
 # had its own hand-written copy of these vhosts.
-#
-# EDGE_CSP_MODE=report-only downgrades the shell Content-Security-Policy to
-# Report-Only for a staged rollout (violations appear in the browser console
-# without breaking the page); default is enforce.
 install_edge_fragment() {
   external_prod_caddy_running || return 0
   local edge_dir="${MOBIUS_EDGE_DIR:-$HOME/projects/edge}"
@@ -565,18 +561,6 @@ install_edge_fragment() {
     rm -f "$rendered"
     exit 1
   fi
-  case "${EDGE_CSP_MODE:-enforce}" in
-    enforce) ;;
-    report-only)
-      sed -i 's|>Content-Security-Policy |>Content-Security-Policy-Report-Only |g' "$rendered"
-      info "edge fragment CSP rendered as Report-Only (EDGE_CSP_MODE=report-only)"
-      ;;
-    *)
-      rm -f "$rendered"
-      fail "EDGE_CSP_MODE must be 'enforce' or 'report-only'."
-      exit 1
-      ;;
-  esac
   # edgectl is transactional: a bad render never replaces the installed
   # fragment, a failed reload restores it, and the previously SERVED fragment
   # stays available as `edgectl rollback mobius`.

--- a/scripts/test-image-fingerprint.sh
+++ b/scripts/test-image-fingerprint.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 ROOT="${MOBIUS_TEST_IMAGE_INPUT_ROOT:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)}"
 CLASSIFIER="$ROOT/backend/app/platform_activation.py"
 mapfile -t files < <(
-  python3 "$CLASSIFIER" dependency-fingerprint-paths "$ROOT"
+  python3 "$CLASSIFIER" "$ROOT"
 )
 
 [ "${#files[@]}" -gt 0 ] || {


### PR DESCRIPTION
## Summary
- narrow activation metadata to only the actions and reasons that apply to the current deployment
- consolidate activation-state derivation and changed-path failure handling in the owning updater seams
- remove route-local response-policy wrappers and the edge report-only switch that could weaken the gateway policy instead of staging origin policy
- keep image fingerprints and UI parity checks behavioral rather than tied to command or source structure

This is the focused follow-up to #584. It preserves the deployment and recovery boundaries introduced there while removing duplicate shapes and compatibility helpers. It also supersedes the older #585 branch, which was closed after #584 merged.

## Testing
- 154 focused backend activation, update, route, security, edge, runtime, and frame tests
- full frontend unit and hook suites (2,401 tests)
- frontend lint and production/PWA build
- Python compile, shell syntax, image fingerprint, and diff checks
- full backend suite launched locally; hosted CI is the authoritative complete gate