### PR TITLE
Add exact chat transcript search and reveal

### DIFF
--- a/backend/app/chat_retention.py
+++ b/backend/app/chat_retention.py
@@ -63,6 +63,12 @@ def purge_expired_chat_tombstones(db: Session) -> list[str]:
     db.query(model).filter(
       model.chat_id.in_(expired_chat_ids),
     ).delete(synchronize_session=False)
+  # Search rows are derived transcript data without a foreign key because the
+  # SQLite FTS trigger owns their lifecycle. Remove them in the same durable
+  # transaction as the source row rather than retaining a hard-deleted chat's
+  # prose until a future search happens to reconcile the index.
+  from app.chat_search import purge_chat_docs
+  purge_chat_docs(db, chat_ids)
   db.query(models.Chat).filter(
     models.Chat.id.in_(expired_chat_ids),
   ).delete(synchronize_session=False)

--- a/backend/app/chat_search.py
+++ b/backend/app/chat_search.py
@@ -1,7 +1,9 @@
 """Full-text search over chat transcripts (drawer search).
 
-Design: an SQLite FTS5 index over conversation prose — the owner's messages,
-the assistant's replies, and chat titles. Tool output, thinking traces, and
+Design: SQLite uses an FTS5 index over conversation prose — the owner's
+messages, the assistant's replies, and chat titles. PostgreSQL and other
+dialects use the same visibility and matching contract through a portable
+candidate query plus bounded Python ranking. Tool output, thinking traces, and
 `blocks` machinery are deliberately excluded: they live in their own tables,
 they are the bulk of the bytes, and they are noise for "where did we talk
 about X".
@@ -13,37 +15,57 @@ The index is DERIVED data, reconciled lazily at query time:
   external-content FTS5 table over it, kept in sync by triggers on the docs
   table itself (the canonical FTS5 external-content pattern — the triggers
   watch OUR derived table, never `chats`).
-- `chat_search_state` remembers, per chat, how many messages are indexed and
-  the exact `chats.updated_at` text at index time. A search request first
-  reconciles: any live chat whose `updated_at` no longer equals the remembered
-  text gets its NEW messages appended (or a per-chat rebuild when history
-  shrank or the title changed); index rows for deleted/purged chats are
-  dropped. Chats whose timestamp moved without new content (run markers,
-  streaming) cost one state-row update, not a re-tokenize.
+- `chat_search_state` remembers the exact `chats.updated_at` text indexed for
+  each chat. A search request first reconciles any live chat whose row changed
+  against its current transcript, while deleted/purged chats are dropped. The
+  comparison is exact because assistant snapshots and owner replacements can
+  rewrite an existing message without changing the list length; stable derived
+  rows keep their identities so FTS re-tokenizes only changed prose.
+- Only chats that belong in the owner's drawer are indexed, and hidden
+  transcript messages are omitted. A small derived-schema version makes those
+  indexing semantics migratable: changing them drops and regenerates only the
+  disposable search tables, never the source chat rows.
 
-Because reconciliation happens inside the search request there is no second
-code path that could forget to update the index, nothing hooks into the turn
-lifecycle, and a missing index (or this feature landing on an existing
-instance) simply rebuilds itself on first use. Memory: FTS5 reads b-tree
-pages from disk per query; nothing is cached in process memory. Only changed
-chats ever have their `messages` JSON hydrated — reconcile compares
-timestamps, not transcripts.
+For SQLite, reconciliation happens inside the search request, so there is no
+second code path that could forget to update the index, nothing hooks into the
+turn lifecycle, and a missing index (or this feature landing on an existing
+instance) simply rebuilds itself on first use. Memory: FTS5 reads b-tree pages
+from disk per query; nothing is cached in process memory. Only changed chats
+ever have their `messages` JSON hydrated — reconcile compares timestamps, not
+transcripts.
 
-Writes here touch only the three `chat_search_*` tables — never
+Writes here touch only the derived `chat_search_*` tables — never
 `Chat.messages` / `Chat.pending_messages` (those stay behind `chat_writer.py`).
 """
 
+import json
 import re
+import threading
 
-from sqlalchemy import text as sql
+from sqlalchemy import Text, cast, func, or_, text as sql
 from sqlalchemy.orm import Session
 
 from app import models
+from app.chat_visibility import visible_in_owner_drawer
 
 # Private-use sentinels around FTS5 snippet matches. The API converts them to
 # a JSON-friendly form; they can never collide with real transcript text.
 _MARK_OPEN = "\ue000"
 _MARK_CLOSE = "\ue001"
+
+# The version covers both table shape and indexing semantics. Search data is
+# entirely derived, so a mismatch is safer and simpler to handle by rebuilding
+# than by carrying migrations for disposable rows.
+_INDEX_VERSION = "2"
+_SCHEMA_LOCK = threading.Lock()
+_RECONCILE_LOCK = threading.Lock()
+
+# The portable backend has no derived full-text index. Keep its fallback
+# honest and bounded: rank matches only within the most recently active chats
+# whose serialized source contains every query token. This avoids turning one
+# broad drawer query into an unbounded transcript hydration. SQLite retains
+# complete-history semantics through its on-disk FTS index.
+_PORTABLE_CANDIDATE_LIMIT = 512
 
 # Message roles whose `content` strings are conversation prose.
 _PROSE_ROLES = ("user", "assistant")
@@ -59,6 +81,8 @@ CREATE TABLE IF NOT EXISTS chat_search_docs (
 );
 CREATE INDEX IF NOT EXISTS chat_search_docs_chat
   ON chat_search_docs(chat_id);
