### PR TITLE
Bind system SSE subscriptions to stream lifetime

### DIFF
--- a/backend/app/routes/notify.py
+++ b/backend/app/routes/notify.py
@@ -15,6 +15,7 @@ import json
 import logging
 import time
 
+import anyio
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, ConfigDict, field_validator, model_validator
@@ -41,6 +42,22 @@ log = logging.getLogger(__name__)
 # Keepalive cadence for the shell-level SSE — same value used in
 # chats_stream so proxies behave consistently.
 _KEEPALIVE_INTERVAL = 30
+
+
+class _SystemEventStreamingResponse(StreamingResponse):
+  """Close the event iterator when ASGI abandons an in-flight body send."""
+
+  async def __call__(self, scope, receive, send):
+    try:
+      await super().__call__(scope, receive, send)
+    finally:
+      close = getattr(self.body_iterator, "aclose", None)
+      if close is not None:
+        # A server can cancel the outer ASGI task as well as Starlette's body
+        # task. Re-enter the suspended async generator even in that state.
+        with anyio.CancelScope(shield=True):
+          await close()
+
 
 # Characters kept from a build_phase label. The label is the one free-text
 # field on this otherwise-closed schema and renders untrusted in the chat foot
@@ -344,9 +361,13 @@ async def stream_system_events(
     principal.embed_session_id if principal.scope == "chat_embed" else None
   )
   db.close()
-  queue = get_system_broadcast().subscribe()
 
   async def generate():
+    # Pair registration with this generator's finally across the whole live
+    # body lifetime. Subscribing while constructing the StreamingResponse
+    # leaks a queue when the client disconnects before body iteration starts.
+    broadcast = get_system_broadcast()
+    queue = broadcast.subscribe()
     last_embed_auth_check = 0.0
 
     def embed_session_active() -> bool:
