### PR TITLE
Bump Claude Code to 2.1.221

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN useradd -m -s /bin/bash mobius
 # agent-browser looks by default).
 # Discard npm's download cache in each layer: installed packages are the
 # runtime artifact; registry tarballs only make the production image larger.
-ARG CLAUDE_CODE_VERSION=2.1.220
+ARG CLAUDE_CODE_VERSION=2.1.221
 ARG AGENT_BROWSER_VERSION=0.33.2
 RUN apt-get update && apt-get install -y --no-install-recommends \
     age ca-certificates cron curl git jq procps ripgrep sqlite3 sudo unzip util-linux \


### PR DESCRIPTION
## Summary
- bump the pinned Claude Code runtime from 2.1.220 to 2.1.221
- pick up the upstream permission-check hardening and reliability fixes without changing the image layout

This stays separate from the resource-pressure work so the dependency update remains independently reviewable and revertible.

Upstream notes: https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#21221

## Validation
- Docker/runtime contract tests: 31 passed
- package smoke: Claude Code reports 2.1.221 under Node 24