### PR TITLE
Fix New chat cover flashing the previous chat mid-transition

### DIFF
--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -2745,6 +2745,11 @@ export default function Shell() {
         const resolvedPresentation = {
           ...presentation,
           chatId: String(chatId),
+          // Adopt the epoch of the navigation that owns this destination (navTo
+          // above bumped it). newChatPresentationIsCurrent keeps the cover while
+          // this epoch still holds, bridging the render before `activeChatId`
+          // commits so the outgoing chat never flashes through.
+          navigationEpoch: navigationEpochRef.current,
         }
         newChatPresentationRef.current = resolvedPresentation
         setNewChatPresentation(current => (

--- a/frontend/src/components/Shell/__tests__/newChatPolicy.test.js
+++ b/frontend/src/components/Shell/__tests__/newChatPolicy.test.js
@@ -78,6 +78,19 @@ test('New Chat presentation ownership follows allocation context then destinatio
   assert.equal(newChatPresentationIsCurrent(resolvedPresentation, {
     ...resolvedCurrent, activeChatId: 'other',
   }), false)
+
+  // Route still catching up to the resolved chat: activeChatId has not
+  // committed yet, but no navigation happened since it resolved (epoch
+  // unchanged). The cover stays current so the outgoing chat never flashes
+  // between the New chat surface and its destination.
+  assert.equal(newChatPresentationIsCurrent(resolvedPresentation, {
+    ...resolvedCurrent, navigationEpoch: 4, activeChatId: 'old',
+  }), true)
+  // A genuine supersede in that same window (navigation bumped the epoch and
+  // landed elsewhere) must still retire the cover.
+  assert.equal(newChatPresentationIsCurrent(resolvedPresentation, {
+    ...resolvedCurrent, navigationEpoch: 5, activeChatId: 'old',
+  }), false)
 })
 
 test('empty-single policy fires only on the transition edge', () => {

--- a/frontend/src/components/Shell/newChatPolicy.js
+++ b/frontend/src/components/Shell/newChatPolicy.js
@@ -19,8 +19,18 @@ export function newChatPresentationIsCurrent(presentation, {
 } = {}) {
   if (!presentation || presentation.viewMode !== viewMode) return false
   if (presentation.chatId != null) {
-    return activeView === 'chat'
-      && normalizedId(activeChatId) === normalizedId(presentation.chatId)
+    if (activeView !== 'chat') return false
+    // The concrete chat route owns the cover once it exists — but navTo bumps
+    // the epoch and commits `activeChatId` a render later, so the route is still
+    // catching up to the resolved chat for one commit. Treat that in-flight
+    // window as current: `activeChatId` already matches, OR no navigation has
+    // happened since the cover resolved (epoch unchanged). A real supersede
+    // (Back, another chat, an app) bumps the epoch past the resolved value and
+    // retires the cover. Without this the cover retires over the OUTGOING chat
+    // mid-transition, flashing it between the New chat surface and its
+    // destination.
+    return normalizedId(activeChatId) === normalizedId(presentation.chatId)
+      || presentation.navigationEpoch === navigationEpoch
   }
   return presentation.navigationEpoch === navigationEpoch
     && presentation.drawerEntryOpen === !!drawerEntryOpen


### PR DESCRIPTION
## Problem

Opening a New chat from an existing chat briefly flashes the **previous** chat: the sequence is new chat → previous chat → new chat. It reproduces on the web (single-screen / docked layouts) and is independent of the keyboard.

## Root cause

While a New chat allocates, an immediate cover (the "What's on your mind?" surface) is painted over the outgoing chat. When the row resolves, `newChat` sets the cover's `chatId` to the new chat and calls `navTo('chat', { chatId })`. But `navTo` bumps `navigationEpoch` and commits `activeChatId` a render *later*. For that one commit the cover is resolved to the new chat while `activeChatId` still points at the outgoing chat, so `newChatPresentationIsCurrent` — which, once `chatId` is set, required `activeChatId === presentation.chatId` — returns false and the supersede effect **retires the cover over the outgoing chat**, flashing it, until the route catches up and the new ChatView paints.

Traced by instrumenting the transition and driving it in a headless browser: the supersede/retire fired with the cover resolved to the new chat while `activeChatId` was still the old chat.

## Fix

A resolved cover stays "current" while the route is still catching up to it: `activeChatId` already matches, **or** no navigation has happened since it resolved (nav epoch unchanged). A genuine supersede — Back, another chat, an app — bumps the epoch past the resolved value and still retires the cover. Two small pieces:

- `newChatPresentationIsCurrent`: treat the in-flight window (epoch unchanged) as current.
- `newChat`: stamp the resolved cover with the epoch of the navigation that owns its destination (the one `navTo` just bumped), so the check holds across the commit gap.

## Testing

Added a `newChatPolicy` regression test covering the catch-up window (stays current) and a genuine supersede in that window (still retires). Frontend Shell/ChatView unit suites pass. Verified by re-running the same headless reproduction: the premature retire no longer fires and the cover holds until the destination paints.