### PR TITLE
Install skill packages atomically and validate them fail-closed

### DIFF
--- a/backend/app/routes/skills.py
+++ b/backend/app/routes/skills.py
@@ -460,6 +460,8 @@ async def _fetch_files(
       except BaseException:
         # Signal before releasing the semaphore so a queued task that acquires
         # this slot cannot begin another request during gather's error handoff.
+        # (test_install_repo_dir_settles_parallel_fetches_before_returning_failure
+        # pins that no request starts beyond the in-flight batch once one fails.)
         fetch_failed.set()
         raise
     return rel, data
@@ -570,7 +572,7 @@ def list_skills(principal=Depends(get_principal)) -> dict:
     "install_contract": {
       "version": 1,
       "max_resources": _RESOURCE_COUNT_MAX,
-      "max_resource_bytes": _RESOURCE_TOTAL_MAX,
+      "max_total_resource_bytes": _RESOURCE_TOTAL_MAX,
       "max_depth": _RESOURCE_MAX_DEPTH,
       "max_skill_bytes": SKILL_MAX_BYTES,
     },

--- a/backend/app/routes/skills.py
+++ b/backend/app/routes/skills.py
@@ -78,9 +78,13 @@ _SKILL_NAME_OK = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
 _RESOURCE_COUNT_MAX = skills.RESOURCE_COUNT_MAX
 _RESOURCE_TOTAL_MAX = skills.RESOURCE_TOTAL_MAX
 _RESOURCE_MAX_DEPTH = skills.RESOURCE_MAX_DEPTH
-# Only text/reference file types are stored; anything else is skipped with a
-# warning rather than materialized into the skills tree.
+# Only text/reference file types are stored; a package carrying anything else
+# is rejected outright rather than materialized into the skills tree minus the
+# files it declared.
 _RESOURCE_SUFFIXES = skills.RESOURCE_SUFFIXES
+# Resources are fetched in parallel under this cap so a large package installs
+# in bounded wall-clock time without opening one connection per file.
+_RESOURCE_FETCH_CONCURRENCY = 8
 
 _GITHUB_API = "https://api.github.com"
 _USAGE_WINDOW_DAYS = 30
@@ -346,43 +350,132 @@ async def _fetch_files(
       f"{body.repo}/{commit}/{prefix}{quote(rel, safe='/')}"
     )
 
-  skill_rel = next(
-    (
-      str(e.get("path"))
-      for e in tree
-      if e.get("type") == "blob" and str(e.get("path", "")).upper() == "SKILL.MD"
-    ),
-    None,
-  )
-  if skill_rel is None:
+  skill_entries = [
+    entry for entry in tree
+    if entry.get("type") == "blob"
+    and str(entry.get("path", "")).upper() == "SKILL.MD"
+  ]
+  if not skill_entries:
     raise HTTPException(
       400,
       f"No SKILL.md in {body.repo}/{body.path} — not a skill directory.",
     )
+  if len(skill_entries) != 1:
+    raise HTTPException(
+      400,
+      "The skill directory contains more than one case-variant of SKILL.md; "
+      "nothing was installed.",
+    )
+  skill_rel = str(skill_entries[0]["path"])
+
+  resources: list[tuple[str, int]] = []
+  seen_resources: set[str] = set()
+  for entry in tree:
+    entry_type = entry.get("type")
+    if entry_type == "tree":
+      continue
+    if entry_type != "blob":
+      raise HTTPException(
+        400,
+        f"Skill package entry {entry.get('path')!r} is not a regular file; "
+        "nothing was installed.",
+      )
+    rel = str(entry.get("path", ""))
+    mode = entry.get("mode")
+    if mode not in {"100644", "100755"}:
+      raise HTTPException(
+        400,
+        f"Skill package entry {rel!r} is not a regular file; nothing was installed.",
+      )
+    declared = entry.get("size")
+    if type(declared) is not int or declared < 0:
+      raise HTTPException(
+        502,
+        f"GitHub tree entry for {rel!r} has no valid byte size; nothing was installed.",
+      )
+    if rel == skill_rel:
+      if declared > SKILL_MAX_BYTES:
+        raise HTTPException(
+          413,
+          f"SKILL.md is {declared} bytes; the limit is {SKILL_MAX_BYTES}. "
+          "Nothing was installed.",
+        )
+      continue
+    if not rel or not _resource_rel_ok(rel):
+      raise HTTPException(
+        400,
+        f"Skill package path {rel!r} is not an installable resource — "
+        "unsupported file type, unsafe path, or deeper than "
+        f"{_RESOURCE_MAX_DEPTH} segments; nothing was installed.",
+      )
+    if rel in seen_resources:
+      raise HTTPException(
+        502,
+        f"GitHub tree listed {rel!r} more than once; nothing was installed.",
+      )
+    seen_resources.add(rel)
+    resources.append((rel, declared))
+
+  # A skill package is one reviewed instruction tree, not a best-effort bag of
+  # files. Reject an unsupported or over-budget tree before fetching any
+  # resource so callers never receive a successful install whose playbooks,
+  # assets, or helpers were silently truncated.
+  if len(resources) > _RESOURCE_COUNT_MAX:
+    raise HTTPException(
+      413,
+      f"Skill package has {len(resources)} resources; the limit is "
+      f"{_RESOURCE_COUNT_MAX}. Nothing was installed.",
+    )
+  declared_total = sum(size for _, size in resources)
+  if declared_total > _RESOURCE_TOTAL_MAX:
+    raise HTTPException(
+      413,
+      f"Skill package resources total {declared_total} bytes; the limit is "
+      f"{_RESOURCE_TOTAL_MAX}. Nothing was installed.",
+    )
+
   files["SKILL.md"] = await install._http_get(
     client, _raw_url(skill_rel), max_bytes=SKILL_MAX_BYTES,
   )
 
-  resource_count = 0
-  resource_total = 0
-  for entry in tree:
-    if entry.get("type") != "blob":
-      continue
-    rel = str(entry.get("path", ""))
-    if not rel or rel == skill_rel or not _resource_rel_ok(rel):
-      continue
-    if resource_count >= _RESOURCE_COUNT_MAX:
-      break
-    remaining = _RESOURCE_TOTAL_MAX - resource_total
-    if remaining <= 0:
-      break
-    declared = entry.get("size")
-    if isinstance(declared, int) and declared > remaining:
-      continue  # skip an over-budget file, smaller ones may still fit
-    data = await install._http_get(client, _raw_url(rel), max_bytes=remaining)
-    files[rel] = data
-    resource_total += len(data)
-    resource_count += 1
+  fetch_slots = asyncio.Semaphore(_RESOURCE_FETCH_CONCURRENCY)
+  fetch_failed = asyncio.Event()
+
+  async def fetch_resource(
+    rel: str,
+    declared: int,
+  ) -> tuple[str, bytes] | None:
+    async with fetch_slots:
+      if fetch_failed.is_set():
+        return None
+      try:
+        data = await install._http_get(
+          client,
+          _raw_url(rel),
+          # The immutable Git tree supplies the exact blob size. Capping each
+          # response to that value keeps concurrent fetch memory within the
+          # already-approved aggregate package budget.
+          max_bytes=declared,
+        )
+      except BaseException:
+        # Signal before releasing the semaphore so a queued task that acquires
+        # this slot cannot begin another request during gather's error handoff.
+        fetch_failed.set()
+        raise
+    return rel, data
+
+  tasks = [
+    asyncio.create_task(fetch_resource(rel, declared))
+    for rel, declared in resources
+  ]
+  try:
+    fetched = await asyncio.gather(*tasks)
+  except BaseException:
+    for task in tasks:
+      task.cancel()
+    await asyncio.gather(*tasks, return_exceptions=True)
+    raise
+  files.update(item for item in fetched if item is not None)
 
   return name, files, _source_label(body.repo), commit
 
@@ -472,7 +565,16 @@ def list_skills(principal=Depends(get_principal)) -> dict:
     _skill_row(skill, installed_records, counts, is_owner=is_owner)
     for skill in skills.enumerate_skills(skills_dir)
   ]
