### PR TITLE
Add secure cross-provider MCP connector registry

### DIFF
--- a/backend/app/connectors.py
+++ b/backend/app/connectors.py
@@ -1,0 +1,745 @@
+"""Owner-managed remote MCP connections shared by both agent providers.
+
+This module owns the provider-neutral connection boundary:
+
+* a bounded Streamable HTTP handshake used by Settings before saving a row;
+* write-only secret encryption compatible with the original connector preview;
+* one detached, plain-data turn plan built while the request DB session is live;
+* provider-specific projections that never query the database during a turn.
+
+Provider-native plugins/apps remain provider-owned.  These rows are the smaller
+cross-provider primitive for an owner-supplied remote MCP endpoint.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import codecs
+import hashlib
+import json
+import logging
+import os
+import re
+import tempfile
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Iterator
+from urllib.parse import urlparse
+
+import httpx
+from cryptography.fernet import Fernet, InvalidToken
+from fastapi import HTTPException
+
+from app import models
+from app.config import get_settings
+from app.net_utils import validate_url_safe
+
+log = logging.getLogger(__name__)
+
+# Probe the current stateless transport first, then fall back to the stateful
+# 2025 transport still used by many deployed servers and provider SDKs.
+MCP_PROTOCOL_VERSION = "2026-07-28"
+_LEGACY_PROTOCOL_VERSION = "2025-11-25"
+_SUPPORTED_LEGACY_PROTOCOL_VERSIONS = {
+  _LEGACY_PROTOCOL_VERSION,
+  "2025-06-18",
+  "2025-03-26",
+}
+_HANDSHAKE_TIMEOUT = httpx.Timeout(15.0, connect=8.0)
+_HANDSHAKE_DEADLINE_SECONDS = 22.0
+_MAX_RPC_BYTES = 2 * 1024 * 1024
+_MAX_TOOLS = 128
+_MAX_TOOL_PAGES = 10
+# A provider turn can legitimately remain alive for hours, but a copied child
+# environment must not retain broker access for days. Cap one turn credential
+# at 24 hours; disabling or deleting the connector revokes it immediately
+# because every broker request still re-reads the enabled row.
+_BROKER_CAPABILITY_TTL_SECONDS = 24 * 60 * 60
+_SLUG_RE = re.compile(r"[^a-z0-9_]+")
+_HEADER_RE = re.compile(r"^[!#$%&'*+.^_`|~0-9A-Za-z-]+$")
+_RESERVED_AUTH_HEADERS = {
+  "accept",
+  "content-length",
+  "content-type",
+  "host",
+  "mcp-protocol-version",
+  "mcp-session-id",
+  "origin",
+}
+
+
+class ConnectorError(Exception):
+  """A connection failure safe to present in the owner-facing Settings UI."""
+
+
+@dataclass(frozen=True)
+class ConnectorTurnPlan:
+  """Detached provider configuration built before the turn releases its DB.
+
+  The values contain turn-lifetime (at most 24-hour) broker capabilities, so their repr is
+  deliberately empty of fields and callers must never log or persist it.
+  """
+
+  claude_servers: dict[str, dict] = field(default_factory=dict, repr=False)
+  codex_config: dict | None = field(default=None, repr=False)
+  codex_env: dict[str, str] = field(default_factory=dict, repr=False)
+
+  @property
+  def empty(self) -> bool:
+    return not self.claude_servers and not self.codex_config
+
+
+EMPTY_CONNECTOR_TURN_PLAN = ConnectorTurnPlan()
+
+
+# ── Secrets ──────────────────────────────────────────────────────────────
+
+
+def _fernet() -> Fernet:
+  # Keep the original salt: an owner who briefly ran PR #431 may still have
+  # dormant connector rows after the source removal, and those keys must remain
+  # decryptable when the feature returns.
+  material = f"mobius-connector-secret-v1:{get_settings().secret_key}".encode()
+  key = base64.urlsafe_b64encode(hashlib.sha256(material).digest())
+  return Fernet(key)
+
+
+def encrypt_secret(value: str) -> str:
+  return _fernet().encrypt(value.encode()).decode()
+
+
+def decrypt_secret(token: str) -> str:
+  try:
+    return _fernet().decrypt(token.encode()).decode()
+  except (InvalidToken, ValueError) as exc:
+    raise ConnectorError(
+      "The stored key can no longer be decrypted. Remove and re-add this connection."
+    ) from exc
+
+
+def _broker_fernet() -> Fernet:
+  material = f"mobius-connector-broker-v1:{get_settings().secret_key}".encode()
+  key = base64.urlsafe_b64encode(hashlib.sha256(material).digest())
+  return Fernet(key)
+
+
+def mint_broker_capability(connector_id: int) -> str:
+  """Mint one short-lived, connector-scoped credential for a provider turn."""
+  payload = json.dumps(
+    {"connector_id": connector_id}, separators=(",", ":"),
+  ).encode()
+  return _broker_fernet().encrypt(payload).decode()
+
+
+def verify_broker_capability(token: str, connector_id: int) -> None:
+  """Fail closed unless ``token`` is live and scoped to this connection."""
+  try:
+    payload = json.loads(
+      _broker_fernet().decrypt(
+        token.encode(), ttl=_BROKER_CAPABILITY_TTL_SECONDS,
+      )
+    )
+  except (InvalidToken, UnicodeError, ValueError, TypeError, json.JSONDecodeError) as exc:
+    raise ConnectorError("The MCP broker capability is not valid.") from exc
+  if not isinstance(payload, dict) or payload.get("connector_id") != connector_id:
+    raise ConnectorError("The MCP broker capability is not valid for this connection.")
+
+
+# ── Pure naming/auth/sizing helpers ─────────────────────────────────────
+
+
+def slugify(name: str) -> str:
+  slug = _SLUG_RE.sub("_", name.strip().lower()).strip("_")
+  return slug[:48] or "connector"
+
+
+def estimate_tokens(tools: list) -> int:
+  """Conservative chars/4 estimate for the cached full tool definitions."""
+  try:
+    return max(0, len(json.dumps(tools, separators=(",", ":"))) // 4)
+  except (TypeError, ValueError):
+    return 0
+
+
+def validate_auth_header(name: str | None) -> str | None:
+  value = (name or "").strip()
+  if not value:
+    return None
+  if not _HEADER_RE.fullmatch(value):
+    raise ConnectorError("The API-key header name is not valid.")
+  if value.lower() in _RESERVED_AUTH_HEADERS:
+    raise ConnectorError(f"{value} is reserved by the MCP transport.")
+  return value
+
+
+def auth_headers(header_name: str | None, secret: str | None) -> dict[str, str]:
+  """Build one static auth header without changing a pasted Bearer value."""
+  if not header_name or not secret:
+    return {}
+  if header_name.lower() == "authorization" and not re.match(
+    r"(?i)^bearer\s+", secret,
+  ):
+    return {header_name: f"Bearer {secret}"}
+  return {header_name: secret}
+
+
+def bare_secret(header_name: str | None, secret: str) -> str:
+  """Codex adds ``Bearer`` for bearer_token_env_var; keep only the token."""
+  if header_name and header_name.lower() == "authorization":
+    return re.sub(r"(?i)^bearer\s+", "", secret, count=1)
+  return secret
+
+
+# ── MCP handshake ────────────────────────────────────────────────────────
+
+
+def _safe_endpoint(url: str) -> tuple[str, str, str]:
+  try:
+    parsed = urlparse(url)
+    # Force validation of these lazy urlparse properties here so malformed
+    # IPv6 authorities and non-numeric/out-of-range ports become domain errors.
+    _ = parsed.hostname, parsed.port
+    if parsed.scheme != "https":
+      raise ConnectorError("Custom MCP endpoints must use public HTTPS.")
+    if parsed.fragment:
+      raise ConnectorError("The MCP endpoint must not contain a URL fragment.")
+    return validate_url_safe(url)
+  except ConnectorError:
+    raise
+  except ValueError as exc:
+    raise ConnectorError("The MCP endpoint URL or port is not valid.") from exc
+  except HTTPException as exc:
+    raise ConnectorError(str(exc.detail)) from exc
+
+
+def _matching_payload(payload: object, rpc_id: int) -> dict | None:
+  candidates = payload if isinstance(payload, list) else [payload]
+  for item in candidates:
+    if isinstance(item, dict) and item.get("id") == rpc_id:
+      return item
+  return None
+
+
+def _decode_rpc_json(data: str, rpc_id: int) -> dict | None:
+  try:
+    return _matching_payload(json.loads(data), rpc_id)
+  except (ValueError, json.JSONDecodeError, RecursionError) as exc:
+    raise ConnectorError("The service did not answer with valid MCP JSON.") from exc
+
+
+async def _matching_rpc(response: httpx.Response, rpc_id: int) -> dict:
+  """Incrementally read one bounded response, stopping at the matching id."""
+  content_type = response.headers.get("content-type", "").lower()
+  total = 0
+  if "text/event-stream" not in content_type:
+    chunks: list[bytes] = []
+    async for chunk in response.aiter_bytes():
+      total += len(chunk)
+      if total > _MAX_RPC_BYTES:
+        raise ConnectorError("The service returned an MCP response that is too large.")
+      chunks.append(chunk)
+    try:
+      text = b"".join(chunks).decode("utf-8")
+    except UnicodeError as exc:
+      raise ConnectorError("The service did not answer with valid MCP JSON.") from exc
+    payload = _decode_rpc_json(text, rpc_id)
+    if payload is not None:
+      return payload
+    raise ConnectorError("The service did not answer the MCP request.")
+
+  decoder = codecs.getincrementaldecoder("utf-8")()
+  buffered = ""
+  data_lines: list[str] = []
+
+  def finish_event() -> dict | None:
+    if not data_lines:
+      return None
+    data = "\n".join(data_lines)
+    data_lines.clear()
+    return _decode_rpc_json(data, rpc_id)
+
+  try:
+    async for chunk in response.aiter_bytes():
+      total += len(chunk)
+      if total > _MAX_RPC_BYTES:
+        raise ConnectorError("The service returned an MCP response that is too large.")
+      buffered += decoder.decode(chunk)
+      while "\n" in buffered:
+        line, buffered = buffered.split("\n", 1)
+        line = line.removesuffix("\r")
+        if not line:
+          payload = finish_event()
+          if payload is not None:
+            return payload
+        elif line.startswith("data:"):
+          value = line[5:]
+          data_lines.append(value[1:] if value.startswith(" ") else value)
+    buffered += decoder.decode(b"", final=True)
+  except UnicodeError as exc:
+    raise ConnectorError("The service did not answer with valid MCP JSON.") from exc
+
+  if buffered:
+    line = buffered.removesuffix("\r")
+    if line.startswith("data:"):
+      value = line[5:]
+      data_lines.append(value[1:] if value.startswith(" ") else value)
+  payload = finish_event()
+  if payload is not None:
+    return payload
+  raise ConnectorError("The service did not answer the MCP request.")
+
+
+def _redact_metadata(value: object, secrets: tuple[str, ...], depth: int = 0) -> object:
+  """Remove submitted credentials recursively before remote metadata persists."""
+  if depth > 64:
+    return "[metadata omitted]"
+  if isinstance(value, str):
+    for secret in secrets:
+      if secret:
+        value = value.replace(secret, "[redacted]")
+    return value
+  if isinstance(value, list):
+    return [_redact_metadata(item, secrets, depth + 1) for item in value]
+  if isinstance(value, dict):
+    return {
+      _redact_metadata(key, secrets, depth + 1) if isinstance(key, str) else key:
+      _redact_metadata(item, secrets, depth + 1)
+      for key, item in value.items()
+    }
+  return value
+
+
+async def _post_rpc(
+  client: httpx.AsyncClient,
+  endpoint: tuple[str, str, str],
+  headers: dict[str, str],
+  method: str,
+  params: dict | None,
+  rpc_id: int | None,
+) -> dict | None:
+  pinned_url, host_header, sni_host = endpoint
+  body: dict = {"jsonrpc": "2.0", "method": method}
+  if params is not None:
+    body["params"] = params
+  if rpc_id is not None:
+    body["id"] = rpc_id
+  request = client.build_request("POST", pinned_url, json=body, headers=headers)
+  request.headers["host"] = host_header
+  request.extensions["sni_hostname"] = sni_host
+  response = await client.send(request, stream=True)
+  try:
+    if response.status_code in (301, 302, 303, 307, 308):
+      raise ConnectorError(
+        "The endpoint redirected. Add the final HTTPS MCP address instead."
+      )
+    if response.status_code in (401, 403):
+      raise ConnectorError(
+        "The service rejected the key or requires an OAuth sign-in flow."
+      )
+    if response.status_code >= 400:
+      raise ConnectorError(
+        f"The service answered HTTP {response.status_code} to {method}."
+      )
+    if rpc_id is None:
+      return None
+    payload = await _matching_rpc(response, rpc_id)
+    if "error" in payload:
+      raise ConnectorError(f"The service reported an MCP error during {method}.")
+    result = payload.get("result")
+    return result if isinstance(result, dict) else {}
+  finally:
+    await response.aclose()
+
+
+async def _close_session(
+  client: httpx.AsyncClient,
+  endpoint: tuple[str, str, str],
+  headers: dict[str, str],
+) -> None:
+  pinned_url, host_header, sni_host = endpoint
+  request = client.build_request("DELETE", pinned_url, headers=headers)
+  request.headers["host"] = host_header
+  request.extensions["sni_hostname"] = sni_host
+  try:
+    response = await client.send(request, stream=True)
+    await response.aclose()
+  except httpx.HTTPError:
+    # Session teardown is advisory and must not turn a successful catalog read
+    # into an add/refresh failure.
+    pass
+
+
+async def _initialize_rpc(
+  client: httpx.AsyncClient,
+  endpoint: tuple[str, str, str],
+  headers: dict[str, str],
+) -> tuple[dict, str | None]:
+  """Initialize while retaining the transport-level session header."""
+  pinned_url, host_header, sni_host = endpoint
+  request = client.build_request(
+    "POST",
+    pinned_url,
+    json={
+      "jsonrpc": "2.0",
+      "id": 1,
+      "method": "initialize",
+      "params": {
+        "protocolVersion": _LEGACY_PROTOCOL_VERSION,
+        "capabilities": {},
+        "clientInfo": {"name": "mobius", "version": "1.0"},
+      },
+    },
+    headers=headers,
+  )
+  request.headers["host"] = host_header
+  request.extensions["sni_hostname"] = sni_host
+  response = await client.send(request, stream=True)
+  try:
+    if response.status_code in (301, 302, 303, 307, 308):
+      raise ConnectorError(
+        "The endpoint redirected. Add the final HTTPS MCP address instead."
+      )
+    if response.status_code in (401, 403):
+      raise ConnectorError(
+        "The service rejected the key or requires an OAuth sign-in flow."
+      )
+    if response.status_code >= 400:
+      raise ConnectorError(
+        f"The service answered HTTP {response.status_code}; check the MCP address."
+      )
+    payload = await _matching_rpc(response, 1)
+    if "error" in payload:
+      raise ConnectorError("The service refused the MCP handshake.")
+    result = payload.get("result")
+    if not isinstance(result, dict):
+      raise ConnectorError("The service returned an invalid initialize result.")
+    return result, response.headers.get("mcp-session-id")
+  finally:
+    await response.aclose()
+
+
+def _modern_request_params(params: dict | None = None) -> dict:
+  return {
+    **(params or {}),
+    "_meta": {
+      "io.modelcontextprotocol/protocolVersion": MCP_PROTOCOL_VERSION,
+      "io.modelcontextprotocol/clientInfo": {
+        "name": "mobius",
+        "version": "1.0",
+      },
+      "io.modelcontextprotocol/clientCapabilities": {},
+    },
+  }
+
+
+async def _modern_rpc(
+  client: httpx.AsyncClient,
+  endpoint: tuple[str, str, str],
+  auth: dict[str, str],
+  method: str,
+  params: dict | None,
+  rpc_id: int,
+  *,
+  allow_unsupported: bool = False,
+) -> dict | None:
+  """Send one stateless 2026 request; return ``None`` for a legacy server."""
+  pinned_url, host_header, sni_host = endpoint
+  headers = {
+    "Accept": "application/json, text/event-stream",
+    "MCP-Protocol-Version": MCP_PROTOCOL_VERSION,
+    "Mcp-Method": method,
+    **auth,
+  }
+  request = client.build_request(
+    "POST",
+    pinned_url,
+    json={
+      "jsonrpc": "2.0",
+      "id": rpc_id,
+      "method": method,
+      "params": _modern_request_params(params),
+    },
+    headers=headers,
+  )
+  request.headers["host"] = host_header
+  request.extensions["sni_hostname"] = sni_host
+  response = await client.send(request, stream=True)
+  try:
+    if response.status_code in (301, 302, 303, 307, 308):
+      raise ConnectorError(
+        "The endpoint redirected. Add the final HTTPS MCP address instead."
+      )
+    if response.status_code in (401, 403):
+      raise ConnectorError(
+        "The service rejected the key or requires an OAuth sign-in flow."
+      )
+    if allow_unsupported and response.status_code in (400, 404):
+      return None
+    if response.status_code >= 400:
+      raise ConnectorError(
+        f"The service answered HTTP {response.status_code} to {method}."
+      )
+    payload = await _matching_rpc(response, rpc_id)
+    error = payload.get("error")
+    if isinstance(error, dict):
+      if allow_unsupported and error.get("code") in (-32601, -32022):
+        return None
+      raise ConnectorError(f"The service reported an MCP error during {method}.")
+    result = payload.get("result")
+    if not isinstance(result, dict):
+      raise ConnectorError(f"The service returned an invalid {method} result.")
+    return result
+  finally:
+    await response.aclose()
+
+
+async def _modern_catalog(
+  client: httpx.AsyncClient,
+  endpoint: tuple[str, str, str],
+  auth: dict[str, str],
+) -> tuple[dict, list[dict]] | None:
+  """Read a stateless 2026 catalog, or return ``None`` for a legacy server."""
+  discovered = await _modern_rpc(
+    client,
+    endpoint,
+    auth,
+    "server/discover",
+    {},
+    1,
+    allow_unsupported=True,
+  )
+  if discovered is None:
+    return None
+  versions = discovered.get("supportedVersions")
+  if not isinstance(versions, list) or MCP_PROTOCOL_VERSION not in versions:
+    return None
+
+  tools: list[dict] = []
+  cursor: str | None = None
+  for page in range(_MAX_TOOL_PAGES):
+    params = {"cursor": cursor} if cursor else {}
+    listed = await _modern_rpc(
+      client,
+      endpoint,
+      auth,
+      "tools/list",
+      params,
+      2 + page,
+    )
+    rows = (listed or {}).get("tools")
+    if not isinstance(rows, list):
+      raise ConnectorError("The service returned an invalid tool catalog.")
+    tools.extend(item for item in rows if isinstance(item, dict))
+    if len(tools) > _MAX_TOOLS:
+      raise ConnectorError(
+        f"The service exposes more than {_MAX_TOOLS} tools; narrow the endpoint first."
+      )
+    next_cursor = (listed or {}).get("nextCursor")
+    cursor = str(next_cursor) if next_cursor else None
+    if not cursor:
+      break
+  else:
+    raise ConnectorError("The service tool catalog has too many pages.")
+
+  metadata = discovered.get("_meta")
+  server_info = (
+    metadata.get("io.modelcontextprotocol/serverInfo")
+    if isinstance(metadata, dict)
+    else {}
+  )
+  return (server_info if isinstance(server_info, dict) else {}), tools
+
+
+async def handshake(
+  url: str,
+  header_name: str | None = None,
+  secret: str | None = None,
+) -> dict:
+  """Probe a Streamable HTTP MCP endpoint and return its bounded tool catalog."""
+  header_name = validate_auth_header(header_name)
+  auth = auth_headers(header_name, secret)
+  legacy_headers = {
+    "Accept": "application/json, text/event-stream",
+    "MCP-Protocol-Version": _LEGACY_PROTOCOL_VERSION,
+    **auth,
+  }
+  try:
+    async with asyncio.timeout(_HANDSHAKE_DEADLINE_SECONDS):
+      # DNS resolution is blocking in the canonical SSRF validator. Keep it
+      # inside the one handshake deadline without blocking the event loop.
+      endpoint = await asyncio.to_thread(_safe_endpoint, url)
+      async with httpx.AsyncClient(
+        timeout=_HANDSHAKE_TIMEOUT,
+        follow_redirects=False,
+        trust_env=False,
+      ) as client:
+        modern = await _modern_catalog(client, endpoint, auth)
+        if modern is not None:
+          server_info, tools = modern
+          negotiated = MCP_PROTOCOL_VERSION
+        else:
+          init, session_id = await _initialize_rpc(
+            client, endpoint, legacy_headers,
+          )
+          negotiated = str(init.get("protocolVersion") or "")
+          if negotiated not in _SUPPORTED_LEGACY_PROTOCOL_VERSIONS:
+            raise ConnectorError(
+              "The service negotiated an unsupported MCP version."
+            )
+          session_headers = dict(legacy_headers)
+          session_headers["MCP-Protocol-Version"] = negotiated
+          if session_id:
+            session_headers["MCP-Session-Id"] = session_id
+
+          await _post_rpc(
+            client, endpoint, session_headers,
+            "notifications/initialized", {}, None,
+          )
+
+          tools = []
+          cursor: str | None = None
+          for page in range(_MAX_TOOL_PAGES):
+            params = {"cursor": cursor} if cursor else {}
+            listed = await _post_rpc(
+              client, endpoint, session_headers,
+              "tools/list", params, 2 + page,
+            )
+            rows = (listed or {}).get("tools")
+            if not isinstance(rows, list):
+              raise ConnectorError("The service returned an invalid tool catalog.")
+            tools.extend(item for item in rows if isinstance(item, dict))
+            if len(tools) > _MAX_TOOLS:
+              raise ConnectorError(
+                f"The service exposes more than {_MAX_TOOLS} tools; narrow the endpoint first."
+              )
+            next_cursor = (listed or {}).get("nextCursor")
+            cursor = str(next_cursor) if next_cursor else None
+            if not cursor:
+              break
+          else:
+            raise ConnectorError("The service tool catalog has too many pages.")
+
+          if session_id:
+            await _close_session(client, endpoint, session_headers)
+          server_info = init.get("serverInfo")
+          if not isinstance(server_info, dict):
+            server_info = {}
+  except ConnectorError:
+    raise
+  except (TimeoutError, httpx.TimeoutException) as exc:
+    raise ConnectorError(
+      "The service did not answer before the connection timed out."
+    ) from exc
+  except httpx.HTTPError as exc:
+    raise ConnectorError("Could not reach the MCP service.") from exc
+
+  submitted_secrets = tuple(filter(None, (
+    secret or "",
+    bare_secret(header_name, secret) if secret else "",
+    *(auth_headers(header_name, secret).values() if secret else ()),
+  )))
+  safe_server_info = _redact_metadata(server_info, submitted_secrets)
+  safe_tools = _redact_metadata(tools, submitted_secrets)
+  if not isinstance(safe_server_info, dict) or not isinstance(safe_tools, list):
+    raise ConnectorError("The service returned invalid MCP metadata.")
+  return {
+    "name": str(
+      safe_server_info.get("title") or safe_server_info.get("name") or ""
+    ).strip(),
+    "tools": safe_tools,
+    "est_tokens": estimate_tokens(safe_tools),
+    "protocol_version": negotiated,
+  }
+
+
+# ── Per-turn provider plan ───────────────────────────────────────────────
+
+
+def _broker_url(connector_id: int) -> str:
+  try:
+    parsed = urlparse(get_settings().api_base_url)
+    _ = parsed.hostname
+    configured_port = parsed.port
+  except ValueError as exc:
+    raise ConnectorError("The configured Möbius API port is invalid.") from exc
+  env_port = os.environ.get("PORT")
+  if parsed.hostname in {"127.0.0.1", "localhost", "::1"}:
+    port = configured_port or (443 if parsed.scheme == "https" else 80)
+  elif env_port and env_port.isdigit():
+    port = int(env_port)
+  else:
+    port = configured_port or 8000
+  if not 1 <= port <= 65535:
+    raise ConnectorError("The configured Möbius API port is invalid.")
+  return f"http://127.0.0.1:{port}/api/connectors/{connector_id}/broker"
+
+
+def build_turn_plan(db) -> ConnectorTurnPlan:
+  """Snapshot enabled rows into provider config while ``db`` is still live."""
+  if db is None:
+    return EMPTY_CONNECTOR_TURN_PLAN
+  rows = (
+    db.query(models.Connector)
+    .filter(models.Connector.enabled.is_(True))
+    .order_by(models.Connector.id)
+    .all()
+  )
+  claude_servers: dict[str, dict] = {}
+  codex_servers: dict[str, dict] = {}
+  codex_env: dict[str, str] = {}
+  for row in rows:
+    try:
+      server_key = f"mobius_connector_{row.id}_{slugify(row.slug)}"
+      broker_url = _broker_url(row.id)
+      capability = mint_broker_capability(row.id)
+      env_var = f"MOBIUS_CONNECTOR_CAPABILITY_{row.id}_{slugify(row.slug).upper()}"
+
+      claude_servers[server_key] = {
+        "type": "http",
+        "url": broker_url,
+        "headers": {"Authorization": f"Bearer {capability}"},
+      }
+      codex_servers[server_key] = {
+        "url": broker_url,
+        "startup_timeout_sec": 15,
+        "bearer_token_env_var": env_var,
+      }
+      codex_env[env_var] = capability
+    except ConnectorError:
+      log.warning("connection %s skipped because its broker plan is invalid", row.slug)
+
+  return ConnectorTurnPlan(
+    claude_servers=claude_servers,
+    codex_config={"mcp_servers": codex_servers} if codex_servers else None,
+    codex_env=codex_env,
+  )
+
+
+@contextmanager
+def claude_mcp_config_path(
+  plan: ConnectorTurnPlan | None,
+) -> Iterator[str | None]:
+  """Yield an anonymous 0600 MCP config path for Claude startup only.
+
+  Passing the server dict directly makes the SDK serialize its short-lived
+  broker capability into ``--mcp-config <json>`` in the process command line.
+  ``TemporaryFile`` is anonymous on Linux; the CLI opens it through this
+  process's `/proc` fd while ``connect()`` runs, then the runner closes it
+  before the model can execute a tool. There is no named capability file left
+  behind after a crash or restart.
+  """
+  servers = plan.claude_servers if plan else {}
+  if not servers:
+    yield None
+    return
+  payload = json.dumps({"mcpServers": servers}, separators=(",", ":")).encode()
+  with tempfile.TemporaryFile(prefix="mobius-mcp-", suffix=".json") as handle:
+    os.fchmod(handle.fileno(), 0o600)
+    handle.write(payload)
+    handle.flush()
+    handle.seek(0)
+    path = f"/proc/{os.getpid()}/fd/{handle.fileno()}"
+    if not os.path.exists(path):
+      raise ConnectorError("Protected MCP configuration files are unavailable.")
+    yield path

--- a/backend/app/connectors.py
+++ b/backend/app/connectors.py
@@ -124,15 +124,25 @@ def _broker_fernet() -> Fernet:
   return Fernet(key)
 
 
-def mint_broker_capability(connector_id: int) -> str:
+def mint_broker_capability(connector_id: int, capability_id: str) -> str:
   """Mint one short-lived, connector-scoped credential for a provider turn."""
+  if not isinstance(capability_id, str) or len(capability_id) < 32:
+    raise ConnectorError("The MCP connection has no broker identity.")
   payload = json.dumps(
-    {"connector_id": connector_id}, separators=(",", ":"),
+    {
+      "connector_id": connector_id,
+      "capability_id": capability_id,
+    },
+    separators=(",", ":"),
   ).encode()
   return _broker_fernet().encrypt(payload).decode()
 
 
-def verify_broker_capability(token: str, connector_id: int) -> None:
+def verify_broker_capability(
+  token: str,
+  connector_id: int,
+  capability_id: str,
+) -> None:
   """Fail closed unless ``token`` is live and scoped to this connection."""
   try:
     payload = json.loads(
@@ -142,7 +152,11 @@ def verify_broker_capability(token: str, connector_id: int) -> None:
     )
   except (InvalidToken, UnicodeError, ValueError, TypeError, json.JSONDecodeError) as exc:
     raise ConnectorError("The MCP broker capability is not valid.") from exc
-  if not isinstance(payload, dict) or payload.get("connector_id") != connector_id:
+  if (
+    not isinstance(payload, dict)
+    or payload.get("connector_id") != connector_id
+    or payload.get("capability_id") != capability_id
+  ):
     raise ConnectorError("The MCP broker capability is not valid for this connection.")
 
 
@@ -474,8 +488,19 @@ async def _modern_rpc(
       raise ConnectorError(
         "The service rejected the key or requires an OAuth sign-in flow."
       )
-    if allow_unsupported and response.status_code in (400, 404):
-      return None
+    if allow_unsupported and response.status_code in (400, 404, 405):
+      payload = await _bounded_error_payload(response, rpc_id)
+      if payload is None:
+        # A legacy Streamable HTTP endpoint commonly answers an unknown modern
+        # probe with an empty/plain HTTP error. Only that unrecognized shape is
+        # an era signal; modern JSON-RPC errors remain authoritative.
+        return None
+      error = payload.get("error")
+      if not isinstance(error, dict):
+        raise ConnectorError("The service returned an invalid server/discover error.")
+      if _modern_error_allows_legacy_fallback(error):
+        return None
+      raise ConnectorError("The service rejected the modern MCP discovery request.")
     if response.status_code >= 400:
       raise ConnectorError(
         f"The service answered HTTP {response.status_code} to {method}."
@@ -483,7 +508,7 @@ async def _modern_rpc(
     payload = await _matching_rpc(response, rpc_id)
     error = payload.get("error")
     if isinstance(error, dict):
-      if allow_unsupported and error.get("code") in (-32601, -32022):
+      if allow_unsupported and _modern_error_allows_legacy_fallback(error):
         return None
       raise ConnectorError(f"The service reported an MCP error during {method}.")
     result = payload.get("result")
@@ -492,6 +517,44 @@ async def _modern_rpc(
     return result
   finally:
     await response.aclose()
+
+
+async def _bounded_error_payload(
+  response: httpx.Response,
+  rpc_id: int,
+) -> dict | None:
+  """Read a bounded HTTP error body, returning only matching JSON-RPC."""
+  chunks: list[bytes] = []
+  total = 0
+  async for chunk in response.aiter_bytes():
+    total += len(chunk)
+    if total > _MAX_RPC_BYTES:
+      raise ConnectorError("The service returned an MCP response that is too large.")
+    chunks.append(chunk)
+  try:
+    payload = json.loads(b"".join(chunks).decode("utf-8"))
+  except (UnicodeError, ValueError, json.JSONDecodeError, RecursionError):
+    return None
+  return _matching_payload(payload, rpc_id)
+
+
+def _modern_error_allows_legacy_fallback(error: dict) -> bool:
+  """Whether a recognized modern probe error proves legacy is worth trying."""
+  code = error.get("code")
+  if code == -32601:
+    return True
+  if code != -32022:
+    return False
+  data = error.get("data")
+  supported = data.get("supported") if isinstance(data, dict) else None
+  return (
+    isinstance(supported, list)
+    and any(
+      isinstance(version, str)
+      and version in _SUPPORTED_LEGACY_PROTOCOL_VERSIONS
+      for version in supported
+    )
+  )
 
 
 async def _modern_catalog(
@@ -692,7 +755,7 @@ def build_turn_plan(db) -> ConnectorTurnPlan:
     try:
       server_key = f"mobius_connector_{row.id}_{slugify(row.slug)}"
       broker_url = _broker_url(row.id)
-      capability = mint_broker_capability(row.id)
+      capability = mint_broker_capability(row.id, row.capability_id)
       env_var = f"MOBIUS_CONNECTOR_CAPABILITY_{row.id}_{slugify(row.slug).upper()}"
 
       claude_servers[server_key] = {

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1304,11 +1304,19 @@ def _require_app_identity(eng) -> None:
         ))
 
 
+def _add_connectors_table(eng) -> None:
+  """Create the provider-neutral MCP registry without replacing preview rows."""
+  from app.models import Connector
+
+  Connector.__table__.create(bind=eng, checkfirst=True)
+
+
 _SCHEMA_MIGRATIONS = (
   ("0001_legacy_schema_convergence", _converge_legacy_schema),
   ("0002_chat_run_goal_objective", _add_chat_run_goal_objective),
   ("0003_chat_run_root_identity", _add_chat_run_root_identity),
   ("0004_app_identity_required", _require_app_identity),
+  ("0005_connectors", _add_connectors_table),
 )
 
 

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1311,12 +1311,62 @@ def _add_connectors_table(eng) -> None:
   Connector.__table__.create(bind=eng, checkfirst=True)
 
 
+def _add_connector_capability_identity(eng) -> None:
+  """Give every connector an immutable identity for broker authorization."""
+  import secrets
+  from sqlalchemy import inspect as sa_inspect, text
+
+  columns = {
+    column["name"] for column in sa_inspect(eng).get_columns("connectors")
+  }
+  with eng.begin() as conn:
+    if "capability_id" not in columns:
+      conn.execute(text(
+        "ALTER TABLE connectors ADD COLUMN capability_id VARCHAR(64) NULL"
+      ))
+    rows = conn.execute(text(
+      "SELECT id FROM connectors "
+      "WHERE capability_id IS NULL OR length(trim(capability_id)) = 0"
+    )).all()
+    for (connector_id,) in rows:
+      conn.execute(text(
+        "UPDATE connectors SET capability_id = :capability_id WHERE id = :id"
+      ), {
+        "capability_id": secrets.token_hex(32),
+        "id": connector_id,
+      })
+    conn.execute(text(
+      "CREATE UNIQUE INDEX IF NOT EXISTS ix_connectors_capability_id "
+      "ON connectors (capability_id)"
+    ))
+    if eng.dialect.name == "postgresql":
+      conn.execute(text(
+        "ALTER TABLE connectors ALTER COLUMN capability_id SET NOT NULL"
+      ))
+    elif eng.dialect.name == "sqlite":
+      predicate = (
+        "NEW.capability_id IS NULL "
+        "OR length(trim(NEW.capability_id)) = 0"
+      )
+      conn.execute(text(
+        "CREATE TRIGGER IF NOT EXISTS connectors_require_capability_insert "
+        f"BEFORE INSERT ON connectors WHEN {predicate} BEGIN "
+        "SELECT RAISE(ABORT, 'connectors require capability_id'); END"
+      ))
+      conn.execute(text(
+        "CREATE TRIGGER IF NOT EXISTS connectors_require_capability_update "
+        f"BEFORE UPDATE OF capability_id ON connectors WHEN {predicate} BEGIN "
+        "SELECT RAISE(ABORT, 'connectors require capability_id'); END"
+      ))
+
+
 _SCHEMA_MIGRATIONS = (
   ("0001_legacy_schema_convergence", _converge_legacy_schema),
   ("0002_chat_run_goal_objective", _add_chat_run_goal_objective),
   ("0003_chat_run_root_identity", _add_chat_run_root_identity),
   ("0004_app_identity_required", _require_app_identity),
   ("0005_connectors", _add_connectors_table),
+  ("0006_connector_capability_identity", _add_connector_capability_identity),
 )
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -63,6 +63,7 @@ from app import activity, models
 from app.routes import (
   admin_router, apps_router, auth_router,
   chat_embed_router, chat_logs_router, chat_router, chats_router, chats_stream_router,
+  connectors_router,
   debug_router, delegations_router, fs_router, github_router, media_router,
   local_services_router, notifications_router, notify_router, proxy_router, push_router,
   secrets_router, self_reminders_router, settings_router, skills_router,
@@ -592,6 +593,7 @@ app.include_router(chats_router)
 app.include_router(chats_stream_router)
 app.include_router(delegations_router)
 app.include_router(chat_logs_router)
+app.include_router(connectors_router)
 # App-attributed chat contract (design §1) — a SECOND router defined in
 # routes/chats.py under /api/app-chats, so it's imported directly rather
 # than via routes/__init__'s `_load` (which only returns `.router`).

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -874,6 +874,13 @@ class Connector(Base):
   __tablename__ = "connectors"
 
   id = Column(Integer, primary_key=True, index=True)
+  # Stable authorization identity. SQLite may reuse an INTEGER PRIMARY KEY
+  # after deletion, so broker capabilities must never authorize by ``id``
+  # alone or an old turn could reach a later connector that reused the row id.
+  capability_id = Column(
+    String(64), nullable=False, unique=True, index=True,
+    default=lambda: secrets.token_hex(32),
+  )
   slug = Column(String(64), nullable=False, unique=True, index=True)
   name = Column(String(128), nullable=False)
   url = Column(String(2048), nullable=False)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -868,6 +868,26 @@ class ToolOutput(Base):
   created_at = Column(DateTime, default=lambda: datetime.now(UTC))
 
 
+class Connector(Base):
+  """Owner-managed remote MCP endpoint shared by both agent providers."""
+
+  __tablename__ = "connectors"
+
+  id = Column(Integer, primary_key=True, index=True)
+  slug = Column(String(64), nullable=False, unique=True, index=True)
+  name = Column(String(128), nullable=False)
+  url = Column(String(2048), nullable=False)
+  auth_header = Column(String(64), nullable=True)
+  auth_value_encrypted = Column(Text, nullable=True)
+  enabled = Column(Boolean, nullable=False, default=True, server_default=true())
+  tools_json = Column(JSON, nullable=False, default=list)
+  est_tokens = Column(Integer, nullable=False, default=0, server_default="0")
+  status = Column(String(16), nullable=False, default="ok", server_default="ok")
+  status_detail = Column(Text, nullable=True)
+  created_at = Column(DateTime, default=lambda: now_naive_utc())
+  last_checked_at = Column(DateTime, nullable=True)
+
+
 class ThinkingTrace(Base):
   """Full reasoning text stored outside the bounded chat transcript.
 

