### PR TITLE
Chat: floating jump-to-latest button above the composer

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -591,7 +591,7 @@ automatically armed by installing Möbius.
 
 ## Chat scroll + steer contract
 
-**Owner-authoritative contract — v1.17 (2026-08-03).** This section is the
+**Owner-authoritative contract — v1.18 (2026-08-04).** This section is the
 canonical source of truth for how a chat scrolls and steers. When implementation,
 comments, and this contract disagree, the implementation/comments are the bug:
 fix behavior to match this contract. If a real case is unspecified or the desired
@@ -757,7 +757,15 @@ and attaches their rule ids to new diagnostic chats. The Playwright lock-in spec
   control must not manufacture future live-follow intent. Both actions route
   through the scroll controller instead of calling `scrollIntoView`, because
   viewport intersection alone cannot detect that the absolutely-positioned
-  composer is covering the target.
+  composer is covering the target. The floating jump-to-latest control
+  (owner ask, 2026-08-04) is the same explicit one-shot action through the
+  identical controller tail reveal, with the same settled `ANCHOR_AT` outcome.
+  Its visibility is a pure geometry read outside the controller's ownership
+  gates: it renders only while the reader holds a position away from the
+  content tail, where reserved spacer room is phantom per R2's send-snapshot
+  bottom rule — so a fresh live-send reservation never summons it. It yields
+  to a visible attention nudge, which navigates to the same tail with strictly
+  more context.
 - **R5b — One keyboard geometry signal; reservation-responsive resize.** Shell alone
   reconciles a browser's visual viewport into the visible shell frame. The chat
   does not race Shell with a second direct visual-viewport listener: its own

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -2001,6 +2001,7 @@
 .chat__foot .chat__attach-tray,
 .chat__foot .chat__question-nudge,
 .chat__foot .chat__resume-nudge,
+.chat__foot .chat__jump-latest,
 .chat__foot .chat__open-app,
 .chat__foot .chat__progress-step--toggle,
 .chat__foot .slash-menu,
@@ -2344,6 +2345,40 @@
 .chat__resume-nudge:active { transform: scale(0.96); }
 
 .chat__offscreen-nudges > button + button { margin-top: 8px; }
