### PR TITLE
Release startup resources before slow work

### DIFF
--- a/backend/app/bootstrap.py
+++ b/backend/app/bootstrap.py
@@ -112,13 +112,19 @@ async def ensure_bootstrap_apps_installed(db: Session) -> None:
       source_url=bootstrap_app.manifest_url,
       manifest_id=bootstrap_app.name,
     )
-    if existing is not None and (
+    existing_id = existing.id if existing is not None else None
+    already_installed = existing is not None and (
       existing.deleted_at is None
       or not bootstrap_app.reinstall_after_uninstall
-    ):
+    )
+    # The identity query autobegins a read transaction. Do not retain its
+    # connection while the installer performs serial network fetches and
+    # compilation; install_from_manifest starts and owns the next transaction.
+    db.rollback()
+    if already_installed:
       log.info(
         "bootstrap: %s already installed (app id=%s)",
-        bootstrap_app.name, existing.id,
+        bootstrap_app.name, existing_id,
       )
       continue
     log.info(

--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -1206,6 +1206,9 @@ class ChatWriterActor:
       # this probe raises, `.set()` is skipped and the except below marks the
       # writer fatal — it never reports ready on a writer that can't persist.
       self._db.execute(text("SELECT 1"))
+      # SQLAlchemy autobegins even for SELECT 1. End that probe transaction
+      # before readiness so an idle writer owns no connection or snapshot.
+      self._db.rollback()
       self._session_ready.set()
     except BaseException:
       # The session factory raising at first use is thread-fatal: there
@@ -1362,6 +1365,7 @@ class ChatWriterActor:
     # outer `except BaseException` → `_go_fatal`, leaving readiness clear rather
     # than advertising a session that can't persist.
     self._db.execute(text("SELECT 1"))
+    self._db.rollback()
     self._session_ready.set()
 
   def _dispatch(self, db, cmd: _Command):

--- a/backend/app/install.py
+++ b/backend/app/install.py
@@ -2824,20 +2824,26 @@ async def install_from_manifest(
         # HTTP fetch, are authoritative on this path.
         if not existing and repo_ref is not None:
           repo_url, ref = repo_ref
-          try:
-            app.upstream_commit = await asyncio.to_thread(
-              app_git.clone_upstream, git_source_dir, repo_url, ref,
-            )
-            entry_bytes = (git_source_dir / "index.jsx").read_bytes()
-            upstream_jsx_sha = hashlib.sha256(entry_bytes).hexdigest()
-            source_tree = {"index.jsx": entry_bytes}
-            cloned_install = True
-          except Exception as exc:
-            log.warning(
-              "install: clone from %s at %s failed; falling back to "
-              "fetched source path — %r",
-              repo_url, ref, exc,
-            )
+          # `git clone --branch` accepts branches/tags, not a raw commit SHA.
+          # Commit-pinned manifests already fetched reviewed bytes above, so
+          # skip that known failure and use the unchanged synthetic fallback.
+          if not re.fullmatch(
+            r"(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})", ref,
+          ):
+            try:
+              app.upstream_commit = await asyncio.to_thread(
+                app_git.clone_upstream, git_source_dir, repo_url, ref,
+              )
+              entry_bytes = (git_source_dir / "index.jsx").read_bytes()
+              upstream_jsx_sha = hashlib.sha256(entry_bytes).hexdigest()
+              source_tree = {"index.jsx": entry_bytes}
+              cloned_install = True
+            except Exception as exc:
+              log.warning(
+                "install: clone from %s at %s failed; falling back to "
+                "fetched source path — %r",
+                repo_url, ref, exc,
+              )
         if not cloned_install:
           # record the pristine source tree on `upstream`, then align the
           # local `main` branch to that commit so the working branch starts

--- a/backend/scripts/init_skills.py
+++ b/backend/scripts/init_skills.py
@@ -33,11 +33,19 @@ backend/scripts/seed-skills/ for dev. Run from entrypoint after
 init_chat_summaries.py.
 """
 
+import hashlib
 import os
 import pwd
 import shutil
-import hashlib
+import sys
 from pathlib import Path
+
+# Entrypoint executes this file by absolute path, which puts /app/scripts rather
+# than its sibling /app package on sys.path. Resolve the trusted runtime root
+# from this script so both boot reconciliation imports work standalone.
+_APP_IMPORT_ROOT = str(Path(__file__).resolve().parent.parent)
+if _APP_IMPORT_ROOT not in sys.path:
+  sys.path.insert(0, _APP_IMPORT_ROOT)
 
 DATA_DIR = Path(os.environ.get("DATA_DIR", "/data"))
 SKILLS = DATA_DIR / "shared" / "skills"
@@ -177,9 +185,6 @@ def _write_index() -> None:
   install.
   """
   try:
-    import sys
-
-    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
     from app.skills import reconcile_installed, write_index
 
     # Startup half of the installer's crash-recovery contract: repair any

--- a/backend/tests/test_apps_install.py
+++ b/backend/tests/test_apps_install.py
@@ -929,6 +929,42 @@ def test_derive_repo_ref_only_root_manifest_single_segment_ref():
   ) is None
 
 
+@pytest.mark.parametrize("commit", ["a" * 40, "b" * 64])
+def test_commit_pinned_install_skips_branch_clone_and_uses_fetched_source(
+  commit,
+  client, auth, bypass_url_validation,
+):
+  """A raw commit ref cannot be cloned with --branch; keep the fallback."""
+  base = f"https://raw.githubusercontent.com/acme/pinned/{commit}/"
+  jsx = "export default function App() { return <div>pinned fetch</div> }"
+  manifest = {
+    "id": "pinned-fetch",
+    "name": "Pinned Fetch",
+    "version": "1.0.0",
+    "description": "Immutable fetched-source install",
+    "entry": "index.jsx",
+    "permissions": {"cross_app_access": "none", "share_with_apps": "none"},
+  }
+  responses = {
+    base + "mobius.json": (200, json.dumps(manifest).encode()),
+    base + "index.jsx": (200, jsx.encode()),
+  }
+  with patch(
+    "app.install.httpx.AsyncClient",
+    side_effect=_fake_async_client(responses),
+  ), patch("app.install.app_git.clone_upstream") as clone:
+    response = client.post("/api/apps/install", headers=auth, json={
+      "manifest_url": base + "mobius.json",
+    })
+
+  assert response.status_code == 201, response.text
+  clone.assert_not_called()
+  source_dir = Path(get_settings().data_dir) / "apps" / "pinned-fetch"
+  assert (source_dir / "index.jsx").read_text(encoding="utf-8") == jsx
+  assert app_git.is_repo(source_dir)
+  assert not app_git.has_origin(source_dir)
+
+
 def test_update_dropping_schedule_unregisters_orphan_cron(
     client, auth, bypass_url_validation):
   """Recurring → on-demand migration must converge cron state, not just add.

--- a/backend/tests/test_bootstrap.py
+++ b/backend/tests/test_bootstrap.py
@@ -78,6 +78,25 @@ async def test_bootstrap_installs_all_apps_in_order_when_absent(db, monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_bootstrap_releases_identity_transaction_before_install(
+  db, monkeypatch,
+):
+  """Serial fetch/compile work must not retain the identity query connection."""
+  monkeypatch.delenv("MOEBIUS_SKIP_BOOTSTRAP", raising=False)
+
+  def install_after_release(*_args, **_kwargs):
+    assert not db.in_transaction()
+    return _install_result()
+
+  install_mock = AsyncMock(side_effect=install_after_release)
+  with patch("app.bootstrap.install_from_manifest", install_mock):
+    await ensure_bootstrap_apps_installed(db)
+
+  assert install_mock.await_count == len(_bootstrap_urls())
+  assert not db.in_transaction()
+
+
+@pytest.mark.asyncio
 async def test_bootstrap_applies_per_app_uninstall_policy(db, monkeypatch):
   """Store returns after uninstall; Skills/Memory stay gone; live Reflection skips."""
   monkeypatch.delenv("MOEBIUS_SKIP_BOOTSTRAP", raising=False)

--- a/backend/tests/test_memory_boot.py
+++ b/backend/tests/test_memory_boot.py
@@ -1,8 +1,11 @@
 """Base boot creates chat continuity only; graph memory belongs to its app."""
 
-import importlib.util
 import hashlib
+import importlib.util
+import os
 import re
+import subprocess
+import sys
 from pathlib import Path
 
 
@@ -51,6 +54,31 @@ def test_base_skill_boot_never_seeds_app_owned_memory_skill(tmp_path, monkeypatc
 
   baked_seed = SCRIPTS / "seed-skills"
   assert not (baked_seed / "memory.md").exists()
+
+
+def test_init_skills_absolute_entrypoint_imports_sibling_app(tmp_path):
+  """Warm boot imports app.skills when invoked outside the backend cwd."""
+  skills = tmp_path / "data" / "shared" / "skills"
+  skills.mkdir(parents=True)
+  (skills / "owner.md").write_text("owner skill", encoding="utf-8")
+  env = os.environ.copy()
+  env.pop("PYTHONPATH", None)
+  env["DATA_DIR"] = str(tmp_path / "data")
+
+  result = subprocess.run(
+    [sys.executable, str(SCRIPTS / "init_skills.py")],
+    cwd=tmp_path,
+    env=env,
+    capture_output=True,
+    text=True,
+    timeout=30,
+    check=False,
+  )
+
+  assert result.returncode == 0, result.stderr
+  assert "init_skills: reconcile skipped" not in result.stdout
+  assert "init_skills: skills-index.md regenerated" in result.stdout
+  assert (skills / "skills-index.md").is_file()
 
 
 def test_later_boot_preserves_existing_memory_skill_but_does_not_reseed_it(

--- a/backend/tests/test_readiness.py
+++ b/backend/tests/test_readiness.py
@@ -40,6 +40,51 @@ def test_ready_returns_200_when_writer_running(client):
   assert body["boot_id"]
 
 
+def test_writer_probe_transactions_end_before_readiness():
+  """Boot and recreate must release SELECT 1 before advertising readiness."""
+  actions = []
+  actor = None
+
+  class _ProbeSession:
+    def __init__(self, name):
+      self.name = name
+
+    def execute(self, *_args, **_kwargs):
+      actions.append((f"{self.name}:execute", actor._session_ready.is_set()))
+
+    def rollback(self):
+      actions.append((f"{self.name}:rollback", actor._session_ready.is_set()))
+
+    def close(self):
+      actions.append((f"{self.name}:close", actor._session_ready.is_set()))
+
+  actor = chat_writer.ChatWriterActor(lambda: _ProbeSession("boot"))
+  actor.start()
+  try:
+    assert actor._session_ready.wait(timeout=5)
+    assert actions[:2] == [
+      ("boot:execute", False),
+      ("boot:rollback", False),
+    ]
+  finally:
+    actor.stop(timeout=5)
+
+  actions.clear()
+  old = _ProbeSession("old")
+  fresh = _ProbeSession("fresh")
+  actor = chat_writer.ChatWriterActor(lambda: fresh)
+  actor._db = old
+  actor._session_ready.set()
+  actor._recreate_session()
+  assert actions == [
+    ("old:rollback", False),
+    ("old:close", False),
+    ("fresh:execute", False),
+    ("fresh:rollback", False),
+  ]
+  assert actor._session_ready.is_set()
+
+
 def test_ready_returns_503_when_writer_fatal_then_recovers(client):
   """A fatal actor flips /api/ready to 503; restoring a healthy writer
   returns it to 200. The restore is the point — a fatal singleton left


### PR DESCRIPTION
## Summary

- end bootstrap lookup transactions before network fetch and compilation
- release ChatWriter readiness probe transactions immediately
- skip guaranteed-failing git clone branch resolution for raw commit-pinned manifests
- make the skills startup script importable from its absolute entrypoint

These are provider-neutral startup ownership fixes for cold starts and constrained containers. They do not add a queue, daemon, hosting-provider branch, or compatibility layer.

## Verification

- 332 impacted backend tests passed in the current Vite/Rolldown container
- focused regression tests cover bootstrap, ChatWriter cold/recreated readiness, raw SHA installs, and standalone skills initialization
- Ruff passed
- git diff --check passed

Full repository CI is the final integration gate.