### PR TITLE
Clarify repair progress and deployment recovery guidance

### DIFF
--- a/frontend/src/components/ErrorBoundary/RecoveryLink.jsx
+++ b/frontend/src/components/ErrorBoundary/RecoveryLink.jsx
@@ -1,7 +1,3 @@
-import { useEffect, useState } from 'react'
-import { api, getToken } from '../../api/client.js'
-import { deploymentKind } from '../../lib/platformUpdateState.js'
-
 export const RECOVERY_CONTROL_URL = 'https://www.mobius.you/'
 
 /** Recovery is external, so nested errors must navigate the top-level control plane. */
@@ -9,60 +5,20 @@ export default function RecoveryLink({
   className = 'errbound__recovery',
   lead = 'If the problem continues after trying again,',
 }) {
-  // Every render site is a fallback for a surface that has already failed —
-  // a crashed boundary, a crashed app host, or a startup error — so there is
-  // no healthy app state to inherit a deployment from. This link owns the one
-  // read it needs. `getToken()` is the gate: the status route is owner-only,
-  // so without credentials the read cannot succeed and is not attempted.
-  const [activeDeployment, setActiveDeployment] = useState(null)
-
-  useEffect(() => {
-    if (!getToken()) return undefined
-    let cancelled = false
-    api.platform.status()
-      .then(async response => {
-        if (!response.ok || cancelled) return
-        const detected = deploymentKind((await response.json())?.activation)
-        if (!cancelled && detected) setActiveDeployment(detected)
-      })
-      .catch(() => {
-        // Recovery guidance must remain usable when the platform-status read
-        // is unavailable; the unresolved view keeps both external options.
-      })
-    return () => { cancelled = true }
-  }, [])
-
+  // Every render site is a fallback for a surface that has already failed — a
+  // crashed boundary, a crashed app host, or a startup error — so there is no
+  // healthy app state to detect a deployment from. Naming both routes is always
+  // correct: the owner picks the one that applies to their instance.
   return (
     <p className={className}>
       <span className="recovery-panel__recovery-lead">{lead}</span>
-      {activeDeployment === 'railway' && (
-        <>
-          <span className="recovery-panel__recovery-context">This instance is managed on Railway.</span>
-          <span className="recovery-panel__recovery-action">
-            <a href={RECOVERY_CONTROL_URL} target="_top">Open Recovery in mobius.you</a>.
-          </span>
-        </>
-      )}
-      {activeDeployment === 'self_hosted' && (
-        <>
-          <span className="recovery-panel__recovery-context">This is a self-hosted Möbius instance.</span>
-          <span className="recovery-panel__recovery-action">
-            Run this on the server:
-          </span>
-          <code className="recovery-panel__recovery-command">mobiusctl recovery start</code>
-        </>
-      )}
-      {!activeDeployment && (
-        <>
-          <span className="recovery-panel__recovery-action">
-            Managed hosting: <a href={RECOVERY_CONTROL_URL} target="_top">open Recovery in mobius.you</a>.
-          </span>
-          <span className="recovery-panel__recovery-action">
-            Self-hosted — run this on the server:
-          </span>
-          <code className="recovery-panel__recovery-command">mobiusctl recovery start</code>
-        </>
-      )}
+      <span className="recovery-panel__recovery-action">
+        Managed hosting: <a href={RECOVERY_CONTROL_URL} target="_top">open Recovery in mobius.you</a>.
+      </span>
+      <span className="recovery-panel__recovery-action">
+        Self-hosted — run this on the server:
+      </span>
+      <code className="recovery-panel__recovery-command">mobiusctl recovery start</code>
     </p>
   )
 }

--- a/frontend/src/components/ErrorBoundary/RecoveryLink.jsx
+++ b/frontend/src/components/ErrorBoundary/RecoveryLink.jsx
@@ -1,44 +1,36 @@
 import { useEffect, useState } from 'react'
 import { api, getToken } from '../../api/client.js'
+import { deploymentKind } from '../../lib/platformUpdateState.js'
 
 export const RECOVERY_CONTROL_URL = 'https://www.mobius.you/'
