### PR TITLE
Rotate cached app frames after WebAssembly CSP change

### DIFF
--- a/frontend/src/lib/__tests__/swCachePolicy.test.js
+++ b/frontend/src/lib/__tests__/swCachePolicy.test.js
@@ -51,6 +51,10 @@ test('runtime cache cleanup evicts old offline app caches', () => {
   // from the frame's opaque origin. Serving one cache-first would reinstate the
   // blocked-network failure on exactly the devices the fix targets.
   assert.equal(isStaleRuntimeCache('mobius-offline-apps-v4'), true)
+  // v5 stored frames before the narrow WebAssembly CSP source was enabled.
+  // Those response headers must not keep blocking Wasm compilation after the
+  // server policy changes.
+  assert.equal(isStaleRuntimeCache('mobius-offline-apps-v5'), true)
   assert.equal(isStaleRuntimeCache(OFFLINE_APPS_CACHE), false)
   assert.equal(isStaleRuntimeCache('mobius-standalone'), true)
   assert.equal(isStaleRuntimeCache('mobius-standalone-v1'), true)

--- a/frontend/src/sw-cache-policy.js
+++ b/frontend/src/sw-cache-policy.js
@@ -37,7 +37,13 @@ export const SHELL_DATA_CACHE = 'mobius-shell-data'
 // blocks every API call and see no fix at all on its first post-upgrade open.
 // That is precisely the population this change is for, so the eviction is the
 // half that actually delivers it.
-export const OFFLINE_APPS_CACHE = 'mobius-offline-apps-v5'
+// Bumped -v5 → -v6 (2026-08-03): app frames now permit the narrow
+// `wasm-unsafe-eval` source needed to compile WebAssembly without enabling
+// JavaScript eval. A cached response retains its original CSP header, so merely
+// changing the backend header leaves existing devices serving v5 indefinitely
+// on this cache-first route. Activation evicts that response before News (or
+// any other Wasm app) opens under the revised policy.
+export const OFFLINE_APPS_CACHE = 'mobius-offline-apps-v6'
 // Bumped -v2 → -v3 (2026-07-30): v2 standalone documents executed app-authored
 // modules directly at owner origin. The secure host now mounts the shared
 // opaque AppCanvas frame; activation must evict every cached v2 document so an


### PR DESCRIPTION
## Summary
- rotate the opaque app-frame document cache after the WebAssembly CSP change
- keep prior cache data isolated behind a new cache name instead of serving stale documents under the old policy
- add a regression that pins the cache version and cleanup behavior

## Validation
- full frontend unit and hook suite passed
- pre-push privacy, conflict-marker, JSX parse, and frontend-unit gates passed
