### PR TITLE
Release agent scratch after physical turn completion

### DIFF
--- a/backend/app/agent_scratch.py
+++ b/backend/app/agent_scratch.py
@@ -15,17 +15,19 @@ sits beside in the runner. A chat with no run in flight cannot be using its
 scratch, so that is the deletion rule.
 """
 
+import asyncio
 import logging
 import re
 import shutil
 import time
+import uuid
 from pathlib import Path
 
-from sqlalchemy import select
-from sqlalchemy.orm import Session
-
-from app import models
+from app.browser_profiles import browser_session_targets_for_chat
 from app.config import agent_scratch_root
+from app.database import SessionLocal
+from app.run_state import has_running_run
+from app.runner_registry import registry
 
 log = logging.getLogger(__name__)
 
@@ -34,6 +36,9 @@ log = logging.getLogger(__name__)
 # by one starting run could delete the scratch of another that had not yet
 # registered. Comfortably longer than that gap, far shorter than a turn.
 _SWEEP_GRACE_SECONDS = 15 * 60
+_RELEASED_DIR = re.compile(
+  r"^\.[A-Za-z0-9_-]+\.released-[0-9a-f]{32}$"
+)
 
 
 def _dir_name(chat_id: str) -> str:
@@ -47,7 +52,76 @@ def scratch_for_chat(chat_id: str) -> Path:
   return path
 
 
-def sweep_idle_scratch(db: Session, *, now: float | None = None) -> dict:
+def _detach_if_idle(chat_id: str) -> Path | None:
+  """Atomically release one canonical scratch name if no run owns it.
+
+  The caller holds the per-chat queue lock. There must be no await between
+  the in-memory starting check, durable running check, and rename: programmatic
+  starts claim the registry before their ChatRun row exists and rely on that
+  uninterrupted sequence rather than taking the queue lock themselves.
+  """
+  if not chat_id or registry.is_alive(chat_id):
+    return None
+  with SessionLocal() as db:
+    if has_running_run(db, chat_id):
+      return None
+  browser_scan = browser_session_targets_for_chat(chat_id)
+  if not browser_scan.complete or browser_scan.targets:
+    return None
+
+  path = agent_scratch_root() / _dir_name(chat_id)
+  if not path.is_dir():
+    return None
+  detached = path.with_name(f".{path.name}.released-{uuid.uuid4().hex}")
+  try:
+    path.rename(detached)
+  except OSError as exc:
+    log.warning("agent scratch release skipped %s: %s", path.name, exc)
+    return None
+  return detached
+
+
+def _reclaim_detached(path: Path) -> int:
+  size = 0
+  for candidate in path.rglob("*"):
+    try:
+      if candidate.is_file() and not candidate.is_symlink():
+        size += candidate.stat().st_size
+    except OSError:
+      pass
+  shutil.rmtree(path)
+  return size
+
+
+async def release_if_idle(chat_id: str) -> int | None:
+  """Delete one chat's scratch when no physical run is in flight.
+
+  Claiming is serialized with the per-chat run-start boundary. Before slow
+  deletion begins, the directory is atomically detached from its canonical
+  name, so cancellation can safely release the lock while the worker finishes
+  and a successor recreates scratch. Returns reclaimed bytes, including zero
+  for an empty released directory, or ``None`` when a live owner kept it.
+  """
+  if not chat_id:
+    return None
+  from app.chat_queue import get_lock
+
+  async with get_lock(chat_id):
+    detached = _detach_if_idle(chat_id)
+  if detached is None:
+    return None
+  try:
+    return await asyncio.to_thread(_reclaim_detached, detached)
+  except asyncio.CancelledError:
+    raise
+  except OSError as exc:
+    # The canonical name is already free for the next run. The hourly sweep
+    # owns physical recovery of a detached directory that could not be removed.
+    log.warning("detached agent scratch cleanup skipped %s: %s", detached, exc)
+    return None
+
+
+async def sweep_idle_scratch(*, now: float | None = None) -> dict:
   """Delete scratch belonging to chats with no run still in flight.
 
   Returns a summary so the runtime retention supervisor can report what it
