### PR TITLE
Unify chat search around normalized documents

### DIFF
--- a/backend/app/chat_search.py
+++ b/backend/app/chat_search.py
@@ -1,208 +1,48 @@
-"""Full-text search over chat transcripts (drawer search).
+"""Search chat titles and conversation prose through normalized documents.
 
-Design: SQLite uses an FTS5 index over conversation prose — the owner's
-messages, the assistant's replies, and chat titles. PostgreSQL and other
-dialects use the same visibility and matching contract through a portable
-candidate query plus bounded Python ranking. Tool output, thinking traces, and
-`blocks` machinery are deliberately excluded: they live in their own tables,
-they are the bulk of the bytes, and they are noise for "where did we talk
-about X".
+``chat_search_docs`` is the one search source on SQLite and PostgreSQL: one
+title row and one row per visible owner/assistant message. Search never scans
+serialized transcript JSON. SQLite uses an external-content FTS5 table to find
+candidate document rows; PostgreSQL filters the same ordinary rows with a
+portable text predicate. Both paths apply the same word/prefix matcher,
+snippet builder, grouping, and ranking after candidate selection.
 
-The index is DERIVED data, reconciled lazily at query time:
-
-- `chat_search_docs` holds one plain-text row per indexed message (plus one
-  title row per chat, ``msg_idx = -1``). `chat_search_fts` is an
-  external-content FTS5 table over it, kept in sync by triggers on the docs
-  table itself (the canonical FTS5 external-content pattern — the triggers
-  watch OUR derived table, never `chats`).
-- `chat_search_state` remembers the exact `chats.updated_at` text indexed for
-  each chat. A search request first reconciles: any live chat whose row changed
-  is rebuilt from its current transcript, while deleted/purged chats are
-  dropped. Rebuilding the changed chat is deliberate: assistant snapshots and
-  owner transcript replacements can rewrite an existing message without
-  changing the list length, so an append-only shortcut would make stale text
-  permanent.
-- Only chats that belong in the owner's drawer are indexed, and hidden
-  transcript messages are omitted. A small derived-schema version makes those
-  indexing semantics migratable: changing them drops and regenerates only the
-  disposable search tables, never the source chat rows.
-
-For SQLite, reconciliation happens inside the search request, so there is no
-second code path that could forget to update the index, nothing hooks into the
-turn lifecycle, and a missing index (or this feature landing on an existing
-instance) simply rebuilds itself on first use. Memory: FTS5 reads b-tree pages
-from disk per query; nothing is cached in process memory. Only changed chats
-ever have their `messages` JSON hydrated — reconcile compares timestamps, not
-transcripts.
-
-Writes here touch only the derived `chat_search_*` tables — never
-`Chat.messages` / `Chat.pending_messages` (those stay behind `chat_writer.py`).
+The documents are disposable derived data. A search lazily reconciles chats
+whose exact ``updated_at`` representation changed, while the numbered schema
+migration owns tables, indexes, and SQLite triggers. Transcript persistence
+remains exclusively behind ``chat_writer.py``.
 """
 
-import json
+import heapq
 import re
 import threading
 
-from sqlalchemy import Text, cast, func, or_, text as sql
+from sqlalchemy import text as sql
 from sqlalchemy.orm import Session
 
-from app import models
-from app.chat_visibility import visible_in_owner_drawer as _visible_in_owner_drawer
+from app import chat_visibility, models
 
-# Private-use sentinels around FTS5 snippet matches. The API converts them to
-# a JSON-friendly form; they can never collide with real transcript text.
+# Private-use sentinels around snippet matches. The API converts them to a
+# JSON-friendly form; they can never collide with real transcript text.
 _MARK_OPEN = "\ue000"
 _MARK_CLOSE = "\ue001"
 
-# The version covers both table shape and indexing semantics. Search data is
-# entirely derived, so a mismatch is safer and simpler to handle by rebuilding
-# than by carrying migrations for disposable rows.
-_INDEX_VERSION = "2"
-_SCHEMA_LOCK = threading.Lock()
-_RECONCILE_LOCK = threading.Lock()
-
-# The portable backend has no derived full-text index. Keep its fallback
-# honest and bounded: rank matches only within the most recently active chats
-# whose serialized source contains every query token. This avoids turning one
-# broad drawer query into an unbounded transcript hydration. SQLite retains
-# complete-history semantics through its on-disk FTS index.
-_PORTABLE_CANDIDATE_LIMIT = 512
-
 # Message roles whose `content` strings are conversation prose.
 _PROSE_ROLES = ("user", "assistant")
-
-_SCHEMA = """
-CREATE TABLE IF NOT EXISTS chat_search_docs (
-  id INTEGER PRIMARY KEY,
-  chat_id TEXT NOT NULL,
-  msg_idx INTEGER NOT NULL,
-  ts INTEGER,
-  role TEXT,
-  text TEXT NOT NULL
-);
-CREATE INDEX IF NOT EXISTS chat_search_docs_chat
-  ON chat_search_docs(chat_id);
-CREATE UNIQUE INDEX IF NOT EXISTS chat_search_docs_chat_message
-  ON chat_search_docs(chat_id, msg_idx);
-CREATE VIRTUAL TABLE IF NOT EXISTS chat_search_fts USING fts5(
-  text,
-  content='chat_search_docs',
-  content_rowid='id',
-  tokenize='unicode61 remove_diacritics 2'
-);
-CREATE TRIGGER IF NOT EXISTS chat_search_docs_ai
-  AFTER INSERT ON chat_search_docs BEGIN
-    INSERT INTO chat_search_fts(rowid, text) VALUES (new.id, new.text);
-  END;
-CREATE TRIGGER IF NOT EXISTS chat_search_docs_ad
-  AFTER DELETE ON chat_search_docs BEGIN
-    INSERT INTO chat_search_fts(chat_search_fts, rowid, text)
-      VALUES ('delete', old.id, old.text);
-  END;
-CREATE TABLE IF NOT EXISTS chat_search_state (
-  chat_id TEXT PRIMARY KEY,
-  indexed_updated_at TEXT NOT NULL
-);
-CREATE TABLE IF NOT EXISTS chat_search_meta (
-  key TEXT PRIMARY KEY,
-  value TEXT NOT NULL
-);
-"""
-
-_schema_ready = False
+_RECONCILE_LOCK = threading.Lock()
 
 
-def _ensure_schema(db: Session) -> None:
-  global _schema_ready
-  if _schema_ready:
-    return
-  with _SCHEMA_LOCK:
-    if _schema_ready:
-      return
-    expected_tables = {
-      "chat_search_docs",
-      "chat_search_fts",
-      "chat_search_state",
-      "chat_search_meta",
-    }
-    present_tables = {
-      row[0]
-      for row in db.execute(sql(
-        "SELECT name FROM sqlite_master WHERE type = 'table'"
-        " AND name IN ('chat_search_docs', 'chat_search_fts',"
-        "              'chat_search_state', 'chat_search_meta')"
-      )).fetchall()
-    }
-    version = None
-    if "chat_search_meta" in present_tables:
-      row = db.execute(sql(
-        "SELECT value FROM chat_search_meta WHERE key = 'index_version'"
-      )).fetchone()
-      version = row[0] if row else None
-    columns = (
-      {
-        row[1]
-        for row in db.execute(sql("PRAGMA table_info(chat_search_docs)"))
-      }
-      if "chat_search_docs" in present_tables
-      else set()
-    )
-    schema_current = (
-      present_tables == expected_tables
-      and version == _INDEX_VERSION
-      and {"id", "chat_id", "msg_idx", "ts", "role", "text"} <= columns
-    )
-    if not schema_current:
-      # Dropping the external-content virtual table removes its shadow tables;
-      # dropping docs removes its sync triggers. A single transaction ensures a
-      # concurrent search sees either the old generation or the new empty one.
-      for statement in (
-        "DROP TABLE IF EXISTS chat_search_fts",
-        "DROP TABLE IF EXISTS chat_search_docs",
-        "DROP TABLE IF EXISTS chat_search_state",
-        "DROP TABLE IF EXISTS chat_search_meta",
-      ):
-        db.execute(sql(statement))
-    for statement in _split_schema(_SCHEMA):
-      db.execute(sql(statement))
-    db.execute(
-      sql(
-        "INSERT INTO chat_search_meta (key, value)"
-        " VALUES ('index_version', :version)"
-        " ON CONFLICT(key) DO UPDATE SET value = excluded.value"
-      ),
-      {"version": _INDEX_VERSION},
-    )
-    db.commit()
-    _schema_ready = True
-
-
-def _split_schema(schema: str) -> list[str]:
-  """Split the DDL on statement boundaries, keeping trigger bodies intact."""
-  statements, buf, in_trigger = [], [], False
-  for line in schema.splitlines():
-    stripped = line.strip()
-    if not stripped:
-      continue
-    buf.append(line)
-    if stripped.upper().startswith("CREATE TRIGGER"):
-      in_trigger = True
-    if stripped.endswith(";"):
-      if in_trigger and stripped.upper() != "END;":
-        continue
-      statements.append("\n".join(buf))
-      buf, in_trigger = [], False
-  return statements
-
-
-def _prose_docs(title: str, messages: list) -> list[tuple[int, object, object, str]]:
+def _prose_docs(
+  title: str,
+  messages: list,
+) -> list[tuple[int, int | None, str | None, str]]:
   """(msg_idx, ts, role, text) rows: title at -1 (ts/role None), then prose.
 
   `ts` and `role` are stored so a search result can point the drawer at the
   exact transcript row to reveal — the chat UI keys each message row as
   ``<role>-<ts>``. `ts` is unique within a chat, so it needs no message index.
   """
-  docs: list[tuple[int, object, object, str]] = []
+  docs: list[tuple[int, int | None, str | None, str]] = []
   if title and title.strip():
     docs.append((-1, None, None, title.strip()))
   for idx, message in enumerate(messages):
@@ -233,7 +73,11 @@ def _delete_chat_docs(db: Session, chat_id: str) -> None:
   )
 
 
-def _write_docs(db: Session, chat_id: str, docs: list[tuple[int, object, object, str]]) -> None:
+def _write_docs(
+  db: Session,
+  chat_id: str,
+  docs: list[tuple[int, int | None, str | None, str]],
+) -> None:
   if not docs:
     return
   db.execute(
@@ -280,8 +124,6 @@ def reconcile(db: Session) -> None:
 
 
 def _reconcile_locked(db: Session) -> None:
-  _ensure_schema(db)
-
   # Index rows whose chat is gone or tombstoned. A restored chat re-enters
   # through the stale scan below (restore bumps updated_at; no state row
   # remains, so it reindexes from scratch).
@@ -298,26 +140,19 @@ def _reconcile_locked(db: Session) -> None:
   # Live chats whose row changed since we last indexed them. Compared as the
   # exact stored text (equality, not ordering) so timestamp formatting can
   # never produce a false "fresh".
-  stale = db.execute(
-    sql(
-      "SELECT c.id FROM chats c"
-      " LEFT JOIN chat_search_state s ON s.chat_id = c.id"
-      " WHERE c.deleted_at IS NULL"
-      "   AND (s.chat_id IS NULL"
-      "        OR s.indexed_updated_at IS NOT CAST(c.updated_at AS TEXT))"
-    )
-  ).fetchall()
+  stale = db.execute(sql(
+    "SELECT c.id, COALESCE(CAST(c.updated_at AS TEXT), '') FROM chats c"
+    " LEFT JOIN chat_search_state s ON s.chat_id = c.id"
+    " WHERE c.deleted_at IS NULL"
+    " AND (s.chat_id IS NULL OR s.indexed_updated_at <>"
+    "      COALESCE(CAST(c.updated_at AS TEXT), ''))"
+  )).fetchall()
 
-  for (chat_id,) in stale:
+  for chat_id, updated_text in stale:
     # Hydrates messages JSON for THIS chat only.
     chat = db.get(models.Chat, chat_id)
     if chat is None or chat.deleted_at is not None:
       continue
-    row = db.execute(
-      sql("SELECT CAST(updated_at AS TEXT) FROM chats WHERE id = :cid"),
-      {"cid": chat_id},
-    ).fetchone()
-    updated_text = row[0] if row else ""
     messages = chat.messages or []
     title = chat.title or ""
     # The index is disposable: replace this chat's derived rows at its durable
@@ -325,7 +160,7 @@ def _reconcile_locked(db: Session) -> None:
     # Non-drawer chats retain only a tiny state row so an unchanged hidden
     # app/autopilot chat is not re-hydrated on every query.
     _delete_chat_docs(db, chat_id)
-    if _visible_in_owner_drawer(chat):
+    if chat_visibility.visible_in_owner_drawer(chat):
       _write_docs(db, chat_id, _prose_docs(title, messages))
     _upsert_state(
       db,
@@ -339,22 +174,19 @@ def _reconcile_locked(db: Session) -> None:
     db.commit()
 
 
-def _fts_query(raw: str) -> str:
-  """User text -> safe FTS5 query: quoted tokens, prefix on the last one."""
-  tokens = _query_tokens(raw)
-  if not tokens:
-    return ""
+def _fts_query(tokens: list[str]) -> str:
+  """Build a safe FTS5 query from already-neutralized tokens."""
   quoted = [f'"{token}"' for token in tokens]
   quoted[-1] = f"{quoted[-1]}*"
   return " ".join(quoted)
 
 
 def _query_tokens(raw: str) -> list[str]:
-  """Normalize one query consistently across FTS and portable backends."""
+  """Normalize one query consistently across both database backends."""
   return re.findall(r"\w+", raw, flags=re.UNICODE)
 
 
-def _portable_token_patterns(tokens: list[str]) -> list[re.Pattern[str]]:
+def _token_patterns(tokens: list[str]) -> list[re.Pattern[str]]:
   patterns = []
   for index, token in enumerate(tokens):
     escaped = re.escape(token)
@@ -366,7 +198,7 @@ def _portable_token_patterns(tokens: list[str]) -> list[re.Pattern[str]]:
   return patterns
 
 
-def _portable_match_spans(
+def _match_spans(
   text: str,
   patterns: list[re.Pattern[str]],
 ) -> list[tuple[int, int]]:
@@ -379,12 +211,12 @@ def _portable_match_spans(
   return sorted(set(spans))
 
 
-def _portable_snippet(
+def _snippet(
   text: str,
   spans: list[tuple[int, int]],
   width: int = 180,
 ) -> str:
-  """Build one sentinel-marked excerpt for the non-FTS fallback."""
+  """Build one sentinel-marked excerpt around the first matching span."""
   first_start = spans[0][0]
   start = max(0, first_start - width // 3)
   end = min(len(text), start + width)
@@ -408,203 +240,132 @@ def _portable_snippet(
   return "".join(pieces)
 
 
-def _portable_like_pattern(token: str) -> str:
-  escaped = (
-    token.lower()
-    .replace("\\", "\\\\")
-    .replace("%", "\\%")
-    .replace("_", "\\_")
-  )
-  return f"%{escaped}%"
-
-
-def _portable_transcript_patterns(token: str) -> tuple[str, ...]:
-  """Candidate forms for JSON serializers that preserve or escape Unicode."""
-  raw = _portable_like_pattern(token)
-  serialized = json.dumps(token, ensure_ascii=True)[1:-1]
-  escaped = _portable_like_pattern(serialized)
-  return (raw,) if escaped == raw else (raw, escaped)
-
-
-def _portable_search(
-  db: Session,
-  raw_query: str,
-  limit: int,
-) -> list[dict]:
-  """Preserve the search contract when SQLite FTS5 is unavailable."""
-  tokens = _query_tokens(raw_query)
-  if not tokens:
-    return []
-  title_text = func.lower(func.coalesce(models.Chat.title, ""))
-  transcript_text = func.lower(cast(models.Chat.messages, Text))
-  candidate_filters = [
-    or_(
-      title_text.like(_portable_like_pattern(token), escape="\\"),
-      *(
-        transcript_text.like(pattern, escape="\\")
-        for pattern in _portable_transcript_patterns(token)
-      ),
-    )
-    for token in tokens
-  ]
-  candidates = (
-    db.query(
-      models.Chat.id,
-      models.Chat.title,
-      models.Chat.messages,
-      models.Chat.agent_settings_json,
-      models.Chat.created_by_app_id,
-      models.Chat.activity_at,
-      models.Chat.updated_at,
-    )
-    .filter(models.Chat.deleted_at.is_(None), *candidate_filters)
-    .order_by(
-      func.coalesce(models.Chat.activity_at, models.Chat.updated_at).desc(),
-      models.Chat.id,
-    )
-    .limit(_PORTABLE_CANDIDATE_LIMIT)
-    .yield_per(64)
-  )
-  patterns = _portable_token_patterns(tokens)
-  results: list[dict] = []
-  for chat in candidates:
-    if not _visible_in_owner_drawer(chat):
-      continue
-    matches = []
-    for doc in _prose_docs(chat.title or "", chat.messages or []):
-      spans = _portable_match_spans(doc[3], patterns)
-      if spans:
-        matches.append((doc, spans))
-    if not matches:
-      continue
-    prose_matches = [match for match in matches if match[0][0] >= 0]
-    chosen_doc, chosen_spans = max(
-      prose_matches or matches,
-      key=lambda match: (len(match[1]), -match[0][0]),
-    )
-    msg_idx, ts, role, doc_text = chosen_doc
-    active = chat.activity_at or chat.updated_at
-    active_text = active.isoformat() if hasattr(active, "isoformat") else str(active or "")
-    entry = {
-      "id": chat.id,
-      "title": chat.title,
-      "snippet": (
-        _portable_snippet(doc_text, chosen_spans) if msg_idx >= 0 else None
-      ),
-      "ts": ts if msg_idx >= 0 else None,
-      "role": role if msg_idx >= 0 else None,
-      "anchor_key": None,
-      "last_active": active_text,
-      "match_count": len(matches),
-      "_occurrences": sum(len(spans) for _, spans in matches),
-    }
-    if msg_idx >= 0:
-      entry["anchor_key"] = (
-        f"{role}-{ts}" if ts is not None else f"{role}-{msg_idx}"
-      )
-    results.append(entry)
-  results.sort(
-    key=lambda entry: (
-      entry["_occurrences"], entry["match_count"], entry["last_active"],
-    ),
-    reverse=True,
-  )
-  for entry in results:
-    entry.pop("_occurrences", None)
-  return results[:limit]
-
-
 def _database_dialect(db: Session) -> str:
   return db.get_bind().dialect.name
 
 
+def _candidate_rows(db: Session, tokens: list[str]):
+  """Return candidate normalized documents through the dialect's light seam."""
+  columns = (
+    "d.chat_id, d.msg_idx, d.ts, d.role, d.text, chat.title, "
+    "CAST(COALESCE(chat.activity_at, chat.updated_at) AS TEXT)"
+  )
+  if _database_dialect(db) == "sqlite":
+    return db.execute(
+      sql(
+        f"SELECT {columns} FROM chat_search_fts "
+        "JOIN chat_search_docs d ON d.id = chat_search_fts.rowid "
+        "JOIN chats chat ON chat.id = d.chat_id "
+        "WHERE chat.deleted_at IS NULL AND chat_search_fts MATCH :query "
+        "ORDER BY d.chat_id, d.msg_idx"
+      ).execution_options(stream_results=True, max_row_buffer=256),
+      {"query": _fts_query(tokens)},
+    )
+
+  # Query tokens cannot contain ``%``. An underscore can broaden LIKE by one
+  # character, but the shared matcher below removes that false positive; the
+  # database predicate therefore cannot discard a true document hit.
+  clauses = []
+  parameters = {}
+  for index, token in enumerate(tokens):
+    key = f"token_{index}"
+    clauses.append(f"LOWER(d.text) LIKE :{key}")
+    parameters[key] = f"%{token.lower()}%"
+  return db.execute(
+    sql(
+      f"SELECT {columns} FROM chat_search_docs d "
+      "JOIN chats chat ON chat.id = d.chat_id "
+      "WHERE chat.deleted_at IS NULL AND " + " AND ".join(clauses)
+      + " ORDER BY d.chat_id, d.msg_idx"
+    ).execution_options(stream_results=True, max_row_buffer=256),
+    parameters,
+  )
+
+
+def _rank_results(rows, tokens: list[str], limit: int) -> list[dict]:
+  """Rank a complete chat-grouped row stream with memory bounded by ``limit``."""
+  patterns = _token_patterns(tokens)
+  top_results = []
+  current = None
+
+  def finish(result) -> None:
+    if result is None or result["match_count"] == 0:
+      return
+    rank = (
+      result["occurrences"],
+      result["match_count"],
+      result["last_active"],
+      result["id"],
+    )
+    heapq.heappush(top_results, (rank, result))
+    if len(top_results) > limit:
+      heapq.heappop(top_results)
+
+  for chat_id, msg_idx, timestamp, role, doc_text, title, active_text in rows:
+    if current is None or current["id"] != chat_id:
+      finish(current)
+      current = {
+        "id": chat_id,
+        "title": title,
+        "last_active": active_text or "",
+        "match_count": 0,
+        "occurrences": 0,
+        "best_prose": None,
+      }
+    spans = _match_spans(doc_text, patterns)
+    if not spans:
+      continue
+    current["match_count"] += 1
+    current["occurrences"] += len(spans)
+    if msg_idx < 0:
+      continue
+    candidate = (len(spans), -msg_idx, timestamp, role, doc_text, spans)
+    if (
+      current["best_prose"] is None
+      or candidate[:2] > current["best_prose"][:2]
+    ):
+      current["best_prose"] = candidate
+  finish(current)
+
+  output = []
+  for _rank, result in sorted(top_results, reverse=True):
+    best = result["best_prose"]
+    if best is None:
+      snippet = None
+      anchor_key = None
+    else:
+      _count, negative_index, timestamp, role, doc_text, spans = best
+      msg_idx = -negative_index
+      snippet = _snippet(doc_text, spans)
+      anchor_key = (
+        f"{role}-{timestamp}" if timestamp is not None else f"{role}-{msg_idx}"
+      )
+    output.append({
+      "id": result["id"],
+      "title": result["title"],
+      "snippet": snippet,
+      "anchor_key": anchor_key,
+    })
+  return output
+
+
 def purge_chat_docs(db: Session, chat_ids: list[str]) -> None:
