### PR TITLE
Give the drawer's owned scroll a momentum fling

### DIFF
--- a/frontend/src/components/Shell/__tests__/dragController.test.js
+++ b/frontend/src/components/Shell/__tests__/dragController.test.js
@@ -7,6 +7,7 @@ import {
   CHIP_MOUSE_DX, CHIP_MOUSE_DY, CHIP_TOUCH_ABOVE,
   EDGE_BAND_MIN, EDGE_BAND_FRACTION,
   passedSlop, touchTabMoveIntent, drawerRowMoveIntent, releasedInPlace, chipOffset,
+  flingReleaseVelocity,
   crossedDrawerExit, edgeBands, edgePreviewRect, caretZone, edgeZone, centerZone,
   rootEdgeZone, hitTest, zoneTarget, releaseZone, zoneEq, buildScene,
 } from '../dragController.js'
@@ -67,6 +68,32 @@ test('drawerRowMoveIntent resolves one gesture without competing owners', () => 
     'an unpinned row cannot enter the reorder branch')
   assert.equal(drawerRowMoveIntent(0, 6, { pinned: true }), 'reorder',
     'mouse rows use ordinary drag slop without a hold')
+})
+
+test('flingReleaseVelocity uses the swipe window, not the decelerating last move', () => {
+  const now = 1000
+  // A real thumb: fast across the window, then a slow crawl right before lifting.
+  const samples = [
+    { t: 940, top: 0 },
+    { t: 956, top: 40 },
+    { t: 972, top: 80 },
+    { t: 988, top: 118 },
+    { t: 998, top: 120 }, // decelerating final move — 2px in 10ms
+  ]
+  const v = flingReleaseVelocity(samples, now)
+  // 120px across 58ms ≈ 2.07 px/ms — the swipe's speed, not the ~0.2 of the crawl
+  // that an EMA of the final move would have reported (which killed the glide).
+  assert.ok(v > 1.5 && v < 2.5, `expected the swipe speed, got ${v}`)
+})
+
+test('flingReleaseVelocity drops a paused or too-short release to zero', () => {
+  const now = 1000
+  // Newest sample is stale (finger rested ~220ms before lifting) → no glide.
+  assert.equal(flingReleaseVelocity([{ t: 700, top: 0 }, { t: 780, top: 200 }], now), 0)
+  assert.equal(flingReleaseVelocity([{ t: 995, top: 10 }], now), 0, 'one sample cannot form a velocity')
+  assert.equal(flingReleaseVelocity([], now), 0)
+  // Two fresh samples spanning under minSpanMs cannot measure a stable speed.
+  assert.equal(flingReleaseVelocity([{ t: 998, top: 10 }, { t: 999, top: 14 }], now), 0)
 })
 
 test('releasedInPlace is true only within the release radius', () => {

--- a/frontend/src/components/Shell/dragController.js
+++ b/frontend/src/components/Shell/dragController.js
@@ -136,6 +136,28 @@ export function releasedInPlace(dx, dy, limit = RELEASE_IN_PLACE_PX) {
   return hypot(dx, dy) <= limit
 }
 
+// Release velocity (layout px/ms) for the drawer's momentum glide. The pinned
+// rows scroll under our own pointer owner (touch-action reserves them for the
+// hold-to-reorder gesture), so the browser gives us no native fling — we measure
+// one. A thumb DECELERATES in the last moment before it lifts, so reading only
+// the final move reports "no flick" and kills the glide; instead average the
+// travel across the recent window. `samples` are {t (ms), top (scroll offset)}
+// pushed each move. Returns 0 for a paused release (newest sample stale) or a
+// window too short to measure, so a deliberate stop keeps its exact position.
+export function flingReleaseVelocity(samples, now, { maxAgeMs = 110, minSpanMs = 8 } = {}) {
+  if (!Array.isArray(samples) || samples.length < 2) return 0
+  const newest = samples[samples.length - 1]
+  if (!newest || now - newest.t > maxAgeMs) return 0
+  let oldest = newest
+  for (let i = samples.length - 1; i >= 0; i -= 1) {
+    if (now - samples[i].t > maxAgeMs) break
+    oldest = samples[i]
+  }
+  const span = newest.t - oldest.t
+  if (span < minSpanMs) return 0
+  return (newest.top - oldest.top) / span
+}
+
 // Whether the workspace-root-edge drop zone may arm for this pointer + mode: it
 // is fine-pointer only (touch collides with the OS edge-back gesture) and never
 // on a phone (portrait width can't sustain a side split). The single predicate

--- a/frontend/src/components/Shell/useWorkspaceDrag.js
+++ b/frontend/src/components/Shell/useWorkspaceDrag.js
@@ -3,6 +3,7 @@ import * as tabModel from './tabModel.js'
 import {
   buildScene, hitTest, zoneTarget, releaseZone, chipOffset, STRIP_CARET_PAD,
   passedSlop, touchTabMoveIntent, drawerRowMoveIntent, releasedInPlace,
+  flingReleaseVelocity,
   TAB_HOLD_MS, DRAWER_DRAG_HOLD_MS, DRAWER_MENU_HOLD_MS,
   crossedDrawerExit,
   rootEdgeAllowed,
@@ -113,6 +114,42 @@ export default function useWorkspaceDrag({
     // Without this boundary, an interrupted drag followed quickly by a tap on
     // the same drawer row made the row look dead for up to 400ms.
     let clearPendingSourceClick = null
+
+    // ── Momentum fling for the JS-owned drawer scroll ─────────────────────────
+    // Pinned drawer rows keep touch-action:pinch-zoom so a held pin can be dragged
+    // to reorder, which means the browser never scrolls those rows natively — the
+    // session pans .drawer__scroll 1:1 with the finger instead (onMove below).
+    // Without a fling that 1:1 pan dead-stops the instant the finger lifts, so on a
+    // tall pinned band the whole list reads as "stuck / something stops the scroll."
+    // This carries the release velocity and decelerates on rAF, reproducing native
+    // momentum. It lives at the effect scope so a glide outlives its pointer session
+    // and a fresh press (or unmount) can halt it. Frame-rate independent: velocity
+    // is layout px/ms and decays by exp(-FRICTION·dt), matching iOS-normal feel.
+    let flingRAF = 0
+    const FLING_FRICTION = 0.002 // per-ms velocity decay (≈ 0.998/ms, iOS normal)
+    const FLING_MIN_V = 0.04 // px/ms — below this the glide has visually stopped
+    function stopFling() {
+      if (flingRAF) { cancelAnimationFrame(flingRAF); flingRAF = 0 }
+    }
+    function startFling(el, velocity) {
+      stopFling()
+      if (!el || !Number.isFinite(velocity) || Math.abs(velocity) < FLING_MIN_V) return
+      let v = velocity
+      let last = performance.now()
+      const step = (now) => {
+        flingRAF = 0
+        const dt = Math.min(32, now - last) // clamp a long/background frame
+        last = now
+        const before = el.scrollTop
+        el.scrollTop = before + v * dt
+        // A short delta versus the request means the scroller hit top/bottom.
+        if (Math.abs(el.scrollTop - before) + 0.5 < Math.abs(v * dt)) return
+        v *= Math.exp(-FLING_FRICTION * dt)
+        if (Math.abs(v) < FLING_MIN_V) return
+        flingRAF = requestAnimationFrame(step)
+      }
+      flingRAF = requestAnimationFrame(step)
+    }
 
     function contentBox() {
       return captureLayoutSpace(contentElRef.current)
@@ -299,6 +336,9 @@ export default function useWorkspaceDrag({
       let scrollEl = null
       let scrollAxis = null
       let scrollSpace = null
+      // Recent {t, top} samples so the lift-off velocity is a short trailing
+      // AVERAGE, not just the final (decelerating) move — see flingReleaseVelocity.
+      let scrollSamples = []
       let curZone = null
       let scene = null
       let drawerEdgeX = null
@@ -494,6 +534,13 @@ export default function useWorkspaceDrag({
               previousPoint.y - ev.clientY,
               scrollSpace,
             )
+            // Sample the real scroll position; the lift handler turns the last
+            // ~110ms of these into a release velocity for the glide.
+            const now = performance.now()
+            scrollSamples.push({ t: now, top: scrollEl.scrollTop })
+            while (scrollSamples.length > 2 && now - scrollSamples[0].t > 110) {
+              scrollSamples.shift()
+            }
           }
           return
         }
@@ -510,6 +557,7 @@ export default function useWorkspaceDrag({
               scrolling = true
               scrollEl = srcEl.closest('.drawer__scroll')
               scrollAxis = 'y'
+              scrollSamples = []
               ev.preventDefault?.()
               if (scrollEl) {
                 scrollSpace = captureLayoutSpace(scrollEl)
@@ -517,6 +565,7 @@ export default function useWorkspaceDrag({
                   start.y - ev.clientY,
                   scrollSpace,
                 )
+                scrollSamples.push({ t: performance.now(), top: scrollEl.scrollTop })
               }
               return
             }
@@ -634,6 +683,12 @@ export default function useWorkspaceDrag({
         }
         if (!armed) {
           if (scrolling) {
+            // Turn the last ~110ms of travel into a release velocity and hand a
+            // still-moving lift to the momentum glide. A finger that paused before
+            // lifting leaves no fresh samples, so it keeps its exact rest position.
+            if (scrollEl && scrollAxis === 'y') {
+              startFling(scrollEl, flingReleaseVelocity(scrollSamples, performance.now()))
+            }
             cleanup({ suppressClick: true })
           } else if (isTouch && held && sourceKind === 'tab') {
             const dx = ev.clientX - start.x
@@ -813,6 +868,9 @@ export default function useWorkspaceDrag({
       // stale-session reconciliation so this fresh interaction stays live.
       clearPendingSourceClick?.()
       clearPendingSourceClick = null
+      // Touching the list halts an in-flight momentum glide, the way native
+      // scrolling stops under a finger.
+      stopFling()
       if (activeCleanup) {
         // Pointer ids are routinely REUSED across sequential touch gestures
         // (notably id=1 on mobile). Liveness comes from capture, never identity:
@@ -880,6 +938,7 @@ export default function useWorkspaceDrag({
       window.removeEventListener('pageshow', reconcileStaleSession)
       document.removeEventListener('visibilitychange', onForegroundVisible)
       activeCleanup?.() // tear down an in-flight drag
+      stopFling() // no rAF may outlive the effect
       clearPendingSourceClick?.()
       removeOverlays()
     }


### PR DESCRIPTION
## Summary
- Add a momentum fling to the drawer's pointer-owned scroll, so a quick swipe on the pinned list coasts to a stop instead of stopping dead on release.
- Derive the release velocity from a short trailing window of the swipe rather than the final move, so a thumb that decelerates before lifting still flings.
- Add unit coverage for the velocity logic.

## Why
Pinned drawer rows keep `touch-action: pinch-zoom` so a held pin can be dragged to reorder (and a longer hold opens its menu). That reservation means the browser never scrolls those rows natively — the pointer session pans `.drawer__scroll` 1:1 with the finger. With no momentum, that pan dead-stops the instant the finger lifts, and when the pinned band fills the drawer every swipe stops short, which reads as "the scroll is stuck."

This adds the missing fling: it carries the release velocity and decelerates on `requestAnimationFrame` (frame-rate independent, iOS-normal feel), a fresh press or unmount halts the glide, and a deliberately paused release keeps its exact position. The release velocity comes from a short trailing window (`flingReleaseVelocity`, a pure, unit-tested helper in `dragController.js`) rather than the final move, which avoids the failure where a thumb slows just before lifting and an end-of-gesture read reports "no flick."

This complements #564, which kept existing chat/drawer momentum uninterrupted; here the pinned-row scroll had no momentum to begin with.

## Testing
- `npm test` (frontend unit; includes new `flingReleaseVelocity` coverage)
- `npm run lint`
- Manual: on an Android phone, a swipe on the pinned list now coasts to a stop.