### PR TITLE
Serve nested chat media paths

### DIFF
--- a/backend/app/image_previews.py
+++ b/backend/app/image_previews.py
@@ -22,8 +22,25 @@ _GENERATION_SLOTS = threading.BoundedSemaphore(2)
 
 
 def preview_cache_path(file_path: Path, base: Path) -> Path:
-  """Return the single stable derivative path owned by one source filename."""
-  digest = hashlib.sha256(file_path.name.encode("utf-8")).hexdigest()[:24]
+  """Return the single stable derivative path owned by one source path."""
+  try:
+    source_path = file_path.resolve()
+  except (OSError, RuntimeError):
+    source_path = Path(os.path.abspath(file_path))
+  try:
+    base_path = base.resolve()
+  except (OSError, RuntimeError):
+    base_path = Path(os.path.abspath(base))
+
+  try:
+    cache_key = os.fsencode(source_path.relative_to(base_path).as_posix())
+  except ValueError:
+    # Normal callers validate containment before reaching this module. Keep an
+    # unexpected out-of-base path deterministic and confined to the cache by
+    # hashing its normalized absolute path, separated from relative keys by a
+    # byte that cannot occur in a filesystem path.
+    cache_key = b"\0outside\0" + os.fsencode(source_path.as_posix())
+  digest = hashlib.sha256(cache_key).hexdigest()[:24]
   return base / PREVIEW_DIR / f"{digest}.webp"
 
 

--- a/backend/app/routes/media.py
+++ b/backend/app/routes/media.py
@@ -4,7 +4,6 @@ import mimetypes
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException
-from fastapi import Path as FastPath
 from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
 
@@ -64,10 +63,10 @@ def _serve_chat_image(chat_id, filename, token_src, db, *, preview=False):
   return FileResponse(str(file_path), media_type=media_type)
 
 
-@router.get("/{chat_id}/media/{filename}")
+@router.get("/{chat_id}/media/{filename:path}")
 def serve_chat_media(
   chat_id: str,
-  filename: str = FastPath(...),
+  filename: str,
   preview: bool = False,
   token_src: TokenSource = Depends(get_auth_token_source),
   db: Session = Depends(get_db),

--- a/backend/tests/test_chat_media_dimensions.py
+++ b/backend/tests/test_chat_media_dimensions.py
@@ -5,6 +5,7 @@ from PIL import Image
 from app.chat_media_dimensions import project_message_image_dimensions
 from app.image_previews import (
   dimensions_cache_path,
+  preview_cache_path,
   stored_image_dimensions,
 )
 
@@ -42,6 +43,52 @@ def test_stored_dimensions_follow_exif_orientation(tmp_path):
     "width": 800,
     "height": 1200,
   }
+
+
+def test_nested_duplicate_basenames_keep_distinct_dimension_sidecars(tmp_path):
+  base = tmp_path / "media"
+  landscape = base / "reports/landscape/result.png"
+  portrait = base / "reports/portrait/result.png"
+  landscape.parent.mkdir(parents=True)
+  portrait.parent.mkdir(parents=True)
+  Image.new("RGB", (120, 60)).save(landscape, "PNG")
+  Image.new("RGB", (60, 120)).save(portrait, "PNG")
+
+  assert stored_image_dimensions(landscape, base) == {
+    "width": 120,
+    "height": 60,
+  }
+  assert stored_image_dimensions(portrait, base) == {
+    "width": 60,
+    "height": 120,
+  }
+  landscape_sidecar = dimensions_cache_path(landscape, base)
+  portrait_sidecar = dimensions_cache_path(portrait, base)
+  assert landscape_sidecar != portrait_sidecar
+  assert landscape_sidecar.is_file()
+  assert portrait_sidecar.is_file()
+
+  with patch("app.image_previews.Image.open", side_effect=AssertionError("reopened")):
+    assert stored_image_dimensions(landscape, base) == {
+      "width": 120,
+      "height": 60,
+    }
+    assert stored_image_dimensions(portrait, base) == {
+      "width": 60,
+      "height": 120,
+    }
+
+
+def test_out_of_base_preview_cache_key_is_normalized_and_confined(tmp_path):
+  base = tmp_path / "media"
+  outside = tmp_path / "outside/result.png"
+  equivalent_outside = base / "../outside/result.png"
+  inside = base / "outside/result.png"
+
+  cache_path = preview_cache_path(outside, base)
+  assert cache_path == preview_cache_path(equivalent_outside, base)
+  assert cache_path.parent == base / ".previews"
+  assert cache_path != preview_cache_path(inside, base)
 
 
 def test_projection_attaches_path_metadata_without_mutating_transcript(tmp_path):

