### PR TITLE
Simplify skill seeding and restore scheduled job outcomes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -491,7 +491,7 @@ The chat is large and self-contained; its hooks live beside it, not in `src/hook
 | Add a supported app package | Pin it in `frontend/package.json`, add it to `BUNDLED_RUNTIME_LIBS`, and run the compiler/offline-frame contracts |
 | Change offline / SW behavior | `frontend/src/sw.js` + `frontend/src/sw-cache-policy.js` (read *Service worker + offline* below first) |
 | Change the in-product agent's instructions | `skill/core.md` (constitution) or `backend/scripts/seed-skills/*.md` (per-task skills) — see below |
-| Add/install a skill | Ecosystem installs go through `POST /api/skills/install` (`routes/skills.py`; the Skills app + `finding-skills.md` seed drive it); new platform seeds go in `backend/scripts/seed-skills/` + a `SEED_VERSION` bump in `init_skills.py`; the index (`skills-index.md`) is generated — never hand-edit it |
+| Add/install a skill | Ecosystem installs go through `POST /api/skills/install` (`routes/skills.py`; the Skills app + `finding-skills.md` seed drive it); new platform seeds go in `backend/scripts/seed-skills/`; edits that must reach existing untouched copies register their predecessor digest in `init_skills.py`; the index (`skills-index.md`) is generated — never hand-edit it |
 | Change a bootstrap app (Store / Memory / Reflection) | Change its catalog repository (`mobius-os/app-<slug>`). `backend/app/bootstrap.py` installs the canonical manifest on first boot; afterward the app is an ordinary owner-editable app under `/data/apps/<slug>` |
 | Theme CSS / tokens | `backend/app/theme.py` + `routes/theme.py` + `frontend/src/hooks/useTheme.js` |
 

--- a/backend/scripts/app-job-runner.py
+++ b/backend/scripts/app-job-runner.py
@@ -226,6 +226,39 @@ def _mint_app_token(app_id: int) -> str | None:
     return None
 
 
+def _emit_cron_outcome(
+  app_id: int,
+  job: Path,
+  exit_code: int,
+  duration_ms: int,
+) -> None:
+  """Best-effort scheduled-run telemetry through the owner-authenticated API."""
+  try:
+    owner_token = TOKEN_FILE.read_text(encoding="utf-8").strip()
+    if not owner_token:
+      raise ValueError("empty service token")
+    body = json.dumps({
+      "ev": "cron_outcome",
+      "app_id": app_id,
+      "job": job.name,
+      "exit_code": exit_code,
+      "duration_ms": max(0, duration_ms),
+    }).encode("utf-8")
+    request = urllib.request.Request(
+      f"{API_BASE_URL}/api/admin/activity/emit",
+      data=body,
+      method="POST",
+      headers={
+        "Authorization": f"Bearer {owner_token}",
+        "Content-Type": "application/json",
+      },
+    )
+    with urllib.request.urlopen(request, timeout=5):
+      pass
+  except Exception as exc:
+    _log(app_id, f"activity emit failed for {job.name}: {exc!r}")
+
+
 def _job_env(app_token: str) -> dict[str, str]:
   """Allowlist job environment; never inherit owner/service credentials."""
   allowed = {
@@ -247,6 +280,7 @@ def _execute_job(
   resolved: Path,
   *,
   wait_for_ready: bool,
+  scheduled: bool,
   run_lock_fd: int,
 ) -> int:
   """Execute one already-validated job."""
@@ -302,6 +336,7 @@ def _execute_job(
     # KILL fallback; exec resets the child's caught handler to the default.
     previous_sigterm = signal.signal(signal.SIGTERM, lambda *_args: None)
     try:
+      started = time.monotonic()
       child = subprocess.Popen(
         command,
         cwd=str(resolved.parent),
@@ -311,8 +346,11 @@ def _execute_job(
         pass_fds=(run_lock_fd,),
       )
       rc = child.wait()
+      duration_ms = int((time.monotonic() - started) * 1000)
     finally:
       signal.signal(signal.SIGTERM, previous_sigterm)
+    if scheduled:
+      _emit_cron_outcome(app_id, resolved, rc, duration_ms)
     if rc != 0:
       _log(app_id, f"job exited rc={rc}: {resolved}")
     return rc
@@ -328,6 +366,9 @@ def run() -> int:
   argv = sys.argv[1:]
   wait_for_ready = argv[:1] == ["--wait-for-ready"]
   if wait_for_ready:
+    argv = argv[1:]
+  scheduled = argv[:1] == ["--scheduled"]
+  if scheduled:
     argv = argv[1:]
   wall_clock = None
   if argv[:1] == ["--wall-clock"]:
@@ -374,6 +415,7 @@ def run() -> int:
       app_id,
       resolved,
       wait_for_ready=wait_for_ready,
+      scheduled=scheduled,
       run_lock_fd=run_lock.fileno(),
     )
   finally:

--- a/backend/scripts/init-cron-scaffold.sh
+++ b/backend/scripts/init-cron-scaffold.sh
@@ -151,9 +151,9 @@ JOB_RUNNER_ARG="$(printf '%q' "$JOB_RUNNER")"
 if [ -n "$SCHEDULE_TZ" ]; then
   SCHEDULE_TZ_ARG="$(printf '%q' "$SCHEDULE_TZ")"
   SCHEDULE_SOURCE_ARG="$(printf '%q' "$SCHEDULE_SOURCE")"
-  CRON_CMD="${JOB_API_BASE_ASSIGNMENT} python3 ${JOB_RUNNER_ARG} --wall-clock ${SCHEDULE_TZ_ARG} ${SCHEDULE_SOURCE_ARG} ${APP_ID} ${JOB_PATH}"
+  CRON_CMD="${JOB_API_BASE_ASSIGNMENT} python3 ${JOB_RUNNER_ARG} --scheduled --wall-clock ${SCHEDULE_TZ_ARG} ${SCHEDULE_SOURCE_ARG} ${APP_ID} ${JOB_PATH}"
 elif [ -n "$APP_ID" ]; then
-  CRON_CMD="${JOB_API_BASE_ASSIGNMENT} python3 ${JOB_RUNNER_ARG} ${APP_ID} ${JOB_PATH}"
+  CRON_CMD="${JOB_API_BASE_ASSIGNMENT} python3 ${JOB_RUNNER_ARG} --scheduled ${APP_ID} ${JOB_PATH}"
 else
   CRON_CMD="${JOB_PATH}"
 fi

--- a/backend/scripts/init_skills.py
+++ b/backend/scripts/init_skills.py
@@ -8,8 +8,8 @@ knowledge graph, this is CREATE-IF-ABSENT — reseeding would clobber the agent'
 own skill edits.
 
 Propagation policy, precisely (the code below is the contract): on first boot
-the whole seed tree is copied and `.seed-version` is stamped. On every later
-boot we add missing seed skills and apply only explicit, hash-gated migrations:
+the whole seed tree is copied. On every later boot we add missing seed skills
+and apply only explicit, hash-gated migrations:
 an existing file is replaced when it is byte-for-byte a known baked predecessor,
 while every owner/agent-edited copy is preserved. A normal baked-seed edit does
 not propagate until its predecessor hash is deliberately registered below; this
@@ -25,9 +25,8 @@ remains an exact-hash match -- an owner edit that differs by one byte is still
 preserved. App-owned
 skills are not part of this seed tree; they arrive through manifests and their
 generic ownership sidecar.
-`.seed-version`/`SEED_VERSION` are kept as a
-record of the baked seed generation for that future, merge-aware migration; the
-sentinel is written but not yet read.
+`.seed-version` remains a reserved internal name for instances that carry the
+retired marker; bootstrap neither reads nor writes it.
 
 Seed source: /app/scripts/seed-skills/ (baked), falling back to the in-repo
 backend/scripts/seed-skills/ for dev. Run from entrypoint after
@@ -42,8 +41,6 @@ from pathlib import Path
 
 DATA_DIR = Path(os.environ.get("DATA_DIR", "/data"))
 SKILLS = DATA_DIR / "shared" / "skills"
-VERSION_FILE = SKILLS / ".seed-version"
-SEED_VERSION = "24"  # v24: propagate current scheduling skill contracts
 # Update only byte-for-byte baked copies; an owner/agent-edited file is never
 # touched. A set preserves every known unmodified predecessor when one skill
 # needs more than one fix-forward migration over its lifetime.
@@ -207,9 +204,8 @@ def init() -> None:
     SKILLS.mkdir(parents=True)
     for src in seed.glob("*.md"):
       shutil.copy2(src, SKILLS / src.name)
-    VERSION_FILE.write_text(SEED_VERSION + "\n", encoding="utf-8")
     n = len(list(SKILLS.glob("*.md")))
-    print(f"init_skills: seeded {n} skills (v{SEED_VERSION})")
+    print(f"init_skills: seeded {n} skills")
     _chown_mobius(SKILLS)
     _write_index()
     return

--- a/backend/tests/test_app_jobs.py
+++ b/backend/tests/test_app_jobs.py
@@ -25,7 +25,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 def test_cron_parser_resolves_supervised_command_to_real_job():
   line = (
     "30 5 * * * python3 /app/scripts/app-job-runner.py "
-    "57 /data/apps/memory/memory-job.sh"
+    "--scheduled 57 /data/apps/memory/memory-job.sh"
   )
   assert app_cron.crontab_command_path(line) == (
     "/data/apps/memory/memory-job.sh"
@@ -35,7 +35,7 @@ def test_cron_parser_resolves_supervised_command_to_real_job():
 def test_cron_parser_resolves_wall_clock_gate_to_real_job():
   line = (
     "* * * * * python3 /app/scripts/app-job-runner.py "
-    "--wall-clock Europe/Belgrade 30\\ 2\\ \\*\\ \\*\\ \\* "
+    "--scheduled --wall-clock Europe/Belgrade 30\\ 2\\ \\*\\ \\*\\ \\* "
     "57 /data/apps/memory/memory-job.sh"
   )
   assert app_cron.crontab_command_path(line) == (
@@ -153,6 +153,10 @@ def test_wall_clock_tick_that_is_not_due_stops_before_job_launch(
   job.write_text("#!/bin/sh\n")
   monkeypatch.setattr(runner, "DATA_DIR", data_dir)
   monkeypatch.setattr(runner, "_claim_wall_clock_run", lambda *_args: False)
+  monkeypatch.setattr(
+    runner, "_emit_cron_outcome",
+    lambda *_args: pytest.fail("a non-due tick must not emit cron telemetry"),
+  )
   mint = pytest.fail
   monkeypatch.setattr(
     runner, "_mint_app_token",
@@ -179,6 +183,10 @@ def test_wrapper_skips_an_overlapping_job_for_the_same_app(
   job = source / "memory-job.sh"
   job.write_text("#!/bin/sh\nexit 0\n")
   monkeypatch.setattr(runner, "DATA_DIR", data_dir)
+  monkeypatch.setattr(
+    runner, "_emit_cron_outcome",
+    lambda *_args: pytest.fail("an overlapping run must not emit cron telemetry"),
+  )
   events = []
   monkeypatch.setattr(runner, "_log", lambda app_id, message: events.append(
     (app_id, message),
@@ -290,6 +298,10 @@ def test_bootstrap_readiness_timeout_never_mints_a_job_token(
   monkeypatch.setattr(runner, "DATA_DIR", data_dir)
   monkeypatch.setattr(runner.os, "getsid", lambda _pid: os.getpid())
   monkeypatch.setattr(runner, "_wait_for_ready", lambda: False)
+  monkeypatch.setattr(
+    runner, "_emit_cron_outcome",
+    lambda *_args: pytest.fail("a preflight failure must not emit cron telemetry"),
+  )
   minted = []
   monkeypatch.setattr(runner, "_mint_app_token", lambda _app_id: minted.append(True))
   monkeypatch.setattr(runner.sys, "argv", [
@@ -368,6 +380,11 @@ def test_wrapper_runs_job_only_after_live_check(tmp_path, monkeypatch):
     "Popen",
     capture_popen,
   )
+  monkeypatch.setattr(
+    runner,
+    "_emit_cron_outcome",
+    lambda *_args: pytest.fail("a manual run must not emit cron telemetry"),
+  )
   monkeypatch.setattr(runner.sys, "argv", [
     "app-job-runner.py", "57", str(job),
   ])
@@ -381,6 +398,76 @@ def test_wrapper_runs_job_only_after_live_check(tmp_path, monkeypatch):
   assert "AGENT_TOKEN" not in child_env
   assert len(calls[0][1]["pass_fds"]) == 1
   assert signal.getsignal(signal.SIGTERM) is prior_sigterm
+
+
+def test_scheduled_job_emits_owner_authenticated_outcome_after_child_exit(
+  tmp_path, monkeypatch,
+):
+  runner = _load_runner()
+  data_dir = tmp_path / "data"
+  source = data_dir / "apps" / "memory"
+  source.mkdir(parents=True)
+  job = source / "fetch.sh"
+  job.write_text("#!/bin/sh\nexit 7\n")
+  token_file = data_dir / "service-token.txt"
+  token_file.write_text("owner-token\n")
+  monkeypatch.setattr(runner, "DATA_DIR", data_dir)
+  monkeypatch.setattr(runner, "TOKEN_FILE", token_file)
+  monkeypatch.setattr(runner, "API_BASE_URL", "http://mobius.test:8000")
+  monkeypatch.setattr(runner, "_mint_app_token", lambda _app_id: "app-token")
+  monkeypatch.setattr(runner, "_app_is_live", lambda *_args: True)
+  monkeypatch.setattr(
+    runner, "_job_context", lambda *_args: {"source_dir": str(source)},
+  )
+  monkeypatch.setattr(runner.os, "getsid", lambda _pid: os.getpid())
+  lifecycle = []
+
+  def wait():
+    lifecycle.append("child-exit")
+    return 7
+
+  monkeypatch.setattr(
+    runner.subprocess, "Popen",
+    lambda *_args, **_kwargs: types.SimpleNamespace(wait=wait),
+  )
+  emitted = {}
+
+  class Response:
+    def __enter__(self):
+      return self
+
+    def __exit__(self, *_args):
+      return False
+
+  def urlopen(request, timeout):
+    lifecycle.append("emit")
+    emitted["url"] = request.full_url
+    emitted["auth"] = request.headers["Authorization"]
+    emitted["body"] = json.loads(request.data)
+    emitted["timeout"] = timeout
+    return Response()
+
+  monkeypatch.setattr(runner.urllib.request, "urlopen", urlopen)
+  monkeypatch.setattr(runner.sys, "argv", [
+    "app-job-runner.py", "--scheduled", "57", str(job),
+  ])
+
+  assert runner.run() == 7
+  assert lifecycle == ["child-exit", "emit"]
+  duration_ms = emitted["body"].pop("duration_ms")
+  assert isinstance(duration_ms, int)
+  assert duration_ms >= 0
+  assert emitted == {
+    "url": "http://mobius.test:8000/api/admin/activity/emit",
+    "auth": "Bearer owner-token",
+    "body": {
+      "ev": "cron_outcome",
+      "app_id": 57,
+      "job": "fetch.sh",
+      "exit_code": 7,
+    },
+    "timeout": 5,
+  }
 
 
 def test_wrapper_rejects_a_job_from_another_live_app(tmp_path, monkeypatch):

--- a/backend/tests/test_cron_scaffold_script.py
+++ b/backend/tests/test_cron_scaffold_script.py
@@ -63,7 +63,7 @@ def test_init_cron_scaffold_does_not_splice_existing_crontab_into_comments(
   assert existing.strip() not in init_text
   assert "ENTRY=\"0 6 * * *" in init_text
   assert "API_BASE_URL=http://jobs.example.test:8123" in init_text
-  assert "/live/scripts/app-job-runner.py 46" in init_text
+  assert "/live/scripts/app-job-runner.py --scheduled 46" in init_text
   live_crontab = state.read_text()
   assert existing.strip() in live_crontab
   assert "0 6 * * *" in live_crontab
@@ -171,6 +171,7 @@ def test_zone_declaration_is_durable_before_live_crontab_changes(tmp_path):
   subprocess.run(["bash", "-c", command], env=env, check=True)
   assert argv_state.read_text().splitlines() == [
     "/live/scripts/app-job-runner.py",
+    "--scheduled",
     "--wall-clock",
     "Europe/Belgrade",
     "30 2 * * *",

--- a/backend/tests/test_cron_tz.py
+++ b/backend/tests/test_cron_tz.py
@@ -106,7 +106,7 @@ def test_parse_zone_declaration_round_trip():
   text = (
     "#!/bin/sh\n"
     'ENTRY="* * * * * python3 /app/scripts/app-job-runner.py '
-    '--wall-clock Europe/Belgrade 0\\ 5\\ \\*\\ \\*\\ \\* 4 '
+    '--scheduled --wall-clock Europe/Belgrade 0\\ 5\\ \\*\\ \\*\\ \\* 4 '
     '/data/apps/memory/fetch.sh"\n'
     "# Zone-aware schedule identity (platform-managed).\n"
     'SCHEDULE_TZ="Europe/Belgrade"\n'

--- a/backend/tests/test_memory_boot.py
+++ b/backend/tests/test_memory_boot.py
@@ -41,12 +41,12 @@ def test_base_skill_boot_never_seeds_app_owned_memory_skill(tmp_path, monkeypatc
   (seed / "files.md").write_text("base owned", encoding="utf-8")
   monkeypatch.setattr(module, "_SEED_CANDIDATES", [seed])
   monkeypatch.setattr(module, "SKILLS", skills)
-  monkeypatch.setattr(module, "VERSION_FILE", skills / ".seed-version")
   monkeypatch.setattr(module, "_chown_mobius", lambda _path: None)
 
   module.init()
 
   assert (skills / "files.md").read_text(encoding="utf-8") == "base owned"
+  assert not (skills / ".seed-version").exists()
   assert not (skills / "memory.md").exists()
 
   baked_seed = SCRIPTS / "seed-skills"
@@ -65,7 +65,6 @@ def test_later_boot_preserves_existing_memory_skill_but_does_not_reseed_it(
   (skills / "memory.md").write_text("installed app copy", encoding="utf-8")
   monkeypatch.setattr(module, "_SEED_CANDIDATES", [seed])
   monkeypatch.setattr(module, "SKILLS", skills)
-  monkeypatch.setattr(module, "VERSION_FILE", skills / ".seed-version")
   monkeypatch.setattr(module, "_chown_mobius", lambda _path: None)
 
   module.init()
@@ -87,7 +86,6 @@ def test_later_boot_migrates_only_unmodified_graph_aware_base_skill(
   live.write_text(old, encoding="utf-8")
   monkeypatch.setattr(module, "_SEED_CANDIDATES", [seed])
   monkeypatch.setattr(module, "SKILLS", skills)
-  monkeypatch.setattr(module, "VERSION_FILE", skills / ".seed-version")
   monkeypatch.setattr(module, "_chown_mobius", lambda _path: None)
   monkeypatch.setattr(module, "_UNMODIFIED_MIGRATIONS", {
     "reflection.md": {hashlib.sha256(old.encode()).hexdigest()},
@@ -104,7 +102,6 @@ def test_later_boot_migrates_only_unmodified_graph_aware_base_skill(
 def test_controlled_skills_have_fix_forward_migrations():
   module = _load("init_skills")
 
-  assert module.SEED_VERSION == "24"
   assert module._UNMODIFIED_MIGRATIONS["cron.md"] == {
     "289336d78ad4268110360f12faac5512d5a53b66aa31c2a6ddd1a44f538f2559",
     "ed100cb496b887a7951adc967e92cda1449c4f8594f7859fbd32762221d24914",


### PR DESCRIPTION
## Summary

- remove the unused seed-version sentinel while preserving exact hash-gated fix-forward migrations
- restore `cron_outcome` telemetry in the existing app job runner after the legacy wrapper removal
- mark only generated cron invocations as scheduled, so manual and skipped runs stay silent

## Maintainability

This keeps one execution path for scheduled and manual jobs. Telemetry is a best-effort post-child action in the existing runner; it does not add another scheduler, wrapper, retry system, or durable state machine.

## Validation

- impacted backend tests: 248 passed
- Ruff 0.16.1
- `bash -n`
- Python bytecode compilation
- `git diff --check`
