### PR TITLE
Keep drawer item menus off the scroll path

### DIFF
--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -310,30 +310,28 @@ export default function Drawer({
     recentWindow,
   ])
 
-  // One row at a time can be in rename or open-menu mode. Tracking the
-  // active id (rather than per-row state) lets a click on another row's
-  // context action replace any open menu without a global listener per row.
-  const [openMenu, setOpenMenu] = useState(null) // { kind, id, surface, placement } | null
+  // The drawer owns one action menu. Rows provide item identity, placement,
+  // and a focus-return target without mounting their own controllers.
+  const [openMenu, setOpenMenu] = useState(null)
+  const menuRestoreFocusRef = useRef(null)
+  const activeMenuItem = openMenu
+    ? (openMenu.kind === 'chat' ? (chats || []) : (apps || []))
+      .find(item => item.id === openMenu.id) || null
+    : null
   const {
     open: openItemMenuHistory,
     close: closeItemMenu,
   } = useHistoryDismiss(() => setOpenMenu(null))
 
-  function showItemMenu(kind, id, surface, placement) {
+  function showItemMenu({ restoreFocusTarget, ...menu }) {
     openItemMenuHistory()
-    setOpenMenu({ kind, id, surface, placement })
+    menuRestoreFocusRef.current = restoreFocusTarget
+    setOpenMenu(menu)
   }
-  // Belt-and-braces orphan cleanup: if the row whose menu was open
-  // disappears from the list (delete, chat soft-delete, agent-side
-  // removal), openMenu would still reference a dead id and the next
-  // row to occupy that slot can look "pressed". Drop the reference
-  // the moment its id is no longer in the relevant collection.
+  // A deleted row cannot keep owning the shared menu.
   useEffect(() => {
-    if (!openMenu) return
-    const collection = openMenu.kind === 'chat' ? (chats || []) : (apps || [])
-    const stillThere = collection.some(item => item.id === openMenu.id)
-    if (!stillThere) closeItemMenu()
-  }, [openMenu, chats, apps, closeItemMenu])
+    if (openMenu && !activeMenuItem) closeItemMenu()
+  }, [openMenu, activeMenuItem, closeItemMenu])
   const [renamingState, setRenamingState] = useState(null) // { kind, id } | null
   // Mirrors `renaming` synchronously (not via useEffect — that's one render
   // behind) so outside-tap cancellation sees the current edit immediately.
