### PR TITLE
Inject owner MCP connectors into provider turns

### DIFF
--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -4233,6 +4233,22 @@ async def _run_chat_impl_with_db(
   from app.memory_provider import resolve_recall_binding
   recall_binding = resolve_recall_binding(db)
 
+  # Snapshot owner-managed MCP connections while this request session is still
+  # live. Provider turns can wait for hours, so neither runner may query the
+  # registry after the pool-release boundary below. The detached plan contains
+  # only plain values; a registry/decryption failure degrades this turn to the
+  # provider's native tools instead of breaking chat.
+  try:
+    from app.connectors import build_turn_plan
+    connector_turn_plan = build_turn_plan(db)
+  except Exception:
+    log.warning(
+      "MCP connection snapshot skipped chat_id=%s",
+      chat_id,
+      exc_info=True,
+    )
+    connector_turn_plan = None
+
   # This is deliberately request-scoped rather than part of the immutable
   # snapshot persisted above. On resumed turns `startup_context` is empty.
   if startup_context:
@@ -4387,6 +4403,7 @@ async def _run_chat_impl_with_db(
         goal_continue=goal_continue,
         fallback_goal_objective=fallback_goal_objective,
         run_policy=run_policy,
+        connector_plan=connector_turn_plan,
       )
       new_session_id = runner_result.get("session_id")
       err = runner_result.get("error")
@@ -4551,6 +4568,7 @@ async def _run_chat_impl_with_db(
           else _skills_enabled(settings.data_dir)
         ),
         run_policy=run_policy,
+        connector_plan=connector_turn_plan,
       )
       new_session_id = runner_result.get("session_id")
       err = runner_result.get("error")

--- a/backend/app/claude_sdk_runner.py
+++ b/backend/app/claude_sdk_runner.py
@@ -64,6 +64,7 @@ import os
 import signal
 import shutil
 from collections import deque
