### PR TITLE
Steer immediately instead of at the next content-block boundary

### DIFF
--- a/backend/app/claude_sdk_runner.py
+++ b/backend/app/claude_sdk_runner.py
@@ -297,17 +297,12 @@ class ActiveClaudeClient:
     # after the steered row on reload (Q1, Q2, A1A2 instead of Q1, A1, Q2, A2).
     self._steer_user_msgs: list[dict] = []
     self._steer_consume_cids: list[str] = []
-    # A steer was requested but not yet cut over. The runner clears the
-    # turn at the NEXT completed content-block boundary (an AssistantMessage)
-    # rather than mid-token, so the user sees the finished sentence/thought
-    # before the steer takes over. Set by `steer()`, consumed by the runner.
-    self._steer_requested = False
-    # One interrupt is in flight: an `interrupt()` has been signalled but the
+    # One interrupt is in flight: `steer()` has signalled `interrupt()` but the
     # terminal ResultMessage that ends the interrupted turn has not arrived
-    # yet. Guards the boundary cut so a second steer (or a second
-    # AssistantMessage) in the drain window can't fire a duplicate interrupt
-    # before the SDK has closed the first; the runner clears it on the
-    # terminal result. Stop's hard `interrupt()` does not consult this — Stop
+    # yet. Guards the steer cut so a second steer arriving in the drain window
+    # can't fire a duplicate interrupt before the SDK has closed the first; the
+    # runner clears it on the terminal result and drains every buffered steer
+    # text together. Stop's hard `interrupt()` does not consult this — Stop
     # always cuts immediately.
     self._interrupt_in_flight = False
     self._finished: asyncio.Future[None] = (
@@ -320,19 +315,23 @@ class ActiveClaudeClient:
     user_msgs: list[dict] | None = None,
     consume_pending_cids: list[str] | None = None,
   ) -> bool:
-    """Buffers a steer to cut in at the next content-block boundary.
+    """Fires an immediate soft interrupt so a steer lands right away.
 
-    Claude's SDK cannot append to an in-flight tool loop, and the only
-    mid-turn lever is `interrupt()` — but interrupting on the token that
-    happens to be streaming throws away a half-finished sentence or
-    thinking trace. Instead we record the redirect text and FLAG the
-    request; the runner watches its own `receive_response()` loop and
-    interrupts only after the next COMPLETED content block is published
-    (an `AssistantMessage`), so the user sees the finished thought, then
-    the steer takes over. The existing drain-then-requery path on the
-    interrupt's terminal result delivers the buffered text on the same
-    connected client, preserving session context. (Stop is the separate
-    immediate-cut path — see `interrupt()`.)
+    Claude's SDK cannot append to an in-flight tool loop, and its only
+    mid-turn lever is `interrupt()`. We record the redirect text, then
+    interrupt the live turn NOW — on the same connected client — instead of
+    waiting for the next completed content block. The runner's
+    `receive_response()` loop can be parked inside a long-running tool call,
+    where no `AssistantMessage` arrives for seconds to minutes; deferring the
+    cut to that boundary is what made steering land unpredictably. Interrupting
+    immediately aborts the in-flight step (its work is redone once the model
+    reads the steer) and may seal a partial block, matching Codex's immediate
+    steer. The interrupt's terminal ResultMessage flows to the existing
+    drain-then-requery path in the runner, which seals the pre-steer A1,
+    appends the steered rows, and re-queries the buffered text on the same
+    session (preserving context). Two rapid steers collapse into one interrupt
+    via `_interrupt_in_flight` and drain together. (Stop is the separate
+    teardown path — see `interrupt()`.)
 
     `user_msgs` / `consume_pending_cids` are the transcript-side payload the
     runner replays into `sink.split_for_steer` when the interrupted turn
@@ -375,7 +374,15 @@ class ActiveClaudeClient:
           continue
         self._steer_consume_cids.append(cid)
         buffered_consume.add(cid)
-    self._steer_requested = True
+    # Fire the interrupt immediately (soft interrupt on the same connected
+    # client) so the steer lands now instead of at the next content-block
+    # boundary. The `_interrupt_in_flight` guard collapses two rapid steers
+    # into a single interrupt — both texts drain together when the terminal
+    # ResultMessage arrives. A racing hard Stop resolves `_finished`, so the
+    # guard no-ops rather than interrupting a torn-down client.
+    if not self._interrupt_in_flight and not self._finished.done():
+      self._interrupt_in_flight = True
+      await self._client.interrupt()
     return True
 
   async def interrupt(self) -> None:
