### PR TITLE
Slim dependency image layers and cleanup paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,8 @@ RUN useradd -m -s /bin/bash mobius
 # agent-browser looks by default).
 # Discard npm's download cache in each layer: installed packages are the
 # runtime artifact; registry tarballs only make the production image larger.
+ARG ESBUILD_VERSION=0.28.1
+ARG CLAUDE_CODE_VERSION=2.1.220
 ARG AGENT_BROWSER_VERSION=0.33.2
 RUN apt-get update && apt-get install -y --no-install-recommends \
     age ca-certificates cron curl git jq procps ripgrep sqlite3 sudo unzip util-linux \
@@ -50,9 +52,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxfixes3 libxrandr2 libgbm1 libpango-1.0-0 libcairo2 libasound2t64 \
     fonts-liberation fonts-noto-color-emoji \
     && npm install -g --engine-strict --strict-allow-scripts \
-      --allow-scripts="esbuild@0.28.1,@anthropic-ai/claude-code@2.1.220,agent-browser@${AGENT_BROWSER_VERSION}" \
-      esbuild@0.28.1 \
-      @anthropic-ai/claude-code@2.1.220 \
+      --allow-scripts="esbuild@${ESBUILD_VERSION},@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION},agent-browser@${AGENT_BROWSER_VERSION}" \
+      "esbuild@${ESBUILD_VERSION}" \
+      "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
       @openai/codex@0.146.0 \
       "agent-browser@${AGENT_BROWSER_VERSION}" \
     && agent-browser install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,9 @@ FROM node-runtime AS frontend
 
 WORKDIR /build
 COPY frontend/package.json frontend/package-lock.json* ./
-RUN npm ci --ignore-scripts
+RUN npm ci --ignore-scripts && rm -rf /root/.npm
 COPY frontend/ .
-RUN npm run build
+RUN npm run build && rm -rf /root/.npm
 
 # -- Stage 2: backend + everything ------------------------------------
 FROM python:3.12-slim-trixie
@@ -30,28 +30,37 @@ COPY --from=node-runtime /usr/local/lib/node_modules/npm /usr/local/lib/node_mod
 RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
     && ln -s ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
+# Create the runtime user before installing the shared browser payload. Setting
+# its ownership in the payload's own layer avoids copying Chromium into a second
+# image layer solely to change metadata later.
+RUN useradd -m -s /bin/bash mobius
+
 # System deps and global npm packages in a single layer.
 # agent-browser downloads its own Chromium during `install`; we move it
 # to /opt/agent-browser so both root and the mobius user share a single
 # Chromium copy via the symlinks below (~/.agent-browser is where
 # agent-browser looks by default).
-#
+# Discard npm's download cache in each layer: installed packages are the
+# runtime artifact; registry tarballs only make the production image larger.
+ARG AGENT_BROWSER_VERSION=0.33.2
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    cron curl ca-certificates git jq ripgrep sqlite3 sudo unzip procps util-linux age \
+    age ca-certificates cron curl git jq procps ripgrep sqlite3 sudo unzip util-linux \
     libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libcups2 \
     libdrm2 libxkbcommon0 libatspi2.0-0 libxcomposite1 libxdamage1 \
     libxfixes3 libxrandr2 libgbm1 libpango-1.0-0 libcairo2 libasound2t64 \
     fonts-liberation fonts-noto-color-emoji \
-    && npm install -g esbuild@0.28.1 \
-    && npm install -g @anthropic-ai/claude-code@2.1.220 \
-    && npm install -g @openai/codex@0.146.0 \
-    && npm install -g --allow-scripts=agent-browser@0.33.2 agent-browser@0.33.2 \
+    && npm install -g --engine-strict --strict-allow-scripts \
+      --allow-scripts="esbuild@0.28.1,@anthropic-ai/claude-code@2.1.220,agent-browser@${AGENT_BROWSER_VERSION}" \
+      esbuild@0.28.1 \
+      @anthropic-ai/claude-code@2.1.220 \
+      @openai/codex@0.146.0 \
+      "agent-browser@${AGENT_BROWSER_VERSION}" \
     && agent-browser install \
     && mv /root/.agent-browser /opt/agent-browser \
+    && chown -R mobius:mobius /opt/agent-browser \
     && git_version="$(git --version | awk '{print $3}')" \
     && [ "$(printf '%s\n' "2.38" "$git_version" | sort -V | head -n1)" = "2.38" ] \
