### PR TITLE
Keep chat history revisions stable during live snapshots

### DIFF
--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -3719,7 +3719,6 @@ def update_live_assistant(
   """Persist the current assistant snapshot without rewriting history."""
   if not chat_id:
     return True
-  from datetime import UTC, datetime
   from app.models import Chat
 
   row = db.execute(
@@ -3773,7 +3772,9 @@ def update_live_assistant(
   db.execute(
     update(Chat)
     .where(Chat.id == chat_id, Chat.deleted_at.is_(None))
-    .values(live_assistant=snapshot, updated_at=datetime.now(UTC))
+    # The stream is authoritative while this value changes. Bypass
+    # updated_at's onupdate default so retained history remains reusable.
+    .values(live_assistant=snapshot, updated_at=Chat.updated_at)
   )
   return _commit_or_rollback(db)
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -173,10 +173,10 @@ class Chat(Base):
   )
   # Advances ONLY when the OWNER sends a message into this chat (initial
   # send, a queued send, or a fast-forward/steer send). This is the drawer
-  # ordering key, deliberately decoupled from `updated_at` — which bumps on
-  # EVERY row write via onupdate (run markers, session id, streamed
-  # transcript, the agent's auto-retitle) and would otherwise re-sort the
-  # chat to the top on activity the owner did not initiate. No onupdate here.
+  # ordering key, deliberately decoupled from `updated_at` — which usually
+  # bumps on row writes (run markers, session id, the agent's auto-retitle)
+  # and would otherwise re-sort the chat to the top on activity the owner did
+  # not initiate. No onupdate here.
   activity_at = Column(
     DateTime, nullable=True, default=lambda: datetime.now(UTC)
   )

--- a/backend/tests/test_chat_live_assistant.py
+++ b/backend/tests/test_chat_live_assistant.py
@@ -28,6 +28,7 @@ def _chat(db, *, trailing_role="user"):
 
 def test_stream_snapshot_updates_only_live_value(db):
   chat, history = _chat(db)
+  history_version = chat.updated_at
 
   assert update_live_assistant(db, chat.id, {
     "role": "assistant",
@@ -38,11 +39,13 @@ def test_stream_snapshot_updates_only_live_value(db):
   assert chat.messages == history
   assert chat.live_assistant["ts"] == 4
   assert chat.live_assistant["blocks"][0]["text"] == "streaming"
+  assert chat.updated_at == history_version
   assert materialized_messages(chat)[-1] == chat.live_assistant
 
 
 def test_finalize_merges_live_turn_once_and_clears_snapshot(db):
   chat, history = _chat(db)
+  history_version = chat.updated_at
   update_live_assistant(db, chat.id, {
     "role": "assistant",
     "blocks": [{"type": "text", "text": "partial"}],
@@ -58,6 +61,7 @@ def test_finalize_merges_live_turn_once_and_clears_snapshot(db):
   assert len(chat.messages) == len(history) + 1
   assert chat.messages[-1]["ts"] == 4
   assert chat.messages[-1]["blocks"][0]["text"] == "complete"
+  assert chat.updated_at != history_version
 
 
 def test_materialized_snapshot_replaces_question_barrier_row():


### PR DESCRIPTION
## Summary
- keep `Chat.updated_at` stable while only the transient live-assistant snapshot changes
- preserve `updated_at` as the retained-history revision/cache key until finalization actually appends the assistant turn
- continue advancing the revision when the live turn is finalized into durable transcript history

## Why
A high-frequency streaming snapshot is authoritative through `live_assistant`, but it does not change retained `messages`. Advancing the retained-history revision for every partial snapshot unnecessarily invalidated transcript/search caches that were still correct.

## Validation
- `scripts/wt-pytest.sh backend/tests/test_chat_live_assistant.py`: 4 passed
- regression proves snapshots preserve the history revision and finalization advances it
- pre-push privacy, conflict-marker, and Python syntax gates passed
