### PR TITLE
Fix New chat soft-keyboard bounce during composer handoff

### DIFF
--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -1043,7 +1043,14 @@ export default function Shell() {
       setNewChatPresentation(current => (
         current === presentation ? releasing : current
       ))
-      releaseComposerFocusLease(composerFocusLeaseRef.current)
+      // The keyboard lease is deliberately NOT released here. Display-ready only
+      // unblocks the composerRequest (gated on surfaceVisible); the destination
+      // composer accepts focus one animation frame later. Releasing now blurs
+      // the lease a frame early, leaving nothing focused — Android drops and
+      // re-raises the soft keyboard (the New-chat "bounce"). On this success
+      // path the composer's own focus atomically takes the keyboard from the
+      // lease and the lease's onBlur clears it; only the abandon paths (failed
+      // or superseded allocation) release the lease explicitly.
     }
     finishDrawerNavigationPresentation()
   }, [finishDrawerNavigationPresentation, focusedPaneViewIdRef, workspaceStateRef])


### PR DESCRIPTION
## Problem

On touch devices, starting a New chat raises the software keyboard immediately (the focus lease from #527 / #559) so the composer is ready to type. On Android the keyboard visibly **bounces** — it starts to drop and then re-raises — before settling. Tapping into an existing chat's composer is unaffected; the bounce is specific to the New-chat handoff.

## Root cause

`handlePaneChatDisplayReady` releases the keyboard lease the moment the destination surface reports display-ready:

```js
releaseComposerFocusLease(composerFocusLeaseRef.current)
```

But the destination composer does **not** take focus at that point. `composerRequest` is gated on `surfaceVisible`:

```jsx
composerRequest={role === 'active' && surfaceVisible ? composerRequest : null}
```

and `ChatView` then focuses the textarea inside a `requestAnimationFrame`. So the lease is blurred **at least one animation frame before** the composer is focused, leaving a frame with no focused element. Android reacts to that gap by starting to dismiss the soft keyboard and then re-raising it when the composer finally takes focus — the bounce. This release was added in #559.

## Fix

Don't release the lease at display-ready. On the success path the composer's own `focus()` atomically takes the keyboard from the lease, and the lease's existing `onBlur` clears its value — so there is never an unfocused frame. The abandon paths (failed or superseded allocation, where no composer will take focus) already release the lease explicitly and are unchanged.

The net change is removing one line plus a comment documenting why the release must not live there.

## Testing

Frontend Shell/ChatView unit suites pass. The visual keyboard behavior is Android-device-specific and not reproducible in headless browsers; this PR removes the concrete one-frame focus gap in the handoff logic that produces it.