### PR TITLE
Fix dropped leading text chunk in Claude streaming

### DIFF
--- a/backend/app/claude_events.py
+++ b/backend/app/claude_events.py
@@ -191,6 +191,26 @@ def _usage_event(usage: dict[str, Any]) -> dict:
   }
 
 
+def _claude_text_item_id(message_id: str | None, index: object) -> str | None:
+  """A turn-unique id for a Claude text content block.
+
+  Claude streams a text block's deltas and then re-sends its authoritative full
+  text (the AssistantMessage TextBlock) to repair any dropped delta — but with
+  no provider item id, so events.py could only pair delta and final
+  POSITIONALLY. When one message carries several text blocks, that pairing
+  lands the earlier block's authoritative text on the wrong (trailing) slot, so
+  a leading chunk dropped from an earlier block is never repaired. The Anthropic
+  message id plus the content-block index names the exact block on both sides,
+  so the reducer repairs by identity. The index resets per message, so the
+  message id is required to stay turn-unique. Returns None when either part is
+  missing, so the reducer keeps its positional fallback (no regression) instead
+  of minting a colliding id.
+  """
+  if message_id is None or index is None:
+    return None
+  return f"{message_id}:{index}"
+
+
 def dispatch_sdk_message(
   sdk_msg: Any,
   bc,
@@ -305,13 +325,27 @@ def dispatch_sdk_message(
       current_session_id = sdk_msg.session_id
     event = sdk_msg.event
     event_type = event.get("type")
+    if event_type == "message_start":
+      # Capture the Anthropic message id so this message's text deltas can be
+      # stamped with a turn-unique id that the AssistantMessage's authoritative
+      # text_final matches by identity (see _claude_text_item_id). The id is not
+      # on the content_block events themselves, only here.
+      message = event.get("message") or {}
+      bc.current_message_id = message.get("id")
+      return current_session_id, None
     if event_type == "content_block_delta":
       delta = event.get("delta", {})
       delta_type = delta.get("type")
       if delta_type == "text_delta":
         text = delta.get("text")
         if text:
-          bc.publish({"type": "text", "content": text})
+          item_id = _claude_text_item_id(
+            getattr(bc, "current_message_id", None), event.get("index"),
+          )
+          bc.publish({
+            "type": "text", "content": text,
+            **({"text_item_id": item_id} if item_id else {}),
+          })
         return current_session_id, None
       if delta_type == "thinking_delta":
         thinking = delta.get("thinking") or delta.get("text") or ""
@@ -346,7 +380,7 @@ def dispatch_sdk_message(
     if sdk_msg.session_id:
       current_session_id = sdk_msg.session_id
     server_tools: dict[str, str] = {}
-    for block in sdk_msg.content:
+    for content_index, block in enumerate(sdk_msg.content):
       if isinstance(block, ToolUseBlock):
         # block.id is the canonical tool_use_id; the matching ToolResultBlock
         # carries it as .tool_use_id. Thread it through so a large tool output
@@ -428,8 +462,16 @@ def dispatch_sdk_message(
         # same message object and so were always durable — this closes the gap
         # for text. Replace, never append: the reducer concatenates plain
         # "text" events, so re-emitting as "text" would double the prose.
+        # The item id (message id + content-block index) matches the streamed
+        # deltas' id, so events.py replaces THIS block by identity instead of
+        # guessing the trailing text block — the fix for an earlier text block
+        # keeping a dropped leading chunk when a message has several.
         if block.text:
-          bc.publish({"type": "text_final", "content": block.text})
+          item_id = _claude_text_item_id(sdk_msg.message_id, content_index)
+          bc.publish({
+            "type": "text_final", "content": block.text,
+            **({"text_item_id": item_id} if item_id else {}),
+          })
         continue
       _emit_unknown(
         bc, f"assistant_block:{type(block).__name__}", block,

--- a/backend/tests/test_claude_sdk_runner.py
+++ b/backend/tests/test_claude_sdk_runner.py
@@ -1999,3 +1999,85 @@ def test_precompact_log_trigger_extracts_and_is_defensive():
   assert _precompact_log_trigger({"trigger": 123}) is None
   assert _precompact_log_trigger(None) is None
   assert _precompact_log_trigger("not-a-dict") is None
+
+
+def _stream_message_start(message_id: str) -> StreamEvent:
+  return StreamEvent(
+    uuid="evt-ms", session_id="sess-1",
+    event={"type": "message_start", "message": {"id": message_id}},
+  )
+
+
+def _stream_text_delta_at(index: int, text: str) -> StreamEvent:
+  return StreamEvent(
+    uuid="evt-td", session_id="sess-1",
+    event={
+      "type": "content_block_delta", "index": index,
+      "delta": {"type": "text_delta", "text": text},
+    },
+  )
+
+
+def _stream_text_block_start(index: int) -> StreamEvent:
+  return StreamEvent(
+    uuid="evt-cbs", session_id="sess-1",
+    event={
+      "type": "content_block_start", "index": index,
+      "content_block": {"type": "text"},
+    },
+  )
+
+
+def test_claude_text_final_repairs_earlier_block_by_id():
+  """A dropped leading delta on the FIRST of two text blocks in one message is
+  repaired by the authoritative text_final, matched by (message id + index).
+
+  Before the id was threaded, text_final for the first block landed on the
+  trailing (second) block positionally, so the first block kept its truncated
+  delta accumulation forever (the dropped-leading-token bug).
+  """
+  from app.events import process_event
+
+  bus = _ChatBus()
+  # One message, TWO text blocks (indices 0 and 1). Block 0's leading delta
+  # ("Al") was dropped, so it accumulates truncated ("pha text here").
+  dispatch_sdk_message(_stream_message_start("msg_abc"), bus, None)
+  dispatch_sdk_message(_stream_text_delta_at(0, "pha text here"), bus, None)
+  dispatch_sdk_message(_stream_text_block_start(1), bus, None)
+  dispatch_sdk_message(_stream_text_delta_at(1, "Beta text"), bus, None)
+  dispatch_sdk_message(
+    AssistantMessage(
+      content=[TextBlock(text="Alpha text here"), TextBlock(text="Beta text")],
+      model="claude-opus",
+      message_id="msg_abc",
+    ),
+    bus, None,
+  )
+
+  # Delta and final events carry matching, turn-unique ids.
+  text_events = [e for e in bus.events if e["type"] == "text"]
+  final_events = [e for e in bus.events if e["type"] == "text_final"]
+  assert text_events[0]["text_item_id"] == "msg_abc:0"
+  assert final_events[0]["text_item_id"] == "msg_abc:0"
+  assert final_events[1]["text_item_id"] == "msg_abc:1"
+
+  # Reduce the emitted events the way the sink does; the first block is repaired.
+  blocks: list[dict] = []
+  for event in bus.events:
+    process_event(event, blocks)
+  texts = [b["content"] for b in blocks if b.get("type") == "text"]
+  assert texts == ["Alpha text here", "Beta text"]
+
+
+def test_claude_text_events_have_no_id_without_message_id():
+  """No message id (no message_start, or a message_id-less AssistantMessage)
+  means no text_item_id — the reducer keeps its positional fallback, so nothing
+  regresses for paths that do not supply the id."""
+  bus = _ChatBus()
+  dispatch_sdk_message(_stream_text_delta_at(0, "hello"), bus, None)
+  dispatch_sdk_message(
+    AssistantMessage(content=[TextBlock(text="hello")], model="claude-opus"),
+    bus, None,
+  )
+  emitted = [e for e in bus.events if e["type"] in ("text", "text_final")]
+  assert emitted and all("text_item_id" not in e for e in emitted)


### PR DESCRIPTION
## Problem

Claude text streams as `text_delta` events, then the SDK's `AssistantMessage` re-sends each block's authoritative full text as a `text_final` that **replaces** the accumulated block — the safety net for a dropped or coalesced delta.

But the Claude path published `text` and `text_final` with **no item id** (the content-block index was available and discarded, unlike the thinking path). So `events.py` could only pair a delta stream with its authoritative `text_final` **positionally**. When a single `AssistantMessage` carries more than one text block, the `text_final` for an earlier block lands on the **trailing** block, so an earlier block that lost its leading delta is never repaired — a permanently truncated paragraph (e.g. "Models …" persisted as "models …").

## Fix

Thread a turn-unique id — the Anthropic message id (captured from `message_start`) plus the content-block index — onto both the text deltas and the `text_final`, so `events.py`'s existing id-based reconciliation repairs the exact block by identity instead of guessing the trailing one. When the id is absent it falls back to the positional path, so nothing regresses.

## Test

`test_claude_text_final_repairs_earlier_block_by_id` dispatches the real event sequence (two text blocks in one message, the first missing its leading delta) through dispatch → reduce and asserts the first block comes out repaired; a companion test confirms no id is emitted when there is no message id.