-  """Delete SQLite-derived search data inside the hard-purge transaction."""
-  if not chat_ids or _database_dialect(db) != "sqlite":
+  """Remove derived rows inside the source chat's hard-purge transaction."""
+  parameters = [{"chat_id": chat_id} for chat_id in chat_ids]
+  if not parameters:
     return
-  tables = {
-    row[0]
-    for row in db.execute(sql(
-      "SELECT name FROM sqlite_master WHERE type = 'table'"
-      " AND name IN ('chat_search_docs', 'chat_search_state')"
-    )).fetchall()
-  }
-  for chat_id in chat_ids:
-    if "chat_search_docs" in tables:
-      db.execute(
-        sql("DELETE FROM chat_search_docs WHERE chat_id = :cid"),
-        {"cid": chat_id},
-      )
-    if "chat_search_state" in tables:
-      db.execute(
-        sql("DELETE FROM chat_search_state WHERE chat_id = :cid"),
-        {"cid": chat_id},
-      )
+  db.execute(
+    sql("DELETE FROM chat_search_docs WHERE chat_id = :chat_id"), parameters,
+  )
+  db.execute(
+    sql("DELETE FROM chat_search_state WHERE chat_id = :chat_id"), parameters,
+  )
 
 
 def search(db: Session, raw_query: str, limit: int = 20) -> list[dict]:
