### PR TITLE
Align mobile tab press-and-hold with the drawer's two-stage gesture

### DIFF
--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -31,7 +31,7 @@ import {
   clearDrawerGestureStyles,
 } from '../../lib/drawerLifecycle.js'
 import {
-  DRAWER_MENU_HOLD_MS,
+  PRESS_MENU_HOLD_MS,
   PRE_HOLD_MOVE_PX,
 } from '../Shell/dragController.js'
 import InstallSheet from './InstallSheet.jsx'
@@ -1570,7 +1570,7 @@ const DrawerRow = memo(function DrawerRow({
         holdTimerRef.current = null
         suppressCardClickRef.current = true
         openItemMenuAt(holdOriginRef.current)
-      }, DRAWER_MENU_HOLD_MS)
+      }, PRESS_MENU_HOLD_MS)
     }
     function cancelCardHold() {
       if (holdTimerRef.current) clearTimeout(holdTimerRef.current)

--- a/frontend/src/components/Shell/__tests__/dragController.test.js
+++ b/frontend/src/components/Shell/__tests__/dragController.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import {
-  POINTER_SLOP, TAB_HOLD_MS, DRAWER_DRAG_HOLD_MS, DRAWER_MENU_HOLD_MS,
+  POINTER_SLOP, PRESS_DRAG_HOLD_MS, PRESS_MENU_HOLD_MS,
   PRE_HOLD_MOVE_PX, RELEASE_IN_PLACE_PX,
   HYSTERESIS_PX, ROOT_EDGE_PX, CARET_W, CARET_H, CENTER_INSET, DRAWER_EXIT_PX,
   CHIP_MOUSE_DX, CHIP_MOUSE_DY, CHIP_TOUCH_ABOVE,
@@ -101,12 +101,13 @@ test('releasedInPlace is true only within the release radius', () => {
   assert.equal(releasedInPlace(RELEASE_IN_PLACE_PX + 0.1, 0), false)
 })
 
-test('drawer rows expose drag before a stationary hold opens actions', () => {
-  assert.equal(TAB_HOLD_MS, 350)
-  assert.equal(DRAWER_DRAG_HOLD_MS, 180)
-  assert.equal(DRAWER_MENU_HOLD_MS, 400)
-  assert.ok(DRAWER_DRAG_HOLD_MS < TAB_HOLD_MS)
-  assert.ok(DRAWER_MENU_HOLD_MS > TAB_HOLD_MS)
+test('a press exposes drag before a stationary hold opens actions', () => {
+  assert.equal(PRESS_DRAG_HOLD_MS, 180)
+  assert.equal(PRESS_MENU_HOLD_MS, 400)
+  // The drag stage must precede the menu stage, so a short hold moves and only a
+  // longer stationary hold opens actions — the single contract drawer rows,
+  // launcher cards, and workspace tabs all share.
+  assert.ok(PRESS_DRAG_HOLD_MS < PRESS_MENU_HOLD_MS)
 })
 
 test('chipOffset floats above a touch point and trails a mouse', () => {

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -685,9 +685,12 @@ test('one held drawer-row gesture resolves menu, reorder, or workspace drag', ()
     /sourceKind === 'drawer' && e\.pointerType !== 'mouse'\) return/,
     'touch drawer rows must remain available to the workspace drag controller',
   )
-  assert.match(dragBinding, /sourceKind === 'drawer' \? DRAWER_DRAG_HOLD_MS : TAB_HOLD_MS/)
-  assert.match(dragBinding, /DRAWER_MENU_HOLD_MS - DRAWER_DRAG_HOLD_MS/,
-    'one sequential timer owns both drawer hold stages')
+  assert.match(dragBinding, /\}, PRESS_DRAG_HOLD_MS\)/,
+    'tabs and drawer rows share one first hold stage — no divergent tab timing')
+  assert.doesNotMatch(dragBinding, /TAB_HOLD_MS/,
+    'the separate longer tab hold is gone; a short hold moves a tab too')
+  assert.match(dragBinding, /PRESS_MENU_HOLD_MS - PRESS_DRAG_HOLD_MS/,
+    'one sequential timer owns both hold stages for drawer rows and tabs')
   assert.match(dragBinding, /drawerRowMoveIntent\(dx, dy, \{[\s\S]*?held,[\s\S]*?isTouch,[\s\S]*?data-pinned-key/,
     'one pure decision boundary owns the held row directions')
   assert.match(dragBinding, /intent === 'reorder'[\s\S]*?beginReorder/,
@@ -713,8 +716,10 @@ test('one held drawer-row gesture resolves menu, reorder, or workspace drag', ()
     'releasing a shorter stationary hold remains a normal tap')
   assert.match(drawerPointerUp, /if \(menuOpened\)[\s\S]*?cleanup\(\{ suppressClick: true \}\)/,
     'the menu-opening gesture restores selection only when its pointer ends')
-  assert.match(dragBinding, /held && sourceKind === 'tab'[\s\S]*?openTabMenuAtRef\?\.current\?\./,
-    'a stationary tab hold opens the same actions on touch')
+  assert.match(dragBinding, /const openTabMenu = openTabMenuAtRef\?\.current[\s\S]*?openTabMenu\(point\.x, point\.y, tabFromKey\(key\), paneId\)/,
+    'a stationary tab hold opens actions from the shared hold timer, while still held')
+  assert.doesNotMatch(drawerPointerUp, /openTabMenuAtRef/,
+    'releasing a tab hold no longer opens actions — the hold timer does, like the drawer')
   assert.doesNotMatch(dragBinding, /addEventListener\('touchmove'/)
   assert.match(shell, /const drawerRowGesturesRef = useRef\(new Map\(\)\)/)
   assert.match(drawer, /const registry = drawerRowGesturesRef\.current[\s\S]*?registry\.set\(key, drawerGestureHandlerRef\)/)
@@ -1006,14 +1011,15 @@ test('launcher cards and drawer rows share the stationary menu threshold', () =>
   const dragImports = drawer.match(
     /import \{([\s\S]*?)\} from '\.\.\/Shell\/dragController\.js'/,
   )?.[1] || ''
-  assert.match(dragImports, /DRAWER_MENU_HOLD_MS/)
+  assert.match(dragImports, /PRESS_MENU_HOLD_MS/)
   assert.match(dragImports, /PRE_HOLD_MOVE_PX/)
-  assert.match(drawer, /\}, DRAWER_MENU_HOLD_MS\)/)
+  assert.match(drawer, /\}, PRESS_MENU_HOLD_MS\)/)
   assert.match(drawer, /> PRE_HOLD_MOVE_PX/)
-  assert.match(dragBinding, /sourceKind === 'drawer' \? DRAWER_DRAG_HOLD_MS : TAB_HOLD_MS/)
+  assert.match(dragBinding, /\}, PRESS_DRAG_HOLD_MS\)/,
+    'the drag stage timing is shared across drawer rows and tabs')
   assert.doesNotMatch(
     drawer.match(/function beginPinnedReorder\([\s\S]*?\n  function onRowPointerDown/)?.[0] || '',
-    /DRAWER_(?:DRAG|MENU)_HOLD_MS/,
+    /PRESS_(?:DRAG|MENU)_HOLD_MS/,
     'the shared controller, not the reorder implementation, owns hold timing',
   )
   assert.doesNotMatch(drawer, /520/)

--- a/frontend/src/components/Shell/dragController.js
+++ b/frontend/src/components/Shell/dragController.js
@@ -33,21 +33,23 @@ import { tabKey } from './tabModel.js'
 // A mouse drag arms once the pointer travels past this from the press point;
 // below it, the press is still a plain click (tab activate / row open).
 export const POINTER_SLOP = 5
-// Touch lift is a long-press. Drawer rows have two deliberate stages: movement
-// can become a drag quickly, while a stationary press must continue longer
-// before opening actions. Keeping both timings here prevents the live pointer
-// owner and launcher cards from inventing their own thresholds.
-export const TAB_HOLD_MS = 350
-export const DRAWER_DRAG_HOLD_MS = 180
+// A touch press-and-hold resolves in two deliberate stages, shared by drawer
+// rows, launcher cards, and workspace tabs so no surface invents its own
+// timing. After the first (short) stage the item becomes draggable — movement
+// picks it up as a reorder/workspace/strip drag — while a press that stays
+// still through the second stage opens that item's actions. A short hold moves,
+// a long hold opens actions, identically everywhere. (Tabs previously diverged
+// with one longer hold whose RELEASE opened the menu; they now share this.)
+export const PRESS_DRAG_HOLD_MS = 180
 // Stay ahead of the platform's own long-press takeover. Some touch browsers
 // cancel the pointer around their native context-menu threshold; opening first
 // keeps the menu on our single Pointer Events path instead of a release-time
 // native contextmenu fallback.
-export const DRAWER_MENU_HOLD_MS = 400
+export const PRESS_MENU_HOLD_MS = 400
 // Movement past this before a hold resolves yields to the source scroller.
 export const PRE_HOLD_MOVE_PX = 8
-// After a touch lift, a release that never moved past this is not a drop. Tabs
-// use that stationary outcome for actions; movement after the hold drags.
+// After a touch lift, a release that never moved past this is not a drop; the
+// menu opens from the hold timer while still held, never from this release.
 export const RELEASE_IN_PLACE_PX = 5
 
 // ── Zone geometry (design §3.2 / §3.3) ───────────────────────────────────────

--- a/frontend/src/components/Shell/useWorkspaceDrag.js
+++ b/frontend/src/components/Shell/useWorkspaceDrag.js
@@ -4,7 +4,7 @@ import {
   buildScene, hitTest, zoneTarget, releaseZone, chipOffset, STRIP_CARET_PAD,
   passedSlop, touchTabMoveIntent, drawerRowMoveIntent, releasedInPlace,
   flingReleaseVelocity,
-  TAB_HOLD_MS, DRAWER_DRAG_HOLD_MS, DRAWER_MENU_HOLD_MS,
+  PRESS_DRAG_HOLD_MS, PRESS_MENU_HOLD_MS,
   crossedDrawerExit,
   rootEdgeAllowed,
 } from './dragController.js'
@@ -406,36 +406,44 @@ export default function useWorkspaceDrag({
         }
       }
 
-      // Tabs and drawer rows share this ONE pointer owner. A tab hold resolves
-      // intent without lifting immediately: movement then drags it, while a
-      // stationary release opens its actions. Drawer rows become draggable after the brief first
-      // stage; if the pointer stays still through the second stage, actions open
-      // immediately. Movement clears the same timer before handing off to reorder,
-      // workspace drag, or scrolling, so no competing gesture lifecycle exists.
+      // Tabs and drawer rows share this ONE pointer owner AND one two-stage
+      // press-and-hold. After the first stage the row/tab becomes draggable, so
+      // movement picks it up (reorder, workspace drag, or a strip drag); if the
+      // pointer instead stays still through the second stage, that item's actions
+      // open immediately, while still held. Movement clears the same timer before
+      // handing off to a drag or to scrolling, so no competing gesture lifecycle
+      // exists — a short hold moves and a long hold opens actions everywhere.
       if (isTouch) {
         holdTimer = setTimeout(() => {
           if (cancelled || cleaned) return
           held = true
           if (navigator.vibrate) { try { navigator.vibrate(8) } catch { /* unsupported */ } }
-          if (sourceKind !== 'drawer') {
-            return
-          }
           holdTimer = setTimeout(() => {
             if (cancelled || cleaned || armed || scrolling) return
-            const handler = drawerGesture()
-            if (!handler?.openMenu) {
-              cleanup()
-              return
-            }
             const point = { ...lastPoint }
             // Keep this pointer session alive until the contact actually ends.
             // Restoring body selection here leaves a small window in which the
             // platform long-press can select whichever menu item appeared under
             // the still-held finger (notably Android's text-selection handles).
-            menuOpened = true
-            handler.openMenu(point)
-          }, DRAWER_MENU_HOLD_MS - DRAWER_DRAG_HOLD_MS)
-        }, sourceKind === 'drawer' ? DRAWER_DRAG_HOLD_MS : TAB_HOLD_MS)
+            if (sourceKind === 'drawer') {
+              const handler = drawerGesture()
+              if (!handler?.openMenu) {
+                cleanup()
+                return
+              }
+              menuOpened = true
+              handler.openMenu(point)
+            } else {
+              const openTabMenu = openTabMenuAtRef?.current
+              if (!openTabMenu) {
+                cleanup()
+                return
+              }
+              menuOpened = true
+              openTabMenu(point.x, point.y, tabFromKey(key), paneId)
+            }
+          }, PRESS_MENU_HOLD_MS - PRESS_DRAG_HOLD_MS)
+        }, PRESS_DRAG_HOLD_MS)
       }
 
       function stopAutoScroll() {
@@ -690,18 +698,6 @@ export default function useWorkspaceDrag({
               startFling(scrollEl, flingReleaseVelocity(scrollSamples, performance.now()))
             }
             cleanup({ suppressClick: true })
-          } else if (isTouch && held && sourceKind === 'tab') {
-            const dx = ev.clientX - start.x
-            const dy = ev.clientY - start.y
-            if (releasedInPlace(dx, dy)) {
-              openTabMenuAtRef?.current?.(
-                ev.clientX,
-                ev.clientY,
-                tabFromKey(key),
-                paneId,
-              )
-            }
-            cleanup({ suppressClick: true })
           } else cleanup()
           return
         }
