### PR TITLE
Simplify app source reconciliation ownership

### DIFF
--- a/backend/app/app_git.py
+++ b/backend/app/app_git.py
@@ -212,6 +212,8 @@ class MergeResult:
   proves a newer semantic base but a later genuine conflict remains, it names
   that synthetic base tree so the owner-gated resolver can materialize only the
   residual conflicts instead of repeating Git's older historical conflict set.
+  `unrelated_histories` records the other explicit merge mode so the resolver
+  can ask Git to materialize the same verdict.
 
   There is one path for one and many files: a single-file app is just a tree
   with one source key (`index.jsx`), so the caller always reads the merged tree
@@ -221,10 +223,25 @@ class MergeResult:
   conflict_paths: list[str] = field(default_factory=list)
   merged_tree_oid: str | None = None
   merge_base_oid: str | None = None
+  unrelated_histories: bool = False
   equivalent_change_refs: tuple[str, ...] = ()
   reconciliation: ReconciliationReceipt = field(
     default_factory=ReconciliationReceipt,
   )
+
+
+@dataclass(frozen=True)
+class FetchUpstreamResult:
+  """Fetched origin tip plus the narrow proof needed for legacy adoption.
+
+  ``allow_unrelated_histories`` is true only when the caller identified the
+  configured origin as trusted and Git proved that its complete tree equals
+  local ``main``.  Keeping the proof beside the fetched SHA prevents later
+  merge callers from widening unrelated-history handling by accident.
+  """
+
+  sha: str
+  allow_unrelated_histories: bool = False
 
 
 @dataclass(frozen=True)
@@ -595,6 +612,7 @@ def merge_refs(
   right: str,
   *,
   merge_base: str | None = None,
+  allow_unrelated_histories: bool = False,
 ) -> MergeResult:
   """Off-tree three-way merge of two refs, optionally with an explicit base.
 
@@ -606,6 +624,8 @@ def merge_refs(
   args = ["merge-tree", "--write-tree", "--name-only"]
   if merge_base is not None:
     args.extend(("--merge-base", merge_base))
+  if allow_unrelated_histories:
+    args.append("--allow-unrelated-histories")
   args.extend((left, right))
   proc = _run(repo, *args, check=False)
   if proc.returncode > 1:
@@ -650,7 +670,11 @@ def _change_is_subsumed(
   )
 
 
-def _diff_paths(repo: Path, left: str, right: str) -> set[str] | None:
+def endpoint_diff_paths(
+  source_dir: str | Path, left: str, right: str,
+) -> set[str] | None:
+  """Complete endpoint path differences, or ``None`` when Git cannot answer."""
+  repo = Path(source_dir)
   proc = _run(
     repo, "diff", "--name-only", "--no-renames", "-z", f"{left}..{right}",
     check=False,
@@ -665,27 +689,12 @@ def ref_trees_equal(
 ) -> bool:
   """Whether two refs name the same complete tree, regardless of history."""
   repo = Path(source_dir)
-  left_tree = _tree_oid(repo, left)
-  right_tree = _tree_oid(repo, right)
+  try:
+    left_tree = _tree_oid(repo, left)
+    right_tree = _tree_oid(repo, right)
+  except (OSError, subprocess.SubprocessError):
+    return False
   return bool(left_tree and left_tree == right_tree)
-
-
-def refs_share_history(
-  source_dir: str | Path, left: str, right: str,
-) -> bool:
-  """Whether two refs have a merge base without moving either ref."""
-  proc = _run(
-    Path(source_dir), "merge-base", left, right, check=False,
-  )
-  return proc.returncode == 0 and bool(proc.stdout.strip())
-
-
-def diff_paths(
-  source_dir: str | Path, left: str, right: str,
-) -> tuple[str, ...]:
-  """Complete endpoint path differences, or an empty tuple on Git failure."""
-  paths = _diff_paths(Path(source_dir), left, right)
-  return tuple(sorted(paths)) if paths is not None else ()
 
 
 def describe_reconciliation(
@@ -707,8 +716,10 @@ def describe_reconciliation(
   """
   repo = Path(source_dir)
   proven = tuple(proven_changes)