+
+/* Jump-to-latest: a round, mostly-transparent control floating in the same
+   slot above the composer, shown once the reader has scrolled away from the
+   content tail (ChatView renders it only then). Tapping routes through the
+   controller's tail reveal — contract R5a's one-shot navigation, never
+   live-follow. Kept quieter than the attention nudges: neutral surface tint
+   at low opacity over blur, no accent, because it is a convenience, not an
+   attention request. */
+.chat__jump-latest {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  margin: 0 auto;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--border) 55%, transparent);
+  background: color-mix(in srgb, var(--surface) 45%, transparent);
+  backdrop-filter: blur(12px) saturate(140%);
+  -webkit-backdrop-filter: blur(12px) saturate(140%);
+  color: color-mix(in srgb, var(--text) 78%, transparent);
+  cursor: pointer;
+  /* Same entrance + press behavior as the nudges (no fill mode — a filled
+     transform would permanently override the :active press scale). */
+  animation: chat-foot-rise 0.22s var(--ease-out-soft, ease-out);
+  transition: background 0.15s, color 0.15s, border-color 0.15s, transform 0.08s;
+}
+.chat__jump-latest:hover {
+  background: color-mix(in srgb, var(--surface) 82%, transparent);
+  border-color: var(--border);
+  color: var(--text);
+}
+.chat__jump-latest:active { transform: scale(0.96); }
 
 /* ── Voice input ──────────────────────────────────── */
 .chat__mic {

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -10,10 +10,12 @@ import {
 import { flushSync } from 'react-dom'
 import { useQueryClient } from '@tanstack/react-query'
 import Check from 'lucide-react/dist/esm/icons/check.mjs'
+import ArrowDown from 'lucide-react/dist/esm/icons/arrow-down.mjs'
 import { apiFetch, getAuthHeaders, jsonOrThrow, BASE } from '../../api/client.js'
 import { chatMessagesQueryKey } from '../../hooks/queries.js'
 import useStreamConnection from './useStreamConnection.js'
 import useScrollMode, {
+  isNearContentBottom,
   remapSavedReadingAnchor,
   retireSavedReadingPosition,
   savedReadingAnchorHasNestedPart,
@@ -99,6 +101,7 @@ import {
   continuationRowsFromPromotedMessage,
   isContinuationMessage,
   isOwnerUserMessage,
+  jumpToLatestShown,
   openAppCtaViewModel,
   shouldAttachRunningStream,
   shouldRetryStopAfterConfirm,
@@ -154,6 +157,12 @@ _touchMql?.addEventListener('change', (e) => { _isTouchPrimary = e.matches })
 const STOP_RETRY_DELAYS_MS = [0, 250, 700, 1200]
 const CHAT_FETCH_TIMEOUT_MS = 15000
 const MESSAGE_META_VISIBLE_MS = 5000
+// The floating jump-to-latest control appears once the reader holds a position
+// this far above the CONTENT tail (reserved spacer room is phantom, per the
+// send-snapshot bottom rule). Deliberately wider than the 50px near-bottom
+// band: settling a line or two up must not summon a control, a real upward
+// scroll should.
+const JUMP_TO_LATEST_GAP_PX = 200
 
 function delay(ms) {
   return new Promise(resolve => setTimeout(resolve, ms))
@@ -2078,7 +2087,23 @@ export default function ChatView({
       .catch(() => { loadingOlder.current = false })
   }
 
+  // Jump-to-latest visibility (contract R5a): a pure geometry READ — it never
+  // writes scrollTop, so it lives outside the scroll controller's ownership
+  // gates. Recomputed from every scroll event (gesture or programmatic) and
+  // from every commit via the dependency-less layout effect below: a stream
+  // growing beneath a held ANCHOR_AT emits no scroll event, but each growth
+  // tick re-renders this component. The guarded setState keeps those
+  // recomputes render-free until the boolean actually flips.
+  const [awayFromLatest, setAwayFromLatest] = useState(false)
+  const updateJumpToLatest = useCallback(() => {
+    const el = scrollRef.current
+    const away = !!el && !isNearContentBottom(el, JUMP_TO_LATEST_GAP_PX)
+    setAwayFromLatest(prev => (prev === away ? prev : away))
+  }, [])
+  useLayoutEffect(updateJumpToLatest)
+
   function handleScroll() {
+    updateJumpToLatest()
     const el = scrollRef.current
     if (!el || loadingOlder.current || loading) return
     // Gesture guard: applyMode's programmatic scrolls (e.g., PIN_USER_MSG
@@ -4273,6 +4298,26 @@ export default function ChatView({
                 {pendingResumeBlock?.pause?.resets_at
                   ? 'Rate limit reached — tap to resume'
                   : 'Turn paused — tap to resume'}
+              </button>
+            )}
+            {/* Jump-to-latest: same one-shot tail navigation as the nudges
+                (contract R5a — lands as a settled hold, never live-follow),
+                shown once the reader has scrolled away from the end. Yields
+                to a visible nudge, which goes to the same place with more
+                context. */}
+            {jumpToLatestShown({
+              awayFromTail: awayFromLatest,
+              questionNudgeShown: hasPendingQuestion && pendingCardOffscreen,
+              resumeNudgeShown: hasPendingResume && resumeCardOffscreen,
+            }) && (
+              <button
+                type="button"
+                className="chat__jump-latest"
+                aria-label="Jump to the latest message"
+                title="Jump to latest"
+                onClick={revealConversationTail}
+              >
+                <ArrowDown size={18} strokeWidth={2.25} aria-hidden="true" />
               </button>
             )}
           </div>

--- a/frontend/src/components/ChatView/__tests__/chatContract.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatContract.test.js
@@ -71,7 +71,7 @@ test('owner contract freezes question answers without locking keyboard movement'
     new URL('../../../../../ARCHITECTURE.md', import.meta.url),
     'utf8',
   )
-  assert.match(architecture, /Owner-authoritative contract — v1\.17 \(2026-08-03\)/)
+  assert.match(architecture, /Owner-authoritative contract — v1\.18 \(2026-08-04\)/)
   assert.match(
     architecture,
     /In-process question is answered \| any \| transient `ANCHOR_AT` over the prior mode; same active assistant row/,

--- a/frontend/src/components/ChatView/__tests__/chatRuntimeState.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatRuntimeState.test.js
@@ -11,6 +11,7 @@ import {
   continuationRowsFromPromotedMessage,
   isContinuationMessage,
   isOwnerUserMessage,
+  jumpToLatestShown,
   openAppCtaViewModel,
   previewReadyAnnouncement,
   previewUpdatedAnnouncement,
@@ -25,6 +26,25 @@ import {
   systemEventForChat,
 } from '../chatRuntimeState.js'
 import { mergeRecentMessagesIntoLoadedWindow } from '../../../lib/chatDetailCache.js'
+
+test('R5a: jump-to-latest shows only away from the tail and yields to attention nudges', () => {
+  // At the content tail there is nothing to jump to.
+  assert.equal(jumpToLatestShown({ awayFromTail: false }), false)
+  // Scrolled up with no competing nudge: show.
+  assert.equal(jumpToLatestShown({ awayFromTail: true }), true)
+  // A visible attention nudge navigates to the same tail with more context —
+  // never stack two controls for one action.
+  assert.equal(
+    jumpToLatestShown({ awayFromTail: true, questionNudgeShown: true }),
+    false,
+  )
+  assert.equal(
+    jumpToLatestShown({ awayFromTail: true, resumeNudgeShown: true }),
+    false,
+  )
+  // Fails closed on an empty call.
+  assert.equal(jumpToLatestShown(), false)
+})
 
 test('automatic and manual continuations are product markers, not owner messages', () => {
   const marker = {

--- a/frontend/src/components/ChatView/chatRuntimeState.js
+++ b/frontend/src/components/ChatView/chatRuntimeState.js
@@ -63,6 +63,18 @@ export function serverSnapshotBehindLocal(serverMsgs, localMsgs) {
   })
 }
 
+/** The floating jump-to-latest control (contract R5a) shows only while the
+ * reader holds a position away from the content tail, and yields to any
+ * visible attention nudge — a nudge navigates to the same tail with strictly
+ * more context, so stacking both would be two controls for one action. */
+export function jumpToLatestShown({
+  awayFromTail = false,
+  questionNudgeShown = false,
+  resumeNudgeShown = false,
+} = {}) {
+  return !!awayFromTail && !questionNudgeShown && !resumeNudgeShown
+}
+
 export function canFastForwardQueue(pendingMessages, turnActive) {
   return !!turnActive
     && Array.isArray(pendingMessages)

--- a/tests/attention-nudges.spec.mjs
+++ b/tests/attention-nudges.spec.mjs
@@ -152,6 +152,10 @@ for (const scenario of SCENARIOS) {
     })
     const nudge = page.locator(scenario.nudgeSelector)
     await expect(nudge).toBeVisible({ timeout: 5000 })
+    // R5a exclusivity: the reader is far above the tail, but the visible
+    // attention nudge owns the slot — jump-to-latest goes to the same place
+    // with more context and must not stack beneath it.
+    await expect(page.locator('.chat__jump-latest')).toHaveCount(0)
     const rail = page.locator('[data-chat-surface="painted"] .chat__progress-rail')
     const composer = page.locator('[data-chat-surface="painted"] .chat__pill')
     await expect(rail).toBeVisible({ timeout: 5000 })
@@ -197,3 +201,118 @@ for (const scenario of SCENARIOS) {
     expect(geometry.modeKind).toBe('ANCHOR_AT')
   })
 }
+
+// R5a jump-to-latest (contract v1.18): the floating control renders only while
+// the reader holds a position away from the content tail; tapping it is the
+// same one-shot controller tail reveal as the nudges and lands a settled
+// ANCHOR_AT hold — never live-follow — after which the control retires itself.
+test('jump-to-latest appears only away from the tail and lands a settled hold', async ({ page }) => {
+  await page.setViewportSize({ width: 1512, height: 861 })
+  await page.goto(BASE, { waitUntil: 'domcontentloaded' })
+  await page.waitForFunction(
+    () => !!(document.querySelector('[data-chat-surface="painted"] .chat__empty-wrap')
+      || document.querySelector('[data-chat-surface="painted"] .chat__scroll')
+      || document.querySelector('[data-chat-surface="painted"] .chat__form')),
+    { timeout: 10000 },
+  )
+
+  const chat = await createTaggedChat(page, 'jump-to-latest-tail')
+  expect(chat?.id).toBeTruthy()
+
+  const paragraphs = Array.from({ length: 42 }, (_, i) => ({
+    type: 'text',
+    content: `Jump history ${i + 1}. ${'Enough content to overflow the viewport. '.repeat(8)}`,
+  }))
+  const messages = [
+    {
+      role: 'user',
+      content: 'Please write the long review.',
+      ts: 1700000300000,
+      cid: 'jump-to-latest-user',
+      blocks: [{ type: 'text', content: 'Please write the long review.' }],
+    },
+    {
+      role: 'assistant',
+      content: '',
+      ts: 1700000300001,
+      blocks: paragraphs,
+    },
+  ]
+
+  await page.route(new RegExp(`/api/chats/${chat.id}\\?limit=`), route => {
+    if (route.request().method() !== 'GET') return route.continue()
+    return route.fulfill({
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        messages,
+        total: messages.length,
+        offset: 0,
+        running: false,
+        pending_messages: [],
+      }),
+    })
+  })
+  await page.route(new RegExp(`/api/chats/${chat.id}/stream$`), route =>
+    route.fulfill({
+      status: 200,
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+      },
+      body: 'data: {"type":"catch_up_done"}\n\ndata: {"type":"done"}\n\n',
+    }))
+
+  await page.evaluate(chatId => {
+    localStorage.setItem('moebius_active_chat', chatId)
+  }, chat.id)
+  await page.goto(`${BASE}/shell/?chat=${chat.id}`, { waitUntil: 'domcontentloaded' })
+
+  await expect(page.locator('[data-chat-surface="painted"] .chat__scroll')).toBeVisible({ timeout: 15000 })
+  await page.waitForFunction(() => {
+    const scroll = document.querySelector('[data-chat-surface="painted"] .chat__scroll')
+    return !!scroll && scroll.scrollHeight > scroll.clientHeight + 1000
+  }, { timeout: 5000 })
+
+  // R4's fallback lands the restored chat at the latest content. Wait for the
+  // settled near-tail restore, then require the control absent: at the end of
+  // the chat there is nothing to jump to.
+  const jump = page.locator('.chat__jump-latest')
+  await page.waitForFunction(() => {
+    const scroll = document.querySelector('[data-chat-surface="painted"] .chat__scroll')
+    return !!scroll
+      && scroll.scrollHeight - scroll.clientHeight - scroll.scrollTop < 200
+  }, { timeout: 5000 })
+  await expect(jump).toHaveCount(0)
+
+  // Scroll well above the tail with the same gesture signal the controller
+  // receives from a human scroll.
+  await page.evaluate(() => {
+    const scroll = document.querySelector('[data-chat-surface="painted"] .chat__scroll')
+    if (!scroll) return
+    scroll.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
+    scroll.scrollTop = Math.max(
+      0,
+      scroll.scrollHeight - scroll.clientHeight - 1200,
+    )
+  })
+  await expect(jump).toBeVisible({ timeout: 5000 })
+
+  await jump.click()
+
+  // Landing is the physical tail, and the control retires itself there.
+  await page.waitForFunction(() => {
+    const scroll = document.querySelector('[data-chat-surface="painted"] .chat__scroll')
+    if (!scroll || document.querySelector('.chat__jump-latest')) return false
+    return Math.abs(scroll.scrollHeight - scroll.clientHeight - scroll.scrollTop) <= 1
+  }, { timeout: 5000 })
+
+  const modeKind = await page.evaluate(chatId => {
+    try {
+      return JSON.parse(
+        localStorage.getItem('chat-reading-position') || '{}',
+      )[chatId]?.kind ?? null
+    } catch { return null }
+  }, chat.id)
+  expect(modeKind).toBe('ANCHOR_AT')
+})


### PR DESCRIPTION
A round, translucent jump-to-latest button floats above the composer once the reader has scrolled away from the end of a chat; tapping it returns to the newest message.

## Behavior

- **Visibility** is a pure geometry read (`isNearContentBottom` at a wider 200px band) recomputed on every scroll event and every commit — it never writes `scrollTop`, so it stays outside the scroll controller's reader-ownership gates. Reserved spacer room below a fresh send is phantom (the send-snapshot bottom rule), so the control never appears right after sending while reply room is still blank.
- **Tapping** routes through the controller's existing attention-nudge tail reveal (R5a) and lands a settled `ANCHOR_AT` hold — never live-follow, consistent with R0's two auto-scroll entrances. The control retires itself on landing.
- **It yields to a visible attention nudge** (question / paused-turn): the nudge navigates to the same tail with strictly more context, so the two never stack.
- Styling reuses the nudge slot and the shell's translucent language (surface color-mix over backdrop blur), works in light and dark, and keeps the `chat-foot-rise` entrance.

## Contract

`ARCHITECTURE.md` "Chat scroll + steer contract" bumped to **v1.18**: R5a now names the jump-to-latest control explicitly, and the version-pinning assertion in `chatContract.test.js` is updated in the same change.

## Tests

- `chatRuntimeState.test.js`: unit coverage for the visibility rule (away-from-tail gating, nudge exclusivity, fails closed).
- `attention-nudges.spec.mjs`: a new Playwright case — control absent at the restored tail, appears after a gesture scroll up, click lands within 1px of the physical tail as a settled `ANCHOR_AT`, control retires; plus an exclusivity assertion in the existing nudge scenarios.
- Full frontend unit suite green locally (2,380 lib + 79 hooks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)