@@ -718,16 +714,8 @@ export default function useWorkspaceDrag({
         const backOverDrawer = sourceKind === 'drawer' && drawerEdgeX != null
           && ev.clientX <= drawerEdgeX && !(isTouch && glided)
         if (isTouch && releasedInPlace(dx, dy)) {
-          // Pointer jitter can lift a held tab without becoming an intentional
-          // move. Keep the stationary-hold contract in that narrow case too.
-          if (sourceKind === 'tab') {
-            openTabMenuAtRef?.current?.(
-              ev.clientX,
-              ev.clientY,
-              tabFromKey(key),
-              paneId,
-            )
-          }
+          // An armed drag lifted essentially in place is a cancel, not a drop —
+          // and never a menu: actions open from the hold timer while still held.
           cleanup({ suppressClick: true })
         } else if (backOverDrawer) {
           // Released back over the drawer = cancel; cleanup reopens it if glided.

--- a/frontend/src/lib/__tests__/appsDirectoryContract.test.js
+++ b/frontend/src/lib/__tests__/appsDirectoryContract.test.js
@@ -45,9 +45,9 @@ test('phone and web share one searchable launcher tab', () => {
   const dragImports = drawer.match(
     /import \{([\s\S]*?)\} from '\.\.\/Shell\/dragController\.js'/,
   )?.[1] || ''
-  assert.match(dragImports, /DRAWER_MENU_HOLD_MS/)
+  assert.match(dragImports, /PRESS_MENU_HOLD_MS/)
   assert.match(dragImports, /PRE_HOLD_MOVE_PX/)
-  assert.match(drawer, /setTimeout\(\(\) => \{[\s\S]*?openItemMenuAt[\s\S]*?DRAWER_MENU_HOLD_MS\)/)
+  assert.match(drawer, /setTimeout\(\(\) => \{[\s\S]*?openItemMenuAt[\s\S]*?PRESS_MENU_HOLD_MS\)/)
   assert.doesNotMatch(drawer, /520/)
   assert.match(drawer, /placement=\{menu\?\.placement\}/)
   assert.match(itemActionMenu, /placeContextMenu/)


### PR DESCRIPTION
On touch devices, workspace tabs and drawer rows disagreed about press-and-hold.

**Drawer rows** use a two-stage hold: a short hold picks the row up so movement drags/reorders it, and a longer *stationary* hold opens its actions menu while still held. **Tabs** used a single ~350ms hold whose stationary **release** opened the tab menu — so moving a tab required that same hold and the menu felt like it opened on a *short* hold, the opposite of drawer rows.

This unifies both surfaces on the drawer's two-stage press-and-hold, in the single shared pointer owner (`useWorkspaceDrag`) that already drives both:

- **Short hold (`PRESS_DRAG_HOLD_MS`, 180ms)** — the tab/row becomes draggable, so movement picks it up (reorder, workspace drag, or a strip drag).
- **Longer stationary hold (`PRESS_MENU_HOLD_MS`, 400ms)** — its actions open immediately, while the finger is still down.

A plain tap still activates a tab and the horizontal strip pan is unchanged. The tab menu now opens from the shared hold timer instead of on pointer-up, matching how drawer rows and launcher cards already behave.

### Changes
- Fold the tab path into the drawer's two-stage timer in `useWorkspaceDrag`; open the tab menu from the second (stationary) stage and drop the two pointer-up menu-open paths.
- Rename the now-shared stage constants so it's clear drawer rows, launcher cards, and tabs share them: `DRAWER_DRAG_HOLD_MS` → `PRESS_DRAG_HOLD_MS`, `DRAWER_MENU_HOLD_MS` → `PRESS_MENU_HOLD_MS`. Remove the superseded `TAB_HOLD_MS`.
- Update the drag-controller unit tests and shell source-shape tests to the unified contract.

### Testing
`node --test` across `dragController.test.js`, `workspaceUi.test.js`, and `appsDirectoryContract.test.js` — all green. The press-and-hold timing is inherently touch-device behavior; the logic and wiring are covered by these tests.