-  """Ranked chats matching the query, best doc per chat, with a snippet."""
-  if _database_dialect(db) != "sqlite":
-    return _portable_search(db, raw_query, limit)
-  match = _fts_query(raw_query)
-  if not match:
+  """Return ranked chat hits with only the fields consumed by the shell."""
+  tokens = _query_tokens(raw_query)
+  if not tokens or limit <= 0:
     return []
   reconcile(db)
-
-  # Choose chats before choosing snippets. Limiting the raw FTS row stream lets
-  # one long conversation with hundreds of matching messages crowd every other
-  # chat out of the result set. The FTS5 `rank` pseudo-column is bm25-compatible
-  # and, unlike the bm25() auxiliary function, can be aggregated by SQLite.
-  chats = db.execute(
-    sql(
-      "SELECT d.chat_id, MIN(chat_search_fts.rank) AS best_rank,"
-      "  COUNT(*) AS match_count, c.title,"
-      "  CAST(COALESCE(c.activity_at, c.updated_at) AS TEXT) AS active_text"
-      " FROM chat_search_fts"
-      " JOIN chat_search_docs d ON d.id = chat_search_fts.rowid"
-      " JOIN chats c ON c.id = d.chat_id AND c.deleted_at IS NULL"
-      " WHERE chat_search_fts MATCH :q"
-      " GROUP BY d.chat_id"
-      " ORDER BY best_rank, active_text DESC, d.chat_id"
-      " LIMIT :limit"
-    ),
-    {"q": match, "limit": limit},
-  ).fetchall()
-
-  results: list[dict] = []
-  for chat_id, _rank, match_count, title, active_text in chats:
-    # Prefer the best prose hit so a chat whose title also matches can still
-    # jump to useful transcript context. A title-only chat returns no snippet
-    # or anchor and opens at its ordinary saved position.
-    hit = db.execute(
-      sql(
-        "SELECT d.msg_idx, d.ts, d.role,"
-        "  snippet(chat_search_fts, 0, :mo, :mc, '…', 12) AS snip"
-        " FROM chat_search_fts"
-        " JOIN chat_search_docs d ON d.id = chat_search_fts.rowid"
-        " WHERE chat_search_fts MATCH :q AND d.chat_id = :cid"
-        " ORDER BY (d.msg_idx < 0), chat_search_fts.rank, d.id"
-        " LIMIT 1"
-      ),
-      {"q": match, "cid": chat_id, "mo": _MARK_OPEN, "mc": _MARK_CLOSE},
-    ).fetchone()
-    msg_idx, ts, role, snip = hit if hit is not None else (-1, None, None, None)
-    entry = {
-      "id": chat_id,
-      "title": title,
-      "snippet": snip if msg_idx >= 0 else None,
-      "ts": ts if msg_idx >= 0 else None,
-      "role": role if msg_idx >= 0 else None,
-      "anchor_key": None,
-      "last_active": active_text,
-      "match_count": match_count,
-    }
-    if msg_idx >= 0:
-      # Match the durable keys accepted by GET /chats/{id}?anchor=… and the
-      # transcript DOM. Timestamps are the normal stable identity; older or
-      # repaired rows without one still have the role/index address.
-      entry["anchor_key"] = (
-        f"{role}-{ts}" if ts is not None else f"{role}-{msg_idx}"
-      )
-    results.append(entry)
-  return results
+  return _rank_results(_candidate_rows(db, tokens), tokens, limit)

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1329,6 +1329,73 @@ def _add_chat_has_messages(eng) -> None:
       ))
 
 