-  return {"skills": out}
+  return {
+    "skills": out,
+    "install_contract": {
+      "version": 1,
+      "max_resources": _RESOURCE_COUNT_MAX,
+      "max_resource_bytes": _RESOURCE_TOTAL_MAX,
+      "max_depth": _RESOURCE_MAX_DEPTH,
+      "max_skill_bytes": SKILL_MAX_BYTES,
+    },
+  }
 
 
 @router.post("/install", status_code=201, dependencies=[Depends(reject_cross_site)])

--- a/backend/tests/test_skills_platform.py
+++ b/backend/tests/test_skills_platform.py
@@ -203,7 +203,7 @@ def test_list_skills_route(client, auth, skills_dir):
   assert r.json()["install_contract"] == {
     "version": 1,
     "max_resources": skills_mod.RESOURCE_COUNT_MAX,
-    "max_resource_bytes": skills_mod.RESOURCE_TOTAL_MAX,
+    "max_total_resource_bytes": skills_mod.RESOURCE_TOTAL_MAX,
     "max_depth": skills_mod.RESOURCE_MAX_DEPTH,
     "max_skill_bytes": 256 * 1024,
   }

--- a/backend/tests/test_skills_platform.py
+++ b/backend/tests/test_skills_platform.py
@@ -7,10 +7,12 @@ monkeypatching `install._http_get` / `_github_contents` with canned bytes,
 the same spirit as test_apps_install's mocked AsyncClient.
 """
 
+import asyncio
 import json
 from pathlib import Path
 
 import pytest
+from fastapi import HTTPException
 
 from app import skills as skills_mod
 from app.config import get_settings
@@ -197,6 +199,14 @@ def test_list_skills_route(client, auth, skills_dir):
   assert row["id"] == "cron"
   assert row["description"] == "Recurring jobs."
   assert "uses_30d" in row
+  # Callers can read the install bounds instead of hard-coding them.
+  assert r.json()["install_contract"] == {
+    "version": 1,
+    "max_resources": skills_mod.RESOURCE_COUNT_MAX,
+    "max_resource_bytes": skills_mod.RESOURCE_TOTAL_MAX,
+    "max_depth": skills_mod.RESOURCE_MAX_DEPTH,
+    "max_skill_bytes": 256 * 1024,
+  }
 
 
 def test_install_from_raw_url(client, auth, skills_dir, monkeypatch):
@@ -236,6 +246,8 @@ def _dir_install_mocks(monkeypatch, rs, tree, raw_files):
 
   `tree` entries are subtree-relative (the `<ref>:<path>` trees call); raw
   bytes are served from raw.githubusercontent.com URLs at the PINNED OID.
+  Blob entries default to a regular-file mode so each case can state only the
+  attribute it is about.
   """
 
   async def fake_resolve(client_, repo, ref):
