### PR TITLE
Track the open AskUserQuestion as a durable chat field

### DIFF
--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -1480,36 +1480,15 @@ def _claim_limit_auto_resume_slot(now: float | None = None) -> bool:
 
 
 def _has_unanswered_question(chat: models.Chat | None) -> bool:
-  """Whether the durable tail is waiting for an owner answer.
+  """Whether the chat is parked on an open AskUserQuestion.
 
-  A restart pause is appended after the question while draining, so ignore that
-  one product-owned tail block before applying the same tail-question invariant
-  as the transcript UI. This is read-only and bounded to the latest assistant
-  row; it never scans tool output or historical questions.
+  Reads the durable `pending_question_id` marker (models.Chat) — the
+  position-independent source of truth, set when the card is asked and cleared
+  when it is answered or the turn ends. A resumable pause (provider limit /
+  planned restart) keeps it, so an interrupted-but-open question still blocks
+  auto-resume here instead of being resumed past and orphaned.
   """
-  if chat is None:
-    return False
-  try:
-    from app.chat_transcript import materialized_messages
-    messages = materialized_messages(chat)
-  except Exception:
-    messages = list(chat.messages or [])
-  if not messages or messages[-1].get("role") != "assistant":
-    return False
-  blocks = list(messages[-1].get("blocks") or [])
-  while blocks:
-    tail = blocks[-1]
-    if not (
-      tail.get("type") == "error"
-      and (tail.get("pause") or {}).get("kind") == "restart"
-    ):
-      break
-    blocks.pop()
-  return bool(
-    blocks
-    and blocks[-1].get("type") == "question"
-    and not blocks[-1].get("answers")
-  )
+  return chat is not None and chat.pending_question_id is not None
 
 
 async def _auto_resume_chat(

--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -1433,6 +1433,17 @@ class ChatWriterActor:
       )
       if outcome is not _WriteOutcome.APPLIED:
         raise _PersistFailed(f"QuestionCommit did not persist ({outcome.value})")
+      # Record which question the chat is now parked on — the durable, position-
+      # independent openness marker every read surface trusts (models.Chat).
+      qid = next(
+        (
+          block.get("question_id")
+          for block in reversed(cmd.snapshot.get("blocks") or [])
+          if block.get("type") == "question" and not block.get("answers")
+        ),
+        None,
+      )
+      self._mark_pending_question(db, cmd.chat_id, qid)
       return True
     if isinstance(cmd, Finalize):
       # Must-persist terminal write: a NOOP (missing row / empty transcript /
@@ -1444,6 +1455,10 @@ class ChatWriterActor:
       )
       if outcome is not _WriteOutcome.APPLIED:
         raise _PersistFailed(f"Finalize did not persist ({outcome.value})")
+      # A terminal turn closes any open question. A resumable pause keeps it
+      # open, but that is ParkRun, not Finalize — so clearing here is correct
+      # (and a no-op when the turn had no question).
+      self._mark_pending_question(db, cmd.chat_id, None)
       return True
     if isinstance(cmd, AnswerQuestion):
       return self._answer_question(db, cmd)
@@ -1615,6 +1630,9 @@ class ChatWriterActor:
     )
     if not applied:
       raise _PersistFailed("AnswerQuestion: no matching question block")
+    # The question is answered — clear the durable open-question marker in the
+    # same commit so every read surface unblocks atomically with the answer.
+    chat.pending_question_id = None
     # Answering an interactive question is an owner action just like a visible
     # send. Keep drawer recency separate from generic transcript writes, but do
     # advance it here so a parked chat returns to the top as soon as the answer
@@ -1624,6 +1642,26 @@ class ChatWriterActor:
     if not _commit_or_rollback(db):
       raise _PersistFailed("AnswerQuestion did not persist")
     return True
+
+  def _mark_pending_question(
+    self, db, chat_id: str, question_id: str | None,
+  ) -> None:
+    """Set or clear the chat's durable open-question marker (models.Chat).
+
+    The position-independent source of truth for an open AskUserQuestion:
+    QuestionCommit sets it, AnswerQuestion and every terminal write clear it,
+    and a resumable ParkRun deliberately leaves it in place. Its own tiny
+    scalar commit (like `_persist_session_id`); the serialized actor makes the
+    back-to-back write with the message/terminal commit race-free.
+    """
+    if hasattr(db, "record_commit"):
+      # DB-free mechanics stub: the message/terminal write already recorded.
+      return
+    chat = _active_chat(db, chat_id)
+    if chat is None or chat.pending_question_id == question_id:
+      return
+    chat.pending_question_id = question_id
+    _commit_or_rollback(db)
 
   def _persist_session_id(self, db, cmd: PersistSessionId) -> bool:
     """Save the chat's provider session/thread id without touching transcript.