--- a/backend/app/net_utils.py
+++ b/backend/app/net_utils.py
@@ -106,6 +106,15 @@ def validate_url_safe(url: str) -> tuple[str, str, str]:
       elif ip in ipaddress.ip_network("::/96"):
         candidates.append(ipaddress.ip_address(int(ip) & 0xFFFFFFFF))
     for cand in candidates:
+      # "Public URL" means every address is globally routable, not merely
+      # absent from today's private-network shortlist. Benchmark, reserved,
+      # multicast, documentation, and future special-use ranges can all be
+      # routed inside a deployment and therefore remain SSRF targets.
+      if not cand.is_global or cand.is_multicast:
+        raise HTTPException(
+          400,
+          f"URL {host!r} resolves to non-public address {ip}.",
+        )
       for net in _BLOCKED_NETS:
         if cand in net:
           raise HTTPException(

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -58,6 +58,7 @@ chat_embed_router = _load("chat_embed")
 chats_router = _load("chats")
 chats_stream_router = _load("chats_stream")
 chat_logs_router = _load("chat_logs")
+connectors_router = _load("connectors")
 proxy_router = _load("proxy")
 local_services_router = _load("local_services")
 notify_router = _load("notify")
@@ -92,6 +93,7 @@ __all__ = [
   "chats_router",
   "chats_stream_router",
   "chat_logs_router",
+  "connectors_router",
   "proxy_router",
   "local_services_router",
   "notify_router",

--- a/backend/app/routes/connectors.py
+++ b/backend/app/routes/connectors.py
@@ -1,0 +1,489 @@
+"""Owner-gated registry for provider-neutral remote MCP connections."""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import json
+import logging
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app import connectors as core
+from app import models
+from app.database import get_db
+from app.deps import get_current_owner, reject_cross_site
+from app.timeutil import now_naive_utc
+
+log = logging.getLogger(__name__)
+
+router = APIRouter(
+  prefix="/api/connectors",
+  tags=["connectors"],
+  dependencies=[Depends(reject_cross_site)],
+)
+
+_MAX_CONNECTORS = 32
+_BROKER_TIMEOUT = httpx.Timeout(connect=10.0, read=None, write=30.0, pool=10.0)
+_BROKER_REQUEST_HEADERS = {
+  "accept",
+  "content-type",
+  "last-event-id",
+  "mcp-protocol-version",
+  "mcp-method",
+  "mcp-name",
+  "mcp-session-id",
+}
+_BROKER_RESPONSE_HEADERS = {
+  "cache-control",
+  "content-type",
+  "mcp-protocol-version",
+  "mcp-session-id",
+}
+_REDIRECT_STATUSES = {301, 302, 303, 307, 308}
+_CREATE_LOCK = asyncio.Lock()
+
+
+@dataclass(frozen=True)
+class _BrokerSnapshot:
+  url: str
+  auth_header: str | None
+  secret: str | None
+
+
+class ConnectorCreate(BaseModel):
+  url: str = Field(min_length=8, max_length=2048)
+  name: str = Field(default="", max_length=128)
+  auth_header: str = Field(default="", max_length=64)
+  auth_value: str = Field(default="", max_length=4096)
+
+
+class ConnectorPatch(BaseModel):
+  enabled: bool | None = None
+  name: str | None = Field(default=None, min_length=1, max_length=128)
+
+
+def _tool_preview(tools: list) -> list[dict]:
+  preview = []
+  for tool in tools[:64]:
+    if not isinstance(tool, dict):
+      continue
+    description = " ".join(str(tool.get("description") or "").split())
+    preview.append({
+      "name": str(tool.get("name") or "")[:128],
+      "description": description[:180],
+    })
+  return preview
+
+
+def _public(row: models.Connector) -> dict:
+  tools = row.tools_json if isinstance(row.tools_json, list) else []
+  return {
+    "id": row.id,
+    "slug": row.slug,
+    "name": row.name,
+    "url": row.url,
+    "enabled": row.enabled,
+    "has_auth": bool(row.auth_header and row.auth_value_encrypted),
+    "auth_header": row.auth_header,
+    "tool_count": len(tools),
+    "tools": _tool_preview(tools),
+    "est_tokens": row.est_tokens,
+    "status": row.status,
+    "status_detail": row.status_detail,
+    "providers": ["claude", "codex"],
+    "last_checked_at": (
+      row.last_checked_at.isoformat() if row.last_checked_at else None
+    ),
+  }
+
+
+def _unique_slug(db: Session, base: str) -> str:
+  slug = base
+  suffix = 2
+  while db.query(models.Connector.id).filter(
+    models.Connector.slug == slug
+  ).first():
+    suffix_text = f"_{suffix}"
+    slug = f"{base[:64 - len(suffix_text)]}{suffix_text}"
+    suffix += 1
+  return slug
+
+
+def _get_row(db: Session, connector_id: int) -> models.Connector:
+  row = db.query(models.Connector).filter(
+    models.Connector.id == connector_id
+  ).first()
+  if row is None:
+    raise HTTPException(status_code=404, detail="Connection not found.")
+  return row
+
+
+def _require_loopback_capability(request: Request, connector_id: int) -> None:
+  peer = request.client.host if request.client else ""
+  try:
+    address = ipaddress.ip_address(peer)
+  except ValueError as exc:
+    raise HTTPException(status_code=403, detail="MCP broker access denied.") from exc
+  if address.version == 6 and address.ipv4_mapped is not None:
+    address = address.ipv4_mapped
+  if not address.is_loopback:
+    raise HTTPException(status_code=403, detail="MCP broker access denied.")
+
+  scheme, _, token = request.headers.get("authorization", "").partition(" ")
+  if scheme.lower() != "bearer" or not token:
+    raise HTTPException(status_code=401, detail="MCP broker capability required.")
+  try:
+    core.verify_broker_capability(token, connector_id)
+  except core.ConnectorError as exc:
+    raise HTTPException(status_code=401, detail="MCP broker capability rejected.") from exc
+
+
+def _snapshot_broker_row(db: Session, connector_id: int) -> _BrokerSnapshot:
+  row = db.query(models.Connector).filter(
+    models.Connector.id == connector_id,
+    models.Connector.enabled.is_(True),
+  ).first()
+  if row is None:
+    raise HTTPException(status_code=404, detail="MCP connection unavailable.")
+  secret = None
+  if row.auth_header and row.auth_value_encrypted:
+    try:
+      secret = core.decrypt_secret(row.auth_value_encrypted)
+    except core.ConnectorError as exc:
+      raise HTTPException(
+        status_code=502, detail="The connection key could not be loaded.",
+      ) from exc
+  return _BrokerSnapshot(
+    url=str(row.url),
+    auth_header=str(row.auth_header) if row.auth_header else None,
+    secret=secret,
+  )
+
+
+def _broker_request_headers(
+  request: Request,
+  snapshot: _BrokerSnapshot,
+) -> dict[str, str]:
+  headers = {
+    name: value for name, value in request.headers.items()
+    if (
+      name.lower() in _BROKER_REQUEST_HEADERS
+      or name.lower().startswith("mcp-param-")
+    )
+  }
+  headers.update(core.auth_headers(snapshot.auth_header, snapshot.secret))
+  return headers
+
+
+def _broker_secret_patterns(snapshot: _BrokerSnapshot) -> tuple[bytes, ...]:
+  if not snapshot.secret:
+    return ()
+  submitted = snapshot.secret
+  values = {
+    submitted,
+    core.bare_secret(snapshot.auth_header, submitted),
+    *core.auth_headers(snapshot.auth_header, submitted).values(),
+  }
+  # JSON string escaping can transform quotes/newlines in a reflected key.
+  values.update(json.dumps(value)[1:-1] for value in tuple(values))
+  return tuple(sorted(
+    {value.encode("utf-8") for value in values if value},
+    key=len,
+    reverse=True,
+  ))
+
+
+async def _redacted_broker_stream(
+  upstream: httpx.Response,
+  snapshot: _BrokerSnapshot,
+):
+  """Stream decoded MCP bytes while retaining only a secret-sized carry.
+
+  The carry prevents a credential split across network chunks from escaping.
+  Scanning original bytes (rather than replacing each chunk independently)
+  keeps memory bounded and preserves normal response streaming.
+  """
+  patterns = _broker_secret_patterns(snapshot)
+  if not patterns:
+    async for chunk in upstream.aiter_bytes():
+      yield chunk
+    return
+
+  pending = b""
+  keep = max(len(pattern) for pattern in patterns) - 1
+  replacement = b"[redacted]"
+  async for chunk in upstream.aiter_bytes():
+    pending += chunk
+    scan_before = max(0, len(pending) - keep)
+    if not scan_before:
+      continue
+    output = bytearray()
+    position = 0
+    while position < scan_before:
+      match = next(
+        (pattern for pattern in patterns if pending.startswith(pattern, position)),
+        None,
+      )
+      if match is not None:
+        output.extend(replacement)
+        position += len(match)
+      else:
+        output.append(pending[position])
+        position += 1
+    pending = pending[position:]
+    if output:
+      yield bytes(output)
+  while pending:
+    match = next(
+      (pattern for pattern in patterns if pending.startswith(pattern)),
+      None,
+    )
+    if match is not None:
+      yield replacement
+      pending = pending[len(match):]
+    else:
+      yield pending[:1]
+      pending = pending[1:]
+
+
+async def _open_broker_upstream(
+  request: Request,
+  snapshot: _BrokerSnapshot,
+) -> tuple[httpx.AsyncClient, httpx.Response]:
+  try:
+    pinned_url, host_header, sni_host = await asyncio.wait_for(
+      asyncio.to_thread(core._safe_endpoint, snapshot.url),
+      timeout=10.0,
+    )
+  except TimeoutError as exc:
+    raise HTTPException(
+      status_code=504, detail="The MCP connection address did not resolve in time.",
+    ) from exc
+  except core.ConnectorError as exc:
+    raise HTTPException(
+      status_code=502, detail="The MCP connection address is no longer safe.",
+    ) from exc
+
+  client = httpx.AsyncClient(
+    follow_redirects=False,
+    timeout=_BROKER_TIMEOUT,
+    trust_env=False,
+  )
+  try:
+    declared_length = request.headers.get("content-length")
+    has_body = (
+      (declared_length is not None and declared_length != "0")
+      or "transfer-encoding" in request.headers
+    )
+    content = request.stream() if has_body else None
+    upstream_request = client.build_request(
+      request.method,
+      pinned_url,
+      headers=_broker_request_headers(request, snapshot),
+      content=content,
+    )
+    upstream_request.headers["host"] = host_header
+    upstream_request.extensions["sni_hostname"] = sni_host
+    upstream = await client.send(upstream_request, stream=True)
+    if upstream.status_code in _REDIRECT_STATUSES:
+      await upstream.aclose()
+      raise HTTPException(
+        status_code=502,
+        detail="The MCP service redirected; configure its final HTTPS address.",
+      )
+    return client, upstream
+  except HTTPException:
+    await client.aclose()
+    raise
+  except httpx.TimeoutException as exc:
+    await client.aclose()
+    raise HTTPException(status_code=504, detail="The MCP service timed out.") from exc
+  except httpx.HTTPError as exc:
+    await client.aclose()
+    raise HTTPException(status_code=502, detail="Could not reach the MCP service.") from exc
+  except BaseException:
+    await client.aclose()
+    raise
+
+
+@router.api_route("/{connector_id}/broker", methods=["GET", "POST", "DELETE"])
+async def broker_connector(
+  connector_id: int,
+  request: Request,
+  db: Session = Depends(get_db),
+):
+  """Stream one capability-authenticated MCP exchange to the pinned endpoint.
+
+  Only provider processes in this container can reach this route. The remote
+  endpoint and credential are copied out of the database, then the session is
+  closed before DNS validation, request upload, or response streaming begins.
+  """
+  _require_loopback_capability(request, connector_id)
+  try:
+    snapshot = _snapshot_broker_row(db, connector_id)
+  finally:
+    db.close()
+
+  client, upstream = await _open_broker_upstream(request, snapshot)
+
+  async def stream():
+    try:
+      async for chunk in _redacted_broker_stream(upstream, snapshot):
+        yield chunk
+    finally:
+      await upstream.aclose()
+      await client.aclose()
+
+  headers = {
+    name: value for name, value in upstream.headers.items()
+    if name.lower() in _BROKER_RESPONSE_HEADERS
+  }
+  return StreamingResponse(
+    stream(),
+    status_code=upstream.status_code,
+    headers=headers,
+  )
+
+
+@router.get("")
+async def list_connectors(
+  _owner: models.Owner = Depends(get_current_owner),
+  db: Session = Depends(get_db),
+):
+  rows = db.query(models.Connector).order_by(models.Connector.id).all()
+  return {"connectors": [_public(row) for row in rows]}
+
+
+@router.post("", status_code=201)
+async def add_connector(
+  body: ConnectorCreate,
+  _owner: models.Owner = Depends(get_current_owner),
+  db: Session = Depends(get_db),
+):
+  url = body.url.strip()
+  auth_value = body.auth_value.strip()
+  auth_header = body.auth_header.strip()
+  if auth_value and not auth_header:
+    auth_header = "Authorization"
+  if auth_header and not auth_value:
+    raise HTTPException(
+      status_code=400,
+      detail="Enter an API key or remove the header name.",
+  )
+  try:
+    normalized_header = core.validate_auth_header(auth_header or None)
+    # The probe can consume the complete handshake deadline. Release the
+    # checked-out connection first; this Session reacquires only after the
+    # network result is back in hand.
+    db.close()
+    probe = await core.handshake(url, normalized_header, auth_value or None)
+  except core.ConnectorError as exc:
+    raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+  parsed = urlparse(url)
+  name = body.name.strip() or probe["name"] or (parsed.hostname or "MCP server")
+  # The supported deployment has one API worker. Serialize the short commit
+  # window so two Settings tabs cannot both pass the limit check or allocate
+  # the same slug. The database uniqueness constraint remains the final guard.
+  async with _CREATE_LOCK:
+    if db.query(models.Connector.id).count() >= _MAX_CONNECTORS:
+      raise HTTPException(status_code=400, detail="Connection limit reached.")
+    row = models.Connector(
+      slug=_unique_slug(db, core.slugify(name)),
+      name=name[:128],
+      url=url,
+      auth_header=normalized_header,
+      auth_value_encrypted=(
+        core.encrypt_secret(auth_value) if normalized_header and auth_value else None
+      ),
+      enabled=True,
+      tools_json=probe["tools"],
+      est_tokens=probe["est_tokens"],
+      status="ok",
+      status_detail=None,
+      last_checked_at=now_naive_utc(),
+    )
+    db.add(row)
+    try:
+      db.commit()
+    except IntegrityError as exc:
+      db.rollback()
+      raise HTTPException(
+        status_code=409,
+        detail="The connection list changed; try adding it again.",
+      ) from exc
+    db.refresh(row)
+  log.info("MCP connection added: %s (%d tools)", row.slug, len(probe["tools"]))
+  return _public(row)
+
+
+@router.patch("/{connector_id}")
+async def patch_connector(
+  connector_id: int,
+  body: ConnectorPatch,
+  _owner: models.Owner = Depends(get_current_owner),
+  db: Session = Depends(get_db),
+):
+  row = _get_row(db, connector_id)
+  if body.enabled is not None:
+    row.enabled = body.enabled
+  if body.name is not None:
+    row.name = body.name.strip()[:128]
+  db.commit()
+  db.refresh(row)
+  return _public(row)
+
+
+@router.post("/{connector_id}/refresh")
+async def refresh_connector(
+  connector_id: int,
+  _owner: models.Owner = Depends(get_current_owner),
+  db: Session = Depends(get_db),
+):
+  stored = _get_row(db, connector_id)
+  secret = None
+  if stored.auth_header and stored.auth_value_encrypted:
+    try:
+      secret = core.decrypt_secret(stored.auth_value_encrypted)
+    except core.ConnectorError as exc:
+      raise HTTPException(status_code=409, detail=str(exc)) from exc
+  url = str(stored.url)
+  auth_header = str(stored.auth_header) if stored.auth_header else None
+  # Do not lease a DB connection while waiting on DNS or a remote service.
+  # Re-fetch after the probe so a concurrent disable/delete remains decisive.
+  db.close()
+  try:
+    probe = await core.handshake(url, auth_header, secret)
+    row = _get_row(db, connector_id)
+    row.tools_json = probe["tools"]
+    row.est_tokens = probe["est_tokens"]
+    row.status = "ok"
+    row.status_detail = None
+  except core.ConnectorError as exc:
+    row = _get_row(db, connector_id)
+    row.status = "error"
+    row.status_detail = str(exc)
+  row.last_checked_at = now_naive_utc()
+  db.commit()
+  db.refresh(row)
+  return _public(row)
+
+
+@router.delete("/{connector_id}")
+async def delete_connector(
+  connector_id: int,
+  _owner: models.Owner = Depends(get_current_owner),
+  db: Session = Depends(get_db),
+):
+  row = _get_row(db, connector_id)
+  db.delete(row)
+  db.commit()
+  return {"ok": True}

--- a/backend/app/routes/connectors.py
+++ b/backend/app/routes/connectors.py
@@ -126,7 +126,7 @@ def _get_row(db: Session, connector_id: int) -> models.Connector:
   return row
 
 
-def _require_loopback_capability(request: Request, connector_id: int) -> None:
+def _require_loopback(request: Request) -> str:
   peer = request.client.host if request.client else ""
   try:
     address = ipaddress.ip_address(peer)
@@ -140,19 +140,30 @@ def _require_loopback_capability(request: Request, connector_id: int) -> None:
   scheme, _, token = request.headers.get("authorization", "").partition(" ")
   if scheme.lower() != "bearer" or not token:
     raise HTTPException(status_code=401, detail="MCP broker capability required.")
-  try:
-    core.verify_broker_capability(token, connector_id)
-  except core.ConnectorError as exc:
-    raise HTTPException(status_code=401, detail="MCP broker capability rejected.") from exc
+  return token
 
 
-def _snapshot_broker_row(db: Session, connector_id: int) -> _BrokerSnapshot:
+def _snapshot_broker_row(
+  db: Session,
+  connector_id: int,
+  capability: str,
+) -> _BrokerSnapshot:
   row = db.query(models.Connector).filter(
     models.Connector.id == connector_id,
     models.Connector.enabled.is_(True),
   ).first()
   if row is None:
     raise HTTPException(status_code=404, detail="MCP connection unavailable.")
+  try:
+    core.verify_broker_capability(
+      capability,
+      connector_id,
+      row.capability_id,
+    )
+  except core.ConnectorError as exc:
+    raise HTTPException(
+      status_code=401, detail="MCP broker capability rejected."
+    ) from exc
   secret = None
   if row.auth_header and row.auth_value_encrypted:
     try:
@@ -199,6 +210,20 @@ def _broker_secret_patterns(snapshot: _BrokerSnapshot) -> tuple[bytes, ...]:
     key=len,
     reverse=True,
   ))