--- a/backend/tests/test_media.py
+++ b/backend/tests/test_media.py
@@ -101,6 +101,37 @@ def test_chat_media_preview_is_bounded_webp_and_original_stays_unchanged(
   assert previews[0].stat().st_mtime_ns == first_mtime
 
 
+def test_nested_chat_media_previews_with_same_name_do_not_share_cache(
+  client, auth, chat,
+):
+  media_dir = Path(get_settings().data_dir) / "chats" / chat.id / "media"
+  landscape = media_dir / "reports/landscape/result.png"
+  portrait = media_dir / "reports/portrait/result.png"
+  landscape.parent.mkdir(parents=True)
+  portrait.parent.mkdir(parents=True)
+  Image.new("RGB", (120, 60), (220, 20, 20)).save(landscape, "PNG")
+  Image.new("RGB", (60, 120), (20, 20, 220)).save(portrait, "PNG")
+  token = _media_token(client, auth, chat.id)
+
+  landscape_preview = client.get(
+    f"/api/chats/{chat.id}/media/reports/landscape/result.png",
+    params={"token": token, "preview": "true"},
+  )
+  portrait_preview = client.get(
+    f"/api/chats/{chat.id}/media/reports/portrait/result.png",
+    params={"token": token, "preview": "true"},
+  )
+
+  assert landscape_preview.status_code == 200
+  assert portrait_preview.status_code == 200
+  assert landscape_preview.content != portrait_preview.content
+  with Image.open(BytesIO(landscape_preview.content)) as image:
+    assert image.size == (120, 60)
+  with Image.open(BytesIO(portrait_preview.content)) as image:
+    assert image.size == (60, 120)
+  assert len(list((media_dir / ".previews").glob("*.webp"))) == 2
+
+
 def test_chat_media_preview_falls_back_for_undecodable_image(client, auth, chat):
   _write_chat_image(chat.id, "media", "broken.png", b"not-a-real-png")
 

--- a/backend/tests/test_media.py
+++ b/backend/tests/test_media.py
@@ -31,6 +31,24 @@ def test_serve_chat_media(client, auth, chat):
   assert response.headers["content-type"] == "image/png"
 
 
+def test_serve_chat_media_from_nested_report_directory(client, auth, chat):
+  _write_chat_image(
+    chat.id,
+    "media/report/desktop",
+    "contact-sheet.png",
+    b"nested-image-bytes",
+  )
+
+  response = client.get(
+    f"/api/chats/{chat.id}/media/report/desktop/contact-sheet.png",
+    params={"token": _media_token(client, auth, chat.id)},
+  )
+
+  assert response.status_code == 200
+  assert response.content == b"nested-image-bytes"
+  assert response.headers["content-type"] == "image/png"
+
+
 def test_serve_chat_media_uses_safe_raster_content_type(client, auth, chat):
   _write_chat_image(chat.id, "media", "photo.jpg", b"jpeg-bytes")
 


### PR DESCRIPTION
## Summary
- serve chat images stored inside nested report directories
- preserve the existing authenticated media-token and path-containment checks
- add regression coverage for nested media paths

## Why
Chat media can be organized into report folders, but the serving route matched only a single filename segment. The files existed and were discovered by the transcript, yet browser requests for nested paths returned 404.

## Tests
- `scripts/wt-pytest.sh backend/tests/test_media.py backend/tests/test_path_utils.py -q` (21 passed)
- `scripts/test.sh --fast` (78 passed)
- `python3 -m py_compile backend/app/routes/media.py`
- live verification: an existing nested chat image returns `200 image/png` after restart