### PR TITLE
Add owner-managed MCP connection settings

### DIFF
--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -465,6 +465,24 @@ export const api = {
       'chats', `/chats/${chatId}/recover`, { method: 'POST' },
     ),
   },
+  connectors: {
+    list: (options = {}) => apiFetch('/connectors', options),
+    add: (payload, options = {}) => apiFetch('/connectors', {
+      ...options,
+      method: 'POST',
+      body: JSON.stringify(payload),
+    }),
+    update: (connectorId, payload) => apiFetch(`/connectors/${connectorId}`, {
+      method: 'PATCH',
+      body: JSON.stringify(payload),
+    }),
+    refresh: (connectorId) => apiFetch(`/connectors/${connectorId}/refresh`, {
+      method: 'POST',
+    }),
+    remove: (connectorId) => apiFetch(`/connectors/${connectorId}`, {
+      method: 'DELETE',
+    }),
+  },
   apps: {
     list: () => apiFetch('/apps/'),
     markOpened: (appId) => apiFetch(`/apps/${appId}/opened`, {

--- a/frontend/src/components/SettingsView/ConnectorsSection.jsx
+++ b/frontend/src/components/SettingsView/ConnectorsSection.jsx
@@ -1,0 +1,434 @@
+/* Owner-managed remote MCP connections, deliberately separate from each
+ * provider's own installed apps/plugins. The backend probes a connection and
+ * returns its tool catalog before this surface adds anything to agent turns. */
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Alert } from '@openai/apps-sdk-ui/components/Alert'
+import {
+  ApiKey,
+  ArrowRotateCw,
+  ConnectorsConnectedApps,
+  Delete,
+} from '@openai/apps-sdk-ui/components/Icon'
+import { api, jsonOrThrow } from '../../api/client.js'
+import {
+  connectorSchemaCostLabel,
+  connectorStatus,
+} from '../../lib/connectorViewModel.js'
+import StatusDot from '../ui/StatusDot.jsx'
+
+export default function ConnectorsSection({ active = true }) {
+  const [connections, setConnections] = useState(null)
+  const [unavailable, setUnavailable] = useState(false)
+  const [listError, setListError] = useState('')
+  const [addOpen, setAddOpen] = useState(false)
+  const [url, setUrl] = useState('')
+  const [name, setName] = useState('')
+  const [usesKey, setUsesKey] = useState(false)
+  const [authValue, setAuthValue] = useState('')
+  const [authHeader, setAuthHeader] = useState('Authorization')
+  const [addPhase, setAddPhase] = useState('idle')
+  const [addError, setAddError] = useState('')
+  const [busyIds, setBusyIds] = useState(() => new Set())
+  const [confirmRemove, setConfirmRemove] = useState(null)
+  const listRequest = useRef(0)
+  const confirmRemoveButton = useRef(null)
+  const removeButtons = useRef(new Map())
+  const addButton = useRef(null)
+  const focusAfterRemove = useRef(null)
+
+  const setConnectionBusy = useCallback((connectionId, busy) => {
+    setBusyIds(current => {
+      const next = new Set(current)
+      if (busy) next.add(connectionId)
+      else next.delete(connectionId)
+      return next
+    })
+  }, [])
+
+  const load = useCallback(async () => {
+    if (!active) return
+    const requestId = ++listRequest.current
+    setListError('')
+    try {
+      const response = await api.connectors.list({ timeoutMs: 10000 })
+      if (requestId !== listRequest.current) return
+      if (response.status === 404 || response.status === 503) {
+        setUnavailable(true)
+        setConnections([])
+        return
+      }
+      const data = await jsonOrThrow(response, 'Could not load connections')
+      if (requestId !== listRequest.current) return
+      setUnavailable(false)
+      setConnections(data.connectors || [])
+    } catch (error) {
+      if (requestId !== listRequest.current) return
+      setListError(error.message || 'Could not load connections')
+      setConnections([])
+    }
+  }, [active])
+
+  useEffect(() => {
+    load()
+    return () => { listRequest.current += 1 }
+  }, [load])
+
+  useEffect(() => {
+    if (!active) return undefined
+    const recheck = () => {
+      if (document.visibilityState === 'visible') load()
+    }
+    window.addEventListener('focus', recheck)
+    document.addEventListener('visibilitychange', recheck)
+    return () => {
+      window.removeEventListener('focus', recheck)
+      document.removeEventListener('visibilitychange', recheck)
+    }
+  }, [active, load])
+
+  useEffect(() => {
+    if (confirmRemove !== null) confirmRemoveButton.current?.focus()
+  }, [confirmRemove])
+
+  useEffect(() => {
+    const connectorId = focusAfterRemove.current
+    if (connectorId === null) return
+    focusAfterRemove.current = null
+    ;(removeButtons.current.get(connectorId) || addButton.current)?.focus()
+  }, [connections])
+
+  async function addConnection(event) {
+    event.preventDefault()
+    if (!url.trim() || addPhase === 'adding') return
+    setAddPhase('adding')
+    setAddError('')
+    try {
+      const response = await api.connectors.add({
+        url: url.trim(),
+        name: name.trim(),
+        auth_header: usesKey ? authHeader.trim() : '',
+        auth_value: usesKey ? authValue.trim() : '',
+      }, { timeoutMs: 25000 })
+      const row = await jsonOrThrow(response, 'Could not add connection')
+      listRequest.current += 1
+      setConnections(current => [...(current || []), row])
+      setUrl('')
+      setName('')
+      setAuthValue('')
+      setAuthHeader('Authorization')
+      setUsesKey(false)
+      setAddOpen(false)
+    } catch (error) {
+      setAddError(error.message || 'Could not add connection')
+    } finally {
+      setAddPhase('idle')
+    }
+  }
+
+  async function updateConnection(connection, patch) {
+    setConnectionBusy(connection.id, true)
+    setListError('')
+    try {
+      const response = await api.connectors.update(connection.id, patch)
+      const row = await jsonOrThrow(response, 'Could not update connection')
+      listRequest.current += 1
+      setConnections(current => current.map(item => (
+        item.id === row.id ? row : item
+      )))
+    } catch (error) {
+      setListError(error.message || 'Could not update connection')
+    } finally {
+      setConnectionBusy(connection.id, false)
+    }
+  }
+
+  async function refreshConnection(connection) {
+    setConnectionBusy(connection.id, true)
+    setListError('')
+    try {
+      const response = await api.connectors.refresh(connection.id)
+      const row = await jsonOrThrow(response, 'Could not re-check connection')
+      listRequest.current += 1
+      setConnections(current => current.map(item => (
+        item.id === row.id ? row : item
+      )))
+    } catch (error) {
+      setListError(error.message || 'Could not re-check connection')
+    } finally {
+      setConnectionBusy(connection.id, false)
+    }
+  }
+
+  async function removeConnection(connection) {
+    setConnectionBusy(connection.id, true)
+    setListError('')
+    try {
+      const response = await api.connectors.remove(connection.id)
+      await jsonOrThrow(response, 'Could not remove connection')
+      listRequest.current += 1
+      const index = connections.findIndex(item => item.id === connection.id)
+      const survivor = connections[index + 1] || connections[index - 1]
+      focusAfterRemove.current = survivor?.id ?? -1
+      setConnections(current => current.filter(item => item.id !== connection.id))
+      setConfirmRemove(null)
+    } catch (error) {
+      setListError(error.message || 'Could not remove connection')
+    } finally {
+      setConnectionBusy(connection.id, false)
+    }
+  }
+
+  return (
+    <section className="settings__section settings-connections" id="settings-connections">
+      <h2 className="settings__section-title">Connections</h2>
+      <div className="settings-connections__heading">
+        <span className="settings-connections__heading-icon" aria-hidden="true">
+          <ConnectorsConnectedApps />
+        </span>
+        <div>
+          <span className="settings__label">Custom MCP</span>
+          <p className="settings__subtext settings__subtext--tight">
+            Shared with Claude Code and Codex. Provider-installed apps stay
+            with their provider; these endpoints become available on the next turn.
+          </p>
+        </div>
+      </div>
+
+      {unavailable && (
+        <div className="settings__notice" role="status">
+          Connections will finish setting up after the server restarts.{' '}
+          <button
+            type="button"
+            className="settings-connections__text-button"
+            onClick={load}
+          >
+            Check again
+          </button>
+        </div>
+      )}
+
+      {connections === null ? (
+        <div className="settings__notice" role="status">Loading connections…</div>
+      ) : connections.length === 0 && !unavailable ? (
+        <div className="settings__notice" role="status">
+          No custom MCP connections yet.
+        </div>
+      ) : (
+        <div className="settings-connections__list">
+          {connections.map(connection => {
+            const status = connectorStatus(connection)
+            const schemaCost = connectorSchemaCostLabel(connection.est_tokens)
+            const removing = confirmRemove === connection.id
+            const busy = busyIds.has(connection.id)
+            return (
+              <article className="settings-connections__item" key={connection.id}>
+                <div className="settings-connections__main">
+                  <div className="settings-connections__title">
+                    <StatusDot color={status.color}>{connection.name}</StatusDot>
+                    <span className="settings-connections__state">{status.text}</span>
+                  </div>
+                  <span className="settings-connections__meta">
+                    {connection.tool_count} tool{connection.tool_count === 1 ? '' : 's'}
+                    {schemaCost ? ` · ${schemaCost}` : ''}
+                    {connection.has_auth ? ' · protected by key' : ''}
+                  </span>
+                  {connection.tools?.length > 0 && (
+                    <span className="settings-connections__tools">
+                      {connection.tools.slice(0, 6).map(tool => tool.name).join(', ')}
+                      {connection.tool_count > 6 ? '…' : ''}
+                    </span>
+                  )}
+                  {connection.status === 'error' && connection.status_detail && (
+                    <span className="settings-connections__error">
+                      {connection.status_detail}
+                    </span>
+                  )}
+                </div>
+
+                <div className="settings-connections__actions">
+                  {removing ? (
+                    <div className="settings-connections__confirm" role="group" aria-label={`Remove ${connection.name}?`}>
+                      <button
+                        type="button"
+                        ref={confirmRemoveButton}
+                        className="settings-connections__danger-button"
+                        disabled={busy}
+                        onClick={() => removeConnection(connection)}
+                      >
+                        Remove
+                      </button>
+                      <button
+                        type="button"
+                        className="settings-connections__quiet-button"
+                        onClick={() => {
+                          setConfirmRemove(null)
+                          requestAnimationFrame(() => {
+                            removeButtons.current.get(connection.id)?.focus()
+                          })
+                        }}
+                      >
+                        Keep
+                      </button>
+                    </div>
+                  ) : (
+                    <>
+                      <button
+                        type="button"
+                        className="settings-connections__icon-button"
+                        aria-label={`Re-check ${connection.name}`}
+                        title="Re-check endpoint and tool catalog"
+                        disabled={busy}
+                        onClick={() => refreshConnection(connection)}
+                      >
+                        <ArrowRotateCw aria-hidden="true" />
+                      </button>
+                      <button
+                        type="button"
+                        className="settings-connections__icon-button settings-connections__icon-button--danger"
+                        ref={element => {
+                          if (element) removeButtons.current.set(connection.id, element)
+                          else removeButtons.current.delete(connection.id)
+                        }}
+                        aria-label={`Remove ${connection.name}`}
+                        title="Remove connection"
+                        disabled={busy}
+                        onClick={() => setConfirmRemove(connection.id)}
+                      >
+                        <Delete aria-hidden="true" />
+                      </button>
+                      <button
+                        type="button"
+                        role="switch"
+                        aria-checked={connection.enabled}
+                        aria-label={`${connection.name} available to agents`}
+                        className={`settings-connections__switch${connection.enabled ? ' settings-connections__switch--on' : ''}`}
+                        disabled={busy}
+                        onClick={() => updateConnection(connection, {
+                          enabled: !connection.enabled,
+                        })}
+                      >
+                        <span aria-hidden="true" />
+                      </button>
+                    </>
+                  )}
+                </div>
+              </article>
+            )
+          })}
+        </div>
+      )}
+
+      {!unavailable && (addOpen ? (
+        <form className="settings-connections__form" onSubmit={addConnection}>
+          <div className="settings-connections__field-grid">
+            <label className="settings-connections__field settings-connections__field--wide">
+              <span>Streamable HTTP endpoint</span>
+              <input
+                type="url"
+                inputMode="url"
+                placeholder="https://example.com/mcp"
+                value={url}
+                onChange={event => setUrl(event.target.value)}
+                autoFocus
+                required
+              />
+            </label>
+            <label className="settings-connections__field">
+              <span>Name <small>optional</small></span>
+              <input
+                type="text"
+                placeholder="Use server name"
+                value={name}
+                onChange={event => setName(event.target.value)}
+                maxLength={128}
+              />
+            </label>
+          </div>
+
+          <button
+            type="button"
+            className="settings-connections__key-toggle"
+            aria-expanded={usesKey}
+            onClick={() => setUsesKey(current => {
+              if (current) {
+                setAuthValue('')
+                setAuthHeader('Authorization')
+              }
+              return !current
+            })}
+          >
+            <ApiKey aria-hidden="true" />
+            <span>{usesKey ? 'Remove API key' : 'Add API key'}</span>
+          </button>
+
+          {usesKey && (
+            <div className="settings-connections__field-grid">
+              <label className="settings-connections__field settings-connections__field--wide">
+                <span>API key</span>
+                <input
+                  type="password"
+                  autoComplete="off"
+                  value={authValue}
+                  onChange={event => setAuthValue(event.target.value)}
+                  required
+                />
+              </label>
+              <label className="settings-connections__field">
+                <span>Header</span>
+                <input
+                  type="text"
+                  value={authHeader}
+                  onChange={event => setAuthHeader(event.target.value)}
+                  placeholder="Authorization"
+                  required
+                />
+              </label>
+            </div>
+          )}
+
+          <p className="settings-connections__support-note">
+            Public HTTPS endpoints with no auth or a static key are supported.
+            OAuth sign-in, including Google, needs the next authorization layer.
+          </p>
+          <div className="settings-connections__form-actions">
+            <button
+              type="submit"
+              className="settings__btn settings__btn--sm"
+              disabled={addPhase === 'adding' || !url.trim() || (usesKey && !authValue.trim())}
+            >
+              {addPhase === 'adding' ? 'Checking…' : 'Check and add'}
+            </button>
+            <button
+              type="button"
+              className="settings__btn settings__btn--outline settings__btn--sm"
+              disabled={addPhase === 'adding'}
+              onClick={() => {
+                setAddOpen(false)
+                setAddError('')
+                setUrl('')
+                setName('')
+                setAuthValue('')
+                setAuthHeader('Authorization')
+                setUsesKey(false)
+              }}
+            >
+              Cancel
+            </button>
+          </div>
+          {addError && <Alert color="danger" variant="soft" description={addError} />}
+        </form>
+      ) : (
+        <button
+          type="button"
+          ref={addButton}
+          className="settings__btn settings__btn--outline settings__btn--sm settings-connections__add-button"
+          onClick={() => setAddOpen(true)}
+        >
+          Add connection
+        </button>
+      ))}
+
+      {listError && <Alert color="danger" variant="soft" description={listError} />}
+    </section>
+  )
+}

--- a/frontend/src/components/SettingsView/SettingsView.css
+++ b/frontend/src/components/SettingsView/SettingsView.css
@@ -563,3 +563,325 @@
 .settings__section--server .settings__subtext--tight {
   margin: -10px 0 0;
 }
+
+/* ── Provider-neutral MCP connections ──────────────────────────────── */
+.settings-connections {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.settings-connections > .settings__section-title,
+.settings-connections > .settings__notice {
+  margin: 0;
+}
+
+.settings-connections__heading {
+  display: flex;
+  align-items: flex-start;
+  gap: 11px;
+}
+
+.settings-connections__heading-icon {
+  flex: 0 0 34px;
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--accent) 12%, var(--surface2));
+  color: var(--accent);
+}
+
+.settings-connections__heading-icon svg {
+  width: 19px;
+  height: 19px;
+}
+
+.settings-connections__list {
+  display: grid;
+  border-top: 1px solid var(--border);
+}
+
+.settings-connections__item {
+  min-width: 0;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.settings-connections__main {
+  min-width: 0;
+  display: grid;
+  gap: 3px;
+}
+
+.settings-connections__title {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.settings-connections__title .status-dot {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.settings-connections__state {
+  flex: none;
+}
+
+.settings-connections__state,
+.settings-connections__meta,
+.settings-connections__tools,
+.settings-connections__error {
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.settings-connections__state,
+.settings-connections__meta {
+  color: var(--muted);
+}
+
+.settings-connections__state {
+  font-weight: 400;
+}
+
+.settings-connections__tools {
+  max-width: 100%;
+  overflow: hidden;
+  color: color-mix(in srgb, var(--text) 76%, var(--muted));
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.settings-connections__error {
+  color: var(--danger);
+  overflow-wrap: anywhere;
+}
+
+.settings-connections__actions,
+.settings-connections__confirm,
+.settings-connections__form-actions {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.settings-connections__icon-button,
+.settings-connections__quiet-button,
+.settings-connections__danger-button,
+.settings-connections__key-toggle,
+.settings-connections__text-button {
+  border: 0;
+  font: inherit;
+  cursor: pointer;
+}
+
+.settings-connections__icon-button {
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--muted);
+}
+
+.settings-connections__icon-button svg {
+  width: 16px;
+  height: 16px;
+}
+
+.settings-connections__icon-button--danger {
+  color: color-mix(in srgb, var(--danger) 78%, var(--muted));
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .settings-connections__icon-button:hover:not(:disabled) {
+    border-color: var(--border);
+    background: var(--surface2);
+    color: var(--text);
+  }
+
+  .settings-connections__icon-button--danger:hover:not(:disabled) {
+    color: var(--danger);
+  }
+}
+
+.settings-connections__icon-button:focus-visible,
+.settings-connections__switch:focus-visible,
+.settings-connections__key-toggle:focus-visible,
+.settings-connections__quiet-button:focus-visible,
+.settings-connections__danger-button:focus-visible,
+.settings-connections__text-button:focus-visible,
+.settings-connections__field input:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.settings-connections__icon-button:disabled,
+.settings-connections__switch:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.settings-connections__switch {
+  position: relative;
+  flex: 0 0 42px;
+  width: 42px;
+  height: 24px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface2);
+  cursor: pointer;
+  transition: background 140ms ease, border-color 140ms ease;
+}
+
+.settings-connections__switch > span {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--muted);
+  transition: transform 140ms ease, background 140ms ease;
+}
+
+.settings-connections__switch--on {
+  border-color: var(--accent);
+  background: var(--accent);
+}
+
+.settings-connections__switch--on > span {
+  transform: translateX(18px);
+  background: var(--accent-fg);
+}
+
+.settings-connections__quiet-button,
+.settings-connections__danger-button {
+  min-height: 32px;
+  padding: 5px 10px;
+  border-radius: 8px;
+  font-size: 12.5px;
+}
+
+.settings-connections__quiet-button {
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text);
+}
+
+.settings-connections__danger-button {
+  background: var(--danger);
+  color: #fff;
+}
+
+.settings-connections__text-button {
+  padding: 0;
+  background: transparent;
+  color: var(--accent);
+  text-decoration: underline;
+}
+
+.settings-connections__add-button {
+  align-self: flex-start;
+}
+
+.settings-connections__form {
+  display: grid;
+  gap: 11px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}
+
+.settings-connections__field-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.7fr) minmax(140px, 1fr);
+  gap: 9px;
+}
+
+.settings-connections__field {
+  min-width: 0;
+  display: grid;
+  gap: 5px;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.settings-connections__field small {
+  font: inherit;
+  font-weight: 400;
+  opacity: 0.7;
+}
+
+.settings-connections__field input {
+  min-width: 0;
+  width: 100%;
+  box-sizing: border-box;
+  height: 40px;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+  color: var(--text);
+  font: inherit;
+  font-size: 14px;
+}
+
+.settings-connections__key-toggle {
+  justify-self: start;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 34px;
+  padding: 5px 9px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text);
+  font-size: 13px;
+}
+
+.settings-connections__key-toggle svg {
+  width: 15px;
+  height: 15px;
+  color: var(--muted);
+}
+
+.settings-connections__support-note {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+@container settings (max-width: 480px) {
+  .settings-connections__item {
+    flex-direction: column;
+  }
+
+  .settings-connections__actions {
+    align-self: flex-end;
+  }
+
+  .settings-connections__field-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/frontend/src/components/SettingsView/SettingsView.jsx
+++ b/frontend/src/components/SettingsView/SettingsView.jsx
@@ -30,6 +30,7 @@ import ModelSheet from '../ui/ModelSheet.jsx'
 import { modelEfforts, validEffort } from '../ui/modelEfforts.js'
 import ManageModelsModal from '../ChatView/ManageModelsModal.jsx'
 import UpdateReviewModal from './UpdateReviewModal.jsx'
+import ConnectorsSection from './ConnectorsSection.jsx'
 import ProviderUsage from './ProviderUsage.jsx'
 import { formatPlanStatus } from './providerUsage.js'
 import { PROVIDER_INFO, PROVIDER_ORDER } from '../ChatView/ChatSettingsPanel.jsx'
@@ -1617,6 +1618,8 @@ export default function SettingsView({
             </div>
           )}
         </section>
+
+        <ConnectorsSection active={active} />
 
         <section className="settings__section settings__section--compact settings__section--appearance">
           <div className="settings__appearance">

--- a/frontend/src/lib/__tests__/connectorViewModel.test.js
+++ b/frontend/src/lib/__tests__/connectorViewModel.test.js
@@ -1,0 +1,26 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  connectorSchemaCostLabel,
+  connectorStatus,
+} from '../connectorViewModel.js'
+
+test('connector schema cost states the neutral catalog size without loading claims', () => {
+  assert.equal(connectorSchemaCostLabel(0), '')
+  assert.equal(connectorSchemaCostLabel(420), '~420 tool-schema tokens')
+  assert.equal(connectorSchemaCostLabel(1250), '~1.3k tool-schema tokens')
+  assert.equal(connectorSchemaCostLabel(12500), '~13k tool-schema tokens')
+})
+
+test('connector status keeps reachability distinct from the owner toggle', () => {
+  assert.deepEqual(connectorStatus({ enabled: true, status: 'ok' }), {
+    color: '--green', text: 'Available',
+  })
+  assert.deepEqual(connectorStatus({ enabled: false, status: 'ok' }), {
+    color: '--border', text: 'Off',
+  })
+  assert.deepEqual(connectorStatus({ enabled: false, status: 'error' }), {
+    color: '--danger', text: 'Needs attention',
+  })
+})

--- a/frontend/src/lib/connectorViewModel.js
+++ b/frontend/src/lib/connectorViewModel.js
@@ -1,0 +1,15 @@
+export function connectorSchemaCostLabel(estTokens) {
+  if (!estTokens) return ''
+  const value = estTokens >= 1000
+    ? `${(estTokens / 1000).toFixed(estTokens >= 10000 ? 0 : 1)}k`
+    : String(estTokens)
+  return `~${value} tool-schema tokens`
+}
+
+export function connectorStatus(connection = {}) {
+  if (connection.status === 'error') {
+    return { color: '--danger', text: 'Needs attention' }
+  }
+  if (!connection.enabled) return { color: '--border', text: 'Off' }
+  return { color: '--green', text: 'Available' }
+}

--- a/tests/connectors-settings.spec.mjs
+++ b/tests/connectors-settings.spec.mjs
@@ -1,0 +1,146 @@
+import { test, expect } from '@playwright/test'
+
+const BASE = process.env.MOBIUS_URL || 'http://localhost:8001'
+
+test.use({ serviceWorkers: 'block' })
+
+function connector(id, overrides = {}) {
+  return {
+    id,
+    slug: `server_${id}`,
+    name: `Server ${id}`,
+    url: `https://mcp${id}.example/mcp`,
+    enabled: true,
+    has_auth: false,
+    tool_count: 2,
+    tools: [{ name: 'lookup' }, { name: 'summarize' }],
+    est_tokens: 420,
+    status: 'ok',
+    status_detail: null,
+    ...overrides,
+  }
+}
+
+async function openConnections(page) {
+  await page.goto(BASE, { waitUntil: 'domcontentloaded' })
+  await page.waitForFunction(
+    () => !!(document.querySelector('.chat__empty-wrap')
+      || document.querySelector('.chat__scroll')
+      || document.querySelector('.chat__form')),
+    { timeout: 10000 },
+  )
+  const navigationToggle = page.getByLabel('Toggle navigation')
+  if (await navigationToggle.getAttribute('aria-expanded') !== 'true') {
+    await navigationToggle.click()
+  }
+  await page.getByRole('button', { name: 'Settings', exact: true }).click()
+  await expect(page.locator('#settings-connections')).toBeVisible()
+}
+
+test('connection actions preserve secrets, ordering, and keyboard focus contracts', async ({ page }) => {
+  await page.setViewportSize({ width: 900, height: 800 })
+  const rows = [connector(1), connector(2)]
+  let addGateResolve
+  const addGate = new Promise(resolve => { addGateResolve = resolve })
+
+  await page.route('**/api/connectors**', async route => {
+    const request = route.request()
+    const url = new URL(request.url())
+    const match = url.pathname.match(/^\/api\/connectors\/(\d+)(?:\/(refresh))?$/)
+    if (request.method() === 'GET' && url.pathname === '/api/connectors') {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ connectors: rows }) })
+    }
+    if (request.method() === 'POST' && url.pathname === '/api/connectors') {
+      await addGate
+      const created = connector(3, { name: request.postDataJSON().name || 'Server 3', has_auth: true })
+      rows.push(created)
+      return route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify(created) })
+    }
+    const id = Number(match?.[1])
+    const row = rows.find(item => item.id === id)
+    if (request.method() === 'PATCH' && row) {
+      Object.assign(row, request.postDataJSON())
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(row) })
+    }
+    if (request.method() === 'POST' && match?.[2] === 'refresh' && row) {
+      row.tool_count = 3
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(row) })
+    }
+    if (request.method() === 'DELETE' && row) {
+      rows.splice(rows.indexOf(row), 1)
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ok: true }) })
+    }
+    return route.fallback()
+  })
+
+  await openConnections(page)
+  await page.getByRole('button', { name: 'Add connection' }).click()
+  await page.getByRole('button', { name: 'Add API key' }).click()
+  await page.getByLabel('API key', { exact: true }).fill('private-value')
+  await page.getByRole('button', { name: 'Remove API key' }).click()
+  await page.getByRole('button', { name: 'Add API key' }).click()
+  await expect(page.getByLabel('API key', { exact: true })).toHaveValue('')
+
+  await page.getByLabel('Streamable HTTP endpoint').fill('https://new.example/mcp')
+  await page.getByLabel('Name optional').fill('New server')
+  await page.getByLabel('API key', { exact: true }).fill('replacement-value')
+  await page.getByRole('button', { name: 'Check and add' }).click()
+  await expect(page.getByRole('button', { name: 'Cancel' })).toBeDisabled()
+  addGateResolve()
+  await expect(page.getByText('New server', { exact: true })).toBeVisible()
+
+  const firstRemove = page.getByRole('button', { name: 'Remove Server 1' })
+  await firstRemove.focus()
+  await firstRemove.click()
+  const confirm = page.getByRole('button', { name: 'Remove', exact: true })
+  await expect(confirm).toBeFocused()
+  await page.getByRole('button', { name: 'Keep' }).click()
+  await expect(firstRemove).toBeFocused()
+  await firstRemove.click()
+  await confirm.click()
+  await expect(page.getByRole('button', { name: 'Remove Server 2' })).toBeFocused()
+
+  const toggle = page.getByRole('switch', { name: 'Server 2 available to agents' })
+  await toggle.click()
+  await expect(toggle).toHaveAttribute('aria-checked', 'false')
+  await page.getByRole('button', { name: 'Re-check Server 2' }).click()
+  await expect(page.getByText(/3 tools/)).toBeVisible()
+})
+
+test('restart-unavailable state retries into the empty connection surface', async ({ page }) => {
+  await page.setViewportSize({ width: 900, height: 800 })
+  let unavailable = true
+  await page.route('**/api/connectors', route => {
+    if (unavailable) {
+      unavailable = false
+      return route.fulfill({ status: 503, contentType: 'application/json', body: '{"detail":"restart"}' })
+    }
+    return route.fulfill({ status: 200, contentType: 'application/json', body: '{"connectors":[]}' })
+  })
+  await openConnections(page)
+  await expect(page.getByText(/finish setting up after the server restarts/)).toBeVisible()
+  await page.getByRole('button', { name: 'Check again' }).click()
+  await expect(page.getByText('No custom MCP connections yet.')).toBeVisible()
+})
+
+test('long connection details stay inside the narrow Settings pane', async ({ page }) => {
+  await page.setViewportSize({ width: 280, height: 720 })
+  const long = 'connection'.repeat(20)
+  await page.route('**/api/connectors', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ connectors: [connector(1, {
+      name: long,
+      status: 'error',
+      status_detail: long,
+    })] }),
+  }))
+  await openConnections(page)
+  const section = page.locator('#settings-connections')
+  await expect.poll(() => section.evaluate(element => ({
+    client: element.clientWidth,
+    scroll: element.scrollWidth,
+  }))).toEqual(expect.objectContaining({ client: expect.any(Number) }))
+  const overflow = await section.evaluate(element => element.scrollWidth - element.clientWidth)
+  expect(overflow).toBeLessThanOrEqual(1)
+})


### PR DESCRIPTION
## Summary
- add a Connections section for owner-managed remote MCP servers
- support probe-and-add, enable/disable, refresh, and deliberate removal flows
- keep provider-installed integrations distinct and show deferred schema cost clearly
- prevent stale list responses and unrelated row operations from overwriting current state
- preserve deterministic confirmation, cancellation, retry, and keyboard-focus behavior across narrow and desktop layouts

## Dependency
The connector registry and provider injection are merged. This branch is rebuilt as one standalone UI commit directly on current `main` and includes no stale foundation/search/speech stack.

## Validation
- frontend unit suite: 2,362 passed
- frontend hook suite: 79 passed
- structural test ratchet: passed
- lint and production/PWA build passed
- behavioral Playwright coverage includes add races, refresh/enable/remove retry paths, focus restoration, and a 280px viewport

Fresh exact-head hosted CI and an independent final audit are required before merge.
