### PR TITLE
Derive browser profile quota from data capacity

### DIFF
--- a/backend/app/browser_profiles.py
+++ b/backend/app/browser_profiles.py
@@ -32,9 +32,7 @@ _CACHE_PATHS = (
   "ShaderCache",
 )
 _DEFAULT_MAX_BYTES = 2 * 1024**3
-_DEFAULT_LOW_WATER_BYTES = 1536 * 1024**2
-_RAILWAY_DEFAULT_MAX_BYTES = 128 * 1024**2
-_RAILWAY_DEFAULT_LOW_WATER_BYTES = 96 * 1024**2
+_DEFAULT_LOW_WATER_BYTES = _DEFAULT_MAX_BYTES * 3 // 4
 _DEFAULT_INACTIVE_DAYS = 30
 _DEFAULT_SWEEP_SECONDS = 60 * 60
 _status = {
@@ -76,26 +74,18 @@ def _env_int(name: str, default: int) -> int:
   return value if value >= 0 else default
 
 
-def _running_on_railway() -> bool:
-  return any(os.environ.get(name) for name in (
-    "RAILWAY_ENVIRONMENT",
-    "RAILWAY_ENVIRONMENT_ID",
-    "RAILWAY_PROJECT_ID",
-    "RAILWAY_SERVICE_ID",
-  ))
-
-
-def default_browser_profile_quota() -> tuple[int, int]:
-  """Return platform-aware high/low water defaults.
-
-  Railway Trial and Free volumes are smaller than the ordinary 2 GiB profile
-  ceiling, so using the self-host default there would wait until after the
-  whole volume was full. Operator env overrides are still applied by the
-  quota function below.
-  """
-  if _running_on_railway():
-    return _RAILWAY_DEFAULT_MAX_BYTES, _RAILWAY_DEFAULT_LOW_WATER_BYTES
-  return _DEFAULT_MAX_BYTES, _DEFAULT_LOW_WATER_BYTES
+def default_browser_profile_quota(
+  data_dir: str | Path,
+) -> tuple[int, int]:
+  """Size profile defaults from the stable capacity of the data filesystem."""
+  try:
+    total_bytes = int(shutil.disk_usage(data_dir).total)
+  except (OSError, TypeError, ValueError):
+    return _DEFAULT_MAX_BYTES, _DEFAULT_LOW_WATER_BYTES
+  if total_bytes <= 0:
+    return _DEFAULT_MAX_BYTES, _DEFAULT_LOW_WATER_BYTES
+  max_bytes = min(_DEFAULT_MAX_BYTES, total_bytes // 4)
+  return max_bytes, max_bytes * 3 // 4
 
 
 def browser_profile_sweep_seconds() -> int:
@@ -268,7 +258,9 @@ def enforce_browser_profile_quota(
   """
   root = Path(data_dir) / "agent-browser-profiles"
   now = now or datetime.now(UTC).replace(tzinfo=None)
-  default_max_bytes, default_low_water_bytes = default_browser_profile_quota()
+  default_max_bytes, default_low_water_bytes = default_browser_profile_quota(
+    data_dir,
+  )
   max_bytes = max_bytes if max_bytes is not None else _env_int(
     "AGENT_BROWSER_PROFILE_MAX_BYTES", default_max_bytes,
   )

--- a/backend/tests/test_browser_profiles.py
+++ b/backend/tests/test_browser_profiles.py
@@ -1,5 +1,6 @@
 import asyncio
 from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
 
 from app import browser_profiles, chat
 from app.browser_profiles import enforce_browser_profile_quota
@@ -27,22 +28,67 @@ def _named_profile(root, name, *, cache_bytes, durable_bytes):
   return profile
 
 
-def test_railway_defaults_fit_below_managed_volume_limit(monkeypatch):
+def test_profile_defaults_follow_data_capacity_not_provider(monkeypatch, tmp_path):
+  monkeypatch.setattr(
+    browser_profiles.shutil,
+    "disk_usage",
+    lambda path: SimpleNamespace(total=512 * 1024**2),
+  )
+  expected = (128 * 1024**2, 96 * 1024**2)
+  assert browser_profiles.default_browser_profile_quota(tmp_path) == expected
   for name in (
     "RAILWAY_ENVIRONMENT",
     "RAILWAY_ENVIRONMENT_ID",
     "RAILWAY_PROJECT_ID",
     "RAILWAY_SERVICE_ID",
   ):
-    monkeypatch.delenv(name, raising=False)
-  assert browser_profiles.default_browser_profile_quota() == (
+    monkeypatch.setenv(name, "railway-test")
+  assert browser_profiles.default_browser_profile_quota(tmp_path) == expected
+
+
+def test_profile_defaults_are_capped_and_fall_back_on_probe_failure(
+  monkeypatch, tmp_path,
+):
+  monkeypatch.setattr(
+    browser_profiles.shutil,
+    "disk_usage",
+    lambda path: SimpleNamespace(total=16 * 1024**3),
+  )
+  assert browser_profiles.default_browser_profile_quota(tmp_path) == (
     2 * 1024**3, 1536 * 1024**2,
   )
 
-  monkeypatch.setenv("RAILWAY_PROJECT_ID", "project-test")
-  assert browser_profiles.default_browser_profile_quota() == (
-    128 * 1024**2, 96 * 1024**2,
+  def fail(_path):
+    raise OSError("unavailable")
+
+  monkeypatch.setattr(browser_profiles.shutil, "disk_usage", fail)
+  assert browser_profiles.default_browser_profile_quota(tmp_path) == (
+    2 * 1024**3, 1536 * 1024**2,
   )
+
+  monkeypatch.setattr(
+    browser_profiles.shutil,
+    "disk_usage",
+    lambda path: SimpleNamespace(total=0),
+  )
+  assert browser_profiles.default_browser_profile_quota(tmp_path) == (
+    2 * 1024**3, 1536 * 1024**2,
+  )
+
+
+def test_profile_quota_environment_overrides_capacity(monkeypatch, tmp_path):
+  monkeypatch.setattr(
+    browser_profiles.shutil,
+    "disk_usage",
+    lambda path: SimpleNamespace(total=512 * 1024**2),
+  )
+  monkeypatch.setenv("AGENT_BROWSER_PROFILE_MAX_BYTES", "42")
+  monkeypatch.setenv("AGENT_BROWSER_PROFILE_LOW_WATER_BYTES", "31")
+
+  result = enforce_browser_profile_quota(tmp_path, {}, set())
+
+  assert result["max_bytes"] == 42
+  assert result["low_water_bytes"] == 31
 
 
 def test_profile_sweep_interval_is_hourly_and_bounded(monkeypatch):


### PR DESCRIPTION
## Summary

- remove the last Railway-environment branch from browser-profile storage policy
- derive the default quota from the actual `/data` filesystem capacity: one quarter of total capacity, capped at 2 GiB, with a 75% low-water mark
- preserve explicit operator overrides and fail open to the existing generic defaults when capacity is unavailable or invalid

## Why

This is static capacity policy, not live contention policy. A 512 MiB volume naturally receives the prior 128/96 MiB managed defaults without knowing which provider hosts it, while larger self-hosted volumes retain the 2 GiB cap.

## Verification

- independent review: approved after adding the non-positive-capacity guard
- `test_browser_profiles.py`, `test_runtime_supervisors.py`, and `test_debug_status.py`: 32 passed in the pinned Mobius image
- no new dependency, daemon, background loop, or provider-specific mode
- `git diff --check` and pre-push gates passed
