### PR TITLE
Keep Reflection evidence run-scoped

### DIFF
--- a/backend/scripts/reflection-brief-template.html
+++ b/backend/scripts/reflection-brief-template.html
@@ -545,7 +545,7 @@
   <!-- ===================== §2 What I did ===================== -->
   <section id="did" aria-labelledby="did-h">
     <div class="sec-head"><span class="sec-num">2</span><h2 id="did-h">What I did</h2></div>
-    <p class="sec-sub">Changes already applied — conservative, reversible, each committed.</p>
+    <p class="sec-sub">Verified outcomes from tonight’s work.</p>
     <div class="items">
       <!-- repeatable collapsed item; badge: done | fixed. The summary is the
            ONE-line headline; lead + triad live inside. Never author `open`. -->
@@ -565,7 +565,7 @@
   <!-- ===================== §3 What I learned ===================== -->
   <section id="learned" aria-labelledby="learned-h">
     <div class="sec-head"><span class="sec-num">3</span><h2 id="learned-h">What I learned</h2></div>
-    <p class="sec-sub">From interviewing the agents that worked, from your usage, and from a little research on what you follow.</p>
+    <p class="sec-sub">From verified evidence, direct review, and focused research.</p>
     <div class="items">
       <!-- repeatable collapsed item; badge: learn -->
       <details class="item">
@@ -591,21 +591,6 @@
   <section id="details" aria-labelledby="details-h">
     <div class="sec-head"><span class="sec-num">5</span><h2 id="details-h">Details</h2></div>
     <p class="sec-sub">The receipts — for when you want them. Safe to skip.</p>
-
-    <!-- Each receipts group is itself collapsed by default. -->
-    <details class="detail-group">
-      <summary>Run ledger</summary>
-      <ul class="ledger">
-        <!-- repeatable -->
-        <li><span class="label">{{LEDGER_LABEL_1}}</span><span class="val">{{LEDGER_VAL_1}}</span></li>
-        <li><span class="label">Chats &amp; subagent runs interviewed</span><span class="val">{{N_INTERVIEWED}}</span></li>
-        <li><span class="label">Skills improved</span><span class="val">{{N_SKILLS}}</span></li>
-        <li><span class="label">Memory: notes merged / pruned / added</span><span class="val">{{N_MEMORY}}</span></li>
-        <li><span class="label">App fixes applied</span><span class="val">{{N_APPFIX}}</span></li>
-        <li><span class="label">Security findings (surfaced)</span><span class="val">{{N_SEC}}</span></li>
-        <!-- /repeatable -->
-      </ul>
-    </details>
 
     <details class="detail-group">
       <summary>Commits</summary>

--- a/backend/scripts/seed-skills/manager-session-evidence.py
+++ b/backend/scripts/seed-skills/manager-session-evidence.py
@@ -25,6 +25,7 @@ import urllib.request
 DB_PATH = "/data/db/ultimate.db"
 MEM_STATE = "/data/shared/memory/app-state"
 MEM_RUN_STATUS = os.path.join(MEM_STATE, "run-status.json")
+MEM_RUN_LOG = os.path.join(MEM_STATE, "run-log")
 MEM_UPDATE_LOG = os.path.join(MEM_STATE, "update-log")
 MEM_READ_TRACE = os.path.join(MEM_STATE, "read-trace")
 MEM_RECALL_STATS = os.path.join(MEM_STATE, "recall-stats.json")
@@ -114,13 +115,6 @@ def parse_ts(value):
         return None
 
 
-def nonzero_exit(value):
-    try:
-        return int(value) != 0
-    except (TypeError, ValueError):
-        return True
-
-
 def short(text, width=64):
     text = " ".join(str(text or "").split())
     return text if len(text) <= width else text[: width - 1] + "…"
@@ -188,8 +182,9 @@ def section_memory(limit):
         dur = f"{(finished - started).total_seconds():.0f}s" if started and finished else "?"
         topo = (status.get("topology") or {})
         before, after = topo.get("before") or {}, topo.get("after") or {}