@@ -388,9 +395,9 @@ class ActiveClaudeClient:
     direct caller.
 
     Stop is the hard, immediate-cut path: it drops the buffered steer
-    ENTIRELY — the provider-facing text (`pending_steer` + `_steer_requested`,
-    so no boundary cut or requery fires for work the user just abandoned) AND
-    the transcript-side rows (`_steer_user_msgs` + `_steer_consume_cids`, so the
+    ENTIRELY — the provider-facing text (`pending_steer`, so no requery fires
+    for work the user just abandoned) AND the transcript-side rows
+    (`_steer_user_msgs` + `_steer_consume_cids`, so the
     turn-end seal appends nothing).
 
     Both halves have to go, because Stop OWNS those rows from here on: a
@@ -405,7 +412,6 @@ class ActiveClaudeClient:
     """
     self._interrupt_requested = True
     self.pending_steer = []
-    self._steer_requested = False
     self._steer_user_msgs = []
     self._steer_consume_cids = []
     await self._client.interrupt()
@@ -1119,28 +1125,13 @@ async def run_claude_sdk_turn(
             sdk_msg, bc, current_session_id,
           )
           if terminal is None:
-            # Boundary-fire a buffered steer. `steer()` only flags the
-            # request (it no longer interrupts mid-token); we cut over at
-            # the next COMPLETED content block, which is exactly when an
-            # AssistantMessage is dispatched (the finished text / thinking /
-            # tool_use block was just published to the broadcast). The
-            # `_interrupt_in_flight` guard makes this fire exactly ONCE per
-            # interrupt cycle: a second steer or another AssistantMessage
-            # arriving before the interrupt's terminal ResultMessage closes
-            # the turn must not issue a duplicate interrupt, and a racing
-            # hard Stop (which clears pending_steer) makes the condition
-            # no-op. The buffered text is delivered by the existing
-            # drain-then-requery path below when that terminal arrives.
-            if (
-              isinstance(sdk_msg, AssistantMessage)
-              and active_client._steer_requested
-              and active_client.pending_steer
-              and not active_client._interrupt_in_flight
-              and not active_client._finished.done()
-            ):
-              active_client._steer_requested = False
-              active_client._interrupt_in_flight = True
-              await client.interrupt()
+            # A steer fires its interrupt synchronously in
+            # ActiveClaudeClient.steer() (a soft interrupt on the same
+            # connected client), so there is no boundary cut to make here — a
+            # steer during a long-running tool call would otherwise sit
+            # buffered until the tool returned. The interrupt's terminal
+            # ResultMessage is handled below, where the drain-then-requery
+            # path seals A1 and re-asks with the buffered steer text.
             continue
           if (
             active_client.interrupt_requested
@@ -1163,7 +1154,6 @@ async def run_claude_sdk_turn(
             # durability catch-all for a steer that never reaches a requery.
             await _seal_steer_split(bc, active_client, chat_id)
             active_client.pending_steer = []
-            active_client._steer_requested = False
             await client.query(
               _steer_redirect_message("\n\n".join(steer_texts))
             )
@@ -1213,7 +1203,6 @@ async def run_claude_sdk_turn(
             # turn-end finally covers the no-requery case.
             await _seal_steer_split(bc, active_client, chat_id)
             active_client.pending_steer = []
-            active_client._steer_requested = False
             await client.query(
               _steer_redirect_message("\n\n".join(steer_texts))
             )

--- a/backend/tests/test_chats_stream_steer.py
+++ b/backend/tests/test_chats_stream_steer.py
@@ -902,7 +902,6 @@ def test_stop_drops_the_buffered_steer_instead_of_appending_it():
     handle = ActiveClaudeClient(_Client(), chat_id="stopsteer")
     handle.mark_finished()
     handle.pending_steer = ["Q2"]
-    handle._steer_requested = True
     handle._steer_user_msgs = [
       {"role": "user", "content": "Q2", "ts": 10, "cid": "c-q2"}
     ]
@@ -911,7 +910,6 @@ def test_stop_drops_the_buffered_steer_instead_of_appending_it():
     await handle.interrupt()
 
     assert handle.pending_steer == []
-    assert handle._steer_requested is False
     assert handle._steer_user_msgs == []
     assert handle._steer_consume_cids == []
 

--- a/backend/tests/test_claude_sdk_runner.py
+++ b/backend/tests/test_claude_sdk_runner.py
@@ -256,11 +256,12 @@ def _stream_delta(delta_type: str, **fields: Any) -> StreamEvent:
 
 
 @pytest.mark.asyncio
-async def test_steer_into_active_turn_buffers_without_interrupting():
-  """A registered Claude handle BUFFERS steer text + flags the request,
-  but does NOT interrupt mid-token. The cut happens at the next
-  content-block boundary in the runner loop (see the boundary tests
-  below), so `steer()` itself never touches live IO."""
+async def test_steer_into_active_turn_interrupts_immediately():
+  """A registered Claude handle buffers the steer text AND fires the
+  interrupt immediately (a soft interrupt on the same connected client),
+  rather than deferring the cut to the next content-block boundary — a
+  steer during a long-running tool call must land now, not whenever the
+  tool happens to finish."""
   calls = []
 
   class _Client:
@@ -272,17 +273,16 @@ async def test_steer_into_active_turn_buffers_without_interrupting():
   try:
     assert await steer_into_active_turn("claude-steer", "use blue") is True
     assert handle.pending_steer == ["use blue"]
-    assert handle._steer_requested is True
-    # Buffering must NOT interrupt — the old behavior cut mid-token and
-    # lost in-flight text; the boundary-fire design defers the cut.
-    assert calls == []
+    # The steer interrupts the live turn right away.
+    assert calls == ["interrupt"]
     # A second rapid steer must QUEUE behind the first (FIFO), not overwrite it
     # — both texts are already persisted to the transcript, so both must reach
-    # Claude when the runner drains the mailbox.
+    # Claude when the runner drains the mailbox. It must NOT fire a second
+    # interrupt: `_interrupt_in_flight` guards the single cut until the first
+    # interrupt's terminal result drains the whole buffer together.
     assert await steer_into_active_turn("claude-steer", "and bold") is True
     assert handle.pending_steer == ["use blue", "and bold"]
-    assert handle._steer_requested is True
-    assert calls == []
+    assert calls == ["interrupt"]
   finally:
     registry.unregister("claude-steer", handle.kind)
 
@@ -306,14 +306,14 @@ async def test_steer_into_active_turn_missing_or_finished_is_false():
 
 
 @pytest.mark.asyncio
-async def test_resteer_requeries_when_terminal_precedes_boundary(monkeypatch):
-  """A steer buffered after a StreamEvent (no AssistantMessage boundary)
-  before a natural ResultMessage still re-queries on the SAME client.
+async def test_steer_requeries_on_interrupt_terminal(monkeypatch):
+  """A steer fired mid-delta interrupts immediately and re-queries on the
+  SAME client when the interrupt's terminal ResultMessage arrives.
 
-  This is edge (a) of the boundary design: a very short turn whose
-  ResultMessage arrives before any completed content block. The boundary
-  cut never fires (interrupts == 0), but the existing pending_steer →
-  requery path on the terminal result MUST still deliver the steer."""
+  The steer fires its soft interrupt as soon as it is requested (interrupts
+  == 1), even though no completed content block preceded the terminal; the
+  pending_steer -> requery path on the terminal result then delivers the
+  steer text on the same session."""
   from app import claude_sdk_runner
 
   class _FakeClient:
@@ -389,9 +389,9 @@ async def test_resteer_requeries_when_terminal_precedes_boundary(monkeypatch):
   )
 
   client = clients[0]
-  # No AssistantMessage boundary preceded the terminal ResultMessage, so
-  # the boundary cut never fired — the steer rode the natural terminal.
-  assert client.interrupts == 0
+  # The steer fired its interrupt immediately when requested; the terminal
+  # ResultMessage then drove the requery.
+  assert client.interrupts == 1
   assert client.disconnected is True
   assert client.queries[0] == "start task"
   assert client.queries[1].startswith(
@@ -633,15 +633,18 @@ async def test_owner_stop_does_not_hide_other_claude_process_failure(monkeypatch
 
 
 @pytest.mark.asyncio
-async def test_steer_fires_at_assistant_boundary_not_on_deltas(monkeypatch):
-  """THE core contract: a steer requested mid-turn does NOT interrupt
-  while token deltas (StreamEvent) stream — it waits for the next
-  COMPLETED content block (an AssistantMessage), interrupts exactly once
-  THERE, then re-queries exactly once on the same client.
+async def test_steer_interrupts_immediately_not_deferred_to_boundary(
+  monkeypatch,
+):
+  """THE core contract: a steer requested mid-turn interrupts the live turn
+  IMMEDIATELY — it does NOT wait for the next completed content block. The
+  cut lands as soon as the steer is requested (matching Codex's immediate
+  steer), then the interrupt's terminal result re-queries exactly once on
+  the same client.
 
   The fake stream records the interrupt-call count at the moment each
-  message is dispatched, so the test can assert interrupt fired AFTER the
-  AssistantMessage and NOT on any preceding StreamEvent delta."""
+  message is dispatched, so the test can assert the interrupt fired the
+  instant the steer arrived (mid-delta), not at a later boundary."""
   from app import claude_sdk_runner
 
   # (message_label, interrupts_observed_when_this_message_was_yielded)
@@ -668,17 +671,17 @@ async def test_steer_fires_at_assistant_boundary_not_on_deltas(monkeypatch):
 
     async def receive_response(self):
       if len(self.queries) == 1:
-        # First turn: deltas stream, the user steers mid-block, MORE
-        # deltas stream (interrupt must NOT have fired yet), then a
-        # COMPLETED text block arrives — that is where the cut fires.
+        # First turn: deltas stream, the user steers mid-block — the
+        # interrupt fires RIGHT THEN, so the count is already 1 on the
+        # very next delta (no waiting for a completed block).
         yield _stream_delta("text_delta", text="thinking ")
         interrupt_trace.append(("delta-1", self.interrupts))
         assert await steer_into_active_turn("boundary-chat", "use blue") \
           is True
         yield _stream_delta("text_delta", text="about it")
         interrupt_trace.append(("delta-2-after-steer", self.interrupts))
-        # The completed block — boundary. The runner interrupts right
-        # after dispatching THIS message.
+        # A completed block still arrives (a few tokens can stream before
+        # the interrupt takes effect); it must NOT fire a second interrupt.
         yield _assistant_text("thinking about it")
         interrupt_trace.append(("assistant-boundary", self.interrupts))
         # The interrupt's terminal result. The runner's drain-then-
@@ -713,11 +716,12 @@ async def test_steer_fires_at_assistant_boundary_not_on_deltas(monkeypatch):
 
   client = clients[0]
   trace = dict(interrupt_trace)
-  # No interrupt while deltas were streaming — the half-sentence was NOT
-  # cut mid-token (this is the whole point of the change).
+  # No interrupt before the steer was requested.
   assert trace["delta-1"] == 0
-  assert trace["delta-2-after-steer"] == 0
-  # The interrupt fired AT the AssistantMessage boundary, exactly once.
+  # The interrupt fired the instant the steer arrived — the next delta
+  # already sees it (this is the whole point of the change).
+  assert trace["delta-2-after-steer"] == 1
+  # Exactly once — the later completed block did not double-interrupt.
   assert client.interrupts == 1
   # Exactly one re-query with the buffered steer (no double).
   assert client.queries[0] == "start task"
@@ -738,11 +742,11 @@ async def test_steer_fires_at_assistant_boundary_not_on_deltas(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_steer_interrupts_once_despite_multiple_boundaries(monkeypatch):
-  """A second AssistantMessage arriving in the drain window (after the
-  boundary interrupt, before its terminal ResultMessage) must NOT fire a
-  SECOND interrupt. `_interrupt_in_flight` guards the single cut. Two
-  buffered steers must both ride the single requery (FIFO, exactly once)."""
+async def test_steer_interrupts_once_despite_two_rapid_steers(monkeypatch):
+  """Two rapid steers before the interrupt's terminal ResultMessage must
+  fire only ONE interrupt — `_interrupt_in_flight` guards the single cut —
+  and both buffered steers ride the single requery (FIFO, exactly once).
+  Later completed blocks arriving in the drain window must not re-interrupt."""
   from app import claude_sdk_runner
 
   class _FakeClient:
@@ -766,13 +770,13 @@ async def test_steer_interrupts_once_despite_multiple_boundaries(monkeypatch):
 
     async def receive_response(self):
       if len(self.queries) == 1:
-        # Two rapid steers buffer before any boundary.
+        # Two rapid steers: the first fires the interrupt, the second is
+        # guarded by _interrupt_in_flight and only buffers its text.
         assert await steer_into_active_turn("multi-chat", "use blue") is True
         assert await steer_into_active_turn("multi-chat", "and bold") is True
-        # First completed block — the single boundary cut fires here.
         yield _assistant_text("first block")
-        # The SDK may still emit a trailing completed block in the drain
-        # window before the interrupt's terminal lands. It must NOT cause
+        # The SDK may still emit trailing completed blocks in the drain
+        # window before the interrupt's terminal lands. They must NOT cause
         # a second interrupt.
         yield _assistant_text("straggler block")
         yield _interrupt_result()
@@ -803,7 +807,7 @@ async def test_steer_interrupts_once_despite_multiple_boundaries(monkeypatch):
   )
 
   client = clients[0]
-  # Exactly one interrupt despite two AssistantMessage boundaries in the
+  # Exactly one interrupt despite two steers and two completed blocks in the
   # drain window — the in-flight guard held.
   assert client.interrupts == 1
   # Exactly one requery, carrying BOTH buffered steers in FIFO order.
@@ -817,10 +821,9 @@ async def test_steer_interrupts_once_despite_multiple_boundaries(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_steer_after_assistant_boundary_already_passed(monkeypatch):
-  """A steer buffered AFTER the only AssistantMessage already streamed,
-  with a fresh boundary still to come, fires the cut on that next
-  boundary — proving the flag (not a one-time event) drives the cut."""
+async def test_steer_after_content_already_streamed(monkeypatch):
+  """A steer requested after some content has already streamed still
+  interrupts immediately and re-queries once on the same client."""
   from app import claude_sdk_runner
 
   class _FakeClient:
@@ -845,9 +848,8 @@ async def test_steer_after_assistant_boundary_already_passed(monkeypatch):
     async def receive_response(self):
       if len(self.queries) == 1:
         yield _assistant_text("first block")
-        # Steer arrives only now — no boundary cut yet because the flag
-        # is checked when a message is dispatched, and the next message
-        # is the boundary we cut on.
+        # Steer arrives after the first block already streamed; it fires
+        # the interrupt immediately all the same.
         assert await steer_into_active_turn("late-chat", "pivot") is True
         yield _assistant_text("second block")
         yield _interrupt_result()
@@ -885,10 +887,10 @@ async def test_steer_after_assistant_boundary_already_passed(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_stop_drops_buffered_steer_and_clears_flags(monkeypatch):
-  """Stop is the hard immediate-cut path: it must drop a buffered steer
-  (no boundary cut, no requery for abandoned work) and clear both steer
-  flags. Distinct from steer's deferred boundary cut."""
+async def test_stop_drops_buffered_steer(monkeypatch):
+  """Stop is the hard teardown path: after a steer has already fired its own
+  soft interrupt, a Stop drops the buffered steer entirely (no requery for
+  abandoned work) and fires its own immediate interrupt on top."""
   del monkeypatch  # this handle-level test needs no SDK patching
 
   calls: list[str] = []
@@ -900,18 +902,19 @@ async def test_stop_drops_buffered_steer_and_clears_flags(monkeypatch):
   handle = ActiveClaudeClient(_Client(), chat_id="stop-chat")
   registry.register(handle)
   try:
-    # Buffer a steer, then Stop.
+    # Steer buffers the text and fires its soft interrupt immediately.
     assert await steer_into_active_turn("stop-chat", "use blue") is True
     assert handle.pending_steer == ["use blue"]
-    assert handle._steer_requested is True
+    assert calls == ["interrupt"]
 
     # mark_finished so interrupt()'s _finished wait returns immediately.
     handle.mark_finished()
     await handle.interrupt()
 
-    assert calls == ["interrupt"]
+    # Stop always cuts immediately — a second interrupt on top of the
+    # steer's — and clears the buffer so no requery fires.
+    assert calls == ["interrupt", "interrupt"]
     assert handle.pending_steer == []
-    assert handle._steer_requested is False
   finally:
     registry.unregister("stop-chat", handle.kind)
 


### PR DESCRIPTION
## Problem

A mid-turn steer buffered the redirect text and set a `_steer_requested` flag, then waited for the runner's `receive_response()` loop to observe the next `AssistantMessage` before firing `interrupt()`. During a long-running tool call **no `AssistantMessage` arrives**, so the loop parked and the interrupt (and its requery) landed anywhere from seconds to minutes later — the "message disappears then steers eventually" symptom.

## Fix

`ActiveClaudeClient.steer()` now fires the soft interrupt **synchronously** on the same connected client (guarded by `_interrupt_in_flight`), matching Codex's immediate steer. The existing drain-then-requery path on the interrupt's terminal `ResultMessage` is unchanged — it still seals the pre-steer output, appends the steered rows, and re-queries the buffered text on the same session. Two rapid steers still collapse into one interrupt and drain together; a racing hard Stop still no-ops the guard.

This **removes** the now-dead boundary-fire branch in the runner and the write-only `_steer_requested` flag (net simplification).

## Tests

`test_chats_stream_steer.py` + `test_claude_sdk_runner.py` pass (106 tests).