### PR TITLE
Prevent Vite OOM under constrained cgroups

### DIFF
--- a/backend/app/build_admission.py
+++ b/backend/app/build_admission.py
@@ -1,23 +1,36 @@
 """One cross-process lease for every Mobius-owned JavaScript build.
 
-Four separate processes can start a native JS build on the same box: uvicorn's
-mini-app Rolldown compile, the warm frontend watcher's Vite build,
-``rebuild_shell.sh``, and the in-container app validator. Each peaks at
+Several processes can start a native JS build on the same box: uvicorn's
+mini-app Rolldown compile, the warm frontend watcher, ``rebuild_shell.sh``,
+frontend package scripts, and the in-container app validator. Each can peak at
 hundreds of megabytes of native memory, so two at once OOM a small instance.
 """
 
 from __future__ import annotations
 
+import argparse
 import asyncio
 import contextlib
 import fcntl
 import os
+import subprocess
+import sys
 import time
 from pathlib import Path
 
+from app.resource_pressure import MIB, assess_memory_pressure
 
-class BuildLeaseUnavailable(RuntimeError):
+
+class BuildAdmissionUnavailable(RuntimeError):
+  """A transient resource condition prevented a native JavaScript build."""
+
+
+class BuildLeaseUnavailable(BuildAdmissionUnavailable):
   """No lease became free within the wait budget."""
+
+
+class ViteBuildDeferred(BuildAdmissionUnavailable):
+  """Vite lacks enough measured cgroup headroom to start safely."""
 
 
 # One Vite build is capped at 180s, so a wait longer than that means a builder
@@ -25,19 +38,75 @@ class BuildLeaseUnavailable(RuntimeError):
 _LEASE_WAIT_SECS = 240.0
 _LEASE_POLL_SECS = 0.1
 
+# Exact 512 MiB cgroup canaries showed Vite drive memory.current to the hard
+# limit and receive an OOM kill when admitted with less headroom, even while
+# working-set ratio and PSI still read "normal". This is a starting reserve,
+# not a claim that Vite itself retains 512 MiB: it also protects the serving
+# process and concurrent user work while the native bundler peaks.
+VITE_BUILD_MIN_HEADROOM_BYTES = 512 * MIB
+
+
+def vite_build_admitted(memory: dict | None = None) -> bool:
+  """Whether a new Vite process can start without a known cgroup OOM risk.
+
+  Missing or unlimited cgroup telemetry stays fail-open for developer hosts.
+  A finite cgroup must have both a healthy pressure state and the canary-backed
+  absolute reserve; ratios alone hide dangerous low-capacity states.
+  """
+  assessment = assess_memory_pressure(memory)
+  if assessment["state"] in {"constrained", "critical"}:
+    return False
+  headroom = assessment.get("headroom_bytes")
+  return not isinstance(headroom, int) or (
+    headroom >= VITE_BUILD_MIN_HEADROOM_BYTES
+  )
+
+
+def require_vite_build_admission(memory: dict | None = None) -> None:
+  """Raise a retryable error instead of starting a known-unsafe Vite build."""
+  assessment = assess_memory_pressure(memory)
+  state = assessment["state"]
+  headroom = assessment.get("headroom_bytes")
+  too_little_headroom = (
+    isinstance(headroom, int)
+    and headroom < VITE_BUILD_MIN_HEADROOM_BYTES
+  )
+  if state not in {"constrained", "critical"} and not too_little_headroom:
+    return
+  detail = f"memory pressure is {state}"
+  if isinstance(headroom, int):
+    detail += f" with {headroom // MIB} MiB cgroup headroom"
+  raise ViteBuildDeferred(
+    "Vite build deferred: "
+    f"{detail}; {VITE_BUILD_MIN_HEADROOM_BYTES // MIB} MiB is required "
+    "before starting. Retry after memory pressure falls."
+  )
+
 
 @contextlib.contextmanager
-def build_lease(*, blocking: bool = True, timeout: float = _LEASE_WAIT_SECS):
+def build_lease(
+  *,
+  blocking: bool = True,
+  timeout: float = _LEASE_WAIT_SECS,
+  data_dir: str | Path | None = None,
+  fail_open: bool = True,
+):
   """Serialize every Mobius-owned JS build across processes."""
   try:
-    # Imported here so the stdlib-only app validator keeps working in a
-    # developer checkout that has neither settings nor pydantic installed.
-    from app.config import get_settings
+    if data_dir is None:
+      # Imported here so the stdlib-only app validator keeps working in a
+      # developer checkout that has neither settings nor pydantic installed.
+      from app.config import get_settings
 