+def _create_chat_search_tables(eng) -> None:
+  """Install the disposable normalized search schema for each database."""
+  from sqlalchemy import text
+
+  dialect = eng.dialect.name
+  if dialect not in {"sqlite", "postgresql"}:
+    raise RuntimeError(f"unsupported chat-search database: {dialect}")
+
+  # Search rows are derived from chats. Replace the runtime-created generation
+  # once rather than preserving a permanent schema detector in the
+  # request path; the first search repopulates these empty canonical tables.
+  with eng.begin() as conn:
+    if dialect == "sqlite":
+      conn.execute(text("DROP TABLE IF EXISTS chat_search_fts"))
+    for table_name in (
+      "chat_search_docs",
+      "chat_search_state",
+      "chat_search_meta",
+    ):
+      conn.execute(text(f"DROP TABLE IF EXISTS {table_name}"))
+
+    id_type = "INTEGER" if dialect == "sqlite" else "BIGSERIAL"
+    conn.execute(text(
+      "CREATE TABLE chat_search_docs ("
+      f"id {id_type} PRIMARY KEY, "
+      "chat_id VARCHAR(64) NOT NULL, "
+      "msg_idx INTEGER NOT NULL, "
+      "ts BIGINT, "
+      "role VARCHAR(16), "
+      "text TEXT NOT NULL"
+      ")"
+    ))
+    # One composite index owns both row identity and chat-local scans; a
+    # separate chat_id index would duplicate its leftmost prefix.
+    conn.execute(text(
+      "CREATE UNIQUE INDEX ix_chat_search_docs_chat_message "
+      "ON chat_search_docs (chat_id, msg_idx)"
+    ))
+    conn.execute(text(
+      "CREATE TABLE chat_search_state ("
+      "chat_id VARCHAR(64) PRIMARY KEY, "
+      "indexed_updated_at TEXT NOT NULL"
+      ")"
+    ))
+
+    if dialect == "sqlite":
+      conn.execute(text(
+        "CREATE VIRTUAL TABLE chat_search_fts USING fts5("
+        "text, content='chat_search_docs', content_rowid='id', "
+        "tokenize='unicode61 remove_diacritics 2'"
+        ")"
+      ))
+      conn.execute(text(
+        "CREATE TRIGGER chat_search_docs_ai "
+        "AFTER INSERT ON chat_search_docs BEGIN "
+        "INSERT INTO chat_search_fts(rowid, text) VALUES (new.id, new.text); "
+        "END"
+      ))
+      conn.execute(text(
+        "CREATE TRIGGER chat_search_docs_ad "
+        "AFTER DELETE ON chat_search_docs BEGIN "
+        "INSERT INTO chat_search_fts(chat_search_fts, rowid, text) "
+        "VALUES ('delete', old.id, old.text); "
+        "END"
+      ))
+
+
 def _add_connectors_table(eng) -> None:
   """Create the provider-neutral MCP registry without replacing preview rows."""
   from app.models import Connector
