### PR TITLE
Persist final app skill reconciliation

### DIFF
--- a/backend/app/install.py
+++ b/backend/app/install.py
@@ -1301,14 +1301,14 @@ async def _sync_app_skills(
         sidecar_path,
         json.dumps(records, indent=2, sort_keys=True) + "\n",
       )
-    # Persist a drop-only reconciliation too (the per-file writes above cover
-    # every non-empty desired set).
-    if not skills:
-      skills_dir.mkdir(parents=True, exist_ok=True)
-      atomic_write(
-        sidecar_path,
-        json.dumps(records, indent=2, sort_keys=True) + "\n",
-      )
+    # Persist the final reconciliation too: a non-empty desired set can still
+    # skip every file, and removals above must not be retried forever. Keep the
+    # per-file writes for crash safety between successful materializations.
+    skills_dir.mkdir(parents=True, exist_ok=True)
+    atomic_write(
+      sidecar_path,
+      json.dumps(records, indent=2, sort_keys=True) + "\n",
+    )
     # The skill set changed (or may have) — refresh the generated tier-1 index
     # INSIDE the lock. Regenerating after release let a concurrent direct
     # install/uninstall's newer index be overwritten by this writer's stale

--- a/backend/tests/test_app_skills.py
+++ b/backend/tests/test_app_skills.py
@@ -403,6 +403,47 @@ def test_update_dropping_skill_retires_and_releases_record(
   assert retired.read_text() == SKILL_V1
 
 
+def test_dropped_skill_record_stays_released_when_remaining_skill_is_skipped(
+  client, auth, bypass_url_validation,
+):
+  first = _install(
+    client,
+    auth,
+    _skill_manifest(
+      skills=["contributing.md", "remaining.md"],
+      source_files=["contributing.md", "remaining.md"],
+    ),
+    {
+      "index.jsx": JSX,
+      "contributing.md": SKILL_V1,
+      "remaining.md": "# remaining v1\n",
+    },
+  )
+  assert first.status_code == 201, first.text
+
+  big = "x" * (256 * 1024 + 1)
+  update = _install(
+    client,
+    auth,
+    _skill_manifest(
+      version="2.0.0",
+      skills=["remaining.md"],
+      source_files=["remaining.md"],
+    ),
+    {"index.jsx": JSX, "remaining.md": big},
+  )
+
+  assert update.status_code == 201, update.text
+  assert any("remaining.md: exceeds" in w for w in update.json()["warnings"])
+  assert "contributing.md" not in _sidecar()
+  assert "remaining.md" in _sidecar()
+  retired = (
+    _skills_dir() / ".inactive" / str(first.json()["id"])
+    / "retired" / "contributing.md"
+  )
+  assert retired.read_text() == SKILL_V1
+
+
 def test_oversized_skill_is_skipped_with_warning(
   client, auth, bypass_url_validation,
 ):
@@ -415,7 +456,7 @@ def test_oversized_skill_is_skipped_with_warning(
     "contributing.md: exceeds" in w for w in r.json()["warnings"]
   ), r.json()["warnings"]
   assert not (_skills_dir() / "contributing.md").exists()
-  assert not (_skills_dir() / ".app-skills.json").exists()
+  assert _sidecar() == {}
 
 
 # --- clone path: skills read from the FINAL on-disk tree --------------------


### PR DESCRIPTION
## Summary
- always persist the final app-skill ownership ledger after reconciliation
- keep crash-safe per-file checkpoints while ensuring skipped files and removals do not leave stale ownership behind
- cover a dropped skill paired with an oversized remaining skill

## Testing
- `scripts/wt-pytest.sh backend/tests/test_app_skills.py -q` (29 passed)

Review pass: this keeps ownership at the existing reconciliation boundary and adds no parallel state path.