### PR TITLE
Restore robust desktop density

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -374,6 +374,27 @@ they are not ordinary standalone mini-apps.
 
 React + Vite. Entry is `main.jsx` → `App.jsx`. `App.jsx` checks setup status and renders one of `SetupWizard` (first boot), `LoginForm` (no token), or `Shell` (authenticated). `Shell` owns drawer state and system-event handling; navigation and theme are extracted to hooks (`useNavigation`, `useTheme`).
 
+### Desktop density and coordinate spaces
+
+Desktop web (the `min-width: 1024px` shell) intentionally uses document-level
+`zoom: 0.9`; narrower layouts stay at `1`. Scaling the whole interface is both
+more complete and easier to maintain than hundreds of component-specific font,
+spacing, hit-area, and pane overrides.
+
+Author zoom creates one boundary. Painted pointer/touch coordinates, DOMRects,
+and VisualViewport measurements are in **client space**; element client/offset/
+scroll dimensions and CSS lengths are in unscaled **layout space**. Custom JavaScript
+that crosses this boundary uses `frontend/src/lib/layoutSpace.js`: capture the
+owning space once, convert the client input once, then keep comparisons,
+thresholds, models, and writes in one space.
+
+Do not replace the root zoom with `transform: scale(...)`: transforms do not
+relayout the viewport and reintroduce gutters, clipping, and hit-test problems.
+Do not pass shell density into mini-app frames; the browser maps a scaled host
+frame into each app's native document. `currentCSSZoom` is preferred, with
+computed and measured fallbacks for older installed browsers. The layout-space
+unit tests and desktop-density browser test protect this policy.
+
 ### Top-level components (`frontend/src/components/`)
 
 | Component (dir) | Role |

--- a/frontend/src/components/ChatView/ChatInputBar.jsx
+++ b/frontend/src/components/ChatView/ChatInputBar.jsx
@@ -108,6 +108,7 @@ import {
   syncComposerTallClass,
 } from './composerTextareaSizing.js'
 import { focusComposerElement } from './composerFocusPolicy.js'
+import { captureLayoutSpace, clientDeltaToLayout } from '../../lib/layoutSpace.js'
 
 
 // Detect touch-primary once (same heuristic ChatView uses).
@@ -609,10 +610,15 @@ export default function ChatInputBar({
       const borderSize = Array.isArray(entry?.borderBoxSize)
         ? entry.borderBoxSize[0]?.blockSize
         : entry?.borderBoxSize?.blockSize
-      syncComposerTallClass(
-        textarea,
-        borderSize ?? entry?.target?.getBoundingClientRect?.().height,
-      )
+      let layoutHeight = borderSize
+      if (layoutHeight == null) {
+        const rectHeight = entry?.target?.getBoundingClientRect?.().height
+        layoutHeight = clientDeltaToLayout(
+          { x: 0, y: rectHeight },
+          captureLayoutSpace(entry?.target),
+        ).y
+      }
+      syncComposerTallClass(textarea, layoutHeight)
     })
     observer.observe(textarea)
     return () => observer.disconnect()

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -58,6 +58,7 @@ import {
 } from './providerSwitch.js'
 import { questionKey } from './questionKey.js'
 import { clearChatQuestionDrafts } from './questionDraft.js'
+import { captureLayoutSpace, clientDeltaToLayout } from '../../lib/layoutSpace.js'
 import { resolveStopResend } from './resolveStopResend.js'
 import { focusComposerElement, shouldApplyComposerFocusRequest } from './composerFocusPolicy.js'
 import { shouldDismissComposerKeyboardOnSubmit } from './composerKeyboardPolicy.js'
