### PR TITLE
Use partner-facing language in app search

### DIFF
--- a/frontend/src/components/GlobalSearch/GlobalSearch.jsx
+++ b/frontend/src/components/GlobalSearch/GlobalSearch.jsx
@@ -174,8 +174,8 @@ export default function GlobalSearch({ onClose, onOpenTarget }) {
             type="search"
             value={query}
             onChange={event => setQuery(event.target.value)}
-            placeholder="Search chats, apps, and manifests"
-            aria-label="Search chats, apps, and manifests"
+            placeholder="Search chats, apps, and app details"
+            aria-label="Search chats, apps, and app details"
             autoComplete="off"
             spellCheck="false"
           />
@@ -189,7 +189,7 @@ export default function GlobalSearch({ onClose, onOpenTarget }) {
                 <MagnifyingGlassSearch width={30} height={30} />
               </span>
               <h3>Find anything you’ve worked on</h3>
-              <p>Search chat titles and conversation text, plus app names and manifest details.</p>
+              <p>Search chat titles and conversation text, plus app names and app details.</p>
             </div>
           )}
 
@@ -273,7 +273,7 @@ export default function GlobalSearch({ onClose, onOpenTarget }) {
               {noResults && (
                 <div className="global-search__empty global-search__empty--results">
                   <h3>No matches</h3>
-                  <p>Try a shorter phrase or a manifest term such as “offline”, “schedule”, or a skill name.</p>
+                  <p>Try a shorter phrase or an app detail such as “offline”, “schedule”, or a skill name.</p>
                 </div>
               )}
             </div>

--- a/frontend/src/components/GlobalSearch/__tests__/globalSearchModel.test.js
+++ b/frontend/src/components/GlobalSearch/__tests__/globalSearchModel.test.js
@@ -32,7 +32,7 @@ const apps = [
 test('installed app search prioritizes names, then descriptions', () => {
   assert.deepEqual(
     searchInstalledApps(apps, 'news').map(result => [result.app.id, result.matchArea]),
-    [[2, 'Name'], [1, 'Manifest']],
+    [[2, 'Name'], [1, 'App details']],
   )
   assert.deepEqual(searchInstalledApps(apps, 'calm'), [{
     app: apps[0],
@@ -40,15 +40,15 @@ test('installed app search prioritizes names, then descriptions', () => {
   }])
 })
 
-test('manifest declarations are searchable without exposing a second index', () => {
+test('manifest declarations stay searchable under partner-facing app details language', () => {
   assert.match(appManifestSearchDocument(apps[0]), /scheduled/)
   assert.deepEqual(searchInstalledApps(apps, 'cron scheduled'), [{
     app: apps[0],
-    matchArea: 'Manifest',
+    matchArea: 'App details',
   }])
   assert.deepEqual(searchInstalledApps(apps, 'offline reads'), [{
     app: apps[1],
-    matchArea: 'Manifest',
+    matchArea: 'App details',
   }])
 })
 
@@ -67,14 +67,14 @@ test('false capability defaults never create manifest matches', () => {
   }
   assert.deepEqual(searchInstalledApps([ordinary, connected], 'github_connect'), [{
     app: connected,
-    matchArea: 'Manifest',
+    matchArea: 'App details',
   }])
 })
 
 test('all query terms must match and result limits are stable', () => {
   assert.deepEqual(searchInstalledApps(apps, 'news scheduled'), [{
     app: apps[0],
-    matchArea: 'Manifest',
+    matchArea: 'App details',
   }])
   assert.deepEqual(searchInstalledApps(apps, 'news missing'), [])
   assert.equal(searchInstalledApps(apps, 'news', 1).length, 1)

--- a/frontend/src/components/GlobalSearch/globalSearchModel.js
+++ b/frontend/src/components/GlobalSearch/globalSearchModel.js
@@ -65,7 +65,7 @@ export function searchInstalledApps(apps, query, limit = 8) {
     if (!includesEvery(whole, tokens)) continue
 
     let score = 100
-    let matchArea = 'Manifest'
+    let matchArea = 'App details'
     const normalizedQuery = tokens.join(' ')
     if (name === normalizedQuery) {
       score = 500


### PR DESCRIPTION
## Summary

- replace partner-facing “manifest” terminology with “app details” in global search
- preserve capability-aware app matching and ranking unchanged
- cover the result label with the existing search-model tests

This is intentionally separate from #629: that pull request improves the search dialog layout and icon reuse, while this change only corrects the language presented to owners.

## Testing

- focused global-search model tests: 6 passed
- production/PWA frontend build passed
- authenticated mobile rendering verified