### PR TITLE
Add live recovery attachment target

### DIFF
--- a/.github/workflows/core-digest-image.yml
+++ b/.github/workflows/core-digest-image.yml
@@ -1,0 +1,486 @@
+name: Publish managed core digest
+
+on:
+  push:
+    branches: [stack/external-recovery-v1]
+  workflow_dispatch:
+    inputs:
+      candidate_sha:
+        description: Exact candidate SHA; set only to resume an older in-flight release
+        required: false
+        type: string
+      prerequisite_sha:
+        description: Exact completed managed-core build SHA (defaults to the protected repository variable)
+        required: false
+        type: string
+      prerequisite_digest:
+        description: Exact completed managed-core image digest (defaults to the protected repository variable)
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  DOCKER_BUILD_RECORD_UPLOAD: 'false'
+  MOBIUS_IMAGE_REPOSITORY: ghcr.io/mobius-os/mobius
+  MOBIUS_RECOVERY_IMAGE_REPOSITORY: ghcr.io/mobius-os/mobius-recovery
+  # This is a controller channel identity, not a mutable core pointer. The
+  # recurring workflow never writes :external-recovery (or any other channel).
+  MOBIUS_RELEASE_CHANNEL: ghcr.io/mobius-os/mobius:external-recovery
+  MOBIUS_PLATFORM_RELEASE_REF: refs/heads/stack/external-recovery-v1
+  CANDIDATE_SHA: ${{ inputs.candidate_sha || github.sha }}
+  CORE_PREREQUISITE_SHA: ${{ inputs.prerequisite_sha || vars.MOBIUS_MANAGED_CORE_PREREQUISITE_SHA }}
+  CORE_PREREQUISITE_DIGEST: ${{ inputs.prerequisite_digest || vars.MOBIUS_MANAGED_CORE_PREREQUISITE_DIGEST }}
+  FROZEN_COMPATIBILITY_SHA: ${{ vars.MOBIUS_EXTERNAL_RECOVERY_PREREQUISITE_SHA }}
+  FROZEN_COMPATIBILITY_DIGEST: ${{ vars.MOBIUS_EXTERNAL_RECOVERY_PREREQUISITE_DIGEST }}
+
+# Serialize with the historical cutover publisher. Once this workflow binds an
+# immutable digest, it must be allowed to finish even if the branch advances.
+concurrency:
+  group: mobius-core-image-publication
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: github.event_name == 'workflow_dispatch' || vars.MOBIUS_MANAGED_CORE_RELEASE_ENABLED == 'true'
+    environment: external-recovery-release
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ env.CANDIDATE_SHA }}
+
+      - name: Resolve exact candidate and protected release intent
+        id: identity
+        run: |
+          test "$GITHUB_REPOSITORY" = mobius-os/mobius
+          case "$GITHUB_EVENT_NAME" in
+            push|workflow_dispatch) ;;
+            *) exit 2 ;;
+          esac
+          test "$GITHUB_REF" = "$MOBIUS_PLATFORM_RELEASE_REF"
+          for sha in "$CANDIDATE_SHA" "$GITHUB_SHA" "$CORE_PREREQUISITE_SHA"; do
+            case "$sha" in
+              *[!0-9a-f]*|'') exit 2 ;;
+            esac
+            test "${#sha}" -eq 40
+          done
+          case "$CORE_PREREQUISITE_DIGEST" in
+            sha256:????????????????????????????????????????????????????????????????) ;;
+            *) exit 2 ;;
+          esac
+          case "${CORE_PREREQUISITE_DIGEST#sha256:}" in
+            *[!0-9a-f]*|'') exit 2 ;;
+          esac
+          test "$(git rev-parse HEAD)" = "$CANDIDATE_SHA"
+          git cat-file -e "$CORE_PREREQUISITE_SHA^{commit}"
+          git merge-base --is-ancestor "$CORE_PREREQUISITE_SHA" "$CANDIDATE_SHA"
+
+          git ls-remote --exit-code origin "$MOBIUS_PLATFORM_RELEASE_REF" > "$RUNNER_TEMP/release-head"
+          test "$(wc -l < "$RUNNER_TEMP/release-head")" -eq 1
+          read -r release_head release_ref < "$RUNNER_TEMP/release-head"
+          test "$release_ref" = "$MOBIUS_PLATFORM_RELEASE_REF"
+          case "$GITHUB_EVENT_NAME" in
+            push)
+              test "$CANDIDATE_SHA" = "$GITHUB_SHA"
+              test "$release_head" = "$CANDIDATE_SHA"
+              ;;
+            workflow_dispatch)
+              test "$release_head" = "$GITHUB_SHA"
+              git merge-base --is-ancestor "$CANDIDATE_SHA" "$release_head"
+              ;;
+          esac
+          {
+            echo "date=$(git show -s --format=%cs HEAD)"
+            echo "epoch=managed-core-v1-$CANDIDATE_SHA"
+          } >> "$GITHUB_OUTPUT"
+
+      # The endpoint is the dynamic source of truth. Protected variables and
+      # dispatch inputs are only intent and must equal this completed identity.
+      - name: Verify current completed core with the controller
+        id: current
+        env:
+          MOBIUS_YOU_CORE_RELEASE_URL: ${{ secrets.MOBIUS_YOU_CORE_RELEASE_URL }}
+          MOBIUS_YOU_CORE_RELEASE_TOKEN: ${{ secrets.MOBIUS_YOU_CORE_RELEASE_TOKEN }}
+          CANDIDATE_EPOCH: ${{ steps.identity.outputs.epoch }}
+        run: |
+          if [ -z "${MOBIUS_YOU_CORE_RELEASE_URL:-}" ] || \
+             [ -z "${MOBIUS_YOU_CORE_RELEASE_TOKEN:-}" ]; then
+            echo "The separate mobius.you core-release credentials are required" >&2
+            exit 1
+          fi
+          response="$RUNNER_TEMP/current-core.json"
+          http_status=$(curl --silent --show-error --retry 3 --retry-all-errors \
+            --connect-timeout 10 --max-time 45 \
+            --output "$response" --write-out '%{http_code}' \
+            --header "Authorization: Bearer $MOBIUS_YOU_CORE_RELEASE_TOKEN" \
+            "${MOBIUS_YOU_CORE_RELEASE_URL%/}/internal/core-releases/current")
+          values=$(python3 scripts/core_digest_release.py current \
+            --response "$response" \
+            --http-status "$http_status" \
+            --release-channel "$MOBIUS_RELEASE_CHANNEL" \
+            --platform-release-ref "$MOBIUS_PLATFORM_RELEASE_REF" \
+            --prerequisite-sha "$CORE_PREREQUISITE_SHA" \
+            --prerequisite-digest "$CORE_PREREQUISITE_DIGEST" \
+            --candidate-sha "$CANDIDATE_SHA" \
+            --candidate-epoch "$CANDIDATE_EPOCH" \
+            --branch-head-sha "$GITHUB_SHA")
+          IFS='|' read -r mode generation active_digest <<EOF
+          $values
+          EOF
+          {
+            echo "mode=$mode"
+            echo "generation=$generation"
+            echo "active_digest=$active_digest"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Prove frozen compatibility channels and dynamic prerequisite
+        run: |
+          anonymous_config="$RUNNER_TEMP/anonymous-docker-prerequisites"
+          install -d -m 0700 "$anonymous_config"
+          DOCKER_CONFIG="$anonymous_config" python3 scripts/external_recovery_release.py \
+            inventory \
+            --repository "$MOBIUS_IMAGE_REPOSITORY" \
+            --prerequisite-revision "$FROZEN_COMPATIBILITY_SHA" \
+            --prerequisite-digest "$FROZEN_COMPATIBILITY_DIGEST"
+          DOCKER_CONFIG="$anonymous_config" python3 scripts/core_digest_release.py \
+            image \
+            --repository "$MOBIUS_IMAGE_REPOSITORY" \
+            --revision "$CORE_PREREQUISITE_SHA" \
+            --digest "$CORE_PREREQUISITE_DIGEST"
+
+      # Candidate == current is a clean manual replay: the controller and
+      # registry have both proved the exact identity, so no mutation is needed.
+      - name: Record exact-current replay
+        if: steps.current.outputs.mode == 'replay'
+        run: echo "The candidate is already the exact completed managed core"
+
+      - name: Acquire recurring core prepublish gate and wait for audit
+        if: steps.current.outputs.mode != 'replay'
+        id: gate
+        env:
+          MOBIUS_YOU_CORE_RELEASE_URL: ${{ secrets.MOBIUS_YOU_CORE_RELEASE_URL }}
+          MOBIUS_YOU_CORE_RELEASE_TOKEN: ${{ secrets.MOBIUS_YOU_CORE_RELEASE_TOKEN }}
+          CUTOVER_EPOCH: ${{ steps.identity.outputs.epoch }}
+          EXPECTED_ACTIVE_DIGEST: ${{ steps.current.outputs.active_digest }}
+        run: |
+          payload="$RUNNER_TEMP/core-release-payload.json"
+          python3 scripts/core_digest_release.py payload \
+            --output "$payload" \
+            --epoch "$CUTOVER_EPOCH" \
+            --release-channel "$MOBIUS_RELEASE_CHANNEL" \
+            --platform-release-ref "$MOBIUS_PLATFORM_RELEASE_REF" \
+            --prerequisite-sha "$CORE_PREREQUISITE_SHA" \
+            --prerequisite-digest "$CORE_PREREQUISITE_DIGEST" \
+            --candidate-sha "$CANDIDATE_SHA"
+          wait_deadline=$(($(date -u +%s) + 7200))
+          response="$RUNNER_TEMP/core-release-prepublish.json"
+          frozen_sequence=""
+          frozen_sha=""
+          frozen_digest=""
+          current_r_sequence=""
+          current_r_sha=""
+          current_r_digest=""
+          while true; do
+            http_status=$(curl --silent --show-error --retry 3 --retry-all-errors \
+              --connect-timeout 10 --max-time 45 \
+              --output "$response" --write-out '%{http_code}' \
+              --request POST \
+              --header "Authorization: Bearer $MOBIUS_YOU_CORE_RELEASE_TOKEN" \
+              --header 'Content-Type: application/json' \
+              --data-binary "@$payload" \
+              "${MOBIUS_YOU_CORE_RELEASE_URL%/}/internal/core-releases/prepublish")
+            values=$(python3 scripts/external_recovery_release.py gate \
+              --response "$response" \
+              --http-status "$http_status" \
+              --epoch "$CUTOVER_EPOCH" \
+              --release-channel "$MOBIUS_RELEASE_CHANNEL" \
+              --platform-release-ref "$MOBIUS_PLATFORM_RELEASE_REF" \
+              --prerequisite-sha "$CORE_PREREQUISITE_SHA" \
+              --prerequisite-digest "$CORE_PREREQUISITE_DIGEST" \
+              --removal-sha "$CANDIDATE_SHA")
+            IFS='|' read -r decision bound_digest frozen_sequence_seen frozen_sha_seen frozen_digest_seen current_sequence_seen current_sha_seen current_digest_seen <<EOF
+          $values
+          EOF
+            if [ -z "$frozen_sequence" ]; then
+              frozen_sequence=$frozen_sequence_seen
+              frozen_sha=$frozen_sha_seen
+              frozen_digest=$frozen_digest_seen
+              current_r_sequence=$current_sequence_seen
+              current_r_sha=$current_sha_seen
+              current_r_digest=$current_digest_seen
+            else
+              test "$frozen_sequence_seen" = "$frozen_sequence"
+              test "$frozen_sha_seen" = "$frozen_sha"
+              test "$frozen_digest_seen" = "$frozen_digest"
+              test "$current_sequence_seen" = "$current_r_sequence"
+              test "$current_sha_seen" = "$current_r_sha"
+              test "$current_digest_seen" = "$current_r_digest"
+            fi
+            if [ "$decision" != wait ]; then
+              if [ -n "$EXPECTED_ACTIVE_DIGEST" ] && \
+                 [ "$bound_digest" != "$EXPECTED_ACTIVE_DIGEST" ]; then
+                echo "The active controller digest changed before prepublish" >&2
+                exit 1
+              fi
+              {
+                echo "mode=$decision"
+                echo "bound_digest=$bound_digest"
+                echo "frozen_recovery_sequence=$frozen_sequence_seen"
+                echo "frozen_recovery_sha=$frozen_sha_seen"
+                echo "frozen_recovery_digest=$frozen_digest_seen"
+                echo "current_recovery_sequence=$current_sequence_seen"
+                echo "current_recovery_sha=$current_sha_seen"
+                echo "current_recovery_digest=$current_digest_seen"
+              } >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            if [ "$(date -u +%s)" -ge "$wait_deadline" ]; then
+              echo "Timed out waiting for the recurring core audit" >&2
+              exit 1
+            fi
+            echo "Recurring core audit is still reconciling"
+            sleep 10
+          done
+
+      - name: Prove the audited recovery worker by exact digest
+        if: steps.current.outputs.mode != 'replay'
+        env:
+          RECOVERY_DIGEST: ${{ steps.gate.outputs.current_recovery_digest }}
+          RECOVERY_SHA: ${{ steps.gate.outputs.current_recovery_sha }}
+        run: |
+          anonymous_config="$RUNNER_TEMP/anonymous-docker-recovery"
+          install -d -m 0700 "$anonymous_config"
+          DOCKER_CONFIG="$anonymous_config" python3 scripts/external_recovery_release.py \
+            worker \
+            --repository "$MOBIUS_RECOVERY_IMAGE_REPOSITORY" \
+            --digest "$RECOVERY_DIGEST" \
+            --revision "$RECOVERY_SHA"
+
+      - name: Log in to GitHub Container Registry
+        if: steps.gate.outputs.mode == 'build_cutover'
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish immutable workflow-attempt image
+        if: steps.gate.outputs.mode == 'build_cutover'
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          push: true
+          tags: ${{ env.MOBIUS_IMAGE_REPOSITORY }}:sha-${{ env.CANDIDATE_SHA }}-run-${{ github.run_id }}-attempt-${{ github.run_attempt }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ env.CANDIDATE_SHA }}
+          build-args: |
+            BUILD_SHA=${{ env.CANDIDATE_SHA }}
+            BUILD_DATE=${{ steps.identity.outputs.date }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max,ignore-error=true
+
+      - name: Select and prove the one immutable candidate digest
+        if: steps.current.outputs.mode != 'replay'
+        id: selected
+        env:
+          BUILT_DIGEST: ${{ steps.build.outputs.digest }}
+          BOUND_DIGEST: ${{ steps.gate.outputs.bound_digest }}
+          RELEASE_MODE: ${{ steps.gate.outputs.mode }}
+        run: |
+          if [ "$RELEASE_MODE" = build_cutover ]; then
+            digest=$BUILT_DIGEST
+          else
+            digest=$BOUND_DIGEST
+          fi
+          case "$digest" in
+            sha256:????????????????????????????????????????????????????????????????) ;;
+            *) echo "The selected image digest is invalid" >&2; exit 1 ;;
+          esac
+          case "${digest#sha256:}" in
+            *[!0-9a-f]*|'') exit 2 ;;
+          esac
+          test "$digest" != "$CORE_PREREQUISITE_DIGEST"
+          anonymous_config="$RUNNER_TEMP/anonymous-docker-candidate"
+          install -d -m 0700 "$anonymous_config"
+          DOCKER_CONFIG="$anonymous_config" python3 scripts/core_digest_release.py \
+            image \
+            --repository "$MOBIUS_IMAGE_REPOSITORY" \
+            --revision "$CANDIDATE_SHA" \
+            --digest "$digest"
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
+      # The audit may take hours. Only a digest already bound by the controller
+      # may outlive branch ownership; a fresh build must still own HEAD at bind.
+      - name: Recheck protected-branch ownership before binding
+        if: steps.gate.outputs.mode == 'build_cutover'
+        run: |
+          git ls-remote --exit-code origin "$MOBIUS_PLATFORM_RELEASE_REF" \
+            > "$RUNNER_TEMP/release-head-before-bind"
+          test "$(wc -l < "$RUNNER_TEMP/release-head-before-bind")" -eq 1
+          read -r release_head release_ref \
+            < "$RUNNER_TEMP/release-head-before-bind"
+          test "$release_ref" = "$MOBIUS_PLATFORM_RELEASE_REF"
+          if [ "$release_head" != "$CANDIDATE_SHA" ]; then
+            echo "Refusing to bind a candidate that no longer owns the protected branch" >&2
+            exit 1
+          fi
+
+      - name: Bind exact candidate digest
+        if: steps.gate.outputs.mode == 'build_cutover'
+        env:
+          MOBIUS_YOU_CORE_RELEASE_URL: ${{ secrets.MOBIUS_YOU_CORE_RELEASE_URL }}
+          MOBIUS_YOU_CORE_RELEASE_TOKEN: ${{ secrets.MOBIUS_YOU_CORE_RELEASE_TOKEN }}
+          CUTOVER_EPOCH: ${{ steps.identity.outputs.epoch }}
+          IMAGE_DIGEST: ${{ steps.selected.outputs.digest }}
+          FROZEN_RECOVERY_SEQUENCE: ${{ steps.gate.outputs.frozen_recovery_sequence }}
+          FROZEN_RECOVERY_SHA: ${{ steps.gate.outputs.frozen_recovery_sha }}
+          FROZEN_RECOVERY_DIGEST: ${{ steps.gate.outputs.frozen_recovery_digest }}
+          CURRENT_RECOVERY_SEQUENCE: ${{ steps.gate.outputs.current_recovery_sequence }}
+          CURRENT_RECOVERY_SHA: ${{ steps.gate.outputs.current_recovery_sha }}
+          CURRENT_RECOVERY_DIGEST: ${{ steps.gate.outputs.current_recovery_digest }}
+        run: |
+          payload="$RUNNER_TEMP/core-release-bound-payload.json"
+          python3 scripts/core_digest_release.py bound-payload \
+            --output "$payload" \
+            --epoch "$CUTOVER_EPOCH" \
+            --release-channel "$MOBIUS_RELEASE_CHANNEL" \
+            --platform-release-ref "$MOBIUS_PLATFORM_RELEASE_REF" \
+            --prerequisite-sha "$CORE_PREREQUISITE_SHA" \
+            --prerequisite-digest "$CORE_PREREQUISITE_DIGEST" \
+            --candidate-sha "$CANDIDATE_SHA" \
+            --candidate-digest "$IMAGE_DIGEST"
+          response="$RUNNER_TEMP/core-release-bind.json"
+          http_status=$(curl --silent --show-error --retry 3 --retry-all-errors \
+            --connect-timeout 10 --max-time 45 \
+            --output "$response" --write-out '%{http_code}' \
+            --request POST \
+            --header "Authorization: Bearer $MOBIUS_YOU_CORE_RELEASE_TOKEN" \
+            --header 'Content-Type: application/json' \
+            --data-binary "@$payload" \
+            "${MOBIUS_YOU_CORE_RELEASE_URL%/}/internal/core-releases/bind")
+          python3 scripts/external_recovery_release.py bind \
+            --response "$response" \
+            --http-status "$http_status" \
+            --epoch "$CUTOVER_EPOCH" \
+            --release-channel "$MOBIUS_RELEASE_CHANNEL" \
+            --platform-release-ref "$MOBIUS_PLATFORM_RELEASE_REF" \
+            --prerequisite-sha "$CORE_PREREQUISITE_SHA" \
+            --prerequisite-digest "$CORE_PREREQUISITE_DIGEST" \
+            --removal-sha "$CANDIDATE_SHA" \
+            --removal-digest "$IMAGE_DIGEST" \
+            --frozen-recovery-sequence "$FROZEN_RECOVERY_SEQUENCE" \
+            --frozen-recovery-sha "$FROZEN_RECOVERY_SHA" \
+            --frozen-recovery-digest "$FROZEN_RECOVERY_DIGEST" \
+            --current-recovery-sequence "$CURRENT_RECOVERY_SEQUENCE" \
+            --current-recovery-sha "$CURRENT_RECOVERY_SHA" \
+            --current-recovery-digest "$CURRENT_RECOVERY_DIGEST"
+
+      - name: Roll exact digest across the audited fleet and finalize
+        if: steps.gate.outputs.mode == 'build_cutover' || steps.gate.outputs.mode == 'resume_cutover'
+        env:
+          MOBIUS_YOU_CORE_RELEASE_URL: ${{ secrets.MOBIUS_YOU_CORE_RELEASE_URL }}
+          MOBIUS_YOU_CORE_RELEASE_TOKEN: ${{ secrets.MOBIUS_YOU_CORE_RELEASE_TOKEN }}
+          CUTOVER_EPOCH: ${{ steps.identity.outputs.epoch }}
+          IMAGE_DIGEST: ${{ steps.selected.outputs.digest }}
+          FROZEN_RECOVERY_SEQUENCE: ${{ steps.gate.outputs.frozen_recovery_sequence }}
+          FROZEN_RECOVERY_SHA: ${{ steps.gate.outputs.frozen_recovery_sha }}
+          FROZEN_RECOVERY_DIGEST: ${{ steps.gate.outputs.frozen_recovery_digest }}
+          CURRENT_RECOVERY_SEQUENCE: ${{ steps.gate.outputs.current_recovery_sequence }}
+          CURRENT_RECOVERY_SHA: ${{ steps.gate.outputs.current_recovery_sha }}
+          CURRENT_RECOVERY_DIGEST: ${{ steps.gate.outputs.current_recovery_digest }}
+        run: |
+          payload="$RUNNER_TEMP/core-release-bound-payload.json"
+          python3 scripts/core_digest_release.py bound-payload \
+            --output "$payload" \
+            --epoch "$CUTOVER_EPOCH" \
+            --release-channel "$MOBIUS_RELEASE_CHANNEL" \
+            --platform-release-ref "$MOBIUS_PLATFORM_RELEASE_REF" \
+            --prerequisite-sha "$CORE_PREREQUISITE_SHA" \
+            --prerequisite-digest "$CORE_PREREQUISITE_DIGEST" \
+            --candidate-sha "$CANDIDATE_SHA" \
+            --candidate-digest "$IMAGE_DIGEST"
+          response="$RUNNER_TEMP/core-release-postpublish.json"
+          wait_deadline=$(($(date -u +%s) + 7200))
+          while true; do
+            http_status=$(curl --silent --show-error --retry 3 --retry-all-errors \
+              --connect-timeout 10 --max-time 45 \
+              --output "$response" --write-out '%{http_code}' \
+              --request POST \
+              --header "Authorization: Bearer $MOBIUS_YOU_CORE_RELEASE_TOKEN" \
+              --header 'Content-Type: application/json' \
+              --data-binary "@$payload" \
+              "${MOBIUS_YOU_CORE_RELEASE_URL%/}/internal/core-releases/postpublish")
+            decision=$(python3 scripts/external_recovery_release.py postpublish \
+              --response "$response" \
+              --http-status "$http_status" \
+              --epoch "$CUTOVER_EPOCH" \
+              --release-channel "$MOBIUS_RELEASE_CHANNEL" \
+              --platform-release-ref "$MOBIUS_PLATFORM_RELEASE_REF" \
+              --prerequisite-sha "$CORE_PREREQUISITE_SHA" \
+              --prerequisite-digest "$CORE_PREREQUISITE_DIGEST" \
+              --removal-sha "$CANDIDATE_SHA" \
+              --removal-digest "$IMAGE_DIGEST" \
+              --frozen-recovery-sequence "$FROZEN_RECOVERY_SEQUENCE" \
+              --frozen-recovery-sha "$FROZEN_RECOVERY_SHA" \
+              --frozen-recovery-digest "$FROZEN_RECOVERY_DIGEST" \
+              --current-recovery-sequence "$CURRENT_RECOVERY_SEQUENCE" \
+              --current-recovery-sha "$CURRENT_RECOVERY_SHA" \
+              --current-recovery-digest "$CURRENT_RECOVERY_DIGEST")
+            [ "$decision" = success ] && break
+            if [ "$(date -u +%s)" -ge "$wait_deadline" ]; then
+              echo "Timed out waiting for exact managed-core fleet verification" >&2
+              exit 1
+            fi
+            echo "Managed-core fleet verification is still reconciling"
+            sleep 10
+          done
+
+      - name: Verify completed controller identity and frozen channels
+        if: steps.current.outputs.mode != 'replay'
+        env:
+          MOBIUS_YOU_CORE_RELEASE_URL: ${{ secrets.MOBIUS_YOU_CORE_RELEASE_URL }}
+          MOBIUS_YOU_CORE_RELEASE_TOKEN: ${{ secrets.MOBIUS_YOU_CORE_RELEASE_TOKEN }}
+          IMAGE_DIGEST: ${{ steps.selected.outputs.digest }}
+          CANDIDATE_EPOCH: ${{ steps.identity.outputs.epoch }}
+        run: |
+          response="$RUNNER_TEMP/final-current-core.json"
+          http_status=$(curl --silent --show-error --retry 3 --retry-all-errors \
+            --connect-timeout 10 --max-time 45 \
+            --output "$response" --write-out '%{http_code}' \
+            --header "Authorization: Bearer $MOBIUS_YOU_CORE_RELEASE_TOKEN" \
+            "${MOBIUS_YOU_CORE_RELEASE_URL%/}/internal/core-releases/current")
+          values=$(python3 scripts/core_digest_release.py current \
+            --response "$response" \
+            --http-status "$http_status" \
+            --release-channel "$MOBIUS_RELEASE_CHANNEL" \
+            --platform-release-ref "$MOBIUS_PLATFORM_RELEASE_REF" \
+            --prerequisite-sha "$CANDIDATE_SHA" \
+            --prerequisite-digest "$IMAGE_DIGEST" \
+            --candidate-sha "$CANDIDATE_SHA" \
+            --candidate-epoch "$CANDIDATE_EPOCH" \
+            --branch-head-sha "$CANDIDATE_SHA")
+          test "${values%%|*}" = replay
+
+          anonymous_config="$RUNNER_TEMP/anonymous-docker-final"
+          install -d -m 0700 "$anonymous_config"
+          DOCKER_CONFIG="$anonymous_config" python3 scripts/core_digest_release.py \
+            image \
+            --repository "$MOBIUS_IMAGE_REPOSITORY" \
+            --revision "$CANDIDATE_SHA" \
+            --digest "$IMAGE_DIGEST"
+          DOCKER_CONFIG="$anonymous_config" python3 scripts/external_recovery_release.py \
+            inventory \
+            --repository "$MOBIUS_IMAGE_REPOSITORY" \
+            --prerequisite-revision "$FROZEN_COMPATIBILITY_SHA" \
+            --prerequisite-digest "$FROZEN_COMPATIBILITY_DIGEST"