-        print(f"  status={status.get('status','?')}  model={status.get('model','?')}  "
-              f"provider={status.get('provider','?')}  new_commit={status.get('new_commit')}")
+        print(f"  run_id={status.get('run_id','?')}  status={status.get('status','?')}  "
+              f"model={status.get('model','?')}  provider={status.get('provider','?')}  "
+              f"new_commit={status.get('new_commit')}")
         print(f"  last run: started {status.get('started_at','?')}  ({dur})")
         if after:
             dn = _delta(after.get("nodes"), before.get("nodes"))
@@ -198,24 +193,13 @@ def section_memory(limit):
                   f"{after.get('edges','?')} edges ({de}) / {after.get('problems','?')} problems")
     if supervisor:
         print(
-            f"  supervisor: exit={supervisor.get('exit_code','?')}  "
+            "  outer scheduler receipt (not run-id linked): "
+            f"exit={supervisor.get('exit_code','?')}  "
             f"at={supervisor.get('ts','?')}  job={supervisor.get('job','?')}"
         )
-        status_at = parse_ts(
-            (status or {}).get("finished_at") or (status or {}).get("started_at")
-        )
-        supervisor_at = parse_ts(supervisor.get("ts"))
-        if (
-            supervisor_at
-            and (status_at is None or supervisor_at > status_at)
-            and nonzero_exit(supervisor.get("exit_code"))
-        ):
-            print(
-                "  WARNING: the latest scheduled attempt failed after the "
-                "current run-status; do not report Memory healthy."
-            )
     elif app:
-        print("  supervisor: (no canonical outcome recorded in the last 7 days)")
+        print("  outer scheduler receipt: (none recorded in the last 7 days)")
+    if status:
         queued = status.get("queued_chat_count")
         sourced = status.get("source_chat_count")
         starved = status.get("chat_input_starved")
@@ -239,7 +223,8 @@ def section_memory(limit):
     for e in entries:
         counts = e.get("counts") or {}
         ts = (e.get("timestamp") or "")[:16]
