### PR TITLE
Adopt exact catalog trees across rewritten app history

### DIFF
--- a/backend/app/app_git.py
+++ b/backend/app/app_git.py
@@ -660,6 +660,34 @@ def _diff_paths(repo: Path, left: str, right: str) -> set[str] | None:
   return {path for path in proc.stdout.split("\0") if path}
 
 
+def ref_trees_equal(
+  source_dir: str | Path, left: str, right: str,
+) -> bool:
+  """Whether two refs name the same complete tree, regardless of history."""
+  repo = Path(source_dir)
+  left_tree = _tree_oid(repo, left)
+  right_tree = _tree_oid(repo, right)
+  return bool(left_tree and left_tree == right_tree)
+
+
+def refs_share_history(
+  source_dir: str | Path, left: str, right: str,
+) -> bool:
+  """Whether two refs have a merge base without moving either ref."""
+  proc = _run(
+    Path(source_dir), "merge-base", left, right, check=False,
+  )
+  return proc.returncode == 0 and bool(proc.stdout.strip())
+
+
+def diff_paths(
+  source_dir: str | Path, left: str, right: str,
+) -> tuple[str, ...]:
+  """Complete endpoint path differences, or an empty tuple on Git failure."""
+  paths = _diff_paths(Path(source_dir), left, right)
+  return tuple(sorted(paths)) if paths is not None else ()
+
+
 def describe_reconciliation(
   source_dir: str | Path,
   shared_base: str,

--- a/backend/app/install.py
+++ b/backend/app/install.py
@@ -2662,7 +2662,41 @@ async def install_from_manifest(
             app_git.UPSTREAM_BRANCH,
           )
         dropped_source_paths = previous_upstream_paths - new_upstream_paths
-        if not diverged:
+        if target.adopting_trusted_origin and cloned_update:
+          # Legacy explicit-apply rewrote Git history even when it preserved
+          # the canonical repository tree byte-for-byte. Exact tree equality
+          # is therefore the safe adoption fast path: there is no local byte
+          # to overwrite, so advancing the catalog baseline cannot lose work.
+          # Different unrelated trees have no honest three-way base; surface
+          # every endpoint difference for owner-gated resolution instead of
+          # guessing or failing the install with a raw merge-tree error.
+          same_tree = await asyncio.to_thread(
+            app_git.ref_trees_equal,
+            git_source_dir,
+            app_git.LOCAL_BRANCH,
+            app_git.UPSTREAM_BRANCH,
+          )
+          if same_tree:
+            diverged = False
+          elif not await asyncio.to_thread(
+            app_git.refs_share_history,
+            git_source_dir,
+            app_git.LOCAL_BRANCH,
+            app_git.UPSTREAM_BRANCH,
+          ):
+            conflict_paths = list(await asyncio.to_thread(
+              app_git.diff_paths,
+              git_source_dir,
+              app_git.LOCAL_BRANCH,
+              app_git.UPSTREAM_BRANCH,
+            )) or [entry_key]
+            mode = "conflict"
+            reconciliation = app_git.ReconciliationReceipt(
+              unresolved_conflict_paths=tuple(conflict_paths),
+            )
+        if mode == "conflict":
+          pass
+        elif not diverged:
           # No local edits → upstream wins outright for the whole tree; it is
           # `source_tree` as fetched for synthetic repos, or the full
           # origin-backed upstream tree for cloned repos. Taking the bytes

--- a/backend/tests/test_apps_install.py
+++ b/backend/tests/test_apps_install.py
@@ -1852,6 +1852,107 @@ def test_trusted_origin_adoption_is_always_reconciled_as_local_source(
   assert target.adopting_trusted_origin is True
 
 
+def test_trusted_origin_adoption_accepts_equal_tree_with_unrelated_history(
+  client, auth, db, bypass_url_validation,
+):
+  """Equal local/catalog bytes adopt in place even after history rewrites."""
+  manifest = {
+    "id": "codex",
+    "name": "Subagents",
+    "version": "1.0.0",
+    "description": "trusted legacy app",
+    "entry": "index.jsx",
+    "permissions": {},
+  }
+  legacy = create_local_app(
+    client,
+    auth,
+    name="Codex",
+    description="trusted legacy app",
+    jsx_source=JSX,
+    manifest_extra={"version": "1.0.0"},
+  )
+  repo = Path(legacy["source_dir"])
+  subprocess.run(
+    [
+      "git", "-C", str(repo), "remote", "add", "origin",
+      "https://github.com/mobius-os/app-subagents.git",
+    ],
+    check=True,
+  )
+  tree = subprocess.run(
+    ["git", "-C", str(repo), "rev-parse", "main^{tree}"],
+    capture_output=True, text=True, check=True,
+  ).stdout.strip()
+  upstream_sha = subprocess.run(
+    [
+      "git", "-c", "user.name=Mobius", "-c",
+      "user.email=mobius@localhost", "-C", str(repo),
+      "commit-tree", tree, "-m", "catalog",
+    ],
+    capture_output=True, text=True, check=True,
+  ).stdout.strip()
+  subprocess.run(
+    [
+      "git", "-C", str(repo), "update-ref",
+      "refs/remotes/origin/main", upstream_sha,
+    ],
+    check=True,
+  )
+  assert subprocess.run(
+    ["git", "-C", str(repo), "merge-base", "main", "origin/main"],
+    capture_output=True,
+  ).returncode != 0
+  before = {
+    path.name: path.read_bytes()
+    for path in (repo / "index.jsx", repo / "mobius.json")
+  }
+
+  def fetch_equal_upstream(source_dir, _ref):
+    subprocess.run(
+      [
+        "git", "-C", str(source_dir), "update-ref",
+        "refs/heads/upstream", upstream_sha,
+      ],
+      check=True,
+    )
+    return upstream_sha
+
+  manifest_url = (
+    "https://raw.githubusercontent.com/mobius-os/"
+    "app-subagents/main/mobius.json"
+  )
+  raw_base = manifest_url.rsplit("/", 1)[0] + "/"
+  responses = {
+    manifest_url: (200, json.dumps(manifest).encode()),
+    raw_base + "index.jsx": (200, JSX.encode()),
+  }
+  with patch(
+    "app.install.httpx.AsyncClient",
+    side_effect=_fake_async_client(responses),
+  ), patch(
+    "app.install.app_git.fetch_upstream",
+    side_effect=fetch_equal_upstream,
+  ):
+    adopted = client.post(
+      "/api/apps/install", headers=auth,
+      json={"manifest_url": manifest_url},
+    )
+
+  assert adopted.status_code == 201, adopted.text
+  payload = adopted.json()
+  assert payload["id"] == legacy["id"]
+  assert payload["mode"] == "update"
+  assert payload["manifest_url"] == (
+    raw_base.rstrip("/") + "#manifest-id=codex"
+  )
+  after = {
+    path.name: path.read_bytes()
+    for path in (repo / "index.jsx", repo / "mobius.json")
+  }
+  assert after == before
+
+
 def test_install_same_manifest_twice_updates(
   client, auth, bypass_url_validation,
 ):


### PR DESCRIPTION
## Summary\n- recognize complete tree equality when a trusted catalog app adopts an existing local repository with rewritten history\n- advance the catalog baseline without rewriting identical local source\n- surface endpoint path differences as an owner-resolvable conflict when unrelated histories genuinely differ\n- cover the legacy equal-tree adoption flow end to end\n\nThis complements #576: source status can already recognize exact canonical trees; the installer now uses the same proof when adopting the catalog origin.\n\n## Testing\n- scripts/wt-pytest.sh backend/tests/test_apps_install.py backend/tests/test_app_git.py -q