### PR TITLE
Keep drawer menu rename focused through menu handoff

### DIFF
--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -415,8 +415,8 @@ export default function Drawer({
       if (next) current.showItemMenu(kind, id, surface, placement)
       else current.closeItemMenu()
     },
-    startRename(kind, id, surface = 'drawer', origin = 'direct') {
-      rowActionInputsRef.current.setRenaming({ kind, id, surface, origin })
+    startRename(kind, id, surface = 'drawer') {
+      rowActionInputsRef.current.setRenaming({ kind, id, surface })
     },
     cancelRename() {
       rowActionInputsRef.current.setRenaming(null)
@@ -1102,12 +1102,10 @@ export default function Drawer({
                         && openMenu.id === item.id
                         ? openMenu.placement
                         : null}
-                      renaming={renaming
+                      renaming={!!(renaming
                         && renaming.surface === 'drawer'
                         && renaming.kind === kind
-                        && renaming.id === item.id
-                        ? renaming
-                        : null}
+                        && renaming.id === item.id)}
                       actions={rowActions}
                       dragActiveRef={dragActiveRef}
                       drawerRowGesturesRef={drawerRowGesturesRef}
@@ -1158,12 +1156,10 @@ export default function Drawer({
                       && openMenu.id === item.id
                       ? openMenu.placement
                       : null}
-                    renaming={renaming
+                    renaming={!!(renaming
                       && renaming.surface === 'drawer'
                       && renaming.kind === kind
-                      && renaming.id === item.id
-                      ? renaming
-                      : null}
+                      && renaming.id === item.id)}
                     actions={rowActions}
                     dragActiveRef={dragActiveRef}
                     drawerRowGesturesRef={drawerRowGesturesRef}
@@ -1260,12 +1256,10 @@ export default function Drawer({
                 && openMenu.id === app.id
                 ? openMenu.placement
                 : null}
-              renaming={renaming
+              renaming={!!(renaming
                 && renaming.surface === 'directory'
                 && renaming.kind === 'app'
-                && renaming.id === app.id
-                ? renaming
-                : null}
+                && renaming.id === app.id)}
               actions={rowActions}
             />
           ))}
@@ -1381,7 +1375,6 @@ const DrawerRow = memo(function DrawerRow({
   // native event cannot open actions before a release. It expires, and keyboard
   // or mouse input clears it, so accessibility and desktop context menus remain.
   const touchMenuPointerAtRef = useRef(0)
-  const recoveredMenuBlurRef = useRef(false)
   // Cancel-on-outside-tap during rename. Capture-phase listeners on
   // pointerdown AND click anywhere outside the rename input normally call
   // preventDefault + stopPropagation so another row, Settings, or New chat
@@ -1448,7 +1441,7 @@ const DrawerRow = memo(function DrawerRow({
   // from scratch or tap into the existing name to edit it.
   useEffect(() => {
     if (renaming && inputRef.current) {
-      recoveredMenuBlurRef.current = false
+      menuRestoreFocusRef.current = inputRef.current
       inputRef.current.focus()
       inputRef.current.select()
     }
@@ -1463,27 +1456,11 @@ const DrawerRow = memo(function DrawerRow({
     actions.submitRename(kind, id, label, value.trim())
   }
 
-  function onRenameBlur(event) {
-    const input = event.currentTarget
-    if (
-      renaming.origin === 'menu'
-      && !recoveredMenuBlurRef.current
-      && event.relatedTarget === null
-      && input.value === label
-    ) {
-      // Consuming the action menu's Back-stack sentinel can move focus to the
-      // document a few milliseconds after this editor mounts. Recover that one
-      // history-owned blur after the traversal, without mistaking later blurs
-      // (Tab, pointer outside, mobile keyboard) for the same handoff.
-      recoveredMenuBlurRef.current = true
-      requestAnimationFrame(() => {
-        if (inputRef.current !== input || !document.hasFocus()) return
-        input.focus()
-        input.select()
-      })
-      return
-    }
-    commitRename()
+  function onRenameBlur() {
+    const input = inputRef.current
+    requestAnimationFrame(() => {
+      if (document.activeElement !== input) commitRename()
+    })
   }
 
   function onInputKeyDown(e) {
@@ -1581,6 +1558,19 @@ const DrawerRow = memo(function DrawerRow({
     return true
   }
 
+  const itemMenu = (
+    <DrawerItemMenu
+      kind={kind}
+      item={item}
+      surface={surface}
+      pinned={pinned}
+      menuOpen={menuOpen}
+      actions={actions}
+      menuPlacement={menuPlacement}
+      restoreFocusRef={menuRestoreFocusRef}
+    />
+  )
+
   if (renaming) {
     if (variant === 'card') {
       return (
@@ -1593,6 +1583,7 @@ const DrawerRow = memo(function DrawerRow({
             onBlur={onRenameBlur}
             aria-label="Rename app"
           />
+          {itemMenu}
         </div>
       )
     }
@@ -1606,6 +1597,7 @@ const DrawerRow = memo(function DrawerRow({
           onBlur={onRenameBlur}
           aria-label={`Rename ${kind}`}
         />
+        {itemMenu}
       </div>
     )
   }
@@ -1671,16 +1663,7 @@ const DrawerRow = memo(function DrawerRow({
             <span className="apps-directory__card-name">{label}</span>
           </span>
         </button>
-        <DrawerItemMenu
-          kind={kind}
-          item={item}
-          surface={surface}
-          pinned={pinned}
-          menuOpen={menuOpen}
-          actions={actions}
-          menuPlacement={menuPlacement}
-          restoreFocusRef={menuRestoreFocusRef}
-        />
+        {itemMenu}
       </div>
     )
   }
@@ -1964,16 +1947,7 @@ const DrawerRow = memo(function DrawerRow({
         ) : null}
         <span className="drawer__item-text">{label}</span>
       </button>
-      <DrawerItemMenu
-        kind={kind}
-        item={item}
-        surface={surface}
-        pinned={pinned}
-        menuOpen={menuOpen}
-        actions={actions}
-        menuPlacement={menuPlacement}
-        restoreFocusRef={menuRestoreFocusRef}
-      />
+      {itemMenu}
     </div>
   )
 })
@@ -2040,7 +2014,7 @@ function DrawerItemMenu({
       restoreFocusRef={restoreFocusRef}
       onClose={() => actions.toggleMenu(kind, id, false, surface)}
       onPin={() => actions.pin(kind, id, !pinned)}
-      onRename={() => actions.startRename(kind, id, surface, 'menu')}
+      onRename={() => actions.startRename(kind, id, surface)}
       onInstall={() => actions.install(item)}
       onShare={() => actions.share(item)}
       onDelete={() => actions.remove(kind, id)}

--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -415,8 +415,8 @@ export default function Drawer({
       if (next) current.showItemMenu(kind, id, surface, placement)
       else current.closeItemMenu()
     },
-    startRename(kind, id, surface = 'drawer') {
-      rowActionInputsRef.current.setRenaming({ kind, id, surface })
+    startRename(kind, id, surface = 'drawer', origin = 'direct') {
+      rowActionInputsRef.current.setRenaming({ kind, id, surface, origin })
     },
     cancelRename() {
       rowActionInputsRef.current.setRenaming(null)
@@ -1102,10 +1102,12 @@ export default function Drawer({
                         && openMenu.id === item.id
                         ? openMenu.placement
                         : null}
-                      renaming={!!(renaming
+                      renaming={renaming
                         && renaming.surface === 'drawer'
                         && renaming.kind === kind
-                        && renaming.id === item.id)}
+                        && renaming.id === item.id
+                        ? renaming
+                        : null}
                       actions={rowActions}
                       dragActiveRef={dragActiveRef}
                       drawerRowGesturesRef={drawerRowGesturesRef}
@@ -1156,10 +1158,12 @@ export default function Drawer({
                       && openMenu.id === item.id
                       ? openMenu.placement
                       : null}
-                    renaming={!!(renaming
+                    renaming={renaming
                       && renaming.surface === 'drawer'
                       && renaming.kind === kind
-                      && renaming.id === item.id)}
+                      && renaming.id === item.id
+                      ? renaming
+                      : null}
                     actions={rowActions}
                     dragActiveRef={dragActiveRef}
                     drawerRowGesturesRef={drawerRowGesturesRef}
@@ -1256,10 +1260,12 @@ export default function Drawer({
                 && openMenu.id === app.id
                 ? openMenu.placement
                 : null}
-              renaming={!!(renaming
+              renaming={renaming
                 && renaming.surface === 'directory'
                 && renaming.kind === 'app'
-                && renaming.id === app.id)}
+                && renaming.id === app.id
+                ? renaming
+                : null}
               actions={rowActions}
             />
           ))}
@@ -1375,6 +1381,7 @@ const DrawerRow = memo(function DrawerRow({
   // native event cannot open actions before a release. It expires, and keyboard
   // or mouse input clears it, so accessibility and desktop context menus remain.
   const touchMenuPointerAtRef = useRef(0)
+  const recoveredMenuBlurRef = useRef(false)
   // Cancel-on-outside-tap during rename. Capture-phase listeners on
   // pointerdown AND click anywhere outside the rename input normally call
   // preventDefault + stopPropagation so another row, Settings, or New chat
@@ -1441,6 +1448,7 @@ const DrawerRow = memo(function DrawerRow({
   // from scratch or tap into the existing name to edit it.
   useEffect(() => {
     if (renaming && inputRef.current) {
+      recoveredMenuBlurRef.current = false
       inputRef.current.focus()
       inputRef.current.select()
     }
@@ -1453,6 +1461,29 @@ const DrawerRow = memo(function DrawerRow({
     }
     const value = inputRef.current?.value || ''
     actions.submitRename(kind, id, label, value.trim())
+  }
+
+  function onRenameBlur(event) {
+    const input = event.currentTarget
+    if (
+      renaming.origin === 'menu'
+      && !recoveredMenuBlurRef.current
+      && event.relatedTarget === null
+      && input.value === label
+    ) {
+      // Consuming the action menu's Back-stack sentinel can move focus to the
+      // document a few milliseconds after this editor mounts. Recover that one
+      // history-owned blur after the traversal, without mistaking later blurs
+      // (Tab, pointer outside, mobile keyboard) for the same handoff.
+      recoveredMenuBlurRef.current = true
+      requestAnimationFrame(() => {
+        if (inputRef.current !== input || !document.hasFocus()) return
+        input.focus()
+        input.select()
+      })
+      return
+    }
+    commitRename()
   }
 
   function onInputKeyDown(e) {
@@ -1559,7 +1590,7 @@ const DrawerRow = memo(function DrawerRow({
             className="drawer__rename-input"
             defaultValue={label}
             onKeyDown={onInputKeyDown}
-            onBlur={commitRename}
+            onBlur={onRenameBlur}
             aria-label="Rename app"
           />
         </div>
@@ -1572,7 +1603,7 @@ const DrawerRow = memo(function DrawerRow({
           className="drawer__rename-input"
           defaultValue={label}
           onKeyDown={onInputKeyDown}
-          onBlur={commitRename}
+          onBlur={onRenameBlur}
           aria-label={`Rename ${kind}`}
         />
       </div>
@@ -2009,7 +2040,7 @@ function DrawerItemMenu({
       restoreFocusRef={restoreFocusRef}
       onClose={() => actions.toggleMenu(kind, id, false, surface)}
       onPin={() => actions.pin(kind, id, !pinned)}
-      onRename={() => actions.startRename(kind, id, surface)}
+      onRename={() => actions.startRename(kind, id, surface, 'menu')}
       onInstall={() => actions.install(item)}
       onShare={() => actions.share(item)}
       onDelete={() => actions.remove(kind, id)}

--- a/frontend/src/components/Drawer/DrawerItemActionMenu.jsx
+++ b/frontend/src/components/Drawer/DrawerItemActionMenu.jsx
@@ -288,7 +288,7 @@ export default function DrawerItemActionMenu({
                 type="button"
                 role="menuitem"
                 className="drawer__item-action-item"
-                onClick={() => run(onRename, { restoreFocus: false })}
+                onClick={() => run(onRename)}
               >
                 Rename
               </button>

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -1021,6 +1021,21 @@ test('double-click edits a drawer row name instead of duplicating its context me
   assert.match(drawer, /onDoubleClick=\{event => \{[\s\S]*?actions\.startRename\(kind, id, surface\)/)
 })
 
+test('menu rename survives the history sentinel focus handoff', () => {
+  assert.match(
+    drawer,
+    /onRename=\{\(\) => actions\.startRename\(kind, id, surface, 'menu'\)\}/,
+  )
+  const blurHandoff = drawer.match(
+    /function onRenameBlur\(event\) \{[\s\S]*?\n  \}/,
+  )?.[0] || ''
+  assert.match(blurHandoff, /renaming\.origin === 'menu'/)
+  assert.match(blurHandoff, /event\.relatedTarget === null/)
+  assert.match(blurHandoff, /recoveredMenuBlurRef\.current = true/)
+  assert.match(blurHandoff, /requestAnimationFrame/)
+  assert.equal((drawer.match(/onBlur=\{onRenameBlur\}/g) || []).length, 2)
+})
+
 test('the Settings surface responds to PANE width via a query container', () => {
   const settingsCss = readFileSync(
     new URL('../../SettingsView/SettingsView.css', import.meta.url), 'utf8',

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -1021,21 +1021,6 @@ test('double-click edits a drawer row name instead of duplicating its context me
   assert.match(drawer, /onDoubleClick=\{event => \{[\s\S]*?actions\.startRename\(kind, id, surface\)/)
 })
 
-test('menu rename survives the history sentinel focus handoff', () => {
-  assert.match(
-    drawer,
-    /onRename=\{\(\) => actions\.startRename\(kind, id, surface, 'menu'\)\}/,
-  )
-  const blurHandoff = drawer.match(
-    /function onRenameBlur\(event\) \{[\s\S]*?\n  \}/,
-  )?.[0] || ''
-  assert.match(blurHandoff, /renaming\.origin === 'menu'/)
-  assert.match(blurHandoff, /event\.relatedTarget === null/)
-  assert.match(blurHandoff, /recoveredMenuBlurRef\.current = true/)
-  assert.match(blurHandoff, /requestAnimationFrame/)
-  assert.equal((drawer.match(/onBlur=\{onRenameBlur\}/g) || []).length, 2)
-})
-
 test('the Settings surface responds to PANE width via a query container', () => {
   const settingsCss = readFileSync(
     new URL('../../SettingsView/SettingsView.css', import.meta.url), 'utf8',

--- a/tests/navigation.spec.mjs
+++ b/tests/navigation.spec.mjs
@@ -497,6 +497,25 @@ test.describe('Desktop sidebar navigation', () => {
     }
   })
 
+  test('rename stays focused after the action menu leaves browser history', async ({ page }) => {
+    await setupDesktop(page)
+    const navigation = page.getByRole('navigation', { name: 'Primary navigation' })
+    const alpha = navigation.getByRole('button', { name: NAV_CHATS[0].title, exact: true })
+
+    await alpha.focus()
+    await page.keyboard.press('Shift+F10')
+    await expect.poll(() => page.evaluate(() => history.state?.kind)).toBe('dismissible')
+    await page.getByRole('menuitem', { name: 'Rename', exact: true }).click()
+
+    const editor = navigation.getByRole('textbox', { name: 'Rename chat' })
+    await expect.poll(() => page.evaluate(() => history.state?.kind)).not.toBe('dismissible')
+    await expect(editor).toBeFocused()
+    await expect(editor).toHaveValue(NAV_CHATS[0].title)
+
+    await page.keyboard.press('Escape')
+    await expect(alpha).toBeVisible()
+  })
+
   test('28. desktop sidebar reserves workspace width and persists its toggle', async ({ page }) => {
     await setupDesktop(page)
 


### PR DESCRIPTION
## Summary

- keep the action menu mounted until its existing focus restoration hands control to the rename editor
- wait for focus ownership to settle before treating blur as a committed rename
- cover the complete menu-to-editor interaction with a browser-level regression test

## Testing

- `npm test`
- `npm run build`
