### PR TITLE
Bound global search and reuse canonical app icons

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,11 +16,11 @@
     "test:structure": "node scripts/check-structural-test-budget.mjs",
     "pretest:lib": "npm run runtime:check && npm run speech-runtime:check && npm run speech-worker:check && npm run test:structure",
     "test": "npm run test:lib && npm run test:hooks",
-    "test:lib": "node --loader=./src/lib/__tests__/vite-env-loader.mjs --test $(find src/lib src/utils src/hooks src/components/DiffView src/components/ProviderAuth src/components/NotificationsView src/components/ChatView/__tests__ src/components/Shell/__tests__ -name '*.test.js')",
+    "test:lib": "node --loader=./src/lib/__tests__/vite-env-loader.mjs --test $(find src/lib src/utils src/hooks src/components/DiffView src/components/GlobalSearch src/components/ProviderAuth src/components/NotificationsView src/components/ChatView/__tests__ src/components/Shell/__tests__ -name '*.test.js')",
     "test:hooks": "node --loader=./src/components/ChatView/hooks/__tests__/react-loader.mjs --test $(find src/components/ChatView/hooks -name '*.test.js') $(find src/components/Shell/__tests__ -name '*.hooktest.js')",
     "test:coverage": "npm run test:lib:coverage && npm run test:hooks:coverage",
     "pretest:lib:coverage": "npm run runtime:check && npm run speech-runtime:check && npm run speech-worker:check && npm run test:structure",
