### PR TITLE
connectors: cost visibility, least-privilege grants, resilient health (follow-ups to #632)

### DIFF
--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -4240,9 +4240,31 @@ async def _run_chat_impl_with_db(
   # provider's native tools instead of breaking chat.
   try:
     from app.connectors import build_turn_plan
+    # Connections follow the owner's own chats. A delegated child run or an
+    # app-attributed chat (embedded app panels, headless scheduled runs) must
+    # not inherit the owner's remote services; a per-app grant can opt in at
+    # this call site if a background app ever genuinely needs one. When the
+    # run has a chat_id but its row could not be loaded, attribution is
+    # unknown — fail closed rather than grant.
+    include_owner_connectors = (
+      run_policy is None
+      and (
+        not chat_id
+        or (chat_row is not None and chat_row.created_by_app_id is None)
+      )
+    )
+    if not include_owner_connectors:
+      reason = (
+        "delegated run policy" if run_policy is not None
+        else "chat attribution unavailable" if chat_row is None
+        else "app-attributed chat"
+      )
+      log.info(
+        "owner MCP connections withheld (%s) chat_id=%s", reason, chat_id,
+      )
     connector_turn_plan = build_turn_plan(
       db,
-      include_owner_connectors=run_policy is None,
+      include_owner_connectors=include_owner_connectors,
     )
   except Exception:
     log.warning(

--- a/backend/app/chat_context.py
+++ b/backend/app/chat_context.py
@@ -229,6 +229,7 @@ def _build_app_context(
     f"Registered chat id: {app.chat_id or ''}",
     f"Available app scripts: {', '.join(scripts) if scripts else 'none detected'}",
     "When changing this app, edit files under the source directory and use the existing register/build workflow.",
+    "Owner-managed MCP connections are not available in app-attributed chats.",
     "</app_context>",
   ])
   env = {

--- a/backend/app/connectors.py
+++ b/backend/app/connectors.py
@@ -21,6 +21,7 @@ import json
 import logging
 import os
 import re
+import socket
 import tempfile
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -41,11 +42,15 @@ log = logging.getLogger(__name__)
 # providers. Codex may move ahead independently, but a saved connection must
 # remain usable by Claude as well.
 MCP_PROTOCOL_VERSION = "2025-11-25"
-_SUPPORTED_PROTOCOL_VERSIONS = {
-  MCP_PROTOCOL_VERSION,
-  "2025-06-18",
-  "2025-03-26",
-}
+# MCP protocol revisions are ISO dates, so ordering is lexicographic. Accept
+# anything at or above the floor: the probe only uses initialize,
+# notifications/initialized, and tools/list (stable across revisions) and it
+# echoes the negotiated version afterwards, while each provider negotiates its
+# own session through the broker at turn time. A closed allowlist here would
+# turn a routine upstream version bump into an outage that only a code edit
+# could clear.
+_MIN_PROTOCOL_VERSION = "2025-03-26"
+_PROTOCOL_VERSION_RE = re.compile(r"\d{4}-\d{2}-\d{2}")
 _HANDSHAKE_TIMEOUT = httpx.Timeout(15.0, connect=8.0)
 _HANDSHAKE_DEADLINE_SECONDS = 22.0
 _MAX_RPC_BYTES = 2 * 1024 * 1024
@@ -85,7 +90,17 @@ _RESERVED_AUTH_HEADERS = {
 
 
 class ConnectorError(Exception):
-  """A connection failure safe to present in the owner-facing Settings UI."""
+  """A connection failure safe to present in the owner-facing Settings UI.
+
+  ``transient`` marks transport-level failures (a timeout, an unreachable
+  host) that say nothing definitive about the saved configuration, so a
+  health re-check may keep the last known status instead of latching the
+  connection out of agent turns.
+  """
+
+  def __init__(self, message: str, *, transient: bool = False):
+    super().__init__(message)
+    self.transient = transient
 
 
 @dataclass(frozen=True)
@@ -194,6 +209,20 @@ def slugify(name: str) -> str:
   return slug[:48] or "connector"
 
 
+def estimate_tokens(tools: list) -> int:
+  """Conservative chars/4 estimate over the full tool definitions.
+
+  Codex pays this schema cost on every message while Claude defers tool
+  loading, and same-count catalogs differ severalfold in size, so the count
+  alone is a misleading cost signal. Computed at handshake time because only
+  bounded tool names are persisted afterwards.
+  """
+  try:
+    return max(0, len(json.dumps(tools, separators=(",", ":"))) // 4)
+  except (TypeError, ValueError):
+    return 0
+
+
 def validate_auth_header(name: str | None) -> str | None:
   value = (name or "").strip()
   if not value:
@@ -256,7 +285,18 @@ def _safe_endpoint(url: str) -> tuple[str, str, str]:
   except ValueError as exc:
     raise ConnectorError("The MCP endpoint URL or port is not valid.") from exc
   except HTTPException as exc:
-    raise ConnectorError(str(exc.detail)) from exc
+    # DNS happens here, not in httpx: the SSRF validator pins the URL to a
+    # resolved IP first. A temporary resolver failure (EAI_AGAIN) says
+    # nothing definitive about the saved endpoint, unlike NXDOMAIN or an
+    # SSRF rejection, so carry the transient marker through.
+    cause = exc.__cause__ or exc.__context__
+    raise ConnectorError(
+      str(exc.detail),
+      transient=(
+        isinstance(cause, socket.gaierror)
+        and cause.errno == socket.EAI_AGAIN
+      ),
+    ) from exc
 
 
 def _matching_payload(payload: object, rpc_id: int) -> dict | None:
@@ -490,7 +530,10 @@ async def handshake(
       ) as client:
         init, session_id = await _initialize_rpc(client, endpoint, headers)
         negotiated = str(init.get("protocolVersion") or "")
-        if negotiated not in _SUPPORTED_PROTOCOL_VERSIONS:
+        if (
+          not _PROTOCOL_VERSION_RE.fullmatch(negotiated)
+          or negotiated < _MIN_PROTOCOL_VERSION
+        ):
           raise ConnectorError(
             "The service negotiated an unsupported MCP version."
           )
@@ -537,10 +580,15 @@ async def handshake(
     raise
   except (TimeoutError, httpx.TimeoutException) as exc:
     raise ConnectorError(
-      "The service did not answer before the connection timed out."
+      "The service did not answer before the connection timed out.",
+      transient=True,
     ) from exc
   except httpx.HTTPError as exc:
-    raise ConnectorError("Could not reach the MCP service.") from exc
+    # HTTP status problems become specific ConnectorErrors inside the RPC
+    # helpers, so only transport-level failures reach this branch.
+    raise ConnectorError(
+      "Could not reach the MCP service.", transient=True,
+    ) from exc
 
   submitted_secrets = tuple(sorted({
     value
@@ -558,6 +606,7 @@ async def handshake(
       128,
     ),
     "tools": _tool_names(tools, submitted_secrets),
+    "est_tokens": estimate_tokens(tools),
   }
 
 

--- a/backend/app/delegations.py
+++ b/backend/app/delegations.py
@@ -71,6 +71,7 @@ class RunPolicy:
       "Do not ask the owner an interactive question; if a required decision or "
       "credential is missing, stop and state the blocker precisely. Do not "
       "inspect unrelated chats, Memory, skills, or installed-app instructions. "
+      "Owner-managed MCP connections are not available in this run. "
       "Never read or write /data/cli-auth or /data/.secret-key. "
       f"Working directory: {self.cwd}. {scope_rule}"
     )

--- a/backend/app/net_utils.py
+++ b/backend/app/net_utils.py
@@ -86,7 +86,7 @@ def validate_url_safe(url: str) -> tuple[str, str, str]:
   try:
     infos = socket.getaddrinfo(host, None)
   except socket.gaierror as exc:
-    raise HTTPException(400, f"Cannot resolve host {host!r}: {exc}")
+    raise HTTPException(400, f"Cannot resolve host {host!r}: {exc}") from exc
   pinned_ip = None
   for info in infos:
     ip_str = info[4][0]

--- a/backend/app/routes/connectors.py
+++ b/backend/app/routes/connectors.py
@@ -85,6 +85,12 @@ class ConnectorPatch(BaseModel):
 
 def _public(row: models.Connector) -> dict:
   tools = row.tools_json if isinstance(row.tools_json, list) else []
+  # Legacy rows persisted full tool metadata dicts; present bounded names.
+  names = [
+    tool.get("name") if isinstance(tool, dict) else tool
+    for tool in tools
+  ]
+  names = [name for name in names if isinstance(name, str) and name]
   return {
     "id": row.id,
     # This generation changes at revocation boundaries. Owner mutations must
@@ -94,7 +100,9 @@ def _public(row: models.Connector) -> dict:
     "url": row.url,
     "enabled": row.enabled,
     "has_auth": bool(row.auth_header and row.auth_value_encrypted),
+    "tools": names,
     "tool_count": len(tools),
+    "est_tokens": row.est_tokens or 0,
     "status": row.status,
     "status_detail": row.status_detail,
   }
@@ -453,7 +461,7 @@ async def add_connector(
       ),
       enabled=True,
       tools_json=probe["tools"],
-      est_tokens=0,
+      est_tokens=probe["est_tokens"],
       status="ok",
       status_detail=None,
       last_checked_at=now_naive_utc(),
@@ -483,11 +491,6 @@ async def patch_connector(
   row = _get_row(db, connector_id, generation)
   values: dict[str, object] = {}
   if body.enabled is not None:
-    if body.enabled and row.status != "ok":
-      raise HTTPException(
-        status_code=409,
-        detail="Re-check this connection successfully before enabling it.",
-      )
     if row.enabled and not body.enabled:
       # Disabling is a revocation boundary. Give a later re-enable a fresh
       # identity so a capability minted before the disable cannot revive.
@@ -497,6 +500,9 @@ async def patch_connector(
     values["name"] = body.name
   if not values:
     return _public(row)
+  # The conditional UPDATE is the single enforcement point: filters express
+  # every precondition, so the miss branch below is the real (and only)
+  # rejection path rather than a dead backstop behind a pre-check.
   target = db.query(models.Connector).filter(
     models.Connector.id == connector_id,
     models.Connector.capability_id == generation,
@@ -506,7 +512,7 @@ async def patch_connector(
   updated = target.update(values, synchronize_session=False)
   if updated != 1:
     db.rollback()
-    if body.enabled:
+    if body.enabled and row.status != "ok":
       raise HTTPException(
         status_code=409,
         detail="Re-check this connection successfully before enabling it.",
@@ -544,6 +550,7 @@ async def refresh_connector(
     except core.ConnectorError as exc:
       raise HTTPException(status_code=409, detail=str(exc)) from exc
   url = str(stored.url)
+  prior_status = str(stored.status)
   # Do not lease a DB connection while waiting on DNS or a remote service.
   # Re-fetch after the probe so a concurrent disable/delete remains decisive.
   db.close()
@@ -551,15 +558,23 @@ async def refresh_connector(
     probe = await core.handshake(url, auth_header, secret)
     values = {
       "tools_json": probe["tools"],
-      "est_tokens": 0,
+      "est_tokens": probe["est_tokens"],
       "status": "ok",
       "status_detail": None,
     }
   except core.ConnectorError as exc:
-    values = {
-      "status": "error",
-      "status_detail": str(exc),
-    }
+    if exc.transient:
+      # A transport blip says nothing definitive about the configuration.
+      # Keep the last known health so one flaky moment cannot silently
+      # remove the connection from later agent turns. Annotate only healthy
+      # rows: an already-latched row keeps its definitive diagnosis instead
+      # of having it overwritten by a generic transport message.
+      values = {"status_detail": str(exc)} if prior_status == "ok" else {}
+    else:
+      values = {
+        "status": "error",
+        "status_detail": str(exc),
+      }
   values["last_checked_at"] = now_naive_utc()
   identity = db.query(models.Connector).filter(
     models.Connector.id == connector_id,

--- a/backend/tests/test_connector_grant_policy.py
+++ b/backend/tests/test_connector_grant_policy.py
@@ -1,0 +1,126 @@
+"""Owner MCP connections must follow the owner's own chats only."""
+
+import asyncio
+
+import pytest
+
+from app import chat as chat_mod
+from app import chat_queue, models, schemas
+from app.broadcast import create_broadcast, remove_broadcast
+
+
+def _app_row(db, marker):
+  row = models.App(
+    slug=f"grant-policy-{marker}",
+    source_dir=f"/tmp/mobius-tests/grant-policy-{marker}",
+    name="grant-policy app",
+    description="test",
+    jsx_source="export default () => null",
+  )
+  db.add(row)
+  db.commit()
+  db.refresh(row)
+  return row
+
+
+async def _drive_turn(chat_id, monkeypatch, *, expected_include):
+  """Run one codex turn with fakes; return the connector plans the runner saw."""
+  observed = []
+  granted_plan = object()
+
+  def fake_connector_plan(_db, *, include_owner_connectors):
+    observed.append(include_owner_connectors)
+    return granted_plan if include_owner_connectors else None
+
+  monkeypatch.setattr("app.connectors.build_turn_plan", fake_connector_plan)
+
+  plans = []
+
+  async def fake_runner(**kwargs):
+    plans.append(kwargs["connector_plan"])
+    return {"session_id": None, "cost_usd": 0.0, "error": None}
+
+  async def fake_complete(**kwargs):
+    kwargs["db"].close()
+    return chat_queue.TerminalDisposition.EMPTY_TERMINAL_CLEARED
+
+  monkeypatch.setattr("app.codex_sdk_runner.run_codex_sdk_turn", fake_runner)
+  monkeypatch.setattr(
+    "app.providers.CodexProvider.check_auth", lambda self, _data_dir: None,
+  )
+  monkeypatch.setattr(chat_mod, "_complete_turn", fake_complete)
+
+  create_broadcast(chat_id)
+  try:
+    await asyncio.wait_for(chat_mod._run_chat_impl(
+      messages=[schemas.ChatMessage(role="user", content="hi")],
+      chat_id=chat_id,
+      session_id="existing-session",
+      provider_id="codex",
+      run_gen=chat_mod.current_run_generation(chat_id),
+    ), timeout=5)
+  finally:
+    remove_broadcast(chat_id)
+  assert observed == [expected_include]
+  return plans, granted_plan
+
+
+@pytest.mark.asyncio
+async def test_app_attributed_chat_does_not_inherit_owner_connections(
+  chat, db, monkeypatch,
+):
+  app_row = _app_row(db, "attributed")
+  chat.provider = "codex"
+  chat.agent_settings_json = {"model": "gpt-5.4"}
+  chat.created_by_app_id = app_row.id
+  db.commit()
+
+  plans, _granted = await _drive_turn(chat.id, monkeypatch, expected_include=False)
+  assert plans == [None]
+
+
+@pytest.mark.asyncio
+async def test_owner_chat_keeps_owner_connections(chat, db, monkeypatch):
+  chat.provider = "codex"
+  chat.agent_settings_json = {"model": "gpt-5.4"}
+  db.commit()
+
+  plans, granted = await _drive_turn(chat.id, monkeypatch, expected_include=True)
+  assert plans == [granted]
+
+
+def test_delegated_prompt_states_connections_unavailable():
+  from app.delegations import RunPolicy
+
+  policy = RunPolicy(
+    delegation_id="delegation-1",
+    app_id=2,
+    provider="codex",
+    model=None,
+    effort=None,
+    scope="read",
+    cwd="/data",
+    max_budget_usd=None,
+  )
+  assert (
+    "Owner-managed MCP connections are not available" in policy.system_prompt
+  )
+
+
+def test_app_chat_context_states_connections_unavailable(db):
+  app_row = _app_row(db, "context")
+  row = models.Chat(
+    id="grant-policy-context-chat",
+    title="app chat",
+    messages=[],
+    created_by_app_id=app_row.id,
+  )
+  db.add(row)
+  db.commit()
+
+  from app.chat_context import _build_app_context
+
+  block, _env = _build_app_context(
+    db, "grant-policy-context-chat", "/tmp/mobius-tests",
+  )
+  assert "Owner-managed MCP connections are not available" in block

--- a/backend/tests/test_connectors.py
+++ b/backend/tests/test_connectors.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import os
+import socket
 import tempfile
 import time
 from unittest.mock import AsyncMock
@@ -175,15 +176,77 @@ async def test_handshake_negotiates_session_and_paginates_tools(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_handshake_rejects_a_2026_only_server(monkeypatch):
+async def test_handshake_accepts_a_newer_protocol_version(monkeypatch):
+  """A routine upstream version bump must not become an outage."""
+  methods = []
+
+  def handler(request: httpx.Request) -> httpx.Response:
+    body = json.loads(request.content)
+    methods.append(body["method"])
+    if body["method"] == "initialize":
+      assert body["params"]["protocolVersion"] == "2025-11-25"
+      assert request.headers["mcp-protocol-version"] == "2025-11-25"
+      return httpx.Response(
+        200,
+        request=request,
+        headers={"content-type": "application/json"},
+        json={
+          "jsonrpc": "2.0",
+          "id": 1,
+          "result": {
+            "protocolVersion": "2026-07-28",
+            "serverInfo": {"name": "Future MCP"},
+          },
+        },
+      )
+    assert request.headers["mcp-protocol-version"] == "2026-07-28"
+    if body["method"] == "notifications/initialized":
+      return httpx.Response(202, request=request)
+    return httpx.Response(
+      200,
+      request=request,
+      headers={"content-type": "application/json"},
+      json={
+        "jsonrpc": "2.0",
+        "id": 2,
+        "result": {"tools": [{"name": "future_tool"}]},
+      },
+    )
+
+  monkeypatch.setattr(
+    core,
+    "_safe_endpoint",
+    lambda _url: ("https://203.0.113.8/mcp", "mcp.example", "mcp.example"),
+  )
+  real_async_client = httpx.AsyncClient
+  monkeypatch.setattr(
+    core.httpx,
+    "AsyncClient",
+    lambda **kwargs: real_async_client(
+      transport=httpx.MockTransport(handler),
+      timeout=kwargs.get("timeout"),
+      follow_redirects=False,
+    ),
+  )
+
+  result = await core.handshake("https://mcp.example/mcp")
+  assert result["name"] == "Future MCP"
+  assert result["tools"] == ["future_tool"]
+  assert result["est_tokens"] > 0
+  assert methods == ["initialize", "notifications/initialized", "tools/list"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("negotiated", ("2024-11-05", "vNext"))
+async def test_handshake_rejects_prefloor_or_malformed_versions(
+  monkeypatch, negotiated,
+):
   methods = []
 
   def handler(request: httpx.Request) -> httpx.Response:
     body = json.loads(request.content)
     methods.append(body["method"])
     assert body["method"] == "initialize"
-    assert body["params"]["protocolVersion"] == "2025-11-25"
-    assert request.headers["mcp-protocol-version"] == "2025-11-25"
     return httpx.Response(
       200,
       request=request,
@@ -192,8 +255,8 @@ async def test_handshake_rejects_a_2026_only_server(monkeypatch):
         "jsonrpc": "2.0",
         "id": 1,
         "result": {
-          "protocolVersion": "2026-07-28",
-          "serverInfo": {"name": "Future MCP"},
+          "protocolVersion": negotiated,
+          "serverInfo": {"name": "Old MCP"},
         },
       },
     )
@@ -294,7 +357,9 @@ async def test_handshake_redacts_secret_echoes_and_rpc_errors(monkeypatch):
   assert result == {
     "name": "[redacted] service",
     "tools": ["[redacted] lookup"],
+    "est_tokens": result["est_tokens"],
   }
+  assert result["est_tokens"] > 0
   assert "inputSchema" not in json.dumps(result)
   assert "echo-secret" not in json.dumps(result)
 
@@ -523,6 +588,7 @@ def test_connector_routes_keep_keys_out_of_responses(
   probe = {
     "name": "Example MCP",
     "tools": ["lookup"],
+    "est_tokens": 5150,
   }
   probe_pool_counts = []
 
@@ -570,8 +636,10 @@ def test_connector_routes_keep_keys_out_of_responses(
   assert body["has_auth"] is True
   assert set(body) == {
     "id", "generation", "name", "url", "enabled", "has_auth",
-    "tool_count", "status", "status_detail",
+    "tools", "tool_count", "est_tokens", "status", "status_detail",
   }
+  assert body["tools"] == ["lookup"]
+  assert body["est_tokens"] == 5150
   assert "top-secret" not in created.text
   assert probe_pool_counts == [add_baseline]
 
@@ -726,6 +794,101 @@ def test_unhealthy_connection_cannot_be_enabled_planned_or_brokered(
   assert denied.status_code == 404
 
 
+@pytest.mark.asyncio
+async def test_dns_blip_is_transient_but_dead_name_is_definitive(monkeypatch):
+  """DNS happens in the SSRF validator, not httpx; classify it there too."""
+
+  def resolver_blip(host, *_args, **_kwargs):
+    raise socket.gaierror(
+      socket.EAI_AGAIN, "Temporary failure in name resolution",
+    )
+
+  monkeypatch.setattr("app.net_utils.socket.getaddrinfo", resolver_blip)
+  with pytest.raises(core.ConnectorError) as blip:
+    await core.handshake("https://mcp.example/mcp")
+  assert blip.value.transient is True
+
+  def dead_name(host, *_args, **_kwargs):
+    raise socket.gaierror(socket.EAI_NONAME, "Name or service not known")
+
+  monkeypatch.setattr("app.net_utils.socket.getaddrinfo", dead_name)
+  with pytest.raises(core.ConnectorError) as gone:
+    await core.handshake("https://mcp.example/mcp")
+  assert gone.value.transient is False
+
+
+def test_estimate_tokens_scales_with_schema_size():
+  small = [{"name": "a", "inputSchema": {}}]
+  large = [
+    {
+      "name": f"tool_{index}",
+      "inputSchema": {
+        "properties": {key: {"type": "string"} for key in ("one", "two")},
+      },
+    }
+    for index in range(40)
+  ]
+  assert core.estimate_tokens([]) == 0
+  assert 0 < core.estimate_tokens(small) < core.estimate_tokens(large)
+  assert core.estimate_tokens([object()]) == 0
+
+
+def test_refresh_transient_failure_keeps_last_known_health(
+  client, auth, db, monkeypatch,
+):
+  row = _row(78, "flaky", "https://remote.example/mcp")
+  row.tools_json = ["lookup"]
+  row.est_tokens = 1200
+  db.add(row)
+  db.commit()
+  generation = row.capability_id
+
+  async def transient_probe(*_args, **_kwargs):
+    raise core.ConnectorError(
+      "Could not reach the MCP service.", transient=True,
+    )
+
+  monkeypatch.setattr(core, "handshake", transient_probe)
+  refreshed = client.post(
+    f"/api/connectors/{row.id}/refresh",
+    headers=_owner_headers(auth, generation),
+  )
+  assert refreshed.status_code == 200
+  body = refreshed.json()
+  # One transport blip must not latch the connection out of agent turns.
+  assert body["status"] == "ok"
+  assert "Could not reach" in body["status_detail"]
+  assert body["est_tokens"] == 1200
+  db.expire_all()
+  assert core.build_turn_plan(db, include_owner_connectors=True) is not None
+
+  async def definitive_probe(*_args, **_kwargs):
+    raise core.ConnectorError(
+      "The service rejected the key or requires an OAuth sign-in flow.",
+    )
+
+  monkeypatch.setattr(core, "handshake", definitive_probe)
+  rejected = client.post(
+    f"/api/connectors/{row.id}/refresh",
+    headers=_owner_headers(auth, generation),
+  )
+  assert rejected.status_code == 200
+  assert rejected.json()["status"] == "error"
+  db.expire_all()
+  assert core.build_turn_plan(db, include_owner_connectors=True) is None
+
+  # A blip while already latched keeps the definitive diagnosis so the owner
+  # still sees the real reason, not a generic transport message.
+  monkeypatch.setattr(core, "handshake", transient_probe)
+  still_error = client.post(
+    f"/api/connectors/{row.id}/refresh",
+    headers=_owner_headers(auth, generation),
+  )
+  assert still_error.status_code == 200
+  assert still_error.json()["status"] == "error"
+  assert "rejected the key" in still_error.json()["status_detail"]
+
+
 def test_refresh_cannot_overwrite_reused_connector_id(
   client, auth, db, monkeypatch,
 ):
@@ -748,6 +911,7 @@ def test_refresh_cannot_overwrite_reused_connector_id(
     return {
       "name": "Stale probe",
       "tools": ["stale"],
+      "est_tokens": 3,
     }
 
   monkeypatch.setattr(core, "handshake", replace_during_probe)

--- a/frontend/src/components/SettingsView/ConnectorsSection.jsx
+++ b/frontend/src/components/SettingsView/ConnectorsSection.jsx
@@ -22,6 +22,16 @@ function displayEndpoint(value) {
   }
 }
 
+/* Same-count catalogs differ severalfold in schema size, and Codex pays that
+   cost on every message, so the count alone is a misleading signal. */
+function schemaCostLabel(estTokens) {
+  if (!estTokens) return ''
+  const value = estTokens >= 1000
+    ? `${(estTokens / 1000).toFixed(estTokens >= 10000 ? 0 : 1)}k`
+    : String(estTokens)
+  return `~${value} tool-schema tokens`
+}
+
 function focusConnectionTarget(root, connectorId = null) {
   const preferred = connectorId === null
     ? null
@@ -204,6 +214,12 @@ export default function ConnectorsSection({ active = true }) {
       const data = await jsonOrThrow(response, label)
       await connectorQueries.list.invalidate(queryClient)
       return data
+    } catch (error) {
+      // A failed action may have committed server-side (lost response) or hit
+      // a stale generation. Resync so the row cannot wedge behind stale state;
+      // fire-and-forget keeps the error surfacing immediately.
+      void connectorQueries.list.invalidate(queryClient)
+      throw error
     } finally {
       mutationPending.current = false
       setPending(false)
@@ -301,8 +317,19 @@ export default function ConnectorsSection({ active = true }) {
                   </span>
                   <span className="settings-connections__meta">
                     {connection.enabled ? 'On' : 'Off'}
-                    {' · '}{unhealthy ? 'Needs attention' : 'Reachable'}
-                    {' · '}{connection.tool_count} tool{connection.tool_count === 1 ? '' : 's'}
+                    {' · '}
+                    {unhealthy
+                      ? 'Needs attention'
+                      : (connection.status_detail
+                        ? 'Unreachable at last check'
+                        : 'Reachable')}
+                    {' · '}
+                    <span title={(connection.tools || []).join(', ') || undefined}>
+                      {connection.tool_count} tool{connection.tool_count === 1 ? '' : 's'}
+                    </span>
+                    {connection.est_tokens
+                      ? ` · ${schemaCostLabel(connection.est_tokens)}`
+                      : ''}
                     {connection.has_auth ? ' · API key saved' : ''}
                   </span>
                   {unhealthy && connection.status_detail && (


### PR DESCRIPTION
Follow-ups from a post-merge review of #632, verified against the merged code. Six changes, smallest-durable-fix each, at the layer that owns the behavior.

## Restore the per-connection token estimate
#632 kept only a tool count, but same-count catalogs differ severalfold in schema size, and Codex pays that cost on every message (Claude defers tool loading). The estimate is recomputed at handshake time — the only moment the full definitions exist in memory — persisted in the existing `est_tokens` column (no migration), and shown in Settings again. The persisted bounded tool names now also reach the owner (tooltip on the count), giving the stored data a consumer.

Existing rows show no estimate until their next successful re-check or add repopulates it; the UI hides the label at zero.

## Grant connections to the owner's own chats only
The rule was "anything that isn't a delegated sub-run", which handed every app-attributed chat — embedded app panels running app-authored prompts, headless scheduled runs — 24-hour capabilities to **all** enabled connections, unwatched. The predicate at the single call site now expresses the intended rule, fails closed when chat attribution can't be loaded, and both denials are non-silent: one sentence in the delegated-run prompt, one in the app-chat context block, and a reason-tagged log line. A per-app opt-in can land at the same call site if a background app ever genuinely needs a connection (the hook `build_turn_plan` reserves).

## Stop latching health on transient failures
A transport blip during an owner Re-check permanently withheld the connection from every turn — including headless runs — while the toggle still read "On". `ConnectorError` now carries a `transient` marker for transport-level failures, **including the DNS leg**: resolution happens in the SSRF validator (the URL is pinned to an IP before httpx connects), so `EAI_AGAIN` is classified there; `EAI_NONAME` stays definitive. On a transient failure the last known health is kept; Settings shows "Unreachable at last check" for a healthy row, and an already-latched row keeps its definitive diagnosis instead of a generic transport message. Definitive rejections latch exactly as before, and the broker still re-validates per request.

## Accept MCP protocol revisions by floor, not allowlist
The closed three-version set made a routine upstream version bump an outage only a code edit could clear — while the runtime path never checks the version (providers negotiate their own sessions through the broker, which forwards `mcp-protocol-version` transparently). Revisions are ISO dates: validate the format, reject only below `2025-03-26`. The probe uses only revision-stable methods and echoes the negotiated version afterwards.

## Resync the Settings list when an action fails
A disable whose response was lost rotated the generation server-side and left the row wedged — every retry answered "Connection not found." until a refetch happened by accident. A failed mutation now invalidates the list (fire-and-forget, so the error still surfaces immediately).

## Make `patch_connector`'s conditional UPDATE the single enforcement point
The pre-check duplicated the guarded UPDATE's conditions with no await between read and write, making the `updated != 1` branch unreachable — dead, untested error paths with duplicate user-facing messages. The filters now express every precondition and the miss branch is the live rejection path, mirroring `refresh_connector` where the same guard is genuinely load-bearing. Behavior is identical; the guard also stays correct if an await or second worker ever appears.

## Tests
- Protocol: future revision accepted end-to-end (negotiated version echoed), pre-floor and malformed rejected at `initialize`.
- Transient health: blip keeps `status="ok"` + turn-plan inclusion, definitive failure latches, blip-while-latched preserves the definitive detail; DNS `EAI_AGAIN` transient vs `EAI_NONAME` definitive.
- Grant rule: app-attributed chat turn receives no connector plan, owner chat still does (driven through `_run_chat_impl` with the real call site); denial sentences asserted in both prompts.
- `est_tokens`: flows through add/refresh/public shape; estimator scales with schema size.
- Full `test_connectors.py`, `test_delegations.py`, `test_app_chat_contract.py`, `test_agent_turn_releases_db_connection.py` pass on this base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)