### PR TITLE
Add digest-bound local runtime capability acceptance

### DIFF
--- a/backend/app/app_capabilities.py
+++ b/backend/app/app_capabilities.py
@@ -350,6 +350,24 @@ def contract_with_chat_log_access(
   return updated
 
 
+def contract_with_runtime_capabilities(
+  contract: dict[str, Any] | None,
+  manifest: dict[str, Any],
+) -> dict[str, Any] | None:
+  """Replace only the runtime capabilities in a reviewed contract.
+
+  Store-installed apps keep package-owned background, data, agent, and offline
+  facts when an owner explicitly accepts capabilities from a local source
+  revision.  The caller binds that acceptance to a digest; this projection
+  merely owns the narrow immutable replacement.
+  """
+  if not isinstance(contract, dict):
+    return None
+  updated = deepcopy(contract)
+  updated["runtime"] = normalize_runtime_capabilities(manifest)
+  return updated
+
+
 def canonical_contract_json(contract: dict[str, Any]) -> str:
   return json.dumps(
     contract, ensure_ascii=False, sort_keys=True, separators=(",", ":"),

--- a/backend/scripts/accept_local_runtime_capabilities.py
+++ b/backend/scripts/accept_local_runtime_capabilities.py
@@ -1,0 +1,176 @@
+"""Review or accept local runtime capabilities for one Store-installed app.
+
+Ordinary source apply deliberately compiles local edits without widening the
+Store-reviewed permission contract.  When the owner explicitly approves the
+precise local runtime declaration, this command preserves every other reviewed
+fact and replaces only ``capability_contract.runtime``.  Acceptance requires
+the digest printed by a prior review, binding the write to the exact manifest
+bytes that were inspected.
+
+Run from ``/data/platform/backend``:
+
+  python -m scripts.accept_local_runtime_capabilities --app-id 61
+  python -m scripts.accept_local_runtime_capabilities --app-id 61 \
+    --accept-digest <digest-from-review>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import stat
+from pathlib import Path
+
+from app import models, timeutil
+from app.app_capabilities import (
+  capability_digest,
+  contract_with_runtime_capabilities,
+  diff_contracts,
+)
+from app.config import get_settings
+from app.database import SessionLocal
+
+
+def _manifest_for(app: models.App) -> dict:
+  if not app.source_dir:
+    raise ValueError("App has no local source directory.")
+  data_dir = Path(get_settings().data_dir).resolve()
+  apps_root = (data_dir / "apps").resolve()
+  # Validate the stored path lexically before touching the filesystem. Resolving
+  # it would turn a symlink to a sibling app into an apparently valid direct
+  # child and lose the Store app's source identity.
+  source_dir = Path(os.path.abspath(app.source_dir))
+  if source_dir.parent != apps_root or source_dir.name.isdigit():
+    raise ValueError("App source directory is outside the reviewed apps root.")
+  root_descriptor = None
+  source_descriptor = None
+  try:
+    directory_flags = (
+      os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+      | getattr(os, "O_CLOEXEC", 0)
+    )
+    root_descriptor = os.open(apps_root, directory_flags)
+    try:
+      source_descriptor = os.open(
+        source_dir.name,
+        directory_flags,
+        dir_fd=root_descriptor,
+      )
+    except OSError as exc:
+      raise ValueError(
+        "App source directory must be a direct, regular directory under the apps root."
+      ) from exc
+    try:
+      descriptor = os.open(
+        "mobius.json",
+        os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | os.O_NOFOLLOW,
+        dir_fd=source_descriptor,
+      )
+    except OSError as exc:
+      raise ValueError(
+        "mobius.json must be a regular file inside the app source."
+      ) from exc
+    with os.fdopen(descriptor, "r", encoding="utf-8") as manifest_file:
+      if not stat.S_ISREG(os.fstat(manifest_file.fileno()).st_mode):
+        raise ValueError("mobius.json must be a regular file inside the app source.")
+      value = json.load(manifest_file)
+  except ValueError:
+    raise
+  except (OSError, json.JSONDecodeError) as exc:
+    raise ValueError(f"Could not read a valid mobius.json: {exc}") from exc
+  finally:
+    if source_descriptor is not None:
+      os.close(source_descriptor)
+    if root_descriptor is not None:
+      os.close(root_descriptor)
+  if not isinstance(value, dict):
+    raise ValueError("mobius.json must contain an object.")
+  return value
+
+
+def review(app: models.App) -> tuple[dict, dict]:
+  if app.manifest_url is None:
+    raise ValueError("This command is only for Store-installed apps.")
+  candidate = contract_with_runtime_capabilities(
+    app.capability_contract,
+    _manifest_for(app),
+  )
+  if candidate is None:
+    raise ValueError("The installed app has no reviewed capability contract.")
+  return candidate, {
+    "app_id": app.id,
+    "app": app.name,
+    "current_runtime": (app.capability_contract or {}).get("runtime", {}),
+    "candidate_runtime": candidate.get("runtime", {}),
+    "diff": diff_contracts(app.capability_contract, candidate),
+    "accept_digest": capability_digest(candidate),
+  }
+
+
+def _accept(db, app: models.App, candidate: dict, report: dict) -> None:
+  """Commit only if the reviewed App row is still the current revision."""
+  snapshot_updated_at = app.updated_at
+  current = models.App.updated_at
+  revision_match = (
+    current.is_(None) if snapshot_updated_at is None
+    else current == snapshot_updated_at
+  )
+  changed = (
+    db.query(models.App)
+    .filter(
+      models.App.id == app.id,
+      models.App.deleted_at.is_(None),
+      revision_match,
+    )
+    .update({
+      models.App.capability_contract: candidate,
+      models.App.updated_at: timeutil.now_naive_utc(),
+    }, synchronize_session=False)
+  )
+  if changed != 1:
+    raise ValueError(
+      "The app changed while capabilities were being accepted; review again."
+    )
+  db.commit()
+  report["status"] = "accepted"
+
+
+def main(argv: list[str] | None = None) -> None:
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--app-id", required=True, type=int)
+  parser.add_argument("--accept-digest")
+  args = parser.parse_args(argv)
+
+  db = SessionLocal()
+  try:
+    app = (
+      db.query(models.App)
+      .filter(models.App.id == args.app_id, models.App.deleted_at.is_(None))
+      .one_or_none()
+    )
+    if app is None:
+      raise ValueError("App not found.")
+    candidate, report = review(app)
+    if args.accept_digest is None:
+      report["status"] = "review"
+      print(json.dumps(report, ensure_ascii=False, sort_keys=True))
+      return
+    if args.accept_digest != report["accept_digest"]:
+      raise ValueError(
+        "Acceptance digest does not match the current local manifest; review again."
+      )
+    _accept(db, app, candidate, report)
+    print(json.dumps(report, ensure_ascii=False, sort_keys=True))
+  except ValueError as exc:
+    db.rollback()
+    parser.exit(2, f"error: {exc}\n")
+  except Exception:
+    db.rollback()
+    raise
+  finally:
+    db.close()
+
+
+if __name__ == "__main__":
+  main()

--- a/backend/tests/test_accept_local_runtime_capabilities.py
+++ b/backend/tests/test_accept_local_runtime_capabilities.py
@@ -1,0 +1,212 @@
+"""Explicit local capability acceptance is bound, confined, and atomic."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app import models, timeutil
+from app.app_capabilities import contract_and_digest
+from app.database import SessionLocal
+from scripts import accept_local_runtime_capabilities as command
+from test_app_fixtures import create_local_app
+
+
+def _store_app(client, auth, db):
+  created = create_local_app(
+    client,
+    auth,
+    name="Capability Manager",
+    capabilities={"device.asset-cache": {"version": 1}},
+  )
+  app = db.query(models.App).filter(models.App.id == created["id"]).one()
+  manifest = json.loads((Path(app.source_dir) / "mobius.json").read_text())
+  app.capability_contract = contract_and_digest(manifest)[0]
+  app.manifest_url = "https://store.example/capability-manager/mobius.json"
+  db.commit()
+  db.refresh(app)
+  manifest["capabilities"] = {
+    "media.speech": {
+      "version": 1,
+      "reason": "Read reports with the selected local voice.",
+    },
+  }
+  (Path(app.source_dir) / "mobius.json").write_text(json.dumps(manifest))
+  return app
+
+
+def _run(args, capsys):
+  command.main(args)
+  return json.loads(capsys.readouterr().out)
+
+
+def test_review_and_accept_round_trip_preserves_store_contract(client, auth, db, capsys):
+  app = _store_app(client, auth, db)
+  before = app.capability_contract
+
+  report = _run(["--app-id", str(app.id)], capsys)
+  assert report["status"] == "review"
+  assert "media.speech" in report["candidate_runtime"]
+
+  accepted = _run([
+    "--app-id", str(app.id), "--accept-digest", report["accept_digest"],
+  ], capsys)
+  assert accepted["status"] == "accepted"
+  db.expire_all()
+  stored = db.get(models.App, app.id).capability_contract
+  assert stored["runtime"] == report["candidate_runtime"]
+  assert {k: v for k, v in stored.items() if k != "runtime"} == {
+    k: v for k, v in before.items() if k != "runtime"
+  }
+
+
+def test_digest_mismatch_is_a_concise_error_and_does_not_write(
+  client, auth, db, capsys,
+):
+  app = _store_app(client, auth, db)
+  before = app.capability_contract
+  with pytest.raises(SystemExit) as exc:
+    command.main([
+      "--app-id", str(app.id), "--accept-digest", "0" * 64,
+    ])
+  assert exc.value.code == 2
+  assert "review again" in capsys.readouterr().err
+  db.expire_all()
+  assert db.get(models.App, app.id).capability_contract == before
+
+
+def test_command_rejects_non_store_apps_and_source_paths_outside_apps_root(
+  client, auth, db, capsys, tmp_path,
+):
+  app = _store_app(client, auth, db)
+  app.manifest_url = None
+  db.commit()
+  with pytest.raises(SystemExit):
+    command.main(["--app-id", str(app.id)])
+  assert "only for Store-installed apps" in capsys.readouterr().err
+
+  app.manifest_url = "https://store.example/app/mobius.json"
+  app.source_dir = str(tmp_path)
+  db.commit()
+  with pytest.raises(SystemExit):
+    command.main(["--app-id", str(app.id)])
+  assert "outside the reviewed apps root" in capsys.readouterr().err
+
+
+def test_manifest_symlink_cannot_escape_the_app_source(client, auth, db, capsys, tmp_path):
+  app = _store_app(client, auth, db)
+  manifest_path = Path(app.source_dir) / "mobius.json"
+  outside = tmp_path / "mobius.json"
+  outside.write_text(manifest_path.read_text())
+  manifest_path.unlink()
+  manifest_path.symlink_to(outside)
+
+  with pytest.raises(SystemExit):
+    command.main(["--app-id", str(app.id)])
+  assert "regular file inside the app source" in capsys.readouterr().err
+
+
+def test_source_directory_symlink_cannot_alias_a_sibling_app(
+  client, auth, db, capsys,
+):
+  app = _store_app(client, auth, db)
+  source = Path(app.source_dir)
+  sibling = source.with_name(f"{source.name}-sibling")
+  source.rename(sibling)
+  source.symlink_to(sibling, target_is_directory=True)
+  try:
+    with pytest.raises(SystemExit):
+      command.main(["--app-id", str(app.id)])
+    assert "direct, regular directory under the apps root" in capsys.readouterr().err
+  finally:
+    source.unlink()
+    sibling.rename(source)
+
+
+def test_pinned_source_directory_cannot_escape_during_parent_swap(
+  client, auth, db, capsys, tmp_path, monkeypatch,
+):
+  app = _store_app(client, auth, db)
+  source = Path(app.source_dir)
+  pinned = source.with_name(f"{source.name}-pinned")
+  outside = tmp_path / "outside"
+  outside.mkdir()
+  outside_manifest = json.loads((source / "mobius.json").read_text())
+  outside_manifest["capabilities"] = {
+    "media.microphone.capture": {"version": 1, "reason": "must not escape"},
+  }
+  (outside / "mobius.json").write_text(json.dumps(outside_manifest))
+
+  real_open = command.os.open
+  swapped = False
+
+  def swap_before_manifest(path, flags, *args, **kwargs):
+    nonlocal swapped
+    if path == "mobius.json" and not swapped:
+      swapped = True
+      source.rename(pinned)
+      source.symlink_to(outside, target_is_directory=True)
+    return real_open(path, flags, *args, **kwargs)
+
+  monkeypatch.setattr(command.os, "open", swap_before_manifest)
+  try:
+    report = _run(["--app-id", str(app.id)], capsys)
+    assert swapped is True
+    assert "media.speech" in report["candidate_runtime"]
+    assert "media.microphone.capture" not in report["candidate_runtime"]
+  finally:
+    if source.is_symlink():
+      source.unlink()
+    if pinned.exists():
+      pinned.rename(source)
+
+
+def test_unexpected_failure_rolls_back_the_command_session(
+  client, auth, db, monkeypatch,
+):
+  app = _store_app(client, auth, db)
+  original_name = app.name
+  digest = command.review(app)[1]["accept_digest"]
+
+  def fail_after_mutation(session, loaded, candidate, report):
+    loaded.name = "must roll back"
+    session.flush()
+    raise RuntimeError("injected failure")
+
+  monkeypatch.setattr(command, "_accept", fail_after_mutation)
+  with pytest.raises(RuntimeError, match="injected failure"):
+    command.main([
+      "--app-id", str(app.id), "--accept-digest", digest,
+    ])
+  db.expire_all()
+  assert db.get(models.App, app.id).name == original_name
+
+
+def test_concurrent_contract_change_wins_and_acceptance_is_rejected(
+  client, auth, db, capsys, monkeypatch,
+):
+  app = _store_app(client, auth, db)
+  report = _run(["--app-id", str(app.id)], capsys)
+  original_review = command.review
+  concurrent_contract = {**app.capability_contract, "concurrent_fact": "preserve-me"}
+
+  def review_then_concurrent_write(loaded):
+    result = original_review(loaded)
+    writer = SessionLocal()
+    try:
+      changed = writer.get(models.App, app.id)
+      changed.capability_contract = concurrent_contract
+      changed.updated_at = timeutil.now_naive_utc()
+      writer.commit()
+    finally:
+      writer.close()
+    return result
+
+  monkeypatch.setattr(command, "review", review_then_concurrent_write)
+  with pytest.raises(SystemExit):
+    command.main([
+      "--app-id", str(app.id), "--accept-digest", report["accept_digest"],
+    ])
+  assert "changed while capabilities were being accepted" in capsys.readouterr().err
+  db.expire_all()
+  assert db.get(models.App, app.id).capability_contract == concurrent_contract

--- a/backend/tests/test_app_capabilities.py
+++ b/backend/tests/test_app_capabilities.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 from app import models
 from app.app_capabilities import contract_and_digest
+from app.app_capabilities import contract_with_runtime_capabilities
 from app.app_capabilities import normalize_runtime_capabilities
 from app.config import get_settings
 from test_app_fixtures import create_local_app, write_local_source
@@ -145,6 +146,33 @@ def test_speech_capabilities_separate_model_management_from_generation():
   assert runtime["media.speech"]["risk"] == "device"
   assert runtime["media.speech"]["lifecycle"] == "background"
   assert runtime["media.speech"]["limits"] == {"max_text_chars": 20_000}
+
+
+def test_explicit_local_runtime_acceptance_preserves_store_contract():
+  installed = _manifest(capabilities={
+    "device.asset-cache": {"version": 1},
+  })
+  contract, _ = contract_and_digest(installed)
+  candidate = contract_with_runtime_capabilities(contract, _manifest(capabilities={
+    "media.speech": {
+      "version": 1,
+      "reason": "Read reports with the shared local voice.",
+      "limits": {"max_text_chars": 50_000},
+    },
+  }))
+
+  assert candidate is not None
+  assert candidate["runtime"] == normalize_runtime_capabilities(_manifest(capabilities={
+    "media.speech": {
+      "version": 1,
+      "reason": "Read reports with the shared local voice.",
+      "limits": {"max_text_chars": 50_000},
+    },
+  }))
+  assert {key: value for key, value in candidate.items() if key != "runtime"} == {
+    key: value for key, value in contract.items() if key != "runtime"
+  }
+  assert contract["runtime"] == normalize_runtime_capabilities(installed)
 
 
 def test_runtime_capability_rejects_unknown_name_version_and_limits():


### PR DESCRIPTION
## Summary
- add an owner-run review/accept command for runtime capabilities declared by a locally edited Store app
- bind acceptance to the exact reviewed capability digest and an atomic app-row compare-and-update, rejecting manifest or concurrent Store/permission changes
- replace only the runtime capability slice while preserving every other Store-reviewed contract fact
- restrict the command to direct app sources under the managed apps root, reject symlink/race path escapes, and require Store-installed records

## Validation
- focused capability and command-path suite: 20 passed, including digest mismatch, path escape, rollback, and concurrent-write preservation
- diff and pre-push privacy/Python gates passed

Fresh hosted CI and independent security review are required before merge.