@@ -380,9 +401,9 @@ async def stream_system_events(
           continue
         yield f"data: {json.dumps(event)}\n\n"
     finally:
-      get_system_broadcast().unsubscribe(queue)
+      broadcast.unsubscribe(queue)
 
-  return StreamingResponse(
+  return _SystemEventStreamingResponse(
     generate(),
     media_type="text/event-stream",
     headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},

--- a/backend/tests/test_system_sse_lifecycle.py
+++ b/backend/tests/test_system_sse_lifecycle.py
@@ -1,0 +1,191 @@
+"""Lifecycle contracts for the process-wide system SSE subscription."""
+
+import asyncio
+
+import pytest
+from starlette.requests import ClientDisconnect
+
+from app import models
+from app.broadcast import SystemBroadcast
+from app.deps import Principal
+from app.routes import notify as notify_routes
+
+
+class _ConnectedRequest:
+  async def is_disconnected(self):
+    return False
+
+
+class _ClosingSession:
+  def __init__(self):
+    self.close_calls = 0
+
+  def close(self):
+    self.close_calls += 1
+
+
+async def _build_system_stream(monkeypatch):
+  broadcast = SystemBroadcast()
+  monkeypatch.setattr(
+    notify_routes, "get_system_broadcast", lambda: broadcast,
+  )
+  db = _ClosingSession()
+  response = await notify_routes.stream_system_events(
+    request=_ConnectedRequest(),
+    principal=Principal(
+      owner=models.Owner(username="test"), app_id=None, scope="owner",
+    ),
+    db=db,
+  )
+  return broadcast, db, response
+
+
+@pytest.mark.asyncio
+async def test_system_stream_response_construction_does_not_subscribe(
+  monkeypatch,
+):
+  """A client lost before body iteration must not leave an unread queue."""
+  broadcast, db, response = await _build_system_stream(monkeypatch)
+
+  assert db.close_calls == 1
+  assert broadcast.subscribers == []
+
+  await response.body_iterator.aclose()
+  assert broadcast.subscribers == []
+
+
+@pytest.mark.asyncio
+async def test_system_stream_first_yield_subscribes_and_close_unsubscribes(
+  monkeypatch,
+):
+  """The live queue exists only for the generator's active lifetime."""
+  broadcast, _db, response = await _build_system_stream(monkeypatch)
+  iterator = response.body_iterator
+
+  try:
+    first = await iterator.__anext__()
+    assert "system_stream_open" in first
+    assert len(broadcast.subscribers) == 1
+  finally:
+    await iterator.aclose()
+
+  assert broadcast.subscribers == []
+
+
+@pytest.mark.asyncio
+async def test_system_stream_cancellation_unsubscribes_waiting_queue(
+  monkeypatch,
+):
+  """Cancelling a client blocked on the next event releases its queue."""
+  broadcast, _db, response = await _build_system_stream(monkeypatch)
+  iterator = response.body_iterator
+  await iterator.__anext__()
+  assert len(broadcast.subscribers) == 1
+
+  waiting = asyncio.create_task(iterator.__anext__())
+  await asyncio.sleep(0)
+  assert not waiting.done()
+
+  waiting.cancel()
+  with pytest.raises(asyncio.CancelledError):
+    await waiting
+
+  assert broadcast.subscribers == []
+  await iterator.aclose()
+
+
+@pytest.mark.asyncio
+async def test_system_stream_disconnect_during_body_send_unsubscribes(
+  monkeypatch,
+):
+  """ASGI cancellation after a yielded frame must close the iterator."""
+  broadcast, _db, response = await _build_system_stream(monkeypatch)
+  body_send_started = asyncio.Event()
+
+  async def receive():
+    await body_send_started.wait()
+    return {"type": "http.disconnect"}
+
+  async def send(message):
+    if message["type"] == "http.response.body":
+      body_send_started.set()
+      await asyncio.Future()
+
+  await response(
+    {
+      "type": "http",
+      "method": "GET",
+      "path": "/api/events/system",
+      "headers": [],
+      "asgi": {"version": "3.0", "spec_version": "2.3"},
+    },
+    receive,
+    send,
+  )
+
+  assert broadcast.subscribers == []
+
+
+@pytest.mark.asyncio
+async def test_system_stream_failed_body_send_unsubscribes(monkeypatch):
+  """ASGI 2.4 send failure must close the iterator before surfacing."""
+  broadcast, _db, response = await _build_system_stream(monkeypatch)
+
+  async def receive():
+    await asyncio.Future()
+
+  async def send(message):
+    if message["type"] == "http.response.body":
+      raise OSError("client closed")
+
+  with pytest.raises(ClientDisconnect):
+    await response(
+      {
+        "type": "http",
+        "method": "GET",
+        "path": "/api/events/system",
+        "headers": [],
+        "asgi": {"version": "3.0", "spec_version": "2.4"},
+      },
+      receive,
+      send,
+    )
+
+  assert broadcast.subscribers == []
+
+
+@pytest.mark.asyncio
+async def test_system_stream_response_task_cancellation_unsubscribes(
+  monkeypatch,
+):
+  """Server cancellation while sending must still run shielded cleanup."""
+  broadcast, _db, response = await _build_system_stream(monkeypatch)
+  body_send_started = asyncio.Event()
+
+  async def receive():
+    await asyncio.Future()
+
+  async def send(message):
+    if message["type"] == "http.response.body":
+      body_send_started.set()
+      await asyncio.Future()
+
+  response_task = asyncio.create_task(response(
+    {
+      "type": "http",
+      "method": "GET",
+      "path": "/api/events/system",
+      "headers": [],
+      "asgi": {"version": "3.0", "spec_version": "2.4"},
+    },
+    receive,
+    send,
+  ))
+  await body_send_started.wait()
+  assert len(broadcast.subscribers) == 1
+
+  response_task.cancel()
+  with pytest.raises(asyncio.CancelledError):
+    await response_task
+
+  assert broadcast.subscribers == []


### PR DESCRIPTION
## Summary

- create the system-event subscription only when the response body begins streaming
- close the body iterator when disconnects, failed sends, or server cancellation abandon an in-flight frame
- pair cleanup with the exact broadcast instance across normal completion and every cancellation boundary

## Testing

- `MOBIUS_TEST_RUNTIME=1 python3 -m pytest backend/tests/test_system_sse_lifecycle.py backend/tests/test_sse_releases_db_connection.py -q`
- full backend pytest suite
- hosted backend static analysis, dependency audit, pytest, frontend unit/packager/browser harness, privacy, and Playwright E2E