### PR TITLE
Mark the multi-generation SW idle-apply e2e as slow (stop merge-queue flake)

### DIFF
--- a/tests/shell-update-idle.spec.mjs
+++ b/tests/shell-update-idle.spec.mjs
@@ -387,6 +387,15 @@ test.describe('shell update — apply on idle, SW on a leash', () => {
   })
 
   test('an idle apply lands the page on the new SW generation, not the outgoing one', async ({ page }) => {
+    // This case drives FOUR real service-worker generation steps (install gen A,
+    // a second gen-A keeper client, install-and-wait gen B, then the mount-time
+    // handoff) plus TWO full page reloads. Those sequential real-SW waits are
+    // legitimately slow and, under parallel-CI load, their cumulative time
+    // (~86s worst case) can exceed Playwright's default 60s per-test budget —
+    // the classic pass-when-fast, time-out-when-slow flake. The behaviour under
+    // test is correct (it settles reliably given enough time); this is genuinely
+    // slow work, not a race, so grant it the extended budget.
+    test.slow()
     // Publish a genuinely new, WAITING service worker (a real update cycle — the
     // window feature 207 bit, biased to a client's FIRST cycle after install),
     // drive the idle apply through the shell's own recovery path, and assert the


### PR DESCRIPTION
## Problem

`shell-update-idle.spec.mjs` › *'an idle apply lands the page on the new SW generation'* is the intermittent e2e failure that has been **ejecting PRs from the merge queue**. It drives **four real service-worker generation steps** (install gen A, a keeper client, install-and-wait gen B, mount-time handoff) plus **two full reloads**. Its sequential real-SW waits total ~86s worst case; under parallel-CI load that cumulative time can exceed Playwright's default **60s** per-test budget — a classic pass-when-fast, time-out-when-slow flake. The three unrelated PRs it failed all fail on this same case, and the SW behaviour itself is correct (it settles reliably given enough time) and separately covered.

## Fix

Add `test.slow()` to that one case — the idiomatic Playwright signal for a legitimately slow test (3× the budget). This is deliberately *not* an ad-hoc per-`waitForFunction` timeout bump: the individual waits are already right; the problem is the total budget for genuinely slow, real-SW work. Only the flaky case is marked; the other six tests in the file are untouched.

## Scope

Test-only, one line + rationale comment. No product change.