+
+
+def _broker_response_headers(
+  upstream: httpx.Response,
+  snapshot: _BrokerSnapshot,
+) -> dict[str, str]:
+  """Forward only transport headers whose values cannot reflect a secret."""
+  patterns = _broker_secret_patterns(snapshot)
+  return {
+    name: value
+    for name, value in upstream.headers.items()
+    if name.lower() in _BROKER_RESPONSE_HEADERS
+    and not any(pattern in value.encode("utf-8") for pattern in patterns)
+  }
 
 
 async def _redacted_broker_stream(
@@ -326,9 +351,9 @@ async def broker_connector(
   endpoint and credential are copied out of the database, then the session is
   closed before DNS validation, request upload, or response streaming begins.
   """
-  _require_loopback_capability(request, connector_id)
+  capability = _require_loopback(request)
   try:
-    snapshot = _snapshot_broker_row(db, connector_id)
+    snapshot = _snapshot_broker_row(db, connector_id, capability)
   finally:
     db.close()
 
@@ -342,10 +367,7 @@ async def broker_connector(
       await upstream.aclose()
       await client.aclose()
 
-  headers = {
-    name: value for name, value in upstream.headers.items()
-    if name.lower() in _BROKER_RESPONSE_HEADERS
-  }
+  headers = _broker_response_headers(upstream, snapshot)
   return StreamingResponse(
     stream(),
     status_code=upstream.status_code,

--- a/backend/tests/test_connectors.py
+++ b/backend/tests/test_connectors.py
@@ -1,0 +1,692 @@
+"""Provider-neutral MCP connection registry and secret-boundary tests."""
+
+import asyncio
+import json
+import os
+import time
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from app import connectors as core
+from app import models
+from app.database import checked_out_connections
+from app.routes import connectors as connector_routes
+
+
+def test_slug_auth_and_token_helpers_are_provider_consistent():
+  assert core.slugify("Context7 Docs!") == "context7_docs"
+  assert core.slugify(" -- ") == "connector"
+  assert len(core.slugify("x" * 200)) == 48
+  assert core.auth_headers("Authorization", "sk-123") == {
+    "Authorization": "Bearer sk-123",
+  }
+  assert core.auth_headers("authorization", "bearer sk-123") == {
+    "authorization": "bearer sk-123",
+  }
+  assert core.auth_headers("X-Api-Key", "sk-123") == {
+    "X-Api-Key": "sk-123",
+  }
+  assert core.bare_secret("Authorization", "Bearer sk-123") == "sk-123"
+  assert core.bare_secret("X-Api-Key", "Bearer sk-123") == "Bearer sk-123"
+  with pytest.raises(core.ConnectorError, match="reserved"):
+    core.validate_auth_header("MCP-Protocol-Version")
+
+
+@pytest.mark.asyncio
+async def test_rpc_parser_accepts_json_and_multiline_sse_events():
+  response = httpx.Response(
+    200,
+    headers={"content-type": "text/event-stream"},
+    text=(
+      'event: message\ndata: {"jsonrpc":"2.0","method":"ping"}\n\n'
+      'event: message\ndata: {"jsonrpc":"2.0",\n'
+      'data: "id":2,"result":{}}\n\n'
+    ),
+  )
+  assert (await core._matching_rpc(response, 2))["id"] == 2
+  plain = httpx.Response(
+    200,
+    headers={"content-type": "application/json"},
+    json={"jsonrpc": "2.0", "id": 1, "result": {}},
+  )
+  assert (await core._matching_rpc(plain, 1))["id"] == 1
+
+
+class _StopAfterMatchStream(httpx.AsyncByteStream):
+  async def __aiter__(self):
+    yield b'data: {"jsonrpc":"2.0","id":7,"result":{}}\n\n'
+    raise AssertionError("matching SSE response was not consumed incrementally")
+
+
+class _BytesStream(httpx.AsyncByteStream):
+  def __init__(self, *chunks: bytes):
+    self.chunks = chunks
+
+  async def __aiter__(self):
+    for chunk in self.chunks:
+      yield chunk
+
+
+@pytest.mark.asyncio
+async def test_rpc_parser_stops_a_live_sse_stream_after_matching_id():
+  response = httpx.Response(
+    200,
+    headers={"content-type": "text/event-stream"},
+    stream=_StopAfterMatchStream(),
+  )
+  assert (await core._matching_rpc(response, 7))["id"] == 7
+
+
+@pytest.mark.asyncio
+async def test_handshake_negotiates_session_and_paginates_tools(monkeypatch):
+  calls = []
+
+  def handler(request: httpx.Request) -> httpx.Response:
+    calls.append(request)
+    assert request.url.host == "203.0.113.8"
+    assert request.headers["host"] == "mcp.example"
+    if request.method == "DELETE":
+      assert request.headers["mcp-session-id"] == "session-1"
+      return httpx.Response(204, request=request)
+    body = json.loads(request.content)
+    if body["method"] == "server/discover":
+      return httpx.Response(404, request=request)
+    if body["method"] == "initialize":
+      return httpx.Response(
+        200,
+        request=request,
+        headers={
+          "content-type": "application/json",
+          "mcp-session-id": "session-1",
+        },
+        json={
+          "jsonrpc": "2.0",
+          "id": 1,
+          "result": {
+            "protocolVersion": "2025-11-25",
+            "serverInfo": {"name": "Example MCP"},
+            "capabilities": {"tools": {}},
+          },
+        },
+      )
+    assert request.headers["mcp-session-id"] == "session-1"
+    assert request.headers["mcp-protocol-version"] == "2025-11-25"
+    if body["method"] == "notifications/initialized":
+      return httpx.Response(202, request=request)
+    if body["params"].get("cursor") == "next":
+      return httpx.Response(
+        200,
+        request=request,
+        headers={"content-type": "application/json"},
+        json={
+          "jsonrpc": "2.0",
+          "id": 3,
+          "result": {"tools": [{"name": "second"}]},
+        },
+      )
+    return httpx.Response(
+      200,
+      request=request,
+      headers={"content-type": "text/event-stream"},
+      text=(
+        'event: message\n'
+        'data: {"jsonrpc":"2.0","id":2,"result":'
+        '{"tools":[{"name":"first"}],"nextCursor":"next"}}\n\n'
+      ),
+    )
+
+  monkeypatch.setattr(
+    core,
+    "_safe_endpoint",
+    lambda _url: ("https://203.0.113.8/mcp", "mcp.example", "mcp.example"),
+  )
+  real_async_client = httpx.AsyncClient
+  monkeypatch.setattr(
+    core.httpx,
+    "AsyncClient",
+    lambda **kwargs: real_async_client(
+      transport=httpx.MockTransport(handler),
+      timeout=kwargs.get("timeout"),
+      follow_redirects=kwargs.get("follow_redirects", False),
+    ),
+  )
+
+  result = await core.handshake(
+    "https://mcp.example/mcp", "Authorization", "secret-key",
+  )
+  assert result["name"] == "Example MCP"
+  assert [tool["name"] for tool in result["tools"]] == ["first", "second"]
+  assert calls[0].headers["authorization"] == "Bearer secret-key"
+  assert calls[-1].method == "DELETE"
+
+
+@pytest.mark.asyncio
+async def test_handshake_prefers_stateless_2026_discovery(monkeypatch):
+  methods = []
+
+  def handler(request: httpx.Request) -> httpx.Response:
+    body = json.loads(request.content)
+    method = body["method"]
+    methods.append(method)
+    assert request.headers["mcp-protocol-version"] == "2026-07-28"
+    assert request.headers["mcp-method"] == method
+    metadata = body["params"]["_meta"]
+    assert metadata["io.modelcontextprotocol/protocolVersion"] == "2026-07-28"
+    assert metadata["io.modelcontextprotocol/clientCapabilities"] == {}
+    if method == "server/discover":
+      result = {
+        "resultType": "complete",
+        "supportedVersions": ["2026-07-28"],
+        "capabilities": {"tools": {}},
+        "ttlMs": 60000,
+        "cacheScope": "private",
+        "_meta": {
+          "io.modelcontextprotocol/serverInfo": {
+            "name": "Modern MCP",
+            "version": "2.0",
+          },
+        },
+      }
+    else:
+      assert method == "tools/list"
+      result = {
+        "resultType": "complete",
+        "tools": [{"name": "modern_lookup"}],
+        "ttlMs": 60000,
+        "cacheScope": "private",
+      }
+    return httpx.Response(
+      200,
+      request=request,
+      headers={"content-type": "application/json"},
+      json={"jsonrpc": "2.0", "id": body["id"], "result": result},
+    )
+
+  monkeypatch.setattr(
+    core,
+    "_safe_endpoint",
+    lambda _url: ("https://203.0.113.8/mcp", "mcp.example", "mcp.example"),
+  )
+  real_async_client = httpx.AsyncClient
+  monkeypatch.setattr(
+    core.httpx,
+    "AsyncClient",
+    lambda **kwargs: real_async_client(
+      transport=httpx.MockTransport(handler),
+      timeout=kwargs.get("timeout"),
+      follow_redirects=False,
+    ),
+  )
+
+  result = await core.handshake("https://mcp.example/mcp")
+  assert methods == ["server/discover", "tools/list"]
+  assert result["name"] == "Modern MCP"
+  assert result["protocol_version"] == "2026-07-28"
+  assert [tool["name"] for tool in result["tools"]] == ["modern_lookup"]
+
+
+@pytest.mark.asyncio
+async def test_handshake_redacts_secret_echoes_and_rpc_errors(monkeypatch):
+  error_mode = False
+
+  def handler(request: httpx.Request) -> httpx.Response:
+    body = json.loads(request.content)
+    if body["method"] == "server/discover":
+      return httpx.Response(404, request=request)
+    if body["method"] == "initialize":
+      if error_mode:
+        return httpx.Response(
+          200,
+          request=request,
+          headers={"content-type": "application/json"},
+          json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "error": {"message": "credential echo-secret was rejected"},
+          },
+        )
+      return httpx.Response(
+        200,
+        request=request,
+        headers={"content-type": "application/json"},
+        json={
+          "jsonrpc": "2.0",
+          "id": 1,
+          "result": {
+            "protocolVersion": "2025-11-25",
+            "serverInfo": {"name": "echo-secret service"},
+          },
+        },
+      )
+    if body["method"] == "notifications/initialized":
+      return httpx.Response(202, request=request)
+    return httpx.Response(
+      200,
+      request=request,
+      headers={"content-type": "application/json"},
+      json={
+        "jsonrpc": "2.0",
+        "id": body["id"],
+        "result": {
+          "tools": [{
+            "name": "lookup",
+            "description": "Bearer echo-secret",
+            "inputSchema": {
+              "type": "object",
+              "properties": {"echo-secret": {"default": "echo-secret"}},
+            },
+          }],
+        },
+      },
+    )
+
+  monkeypatch.setattr(
+    core,
+    "_safe_endpoint",
+    lambda _url: ("https://203.0.113.8/mcp", "mcp.example", "mcp.example"),
+  )
+  real_async_client = httpx.AsyncClient
+  monkeypatch.setattr(
+    core.httpx,
+    "AsyncClient",
+    lambda **kwargs: real_async_client(
+      transport=httpx.MockTransport(handler),
+      timeout=kwargs.get("timeout"),
+      follow_redirects=False,
+    ),
+  )
+
+  result = await core.handshake(
+    "https://mcp.example/mcp", "Authorization", "echo-secret",
+  )
+  assert "echo-secret" not in json.dumps(result)
+  assert "[redacted]" in json.dumps(result)
+
+  error_mode = True
+  with pytest.raises(core.ConnectorError) as raised:
+    await core.handshake(
+      "https://mcp.example/mcp", "Authorization", "echo-secret",
+    )
+  assert "echo-secret" not in str(raised.value)
+
+
+class _NeverEndingStream(httpx.AsyncByteStream):
+  async def __aiter__(self):
+    while True:
+      await asyncio.sleep(3600)
+      yield b": heartbeat\n\n"
+
+
+@pytest.mark.asyncio
+async def test_handshake_has_one_bounded_deadline_for_live_sse(monkeypatch):
+  def handler(request: httpx.Request) -> httpx.Response:
+    return httpx.Response(
+      200,
+      request=request,
+      headers={"content-type": "text/event-stream"},
+      stream=_NeverEndingStream(),
+    )
+
+  monkeypatch.setattr(
+    core,
+    "_safe_endpoint",
+    lambda _url: ("https://203.0.113.8/mcp", "mcp.example", "mcp.example"),
+  )
+  monkeypatch.setattr(core, "_HANDSHAKE_DEADLINE_SECONDS", 0.02)
+  real_async_client = httpx.AsyncClient
+  monkeypatch.setattr(
+    core.httpx,
+    "AsyncClient",
+    lambda **kwargs: real_async_client(
+      transport=httpx.MockTransport(handler),
+      timeout=kwargs.get("timeout"),
+      follow_redirects=False,
+    ),
+  )
+  with pytest.raises(core.ConnectorError, match="timed out"):
+    await core.handshake("https://mcp.example/mcp")
+  assert core._HANDSHAKE_DEADLINE_SECONDS <= 22
+
+
+@pytest.mark.asyncio
+async def test_handshake_deadline_includes_dns_validation(monkeypatch):
+  def slow_endpoint(_url):
+    time.sleep(0.08)
+    return "https://203.0.113.8/mcp", "mcp.example", "mcp.example"
+
+  monkeypatch.setattr(core, "_safe_endpoint", slow_endpoint)
+  monkeypatch.setattr(core, "_HANDSHAKE_DEADLINE_SECONDS", 0.01)
+  with pytest.raises(core.ConnectorError, match="timed out"):
+    await core.handshake("https://mcp.example/mcp")
+
+
+@pytest.mark.parametrize("url", [
+  "https://example.test:not-a-port/mcp",
+  "https://example.test:99999/mcp",
+  "https://[broken/mcp",
+])
+def test_malformed_endpoint_and_port_are_connector_errors(url):
+  with pytest.raises(core.ConnectorError):
+    core._safe_endpoint(url)
+
+
+def test_secret_roundtrip_and_garbage_are_write_only():
+  token = core.encrypt_secret("sk-value")
+  assert token != "sk-value"
+  assert core.decrypt_secret(token) == "sk-value"
+  with pytest.raises(core.ConnectorError):
+    core.decrypt_secret("not-a-fernet-token")
+
+
+def test_broker_capability_expires_and_is_connector_scoped():
+  assert core._BROKER_CAPABILITY_TTL_SECONDS <= 24 * 60 * 60
+  capability = core.mint_broker_capability(41)
+  core.verify_broker_capability(capability, 41)
+  with pytest.raises(core.ConnectorError, match="not valid for"):
+    core.verify_broker_capability(capability, 42)
+
+  expired = core._broker_fernet().encrypt_at_time(
+    b'{"connector_id":41}', current_time=0,
+  ).decode()
+  with pytest.raises(core.ConnectorError, match="not valid"):
+    core.verify_broker_capability(expired, 41)
+
+
+class _FakeQuery:
+  def __init__(self, rows):
+    self.rows = rows
+
+  def filter(self, *_args, **_kwargs):
+    return self
+
+  def order_by(self, *_args, **_kwargs):
+    return self
+
+  def all(self):
+    return self.rows
+
+
+class _FakeDb:
+  def __init__(self, rows):
+    self.rows = rows
+
+  def query(self, _model):
+    return _FakeQuery(self.rows)
+
+
+def _row(row_id, slug, url, auth_header=None, secret=None):
+  return models.Connector(
+    id=row_id,
+    slug=slug,
+    name=slug,
+    url=url,
+    enabled=True,
+    auth_header=auth_header,
+    auth_value_encrypted=core.encrypt_secret(secret) if secret else None,
+    tools_json=[],
+    est_tokens=0,
+    status="ok",
+  )
+
+
+def test_turn_plan_serves_both_providers_without_config_secrets():
+  plan = core.build_turn_plan(_FakeDb([
+    _row(4, "docs", "https://docs.example/mcp"),
+    _row(9, "search", "https://search.example/mcp", "Authorization", "sk-9"),
+    _row(12, "data", "https://data.example/mcp", "X-Api-Key", "key-12"),
+  ]))
+
+  expected_keys = {
+    "mobius_connector_4_docs",
+    "mobius_connector_9_search",
+    "mobius_connector_12_data",
+  }
+  assert set(plan.claude_servers) == expected_keys
+  servers = plan.codex_config["mcp_servers"]
+  assert set(servers) == expected_keys
+  for key in expected_keys:
+    connector_id = int(key.split("_")[2])
+    claude = plan.claude_servers[key]
+    codex = servers[key]
+    expected_url = f"http://127.0.0.1:9/api/connectors/{connector_id}/broker"
+    assert claude["url"] == expected_url
+    assert codex["url"] == expected_url
+    assert "example" not in claude["url"]
+    capability = claude["headers"]["Authorization"].removeprefix("Bearer ")
+    core.verify_broker_capability(capability, connector_id)
+    env_var = codex["bearer_token_env_var"]
+    assert plan.codex_env[env_var] == capability
+  assert "sk-9" not in repr(plan)
+  assert "sk-9" not in repr(plan.codex_config)
+  assert "key-12" not in repr(plan.codex_config)
+
+
+def test_claude_config_is_anonymous_and_disappears_after_startup_window():
+  plan = core.ConnectorTurnPlan(
+    claude_servers={
+      "search": {
+        "type": "http",
+        "url": "https://search.example/mcp",
+        "headers": {"Authorization": "Bearer secret-in-file"},
+      },
+    },
+  )
+  with core.claude_mcp_config_path(plan) as path:
+    assert path.startswith(f"/proc/{os.getpid()}/fd/")
+    assert "secret-in-file" not in path
+    with open(path, encoding="utf-8") as config_file:
+      payload = json.load(config_file)
+    assert payload["mcpServers"]["search"]["headers"]["Authorization"] == (
+      "Bearer secret-in-file"
+    )
+  assert not os.path.exists(path)
+
+
+def test_connector_routes_keep_keys_out_of_responses(
+  client, auth, db, monkeypatch,
+):
+  probe = {
+    "name": "Example MCP",
+    "tools": [{"name": "lookup", "description": "Look up a record."}],
+    "est_tokens": 42,
+    "protocol_version": "2025-11-25",
+  }
+  probe_pool_counts = []
+
+  async def probe_without_db_lease(*_args, **_kwargs):
+    probe_pool_counts.append(checked_out_connections())
+    return probe
+
+  handshake = AsyncMock(side_effect=probe_without_db_lease)
+  monkeypatch.setattr("app.routes.connectors.core.handshake", handshake)
+
+  add_baseline = checked_out_connections()
+  created = client.post("/api/connectors", headers=auth, json={
+    "url": "https://mcp.example/mcp",
+    "auth_value": "top-secret",
+  })
+  assert created.status_code == 201, created.text
+  body = created.json()
+  assert body["name"] == "Example MCP"
+  assert body["has_auth"] is True
+  assert body["providers"] == ["claude", "codex"]
+  assert "top-secret" not in created.text
+  assert probe_pool_counts == [add_baseline]
+
+  stored = db.query(models.Connector).one()
+  assert stored.auth_value_encrypted != "top-secret"
+  assert core.decrypt_secret(stored.auth_value_encrypted) == "top-secret"
+
+  listed = client.get("/api/connectors", headers=auth)
+  assert listed.status_code == 200
+  assert "top-secret" not in listed.text
+
+  toggled = client.patch(
+    f"/api/connectors/{stored.id}", headers=auth, json={"enabled": False},
+  )
+  assert toggled.status_code == 200
+  assert toggled.json()["enabled"] is False
+
+  # The direct assertion session above owns its own checkout; release it so
+  # the refresh probe can prove the request-owned lease is gone independently.
+  db.close()
+  refresh_baseline = checked_out_connections()
+  refreshed = client.post(
+    f"/api/connectors/{stored.id}/refresh", headers=auth,
+  )
+  assert refreshed.status_code == 200
+  assert handshake.await_count == 2
+  assert probe_pool_counts[-1] == refresh_baseline
+
+
+def test_broker_requires_loopback_and_connector_scoped_capability(
+  client, db,
+):
+  row = _row(
+    21, "private", "https://private.example/mcp",
+    "Authorization", "upstream-secret",
+  )
+  db.add(row)
+  db.commit()
+  capability = core.mint_broker_capability(row.id)
+
+  denied = client.get(
+    f"/api/connectors/{row.id}/broker",
+    headers={"Authorization": f"Bearer {capability}"},
+  )
+  assert denied.status_code == 403
+
+  with TestClient(client.app, client=("127.0.0.1", 43100)) as loopback:
+    missing = loopback.get(f"/api/connectors/{row.id}/broker")
+    assert missing.status_code == 401
+    wrong_scope = loopback.get(
+      f"/api/connectors/{row.id}/broker",
+      headers={
+        "Authorization": f"Bearer {core.mint_broker_capability(row.id + 1)}",
+      },
+    )
+    assert wrong_scope.status_code == 401
+
+
+def test_broker_revalidates_pins_and_streams_each_mcp_method(
+  client, db, monkeypatch,
+):
+  row = _row(
+    22, "remote", "https://remote.example/mcp",
+    "X-Api-Key", "upstream-secret",
+  )
+  db.add(row)
+  db.commit()
+  capability = core.mint_broker_capability(row.id)
+  validated = []
+  upstream_calls = []
+
+  def safe_endpoint(url):
+    validated.append(url)
+    return "https://203.0.113.9/mcp", "remote.example", "remote.example"
+
+  def handler(request: httpx.Request) -> httpx.Response:
+    upstream_calls.append(request)
+    assert request.url.host == "203.0.113.9"
+    assert request.headers["host"] == "remote.example"
+    assert request.headers["x-api-key"] == "upstream-secret"
+    assert "Bearer " not in request.headers.get("authorization", "")
+    assert request.headers["mcp-protocol-version"] == "2025-11-25"
+    assert request.headers["mcp-method"] == "tools/list"
+    assert request.headers["mcp-name"] == "lookup"
+    assert request.headers["mcp-param-region"] == "us-west1"
+    return httpx.Response(
+      200,
+      request=request,
+      headers={
+        "content-type": "text/event-stream",
+        "mcp-session-id": "session-22",
+        "content-encoding": "identity",
+        "content-length": "999",
+        "x-untrusted": "not-forwarded",
+      },
+      stream=_BytesStream(
+        b"data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"echo\":\"upstream-",
+        b"secret\"}}\n\n",
+      ),
+    )
+
+  monkeypatch.setattr(core, "_safe_endpoint", safe_endpoint)
+  real_async_client = httpx.AsyncClient
+  monkeypatch.setattr(
+    connector_routes.httpx,
+    "AsyncClient",
+    lambda **kwargs: real_async_client(
+      transport=httpx.MockTransport(handler),
+      timeout=kwargs.get("timeout"),
+      follow_redirects=False,
+    ),
+  )
+  headers = {
+    "Authorization": f"Bearer {capability}",
+    "MCP-Protocol-Version": "2025-11-25",
+    "Mcp-Method": "tools/list",
+    "Mcp-Name": "lookup",
+    "Mcp-Param-Region": "us-west1",
+    "Content-Type": "application/json",
+  }
+  with TestClient(client.app, client=("127.0.0.1", 43100)) as loopback:
+    responses = [
+      loopback.get(f"/api/connectors/{row.id}/broker", headers=headers),
+      loopback.post(
+        f"/api/connectors/{row.id}/broker",
+        headers=headers,
+        content=b'{"jsonrpc":"2.0","id":1,"method":"tools/list"}',
+      ),
+      loopback.delete(f"/api/connectors/{row.id}/broker", headers=headers),
+    ]
+
+  assert [response.status_code for response in responses] == [200, 200, 200]
+  assert [request.method for request in upstream_calls] == ["GET", "POST", "DELETE"]
+  assert upstream_calls[1].content == (
+    b'{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+  )
+  assert validated == [row.url, row.url, row.url]
+  assert all(response.headers["mcp-session-id"] == "session-22" for response in responses)
+  assert all("x-untrusted" not in response.headers for response in responses)
+  assert all("content-encoding" not in response.headers for response in responses)
+  assert all("upstream-secret" not in response.text for response in responses)
+  assert all("[redacted]" in response.text for response in responses)
+
+
+def test_broker_refuses_redirects_and_releases_upstream(
+  client, db, monkeypatch,
+):
+  row = _row(23, "redirect", "https://remote.example/mcp")
+  db.add(row)
+  db.commit()
+  capability = core.mint_broker_capability(row.id)
+  monkeypatch.setattr(
+    core,
+    "_safe_endpoint",
+    lambda _url: ("https://203.0.113.9/mcp", "remote.example", "remote.example"),
+  )
+  real_async_client = httpx.AsyncClient
+  monkeypatch.setattr(
+    connector_routes.httpx,
+    "AsyncClient",
+    lambda **kwargs: real_async_client(
+      transport=httpx.MockTransport(lambda request: httpx.Response(
+        307,
+        request=request,
+        headers={"location": "https://elsewhere.example/mcp"},
+      )),
+      timeout=kwargs.get("timeout"),
+      follow_redirects=False,
+    ),
+  )
+  with TestClient(client.app, client=("127.0.0.1", 43100)) as loopback:
+    response = loopback.get(
+      f"/api/connectors/{row.id}/broker",
+      headers={"Authorization": f"Bearer {capability}"},
+    )
+  assert response.status_code == 502
+  assert "elsewhere" not in response.text

--- a/backend/tests/test_connectors.py
+++ b/backend/tests/test_connectors.py
@@ -229,6 +229,41 @@ async def test_handshake_prefers_stateless_2026_discovery(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_modern_probe_distinguishes_protocol_errors_from_legacy_fallback():
+  endpoint = ("https://203.0.113.8/mcp", "mcp.example", "mcp.example")
+
+  async def probe(error, status=400):
+    def handler(request: httpx.Request) -> httpx.Response:
+      return httpx.Response(
+        status,
+        request=request,
+        headers={"content-type": "application/json"},
+        json={"jsonrpc": "2.0", "id": 1, "error": error},
+      )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+      return await core._modern_rpc(
+        client, endpoint, {}, "server/discover", {}, 1,
+        allow_unsupported=True,
+      )
+
+  assert await probe({
+    "code": -32022,
+    "message": "unsupported",
+    "data": {"supported": ["2025-11-25"]},
+  }) is None
+  assert await probe({"code": -32601, "message": "unknown"}, 404) is None
+  with pytest.raises(core.ConnectorError, match="rejected"):
+    await probe({"code": -32020, "message": "header mismatch"})
+  with pytest.raises(core.ConnectorError, match="rejected"):
+    await probe({
+      "code": -32022,
+      "message": "unsupported",
+      "data": {"supported": ["2027-01-01"]},
+    })
+
+
+@pytest.mark.asyncio
 async def test_handshake_redacts_secret_echoes_and_rpc_errors(monkeypatch):
   error_mode = False
 
@@ -383,16 +418,21 @@ def test_secret_roundtrip_and_garbage_are_write_only():
 
 def test_broker_capability_expires_and_is_connector_scoped():
   assert core._BROKER_CAPABILITY_TTL_SECONDS <= 24 * 60 * 60
-  capability = core.mint_broker_capability(41)
-  core.verify_broker_capability(capability, 41)
+  stable_a = "a" * 64
+  stable_b = "b" * 64
+  capability = core.mint_broker_capability(41, stable_a)
+  core.verify_broker_capability(capability, 41, stable_a)
   with pytest.raises(core.ConnectorError, match="not valid for"):
-    core.verify_broker_capability(capability, 42)
+    core.verify_broker_capability(capability, 42, stable_a)
+  with pytest.raises(core.ConnectorError, match="not valid for"):
+    core.verify_broker_capability(capability, 41, stable_b)
 
   expired = core._broker_fernet().encrypt_at_time(
-    b'{"connector_id":41}', current_time=0,
+    json.dumps({"connector_id": 41, "capability_id": stable_a}).encode(),
+    current_time=0,
   ).decode()
   with pytest.raises(core.ConnectorError, match="not valid"):
-    core.verify_broker_capability(expired, 41)
+    core.verify_broker_capability(expired, 41, stable_a)
 
 
 class _FakeQuery:
@@ -420,6 +460,7 @@ class _FakeDb:
 def _row(row_id, slug, url, auth_header=None, secret=None):
   return models.Connector(
     id=row_id,
+    capability_id=(f"stable-{row_id}-{slug}-" + "x" * 64)[:64],
     slug=slug,
     name=slug,
     url=url,
@@ -433,11 +474,12 @@ def _row(row_id, slug, url, auth_header=None, secret=None):
 
 
 def test_turn_plan_serves_both_providers_without_config_secrets():
-  plan = core.build_turn_plan(_FakeDb([
+  plan_source_rows = [
     _row(4, "docs", "https://docs.example/mcp"),
     _row(9, "search", "https://search.example/mcp", "Authorization", "sk-9"),
     _row(12, "data", "https://data.example/mcp", "X-Api-Key", "key-12"),
-  ]))
+  ]
+  plan = core.build_turn_plan(_FakeDb(plan_source_rows))
 
   expected_keys = {
     "mobius_connector_4_docs",
@@ -456,7 +498,8 @@ def test_turn_plan_serves_both_providers_without_config_secrets():
     assert codex["url"] == expected_url
     assert "example" not in claude["url"]
     capability = claude["headers"]["Authorization"].removeprefix("Bearer ")
-    core.verify_broker_capability(capability, connector_id)
+    row = next(row for row in plan_source_rows if row.id == connector_id)
+    core.verify_broker_capability(capability, connector_id, row.capability_id)
     env_var = codex["bearer_token_env_var"]
     assert plan.codex_env[env_var] == capability
   assert "sk-9" not in repr(plan)
@@ -551,7 +594,7 @@ def test_broker_requires_loopback_and_connector_scoped_capability(
   )
   db.add(row)
   db.commit()
-  capability = core.mint_broker_capability(row.id)
+  capability = core.mint_broker_capability(row.id, row.capability_id)
 
   denied = client.get(
     f"/api/connectors/{row.id}/broker",
@@ -565,10 +608,58 @@ def test_broker_requires_loopback_and_connector_scoped_capability(
     wrong_scope = loopback.get(
       f"/api/connectors/{row.id}/broker",
       headers={
-        "Authorization": f"Bearer {core.mint_broker_capability(row.id + 1)}",
+        "Authorization": f"Bearer {core.mint_broker_capability(row.id + 1, row.capability_id)}",
       },
     )
     assert wrong_scope.status_code == 401
+    row.enabled = False
+    db.commit()
+    disabled = loopback.get(
+      f"/api/connectors/{row.id}/broker",
+      headers={"Authorization": f"Bearer {capability}"},
+    )
+    assert disabled.status_code == 404
+
+
+def test_deleted_connector_capability_cannot_authorize_reused_row_id(client, db):
+  old = _row(31, "old", "https://old.example/mcp", secret="old-secret")
+  db.add(old)
+  db.commit()
+  old_identity = old.capability_id
+  old_capability = core.mint_broker_capability(old.id, old_identity)
+  db.delete(old)
+  db.commit()
+
+  replacement = _row(
+    31, "replacement", "https://new.example/mcp", secret="new-secret",
+  )
+  db.add(replacement)
+  db.commit()
+  assert replacement.capability_id != old_identity
+
+  with TestClient(client.app, client=("127.0.0.1", 43100)) as loopback:
+    denied = loopback.get(
+      f"/api/connectors/{replacement.id}/broker",
+      headers={"Authorization": f"Bearer {old_capability}"},
+    )
+  assert denied.status_code == 401
+
+
+def test_broker_drops_allowed_response_headers_that_reflect_secrets():
+  snapshot = connector_routes._BrokerSnapshot(
+    url="https://remote.example/mcp",
+    auth_header="Authorization",
+    secret="Bearer upstream-secret",
+  )
+  upstream = httpx.Response(200, headers={
+    "content-type": "application/json",
+    "mcp-protocol-version": "upstream-secret",
+    "mcp-session-id": "Bearer upstream-secret",
+    "cache-control": "private, upstream-secret",
+    "x-untrusted": "ignored",
+  })
+  headers = connector_routes._broker_response_headers(upstream, snapshot)
+  assert headers == {"content-type": "application/json"}
 
 
 def test_broker_revalidates_pins_and_streams_each_mcp_method(
@@ -580,7 +671,7 @@ def test_broker_revalidates_pins_and_streams_each_mcp_method(
   )
   db.add(row)
   db.commit()
-  capability = core.mint_broker_capability(row.id)
+  capability = core.mint_broker_capability(row.id, row.capability_id)
   validated = []
   upstream_calls = []
 
@@ -663,7 +754,7 @@ def test_broker_refuses_redirects_and_releases_upstream(
   row = _row(23, "redirect", "https://remote.example/mcp")
   db.add(row)
   db.commit()
-  capability = core.mint_broker_capability(row.id)
+  capability = core.mint_broker_capability(row.id, row.capability_id)
   monkeypatch.setattr(
     core,
     "_safe_endpoint",

--- a/backend/tests/test_db_migrations.py
+++ b/backend/tests/test_db_migrations.py
@@ -1008,6 +1008,7 @@ def test_run_migrations_records_an_inspectable_append_only_history(tmp_path):
     "0003_chat_run_root_identity",
     "0004_app_identity_required",
     "0005_connectors",
+    "0006_connector_capability_identity",
   ]
   assert second == first
 
@@ -1029,6 +1030,16 @@ def test_connectors_migration_preserves_preview_era_rows(tmp_path):
       "est_tokens INTEGER NOT NULL DEFAULT 0, status VARCHAR(16) NOT NULL, "
       "status_detail TEXT, created_at DATETIME, last_checked_at DATETIME)"
     ))
+    # Simulate a preview checkout that already recorded the original table
+    # migration before immutable broker identities were added in 0006.
+    conn.execute(text(
+      "CREATE TABLE schema_migrations ("
+      "version VARCHAR(128) PRIMARY KEY, applied_at TIMESTAMP NOT NULL)"
+    ))
+    conn.execute(text(
+      "INSERT INTO schema_migrations (version, applied_at) "
+      "VALUES ('0005_connectors', '2026-08-03 00:00:00')"
+    ))
     conn.execute(text(
       "INSERT INTO connectors ("
       "id, slug, name, url, auth_header, auth_value_encrypted, enabled, "
@@ -1042,12 +1053,17 @@ def test_connectors_migration_preserves_preview_era_rows(tmp_path):
 
   with eng.connect() as conn:
     row = conn.execute(text(
-      "SELECT slug, url, auth_value_encrypted FROM connectors WHERE id = 7"
+      "SELECT slug, url, auth_value_encrypted, capability_id "
+      "FROM connectors WHERE id = 7"
     )).one()
-  assert tuple(row) == (
+  assert tuple(row[:3]) == (
     "preview", "https://mcp.example/mcp", "encrypted-preview-key",
   )
+  assert isinstance(row.capability_id, str) and len(row.capability_id) == 64
   assert "0005_connectors" in {
+    entry["version"] for entry in schema_migration_history(eng)
+  }
+  assert "0006_connector_capability_identity" in {
     entry["version"] for entry in schema_migration_history(eng)
   }
 

--- a/backend/tests/test_db_migrations.py
+++ b/backend/tests/test_db_migrations.py
@@ -1007,8 +1007,49 @@ def test_run_migrations_records_an_inspectable_append_only_history(tmp_path):
     "0002_chat_run_goal_objective",
     "0003_chat_run_root_identity",
     "0004_app_identity_required",
+    "0005_connectors",
   ]
   assert second == first
+
+
+def test_connectors_migration_preserves_preview_era_rows(tmp_path):
+  eng = create_engine(f"sqlite:///{tmp_path / 'preview-connectors.db'}")
+  with eng.begin() as conn:
+    conn.execute(text(
+      "CREATE TABLE apps ("
+      "id INTEGER PRIMARY KEY, name VARCHAR(255), slug VARCHAR(128), "
+      "source_dir VARCHAR(512))"
+    ))
+    conn.execute(text(
+      "CREATE TABLE connectors ("
+      "id INTEGER PRIMARY KEY, slug VARCHAR(64) NOT NULL UNIQUE, "
+      "name VARCHAR(128) NOT NULL, url VARCHAR(2048) NOT NULL, "
+      "auth_header VARCHAR(64), auth_value_encrypted TEXT, "
+      "enabled BOOLEAN NOT NULL DEFAULT TRUE, tools_json JSON NOT NULL, "
+      "est_tokens INTEGER NOT NULL DEFAULT 0, status VARCHAR(16) NOT NULL, "
+      "status_detail TEXT, created_at DATETIME, last_checked_at DATETIME)"
+    ))
+    conn.execute(text(
+      "INSERT INTO connectors ("
+      "id, slug, name, url, auth_header, auth_value_encrypted, enabled, "
+      "tools_json, est_tokens, status) VALUES ("
+      "7, 'preview', 'Preview', 'https://mcp.example/mcp', "
+      "'Authorization', 'encrypted-preview-key', TRUE, '[]', 0, 'ok')"
+    ))
+
+  run_migrations(eng)
+  run_migrations(eng)
+
+  with eng.connect() as conn:
+    row = conn.execute(text(
+      "SELECT slug, url, auth_value_encrypted FROM connectors WHERE id = 7"
+    )).one()
+  assert tuple(row) == (
+    "preview", "https://mcp.example/mcp", "encrypted-preview-key",
+  )
+  assert "0005_connectors" in {
+    entry["version"] for entry in schema_migration_history(eng)
+  }
 
 
 def test_chat_run_root_migration_backfills_existing_physical_runs(tmp_path):

--- a/backend/tests/test_proxy.py
+++ b/backend/tests/test_proxy.py
@@ -462,6 +462,19 @@ def test_validate_url_rejects_if_any_ip_is_private():
     assert exc_info.value.status_code == 400
 
 
+@pytest.mark.parametrize("address", [
+  "198.18.0.1",  # benchmarking; commonly routed inside test networks
+  "192.0.0.8",   # IETF special-purpose space
+  "224.0.0.1",   # multicast
+  "240.0.0.1",   # reserved
+])
+def test_validate_url_rejects_every_non_global_address(address):
+  fake = _fake_getaddrinfo([(2, 1, 6, "", (address, 443))])
+  with patch("app.net_utils.socket.getaddrinfo", side_effect=fake):
+    with pytest.raises(HTTPException, match="non-public"):
+      validate_url_safe("https://internal.example/mcp")
+
+
 def test_validate_url_ipv6_brackets():
   """IPv6 validated IPs are wrapped in brackets in the pinned URL."""
   fake = _fake_getaddrinfo([


### PR DESCRIPTION
## Summary

- add an owner-managed remote MCP registry with encrypted write-only credentials
- validate and pin globally routable HTTPS endpoints, then expose a loopback-only capability broker so provider processes never receive upstream secrets
- probe both the current stateless MCP 2026-07-28 transport and deployed 2025 Streamable HTTP servers without misclassifying modern protocol errors as legacy fallback
- bind short-lived capabilities to immutable connector identities and redact reflected secrets from response bodies and allowed headers
- bound catalogs, streams, deadlines, capability lifetime, and creation races
- add append-only migrations `0005_connectors` and `0006_connector_capability_identity`; the latter safely backfills preview or early-branch rows without replacing the original migration

## Review notes

This is the provider-neutral backend foundation only. Provider injection and Settings UI follow as separate stacked PRs. Broker capabilities are connector-scoped, capped at 24 hours, and immediately lose usefulness when a connector is disabled, deleted, or replaced because every request re-reads the enabled row and immutable identity.

The 2026 transport update follows the official MCP 2026-07-28 specification and preserves explicit fallback to 2025-11-25/2025-06-18/2025-03-26 servers.

## Validation

- focused connector and migration suite: 82 passed
- widened auth, secrets, install, proxy, and migration suite: 293 passed
- compile, diff, and pre-push gates passed

Full hosted backend/E2E CI and an independent exact-head audit are required before merge.