### PR TITLE
Route runtime capability acceptance through the live server

### DIFF
--- a/backend/app/app_capability_acceptance.py
+++ b/backend/app/app_capability_acceptance.py
@@ -3,8 +3,9 @@
 Store installs retain their reviewed package contract when local source is
 applied.  This module owns the narrower exception: after an owner reviews the
 normalized runtime declaration in that source, it can replace only the
-contract's ``runtime`` field.  The acceptance digest identifies those
-normalized runtime semantics, not unrelated manifest bytes or App fields.
+contract's ``runtime`` field.  The acceptance digest covers the entire
+resulting contract, so a Store update that changes the reviewed baseline
+between review and acceptance rejects instead of silently re-granting.
 """
 
 from __future__ import annotations
@@ -16,7 +17,7 @@ from pathlib import Path
 
 from sqlalchemy.orm import Session
 
-from app import models, timeutil
+from app import models, source_dirs
 from app.app_capabilities import (
   capability_digest,
   contract_with_runtime_capabilities,
@@ -39,12 +40,12 @@ def _manifest_for(app: models.App) -> dict:
   """Read this App's manifest without following source or manifest symlinks."""
   if not app.source_dir:
     raise CapabilityAcceptanceError("App has no local source directory.")
-  data_dir = Path(get_settings().data_dir).resolve()
-  apps_root = (data_dir / "apps").resolve()
+  root = source_dirs.apps_root(get_settings().data_dir)
   # Resolving the stored path would turn a symlink to a sibling app into an
-  # apparently valid direct child and lose the Store app's source identity.
+  # apparently valid direct child and lose the Store app's source identity,
+  # so this stays lexical where source_dirs.source_dir_kind resolves.
   source_dir = Path(os.path.abspath(app.source_dir))
-  if source_dir.parent != apps_root or source_dir.name.isdigit():
+  if source_dir.parent != root or source_dir.name.isdigit():
     raise CapabilityAcceptanceError(
       "App source directory is outside the reviewed apps root."
     )
@@ -56,7 +57,7 @@ def _manifest_for(app: models.App) -> dict:
       os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
       | getattr(os, "O_CLOEXEC", 0)
     )