+CREATE UNIQUE INDEX IF NOT EXISTS chat_search_docs_chat_message
+  ON chat_search_docs(chat_id, msg_idx);
 CREATE VIRTUAL TABLE IF NOT EXISTS chat_search_fts USING fts5(
   text,
   content='chat_search_docs',
@@ -76,9 +100,11 @@ CREATE TRIGGER IF NOT EXISTS chat_search_docs_ad
   END;
 CREATE TABLE IF NOT EXISTS chat_search_state (
   chat_id TEXT PRIMARY KEY,
-  indexed_count INTEGER NOT NULL,
-  indexed_title TEXT NOT NULL,
   indexed_updated_at TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS chat_search_meta (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
 );
 """
 
@@ -89,32 +115,65 @@ def _ensure_schema(db: Session) -> None:
   global _schema_ready
   if _schema_ready:
     return
-  # A pre-reveal index has a `chat_search_docs` without the `ts`/`role`
-  # columns. This is DERIVED data that rebuilds itself, so drop the stale
-  # search tables and recreate at the current schema rather than ALTER-dancing;
-  # the reconcile in the same search request repopulates from `chats`. Dropping
-  # the external-content FTS virtual table also removes its shadow tables, and
-  # dropping the docs table removes the sync triggers defined on it.
-  existing = db.execute(
-    sql(
-      "SELECT 1 FROM sqlite_master"
-      " WHERE type = 'table' AND name = 'chat_search_docs'"
+  with _SCHEMA_LOCK:
+    if _schema_ready:
+      return
+    expected_tables = {
+      "chat_search_docs",
+      "chat_search_fts",
+      "chat_search_state",
+      "chat_search_meta",
+    }
+    present_tables = {
+      row[0]
+      for row in db.execute(sql(
+        "SELECT name FROM sqlite_master WHERE type = 'table'"
+        " AND name IN ('chat_search_docs', 'chat_search_fts',"
+        "              'chat_search_state', 'chat_search_meta')"
+      )).fetchall()
+    }
+    version = None
+    if "chat_search_meta" in present_tables:
+      row = db.execute(sql(
+        "SELECT value FROM chat_search_meta WHERE key = 'index_version'"
+      )).fetchone()
+      version = row[0] if row else None
+    columns = (
+      {
+        row[1]
+        for row in db.execute(sql("PRAGMA table_info(chat_search_docs)"))
+      }
+      if "chat_search_docs" in present_tables
+      else set()
     )
-  ).fetchone()
-  if existing is not None:
-    columns = [row[1] for row in db.execute(sql("PRAGMA table_info(chat_search_docs)"))]
-    if "ts" not in columns:
+    schema_current = (
+      present_tables == expected_tables
+      and version == _INDEX_VERSION
+      and {"id", "chat_id", "msg_idx", "ts", "role", "text"} <= columns
+    )
+    if not schema_current:
+      # Dropping the external-content virtual table removes its shadow tables;
+      # dropping docs removes its sync triggers. A single transaction ensures a
+      # concurrent search sees either the old generation or the new empty one.
       for statement in (
         "DROP TABLE IF EXISTS chat_search_fts",
         "DROP TABLE IF EXISTS chat_search_docs",
         "DROP TABLE IF EXISTS chat_search_state",
+        "DROP TABLE IF EXISTS chat_search_meta",
       ):
         db.execute(sql(statement))
-      db.commit()
-  for statement in _split_schema(_SCHEMA):
-    db.execute(sql(statement))
-  db.commit()
-  _schema_ready = True
+    for statement in _split_schema(_SCHEMA):
+      db.execute(sql(statement))
+    db.execute(
+      sql(
+        "INSERT INTO chat_search_meta (key, value)"
+        " VALUES ('index_version', :version)"
+        " ON CONFLICT(key) DO UPDATE SET value = excluded.value"
+      ),
+      {"version": _INDEX_VERSION},
+    )
+    db.commit()
+    _schema_ready = True
 
 
 def _split_schema(schema: str) -> list[str]:
@@ -148,6 +207,12 @@ def _prose_docs(title: str, messages: list) -> list[tuple[int, object, object, s
   for idx, message in enumerate(messages):
     if not isinstance(message, dict):
       continue
+    # Hidden rows carry internal reminders and silent question answers. They
+    # are deliberately absent from the transcript, so returning their text in
+    # drawer snippets would both disclose UI-private content and produce an
+    # anchor that can never render.
+    if message.get("hidden"):
+      continue
     role = message.get("role")
     if role not in _PROSE_ROLES:
       continue
@@ -156,6 +221,9 @@ def _prose_docs(title: str, messages: list) -> list[tuple[int, object, object, s
       ts = message.get("ts")
       docs.append((idx, ts if isinstance(ts, int) else None, role, content))
   return docs
+
+
+_visible_in_owner_drawer = visible_in_owner_drawer
 
 
 def _delete_chat_docs(db: Session, chat_id: str) -> None:
@@ -168,18 +236,99 @@ def _delete_chat_docs(db: Session, chat_id: str) -> None:
 
 
 def _write_docs(db: Session, chat_id: str, docs: list[tuple[int, object, object, str]]) -> None:
-  for msg_idx, ts, role, doc_text in docs:
-    db.execute(
+  if not docs:
+    return
+  db.execute(
+    sql(
+      "INSERT INTO chat_search_docs (chat_id, msg_idx, ts, role, text)"
+      " VALUES (:cid, :idx, :ts, :role, :txt)"
+    ),
+    [
+      {"cid": chat_id, "idx": idx, "ts": ts, "role": role, "txt": text}
+      for idx, ts, role, text in docs
+    ],
+  )
+
+
+def _sync_docs(
+  db: Session,
+  chat_id: str,
+  docs: list[tuple[int, object, object, str]],
+) -> None:
+  """Make one chat's derived rows exact without re-tokenizing stable prose.
+
+  A changed chat still has to deserialize and scan its transcript: only the
+  source transcript can prove an equal-length replacement did not occur. But
+  most updates append one message or replace the trailing assistant snapshot.
+  Comparing exact derived rows lets FTS delete/insert only those changed rows
+  rather than rebuilding and re-tokenizing the full history.
+  """
+  existing = {
+    msg_idx: (row_id, ts, role, doc_text)
+    for row_id, msg_idx, ts, role, doc_text in db.execute(
       sql(
-        "INSERT INTO chat_search_docs (chat_id, msg_idx, ts, role, text)"
-        " VALUES (:cid, :idx, :ts, :role, :txt)"
+        "SELECT id, msg_idx, ts, role, text FROM chat_search_docs"
+        " WHERE chat_id = :cid"
       ),
-      {"cid": chat_id, "idx": msg_idx, "ts": ts, "role": role, "txt": doc_text},
+      {"cid": chat_id},
+    ).fetchall()
+  }
+  desired = {msg_idx: (ts, role, doc_text) for msg_idx, ts, role, doc_text in docs}
+
+  remove_ids = [
+    row_id
+    for msg_idx, (row_id, ts, role, doc_text) in existing.items()
+    if desired.get(msg_idx) != (ts, role, doc_text)
+  ]
+  if remove_ids:
+    db.execute(
+      sql("DELETE FROM chat_search_docs WHERE id = :id"),
+      [{"id": row_id} for row_id in remove_ids],
     )
+
+  changed = [
+    (msg_idx, ts, role, doc_text)
+    for msg_idx, (ts, role, doc_text) in desired.items()
+    if (
+      msg_idx not in existing
+      or existing[msg_idx][1:] != (ts, role, doc_text)
+    )
+  ]
+  _write_docs(db, chat_id, changed)
+
+
+def _upsert_state(
+  db: Session,
+  *,
+  chat_id: str,
+  updated_text: str,
+) -> None:
+  db.execute(
+    sql(
+      "INSERT INTO chat_search_state"
+      " (chat_id, indexed_updated_at)"
+      " VALUES (:cid, :updated)"
+      " ON CONFLICT(chat_id) DO UPDATE SET"
+      "  indexed_updated_at = excluded.indexed_updated_at"
+    ),
+    {
+      "cid": chat_id,
+      "updated": updated_text,
+    },
+  )
 
 
 def reconcile(db: Session) -> None:
-  """Bring the index in line with the chats table. Cheap when nothing changed."""
+  """Bring the derived index in line with chats, one reconciler at a time."""
+  # FastAPI runs this synchronous route in a worker pool. Aborting an older
+  # browser fetch does not stop its worker, so successive debounced queries can
+  # overlap on first-use backfill. Serialize the derived writer in-process;
+  # the unique `(chat_id, msg_idx)` index is the database-level idempotency net.
+  with _RECONCILE_LOCK:
+    _reconcile_locked(db)
+
+
+def _reconcile_locked(db: Session) -> None:
   _ensure_schema(db)
 
   # Index rows whose chat is gone or tombstoned. A restored chat re-enters
@@ -220,42 +369,18 @@ def reconcile(db: Session) -> None:
     updated_text = row[0] if row else ""
     messages = chat.messages or []
     title = chat.title or ""
-    state = db.execute(
-      sql(
-        "SELECT indexed_count, indexed_title FROM chat_search_state"
-        " WHERE chat_id = :cid"
-      ),
-      {"cid": chat_id},
-    ).fetchone()
-
-    if state is not None and state[1] == title and len(messages) >= state[0]:
-      # History is append-only, so only messages beyond the indexed count are
-      # new. A shrink (retention/repair rewrote history) or retitle falls
-      # through to the full per-chat rebuild below.
-      new_docs = [
-        doc for doc in _prose_docs("", messages) if doc[0] >= state[0]
-      ]
-      _write_docs(db, chat_id, new_docs)
+    # Exact row reconciliation preserves same-length replacement correctness
+    # without forcing FTS to re-tokenize every stable message. Non-drawer chats
+    # retain only a tiny state row so an unchanged hidden app/autopilot chat is
+    # not re-hydrated on every query.
+    if _visible_in_owner_drawer(chat):
+      _sync_docs(db, chat_id, _prose_docs(title, messages))
     else:
       _delete_chat_docs(db, chat_id)
-      _write_docs(db, chat_id, _prose_docs(title, messages))
-
-    db.execute(
-      sql(
-        "INSERT INTO chat_search_state"
-        " (chat_id, indexed_count, indexed_title, indexed_updated_at)"
-        " VALUES (:cid, :count, :title, :updated)"
-        " ON CONFLICT(chat_id) DO UPDATE SET"
-        "  indexed_count = excluded.indexed_count,"
-        "  indexed_title = excluded.indexed_title,"
-        "  indexed_updated_at = excluded.indexed_updated_at"
-      ),
-      {
-        "cid": chat_id,
-        "count": len(messages),
-        "title": title,
-        "updated": updated_text,
-      },
+    _upsert_state(
+      db,
+      chat_id=chat_id,
+      updated_text=updated_text,
     )
     # Release the hydrated transcript before the next stale chat.
     db.expire(chat)
@@ -266,7 +391,7 @@ def reconcile(db: Session) -> None:
 
 def _fts_query(raw: str) -> str:
   """User text -> safe FTS5 query: quoted tokens, prefix on the last one."""
-  tokens = re.findall(r"[^\s\"'()*^]+", raw)
+  tokens = _query_tokens(raw)
   if not tokens:
     return ""
   quoted = [f'"{token}"' for token in tokens]
@@ -274,57 +399,262 @@ def _fts_query(raw: str) -> str:
   return " ".join(quoted)
 
 
+def _query_tokens(raw: str) -> list[str]:
+  """Normalize one query consistently across FTS and portable backends."""
+  return re.findall(r"\w+", raw, flags=re.UNICODE)
+
+
+def _portable_token_patterns(tokens: list[str]) -> list[re.Pattern[str]]:
+  patterns = []
+  for index, token in enumerate(tokens):
+    escaped = re.escape(token)
+    if index == len(tokens) - 1:
+      escaped = rf"(?<!\w){escaped}\w*"
+    else:
+      escaped = rf"(?<!\w){escaped}(?!\w)"
+    patterns.append(re.compile(escaped, flags=re.IGNORECASE | re.UNICODE))
+  return patterns
+
+
+def _portable_match_spans(
+  text: str,
+  patterns: list[re.Pattern[str]],
+) -> list[tuple[int, int]]:
+  spans: list[tuple[int, int]] = []
+  for pattern in patterns:
+    matches = list(pattern.finditer(text))
+    if not matches:
+      return []
+    spans.extend(match.span() for match in matches)
+  return sorted(set(spans))
+
+
+def _portable_snippet(
+  text: str,
+  spans: list[tuple[int, int]],
+  width: int = 180,
+) -> str:
+  """Build one sentinel-marked excerpt for the non-FTS fallback."""
+  first_start = spans[0][0]
+  start = max(0, first_start - width // 3)
+  end = min(len(text), start + width)
+  start = max(0, end - width)
+  visible = [span for span in spans if span[0] >= start and span[1] <= end]
+  pieces = ["…"] if start else []
+  cursor = start
+  for span_start, span_end in visible:
+    if span_start < cursor:
+      continue
+    pieces.extend((
+      text[cursor:span_start],
+      _MARK_OPEN,
+      text[span_start:span_end],
+      _MARK_CLOSE,
+    ))
+    cursor = span_end
+  pieces.append(text[cursor:end])
+  if end < len(text):
+    pieces.append("…")
+  return "".join(pieces)
+
+
+def _portable_like_pattern(token: str) -> str:
+  escaped = (
+    token.lower()
+    .replace("\\", "\\\\")
+    .replace("%", "\\%")
+    .replace("_", "\\_")
+  )
+  return f"%{escaped}%"
+
+
+def _portable_transcript_patterns(token: str) -> tuple[str, ...]:
+  """Candidate forms for JSON serializers that preserve or escape Unicode."""
+  raw = _portable_like_pattern(token)
+  serialized = json.dumps(token, ensure_ascii=True)[1:-1]
+  escaped = _portable_like_pattern(serialized)
+  return (raw,) if escaped == raw else (raw, escaped)
+
+
+def _portable_search(
+  db: Session,
+  raw_query: str,
+  limit: int,
+) -> list[dict]:
+  """Preserve the search contract when SQLite FTS5 is unavailable."""
+  tokens = _query_tokens(raw_query)
+  if not tokens:
+    return []
+  title_text = func.lower(func.coalesce(models.Chat.title, ""))
+  transcript_text = func.lower(cast(models.Chat.messages, Text))
+  candidate_filters = [
+    or_(
+      title_text.like(_portable_like_pattern(token), escape="\\"),
+      *(
+        transcript_text.like(pattern, escape="\\")
+        for pattern in _portable_transcript_patterns(token)
+      ),
+    )
+    for token in tokens
+  ]
+  candidates = (
+    db.query(
+      models.Chat.id,
+      models.Chat.title,
+      models.Chat.messages,
+      models.Chat.agent_settings_json,
+      models.Chat.created_by_app_id,
+      models.Chat.activity_at,
+      models.Chat.updated_at,
+    )
+    .filter(models.Chat.deleted_at.is_(None), *candidate_filters)
+    .order_by(
+      func.coalesce(models.Chat.activity_at, models.Chat.updated_at).desc(),
+      models.Chat.id,
+    )
+    .limit(_PORTABLE_CANDIDATE_LIMIT)
+    .yield_per(64)
+  )
+  patterns = _portable_token_patterns(tokens)
+  results: list[dict] = []
+  for chat in candidates:
+    if not _visible_in_owner_drawer(chat):
+      continue
+    matches = []
+    for doc in _prose_docs(chat.title or "", chat.messages or []):
+      spans = _portable_match_spans(doc[3], patterns)
+      if spans:
+        matches.append((doc, spans))
+    if not matches:
+      continue
+    prose_matches = [match for match in matches if match[0][0] >= 0]
+    chosen_doc, chosen_spans = max(
+      prose_matches or matches,
+      key=lambda match: (len(match[1]), -match[0][0]),
+    )
+    msg_idx, ts, role, doc_text = chosen_doc
+    active = chat.activity_at or chat.updated_at
+    active_text = active.isoformat() if hasattr(active, "isoformat") else str(active or "")
+    entry = {
+      "id": chat.id,
+      "title": chat.title,
+      "snippet": (
+        _portable_snippet(doc_text, chosen_spans) if msg_idx >= 0 else None
+      ),
+      "ts": ts if msg_idx >= 0 else None,
+      "role": role if msg_idx >= 0 else None,
+      "anchor_key": None,
+      "last_active": active_text,
+      "match_count": len(matches),
+      "_occurrences": sum(len(spans) for _, spans in matches),
+    }
+    if msg_idx >= 0:
+      entry["anchor_key"] = (
+        f"{role}-{ts}" if ts is not None else f"{role}-{msg_idx}"
+      )
+    results.append(entry)
+  results.sort(
+    key=lambda entry: (
+      entry["_occurrences"], entry["match_count"], entry["last_active"],
+    ),
+    reverse=True,
+  )
+  for entry in results:
+    entry.pop("_occurrences", None)
+  return results[:limit]
+
+
+def _database_dialect(db: Session) -> str:
+  return db.get_bind().dialect.name
+
+
+def purge_chat_docs(db: Session, chat_ids: list[str]) -> None:
+  """Delete SQLite-derived search data inside the hard-purge transaction."""
+  if not chat_ids or _database_dialect(db) != "sqlite":
+    return
+  tables = {
+    row[0]
+    for row in db.execute(sql(
+      "SELECT name FROM sqlite_master WHERE type = 'table'"
+      " AND name IN ('chat_search_docs', 'chat_search_state')"
+    )).fetchall()
+  }
+  for chat_id in chat_ids:
+    if "chat_search_docs" in tables:
+      db.execute(
+        sql("DELETE FROM chat_search_docs WHERE chat_id = :cid"),
+        {"cid": chat_id},
+      )
+    if "chat_search_state" in tables:
+      db.execute(
+        sql("DELETE FROM chat_search_state WHERE chat_id = :cid"),
+        {"cid": chat_id},
+      )
+
+
 def search(db: Session, raw_query: str, limit: int = 20) -> list[dict]:
   """Ranked chats matching the query, best doc per chat, with a snippet."""
+  if _database_dialect(db) != "sqlite":
+    return _portable_search(db, raw_query, limit)
   match = _fts_query(raw_query)
   if not match:
     return []
   reconcile(db)
 
-  rows = db.execute(
+  # Choose chats before choosing snippets. Limiting the raw FTS row stream lets
+  # one long conversation with hundreds of matching messages crowd every other
+  # chat out of the result set. The FTS5 `rank` pseudo-column is bm25-compatible
+  # and, unlike the bm25() auxiliary function, can be aggregated by SQLite.
+  chats = db.execute(
     sql(
-      "SELECT d.chat_id, d.msg_idx, d.ts, d.role,"
-      "  snippet(chat_search_fts, 0, :mo, :mc, '…', 12) AS snip,"
-      "  bm25(chat_search_fts) AS rank,"
-      "  c.title, CAST(COALESCE(c.activity_at, c.updated_at) AS TEXT)"
+      "SELECT d.chat_id, MIN(chat_search_fts.rank) AS best_rank,"
+      "  COUNT(*) AS match_count, c.title,"
+      "  CAST(COALESCE(c.activity_at, c.updated_at) AS TEXT) AS active_text"
       " FROM chat_search_fts"
       " JOIN chat_search_docs d ON d.id = chat_search_fts.rowid"
       " JOIN chats c ON c.id = d.chat_id AND c.deleted_at IS NULL"
       " WHERE chat_search_fts MATCH :q"
-      " ORDER BY rank LIMIT 200"
+      " GROUP BY d.chat_id"
+      " ORDER BY best_rank, active_text DESC, d.chat_id"
+      " LIMIT :limit"
     ),
-    {"q": match, "mo": _MARK_OPEN, "mc": _MARK_CLOSE},
+    {"q": match, "limit": limit},
   ).fetchall()
 
-  # Best-ranked doc per chat wins; a title hit falls back to no snippet (the
-  # row already shows the title). bm25 is ascending-better in SQLite. The
-  # snippet's own prose doc supplies `ts`/`role` so the drawer can reveal that
-  # exact transcript row — a title-only hit has neither and simply opens the
-  # chat at its last position.
-  by_chat: dict[str, dict] = {}
-  for chat_id, msg_idx, ts, role, snip, rank, title, active_text in rows:
-    entry = by_chat.get(chat_id)
-    if entry is None:
-      entry = {
-        "id": chat_id,
-        "title": title,
-        "snippet": None,
-        "ts": None,
-        "role": None,
-        "rank": rank,
-        "last_active": active_text,
-        "match_count": 0,
-      }
-      by_chat[chat_id] = entry
-    entry["match_count"] += 1
-    if msg_idx >= 0 and entry["snippet"] is None:
-      entry["snippet"] = snip
-      entry["ts"] = ts
-      entry["role"] = role
-
-  results = sorted(
-    by_chat.values(), key=lambda e: (e["rank"], e["last_active"] or "")
-  )[:limit]
-  for entry in results:
-    entry.pop("rank", None)
+  results: list[dict] = []
+  for chat_id, _rank, match_count, title, active_text in chats:
+    # Prefer the best prose hit so a chat whose title also matches can still
+    # jump to useful transcript context. A title-only chat returns no snippet
+    # or anchor and opens at its ordinary saved position.
+    hit = db.execute(
+      sql(
+        "SELECT d.msg_idx, d.ts, d.role,"
+        "  snippet(chat_search_fts, 0, :mo, :mc, '…', 12) AS snip"
+        " FROM chat_search_fts"
+        " JOIN chat_search_docs d ON d.id = chat_search_fts.rowid"
+        " WHERE chat_search_fts MATCH :q AND d.chat_id = :cid"
+        " ORDER BY (d.msg_idx < 0), chat_search_fts.rank, d.id"
+        " LIMIT 1"
+      ),
+      {"q": match, "cid": chat_id, "mo": _MARK_OPEN, "mc": _MARK_CLOSE},
+    ).fetchone()
+    msg_idx, ts, role, snip = hit if hit is not None else (-1, None, None, None)
+    entry = {
+      "id": chat_id,
+      "title": title,
+      "snippet": snip if msg_idx >= 0 else None,
+      "ts": ts if msg_idx >= 0 else None,
+      "role": role if msg_idx >= 0 else None,
+      "anchor_key": None,
+      "last_active": active_text,
+      "match_count": match_count,
+    }
+    if msg_idx >= 0:
+      # Match the durable keys accepted by GET /chats/{id}?anchor=… and the
+      # transcript DOM. Timestamps are the normal stable identity; older or
+      # repaired rows without one still have the role/index address.
+      entry["anchor_key"] = (
+        f"{role}-{ts}" if ts is not None else f"{role}-{msg_idx}"
+      )
+    results.append(entry)
   return results

--- a/backend/app/chat_visibility.py
+++ b/backend/app/chat_visibility.py
@@ -1,0 +1,38 @@
+"""Shared owner-drawer visibility policy for chats.
+
+The drawer list and every derived view of that list (notably full-text search)
+must use one predicate. Keeping the legacy JSON coercion here also makes old
+text-backed rows behave identically at every caller.
+"""
+
+import json
+
+from app import models
+
+
+def coerce_agent_settings(raw) -> dict:
+  """Return a fresh dict from a dict or legacy JSON string; otherwise empty."""
+  if raw is None:
+    return {}
+  if isinstance(raw, dict):
+    return dict(raw)
+  if isinstance(raw, str):
+    try:
+      parsed = json.loads(raw)
+      return dict(parsed) if isinstance(parsed, dict) else {}
+    except (ValueError, TypeError):
+      return {}
+  return {}
+
+
+def visible_in_owner_drawer(chat: models.Chat) -> bool:
+  """Whether an active chat belongs in the owner's primary chat history."""
+  settings = coerce_agent_settings(chat.agent_settings_json)
+  # Explicit drawer_hidden wins in either direction. Autopilot follow-up chats
+  # use it to become visible only while owner attention is required.
+  hidden = settings.get("drawer_hidden")
+  if hidden is not None:
+    return not bool(hidden)
+  if chat.created_by_app_id is None:
+    return True
+  return settings.get("owner_visible") is True

--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -1792,7 +1792,11 @@ class ChatWriterActor:
     chat_update = db.execute(
       update(Chat)
       .where(Chat.id == cmd.chat_id, Chat.deleted_at.is_(None))
-      .values(messages=cmd.messages, live_assistant=None)
+      .values(
+        messages=cmd.messages,
+        has_messages=bool(cmd.messages),
+        live_assistant=None,
+      )
     )
     if chat_update.rowcount != 1:
       db.rollback()
@@ -1938,7 +1942,11 @@ class ChatWriterActor:
           ~active_run_exists,
           Chat.updated_at == snap_updated_at,
         )
-        .values(messages=plan.new_messages, pending_messages=plan.new_pending)
+        .values(
+          messages=plan.new_messages,
+          has_messages=bool(plan.new_messages),
+          pending_messages=plan.new_pending,
+        )
       )
     except OperationalError:
       db.rollback()

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1304,6 +1304,31 @@ def _require_app_identity(eng) -> None:
         ))
 
 
