### PR TITLE
Keep focused Builder chat switches fully painted

### DIFF
--- a/frontend/src/components/Shell/PaneChatView.jsx
+++ b/frontend/src/components/Shell/PaneChatView.jsx
@@ -27,6 +27,7 @@ function PaneChatView({
   apps,
   runtimeActive = true,
   keepTranscriptPainted = false,
+  focusedPresentation = false,
   paneContentHeight,
   // Shell selects this chat's stable signal before React.memo compares props.
   // An unrelated chat can replace the global signal Map without crossing this
@@ -107,9 +108,9 @@ function PaneChatView({
     // ChatView reports layout readiness before the transcript's first paint.
     // Prepare that frame beneath the outgoing cover before promotion.
     displayReadyCancelRef.current = scheduleAfterBrowserPaint(
-      () => onDisplayReady(paneId, readyChatId),
+      () => onDisplayReady(paneId, readyChatId, focusedPresentation),
     )
-  }, [onDisplayReady, paneId])
+  }, [focusedPresentation, onDisplayReady, paneId])
 
   useEffect(() => () => displayReadyCancelRef.current(), [])
 

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -103,6 +103,7 @@ import { undoKeyPressed, isEditableTarget } from './workspaceOnboarding.js'
 import PaneChatView from './PaneChatView.jsx'
 import {
   BUILDER_CHAT_WORLD,
+  FOCUSED_BUILDER_CHAT_SURFACE,
   STANDARD_CHAT_WORLD,
   deriveChatSurfaceLayers,
   deriveChatSurfaceOwners,
@@ -970,26 +971,32 @@ export default function Shell() {
   const visibleChatPanes = useMemo(() => {
     return deriveChatSurfaceOwners({ workspace, baseProjection, projection })
   }, [baseProjection, projection, workspace])
-  // Last chat that reached a stable painted frame in each visible pane. On a
-  // chat-tab change, keep that outgoing ChatView mounted as an inert cover while
-  // the incoming chat runs its existing hide/restore/reveal transaction below.
-  // The map advances only from the incoming ChatView's layout-ready callback,
-  // so rapid A -> B -> C navigation keeps A painted and replaces only staging B.
-  const [presentedChatByPane, setPresentedChatByPane] = useState(() => new Map())
+  // Last chat that reached a stable painted frame on each presentation surface.
+  // Physical pane ids own ordinary Builder handoffs; one synthetic surface owns
+  // focused Builder presentation across pane changes. The map advances only from
+  // the incoming ChatView's layout-ready callback, so rapid A -> B -> C
+  // navigation keeps A painted and replaces only staging B.
+  const [presentedChatBySurface, setPresentedChatBySurface] = useState(() => new Map())
   const visibleChatPaneSignature = visibleChatPanes
     .map(({ world, paneId, chatId }) => `${world}:${paneId}:${chatId}`)
     .join('|')
 
-  // Drop state for panes whose active visible surface is no longer a chat.
+  // Drop state for surfaces whose active owner is no longer a chat.
   // Same-pane A -> B deliberately keeps A until B reports display-ready.
   useEffect(() => {
-    const livePaneIds = new Set(visibleChatPanes.map(({ paneId }) => String(paneId)))
-    setPresentedChatByPane(prev => {
+    const liveSurfaceIds = new Set(visibleChatPanes.map(({ paneId }) => String(paneId)))
+    if (focusedPaneViewId != null && visibleChatPanes.some(owner => (
+      owner.world === BUILDER_CHAT_WORLD
+      && String(owner.paneId) === String(focusedPaneViewId)
+    ))) {
+      liveSurfaceIds.add(FOCUSED_BUILDER_CHAT_SURFACE)
+    }
+    setPresentedChatBySurface(prev => {
       let changed = false
       const next = new Map(prev)
-      for (const paneId of next.keys()) {
-        if (!livePaneIds.has(String(paneId))) {
-          next.delete(paneId)
+      for (const surfaceId of next.keys()) {
+        if (!liveSurfaceIds.has(String(surfaceId))) {
+          next.delete(surfaceId)
           changed = true
         }
       }
@@ -998,20 +1005,33 @@ export default function Shell() {
     // The primitive signature is the intentional dependency: visibleChatPanes
     // is rebuilt from workspace objects and should not churn this cleanup.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [visibleChatPaneSignature])
+  }, [focusedPaneViewId, visibleChatPaneSignature])
 
-  const handlePaneChatDisplayReady = useCallback((paneId, readyChatId) => {
+  const handlePaneChatDisplayReady = useCallback((
+    paneId,
+    readyChatId,
+    focusedPresentation = false,
+  ) => {
     const id = String(readyChatId)
     const paneKey = String(paneId)
     // Ignore a late ready signal from staging B after rapid navigation reached C.
     // Surface owners include both real builder panes and the single world's
     // synthetic slot, so resolve the selected key through their shared boundary.
     if (paneModel.activeKeyForOwner(workspaceStateRef.current.ws, paneKey) !== `chat:${id}`) return
-    setPresentedChatByPane(prev => {
-      if (String(prev.get(paneKey) ?? '') === id) return prev
+    setPresentedChatBySurface(prev => {
       const next = new Map(prev)
-      next.set(paneKey, id)
-      return next
+      let changed = false
+      if (String(next.get(paneKey) ?? '') !== id) {
+        next.set(paneKey, id)
+        changed = true
+      }
+      if (focusedPresentation
+          && String(focusedPaneViewIdRef.current) === paneKey
+          && String(next.get(FOCUSED_BUILDER_CHAT_SURFACE) ?? '') !== id) {
+        next.set(FOCUSED_BUILDER_CHAT_SURFACE, id)
+        changed = true
+      }
+      return changed ? next : prev
     })
     const presentation = newChatPresentationRef.current
     if (
@@ -1026,7 +1046,7 @@ export default function Shell() {
       releaseComposerFocusLease(composerFocusLeaseRef.current)
     }
     finishDrawerNavigationPresentation()
-  }, [finishDrawerNavigationPresentation, workspaceStateRef])
+  }, [finishDrawerNavigationPresentation, focusedPaneViewIdRef, workspaceStateRef])
 
   const finishNewChatPresentationRelease = useCallback((presentation) => {
     if (!presentation?.releasing || newChatPresentationRef.current !== presentation) return
@@ -1067,8 +1087,12 @@ export default function Shell() {
   // current active chat. Handoff dedupe is world-local: Standard's retained copy
   // must never suppress Builder's outgoing cover for the same underlying chat.
   const chatPaneLayers = useMemo(() => {
-    return deriveChatSurfaceLayers(visibleChatPanes, presentedChatByPane)
-  }, [presentedChatByPane, visibleChatPanes])
+    return deriveChatSurfaceLayers(
+      visibleChatPanes,
+      presentedChatBySurface,
+      { focusedBuilderPaneId: focusedPaneViewId },
+    )
+  }, [focusedPaneViewId, presentedChatBySurface, visibleChatPanes])
   // Shell is the only layer that knows which retained workspace world is
   // actually painted. Publish one stable readiness contract for visual tools;
   // they must not learn private handoff classes or compositor attributes.
@@ -2771,7 +2795,14 @@ export default function Shell() {
     const destinationAlreadyPainted = visibleChatPanes.some(owner => (
       owner.world === paintedWorld
       && String(owner.chatId) === chatId
-      && String(presentedChatByPane.get(String(owner.paneId)) ?? '') === chatId
+      && (paintedWorld !== BUILDER_CHAT_WORLD
+        || focusedPaneViewId == null
+        || String(owner.paneId) === String(focusedPaneViewId))
+      && String(presentedChatBySurface.get(
+        paintedWorld === BUILDER_CHAT_WORLD && focusedPaneViewId != null
+          ? FOCUSED_BUILDER_CHAT_SURFACE
+          : String(owner.paneId),
+      ) ?? '') === chatId
     ))
     const preserveDrawerPresentation = modalDrawerOpen
       && !(activeView === 'chat' && String(activeChatId) === chatId)
@@ -3341,10 +3372,13 @@ export default function Shell() {
             their projected pane geometry even while hidden. During a chat change
             the last painted chat remains as an inert opaque same-world cover until
             the incoming chat reports a stable frame. */}
-        {chatPaneLayers.map(({ world, paneId, chatId, role, surfaceKey }) => {
+        {chatPaneLayers.map(({
+          world, paneId, presentationPaneId, chatId, role, surfaceKey,
+        }) => {
           const tabKey = `chat:${chatId}`
           const standardOwner = world === STANDARD_CHAT_WORLD
-          const paneActiveKey = paneModel.activeKeyForOwner(workspace, paneId) || tabKey
+          const layoutPaneId = presentationPaneId ?? paneId
+          const paneActiveKey = paneModel.activeKeyForOwner(workspace, layoutPaneId) || tabKey
           const builderRect = standardOwner ? null : builderChatTabRects.get(paneActiveKey)
           const builderPainted = !standardOwner
             && effectiveViewMode === 'panes'
@@ -3378,7 +3412,7 @@ export default function Shell() {
           const chatViewStyle = builderRect
             ? {
               ...posStyle,
-              ...(paned ? modeViewTransitionStyle('pane', paneId, surfaceKey) : {}),
+              ...(paned ? modeViewTransitionStyle('pane', layoutPaneId, surfaceKey) : {}),
             }
             : undefined
           return (
@@ -3389,7 +3423,7 @@ export default function Shell() {
               aria-labelledby={tabPanel ? paneTabDomId(paneId, tabKey) : undefined}
               data-chat-world={world}
               data-chat-id={chatId}
-              data-mode-pane-vt={paned ? paneId : undefined}
+              data-mode-pane-vt={paned ? layoutPaneId : undefined}
               data-tab-key={!standardOwner && (multiPane || focusedPaneViewId != null)
                 && role !== 'held'
                 ? tabKey : undefined}
@@ -3410,8 +3444,8 @@ export default function Shell() {
                 ? 'true' : undefined}
               onPointerDownCapture={paned && role === 'active' && !modeBeatActive
                 ? (event) => {
-                  const wasFocused = workspaceStateRef.current.ws.focusedPaneId === paneId
-                  dispatchWorkspace({ type: 'FOCUS', paneId })
+                  const wasFocused = workspaceStateRef.current.ws.focusedPaneId === layoutPaneId
+                  dispatchWorkspace({ type: 'FOCUS', paneId: layoutPaneId })
                   if (supportsDesktopPaneComposerFocus()
                     && shouldFocusComposerAfterPanePointer({
                       wasFocused,
@@ -3432,6 +3466,9 @@ export default function Shell() {
                 // staging owns the work while held remains the visual cover.
                 runtimeActive={surfaceVisible && chatPanesVisible && role !== 'held'}
                 keepTranscriptPainted={surfaceVisible && role === 'held'}
+                focusedPresentation={!standardOwner
+                  && focusedPaneViewId != null
+                  && String(layoutPaneId) === String(focusedPaneViewId)}
                 paneContentHeight={builderRect ? builderRect.h : null}
                 // Select before the memo boundary. Passing the replacement Map
                 // would rerender every visible chat pane for another chat's run.

--- a/frontend/src/components/Shell/__tests__/chatHandoff.test.js
+++ b/frontend/src/components/Shell/__tests__/chatHandoff.test.js
@@ -45,7 +45,7 @@ test('chat display readiness admits only coordinate-complete cached transcripts'
     'ChatView must report layout readiness before its transcript can be promoted')
   assert.match(
     paneChatView,
-    /scheduleAfterBrowserPaint\(\s*\(\) => onDisplayReady\(paneId, readyChatId\),\s*\)/,
+    /scheduleAfterBrowserPaint\(\s*\(\) => onDisplayReady\(paneId, readyChatId, focusedPresentation\),\s*\)/,
     'the pane boundary must prepare one real destination paint before promotion',
   )
   assert.match(
@@ -195,7 +195,7 @@ test('each pane holds one outgoing chat over one staging chat', () => {
 test('only the painted workspace world can expose its handoff layers', () => {
   assert.match(
     shell,
-    /const paneActiveKey = paneModel\.activeKeyForOwner\(workspace, paneId\) \|\| tabKey/,
+    /const layoutPaneId = presentationPaneId \?\? paneId[\s\S]*const paneActiveKey = paneModel\.activeKeyForOwner\(workspace, layoutPaneId\) \|\| tabKey/,
     'handoff visibility must follow the owner current content, including the synthetic single-screen owner',
   )
   assert.match(

--- a/frontend/src/components/Shell/__tests__/chatSurfaceModel.test.js
+++ b/frontend/src/components/Shell/__tests__/chatSurfaceModel.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 
 import {
   BUILDER_CHAT_WORLD,
+  FOCUSED_BUILDER_CHAT_SURFACE,
   STANDARD_CHAT_WORLD,
   chatSurfaceKey,
   deriveChatSurfaceLayers,
@@ -27,6 +28,24 @@ function workspace({ slot = 'a', left = 'a', right = 'b' } = {}) {
 }
 
 const projection = { visibleLeaves: ['left', 'right'] }
+
+function focusedBuilderLayers(presentedFocusedId) {
+  const owners = deriveChatSurfaceOwners({
+    workspace: workspace({ slot: 'a', left: 'a', right: 'b' }),
+    baseProjection: projection,
+    projection: {
+      visibleLeaves: ['right'],
+      focusedPaneView: true,
+    },
+  })
+  return deriveChatSurfaceLayers(owners, new Map([
+    ['left', 'a'],
+    ['right', 'b'],
+    [FOCUSED_BUILDER_CHAT_SURFACE, presentedFocusedId],
+  ]), {
+    focusedBuilderPaneId: 'right',
+  })
+}
 
 test('a legacy absent slot retains the focused chat in the Standard world immediately', () => {
   const legacy = workspace()
@@ -117,4 +136,41 @@ test('a Standard duplicate does not suppress Builder chat handoff coverage', () 
       && layer.chatId === 'a'
       && layer.role === 'active'
   )))
+})
+
+test('focused Builder presentation holds the outgoing chat across pane focus changes', () => {
+  const layers = focusedBuilderLayers('a')
+
+  const outgoing = layers.filter(layer => (
+    layer.world === BUILDER_CHAT_WORLD && layer.chatId === 'a'
+  ))
+  assert.equal(outgoing.length, 1, 'the retained ChatView is moved, never duplicated')
+  assert.equal(outgoing[0].role, 'held')
+  assert.equal(outgoing[0].paneId, 'left', 'runtime ownership stays with its pane')
+  assert.equal(outgoing[0].presentationPaneId, 'right',
+    'the cover occupies the newly focused presentation rectangle')
+
+  const incoming = layers.find(layer => (
+    layer.world === BUILDER_CHAT_WORLD && layer.chatId === 'b'
+  ))
+  assert.equal(incoming.role, 'staging')
+  assert.ok(layers.some(layer => (
+    layer.world === STANDARD_CHAT_WORLD
+      && layer.chatId === 'a'
+      && layer.role === 'active'
+  )), 'the parked Standard duplicate remains independent')
+})
+
+test('focused Builder presentation releases the cover after destination readiness', () => {
+  const layers = focusedBuilderLayers('b')
+
+  assert.equal(layers.some(layer => layer.role !== 'active'), false)
+  assert.equal(layers.some(layer => layer.presentationPaneId), false)
+})
+
+test('focused Builder presentation never manufactures a stale outgoing cover', () => {
+  const layers = focusedBuilderLayers('departed')
+
+  assert.equal(layers.some(layer => layer.chatId === 'departed'), false)
+  assert.equal(layers.every(layer => layer.role === 'active'), true)
 })

--- a/frontend/src/components/Shell/chatSurfaceModel.js
+++ b/frontend/src/components/Shell/chatSurfaceModel.js
@@ -6,6 +6,7 @@ import { focusedSlotSeed, SINGLE_SLOT_PANE } from './paneModel.js'
 
 export const STANDARD_CHAT_WORLD = 'standard'
 export const BUILDER_CHAT_WORLD = 'builder'
+export const FOCUSED_BUILDER_CHAT_SURFACE = '__builder-focused-chat__'
 
 export function chatSurfaceKey(world, chatId) {
   return `${world}:chat:${chatId}`
@@ -69,18 +70,60 @@ export function deriveChatSurfaceOwners({ workspace, baseProjection, projection 
  * display-ready. A Standard owner never suppresses Builder's cover for the
  * same chat (and vice versa); their layout lifecycles are independent.
  */
-export function deriveChatSurfaceLayers(owners, presentedChatByPane) {
+export function deriveChatSurfaceLayers(
+  owners,
+  presentedChatBySurface,
+  { focusedBuilderPaneId = null } = {},
+) {
   const desiredByWorld = new Map()
   for (const owner of owners) {
     if (!desiredByWorld.has(owner.world)) desiredByWorld.set(owner.world, new Set())
     desiredByWorld.get(owner.world).add(String(owner.chatId))
   }
 
+  // A focused Builder pane is one visual surface even when focus moves between
+  // physical panes. Per-pane handoff state cannot cover that move: the outgoing
+  // pane and incoming pane each still own their active chat, so neither looks
+  // like a chat change.
+  const focusedPaneKey = focusedBuilderPaneId == null
+    ? null
+    : String(focusedBuilderPaneId)
+  const focusedOwner = focusedPaneKey == null
+    ? null
+    : owners.find(owner => (
+        owner.world === BUILDER_CHAT_WORLD
+        && String(owner.paneId) === focusedPaneKey
+      ))
+  const presentedFocusedId = presentedChatBySurface.get(
+    FOCUSED_BUILDER_CHAT_SURFACE,
+  )
+  const previousFocusedOwner = focusedOwner
+      && presentedFocusedId
+      && String(presentedFocusedId) !== String(focusedOwner.chatId)
+    ? owners.find(owner => (
+        owner.world === BUILDER_CHAT_WORLD
+        && String(owner.chatId) === String(presentedFocusedId)
+      ))
+    : null
+
   const layers = []
   for (const owner of owners) {
+    if (previousFocusedOwner && owner.surfaceKey === previousFocusedOwner.surfaceKey) {
+      layers.push({
+        ...owner,
+        presentationPaneId: focusedPaneKey,
+        role: 'held',
+      })
+      continue
+    }
+    if (previousFocusedOwner && owner.surfaceKey === focusedOwner.surfaceKey) {
+      layers.push({ ...owner, role: 'staging' })
+      continue
+    }
+
     const paneKey = String(owner.paneId)
     const activeId = String(owner.chatId)
-    const previousId = presentedChatByPane.get(paneKey)
+    const previousId = presentedChatBySurface.get(paneKey)
     const transitioning = previousId && previousId !== activeId
     if (transitioning && !desiredByWorld.get(owner.world)?.has(String(previousId))) {
       layers.push({


### PR DESCRIPTION
## Summary

- keep the outgoing focused Builder chat painted when focus moves between panes
- prepare the destination beneath the existing opaque handoff cover until it is display-ready
- preserve the same atomic swap for idle and running chat destinations

## Context

#542 established the opaque outgoing-chat cover, and #571 extended that invariant through running-chat stream catch-up. Both handoffs were tracked by physical pane, so changing focus between Builder panes could hide the outgoing pane before the destination transcript was ready.

This extends the existing handoff owner to the focused Builder presentation surface. It reuses the retained outgoing ChatView as the cover; it does not add an animation, timer, or stale-content path.

## Testing

- `npm test`
- `npm run lint` (0 errors; existing warnings remain within the configured budget)
- desktop focused-pane frame traces with both idle and running destinations; the outgoing transcript remained painted until the destination had produced a visible frame