### PR TITLE
Warm recently used chats on startup

### DIFF
--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -122,7 +122,8 @@ import {
   MODE_MOTION, EMPTY_SINGLE_SURFACE_KEY,
 } from './workspaceView.js'
 import NewChatLanding from './NewChatLanding.jsx'
-import { recentChatsToPrefetch } from './chatPrefetch.js'
+import { warmChatCandidates } from './chatPrefetch.js'
+import { readRecentlyOpenedChatIds } from '../../lib/navigationPersistence.js'
 import {
   PaneTab, panePanelDomId, paneTabDomId, scrollStripWheel, stripKeyDown,
 } from './PaneStrip.jsx'
@@ -491,13 +492,18 @@ export default function Shell() {
   const chatsStatus = chats.length > 0 || chatsQuery.isSuccess
     ? 'success'
     : (chatsQuery.isError ? 'error' : 'loading')
-  // Prime only the two most-recent chats that are not already open, including
-  // active chats: their cached transcript is useful while stream catch-up runs.
+  // Prime a bounded blend of recently opened and recently owner-active chats.
+  // The blend stays useful when the owner is moving among several pieces of
+  // work without letting background agent updates consume the warm budget.
   // ChatView still revalidates on mount, but this gives its synchronous cache
   // read a real transcript so a later chat switch can paint immediately. Run
   // once after the live drawer projection arrives, at browser idle, and stand
   // down under data-saver so speed never creates surprise background transfer.
   const warmedChatsOnLoadRef = useRef(false)
+  const recentlyOpenedChatIds = useMemo(
+    () => readRecentlyOpenedChatIds(),
+    [],
+  )
   useEffect(() => {
     if (
       warmedChatsOnLoadRef.current
@@ -506,7 +512,9 @@ export default function Shell() {
     ) return
     warmedChatsOnLoadRef.current = true
     if (navigator.connection?.saveData) return
-    const candidates = recentChatsToPrefetch(chats, activeChatId)
+    const candidates = warmChatCandidates(
+      chats, activeChatId, recentlyOpenedChatIds,
+    )
     if (candidates.length === 0) return
     const warm = async () => {
       for (const chat of candidates) {
@@ -524,6 +532,7 @@ export default function Shell() {
     chatsQuery.isFetchedAfterMount,
     chatsQuery.isSuccess,
     queryClient,
+    recentlyOpenedChatIds,
   ])
   const appPreviewAckRef = useRef(new Set())
   const handleAppPreviewSeen = useCallback((app, final) => {

--- a/frontend/src/components/Shell/__tests__/chatPrefetch.test.js
+++ b/frontend/src/components/Shell/__tests__/chatPrefetch.test.js
@@ -2,22 +2,47 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 
 import {
-  RECENT_CHAT_PREFETCH_LIMIT,
-  recentChatsToPrefetch,
+  CHAT_PREFETCH_LIMIT,
+  warmChatCandidates,
 } from '../chatPrefetch.js'
 
-test('recent chat prefetch stays bounded, skips active/empty, and keeps running chats', () => {
+test('warm chats blend recent opens with owner activity and ignore agent-only churn', () => {
   const chats = [
     { id: 'active', has_messages: true, activity_at: '2026-07-26T10:00:00Z' },
-    { id: 'running', has_messages: true, running: true, activity_at: '2026-07-26T12:00:00Z' },
-    { id: 'empty', has_messages: false, activity_at: '2026-07-26T13:00:00Z' },
-    { id: 'older', has_messages: true, activity_at: '2026-07-25T10:00:00Z' },
-    { id: 'newer', has_messages: true, activity_at: '2026-07-26T09:00:00Z' },
-    { id: 'middle', has_messages: true, activity_at: '2026-07-26T08:00:00Z' },
+    { id: 'opened-old', has_messages: true, activity_at: '2026-07-20T10:00:00Z' },
+    { id: 'opened-empty', has_messages: false, activity_at: '2026-07-26T13:00:00Z' },
+    { id: 'owner-1', has_messages: true, activity_at: '2026-07-26T12:00:00Z' },
+    { id: 'owner-2', has_messages: true, activity_at: '2026-07-26T11:00:00Z' },
+    { id: 'owner-3', has_messages: true, activity_at: '2026-07-26T10:00:00Z' },
+    { id: 'owner-4', has_messages: true, activity_at: '2026-07-26T09:00:00Z' },
+    { id: 'owner-5', has_messages: true, activity_at: '2026-07-26T08:00:00Z' },
+    {
+      id: 'agent-busy', has_messages: true,
+      activity_at: '2026-07-01T08:00:00Z', updated_at: '2026-07-27T08:00:00Z',
+    },
   ]
 
-  const selected = recentChatsToPrefetch(chats, 'active')
+  const selected = warmChatCandidates(
+    chats,
+    'active',
+    ['opened-old', 'owner-2', 'opened-empty', 'active'],
+  )
 
-  assert.equal(selected.length, RECENT_CHAT_PREFETCH_LIMIT)
-  assert.deepEqual(selected.map(chat => chat.id), ['running', 'newer'])
+  assert.equal(selected.length, CHAT_PREFETCH_LIMIT)
+  assert.deepEqual(selected.map(chat => chat.id), [
+    'opened-old', 'owner-2', 'owner-1', 'owner-3', 'owner-4', 'owner-5',
+  ])
+  assert.equal(selected.some(chat => chat.id === 'agent-busy'), false)
+})
+
+test('warm chats fall back to owner activity without local open history', () => {
+  const chats = [
+    { id: 'older', has_messages: true, activity_at: '2026-07-25T10:00:00Z' },
+    { id: 'newer', has_messages: true, activity_at: '2026-07-26T09:00:00Z' },
+  ]
+
+  assert.deepEqual(
+    warmChatCandidates(chats, null).map(chat => chat.id),
+    ['newer', 'older'],
+  )
 })

--- a/frontend/src/components/Shell/chatPrefetch.js
+++ b/frontend/src/components/Shell/chatPrefetch.js
@@ -1,12 +1,37 @@
-export const RECENT_CHAT_PREFETCH_LIMIT = 2
+export const CHAT_PREFETCH_LIMIT = 6
+export const RECENT_OPEN_CHAT_PREFETCH_LIMIT = 3
 
-export function recentChatsToPrefetch(chats, activeChatId) {
-  return (Array.isArray(chats) ? chats : [])
-    .filter(chat => (
-      chat?.has_messages
-      && String(chat.id) !== String(activeChatId)
-    ))
-    .sort((a, b) => String(b.activity_at || b.updated_at || '')
-      .localeCompare(String(a.activity_at || a.updated_at || '')))
-    .slice(0, RECENT_CHAT_PREFETCH_LIMIT)
+export function warmChatCandidates(
+  chats, activeChatId, recentlyOpenedChatIds = [],
+) {
+  const activeId = String(activeChatId || '')
+  const eligible = (Array.isArray(chats) ? chats : [])
+    .filter(chat => chat?.has_messages && String(chat.id) !== activeId)
+  const byId = new Map(eligible.map(chat => [String(chat.id), chat]))
+  const selected = []
+  const selectedIds = new Set()
+  const add = (chat) => {
+    if (!chat || selectedIds.has(String(chat.id))) return
+    selected.push(chat)
+    selectedIds.add(String(chat.id))
+  }
+
+  // Device-local open history catches the chats the owner actually moves
+  // between, while server owner activity covers recent work from other devices.
+  // Agent-only updated_at churn deliberately cannot crowd out either signal.
+  const opened = (Array.isArray(recentlyOpenedChatIds)
+    ? recentlyOpenedChatIds
+    : [])
+    .map(id => byId.get(String(id)))
+    .filter(Boolean)
+  opened.slice(0, RECENT_OPEN_CHAT_PREFETCH_LIMIT).forEach(add)
+
+  eligible
+    .filter(chat => chat.activity_at)
+    .sort((a, b) => String(b.activity_at).localeCompare(String(a.activity_at)))
+    .forEach((chat) => {
+      if (selected.length < CHAT_PREFETCH_LIMIT) add(chat)
+    })
+
+  return selected.slice(0, CHAT_PREFETCH_LIMIT)
 }

--- a/frontend/src/lib/__tests__/navigationPersistence.test.js
+++ b/frontend/src/lib/__tests__/navigationPersistence.test.js
@@ -5,6 +5,7 @@ import {
   consumeReturnView,
   parseShellDeepLink,
   persistActiveNavigation,
+  readRecentlyOpenedChatIds,
   readRestoredCanvas,
   readStoredChatId,
 } from '../navigationPersistence.js'
@@ -57,4 +58,39 @@ test('active navigation mirrors cold state without retaining a stale app', () =>
     activeView: 'chat', activeChatId: 'chat-2', activeAppId: null,
   })
   assert.equal(store.values.has('moebius_active_app'), false)
+})
+
+test('recent chat history is device-local, deduplicated, and bounded', () => {
+  const store = storage()
+  for (let index = 0; index < 14; index += 1) {
+    persistActiveNavigation(store, {
+      activeView: 'chat', activeChatId: `chat-${index}`, activeAppId: null,
+    })
+  }
+  persistActiveNavigation(store, {
+    activeView: 'chat', activeChatId: 'chat-7', activeAppId: null,
+  })
+
+  const recent = readRecentlyOpenedChatIds(store)
+  assert.equal(recent.length, 12)
+  assert.equal(recent[0], 'chat-7')
+  assert.equal(recent.filter(id => id === 'chat-7').length, 1)
+})
+
+test('only a visible chat navigation records an open', () => {
+  const store = storage()
+  persistActiveNavigation(store, {
+    activeView: 'canvas', activeChatId: 'remembered-chat', activeAppId: 7,
+  })
+  assert.deepEqual(readRecentlyOpenedChatIds(store), [])
+
+  persistActiveNavigation(store, {
+    activeView: 'chat', activeChatId: 'visible-chat', activeAppId: null,
+  })
+  assert.deepEqual(readRecentlyOpenedChatIds(store), ['visible-chat'])
+})
+
+test('malformed recent chat history degrades to no history', () => {
+  const store = storage({ 'mobius:recent-chat-ids': '{bad' })
+  assert.deepEqual(readRecentlyOpenedChatIds(store), [])
 })

--- a/frontend/src/lib/navigationPersistence.js
+++ b/frontend/src/lib/navigationPersistence.js
@@ -2,6 +2,31 @@ const ACTIVE_CHAT_KEY = 'moebius_active_chat'
 const ACTIVE_VIEW_KEY = 'moebius_active_view'
 const ACTIVE_APP_KEY = 'moebius_active_app'
 const RETURN_VIEW_KEY = 'mobius:return-view'
+const RECENT_CHAT_IDS_KEY = 'mobius:recent-chat-ids'
+
+export const RECENT_CHAT_HISTORY_LIMIT = 12
+
+export function readRecentlyOpenedChatIds(storage = globalThis.localStorage) {
+  try {
+    const parsed = JSON.parse(storage?.getItem(RECENT_CHAT_IDS_KEY) || '[]')
+    if (!Array.isArray(parsed)) return []
+    return [...new Set(parsed.map(String).filter(Boolean))]
+      .slice(0, RECENT_CHAT_HISTORY_LIMIT)
+  } catch { return [] }
+}
+
+export function rememberOpenedChat(storage, chatId) {
+  const normalized = String(chatId || '')
+  if (!normalized) return
+  try {
+    const recent = readRecentlyOpenedChatIds(storage)
+      .filter(id => id !== normalized)
+    storage?.setItem(
+      RECENT_CHAT_IDS_KEY,
+      JSON.stringify([normalized, ...recent].slice(0, RECENT_CHAT_HISTORY_LIMIT)),
+    )
+  } catch { /* private mode / disabled storage: navigation remains live */ }
+}
 
 export function readStoredChatId(storage = globalThis.localStorage) {
   try { return storage?.getItem(ACTIVE_CHAT_KEY) ?? null } catch { return null }
@@ -53,6 +78,9 @@ export function persistActiveNavigation(
 ) {
   try {
     if (activeChatId) storage?.setItem(ACTIVE_CHAT_KEY, activeChatId)
+    if (activeView === 'chat' && activeChatId) {
+      rememberOpenedChat(storage, activeChatId)
+    }
     storage?.setItem(ACTIVE_VIEW_KEY, activeView)
     if (activeView === 'canvas' && activeAppId != null) {
       storage?.setItem(ACTIVE_APP_KEY, String(activeAppId))


### PR DESCRIPTION
## Summary
- warm a bounded blend of recently opened and recently owner-active chats after the drawer settles
- persist a small device-local recently-opened history so background agent activity cannot consume the entire warm budget
- respect data-saver, skip the active/empty chats, schedule at browser idle, and cap total/background fetches
- keep navigation focus behavior unchanged

## Validation
- full frontend unit and hook suite passed: 2,345 unit + 79 hook tests
- pre-push privacy, conflict-marker, JSX parse, and frontend-unit gates passed

Fresh hosted CI and independent review are required before merge.
