### PR TITLE
Pin production Compose identities

### DIFF
--- a/backend/tests/test_deploy_image_identity.py
+++ b/backend/tests/test_deploy_image_identity.py
@@ -1,0 +1,126 @@
+"""The deploy must preflight and roll back the same image Compose deploys."""
+
+from pathlib import Path
+import subprocess
+import textwrap
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "deploy-prod.sh"
+
+
+def _read() -> str:
+  return SCRIPT.read_text(encoding="utf-8")
+
+
+def _identity_block() -> str:
+  source = _read()
+  start = source.index("# ── deploy image identity\n")
+  end = source.index("# ── end deploy image identity", start)
+  return source[start:end]
+
+
+def _function_source(name: str, following_comment: str) -> str:
+  source = _read()
+  start = source.index(f"{name}() {{")
+  end = source.index(following_comment, start)
+  return source[start:end]
+
+
+def test_mismatched_running_reference_migrates_to_compose_image():
+  setup = textwrap.dedent("""\
+    info() { :; }
+    docker() {
+      case "$*" in
+        *"{{.Image}}"*) printf 'sha256:old-image\\n' ;;
+        *"{{.Config.Image}}"*) printf 'mobius:selfhost-old-sha\\n' ;;
+        *) return 99 ;;
+      esac
+    }
+    CONTAINER=mobius
+    MOBIUS_IMAGE=mobius:prod
+  """)
+  assertions = textwrap.dedent("""\
+    compose_value=$(sh -c 'printf %s "$MOBIUS_IMAGE"')
+    printf 'previous=%s\\nrunning=%s\\ntarget=%s\\ncompose=%s\\n' \
+      "$PREV_IMAGE" "$RUNNING_IMAGE_REF" "$IMAGE_TAG" "$compose_value"
+  """)
+  harness = setup + _identity_block() + assertions
+
+  result = subprocess.run(
+    ["bash", "-c", harness], capture_output=True, text=True,
+  )
+
+  assert result.returncode == 0, result.stderr
+  assert result.stdout == (
+    "previous=sha256:old-image\n"
+    "running=mobius:selfhost-old-sha\n"
+    "target=mobius:prod\n"
+    "compose=mobius:prod\n"
+  )
+
+
+def test_compose_image_default_is_stable():
+  setup = textwrap.dedent("""\
+    unset MOBIUS_IMAGE
+    info() { :; }
+    docker() {
+      case "$*" in
+        *"{{.Image}}"*) printf 'sha256:old-image\\n' ;;
+        *"{{.Config.Image}}"*) printf 'mobius:selfhost-old-sha\\n' ;;
+      esac
+    }
+    CONTAINER=mobius
+  """)
+  harness = setup + _identity_block() + "printf '%s\\n' \"$IMAGE_TAG\"\n"
+  result = subprocess.run(
+    ["bash", "-c", harness], capture_output=True, text=True,
+  )
+
+  assert result.returncode == 0, result.stderr
+  assert result.stdout == "mobius\n"
+
+
+def test_scratch_preflight_runs_the_compose_image_not_the_old_reference():
+  source = _read()
+  start = source.index("# ── preflight: boot the new image")
+  end = source.index("# ── step 2: recreate container", start)
+  preflight = source[start:end]
+
+  assert '"$IMAGE_TAG" >/dev/null' in preflight
+  assert "RUNNING_IMAGE_REF" not in preflight
+
+
+def test_rollback_retags_previous_id_then_recreates_compose_image(tmp_path):
+  docker_log = tmp_path / "docker.log"
+  rollback = _function_source(
+    "attempt_rollback", "# Wait for a live-container probe",
+  )
+  harness = rollback + textwrap.dedent(f"""\
+    warn() {{ :; }}
+    intent() {{ :; }}
+    fail() {{ printf 'FAIL %s\\n' "$1" >&2; }}
+    ok() {{ :; }}
+    external_prod_caddy_running() {{ return 1; }}
+    docker() {{
+      printf '%s\\n' "$*" >> {str(docker_log)!r}
+      if [ "$1" = exec ]; then printf '200'; fi
+      return 0
+    }}
+    PREV_IMAGE=sha256:old-image
+    IMAGE_TAG=mobius:prod
+    CONTAINER=mobius
+    CUTOVER_WAIT_SECONDS=1
+    INTERNAL_BASE=http://localhost:8000
+    COMPOSE_ARGS=(-p mobius)
+    attempt_rollback
+  """)
+
+  result = subprocess.run(
+    ["bash", "-c", harness], capture_output=True, text=True,
+  )
+
+  assert result.returncode == 0, result.stderr
+  calls = docker_log.read_text(encoding="utf-8").splitlines()
+  assert calls[0] == "tag sha256:old-image mobius:prod"
+  assert calls[1] == "compose -p mobius up -d --force-recreate"
+  assert calls[2].startswith("exec mobius sh -c curl ")

