### PR TITLE
Keep the last search when the search dialog reopens

### DIFF
--- a/frontend/src/components/GlobalSearch/GlobalSearch.jsx
+++ b/frontend/src/components/GlobalSearch/GlobalSearch.jsx
@@ -19,6 +19,8 @@ import { searchSnippetPresentation } from '../../lib/searchTermHighlight.js'
 import {
   chatSearchOpenTarget,
   chatSearchResultIsCurrent,
+  readLastSearch,
+  rememberLastSearch,
   searchInstalledApps,
   visibleChatSearchState,
 } from './globalSearchModel.js'
@@ -49,11 +51,14 @@ export default function GlobalSearch({ onClose, onOpenTarget }) {
   const dialogRef = useRef(null)
   const inputRef = useRef(null)
   const chatSearchControllerRef = useRef(null)
-  const latestQueryRef = useRef('')
-  const [query, setQuery] = useState('')
-  const [chatState, setChatState] = useState({
-    query: '', status: 'idle', results: [],
-  })
+  // Reopening restores the owner's last search (see rememberLastSearch), so the
+  // in-flight-result guard has to start from that same term rather than '' —
+  // otherwise clicking a restored result before the revalidating fetch lands
+  // would be discarded as stale.
+  const restored = useRef(readLastSearch()).current
+  const latestQueryRef = useRef(restored.query.trim())
+  const [query, setQuery] = useState(restored.query)
+  const [chatState, setChatState] = useState(restored.chatState)
   const appsQuery = appQueries.list.useQuery()
 
   useDialogFocus({
@@ -61,6 +66,17 @@ export default function GlobalSearch({ onClose, onOpenTarget }) {
     initialFocusRef: inputRef,
     onClose,
   })
+
+  // A restored term is a starting point, not something to edit around: select
+  // it so the next keystroke replaces it, exactly like reopening a browser's
+  // find bar. Runs once, after useDialogFocus has moved focus to the input.
+  useEffect(() => {
+    if (restored.query) inputRef.current?.select()
+  }, [restored.query])
+
+  useEffect(() => {
+    rememberLastSearch(query, chatState)
+  }, [query, chatState])
 
   useEffect(() => {
     const normalizedQuery = query.trim()
@@ -74,7 +90,16 @@ export default function GlobalSearch({ onClose, onOpenTarget }) {
 
     const controller = new AbortController()
     chatSearchControllerRef.current = controller
-    setChatState({ query: normalizedQuery, status: 'loading', results: [] })
+    // Reopening re-runs the query so a chat renamed, added, or deleted since
+    // last time is reflected. Keep the restored results on screen while that
+    // happens: blanking them to "Searching chats…" would undo the point of
+    // restoring them. A genuinely new term has no settled results to hold, so
+    // it still shows the loading state.
+    setChatState(previous => (
+      previous.query === normalizedQuery && previous.status === 'ready'
+        ? previous
+        : { query: normalizedQuery, status: 'loading', results: [] }
+    ))
     const timer = window.setTimeout(async () => {
       try {
         const response = await api.chats.search(normalizedQuery, {

--- a/frontend/src/components/GlobalSearch/__tests__/globalSearchModel.test.js
+++ b/frontend/src/components/GlobalSearch/__tests__/globalSearchModel.test.js
@@ -4,6 +4,9 @@ import {
   appManifestSearchDocument,
   chatSearchOpenTarget,
   chatSearchResultIsCurrent,
+  clearLastSearch,
+  readLastSearch,
+  rememberLastSearch,
   searchInstalledApps,
   visibleChatSearchState,
 } from '../globalSearchModel.js'
@@ -106,4 +109,44 @@ test('chat destinations focus either the matched row or the ordinary composer', 
     chatId: 'chat-row',
     focusComposer: false,
   })
+})
+
+test('the last search survives a close/reopen so the term does not have to be retyped', () => {
+  clearLastSearch()
+  assert.deepEqual(readLastSearch(), {
+    query: '',
+    chatState: { query: '', status: 'idle', results: [] },
+  })
+
+  const settled = {
+    query: 'password',
+    status: 'ready',
+    results: [{ id: 'chat-1', searchQuery: 'password' }],
+  }
+  rememberLastSearch('password', settled)
+
+  // What a reopened dialog seeds its state from: the term AND the results the
+  // owner was looking at, so the list is on screen before any refetch lands.
+  const restored = readLastSearch()
+  assert.equal(restored.query, 'password')
+  assert.equal(restored.chatState.status, 'ready')
+  assert.deepEqual(restored.chatState.results, settled.results)
+  assert.deepEqual(visibleChatSearchState(restored.chatState, restored.query), settled)
+  // The restored rows stay clickable: the staleness guard keys off the term the
+  // dialog reopens with, not a fresh empty one.
+  assert.equal(chatSearchResultIsCurrent(restored.chatState.results[0], restored.query), true)
+
+  clearLastSearch()
+})
+
+test('an unsettled search is not restored, only its term', () => {
+  clearLastSearch()
+  for (const status of ['loading', 'error', 'idle']) {
+    rememberLastSearch('half typed', { query: 'half typed', status, results: [] })
+    const restored = readLastSearch()
+    assert.equal(restored.query, 'half typed', `${status} keeps the term`)
+    assert.equal(restored.chatState.status, 'idle', `${status} is not replayed`)
+    assert.deepEqual(restored.chatState.results, [])
+  }
+  clearLastSearch()
 })

--- a/frontend/src/components/GlobalSearch/globalSearchModel.js
+++ b/frontend/src/components/GlobalSearch/globalSearchModel.js
@@ -94,6 +94,35 @@ export function searchInstalledApps(apps, query, limit = 8) {
     .map(({ score: _score, ...result }) => result)
 }
 
+// The dialog unmounts on close (NotificationCenter renders it behind
+// `searchOpen &&`), so component state cannot survive a reopen. The owner's
+// last search lives here instead: type a term, open a result, reopen search,
+// and the term and its results are still there rather than a blank field.
+//
+// Memory-only on purpose. It is owner-authored content, so it must not outlive
+// the session — and because nothing is written to storage, a reload or logout
+// drops it without any explicit clean-up path to keep correct.
+const IDLE_CHAT_STATE = { query: '', status: 'idle', results: [] }
+let lastSearch = { query: '', chatState: IDLE_CHAT_STATE }
+
+export function readLastSearch() {
+  return lastSearch
+}
+
+// Only a settled result set is worth restoring: replaying a `loading` or
+// `error` snapshot would reopen the dialog into a state the owner never saw
+// settle, and the mount effect re-runs the query anyway.
+export function rememberLastSearch(query, chatState) {
+  lastSearch = {
+    query: String(query || ''),
+    chatState: chatState?.status === 'ready' ? chatState : IDLE_CHAT_STATE,
+  }
+}
+
+export function clearLastSearch() {
+  lastSearch = { query: '', chatState: IDLE_CHAT_STATE }
+}
+
 export function visibleChatSearchState(chatState, query) {
   const normalizedQuery = String(query || '').trim()
   if (chatState?.query === normalizedQuery) return chatState


### PR DESCRIPTION
The search dialog unmounts when it closes, so its query and results go with it. Opening a result and reopening search lands on an empty field, and the same term has to be typed again to get back to the same list — which is exactly the moment you want it, since scanning several matches means reopening between each one.

**What changes**

The last settled search is kept in `globalSearchModel` beside the rest of this dialog's search-state rules, and the dialog seeds its initial state from it. Reopening shows the previous term and its results straight away.

- The restored term is **selected on open**, so the next keystroke replaces it outright. It is a starting point, not something to clear first — the same behaviour as reopening a browser's find bar.
- `latestQueryRef` starts from the restored term rather than `''`, so a restored row stays clickable: `chatSearchResultIsCurrent` would otherwise discard it as stale until the revalidating fetch lands.
- Reopening still re-runs the query, so a chat renamed, added, or deleted since last time is reflected. The restored results stay on screen while that happens instead of blanking to "Searching chats…", which would undo the point of restoring them. A genuinely new term has no settled results to hold, so it still shows the loading state.
- Only a `ready` snapshot is restored. A `loading` or `error` state keeps its term and nothing else, so the dialog never reopens into a state that was never seen to settle.

**Scope**

Memory-only and session-scoped, held in the module rather than any storage. The term is owner-authored content, so it should not outlive the session; keeping it in memory means a reload or logout drops it with no clean-up path that has to stay correct. Nothing is added to the network path, and the debounce, abort, and staleness handling are untouched.

**Tests**

Two cases in `globalSearchModel.test.js` cover what a reopened dialog seeds from — the term, the settled results, that `visibleChatSearchState` accepts the pair, and that a restored row still passes the staleness guard — plus that `loading`, `error`, and `idle` snapshots are not replayed.

Note: #637 is open against these same three files, but changes only user-facing wording in different regions; the two should not conflict meaningfully.

Co-authored-by: Möbius Agent <mobius-agent@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)