### PR TITLE
Make frame commit own capability readiness

### DIFF
--- a/backend/tests/test_frame_mount_guard.py
+++ b/backend/tests/test_frame_mount_guard.py
@@ -5,10 +5,12 @@ handleFrameError in app-frame.html suppresses the error panel when
 RUNNING mini-app (e.g. an offline fetch failing at game-over) doesn't blank
 a working UI. The guard shipped once with NOTHING ever setting the flag —
 read-but-never-assigned made it dead code and every post-mount error still
-destroyed the app. These tests lock the read and the write together, and
-pin the write to a passive effect: createRoot().render() only SCHEDULES the
-first render, so a synchronous assignment after it would also swallow
-errors thrown during the initial render (which must still show the panel).
+destroyed the app. These tests lock the read and the write together, and pin the write to a
+commit-time ref callback: createRoot().render() only SCHEDULES the first
+render, so a synchronous assignment after it would also swallow errors thrown
+during the initial render (which must still show the panel). A ref runs during
+commit — after the DOM is attached, before layout effects, and never on a
+render that throws — so the flag means "committed, visible DOM".
 """
 
 import re
@@ -49,18 +51,42 @@ def test_error_guard_reads_mounted_flag():
   )
 
 
-def test_mounted_flag_is_set_inside_an_effect():
+def test_mounted_flag_is_set_by_a_commit_ref():
   html = _frame_html()
-  # The assignment must exist (the original bug: guard read a flag nothing
-  # set) and must live inside a useEffect callback so it only flips after
-  # React COMMITS the first render — a synchronous set after render() would
-  # suppress the panel for components that throw during their first render.
+  # The assignment must exist (the original bug: the guard read a flag nothing
+  # set) and must flip only when React COMMITS the first render. The signal is a
+  # commit-time ref callback, not a synchronous set after createRoot().render()
+  # (which only SCHEDULES the render and would suppress the panel for a component
+  # that throws during it).
   assignment = re.search(
-    r"useEffect\(\(\)\s*=>\s*\{\s*window\.__frameMounted\s*=\s*true", html
+    r"function signalFrameMounted\([^)]*\)\s*\{[^}]*window\.__frameMounted\s*=\s*true",
+    html,
+    re.DOTALL,
   )
   assert assignment, (
-    "window.__frameMounted is never set inside a useEffect — the post-mount "
-    "error guard is dead code (or fires before the first render commits)."
+    "window.__frameMounted is no longer assigned in signalFrameMounted — the "
+    "post-mount error guard would read a flag nothing sets (dead code)."
+  )
+  # The setter ignores ref detach (a null node) and never flips twice, so a
+  # re-attach cannot re-post 'mounted'.
+  assert re.search(
+    r"function signalFrameMounted\([^)]*\)\s*\{\s*if\s*\(!node\s*\|\|\s*"
+    r"window\.__frameMounted\)\s*return",
+    html,
+  ), "signalFrameMounted no longer guards against a null node / double flip."
+  # MountSignal must attach the setter as a commit ref, not a passive effect: a
+  # ref runs during commit (DOM attached, before layout effects), never on an
+  # aborted first render.
+  mount_signal = html[
+    html.index("function MountSignal"):
+    html.index("// Immersive safe-area passthrough")
+  ]
+  assert re.search(r"ref:\s*signalFrameMounted", mount_signal), (
+    "MountSignal no longer wires signalFrameMounted as a commit ref."
+  )
+  assert "useEffect" not in mount_signal, (
+    "MountSignal sets the mount flag from an effect again — use the commit ref "
+    "so 'mounted' means committed, visible DOM."
   )
 
 

--- a/frontend/public/app-frame.html
+++ b/frontend/public/app-frame.html
@@ -468,9 +468,9 @@
     // fetch/storage save failing at Snake's game-over — would otherwise
     // destroy the whole app to a blank/error screen. So once mounted we
     // keep the app on screen and only LOG the error; pre-mount errors
-    // still surface the panel. `window.__frameMounted` is set by a
-    // passive effect after React commits the first render (see
-    // MountSignal in the module script below) — NOT right after
+    // still surface the panel. `window.__frameMounted` is set by a stable
+    // DOM ref while React commits the first render (see MountSignal in the
+    // module script below) — NOT right after
     // createRoot().render(), because render() only schedules the first
     // render and a component that throws during it reports the error
     // asynchronously, after render() returns.
@@ -543,10 +543,11 @@
     //      cache offline; this opaque frame cannot. The parent transfers only
     //      the exact source-attributed app/version bytes back.
     //   4. iframe imports those bytes from a short-lived blob URL and mounts.
-    //   5. iframe posts {type:'moebius:frame-mounted', appId} AFTER the
-    //      first render COMMITS (MountSignal's effect, not render()-
-    //      returned) — parent hides the loading overlay / promotes the
-    //      buffered frame in a version swap.
+    //   5. iframe posts {type:'moebius:frame-mounted', appId} as the first
+    //      render COMMITS (MountSignal's stable ref, not render()-returned).
+    //      Ref attachment precedes app layout effects, so their mount-time host
+    //      requests cannot overtake promotion of this frame. The parent then
+    //      hides the loading overlay / promotes the buffered version swap.
     //   5b. on a terminal load failure instead of (5), iframe posts
     //      {type:'moebius:frame-error', appId} so the parent hides the
     //      overlay and this frame's error panel becomes visible.
@@ -576,7 +577,6 @@
     let createRoot = null;
     let createElement = null;
     let Fragment = null;
-    let useEffect = null;
     const COMPILED_RUNTIME_ABI = 1;
     let suspendedScrollFrame = null;
     let nextModuleRequest = 0;
@@ -870,33 +870,25 @@
     }
 
     // Flips the post-mount error guard (handleFrameError above) AND tells the
-    // parent the app is mounted. Rendered as the FIRST sibling of the app
-    // component, so its passive effect is the first thing React runs after
-    // COMMITTING the initial render — i.e. the app's DOM is actually on
-    // screen. A component that throws DURING its first render aborts the
-    // commit, this effect never runs, and the error panel still shows (the
-    // pre-mount path). A throw in the app's own mount effects happens with
-    // committed, visible DOM, so counting it as post-mount (suppressed +
-    // logged) is correct.
-    //
-    // frame-mounted MUST be posted here and not after createRoot().render()
-    // in loadModule: render() only SCHEDULES the first render, so posting
-    // there claims "mounted" for a component that may still throw during
-    // that render. The parent's double-buffered swap (AppCanvas) PROMOTES
-    // the new frame and unmounts the old working one on this signal — a
-    // premature post would swap in a frame whose commit then aborts,
-    // stranding the owner on an error panel with the working frame already
-    // gone. Posting at commit makes "mounted" mean visible DOM for both the
-    // parent's overlay and the swap.
+    // parent the app is mounted. This stable ref is attached during React's
+    // commit, before app layout effects can invoke a host capability. A render
+    // failure never commits the marker, while an effect failure happens after
+    // visible DOM exists and correctly counts as post-mount.
+    function signalFrameMounted(node) {
+      if (!node || window.__frameMounted) return;
+      window.__frameMounted = true;
+      window.parent.postMessage(
+        { type: 'moebius:frame-mounted', appId: _FRAME_APP_ID },
+        window.location.origin
+      );
+    }
+
     function MountSignal() {
-      useEffect(() => {
-        window.__frameMounted = true;
-        window.parent.postMessage(
-          { type: 'moebius:frame-mounted', appId: _FRAME_APP_ID },
-          window.location.origin
-        );
-      }, []);
-      return null;
+      return createElement('span', {
+        hidden: true,
+        'aria-hidden': 'true',
+        ref: signalFrameMounted,
+      });
     }
 
     // Immersive safe-area passthrough. env(safe-area-inset-*) reads 0 inside
@@ -1121,14 +1113,12 @@
         if (!compiledRuntime ||
             compiledRuntime.abi !== COMPILED_RUNTIME_ABI ||
             typeof compiledRuntime.createRoot !== 'function' ||
-            typeof compiledRuntime.createElement !== 'function' ||
-            typeof compiledRuntime.useEffect !== 'function') {
+            typeof compiledRuntime.createElement !== 'function') {
           throw new Error('The app bundle is missing the compiled runtime.');
         }
         createRoot = compiledRuntime.createRoot;
         createElement = compiledRuntime.createElement;
         Fragment = compiledRuntime.Fragment;
-        useEffect = compiledRuntime.useEffect;
         const Component = mod.default;
         if (!Component) {
           showErr('Module error', 'The app module has no default export.');
@@ -1137,12 +1127,10 @@
         mountedRoot = createRoot(document.getElementById('root'));
         mountedComponent = Component;
         renderMountedComponent();
-        // frame-mounted is posted by MountSignal's passive effect (above),
-        // which runs only after React COMMITS this first render. Posting
-        // here would be premature: render() has merely been scheduled, and
-        // a component that throws during its first render would have
-        // already claimed "mounted" — the parent's double-buffered swap
-        // would promote a dead frame on that lie. See MountSignal.
+        // frame-mounted is posted by MountSignal's commit ref (above).
+        // Posting here would be premature: render() has merely been scheduled,
+        // and a component that throws during its first render would have already
+        // claimed "mounted". See MountSignal.
       } catch (err) {
         showErr('Failed to load app', err.stack || err.message);
       } finally {

--- a/frontend/src/components/AppCanvas/AppCanvas.jsx
+++ b/frontend/src/components/AppCanvas/AppCanvas.jsx
@@ -75,8 +75,10 @@ function appFrameRequestUrl(appId, version, frameRev) {
 //
 //   2. {type: 'moebius:frame-mounted', appId}              frame → parent
 //      Fired by the frame AFTER its first render COMMITS (MountSignal's
-//      passive effect in app-frame.html — NOT right after
-//      `createRoot.render()` returns, which only schedules the render).
+//      stable DOM ref in app-frame.html — NOT right after
+//      `createRoot.render()` returns, which only schedules the render). The
+//      commit callback runs before app layout effects, so a mount-time
+//      capability request cannot overtake promotion of its own frame.
 //      Parent hides the loading overlay / promotes a buffered version swap
 //      only on this signal — `iframe.onLoad` is too early (document loaded
 //      ≠ React rendered), and a render()-returned post would be too early
@@ -170,6 +172,7 @@ function appFrameRequestUrl(appId, version, frameRev) {
 // is only meaningfully invoked client-side from the iframe onLoad / immersive
 // effect, so the probe is never needed before the DOM exists.
 let _insetProbe = null
+
 function readDeviceInsets() {
   if (typeof document === 'undefined') return zeroInsets()
   if (!_insetProbe) {

--- a/frontend/src/lib/__tests__/capabilityBrokerContract.test.js
+++ b/frontend/src/lib/__tests__/capabilityBrokerContract.test.js
@@ -3,14 +3,98 @@ import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
+import { initSwapState, reduceSwap } from '../previewSwapState.js'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const canvas = readFileSync(
   resolve(here, '../../components/AppCanvas/AppCanvas.jsx'),
   'utf8',
 )
+const frame = readFileSync(
+  resolve(here, '../../../public/app-frame.html'),
+  'utf8',
+)
 
-test('capability sessions are bound to one live app document', () => {
+function extractFunction(source, name) {
+  const start = source.indexOf(`function ${name}(`)
+  assert.notEqual(start, -1, `${name} is present`)
+  const open = source.indexOf('{', start)
+  let depth = 0
+  for (let index = open; index < source.length; index += 1) {
+    if (source[index] === '{') depth += 1
+    if (source[index] === '}') depth -= 1
+    if (depth === 0) return source.slice(start, index + 1)
+  }
+  throw new Error(`${name} is incomplete`)
+}
+
+function frameMountSignal(version, queue) {
+  const source = { version }
+  const frameWindow = {
+    __frameMounted: false,
+    location: { origin: 'https://mobius.test' },
+    parent: {
+      postMessage(message) { queue.push({ source, version, message }) },
+    },
+  }
+  const createElement = (type, props) => ({ type, props })
+  const factory = new Function(
+    'window',
+    'createElement',
+    '_FRAME_APP_ID',
+    `${extractFunction(frame, 'signalFrameMounted')}\n`
+      + `${extractFunction(frame, 'MountSignal')}\n`
+      + 'return MountSignal',
+  )
+  return { source, mount: factory(frameWindow, createElement, '42') }
+}
+
+test('commit ordering keeps capability sessions on the exact live document', () => {
+  const queue = []
+  const incoming = frameMountSignal('new', queue)
+  const marker = incoming.mount()
+
+  // React attaches a host ref during commit before running layout effects.
+  marker.props.ref({})
+  queue.push({
+    source: incoming.source,
+    version: 'new',
+    message: {
+      type: 'moebius:capability-open', requestId: 'layout', capability: 'device.test',
+    },
+  })
+  marker.props.ref(null)
+  marker.props.ref({})
+
+  assert.deepEqual(queue.map(event => event.message.type), [
+    'moebius:frame-mounted',
+    'moebius:capability-open',
+  ], 'the stable commit signal fires once and cannot be overtaken or replayed')
+
+  let swap = reduceSwap(initSwapState('old'), { type: 'frame-mounted', version: 'old' })
+  swap = reduceSwap(swap, { type: 'version', version: 'new' })
+  const handled = []
+  function deliver(event) {
+    if (event.message.type === 'moebius:frame-mounted') {
+      swap = reduceSwap(swap, { type: 'frame-mounted', version: event.version })
+    } else if (event.version === swap.liveVersion) {
+      handled.push(event)
+    }
+  }
+  queue.forEach(deliver)
+
+  assert.equal(swap.liveVersion, 'new')
+  assert.deepEqual(handled.map(event => event.message.requestId), ['layout'])
+
+  deliver({
+    source: { version: 'old' },
+    version: 'old',
+    message: {
+      type: 'moebius:capability-open', requestId: 'superseded', capability: 'device.test',
+    },
+  })
+  assert.deepEqual(handled.map(event => event.message.requestId), ['layout'],
+    'a superseded frame is ignored rather than retained for later replay')
   assert.match(
     canvas,
     /if \(srcVersion !== liveVersionRef\.current\) return[\s\S]*?capabilityHostRef\.current\.handle\(e\.source, msg\)/,
@@ -24,6 +108,7 @@ test('capability sessions are bound to one live app document', () => {
     /if \(loadedDocsRef\.current\.has\(v\)\) \{[\s\S]*?capabilityHostRef\.current\.detachSource/,
   )
   assert.match(canvas, /capabilityHostRef\.current\.destroy\(\)/)
+  assert.doesNotMatch(canvas, /deferredCapability|boundedWireBytes/)
 })
 
 test('a visible background pane remains inside the capability boundary', () => {


### PR DESCRIPTION
## Summary
- post `moebius:frame-mounted` from a stable DOM ref attached during React's commit, instead of from `MountSignal`'s passive effect
- drop `useEffect` from the compiled-runtime ABI validity check (the runtime still exports it; the ABI stays at 1)
- cover the ordering directly in the capability broker contract test

## Why
Passive effects run *after* layout effects. An app that requested a host capability from a mount-time layout effect could therefore have that request race ahead of its own frame's promotion in the parent's double-buffered swap (`AppCanvas`), resolving it against a frame the parent had not promoted yet.

Ref attachment happens during the commit, before any layout effect can run, so the frame is promotable before an app can ask for anything.

The existing failure semantics are unchanged: a component that throws during its first render aborts the commit, never attaches the ref, and still surfaces the pre-mount error panel. A throw in the app's own mount effects still happens with committed, visible DOM and is still correctly counted as post-mount.

## Testing
- `frontend` capability broker contract tests (3 passing)
- structural-test ratchet: 88/88 files, 779/779 cases