-    path = Path(get_settings().data_dir) / "run" / "build.lock"
+      data_dir = get_settings().data_dir
+    path = Path(data_dir) / "run" / "build.lock"
     path.parent.mkdir(parents=True, exist_ok=True)
     fd = os.open(path, os.O_CREAT | os.O_RDWR, 0o644)
-  except Exception:
+  except Exception as exc:
+    if not fail_open:
+      raise BuildAdmissionUnavailable(
+        f"cannot open the shared JavaScript build lease: {exc}"
+      ) from exc
     yield  # No reachable runtime directory means no competing Mobius process.
     return
   deadline = time.monotonic() + timeout
@@ -69,3 +138,47 @@ async def build_lease_async(*, timeout: float = _LEASE_WAIT_SECS):
           raise
         await asyncio.sleep(_LEASE_POLL_SECS)
     yield
+
+
+def _cli(argv: list[str] | None = None) -> int:
+  """Run one frontend-owned command under the authoritative runtime lease."""
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+    "--vite", action="store_true",
+    help="also require the Vite cgroup headroom reserve",
+  )
+  parser.add_argument("command", nargs=argparse.REMAINDER)
+  args = parser.parse_args(argv)
+  command = args.command[1:] if args.command[:1] == ["--"] else args.command
+  if not command:
+    parser.error("a command is required after --")
+  # A source checkout has a sibling backend too, but no running Mobius process
+  # to contend with. Keep package tests/builds zero-configuration there. Every
+  # real runtime has SECRET_KEY, and managed/container setups may also declare
+  # DATA_DIR explicitly.
+  runtime_configured = bool(
+    os.environ.get("SECRET_KEY") or os.environ.get("DATA_DIR")
+  )
+  try:
+    if runtime_configured:
+      # DATA_DIR is sufficient to take the lock without importing pydantic,
+      # keeping this CLI authoritative in a minimally provisioned runtime.
+      with build_lease(
+        data_dir=os.environ.get("DATA_DIR", "/data"),
+        fail_open=False,
+      ):
+        if args.vite:
+          require_vite_build_admission()
+        result = subprocess.run(command, check=False)
+    else:
+      result = subprocess.run(command, check=False)
+  except BuildAdmissionUnavailable as exc:
+    print(str(exc), file=sys.stderr, flush=True)
+    return os.EX_TEMPFAIL
+  if result.returncode < 0:
+    return 128 - result.returncode
+  return result.returncode
+
+
+if __name__ == "__main__":
+  raise SystemExit(_cli())

--- a/backend/app/frontend_watcher.py
+++ b/backend/app/frontend_watcher.py
@@ -32,12 +32,16 @@ from pathlib import Path
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers.polling import PollingObserverVFS
 
-from app.build_admission import BuildLeaseUnavailable, build_lease
+from app.build_admission import (
+  BuildLeaseUnavailable,
+  build_lease,
+  require_vite_build_admission,
+  vite_build_admitted,
+)
 from app.process_groups import (
   isolated_process_group_id,
   lower_process_group_priority,
 )
-from app.resource_pressure import assess_memory_pressure
 
 log = logging.getLogger(__name__)
 
@@ -103,10 +107,10 @@ _ACTIVE_SUPERVISOR: "_FrontendSupervisor | None" = None
 def _memory_is_tight() -> bool:
   """True when starting another native JS build risks an OOM kill.
 
-  Unmeasurable memory is ``unknown``, which fails open. Only the watcher may
-  act on this: it owns a free retry, so a deferral costs nothing.
+  Unmeasurable memory is ``unknown``, which fails open. The shared Vite policy
+  combines ratio/PSI pressure with the absolute reserve small cgroups need.
   """
