### PR TITLE
Repair connector schema convergence after restart

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1385,6 +1385,43 @@ def _add_connector_capability_identity(eng) -> None:
       ))
 
 
+def _converge_interim_connector_schema(eng) -> None:
+  """Retire the short-lived nonce shape without a compatibility path.
+
+  One local restoration briefly replaced ``capability_id`` with a required
+  ``capability_nonce`` and omitted ``last_checked_at``. ``create_all`` cannot
+  repair an existing table, so converge that physical shape once before ORM
+  access.
+  """
+  from sqlalchemy import inspect as sa_inspect, text
+
+  inspector = sa_inspect(eng)
+  if "connectors" not in inspector.get_table_names():
+    return
+  columns = {column["name"] for column in inspector.get_columns("connectors")}
+  with eng.begin() as conn:
+    if "last_checked_at" not in columns:
+      column_type = (
+        "TIMESTAMP" if eng.dialect.name == "postgresql" else "DATETIME"
+      )
+      conn.execute(text(
+        f"ALTER TABLE connectors ADD COLUMN last_checked_at {column_type}"
+      ))
+
+    if eng.dialect.name == "sqlite":
+      conn.execute(text(
+        "DROP TRIGGER IF EXISTS connectors_require_nonce_insert"
+      ))
+      conn.execute(text(
+        "DROP TRIGGER IF EXISTS connectors_require_nonce_update"
+      ))
+    conn.execute(text("DROP INDEX IF EXISTS ix_connectors_capability_nonce"))
+    if "capability_nonce" in columns:
+      conn.execute(text(
+        "ALTER TABLE connectors DROP COLUMN capability_nonce"
+      ))
+
+
 _SCHEMA_MIGRATIONS = (
   ("0001_legacy_schema_convergence", _converge_legacy_schema),
   ("0002_chat_run_goal_objective", _add_chat_run_goal_objective),
@@ -1393,6 +1430,7 @@ _SCHEMA_MIGRATIONS = (
   ("0005_connectors", _add_connectors_table),
   ("0006_connector_capability_identity", _add_connector_capability_identity),
   ("0007_chat_has_messages", _add_chat_has_messages),
+  ("0008_converge_interim_connector_schema", _converge_interim_connector_schema),
 )
 
 

--- a/backend/tests/test_db_migrations.py
+++ b/backend/tests/test_db_migrations.py
@@ -1010,6 +1010,7 @@ def test_run_migrations_records_an_inspectable_append_only_history(tmp_path):
     "0005_connectors",
     "0006_connector_capability_identity",
     "0007_chat_has_messages",
+    "0008_converge_interim_connector_schema",
   ]
   assert second == first
 
@@ -1067,6 +1068,146 @@ def test_connectors_migration_preserves_preview_era_rows(tmp_path):
   assert "0006_connector_capability_identity" in {
     entry["version"] for entry in schema_migration_history(eng)
   }
