### PR TITLE
Keep Reflection run evidence verifiable

### DIFF
--- a/backend/scripts/reflection-brief-template.html
+++ b/backend/scripts/reflection-brief-template.html
@@ -425,24 +425,6 @@
   .detail-group > summary:focus-visible {
     outline: none; border-radius: 6px; box-shadow: var(--ring);
   }
-  .ledger {
-    list-style: none; margin: 0; padding: 0;
-    border: 1px solid var(--border);
-    border-radius: var(--radius-sm);
-    overflow: hidden;
-    background: var(--surface);
-  }
-  .ledger li {
-    display: flex; gap: var(--sp-3);
-    padding: var(--sp-3) var(--sp-4);
-    border-top: 1px solid var(--border);
-    font-size: var(--step--1);
-  }
-  .ledger li:first-child { border-top: none; }
-  .ledger .label { color: var(--text); flex: 1; }
-  .ledger .val   { color: var(--muted); font-variant-numeric: tabular-nums;
-                   font-family: var(--mono); }
-
   .commits {
     margin: var(--sp-3) 0 0;
     padding: var(--sp-3) var(--sp-4);
@@ -498,7 +480,7 @@
     }
     body { background: #fff; }
     .wrap { max-width: none; padding: 0; }
-    .lede, .item, .ledger, .commits { box-shadow: none; }
+    .lede, .item, .commits { box-shadow: none; }
     section { break-inside: avoid; }
     .item, .lede { break-inside: avoid; }
     .handoff { display: none; }

--- a/backend/scripts/seed-skills/manager-session-evidence.py
+++ b/backend/scripts/seed-skills/manager-session-evidence.py
@@ -4,8 +4,8 @@
 
 Instead of running many sequential tools (read the memory run-status, tail the
 update log, cross-check read-traces against the chat DB, tail reflection
-metrics, list interview artifacts, curl the skills API), this prints all of it
-as a single readable report so a 1-on-1 can start from one command.
+metrics, list Reflection run artifacts, curl the skills API), this prints all
+of it as a single readable report so a 1-on-1 can start from one command.
 
 Read-only, defensive (missing pieces are skipped, never fatal), python3 stdlib
 + sqlite3 only. It gathers evidence; it does not judge — the manager session
@@ -37,10 +37,6 @@ REFLECTION_DIR = "/data/apps/reflection"
 REFLECTION_METRICS = os.path.join(REFLECTION_DIR, "reflection-run-metrics.jsonl")
 REFLECTION_RUNS = os.path.join(REFLECTION_DIR, "runs")
 TOOL_FRICTION = os.path.join(REFLECTION_DIR, "tool_friction.py")
-
-# Filename tokens that identify a reflection run's interview capture.
-INTERVIEW_HINTS = ("interview", "int-", "fork", "1on1", "1-on-1")
-
 
 def now_utc():
     return dt.datetime.now(dt.timezone.utc)
@@ -223,7 +219,7 @@ def section_memory(limit):
     for e in entries:
         counts = e.get("counts") or {}
         ts = (e.get("timestamp") or "")[:16]
