### PR TITLE
Scope additive New Chat tabs to Builder

### DIFF
--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -2736,6 +2736,13 @@ export default function Shell() {
     }
   }
 
+  // Single screen owns one compose surface; Builder treats New chat as an
+  // additive tab action in the focused pane.
+  function startUserChat() {
+    const forceNew = workspaceStateRef.current.ws.viewMode === 'panes'
+    return newChat({ forceNew, focusComposer: true, recordHistory: true })
+  }
+
   // Keep the latest-newChat ref current so handleAppError's crash-report
   // fallback starts a chat with this render's live closure.
   newChatRef.current = newChat
@@ -3080,7 +3087,7 @@ export default function Shell() {
             className="shell__rail-action"
             aria-label="New chat shortcut"
             title="New chat"
-            onClick={() => newChat({ forceNew: true, focusComposer: true, recordHistory: true })}
+            onClick={startUserChat}
           >
             <NewChatNavIcon aria-hidden="true" />
           </button>
@@ -3141,7 +3148,7 @@ export default function Shell() {
         activeChatId={activeChatId}
         onChat={selectChat}
         onApp={(id) => navTo('canvas', { appId: id })}
-        onNewChat={() => newChat({ forceNew: true, focusComposer: true, recordHistory: true })}
+        onNewChat={startUserChat}
         onDeleteChat={deleteChat}
         onDeleteApp={deleteApp}
         onDeleteAppData={deleteAppData}

--- a/frontend/src/components/Shell/__tests__/chatHandoff.test.js
+++ b/frontend/src/components/Shell/__tests__/chatHandoff.test.js
@@ -243,11 +243,19 @@ test('direct chat actions hand focus to the destination composer', () => {
   assert.match(shell,
     /if \(!startupChatComposerFocusPendingRef\.current\) return[\s\S]*activeView !== 'chat' \|\| activeChatId == null[\s\S]*startupChatComposerFocusPendingRef\.current = false[\s\S]*focusDesktopChatPaneComposer\(activeChatId\)/,
     'restored chat focus must be one-shot rather than following later mode changes')
-  const ownerNewChatCalls = shell.match(
-    /newChat\(\{ forceNew: true, focusComposer: true, recordHistory: true \}\)/g,
-  ) || []
-  assert.equal(ownerNewChatCalls.length, 2,
-    'desktop rail and mobile drawer must both allocate and focus a fresh chat')
+  const startUserChat = shell.match(
+    /function startUserChat\(\) \{([\s\S]*?)\n  \}/,
+  )?.[1] || ''
+  assert.match(startUserChat,
+    /const forceNew = workspaceStateRef\.current\.ws\.viewMode === 'panes'/,
+    'only Builder makes the owner-facing New chat action additive')
+  assert.match(startUserChat,
+    /newChat\(\{ forceNew, focusComposer: true, recordHistory: true \}\)/,
+    'the mode-scoped action must still focus the destination composer')
+  assert.match(shell, /onClick=\{startUserChat\}/,
+    'the desktop rail must use the shared mode-scoped action')
+  assert.match(shell, /onNewChat=\{startUserChat\}/,
+    'the mobile drawer must use the shared mode-scoped action')
   assert.match(shell,
     /beginTouchComposerFocusLease\([\s\S]*?await resolveNewChatId/,
     'New chat must reserve phone keyboard focus before its first async boundary')


### PR DESCRIPTION
## Summary

- Preserve Single screen's one compose surface by reusing its active untouched blank chat.
- Keep Builder's New chat action additive in the focused pane.
- Route the desktop rail and mobile drawer through the same mode-aware action.

## Testing

- Focused Shell suite: 55 tests passed.
- Structural-test ratchet: 779/779 cases.
- Live browser checks in Single screen, desktop Builder, and mobile Builder.