### PR TITLE
Give the icon recipe a platform-owned chroma-key cutter

### DIFF
--- a/backend/scripts/remove_chroma_key.py
+++ b/backend/scripts/remove_chroma_key.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Turn a chroma-key rendered image into real alpha.
+
+Generated icon art arrives on a solid key background (`#00ff00`, or `#ff00ff`
+when the subject itself is green). Removing that key by flood fill from the
+edges leaves enclosed holes opaque -- the gap inside a ring, a handle, or a
+loop stays filled with key colour. This keys on colour distance instead, so a
+key pixel becomes transparent wherever it sits, including inside a closed
+shape.
+
+Distance is Chebyshev (largest per-channel difference), which separates a
+saturated key from real artwork far more cleanly than a Euclidean average.
+
+Pixels nearer than `--clear-below` are fully transparent, pixels beyond
+`--solid-above` are fully opaque, and the band between ramps linearly so edges
+stay soft instead of aliasing. Those partial-alpha pixels are a blend of the
+subject and the key, so their stored colour still carries the key's cast --
+the green fringe around an otherwise clean cut-out. Because the background
+colour is known exactly, that blend is reversible: dividing the key's
+contribution back out recovers the subject's own colour instead of merely
+damping the offending channel.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections import Counter
+from pathlib import Path
+
+from PIL import Image
+
+
+class KeyRemovalError(RuntimeError):
+  """The key colour or thresholds did not describe this image."""
+
+
+def _parse_key(value: str) -> tuple[int, int, int]:
+  text = value.strip().lstrip("#")
+  if len(text) != 6:
+    raise argparse.ArgumentTypeError(f"expected #rrggbb, got {value!r}")
+  try:
+    return tuple(int(text[i:i + 2], 16) for i in (0, 2, 4))  # type: ignore[return-value]
+  except ValueError:
+    raise argparse.ArgumentTypeError(f"expected #rrggbb, got {value!r}") from None
+
+
+def detect_key(image: Image.Image) -> tuple[int, int, int]:
+  """The dominant colour on the 1px border, which the key fully occupies."""
+  width, height = image.size
+  pixels = image.load()
+  border = Counter()
+  for x in range(width):
+    border[pixels[x, 0][:3]] += 1
+    border[pixels[x, height - 1][:3]] += 1
+  for y in range(height):
+    border[pixels[0, y][:3]] += 1
+    border[pixels[width - 1, y][:3]] += 1
+  colour, count = border.most_common(1)[0]
+  if count < sum(border.values()) * 0.5:
+    raise KeyRemovalError(
+      "border is not a uniform key colour -- pass --key explicitly, or "
+      "regenerate the source against a flat background",
+    )
+  return colour
+
+
+def _unblend(value: int, key_value: int, alpha: int) -> int:
+  """The subject's own channel value, with the key's share divided out.
+
+  A fringe pixel holds ``alpha*subject + (1-alpha)*key``. Inverting that is
+  exact for the background actually used, and only ever runs where alpha is
+  partial, so a fully opaque interior keeps its rendered colour untouched.
+  """
+  recovered = round((value - key_value) * 255 / alpha) + key_value
+  return min(255, max(0, recovered))
+
+
+def remove_chroma_key(
+  image: Image.Image,
+  *,
+  key: tuple[int, int, int] | None = None,
+  clear_below: int = 16,
+  solid_above: int = 64,
+  unblend: bool = True,
+) -> Image.Image:
+  if clear_below >= solid_above:
+    raise KeyRemovalError("--clear-below must be smaller than --solid-above")
+  rgb = image.convert("RGB")
+  key = key or detect_key(rgb)
+  key_r, key_g, key_b = key
+  span = solid_above - clear_below
+
+  source = rgb.tobytes()
+  pixels = bytearray(len(source) // 3 * 4)
+  for read, write in zip(range(0, len(source), 3), range(0, len(pixels), 4)):
+    red, green, blue = source[read], source[read + 1], source[read + 2]
+    distance = max(abs(red - key_r), abs(green - key_g), abs(blue - key_b))
+    if distance <= clear_below:
+      continue
+    if distance >= solid_above:
+      pixels[write:write + 4] = bytes((red, green, blue, 255))
+      continue
+    alpha = round((distance - clear_below) * 255 / span) or 1
+    pixels[write:write + 4] = bytes((
+      _unblend(red, key_r, alpha) if unblend else red,
+      _unblend(green, key_g, alpha) if unblend else green,
+      _unblend(blue, key_b, alpha) if unblend else blue,
+      alpha,
+    ))
+
+  return Image.frombytes("RGBA", rgb.size, bytes(pixels))
+
+
+def verify_icon(icon: Image.Image) -> None:
+  """Reject the two failures that are invisible until the icon ships."""
+  alpha = icon.getchannel("A")
+  if alpha.getbbox() is None:
+    raise KeyRemovalError(
+      "every pixel was keyed out -- the detected key matches the subject, so "
+      "regenerate against the other key colour",
+    )
+  width, height = icon.size
+  corners = [(0, 0), (width - 1, 0), (0, height - 1), (width - 1, height - 1)]
+  if any(alpha.getpixel(point) for point in corners):
+    raise KeyRemovalError(
+      "corners are still opaque -- the background is not the detected key "
+      "colour, or the subject bleeds to the canvas edge",
+    )
+
+
+def main() -> int:
+  parser = argparse.ArgumentParser(description=__doc__)
+  parser.add_argument("input", type=Path, help="chroma-key source image")
+  parser.add_argument("--out", type=Path, required=True, help="destination PNG")
+  parser.add_argument(
+    "--key", type=_parse_key, default=None,
+    help="key colour as #rrggbb (default: detect from the border)",
+  )
+  parser.add_argument(
+    "--clear-below", type=int, default=16,
+    help="colour distance under which a pixel is fully transparent",
+  )
+  parser.add_argument(
+    "--solid-above", type=int, default=64,
+    help="colour distance over which a pixel is fully opaque",
+  )
+  parser.add_argument(
+    "--keep-spill", action="store_true",
+    help="leave the key's colour cast on edge pixels",
+  )
+  args = parser.parse_args()
+
+  with Image.open(args.input) as source:
+    source.load()
+    icon = remove_chroma_key(
+      source,
+      key=args.key,
+      clear_below=args.clear_below,
+      solid_above=args.solid_above,
+      unblend=not args.keep_spill,
+    )
+  verify_icon(icon)
+  args.out.parent.mkdir(parents=True, exist_ok=True)
+  icon.save(args.out, format="PNG", optimize=True)
+  return 0
+
+
+if __name__ == "__main__":
+  try:
+    sys.exit(main())
+  except KeyRemovalError as error:
+    print(f"remove_chroma_key: {error}", file=sys.stderr)
+    sys.exit(1)

--- a/backend/scripts/seed-skills/images.md
+++ b/backend/scripts/seed-skills/images.md
@@ -26,3 +26,78 @@ Paste the returned `embed` value into the reply before describing the image.
 The helper writes to the resolved current chat and deliberately requires the
 exact generated path; never rediscover an output by modification time, which
 can select another run's image.
+
+---
+
+## Möbius app icons
+
+Möbius app icons are one visual family: a compact sculptural object in
+dimensional enamel and polished warm metal, restrained gold or silver
+structure, and an occasional small violet jewel. An icon that ignores that
+language looks broken beside its neighbours in the launcher.
+
+Use this as the starting prompt whenever the partner asks for an app icon,
+unless they want a different art direction. Replace every bracketed field. If
+the app already has an icon, attach it as the identity reference and keep
+roughly 70% of its defining silhouette, subject, orientation, and palette,
+spending the remaining 30% on the shared finish.
+
+```text
+Create one isolated app-icon symbol for [APP NAME], an app that [APP PURPOSE].
+The central metaphor is [ONE CLEAR, RECOGNIZABLE SYMBOL]. Make the metaphor
+immediately legible, distinctive to the app, and readable at 40px.
+
+Match the Möbius icon family: a compact premium sculptural object, dimensional
+enamel and polished warm metal, gentle rounded bevels, controlled depth,
+restrained highlights, and rich material detail that survives downscaling.
+Use [APP-SPECIFIC DOMINANT COLORS] rather than a generic brand palette. A single
+small violet jewel may be used as a quiet family accent when it fits the
+composition; do not add multiple jewels or decoration without meaning.
+
+Center one bold symbol on a 512x512 canvas with generous transparent padding
+and a clean, balanced silhouette. The icon must work on both light and dark
+themes. No rounded-square app tile or backplate, no text or letters, no scene,
+no floor, no cast/contact shadow, no background glow, no watermark, and no
+tiny details that disappear at thumbnail size.
+
+Generate on a perfectly uniform solid #00ff00 chroma-key background for clean
+background removal. If the subject itself needs green, use #ff00ff instead.
+The key background must contain no gradient, texture, lighting variation,
+reflection, or shadow, and its color must not appear in the subject.
+```
+
+Two constraints are the easiest to lose and the most expensive to discover
+late: **no cast shadow** (a shadow cannot be keyed out and looks wrong in dark
+mode) and **the key colour must not appear in the subject** (keying it out
+would punch holes in the artwork — that is what the magenta alternative is
+for).
+
+### Cutting the key out
+
+```bash
+python3 "$SCRIPTS_DIR/remove_chroma_key.py" <generated.png> --out icon.png
+```
+
+The key colour is detected from the border, so a flat background needs no
+flags. Removal keys on colour distance rather than flooding in from the edges,
+so enclosed holes — the gap inside a ring, a loop, a handle — become genuinely
+transparent instead of staying filled. Partial-alpha edge pixels have the key's
+colour divided back out, which is what prevents the fringe around an otherwise
+clean cut-out.
+
+The helper refuses two failures that stay invisible until the icon ships: an
+all-transparent result (the key matched the subject — regenerate against the
+other key colour) and opaque corners (the background was not actually flat).
+Widen `--clear-below` / `--solid-above` only when a soft edge genuinely needs
+it.
+
+### Judging the result
+
+Inspect the finished icon at 40px on both a warm light surface and a dark one
+before showing it to the partner. Reject key-coloured fringes, clipped
+silhouettes, muddy transparency, weak metaphors, and anything that only reads
+at full size.
+
+Then keep `icon.png` in the app's source tree and declare it in `mobius.json`.
+An icon applied only as a live override leaves the app's own package still
+shipping the old artwork, so every other install keeps the icon you replaced.

--- a/backend/tests/test_remove_chroma_key.py
+++ b/backend/tests/test_remove_chroma_key.py
@@ -1,0 +1,111 @@
+"""Contract for recovering real alpha from a chroma-key rendered icon."""
+
+import importlib.util
+from pathlib import Path
+import sys
+
+from PIL import Image
+import pytest
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "remove_chroma_key.py"
+SPEC = importlib.util.spec_from_file_location("remove_chroma_key", SCRIPT)
+assert SPEC and SPEC.loader
+CHROMA = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = CHROMA
+SPEC.loader.exec_module(CHROMA)
+
+
+GREEN = (0, 255, 0)
+MAGENTA = (255, 0, 255)
+
+
+def _ring(size: int, key: tuple[int, int, int], subject: tuple[int, int, int]) -> Image.Image:
+  """A subject with a hole in it, rendered opaque on a flat key background."""
+  image = Image.new("RGB", (size, size), key)
+  pixels = image.load()
+  centre = size / 2
+  for y in range(size):
+    for x in range(size):
+      radius = ((x - centre) ** 2 + (y - centre) ** 2) ** 0.5
+      if size * 0.15 < radius < size * 0.40:
+        pixels[x, y] = subject
+  return image
+
+
+def test_enclosed_hole_becomes_transparent():
+  """A flood fill from the edges would leave the ring's centre opaque."""
+  icon = CHROMA.remove_chroma_key(_ring(64, GREEN, (200, 40, 90)))
+  alpha = icon.getchannel("A")
+
+  assert alpha.getpixel((32, 32)) == 0, "the hole inside the ring stayed filled"
+  assert alpha.getpixel((32, 32 - 17)) == 255, "the ring itself was keyed away"
+  assert alpha.getpixel((0, 0)) == 0
+
+
+def test_opaque_subject_round_trips_exactly():
+  """The rendered subject's own colour survives the cut unchanged."""
+  subject = (200, 40, 90)
+  icon = CHROMA.remove_chroma_key(_ring(64, GREEN, subject))
+
+  assert icon.getpixel((32, 32 - 17)) == (*subject, 255)
+
+
+def test_green_subject_keys_against_magenta():
+  """The alternate key is what keeps a green subject from being erased."""
+  subject = (20, 220, 60)
+  icon = CHROMA.remove_chroma_key(_ring(64, MAGENTA, subject))
+
+  assert icon.getpixel((32, 32 - 17)) == (*subject, 255)
+
+
+def test_subject_matching_the_key_is_rejected():
+  """Keying a green subject on green silently returns an empty icon."""
+  icon = CHROMA.remove_chroma_key(_ring(64, GREEN, (0, 250, 4)))
+
+  with pytest.raises(CHROMA.KeyRemovalError, match="every pixel was keyed out"):
+    CHROMA.verify_icon(icon)
+
+
+def test_unflat_background_is_rejected():
+  """A gradient background cannot be keyed, and must not pass as an icon."""
+  image = Image.new("RGB", (64, 64))
+  pixels = image.load()
+  for y in range(64):
+    for x in range(64):
+      pixels[x, y] = (0, 255, y * 3)
+
+  with pytest.raises(CHROMA.KeyRemovalError, match="not a uniform key colour"):
+    CHROMA.remove_chroma_key(image)
+
+
+def test_edge_pixels_shed_the_key_colour():
+  """A blended edge keeps the subject's hue rather than the key's cast."""
+  image = Image.new("RGB", (8, 8), GREEN)
+  blended = (0, 128, 128)  # pure blue, rendered half-covered over the key
+  image.putpixel((4, 4), blended)
+
+  icon = CHROMA.remove_chroma_key(image, clear_below=8, solid_above=200)
+  red, green, blue, alpha = icon.getpixel((4, 4))
+
+  assert 0 < alpha < 255
+  assert green < blended[1] / 2, "the key's cast was left on the edge pixel"
+  assert blue > green, "the subject's own hue did not survive the cut"
+  assert red == 0
+
+
+def test_edge_pixels_recomposite_onto_the_key_unchanged():
+  """De-fringing corrects colour for the alpha it assigned, losing nothing."""
+  image = Image.new("RGB", (8, 8), GREEN)
+  blended = (0, 128, 128)
+  image.putpixel((4, 4), blended)
+
+  icon = CHROMA.remove_chroma_key(image, clear_below=8, solid_above=200)
+  red, green, blue, alpha = icon.getpixel((4, 4))
+  coverage = alpha / 255
+  recomposited = tuple(
+    round(coverage * channel + (1 - coverage) * key)
+    for channel, key in zip((red, green, blue), GREEN)
+  )
+
+  assert all(abs(a - b) <= 1 for a, b in zip(recomposited, blended))


### PR DESCRIPTION
Adds the Möbius app-icon recipe to the shared image-generation skill, and the
background-removal helper it depends on.

Möbius app icons are meant to read as one family, but nothing in the repository
said what that family is, so each new icon was reinvented from scratch and drifted.
The skill now carries the working prompt — one clear metaphor per app, the shared
material treatment, 512x512 with transparent padding, legible at 40px, no cast
shadow — along with the two constraints that are cheapest to state and most
expensive to discover after generation.

Generated icons arrive on a flat chroma-key background, and removing that key
was previously done by a script living outside the platform, so the recipe only
worked for one provider on one machine. `backend/scripts/remove_chroma_key.py`
makes that step available to any agent on any install:

- It keys on colour distance rather than flooding in from the edges, so an
  enclosed hole — the gap inside a ring or a loop — becomes genuinely
  transparent instead of staying filled with key colour.
- Partial-alpha edge pixels have the key's contribution divided back out. The
  background colour is known exactly, so the blend is reversible, which removes
  the fringe rather than damping the offending channel and greying the edge.
- It refuses an all-transparent result and opaque corners, the two failures that
  otherwise stay invisible until the icon is already shipped.

An opaque subject rendered on a flat key round-trips to its exact original
colour and alpha; the tests pin that, the enclosed-hole case, the magenta path
for green subjects, and both refusals.