--- a/backend/tests/test_self_hosted_recovery.py
+++ b/backend/tests/test_self_hosted_recovery.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import subprocess
 import time
 from pathlib import Path
@@ -111,6 +112,49 @@ def test_mobiusctl_is_recovery_only(tmp_path):
   )
   assert result.returncode == 64
   assert "Usage: scripts/mobiusctl recovery" in result.stderr
+
+
+def test_linked_worktree_lifecycle_targets_the_live_compose_project(tmp_path):
+  linked = tmp_path / "some-linked-worktree"
+  scripts = linked / "scripts"
+  scripts.mkdir(parents=True)
+  copied = scripts / "mobiusctl"
+  shutil.copy2(ROOT / "scripts" / "mobiusctl", copied)
+  state = tmp_path / "recovery.env"
+  _write_recovery_state(state)
+  fake_env, log = _fake_docker(tmp_path)
+
+  result = subprocess.run(
+    [str(copied), "recovery", "finish"],
+    cwd=linked,
+    env={
+      **os.environ,
+      **fake_env,
+      "MOBIUS_RECOVERY_STATE_FILE": str(state),
+      "MOBIUS_RECOVERY_LOCK_DIR": str(tmp_path),
+    },
+    text=True,
+    capture_output=True,
+    timeout=10,
+  )
+
+  assert result.returncode == 0, result.stderr
+  commands = log.read_text().splitlines()
+  assert commands[:3] == [
+    "compose -p mobius --profile recovery "
+    f"--env-file {state} stop recovery recovery-target",
+    "compose -p mobius --profile recovery "
+    f"--env-file {state} rm -f recovery recovery-target",
+    "compose -p mobius --profile recovery "
+    f"--env-file {state} ps -aq recovery recovery-target",
+  ]
+  assert "compose -p mobius up -d --force-recreate app" in commands
+  assert "compose -p mobius ps -q app" in commands
+  assert all("some-linked-worktree" not in command for command in commands)
+  # The pinned project and the compose volume key resolve to the live volume,
+  # independent of the linked worktree's basename.
+  target_volume = _compose()["services"]["recovery-target"]["volumes"][0]
+  assert f"mobius_{target_volume.split(':')[0]}" == "mobius_app_data"
 
 
 def test_app_sudo_is_full_root_by_default_with_operator_kill_switch():

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -31,6 +31,8 @@
 #                           prune unused build cache older than this after success (24)
 #   DEPLOY_BUILD_CACHE_MAX_GB
 #                           target maximum retained build cache after success (8)
+#   MOBIUS_IMAGE            stable Compose app image tag used for build,
+#                           preflight, cutover, and rollback (default: mobius)
 #
 # Safety: only the `docker compose build` step prompts (it's slow and
 # has OOM'd this 7.6GB host before). Everything else auto-proceeds.
@@ -932,11 +934,23 @@ info "target: ${C_BOLD}${TARGET}${C_RESET} (${CONTAINER})"
 # crash-loop at runtime (a SyntaxError fails Python at import, not
 # `docker build` — exactly the 2026-05-30 conflict-marker outage), and the
 # recreate has already replaced the live container by the time we notice.
-# PREV_IMAGE is the image ID (stable); IMAGE_TAG is the tag compose
-# resolves (e.g. `mobius-app`) that we re-point at it to restore.
+# ── deploy image identity
+# PREV_IMAGE is the immutable ID of what is serving now. IMAGE_TAG is the
+# stable tag Compose resolves for THIS deploy, which can intentionally differ
+# from the old container's Config.Image during a one-time tag migration. Using
+# the Compose tag everywhere is load-bearing: otherwise preflight can boot the
+# old image and rollback can re-tag a reference Compose never recreates.
 PREV_IMAGE=$(docker inspect -f '{{.Image}}' "$CONTAINER" 2>/dev/null || echo "")