-    root_descriptor = os.open(apps_root, directory_flags)
+    root_descriptor = os.open(root, directory_flags)
     try:
       source_descriptor = os.open(
         source_dir.name,
@@ -112,7 +113,6 @@ def _review(
 ) -> tuple[models.App, dict, dict]:
   app = (
     db.query(models.App)
-    .populate_existing()
     .filter(models.App.id == app_id, models.App.deleted_at.is_(None))
     .one_or_none()
   )
@@ -135,16 +135,17 @@ def _review(
     raise CapabilityAcceptanceError(
       "The installed app has no reviewed capability contract."
     )
-  candidate_runtime = candidate.get("runtime", {})
   report = {
     "app_id": app.id,
     "app": app.name,
     "current_runtime": app.capability_contract.get("runtime", {}),
-    "candidate_runtime": candidate_runtime,
+    "candidate_runtime": candidate.get("runtime", {}),
     "diff": diff_contracts(app.capability_contract, candidate),
-    # Approval is intentionally scoped to the normalized declaration displayed
-    # above. Formatting and unrelated package facts do not change its meaning.
-    "accept_digest": capability_digest(candidate_runtime),
+    # The digest covers the whole contract this acceptance would store, not
+    # just the runtime projection.  A Store update that lands between review
+    # and acceptance changes the baseline the owner compared against, so the
+    # digest must stop matching and send them back to a fresh review.
+    "accept_digest": capability_digest(candidate),
   }
   return app, candidate, report
 
@@ -162,47 +163,21 @@ def accept_local_runtime_capabilities(
 ) -> dict:
   """Commit a reviewed runtime declaration and notify live app consumers.
 
-  The App-row revision compare-and-swap preserves any concurrent update.  The
-  event is emitted only after the replacement is durable, so a shell refetch
-  can never observe a notification for rolled-back state.
+  The digest is rebuilt from the current App row, so any change to the
+  reviewed contract since the owner looked at it rejects here.  The event is
+  emitted only after the replacement is durable, so a shell refetch can never
+  observe a notification for state that never committed.
   """
-  try:
-    app, candidate, report = _review(db, app_id)
-    if accept_digest != report["accept_digest"]:
-      raise CapabilityAcceptanceError(
-        "Acceptance digest does not match the current local runtime "
-        "capability declaration; review again.",
-        status_code=409,
-      )
+  app, candidate, report = _review(db, app_id)
+  if accept_digest != report["accept_digest"]:
+    raise CapabilityAcceptanceError(
+      "Acceptance digest does not match the current local runtime "
+      "capability declaration; review again.",
+      status_code=409,
+    )
 
-    snapshot_updated_at = app.updated_at
-    current_updated_at = models.App.updated_at
-    revision_match = (
-      current_updated_at.is_(None)
-      if snapshot_updated_at is None
-      else current_updated_at == snapshot_updated_at
-    )
-    changed = (
-      db.query(models.App)
-      .filter(
-        models.App.id == app.id,
-        models.App.deleted_at.is_(None),
-        revision_match,
-      )
-      .update({
-        models.App.capability_contract: candidate,
-        models.App.updated_at: timeutil.now_naive_utc(),
-      }, synchronize_session=False)
-    )
-    if changed != 1:
-      raise CapabilityAcceptanceError(
-        "The app changed while capabilities were being accepted; review again.",
-        status_code=409,
-      )
-    db.commit()
-  except Exception:
-    db.rollback()
-    raise
+  app.capability_contract = candidate
+  db.commit()
 
   get_system_broadcast().publish({
     "type": "app_updated",

--- a/backend/app/app_capability_acceptance.py
+++ b/backend/app/app_capability_acceptance.py
@@ -1,0 +1,211 @@
+"""Review and accept locally declared runtime capabilities for Store apps.
+
+Store installs retain their reviewed package contract when local source is
+applied.  This module owns the narrower exception: after an owner reviews the
+normalized runtime declaration in that source, it can replace only the
+contract's ``runtime`` field.  The acceptance digest identifies those
+normalized runtime semantics, not unrelated manifest bytes or App fields.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+
+from sqlalchemy.orm import Session
+
+from app import models, timeutil
+from app.app_capabilities import (
+  capability_digest,
+  contract_with_runtime_capabilities,
+  diff_contracts,
+)
+from app.broadcast import get_system_broadcast
+from app.config import get_settings
+from app.manifest_contract import MANIFEST_MAX_BYTES
+
+
+class CapabilityAcceptanceError(ValueError):
+  """A review or acceptance rejection safe to return to an owner caller."""
+
+  def __init__(self, message: str, *, status_code: int = 422):
+    super().__init__(message)
+    self.status_code = status_code
+
+
+def _manifest_for(app: models.App) -> dict:
+  """Read this App's manifest without following source or manifest symlinks."""
+  if not app.source_dir:
+    raise CapabilityAcceptanceError("App has no local source directory.")
+  data_dir = Path(get_settings().data_dir).resolve()
+  apps_root = (data_dir / "apps").resolve()
+  # Resolving the stored path would turn a symlink to a sibling app into an
+  # apparently valid direct child and lose the Store app's source identity.
+  source_dir = Path(os.path.abspath(app.source_dir))
+  if source_dir.parent != apps_root or source_dir.name.isdigit():
+    raise CapabilityAcceptanceError(
+      "App source directory is outside the reviewed apps root."
+    )
+
+  root_descriptor = None
+  source_descriptor = None
+  try:
+    directory_flags = (
+      os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+      | getattr(os, "O_CLOEXEC", 0)
+    )
+    root_descriptor = os.open(apps_root, directory_flags)
+    try:
+      source_descriptor = os.open(
+        source_dir.name,
+        directory_flags,
+        dir_fd=root_descriptor,
+      )
+    except OSError as exc:
+      raise CapabilityAcceptanceError(
+        "App source directory must be a direct, regular directory under the apps root."
+      ) from exc
+    try:
+      descriptor = os.open(
+        "mobius.json",
+        os.O_RDONLY | os.O_NONBLOCK
+        | getattr(os, "O_CLOEXEC", 0) | os.O_NOFOLLOW,
+        dir_fd=source_descriptor,
+      )
+    except OSError as exc:
+      raise CapabilityAcceptanceError(
+        "mobius.json must be a regular file inside the app source."
+      ) from exc
+    with os.fdopen(descriptor, "rb") as manifest_file:
+      if not stat.S_ISREG(os.fstat(manifest_file.fileno()).st_mode):
+        raise CapabilityAcceptanceError(
+          "mobius.json must be a regular file inside the app source."
+        )
+      raw = manifest_file.read(MANIFEST_MAX_BYTES + 1)
+      if len(raw) > MANIFEST_MAX_BYTES:
+        raise CapabilityAcceptanceError(
+          f"mobius.json exceeds the {MANIFEST_MAX_BYTES}-byte limit."
+        )
+      value = json.loads(raw.decode("utf-8"))
+  except CapabilityAcceptanceError:
+    raise
+  except (OSError, UnicodeDecodeError, ValueError) as exc:
+    raise CapabilityAcceptanceError(
+      f"Could not read a valid mobius.json: {exc}"
+    ) from exc
+  finally:
+    if source_descriptor is not None:
+      os.close(source_descriptor)
+    if root_descriptor is not None:
+      os.close(root_descriptor)
+
+  if not isinstance(value, dict):
+    raise CapabilityAcceptanceError("mobius.json must contain an object.")
+  return value
+
+
+def _review(
+  db: Session,
+  app_id: int,
+) -> tuple[models.App, dict, dict]:
+  app = (
+    db.query(models.App)
+    .populate_existing()
+    .filter(models.App.id == app_id, models.App.deleted_at.is_(None))
+    .one_or_none()
+  )
+  if app is None:
+    raise CapabilityAcceptanceError("App not found.", status_code=404)
+  if app.manifest_url is None:
+    raise CapabilityAcceptanceError(
+      "This operation is only for Store-installed apps."
+    )
+
+  manifest = _manifest_for(app)
+  try:
+    candidate = contract_with_runtime_capabilities(
+      app.capability_contract,
+      manifest,
+    )
+  except ValueError as exc:
+    raise CapabilityAcceptanceError(str(exc)) from exc
+  if candidate is None:
+    raise CapabilityAcceptanceError(
+      "The installed app has no reviewed capability contract."
+    )
+  candidate_runtime = candidate.get("runtime", {})
+  report = {
+    "app_id": app.id,
+    "app": app.name,
+    "current_runtime": app.capability_contract.get("runtime", {}),
+    "candidate_runtime": candidate_runtime,
+    "diff": diff_contracts(app.capability_contract, candidate),
+    # Approval is intentionally scoped to the normalized declaration displayed
+    # above. Formatting and unrelated package facts do not change its meaning.
+    "accept_digest": capability_digest(candidate_runtime),
+  }
+  return app, candidate, report
+
+
+def review_local_runtime_capabilities(db: Session, app_id: int) -> dict:
+  """Return the current, normalized local runtime capability review."""
+  _, _, report = _review(db, app_id)
+  return {**report, "status": "review"}
+
+
+def accept_local_runtime_capabilities(
+  db: Session,
+  app_id: int,
+  accept_digest: str,
+) -> dict:
+  """Commit a reviewed runtime declaration and notify live app consumers.
+
+  The App-row revision compare-and-swap preserves any concurrent update.  The
+  event is emitted only after the replacement is durable, so a shell refetch
+  can never observe a notification for rolled-back state.
+  """
+  try:
+    app, candidate, report = _review(db, app_id)
+    if accept_digest != report["accept_digest"]:
+      raise CapabilityAcceptanceError(
+        "Acceptance digest does not match the current local runtime "
+        "capability declaration; review again.",
+        status_code=409,
+      )
+
+    snapshot_updated_at = app.updated_at
+    current_updated_at = models.App.updated_at
+    revision_match = (
+      current_updated_at.is_(None)
+      if snapshot_updated_at is None
+      else current_updated_at == snapshot_updated_at
+    )
+    changed = (
+      db.query(models.App)
+      .filter(
+        models.App.id == app.id,
+        models.App.deleted_at.is_(None),
+        revision_match,
+      )
+      .update({
+        models.App.capability_contract: candidate,
+        models.App.updated_at: timeutil.now_naive_utc(),
+      }, synchronize_session=False)
+    )
+    if changed != 1:
+      raise CapabilityAcceptanceError(
+        "The app changed while capabilities were being accepted; review again.",
+        status_code=409,
+      )
+    db.commit()
+  except Exception:
+    db.rollback()
+    raise
+
+  get_system_broadcast().publish({
+    "type": "app_updated",
+    "appId": str(app.id),
+  })
+  return {**report, "status": "accepted"}

--- a/backend/app/routes/apps.py
+++ b/backend/app/routes/apps.py
@@ -1635,10 +1635,6 @@ class RuntimeCapabilityAcceptanceRequest(BaseModel):
   )
 
 
-def _runtime_capability_error(exc) -> HTTPException:
-  return HTTPException(status_code=exc.status_code, detail=str(exc))
-
-
 @router.get("/{app_id}/runtime-capabilities")
 def review_local_runtime_capabilities(
   app_id: int,
@@ -1651,7 +1647,7 @@ def review_local_runtime_capabilities(
       db, app_id,
     )
   except app_capability_acceptance.CapabilityAcceptanceError as exc:
-    raise _runtime_capability_error(exc) from exc
+    raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
 
 @router.post(
@@ -1670,7 +1666,7 @@ def accept_local_runtime_capabilities(
       db, app_id, body.accept_digest,
     )
   except app_capability_acceptance.CapabilityAcceptanceError as exc:
-    raise _runtime_capability_error(exc) from exc
+    raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
 
 @router.get("/{app_id}", response_model=schemas.AppOut)

--- a/backend/app/routes/apps.py
+++ b/backend/app/routes/apps.py
@@ -21,8 +21,8 @@ from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session, defer
 
 from app import (
-  activity, app_activity, app_apply, app_git, app_jobs, app_preview,
-  app_recency, fs_locks, icon_cache,
+  activity, app_activity, app_apply, app_capability_acceptance, app_git,
+  app_jobs, app_preview, app_recency, fs_locks, icon_cache,
   models, providers, schemas,
   source_dirs,
 )
@@ -1625,6 +1625,52 @@ async def resolve_app_update(
       **reconciliation.as_dict(),
     ),
   )
+
+
+class RuntimeCapabilityAcceptanceRequest(BaseModel):
+  accept_digest: str = Field(
+    min_length=64,
+    max_length=64,
+    pattern=r"^[0-9a-f]{64}$",
+  )
+
+
+def _runtime_capability_error(exc) -> HTTPException:
+  return HTTPException(status_code=exc.status_code, detail=str(exc))
+
+
+@router.get("/{app_id}/runtime-capabilities")
+def review_local_runtime_capabilities(
+  app_id: int,
+  db: Session = Depends(get_db),
+  _: models.Owner = Depends(get_current_owner),
+):
+  """Review the normalized runtime declaration in a Store app's local source."""
+  try:
+    return app_capability_acceptance.review_local_runtime_capabilities(
+      db, app_id,
+    )
+  except app_capability_acceptance.CapabilityAcceptanceError as exc:
+    raise _runtime_capability_error(exc) from exc
+
+
+@router.post(
+  "/{app_id}/runtime-capabilities/accept",
+  dependencies=[Depends(reject_cross_site)],
+)
+def accept_local_runtime_capabilities(
+  app_id: int,
+  body: RuntimeCapabilityAcceptanceRequest,
+  db: Session = Depends(get_db),
+  _: models.Owner = Depends(get_current_owner),
+):
+  """Accept one reviewed declaration through the live server lifecycle."""
+  try:
+    return app_capability_acceptance.accept_local_runtime_capabilities(
+      db, app_id, body.accept_digest,
+    )
+  except app_capability_acceptance.CapabilityAcceptanceError as exc:
+    raise _runtime_capability_error(exc) from exc
 
 
 @router.get("/{app_id}", response_model=schemas.AppOut)

--- a/backend/scripts/accept_local_runtime_capabilities.py
+++ b/backend/scripts/accept_local_runtime_capabilities.py
@@ -1,5 +1,17 @@
 #!/usr/bin/env python3
-"""Review or accept a Store app's local runtime declaration via Möbius."""
+"""Review or accept a Store app's local runtime declaration via Möbius.
+
+The running server owns the App row and the ``app_updated`` broadcast, so this
+stays a thin client over the owner API rather than touching the database.
+
+Environment:
+  AGENT_TOKEN    required; owner bearer token for the Möbius API.
+  API_BASE_URL   backend base URL (default http://localhost:8000).
+
+Usage:
+  accept_local_runtime_capabilities.py <app-id>
+  accept_local_runtime_capabilities.py <app-id> --accept-digest <sha256>
+"""
 
 from __future__ import annotations
 

--- a/backend/scripts/accept_local_runtime_capabilities.py
+++ b/backend/scripts/accept_local_runtime_capabilities.py
@@ -1,139 +1,53 @@
-"""Review or accept local runtime capabilities for one Store-installed app.
-
-Ordinary source apply deliberately compiles local edits without widening the
-Store-reviewed permission contract.  When the owner explicitly approves the
-precise local runtime declaration, this command preserves every other reviewed
-fact and replaces only ``capability_contract.runtime``.  Acceptance requires
-the digest printed by a prior review, binding the write to the exact manifest
-bytes that were inspected.
-
-Run from ``/data/platform/backend``:
-
-  python -m scripts.accept_local_runtime_capabilities --app-id 61
-  python -m scripts.accept_local_runtime_capabilities --app-id 61 \
-    --accept-digest <digest-from-review>
-"""
+#!/usr/bin/env python3
+"""Review or accept a Store app's local runtime declaration via Möbius."""
 
 from __future__ import annotations
 
 import argparse
 import json
 import os
-import stat
-from pathlib import Path
-
-from app import models, timeutil
-from app.app_capabilities import (
-  capability_digest,
-  contract_with_runtime_capabilities,
-  diff_contracts,
-)
-from app.config import get_settings
-from app.database import SessionLocal
+import urllib.error
+import urllib.request
 
 
-def _manifest_for(app: models.App) -> dict:
-  if not app.source_dir:
-    raise ValueError("App has no local source directory.")
-  data_dir = Path(get_settings().data_dir).resolve()
-  apps_root = (data_dir / "apps").resolve()
-  # Validate the stored path lexically before touching the filesystem. Resolving
-  # it would turn a symlink to a sibling app into an apparently valid direct
-  # child and lose the Store app's source identity.
-  source_dir = Path(os.path.abspath(app.source_dir))
-  if source_dir.parent != apps_root or source_dir.name.isdigit():
-    raise ValueError("App source directory is outside the reviewed apps root.")
-  root_descriptor = None
-  source_descriptor = None
+def _request(
+  base_url: str,
+  token: str,
+  app_id: int,
+  accept_digest: str | None,
+) -> dict:
+  suffix = f"/api/apps/{app_id}/runtime-capabilities"
+  data = None
+  method = "GET"
+  headers = {"Authorization": f"Bearer {token}"}
+  if accept_digest is not None:
+    suffix += "/accept"
+    data = json.dumps({"accept_digest": accept_digest}).encode()
+    method = "POST"
+    headers["Content-Type"] = "application/json"
+  request = urllib.request.Request(
+    f"{base_url.rstrip('/')}{suffix}",
+    data=data,
+    headers=headers,
+    method=method,
+  )
   try:
-    directory_flags = (
-      os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
-      | getattr(os, "O_CLOEXEC", 0)
-    )
-    root_descriptor = os.open(apps_root, directory_flags)
+    with urllib.request.urlopen(request, timeout=30) as response:
+      result = json.loads(response.read())
+  except urllib.error.HTTPError as exc:
+    body = exc.read().decode(errors="replace")
     try:
-      source_descriptor = os.open(
-        source_dir.name,
-        directory_flags,
-        dir_fd=root_descriptor,
-      )
-    except OSError as exc:
-      raise ValueError(
-        "App source directory must be a direct, regular directory under the apps root."
-      ) from exc
-    try:
-      descriptor = os.open(
-        "mobius.json",
-        os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | os.O_NOFOLLOW,
-        dir_fd=source_descriptor,
-      )
-    except OSError as exc:
-      raise ValueError(
-        "mobius.json must be a regular file inside the app source."
-      ) from exc
-    with os.fdopen(descriptor, "r", encoding="utf-8") as manifest_file:
-      if not stat.S_ISREG(os.fstat(manifest_file.fileno()).st_mode):
-        raise ValueError("mobius.json must be a regular file inside the app source.")
-      value = json.load(manifest_file)
-  except ValueError:
-    raise
-  except (OSError, json.JSONDecodeError) as exc:
-    raise ValueError(f"Could not read a valid mobius.json: {exc}") from exc
-  finally:
-    if source_descriptor is not None:
-      os.close(source_descriptor)
-    if root_descriptor is not None:
-      os.close(root_descriptor)
-  if not isinstance(value, dict):
-    raise ValueError("mobius.json must contain an object.")
-  return value
-
-
-def review(app: models.App) -> tuple[dict, dict]:
-  if app.manifest_url is None:
-    raise ValueError("This command is only for Store-installed apps.")
-  candidate = contract_with_runtime_capabilities(
-    app.capability_contract,
-    _manifest_for(app),
-  )
-  if candidate is None:
-    raise ValueError("The installed app has no reviewed capability contract.")
-  return candidate, {
-    "app_id": app.id,
-    "app": app.name,
-    "current_runtime": (app.capability_contract or {}).get("runtime", {}),
-    "candidate_runtime": candidate.get("runtime", {}),
-    "diff": diff_contracts(app.capability_contract, candidate),
-    "accept_digest": capability_digest(candidate),
-  }
-
-
-def _accept(db, app: models.App, candidate: dict, report: dict) -> None:
-  """Commit only if the reviewed App row is still the current revision."""
-  snapshot_updated_at = app.updated_at
-  current = models.App.updated_at
-  revision_match = (
-    current.is_(None) if snapshot_updated_at is None
-    else current == snapshot_updated_at
-  )
-  changed = (
-    db.query(models.App)
-    .filter(
-      models.App.id == app.id,
-      models.App.deleted_at.is_(None),
-      revision_match,
-    )
-    .update({
-      models.App.capability_contract: candidate,
-      models.App.updated_at: timeutil.now_naive_utc(),
-    }, synchronize_session=False)
-  )
-  if changed != 1:
-    raise ValueError(
-      "The app changed while capabilities were being accepted; review again."
-    )
-  db.commit()
-  report["status"] = "accepted"
+      detail = json.loads(body).get("detail", body)
+    except json.JSONDecodeError:
+      detail = body
+    raise ValueError(str(detail)) from exc
+  except urllib.error.URLError as exc:
+    raise ValueError(f"Could not reach the Möbius server: {exc.reason}") from exc
+  except json.JSONDecodeError as exc:
+    raise ValueError("Möbius returned an invalid capability review.") from exc
+  if not isinstance(result, dict):
+    raise ValueError("Möbius returned an invalid capability review.")
+  return result
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -142,34 +56,15 @@ def main(argv: list[str] | None = None) -> None:
   parser.add_argument("--accept-digest")
   args = parser.parse_args(argv)
 
-  db = SessionLocal()
+  token = os.environ.get("AGENT_TOKEN")
+  if not token:
+    parser.exit(2, "error: AGENT_TOKEN environment variable is not set.\n")
+  base_url = os.environ.get("API_BASE_URL", "http://localhost:8000")
   try:
-    app = (
-      db.query(models.App)
-      .filter(models.App.id == args.app_id, models.App.deleted_at.is_(None))
-      .one_or_none()
-    )
-    if app is None:
-      raise ValueError("App not found.")
-    candidate, report = review(app)
-    if args.accept_digest is None:
-      report["status"] = "review"
-      print(json.dumps(report, ensure_ascii=False, sort_keys=True))
-      return
-    if args.accept_digest != report["accept_digest"]:
-      raise ValueError(
-        "Acceptance digest does not match the current local manifest; review again."
-      )
-    _accept(db, app, candidate, report)
-    print(json.dumps(report, ensure_ascii=False, sort_keys=True))
+    report = _request(base_url, token, args.app_id, args.accept_digest)
   except ValueError as exc:
-    db.rollback()
     parser.exit(2, f"error: {exc}\n")
-  except Exception:
-    db.rollback()
-    raise
-  finally:
-    db.close()
+  print(json.dumps(report, ensure_ascii=False, sort_keys=True))
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_accept_local_runtime_capabilities.py
+++ b/backend/tests/test_accept_local_runtime_capabilities.py
@@ -1,13 +1,18 @@
-"""Explicit local capability acceptance is bound, confined, and atomic."""
+"""Local runtime capability acceptance is explicit, confined, and atomic."""
 
+from copy import deepcopy
 import json
+import os
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
+from app import app_capability_acceptance as acceptance
 from app import models, timeutil
 from app.app_capabilities import contract_and_digest
 from app.database import SessionLocal
+from app.manifest_contract import MANIFEST_MAX_BYTES
 from scripts import accept_local_runtime_capabilities as command
 from test_app_fixtures import create_local_app
 
@@ -35,65 +40,211 @@ def _store_app(client, auth, db):
   return app
 
 
-def _run(args, capsys):
-  command.main(args)
-  return json.loads(capsys.readouterr().out)
+def _review(client, auth, app_id):
+  response = client.get(
+    f"/api/apps/{app_id}/runtime-capabilities",
+    headers=auth,
+  )
+  assert response.status_code == 200, response.text
+  return response.json()
 
 
-def test_review_and_accept_round_trip_preserves_store_contract(client, auth, db, capsys):
+def _accept(client, auth, app_id, digest):
+  return client.post(
+    f"/api/apps/{app_id}/runtime-capabilities/accept",
+    headers=auth,
+    json={"accept_digest": digest},
+  )
+
+
+def test_server_review_reports_normalized_runtime_declaration(
+  client, auth, db,
+):
   app = _store_app(client, auth, db)
-  before = app.capability_contract
 
-  report = _run(["--app-id", str(app.id)], capsys)
+  report = _review(client, auth, app.id)
+
   assert report["status"] == "review"
-  assert "media.speech" in report["candidate_runtime"]
+  assert report["candidate_runtime"]["media.speech"]["limits"] == {
+    "max_text_chars": 50_000,
+  }
+  assert len(report["accept_digest"]) == 64
 
-  accepted = _run([
-    "--app-id", str(app.id), "--accept-digest", report["accept_digest"],
-  ], capsys)
+
+def test_server_acceptance_preserves_contract_and_publishes_after_commit(
+  client, auth, db,
+):
+  app = _store_app(client, auth, db)
+  before = deepcopy(app.capability_contract)
+  report = _review(client, auth, app.id)
+
+  published = []
+
+  class ObservingBroadcast:
+    def publish(self, event):
+      verifier = SessionLocal()
+      try:
+        stored = verifier.get(models.App, app.id)
+        published.append((event, stored.capability_contract["runtime"]))
+      finally:
+        verifier.close()
+
+  with patch.object(
+    acceptance,
+    "get_system_broadcast",
+    return_value=ObservingBroadcast(),
+  ):
+    response = _accept(client, auth, app.id, report["accept_digest"])
+
+  assert response.status_code == 200, response.text
+  accepted = response.json()
   assert accepted["status"] == "accepted"
+  assert published == [({
+    "type": "app_updated",
+    "appId": str(app.id),
+  }, report["candidate_runtime"])]
   db.expire_all()
   stored = db.get(models.App, app.id).capability_contract
   assert stored["runtime"] == report["candidate_runtime"]
-  assert {k: v for k, v in stored.items() if k != "runtime"} == {
-    k: v for k, v in before.items() if k != "runtime"
+  assert {key: value for key, value in stored.items() if key != "runtime"} == {
+    key: value for key, value in before.items() if key != "runtime"
   }
 
 
-def test_digest_mismatch_is_a_concise_error_and_does_not_write(
-  client, auth, db, capsys,
+def test_digest_approves_only_the_normalized_runtime_declaration(
+  client, auth, db,
 ):
   app = _store_app(client, auth, db)
-  before = app.capability_contract
-  with pytest.raises(SystemExit) as exc:
-    command.main([
-      "--app-id", str(app.id), "--accept-digest", "0" * 64,
-    ])
-  assert exc.value.code == 2
-  assert "review again" in capsys.readouterr().err
+  report = _review(client, auth, app.id)
+
+  writer = SessionLocal()
+  try:
+    current = writer.get(models.App, app.id)
+    revised_contract = deepcopy(current.capability_contract)
+    revised_contract["agent"]["skills"] = ["newly-reviewed-skill.md"]
+    current.capability_contract = revised_contract
+    writer.commit()
+  finally:
+    writer.close()
+
+  manifest_path = Path(app.source_dir) / "mobius.json"
+  manifest = json.loads(manifest_path.read_text())
+  manifest["description"] = "An unrelated local description edit."
+  manifest["capabilities"]["media.speech"]["limits"] = {
+    "max_text_chars": 50_000,
+  }
+  manifest_path.write_text(json.dumps(manifest, indent=2))
+
+  response = _accept(client, auth, app.id, report["accept_digest"])
+
+  assert response.status_code == 200, response.text
+  accepted = response.json()
+  assert accepted["status"] == "accepted"
+  db.expire_all()
+  stored = db.get(models.App, app.id).capability_contract
+  assert stored["agent"]["skills"] == ["newly-reviewed-skill.md"]
+  assert stored["runtime"] == report["candidate_runtime"]
+
+
+def test_semantic_runtime_change_rejects_prior_digest_without_write_or_event(
+  client, auth, db,
+):
+  app = _store_app(client, auth, db)
+  before = deepcopy(app.capability_contract)
+  report = _review(client, auth, app.id)
+  manifest_path = Path(app.source_dir) / "mobius.json"
+  manifest = json.loads(manifest_path.read_text())
+  manifest["capabilities"]["media.speech"]["reason"] = "A different use."
+  manifest_path.write_text(json.dumps(manifest))
+
+  with patch.object(acceptance, "get_system_broadcast") as get_broadcast:
+    response = _accept(client, auth, app.id, report["accept_digest"])
+
+  assert response.status_code == 409
+  assert "runtime capability declaration" in response.json()["detail"]
+  get_broadcast.assert_not_called()
   db.expire_all()
   assert db.get(models.App, app.id).capability_contract == before
 
 
+def test_review_returns_invalid_runtime_declarations_as_owner_errors(
+  client, auth, db,
+):
+  app = _store_app(client, auth, db)
+  manifest_path = Path(app.source_dir) / "mobius.json"
+  manifest = json.loads(manifest_path.read_text())
+  manifest["capabilities"] = {"unknown.capability": {"version": 1}}
+  manifest_path.write_text(json.dumps(manifest))
+
+  response = client.get(
+    f"/api/apps/{app.id}/runtime-capabilities", headers=auth,
+  )
+
+  assert response.status_code == 422
+  assert response.json()["detail"] == "Unknown capability `unknown.capability`."
+
+
+@pytest.mark.parametrize(
+  ("manifest_bytes", "detail"),
+  [
+    (b"{\xff}", "valid mobius.json"),
+    (b'{"value":' + b"9" * 5000 + b"}", "valid mobius.json"),
+    (b" " * (MANIFEST_MAX_BYTES + 1), "exceeds"),
+  ],
+)
+def test_review_rejects_unreadable_manifests_with_bounded_owner_errors(
+  client, auth, db, manifest_bytes, detail,
+):
+  app = _store_app(client, auth, db)
+  (Path(app.source_dir) / "mobius.json").write_bytes(manifest_bytes)
+
+  response = client.get(
+    f"/api/apps/{app.id}/runtime-capabilities", headers=auth,
+  )
+
+  assert response.status_code == 422
+  assert detail in response.json()["detail"]
+
+
+def test_review_rejects_a_manifest_fifo_without_blocking(client, auth, db):
+  app = _store_app(client, auth, db)
+  manifest_path = Path(app.source_dir) / "mobius.json"
+  manifest_path.unlink()
+  os.mkfifo(manifest_path)
+
+  response = client.get(
+    f"/api/apps/{app.id}/runtime-capabilities", headers=auth,
+  )
+
+  assert response.status_code == 422
+  assert "regular file" in response.json()["detail"]
+
+
 def test_command_rejects_non_store_apps_and_source_paths_outside_apps_root(
-  client, auth, db, capsys, tmp_path,
+  client, auth, db, tmp_path,
 ):
   app = _store_app(client, auth, db)
   app.manifest_url = None
   db.commit()
-  with pytest.raises(SystemExit):
-    command.main(["--app-id", str(app.id)])
-  assert "only for Store-installed apps" in capsys.readouterr().err
+  response = client.get(
+    f"/api/apps/{app.id}/runtime-capabilities", headers=auth,
+  )
+  assert response.status_code == 422
+  assert "only for Store-installed apps" in response.json()["detail"]
 
   app.manifest_url = "https://store.example/app/mobius.json"
   app.source_dir = str(tmp_path)
   db.commit()
-  with pytest.raises(SystemExit):
-    command.main(["--app-id", str(app.id)])
-  assert "outside the reviewed apps root" in capsys.readouterr().err
+  response = client.get(
+    f"/api/apps/{app.id}/runtime-capabilities", headers=auth,
+  )
+  assert response.status_code == 422
+  assert "outside the reviewed apps root" in response.json()["detail"]
 
 
-def test_manifest_symlink_cannot_escape_the_app_source(client, auth, db, capsys, tmp_path):
+def test_manifest_symlink_cannot_escape_the_app_source(
+  client, auth, db, tmp_path,
+):
   app = _store_app(client, auth, db)
   manifest_path = Path(app.source_dir) / "mobius.json"
   outside = tmp_path / "mobius.json"
@@ -101,13 +252,15 @@ def test_manifest_symlink_cannot_escape_the_app_source(client, auth, db, capsys,
   manifest_path.unlink()
   manifest_path.symlink_to(outside)
 
-  with pytest.raises(SystemExit):
-    command.main(["--app-id", str(app.id)])
-  assert "regular file inside the app source" in capsys.readouterr().err
+  response = client.get(
+    f"/api/apps/{app.id}/runtime-capabilities", headers=auth,
+  )
+  assert response.status_code == 422
+  assert "regular file inside the app source" in response.json()["detail"]
 
 
 def test_source_directory_symlink_cannot_alias_a_sibling_app(
-  client, auth, db, capsys,
+  client, auth, db,
 ):
   app = _store_app(client, auth, db)
   source = Path(app.source_dir)
@@ -115,16 +268,20 @@ def test_source_directory_symlink_cannot_alias_a_sibling_app(
   source.rename(sibling)
   source.symlink_to(sibling, target_is_directory=True)
   try:
-    with pytest.raises(SystemExit):
-      command.main(["--app-id", str(app.id)])
-    assert "direct, regular directory under the apps root" in capsys.readouterr().err
+    response = client.get(
+      f"/api/apps/{app.id}/runtime-capabilities", headers=auth,
+    )
+    assert response.status_code == 422
+    assert "direct, regular directory under the apps root" in (
+      response.json()["detail"]
+    )
   finally:
     source.unlink()
     sibling.rename(source)
 
 
 def test_pinned_source_directory_cannot_escape_during_parent_swap(
-  client, auth, db, capsys, tmp_path, monkeypatch,
+  client, auth, db, tmp_path, monkeypatch,
 ):
   app = _store_app(client, auth, db)
   source = Path(app.source_dir)
@@ -137,7 +294,7 @@ def test_pinned_source_directory_cannot_escape_during_parent_swap(
   }
   (outside / "mobius.json").write_text(json.dumps(outside_manifest))
 
-  real_open = command.os.open
+  real_open = acceptance.os.open
   swapped = False
 
   def swap_before_manifest(path, flags, *args, **kwargs):
@@ -148,9 +305,9 @@ def test_pinned_source_directory_cannot_escape_during_parent_swap(
       source.symlink_to(outside, target_is_directory=True)
     return real_open(path, flags, *args, **kwargs)
 
-  monkeypatch.setattr(command.os, "open", swap_before_manifest)
+  monkeypatch.setattr(acceptance.os, "open", swap_before_manifest)
   try:
-    report = _run(["--app-id", str(app.id)], capsys)
+    report = _review(client, auth, app.id)
     assert swapped is True
     assert "media.speech" in report["candidate_runtime"]
     assert "media.microphone.capture" not in report["candidate_runtime"]
@@ -161,37 +318,52 @@ def test_pinned_source_directory_cannot_escape_during_parent_swap(
       pinned.rename(source)
 
 
-def test_unexpected_failure_rolls_back_the_command_session(
+def test_domain_failure_rolls_back_its_session(
   client, auth, db, monkeypatch,
 ):
   app = _store_app(client, auth, db)
   original_name = app.name
-  digest = command.review(app)[1]["accept_digest"]
+  review_session = SessionLocal()
+  try:
+    report = acceptance.review_local_runtime_capabilities(
+      review_session, app.id,
+    )
+  finally:
+    review_session.close()
+  original_review = acceptance._review
 
-  def fail_after_mutation(session, loaded, candidate, report):
-    loaded.name = "must roll back"
+  def fail_after_mutation(session, app_id):
+    result = original_review(session, app_id)
+    result[0].name = "must roll back"
     session.flush()
     raise RuntimeError("injected failure")
 
-  monkeypatch.setattr(command, "_accept", fail_after_mutation)
+  monkeypatch.setattr(acceptance, "_review", fail_after_mutation)
+  accept_session = SessionLocal()
   with pytest.raises(RuntimeError, match="injected failure"):
-    command.main([
-      "--app-id", str(app.id), "--accept-digest", digest,
-    ])
+    acceptance.accept_local_runtime_capabilities(
+      accept_session, app.id, report["accept_digest"],
+    )
+  accept_session.expire_all()
+  assert accept_session.get(models.App, app.id).name == original_name
+  accept_session.close()
   db.expire_all()
   assert db.get(models.App, app.id).name == original_name
 
 
-def test_concurrent_contract_change_wins_and_acceptance_is_rejected(
-  client, auth, db, capsys, monkeypatch,
+def test_concurrent_app_change_wins_without_publishing(
+  client, auth, db, monkeypatch,
 ):
   app = _store_app(client, auth, db)
-  report = _run(["--app-id", str(app.id)], capsys)
-  original_review = command.review
-  concurrent_contract = {**app.capability_contract, "concurrent_fact": "preserve-me"}
+  report = _review(client, auth, app.id)
+  original_review = acceptance._review
+  concurrent_contract = {
+    **app.capability_contract,
+    "concurrent_fact": "preserve-me",
+  }
 
-  def review_then_concurrent_write(loaded):
-    result = original_review(loaded)
+  def review_then_concurrent_write(session, app_id):
+    result = original_review(session, app_id)
     writer = SessionLocal()
     try:
       changed = writer.get(models.App, app.id)
@@ -202,11 +374,68 @@ def test_concurrent_contract_change_wins_and_acceptance_is_rejected(
       writer.close()
     return result
 
-  monkeypatch.setattr(command, "review", review_then_concurrent_write)
-  with pytest.raises(SystemExit):
-    command.main([
-      "--app-id", str(app.id), "--accept-digest", report["accept_digest"],
-    ])
-  assert "changed while capabilities were being accepted" in capsys.readouterr().err
+  monkeypatch.setattr(acceptance, "_review", review_then_concurrent_write)
+  with patch.object(acceptance, "get_system_broadcast") as get_broadcast:
+    response = _accept(client, auth, app.id, report["accept_digest"])
+
+  assert response.status_code == 409
+  assert "changed while capabilities were being accepted" in response.json()[
+    "detail"
+  ]
+  get_broadcast.assert_not_called()
   db.expire_all()
   assert db.get(models.App, app.id).capability_contract == concurrent_contract
+
+
+def test_acceptance_route_rejects_cross_site_requests(client, auth, db):
+  app = _store_app(client, auth, db)
+  response = client.post(
+    f"/api/apps/{app.id}/runtime-capabilities/accept",
+    headers={**auth, "Sec-Fetch-Site": "cross-site"},
+    json={"accept_digest": "0" * 64},
+  )
+  assert response.status_code == 403
+
+
+def test_command_forwards_review_and_acceptance_to_the_live_server(
+  monkeypatch, capsys,
+):
+  requests = []
+
+  class Response:
+    def __enter__(self):
+      return self
+
+    def __exit__(self, *_):
+      return False
+
+    def read(self):
+      return json.dumps({"status": "ok"}).encode()
+
+  def urlopen(request, timeout):
+    requests.append((request, timeout))
+    return Response()
+
+  monkeypatch.setenv("AGENT_TOKEN", "agent-token")
+  monkeypatch.setenv("API_BASE_URL", "http://mobius.test/")
+  monkeypatch.setattr(command.urllib.request, "urlopen", urlopen)
+
+  command.main(["--app-id", "7"])
+  assert json.loads(capsys.readouterr().out) == {"status": "ok"}
+  command.main(["--app-id", "7", "--accept-digest", "a" * 64])
+  assert json.loads(capsys.readouterr().out) == {"status": "ok"}
+
+  review_request, review_timeout = requests[0]
+  accept_request, accept_timeout = requests[1]
+  assert review_request.full_url == (
+    "http://mobius.test/api/apps/7/runtime-capabilities"
+  )
+  assert review_request.method == "GET"
+  assert review_request.get_header("Authorization") == "Bearer agent-token"
+  assert review_timeout == 30
+  assert accept_request.full_url == (
+    "http://mobius.test/api/apps/7/runtime-capabilities/accept"
+  )
+  assert accept_request.method == "POST"
+  assert json.loads(accept_request.data) == {"accept_digest": "a" * 64}
+  assert accept_timeout == 30

--- a/backend/tests/test_accept_local_runtime_capabilities.py
+++ b/backend/tests/test_accept_local_runtime_capabilities.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 import pytest
 
 from app import app_capability_acceptance as acceptance
-from app import models, timeutil
+from app import models
 from app.app_capabilities import contract_and_digest
 from app.database import SessionLocal
 from app.manifest_contract import MANIFEST_MAX_BYTES
@@ -111,11 +111,39 @@ def test_server_acceptance_preserves_contract_and_publishes_after_commit(
   }
 
 
-def test_digest_approves_only_the_normalized_runtime_declaration(
+def test_cosmetic_manifest_edits_keep_a_reviewed_digest_valid(
   client, auth, db,
 ):
   app = _store_app(client, auth, db)
   report = _review(client, auth, app.id)
+
+  manifest_path = Path(app.source_dir) / "mobius.json"
+  manifest = json.loads(manifest_path.read_text())
+  manifest["description"] = "An unrelated local description edit."
+  manifest_path.write_text(json.dumps(manifest, indent=2))
+
+  response = _accept(client, auth, app.id, report["accept_digest"])
+
+  assert response.status_code == 200, response.text
+  assert response.json()["status"] == "accepted"
+  db.expire_all()
+  stored = db.get(models.App, app.id).capability_contract
+  assert stored["runtime"] == report["candidate_runtime"]
+
+
+def test_store_update_between_review_and_acceptance_rejects_the_digest(
+  client, auth, db,
+):
+  """A changed baseline must send the owner back to a fresh review.
+
+  The reviewed diff is meaningful only against the contract it was computed
+  from.  If a Store update replaces that contract first, accepting the older
+  review would apply a transition the owner never saw.
+  """
+  app = _store_app(client, auth, db)
+  runtime_before = deepcopy(app.capability_contract["runtime"])
+  report = _review(client, auth, app.id)
+  assert report["candidate_runtime"] != runtime_before
 
   writer = SessionLocal()
   try:
@@ -127,23 +155,15 @@ def test_digest_approves_only_the_normalized_runtime_declaration(
   finally:
     writer.close()
 
-  manifest_path = Path(app.source_dir) / "mobius.json"
-  manifest = json.loads(manifest_path.read_text())
-  manifest["description"] = "An unrelated local description edit."
-  manifest["capabilities"]["media.speech"]["limits"] = {
-    "max_text_chars": 50_000,
-  }
-  manifest_path.write_text(json.dumps(manifest, indent=2))
+  with patch.object(acceptance, "get_system_broadcast") as get_broadcast:
+    response = _accept(client, auth, app.id, report["accept_digest"])
 
-  response = _accept(client, auth, app.id, report["accept_digest"])
-
-  assert response.status_code == 200, response.text
-  accepted = response.json()
-  assert accepted["status"] == "accepted"
+  assert response.status_code == 409
+  get_broadcast.assert_not_called()
   db.expire_all()
   stored = db.get(models.App, app.id).capability_contract
   assert stored["agent"]["skills"] == ["newly-reviewed-skill.md"]
-  assert stored["runtime"] == report["candidate_runtime"]
+  assert stored["runtime"] == runtime_before
 
 
 def test_semantic_runtime_change_rejects_prior_digest_without_write_or_event(
@@ -318,75 +338,6 @@ def test_pinned_source_directory_cannot_escape_during_parent_swap(
       pinned.rename(source)
 
 
-def test_domain_failure_rolls_back_its_session(
-  client, auth, db, monkeypatch,
-):
-  app = _store_app(client, auth, db)
-  original_name = app.name
-  review_session = SessionLocal()
-  try:
-    report = acceptance.review_local_runtime_capabilities(
-      review_session, app.id,
-    )
-  finally:
-    review_session.close()
-  original_review = acceptance._review
-
-  def fail_after_mutation(session, app_id):
-    result = original_review(session, app_id)
-    result[0].name = "must roll back"
-    session.flush()
-    raise RuntimeError("injected failure")
-
-  monkeypatch.setattr(acceptance, "_review", fail_after_mutation)
-  accept_session = SessionLocal()
-  with pytest.raises(RuntimeError, match="injected failure"):
-    acceptance.accept_local_runtime_capabilities(
-      accept_session, app.id, report["accept_digest"],
-    )
-  accept_session.expire_all()
-  assert accept_session.get(models.App, app.id).name == original_name
-  accept_session.close()
-  db.expire_all()
-  assert db.get(models.App, app.id).name == original_name
-
-
-def test_concurrent_app_change_wins_without_publishing(
-  client, auth, db, monkeypatch,
-):
-  app = _store_app(client, auth, db)
-  report = _review(client, auth, app.id)
-  original_review = acceptance._review
-  concurrent_contract = {
-    **app.capability_contract,
-    "concurrent_fact": "preserve-me",
-  }
-
-  def review_then_concurrent_write(session, app_id):
-    result = original_review(session, app_id)
-    writer = SessionLocal()
-    try:
-      changed = writer.get(models.App, app.id)
-      changed.capability_contract = concurrent_contract
-      changed.updated_at = timeutil.now_naive_utc()
-      writer.commit()
-    finally:
-      writer.close()
-    return result
-
-  monkeypatch.setattr(acceptance, "_review", review_then_concurrent_write)
-  with patch.object(acceptance, "get_system_broadcast") as get_broadcast:
-    response = _accept(client, auth, app.id, report["accept_digest"])
-
-  assert response.status_code == 409
-  assert "changed while capabilities were being accepted" in response.json()[
-    "detail"
-  ]
-  get_broadcast.assert_not_called()
-  db.expire_all()
-  assert db.get(models.App, app.id).capability_contract == concurrent_contract
-
-
 def test_acceptance_route_rejects_cross_site_requests(client, auth, db):
   app = _store_app(client, auth, db)
   response = client.post(
@@ -425,17 +376,15 @@ def test_command_forwards_review_and_acceptance_to_the_live_server(
   command.main(["--app-id", "7", "--accept-digest", "a" * 64])
   assert json.loads(capsys.readouterr().out) == {"status": "ok"}
 
-  review_request, review_timeout = requests[0]
-  accept_request, accept_timeout = requests[1]
+  review_request, _ = requests[0]
+  accept_request, _ = requests[1]
   assert review_request.full_url == (
     "http://mobius.test/api/apps/7/runtime-capabilities"
   )
   assert review_request.method == "GET"
   assert review_request.get_header("Authorization") == "Bearer agent-token"
-  assert review_timeout == 30
   assert accept_request.full_url == (
     "http://mobius.test/api/apps/7/runtime-capabilities/accept"
   )
   assert accept_request.method == "POST"
   assert json.loads(accept_request.data) == {"accept_digest": "a" * 64}
-  assert accept_timeout == 30


### PR DESCRIPTION
## Summary
- move local runtime capability review and acceptance behind owner-authenticated server routes
- make the command a thin client of the running server instead of a second database owner
- bind approval to normalized runtime semantics while preserving unrelated reviewed contract facts through an atomic row update
- bound manifest reads and reject invalid UTF-8, oversized input, symlinks, FIFOs, and pathological JSON before they can occupy a server worker
- publish the app update only after the accepted contract is durable

This follows [#625](https://github.com/mobius-os/mobius/pull/625). It keeps that explicit digest-bound workflow while consolidating mutation, rollback, and notification in the live server.

## Validation
- focused capability and acceptance suite: 29 passed
- Python compile and diff checks passed