@@ -404,10 +402,11 @@ export default function Drawer({
       if (kind === 'chat') current.onChat(id)
       else current.onApp(id)
     },
-    toggleMenu(kind, id, next, surface = 'drawer', placement = null) {
-      const current = rowActionInputsRef.current
-      if (next) current.showItemMenu(kind, id, surface, placement)
-      else current.closeItemMenu()
+    openMenu(menu) {
+      rowActionInputsRef.current.showItemMenu(menu)
+    },
+    closeMenu() {
+      rowActionInputsRef.current.closeItemMenu()
     },
     startRename(kind, id, surface = 'drawer') {
       rowActionInputsRef.current.setRenaming({ kind, id, surface })
@@ -1086,16 +1085,6 @@ export default function Drawer({
                           ? activeView === 'chat' && activeChatId === item.id
                           : activeView === 'canvas' && Number(activeAppId) === Number(item.id)
                       )}
-                      menuOpen={!!(openMenu
-                        && openMenu.surface === 'drawer'
-                        && openMenu.kind === kind
-                        && openMenu.id === item.id)}
-                      menuPlacement={openMenu
-                        && openMenu.surface === 'drawer'
-                        && openMenu.kind === kind
-                        && openMenu.id === item.id
-                        ? openMenu.placement
-                        : null}
                       renaming={!!(renaming
                         && renaming.surface === 'drawer'
                         && renaming.kind === kind
@@ -1140,16 +1129,6 @@ export default function Drawer({
                         ? activeView === 'chat' && activeChatId === item.id
                         : activeView === 'canvas' && Number(activeAppId) === Number(item.id)
                     )}
-                    menuOpen={!!(openMenu
-                      && openMenu.surface === 'drawer'
-                      && openMenu.kind === kind
-                      && openMenu.id === item.id)}
-                    menuPlacement={openMenu
-                      && openMenu.surface === 'drawer'
-                      && openMenu.kind === kind
-                      && openMenu.id === item.id
-                      ? openMenu.placement
-                      : null}
                     renaming={!!(renaming
                       && renaming.surface === 'drawer'
                       && renaming.kind === kind
@@ -1240,16 +1219,6 @@ export default function Drawer({
               building={!!(app.chat_id && streamingSet.has(app.chat_id))}
               attention={newAppSet.has(Number(app.id))}
               active={activeView === 'canvas' && Number(activeAppId) === Number(app.id)}
-              menuOpen={!!(openMenu
-                && openMenu.surface === 'directory'
-                && openMenu.kind === 'app'
-                && openMenu.id === app.id)}
-              menuPlacement={openMenu
-                && openMenu.surface === 'directory'
-                && openMenu.kind === 'app'
-                && openMenu.id === app.id
-                ? openMenu.placement
-                : null}
               renaming={!!(renaming
                 && renaming.surface === 'directory'
                 && renaming.kind === 'app'
@@ -1259,6 +1228,12 @@ export default function Drawer({
           ))}
         </AppsDirectory>
       ), appsHost)}
+      <DrawerItemMenu
+        menu={openMenu}
+        item={activeMenuItem}
+        actions={rowActions}
+        restoreFocusRef={menuRestoreFocusRef}
+      />
       {installingApp && (
         <InstallSheet
           app={installingApp}
@@ -1336,8 +1311,6 @@ const DrawerRow = memo(function DrawerRow({
   // pulses the same way an active chat does.
   building,
   attention,
-  menuOpen,
-  menuPlacement,
   renaming,
   actions,
   dragActiveRef,
@@ -1352,7 +1325,6 @@ const DrawerRow = memo(function DrawerRow({
   const holdTimerRef = useRef(null)
   const holdOriginRef = useRef(null)
   const itemButtonRef = useRef(null)
-  const menuRestoreFocusRef = useRef(null)
   const suppressCardClickRef = useRef(false)
   const suppressRowClickRef = useRef(false)
   const reorderCleanupRef = useRef(null)
@@ -1429,7 +1401,6 @@ const DrawerRow = memo(function DrawerRow({
   // from scratch or tap into the existing name to edit it.
   useEffect(() => {
     if (renaming && inputRef.current) {
-      menuRestoreFocusRef.current = inputRef.current
       inputRef.current.focus()
       inputRef.current.select()
     }
@@ -1471,8 +1442,13 @@ const DrawerRow = memo(function DrawerRow({
   }
 
   function openItemMenuAt(point, trigger = itemButtonRef.current) {
-    menuRestoreFocusRef.current = trigger
-    actions.toggleMenu(kind, id, true, surface, itemMenuPlacement(point))
+    actions.openMenu({
+      kind,
+      id,
+      surface,
+      placement: itemMenuPlacement(point),
+      restoreFocusTarget: trigger,
+    })
   }
 
   function suppressTouchContextMenu(event) {
@@ -1546,19 +1522,6 @@ const DrawerRow = memo(function DrawerRow({
     return true
   }
 
-  const itemMenu = (
-    <DrawerItemMenu
-      kind={kind}
-      item={item}
-      surface={surface}
-      pinned={pinned}
-      menuOpen={menuOpen}
-      actions={actions}
-      menuPlacement={menuPlacement}
-      restoreFocusRef={menuRestoreFocusRef}
-    />
-  )
-
   if (renaming) {
     if (variant === 'card') {
       return (
@@ -1571,7 +1534,6 @@ const DrawerRow = memo(function DrawerRow({
             onBlur={onRenameBlur}
             aria-label="Rename app"
           />
-          {itemMenu}
         </div>
       )
     }
@@ -1585,7 +1547,6 @@ const DrawerRow = memo(function DrawerRow({
           onBlur={onRenameBlur}
           aria-label={`Rename ${kind}`}
         />
-        {itemMenu}
       </div>
     )
   }
@@ -1651,7 +1612,6 @@ const DrawerRow = memo(function DrawerRow({
             <span className="apps-directory__card-name">{label}</span>
           </span>
         </button>
-        {itemMenu}
       </div>
     )
   }
@@ -1935,35 +1895,33 @@ const DrawerRow = memo(function DrawerRow({
         ) : null}
         <span className="drawer__item-text">{label}</span>
       </button>
-      {itemMenu}
     </div>
   )
 })
 
-function DrawerItemMenu({
-  kind,
+const DrawerItemMenu = memo(function DrawerItemMenu({
+  menu,
   item,
-  surface,
-  pinned,
-  menuOpen,
-  menuPlacement,
-  restoreFocusRef,
   actions,
+  restoreFocusRef,
 }) {
-  const id = item.id
-  const label = kind === 'chat' ? item.title : item.name
+  const kind = menu?.kind || 'chat'
+  const id = menu?.id
+  const surface = menu?.surface || 'drawer'
+  const pinned = !!item?.pinned_at
+  const label = item ? (kind === 'chat' ? item.title : item.name) : ''
 
   return (
     <DrawerItemActionMenu
-      open={menuOpen}
+      open={Boolean(menu && item)}
       itemKind={kind}
       itemName={label}
       pinned={pinned}
-      canInstall={kind === 'app' && Boolean(item.slug)}
+      canInstall={kind === 'app' && Boolean(item?.slug)}
       canShare={kind === 'app' && isDrawerAppShareEligible(item)}
-      placement={menuPlacement}
+      placement={menu?.placement}
       restoreFocusRef={restoreFocusRef}
-      onClose={() => actions.toggleMenu(kind, id, false, surface)}
+      onClose={actions.closeMenu}
       onPin={() => actions.pin(kind, id, !pinned)}
       onRename={() => actions.startRename(kind, id, surface)}
       onInstall={() => actions.install(item)}
@@ -1972,4 +1930,4 @@ function DrawerItemMenu({
       onDeleteData={() => actions.removeData(id)}
     />
   )
-}
+})

--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -409,6 +409,16 @@ export default function Drawer({
     startRename(kind, id, surface = 'drawer') {
       rowActionInputsRef.current.setRenaming({ kind, id, surface })
     },
+    // Closing the menu consumes its Back-stack sentinel, and the traversal that
+    // follows drops focus to the document a few milliseconds later. The menu's
+    // post-close animation frame is the one place that focus is reclaimed, so
+    // its target has to be whatever the action left behind. Rename replaces the
+    // row trigger with an editor, and reasserting focus onto the now-unmounted
+    // trigger does nothing at all — the editor stays blurred, and its own blur
+    // handler then commits and unmounts it before the user can type.
+    claimMenuFocusReturn(element) {
+      rowActionInputsRef.current.menuRestoreFocusRef.current = element
+    },
     cancelRename() {
       rowActionInputsRef.current.setRenaming(null)
     },
@@ -951,6 +961,7 @@ export default function Drawer({
     onDeleteAppData,
     showItemMenu,
     closeItemMenu,
+    menuRestoreFocusRef,
     setRenaming,
     setInstallingApp,
     resetAppsSurfaceUi,
@@ -1399,10 +1410,11 @@ const DrawerRow = memo(function DrawerRow({
   // from scratch or tap into the existing name to edit it.
   useEffect(() => {
     if (renaming && inputRef.current) {
+      actions.claimMenuFocusReturn(inputRef.current)
       inputRef.current.focus()
       inputRef.current.select()
     }
-  }, [renaming])
+  }, [actions, renaming])
 
   function commitRename() {
     if (cancelingRef.current) {

--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -40,6 +40,7 @@ import DrawerItemActionMenu from './DrawerItemActionMenu.jsx'
 import {
   buildDrawerSections,
   filterInstalledApps,
+  findDrawerMenuItem,
 } from './drawerInformationArchitecture.js'
 import ShareAppSheet from './ShareAppSheet.jsx'
 import { isDrawerAppShareEligible } from './appShareState.js'
@@ -314,10 +315,7 @@ export default function Drawer({
   // and a focus-return target without mounting their own controllers.
   const [openMenu, setOpenMenu] = useState(null)
   const menuRestoreFocusRef = useRef(null)
-  const activeMenuItem = openMenu
-    ? (openMenu.kind === 'chat' ? (chats || []) : (apps || []))
-      .find(item => item.id === openMenu.id) || null
-    : null
+  const activeMenuItem = findDrawerMenuItem(openMenu, chats, apps)
   const {
     open: openItemMenuHistory,
     close: closeItemMenu,

--- a/frontend/src/components/Drawer/DrawerItemActionMenu.jsx
+++ b/frontend/src/components/Drawer/DrawerItemActionMenu.jsx
@@ -1,5 +1,5 @@
-/* DrawerItemActionMenu gives app launcher cards and drawer rows one compact,
-   pointer-accurate contextual menu across mouse, keyboard, and touch. */
+/* Drawer mounts one retargetable action-menu controller so virtualized rows
+   stay free of dormant menu hooks while scrolling. */
 
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'

--- a/frontend/src/components/Drawer/drawerInformationArchitecture.js
+++ b/frontend/src/components/Drawer/drawerInformationArchitecture.js
@@ -89,3 +89,12 @@ export function filterInstalledApps(apps = [], query = '') {
       .includes(needle)
   ))
 }
+
+// The shared menu names a row by identity, so it must survive that row
+// disappearing mid-render (deleted, filtered, or refreshed away) as ordinary
+// absence rather than a crash.
+export function findDrawerMenuItem(menu, chats = [], apps = []) {
+  if (!menu) return null
+  const items = menu.kind === 'chat' ? (chats || []) : (apps || [])
+  return items.find(item => item?.id === menu.id) || null
+}

--- a/frontend/src/components/Shell/__tests__/menuPointerOwnership.test.js
+++ b/frontend/src/components/Shell/__tests__/menuPointerOwnership.test.js
@@ -12,7 +12,7 @@ const empty = () => ({ press: null, clickAction: null })
 const actionA = {}
 const actionB = {}
 
-test('the opener release has no menu-owned press and cannot activate an action', () => {
+test('the shared menu ignores its opener release without a menu-owned press', () => {
   const outcome = consumeMenuClick(empty(), { detail: 1, action: actionA })
   assert.equal(outcome.allowed, false)
 })

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -885,6 +885,8 @@ test('large drawer lists memoize ordering and row actions without changing row o
   assert.match(drawer, /visibleRecents\.map\(\(\{ kind, item \}\)[\s\S]*?item=\{item\}[\s\S]*?actions=\{rowActions\}/)
   assert.match(drawer, /item=\{app\}[\s\S]*?actions=\{rowActions\}/)
   assert.doesNotMatch(drawer, /onSelect=\{\(\) => on(?:Chat|App)/)
+  assert.equal((drawer.match(/<DrawerItemMenu/g) || []).length, 1,
+    'the drawer must render one item-menu controller')
 })
 
 test('mixed recents reserve artwork for apps without redundant chat icons', () => {
@@ -953,9 +955,9 @@ test('chat deletion is immediate while app deletion still requires confirmation'
 test('drawer row actions have one opening path without a custom touch hold', () => {
   assert.match(drawer, /import \{ useHistoryDismiss \} from '\.\.\/\.\.\/hooks\/useHistoryDismiss\.jsx'/)
   assert.match(drawer, /open: openItemMenuHistory,[\s\S]*?close: closeItemMenu,[\s\S]*?useHistoryDismiss\(\(\) => setOpenMenu\(null\)\)/)
-  assert.match(drawer, /function showItemMenu\(kind, id, surface, placement\) \{[\s\S]*?openItemMenuHistory\(\)[\s\S]*?setOpenMenu/,
+  assert.match(drawer, /function showItemMenu\(\{ restoreFocusTarget, \.\.\.menu \}\) \{[\s\S]*?openItemMenuHistory\(\)[\s\S]*?setOpenMenu\(menu\)/,
     'Back ownership must be registered before the portaled menu paints')
-  assert.match(drawer, /function openItemMenuAt\(point,[\s\S]*?actions\.toggleMenu\(kind, id, true, surface,/)
+  assert.match(drawer, /function openItemMenuAt\(point,[\s\S]*?actions\.openMenu\(\{[\s\S]*?restoreFocusTarget: trigger,/)
   assert.equal((drawer.match(/onContextMenu=\{openItemMenu\}/g) || []).length, 2,
     'app cards and drawer rows must share one semantic opening function')
   assert.match(drawer, /if \(suppressTouchContextMenu\(event\)\) return/,

--- a/frontend/src/lib/__tests__/appsDirectoryContract.test.js
+++ b/frontend/src/lib/__tests__/appsDirectoryContract.test.js
@@ -25,9 +25,9 @@ test('Apps is a single drawer destination and the old full app list is gone', ()
   assert.match(drawer, /pinnedItems\.map\(\(\{ kind, item \}\)/)
 })
 
-test('the directory preserves app management on every card', () => {
-  assert.match(drawer, /variant="card"/)
-  assert.match(drawer, /<DrawerItemMenu[\s\S]*?surface=\{surface\}/)
+test('directory cards preserve app management through shared row actions', () => {
+  assert.match(drawer, /variant="card"[\s\S]*?actions=\{rowActions\}/,
+    'app cards must keep the shared row action surface')
   for (const action of ['Install to home screen', 'Share app', 'Delete data', 'Rename']) {
     assert.match(itemActionMenu, new RegExp(action))
   }
@@ -49,7 +49,7 @@ test('phone and web share one searchable launcher tab', () => {
   assert.match(dragImports, /PRE_HOLD_MOVE_PX/)
   assert.match(drawer, /setTimeout\(\(\) => \{[\s\S]*?openItemMenuAt[\s\S]*?DRAWER_MENU_HOLD_MS\)/)
   assert.doesNotMatch(drawer, /520/)
-  assert.match(drawer, /menuPlacement=\{openMenu/)
+  assert.match(drawer, /placement=\{menu\?\.placement\}/)
   assert.match(itemActionMenu, /placeContextMenu/)
   assert.match(itemActionMenu, /stopImmediatePropagation/)
   const phoneMenu = drawerCss.match(

--- a/frontend/src/lib/__tests__/drawerInformationArchitecture.test.js
+++ b/frontend/src/lib/__tests__/drawerInformationArchitecture.test.js
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict'
 import {
   buildDrawerSections,
   filterInstalledApps,
+  findDrawerMenuItem,
 } from '../../components/Drawer/drawerInformationArchitecture.js'
 
 test('drawer separates mixed pins from mixed recents ordered by activity', () => {
@@ -117,4 +118,14 @@ test('app search covers names, descriptions, and slugs without reordering', () =
   assert.equal(filterInstalledApps(apps, 'places')[0].id, 2)
   assert.equal(filterInstalledApps(apps, 'missing').length, 0)
   assert.equal(filterInstalledApps(apps, ''), apps)
+})
+
+test('a drawer menu item becomes ordinary absence when its row disappears', () => {
+  const chat = { id: 'chat-a', title: 'Chat A' }
+  const app = { id: 7, name: 'Atlas' }
+
+  assert.equal(findDrawerMenuItem({ kind: 'chat', id: chat.id }, [chat], [app]), chat)
+  assert.equal(findDrawerMenuItem({ kind: 'app', id: app.id }, [chat], [app]), app)
+  assert.equal(findDrawerMenuItem({ kind: 'chat', id: chat.id }, [], [app]), null)
+  assert.equal(findDrawerMenuItem(null, [chat], [app]), null)
 })


### PR DESCRIPTION
## Summary
- render one shared drawer item menu instead of a closed controller beside every mounted row
- pass menu identity and placement through the existing drawer action surface
- preserve keyboard, focus-return, deletion, and Apps launcher behavior

## Why
The Recents list mounts virtualized rows in batches while scrolling. Each new row previously brought along a complete closed action-menu controller, so crossing a window boundary could initialize many controllers on the same frame. Moving that controller to the drawer owner removes that work and also deletes the duplicated per-row menu state.

## Testing
- `npm test`
- `npm run lint`
- `npm run build`