-
-function deploymentFromStatus(value) {
-  return normalizeDeployment(value?.activation?.deployment)
-}
-
-function normalizeDeployment(deployment) {
-  return deployment === 'railway' || deployment === 'self_hosted'
-    ? deployment
-    : null
-}
 
 /** Recovery is external, so nested errors must navigate the top-level control plane. */
 export default function RecoveryLink({
   className = 'errbound__recovery',
-  deployment = null,
-  detectDeployment = true,
   lead = 'If the problem continues after trying again,',
 }) {
-  const suppliedDeployment = normalizeDeployment(deployment)
-  const [detectedDeployment, setDetectedDeployment] = useState(null)
-  const activeDeployment = suppliedDeployment || detectedDeployment
+  // Every render site is a fallback for a surface that has already failed —
+  // a crashed boundary, a crashed app host, or a startup error — so there is
+  // no healthy app state to inherit a deployment from. This link owns the one
+  // read it needs. `getToken()` is the gate: the status route is owner-only,
+  // so without credentials the read cannot succeed and is not attempted.
+  const [activeDeployment, setActiveDeployment] = useState(null)
 
   useEffect(() => {
-    if (!detectDeployment || suppliedDeployment || !getToken()) return undefined
+    if (!getToken()) return undefined
     let cancelled = false
     api.platform.status()
       .then(async response => {
         if (!response.ok || cancelled) return
-        const detected = deploymentFromStatus(await response.json())
-        if (!cancelled && detected) setDetectedDeployment(detected)
+        const detected = deploymentKind((await response.json())?.activation)
+        if (!cancelled && detected) setActiveDeployment(detected)
       })
       .catch(() => {
         // Recovery guidance must remain usable when the platform-status read
         // is unavailable; the unresolved view keeps both external options.
       })
     return () => { cancelled = true }
-  }, [detectDeployment, suppliedDeployment])
+  }, [])
 
   return (
     <p className={className}>
@@ -55,7 +47,7 @@ export default function RecoveryLink({
         <>
           <span className="recovery-panel__recovery-context">This is a self-hosted Möbius instance.</span>
           <span className="recovery-panel__recovery-action">
-            Ask the server operator to run:
+            Run this on the server:
           </span>
           <code className="recovery-panel__recovery-command">mobiusctl recovery start</code>
         </>
@@ -66,7 +58,7 @@ export default function RecoveryLink({
             Managed hosting: <a href={RECOVERY_CONTROL_URL} target="_top">open Recovery in mobius.you</a>.
           </span>
           <span className="recovery-panel__recovery-action">
-            Self-hosted: ask the server operator to run:
+            Self-hosted — run this on the server:
           </span>
           <code className="recovery-panel__recovery-command">mobiusctl recovery start</code>
         </>

--- a/frontend/src/components/ErrorBoundary/RecoveryLink.jsx
+++ b/frontend/src/components/ErrorBoundary/RecoveryLink.jsx
@@ -1,15 +1,76 @@
+import { useEffect, useState } from 'react'
+import { api, getToken } from '../../api/client.js'
+
 export const RECOVERY_CONTROL_URL = 'https://www.mobius.you/'
+
+function deploymentFromStatus(value) {
+  return normalizeDeployment(value?.activation?.deployment)
+}
+
+function normalizeDeployment(deployment) {
+  return deployment === 'railway' || deployment === 'self_hosted'
+    ? deployment
+    : null
+}
 
 /** Recovery is external, so nested errors must navigate the top-level control plane. */
 export default function RecoveryLink({
   className = 'errbound__recovery',
+  deployment = null,
+  detectDeployment = true,
   lead = 'If the problem continues after trying again,',
 }) {
+  const suppliedDeployment = normalizeDeployment(deployment)
+  const [detectedDeployment, setDetectedDeployment] = useState(null)
+  const activeDeployment = suppliedDeployment || detectedDeployment
+
+  useEffect(() => {
+    if (!detectDeployment || suppliedDeployment || !getToken()) return undefined
+    let cancelled = false
+    api.platform.status()
+      .then(async response => {
+        if (!response.ok || cancelled) return
+        const detected = deploymentFromStatus(await response.json())
+        if (!cancelled && detected) setDetectedDeployment(detected)
+      })
+      .catch(() => {
+        // Recovery guidance must remain usable when the platform-status read
+        // is unavailable; the unresolved view keeps both external options.
+      })
+    return () => { cancelled = true }
+  }, [detectDeployment, suppliedDeployment])
+
   return (
     <p className={className}>
-      {lead}{' '}
-      <a href={RECOVERY_CONTROL_URL} target="_top">open Recovery in mobius.you</a>.
-      {' '}Self-hosted: run <code>mobiusctl recovery start</code>.
+      <span className="recovery-panel__recovery-lead">{lead}</span>
+      {activeDeployment === 'railway' && (
+        <>
+          <span className="recovery-panel__recovery-context">This instance is managed on Railway.</span>
+          <span className="recovery-panel__recovery-action">
+            <a href={RECOVERY_CONTROL_URL} target="_top">Open Recovery in mobius.you</a>.
+          </span>
+        </>
+      )}
+      {activeDeployment === 'self_hosted' && (
+        <>
+          <span className="recovery-panel__recovery-context">This is a self-hosted Möbius instance.</span>
+          <span className="recovery-panel__recovery-action">
+            Ask the server operator to run:
+          </span>
+          <code className="recovery-panel__recovery-command">mobiusctl recovery start</code>
+        </>
+      )}
+      {!activeDeployment && (
+        <>
+          <span className="recovery-panel__recovery-action">
+            Managed hosting: <a href={RECOVERY_CONTROL_URL} target="_top">open Recovery in mobius.you</a>.
+          </span>
+          <span className="recovery-panel__recovery-action">
+            Self-hosted: ask the server operator to run:
+          </span>
+          <code className="recovery-panel__recovery-command">mobiusctl recovery start</code>
+        </>
+      )}
     </p>
   )
 }

--- a/frontend/src/components/ErrorBoundary/RecoveryPanel.css
+++ b/frontend/src/components/ErrorBoundary/RecoveryPanel.css
@@ -192,7 +192,25 @@
   color: var(--muted, #a3a3a3);
   font-size: 13px;
   line-height: 1.5;
-  text-align: end;
+  text-align: start;
+}
+
+.recovery-panel__recovery-lead,
+.recovery-panel__recovery-context,
+.recovery-panel__recovery-action {
+  display: block;
+}
+
+.recovery-panel__recovery-context {
+  margin-top: 4px;
+}
+
+.recovery-panel__recovery-command {
+  display: block;
+  width: max-content;
+  max-width: 100%;
+  margin-top: 2px;
+  white-space: nowrap;
 }
 
 .recovery-panel__recovery a,

--- a/frontend/src/components/ErrorBoundary/RecoveryPanel.jsx
+++ b/frontend/src/components/ErrorBoundary/RecoveryPanel.jsx
@@ -19,7 +19,7 @@ function recoveryMessage({ phase, attemptPhase, canAskAgent, subject }) {
     return `Refreshing didn’t fix ${currentSubject}. Use system recovery to diagnose the problem without relying on this embedded chat.`
   }
   if (attemptPhase === 'agent-directed') {
-    return `The repair chat started, but ${currentSubject} still can’t open. System recovery is the remaining fallback.`
+    return `The repair request was sent. Give the agent a few minutes to work, then refresh ${currentSubject}.`
   }
   return 'The repair chat couldn’t start. You can retry it or use system recovery as a last resort.'
 }
@@ -38,6 +38,7 @@ export default function RecoveryPanel({
   subject,
   title,
   variant,
+  deployment,
 }) {
   const headingId = useId()
   const phase = recoveryPhaseForAttempt(attempt, { canAskAgent })
@@ -104,7 +105,7 @@ export default function RecoveryPanel({
             Refresh again
           </button>
         )}
-        {phase === 'recovery' && repairChatId && (
+        {phase === 'recovery' && repairChatId && attemptPhase !== 'agent-directed' && (
           <a className="recovery-panel__button" href={repairChatPath(repairChatId, BASE)}>
             Open repair chat
           </a>
@@ -124,6 +125,8 @@ export default function RecoveryPanel({
         <RecoveryLink
           className="recovery-panel__recovery"
           lead="If the repair chat can’t get you back in,"
+          deployment={deployment}
+          detectDeployment={canAskAgent}
         />
       )}
     </section>

--- a/frontend/src/components/ErrorBoundary/RecoveryPanel.jsx
+++ b/frontend/src/components/ErrorBoundary/RecoveryPanel.jsx
@@ -7,7 +7,7 @@ import {
 import RecoveryLink from './RecoveryLink.jsx'
 import './RecoveryPanel.css'
 
-function recoveryMessage({ phase, attemptPhase, canAskAgent, subject }) {
+function recoveryMessage({ phase, attemptPhase, canAskAgent, hasRepairChat, subject }) {
   const currentSubject = subject === 'screen' ? 'this screen' : 'the app'
   if (phase === 'refresh') {
     return `This ${subject} hit an unexpected error. Refreshing won’t delete your chats.`
@@ -19,9 +19,15 @@ function recoveryMessage({ phase, attemptPhase, canAskAgent, subject }) {
     return `Refreshing didn’t fix ${currentSubject}. Use system recovery to diagnose the problem without relying on this embedded chat.`
   }
   if (attemptPhase === 'agent-directed') {
-    return `The repair request was sent. Give the agent a few minutes to work, then refresh ${currentSubject}.`
+    // The agent may already be mid-work or waiting on a clarifying question,
+    // so waiting is a suggestion, never the only route.
+    return hasRepairChat
+      ? `The repair request was sent. Give the agent a few minutes, then refresh ${currentSubject} — or open the repair chat to follow along and answer any questions.`
+      : `The repair request was sent. Give the agent a few minutes, then refresh ${currentSubject}.`
   }
-  return 'The repair chat couldn’t start. You can retry it or use system recovery as a last resort.'
+  // The chat itself may exist — delivery is what failed — so this must not
+  // claim otherwise while an "Open repair chat" link sits beside it.
+  return 'The repair request didn’t go through. You can retry it, or use system recovery as a last resort.'
 }
 
 export default function RecoveryPanel({
@@ -38,7 +44,6 @@ export default function RecoveryPanel({
   subject,
   title,
   variant,
-  deployment,
 }) {
   const headingId = useId()
   const phase = recoveryPhaseForAttempt(attempt, { canAskAgent })
@@ -74,7 +79,13 @@ export default function RecoveryPanel({
         {title}
       </h1>
       <p className="recovery-panel__body">
-        {recoveryMessage({ phase, attemptPhase, canAskAgent, subject })}
+        {recoveryMessage({
+          phase,
+          attemptPhase,
+          canAskAgent,
+          hasRepairChat: !!repairChatId,
+          subject,
+        })}
       </p>
       <details className="recovery-panel__details">
         <summary>Technical details</summary>
@@ -105,7 +116,7 @@ export default function RecoveryPanel({
             Refresh again
           </button>
         )}
-        {phase === 'recovery' && repairChatId && attemptPhase !== 'agent-directed' && (
+        {phase === 'recovery' && repairChatId && (
           <a className="recovery-panel__button" href={repairChatPath(repairChatId, BASE)}>
             Open repair chat
           </a>
@@ -125,8 +136,6 @@ export default function RecoveryPanel({
         <RecoveryLink
           className="recovery-panel__recovery"
           lead="If the repair chat can’t get you back in,"
-          deployment={deployment}
-          detectDeployment={canAskAgent}
         />
       )}
     </section>

--- a/frontend/src/components/SettingsView/UpdateReviewModal.jsx
+++ b/frontend/src/components/SettingsView/UpdateReviewModal.jsx
@@ -30,7 +30,7 @@ import {
   summarizePreview,
   isTrivialUpdate,
 } from '../../lib/platformUpdatePreview.js'
-import { platformActivationLabel } from '../../lib/platformUpdateState.js'
+import { deploymentKindLabel, platformActivationLabel } from '../../lib/platformUpdateState.js'
 import FileDiffList from '../DiffView/FileDiffList.jsx'
 import './UpdateReviewModal.css'
 
@@ -244,7 +244,7 @@ export default function UpdateReviewModal({
                   {platformActivationLabel(activation)}
                 </h3>
                 <span className="urm__activation-deployment">
-                  {activation.deployment === 'railway' ? 'Railway' : 'Self-hosted'}
+                  {deploymentKindLabel(activation)}
                 </span>
               </div>
               {activationGuidance.map((line) => (

--- a/frontend/src/lib/__tests__/platformUpdateState.test.js
+++ b/frontend/src/lib/__tests__/platformUpdateState.test.js
@@ -1,10 +1,28 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import {
+  deploymentKind,
+  deploymentKindLabel,
   platformActivationLabel,
   platformStatusFromApply,
   platformUpdateStatusLabel,
 } from '../platformUpdateState.js'
+
+test('the deployment classifier stays as binary as the backend that emits it', () => {
+  assert.equal(deploymentKind({ deployment: 'railway' }), 'railway')
+  assert.equal(deploymentKind({ deployment: 'self_hosted' }), 'self_hosted')
+  // deployment_kind() returns only those two, so anything else is unknown
+  // rather than a third kind the UI may render guidance for.
+  for (const unknown of [undefined, null, {}, { deployment: null }, { deployment: 'fly' }]) {
+    assert.equal(deploymentKind(unknown), null)
+  }
+})
+
+test('the deployment badge names an unresolved deployment self-hosted', () => {
+  assert.equal(deploymentKindLabel({ deployment: 'railway' }), 'Railway')
+  assert.equal(deploymentKindLabel({ deployment: 'self_hosted' }), 'Self-hosted')
+  assert.equal(deploymentKindLabel(null), 'Self-hosted')
+})
 
 test('a clean apply consumes the reviewed target but preserves restart readiness', () => {
   const projected = platformStatusFromApply(

--- a/frontend/src/lib/__tests__/recoveryLink.test.js
+++ b/frontend/src/lib/__tests__/recoveryLink.test.js
@@ -17,6 +17,20 @@ test('recovery points outside the Mobius container with self-host guidance', () 
   assert.match(defaultHtml, /mobiusctl recovery start/)
   assert.doesNotMatch(defaultHtml, /href="\/recover/)
 
+  const selfHostedHtml = renderToStaticMarkup(createElement(RecoveryLink, {
+    deployment: 'self_hosted',
+  }))
+  assert.match(selfHostedHtml, /This is a self-hosted Möbius instance/)
+  assert.match(selfHostedHtml, /mobiusctl recovery start/)
+  assert.doesNotMatch(selfHostedHtml, /mobius\.you/)
+
+  const railwayHtml = renderToStaticMarkup(createElement(RecoveryLink, {
+    deployment: 'railway',
+  }))
+  assert.match(railwayHtml, /managed on Railway/)
+  assert.match(railwayHtml, />Open Recovery in mobius\.you<\/a>/)
+  assert.doesNotMatch(railwayHtml, /mobiusctl recovery start/)
+
   const standaloneHtml = renderToStaticMarkup(createElement(RecoveryLink, {
     className: 'standalone-app__recovery',
     lead: 'If the app still won’t open,',

--- a/frontend/src/lib/__tests__/recoveryLink.test.js
+++ b/frontend/src/lib/__tests__/recoveryLink.test.js
@@ -1,41 +1,157 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 
+import { renderHook } from '../../components/ChatView/hooks/__tests__/react-hook-shim.mjs'
+import { api } from '../../api/client.js'
 import RecoveryLink, {
   RECOVERY_CONTROL_URL,
 } from '../../components/ErrorBoundary/RecoveryLink.jsx'
 
-test('recovery points outside the Mobius container with self-host guidance', () => {
+const realStatus = api.platform.status
+
+function jsonResponse(body, { ok = true } = {}) {
+  return { ok, json: async () => body }
+}
+
+function railwayStatus() {
+  return jsonResponse({ activation: { level: 'live', deployment: 'railway' } })
+}
+
+function selfHostedStatus() {
+  return jsonResponse({ activation: { level: 'live', deployment: 'self_hosted' } })
+}
+
+/**
+ * Installs the credentials and the platform-status reply the link will see.
+ * `token: null` models a surface with no owner credentials at all.
+ */
+function installPlatform({ status, token = 'owner-token' }) {
+  const calls = []
+  // api.platform.status is a fetch wrapper, so it always answers with a promise.
+  api.platform.status = async (...args) => {
+    calls.push(args)
+    return status()
+  }
+  globalThis.localStorage = { getItem: key => (key === 'token' ? token : null) }
+  return {
+    calls,
+    restore() {
+      api.platform.status = realStatus
+      delete globalThis.localStorage
+    },
+  }
+}
+
+/**
+ * Renders the component the app actually ships: renderHook supplies the hook
+ * runtime and flushes the detection effect, then the returned (real) React
+ * tree is serialized. renderToStaticMarkup alone never runs effects, so it
+ * can only ever see the undetected state.
+ */
+async function renderLink(props = {}) {
+  const view = renderHook(() => RecoveryLink(props))
+  // The effect resolves the fetch and then awaits response.json(); let both
+  // microtask hops land before reading what the link settled on.
+  await new Promise(resolve => setTimeout(resolve, 0))
+  const html = renderToStaticMarkup(view.result.current)
+  view.unmount()
+  return html
+}
+
+test('an undetected deployment keeps both external recovery routes', async () => {
   assert.equal(RECOVERY_CONTROL_URL, 'https://www.mobius.you/')
-  const defaultHtml = renderToStaticMarkup(createElement(RecoveryLink))
-  assert.match(defaultHtml, /class="errbound__recovery"/)
-  assert.match(defaultHtml, /If the problem continues after trying again/)
-  assert.match(defaultHtml, new RegExp(`href="${RECOVERY_CONTROL_URL}"`))
-  assert.match(defaultHtml, /target="_top"/)
-  assert.match(defaultHtml, /mobiusctl recovery start/)
-  assert.doesNotMatch(defaultHtml, /href="\/recover/)
+  const platform = installPlatform({ status: railwayStatus, token: null })
+  try {
+    const html = await renderLink()
+    assert.deepEqual(platform.calls, [], 'no credentials must mean no owner-only read')
+    assert.match(html, /class="errbound__recovery"/)
+    assert.match(html, /If the problem continues after trying again/)
+    assert.match(html, new RegExp(`href="${RECOVERY_CONTROL_URL}"`))
+    assert.match(html, /target="_top"/)
+    assert.match(html, /mobiusctl recovery start/)
+    assert.doesNotMatch(html, /href="\/recover/)
+  } finally {
+    platform.restore()
+  }
+})
 
-  const selfHostedHtml = renderToStaticMarkup(createElement(RecoveryLink, {
-    deployment: 'self_hosted',
-  }))
-  assert.match(selfHostedHtml, /This is a self-hosted Möbius instance/)
-  assert.match(selfHostedHtml, /mobiusctl recovery start/)
-  assert.doesNotMatch(selfHostedHtml, /mobius\.you/)
+test('a detected deployment shows only the route that applies to it', async () => {
+  const railway = installPlatform({ status: railwayStatus })
+  try {
+    const html = await renderLink()
+    assert.equal(railway.calls.length, 1)
+    assert.match(html, /managed on Railway/)
+    assert.match(html, />Open Recovery in mobius\.you<\/a>/)
+    assert.doesNotMatch(html, /mobiusctl recovery start/)
+  } finally {
+    railway.restore()
+  }
 
-  const railwayHtml = renderToStaticMarkup(createElement(RecoveryLink, {
-    deployment: 'railway',
-  }))
-  assert.match(railwayHtml, /managed on Railway/)
-  assert.match(railwayHtml, />Open Recovery in mobius\.you<\/a>/)
-  assert.doesNotMatch(railwayHtml, /mobiusctl recovery start/)
+  const selfHosted = installPlatform({ status: selfHostedStatus })
+  try {
+    const html = await renderLink()
+    assert.match(html, /This is a self-hosted Möbius instance/)
+    assert.match(html, /<code[^>]*>mobiusctl recovery start<\/code>/)
+    assert.doesNotMatch(html, /mobius\.you/)
+  } finally {
+    selfHosted.restore()
+  }
+})
 
-  const standaloneHtml = renderToStaticMarkup(createElement(RecoveryLink, {
-    className: 'standalone-app__recovery',
-    lead: 'If the app still won’t open,',
-  }))
-  assert.match(standaloneHtml, /class="standalone-app__recovery"/)
-  assert.match(standaloneHtml, /If the app still won’t open/)
-  assert.match(standaloneHtml, />open Recovery in mobius\.you<\/a>/)
+test('self-host guidance addresses the owner rather than a separate operator', async () => {
+  const selfHosted = installPlatform({ status: selfHostedStatus })
+  try {
+    const html = await renderLink()
+    assert.match(html, /Run this on the server:/)
+    assert.doesNotMatch(html, /ask the server operator/i)
+  } finally {
+    selfHosted.restore()
+  }
+
+  const unresolved = installPlatform({ status: railwayStatus, token: null })
+  try {
+    const html = await renderLink()
+    assert.match(html, /Self-hosted — run this on the server:/)
+    assert.doesNotMatch(html, /ask the server operator/i)
+  } finally {
+    unresolved.restore()
+  }
+})
+
+test('an unreadable platform status degrades to both routes instead of guessing', async () => {
+  const unreadable = [
+    ['a rejected read', () => Promise.reject(new Error('offline'))],
+    ['a non-ok response', () => jsonResponse({ activation: { deployment: 'railway' } }, { ok: false })],
+    ['an unparseable body', () => ({ ok: true, json: async () => { throw new Error('bad json') } })],
+    ['a deployment the backend never emits', () => jsonResponse({ activation: { deployment: 'fly' } })],
+    ['a status with no activation', () => jsonResponse({ state: 'up_to_date' })],
+  ]
+  for (const [label, status] of unreadable) {
+    const platform = installPlatform({ status })
+    try {
+      const html = await renderLink()
+      assert.equal(platform.calls.length, 1, label)
+      assert.match(html, /Managed hosting:/, label)
+      assert.match(html, /Self-hosted — run this on the server:/, label)
+      assert.doesNotMatch(html, /managed on Railway/, label)
+    } finally {
+      platform.restore()
+    }
+  }
+})
+
+test('the link keeps its host surface class and lead', async () => {
+  const platform = installPlatform({ status: selfHostedStatus })
+  try {
+    const html = await renderLink({
+      className: 'standalone-app__recovery',
+      lead: 'If the app still won’t open,',
+    })
+    assert.match(html, /class="standalone-app__recovery"/)
+    assert.match(html, /If the app still won’t open/)
+    assert.match(html, /This is a self-hosted Möbius instance/)
+  } finally {
+    platform.restore()
+  }
 })

--- a/frontend/src/lib/__tests__/recoveryLink.test.js
+++ b/frontend/src/lib/__tests__/recoveryLink.test.js
@@ -1,157 +1,39 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
+import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 
-import { renderHook } from '../../components/ChatView/hooks/__tests__/react-hook-shim.mjs'
-import { api } from '../../api/client.js'
 import RecoveryLink, {
   RECOVERY_CONTROL_URL,
 } from '../../components/ErrorBoundary/RecoveryLink.jsx'
 
-const realStatus = api.platform.status
-
-function jsonResponse(body, { ok = true } = {}) {
-  return { ok, json: async () => body }
+function renderLink(props = {}) {
+  return renderToStaticMarkup(createElement(RecoveryLink, props))
 }
 
-function railwayStatus() {
-  return jsonResponse({ activation: { level: 'live', deployment: 'railway' } })
-}
-
-function selfHostedStatus() {
-  return jsonResponse({ activation: { level: 'live', deployment: 'self_hosted' } })
-}
-
-/**
- * Installs the credentials and the platform-status reply the link will see.
- * `token: null` models a surface with no owner credentials at all.
- */
-function installPlatform({ status, token = 'owner-token' }) {
-  const calls = []
-  // api.platform.status is a fetch wrapper, so it always answers with a promise.
-  api.platform.status = async (...args) => {
-    calls.push(args)
-    return status()
-  }
-  globalThis.localStorage = { getItem: key => (key === 'token' ? token : null) }
-  return {
-    calls,
-    restore() {
-      api.platform.status = realStatus
-      delete globalThis.localStorage
-    },
-  }
-}
-
-/**
- * Renders the component the app actually ships: renderHook supplies the hook
- * runtime and flushes the detection effect, then the returned (real) React
- * tree is serialized. renderToStaticMarkup alone never runs effects, so it
- * can only ever see the undetected state.
- */
-async function renderLink(props = {}) {
-  const view = renderHook(() => RecoveryLink(props))
-  // The effect resolves the fetch and then awaits response.json(); let both
-  // microtask hops land before reading what the link settled on.
-  await new Promise(resolve => setTimeout(resolve, 0))
-  const html = renderToStaticMarkup(view.result.current)
-  view.unmount()
-  return html
-}
-
-test('an undetected deployment keeps both external recovery routes', async () => {
+test('the recovery link always offers both external recovery routes', () => {
   assert.equal(RECOVERY_CONTROL_URL, 'https://www.mobius.you/')
-  const platform = installPlatform({ status: railwayStatus, token: null })
-  try {
-    const html = await renderLink()
-    assert.deepEqual(platform.calls, [], 'no credentials must mean no owner-only read')
-    assert.match(html, /class="errbound__recovery"/)
-    assert.match(html, /If the problem continues after trying again/)
-    assert.match(html, new RegExp(`href="${RECOVERY_CONTROL_URL}"`))
-    assert.match(html, /target="_top"/)
-    assert.match(html, /mobiusctl recovery start/)
-    assert.doesNotMatch(html, /href="\/recover/)
-  } finally {
-    platform.restore()
-  }
+  const html = renderLink()
+  assert.match(html, /class="errbound__recovery"/)
+  assert.match(html, /If the problem continues after trying again/)
+  assert.match(html, /Managed hosting:/)
+  assert.match(html, new RegExp(`href="${RECOVERY_CONTROL_URL}"`))
+  assert.match(html, /target="_top"/)
+  assert.match(html, />open Recovery in mobius\.you<\/a>/)
+  assert.match(html, /Self-hosted — run this on the server:/)
+  assert.match(html, /<code[^>]*>mobiusctl recovery start<\/code>/)
+  // It is a fallback for a surface that already failed, so it must never point
+  // back at an in-app recovery route.
+  assert.doesNotMatch(html, /href="\/recover/)
 })
 
-test('a detected deployment shows only the route that applies to it', async () => {
-  const railway = installPlatform({ status: railwayStatus })
-  try {
-    const html = await renderLink()
-    assert.equal(railway.calls.length, 1)
-    assert.match(html, /managed on Railway/)
-    assert.match(html, />Open Recovery in mobius\.you<\/a>/)
-    assert.doesNotMatch(html, /mobiusctl recovery start/)
-  } finally {
-    railway.restore()
-  }
-
-  const selfHosted = installPlatform({ status: selfHostedStatus })
-  try {
-    const html = await renderLink()
-    assert.match(html, /This is a self-hosted Möbius instance/)
-    assert.match(html, /<code[^>]*>mobiusctl recovery start<\/code>/)
-    assert.doesNotMatch(html, /mobius\.you/)
-  } finally {
-    selfHosted.restore()
-  }
-})
-
-test('self-host guidance addresses the owner rather than a separate operator', async () => {
-  const selfHosted = installPlatform({ status: selfHostedStatus })
-  try {
-    const html = await renderLink()
-    assert.match(html, /Run this on the server:/)
-    assert.doesNotMatch(html, /ask the server operator/i)
-  } finally {
-    selfHosted.restore()
-  }
-
-  const unresolved = installPlatform({ status: railwayStatus, token: null })
-  try {
-    const html = await renderLink()
-    assert.match(html, /Self-hosted — run this on the server:/)
-    assert.doesNotMatch(html, /ask the server operator/i)
-  } finally {
-    unresolved.restore()
-  }
-})
-
-test('an unreadable platform status degrades to both routes instead of guessing', async () => {
-  const unreadable = [
-    ['a rejected read', () => Promise.reject(new Error('offline'))],
-    ['a non-ok response', () => jsonResponse({ activation: { deployment: 'railway' } }, { ok: false })],
-    ['an unparseable body', () => ({ ok: true, json: async () => { throw new Error('bad json') } })],
-    ['a deployment the backend never emits', () => jsonResponse({ activation: { deployment: 'fly' } })],
-    ['a status with no activation', () => jsonResponse({ state: 'up_to_date' })],
-  ]
-  for (const [label, status] of unreadable) {
-    const platform = installPlatform({ status })
-    try {
-      const html = await renderLink()
-      assert.equal(platform.calls.length, 1, label)
-      assert.match(html, /Managed hosting:/, label)
-      assert.match(html, /Self-hosted — run this on the server:/, label)
-      assert.doesNotMatch(html, /managed on Railway/, label)
-    } finally {
-      platform.restore()
-    }
-  }
-})
-
-test('the link keeps its host surface class and lead', async () => {
-  const platform = installPlatform({ status: selfHostedStatus })
-  try {
-    const html = await renderLink({
-      className: 'standalone-app__recovery',
-      lead: 'If the app still won’t open,',
-    })
-    assert.match(html, /class="standalone-app__recovery"/)
-    assert.match(html, /If the app still won’t open/)
-    assert.match(html, /This is a self-hosted Möbius instance/)
-  } finally {
-    platform.restore()
-  }
+test('the link takes its host surface class and lead', () => {
+  const html = renderLink({
+    className: 'standalone-app__recovery',
+    lead: 'If the app still won’t open,',
+  })
+  assert.match(html, /class="standalone-app__recovery"/)
+  assert.match(html, /If the app still won’t open/)
+  assert.match(html, /Managed hosting:/)
+  assert.match(html, /<code[^>]*>mobiusctl recovery start<\/code>/)
 })

--- a/frontend/src/lib/__tests__/recoveryPanel.test.js
+++ b/frontend/src/lib/__tests__/recoveryPanel.test.js
@@ -66,15 +66,36 @@ test('recovery panel exposes last resorts only after repair fails', () => {
   assert.match(restricted, /<code[^>]*>mobiusctl recovery start<\/code>/)
 })
 
-test('a directed repair asks the owner to wait instead of linking back to the broken screen', () => {
+test('a directed repair keeps the live repair chat reachable while it works', () => {
+  // 'agent-directed' is written only once the prompt was delivered, so the
+  // chat exists and the agent may be mid-work or waiting on an answer.
+  // Telling the owner to wait must never be the only thing they can do.
   const directed = renderPanel({
     attempt: { phase: 'agent-directed', chatId: 'repair/chat' },
-    deployment: 'self_hosted',
   })
   assert.match(directed, /repair request was sent/i)
   assert.match(directed, /Give the agent a few minutes/i)
+  assert.match(directed, /open the repair chat to follow along/i)
   assert.match(directed, />Refresh again</)
+  assert.match(directed, />Open repair chat</)
+  assert.match(directed, /chat=repair%2Fchat/)
+})
+
+test('a directed repair with no recorded chat only offers the refresh', () => {
+  const directed = renderPanel({ attempt: { phase: 'agent-directed' } })
+  assert.match(directed, /repair request was sent/i)
+  assert.match(directed, /Give the agent a few minutes/i)
+  assert.doesNotMatch(directed, /open the repair chat/i)
   assert.doesNotMatch(directed, />Open repair chat</)
-  assert.match(directed, /This is a self-hosted Möbius instance/)
-  assert.doesNotMatch(directed, /mobius\.you/)
+})
+
+test('a failed dispatch does not deny a repair chat it can still link to', () => {
+  // The chat is created before the prompt is sent, so a send failure leaves a
+  // real chat behind. The copy must not contradict the link beside it.
+  const failed = renderPanel({
+    attempt: { phase: 'agent-failed', chatId: 'repair/chat' },
+  })
+  assert.match(failed, /repair request didn’t go through/i)
+  assert.doesNotMatch(failed, /couldn’t start/i)
+  assert.match(failed, />Open repair chat</)
 })

--- a/frontend/src/lib/__tests__/recoveryPanel.test.js
+++ b/frontend/src/lib/__tests__/recoveryPanel.test.js
@@ -55,7 +55,7 @@ test('recovery panel exposes last resorts only after repair fails', () => {
   assert.match(failed, /href="https:\/\/www\.mobius\.you\/"/)
   assert.match(failed, /target="_top"/)
   assert.match(failed, /open Recovery in mobius\.you/i)
-  assert.match(failed, /<code>mobiusctl recovery start<\/code>/)
+  assert.match(failed, /<code[^>]*>mobiusctl recovery start<\/code>/)
 
   const restricted = renderPanel({
     attempt: { phase: 'refreshed' },
@@ -63,5 +63,18 @@ test('recovery panel exposes last resorts only after repair fails', () => {
   })
   assert.doesNotMatch(restricted, /Start repair chat|Retry repair chat/)
   assert.match(restricted, /open Recovery in mobius\.you/i)
-  assert.match(restricted, /<code>mobiusctl recovery start<\/code>/)
+  assert.match(restricted, /<code[^>]*>mobiusctl recovery start<\/code>/)
+})
+
+test('a directed repair asks the owner to wait instead of linking back to the broken screen', () => {
+  const directed = renderPanel({
+    attempt: { phase: 'agent-directed', chatId: 'repair/chat' },
+    deployment: 'self_hosted',
+  })
+  assert.match(directed, /repair request was sent/i)
+  assert.match(directed, /Give the agent a few minutes/i)
+  assert.match(directed, />Refresh again</)
+  assert.doesNotMatch(directed, />Open repair chat</)
+  assert.match(directed, /This is a self-hosted Möbius instance/)
+  assert.doesNotMatch(directed, /mobius\.you/)
 })

--- a/frontend/src/lib/__tests__/vite-env-loader.mjs
+++ b/frontend/src/lib/__tests__/vite-env-loader.mjs
@@ -23,10 +23,20 @@ const REACT_SHIM = new URL(
 // this suite can drive them with renderHook. Opt-in per module rather than
 // blanket: most files here are read as source text, and a global alias would
 // silently swap React out from under anything that later imports for real.
+//
+// RecoveryLink is a component rather than a hook, and is listed for one
+// reason: its only behaviour beyond static markup is the deployment-detection
+// effect, and renderToStaticMarkup never runs effects. Only its `react`
+// import is redirected — JSX still resolves through the real
+// `react/jsx-runtime`, so the tree renderHook returns is an ordinary React
+// tree that react-dom/server can serialize. A test that renders RecoveryLink
+// through a parent (recoveryPanel.test.js) therefore sees the pre-detection
+// render, which is exactly the first frame production paints.
 const REACT_SHIMMED_MODULES = [
   '/components/Shell/useAppIntentNavigation.js',
   '/components/ChatView/useFileUpload.js',
   '/components/ChatView/useScrollMode.js',
+  '/components/ErrorBoundary/RecoveryLink.jsx',
   '/hooks/useNavigation.js',
 ]
 

--- a/frontend/src/lib/__tests__/vite-env-loader.mjs
+++ b/frontend/src/lib/__tests__/vite-env-loader.mjs
@@ -23,20 +23,10 @@ const REACT_SHIM = new URL(
 // this suite can drive them with renderHook. Opt-in per module rather than
 // blanket: most files here are read as source text, and a global alias would
 // silently swap React out from under anything that later imports for real.
-//
-// RecoveryLink is a component rather than a hook, and is listed for one
-// reason: its only behaviour beyond static markup is the deployment-detection
-// effect, and renderToStaticMarkup never runs effects. Only its `react`
-// import is redirected — JSX still resolves through the real
-// `react/jsx-runtime`, so the tree renderHook returns is an ordinary React
-// tree that react-dom/server can serialize. A test that renders RecoveryLink
-// through a parent (recoveryPanel.test.js) therefore sees the pre-detection
-// render, which is exactly the first frame production paints.
 const REACT_SHIMMED_MODULES = [
   '/components/Shell/useAppIntentNavigation.js',
   '/components/ChatView/useFileUpload.js',
   '/components/ChatView/useScrollMode.js',
-  '/components/ErrorBoundary/RecoveryLink.jsx',
   '/hooks/useNavigation.js',
 ]
 

--- a/frontend/src/lib/platformUpdateState.js
+++ b/frontend/src/lib/platformUpdateState.js
@@ -62,6 +62,25 @@ export function platformUpdateStatusLabel(platform) {
   return 'Up to date'
 }
 
+/**
+ * The single frontend reading of the backend's deployment classifier.
+ *
+ * `platform_activation.deployment_kind` is binary — it returns exactly
+ * 'railway' or 'self_hosted' — so the frontend must not invent a third kind.
+ * `null` means "not read yet, or unreadable", which callers render as
+ * guidance that covers both deployments rather than guessing one.
+ */
+export function deploymentKind(activation) {
+  const deployment = activation?.deployment
+  return deployment === 'railway' || deployment === 'self_hosted'
+    ? deployment
+    : null
+}
+
+export function deploymentKindLabel(activation) {
+  return deploymentKind(activation) === 'railway' ? 'Railway' : 'Self-hosted'
+}
+
 export function platformActivationLabel(activation) {
   const labels = {
     live: 'Live refresh',


### PR DESCRIPTION
## Summary
- explain that a dispatched repair request may need a few minutes before the broken screen can recover
- remove the repair-chat link when it only points back into the same shell-wide failure
- tailor the fallback to Railway or self-hosted recovery and keep the operator command on a deliberate line

## Testing
- `npm test`
- focused ESLint checks for the updated recovery components and tests
- rendered the repaired fallback at the production shell viewport