+from contextlib import ExitStack
 from typing import Any
 
 from claude_agent_sdk import (
@@ -755,6 +756,7 @@ async def run_claude_sdk_turn(
   agent_settings: dict | None = None,
   skills_enabled: bool = False,
   run_policy=None,
+  connector_plan=None,
 ) -> RunnerResult:
   """Runs one Claude SDK turn and translates SDK messages to Möbius events.
 
@@ -775,6 +777,8 @@ async def run_claude_sdk_turn(
       path can ship without changing what the agent does — skill loads
       are still observed (chip + activity log) whenever a skill does
       load, regardless of this flag.
+    connector_plan: Detached owner-managed MCP configuration built before the
+      request session was released. It is plain data and never queries SQLite.
 
   Returns:
     A dict containing the resulting session ID, final cost, and error.
@@ -1021,15 +1025,51 @@ async def run_claude_sdk_turn(
     # Passed via --settings as inline JSON.
     _cli_settings = {"ultracode": True} if _ultracode else {"disableWorkflows": True}
     options_kwargs["extra_args"] = {"settings": json.dumps(_cli_settings)}
-    options = ClaudeAgentOptions(**options_kwargs)
 
-    client = ClaudeSDKClient(options)
+    # A dict-valued SDK mcp_servers option is serialized directly into the CLI
+    # argv. Keep credentials out of /proc/cmdline by handing Claude an anonymous
+    # 0600 config file path instead. After connect(), replace that fd with
+    # /dev/null but keep its number reserved until teardown: simply closing it
+    # would let the argv-visible path alias an unrelated descriptor later.
+    connector_config_stack = ExitStack()
+    connector_config_handle = None
+    if connector_plan is not None:
+      try:
+        from app.connectors import claude_mcp_config_handle
+        connector_config_handle = connector_config_stack.enter_context(
+          claude_mcp_config_handle(connector_plan)
+        )
+        if connector_config_handle:
+          options_kwargs["mcp_servers"] = connector_config_handle.path
+      except Exception:
+        connector_config_stack.close()
+        connector_config_stack = ExitStack()
+        log.warning(
+          "Claude MCP connection injection skipped chat_id=%s",
+          chat_id,
+          exc_info=True,
+        )
+    try:
+      options = ClaudeAgentOptions(**options_kwargs)
+      client = ClaudeSDKClient(options)
+    except Exception:
+      connector_config_stack.close()
+      raise
+
     active_client = ActiveClaudeClient(client, chat_id=chat_id)
     registry.register(active_client)
 
     try:
       try:
-        await asyncio.wait_for(client.connect(), timeout=30.0)
+        try:
+          await asyncio.wait_for(client.connect(), timeout=30.0)
+        finally:
+          # Claude has consumed the config by the time the control channel is
+          # connected. Destroy its contents before query() gives the model a
+          # shell or process-inspection tool, while reserving the argv-visible
+          # fd number so it cannot alias another live descriptor.
+          if connector_config_handle is not None:
+            connector_config_handle.retire()
       except asyncio.TimeoutError:
         bc.publish({
           "type": "error",
@@ -1277,6 +1317,7 @@ async def run_claude_sdk_turn(
       try:
         await client.disconnect()
       finally:
+        connector_config_stack.close()
         # The SDK closes only its direct CLI PID. Reap the verified private
         # group as a bounded backstop for tool children, and do not let a
         # repeated task cancellation skip the SIGKILL worker once it starts.

--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -1447,6 +1447,7 @@ async def run_codex_sdk_turn(
   goal_continue: bool = False,
   fallback_goal_objective: str | None = None,
   run_policy=None,
+  connector_plan=None,
 ) -> RunnerResult:
   """Runs one Codex SDK turn and publishes Möbius-shaped events.
 
@@ -1462,6 +1463,8 @@ async def run_codex_sdk_turn(
       bridge to park on a future while the user answers.
     db: SQLAlchemy session for durable-chat persistence paths, or None for an
       out-of-band turn with no Chat row (for example nightly Reflection).
+    connector_plan: Detached owner-managed MCP configuration built before the
+      request session was released. It is plain data and never queries SQLite.
 
   Returns:
     Dict with `session_id`, `cost_usd`, and `error`.
@@ -1540,6 +1543,23 @@ async def run_codex_sdk_turn(
 
   env = dict(base_env)
   env.setdefault("CODEX_HOME", "/data/cli-auth/codex")
+
+  # Remote MCP connections are materialized in chat.py while its DB session is
+  # still live. Secrets use Codex's env indirection rather than thread config or
+  # argv; the thread receives only env-variable names. A malformed plan is
+  # local to this optional capability and must not stop the owner from chatting.
+  connector_thread_config = None
+  if connector_plan is not None:
+    try:
+      connector_thread_config = connector_plan.codex_config
+      env.update(connector_plan.codex_env)
+    except Exception:
+      log.warning(
+        "Codex MCP connection injection skipped chat_id=%s",
+        chat_id,
+        exc_info=True,
+      )
+      connector_thread_config = None
 
   # config_overrides always isolates the prompt stack, then carries the
   # request_user_input (AskUserQuestion parity), goal, and multi-agent flags.
@@ -1771,6 +1791,7 @@ async def run_codex_sdk_turn(
           sandbox=_sandbox,
           base_instructions=base_instructions,
           developer_instructions="",
+          config=connector_thread_config,
           cwd=cwd,
           model=model,
           personality=sdk["Personality"].none,
@@ -1789,6 +1810,7 @@ async def run_codex_sdk_turn(
           sandbox=_sandbox,
           base_instructions=base_instructions,
           developer_instructions="",
+          config=connector_thread_config,
           cwd=cwd,
           model=model,
           personality=sdk["Personality"].none,

--- a/backend/app/connectors.py
+++ b/backend/app/connectors.py
@@ -24,7 +24,7 @@ import re
 import tempfile
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import Iterator
+from typing import BinaryIO, Iterator
 from urllib.parse import urlparse
 
 import httpx
@@ -91,6 +91,23 @@ class ConnectorTurnPlan:
 
 
 EMPTY_CONNECTOR_TURN_PLAN = ConnectorTurnPlan()
+
+
+@dataclass
+class ClaudeMcpConfigHandle:
+  """Anonymous startup config whose proc fd stays safely reserved for a turn."""
+
+  path: str
+  _file: BinaryIO = field(repr=False)
+  _retired: bool = field(default=False, init=False, repr=False)
+
+  def retire(self) -> None:
+    """Destroy the config while keeping its argv-visible fd bound harmlessly."""
+    if self._retired:
+      return
+    with open(os.devnull, "rb") as harmless:
+      os.dup2(harmless.fileno(), self._file.fileno())
+    self._retired = True
 
 
 # ── Secrets ──────────────────────────────────────────────────────────────
@@ -780,17 +797,19 @@ def build_turn_plan(db) -> ConnectorTurnPlan:
 
 
 @contextmanager
-def claude_mcp_config_path(
+def claude_mcp_config_handle(
   plan: ConnectorTurnPlan | None,
-) -> Iterator[str | None]:
-  """Yield an anonymous 0600 MCP config path for Claude startup only.
+) -> Iterator[ClaudeMcpConfigHandle | None]:
+  """Yield an anonymous 0600 MCP config handle for Claude startup only.
 
   Passing the server dict directly makes the SDK serialize its short-lived
   broker capability into ``--mcp-config <json>`` in the process command line.
   ``TemporaryFile`` is anonymous on Linux; the CLI opens it through this
-  process's `/proc` fd while ``connect()`` runs, then the runner closes it
-  before the model can execute a tool. There is no named capability file left
-  behind after a crash or restart.
+  process's ``/proc`` fd while ``connect()`` runs. The runner then calls
+  :meth:`ClaudeMcpConfigHandle.retire`, atomically replacing that descriptor
+  with ``/dev/null``. Keeping the harmless descriptor reserved until teardown
+  prevents the argv-visible fd number from being reused for unrelated data.
+  There is no named capability file left behind after a crash or restart.
   """
   servers = plan.claude_servers if plan else {}
   if not servers:
@@ -805,4 +824,4 @@ def claude_mcp_config_path(
     path = f"/proc/{os.getpid()}/fd/{handle.fileno()}"
     if not os.path.exists(path):
       raise ConnectorError("Protected MCP configuration files are unavailable.")
-    yield path
+    yield ClaudeMcpConfigHandle(path=path, _file=handle)

--- a/backend/tests/test_agent_turn_releases_db_connection.py
+++ b/backend/tests/test_agent_turn_releases_db_connection.py
@@ -86,6 +86,16 @@ async def test_agent_turn_closes_preflight_session_before_provider_wait(
   monkeypatch.setattr(database, "SessionLocal", tracking_session_factory)
   runner_started = asyncio.Event()
   release_runner = asyncio.Event()
+  connector_plan = object()
+
+  def fake_connector_plan(turn_db):
+    assert turn_db is turn_sessions[0]
+    assert turn_db.close_calls == 0
+    # Prove the registry snapshot can still read at the preflight boundary.
+    turn_db.query(models.Chat).filter(models.Chat.id == chat.id).one()
+    return connector_plan
+
+  monkeypatch.setattr("app.connectors.build_turn_plan", fake_connector_plan)
 
   async def fake_runner(**kwargs):
     turn_db = kwargs["db"]
@@ -94,6 +104,7 @@ async def test_agent_turn_closes_preflight_session_before_provider_wait(
       "the turn must close its preflight DB session before provider execution"
     )
     assert not turn_db.real.in_transaction()
+    assert kwargs["connector_plan"] is connector_plan
     runner_started.set()
     await release_runner.wait()
     return {"session_id": None, "cost_usd": 0.0, "error": None}

--- a/backend/tests/test_claude_sdk_runner.py
+++ b/backend/tests/test_claude_sdk_runner.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import tempfile
 from typing import Any
 
 import pytest
@@ -38,6 +39,7 @@ from claude_agent_sdk.types import (
 )
 
 from app import claude_events, claude_sdk_runner, models
+from app import connectors as connector_core
 from app.claude_sdk_runner import (
   ActiveClaudeClient,
   dispatch_sdk_message,
@@ -69,6 +71,176 @@ class _Bus:
 class _ChatBus(_Bus):
   chat_id = "chat-42"
   run_token = "run-1"
+
+
+@pytest.mark.asyncio
+async def test_claude_connection_secret_is_retired_after_connect_without_fd_reuse(
+  monkeypatch,
+):
+  observed = {}
+
+  class _FakeClient:
+    def __init__(self, options):
+      observed["path"] = str(options.mcp_servers)
+      assert observed["path"].startswith(f"/proc/{os.getpid()}/fd/")
+      assert "private-key" not in observed["path"]
+      with open(observed["path"], encoding="utf-8") as file:
+        observed["config"] = file.read()
+
+    async def connect(self):
+      assert os.path.exists(observed["path"])
+
+    async def query(self, _message):
+      # connect() has consumed the config. Its argv-visible fd remains reserved
+      # but harmless, rather than being reusable for unrelated process data.
+      assert os.path.exists(observed["path"])
+      with open(observed["path"], "rb") as retired_file:
+        assert retired_file.read() == b""
+      held_fd = int(observed["path"].rsplit("/", 1)[1])
+      with tempfile.TemporaryFile() as unrelated:
+        unrelated.write(b"unrelated-live-secret")
+        unrelated.flush()
+        assert unrelated.fileno() != held_fd
+        with open(observed["path"], "rb") as retired_file:
+          assert retired_file.read() == b""
+
+    async def receive_response(self):
+      yield _success_result()
+
+    async def disconnect(self):
+      return None
+
+  monkeypatch.setattr(claude_sdk_runner, "ClaudeSDKClient", _FakeClient)
+  plan = connector_core.ConnectorTurnPlan(claude_servers={
+    "private": {
+      "type": "http",
+      "url": "https://mcp.example/mcp",
+      "headers": {"Authorization": "Bearer private-key"},
+    },
+  })
+
+  result = await run_claude_sdk_turn(
+    "hello",
+    session_id=None,
+    base_env={},
+    cwd="/tmp",
+    chat_id="claude-mcp-config",
+    skill_text="system",
+    bc=_ChatBus(),
+    pending_questions={},
+    db=None,
+    connector_plan=plan,
+  )
+
+  assert "private-key" in observed["config"]
+  assert not os.path.exists(observed["path"])
+  assert result["error"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+  ("connect_error", "expected_error"),
+  [
+    (asyncio.TimeoutError(), "connect timeout"),
+    (RuntimeError("connect failed"), "connect failed"),
+  ],
+)
+async def test_claude_connection_secret_file_closes_when_connect_fails(
+  monkeypatch,
+  connect_error,
+  expected_error,
+):
+  observed = {}
+
+  class _FailingClient:
+    def __init__(self, options):
+      observed["path"] = str(options.mcp_servers)
+      assert os.path.exists(observed["path"])
+
+    async def connect(self):
+      raise connect_error
+
+    async def disconnect(self):
+      with open(observed["path"], "rb") as retired_file:
+        assert retired_file.read() == b""
+      observed["disconnected"] = True
+
+  monkeypatch.setattr(claude_sdk_runner, "ClaudeSDKClient", _FailingClient)
+  plan = connector_core.ConnectorTurnPlan(claude_servers={
+    "private": {
+      "type": "http",
+      "url": "https://mcp.example/mcp",
+      "headers": {"Authorization": "Bearer private-key"},
+    },
+  })
+
+  result = await run_claude_sdk_turn(
+    "hello",
+    session_id=None,
+    base_env={},
+    cwd="/tmp",
+    chat_id=f"claude-mcp-{expected_error}",
+    skill_text="system",
+    bc=_ChatBus(),
+    pending_questions={},
+    db=None,
+    connector_plan=plan,
+  )
+
+  assert result["error"] == expected_error
+  assert observed["disconnected"] is True
+  assert not os.path.exists(observed["path"])
+
+
+@pytest.mark.asyncio
+async def test_claude_connection_secret_file_closes_when_connect_is_cancelled(
+  monkeypatch,
+):
+  observed = {}
+  connecting = asyncio.Event()
+
+  class _CancelledClient:
+    def __init__(self, options):
+      observed["path"] = str(options.mcp_servers)
+
+    async def connect(self):
+      assert os.path.exists(observed["path"])
+      connecting.set()
+      await asyncio.Future()
+
+    async def disconnect(self):
+      with open(observed["path"], "rb") as retired_file:
+        assert retired_file.read() == b""
+      observed["disconnected"] = True
+
+  monkeypatch.setattr(claude_sdk_runner, "ClaudeSDKClient", _CancelledClient)
+  plan = connector_core.ConnectorTurnPlan(claude_servers={
+    "private": {
+      "type": "http",
+      "url": "https://mcp.example/mcp",
+      "headers": {"Authorization": "Bearer private-key"},
+    },
+  })
+  turn = asyncio.create_task(run_claude_sdk_turn(
+    "hello",
+    session_id=None,
+    base_env={},
+    cwd="/tmp",
+    chat_id="claude-mcp-cancelled",
+    skill_text="system",
+    bc=_ChatBus(),
+    pending_questions={},
+    db=None,
+    connector_plan=plan,
+  ))
+
+  await connecting.wait()
+  turn.cancel()
+  with pytest.raises(asyncio.CancelledError):
+    await turn
+
+  assert observed["disconnected"] is True
+  assert not os.path.exists(observed["path"])
 
 
 def _stream_delta(delta_type: str, **fields: Any) -> StreamEvent:

--- a/backend/tests/test_codex_sdk_runner.py
+++ b/backend/tests/test_codex_sdk_runner.py
@@ -7,7 +7,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from app import codex_sdk_runner, models
+from app import codex_sdk_runner, connectors as connector_core, models
 from app.agent_lifecycle import normalize_chat_event
 from app.database import SessionLocal
 from app.runner_registry import RunnerKind, registry
@@ -3794,10 +3794,22 @@ def test_run_codex_sdk_turn_controls_prompt_layers(monkeypatch, session_id):
   ]
   thread = _FakeThread("resumed-thread", _FakeTurnHandle(notifications))
   captured: dict = {}
+  connector_plan = connector_core.ConnectorTurnPlan(
+    codex_config={
+      "mcp_servers": {
+        "search": {
+          "url": "https://mcp.example/mcp",
+          "bearer_token_env_var": "MOBIUS_CONNECTOR_3_SEARCH",
+        },
+      },
+    },
+    codex_env={"MOBIUS_CONNECTOR_3_SEARCH": "private-key"},
+  )
 
   class FakeAsyncCodex:
     def __init__(self, config=None):
       self.config = config
+      captured["process_config"] = config
 
     async def __aenter__(self):
       return self
@@ -3829,6 +3841,7 @@ def test_run_codex_sdk_turn_controls_prompt_layers(monkeypatch, session_id):
     pending_questions={},
     db=None,
     system_prompt="FROZEN CONSTITUTION SNAPSHOT",
+    connector_plan=connector_plan,
   ))
 
   assert captured["session_id"] == session_id
@@ -3837,6 +3850,10 @@ def test_run_codex_sdk_turn_controls_prompt_layers(monkeypatch, session_id):
   )
   assert captured["thread_options"]["developer_instructions"] == ""
   assert captured["thread_options"]["personality"] == "none"
+  assert captured["thread_options"]["config"] == connector_plan.codex_config
+  process_env = captured["process_config"].kwargs["env"]
+  assert process_env["MOBIUS_CONNECTOR_3_SEARCH"] == "private-key"
+  assert "private-key" not in repr(captured["thread_options"]["config"])
   assert result["session_id"] == "resumed-thread"
   assert result["error"] is None
 # --- Structured rate-limit reset extraction --------------------------------

--- a/backend/tests/test_connectors.py
+++ b/backend/tests/test_connectors.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import os
+import tempfile
 import time
 from unittest.mock import AsyncMock
 
@@ -507,7 +508,7 @@ def test_turn_plan_serves_both_providers_without_config_secrets():
   assert "key-12" not in repr(plan.codex_config)
 
 
-def test_claude_config_is_anonymous_and_disappears_after_startup_window():
+def test_claude_config_is_retired_without_releasing_argv_visible_fd():
   plan = core.ConnectorTurnPlan(
     claude_servers={
       "search": {
@@ -517,15 +518,23 @@ def test_claude_config_is_anonymous_and_disappears_after_startup_window():
       },
     },
   )
-  with core.claude_mcp_config_path(plan) as path:
-    assert path.startswith(f"/proc/{os.getpid()}/fd/")
-    assert "secret-in-file" not in path
-    with open(path, encoding="utf-8") as config_file:
+  with core.claude_mcp_config_handle(plan) as config:
+    assert config is not None
+    assert config.path.startswith(f"/proc/{os.getpid()}/fd/")
+    assert "secret-in-file" not in config.path
+    with open(config.path, encoding="utf-8") as config_file:
       payload = json.load(config_file)
     assert payload["mcpServers"]["search"]["headers"]["Authorization"] == (
       "Bearer secret-in-file"
     )
-  assert not os.path.exists(path)
+    held_fd = int(config.path.rsplit("/", 1)[1])
+    config.retire()
+    with open(config.path, "rb") as retired_file:
+      assert retired_file.read() == b""
+    with tempfile.TemporaryFile() as unrelated:
+      assert unrelated.fileno() != held_fd
+    config.retire()  # Retirement is idempotent across nested cleanup paths.
+  assert not os.path.exists(config.path)
 
 
 def test_connector_routes_keep_keys_out_of_responses(


### PR DESCRIPTION
## Summary

- snapshot enabled connector broker plans while the request DB session is still live, then release the pool lease before provider waits
- inject Claude MCP configuration through an anonymous 0600 `/proc/.../fd` path, then atomically replace its descriptor with `/dev/null` after SDK connect
- reserve that harmless fd number through provider teardown so the argv-visible path cannot alias an unrelated live descriptor; close it on success, failure, timeout, and cancellation
- inject Codex MCP configuration using bearer-token environment indirection so thread config and argv contain only variable names
- degrade connector snapshot/injection failures locally without breaking an otherwise valid chat turn

## Dependency

The connector foundation from #613 is now merged. This branch has been rebuilt directly on the current `main`; the PR contains only the provider-injection delta.

## Validation

- provider runner + DB lease suite: 210 passed
- descriptor tests cover secret retirement, fd-reuse pressure, idempotence, and success/failure/timeout/cancellation cleanup
- `git diff --check` clean
- pre-push privacy/syntax gates passed

Fresh exact-head hosted CI and an independent final audit are required before merge.
