### PR TITLE
Contain chat layers within shell presentation surfaces

### DIFF
--- a/frontend/src/components/Shell/Shell.css
+++ b/frontend/src/components/Shell/Shell.css
@@ -288,6 +288,10 @@
    visibility:hidden settlement frame is never exposed. */
 .shell__chat-view {
   background: var(--bg);
+  /* A ChatView owns several internal paint layers (composer, progress rail,
+     menus). Keep those z-index values local to the view so they cannot punch
+     through a shell-owned handoff or New Chat presentation above it. */
+  isolation: isolate;
 }
 
 .shell__chat-view--staging {

--- a/frontend/src/components/Shell/__tests__/chatHandoff.test.js
+++ b/frontend/src/components/Shell/__tests__/chatHandoff.test.js
@@ -282,6 +282,8 @@ test('direct chat actions hand focus to the destination composer', () => {
 test('the held chat is an opaque layer above staging until the atomic swap', () => {
   assert.match(ruleBody('.shell__chat-view'), /background:\s*var\(--bg\)/,
     'the cover must be opaque so hidden incoming content cannot leak through')
+  assert.match(ruleBody('.shell__chat-view'), /isolation:\s*isolate/,
+    'chat-owned z-index layers must not escape above shell-owned presentations')
   assert.match(ruleBody('.shell__chat-view--staging'), /visibility:\s*visible/)
   assert.match(ruleBody('.shell__chat-view--staging'), /z-index:\s*1/)
   assert.match(ruleBody('.shell__chat-view--held'), /visibility:\s*visible/)


### PR DESCRIPTION
## Summary

- keep every chat’s internal paint layers inside its shell-owned surface
- prevent goals, progress, menus, and other chat-local overlays from appearing above New chat and chat-handoff covers
- preserve intentional document-level lightboxes through their existing portals

## Context

#541 introduced the immediate New chat welcome surface, but ChatView’s internal z-index layers still participated in the shell’s stacking context. The outgoing footer could therefore paint above the welcome surface even while the transcript itself was correctly covered.

This establishes the missing surface boundary instead of raising a New-chat-specific z-index. It also strengthens ordinary held/staging chat handoffs. The adjacent focused-Builder work in #634 remains independent; it chooses which chat surface is held, while this change keeps each surface’s internal layers contained.

## Testing

- targeted chat-handoff unit suite
- full Chat/Shell unit suite (1,535 passing)
- production frontend build
- rendered Single-screen transition from an active goal chat while creation was deliberately held open