### PR TITLE
Add app-owned playback controls to the drawer

### DIFF
--- a/frontend/src/components/AppCanvas/AppCanvas.jsx
+++ b/frontend/src/components/AppCanvas/AppCanvas.jsx
@@ -22,6 +22,7 @@ import { builtInCapabilityProviders } from '../../lib/capabilityProviders.js'
 import { requestAppCodeWarm } from '../../lib/appPrecache.js'
 import { appHostRequest } from '../../lib/appHostRequest.js'
 import {
+  appMediaSessionEvent,
   applyVirtualStorageMutation,
   attributedFrameVersion,
   serveModuleRequest,
@@ -264,6 +265,7 @@ const AppCanvas = forwardRef(function AppCanvas({
   pendingIntent = null,
   onNavPush, onNavPop, onNavReset, onNavForwardResult,
   onAppFocus, onImmersive, onIntentDelivered, onAppError, onHostRequest,
+  onMediaSession,
 }, hostRef) {
   const queryClient = useQueryClient()
   const [serviceSurface, setServiceSurface] = useState(null)
@@ -356,6 +358,17 @@ const AppCanvas = forwardRef(function AppCanvas({
   // VERSION — a Map, not a single ref, because two iframes are alive during the
   // swap window and each must be addressable independently.
   const framesRef = useRef(new Map())
+  // Playback remains inside the app frame. This map only binds the shell's
+  // small metadata/control surface to the exact document that owns it.
+  const frameMediaSessionRef = useRef(new Map())
+  const onMediaSessionRef = useRef(onMediaSession)
+  onMediaSessionRef.current = onMediaSession
+  function retireFrameMediaSession(v) {
+    const sessionId = frameMediaSessionRef.current.get(v)
+    if (!sessionId) return
+    frameMediaSessionRef.current.delete(v)
+    onMediaSessionRef.current?.(appId, { event: 'close', sessionId })
+  }
   // Message attribution lives in one intentionally stable listener below, so
   // keep the current one-shot intent in a ref rather than re-registering that
   // listener on every deep link. The nonce prevents a late acknowledgement for
@@ -426,6 +439,7 @@ const AppCanvas = forwardRef(function AppCanvas({
             framesRef.current.get(v)?.contentWindow,
           )
           storageHostRef.current.detachSource(framesRef.current.get(v)?.contentWindow)
+          retireFrameMediaSession(v)
           // A service-surface takeover can remove the live iframe without
           // unmounting AppCanvas or advancing the buffered version. Retire its
           // host sentinels at this exhaustive document-removal boundary too.
@@ -721,6 +735,38 @@ const AppCanvas = forwardRef(function AppCanvas({
       // browsing context). Route acks back to the source frame via e.source
       // directly — it is the verified sender window.
       if (srcVersion !== liveVersionRef.current) return
+
+      // App-owned playback may continue while its warm frame is hidden, so its
+      // drawer control surface is live-frame-scoped rather than visibility-
+      // scoped. Only small metadata/state crosses this boundary; the frame
+      // keeps the audio graph, buffers, and native Media Session integration.
+      const mediaEvent = appMediaSessionEvent(msg)
+      if (mediaEvent) {
+        const currentSessionId = frameMediaSessionRef.current.get(srcVersion)
+        if (mediaEvent.event === 'close') {
+          if (currentSessionId !== mediaEvent.sessionId) return
+          frameMediaSessionRef.current.delete(srcVersion)
+          onMediaSessionRef.current?.(appId, mediaEvent)
+          return
+        }
+        if (mediaEvent.event === 'update' && currentSessionId !== mediaEvent.sessionId) return
+        frameMediaSessionRef.current.set(srcVersion, mediaEvent.sessionId)
+        const source = e.source
+        onMediaSessionRef.current?.(appId, mediaEvent, (action) => {
+          if (!['play', 'pause', 'stop'].includes(action)) return false
+          try {
+            source?.postMessage({
+              type: 'moebius:media-control',
+              sessionId: mediaEvent.sessionId,
+              action,
+            }, '*')
+            return true
+          } catch {
+            return false
+          }
+        })
+        return
+      }
 
       if (msg.type === 'moebius:app-intent-applied') {
         const pending = pendingIntentRef.current
@@ -1236,6 +1282,7 @@ const AppCanvas = forwardRef(function AppCanvas({
     // re-init below then runs the fresh document's handshake (this is exactly
     // why the parent never dedups frame-init).
     if (loadedDocsRef.current.has(v)) {
+      retireFrameMediaSession(v)
       capabilityHostRef.current.detachSource(
         framesRef.current.get(v)?.contentWindow,
       )

--- a/frontend/src/components/AppCanvas/appFrameProtocol.js
+++ b/frontend/src/components/AppCanvas/appFrameProtocol.js
@@ -13,6 +13,27 @@ export function attributedFrameVersion(frames, source) {
   return null
 }
 
+const MEDIA_EVENTS = new Set(['open', 'update', 'close'])
+const MEDIA_STATES = new Set(['loading', 'playing', 'paused'])
+
+export function appMediaSessionEvent(message) {
+  if (!message || message.type !== 'moebius:media-session') return null
+  if (!MEDIA_EVENTS.has(message.event)) return null
+  const sessionId = typeof message.sessionId === 'string' ? message.sessionId : ''
+  if (!sessionId || sessionId.length > 160 || sessionId.trim() !== sessionId) return null
+  if (message.event === 'close') return { event: 'close', sessionId }
+  return {
+    event: message.event,
+    sessionId,
+    title: typeof message.title === 'string'
+      ? message.title.trim().slice(0, 120) || 'Playing audio'
+      : 'Playing audio',
+    playbackState: MEDIA_STATES.has(message.playbackState)
+      ? message.playbackState
+      : 'loading',
+  }
+}
+
 function requestIdOf(message) {
   return typeof message.requestId === 'string' && message.requestId.length <= 160
     ? message.requestId

--- a/frontend/src/components/Drawer/Drawer.css
+++ b/frontend/src/components/Drawer/Drawer.css
@@ -275,6 +275,127 @@
   font-weight: 500;
 }
 
+.drawer__now-playing {
+  min-height: 54px;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  margin: 2px 0 8px;
+  padding: 5px 6px;
+  border: 1px solid var(--border-light);
+  border-radius: 12px;
+  background: var(--surface);
+}
+
+.drawer__now-playing-main,
+.drawer__now-playing-control {
+  border: 0;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.drawer__now-playing-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 3px 5px;
+  text-align: left;
+}
+
+.drawer__now-playing-icon {
+  position: relative;
+  flex: 0 0 30px;
+  width: 30px;
+  height: 30px;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  border-radius: 8px;
+  background: var(--app-color, var(--accent));
+  color: var(--accent-fg, #fff);
+  font-size: 9px;
+  font-weight: 750;
+}
+
+.drawer__now-playing-icon img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.drawer__now-playing-icon.is-image {
+  overflow: visible;
+  border-radius: 0;
+  background: transparent;
+}
+
+.drawer__now-playing-icon.is-image > span { visibility: hidden; }
+
+.drawer__now-playing-copy {
+  min-width: 0;
+  display: grid;
+  gap: 1px;
+}
+
+.drawer__now-playing-copy strong,
+.drawer__now-playing-copy small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.drawer__now-playing-copy strong {
+  font-size: 13px;
+  line-height: 17px;
+  font-weight: 600;
+}
+
+.drawer__now-playing-copy small {
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 15px;
+}
+
+.drawer__now-playing-control {
+  flex: 0 0 34px;
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  padding: 8px;
+  border-radius: 999px;
+}
+
+.drawer__now-playing-control svg {
+  width: 17px;
+  height: 17px;
+}
+
+.drawer__now-playing-main:focus-visible,
+.drawer__now-playing-control:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.drawer__now-playing-control:disabled {
+  opacity: 0.38;
+  cursor: default;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .drawer__now-playing-main:hover,
+  .drawer__now-playing-control:not(:disabled):hover {
+    background: var(--surface-raised, var(--border-light));
+  }
+}
+
 .drawer__item-count {
   flex: 0 0 auto;
   min-width: 20px;

--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -2,6 +2,7 @@ import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useStat
 import { createPortal } from 'react-dom'
 import { useQueryClient } from '@tanstack/react-query'
 import { EmptyMessage } from '@openai/apps-sdk-ui/components/EmptyMessage'
+import { Pause, Play, Stop } from '@openai/apps-sdk-ui/components/Icon'
 import { api } from '../../api/client.js'
 import { appQueries, chatQueries } from '../../hooks/queries.js'
 import { useHistoryDismiss } from '../../hooks/useHistoryDismiss.jsx'
@@ -90,6 +91,9 @@ export default function Drawer({
   appsActive = false,
   onAppsOpen,
   appsHost,
+  nowPlaying,
+  onNowPlayingOpen,
+  onNowPlayingControl,
   // Set of chat ids whose agent is currently streaming. Used to
   // show a small accent dot next to the row label so the user can
   // see at a glance which background builds are still running.
@@ -1019,6 +1023,15 @@ export default function Drawer({
                 <span className="drawer__item-text">Apps</span>
               </button>
 
+              {nowPlaying && (
+                <NowPlaying
+                  session={nowPlaying}
+                  app={apps.find(app => String(app.id) === String(nowPlaying.appId))}
+                  onOpen={onNowPlayingOpen}
+                  onControl={onNowPlayingControl}
+                />
+              )}
+
               {pinnedItems.length > 0 && (
                 <section className="drawer__section" aria-labelledby="drawer-pinned-label">
                   <h2 id="drawer-pinned-label" className="drawer__label">
@@ -1228,6 +1241,54 @@ export default function Drawer({
         />
       )}
     </>
+  )
+}
+
+function NowPlaying({ session, app, onOpen, onControl }) {
+  const appName = app?.name || 'App'
+  const paused = session.playbackState === 'paused'
+  const loading = session.playbackState === 'loading'
+  const stateLabel = loading ? 'Preparing' : paused ? 'Paused' : 'Playing'
+  return (
+    <section className="drawer__now-playing" aria-label={`Now playing from ${appName}`}>
+      <button
+        type="button"
+        className="drawer__now-playing-main"
+        onClick={() => onOpen?.(session.appId)}
+        aria-label={`Open ${appName}`}
+      >
+        {app ? (
+          <AppIcon item={app} label={appName} className="drawer__now-playing-icon" size={64} />
+        ) : (
+          <span className="drawer__now-playing-icon" aria-hidden="true">
+            <span>{appInitials(appName)}</span>
+          </span>
+        )}
+        <span className="drawer__now-playing-copy">
+          <strong>{session.title}</strong>
+          <small>{appName} · {stateLabel}</small>
+        </span>
+      </button>
+      <button
+        type="button"
+        className="drawer__now-playing-control"
+        aria-label={paused ? 'Resume playback' : 'Pause playback'}
+        title={paused ? 'Resume' : 'Pause'}
+        disabled={loading}
+        onClick={() => onControl?.(paused ? 'play' : 'pause')}
+      >
+        {paused ? <Play aria-hidden="true" /> : <Pause aria-hidden="true" />}
+      </button>
+      <button
+        type="button"
+        className="drawer__now-playing-control"
+        aria-label="Stop playback"
+        title="Stop"
+        onClick={() => onControl?.('stop')}
+      >
+        <Stop aria-hidden="true" />
+      </button>
+    </section>
   )
 }
 

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -134,6 +134,7 @@ import useShellReloadController from './useShellReloadController.js'
 import useAppFrameCache from './useAppFrameCache.js'
 import useShellVisualViewport from './useShellVisualViewport.js'
 import ShellBrand from './ShellBrand.jsx'
+import { createMediaSessionOwner } from './mediaSessionOwner.js'
 import { HistoryDismissProvider } from '../../hooks/useHistoryDismiss.jsx'
 
 const APP_SETTINGS_SECTIONS = new Set([
@@ -327,6 +328,17 @@ export default function Shell() {
   // immersive can solo its pane over the whole workspace (§4/§9). Full contract:
   // lib/immersive.js.
   const [immersiveAppId, dispatchImmersive] = useReducer(immersiveReducer, null)
+  const [nowPlaying, setNowPlaying] = useState(null)
+  const mediaSessionOwnerRef = useRef(null)
+  if (!mediaSessionOwnerRef.current) {
+    mediaSessionOwnerRef.current = createMediaSessionOwner(setNowPlaying)
+  }
+  const handleMediaSession = useCallback((appId, event, sendControl) => {
+    mediaSessionOwnerRef.current.receive(appId, event, sendControl)
+  }, [])
+  const handleNowPlayingControl = useCallback((action) => {
+    mediaSessionOwnerRef.current.control(action)
+  }, [])
   // Stable identity — AppCanvas's message-listener effect depends on it.
   const handleImmersive = useCallback((appId, value) => {
     dispatchImmersive({ type: 'request', appId, value })
@@ -380,6 +392,9 @@ export default function Shell() {
   // with the per-render navTo identity. Pane handlers call through this stable
   // facade and still reach the latest navigation implementation via the ref.
   const stablePaneNavTo = useCallback((view, opts) => navToRef.current(view, opts), [])
+  const handleNowPlayingOpen = useCallback((appId) => {
+    navToRef.current('canvas', { appId })
+  }, [])
   // Reconcile in-memory route hints after every workspace transition (design
   // §5.1.3). navStackRef is stable, so recreating this closure each render is
   // behaviourally identical. reconcileRoutePanes points each hint at the pane
@@ -3111,6 +3126,9 @@ export default function Shell() {
         appsActive={appsVisibleAsTab}
         onAppsOpen={() => navTo('apps')}
         appsHost={appsDirectoryHost}
+        nowPlaying={nowPlaying}
+        onNowPlayingOpen={handleNowPlayingOpen}
+        onNowPlayingControl={handleNowPlayingControl}
         streamingChatIds={streamingChatIds}
         attentionChatIds={attentionChatIds}
         newAppIds={appAttentionSet}
@@ -3286,6 +3304,7 @@ export default function Shell() {
               onIntentDelivered={handleAppIntentDelivered}
               onAppError={handleAppError}
               onHostRequest={handleAppHostRequest}
+              onMediaSession={handleMediaSession}
             />
             </ErrorBoundary>
           </div>

--- a/frontend/src/components/Shell/__tests__/appFrameProtocol.test.js
+++ b/frontend/src/components/Shell/__tests__/appFrameProtocol.test.js
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
+  appMediaSessionEvent,
   applyVirtualStorageMutation,
   attributedFrameVersion,
   serveModuleRequest,
@@ -91,4 +92,28 @@ test('storage RPC narrows arguments and returns one correlated result', async ()
 
 test('unknown virtual-storage messages remain outside the storage owner', () => {
   assert.equal(applyVirtualStorageMutation(7, { type: 'other' }, () => {}), false)
+})
+
+
+test('media-session messages are bounded to the drawer contract', () => {
+  assert.deepEqual(appMediaSessionEvent({
+    type: 'moebius:media-session', event: 'open', sessionId: 'digest-1',
+    title: ' Daily digest ', subtitle: ' Untrusted app label ', playbackState: 'playing',
+  }), {
+    event: 'open', sessionId: 'digest-1', title: 'Daily digest',
+    playbackState: 'playing',
+  })
+  assert.deepEqual(appMediaSessionEvent({
+    type: 'moebius:media-session', event: 'close', sessionId: 'digest-1',
+  }), { event: 'close', sessionId: 'digest-1' })
+  assert.equal(appMediaSessionEvent({
+    type: 'moebius:media-session', event: 'update', sessionId: '',
+  }), null)
+  assert.equal(appMediaSessionEvent({
+    type: 'moebius:media-session', event: 'open', sessionId: ' padded ',
+  }), null)
+  assert.equal(appMediaSessionEvent({
+    type: 'moebius:media-session', event: 'open', sessionId: 'x'.repeat(161),
+  }), null)
+  assert.equal(appMediaSessionEvent({ type: 'moebius:other' }), null)
 })

--- a/frontend/src/components/Shell/__tests__/mediaSessionOwner.test.js
+++ b/frontend/src/components/Shell/__tests__/mediaSessionOwner.test.js
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { createMediaSessionOwner } from '../mediaSessionOwner.js'
+
+function event(kind, sessionId, playbackState = 'playing') {
+  return {
+    event: kind,
+    sessionId,
+    title: `Title ${sessionId}`,
+    playbackState,
+  }
+}
+
+test('a newer app session stops and replaces the previous playback lease', () => {
+  const changes = []
+  const controls = []
+  const owner = createMediaSessionOwner(value => changes.push(value))
+
+  owner.receive(1, event('open', 'one'), action => controls.push(['one', action]) || true)
+  owner.receive(2, event('open', 'two'), action => controls.push(['two', action]) || true)
+
+  assert.deepEqual(controls, [['one', 'stop']])
+  assert.equal(changes.at(-1).appId, 2)
+  assert.equal(changes.at(-1).sessionId, 'two')
+})
+
+test('late updates and closes cannot take over or clear the current lease', () => {
+  const changes = []
+  const owner = createMediaSessionOwner(value => changes.push(value))
+  owner.receive(1, event('open', 'one'), () => true)
+  owner.receive(2, event('open', 'two'), () => true)
+
+  assert.equal(owner.receive(1, event('update', 'one', 'paused'), () => true), false)
+  assert.equal(owner.receive(1, event('close', 'one'), () => true), false)
+  assert.equal(changes.at(-1).sessionId, 'two')
+})
+
+test('stop remains app-confirmed and a failed delivery keeps controls available', () => {
+  const changes = []
+  const controls = []
+  const owner = createMediaSessionOwner(value => changes.push(value))
+  owner.receive(1, event('open', 'one'), action => { controls.push(action); return false })
+
+  assert.equal(owner.control('stop'), false)
+  assert.deepEqual(controls, ['stop'])
+  assert.equal(changes.at(-1).sessionId, 'one')
+
+  assert.equal(owner.receive(1, event('close', 'one'), () => true), true)
+  assert.equal(changes.at(-1), null)
+})

--- a/frontend/src/components/Shell/mediaSessionOwner.js
+++ b/frontend/src/components/Shell/mediaSessionOwner.js
@@ -1,0 +1,47 @@
+const MEDIA_CONTROLS = new Set(['play', 'pause', 'stop'])
+
+function sameSession(owner, appId, sessionId) {
+  return owner
+    && String(owner.appId) === String(appId)
+    && owner.sessionId === sessionId
+}
+
+/**
+ * Own the shell's single app playback lease. Apps retain the media graph and
+ * confirm every state transition; the shell only forwards controls and paints
+ * the latest confirmed metadata.
+ */
+export function createMediaSessionOwner(onChange) {
+  let owner = null
+
+  return {
+    receive(appId, event, sendControl) {
+      const matches = sameSession(owner, appId, event.sessionId)
+      if (event.event === 'close') {
+        if (!matches) return false
+        owner = null
+        onChange(null)
+        return true
+      }
+      if (event.event === 'update' && !matches) return false
+      if (event.event === 'open' && owner && !matches) {
+        owner.sendControl?.('stop')
+      }
+      owner = { appId, sessionId: event.sessionId, sendControl }
+      onChange({
+        appId,
+        sessionId: event.sessionId,
+        title: event.title,
+        playbackState: event.playbackState,
+      })
+      return true
+    },
+
+    control(action) {
+      if (!owner || !MEDIA_CONTROLS.has(action)) return false
+      // A stop request is not completion. Keep the lease visible until the app
+      // closes it, so a dead/stale frame cannot leave audible media unowned.
+      return owner.sendControl?.(action) === true
+    },
+  }
+}

--- a/tests/app-canvas.spec.mjs
+++ b/tests/app-canvas.spec.mjs
@@ -344,6 +344,75 @@ test.describe('AppCanvas: iframe-mount contract', () => {
     await expect(page.locator('.canvas-loading')).toBeHidden({ timeout: 6000 })
   })
 
+  test('drawer playback controls stay bound to the owning live frame', async ({ page }) => {
+    const appId = 97
+    await setupAppRoutes(page, appId, mockFrameHTML(appId))
+    await page.goto(`${BASE}/app/${appId}`, { waitUntil: 'domcontentloaded' })
+    await expect(page.locator('.canvas-loading')).toBeHidden({ timeout: 10000 })
+    const frame = await waitForContentFrame(page, 'iframe.canvas--live')
+    await frame.evaluate(() => {
+      window.__mediaControls = []
+      window.addEventListener('message', (event) => {
+        if (event.data?.type === 'moebius:media-control') {
+          window.__mediaControls.push(event.data)
+        }
+      })
+      window.parent.postMessage({
+        type: 'moebius:media-session',
+        event: 'open',
+        sessionId: 'digest-one',
+        title: 'Daily digest',
+        subtitle: 'Spoofed app name',
+        playbackState: 'playing',
+      }, window.location.origin)
+    })
+
+    const drawerToggle = page.getByRole('button', { name: 'Toggle navigation' })
+    await drawerToggle.click()
+    const player = page.getByRole('region', { name: 'Now playing from mock-app' })
+    await expect(player).toBeVisible()
+    await expect(player).toContainText('Daily digest')
+    await expect(player).toContainText('mock-app · Playing')
+    await expect(player).not.toContainText('Spoofed app name')
+
+    await player.getByRole('button', { name: 'Pause playback' }).click()
+    await expect.poll(() => frame.evaluate(() => window.__mediaControls.at(-1)?.action))
+      .toBe('pause')
+    await frame.evaluate(() => window.parent.postMessage({
+      type: 'moebius:media-session',
+      event: 'update',
+      sessionId: 'digest-one',
+      title: 'Daily digest',
+      playbackState: 'paused',
+    }, window.location.origin))
+    await expect(player.getByRole('button', { name: 'Resume playback' })).toBeVisible()
+
+    await player.getByRole('button', { name: 'Stop playback' }).click()
+    await expect.poll(() => frame.evaluate(() => window.__mediaControls.at(-1)?.action))
+      .toBe('stop')
+    // Stop is a request, not confirmation: controls remain until the app closes.
+    await expect(player).toBeVisible()
+    await frame.evaluate(() => window.parent.postMessage({
+      type: 'moebius:media-session',
+      event: 'close',
+      sessionId: 'digest-one',
+    }, window.location.origin))
+    await expect(player).toBeHidden()
+
+    // A same-element iframe reload replaces its document without firing a
+    // callback-ref teardown. The load boundary must retire the old lease too.
+    await frame.evaluate(() => window.parent.postMessage({
+      type: 'moebius:media-session',
+      event: 'open',
+      sessionId: 'digest-two',
+      title: 'Reloading digest',
+      playbackState: 'playing',
+    }, window.location.origin))
+    await expect(player).toContainText('Reloading digest')
+    await frame.evaluate(() => window.location.reload())
+    await expect(player).toBeHidden({ timeout: 10000 })
+  })
+
   test('app-token failure shows a retry that opens the app', async ({ page }) => {
     const appId = 98
     let tokenAttempts = 0


### PR DESCRIPTION
## Summary
- let app frames publish one bounded playback metadata/control lease while keeping all audio generation and playback app-owned
- bind controls to the exact live frame and app identity, reject stale or malformed sessions, and retire ownership on close, teardown, or same-frame document reload
- keep stop app-confirmed so failed delivery cannot hide controls while audio continues
- add an accessible drawer player with authoritative app identity and play, pause, stop, and reopen actions

This deliberately remains a narrow frame protocol rather than a host media API: apps keep their media graph, timing, buffers, and native Media Session integration. The shell receives no audio or progress stream.

## Verification
- `npm test` (2,328 library tests + 79 hook tests)
- `npm run lint` (44 existing warnings, 0 errors)
- `npm run build`
- `git diff --check`
- added hosted E2E coverage for source attribution, spoof-resistant app labeling, app-confirmed stop, and same-frame reload cleanup

Paired with mobius-os/app-news (follow-up PR) as the first consumer.