-  return assess_memory_pressure()["state"] in {"constrained", "critical"}
+  return not vite_build_admitted()
 
 
 def _source_tree_scandir(
@@ -713,11 +717,12 @@ def _publish_built_dir(source_dir: Path, reason: str) -> bool:
 def _run_vite_build_once(out_dir: Path) -> str:
   """Run one explicit full Vite build into ``out_dir``.
 
-  This path has no free retry — owner Apply rolls the source tree back and
-  rebuild_shell.sh aborts a production deploy — so it waits for the lease
-  rather than deferring, and never declines on memory pressure.
+  This path waits for the shared lease. If the cgroup is still unsafe once it
+  owns the lease, owner Apply rolls its source change back and rebuild_shell.sh
+  aborts cleanly; either operation can be retried without risking an OOM kill.
   """
   with build_lease():
+    require_vite_build_admission()
     _ensure_node_modules()
     if out_dir.exists():
       shutil.rmtree(out_dir)

--- a/backend/tests/test_build_admission.py
+++ b/backend/tests/test_build_admission.py
@@ -1,6 +1,8 @@
 """One cross-process lease admits one Mobius-owned JavaScript build."""
 
 import asyncio
+import fcntl
+import os
 import subprocess
 import sys
 import textwrap
@@ -11,8 +13,12 @@ import pytest
 
 from app.build_admission import (
   BuildLeaseUnavailable,
+  VITE_BUILD_MIN_HEADROOM_BYTES,
+  ViteBuildDeferred,
   build_lease,
   build_lease_async,
+  require_vite_build_admission,
+  vite_build_admitted,
 )
 
 
@@ -84,3 +90,108 @@ def test_no_reachable_runtime_directory_admits_every_build(
   with build_lease(blocking=False):
     with build_lease(blocking=False):
       pass
+
+
+def _memory(*, working_set: int, limit: int | None) -> dict:
+  return {
+    "available": True,
+    "working_set_bytes": working_set,
+    "limit_bytes": limit,
+    "pressure": {
+      "some": {"avg60": 0.0},
+      "full": {"avg60": 0.0},
+    },
+  }
+
+
+def test_vite_admission_needs_absolute_headroom_even_at_a_normal_ratio():
+  one_gib = 1024 * 1024 * 1024
+  just_below = _memory(
+    working_set=one_gib - VITE_BUILD_MIN_HEADROOM_BYTES + 1,
+    limit=one_gib,
+  )
+
+  assert vite_build_admitted(just_below) is False
+  with pytest.raises(ViteBuildDeferred, match="511 MiB cgroup headroom"):
+    require_vite_build_admission(just_below)
+
+  at_reserve = _memory(
+    working_set=one_gib - VITE_BUILD_MIN_HEADROOM_BYTES,
+    limit=one_gib,
+  )
+  assert vite_build_admitted(at_reserve) is True
+  require_vite_build_admission(at_reserve)
+
+
+def test_vite_admission_fails_open_without_a_finite_cgroup_limit():
+  unknown = _memory(working_set=128 * 1024 * 1024, limit=None)
+
+  assert vite_build_admitted(unknown) is True
+  require_vite_build_admission(unknown)
+
+
+def test_frontend_node_entrypoint_uses_the_python_lease_without_nesting(
+  tmp_path,
+):
+  """One outer lease covers a nested build script without self-deadlocking."""
+  repo = Path(__file__).resolve().parents[2]
+  helper = repo / "frontend" / "scripts" / "build-admission.mjs"
+  child = tmp_path / "child.mjs"
+  marker = tmp_path / "entered"
+  child.write_text(
+    "\n".join((
+      "import fs from 'node:fs'",
+      f"import {{ enterBuildAdmission }} from {helper.as_uri()!r}",
+      "enterBuildAdmission()",
+      f"fs.writeFileSync({str(marker)!r}, 'entered')",
+    )),
+    encoding="utf-8",
+  )
+  outer = tmp_path / "outer.mjs"
+  outer.write_text(
+    "\n".join((
+      "import { spawnSync } from 'node:child_process'",
+      f"import {{ enterBuildAdmission }} from {helper.as_uri()!r}",
+      "enterBuildAdmission()",
+      f"const result = spawnSync(process.execPath, [{str(child)!r}], "
+      "{ stdio: 'inherit', env: process.env })",
+      "if (result.error) throw result.error",
+      "process.exitCode = result.status ?? 1",
+    )),
+    encoding="utf-8",
+  )
+  runtime = tmp_path / "runtime"
+  lock_path = runtime / "run" / "build.lock"
+  lock_path.parent.mkdir(parents=True)
+  lock_fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o644)
+  fcntl.flock(lock_fd, fcntl.LOCK_EX)
+  env = {
+    **os.environ,
+    "DATA_DIR": str(runtime),
+    "SECRET_KEY": "x" * 32,
+  }
+  proc = subprocess.Popen(["node", str(outer)], env=env)
+  try:
+    # If the Node entrypoint bypasses the Python lease, the marker appears.
+    with pytest.raises(subprocess.TimeoutExpired):
+      proc.wait(timeout=0.4)
+    assert not marker.exists()
+    fcntl.flock(lock_fd, fcntl.LOCK_UN)
+    assert proc.wait(timeout=10) == 0
+  finally:
+    fcntl.flock(lock_fd, fcntl.LOCK_UN)
+    os.close(lock_fd)
+    if proc.poll() is None:
+      proc.kill()
+      proc.wait(timeout=10)
+
+  assert marker.read_text(encoding="utf-8") == "entered"
+
+
+def test_all_frontend_native_build_entrypoints_enter_admission():
+  scripts = Path(__file__).resolve().parents[2] / "frontend" / "scripts"
+
+  for name in ("safe-build.mjs", "build-runtime.mjs", "build-tts-worker.mjs"):
+    source = (scripts / name).read_text(encoding="utf-8")
+    assert "from './build-admission.mjs'" in source
+    assert "enterBuildAdmission(" in source

--- a/backend/tests/test_frontend_watcher_publish.py
+++ b/backend/tests/test_frontend_watcher_publish.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pytest
 
 import app.frontend_watcher as fw
+from app.build_admission import ViteBuildDeferred
 
 
 def _write_build(root, marker):
@@ -62,6 +63,7 @@ def fw_dirs(tmp_path, monkeypatch):
   monkeypatch.setattr(fw, "_CACHE_DIR", dirs["cache"])
   monkeypatch.setattr(fw, "_TMP_DIR", dirs["tmp"])
   monkeypatch.setattr(fw, "_memory_is_tight", lambda: False)
+  monkeypatch.setattr(fw, "require_vite_build_admission", lambda: None)
   monkeypatch.setattr(
     fw,
     "_BUILT_GLOBAL_CHECK",
@@ -505,11 +507,9 @@ def test_memory_pressure_defers_a_demand_build_and_keeps_its_reason(
   assert publish_calls == [(fw_dirs["staging"], f"build:{source_file}")]
 
 
-def test_explicit_rebuild_still_builds_under_memory_pressure(
+def test_explicit_rebuild_builds_after_admission(
   fw_dirs, monkeypatch,
 ):
-  """Apply and deploy cannot retry, so pressure must never refuse them."""
-  monkeypatch.setattr(fw, "_memory_is_tight", lambda: True)
   monkeypatch.setattr(fw, "_ensure_node_modules", lambda: None)
   runs = []
 
@@ -522,6 +522,33 @@ def test_explicit_rebuild_still_builds_under_memory_pressure(
 
   assert fw._run_vite_build_once(fw_dirs["rebuild"]) == "vite build complete"
   assert len(runs) == 1
+
+
+def test_explicit_rebuild_defers_before_mutating_or_starting_vite(
+  fw_dirs, monkeypatch,
+):
+  """Apply/deploy stay retryable and preserve prior output under pressure."""
+  fw_dirs["rebuild"].mkdir()
+  previous = fw_dirs["rebuild"] / "previous.txt"
+  previous.write_text("keep", encoding="utf-8")
+
+  def defer():
+    raise ViteBuildDeferred("retry after memory pressure falls")
+
+  monkeypatch.setattr(fw, "require_vite_build_admission", defer)
+  monkeypatch.setattr(
+    fw, "_ensure_node_modules",
+    lambda: pytest.fail("admission must run before frontend setup"),
+  )
+  monkeypatch.setattr(
+    fw.subprocess, "run",
+    lambda *args, **kwargs: pytest.fail("deferred build must not start Vite"),
+  )
+
+  with pytest.raises(ViteBuildDeferred, match="retry after memory pressure"):
+    fw._run_vite_build_once(fw_dirs["rebuild"])
+
+  assert previous.read_text(encoding="utf-8") == "keep"
 
 
 def test_conflict_markers_defer_vite_without_touching_generations(

--- a/frontend/scripts/build-admission.mjs
+++ b/frontend/scripts/build-admission.mjs
@@ -1,0 +1,41 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+
+const frontendDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const backendDir = path.resolve(frontendDir, '..', 'backend')
+const admissionModule = path.join(backendDir, 'app', 'build_admission.py')
+const activeBackendEnv = '_MOBIUS_BUILD_ADMISSION_BACKEND'
+
+
+export function enterBuildAdmission({ vite = false } = {}) {
+  // The image's frontend-only build stage and standalone frontend checkouts do
+  // not contain a sibling backend. Runtime checkouts do, and must use its one
+  // authoritative flock + cgroup policy rather than duplicating either here.
+  if (!fs.existsSync(admissionModule)) return
+
+  const activeBackend = fs.realpathSync(backendDir)
+  // This private marker only prevents a child build from flocking behind its
+  // own parent. The exact backend path avoids suppressing admission for a
+  // different checkout; it is process coordination, not a security boundary.
+  if (process.env[activeBackendEnv] === activeBackend) return
+
+  const childEnv = {
+    ...process.env,
+    [activeBackendEnv]: activeBackend,
+    PYTHONPATH: [activeBackend, process.env.PYTHONPATH].filter(Boolean).join(path.delimiter),
+  }
+  const args = ['-m', 'app.build_admission']
+  if (vite) args.push('--vite')
+  args.push('--', process.execPath, ...process.execArgv, ...process.argv.slice(1))
+  const result = spawnSync('python3', args, {
+    cwd: process.cwd(),
+    env: childEnv,
+    stdio: 'inherit',
+  })
+  if (result.error) throw result.error
+  if (result.signal) process.kill(process.pid, result.signal)
+  process.exit(result.status ?? 1)
+}

--- a/frontend/scripts/build-runtime.mjs
+++ b/frontend/scripts/build-runtime.mjs
@@ -3,6 +3,10 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { rolldown } from 'rolldown'
+import { enterBuildAdmission } from './build-admission.mjs'
+
+
+enterBuildAdmission()
 
 const frontendDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const outputPath = path.join(frontendDir, 'public', 'mobius-runtime.js')

--- a/frontend/scripts/build-tts-worker.mjs
+++ b/frontend/scripts/build-tts-worker.mjs
@@ -3,6 +3,11 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { enterBuildAdmission } from './build-admission.mjs'
+
+
+enterBuildAdmission()
+
 // The speech worker is served from public/speech/ as an ordinary same-origin
 // script, alongside the Wasm binary it loads. Shipping it as a JavaScript
 // string that the page turns into a blob: URL would need `blob:` in the

--- a/frontend/scripts/safe-build.mjs
+++ b/frontend/scripts/safe-build.mjs
@@ -4,8 +4,11 @@ import path from 'node:path'
 import { spawnSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 
+import { enterBuildAdmission } from './build-admission.mjs'
 import { resolveBuildOutput } from './build-output-policy.mjs'
 
+
+enterBuildAdmission({ vite: true })
 
 const frontendDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const watcherLeasePath = path.join(frontendDir, '.watch.lock')


### PR DESCRIPTION
## Summary

- require a canary-backed 512 MiB finite-cgroup headroom reserve before starting Vite, in addition to the existing ratio/PSI states
- let the warm watcher defer and retry while explicit Apply/deploy builds fail cleanly before mutating output or spawning Vite
- route live frontend package builds and generated-runtime Rolldown scripts through the same Python-owned cross-process lease, with one inherited coordination marker so nested build steps cannot deadlock
- keep unlimited/unobservable developer hosts fail-open and leave the Rolldown dependency update to its separate owner

## Why

On current main in an exact 512 MiB container, a modest 128 MiB user workload still assessed as `normal` (~53.5% working set). The watcher admitted Vite, `memory.current` reached the hard 536,870,912-byte limit, and `memory.events` recorded `oom +1` and `oom_kill +1`. The previous absolute reserve had been removed before #640 merged, so the older canary did not cover the merged behavior.

A second audit also proved that `npm run build` completed while `/data/run/build.lock` was held: `safe-build.mjs` only probed the publication watch lock, while runtime/speech generators launched Rolldown directly.

## Verification

- 100 focused backend admission, pressure, watcher, validator, compiler-contract, and app-apply tests passed
- frontend lint passed (existing warning budget only)
- repository pre-push frontend-unit gate passed after rebasing onto `b5c3c819`
- exact candidate image `b08d658f32fee5dea4147924be80d60a18539f4b` built successfully
- 512 MiB exact canary: pressure remained `normal` with only 380 MiB headroom; a source edit started no Vite; explicit rebuild exited cleanly with the retry message; served dist hash, health, restart count, and `memory.events` stayed unchanged (`oom=0`, `oom_kill=0`)
- 1 GiB exact canary: the same source edit rebuilt and rotated the served bundle, advanced the source signature, stayed healthy with zero restarts, and left `memory.events max/oom/oom_kill` at zero
- shared-lock canary: while another process held `build.lock`, live `npm run build` waited and no Vite appeared; after release it followed admission (temporary failure at 512 MiB, successful build at 1 GiB)