-        print(f"    {ts or '?':16}  run={short(e.get('run_id'), 8):8}  "
+        print(f"    {ts or '?':16}  run={e.get('run_id') or '?'}  "
               f"changed={len(e.get('changed_paths') or [])}  "
               f"deleted={len(e.get('deleted_paths') or [])}  "
               f"problems={counts.get('problems','?')}  "
@@ -399,7 +395,7 @@ def _applied_memory_diff(outcome):
 
 
 def section_memory_writer_packet():
-    """One bounded packet with native testimony and reconstruction evidence."""
+    """One bounded packet for reviewing a writer outcome."""
     sub("MEMORY WRITER — latest decision-evidence packet")
     outcomes = _read_update_log(1)
     if not outcomes:
@@ -411,7 +407,8 @@ def section_memory_writer_packet():
     current_status = _read_json(MEM_RUN_STATUS)
     status = _memory_run_for_id(run_id)
     if (
-        status is None
+        run_id
+        and status is None
         and isinstance(current_status, dict)
         and current_status.get("run_id") == run_id
     ):
@@ -426,8 +423,10 @@ def section_memory_writer_packet():
     if native:
         print("  testimony=native writer self-review captured during the run")
     else:
-        print("  testimony=unavailable; any later interview is a stateless reconstruction")
-    if current_status and current_status.get("run_id") != run_id:
+        print("  native self-review=unavailable; any later review is stateless evidence")
+    if not run_id:
+        print("  WARNING: writer outcome has no run_id; no terminal receipt was matched.")
+    elif current_status and current_status.get("run_id") != run_id:
         print("  WARNING: current run-status belongs to a different run; "
               "the outcome below is the latest published writer outcome.")
     print("\nMATCHED TERMINAL RUN RECEIPT:")
@@ -482,9 +481,8 @@ def section_reflection(limit):
                   f"{'  DRY-RUN' if r.get('dry_run') else ''}")
 
     # Enumerate actual metric-backed run days, including days that left no
-    # artifact directory. Listing only existing directories hid the exact
-    # failure this section is meant to reveal: a completed run that skipped
-    # its interviews entirely.
+    # artifact directory. Filenames are listed as artifacts only: they cannot
+    # prove that a provider interview completed successfully.
     run_days = list(dict.fromkeys(
         str(row.get("started_at") or "")[:10]
         for row in recent
@@ -495,13 +493,11 @@ def section_reflection(limit):
             day for day in os.listdir(REFLECTION_RUNS)
             if os.path.isdir(os.path.join(REFLECTION_RUNS, day))
         )[-limit:]
-    print(f"  interview artifacts for recent runs ({len(run_days)} days):")
+    print(f"  artifacts for recent runs ({len(run_days)} days):")
     for day in run_days:
         directory = os.path.join(REFLECTION_RUNS, day)
         files = sorted(os.listdir(directory)) if os.path.isdir(directory) else []
-        interview = [f for f in files if any(h in f.lower() for h in INTERVIEW_HINTS)]
-        tag = f"  [interview: {', '.join(interview)}]" if interview else "  [no interview capture]"
-        print(f"    {day}: {', '.join(files) if files else '(empty)'}{tag}")
+        print(f"    {day}: {', '.join(files) if files else '(empty)'}")
 
 
 def section_tool_friction(hours):
@@ -676,7 +672,7 @@ def main():
     ap.add_argument("--traces", type=int, default=12,
                     help="how many recent read-traces to list (default 12)")
     ap.add_argument("--memory-writer-packet", action="store_true",
-                    help="append a bounded packet for the latest Memory writer interview")
+                    help="append a bounded review of the latest Memory writer outcome")
     ap.add_argument("chat_id", nargs="?", default=None,
                     help="optional chat id to profile as a focus block")
     args = ap.parse_args()

--- a/backend/scripts/seed-skills/manager-session.md
+++ b/backend/scripts/seed-skills/manager-session.md
@@ -49,7 +49,7 @@ coaching reshapes the fix.
 Before opening any transcript, run the companion script. It exists precisely so
 a session starts from **one consolidated report** instead of six sequential
 tools (read Memory's run-status, tail the update log, cross-check read-traces
-against the chat DB, tail Reflection's metrics, list interview artifacts, curl
+against the chat DB, tail Reflection's metrics, list Reflection run artifacts, curl
 the skills API). One call, one readable bundle:
 
 ```bash
@@ -59,17 +59,18 @@ python3 /data/shared/skills/manager-session-evidence.py [--hours 72] [--limit 5]
 It prints, for the memory + reflection agents: run-status and the last few
 consolidation outcomes (counts, deletes, problems, followups); recent reflection
 exit codes / durations / brief-written; the recent read-trace count with the
-last N traces mapped to their chat titles; which reflection runs left interview
-artifacts; and platform-wide skill-load counts. Pass a `CHAT_ID` to profile one
+last N traces mapped to their chat titles; which artifact files each Reflection
+run left; and platform-wide skill-load counts. Pass a `CHAT_ID` to profile one
 chat (title, provider, message count, whether Memory recalled into it, and the
 exact fork command to use in beat 3). It is read-only and defensive: missing
 pieces are skipped, never fatal.
 
-For a Memory writer 1-on-1, add `--memory-writer-packet`. The same call appends
-the latest run status and writer outcome, the applied diff limited to changed
-or deleted memory paths, that run's recall verdicts, and the current Memory
-governing skill plus writer prompt builder. It includes no raw chat bodies and
-is bounded for a stateless reconstructed interview.
+For a Memory writer review, add `--memory-writer-packet`. The same call appends
+one writer outcome, a terminal receipt only when its non-empty `run_id` matches
+exactly, the applied diff limited to changed or deleted memory paths, that
+run's recall verdicts, and the current Memory governing skill plus writer prompt
+builder. It includes no raw chat bodies and supports a stateless evidence
+review, not an interview.
 
 Read the bundle first and let it *point* you — a run that failed, a followup that
 keeps recurring, a skill an agent leaned on hard, a chat where recall served

--- a/backend/scripts/seed-skills/reflection.md
+++ b/backend/scripts/seed-skills/reflection.md
@@ -42,7 +42,7 @@ quota and need not receive equal attention. Follow the strongest signal while
 preserving the brief and safety contracts.
 
 After phase 0, name tonight's **mandatory assessment gates** from the live
-evidence (for example, the Memory writer 1-on-1 when Memory consolidated).
+evidence (for example, the Memory writer review when Memory consolidated).
 Complete those gates before discretionary investigations. If a gate does not
 run, the brief must call that subsystem **not assessed**; never infer healthy
 or failed from evidence you did not examine. A skipped item names the concrete
@@ -228,13 +228,14 @@ Read, in this order:
    assess. On an older handoff without that field, use `last_run` only when it
    is terminal. Report a newer running attempt separately rather than treating
    the completed run as unavailable.
-2. Run `python3 /data/shared/skills/manager-session-evidence.py --limit 3` and
-   match provider, queue, update-log, and supervisor claims by `run_id`. Never
-   combine the current attempt with an earlier publication. If a supervisor
-   receipt has no `run_id`, treat it only as separate scheduling evidence.
-3. `/data/shared/memory/app-state/update-log/*.jsonl` — only for a completed
-   publication whose `run_id` matches the terminal operational evidence.
-4. The interviews' Memory answers from phase 1 — complaints about missing,
+2. Run the helper once:
+   `python3 /data/shared/skills/manager-session-evidence.py --limit 3 --memory-writer-packet`
+   The base section identifies the current attempt and recent writer outcomes;
+   the packet adds evidence for one outcome. Attribute provider, queue, and
+   update claims only when their non-empty full `run_id` matches the terminal
+   outcome from step 1. A supervisor receipt without a `run_id` is separate
+   scheduling evidence, never a join key.
+3. The interviews' Memory answers from phase 1 — complaints about missing,
    stale, misleading, or over-broad recall.
 
 When a recent Memory consolidation completed, review its **native writer
@@ -243,23 +244,16 @@ possibly missed evidence, and proposed prompt change while the run context is
 still present; this is the primary testimony. Verify it against the update-log
 outcome, applied diff, and recall-audit verdicts. Only when native testimony is
 absent may a read-only subagent reconstruct the run from those artifacts. Label
-that fallback **stateless reconstructed interview** and never present it as the
-writer's own recollection. Prefer no prompt change over invented coaching. If
+that fallback a **stateless evidence review**, never an interview or the writer's
+own recollection. Prefer no prompt change over invented coaching. If
 the run made no proposal, review the failure evidence instead. This review may
 recommend changes to Memory's owning app, but it never writes the graph.
 
-Gather that successful-run packet in one call rather than reopening those
-files individually:
-
-```bash
-python3 /data/shared/skills/manager-session-evidence.py --limit 1 --memory-writer-packet
-```
-
 Only open raw Memory evidence or the bounded job log afterward when the packet
 names a specific gap. Never infer health from update-log recency alone.
-Save the verified interview to
-`/data/apps/reflection/runs/<YYYY-MM-DD>/memory-writer-1on1.md` so the next
-manager bundle can show whether this mandatory gate actually ran.
+Save the verified review to
+`/data/apps/reflection/runs/<YYYY-MM-DD>/memory-writer-review.md` for later
+inspection without claiming that an interview completed.
 
 Then act on the **system** signal:
 

--- a/backend/tests/test_manager_session_evidence.py
+++ b/backend/tests/test_manager_session_evidence.py
@@ -91,7 +91,24 @@ class ManagerSessionEvidenceTests(unittest.TestCase):
     self.assertEqual(receipt["seq"], 2)
     self.assertIsNone(missing)
 
-  def test_reflection_section_marks_metric_backed_run_without_interview(self):
+  def test_memory_section_prints_complete_update_run_id(self):
+    run_id = "12345678-1234-5678-1234-567812345678"
+    output = io.StringIO()
+    with (
+      mock.patch.object(manager_evidence, "MEM_RUN_STATUS", "/missing/status"),
+      mock.patch.object(manager_evidence, "installed_app", return_value=None),
+      mock.patch.object(
+        manager_evidence,
+        "_read_update_log",
+        return_value=[{"run_id": run_id, "status": "published"}],
+      ),
+      contextlib.redirect_stdout(output),
+    ):
+      manager_evidence.section_memory(3)
+
+    self.assertIn(f"run={run_id}", output.getvalue())
+
+  def test_reflection_section_lists_artifacts_without_inventing_interviews(self):
     with tempfile.TemporaryDirectory() as raw:
       root = Path(raw)
       metrics = root / "reflection-run-metrics.jsonl"
@@ -101,20 +118,28 @@ class ManagerSessionEvidenceTests(unittest.TestCase):
         "duration_seconds": 42,
         "brief_written": True,
       }) + "\n")
+      run_dir = root / "runs" / "2026-07-28"
+      run_dir.mkdir(parents=True)
+      (run_dir / "failed-interview.txt").write_text("provider error\n")
+      (run_dir / "memory-writer-review.md").write_text("review\n")
       output = io.StringIO()
       with (
         mock.patch.object(manager_evidence, "REFLECTION_METRICS", str(metrics)),
         mock.patch.object(
           manager_evidence,
           "REFLECTION_RUNS",
-          str(root / "missing-runs"),
+          str(root / "runs"),
         ),
         contextlib.redirect_stdout(output),
       ):
         manager_evidence.section_reflection(5)
 
-    self.assertIn("2026-07-28", output.getvalue())
-    self.assertIn("[no interview capture]", output.getvalue())
+    rendered = output.getvalue()
+    self.assertIn("2026-07-28", rendered)
+    self.assertIn("failed-interview.txt", rendered)
+    self.assertIn("memory-writer-review.md", rendered)
+    self.assertNotIn("[interview:", rendered)
+    self.assertNotIn("[no interview capture]", rendered)
 
   def test_writer_diff_is_limited_to_reported_memory_paths(self):
     with tempfile.TemporaryDirectory() as raw:
@@ -235,6 +260,33 @@ class ManagerSessionEvidenceTests(unittest.TestCase):
     self.assertIn('"model": "historical"', rendered)
     self.assertIn('"pending_chat_count": 12', rendered)
     self.assertNotIn('"provider": "claude"', rendered)
+    self.assertNotIn('"pending_chat_count": 999', rendered)
+
+  def test_writer_packet_never_matches_missing_run_ids(self):
+    output = io.StringIO()
+    current = {
+      "provider_summary": [{"provider": "current-without-id"}],
+      "pending_chat_count": 999,
+    }
+    with (
+      mock.patch.object(
+        manager_evidence,
+        "_read_update_log",
+        return_value=[{"status": "published"}],
+      ),
+      mock.patch.object(manager_evidence, "_recall_audits_for_run", return_value=[]),
+      mock.patch.object(manager_evidence, "_read_json", return_value=current),
+      mock.patch.object(manager_evidence, "_memory_run_for_id", return_value=None),
+      mock.patch.object(manager_evidence, "_read_text", return_value="skill"),
+      mock.patch.object(manager_evidence, "_function_source", return_value="prompt"),
+      mock.patch.object(manager_evidence, "_applied_memory_diff", return_value="diff"),
+      contextlib.redirect_stdout(output),
+    ):
+      manager_evidence.section_memory_writer_packet()
+
+    rendered = output.getvalue()
+    self.assertIn("writer outcome has no run_id", rendered)
+    self.assertNotIn("current-without-id", rendered)
     self.assertNotIn('"pending_chat_count": 999', rendered)
 
 

--- a/backend/tests/test_reflection_brief_template.py
+++ b/backend/tests/test_reflection_brief_template.py
@@ -25,4 +25,5 @@ def test_default_reflection_brief_has_no_unverified_run_ledger():
 
   assert "Run ledger" not in template
   assert "{{N_INTERVIEWED}}" not in template
+  assert ".ledger" not in template
   assert "From verified evidence" in template


### PR DESCRIPTION
## Summary
- join Memory writer receipts only by a non-empty full run ID and keep unlinked scheduler receipts separate
- stop inferring successful interviews from artifact filenames, and distinguish native writer self-review from stateless evidence review
- gather the Memory review bundle once instead of reopening overlapping evidence paths
- remove the unverified run ledger, its dead styling, and duplicated app-contract guidance

Follow-up to #381: that change introduced native Memory writer evidence; this prevents the review helper from pairing a prior publication with current attempt or scheduler data and removes evidence claims that filenames cannot prove.

## Testing
- 11 focused manager-evidence and brief-template tests
- 73-test hermetic fast backend suite