-  local_paths = (_diff_paths(repo, shared_base, local) if local else set()) or set()
-  new_paths = _diff_paths(repo, shared_base, upstream) or set()
+  local_paths = (
+    endpoint_diff_paths(repo, shared_base, local) if local else set()
+  ) or set()
+  new_paths = endpoint_diff_paths(repo, shared_base, upstream) or set()
   conflicts = set(conflict_paths)
   compatible = local_paths & new_paths - conflicts
   return ReconciliationReceipt(
@@ -750,8 +761,8 @@ def _source_is_resolved_projection(
   if len(parent_line) != 2:
     return False
   source_parent = parent_line[1]
-  reviewed_paths = _diff_paths(repo, reviewed_base, reviewed_head)
-  source_paths = _diff_paths(repo, source_parent, source_sha)
+  reviewed_paths = endpoint_diff_paths(repo, reviewed_base, reviewed_head)
+  source_paths = endpoint_diff_paths(repo, source_parent, source_sha)
   if not reviewed_paths or source_paths != reviewed_paths:
     return False
 
@@ -1267,7 +1278,15 @@ def preview_reconciliation(
     return equivalent.reconciliation
   base = _run(repo, "merge-base", local, upstream, check=False).stdout.strip()
   if not base:
-    return ReconciliationReceipt()
+    try:
+      unrelated = merge_refs(
+        repo, local, upstream, allow_unrelated_histories=True,
+      )
+    except (OSError, subprocess.SubprocessError, RuntimeError):
+      return ReconciliationReceipt()
+    return ReconciliationReceipt(
+      unresolved_conflict_paths=tuple(sorted(unrelated.conflict_paths)),
+    )
   try:
     ordinary = merge_refs(repo, local, upstream)
     conflicts = ordinary.conflict_paths
@@ -1416,7 +1435,12 @@ def clone_upstream(
     return sha
 
 
-def fetch_upstream(source_dir: str | Path, ref: str) -> str:
+def fetch_upstream(
+  source_dir: str | Path,
+  ref: str,
+  *,
+  adopt_equal_local_tree: bool = False,
+) -> FetchUpstreamResult:
   """Fetch `origin/<ref>` and advance local `upstream` to that real commit.
 
   This is the cloned-app update analogue of `record_upstream`: the catalog's
@@ -1426,8 +1450,15 @@ def fetch_upstream(source_dir: str | Path, ref: str) -> str:
   when that happens, unshallow so Git can prove ancestry and the existing merge
   path can compute a real merge base.
 
+  ``adopt_equal_local_tree`` is the narrow legacy-adoption exception. The
+  caller must first prove that this repo's configured origin is the trusted
+  package identity. When the fetched origin commit has the exact same complete
+  tree as local ``main``, moving the old synthetic ``upstream`` ref cannot
+  overwrite a local byte; rebinding it to the real origin repairs provenance
+  without asking the owner to resolve unrelated installer history.
+
   Returns:
-    The fetched `origin/<ref>` commit sha.
+    The fetched commit and any trusted equal-tree adoption proof.
   """
   repo = Path(source_dir)
   previous = _run(
@@ -1440,18 +1471,25 @@ def fetch_upstream(source_dir: str | Path, ref: str) -> str:
   # A depth-one fetch can re-graft even an unchanged tip. Repair based on the
   # relationship the installer actually needs (local main ↔ fetched tip), not
   # only on whether the remote SHA string changed.
-  _unshallow_if_no_merge_base(repo, LOCAL_BRANCH, remote_ref)
+  _restore_shallow_history_if_needed(repo, LOCAL_BRANCH, remote_ref)
+  equal_local_adoption = (
+    adopt_equal_local_tree
+    and ref_trees_equal(repo, LOCAL_BRANCH, remote_ref)
+  )
   if previous_sha and previous_sha != sha:
     related = _run(
       repo, "merge-base", "--is-ancestor", previous_sha, sha, check=False,
     )
-    if related.returncode != 0:
+    if related.returncode != 0 and not equal_local_adoption:
       raise RuntimeError(
         f"origin/{ref} is unrelated to recorded upstream {previous_sha}; "
         "falling back to manifest-source update"
       )
   _run(repo, "branch", "-f", UPSTREAM_BRANCH, remote_ref)
-  return sha
+  return FetchUpstreamResult(
+    sha=sha,
+    allow_unrelated_histories=equal_local_adoption,
+  )
 
 
 def ensure_repo(source_dir: str | Path) -> None:
@@ -1906,18 +1944,20 @@ def local_diverged_from(source_dir: str | Path, base_commit: str) -> bool:
   return proc.returncode != 0
 
 
-def _unshallow_if_no_merge_base(
+def _restore_shallow_history_if_needed(
   source_dir: str | Path,
   left: str = LOCAL_BRANCH,
   right: str = UPSTREAM_BRANCH,
 ) -> None:
-  """Restore remote history when a shallow graft hides a real merge base.
+  """Restore remote history when a shallow graft may hide a merge base.
 
   Depth-one app fetches can make ``main`` and ``upstream`` appear unrelated
   even though both came from the same origin. The update verdict and the
   resolver's real merge both require that base, so they self-heal at their
-  entry points. A failed/offline fetch is best-effort and leaves refs and the
-  working tree untouched; the subsequent merge reports its normal error.
+  entry points. A failed/offline fetch raises without moving refs or the
+  working tree. If unshallowing proves the histories are genuinely unrelated,
+  return normally: the merge seam handles that valid legacy-adoption shape
+  with Git's empty-base semantics.
   """
   repo = Path(source_dir)
   shallow_raw = _run(repo, "rev-parse", "--git-path", "shallow").stdout.strip()
@@ -1941,15 +1981,13 @@ def _unshallow_if_no_merge_base(
   if fetched.returncode != 0:
     detail = fetched.stderr.strip() or fetched.stdout.strip()
     raise RuntimeError(f"failed to restore app git history: {detail}")
-  base = _run(repo, "merge-base", left, right, check=False)
-  if base.returncode != 0 or not base.stdout.strip():
-    raise RuntimeError(
-      f"unrelated histories: no merge base between {left} and {right} "
-      "after unshallow"
-    )
 
 
-def merge_upstream(source_dir: str | Path) -> MergeResult:
+def merge_upstream(
+  source_dir: str | Path,
+  *,
+  allow_unrelated_histories: bool = False,
+) -> MergeResult:
   """Merges `upstream` into `main` and returns the verdict.
 
   Uses `git merge-tree --write-tree` to perform the three-way merge in
@@ -1970,11 +2008,23 @@ def merge_upstream(source_dir: str | Path) -> MergeResult:
   """
   repo = Path(source_dir)
   ensure_repo(repo)
-  _unshallow_if_no_merge_base(repo)
-  ordinary = merge_refs(repo, LOCAL_BRANCH, UPSTREAM_BRANCH)
+  _restore_shallow_history_if_needed(repo)
   ordinary_base = _run(
     repo, "merge-base", LOCAL_BRANCH, UPSTREAM_BRANCH, check=False,
   ).stdout.strip()
+  if ordinary_base:
+    ordinary = merge_refs(repo, LOCAL_BRANCH, UPSTREAM_BRANCH)
+  else:
+    if not allow_unrelated_histories:
+      raise RuntimeError(
+        "local main and recorded upstream have unrelated histories"
+      )
+    # A rewritten legacy checkout and its explicitly proven catalog origin can
+    # have no common commit. The empty tree is the only honest shared state.
+    ordinary = merge_refs(
+      repo, LOCAL_BRANCH, UPSTREAM_BRANCH, allow_unrelated_histories=True,
+    )
+    ordinary.unrelated_histories = True
   if ordinary_base:
     ordinary.reconciliation = describe_reconciliation(
       repo,
@@ -1982,6 +2032,10 @@ def merge_upstream(source_dir: str | Path) -> MergeResult:
       UPSTREAM_BRANCH,
       local=LOCAL_BRANCH,
       conflict_paths=ordinary.conflict_paths,
+    )
+  elif ordinary.conflict_paths:
+    ordinary.reconciliation = ReconciliationReceipt(
+      unresolved_conflict_paths=tuple(sorted(ordinary.conflict_paths)),
     )
   if ordinary.status == "clean":
     return ordinary
@@ -2119,6 +2173,7 @@ def start_conflict_merge(
   source_dir: str | Path,
   *,
   merge_base: str | None = None,
+  allow_unrelated_histories: bool = False,
   local_branch: str = LOCAL_BRANCH,
   upstream_branch: str = UPSTREAM_BRANCH,
 ) -> list[str]:
@@ -2145,20 +2200,28 @@ def start_conflict_merge(
   same as an ordinary merge while already-landed contribution conflicts stay
   eliminated for both platform and app resolvers.
 
+  When ``allow_unrelated_histories`` is true, Git owns the corresponding
+  empty-base merge directly. This is reserved for legacy source whose catalog
+  identity is proven even though an earlier apply rewrote its commit history.
+
   Returns the conflicting repo-relative paths. In the pathological case where
   the materialized merge resolves clean, it resets to the committed local state
   and returns an empty list so the caller never strands a half-merge.
   """
   repo = Path(source_dir)
   ensure_repo(repo)
-  _unshallow_if_no_merge_base(repo, local_branch, upstream_branch)
+  _restore_shallow_history_if_needed(repo, local_branch, upstream_branch)
   local_sha = head_sha(repo, local_branch)
   upstream_sha = head_sha(repo, upstream_branch)
   if _run(repo, "status", "--porcelain").stdout.strip():
     raise RuntimeError("cannot start conflict merge with local source edits")
   if merge_base is None:
+    merge_args = ["merge", "--no-commit", "--no-ff"]
+    if allow_unrelated_histories:
+      merge_args.append("--allow-unrelated-histories")
+    merge_args.append(upstream_branch)
     merged = _run(
-      repo, "merge", "--no-commit", "--no-ff", upstream_branch, check=False,
+      repo, *merge_args, check=False,
     )
   else:
     verdict = merge_refs(

--- a/backend/app/install.py
+++ b/backend/app/install.py
@@ -2488,6 +2488,7 @@ async def install_from_manifest(
   )
   cloned_install = False
   cloned_update = False
+  allow_unrelated_histories = False
   # Source deletes are computed from old-upstream minus new-upstream. The prune
   # phase consumes this explicit diff so local-only tracked siblings are not
   # mistaken for files the manifest intentionally removed.
@@ -2634,8 +2635,15 @@ async def install_from_manifest(
         ):
           _, ref = repo_ref
           try:
-            app.upstream_commit = await asyncio.to_thread(
-              app_git.fetch_upstream, git_source_dir, ref,
+            fetched_upstream = await asyncio.to_thread(
+              app_git.fetch_upstream,
+              git_source_dir,
+              ref,
+              adopt_equal_local_tree=target.adopting_trusted_origin,
+            )
+            app.upstream_commit = fetched_upstream.sha
+            allow_unrelated_histories = (
+              fetched_upstream.allow_unrelated_histories
             )
             cloned_update = True
           except Exception as exc:
@@ -2662,41 +2670,7 @@ async def install_from_manifest(
             app_git.UPSTREAM_BRANCH,
           )
         dropped_source_paths = previous_upstream_paths - new_upstream_paths
-        if target.adopting_trusted_origin and cloned_update:
-          # Legacy explicit-apply rewrote Git history even when it preserved
-          # the canonical repository tree byte-for-byte. Exact tree equality
-          # is therefore the safe adoption fast path: there is no local byte
-          # to overwrite, so advancing the catalog baseline cannot lose work.
-          # Different unrelated trees have no honest three-way base; surface
-          # every endpoint difference for owner-gated resolution instead of
-          # guessing or failing the install with a raw merge-tree error.
-          same_tree = await asyncio.to_thread(
-            app_git.ref_trees_equal,
-            git_source_dir,
-            app_git.LOCAL_BRANCH,
-            app_git.UPSTREAM_BRANCH,
-          )
-          if same_tree:
-            diverged = False
-          elif not await asyncio.to_thread(
-            app_git.refs_share_history,
-            git_source_dir,
-            app_git.LOCAL_BRANCH,
-            app_git.UPSTREAM_BRANCH,
-          ):
-            conflict_paths = list(await asyncio.to_thread(
-              app_git.diff_paths,
-              git_source_dir,
-              app_git.LOCAL_BRANCH,
-              app_git.UPSTREAM_BRANCH,
-            )) or [entry_key]
-            mode = "conflict"
-            reconciliation = app_git.ReconciliationReceipt(
-              unresolved_conflict_paths=tuple(conflict_paths),
-            )
-        if mode == "conflict":
-          pass
-        elif not diverged:
+        if not diverged:
           # No local edits → upstream wins outright for the whole tree; it is
           # `source_tree` as fetched for synthetic repos, or the full
           # origin-backed upstream tree for cloned repos. Taking the bytes
@@ -2747,7 +2721,9 @@ async def install_from_manifest(
           # a three-way merge that touches neither `main` nor the working
           # tree, then act on the clean-vs-conflict verdict.
           merge = await asyncio.to_thread(
-            app_git.merge_upstream, git_source_dir,
+            app_git.merge_upstream,
+            git_source_dir,
+            allow_unrelated_histories=allow_unrelated_histories,
           )
           reconciliation = merge.reconciliation
           if merge.status == "conflict":

--- a/backend/app/routes/apps.py
+++ b/backend/app/routes/apps.py
@@ -1279,6 +1279,7 @@ async def create_conflict_resolver_chat(
         app_git.start_conflict_merge,
         repo,
         merge_base=merge.merge_base_oid,
+        allow_unrelated_histories=merge.unrelated_histories,
       ) or conflict_paths
       if not conflict_paths:
         raise HTTPException(

--- a/backend/app/source_status.py
+++ b/backend/app/source_status.py
@@ -73,13 +73,6 @@ def _rev(repo: Path, ref: str) -> str | None:
   return value if proc.returncode == 0 and value else None
 
 
-def _trees_equal(repo: Path, left: str, right: str) -> bool:
-  """Return whether two refs name byte-identical source trees."""
-  left_tree = _rev(repo, f"{left}^{{tree}}")
-  right_tree = _rev(repo, f"{right}^{{tree}}")
-  return bool(left_tree and left_tree == right_tree)
-
-
 def _canonical_repo(url: str | None) -> str | None:
   """Turn common GitHub remote/manifest URLs into ``owner/repo``."""
   if not url:
@@ -242,14 +235,6 @@ def _diff_summary(
   return summary
 
 
-def _endpoint_diff_paths(repo: Path, left: str, right: str) -> set[str] | None:
-  """Return path names whose endpoint bytes differ, independent of topology."""
-  proc = _git(repo, "diff", "--name-only", "--no-renames", "-z", left, right, "--")
-  if proc.returncode != 0:
-    return None
-  return {path for path in proc.stdout.split("\0") if path}
-
-
 def _reconciliation_summary(
   repo: Path,
   local: str,
@@ -274,7 +259,7 @@ def _reconciliation_summary(
   }
   try:
     receipt = app_git.preview_reconciliation(repo, local, upstream)
-    endpoint_paths = _endpoint_diff_paths(repo, upstream, local)
+    endpoint_paths = app_git.endpoint_diff_paths(repo, upstream, local)
   except (OSError, subprocess.SubprocessError, RuntimeError):
     return empty
   if endpoint_paths is None:
@@ -511,7 +496,7 @@ def _project_status(
     # update advances that marker. Exact tree equality is a projection-safe
     # witness: unlike an ordinary origin diff, it cannot turn omitted package
     # files into apparent owner deletions.
-    origin["head_tree_matches_origin"] = _trees_equal(
+    origin["head_tree_matches_origin"] = app_git.ref_trees_equal(
       repo, origin["ref"], "HEAD",
     )
   response.update({"origin": origin, "forks": forks})

--- a/backend/tests/test_app_git.py
+++ b/backend/tests/test_app_git.py
@@ -173,6 +173,28 @@ def _commit_all(repo: Path, msg: str) -> str:
   ).stdout.strip()
 
 
+def _init_unrelated_branches(
+  repo: Path,
+  local_files: dict[str, str],
+  upstream_files: dict[str, str],
+) -> None:
+  """Create canonical main/upstream branches with no shared commit."""
+  subprocess.run(["git", "init", "-q", "-b", "main", str(repo)], check=True)
+  for rel, body in local_files.items():
+    path = repo / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+  _commit_all(repo, "local root")
+  app_git._run(repo, "checkout", "-q", "--orphan", app_git.UPSTREAM_BRANCH)
+  app_git._run(repo, "rm", "-q", "-rf", ".")
+  for rel, body in upstream_files.items():
+    path = repo / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+  _commit_all(repo, "upstream root")
+  app_git._run(repo, "checkout", "-q", app_git.LOCAL_BRANCH)
+
+
 def test_ref_is_ancestor_distinguishes_false_from_git_errors(tmp_path):
   repo = tmp_path / "app"
   repo.mkdir()
@@ -481,7 +503,8 @@ def test_fetch_upstream_advances_real_origin_and_reads_full_tree(tmp_path):
   fetched = app_git.fetch_upstream(source_dir, "main")
   tree = app_git.read_ref_tree(source_dir, app_git.UPSTREAM_BRANCH)
 
-  assert fetched == new_head
+  assert fetched.sha == new_head
+  assert fetched.allow_unrelated_histories is False
   assert app_git.head_sha(source_dir, app_git.UPSTREAM_BRANCH) == new_head
   origin_head = app_git._run(
     source_dir, "rev-parse", "origin/main",
@@ -1680,6 +1703,70 @@ def test_start_conflict_merge_leaves_real_markers_and_merge_head(tmp_path):
   assert (repo / "index.jsx").read_text() == local_before
 
 
+def test_unrelated_history_conflict_uses_same_verdict_and_resolver(tmp_path):
+  """A rewritten legacy checkout remains resolvable through ordinary Git."""
+  repo = tmp_path / "unrelated-conflict"
+  _init_unrelated_branches(
+    repo,
+    {"index.jsx": "local\n", "local.js": "local only\n"},
+    {"index.jsx": "upstream\n", "upstream.js": "upstream only\n"},
+  )
+
+  result = app_git.merge_upstream(repo, allow_unrelated_histories=True)
+
+  assert result.status == "conflict"
+  assert result.conflict_paths == ["index.jsx"]
+  assert result.unrelated_histories is True
+  assert result.reconciliation.unresolved_conflict_paths == ("index.jsx",)
+
+  paths = app_git.start_conflict_merge(
+    repo, allow_unrelated_histories=result.unrelated_histories,
+  )
+
+  assert paths == ["index.jsx"]
+  materialized = (repo / "index.jsx").read_text()
+  assert "<<<<<<<" in materialized and ">>>>>>>" in materialized
+  assert "local" in materialized and "upstream" in materialized
+  assert (repo / "local.js").read_text() == "local only\n"
+  assert (repo / "upstream.js").read_text() == "upstream only\n"
+  assert app_git.abort_in_progress_merge(repo) is True
+  assert (repo / "index.jsx").read_text() == "local\n"
+  assert not (repo / "upstream.js").exists()
+
+
+def test_unrelated_history_preserves_compatible_files_without_conflict(tmp_path):
+  """Unrelated roots still combine non-overlapping source through Git."""
+  repo = tmp_path / "unrelated-clean"
+  _init_unrelated_branches(
+    repo,
+    {"index.jsx": "same\n", "local.js": "local only\n"},
+    {"index.jsx": "same\n", "upstream.js": "upstream only\n"},
+  )
+
+  result = app_git.merge_upstream(repo, allow_unrelated_histories=True)
+  tree = app_git.read_merged_tree(repo, result.merged_tree_oid)
+
+  assert result.status == "clean"
+  assert result.unrelated_histories is True
+  assert tree == {
+    "index.jsx": b"same\n",
+    "local.js": b"local only\n",
+    "upstream.js": b"upstream only\n",
+  }
+
+
+def test_unrelated_history_is_rejected_without_explicit_proof(tmp_path):
+  repo = tmp_path / "unrelated-default-rejection"
+  _init_unrelated_branches(
+    repo,
+    {"index.jsx": "same\n", "local.js": "local only\n"},
+    {"index.jsx": "same\n", "upstream.js": "upstream only\n"},
+  )
+
+  with pytest.raises(RuntimeError, match="unrelated histories"):
+    app_git.merge_upstream(repo)
+
+
 @pytest.mark.parametrize("entrypoint", ["verdict", "resolver"])
 def test_merge_entry_points_unshallow_when_depth_one_hides_base(
   tmp_path, entrypoint,
@@ -1749,7 +1836,9 @@ def test_fetch_upstream_repairs_same_tip_depth_one_regraft(tmp_path):
     check=False,
   ).returncode != 0
 
-  assert app_git.fetch_upstream(repo, "main") == poisoned_tip
+  fetched = app_git.fetch_upstream(repo, "main")
+  assert fetched.sha == poisoned_tip
+  assert fetched.allow_unrelated_histories is False
   assert app_git._run(
     repo, "merge-base", app_git.LOCAL_BRANCH, app_git.UPSTREAM_BRANCH,
   ).stdout.strip()

--- a/backend/tests/test_apps_install.py
+++ b/backend/tests/test_apps_install.py
@@ -1853,9 +1853,9 @@ def test_trusted_origin_adoption_is_always_reconciled_as_local_source(
 
 
 def test_trusted_origin_adoption_accepts_equal_tree_with_unrelated_history(
-  client, auth, db, bypass_url_validation,
+  client, auth, db, bypass_url_validation, tmp_path,
 ):
-  """Equal local/catalog bytes adopt in place even after history rewrites."""
+  """Equal trusted-origin bytes replace unrelated synthetic provenance."""
   manifest = {
     "id": "codex",
     "name": "Subagents",
@@ -1873,50 +1873,85 @@ def test_trusted_origin_adoption_accepts_equal_tree_with_unrelated_history(
     manifest_extra={"version": "1.0.0"},
   )
   repo = Path(legacy["source_dir"])
+
+  # Model Atlas's exact legacy shape. The installer-owned upstream branch has
+  # synthetic history + a generated .gitignore, while a prior explicit apply
+  # rewrote main onto the canonical repository's complete tree. The configured
+  # origin proves package identity even though neither history shares a root.
+  fixture = tmp_path / "trusted-origin"
+  bare = tmp_path / "trusted-origin.git"
+  fixture.mkdir()
+  subprocess.run(
+    ["git", "init", "-q", "-b", "main", str(fixture)], check=True,
+  )
+  canonical_files = {
+    ".gitignore": "node_modules/\ntests/.build/\n",
+    "README.md": "canonical package data\n",
+    "index.jsx": JSX,
+    "mobius.json": json.dumps(manifest, sort_keys=True) + "\n",
+  }
+  for rel, content in canonical_files.items():
+    (fixture / rel).write_text(content, encoding="utf-8")
+  subprocess.run(["git", "-C", str(fixture), "add", "-A"], check=True)
   subprocess.run(
     [
-      "git", "-C", str(repo), "remote", "add", "origin",
-      "https://github.com/mobius-os/app-subagents.git",
+      "git", "-c", "user.name=Mobius", "-c",
+      "user.email=mobius@localhost", "-C", str(fixture),
+      "commit", "-q", "-m", "canonical release",
     ],
     check=True,
   )
-  tree = subprocess.run(
-    ["git", "-C", str(repo), "rev-parse", "main^{tree}"],
+  canonical_head = subprocess.run(
+    ["git", "-C", str(fixture), "rev-parse", "HEAD"],
     capture_output=True, text=True, check=True,
   ).stdout.strip()
-  upstream_sha = subprocess.run(
+  canonical_tree = subprocess.run(
+    ["git", "-C", str(fixture), "rev-parse", "HEAD^{tree}"],
+    capture_output=True, text=True, check=True,
+  ).stdout.strip()
+  subprocess.run(
+    ["git", "clone", "-q", "--bare", str(fixture), str(bare)],
+    check=True,
+  )
+  subprocess.run(
+    ["git", "-C", str(repo), "remote", "add", "origin", bare.as_uri()],
+    check=True,
+  )
+  subprocess.run(
+    ["git", "-C", str(repo), "fetch", "-q", "origin", "main"], check=True,
+  )
+
+  synthetic_upstream = subprocess.run(
+    ["git", "-C", str(repo), "rev-parse", "upstream"],
+    capture_output=True, text=True, check=True,
+  ).stdout.strip()
+  # An orphan commit preserves the canonical tree but intentionally shares no
+  # ancestry with the installer-owned upstream branch.
+  rewritten_main = subprocess.run(
     [
       "git", "-c", "user.name=Mobius", "-c",
       "user.email=mobius@localhost", "-C", str(repo),
-      "commit-tree", tree, "-m", "catalog",
+      "commit-tree", canonical_tree, "-m", "apply app source",
     ],
     capture_output=True, text=True, check=True,
   ).stdout.strip()
   subprocess.run(
-    [
-      "git", "-C", str(repo), "update-ref",
-      "refs/remotes/origin/main", upstream_sha,
-    ],
+    ["git", "-C", str(repo), "update-ref", "refs/heads/main", rewritten_main],
     check=True,
   )
+  subprocess.run(
+    ["git", "-C", str(repo), "reset", "-q", "--hard", "main"], check=True,
+  )
   assert subprocess.run(
-    ["git", "-C", str(repo), "merge-base", "main", "origin/main"],
+    ["git", "-C", str(repo), "merge-base", "main", "upstream"],
     capture_output=True,
   ).returncode != 0
-  before = {
-    path.name: path.read_bytes()
-    for path in (repo / "index.jsx", repo / "mobius.json")
-  }
+  assert subprocess.run(
+    ["git", "-C", str(repo), "rev-parse", "main^{tree}"],
+    capture_output=True, text=True, check=True,
+  ).stdout.strip() == canonical_tree
 
-  def fetch_equal_upstream(source_dir, _ref):
-    subprocess.run(
-      [
-        "git", "-C", str(source_dir), "update-ref",
-        "refs/heads/upstream", upstream_sha,
-      ],
-      check=True,
-    )
-    return upstream_sha
+  expected_origin = "https://github.com/mobius-os/app-subagents.git"
 
   manifest_url = (
     "https://raw.githubusercontent.com/mobius-os/"
@@ -1931,8 +1966,8 @@ def test_trusted_origin_adoption_accepts_equal_tree_with_unrelated_history(
     "app.install.httpx.AsyncClient",
     side_effect=_fake_async_client(responses),
   ), patch(
-    "app.install.app_git.fetch_upstream",
-    side_effect=fetch_equal_upstream,
+    "app.install.app_git.origin_url",
+    return_value=expected_origin,
   ):
     adopted = client.post(
       "/api/apps/install", headers=auth,
@@ -1946,11 +1981,27 @@ def test_trusted_origin_adoption_accepts_equal_tree_with_unrelated_history(
   assert payload["manifest_url"] == (
     raw_base.rstrip("/") + "#manifest-id=codex"
   )
-  after = {
-    path.name: path.read_bytes()
-    for path in (repo / "index.jsx", repo / "mobius.json")
-  }
-  assert after == before
+  assert payload["divergence"] == "clean_merge"
+  assert subprocess.run(
+    ["git", "-C", str(repo), "rev-parse", "upstream"],
+    capture_output=True, text=True, check=True,
+  ).stdout.strip() == canonical_head
+  assert subprocess.run(
+    ["git", "-C", str(repo), "merge-base", "--is-ancestor", canonical_head, "main"],
+  ).returncode == 0
+  assert subprocess.run(
+    ["git", "-C", str(repo), "rev-parse", "main^{tree}"],
+    capture_output=True, text=True, check=True,
+  ).stdout.strip() == canonical_tree
+  assert subprocess.run(
+    ["git", "-C", str(repo), "status", "--porcelain"],
+    capture_output=True, text=True, check=True,
+  ).stdout == ""
+  assert (repo / "README.md").read_text() == canonical_files["README.md"]
+  assert (repo / ".gitignore").read_text() == canonical_files[".gitignore"]
+  assert subprocess.run(
+    ["git", "-C", str(repo), "merge-base", "--is-ancestor", synthetic_upstream, "main"],
+  ).returncode != 0
 
 
 def test_install_same_manifest_twice_updates(


### PR DESCRIPTION
## Summary
- make app source reconciliation one explicit owner in `app_git` instead of duplicating adoption and merge policy across install/status layers
- adopt identity-proven trusted origin history only when the complete live source tree exactly equals the fetched release, avoiding unrelated synthetic-history and installer-managed `.gitignore` conflicts
- preserve dirty/conflict safety and expose the reconciliation outcome consistently to install, source status, and app routes
- add regression coverage for equal-tree trusted-origin adoption and local-history preservation

## Validation
- app git, source-status, install-pass, install-phase, and app-install focused suites: 262 passed
- diff and pre-push privacy/Python gates passed

Fresh hosted CI and independent review are required before merge.