@@ -56,45 +130,42 @@ def sweep_idle_scratch(db: Session, *, now: float | None = None) -> dict:
   """
   root = agent_scratch_root()
   if not root.is_dir():
-    return {"removed": 0, "bytes": 0, "kept_live": 0, "kept_recent": 0}
+    return {"removed": 0, "bytes": 0, "kept_recent": 0}
 
-  live = {
-    _dir_name(chat_id)
-    for chat_id in db.scalars(
-      select(models.ChatRun.chat_id).where(
-        models.ChatRun.status.in_(models.NONTERMINAL_RUN_STATUSES)
-      )
-    ).all()
-  }
   cutoff = (time.time() if now is None else now) - _SWEEP_GRACE_SECONDS
-  removed = reclaimed = kept_live = kept_recent = 0
+  removed = reclaimed = kept_recent = 0
 
-  for entry in root.iterdir():
+  for entry in list(root.iterdir()):
     if not entry.is_dir():
       continue
-    if entry.name in live:
-      kept_live += 1
+    if _RELEASED_DIR.fullmatch(entry.name):
+      try:
+        reclaimed += await asyncio.to_thread(_reclaim_detached, entry)
+      except OSError as exc:
+        log.warning("detached agent scratch sweep skipped %s: %s", entry, exc)
+        continue
+      removed += 1
       continue
     try:
       if entry.stat().st_mtime > cutoff:
         kept_recent += 1
         continue
-      size = sum(f.stat().st_size for f in entry.rglob("*") if f.is_file())
-      shutil.rmtree(entry)
     except OSError as exc:
       log.warning("agent scratch sweep skipped %s: %s", entry.name, exc)
+      continue
+    size = await release_if_idle(entry.name)
+    if size is None:
       continue
     removed += 1
     reclaimed += size
 
   if removed:
     log.info(
-      "agent scratch swept dirs=%d bytes=%d kept_live=%d kept_recent=%d",
-      removed, reclaimed, kept_live, kept_recent,
+      "agent scratch swept dirs=%d bytes=%d kept_recent=%d",
+      removed, reclaimed, kept_recent,
     )
   return {
     "removed": removed,
     "bytes": reclaimed,
-    "kept_live": kept_live,
     "kept_recent": kept_recent,
   }

--- a/backend/app/browser_profiles.py
+++ b/backend/app/browser_profiles.py
@@ -56,6 +56,14 @@ class BrowserSessionTarget:
   socket_dir: str | None = None
 
 
+@dataclass(frozen=True)
+class BrowserSessionScan:
+  """Exact targets plus whether process discovery was complete."""
+
+  targets: frozenset[BrowserSessionTarget]
+  complete: bool
+
+
 def _env_int(name: str, default: int) -> int:
   try:
     value = int(os.environ.get(name, str(default)))
@@ -155,7 +163,7 @@ def browser_session_targets_for_chat(
   chat_id: str,
   *,
   proc_root: Path = Path("/proc"),
-) -> set[BrowserSessionTarget]:
+) -> BrowserSessionScan:
   """Return live agent-browser routing targets created by one chat.
 
   ``AGENT_BROWSER_SESSION=chat-<id>`` gives ordinary invocations a safe