--- a/backend/recovery_target/CAPABILITIES.md
+++ b/backend/recovery_target/CAPABILITIES.md
@@ -1,0 +1,80 @@
+# Live recovery capabilities
+
+Normal Möbius containers start the private recovery target on port `18002`
+when `MOBIUS_RECOVERY_CAPABILITY_PUBLIC_KEY` is configured. The value is the
+unpadded base64url encoding of a raw 32-byte Ed25519 public key. The normal app
+keeps running; live recovery does not change `MOBIUS_BOOT_MODE`.
+
+The launcher supplies the worker with a bearer token no longer than 512 ASCII
+bytes in this exact form:
+
+```
+mrc1.<payload>.<signature>
+```
+
+- `payload` is unpadded base64url of UTF-8 JSON produced with sorted keys and
+  compact separators (`json.dumps(claims, sort_keys=True,
+  separators=(",", ":"), ensure_ascii=True)`).
+- `signature` is unpadded base64url of the 64-byte Ed25519 signature over the
+  ASCII bytes `mrc1.<payload>`.
+- Every capability has exactly `v=1`, `iss="mobius.you"`,
+  `aud="mobius-recovery-target"`, `sub` (Möbius instance id), `dep` (Railway
+  deployment id), `scp`, and integer epoch seconds `iat`, `nbf`, and `exp`.
+- A probe has `scp="probe"`, no `sid` or `bid`, a maximum 60-second lifetime,
+  and authorizes only `GET /v1/health`.
+- A repair session has `scp="session"`, `sid` (recovery session id), and `bid`
+  (the exact target boot id). It has a maximum 3,600-second lifetime and
+  authorizes health, exec, filesystem, and self-revoke operations.
+- Identifiers contain 1–128 printable ASCII bytes, and the complete signed
+  token must still fit the 512-byte wire limit. The launcher rejects oversized
+  aggregate claims before issuance; its compact managed instance, deployment,
+  and session identifiers fit this bound. Unknown or missing claims are
+  rejected. `iat <= nbf < exp`; expiry is enforced without clock skew. A
+  30-second positive skew is accepted only for `iat` and `nbf`.
+
+`MOBIUS_INSTANCE_ID` and `RAILWAY_DEPLOYMENT_ID` are required target
+configuration. `sub` and `dep` must match them. The entrypoint also generates a
+fresh, unpredictable 32-character base64url `MOBIUS_RECOVERY_BOOT_ID` for every
+container start. Session `bid` must match that exact boot, so a restart rejects
+all tokens from the previous process even if Railway retains its deployment id.
+Missing or invalid local identity disables the live target without blocking the
+normal Möbius app.
+
+The entrypoint spawns the target early, best-effort, and never probes or waits
+for it, so target initialization or bind failure cannot delay the normal app.
+A unique root-owned `mktemp` file keeps normal target endpoints at
+`503 attach_not_ready` while entrypoint performs boot-time mutations. Immediately
+before handing off to uvicorn, entrypoint writes `ready:<boot-id>`. The target
+validates the exact boot-bound marker as a regular root-owned `0600` `/tmp`
+file, caches readiness, and unlinks it. This is an attachment gate, not an
+application-health gate: repair remains available when uvicorn is degraded or
+fails its health endpoint, while it cannot race initialization or reuse a stale
+marker from another boot.
+
+Every endpoint, including `/v1/health`, verifies the signed bearer. Successful
+live health responses include `deployment_id` and `boot_id`; the launcher can
+exchange a short read-only probe for a session bound to that boot. The server
+admits at most 16 concurrent request handlers, gives the complete request line
+and headers five seconds, and gives an authenticated body at most 30 seconds or
+the time remaining until `exp`, whichever is shorter. An exec still running at
+`exp` has its complete supervised process tree killed before the target returns
+`auth_expired`.
+
+`POST /v1/revoke` accepts exactly `{}` and is intentionally available before
+attachment readiness for session capabilities only. It derives `sid`, `dep`,
+and `exp` from the verified token and retains the released worker's exact
+response contract:
+
+```
+{"status":"revoked","deployment_id":"<dep>","session_id":"<sid>"}
+```
+
+The same still-valid token may retry its own revoke. A successful response
+guarantees subsequent normal endpoints reject that `sid` until `exp` and that
+only that session's active exec supervisors have been killed. Revoked entries
+are pruned at expiry and held in a bounded denylist. A new boot has a new `bid`,
+so tokens from an earlier boot are rejected independently of this process-local
+denylist.
+
+The legacy `MOBIUS_BOOT_MODE=recovery` opaque-token path remains available for
+rollout compatibility; it does not use this capability format.

--- a/backend/recovery_target/targetd.py
+++ b/backend/recovery_target/targetd.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """Immutable root repair target used only by an external recovery worker.
 
-This module is deliberately stdlib-only and is launched by the baked entrypoint
-before any path below /data is imported.  It is not a recovery user interface or
-an agent runner: it is a small, bearer-authenticated capability endpoint for the
-separate recovery service.
+The legacy stopped-app mode is launched by the baked entrypoint before any path
+below /data is imported.  Normal Mobius boots may also attach this target as a
+private sidecar process.  It is not a recovery user interface or an agent
+runner: it is a small, bearer-authenticated capability endpoint for the separate
+recovery service.
 """
 
 from __future__ import annotations
@@ -55,6 +56,21 @@ _RESOLVE_NO_XDEV = 0x01
 _RESOLVE_NO_MAGICLINKS = 0x02
 _RESOLVE_BENEATH = 0x08
 _TOKEN_DIGEST_DOMAIN = b"mobius-recovery-target/v1 bearer\x00"
+CAPABILITY_PUBLIC_KEY_ENV = "MOBIUS_RECOVERY_CAPABILITY_PUBLIC_KEY"
+CAPABILITY_TOKEN_PREFIX = "mrc1"
+CAPABILITY_ISSUER = "mobius.you"
+CAPABILITY_AUDIENCE = "mobius-recovery-target"
+MAX_CAPABILITY_TOKEN_BYTES = 512
+MAX_PROBE_CAPABILITY_LIFETIME_SECONDS = 60
+MAX_SESSION_CAPABILITY_LIFETIME_SECONDS = 60 * 60
+CAPABILITY_CLOCK_SKEW_SECONDS = 30
+MAX_CAPABILITY_ID_BYTES = 128
+BOOT_ID_ENV = "MOBIUS_RECOVERY_BOOT_ID"
+ATTACH_READY_FILE_ENV = "MOBIUS_RECOVERY_ATTACH_READY_FILE"
+MAX_CONCURRENT_REQUESTS = 16
+MAX_REVOKED_SESSIONS = 4096
+HEADER_TIMEOUT_SECONDS = 5.0
+BODY_TIMEOUT_SECONDS = 30.0
 # An 8 MiB decoded payload expands to about 10.67 MiB as base64 before the JSON
 # envelope is counted. Keep the wire budget large enough for the advertised
 # file/stdin boundary while still rejecting unbounded request bodies.
@@ -70,20 +86,33 @@ MAX_ENV_BYTES = 256 * 1024
 MAX_CONCURRENT_EXEC = 2
 MAX_TARGET_LIFETIME_SECONDS = 24 * 60 * 60
 _EXEC_SLOTS = threading.BoundedSemaphore(MAX_CONCURRENT_EXEC)
-_ACTIVE_SUPERVISORS: set[int] = set()
+_REQUEST_SLOTS = threading.BoundedSemaphore(MAX_CONCURRENT_REQUESTS)
+# pid -> (owning live-session id, original /proc starttime). Recording the
+# kernel starttime prevents revocation cleanup from acting on a reused PID.
+_ACTIVE_SUPERVISORS: dict[int, tuple[str | None, int]] = {}
 _ACTIVE_SUPERVISORS_LOCK = threading.Lock()
+_REVOKED_SESSIONS: dict[str, int] = {}
+_REVOKED_SESSIONS_LOCK = threading.Lock()
 _STARTUP_TOKEN_DIGEST: bytes | None = None
 _TARGET_EXPIRES_AT: int | None = None
+_CAPABILITY_PUBLIC_KEY: Any | None = None
+_LOCAL_INSTANCE_ID: str | None = None
+_LOCAL_DEPLOYMENT_ID: str | None = None
+_LOCAL_BOOT_ID: str | None = None
+_ATTACH_READY_FILE: Path | None = None
+_ATTACH_READY = threading.Event()
+_AUTH_MODE = "legacy"
+_SECURITY_INITIALIZED = False
 _TARGET_EXPIRED = threading.Event()
 _TARGET_REVOCATION_LOCK = threading.Lock()
 _TARGET_SHUTDOWN_STARTED = False
 _BUILD_REVISION = "unknown"
 _DATA_ROOT = Path(os.environ.get("DATA_DIR", "/data"))
 # Convenience file operations are deliberately narrower than root exec. They
-# run inside target PID1 and therefore must never act as a confused deputy for
-# /proc memory. Recovery data, baked app sources, and scratch paths are
-# sufficient for inspection; only stopped-instance data and scratch are
-# writable. openat2 enforces these roots against symlink and mount races.
+# run inside the privileged target and therefore must never act as a confused
+# deputy for /proc memory. Recovery data, baked app sources, and scratch paths
+# are sufficient for inspection; only instance data and scratch are writable.
+# openat2 enforces these roots against symlink and mount races.
 _FS_READ_ROOTS = (_DATA_ROOT, Path("/app"), Path("/tmp"))
 _FS_WRITE_ROOTS = (_DATA_ROOT, Path("/tmp"))
 
@@ -142,6 +171,363 @@ def _token_digest(value: bytes | bytearray | memoryview) -> bytes:
   return verifier.digest()
 
 