@@ -2691,6 +2729,12 @@ class ChatWriterActor:
       ) or changed
     if changed and not _commit_or_rollback(db):
       raise _PersistFailed("FinishRun did not persist")
+    # A genuinely ended turn closes any open question — including the
+    # orphaned-run-after-restart Stop, which finishes the run with no Finalize.
+    # Only "interrupted" may still be recoverable (crash recovery can re-offer
+    # the card), so leave the marker for that one; ParkRun owns resumable pauses.
+    if cmd.terminal_status != "interrupted":
+      self._mark_pending_question(db, cmd.chat_id, None)
     if not cmd.run_token or owner == cmd.run_token:
       self._run_token_owner.pop(cmd.chat_id, None)
     return None

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1502,6 +1502,28 @@ def _add_app_connections_manage(eng) -> None:
     ))
 
 
+def _add_chat_pending_question_id(eng) -> None:
+  """Add the durable open-AskUserQuestion marker (models.Chat).
+
+  Nullable, defaults NULL. Existing installs start with no marker; it becomes
+  authoritative from the next asked question onward (the writer sets it on
+  QuestionCommit). No backfill is attempted for a chat parked at upgrade time —
+  that transient resolves on the next answer/ask.
+  """
+  from sqlalchemy import inspect as sa_inspect, text
+
+  inspector = sa_inspect(eng)
+  if "chats" not in inspector.get_table_names():
+    return
+  columns = {column["name"] for column in inspector.get_columns("chats")}
+  if "pending_question_id" in columns:
+    return
+  with eng.begin() as conn:
+    conn.execute(text(
+      "ALTER TABLE chats ADD COLUMN pending_question_id VARCHAR(64) NULL"
+    ))
+
+
 _SCHEMA_MIGRATIONS = (
   ("0001_legacy_schema_convergence", _converge_legacy_schema),
   ("0002_chat_run_goal_objective", _add_chat_run_goal_objective),
@@ -1512,6 +1534,7 @@ _SCHEMA_MIGRATIONS = (
   ("0007_chat_has_messages", _add_chat_has_messages),
   ("0008_chat_search_documents", _create_chat_search_tables),
   ("0009_app_connections_manage", _add_app_connections_manage),
+  ("0010_chat_pending_question_id", _add_chat_pending_question_id),
 )
 
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -127,6 +127,14 @@ class Chat(Base):
   # streaming update never rewrites every prior message. Finalize and startup
   # recovery merge this bounded value into `messages`.
   live_assistant = Column(JSON, nullable=True, default=None)
+  # The AskUserQuestion this chat is currently parked on, or NULL. The single
+  # durable source of truth for "a question is open": set when the card is
+  # committed, cleared when it is answered or the turn ends, and KEPT across a
+  # resumable pause (provider limit / planned restart). Position-independent, so
+  # parallel tool/subagent output or a terminal error after the card never
+  # hides that it is still open. Every read surface — including the lightweight
+  # /runtime poll that never loads the transcript — trusts this column.
+  pending_question_id = Column(String(64), nullable=True, default=None)
   pending_messages = Column(JSON, nullable=False, default=list)
   uploads = Column(JSON, nullable=False, default=list)
   deleted_at = Column(DateTime, nullable=True, default=None)

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -58,6 +58,7 @@ log = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/chats", tags=["chats"])
 
+
 # Separate router for the app-attributed chat contract (design §1). It
 # lives under its own /api/app-chats prefix so the owner-only /api/chats
 # surface stays unambiguously owner-only — the app path is additive and
@@ -397,7 +398,6 @@ def _chat_detail_response(
 
   all_msgs = materialized_messages(chat)
   running = is_chat_running(chat.id) or has_running_run(db, chat.id)
-  pending_question = questions.get(chat.id)
   live_snapshot = chat.live_assistant
   live_message = (
     all_msgs[-1]
@@ -485,9 +485,7 @@ def _chat_detail_response(
     "offset": start,
     "running": running,
     "active_goal_objective": active_goal_objective,
-    "pending_question_id": (
-      pending_question.question_id if pending_question is not None else None
-    ),
+    "pending_question_id": chat.pending_question_id,
     "session_id": chat.session_id if expose_session else None,
     "provider": provider,
     "created_by_app_id": chat.created_by_app_id,
@@ -1282,17 +1280,15 @@ def get_chat_runtime(
     principal,
     load_fields=(
       models.Chat.pending_messages,
+      models.Chat.pending_question_id,
       models.Chat.updated_at,
     ),
   )
-  pending_question = questions.get(chat.id)
   return {
     "running": is_chat_running(chat.id),
     "active_goal_objective": running_goal_objective(db, chat.id),
     "pending_messages": list(chat.pending_messages or []),
-    "pending_question_id": (
-      pending_question.question_id if pending_question is not None else None
-    ),
+    "pending_question_id": chat.pending_question_id,
     "updated_at": chat.updated_at.isoformat() if chat.updated_at else None,
   }
 

--- a/backend/app/routes/chats_stream.py
+++ b/backend/app/routes/chats_stream.py
@@ -203,29 +203,33 @@ def _has_unanswered_question(
   chat: models.Chat,
   question_id: str | None,
 ) -> bool:
-  """Whether the durable tail prompt is the question being answered."""
-  msgs = list(chat.messages or [])
-  tail_questions: list[dict] = []
-  for msg in reversed(msgs):
+  """Whether an answer to `question_id` should be accepted for this chat.
+
+  Primary signal is the durable `pending_question_id` marker, so an answer
+  lands even when parallel tool/subagent output or a terminal error trails the
+  card, and across a restart. Fallback: a *targeted* answer (a specific
+  question_id) is still honored when the marker has cleared but that exact card
+  is unanswered in the latest turn — answering the card after a Stop is a fresh
+  continuation request, not a stale race. Position-independent; a later user
+  turn (the decision was superseded) is not eligible.
+  """
+  open_id = chat.pending_question_id
+  if open_id is not None:
+    return question_id is None or question_id == open_id
+  if not question_id:
+    return False
+  for msg in reversed(chat.messages or []):
     if msg.get("hidden"):
       continue
     if msg.get("role") != "assistant":
       return False
-    blocks = list(msg.get("blocks") or [])
-    while blocks:
-      block = blocks.pop()
-      if block.get("type") != "question" or block.get("answers"):
-        break
-      tail_questions.append(block)
-    break
-
-  if not tail_questions:
-    return False
-  if question_id:
     return any(
-      block.get("question_id") == question_id for block in tail_questions
+      block.get("type") == "question"
+      and block.get("question_id") == question_id
+      and not block.get("answers")
+      for block in (msg.get("blocks") or [])
     )
-  return True
+  return False
 
 
 def _queued_response(
@@ -720,6 +724,19 @@ async def send_message(
           "message": started_message,
         },
       )
+
+  # A durable open question parks the turn on the owner's decision. Only an
+  # answer (handled above) or Stop advances it; a plain send must not slip past
+  # and orphan it. That was the pre-fix bug: once the parked turn hit a terminal
+  # error, a follow-up send started a fresh turn and stranded the still-open
+  # card. The composer is disabled client-side while a question is open — this
+  # is the authoritative guard for API clients and post-restart races. Answers
+  # short-circuit above; force_steer keeps its own refusal below.
+  if not body.force_steer and chat.pending_question_id is not None:
+    raise HTTPException(
+      status_code=409,
+      detail="Answer the pending question, or Stop the turn, before sending.",
+    )
 
   # A pending question parks the provider's control channel inside the
   # synchronous request_user_input bridge. A force-steer cannot be accepted

--- a/backend/tests/test_chat_transcript_compact.py
+++ b/backend/tests/test_chat_transcript_compact.py
@@ -273,6 +273,9 @@ def test_compact_route_folds_settled_activity_while_live_turn_waits_for_answer(
       {"type": "question", "question_id": "question-1", "questions": []},
     ],
   }
+  # A live parked question carries the durable marker (QuestionCommit sets it);
+  # the read APIs report it straight from the column.
+  chat.pending_question_id = "question-1"
   db.commit()
   question_loop = asyncio.new_event_loop()
   pending = PendingQuestion(

--- a/backend/tests/test_chats_stream_answer_race.py
+++ b/backend/tests/test_chats_stream_answer_race.py
@@ -508,3 +508,56 @@ def test_answer_returns_410_after_grace_when_nothing_registers(
     assert questions.get(chat.id) is None
 
   asyncio.run(go())
+
+
+def test_open_question_survives_trailing_output_and_blocks_plain_send(
+  client, auth, chat,
+):
+  """The reported bug: a still-open card buried behind later output.
+
+  A parked question followed by parallel/subagent output and a terminal error
+  is NOT the tail block, yet it is still open. The durable `pending_question_id`
+  marker — not block position — decides that, so the read API reports it and a
+  plain follow-up is refused (409) instead of silently orphaning the card.
+  """
+  qid = "q-buried-behind-error"
+  db = SessionLocal()
+  try:
+    row = db.query(models.Chat).filter(models.Chat.id == chat.id).first()
+    row.messages = [
+      {"role": "user", "content": "clean up the new-chat debt", "ts": 1},
+      {
+        "role": "assistant",
+        "content": "",
+        "ts": 2,
+        "blocks": [
+          {
+            "type": "question",
+            "question_id": qid,
+            "questions": [
+              {"id": "q1", "question": "How far?", "options": ["a", "b"]}
+            ],
+          },
+          {"type": "text", "content": "subagent findings streamed in after"},
+          {"type": "error", "message": "You've hit your session limit"},
+        ],
+      },
+    ]
+    row.pending_question_id = qid
+    db.commit()
+  finally:
+    db.close()
+
+  # The read API reports the open question though it is not the tail block.
+  detail = client.get(f"/api/chats/{chat.id}?limit=20", headers=auth)
+  assert detail.status_code == 200
+  assert detail.json()["pending_question_id"] == qid
+
+  # A plain follow-up is refused while the question is open (no silent orphan);
+  # only an answer (or Stop) may advance the turn.
+  blocked = client.post(
+    f"/api/chats/{chat.id}/messages",
+    json={"content": "never mind - do this other thing instead"},
+    headers=auth,
+  )
+  assert blocked.status_code == 409, blocked.text

--- a/backend/tests/test_db_migrations.py
+++ b/backend/tests/test_db_migrations.py
@@ -1012,6 +1012,7 @@ def test_run_migrations_records_an_inspectable_append_only_history(tmp_path):
     "0007_chat_has_messages",
     "0008_chat_search_documents",
     "0009_app_connections_manage",
+    "0010_chat_pending_question_id",
   ]
   assert second == first
 

--- a/backend/tests/test_limit_park.py
+++ b/backend/tests/test_limit_park.py
@@ -569,6 +569,17 @@ def _due_park(
             initiated_by_app_id=initiated_by_app_id)
 
 
+def _set_pending_question(cid: str, question_id: str | None) -> None:
+  """Set the chat's durable open-question marker (what QuestionCommit does)."""
+  db = SessionLocal()
+  try:
+    chat = db.query(models.Chat).filter(models.Chat.id == cid).first()
+    chat.pending_question_id = question_id
+    db.commit()
+  finally:
+    db.close()
+
+
 def _run_sweep_result():
   db = SessionLocal()
   try:
@@ -1033,12 +1044,17 @@ def test_restart_park_waiting_on_question_stays_manual(
           },
           {
             "type": "question",
+            "question_id": "restart-q",
             "questions": [{"question": "Which one?"}],
           },
         ],
       },
     ],
   )