@@ -247,7 +259,10 @@ def _dir_install_mocks(monkeypatch, rs, tree, raw_files):
 
   async def fake_tree(client_, repo, path, ref):
     assert ref == PINNED
-    return tree
+    return [
+      {"mode": "100644", **entry} if entry.get("type") == "blob" else entry
+      for entry in tree
+    ]
 
   monkeypatch.setattr(rs, "_resolve_commit", fake_resolve)
   monkeypatch.setattr(rs, "_github_contents", fake_contents)
@@ -266,9 +281,6 @@ def test_install_repo_dir_fetches_whole_subtree_of_vetted_resources(
     {"type": "blob", "path": "ref.md", "size": 9},
     {"type": "blob", "path": "scripts/helper.py", "size": 12},
     {"type": "tree", "path": "scripts"},
-    {"type": "blob", "path": "logo.png", "size": 10},  # unvetted suffix
-    {"type": "blob", "path": ".github/ci.yml", "size": 5},  # dot segment
-    {"type": "blob", "path": "a/b/c/d/e/f/g/h/deep.md", "size": 5},  # over depth cap
   ]
   _dir_install_mocks(monkeypatch, rs, tree, {
     f"{raw}/SKILL.md": b"---\nname: pdf\ndescription: PDFs.\n---\n",
@@ -284,11 +296,164 @@ def test_install_repo_dir_fetches_whole_subtree_of_vetted_resources(
   # Subdirectory structure is preserved on disk.
   assert (skills_dir / "pdf" / "scripts" / "helper.py").read_text() == "print('hi')\n"
   assert (skills_dir / "pdf" / "ref.md").read_text() == "reference"
-  # Unvetted suffix, dot segments, and over-depth paths were never fetched
-  # (_fake_fetch would have raised) and never materialized.
-  assert not (skills_dir / "pdf" / "logo.png").exists()
-  assert not (skills_dir / "pdf" / ".github").exists()
-  assert not (skills_dir / "pdf" / "a").exists()
+
+
+@pytest.mark.parametrize(
+  "entry",
+  [
+    {"type": "blob", "path": "logo.png", "size": 10},  # unvetted suffix
+    {"type": "blob", "path": ".github/ci.yml", "size": 5},  # dot segment
+    {"type": "blob", "path": "a/b/c/d/e/f/g/h/deep.md", "size": 5},  # over depth
+    {"type": "blob", "path": "link.md", "size": 9, "mode": "120000"},  # symlink
+    {"type": "blob", "path": "gitlink.md", "size": 9, "mode": None},  # no mode
+    {"type": "commit", "path": "nested-repo", "size": 0},  # submodule
+  ],
+)
+def test_install_repo_dir_rejects_unsupported_entries_without_truncating(
+  client, auth, skills_dir, monkeypatch, entry,
+):
+  """An unsupported entry fails the whole install rather than dropping a file.
+
+  A skill package is one reviewed instruction tree. Publishing it minus the
+  parts the installer could not carry hands the caller a skill whose SKILL.md
+  references files that are not there — so the install is refused instead, and
+  no resource is fetched (`_dir_install_mocks` serves no raw bytes here, so any
+  fetch attempt would raise).
+  """
+  from app.routes import skills as rs
+
+  tree = [
+    {"type": "blob", "path": "SKILL.md", "size": 9},
+    entry,
+  ]
+  _dir_install_mocks(monkeypatch, rs, tree, {})
+
+  response = client.post(
+    "/api/skills/install", headers=auth,
+    json={"repo": "o/r", "path": "strict", "ref": "main"},
+  )
+
+  assert response.status_code == 400, response.text
+  assert "nothing was installed" in response.json()["detail"]
+  assert not (skills_dir / "strict").exists()
+  assert not (skills_dir / skills_mod.INSTALLED_SKILLS_SIDECAR).exists()
+
+
+def test_install_repo_dir_rejects_duplicate_case_variants_of_skill_md(
+  client, auth, skills_dir, monkeypatch,
+):
+  """Two case-variants make "the" SKILL.md ambiguous; pick neither."""
+  from app.routes import skills as rs
+
+  tree = [
+    {"type": "blob", "path": "SKILL.md", "size": 9},
+    {"type": "blob", "path": "skill.md", "size": 9},
+  ]
+  _dir_install_mocks(monkeypatch, rs, tree, {})
+
+  response = client.post(
+    "/api/skills/install", headers=auth,
+    json={"repo": "o/r", "path": "ambiguous", "ref": "main"},
+  )
+
+  assert response.status_code == 400, response.text
+  assert "more than one" in response.json()["detail"]
+  assert not (skills_dir / "ambiguous").exists()
+
+
+def test_install_repo_dir_rejects_duplicate_tree_entries(
+  client, auth, skills_dir, monkeypatch,
+):
+  """A path listed twice means the listing is not the tree it claims to be."""
+  from app.routes import skills as rs
+
+  tree = [
+    {"type": "blob", "path": "SKILL.md", "size": 9},
+    {"type": "blob", "path": "ref.md", "size": 5},
+    {"type": "blob", "path": "ref.md", "size": 5},
+  ]
+  _dir_install_mocks(monkeypatch, rs, tree, {})
+
+  response = client.post(
+    "/api/skills/install", headers=auth,
+    json={"repo": "o/r", "path": "dupe", "ref": "main"},
+  )
+
+  assert response.status_code == 502, response.text
+  assert "more than once" in response.json()["detail"]
+  assert not (skills_dir / "dupe").exists()
+
+
+def test_install_repo_dir_preserves_a_large_command_routed_package(
+  client, auth, skills_dir, monkeypatch,
+):
+  """A many-file toolkit installs whole, fetched under a concurrency cap."""
+  from app.routes import skills as rs
+
+  raw = f"https://raw.githubusercontent.com/o/r/{PINNED}/toolkit"
+  resources = {
+    **{
+      f"commands/command-{index:02d}.mjs": f"export default {index}\n".encode()
+      for index in range(30)
+    },
+    "components/card.tsx": b"export const Card = () => null\n",
+    "components/panel.jsx": b"export const Panel = () => null\n",
+    "scripts/load.cjs": b"module.exports = {}\n",
+  }
+  skill = b"---\nname: toolkit\ndescription: Complete toolkit.\n---\n"
+  tree = [
+    {"type": "blob", "path": "SKILL.md", "size": len(skill)},
+    *(
+      {"type": "blob", "path": rel, "size": len(data)}
+      for rel, data in resources.items()
+    ),
+  ]
+  raw_files = {
+    f"{raw}/SKILL.md": skill,
+    **{f"{raw}/{rel}": data for rel, data in resources.items()},
+  }
+  _dir_install_mocks(monkeypatch, rs, tree, raw_files)
+  active_fetches = 0
+  peak_fetches = 0
+
+  async def tracked_fetch(client_, url, max_bytes, _hops=0):
+    nonlocal active_fetches, peak_fetches
+    if url not in raw_files:
+      raise AssertionError(f"unexpected fetch: {url}")
+    if url.endswith("/SKILL.md"):
+      return raw_files[url]
+    # Each resource is capped at its own declared blob size, not the whole
+    # package budget, so N concurrent fetches cannot allocate N × the budget.
+    assert max_bytes == len(raw_files[url])
+    active_fetches += 1
+    peak_fetches = max(peak_fetches, active_fetches)
+    try:
+      await asyncio.sleep(0)
+      return raw_files[url]
+    finally:
+      active_fetches -= 1
+
+  monkeypatch.setattr(rs.install, "_http_get", tracked_fetch)
+
+  response = client.post(
+    "/api/skills/install", headers=auth,
+    json={"repo": "o/r", "path": "toolkit", "ref": "main"},
+  )
+
+  assert response.status_code == 201, response.text
+  expected_files = ["SKILL.md", *resources]
+  assert sorted(response.json()["skill"]["files"]) == sorted(expected_files)
+  for rel, data in resources.items():
+    assert (skills_dir / "toolkit" / rel).read_bytes() == data
+  record = json.loads(
+    (skills_dir / skills_mod.INSTALLED_SKILLS_SIDECAR).read_text(),
+  )["toolkit"]
+  assert record["files"] == sorted(expected_files)
+  assert record["tree_digest"] == skills_mod.tree_digest_from_files({
+    "SKILL.md": skill,
+    **resources,
+  })
+  assert 1 < peak_fetches <= rs._RESOURCE_FETCH_CONCURRENCY
 
 
 def test_install_repo_dir_rejects_traversal_paths_in_tree(
@@ -296,28 +461,27 @@ def test_install_repo_dir_rejects_traversal_paths_in_tree(
 ):
   from app.routes import skills as rs
 
-  raw = f"https://raw.githubusercontent.com/o/r/{PINNED}/sk"
   tree = [
     {"type": "blob", "path": "SKILL.md", "size": 10},
     {"type": "blob", "path": "../escape.md", "size": 5},
     {"type": "blob", "path": "ok/../../escape2.md", "size": 5},
   ]
-  _dir_install_mocks(monkeypatch, rs, tree, {
-    f"{raw}/SKILL.md": b"# sk\n",
-  })
+  _dir_install_mocks(monkeypatch, rs, tree, {})
   r = client.post(
     "/api/skills/install", headers=auth,
     json={"repo": "o/r", "path": "sk", "ref": "main"},
   )
-  assert r.status_code == 201, r.text
-  assert r.json()["skill"]["files"] == ["SKILL.md"]
+  assert r.status_code == 400, r.text
+  assert "nothing was installed" in r.json()["detail"]
+  assert not (skills_dir / "sk").exists()
   assert not (skills_dir / "escape.md").exists()
   assert not (skills_dir / "escape2.md").exists()
 
 
-def test_install_repo_dir_skips_over_budget_files_by_declared_size(
+def test_install_repo_dir_rejects_over_budget_tree_without_publishing_a_subset(
   client, auth, skills_dir, monkeypatch,
 ):
+  """The byte budget is checked against the tree before anything is fetched."""
   from app.routes import skills as rs
 
   raw = f"https://raw.githubusercontent.com/o/r/{PINNED}/sk"
@@ -328,15 +492,113 @@ def test_install_repo_dir_skips_over_budget_files_by_declared_size(
   ]
   _dir_install_mocks(monkeypatch, rs, tree, {
     f"{raw}/SKILL.md": b"# sk\n",
-    f"{raw}/small.md": b"small",
   })
   r = client.post(
     "/api/skills/install", headers=auth,
     json={"repo": "o/r", "path": "sk", "ref": "main"},
   )
-  assert r.status_code == 201, r.text
-  # huge.md was skipped WITHOUT being fetched; the smaller file still landed.
-  assert sorted(r.json()["skill"]["files"]) == ["SKILL.md", "small.md"]
+  assert r.status_code == 413, r.text
+  assert "total" in r.json()["detail"]
+  # small.md was NOT published on its own; the package is all-or-nothing.
+  assert not (skills_dir / "sk").exists()
+  assert not (skills_dir / skills_mod.INSTALLED_SKILLS_SIDECAR).exists()
+
+
+def test_install_repo_dir_rejects_over_count_tree_before_resource_fetch(
+  client, auth, skills_dir, monkeypatch,
+):
+  from app.routes import skills as rs
+
+  raw = f"https://raw.githubusercontent.com/o/r/{PINNED}/many"
+  tree = [
+    {"type": "blob", "path": "SKILL.md", "size": 7},
+    *(
+      {"type": "blob", "path": f"commands/{index}.mjs", "size": 1}
+      for index in range(rs._RESOURCE_COUNT_MAX + 1)
+    ),
+  ]
+  _dir_install_mocks(monkeypatch, rs, tree, {
+    f"{raw}/SKILL.md": b"# many\n",
+  })
+
+  response = client.post(
+    "/api/skills/install", headers=auth,
+    json={"repo": "o/r", "path": "many", "ref": "main"},
+  )
+
+  assert response.status_code == 413, response.text
+  assert "resources" in response.json()["detail"]
+  assert not (skills_dir / "many").exists()
+  assert not (skills_dir / skills_mod.INSTALLED_SKILLS_SIDECAR).exists()
+
+
+def test_install_repo_dir_rejects_a_tree_entry_without_a_usable_size(
+  client, auth, skills_dir, monkeypatch,
+):
+  """No declared size means no way to pre-check the budget — refuse."""
+  from app.routes import skills as rs
+
+  tree = [
+    {"type": "blob", "path": "SKILL.md", "size": 9},
+    {"type": "blob", "path": "ref.md"},
+  ]
+  _dir_install_mocks(monkeypatch, rs, tree, {})
+
+  response = client.post(
+    "/api/skills/install", headers=auth,
+    json={"repo": "o/r", "path": "sizeless", "ref": "main"},
+  )
+
+  assert response.status_code == 502, response.text
+  assert "byte size" in response.json()["detail"]
+  assert not (skills_dir / "sizeless").exists()
+
+
+def test_install_repo_dir_settles_parallel_fetches_before_returning_failure(
+  client, auth, skills_dir, monkeypatch,
+):
+  """One failed resource cancels the rest; no request outlives the response."""
+  from app.routes import skills as rs
+
+  tree = [
+    {"type": "blob", "path": "SKILL.md", "size": 9},
+    *(
+      {"type": "blob", "path": f"files/{index}.md", "size": 1}
+      for index in range(rs._RESOURCE_FETCH_CONCURRENCY + 4)
+    ),
+  ]
+  _dir_install_mocks(monkeypatch, rs, tree, {})
+  active = 0
+  started = []
+
+  async def failing_fetch(client_, url, max_bytes, _hops=0):
+    nonlocal active
+    if url.endswith("/SKILL.md"):
+      return b"# broken\n"
+    index = int(url.rsplit("/", 1)[1].split(".", 1)[0])
+    active += 1
+    started.append(index)
+    try:
+      if index == 0:
+        await asyncio.sleep(0)
+        raise HTTPException(502, "injected resource failure")
+      await asyncio.Event().wait()
+    finally:
+      active -= 1
+
+  monkeypatch.setattr(rs.install, "_http_get", failing_fetch)
+
+  response = client.post(
+    "/api/skills/install", headers=auth,
+    json={"repo": "o/r", "path": "broken", "ref": "main"},
+  )
+
+  assert response.status_code == 502
+  # Every in-flight fetch was cancelled and awaited before the handler returned,
+  # and the concurrency cap held so no extra request started after the failure.
+  assert active == 0
+  assert started == list(range(rs._RESOURCE_FETCH_CONCURRENCY))
+  assert not (skills_dir / "broken").exists()
 
 
 def test_resource_rel_ok_contract():
@@ -600,7 +862,11 @@ def test_install_pins_every_fetch_to_the_resolved_commit(
     f"https://api.github.com/repos/o/r/contents/sk?ref={PINNED}":
       json.dumps([{"type": "dir", "name": "marker"}]).encode(),
     f"https://api.github.com/repos/o/r/git/trees/{spec}?recursive=1":
-      json.dumps({"tree": [{"type": "blob", "path": "SKILL.md", "size": 4}]}).encode(),
+      json.dumps({
+        "tree": [{
+          "type": "blob", "mode": "100644", "path": "SKILL.md", "size": 4,
+        }],
+      }).encode(),
     f"https://raw.githubusercontent.com/o/r/{PINNED}/sk/SKILL.md":
       b"# sk\n",
   }
@@ -629,7 +895,9 @@ def test_install_rejects_truncated_tree(client, auth, skills_dir, monkeypatch):
     f"https://api.github.com/repos/o/r/git/trees/{spec}?recursive=1":
       json.dumps({
         "truncated": True,
-        "tree": [{"type": "blob", "path": "SKILL.md", "size": 4}],
+        "tree": [{
+          "type": "blob", "mode": "100644", "path": "SKILL.md", "size": 4,
+        }],
       }).encode(),
   }
   monkeypatch.setattr(rs.install, "_http_get", _fake_fetch(canned))


### PR DESCRIPTION
## What

#638 taught the skills installer to fetch a whole multi-file package instead of just `SKILL.md`. It still published on a best-effort basis, though: an entry it could not carry was skipped, and the resource-count and byte budgets were consumed *inside* the fetch loop, so crossing either one `break`s the walk and publishes whatever had already landed.

The caller gets a `201` and a skill directory whose `SKILL.md` references playbooks, helpers, and references that were never written. Nothing in the response says a file is missing.

This hardens the installer #638 introduced: it validates the entire GitHub tree **before** fetching a single resource, and refuses the install if any part of the package cannot be carried whole.

## Validation, before any fetch

- **Exactly one case-variant of `SKILL.md`.** A tree carrying both `SKILL.md` and `skill.md` made "the" SKILL.md a `next()` accident. Now it is a `400`.
- **Every entry is a blob with mode `100644` or `100755`.** This rejects symlinks (`120000`) and submodule gitlinks (`type: commit`) before they can be materialized under the skills tree.
- **Every entry carries a valid integer `size`.** A budget check run against a missing or non-integer size is not a budget check.
- **Unsafe, dot-segment, unsupported-suffix, and over-depth paths are rejected rather than silently skipped.**
- **No path is listed twice.** A duplicate means the listing is not the tree it claims to be.
- **Resource count and total declared bytes are checked against the shared bounds up front**, so a partial tree is never published. `SKILL.md`'s own declared size is checked against `SKILL_MAX_BYTES` here too, rather than being discovered mid-download.

Every rejection says `nothing was installed`, and leaves behind no directory and no sidecar record.

## Fetching

Resources are fetched in parallel under a bounded semaphore (`_RESOURCE_FETCH_CONCURRENCY = 8`) rather than strictly one at a time — a 30-file command-routed toolkit was previously 30 sequential round trips.

Each response is capped at *that blob's* declared size rather than at the remaining package budget, so N concurrent fetches cannot allocate N x the budget.

On failure, the failing task sets a shared flag **before** releasing its semaphore slot — so a queued task that acquires that slot during `gather`'s error handoff cannot begin another request — and the handler then cancels the outstanding tasks and awaits them. The response never returns while requests are still in flight.

## API

`GET /api/skills` gains an additive `install_contract` block, so callers can read the bounds instead of hard-coding them:

```json
{
  "install_contract": {
    "version": 1,
    "max_resources": 256,
    "max_resource_bytes": 8388608,
    "max_depth": 8,
    "max_skill_bytes": 262144
  }
}
```

No existing field changes shape.

## Scope: the extension allowlist is deliberately untouched

#638 kept `RESOURCE_SUFFIXES` and extended it with `.mjs` / `.cjs` / `.tsx` / `.jsx`. This change does not touch the allowlist, and does not touch `backend/app/skills.py` at all.

It does change what happens to a file that *fails* the allowlist. Previously such a file was silently dropped and the install still returned `201`; now it fails the install with a `400` naming the path. That is the intent — a truncated package is worse than a refused one — but it is a real behavioural consequence worth stating plainly: a repo directory carrying, say, a `logo.png` or a `.gitignore` next to its `SKILL.md` goes from "installs without that file" to "does not install".

Whether the allowlist should exist at all is a separate design question, and not one I wanted to settle inside a hardening change. Happy to open it on its own if you'd like it revisited.

## Tests

New coverage in `backend/tests/test_skills_platform.py`:

- unsupported tree entries are rejected without truncating, parametrized over unvetted suffix, dot segment, over-depth path, symlink mode, missing mode, and submodule
- duplicate case-variants of `SKILL.md`
- duplicate tree entries
- a tree entry with no usable `size`
- a 33-file command-routed toolkit installs whole, with the observed peak fetch concurrency asserted to stay above 1 and within the cap, each fetch capped at its own declared size, and the recorded `tree_digest` matching
- the over-byte-budget and over-count cases now assert `413` plus the absence of any published directory or sidecar, replacing the previous "skip the big file, publish the rest" expectations
- traversal paths in the tree now fail the install rather than being quietly dropped

`_dir_install_mocks` now defaults blob entries to mode `100644`, so each case states only the attribute it is about.

The bounds contract test from #638 (`test_skill_package_bounds_fit_command_routed_toolkits`) and `test_resource_rel_ok_contract` are unchanged.

## Verification

`scripts/wt-pytest.sh tests/test_skills_platform.py -q` -> 68 passed.
`scripts/wt-pytest.sh tests/test_catalog_index.py tests/test_skills_platform.py -q` -> 85 passed (the only other suite that touches `/api/skills`).
`scripts/test.sh --fast` -> backend PASS, 79 passed.