+def _base64url_decode_unpadded(
+  value: str, *, field: str, expected_bytes: int | None = None,
+) -> bytes:
+  """Decode one canonical base64url segment without accepting aliases."""
+  if (
+    not value
+    or "=" in value
+    or any(
+      not (
+        "A" <= char <= "Z"
+        or "a" <= char <= "z"
+        or "0" <= char <= "9"
+        or char in "-_"
+      )
+      for char in value
+    )
+  ):
+    raise ValueError(f"{field} is not unpadded base64url")
+  try:
+    decoded = base64.b64decode(
+      value + "=" * (-len(value) % 4), altchars=b"-_", validate=True,
+    )
+  except (binascii.Error, ValueError) as exc:
+    raise ValueError(f"{field} is not unpadded base64url") from exc
+  canonical = base64.urlsafe_b64encode(decoded).rstrip(b"=").decode("ascii")
+  if canonical != value:
+    raise ValueError(f"{field} is not canonical base64url")
+  if expected_bytes is not None and len(decoded) != expected_bytes:
+    raise ValueError(f"{field} has the wrong length")
+  return decoded
+
+
+def _validate_capability_identifier(value: Any, field: str) -> str:
+  if not isinstance(value, str):
+    raise ValueError(f"{field} must be a string")
+  try:
+    encoded = value.encode("ascii")
+  except UnicodeEncodeError as exc:
+    raise ValueError(f"{field} must be ASCII") from exc
+  if (
+    not 1 <= len(encoded) <= MAX_CAPABILITY_ID_BYTES
+    or any(byte < 0x21 or byte > 0x7E for byte in encoded)
+  ):
+    raise ValueError(f"{field} is invalid")
+  return value
+
+
+def _read_capability_public_key() -> Any:
+  """Load an unpadded-base64url raw Ed25519 public key from the environment."""
+  encoded = os.environ.pop(CAPABILITY_PUBLIC_KEY_ENV, "")
+  try:
+    raw = _base64url_decode_unpadded(
+      encoded, field=CAPABILITY_PUBLIC_KEY_ENV, expected_bytes=32,
+    )
+  except ValueError as exc:
+    raise RuntimeError(
+      f"{CAPABILITY_PUBLIC_KEY_ENV} must be an unpadded base64url "
+      "32-byte Ed25519 public key"
+    ) from exc
+  try:
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+      Ed25519PublicKey,
+    )
+  except ImportError as exc:
+    raise RuntimeError(
+      "recovery capability verification requires cryptography"
+    ) from exc
+  try:
+    return Ed25519PublicKey.from_public_bytes(raw)
+  except ValueError as exc:
+    raise RuntimeError("recovery capability public key is invalid") from exc
+
+
+def _read_local_identity(name: str) -> str | None:
+  value = os.environ.get(name)
+  if value is None or value == "":
+    return None
+  try:
+    return _validate_capability_identifier(value, name)
+  except ValueError as exc:
+    raise RuntimeError(
+      f"{name} must contain 1-{MAX_CAPABILITY_ID_BYTES} printable ASCII bytes"
+    ) from exc
+
+
+def _read_required_local_identity(name: str) -> str:
+  value = _read_local_identity(name)
+  if value is None:
+    raise RuntimeError(f"{name} is required for live recovery")
+  return value
+
+
+def _read_boot_id() -> str:
+  value = os.environ.pop(BOOT_ID_ENV, "")
+  if (
+    len(value) != 32
+    or any(
+      not (
+        "A" <= char <= "Z"
+        or "a" <= char <= "z"
+        or "0" <= char <= "9"
+        or char in "-_"
+      )
+      for char in value
+    )
+  ):
+    raise RuntimeError(f"{BOOT_ID_ENV} must be a 32-character base64url id")
+  return value
+
+
+def _read_attach_ready_file() -> Path:
+  raw = os.environ.pop(ATTACH_READY_FILE_ENV, "")
+  path = Path(raw)
+  if (
+    not raw
+    or path.parent != Path("/tmp")
+    or not path.name.startswith("mobius-recovery-attach-ready.")
+    or len(path.name) > 128
+  ):
+    raise RuntimeError(
+      f"{ATTACH_READY_FILE_ENV} must name a private /tmp signal file"
+    )
+  try:
+    info = path.lstat()
+  except OSError as exc:
+    raise RuntimeError(f"{ATTACH_READY_FILE_ENV} is unavailable") from exc
+  if (
+    not stat.S_ISREG(info.st_mode)
+    or info.st_uid != os.geteuid()
+    or info.st_nlink != 1
+    or (info.st_mode & 0o777) != 0o600
+    or info.st_size not in {0, 39}
+  ):
+    raise RuntimeError(f"{ATTACH_READY_FILE_ENV} is insecure")
+  return path
+
+
+def _attach_is_ready() -> bool:
+  if _AUTH_MODE != "capability":
+    return True
+  if _ATTACH_READY.is_set():
+    return True
+  path = _ATTACH_READY_FILE
+  boot_id = _LOCAL_BOOT_ID
+  if path is None or boot_id is None:
+    return False
+  flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+  fd: int | None = None
+  try:
+    fd = os.open(path, flags)
+    info = os.fstat(fd)
+    if (
+      not stat.S_ISREG(info.st_mode)
+      or info.st_uid != os.geteuid()
+      or info.st_nlink != 1
+      or (info.st_mode & 0o777) != 0o600
+    ):
+      return False
+    value = os.read(fd, 40)
+  except OSError:
+    return False
+  finally:
+    if fd is not None:
+      os.close(fd)
+  expected = f"ready:{boot_id}\n".encode("ascii")
+  if not hmac.compare_digest(value, expected):
+    return False
+  _ATTACH_READY.set()
+  try:
+    path.unlink()
+  except OSError:
+    pass
+  return True
+
+
+def _invalid_capability(*, expired: bool = False) -> RequestError:
+  if expired:
+    return RequestError(
+      "auth_expired",
+      "recovery target capability has expired",
+      HTTPStatus.UNAUTHORIZED,
+    )
+  return RequestError(
+    "unauthorized", "invalid bearer token", HTTPStatus.UNAUTHORIZED,
+  )
+
+
+def _attach_not_ready() -> RequestError:
+  return RequestError(
+    "attach_not_ready",
+    "normal Mobius entrypoint initialization has not completed",
+    HTTPStatus.SERVICE_UNAVAILABLE,
+  )
+
+
+def _insufficient_scope() -> RequestError:
+  return RequestError(
+    "insufficient_scope",
+    "this recovery capability does not authorize the requested operation",
+    HTTPStatus.FORBIDDEN,
+  )
+
+
+def _revoked_capability() -> RequestError:
+  return RequestError(
+    "auth_revoked",
+    "recovery session has been revoked",
+    HTTPStatus.UNAUTHORIZED,
+  )
+
+
+def _prune_revoked_sessions_locked(now: int) -> None:
+  for session_id, expires_at in list(_REVOKED_SESSIONS.items()):
+    if expires_at <= now:
+      del _REVOKED_SESSIONS[session_id]
+
+
+def _session_is_revoked(session_id: str) -> bool:
+  now = int(time.time())
+  with _REVOKED_SESSIONS_LOCK:
+    _prune_revoked_sessions_locked(now)
+    return _REVOKED_SESSIONS.get(session_id, 0) > now
+
+
+def _revoke_capability_session(claims: dict[str, Any]) -> dict[str, Any]:
+  session_id = str(claims["sid"])
+  expires_at = int(claims["exp"])
+  now = int(time.time())
+  with _REVOKED_SESSIONS_LOCK:
+    _prune_revoked_sessions_locked(now)
+    existing = _REVOKED_SESSIONS.get(session_id)
+    if existing is None and len(_REVOKED_SESSIONS) >= MAX_REVOKED_SESSIONS:
+      raise RequestError(
+        "revocation_capacity",
+        "recovery session revocation capacity is temporarily exhausted",
+        HTTPStatus.SERVICE_UNAVAILABLE,
+      )
+    _REVOKED_SESSIONS[session_id] = max(existing or 0, expires_at)
+  _retire_session_supervisors(session_id)
+  return {
+    "status": "revoked",
+    "deployment_id": str(claims["dep"]),
+    "session_id": session_id,
+  }
+
+
+def _verify_capability_token(value: str) -> dict[str, Any]:
+  """Verify a compact, Ed25519-signed recovery bearer capability.
+
+  The exact wire form is ``mrc1.<payload>.<signature>``. ``payload`` is
+  unpadded base64url of UTF-8 JSON serialized with sorted keys and compact
+  separators. ``signature`` is unpadded base64url of the 64-byte Ed25519
+  signature over the ASCII bytes ``mrc1.<payload>``.
+  """
+  try:
+    raw_token = value.encode("ascii")
+  except (AttributeError, UnicodeEncodeError) as exc:
+    raise _invalid_capability() from exc
+  if not 1 <= len(raw_token) <= MAX_CAPABILITY_TOKEN_BYTES:
+    raise _invalid_capability()
+  parts = value.split(".")
+  if len(parts) != 3 or parts[0] != CAPABILITY_TOKEN_PREFIX:
+    raise _invalid_capability()
+  payload_segment, signature_segment = parts[1], parts[2]
+  try:
+    payload_raw = _base64url_decode_unpadded(
+      payload_segment, field="capability payload",
+    )
+    signature = _base64url_decode_unpadded(
+      signature_segment, field="capability signature", expected_bytes=64,
+    )
+  except ValueError as exc:
+    raise _invalid_capability() from exc
+
+  public_key = _CAPABILITY_PUBLIC_KEY
+  if public_key is None:
+    raise _invalid_capability()
+  signed = f"{CAPABILITY_TOKEN_PREFIX}.{payload_segment}".encode("ascii")
+  try:
+    public_key.verify(signature, signed)
+  except Exception as exc:
+    # Ed25519 verification deliberately has one externally visible failure.
+    raise _invalid_capability() from exc
+
+  try:
+    claims = json.loads(payload_raw.decode("utf-8"))
+  except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+    raise _invalid_capability() from exc
+  if not isinstance(claims, dict):
+    raise _invalid_capability()
+  canonical = json.dumps(
+    claims, sort_keys=True, separators=(",", ":"), ensure_ascii=True,
+  ).encode("utf-8")
+  if not hmac.compare_digest(canonical, payload_raw):
+    raise _invalid_capability()
+
+  common = {"v", "iss", "aud", "sub", "dep", "scp", "iat", "nbf", "exp"}
+  scope = claims.get("scp")
+  if scope == "probe":
+    required = common
+    maximum_lifetime = MAX_PROBE_CAPABILITY_LIFETIME_SECONDS
+  elif scope == "session":
+    required = common | {"sid", "bid"}
+    maximum_lifetime = MAX_SESSION_CAPABILITY_LIFETIME_SECONDS
+  else:
+    raise _invalid_capability()
+  if set(claims) != required:
+    raise _invalid_capability()
+  if (
+    type(claims["v"]) is not int
+    or claims["v"] != 1
+    or claims["iss"] != CAPABILITY_ISSUER
+    or claims["aud"] != CAPABILITY_AUDIENCE
+  ):
+    raise _invalid_capability()
+  try:
+    subject = _validate_capability_identifier(claims["sub"], "sub")
+    deployment = _validate_capability_identifier(claims["dep"], "dep")
+    if scope == "session":
+      _validate_capability_identifier(claims["sid"], "sid")
+      boot_id = _validate_capability_identifier(claims["bid"], "bid")
+    else:
+      boot_id = None
+  except ValueError as exc:
+    raise _invalid_capability() from exc
+  if _LOCAL_INSTANCE_ID is None or subject != _LOCAL_INSTANCE_ID:
+    raise _invalid_capability()
+  if _LOCAL_DEPLOYMENT_ID is None or deployment != _LOCAL_DEPLOYMENT_ID:
+    raise _invalid_capability()
+  if scope == "session" and (
+    _LOCAL_BOOT_ID is None or boot_id != _LOCAL_BOOT_ID
+  ):
+    raise _invalid_capability()
+
+  timestamps = (claims["iat"], claims["nbf"], claims["exp"])
+  if any(
+    type(timestamp) is not int or not 0 < timestamp <= 9_999_999_999
+    for timestamp in timestamps
+  ):
+    raise _invalid_capability()
+  issued_at, not_before, expires_at = timestamps
+  if (
+    not issued_at <= not_before < expires_at
+    or expires_at - issued_at > maximum_lifetime
+  ):
+    raise _invalid_capability()
+  now = int(time.time())
+  if expires_at <= now:
+    raise _invalid_capability(expired=True)
+  if (
+    issued_at > now + CAPABILITY_CLOCK_SKEW_SECONDS
+    or not_before > now + CAPABILITY_CLOCK_SKEW_SECONDS
+  ):
+    raise _invalid_capability()
+  return claims
+
+
 def _capability_state(
   libc: ctypes.CDLL,
 ) -> tuple[_CapabilityHeader, Any]:
@@ -163,8 +549,8 @@ def _drop_recovery_escape_capabilities() -> None:
     raise RuntimeError("recovery target requires Linux capability controls")
 
   # A root repair command must not capture a later Authorization header,
-  # ptrace target PID1, or create a nested mount that bypasses filesystem-root
-  # policy. None of these powers are needed to repair the stopped /data tree.
+  # ptrace the target or application, or create a nested mount that bypasses
+  # filesystem-root policy. None of these powers are needed to repair /data.
   # Remove them from every mutable set and the bounding set before listening.
   header, data = _capability_state(libc)
   for capability in _BLOCKED_CAPABILITIES:
@@ -227,11 +613,11 @@ def _set_process_nondumpable() -> None:
 
 
 def _set_child_subreaper() -> None:
-  """Keep every orphaned repair process below this immutable PID1.
+  """Keep every orphaned repair process below the immutable target.
 