@@ -1393,6 +1460,7 @@ _SCHEMA_MIGRATIONS = (
   ("0005_connectors", _add_connectors_table),
   ("0006_connector_capability_identity", _add_connector_capability_identity),
   ("0007_chat_has_messages", _add_chat_has_messages),
+  ("0008_chat_search_documents", _create_chat_search_tables),
 )
 
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -71,7 +71,7 @@ if not (_static / "index.html").is_file():
     encoding="utf-8",
   )
 
-from app.database import Base, engine
+from app.database import Base, _create_chat_search_tables, engine
 from app.main import app
 from app.routes import auth as auth_module
 from app.routes.auth import _limiter as auth_limiter
@@ -116,10 +116,18 @@ def _isolate_git_env(monkeypatch, tmp_path):
 
 @pytest.fixture(scope="session", autouse=True)
 def _test_schema():
-  """Create the immutable schema once; per-test cleanup removes its rows."""
+  """Create model and migration-owned schemas once for the test process."""
   Base.metadata.drop_all(bind=engine)
   Base.metadata.create_all(bind=engine)
+  # Tests do not enter FastAPI's production lifespan, which normally runs
+  # numbered migrations after create_all. Search tables deliberately have no
+  # ORM model, so install their migration-owned schema explicitly here.
+  _create_chat_search_tables(engine)
   yield
