### PR TITLE
Support complete multi-file skill packages

### DIFF
--- a/backend/app/catalog_index.py
+++ b/backend/app/catalog_index.py
@@ -46,6 +46,7 @@ CATALOG_SOURCES: list[dict] = [
   {"label": "Anthropic Knowledge Work", "repo": "anthropics/knowledge-work-plugins", "path": "", "ref": "main"},
   {"label": "Superpowers", "repo": "obra/superpowers", "path": "skills", "ref": "main"},
   {"label": "Trail of Bits Security", "repo": "trailofbits/skills", "path": "", "ref": "main"},
+  {"label": "Impeccable", "repo": "pbakaus/impeccable", "path": ".claude/skills", "ref": "main"},
   {"label": "Cloudflare", "repo": "cloudflare/skills", "path": "skills", "ref": "main"},
   {"label": "Hermes bundled", "repo": "NousResearch/hermes-agent", "path": "skills", "ref": "main"},
   {"label": "Hermes optional", "repo": "NousResearch/hermes-agent", "path": "optional-skills", "ref": "main"},

--- a/backend/app/skills.py
+++ b/backend/app/skills.py
@@ -242,12 +242,17 @@ _STAGING_GC_AGE_SECONDS = 3600
 # One install/recovery tree contract. The writer and the recovery reader share
 # these bounds so recovery never accepts or loads a shape the installer could
 # not have published.
-RESOURCE_COUNT_MAX = 24
-RESOURCE_TOTAL_MAX = 2 * 1024 * 1024
-RESOURCE_MAX_DEPTH = 4
+# Modern skill packages can be command-routed toolkits with many small
+# playbooks and helper modules (rather than one SKILL.md plus a handful of
+# references). Keep the tree tightly bounded, but make the bound large enough
+# to preserve those packages whole instead of publishing a silently truncated
+# instruction set.
+RESOURCE_COUNT_MAX = 256
+RESOURCE_TOTAL_MAX = 8 * 1024 * 1024
+RESOURCE_MAX_DEPTH = 8
 RESOURCE_SUFFIXES = frozenset({
-  ".md", ".txt", ".json", ".yaml", ".yml", ".csv", ".py", ".js", ".ts",
-  ".sh", ".toml", ".html", ".css",
+  ".md", ".txt", ".json", ".yaml", ".yml", ".csv", ".py", ".js", ".mjs",
+  ".cjs", ".ts", ".tsx", ".jsx", ".sh", ".toml", ".html", ".css",
 })
 TREE_FILE_COUNT_MAX = 1 + RESOURCE_COUNT_MAX  # root SKILL.md + resources
 TREE_TOTAL_BYTES_MAX = SKILL_MAX_BYTES + RESOURCE_TOTAL_MAX

--- a/backend/tests/test_skills_platform.py
+++ b/backend/tests/test_skills_platform.py
@@ -268,7 +268,7 @@ def test_install_repo_dir_fetches_whole_subtree_of_vetted_resources(
     {"type": "tree", "path": "scripts"},
     {"type": "blob", "path": "logo.png", "size": 10},  # unvetted suffix
     {"type": "blob", "path": ".github/ci.yml", "size": 5},  # dot segment
-    {"type": "blob", "path": "a/b/c/d/deep.md", "size": 5},  # over depth cap
+    {"type": "blob", "path": "a/b/c/d/e/f/g/h/deep.md", "size": 5},  # over depth cap
   ]
   _dir_install_mocks(monkeypatch, rs, tree, {
     f"{raw}/SKILL.md": b"---\nname: pdf\ndescription: PDFs.\n---\n",
@@ -344,8 +344,10 @@ def test_resource_rel_ok_contract():
 
   assert _resource_rel_ok("ref.md")
   assert _resource_rel_ok("scripts/run.py")
-  assert _resource_rel_ok("a/b/c/deep.md")  # depth 4 = at the cap
-  assert not _resource_rel_ok("a/b/c/d/deep.md")  # depth 5
+  assert _resource_rel_ok("scripts/context.mjs")
+  assert _resource_rel_ok("scripts/ui/card.tsx")
+  assert _resource_rel_ok("a/b/c/d/e/f/g/deep.md")  # depth 8 = at the cap
+  assert not _resource_rel_ok("a/b/c/d/e/f/g/h/deep.md")  # depth 9
   assert not _resource_rel_ok("../up.md")
   assert not _resource_rel_ok(".hidden.md")
   assert not _resource_rel_ok("dir/.hidden.md")
@@ -353,6 +355,14 @@ def test_resource_rel_ok_contract():
   assert not _resource_rel_ok("win\\path.md")
   assert not _resource_rel_ok("binary.png")
   assert not _resource_rel_ok("")
+
+
+def test_skill_package_bounds_fit_command_routed_toolkits():
+  from app import skills as skills_mod
+
+  assert skills_mod.RESOURCE_COUNT_MAX >= 256
+  assert skills_mod.RESOURCE_TOTAL_MAX >= 8 * 1024 * 1024
+  assert skills_mod.RESOURCE_MAX_DEPTH >= 8
 
 
 def test_install_collision_is_409_with_provenance(

--- a/backend/tests/test_skills_platform.py
+++ b/backend/tests/test_skills_platform.py
@@ -360,9 +360,9 @@ def test_resource_rel_ok_contract():
 def test_skill_package_bounds_fit_command_routed_toolkits():
   from app import skills as skills_mod
 
-  assert skills_mod.RESOURCE_COUNT_MAX >= 256
-  assert skills_mod.RESOURCE_TOTAL_MAX >= 8 * 1024 * 1024
-  assert skills_mod.RESOURCE_MAX_DEPTH >= 8
+  assert skills_mod.RESOURCE_COUNT_MAX == 256
+  assert skills_mod.RESOURCE_TOTAL_MAX == 8 * 1024 * 1024
+  assert skills_mod.RESOURCE_MAX_DEPTH == 8
 
 
 def test_install_collision_is_409_with_provenance(


### PR DESCRIPTION
## Summary

- preserve modern multi-file skill packages instead of truncating them at 24 supporting files
- accept common JavaScript module and component source extensions used by skill helpers
- raise the bounded package depth and total-size limits while retaining traversal, hidden-file, type, count, and byte protections
- add Impeccable to the shared catalog index

## Testing

- targeted backend skill-platform suite: 73 passed
- Python compilation check passed

No credentials, installed skill contents, or owner data are included.
