### PR TITLE
Make terminal contribution cleanup ownership-safe

### DIFF
--- a/backend/app/github_contributions.py
+++ b/backend/app/github_contributions.py
@@ -333,79 +333,113 @@ def _cleanup_terminal_staging_checkout(record: dict) -> bool:
   }:
     return False
   plan = record.get("plan") if isinstance(record.get("plan"), dict) else {}
-  repo = _safe_repo_path(plan.get("repo_path"))
+  raw_repo = plan.get("repo_path")
+  repo = _safe_repo_path(raw_repo)
+  recorded_repo = Path(raw_repo)
+  if not recorded_repo.is_absolute() or recorded_repo != repo:
+    return False
   data_dir = Path(get_settings().data_dir).resolve()
   roots = (data_dir / "contrib", data_dir / "contributions")
   if not any(repo.is_relative_to(root) for root in roots):
     return False
+  if not repo.exists():
+    return True
   marker = repo / ".git"
   if not marker.exists() or marker.is_symlink():
     return False
 
-  # A linked worktree has a .git *file*. Deleting its directory directly
-  # strands the registration and branch lock in the source repository. Ask Git
-  # to remove it instead, using the common directory as the stable owner even
-  # while the checkout itself disappears.
+  # Linked worktrees and separate-git-dir checkouts both use a .git file.
   if marker.is_file():
+    try:
+      marker_value = marker.read_text().strip()
+    except OSError:
+      return False
+    if not marker_value.startswith("gitdir:"):
+      return False
+    raw_git_dir = marker_value.removeprefix("gitdir:").strip()
+    if not raw_git_dir:
+      return False
+    marker_git_dir = Path(raw_git_dir)
+    if not marker_git_dir.is_absolute():
+      marker_git_dir = marker.parent / marker_git_dir
+    try:
+      marker_git_dir = marker_git_dir.resolve()
+    except (OSError, RuntimeError):
+      return False
+
+    separate_git_dir = (
+      marker_git_dir.name == "git" and marker_git_dir.parent == repo.parent
+    )
+    if separate_git_dir:
+      # Delete the Git directory first. If removing the checkout then fails,
+      # the next call sees its missing sibling and can finish idempotently.
+      if marker_git_dir.exists():
+        shutil.rmtree(marker_git_dir)
+      shutil.rmtree(repo)
+      return True
+
+    # Git can recycle a pruned worktree admin slot for a newer checkout. Every
+    # linked admin directory must still point back to this exact checkout.
+    back_reference = marker_git_dir / "gitdir"
+    owns_checkout = False
+    if back_reference.is_file() and not back_reference.is_symlink():
+      try:
+        registered_marker = Path(back_reference.read_text().strip())
+        if not registered_marker.is_absolute():
+          registered_marker = back_reference.parent / registered_marker
+        owns_checkout = registered_marker.resolve() == marker.resolve()
+      except (OSError, RuntimeError):
+        owns_checkout = False
+    if not owns_checkout:
+      shutil.rmtree(repo)
+      return True
+
+    common_pointer = marker_git_dir / "commondir"
+    if not common_pointer.is_file() or common_pointer.is_symlink():
+      return False
+    try:
+      raw_common_dir = common_pointer.read_text().strip()
+      if not raw_common_dir:
+        return False
+      common_dir = Path(raw_common_dir)
+      if not common_dir.is_absolute():
+        common_dir = common_pointer.parent / common_dir
+      common_dir = common_dir.resolve()
+    except (OSError, RuntimeError):
+      return False
+    common_roots = (
+      data_dir / "platform",
+      data_dir / "apps",
+      data_dir / "contrib",
+      data_dir / "contributions",
+    )
+    if not any(common_dir.is_relative_to(root) for root in common_roots):
+      return False
+
     env = dict(os.environ)
     for name in (
       "GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE",
       "GIT_OBJECT_DIRECTORY", "GIT_COMMON_DIR", "GIT_NAMESPACE",
     ):
       env.pop(name, None)