-IMAGE_TAG=$(docker inspect -f '{{.Config.Image}}' "$CONTAINER" 2>/dev/null || echo "")
-info "rollback image: ${IMAGE_TAG:-<unknown>} (${PREV_IMAGE:0:19}…)"
+RUNNING_IMAGE_REF=$(
+  docker inspect -f '{{.Config.Image}}' "$CONTAINER" 2>/dev/null || echo ""
+)
+# Keep this identical to docker-compose.yml's image expression, then export it
+# so Compose cannot implicitly load a different .env value after the preflight
+# and rollback target has been chosen.
+IMAGE_TAG=${MOBIUS_IMAGE:-mobius}
+export MOBIUS_IMAGE="$IMAGE_TAG"
+info "deploy image: ${IMAGE_TAG}; rollback source: ${PREV_IMAGE:0:19}… (running ref: ${RUNNING_IMAGE_REF:-<unknown>})"
+# ── end deploy image identity
 ROLLBACK_TAG=""
 PREVIOUS_ROLLBACK_IMAGE=""
 if [ -n "$IMAGE_TAG" ]; then

--- a/scripts/mobiusctl
+++ b/scripts/mobiusctl
@@ -7,6 +7,9 @@ set -eu
 
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 PROJECT_DIR=$(dirname "$SCRIPT_DIR")
+# Pin the installation identity just like deploy-prod.sh. A linked worktree's
+# directory name must never select a fresh project/volume or miss the live app.
+COMPOSE_PROJECT=${MOBIUS_COMPOSE_PROJECT:-mobius}
 STATE_FILE=${MOBIUS_RECOVERY_STATE_FILE:-"$PROJECT_DIR/.mobius-recovery.env"}
 RECOVERY_TARGET_MIN_TTL_SECONDS=300
 RECOVERY_TARGET_MAX_TTL_SECONDS=86400
@@ -73,9 +76,9 @@ normal_compose() {
   (
     cd "$PROJECT_DIR"
     if [ -f .env ]; then
-      docker compose --env-file .env "$@"
+      docker compose -p "$COMPOSE_PROJECT" --env-file .env "$@"
     else
-      docker compose "$@"
+      docker compose -p "$COMPOSE_PROJECT" "$@"
     fi
   )
 }
@@ -85,15 +88,17 @@ compose() {
     cd "$PROJECT_DIR"
     if [ -f .env ]; then
       if [ -f "$STATE_FILE" ]; then
-        docker compose --profile recovery \
+        docker compose -p "$COMPOSE_PROJECT" --profile recovery \
           --env-file .env --env-file "$STATE_FILE" "$@"
       else
-        docker compose --profile recovery --env-file .env "$@"
+        docker compose -p "$COMPOSE_PROJECT" --profile recovery \
+          --env-file .env "$@"
       fi
     elif [ -f "$STATE_FILE" ]; then
-      docker compose --profile recovery --env-file "$STATE_FILE" "$@"
+      docker compose -p "$COMPOSE_PROJECT" --profile recovery \
+        --env-file "$STATE_FILE" "$@"
     else
-      docker compose --profile recovery "$@"
+      docker compose -p "$COMPOSE_PROJECT" --profile recovery "$@"
     fi
   )
 }


### PR DESCRIPTION
## Summary
- resolve the deployment image from the same `MOBIUS_IMAGE` expression as Compose, rather than inheriting a stale running-container reference
- export that stable tag so build, scratch preflight, cutover, and rollback cannot diverge through implicit `.env` loading
- retain the live immutable image ID separately as the rollback source, including one-time migration from older SHA-named tags
- pin both self-hosted recovery Compose wrappers to project `mobius` (overridable with `MOBIUS_COMPOSE_PROJECT`) so a linked release worktree still stops/recreates the live app and mounts `mobius_app_data`

## Why
Local production currently reports `mobius:selfhost-<sha>`, while current Compose defaults to `mobius`. The old deploy therefore preflighted the old image, cut over to the new one, and could retag a reference Compose did not use during rollback. Separately, `mobiusctl` inherited the checkout directory as its project name, so running the merged recovery lifecycle from an exact-SHA worktree could target a fresh project and volume instead of production.

## Verification
- `bash -n scripts/deploy-prod.sh scripts/mobiusctl`
- `python -m pytest -q backend/tests/test_self_hosted_recovery.py backend/tests/test_deploy*.py` (115 passed)
- behavioral coverage for mismatched image migration, preflight target, rollback recreate, and linked-worktree recovery finish against project `mobius` / volume `mobius_app_data`
- `git diff --check`

Not enqueued yet; it should follow the dependency/runtime merge sequence.