+def _add_chat_has_messages(eng) -> None:
+  """Materialize transcript emptiness for the drawer's hot list query."""
+  from sqlalchemy import inspect as sa_inspect, text
+
+  inspector = sa_inspect(eng)
+  if "chats" not in inspector.get_table_names():
+    return
+  columns = {column["name"] for column in inspector.get_columns("chats")}
+  if "has_messages" in columns:
+    return
+  with eng.begin() as conn:
+    conn.execute(text(
+      "ALTER TABLE chats ADD COLUMN has_messages BOOLEAN "
+      "NOT NULL DEFAULT FALSE"
+    ))
+    # One deliberate upgrade-time scan replaces the same scan on every drawer
+    # refresh. Legacy rows are non-null JSON, but guard NULL for hand-built DBs.
+    if "messages" in columns:
+      conn.execute(text(
+        "UPDATE chats SET has_messages = CASE "
+        "WHEN messages IS NOT NULL AND CAST(messages AS TEXT) != '[]' "
+        "THEN TRUE ELSE FALSE END"
+      ))
+
+
 def _add_connectors_table(eng) -> None:
   """Create the provider-neutral MCP registry without replacing preview rows."""
   from app.models import Connector
@@ -1367,6 +1392,7 @@ _SCHEMA_MIGRATIONS = (
   ("0004_app_identity_required", _require_app_identity),
   ("0005_connectors", _add_connectors_table),
   ("0006_connector_capability_identity", _add_connector_capability_identity),
+  ("0007_chat_has_messages", _add_chat_has_messages),
 )
 
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -21,7 +21,7 @@ from sqlalchemy import (
   LargeBinary, String, Text, UniqueConstraint, event, false, or_, true,
 )
 
-from sqlalchemy.orm import column_property
+from sqlalchemy.orm import column_property, validates
 
 from app.database import Base
 from app.timeutil import now_naive_utc
@@ -116,6 +116,13 @@ class Chat(Base):
   # drops back to the agent summary / first message and gets re-derived.
   title_locked = Column(Boolean, nullable=False, default=False)
   messages = Column(JSON, nullable=False, default=list)
+  # Drawer/list reads need only to know whether a transcript is empty. Keeping
+  # that fact beside the blob prevents every chat-list request from scanning
+  # every stored transcript. All runtime transcript writes flow through normal
+  # ORM assignment or the two explicit bulk paths in chat_writer.
+  has_messages = Column(
+    Boolean, nullable=False, default=False, server_default=false()
+  )
   # Current in-flight assistant state is separate from immutable history so a
   # streaming update never rewrites every prior message. Finalize and startup
   # recovery merge this bounded value into `messages`.
@@ -180,6 +187,11 @@ class Chat(Base):
   activity_at = Column(
     DateTime, nullable=True, default=lambda: datetime.now(UTC)
   )