-    probe = subprocess.run(
+    removed = subprocess.run(
       [
-        "git", "-C", str(repo), "rev-parse", "--path-format=absolute",
-        "--git-dir", "--git-common-dir",
+        "git", f"--git-dir={common_dir}",
+        "worktree", "remove", "--force", str(repo),
       ],
-      cwd=str(repo.parent),
+      cwd=str(data_dir),
       capture_output=True,
       text=True,
       check=False,
       env=env,
     )
-    paths = [Path(line).resolve() for line in probe.stdout.splitlines() if line]
-    if probe.returncode != 0 or len(paths) != 2:
-      return False
-    git_dir, common_dir = paths
-    if not common_dir.is_relative_to(data_dir):
-      return False
-
-    if git_dir != common_dir:
-      removed = subprocess.run(
-        [
-          "git", f"--git-dir={common_dir}",
-          "worktree", "remove", "--force", str(repo),
-        ],
-        cwd=str(data_dir),
-        capture_output=True,
-        text=True,
-        check=False,
-        env=env,
+    if removed.returncode != 0:
+      raise ContributionSubmitError(
+        "Could not clear the old review checkout for this contribution.",
+        detail=readable_output(
+          removed.stderr or removed.stdout or "git worktree remove failed",
+        ),
       )
-      if removed.returncode != 0:
-        raise ContributionSubmitError(
-          "Could not clear the old review checkout for this contribution.",
-          detail=readable_output(
-            removed.stderr or removed.stdout or "git worktree remove failed",
-          ),
-        )
-      subprocess.run(
-        ["git", f"--git-dir={common_dir}", "worktree", "prune"],
-        cwd=str(data_dir),
-        capture_output=True,
-        text=True,
-        check=False,
-        env=env,
-      )
-      return True
-
-    # Manifest-installed apps use `--separate-git-dir=<record-root>/git`.
-    # That is a main checkout rather than a linked worktree, so remove both
-    # halves only when the git directory is the documented sibling.
-    shutil.rmtree(repo)
-    if common_dir.name == "git" and common_dir.parent == repo.parent:
-      shutil.rmtree(common_dir, ignore_errors=True)
     return True
 
   # Ordinary standalone clones keep a real .git directory inside the checkout.

--- a/backend/app/routes/github.py
+++ b/backend/app/routes/github.py
@@ -1704,11 +1704,32 @@ async def cleanup_contribution_staging(
     record = _read_record(record_path)
   plan = record.get("plan") if isinstance(record.get("plan"), dict) else {}
   repo = _safe_repo_path(plan.get("repo_path"))
-  equivalence_repos = _equivalence_source_repo(record)
+  try:
+    equivalence_repos = await asyncio.to_thread(
+      _equivalence_source_repo, record,
+    )
+  except Exception:
+    # Provenance is best-effort at this terminal boundary. A stale installed
+    # source must not retain a disposable checkout, but a valid linked
+    # worktree still needs its real owner lock while Git unregisters it.
+    try:
+      primary_repo = await asyncio.to_thread(
+        app_git.primary_worktree_path, repo,
+      )
+    except Exception:
+      primary_repo = None
+    lock_repo = primary_repo or repo
+  else:
+    lock_repo = equivalence_repos[0] if equivalence_repos else repo
   upstream_sha = None
   if record.get("status") == "merged":
-    upstream_sha = await asyncio.to_thread(_merged_upstream_sha, record, repo)
-  lock_repo = equivalence_repos[0] if equivalence_repos else repo
+    try:
+      upstream_sha = await asyncio.to_thread(_merged_upstream_sha, record, repo)
+    except Exception:
+      log.warning(
+        "terminal contribution upstream lookup failed %s/%s",
+        app_id, record_id, exc_info=True,
+      )
   async with fs_locks.source_dir_lock(str(lock_repo)):
     try:
       await asyncio.to_thread(_settle_equivalence, record, upstream_sha)

--- a/backend/tests/test_contribution_cleanup_route.py
+++ b/backend/tests/test_contribution_cleanup_route.py
@@ -1,0 +1,110 @@
+"""Focused route tests for terminal contribution staging disposal."""
+
+import json
+import subprocess
+from pathlib import Path
+
+from app import fs_locks
+from app.config import get_settings
+from app.storage_io import atomic_write
+from app.routes import github as github_routes
+from test_app_fixtures import create_local_app
+
+
+def _write_terminal_record(app_id: int, record_id: str, record: dict) -> None:
+  root = Path(get_settings().data_dir) / "apps" / str(app_id) / "contributions"
+  root.mkdir(parents=True, exist_ok=True)
+  atomic_write(root / f"{record_id}.json", json.dumps(record))
+
+
+def test_cleanup_uses_linked_owner_when_equivalence_source_is_missing(
+  client, auth, monkeypatch,
+):
+  app = create_local_app(client, auth, name="Cleanup route owner")
+  source = Path(app["source_dir"])
+  checkout = (
+    Path(get_settings().data_dir)
+    / "contrib"
+    / "cleanup-route-missing-source"
+    / "worktree"
+  )
+  checkout.parent.mkdir(parents=True)
+  subprocess.run(
+    [
+      "git", "-C", str(source), "worktree", "add", "-qb",
+      "test/cleanup-route-missing-source", str(checkout),
+    ],
+    check=True,
+  )
+
+  record_id = "cleanup-route-missing-source"
+  _write_terminal_record(app["id"], record_id, {
+    "id": record_id,
+    "status": "closed",
+    "plan": {
+      "repo_path": str(checkout),
+      "source_repo_path": str(
+        Path(get_settings().data_dir) / "apps" / "missing-source"
+      ),
+    },
+  })
+
+  locked = []
+  real_source_dir_lock = fs_locks.source_dir_lock
+
+  def tracking_source_dir_lock(path):
+    locked.append(Path(path).resolve())
+    return real_source_dir_lock(path)
+
+  monkeypatch.setattr(fs_locks, "source_dir_lock", tracking_source_dir_lock)
+  response = client.post(
+    f"/api/github/contributions/{app['id']}/{record_id}/cleanup-staging",
+    headers=auth,
+  )
+
+  assert response.status_code == 200, response.text
+  assert response.json() == {"cleaned": True}
+  assert locked == [source.resolve()]
+  assert not checkout.exists()
+  worktrees = subprocess.run(
+    ["git", "-C", str(source), "worktree", "list", "--porcelain"],
+    check=True,
+    capture_output=True,
+    text=True,
+  ).stdout
+  assert str(checkout) not in worktrees
+
+
+def test_cleanup_survives_merged_upstream_lookup_failure(
+  client, auth, monkeypatch,
+):
+  app = create_local_app(client, auth, name="Cleanup route merged")
+  checkout = (
+    Path(get_settings().data_dir)
+    / "contrib"
+    / "cleanup-route-upstream-failure"
+    / "repo"
+  )
+  (checkout / ".git").mkdir(parents=True)
+
+  record_id = "cleanup-route-upstream-failure"
+  _write_terminal_record(app["id"], record_id, {
+    "id": record_id,
+    "status": "merged",
+    "plan": {"repo_path": str(checkout)},
+  })
+
+  def fail_upstream_lookup(*_args):
+    raise RuntimeError("upstream unavailable")
+
+  monkeypatch.setattr(
+    github_routes, "_merged_upstream_sha", fail_upstream_lookup,
+  )
+  response = client.post(
+    f"/api/github/contributions/{app['id']}/{record_id}/cleanup-staging",
+    headers=auth,
+  )
+
+  assert response.status_code == 200, response.text
+  assert response.json() == {"cleaned": True}
+  assert not checkout.exists()

--- a/backend/tests/test_github_routes.py
+++ b/backend/tests/test_github_routes.py
@@ -16,6 +16,7 @@ import asyncio
 import hashlib
 import json
 import os
+import shutil
 import stat
 import subprocess
 import time
@@ -2592,7 +2593,135 @@ def test_cleanup_terminal_staging_checkout_unregisters_linked_worktree():
   assert str(checkout) not in listed
 
 
-def test_cleanup_terminal_staging_checkout_removes_separate_git_dir():
+def test_cleanup_terminal_staging_checkout_removes_stale_missing_admin():
+  from app.routes.github import _cleanup_terminal_staging_checkout
+
+  data_dir = Path(get_settings().data_dir)
+  checkout = data_dir / "contrib" / "terminal-cleanup-missing-admin" / "worktree"
+  missing_admin = data_dir / "contrib" / "missing-owner" / ".git" / "worktrees" / "worktree"
+  checkout.mkdir(parents=True)
+  (checkout / ".git").write_text(f"gitdir: {missing_admin}\n")
+  (checkout / "review.txt").write_text("stale\n")
+
+  record = {
+    "status": "closed",
+    "plan": {"repo_path": str(checkout)},
+  }
+  assert _cleanup_terminal_staging_checkout(record) is True
+  assert not checkout.exists()
+
+
+def test_cleanup_terminal_staging_checkout_preserves_recycled_worktree_slot():
+  from app.routes.github import _cleanup_terminal_staging_checkout
+
+  data_dir = Path(get_settings().data_dir)
+  owner = data_dir / "contrib" / "terminal-cleanup-recycled-owner"
+  stale = data_dir / "contrib" / "terminal-cleanup-recycled-old" / "worktree"
+  current = data_dir / "contrib" / "terminal-cleanup-recycled-new" / "worktree"
+  owner.mkdir(parents=True)
+  subprocess.run(["git", "init", "-qb", "main", str(owner)], check=True)
+  subprocess.run(["git", "-C", str(owner), "config", "user.name", "Test"], check=True)
+  subprocess.run(
+    ["git", "-C", str(owner), "config", "user.email", "test@example.invalid"],
+    check=True,
+  )
+  (owner / "tracked.txt").write_text("base\n")
+  subprocess.run(["git", "-C", str(owner), "add", "tracked.txt"], check=True)
+  subprocess.run(["git", "-C", str(owner), "commit", "-qm", "base"], check=True)
+
+  stale.parent.mkdir(parents=True)
+  subprocess.run(
+    ["git", "-C", str(owner), "worktree", "add", "-qb", "fix/stale", str(stale)],
+    check=True,
+  )
+  admin_dir = Path((stale / ".git").read_text().split(":", 1)[1].strip())
+  shutil.rmtree(admin_dir)
+
+  current.parent.mkdir(parents=True)
+  subprocess.run(
+    ["git", "-C", str(owner), "worktree", "add", "-qb", "fix/current", str(current)],
+    check=True,
+  )
+  assert Path((current / ".git").read_text().split(":", 1)[1].strip()) == admin_dir
+
+  record = {
+    "status": "merged",
+    "plan": {"repo_path": str(stale)},
+  }
+  assert _cleanup_terminal_staging_checkout(record) is True
+  assert not stale.exists()
+  assert current.exists()
+  assert (admin_dir / "gitdir").read_text().strip() == str(current / ".git")
+  listed = subprocess.run(
+    ["git", "-C", str(owner), "worktree", "list", "--porcelain"],
+    check=True,
+    capture_output=True,
+    text=True,
+  ).stdout
+  assert str(current) in listed
+
+
+def test_cleanup_terminal_staging_checkout_preserves_reciprocal_outside_owner():
+  from app.routes.github import _cleanup_terminal_staging_checkout
+
+  data_dir = Path(get_settings().data_dir)
+  checkout = data_dir / "contrib" / "terminal-cleanup-outside-owner" / "worktree"
+  admin_dir = data_dir / "shared" / "outside-owner-admin"
+  outside_owner = data_dir / "shared" / "outside-owner.git"
+  checkout.mkdir(parents=True)
+  admin_dir.mkdir(parents=True)
+  outside_owner.mkdir(parents=True)
+  (checkout / ".git").write_text(f"gitdir: {admin_dir}\n")
+  (admin_dir / "gitdir").write_text(f"{checkout / '.git'}\n")
+  (admin_dir / "commondir").write_text(f"{outside_owner}\n")
+  (outside_owner / "sentinel").write_text("keep\n")
+
+  record = {
+    "status": "closed",
+    "plan": {"repo_path": str(checkout)},
+  }
+  assert _cleanup_terminal_staging_checkout(record) is False
+  assert checkout.exists()
+  assert (outside_owner / "sentinel").read_text() == "keep\n"
+
+
+def test_cleanup_terminal_staging_checkout_rejects_repo_symlink_alias():
+  from app.routes.github import _cleanup_terminal_staging_checkout
+
+  data_dir = Path(get_settings().data_dir)
+  target = data_dir / "contrib" / "terminal-cleanup-alias-target" / "repo"
+  alias = data_dir / "contrib" / "terminal-cleanup-alias"
+  (target / ".git").mkdir(parents=True)
+  (target / "sentinel").write_text("keep\n")
+  alias.symlink_to(target)
+
+  record = {
+    "status": "closed",
+    "plan": {"repo_path": str(alias)},
+  }
+  assert _cleanup_terminal_staging_checkout(record) is False
+  assert alias.is_symlink()
+  assert (target / "sentinel").read_text() == "keep\n"
+
+
+def test_cleanup_terminal_staging_checkout_is_idempotent_after_removal():
+  from app.routes.github import _cleanup_terminal_staging_checkout
+
+  data_dir = Path(get_settings().data_dir)
+  checkout = data_dir / "contrib" / "terminal-cleanup-idempotent" / "repo"
+  (checkout / ".git").mkdir(parents=True)
+  record = {
+    "status": "abandoned",
+    "plan": {"repo_path": str(checkout)},
+  }
+
+  assert _cleanup_terminal_staging_checkout(record) is True
+  assert _cleanup_terminal_staging_checkout(record) is True
+
+
+def test_cleanup_terminal_staging_checkout_retries_separate_git_dir_partial_failure(
+  monkeypatch,
+):
   from app.routes.github import _cleanup_terminal_staging_checkout
 
   data_dir = Path(get_settings().data_dir)
@@ -2609,6 +2738,22 @@ def test_cleanup_terminal_staging_checkout_removes_separate_git_dir():
     "status": "closed",
     "plan": {"repo_path": str(checkout)},
   }
+  real_rmtree = shutil.rmtree
+  checkout_failed = False
+
+  def fail_checkout_once(path, *args, **kwargs):
+    nonlocal checkout_failed
+    if Path(path) == checkout and not checkout_failed:
+      checkout_failed = True
+      raise OSError("simulated checkout removal failure")
+    return real_rmtree(path, *args, **kwargs)
+
+  monkeypatch.setattr(shutil, "rmtree", fail_checkout_once)
+  with pytest.raises(OSError, match="simulated checkout removal failure"):
+    _cleanup_terminal_staging_checkout(record)
+  assert checkout.exists()
+  assert not git_dir.exists()
+
   assert _cleanup_terminal_staging_checkout(record) is True
   assert not checkout.exists()
   assert not git_dir.exists()


### PR DESCRIPTION
## Summary
- make terminal staging cleanup idempotent across linked worktrees, separate Git directories, and already-removed checkouts
- validate the recorded checkout and its Git ownership before deleting anything
- preserve cleanup progress when optional provenance or upstream lookups fail

## Testing
- `scripts/wt-pytest.sh backend/tests/test_contribution_cleanup_route.py backend/tests/test_github_routes.py -q` (147 passed)

Review pass: cleanup stays at the terminal staging boundary, validates ownership before destructive work, and keeps retries idempotent.