+  # A parked turn waiting on a question carries the durable open-question marker
+  # (QuestionCommit set it; ParkRun kept it across the restart). That marker is
+  # what keeps auto-resume manual — the answer is the continuation.
+  _set_pending_question(cid, "restart-q")
 
   assert _run_sweep() == [cid]
   assert resumes == []

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -3734,25 +3734,15 @@ export default function ChatView({
   // A pending AskUserQuestion freezes the turn until the user answers,
   // but the card can sit outside the viewport (the user scrolled away,
   // or content streamed in around it) — the chat then just looks hung.
-  // Detect a pending card in whichever surface currently renders it:
-  // the live stream (a question item without answers) or the durable
-  // tail-question invariant on the last visible assistant message (the
-  // same rule MsgContent's blockAnswerable enforces; recovery preserves
-  // that tail question even when the original process was interrupted).
+  // "A question is open" is the chat's durable pending_question_id
+  // (liveQuestionId) — set when the card is asked, cleared when it is answered
+  // or the turn ends, and KEPT across a resumable interruption. Trusting that
+  // marker instead of the card's block position is what lets a still-open card
+  // trailed by parallel output or a terminal error keep blocking the composer.
+  // The live-stream branch covers the window before the question_id persists.
   const pendingQuestionInStream = activeAssistantIsStreaming
     && streamItems.some(it => it.type === 'question' && !it.answers)
-  const pendingQuestionInMessages = (() => {
-    for (let i = messages.length - 1; i >= 0; i--) {
-      if (messages[i].hidden) continue
-      const msg = messages[i]
-      if (msg.role !== 'assistant' || !msg.blocks?.length) return false
-      const tail = msg.blocks[msg.blocks.length - 1]
-      return !!(tail.type === 'question' && !tail.answers
-        && (!liveQuestionId || tail.question_id === liveQuestionId))
-    }
-    return false
-  })()
-  const hasPendingQuestion = pendingQuestionInStream || pendingQuestionInMessages
+  const hasPendingQuestion = pendingQuestionInStream || !!liveQuestionId
 
   // A live question parks Codex's JSON-RPC reader inside request_user_input.
   // turn/steer cannot be acknowledged until that question is released, so a
@@ -3780,7 +3770,9 @@ export default function ChatView({
   // nudge + SR status can name the recovery. A pause is terminal (the turn has
   // ended), so it only ever lives in `messages`, never in a live stream item.
   const pendingResumeBlock = tailResumableBlock(messages)
-  const hasPendingResume = !!pendingResumeBlock
+  // An open question is the single blocker: answering it IS the continuation,
+  // so don't surface a competing Resume (which the backend would now refuse).
+  const hasPendingResume = !!pendingResumeBlock && !hasPendingQuestion
   const pendingLimitResetAt = pendingResumeBlock?.pause?.resets_at || null
   useEffect(() => {
     if (!embedded || !autoResumeEnabled || !pendingLimitResetAt) {

--- a/frontend/src/components/ChatView/MsgContent.jsx
+++ b/frontend/src/components/ChatView/MsgContent.jsx
@@ -25,13 +25,19 @@ import { assistantBlockKey } from './streamPromotion.js'
 // tick — the only message that changes during streaming is the streaming <li>
 // itself, not the static history above it.
 function blockAnswerable(block, { msg, isLastMsg, liveQuestionId, onQuestionAnswer }) {
+  // Answerable iff this block IS the chat's durable open question
+  // (liveQuestionId = pending_question_id) and still unanswered — matched by id,
+  // not by block position, so a card trailed by parallel output or a terminal
+  // error stays answerable. liveQuestionId clears when the question is answered
+  // or the turn ends, so nothing is answerable once it's null.
   return !!(
     onQuestionAnswer
     && msg.role === 'assistant'
     && block?.type === 'question'
     && isLastMsg
     && !block.answers
-    && (!liveQuestionId || block.question_id === liveQuestionId)
+    && liveQuestionId
+    && block.question_id === liveQuestionId
   )
 }
 
@@ -205,13 +211,13 @@ function MsgContentInner({
         // streamItems simultaneously.
         if (suppressedQuestionKeys?.has(questionKey(block))) return null
         const answers = block.answers
-        // Only the LAST block's question is answerable (see
-        // isQuestionAnswerable in ChatView). Recovery keeps a still-open
-        // question at the tail; if anything later follows it, the turn has
-        // moved on and the card is transcript history.
-        const isTailBlock = i === lastEntryIdx
+        // Answerable when it is the open question on the latest turn —
+        // position-independent. A still-open card can be trailed by parallel
+        // tool/subagent output or a terminal error; openness is identity, not
+        // tail position. blockAnswerable scopes to isLastMsg + the live id,
+        // which mirrors the backend's durable pending_question_id marker.
         const answerable = !!(
-          onQuestionAnswer && isTailBlock && isQuestionAnswerable?.(block)
+          onQuestionAnswer && isQuestionAnswerable?.(block)
         )
         return (
           <div key={assistantBlockKey(block, i)}>


### PR DESCRIPTION
## Problem

An AskUserQuestion card was only treated as "open" when it was the **last block of the last assistant message**, and its identity lived only in an **in-memory registry lost on restart**. When a turn kept working after posting the card — parallel tool/subagent output, then a terminal error — the card was no longer the tail block, so it rendered **disabled** (unanswerable) and stopped blocking the composer. A plain follow-up then started a fresh turn and **silently orphaned** the still-open question. After a restart, the same card could not be answered at all.

## Fix

Make "a question is open" an explicit durable fact: a nullable `chats.pending_question_id` column, set when the card is committed, cleared when it is answered or the turn ends, and kept across a resumable pause (provider limit / planned restart). Card answerability, the composer lock, the read APIs (including the lightweight `/runtime` poll that never loads the transcript), and a new backend send-guard all key off it — position-independent and restart-durable. The answer route keeps a transcript fallback so answering a card after a Stop still recovers.

## Tests

A new migration-ledger assertion; the writer set/clear lifecycle exercised through the answer-race and limit-park suites; and a regression test that a still-open card buried behind a trailing error is reported open and refuses a plain send.