### PR TITLE
Speed up chat switching and drawer loading

### DIFF
--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -1792,7 +1792,11 @@ class ChatWriterActor:
     chat_update = db.execute(
       update(Chat)
       .where(Chat.id == cmd.chat_id, Chat.deleted_at.is_(None))
-      .values(messages=cmd.messages, live_assistant=None)
+      .values(
+        messages=cmd.messages,
+        has_messages=bool(cmd.messages),
+        live_assistant=None,
+      )
     )
     if chat_update.rowcount != 1:
       db.rollback()
@@ -1938,7 +1942,11 @@ class ChatWriterActor:
           ~active_run_exists,
           Chat.updated_at == snap_updated_at,
         )
-        .values(messages=plan.new_messages, pending_messages=plan.new_pending)
+        .values(
+          messages=plan.new_messages,
+          has_messages=bool(plan.new_messages),
+          pending_messages=plan.new_pending,
+        )
       )
     except OperationalError:
       db.rollback()

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1360,6 +1360,31 @@ def _add_connector_capability_identity(eng) -> None:
       ))
 
 
+def _add_chat_has_messages(eng) -> None:
+  """Materialize transcript emptiness for the drawer's hot list query."""
+  from sqlalchemy import inspect as sa_inspect, text
+
+  inspector = sa_inspect(eng)
+  if "chats" not in inspector.get_table_names():
+    return
+  columns = {column["name"] for column in inspector.get_columns("chats")}
+  if "has_messages" in columns:
+    return
+  with eng.begin() as conn:
+    conn.execute(text(
+      "ALTER TABLE chats ADD COLUMN has_messages BOOLEAN "
+      "NOT NULL DEFAULT FALSE"
+    ))
+    # One deliberate upgrade-time scan replaces the same scan on every drawer
+    # refresh. Legacy rows are non-null JSON, but guard NULL for hand-built DBs.
+    if "messages" in columns:
+      conn.execute(text(
+        "UPDATE chats SET has_messages = CASE "
+        "WHEN messages IS NOT NULL AND CAST(messages AS TEXT) != '[]' "
+        "THEN TRUE ELSE FALSE END"
+      ))
+
+
 _SCHEMA_MIGRATIONS = (
   ("0001_legacy_schema_convergence", _converge_legacy_schema),
   ("0002_chat_run_goal_objective", _add_chat_run_goal_objective),
@@ -1367,6 +1392,7 @@ _SCHEMA_MIGRATIONS = (
   ("0004_app_identity_required", _require_app_identity),
   ("0005_connectors", _add_connectors_table),
   ("0006_connector_capability_identity", _add_connector_capability_identity),
+  ("0007_chat_has_messages", _add_chat_has_messages),
 )
 
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -21,7 +21,7 @@ from sqlalchemy import (
   LargeBinary, String, Text, UniqueConstraint, event, false, or_, true,
 )
 
-from sqlalchemy.orm import column_property
+from sqlalchemy.orm import column_property, validates
 
 from app.database import Base
 from app.timeutil import now_naive_utc
@@ -116,6 +116,13 @@ class Chat(Base):
   # drops back to the agent summary / first message and gets re-derived.
   title_locked = Column(Boolean, nullable=False, default=False)
   messages = Column(JSON, nullable=False, default=list)
+  # Drawer/list reads need only to know whether a transcript is empty. Keeping
+  # that fact beside the blob prevents every chat-list request from scanning
+  # every stored transcript. All runtime transcript writes flow through normal
+  # ORM assignment or the two explicit bulk paths in chat_writer.
+  has_messages = Column(
+    Boolean, nullable=False, default=False, server_default=false()
+  )
   # Current in-flight assistant state is separate from immutable history so a
   # streaming update never rewrites every prior message. Finalize and startup
   # recovery merge this bounded value into `messages`.
@@ -180,6 +187,11 @@ class Chat(Base):
   activity_at = Column(
     DateTime, nullable=True, default=lambda: datetime.now(UTC)
   )
+
+  @validates("messages")
+  def _sync_has_messages(self, _key, value):
+    self.has_messages = bool(value)
+    return value
 
 
 class ChatRun(Base):

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -341,7 +341,7 @@ def _owner_chat_summary(chat: models.Chat, *, durable_running: bool = False) -> 
     "updated_at": chat.updated_at.isoformat(),
     "activity_at": chat.activity_at.isoformat() if chat.activity_at else None,
     "pinned_at": chat.pinned_at.isoformat() if chat.pinned_at else None,
-    "has_messages": bool(chat.messages and len(chat.messages) > 0),
+    "has_messages": bool(chat.has_messages),
     "created_by_app_id": chat.created_by_app_id,
     "running": durable_running or is_chat_running(chat.id),
   }