-    && apt-get autoremove -y \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /root/.npm /var/lib/apt/lists/*
 
 # tectonic is a server-side subprocess; CSP connect-src 'self' applies only to
 # browser fetches from the mini-app iframe, not OS-level subprocesses — tectonic's
@@ -98,12 +107,9 @@ RUN set -eux; \
       "/tmp/gh_${GH_CLI_VERSION}_linux_${arch}"; \
     gh --version
 
-# Share the agent-browser install between root and mobius via symlinks.
-# The mobius user is created further down; we chown the shared dir to
-# mobius:mobius after that, so mobius can write session sockets/locks
-# as the owner without needing world-write on the Chromium binaries.
-# (root still has access because root always does.)
-RUN ln -s /opt/agent-browser /root/.agent-browser
+# Share the mobius-owned agent-browser install without a second Chromium copy.
+RUN ln -s /opt/agent-browser /root/.agent-browser \
+    && ln -s /opt/agent-browser /home/mobius/.agent-browser
 
 # openai/codex-plugin-cc — Claude Code plugin that exposes Codex as a
 # delegation/review subagent inside the agent's session. Cloned at
@@ -165,7 +171,7 @@ RUN pip install --no-cache-dir --no-deps \
 # refreshes the date automatically — no hand-maintained map, no test to
 # satisfy. Best effort: if the npm registry is unreachable the file is left
 # empty and the Settings row simply shows the bare version, never an error.
-RUN node -e "const cp=require('child_process'),fs=require('fs');\
+RUN if ! node -e "const cp=require('child_process'),fs=require('fs');\
 const want=['@anthropic-ai/claude-code','@openai/codex'];\
 let installed={};\
 try{installed=(JSON.parse(cp.execSync('npm ls -g --depth=0 --json',{stdio:['ignore','pipe','ignore']}).toString()).dependencies)||{};}catch(e){}\
@@ -173,15 +179,19 @@ const out={};\
 for(const name of want){const v=installed[name]&&installed[name].version;if(!v)continue;\
 try{const t=JSON.parse(cp.execSync('npm view '+name+'@'+v+' time --json',{stdio:['ignore','pipe','ignore']}).toString());if(t&&t[v])out[v]=String(t[v]).slice(0,10);}catch(e){}}\
 fs.writeFileSync('/app/cli-release-dates.json',JSON.stringify(out));\
-console.log('cli-release-dates.json:',JSON.stringify(out));" \
-    || echo '{}' > /app/cli-release-dates.json
+console.log('cli-release-dates.json:',JSON.stringify(out));"; then \
+      echo '{}' > /app/cli-release-dates.json; \
+    fi; \
+    rm -rf /root/.npm
 
 # Install the shell and mini-app compiler dependency tree from manifests alone.
 # Application source is copied later, so ordinary frontend edits reuse this
 # pinned npm layer. The production compiler resolves app bare imports only from
 # this directory and embeds the complete graph into each app module.
 COPY frontend/package.json frontend/package-lock.json* ./shell-src/
-RUN cd ./shell-src && npm ci --ignore-scripts 2>/dev/null && rm -rf .vite
+RUN cd ./shell-src \
+    && npm ci --ignore-scripts 2>/dev/null \
+    && rm -rf .vite /root/.npm
 
 # pdf.js (Mozilla's engine — what Firefox's built-in PDF viewer uses),
 # vendored same-origin so the LaTeX app renders a compiled PDF as a real
@@ -193,12 +203,13 @@ RUN cd ./shell-src && npm ci --ignore-scripts 2>/dev/null && rm -rf .vite
 # app sets GlobalWorkerOptions.workerSrc to the /vendor worker URL.
 RUN mkdir -p /tmp/pdfjs-install && cd /tmp/pdfjs-install \
     && npm init -y >/dev/null \
-    && npm install --no-audit --no-fund --silent pdfjs-dist@4.10.38 \
+    && npm install --no-audit --no-fund --silent \
+      --engine-strict --strict-allow-scripts pdfjs-dist@4.10.38 \
     && mkdir -p /app/static/vendor/pdfjs@4.10.38 \
     && cp node_modules/pdfjs-dist/build/pdf.mjs /app/static/vendor/pdfjs@4.10.38/pdf.mjs \
     && cp node_modules/pdfjs-dist/build/pdf.worker.mjs /app/static/vendor/pdfjs@4.10.38/pdf.worker.mjs \
     && ln -s pdfjs@4.10.38 /app/static/vendor/pdfjs \
-    && cd / && rm -rf /tmp/pdfjs-install
+    && cd / && rm -rf /tmp/pdfjs-install /root/.npm
 
 # KaTeX browser assets — the package's JavaScript is bundled when an app imports
 # it, while the shell and app-authored stylesheets still use these public files.
@@ -211,14 +222,15 @@ RUN mkdir -p /tmp/pdfjs-install && cd /tmp/pdfjs-install \
 # The stable /vendor/katex/ alias is used by installed app stylesheets.
 RUN mkdir -p /tmp/katex-install && cd /tmp/katex-install \
     && npm init -y >/dev/null \
-    && npm install --no-audit --no-fund --silent katex@0.18.1 \
+    && npm install --no-audit --no-fund --silent \
+      --engine-strict --strict-allow-scripts katex@0.18.1 \
     && mkdir -p /app/static/vendor/katex@0.18.1/fonts \
     && cp node_modules/katex/dist/katex.min.js /app/static/vendor/katex@0.18.1/ \
     && cp node_modules/katex/dist/katex.mjs    /app/static/vendor/katex@0.18.1/ \
     && cp node_modules/katex/dist/katex.min.css /app/static/vendor/katex@0.18.1/ \
     && cp node_modules/katex/dist/fonts/*.woff2 /app/static/vendor/katex@0.18.1/fonts/ \
     && ln -s katex@0.18.1 /app/static/vendor/katex \
-    && cd / && rm -rf /tmp/katex-install
+    && cd / && rm -rf /tmp/katex-install /root/.npm
 
 # Frontend static files + app-frame served by FastAPI, plus the full source
 # tree retained for /data/platform/frontend/node_modules to link at runtime.
@@ -310,12 +322,9 @@ RUN set -eux; \
     chown -R root:root /app/platform-baked; \
     chmod -R a+rX,go-w /app/platform-baked
 
-# Create a non-root user so the agent can use --dangerously-skip-permissions.
-RUN useradd -m -s /bin/bash mobius \
-    && mkdir -p /data/db /data/apps /data/compiled /data/shared \
-    && chown -R mobius:mobius /data \
-    && ln -s /opt/agent-browser /home/mobius/.agent-browser \
-    && chown -R mobius:mobius /opt/agent-browser
+# Initialize the runtime volume paths for the non-root agent user.
+RUN mkdir -p /data/db /data/apps /data/compiled /data/shared \
+    && chown -R mobius:mobius /data
 
 # Runtime source belongs at the tail of the image so normal code changes reuse
 # the browser, CLI, Python, vendor, and platform-seed layers above.

--- a/backend/app/browser_profiles.py
+++ b/backend/app/browser_profiles.py
@@ -17,6 +17,10 @@ from app.run_state import running_chat_ids
 
 
 _CHAT_PROFILE = re.compile(r"^chat-([0-9a-fA-F-]{36})$")
+_AGENT_BROWSER_SERVER_EXECUTABLES = frozenset({
+  "agent-browser-linux-arm64",
+  "agent-browser-linux-x64",
+})
 _CACHE_PATHS = (
   "Default/Cache",
   "Default/Code Cache",
@@ -197,7 +201,7 @@ def browser_session_targets_for_chat(
     try:
       argv = (process / "cmdline").read_bytes().split(b"\0")
       executable = Path(argv[0].decode("utf-8", errors="replace")).name
-      if executable != "agent-browser-linux-x64":
+      if executable not in _AGENT_BROWSER_SERVER_EXECUTABLES:
         continue
       values: dict[bytes, str] = {}
       for raw in (process / "environ").read_bytes().split(b"\0"):

--- a/backend/scripts/fork-chat.sh
+++ b/backend/scripts/fork-chat.sh
@@ -51,7 +51,7 @@ proj_dir="-$(echo "$DATA_DIR" | sed 's#^/##; s#/#-#g')"
 transcript_exists() { [[ -n "$1" && -f "$CLAUDE_CONFIG_DIR/projects/$proj_dir/$1.jsonl" ]]; }
 
 # The chat's recent transcript tail (last N messages), the seed for the
-# reseed fallbacks. (python3; the container has no sqlite3 CLI.)
+# reseed fallbacks. Python keeps the message-boundary handling explicit.
 #
 # Boundary-safe by construction: the old `tail -c 8000` sliced the messages
 # JSON mid-object / mid-UTF-8 while labeling the result "recent messages as

--- a/backend/scripts/seed-skills/reflection.md
+++ b/backend/scripts/seed-skills/reflection.md
@@ -129,7 +129,8 @@ On nights with user activity, this is the first phase and the one you may not sk
 **Find every active chat and subagent run with activity in the last 24h, plus
 every recoverable deleted chat from the last 7 days.**
 
-User chats — query the DB directly (no auth needed; the container has no `sqlite3` CLI, use `python3`):
+User chats — query the DB directly with Python (no auth needed) so the timestamp
+and output handling stay explicit:
 
 ```bash
 python3 - <<'PY'

--- a/backend/tests/test_browser_profiles.py
+++ b/backend/tests/test_browser_profiles.py
@@ -56,11 +56,12 @@ def test_profile_sweep_interval_is_hourly_and_bounded(monkeypatch):
 
 def _fake_browser_process(
   proc, pid, *, chat_id, session, namespace=None, socket_dir=None,
+  executable="agent-browser-linux-x64",
 ):
   process = proc / str(pid)
   process.mkdir(parents=True)
   (process / "cmdline").write_bytes(
-    b"/usr/local/lib/agent-browser-linux-x64\0"
+    f"/usr/local/lib/{executable}\0".encode()
   )
   values = {
     "CHAT_ID": chat_id,
@@ -90,6 +91,14 @@ def test_browser_sessions_for_chat_preserves_opaque_session_values(tmp_path):
     namespace="custom/ns", socket_dir="/tmp/ab-sockets",
   )
   _fake_browser_process(proc, 107, chat_id="chat-a", session="-x")
+  _fake_browser_process(
+    proc, 108, chat_id="chat-a", session="arm-preview",
+    executable="agent-browser-linux-arm64",
+  )
+  _fake_browser_process(
+    proc, 109, chat_id="chat-a", session="lookalike",
+    executable="agent-browser-linux-x64-wrapper",
+  )
 
   foreign = proc / "104"
   foreign.mkdir()
@@ -119,6 +128,7 @@ def test_browser_sessions_for_chat_preserves_opaque_session_values(tmp_path):
       socket_dir="/tmp/ab-sockets",
     ),
     browser_profiles.BrowserSessionTarget(session="-x"),
+    browser_profiles.BrowserSessionTarget(session="arm-preview"),
   })
 
 

--- a/backend/tests/test_verify_test_runtime.py
+++ b/backend/tests/test_verify_test_runtime.py
@@ -139,19 +139,24 @@ def test_node_runtime_satisfies_the_pinned_agent_browser_engine():
   dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
   preship = (ROOT / "scripts" / "preship-gate.sh").read_text(encoding="utf-8")
   assert "FROM node:24-trixie-slim AS node-runtime" in dockerfile
-  assert re.search(
-    r"^ARG AGENT_BROWSER_VERSION=\d+\.\d+\.\d+$", dockerfile, re.MULTILINE,
-  )
-  assert dockerfile.count("agent-browser@${AGENT_BROWSER_VERSION}") == 2
-  assert (
-    '--allow-scripts="esbuild@0.28.1,@anthropic-ai/claude-code@2.1.220,'
-    'agent-browser@${AGENT_BROWSER_VERSION}"'
-  ) in dockerfile
-  assert dockerfile.count("--engine-strict --strict-allow-scripts") == 3
+  pinned_script_packages = {
+    "esbuild": "ESBUILD_VERSION",
+    "@anthropic-ai/claude-code": "CLAUDE_CODE_VERSION",
+    "agent-browser": "AGENT_BROWSER_VERSION",
+  }
+  for version_argument in pinned_script_packages.values():
+    assert re.search(
+      rf"^ARG {version_argument}=\d+\.\d+\.\d+$",
+      dockerfile,
+      re.MULTILINE,
+    )
   apt_layer = dockerfile[
     dockerfile.index("# System deps and global npm packages"):
     dockerfile.index("# tectonic is a server-side subprocess")
   ]
+  for package, version_argument in pinned_script_packages.items():
+    assert apt_layer.count(f"{package}@${{{version_argument}}}") == 2
+  assert "--engine-strict --strict-allow-scripts" in apt_layer
   for package in ("jq", "ripgrep", "sqlite3", "unzip"):
     assert re.search(rf"\b{package}\b", apt_layer)
   assert "node:24-trixie-slim sh -c" in preship

--- a/backend/tests/test_verify_test_runtime.py
+++ b/backend/tests/test_verify_test_runtime.py
@@ -1,6 +1,7 @@
 import fcntl
 import os
 from pathlib import Path
+import re
 import shutil
 import subprocess
 import sys
@@ -114,10 +115,12 @@ def test_test_wrapper_isolates_compose_and_rejects_stale_images():
   assert "the test runner never rebuilds" in wrapper
   dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
   assert "COPY Dockerfile ./test-image-inputs/Dockerfile" not in dockerfile
-  shell_deps = "RUN cd ./shell-src && npm ci --ignore-scripts"
+  shell_deps = (
+    "COPY frontend/package.json frontend/package-lock.json* ./shell-src/"
+  )
   retained_assets = (
-    "RUN mkdir -p /tmp/pdfjs-install",
-    "RUN mkdir -p /tmp/katex-install",
+    "mkdir -p /tmp/pdfjs-install",
+    "mkdir -p /tmp/katex-install",
   )
   backend_source = "COPY backend/app ./app/"
   backend_scripts = "COPY backend/scripts ./scripts/"
@@ -136,11 +139,21 @@ def test_node_runtime_satisfies_the_pinned_agent_browser_engine():
   dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
   preship = (ROOT / "scripts" / "preship-gate.sh").read_text(encoding="utf-8")
   assert "FROM node:24-trixie-slim AS node-runtime" in dockerfile
+  assert re.search(
+    r"^ARG AGENT_BROWSER_VERSION=\d+\.\d+\.\d+$", dockerfile, re.MULTILINE,
+  )
+  assert dockerfile.count("agent-browser@${AGENT_BROWSER_VERSION}") == 2
   assert (
-    "npm install -g --allow-scripts=agent-browser@0.33.2 "
-    "agent-browser@0.33.2"
+    '--allow-scripts="esbuild@0.28.1,@anthropic-ai/claude-code@2.1.220,'
+    'agent-browser@${AGENT_BROWSER_VERSION}"'
   ) in dockerfile
-  assert "git jq ripgrep sqlite3 sudo unzip" in dockerfile
+  assert dockerfile.count("--engine-strict --strict-allow-scripts") == 3
+  apt_layer = dockerfile[
+    dockerfile.index("# System deps and global npm packages"):
+    dockerfile.index("# tectonic is a server-side subprocess")
+  ]
+  for package in ("jq", "ripgrep", "sqlite3", "unzip"):
+    assert re.search(rf"\b{package}\b", apt_layer)
   assert "node:24-trixie-slim sh -c" in preship
   assert "node:22" not in dockerfile
   assert "node:22" not in preship
@@ -149,12 +162,16 @@ def test_node_runtime_satisfies_the_pinned_agent_browser_engine():
 def test_tectonic_release_is_verified_for_supported_image_architectures():
   dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
   tectonic_layer = dockerfile[
-    dockerfile.index("ARG TECTONIC_VERSION=0.17.0"):
+    dockerfile.index("ARG TECTONIC_VERSION="):
     dockerfile.index("# GitHub CLI:")
   ]
 
-  assert "TECTONIC_SHA256_AMD64=" in tectonic_layer
-  assert "TECTONIC_SHA256_ARM64=" in tectonic_layer
+  for architecture in ("AMD64", "ARM64"):
+    assert re.search(
+      rf"^ARG TECTONIC_SHA256_{architecture}=[0-9a-f]{{64}}$",
+      tectonic_layer,
+      re.MULTILINE,
+    )
   assert "amd64) target=x86_64" in tectonic_layer
   assert "arm64) target=aarch64" in tectonic_layer
   assert 'echo "${sha256}  /tmp/${tarball}" | sha256sum -c -' in tectonic_layer


### PR DESCRIPTION
## Summary

- keep npm download caches out of every image layer and set Chromium ownership in its creation layer, avoiding a later copy-on-write duplicate
- make the agent-browser version a single Docker build argument, enforce Node engines, and allow lifecycle scripts only for the three pinned packages that require them
- preserve best-effort CLI release metadata generation while cleaning its npm cache
- recognize only the supported x64 and ARM64 agent-browser Linux daemons during chat cleanup, rejecting lookalike process names
- replace version/order-coupled Dockerfile tests with semantic pin, checksum, architecture, lifecycle-policy, and tool-presence checks
- correct guidance that still said sqlite3 was absent

## Why

The current production image exposes a 359 MB npm cache, and its late recursive Chromium chown creates a separate roughly 408 MB uncompressed layer. Neither payload serves runtime work. The running hot-updated container has accumulated a 609 MB npm cache, confirming this is material for constrained self-host and Railway deployments.

Consolidating the global npm install under a strict exact-version lifecycle policy also makes future transitive install scripts fail closed instead of silently executing during image construction. The static browser daemon allowlist keeps multi-architecture cleanup support from accepting arbitrary similarly named processes.

## Validation

- post-#601 scratch/browser/supervisor and Docker contract integration tests: 71 passed
- hermetic backend contract suite: 73 passed
- Dockerfile build check: passed with no warnings on the original branch revision
- shell syntax and diff checks: passed
- strict agent-browser 0.33.2 npm install under Node 24: passed on the original branch revision

The live container is intentionally unchanged by this PR; these image-size improvements take effect on the next normal image build. The revision is rebased onto #601’s complete process-discovery contract and is also covered by the repository's full hosted backend and E2E gates before merge.