+
+  @validates("messages")
+  def _sync_has_messages(self, _key, value):
+    self.has_messages = bool(value)
+    return value
 
 
 class ChatRun(Base):

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -15,6 +15,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app import activity, auth, chat_search, models, providers, questions
+from app.chat_visibility import coerce_agent_settings, visible_in_owner_drawer
 from app.config import get_settings
 from app.chat import (
   _finish_run,
@@ -209,29 +210,7 @@ class PinnedOrderUpdate(BaseModel):
   items: list[PinnedOrderItem] = Field(min_length=1, max_length=5000)
 
 
-def _coerce_agent_settings(raw) -> dict:
-  """Returns a fresh dict from a possibly-string JSON value.
-
-  SQLAlchemy's JSON column type usually returns dict on read, but
-  on some SQLite + driver combos (especially with text-backed JSON
-  columns) the value comes back as a raw string. Calling
-  `dict(some_str)` raises TypeError. Normalize once at every
-  read site to defend against that — and against legacy rows
-  written before the column was typed as JSON.
-
-  Returns `{}` for None, invalid JSON, or non-dict values.
-  """
-  if raw is None:
-    return {}
-  if isinstance(raw, dict):
-    return dict(raw)
-  if isinstance(raw, str):
-    try:
-      parsed = json.loads(raw)
-      return dict(parsed) if isinstance(parsed, dict) else {}
-    except (ValueError, TypeError):
-      return {}
-  return {}
+_coerce_agent_settings = coerce_agent_settings
 
 
 def _mirror_agent_defaults(
@@ -269,18 +248,7 @@ def _switch_request_fingerprint(provider_id: str, settings_patch: dict) -> str:
   return hashlib.sha256(payload).hexdigest()
 
 
-def _visible_in_owner_drawer(chat: models.Chat) -> bool:
-  settings = _coerce_agent_settings(chat.agent_settings_json)
-  # An explicit ``drawer_hidden`` bit overrides the default rule in either
-  # direction. Autopilot follow-up chats are ordinary owner chats that use it to
-  # stay out of the drawer except while an escalation is waiting on the owner, so
-  # routine self-resolving rounds never clutter the chat list.
-  hidden = settings.get("drawer_hidden")
-  if hidden is not None:
-    return not bool(hidden)
-  if chat.created_by_app_id is None:
-    return True
-  return settings.get("owner_visible") is True
+_visible_in_owner_drawer = visible_in_owner_drawer
 
 
 @router.post(
@@ -341,7 +309,7 @@ def _owner_chat_summary(chat: models.Chat, *, durable_running: bool = False) -> 
     "updated_at": chat.updated_at.isoformat(),
     "activity_at": chat.activity_at.isoformat() if chat.activity_at else None,
     "pinned_at": chat.pinned_at.isoformat() if chat.pinned_at else None,
-    "has_messages": bool(chat.messages and len(chat.messages) > 0),
+    "has_messages": bool(chat.has_messages),
     "created_by_app_id": chat.created_by_app_id,
     "running": durable_running or is_chat_running(chat.id),
   }
@@ -353,8 +321,8 @@ def _owner_chat_summary_projection(chat, *, durable_running: bool = False) -> di
   ``GET /api/chats`` used to hydrate every complete ``Chat`` ORM object merely
   to return eight summary fields. On a long-lived instance that decoded tens of
   megabytes of transcript JSON on every drawer open and chat switch, contending
-  with the selected chat's small detail read. Keep transcript inspection inside
-  the database (``message_count``) and never materialize ``messages`` here.
+  with the selected chat's small detail read. The writer-owned ``has_messages``
+  summary keeps this projection independent of the transcript blob entirely.
   """
   return {
     "id": chat.id,
@@ -362,7 +330,7 @@ def _owner_chat_summary_projection(chat, *, durable_running: bool = False) -> di
     "updated_at": chat.updated_at.isoformat(),
     "activity_at": chat.activity_at.isoformat() if chat.activity_at else None,
     "pinned_at": chat.pinned_at.isoformat() if chat.pinned_at else None,
-    "has_messages": bool(chat.message_count),
+    "has_messages": bool(chat.has_messages),
     "created_by_app_id": chat.created_by_app_id,
     "running": durable_running or is_chat_running(chat.id),
   }
@@ -577,16 +545,9 @@ def list_chats(
   # a `desc()` on a nullable column would put NULL last under our
   # SQLite collation, but making the boolean explicit is clearer and
   # portable.
-  # Drawer projection only. Selecting the Chat entity here hydrates its full
-  # ``messages`` JSON column even though the response needs only a boolean; on
-  # this owner's history that was ~47 MB of JSON decoding per refresh. Compare
-  # the canonical serialized empty-array value in SQL instead of parsing every
-  # JSON array with json_array_length: Chat.messages is a non-null list written
-  # by SQLAlchemy's canonical serializer, and CAST(... AS TEXT) is portable
-  # across SQLite and PostgreSQL. A future raw-import path must normalize JSON
-  # text first (PostgreSQL's json type preserves whitespace such as ``[ ]``).
-  # The database can reject non-empty values from their stored length without
-  # walking every transcript.
+  # Drawer projection only. ``has_messages`` is maintained with the transcript
+  # by the Chat model and the two writer bulk-update paths, so this hot query
+  # never reads or decodes the potentially large ``messages`` JSON column.
   q = db.query(
     models.Chat.id,
     models.Chat.title,
@@ -598,10 +559,7 @@ def list_chats(
     # chats normally keep this NULL, so this remains a tiny projection rather
     # than pulling transcript/runtime JSON into the hot path.
     models.Chat.agent_settings_json,
-    case(
-      (cast(models.Chat.messages, Text) != "[]", 1),
-      else_=0,
-    ).label("message_count"),
+    models.Chat.has_messages,
   ).filter(models.Chat.deleted_at.is_(None))
   chats = (
     q.order_by(
@@ -2373,7 +2331,7 @@ def _app_chat_summary(chat: models.Chat) -> dict:
     "created_at": chat.created_at.isoformat() if chat.created_at else None,
     "updated_at": chat.updated_at.isoformat() if chat.updated_at else None,
     "activity_at": chat.activity_at.isoformat() if chat.activity_at else None,
-    "has_messages": bool(chat.messages and len(chat.messages) > 0),
+    "has_messages": bool(chat.has_messages),
     "provider": chat.provider or "claude",
     "scope": _app_chat_scope(chat),
     "scope_label": _app_chat_scope_label(chat),

--- a/backend/tests/test_chat_search.py
+++ b/backend/tests/test_chat_search.py
@@ -1,9 +1,13 @@
 """Drawer chat search: FTS index reconciliation + /api/chats/search."""
 
+from concurrent.futures import ThreadPoolExecutor
+from datetime import timedelta
+import threading
 import uuid
 
 from app import chat_search, models
 from app.chat_search import sql
+from app.timeutil import now_naive_utc
 
 
 def _make_chat(db, title, texts, role="user"):
@@ -44,17 +48,121 @@ def test_result_carries_reveal_anchor_of_matching_message(db):
   hit = next(r for r in chat_search.search(db, "wombat") if r["id"] == c.id)
   assert hit["role"] == "user"
   assert hit["ts"] == 1001
+  assert hit["anchor_key"] == "user-1001"
+
+
+def test_result_falls_back_to_role_index_anchor_without_timestamp(db):
+  c = models.Chat(
+    id=str(uuid.uuid4()),
+    title="Untimed notes",
+    messages=[
+      {"role": "user", "content": "intro"},
+      {"role": "assistant", "content": "needle in an untimed row"},
+    ],
+  )
+  db.add(c)
+  db.commit()
+  hit = next(r for r in chat_search.search(db, "needle") if r["id"] == c.id)
+  assert hit["anchor_key"] == "assistant-1"
 
 
 def test_title_only_hit_has_no_reveal_anchor(db):
   c = _make_chat(db, "Marimba tuning", ["unrelated body"])
   hit = next(r for r in chat_search.search(db, "marimba") if r["id"] == c.id)
   assert hit["ts"] is None and hit["role"] is None
+  assert hit["anchor_key"] is None
 
 
 def test_prefix_match_on_last_token(db):
   c = _make_chat(db, "Money", ["monthly budgeting spreadsheet"])
   assert any(r["id"] == c.id for r in chat_search.search(db, "budg"))
+
+
+def test_portable_fallback_preserves_visibility_prefix_and_reveal_contract(
+  db, monkeypatch,
+):
+  suffix = uuid.uuid4().hex
+  exact = f"portablepostgres{suffix}"
+  visible = _make_chat(
+    db,
+    "Portable result",
+    [f"{exact} capybara appears in visible prose"],
+  )
+  hidden_row = models.Chat(
+    id=str(uuid.uuid4()),
+    title="Hidden transcript row",
+    messages=[{
+      "role": "user",
+      "content": f"{exact} capybara private answer",
+      "ts": 1000,
+      "hidden": True,
+    }],
+  )
+  hidden_chat = models.Chat(
+    id=str(uuid.uuid4()),
+    title="Hidden drawer chat",
+    messages=[{
+      "role": "user",
+      "content": f"{exact} capybara hidden chat",
+      "ts": 1000,
+    }],
+    agent_settings_json={"drawer_hidden": True},
+  )
+  tool_only = models.Chat(
+    id=str(uuid.uuid4()),
+    title="Tool output",
+    messages=[{
+      "role": "tool",
+      "content": f"{exact} capybara tool payload",
+      "ts": 1000,
+    }],
+  )
+  db.add_all((hidden_row, hidden_chat, tool_only))
+  db.commit()
+
+  monkeypatch.setattr(chat_search, "_database_dialect", lambda _db: "postgresql")
+
+  def unexpected_reconcile(_db):
+    raise AssertionError("portable search must not touch the SQLite FTS schema")
+
+  monkeypatch.setattr(chat_search, "reconcile", unexpected_reconcile)
+  results = chat_search.search(db, f"{exact} capy")
+  ids = {result["id"] for result in results}
+  assert visible.id in ids
+  assert {hidden_row.id, hidden_chat.id, tool_only.id}.isdisjoint(ids)
+  hit = next(result for result in results if result["id"] == visible.id)
+  assert hit["anchor_key"] == "user-1000"
+  assert "capybara" in hit["snippet"]
+
+
+def test_portable_fallback_finds_json_escaped_unicode_transcript(db, monkeypatch):
+  c = _make_chat(db, "Unicode", ["réunion café itinerary"])
+  monkeypatch.setattr(chat_search, "_database_dialect", lambda _db: "postgresql")
+
+  hit = next(
+    result for result in chat_search.search(db, "réunion caf")
+    if result["id"] == c.id
+  )
+
+  assert hit["anchor_key"] == "user-1000"
+  assert "café" in hit["snippet"]
+
+
+def test_portable_fallback_bounds_candidates_by_recent_activity(db, monkeypatch):
+  needle = f"boundedportable{uuid.uuid4().hex}"
+  now = now_naive_utc()
+  older = _make_chat(db, "Older dense match", [f"{needle} {needle} {needle}"])
+  newer = _make_chat(db, "Newer match", [needle])
+  older.activity_at = now - timedelta(days=1)
+  newer.activity_at = now
+  db.commit()
+
+  monkeypatch.setattr(chat_search, "_database_dialect", lambda _db: "postgresql")
+  monkeypatch.setattr(chat_search, "_PORTABLE_CANDIDATE_LIMIT", 1)
+
+  results = chat_search.search(db, needle, limit=20)
+
+  assert [result["id"] for result in results] == [newer.id]
 
 
 def test_title_match_has_no_snippet(db):
@@ -65,7 +173,7 @@ def test_title_match_has_no_snippet(db):
   assert hit["snippet"] is None
 
 
-def test_new_messages_append_incrementally(db):
+def test_appended_message_sync_keeps_one_doc_per_transcript_row(db):
   c = _make_chat(db, "Log", ["first entry"])
   chat_search.search(db, "first")  # index it
   before = _doc_count(db, c.id)
@@ -75,6 +183,41 @@ def test_new_messages_append_incrementally(db):
   db.commit()
   assert any(r["id"] == c.id for r in chat_search.search(db, "quokka"))
   assert _doc_count(db, c.id) == before + 1
+
+
+def test_append_preserves_stable_fts_document_rows(db):
+  c = _make_chat(db, "Stable history", ["first stable", "second stable"])
+  chat_search.search(db, "stable")
+  before = dict(db.execute(
+    sql("SELECT msg_idx, id FROM chat_search_docs WHERE chat_id = :cid"),
+    {"cid": c.id},
+  ).fetchall())
+
+  c.messages = c.messages + [
+    {"role": "assistant", "content": "third stable", "ts": 1002}
+  ]
+  db.commit()
+  chat_search.search(db, "stable")
+  after = dict(db.execute(
+    sql("SELECT msg_idx, id FROM chat_search_docs WHERE chat_id = :cid"),
+    {"cid": c.id},
+  ).fetchall())
+
+  assert before.items() <= after.items()
+  assert 2 in after
+
+
+def test_same_length_transcript_replacement_updates_existing_search_rows(db):
+  c = _make_chat(db, "Mutable", ["oldplatypus phrase"])
+  assert any(r["id"] == c.id for r in chat_search.search(db, "oldplatypus"))
+
+  c.messages = [
+    {"role": "user", "content": "newporcupine phrase", "ts": 1000},
+  ]
+  db.commit()
+
+  assert any(r["id"] == c.id for r in chat_search.search(db, "newporcupine"))
+  assert not any(r["id"] == c.id for r in chat_search.search(db, "oldplatypus"))
 
 
 def test_rename_reindexes_title(db):
@@ -127,6 +270,181 @@ def test_tool_noise_roles_are_not_indexed(db):
   )
 
 
+def test_hidden_transcript_rows_never_surface_and_can_become_visible(db):
+  c = models.Chat(
+    id=str(uuid.uuid4()),
+    title="Private transcript mechanics",
+    messages=[
+      {"role": "user", "content": "ordinary visible prose", "ts": 1000},
+      {
+        "role": "user",
+        "content": "concealedcassowary answer",
+        "ts": 1001,
+        "hidden": True,
+      },
+    ],
+  )
+  db.add(c)
+  db.commit()
+
+  assert not any(
+    r["id"] == c.id for r in chat_search.search(db, "concealedcassowary")
+  )
+  assert _doc_count(db, c.id) == 2  # title + visible message
+
+  messages = list(c.messages)
+  messages[1] = {**messages[1], "hidden": False}
+  c.messages = messages
+  db.commit()
+  hit = next(
+    r for r in chat_search.search(db, "concealedcassowary") if r["id"] == c.id
+  )
+  assert hit["anchor_key"] == "user-1001"
+
+
+def test_search_visibility_matches_owner_drawer_contract(db):
+  suffix = uuid.uuid4().hex
+  needle = f"drawercontract{suffix}"
+  app = models.App(
+    source_dir=f"/tmp/search-visibility-{suffix}",
+    name="Search visibility fixture",
+    description="",
+    jsx_source="",
+    slug=f"search-visibility-{suffix}",
+  )
+  db.add(app)
+  db.flush()
+
+  def chat(label, *, app_owned=False, settings=None):
+    row = models.Chat(
+      id=str(uuid.uuid4()),
+      title=label,
+      messages=[{"role": "user", "content": needle, "ts": 1000}],
+      created_by_app_id=app.id if app_owned else None,
+      agent_settings_json=settings,
+    )
+    db.add(row)
+    return row
+
+  owner_default = chat("Owner default")
+  owner_hidden = chat("Owner hidden", settings={"drawer_hidden": True})
+  app_default = chat("App default", app_owned=True)
+  app_visible = chat(
+    "App owner visible", app_owned=True,
+    settings='{"owner_visible": true}',
+  )
+  app_forced_visible = chat(
+    "App forced visible", app_owned=True,
+    settings={"drawer_hidden": False},
+  )
+  app_forced_hidden = chat(
+    "App forced hidden", app_owned=True,
+    settings={"owner_visible": True, "drawer_hidden": True},
+  )
+  db.commit()
+
+  ids = {result["id"] for result in chat_search.search(db, needle)}
+  assert {owner_default.id, app_visible.id, app_forced_visible.id} <= ids
+  assert {owner_hidden.id, app_default.id, app_forced_hidden.id}.isdisjoint(ids)
+  assert _doc_count(db, owner_hidden.id) == 0
+  assert _doc_count(db, app_default.id) == 0
+
+
+def test_search_and_drawer_visibility_helpers_share_one_behavior_contract():
+  from app.routes.chats import _visible_in_owner_drawer as drawer_visible
+
+  cases = (
+    (None, None),
+    (None, {"drawer_hidden": True}),
+    (42, None),
+    (42, {"owner_visible": True}),
+    (42, '{"owner_visible": true}'),
+    (42, {"owner_visible": True, "drawer_hidden": True}),
+    (42, {"drawer_hidden": False}),
+  )
+  for created_by_app_id, settings in cases:
+    chat = models.Chat(
+      id=str(uuid.uuid4()),
+      title="Visibility contract",
+      messages=[],
+      created_by_app_id=created_by_app_id,
+      agent_settings_json=settings,
+    )
+    assert chat_search._visible_in_owner_drawer(chat) is drawer_visible(chat)
+
+
+def test_index_version_rebuild_purges_rows_from_older_indexing_semantics(db):
+  c = models.Chat(
+    id=str(uuid.uuid4()),
+    title="Versioned search",
+    messages=[{
+      "role": "user",
+      "content": "legacyhiddenibis",
+      "ts": 1000,
+      "hidden": True,
+    }],
+  )
+  db.add(c)
+  db.commit()
+  chat_search.search(db, "unrelated")
+
+  # Model an older generation that indexed this now-hidden row. Changing the
+  # semantic version must replace the complete disposable index before query.
+  db.execute(sql(
+    "INSERT INTO chat_search_docs (chat_id, msg_idx, ts, role, text)"
+    " VALUES (:cid, 0, 1000, 'user', 'legacyhiddenibis')"
+  ), {"cid": c.id})
+  db.execute(sql(
+    "UPDATE chat_search_meta SET value = 'legacy' WHERE key = 'index_version'"
+  ))
+  db.commit()
+  chat_search._schema_ready = False
+
+  assert not any(
+    result["id"] == c.id
+    for result in chat_search.search(db, "legacyhiddenibis")
+  )
+  version = db.execute(sql(
+    "SELECT value FROM chat_search_meta WHERE key = 'index_version'"
+  )).scalar_one()
+  assert version == chat_search._INDEX_VERSION
+  assert _doc_count(db, c.id) == 1  # title only; hidden message stayed absent
+
+
+def test_long_matching_chat_cannot_crowd_other_chats_out_before_grouping(db):
+  suffix = uuid.uuid4().hex
+  needle = f"fairresult{suffix}"
+  long_chat = _make_chat(db, "Long match", [needle] * 240)
+  short_a = _make_chat(db, "Short A", [needle])
+  short_b = _make_chat(db, "Short B", [needle])
+
+  ids = {result["id"] for result in chat_search.search(db, needle, limit=3)}
+  assert ids == {long_chat.id, short_a.id, short_b.id}
+
+
+def test_overlapping_first_searches_leave_one_idempotent_document_generation(db):
+  suffix = uuid.uuid4().hex
+  needle = f"concurrentsearch{suffix}"
+  c = _make_chat(db, "Concurrent index", [needle])
+  start = threading.Barrier(2)
+
+  def run_search():
+    from app.database import SessionLocal
+
+    session = SessionLocal()
+    try:
+      start.wait(timeout=2)
+      return chat_search.search(session, needle)
+    finally:
+      session.close()
+
+  with ThreadPoolExecutor(max_workers=2) as pool:
+    outcomes = list(pool.map(lambda _: run_search(), range(2)))
+
+  assert all(any(result["id"] == c.id for result in rows) for rows in outcomes)
+  assert _doc_count(db, c.id) == 2  # one title row + one message row
+
+
 def test_operator_input_is_neutralized(db):
   _make_chat(db, "Safe", ["plain text"])
   for hostile in ['" OR 1=1 --', "NEAR(", "a*b^c", "   ", ""]:
@@ -140,3 +458,21 @@ def test_search_endpoint_requires_owner_and_returns_hits(client, auth, db):
   assert r.status_code == 200
   assert any(hit["id"] == c.id for hit in r.json())
   assert client.get("/api/chats/search?q=", headers=auth).json() == []
+
+
+def test_search_anchor_opens_one_authoritative_window_through_the_tail(client, auth, db):
+  c = _make_chat(db, "Window", ["before", "the searchable narwhal", "after"])
+  hit = next(
+    result for result in client.get(
+      "/api/chats/search?q=narwhal", headers=auth
+    ).json() if result["id"] == c.id
+  )
+  detail = client.get(
+    f"/api/chats/{c.id}?anchor={hit['anchor_key']}&compact=1",
+    headers=auth,
+  ).json()
+  assert detail["requested_anchor_found"] is True
+  assert detail["offset"] == 1
+  assert [row["content"] for row in detail["messages"]] == [
+    "the searchable narwhal", "after",
+  ]

--- a/backend/tests/test_chats.py
+++ b/backend/tests/test_chats.py
@@ -277,7 +277,7 @@ def test_create_repair_chat_is_idempotent_across_ambiguous_retries(client, auth)
 
 
 def test_chat_list_projects_summaries_without_hydrating_transcripts(
-  client, auth,
+  client, auth, db,
 ):
   created = client.post(
     "/api/chats",
@@ -290,15 +290,22 @@ def test_chat_list_projects_summaries_without_hydrating_transcripts(
   assert created.status_code == 200
 
   hydrated_chat_ids = []
+  drawer_selects = []
 
   def on_load(chat, _context):
     hydrated_chat_ids.append(chat.id)
 
+  def capture_sql(_conn, _cursor, statement, _parameters, _context, _many):
+    if "FROM chats" in statement:
+      drawer_selects.append(statement)
+
   event.listen(models.Chat, "load", on_load)
+  event.listen(db.get_bind(), "before_cursor_execute", capture_sql)
   try:
     listed = client.get("/api/chats", headers=auth)
   finally:
     event.remove(models.Chat, "load", on_load)
+    event.remove(db.get_bind(), "before_cursor_execute", capture_sql)
 
   assert listed.status_code == 200
   row = next(item for item in listed.json() if item["id"] == created.json()["id"])
@@ -306,6 +313,48 @@ def test_chat_list_projects_summaries_without_hydrating_transcripts(
   assert hydrated_chat_ids == [], (
     "the drawer list must not instantiate Chat objects and decode messages"
   )
+  drawer_query = next(
+    statement for statement in drawer_selects
+    if "ORDER BY" in statement and "chats.has_messages" in statement
+  )
+  assert "chats.messages AS" not in drawer_query, (
+    "the drawer list must not read the transcript blob"
+  )
+
+
+def test_chat_list_message_summary_tracks_transcript_replacements(
+  client, auth,
+):
+  created = client.post(
+    "/api/chats",
+    json={
+      "title": "Summary invariant",
+      "messages": [{"role": "user", "content": "hello"}],
+    },
+    headers=auth,
+  )
+  assert created.status_code == 200
+  chat_id = created.json()["id"]
+
+  cleared = client.put(
+    f"/api/chats/{chat_id}", json={"messages": []}, headers=auth,
+  )
+  assert cleared.status_code == 200
+  listed = client.get("/api/chats", headers=auth)
+  assert next(row for row in listed.json() if row["id"] == chat_id)[
+    "has_messages"
+  ] is False
+
+  restored = client.put(
+    f"/api/chats/{chat_id}",
+    json={"messages": [{"role": "user", "content": "back"}]},
+    headers=auth,
+  )
+  assert restored.status_code == 200
+  listed = client.get("/api/chats", headers=auth)
+  assert next(row for row in listed.json() if row["id"] == chat_id)[
+    "has_messages"
+  ] is True
 
 
 def test_chat_list_orders_by_owner_activity_not_agent_updates(

--- a/backend/tests/test_db_migrations.py
+++ b/backend/tests/test_db_migrations.py
@@ -1009,6 +1009,7 @@ def test_run_migrations_records_an_inspectable_append_only_history(tmp_path):
     "0004_app_identity_required",
     "0005_connectors",
     "0006_connector_capability_identity",
+    "0007_chat_has_messages",
   ]
   assert second == first
 
@@ -1065,6 +1066,38 @@ def test_connectors_migration_preserves_preview_era_rows(tmp_path):
   }
   assert "0006_connector_capability_identity" in {
     entry["version"] for entry in schema_migration_history(eng)
+  }
+
+
+def test_chat_message_summary_migration_backfills_legacy_transcripts(tmp_path):
+  eng = create_engine(f"sqlite:///{tmp_path / 'chat-message-summary.db'}")
+  with eng.begin() as conn:
+    conn.execute(text(
+      "CREATE TABLE apps (id INTEGER PRIMARY KEY, name VARCHAR(255))"
+    ))
+    conn.execute(text(
+      "CREATE TABLE chats ("
+      "id VARCHAR(64) PRIMARY KEY, title VARCHAR(255), messages JSON, "
+      "updated_at DATETIME)"
+    ))
+    conn.execute(text(
+      "INSERT INTO chats (id, title, messages) VALUES "
+      "('empty', 'Empty', '[]'), "
+      "('started', 'Started', '[{\"role\": \"user\"}]')"
+    ))
+
+  run_migrations(eng)
+  run_migrations(eng)
+
+  columns = {item["name"] for item in inspect(eng).get_columns("chats")}
+  with eng.connect() as conn:
+    values = conn.execute(text(
+      "SELECT id, has_messages FROM chats ORDER BY id"
+    )).all()
+  assert "has_messages" in columns
+  assert values == [("empty", 0), ("started", 1)]
+  assert "0007_chat_has_messages" in {
+    row["version"] for row in schema_migration_history(eng)
   }
 
 

--- a/backend/tests/test_lifecycle.py
+++ b/backend/tests/test_lifecycle.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 import uuid
 
-from app import models
+from app import chat_search, models
 from app.chat_retention import purge_expired_chat_tombstones
 from sqlalchemy import event
 
@@ -34,6 +34,39 @@ def test_purge_after_seven_days(db, chat):
     models.Chat.id == chat_id
   ).first()
   assert gone is None, "Chat deleted 8 days ago must be purged"
+
+
+def test_hard_purge_removes_derived_search_transcript_without_later_search(
+  db, chat,
+):
+  chat.messages = [{
+    "role": "user",
+    "content": "retentioncassowary searchable transcript",
+    "ts": 1000,
+  }]
+  db.commit()
+  assert any(
+    result["id"] == chat.id
+    for result in chat_search.search(db, "retentioncassowary")
+  )
+
+  chat_id = chat.id
+  chat.deleted_at = datetime.utcnow() - timedelta(days=8)
+  db.commit()
+  purge_expired_chat_tombstones(db)
+
+  assert db.execute(
+    chat_search.sql(
+      "SELECT count(*) FROM chat_search_docs WHERE chat_id = :chat_id"
+    ),
+    {"chat_id": chat_id},
+  ).scalar_one() == 0
+  assert db.execute(
+    chat_search.sql(
+      "SELECT count(*) FROM chat_search_state WHERE chat_id = :chat_id"
+    ),
+    {"chat_id": chat_id},
+  ).scalar_one() == 0
 
 
 def test_expired_tombstone_purge_does_not_hydrate_transcript_json(

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -423,6 +423,10 @@ export const api = {
   },
   chats: {
     list: (options = {}) => apiFetch('/chats', options),
+    search: (query, options = {}) => apiFetch(
+      `/chats/search?q=${encodeURIComponent(query)}`,
+      { timeoutMs: 10000, ...options },
+    ),
     create: (payload, options = {}) => listAffectingMutation('chats', '/chats', {
       ...options,
       method: 'POST',
@@ -433,10 +437,11 @@ export const api = {
       method: 'POST',
       body: JSON.stringify(payload),
     }),
-    detail: (chatId, { limit, compact, signal, timeoutMs } = {}) => {
+    detail: (chatId, { limit, compact, anchor, signal, timeoutMs } = {}) => {
       const params = new URLSearchParams()
       if (limit !== undefined) params.set('limit', String(limit))
       if (compact !== undefined) params.set('compact', compact ? '1' : '0')
+      if (anchor) params.set('anchor', String(anchor))
       const query = params.toString()
       return apiFetch(
         `/chats/${chatId}${query ? `?${query}` : ''}`,

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -370,6 +370,34 @@
   align-items: flex-start;
 }
 
+/* A search jump is a one-shot held position, not a new scrolling mode. The
+   restrained row wash and text highlight make the destination legible without
+   competing with ordinary user/assistant surfaces. */
+.chat__msg--search-reveal {
+  animation: chat-search-reveal 2.6s ease-out both;
+}
+
+.chat__msg--search-reveal .chat__text::highlight(chat-search-result) {
+  color: inherit;
+  background-color: color-mix(in srgb, var(--accent) 34%, transparent);
+}
+
+.chat__msg--search-reveal:focus { outline: none; }
+.chat__msg--search-reveal:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+  border-radius: 6px;
+}
+
+@keyframes chat-search-reveal {
+  0%, 55% { filter: drop-shadow(0 0 0.55rem color-mix(in srgb, var(--accent) 45%, transparent)); }
+  100% { filter: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chat__msg--search-reveal { animation: none; }
+}
+
 /* Tap-to-show message metadata. User timestamps and copy share one row, while
    assistant rows show the copy action alone. ChatView clears the visible state
    automatically after a short glance, so the row never remains expanded. */

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -73,6 +73,16 @@ import {
   messageMatchesKey,
   optimisticHandoffWindow,
 } from '../../lib/chatDetailCache.js'
+import {
+  chatSearchRevealFor,
+  clearChatSearchReveal,
+  consumeChatSearchActivation,
+  reconcileChatSearchActivation,
+  subscribeChatSearchReveal,
+} from '../../lib/chatSearchReveal.js'
+import {
+  highlightSearchTerms,
+} from '../../lib/searchTermHighlight.js'
 import { composerHistoryFromMessages } from './composerHistory.js'
 import { sendFailureMessage } from './sendFailure.js'
 import { assistantStreamCoversMessage, chooseActiveAssistantDataKey, findTrailingAssistantPartialIndex, streamItemsHaveRenderableContent } from './streamPromotion.js'
@@ -278,6 +288,30 @@ export default function ChatView({
   const queryClient = useQueryClient()
   const hiddenRef = useRef(hidden)
   hiddenRef.current = hidden
+  // A drawer search may target a ChatView that is already mounted. Subscribe
+  // to its tiny transient intent store so same-chat searches do not require a
+  // route/remount to run the anchor reveal.
+  const [, setSearchRevealVersion] = useState(0)
+  const searchActivationRef = useRef(null)
+  searchActivationRef.current = reconcileChatSearchActivation(
+    searchActivationRef.current,
+    chatId,
+    chatSearchRevealFor(chatId),
+  )
+  useEffect(() => subscribeChatSearchReveal(chatId, () => {
+    const next = reconcileChatSearchActivation(
+      searchActivationRef.current,
+      chatId,
+      chatSearchRevealFor(chatId),
+    )
+    if (next === searchActivationRef.current) return
+    searchActivationRef.current = next
+    setSearchRevealVersion(version => version + 1)
+  }), [chatId])
+  const searchReveal = searchActivationRef.current.reveal
+  const searchRevealConsumed = searchActivationRef.current.consumedId === searchReveal?.id
+  const searchRevealCleanupRef = useRef(() => {})
+  useEffect(() => () => searchRevealCleanupRef.current(), [])
   const inputRef = useRef(null)
   const handleInternalNav = useCallback((url) => {
     onInternalNav?.(url)
@@ -320,10 +354,11 @@ export default function ChatView({
   // saved coordinate; an incomplete restoration window stays hidden until the
   // anchor-addressed read repairs or retires that coordinate.
   const initialSavedAnchorKey = savedReadingAnchorKey(chatId)
+  const initialActivationAnchorKey = searchReveal?.anchorKey || initialSavedAnchorKey
   const initialCacheEntryState = chatCacheEntryState(
     cached,
-    initialSavedAnchorKey,
-    savedReadingAnchorHasNestedPart(chatId),
+    initialActivationAnchorKey,
+    !searchReveal && savedReadingAnchorHasNestedPart(chatId),
   )
   const [loading, setLoading] = useState(initialCacheEntryState === 'missing')
   const [initialEntryPhase, setInitialEntryPhase] = useState(
@@ -729,6 +764,7 @@ export default function ChatView({
     freezeQuestionSubmission,
     freezeQueuedSubmission,
     revealConversationTail,
+    revealAnchor,
     reapplyActiveMode,
     settleSendIntent,
     settleStreamingPin,
@@ -1638,11 +1674,17 @@ export default function ChatView({
     const queryKey = chatMessagesQueryKey(chatId)
     const activationCache = queryClient.getQueryData(queryKey)
     const savedAnchorKey = savedReadingAnchorKey(chatId)
+    const searchAnchorKey = searchReveal?.anchorKey || null
+    // A search selection is a deliberate one-shot navigation, so it wins over
+    // the stored reader coordinate for this activation. It never remaps or
+    // retires that saved position.
+    const activationAnchorKey = searchAnchorKey || savedAnchorKey
+    const searchActivation = !!searchAnchorKey
     const anchorMatchIn = (snapshot) => {
-      if (!savedAnchorKey || !Array.isArray(snapshot?.messages)) return null
+      if (!activationAnchorKey || !Array.isArray(snapshot?.messages)) return null
       const baseOffset = Number.isInteger(snapshot.offset) ? snapshot.offset : 0
       const localIndex = snapshot.messages.findIndex((message, index) => (
-        messageMatchesKey(message, baseOffset + index, savedAnchorKey)
+        messageMatchesKey(message, baseOffset + index, activationAnchorKey)
       ))
       if (localIndex < 0) return null
       const messageIndex = baseOffset + localIndex
@@ -1652,16 +1694,16 @@ export default function ChatView({
       }
     }
     const remapAnchorMatch = (match) => {
-      if (match?.canonicalKey && match.canonicalKey !== savedAnchorKey) {
+      if (!searchActivation && match?.canonicalKey && match.canonicalKey !== savedAnchorKey) {
         remapSavedReadingAnchor(chatId, savedAnchorKey, match.canonicalKey)
       }
     }
     const activationAnchorMatch = anchorMatchIn(activationCache)
-    const cacheCoversSavedAnchor = !savedAnchorKey || !!activationAnchorMatch
+    const cacheCoversSavedAnchor = !activationAnchorKey || !!activationAnchorMatch
     const activationCacheEntryState = chatCacheEntryState(
       activationCache,
-      savedAnchorKey,
-      savedReadingAnchorHasNestedPart(chatId),
+      activationAnchorKey,
+      !searchActivation && savedReadingAnchorHasNestedPart(chatId),
     )
     remapAnchorMatch(activationAnchorMatch)
     chatIdStaleRef.current = false
@@ -1742,7 +1784,7 @@ export default function ChatView({
         // captured object can never overwrite the fresher publication.
         const latestCache = queryClient.getQueryData(queryKey)
         const latestAnchorMatch = anchorMatchIn(latestCache)
-        const latestCoversSavedAnchor = !savedAnchorKey || !!latestAnchorMatch
+        const latestCoversSavedAnchor = !activationAnchorKey || !!latestAnchorMatch
         remapAnchorMatch(latestAnchorMatch)
         if (latestCoversSavedAnchor && chatSnapshotMatchesRuntime(latestCache, runtime)) {
           detailCache = latestCache
@@ -1750,28 +1792,32 @@ export default function ChatView({
         }
       }
       if (!reused) {
-        const anchorParam = savedAnchorKey
-          ? `&anchor=${encodeURIComponent(savedAnchorKey)}`
+        const anchorParam = activationAnchorKey
+          ? `&anchor=${encodeURIComponent(activationAnchorKey)}`
           : ''
         runtime = await requestJson(
           `/chats/${chatId}?limit=20&compact=1${anchorParam}`,
           'CHAT_LOAD_FAILED',
         )
         const runtimeAnchorMatch = anchorMatchIn(runtime)
-        if (savedAnchorKey && runtime.requested_anchor_found === true) {
+        if (activationAnchorKey && runtime.requested_anchor_found === true) {
           if (!runtimeAnchorMatch) {
             throw new Error('CHAT_READING_ANCHOR_NOT_FOUND')
           }
           remapAnchorMatch(runtimeAnchorMatch)
-        } else if (savedAnchorKey && runtime.requested_anchor_found === false) {
+        } else if (activationAnchorKey && runtime.requested_anchor_found === false) {
           // Only the authoritative false + absent-row combination proves that
           // the durable coordinate is gone. A contradictory response is a
           // protocol error; retiring on it would destroy a valid location.
           if (runtimeAnchorMatch) {
             throw new Error('CHAT_READING_ANCHOR_NOT_FOUND')
           }
-          retireSavedReadingPosition(chatId)
-          anchorRetired = true
+          if (!searchActivation) {
+            retireSavedReadingPosition(chatId)
+            anchorRetired = true
+          } else {
+            clearChatSearchReveal(chatId, searchReveal?.id)
+          }
         } else {
           // Rolling servers may omit the coverage bit. A row that is present
           // can still be canonicalized safely; absence without the bit cannot.
@@ -1958,7 +2004,7 @@ export default function ChatView({
       loadingOlder.current = false
       disconnect()
     }
-  }, [chatId, loadNonce, hidden])
+  }, [chatId, loadNonce, hidden, searchReveal?.id, searchReveal?.anchorKey])
 
 
   // Paginate older messages. Captures a pre-prepend anchor so we can
@@ -3559,6 +3605,62 @@ export default function ChatView({
   const displayReady = activationSettled
     && !loading
     && (transcriptPaintable || showEmpty || showLoadError)
+
+  // The requested server window contains the matching row through the tail.
+  // Resolve the result's alias only after validation made the visible transcript
+  // paintable. The saved reading coordinate stays untouched until the owner
+  // next scrolls or otherwise chooses a new position.
+  useLayoutEffect(() => {
+    if (!searchReveal || searchRevealConsumed || !displayReady) return
+    if (hidden) {
+      // More than one physical ChatView can retain this logical chat. A hidden
+      // copy must neither reveal nor consume the one intent; the visible copy
+      // owns it, and the TTL clears a navigation that never becomes visible.
+      return
+    }
+    const localIndex = messages.findIndex((message, index) => (
+      messageMatchesKey(message, offset + index, searchReveal.anchorKey)
+    ))
+    if (localIndex < 0) return
+    const canonicalKey = messageKey(messages[localIndex], offset + localIndex)
+    const row = [...(scrollRef.current?.querySelectorAll('.chat__msg[data-key]') || [])]
+      .find(element => element.dataset.key === canonicalKey)
+    if (!canonicalKey || !row) return
+
+    searchRevealCleanupRef.current()
+    row.classList.add('chat__msg--search-reveal')
+    const highlight = highlightSearchTerms(row, searchReveal.terms)
+    row.focus({ preventScroll: true })
+    if (!revealAnchor(canonicalKey, 96, highlight.firstRange)) {
+      row.classList.remove('chat__msg--search-reveal')
+      highlight.clear()
+      return
+    }
+    const timer = setTimeout(() => {
+      row.classList.remove('chat__msg--search-reveal')
+      highlight.clear()
+    }, 2600)
+    searchRevealCleanupRef.current = () => {
+      clearTimeout(timer)
+      row.classList.remove('chat__msg--search-reveal')
+      highlight.clear()
+    }
+    searchActivationRef.current = consumeChatSearchActivation(
+      searchActivationRef.current,
+      searchReveal.id,
+    )
+    clearChatSearchReveal(chatId, searchReveal.id)
+  }, [
+    chatId,
+    displayReady,
+    hidden,
+    messages,
+    offset,
+    revealAnchor,
+    searchReveal,
+    searchRevealConsumed,
+  ])
+
   useLayoutEffect(() => {
     if (displayReady) onDisplayReady?.(chatId)
   }, [chatId, displayReady, onDisplayReady])
@@ -4003,6 +4105,7 @@ export default function ChatView({
             <li
               key={userCid || msg.id || msg.ts || `${msg.role}-${i}`}
               className={`chat__msg chat__msg--${continuationMarker ? 'marker' : msg.role}`}
+              tabIndex={-1}
               ref={i === lastUserIdx ? setLastUserMsgRef : null}
               data-key={dataKey}
               data-anchor-key={anchorKey === dataKey ? undefined : anchorKey}

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -1252,6 +1252,10 @@ export default function useScrollMode({
   // used the automatic latest-message fallback. Passive lifecycle/viewport
   // changes must not promote that fallback into a saved reading position.
   const readerLocationExplicitRef = useRef(false)
+  // A drawer result is navigation, not a new saved reading location. Preserve
+  // the owner's prior coordinate until they actively scroll or send from the
+  // revealed row.
+  const transientSearchRevealRef = useRef(false)
   // A saved location existed but this visit could not resolve it (its row or
   // part was not in the committed window yet). That is a RETRIEVAL failure,
   // not the reader choosing the tail — so the automatic tail fallback must not
@@ -1437,6 +1441,7 @@ export default function useScrollMode({
   const persistMode = useCallback(({ freezeToCurrentPosition = false } = {}) => {
     try {
       if (!readingPositionOwnerRef.current) return
+      if (transientSearchRevealRef.current) return
       if (!readerLocationExplicitRef.current) {
         // Keep a stored location this visit merely failed to resolve. Only an
         // absent location — never a retrieval failure — may be cleared here.
@@ -1540,6 +1545,7 @@ export default function useScrollMode({
     isFirstUserMsg = false,
     previousIntent = null,
   } = {}) => {
+    transientSearchRevealRef.current = false
     const readerIntentVersion = readerIntentVersionRef.current
     const willPinNow = canPin && shouldPinSend({
       scrollEl: scrollRef.current,
@@ -1627,6 +1633,35 @@ export default function useScrollMode({
       'reader:paginate-anchor',
     )
   }, [transitionMode])
+
+  /** One held search result reveal; unlike a reader gesture it is never
+   * persisted over the owner's saved location. */
+  const revealAnchor = useCallback((key, offset = 96, exactTarget = null) => {
+    const scrollEl = scrollRef.current
+    const row = _anchorRow(scrollEl, key)
+    if (!scrollEl || !row) return false
+    let anchorOffset = offset
+    const targetRect = exactTarget?.getBoundingClientRect?.()
+    const rowRect = row.getBoundingClientRect?.()
+    if (Number.isFinite(targetRect?.top) && Number.isFinite(rowRect?.top)) {
+      const targetDelta = clientDeltaToLayout(
+        { x: 0, y: targetRect.top - rowRect.top },
+        captureLayoutSpace(scrollEl),
+      ).y
+      if (Number.isFinite(targetDelta)) anchorOffset -= targetDelta
+    }
+    supersedePendingReaderGesture()
+    transientSearchRevealRef.current = true
+    readerLocationExplicitRef.current = false
+    const mode = transitionMode(
+      { kind: 'ANCHOR_AT', key: row.dataset.key, offset: anchorOffset },
+      'search:reveal-anchor',
+    )
+    const authorityVersion = readerIntentVersionRef.current
+    writeMode(scrollEl, mode, 'search:reveal-anchor', authorityVersion)
+    lastAppliedModeRef.current = mode
+    return true
+  }, [scrollRef, supersedePendingReaderGesture, transitionMode, writeMode])
 
   const freezeForegroundReturn = useCallback(() => {
     const nextMode = modeForForegroundReturn(scrollRef.current)
@@ -2473,6 +2508,7 @@ export default function useScrollMode({
       if (!userDriven) {
         return
       }
+      transientSearchRevealRef.current = false
       const distanceToBottom = scrollEl.scrollHeight
         - scrollEl.scrollTop
         - scrollEl.clientHeight
@@ -2741,6 +2777,7 @@ export default function useScrollMode({
     freezeQuestionSubmission,
     freezeQueuedSubmission,
     revealConversationTail,
+    revealAnchor,
     reapplyActiveMode,
     settleSendIntent,
     settleStreamingPin,

--- a/frontend/src/components/Drawer/Drawer.css
+++ b/frontend/src/components/Drawer/Drawer.css
@@ -204,6 +204,101 @@
   background: var(--surface);
 }
 
+/* Search is a compact, fixed navigation control: results remain close to the
+   query while the ordinary recents list keeps its single scroll owner. */
+.drawer__chat-search {
+  position: relative;
+  z-index: 3;
+  margin: 6px 0 2px;
+}
+
+.drawer__chat-search-input {
+  min-height: 38px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 10px;
+  border: 1px solid var(--border-light);
+  border-radius: 10px;
+  color: var(--muted);
+  background: var(--surface);
+}
+
+.drawer__chat-search-input svg {
+  flex: 0 0 auto;
+  width: 17px;
+  height: 17px;
+}
+
+.drawer__chat-search-input input {
+  width: 100%;
+  min-width: 0;
+  border: 0;
+  outline: 0;
+  color: var(--text);
+  background: transparent;
+  font: inherit;
+  font-size: 14px;
+}
+
+.drawer__chat-search-input:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-dim);
+}
+
+.drawer__chat-search-results {
+  display: grid;
+  gap: 3px;
+  max-height: min(42dvh, 320px);
+  margin-top: 5px;
+  padding: 4px;
+  overflow-y: auto;
+  border: 1px solid var(--border-light);
+  border-radius: 10px;
+  background: var(--surface);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.16);
+}
+
+.drawer__chat-search-result {
+  width: 100%;
+  display: grid;
+  gap: 2px;
+  padding: 8px;
+  border: 0;
+  border-radius: 7px;
+  color: var(--text);
+  background: transparent;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.drawer__chat-search-result:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .drawer__chat-search-result:hover { background: var(--surface2); }
+}
+
+.drawer__chat-search-title,
+.drawer__chat-search-snippet {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.drawer__chat-search-title { font-size: 13px; font-weight: 600; }
+.drawer__chat-search-snippet,
+.drawer__chat-search-status { color: var(--muted); font-size: 12px; line-height: 1.35; }
+.drawer__chat-search-status { margin: 5px 6px; }
+.drawer__chat-search-snippet mark {
+  padding: 0;
+  color: inherit;
+  background: color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
 /* ── Navigation sections ──────────────────────────── */
 
 .drawer__group {

--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -9,8 +9,11 @@ import { useHistoryDismiss } from '../../hooks/useHistoryDismiss.jsx'
 import {
   AppsNavIcon,
   NewChatNavIcon,
+  SearchNavIcon,
   SettingsNavIcon,
 } from '../navigationIcons.js'
+import { requestChatSearchReveal } from '../../lib/chatSearchReveal.js'
+import { searchSnippetPresentation } from '../../lib/searchTermHighlight.js'
 import { appIconUrl } from '../appIcon.js'
 import {
   computePinnedDrag,
@@ -65,6 +68,7 @@ import './Drawer.css'
 // downstream.
 const EMPTY_SET = new Set()
 const TOUCH_CONTEXT_MENU_PROVENANCE_MS = 1500
+const SEARCH_DEBOUNCE_MS = 180
 
 export default function Drawer({
   open,
@@ -336,6 +340,12 @@ export default function Drawer({
   // rather than in Shell so this stays drawer-local.
   const [installingApp, setInstallingApp] = useState(null)
   const [appQuery, setAppQuery] = useState('')
+  const [chatSearchQuery, setChatSearchQuery] = useState('')
+  const [chatSearchState, setChatSearchState] = useState({
+    query: '', status: 'idle', results: [],
+  })
+  const latestChatSearchQueryRef = useRef('')
+  const chatSearchControllerRef = useRef(null)
   const appsButtonRef = useRef(null)
   const filteredApps = useMemo(
     () => filterInstalledApps(sortedApps, appQuery),
@@ -373,6 +383,79 @@ export default function Drawer({
     window.addEventListener('pageshow', closeOnReshow)
     return () => window.removeEventListener('pageshow', closeOnReshow)
   }, [])
+
+  // Search deliberately stays drawer-local. Results carry the exact normalized
+  // query that produced them, so the first render of a changed input cannot
+  // leave the previous response actionable during the debounce window.
+  useEffect(() => {
+    const query = chatSearchQuery.trim()
+    chatSearchControllerRef.current?.abort()
+    chatSearchControllerRef.current = null
+    if (!query) {
+      setChatSearchState({ query: '', status: 'idle', results: [] })
+      return undefined
+    }
+    const controller = new AbortController()
+    chatSearchControllerRef.current = controller
+    setChatSearchState({ query, status: 'loading', results: [] })
+    const timer = setTimeout(async () => {
+      try {
+        const response = await api.chats.search(query, { signal: controller.signal })
+        if (!response.ok) throw new Error(`CHAT_SEARCH_${response.status}`)
+        const results = await response.json()
+        if (!controller.signal.aborted && chatSearchControllerRef.current === controller) {
+          setChatSearchState({
+            query,
+            status: 'ready',
+            results: (Array.isArray(results) ? results : []).map(result => {
+              const snippet = searchSnippetPresentation(result.snippet)
+              return {
+                ...result,
+                searchQuery: query,
+                searchTerms: snippet.terms,
+                snippetParts: snippet.parts,
+              }
+            }),
+          })
+        }
+      } catch (error) {
+        if (error?.name !== 'AbortError'
+            && !controller.signal.aborted
+            && chatSearchControllerRef.current === controller) {
+          setChatSearchState({ query, status: 'error', results: [] })
+        }
+      }
+    }, SEARCH_DEBOUNCE_MS)
+    return () => {
+      clearTimeout(timer)
+      controller.abort()
+      if (chatSearchControllerRef.current === controller) {
+        chatSearchControllerRef.current = null
+      }
+    }
+  }, [chatSearchQuery])
+
+  useEffect(() => () => chatSearchControllerRef.current?.abort(), [])
+
+  const selectChatSearchResult = useCallback((result) => {
+    if (!result || result.searchQuery !== latestChatSearchQueryRef.current) return
+    resetAppsSurfaceUi({ restoreFocus: false })
+    const reveal = result.anchor_key
+      ? requestChatSearchReveal(result.id, {
+          anchorKey: result.anchor_key,
+          terms: result.searchTerms,
+        })
+      : null
+    // Exact transcript hits transfer focus to the addressed row. A title-only
+    // result has no row to receive focus, so use the ordinary composer handoff
+    // rather than leaving focus on a drawer button that is about to unmount.
+    onChat(result.id, { focusComposer: !reveal })
+  }, [onChat, resetAppsSurfaceUi])
+
+  const normalizedChatSearchQuery = chatSearchQuery.trim()
+  const visibleChatSearch = chatSearchState.query === normalizedChatSearchQuery
+    ? chatSearchState
+    : { query: normalizedChatSearchQuery, status: 'loading', results: [] }
 
   // Rows receive one stable action surface instead of a new closure for every
   // action on every item. The ref supplies the latest props and local helpers,
@@ -1022,6 +1105,54 @@ export default function Drawer({
               </span>
               <span className="drawer__item-text">New chat</span>
             </button>
+
+            <section className="drawer__chat-search" aria-label="Search chats">
+              <label className="drawer__chat-search-input">
+                <SearchNavIcon aria-hidden="true" />
+                <input
+                  type="search"
+                  value={chatSearchQuery}
+                  onChange={event => {
+                    latestChatSearchQueryRef.current = event.target.value.trim()
+                    setChatSearchQuery(event.target.value)
+                  }}
+                  placeholder="Search chats"
+                  aria-label="Search chats"
+                />
+              </label>
+              {chatSearchQuery.trim() && (
+                <div className="drawer__chat-search-results" aria-live="polite">
+                  {visibleChatSearch.status === 'loading' && (
+                    <p className="drawer__chat-search-status">Searching chats…</p>
+                  )}
+                  {visibleChatSearch.status === 'error' && (
+                    <p className="drawer__chat-search-status">Search is unavailable right now.</p>
+                  )}
+                  {visibleChatSearch.status === 'ready' && visibleChatSearch.results.length === 0 && (
+                    <p className="drawer__chat-search-status">No matching chats.</p>
+                  )}
+                  {visibleChatSearch.results.map(result => (
+                    <button
+                      key={result.id}
+                      type="button"
+                      className="drawer__chat-search-result"
+                      onClick={() => selectChatSearchResult(result)}
+                    >
+                      <span className="drawer__chat-search-title">{result.title || 'Untitled chat'}</span>
+                      {result.snippet && (
+                        <span className="drawer__chat-search-snippet">
+                          {result.snippetParts.map((part, index) => (
+                            part.marked
+                              ? <mark key={index}>{part.text}</mark>
+                              : <span key={index}>{part.text}</span>
+                          ))}
+                        </span>
+                      )}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </section>
 
             <div className="drawer__scroll drawer__scroll--navigation" ref={navigationScrollRef}>
               <button

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -2738,7 +2738,7 @@ export default function Shell() {
   }, [pendingNewChatToken, materializeNewChatRevision, modeView.active, modeState.transition,
       workspace.viewMode, workspace.singleScreen, workspaceStateRef])
 
-  function selectChat(id) {
+  function selectChat(id, { focusComposer = true } = {}) {
     const chatId = String(id)
     const paintedWorld = effectiveViewMode === 'single'
       ? STANDARD_CHAT_WORLD
@@ -2753,7 +2753,7 @@ export default function Shell() {
       && !destinationAlreadyPainted
     clearChatAttention(id)
     navTo('chat', { chatId: id, preserveDrawerPresentation })
-    focusDesktopChatPaneComposer(id)
+    if (focusComposer) focusDesktopChatPaneComposer(id)
   }
 
   async function deleteChat(id) {

--- a/frontend/src/components/Shell/__tests__/chatHandoff.test.js
+++ b/frontend/src/components/Shell/__tests__/chatHandoff.test.js
@@ -5,6 +5,7 @@ import assert from 'node:assert/strict'
 const shell = readFileSync(new URL('../Shell.jsx', import.meta.url), 'utf8')
 const shellCss = readFileSync(new URL('../Shell.css', import.meta.url), 'utf8')
 const paneChatView = readFileSync(new URL('../PaneChatView.jsx', import.meta.url), 'utf8')
+const drawer = readFileSync(new URL('../../Drawer/Drawer.jsx', import.meta.url), 'utf8')
 const drawerCss = readFileSync(new URL('../../Drawer/Drawer.css', import.meta.url), 'utf8')
 const indexCss = readFileSync(new URL('../../../index.css', import.meta.url), 'utf8')
 const chatSurfaceModel = readFileSync(new URL('../chatSurfaceModel.js', import.meta.url), 'utf8')
@@ -12,6 +13,7 @@ const workspaceChrome = readFileSync(new URL('../WorkspaceChrome.jsx', import.me
 const chatView = readFileSync(new URL('../../ChatView/ChatView.jsx', import.meta.url), 'utf8')
 const scrollMode = readFileSync(new URL('../../ChatView/useScrollMode.js', import.meta.url), 'utf8')
 const detailCache = readFileSync(new URL('../../../lib/chatDetailCache.js', import.meta.url), 'utf8')
+const searchTermHighlight = readFileSync(new URL('../../../lib/searchTermHighlight.js', import.meta.url), 'utf8')
 const apiClient = readFileSync(new URL('../../../api/client.js', import.meta.url), 'utf8')
 
 function ruleBody(selector, source = shellCss) {
@@ -87,11 +89,31 @@ test('activation holds an unchanged running transcript until stream catch-up', (
     /if \(reused\) \{[\s\S]*updateChatRuntimeCache[\s\S]*applyMessagesToView\(msgs, detailCache\.offset\)[\s\S]*settleRuntime\(runtime, msgs\)[\s\S]*return/,
     'the fast path must reconcile a retained hidden owner before revealing it',
   )
-  assert.match(initialLoad,
-    /anchorParam = savedAnchorKey[\s\S]*&anchor=\$\{encodeURIComponent\(savedAnchorKey\)\}/,
-    'every authoritative return read must contain the exact saved row')
   assert.match(chatView,
-    /messageMatchesKey\(message, baseOffset \+ index, savedAnchorKey\)[\s\S]*remapSavedReadingAnchor/,
+    /activationAnchorKey = searchAnchorKey \|\| savedAnchorKey/,
+    'search navigation takes precedence over the saved reading row for one activation')
+  assert.match(drawer,
+    /chatSearchState\.query === normalizedChatSearchQuery[\s\S]*results: \[\]/,
+    'a changed query must hide stale result buttons before debounce completes')
+  assert.match(drawer,
+    /result\.searchQuery !== latestChatSearchQueryRef\.current/,
+    'a stale result handler must also reject an activation after input changes')
+  assert.match(drawer,
+    /searchSnippetPresentation\(result\.snippet\)[\s\S]*searchTerms: snippet\.terms/,
+    'the server-marked visible snippet, not a second query parser, owns destination terms')
+  assert.match(chatView,
+    /reconcileChatSearchActivation\([\s\S]*const searchRevealConsumed[\s\S]*if \(!searchReveal \|\| searchRevealConsumed \|\| !displayReady\) return[\s\S]*consumeChatSearchActivation\([\s\S]*clearChatSearchReveal/,
+    'consumption stays latched to the searched activation instead of reloading its saved anchor')
+  assert.match(chatView,
+    /highlightSearchTerms\(row, searchReveal\.terms\)[\s\S]*row\.focus\(\{ preventScroll: true \}\)[\s\S]*revealAnchor\(canonicalKey, 96, highlight\.firstRange\)/,
+    'a validated visible destination focuses and positions the exact marked word')
+  assert.doesNotMatch(searchTermHighlight, /replaceWith\(|createElement\(['"]mark['"]\)/,
+    'search emphasis must never rewrite React-owned transcript text')
+  assert.match(initialLoad,
+    /anchorParam = activationAnchorKey[\s\S]*&anchor=\$\{encodeURIComponent\(activationAnchorKey\)\}/,
+    'every authoritative return read must contain the exact saved or searched row')
+  assert.match(chatView,
+    /messageMatchesKey\(message, baseOffset \+ index, activationAnchorKey\)[\s\S]*!searchActivation[\s\S]*remapSavedReadingAnchor/,
     'cache and server rows must resolve every durable alias before canonicalizing it')
   assert.match(initialLoad,
     /runtime\.requested_anchor_found === false[\s\S]*if \(runtimeAnchorMatch\)[\s\S]*CHAT_READING_ANCHOR_NOT_FOUND[\s\S]*retireSavedReadingPosition\(chatId\)[\s\S]*anchorRetired = true/,
@@ -242,10 +264,18 @@ test('direct chat actions hand focus to the destination composer', () => {
   assert.match(shell,
     /className="shell__composer-focus-lease"[\s\S]*?aria-label="New chat message"/,
     'the keyboard lease must remain a named, programmatically focused text control')
-  const selectChat = shell.match(/function selectChat\(id\) \{([\s\S]*?)\n  \}/)?.[1] || ''
+  const selectChat = shell.match(
+    /function selectChat\(id, \{ focusComposer = true \} = \{\}\) \{([\s\S]*?)\n  \}/,
+  )?.[1] || ''
   assert.match(selectChat,
-    /navTo\('chat', \{ chatId: id, preserveDrawerPresentation \}\)[\s\S]*focusDesktopChatPaneComposer\(id\)/,
+    /navTo\('chat', \{ chatId: id, preserveDrawerPresentation \}\)[\s\S]*if \(focusComposer\) focusDesktopChatPaneComposer\(id\)/,
     'drawer and settings chat selection must focus after requesting navigation')
+  assert.match(drawer,
+    /selectChatSearchResult[\s\S]*const reveal = result\.anchor_key[\s\S]*onChat\(result\.id, \{ focusComposer: !reveal \}\)/,
+    'search focuses an exact message row and gives title-only results a composer fallback')
+  assert.match(chatView,
+    /className=\{`chat__msg[\s\S]*tabIndex=\{-1\}/,
+    'message rows must accept the programmatic search focus without joining tab order')
   assert.match(shell,
     /onActivate=\{\(\) => \{[\s\S]*tabModel\.tabNavTarget\(tab\)[\s\S]*navTo\(view, opts\)[\s\S]*tab\.kind === 'chat'[\s\S]*focusDesktopChatPaneComposer\(tab\.id\)/,
     'the single-pane tab strip must focus a selected chat composer')

--- a/frontend/src/components/Shell/__tests__/newChatPolicy.test.js
+++ b/frontend/src/components/Shell/__tests__/newChatPolicy.test.js
@@ -274,7 +274,7 @@ test('a created chat enters the cache without displacing pinned chats', () => {
 
 test('ordinary chat selection does not launch a competing drawer refresh', () => {
   const selectChat = shellSource.match(
-    /function selectChat\(id\) \{([\s\S]*?)\n  \}/,
+    /function selectChat\(id, \{ focusComposer = true \} = \{\}\) \{([\s\S]*?)\n  \}/,
   )?.[1] || ''
   assert.match(selectChat,
     /navTo\('chat', \{ chatId: id, preserveDrawerPresentation \}\)/)

--- a/frontend/src/components/navigationIcons.js
+++ b/frontend/src/components/navigationIcons.js
@@ -5,5 +5,6 @@ export {
   Chat as ChatNavIcon,
   ComposeEditSquare as NewChatNavIcon,
   Grid as AppsNavIcon,
+  MagnifyingGlassSearch as SearchNavIcon,
   SettingsSlider as SettingsNavIcon,
 } from '@openai/apps-sdk-ui/components/Icon'

--- a/frontend/src/lib/__tests__/chatSearchReveal.test.js
+++ b/frontend/src/lib/__tests__/chatSearchReveal.test.js
@@ -1,0 +1,79 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  CHAT_SEARCH_REVEAL_TTL_MS,
+  chatSearchRevealFor,
+  clearChatSearchReveal,
+  consumeChatSearchActivation,
+  reconcileChatSearchActivation,
+  requestChatSearchReveal,
+  subscribeChatSearchReveal,
+} from '../chatSearchReveal.js'
+
+test('search reveal is transient and only its matching request may clear it', () => {
+  const first = requestChatSearchReveal('chat-1', {
+    anchorKey: 'assistant-12', terms: ['wombat'],
+  })
+  const second = requestChatSearchReveal('chat-1', {
+    anchorKey: 'user-13', terms: ['capybara'],
+  })
+  assert.equal(clearChatSearchReveal('chat-1', first.id), false)
+  assert.equal(chatSearchRevealFor('chat-1').anchorKey, 'user-13')
+  assert.equal(clearChatSearchReveal('chat-1', second.id), true)
+  assert.equal(chatSearchRevealFor('chat-1'), null)
+
+  let activation = reconcileChatSearchActivation(null, 'chat-1', second)
+  activation = consumeChatSearchActivation(activation, second.id)
+  activation = reconcileChatSearchActivation(activation, 'chat-1', null)
+  assert.equal(activation.reveal.id, second.id,
+    'consumption keeps this activation on the searched row after store cleanup')
+  activation = reconcileChatSearchActivation(activation, 'chat-2', null)
+  assert.equal(activation.reveal, null, 'a chat change clears the captured activation')
+})
+
+test('mounted chat listeners receive a same-chat search intent', () => {
+  let notices = 0
+  const stop = subscribeChatSearchReveal('chat-mounted', () => { notices += 1 })
+  const reveal = requestChatSearchReveal('chat-mounted', {
+    anchorKey: 'user-7', terms: ['needle'],
+  })
+  assert.equal(notices, 1)
+  clearChatSearchReveal('chat-mounted', reveal.id)
+  assert.equal(notices, 2)
+  stop()
+})
+
+test('expiry notifies a mounted chat and an older timer cannot clear its replacement', () => {
+  const originalSetTimeout = globalThis.setTimeout
+  const originalClearTimeout = globalThis.clearTimeout
+  const scheduled = []
+  globalThis.setTimeout = callback => {
+    scheduled.push(callback)
+    return scheduled.length
+  }
+  globalThis.clearTimeout = () => {}
+  let notices = 0
+  const stop = subscribeChatSearchReveal('chat-expired', () => { notices += 1 })
+  try {
+    const first = requestChatSearchReveal('chat-expired', {
+      anchorKey: 'assistant-2', terms: ['old'],
+    })
+    const second = requestChatSearchReveal('chat-expired', {
+      anchorKey: 'assistant-3', terms: ['new'],
+    })
+    assert.ok(first.expiresAt - Date.now() <= CHAT_SEARCH_REVEAL_TTL_MS)
+    assert.ok(second.expiresAt >= first.expiresAt)
+    assert.equal(notices, 2)
+    scheduled[0]()
+    assert.equal(chatSearchRevealFor('chat-expired').id, second.id)
+    assert.equal(notices, 2)
+    scheduled[1]()
+    assert.equal(chatSearchRevealFor('chat-expired'), null)
+    assert.equal(notices, 3)
+  } finally {
+    stop()
+    clearChatSearchReveal('chat-expired')
+    globalThis.setTimeout = originalSetTimeout
+    globalThis.clearTimeout = originalClearTimeout
+  }
+})

--- a/frontend/src/lib/__tests__/searchTermHighlight.test.js
+++ b/frontend/src/lib/__tests__/searchTermHighlight.test.js
@@ -1,0 +1,84 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  highlightSearchTerms,
+  searchSnippetPresentation,
+  searchTextMatches,
+} from '../searchTermHighlight.js'
+
+test('the FTS-marked snippet owns both visible parts and exact destination terms', () => {
+  assert.deepEqual(
+    searchSnippetPresentation('The \ue000Wombat\ue001 takes the \ue000route map\ue001.'),
+    {
+      parts: [
+        { text: 'The ', marked: false },
+        { text: 'Wombat', marked: true },
+        { text: ' takes the ', marked: false },
+        { text: 'route map', marked: true },
+        { text: '.', marked: false },
+      ],
+      terms: ['Wombat', 'route map'],
+    },
+  )
+})
+
+test('exact marked terms produce case-insensitive, non-overlapping text ranges', () => {
+  assert.deepEqual(searchTextMatches('The Wombat route map is open', [
+    'wombat', 'route map',
+  ]), [
+    { start: 4, end: 10, text: 'Wombat' },
+    { start: 11, end: 20, text: 'route map' },
+  ])
+})
+
+test('Custom Highlight ranges leave React-owned text nodes intact and stay bounded', () => {
+  const source = `needle ${'needle '.repeat(180)}`
+  const textNode = {
+    nodeValue: source,
+    parentElement: { closest: () => null },
+  }
+  const ranges = []
+  const registry = new Map()
+  class FakeHighlight {
+    constructor(...items) { this.items = items }
+  }
+  const doc = {
+    defaultView: {
+      NodeFilter: { SHOW_TEXT: 4, FILTER_ACCEPT: 1, FILTER_REJECT: 2 },
+      CSS: { highlights: registry },
+      Highlight: FakeHighlight,
+    },
+    createTreeWalker() {
+      let read = false
+      return {
+        currentNode: null,
+        nextNode() {
+          if (read) return false
+          read = true
+          this.currentNode = textNode
+          return true
+        },
+      }
+    },
+    createRange() {
+      const range = {
+        setStart(node, offset) { this.start = { node, offset } },
+        setEnd(node, offset) { this.end = { node, offset } },
+      }
+      ranges.push(range)
+      return range
+    },
+  }
+  const root = {
+    ownerDocument: doc,
+    querySelectorAll: selector => selector === '.chat__text' ? [{}] : [],
+  }
+
+  const handle = highlightSearchTerms(root, ['needle'])
+  assert.equal(textNode.nodeValue, source)
+  assert.equal(ranges.length, 128)
+  assert.equal(handle.firstRange, ranges[0])
+  assert.equal(registry.get('chat-search-result').items.length, 128)
+  handle.clear()
+  assert.equal(registry.has('chat-search-result'), false)
+})

--- a/frontend/src/lib/chatSearchReveal.js
+++ b/frontend/src/lib/chatSearchReveal.js
@@ -1,0 +1,97 @@
+// A drawer result is navigation plus one short-lived instruction for the
+// transcript already mounted for that chat. Keep it out of URL/state
+// persistence: a search jump must not replace the owner's saved reading
+// position or reappear after a reload.
+const reveals = new Map()
+const listeners = new Map()
+const expiryTimers = new Map()
+let serial = 0
+export const CHAT_SEARCH_REVEAL_TTL_MS = 30_000
+
+function notify(chatId) {
+  for (const listener of listeners.get(String(chatId)) || []) listener()
+}
+
+/** Keep a successfully consumed reveal captured for this ChatView activation.
+ * Removing it from the live store must not re-run activation with the owner's
+ * saved anchor, while expiry of an unconsumed reveal still cancels it. */
+export function reconcileChatSearchActivation(current, chatId, liveReveal) {
+  const id = String(chatId || '')
+  if (!current || current.chatId !== id) {
+    return { chatId: id, reveal: liveReveal || null, consumedId: null }
+  }
+  if (liveReveal) {
+    if (current.reveal?.id === liveReveal.id) return current
+    return { chatId: id, reveal: liveReveal, consumedId: null }
+  }
+  if (current.reveal && current.consumedId !== current.reveal.id) {
+    return { chatId: id, reveal: null, consumedId: null }
+  }
+  return current
+}
+
+export function consumeChatSearchActivation(current, revealId) {
+  if (!current?.reveal || current.reveal.id !== revealId) return current
+  if (current.consumedId === revealId) return current
+  return { ...current, consumedId: revealId }
+}
+
+export function requestChatSearchReveal(chatId, { anchorKey, terms } = {}) {
+  const id = String(chatId || '')
+  if (!id || typeof anchorKey !== 'string' || !anchorKey) return null
+  clearTimeout(expiryTimers.get(id))
+  const reveal = {
+    id: ++serial,
+    anchorKey,
+    terms: Array.isArray(terms) ? [...terms] : [],
+    expiresAt: Date.now() + CHAT_SEARCH_REVEAL_TTL_MS,
+  }
+  reveals.set(id, reveal)
+  const timer = setTimeout(() => {
+    if (reveals.get(id)?.id !== reveal.id) return
+    reveals.delete(id)
+    expiryTimers.delete(id)
+    notify(id)
+  }, CHAT_SEARCH_REVEAL_TTL_MS)
+  timer?.unref?.()
+  expiryTimers.set(id, timer)
+  notify(id)
+  return reveal
+}
+
+export function chatSearchRevealFor(chatId) {
+  const id = String(chatId || '')
+  const reveal = reveals.get(id) || null
+  if (reveal && reveal.expiresAt <= Date.now()) {
+    reveals.delete(id)
+    clearTimeout(expiryTimers.get(id))
+    expiryTimers.delete(id)
+    return null
+  }
+  return reveal
+}
+
+export function clearChatSearchReveal(chatId, revealId = null) {
+  const id = String(chatId || '')
+  const current = reveals.get(id)
+  if (!current || (revealId != null && current.id !== revealId)) return false
+  reveals.delete(id)
+  clearTimeout(expiryTimers.get(id))
+  expiryTimers.delete(id)
+  notify(id)
+  return true
+}
+
+export function subscribeChatSearchReveal(chatId, listener) {
+  const id = String(chatId || '')
+  let set = listeners.get(id)
+  if (!set) {
+    set = new Set()
+    listeners.set(id, set)
+  }
+  set.add(listener)
+  return () => {
+    set.delete(listener)
+    if (set.size === 0) listeners.delete(id)
+  }
+}

--- a/frontend/src/lib/searchTermHighlight.js
+++ b/frontend/src/lib/searchTermHighlight.js
@@ -1,0 +1,103 @@
+export const SEARCH_MARK_OPEN = '\ue000'
+export const SEARCH_MARK_CLOSE = '\ue001'
+const CHAT_SEARCH_HIGHLIGHT_NAME = 'chat-search-result'
+const MAX_HIGHLIGHT_RANGES = 128
+
+function uniqueTerms(terms) {
+  const seen = new Set()
+  return (Array.isArray(terms) ? terms : [])
+    .map(term => String(term || '').trim())
+    .filter(term => {
+      const key = term.toLocaleLowerCase()
+      if (!key || seen.has(key)) return false
+      seen.add(key)
+      return true
+    })
+}
+
+/** Parse the server's FTS sentinels once. The marked text—not a second client
+ * query parser—is the exact visible match contract shared by the result row
+ * and destination transcript. */
+export function searchSnippetPresentation(snippet) {
+  const parts = []
+  const terms = []
+  let marked = false
+  for (const text of String(snippet || '').split(/([\ue000\ue001])/)) {
+    if (text === SEARCH_MARK_OPEN) { marked = true; continue }
+    if (text === SEARCH_MARK_CLOSE) { marked = false; continue }
+    if (!text) continue
+    parts.push({ text, marked })
+    if (marked) terms.push(text)
+  }
+  return { parts, terms: uniqueTerms(terms) }
+}
+
+function escapedExpression(terms) {
+  const alternatives = uniqueTerms(terms)
+    .sort((a, b) => b.length - a.length)
+    .map(term => term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+  return alternatives.length ? new RegExp(alternatives.join('|'), 'giu') : null
+}
+
+/** Pure offset form used by the DOM range builder and its focused tests. */
+export function searchTextMatches(text, terms) {
+  const expression = escapedExpression(terms)
+  if (!expression) return []
+  return [...String(text || '').matchAll(expression)].map(match => ({
+    start: match.index,
+    end: match.index + match[0].length,
+    text: match[0],
+  }))
+}
+
+/** Highlight only rendered prose without replacing React-owned text nodes.
+ * The returned first Range also addresses the exact word for scroll placement.
+ * Unsupported browsers still receive that Range and the caller's row pulse. */
+export function highlightSearchTerms(root, terms) {
+  const doc = root?.ownerDocument
+  const NodeFilterCtor = doc?.defaultView?.NodeFilter
+  if (!root?.querySelectorAll || !doc?.createRange || !NodeFilterCtor) {
+    return { firstRange: null, clear() {} }
+  }
+
+  const ranges = []
+  proseBlocks: for (const prose of root.querySelectorAll('.chat__text')) {
+    const walker = doc.createTreeWalker(prose, NodeFilterCtor.SHOW_TEXT, {
+      acceptNode(node) {
+        if (!node.nodeValue?.trim() || node.parentElement?.closest(
+          'script, style',
+        )) return NodeFilterCtor.FILTER_REJECT
+        return NodeFilterCtor.FILTER_ACCEPT
+      },
+    })
+    while (walker.nextNode()) {
+      const node = walker.currentNode
+      for (const match of searchTextMatches(node.nodeValue, terms)) {
+        const range = doc.createRange()
+        range.setStart(node, match.start)
+        range.setEnd(node, match.end)
+        ranges.push(range)
+        if (ranges.length >= MAX_HIGHLIGHT_RANGES) break proseBlocks
+      }
+    }
+  }
+
+  const registry = doc.defaultView?.CSS?.highlights
+  const HighlightCtor = doc.defaultView?.Highlight
+  const highlight = ranges.length && registry?.set && HighlightCtor
+    ? new HighlightCtor(...ranges)
+    : null
+  if (highlight) registry.set(CHAT_SEARCH_HIGHLIGHT_NAME, highlight)
+
+  let active = true
+  return {
+    firstRange: ranges[0] || null,
+    clear() {
+      if (!active) return
+      active = false
+      if (highlight && registry.get?.(CHAT_SEARCH_HIGHLIGHT_NAME) === highlight) {
+        registry.delete(CHAT_SEARCH_HIGHLIGHT_NAME)
+      }
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- add owner-drawer full-text chat search with fair per-chat ranking, private-message filtering, and one shared drawer-visibility policy
- reveal the exact matching transcript row and highlighted words without mutating React-owned text or the owner's saved reading position
- materialize the drawer's `has_messages` summary so list reads never scan transcript blobs, with writer-owned synchronization and append-only migration `0007_chat_has_messages`
- reconcile changed search documents exactly while preserving stable FTS rows, so same-length replacements stay correct without re-tokenizing an entire unchanged history
- use SQLite FTS5 where available and a portable PostgreSQL-safe candidate/ranking path elsewhere, preserving the same visibility, prefix, snippet, and reveal contract
- purge derived transcript rows in the same transaction as permanent chat deletion

## Dependency
The connector foundation from #613 is merged. This branch is rebuilt directly on current `main`: `0006_connector_capability_identity` remains foundation-owned and this PR appends `0007_chat_has_messages`. The PR now contains only the chat-search delta.

## Validation
- focused rebased backend search/chat/migration/lifecycle suite: 100 passed
- post-hardening search/lifecycle regression suite: 36 passed
- `npm test`: 2,346 frontend unit + 79 hook tests passed
- `npm run lint -- --quiet`: passed
- production and service-worker builds passed
- pre-push privacy, conflict-marker, Python syntax, JSX parse, and frontend-unit gates passed

Not queued: fresh exact-head hosted CI and an independent final review are required before merge.