+  with engine.begin() as connection:
+    connection.exec_driver_sql("DROP TABLE IF EXISTS chat_search_fts")
+    connection.exec_driver_sql("DROP TABLE IF EXISTS chat_search_docs")
+    connection.exec_driver_sql("DROP TABLE IF EXISTS chat_search_state")
   Base.metadata.drop_all(bind=engine)
 
 
@@ -228,6 +236,11 @@ def fresh_db():
   # The writer is already stopped, so no background transaction can race this
   # cleanup; the next test still gets a fresh actor and SQLAlchemy session.
   with engine.begin() as connection:
+    # These disposable tables are migration-owned rather than ORM-owned, so
+    # Base.metadata cannot include them in the generic deletion pass. Deleting
+    # docs first also drives the SQLite external-content FTS trigger.
+    connection.exec_driver_sql("DELETE FROM chat_search_docs")
+    connection.exec_driver_sql("DELETE FROM chat_search_state")
     for table in reversed(Base.metadata.sorted_tables):
       connection.execute(table.delete())
 

--- a/backend/tests/test_chat_search.py
+++ b/backend/tests/test_chat_search.py
@@ -7,6 +7,7 @@ import uuid
 
 from app import chat_search, models
 from app.chat_search import sql
+from app.chat_visibility import visible_in_owner_drawer
 from app.timeutil import now_naive_utc
 
 
@@ -46,9 +47,8 @@ def test_result_carries_reveal_anchor_of_matching_message(db):
     db, "Notes", ["intro line", "the wombat migration route", "outro line"]
   )
   hit = next(r for r in chat_search.search(db, "wombat") if r["id"] == c.id)
-  assert hit["role"] == "user"
-  assert hit["ts"] == 1001
   assert hit["anchor_key"] == "user-1001"
+  assert set(hit) == {"id", "title", "snippet", "anchor_key"}
 
 
 def test_result_falls_back_to_role_index_anchor_without_timestamp(db):
@@ -69,7 +69,6 @@ def test_result_falls_back_to_role_index_anchor_without_timestamp(db):
 def test_title_only_hit_has_no_reveal_anchor(db):
   c = _make_chat(db, "Marimba tuning", ["unrelated body"])
   hit = next(r for r in chat_search.search(db, "marimba") if r["id"] == c.id)
-  assert hit["ts"] is None and hit["role"] is None
   assert hit["anchor_key"] is None
 
 
@@ -78,7 +77,7 @@ def test_prefix_match_on_last_token(db):
   assert any(r["id"] == c.id for r in chat_search.search(db, "budg"))
 
 