-        print(f"    {ts or '?':16}  changed={len(e.get('changed_paths') or [])}  "
+        print(f"    {ts or '?':16}  run={short(e.get('run_id'), 8):8}  "
+              f"changed={len(e.get('changed_paths') or [])}  "
               f"deleted={len(e.get('deleted_paths') or [])}  "
               f"problems={counts.get('problems','?')}  "
               f"followups={len(e.get('followups') or [])}  status={e.get('status','?')}")
@@ -303,6 +288,35 @@ def _read_json(path):
         return value if isinstance(value, dict) else None
     except (OSError, ValueError):
         return None
+
+
+def _memory_run_for_id(run_id):
+    """Return the terminal Memory receipt for one exact run identity."""
+    if not run_id or not os.path.isdir(MEM_RUN_LOG):
+        return None
+    for name in sorted(os.listdir(MEM_RUN_LOG), reverse=True):
+        if not name.endswith(".jsonl"):
+            continue
+        try:
+            with open(os.path.join(MEM_RUN_LOG, name)) as fh:
+                terminal = None
+                for line in fh:
+                    try:
+                        row = json.loads(line)
+                    except ValueError:
+                        continue
+                    if (
+                        isinstance(row, dict)
+                        and row.get("run_id") == run_id
+                        and row.get("status")
+                        in {"published", "failed", "degraded", "abandoned"}
+                    ):
+                        terminal = row
+        except OSError:
+            continue
+        if terminal is not None:
+            return terminal
+    return None
 
 
 def _read_text(path, limit=80_000):
@@ -394,11 +408,14 @@ def section_memory_writer_packet():
     outcome = outcomes[-1]
     run_id = outcome.get("run_id")
     audits = _recall_audits_for_run(run_id)
-    status = _read_json(MEM_RUN_STATUS)
-    app = installed_app("memory")
-    supervisor = (
-        latest_cron_outcome(app.get("id")) if isinstance(app, dict) else None
-    )
+    current_status = _read_json(MEM_RUN_STATUS)
+    status = _memory_run_for_id(run_id)
+    if (
+        status is None
+        and isinstance(current_status, dict)
+        and current_status.get("run_id") == run_id
+    ):
+        status = current_status
     skill = _read_text(MEMORY_SKILL)
     prompt_builder = _function_source(MEMORY_RUNNER, "_proposal_prompt")
 
@@ -410,13 +427,11 @@ def section_memory_writer_packet():
         print("  testimony=native writer self-review captured during the run")
     else:
         print("  testimony=unavailable; any later interview is a stateless reconstruction")
-    if status and status.get("run_id") != run_id:
+    if current_status and current_status.get("run_id") != run_id:
         print("  WARNING: current run-status belongs to a different run; "
               "the outcome below is the latest published writer outcome.")
-    print("\nLATEST RUN STATUS (operational input):")
+    print("\nMATCHED TERMINAL RUN RECEIPT:")
     print(json.dumps(status or {}, ensure_ascii=False, indent=2, sort_keys=True))
-    print("\nLATEST SUPERVISOR OUTCOME:")
-    print(json.dumps(supervisor or {}, ensure_ascii=False, indent=2, sort_keys=True))
     print("\nNATIVE WRITER SELF-REVIEWS:")
     print(json.dumps(native, ensure_ascii=False, indent=2, sort_keys=True))
     print("\nLATEST WRITER OUTCOME:")

--- a/backend/scripts/seed-skills/reflection.md
+++ b/backend/scripts/seed-skills/reflection.md
@@ -177,7 +177,7 @@ The directory name is the cwd with `/` → `-` (e.g. `-data-apps-news-2` == `/da
 - Chats: `/data/apps/reflection/fork-chat.sh <chat_id> "<interview>"` (runtime wrapper around the platform script; looks up provider + session, forks a throwaway copy, prints the answer to stdout). The original transcript is never modified.
 - App subagent runs: `bash "$SCRIPTS_DIR/fork-session.sh" <session_id> <cwd> "<interview>"`.
 
-**Time-box each fork, and fall back to the transcript when it comes back empty.** The Bash tool's default wall is shorter than the inner interview timeout, so the outer tool can kill the call first and leave an empty file. Two fixes, use both: pass the Bash `timeout` param explicitly (e.g. `timeout: 170000`) AND set the inner shell timeout just below it (`timeout 150`), so the inner one wins and you capture partial output instead of nothing. Codex forks are slow to first token — even a *small* (<50k) codex chat can blow past 120s, so don't assume "small = fast"; budget the higher Bash timeout for any codex fork. A chat over ~150k chars (check `length(messages)` in the phase-1 triage query) will strain the timeout — but these giants usually hold the richest struggle-testimony, and the resumed agent already carries its own context (you pay resume latency, not a re-read), so do NOT reflexively skip them. Fork the single highest-struggle giant of the night with an explicit long budget (Bash `timeout: 300000`, inner `timeout 280`) and a tightly scoped prompt. Use the DB messages-tail synthesis (last ~5 messages, role + truncated text) only for the OTHER giants, and whenever that long fork still fails. Long chats run past the harness limit and return nothing; a `claude --resume` of an aged-off session jsonl exits 0 with *no output at all* (Claude Code prunes jsonls aggressively). After a fork, **validate the body, not just the size** (`[ -s <out> ]` catches only an empty file): treat the interview as FAILED if the output is empty, under ~200 chars, matches a provider-error signature (spend/usage limit, rate limit, closed stdout, auth/credits), or lacks the structure you asked for. On FAILED, read the chat's `messages` JSON straight from the DB and synthesize from its tail — AND state plainly in the run notes and the brief that the interview did not complete, so its facts stay flagged as unverified. A non-empty error string is NOT testimony. Forks are a convenience; the transcript is always there.
+**Time-box each fork, and fall back to the transcript when it comes back empty.** The Bash tool's default wall is shorter than the inner interview timeout, so the outer tool can kill the call first and leave an empty file. Two fixes, use both: pass the Bash `timeout` param explicitly (e.g. `timeout: 170000`) AND set the inner shell timeout just below it (`timeout 150`), so the inner one wins and you capture partial output instead of nothing. Codex forks are slow to first token — even a *small* (<50k) codex chat can blow past 120s, so don't assume "small = fast"; budget the higher Bash timeout for any codex fork. A chat over ~150k chars (check `length(messages)` in the phase-1 triage query) will strain the timeout — but these giants usually hold the richest struggle-testimony, and the resumed agent already carries its own context (you pay resume latency, not a re-read), so do NOT reflexively skip them. Fork the single highest-struggle giant of the night with an explicit long budget (Bash `timeout: 300000`, inner `timeout 280`) and a tightly scoped prompt. Use the DB messages-tail synthesis (last ~5 messages, role + truncated text) only for the OTHER giants, and whenever that long fork still fails. Long chats run past the harness limit and return nothing; a `claude --resume` of an aged-off session jsonl exits 0 with *no output at all* (Claude Code prunes jsonls aggressively). After a fork, **validate the body, not just the size** (`[ -s <out> ]` catches only an empty file): treat the interview as FAILED if the output is empty, under ~200 chars, matches a provider-error signature (spend/usage limit, rate limit, closed stdout, auth/credits), or lacks the structure you asked for. On FAILED, read the chat's `messages` JSON straight from the DB and synthesize from its tail — AND state plainly in the run notes and the brief that the interview did not complete, so its facts stay flagged as unverified. **A transcript or tail synthesis is an evidence review, never an interview; do not count or label it as one.** A non-empty error string is NOT testimony. Forks are a convenience; the transcript is always there.
 
 **What to ask** (specialize per chat — read what the agent actually did first, then ask about *that*; a generic template gets shallow answers):
 
@@ -223,15 +223,18 @@ Memory alone.
 
 Read, in this order:
 
-1. Run `python3 /data/shared/skills/manager-session-evidence.py --limit 3`.
-   Its Memory section joins the app's own run-status to the platform
-   supervisor's canonical scheduled-job outcome. **The newer timestamp wins:**
-   if a failed supervisor outcome is newer than the run-status, Memory is
-   failed/not assessed, never healthy because yesterday's status file remains.
-2. `/data/shared/memory/app-state/update-log/*.jsonl` — only for completed
-   consolidations that match the latest operational evidence. Prefer the latest
-   few files; an old publication is history, not proof that tonight ran.
-3. The interviews' Memory answers from phase 1 — complaints about missing,
+1. Read `inputs/memory-health.json`. `last_run` is the newest state and may be
+   running; `latest_terminal_run`, when present, is the completed outcome to
+   assess. On an older handoff without that field, use `last_run` only when it
+   is terminal. Report a newer running attempt separately rather than treating
+   the completed run as unavailable.
+2. Run `python3 /data/shared/skills/manager-session-evidence.py --limit 3` and
+   match provider, queue, update-log, and supervisor claims by `run_id`. Never
+   combine the current attempt with an earlier publication. If a supervisor
+   receipt has no `run_id`, treat it only as separate scheduling evidence.
+3. `/data/shared/memory/app-state/update-log/*.jsonl` — only for a completed
+   publication whose `run_id` matches the terminal operational evidence.
+4. The interviews' Memory answers from phase 1 — complaints about missing,
    stale, misleading, or over-broad recall.
 
 When a recent Memory consolidation completed, review its **native writer
@@ -402,7 +405,9 @@ Then, for the apps the digest + interviews confirm the partner actually uses:
 
 Commit each `/data` fix on its own: `pm-commit --from <sha-before-edit> 'app(<slug>): <what and why>' -- <exact paths>`.
 
-Keep the brief current as the run progresses rather than deferring the whole deliverable until the end. A partial night that shipped a clear brief beats a "complete" night that produced no report; state honestly what remains unfinished.
+Complete mandatory gates before optional work. The app-owned operating
+contract owns finalization order; if time is short, stop optional work early so
+a truthful partial brief still ships.
 
 ### 5. RESEARCH tailored to the partner's known interests
 
@@ -520,7 +525,7 @@ Append ONE carrier as a sibling AFTER `</article>` (or after your brief's root e
 </section>
 ```
 
-The `questions` array is the EXACT shell QuestionCard shape: `{question, header, multiSelect, options:[{label, description}]}`. Questions are **optional and zero is the default, not merely an allowed edge case**: ship a card only when a real decision blocks a better next step and a safe reversible default is not good enough. Several cards should be rare. Never ask for general engagement, invent a question to fill the section, or repeat a low-stakes question just because it went unanswered. `header` is a 1–2 word category; set `multiSelect` only when more than one answer makes sense. The JSON must be valid — a malformed carrier is silently dropped, so the brief still ships. **Say plainly in the brief that these guide tomorrow night, not tonight** — there is no live agent waiting, so don't write "answer below and I'll act now." When the partner taps an answer, the app saves it to `question-answers/<date>.json`; your **next run's** `fetch.sh` stages it at `inputs/prev-question-answers.json` and you act on it in phase 2.
+The `questions` array is the EXACT shell QuestionCard shape: `{question, header, multiSelect, options:[{label, description}]}`. Questions are **optional and zero is the default, not merely an allowed edge case**: ship a card only when a real decision blocks a better next step and a safe reversible default is not good enough. Several cards should be rare. Never ask for general engagement, invent a question to fill the section, or repeat a low-stakes question just because it went unanswered. `header` is a 1–2 word category; follow the app-owned operating contract for `multiSelect` semantics. The JSON must be valid — a malformed carrier is silently dropped, so the brief still ships. **Say plainly in the brief that these guide tomorrow night, not tonight** — there is no live agent waiting, so don't write "answer below and I'll act now." When the partner taps an answer, the app saves it to `question-answers/<date>.json`; your **next run's** `fetch.sh` stages it at `inputs/prev-question-answers.json` and you act on it in phase 2.
 
 **Treat unanswered questions as channel evidence, not answers.** No tap is not "no," but repeated non-response means this channel is currently low-yield. Carry a still-essential question at most once; otherwise retire it without inferring a preference, choose the safest reversible default where one exists, and keep delivering value without waiting. Ask fewer, sharper questions in later briefs and record the engagement lesson in this skill or the resource decision ledger as appropriate. Answering is optional and never a gate, and open cards must never become homework or a backlog.
 

--- a/backend/tests/test_manager_session_evidence.py
+++ b/backend/tests/test_manager_session_evidence.py
@@ -36,7 +36,7 @@ class ManagerSessionEvidenceTests(unittest.TestCase):
     self.assertIn("complete=0", output.getvalue())
     self.assertIn("legacy=7", output.getvalue())
 
-  def test_memory_section_never_calls_stale_status_healthy_after_newer_failure(self):
+  def test_memory_section_keeps_unmatched_scheduler_receipt_separate(self):
     with tempfile.TemporaryDirectory() as raw:
       root = Path(raw)
       status = root / "run-status.json"
@@ -69,8 +69,27 @@ class ManagerSessionEvidenceTests(unittest.TestCase):
       ):
         manager_evidence.section_memory(3)
 
-    self.assertIn("supervisor: exit=4", output.getvalue())
-    self.assertIn("do not report Memory healthy", output.getvalue())
+    rendered = output.getvalue()
+    self.assertIn("outer scheduler receipt (not run-id linked): exit=4", rendered)
+    self.assertNotIn("do not report Memory healthy", rendered)
+
+  def test_memory_run_lookup_returns_last_terminal_receipt_for_exact_run(self):
+    with tempfile.TemporaryDirectory() as raw:
+      run_log = Path(raw)
+      (run_log / "2026-07-20.jsonl").write_text("\n".join([
+        "not-json",
+        json.dumps({"run_id": "target", "status": "running"}),
+        json.dumps({"run_id": "other", "status": "failed"}),
+        json.dumps({"run_id": "target", "status": "published", "seq": 1}),
+        json.dumps({"run_id": "target", "status": "abandoned", "seq": 2}),
+      ]) + "\n")
+      with mock.patch.object(manager_evidence, "MEM_RUN_LOG", str(run_log)):
+        receipt = manager_evidence._memory_run_for_id("target")
+        missing = manager_evidence._memory_run_for_id("missing")
+
+    self.assertEqual(receipt["status"], "abandoned")
+    self.assertEqual(receipt["seq"], 2)
+    self.assertIsNone(missing)
 
   def test_reflection_section_marks_metric_backed_run_without_interview(self):
     with tempfile.TemporaryDirectory() as raw:
@@ -167,7 +186,6 @@ class ManagerSessionEvidenceTests(unittest.TestCase):
       mock.patch.object(manager_evidence, "_read_update_log", return_value=[outcome]),
       mock.patch.object(manager_evidence, "_recall_audits_for_run", return_value=[]),
       mock.patch.object(manager_evidence, "_read_json", return_value={"run_id": "run-1"}),
-      mock.patch.object(manager_evidence, "installed_app", return_value=None),
       mock.patch.object(manager_evidence, "_read_text", return_value="skill"),
       mock.patch.object(manager_evidence, "_function_source", return_value="prompt"),
       mock.patch.object(manager_evidence, "_applied_memory_diff", return_value="diff"),
@@ -177,6 +195,47 @@ class ManagerSessionEvidenceTests(unittest.TestCase):
 
     self.assertIn("testimony=native writer self-review", output.getvalue())
     self.assertIn("Which route to shorten", output.getvalue())
+
+  def test_writer_packet_never_mixes_current_status_into_prior_outcome(self):
+    output = io.StringIO()
+    outcome = {"run_id": "published-run", "status": "published"}
+    historical = {
+      "run_id": "published-run",
+      "provider_summary": [{
+        "provider": "codex", "model": "historical",
+        "accepted": 5, "considered": 5, "failures": {},
+      }],
+      "pending_chat_count": 12,
+      "queued_chat_count": 40,
+      "deferred_chat_count": 2,
+    }
+    current = {
+      "run_id": "current-run",
+      "provider_summary": [{
+        "provider": "claude", "model": "current",
+        "accepted": 1, "considered": 9, "failures": {"invalid": 8},
+      }],
+      "pending_chat_count": 999,
+      "queued_chat_count": 100,
+      "deferred_chat_count": 90,
+    }
+    with (
+      mock.patch.object(manager_evidence, "_read_update_log", return_value=[outcome]),
+      mock.patch.object(manager_evidence, "_recall_audits_for_run", return_value=[]),
+      mock.patch.object(manager_evidence, "_read_json", return_value=current),
+      mock.patch.object(manager_evidence, "_memory_run_for_id", return_value=historical),
+      mock.patch.object(manager_evidence, "_read_text", return_value="skill"),
+      mock.patch.object(manager_evidence, "_function_source", return_value="prompt"),
+      contextlib.redirect_stdout(output),
+    ):
+      manager_evidence.section_memory_writer_packet()
+
+    rendered = output.getvalue()
+    self.assertIn('"provider": "codex"', rendered)
+    self.assertIn('"model": "historical"', rendered)
+    self.assertIn('"pending_chat_count": 12', rendered)
+    self.assertNotIn('"provider": "claude"', rendered)
+    self.assertNotIn('"pending_chat_count": 999', rendered)
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_reflection_brief_template.py
+++ b/backend/tests/test_reflection_brief_template.py
@@ -14,3 +14,15 @@ def test_default_reflection_brief_has_no_placeholder_question_carrier():
   assert "data-report-questions" not in template
   assert "{{QUESTION_" not in template
   assert "{{INPUT_" not in template
+
+
+def test_default_reflection_brief_has_no_unverified_run_ledger():
+  template = (
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "reflection-brief-template.html"
+  ).read_text(encoding="utf-8")
+
+  assert "Run ledger" not in template
+  assert "{{N_INTERVIEWED}}" not in template
+  assert "From verified evidence" in template


### PR DESCRIPTION
## Summary
- match Memory operational evidence by exact run identity instead of combining unrelated scheduler receipts and current status
- distinguish completed terminal outcomes from newer in-progress attempts
- make Reflection’s brief template and operating guidance claim only verified outcomes

## Testing
- `scripts/wt-pytest.sh backend/tests/test_manager_session_evidence.py backend/tests/test_reflection_brief_template.py -q` (9 passed)

Review pass: the evidence helper now has one run-scoped truth boundary; unlinked scheduler receipts remain visible but cannot silently override or validate another run.