### PR TITLE
Recover stale-generation crashes through the service-worker handoff

### DIFF
--- a/frontend/src/components/ErrorBoundary/ErrorBoundary.css
+++ b/frontend/src/components/ErrorBoundary/ErrorBoundary.css
@@ -37,3 +37,17 @@
   border-radius: 8px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.32);
 }
+
+/* Quiet status shown while a stale-generation crash reloads onto the fixed
+   build — no alarming "Something broke" flash for a self-healing update. */
+.errbound__updating {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  color: var(--text-muted, rgba(236, 236, 236, 0.72));
+}
+
+.errbound__updating-text {
+  outline: none;
+}

--- a/frontend/src/components/ErrorBoundary/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary/ErrorBoundary.jsx
@@ -9,8 +9,13 @@ import {
   runAgentRepair,
   writeRefreshedRecoveryAttempt,
 } from '../../lib/errorRecovery.js'
+import { reloadIfGenerationStale } from '../Shell/swHandoff.js'
 import RecoveryPanel from './RecoveryPanel.jsx'
 import './ErrorBoundary.css'
+
+function readStalePrecacheFlag() {
+  try { return sessionStorage.getItem('sw-stale-precache-pending') === '1' } catch { return false }
+}
 
 /**
  * App-level error boundary. Without one, a render throw anywhere below
@@ -38,6 +43,7 @@ export default class ErrorBoundary extends Component {
     error: null,
     attempt: null,
     repairActive: false,
+    selfHealing: false,
   }
 
   crashContext = null
@@ -72,7 +78,67 @@ export default class ErrorBoundary extends Component {
       attempt,
     }
     this.listenForPageShow()
-    this.setState({ attempt, repairActive: false }, () => this.headingRef?.focus())
+    if (attempt) {
+      // A recovery attempt for THIS exact crash is already on record — the
+      // stale-generation self-heal (or a manual refresh) has already run once
+      // and it still failed. Do not auto-reload again; show the recovery panel
+      // so the escalation (refresh → ask agent) proceeds. This ledger is the
+      // loop guard that keeps a genuine bug from reload-looping.
+      this.setState({ attempt, repairActive: false }, () => this.headingRef?.focus())
+    } else {
+      // First occurrence: if a newer shell generation exists this is a
+      // stale-bundle crash — silently reload onto the fixed generation.
+      // Otherwise fall through to the panel (genuine failure on the newest build).
+      this.setState({ selfHealing: true }, () => this.headingRef?.focus())
+      this.selfHealIfStale()
+    }
+  }
+
+  // Recovery reload shared by auto-heal and the manual refresh: escape a stale
+  // generation through the SW handoff, reloading via applyRecoveryReload.
+  // Resolves true when a newer generation was found and a reload was initiated.
+  recoverReload = (context) => reloadIfGenerationStale({
+    serviceWorker: typeof navigator !== 'undefined' ? navigator.serviceWorker : null,
+    readStaleFlag: readStalePrecacheFlag,
+    reload: () => this.applyRecoveryReload(context),
+  })
+
+  selfHealIfStale = async () => {
+    const context = this.crashContext
+    let healing = false
+    try {
+      healing = await this.recoverReload(context)
+    } catch {
+      healing = false
+    }
+    // No newer generation: the running build itself is broken. Drop the
+    // "updating" state and show the recovery panel (manual refresh + ask agent).
+    // The identity guard skips this if a newer crash has since replaced context.
+    if (!healing && this.crashContext === context) {
+      this.setState(
+        { selfHealing: false, attempt: context.attempt, repairActive: false },
+        () => this.headingRef?.focus(),
+      )
+    }
+  }
+
+  // Single reload executor for both auto-heal and the manual refresh button:
+  // record the attempt (loop guard for a repeat crash), notify the owning
+  // surface, mark the reload so App.jsx skips the splash, then reload.
+  applyRecoveryReload = (context) => {
+    if (context) {
+      writeRefreshedRecoveryAttempt({
+        surfaceKey: context.surfaceKey,
+        fingerprint: context.fingerprint,
+      })
+    }
+    this.props.onReset?.()
+    try {
+      sessionStorage.setItem('shell-reload', '1')
+    } catch {
+      /* ignore */
+    }
+    window.location.reload()
   }
 
   componentWillUnmount() {
@@ -104,23 +170,13 @@ export default class ErrorBoundary extends Component {
     this.setState({ attempt, repairActive: false })
   }
 
-  handleRefresh = () => {
+  handleRefresh = async () => {
     if (this.repairController) return
     const context = this.crashContext
-    if (context) {
-      writeRefreshedRecoveryAttempt({
-        surfaceKey: context.surfaceKey,
-        fingerprint: context.fingerprint,
-      })
-    }
-    this.props.onReset?.()
-    // Mirror App.jsx's shell-reload path so a full refresh skips the splash.
-    try {
-      sessionStorage.setItem('shell-reload', '1')
-    } catch {
-      /* ignore */
-    }
-    window.location.reload()
+    // Escape a stale generation if one exists; otherwise honor the refresh with a
+    // plain reload. A blind reload alone can be answered by the outgoing worker's
+    // precache and land back on the same stale bundle.
+    if (!(await this.recoverReload(context))) this.applyRecoveryReload(context)
   }
 
   handleAgentRepair = async () => {
@@ -161,8 +217,25 @@ export default class ErrorBoundary extends Component {
 
   render() {
     if (!this.state.error) return this.props.children
-    const message = redactDiagnosticText(this.state.error?.message || this.state.error)
     const cls = this.props.variant === 'inline' ? 'errbound errbound--inline' : 'errbound'
+    if (this.state.selfHealing) {
+      // Stale-generation self-heal in flight: the page is reloading onto the
+      // fixed build, so show a quiet status instead of flashing "Something broke".
+      return (
+        <div className={cls}>
+          <div className="errbound__card errbound__updating" role="status" aria-live="polite">
+            <span
+              className="errbound__updating-text"
+              tabIndex={-1}
+              ref={node => { this.headingRef = node }}
+            >
+              Updating to the latest version…
+            </span>
+          </div>
+        </div>
+      )
+    }
+    const message = redactDiagnosticText(this.state.error?.message || this.state.error)
     return (
       <div className={cls}>
         <RecoveryPanel

--- a/frontend/src/components/Shell/__tests__/swHandoff.test.js
+++ b/frontend/src/components/Shell/__tests__/swHandoff.test.js
@@ -2,6 +2,7 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 
 import {
+  reloadIfGenerationStale,
   reloadWhenWorkerTakesOver,
   shouldRearmShellApply,
   watchForShellUpdateOnForeground,
@@ -397,4 +398,70 @@ test('shouldRearmShellApply: an active worker newer than the controller re-arms 
   assert.equal(shouldRearmShellApply({
     waiting: null, active: newWorker, controller: oldWorker,
   }), true)
+})
+
+// --- reloadIfGenerationStale (recovery reload) ------------------------------
+
+test('reloadIfGenerationStale: forces reg.update() before deciding staleness', async () => {
+  let updated = 0
+  const active = { id: 'a' }
+  const reg = makeReg({ waiting: { id: 'w' }, active, onUpdate: () => { updated += 1 } })
+  const sw = makeSwWith(reg, { controller: active })
+  await reloadIfGenerationStale({ serviceWorker: sw, reload: () => {}, handoff: () => {} })
+  assert.equal(updated, 1, 'a fresh sw.js fetch is forced so a just-shipped worker is discovered')
+})
+
+test('reloadIfGenerationStale: newer generation waiting → hands off and returns true', async () => {
+  const active = { id: 'a' }
+  const reg = makeReg({ waiting: { id: 'w' }, active })
+  const sw = makeSwWith(reg, { controller: active })
+  let handedOff = 0
+  const healed = await reloadIfGenerationStale({
+    serviceWorker: sw,
+    reload: () => {},
+    handoff: () => { handedOff += 1 },
+  })
+  assert.equal(healed, true, 'a waiting worker means a stale bundle → self-heal')
+  assert.equal(handedOff, 1)
+})
+
+test('reloadIfGenerationStale: already newest generation → no reload, returns false', async () => {
+  const controller = { id: 'a' }
+  // active === controller, nothing waiting, no stale flag → current generation.
+  const reg = makeReg({ waiting: null, active: controller })
+  const sw = makeSwWith(reg, { controller })
+  let handedOff = 0
+  const healed = await reloadIfGenerationStale({
+    serviceWorker: sw,
+    reload: () => {},
+    handoff: () => { handedOff += 1 },
+  })
+  assert.equal(healed, false, 'a genuine bug on the newest build must not auto-reload')
+  assert.equal(handedOff, 0)
+})
+
+test('reloadIfGenerationStale: stale-precache flag alone triggers self-heal', async () => {
+  const controller = { id: 'a' }
+  const reg = makeReg({ waiting: null, active: controller })
+  const sw = makeSwWith(reg, { controller })
+  let handedOff = 0
+  const healed = await reloadIfGenerationStale({
+    serviceWorker: sw,
+    reload: () => {},
+    readStaleFlag: () => true,
+    handoff: () => { handedOff += 1 },
+  })
+  assert.equal(healed, true, 'the Chromium stale-precache flag is a stale generation')
+  assert.equal(handedOff, 1)
+})
+
+test('reloadIfGenerationStale: no service worker → returns false (no reload)', async () => {
+  let handedOff = 0
+  const healed = await reloadIfGenerationStale({
+    serviceWorker: null,
+    reload: () => {},
+    handoff: () => { handedOff += 1 },
+  })
+  assert.equal(healed, false)
+  assert.equal(handedOff, 0)
 })

--- a/frontend/src/components/Shell/swHandoff.js
+++ b/frontend/src/components/Shell/swHandoff.js
@@ -105,6 +105,48 @@ export function shouldRearmShellApply({
   return false
 }
 
+// Error-recovery reload that ESCAPES a stale service-worker generation.
+//
+// The error boundary's refresh used a blind location.reload(). On an installed
+// PWA a blind reload is answered by the CURRENTLY-CONTROLLING worker's precache,
+// so a crash caused by a stale bundle reloads straight back into the same broken
+// generation — recovery loops out to an agent instead of self-healing. Every
+// other reload in the shell escapes this through reloadWhenWorkerTakesOver
+// (performReload); this is the error-recovery analogue. It forces a fresh sw.js
+// fetch (so a just-shipped worker is discovered), then hands control to a waiting
+// worker before reloading, so recovery lands on the NEWEST generation.
+//
+// Reloads ONLY when a newer generation actually exists, reusing the same "newer
+// generation available?" predicate the foreground watcher uses
+// (shouldRearmShellApply); returns whether it did. The auto-heal caller keeps a
+// false as "genuine bug on the newest build → show the recovery panel, never
+// reload-loop"; the manual-refresh caller treats a false as "already newest →
+// honor the refresh with a plain reload". Deps are injected so the wiring is
+// unit-testable without a live worker.
+export async function reloadIfGenerationStale({
+  serviceWorker,
+  reload,
+  readStaleFlag = () => false,
+  handoff = reloadWhenWorkerTakesOver,
+} = {}) {
+  if (!serviceWorker || typeof serviceWorker.getRegistration !== 'function') return false
+  let registration = null
+  try { registration = await serviceWorker.getRegistration() } catch { return false }
+  if (!registration) return false
+  if (typeof registration.update === 'function') {
+    try { await registration.update() } catch { /* offline / transient — decide on what we have */ }
+  }
+  const stale = shouldRearmShellApply({
+    stalePrecacheFlagged: readStaleFlag(),
+    waiting: registration.waiting || null,
+    active: registration.active || null,
+    controller: serviceWorker.controller || null,
+  })
+  if (!stale) return false
+  handoff({ registration, serviceWorker, reload })
+  return true
+}
+
 // Foreground/online shell-update watch — the APPLY trigger that lets a deploy
 // reach an ALREADY-INSTALLED PWA promptly, closing the "still broken after the
 // deploy" gap for a warm install.


### PR DESCRIPTION
## Problem

When an installed PWA is running an outdated bundle (a new version deployed while the tab was open) and a screen crashes, the error boundary's "Refresh screen" did a blind `window.location.reload()`. On an installed PWA that reload is answered by the currently-controlling (outgoing/leashed) service worker's precache, so the page reloads straight back into the same stale, broken generation. Recovery could not escape the stale bundle and instead escalated to the agent-repair path — a crash loop the user had to break manually.

Every other reload path in the shell already avoids this via `reloadWhenWorkerTakesOver` (the apply-on-idle controller's `performReload`); the error-recovery path was the one reload that bypassed the handoff.

## Fix

Route error recovery through the same service-worker generation handoff, reusing existing primitives (`reloadWhenWorkerTakesOver` + `shouldRearmShellApply`) rather than adding a parallel mechanism. A single `reloadIfGenerationStale` helper fetches a fresh `sw.js` and reloads through the worker handoff only when a newer generation actually exists:

- **Auto-heal:** on a crash, if a newer generation exists, the boundary silently reloads onto it once, showing a quiet "Updating to the latest version…" state instead of "Something broke". Gated by the existing recovery-attempt ledger so it fires at most once per crash fingerprint; a genuine bug on the newest build finds nothing newer, never auto-reload-loops, and still reaches the manual panel + ask-agent path.
- **Manual refresh:** "Refresh screen" runs the same helper and falls back to a plain reload when already on the newest generation, so it too escapes a stale generation instead of bouncing back into it.

## Tests

Adds unit coverage in `swHandoff.test.js` for the helper: no-service-worker fallback, forced `update()` before deciding, self-heal when a newer generation is waiting or the stale-precache flag is set, and no reload when already on the newest generation.