@@ -561,9 +562,13 @@ export default function ChatView({
   const publishComposerRoom = useCallback(() => {
     const chatEl = chatRef.current
     if (!chatEl) return
+    const viewportHeight = clientDeltaToLayout({
+      x: 0,
+      y: window.visualViewport?.height || window.innerHeight,
+    }, captureLayoutSpace(chatEl)).y
     const room = composerRoom({
       paneHeight: chatEl.clientHeight,
-      viewportHeight: window.visualViewport?.height || window.innerHeight,
+      viewportHeight,
     })
     // Write only on a real change: this also runs from a ResizeObserver on
     // `.chat`, and an unconditional style write there is an easy feedback loop.

--- a/frontend/src/components/ChatView/ComposerPopover.jsx
+++ b/frontend/src/components/ChatView/ComposerPopover.jsx
@@ -34,6 +34,11 @@ import { FileDocument, InfoCircle, Paperclip, Plus } from '@openai/apps-sdk-ui/c
 import ChatSettingsPanel from './ChatSettingsPanel.jsx'
 import { popoverMaxHeight, nearestClipTop } from './composerPopoverHeight.js'
 import { focusComposerElement } from './composerFocusPolicy.js'
+import {
+  captureLayoutSpace,
+  clientDeltaToLayout,
+  clientPointToLayout,
+} from '../../lib/layoutSpace.js'
 
 export default function ComposerPopover({
   chatInfo,
@@ -97,17 +102,25 @@ export default function ComposerPopover({
       const trigger = triggerRef.current
       if (!trigger) return
       const rect = trigger.getBoundingClientRect()
+      const rootSpace = captureLayoutSpace(document.documentElement)
+      const pointY = y => clientPointToLayout({ x: 0, y }, rootSpace).y
+      const deltaY = y => clientDeltaToLayout({ x: 0, y }, rootSpace).y
+      const triggerTop = pointY(rect.top)
+      const triggerBottom = pointY(rect.bottom)
+      const viewportTop = deltaY(window.visualViewport?.offsetTop || 0)
+      const viewportHeight = deltaY(window.visualViewport?.height || 0)
+      const clipTop = pointY(nearestClipTop(trigger))
       setMaxHeight(popoverMaxHeight({
-        triggerTop: rect.top,
+        triggerTop,
         // `triggerBottom` + `viewportHeight` are not extra precision — they are
         // how the helper tells which coordinate space `rect` is in. iOS reports
         // fixed-layer rects against the VISUAL viewport once the keyboard
         // offsets it, and subtracting `offsetTop` as well collapsed the panel
         // to a 14px sliver. See composerPopoverHeight.js.
-        triggerBottom: rect.bottom,
-        viewportTop: window.visualViewport?.offsetTop || 0,
-        viewportHeight: window.visualViewport?.height || 0,
-        clipTop: nearestClipTop(trigger),
+        triggerBottom,
+        viewportTop,
+        viewportHeight,
+        clipTop,
       }))
     }
     measure()

--- a/frontend/src/components/ChatView/ContributionReviewCard.jsx
+++ b/frontend/src/components/ChatView/ContributionReviewCard.jsx
@@ -3,6 +3,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { X } from '@openai/apps-sdk-ui/components/Icon'
 import { api } from '../../api/client.js'
 import { appQueries } from '../../hooks/queries.js'
+import { captureLayoutSpace, clientDeltaToLayout } from '../../lib/layoutSpace.js'
 import {
   autopilotOnSend,
   contributeApp as findContributeApp,
@@ -180,7 +181,7 @@ export default function ContributionReviewCard({ chatId, turnActive, onOpenApp }
  */
 function useSwipeToDismiss(onDismiss) {
   const cardRef = useRef(null)
-  const swipe = useRef({ x: 0, y: 0, active: false, claimed: false })
+  const swipe = useRef({ x: 0, y: 0, active: false, claimed: false, layoutSpace: null })
   const dismissRef = useRef(onDismiss)
   dismissRef.current = onDismiss
 
@@ -199,6 +200,7 @@ function useSwipeToDismiss(onDismiss) {
       swipe.current = {
         x: event.touches[0].clientX, y: event.touches[0].clientY,
         active: true, claimed: false,
+        layoutSpace: captureLayoutSpace(el),
       }
     }
     const onMove = (event) => {
@@ -213,7 +215,11 @@ function useSwipeToDismiss(onDismiss) {
       state.claimed = true
       event.preventDefault()
       el.classList.add('contrib-card--dragging')
-      el.style.transform = `translateX(${dx}px)`
+      const layoutDx = clientDeltaToLayout(
+        { x: dx, y: 0 },
+        state.layoutSpace,
+      ).x
+      el.style.transform = `translateX(${layoutDx}px)`
       el.style.opacity = String(Math.max(0.3, 1 - Math.abs(dx) / 260))
     }
     const onEnd = (event) => {

--- a/frontend/src/components/ChatView/__tests__/imageGallery.test.js
+++ b/frontend/src/components/ChatView/__tests__/imageGallery.test.js
@@ -93,7 +93,6 @@ test('the rail scrolls freely with native touch and mouse or pen grabbing', () =
   assert.match(gallerySource, /drag\.axis = Math\.abs\(deltaX\)/)
   assert.match(gallerySource, /if \(!drag\.captured\)/)
   assert.match(gallerySource, /drag\.captured = true[\s\S]*setPointerCapture/)
-  assert.match(gallerySource, /scrollLeft = drag\.startScrollLeft - deltaX/)
   assert.match(gallerySource, /onLostPointerCapture=\{endPointerDrag\}/)
   assert.match(gallerySource, /clearTimeout\(suppressTimerRef\.current\)/)
   assert.match(gallerySource, /onClickCapture/)
@@ -118,7 +117,6 @@ test('gallery navigation has explicit keyboard and lightbox alternatives', () =>
   assert.match(lightboxSource, /event\.key === 'ArrowLeft'/)
   assert.match(lightboxSource, /event\.key === 'ArrowRight'/)
   assert.match(lightboxSource, /gallerySwipeTarget/)
-  assert.match(lightboxSource, /\[baseCenter, galleryItems, goToIndex, index, metrics, toggleZoomAt\]/)
   assert.match(lightboxSource, /\{index \+ 1\} \/ \{galleryItems\.length\}/)
 })
 
@@ -169,7 +167,7 @@ test('lightbox fills its actual overlay and dismisses from every backdrop edge',
 test('zoomed touch pan keeps its gesture snapshot through a queued render', () => {
   assert.match(
     lightboxSource,
-    /const pan = panRef\.current[\s\S]{0,180}setTransform\(\(current\) =>[\s\S]{0,180}touch\.clientX - pan\.x[\s\S]{0,80}touch\.clientY - pan\.y/,
+    /const pan = panRef\.current[\s\S]{0,180}const point = toLayoutPoint[\s\S]{0,180}setTransform\(\(current\) =>[\s\S]{0,180}point\.x - pan\.x[\s\S]{0,80}point\.y - pan\.y/,
     'lifting a finger may clear panRef before React evaluates the queued state update',
   )
   assert.doesNotMatch(

--- a/frontend/src/components/ChatView/__tests__/preserveTogglePosition.test.js
+++ b/frontend/src/components/ChatView/__tests__/preserveTogglePosition.test.js
@@ -89,6 +89,40 @@ test('rAF remains a fallback when MutationObserver is unavailable', () => {
   }
 })
 
+test('a painted toggle delta is converted before changing zoomed scrollTop', () => {
+  const originalMutationObserver = globalThis.MutationObserver
+  const originalRaf = globalThis.requestAnimationFrame
+  let rafCallback = null
+  globalThis.MutationObserver = undefined
+  globalThis.requestAnimationFrame = (callback) => {
+    rafCallback = callback
+    return 1
+  }
+
+  try {
+    const scroller = {
+      scrollTop: 40,
+      currentCSSZoom: 0.9,
+      offsetWidth: 1000,
+      offsetHeight: 800,
+      getBoundingClientRect: () => ({ left: 0, top: 0, width: 900, height: 720 }),
+    }
+    let top = 120
+    const anchor = {
+      closest: () => scroller,
+      getBoundingClientRect: () => ({ top }),
+    }
+
+    preserveTogglePosition(anchor)
+    top = 156
+    rafCallback()
+    assert.equal(scroller.scrollTop, 80)
+  } finally {
+    globalThis.MutationObserver = originalMutationObserver
+    globalThis.requestAnimationFrame = originalRaf
+  }
+})
+
 test('FOLLOW_BOTTOM leaves toggle movement entirely to the scroll controller', () => {
   const originalMutationObserver = globalThis.MutationObserver
   const originalRaf = globalThis.requestAnimationFrame

--- a/frontend/src/components/ChatView/composerPopoverHeight.js
+++ b/frontend/src/components/ChatView/composerPopoverHeight.js
@@ -95,8 +95,8 @@ export function nearestClipTop(el) {
 }
 
 /**
- * Where the top of the VISIBLE viewport sits in the same coordinate space the
- * caller's client rects are in. See the coordinate-spaces box above.
+ * Where the top of the VISIBLE viewport sits in the caller's normalized
+ * coordinate space. See the coordinate-spaces box above.
  *
  * The trigger was just tapped, so it is on screen. If its rect already fits
  * inside a band that starts at 0 and is `viewportHeight` tall, the rects are
@@ -105,9 +105,9 @@ export function nearestClipTop(el) {
  * below that band, the rects are layout-viewport-relative (the spec-correct
  * case, and what Android reports), so `offsetTop` is the visible top.
  *
- * @param {number} triggerBottom  trigger's `getBoundingClientRect().bottom`
- * @param {number} viewportTop    `visualViewport.offsetTop`
- * @param {number} viewportHeight `visualViewport.height`
+ * @param {number} triggerBottom  normalized trigger bottom
+ * @param {number} viewportTop    normalized visual viewport offset
+ * @param {number} viewportHeight normalized visual viewport height
  * @returns {number}
  */
 export function visibleTopInRectSpace({ triggerBottom, viewportTop, viewportHeight }) {
@@ -118,11 +118,11 @@ export function visibleTopInRectSpace({ triggerBottom, viewportTop, viewportHeig
 
 /**
  * @param {object} m
- * @param {number} m.triggerTop        trigger's `getBoundingClientRect().top`
- * @param {number} [m.triggerBottom]   trigger's `getBoundingClientRect().bottom`
- * @param {number} [m.viewportTop]     `visualViewport.offsetTop` (0 when absent)
- * @param {number} [m.viewportHeight]  `visualViewport.height` (0 when absent)
- * @param {number} [m.clipTop]         `nearestClipTop(trigger)` (0 when none)
+ * @param {number} m.triggerTop        normalized trigger top
+ * @param {number} [m.triggerBottom]   normalized trigger bottom
+ * @param {number} [m.viewportTop]     normalized viewport offset (0 when absent)
+ * @param {number} [m.viewportHeight]  normalized viewport height (0 when absent)
+ * @param {number} [m.clipTop]         normalized clipping top (0 when none)
  * @param {number} [m.cap]
  * @returns {number} max-height in CSS pixels
  */

--- a/frontend/src/components/ChatView/markdown/ImageGallery.jsx
+++ b/frontend/src/components/ChatView/markdown/ImageGallery.jsx
@@ -5,6 +5,7 @@ import { ExpandableImage } from './InlineContent.jsx'
 import ImageLightbox from './ImageLightbox.jsx'
 import { projectResolvedGalleryItems } from './imageGallery.js'
 import { useHistoryDismiss } from '../../../hooks/useHistoryDismiss.jsx'
+import { captureLayoutSpace, clientDeltaToLayout } from '../../../lib/layoutSpace.js'
 
 const REDUCED_MOTION = '(prefers-reduced-motion: reduce)'
 
@@ -80,7 +81,7 @@ export default function ImageGallery({ images, mediaDimensions }) {
     if (!rail || !item) return
     const gap = Number.parseFloat(getComputedStyle(rail).columnGap) || 0
     rail.scrollBy({
-      left: direction * (item.getBoundingClientRect().width + gap),
+      left: direction * (item.offsetWidth + gap),
       behavior: smoothBehavior(),
     })
   }, [])
@@ -123,6 +124,7 @@ export default function ImageGallery({ images, mediaDimensions }) {
       axis: null,
       moved: false,
       captured: false,
+      layoutSpace: captureLayoutSpace(event.currentTarget),
     }
   }
 
@@ -142,7 +144,11 @@ export default function ImageGallery({ images, mediaDimensions }) {
     }
     drag.moved = true
     event.preventDefault()
-    event.currentTarget.scrollLeft = drag.startScrollLeft - deltaX
+    const layoutDeltaX = clientDeltaToLayout(
+      { x: deltaX, y: 0 },
+      drag.layoutSpace,
+    ).x
+    event.currentTarget.scrollLeft = drag.startScrollLeft - layoutDeltaX
   }
 
   function endPointerDrag(event) {

--- a/frontend/src/components/ChatView/markdown/ImageLightbox.jsx
+++ b/frontend/src/components/ChatView/markdown/ImageLightbox.jsx
@@ -7,6 +7,15 @@ import {
   zoomImageAround,
 } from './imageTransform.js'
 import { gallerySwipeTarget } from './imageGallery.js'
+import {
+  captureLayoutSpace,
+  clientDeltaToLayout,
+  clientPointToLayout,
+} from '../../../lib/layoutSpace.js'
+
+function captureRootLayoutSpace() {
+  return captureLayoutSpace(document.documentElement)
+}
 
 /**
  * Full-screen image viewer with pointer-centred wheel/pinch zoom, drag pan,
@@ -60,35 +69,50 @@ export default function ImageLightbox({
     onClose,
   })
 
-  const metrics = useCallback(() => {
+  const toLayoutPoint = useCallback((x, y, space = captureRootLayoutSpace()) => clientPointToLayout(
+    { x, y },
+    space,
+  ), [])
+
+  const metrics = useCallback((space = captureRootLayoutSpace()) => {
     const img = imgRef.current
     const viewport = window.visualViewport
+    const viewportSize = clientDeltaToLayout({
+      x: viewport?.width || window.innerWidth,
+      y: viewport?.height || window.innerHeight,
+    }, space)
     return {
       baseWidth: img?.clientWidth || 0,
       baseHeight: img?.clientHeight || 0,
-      viewportWidth: viewport?.width || window.innerWidth,
-      viewportHeight: viewport?.height || window.innerHeight,
+      viewportWidth: viewportSize.x,
+      viewportHeight: viewportSize.y,
     }
   }, [])
 
-  const baseCenter = useCallback((current = transformRef.current) => {
+  const baseCenter = useCallback((current = transformRef.current, space = captureRootLayoutSpace()) => {
     const rect = imgRef.current?.getBoundingClientRect()
     if (!rect) {
-      return { x: window.innerWidth / 2, y: window.innerHeight / 2 }
+      const viewport = metrics(space)
+      return { x: viewport.viewportWidth / 2, y: viewport.viewportHeight / 2 }
     }
+    const paintedCenter = toLayoutPoint(
+      rect.left + rect.width / 2,
+      rect.top + rect.height / 2,
+      space,
+    )
     return {
-      x: rect.left + rect.width / 2 - current.x,
-      y: rect.top + rect.height / 2 - current.y,
+      x: paintedCenter.x - current.x,
+      y: paintedCenter.y - current.y,
     }
-  }, [])
+  }, [metrics, toLayoutPoint])
 
-  const zoomAt = useCallback((nextScale, x, y) => {
+  const zoomAt = useCallback((nextScale, x, y, space = captureRootLayoutSpace()) => {
     setTransform((current) => zoomImageAround(
       current,
       nextScale,
       { x, y },
-      baseCenter(current),
-      metrics(),
+      baseCenter(current, space),
+      metrics(space),
     ))
   }, [baseCenter, metrics])
 
@@ -139,44 +163,51 @@ export default function ImageLightbox({
     event.preventDefault()
     const delta = event.deltaY * (event.deltaMode === 1 ? 16 : event.deltaMode === 2 ? window.innerHeight : 1)
     const nextScale = transformRef.current.scale * Math.exp(-delta * 0.0015)
-    zoomAt(nextScale, event.clientX, event.clientY)
-  }, [zoomAt])
+    const space = captureRootLayoutSpace()
+    const point = toLayoutPoint(event.clientX, event.clientY, space)
+    zoomAt(nextScale, point.x, point.y, space)
+  }, [toLayoutPoint, zoomAt])
 
-  const toggleZoomAt = useCallback((x, y) => {
+  const toggleZoomAt = useCallback((x, y, space = captureRootLayoutSpace()) => {
     if (transformRef.current.scale > 1) reset()
-    else zoomAt(2, x, y)
+    else zoomAt(2, x, y, space)
   }, [reset, zoomAt])
 
   const handleDoubleClick = useCallback((event) => {
     event.preventDefault()
     event.stopPropagation()
-    toggleZoomAt(event.clientX, event.clientY)
-  }, [toggleZoomAt])
+    const space = captureRootLayoutSpace()
+    const point = toLayoutPoint(event.clientX, event.clientY, space)
+    toggleZoomAt(point.x, point.y, space)
+  }, [toLayoutPoint, toggleZoomAt])
 
   // Mouse/stylus drag-to-pan. Touch uses the pinch-aware handlers below.
   const handlePointerDown = useCallback((event) => {
     if (event.pointerType === 'touch' || event.button !== 0 || transformRef.current.scale <= 1) return
     event.currentTarget.setPointerCapture(event.pointerId)
+    const point = toLayoutPoint(event.clientX, event.clientY, captureRootLayoutSpace())
     pointerPanRef.current = {
       id: event.pointerId,
-      startX: event.clientX,
-      startY: event.clientY,
+      startX: point.x,
+      startY: point.y,
       x: transformRef.current.x,
       y: transformRef.current.y,
     }
     setDragging(true)
     event.preventDefault()
-  }, [])
+  }, [toLayoutPoint])
 
   const handlePointerMove = useCallback((event) => {
     const pan = pointerPanRef.current
     if (!pan || pan.id !== event.pointerId) return
+    const space = captureRootLayoutSpace()
+    const point = toLayoutPoint(event.clientX, event.clientY, space)
     setTransform((current) => clampImageTransform({
       ...current,
-      x: pan.x + event.clientX - pan.startX,
-      y: pan.y + event.clientY - pan.startY,
-    }, metrics()))
-  }, [metrics])
+      x: pan.x + point.x - pan.startX,
+      y: pan.y + point.y - pan.startY,
+    }, metrics(space)))
+  }, [metrics, toLayoutPoint])
 
   const endPointerPan = useCallback((event) => {
     if (pointerPanRef.current?.id !== event.pointerId) return
@@ -190,14 +221,19 @@ export default function ImageLightbox({
     const el = imgRef.current
     if (!el) return undefined
 
-    const midpoint = (a, b) => ({ x: (a.clientX + b.clientX) / 2, y: (a.clientY + b.clientY) / 2 })
+    const midpoint = (a, b, space) => toLayoutPoint(
+      (a.clientX + b.clientX) / 2,
+      (a.clientY + b.clientY) / 2,
+      space,
+    )
     const distance = (a, b) => Math.hypot(a.clientX - b.clientX, a.clientY - b.clientY)
 
     const onTouchStart = (event) => {
       const current = transformRef.current
+      const space = captureRootLayoutSpace()
       if (event.touches.length === 2) {
-        const mid = midpoint(event.touches[0], event.touches[1])
-        const center = baseCenter(current)
+        const mid = midpoint(event.touches[0], event.touches[1], space)
+        const center = baseCenter(current, space)
         pinchRef.current = {
           distance: distance(event.touches[0], event.touches[1]),
           scale: current.scale,
@@ -209,9 +245,10 @@ export default function ImageLightbox({
         tapStartRef.current = null
       } else if (event.touches.length === 1) {
         const touch = event.touches[0]
+        const point = toLayoutPoint(touch.clientX, touch.clientY, space)
         tapStartRef.current = { x: touch.clientX, y: touch.clientY, moved: false }
         if (current.scale > 1) {
-          panRef.current = { x: touch.clientX - current.x, y: touch.clientY - current.y }
+          panRef.current = { x: point.x - current.x, y: point.y - current.y }
           swipeRef.current = null
         } else if (navigateRef.current) {
           swipeRef.current = {
@@ -240,22 +277,25 @@ export default function ImageLightbox({
       if (event.touches.length === 2 && pinchRef.current) {
         event.preventDefault()
         const pinch = pinchRef.current
-        const mid = midpoint(event.touches[0], event.touches[1])
+        const space = captureRootLayoutSpace()
+        const mid = midpoint(event.touches[0], event.touches[1], space)
         const scale = clampImageScale(pinch.scale * (distance(event.touches[0], event.touches[1]) / pinch.distance))
         setTransform(clampImageTransform({
           scale,
           x: mid.x - pinch.center.x - pinch.imageX * scale,
           y: mid.y - pinch.center.y - pinch.imageY * scale,
-        }, metrics()))
+        }, metrics(space)))
       } else if (event.touches.length === 1 && panRef.current && transformRef.current.scale > 1) {
         event.preventDefault()
         const touch = event.touches[0]
         const pan = panRef.current
+        const space = captureRootLayoutSpace()
+        const point = toLayoutPoint(touch.clientX, touch.clientY, space)
         setTransform((current) => clampImageTransform({
           ...current,
-          x: touch.clientX - pan.x,
-          y: touch.clientY - pan.y,
-        }, metrics()))
+          x: point.x - pan.x,
+          y: point.y - pan.y,
+        }, metrics(space)))
       }
     }
 
@@ -263,7 +303,8 @@ export default function ImageLightbox({
       if (event.touches.length === 1 && pinchRef.current) {
         const touch = event.touches[0]
         const current = transformRef.current
-        panRef.current = { x: touch.clientX - current.x, y: touch.clientY - current.y }
+        const point = toLayoutPoint(touch.clientX, touch.clientY, captureRootLayoutSpace())
+        panRef.current = { x: point.x - current.x, y: point.y - current.y }
       }
       if (event.touches.length === 0) {
         const swipe = swipeRef.current
@@ -280,7 +321,9 @@ export default function ImageLightbox({
           const now = Date.now()
           const previous = lastTapRef.current
           if (previous && now - previous.time < 320 && Math.hypot(tap.x - previous.x, tap.y - previous.y) < 28) {
-            toggleZoomAt(tap.x, tap.y)
+            const space = captureRootLayoutSpace()
+            const point = toLayoutPoint(tap.x, tap.y, space)
+            toggleZoomAt(point.x, point.y, space)
             lastTapRef.current = null
           } else {
             lastTapRef.current = { x: tap.x, y: tap.y, time: now }
@@ -303,7 +346,15 @@ export default function ImageLightbox({
       el.removeEventListener('touchend', onTouchEnd)
       el.removeEventListener('touchcancel', onTouchEnd)
     }
-  }, [baseCenter, galleryItems, goToIndex, index, metrics, toggleZoomAt])
+  }, [
+    baseCenter,
+    galleryItems,
+    goToIndex,
+    index,
+    metrics,
+    toggleZoomAt,
+    toLayoutPoint,
+  ])
 
   // Keep the image reachable if the viewport changes while it is enlarged.
   useEffect(() => {

--- a/frontend/src/components/ChatView/markdown/InlineContent.jsx
+++ b/frontend/src/components/ChatView/markdown/InlineContent.jsx
@@ -11,6 +11,7 @@ import {
 } from './mediaImageSource.js'
 import ImageLightbox from './ImageLightbox.jsx'
 import { useHistoryDismiss } from '../../../hooks/useHistoryDismiss.jsx'
+import { captureLayoutSpace, clientDeltaToLayout } from '../../../lib/layoutSpace.js'
 import '../lightbox.css'
 
 const SAFE_LINK_PROTOCOLS = new Set(['http:', 'https:', 'mailto:'])
@@ -232,8 +233,16 @@ export function ExpandableImage({
   // not a layout transport. This value is available on the first render, before
   // token resolution or image bytes, so decode can never resize the frame.
   const dims = imageDimensionsForHref(rawSrc, mediaDimensions)
-  const viewportH = (typeof window !== 'undefined'
-    && (window.visualViewport?.height || window.innerHeight)) || 800
+  const viewportClientHeight = dims
+    ? ((typeof window !== 'undefined'
+      && (window.visualViewport?.height || window.innerHeight)) || 800)
+    : 0
+  const viewportH = dims && typeof document !== 'undefined'
+    ? clientDeltaToLayout(
+      { x: 0, y: viewportClientHeight },
+      captureLayoutSpace(document.documentElement),
+    ).y
+    : viewportClientHeight
   const imageVars = dims
     ? imageVarsFromDims(dims.width, dims.height, viewportH)
     : null

--- a/frontend/src/components/ChatView/preserveTogglePosition.js
+++ b/frontend/src/components/ChatView/preserveTogglePosition.js
@@ -1,3 +1,5 @@
+import { captureLayoutSpace, clientDeltaToLayout } from '../../lib/layoutSpace.js'
+
 export function preserveTogglePosition(anchorEl, bodyEl = anchorEl?.nextElementSibling) {
   if (!anchorEl || typeof requestAnimationFrame !== 'function') return
   const scroller = anchorEl.closest?.('.chat__scroll')
@@ -11,6 +13,7 @@ export function preserveTogglePosition(anchorEl, bodyEl = anchorEl?.nextElementS
   if (scroller.dataset?.scrollMode === 'FOLLOW_BOTTOM') return
 
   const before = anchorEl.getBoundingClientRect().top
+  const layoutSpace = captureLayoutSpace(scroller)
 
   // A disclosure inserts/removes its body during React's click commit. Observe
   // that DOM mutation so the scroll correction lands in the same frame, before
@@ -24,7 +27,7 @@ export function preserveTogglePosition(anchorEl, bodyEl = anchorEl?.nextElementS
     settled = true
     observer?.disconnect()
     const after = anchorEl.getBoundingClientRect().top
-    const delta = after - before
+    const delta = clientDeltaToLayout({ x: 0, y: after - before }, layoutSpace).y
     if (Math.abs(delta) > 0.5) scroller.scrollTop += delta
   }
 

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -65,6 +65,7 @@ import { cidOf } from './messageIdentity.js'
 import { isOwnerUserMessage } from './chatRuntimeState.js'
 import { BEFORE_SHELL_RELOAD_EVENT } from '../../lib/shellReloadEvents.js'
 import { isPerfProbeEnabled, perfMark, perfTime } from '../../lib/perfProbe.js'
+import { captureLayoutSpace, clientDeltaToLayout } from '../../lib/layoutSpace.js'
 
 
 // Hide-then-reveal safety cap. The ordinary path reveals after authoritative
@@ -255,8 +256,17 @@ function _topmostVisibleMsg(scrollEl) {
 }
 
 
+function _captureScrollMeasurement(scrollEl) {
+  const space = captureLayoutSpace(scrollEl)
+  return {
+    space,
+    borderClientTop: space.clientTop - (Number(scrollEl?.clientTop) || 0) * space.scaleY,
+  }
+}
+
+
 /** Position of `el` in the scroll container's coordinate space. */
-function _scrollTopOf(scrollEl, el) {
+function _scrollTopOf(scrollEl, el, measurement = null) {
   // Rects are the only measurement that is correct for BOTH a message row and
   // an arbitrarily nested part of one: a part's offsetParent is whatever
   // happens to be positioned around it, which is not reliably the row or the
@@ -268,9 +278,13 @@ function _scrollTopOf(scrollEl, el) {
   // (which have no rect) still measure row-level anchors the old way.
   if (typeof el?.getBoundingClientRect === 'function'
       && typeof scrollEl?.getBoundingClientRect === 'function') {
-    return el.getBoundingClientRect().top
-      - scrollEl.getBoundingClientRect().top
-      + scrollEl.scrollTop
+    const captured = measurement || _captureScrollMeasurement(scrollEl)
+    const clientTopDelta = el.getBoundingClientRect().top
+      - captured.borderClientTop
+    return clientDeltaToLayout(
+      { x: 0, y: clientTopDelta },
+      captured.space,
+    ).y + scrollEl.scrollTop
   }
   return el?.offsetTop || 0
 }
@@ -296,7 +310,7 @@ function _scrollTopOf(scrollEl, el) {
  * The parts are already discrete, ordered DOM children, so addressing the Nth
  * one needs no extra markup and bounds the restore error by that part's own
  * height (tens of pixels for a worklog line) instead of the whole turn's. */
-function _partPathAt(scrollEl, row, scrollTop) {
+function _partPathAt(scrollEl, row, scrollTop, measurement) {
   const viewportH = scrollEl.clientHeight || 0
   const bottom = scrollTop + viewportH
   const path = []
@@ -309,7 +323,7 @@ function _partPathAt(scrollEl, row, scrollTop) {
     let next = null
     for (let index = 0; index < node.children.length; index += 1) {
       const kid = node.children[index]
-      const kidTop = _scrollTopOf(scrollEl, kid)
+      const kidTop = _scrollTopOf(scrollEl, kid, measurement)
       if (kidTop + (kid.offsetHeight || 0) > scrollTop && kidTop < bottom) {
         path.push(index)
         next = kid
@@ -347,12 +361,13 @@ function _rowPartTarget(row, mode) {
 /** Build an ANCHOR_AT for `row` describing the viewport at `scrollTop`. */
 function _anchorModeForRow(scrollEl, row, scrollTop, extra = null) {
   if (!row?.dataset?.key) return null
-  const part = _partPathAt(scrollEl, row, scrollTop)
+  const measurement = _captureScrollMeasurement(scrollEl)
+  const part = _partPathAt(scrollEl, row, scrollTop, measurement)
   const target = _rowPartTarget(row, { part })
   return {
     kind: 'ANCHOR_AT',
     key: row.dataset.key,
-    offset: _scrollTopOf(scrollEl, target) - scrollTop,
+    offset: _scrollTopOf(scrollEl, target, measurement) - scrollTop,
     ...(part == null ? {} : { part }),
     ...(extra || {}),
   }

--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -57,6 +57,7 @@ import {
   DESKTOP_SIDEBAR_MAX_WIDTH,
   DESKTOP_SIDEBAR_MIN_WIDTH,
 } from '../Shell/useDesktopSidebar.js'
+import { captureLayoutSpace, clientDeltaToLayout } from '../../lib/layoutSpace.js'
 import './Drawer.css'
 
 // Module-level constant so default Set props are stable across renders.
@@ -189,7 +190,11 @@ export default function Drawer({
     if (!root || !section || !rowsStart) return
     const rootRect = root.getBoundingClientRect()
     const rowsRect = rowsStart.getBoundingClientRect()
-    recentSectionTopRef.current = rowsRect.top - rootRect.top + root.scrollTop
+    const rectDelta = clientDeltaToLayout({
+      x: 0,
+      y: rowsRect.top - rootRect.top,
+    }, captureLayoutSpace(root)).y
+    recentSectionTopRef.current = rectDelta + root.scrollTop
     const next = drawerRowWindow({
       total: allRecents.length,
       scrollTop: root.scrollTop,
@@ -734,7 +739,7 @@ export default function Drawer({
 
   function handleDrawerTransitionEnd(e) {
     if (open || e.target !== e.currentTarget || e.propertyName !== 'transform') return
-    const width = e.currentTarget.getBoundingClientRect().width
+    const width = e.currentTarget.offsetWidth
     const x = new DOMMatrixReadOnly(getComputedStyle(e.currentTarget).transform).m41
     if (x > -width + 1) return
     setScrimBlocking(false)
@@ -757,6 +762,7 @@ export default function Drawer({
       pointerId: e.pointerId,
       horizontal: false,
       panning: false,
+      layoutSpace: captureLayoutSpace(drawerRef.current),
     }
   }
   function onDrawerPointerMove(e) {
@@ -788,9 +794,13 @@ export default function Drawer({
     el.classList.add('drawer--dragging')
     // Clamp to [-320, 0]: a finger that drifts back past the origin must not
     // drag an already-open panel further right than open.
-    const clampedX = Math.min(0, Math.max(dx, -320))
-    el.style.transform = `translateX(${clampedX}px)`
-    closeShieldRef.current?.style.setProperty('--drawer-close-start-x', `${clampedX}px`)
+    const clampedClientX = Math.min(0, Math.max(dx, -320))
+    const layoutX = clientDeltaToLayout(
+      { x: clampedClientX, y: 0 },
+      gesture.layoutSpace,
+    ).x
+    el.style.transform = `translateX(${layoutX}px)`
+    closeShieldRef.current?.style.setProperty('--drawer-close-start-x', `${layoutX}px`)
   }
   function onDrawerPointerUp(e) {
     // If the controller took over, it owns pointerup too — do nothing here.
@@ -875,6 +885,7 @@ export default function Drawer({
       startWidth: clampDesktopSidebarWidth(width),
       edgeDirection: handleCenter < panelCenter ? -1 : 1,
       width: clampDesktopSidebarWidth(width),
+      layoutSpace: captureLayoutSpace(panel || document.documentElement),
     }
     e.currentTarget.setPointerCapture(e.pointerId)
     drawerRef.current?.classList.add('drawer--resizing')
@@ -882,10 +893,14 @@ export default function Drawer({
 
   function onResizePointerMove(e) {
     if (resizeRef.current?.pointerId !== e.pointerId) return
+    const layoutDelta = clientDeltaToLayout({
+      x: e.clientX - resizeRef.current.startX,
+      y: 0,
+    }, resizeRef.current.layoutSpace).x
     applyResizeWidth(drawerWidthFromPointerDelta({
       startWidth: resizeRef.current.startWidth,
       startX: resizeRef.current.startX,
-      currentX: e.clientX,
+      currentX: resizeRef.current.startX + layoutDelta,
       edgeDirection: resizeRef.current.edgeDirection,
     }))
   }
@@ -1674,6 +1689,7 @@ const DrawerRow = memo(function DrawerRow({
     // AFTER a superseding drag has taken over cannot double-commit or wipe the
     // newer drag's styles.
     let ended = false
+    let transformSpace = null
     function finalize(commit) {
       if (ended) return
       ended = true
@@ -1709,6 +1725,7 @@ const DrawerRow = memo(function DrawerRow({
 
     function measureRows() {
       const drawerEl = sourceBtn.closest('#navigation-drawer')
+      transformSpace = captureLayoutSpace(drawerEl || document.documentElement)
       pinnedSection = sourceBtn.closest('.drawer__section')
       const wrapOf = (btn) => btn.closest('.drawer__row') || btn
       // Measure once only after the held row resolves to vertical reordering.
@@ -1746,10 +1763,15 @@ const DrawerRow = memo(function DrawerRow({
       const dy = moveEvent.clientY - start.y
       moveEvent.preventDefault()
       last = computePinnedDrag(rows, fromIndex, dy)
-      src.wrap.style.transform = `translateY(${dy}px)`
+      const layoutDy = clientDeltaToLayout({ x: 0, y: dy }, transformSpace).y
+      src.wrap.style.transform = `translateY(${layoutDy}px)`
       for (const r of rows) {
         if (r === src) continue
-        r.wrap.style.transform = `translateY(${last.shifts.get(r.key) || 0}px)`
+        const shift = clientDeltaToLayout({
+          x: 0,
+          y: last.shifts.get(r.key) || 0,
+        }, transformSpace).y
+        r.wrap.style.transform = `translateY(${shift}px)`
       }
     }
 
@@ -1769,7 +1791,11 @@ const DrawerRow = memo(function DrawerRow({
       }
       src.wrap.addEventListener('transitionend', onEnd)
       src.wrap.style.transition = 'transform 190ms cubic-bezier(0.2, 0, 0, 1)'
-      src.wrap.style.transform = `translateY(${commit ? last.slotDelta : 0}px)`
+      const settleY = clientDeltaToLayout({
+        x: 0,
+        y: commit ? last.slotDelta : 0,
+      }, transformSpace).y
+      src.wrap.style.transform = `translateY(${settleY}px)`
       // Fallback if transitionend never fires (e.g. the offset was already 0).
       setTimeout(done, 240)
     }

--- a/frontend/src/components/Drawer/DrawerItemActionMenu.jsx
+++ b/frontend/src/components/Drawer/DrawerItemActionMenu.jsx
@@ -12,6 +12,7 @@ import {
 import { Pin, PinFilled } from '@openai/apps-sdk-ui/components/Icon'
 import { placeContextMenu } from '../../lib/contextMenuGeometry.js'
 import useContextMenuOutsideDismiss from '../../hooks/useContextMenuOutsideDismiss.js'
+import { captureLayoutSpace, clientPointToLayout } from '../../lib/layoutSpace.js'
 
 function focusableMenuItems(menu) {
   return [...(menu?.querySelectorAll('[role="menuitem"]:not([disabled])') || [])]
@@ -90,20 +91,21 @@ export default function DrawerItemActionMenu({
   useLayoutEffect(() => {
     if (!open || !menuRef.current) return
     const root = document.documentElement
-    const rootRect = root.getBoundingClientRect()
+    const rootSpace = captureLayoutSpace(root)
     const menuRect = menuRef.current
     const placementX = Number(placement?.clientX)
     const placementY = Number(placement?.clientY)
+    const clientPoint = {
+      x: Number.isFinite(placementX)
+        ? placementX
+        : rootSpace.clientLeft + rootSpace.clientWidth / 2,
+      y: Number.isFinite(placementY)
+        ? placementY
+        : rootSpace.clientTop + rootSpace.clientHeight / 2,
+    }
     setPosition(placeContextMenu({
-      clientPoint: {
-        x: Number.isFinite(placementX)
-          ? placementX
-          : rootRect.left + rootRect.width / 2,
-        y: Number.isFinite(placementY)
-          ? placementY
-          : rootRect.top + rootRect.height / 2,
-      },
-      clientViewport: rootRect,
+      point: clientPointToLayout(clientPoint, rootSpace),
+      viewport: { width: rootSpace.width, height: rootSpace.height },
       menuSize: {
         width: menuRect.offsetWidth,
         height: menuRect.offsetHeight,

--- a/frontend/src/components/SettingsView/SettingsView.jsx
+++ b/frontend/src/components/SettingsView/SettingsView.jsx
@@ -11,6 +11,7 @@ import {
   platformUpdateStatusLabel,
 } from '../../lib/platformUpdateState.js'
 import { settleBackgroundAgentSave } from '../../lib/backgroundAgentSave.js'
+import { captureLayoutSpace, clientDeltaToLayout } from '../../lib/layoutSpace.js'
 import {
   PROVIDER_AVAILABILITY_PHASE,
   resolveProviderAvailability,
@@ -688,6 +689,7 @@ export default function SettingsView({
       grabOffsetY: grabY - rowRect.top,
       rowHeight: rowRect.height,
       slots,
+      layoutSpace: captureLayoutSpace(node),
     }
     setBackgroundDrag(next)
   }, [])
@@ -699,7 +701,7 @@ export default function SettingsView({
     // handlers never read stale React state.
     const start = backgroundDragRef.current
     if (!start) return undefined
-    const { fromIndex, grabOffsetY, rowHeight, slots } = start
+    const { fromIndex, grabOffsetY, rowHeight, slots, layoutSpace } = start
     const originTop = slots[fromIndex]?.top ?? 0
     const minOffset = slots.length ? slots[0].top - originTop : 0
     const maxOffset = slots.length ? slots[slots.length - 1].top - originTop : 0
@@ -717,7 +719,11 @@ export default function SettingsView({
       // without re-rendering the whole panel every frame.
       const node = backgroundRowRefs.current[fromIndex]
       if (node) {
-        node.style.transform = `translateY(${followOffset(event.clientY)}px) scale(1.02)`
+        const layoutOffset = clientDeltaToLayout({
+          x: 0,
+          y: followOffset(event.clientY),
+        }, layoutSpace).y
+        node.style.transform = `translateY(${layoutOffset}px) scale(1.02)`
       }
       // Only re-render (to slide the other rows aside) when the target
       // slot actually changes.
@@ -1367,7 +1373,10 @@ export default function SettingsView({
       const raw = (backgroundPointerYRef.current - backgroundDrag.grabOffsetY) - originTop
       const minOffset = slots.length ? slots[0].top - originTop : 0
       const maxOffset = slots.length ? slots[slots.length - 1].top - originTop : 0
-      const offset = Math.max(minOffset, Math.min(maxOffset, raw))
+      const offset = clientDeltaToLayout({
+        x: 0,
+        y: Math.max(minOffset, Math.min(maxOffset, raw)),
+      }, backgroundDrag.layoutSpace).y
       return {
         transform: `translateY(${offset}px) scale(1.02)`,
         zIndex: 3,
@@ -1381,7 +1390,10 @@ export default function SettingsView({
     ) {
       const originSlot = slots[index]
       const targetSlot = slots[index - 1]
-      const offset = originSlot && targetSlot ? targetSlot.top - originSlot.top : 0
+      const offset = clientDeltaToLayout({
+        x: 0,
+        y: originSlot && targetSlot ? targetSlot.top - originSlot.top : 0,
+      }, backgroundDrag.layoutSpace).y
       return { transform: `translateY(${offset}px)` }
     }
     if (
@@ -1391,7 +1403,10 @@ export default function SettingsView({
     ) {
       const originSlot = slots[index]
       const targetSlot = slots[index + 1]
-      const offset = originSlot && targetSlot ? targetSlot.top - originSlot.top : 0
+      const offset = clientDeltaToLayout({
+        x: 0,
+        y: originSlot && targetSlot ? targetSlot.top - originSlot.top : 0,
+      }, backgroundDrag.layoutSpace).y
       return { transform: `translateY(${offset}px)` }
     }
     return undefined

--- a/frontend/src/components/Shell/PaneStrip.jsx
+++ b/frontend/src/components/Shell/PaneStrip.jsx
@@ -2,6 +2,7 @@ import { useLayoutEffect, useRef } from 'react'
 import { CollapseSm, ExpandSm, X } from '@openai/apps-sdk-ui/components/Icon'
 import * as tabModel from './tabModel.js'
 import { STRIP_H } from './paneModel.js'
+import { captureLayoutSpace, clientDeltaToLayout } from '../../lib/layoutSpace.js'
 
 // Each direction owns 40% of the one-shot cycle, so 1000/12 ms per clipped pixel
 // keeps travel at a readable 30px/s. The cycle runs once, returns to the beginning,
@@ -63,7 +64,14 @@ export function scrollStripWheel(e) {
   if (Math.abs(e.deltaX) >= Math.abs(e.deltaY) || e.deltaY === 0) return
   const strip = e.currentTarget
   if (strip.scrollWidth <= strip.clientWidth) return
-  const scale = e.deltaMode === 1 ? 16 : (e.deltaMode === 2 ? strip.clientWidth : 1)
+  if (e.deltaMode === 0) {
+    strip.scrollLeft += clientDeltaToLayout(
+      { x: e.deltaY, y: 0 },
+      captureLayoutSpace(strip),
+    ).x
+    return
+  }
+  const scale = e.deltaMode === 1 ? 16 : strip.clientWidth
   strip.scrollLeft += e.deltaY * scale
 }
 

--- a/frontend/src/components/Shell/Shell.css
+++ b/frontend/src/components/Shell/Shell.css
@@ -627,10 +627,15 @@
 /* Desktop productivity shell: the workspace starts at the very top, while a
    narrow left rail remains as the only persistent chrome. Expanding navigation
    turns that same rail into the drawer header (brand + notification bell);
-   collapsing it leaves a stable Möbius mark plus compact quick actions. Density
-   comes from removing redundant chrome while the document remains at native
-   scale, so viewport, pointer, iframe, and layout geometry share one space. */
+   collapsing it leaves a stable Möbius mark plus compact quick actions. */
 @media (min-width: 1024px) {
+  /* Intentional desktop density. Keep custom client/layout conversion
+     centralized in lib/layoutSpace.js; see ARCHITECTURE.md. */
+  :root {
+    --desktop-shell-density: 0.9;
+    zoom: var(--desktop-shell-density);
+  }
+
   .shell {
     --desktop-rail-width: 58px;
     --shell-bar-height: 0px;

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -19,6 +19,7 @@ import usePushSubscription from '../../hooks/usePushSubscription.js'
 import useNavigation, { deepLink } from '../../hooks/useNavigation.js'
 import useContextMenuOutsideDismiss from '../../hooks/useContextMenuOutsideDismiss.js'
 import { placeContextMenu } from '../../lib/contextMenuGeometry.js'
+import { captureLayoutSpace, clientPointToLayout } from '../../lib/layoutSpace.js'
 import { parseNotificationTarget } from '../../lib/notificationTarget.js'
 import useSystemEventStream from '../../hooks/useSystemEventStream.js'
 import useTheme from '../../hooks/useTheme.js'
@@ -1162,10 +1163,10 @@ export default function Shell() {
     if (!tabMenu || !tabMenuRef.current) return
     const menu = tabMenuRef.current
     const root = document.documentElement
-    const rootRect = root.getBoundingClientRect()
+    const rootSpace = captureLayoutSpace(root)
     const position = placeContextMenu({
-      clientPoint: { x: tabMenu.x, y: tabMenu.y },
-      clientViewport: rootRect,
+      point: clientPointToLayout({ x: tabMenu.x, y: tabMenu.y }, rootSpace),
+      viewport: { width: rootSpace.width, height: rootSpace.height },
       menuSize: { width: menu.offsetWidth, height: menu.offsetHeight },
     })
     menu.style.setProperty('--workspace-menu-x', `${position.x}px`)

--- a/frontend/src/components/Shell/WorkspaceChrome.jsx
+++ b/frontend/src/components/Shell/WorkspaceChrome.jsx
@@ -6,6 +6,7 @@ import {
 import { ARROW_STEP_RATIO } from '../../lib/splitHelper.js'
 import { PaneStrip } from './PaneStrip.jsx'
 import { modeViewTransitionStyle } from './useModeViewTransition.js'
+import { captureLayoutSpace, clientPointToLayout } from '../../lib/layoutSpace.js'
 
 // The chrome layer for a tiled (≥2 visible leaves) workspace (design §2). It is
 // a sibling AFTER the flat content wrappers, absolute inset:0, pointer-events
@@ -140,8 +141,13 @@ export default function WorkspaceChrome({
     // the rects are written imperatively per frame and there is no interpolation to
     // suppress. A divider drag also cannot overlap a mode beat — the chrome is inert
     // during one.
-    const contentBounds = contentEl.getBoundingClientRect()
+    const contentSpace = captureLayoutSpace(contentEl)
     const { dir, splitId } = divider
+    const startPoint = clientPointToLayout({ x: e.clientX, y: e.clientY }, contentSpace)
+    const dividerCenter = dir === 'row'
+      ? divider.x + divider.w / 2
+      : divider.y + divider.h / 2
+    const grabOffset = (dir === 'row' ? startPoint.x : startPoint.y) - dividerCenter
 
     // Cache the elements to move; no React render fires during the drag, so the
     // DOM is stable and one lookup suffices.
@@ -164,10 +170,15 @@ export default function WorkspaceChrome({
     let committed = divider.ratio
 
     const paint = (clientX, clientY) => {
-      const axis = dir === 'row'
-        ? clientX - contentBounds.left
-        : clientY - contentBounds.top
-      const raw = divider.span > 0 ? (axis - divider.origin) / divider.span : 0.5
+      const point = clientPointToLayout({ x: clientX, y: clientY }, contentSpace)
+      const pointerAxis = dir === 'row'
+        ? point.x
+        : point.y
+      const gap = dir === 'row' ? divider.w : divider.h
+      const dividerStart = pointerAxis - grabOffset - gap / 2
+      const raw = divider.span > 0
+        ? (dividerStart - divider.origin) / divider.span
+        : 0.5
       const proj = projectLayout(workspace, mode, contentRect, { splitId, ratio: raw })
       committed = proj.dividers.find(d => d.splitId === splitId)?.ratio ?? committed
       for (const paneId of proj.visibleLeaves) {

--- a/frontend/src/components/Shell/__tests__/dragController.test.js
+++ b/frontend/src/components/Shell/__tests__/dragController.test.js
@@ -7,7 +7,6 @@ import {
   CHIP_MOUSE_DX, CHIP_MOUSE_DY, CHIP_TOUCH_ABOVE,
   EDGE_BAND_MIN, EDGE_BAND_FRACTION,
   passedSlop, touchTabMoveIntent, drawerRowMoveIntent, releasedInPlace, chipOffset,
-  clientPointToLocal,
   crossedDrawerExit, edgeBands, edgePreviewRect, caretZone, edgeZone, centerZone,
   rootEdgeZone, hitTest, zoneTarget, releaseZone, zoneEq, buildScene,
 } from '../dragController.js'
@@ -34,18 +33,6 @@ function scene(panes, opts = {}) {
     rootCanSplit: { left: true, right: true, top: true, bottom: true, ...(opts.rootCanSplit || {}) },
   }
 }
-
-// ── Client-to-local coordinate boundary ─────────────────────────────────────
-
-test('clientPointToLocal translates viewport coordinates into the content box', () => {
-  assert.deepEqual(
-    clientPointToLocal(
-      { x: 235, y: 120 },
-      { left: 200, top: 80, width: 500, height: 300 },
-    ),
-    { x: 35, y: 40 },
-  )
-})
 
 // ── Threshold predicates ─────────────────────────────────────────────────────
 

--- a/frontend/src/components/Shell/__tests__/shellVisualViewport.test.js
+++ b/frontend/src/components/Shell/__tests__/shellVisualViewport.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 
 import { fitShellToVisualViewport } from '../useShellVisualViewport.js'
 
-function fakeShell(layoutHeight) {
+function fakeShell(layoutHeight, zoom = 1) {
   const properties = new Map()
   return {
     style: {
@@ -13,6 +13,17 @@ function fakeShell(layoutHeight) {
     get clientHeight() {
       const framed = Number.parseFloat(properties.get('height'))
       return Number.isFinite(framed) ? framed : layoutHeight
+    },
+    offsetWidth: 1000,
+    get offsetHeight() { return this.clientHeight },
+    currentCSSZoom: zoom,
+    getBoundingClientRect() {
+      return {
+        left: 0,
+        top: 0,
+        width: 1000 * zoom,
+        height: this.clientHeight * zoom,
+      }
     },
     property: name => properties.get(name),
   }
@@ -27,6 +38,34 @@ test('a keyboard overlay fits the shell to the visible viewport', () => {
   assert.equal(root.property('top'), '44px')
   assert.equal(root.property('bottom'), 'auto')
   assert.equal(root.property('height'), '492px')
+})
+
+test('desktop author zoom is not mistaken for a software keyboard', () => {
+  const root = fakeShell(1000, 0.9)
+  assert.equal(fitShellToVisualViewport(root, {
+    height: 900,
+    offsetTop: 0,
+  }), false)
+  assert.equal(root.property('height'), undefined)
+})
+
+test('the keyboard threshold remains a painted-pixel policy under author zoom', () => {
+  const root = fakeShell(1000, 0.9)
+  assert.equal(fitShellToVisualViewport(root, {
+    height: 821,
+    offsetTop: 0,
+  }), false)
+  assert.equal(root.property('height'), undefined)
+})
+
+test('keyboard viewport dimensions cross into zoomed layout space once', () => {
+  const root = fakeShell(1000, 0.9)
+  assert.equal(fitShellToVisualViewport(root, {
+    height: 540,
+    offsetTop: 45,
+  }), true)
+  assert.equal(root.property('top'), '50px')
+  assert.equal(root.property('height'), '600px')
 })
 
 test('open, close, and open again always remeasure the unframed shell', () => {

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -658,7 +658,6 @@ test('one held drawer-row gesture resolves menu, reorder, or workspace drag', ()
   assert.match(drawerCss, /\.drawer__row \.drawer__item\[data-drag-key\]\s*\{[\s\S]*?touch-action:\s*pan-y pinch-zoom/)
   assert.match(drawerCss, /\.drawer__row \.drawer__item\[data-pinned-key\]\s*\{[\s\S]*?touch-action:\s*pinch-zoom/)
   assert.match(dragBinding, /touchTabMoveIntent\(dx, dy\)/)
-  assert.match(dragBinding, /scrollAxis === 'x'\)[\s\S]*?scrollEl\.scrollLeft \+= previousPoint\.x - ev\.clientX/)
   assert.doesNotMatch(
     dragBinding,
     /sourceKind === 'drawer' && e\.pointerType !== 'mouse'\) return/,
@@ -673,8 +672,6 @@ test('one held drawer-row gesture resolves menu, reorder, or workspace drag', ()
     'the reorder outcome hands off to the row implementation')
   assert.match(dragBinding, /intent === 'workspace'\) arm\(\)/,
     'the workspace outcome arms the shared drag implementation')
-  assert.match(dragBinding, /intent === 'scroll'[\s\S]*?scrollAxis = 'y'[\s\S]*?scrollTop \+= start\.y - ev\.clientY/,
-    'pre-hold row movement scrolls without surrendering the pointer to the browser')
   assert.match(dragBinding, /const point = \{ \.\.\.lastPoint \}[\s\S]*?menuOpened = true[\s\S]*?handler\.openMenu\(point\)/,
     'a stationary long hold opens actions before release')
   assert.doesNotMatch(dragBinding, /const point = \{ \.\.\.lastPoint \}[\s\S]{0,120}?cleanup\(/,
@@ -714,7 +711,6 @@ test('drawer whitespace stays native while pinned rows reserve the shared pointe
   assert.match(drawer, /onPointerCancel=\{onDrawerPointerCancel\}/)
   assert.doesNotMatch(drawer, /addEventListener\('touchmove', move/,
     'the panel must never install a scroll-blocking touch listener')
-  assert.match(dragBinding, /scrollAxis === 'y'[\s\S]*?scrollEl\.scrollTop \+= previousPoint\.y - ev\.clientY/)
   assert.match(drawer, /if \(dx < 0 && isHorizontalSwipe\) gesture\.panning = true/)
   assert.match(drawer, /setPointerCapture\?\.\(e\.pointerId\)/)
 })
@@ -1128,13 +1124,8 @@ test('workspace focus, drag label, and cancel visuals remain coherent', () => {
   const focused = css.match(/\.workspace__strip--focused \.shell__tab--active \{[\s\S]*?\n\}/)?.[0] || ''
   assert.match(focused, /box-shadow: inset 0 -2px 0 0 var\(--accent\)/)
   assert.match(focused, /border-color: color-mix\(in srgb, var\(--accent\) 45%, var\(--border-light\)\)/)
-  // Pointer and tab measurements translate through the one content-box origin.
-  // Fixed drag chrome remains in viewport coordinates and clamps at that edge.
-  assert.match(dragBinding, /return clientPointToLocal\(\{ x: clientX, y: clientY \}, box\)/)
-  assert.match(dragBinding, /left: toLocal\(r\.left, r\.top, box\)\.x/)
-  assert.match(dragBinding, /chipOffset\(\{ x: clientX, y: clientY \}, isTouch\)/)
-  assert.doesNotMatch(dragBinding, /toViewportLayout/)
-  assert.match(dragBinding, /const viewportWidth = document\.documentElement\.clientWidth\s*\n\s*\|\| window\.innerWidth/)
+  // Fixed drag chrome remains clamped inside the viewport edge.
+  assert.match(dragBinding, /const viewportWidth = viewport\.width \|\| window\.innerWidth/)
   assert.match(dragBinding, /const maxLeft = Math\.max\(margin, viewportWidth - chipWidth - margin\)/)
   assert.match(dragBinding, /Math\.max\(margin, Math\.min\(left, maxLeft\)\)/)
   // V6: a CANCELLED drag blurs the drag-origin row so its focus ring clears; a

--- a/frontend/src/components/Shell/dragController.js
+++ b/frontend/src/components/Shell/dragController.js
@@ -165,17 +165,6 @@ export function crossedDrawerExit(pointX, edgeX, gap = DRAWER_EXIT_PX) {
 
 // ── Small geometry helpers ───────────────────────────────────────────────────
 
-// Translate viewport pointer coordinates into an element's local geometry.
-// The shell stays at native document scale, so this boundary owns translation
-// only; introducing a second scaled coordinate space here would make every
-// drag and fixed overlay carry special conversion rules again.
-export function clientPointToLocal(point, clientRect) {
-  return {
-    x: Number(point?.x) - (Number(clientRect?.left) || 0),
-    y: Number(point?.y) - (Number(clientRect?.top) || 0),
-  }
-}
-
 function contains(rect, point) {
   return point.x >= rect.x && point.x <= rect.x + rect.w
     && point.y >= rect.y && point.y <= rect.y + rect.h

--- a/frontend/src/components/Shell/useShellVisualViewport.js
+++ b/frontend/src/components/Shell/useShellVisualViewport.js
@@ -1,6 +1,10 @@
 /* Keep the full-screen shell inside the actually visible mobile viewport. */
 
 import { useLayoutEffect } from 'react'
+import {
+  captureLayoutSpace,
+  clientDeltaToLayout,
+} from '../../lib/layoutSpace.js'
 
 // Ignore small browser-bar changes; a software keyboard consumes much more.
 const MIN_KEYBOARD_INSET = 80
@@ -20,14 +24,24 @@ export function fitShellToVisualViewport(root, viewport) {
   if (!root) return false
   clearShellFrame(root)
 
-  const visibleHeight = Number(viewport?.height)
-  const layoutHeight = root.clientHeight
+  const space = captureLayoutSpace(root)
+  const visibleClientHeight = Number(viewport?.height)
+  if (!(visibleClientHeight > 0)) return false
+  const visibleHeight = clientDeltaToLayout({
+    x: 0,
+    y: visibleClientHeight,
+  }, space).y
+  const layoutHeight = space.height
   const coveredHeight = layoutHeight - visibleHeight
-  if (!(visibleHeight > 0) || coveredHeight < MIN_KEYBOARD_INSET) return false
+  const coveredClientHeight = space.clientHeight - visibleClientHeight
+  if (coveredClientHeight < MIN_KEYBOARD_INSET) return false
 
   const visibleTop = Math.min(
     coveredHeight,
-    Math.max(0, Number(viewport.offsetTop) || 0),
+    Math.max(0, clientDeltaToLayout({
+      x: 0,
+      y: Number(viewport.offsetTop) || 0,
+    }, space).y),
   )
   root.style.setProperty('top', `${visibleTop}px`)
   root.style.setProperty('bottom', 'auto')

--- a/frontend/src/components/Shell/useWorkspaceDrag.js
+++ b/frontend/src/components/Shell/useWorkspaceDrag.js
@@ -6,8 +6,13 @@ import {
   passedSlop, touchTabMoveIntent, drawerRowMoveIntent, releasedInPlace,
   TAB_HOLD_MS, DRAWER_DRAG_HOLD_MS, DRAWER_MENU_HOLD_MS,
   crossedDrawerExit,
-  rootEdgeAllowed, clientPointToLocal,
+  rootEdgeAllowed,
 } from './dragController.js'
+import {
+  captureLayoutSpace,
+  clientDeltaToLayout,
+  clientPointToLayout,
+} from '../../lib/layoutSpace.js'
 
 // The thin React binding for the workspace drag controller (design §3). It owns
 // only the side-effects the pure dragController.js cannot: pointer capture, the
@@ -96,6 +101,7 @@ export default function useWorkspaceDrag({
     let chipEl = null
     let chipWidth = 0
     let previewEl = null
+    let fixedSpace = null
     // The one in-flight session's teardown, so an unmount / disable can tear a
     // live drag down cleanly — no orphaned shield. activePointerId / activeSrcEl
     // travel with it so the next-interaction reconcile (below) can tell whether the
@@ -112,13 +118,19 @@ export default function useWorkspaceDrag({
 
     function contentBox() {
       const host = contentElRef.current
-      return host?.getBoundingClientRect() || { left: 0, top: 0 }
+      return captureLayoutSpace(host, {
+        left: 0,
+        top: 0,
+        width: window.innerWidth,
+        height: window.innerHeight,
+      })
     }
     function toLocal(clientX, clientY, box = contentBox()) {
-      return clientPointToLocal({ x: clientX, y: clientY }, box)
+      return clientPointToLayout({ x: clientX, y: clientY }, box)
     }
 
     function ensureOverlays() {
+      fixedSpace = captureLayoutSpace(document.documentElement)
       if (!shieldEl) {
         shieldEl = document.createElement('div')
         shieldEl.className = 'workspace__drag-shield'
@@ -153,6 +165,7 @@ export default function useWorkspaceDrag({
       shieldEl?.remove(); shieldEl = null
       chipEl?.remove(); chipEl = null; chipWidth = 0
       previewEl?.remove(); previewEl = null
+      fixedSpace = null
       clearPreGlow()
     }
 
@@ -166,12 +179,13 @@ export default function useWorkspaceDrag({
         chipEl.hidden = false
         chipWidth = chipEl.offsetWidth || 0
       }
-      const { left, top } = chipOffset({ x: clientX, y: clientY }, isTouch)
+      const viewport = fixedSpace || captureLayoutSpace(document.documentElement)
+      const point = clientPointToLayout({ x: clientX, y: clientY }, viewport)
+      const { left, top } = chipOffset(point, isTouch)
       // V5 (vizreview): clamp the chip within the viewport so its label never clips
       // at the right edge (the +12 offset pushed a right-edge drag off-screen).
       const margin = 8
-      const viewportWidth = document.documentElement.clientWidth
-        || window.innerWidth
+      const viewportWidth = viewport.width || window.innerWidth
       const maxLeft = Math.max(margin, viewportWidth - chipWidth - margin)
       chipEl.style.left = `${Math.max(margin, Math.min(left, maxLeft))}px`
       chipEl.style.top = `${top}px`
@@ -231,7 +245,16 @@ export default function useWorkspaceDrag({
     function buildSceneNow(source, allowRootEdge) {
       const { projection, mode, contentRect } = sceneInputsRef.current
       const ws = workspaceStateRef.current.ws
-      return buildScene(ws, projection, mode, contentRect, source, allowRootEdge, measureTabs)
+      const box = contentBox()
+      return buildScene(
+        ws,
+        projection,
+        mode,
+        contentRect,
+        source,
+        allowRootEdge,
+        paneId => measureTabs(paneId, box),
+      )
     }
 
     // ── One drag session ──────────────────────────────────────────────────────
@@ -248,6 +271,7 @@ export default function useWorkspaceDrag({
       let scrolling = false
       let scrollEl = null
       let scrollAxis = null
+      let scrollSpace = null
       let curZone = null
       let scene = null
       let drawerEdgeX = null
@@ -421,8 +445,12 @@ export default function useWorkspaceDrag({
         const dy = ev.clientY - start.y
         if (scrolling) {
           ev.preventDefault?.()
-          if (scrollEl && scrollAxis === 'x') scrollEl.scrollLeft += previousPoint.x - ev.clientX
-          else if (scrollEl && scrollAxis === 'y') scrollEl.scrollTop += previousPoint.y - ev.clientY
+          const delta = clientDeltaToLayout({
+            x: previousPoint.x - ev.clientX,
+            y: previousPoint.y - ev.clientY,
+          }, scrollSpace)
+          if (scrollEl && scrollAxis === 'x') scrollEl.scrollLeft += delta.x
+          else if (scrollEl && scrollAxis === 'y') scrollEl.scrollTop += delta.y
           return
         }
         if (!armed) {
@@ -438,8 +466,14 @@ export default function useWorkspaceDrag({
               scrolling = true
               scrollEl = srcEl.closest('.drawer__scroll')
               scrollAxis = 'y'
+              scrollSpace = captureLayoutSpace(scrollEl)
               ev.preventDefault?.()
-              if (scrollEl) scrollEl.scrollTop += start.y - ev.clientY
+              if (scrollEl) {
+                scrollEl.scrollTop += clientDeltaToLayout(
+                  { x: 0, y: start.y - ev.clientY },
+                  scrollSpace,
+                ).y
+              }
               return
             }
             if (intent === 'reorder') {
@@ -474,8 +508,14 @@ export default function useWorkspaceDrag({
                 scrolling = true
                 scrollEl = srcEl.closest('.shell__tabstrip')
                 scrollAxis = 'x'
+                scrollSpace = captureLayoutSpace(scrollEl)
                 ev.preventDefault?.()
-                if (scrollEl) scrollEl.scrollLeft += start.x - ev.clientX
+                if (scrollEl) {
+                  scrollEl.scrollLeft += clientDeltaToLayout(
+                    { x: start.x - ev.clientX, y: 0 },
+                    scrollSpace,
+                  ).x
+                }
                 return
               }
               if (!armed) return

--- a/frontend/src/lib/__tests__/appsDirectoryContract.test.js
+++ b/frontend/src/lib/__tests__/appsDirectoryContract.test.js
@@ -15,11 +15,6 @@ const itemActionMenu = readFileSync(
   'utf8',
 )
 const shell = readFileSync(resolve(src, 'components/Shell/Shell.jsx'), 'utf8')
-const shellCss = readFileSync(resolve(src, 'components/Shell/Shell.css'), 'utf8')
-const workspaceChrome = readFileSync(
-  resolve(src, 'components/Shell/WorkspaceChrome.jsx'),
-  'utf8',
-)
 const tabModel = readFileSync(resolve(src, 'components/Shell/tabModel.js'), 'utf8')
 const navigationIcons = readFileSync(resolve(src, 'components/navigationIcons.js'), 'utf8')
 
@@ -73,14 +68,6 @@ test('chat and app rows share one placed action menu contract', () => {
   assert.doesNotMatch(itemActionMenu, /drawer__item-action-header|drawer__item-action-handle/)
   assert.match(itemActionMenu, /itemKind === 'app' && \(/,
     'Delete data must stay app-only')
-})
-
-test('desktop density keeps the shell at native document scale', () => {
-  const desktop = shellCss.match(/@media \(min-width: 1024px\) \{[\s\S]*$/)?.[0] || ''
-  assert.doesNotMatch(desktop, /(?:^|[;{])\s*zoom\s*:/)
-  assert.match(shellCss, /document remains at native[\s\S]*geometry share one space/)
-  assert.doesNotMatch(drawer, /clientDeltaToLocal/)
-  assert.doesNotMatch(workspaceChrome, /clientPointToLocal/)
 })
 
 test('the app directory distinguishes loading, errors, and confirmed emptiness', () => {

--- a/frontend/src/lib/__tests__/contextMenuGeometry.test.js
+++ b/frontend/src/lib/__tests__/contextMenuGeometry.test.js
@@ -2,10 +2,10 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import { placeContextMenu } from '../contextMenuGeometry.js'
 
-test('a desktop context menu stays beside the pointer in a native viewport', () => {
+test('a desktop context menu stays beside its layout-space anchor', () => {
   const position = placeContextMenu({
-    clientPoint: { x: 380, y: 215 },
-    clientViewport: { left: 0, top: 0, width: 1512, height: 861 },
+    point: { x: 380, y: 215 },
+    viewport: { width: 1512, height: 861 },
     menuSize: { width: 220, height: 190 },
   })
 
@@ -14,8 +14,8 @@ test('a desktop context menu stays beside the pointer in a native viewport', () 
 
 test('a context menu flips before the right and bottom viewport edges', () => {
   const position = placeContextMenu({
-    clientPoint: { x: 790, y: 590 },
-    clientViewport: { left: 0, top: 0, width: 800, height: 600 },
+    point: { x: 790, y: 590 },
+    viewport: { width: 800, height: 600 },
     menuSize: { width: 220, height: 180 },
   })
 
@@ -24,8 +24,8 @@ test('a context menu flips before the right and bottom viewport edges', () => {
 
 test('an oversized context menu clamps to the viewport padding', () => {
   const position = placeContextMenu({
-    clientPoint: { x: 10, y: 10 },
-    clientViewport: { left: 0, top: 0, width: 200, height: 150 },
+    point: { x: 10, y: 10 },
+    viewport: { width: 200, height: 150 },
     menuSize: { width: 240, height: 180 },
   })
 

--- a/frontend/src/lib/__tests__/layoutSpace.test.js
+++ b/frontend/src/lib/__tests__/layoutSpace.test.js
@@ -1,0 +1,144 @@
+/* Layout-space tests pin the shell's one client-to-layout boundary under author zoom. */
+
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  captureLayoutSpace,
+  clientDeltaToLayout,
+  clientPointToLayout,
+} from '../layoutSpace.js'
+
+function box({
+  left = 0,
+  top = 0,
+  clientWidth = 900,
+  clientHeight = 720,
+  layoutWidth = 1000,
+  layoutHeight = 800,
+  currentCSSZoom = 0.9,
+} = {}) {
+  return {
+    currentCSSZoom,
+    offsetWidth: layoutWidth,
+    offsetHeight: layoutHeight,
+    getBoundingClientRect: () => ({
+      left,
+      top,
+      width: clientWidth,
+      height: clientHeight,
+    }),
+  }
+}
+
+test('captureLayoutSpace records the effective 90% client-to-layout scale', () => {
+  assert.deepEqual(captureLayoutSpace(box({ left: 288 })), {
+    clientLeft: 288,
+    clientTop: 0,
+    clientWidth: 900,
+    clientHeight: 720,
+    width: 1000,
+    height: 800,
+    scaleX: 0.9,
+    scaleY: 0.9,
+  })
+})
+
+test('the zoomed document root keeps its expanded offset dimensions as layout space', () => {
+  const root = box({
+    clientWidth: 1080,
+    clientHeight: 720,
+    layoutWidth: 1200,
+    layoutHeight: 800,
+  })
+  root.clientWidth = 1080
+  root.clientHeight = 720
+  root.ownerDocument = { documentElement: root }
+
+  const space = captureLayoutSpace(root)
+
+  assert.equal(space.width, 1200)
+  assert.equal(space.height, 800)
+  assert.deepEqual(clientPointToLayout({ x: 1080, y: 720 }, space), {
+    x: 1200,
+    y: 800,
+  })
+})
+
+test('client points and deltas cross the zoom boundary once', () => {
+  const space = captureLayoutSpace(box({ left: 288, top: 18 }))
+
+  assert.deepEqual(
+    clientPointToLayout({ x: 738, y: 288 }, space),
+    { x: 500, y: 300 },
+  )
+  assert.deepEqual(
+    clientDeltaToLayout({ x: 90, y: -45 }, space),
+    { x: 100, y: -50 },
+  )
+})
+
+test('native scale remains an ordinary identity boundary', () => {
+  const space = captureLayoutSpace(box({
+    left: 20,
+    top: 30,
+    clientWidth: 500,
+    clientHeight: 300,
+    layoutWidth: 500,
+    layoutHeight: 300,
+    currentCSSZoom: 1,
+  }))
+
+  assert.deepEqual(clientPointToLayout({ x: 55, y: 70 }, space), { x: 35, y: 40 })
+  assert.deepEqual(clientDeltaToLayout({ x: 48, y: 24 }, space), { x: 48, y: 24 })
+})
+
+test('measured geometry discovers zoom when currentCSSZoom is unavailable', () => {
+  const legacy = box({ currentCSSZoom: undefined })
+  const space = captureLayoutSpace(legacy)
+  assert.equal(space.scaleX, 0.9)
+  assert.equal(space.scaleY, 0.9)
+})
+
+test('currentCSSZoom does not mistake transform scaling for CSS zoom', () => {
+  const transformed = box({
+    currentCSSZoom: 0.9,
+    clientWidth: 720,
+    clientHeight: 576,
+  })
+  const space = captureLayoutSpace(transformed)
+  assert.equal(space.scaleX, 0.9)
+  assert.equal(space.scaleY, 0.9)
+})
+
+test('legacy engines multiply authored zoom through the ancestor chain', () => {
+  const originalGetComputedStyle = globalThis.getComputedStyle
+  const root = { parentElement: null, authoredZoom: 0.9 }
+  const child = box({ currentCSSZoom: undefined, clientWidth: 720, clientHeight: 576 })
+  child.parentElement = root
+  child.authoredZoom = 1
+  globalThis.getComputedStyle = node => ({ zoom: String(node.authoredZoom) })
+  try {
+    const space = captureLayoutSpace(child)
+    assert.equal(space.scaleX, 0.9)
+    assert.equal(space.scaleY, 0.9)
+  } finally {
+    globalThis.getComputedStyle = originalGetComputedStyle
+  }
+})
+
+test('currentCSSZoom keeps zero-sized measurement fallbacks finite', () => {
+  const zero = {
+    currentCSSZoom: 0.9,
+    offsetWidth: 0,
+    offsetHeight: 0,
+    clientWidth: 0,
+    clientHeight: 0,
+    getBoundingClientRect: () => ({ left: 4, top: 6, width: 0, height: 0 }),
+  }
+  const space = captureLayoutSpace(zero)
+
+  assert.equal(space.scaleX, 0.9)
+  assert.equal(space.scaleY, 0.9)
+  assert.deepEqual(clientPointToLayout({ x: 13, y: 15 }, space), { x: 10, y: 10 })
+})

--- a/frontend/src/lib/__tests__/shellViewportZoom.test.js
+++ b/frontend/src/lib/__tests__/shellViewportZoom.test.js
@@ -1,10 +1,14 @@
-/* Browser zoom never scales the Möbius shell chrome; each app owns local zoom. */
+/* Browser pinch stays locked; intentional desktop author zoom owns shell density. */
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 
 const indexHtml = readFileSync(new URL('../../../index.html', import.meta.url), 'utf8')
 const indexCss = readFileSync(new URL('../../index.css', import.meta.url), 'utf8')
+const shellCss = readFileSync(
+  new URL('../../components/Shell/Shell.css', import.meta.url),
+  'utf8',
+)
 const appFrameHtml = readFileSync(new URL('../../../public/app-frame.html', import.meta.url), 'utf8')
 const buildingApps = readFileSync(
   new URL('../../../../backend/scripts/seed-skills/building-apps.md', import.meta.url),
@@ -14,6 +18,12 @@ const buildingApps = readFileSync(
 function viewportContent(html) {
   return html.match(/<meta name="viewport" content="([^"]+)"/)?.[1] || ''
 }
+
+test('desktop web keeps its intentional 90% author zoom in one policy', () => {
+  const desktop = shellCss.match(/@media \(min-width: 1024px\) \{[\s\S]*$/)?.[0] || ''
+  assert.match(desktop, /--desktop-shell-density:\s*0\.9/)
+  assert.match(desktop, /zoom:\s*var\(--desktop-shell-density\)/)
+})
 
 test('browser pinch cannot scale the shell chrome and active app together', () => {
   const viewport = viewportContent(indexHtml)

--- a/frontend/src/lib/contextMenuGeometry.js
+++ b/frontend/src/lib/contextMenuGeometry.js
@@ -1,4 +1,4 @@
-/* Keep a context menu beside the pointer and inside the client viewport. */
+/* Keep a context menu beside its anchor and inside one shared layout viewport. */
 
 function positiveNumber(value, fallback) {
   const number = Number(value)
@@ -10,16 +10,16 @@ function clamp(value, minimum, maximum) {
 }
 
 export function placeContextMenu({
-  clientPoint,
-  clientViewport,
+  point,
+  viewport,
   menuSize,
   gap = 8,
   padding = 12,
 }) {
-  const viewportWidth = positiveNumber(clientViewport?.width, 1)
-  const viewportHeight = positiveNumber(clientViewport?.height, 1)
-  const pointX = Number(clientPoint?.x) - (Number(clientViewport?.left) || 0)
-  const pointY = Number(clientPoint?.y) - (Number(clientViewport?.top) || 0)
+  const viewportWidth = positiveNumber(viewport?.width, 1)
+  const viewportHeight = positiveNumber(viewport?.height, 1)
+  const pointX = Number(point?.x) || 0
+  const pointY = Number(point?.y) || 0
   const menuWidth = positiveNumber(menuSize?.width, 0)
   const menuHeight = positiveNumber(menuSize?.height, 0)
   const safeGap = Math.max(0, Number(gap) || 0)

--- a/frontend/src/lib/layoutSpace.js
+++ b/frontend/src/lib/layoutSpace.js
@@ -1,0 +1,115 @@
+/* Bridge viewport/client geometry into the CSS layout space that inline styles consume. */
+
+function finiteNumber(value, fallback = 0) {
+  const number = Number(value)
+  return Number.isFinite(number) ? number : fallback
+}
+
+function positiveNumber(value, fallback = 0) {
+  const number = Number(value)
+  return Number.isFinite(number) && number > 0 ? number : fallback
+}
+
+function firstPositive(...values) {
+  for (const value of values) {
+    const number = positiveNumber(value)
+    if (number) return number
+  }
+  return 0
+}
+
+function computedEffectiveZoom(element) {
+  if (typeof getComputedStyle !== 'function' || !element) return 0
+  let node = element
+  let zoom = 1
+  let found = false
+  while (node) {
+    try {
+      const raw = getComputedStyle(node)?.zoom
+      const value = positiveNumber(raw)
+      if (value) {
+        zoom *= value
+        found = true
+      }
+    } catch {
+      return 0
+    }
+    node = node.parentElement || node.getRootNode?.().host || null
+  }
+  return found ? zoom : 0
+}
+
+/**
+ * Capture one axis-aligned element's padding box (the document box for <html>)
+ * as both viewport/client geometry and local CSS-layout geometry. CSS `zoom`
+ * deliberately makes those spaces differ:
+ * getBoundingClientRect() includes the effective zoom while offset* dimensions
+ * do not. Keeping that fact in one value prevents pointer, viewport, and fixed
+ * overlay code from each inventing its own scale calculation.
+ */
+export function captureLayoutSpace(element, fallbackRect = null) {
+  const rect = element?.getBoundingClientRect?.() || fallbackRect || {}
+  const effectiveZoom = positiveNumber(element?.currentCSSZoom)
+    || computedEffectiveZoom(element)
+  const cssZoom = effectiveZoom || 1
+  const rectWidth = finiteNumber(rect?.width)
+  const rectHeight = finiteNumber(rect?.height)
+  const borderLayoutWidth = positiveNumber(element?.offsetWidth)
+  const borderLayoutHeight = positiveNumber(element?.offsetHeight)
+  const innerLayoutWidth = positiveNumber(element?.clientWidth)
+  const innerLayoutHeight = positiveNumber(element?.clientHeight)
+  const isDocumentRoot = Boolean(
+    element && element.ownerDocument?.documentElement === element,
+  )
+  const layoutWidth = isDocumentRoot
+    ? firstPositive(borderLayoutWidth, innerLayoutWidth, rectWidth / cssZoom)
+    : firstPositive(innerLayoutWidth, borderLayoutWidth, rectWidth / cssZoom)
+  const layoutHeight = isDocumentRoot
+    ? firstPositive(borderLayoutHeight, innerLayoutHeight, rectHeight / cssZoom)
+    : firstPositive(innerLayoutHeight, borderLayoutHeight, rectHeight / cssZoom)
+
+  // currentCSSZoom reports effective author zoom without mistaking transforms
+  // for zoom. The ancestor walk, then measured ratio, keep this
+  // bridge working in engines that predate that API.
+  const scaleX = effectiveZoom || positiveNumber(
+    rectWidth / (borderLayoutWidth || layoutWidth),
+    1,
+  )
+  const scaleY = effectiveZoom || positiveNumber(
+    rectHeight / (borderLayoutHeight || layoutHeight),
+    1,
+  )
+  const clientLeft = finiteNumber(rect?.left)
+    + finiteNumber(element?.clientLeft) * scaleX
+  const clientTop = finiteNumber(rect?.top)
+    + finiteNumber(element?.clientTop) * scaleY
+
+  return {
+    clientLeft,
+    clientTop,
+    clientWidth: layoutWidth * scaleX,
+    clientHeight: layoutHeight * scaleY,
+    width: layoutWidth,
+    height: layoutHeight,
+    scaleX,
+    scaleY,
+  }
+}
+
+/** Convert a viewport/client point into an element-local CSS-layout point. */
+export function clientPointToLayout(point, space) {
+  return {
+    x: (finiteNumber(point?.x) - finiteNumber(space?.clientLeft))
+      / positiveNumber(space?.scaleX, 1),
+    y: (finiteNumber(point?.y) - finiteNumber(space?.clientTop))
+      / positiveNumber(space?.scaleY, 1),
+  }
+}
+
+/** Convert a viewport/client displacement into a CSS-layout displacement. */
+export function clientDeltaToLayout(delta, space) {
+  return {
+    x: finiteNumber(delta?.x) / positiveNumber(space?.scaleX, 1),
+    y: finiteNumber(delta?.y) / positiveNumber(space?.scaleY, 1),
+  }
+}

--- a/frontend/src/lib/themeService.js
+++ b/frontend/src/lib/themeService.js
@@ -7,6 +7,7 @@ import {
 } from '../theme.js'
 import { themeQueries } from '../hooks/queries.js'
 import { applyTheme, inferMode, HEX_RE } from './applyTheme.js'
+import { captureLayoutSpace, clientPointToLayout } from './layoutSpace.js'
 
 /**
  * Owns the theme lifecycle: read, transform, apply (DOM + body bg
@@ -88,10 +89,10 @@ function shouldAnimateThemeChange() {
 
 function defaultThemeTransitionOrigin() {
   if (typeof window === 'undefined') return null
-  const width = window.innerWidth || document.documentElement?.clientWidth || 0
-  const height = window.innerHeight || document.documentElement?.clientHeight || 0
-  if (!width || !height) return null
-  return { x: width / 2, y: height / 2 }
+  const root = document.documentElement
+  const space = captureLayoutSpace(root)
+  if (!space.width || !space.height) return null
+  return { x: space.width / 2, y: space.height / 2 }
 }
 
 function applyThemeTransitionOrigin(root, origin) {
@@ -118,18 +119,20 @@ export function setThemeTransitionOriginFromEvent(event) {
     || native
   const x = Number(point?.clientX)
   const y = Number(point?.clientY)
+  const root = document.documentElement
+  const space = captureLayoutSpace(root)
   if (Number.isFinite(x) && Number.isFinite(y)) {
-    nextThemeTransitionOrigin = { x, y }
+    nextThemeTransitionOrigin = clientPointToLayout({ x, y }, space)
     return
   }
 
   const target = event?.currentTarget || event?.target
   const rect = target?.getBoundingClientRect?.()
   if (rect) {
-    nextThemeTransitionOrigin = {
+    nextThemeTransitionOrigin = clientPointToLayout({
       x: rect.left + rect.width / 2,
       y: rect.top + rect.height / 2,
-    }
+    }, space)
   }
 }
 

--- a/tests/app-apply-lifecycle.spec.mjs
+++ b/tests/app-apply-lifecycle.spec.mjs
@@ -1,6 +1,7 @@
 import { execFileSync } from 'node:child_process'
 import { expect, test } from '@playwright/test'
 import { applyApp, applySource, writeAppSource } from './app-source.mjs'
+import { activateFrameControl } from './frame-actions.mjs'
 
 const BASE = process.env.MOBIUS_URL || 'http://localhost:8001'
 const CONTAINER = process.env.MOBIUS_CONTAINER || 'mobius-test'
@@ -113,7 +114,7 @@ test('explicit apply owns draft, publication, iframe refresh, and rollback', asy
     })
     let frame = await currentFrame(page, app.id)
     await expect(frame.locator('#revision')).toHaveText('revision one ready')
-    await frame.locator('#increment').click()
+    await activateFrameControl(frame.locator('#increment'))
     await expect(frame.locator('#count')).toHaveText('1')
 
     await page.waitForTimeout(1_000)

--- a/tests/embedded-chat-capability.spec.mjs
+++ b/tests/embedded-chat-capability.spec.mjs
@@ -9,6 +9,7 @@
  */
 import { test, expect } from '@playwright/test'
 import { applyApp } from './app-source.mjs'
+import { activateFrameControl } from './frame-actions.mjs'
 
 const BASE = process.env.MOBIUS_URL || 'http://localhost:8001'
 
@@ -205,7 +206,7 @@ test('opaque embedded chat completes authenticated flow and survives remount', a
     expect(embedResponses.at(-1).headers['x-content-type-options']).toBe('nosniff')
 
     // Picker + real attachment path use the same chat-only principal.
-    await chatFrame.getByRole('button', { name: 'Attach or change model' }).click()
+    await activateFrameControl(chatFrame.getByRole('button', { name: 'Attach or change model' }))
     await expect(chatFrame.getByRole('button', { name: 'Attach files' })).toBeVisible()
     await chatFrame.locator('input[type="file"]').setInputFiles({
       name: 'e2e.txt',
@@ -221,7 +222,7 @@ test('opaque embedded chat completes authenticated flow and survives remount', a
     await chatFrame.locator('textarea').fill(
       'This is a transport test. Reply exactly `capability-ok`; do not call tools or edit files.',
     )
-    await chatFrame.getByRole('button', { name: /send/i }).click()
+    await activateFrameControl(chatFrame.getByRole('button', { name: /send/i }))
     await expect.poll(() => sendBody, { timeout: 10_000 }).not.toBeNull()
     expect(sendBody.content).toContain('<marker>opaque-context-ok</marker>')
     expect(sendBody.attachments?.[0]?.name).toBe('e2e.txt')
@@ -265,7 +266,7 @@ test('opaque embedded chat completes authenticated flow and survives remount', a
 
     // The runtime's supported New chat control rotates both chat and embed
     // instance, revokes the old session and authorizes a fresh blank document.
-    await remountedAppFrame.getByRole('button', { name: 'New chat' }).click()
+    await activateFrameControl(remountedAppFrame.getByRole('button', { name: 'New chat' }))
     await expect.poll(async () => remountedStatus.getAttribute('data-chat'))
       .not.toBe(firstChat)
     await expect(remountedStatus).toHaveText('ready', { timeout: 20_000 })

--- a/tests/frame-actions.mjs
+++ b/tests/frame-actions.mjs
@@ -1,0 +1,17 @@
+/**
+ * Activate a control inside an iframe when the desktop shell uses root zoom.
+ *
+ * Chromium delivers physical pointer input correctly, but Playwright projects
+ * nested-frame actionability coordinates through root zoom twice. The synthetic
+ * point can land on a containing element even though the control is visible.
+ * Frame behavior after activation remains asserted by each caller; shell-level
+ * pointer geometry has separate physical mouse regressions.
+ */
+export async function activateFrameControl(locator) {
+  await locator.evaluate((element) => {
+    if (!(element instanceof HTMLElement)) {
+      throw new TypeError('Frame control must be an HTMLElement')
+    }
+    element.click()
+  })
+}

--- a/tests/navigation.spec.mjs
+++ b/tests/navigation.spec.mjs
@@ -461,6 +461,49 @@ test.describe('Desktop sidebar navigation', () => {
     await setup(page, { width: 1280, height: 800 })
   }
 
+  test('desktop web keeps 90% density while tablet and phone stay native', async ({ page }) => {
+    await setupDesktop(page)
+
+    const readDensity = () => page.evaluate(() => {
+      const root = document.documentElement
+      const rootRect = root.getBoundingClientRect()
+      const shellRect = document.querySelector('.shell').getBoundingClientRect()
+      return {
+        ratio: root.offsetWidth > 0 ? rootRect.width / root.offsetWidth : 0,
+        shell: {
+          left: shellRect.left,
+          top: shellRect.top,
+          right: shellRect.right,
+          bottom: shellRect.bottom,
+        },
+        viewport: { width: innerWidth, height: innerHeight },
+      }
+    })
+
+    const desktop = await readDensity()
+    expect(desktop.ratio).toBeCloseTo(0.9, 2)
+    expect(desktop.shell.left).toBeCloseTo(0, 1)
+    expect(desktop.shell.top).toBeCloseTo(0, 1)
+    expect(desktop.shell.right).toBeCloseTo(desktop.viewport.width, 1)
+    expect(desktop.shell.bottom).toBeCloseTo(desktop.viewport.height, 1)
+
+    await page.setViewportSize({ width: 900, height: 800 })
+    await expect.poll(async () => (await readDensity()).ratio).toBeCloseTo(1, 2)
+    const tablet = await readDensity()
+    expect(tablet.shell.left).toBeCloseTo(0, 1)
+    expect(tablet.shell.top).toBeCloseTo(0, 1)
+    expect(tablet.shell.right).toBeCloseTo(tablet.viewport.width, 1)
+    expect(tablet.shell.bottom).toBeCloseTo(tablet.viewport.height, 1)
+
+    await page.setViewportSize({ width: 390, height: 844 })
+    const phone = await readDensity()
+    expect(phone.ratio).toBeCloseTo(1, 2)
+    expect(phone.shell.left).toBeCloseTo(0, 1)
+    expect(phone.shell.top).toBeCloseTo(0, 1)
+    expect(phone.shell.right).toBeCloseTo(phone.viewport.width, 1)
+    expect(phone.shell.bottom).toBeCloseTo(phone.viewport.height, 1)
+  })
+
   test('28. desktop sidebar reserves workspace width and persists its toggle', async ({ page }) => {
     await setupDesktop(page)
 

--- a/tests/service-surface.spec.mjs
+++ b/tests/service-surface.spec.mjs
@@ -2,6 +2,7 @@
 import { test, expect } from '@playwright/test'
 import { readFileSync } from 'node:fs'
 import { applyApp } from './app-source.mjs'
+import { activateFrameControl } from './frame-actions.mjs'
 
 const BASE = process.env.MOBIUS_URL || 'http://localhost:8001'
 const baseUrl = new URL(BASE)
@@ -373,7 +374,7 @@ test('shared gateway stays branded until heartbeat, preserves cookies, and rejec
     // A later navigation failure must re-cover before Chromium's error
     // document can surface. The child becomes unreadable; adapter branding
     // remains the visible document.
-    await service.locator('#go-bad').click()
+    await activateFrameControl(service.locator('#go-bad'))
     await expect(adapter.locator('#cover')).toBeVisible()
     await expect(adapter.locator('#app')).toHaveCSS('opacity', '0')
     await expect(page.getByText(/refused to connect|127\.0\.0\.1/i)).toHaveCount(0)

--- a/tests/workspace-panes.spec.mjs
+++ b/tests/workspace-panes.spec.mjs
@@ -21,6 +21,7 @@
 import { test, expect } from '@playwright/test'
 import { createTaggedChat, attachCleanup } from './_chatTracker.mjs'
 import { mockAcceptedMessages } from './_mockAcceptedMessages.mjs'
+import { activateFrameControl } from './frame-actions.mjs'
 import * as paneModel from '../frontend/src/components/Shell/paneModel.js'
 
 const BASE = process.env.MOBIUS_URL || 'http://localhost:8001'
@@ -357,6 +358,7 @@ test.describe('Workspace panes (PR2 gate)', () => {
     // Drag the vertical divider right — changes pane WIDTHS. A short top-pinned
     // message must not move vertically.
     const box = await page.locator('.workspace__divider').boundingBox()
+    const dividerCenterBefore = box.x + box.width / 2
     await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
     await page.mouse.down()
     await page.mouse.move(box.x + box.width / 2 + 140, box.y + box.height / 2, { steps: 6 })
@@ -365,6 +367,9 @@ test.describe('Workspace panes (PR2 gate)', () => {
       requestAnimationFrame(() => requestAnimationFrame(r))))
 
     const after = await readTop()
+    const movedBox = await page.locator('.workspace__divider').boundingBox()
+    const dividerCenterAfter = movedBox.x + movedBox.width / 2
+    expect(dividerCenterAfter - dividerCenterBefore).toBeCloseTo(140, 0)
     expect(after, 'pinned message still measurable after drag').not.toBeNull()
     // Vertical position held (width change must not re-scroll the pin).
     expect(Math.abs(after - before)).toBeLessThanOrEqual(16)
@@ -679,8 +684,10 @@ test.describe('Workspace panes (PR2 gate)', () => {
     await expect(page.getByRole('menu', { name: 'Tab actions' })).toBeVisible()
 
     const frame = page.frameLocator(`iframe[data-app-id="${appId}"]`)
-    await frame.locator('#probe').click()
+    const probe = frame.locator('#probe')
+    await probe.focus()
     await expect(page.getByRole('menu', { name: 'Tab actions' })).toHaveCount(0)
+    await activateFrameControl(probe)
     await expect.poll(() => frame.locator('#probe').evaluate(() => window.__clicks)).toBe(1)
   })
 


### PR DESCRIPTION
## Summary

Restore the owner-selected 90% density for desktop web while keeping tablet and phone layouts at native scale. The change centralizes the real browser boundary between painted client coordinates and zoomed layout coordinates so compact desktop chrome no longer compromises dragging, menus, scrolling, viewport fitting, image gestures, or theme transitions.

## Changes

- restore document-level desktop density at the existing 1024px breakpoint
- add one small layout-space module and route custom client-to-layout geometry through it
- keep mini-app frames native and preserve physical gesture thresholds
- cover desktop, tablet, and phone shell bounds plus physical divider travel
- document the coordinate-space contract and remove superseded native-only helpers

This deliberately revisits #480. That PR correctly removed an incomplete zoom implementation whose callers mixed painted and layout coordinates; this version restores the requested density together with a reviewed, single conversion boundary and browser-level regressions for the interactions that previously broke.

## Testing

- 2,336 frontend library tests
- 79 frontend hook tests
- lint (44/47 warning ratchet)
- production and offline/PWA builds
- `git diff --check`

Pre-ship review: the coordinate bridge exposes only captured space plus client point/delta conversion; unused inverse and rectangle APIs were removed, gesture snapshots reuse one captured space, and source-reading assertions were reduced in favor of unit and browser behavior.