### PR TITLE
Remove redundant viewport mode writes

### DIFF
--- a/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
+++ b/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
@@ -727,8 +727,13 @@ test('anchor reapply is inert for non-anchor modes and unresolved keys', () => {
 test('viewport resize reapplies the current mode without reclassifying it', () => {
   assert.match(
     scrollModeSource,
-    /transitionMode\(\s*modeRef\.current,\s*'layout:viewport-change'/,
+    /applyLayoutMode\('layout:viewport-change', authorityVersion\)/,
     'keyboard geometry keeps the existing pin, follow, or exact anchor',
+  )
+  assert.doesNotMatch(
+    scrollModeSource,
+    /transitionMode\(\s*modeRef\.current,\s*'layout:viewport-change'/,
+    'geometry must not manufacture a semantic no-op transition',
   )
   assert.doesNotMatch(
     scrollModeSource,

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -1935,6 +1935,7 @@ export default function useScrollMode({
         )
         if (released !== modeRef.current) {
           transitionMode(released, 'layout:question-viewport-release')
+          persistMode()
         }
       }
       // Releasing the submitted-question overlay is a semantic state change,
@@ -1950,11 +1951,6 @@ export default function useScrollMode({
         // A viewport resize is geometry, not reading intent. Reapply the mode
         // that already owns the chat instead of deriving a different mode from
         // the browser's intermediate clamp.
-        transitionMode(
-          modeRef.current,
-          'layout:viewport-change',
-        )
-        persistMode()
         applyLayoutMode('layout:viewport-change', authorityVersion)
       } else if (forceApply) {
         writeMode(


### PR DESCRIPTION
## Summary
- treat viewport resizing as geometry reapplication rather than a semantic mode transition
- persist the actual question-overlay release at its owning transition
- guard against reintroducing resize-driven no-op mode writes

## Testing
- `npm test` in `frontend` (full unit and hook suites passed)

Review pass: semantic state persists only at the semantic transition; resize remains an ordinary layout update with no duplicate write path.