@@ -169,17 +177,20 @@ def browser_session_targets_for_chat(
   Routing values are opaque. agent-browser accepts values that look like paths
   or options; cleanup passes them only through a child environment (never a
   shell, CLI option value, or path operation), matching the daemon exactly.
-  Only the agent-browser server binary is considered. Proc races and permission
-  errors are normal and read as an incomplete, best-effort set.
+  Only the agent-browser server binary is considered. A process disappearing
+  during the scan cannot remain a live target and is safe to ignore; any other
+  unreadable process makes the result incomplete so destructive callers can
+  preserve scratch rather than mistaking uncertainty for an empty inventory.
   """
   if not chat_id or not proc_root.is_dir():
-    return set()
+    return BrowserSessionScan(frozenset(), False)
   try:
     processes = list(proc_root.iterdir())
   except OSError:
-    return set()
+    return BrowserSessionScan(frozenset(), False)
 
   targets: set[BrowserSessionTarget] = set()
+  complete = True
   for process in processes:
     if not process.name.isdigit():
       continue
@@ -198,7 +209,10 @@ def browser_session_targets_for_chat(
           b"AGENT_BROWSER_SOCKET_DIR",
         ):
           values[key] = value.decode("utf-8", errors="surrogateescape")
+    except (FileNotFoundError, ProcessLookupError):
+      continue
     except OSError:
+      complete = False
       continue
     session = values.get(b"AGENT_BROWSER_SESSION")
     if values.get(b"CHAT_ID") == chat_id and session is not None:
@@ -207,7 +221,7 @@ def browser_session_targets_for_chat(
         namespace=values.get(b"AGENT_BROWSER_NAMESPACE"),
         socket_dir=values.get(b"AGENT_BROWSER_SOCKET_DIR"),
       ))
-  return targets
+  return BrowserSessionScan(frozenset(targets), complete)
 
 
 def chat_activity_snapshot(db: Session) -> dict[str, dict]:

--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -2093,6 +2093,15 @@ def _publish_chat_run_finished(chat_id: str) -> None:
     })
 
 
+def _publish_chat_scratch_releasable(chat_id: str) -> None:
+  """Hint that physical turn cleanup finished; consumers recheck ownership."""
+  if chat_id:
+    get_system_broadcast().publish({
+      "type": "chat_scratch_releasable",
+      "chatId": chat_id,
+    })
+
+
 def is_chat_running(chat_id: str) -> bool:
   """Returns True if an agent subprocess is running or starting for this chat."""
   if registry.is_alive(chat_id):
@@ -2452,9 +2461,12 @@ async def _close_browser_session(chat_id: str) -> None:
   targets = {BrowserSessionTarget(session=f"chat-{chat_id}")}
   try:
     from app.browser_profiles import browser_session_targets_for_chat
-    targets.update(
-      await asyncio.to_thread(browser_session_targets_for_chat, chat_id)
-    )
+    scan = await asyncio.to_thread(browser_session_targets_for_chat, chat_id)
+    targets.update(scan.targets)
+    if not scan.complete:
+      log.warning(
+        "agent-browser session discovery incomplete for chat %s", chat_id,
+      )
   except Exception as exc:
     log.warning(
       "agent-browser session discovery failed for chat %s: %s",
@@ -3352,6 +3364,7 @@ async def run_chat(
   # (which `_run_chat_impl` doesn't catch) leaves the marker set for
   # reconciliation rather than silently wiping it — the safe default.
   disposition = chat_queue.TerminalDisposition.FAILED_LEAVE_MARKER
+  runtime_settled = False
   try:
     disposition = await _run_chat_impl(
       messages, chat_id=chat_id, session_id=session_id,
@@ -3359,6 +3372,7 @@ async def run_chat(
       attachments=attachments, timezone=timezone, viewport=viewport,
       run_token=run_token,
     )
+    runtime_settled = True
   finally:
     stopped_gen = _clear_after_terminal_generation.get(chat_id)
     clear_stopped_run = run_gen is not None and stopped_gen == run_gen
@@ -3451,6 +3465,24 @@ async def run_chat(
       _get_logger().debug(
         "terminal disposition chat_id=%s %s", chat_id, disposition.value,
       )
+    if runtime_settled and chat_id:
+      # chat_run_finished is intentionally earlier for responsive shell UI.
+      # Scratch needs a stricter physical boundary: _run_chat_impl has returned
+      # after browser cleanup, and a complete empty process inventory proves no
+      # detached Chromium session still inherits this turn's TMPDIR. The
+      # scratch owner rechecks both runtime and durable run identity again.
+      try:
+        from app.browser_profiles import browser_session_targets_for_chat
+        browser_scan = await asyncio.to_thread(
+          browser_session_targets_for_chat, chat_id,
+        )
+        if browser_scan.complete and not browser_scan.targets:
+          _publish_chat_scratch_releasable(chat_id)
+      except Exception:
+        _get_logger().debug(
+          "agent scratch release hint skipped chat_id=%s",
+          chat_id, exc_info=True,
+        )
     # Turn-end chat-note guarantee: when the chat SETTLED (no pending
     # follow-up), the platform's sole publisher updates its three summary
     # granularities. Runs AFTER the reply is sent → no user-facing latency;

--- a/backend/app/runtime_supervisors.py
+++ b/backend/app/runtime_supervisors.py
@@ -70,6 +70,7 @@ class RuntimeSupervisors:
       self.log.error("start_frontend_watcher failed: %s", exc, exc_info=True)
 
   async def _start_chat_supervisors(self) -> None:
+    from app.agent_scratch import release_if_idle, sweep_idle_scratch
     from app.broadcast import get_system_broadcast
     from app.chat import (
       ContinuationSweepResult,
@@ -217,30 +218,54 @@ class RuntimeSupervisors:
         await asyncio.sleep(sweep_seconds)
 
     async def agent_scratch_loop():
-      # Scratch cleanup is retention work, not part of starting a chat. Keeping
-      # it here avoids making every concurrent turn rescan the same directory.
-      await asyncio.sleep(300)
-      while True:
-        try:
-          from app.agent_scratch import sweep_idle_scratch
+      # Exact physical-completion hints own the normal path. The deadline is
+      # independent of event traffic so the broad sweep still repairs missed
+      # hints after five minutes at startup and hourly thereafter.
+      system_broadcast = get_system_broadcast()
+      events = system_broadcast.subscribe()
+      loop = asyncio.get_running_loop()
+      next_sweep_at = loop.time() + 300
+      try:
+        while True:
+          event = None
+          wait_seconds = max(0.0, next_sweep_at - loop.time())
+          if wait_seconds:
+            try:
+              async with asyncio.timeout(wait_seconds):
+                event = await events.get()
+            except asyncio.TimeoutError:
+              pass
 
-          def sweep_once():
-            with SessionLocal() as db:
-              return sweep_idle_scratch(db)
+          if event and event.get("type") == "chat_scratch_releasable":
+            chat_id = event.get("chatId")
+            if isinstance(chat_id, str) and chat_id:
+              try:
+                await release_if_idle(chat_id)
+              except asyncio.CancelledError:
+                raise
+              except Exception as exc:
+                self.log.error(
+                  "agent scratch release failed chat_id=%s: %s",
+                  chat_id, exc, exc_info=True,
+                )
 
-          result = await asyncio.to_thread(sweep_once)
-          if result["bytes"]:
-            self.log.info(
-              "agent scratch retention reclaimed %d bytes",
-              result["bytes"],
-            )
-        except asyncio.CancelledError:
-          raise
-        except Exception as exc:
-          self.log.error(
-            "agent scratch retention failed: %s", exc, exc_info=True,
-          )
-        await asyncio.sleep(60 * 60)
+          if loop.time() >= next_sweep_at:
+            try:
+              result = await sweep_idle_scratch()
+              if result["bytes"]:
+                self.log.info(
+                  "agent scratch retention reclaimed %d bytes",
+                  result["bytes"],
+                )
+            except asyncio.CancelledError:
+              raise
+            except Exception as exc:
+              self.log.error(
+                "agent scratch retention failed: %s", exc, exc_info=True,
+              )
+            next_sweep_at = loop.time() + 60 * 60
+      finally:
+        system_broadcast.unsubscribe(events)
 
     self._spawn("wedged-marker-sweep", wedged_marker_loop())
     self._spawn("reset-park-sweep", reset_park_loop())

--- a/backend/tests/test_agent_scratch.py
+++ b/backend/tests/test_agent_scratch.py
@@ -6,9 +6,24 @@ data volume bounds it — but that volume also holds SQLite, so scratch without
 a lifecycle would take durable data down with it. These cover both halves.
 """
 
+import asyncio
+import threading
 import time
 
+import pytest
+
 from app import agent_scratch, config, models
+from app.browser_profiles import BrowserSessionScan, BrowserSessionTarget
+from app.runner_registry import registry
+
+
+@pytest.fixture(autouse=True)
+def _complete_empty_browser_inventory(monkeypatch):
+  monkeypatch.setattr(
+    agent_scratch,
+    "browser_session_targets_for_chat",
+    lambda _chat_id: BrowserSessionScan(frozenset(), True),
+  )
 
 
 def _pin_data_dir(monkeypatch, tmp_path):
@@ -48,15 +63,152 @@ def test_scratch_is_isolated_per_chat(monkeypatch, tmp_path):
   assert agent_scratch.scratch_for_chat("a") != agent_scratch.scratch_for_chat("b")
 
 
-def test_sweep_reclaims_scratch_for_a_chat_with_no_run_in_flight(
+@pytest.mark.asyncio
+async def test_release_if_idle_removes_only_the_finished_chats_scratch(
+  monkeypatch, tmp_path, db
+):
+  """Turn completion should not wait for the broad crash-recovery sweep."""
+  _pin_data_dir(monkeypatch, tmp_path)
+  finished = agent_scratch.scratch_for_chat("finished-chat")
+  sibling = agent_scratch.scratch_for_chat("other-chat")
+
+  assert await agent_scratch.release_if_idle("finished-chat") is not None
+
+  assert not finished.exists()
+  assert sibling.is_dir()
+
+
+@pytest.mark.asyncio
+async def test_release_if_idle_preserves_a_newer_running_run(
+  monkeypatch, tmp_path, db, chat
+):
+  """A stale finished event cannot delete scratch adopted by a successor."""
+  _pin_data_dir(monkeypatch, tmp_path)
+  chat_id = getattr(chat, "id", chat)
+  db.add_all([
+    models.ChatRun(
+      id="run-finished", root_run_id="run-finished", chat_id=chat_id,
+      status="completed",
+    ),
+    models.ChatRun(
+      id="run-successor", root_run_id="run-successor", chat_id=chat_id,
+      status="running",
+    ),
+  ])
+  db.commit()
+  scratch = agent_scratch.scratch_for_chat(chat_id)
+
+  assert await agent_scratch.release_if_idle(chat_id) is None
+  assert scratch.is_dir()
+
+
+@pytest.mark.parametrize("status", ["parked", "resume_pending"])
+@pytest.mark.asyncio
+async def test_release_if_idle_reclaims_scratch_between_physical_runs(
+  monkeypatch, tmp_path, db, chat, status
+):
+  """A durable continuation recreates scratch when its next process starts."""
+  _pin_data_dir(monkeypatch, tmp_path)
+  chat_id = getattr(chat, "id", chat)
+  db.add(models.ChatRun(
+    id=f"run-{status}", root_run_id=f"run-{status}", chat_id=chat_id,
+    status=status,
+  ))
+  db.commit()
+  scratch = agent_scratch.scratch_for_chat(chat_id)
+
+  assert await agent_scratch.release_if_idle(chat_id) is not None
+  assert not scratch.exists()
+
+
+@pytest.mark.asyncio
+async def test_release_if_idle_preserves_a_starting_run_without_a_row(
+  monkeypatch, tmp_path
+):
+  """Programmatic starts claim the registry before StartTurn reaches SQLite."""
+  _pin_data_dir(monkeypatch, tmp_path)
+  scratch = agent_scratch.scratch_for_chat("starting-chat")
+  assert registry.mark_starting("starting-chat") is True
+
+  assert await agent_scratch.release_if_idle("starting-chat") is None
+  assert scratch.is_dir()
+
+
+@pytest.mark.asyncio
+async def test_release_if_idle_requires_a_complete_empty_browser_inventory(
+  monkeypatch, tmp_path
+):
+  _pin_data_dir(monkeypatch, tmp_path)
+  scratch = agent_scratch.scratch_for_chat("browser-chat")
+  monkeypatch.setattr(
+    agent_scratch,
+    "browser_session_targets_for_chat",
+    lambda _chat_id: BrowserSessionScan(frozenset(), False),
+  )
+
+  assert await agent_scratch.release_if_idle("browser-chat") is None
+  assert scratch.is_dir()
+
+  monkeypatch.setattr(
+    agent_scratch,
+    "browser_session_targets_for_chat",
+    lambda _chat_id: BrowserSessionScan(frozenset({
+      BrowserSessionTarget(session="chat-browser-chat"),
+    }), True),
+  )
+  assert await agent_scratch.release_if_idle("browser-chat") is None
+  assert scratch.is_dir()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_reclaim_cannot_delete_a_successors_canonical_scratch(
+  monkeypatch, tmp_path
+):
+  _pin_data_dir(monkeypatch, tmp_path)
+  original = agent_scratch.scratch_for_chat("chat-cancel")
+  entered = threading.Event()
+  finish = threading.Event()
+  real_reclaim = agent_scratch._reclaim_detached
+
+  def blocked_reclaim(path):
+    entered.set()
+    assert finish.wait(timeout=2)
+    return real_reclaim(path)
+
+  monkeypatch.setattr(agent_scratch, "_reclaim_detached", blocked_reclaim)
+  task = asyncio.create_task(agent_scratch.release_if_idle("chat-cancel"))
+  try:
+    for _ in range(100):
+      if entered.is_set():
+        break
+      await asyncio.sleep(0.01)
+    assert entered.is_set()
+    assert not original.exists()
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+      await task
+    successor = agent_scratch.scratch_for_chat("chat-cancel")
+  finally:
+    finish.set()
+
+  for _ in range(100):
+    if not any(tmp_path.joinpath("agent-scratch").glob(".chat-cancel.released-*")):
+      break
+    await asyncio.sleep(0.01)
+  assert successor.is_dir()
+
+
+@pytest.mark.asyncio
+async def test_sweep_reclaims_scratch_for_a_chat_with_no_run_in_flight(
   monkeypatch, tmp_path, db
 ):
   _pin_data_dir(monkeypatch, tmp_path)
   idle = agent_scratch.scratch_for_chat("idle-chat")
   (idle / "leftover.bin").write_bytes(b"x" * 2048)
 
-  result = agent_scratch.sweep_idle_scratch(
-    db, now=time.time() + agent_scratch._SWEEP_GRACE_SECONDS + 1
+  result = await agent_scratch.sweep_idle_scratch(
+    now=time.time() + agent_scratch._SWEEP_GRACE_SECONDS + 1
   )
 
   assert not idle.exists()
@@ -64,7 +216,8 @@ def test_sweep_reclaims_scratch_for_a_chat_with_no_run_in_flight(
   assert result["bytes"] >= 2048
 
 
-def test_sweep_never_deletes_scratch_of_a_run_still_in_flight(
+@pytest.mark.asyncio
+async def test_sweep_never_deletes_scratch_of_a_run_still_in_fight(
   monkeypatch, tmp_path, db, chat
 ):
   """Deleting a live run's scratch would corrupt a turn already in progress."""
@@ -78,16 +231,38 @@ def test_sweep_never_deletes_scratch_of_a_run_still_in_flight(
   db.commit()
   live = agent_scratch.scratch_for_chat(chat_id)
 
-  result = agent_scratch.sweep_idle_scratch(
-    db, now=time.time() + agent_scratch._SWEEP_GRACE_SECONDS + 1
+  result = await agent_scratch.sweep_idle_scratch(
+    now=time.time() + agent_scratch._SWEEP_GRACE_SECONDS + 1
   )
 
   assert live.is_dir()
-  assert result["kept_live"] == 1
   assert result["removed"] == 0
 
 
-def test_sweep_spares_scratch_created_before_its_run_row_exists(
+@pytest.mark.asyncio
+async def test_crash_recovery_sweep_reclaims_parked_scratch(
+  monkeypatch, tmp_path, db, chat
+):
+  """A missed finish event must not retain scratch until a later resume."""
+  _pin_data_dir(monkeypatch, tmp_path)
+  chat_id = getattr(chat, "id", chat)
+  db.add(models.ChatRun(
+    id="run-parked", root_run_id="run-parked", chat_id=chat_id,
+    status="parked",
+  ))
+  db.commit()
+  scratch = agent_scratch.scratch_for_chat(chat_id)
+
+  result = await agent_scratch.sweep_idle_scratch(
+    now=time.time() + agent_scratch._SWEEP_GRACE_SECONDS + 1,
+  )
+
+  assert not scratch.exists()
+  assert result["removed"] == 1
+
+
+@pytest.mark.asyncio
+async def test_sweep_spares_scratch_created_before_its_run_row_exists(
   monkeypatch, tmp_path, db
 ):
   """Scratch and the ChatRun row are created around the same moment and are not
@@ -96,15 +271,18 @@ def test_sweep_spares_scratch_created_before_its_run_row_exists(
   _pin_data_dir(monkeypatch, tmp_path)
   starting = agent_scratch.scratch_for_chat("just-started")
 
-  result = agent_scratch.sweep_idle_scratch(db)
+  result = await agent_scratch.sweep_idle_scratch()
 
   assert starting.is_dir()
   assert result["kept_recent"] == 1
   assert result["removed"] == 0
 
 
-def test_sweep_reports_zero_before_any_scratch_exists(monkeypatch, tmp_path, db):
+@pytest.mark.asyncio
+async def test_sweep_reports_zero_before_any_scratch_exists(
+  monkeypatch, tmp_path, db
+):
   """First run on a fresh volume: absence is an ordinary result, not an error."""
   _pin_data_dir(monkeypatch, tmp_path / "never-written")
 
-  assert agent_scratch.sweep_idle_scratch(db)["removed"] == 0
+  assert (await agent_scratch.sweep_idle_scratch())["removed"] == 0

--- a/backend/tests/test_browser_profiles.py
+++ b/backend/tests/test_browser_profiles.py
@@ -105,9 +105,11 @@ def test_browser_sessions_for_chat_preserves_opaque_session_values(tmp_path):
     b"CHAT_ID=chat-a\0AGENT_BROWSER_SESSION=not-a-browser\0"
   )
 
-  assert browser_profiles.browser_session_targets_for_chat(
+  scan = browser_profiles.browser_session_targets_for_chat(
     "chat-a", proc_root=proc,
-  ) == {
+  )
+  assert scan.complete is True
+  assert scan.targets == frozenset({
     browser_profiles.BrowserSessionTarget(session="custom:colon"),
     browser_profiles.BrowserSessionTarget(session="unicode-ø-世界"),
     browser_profiles.BrowserSessionTarget(session=long_name),
@@ -117,7 +119,7 @@ def test_browser_sessions_for_chat_preserves_opaque_session_values(tmp_path):
       socket_dir="/tmp/ab-sockets",
     ),
     browser_profiles.BrowserSessionTarget(session="-x"),
-  }
+  })
 
 
 def test_terminal_browser_cleanup_closes_inherited_and_custom_sessions(
@@ -129,7 +131,7 @@ def test_terminal_browser_cleanup_closes_inherited_and_custom_sessions(
   monkeypatch.setattr(
     browser_profiles,
     "browser_session_targets_for_chat",
-    lambda _chat_id: {
+    lambda _chat_id: browser_profiles.BrowserSessionScan(frozenset({
       browser_profiles.BrowserSessionTarget(session="custom:colon"),
       browser_profiles.BrowserSessionTarget(session="unicode-ø-世界"),
       browser_profiles.BrowserSessionTarget(session=long_name),
@@ -139,7 +141,7 @@ def test_terminal_browser_cleanup_closes_inherited_and_custom_sessions(
         socket_dir="/tmp/ab-sockets",
       ),
       browser_profiles.BrowserSessionTarget(session="-x"),
-    },
+    }), True),
   )
   calls = []
 
@@ -176,7 +178,8 @@ def test_terminal_browser_cleanup_closes_inherited_and_custom_sessions(
 
 def test_terminal_browser_cleanup_kills_timed_out_close_process(monkeypatch):
   monkeypatch.setattr(
-    browser_profiles, "browser_session_targets_for_chat", lambda _chat_id: set(),
+    browser_profiles, "browser_session_targets_for_chat",
+    lambda _chat_id: browser_profiles.BrowserSessionScan(frozenset(), True),
   )
   monkeypatch.setattr(chat, "_BROWSER_CLOSE_WAIT_TIMEOUT", 0.01)
   monkeypatch.setattr(chat, "_BROWSER_CLOSE_KILL_GRACE", 0.01)
@@ -221,7 +224,8 @@ def test_terminal_browser_cleanup_kills_timed_out_close_process(monkeypatch):
 
 def test_terminal_browser_cleanup_bounds_wait_after_sigkill(monkeypatch, caplog):
   monkeypatch.setattr(
-    browser_profiles, "browser_session_targets_for_chat", lambda _chat_id: set(),
+    browser_profiles, "browser_session_targets_for_chat",
+    lambda _chat_id: browser_profiles.BrowserSessionScan(frozenset(), True),
   )
   monkeypatch.setattr(chat, "_BROWSER_CLOSE_WAIT_TIMEOUT", 0.01)
   monkeypatch.setattr(chat, "_BROWSER_CLOSE_KILL_GRACE", 0.01)
@@ -268,7 +272,8 @@ def test_terminal_browser_cleanup_bounds_wait_when_process_disappears_before_ter
   monkeypatch, caplog,
 ):
   monkeypatch.setattr(
-    browser_profiles, "browser_session_targets_for_chat", lambda _chat_id: set(),
+    browser_profiles, "browser_session_targets_for_chat",
+    lambda _chat_id: browser_profiles.BrowserSessionScan(frozenset(), True),
   )
   monkeypatch.setattr(chat, "_BROWSER_CLOSE_WAIT_TIMEOUT", 0.01)
   monkeypatch.setattr(chat, "_BROWSER_CLOSE_KILL_WAIT_TIMEOUT", 0.01)

--- a/backend/tests/test_runtime_supervisors.py
+++ b/backend/tests/test_runtime_supervisors.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import threading
 from types import SimpleNamespace
 
 import pytest
@@ -95,7 +96,9 @@ async def test_reset_park_subscription_exists_only_while_its_task_runs(
   assert broadcast.subscribers == []
 
   await asyncio.sleep(0)
-  assert len(broadcast.subscribers) == 1
+  # Reset-park recovery and exact scratch-release hints each own one bounded
+  # subscription for the lifetime of their supervisor task.
+  assert len(broadcast.subscribers) == 2
 
   await supervisors.stop()
   assert broadcast.subscribers == []
@@ -135,4 +138,88 @@ async def test_restart_backlog_gets_prompt_followup_without_turn_completion(
     await asyncio.sleep(0)
 
   assert sweep_authorizations == ["accepted-restart", "accepted-restart"]
+  await supervisors.stop()
+
+
+@pytest.mark.asyncio
+async def test_finished_run_releases_scratch_under_the_chat_start_lock(
+  monkeypatch,
+):
+  import app.agent_scratch as scratch_module
+  import app.broadcast as broadcast_module
+  import app.chat as chat_module
+  import app.chat_queue as chat_queue_module
+  import app.runtime_supervisors as supervisors_module
+
+  broadcast = SystemBroadcast()
+  released = threading.Event()
+  release_calls = []
+
+  async def no_chats(*_args, **_kwargs):
+    return chat_module.ContinuationSweepResult()
+
+  def detach_if_idle(chat_id):
+    release_calls.append(chat_id)
+    released.set()
+    return None
+
+  monkeypatch.setattr(broadcast_module, "get_system_broadcast", lambda: broadcast)
+  monkeypatch.setattr(supervisors_module, "SessionLocal", _EmptySession)
+  monkeypatch.setattr(chat_module, "sweep_reset_parks", no_chats)
+  monkeypatch.setattr(scratch_module, "_detach_if_idle", detach_if_idle)
+
+  supervisors = _supervisors()
+  await supervisors._start_chat_supervisors()
+  await asyncio.sleep(0)
+
+  lock = chat_queue_module.get_lock("chat-1")
+  await lock.acquire()
+  try:
+    broadcast.publish({"type": "chat_scratch_releasable", "chatId": "chat-1"})
+    await asyncio.sleep(0)
+    assert release_calls == []
+  finally:
+    lock.release()
+
+  for _ in range(100):
+    if released.is_set():
+      break
+    await asyncio.sleep(0.01)
+  assert released.is_set()
+  assert release_calls == ["chat-1"]
+  await supervisors.stop()
+
+
+@pytest.mark.asyncio
+async def test_malformed_scratch_release_event_is_ignored(
+  monkeypatch,
+):
+  import app.agent_scratch as scratch_module
+  import app.broadcast as broadcast_module
+  import app.chat as chat_module
+  import app.runtime_supervisors as supervisors_module
+
+  broadcast = SystemBroadcast()
+  release_calls = []
+
+  async def no_chats(*_args, **_kwargs):
+    return chat_module.ContinuationSweepResult()
+
+  async def release_if_idle(chat_id):
+    release_calls.append(chat_id)
+
+  monkeypatch.setattr(broadcast_module, "get_system_broadcast", lambda: broadcast)
+  monkeypatch.setattr(supervisors_module, "SessionLocal", _EmptySession)
+  monkeypatch.setattr(chat_module, "sweep_reset_parks", no_chats)
+  monkeypatch.setattr(
+    scratch_module, "release_if_idle",
+    release_if_idle,
+  )
+
+  supervisors = _supervisors()
+  await supervisors._start_chat_supervisors()
+  await asyncio.sleep(0)
+  broadcast.publish({"type": "chat_scratch_releasable"})
+  await asyncio.sleep(0)
+  assert release_calls == []
   await supervisors.stop()


### PR DESCRIPTION
## Summary
- reclaim a chat’s durable scratch immediately after its physical agent and browser processes finish
- atomically detach the old scratch name before asynchronous deletion so cancellation cannot erase a successor’s directory
- require complete process discovery and recheck in-memory, durable, browser, and per-chat start ownership before release
- retain the periodic sweep as crash recovery for missed hints and abandoned detached directories

## Testing
- `scripts/wt-pytest.sh backend/tests/test_agent_scratch.py backend/tests/test_runtime_supervisors.py backend/tests/test_browser_profiles.py -q` (41 passed)
- `python3 -m py_compile` on every changed backend module

Review pass: normal cleanup is event-driven at the physical-lifetime boundary, while incomplete discovery, concurrent starts, cancellation, and missed events all fail toward preservation or the existing repair sweep.