-  PID 1 is already the final reparenting point in a container PID namespace,
-  but setting and verifying the Linux subreaper bit makes that dependency
-  explicit and gives the per-exec supervisor the same fail-closed primitive.
+  The legacy target is PID 1; the live attachment is not. Setting and verifying
+  the Linux subreaper bit gives both modes and each per-exec supervisor the same
+  fail-closed process-tree ownership primitive.
   """
   libc = ctypes.CDLL(None, use_errno=True)
   prctl = getattr(libc, "prctl", None)
@@ -324,6 +710,8 @@ def _read_target_expiry() -> int:
 
 
 def _target_is_expired() -> bool:
+  if _AUTH_MODE == "capability":
+    return False
   expires_at = _TARGET_EXPIRES_AT
   if _TARGET_EXPIRED.is_set() or expires_at is None:
     return True
@@ -352,23 +740,44 @@ def _load_baked_build_revision() -> str:
   return value
 
 
-def _initialize_startup_security(*, require_pid_one: bool = True) -> None:
-  """Loads immutable identity + bearer before any request can be accepted."""
-  global _BUILD_REVISION, _STARTUP_TOKEN_DIGEST, _TARGET_EXPIRES_AT
+def _initialize_startup_security(
+  *, require_pid_one: bool = True, auth_mode: str = "legacy",
+) -> None:
+  """Load immutable identity and request authentication before listening."""
+  global _AUTH_MODE, _BUILD_REVISION, _CAPABILITY_PUBLIC_KEY
+  global _ATTACH_READY_FILE, _LOCAL_BOOT_ID
+  global _LOCAL_DEPLOYMENT_ID, _LOCAL_INSTANCE_ID
+  global _SECURITY_INITIALIZED
+  global _STARTUP_TOKEN_DIGEST, _TARGET_EXPIRES_AT
   if require_pid_one and os.getpid() != 1:
     raise RuntimeError(
       "recovery target must be container pid 1 so no parent retains its bearer"
     )
-  if _STARTUP_TOKEN_DIGEST is not None:
+  if _SECURITY_INITIALIZED:
     raise RuntimeError("recovery target startup security was already initialized")
+  if auth_mode not in {"legacy", "capability"}:
+    raise RuntimeError("recovery target authentication mode is invalid")
   _assert_clean_initial_environment()
   _assert_fs_policy_supported()
   _drop_recovery_escape_capabilities()
   _set_process_nondumpable()
   _set_child_subreaper()
-  _TARGET_EXPIRES_AT = _read_target_expiry()
-  _STARTUP_TOKEN_DIGEST = _read_startup_token_digest()
+  if auth_mode == "legacy":
+    _TARGET_EXPIRES_AT = _read_target_expiry()
+    _STARTUP_TOKEN_DIGEST = _read_startup_token_digest()
+  else:
+    _CAPABILITY_PUBLIC_KEY = _read_capability_public_key()
+    _LOCAL_INSTANCE_ID = _read_required_local_identity("MOBIUS_INSTANCE_ID")
+    _LOCAL_DEPLOYMENT_ID = _read_required_local_identity(
+      "RAILWAY_DEPLOYMENT_ID"
+    )
+    _LOCAL_BOOT_ID = _read_boot_id()
+    _ATTACH_READY_FILE = _read_attach_ready_file()
+    _TARGET_EXPIRES_AT = None
+    _STARTUP_TOKEN_DIGEST = None
   _BUILD_REVISION = _load_baked_build_revision()
+  _AUTH_MODE = auth_mode
+  _SECURITY_INITIALIZED = True
 
 
 def _startup_token_digest() -> bytes:
@@ -677,17 +1086,45 @@ def _force_kill_supervisor(process: subprocess.Popen[bytes]) -> None:
 def _retire_active_supervisors(*, force: bool) -> None:
   """Stop every in-flight root command when the capability expires."""
   with _ACTIVE_SUPERVISORS_LOCK:
-    active = list(_ACTIVE_SUPERVISORS)
-  for pid in active:
-    record = _process_record(pid)
-    if record is None:
+    active = [
+      (pid, starttime)
+      for pid, (_owner, starttime) in _ACTIVE_SUPERVISORS.items()
+    ]
+  for pid, starttime in active:
+    current = _process_record(pid)
+    if current is None or current[1] != starttime:
       continue
-    _ppid, starttime = record
     if force:
+      # Freeze the exact recorded supervisor before walking its descendants.
+      # A stale mapping must never turn a reused PID into a cleanup root.
+      _signal_recorded_process(pid, starttime, signal.SIGSTOP)
+      current = _process_record(pid)
+      if current is None or current[1] != starttime:
+        continue
       _stop_and_kill_descendants(pid)
       _signal_recorded_process(pid, starttime, signal.SIGKILL)
     else:
       _signal_recorded_process(pid, starttime, signal.SIGTERM)
+
+
+def _retire_session_supervisors(session_id: str) -> None:
+  """Immediately retire only commands owned by one revoked live session."""
+  with _ACTIVE_SUPERVISORS_LOCK:
+    active = [
+      (pid, starttime)
+      for pid, (owner, starttime) in _ACTIVE_SUPERVISORS.items()
+      if owner == session_id
+    ]
+  for pid, starttime in active:
+    current = _process_record(pid)
+    if current is None or current[1] != starttime:
+      continue
+    _signal_recorded_process(pid, starttime, signal.SIGSTOP)
+    current = _process_record(pid)
+    if current is None or current[1] != starttime:
+      continue
+    _stop_and_kill_descendants(pid)
+    _signal_recorded_process(pid, starttime, signal.SIGKILL)
 
 
 def _revoke_target(server: Any) -> None:
@@ -796,8 +1233,34 @@ def _exec_supervisor_main(raw_fd: str) -> int:
   return returncode
 
 
-def _run_exec(body: dict[str, Any]) -> dict[str, Any]:
+def _run_exec(
+  body: dict[str, Any], *, capability_expires_at: int | None = None,
+  capability_session_id: str | None = None,
+) -> dict[str, Any]:
   _require_active_target()
+  if capability_session_id is not None:
+    try:
+      _validate_capability_identifier(capability_session_id, "sid")
+    except ValueError as exc:
+      raise RequestError(
+        "internal_error",
+        "recovery target capability session is invalid",
+        HTTPStatus.INTERNAL_SERVER_ERROR,
+      ) from exc
+    if _session_is_revoked(capability_session_id):
+      raise _revoked_capability()
+  capability_deadline: float | None = None
+  if capability_expires_at is not None:
+    if type(capability_expires_at) is not int:
+      raise RequestError(
+        "internal_error",
+        "recovery target capability deadline is invalid",
+        HTTPStatus.INTERNAL_SERVER_ERROR,
+      )
+    remaining_capability = capability_expires_at - time.time()
+    if remaining_capability <= 0:
+      raise _invalid_capability(expired=True)
+    capability_deadline = time.monotonic() + remaining_capability
   argv = body.get("argv")
   if (
     not isinstance(argv, list)
@@ -888,6 +1351,11 @@ def _run_exec(body: dict[str, Any]) -> dict[str, Any]:
   config_read_fd: int | None = None
   config_write_fd: int | None = None
   try:
+    if (
+      capability_deadline is not None
+      and time.monotonic() >= capability_deadline
+    ):
+      raise _invalid_capability(expired=True)
     try:
       config_read_fd, config_write_fd = os.pipe()
       supervisor_env = {
@@ -899,6 +1367,11 @@ def _run_exec(body: dict[str, Any]) -> dict[str, Any]:
         "DATA_DIR": os.environ.get("DATA_DIR", "/data"),
       }
       with _ACTIVE_SUPERVISORS_LOCK:
+        if (
+          capability_session_id is not None
+          and _session_is_revoked(capability_session_id)
+        ):
+          raise _revoked_capability()
         process = subprocess.Popen(
           [
             sys.executable, "-I", str(Path(__file__).resolve()),
@@ -912,7 +1385,16 @@ def _run_exec(body: dict[str, Any]) -> dict[str, Any]:
           start_new_session=True,
           pass_fds=(config_read_fd,),
         )
-        _ACTIVE_SUPERVISORS.add(process.pid)
+        process_record = _process_record(process.pid)
+        if process_record is None:
+          raise RequestError(
+            "exec_failed",
+            "recovery exec supervisor identity is unavailable",
+            HTTPStatus.UNPROCESSABLE_ENTITY,
+          )
+        _ACTIVE_SUPERVISORS[process.pid] = (
+          capability_session_id, process_record[1],
+        )
       os.close(config_read_fd)
       config_read_fd = None
       config_payload = json.dumps({
@@ -948,10 +1430,33 @@ def _run_exec(body: dict[str, Any]) -> dict[str, Any]:
     output = {"stdout": bytearray(), "stderr": bytearray()}
     truncated = False
     timed_out = False
+    capability_expired = False
+    session_revoked = False
     termination_requested_at: float | None = None
     process_exited_at: float | None = None
     while selector.get_map():
-      if _target_is_expired() and termination_requested_at is None:
+      now_monotonic = time.monotonic()
+      if (
+        capability_session_id is not None
+        and _session_is_revoked(capability_session_id)
+      ):
+        session_revoked = True
+        if termination_requested_at is None:
+          termination_requested_at = now_monotonic
+        if process.poll() is None:
+          _force_kill_supervisor(process)
+      elif (
+        capability_deadline is not None
+        and now_monotonic >= capability_deadline
+        and process.poll() is None
+      ):
+        capability_expired = True
+        if termination_requested_at is None:
+          termination_requested_at = now_monotonic
+        # Capability expiry is an authorization boundary, not a friendly
+        # command timeout. Retire the full supervised process tree at once.
+        _force_kill_supervisor(process)
+      elif _target_is_expired() and termination_requested_at is None:
         termination_requested_at = time.monotonic()
         _request_supervisor_termination(process)
       remaining = timeout - (time.monotonic() - started)
@@ -961,7 +1466,13 @@ def _run_exec(body: dict[str, Any]) -> dict[str, Any]:
           termination_requested_at = time.monotonic()
           _request_supervisor_termination(process)
         remaining = 0.1
-      events = selector.select(min(max(remaining, 0.01), 0.25))
+      wait_for = min(max(remaining, 0.01), 0.25)
+      if capability_deadline is not None and not capability_expired:
+        wait_for = min(
+          wait_for,
+          max(capability_deadline - time.monotonic(), 0.001),
+        )
+      events = selector.select(wait_for)
       for key, _mask in events:
         stream = key.fileobj
         kind = key.data
@@ -1028,6 +1539,16 @@ def _run_exec(body: dict[str, Any]) -> dict[str, Any]:
           "repair process supervisor could not be retired",
           HTTPStatus.INTERNAL_SERVER_ERROR,
         ) from final_exc
+    if (
+      session_revoked
+      or (
+        capability_session_id is not None
+        and _session_is_revoked(capability_session_id)
+      )
+    ):
+      raise _revoked_capability()
+    if capability_expired:
+      raise _invalid_capability(expired=True)
     elapsed_ms = round((time.monotonic() - started) * 1000)
     return {
       "exit_code": exit_code,
@@ -1056,7 +1577,7 @@ def _run_exec(body: dict[str, Any]) -> dict[str, Any]:
           pass
     if process is not None:
       with _ACTIVE_SUPERVISORS_LOCK:
-        _ACTIVE_SUPERVISORS.discard(process.pid)
+        _ACTIVE_SUPERVISORS.pop(process.pid, None)
     _retire_untracked_target_children()
     _EXEC_SLOTS.release()
 
@@ -1244,6 +1765,52 @@ class _Handler(BaseHTTPRequestHandler):
   protocol_version = "HTTP/1.1"
   server_version = "MobiusRecoveryTarget/1"
 
+  def setup(self) -> None:
+    super().setup()
+    self._header_timer: threading.Timer | None = None
+    self._header_expired: threading.Event | None = None
+    self.connection.settimeout(HEADER_TIMEOUT_SECONDS)
+
+  def _expire_read(self, expired: threading.Event) -> None:
+    expired.set()
+    try:
+      self.connection.shutdown(socket.SHUT_RD)
+    except OSError:
+      pass
+
+  def _read_timer(
+    self, seconds: float, expired: threading.Event,
+  ) -> threading.Timer:
+    timer = threading.Timer(seconds, self._expire_read, args=(expired,))
+    timer.daemon = True
+    timer.start()
+    return timer
+
+  def handle_one_request(self) -> None:
+    expired = threading.Event()
+    self._header_expired = expired
+    self._header_timer = self._read_timer(HEADER_TIMEOUT_SECONDS, expired)
+    try:
+      super().handle_one_request()
+    finally:
+      if self._header_timer is not None:
+        self._header_timer.cancel()
+        self._header_timer = None
+
+  def parse_request(self) -> bool:
+    try:
+      parsed = super().parse_request()
+      if self._header_expired is not None and self._header_expired.is_set():
+        self.close_connection = True
+        return False
+      return parsed
+    finally:
+      # The timer began before raw_requestline, so it bounds the complete
+      # request-line + header parse instead of each individual socket read.
+      if self._header_timer is not None:
+        self._header_timer.cancel()
+        self._header_timer = None
+
   def log_message(self, fmt: str, *args: object) -> None:
     print(f"recovery-target: {self.address_string()} {fmt % args}", flush=True)
 
@@ -1266,19 +1833,37 @@ class _Handler(BaseHTTPRequestHandler):
     )
 
   def _authorized(self) -> bool:
+    values = self.headers.get_all("Authorization", failobj=[]) or []
+    self._request_expires_at = None
+    self._request_claims = None
+
+    if _AUTH_MODE == "capability":
+      if len(values) != 1 or not values[0].startswith("Bearer "):
+        values.clear()
+        self._error(_invalid_capability())
+        return False
+      try:
+        claims = _verify_capability_token(values[0][7:])
+      except RequestError as exc:
+        self._error(exc)
+        return False
+      finally:
+        values.clear()
+      self._request_expires_at = int(claims["exp"])
+      self._request_claims = claims
+      if (
+        claims["scp"] == "session"
+        and self.path != "/v1/revoke"
+        and _session_is_revoked(str(claims["sid"]))
+      ):
+        self._error(_revoked_capability())
+        return False
+      return True
+
     if _target_is_expired():
       _revoke_target(self.server)
-      self._send(
-        HTTPStatus.UNAUTHORIZED,
-        {
-          "error": {
-            "code": "auth_expired",
-            "message": "recovery target capability has expired",
-          }
-        },
-      )
+      self._error(_invalid_capability(expired=True))
       return False
-    values = self.headers.get_all("Authorization", failobj=[]) or []
     supplied_buffer: bytearray | None = None
     authorized = False
     if len(values) == 1 and values[0].startswith("Bearer "):
@@ -1303,22 +1888,12 @@ class _Handler(BaseHTTPRequestHandler):
     # adjustment cannot make a revoked capability valid again.
     if _target_is_expired():
       _revoke_target(self.server)
-      self._send(
-        HTTPStatus.UNAUTHORIZED,
-        {
-          "error": {
-            "code": "auth_expired",
-            "message": "recovery target capability has expired",
-          }
-        },
-      )
+      self._error(_invalid_capability(expired=True))
       return False
     if not authorized:
-      self._send(
-        HTTPStatus.UNAUTHORIZED,
-        {"error": {"code": "unauthorized", "message": "invalid bearer token"}},
-      )
+      self._error(_invalid_capability())
       return False
+    self._request_expires_at = _TARGET_EXPIRES_AT
     return True
 
   def _body(self) -> dict[str, Any]:
@@ -1336,7 +1911,52 @@ class _Handler(BaseHTTPRequestHandler):
         f"request exceeds {MAX_REQUEST_BYTES} bytes",
         HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
       )
-    raw = self.rfile.read(length)
+    body_window = BODY_TIMEOUT_SECONDS
+    token_limited = False
+    if self._request_expires_at is not None:
+      token_remaining = self._request_expires_at - time.time()
+      if token_remaining <= 0:
+        raise _invalid_capability(expired=True)
+      if token_remaining <= body_window:
+        body_window = token_remaining
+        token_limited = True
+    deadline = time.monotonic() + body_window
+    expired = threading.Event()
+    timer = self._read_timer(body_window, expired)
+    raw = bytearray()
+    read_error: OSError | None = None
+    try:
+      while len(raw) < length:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+          expired.set()
+          break
+        self.connection.settimeout(max(remaining, 0.001))
+        try:
+          chunk = self.rfile.read(min(64 * 1024, length - len(raw)))
+        except OSError as exc:
+          read_error = exc
+          break
+        if not chunk:
+          break
+        raw.extend(chunk)
+    finally:
+      timer.cancel()
+    deadline_reached = expired.is_set() or time.monotonic() >= deadline
+    if deadline_reached:
+      if token_limited:
+        raise _invalid_capability(expired=True)
+      raise RequestError(
+        "request_timeout",
+        "request body deadline exceeded",
+        HTTPStatus.REQUEST_TIMEOUT,
+      )
+    if read_error is not None:
+      raise RequestError(
+        "request_timeout",
+        "request body read failed",
+        HTTPStatus.REQUEST_TIMEOUT,
+      ) from read_error
     if len(raw) != length:
       raise RequestError("invalid_framing", "request body ended early")
     try:
@@ -1350,19 +1970,62 @@ class _Handler(BaseHTTPRequestHandler):
   def do_GET(self) -> None:  # noqa: N802
     if not self._authorized():
       return
+    if not _attach_is_ready():
+      self._error(_attach_not_ready())
+      return
     if self.path != "/v1/health":
       self._error(RequestError("not_found", "endpoint not found", HTTPStatus.NOT_FOUND))
       return
-    self._send(HTTPStatus.OK, {
+    payload = {
       "protocol": PROTOCOL,
       "target": "mobius",
-      "mode": "recovery",
       "build_sha": _BUILD_REVISION,
-      "expires_at": _TARGET_EXPIRES_AT,
-    })
+    }
+    if _AUTH_MODE == "capability":
+      payload.update({
+        "mode": "normal",
+        "attachment": "live",
+        "expires_at": self._request_expires_at,
+        "deployment_id": _LOCAL_DEPLOYMENT_ID,
+        "boot_id": _LOCAL_BOOT_ID,
+      })
+    else:
+      payload.update({
+        "mode": "recovery",
+        "expires_at": _TARGET_EXPIRES_AT,
+      })
+    self._send(HTTPStatus.OK, payload)
 
   def do_POST(self) -> None:  # noqa: N802
     if not self._authorized():
+      return
+    if (
+      _AUTH_MODE == "capability"
+      and self._request_claims is not None
+      and self._request_claims["scp"] != "session"
+    ):
+      self._error(_insufficient_scope())
+      return
+    if self.path == "/v1/revoke":
+      if _AUTH_MODE != "capability" or self._request_claims is None:
+        self._error(RequestError(
+          "not_found", "endpoint not found", HTTPStatus.NOT_FOUND,
+        ))
+        return
+      try:
+        body = self._body()
+        if body:
+          raise RequestError(
+            "invalid_request", "revoke body must be an empty JSON object",
+          )
+        result = _revoke_capability_session(self._request_claims)
+      except RequestError as exc:
+        self._error(exc)
+        return
+      self._send(HTTPStatus.OK, result)
+      return
+    if not _attach_is_ready():
+      self._error(_attach_not_ready())
       return
     handlers = {
       "/v1/exec": _run_exec,
@@ -1375,7 +2038,35 @@ class _Handler(BaseHTTPRequestHandler):
       self._error(RequestError("not_found", "endpoint not found", HTTPStatus.NOT_FOUND))
       return
     try:
-      result = operation(self._body())
+      body = self._body()
+      if (
+        _AUTH_MODE == "capability"
+        and (
+          self._request_expires_at is None
+          or time.time() >= self._request_expires_at
+        )
+      ):
+        raise _invalid_capability(expired=True)
+      if (
+        _AUTH_MODE == "capability"
+        and self._request_claims is not None
+        and _session_is_revoked(str(self._request_claims["sid"]))
+      ):
+        raise _revoked_capability()
+      if self.path == "/v1/exec":
+        result = operation(
+          body, capability_expires_at=(
+            self._request_expires_at
+            if _AUTH_MODE == "capability" else None
+          ),
+          capability_session_id=(
+            str(self._request_claims["sid"])
+            if _AUTH_MODE == "capability"
+            and self._request_claims is not None else None
+          ),
+        )
+      else:
+        result = operation(body)
     except RequestError as exc:
       self._error(exc)
       return
@@ -1387,19 +2078,54 @@ class _Handler(BaseHTTPRequestHandler):
     self._send(HTTPStatus.OK, result)
 
 
-class _DualStackServer(ThreadingHTTPServer):
-  address_family = socket.AF_INET6
+class _BoundedThreadingHTTPServer(ThreadingHTTPServer):
   daemon_threads = True
   allow_reuse_address = True
+
+  _BUSY_RESPONSE = (
+    b"HTTP/1.1 503 Service Unavailable\r\n"
+    b"Content-Length: 0\r\nConnection: close\r\n\r\n"
+  )
+
+  def __init__(self, *args: Any, **kwargs: Any) -> None:
+    self._request_slots = _REQUEST_SLOTS
+    super().__init__(*args, **kwargs)
+
+  def process_request(self, request: socket.socket, client_address: Any) -> None:
+    if not self._request_slots.acquire(blocking=False):
+      try:
+        request.settimeout(0.25)
+        request.sendall(self._BUSY_RESPONSE)
+      except OSError:
+        pass
+      finally:
+        self.shutdown_request(request)
+      return
+    try:
+      super().process_request(request, client_address)
+    except BaseException:
+      self._request_slots.release()
+      raise
+
+  def process_request_thread(
+    self, request: socket.socket, client_address: Any,
+  ) -> None:
+    try:
+      super().process_request_thread(request, client_address)
+    finally:
+      self._request_slots.release()
+
+
+class _DualStackServer(_BoundedThreadingHTTPServer):
+  address_family = socket.AF_INET6
 
   def server_bind(self) -> None:
     self.socket.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
     super().server_bind()
 
 
-class _IPv4Server(ThreadingHTTPServer):
-  daemon_threads = True
-  allow_reuse_address = True
+class _IPv4Server(_BoundedThreadingHTTPServer):
+  pass
 
 
 def _create_server(port: int) -> ThreadingHTTPServer:
@@ -1446,12 +2172,23 @@ def _park_expired_target() -> None:
 
 
 def main() -> None:
-  if os.environ.get("MOBIUS_BOOT_MODE") != "recovery":
-    raise SystemExit("recovery target refuses to run outside recovery boot mode")
+  boot_mode = os.environ.get("MOBIUS_BOOT_MODE", "normal")
+  if boot_mode == "recovery":
+    auth_mode = "legacy"
+    require_pid_one = True
+  elif boot_mode == "normal" and os.environ.get(CAPABILITY_PUBLIC_KEY_ENV):
+    auth_mode = "capability"
+    require_pid_one = False
+  else:
+    raise SystemExit(
+      "recovery target requires recovery boot mode or a capability public key"
+    )
   if os.geteuid() != 0:
     raise SystemExit("recovery target must run as root")
   try:
-    _initialize_startup_security()
+    _initialize_startup_security(
+      require_pid_one=require_pid_one, auth_mode=auth_mode,
+    )
   except RuntimeError as exc:
     raise SystemExit(f"recovery target security initialization failed: {exc}") from exc
   raw_port = os.environ.get("MOBIUS_RECOVERY_TARGET_PORT", str(DEFAULT_PORT))
@@ -1465,17 +2202,22 @@ def main() -> None:
   # launchers therefore clear provider-level unauthenticated health checks and
   # probe /v1/health themselves before handing the worker to the owner.
   server = _create_server(port)
+  attachment = "stopped" if auth_mode == "legacy" else "live"
   print(
-    f"Mobius recovery target {PROTOCOL} listening privately on [::]:{port}",
+    f"Mobius recovery target {PROTOCOL} ({attachment}) listening privately "
+    f"on [::]:{port}",
     flush=True,
   )
-  expiry_timer = _schedule_target_expiry(server)
+  expiry_timer = (
+    _schedule_target_expiry(server) if auth_mode == "legacy" else None
+  )
   try:
     server.serve_forever(poll_interval=0.25)
   finally:
-    expiry_timer.cancel()
+    if expiry_timer is not None:
+      expiry_timer.cancel()
     server.server_close()
-  if _TARGET_EXPIRED.is_set():
+  if auth_mode == "legacy" and _TARGET_EXPIRED.is_set():
     print(
       "recovery-target: capability expired; listener closed and PID1 parked",
       flush=True,

--- a/backend/scripts/entrypoint.sh
+++ b/backend/scripts/entrypoint.sh
@@ -48,14 +48,100 @@ esac
 . /app/scripts/agent_sudo.sh
 configure_agent_sudo "${MOBIUS_AGENT_SUDO:-1}" || exit $?
 
-# Stop cron on container shutdown so it doesn't orphan processes.
-cleanup() { kill "$(cat /var/run/crond.pid 2>/dev/null)" 2>/dev/null; }
+# Stop boot-time background services if the shell is terminated before it
+# hands pid 1 to the application server.
+cleanup() {
+  kill "$(cat /var/run/crond.pid 2>/dev/null)" 2>/dev/null
+  if [ -n "${_live_recovery_target_pid:-}" ]; then
+    kill "$_live_recovery_target_pid" 2>/dev/null
+  fi
+  if [ -n "${_live_recovery_attach_ready_file:-}" ]; then
+    rm -f -- "$_live_recovery_attach_ready_file"
+  fi
+}
 trap cleanup TERM INT
 
 # Ensure /data and key subdirectories exist and are writable by mobius.
 # Railway (and similar platforms) mount a fresh volume at /data owned by
 # root — the dirs from the Dockerfile are replaced by the empty mount.
 mkdir -p /data/db /data/apps /data/app-secrets /data/compiled /data/shared /data/logs /data/cron-logs /data/cli-auth /data/agent-browser-profiles /data/platform /data/run
+
+# When the launcher provisions its Ed25519 verifier, attach the immutable
+# recovery target to this normal boot on the private target port. The ordinary
+# Mobius app continues booting below; signed, short-lived request capabilities
+# authorize recovery without changing MOBIUS_BOOT_MODE or restarting it into a
+# mutually exclusive recovery container.
+if [ -n "${MOBIUS_RECOVERY_CAPABILITY_PUBLIC_KEY:-}" ]; then
+  _live_recovery_target_port=${MOBIUS_RECOVERY_TARGET_PORT:-18002}
+  _live_recovery_target_enabled=1
+  _live_recovery_target_disable_reason="invalid or public-conflicting port"
+  case "$_live_recovery_target_port" in
+    ''|*[!0-9]*) _live_recovery_target_enabled=0 ;;
+    *)
+      if [ "${#_live_recovery_target_port}" -gt 5 ]; then
+        _live_recovery_target_enabled=0
+      elif [ "$_live_recovery_target_port" -lt 1 ] \
+        || [ "$_live_recovery_target_port" -gt 65535 ]; then
+        _live_recovery_target_enabled=0
+      elif [ "$_live_recovery_target_port" -eq "${PORT:-8000}" ] 2>/dev/null \
+        || { [ -n "${MOBIUS_PORT:-}" ] \
+          && [ "$_live_recovery_target_port" -eq "$MOBIUS_PORT" ] 2>/dev/null; }; then
+        _live_recovery_target_enabled=0
+      fi
+      ;;
+  esac
+  if [ "$_live_recovery_target_enabled" -eq 1 ]; then
+    _live_recovery_boot_id=$(python3 -I -c \
+      'import secrets; print(secrets.token_urlsafe(24))') \
+      || _live_recovery_target_enabled=0
+    case "${_live_recovery_boot_id:-}" in
+      *[!A-Za-z0-9_-]*|'') _live_recovery_target_enabled=0 ;;
+    esac
+    if [ "${#_live_recovery_boot_id}" -ne 32 ]; then
+      _live_recovery_target_enabled=0
+    fi
+    if [ "$_live_recovery_target_enabled" -eq 1 ]; then
+      _live_recovery_attach_ready_file=$(mktemp \
+        /tmp/mobius-recovery-attach-ready.XXXXXX) \
+        || _live_recovery_target_enabled=0
+    fi
+    if [ "$_live_recovery_target_enabled" -ne 1 ]; then
+      _live_recovery_target_disable_reason="could not allocate boot attachment identity"
+    fi
+  fi
+  # The verifier is public, but the application and agent do not need it.
+  # Retain it only until the target has inherited its startup environment.
+  if [ "$_live_recovery_target_enabled" -eq 1 ]; then
+    # Do not leak app/SSO/provider secrets (or restored empty legacy recovery
+    # variables) into the privileged target's initial /proc environment.
+    env -i \
+      HOME=/root \
+      PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+      LANG="${LANG:-C.UTF-8}" \
+      DATA_DIR=/data \
+      MOBIUS_BOOT_MODE=normal \
+      MOBIUS_RECOVERY_CAPABILITY_PUBLIC_KEY="$MOBIUS_RECOVERY_CAPABILITY_PUBLIC_KEY" \
+      MOBIUS_RECOVERY_TARGET_PORT="$_live_recovery_target_port" \
+      MOBIUS_RECOVERY_BOOT_ID="$_live_recovery_boot_id" \
+      MOBIUS_RECOVERY_ATTACH_READY_FILE="$_live_recovery_attach_ready_file" \
+      MOBIUS_INSTANCE_ID="${MOBIUS_INSTANCE_ID:-}" \
+      RAILWAY_DEPLOYMENT_ID="${RAILWAY_DEPLOYMENT_ID:-}" \
+      python3 -I /app/recovery-target/targetd.py &
+    _live_recovery_target_pid=$!
+  else
+    if [ -n "${_live_recovery_attach_ready_file:-}" ]; then
+      rm -f -- "$_live_recovery_attach_ready_file"
+      unset _live_recovery_attach_ready_file
+    fi
+    unset _live_recovery_boot_id
+    echo "WARNING: live recovery target disabled: ${_live_recovery_target_disable_reason}; normal Möbius boot will continue." >&2
+  fi
+  unset MOBIUS_RECOVERY_CAPABILITY_PUBLIC_KEY MOBIUS_RECOVERY_BOOT_ID
+  unset MOBIUS_RECOVERY_ATTACH_READY_FILE
+  unset _live_recovery_target_disable_reason _live_recovery_target_enabled
+  unset _live_recovery_target_port
+fi
+
 # Retire embedded-recovery authority before any persisted platform code can be
 # imported. These credentials and the pending sentinel have no consumer after
 # the external cutover; preserving them would leave dormant authority on old
@@ -1392,6 +1478,17 @@ else
   _start_cmd="umask 022 && export PYTHONDONTWRITEBYTECODE=1"
   _start_cmd="$_start_cmd && cd $_serve_workdir"
   _start_cmd="$_start_cmd && exec $_env_scrub uvicorn app.main:app $_uvicorn_flags"
+fi
+
+# Entrypoint initialization is complete. Publish the exact per-container boot
+# identity immediately before handing pid 1 to uvicorn. This releases repair
+# attachment even if the application later starts degraded or fails its health
+# endpoint, while still preventing repair from racing boot-time mutations.
+if [ -n "${_live_recovery_attach_ready_file:-}" ]; then
+  if ! printf 'ready:%s\n' "$_live_recovery_boot_id" \
+    > "$_live_recovery_attach_ready_file"; then
+    echo "WARNING: live recovery attach readiness could not be published." >&2
+  fi
 fi
 
 exec su -s /bin/sh mobius -c \

--- a/backend/tests/test_core_digest_release.py
+++ b/backend/tests/test_core_digest_release.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+SPEC = importlib.util.spec_from_file_location(
+  "core_digest_release", SCRIPTS / "core_digest_release.py"
+)
+assert SPEC and SPEC.loader
+release = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = release
+SPEC.loader.exec_module(release)
+
+CURRENT_SHA = "a" * 40
+CANDIDATE_SHA = "b" * 40
+FAILED_SHA = "e" * 40
+CURRENT_DIGEST = "sha256:" + "c" * 64
+CANDIDATE_DIGEST = "sha256:" + "d" * 64
+CHANNEL = "ghcr.io/mobius-os/mobius:external-recovery"
+RELEASE_REF = "refs/heads/stack/external-recovery-v1"
+
+
+def current_response(**changes):
+  body = {
+    "status": "completed",
+    "generation": 7,
+    "build_sha": CURRENT_SHA,
+    "image_digest": CURRENT_DIGEST,
+    "release_channel": CHANNEL,
+    "platform_release_ref": RELEASE_REF,
+  }
+  body.update(changes)
+  return body
+
+
+def classify(
+  body,
+  *,
+  candidate=CANDIDATE_SHA,
+  branch_head=CANDIDATE_SHA,
+  status=200,
+):
+  return release.classify_current_response(
+    body,
+    status,
+    prerequisite=release.ImageIdentity(CURRENT_DIGEST, CURRENT_SHA),
+    candidate_sha=candidate,
+    candidate_epoch=f"managed-core-v1-{candidate}",
+    branch_head_sha=branch_head,
+    release_channel=CHANNEL,
+    platform_release_ref=RELEASE_REF,
+  )
+
+
+def test_current_core_requires_exact_completed_controller_identity():
+  decision = classify(current_response())
+  assert decision.decision == "release"
+  assert decision.current == release.CurrentCoreIdentity(
+    7, CURRENT_SHA, CURRENT_DIGEST, CHANNEL, RELEASE_REF
+  )
+
+  replay = classify(current_response(), candidate=CURRENT_SHA)
+  assert replay.decision == "replay"
+
+  with pytest.raises(release.ReleaseError, match="protected branch HEAD"):
+    classify(current_response(), candidate=FAILED_SHA)
+
+
+def test_active_core_allows_only_the_exact_candidate_tuple():
+  active = current_response(
+    status="active",
+    cutover_status="publish_authorized",
+    active_epoch=f"managed-core-v1-{CANDIDATE_SHA}",
+    active_build_sha=CANDIDATE_SHA,
+    active_image_digest=CANDIDATE_DIGEST,
+  )
+  decision = classify(active, branch_head=FAILED_SHA)
+  assert decision.decision == "resume"
+  assert decision.active_image_digest == CANDIDATE_DIGEST
+
+  unbound = dict(active, active_image_digest="")
+  with pytest.raises(release.ReleaseError, match="unbound active candidate"):
+    classify(unbound, branch_head=FAILED_SHA)
+  assert classify(unbound).decision == "resume"
+
+  with pytest.raises(release.ReleaseError, match="exact active controller tuple"):
+    classify(active, candidate=FAILED_SHA, branch_head=FAILED_SHA)
+
+  active["active_epoch"] = f"managed-core-v1-{FAILED_SHA}"
+  with pytest.raises(release.ReleaseError, match="exact active controller tuple"):
+    classify(active)
+
+
+def test_awaiting_replacement_accepts_only_a_new_branch_head():
+  replacement = current_response(
+    status="awaiting_replacement",
+    cutover_status="awaiting_replacement",
+    active_epoch=f"managed-core-v1-{FAILED_SHA}",
+    active_build_sha=FAILED_SHA,
+    active_image_digest=CANDIDATE_DIGEST,
+  )
+  decision = classify(replacement)
+  assert decision.decision == "replacement"
+  assert decision.active_image_digest == ""
+
+  with pytest.raises(release.ReleaseError, match="protected branch HEAD"):
+    classify(replacement, branch_head=FAILED_SHA)
+  with pytest.raises(release.ReleaseError, match="supersede the failed candidate"):
+    classify(replacement, candidate=FAILED_SHA, branch_head=FAILED_SHA)
+
+
+@pytest.mark.parametrize(
+  ("changes", "message"),
+  (
+    ({"status": "redeploying"}, "unsupported current-core status"),
+    ({"generation": 0}, "completed core generation"),
+    ({"build_sha": CANDIDATE_SHA}, "protected release prerequisite"),
+    ({"image_digest": CANDIDATE_DIGEST}, "protected release prerequisite"),
+    ({"release_channel": "ghcr.io/example/wrong"}, "release_channel"),
+    ({"platform_release_ref": "refs/heads/main"}, "platform_release_ref"),
+  ),
+)
+def test_current_core_rejects_ambiguous_or_changed_state(changes, message):
+  with pytest.raises(release.ReleaseError, match=message):
+    classify(current_response(**changes))
+
+
+def test_current_core_rejects_non_success_response():
+  with pytest.raises(release.ReleaseError, match=r"HTTP 409 \(core_release_active\)"):
+    classify({"error": "core_release_active"}, status=409)
+
+
+def test_exact_image_requires_both_digest_and_revision(monkeypatch):
+  expected = release.ImageIdentity(CURRENT_DIGEST, CURRENT_SHA)
+  monkeypatch.setattr(release, "inspect_digest", lambda *_args: expected)
+  release.assert_exact_image("ghcr.io/mobius-os/mobius", expected)
+
+  monkeypatch.setattr(
+    release,
+    "inspect_digest",
+    lambda *_args: release.ImageIdentity(CURRENT_DIGEST, CANDIDATE_SHA),
+  )
+  with pytest.raises(release.ReleaseError, match="expected revision"):
+    release.assert_exact_image("ghcr.io/mobius-os/mobius", expected)
+
+
+def test_payload_is_canonical_and_bound_digest_is_explicit(tmp_path):
+  path = tmp_path / "payload.json"
+  identity = release.CutoverIdentity(
+    epoch=f"managed-core-v1-{CANDIDATE_SHA}",
+    release_channel=CHANNEL,
+    platform_release_ref=RELEASE_REF,
+    prerequisite_build_sha=CURRENT_SHA,
+    prerequisite_image_digest=CURRENT_DIGEST,
+    removal_build_sha=CANDIDATE_SHA,
+  )
+  release.write_payload(str(path), identity)
+  body = json.loads(path.read_text(encoding="utf-8"))
+  assert body == {
+    "epoch": f"managed-core-v1-{CANDIDATE_SHA}",
+    "release_channel": CHANNEL,
+    "platform_release_ref": RELEASE_REF,
+    "prerequisite_build_sha": CURRENT_SHA,
+    "prerequisite_image_digest": CURRENT_DIGEST,
+    "removal_build_sha": CANDIDATE_SHA,
+  }
+  assert "removal_image_digest" not in body
+
+  release.write_payload(
+    str(path),
+    replace(identity, removal_image_digest=CANDIDATE_DIGEST),
+  )
+  assert json.loads(path.read_text(encoding="utf-8"))[
+    "removal_image_digest"
+  ] == CANDIDATE_DIGEST

--- a/backend/tests/test_recovery_target.py
+++ b/backend/tests/test_recovery_target.py
@@ -197,7 +197,10 @@ def test_live_session_scope_serves_health_exec_and_filesystem(
   with _server(target) as url:
     assert _request(url, "/v1/health", token=token)[1]["boot_id"] == _BOOT_ID
     status, result = _request(
-      url, "/v1/exec", token=token, body={"argv": ["/bin/true"]},
+      url,
+      "/v1/exec",
+      token=token,
+      body={"argv": ["/bin/true"], "cwd": str(tmp_path)},
     )
     assert status == 200 and result["exit_code"] == 0
     status, result = _request(

--- a/backend/tests/test_recovery_target.py
+++ b/backend/tests/test_recovery_target.py
@@ -8,6 +8,7 @@ import json
 import os
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 import urllib.error
@@ -17,11 +18,75 @@ from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 
 _TARGET_PATH = (
   Path(__file__).resolve().parents[1] / "recovery_target" / "targetd.py"
 )
+_BOOT_ID = "B" * 32
+
+
+def _base64url(value: bytes) -> str:
+  return base64.urlsafe_b64encode(value).rstrip(b"=").decode("ascii")
+
+
+def _capability_token(
+  private_key: Ed25519PrivateKey,
+  *,
+  now: int | None = None,
+  scope: str = "session",
+  **overrides,
+) -> tuple[str, dict]:
+  issued_at = int(time.time()) if now is None else now
+  claims = {
+    "v": 1,
+    "iss": "mobius.you",
+    "aud": "mobius-recovery-target",
+    "sub": "instance-123",
+    "dep": "deployment-789",
+    "scp": scope,
+    "iat": issued_at,
+    "nbf": issued_at,
+    "exp": issued_at + (30 if scope == "probe" else 300),
+  }
+  if scope == "session":
+    claims.update({"sid": "session-456", "bid": _BOOT_ID})
+  claims.update(overrides)
+  payload = json.dumps(
+    claims, sort_keys=True, separators=(",", ":"), ensure_ascii=True,
+  ).encode("utf-8")
+  payload_segment = _base64url(payload)
+  signed = f"mrc1.{payload_segment}".encode("ascii")
+  token = f"mrc1.{payload_segment}.{_base64url(private_key.sign(signed))}"
+  return token, claims
+
+
+def _configure_live_capabilities(target):
+  private_key = Ed25519PrivateKey.generate()
+  target._AUTH_MODE = "capability"
+  target._CAPABILITY_PUBLIC_KEY = private_key.public_key()
+  target._LOCAL_INSTANCE_ID = "instance-123"
+  target._LOCAL_DEPLOYMENT_ID = "deployment-789"
+  target._LOCAL_BOOT_ID = _BOOT_ID
+  target._TARGET_EXPIRES_AT = None
+  return private_key
+
+
+def _configure_live_attach_gate(target, path: Path, *, ready: bool) -> None:
+  path.write_text(f"ready:{_BOOT_ID}\n" if ready else "", encoding="ascii")
+  path.chmod(0o600)
+  target._ATTACH_READY_FILE = path
+  target._ATTACH_READY.clear()
+
+
+def _revoked_response(session_id: str) -> dict:
+  return {
+    "status": "revoked",
+    "deployment_id": "deployment-789",
+    "session_id": session_id,
+  }
 
 
 @pytest.fixture()
@@ -63,6 +128,15 @@ def _request(url, path, *, token="t" * 43, body=None, timeout=15):
     return response.status, json.load(response)
 
 
+def _socket_response(sock) -> bytes:
+  chunks = []
+  while True:
+    chunk = sock.recv(4096)
+    if not chunk:
+      return b"".join(chunks)
+    chunks.append(chunk)
+
+
 def test_dual_stack_health_is_authenticated(target):
   with _server(target) as url:
     with pytest.raises(urllib.error.HTTPError) as denied:
@@ -78,6 +152,433 @@ def test_dual_stack_health_is_authenticated(target):
       "build_sha": "unknown",
       "expires_at": target._TARGET_EXPIRES_AT,
     }
+
+    with pytest.raises(urllib.error.HTTPError) as legacy_revoke:
+      _request(url, "/v1/revoke", body={})
+    assert legacy_revoke.value.code == 404
+
+
+def test_live_health_uses_signed_capability_and_reports_bound_deployment(
+  target, tmp_path,
+):
+  private_key = _configure_live_capabilities(target)
+  _configure_live_attach_gate(target, tmp_path / "attach-ready", ready=True)
+  token, claims = _capability_token(private_key, scope="probe")
+  assert len(token) <= target.MAX_CAPABILITY_TOKEN_BYTES
+
+  with _server(target) as url:
+    with pytest.raises(urllib.error.HTTPError) as denied:
+      _request(url, "/v1/health", token="t" * 43)
+    assert denied.value.code == 401
+
+    status, body = _request(url, "/v1/health", token=token)
+  assert status == 200
+  assert body == {
+    "protocol": "mobius-recovery-target/v1",
+    "target": "mobius",
+    "mode": "normal",
+    "attachment": "live",
+    "build_sha": "unknown",
+    "expires_at": claims["exp"],
+    "deployment_id": "deployment-789",
+    "boot_id": _BOOT_ID,
+  }
+
+
+def test_live_session_scope_serves_health_exec_and_filesystem(
+  target, tmp_path,
+):
+  private_key = _configure_live_capabilities(target)
+  _configure_live_attach_gate(target, tmp_path / "attach-ready", ready=True)
+  token, _claims = _capability_token(private_key)
+  payload = tmp_path / "payload.txt"
+  payload.write_text("repair-data", encoding="ascii")
+
+  with _server(target) as url:
+    assert _request(url, "/v1/health", token=token)[1]["boot_id"] == _BOOT_ID
+    status, result = _request(
+      url, "/v1/exec", token=token, body={"argv": ["/bin/true"]},
+    )
+    assert status == 200 and result["exit_code"] == 0
+    status, result = _request(
+      url, "/v1/fs/read", token=token, body={"path": str(payload)},
+    )
+    assert status == 200
+    assert base64.b64decode(result["data_base64"]) == b"repair-data"
+
+
+@pytest.mark.parametrize(
+  ("path", "body"),
+  (
+    ("/v1/exec", {"argv": ["/bin/true"]}),
+    ("/v1/fs/read", {"path": "/tmp/anything"}),
+    ("/v1/fs/write", {"path": "/tmp/anything", "data_base64": ""}),
+    ("/v1/fs/list", {"path": "/tmp"}),
+    ("/v1/revoke", {}),
+  ),
+)
+def test_probe_scope_cannot_exec_access_files_or_revoke(
+  target, tmp_path, path, body,
+):
+  private_key = _configure_live_capabilities(target)
+  _configure_live_attach_gate(target, tmp_path / "attach-ready", ready=True)
+  token, _claims = _capability_token(private_key, scope="probe")
+  with _server(target) as url:
+    with pytest.raises(urllib.error.HTTPError) as denied:
+      _request(url, path, token=token, body=body)
+  assert denied.value.code == 403
+  assert json.load(denied.value)["error"]["code"] == "insufficient_scope"
+
+
+def test_session_capability_is_bound_to_this_exact_container_boot(target):
+  private_key = _configure_live_capabilities(target)
+  token, claims = _capability_token(private_key)
+  assert len(token) <= target.MAX_CAPABILITY_TOKEN_BYTES
+  assert target._verify_capability_token(token) == claims
+
+  wrong_token, _claims = _capability_token(private_key, bid="W" * 32)
+  with pytest.raises(target.RequestError) as wrong_boot:
+    target._verify_capability_token(wrong_token)
+  assert wrong_boot.value.code == "unauthorized"
+
+  # A container restart creates a new boot identity even when Railway retains
+  # the same deployment id. The previously valid root session fails closed.
+  target._LOCAL_BOOT_ID = "N" * 32
+  with pytest.raises(target.RequestError) as old_boot:
+    target._verify_capability_token(token)
+  assert old_boot.value.code == "unauthorized"
+
+
+def test_probe_has_no_session_or_boot_authority_claims(target):
+  private_key = _configure_live_capabilities(target)
+  token, claims = _capability_token(private_key, scope="probe")
+  assert "sid" not in claims
+  assert "bid" not in claims
+  assert target._verify_capability_token(token) == claims
+
+  token, _claims = _capability_token(
+    private_key, scope="probe", sid="forbidden-session",
+  )
+  with pytest.raises(target.RequestError) as extra_claim:
+    target._verify_capability_token(token)
+  assert extra_claim.value.code == "unauthorized"
+
+
+def test_live_target_denies_startup_window_until_entrypoint_init_completes(
+  target, tmp_path,
+):
+  private_key = _configure_live_capabilities(target)
+  ready_file = tmp_path / "attach-ready"
+  _configure_live_attach_gate(target, ready_file, ready=False)
+  token, _claims = _capability_token(private_key, scope="probe")
+
+  with _server(target) as url:
+    with pytest.raises(urllib.error.HTTPError) as starting:
+      _request(url, "/v1/health", token=token)
+    assert starting.value.code == 503
+    assert json.load(starting.value)["error"]["code"] == "attach_not_ready"
+
+    # A stale or foreign boot marker cannot release the gate.
+    ready_file.write_text(f"ready:{'S' * 32}\n", encoding="ascii")
+    with pytest.raises(urllib.error.HTTPError) as stale:
+      _request(url, "/v1/health", token=token)
+    assert stale.value.code == 503
+
+    # No application health result participates in this gate. The private
+    # marker means only that entrypoint initialization reached its final handoff.
+    ready_file.write_text(f"ready:{_BOOT_ID}\n", encoding="ascii")
+    status, health = _request(url, "/v1/health", token=token)
+  assert status == 200
+  assert health["attachment"] == "live"
+  assert not ready_file.exists()
+
+
+def test_live_target_accepts_ready_marker_written_before_target_initializes(
+  target, monkeypatch,
+):
+  fd, ready_name = tempfile.mkstemp(
+    prefix="mobius-recovery-attach-ready.", dir="/tmp",
+  )
+  ready_file = Path(ready_name)
+  try:
+    with os.fdopen(fd, "wb") as handle:
+      handle.write(f"ready:{_BOOT_ID}\n".encode("ascii"))
+    monkeypatch.setenv(target.ATTACH_READY_FILE_ENV, ready_name)
+
+    assert target._read_attach_ready_file() == ready_file
+    target._AUTH_MODE = "capability"
+    target._LOCAL_BOOT_ID = _BOOT_ID
+    target._ATTACH_READY_FILE = ready_file
+    target._ATTACH_READY.clear()
+    assert target._attach_is_ready()
+    assert not ready_file.exists()
+  finally:
+    ready_file.unlink(missing_ok=True)
+
+
+@pytest.mark.parametrize("kind", ("symlink", "hardlink", "public_mode"))
+def test_live_attach_marker_rejects_insecure_files(target, monkeypatch, kind):
+  fd, source_name = tempfile.mkstemp(
+    prefix="mobius-recovery-attach-ready.", dir="/tmp",
+  )
+  os.close(fd)
+  source = Path(source_name)
+  candidate = source
+  extra: Path | None = None
+  try:
+    if kind == "symlink":
+      extra = Path(source_name + ".symlink")
+      extra.symlink_to(source)
+      candidate = extra
+    elif kind == "hardlink":
+      extra = Path(source_name + ".hardlink")
+      os.link(source, extra)
+      candidate = extra
+    else:
+      source.chmod(0o644)
+    monkeypatch.setenv(target.ATTACH_READY_FILE_ENV, str(candidate))
+    with pytest.raises(RuntimeError, match="insecure"):
+      target._read_attach_ready_file()
+  finally:
+    if extra is not None:
+      extra.unlink(missing_ok=True)
+    source.unlink(missing_ok=True)
+
+
+def test_live_session_self_revoke_is_pre_ready_idempotent_and_scoped(
+  target, tmp_path,
+):
+  private_key = _configure_live_capabilities(target)
+  _configure_live_attach_gate(target, tmp_path / "attach-ready", ready=False)
+  revoked_token, _revoked_claims = _capability_token(
+    private_key, sid="session-revoked",
+  )
+  other_token, _other_claims = _capability_token(
+    private_key, sid="session-other",
+  )
+
+  with _server(target) as url:
+    status, result = _request(
+      url, "/v1/revoke", token=revoked_token, body={},
+    )
+    assert status == 200
+    assert result == _revoked_response("session-revoked")
+
+    # The same still-valid signed token may retry its own revoke.
+    status, result = _request(
+      url, "/v1/revoke", token=revoked_token, body={},
+    )
+    assert status == 200
+    assert result == _revoked_response("session-revoked")
+
+    with pytest.raises(urllib.error.HTTPError) as revoked:
+      _request(url, "/v1/health", token=revoked_token)
+    assert revoked.value.code == 401
+    assert json.load(revoked.value)["error"]["code"] == "auth_revoked"
+
+    # Revoke never accepts a caller-selected session id and does not affect a
+    # different signed session.
+    with pytest.raises(urllib.error.HTTPError) as selected:
+      _request(
+        url, "/v1/revoke", token=other_token,
+        body={"sid": "session-revoked"},
+      )
+    assert selected.value.code == 400
+    with pytest.raises(urllib.error.HTTPError) as still_starting:
+      _request(url, "/v1/health", token=other_token)
+    assert still_starting.value.code == 503
+    assert json.load(still_starting.value)["error"]["code"] == "attach_not_ready"
+
+
+def test_session_revoke_kills_only_that_sessions_active_exec(target, tmp_path):
+  _configure_live_capabilities(target)
+  expires_at = int(time.time()) + 30
+  first_ready = tmp_path / "first.ready"
+  second_ready = tmp_path / "second.ready"
+
+  def command(marker: Path, delay: float, session_id: str):
+    return target._run_exec({
+      "argv": [
+        sys.executable, "-c",
+        f"import pathlib,time; pathlib.Path({str(marker)!r}).touch(); "
+        f"time.sleep({delay}); print({session_id!r})",
+      ],
+      "cwd": str(tmp_path),
+      "timeout_seconds": 10,
+    }, capability_expires_at=expires_at, capability_session_id=session_id)
+
+  with ThreadPoolExecutor(max_workers=2) as executor:
+    first = executor.submit(command, first_ready, 30, "session-first")
+    second = executor.submit(command, second_ready, 0.8, "session-second")
+    deadline = time.monotonic() + 3
+    while (
+      (not first_ready.exists() or not second_ready.exists())
+      and time.monotonic() < deadline
+    ):
+      time.sleep(0.01)
+    assert first_ready.exists() and second_ready.exists()
+    assert target._revoke_capability_session({
+      "sid": "session-first", "dep": "deployment-789", "bid": _BOOT_ID,
+      "exp": expires_at,
+    }) == _revoked_response("session-first")
+
+  with pytest.raises(target.RequestError) as revoked:
+    first.result()
+  assert revoked.value.code == "auth_revoked"
+  survivor = second.result()
+  assert survivor["exit_code"] == 0
+  assert base64.b64decode(survivor["stdout_base64"]) == b"session-second\n"
+
+
+def test_session_revoke_ignores_a_reused_supervisor_pid(target, monkeypatch):
+  target._ACTIVE_SUPERVISORS[4242] = ("session-stale", 100)
+  signals = []
+  tree_walks = []
+  monkeypatch.setattr(target, "_process_record", lambda _pid: (1, 101))
+  monkeypatch.setattr(
+    target, "_signal_recorded_process",
+    lambda *args: signals.append(args),
+  )
+  monkeypatch.setattr(
+    target, "_stop_and_kill_descendants",
+    lambda pid: tree_walks.append(pid),
+  )
+
+  target._retire_session_supervisors("session-stale")
+
+  assert signals == []
+  assert tree_walks == []
+
+
+def test_revoked_session_denylist_is_bounded_and_pruned(target, monkeypatch):
+  monkeypatch.setattr(target, "MAX_REVOKED_SESSIONS", 1)
+  now = 1_800_000_000
+  monkeypatch.setattr(target.time, "time", lambda: now)
+  assert target._revoke_capability_session({
+    "sid": "session-one", "dep": "deployment-789", "bid": _BOOT_ID,
+    "exp": now + 10,
+  }) == _revoked_response("session-one")
+  with pytest.raises(target.RequestError) as full:
+    target._revoke_capability_session({
+      "sid": "session-two", "dep": "deployment-789", "bid": _BOOT_ID,
+      "exp": now + 20,
+    })
+  assert full.value.code == "revocation_capacity"
+  assert full.value.status == target.HTTPStatus.SERVICE_UNAVAILABLE
+
+  now += 10
+  assert target._revoke_capability_session({
+    "sid": "session-two", "dep": "deployment-789", "bid": _BOOT_ID,
+    "exp": now + 20,
+  }) == _revoked_response("session-two")
+  assert set(target._REVOKED_SESSIONS) == {"session-two"}
+
+
+@pytest.mark.parametrize(
+  ("overrides", "expected_code"),
+  [
+    ({"sub": "different-instance"}, "unauthorized"),
+    ({"dep": "different-deployment"}, "unauthorized"),
+    ({"exp": 1}, "unauthorized"),
+    ({"iat": 1_800_000_031, "nbf": 1_800_000_031,
+      "exp": 1_800_000_331}, "unauthorized"),
+    ({"iat": 1_800_000_000, "nbf": 1_800_000_000,
+      "exp": 1_800_003_601}, "unauthorized"),
+  ],
+)
+def test_live_capability_enforces_identity_time_and_lifetime(
+  target, monkeypatch, overrides, expected_code,
+):
+  private_key = _configure_live_capabilities(target)
+  monkeypatch.setattr(target.time, "time", lambda: 1_800_000_000)
+  token, _claims = _capability_token(
+    private_key, now=1_800_000_000, **overrides,
+  )
+  with pytest.raises(target.RequestError) as denied:
+    target._verify_capability_token(token)
+  assert denied.value.code == expected_code
+
+
+def test_live_capability_reports_exact_expiry(target, monkeypatch):
+  private_key = _configure_live_capabilities(target)
+  token, _claims = _capability_token(
+    private_key, now=1_800_000_000, exp=1_800_000_100,
+  )
+  monkeypatch.setattr(target.time, "time", lambda: 1_800_000_100)
+  with pytest.raises(target.RequestError) as expired:
+    target._verify_capability_token(token)
+  assert expired.value.code == "auth_expired"
+
+
+def test_probe_and_session_lifetime_boundaries_are_exact(target, monkeypatch):
+  now = 1_800_000_000
+  private_key = _configure_live_capabilities(target)
+  monkeypatch.setattr(target.time, "time", lambda: now)
+
+  for scope, lifetime in (
+    ("probe", target.MAX_PROBE_CAPABILITY_LIFETIME_SECONDS),
+    ("session", target.MAX_SESSION_CAPABILITY_LIFETIME_SECONDS),
+  ):
+    token, claims = _capability_token(
+      private_key, scope=scope, now=now, exp=now + lifetime,
+    )
+    assert target._verify_capability_token(token) == claims
+    too_long, _claims = _capability_token(
+      private_key, scope=scope, now=now, exp=now + lifetime + 1,
+    )
+    with pytest.raises(target.RequestError) as denied:
+      target._verify_capability_token(too_long)
+    assert denied.value.code == "unauthorized"
+
+
+def test_launcher_sized_session_capability_fits_the_wire_limit(target):
+  private_key = _configure_live_capabilities(target)
+  token, claims = _capability_token(
+    private_key,
+    sub="mob_" + "a" * 10,
+    dep="12345678-1234-1234-1234-123456789abc",
+    sid="rec_audit_" + "b" * 32,
+  )
+  target._LOCAL_INSTANCE_ID = claims["sub"]
+  target._LOCAL_DEPLOYMENT_ID = claims["dep"]
+
+  assert len(token.encode("ascii")) <= target.MAX_CAPABILITY_TOKEN_BYTES
+  assert target._verify_capability_token(token) == claims
+
+
+def test_individually_valid_ids_cannot_exceed_aggregate_wire_limit(target):
+  private_key = _configure_live_capabilities(target)
+  token, _claims = _capability_token(
+    private_key, sub="s" * 128, dep="d" * 128, sid="i" * 128,
+  )
+  assert len(token.encode("ascii")) > target.MAX_CAPABILITY_TOKEN_BYTES
+
+  with pytest.raises(target.RequestError) as denied:
+    target._verify_capability_token(token)
+  assert denied.value.code == "unauthorized"
+
+
+def test_live_capability_signature_covers_the_exact_canonical_payload(target):
+  private_key = _configure_live_capabilities(target)
+  token, _claims = _capability_token(private_key)
+  prefix, payload, signature = token.split(".")
+  decoded = json.loads(target._base64url_decode_unpadded(
+    payload, field="payload",
+  ))
+  noncanonical = _base64url(
+    json.dumps(decoded, sort_keys=False, indent=1).encode("utf-8")
+  )
+  resigned = private_key.sign(f"{prefix}.{noncanonical}".encode("ascii"))
+  malformed = f"{prefix}.{noncanonical}.{_base64url(resigned)}"
+  with pytest.raises(target.RequestError) as denied:
+    target._verify_capability_token(malformed)
+  assert denied.value.code == "unauthorized"
+
+  replacement = "A" if signature[0] != "A" else "B"
+  tampered = f"{prefix}.{payload}.{replacement}{signature[1:]}"
+  with pytest.raises(target.RequestError) as denied:
+    target._verify_capability_token(tampered)
+  assert denied.value.code == "unauthorized"
 
 
 def test_expired_target_rejects_a_valid_bearer_and_closes_listener(
@@ -138,6 +639,110 @@ def test_listener_falls_back_to_ipv4_when_ipv6_is_unavailable(target, monkeypatc
     server.server_close()
 
 
+def test_request_thread_capacity_is_bounded(target, monkeypatch):
+  slots = threading.BoundedSemaphore(1)
+  monkeypatch.setattr(target, "_REQUEST_SLOTS", slots)
+  monkeypatch.setattr(target, "HEADER_TIMEOUT_SECONDS", 2.0)
+  with _server(target) as url:
+    port = int(url.rsplit(":", 1)[1])
+    held = target.socket.create_connection(("127.0.0.1", port), timeout=2)
+    held.sendall(b"GET /v1/health HTTP/1.1\r\nHost: target\r\n")
+    deadline = time.monotonic() + 1
+    while time.monotonic() < deadline:
+      if not slots.acquire(blocking=False):
+        break
+      slots.release()
+      time.sleep(0.01)
+    else:
+      raise AssertionError("first request never occupied the bounded slot")
+
+    rejected = target.socket.create_connection(("127.0.0.1", port), timeout=2)
+    response = rejected.recv(4096)
+    rejected.close()
+    assert response.startswith(b"HTTP/1.1 503 Service Unavailable")
+    held.close()
+
+
+def test_partial_headers_have_an_aggregate_deadline_and_release_slot(
+  target, monkeypatch,
+):
+  slots = threading.BoundedSemaphore(1)
+  monkeypatch.setattr(target, "_REQUEST_SLOTS", slots)
+  monkeypatch.setattr(target, "HEADER_TIMEOUT_SECONDS", 0.15)
+  with _server(target) as url:
+    port = int(url.rsplit(":", 1)[1])
+    stalled = target.socket.create_connection(("127.0.0.1", port), timeout=2)
+    started = time.monotonic()
+    stalled.sendall(b"GET /v1/health HTTP/1.1\r\nHost: target")
+    assert stalled.recv(4096) == b""
+    assert time.monotonic() - started < 1
+    stalled.close()
+
+    deadline = time.monotonic() + 1
+    while time.monotonic() < deadline:
+      try:
+        status, _body = _request(url, "/v1/health")
+      except urllib.error.HTTPError as exc:
+        if exc.code == 503:
+          time.sleep(0.01)
+          continue
+        raise
+      assert status == 200
+      break
+    else:
+      raise AssertionError("header timeout did not release the request slot")
+
+
+def test_post_auth_body_read_has_a_fixed_deadline(target, monkeypatch):
+  monkeypatch.setattr(target, "_REQUEST_SLOTS", threading.BoundedSemaphore(1))
+  monkeypatch.setattr(target, "HEADER_TIMEOUT_SECONDS", 1.0)
+  monkeypatch.setattr(target, "BODY_TIMEOUT_SECONDS", 0.15)
+  with _server(target) as url:
+    port = int(url.rsplit(":", 1)[1])
+    stalled = target.socket.create_connection(("127.0.0.1", port), timeout=2)
+    stalled.sendall(
+      b"POST /v1/fs/list HTTP/1.1\r\n"
+      b"Host: target\r\n"
+      + f"Authorization: Bearer {'t' * 43}\r\n".encode("ascii")
+      + b"Content-Type: application/json\r\n"
+      b"Content-Length: 100\r\n\r\n{"
+    )
+    response = _socket_response(stalled)
+    stalled.close()
+  assert response.startswith(b"HTTP/1.1 408 Request Timeout")
+
+
+def test_post_auth_body_deadline_is_capped_by_capability_expiry(
+  target, monkeypatch, tmp_path,
+):
+  private_key = _configure_live_capabilities(target)
+  _configure_live_attach_gate(target, tmp_path / "attach-ready", ready=True)
+  monkeypatch.setattr(target, "_REQUEST_SLOTS", threading.BoundedSemaphore(1))
+  monkeypatch.setattr(target, "HEADER_TIMEOUT_SECONDS", 1.0)
+  monkeypatch.setattr(target, "BODY_TIMEOUT_SECONDS", 10.0)
+  now = int(time.time())
+  token, _claims = _capability_token(
+    private_key, now=now, exp=now + 2,
+  )
+  with _server(target) as url:
+    port = int(url.rsplit(":", 1)[1])
+    stalled = target.socket.create_connection(("127.0.0.1", port), timeout=4)
+    started = time.monotonic()
+    stalled.sendall(
+      b"POST /v1/fs/list HTTP/1.1\r\n"
+      b"Host: target\r\n"
+      + f"Authorization: Bearer {token}\r\n".encode("ascii")
+      + b"Content-Type: application/json\r\n"
+      b"Content-Length: 100\r\n\r\n{"
+    )
+    response = _socket_response(stalled)
+    elapsed = time.monotonic() - started
+    stalled.close()
+  assert response.startswith(b"HTTP/1.1 401 Unauthorized")
+  assert b'"code":"auth_expired"' in response
+  assert elapsed < 3
+
+
 def test_exec_uses_argv_without_shell_and_does_not_inherit_target_token(
   target, tmp_path,
 ):
@@ -167,6 +772,28 @@ def test_exec_timeout_kills_the_process_group(target, tmp_path):
   assert result["timed_out"] is True
   assert result["exit_code"] != 0
   assert time.monotonic() - started < 3
+
+
+def test_live_capability_expiry_kills_an_inflight_exec_tree(target, tmp_path):
+  _configure_live_capabilities(target)
+  marker = tmp_path / "capability-command.pid"
+  # Ceil to the next second, then allow one complete second so the command is
+  # definitely in flight before the integer epoch capability expires.
+  expires_at = int(time.time()) + 2
+  started = time.monotonic()
+  with pytest.raises(target.RequestError) as expired:
+    target._run_exec({
+      "argv": [
+        "/bin/sh", "-c", f"echo $$ > {marker}; exec sleep 30",
+      ],
+      "cwd": str(tmp_path),
+      "timeout_seconds": 10,
+    }, capability_expires_at=expires_at)
+  assert expired.value.code == "auth_expired"
+  assert time.monotonic() - started < 4
+  assert marker.exists()
+  command_pid = int(marker.read_text())
+  assert not Path(f"/proc/{command_pid}").exists()
 
 
 def test_exec_supervisor_kills_and_reaps_setsid_double_fork(
@@ -470,6 +1097,74 @@ def test_direct_secret_environment_is_rejected(target, monkeypatch):
     target._read_startup_token_digest()
 
 
+def test_live_public_key_is_raw_unpadded_base64url_and_consumed(
+  target, monkeypatch,
+):
+  private_key = Ed25519PrivateKey.generate()
+  raw = private_key.public_key().public_bytes(
+    encoding=serialization.Encoding.Raw,
+    format=serialization.PublicFormat.Raw,
+  )
+  encoded = _base64url(raw)
+  assert "=" not in encoded
+  monkeypatch.setenv(target.CAPABILITY_PUBLIC_KEY_ENV, encoded)
+  loaded = target._read_capability_public_key()
+  signature = private_key.sign(b"probe")
+  loaded.verify(signature, b"probe")
+  assert target.CAPABILITY_PUBLIC_KEY_ENV not in os.environ
+
+
+@pytest.mark.parametrize(
+  "value",
+  ("", "short", "A" * 31, "A" * 33, "A" * 31 + "!"),
+)
+def test_live_boot_id_is_exact_base64url_and_consumed(target, monkeypatch, value):
+  monkeypatch.setenv(target.BOOT_ID_ENV, value)
+  with pytest.raises(RuntimeError, match="32-character base64url"):
+    target._read_boot_id()
+
+
+def test_live_boot_id_accepts_entrypoint_generated_grammar(target, monkeypatch):
+  monkeypatch.setenv(target.BOOT_ID_ENV, _BOOT_ID)
+  assert target._read_boot_id() == _BOOT_ID
+  assert target.BOOT_ID_ENV not in os.environ
+
+
+@pytest.mark.parametrize("missing", ["MOBIUS_INSTANCE_ID", "RAILWAY_DEPLOYMENT_ID"])
+def test_live_security_initialization_requires_both_local_identities(
+  target, monkeypatch, missing,
+):
+  private_key = Ed25519PrivateKey.generate()
+  raw = private_key.public_key().public_bytes(
+    encoding=serialization.Encoding.Raw,
+    format=serialization.PublicFormat.Raw,
+  )
+  monkeypatch.setenv(target.CAPABILITY_PUBLIC_KEY_ENV, _base64url(raw))
+  monkeypatch.setenv("MOBIUS_INSTANCE_ID", "instance-123")
+  monkeypatch.setenv("RAILWAY_DEPLOYMENT_ID", "deployment-789")
+  monkeypatch.delenv(missing)
+  monkeypatch.setattr(target, "_assert_clean_initial_environment", lambda: None)
+  monkeypatch.setattr(target, "_assert_fs_policy_supported", lambda: None)
+  monkeypatch.setattr(target, "_drop_recovery_escape_capabilities", lambda: None)
+  monkeypatch.setattr(target, "_set_process_nondumpable", lambda: None)
+  monkeypatch.setattr(target, "_set_child_subreaper", lambda: None)
+  monkeypatch.setattr(target, "_load_baked_build_revision", lambda: "a" * 40)
+  with pytest.raises(RuntimeError, match=f"{missing} is required"):
+    target._initialize_startup_security(
+      require_pid_one=False, auth_mode="capability",
+    )
+
+
+@pytest.mark.parametrize("suffix", ["=", "!", "A"])
+def test_live_public_key_rejects_noncanonical_or_wrong_length(
+  target, monkeypatch, suffix,
+):
+  encoded = _base64url(b"k" * 32) + suffix
+  monkeypatch.setenv(target.CAPABILITY_PUBLIC_KEY_ENV, encoded)
+  with pytest.raises(RuntimeError, match="32-byte Ed25519"):
+    target._read_capability_public_key()
+
+
 def test_target_retains_only_a_one_way_bearer_verifier(target):
   raw = b"t" * 43
   assert not hasattr(target, "_STARTUP_TOKEN")
@@ -646,3 +1341,88 @@ def test_request_body_and_file_bounds_are_explicit(target, monkeypatch, tmp_path
       "data_base64": base64.b64encode(b"12345").decode(),
     })
   assert too_large.value.code == "payload_too_large"
+
+
+def test_entrypoint_attaches_live_target_without_replacing_normal_boot():
+  entrypoint = (
+    Path(__file__).resolve().parents[1] / "scripts" / "entrypoint.sh"
+  ).read_text(encoding="utf-8")
+  data_init = entrypoint.index("mkdir -p /data/db")
+  live_start = entrypoint.index(
+    "python3 -I /app/recovery-target/targetd.py &", data_init,
+  )
+  normal_app = entrypoint.index("exec su -s /bin/sh mobius -c")
+  assert data_init < live_start < normal_app
+  assert "MOBIUS_BOOT_MODE=recovery" not in entrypoint[data_init:live_start]
+
+
+def test_live_target_child_environment_excludes_empty_legacy_variables():
+  entrypoint = (
+    Path(__file__).resolve().parents[1] / "scripts" / "entrypoint.sh"
+  ).read_text(encoding="utf-8")
+  start = entrypoint.index("    env -i ")
+  end = entrypoint.index(
+    "python3 -I /app/recovery-target/targetd.py &", start,
+  )
+  command = entrypoint[start:end]
+  assert "MOBIUS_BOOT_MODE=normal" in command
+  assert "MOBIUS_INSTANCE_ID" in command
+  assert "RAILWAY_DEPLOYMENT_ID" in command
+  for legacy in (
+    "MOBIUS_RECOVERY_TARGET_TOKEN",
+    "MOBIUS_RECOVERY_TARGET_TOKEN_FD",
+    "MOBIUS_RECOVERY_TARGET_EXPIRES_AT",
+  ):
+    assert legacy not in command
+
+
+def test_live_target_failure_or_port_conflict_never_blocks_normal_app():
+  entrypoint = (
+    Path(__file__).resolve().parents[1] / "scripts" / "entrypoint.sh"
+  ).read_text(encoding="utf-8")
+  start = entrypoint.index("# When the launcher provisions its Ed25519 verifier")
+  end = entrypoint.index("# Retire embedded-recovery authority", start)
+  block = entrypoint[start:end]
+  assert "MOBIUS_RECOVERY_CAPABILITY_PUBLIC_KEY" in block
+  assert "MOBIUS_RECOVERY_TARGET_PORT" in block
+  assert "${PORT:-8000}" in block
+  assert "MOBIUS_PORT" in block
+  assert "normal Möbius boot will continue" in block
+  assert "exit " not in block
+
+
+def test_entrypoint_never_waits_for_or_infers_live_target_readiness():
+  entrypoint = (
+    Path(__file__).resolve().parents[1] / "scripts" / "entrypoint.sh"
+  ).read_text(encoding="utf-8")
+  start = entrypoint.index("# When the launcher provisions its Ed25519 verifier")
+  end = entrypoint.index("# Retire embedded-recovery authority", start)
+  block = entrypoint[start:end]
+  assert "MOBIUS_RECOVERY_ATTACH_READY_FILE" in block
+  assert "MOBIUS_RECOVERY_BOOT_ID" in block
+  assert "MOBIUS_RECOVERY_APP_READY_FILE" not in block
+  assert "MOBIUS_RECOVERY_TARGET_READY_FILE" not in block
+  assert "/v1/health" not in block
+  assert " wait " not in block
+  assert "python3 -I /app/recovery-target/targetd.py &" in block
+
+
+def test_entrypoint_releases_attach_gate_after_init_without_app_health():
+  entrypoint = (
+    Path(__file__).resolve().parents[1] / "scripts" / "entrypoint.sh"
+  ).read_text(encoding="utf-8")
+  target_start = entrypoint.index(
+    "python3 -I /app/recovery-target/targetd.py &",
+  )
+  probe = entrypoint.index('if curl -sf "$_health_url"')
+  start_command = entrypoint.index('_uvicorn_flags="')
+  publish = entrypoint.index(
+    '> "$_live_recovery_attach_ready_file"', start_command,
+  )
+  app_start = entrypoint.index("exec su -s /bin/sh mobius -c")
+  assert target_start < probe < start_command < publish < app_start
+  health_probe = entrypoint[
+    probe:entrypoint.index(") &", probe) + len(") &")
+  ]
+  assert "_live_recovery_attach_ready_file" not in health_probe
+  assert "printf 'ready:%s\\n' \"$_live_recovery_boot_id\"" in entrypoint

--- a/backend/tests/test_verify_test_runtime.py
+++ b/backend/tests/test_verify_test_runtime.py
@@ -104,6 +104,8 @@ def test_test_compose_pins_runtime_to_mounted_checkout():
   assert "BUILD_SHA=${GITHUB_SHA:-unknown}" in compose
   assert "./:/workspace:ro" in compose
   assert 'python3", "/app/scripts/verify_test_runtime.py"' in compose
+  pytest_service = compose.split("\n  pytest:\n", 1)[1].split("\nvolumes:\n", 1)[0]
+  assert "\n    init: true\n" in pytest_service
 
 
 def test_test_wrapper_isolates_compose_and_rejects_stale_images():
@@ -592,6 +594,9 @@ def test_manual_and_pull_request_runs_cover_suites_and_cutover_image():
   image_workflow = (
     ROOT / ".github" / "workflows" / "external-recovery-image.yml"
   ).read_text(encoding="utf-8")
+  digest_workflow = (
+    ROOT / ".github" / "workflows" / "core-digest-image.yml"
+  ).read_text(encoding="utf-8")
   assert not (ROOT / ".github" / "workflows" / "main-image.yml").exists()
   assert not (
     ROOT / ".github" / "workflows" / "compatibility-bootstrap.yml"
@@ -706,11 +711,86 @@ def test_manual_and_pull_request_runs_cover_suites_and_cutover_image():
   assert "cache-to: type=gha,mode=max,ignore-error=true" in image_workflow
   assert "load: true" not in image_workflow
 
-  workflows = test_workflow + image_workflow
-  assert workflows.count("DOCKER_BUILD_RECORD_UPLOAD: 'false'") == 2
+  workflows = test_workflow + image_workflow + digest_workflow
+  assert workflows.count("DOCKER_BUILD_RECORD_UPLOAD: 'false'") == 3
   assert "actions/checkout@v5" not in workflows
   assert "actions/setup-node@v5" not in workflows
   assert "actions/setup-python@v5" not in workflows
+
+
+def test_recurring_core_digest_workflow_keeps_dynamic_and_frozen_identity_separate():
+  workflow = (
+    ROOT / ".github" / "workflows" / "core-digest-image.yml"
+  ).read_text(encoding="utf-8")
+  triggers = workflow.split("\npermissions:\n", 1)[0]
+  assert "push:\n" in triggers
+  assert "workflow_dispatch:\n" in triggers
+  assert "    branches: [stack/external-recovery-v1]\n" in triggers
+  assert "pull_request:\n" not in triggers
+
+  current = workflow.index("/internal/core-releases/current")
+  prepublish = workflow.index("/internal/core-releases/prepublish")
+  registry_login = workflow.index("docker/login-action@")
+  build = workflow.index("docker/build-push-action@")
+  ownership_recheck = workflow.index(
+    "Recheck protected-branch ownership before binding"
+  )
+  bind = workflow.index("/internal/core-releases/bind")
+  postpublish = workflow.index("/internal/core-releases/postpublish")
+  final_current = workflow.rindex("/internal/core-releases/current")
+  assert (
+    current < prepublish < registry_login < build < ownership_recheck
+    < bind < postpublish
+  )
+  assert postpublish < final_current
+
+  assert "permissions:\n  contents: read\n  packages: write\n" in workflow
+  assert "environment: external-recovery-release" in workflow
+  assert "group: mobius-core-image-publication" in workflow
+  assert "cancel-in-progress: false" in workflow
+  assert "MOBIUS_MANAGED_CORE_RELEASE_ENABLED == 'true'" in workflow
+  assert "MOBIUS_MANAGED_CORE_PREREQUISITE_SHA" in workflow
+  assert "MOBIUS_MANAGED_CORE_PREREQUISITE_DIGEST" in workflow
+  assert "FROZEN_COMPATIBILITY_SHA" in workflow
+  assert "FROZEN_COMPATIBILITY_DIGEST" in workflow
+  assert "CORE_PREREQUISITE_SHA" in workflow
+  assert "CORE_PREREQUISITE_DIGEST" in workflow
+  assert "scripts/core_digest_release.py current" in workflow
+  assert "scripts/external_recovery_release.py" in workflow
+  assert "inventory" in workflow
+  assert "exact-current replay" in workflow
+  assert "steps.current.outputs.mode == 'replay'" in workflow
+  assert "steps.current.outputs.active_digest" in workflow
+  assert "The active controller digest changed before prepublish" in workflow
+  assert "steps.gate.outputs.mode == 'resume_cutover'" in workflow
+  assert "steps.gate.outputs.mode == 'completed_replay'" not in workflow
+  assert "candidate_sha:" in triggers
+  assert "ref: ${{ env.CANDIDATE_SHA }}" in workflow
+  assert 'test "$release_head" = "$CANDIDATE_SHA"' in workflow
+  assert 'git merge-base --is-ancestor "$CANDIDATE_SHA" "$release_head"' in workflow
+  assert workflow.count(
+    'if [ "$release_head" != "$CANDIDATE_SHA" ]; then'
+  ) == 1
+  assert "Refusing to bind a candidate that no longer owns" in workflow
+  assert "persist-credentials: false" in workflow
+  assert "cache-to: type=gha,mode=max,ignore-error=true" in workflow
+
+  immutable_tag = (
+    "tags: ${{ env.MOBIUS_IMAGE_REPOSITORY }}:sha-${{ env.CANDIDATE_SHA }}-"
+    "run-${{ github.run_id }}-attempt-${{ github.run_attempt }}"
+  )
+  assert immutable_tag in workflow
+  assert '--tag "$MOBIUS_RELEASE_CHANNEL"' not in workflow
+  assert 'tags: ${{ env.MOBIUS_RELEASE_CHANNEL }}' not in workflow
+  assert '--tag "$MOBIUS_IMAGE_REPOSITORY:main"' not in workflow
+  assert '--tag "$MOBIUS_IMAGE_REPOSITORY:daily"' not in workflow
+  assert "docker buildx imagetools create" not in workflow
+
+  assert "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" in workflow
+  assert "docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c" in workflow
+  assert "docker/login-action@dbcb813823bdd20940b903addbd779551569679f" in workflow
+  assert "docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a" in workflow
+
 
 def test_hosted_concurrency_is_scoped_to_the_pull_request():
   workflow = (ROOT / ".github" / "workflows" / "test.yml").read_text(

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -87,6 +87,10 @@ services:
   pytest:
     image: ${MOBIUS_IMAGE:-mobius-test:ci}
     profiles: ["test"]
+    # The full suite launches many short-lived subprocesses. Keep pytest out
+    # of PID 1 so orphaned children are reaped and later /proc-based recovery
+    # target tests see a production-shaped process table.
+    init: true
     volumes:
       # Mount one coherent checkout at a non-runtime path and run exactly like
       # CI (`cd backend && pytest`). Mounting only app/tests/scripts at /app

--- a/scripts/CORE-DIGEST-RELEASE.md
+++ b/scripts/CORE-DIGEST-RELEASE.md
@@ -1,0 +1,82 @@
+# Managed core digest releases
+
+`core-digest-image.yml` publishes recurring managed-core releases from the
+protected `stack/external-recovery-v1` branch. It does not replace or modify the
+historical one-time external-Recovery cutover workflow.
+
+There are two distinct core identities:
+
+- The frozen compatibility floor remains
+  `46cac47ef7082f0ddebc8f63f3bf0bcce9353b5e` at
+  `sha256:c85a50babb768e036cf1db748efbec6e26b846b2172379d0cadac0d2d162dddd`.
+  The public `:main` and `:external-recovery` tags stay at that identity.
+- The moving managed-core prerequisite is the controller's latest completed
+  digest. The first recurring release starts from
+  `e98a281431d91071364409284c3b3c5797c335c4` at
+  `sha256:acff72f92a1c6192e2e3bc9fc3c9731459abc59662d38ec7c6e6f445ddc390e8`.
+
+The authenticated `GET /internal/core-releases/current` response is the source
+of truth for the moving identity. Protected repository variables (or explicit
+manual inputs) express release intent and must match it exactly. The workflow
+also proves the registry digest's baked revision and verifies that the
+prerequisite commit is an ancestor of the candidate before any registry write.
+
+## One-time activation
+
+Deploy the controller support for the authenticated current-core endpoint and
+next-generation admission first. Confirm that it reports the e98/acff identity,
+then configure release intent without changing the frozen compatibility vars.
+Keep the historical `MOBIUS_EXTERNAL_RECOVERY_RELEASE_ENABLED` variable
+`false`:
+
+```bash
+gh variable set MOBIUS_MANAGED_CORE_PREREQUISITE_SHA \
+  --repo mobius-os/mobius \
+  --body e98a281431d91071364409284c3b3c5797c335c4
+gh variable set MOBIUS_MANAGED_CORE_PREREQUISITE_DIGEST \
+  --repo mobius-os/mobius \
+  --body sha256:acff72f92a1c6192e2e3bc9fc3c9731459abc59662d38ec7c6e6f445ddc390e8
+gh variable set MOBIUS_MANAGED_CORE_RELEASE_ENABLED \
+  --repo mobius-os/mobius \
+  --body true
+```
+
+The protected `external-recovery-release` environment must already provide
+`MOBIUS_YOU_CORE_RELEASE_URL` and `MOBIUS_YOU_CORE_RELEASE_TOKEN`. The job token
+receives only `contents: read` and `packages: write`.
+
+## Release and replay
+
+A push to the protected branch starts the release. A manual run can make the
+prerequisite explicit:
+
+```bash
+gh workflow run core-digest-image.yml \
+  --repo mobius-os/mobius \
+  --ref stack/external-recovery-v1 \
+  -f prerequisite_sha=e98a281431d91071364409284c3b3c5797c335c4 \
+  -f prerequisite_digest=sha256:acff72f92a1c6192e2e3bc9fc3c9731459abc59662d38ec7c6e6f445ddc390e8
+```
+
+Prepublish freezes and audits the fleet before registry login. The workflow
+then builds one attempt-specific tag, binds its immutable digest, asks the
+controller to deploy that digest, and waits for both fleet completion and the
+new completed current-core identity. A rerun resumes only the exact bound
+tuple. If branch HEAD already equals the controller's completed identity, the
+workflow verifies the digest and exits without mutating the controller or
+registry.
+
+If a job is interrupted after its digest is bound and the protected branch
+advances, resume that durable older owner by passing its exact SHA as
+`candidate_sha` along with its original prerequisite. An unbound build must
+still be protected-branch HEAD immediately before bind; the workflow rechecks
+the remote ref after its audit and build. A push may publish only its own exact
+branch head, and the older-candidate input is accepted only for the exact
+already-bound controller tuple. An `awaiting_replacement` generation accepts
+only a different protected-branch HEAD, so the failed candidate cannot be
+mistaken for a fresh release.
+
+After a successful release, advance the two `MOBIUS_MANAGED_CORE_PREREQUISITE_*`
+variables together to the completed SHA and digest before publishing its
+successor. Never advance the frozen `MOBIUS_EXTERNAL_RECOVERY_PREREQUISITE_*`
+variables and never retag `:external-recovery`.

--- a/scripts/core_digest_release.py
+++ b/scripts/core_digest_release.py
@@ -1,0 +1,318 @@
+"""Fail-closed helpers for recurring immutable managed-core releases.
+
+The controller's authenticated ``/internal/core-releases/current`` endpoint is
+the source of truth for the dynamic core prerequisite.  Repository variables
+or manual inputs express release intent; this module requires those values to
+match the completed controller identity exactly before a workflow can build or
+bind its successor.
+
+The frozen ``:external-recovery`` compatibility channel is deliberately not a
+dynamic release pointer.  Its separate A' inventory remains owned by
+``external_recovery_release.py``.  This module only inspects digest references
+and writes controller payload files; it has no registry-write operation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from external_recovery_release import (
+  CutoverIdentity,
+  DIGEST_RE,
+  EPOCH_RE,
+  GIT_SHA_RE,
+  ImageIdentity,
+  ReleaseError,
+  inspect_digest,
+  validate_cutover_identity,
+)
+
+
+@dataclass(frozen=True)
+class CurrentCoreIdentity:
+  generation: int
+  build_sha: str
+  image_digest: str
+  release_channel: str
+  platform_release_ref: str
+
+
+@dataclass(frozen=True)
+class CurrentDecision:
+  decision: str
+  current: CurrentCoreIdentity
+  active_image_digest: str = ""
+
+
+ACTIVE_STATUSES = {
+  "aborting",
+  "auditing",
+  "awaiting_redeploy",
+  "finalizing",
+  "publish_authorized",
+  "redeploy_failed",
+  "redeploying",
+  "repair_required",
+  "rolling_back",
+}
+ACTIVE_FIELDS = (
+  "cutover_status",
+  "active_epoch",
+  "active_build_sha",
+  "active_image_digest",
+)
+
+
+def _string(body: Mapping[str, Any], field: str) -> str:
+  value = body.get(field, "")
+  if not isinstance(value, str):
+    raise ReleaseError(f"controller field {field} is not a string")
+  return value.strip().lower()
+
+
+def _load_json(path: str) -> Mapping[str, Any]:
+  try:
+    with Path(path).open(encoding="utf-8") as source:
+      value = json.load(source)
+  except (OSError, ValueError) as exc:
+    raise ReleaseError("controller returned invalid JSON") from exc
+  if not isinstance(value, dict):
+    raise ReleaseError("controller response is not an object")
+  return value
+
+
+def classify_current_response(
+  body: Mapping[str, Any],
+  http_status: int,
+  *,
+  prerequisite: ImageIdentity,
+  candidate_sha: str,
+  candidate_epoch: str,
+  branch_head_sha: str,
+  release_channel: str,
+  platform_release_ref: str,
+) -> CurrentDecision:
+  """Require release intent to equal the controller's completed core."""
+
+  if not GIT_SHA_RE.fullmatch(candidate_sha):
+    raise ReleaseError("invalid candidate build SHA")
+  if not GIT_SHA_RE.fullmatch(branch_head_sha):
+    raise ReleaseError("invalid protected branch head SHA")
+  if (
+    not EPOCH_RE.fullmatch(candidate_epoch)
+    or candidate_epoch != f"managed-core-v1-{candidate_sha}"
+  ):
+    raise ReleaseError("candidate epoch is not deterministic")
+  if not GIT_SHA_RE.fullmatch(prerequisite.revision):
+    raise ReleaseError("invalid prerequisite build SHA")
+  if not DIGEST_RE.fullmatch(prerequisite.digest):
+    raise ReleaseError("invalid prerequisite image digest")
+  if http_status != 200:
+    error = _string(body, "error") or _string(body, "status") or "unknown_error"
+    raise ReleaseError(
+      f"controller current-core lookup returned HTTP {http_status} ({error})"
+    )
+  status = _string(body, "status")
+
+  generation = body.get("generation")
+  if (
+    isinstance(generation, bool)
+    or not isinstance(generation, int)
+    or generation <= 0
+  ):
+    raise ReleaseError("controller omitted the completed core generation")
+  current = CurrentCoreIdentity(
+    generation=generation,
+    build_sha=_string(body, "build_sha"),
+    image_digest=_string(body, "image_digest"),
+    release_channel=_string(body, "release_channel"),
+    platform_release_ref=_string(body, "platform_release_ref"),
+  )
+  if not GIT_SHA_RE.fullmatch(current.build_sha):
+    raise ReleaseError("controller returned an invalid current build SHA")
+  if not DIGEST_RE.fullmatch(current.image_digest):
+    raise ReleaseError("controller returned an invalid current image digest")
+  if current.release_channel != release_channel.lower():
+    raise ReleaseError("controller current core changed release_channel")
+  if current.platform_release_ref != platform_release_ref.lower():
+    raise ReleaseError("controller current core changed platform_release_ref")
+  if (
+    current.build_sha != prerequisite.revision
+    or current.image_digest != prerequisite.digest
+  ):
+    raise ReleaseError(
+      "protected release prerequisite does not match the completed controller core"
+    )
+  if status == "completed":
+    if any(body.get(field) not in (None, "") for field in ACTIVE_FIELDS):
+      raise ReleaseError("completed controller core unexpectedly has an active tuple")
+    if candidate_sha == current.build_sha:
+      return CurrentDecision("replay", current)
+    if candidate_sha != branch_head_sha:
+      raise ReleaseError("a fresh release candidate must be protected branch HEAD")
+    return CurrentDecision("release", current)
+
+  if status not in {"active", "awaiting_replacement"}:
+    raise ReleaseError(f"controller returned unsupported current-core status {status!r}")
+
+  cutover_status = _string(body, "cutover_status")
+  active_epoch = _string(body, "active_epoch")
+  active_build_sha = _string(body, "active_build_sha")
+  active_image_digest = _string(body, "active_image_digest")
+  if not EPOCH_RE.fullmatch(active_epoch):
+    raise ReleaseError("controller returned an invalid active epoch")
+  if not GIT_SHA_RE.fullmatch(active_build_sha):
+    raise ReleaseError("controller returned an invalid active build SHA")
+  if active_image_digest and not DIGEST_RE.fullmatch(active_image_digest):
+    raise ReleaseError("controller returned an invalid active image digest")
+  if active_image_digest == current.image_digest:
+    raise ReleaseError("controller active digest equals its prerequisite")
+
+  if status == "active":
+    if cutover_status not in ACTIVE_STATUSES:
+      raise ReleaseError("controller returned an unsupported active cutover status")
+    if active_build_sha != candidate_sha or active_epoch != candidate_epoch:
+      raise ReleaseError("candidate does not match the exact active controller tuple")
+    if candidate_sha != branch_head_sha and not active_image_digest:
+      raise ReleaseError(
+        "an unbound active candidate must remain protected branch HEAD"
+      )
+    return CurrentDecision("resume", current, active_image_digest)
+
+  if status == "awaiting_replacement":
+    if cutover_status != "awaiting_replacement":
+      raise ReleaseError("controller replacement status is inconsistent")
+    if candidate_sha != branch_head_sha:
+      raise ReleaseError("a replacement candidate must be protected branch HEAD")
+    if candidate_sha in {current.build_sha, active_build_sha}:
+      raise ReleaseError("replacement candidate must supersede the failed candidate")
+    return CurrentDecision("replacement", current)
+
+  raise AssertionError("unreachable current-core status")
+
+
+def assert_exact_image(repository: str, expected: ImageIdentity) -> None:
+  observed = inspect_digest(repository, expected.digest)
+  if observed != expected:
+    raise ReleaseError("immutable core image does not match its expected revision")
+
+
+def write_payload(path: str, identity: CutoverIdentity) -> None:
+  validate_cutover_identity(
+    identity, require_removal_digest=bool(identity.removal_image_digest)
+  )
+  body = {
+    "epoch": identity.epoch,
+    "release_channel": identity.release_channel,
+    "platform_release_ref": identity.platform_release_ref,
+    "prerequisite_build_sha": identity.prerequisite_build_sha,
+    "prerequisite_image_digest": identity.prerequisite_image_digest,
+    "removal_build_sha": identity.removal_build_sha,
+  }
+  if identity.removal_image_digest:
+    body["removal_image_digest"] = identity.removal_image_digest
+  try:
+    Path(path).write_text(
+      json.dumps(body, separators=(",", ":"), sort_keys=True),
+      encoding="utf-8",
+    )
+  except OSError as exc:
+    raise ReleaseError("could not write the controller payload") from exc
+
+
+def _add_identity_args(parser: argparse.ArgumentParser, *, digest: bool) -> None:
+  parser.add_argument("--epoch", required=True)
+  parser.add_argument("--release-channel", required=True)
+  parser.add_argument("--platform-release-ref", required=True)
+  parser.add_argument("--prerequisite-sha", required=True)
+  parser.add_argument("--prerequisite-digest", required=True)
+  parser.add_argument("--candidate-sha", required=True)
+  if digest:
+    parser.add_argument("--candidate-digest", required=True)
+
+
+def build_parser() -> argparse.ArgumentParser:
+  parser = argparse.ArgumentParser()
+  commands = parser.add_subparsers(dest="command", required=True)
+
+  current = commands.add_parser("current")
+  current.add_argument("--response", required=True)
+  current.add_argument("--http-status", required=True, type=int)
+  current.add_argument("--release-channel", required=True)
+  current.add_argument("--platform-release-ref", required=True)
+  current.add_argument("--prerequisite-sha", required=True)
+  current.add_argument("--prerequisite-digest", required=True)
+  current.add_argument("--candidate-sha", required=True)
+  current.add_argument("--candidate-epoch", required=True)
+  current.add_argument("--branch-head-sha", required=True)
+
+  image = commands.add_parser("image")
+  image.add_argument("--repository", required=True)
+  image.add_argument("--digest", required=True)
+  image.add_argument("--revision", required=True)
+
+  payload = commands.add_parser("payload")
+  payload.add_argument("--output", required=True)
+  _add_identity_args(payload, digest=False)
+
+  bound_payload = commands.add_parser("bound-payload")
+  bound_payload.add_argument("--output", required=True)
+  _add_identity_args(bound_payload, digest=True)
+  return parser
+
+
+def _identity_from_args(args: argparse.Namespace, *, bound: bool) -> CutoverIdentity:
+  return CutoverIdentity(
+    epoch=args.epoch,
+    release_channel=args.release_channel,
+    platform_release_ref=args.platform_release_ref,
+    prerequisite_build_sha=args.prerequisite_sha,
+    prerequisite_image_digest=args.prerequisite_digest,
+    removal_build_sha=args.candidate_sha,
+    removal_image_digest=args.candidate_digest if bound else "",
+  )
+
+
+def main(argv: list[str] | None = None) -> int:
+  args = build_parser().parse_args(argv)
+  if args.command == "current":
+    decision = classify_current_response(
+      _load_json(args.response),
+      args.http_status,
+      prerequisite=ImageIdentity(
+        digest=args.prerequisite_digest, revision=args.prerequisite_sha
+      ),
+      candidate_sha=args.candidate_sha,
+      candidate_epoch=args.candidate_epoch,
+      branch_head_sha=args.branch_head_sha,
+      release_channel=args.release_channel,
+      platform_release_ref=args.platform_release_ref,
+    )
+    print(
+      f"{decision.decision}|{decision.current.generation}|"
+      f"{decision.active_image_digest}"
+    )
+    return 0
+  if args.command == "image":
+    assert_exact_image(
+      args.repository, ImageIdentity(args.digest, args.revision)
+    )
+    return 0
+  if args.command == "payload":
+    write_payload(args.output, _identity_from_args(args, bound=False))
+    return 0
+  write_payload(args.output, _identity_from_args(args, bound=True))
+  return 0
+
+
+if __name__ == "__main__":
+  try:
+    raise SystemExit(main())
+  except ReleaseError as exc:
+    print(f"managed core release refused: {exc}", file=sys.stderr)
+    raise SystemExit(1) from exc


### PR DESCRIPTION
## Summary

- attach the immutable recovery target to normal Möbius boots on the private Railway network
- authorize short-lived, deployment- and boot-bound recovery sessions with signed Ed25519 capabilities
- keep legacy stopped-app recovery only for existing rollout compatibility
- add a fail-closed recurring immutable core-digest release workflow
- make the full Docker test runner use an init process so subprocess-heavy suites are reaped correctly

Opening, using, or closing live Recovery does not change `MOBIUS_BOOT_MODE`, service source, health-check configuration, or the running main deployment.

## Verification

- clean Docker suite: 3,701 passed, 1 skipped
- focused post-rebase suite: 136 passed
- disposable coexistence test kept normal app health at HTTP 200 with the same container identity before and after live health, exec, filesystem, and revoke operations
- actionlint, shell syntax, Python compilation, and diff checks pass