@@ -353,8 +353,8 @@ def _owner_chat_summary_projection(chat, *, durable_running: bool = False) -> di
   ``GET /api/chats`` used to hydrate every complete ``Chat`` ORM object merely
   to return eight summary fields. On a long-lived instance that decoded tens of
   megabytes of transcript JSON on every drawer open and chat switch, contending
-  with the selected chat's small detail read. Keep transcript inspection inside
-  the database (``message_count``) and never materialize ``messages`` here.
+  with the selected chat's small detail read. The writer-owned ``has_messages``
+  summary keeps this projection independent of the transcript blob entirely.
   """
   return {
     "id": chat.id,
@@ -362,7 +362,7 @@ def _owner_chat_summary_projection(chat, *, durable_running: bool = False) -> di
     "updated_at": chat.updated_at.isoformat(),
     "activity_at": chat.activity_at.isoformat() if chat.activity_at else None,
     "pinned_at": chat.pinned_at.isoformat() if chat.pinned_at else None,
-    "has_messages": bool(chat.message_count),
+    "has_messages": bool(chat.has_messages),
     "created_by_app_id": chat.created_by_app_id,
     "running": durable_running or is_chat_running(chat.id),
   }
@@ -577,16 +577,9 @@ def list_chats(
   # a `desc()` on a nullable column would put NULL last under our
   # SQLite collation, but making the boolean explicit is clearer and
   # portable.
-  # Drawer projection only. Selecting the Chat entity here hydrates its full
-  # ``messages`` JSON column even though the response needs only a boolean; on
-  # this owner's history that was ~47 MB of JSON decoding per refresh. Compare
-  # the canonical serialized empty-array value in SQL instead of parsing every
-  # JSON array with json_array_length: Chat.messages is a non-null list written
-  # by SQLAlchemy's canonical serializer, and CAST(... AS TEXT) is portable
-  # across SQLite and PostgreSQL. A future raw-import path must normalize JSON
-  # text first (PostgreSQL's json type preserves whitespace such as ``[ ]``).
-  # The database can reject non-empty values from their stored length without
-  # walking every transcript.
+  # Drawer projection only. ``has_messages`` is maintained with the transcript
+  # by the Chat model and the two writer bulk-update paths, so this hot query
+  # never reads or decodes the potentially large ``messages`` JSON column.
   q = db.query(
     models.Chat.id,
     models.Chat.title,
@@ -598,10 +591,7 @@ def list_chats(
     # chats normally keep this NULL, so this remains a tiny projection rather
     # than pulling transcript/runtime JSON into the hot path.
     models.Chat.agent_settings_json,
-    case(
-      (cast(models.Chat.messages, Text) != "[]", 1),
-      else_=0,
-    ).label("message_count"),
+    models.Chat.has_messages,
   ).filter(models.Chat.deleted_at.is_(None))
   chats = (
     q.order_by(
@@ -2373,7 +2363,7 @@ def _app_chat_summary(chat: models.Chat) -> dict:
     "created_at": chat.created_at.isoformat() if chat.created_at else None,
     "updated_at": chat.updated_at.isoformat() if chat.updated_at else None,
     "activity_at": chat.activity_at.isoformat() if chat.activity_at else None,
-    "has_messages": bool(chat.messages and len(chat.messages) > 0),
+    "has_messages": bool(chat.has_messages),
     "provider": chat.provider or "claude",
     "scope": _app_chat_scope(chat),
     "scope_label": _app_chat_scope_label(chat),

--- a/backend/tests/test_chats.py
+++ b/backend/tests/test_chats.py
@@ -277,7 +277,7 @@ def test_create_repair_chat_is_idempotent_across_ambiguous_retries(client, auth)
 
 
 def test_chat_list_projects_summaries_without_hydrating_transcripts(
-  client, auth,
+  client, auth, db,
 ):
   created = client.post(
     "/api/chats",
@@ -290,15 +290,22 @@ def test_chat_list_projects_summaries_without_hydrating_transcripts(
   assert created.status_code == 200
 
   hydrated_chat_ids = []
+  drawer_selects = []
 
   def on_load(chat, _context):
     hydrated_chat_ids.append(chat.id)
 
+  def capture_sql(_conn, _cursor, statement, _parameters, _context, _many):
+    if "FROM chats" in statement:
+      drawer_selects.append(statement)
+
   event.listen(models.Chat, "load", on_load)
+  event.listen(db.get_bind(), "before_cursor_execute", capture_sql)
   try:
     listed = client.get("/api/chats", headers=auth)
   finally:
     event.remove(models.Chat, "load", on_load)
+    event.remove(db.get_bind(), "before_cursor_execute", capture_sql)
 
   assert listed.status_code == 200
   row = next(item for item in listed.json() if item["id"] == created.json()["id"])
@@ -306,6 +313,48 @@ def test_chat_list_projects_summaries_without_hydrating_transcripts(
   assert hydrated_chat_ids == [], (
     "the drawer list must not instantiate Chat objects and decode messages"
   )
+  drawer_query = next(
+    statement for statement in drawer_selects
+    if "ORDER BY" in statement and "chats.has_messages" in statement
+  )
+  assert "chats.messages AS" not in drawer_query, (
+    "the drawer list must not read the transcript blob"
+  )
+
+
+def test_chat_list_message_summary_tracks_transcript_replacements(
+  client, auth,
+):
+  created = client.post(
+    "/api/chats",
+    json={
+      "title": "Summary invariant",
+      "messages": [{"role": "user", "content": "hello"}],
+    },
+    headers=auth,
+  )
+  assert created.status_code == 200
+  chat_id = created.json()["id"]
+
+  cleared = client.put(
+    f"/api/chats/{chat_id}", json={"messages": []}, headers=auth,
+  )
+  assert cleared.status_code == 200
+  listed = client.get("/api/chats", headers=auth)
+  assert next(row for row in listed.json() if row["id"] == chat_id)[
+    "has_messages"
+  ] is False
+
+  restored = client.put(
+    f"/api/chats/{chat_id}",
+    json={"messages": [{"role": "user", "content": "back"}]},
+    headers=auth,
+  )
+  assert restored.status_code == 200
+  listed = client.get("/api/chats", headers=auth)
+  assert next(row for row in listed.json() if row["id"] == chat_id)[
+    "has_messages"
+  ] is True
 
 
 def test_chat_list_orders_by_owner_activity_not_agent_updates(

--- a/backend/tests/test_db_migrations.py
+++ b/backend/tests/test_db_migrations.py
@@ -1009,6 +1009,7 @@ def test_run_migrations_records_an_inspectable_append_only_history(tmp_path):
     "0004_app_identity_required",
     "0005_connectors",
     "0006_connector_capability_identity",
+    "0007_chat_has_messages",
   ]
   assert second == first
 
@@ -1065,6 +1066,38 @@ def test_connectors_migration_preserves_preview_era_rows(tmp_path):
   }
   assert "0006_connector_capability_identity" in {
     entry["version"] for entry in schema_migration_history(eng)
+  }
+
+
+def test_chat_message_summary_migration_backfills_legacy_transcripts(tmp_path):
+  eng = create_engine(f"sqlite:///{tmp_path / 'chat-message-summary.db'}")
+  with eng.begin() as conn:
+    conn.execute(text(
+      "CREATE TABLE apps (id INTEGER PRIMARY KEY, name VARCHAR(255))"
+    ))
+    conn.execute(text(
+      "CREATE TABLE chats ("
+      "id VARCHAR(64) PRIMARY KEY, title VARCHAR(255), messages JSON, "
+      "updated_at DATETIME)"
+    ))
+    conn.execute(text(
+      "INSERT INTO chats (id, title, messages) VALUES "
+      "('empty', 'Empty', '[]'), "
+      "('started', 'Started', '[{\"role\": \"user\"}]')"
+    ))
+
+  run_migrations(eng)
+  run_migrations(eng)
+
+  columns = {item["name"] for item in inspect(eng).get_columns("chats")}
+  with eng.connect() as conn:
+    values = conn.execute(text(
+      "SELECT id, has_messages FROM chats ORDER BY id"
+    )).all()
+  assert "has_messages" in columns
+  assert values == [("empty", 0), ("started", 1)]
+  assert "0007_chat_has_messages" in {
+    row["version"] for row in schema_migration_history(eng)
   }
 
 

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -122,7 +122,8 @@ import {
   MODE_MOTION, EMPTY_SINGLE_SURFACE_KEY,
 } from './workspaceView.js'
 import NewChatLanding from './NewChatLanding.jsx'
-import { recentChatsToPrefetch } from './chatPrefetch.js'
+import { warmChatCandidates } from './chatPrefetch.js'
+import { readRecentlyOpenedChatIds } from '../../lib/navigationPersistence.js'
 import {
   PaneTab, panePanelDomId, paneTabDomId, scrollStripWheel, stripKeyDown,
 } from './PaneStrip.jsx'
@@ -491,13 +492,18 @@ export default function Shell() {
   const chatsStatus = chats.length > 0 || chatsQuery.isSuccess
     ? 'success'
     : (chatsQuery.isError ? 'error' : 'loading')
-  // Prime only the two most-recent chats that are not already open, including
-  // active chats: their cached transcript is useful while stream catch-up runs.
+  // Prime a bounded blend of recently opened and recently owner-active chats.
+  // The blend stays useful when the owner is moving among several pieces of
+  // work without letting background agent updates consume the warm budget.
   // ChatView still revalidates on mount, but this gives its synchronous cache
   // read a real transcript so a later chat switch can paint immediately. Run
   // once after the live drawer projection arrives, at browser idle, and stand
   // down under data-saver so speed never creates surprise background transfer.
   const warmedChatsOnLoadRef = useRef(false)
+  const recentlyOpenedChatIds = useMemo(
+    () => readRecentlyOpenedChatIds(),
+    [],
+  )
   useEffect(() => {
     if (
       warmedChatsOnLoadRef.current
@@ -506,7 +512,9 @@ export default function Shell() {
     ) return
     warmedChatsOnLoadRef.current = true
     if (navigator.connection?.saveData) return
-    const candidates = recentChatsToPrefetch(chats, activeChatId)
+    const candidates = warmChatCandidates(
+      chats, activeChatId, recentlyOpenedChatIds,
+    )
     if (candidates.length === 0) return
     const warm = async () => {
       for (const chat of candidates) {
@@ -524,6 +532,7 @@ export default function Shell() {
     chatsQuery.isFetchedAfterMount,
     chatsQuery.isSuccess,
     queryClient,
+    recentlyOpenedChatIds,
   ])
   const appPreviewAckRef = useRef(new Set())
   const handleAppPreviewSeen = useCallback((app, final) => {

--- a/frontend/src/components/Shell/__tests__/chatPrefetch.test.js
+++ b/frontend/src/components/Shell/__tests__/chatPrefetch.test.js
@@ -2,22 +2,47 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 
 import {
-  RECENT_CHAT_PREFETCH_LIMIT,
-  recentChatsToPrefetch,
+  CHAT_PREFETCH_LIMIT,
+  warmChatCandidates,
 } from '../chatPrefetch.js'
 
-test('recent chat prefetch stays bounded, skips active/empty, and keeps running chats', () => {
+test('warm chats blend recent opens with owner activity and ignore agent-only churn', () => {
   const chats = [
     { id: 'active', has_messages: true, activity_at: '2026-07-26T10:00:00Z' },
-    { id: 'running', has_messages: true, running: true, activity_at: '2026-07-26T12:00:00Z' },
-    { id: 'empty', has_messages: false, activity_at: '2026-07-26T13:00:00Z' },
-    { id: 'older', has_messages: true, activity_at: '2026-07-25T10:00:00Z' },
-    { id: 'newer', has_messages: true, activity_at: '2026-07-26T09:00:00Z' },
-    { id: 'middle', has_messages: true, activity_at: '2026-07-26T08:00:00Z' },
+    { id: 'opened-old', has_messages: true, activity_at: '2026-07-20T10:00:00Z' },
+    { id: 'opened-empty', has_messages: false, activity_at: '2026-07-26T13:00:00Z' },
+    { id: 'owner-1', has_messages: true, activity_at: '2026-07-26T12:00:00Z' },
+    { id: 'owner-2', has_messages: true, activity_at: '2026-07-26T11:00:00Z' },
+    { id: 'owner-3', has_messages: true, activity_at: '2026-07-26T10:00:00Z' },
+    { id: 'owner-4', has_messages: true, activity_at: '2026-07-26T09:00:00Z' },
+    { id: 'owner-5', has_messages: true, activity_at: '2026-07-26T08:00:00Z' },
+    {
+      id: 'agent-busy', has_messages: true,
+      activity_at: '2026-07-01T08:00:00Z', updated_at: '2026-07-27T08:00:00Z',
+    },
   ]
 
-  const selected = recentChatsToPrefetch(chats, 'active')
+  const selected = warmChatCandidates(
+    chats,
+    'active',
+    ['opened-old', 'owner-2', 'opened-empty', 'active'],
+  )
 
-  assert.equal(selected.length, RECENT_CHAT_PREFETCH_LIMIT)
-  assert.deepEqual(selected.map(chat => chat.id), ['running', 'newer'])
+  assert.equal(selected.length, CHAT_PREFETCH_LIMIT)
+  assert.deepEqual(selected.map(chat => chat.id), [
+    'opened-old', 'owner-2', 'owner-1', 'owner-3', 'owner-4', 'owner-5',
+  ])
+  assert.equal(selected.some(chat => chat.id === 'agent-busy'), false)
+})
+
+test('warm chats fall back to owner activity without local open history', () => {
+  const chats = [
+    { id: 'older', has_messages: true, activity_at: '2026-07-25T10:00:00Z' },
+    { id: 'newer', has_messages: true, activity_at: '2026-07-26T09:00:00Z' },
+  ]
+
+  assert.deepEqual(
+    warmChatCandidates(chats, null).map(chat => chat.id),
+    ['newer', 'older'],
+  )
 })

--- a/frontend/src/components/Shell/chatPrefetch.js
+++ b/frontend/src/components/Shell/chatPrefetch.js
@@ -1,12 +1,37 @@
-export const RECENT_CHAT_PREFETCH_LIMIT = 2
+export const CHAT_PREFETCH_LIMIT = 6
+export const RECENT_OPEN_CHAT_PREFETCH_LIMIT = 3
 
-export function recentChatsToPrefetch(chats, activeChatId) {
-  return (Array.isArray(chats) ? chats : [])
-    .filter(chat => (
-      chat?.has_messages
-      && String(chat.id) !== String(activeChatId)
-    ))
-    .sort((a, b) => String(b.activity_at || b.updated_at || '')
-      .localeCompare(String(a.activity_at || a.updated_at || '')))
-    .slice(0, RECENT_CHAT_PREFETCH_LIMIT)
+export function warmChatCandidates(
+  chats, activeChatId, recentlyOpenedChatIds = [],
+) {
+  const activeId = String(activeChatId || '')
+  const eligible = (Array.isArray(chats) ? chats : [])
+    .filter(chat => chat?.has_messages && String(chat.id) !== activeId)
+  const byId = new Map(eligible.map(chat => [String(chat.id), chat]))
+  const selected = []
+  const selectedIds = new Set()
+  const add = (chat) => {
+    if (!chat || selectedIds.has(String(chat.id))) return
+    selected.push(chat)
+    selectedIds.add(String(chat.id))
+  }
+
+  // Device-local open history catches the chats the owner actually moves
+  // between, while server owner activity covers recent work from other devices.
+  // Agent-only updated_at churn deliberately cannot crowd out either signal.
+  const opened = (Array.isArray(recentlyOpenedChatIds)
+    ? recentlyOpenedChatIds
+    : [])
+    .map(id => byId.get(String(id)))
+    .filter(Boolean)
+  opened.slice(0, RECENT_OPEN_CHAT_PREFETCH_LIMIT).forEach(add)
+
+  eligible
+    .filter(chat => chat.activity_at)
+    .sort((a, b) => String(b.activity_at).localeCompare(String(a.activity_at)))
+    .forEach((chat) => {
+      if (selected.length < CHAT_PREFETCH_LIMIT) add(chat)
+    })
+
+  return selected.slice(0, CHAT_PREFETCH_LIMIT)
 }

--- a/frontend/src/lib/__tests__/navigationPersistence.test.js
+++ b/frontend/src/lib/__tests__/navigationPersistence.test.js
@@ -5,6 +5,7 @@ import {
   consumeReturnView,
   parseShellDeepLink,
   persistActiveNavigation,
+  readRecentlyOpenedChatIds,
   readRestoredCanvas,
   readStoredChatId,
 } from '../navigationPersistence.js'
@@ -57,4 +58,39 @@ test('active navigation mirrors cold state without retaining a stale app', () =>
     activeView: 'chat', activeChatId: 'chat-2', activeAppId: null,
   })
   assert.equal(store.values.has('moebius_active_app'), false)
+})
+
+test('recent chat history is device-local, deduplicated, and bounded', () => {
+  const store = storage()
+  for (let index = 0; index < 14; index += 1) {
+    persistActiveNavigation(store, {
+      activeView: 'chat', activeChatId: `chat-${index}`, activeAppId: null,
+    })
+  }
+  persistActiveNavigation(store, {
+    activeView: 'chat', activeChatId: 'chat-7', activeAppId: null,
+  })
+
+  const recent = readRecentlyOpenedChatIds(store)
+  assert.equal(recent.length, 12)
+  assert.equal(recent[0], 'chat-7')
+  assert.equal(recent.filter(id => id === 'chat-7').length, 1)
+})
+
+test('only a visible chat navigation records an open', () => {
+  const store = storage()
+  persistActiveNavigation(store, {
+    activeView: 'canvas', activeChatId: 'remembered-chat', activeAppId: 7,
+  })
+  assert.deepEqual(readRecentlyOpenedChatIds(store), [])
+
+  persistActiveNavigation(store, {
+    activeView: 'chat', activeChatId: 'visible-chat', activeAppId: null,
+  })
+  assert.deepEqual(readRecentlyOpenedChatIds(store), ['visible-chat'])
+})
+
+test('malformed recent chat history degrades to no history', () => {
+  const store = storage({ 'mobius:recent-chat-ids': '{bad' })
+  assert.deepEqual(readRecentlyOpenedChatIds(store), [])
 })

--- a/frontend/src/lib/navigationPersistence.js
+++ b/frontend/src/lib/navigationPersistence.js
@@ -2,6 +2,31 @@ const ACTIVE_CHAT_KEY = 'moebius_active_chat'
 const ACTIVE_VIEW_KEY = 'moebius_active_view'
 const ACTIVE_APP_KEY = 'moebius_active_app'
 const RETURN_VIEW_KEY = 'mobius:return-view'
+const RECENT_CHAT_IDS_KEY = 'mobius:recent-chat-ids'
+
+export const RECENT_CHAT_HISTORY_LIMIT = 12
+
+export function readRecentlyOpenedChatIds(storage = globalThis.localStorage) {
+  try {
+    const parsed = JSON.parse(storage?.getItem(RECENT_CHAT_IDS_KEY) || '[]')
+    if (!Array.isArray(parsed)) return []
+    return [...new Set(parsed.map(String).filter(Boolean))]
+      .slice(0, RECENT_CHAT_HISTORY_LIMIT)
+  } catch { return [] }
+}
+
+export function rememberOpenedChat(storage, chatId) {
+  const normalized = String(chatId || '')
+  if (!normalized) return
+  try {
+    const recent = readRecentlyOpenedChatIds(storage)
+      .filter(id => id !== normalized)
+    storage?.setItem(
+      RECENT_CHAT_IDS_KEY,
+      JSON.stringify([normalized, ...recent].slice(0, RECENT_CHAT_HISTORY_LIMIT)),
+    )
+  } catch { /* private mode / disabled storage: navigation remains live */ }
+}
 
 export function readStoredChatId(storage = globalThis.localStorage) {
   try { return storage?.getItem(ACTIVE_CHAT_KEY) ?? null } catch { return null }
@@ -53,6 +78,9 @@ export function persistActiveNavigation(
 ) {
   try {
     if (activeChatId) storage?.setItem(ACTIVE_CHAT_KEY, activeChatId)
+    if (activeView === 'chat' && activeChatId) {
+      rememberOpenedChat(storage, activeChatId)
+    }
     storage?.setItem(ACTIVE_VIEW_KEY, activeView)
     if (activeView === 'canvas' && activeAppId != null) {
       storage?.setItem(ACTIVE_APP_KEY, String(activeAppId))


### PR DESCRIPTION
## Summary

- warm a bounded mix of recently opened and owner-active chats after the live chat list arrives, while respecting Data Saver
- keep drawer chat summaries independent of transcript blobs with a maintained `has_messages` field and a one-time backfill
- verify the drawer query never selects transcript content and that the summary stays synchronized with transcript replacements

## Testing

- `scripts/wt-pytest.sh backend/tests/test_chats.py backend/tests/test_db_migrations.py -q --tb=short`
- `npm test`