+
+
+def test_connector_migration_repairs_partially_upgraded_nonce_schema(tmp_path):
+  eng = create_engine(f"sqlite:///{tmp_path / 'connector-interim.db'}")
+  capability_id = "a" * 64
+  with eng.begin() as conn:
+    conn.execute(text(
+      "CREATE TABLE apps ("
+      "id INTEGER PRIMARY KEY, name VARCHAR(255), slug VARCHAR(128), "
+      "source_dir VARCHAR(512))"
+    ))
+    conn.execute(text(
+      "CREATE TABLE connectors ("
+      "id INTEGER PRIMARY KEY, capability_nonce VARCHAR(64) NOT NULL, "
+      "slug VARCHAR(64) NOT NULL UNIQUE, name VARCHAR(128) NOT NULL, "
+      "url VARCHAR(2048) NOT NULL, auth_header VARCHAR(64), "
+      "auth_value_encrypted TEXT, enabled BOOLEAN NOT NULL DEFAULT TRUE, "
+      "tools_json JSON NOT NULL, est_tokens INTEGER NOT NULL DEFAULT 0, "
+      "status VARCHAR(16) NOT NULL, status_detail TEXT, created_at DATETIME, "
+      "capability_id VARCHAR(64))"
+    ))
+    conn.execute(text(
+      "CREATE UNIQUE INDEX ix_connectors_capability_nonce "
+      "ON connectors (capability_nonce)"
+    ))
+    conn.execute(text(
+      "CREATE TRIGGER connectors_require_nonce_insert "
+      "BEFORE INSERT ON connectors WHEN NEW.capability_nonce IS NULL "
+      "OR length(trim(NEW.capability_nonce)) = 0 BEGIN "
+      "SELECT RAISE(ABORT, 'connectors require a capability nonce'); END"
+    ))
+    conn.execute(text(
+      "CREATE TRIGGER connectors_require_nonce_update "
+      "BEFORE UPDATE OF capability_nonce ON connectors "
+      "WHEN NEW.capability_nonce IS NULL "
+      "OR length(trim(NEW.capability_nonce)) = 0 BEGIN "
+      "SELECT RAISE(ABORT, 'connectors require a capability nonce'); END"
+    ))
+    conn.execute(text(
+      "INSERT INTO connectors ("
+      "id, capability_nonce, capability_id, slug, name, url, enabled, "
+      "tools_json, status, created_at) VALUES ("
+      "1, 'legacy-nonce', :capability_id, 'legacy', 'Legacy', "
+      "'https://old.example/mcp', TRUE, '[]', 'ok', "
+      "'2026-08-03 00:00:00')"
+    ), {"capability_id": capability_id})
+    conn.execute(text(
+      "CREATE TABLE schema_migrations ("
+      "version VARCHAR(128) PRIMARY KEY, applied_at TIMESTAMP NOT NULL)"
+    ))
+    for version in (
+      "0001_legacy_schema_convergence",
+      "0002_chat_run_goal_objective",
+      "0003_chat_run_root_identity",
+      "0004_app_identity_required",
+      "0005_connectors",
+      "0006_connector_capability_identity",
+      "0007_chat_has_messages",
+      "0006_chat_has_messages",
+    ):
+      conn.execute(text(
+        "INSERT INTO schema_migrations (version, applied_at) "
+        "VALUES (:version, '2026-08-04 08:07:51')"
+      ), {"version": version})
+
+  run_migrations(eng)
+  run_migrations(eng)
+
+  inspector = inspect(eng)
+  columns = {item["name"] for item in inspector.get_columns("connectors")}
+  indexes = {item["name"] for item in inspector.get_indexes("connectors")}
+  with eng.begin() as conn:
+    row = conn.execute(text(
+      "SELECT slug, url, capability_id, last_checked_at "
+      "FROM connectors WHERE id = 1"
+    )).one()
+    triggers = {
+      trigger[0] for trigger in conn.execute(text(
+        "SELECT name FROM sqlite_master WHERE type = 'trigger' "
+        "AND name LIKE 'connectors_require_nonce_%'"
+      ))
+    }
+    conn.execute(text(
+      "INSERT INTO connectors ("
+      "id, capability_id, slug, name, url, enabled, tools_json, status) "
+      "VALUES (2, :capability_id, 'new', 'New', "
+      "'https://new.example/mcp', TRUE, '[]', 'ok')"
+    ), {"capability_id": "b" * 64})
+
+  assert tuple(row) == (
+    "legacy", "https://old.example/mcp", capability_id, None,
+  )
+  assert "capability_id" in columns
+  assert "last_checked_at" in columns
+  assert "capability_nonce" not in columns
+  assert "ix_connectors_capability_nonce" not in indexes
+  assert triggers == set()
+  assert "0008_converge_interim_connector_schema" in {
+    entry["version"] for entry in schema_migration_history(eng)
+  }
+
+
+def test_connector_interim_convergence_emits_postgres_ddl(monkeypatch):
+  statements = []
+
+  class Inspector:
+    def get_table_names(self):
+      return ["connectors"]
+
+    def get_columns(self, _table):
+      return [{"name": "capability_nonce"}]
+
+  class RecordingConnection:
+    def execute(self, statement):
+      statements.append(str(statement))
+
+  class RecordingEngine:
+    dialect = SimpleNamespace(name="postgresql")
+
+    def begin(self):
+      connection = RecordingConnection()
+
+      class Transaction:
+        def __enter__(self):
+          return connection
+
+        def __exit__(self, *_args):
+          return False
+
+      return Transaction()
+
+  import sqlalchemy
+  monkeypatch.setattr(sqlalchemy, "inspect", lambda _eng: Inspector())
+  database._converge_interim_connector_schema(RecordingEngine())
+
+  assert statements == [
+    "ALTER TABLE connectors ADD COLUMN last_checked_at TIMESTAMP",
+    "DROP INDEX IF EXISTS ix_connectors_capability_nonce",
+    "ALTER TABLE connectors DROP COLUMN capability_nonce",
+  ]
 
 
 def test_chat_message_summary_migration_backfills_legacy_transcripts(tmp_path):


### PR DESCRIPTION
## Summary

- add an append-only migration for the short-lived nonce-shaped connector table
- add the missing `last_checked_at` field and remove the retired nonce triggers, index, and column without replacing connector rows
- cover the exact partially upgraded SQLite state and the equivalent PostgreSQL DDL

## Why

Follow-up to #613. The local connector restoration briefly used `capability_nonce` and omitted `last_checked_at`. Installations that restarted while that shape was active retain the physical table because `create_all()` does not alter existing tables. The canonical `0006_connector_capability_identity` migration then adds `capability_id` but leaves the missing field and retired nonce machinery. Subsequent list queries fail with `no such column: connectors.last_checked_at`, so Custom MCP is unavailable after restart.

This one-time migration converges the exact partially upgraded shape before ORM access. It preserves connector rows and is safe to retry after interruption.

## Validation

- `python3 -m py_compile backend/app/database.py backend/tests/test_db_migrations.py`
- `scripts/wt-pytest.sh backend/tests/test_db_migrations.py backend/tests/test_connectors.py -q` — 61 passed