-    "test:lib:coverage": "node --experimental-test-coverage --test-coverage-lines=63 --test-coverage-branches=60 --test-coverage-functions=58 --loader=./src/lib/__tests__/vite-env-loader.mjs --test $(find src/lib src/utils src/hooks src/components/DiffView src/components/ProviderAuth src/components/NotificationsView src/components/ChatView/__tests__ src/components/Shell/__tests__ -name '*.test.js')",
+    "test:lib:coverage": "node --experimental-test-coverage --test-coverage-lines=63 --test-coverage-branches=60 --test-coverage-functions=58 --loader=./src/lib/__tests__/vite-env-loader.mjs --test $(find src/lib src/utils src/hooks src/components/DiffView src/components/GlobalSearch src/components/ProviderAuth src/components/NotificationsView src/components/ChatView/__tests__ src/components/Shell/__tests__ -name '*.test.js')",
     "test:hooks:coverage": "node --experimental-test-coverage --test-coverage-lines=63 --test-coverage-branches=60 --test-coverage-functions=58 --loader=./src/components/ChatView/hooks/__tests__/react-loader.mjs --test $(find src/components/ChatView/hooks -name '*.test.js') $(find src/components/Shell/__tests__ -name '*.hooktest.js')"
   },
   "dependencies": {

--- a/frontend/src/components/AppIcon.css
+++ b/frontend/src/components/AppIcon.css
@@ -1,0 +1,27 @@
+/* Shared artwork/fallback behavior; each surface owns only icon size and radius. */
+.app-icon {
+  position: relative;
+  flex-shrink: 0;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  background: var(--app-color, var(--accent));
+  color: var(--accent-fg, #fff);
+  font-weight: 750;
+}
+
+.app-icon img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.app-icon.is-image {
+  overflow: visible;
+  border-radius: 0;
+  background: transparent;
+}
+
+.app-icon.is-image > span { visibility: hidden; }

--- a/frontend/src/components/AppIcon.jsx
+++ b/frontend/src/components/AppIcon.jsx
@@ -1,0 +1,48 @@
+/* AppIcon renders one installed app's artwork with a stable initials fallback. */
+import { useState } from 'react'
+import {
+  appIconIsReady,
+  appIconUrl,
+  appInitials,
+  forgetAppIconReady,
+  rememberAppIconReady,
+} from './appIcon.js'
+import './AppIcon.css'
+
+export default function AppIcon({ item, label, className = '' }) {
+  const iconUrl = appIconUrl(item)
+  const [loadedUrl, setLoadedUrl] = useState(
+    () => (appIconIsReady(iconUrl) ? iconUrl : null),
+  )
+  const hasImage = Boolean(
+    iconUrl && (loadedUrl === iconUrl || appIconIsReady(iconUrl)),
+  )
+
+  return (
+    <span
+      className={`app-icon${className ? ` ${className}` : ''}${hasImage ? ' is-image' : ''}`}
+      style={{ '--app-color': item?.background_color || item?.theme_color || 'var(--accent)' }}
+      aria-hidden="true"
+    >
+      <span>{appInitials(label)}</span>
+      {iconUrl && (
+        <img
+          src={iconUrl}
+          alt=""
+          loading="eager"
+          decoding="async"
+          onLoad={event => {
+            event.currentTarget.hidden = false
+            rememberAppIconReady(iconUrl)
+            setLoadedUrl(iconUrl)
+          }}
+          onError={event => {
+            event.currentTarget.hidden = true
+            forgetAppIconReady(iconUrl)
+            setLoadedUrl(null)
+          }}
+        />
+      )}
+    </span>
+  )
+}

--- a/frontend/src/components/Drawer/Drawer.css
+++ b/frontend/src/components/Drawer/Drawer.css
@@ -308,35 +308,12 @@
 }
 
 .drawer__now-playing-icon {
-  position: relative;
   flex: 0 0 30px;
   width: 30px;
   height: 30px;
-  display: grid;
-  place-items: center;
-  overflow: hidden;
   border-radius: 8px;
-  background: var(--app-color, var(--accent));
-  color: var(--accent-fg, #fff);
   font-size: 9px;
-  font-weight: 750;
 }
-
-.drawer__now-playing-icon img {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
-}
-
-.drawer__now-playing-icon.is-image {
-  overflow: visible;
-  border-radius: 0;
-  background: transparent;
-}
-
-.drawer__now-playing-icon.is-image > span { visibility: hidden; }
 
 .drawer__now-playing-copy {
   min-width: 0;
@@ -509,36 +486,10 @@
 }
 
 .drawer__app-icon {
-  position: relative;
-  flex-shrink: 0;
   width: 24px;
   height: 24px;
-  display: grid;
-  place-items: center;
-  overflow: hidden;
   border-radius: 7px;
-  background: var(--app-color, var(--accent));
-  color: var(--accent-fg, #fff);
   font-size: 8px;
-  font-weight: 750;
-}
-
-.drawer__app-icon img {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
-}
-
-.drawer__app-icon.is-image {
-  overflow: visible;
-  border-radius: 0;
-  background: transparent;
-}
-
-.drawer__app-icon.is-image > span {
-  visibility: hidden;
 }
 
 /* ── Context-menu row ──────────────────────────────── */

--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -11,13 +11,8 @@ import {
   NewChatNavIcon,
   SettingsNavIcon,
 } from '../navigationIcons.js'
-import {
-  appIconIsReady,
-  appIconUrl,
-  forgetAppIconReady,
-  preloadAppIcons,
-  rememberAppIconReady,
-} from '../appIcon.js'
+import AppIcon from '../AppIcon.jsx'
+import { preloadAppIcons } from '../appIcon.js'
 import {
   computePinnedDrag,
   observePinnedOrderHandoff,
@@ -43,7 +38,6 @@ import InstallSheet from './InstallSheet.jsx'
 import AppsDirectory from './AppsDirectory.jsx'
 import DrawerItemActionMenu from './DrawerItemActionMenu.jsx'
 import {
-  appInitials,
   buildDrawerSections,
   filterInstalledApps,
 } from './drawerInformationArchitecture.js'
@@ -1296,13 +1290,7 @@ function NowPlaying({ session, app, onOpen, onControl }) {
         onClick={() => onOpen?.(session.appId)}
         aria-label={`Open ${appName}`}
       >
-        {app ? (
-          <AppIcon item={app} label={appName} className="drawer__now-playing-icon" />
-        ) : (
-          <span className="drawer__now-playing-icon" aria-hidden="true">
-            <span>{appInitials(appName)}</span>
-          </span>
-        )}
+        <AppIcon item={app} label={appName} className="drawer__now-playing-icon" />
         <span className="drawer__now-playing-copy">
           <strong>{session.title}</strong>
           <small>{appName} · {stateLabel}</small>
@@ -1946,43 +1934,6 @@ const DrawerRow = memo(function DrawerRow({
     </div>
   )
 })
-
-function AppIcon({ item, label, className }) {
-  const iconUrl = appIconUrl(item)
-  const [loadedUrl, setLoadedUrl] = useState(
-    () => (appIconIsReady(iconUrl) ? iconUrl : null),
-  )
-  const hasImage = Boolean(
-    iconUrl && (loadedUrl === iconUrl || appIconIsReady(iconUrl)),
-  )
-  return (
-    <span
-      className={`${className}${hasImage ? ' is-image' : ''}`}
-      style={{ '--app-color': item.background_color || item.theme_color || 'var(--accent)' }}
-      aria-hidden="true"
-    >
-      <span>{appInitials(label)}</span>
-      {iconUrl && (
-        <img
-          src={iconUrl}
-          alt=""
-          loading="eager"
-          decoding="async"
-          onLoad={event => {
-            event.currentTarget.hidden = false
-            rememberAppIconReady(iconUrl)
-            setLoadedUrl(iconUrl)
-          }}
-          onError={event => {
-            event.currentTarget.hidden = true
-            forgetAppIconReady(iconUrl)
-            setLoadedUrl(null)
-          }}
-        />
-      )}
-    </span>
-  )
-}
 
 function DrawerItemMenu({
   kind,

--- a/frontend/src/components/Drawer/drawerInformationArchitecture.js
+++ b/frontend/src/components/Drawer/drawerInformationArchitecture.js
@@ -89,14 +89,3 @@ export function filterInstalledApps(apps = [], query = '') {
       .includes(needle)
   ))
 }
-
-export function appInitials(name) {
-  const words = String(name || '')
-    .replace(/[^a-z0-9]+/gi, ' ')
-    .trim()
-    .split(/\s+/)
-    .filter(Boolean)
-  if (words.length === 0) return 'A'
-  if (words.length === 1) return words[0].slice(0, 2).toLocaleUpperCase()
-  return `${words[0][0]}${words[1][0]}`.toLocaleUpperCase()
-}

--- a/frontend/src/components/GlobalSearch/GlobalSearch.css
+++ b/frontend/src/components/GlobalSearch/GlobalSearch.css
@@ -1,4 +1,4 @@
-/* Full-screen shell search: one overlay on mobile and desktop, with a bounded reading column. */
+/* Search stays full-screen on phones and becomes a wide, bounded dialog on web. */
 
 .global-search-button {
   position: relative;
@@ -259,9 +259,13 @@
   flex: none;
   width: 34px;
   height: 34px;
+  border-radius: 10px;
+  font-size: 10px;
+}
+
+.global-search__result-icon:not(.app-icon) {
   display: grid;
   place-items: center;
-  border-radius: 10px;
   background: var(--surface2);
   color: var(--muted);
 }
@@ -305,6 +309,30 @@
 }
 
 .global-search__status--error { color: var(--danger); }
+
+@media (min-width: 700px) {
+  .global-search__overlay {
+    align-items: flex-start;
+    padding:
+      max(40px, env(safe-area-inset-top))
+      max(32px, env(safe-area-inset-right))
+      max(40px, env(safe-area-inset-bottom))
+      max(32px, env(safe-area-inset-left));
+    background: rgba(0, 0, 0, 0.46);
+  }
+
+  .global-search {
+    box-sizing: border-box;
+    width: min(1120px, 100%);
+    height: min(720px, 100%);
+    padding: 20px 22px 22px;
+    overflow: hidden;
+    border: 1px solid var(--border);
+    border-radius: 18px;
+    background: color-mix(in srgb, var(--bg) 96%, var(--surface));
+    box-shadow: 0 24px 72px rgba(0, 0, 0, 0.32);
+  }
+}
 
 @media (max-width: 520px) {
   .global-search__overlay {

--- a/frontend/src/components/GlobalSearch/GlobalSearch.jsx
+++ b/frontend/src/components/GlobalSearch/GlobalSearch.jsx
@@ -1,9 +1,8 @@
-/* GlobalSearch is the full-screen, keyboard-openable search surface for chats and installed apps. */
+/* GlobalSearch is the keyboard-openable search dialog for chats and installed apps. */
 import { createPortal } from 'react-dom'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   Chat,
-  Grid,
   MagnifyingGlassSearch,
   X,
 } from '@openai/apps-sdk-ui/components/Icon'
@@ -11,6 +10,7 @@ import { api } from '../../api/client.js'
 import { appQueries } from '../../hooks/queries.js'
 import useDialogFocus from '../../hooks/useDialogFocus.js'
 import { requestChatSearchReveal } from '../../lib/chatSearchReveal.js'
+import AppIcon from '../AppIcon.jsx'
 import {
   SHELL_SHORTCUTS,
   shortcutLabel,
@@ -144,14 +144,20 @@ export default function GlobalSearch({ onClose, onOpenTarget }) {
 
   return createPortal(
     <div
-      id="global-search-dialog"
-      ref={dialogRef}
       className="global-search__overlay"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="global-search-title"
+      role="presentation"
+      onPointerDown={(event) => {
+        if (event.target === event.currentTarget) onClose()
+      }}
     >
-      <div className="global-search">
+      <div
+        id="global-search-dialog"
+        ref={dialogRef}
+        className="global-search"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="global-search-title"
+      >
         <header className="global-search__header">
           <div>
             <h2 id="global-search-title" className="global-search__title">Search</h2>
@@ -206,9 +212,11 @@ export default function GlobalSearch({ onClose, onOpenTarget }) {
                         className="global-search__result"
                         onClick={() => openApp(app)}
                       >
-                        <span className="global-search__result-icon" aria-hidden="true">
-                          <Grid width={18} height={18} />
-                        </span>
+                        <AppIcon
+                          item={app}
+                          label={app.name}
+                          className="global-search__result-icon"
+                        />
                         <span className="global-search__result-main">
                           <span className="global-search__result-title">{app.name}</span>
                           <span className="global-search__result-detail">

--- a/frontend/src/components/Shell/__tests__/appIcon.test.js
+++ b/frontend/src/components/Shell/__tests__/appIcon.test.js
@@ -3,8 +3,15 @@ import assert from 'node:assert/strict'
 import {
   appIconIsReady,
   appIconUrl,
+  appInitials,
   preloadAppIcons,
 } from '../../appIcon.js'
+
+test('app initials remain useful when custom artwork is missing', () => {
+  assert.equal(appInitials('Beat Machine'), 'BM')
+  assert.equal(appInitials('Atlas'), 'AT')
+  assert.equal(appInitials('---'), 'A')
+})
 
 test('installed app chrome sizes the canonical icon reference from AppOut', () => {
   const app = {

--- a/frontend/src/components/appIcon.js
+++ b/frontend/src/components/appIcon.js
@@ -4,6 +4,17 @@ const readyIconUrls = new Set()
 
 const APP_ICON_READY_CACHE_MAX = 256
 
+export function appInitials(name) {
+  const words = String(name || '')
+    .replace(/[^a-z0-9]+/gi, ' ')
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+  if (words.length === 0) return 'A'
+  if (words.length === 1) return words[0].slice(0, 2).toLocaleUpperCase()
+  return `${words[0][0]}${words[1][0]}`.toLocaleUpperCase()
+}
+
 export function appIconUrl(app, size = 128) {
   if (!app?.icon_url) return null
   if (size == null) return app.icon_url

--- a/frontend/src/lib/__tests__/drawerInformationArchitecture.test.js
+++ b/frontend/src/lib/__tests__/drawerInformationArchitecture.test.js
@@ -2,7 +2,6 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 
 import {
-  appInitials,
   buildDrawerSections,
   filterInstalledApps,
 } from '../../components/Drawer/drawerInformationArchitecture.js'
@@ -118,10 +117,4 @@ test('app search covers names, descriptions, and slugs without reordering', () =
   assert.equal(filterInstalledApps(apps, 'places')[0].id, 2)
   assert.equal(filterInstalledApps(apps, 'missing').length, 0)
   assert.equal(filterInstalledApps(apps, ''), apps)
-})
-
-test('app initials remain useful for missing custom icons', () => {
-  assert.equal(appInitials('Beat Machine'), 'BM')
-  assert.equal(appInitials('Atlas'), 'AT')
-  assert.equal(appInitials('---'), 'A')
 })

--- a/frontend/src/lib/__tests__/keyboardShortcuts.test.js
+++ b/frontend/src/lib/__tests__/keyboardShortcuts.test.js
@@ -1,7 +1,6 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import {
-  SHORTCUT_CATALOG,
   SHELL_SHORTCUTS,
   shortcutLabel,
   shortcutMatches,
@@ -22,14 +21,4 @@ test('shortcut labels adapt to the owner platform', () => {
   assert.equal(shortcutLabel(SHELL_SHORTCUTS.openSearch, 'Win32'), 'Ctrl+K')
   assert.equal(shortcutLabel(SHELL_SHORTCUTS.toggleBuilder, 'MacIntel'), '⇧↵')
   assert.equal(shortcutLabel(SHELL_SHORTCUTS.toggleBuilder, 'Linux x86_64'), 'Shift+Enter')
-})
-
-test('the code-owned catalog has stable unique action ids', () => {
-  const ids = SHORTCUT_CATALOG.map(shortcut => shortcut.id)
-  assert.deepEqual(ids, [
-    'search.open',
-    'workspace.undo',
-    'workspace.toggle-builder',
-  ])
-  assert.equal(new Set(ids).size, ids.length)
 })

--- a/frontend/src/lib/keyboardShortcuts.js
+++ b/frontend/src/lib/keyboardShortcuts.js
@@ -1,35 +1,13 @@
-/* The discoverable keyboard-shortcut catalog is the single source of truth for
-   shell shortcut matching and labels. */
+/* Shell shortcut bindings stay centralized so matching and labels cannot drift. */
 
 export const SHELL_SHORTCUTS = {
-  openSearch: {
-    id: 'search.open',
-    title: 'Open search',
-    description: 'Search chats and installed apps from anywhere in Möbius.',
-    scope: 'Anywhere',
-    binding: { key: 'k', mod: true },
-  },
-  undoWorkspace: {
-    id: 'workspace.undo',
-    title: 'Undo workspace change',
-    description: 'Undo the latest pane or tab arrangement outside text fields.',
-    scope: 'Workspace',
-    binding: { key: 'z', mod: true },
-  },
-  toggleBuilder: {
-    id: 'workspace.toggle-builder',
-    title: 'Toggle Builder mode',
-    description: 'Switch workspace modes while the Möbius logo is focused.',
-    scope: 'Möbius logo',
-    binding: { key: 'Enter', shift: true },
-  },
+  openSearch: { key: 'k', mod: true },
+  undoWorkspace: { key: 'z', mod: true },
+  toggleBuilder: { key: 'Enter', shift: true },
 }
 
-export const SHORTCUT_CATALOG = Object.values(SHELL_SHORTCUTS)
-
-export function shortcutMatches(event, shortcut) {
-  if (!event || !shortcut?.binding || event.isComposing || event.repeat) return false
-  const binding = shortcut.binding
+export function shortcutMatches(event, binding) {
+  if (!event || !binding || event.isComposing || event.repeat) return false
   const eventKey = typeof event.key === 'string' ? event.key.toLowerCase() : ''
   const bindingKey = String(binding.key || '').toLowerCase()
   if (!bindingKey || eventKey !== bindingKey) return false
@@ -41,8 +19,7 @@ export function shortcutMatches(event, shortcut) {
   return true
 }
 
-export function shortcutLabel(shortcut, platform = globalThis.navigator?.platform || '') {
-  const binding = shortcut?.binding
+export function shortcutLabel(binding, platform = globalThis.navigator?.platform || '') {
   if (!binding) return ''
   const apple = /Mac|iPhone|iPad|iPod/i.test(platform)
   const parts = []
@@ -55,8 +32,3 @@ export function shortcutLabel(shortcut, platform = globalThis.navigator?.platfor
   if (key) parts.push(key)
   return apple ? parts.join('') : parts.join('+')
 }
-
-// Future owner customization should persist only `{ id, binding }` overrides
-// for catalogued actions. Never deserialize executable callbacks from app or
-// owner data; apps keep their own iframe-local shortcuts unless the shell later
-// introduces a reviewed, intent-based action declaration.


### PR DESCRIPTION
Follow-up to #623.

## Summary
- present global search as a wide, bounded dialog on the web while keeping the phone layout full-screen
- close search from any backdrop click while retaining the existing Escape, close-button, focus, and keyboard-shortcut behavior
- show canonical app artwork in app results while chat results keep the chat icon
- share one icon renderer across search, the drawer, and now-playing instead of duplicating loading and fallback logic
- remove unused shortcut-catalog scaffolding and include the existing search-model tests in the normal frontend suite

## Validation
- full frontend unit and hook suites passed
- structural-test ratchet passed without raising its budget
- focused lint and the production/PWA build passed
- rendered desktop search verified with app and chat results, plus backdrop dismissal