### PR TITLE
Resolve deploy image from Compose

### DIFF
--- a/backend/tests/test_deploy_image_identity.py
+++ b/backend/tests/test_deploy_image_identity.py
@@ -33,11 +33,14 @@ def test_mismatched_running_reference_migrates_to_compose_image():
       case "$*" in
         *"{{.Image}}"*) printf 'sha256:old-image\\n' ;;
         *"{{.Config.Image}}"*) printf 'mobius:selfhost-old-sha\\n' ;;
+        *"config --images app"*) printf 'mobius:prod\\n' ;;
         *) return 99 ;;
       esac
     }
     CONTAINER=mobius
+    COMPOSE_ARGS=(-p mobius)
     MOBIUS_IMAGE=mobius:prod
+    SKIP_BUILD=0
   """)
   assertions = textwrap.dedent("""\
     compose_value=$(sh -c 'printf %s "$MOBIUS_IMAGE"')
@@ -59,7 +62,7 @@ def test_mismatched_running_reference_migrates_to_compose_image():
   )
 
 
-def test_compose_image_default_is_stable():
+def test_compose_image_comes_from_rendered_prod_config():
   setup = textwrap.dedent("""\
     unset MOBIUS_IMAGE
     info() { :; }
@@ -67,9 +70,12 @@ def test_compose_image_default_is_stable():
       case "$*" in
         *"{{.Image}}"*) printf 'sha256:old-image\\n' ;;
         *"{{.Config.Image}}"*) printf 'mobius:selfhost-old-sha\\n' ;;
+        *"config --images app"*) printf 'mobius\\n' ;;
       esac
     }
     CONTAINER=mobius
+    COMPOSE_ARGS=(-p mobius)
+    SKIP_BUILD=0
   """)
   harness = setup + _identity_block() + "printf '%s\\n' \"$IMAGE_TAG\"\n"
   result = subprocess.run(
@@ -78,6 +84,87 @@ def test_compose_image_default_is_stable():
 
   assert result.returncode == 0, result.stderr
   assert result.stdout == "mobius\n"
+
+
+def test_test_target_uses_its_rendered_image_not_the_prod_default(tmp_path):
+  docker_log = tmp_path / "docker.log"
+  setup = textwrap.dedent(f"""\
+    unset MOBIUS_IMAGE
+    info() {{ :; }}
+    docker() {{
+      printf '%s\\n' "$*" >> {str(docker_log)!r}
+      case "$*" in
+        *"{{{{.Image}}}}"*) printf 'sha256:test-image\\n' ;;
+        *"{{{{.Config.Image}}}}"*) printf 'mobius-test:ci\\n' ;;
+        *"config --images app"*) printf 'mobius-test:ci\\n' ;;
+      esac
+    }}
+    CONTAINER=mobius-test
+    COMPOSE_ARGS=(-p mobius-test -f docker-compose.test.yml)
+    SKIP_BUILD=0
+  """)
+  harness = setup + _identity_block() + "printf '%s\\n' \"$IMAGE_TAG\"\n"
+
+  result = subprocess.run(
+    ["bash", "-c", harness], capture_output=True, text=True,
+  )
+
+  assert result.returncode == 0, result.stderr
+  assert result.stdout == "mobius-test:ci\n"
+  assert "compose -p mobius-test -f docker-compose.test.yml config --images app" in (
+    docker_log.read_text(encoding="utf-8").splitlines()
+  )
+
+
+def test_skip_build_refuses_a_stale_compose_tag():
+  setup = textwrap.dedent("""\
+    info() { :; }
+    fail() { printf '%s\\n' "$1" >&2; }
+    docker() {
+      case "$*" in
+        *"{{.Image}}"*) printf 'sha256:serving\\n' ;;
+        *"{{.Config.Image}}"*) printf 'mobius:selfhost-old-sha\\n' ;;
+        *"config --images app"*) printf 'mobius\\n' ;;
+        *"image inspect"*) printf 'sha256:stale\\n' ;;
+      esac
+    }
+    CONTAINER=mobius
+    COMPOSE_ARGS=(-p mobius)
+    SKIP_BUILD=1
+  """)
+
+  result = subprocess.run(
+    ["bash", "-c", setup + _identity_block()],
+    capture_output=True,
+    text=True,
+  )
+
+  assert result.returncode == 1
+  assert "--skip-build target mobius is not the image serving" in result.stderr
+
+
+def test_prod_image_override_loads_from_worktree_env(tmp_path):
+  (tmp_path / ".env").write_text("MOBIUS_IMAGE=mobius:from-env\n", encoding="utf-8")
+  env_reader = _function_source("env_value_from_file", "ensure_prod_env()")
+  resolver = _function_source(
+    "resolve_prod_image_override", "resolve_platform_release_ref()",
+  )
+  harness = env_reader + resolver + textwrap.dedent(f"""\
+    unset MOBIUS_IMAGE
+    TARGET=prod
+    REPO_ROOT={str(tmp_path)!r}
+    canonical_env_path() {{ return 1; }}
+    info() {{ :; }}
+    resolve_prod_image_override
+    printf '%s\\n' "$MOBIUS_IMAGE"
+  """)
+
+  result = subprocess.run(
+    ["bash", "-c", harness], capture_output=True, text=True,
+  )
+
+  assert result.returncode == 0, result.stderr
+  assert result.stdout == "mobius:from-env\n"
 
 
 def test_scratch_preflight_runs_the_compose_image_not_the_old_reference():

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -348,6 +348,24 @@ resolve_prod_service_gateway_origin() {
   export MOBIUS_SERVICE_GATEWAY_ORIGIN
 }
 
+resolve_prod_image_override() {
+  [ "$TARGET" = "prod" ] || return 0
+  [ -n "${MOBIUS_IMAGE:-}" ] && return 0
+
+  local canonical_env="" file candidate
+  canonical_env=$(canonical_env_path || true)
+  for file in "$REPO_ROOT/.env" "$canonical_env"; do
+    [ -n "$file" ] || continue
+    candidate=$(env_value_from_file "$file" MOBIUS_IMAGE || true)
+    if [ -n "$candidate" ]; then
+      MOBIUS_IMAGE="$candidate"
+      export MOBIUS_IMAGE
+      info "loaded deploy image from $file"
+      return 0
+    fi
+  done
+}
+
 resolve_platform_release_ref() {
   local value="${MOBIUS_PLATFORM_RELEASE_REF:-}" source="environment"
   local file candidate canonical_env=""
@@ -375,6 +393,7 @@ resolve_platform_release_ref() {
 # ── end prod environment resolution ──────────────────────────────
 
 ensure_prod_env
+resolve_prod_image_override
 resolve_prod_service_gateway_origin
 resolve_platform_release_ref
 
@@ -944,12 +963,29 @@ PREV_IMAGE=$(docker inspect -f '{{.Image}}' "$CONTAINER" 2>/dev/null || echo "")
 RUNNING_IMAGE_REF=$(
   docker inspect -f '{{.Config.Image}}' "$CONTAINER" 2>/dev/null || echo ""
 )
-# Keep this identical to docker-compose.yml's image expression, then export it
-# so Compose cannot implicitly load a different .env value after the preflight
-# and rollback target has been chosen.
-IMAGE_TAG=${MOBIUS_IMAGE:-mobius}
+# Ask Compose once instead of duplicating the prod and test defaults here. This
+# also honors an image configured in .env before we freeze the result for the
+# preflight, cutover, and rollback paths.
+if ! IMAGE_TAG=$(docker compose "${COMPOSE_ARGS[@]}" config --images app); then
+  fail "could not resolve the app image from the rendered Compose configuration"
+  exit 1
+fi
+if [ -z "$IMAGE_TAG" ] || [[ "$IMAGE_TAG" == *$'\n'* ]]; then
+  fail "Compose resolved an invalid app image: ${IMAGE_TAG:-<empty>}"
+  exit 1
+fi
 export MOBIUS_IMAGE="$IMAGE_TAG"
 info "deploy image: ${IMAGE_TAG}; rollback source: ${PREV_IMAGE:0:19}… (running ref: ${RUNNING_IMAGE_REF:-<unknown>})"
+
+# --skip-build means reuse what is serving now. Refuse to repoint Compose at a
+# stale same-named tag when the live container was created under an older tag.
+if [ "$SKIP_BUILD" = "1" ]; then
+  TARGET_IMAGE=$(docker image inspect -f '{{.Id}}' "$IMAGE_TAG" 2>/dev/null || true)
+  if [ -z "$PREV_IMAGE" ] || [ "$TARGET_IMAGE" != "$PREV_IMAGE" ]; then
+    fail "--skip-build target ${IMAGE_TAG} is not the image serving in ${CONTAINER}; run the normal build"
+    exit 1
+  fi
+fi
 # ── end deploy image identity
 ROLLBACK_TAG=""
 PREVIOUS_ROLLBACK_IMAGE=""


### PR DESCRIPTION
Fixes the final deployment-identity audit findings without adding a second image policy. The deploy now resolves the app image once from rendered Compose configuration, preserves worktree .env image overrides, keeps the test target on mobius-test:ci, and refuses --skip-build when the resolved tag is not the image currently serving. Focused result: 34 deployment/recovery tests pass; bash syntax, diff checks, and real Compose resolution for prod/test/custom images pass.