-def test_portable_fallback_preserves_visibility_prefix_and_reveal_contract(
+def test_normalized_documents_preserve_visibility_prefix_and_reveal_contract(
   db, monkeypatch,
 ):
   suffix = uuid.uuid4().hex
@@ -121,11 +120,6 @@ def test_portable_fallback_preserves_visibility_prefix_and_reveal_contract(
   db.commit()
 
   monkeypatch.setattr(chat_search, "_database_dialect", lambda _db: "postgresql")
-
-  def unexpected_reconcile(_db):
-    raise AssertionError("portable search must not touch the SQLite FTS schema")
-
-  monkeypatch.setattr(chat_search, "reconcile", unexpected_reconcile)
   results = chat_search.search(db, f"{exact} capy")
   ids = {result["id"] for result in results}
   assert visible.id in ids
@@ -135,7 +129,7 @@ def test_portable_fallback_preserves_visibility_prefix_and_reveal_contract(
   assert "capybara" in hit["snippet"]
 
 
-def test_portable_fallback_finds_json_escaped_unicode_transcript(db, monkeypatch):
+def test_normalized_postgres_path_finds_unicode_document_text(db, monkeypatch):
   c = _make_chat(db, "Unicode", ["réunion café itinerary"])
   monkeypatch.setattr(chat_search, "_database_dialect", lambda _db: "postgresql")
 
@@ -148,21 +142,38 @@ def test_portable_fallback_finds_json_escaped_unicode_transcript(db, monkeypatch
   assert "café" in hit["snippet"]
 
 
-def test_portable_fallback_bounds_candidates_by_recent_activity(db, monkeypatch):
-  needle = f"boundedportable{uuid.uuid4().hex}"
+def test_postgres_path_ranks_all_matches_beyond_the_old_512_chat_cap(
+  db, monkeypatch,
+):
+  needle = f"completeportable{uuid.uuid4().hex}"
   now = now_naive_utc()
-  older = _make_chat(db, "Older dense match", [f"{needle} {needle} {needle}"])
-  newer = _make_chat(db, "Newer match", [needle])
-  older.activity_at = now - timedelta(days=1)
-  newer.activity_at = now
+  best = models.Chat(
+    id=str(uuid.uuid4()),
+    title="Older best match",
+    messages=[{
+      "role": "user",
+      "content": f"{needle} {needle} {needle}",
+      "ts": 1000,
+    }],
+    activity_at=now - timedelta(days=1),
+  )
+  recent = [
+    models.Chat(
+      id=str(uuid.uuid4()),
+      title=f"Recent match {index}",
+      messages=[{"role": "user", "content": needle, "ts": 1000}],
+      activity_at=now,
+    )
+    for index in range(512)
+  ]
+  db.add_all([best, *recent])
   db.commit()
 
   monkeypatch.setattr(chat_search, "_database_dialect", lambda _db: "postgresql")
-  monkeypatch.setattr(chat_search, "_PORTABLE_CANDIDATE_LIMIT", 1)
 
-  results = chat_search.search(db, needle, limit=20)
-
-  assert [result["id"] for result in results] == [newer.id]
+  assert [result["id"] for result in chat_search.search(db, needle, limit=1)] == [
+    best.id,
+  ]
 
 
 def test_title_match_has_no_snippet(db):
@@ -208,8 +219,6 @@ def test_rename_reindexes_title(db):
 
 
 def test_deleted_chat_leaves_index_and_restore_returns(db):
-  from app.timeutil import now_naive_utc
-
   c = _make_chat(db, "Doomed", ["ephemeral pangolin facts"])
   chat_search.search(db, "pangolin")
   c.deleted_at = now_naive_utc()
@@ -226,7 +235,7 @@ def test_shrunk_history_triggers_full_rebuild(db):
   chat_search.search(db, "wombat")
   c.messages = [{"role": "user", "content": "gamma capybara", "ts": 3}]
   db.commit()
-  assert chat_search.search(db, "wombat") == [] or not any(
+  assert not any(
     r["id"] == c.id for r in chat_search.search(db, "wombat")
   )
   assert any(r["id"] == c.id for r in chat_search.search(db, "capybara"))
@@ -348,45 +357,7 @@ def test_search_and_drawer_visibility_helpers_share_one_behavior_contract():
       created_by_app_id=created_by_app_id,
       agent_settings_json=settings,
     )
-    assert chat_search._visible_in_owner_drawer(chat) is drawer_visible(chat)
-
-
-def test_index_version_rebuild_purges_rows_from_older_indexing_semantics(db):
-  c = models.Chat(
-    id=str(uuid.uuid4()),
-    title="Versioned search",
-    messages=[{
-      "role": "user",
-      "content": "legacyhiddenibis",
-      "ts": 1000,
-      "hidden": True,
-    }],
-  )
-  db.add(c)
-  db.commit()
-  chat_search.search(db, "unrelated")
-
-  # Model an older generation that indexed this now-hidden row. Changing the
-  # semantic version must replace the complete disposable index before query.
-  db.execute(sql(
-    "INSERT INTO chat_search_docs (chat_id, msg_idx, ts, role, text)"
-    " VALUES (:cid, 0, 1000, 'user', 'legacyhiddenibis')"
-  ), {"cid": c.id})
-  db.execute(sql(
-    "UPDATE chat_search_meta SET value = 'legacy' WHERE key = 'index_version'"
-  ))
-  db.commit()
-  chat_search._schema_ready = False
-
-  assert not any(
-    result["id"] == c.id
-    for result in chat_search.search(db, "legacyhiddenibis")
-  )
-  version = db.execute(sql(
-    "SELECT value FROM chat_search_meta WHERE key = 'index_version'"
-  )).scalar_one()
-  assert version == chat_search._INDEX_VERSION
-  assert _doc_count(db, c.id) == 1  # title only; hidden message stayed absent
+    assert visible_in_owner_drawer(chat) is drawer_visible(chat)
 
 
 def test_long_matching_chat_cannot_crowd_other_chats_out_before_grouping(db):
@@ -398,6 +369,17 @@ def test_long_matching_chat_cannot_crowd_other_chats_out_before_grouping(db):
 
   ids = {result["id"] for result in chat_search.search(db, needle, limit=3)}
   assert ids == {long_chat.id, short_a.id, short_b.id}
+
+
+def test_streaming_ranker_keeps_complete_top_k_when_best_chat_arrives_last():
+  rows = iter((
+    ("chat-a", 0, 1, "user", "one lynx", "A", "2026-08-01"),
+    ("chat-b", 0, 2, "user", "lynx lynx lynx", "B", "2026-08-02"),
+  ))
+
+  results = chat_search._rank_results(rows, ["lynx"], limit=1)
+
+  assert [result["id"] for result in results] == ["chat-b"]
 
 
 def test_overlapping_first_searches_leave_one_idempotent_document_generation(db):

--- a/backend/tests/test_db_migrations.py
+++ b/backend/tests/test_db_migrations.py
@@ -1010,6 +1010,7 @@ def test_run_migrations_records_an_inspectable_append_only_history(tmp_path):
     "0005_connectors",
     "0006_connector_capability_identity",
     "0007_chat_has_messages",
+    "0008_chat_search_documents",
   ]
   assert second == first
 
@@ -1100,6 +1101,127 @@ def test_chat_message_summary_migration_backfills_legacy_transcripts(tmp_path):
   assert "0007_chat_has_messages" in {
     row["version"] for row in schema_migration_history(eng)
   }
+
+
+def test_chat_search_migration_replaces_runtime_schema_and_uses_one_docs_index(
+  tmp_path,
+):
+  eng = create_engine(f"sqlite:///{tmp_path / 'chat-search-schema.db'}")
+  with eng.begin() as conn:
+    conn.execute(text(
+      "CREATE TABLE apps (id INTEGER PRIMARY KEY, name VARCHAR(255))"
+    ))
+    conn.execute(text(
+      "CREATE TABLE chat_search_docs ("
+      "id INTEGER PRIMARY KEY, chat_id TEXT, msg_idx INTEGER, text TEXT)"
+    ))
+    conn.execute(text(
+      "CREATE INDEX chat_search_docs_chat ON chat_search_docs (chat_id)"
+    ))
+    conn.execute(text(
+      "CREATE VIRTUAL TABLE chat_search_fts USING fts5("
+      "text, content='chat_search_docs', content_rowid='id')"
+    ))
+    conn.execute(text(
+      "CREATE TRIGGER chat_search_docs_ai "
+      "AFTER INSERT ON chat_search_docs BEGIN "
+      "INSERT INTO chat_search_fts(rowid, text) VALUES (new.id, new.text); "
+      "END"
+    ))
+    conn.execute(text(
+      "CREATE TRIGGER chat_search_docs_ad "
+      "AFTER DELETE ON chat_search_docs BEGIN "
+      "INSERT INTO chat_search_fts(chat_search_fts, rowid, text) "
+      "VALUES ('delete', old.id, old.text); END"
+    ))
+    conn.execute(text(
+      "CREATE TABLE chat_search_state ("
+      "chat_id TEXT PRIMARY KEY, indexed_updated_at TEXT)"
+    ))
+    conn.execute(text(
+      "CREATE TABLE chat_search_meta (key TEXT PRIMARY KEY, value TEXT)"
+    ))
+    conn.execute(text(
+      "INSERT INTO chat_search_docs (chat_id, msg_idx, text) "
+      "VALUES ('runtime-chat', 0, 'discarded derived prose')"
+    ))
+
+  run_migrations(eng)
+  run_migrations(eng)
+
+  inspector = inspect(eng)
+  tables = set(inspector.get_table_names())
+  columns = {
+    column["name"] for column in inspector.get_columns("chat_search_docs")
+  }
+  indexes = inspector.get_indexes("chat_search_docs")
+  with eng.connect() as conn:
+    doc_count = conn.execute(text(
+      "SELECT COUNT(*) FROM chat_search_docs"
+    )).scalar_one()
+    triggers = {
+      row[0] for row in conn.execute(text(
+        "SELECT name FROM sqlite_master WHERE type = 'trigger' "
+        "AND name LIKE 'chat_search_docs_%'"
+      ))
+    }
+    plan = " ".join(
+      row[-1] for row in conn.execute(text(
+        "EXPLAIN QUERY PLAN SELECT id, msg_idx, ts, role, text "
+        "FROM chat_search_docs WHERE chat_id = 'runtime-chat' "
+        "ORDER BY msg_idx"
+      ))
+    )
+
+  assert {"chat_search_docs", "chat_search_state", "chat_search_fts"} <= tables
+  assert "chat_search_meta" not in tables
+  assert columns == {"id", "chat_id", "msg_idx", "ts", "role", "text"}
+  assert doc_count == 0
+  assert triggers == {"chat_search_docs_ai", "chat_search_docs_ad"}
+  assert [
+    (index["name"], index["column_names"], index["unique"])
+    for index in indexes
+  ] == [(
+    "ix_chat_search_docs_chat_message",
+    ["chat_id", "msg_idx"],
+    1,
+  )]
+  assert "USING INDEX ix_chat_search_docs_chat_message" in plan
+  assert "0008_chat_search_documents" in {
+    row["version"] for row in schema_migration_history(eng)
+  }
+
+
+def test_chat_search_migration_emits_plain_postgres_documents_without_fts():
+  statements = []
+
+  class RecordingConnection:
+    dialect = SimpleNamespace(name="postgresql")
+
+    def begin(self):
+      return self
+
+    def __enter__(self):
+      return self
+
+    def __exit__(self, *_args):
+      return False
+
+    def execute(self, statement):
+      statements.append(str(statement))
+
+  database._create_chat_search_tables(RecordingConnection())
+
+  emitted = "\n".join(statements)
+  assert "DROP TABLE IF EXISTS chat_search_docs" in emitted
+  assert "DROP TABLE IF EXISTS chat_search_meta" in emitted
+  assert "id BIGSERIAL PRIMARY KEY" in emitted
+  assert "CREATE TABLE chat_search_state" in emitted
+  assert "ts BIGINT" in emitted
+  assert emitted.count("CREATE UNIQUE INDEX") == 1
+  assert "ON chat_search_docs (chat_id, msg_idx)" in emitted
+  assert "VIRTUAL TABLE" not in emitted
+  assert "CREATE TRIGGER" not in emitted
 
 
 def test_chat_run_root_migration_backfills_existing_physical_runs(tmp_path):


### PR DESCRIPTION
Follow-up to #614.

## What changed

- Move the disposable chat-search tables, indexes, and SQLite triggers into append-only schema migration `0008_chat_search_documents` instead of detecting and rebuilding schema inside requests.
- Use normalized title/message documents as the single search source on SQLite and PostgreSQL; the portable path no longer scans serialized transcript JSON.
- Keep the database-specific seam narrow: SQLite selects candidates through FTS5, PostgreSQL through ordinary document predicates, and both use one tokenizer, matcher, snippet builder, grouper, and ranker.
- Stream candidate rows and retain only the requested top results with a bounded heap, removing the previous 512-chat portable cap without retaining every match in memory.
- Reconcile only chats whose exact stored update marker changed, rebuilding their disposable documents while continuing to exclude hidden chats, hidden messages, tool output, and thinking traces.
- Preserve prefix matching, operator neutralization, snippets, and exact reveal anchors while narrowing the response to fields the shell consumes.
- Rank both database paths consistently by occurrences, matched documents, recency, and chat identity rather than maintaining separate backend-specific ranking implementations.

The migration replaces derived search data only. Source chat transcripts remain untouched and the first search repopulates the canonical document generation.

## Verification

- `scripts/wt-pytest.sh backend/tests/test_chat_search.py backend/tests/test_db_migrations.py -q --tb=short` — 63 passed
- Combined live-path coverage across search, migrations, retention, chat lifecycle, Connections, and turn-plan release — 162 passed
- Platform fast contract suite — 78 passed
- Python compilation and `git diff --check` — passed

Coverage includes message and title matches, Unicode and prefix behavior, exact reveal anchors, transcript replacement and shrinkage, rename/delete/restore reconciliation, drawer visibility, hidden and tool-message exclusion, operator neutralization, complete top-k ranking beyond the former 512-chat cap, concurrent first searches, and both SQLite and recorded PostgreSQL schema shapes.

## Known limits

- The first search after migration lazily rebuilds the disposable document index, so a large existing history can make that one request slower.
- PostgreSQL deliberately keeps a portable predicate over normalized documents rather than adding a second native full-text implementation. It now searches complete derived history correctly, but very large PostgreSQL datasets may warrant a future indexed candidate selector behind the existing database seam.
- PostgreSQL DDL and search behavior are covered by recorded/simulated tests; a real PostgreSQL server was not available for this local review.
- Result ordering is now intentionally consistent across database engines; it may differ from SQLite's former FTS-specific BM25 ordering even though matching and reveal behavior are preserved.